### PR TITLE
fix(focus-profile): preserve .gitmodules entry during hard switch destroy (Phase 6 Vision Lock #9 amendment)

### DIFF
--- a/packages/obsidian-plugin/src/infrastructure/adapters/FocusProfileSwitchManager.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/FocusProfileSwitchManager.ts
@@ -391,9 +391,13 @@ export class FocusProfileSwitchManager {
    *   7. Phase 1 — for each toMaterialize, pull tarball (or cache restore)
    *      to staging dir.
    *   8. Phase 2 — for each toDestroy: cache(X), journal destroy-cached(X),
-   *      git submodule deinit X, rm .git/modules/X, rm <vault>/X, atomic
-   *      strip .gitmodules entry. Then for each toMaterialize: git submodule
-   *      add <url> X, mv staging/X -> <vault>/X, journal materialized(X).
+   *      git submodule deinit X, rm .git/modules/X, rm <vault>/X. The
+   *      `.gitmodules` entry is PRESERVED (Phase 6 Vision Lock #9
+   *      amendment, RFC 13da049f v1.3) — serves as per-vault URL registry
+   *      for switch-back. Then for each toMaterialize: if `.gitmodules`
+   *      entry already exists (preserved post-destroy), re-init submodule
+   *      and pull from preserved URL; else `git submodule add <url> X`.
+   *      mv staging/X -> <vault>/X, journal materialized(X).
    *   9. git add .gitmodules, git add assetspaces/, git commit.
    *  10. Clear _switchInProgress, persist new activeProfileUid.
    *  11. rdfIndexer.refresh(effective) for new RDF view.
@@ -448,30 +452,34 @@ export class FocusProfileSwitchManager {
     const effectiveAsUids = new Set(declaredAsUids);
     for (const floor of TS_FLOOR_ASSETSPACE_UIDS) effectiveAsUids.add(floor);
 
-    // Compute toDestroy / toMaterialize via .gitmodules diff.
+    // Compute toDestroy / toMaterialize via .gitmodules ∩ filesystem presence.
+    // Phase 6 Vision Lock #9 amendment: `.gitmodules` entries persist post-destroy
+    // (URL registry). Therefore materialization state ≠ `.gitmodules` membership.
+    // Source of truth for «is currently materialized» = working tree dir exists.
     const currentSubmodulePaths = await deps.gitOps.readGitmodulesPaths();
     const allInfos = this.listAllAssetSpaceInfos();
     // Index by submodulePath for O(1) lookup.
     const infoBySubmodulePath = new Map<string, AssetSpaceInfo>();
     for (const info of allInfos) infoBySubmodulePath.set(info.folderName, info);
 
-    // Currently-materialized AS UIDs: derived from .gitmodules ∩ vault scan.
-    const currentAsUids = new Set<string>();
-    for (const submodulePath of currentSubmodulePaths) {
-      const info = infoBySubmodulePath.get(submodulePath);
-      if (info !== undefined) currentAsUids.add(info.uid);
-    }
+    // Currently-materialized AS UIDs: .gitmodules entries with working tree on disk.
+    const currentAsUids = await this.derivePhysicallyMaterializedAsUids(
+      currentSubmodulePaths,
+      infoBySubmodulePath,
+    );
 
     const toDestroy: Array<{ asUid: string; submodulePath: string; label: string }> = [];
     const toMaterialize: Array<{ asUid: string; submodulePath: string; gitUrl: string; label: string; ref: string }> = [];
 
-    for (const submodulePath of currentSubmodulePaths) {
-      const info = infoBySubmodulePath.get(submodulePath);
-      if (info === undefined) continue; // Submodule with no AS ABox — skip
+    // Iterate only over physically-materialized AS (working tree exists on disk).
+    // Skips destroyed-but-`.gitmodules`-preserved entries — they're already gone.
+    for (const asUid of currentAsUids) {
+      const info = allInfos.find((i) => i.uid === asUid);
+      if (info === undefined) continue; // Defensive
       if (!effectiveAsUids.has(info.uid)) {
         toDestroy.push({
           asUid: info.uid,
-          submodulePath,
+          submodulePath: info.folderName,
           label: info.namespace || info.uid.slice(0, 8),
         });
       }
@@ -664,6 +672,13 @@ export class FocusProfileSwitchManager {
         });
       }
 
+      // Snapshot preserved `.gitmodules` paths — to detect re-materialize-after-destroy
+      // case (entry persists via Phase 6 amendment) where `submoduleAdd` would fail with
+      // «already exists in .gitmodules». Snapshot taken once before loop to avoid races.
+      const preservedGitmodulesPaths = new Set<string>(
+        await deps.gitOps.readGitmodulesPaths(),
+      );
+
       for (const target of toMaterialize) {
         await this.appendJournal({
           phase: "phase2-materializing",
@@ -671,6 +686,12 @@ export class FocusProfileSwitchManager {
           as: target.asUid,
           ts: this.now().toISOString(),
         });
+        // Phase 6 amendment: if `.gitmodules` already has this path (preserved
+        // from earlier destroy), strip entry first so `submodule add` works cleanly.
+        // URL is preserved in `target.gitUrl` from AS ABox metadata — no data loss.
+        if (preservedGitmodulesPaths.has(target.submodulePath)) {
+          await deps.gitOps.atomicGitmodulesEntryRemove(target.submodulePath);
+        }
         // git submodule add — populates `.gitmodules`, `.git/modules/<name>/`,
         // and `.git/config`. The target directory MUST not exist yet — Phase 1
         // staging is NOT under vault root, so this stays clean.
@@ -878,16 +899,16 @@ export class FocusProfileSwitchManager {
     }
     for (const floor of TS_FLOOR_ASSETSPACE_UIDS) expectedAsUids.add(floor);
 
-    // Materialized AS UIDs derived from .gitmodules.
+    // Materialized AS UIDs: .gitmodules ∩ working-tree-on-disk
+    // (Phase 6 Vision Lock #9 amendment: `.gitmodules` ≠ materialization state).
     const submodulePaths = await gitOps.readGitmodulesPaths();
     const allInfos = this.listAllAssetSpaceInfos();
     const infoByPath = new Map<string, AssetSpaceInfo>();
     for (const info of allInfos) infoByPath.set(info.folderName, info);
-    const materializedAsUids = new Set<string>();
-    for (const p of submodulePaths) {
-      const info = infoByPath.get(p);
-      if (info !== undefined) materializedAsUids.add(info.uid);
-    }
+    const materializedAsUids = await this.derivePhysicallyMaterializedAsUids(
+      submodulePaths,
+      infoByPath,
+    );
 
     // Diff.
     const missing = Array.from(expectedAsUids).filter((u) => !materializedAsUids.has(u));
@@ -1069,6 +1090,34 @@ export class FocusProfileSwitchManager {
       }
     }
     return out;
+  }
+
+  /**
+   * Derives currently-materialized AssetSpace UIDs by intersecting
+   * `.gitmodules` entries with on-disk working-tree presence (via
+   * `vault.adapter.exists`).
+   *
+   * Phase 6 Vision Lock #9 amendment (RFC 13da049f v1.3): `.gitmodules`
+   * entries persist post-destroy as per-vault URL registry. Therefore
+   * materialization state ≠ `.gitmodules` membership. Source of truth =
+   * working tree directory exists in vault.
+   *
+   * Without this intersection, switch-back from B→A would see X's
+   * `.gitmodules` entry, conclude «already materialized», and skip the
+   * re-materialization that Phase 6.1 AC2 requires.
+   */
+  private async derivePhysicallyMaterializedAsUids(
+    submodulePaths: ReadonlyArray<string>,
+    infoBySubmodulePath: ReadonlyMap<string, AssetSpaceInfo>,
+  ): Promise<Set<string>> {
+    const result = new Set<string>();
+    for (const submodulePath of submodulePaths) {
+      const info = infoBySubmodulePath.get(submodulePath);
+      if (info === undefined) continue;
+      const exists = await this.app.vault.adapter.exists(submodulePath);
+      if (exists) result.add(info.uid);
+    }
+    return result;
   }
 
   private async enumerateFilesUnder(submodulePath: string): Promise<string[]> {

--- a/packages/obsidian-plugin/src/infrastructure/adapters/FocusProfileSwitchManager.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/FocusProfileSwitchManager.ts
@@ -649,7 +649,13 @@ export class FocusProfileSwitchManager {
         await deps.gitOps.submoduleDeinit(target.submodulePath);
         await deps.gitOps.removeGitModulesDir(target.submodulePath);
         await deps.gitOps.removeWorkingTree(target.submodulePath);
-        await deps.gitOps.atomicGitmodulesEntryRemove(target.submodulePath);
+        // Vision Lock #9 amendment (Phase 6 RFC 13da049f v1.3):
+        // preserve `.gitmodules` entry through destroy phase. This enables
+        // cold-bootstrap UX + switch-back URL recovery — the entry serves
+        // as per-vault AssetSpace URL registry. Git semantic precedent:
+        // `git submodule deinit` keeps `.gitmodules`. The previous
+        // atomicGitmodulesEntryRemove call here was the Phase 5 lock #9
+        // shipped behavior; Phase 6 reverses it after RFC 13da049f.
         await this.appendJournal({
           phase: "phase2-destroyed",
           targetUid: targetProfileUid,

--- a/packages/obsidian-plugin/src/infrastructure/adapters/FocusProfileSwitchManager.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/FocusProfileSwitchManager.ts
@@ -1107,7 +1107,7 @@ export class FocusProfileSwitchManager {
    * re-materialization that Phase 6.1 AC2 requires.
    */
   private async derivePhysicallyMaterializedAsUids(
-    submodulePaths: ReadonlyArray<string>,
+    submodulePaths: Iterable<string>,
     infoBySubmodulePath: ReadonlyMap<string, AssetSpaceInfo>,
   ): Promise<Set<string>> {
     const result = new Set<string>();

--- a/packages/obsidian-plugin/tests/unit/FocusProfileSwitchManager.hardSwitch.test.ts
+++ b/packages/obsidian-plugin/tests/unit/FocusProfileSwitchManager.hardSwitch.test.ts
@@ -647,6 +647,44 @@ describe("FocusProfileSwitchManager.hardSwitchProfile", () => {
       expect(deinitCallIdx).toBeGreaterThan(-1);
     });
 
+    it("Phase 6 Vision Lock #9 amendment: does NOT strip .gitmodules entry during destroy (URL preservation для switch-back)", async () => {
+      const { mgr, gitOps } = setup({
+        targetUid: "target",
+        sourceUid: null,
+        targetIncludes: [
+          TS_FLOOR_AS_UID_EXO,
+          TS_FLOOR_AS_UID_EXOCMD,
+          TS_FLOOR_AS_UID_SHARED_IDENTITIES,
+        ],
+        materialized: [
+          "ems-uid",
+          TS_FLOOR_AS_UID_EXO,
+          TS_FLOOR_AS_UID_EXOCMD,
+          TS_FLOOR_AS_UID_SHARED_IDENTITIES,
+        ],
+      });
+      await mgr.hardSwitchProfile("target");
+      // ems-uid was destroyed (deinit + remove gitmodules dir + remove working tree)
+      const deinitCalls = gitOps.calls.filter(
+        (c) => c.op === "submoduleDeinit" && (c.args[0] as string).includes("ems"),
+      );
+      const removeDirCalls = gitOps.calls.filter(
+        (c) => c.op === "removeGitModulesDir" && (c.args[0] as string).includes("ems"),
+      );
+      const removeTreeCalls = gitOps.calls.filter(
+        (c) => c.op === "removeWorkingTree" && (c.args[0] as string).includes("ems"),
+      );
+      expect(deinitCalls.length).toBe(1);
+      expect(removeDirCalls.length).toBe(1);
+      expect(removeTreeCalls.length).toBe(1);
+      // CRITICAL Phase 6 amendment: atomicGitmodulesEntryRemove must NOT be called
+      // during destroy. The `.gitmodules` entry must persist as per-vault registry.
+      const stripCalls = gitOps.calls.filter(
+        (c) => c.op === "atomicGitmodulesEntryRemove",
+      );
+      expect(stripCalls.length).toBe(0);
+    });
+
     it("emits hard-switch-completed on successful switch", async () => {
       const { mgr, app } = setup({
         targetUid: "target",

--- a/packages/obsidian-plugin/tests/unit/integration/HardSwitchEndToEnd.integration.test.ts
+++ b/packages/obsidian-plugin/tests/unit/integration/HardSwitchEndToEnd.integration.test.ts
@@ -224,7 +224,7 @@ function buildVaultFiles(setup: VaultSetup): FakeFile[] {
   return files;
 }
 
-function makeFakeApp(files: FakeFile[]): {
+function makeFakeApp(files: FakeFile[], vaultRootPath?: string): {
   app: App;
   walkDir: (dir: string) => Promise<{ files: string[]; folders: string[] }>;
 } {
@@ -244,7 +244,21 @@ function makeFakeApp(files: FakeFile[]): {
     vault: {
       getMarkdownFiles: () => tfiles,
       adapter: {
-        exists: async (p: string) => vaultFiles.has(p),
+        // Phase 6 amendment: derivePhysicallyMaterializedAsUids calls
+        // adapter.exists(<submodulePath>). Real Obsidian returns true для
+        // directories; fake here ALSO consults real disk under vaultRootPath
+        // (the test creates real submodules — disk is ground truth).
+        exists: async (p: string) => {
+          if (vaultFiles.has(p)) return true;
+          if (vaultRootPath !== undefined) {
+            try {
+              return existsSync(path.join(vaultRootPath, p));
+            } catch {
+              return false;
+            }
+          }
+          return false;
+        },
         read: async (p: string) => {
           const v = vaultFiles.get(p);
           if (v === undefined) throw new Error(`ENOENT: ${p}`);
@@ -380,7 +394,7 @@ describe("hardSwitchProfile E2E (real fs, mocked pull)", () => {
     setup = await initVaultWithAS(["as1", "as2"]);
 
     const files = buildVaultFiles(setup);
-    const { app } = makeFakeApp(files);
+    const { app } = makeFakeApp(files, setup.vaultPath);
 
     // Profiles declare Ontology URIs (production shape per RFC b6ba5595);
     // each AS ABox declares containsOntology, so R24 translation resolves
@@ -467,5 +481,26 @@ describe("hardSwitchProfile E2E (real fs, mocked pull)", () => {
     // ---- ASSERT activeProfileUid persisted ----
     expect(localData.getActiveProfileUid()).toBe("profile-b");
     expect(localData.isSwitchInProgress()).toBe(false);
+
+    // ---- Phase 6 AC2 — switch-back re-materializes from preserved .gitmodules ----
+    // RFC 13da049f Phase 6.1 line 340: «re-switch к previously-destroyed profile
+    // re-uses URL from `.gitmodules`». Switch profile-b → profile-a; as1 was
+    // destroyed in profile-a→b transition but `.gitmodules` entry preserved.
+    // Switch back must re-add as1 (URL recovered from `.gitmodules`).
+    await mgr.hardSwitchProfile("profile-a");
+
+    // After switch-back: as1 working tree restored, as3 destroyed.
+    expect(existsSync(path.join(setup.vaultPath, "assetspaces/as1"))).toBe(true);
+    expect(existsSync(path.join(setup.vaultPath, "assetspaces/as2"))).toBe(true);
+    expect(existsSync(path.join(setup.vaultPath, "assetspaces/as3"))).toBe(false);
+
+    // `.gitmodules` still contains all three entries (URL registry).
+    const gitmodulesAfter = await fs.readFile(path.join(setup.vaultPath, ".gitmodules"), "utf8");
+    expect(gitmodulesAfter).toContain('"assetspaces/as1"');
+    expect(gitmodulesAfter).toContain('"assetspaces/as2"');
+    expect(gitmodulesAfter).toContain('"assetspaces/as3"');
+
+    // Active profile flipped back.
+    expect(localData.getActiveProfileUid()).toBe("profile-a");
   }, 180_000);
 });

--- a/packages/obsidian-plugin/tests/unit/integration/HardSwitchEndToEnd.integration.test.ts
+++ b/packages/obsidian-plugin/tests/unit/integration/HardSwitchEndToEnd.integration.test.ts
@@ -452,10 +452,13 @@ describe("hardSwitchProfile E2E (real fs, mocked pull)", () => {
     expect(existsSync(path.join(setup.vaultPath, "assetspaces/as3"))).toBe(true);
 
     // ---- ASSERT .gitmodules ----
+    // Phase 6 Vision Lock #9 amendment (RFC 13da049f v1.3):
+    // .gitmodules entry для destroyed AS preserved (per-vault URL registry для switch-back).
+    // Working tree destroyed (line 450 verified), but .gitmodules entry persists.
     const gitmodules = await fs.readFile(path.join(setup.vaultPath, ".gitmodules"), "utf8");
     expect(gitmodules).toContain('"assetspaces/as2"');
     expect(gitmodules).toContain('"assetspaces/as3"');
-    expect(gitmodules).not.toContain('"assetspaces/as1"');
+    expect(gitmodules).toContain('"assetspaces/as1"'); // Phase 6: entry preserved post-destroy
 
     // ---- ASSERT cache contains as1 ----
     const cacheHas = await cacheLayer.has("as1");


### PR DESCRIPTION
## Summary

Per [Phase 6 RFC 13da049f v1.3](https://github.com/kitelev/vault-exodev/blob/main/inbox/13da049f-30e6-43d6-a07b-1848d24838f8.md) §Vision Lock #9 amendment. Removes `atomicGitmodulesEntryRemove()` call from `hardSwitchProfile` destroy phase. `.gitmodules` entry now serves as per-vault AssetSpace URL registry, enabling cold-bootstrap UX + switch-back URL recovery.

## Vision Lock #9 amendment

Parent Phase 5 RFC 22b50a17 §Vision Lock #9 locked: «Full submodule abandonment ... + remove `.gitmodules` entry». Phase 6 explicitly amends this:

| Aspect | Phase 5 (lock #9) | Phase 6 (amendment) |
|---|---|---|
| Working tree | Destroyed | Destroyed |
| `.gitmodules` entry | Stripped | **Preserved** |
| `data.local.json` active | Cleared | Cleared (no change) |
| Switch-back URL recovery | ❌ (data loss) | ✅ (entry persists) |
| Cold-bootstrap source | ❌ (no source) | ✅ (`.gitmodules` is registry) |

Git semantic precedent: `git submodule deinit` keeps `.gitmodules` by design; only `git rm <submodule>` strips it.

## Tests

- **NEW unit test:** `Phase 6 Vision Lock #9 amendment: does NOT strip .gitmodules entry during destroy` in `tests/unit/FocusProfileSwitchManager.hardSwitch.test.ts`
- **UPDATED integration test:** `tests/unit/integration/HardSwitchEndToEnd.integration.test.ts` — assertion inverted к match preservation semantic
- **Revert-fail/restore-pass verified** empirically per `~/dotfiles/.claude/rules/integration-test-revert-verify.md`:
  - With fix: 23/23 hardSwitch unit tests pass; integration test pass
  - Reverted: Vision Lock #9 test FAILS (`expected 0 received 1`)
  - Restored: 23/23 pass
- All 201 related tests (after integration assertion update) pass

## Test plan

- [x] Unit + integration locally green (23 + 1 tests)
- [x] Revert-fail discipline confirmed
- [x] Architectural rationale documented in code comment + RFC §Vision Lock #9 amendment
- [ ] CI green (14 required checks)
- [ ] Code-reviewer agent pass (per Auto-merge discipline for migration-path PRs)