### PR TITLE
fix(switch-cache): close file-system race in SwitchCacheLayer F6 verify

### DIFF
--- a/packages/obsidian-plugin/src/infrastructure/adapters/SwitchCacheLayer.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/SwitchCacheLayer.ts
@@ -160,27 +160,28 @@ export class SwitchCacheLayer implements ICacheLayer {
       );
     }
 
-    // F6: verify-before-return on tmp file.
-    let sizeBytes: number;
+    // F6: verify-before-return on tmp file. Single `readFile` instead of
+    // `stat` then `readFile` to close the TOCTOU window flagged by CodeQL
+    // `js/file-system-race` (Issue #3336). `sizeBytes` is derived from the
+    // buffer length, identical to `stat.size` for regular files.
+    let buf: Buffer;
     try {
-      const stat = await fsPromises.stat(cacheTmpPath);
-      sizeBytes = stat.size;
+      buf = await fsPromises.readFile(cacheTmpPath);
     } catch (err) {
       await fsPromises.rm(cacheTmpPath, { force: true }).catch(() => undefined);
       throw new CacheWriteError(
-        `Cannot stat cache tmp ${cacheTmpPath}: ${errorMessage(err)}`,
+        `Cannot read cache tmp ${cacheTmpPath}: ${errorMessage(err)}`,
       );
     }
+    const sizeBytes = buf.length;
     if (sizeBytes === 0) {
       await fsPromises.rm(cacheTmpPath, { force: true }).catch(() => undefined);
       throw new CacheWriteError(`Cache file empty: ${cacheTmpPath}`);
     }
-    // Verify archive parses + has non-zero entries — re-read from disk so
-    // F6 catches post-write filesystem corruption (write returned success
-    // but file truncated). Buffer (`archive`) is also in memory but reading
-    // back is the actual integrity check the F6 contract describes.
+    // Verify archive parses + has non-zero entries — using the buffer just
+    // read above. Catches post-write filesystem corruption (write returned
+    // success but the bytes that landed on disk don't form a valid tar.gz).
     try {
-      const buf = await fsPromises.readFile(cacheTmpPath);
       const parsed = await parseTarGzip(buf);
       if (!Array.isArray(parsed) || parsed.length === 0) {
         await fsPromises.rm(cacheTmpPath, { force: true }).catch(() => undefined);


### PR DESCRIPTION
## Summary

Closes #3336. CodeQL alert `js/file-system-race` (severity high, alert ID 306) flagged a TOCTOU window in `SwitchCacheLayer.ts:166-183` — `fsPromises.stat` followed by `fsPromises.readFile` on the same temp file. Another process could delete/truncate/modify `cacheTmpPath` in the gap, making the `sizeBytes === 0` guard inconsistent with the bytes the parse subsequently saw.

## Fix

Single `readFile` instead of `stat` + `readFile`. `sizeBytes` derives from `buf.length` (identical to `stat.size` for regular files, which cache tmp paths always are). The empty-archive + parse-failure branches both observe the same buffer they read, so the race window is closed.

## Diff

```diff
-    // F6: verify-before-return on tmp file.
-    let sizeBytes: number;
+    // F6: verify-before-return on tmp file. Single `readFile` instead of
+    // `stat` then `readFile` to close the TOCTOU window flagged by CodeQL
+    // `js/file-system-race` (Issue #3336). `sizeBytes` is derived from the
+    // buffer length, identical to `stat.size` for regular files.
+    let buf: Buffer;
     try {
-      const stat = await fsPromises.stat(cacheTmpPath);
-      sizeBytes = stat.size;
+      buf = await fsPromises.readFile(cacheTmpPath);
     } catch (err) {
       ...
-        `Cannot stat cache tmp ${cacheTmpPath}: ${errorMessage(err)}`,
+        `Cannot read cache tmp ${cacheTmpPath}: ${errorMessage(err)}`,
       ...
     }
+    const sizeBytes = buf.length;
     if (sizeBytes === 0) { ... }
     ...
     try {
-      const buf = await fsPromises.readFile(cacheTmpPath);
       const parsed = await parseTarGzip(buf);
       ...
     }
```

Net: -10 lines, +11 lines. One filesystem syscall instead of two; same observable behaviour for `sizeBytes` / empty-archive / corrupted-archive contracts.

## Test plan

- [x] `packages/obsidian-plugin/tests/unit/SwitchCacheLayer.test.ts` — 21/21 PASS unchanged (covers F6: non-existent source, empty archive, pre-existing corrupted, cache cleanup, sizeBytes meta parity).
- [x] Pre-commit hook PASS (lint-staged + Archgate 13/13).
- [x] Format check PASS (prettier auto-applied).
- CodeQL re-scan on this PR should clear alert ID 306.

## Risk

Minimal. Same semantic contract — F6 verify-before-return on cache tmp; `sizeBytes` field in `CacheEntry` retains identical value for normal files. No production behavior change visible to callers; only the implementation no longer races between two filesystem reads.