### PR TITLE
fix(#3281): cross-vault SPARQL index + runtime materialization

### DIFF
--- a/packages/cli/src/cache/CacheManager.ts
+++ b/packages/cli/src/cache/CacheManager.ts
@@ -1,7 +1,18 @@
 import path from "path";
 import fs from "fs-extra";
-import { NoteToRDFConverter, Triple, IRI, Literal, BlankNode } from "exocortex";
+import { NoteToRDFConverter, Triple, IRI } from "exocortex";
 import { FileSystemVaultAdapter } from "../adapters/FileSystemVaultAdapter.js";
+import {
+  serializeNode,
+  deserializeNode,
+  type SerializedNode,
+  type SerializedTriple,
+} from "./tripleSerialization.js";
+
+// Re-export for callers that previously imported these from CacheManager
+// (kept for backward compatibility within the cli package surface).
+export { serializeNode, deserializeNode };
+export type { SerializedNode, SerializedTriple };
 
 /**
  * Cache metadata stored alongside the triple cache
@@ -17,25 +28,6 @@ export interface CacheMetadata {
   tripleCount: number;
   /** Vault directory mtime when cache was created */
   vaultMtime: number;
-}
-
-/**
- * Serializable triple representation for JSON storage
- */
-interface SerializedTriple {
-  subject: SerializedNode;
-  predicate: SerializedNode;
-  object: SerializedNode;
-}
-
-/**
- * Serializable RDF node representation
- */
-interface SerializedNode {
-  type: "IRI" | "Literal" | "BlankNode";
-  value: string;
-  datatype?: string;
-  language?: string;
 }
 
 /**
@@ -395,51 +387,6 @@ export class CacheManager {
   }
 }
 
-/**
- * Serializes an RDF node to JSON-compatible format
- */
-function serializeNode(node: Triple["subject"] | Triple["predicate"] | Triple["object"]): SerializedNode {
-  if (node instanceof IRI) {
-    return { type: "IRI", value: node.value };
-  }
-
-  if (node instanceof Literal) {
-    const result: SerializedNode = { type: "Literal", value: node.value };
-    if (node.datatype) {
-      result.datatype = node.datatype.value;
-    }
-    if (node.language) {
-      result.language = node.language;
-    }
-    return result;
-  }
-
-  if (node instanceof BlankNode) {
-    return { type: "BlankNode", value: node.value };
-  }
-
-  // Fallback for QuotedTriple or unknown types
-  return { type: "IRI", value: String(node) };
-}
-
-/**
- * Deserializes an RDF node from JSON format
- */
-function deserializeNode(data: SerializedNode): IRI | Literal | BlankNode {
-  switch (data.type) {
-    case "IRI":
-      return new IRI(data.value);
-    case "Literal":
-      if (data.datatype) {
-        return new Literal(data.value, new IRI(data.datatype));
-      }
-      if (data.language) {
-        return new Literal(data.value, undefined, data.language);
-      }
-      return new Literal(data.value);
-    case "BlankNode":
-      return new BlankNode(data.value);
-    default:
-      return new IRI(data.value);
-  }
-}
+// serializeNode/deserializeNode now live in ./tripleSerialization.ts —
+// re-exported above for backward compatibility with imports that
+// previously pulled them from this module.

--- a/packages/cli/src/cache/CombinedCacheManager.ts
+++ b/packages/cli/src/cache/CombinedCacheManager.ts
@@ -1,0 +1,340 @@
+import path from "path";
+import crypto from "crypto";
+import fs from "fs-extra";
+import { Triple } from "exocortex";
+import {
+  serializeNode,
+  deserializeNode,
+  type SerializedTriple,
+} from "./tripleSerialization.js";
+import type { LoadOrBuildResult } from "./CacheManager.js";
+
+/**
+ * Combined-cache metadata stored alongside the multi-vault triple cache.
+ *
+ * Unlike single-vault CacheManager metadata, this tracks mtimes for ALL
+ * participating vaults so the cache invalidates whenever ANY vault changes.
+ */
+export interface CombinedCacheMetadata {
+  /** CLI version used to create cache */
+  version: string;
+  /** Cache creation timestamp (Unix ms) */
+  timestamp: number;
+  /**
+   * All vault paths participating in the combined cache, sorted lexically.
+   * Order is normalized — `--also A --also B` and `--also B --also A` produce
+   * the same metadata.vaultPaths array and the same cache file name.
+   */
+  vaultPaths: string[];
+  /** Map of vaultPath → mtimeMs at cache creation time */
+  vaultMtimes: Record<string, number>;
+  /** Number of triples cached (after RDFS + prototype materialization) */
+  tripleCount: number;
+}
+
+interface CombinedCacheData {
+  metadata: CombinedCacheMetadata;
+  triples: SerializedTriple[];
+}
+
+export interface CombinedCacheStats {
+  /** Triple count in cache */
+  tripleCount: number;
+  /** Cache creation timestamp */
+  createdAt: Date;
+  /** Whether cache is currently valid (all vault mtimes match) */
+  isValid: boolean;
+  /** Cache file size in bytes */
+  sizeBytes: number;
+  /** All vault paths represented in the cache */
+  vaultPaths: string[];
+}
+
+/**
+ * Manages a persistent triple cache that spans multiple vaults.
+ *
+ * Issue #3281: cross-vault SPARQL recall was ~19% because (a) `sparql index`
+ * had no `--also` flag and (b) `query --use-cache --also` could only load
+ * per-vault caches that materialize inferences within each vault individually,
+ * missing cross-vault RDFS subClass chains and prototype inheritance.
+ *
+ * CombinedCacheManager fixes this by:
+ *   - Concatenating triples from primary + each `--also` vault
+ *   - Allowing the caller (sparql-index command) to run RDFS / prototype-chain
+ *     materialization on the **combined** triple store before saving
+ *   - Persisting the materialized result to a per-combination cache file so
+ *     subsequent `query --use-cache --also` reads see the full inference set
+ *
+ * Cache file path: `<primary>/.exocortex/cache/combined-<hash>.json`
+ *   where `<hash>` is a stable hash of the sorted list of all vault paths.
+ *   Two runs that pass the same vaults in different `--also` orders share
+ *   the same physical cache file.
+ *
+ * Invalidation: cache is invalid when ANY participating vault's mtimeMs no
+ * longer matches the recorded value.
+ *
+ * @example
+ * ```typescript
+ * const cache = new CombinedCacheManager("/path/to/primary", ["/path/to/other"]);
+ *
+ * // Check / build
+ * if (!await cache.isCacheValid()) {
+ *   const triples = await loadAllVaultTriples(); // caller orchestrates
+ *   // ... caller runs RDFS + prototype-chain materialization ...
+ *   await cache.saveTriples(materializedTriples);
+ * }
+ *
+ * // Load
+ * const triples = await cache.loadFromCache();
+ * ```
+ */
+export class CombinedCacheManager {
+  private readonly primaryVaultPath: string;
+  /** Sorted, deduplicated `--also` vault paths (does NOT include primary). */
+  private readonly alsoVaultPaths: string[];
+  /** Primary + sorted alsos, used for cache-key hash and mtime tracking. */
+  private readonly allVaultPaths: string[];
+  private readonly cachePath: string;
+  private readonly cliVersion: string = "1.0.0";
+
+  constructor(primaryVaultPath: string, alsoVaultPaths: string[] = []) {
+    this.primaryVaultPath = path.resolve(primaryVaultPath);
+
+    // Resolve, dedupe, and sort `--also` paths. Sorting normalizes ordering so
+    // `--also A --also B` and `--also B --also A` share the same cache file.
+    // Dedupe protects against accidental repetition of the primary path or
+    // duplicate `--also` flags.
+    const resolved = alsoVaultPaths
+      .map((p) => path.resolve(p))
+      .filter((p) => p !== this.primaryVaultPath);
+    const uniq = Array.from(new Set(resolved)).sort();
+    this.alsoVaultPaths = uniq;
+
+    // Full sorted list including primary, used for cache key + mtime tracking.
+    this.allVaultPaths = [this.primaryVaultPath, ...uniq].sort();
+
+    const hash = CombinedCacheManager.computeCacheKey(this.allVaultPaths);
+    this.cachePath = path.join(
+      this.primaryVaultPath,
+      ".exocortex",
+      "cache",
+      `combined-${hash}.json`,
+    );
+  }
+
+  /**
+   * Returns the path to the combined cache file. Always lives under
+   * `<primary>/.exocortex/cache/`.
+   */
+  getCachePath(): string {
+    return this.cachePath;
+  }
+
+  /** Returns the resolved primary vault path. */
+  getPrimaryVaultPath(): string {
+    return this.primaryVaultPath;
+  }
+
+  /**
+   * Returns the resolved `--also` vault paths, sorted and deduplicated.
+   * Does NOT include the primary vault.
+   */
+  getAlsoVaultPaths(): string[] {
+    return [...this.alsoVaultPaths];
+  }
+
+  /**
+   * Returns all vault paths (primary + alsos), sorted. Used for hash
+   * computation and mtime checks.
+   */
+  getAllVaultPaths(): string[] {
+    return [...this.allVaultPaths];
+  }
+
+  /**
+   * Computes a stable cache-key hash from a sorted list of vault paths.
+   *
+   * 64-bit hex digest is enough to make accidental collisions astronomically
+   * unlikely across realistic combinations of vault paths a user might run.
+   */
+  static computeCacheKey(sortedVaultPaths: string[]): string {
+    return crypto
+      .createHash("sha256")
+      .update(sortedVaultPaths.join("\n"))
+      .digest("hex")
+      .slice(0, 16);
+  }
+
+  /**
+   * Cache is valid when:
+   *   - Cache file exists and parses
+   *   - Metadata version present
+   *   - Recorded vaultPaths set matches current allVaultPaths (deep equal)
+   *   - mtimeMs of every recorded vault still matches
+   */
+  async isCacheValid(): Promise<boolean> {
+    try {
+      if (!(await fs.pathExists(this.cachePath))) {
+        return false;
+      }
+
+      const cacheData = (await fs.readJson(this.cachePath)) as CombinedCacheData;
+
+      if (
+        !cacheData.metadata ||
+        typeof cacheData.metadata.tripleCount !== "number" ||
+        !Array.isArray(cacheData.metadata.vaultPaths) ||
+        !cacheData.metadata.vaultMtimes ||
+        typeof cacheData.metadata.vaultMtimes !== "object"
+      ) {
+        return false;
+      }
+
+      // Path set must match exactly (same vaults participated)
+      const recordedSorted = [...cacheData.metadata.vaultPaths].sort();
+      if (
+        recordedSorted.length !== this.allVaultPaths.length ||
+        recordedSorted.some((p, i) => p !== this.allVaultPaths[i])
+      ) {
+        return false;
+      }
+
+      // Every vault's current mtime must match the recorded value
+      for (const vp of this.allVaultPaths) {
+        const recordedMtime = cacheData.metadata.vaultMtimes[vp];
+        if (typeof recordedMtime !== "number") {
+          return false;
+        }
+        try {
+          const stats = await fs.stat(vp);
+          if (stats.mtimeMs !== recordedMtime) {
+            return false;
+          }
+        } catch {
+          // Vault disappeared since cache was built
+          return false;
+        }
+      }
+
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * Loads triples from the cache file. Caller MUST ensure cache is valid first
+   * (via `isCacheValid()`); calling this on a stale cache returns stale data.
+   */
+  async loadFromCache(): Promise<Triple[]> {
+    const cacheData = (await fs.readJson(this.cachePath)) as CombinedCacheData;
+    return cacheData.triples.map((data) => {
+      return new Triple(
+        deserializeNode(data.subject) as Triple["subject"],
+        deserializeNode(data.predicate) as Triple["predicate"],
+        deserializeNode(data.object) as Triple["object"],
+      );
+    });
+  }
+
+  /**
+   * Convenience: load triples from cache if valid, otherwise return null.
+   *
+   * Unlike single-vault CacheManager.loadOrBuild, this does NOT auto-build
+   * the cache — building requires orchestration (multi-vault loading,
+   * cross-vault wikilink resolution, RDFS + prototype materialization) that
+   * is owned by the `sparql-index` command. Callers that get null should
+   * either build via `sparql-index --also` first, or fall back to a per-vault
+   * non-cached path.
+   */
+  async loadIfValid(): Promise<LoadOrBuildResult | null> {
+    const startTime = Date.now();
+    if (!(await this.isCacheValid())) {
+      return null;
+    }
+    const triples = await this.loadFromCache();
+    return {
+      triples,
+      cacheHit: true,
+      durationMs: Date.now() - startTime,
+    };
+  }
+
+  /**
+   * Saves a set of materialized triples to the combined cache.
+   *
+   * Captures the mtime of every participating vault so subsequent
+   * `isCacheValid()` calls can detect any vault change.
+   *
+   * Implementation note: the cache directory is created BEFORE capturing
+   * vault mtimes, because creating `.exocortex/cache/` under the primary
+   * vault mutates the primary vault's directory mtime. Capturing mtimes
+   * after the ensureDir guarantees the recorded value matches the
+   * post-write filesystem state, so a fresh `isCacheValid()` immediately
+   * after `saveTriples()` returns true.
+   */
+  async saveTriples(triples: Triple[]): Promise<void> {
+    // Create cache dir first so it doesn't bump primary's mtime after
+    // we've already recorded the "before" value.
+    await fs.ensureDir(path.dirname(this.cachePath));
+
+    const serializedTriples = triples.map((triple) => ({
+      subject: serializeNode(triple.subject),
+      predicate: serializeNode(triple.predicate),
+      object: serializeNode(triple.object),
+    }));
+
+    // Capture mtimes after ensureDir so the values reflect post-write state.
+    const vaultMtimes: Record<string, number> = {};
+    for (const vp of this.allVaultPaths) {
+      const stats = await fs.stat(vp);
+      vaultMtimes[vp] = stats.mtimeMs;
+    }
+
+    const cacheData: CombinedCacheData = {
+      metadata: {
+        version: this.cliVersion,
+        timestamp: Date.now(),
+        vaultPaths: [...this.allVaultPaths],
+        vaultMtimes,
+        tripleCount: triples.length,
+      },
+      triples: serializedTriples,
+    };
+
+    await fs.writeJson(this.cachePath, cacheData, { spaces: 0 });
+  }
+
+  /** Deletes the combined cache file if it exists. */
+  async invalidate(): Promise<void> {
+    if (await fs.pathExists(this.cachePath)) {
+      await fs.remove(this.cachePath);
+    }
+  }
+
+  /**
+   * Returns statistics about the current combined cache, or null if the cache
+   * file does not exist.
+   */
+  async getCacheStats(): Promise<CombinedCacheStats | null> {
+    try {
+      if (!(await fs.pathExists(this.cachePath))) {
+        return null;
+      }
+
+      const cacheData = (await fs.readJson(this.cachePath)) as CombinedCacheData;
+      const fileStats = await fs.stat(this.cachePath);
+      const isValid = await this.isCacheValid();
+
+      return {
+        tripleCount: cacheData.metadata.tripleCount,
+        createdAt: new Date(cacheData.metadata.timestamp),
+        isValid,
+        sizeBytes: fileStats.size,
+        vaultPaths: cacheData.metadata.vaultPaths,
+      };
+    } catch {
+      return null;
+    }
+  }
+}

--- a/packages/cli/src/cache/buildCombinedTriples.ts
+++ b/packages/cli/src/cache/buildCombinedTriples.ts
@@ -1,0 +1,165 @@
+import { existsSync } from "fs";
+import { resolve } from "path";
+import {
+  InMemoryTripleStore,
+  RDFSInferenceEngine,
+  NonInheritablePropertyRegistry,
+  PropertyCardinalityRegistry,
+  PrototypeChainMaterializer,
+  NoteToRDFConverter,
+  Triple,
+} from "exocortex";
+import { FileSystemVaultAdapter } from "../adapters/FileSystemVaultAdapter.js";
+import { VaultNotFoundError } from "../utils/errors/index.js";
+import { resolveCrossVaultInstanceClassWikilinks } from "../commands/validate-schema.js";
+
+export interface BuildCombinedTriplesOptions {
+  /** Disable RDFS subClassOf inference materialization */
+  noInference?: boolean;
+  /** Suppress console output during build (default: false) */
+  silent?: boolean;
+  /** Custom logger; defaults to console.log */
+  log?: (msg: string) => void;
+}
+
+export interface BuildCombinedTriplesResult {
+  /** Materialized triple set (cross-vault resolved + RDFS + prototype chain) */
+  triples: Triple[];
+  /** Raw triples loaded from vaults, before any post-processing */
+  rawTripleCount: number;
+  /** Triples emitted by cross-vault Instance_class resolution */
+  crossVaultAddedTripleCount: number;
+  /** Triples emitted by RDFS + prototype chain materialization */
+  inferredTripleCount: number;
+}
+
+/**
+ * Loads triples from a primary vault plus zero or more `--also` vaults,
+ * applies cross-vault wikilink resolution, and runs RDFS + prototype-chain
+ * materialization on the combined triple store.
+ *
+ * This is the orchestration shared by `sparql index --also` (Issue #3281)
+ * and any future caller that needs a cross-vault materialized triple set.
+ *
+ * Behaviour:
+ *   1. For each vault path (primary + alsos): construct a per-vault adapter,
+ *      run NoteToRDFConverter.convertVault, and concat the raw triples.
+ *   2. Apply `resolveCrossVaultInstanceClassWikilinks` so an asset in vault A
+ *      that declares `exo__Instance_class: [[<class-uid>]]` is properly typed
+ *      even when the class file lives in vault B.
+ *   3. Add all triples to an InMemoryTripleStore.
+ *   4. Run RDFSInferenceEngine.materialize on the combined store, then
+ *      PrototypeChainMaterializer (gated on NonInheritablePropertyRegistry +
+ *      PropertyCardinalityRegistry, mirroring sparql-index.ts behaviour).
+ *   5. Return the materialized triple set together with diagnostic counts.
+ *
+ * @throws VaultNotFoundError if any vault path does not exist.
+ */
+export async function buildCombinedTriples(
+  primaryVaultPath: string,
+  alsoVaultPaths: string[],
+  options: BuildCombinedTriplesOptions = {},
+): Promise<BuildCombinedTriplesResult> {
+  const silent = options.silent ?? false;
+  const log = options.log ?? ((msg: string) => console.log(msg));
+
+  const primary = resolve(primaryVaultPath);
+  if (!existsSync(primary)) {
+    throw new VaultNotFoundError(primary);
+  }
+
+  // Resolve, dedupe (against primary), and preserve original order for log clarity.
+  const resolvedAlsos: string[] = [];
+  for (const a of alsoVaultPaths) {
+    const r = resolve(a);
+    if (!existsSync(r)) {
+      throw new VaultNotFoundError(r);
+    }
+    if (r === primary || resolvedAlsos.includes(r)) {
+      continue;
+    }
+    resolvedAlsos.push(r);
+  }
+
+  // Load primary
+  if (!silent) {
+    log(`📦 Loading primary vault: ${primary}...`);
+  }
+  let triples: Triple[] = [];
+  const primaryAdapter = new FileSystemVaultAdapter(primary);
+  const primaryConverter = new NoteToRDFConverter(primaryAdapter);
+  const primaryTriples = await primaryConverter.convertVault();
+  triples = triples.concat(primaryTriples);
+  if (!silent) {
+    log(`   ➕ Added ${primaryTriples.length} triples from primary vault`);
+  }
+
+  // Load each --also vault
+  for (const alsoPath of resolvedAlsos) {
+    if (!silent) {
+      log(`📦 Loading additional vault: ${alsoPath}...`);
+    }
+    const alsoAdapter = new FileSystemVaultAdapter(alsoPath);
+    const alsoConverter = new NoteToRDFConverter(alsoAdapter);
+    const alsoTriples = await alsoConverter.convertVault();
+    triples = triples.concat(alsoTriples);
+    if (!silent) {
+      log(`   ➕ Added ${alsoTriples.length} triples from ${alsoPath}`);
+    }
+  }
+
+  const rawTripleCount = triples.length;
+
+  // Cross-vault Instance_class resolution — emits canonical-IRI triples for
+  // assets whose class definition lives in another vault.
+  let crossVaultAddedTripleCount = 0;
+  if (resolvedAlsos.length > 0) {
+    const before = triples.length;
+    // resolveCrossVaultInstanceClassWikilinks operates on the DomainTriple type
+    // which is a re-export of the same Triple class; safe to cast.
+    triples = resolveCrossVaultInstanceClassWikilinks(triples as Triple[]) as Triple[];
+    crossVaultAddedTripleCount = triples.length - before;
+    if (!silent && crossVaultAddedTripleCount > 0) {
+      log(
+        `   🔗 Cross-vault Instance_class resolution: emitted ${crossVaultAddedTripleCount} canonical-IRI triple(s)`,
+      );
+    }
+  }
+
+  // Materialization (mirrors sparql-index.ts current single-vault behaviour
+  // but runs on the combined store so cross-vault subclass / prototype
+  // chains are now visible to the reasoner).
+  let inferredTripleCount = 0;
+  if (options.noInference !== true) {
+    const tripleStore = new InMemoryTripleStore();
+    await tripleStore.addAll(triples);
+
+    const rdfsEngine = new RDFSInferenceEngine();
+    const rdfsCount = await rdfsEngine.materialize(tripleStore);
+    inferredTripleCount += rdfsCount;
+
+    const registry = new NonInheritablePropertyRegistry();
+    await registry.initialize(tripleStore);
+    const cardinalityRegistry = new PropertyCardinalityRegistry();
+    await cardinalityRegistry.initialize(tripleStore);
+    const protoMaterializer = new PrototypeChainMaterializer(registry, cardinalityRegistry);
+    const protoCount = await protoMaterializer.materialize(tripleStore);
+    inferredTripleCount += protoCount;
+
+    if (inferredTripleCount > 0) {
+      triples = await tripleStore.match();
+      if (!silent) {
+        log(
+          `🧠 Materialized ${inferredTripleCount} inferred triples on combined store (RDFS + prototype chain)`,
+        );
+      }
+    }
+  }
+
+  return {
+    triples,
+    rawTripleCount,
+    crossVaultAddedTripleCount,
+    inferredTripleCount,
+  };
+}

--- a/packages/cli/src/cache/tripleSerialization.ts
+++ b/packages/cli/src/cache/tripleSerialization.ts
@@ -1,0 +1,75 @@
+import { Triple, IRI, Literal, BlankNode } from "exocortex";
+
+/**
+ * Serializable RDF node representation used by the JSON triple-cache format.
+ */
+export interface SerializedNode {
+  type: "IRI" | "Literal" | "BlankNode";
+  value: string;
+  datatype?: string;
+  language?: string;
+}
+
+/**
+ * Serializable triple representation used by the JSON triple-cache format.
+ */
+export interface SerializedTriple {
+  subject: SerializedNode;
+  predicate: SerializedNode;
+  object: SerializedNode;
+}
+
+/**
+ * Serializes an RDF node to JSON-compatible format.
+ *
+ * Used by both CacheManager (single-vault cache) and CombinedCacheManager
+ * (cross-vault cache, Issue #3281). Keep these helpers in their own module
+ * so test mocks of either cache class do not need to re-export them.
+ */
+export function serializeNode(
+  node: Triple["subject"] | Triple["predicate"] | Triple["object"],
+): SerializedNode {
+  if (node instanceof IRI) {
+    return { type: "IRI", value: node.value };
+  }
+
+  if (node instanceof Literal) {
+    const result: SerializedNode = { type: "Literal", value: node.value };
+    if (node.datatype) {
+      result.datatype = node.datatype.value;
+    }
+    if (node.language) {
+      result.language = node.language;
+    }
+    return result;
+  }
+
+  if (node instanceof BlankNode) {
+    return { type: "BlankNode", value: node.value };
+  }
+
+  // Fallback for QuotedTriple or unknown types
+  return { type: "IRI", value: String(node) };
+}
+
+/**
+ * Deserializes an RDF node from JSON format.
+ */
+export function deserializeNode(data: SerializedNode): IRI | Literal | BlankNode {
+  switch (data.type) {
+    case "IRI":
+      return new IRI(data.value);
+    case "Literal":
+      if (data.datatype) {
+        return new Literal(data.value, new IRI(data.datatype));
+      }
+      if (data.language) {
+        return new Literal(data.value, undefined, data.language);
+      }
+      return new Literal(data.value);
+    case "BlankNode":
+      return new BlankNode(data.value);
+    default:
+      return new IRI(data.value);
+  }
+}

--- a/packages/cli/src/commands/sparql-index.ts
+++ b/packages/cli/src/commands/sparql-index.ts
@@ -3,12 +3,15 @@ import { existsSync } from "fs";
 import { resolve } from "path";
 import { InMemoryTripleStore, RDFSInferenceEngine, NonInheritablePropertyRegistry, PropertyCardinalityRegistry, PrototypeChainMaterializer } from "exocortex";
 import { CacheManager } from "../cache/CacheManager.js";
+import { CombinedCacheManager } from "../cache/CombinedCacheManager.js";
+import { buildCombinedTriples } from "../cache/buildCombinedTriples.js";
 import { ErrorHandler, type OutputFormat } from "../utils/ErrorHandler.js";
 import { VaultNotFoundError } from "../utils/errors/index.js";
 import { ResponseBuilder, type CacheResult, type CacheStatsResult } from "../responses/index.js";
 
 export interface SparqlIndexOptions {
   vault: string;
+  also?: string[];
   output?: OutputFormat;
   stats?: boolean;
   force?: boolean;
@@ -17,10 +20,24 @@ export interface SparqlIndexOptions {
 }
 
 /**
+ * Commander.js accumulator for repeatable --also flag.
+ * Each --also <path> adds a vault path to the array.
+ */
+function collectAlso(value: string, previous: string[]): string[] {
+  return previous.concat([value]);
+}
+
+/**
  * Creates the 'sparql index' subcommand for building/managing the triple cache.
  *
  * The index command creates a persistent cache of RDF triples from the vault,
  * enabling fast subsequent SPARQL queries without re-parsing all files.
+ *
+ * With one or more `--also <path>` flags, the command builds a **combined**
+ * cross-vault cache materialized over the union of the primary and `--also`
+ * vaults (Issue #3281). The combined cache lives at
+ * `<primary>/.exocortex/cache/combined-<hash>.json` and is consumed by
+ * `sparql query --use-cache --also` when the same set of vaults is queried.
  *
  * @returns Commander Command instance configured for cache management
  *
@@ -29,11 +46,13 @@ export interface SparqlIndexOptions {
  * exocortex sparql index --vault /path/to/vault --stats
  * exocortex sparql index --vault /path/to/vault --force
  * exocortex sparql index --vault /path/to/vault --strict
+ * exocortex sparql index --vault /path/to/primary --also /path/to/other
  */
 export function sparqlIndexCommand(): Command {
   return new Command("index")
     .description("Build or refresh the triple cache for faster SPARQL queries")
     .option("--vault <path>", "Path to Obsidian vault", process.cwd())
+    .option("--also <path>", "Additional vault to include in combined index (repeatable, Issue #3281)", collectAlso, [])
     .option("--output <type>", "Response format: text|json (for MCP tools)", "text")
     .option("--stats", "Show cache statistics after building")
     .option("--force", "Force rebuild even if cache is valid")
@@ -49,6 +68,15 @@ export function sparqlIndexCommand(): Command {
           throw new VaultNotFoundError(vaultPath);
         }
 
+        const alsoVaults = options.also ?? [];
+
+        // Multi-vault path: build combined cross-vault index (Issue #3281)
+        if (alsoVaults.length > 0) {
+          await runCombinedIndex(vaultPath, alsoVaults, options, outputFormat);
+          return;
+        }
+
+        // Single-vault path: original behaviour, unchanged for backward compat
         const cacheManager = new CacheManager(vaultPath);
         const cachePath = cacheManager.getCachePath();
 
@@ -171,6 +199,134 @@ export function sparqlIndexCommand(): Command {
         ErrorHandler.handle(error as Error);
       }
     });
+}
+
+/**
+ * Build/refresh a combined cross-vault triple cache (Issue #3281).
+ *
+ * Materializes RDFS + prototype-chain inferences over the union of triples
+ * from `primary` and every `alsoVaults` path. The resulting triple set is
+ * persisted under `<primary>/.exocortex/cache/combined-<hash>.json` where
+ * `<hash>` is a stable hash of the sorted vault-path set, so subsequent
+ * `sparql query --use-cache --also` calls with the same vault set hit the
+ * combined cache directly.
+ */
+async function runCombinedIndex(
+  primary: string,
+  alsoVaults: string[],
+  options: SparqlIndexOptions,
+  outputFormat: OutputFormat,
+): Promise<void> {
+  // Pre-validate that every --also path exists so the user sees an early
+  // error rather than partial-build state.
+  for (const a of alsoVaults) {
+    const resolved = resolve(a);
+    if (!existsSync(resolved)) {
+      throw new VaultNotFoundError(resolved);
+    }
+  }
+
+  const combinedCache = new CombinedCacheManager(primary, alsoVaults);
+  const cachePath = combinedCache.getCachePath();
+
+  if (options.force) {
+    if (outputFormat === "text") {
+      console.log("🗑️  Invalidating existing combined cache...");
+    }
+    await combinedCache.invalidate();
+  }
+
+  if (outputFormat === "text") {
+    console.log(
+      `📦 Building combined triple cache (${combinedCache.getAllVaultPaths().length} vaults)...`,
+    );
+  }
+
+  const startTime = Date.now();
+
+  // buildCombinedTriples handles per-vault load, cross-vault Instance_class
+  // resolution, and RDFS + prototype-chain materialization on the combined
+  // store. Disabling `noInference` mirrors `--no-inference` flag semantics.
+  const buildResult = await buildCombinedTriples(primary, alsoVaults, {
+    noInference: options.inference === false,
+    silent: outputFormat !== "text",
+  });
+
+  await combinedCache.saveTriples(buildResult.triples);
+
+  const totalDuration = Date.now() - startTime;
+  const tripleCount = buildResult.triples.length;
+
+  if (outputFormat === "json") {
+    const cacheResult: CacheResult = {
+      action: "build",
+      cachePath,
+      tripleCount,
+      durationMs: totalDuration,
+    };
+
+    if (options.stats) {
+      const stats = await combinedCache.getCacheStats();
+      if (stats) {
+        const statsResult: CacheStatsResult = {
+          tripleCount: stats.tripleCount,
+          createdAt: stats.createdAt.toISOString(),
+          isValid: stats.isValid,
+          sizeBytes: stats.sizeBytes,
+          cachePath,
+        };
+        const response = ResponseBuilder.success(
+          {
+            cache: cacheResult,
+            stats: statsResult,
+            combined: {
+              vaultPaths: combinedCache.getAllVaultPaths(),
+              rawTripleCount: buildResult.rawTripleCount,
+              crossVaultAddedTripleCount: buildResult.crossVaultAddedTripleCount,
+              inferredTripleCount: buildResult.inferredTripleCount,
+            },
+          },
+          { durationMs: totalDuration },
+        );
+        console.log(JSON.stringify(response, null, 2));
+        return;
+      }
+    }
+
+    const response = ResponseBuilder.success(
+      {
+        cache: cacheResult,
+        combined: {
+          vaultPaths: combinedCache.getAllVaultPaths(),
+          rawTripleCount: buildResult.rawTripleCount,
+          crossVaultAddedTripleCount: buildResult.crossVaultAddedTripleCount,
+          inferredTripleCount: buildResult.inferredTripleCount,
+        },
+      },
+      { durationMs: totalDuration },
+    );
+    console.log(JSON.stringify(response, null, 2));
+  } else {
+    console.log(
+      `📊 Created combined cache with ${tripleCount.toLocaleString()} triples at ${cachePath}`,
+    );
+    console.log(`⏱️  Build time: ${totalDuration}ms`);
+
+    if (options.stats) {
+      const stats = await combinedCache.getCacheStats();
+      if (stats) {
+        console.log("\n📊 Combined Cache Statistics:");
+        console.log(`   Triples: ${stats.tripleCount.toLocaleString()}`);
+        console.log(`   Created: ${stats.createdAt.toISOString()}`);
+        console.log(`   Valid: ${stats.isValid ? "✅ Yes" : "❌ No"}`);
+        console.log(`   Size: ${formatBytes(stats.sizeBytes)}`);
+        console.log(`   Vaults (${stats.vaultPaths.length}):`);
+        for (const vp of stats.vaultPaths) {
+          console.log(`     - ${vp}`);
+        }
+      }
+    }
+  }
 }
 
 /**

--- a/packages/cli/src/commands/sparql-query.ts
+++ b/packages/cli/src/commands/sparql-query.ts
@@ -27,6 +27,7 @@ import { VaultNotFoundError, InvalidArgumentsError, QueryTimeoutError } from "..
 import { ResponseBuilder, ErrorCode, type QueryResult, type ConstructResult } from "../responses/index.js";
 import { ExitCodes } from "../utils/ExitCodes.js";
 import { CacheManager } from "../cache/CacheManager.js";
+import { CombinedCacheManager } from "../cache/CombinedCacheManager.js";
 import { QueryResultCache } from "../cache/QueryResultCache.js";
 import { ProgressIndicator } from "../utils/ProgressIndicator.js";
 import { QueryAnalyzer } from "../utils/QueryAnalyzer.js";
@@ -398,55 +399,94 @@ export function sparqlQueryCommand(): Command {
           useCacheEffective = false;
         }
 
-        let triples: Triple[];
+        let triples: Triple[] = [];
         let cacheHit = false;
+        let combinedCacheHit = false;
 
-        if (useCacheEffective) {
-          // Use cached triples for faster loading
-          const cacheManager = new CacheManager(vaultPath);
-          const cacheResult = await cacheManager.loadOrBuild();
-          triples = cacheResult.triples;
-          cacheHit = cacheResult.cacheHit;
-
-          if (outputFormat === "text" && cacheHit) {
-            console.log(`🚀 Cache hit! Loading from persistent cache...`);
-          }
-        } else {
-          // Traditional vault loading
-          const vaultAdapter = new FileSystemVaultAdapter(vaultPath);
-          const converter = new NoteToRDFConverter(vaultAdapter);
-          triples = await converter.convertVault(
-            profileFilter !== null
-              ? {
-                  effectiveOntologies: profileFilter.effective,
-                  assetSpaceFolderToUid: profileFilter.folderMap,
-                }
-              : {},
+        // Issue #3281: when both --use-cache and --also are specified, try the
+        // combined cross-vault index first. It contains primary + every --also
+        // vault's triples WITH RDFS / prototype-chain materialization applied
+        // over the combined store, so cross-vault subClass and prototype chains
+        // resolve correctly (previous per-vault caches materialized inferences
+        // within each vault individually, missing cross-vault deductions).
+        //
+        // Combined cache is gated on `profileFilter === null` because profile
+        // filters apply at convertVault() time and the combined cache was
+        // built without profile awareness — applying a profile to cached
+        // triples would silently mis-filter. Profile-aware combined caching
+        // is follow-up scope (#3286/#3282 + future profile interaction).
+        if (useCacheEffective && alsoVaults.length > 0 && profileFilter === null) {
+          const combinedCache = new CombinedCacheManager(
+            vaultPath,
+            alsoVaults.map((a) => resolve(a)),
           );
+          const combinedResult = await combinedCache.loadIfValid();
+          if (combinedResult !== null) {
+            triples = combinedResult.triples;
+            cacheHit = true;
+            combinedCacheHit = true;
+            if (outputFormat === "text") {
+              console.log(
+                `🚀 Combined cache hit! Loaded ${triples.length} triples from cross-vault index (${combinedCache.getAllVaultPaths().length} vaults).`,
+              );
+            }
+          } else {
+            if (outputFormat === "text") {
+              console.log(
+                `ℹ️  Combined cache miss (or invalid). Falling back to per-vault load. Run \`exocortex sparql index --vault <primary> --also <...>\` to build the cross-vault index.`,
+              );
+            }
+          }
         }
 
-        // Load additional vaults if --also specified
-        for (const alsoPath of alsoVaults) {
-          const resolvedAlsoPath = resolve(alsoPath);
-          if (!existsSync(resolvedAlsoPath)) {
-            throw new VaultNotFoundError(resolvedAlsoPath);
+        if (!combinedCacheHit) {
+          if (useCacheEffective) {
+            // Use cached triples for faster loading (primary vault only)
+            const cacheManager = new CacheManager(vaultPath);
+            const cacheResult = await cacheManager.loadOrBuild();
+            triples = cacheResult.triples;
+            cacheHit = cacheResult.cacheHit;
+
+            if (outputFormat === "text" && cacheHit) {
+              console.log(`🚀 Cache hit! Loading from persistent cache...`);
+            }
+          } else {
+            // Traditional vault loading
+            const vaultAdapter = new FileSystemVaultAdapter(vaultPath);
+            const converter = new NoteToRDFConverter(vaultAdapter);
+            triples = await converter.convertVault(
+              profileFilter !== null
+                ? {
+                    effectiveOntologies: profileFilter.effective,
+                    assetSpaceFolderToUid: profileFilter.folderMap,
+                  }
+                : {},
+            );
           }
-          if (outputFormat === "text") {
-            console.log(`📦 Loading additional vault: ${resolvedAlsoPath}...`);
-          }
-          const alsoAdapter = new FileSystemVaultAdapter(resolvedAlsoPath);
-          const alsoConverter = new NoteToRDFConverter(alsoAdapter);
-          const alsoTriples = await alsoConverter.convertVault(
-            profileFilter !== null
-              ? {
-                  effectiveOntologies: profileFilter.effective,
-                  assetSpaceFolderToUid: profileFilter.folderMap,
-                }
-              : {},
-          );
-          triples = triples.concat(alsoTriples);
-          if (outputFormat === "text") {
-            console.log(`   ➕ Added ${alsoTriples.length} triples from ${resolvedAlsoPath}`);
+
+          // Load additional vaults if --also specified
+          for (const alsoPath of alsoVaults) {
+            const resolvedAlsoPath = resolve(alsoPath);
+            if (!existsSync(resolvedAlsoPath)) {
+              throw new VaultNotFoundError(resolvedAlsoPath);
+            }
+            if (outputFormat === "text") {
+              console.log(`📦 Loading additional vault: ${resolvedAlsoPath}...`);
+            }
+            const alsoAdapter = new FileSystemVaultAdapter(resolvedAlsoPath);
+            const alsoConverter = new NoteToRDFConverter(alsoAdapter);
+            const alsoTriples = await alsoConverter.convertVault(
+              profileFilter !== null
+                ? {
+                    effectiveOntologies: profileFilter.effective,
+                    assetSpaceFolderToUid: profileFilter.folderMap,
+                  }
+                : {},
+            );
+            triples = triples.concat(alsoTriples);
+            if (outputFormat === "text") {
+              console.log(`   ➕ Added ${alsoTriples.length} triples from ${resolvedAlsoPath}`);
+            }
           }
         }
 

--- a/packages/cli/tests/integration/cross-vault-sparql-recall.test.ts
+++ b/packages/cli/tests/integration/cross-vault-sparql-recall.test.ts
@@ -53,7 +53,6 @@ import { describe, it, expect, beforeEach, afterEach } from "@jest/globals";
 import fs from "fs-extra";
 import path from "path";
 import os from "os";
-import { randomUUID } from "crypto";
 import {
   InMemoryTripleStore,
   NoteToRDFConverter,

--- a/packages/cli/tests/integration/cross-vault-sparql-recall.test.ts
+++ b/packages/cli/tests/integration/cross-vault-sparql-recall.test.ts
@@ -1,0 +1,299 @@
+/**
+ * Empirical cross-vault SPARQL recall test (Issue #3281).
+ *
+ * Fixture design — isolating #3281 from sibling issues:
+ *   - UID-form filenames only (`<uuid>.md`) → sidesteps #3286 (canonical IRI)
+ *   - Wikilinks use UUID-form `[[<uuid>]]` only, never label-form
+ *     → sidesteps #3282 (PropertyPathExecutor label-safety guard)
+ *   - Inference is materialized at INDEX time (sparql-index --also flow),
+ *     not at query time → that is what #3281 fixes (#3283 separate)
+ *   - Class labels use whitelisted namespace prefix `ems__` so
+ *     resolveCrossVaultInstanceClassWikilinks (NAMESPACE_PREFIX_MAP-driven)
+ *     accepts them and produces canonical ontology IRIs
+ *   - Ground truth is computed independently by hand-counting fixtures
+ *     before invoking the engine, never by re-running the engine
+ *
+ * Cross-vault topology:
+ *   - vault-B/<classBaseUid>.md:      ems__XVaultRecallBase    (parent class)
+ *   - vault-B/<classDerivedUid>.md:   ems__XVaultRecallDerived
+ *                                       exo__Class_superClass: [[<classBaseUid>]]
+ *   - vault-A/<assetUid_i>.md × ASSET_COUNT:
+ *                                       exo__Instance_class: [[<classDerivedUid>]]
+ *
+ * Ground-truth representative query: "Find every asset whose canonical
+ * class IRI is <ems#XVaultRecallDerived>", i.e.
+ *
+ *     ?asset rdf:type <https://exocortex.my/ontology/ems#XVaultRecallDerived>
+ *
+ * (RDFS subClassOf propagation up to XVaultRecallBase is deliberately NOT
+ *  exercised — that requires Issue #3286 fixes, since the file-IRI of the
+ *  class definition differs from the canonical class IRI used as the
+ *  object of rdf:type. Within #3281 scope, the load-bearing assertion is
+ *  that cross-vault Instance_class wikilinks resolve to canonical IRIs in
+ *  the combined materialized index.)
+ *
+ * Without cross-vault materialization (#3281 pre-fix), per-vault loading:
+ *   - vault A converter cannot resolve `[[<classDerivedUid>]]` to the
+ *     canonical class IRI because the class file lives in vault B
+ *     → no `?asset rdf:type <ems#XVaultRecallDerived>` triple is emitted
+ *   - vault B contributes no such asset → query recall = 0/ASSET_COUNT
+ *
+ * With cross-vault materialization (#3281 post-fix):
+ *   - buildCombinedTriples loads both vaults, then
+ *     resolveCrossVaultInstanceClassWikilinks emits an
+ *     `<asset> rdf:type <ems#XVaultRecallDerived>` triple for every
+ *     fixture asset → query recall = ASSET_COUNT/ASSET_COUNT
+ *
+ * DoD assertion (issue body): combined-vault recall ≥ 85% on representative
+ * cross-vault analytical query. We assert ≥ 85% post-fix AND <= 20% pre-fix
+ * (revert→fail / restore→pass per integration-test-revert-verify rule).
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "@jest/globals";
+import fs from "fs-extra";
+import path from "path";
+import os from "os";
+import { randomUUID } from "crypto";
+import {
+  InMemoryTripleStore,
+  NoteToRDFConverter,
+  IRI,
+} from "exocortex";
+import { FileSystemVaultAdapter } from "../../src/adapters/FileSystemVaultAdapter.js";
+import { buildCombinedTriples } from "../../src/cache/buildCombinedTriples.js";
+
+const RDF_TYPE_IRI = "http://www.w3.org/1999/02/22-rdf-syntax-ns#type";
+// Use a whitelisted namespace prefix (`ems__`) so the cross-vault wikilink
+// resolver in validate-schema.ts (NAMESPACE_PREFIX_MAP-driven) accepts the
+// class labels and emits canonical IRIs. The unused `test__` prefix is NOT
+// in the whitelist — using it silently breaks cross-vault resolution.
+const TEST_BASE_IRI = "https://exocortex.my/ontology/ems#XVaultRecallBase";
+const TEST_DERIVED_IRI = "https://exocortex.my/ontology/ems#XVaultRecallDerived";
+
+const ASSET_COUNT = 12;
+
+/** Synthesize a UUID-named markdown file with the given frontmatter properties. */
+async function writeAsset(
+  vaultRoot: string,
+  uid: string,
+  frontmatter: Record<string, string | string[]>,
+): Promise<string> {
+  const fmLines: string[] = ["---"];
+  for (const [key, value] of Object.entries(frontmatter)) {
+    if (Array.isArray(value)) {
+      fmLines.push(`${key}:`);
+      for (const v of value) {
+        fmLines.push(`  - "${v}"`);
+      }
+    } else {
+      fmLines.push(`${key}: "${value}"`);
+    }
+  }
+  fmLines.push("---", "");
+  const fullPath = path.join(vaultRoot, `${uid}.md`);
+  await fs.ensureDir(path.dirname(fullPath));
+  await fs.writeFile(fullPath, fmLines.join("\n"));
+  return fullPath;
+}
+
+/**
+ * Build a deterministic UID set so the test can hand-compute ground truth.
+ * UIDs are valid v4-shaped lowercase hex; resolveCrossVaultInstanceClassWikilinks
+ * matches them via /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.
+ */
+function makeUid(seed: string): string {
+  // Build a UUID-v4-shaped string deterministically from the seed.
+  const padded = seed.padEnd(32, "0").slice(0, 32);
+  return [
+    padded.slice(0, 8),
+    padded.slice(8, 12),
+    "4" + padded.slice(13, 16),       // version 4
+    "8" + padded.slice(17, 20),       // variant 10xx
+    padded.slice(20, 32),
+  ].join("-").toLowerCase();
+}
+
+describe("cross-vault SPARQL recall (Issue #3281)", () => {
+  let tempRoot: string;
+  let vaultA: string; // instance vault
+  let vaultB: string; // ontology vault
+  let classBaseUid: string;
+  let classDerivedUid: string;
+  let assetUids: string[];
+
+  beforeEach(async () => {
+    tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "exoc-3281-"));
+    vaultA = path.join(tempRoot, "vault-A");
+    vaultB = path.join(tempRoot, "vault-B");
+    await fs.ensureDir(vaultA);
+    await fs.ensureDir(vaultB);
+
+    classBaseUid = makeUid("aaaaaaaaaaaaaaaa");
+    classDerivedUid = makeUid("bbbbbbbbbbbbbbbb");
+
+    // Vault B: class hierarchy.
+    // Note: labels are namespace__LocalName form so resolveCrossVaultInstanceClassWikilinks
+    // can derive the canonical class IRI from the label.
+    await writeAsset(vaultB, classBaseUid, {
+      exo__Asset_uid: classBaseUid,
+      exo__Asset_label: "ems__XVaultRecallBase",
+      exo__Instance_class:
+        "[[8619c4fc-64f1-4869-b17e-e34186cacca9]]", // exo__Class metaclass UID
+    });
+    await writeAsset(vaultB, classDerivedUid, {
+      exo__Asset_uid: classDerivedUid,
+      exo__Asset_label: "ems__XVaultRecallDerived",
+      exo__Instance_class:
+        "[[8619c4fc-64f1-4869-b17e-e34186cacca9]]",
+      exo__Class_superClass: `[[${classBaseUid}]]`,
+    });
+
+    // Vault A: ASSET_COUNT assets typed as Derived (and therefore Base via subClassOf).
+    assetUids = [];
+    for (let i = 0; i < ASSET_COUNT; i++) {
+      const uid = makeUid(`c${i.toString(16).padStart(2, "0")}cccccccccccccc`);
+      assetUids.push(uid);
+      await writeAsset(vaultA, uid, {
+        exo__Asset_uid: uid,
+        exo__Asset_label: `Asset ${i}`,
+        exo__Instance_class: `[[${classDerivedUid}]]`,
+      });
+    }
+  });
+
+  afterEach(async () => {
+    await fs.remove(tempRoot);
+  });
+
+  /**
+   * Pre-fix recall: simulates the current `sparql query --also` flow
+   * without cross-vault materialization — per-vault load, concat, no
+   * RDFS inference, no resolveCrossVaultInstanceClassWikilinks.
+   *
+   * Recall is computed against the ground-truth set of ASSET_COUNT assets
+   * that should match `?s rdf:type <TestBase>`.
+   */
+  async function recallWithoutCombinedIndex(): Promise<{
+    matches: number;
+    expected: number;
+  }> {
+    const adapterA = new FileSystemVaultAdapter(vaultA);
+    const adapterB = new FileSystemVaultAdapter(vaultB);
+    const triplesA = await new NoteToRDFConverter(adapterA).convertVault();
+    const triplesB = await new NoteToRDFConverter(adapterB).convertVault();
+    const combined = [...triplesA, ...triplesB];
+
+    const store = new InMemoryTripleStore();
+    await store.addAll(combined);
+
+    // Hand-execute the analytical query without materialization.
+    const matched = await store.match(
+      undefined,
+      new IRI(RDF_TYPE_IRI),
+      new IRI(TEST_DERIVED_IRI),
+    );
+
+    // Restrict matches to fixture assets (sanity vs accidental TBox hits)
+    const matchSubjects = new Set(
+      matched
+        .map((t) => t.subject)
+        .filter((s): s is IRI => s instanceof IRI)
+        .map((s) => s.value),
+    );
+
+    let assetMatches = 0;
+    for (const assetUid of assetUids) {
+      // Asset IRI lives under obsidian://vault/... — accept any matched
+      // subject whose IRI contains the asset UID.
+      const found = Array.from(matchSubjects).some((s) =>
+        s.toLowerCase().includes(assetUid),
+      );
+      if (found) assetMatches++;
+    }
+
+    return { matches: assetMatches, expected: assetUids.length };
+  }
+
+  /**
+   * Post-fix recall: runs the new buildCombinedTriples orchestration
+   * (cross-vault wikilink resolution + RDFS + prototype chain on the
+   * combined store) and queries the resulting triple set.
+   */
+  async function recallWithCombinedIndex(): Promise<{
+    matches: number;
+    expected: number;
+  }> {
+    const result = await buildCombinedTriples(vaultA, [vaultB], {
+      silent: true,
+    });
+
+    const store = new InMemoryTripleStore();
+    await store.addAll(result.triples);
+
+    const matched = await store.match(
+      undefined,
+      new IRI(RDF_TYPE_IRI),
+      new IRI(TEST_DERIVED_IRI),
+    );
+
+    const matchSubjects = new Set(
+      matched
+        .map((t) => t.subject)
+        .filter((s): s is IRI => s instanceof IRI)
+        .map((s) => s.value),
+    );
+
+    let assetMatches = 0;
+    for (const assetUid of assetUids) {
+      const found = Array.from(matchSubjects).some((s) =>
+        s.toLowerCase().includes(assetUid),
+      );
+      if (found) assetMatches++;
+    }
+
+    return { matches: assetMatches, expected: assetUids.length };
+  }
+
+  it("post-fix combined index achieves ≥85% recall on cross-vault analytical query (DoD)", async () => {
+    const { matches, expected } = await recallWithCombinedIndex();
+    const recall = matches / expected;
+    // DoD threshold from issue #3281 body.
+    expect(recall).toBeGreaterThanOrEqual(0.85);
+    // Stronger assertion: with this fixture shape the combined index should
+    // catch every asset (recall = 1.0); allowing a small slack only for
+    // future TBox/parser drift that doesn't affect correctness.
+    expect(matches).toBeGreaterThanOrEqual(Math.ceil(expected * 0.85));
+  });
+
+  it("pre-fix per-vault flow falls well below the 85% target (regression baseline)", async () => {
+    // Establishes the empirical signal: without combined materialization the
+    // same fixture and query produce sub-20% recall. This is the revert→fail
+    // half of the integration-test-revert-verify discipline. If this test
+    // starts passing, the fixture no longer exercises Issue #3281's gap.
+    const { matches, expected } = await recallWithoutCombinedIndex();
+    const recall = matches / expected;
+    expect(recall).toBeLessThanOrEqual(0.2);
+  });
+
+  it("documents the recall lift achieved by the cross-vault index", async () => {
+    const before = await recallWithoutCombinedIndex();
+    const after = await recallWithCombinedIndex();
+    const beforeRecall = before.matches / before.expected;
+    const afterRecall = after.matches / after.expected;
+    // Captures the empirical lift for the PR description / future audits.
+    expect(afterRecall - beforeRecall).toBeGreaterThanOrEqual(0.65);
+  });
+
+  it("combined index keeps the same recall regardless of --also ordering", async () => {
+    // Sanity: the cache-key sort/dedupe contract in CombinedCacheManager
+    // means logical equivalence of --also orderings; here we just verify
+    // buildCombinedTriples is order-stable on result count.
+    const first = await buildCombinedTriples(vaultA, [vaultB], { silent: true });
+    // A duplicate --also of the SAME vault is filtered (dedupe), so we exercise
+    // dedupe at the orchestration layer by passing the primary path as also too.
+    const second = await buildCombinedTriples(vaultA, [vaultB, vaultA], {
+      silent: true,
+    });
+    expect(second.triples.length).toBe(first.triples.length);
+  });
+});

--- a/packages/cli/tests/unit/cache/CombinedCacheManager.test.ts
+++ b/packages/cli/tests/unit/cache/CombinedCacheManager.test.ts
@@ -1,0 +1,177 @@
+import { describe, it, expect, beforeEach, afterEach } from "@jest/globals";
+import fs from "fs-extra";
+import path from "path";
+import os from "os";
+import { IRI, Literal, Triple } from "exocortex";
+import { CombinedCacheManager } from "../../../src/cache/CombinedCacheManager.js";
+
+const PRED = new IRI("https://example.org/p");
+
+function makeTriple(s: string, o: string): Triple {
+  return new Triple(new IRI(`https://example.org/${s}`), PRED, new Literal(o));
+}
+
+describe("CombinedCacheManager", () => {
+  let tempRoot: string;
+  let primary: string;
+  let alsoA: string;
+  let alsoB: string;
+
+  beforeEach(async () => {
+    tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "ccm-test-"));
+    primary = path.join(tempRoot, "primary");
+    alsoA = path.join(tempRoot, "also-a");
+    alsoB = path.join(tempRoot, "also-b");
+    await fs.ensureDir(primary);
+    await fs.ensureDir(alsoA);
+    await fs.ensureDir(alsoB);
+  });
+
+  afterEach(async () => {
+    await fs.remove(tempRoot);
+  });
+
+  describe("cache key stability", () => {
+    it("produces the same cache file regardless of --also ordering", () => {
+      const c1 = new CombinedCacheManager(primary, [alsoA, alsoB]);
+      const c2 = new CombinedCacheManager(primary, [alsoB, alsoA]);
+      expect(c1.getCachePath()).toBe(c2.getCachePath());
+    });
+
+    it("dedupes duplicate --also paths (primary + repeated also)", () => {
+      const c1 = new CombinedCacheManager(primary, [alsoA, alsoA, alsoB]);
+      const c2 = new CombinedCacheManager(primary, [alsoA, alsoB]);
+      expect(c1.getCachePath()).toBe(c2.getCachePath());
+      expect(c1.getAlsoVaultPaths()).toEqual(c2.getAlsoVaultPaths());
+    });
+
+    it("dedupes --also entry that points at the primary vault", () => {
+      const c1 = new CombinedCacheManager(primary, [primary, alsoA]);
+      const c2 = new CombinedCacheManager(primary, [alsoA]);
+      expect(c1.getCachePath()).toBe(c2.getCachePath());
+      expect(c1.getAlsoVaultPaths()).toEqual([alsoA]);
+    });
+
+    it("differs when the vault set differs (cache isolation)", () => {
+      const c1 = new CombinedCacheManager(primary, [alsoA]);
+      const c2 = new CombinedCacheManager(primary, [alsoB]);
+      expect(c1.getCachePath()).not.toBe(c2.getCachePath());
+    });
+
+    it("places combined cache under primary vault's .exocortex/cache/", () => {
+      const c = new CombinedCacheManager(primary, [alsoA]);
+      expect(c.getCachePath()).toContain(
+        path.join(primary, ".exocortex", "cache"),
+      );
+      expect(c.getCachePath()).toMatch(/combined-[a-f0-9]+\.json$/);
+    });
+  });
+
+  describe("save + load round-trip", () => {
+    it("persists triples and reads them back via loadFromCache", async () => {
+      const c = new CombinedCacheManager(primary, [alsoA]);
+      const original = [makeTriple("s1", "o1"), makeTriple("s2", "o2")];
+      await c.saveTriples(original);
+
+      expect(await c.isCacheValid()).toBe(true);
+      const loaded = await c.loadFromCache();
+      expect(loaded.length).toBe(original.length);
+      expect((loaded[0].subject as IRI).value).toBe("https://example.org/s1");
+      expect((loaded[0].object as Literal).value).toBe("o1");
+    });
+
+    it("loadIfValid returns null when no cache exists yet", async () => {
+      const c = new CombinedCacheManager(primary, [alsoA]);
+      const result = await c.loadIfValid();
+      expect(result).toBeNull();
+    });
+
+    it("loadIfValid returns LoadOrBuildResult when cache is valid", async () => {
+      const c = new CombinedCacheManager(primary, [alsoA]);
+      await c.saveTriples([makeTriple("x", "y")]);
+      const result = await c.loadIfValid();
+      expect(result).not.toBeNull();
+      expect(result?.cacheHit).toBe(true);
+      expect(result?.triples.length).toBe(1);
+    });
+  });
+
+  describe("invalidation", () => {
+    it("isCacheValid returns false after a participating vault is mutated", async () => {
+      const c = new CombinedCacheManager(primary, [alsoA]);
+      await c.saveTriples([makeTriple("s", "o")]);
+      expect(await c.isCacheValid()).toBe(true);
+
+      // Mutate the alsoA vault directory mtime by writing a file
+      await new Promise((r) => setTimeout(r, 10));
+      await fs.writeFile(path.join(alsoA, "new-file.md"), "---\n---\n");
+
+      expect(await c.isCacheValid()).toBe(false);
+    });
+
+    it("invalidate() removes the cache file", async () => {
+      const c = new CombinedCacheManager(primary, [alsoA]);
+      await c.saveTriples([makeTriple("s", "o")]);
+      expect(await c.isCacheValid()).toBe(true);
+
+      await c.invalidate();
+      expect(await fs.pathExists(c.getCachePath())).toBe(false);
+      expect(await c.isCacheValid()).toBe(false);
+    });
+
+    it("isCacheValid returns false when participating vault no longer exists", async () => {
+      const c = new CombinedCacheManager(primary, [alsoA]);
+      await c.saveTriples([makeTriple("s", "o")]);
+
+      await fs.remove(alsoA);
+      expect(await c.isCacheValid()).toBe(false);
+    });
+
+    it("isCacheValid returns false when the --also set changed since cache built", async () => {
+      const cBuilder = new CombinedCacheManager(primary, [alsoA]);
+      await cBuilder.saveTriples([makeTriple("s", "o")]);
+
+      // A reader instance configured for a different --also set must not
+      // accept the previous cache file even though the cache key differs;
+      // we exercise the path-set membership check explicitly by checking
+      // the wrong-set instance reports invalid.
+      const cReader = new CombinedCacheManager(primary, [alsoA, alsoB]);
+      expect(await cReader.isCacheValid()).toBe(false);
+    });
+  });
+
+  describe("getCacheStats", () => {
+    it("returns null when no cache file exists", async () => {
+      const c = new CombinedCacheManager(primary, [alsoA]);
+      expect(await c.getCacheStats()).toBeNull();
+    });
+
+    it("returns triple count + valid flag + vault list after save", async () => {
+      const c = new CombinedCacheManager(primary, [alsoA, alsoB]);
+      const triples = [makeTriple("a", "1"), makeTriple("b", "2"), makeTriple("c", "3")];
+      await c.saveTriples(triples);
+
+      const stats = await c.getCacheStats();
+      expect(stats).not.toBeNull();
+      expect(stats?.tripleCount).toBe(3);
+      expect(stats?.isValid).toBe(true);
+      expect(stats?.vaultPaths.sort()).toEqual(
+        [primary, alsoA, alsoB].sort(),
+      );
+      expect(stats?.sizeBytes).toBeGreaterThan(0);
+    });
+  });
+
+  describe("computeCacheKey", () => {
+    it("produces a 16-char hex digest", () => {
+      const key = CombinedCacheManager.computeCacheKey(["/a", "/b"]);
+      expect(key).toMatch(/^[a-f0-9]{16}$/);
+    });
+
+    it("is deterministic for identical inputs", () => {
+      const a = CombinedCacheManager.computeCacheKey(["/x", "/y"]);
+      const b = CombinedCacheManager.computeCacheKey(["/x", "/y"]);
+      expect(a).toBe(b);
+    });
+  });
+});

--- a/packages/cli/tests/unit/commands/sparql-index.test.ts
+++ b/packages/cli/tests/unit/commands/sparql-index.test.ts
@@ -48,6 +48,62 @@ jest.unstable_mockModule("exocortex", () => ({
   PrototypeChainMaterializer: jest.fn(() => ({
     materialize: mockProtoMaterialize,
   })),
+  // Issue #3281: sparql-index.ts now also pulls in CombinedCacheManager +
+  // buildCombinedTriples (for --also flow). Those transitively reference
+  // Triple / IRI / Literal / BlankNode / NoteToRDFConverter from the
+  // exocortex package; stub them out so the test loads even though the
+  // single-vault tests below never exercise the cross-vault branch.
+  Triple: class MockTriple {
+    constructor(
+      public subject: unknown,
+      public predicate: unknown,
+      public object: unknown,
+    ) {}
+  },
+  IRI: class MockIRI {
+    constructor(public value: string) {}
+  },
+  Literal: class MockLiteral {
+    constructor(
+      public value: string,
+      public datatype?: unknown,
+      public language?: string,
+    ) {}
+  },
+  BlankNode: class MockBlankNode {
+    constructor(public value: string) {}
+  },
+  NoteToRDFConverter: jest.fn(() => ({
+    convertVault: jest.fn().mockResolvedValue([]),
+    convertVaultWithValidation: jest
+      .fn()
+      .mockResolvedValue({
+        triples: [],
+        skippedFiles: [],
+        summary: { total: 0, indexed: 0, skipped: 0 },
+      }),
+  })),
+}));
+
+// Mock CombinedCacheManager — the cross-vault index path is exercised in
+// its own dedicated unit + integration tests; here we just need a stub.
+jest.unstable_mockModule("../../../src/cache/CombinedCacheManager.js", () => ({
+  CombinedCacheManager: jest.fn(() => ({
+    getCachePath: jest.fn().mockReturnValue("/tmp/combined-cache-stub.json"),
+    getAllVaultPaths: jest.fn().mockReturnValue([]),
+    invalidate: jest.fn().mockResolvedValue(undefined),
+    saveTriples: jest.fn().mockResolvedValue(undefined),
+    getCacheStats: jest.fn().mockResolvedValue(null),
+  })),
+}));
+
+jest.unstable_mockModule("../../../src/cache/buildCombinedTriples.js", () => ({
+  buildCombinedTriples: jest.fn().mockResolvedValue({
+    triples: [],
+    rawTripleCount: 0,
+    crossVaultAddedTripleCount: 0,
+    inferredTripleCount: 0,
+  }),
 }));
 
 const { sparqlIndexCommand } = await import("../../../src/commands/sparql-index.js");

--- a/packages/cli/tests/unit/commands/sparql-query-also.test.ts
+++ b/packages/cli/tests/unit/commands/sparql-query-also.test.ts
@@ -80,6 +80,16 @@ jest.unstable_mockModule("../../../src/cache/CacheManager.js", () => ({
     loadOrBuild: jest.fn().mockResolvedValue({ triples: [], cacheHit: false }),
   })),
 }));
+// Issue #3281: sparql-query.ts now also pulls in CombinedCacheManager for
+// the cross-vault index read path. Default to "no combined cache" so the
+// existing --also tests below exercise the legacy per-vault concat flow.
+jest.unstable_mockModule("../../../src/cache/CombinedCacheManager.js", () => ({
+  CombinedCacheManager: jest.fn(() => ({
+    getCachePath: jest.fn().mockReturnValue("/mock/combined-cache/path"),
+    getAllVaultPaths: jest.fn().mockReturnValue([]),
+    loadIfValid: jest.fn().mockResolvedValue(null),
+  })),
+}));
 jest.unstable_mockModule("../../../src/cache/QueryResultCache.js", () => ({
   QueryResultCache: jest.fn(() => ({
     get: jest.fn().mockResolvedValue(null),

--- a/packages/cli/tests/unit/commands/sparql-query.test.ts
+++ b/packages/cli/tests/unit/commands/sparql-query.test.ts
@@ -96,6 +96,17 @@ jest.unstable_mockModule("../../../src/cache/CacheManager.js", () => ({
   })),
 }));
 
+// Mock CombinedCacheManager — Issue #3281 introduces cross-vault index
+// reads from sparql-query when --use-cache + --also are used. Default
+// behaviour for these single-vault tests is "no combined cache available".
+jest.unstable_mockModule("../../../src/cache/CombinedCacheManager.js", () => ({
+  CombinedCacheManager: jest.fn(() => ({
+    getCachePath: jest.fn().mockReturnValue("/mock/combined-cache/path"),
+    getAllVaultPaths: jest.fn().mockReturnValue([]),
+    loadIfValid: jest.fn().mockResolvedValue(null),
+  })),
+}));
+
 const { sparqlQueryCommand } = await import("../../../src/commands/sparql-query.js");
 
 // Note: These tests require complex mocking due to new ErrorHandler/VaultNotFoundError imports.


### PR DESCRIPTION
Closes #3281

## Summary

Adds `--also <path>` to `exocortex sparql index` and a combined cross-vault triple cache so analytical queries that span multiple vaults reach RDFS / prototype-chain inferences which previously only fired per-vault.

- New `CombinedCacheManager` sibling to `CacheManager` for multi-vault cache at `<primary>/.exocortex/cache/combined-<hash>.json`. Cache key = stable hash of sorted vault path set; `--also A --also B` and `--also B --also A` share one cache file.
- New `buildCombinedTriples` orchestrator — concats per-vault triples → applies existing `resolveCrossVaultInstanceClassWikilinks` post-processing → runs RDFSInferenceEngine + PrototypeChainMaterializer on the **combined** store (the load-bearing change for #3281).
- `sparql query --use-cache --also <...>` now reads the combined cache when valid; falls back to legacy per-vault concat on cache miss. Gated on `profileFilter === null` to preserve existing profile semantics.
- `tripleSerialization.ts` extracted from CacheManager so mocks of either cache class don't need to re-export serializer helpers.

## Scope note (sibling issues NOT addressed)

Per the cross-vault SPARQL recall empirical reference, production recall (~19%) stacks **four** independent gaps:
1. **#3281** — materialization per-vault only ← this PR
2. **#3286** — triple-IRI representation (canonical vs file vs literal forms)
3. **#3282** — label-form wikilinks via `PropertyPathExecutor` literal-safety guard
4. **#3283** — runtime materialization (`query --inference`)

The test fixture in this PR is deliberately constructed to **isolate #3281** from #3286/#3282/#3283: UID-form filenames only, UUID-form wikilinks only, whitelisted `ems__` namespace labels. The 100% recall measured here is for that isolated fixture only; the production analytical query needs all four gaps closed before its recall lifts comparably. See sibling issues for the remaining work.

## Inherited limitation surfaced for reviewers

`CombinedCacheManager.isCacheValid()` checks `fs.stat(vaultPath).mtimeMs` of each participating vault root. This catches entry-add/remove/rename at the vault root but not in-place file mutations deeper in subdirectories. **This is the same model already used by the single-vault `CacheManager`** (`packages/cli/src/cache/CacheManager.ts` `isCacheValid`); users running `--use-cache` already accept this trade-off. Combined cache adopts the same baseline rather than tightening it as part of this PR.

## Test plan

- [x] New integration test `cross-vault-sparql-recall.test.ts`:
  - Asserts post-fix recall ≥ 85% on representative cross-vault query (DoD)
  - Asserts pre-fix per-vault flow recall ≤ 20% (revert/restore baseline)
  - Asserts recall lift ≥ 65% (documenting the empirical gain)
  - Asserts cache-key stability across `--also` ordering
- [x] 16 unit tests for `CombinedCacheManager` — cache-key stability (sort/dedupe/primary-collision), save+load round-trip, mtime/path-set invalidation, stats accessor, hash function
- [x] Existing mock chains updated for new dependency graph (`sparql-index`, `sparql-query`, `sparql-query-also`, `sparql-query-debug`, `sparql-query-profile`)
- [x] Full CLI suite green: 1925 production tests pass, 25 skipped. Only pre-existing failures in `sparql-exo003.integration.test.ts` (verified unchanged on origin/main, not introduced by this PR)
- [x] CLI build succeeds (esbuild)
- [x] code-reviewer round: APPROVE 0 CRITICAL / 0 HIGH / 0 MEDIUM, 4 LOW (1 mechanical fix applied — unused import removed; 3 deferred as optional follow-ups)
- [x] advisor round-1 pre-implementation + post-code-reviewer round-2

## Open follow-ups (LOW, deferred)

1. End-to-end seam test: `build → save → load → query` recall preserved across the cache round-trip (defensive coverage gap; underlying serialization is shared with the well-tested single-vault CacheManager).
2. Architectural: `cache/buildCombinedTriples.ts` imports `resolveCrossVaultInstanceClassWikilinks` from `commands/validate-schema.ts` — cycle-free but pulls in a 1379-line command module to reuse one utility. Extract to shared util in a follow-up PR.
3. Consistency in `buildCombinedTriples` zero-inference branch: pre-materialization concat is returned when `inferredTripleCount === 0`, but `tripleStore.match()` (deduped) is returned otherwise. Downstream consumer re-adds to a fresh store which dedupes again, so cosmetic only.

🤖 Spawned via /spawn-issue-standalone (standalone overnight loop, no parent orchestration).