### PR TITLE
feat(nl-sparql): add active_tasks template for Task status queries

### DIFF
--- a/packages/exocortex/src/services/SPARQLTemplateLibrary.ts
+++ b/packages/exocortex/src/services/SPARQLTemplateLibrary.ts
@@ -137,7 +137,17 @@ export const KNOWN_CLASSES: KnownClass[] = [
     label: "ems__Area",
   },
   {
-    terms: ["персона", "персоны", "персон", "человек", "люди", "людей", "людям", "person", "persons"],
+    terms: [
+      "персона",
+      "персоны",
+      "персон",
+      "человек",
+      "люди",
+      "людей",
+      "людям",
+      "person",
+      "persons",
+    ],
     match: "ims__Person",
     label: "ims__Person",
   },
@@ -148,9 +158,7 @@ export const KNOWN_CLASSES: KnownClass[] = [
  */
 export function findClassByTerm(query: string): KnownClass | undefined {
   const lower = query.toLowerCase();
-  return KNOWN_CLASSES.find((c) =>
-    c.terms.some((t) => lower.includes(t))
-  );
+  return KNOWN_CLASSES.find((c) => c.terms.some((t) => lower.includes(t)));
 }
 
 /**
@@ -313,7 +321,15 @@ ORDER BY ?start`,
       "когда я спал",
       "сколько я спал в ноябре",
     ],
-    keywords: ["сон", "сна", "спать", "поспать", "sleep", "спал", "статистика сна"],
+    keywords: [
+      "сон",
+      "сна",
+      "спать",
+      "поспать",
+      "sleep",
+      "спал",
+      "статистика сна",
+    ],
   },
   {
     name: "active_projects",
@@ -339,6 +355,48 @@ ORDER BY ?label`,
       "активных",
       "проекты",
       "projects",
+      "в работе",
+      "doing",
+    ],
+  },
+  {
+    // Issue #3289 short-term: mirror `active_projects` for `ems__Task` so
+    // queries like "какие задачи в статусе Doing?" / "задачи в работе"
+    // resolve to the correct status-filtered SPARQL instead of falling
+    // back to a label-REGEX guess. Long-term homoiconic NL→SPARQL (per
+    // issue body §"Решение") remains tracked in #3289 — this template is
+    // the immediate slice unlocking the documented AC for task status
+    // queries.
+    name: "active_tasks",
+    description: "Find active tasks with status Doing",
+    template: `${SPARQL_PREFIXES}
+
+SELECT ?task ?label
+WHERE {
+  ?task ${PREDICATES.INSTANCE_CLASS} "[[${ASSET_CLASSES.TASK}]]" .
+  ?task ${PREDICATES.EFFORT_STATUS} ${EFFORT_STATUSES.DOING} .
+  ?task ${PREDICATES.ASSET_LABEL} ?label .
+}
+ORDER BY ?label`,
+    parameters: [],
+    // Examples avoid the bare Russian particle "в" so they do not match
+    // generic queries like "найди все задачи" by substring on "в" ⊂
+    // "все". Keyword set carries the natural "в статусе doing" / "в
+    // работе" phrasing for ranking on the issue-3289 AC queries.
+    examples: [
+      "активные задачи",
+      "какие задачи doing",
+      "задачи со статусом doing",
+      "текущие задачи",
+    ],
+    // Keywords intentionally exclude the bare "задачи" / "tasks" tokens so
+    // that the existing `search_by_label` template still wins for general
+    // search queries like "найди все задачи со словом X". The
+    // disambiguator is the status phrase or the "активные" qualifier.
+    keywords: [
+      "активные задачи",
+      "в статусе doing",
+      "статусе doing",
       "в работе",
       "doing",
     ],
@@ -497,11 +555,7 @@ WHERE {
         example: "Поспать 2025-11-30",
       },
     ],
-    examples: [
-      "все свойства задачи",
-      "покажи детали записи",
-      "информация о",
-    ],
+    examples: ["все свойства задачи", "покажи детали записи", "информация о"],
     keywords: ["свойства", "properties", "детали", "информация"],
   },
   {
@@ -522,10 +576,7 @@ WHERE {
         example: "2d369bb0-159f-4639-911d-ec2c585e8d00",
       },
     ],
-    examples: [
-      "свойства по UUID",
-      "покажи запись с UUID",
-    ],
+    examples: ["свойства по UUID", "покажи запись с UUID"],
     keywords: ["UUID", "uid"],
   },
   {
@@ -636,16 +687,22 @@ WHERE {
 ORDER BY ?label`,
     parameters: [],
     examples: ["все люди", "контакты", "persons"],
-    keywords: ["люди", "контакты", "персон", "персоны", "персона", "persons", "person"],
+    keywords: [
+      "люди",
+      "контакты",
+      "персон",
+      "персоны",
+      "персона",
+      "persons",
+      "person",
+    ],
   },
 ];
 
 /**
  * Get a template by name
  */
-export function getTemplateByName(
-  name: string
-): SPARQLTemplate | undefined {
+export function getTemplateByName(name: string): SPARQLTemplate | undefined {
   return SPARQL_TEMPLATES.find((t) => t.name === name);
 }
 
@@ -654,7 +711,7 @@ export function getTemplateByName(
  */
 export function findMatchingTemplates(
   query: string,
-  maxResults = 3
+  maxResults = 3,
 ): SPARQLTemplate[] {
   const normalizedQuery = query.toLowerCase();
   const scores = new Map<SPARQLTemplate, number>();
@@ -674,7 +731,7 @@ export function findMatchingTemplates(
       const exampleWords = example.toLowerCase().split(/\s+/);
       const queryWords = normalizedQuery.split(/\s+/);
       const matchingWords = exampleWords.filter((w) =>
-        queryWords.some((qw) => qw.includes(w) || w.includes(qw))
+        queryWords.some((qw) => qw.includes(w) || w.includes(qw)),
       );
       score += matchingWords.length * 0.5;
     }
@@ -696,7 +753,7 @@ export function findMatchingTemplates(
  */
 export function fillTemplate(
   template: SPARQLTemplate,
-  params: Record<string, string>
+  params: Record<string, string>,
 ): string {
   let query = template.template;
 
@@ -723,7 +780,7 @@ export function fillTemplate(
  */
 export function validateParameters(
   template: SPARQLTemplate,
-  params: Record<string, string>
+  params: Record<string, string>,
 ): { valid: boolean; missing: string[] } {
   const missing: string[] = [];
 

--- a/packages/exocortex/tests/services/SPARQLTemplateLibrary.test.ts
+++ b/packages/exocortex/tests/services/SPARQLTemplateLibrary.test.ts
@@ -47,7 +47,9 @@ describe("SPARQLTemplateLibrary", () => {
       });
 
       it("should have effort predicates", () => {
-        expect(PREDICATES.EFFORT_START_TIMESTAMP).toBe("ems:Effort_startTimestamp");
+        expect(PREDICATES.EFFORT_START_TIMESTAMP).toBe(
+          "ems:Effort_startTimestamp",
+        );
         expect(PREDICATES.EFFORT_END_TIMESTAMP).toBe("ems:Effort_endTimestamp");
         expect(PREDICATES.EFFORT_STATUS).toBe("ems:Effort_status");
         expect(PREDICATES.EFFORT_PARENT).toBe("ems:Effort_parent");
@@ -73,8 +75,12 @@ describe("SPARQLTemplateLibrary", () => {
 
     describe("KNOWN_PROTOTYPES", () => {
       it("should have known prototype UUIDs", () => {
-        expect(KNOWN_PROTOTYPES.MORNING_SHOWER).toBe("2d369bb0-159f-4639-911d-ec2c585e8d00");
-        expect(KNOWN_PROTOTYPES.CUT_NAILS).toBe("1d7b739c-0e3e-46f2-ba88-e66f30b732f9");
+        expect(KNOWN_PROTOTYPES.MORNING_SHOWER).toBe(
+          "2d369bb0-159f-4639-911d-ec2c585e8d00",
+        );
+        expect(KNOWN_PROTOTYPES.CUT_NAILS).toBe(
+          "1d7b739c-0e3e-46f2-ba88-e66f30b732f9",
+        );
       });
     });
   });
@@ -121,6 +127,7 @@ describe("SPARQLTemplateLibrary", () => {
         "average_duration_by_prototype",
         "sleep_analysis",
         "active_projects",
+        "active_tasks",
         "projects_without_tasks",
         "recent_activities",
         "tasks_by_label_pattern",
@@ -158,14 +165,41 @@ describe("SPARQLTemplateLibrary", () => {
     it("should find templates for project queries", () => {
       const matches = findMatchingTemplates("активные проекты");
       expect(matches.length).toBeGreaterThan(0);
-      const hasActiveProjects = matches.some((t) => t.name === "active_projects");
+      const hasActiveProjects = matches.some(
+        (t) => t.name === "active_projects",
+      );
       expect(hasActiveProjects).toBe(true);
+    });
+
+    // Issue #3289 — verify the active_tasks template wins over
+    // active_projects for task-specific status queries. Without this
+    // template the query falls back to a label-REGEX guess and
+    // returns "No results found" for valid Doing-status tasks.
+    it("should prefer active_tasks over active_projects for the issue-3289 query", () => {
+      const matches = findMatchingTemplates("Какие задачи в статусе Doing?");
+      expect(matches.length).toBeGreaterThan(0);
+      const winner = matches[0];
+      expect(winner.name).toBe("active_tasks");
+      expect(winner.template).toContain("ems__Task");
+      expect(winner.template).toContain("EffortStatusDoing");
+    });
+
+    it('should match active_tasks on the synonym "задачи в работе"', () => {
+      const matches = findMatchingTemplates("задачи в работе");
+      expect(matches.some((t) => t.name === "active_tasks")).toBe(true);
+    });
+
+    it('should match active_tasks on "активные задачи"', () => {
+      const matches = findMatchingTemplates("активные задачи");
+      expect(matches.some((t) => t.name === "active_tasks")).toBe(true);
     });
 
     it("should find templates for average duration", () => {
       const matches = findMatchingTemplates("среднее время");
       expect(matches.length).toBeGreaterThan(0);
-      const hasAverageDuration = matches.some((t) => t.name === "average_duration_by_prototype");
+      const hasAverageDuration = matches.some(
+        (t) => t.name === "average_duration_by_prototype",
+      );
       expect(hasAverageDuration).toBe(true);
     });
 


### PR DESCRIPTION
## Summary

Closes #3289 (short-term mitigation per issue body §"Решение / Краткосрочное"). Adds an `active_tasks` SPARQL template so NL queries like *"Какие задачи в статусе Doing?"*, *"задачи в работе"*, and *"активные задачи"* resolve to a real status-filtered SPARQL query instead of falling back to a label-REGEX guess that returns `No results found`.

## Diff outline

- `packages/exocortex/src/services/SPARQLTemplateLibrary.ts`: new `active_tasks` template mirroring `active_projects` but with `ASSET_CLASSES.TASK` + Doing-status filter. Inline comment documents the long-term homoiconic NL→SPARQL roadmap (still tracked in #3289).
- `packages/exocortex/tests/services/SPARQLTemplateLibrary.test.ts`: 3 new tests asserting the new template wins for the AC queries; `knownTemplates` list extended.

## Disambiguation discipline

The template's keyword set excludes the bare tokens `задачи` / `tasks`, and the examples avoid the Russian particle `в`. For the legacy query *"найди все задачи"* the existing `search_by_label` template still wins — its `найди` keyword + 3-word example overlap (`найди все задачи`) yield score 3.5 vs `active_tasks`' 2.0, preserving the legacy test contract.

## Test plan

- [x] `packages/exocortex/tests/services/SPARQLTemplateLibrary.test.ts` — 38/38 PASS
  - 3 new tests assert `active_tasks` wins for the AC queries
  - `should find templates matching search keywords` (legacy: search_by_label wins for "найди все задачи") — unchanged ✓
  - `should find templates for project queries` (active_projects wins for "активные проекты") — unchanged ✓
- [x] Pre-commit hook (lint-staged + Archgate 13/13 + BDD coverage) PASS

## Risk

Low. Pure additive — one new template entry. Disambiguation strategy explicitly verified by keeping the legacy test contract intact. Long-term architectural rework remains tracked in #3289.