### PR TITLE
fix(#3282): fail-visible literal-safety guard in BGPExecutor + PropertyPathExecutor (Sub-task C)

### DIFF
--- a/packages/cli/src/commands/sparql-query.ts
+++ b/packages/cli/src/commands/sparql-query.ts
@@ -60,6 +60,13 @@ export interface SparqlQueryOptions {
    * path is silently disabled with a warn so the filter takes effect.
    */
   profile?: string;
+  /**
+   * Issue #3282: when true, the PropertyPathExecutor literal-safety guard
+   * throws a `PropertyPathExecutorError` instead of warn-and-empty. Sets
+   * `EXOCORTEX_SPARQL_STRICT=1` for the lifetime of this command — runtime
+   * callers can opt in directly via the env var.
+   */
+  strict?: boolean;
 }
 
 /** Default TTL for query result cache in seconds */
@@ -261,9 +268,23 @@ export function sparqlQueryCommand(): Command {
       "--profile <uid>",
       "FocusProfile UID — restrict graph to effective AssetSpace set (RFC 0a0791c1)",
     )
+    .option(
+      "--strict",
+      "Fail on unresolved label-form wikilinks in property paths (sets EXOCORTEX_SPARQL_STRICT=1, Issue #3282)",
+    )
     .action(async (queryArg: string | undefined, options: SparqlQueryOptions) => {
       const outputFormat = (options.output || "text") as OutputFormat;
       ErrorHandler.setFormat(outputFormat);
+
+      // Issue #3282: --strict opts into a hard failure when the
+      // PropertyPathExecutor literal-safety guard fires (label-form
+      // wikilinks that NoteToRDFConverter.valueToRDFObject could not
+      // resolve and stored as bare literals). Propagate via env var
+      // so any executor instance picks it up without constructor
+      // plumbing. Mirrors the EXOCORTEX_SPARQL_TIMEOUT precedent.
+      if (options.strict) {
+        process.env.EXOCORTEX_SPARQL_STRICT = "1";
+      }
 
       // Declared before try so it's accessible in the catch block for error reporting
       let queryString: string = "";

--- a/packages/cli/src/commands/sparql-query.ts
+++ b/packages/cli/src/commands/sparql-query.ts
@@ -277,11 +277,16 @@ export function sparqlQueryCommand(): Command {
       ErrorHandler.setFormat(outputFormat);
 
       // Issue #3282: --strict opts into a hard failure when the
-      // PropertyPathExecutor literal-safety guard fires (label-form
-      // wikilinks that NoteToRDFConverter.valueToRDFObject could not
-      // resolve and stored as bare literals). Propagate via env var
-      // so any executor instance picks it up without constructor
-      // plumbing. Mirrors the EXOCORTEX_SPARQL_TIMEOUT precedent.
+      // PropertyPathExecutor / BGPExecutor literal-safety guard fires
+      // (label-form wikilinks that NoteToRDFConverter.valueToRDFObject
+      // could not resolve and stored as bare literals). Propagate via
+      // env var so any executor instance picks it up without
+      // constructor plumbing. Mirrors the EXOCORTEX_SPARQL_TIMEOUT
+      // precedent. We capture the original value and restore it in the
+      // outer try/finally below so embedded callers (MCP host, test
+      // harness, programmatic invocation) cannot leak strict mode
+      // across subsequent queries.
+      const originalStrictEnv = process.env.EXOCORTEX_SPARQL_STRICT;
       if (options.strict) {
         process.env.EXOCORTEX_SPARQL_STRICT = "1";
       }
@@ -779,6 +784,17 @@ export function sparqlQueryCommand(): Command {
         }
       } catch (error) {
         handleSparqlError(error as Error, queryString, outputFormat);
+      } finally {
+        // Issue #3282: restore EXOCORTEX_SPARQL_STRICT so embedded callers
+        // (MCP host, programmatic invocation, test harness) do not inherit
+        // strict mode from a prior --strict invocation.
+        if (options.strict) {
+          if (originalStrictEnv === undefined) {
+            delete process.env.EXOCORTEX_SPARQL_STRICT;
+          } else {
+            process.env.EXOCORTEX_SPARQL_STRICT = originalStrictEnv;
+          }
+        }
       }
     });
 }

--- a/packages/exocortex/src/infrastructure/sparql/executors/BGPExecutor.ts
+++ b/packages/exocortex/src/infrastructure/sparql/executors/BGPExecutor.ts
@@ -535,21 +535,43 @@ export class BGPExecutor {
   }
 
   /**
-   * Warn-level log when a literal-safety guard fires (Issue #2997 Phase 3).
-   * Indicates upstream bad data (loader leak, malformed wikilink, ...) reached
-   * the BGP executor; the guard suppresses the crash but the log preserves
-   * diagnostic visibility.
+   * Error-level log when a literal-safety guard fires (Issue #2997 Phase 3
+   * + Issue #3282 fail-visible upgrade). Indicates upstream bad data
+   * (loader leak, malformed wikilink, ...) reached the BGP executor; the
+   * guard suppresses the crash but the log preserves diagnostic visibility.
+   *
+   * Issue #3282: when `EXOCORTEX_SPARQL_STRICT` is truthy
+   * (1 / true / yes — set explicitly or via CLI `--strict`), this throws
+   * a `BGPExecutorError` instead of swallowing the literal — surfaces the
+   * silent recall loss that motivated the issue's audit reproducer.
    */
   private warnLiteralGuard(
     context: string,
     position: "subject" | "predicate" | "object",
     element: TripleElement,
   ): void {
-    const value = "value" in element ? String((element as { value: unknown }).value) : "<unknown>";
-    const truncated = value.length > 80 ? `${value.slice(0, 77)}...` : value;
-    console.warn(
+    const rawValue = "value" in element ? String((element as { value: unknown }).value) : "<unknown>";
+    const truncated = rawValue.length > 80 ? `${rawValue.slice(0, 77)}...` : rawValue;
+    const diagnostic = {
+      executor: "BGPExecutor",
+      context,
+      position,
+      value: truncated,
+      hint:
+        "Wikilink could not be resolved to IRI (likely label-form wikilink with no matching basename/alias). " +
+        "Check whether the target file exists in the queried vault, add an alias, " +
+        "or load the target vault via --also. See issue #3282.",
+    };
+    console.error(
       `[BGPExecutor] literal-safety guard fired in ${context}: literal in ${position} position — yielding 0 solutions. value="${truncated}"`,
+      diagnostic,
     );
+    if (PropertyPathExecutor.isStrictModeEnabled()) {
+      throw new BGPExecutorError(
+        `Literal in ${position} position (${context}): "${truncated}". ` +
+          "Set EXOCORTEX_SPARQL_STRICT=0 or omit --strict to fall back to warn-and-empty behaviour.",
+      );
+    }
   }
 
   /**

--- a/packages/exocortex/src/infrastructure/sparql/executors/PropertyPathExecutor.ts
+++ b/packages/exocortex/src/infrastructure/sparql/executors/PropertyPathExecutor.ts
@@ -46,16 +46,41 @@ export class PropertyPathExecutor {
     // Issue #2997 Phase 3: defense-in-depth literal safety guard.
     // Property paths require IRI/blank/variable in subject and object
     // positions; a literal here means upstream code (loader, join
-    // instantiation) leaked bad data. Yield zero solutions instead of
-    // throwing.
+    // instantiation) leaked bad data — typically an unresolved label-form
+    // wikilink (Issue #3282) stored as a bare literal by
+    // NoteToRDFConverter.valueToRDFObject when getFirstLinkpathDest
+    // returned null. By default yield zero solutions (warn-and-continue)
+    // for backwards compatibility; under EXOCORTEX_SPARQL_STRICT=1 throw
+    // a PropertyPathExecutorError so CI / scripts can surface the silent
+    // recall loss instead of swallowing it.
     if (this.isLiteralElement(subject) || this.isLiteralElement(object)) {
       const position = this.isLiteralElement(subject) ? "subject" : "object";
       const offending = this.isLiteralElement(subject) ? subject : object;
-      const value = "value" in offending ? String((offending as { value: unknown }).value) : "<unknown>";
-      const truncated = value.length > 80 ? `${value.slice(0, 77)}...` : value;
-      console.warn(
-        `[PropertyPathExecutor] literal-safety guard fired: literal in ${position} position — yielding 0 solutions. value="${truncated}"`,
+      const rawValue = "value" in offending ? String((offending as { value: unknown }).value) : "<unknown>";
+      const truncated = rawValue.length > 80 ? `${rawValue.slice(0, 77)}...` : rawValue;
+      const pathDesc = this.describePath(path);
+      const diagnostic = {
+        position,
+        value: truncated,
+        path: pathDesc,
+        hint:
+          "Wikilink could not be resolved to IRI (likely label-form wikilink with no matching basename/alias). " +
+          "Check whether the target file exists in the queried vault, add an alias, " +
+          "or load the target vault via --also. See issue #3282.",
+      };
+      // Use console.error for visibility — previous console.warn was silently
+      // swallowed by tooling and users could not diagnose zero-result queries.
+      console.error(
+        `[PropertyPathExecutor] literal-safety guard fired: literal in ${position} position — yielding 0 solutions. ` +
+          `value="${truncated}" path=${pathDesc}`,
+        diagnostic,
       );
+      if (PropertyPathExecutor.isStrictModeEnabled()) {
+        throw new PropertyPathExecutorError(
+          `Literal subject in property path: "${truncated}" (path=${pathDesc}). ` +
+            "Set EXOCORTEX_SPARQL_STRICT=0 or omit --strict to fall back to warn-and-empty behaviour.",
+        );
+      }
       return;
     }
 
@@ -451,5 +476,44 @@ export class PropertyPathExecutor {
       if (this.nodeToKey(n) === key) return true;
     }
     return false;
+  }
+
+  /**
+   * Produce a short textual description of a property-path expression for
+   * diagnostic output (Issue #3282). Falls back to JSON for unknown
+   * shapes — we keep this best-effort so error logs always have *some*
+   * locating information without forcing a full SPARQL serialiser
+   * dependency.
+   */
+  private describePath(path: PropertyPath): string {
+    try {
+      const items = (path as PropertyPath & { items?: unknown[] }).items;
+      const renderItem = (item: unknown): string => {
+        if (item && typeof item === "object" && "type" in item) {
+          const typed = item as { type: string; value?: unknown };
+          if (typed.type === "iri") return `<${String(typed.value)}>`;
+          if (typed.type === "path") return this.describePath(typed as PropertyPath);
+        }
+        return "?";
+      };
+      const rendered = Array.isArray(items) ? items.map(renderItem).join(` ${path.pathType} `) : "?";
+      return `(${rendered})`;
+    } catch {
+      return "<unprintable-path>";
+    }
+  }
+
+  /**
+   * Read the EXOCORTEX_SPARQL_STRICT environment variable (Issue #3282).
+   * Mirrors the EXOCORTEX_SPARQL_TIMEOUT pattern in
+   * packages/cli/src/commands/sparql-query.ts — CLI `--strict` sets this
+   * before constructing the query executor, runtime callers can opt in
+   * directly. Truthy values: "1", "true", "yes" (case-insensitive).
+   */
+  static isStrictModeEnabled(): boolean {
+    const raw = process.env?.EXOCORTEX_SPARQL_STRICT;
+    if (!raw) return false;
+    const normalized = raw.trim().toLowerCase();
+    return normalized === "1" || normalized === "true" || normalized === "yes";
   }
 }

--- a/packages/exocortex/src/infrastructure/sparql/executors/PropertyPathExecutor.ts
+++ b/packages/exocortex/src/infrastructure/sparql/executors/PropertyPathExecutor.ts
@@ -496,7 +496,23 @@ export class PropertyPathExecutor {
         }
         return "?";
       };
-      const rendered = Array.isArray(items) ? items.map(renderItem).join(` ${path.pathType} `) : "?";
+      if (!Array.isArray(items) || items.length === 0) {
+        return "(?)";
+      }
+      // Unary path operators have a single item: inverse (^p) is prefix,
+      // quantifiers (+, *, ?) are suffix. Render them faithfully so the
+      // diagnostic disambiguates p+ from p? in literal-safety reports.
+      if (items.length === 1) {
+        const inner = renderItem(items[0]);
+        if (path.pathType === "^") return `(^${inner})`;
+        if (path.pathType === "+" || path.pathType === "*" || path.pathType === "?") {
+          return `(${inner}${path.pathType})`;
+        }
+        // Sequence / alternative with a single item — render verbatim.
+        return `(${inner})`;
+      }
+      // Binary / n-ary operators (sequence /, alternative |) — infix.
+      const rendered = items.map(renderItem).join(` ${path.pathType} `);
       return `(${rendered})`;
     } catch {
       return "<unprintable-path>";

--- a/packages/exocortex/tests/unit/infrastructure/sparql/executors/BGPExecutor.issue-2997.test.ts
+++ b/packages/exocortex/tests/unit/infrastructure/sparql/executors/BGPExecutor.issue-2997.test.ts
@@ -18,7 +18,7 @@ import { BGPOperation, PropertyPath } from "../../../../../src/infrastructure/sp
 describe("BGPExecutor — Issue #2997 Phase 3 literal-safety guard", () => {
   let tripleStore: InMemoryTripleStore;
   let executor: BGPExecutor;
-  let warnSpy: jest.SpyInstance;
+  let errorSpy: jest.SpyInstance;
 
   const ex = (local: string) => new IRI(`http://example.org/${local}`);
 
@@ -37,11 +37,13 @@ describe("BGPExecutor — Issue #2997 Phase 3 literal-safety guard", () => {
       new Triple(ex("project-1"), ex("Effort_parent"), ex("root-1")),
     );
 
-    warnSpy = jest.spyOn(console, "warn").mockImplementation(() => undefined);
+    // Issue #3282 promoted the literal-safety log from console.warn → console.error
+    // so the silent recall loss is visible in tooling. Spy on error here.
+    errorSpy = jest.spyOn(console, "error").mockImplementation(() => undefined);
   });
 
   afterEach(() => {
-    warnSpy.mockRestore();
+    errorSpy.mockRestore();
   });
 
   it("yields no rows and does not throw when a join binds a variable to a literal then reuses it as subject", async () => {
@@ -76,8 +78,8 @@ describe("BGPExecutor — Issue #2997 Phase 3 literal-safety guard", () => {
     // way the execution must complete without throwing.
     expect(Array.isArray(results)).toBe(true);
     // Guard must have fired at least once for the literal-bound row.
-    expect(warnSpy).toHaveBeenCalled();
-    const messages = warnSpy.mock.calls.map((c) => c.join(" "));
+    expect(errorSpy).toHaveBeenCalled();
+    const messages = errorSpy.mock.calls.map((c) => c.join(" "));
     expect(messages.some((m) => m.includes("literal-safety guard"))).toBe(true);
   });
 
@@ -117,8 +119,8 @@ describe("BGPExecutor — Issue #2997 Phase 3 literal-safety guard", () => {
 
     const results = await executor.executeAll(bgp);
     expect(Array.isArray(results)).toBe(true);
-    expect(warnSpy).toHaveBeenCalled();
-    const messages = warnSpy.mock.calls.map((c) => c.join(" "));
+    expect(errorSpy).toHaveBeenCalled();
+    const messages = errorSpy.mock.calls.map((c) => c.join(" "));
     expect(
       messages.some((m) => m.includes("literal-safety guard")),
     ).toBe(true);
@@ -144,7 +146,7 @@ describe("BGPExecutor — Issue #2997 Phase 3 literal-safety guard", () => {
 
     const results = await executor.executeAll(bgp);
     expect(results).toHaveLength(0);
-    expect(warnSpy).toHaveBeenCalled();
+    expect(errorSpy).toHaveBeenCalled();
   });
 
   it("STR-coercion FILTER pattern shape from the #2997 issue does not throw", async () => {
@@ -170,5 +172,104 @@ describe("BGPExecutor — Issue #2997 Phase 3 literal-safety guard", () => {
     };
 
     await expect(executor.executeAll(bgp)).resolves.toBeDefined();
+  });
+
+  // Issue #3282 — strict-mode escalation. The audit reproducer's 9
+  // literal-safety warnings come from this guard (BGPExecutor), not
+  // PropertyPathExecutor. Under EXOCORTEX_SPARQL_STRICT=1 the silent fail
+  // becomes a hard error so CI / scripts can surface the recall loss.
+  describe("Issue #3282 strict mode (EXOCORTEX_SPARQL_STRICT)", () => {
+    let originalStrictEnv: string | undefined;
+
+    beforeEach(() => {
+      originalStrictEnv = process.env.EXOCORTEX_SPARQL_STRICT;
+      delete process.env.EXOCORTEX_SPARQL_STRICT;
+    });
+
+    afterEach(() => {
+      if (originalStrictEnv === undefined) {
+        delete process.env.EXOCORTEX_SPARQL_STRICT;
+      } else {
+        process.env.EXOCORTEX_SPARQL_STRICT = originalStrictEnv;
+      }
+    });
+
+    it("emits console.error with a structured payload (default mode)", async () => {
+      const path: PropertyPath = {
+        type: "path",
+        pathType: "*",
+        items: [{ type: "iri", value: "http://example.org/p" }],
+      };
+
+      const bgp: BGPOperation = {
+        type: "bgp",
+        triples: [
+          {
+            subject: { type: "literal", value: "Барик (Area)" },
+            predicate: path,
+            object: { type: "variable", value: "o" },
+          },
+        ],
+      };
+
+      await executor.executeAll(bgp);
+
+      expect(errorSpy).toHaveBeenCalled();
+      const lastCall = errorSpy.mock.calls[errorSpy.mock.calls.length - 1];
+      expect(lastCall[1]).toMatchObject({
+        executor: "BGPExecutor",
+        position: "subject",
+        value: "Барик (Area)",
+        hint: expect.stringContaining("Wikilink"),
+      });
+    });
+
+    it("throws BGPExecutorError when EXOCORTEX_SPARQL_STRICT=1", async () => {
+      process.env.EXOCORTEX_SPARQL_STRICT = "1";
+      const path: PropertyPath = {
+        type: "path",
+        pathType: "*",
+        items: [{ type: "iri", value: "http://example.org/p" }],
+      };
+
+      const bgp: BGPOperation = {
+        type: "bgp",
+        triples: [
+          {
+            subject: { type: "literal", value: "Барик (Area)" },
+            predicate: path,
+            object: { type: "variable", value: "o" },
+          },
+        ],
+      };
+
+      await expect(executor.executeAll(bgp)).rejects.toThrow(
+        /Literal in subject position/,
+      );
+    });
+
+    it("does not throw when EXOCORTEX_SPARQL_STRICT=0 (explicit opt-out)", async () => {
+      process.env.EXOCORTEX_SPARQL_STRICT = "0";
+      const path: PropertyPath = {
+        type: "path",
+        pathType: "*",
+        items: [{ type: "iri", value: "http://example.org/p" }],
+      };
+
+      const bgp: BGPOperation = {
+        type: "bgp",
+        triples: [
+          {
+            subject: { type: "literal", value: "Барик (Area)" },
+            predicate: path,
+            object: { type: "variable", value: "o" },
+          },
+        ],
+      };
+
+      const results = await executor.executeAll(bgp);
+      expect(results).toEqual([]);
+      expect(errorSpy).toHaveBeenCalled();
+    });
   });
 });

--- a/packages/exocortex/tests/unit/infrastructure/sparql/executors/PropertyPathExecutor.literal-safety.test.ts
+++ b/packages/exocortex/tests/unit/infrastructure/sparql/executors/PropertyPathExecutor.literal-safety.test.ts
@@ -1,0 +1,214 @@
+/**
+ * PropertyPathExecutor literal-safety guard — Issue #3282 regression tests.
+ *
+ * The guard at PropertyPathExecutor.execute:51 fires when a literal leaks
+ * into the subject or object position of a property-path operation. Issue
+ * #3282 root-caused this to label-form wikilinks like `[[Барик (Area)]]`:
+ * when NoteToRDFConverter.valueToRDFObject cannot resolve the linkpath via
+ * getFirstLinkpathDest, the value is stored as a bare RDFLiteral and any
+ * downstream property-path query (`?s ems:Effort_area/ems:Area_parent* ?a`)
+ * silently returns zero solutions.
+ *
+ * Sub-task C deliverable:
+ *   - Switch the diagnostic from console.warn → console.error so the silent
+ *     recall loss surfaces in tooling.
+ *   - Emit a structured payload (position, value, path, hint) so users can
+ *     identify which wikilink failed.
+ *   - Honour `EXOCORTEX_SPARQL_STRICT` (truthy = "1" / "true" / "yes") and
+ *     throw a `PropertyPathExecutorError` instead of swallowing — CLI
+ *     `--strict` flag turns label-form recall loss into a hard failure.
+ *
+ * NOTE: revert-verify discipline (per
+ *   `~/dotfiles/.claude/rules/integration-test-revert-verify.md`):
+ *   each test FAILS against the pre-fix PropertyPathExecutor (it printed
+ *   plain `console.warn(...)` and never inspected an env var). Run the
+ *   suite with `git stash push -- packages/exocortex/src/infrastructure/sparql/executors/PropertyPathExecutor.ts`
+ *   to confirm RED→GREEN behaviour.
+ */
+
+import {
+  PropertyPathExecutor,
+  PropertyPathExecutorError,
+} from "../../../../../src/infrastructure/sparql/executors/PropertyPathExecutor";
+import type { ITripleStore } from "../../../../../src/interfaces/ITripleStore";
+import { Triple } from "../../../../../src/domain/models/rdf/Triple";
+import { SolutionMapping } from "../../../../../src/infrastructure/sparql/SolutionMapping";
+import type {
+  TripleElement,
+  PropertyPath,
+  IRI as AlgebraIRI,
+} from "../../../../../src/infrastructure/sparql/algebra/AlgebraOperation";
+
+const algebraIri = (value: string): AlgebraIRI => ({ type: "iri", value });
+const algebraVar = (name: string): TripleElement => ({ type: "variable", value: name });
+
+describe("PropertyPathExecutor literal-safety guard (Issue #3282)", () => {
+  let executor: PropertyPathExecutor;
+  let triples: Triple[];
+  let mockTripleStore: jest.Mocked<ITripleStore>;
+  let originalStrictEnv: string | undefined;
+
+  beforeEach(() => {
+    triples = [];
+    mockTripleStore = {
+      add: jest.fn(),
+      match: jest.fn().mockResolvedValue([]),
+      clear: jest.fn(),
+      size: jest.fn().mockReturnValue(0),
+      getTriples: jest.fn().mockReturnValue(triples),
+    } as unknown as jest.Mocked<ITripleStore>;
+
+    executor = new PropertyPathExecutor(mockTripleStore);
+    originalStrictEnv = process.env.EXOCORTEX_SPARQL_STRICT;
+    delete process.env.EXOCORTEX_SPARQL_STRICT;
+  });
+
+  afterEach(() => {
+    if (originalStrictEnv === undefined) {
+      delete process.env.EXOCORTEX_SPARQL_STRICT;
+    } else {
+      process.env.EXOCORTEX_SPARQL_STRICT = originalStrictEnv;
+    }
+  });
+
+  async function collectResults(
+    subject: TripleElement,
+    path: PropertyPath,
+    object: TripleElement,
+  ): Promise<SolutionMapping[]> {
+    const results: SolutionMapping[] = [];
+    for await (const mapping of executor.execute(subject, path, object)) {
+      results.push(mapping);
+    }
+    return results;
+  }
+
+  const labelLiteral: TripleElement = {
+    type: "literal" as const,
+    value: "Барик (Area)",
+  };
+  const oneOrMorePath: PropertyPath = {
+    type: "path",
+    pathType: "+",
+    items: [algebraIri("https://exocortex.my/ontology/ems#Effort_area")],
+  };
+
+  describe("default (non-strict) mode", () => {
+    it("emits console.error with structured payload (Sub-task C visibility)", async () => {
+      const errorSpy = jest.spyOn(console, "error").mockImplementation(() => undefined);
+      const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => undefined);
+      try {
+        const results = await collectResults(labelLiteral, oneOrMorePath, algebraVar("o"));
+
+        expect(results).toEqual([]);
+        // Pre-fix the guard called console.warn — Issue #3282 promotes to error.
+        expect(errorSpy).toHaveBeenCalled();
+        expect(warnSpy).not.toHaveBeenCalled();
+
+        // Structured payload — Issue #3282 acceptance criterion.
+        const lastCall = errorSpy.mock.calls[errorSpy.mock.calls.length - 1];
+        const diagnostic = lastCall[1];
+        expect(diagnostic).toMatchObject({
+          position: "subject",
+          value: "Барик (Area)",
+          hint: expect.stringContaining("Wikilink"),
+        });
+        expect(typeof (diagnostic as { path: unknown }).path).toBe("string");
+      } finally {
+        errorSpy.mockRestore();
+        warnSpy.mockRestore();
+      }
+    });
+
+    it("surfaces literal in object position with the structured payload", async () => {
+      const errorSpy = jest.spyOn(console, "error").mockImplementation(() => undefined);
+      try {
+        const results = await collectResults(algebraVar("s"), oneOrMorePath, labelLiteral);
+
+        expect(results).toEqual([]);
+        expect(errorSpy).toHaveBeenCalled();
+        const diagnostic = errorSpy.mock.calls[errorSpy.mock.calls.length - 1][1];
+        expect(diagnostic).toMatchObject({ position: "object", value: "Барик (Area)" });
+      } finally {
+        errorSpy.mockRestore();
+      }
+    });
+
+    it("truncates long literal values in the diagnostic for readability", async () => {
+      const longValue = "x".repeat(200);
+      const longLiteral: TripleElement = { type: "literal" as const, value: longValue };
+      const errorSpy = jest.spyOn(console, "error").mockImplementation(() => undefined);
+      try {
+        await collectResults(longLiteral, oneOrMorePath, algebraVar("o"));
+        const diagnostic = errorSpy.mock.calls[errorSpy.mock.calls.length - 1][1];
+        const value = (diagnostic as { value: string }).value;
+        expect(value.length).toBeLessThanOrEqual(80);
+        expect(value.endsWith("...")).toBe(true);
+      } finally {
+        errorSpy.mockRestore();
+      }
+    });
+  });
+
+  describe("strict mode (EXOCORTEX_SPARQL_STRICT)", () => {
+    it("throws PropertyPathExecutorError when env=1", async () => {
+      process.env.EXOCORTEX_SPARQL_STRICT = "1";
+      const errorSpy = jest.spyOn(console, "error").mockImplementation(() => undefined);
+      try {
+        await expect(collectResults(labelLiteral, oneOrMorePath, algebraVar("o"))).rejects.toThrow(
+          PropertyPathExecutorError,
+        );
+      } finally {
+        errorSpy.mockRestore();
+      }
+    });
+
+    it("throws when env=true (case-insensitive)", async () => {
+      process.env.EXOCORTEX_SPARQL_STRICT = "TRUE";
+      const errorSpy = jest.spyOn(console, "error").mockImplementation(() => undefined);
+      try {
+        await expect(collectResults(labelLiteral, oneOrMorePath, algebraVar("o"))).rejects.toThrow(
+          /Literal subject in property path/,
+        );
+      } finally {
+        errorSpy.mockRestore();
+      }
+    });
+
+    it("warns but does not throw when env=0 (explicit opt-out)", async () => {
+      process.env.EXOCORTEX_SPARQL_STRICT = "0";
+      const errorSpy = jest.spyOn(console, "error").mockImplementation(() => undefined);
+      try {
+        const results = await collectResults(labelLiteral, oneOrMorePath, algebraVar("o"));
+        expect(results).toEqual([]);
+        expect(errorSpy).toHaveBeenCalled();
+      } finally {
+        errorSpy.mockRestore();
+      }
+    });
+
+    it("isStrictModeEnabled() honours yes/true/1 only", () => {
+      const cases: Array<[string | undefined, boolean]> = [
+        [undefined, false],
+        ["", false],
+        ["0", false],
+        ["false", false],
+        ["no", false],
+        ["1", true],
+        ["true", true],
+        ["TRUE", true],
+        ["yes", true],
+        ["YES", true],
+        ["  true  ", true],
+      ];
+      for (const [raw, expected] of cases) {
+        if (raw === undefined) {
+          delete process.env.EXOCORTEX_SPARQL_STRICT;
+        } else {
+          process.env.EXOCORTEX_SPARQL_STRICT = raw;
+        }
+        expect(PropertyPathExecutor.isStrictModeEnabled()).toBe(expected);
+      }
+    });
+  });
+});

--- a/packages/exocortex/tests/unit/infrastructure/sparql/executors/PropertyPathExecutor.test.ts
+++ b/packages/exocortex/tests/unit/infrastructure/sparql/executors/PropertyPathExecutor.test.ts
@@ -650,13 +650,15 @@ describe("PropertyPathExecutor", () => {
         // Pre-#2997 this threw "Unsupported element type"; the Phase 3 guard
         // converts the throw to a warn-and-empty so a literal leaked from the
         // loader or a join-instantiation cannot crash the algebra pipeline.
-        const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => undefined);
+        // Issue #3282 upgraded the diagnostic to console.error with a
+        // structured payload so the silent recall loss is now visible.
+        const errorSpy = jest.spyOn(console, "error").mockImplementation(() => undefined);
         try {
           const results = await collectResults(literalSubject, path, algebraVar("o"));
           expect(results).toEqual([]);
-          expect(warnSpy).toHaveBeenCalled();
+          expect(errorSpy).toHaveBeenCalled();
         } finally {
-          warnSpy.mockRestore();
+          errorSpy.mockRestore();
         }
       });
     });


### PR DESCRIPTION
## Summary

Refs #3282 — ships **Sub-task C only** (structured-error promotion + `--strict` flag). Sub-tasks A and B explicitly deferred — see follow-ups #3352 (broader synthesis) and #3353 (dual-storage feature flag). **Does not close #3282** — partial closure under issue body's «can ship independently» clause.

`PropertyPathExecutor.execute:51` and `BGPExecutor.warnLiteralGuard:543` previously called `console.warn` and silently yielded zero solutions when a literal leaked into subject / object / predicate position — typically from `NoteToRDFConverter.valueToRDFObject` failing to resolve a label-form wikilink like `[[Барик (Area)]]`. The audit reproducer's 9 warnings (2026-05-27, issue body evidence) were silent recall losses.

## Changes

### Structured error visibility
- `BGPExecutor.warnLiteralGuard`: `console.warn` → `console.error` with a structured payload (`executor`, `context`, `position`, `value`, `hint`). **This is the actual production fire site** for the audit reproducer's 9 warnings.
- `PropertyPathExecutor.execute:51`: same promotion + `describePath` helper for diagnostic readability (renders `^p`, `p+`, `p*`, `p?` faithfully).
- Both guards share `PropertyPathExecutor.isStrictModeEnabled()` — single source of truth.

### Strict mode escalation
- New env var `EXOCORTEX_SPARQL_STRICT` (truthy = `1` / `true` / `yes`, case-insensitive). When set, guards throw `BGPExecutorError` / `PropertyPathExecutorError` instead of warn-and-empty.
- New CLI flag `exocortex sparql query --strict` sets the env var for the lifetime of the command, with `try / finally` restore so embedded callers (MCP host, programmatic invocation) cannot inherit strict mode across queries.
- Mirrors the `EXOCORTEX_SPARQL_TIMEOUT` precedent.

## Empirical verification

Per \`~/dotfiles/.claude/rules/integration-test-revert-verify.md\`:

1. **PropertyPathExecutor.ts revert** → \`PropertyPathExecutor.literal-safety.test.ts\` (7 tests) FAILS to compile (\`isStrictModeEnabled\` missing) + behavioural assertions FAIL (warn vs error). Restore → 7/7 PASS.
2. **BGPExecutor.ts revert** → \`BGPExecutor.issue-2997.test.ts\` 6 fail / 1 pass (warn-spy assertions + missing strict branches). Restore → 7/7 PASS.

**Full SPARQL executor suite:** 2905/2906 PASS (1 unrelated pre-existing \`QueryExecutor.branch.test.ts:104\` failure — verified persists on origin/main stashed-clean state).

**Typecheck:** clean. **Lint:** 0 errors (2 pre-existing warnings unrelated). **Archgate:** PASS (13/13 ADR rules).

## Transitive proof for CLI \`--strict\` end-to-end

Per \`~/dotfiles/.claude/rules/ui-smoke-transitive-proof.md\`. Unit-test coverage exercises every link in the chain:

- Commander option parse → \`process.env.EXOCORTEX_SPARQL_STRICT = \"1\"\` (asserted by reading handler diff)
- \`isStrictModeEnabled()\` parses env correctly (11-case truth table)
- Both executor guards throw on truthy env (BGP + PropertyPath strict tests)
- \`try / finally\` restores env (verified by code inspection)

The \`EXOCORTEX_SPARQL_TIMEOUT\` precedent exercises the same plumbing pattern (commander → env mutation → executor read) in production. No new constructor cascade introduced.

## Scope discipline

Issue body lists 4 acceptance criteria across Sub-tasks A / B / C; issue body explicitly says «Sub-task A → B → C can ship independently». This PR closes AC #2 («PropertyPathExecutor.ts:51 emits structured error (not silent WARN)») and AC #3 («\`--strict\` flag causes query to fail with clear diagnostic»). Sub-tasks A and B tracked separately:

- **#3352** — Sub-task A (broader synthesis) — requires \`FileSystemVaultAdapter\` cross-vault adapter plumbing per the converter-architecture finding during this PR's structural audit.
- **#3353** — Sub-task B (dual-storage feature flag) — requires SHACL cardinality safety analysis (the existing scope comment at \`NoteToRDFConverter.ts:1264\` cites \`sh:maxCount=1\` violations as the reason dual-storage is currently scoped to \`exo__Asset_prototype\` only).

Decision reached via advisor round-1 + advisor round-2 + code-reviewer round-1 (HIGH finding correctly flagged the BGPExecutor reachability gap and was addressed in commit f62b8861 of this PR).

## Test plan

- [x] New regression suite \`PropertyPathExecutor.literal-safety.test.ts\` (7 tests)
- [x] Extended \`BGPExecutor.issue-2997.test.ts\` with 3 strict-mode tests
- [x] Existing literal-guard test in \`PropertyPathExecutor.test.ts\` updated for \`console.error\` promotion
- [x] Empirical revert-fail / restore-pass verified on both production files
- [x] Full SPARQL executor suite regression (2905/2906)
- [x] Typecheck + lint + archgate green locally
- [ ] CI green