### PR TITLE
feat(rdf): env-flag-gated dual-storage emission for additional predicates (#3353)

### DIFF
--- a/packages/exocortex/src/services/NoteToRDFConverter.ts
+++ b/packages/exocortex/src/services/NoteToRDFConverter.ts
@@ -1304,10 +1304,26 @@ export class NoteToRDFConverter {
             // Fix #ff3858e5: dual-storage (IRI + UUID Literal) is scoped to
             // exo__Asset_prototype only. All other predicates emit a single IRI
             // to avoid sh:maxCount=1 cardinality violations.
+            //
+            // Issue #3353 (Sub-task B of #3282): opt-in env-flag escape hatch
+            // extends dual-storage to additional predicates listed in
+            // `EXOCORTEX_DUAL_STORAGE_PREDICATES` (comma-separated local names,
+            // e.g. `Effort_area,Effort_parent`). Default unset → no behavior
+            // change. Trim+filter handles whitespace and avoids matching empty
+            // string ("".endsWith("#") === false anyway, but skip the work).
             const isProtoPredicate =
               predicate?.value.endsWith("#Asset_prototype") ||
               predicate?.value.endsWith("/Asset_prototype");
-            if (isProtoPredicate) {
+            const dualPredicates = (
+              process.env.EXOCORTEX_DUAL_STORAGE_PREDICATES ?? ""
+            )
+              .split(",")
+              .map((p) => p.trim())
+              .filter(Boolean);
+            const isDualPredicate =
+              dualPredicates.length > 0 &&
+              dualPredicates.some((p) => predicate?.value.endsWith(`#${p}`));
+            if (isProtoPredicate || isDualPredicate) {
               return [fileIRI, uuidLiteral];
             }
             return [fileIRI];

--- a/packages/exocortex/src/services/NoteToRDFConverter.ts
+++ b/packages/exocortex/src/services/NoteToRDFConverter.ts
@@ -1309,8 +1309,8 @@ export class NoteToRDFConverter {
             // extends dual-storage to additional predicates listed in
             // `EXOCORTEX_DUAL_STORAGE_PREDICATES` (comma-separated local names,
             // e.g. `Effort_area,Effort_parent`). Default unset → no behavior
-            // change. Trim+filter handles whitespace and avoids matching empty
-            // string ("".endsWith("#") === false anyway, but skip the work).
+            // change. `.filter(Boolean)` strips empty/whitespace entries so a
+            // stray "," or empty env value never produces a match.
             const isProtoPredicate =
               predicate?.value.endsWith("#Asset_prototype") ||
               predicate?.value.endsWith("/Asset_prototype");

--- a/packages/exocortex/tests/unit/services/NoteToRDFConverter.dual-storage-flag.test.ts
+++ b/packages/exocortex/tests/unit/services/NoteToRDFConverter.dual-storage-flag.test.ts
@@ -1,0 +1,333 @@
+import "reflect-metadata";
+import { NoteToRDFConverter } from "../../../src/services/NoteToRDFConverter";
+import { IVaultAdapter, IFile, IFrontmatter } from "../../../src/interfaces/IVaultAdapter";
+import { IRI } from "../../../src/domain/models/rdf/IRI";
+import { Literal } from "../../../src/domain/models/rdf/Literal";
+
+/**
+ * Issue #3353 (Sub-task B of #3282): env-flag-gated dual-storage emission
+ * extension. `EXOCORTEX_DUAL_STORAGE_PREDICATES=Effort_area,Effort_parent`
+ * enables (file IRI + UUID Literal) emission for the listed predicates;
+ * default unset preserves single-IRI behavior (Fix #ff3858e5 contract).
+ *
+ * Empirical revert-verify discipline (per
+ * ~/dotfiles/.claude/rules/integration-test-revert-verify.md):
+ * - "default off" must FAIL if dual emission shipped unconditionally
+ * - "flag on" must FAIL if env check is removed
+ * - "prototype dual preserved" must PASS in both states (regression guard)
+ */
+describe("NoteToRDFConverter dual-storage env-flag (Issue #3353)", () => {
+  let converter: NoteToRDFConverter;
+  let mockVault: jest.Mocked<IVaultAdapter>;
+  let originalEnv: string | undefined;
+
+  const sourceUUID = "11111111-1111-1111-1111-111111111111";
+  const areaUUID = "22222222-2222-2222-2222-222222222222";
+  const parentUUID = "33333333-3333-3333-3333-333333333333";
+  const protoUUID = "44444444-4444-4444-4444-444444444444";
+
+  const sourceFile: IFile = {
+    path: `03 Knowledge/kitelev/${sourceUUID}.md`,
+    basename: sourceUUID,
+    name: `${sourceUUID}.md`,
+    parent: null,
+  };
+  const areaFile: IFile = {
+    path: `03 Knowledge/ems/${areaUUID}.md`,
+    basename: areaUUID,
+    name: `${areaUUID}.md`,
+    parent: null,
+  };
+  const parentFile: IFile = {
+    path: `03 Knowledge/ems/${parentUUID}.md`,
+    basename: parentUUID,
+    name: `${parentUUID}.md`,
+    parent: null,
+  };
+  const protoFile: IFile = {
+    path: `03 Knowledge/ems/${protoUUID}.md`,
+    basename: protoUUID,
+    name: `${protoUUID}.md`,
+    parent: null,
+  };
+
+  beforeEach(() => {
+    originalEnv = process.env.EXOCORTEX_DUAL_STORAGE_PREDICATES;
+    delete process.env.EXOCORTEX_DUAL_STORAGE_PREDICATES;
+
+    mockVault = {
+      getFrontmatter: jest.fn(),
+      getAllFiles: jest.fn(),
+      read: jest.fn(),
+      create: jest.fn(),
+      modify: jest.fn(),
+      delete: jest.fn(),
+      exists: jest.fn(),
+      getAbstractFileByPath: jest.fn(),
+      updateFrontmatter: jest.fn(),
+      rename: jest.fn(),
+      createFolder: jest.fn(),
+      getFirstLinkpathDest: jest.fn(),
+      process: jest.fn(),
+      updateLinks: jest.fn(),
+      getDefaultNewFileParent: jest.fn(),
+    } as jest.Mocked<IVaultAdapter>;
+
+    converter = new NoteToRDFConverter(mockVault);
+  });
+
+  afterEach(() => {
+    if (originalEnv === undefined) {
+      delete process.env.EXOCORTEX_DUAL_STORAGE_PREDICATES;
+    } else {
+      process.env.EXOCORTEX_DUAL_STORAGE_PREDICATES = originalEnv;
+    }
+  });
+
+  it("default (env unset): ems__Effort_area emits single IRI only", async () => {
+    mockVault.getFrontmatter.mockImplementation((f: IFile) => {
+      if (f.path === sourceFile.path) {
+        return { ems__Effort_area: `[[${areaUUID}]]` } as IFrontmatter;
+      }
+      if (f.path === areaFile.path) {
+        return { exo__Asset_label: "Some Area" } as IFrontmatter;
+      }
+      return null;
+    });
+    mockVault.getFirstLinkpathDest.mockImplementation((linkpath: string) => {
+      if (linkpath === areaUUID) return areaFile;
+      return null;
+    });
+    mockVault.read.mockResolvedValue("");
+
+    const triples = await converter.convertNote(sourceFile);
+    const areaTriples = triples.filter((t) =>
+      (t.predicate as IRI).value.endsWith("#Effort_area"),
+    );
+
+    expect(areaTriples).toHaveLength(1);
+    expect(areaTriples[0].object).toBeInstanceOf(IRI);
+  });
+
+  it("default (env unset): ems__Effort_parent emits single IRI only", async () => {
+    mockVault.getFrontmatter.mockImplementation((f: IFile) => {
+      if (f.path === sourceFile.path) {
+        return { ems__Effort_parent: `[[${parentUUID}]]` } as IFrontmatter;
+      }
+      if (f.path === parentFile.path) {
+        return { exo__Asset_label: "Parent Task" } as IFrontmatter;
+      }
+      return null;
+    });
+    mockVault.getFirstLinkpathDest.mockImplementation((linkpath: string) => {
+      if (linkpath === parentUUID) return parentFile;
+      return null;
+    });
+    mockVault.read.mockResolvedValue("");
+
+    const triples = await converter.convertNote(sourceFile);
+    const parentTriples = triples.filter((t) =>
+      (t.predicate as IRI).value.endsWith("#Effort_parent"),
+    );
+
+    expect(parentTriples).toHaveLength(1);
+    expect(parentTriples[0].object).toBeInstanceOf(IRI);
+  });
+
+  it("flag set: ems__Effort_area emits BOTH IRI and UUID Literal", async () => {
+    process.env.EXOCORTEX_DUAL_STORAGE_PREDICATES = "Effort_area,Effort_parent";
+
+    mockVault.getFrontmatter.mockImplementation((f: IFile) => {
+      if (f.path === sourceFile.path) {
+        return { ems__Effort_area: `[[${areaUUID}]]` } as IFrontmatter;
+      }
+      if (f.path === areaFile.path) {
+        return { exo__Asset_label: "Some Area" } as IFrontmatter;
+      }
+      return null;
+    });
+    mockVault.getFirstLinkpathDest.mockImplementation((linkpath: string) => {
+      if (linkpath === areaUUID) return areaFile;
+      return null;
+    });
+    mockVault.read.mockResolvedValue("");
+
+    const triples = await converter.convertNote(sourceFile);
+    const areaTriples = triples.filter((t) =>
+      (t.predicate as IRI).value.endsWith("#Effort_area"),
+    );
+
+    expect(areaTriples).toHaveLength(2);
+    expect(areaTriples.some((t) => t.object instanceof IRI)).toBe(true);
+    const literalTriple = areaTriples.find((t) => t.object instanceof Literal);
+    expect(literalTriple).toBeDefined();
+    expect((literalTriple!.object as Literal).value).toBe(areaUUID);
+  });
+
+  it("flag set: ems__Effort_parent emits BOTH IRI and UUID Literal", async () => {
+    process.env.EXOCORTEX_DUAL_STORAGE_PREDICATES = "Effort_area,Effort_parent";
+
+    mockVault.getFrontmatter.mockImplementation((f: IFile) => {
+      if (f.path === sourceFile.path) {
+        return { ems__Effort_parent: `[[${parentUUID}]]` } as IFrontmatter;
+      }
+      if (f.path === parentFile.path) {
+        return { exo__Asset_label: "Parent" } as IFrontmatter;
+      }
+      return null;
+    });
+    mockVault.getFirstLinkpathDest.mockImplementation((linkpath: string) => {
+      if (linkpath === parentUUID) return parentFile;
+      return null;
+    });
+    mockVault.read.mockResolvedValue("");
+
+    const triples = await converter.convertNote(sourceFile);
+    const parentTriples = triples.filter((t) =>
+      (t.predicate as IRI).value.endsWith("#Effort_parent"),
+    );
+
+    expect(parentTriples).toHaveLength(2);
+    const literalTriple = parentTriples.find((t) => t.object instanceof Literal);
+    expect(literalTriple).toBeDefined();
+    expect((literalTriple!.object as Literal).value).toBe(parentUUID);
+  });
+
+  it("flag set with whitespace: 'Effort_area, Effort_parent' (comma+space) trims correctly", async () => {
+    process.env.EXOCORTEX_DUAL_STORAGE_PREDICATES = "Effort_area, Effort_parent";
+
+    mockVault.getFrontmatter.mockImplementation((f: IFile) => {
+      if (f.path === sourceFile.path) {
+        return { ems__Effort_area: `[[${areaUUID}]]` } as IFrontmatter;
+      }
+      if (f.path === areaFile.path) {
+        return { exo__Asset_label: "Area" } as IFrontmatter;
+      }
+      return null;
+    });
+    mockVault.getFirstLinkpathDest.mockImplementation((linkpath: string) => {
+      if (linkpath === areaUUID) return areaFile;
+      return null;
+    });
+    mockVault.read.mockResolvedValue("");
+
+    const triples = await converter.convertNote(sourceFile);
+    const areaTriples = triples.filter((t) =>
+      (t.predicate as IRI).value.endsWith("#Effort_area"),
+    );
+
+    expect(areaTriples).toHaveLength(2);
+  });
+
+  it("flag set selectively: only listed predicates get dual storage", async () => {
+    // Only Effort_area in flag — Effort_parent should remain single IRI.
+    process.env.EXOCORTEX_DUAL_STORAGE_PREDICATES = "Effort_area";
+
+    mockVault.getFrontmatter.mockImplementation((f: IFile) => {
+      if (f.path === sourceFile.path) {
+        return {
+          ems__Effort_area: `[[${areaUUID}]]`,
+          ems__Effort_parent: `[[${parentUUID}]]`,
+        } as IFrontmatter;
+      }
+      if (f.path === areaFile.path) return { exo__Asset_label: "Area" } as IFrontmatter;
+      if (f.path === parentFile.path) return { exo__Asset_label: "Parent" } as IFrontmatter;
+      return null;
+    });
+    mockVault.getFirstLinkpathDest.mockImplementation((linkpath: string) => {
+      if (linkpath === areaUUID) return areaFile;
+      if (linkpath === parentUUID) return parentFile;
+      return null;
+    });
+    mockVault.read.mockResolvedValue("");
+
+    const triples = await converter.convertNote(sourceFile);
+    const areaTriples = triples.filter((t) =>
+      (t.predicate as IRI).value.endsWith("#Effort_area"),
+    );
+    const parentTriples = triples.filter((t) =>
+      (t.predicate as IRI).value.endsWith("#Effort_parent"),
+    );
+
+    expect(areaTriples).toHaveLength(2);
+    expect(parentTriples).toHaveLength(1);
+  });
+
+  it("regression: exo__Asset_prototype dual storage preserved regardless of flag", async () => {
+    // env unset (default) — prototype must still emit IRI + Literal (Issue #2102 / #ff3858e5)
+    mockVault.getFrontmatter.mockImplementation((f: IFile) => {
+      if (f.path === sourceFile.path) {
+        return { exo__Asset_prototype: `[[${protoUUID}]]` } as IFrontmatter;
+      }
+      if (f.path === protoFile.path) {
+        return { exo__Asset_label: "Some template" } as IFrontmatter;
+      }
+      return null;
+    });
+    mockVault.getFirstLinkpathDest.mockImplementation((linkpath: string) => {
+      if (linkpath === protoUUID) return protoFile;
+      return null;
+    });
+    mockVault.read.mockResolvedValue("");
+
+    const triples = await converter.convertNote(sourceFile);
+    const protoTriples = triples.filter((t) =>
+      (t.predicate as IRI).value.endsWith("Asset_prototype"),
+    );
+
+    expect(protoTriples).toHaveLength(2);
+    expect(protoTriples.some((t) => t.object instanceof IRI)).toBe(true);
+    expect(protoTriples.some((t) => t.object instanceof Literal)).toBe(true);
+  });
+
+  it("regression: exo__Asset_prototype dual storage preserved WHEN flag set for other predicates", async () => {
+    // Prototype dual emission must not be affected by env-flag presence.
+    process.env.EXOCORTEX_DUAL_STORAGE_PREDICATES = "Effort_area,Effort_parent";
+
+    mockVault.getFrontmatter.mockImplementation((f: IFile) => {
+      if (f.path === sourceFile.path) {
+        return { exo__Asset_prototype: `[[${protoUUID}]]` } as IFrontmatter;
+      }
+      if (f.path === protoFile.path) {
+        return { exo__Asset_label: "Some template" } as IFrontmatter;
+      }
+      return null;
+    });
+    mockVault.getFirstLinkpathDest.mockImplementation((linkpath: string) => {
+      if (linkpath === protoUUID) return protoFile;
+      return null;
+    });
+    mockVault.read.mockResolvedValue("");
+
+    const triples = await converter.convertNote(sourceFile);
+    const protoTriples = triples.filter((t) =>
+      (t.predicate as IRI).value.endsWith("Asset_prototype"),
+    );
+
+    expect(protoTriples).toHaveLength(2);
+  });
+
+  it("empty/whitespace flag value behaves as unset (single IRI for Effort_area)", async () => {
+    process.env.EXOCORTEX_DUAL_STORAGE_PREDICATES = "  ,  ,";
+
+    mockVault.getFrontmatter.mockImplementation((f: IFile) => {
+      if (f.path === sourceFile.path) {
+        return { ems__Effort_area: `[[${areaUUID}]]` } as IFrontmatter;
+      }
+      if (f.path === areaFile.path) return { exo__Asset_label: "Area" } as IFrontmatter;
+      return null;
+    });
+    mockVault.getFirstLinkpathDest.mockImplementation((linkpath: string) => {
+      if (linkpath === areaUUID) return areaFile;
+      return null;
+    });
+    mockVault.read.mockResolvedValue("");
+
+    const triples = await converter.convertNote(sourceFile);
+    const areaTriples = triples.filter((t) =>
+      (t.predicate as IRI).value.endsWith("#Effort_area"),
+    );
+
+    expect(areaTriples).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
Closes #3353. Sub-task B of #3282.

## Summary

Adds opt-in `EXOCORTEX_DUAL_STORAGE_PREDICATES` env flag that extends dual-storage (file IRI + UUID Literal) emission to additional predicates beyond `exo__Asset_prototype`. Default unset preserves Fix #ff3858e5 single-IRI contract — no behavior change without explicit opt-in.

**Implementation:** `packages/exocortex/src/services/NoteToRDFConverter.ts:1304-1329` extends existing `isProtoPredicate` gate with `isDualPredicate` env check. Inline read mirrors `BGPExecutor`'s `EXOCORTEX_SPARQL_STRICT` pattern. Robust env parsing via `.split(",").map(trim).filter(Boolean)`.

## Case sensitivity (Issue body typo callout)

Issue body AC uses lowercase `EXOCORTEX_DUAL_STORAGE_PREDICATES=effort_area,effort_parent`, but predicate IRIs end with capitalized `#Effort_area`. Flag values are **case-sensitive** and must match IRI local-name suffix exactly. Correct: `EXOCORTEX_DUAL_STORAGE_PREDICATES=Effort_area,Effort_parent`.

## SHACL safety analysis (vault-2025 empirical run)

| Metric                            | Baseline (flag unset) | Flag on (`Effort_area,Effort_parent`) | Δ   |
|-----------------------------------|----------------------:|--------------------------------------:|----:|
| TOTAL violations                  |                   324 |                                   324 |   0 |
| `Effort_area` violations          |                     0 |                                     0 |   0 |
| `Effort_parent` violations        |                    91 |                                    91 |   0 |
| New `maxCount`/cardinality issues |                     – |                                     0 |   0 |

`diff` of filtered violation entries (Effort_area + Effort_parent) was **byte-identical** between baseline and flag-on runs. Pre-existing 91 `Effort_parent` violations are all `sh:class` (cross-vault target resolution, unrelated to this change).

**Caveat (per code-reviewer LOW finding):** the zero-delta result is structurally explained — `Effort_area`/`Effort_parent` property files do NOT declare `exo__Property_cardinality`, so `ShaclLiteValidator`'s maxCount gate is unreachable for those predicates. If cardinality declarations are added later to those property files, re-run safety analysis before enabling the flag in any production environment.

## Test plan

Empirical revert-fail / restore-pass verified per `~/.claude/rules/integration-test-revert-verify.md`:

- Temporarily removing the `isDualPredicate` check → **4 flag-on tests FAIL** (as expected, proving they exercise the new behavior).
- Restoring the check → **9/9 tests PASS**.
- The 2 `exo__Asset_prototype` regression tests **PASS in both states** (regression guard works).
- Existing `NoteToRDFConverter.shacl-cardinality.test.ts` (7 tests) PASS unchanged.

**Test coverage (new file: `NoteToRDFConverter.dual-storage-flag.test.ts`, 9 tests):**

- [x] Default (env unset): `ems__Effort_area` emits single IRI
- [x] Default (env unset): `ems__Effort_parent` emits single IRI
- [x] Flag set: `ems__Effort_area` emits BOTH IRI and UUID Literal
- [x] Flag set: `ems__Effort_parent` emits BOTH IRI and UUID Literal
- [x] Whitespace in flag (`"Effort_area, Effort_parent"`) trims correctly
- [x] Selective flag (only `Effort_area`) — `Effort_parent` stays single IRI
- [x] Regression: `exo__Asset_prototype` dual storage preserved when env unset
- [x] Regression: `exo__Asset_prototype` dual storage preserved when flag set for other predicates
- [x] Empty/whitespace flag (`"  ,  ,"`) behaves as unset (single IRI)

## Review trail

- **code-reviewer agent:** APPROVE WITH WARNING (0 CRITICAL, 1 HIGH = process gate "no `--auto` merge per CLAUDE.md", 2 MEDIUM = comment precision + optional optimization, 2 LOW = SHACL caveat + case-sensitivity callout — both addressed in this PR body).
- Commit `1caa094e` addresses MEDIUM finding (tighter inline comment).
- Per repo `CLAUDE.md` Auto-merge discipline — **manual squash merge only** after CI green; no `gh pr merge --auto`.

## Out of scope (per critical rules)

- ❌ TBox/ontology/SHACL shape modifications
- ❌ Default behavior change (must be opt-in)
- ❌ Bundling with #3286 (canonical IRI refactor) or other #3282 sub-tasks

🤖 Spawned via /spawn-issue-standalone v3