### PR TITLE
fix(e2e): add retries to daily-archive-filter spec (short-term mitigation)

### DIFF
--- a/packages/obsidian-plugin/tests/e2e/specs/daily-archive-filter.spec.ts
+++ b/packages/obsidian-plugin/tests/e2e/specs/daily-archive-filter.spec.ts
@@ -9,7 +9,14 @@ import { test, expect } from "@playwright/test";
 import { ObsidianLauncher } from "../utils/obsidian-launcher";
 import * as path from "path";
 
-test.describe.configure({ mode: "parallel" });
+// Issue #3280 short-term mitigation per RFC 32a64ed9 §3.3 escalation:
+// incident #2 (2026-05-26) within the 30-day watch window after #2988
+// closed. Adds `test.retry(1)` on this file so unrelated PRs do not
+// block on the page-close/modal-dismiss race in `ObsidianLauncher`
+// (see issue body §"Error signature"). Root-cause investigation of
+// `ObsidianLauncher.ts:500` modal-dismiss race remains open; remove
+// `retries` once that lands and N≥100 zero-further on main is hit.
+test.describe.configure({ mode: "parallel", retries: 1 });
 
 test.describe(
   "DailyNote Archive Filter",
@@ -22,116 +29,123 @@ test.describe(
     },
   },
   () => {
-  let launcher: ObsidianLauncher;
+    let launcher: ObsidianLauncher;
 
-  test.beforeAll(async () => {
-    const vaultPath = path.join(__dirname, "../test-vault");
-    launcher = new ObsidianLauncher(vaultPath);
-    await launcher.launch();
-  });
-
-  test.afterAll(async () => {
-    if (launcher) {
-      await launcher.close();
-    }
-  });
-
-  test("should toggle archived tasks visibility with button click", async () => {
-    await launcher.openFile("Daily Notes/2025-10-18.md");
-
-    const window = await launcher.getWindow();
-
-    await launcher.waitForModalsToClose(10000);
-    await launcher.waitForElement(".exocortex-layout-rendered", 30000);
-
-    const toggleButton = window.locator(
-      ".exocortex-daily-tasks-section .exocortex-toggle-archived",
-    );
-    await expect(toggleButton).toContainText("Show Archived", {
-      timeout: 30000,
+    test.beforeAll(async () => {
+      const vaultPath = path.join(__dirname, "../test-vault");
+      launcher = new ObsidianLauncher(vaultPath);
+      await launcher.launch();
     });
 
-    const initialButtonText = await toggleButton.textContent();
-    expect(initialButtonText).toContain("Show Archived");
-
-    const tasksTable = window
-      .locator(".exocortex-daily-tasks-section table")
-      .first();
-    await expect(tasksTable).toBeVisible({ timeout: 10000 });
-
-    const rows = tasksTable.locator("tbody tr");
-    await expect(rows.first()).toBeVisible({ timeout: 5000 });
-
-    const initialRowCount = await rows.count();
-
-    const tableContent = await tasksTable.textContent();
-    expect(tableContent).not.toContain("Archived Task");
-
-    await toggleButton.click();
-    await expect(toggleButton).toContainText("Hide Archived", { timeout: 5000 });
-
-    const updatedButtonText = await toggleButton.textContent();
-    expect(updatedButtonText).toContain("Hide Archived");
-
-    const updatedRows = tasksTable.locator("tbody tr");
-    const updatedRowCount = await updatedRows.count();
-
-    expect(updatedRowCount).toBeGreaterThan(initialRowCount);
-
-    const updatedTableContent = await tasksTable.textContent();
-    expect(updatedTableContent).toContain("Archived Task");
-
-    await toggleButton.click();
-    await expect(toggleButton).toContainText("Show Archived", { timeout: 5000 });
-
-    const finalButtonText = await toggleButton.textContent();
-    expect(finalButtonText).toContain("Show Archived");
-
-    const finalRows = tasksTable.locator("tbody tr");
-    const finalRowCount = await finalRows.count();
-    expect(finalRowCount).toBe(initialRowCount);
-
-    const finalTableContent = await tasksTable.textContent();
-    expect(finalTableContent).not.toContain("Archived Task");
-  });
-
-  test("should persist archived filter state across page refreshes", async () => {
-    await launcher.openFile("Daily Notes/2025-10-18.md");
-
-    const window = await launcher.getWindow();
-
-    await launcher.waitForModalsToClose(10000);
-    await launcher.waitForElement(".exocortex-layout-rendered", 30000);
-
-    const toggleButton = window.locator(
-      ".exocortex-daily-tasks-section .exocortex-toggle-archived",
-    );
-    await expect(toggleButton).toContainText("Show Archived", {
-      timeout: 30000,
+    test.afterAll(async () => {
+      if (launcher) {
+        await launcher.close();
+      }
     });
 
-    await toggleButton.click();
-    await expect(toggleButton).toContainText("Hide Archived", { timeout: 5000 });
+    test("should toggle archived tasks visibility with button click", async () => {
+      await launcher.openFile("Daily Notes/2025-10-18.md");
 
-    let buttonText = await toggleButton.textContent();
-    expect(buttonText).toContain("Hide Archived");
+      const window = await launcher.getWindow();
 
-    await launcher.openFile("Daily Notes/2025-10-17.md");
-    await launcher.waitForModalsToClose(10000);
-    await launcher.waitForElement(".exocortex-layout-rendered", 30000);
+      await launcher.waitForModalsToClose(10000);
+      await launcher.waitForElement(".exocortex-layout-rendered", 30000);
 
-    await launcher.openFile("Daily Notes/2025-10-18.md");
-    await launcher.waitForModalsToClose(10000);
-    await launcher.waitForElement(".exocortex-layout-rendered", 30000);
+      const toggleButton = window.locator(
+        ".exocortex-daily-tasks-section .exocortex-toggle-archived",
+      );
+      await expect(toggleButton).toContainText("Show Archived", {
+        timeout: 30000,
+      });
 
-    const toggleButtonAfterRefresh = window.locator(
-      ".exocortex-daily-tasks-section .exocortex-toggle-archived",
-    );
-    await expect(toggleButtonAfterRefresh).toContainText("Hide Archived", {
-      timeout: 30000,
+      const initialButtonText = await toggleButton.textContent();
+      expect(initialButtonText).toContain("Show Archived");
+
+      const tasksTable = window
+        .locator(".exocortex-daily-tasks-section table")
+        .first();
+      await expect(tasksTable).toBeVisible({ timeout: 10000 });
+
+      const rows = tasksTable.locator("tbody tr");
+      await expect(rows.first()).toBeVisible({ timeout: 5000 });
+
+      const initialRowCount = await rows.count();
+
+      const tableContent = await tasksTable.textContent();
+      expect(tableContent).not.toContain("Archived Task");
+
+      await toggleButton.click();
+      await expect(toggleButton).toContainText("Hide Archived", {
+        timeout: 5000,
+      });
+
+      const updatedButtonText = await toggleButton.textContent();
+      expect(updatedButtonText).toContain("Hide Archived");
+
+      const updatedRows = tasksTable.locator("tbody tr");
+      const updatedRowCount = await updatedRows.count();
+
+      expect(updatedRowCount).toBeGreaterThan(initialRowCount);
+
+      const updatedTableContent = await tasksTable.textContent();
+      expect(updatedTableContent).toContain("Archived Task");
+
+      await toggleButton.click();
+      await expect(toggleButton).toContainText("Show Archived", {
+        timeout: 5000,
+      });
+
+      const finalButtonText = await toggleButton.textContent();
+      expect(finalButtonText).toContain("Show Archived");
+
+      const finalRows = tasksTable.locator("tbody tr");
+      const finalRowCount = await finalRows.count();
+      expect(finalRowCount).toBe(initialRowCount);
+
+      const finalTableContent = await tasksTable.textContent();
+      expect(finalTableContent).not.toContain("Archived Task");
     });
 
-    buttonText = await toggleButtonAfterRefresh.textContent();
-    expect(buttonText).toContain("Hide Archived");
-  });
-});
+    test("should persist archived filter state across page refreshes", async () => {
+      await launcher.openFile("Daily Notes/2025-10-18.md");
+
+      const window = await launcher.getWindow();
+
+      await launcher.waitForModalsToClose(10000);
+      await launcher.waitForElement(".exocortex-layout-rendered", 30000);
+
+      const toggleButton = window.locator(
+        ".exocortex-daily-tasks-section .exocortex-toggle-archived",
+      );
+      await expect(toggleButton).toContainText("Show Archived", {
+        timeout: 30000,
+      });
+
+      await toggleButton.click();
+      await expect(toggleButton).toContainText("Hide Archived", {
+        timeout: 5000,
+      });
+
+      let buttonText = await toggleButton.textContent();
+      expect(buttonText).toContain("Hide Archived");
+
+      await launcher.openFile("Daily Notes/2025-10-17.md");
+      await launcher.waitForModalsToClose(10000);
+      await launcher.waitForElement(".exocortex-layout-rendered", 30000);
+
+      await launcher.openFile("Daily Notes/2025-10-18.md");
+      await launcher.waitForModalsToClose(10000);
+      await launcher.waitForElement(".exocortex-layout-rendered", 30000);
+
+      const toggleButtonAfterRefresh = window.locator(
+        ".exocortex-daily-tasks-section .exocortex-toggle-archived",
+      );
+      await expect(toggleButtonAfterRefresh).toContainText("Hide Archived", {
+        timeout: 30000,
+      });
+
+      buttonText = await toggleButtonAfterRefresh.textContent();
+      expect(buttonText).toContain("Hide Archived");
+    });
+  },
+);


### PR DESCRIPTION
## Summary

Closes #3280 (short-term mitigation per RFC 32a64ed9 §3.3 escalation path).

Issue #3280 escalates closed #2988 after incident #2 (2026-05-26) appeared inside the 30-day watch window. Failure signature is the `ObsidianLauncher` page-close/modal-dismiss race (`ObsidianLauncher.ts:500` → `Obsidian not launched. Call launch() first.` after a `Target page closed` in the modal click). This same race re-appeared on the CI run for PR #3345 today.

## Changes

Single semantic edit in `packages/obsidian-plugin/tests/e2e/specs/daily-archive-filter.spec.ts`:

```diff
- test.describe.configure({ mode: "parallel" });
+ test.describe.configure({ mode: "parallel", retries: 1 });
```

Plus an explanatory comment above the line documenting the sunset condition (remove `retries: 1` once root cause patched and N≥100 zero-further on main is met). Prettier reformatted the rest of the file as a side-effect of the same auto-format hook; semantic diff is the one line above.

## Why retries vs other options

Per the issue body §"Why this matters":
- Per-spec `retries: 1` is the **short-term option recommended in the issue** to unblock unrelated PRs (e.g. #3345 today, #3278, #3211 historically) from manually re-running shard-2.
- Root-cause investigation of `ObsidianLauncher.ts:500` modal-dismiss/page-close race remains open as the **second action item** in the issue body — separate scope.
- Test was already tagged `@flaky-track`; this PR layers retry on top so the tag stays informational + the actual mitigation lands.

## Test plan

- [x] Spec edit only — no production code, no other specs touched.
- [x] Format check passes (`prettier --check`).
- [x] Sibling pattern verified — `retries` is a valid Playwright `describe.configure` option (see Playwright docs).
- Empirical confirmation that retry-rate stays < 5% on the Phase 3.4 dashboard — observable post-merge.