### PR TITLE
fix(#3352): broader synthesis for label-form wikilinks via sibling FileSystemVaultAdapter scan

### DIFF
--- a/packages/cli/src/adapters/FileSystemVaultAdapter.ts
+++ b/packages/cli/src/adapters/FileSystemVaultAdapter.ts
@@ -7,6 +7,39 @@ import { rewriteInboundWikilinks } from "../utils/wikilinkRewriter.js";
 /** UUID v4 pattern for wikilink resolution */
 const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
+/**
+ * Options for `FileSystemVaultAdapter` (Issue #3352 — broader synthesis for
+ * label-form wikilinks targeting `--also` vaults).
+ *
+ * Both fields are optional; omitting them preserves the single-vault adapter
+ * behaviour used by the Obsidian plugin runtime and all pre-#3352 CLI
+ * callsites.
+ */
+export interface FileSystemVaultAdapterOptions {
+  /**
+   * Sibling adapters consulted by `getFirstLinkpathDest` when the primary
+   * lookup returns null. Used by the CLI to extend label-form wikilink
+   * resolution across `--also` vaults without plumbing multi-vault
+   * awareness into `NoteToRDFConverter`.
+   *
+   * The plugin runtime never sets this (single vault per app), so it has
+   * no behavioural effect there.
+   */
+  siblingAdapters?: FileSystemVaultAdapter[];
+  /**
+   * Subject IRI prefix for THIS adapter's vault (e.g. `assetspaces/areas`).
+   * When a sibling lookup hits this adapter, the resolved file path is
+   * prefixed with this segment so the returned `IFile.path` is the LOGICAL
+   * cross-vault path that primary `notePathToIRI` (with empty prefix) maps
+   * to the canonical sibling subject IRI.
+   *
+   * Mirrors `NoteToRDFConverter.subjectIriPrefix` (Issue #3219). Callers
+   * deriving the prefix via `deriveSubjectIriPrefix` should pass the same
+   * value to both the adapter and the converter.
+   */
+  subjectIriPrefix?: string;
+}
+
 export class FileSystemVaultAdapter implements IVaultAdapter {
   /** UUID (lowercase) → relative filepath mapping for O(1) lookups */
   private uuidIndex: Map<string, string> | null = null;
@@ -26,7 +59,39 @@ export class FileSystemVaultAdapter implements IVaultAdapter {
    */
   private aliasIndex: Map<string, string> | null = null;
 
-  constructor(private rootPath: string) {}
+  /**
+   * Sibling adapters (Issue #3352). When non-empty,
+   * `getFirstLinkpathDest` falls through to these adapters' indices after
+   * the primary basename / alias lookup misses. Always empty in the
+   * Obsidian plugin runtime (single vault per app).
+   */
+  private readonly siblingAdapters: FileSystemVaultAdapter[];
+
+  /**
+   * Subject IRI prefix for this adapter (Issue #3352 — broader synthesis).
+   * Returned via `getSubjectIriPrefix()` so a primary adapter can build
+   * logical cross-vault paths when one of its siblings resolves a
+   * wikilink. Empty by default.
+   */
+  private readonly subjectIriPrefix: string;
+
+  constructor(
+    private rootPath: string,
+    options: FileSystemVaultAdapterOptions = {},
+  ) {
+    this.siblingAdapters = options.siblingAdapters ?? [];
+    this.subjectIriPrefix = options.subjectIriPrefix ?? "";
+  }
+
+  /**
+   * Subject IRI prefix of this adapter's vault (Issue #3352). Used by a
+   * primary adapter to construct the logical cross-vault path returned
+   * from `getFirstLinkpathDest` when one of its siblings resolves the
+   * linkpath. Empty string when the adapter is rooted at a plain vault.
+   */
+  getSubjectIriPrefix(): string {
+    return this.subjectIriPrefix;
+  }
 
   async read(file: IFile): Promise<string> {
     const fullPath = this.resolvePath(file.path);
@@ -197,7 +262,61 @@ export class FileSystemVaultAdapter implements IVaultAdapter {
       return this.createFileObject(aliasMatch);
     }
 
+    // Step 5: cross-vault fallback (Issue #3352 — broader synthesis for
+    // label-form wikilinks targeting an `--also` vault). Only kicks in
+    // when this adapter has registered siblings; plugin runtime never
+    // sets them. Restricted to the Step-4 miss path: UUID linkpaths are
+    // intentionally NOT routed here because Step 2 / synthesis logic in
+    // `NoteToRDFConverter.synthesizeWikilinkTargetIRI` already covers
+    // UUID-form (Issue #3286 territory).
+    //
+    // Each sibling is consulted with an empty sourcePath so its own
+    // Step 1-4 lookup runs against its own root. The first sibling that
+    // resolves wins. The resulting IFile.path is wrapped with the
+    // sibling's `subjectIriPrefix` so the caller (primary
+    // NoteToRDFConverter with empty prefix) emits the canonical
+    // cross-vault subject IRI via `notePathToIRI`. A sibling without a
+    // prefix is skipped — its files would shadow primary paths and the
+    // dispatch routing in `read`/`getFrontmatter` (not implemented in
+    // this pass) cannot disambiguate.
+    for (const sibling of this.siblingAdapters) {
+      const siblingPrefix = sibling.getSubjectIriPrefix();
+      if (!siblingPrefix) {
+        continue;
+      }
+      const siblingResult = sibling.getFirstLinkpathDest(cleanLinkpath, "");
+      if (siblingResult) {
+        const logicalPath = `${siblingPrefix}/${siblingResult.path}`;
+        return this.createCrossVaultFileObject(logicalPath);
+      }
+    }
+
     return null;
+  }
+
+  /**
+   * Issue #3352 — build an `IFile` whose `path` is the logical
+   * cross-vault path (sibling prefix + sibling-relative path). Mirrors
+   * `createFileObject` but constructs `parent` from the logical path so
+   * `IFile.basename` / `IFile.name` match Obsidian TFile semantics. The
+   * resulting file is NOT readable through this adapter — callers must
+   * route `read` / `getFrontmatter` to the owning sibling adapter.
+   * `NoteToRDFConverter`'s label-form path only touches `basename` and
+   * `path` so this minimal wrapping is sufficient.
+   */
+  private createCrossVaultFileObject(logicalPath: string): IFile {
+    const name = path.basename(logicalPath);
+    const basename = path.basename(logicalPath, path.extname(logicalPath));
+    const parentPath = path.dirname(logicalPath);
+    return {
+      path: logicalPath,
+      basename,
+      name,
+      parent:
+        parentPath !== "."
+          ? { path: parentPath, name: path.basename(parentPath) }
+          : null,
+    };
   }
 
   /**

--- a/packages/cli/src/cache/buildCombinedTriples.ts
+++ b/packages/cli/src/cache/buildCombinedTriples.ts
@@ -82,12 +82,33 @@ export async function buildCombinedTriples(
     resolvedAlsos.push(r);
   }
 
+  // Issue #3352 — pre-build sibling adapters with their derived
+  // `subjectIriPrefix` before constructing the primary adapter. The
+  // primary adapter is then configured with these siblings so its
+  // `getFirstLinkpathDest` (Step 5) resolves label-form wikilinks whose
+  // target lives in an `--also` vault. Keeps the combined-cache path
+  // symmetric with the non-cached `sparql query --also` path.
+  const alsoAdapters: FileSystemVaultAdapter[] = [];
+  const alsoPrefixes: string[] = [];
+  for (const alsoPath of resolvedAlsos) {
+    // Issue #3219 — preserve `assetspaces/<sub>/` prefix on subject IRIs so
+    // cached cross-vault triples match the form that non-cached `--also`
+    // loads produce, keeping cache-hit and cache-miss queries consistent.
+    const subjectIriPrefix = deriveSubjectIriPrefix(alsoPath);
+    alsoAdapters.push(
+      new FileSystemVaultAdapter(alsoPath, { subjectIriPrefix }),
+    );
+    alsoPrefixes.push(subjectIriPrefix);
+  }
+
   // Load primary
   if (!silent) {
     log(`📦 Loading primary vault: ${primary}...`);
   }
   let triples: Triple[] = [];
-  const primaryAdapter = new FileSystemVaultAdapter(primary);
+  const primaryAdapter = new FileSystemVaultAdapter(primary, {
+    siblingAdapters: alsoAdapters,
+  });
   const primaryConverter = new NoteToRDFConverter(primaryAdapter);
   const primaryTriples = await primaryConverter.convertVault();
   triples = triples.concat(primaryTriples);
@@ -95,16 +116,14 @@ export async function buildCombinedTriples(
     log(`   ➕ Added ${primaryTriples.length} triples from primary vault`);
   }
 
-  // Load each --also vault
-  for (const alsoPath of resolvedAlsos) {
+  // Load each --also vault using the pre-built adapter.
+  for (let i = 0; i < alsoAdapters.length; i++) {
+    const alsoPath = resolvedAlsos[i];
+    const alsoAdapter = alsoAdapters[i];
+    const subjectIriPrefix = alsoPrefixes[i];
     if (!silent) {
       log(`📦 Loading additional vault: ${alsoPath}...`);
     }
-    // Issue #3219 — preserve `assetspaces/<sub>/` prefix on subject IRIs so
-    // cached cross-vault triples match the form that non-cached `--also`
-    // loads produce, keeping cache-hit and cache-miss queries consistent.
-    const subjectIriPrefix = deriveSubjectIriPrefix(alsoPath);
-    const alsoAdapter = new FileSystemVaultAdapter(alsoPath);
     const alsoConverter = new NoteToRDFConverter(alsoAdapter, undefined, {
       subjectIriPrefix,
     });

--- a/packages/cli/src/commands/sparql-query.ts
+++ b/packages/cli/src/commands/sparql-query.ts
@@ -468,8 +468,38 @@ export function sparqlQueryCommand(): Command {
         }
 
         if (!combinedCacheHit) {
+          // Issue #3352 — pre-build sibling adapters once so primary's
+          // `getFirstLinkpathDest` can resolve label-form wikilinks
+          // whose target lives in an additional vault. The same adapters
+          // are reused below when loading each additional vault, so the
+          // adapter that walked the vault is the same one consulted as a
+          // sibling.
+          const alsoAdapters: FileSystemVaultAdapter[] = [];
+          const alsoPaths: {
+            resolvedAlsoPath: string;
+            subjectIriPrefix: string;
+          }[] = [];
+          for (const alsoPath of alsoVaults) {
+            const resolvedAlsoPath = resolve(alsoPath);
+            if (!existsSync(resolvedAlsoPath)) {
+              throw new VaultNotFoundError(resolvedAlsoPath);
+            }
+            const subjectIriPrefix = deriveSubjectIriPrefix(resolvedAlsoPath);
+            alsoAdapters.push(
+              new FileSystemVaultAdapter(resolvedAlsoPath, {
+                subjectIriPrefix,
+              }),
+            );
+            alsoPaths.push({ resolvedAlsoPath, subjectIriPrefix });
+          }
+
           if (useCacheEffective) {
-            // Use cached triples for faster loading (primary vault only)
+            // Use cached triples for faster loading (primary vault only).
+            // Note (#3352): siblingAdapters cannot retro-fix wikilinks that
+            // were already serialised as bare Literals at cache build time.
+            // Users who need cross-vault label-form resolution on the cached
+            // path should rebuild the index via `sparql index --also` (which
+            // routes through `buildCombinedTriples`).
             const cacheManager = new CacheManager(vaultPath);
             const cacheResult = await cacheManager.loadOrBuild();
             triples = cacheResult.triples;
@@ -479,8 +509,11 @@ export function sparqlQueryCommand(): Command {
               console.log(`🚀 Cache hit! Loading from persistent cache...`);
             }
           } else {
-            // Traditional vault loading
-            const vaultAdapter = new FileSystemVaultAdapter(vaultPath);
+            // Traditional vault loading — primary adapter is configured
+            // with the pre-built sibling adapters.
+            const vaultAdapter = new FileSystemVaultAdapter(vaultPath, {
+              siblingAdapters: alsoAdapters,
+            });
             const converter = new NoteToRDFConverter(vaultAdapter);
             triples = await converter.convertVault(
               profileFilter !== null
@@ -492,24 +525,14 @@ export function sparqlQueryCommand(): Command {
             );
           }
 
-          // Load additional vaults if --also specified
-          for (const alsoPath of alsoVaults) {
-            const resolvedAlsoPath = resolve(alsoPath);
-            if (!existsSync(resolvedAlsoPath)) {
-              throw new VaultNotFoundError(resolvedAlsoPath);
-            }
+          // Load additional vaults if --also specified, using the
+          // pre-built adapters so primary's sibling list stays in sync.
+          for (let i = 0; i < alsoAdapters.length; i++) {
+            const alsoAdapter = alsoAdapters[i];
+            const { resolvedAlsoPath, subjectIriPrefix } = alsoPaths[i];
             if (outputFormat === "text") {
               console.log(`📦 Loading additional vault: ${resolvedAlsoPath}...`);
             }
-            // Issue #3219 — when `--also` points at an `<root>/assetspaces/<sub>`
-            // subdirectory, file.path is relative to that subdirectory and
-            // the synthesised subject IRI loses the path prefix. Derive a
-            // mount prefix from the path so subject IRIs match what they
-            // would be if the same files were loaded as part of a primary
-            // vault rooted at `<root>`. Non-assetspaces paths get an empty
-            // prefix (backward compatible).
-            const subjectIriPrefix = deriveSubjectIriPrefix(resolvedAlsoPath);
-            const alsoAdapter = new FileSystemVaultAdapter(resolvedAlsoPath);
             const alsoConverter = new NoteToRDFConverter(
               alsoAdapter,
               undefined,

--- a/packages/cli/tests/integration/issue-3352-broader-synthesis.integration.test.ts
+++ b/packages/cli/tests/integration/issue-3352-broader-synthesis.integration.test.ts
@@ -1,0 +1,229 @@
+/**
+ * Issue #3352 — broader synthesis for label-form wikilinks targeting an
+ * `--also` vault. Sub-task A of #3282.
+ *
+ * Scenario:
+ *   primaryVault/  — contains an asset whose frontmatter has a label-form
+ *     wikilink (`ems__Effort_area: "[[Барик (Area)]]"`). The target file
+ *     does NOT exist in this vault.
+ *
+ *   additionalRoot/assetspaces/areas/  — contains the target file, a
+ *     UID-named area asset with `aliases: ["Барик (Area)"]`. The user
+ *     loads this vault via `--also`.
+ *
+ * Pre-fix:
+ *   Primary's `FileSystemVaultAdapter.getFirstLinkpathDest` only scans its
+ *   own root. The label-form wikilink misses, falls through the
+ *   non-UUID synthesis branch in `NoteToRDFConverter`, and is emitted as
+ *   a bare Literal `"[[Барик (Area)]]"`. SPARQL queries on
+ *   `ems:Effort_area` see a Literal where they expect an IRI.
+ *
+ * Post-fix:
+ *   Primary adapter is constructed with `siblingAdapters` populated by
+ *   the sparql-query.ts `--also` plumbing. Step 5 of
+ *   `getFirstLinkpathDest` iterates the siblings, finds the alias match
+ *   in the additional vault, and returns an `IFile` whose `path` is the
+ *   logical cross-vault path (`assetspaces/areas/<area-uid>.md`).
+ *   `NoteToRDFConverter` emits the canonical IRI
+ *   `obsidian://vault/assetspaces/areas/<area-uid>.md`.
+ *
+ * Empirical revert-verify discipline: this test FAILS pre-fix and PASSES
+ * post-fix (see `~/dotfiles/.claude/rules/integration-test-revert-verify.md`).
+ */
+import { describe, it, expect, beforeAll, afterAll } from "@jest/globals";
+import * as fs from "fs";
+import * as path from "path";
+import * as os from "os";
+
+const { NoteToRDFConverter, IRI, Literal } = await import("exocortex");
+const { FileSystemVaultAdapter } = await import(
+  "../../src/adapters/FileSystemVaultAdapter.js"
+);
+const { deriveSubjectIriPrefix } = await import(
+  "../../src/utils/AlsoVaultMountPrefix.js"
+);
+
+const AREA_UID = "e266a2e9-9eb0-431d-b1fe-b95b9d3e9a3f";
+const TASK_UID = "9a3f0b5e-1234-4abc-9def-fedcba987654";
+const TASK_CLASS_UID = "1b20a8f0-d745-4e93-91db-4531b3df120e";
+const AREA_CLASS_UID = "9b88b0d9-1234-4abc-9def-cafebabe0001";
+const AREA_LABEL = "Барик (Area)";
+
+let tmpRoot: string;
+let primaryVault: string;
+let additionalRoot: string;
+let additionalAreasSubdir: string;
+
+beforeAll(() => {
+  tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "exo-3352-"));
+  primaryVault = path.join(tmpRoot, "primary");
+  additionalRoot = path.join(tmpRoot, "additional");
+  additionalAreasSubdir = path.join(additionalRoot, "assetspaces", "areas");
+
+  fs.mkdirSync(primaryVault, { recursive: true });
+  fs.mkdirSync(additionalAreasSubdir, { recursive: true });
+
+  // Primary vault: task asset that wikilinks the label-form area target.
+  // The target file does NOT exist in this vault.
+  // `exo__Instance_class` is required by `NoteToRDFConverter.validateExocortexAsset`;
+  // pointing it at a UID-form wikilink (not declared cross-vault) keeps the
+  // shape valid without polluting the test's wikilink-resolution surface.
+  fs.writeFileSync(
+    path.join(primaryVault, `${TASK_UID}.md`),
+    `---
+exo__Asset_uid: ${TASK_UID}
+exo__Asset_label: Test Task
+exo__Instance_class: "[[${TASK_CLASS_UID}]]"
+ems__Effort_area: "[[${AREA_LABEL}]]"
+---
+Task body.
+`,
+  );
+
+  // Additional vault: area asset, UID-named, with the label as an alias.
+  fs.writeFileSync(
+    path.join(additionalAreasSubdir, `${AREA_UID}.md`),
+    `---
+exo__Asset_uid: ${AREA_UID}
+exo__Asset_label: ${AREA_LABEL}
+exo__Instance_class: "[[${AREA_CLASS_UID}]]"
+aliases:
+  - ${AREA_LABEL}
+---
+Area body.
+`,
+  );
+});
+
+afterAll(() => {
+  fs.rmSync(tmpRoot, { recursive: true, force: true });
+});
+
+describe("Issue #3352: broader synthesis for label-form wikilinks in --also vault", () => {
+  describe("FileSystemVaultAdapter Step 5 sibling fallback", () => {
+    it("resolves alias-match in a sibling adapter and returns the logical cross-vault path", () => {
+      const subjectIriPrefix = deriveSubjectIriPrefix(additionalAreasSubdir);
+      expect(subjectIriPrefix).toBe("assetspaces/areas");
+
+      const siblingAdapter = new FileSystemVaultAdapter(
+        additionalAreasSubdir,
+        { subjectIriPrefix },
+      );
+      const primaryAdapter = new FileSystemVaultAdapter(primaryVault, {
+        siblingAdapters: [siblingAdapter],
+      });
+
+      const resolved = primaryAdapter.getFirstLinkpathDest(
+        AREA_LABEL,
+        `${TASK_UID}.md`,
+      );
+
+      expect(resolved).not.toBeNull();
+      expect(resolved!.path).toBe(`assetspaces/areas/${AREA_UID}.md`);
+      expect(resolved!.basename).toBe(AREA_UID);
+    });
+
+    it("returns null when sibling list is empty (regression guard for single-vault behaviour)", () => {
+      const primaryAdapter = new FileSystemVaultAdapter(primaryVault);
+      const resolved = primaryAdapter.getFirstLinkpathDest(
+        AREA_LABEL,
+        `${TASK_UID}.md`,
+      );
+      expect(resolved).toBeNull();
+    });
+
+    it("skips siblings without a subjectIriPrefix (cannot disambiguate paths)", () => {
+      // Sibling with empty prefix — Step 5 should silently skip it so the
+      // sibling's files don't leak into primary's namespace.
+      const siblingNoPrefix = new FileSystemVaultAdapter(additionalAreasSubdir);
+      const primaryAdapter = new FileSystemVaultAdapter(primaryVault, {
+        siblingAdapters: [siblingNoPrefix],
+      });
+      const resolved = primaryAdapter.getFirstLinkpathDest(
+        AREA_LABEL,
+        `${TASK_UID}.md`,
+      );
+      expect(resolved).toBeNull();
+    });
+  });
+
+  describe("End-to-end: cross-vault label-form wikilink emits IRI, not Literal", () => {
+    it("primary converter (with sibling adapter) emits canonical cross-vault IRI for the area reference", async () => {
+      const subjectIriPrefix = deriveSubjectIriPrefix(additionalAreasSubdir);
+      const siblingAdapter = new FileSystemVaultAdapter(
+        additionalAreasSubdir,
+        { subjectIriPrefix },
+      );
+      const primaryAdapter = new FileSystemVaultAdapter(primaryVault, {
+        siblingAdapters: [siblingAdapter],
+      });
+      const primaryConverter = new NoteToRDFConverter(primaryAdapter);
+      const triples = await primaryConverter.convertVault();
+
+      const expectedAreaIRI = `obsidian://vault/assetspaces/areas/${AREA_UID}.md`;
+      const taskSubjectIRI = `obsidian://vault/${TASK_UID}.md`;
+      const areaPredicateIRI =
+        "https://exocortex.my/ontology/ems#Effort_area";
+
+      let foundAreaIRITriple = false;
+      let foundAreaLiteralTriple = false;
+      for (const t of triples as Array<{
+        subject: IRI;
+        predicate: IRI;
+        object: IRI | Literal;
+      }>) {
+        if (
+          !(t.subject instanceof IRI) ||
+          t.subject.value !== taskSubjectIRI ||
+          !(t.predicate instanceof IRI) ||
+          t.predicate.value !== areaPredicateIRI
+        ) {
+          continue;
+        }
+        if (t.object instanceof IRI && t.object.value === expectedAreaIRI) {
+          foundAreaIRITriple = true;
+        }
+        if (
+          t.object instanceof Literal &&
+          t.object.value.includes(AREA_LABEL)
+        ) {
+          foundAreaLiteralTriple = true;
+        }
+      }
+
+      // Post-fix: IRI triple present, bare-Literal triple absent.
+      expect(foundAreaIRITriple).toBe(true);
+      expect(foundAreaLiteralTriple).toBe(false);
+    });
+
+    it("without siblings, primary emits bare Literal for the same label-form wikilink (single-vault regression guard)", async () => {
+      const primaryAdapter = new FileSystemVaultAdapter(primaryVault);
+      const primaryConverter = new NoteToRDFConverter(primaryAdapter);
+      const triples = await primaryConverter.convertVault();
+
+      const taskSubjectIRI = `obsidian://vault/${TASK_UID}.md`;
+      const areaPredicateIRI =
+        "https://exocortex.my/ontology/ems#Effort_area";
+
+      let foundLiteral = false;
+      for (const t of triples as Array<{
+        subject: IRI;
+        predicate: IRI;
+        object: IRI | Literal;
+      }>) {
+        if (
+          t.subject instanceof IRI &&
+          t.subject.value === taskSubjectIRI &&
+          t.predicate instanceof IRI &&
+          t.predicate.value === areaPredicateIRI &&
+          t.object instanceof Literal &&
+          t.object.value.includes(AREA_LABEL)
+        ) {
+          foundLiteral = true;
+          break;
+        }
+      }
+      expect(foundLiteral).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
Closes #3352
Sub-task A of #3282

## Summary

When `exocortex-cli sparql query --vault X --also Y` encounters a label-form wikilink in vault X whose target lives only in vault Y, the wikilink previously degraded to a bare Literal `"[[<label>]]"` because `FileSystemVaultAdapter.getFirstLinkpathDest` only scanned its own root. This shipped fix routes label-form (non-UUID) wikilinks through optional sibling adapters when the primary lookup misses, emitting the canonical cross-vault subject IRI instead.

## Approach (b) per issue body

Plumbing multi-vault awareness into `FileSystemVaultAdapter`, NOT into `NoteToRDFConverter`. Follows the per-vault orchestration shape from `CombinedCacheManager` (#3281), but consults siblings directly rather than through the cache layer. Preserves the plugin's single-vault assumption (plugin never sets `siblingAdapters` → no behavioural change in Obsidian runtime, verified by grep against plugin source).

## What changed

- `FileSystemVaultAdapter` — new optional constructor options:
  - `siblingAdapters?: FileSystemVaultAdapter[]` — consulted by `getFirstLinkpathDest` Step 5 (added) when primary Steps 1-4 all miss.
  - `subjectIriPrefix?: string` — used so a primary adapter can wrap a sibling's resolved file path into a LOGICAL cross-vault path (`<sibling.subjectIriPrefix>/<sibling-rel>`); primary `NoteToRDFConverter.notePathToIRI` (empty prefix) then emits the canonical sibling IRI.
- `sparql-query.ts` non-cached `--also` path — pre-builds sibling adapters once, wires primary adapter with siblings. Cached path documented inline (already-serialised cache cannot be retro-fixed; users rebuild via `sparql index --also`).
- `buildCombinedTriples.ts` (cache-build path) — same wiring, keeps cached/non-cached query paths symmetric.
- New integration test `issue-3352-broader-synthesis.integration.test.ts` — 5 tests covering Step 5 mechanics + end-to-end fixture-vault-pair scenario + regression guards.

## Empirical revert-verify

Per `~/dotfiles/.claude/rules/integration-test-revert-verify.md`:

- Pre-fix (Step 5 loop body commented out): **2/5 FAIL** (the two that exercise Step 5 sibling iteration: `resolves alias-match in a sibling adapter` and `primary converter (with sibling adapter) emits canonical cross-vault IRI`).
- Post-fix restored: **5/5 PASS**.
- Adjacent suites (`FileSystemVaultAdapter`, `issue-3219`, `sparql-query.*`): 7 suites, 93 passed, 9 skipped, **0 failures** — no regression.
- Build clean.

## Known limitations (intentional scope-outs)

1. **Cross-vault `read` / `getFrontmatter` dispatch NOT implemented.** The label-form path in `NoteToRDFConverter` only touches `targetFile.path` + `targetFile.basename` for the typical case (sibling target is UID-named → `expandClassValue(basename)` returns null → `return [fileIRI]`, no frontmatter read). Edge case: sibling-found file's basename is class-prefixed (e.g. `ems__EffortStatusDone.md`) → `emitTypeTripleForEnumInstance` calls `getFrontmatter` which silently returns null in primary's root → type-triple skipped, but `basenameClassIRI` still emitted (correct IRI, only minor info loss).
2. **UUID-form wikilinks NOT routed through siblings** — `synthesizeWikilinkTargetIRI` already handles them (#3286 territory).
3. **Cached primary path** (`useCacheEffective=true` && `!combinedCacheHit`) does NOT retro-fix wikilinks already serialised as bare Literals at cache build time. Users running `sparql query --use-cache --vault X --also Y` without a prior `sparql index --also` invocation will see bare Literals — they need to rebuild the index first. Documented inline; matters at discovery time.
4. **Siblings with empty `subjectIriPrefix`** silently skipped (cannot disambiguate cross-vault from primary tree without a prefix). Tested.

## Out of scope (follow-up)

`packages/cli/src/commands/find.ts:178,187` exhibits the same bug shape for `find --also`. Issue body explicitly scopes #3352 to sparql paths; tracking issue to be filed post-merge.

## Test plan

- [x] Existing CLI tests pass (single-vault regression check — 93/102 across adjacent suites)
- [x] Plugin runtime unchanged (constructor options optional, plugin never sets siblings)
- [x] Integration test reproduces #3282 issue body reproducer empirically (label-form wikilink to sibling vault target → IRI not Literal)
- [x] Revert-verify discipline applied: 2/5 FAIL pre-fix, 5/5 PASS post-fix
- [x] Build clean
- [x] code-reviewer agent APPROVE (0 CRITICAL / 0 HIGH / 1 MEDIUM out-of-scope follow-up / 2 LOW notes)
- [x] advisor round-2 sign-off

🤖 Spawned via /spawn-issue-standalone v3