### PR TITLE
refactor(focus-profile): Knowledge/Focus switch method split (RFC 13da049f AC15)

### DIFF
--- a/packages/obsidian-plugin/src/infrastructure/adapters/FocusProfileCommands.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/FocusProfileCommands.ts
@@ -3,7 +3,7 @@
  *
  * Two commands provided:
  *   1. `Exocortex: Switch focus profile` — fuzzy-picks a FocusProfile asset,
- *      invokes B.4 `FocusProfileSwitchManager.switchProfile`
+ *      invokes B.4 `FocusProfileSwitchManager.softSwitchFocusProfile`
  *   2. `Exocortex: Push current assetspace` — identifies AssetSpace from
  *      active file path (B.3 `lookupAssetSpaceForPath`), invokes
  *      B.3 `AssetSpaceManager.pushAssetSpace`
@@ -86,7 +86,7 @@ export class FocusProfileCommands {
   /**
    * Command 1 — `Exocortex: Switch focus profile`.
    *
-   * Lists available profiles → fuzzy pick → invokes B.4 switchProfile.
+   * Lists available profiles → fuzzy pick → invokes B.4 softSwitchFocusProfile.
    * Errors during switch surface as a Notice (redacted in lower layers).
    */
   async invokeSwitchProfile(): Promise<void> {
@@ -108,8 +108,8 @@ export class FocusProfileCommands {
 
     this.notify(`Switching to ${chosen.label}…`);
     try {
-      await this.switchMgr.switchProfile(chosen.uid);
-      // switchProfile itself emits a success Notice; nothing more here
+      await this.switchMgr.softSwitchFocusProfile(chosen.uid);
+      // softSwitchFocusProfile itself emits a success Notice; nothing more here
     } catch (e) {
       this.notify(`Switch failed: ${this.safeMessage(e)}`);
     }
@@ -119,7 +119,7 @@ export class FocusProfileCommands {
    * Command 3 — `Exocortex: Hard switch focus profile` (RFC 22b50a17 Phase 3).
    *
    * Same fuzzy pick UX as soft switch, then invokes
-   * `FocusProfileSwitchManager.hardSwitchProfile` which:
+   * `FocusProfileSwitchManager.hardSwitchKnowledgeProfile` which:
    *   1. R24 TS-floor assert (refuses targets that brick the plugin)
    *   2. Vision Lock #5 uncommitted abort (with file list)
    *   3. ModalConfirmGate (DI via switchMgr constructor)
@@ -150,7 +150,7 @@ export class FocusProfileCommands {
 
     this.notify(`Hard switching to ${chosen.label}…`);
     try {
-      await this.switchMgr.hardSwitchProfile(chosen.uid);
+      await this.switchMgr.hardSwitchKnowledgeProfile(chosen.uid);
     } catch (e) {
       if (e instanceof HardSwitchAbortedByUser) {
         this.notify("Hard switch cancelled.");

--- a/packages/obsidian-plugin/src/infrastructure/adapters/FocusProfileSwitchManager.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/FocusProfileSwitchManager.ts
@@ -249,10 +249,16 @@ export class FocusProfileSwitchManager {
   }
 
   /**
-   * Switch active focus profile. Lock-guarded, journaled. Idempotent re-index
-   * on failure (no destructive rollback in v3).
+   * Soft switch — set the active FocusProfile (RDF query-time filter only).
+   * Lock-guarded, journaled. Idempotent re-index on failure (no destructive
+   * rollback in v3). Does NOT mutate the filesystem — that is hard switch
+   * (see {@link hardSwitchKnowledgeProfile}).
+   *
+   * RFC 13da049f Phase 6.5b (AC15): canonical name for the soft-switch path.
+   * Legacy callers reach this via the deprecated {@link switchProfile} /
+   * {@link softSwitchProfile} aliases.
    */
-  async switchProfile(targetProfileUid: string): Promise<void> {
+  async softSwitchFocusProfile(targetProfileUid: string): Promise<void> {
     const acquired = await this.lockMgr.acquireLock(`switch-profile-${targetProfileUid}`);
     if (!acquired) {
       throw new Error(`Another switch is in progress (lock held). Try again shortly.`);
@@ -314,6 +320,33 @@ export class FocusProfileSwitchManager {
   }
 
   /**
+   * @deprecated Use {@link softSwitchFocusProfile}. Retained for backward
+   * compatibility (RFC 13da049f Phase 6.5b AC15 — Knowledge/Focus split).
+   * This was the original method name before the soft/hard semantic split.
+   */
+  async switchProfile(targetProfileUid: string): Promise<void> {
+    return this.softSwitchFocusProfile(targetProfileUid);
+  }
+
+  /**
+   * @deprecated Use {@link softSwitchFocusProfile}. Alias matching the RFC
+   * 13da049f naming convention (`softSwitchProfile` → `softSwitchFocusProfile`).
+   */
+  async softSwitchProfile(targetProfileUid: string): Promise<void> {
+    return this.softSwitchFocusProfile(targetProfileUid);
+  }
+
+  /**
+   * @deprecated Use {@link hardSwitchKnowledgeProfile}. Retained for backward
+   * compatibility (RFC 13da049f Phase 6.5b AC15 — Knowledge/Focus split).
+   * Hard switch materialises filesystem state, so it is semantically a
+   * Knowledge-profile operation.
+   */
+  async hardSwitchProfile(targetProfileUid: string): Promise<void> {
+    return this.hardSwitchKnowledgeProfile(targetProfileUid);
+  }
+
+  /**
    * Plugin-load recovery: if last journal entry shows an incomplete switch
    * AND settings._switchInProgress=true, re-trigger the re-index идempotently.
    *
@@ -333,7 +366,7 @@ export class FocusProfileSwitchManager {
 
     // Incomplete: re-trigger
     this.notify(`Recovering incomplete switch to ${lastEntry.targetUid}...`);
-    await this.switchProfile(lastEntry.targetUid);
+    await this.softSwitchFocusProfile(lastEntry.targetUid);
     return { recovered: true, targetUid: lastEntry.targetUid };
   }
 
@@ -410,9 +443,9 @@ export class FocusProfileSwitchManager {
    * @throws UncommittedChangesAbortError if dirty files in any to-destroy AS.
    * @throws HardSwitchAbortedByUser if confirmGate declines.
    */
-  async hardSwitchProfile(targetProfileUid: string): Promise<void> {
+  async hardSwitchKnowledgeProfile(targetProfileUid: string): Promise<void> {
     if (typeof targetProfileUid !== "string" || targetProfileUid.length === 0) {
-      throw new Error("hardSwitchProfile: targetProfileUid is required");
+      throw new Error("hardSwitchKnowledgeProfile: targetProfileUid is required");
     }
     const deps = this.assertHardSwitchWired();
 
@@ -549,7 +582,7 @@ export class FocusProfileSwitchManager {
         targetUid: targetProfileUid,
         ts: new Date(startedAt).toISOString(),
       });
-      await this.switchProfile(targetProfileUid);
+      await this.softSwitchFocusProfile(targetProfileUid);
       await this.appendJournal({
         phase: "hard-switch-completed",
         targetUid: targetProfileUid,
@@ -866,7 +899,7 @@ export class FocusProfileSwitchManager {
    * Detection: parse `.gitmodules` to get currently-materialized AS folders,
    * compare to effective set derived from local `activeProfileUid`. Mismatch
    * → call confirmGate (reusing IConfirmGate plan shape) to get user OK
-   * before reconciling via hardSwitchProfile.
+   * before reconciling via hardSwitchKnowledgeProfile.
    *
    * Returns `null` if no divergence detected. Otherwise returns the action
    * taken: `"reconciled"` if user approved, `"declined"` if user declined.
@@ -928,7 +961,7 @@ export class FocusProfileSwitchManager {
       ? await this.confirmGate.confirmHardSwitch(reconcilePlan)
       : true; // No gate wired (tests / headless) — proceed.
     if (!approved) return { outcome: "declined" };
-    await this.hardSwitchProfile(activeProfileUid);
+    await this.hardSwitchKnowledgeProfile(activeProfileUid);
     return { outcome: "reconciled" };
   }
 
@@ -995,7 +1028,7 @@ export class FocusProfileSwitchManager {
       this.vaultRootPath === undefined
     ) {
       throw new Error(
-        "hardSwitchProfile: dependencies not wired (assetSpaceManager, cacheLayer, gitOps, uncommittedGuard, confirmGate, localDataStore, vaultRootPath required)",
+        "hardSwitchKnowledgeProfile: dependencies not wired (assetSpaceManager, cacheLayer, gitOps, uncommittedGuard, confirmGate, localDataStore, vaultRootPath required)",
       );
     }
     return {

--- a/packages/obsidian-plugin/src/presentation/settings/ExocortexSettingTab.ts
+++ b/packages/obsidian-plugin/src/presentation/settings/ExocortexSettingTab.ts
@@ -687,7 +687,7 @@ export class ExocortexSettingTab extends PluginSettingTab {
       .setDesc(
         "Dispatches FocusProfileSwitchManager — same code path as the " +
           "Cmd+P «Switch focus profile» command. Triggers RDF re-index. " +
-          "v3 dropdown: no «none» option (switchProfile requires a target " +
+          "v3 dropdown: no «none» option (softSwitchFocusProfile requires a target " +
           "UID — clear via plugin reload).",
       );
 
@@ -737,7 +737,7 @@ export class ExocortexSettingTab extends PluginSettingTab {
           return;
         }
         try {
-          await switchMgr.switchProfile(uid);
+          await switchMgr.softSwitchFocusProfile(uid);
         } catch (error) {
           notifier.error(`Switch failed: ${errorMessage(error)}`);
         }

--- a/packages/obsidian-plugin/tests/unit/ExocortexSettingTab.focusProfile.test.ts
+++ b/packages/obsidian-plugin/tests/unit/ExocortexSettingTab.focusProfile.test.ts
@@ -6,7 +6,7 @@
  * sequence: PAT → Active focus profile → Switch cache → Operations log.
  *
  * The integration shape (real PAT persistence round-trip, real GitHub call,
- * real switchProfile dispatch) is intentionally out of scope here — those
+ * real softSwitchFocusProfile dispatch) is intentionally out of scope here — those
  * are covered by `LocalSecretsStore.test.ts`, `GitHubRestClient.test.ts`,
  * `FocusProfileSwitchManager.test.ts`. These tests only assert the UI
  * renders the expected scaffold so a future regression that drops one of
@@ -361,7 +361,7 @@ describe("ExocortexSettingTab — Issue #3320 FocusProfile sections", () => {
     ).toHaveBeenCalledWith("uid-a");
   });
 
-  it("ignores empty dropdown selection without dispatching switchProfile", async () => {
+  it("ignores empty dropdown selection without dispatching softSwitchFocusProfile", async () => {
     let capturedOnChange: ((uid: string) => Promise<void>) | null = null;
     MockSetting.mockImplementation((containerEl: any) => {
       const setting: any = {

--- a/packages/obsidian-plugin/tests/unit/ExocortexSettingTab.focusProfile.test.ts
+++ b/packages/obsidian-plugin/tests/unit/ExocortexSettingTab.focusProfile.test.ts
@@ -160,7 +160,7 @@ describe("ExocortexSettingTab — Issue #3320 FocusProfile sections", () => {
       applyDisplayNameTemplate: jest.fn(),
       configureLogChannels: jest.fn(),
       focusProfileSwitchManager: {
-        switchProfile: jest.fn().mockResolvedValue(undefined),
+        softSwitchFocusProfile: jest.fn().mockResolvedValue(undefined),
       },
       listFocusProfileChoices: jest.fn().mockResolvedValue([
         { uid: "uid-a", label: "Personal", isActive: false },
@@ -286,7 +286,7 @@ describe("ExocortexSettingTab — Issue #3320 FocusProfile sections", () => {
     expect(preCalls.length).toBeGreaterThanOrEqual(1);
   });
 
-  it("invokes plugin.focusProfileSwitchManager.switchProfile when dropdown changes", async () => {
+  it("invokes plugin.focusProfileSwitchManager.softSwitchFocusProfile when dropdown changes", async () => {
     let capturedOnChange: ((uid: string) => Promise<void>) | null = null;
     // Override addDropdown to capture the onChange callback registered by
     // the production code, then trigger it manually.
@@ -357,7 +357,7 @@ describe("ExocortexSettingTab — Issue #3320 FocusProfile sections", () => {
     expect(capturedOnChange).not.toBeNull();
     await capturedOnChange!("uid-a");
     expect(
-      mockPlugin.focusProfileSwitchManager.switchProfile,
+      mockPlugin.focusProfileSwitchManager.softSwitchFocusProfile,
     ).toHaveBeenCalledWith("uid-a");
   });
 
@@ -421,13 +421,13 @@ describe("ExocortexSettingTab — Issue #3320 FocusProfile sections", () => {
     settingTab.display();
     if (capturedOnChange) await (capturedOnChange as (uid: string) => Promise<void>)("");
     expect(
-      mockPlugin.focusProfileSwitchManager.switchProfile,
+      mockPlugin.focusProfileSwitchManager.softSwitchFocusProfile,
     ).not.toHaveBeenCalled();
   });
 
   it("surfaces switch failure as a Notice without throwing", async () => {
     let capturedOnChange: ((uid: string) => Promise<void>) | null = null;
-    mockPlugin.focusProfileSwitchManager.switchProfile = jest.fn(
+    mockPlugin.focusProfileSwitchManager.softSwitchFocusProfile = jest.fn(
       async () => {
         throw new Error("lock held");
       },

--- a/packages/obsidian-plugin/tests/unit/FocusProfileCommands.test.ts
+++ b/packages/obsidian-plugin/tests/unit/FocusProfileCommands.test.ts
@@ -11,7 +11,7 @@ import type { FocusProfileSwitchManager } from "../../src/infrastructure/adapter
 class FakeSwitchMgr {
   switchCalls: string[] = [];
   failOnce = false;
-  async switchProfile(uid: string): Promise<void> {
+  async softSwitchFocusProfile(uid: string): Promise<void> {
     this.switchCalls.push(uid);
     if (this.failOnce) {
       this.failOnce = false;
@@ -103,7 +103,7 @@ describe("FocusProfileCommands.invokeSwitchProfile", () => {
     expect(h.pickCalls[0].title).toBe("Switch focus profile");
   });
 
-  it("invokes switchMgr.switchProfile with chosen uid", async () => {
+  it("invokes switchMgr.softSwitchFocusProfile with chosen uid", async () => {
     const profiles = [{ uid: "u2", label: "profile-personal" }];
     const h = makeHarness({ profiles, pickResult: profiles[0] });
     await h.cmd.invokeSwitchProfile();
@@ -139,7 +139,7 @@ describe("FocusProfileCommands.invokeSwitchProfile", () => {
     expect(h.notices.some((n) => /Could not list profiles.*vault read failed/.test(n))).toBe(true);
   });
 
-  it("surfaces switchProfile failure as Notice без re-throw", async () => {
+  it("surfaces softSwitchFocusProfile failure as Notice без re-throw", async () => {
     const profiles = [{ uid: "u1", label: "p1" }];
     const h = makeHarness({ profiles, pickResult: profiles[0] });
     h.switchMgr.failOnce = true;

--- a/packages/obsidian-plugin/tests/unit/FocusProfileSwitchManager.aliases.test.ts
+++ b/packages/obsidian-plugin/tests/unit/FocusProfileSwitchManager.aliases.test.ts
@@ -1,0 +1,207 @@
+import type { App } from "obsidian";
+
+import {
+  FocusProfileSwitchManager,
+  type FocusProfileSwitchManagerOptions,
+  type IProfileResolver,
+  type IRdfIndexer,
+  type ISettingsStore,
+  type ProfileResolution,
+  type SwitchSettings,
+} from "../../src/infrastructure/adapters/FocusProfileSwitchManager";
+import { PluginLockManager } from "../../src/infrastructure/adapters/PluginLockManager";
+
+/**
+ * AC15 (RFC 13da049f Phase 6.5b) — Knowledge/Focus method split.
+ *
+ * Canonical names:
+ *   - softSwitchFocusProfile  (RDF query-time filter only)
+ *   - hardSwitchKnowledgeProfile  (destructive filesystem materialize)
+ *
+ * Deprecated aliases (retained for backward compatibility):
+ *   - switchProfile          → softSwitchFocusProfile
+ *   - softSwitchProfile      → softSwitchFocusProfile
+ *   - hardSwitchProfile      → hardSwitchKnowledgeProfile
+ *
+ * These tests verify:
+ *   1. canonical methods perform the correct path
+ *   2. each deprecated alias delegates to its canonical counterpart
+ *      (proven via spyOn — alias body MUST call canonical method)
+ */
+
+// ─── Fakes ───────────────────────────────────────────────────────────────
+
+function makeFakeApp(): { app: App; files: Map<string, string> } {
+  const files = new Map<string, string>();
+  const app = {
+    vault: {
+      adapter: {
+        exists: async (path: string) => files.has(path),
+        read: async (path: string) => {
+          const v = files.get(path);
+          if (v === undefined) throw new Error(`ENOENT: ${path}`);
+          return v;
+        },
+        write: async (path: string, data: string) => {
+          files.set(path, data);
+        },
+        remove: async (path: string) => {
+          files.delete(path);
+        },
+      },
+      getMarkdownFiles: () => [],
+    },
+    metadataCache: {
+      getFileCache: () => null,
+    },
+  } as unknown as App;
+  return { app, files };
+}
+
+class FakeProfileResolver implements IProfileResolver {
+  constructor(private readonly profiles: Map<string, ProfileResolution>) {}
+  async resolve(uid: string): Promise<ProfileResolution | null> {
+    return this.profiles.get(uid) ?? null;
+  }
+  async discoverSharedOntologies(): Promise<string[]> {
+    return [];
+  }
+}
+
+class FakeRdfIndexer implements IRdfIndexer {
+  refreshCalls: ReadonlySet<string>[] = [];
+  async refresh(effectiveOntologies: ReadonlySet<string>): Promise<void> {
+    this.refreshCalls.push(new Set(effectiveOntologies));
+  }
+}
+
+class FakeSettingsStore implements ISettingsStore {
+  state: SwitchSettings = { activeProfileUid: null, _switchInProgress: false };
+  async load(): Promise<SwitchSettings> {
+    return { ...this.state };
+  }
+  async save(s: SwitchSettings): Promise<void> {
+    this.state = { ...s };
+  }
+}
+
+interface Harness {
+  mgr: FocusProfileSwitchManager;
+  rdf: FakeRdfIndexer;
+  settings: FakeSettingsStore;
+  notifyCalls: string[];
+}
+
+const UID_BASE = "ae00f219-base";
+const ONTO_EXO = "https://exocortex.my/ontology/exo";
+const ONTO_EXOCMD = "https://exocortex.my/ontology/exocmd";
+const ONTO_KITELEV = "https://exocortex.my/ontology/kitelev";
+
+function makeHarness(): Harness {
+  const { app } = makeFakeApp();
+  const profiles = new Map<string, ProfileResolution>([
+    [
+      UID_BASE,
+      {
+        uid: UID_BASE,
+        includes: [ONTO_KITELEV],
+        alwaysOnOverlay: [],
+        extends: null,
+        label: "profile-base",
+      },
+    ],
+  ]);
+  const resolver = new FakeProfileResolver(profiles);
+  const rdf = new FakeRdfIndexer();
+  const settings = new FakeSettingsStore();
+  const current = new Date("2026-06-04T00:00:00.000Z");
+  const lockMgr = new PluginLockManager({ app, pid: "fixed-pid", now: () => current });
+  const notifyCalls: string[] = [];
+  const opts: FocusProfileSwitchManagerOptions = {
+    app,
+    lockMgr,
+    resolver,
+    rdfIndexer: rdf,
+    settingsStore: settings,
+    now: () => current,
+    notify: (m) => notifyCalls.push(m),
+  };
+  const mgr = new FocusProfileSwitchManager(opts);
+  return { mgr, rdf, settings, notifyCalls };
+}
+
+// ─── Canonical softSwitchFocusProfile ────────────────────────────────────
+
+describe("FocusProfileSwitchManager.softSwitchFocusProfile (canonical)", () => {
+  it("performs the soft-switch path: persists activeProfileUid + triggers RDF refresh", async () => {
+    const h = makeHarness();
+    await h.mgr.softSwitchFocusProfile(UID_BASE);
+
+    expect(h.settings.state.activeProfileUid).toBe(UID_BASE);
+    expect(h.settings.state._switchInProgress).toBe(false);
+    expect(h.rdf.refreshCalls).toHaveLength(1);
+
+    const refreshed = h.rdf.refreshCalls[0];
+    expect(refreshed.has(ONTO_KITELEV)).toBe(true);
+    // TS-floor URIs always present
+    expect(refreshed.has(ONTO_EXO)).toBe(true);
+    expect(refreshed.has(ONTO_EXOCMD)).toBe(true);
+  });
+
+  it("emits a user-facing notice on success", async () => {
+    const h = makeHarness();
+    await h.mgr.softSwitchFocusProfile(UID_BASE);
+    expect(h.notifyCalls).toHaveLength(1);
+    expect(h.notifyCalls[0]).toContain("profile-base");
+  });
+});
+
+// ─── Deprecated alias delegation ─────────────────────────────────────────
+
+describe("FocusProfileSwitchManager — deprecated aliases delegate to canonical", () => {
+  it("switchProfile delegates to softSwitchFocusProfile", async () => {
+    const h = makeHarness();
+    const spy = jest.spyOn(h.mgr, "softSwitchFocusProfile");
+    await h.mgr.switchProfile(UID_BASE);
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy).toHaveBeenCalledWith(UID_BASE);
+    // And observable side-effect: same as canonical
+    expect(h.settings.state.activeProfileUid).toBe(UID_BASE);
+    expect(h.rdf.refreshCalls).toHaveLength(1);
+  });
+
+  it("softSwitchProfile delegates to softSwitchFocusProfile", async () => {
+    const h = makeHarness();
+    const spy = jest.spyOn(h.mgr, "softSwitchFocusProfile");
+    await h.mgr.softSwitchProfile(UID_BASE);
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy).toHaveBeenCalledWith(UID_BASE);
+    expect(h.settings.state.activeProfileUid).toBe(UID_BASE);
+    expect(h.rdf.refreshCalls).toHaveLength(1);
+  });
+
+  it("hardSwitchProfile delegates to hardSwitchKnowledgeProfile", async () => {
+    const h = makeHarness();
+    // Hard switch requires extra deps wired; without them, the canonical method
+    // throws via assertHardSwitchWired(). What we verify here is that the alias
+    // routes into the canonical method (not into soft-switch), so the very same
+    // wiring error surfaces. Delegation proven by spy + identical throw signature.
+    const spy = jest.spyOn(h.mgr, "hardSwitchKnowledgeProfile");
+    await expect(h.mgr.hardSwitchProfile(UID_BASE)).rejects.toThrow(
+      /dependencies not wired/,
+    );
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy).toHaveBeenCalledWith(UID_BASE);
+  });
+});
+
+// ─── Canonical hardSwitchKnowledgeProfile (wiring assertion) ─────────────
+
+describe("FocusProfileSwitchManager.hardSwitchKnowledgeProfile (canonical)", () => {
+  it("throws when hard-switch dependencies are not wired (assertHardSwitchWired)", async () => {
+    const h = makeHarness();
+    await expect(h.mgr.hardSwitchKnowledgeProfile(UID_BASE)).rejects.toThrow(
+      /hardSwitchKnowledgeProfile: dependencies not wired/,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Completes **Phase 6.5b AC15** (RFC `13da049f`) — Knowledge/Focus switch method semantic split in `FocusProfileSwitchManager`.

This PR migrates external callers to the new **canonical** method names introduced upstream in commit `11d6c966`. Deprecated aliases remain in place for backward compatibility — **zero behavior change**.

## Canonical methods

| Old (deprecated alias)  | New (canonical)               | Semantics                                       |
| ----------------------- | ----------------------------- | ----------------------------------------------- |
| `switchProfile`         | `softSwitchFocusProfile`      | Focus Profile — soft, RDF query-time filter     |
| `softSwitchProfile`     | `softSwitchFocusProfile`      | Same path (Focus model)                         |
| `hardSwitchProfile`     | `hardSwitchKnowledgeProfile`  | Knowledge Profile — hard, filesystem materialize |

## Changes

**Source migration (canonical-name adoption):**
- `packages/obsidian-plugin/src/infrastructure/adapters/FocusProfileCommands.ts`
  - `invokeSwitchProfile` → `softSwitchFocusProfile`
  - `invokeHardSwitchProfile` → `hardSwitchKnowledgeProfile`
  - JSDoc references updated
- `packages/obsidian-plugin/src/presentation/settings/ExocortexSettingTab.ts`
  - Dropdown handler dispatches `softSwitchFocusProfile`

**New unit test suite** (`FocusProfileSwitchManager.aliases.test.ts`, 6 tests):
- canonical `softSwitchFocusProfile` performs soft-switch path (settings persist, RDF refresh, notice)
- canonical `hardSwitchKnowledgeProfile` asserts wiring (no extra deps → throws)
- all 3 deprecated aliases delegate to their canonical counterparts (verified via `jest.spyOn` on canonical method + observable side-effect)

**Existing tests updated** to use canonical names via mocks:
- `FocusProfileCommands.test.ts` — `FakeSwitchMgr` exposes `softSwitchFocusProfile`
- `ExocortexSettingTab.focusProfile.test.ts` — mock plugin uses `softSwitchFocusProfile`

## Local verification

| Check                                          | Result                  |
| ---------------------------------------------- | ----------------------- |
| FocusProfile cluster (8 suites, 106 tests)     | ✅ 106/106              |
| Full obsidian-plugin (274 suites, 5440 tests)  | ✅ 5440/5440            |
| UI (jest.ui.config.js, 2 suites, 53 tests)     | ✅ 53/53                |
| `tsc --noEmit --skipLibCheck`                  | ✅ clean                |
| `npm run lint`                                 | ✅ 0 errors             |

Pre-existing CLI `sparql-exo003.integration.test.ts` failures (10/10) reproduce identically on parent `87fa3713` — unrelated to this refactor, will reproduce in CI.

## What's NOT in scope

Per RFC 13da049f Phase 6.5b split:
- ⛔ AC14 (`PluginLocalDataStore` schema) — PR-B
- ⛔ Settings UI labels / docs — PR-D
- ⛔ Removing deprecated aliases — preserves backward compat

## RFC reference

- RFC `13da049f` Phase 6.5b AC15 (Knowledge/Focus method split)
- Builds on commit `11d6c966` (AC15 source rename)

## Test plan
- [x] Canonical methods perform correct semantic path
- [x] All 3 deprecated aliases delegate via spy proof
- [x] External callers updated to canonical names
- [x] Existing test mocks updated to expose canonical names
- [x] Full plugin test suite green locally
- [x] Typecheck + lint clean