### PR TITLE
feat(cli): Phase 6.5 migration tool — shared-identities profiles → profiles/ AS + dual-class

### DIFF
--- a/packages/cli/src/commands/migrate-shared-identities-profiles.ts
+++ b/packages/cli/src/commands/migrate-shared-identities-profiles.ts
@@ -1,0 +1,97 @@
+import { Command } from "commander";
+import { resolve } from "path";
+import { existsSync } from "fs";
+import { SharedIdentitiesProfileMigrationService } from "../services/SharedIdentitiesProfileMigrationService.js";
+import { VaultNotFoundError, InvalidArgumentsError } from "../utils/errors/index.js";
+import { ErrorHandler } from "../utils/ErrorHandler.js";
+
+interface MigrateOptions {
+  vault: string;
+  apply?: boolean;
+  json?: boolean;
+}
+
+/**
+ * `exocortex migrate-shared-identities-profiles`
+ *
+ * Phase 6.5 migration tool per RFC 13da049f v1.3. Relocates FocusProfile
+ * instances from `assetspaces/shared-identities/` к `assetspaces/profiles/`
+ * + adds dual-class `exo__KnowledgeProfile` membership.
+ *
+ * Default: DRY-RUN. Pass `--apply` to mutate vault.
+ *
+ * Idempotent: re-running after successful apply is a no-op (sources renamed
+ * к `.migrated-backup` suffix to mark migrated state).
+ *
+ * Other shared-identities content (ims__Concepts, ConceptSchemas, etc.)
+ * stays untouched — separate future migration phase.
+ */
+export function migrateSharedIdentitiesProfilesCommand(): Command {
+  return new Command("migrate-shared-identities-profiles")
+    .description(
+      "Phase 6.5: relocate FocusProfile instances from shared-identities/ к profiles/ + add dual-class KnowledgeProfile (RFC 13da049f). Dry-run by default; --apply to mutate.",
+    )
+    .requiredOption("--vault <path>", "Path to Obsidian vault root")
+    .option("--apply", "Execute migration (default: dry-run)", false)
+    .option("--json", "Emit plan / result as JSON", false)
+    .action(async (options: MigrateOptions) => {
+      try {
+        if (!options.vault) {
+          throw new InvalidArgumentsError("--vault is required");
+        }
+        const vaultPath = resolve(options.vault);
+        if (!existsSync(vaultPath)) {
+          throw new VaultNotFoundError(vaultPath);
+        }
+
+        const svc = new SharedIdentitiesProfileMigrationService();
+
+        if (options.apply) {
+          const result = svc.apply({ vaultPath, apply: true });
+          if (options.json) {
+            process.stdout.write(JSON.stringify(result, null, 2) + "\n");
+          } else {
+            process.stdout.write(
+              `Migration applied: ${result.applied.length} relocated, ${result.errors.length} errors\n`,
+            );
+            for (const e of result.applied) {
+              process.stdout.write(`  ✓ ${e.uid}: ${e.from} → ${e.to}\n`);
+            }
+            for (const err of result.errors) {
+              process.stderr.write(`  ✗ ${err.uid}: ${err.reason}\n`);
+            }
+            process.stdout.write(
+              `\nNext steps:\n` +
+                `  1. cd ${result.plan.profilesDirPath} && git add . && git commit + push\n` +
+                `  2. cd ${vaultPath} && git submodule deinit assetspaces/shared-identities (if all migrated)\n` +
+                `  3. cd ${vaultPath} && git submodule add <exoas-profiles-url> assetspaces/profiles\n` +
+                `  4. Repeat 1-3 в sibling vault if dual-vault setup\n`,
+            );
+          }
+          process.exit(result.errors.length > 0 ? 1 : 0);
+        } else {
+          // Dry-run.
+          const plan = svc.generatePlan({ vaultPath });
+          if (options.json) {
+            process.stdout.write(JSON.stringify(plan, null, 2) + "\n");
+          } else {
+            process.stdout.write(`Dry-run plan для ${vaultPath}:\n`);
+            process.stdout.write(`  Source: ${plan.sharedIdentitiesPath}\n`);
+            process.stdout.write(`  Target: ${plan.profilesDirPath}\n`);
+            process.stdout.write(`  Summary: ${plan.summary.relocate} к relocate, ${plan.summary.alreadyMigrated} already migrated, ${plan.summary.skipped} skipped (non-FocusProfile)\n\n`);
+            for (const a of plan.actions) {
+              if (a.kind === "relocate-and-dual-class") {
+                process.stdout.write(`  RELOCATE: ${a.uid} (${a.label}) → ${a.profilesDirPath}\n`);
+              } else if (a.kind === "already-migrated") {
+                process.stdout.write(`  SKIP-DONE: ${a.uid} (${a.label}) — already at ${a.profilesDirPath}\n`);
+              }
+            }
+            process.stdout.write(`\nRun с --apply к execute.\n`);
+          }
+          process.exit(0);
+        }
+      } catch (e) {
+        ErrorHandler.handle(e as Error);
+      }
+    });
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -21,6 +21,7 @@ import { findCommand } from "./commands/find.js";
 import { applyCommand } from "./commands/apply.js";
 import { auditCommand } from "./commands/audit.js";
 import { hardSwitchCommand } from "./commands/hard-switch.js";
+import { migrateSharedIdentitiesProfilesCommand } from "./commands/migrate-shared-identities-profiles.js";
 
 // Version injected at build time by esbuild (see esbuild.config.mjs)
 declare const __CLI_VERSION__: string;
@@ -67,6 +68,9 @@ export function createProgram(version?: string): Command {
 
   // RFC 22b50a17 Phase 1b — hard switch CLI scaffold (Phase 3 wires orchestrator)
   program.addCommand(hardSwitchCommand());
+
+  // RFC 13da049f Phase 6.5 — shared-identities → profiles AS migration tool
+  program.addCommand(migrateSharedIdentitiesProfilesCommand());
 
   return program;
 }

--- a/packages/cli/src/services/SharedIdentitiesProfileMigrationService.ts
+++ b/packages/cli/src/services/SharedIdentitiesProfileMigrationService.ts
@@ -1,0 +1,260 @@
+/**
+ * Phase 6.5 migration service — Knowledge/Focus dual-class assignment for
+ * FocusProfile instances + relocation from `assetspaces/shared-identities/`
+ * к `assetspaces/profiles/` (kitelev/exoas-profiles submodule).
+ *
+ * Per RFC 13da049f (Phase 6 consumer) + sibling onto-RFC 52f2acdd.
+ *
+ * Scope (intentionally narrow):
+ *  - FocusProfile instances → relocate к profiles/ + add KnowledgeProfile class
+ *  - ExoAssistant identity → relocate к exo/ (out of overnight scope, marked TODO)
+ *  - Other shared-identities content → untouched (future migration phase)
+ *
+ * Idempotent: re-running against partially-migrated vault skips already-moved files.
+ *
+ * Defensive: dry-run output mirrors apply mode exactly. Apply mode requires
+ * --apply flag + --profiles-dir pointing к exoas-profiles submodule working tree.
+ */
+
+import { readdirSync, readFileSync, writeFileSync, existsSync, mkdirSync, renameSync, statSync } from "node:fs";
+import * as path from "node:path";
+
+/**
+ * Pre-allocated UIDs from sibling onto-RFC 52f2acdd.
+ */
+export const KNOWLEDGE_PROFILE_CLASS_UID = "b8884976-596f-43d2-b7f4-3da518f825d4";
+export const KNOWLEDGE_PROFILE_INCLUDES_UID = "4c118802-258d-47f6-8a4e-4b13e04077b2";
+export const KNOWLEDGE_PROFILE_EXTENDS_UID = "a1f42d5a-237c-4104-83d5-152b4960f964";
+export const KNOWLEDGE_PROFILE_ALWAYS_ON_OVERLAY_UID = "103dab8d-5a7c-46d2-a82a-f4db4b5aef3c";
+export const FOCUS_PROFILE_CLASS_UID = "3de846cd-1f0e-4f98-8613-b8587aa15174";
+
+export type MigrationAction =
+  | { kind: "relocate-and-dual-class"; uid: string; label: string; srcPath: string; profilesDirPath: string }
+  | { kind: "already-migrated"; uid: string; label: string; profilesDirPath: string }
+  | { kind: "skip-not-focus-profile"; uid: string; label: string; srcPath: string };
+
+export interface MigrationPlan {
+  vaultPath: string;
+  sharedIdentitiesPath: string;
+  profilesDirPath: string;
+  actions: MigrationAction[];
+  summary: {
+    relocate: number;
+    alreadyMigrated: number;
+    skipped: number;
+  };
+}
+
+export interface PlanOptions {
+  vaultPath: string;
+  profilesDirRelative?: string;
+}
+
+export interface ApplyOptions extends PlanOptions {
+  /** Defaults к dry-run if false. */
+  apply: boolean;
+}
+
+export interface ApplyResult {
+  plan: MigrationPlan;
+  applied: Array<{ kind: string; uid: string; from: string; to: string }>;
+  errors: Array<{ uid: string; reason: string }>;
+}
+
+/**
+ * Reads ALL .md files в `assetspaces/shared-identities/`, identifies which are
+ * FocusProfile instances, and produces a migration plan.
+ */
+export class SharedIdentitiesProfileMigrationService {
+  /**
+   * Generate plan — read-only, no mutations.
+   */
+  generatePlan(opts: PlanOptions): MigrationPlan {
+    const sharedPath = path.join(opts.vaultPath, "assetspaces", "shared-identities");
+    const profilesRel = opts.profilesDirRelative ?? "assetspaces/profiles";
+    const profilesPath = path.join(opts.vaultPath, profilesRel);
+
+    const actions: MigrationAction[] = [];
+
+    if (!existsSync(sharedPath)) {
+      return {
+        vaultPath: opts.vaultPath,
+        sharedIdentitiesPath: sharedPath,
+        profilesDirPath: profilesPath,
+        actions,
+        summary: { relocate: 0, alreadyMigrated: 0, skipped: 0 },
+      };
+    }
+
+    const entries = readdirSync(sharedPath).filter((f) => f.endsWith(".md"));
+
+    for (const fname of entries) {
+      const srcPath = path.join(sharedPath, fname);
+      const uid = fname.replace(/\.md$/, "");
+      const { label, isFocusProfile } = this.parseSourceFile(srcPath);
+
+      if (!isFocusProfile) {
+        actions.push({ kind: "skip-not-focus-profile", uid, label, srcPath });
+        continue;
+      }
+
+      const targetPath = path.join(profilesPath, fname);
+      if (existsSync(targetPath)) {
+        actions.push({ kind: "already-migrated", uid, label, profilesDirPath: targetPath });
+        continue;
+      }
+
+      actions.push({ kind: "relocate-and-dual-class", uid, label, srcPath, profilesDirPath: targetPath });
+    }
+
+    return {
+      vaultPath: opts.vaultPath,
+      sharedIdentitiesPath: sharedPath,
+      profilesDirPath: profilesPath,
+      actions,
+      summary: {
+        relocate: actions.filter((a) => a.kind === "relocate-and-dual-class").length,
+        alreadyMigrated: actions.filter((a) => a.kind === "already-migrated").length,
+        skipped: actions.filter((a) => a.kind === "skip-not-focus-profile").length,
+      },
+    };
+  }
+
+  /**
+   * Execute plan (apply mode). Writes к both vault и profilesDir.
+   * Idempotent: re-running на already-migrated state = no-op.
+   *
+   * IMPORTANT: caller must ensure `profilesDir` is a fresh git working tree
+   * for `kitelev/exoas-profiles` repo. This service does NOT call git.
+   * Commit + push happens via wrapping command after success.
+   */
+  apply(opts: ApplyOptions): ApplyResult {
+    const plan = this.generatePlan(opts);
+    const applied: ApplyResult["applied"] = [];
+    const errors: ApplyResult["errors"] = [];
+
+    if (!opts.apply) {
+      return { plan, applied, errors };
+    }
+
+    // Ensure profiles dir exists.
+    if (!existsSync(plan.profilesDirPath)) {
+      mkdirSync(plan.profilesDirPath, { recursive: true });
+    }
+
+    for (const action of plan.actions) {
+      if (action.kind !== "relocate-and-dual-class") continue;
+
+      try {
+        const transformed = this.transformProfileFile(action.srcPath);
+        writeFileSync(action.profilesDirPath, transformed, "utf8");
+        // Delete original AFTER successful write (atomic semantic).
+        renameSync(action.srcPath, action.srcPath + ".migrated-backup");
+        applied.push({
+          kind: "relocate-and-dual-class",
+          uid: action.uid,
+          from: action.srcPath,
+          to: action.profilesDirPath,
+        });
+      } catch (err) {
+        errors.push({
+          uid: action.uid,
+          reason: err instanceof Error ? err.message : String(err),
+        });
+      }
+    }
+
+    return { plan, applied, errors };
+  }
+
+  /**
+   * Parse just enough frontmatter к determine class membership + label.
+   * Avoids full YAML parser dependency; relies on regex против UID-form
+   * wikilinks + label-form fallback.
+   */
+  private parseSourceFile(srcPath: string): { label: string; isFocusProfile: boolean } {
+    const content = readFileSync(srcPath, "utf8");
+    const frontmatterMatch = content.match(/^---\n([\s\S]+?)\n---/);
+    if (frontmatterMatch === null) {
+      return { label: "<no-frontmatter>", isFocusProfile: false };
+    }
+    const fm = frontmatterMatch[1];
+    const labelMatch = fm.match(/^exo__Asset_label:\s*(.+)$/m);
+    const label = labelMatch !== null ? labelMatch[1].trim() : "<no-label>";
+
+    // exo__Instance_class can be array OR string. FocusProfile detection:
+    // (a) UID-form: contains FOCUS_PROFILE_CLASS_UID
+    // (b) Label-form: contains `exo__FocusProfile`
+    const isFocusProfile =
+      fm.includes(FOCUS_PROFILE_CLASS_UID) ||
+      /exo__Instance_class:\s*[\s\S]*?\[\[exo__FocusProfile/.test(fm);
+
+    return { label, isFocusProfile };
+  }
+
+  /**
+   * Transform FocusProfile source file → dual-class (KnowledgeProfile + FocusProfile).
+   *
+   * Rules per RFC 13da049f §Backward compat:
+   * 1. Add `[[<KP-class-uid>]]` к `exo__Instance_class` array (preserve FocusProfile)
+   * 2. Copy `exo__FocusProfile_includes` к `exo__KnowledgeProfile_includes` (same list)
+   * 3. Copy `exo__FocusProfile_extends` к `exo__KnowledgeProfile_extends` если present
+   * 4. Copy `exo__FocusProfile_alwaysOnOverlay` к `exo__KnowledgeProfile_alwaysOnOverlay` если present
+   * 5. Preserve original FocusProfile_* properties (no removal — dual semantic)
+   *
+   * Idempotent: skips transformation if KnowledgeProfile class already added.
+   */
+  private transformProfileFile(srcPath: string): string {
+    const content = readFileSync(srcPath, "utf8");
+    const fmMatch = content.match(/^(---\n[\s\S]+?\n---)(\n[\s\S]*)?$/);
+    if (fmMatch === null) {
+      throw new Error(`Source file ${srcPath} has no parseable frontmatter`);
+    }
+    const fm = fmMatch[1];
+    const body = fmMatch[2] ?? "";
+
+    // Already dual-class? Skip transformation.
+    if (fm.includes(KNOWLEDGE_PROFILE_CLASS_UID)) {
+      return content;
+    }
+
+    // Add KnowledgeProfile UID к Instance_class array.
+    let newFm = fm.replace(
+      /(exo__Instance_class:\s*\n((?:\s+-\s+.+\n)+))/,
+      (_match, _full, items: string) => {
+        const newLine = `  - "[[${KNOWLEDGE_PROFILE_CLASS_UID}]]"\n`;
+        return `exo__Instance_class:\n${newLine}${items}`;
+      },
+    );
+
+    // Add KnowledgeProfile_includes mirroring FocusProfile_includes.
+    const includesMatch = newFm.match(/(exo__FocusProfile_includes:\s*\n((?:\s+-\s+.+\n)+))/);
+    if (includesMatch !== null) {
+      const includesList = includesMatch[2];
+      const knowledgeIncludes = `exo__KnowledgeProfile_includes:\n${includesList}`;
+      newFm = newFm.replace(includesMatch[1], `${includesMatch[1]}${knowledgeIncludes}`);
+    }
+
+    // Mirror _extends (single-value property).
+    const extendsMatch = newFm.match(/(exo__FocusProfile_extends:\s*.+\n)/);
+    if (extendsMatch !== null) {
+      const value = extendsMatch[1].replace("FocusProfile_extends", "KnowledgeProfile_extends");
+      newFm = newFm.replace(extendsMatch[1], `${extendsMatch[1]}${value}`);
+    }
+
+    // Mirror _alwaysOnOverlay.
+    const overlayMatch = newFm.match(/(exo__FocusProfile_alwaysOnOverlay:\s*\n((?:\s+-\s+.+\n)+))/);
+    if (overlayMatch !== null) {
+      const overlayList = overlayMatch[2];
+      const knowledgeOverlay = `exo__KnowledgeProfile_alwaysOnOverlay:\n${overlayList}`;
+      newFm = newFm.replace(overlayMatch[1], `${overlayMatch[1]}${knowledgeOverlay}`);
+    }
+
+    return newFm + body;
+  }
+}
+
+/* eslint-disable @typescript-eslint/no-unused-vars */
+// Re-exported to silence "unused import" warnings when only types are used.
+const _types = { statSync };
+/* eslint-enable @typescript-eslint/no-unused-vars */

--- a/packages/cli/src/services/SharedIdentitiesProfileMigrationService.ts
+++ b/packages/cli/src/services/SharedIdentitiesProfileMigrationService.ts
@@ -16,7 +16,7 @@
  * --apply flag + --profiles-dir pointing к exoas-profiles submodule working tree.
  */
 
-import { readdirSync, readFileSync, writeFileSync, existsSync, mkdirSync, renameSync, statSync } from "node:fs";
+import { readdirSync, readFileSync, writeFileSync, existsSync, mkdirSync, renameSync } from "node:fs";
 import * as path from "node:path";
 
 /**
@@ -58,7 +58,7 @@ export interface ApplyOptions extends PlanOptions {
 export interface ApplyResult {
   plan: MigrationPlan;
   applied: Array<{ kind: string; uid: string; from: string; to: string }>;
-  errors: Array<{ uid: string; reason: string }>;
+  errors: Array<{ uid: string; srcPath: string; reason: string }>;
 }
 
 /**
@@ -159,6 +159,7 @@ export class SharedIdentitiesProfileMigrationService {
       } catch (err) {
         errors.push({
           uid: action.uid,
+          srcPath: action.srcPath,
           reason: err instanceof Error ? err.message : String(err),
         });
       }
@@ -168,12 +169,21 @@ export class SharedIdentitiesProfileMigrationService {
   }
 
   /**
+   * Normalize EOL + strip UTF-8 BOM. Defensive against CRLF (Windows / некоторые
+   * Obsidian Sync клиенты) и BOM-prefixed files (legacy migration scripts).
+   * Per PR #3359 code-reviewer round-1 HIGH findings.
+   */
+  private normalizeContent(raw: string): string {
+    return raw.replace(/^﻿/, "").replace(/\r\n/g, "\n");
+  }
+
+  /**
    * Parse just enough frontmatter к determine class membership + label.
    * Avoids full YAML parser dependency; relies on regex против UID-form
    * wikilinks + label-form fallback.
    */
   private parseSourceFile(srcPath: string): { label: string; isFocusProfile: boolean } {
-    const content = readFileSync(srcPath, "utf8");
+    const content = this.normalizeContent(readFileSync(srcPath, "utf8"));
     const frontmatterMatch = content.match(/^---\n([\s\S]+?)\n---/);
     if (frontmatterMatch === null) {
       return { label: "<no-frontmatter>", isFocusProfile: false };
@@ -205,7 +215,7 @@ export class SharedIdentitiesProfileMigrationService {
    * Idempotent: skips transformation if KnowledgeProfile class already added.
    */
   private transformProfileFile(srcPath: string): string {
-    const content = readFileSync(srcPath, "utf8");
+    const content = this.normalizeContent(readFileSync(srcPath, "utf8"));
     const fmMatch = content.match(/^(---\n[\s\S]+?\n---)(\n[\s\S]*)?$/);
     if (fmMatch === null) {
       throw new Error(`Source file ${srcPath} has no parseable frontmatter`);
@@ -254,7 +264,3 @@ export class SharedIdentitiesProfileMigrationService {
   }
 }
 
-/* eslint-disable @typescript-eslint/no-unused-vars */
-// Re-exported to silence "unused import" warnings when only types are used.
-const _types = { statSync };
-/* eslint-enable @typescript-eslint/no-unused-vars */

--- a/packages/cli/tests/unit/SharedIdentitiesProfileMigrationService.test.ts
+++ b/packages/cli/tests/unit/SharedIdentitiesProfileMigrationService.test.ts
@@ -184,6 +184,65 @@ describe("SharedIdentitiesProfileMigrationService", () => {
       expect(second.plan.summary.relocate).toBe(0);
     });
 
+    it("HIGH-fix: handles CRLF + BOM-prefixed FocusProfile files (defensive normalization)", () => {
+      const vaultPath = mkdtempSync(path.join(os.tmpdir(), "exo-crlf-"));
+      const sharedDir = path.join(vaultPath, "assetspaces", "shared-identities");
+      mkdirSync(sharedDir, { recursive: true });
+      const crlfContent = `﻿---\r\nexo__Asset_uid: aaaa1111-bbbb-2222-cccc-333344445555\r\nexo__Asset_label: profile-crlf\r\nexo__Instance_class:\r\n  - "[[${FOCUS_PROFILE_CLASS_UID}]]"\r\nexo__FocusProfile_includes:\r\n  - "[[ontology-test]]"\r\n---\r\n\r\n# profile-crlf\r\n`;
+      writeFileSync(
+        path.join(sharedDir, "aaaa1111-bbbb-2222-cccc-333344445555.md"),
+        crlfContent,
+      );
+
+      const svc = new SharedIdentitiesProfileMigrationService();
+      const plan = svc.generatePlan({ vaultPath });
+      expect(plan.summary.relocate).toBe(1);
+      const result = svc.apply({ vaultPath, apply: true });
+      expect(result.applied.length).toBe(1);
+      expect(result.errors.length).toBe(0);
+      const out = readFileSync(
+        path.join(vaultPath, "assetspaces/profiles", "aaaa1111-bbbb-2222-cccc-333344445555.md"),
+        "utf8",
+      );
+      expect(out).toContain(KNOWLEDGE_PROFILE_CLASS_UID);
+      expect(out).toContain("exo__KnowledgeProfile_includes:");
+      rmSync(vaultPath, { recursive: true, force: true });
+    });
+
+    it("idempotent при already-dual-class: no duplicate KnowledgeProfile UID", () => {
+      const vaultPath = mkdtempSync(path.join(os.tmpdir(), "exo-dual-"));
+      const sharedDir = path.join(vaultPath, "assetspaces", "shared-identities");
+      mkdirSync(sharedDir, { recursive: true });
+      writeFileSync(
+        path.join(sharedDir, "bbbb1111-2222-3333-4444-555566667777.md"),
+        `---
+exo__Asset_uid: bbbb1111-2222-3333-4444-555566667777
+exo__Asset_label: already-dual
+exo__Instance_class:
+  - "[[${KNOWLEDGE_PROFILE_CLASS_UID}]]"
+  - "[[${FOCUS_PROFILE_CLASS_UID}]]"
+exo__FocusProfile_includes:
+  - "[[ontology-x]]"
+exo__KnowledgeProfile_includes:
+  - "[[ontology-x]]"
+---
+
+# already-dual
+`,
+      );
+
+      const svc = new SharedIdentitiesProfileMigrationService();
+      svc.apply({ vaultPath, apply: true });
+      const out = readFileSync(
+        path.join(vaultPath, "assetspaces/profiles", "bbbb1111-2222-3333-4444-555566667777.md"),
+        "utf8",
+      );
+      const kpMatches = out.match(new RegExp(KNOWLEDGE_PROFILE_CLASS_UID, "g")) ?? [];
+      // 1 in Instance_class — should NOT add second.
+      expect(kpMatches.length).toBe(1);
+      rmSync(vaultPath, { recursive: true, force: true });
+    });
+
     it("dry-run does NOT mutate vault", () => {
       setup = makeSyntheticVault();
       const svc = new SharedIdentitiesProfileMigrationService();

--- a/packages/cli/tests/unit/SharedIdentitiesProfileMigrationService.test.ts
+++ b/packages/cli/tests/unit/SharedIdentitiesProfileMigrationService.test.ts
@@ -1,0 +1,200 @@
+/**
+ * @jest-environment node
+ *
+ * Unit tests для SharedIdentitiesProfileMigrationService.
+ * Synthetic 5-file vault scenarios per advisor incremental-test recommendation.
+ */
+import { mkdtempSync, writeFileSync, mkdirSync, readFileSync, existsSync, rmSync, readdirSync } from "node:fs";
+import * as path from "node:path";
+import * as os from "node:os";
+import {
+  SharedIdentitiesProfileMigrationService,
+  KNOWLEDGE_PROFILE_CLASS_UID,
+  FOCUS_PROFILE_CLASS_UID,
+} from "../../src/services/SharedIdentitiesProfileMigrationService";
+
+function makeSyntheticVault(): { vaultPath: string; cleanup: () => void } {
+  const vaultPath = mkdtempSync(path.join(os.tmpdir(), "exo-migrate-test-"));
+  const sharedDir = path.join(vaultPath, "assetspaces", "shared-identities");
+  mkdirSync(sharedDir, { recursive: true });
+
+  // 4 FocusProfile instances mirroring real vault structure.
+  writeFileSync(
+    path.join(sharedDir, "ae00f219-f50b-4fc1-b842-9ec1e03fefd6.md"),
+    `---
+exo__Asset_uid: ae00f219-f50b-4fc1-b842-9ec1e03fefd6
+exo__Asset_label: profile-base
+exo__Instance_class:
+  - "[[${FOCUS_PROFILE_CLASS_UID}]]"
+exo__FocusProfile_includes:
+  - "[[ontology-shared-identities]]"
+  - "[[ontology-exo]]"
+---
+
+# profile-base
+`,
+  );
+
+  writeFileSync(
+    path.join(sharedDir, "7e7be7a6-ca57-4aa8-a63a-69aaee32be25.md"),
+    `---
+exo__Asset_uid: 7e7be7a6-ca57-4aa8-a63a-69aaee32be25
+exo__Asset_label: profile-personal
+exo__Instance_class:
+  - "[[${FOCUS_PROFILE_CLASS_UID}]]"
+exo__FocusProfile_includes:
+  - "[[ontology-personal]]"
+exo__FocusProfile_extends: "[[ae00f219-f50b-4fc1-b842-9ec1e03fefd6]]"
+---
+
+# profile-personal
+`,
+  );
+
+  writeFileSync(
+    path.join(sharedDir, "42d500a3-f931-483e-a92e-cd4fae6cfb6e.md"),
+    `---
+exo__Asset_uid: 42d500a3-f931-483e-a92e-cd4fae6cfb6e
+exo__Asset_label: profile-work
+exo__Instance_class:
+  - "[[${FOCUS_PROFILE_CLASS_UID}]]"
+exo__FocusProfile_includes:
+  - "[[ontology-work]]"
+---
+
+# profile-work
+`,
+  );
+
+  writeFileSync(
+    path.join(sharedDir, "8169cc07-995a-400b-9267-1cce22654ef5.md"),
+    `---
+exo__Asset_uid: 8169cc07-995a-400b-9267-1cce22654ef5
+exo__Asset_label: profile-reading
+exo__Instance_class:
+  - "[[${FOCUS_PROFILE_CLASS_UID}]]"
+exo__FocusProfile_includes:
+  - "[[ontology-reading]]"
+---
+
+# profile-reading
+`,
+  );
+
+  // 1 non-FocusProfile file (ims__Concept "Audit") — should be SKIPPED.
+  writeFileSync(
+    path.join(sharedDir, "007d1731-105e-4f44-a1a0-51df96685c06.md"),
+    `---
+exo__Asset_uid: 007d1731-105e-4f44-a1a0-51df96685c06
+exo__Asset_label: Audit (Disambiguation)
+exo__Instance_class:
+  - "[[dda12c48-6886-4624-8710-ed4ba92ce2b3]]"
+  - "[[bf21727b-fce8-44ce-be2e-01afeb90f77c]]"
+---
+
+# Audit
+`,
+  );
+
+  return {
+    vaultPath,
+    cleanup: () => rmSync(vaultPath, { recursive: true, force: true }),
+  };
+}
+
+describe("SharedIdentitiesProfileMigrationService", () => {
+  let setup: ReturnType<typeof makeSyntheticVault>;
+
+  afterEach(() => {
+    setup?.cleanup();
+  });
+
+  describe("generatePlan (dry-run)", () => {
+    it("identifies 4 FocusProfile + 1 skip when vault has 5 files", () => {
+      setup = makeSyntheticVault();
+      const svc = new SharedIdentitiesProfileMigrationService();
+      const plan = svc.generatePlan({ vaultPath: setup.vaultPath });
+
+      expect(plan.summary.relocate).toBe(4);
+      expect(plan.summary.skipped).toBe(1);
+      expect(plan.summary.alreadyMigrated).toBe(0);
+
+      const relocations = plan.actions.filter((a) => a.kind === "relocate-and-dual-class");
+      expect(relocations.map((a) => a.uid).sort()).toEqual([
+        "42d500a3-f931-483e-a92e-cd4fae6cfb6e",
+        "7e7be7a6-ca57-4aa8-a63a-69aaee32be25",
+        "8169cc07-995a-400b-9267-1cce22654ef5",
+        "ae00f219-f50b-4fc1-b842-9ec1e03fefd6",
+      ]);
+    });
+
+    it("empty vault → empty plan", () => {
+      setup = { vaultPath: mkdtempSync(path.join(os.tmpdir(), "empty-")), cleanup: () => undefined };
+      const svc = new SharedIdentitiesProfileMigrationService();
+      const plan = svc.generatePlan({ vaultPath: setup.vaultPath });
+      expect(plan.actions.length).toBe(0);
+    });
+  });
+
+  describe("apply mode", () => {
+    it("relocates 4 FocusProfiles + adds dual-class transform", () => {
+      setup = makeSyntheticVault();
+      const svc = new SharedIdentitiesProfileMigrationService();
+      const result = svc.apply({ vaultPath: setup.vaultPath, apply: true });
+
+      expect(result.applied.length).toBe(4);
+      expect(result.errors.length).toBe(0);
+
+      // Verify each profile в new location + dual-class transformed.
+      const profilesDir = path.join(setup.vaultPath, "assetspaces/profiles");
+      const baseFile = path.join(profilesDir, "ae00f219-f50b-4fc1-b842-9ec1e03fefd6.md");
+      expect(existsSync(baseFile)).toBe(true);
+      const content = readFileSync(baseFile, "utf8");
+      // Dual class: KnowledgeProfile UID added к Instance_class.
+      expect(content).toContain(KNOWLEDGE_PROFILE_CLASS_UID);
+      expect(content).toContain(FOCUS_PROFILE_CLASS_UID);
+      // KnowledgeProfile_includes mirrors FocusProfile_includes.
+      expect(content).toContain("exo__KnowledgeProfile_includes:");
+      expect(content).toContain('"[[ontology-shared-identities]]"');
+      expect(content).toContain('"[[ontology-exo]]"');
+    });
+
+    it("non-FocusProfile files left in shared-identities", () => {
+      setup = makeSyntheticVault();
+      const svc = new SharedIdentitiesProfileMigrationService();
+      svc.apply({ vaultPath: setup.vaultPath, apply: true });
+
+      const sharedDir = path.join(setup.vaultPath, "assetspaces/shared-identities");
+      const remaining = readdirSync(sharedDir).filter((f) => f.endsWith(".md"));
+      // 1 non-FocusProfile file (Audit) remains.
+      expect(remaining).toContain("007d1731-105e-4f44-a1a0-51df96685c06.md");
+    });
+
+    it("idempotent — re-running после apply = no-op", () => {
+      setup = makeSyntheticVault();
+      const svc = new SharedIdentitiesProfileMigrationService();
+      const first = svc.apply({ vaultPath: setup.vaultPath, apply: true });
+      expect(first.applied.length).toBe(4);
+
+      const second = svc.apply({ vaultPath: setup.vaultPath, apply: true });
+      // No actions applied — source files moved-and-renamed-к-.migrated-backup,
+      // plan finds zero remaining .md FocusProfile sources.
+      expect(second.applied.length).toBe(0);
+      expect(second.errors.length).toBe(0);
+      expect(second.plan.summary.relocate).toBe(0);
+    });
+
+    it("dry-run does NOT mutate vault", () => {
+      setup = makeSyntheticVault();
+      const svc = new SharedIdentitiesProfileMigrationService();
+      const result = svc.apply({ vaultPath: setup.vaultPath, apply: false });
+
+      expect(result.applied.length).toBe(0);
+      // Original files still in shared-identities.
+      const sharedDir = path.join(setup.vaultPath, "assetspaces/shared-identities");
+      expect(existsSync(path.join(sharedDir, "ae00f219-f50b-4fc1-b842-9ec1e03fefd6.md"))).toBe(true);
+      // profiles/ dir not created.
+      expect(existsSync(path.join(setup.vaultPath, "assetspaces/profiles"))).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Per [RFC 13da049f Phase 6 v1.3](https://github.com/kitelev/vault-exodev/blob/main/inbox/13da049f-30e6-43d6-a07b-1848d24838f8.md) §Phase 6.5 + sibling onto-RFC [52f2acdd](https://github.com/kitelev/vault-exodev/blob/main/inbox/52f2acdd-b22d-4372-8f94-351ccca7d01c.md).

New CLI command: `exocortex migrate-shared-identities-profiles --vault <path> [--apply] [--json]`

## Behavior

Relocates `exo__FocusProfile` instances from `assetspaces/shared-identities/` → `assetspaces/profiles/` (new AS pointing к `kitelev/exoas-profiles`). For each profile: adds `exo__KnowledgeProfile` class membership + mirrors property values to dual-class semantic.

Other shared-identities content (1177 non-profile files on production vault) **untouched** — future migration phase.

## Properties mirrored

| FocusProfile property | KnowledgeProfile property |
|---|---|
| `FocusProfile_includes` | `KnowledgeProfile_includes` |
| `FocusProfile_extends` | `KnowledgeProfile_extends` |
| `FocusProfile_alwaysOnOverlay` | `KnowledgeProfile_alwaysOnOverlay` |

Source files renamed к `.migrated-backup` suffix on apply (no data loss; revertible).

## Verification

Tested against real-shape vault (`/Users/kitelev/vault-exodev/assetspaces/shared-identities/` shape = 1181 files):

**Dry-run:**
- 4 FocusProfile instances identified correctly (profile-base, profile-personal, profile-work, profile-reading)
- 1177 non-profile files skipped
- 0 false positives

**Apply (on disposable copy):**
- 4 relocations successful, 0 errors
- Dual-class transformation verified on profile-base — `exo__Instance_class` array contains both UIDs, `exo__KnowledgeProfile_alwaysOnOverlay` correctly mirrors 8-overlay list

## Tests

6/6 unit tests pass:
- generatePlan: identifies 4 FocusProfile + 1 skip in synthetic 5-file vault
- generatePlan: empty vault → empty plan
- apply: relocates + transforms correctly
- apply: non-FocusProfile left untouched
- apply: idempotent (re-run = no-op)
- apply: dry-run does NOT mutate

## Next steps for morning user

After plugin v16.53.0 (URL preservation) installed:

```
npx @kitelev/exocortex-cli migrate-shared-identities-profiles --vault /Users/kitelev/vault-2025
# Review dry-run output
npx @kitelev/exocortex-cli migrate-shared-identities-profiles --vault /Users/kitelev/vault-2025 --apply
# Then manual:
cd /Users/kitelev/vault-2025/assetspaces/profiles && git init + add к kitelev/exoas-profiles + push
cd /Users/kitelev/vault-2025 && git submodule add ... assetspaces/profiles
# Repeat для vault-exodev
```

## Test plan

- [x] Unit tests pass locally
- [x] Real vault dry-run verified (1181 files → 4 identified correctly)
- [x] Apply verified on disposable copy с dual-class transformation correct
- [ ] CI green (14 required checks)