### PR TITLE
feat(focus-profile): FocusProfile narrowing + compat WARN/fallback + dual palette (RFC 13da049f AC13/16/17)

### DIFF
--- a/packages/obsidian-plugin/src/ExocortexPlugin.ts
+++ b/packages/obsidian-plugin/src/ExocortexPlugin.ts
@@ -2802,9 +2802,14 @@ export default class ExocortexPlugin extends Plugin {
     // RFC 13da049f Phase 6.5b AC17 — «Switch knowledge profile» (hard switch;
     // supersedes the RFC 22b50a17 «Hard switch focus profile» command). Needs
     // desktop hard-switch deps wired (filesystem materialisation).
+    //
+    // Command id is intentionally kept as the legacy `hard-switch-focus-profile`
+    // so any hotkey a user already bound to the hard-switch command survives the
+    // Knowledge/Focus split (Obsidian persists hotkeys by command id). Only the
+    // user-facing name + picker source change.
     if (hardSwitchDeps !== null) {
       this.addCommand({
-        id: "switch-knowledge-profile",
+        id: "hard-switch-focus-profile",
         name: "Switch knowledge profile (filesystem destroy + materialize)",
         callback: () => {
           void commandsHandler.invokeSwitchKnowledgeProfile();

--- a/packages/obsidian-plugin/src/ExocortexPlugin.ts
+++ b/packages/obsidian-plugin/src/ExocortexPlugin.ts
@@ -2698,11 +2698,14 @@ export default class ExocortexPlugin extends Plugin {
 
     const pushMgr = await this.buildAssetSpacePusher();
 
-    const profileLister: () => Promise<FocusProfileChoice[]> = async () => {
-      // Item #3 — device-local store (no Sync replication).
-      const activeUid = localDataStore.getActiveProfileUid();
+    // Shared choice-builder for the per-class palette pickers (RFC 13da049f
+    // AC17). `activeUid` drives the `isActive` flag the picker surfaces.
+    const buildProfileChoices = (
+      files: TFile[],
+      activeUid: string | null,
+    ): FocusProfileChoice[] => {
       const choices: FocusProfileChoice[] = [];
-      for (const file of resolver.listFocusProfileFiles()) {
+      for (const file of files) {
         const cache = this.app.metadataCache.getFileCache(file);
         const fm = cache?.frontmatter as Record<string, unknown> | undefined;
         if (!fm) continue;
@@ -2724,6 +2727,24 @@ export default class ExocortexPlugin extends Plugin {
       return choices;
     };
 
+    const profileLister: () => Promise<FocusProfileChoice[]> = async () =>
+      // Item #3 — device-local store (no Sync replication). Legacy
+      // `activeProfileUid` mirrors the active Focus selection (soft switch).
+      buildProfileChoices(
+        resolver.listFocusProfileFiles(),
+        localDataStore.getActiveProfileUid(),
+      );
+
+    // AC17 — KnowledgeProfile picker source. Dual-class assets surface in both
+    // listers because the discrimination is by `exo__Instance_class` membership.
+    const knowledgeProfileLister: () => Promise<
+      FocusProfileChoice[]
+    > = async () =>
+      buildProfileChoices(
+        resolver.listKnowledgeProfileFiles(),
+        localDataStore.getActiveKnowledgeProfileUid(),
+      );
+
     // Issue #3320 — share the same lister с Settings UI so its dropdown
     // matches the Cmd+P fuzzy-pick ordering exactly.
     this.listFocusProfileChoices = profileLister;
@@ -2742,9 +2763,13 @@ export default class ExocortexPlugin extends Plugin {
       switchMgr,
       pushMgr,
       profileLister,
+      knowledgeProfileLister,
       fuzzyPick,
       getActiveFilePath: () =>
         this.app.workspace.getActiveFile()?.path ?? null,
+      getActiveKnowledgeProfileUid: () =>
+        localDataStore.getActiveKnowledgeProfileUid(),
+      getActiveFocusProfileUid: () => localDataStore.getActiveFocusProfileUid(),
       notify: (message) => this.notifier.info(message),
     });
 
@@ -2764,13 +2789,25 @@ export default class ExocortexPlugin extends Plugin {
       },
     });
 
-    // RFC 22b50a17 Phase 3 — hard switch palette command.
+    // RFC 13da049f Phase 6.5b AC17 — «Show current state» (active Knowledge +
+    // Focus). Available regardless of platform / hard-switch wiring.
+    this.addCommand({
+      id: "show-profile-state",
+      name: "Show current state",
+      callback: () => {
+        void commandsHandler.invokeShowCurrentState();
+      },
+    });
+
+    // RFC 13da049f Phase 6.5b AC17 — «Switch knowledge profile» (hard switch;
+    // supersedes the RFC 22b50a17 «Hard switch focus profile» command). Needs
+    // desktop hard-switch deps wired (filesystem materialisation).
     if (hardSwitchDeps !== null) {
       this.addCommand({
-        id: "hard-switch-focus-profile",
-        name: "Hard switch focus profile (filesystem destroy + materialize)",
+        id: "switch-knowledge-profile",
+        name: "Switch knowledge profile (filesystem destroy + materialize)",
         callback: () => {
-          void commandsHandler.invokeHardSwitchProfile();
+          void commandsHandler.invokeSwitchKnowledgeProfile();
         },
       });
     }

--- a/packages/obsidian-plugin/src/infrastructure/adapters/FocusProfileCommands.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/FocusProfileCommands.ts
@@ -1,20 +1,31 @@
 /**
- * FocusProfileCommands — command-palette logic handler для RFC 0a0791c1 §B.7.
+ * FocusProfileCommands — command-palette logic handler для RFC 0a0791c1 §B.7
+ * + RFC 13da049f Phase 6.5b AC17 (dual Knowledge/Focus palette commands).
  *
- * Two commands provided:
+ * Commands provided:
  *   1. `Exocortex: Switch focus profile` — fuzzy-picks a FocusProfile asset,
- *      invokes B.4 `FocusProfileSwitchManager.softSwitchFocusProfile`
- *   2. `Exocortex: Push current assetspace` — identifies AssetSpace from
+ *      invokes B.4 `FocusProfileSwitchManager.softSwitchFocusProfile` (soft —
+ *      RDF query-time filter only).
+ *   2. `Exocortex: Switch knowledge profile` — fuzzy-picks a KnowledgeProfile
+ *      asset, invokes `FocusProfileSwitchManager.hardSwitchKnowledgeProfile`
+ *      (hard — filesystem destroy + materialise).
+ *   3. `Exocortex: Show current state` — Notice with the active Knowledge +
+ *      Focus profile labels.
+ *   4. `Exocortex: Push current assetspace` — identifies AssetSpace from
  *      active file path (B.3 `lookupAssetSpaceForPath`), invokes
- *      B.3 `AssetSpaceManager.pushAssetSpace`
+ *      B.3 `AssetSpaceManager.pushAssetSpace`.
  *
  * Pure logic — does NOT depend on Obsidian Plugin / FuzzySuggestModal /
  * App.workspace runtime. Dependencies passed via constructor:
  *   - `switchMgr` (B.4)
  *   - `pushMgr` (B.3 — interface `IAssetSpacePusher`)
- *   - `profileLister` — returns available FocusProfile assets
+ *   - `profileLister` — returns available FocusProfile assets (soft picker)
+ *   - `knowledgeProfileLister` — returns available KnowledgeProfile assets
+ *     (hard picker, AC17). Dual-class assets appear in both lists.
  *   - `fuzzyPick` — opens picker UI, returns chosen profile or null on cancel
  *   - `getActiveFilePath` — returns active file path или null
+ *   - `getActiveKnowledgeProfileUid` / `getActiveFocusProfileUid` — current
+ *     active selections for the «Show current state» command (AC17)
  *   - `notify` — user-facing Notice
  *
  * Real Obsidian wiring (plugin.addCommand + FuzzySuggestModal + Notice)
@@ -49,8 +60,14 @@ export interface FocusProfileChoice {
 export interface FocusProfileCommandsDeps {
   switchMgr: FocusProfileSwitchManager;
   pushMgr: IAssetSpacePusher;
-  /** Returns available FocusProfile assets (label + uid pairs). */
+  /** Returns available FocusProfile assets (label + uid pairs) — soft picker. */
   profileLister: () => Promise<FocusProfileChoice[]>;
+  /**
+   * Returns available KnowledgeProfile assets — hard picker (AC17). Dual-class
+   * assets (declaring both Focus + Knowledge) appear in both this list and
+   * {@link profileLister}.
+   */
+  knowledgeProfileLister: () => Promise<FocusProfileChoice[]>;
   /**
    * Open a fuzzy picker UI. Returns the user's choice, or null if the
    * picker was cancelled. Real implementation wraps Obsidian
@@ -62,6 +79,16 @@ export interface FocusProfileCommandsDeps {
   ) => Promise<FocusProfileChoice | null>;
   /** Returns the currently-active file path, or null if no file is open. */
   getActiveFilePath: () => string | null;
+  /**
+   * Returns the active Knowledge profile UID (hard switch slot), or null.
+   * Used by «Show current state» (AC17).
+   */
+  getActiveKnowledgeProfileUid: () => string | null;
+  /**
+   * Returns the active Focus profile UID (soft switch slot), or null.
+   * Used by «Show current state» (AC17).
+   */
+  getActiveFocusProfileUid: () => string | null;
   /** Show a user-facing Notice. */
   notify: (message: string) => void;
 }
@@ -70,16 +97,22 @@ export class FocusProfileCommands {
   private readonly switchMgr: FocusProfileSwitchManager;
   private readonly pushMgr: IAssetSpacePusher;
   private readonly profileLister: () => Promise<FocusProfileChoice[]>;
+  private readonly knowledgeProfileLister: () => Promise<FocusProfileChoice[]>;
   private readonly fuzzyPick: FocusProfileCommandsDeps["fuzzyPick"];
   private readonly getActiveFilePath: () => string | null;
+  private readonly getActiveKnowledgeProfileUid: () => string | null;
+  private readonly getActiveFocusProfileUid: () => string | null;
   private readonly notify: (message: string) => void;
 
   constructor(deps: FocusProfileCommandsDeps) {
     this.switchMgr = deps.switchMgr;
     this.pushMgr = deps.pushMgr;
     this.profileLister = deps.profileLister;
+    this.knowledgeProfileLister = deps.knowledgeProfileLister;
     this.fuzzyPick = deps.fuzzyPick;
     this.getActiveFilePath = deps.getActiveFilePath;
+    this.getActiveKnowledgeProfileUid = deps.getActiveKnowledgeProfileUid;
+    this.getActiveFocusProfileUid = deps.getActiveFocusProfileUid;
     this.notify = deps.notify;
   }
 
@@ -116,9 +149,10 @@ export class FocusProfileCommands {
   }
 
   /**
-   * Command 3 — `Exocortex: Hard switch focus profile` (RFC 22b50a17 Phase 3).
+   * Command 2 — `Exocortex: Switch knowledge profile` (RFC 13da049f Phase 6.5b
+   * AC17; supersedes the RFC 22b50a17 «Hard switch focus profile» command).
    *
-   * Same fuzzy pick UX as soft switch, then invokes
+   * Fuzzy-picks a **KnowledgeProfile** asset (per-class picker), then invokes
    * `FocusProfileSwitchManager.hardSwitchKnowledgeProfile` which:
    *   1. R24 TS-floor assert (refuses targets that brick the plugin)
    *   2. Vision Lock #5 uncommitted abort (with file list)
@@ -128,47 +162,81 @@ export class FocusProfileCommands {
    * User-facing error mapping: TsFloorViolationError, UncommittedChangesAbortError,
    * and HardSwitchAbortedByUser get clear notices distinct from generic «Switch failed».
    */
-  async invokeHardSwitchProfile(): Promise<void> {
+  async invokeSwitchKnowledgeProfile(): Promise<void> {
     let profiles: FocusProfileChoice[];
     try {
-      profiles = await this.profileLister();
+      profiles = await this.knowledgeProfileLister();
     } catch (e) {
       this.notify(`Could not list profiles: ${this.safeMessage(e)}`);
       return;
     }
 
     if (profiles.length === 0) {
-      this.notify("No FocusProfile assets found in vault");
+      this.notify("No KnowledgeProfile assets found in vault");
       return;
     }
 
     const chosen = await this.fuzzyPick(
       profiles,
-      "Hard switch focus profile (filesystem destroy + materialize)",
+      "Switch knowledge profile (filesystem destroy + materialize)",
     );
     if (chosen === null) return; // user cancelled
 
-    this.notify(`Hard switching to ${chosen.label}…`);
+    this.notify(`Switching knowledge profile to ${chosen.label}…`);
     try {
       await this.switchMgr.hardSwitchKnowledgeProfile(chosen.uid);
     } catch (e) {
       if (e instanceof HardSwitchAbortedByUser) {
-        this.notify("Hard switch cancelled.");
+        this.notify("Knowledge profile switch cancelled.");
         return;
       }
       if (e instanceof TsFloorViolationError) {
-        this.notify(`Hard switch refused — ${e.message}`);
+        this.notify(`Knowledge profile switch refused — ${e.message}`);
         return;
       }
       if (e instanceof UncommittedChangesAbortError) {
         const total = e.affectedFiles.reduce((s, a) => s + a.files.length, 0);
         this.notify(
-          `Hard switch aborted — ${total} uncommitted file(s) в ${e.affectedFiles.length} AssetSpace(s). Commit or stash first.`,
+          `Knowledge profile switch aborted — ${total} uncommitted file(s) в ${e.affectedFiles.length} AssetSpace(s). Commit or stash first.`,
         );
         return;
       }
-      this.notify(`Hard switch failed: ${this.safeMessage(e)}`);
+      this.notify(`Knowledge profile switch failed: ${this.safeMessage(e)}`);
     }
+  }
+
+  /**
+   * @deprecated Use {@link invokeSwitchKnowledgeProfile}. Retained for backward
+   * compatibility (RFC 13da049f Phase 6.5b AC17 — Knowledge/Focus palette split).
+   * Hard switch is now surfaced as «Switch knowledge profile» and picks from
+   * KnowledgeProfile assets rather than FocusProfile assets.
+   */
+  async invokeHardSwitchProfile(): Promise<void> {
+    return this.invokeSwitchKnowledgeProfile();
+  }
+
+  /**
+   * Command 3 — `Exocortex: Show current state` (RFC 13da049f Phase 6.5b AC17).
+   *
+   * Surfaces a Notice reporting the currently-active Knowledge profile (hard
+   * switch slot) and Focus profile (soft switch slot). Labels are resolved
+   * best-effort from the per-class listers; an unresolved UID falls back to the
+   * raw UID, and an unset slot shows «(none)». Never throws — lister failures
+   * degrade to the UID / «(unknown)».
+   */
+  async invokeShowCurrentState(): Promise<void> {
+    const knowledgeUid = this.getActiveKnowledgeProfileUid();
+    const focusUid = this.getActiveFocusProfileUid();
+
+    const knowledgeLabel = await this.resolveLabel(
+      knowledgeUid,
+      this.knowledgeProfileLister,
+    );
+    const focusLabel = await this.resolveLabel(focusUid, this.profileLister);
+
+    this.notify(
+      `Active profiles — Knowledge: ${knowledgeLabel} · Focus: ${focusLabel}`,
+    );
   }
 
   /**
@@ -237,5 +305,24 @@ export class FocusProfileCommands {
   private safeMessage(e: unknown): string {
     if (e instanceof Error) return e.message;
     return String(e);
+  }
+
+  /**
+   * Best-effort UID → label resolution for «Show current state». Returns
+   * «(none)» when the slot is unset, the matched label when the lister has it,
+   * the raw UID when unmatched, and «(unknown)» when the lister throws.
+   */
+  private async resolveLabel(
+    uid: string | null,
+    lister: () => Promise<FocusProfileChoice[]>,
+  ): Promise<string> {
+    if (uid === null || uid.length === 0) return "(none)";
+    try {
+      const choices = await lister();
+      const match = choices.find((c) => c.uid === uid);
+      return match !== undefined ? match.label : uid;
+    } catch {
+      return `${uid} (unknown)`;
+    }
   }
 }

--- a/packages/obsidian-plugin/src/infrastructure/adapters/FocusProfileSwitchManager.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/FocusProfileSwitchManager.ts
@@ -608,7 +608,7 @@ export class FocusProfileSwitchManager {
       // surprise the user more than a best-effort narrowed view).
       console.warn(
         `[FocusProfileSwitchManager] compat evaluation errored for ${targetProfileUid}; ` +
-          `proceeding with the declared filter. ${String(e)}`,
+          `proceeding with the declared filter. ${this.redactError(String(e))}`,
       );
       return { compatible: true };
     }

--- a/packages/obsidian-plugin/src/infrastructure/adapters/FocusProfileSwitchManager.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/FocusProfileSwitchManager.ts
@@ -29,7 +29,30 @@ import { TS_FLOOR_ASSETSPACE_UIDS } from "./FocusProfileOnloadWiring";
  * Per RFC 0a0791c1 §B.4 + Vision Lock #17 + Architect #2.
  */
 
+/**
+ * `exo__FocusProfile` class UID (frozen by RFC b6ba5595).
+ *
+ * RFC 13da049f Phase 6.5b (AC13) — **filter-only narrowing**: a FocusProfile
+ * is strictly a *soft switch* — a query-time RDF-graph filter. It does NOT
+ * materialise filesystem state; physical AssetSpace materialisation is the
+ * responsibility of `exo__KnowledgeProfile` (hard switch, see
+ * {@link KNOWLEDGE_PROFILE_CLASS_UID} + {@link hardSwitchKnowledgeProfile}).
+ * The optional `exo__FocusProfile_appliesTo` predicate binds a FocusProfile to
+ * the Knowledge profile it is meant to narrow — consumed at runtime by the
+ * AC16 compatibility check in {@link softSwitchFocusProfile}.
+ */
 export const FOCUS_PROFILE_CLASS_UID = "3de846cd-1f0e-4f98-8613-b8587aa15174";
+
+/**
+ * `exo__KnowledgeProfile` class UID (RFC 13da049f Phase 6.5b).
+ *
+ * A KnowledgeProfile drives the **hard switch** — destructive filesystem
+ * materialisation of `assetspaces/<as>/`. Distinct from {@link FOCUS_PROFILE_CLASS_UID}
+ * (query-time filter only). An asset may declare BOTH classes (dual-class) when
+ * it serves as both a materialisation target and a query-time filter.
+ */
+export const KNOWLEDGE_PROFILE_CLASS_UID =
+  "b8884976-596f-43d2-b7f4-3da518f825d4";
 
 /**
  * TS-floor (Vision Lock #17): ontology URIs that are ALWAYS in the effective
@@ -57,6 +80,14 @@ export interface ProfileResolution {
   extends?: string | null;
   /** Directly declared `_alwaysOnOverlay` (ontology URIs). */
   alwaysOnOverlay: string[];
+  /**
+   * Optional `exo__FocusProfile_appliesTo` (RFC 13da049f Phase 6.5b AC13) —
+   * the Knowledge profile UID this Focus profile is scoped to. When declared,
+   * the AC16 compatibility check (see {@link FocusProfileSwitchManager.softSwitchFocusProfile})
+   * WARN+fallbacks to no-filter if the active Knowledge profile differs.
+   * Empty / null means «applies to any active Knowledge — subset check only».
+   */
+  appliesTo?: string | null;
   /** Display label (used in user-facing Notice). */
   label?: string;
 }
@@ -262,6 +293,27 @@ export class FocusProfileSwitchManager {
    * rollback in v3). Does NOT mutate the filesystem — that is hard switch
    * (see {@link hardSwitchKnowledgeProfile}).
    *
+   * RFC 13da049f Phase 6.5b (AC13) — **filter-only narrowing**: the Focus
+   * filter narrows the *view* within the materialised Knowledge set; it never
+   * materialises ontologies the active Knowledge profile does not provide.
+   *
+   * AC16 — **compatibility check (WARN + fallback, NEVER throw)**: before
+   * applying the target profile's filter, validate it against the active
+   * Knowledge profile (`activeKnowledgeProfileUid`, surfaced by
+   * `PluginSettingsStoreAdapter` from `localDataStore.getActiveKnowledgeProfileUid()`):
+   *   - If the target declares `_appliesTo` and it differs from the active
+   *     Knowledge profile → incompatible.
+   *   - If the active Knowledge profile's effective set is empty / not
+   *     materialised (EC3) → incompatible.
+   *   - If the target's `_includes ⊄ active Knowledge effective set` →
+   *     incompatible.
+   * On incompatibility the switch still **resolves successfully** (no throw):
+   * it logs a `console.warn`, surfaces a `Notice`, and sets the RDF filter to
+   * **no-filter** (empty set → full vault) instead of the target's narrowed
+   * set. When no Knowledge profile is active and the target declares no
+   * `_appliesTo`, the check is a backward-compatible pass-through (pre-AC16
+   * behaviour — the declared filter is applied).
+   *
    * RFC 13da049f Phase 6.5b (AC15): canonical name for the soft-switch path.
    * Legacy callers reach this via the deprecated {@link switchProfile} /
    * {@link softSwitchProfile} aliases.
@@ -292,6 +344,28 @@ export class FocusProfileSwitchManager {
 
       // Persist BEFORE filesystem changes (Architect #2 — atomicity invariant)
       const settings = await this.settingsStore.load();
+
+      // AC16 — compatibility check against the active Knowledge profile. On
+      // violation we still persist the Focus selection but apply a no-filter
+      // (empty set → full vault) instead of the target's narrowed set. The
+      // check NEVER throws (R37 — soft fallback).
+      const compat = await this.evaluateFocusKnowledgeCompat(
+        targetProfileUid,
+        settings,
+      );
+      // No-filter signal: an empty set makes `NoteToRDFConverter` fall back to
+      // the no-filter path (see `shouldSkipFileForEffectiveSet` — empty
+      // effective set → index everything, avoids self-brick).
+      const filterSet: ReadonlySet<string> = compat.compatible
+        ? effective
+        : new Set<string>();
+      if (!compat.compatible) {
+        // AC16 action #1 — console.warn with the compatibility violation.
+        console.warn(`[FocusProfileSwitchManager] ${compat.reason}`);
+        // AC16 action #2 — user-facing Notice.
+        this.notify(compat.userMessage);
+      }
+
       settings.activeProfileUid = targetProfileUid;
       // AC14 — soft switch owns the Focus slot. The legacy `activeProfileUid`
       // mirror is retained above for backward read / downgrade safety.
@@ -299,8 +373,8 @@ export class FocusProfileSwitchManager {
       settings._switchInProgress = true;
       await this.settingsStore.save(settings);
 
-      // Trigger RDF re-index
-      await this.rdfIndexer.refresh(effective);
+      // AC16 action #3 — Trigger RDF re-index (no-filter set on violation).
+      await this.rdfIndexer.refresh(filterSet);
 
       // Clear in-progress flag
       settings._switchInProgress = false;
@@ -314,8 +388,14 @@ export class FocusProfileSwitchManager {
         elapsedMs,
       });
 
-      const profileLabel = await this.profileLabel(targetProfileUid);
-      this.notify(`Switched to ${profileLabel} (${elapsedMs}ms)`);
+      // On the compatible path emit the success Notice. On the incompatible
+      // path the AC16 fallback Notice (above) is the user-facing message, so
+      // we skip a second «Switched…» line to avoid implying the narrowed view
+      // was applied when it was not.
+      if (compat.compatible) {
+        const profileLabel = await this.profileLabel(targetProfileUid);
+        this.notify(`Switched to ${profileLabel} (${elapsedMs}ms)`);
+      }
     } catch (e) {
       await this.appendJournal({
         phase: "failed",
@@ -413,6 +493,125 @@ export class FocusProfileSwitchManager {
     const result = new Set<string>();
     await this.walkProfileChain(profileUid, visited, result, 0);
     return result;
+  }
+
+  /**
+   * AC16 (RFC 13da049f Phase 6.5b) — evaluate whether a target FocusProfile is
+   * compatible with the currently-active Knowledge profile.
+   *
+   * Decision layers (matches `exo__FocusProfile_appliesTo` TBox semantics):
+   *   1. `_appliesTo` declared → must equal the active Knowledge UID; any
+   *      mismatch (including no active Knowledge) is incompatible.
+   *   2. No `_appliesTo` AND no active Knowledge → backward-compatible
+   *      pass-through (apply the declared filter; pre-AC16 behaviour).
+   *   3. Active Knowledge resolves to an empty derived set (EC3 — not
+   *      materialised) → incompatible.
+   *   4. Target `_includes ⊄ active Knowledge effective set` → incompatible.
+   *
+   * The active Knowledge UID is read from `settings.activeKnowledgeProfileUid`,
+   * which `PluginSettingsStoreAdapter` populates from
+   * `PluginLocalDataStore.getActiveKnowledgeProfileUid()`.
+   *
+   * NEVER throws — on any evaluation error it returns `compatible` (apply the
+   * declared filter) and logs, so a compat-evaluation bug cannot block a switch
+   * (AC16 invariant: WARN + fallback, never throw).
+   */
+  private async evaluateFocusKnowledgeCompat(
+    targetProfileUid: string,
+    settings: SwitchSettings,
+  ): Promise<
+    | { compatible: true }
+    | { compatible: false; reason: string; userMessage: string }
+  > {
+    try {
+      const activeKnowledgeUid =
+        typeof settings.activeKnowledgeProfileUid === "string" &&
+        settings.activeKnowledgeProfileUid.length > 0
+          ? settings.activeKnowledgeProfileUid
+          : null;
+
+      const profile = await this.resolver.resolve(targetProfileUid);
+      const appliesTo =
+        profile !== null &&
+        typeof profile.appliesTo === "string" &&
+        profile.appliesTo.length > 0
+          ? profile.appliesTo
+          : null;
+
+      // Layer 1 — `_appliesTo` declared: the Focus profile is bound to one
+      // Knowledge profile. Mismatch (incl. no active Knowledge) is incompatible.
+      if (appliesTo !== null) {
+        if (activeKnowledgeUid !== appliesTo) {
+          return {
+            compatible: false,
+            reason:
+              `Focus profile ${targetProfileUid} declares _appliesTo=${appliesTo} but active ` +
+              `Knowledge profile is ${activeKnowledgeUid ?? "<none>"}. Applying no-filter (AC16 ` +
+              `applies-to mismatch — soft fallback, no throw).`,
+            userMessage:
+              "Focus profile is scoped to a different Knowledge profile — showing the full " +
+              "vault instead. Hard-switch the matching Knowledge profile first to narrow the view.",
+          };
+        }
+        // appliesTo === activeKnowledgeUid → fall through to the subset check.
+      } else if (activeKnowledgeUid === null) {
+        // Layer 2 — no `_appliesTo` constraint AND no active Knowledge profile:
+        // there is no Knowledge scope to validate against. Backward-compatible
+        // pass-through (pre-AC16 behaviour) — apply the Focus filter as declared.
+        return { compatible: true };
+      }
+
+      // Defensive: activeKnowledgeUid is non-null past this point (either
+      // appliesTo matched it, or appliesTo was absent but Knowledge is active).
+      if (activeKnowledgeUid === null) return { compatible: true };
+
+      // Layer 3 (EC3) — active Knowledge resolves to an empty derived set
+      // (no declared ontologies, e.g. not materialised). Cannot validate the
+      // Focus scope against it → no-filter fallback.
+      const knowledgeDerived = await this.computeDerivedSet(activeKnowledgeUid);
+      if (knowledgeDerived.size === 0) {
+        return {
+          compatible: false,
+          reason:
+            `Active Knowledge profile ${activeKnowledgeUid} has an empty effective set ` +
+            `(not materialised) — cannot validate Focus scope. Applying no-filter (AC16 EC3).`,
+          userMessage:
+            "The active Knowledge profile has no materialised ontologies yet — showing the full " +
+            "vault. Hard-switch a Knowledge profile to enable focused filtering.",
+        };
+      }
+
+      // Layer 4 — `_includes ⊆ active Knowledge effective set`. The effective
+      // set includes the TS-floor, so a Focus profile may always reference the
+      // plugin foundations ($exo, $exocmd) regardless of the Knowledge declaration.
+      const knowledgeEffective =
+        await this.resolveEffectiveSet(activeKnowledgeUid);
+      const includes = profile !== null ? profile.includes : [];
+      const missing = includes.filter((u) => !knowledgeEffective.has(u));
+      if (missing.length > 0) {
+        return {
+          compatible: false,
+          reason:
+            `Focus profile ${targetProfileUid} _includes references ontologies outside the active ` +
+            `Knowledge effective set: ${missing.slice(0, 5).join(", ")}` +
+            `${missing.length > 5 ? ", …" : ""}. Applying no-filter (AC16 subset violation).`,
+          userMessage:
+            "Focus profile references ontologies the active Knowledge profile does not provide — " +
+            "showing the full vault to avoid an empty view.",
+        };
+      }
+
+      return { compatible: true };
+    } catch (e) {
+      // AC16 invariant — compat evaluation must never throw / block the switch.
+      // Proceed with the declared filter (failing closed to no-filter would
+      // surprise the user more than a best-effort narrowed view).
+      console.warn(
+        `[FocusProfileSwitchManager] compat evaluation errored for ${targetProfileUid}; ` +
+          `proceeding with the declared filter. ${String(e)}`,
+      );
+      return { compatible: true };
+    }
   }
 
   // === Hard switch orchestration (RFC 22b50a17 Phase 3) ===

--- a/packages/obsidian-plugin/src/infrastructure/adapters/VaultProfileResolver.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/VaultProfileResolver.ts
@@ -4,7 +4,10 @@ import type {
   IProfileResolver,
   ProfileResolution,
 } from "./FocusProfileSwitchManager";
-import { FOCUS_PROFILE_CLASS_UID } from "./FocusProfileSwitchManager";
+import {
+  FOCUS_PROFILE_CLASS_UID,
+  KNOWLEDGE_PROFILE_CLASS_UID,
+} from "./FocusProfileSwitchManager";
 
 /**
  * Vault-backed implementation of {@link IProfileResolver}. Reads
@@ -57,6 +60,13 @@ export class VaultProfileResolver implements IProfileResolver {
       typeof extendsRaw === "string" && extendsRaw.length > 0
         ? this.resolveExtendsToUid(extendsRaw)
         : null;
+    // AC13 (RFC 13da049f Phase 6.5b) — consume `exo__FocusProfile_appliesTo`,
+    // the Knowledge profile UID this Focus profile is scoped to (compat
+    // constraint anchor for the AC16 runtime check). Stored as a wikilink to
+    // the Knowledge profile's UID-named file; normalised to the bare UID.
+    const appliesTo = this.extractFirstWikilink(
+      fm["exo__FocusProfile_appliesTo"],
+    );
     const label =
       typeof fm["exo__Asset_label"] === "string"
         ? (fm["exo__Asset_label"] as string)
@@ -67,6 +77,7 @@ export class VaultProfileResolver implements IProfileResolver {
       includes,
       extends: extendsUid,
       alwaysOnOverlay,
+      appliesTo,
       label,
     };
   }
@@ -101,21 +112,45 @@ export class VaultProfileResolver implements IProfileResolver {
    * fuzzy picker.
    */
   public listFocusProfileFiles(): TFile[] {
+    return this.listProfileFilesByClass(FOCUS_PROFILE_CLASS_UID);
+  }
+
+  /**
+   * Walks the vault returning every KnowledgeProfile asset (RFC 13da049f
+   * Phase 6.5b AC17). Used by the «Switch knowledge profile» palette picker.
+   * Dual-class assets (declaring both Focus + Knowledge) appear in BOTH
+   * `listFocusProfileFiles()` and this list because the discrimination is by
+   * `exo__Instance_class` membership, not exclusivity.
+   */
+  public listKnowledgeProfileFiles(): TFile[] {
+    return this.listProfileFilesByClass(KNOWLEDGE_PROFILE_CLASS_UID);
+  }
+
+  /**
+   * Walks the vault returning assets whose `exo__Instance_class` contains the
+   * given class UID. Shared by {@link listFocusProfileFiles} and
+   * {@link listKnowledgeProfileFiles} so the per-class fuzzy pickers (AC17)
+   * and the dual-class membership rule stay in one place.
+   */
+  public listProfileFilesByClass(classUid: string): TFile[] {
     const out: TFile[] = [];
     for (const file of this.app.vault.getMarkdownFiles()) {
       const fm = this.readFrontmatter(file);
       if (fm === null) continue;
-      if (this.isFocusProfileFrontmatter(fm)) out.push(file);
+      if (this.instanceClassContains(fm, classUid)) out.push(file);
     }
     return out;
   }
 
-  private isFocusProfileFrontmatter(fm: Record<string, unknown>): boolean {
+  private instanceClassContains(
+    fm: Record<string, unknown>,
+    classUid: string,
+  ): boolean {
     const raw = fm["exo__Instance_class"];
     const classes: unknown[] = Array.isArray(raw) ? raw : raw ? [raw] : [];
     for (const c of classes) {
       if (typeof c !== "string") continue;
-      if (c.includes(FOCUS_PROFILE_CLASS_UID)) return true;
+      if (c.includes(classUid)) return true;
     }
     return false;
   }
@@ -145,6 +180,24 @@ export class VaultProfileResolver implements IProfileResolver {
       if (cleaned.length > 0) out.push(cleaned);
     }
     return out;
+  }
+
+  /**
+   * Extract a single wikilink target as a bare UID. Accepts a string
+   * (`[[<uid>]]` / `[[<uid>|alias]]`) or a single-element array (frontmatter
+   * may serialise a 0..1 wikilink either way). Returns null when absent/empty.
+   * Used for `exo__FocusProfile_appliesTo` (AC13, cardinality 0..1).
+   */
+  private extractFirstWikilink(value: unknown): string | null {
+    const first = Array.isArray(value) ? value[0] : value;
+    if (typeof first !== "string") return null;
+    const cleaned = first
+      .trim()
+      .replace(/^\[\[/, "")
+      .replace(/\]\]$/, "")
+      .split("|")[0]
+      .trim();
+    return cleaned.length === 0 ? null : cleaned;
   }
 
   /**

--- a/packages/obsidian-plugin/tests/unit/FocusProfileCommands.test.ts
+++ b/packages/obsidian-plugin/tests/unit/FocusProfileCommands.test.ts
@@ -4,18 +4,34 @@ import {
   type FocusProfileCommandsDeps,
   type IAssetSpacePusher,
 } from "../../src/infrastructure/adapters/FocusProfileCommands";
-import type { FocusProfileSwitchManager } from "../../src/infrastructure/adapters/FocusProfileSwitchManager";
+import {
+  type FocusProfileSwitchManager,
+  HardSwitchAbortedByUser,
+  TsFloorViolationError,
+  UncommittedChangesAbortError,
+} from "../../src/infrastructure/adapters/FocusProfileSwitchManager";
 
 // ─── Test doubles ────────────────────────────────────────────────────────
 
 class FakeSwitchMgr {
   switchCalls: string[] = [];
+  hardSwitchCalls: string[] = [];
   failOnce = false;
+  /** Error to throw from the next hardSwitchKnowledgeProfile call (then cleared). */
+  hardSwitchThrows: Error | null = null;
   async softSwitchFocusProfile(uid: string): Promise<void> {
     this.switchCalls.push(uid);
     if (this.failOnce) {
       this.failOnce = false;
       throw new Error("simulated switch failure");
+    }
+  }
+  async hardSwitchKnowledgeProfile(uid: string): Promise<void> {
+    this.hardSwitchCalls.push(uid);
+    if (this.hardSwitchThrows) {
+      const e = this.hardSwitchThrows;
+      this.hardSwitchThrows = null;
+      throw e;
     }
   }
 }
@@ -48,15 +64,20 @@ interface Harness {
 
 function makeHarness(opts: {
   profiles: FocusProfileChoice[];
+  knowledgeProfiles?: FocusProfileChoice[];
   pickResult?: FocusProfileChoice | null;
   activeFilePath?: string | null;
   asLookups?: Array<[string, string]>;
   listError?: Error;
+  knowledgeListError?: Error;
+  activeKnowledgeUid?: string | null;
+  activeFocusUid?: string | null;
 }): Harness {
   const switchMgr = new FakeSwitchMgr();
   const pushMgr = new FakePushMgr();
   if (opts.asLookups) {
-    for (const [folder, uid] of opts.asLookups) pushMgr.lookups.set(folder, uid);
+    for (const [folder, uid] of opts.asLookups)
+      pushMgr.lookups.set(folder, uid);
   }
   const notices: string[] = [];
   const pickCalls: { options: FocusProfileChoice[]; title: string }[] = [];
@@ -67,11 +88,17 @@ function makeHarness(opts: {
       if (opts.listError) throw opts.listError;
       return opts.profiles;
     },
+    knowledgeProfileLister: async () => {
+      if (opts.knowledgeListError) throw opts.knowledgeListError;
+      return opts.knowledgeProfiles ?? [];
+    },
     fuzzyPick: async (options, title) => {
       pickCalls.push({ options, title });
       return opts.pickResult === undefined ? null : opts.pickResult;
     },
     getActiveFilePath: () => opts.activeFilePath ?? null,
+    getActiveKnowledgeProfileUid: () => opts.activeKnowledgeUid ?? null,
+    getActiveFocusProfileUid: () => opts.activeFocusUid ?? null,
     notify: (m) => notices.push(m),
   };
   return {
@@ -136,7 +163,11 @@ describe("FocusProfileCommands.invokeSwitchProfile", () => {
     await h.cmd.invokeSwitchProfile();
 
     expect(h.pickCalls).toHaveLength(0);
-    expect(h.notices.some((n) => /Could not list profiles.*vault read failed/.test(n))).toBe(true);
+    expect(
+      h.notices.some((n) =>
+        /Could not list profiles.*vault read failed/.test(n),
+      ),
+    ).toBe(true);
   });
 
   it("surfaces softSwitchFocusProfile failure as Notice без re-throw", async () => {
@@ -145,7 +176,9 @@ describe("FocusProfileCommands.invokeSwitchProfile", () => {
     h.switchMgr.failOnce = true;
 
     await expect(h.cmd.invokeSwitchProfile()).resolves.not.toThrow();
-    expect(h.notices.some((n) => /Switch failed.*simulated/.test(n))).toBe(true);
+    expect(h.notices.some((n) => /Switch failed.*simulated/.test(n))).toBe(
+      true,
+    );
   });
 });
 
@@ -170,7 +203,9 @@ describe("FocusProfileCommands.invokePushCurrentAssetSpace", () => {
     await h.cmd.invokePushCurrentAssetSpace();
 
     expect(h.pushMgr.pushedAs).toHaveLength(0);
-    expect(h.notices.some((n) => /Not in an assetspace folder/.test(n))).toBe(true);
+    expect(h.notices.some((n) => /Not in an assetspace folder/.test(n))).toBe(
+      true,
+    );
   });
 
   it("Notice when folder is не declared AssetSpace ABox", async () => {
@@ -182,7 +217,9 @@ describe("FocusProfileCommands.invokePushCurrentAssetSpace", () => {
     await h.cmd.invokePushCurrentAssetSpace();
 
     expect(h.pushMgr.pushedAs).toHaveLength(0);
-    expect(h.notices.some((n) => /not declared as an AssetSpace/.test(n))).toBe(true);
+    expect(h.notices.some((n) => /not declared as an AssetSpace/.test(n))).toBe(
+      true,
+    );
   });
 
   it("invokes pushAssetSpace and shows SHA Notice on success", async () => {
@@ -232,24 +269,226 @@ describe("FocusProfileCommands.invokePushCurrentAssetSpace", () => {
 
 describe("FocusProfileCommands.extractAssetSpaceFolder", () => {
   it("extracts folder from typical path", () => {
-    expect(FocusProfileCommands.extractAssetSpaceFolder("assetspaces/exo/foo.md")).toBe("assetspaces/exo");
+    expect(
+      FocusProfileCommands.extractAssetSpaceFolder("assetspaces/exo/foo.md"),
+    ).toBe("assetspaces/exo");
   });
 
   it("extracts folder from deeply nested path", () => {
-    expect(FocusProfileCommands.extractAssetSpaceFolder("assetspaces/ems/sub/dir/bar.md")).toBe("assetspaces/ems");
+    expect(
+      FocusProfileCommands.extractAssetSpaceFolder(
+        "assetspaces/ems/sub/dir/bar.md",
+      ),
+    ).toBe("assetspaces/ems");
   });
 
   it("normalizes Windows backslash separators", () => {
     // Source `\\` = single backslash in actual string → regex /\\/ matches
-    expect(FocusProfileCommands.extractAssetSpaceFolder("assetspaces\\shared-identities\\file.md")).toBe("assetspaces/shared-identities");
+    expect(
+      FocusProfileCommands.extractAssetSpaceFolder(
+        "assetspaces\\shared-identities\\file.md",
+      ),
+    ).toBe("assetspaces/shared-identities");
   });
 
   it("returns null for path outside assetspaces", () => {
-    expect(FocusProfileCommands.extractAssetSpaceFolder("03 Knowledge/inbox/note.md")).toBeNull();
-    expect(FocusProfileCommands.extractAssetSpaceFolder("inbox/note.md")).toBeNull();
+    expect(
+      FocusProfileCommands.extractAssetSpaceFolder(
+        "03 Knowledge/inbox/note.md",
+      ),
+    ).toBeNull();
+    expect(
+      FocusProfileCommands.extractAssetSpaceFolder("inbox/note.md"),
+    ).toBeNull();
   });
 
   it("returns null when assetspaces/ has no sub-folder", () => {
-    expect(FocusProfileCommands.extractAssetSpaceFolder("assetspaces/loose.md")).toBeNull();
+    expect(
+      FocusProfileCommands.extractAssetSpaceFolder("assetspaces/loose.md"),
+    ).toBeNull();
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// invokeSwitchKnowledgeProfile (RFC 13da049f Phase 6.5b AC17)
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe("FocusProfileCommands.invokeSwitchKnowledgeProfile", () => {
+  it("opens picker from the KnowledgeProfile lister (per-class), not the Focus lister", async () => {
+    const focusProfiles = [{ uid: "f1", label: "focus-only" }];
+    const knowledgeProfiles = [{ uid: "k1", label: "knowledge-one" }];
+    const h = makeHarness({
+      profiles: focusProfiles,
+      knowledgeProfiles,
+      pickResult: knowledgeProfiles[0],
+    });
+    await h.cmd.invokeSwitchKnowledgeProfile();
+
+    expect(h.pickCalls).toHaveLength(1);
+    expect(h.pickCalls[0].options).toEqual(knowledgeProfiles);
+    expect(h.pickCalls[0].title).toMatch(/Switch knowledge profile/);
+  });
+
+  it("invokes hardSwitchKnowledgeProfile with the chosen uid", async () => {
+    const knowledgeProfiles = [{ uid: "k1", label: "knowledge-one" }];
+    const h = makeHarness({
+      profiles: [],
+      knowledgeProfiles,
+      pickResult: knowledgeProfiles[0],
+    });
+    await h.cmd.invokeSwitchKnowledgeProfile();
+
+    expect(h.switchMgr.hardSwitchCalls).toEqual(["k1"]);
+    expect(h.switchMgr.switchCalls).toHaveLength(0); // soft NOT invoked
+  });
+
+  it("shows Notice when no KnowledgeProfile assets in vault", async () => {
+    const h = makeHarness({ profiles: [], knowledgeProfiles: [] });
+    await h.cmd.invokeSwitchKnowledgeProfile();
+
+    expect(h.pickCalls).toHaveLength(0);
+    expect(h.notices.some((n) => /No KnowledgeProfile/.test(n))).toBe(true);
+  });
+
+  it("does nothing when user cancels picker", async () => {
+    const knowledgeProfiles = [{ uid: "k1", label: "k1" }];
+    const h = makeHarness({
+      profiles: [],
+      knowledgeProfiles,
+      pickResult: null,
+    });
+    await h.cmd.invokeSwitchKnowledgeProfile();
+
+    expect(h.switchMgr.hardSwitchCalls).toHaveLength(0);
+  });
+
+  it("maps HardSwitchAbortedByUser to a cancelled Notice (no re-throw)", async () => {
+    const knowledgeProfiles = [{ uid: "k1", label: "k1" }];
+    const h = makeHarness({
+      profiles: [],
+      knowledgeProfiles,
+      pickResult: knowledgeProfiles[0],
+    });
+    h.switchMgr.hardSwitchThrows = new HardSwitchAbortedByUser();
+
+    await expect(h.cmd.invokeSwitchKnowledgeProfile()).resolves.not.toThrow();
+    expect(h.notices.some((n) => /cancelled/i.test(n))).toBe(true);
+  });
+
+  it("maps TsFloorViolationError to a refused Notice", async () => {
+    const knowledgeProfiles = [{ uid: "k1", label: "k1" }];
+    const h = makeHarness({
+      profiles: [],
+      knowledgeProfiles,
+      pickResult: knowledgeProfiles[0],
+    });
+    h.switchMgr.hardSwitchThrows = new TsFloorViolationError(
+      "missing $exo floor",
+    );
+
+    await h.cmd.invokeSwitchKnowledgeProfile();
+    expect(h.notices.some((n) => /refused.*missing \$exo floor/.test(n))).toBe(
+      true,
+    );
+  });
+
+  it("maps UncommittedChangesAbortError to an aborted Notice with file count", async () => {
+    const knowledgeProfiles = [{ uid: "k1", label: "k1" }];
+    const h = makeHarness({
+      profiles: [],
+      knowledgeProfiles,
+      pickResult: knowledgeProfiles[0],
+    });
+    h.switchMgr.hardSwitchThrows = new UncommittedChangesAbortError("dirty", [
+      { asUid: "as1", submodulePath: "assetspaces/x", files: ["a.md", "b.md"] },
+    ]);
+
+    await h.cmd.invokeSwitchKnowledgeProfile();
+    expect(h.notices.some((n) => /aborted.*2 uncommitted file/.test(n))).toBe(
+      true,
+    );
+  });
+
+  it("surfaces generic switch failure as a Notice без re-throw", async () => {
+    const knowledgeProfiles = [{ uid: "k1", label: "k1" }];
+    const h = makeHarness({
+      profiles: [],
+      knowledgeProfiles,
+      pickResult: knowledgeProfiles[0],
+    });
+    h.switchMgr.hardSwitchThrows = new Error("boom");
+
+    await expect(h.cmd.invokeSwitchKnowledgeProfile()).resolves.not.toThrow();
+    expect(h.notices.some((n) => /failed.*boom/.test(n))).toBe(true);
+  });
+
+  it("deprecated invokeHardSwitchProfile delegates to the Knowledge picker", async () => {
+    const knowledgeProfiles = [{ uid: "k1", label: "knowledge-one" }];
+    const h = makeHarness({
+      profiles: [{ uid: "f1", label: "focus-only" }],
+      knowledgeProfiles,
+      pickResult: knowledgeProfiles[0],
+    });
+    await h.cmd.invokeHardSwitchProfile();
+
+    expect(h.pickCalls[0].options).toEqual(knowledgeProfiles);
+    expect(h.switchMgr.hardSwitchCalls).toEqual(["k1"]);
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// invokeShowCurrentState (RFC 13da049f Phase 6.5b AC17)
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe("FocusProfileCommands.invokeShowCurrentState", () => {
+  it("reports both active Knowledge and Focus labels", async () => {
+    const h = makeHarness({
+      profiles: [{ uid: "f1", label: "focus-work" }],
+      knowledgeProfiles: [{ uid: "k1", label: "knowledge-main" }],
+      activeKnowledgeUid: "k1",
+      activeFocusUid: "f1",
+    });
+    await h.cmd.invokeShowCurrentState();
+
+    expect(h.notices).toHaveLength(1);
+    expect(h.notices[0]).toMatch(/Knowledge: knowledge-main/);
+    expect(h.notices[0]).toMatch(/Focus: focus-work/);
+  });
+
+  it("shows (none) for unset slots", async () => {
+    const h = makeHarness({
+      profiles: [],
+      knowledgeProfiles: [],
+      activeKnowledgeUid: null,
+      activeFocusUid: null,
+    });
+    await h.cmd.invokeShowCurrentState();
+
+    expect(h.notices[0]).toMatch(/Knowledge: \(none\)/);
+    expect(h.notices[0]).toMatch(/Focus: \(none\)/);
+  });
+
+  it("falls back to the raw UID when the label is not in the lister", async () => {
+    const h = makeHarness({
+      profiles: [],
+      knowledgeProfiles: [{ uid: "other", label: "other" }],
+      activeKnowledgeUid: "k-missing",
+      activeFocusUid: null,
+    });
+    await h.cmd.invokeShowCurrentState();
+
+    expect(h.notices[0]).toMatch(/Knowledge: k-missing/);
+  });
+
+  it("degrades to «(unknown)» when a lister throws (never crashes)", async () => {
+    const h = makeHarness({
+      profiles: [],
+      knowledgeProfiles: [],
+      knowledgeListError: new Error("vault read failed"),
+      activeKnowledgeUid: "k1",
+      activeFocusUid: null,
+    });
+    await expect(h.cmd.invokeShowCurrentState()).resolves.not.toThrow();
+    expect(h.notices[0]).toMatch(/Knowledge: k1 \(unknown\)/);
   });
 });

--- a/packages/obsidian-plugin/tests/unit/FocusProfileSwitchManager.compat.test.ts
+++ b/packages/obsidian-plugin/tests/unit/FocusProfileSwitchManager.compat.test.ts
@@ -1,0 +1,287 @@
+import type { App } from "obsidian";
+
+import {
+  FocusProfileSwitchManager,
+  type IProfileResolver,
+  type IRdfIndexer,
+  type ISettingsStore,
+  type ProfileResolution,
+  type SwitchSettings,
+} from "../../src/infrastructure/adapters/FocusProfileSwitchManager";
+import { PluginLockManager } from "../../src/infrastructure/adapters/PluginLockManager";
+
+/**
+ * AC16 (RFC 13da049f Phase 6.5b) — soft-switch compatibility check.
+ *
+ * On incompatibility the switch must perform 4 measurable actions WITHOUT
+ * throwing:
+ *   1. console.warn with the violation message
+ *   2. user-facing Notice
+ *   3. RDF re-index with the no-filter set (empty)
+ *   4. resolve successfully (no throw); the Focus selection is still persisted
+ */
+
+// ─── Fakes ───────────────────────────────────────────────────────────────
+
+function makeFakeApp(): { app: App; files: Map<string, string> } {
+  const files = new Map<string, string>();
+  const app = {
+    vault: {
+      adapter: {
+        exists: async (p: string) => files.has(p),
+        read: async (p: string) => {
+          const v = files.get(p);
+          if (v === undefined) throw new Error(`ENOENT: ${p}`);
+          return v;
+        },
+        write: async (p: string, d: string) => {
+          files.set(p, d);
+        },
+        remove: async (p: string) => {
+          files.delete(p);
+        },
+      },
+    },
+  } as unknown as App;
+  return { app, files };
+}
+
+class FakeProfileResolver implements IProfileResolver {
+  constructor(
+    private readonly profiles: Map<string, ProfileResolution>,
+    private readonly throwForUids: Set<string> = new Set(),
+  ) {}
+  async resolve(uid: string): Promise<ProfileResolution | null> {
+    if (this.throwForUids.has(uid)) throw new Error(`boom resolving ${uid}`);
+    return this.profiles.get(uid) ?? null;
+  }
+  async discoverSharedOntologies(): Promise<string[]> {
+    return [];
+  }
+}
+
+class FakeRdfIndexer implements IRdfIndexer {
+  refreshCalls: ReadonlySet<string>[] = [];
+  async refresh(effectiveOntologies: ReadonlySet<string>): Promise<void> {
+    this.refreshCalls.push(new Set(effectiveOntologies));
+  }
+}
+
+class FakeSettingsStore implements ISettingsStore {
+  state: SwitchSettings;
+  constructor(initial?: Partial<SwitchSettings>) {
+    this.state = {
+      activeProfileUid: null,
+      _switchInProgress: false,
+      ...initial,
+    };
+  }
+  async load(): Promise<SwitchSettings> {
+    return { ...this.state };
+  }
+  async save(s: SwitchSettings): Promise<void> {
+    this.state = { ...s };
+  }
+}
+
+const ONTO_EXO = "https://exocortex.my/ontology/exo";
+const ONTO_EXOCMD = "https://exocortex.my/ontology/exocmd";
+const ONTO_KITELEV = "https://exocortex.my/ontology/kitelev";
+const ONTO_TBANK = "https://exocortex.my/ontology/tbank";
+const ONTO_PERSONAL = "https://exocortex.my/ontology/personal";
+
+const FOCUS_F1 = "focus-1";
+const KNOWLEDGE_K1 = "knowledge-1";
+const KNOWLEDGE_K2 = "knowledge-2";
+const KNOWLEDGE_EMPTY = "knowledge-empty";
+const KNOWLEDGE_THROW = "knowledge-throw";
+
+function makeMgr(opts: {
+  profiles: Array<[string, ProfileResolution]>;
+  settings?: Partial<SwitchSettings>;
+  throwForUids?: string[];
+}): {
+  mgr: FocusProfileSwitchManager;
+  rdf: FakeRdfIndexer;
+  settings: FakeSettingsStore;
+  notifyCalls: string[];
+} {
+  const { app } = makeFakeApp();
+  const resolver = new FakeProfileResolver(
+    new Map(opts.profiles),
+    new Set(opts.throwForUids ?? []),
+  );
+  const rdf = new FakeRdfIndexer();
+  const settings = new FakeSettingsStore(opts.settings);
+  const now = new Date("2026-06-05T00:00:00.000Z");
+  const lockMgr = new PluginLockManager({ app, pid: "pid", now: () => now });
+  const notifyCalls: string[] = [];
+  const mgr = new FocusProfileSwitchManager({
+    app,
+    lockMgr,
+    resolver,
+    rdfIndexer: rdf,
+    settingsStore: settings,
+    now: () => now,
+    notify: (m) => notifyCalls.push(m),
+  });
+  return { mgr, rdf, settings, notifyCalls };
+}
+
+function profile(
+  uid: string,
+  fields: Partial<ProfileResolution>,
+): [string, ProfileResolution] {
+  return [
+    uid,
+    {
+      uid,
+      includes: [],
+      alwaysOnOverlay: [],
+      extends: null,
+      ...fields,
+    },
+  ];
+}
+
+describe("FocusProfileSwitchManager.softSwitchFocusProfile — AC16 compat", () => {
+  let warnSpy: jest.SpyInstance;
+  beforeEach(() => {
+    warnSpy = jest.spyOn(console, "warn").mockImplementation(() => undefined);
+  });
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  it("backward-compat: no active Knowledge + no _appliesTo → applies the Focus filter (no warn)", async () => {
+    const { mgr, rdf, notifyCalls } = makeMgr({
+      profiles: [profile(FOCUS_F1, { includes: [ONTO_TBANK] })],
+      // no activeKnowledgeProfileUid set
+    });
+    await expect(mgr.softSwitchFocusProfile(FOCUS_F1)).resolves.toBeUndefined();
+
+    expect(rdf.refreshCalls).toHaveLength(1);
+    const set = rdf.refreshCalls[0];
+    expect(set.has(ONTO_TBANK)).toBe(true); // narrowed filter applied
+    expect(set.has(ONTO_EXO)).toBe(true); // TS-floor
+    expect(warnSpy).not.toHaveBeenCalled();
+    expect(notifyCalls.some((n) => /Switched to/.test(n))).toBe(true);
+  });
+
+  it("violation — _appliesTo mismatch → 4 actions (warn, Notice, no-filter, no throw)", async () => {
+    const { mgr, rdf, settings, notifyCalls } = makeMgr({
+      profiles: [
+        profile(FOCUS_F1, {
+          includes: [ONTO_KITELEV],
+          appliesTo: KNOWLEDGE_K1,
+        }),
+        profile(KNOWLEDGE_K2, { includes: [ONTO_KITELEV] }),
+      ],
+      settings: { activeKnowledgeProfileUid: KNOWLEDGE_K2 },
+    });
+
+    // Action #4 — resolves successfully (no throw).
+    await expect(mgr.softSwitchFocusProfile(FOCUS_F1)).resolves.toBeUndefined();
+
+    // Action #1 — console.warn with compatibility message.
+    expect(warnSpy).toHaveBeenCalled();
+    expect(String(warnSpy.mock.calls[0][0])).toMatch(
+      /applies-to mismatch|_appliesTo/,
+    );
+    // Action #2 — user-facing Notice.
+    expect(notifyCalls.some((n) => /full vault/i.test(n))).toBe(true);
+    // Action #3 — RDF re-index with empty (no-filter) set.
+    expect(rdf.refreshCalls).toHaveLength(1);
+    expect(rdf.refreshCalls[0].size).toBe(0);
+    // Selection still persisted (Focus slot).
+    expect(settings.state.activeFocusProfileUid).toBe(FOCUS_F1);
+    expect(settings.state._switchInProgress).toBe(false);
+    // No misleading «Switched to» success Notice.
+    expect(notifyCalls.some((n) => /Switched to/.test(n))).toBe(false);
+  });
+
+  it("compatible — _appliesTo matches active Knowledge AND includes ⊆ effective → narrowed filter", async () => {
+    const { mgr, rdf } = makeMgr({
+      profiles: [
+        profile(FOCUS_F1, {
+          includes: [ONTO_KITELEV],
+          appliesTo: KNOWLEDGE_K1,
+        }),
+        profile(KNOWLEDGE_K1, { includes: [ONTO_KITELEV, ONTO_TBANK] }),
+      ],
+      settings: { activeKnowledgeProfileUid: KNOWLEDGE_K1 },
+    });
+    await mgr.softSwitchFocusProfile(FOCUS_F1);
+
+    expect(rdf.refreshCalls).toHaveLength(1);
+    const set = rdf.refreshCalls[0];
+    expect(set.has(ONTO_KITELEV)).toBe(true); // narrowed filter, not empty
+    expect(set.size).toBeGreaterThan(0);
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it("violation — includes ⊄ active Knowledge effective set → no-filter", async () => {
+    const { mgr, rdf, notifyCalls } = makeMgr({
+      profiles: [
+        // F1 references ONTO_PERSONAL which K1 does not provide.
+        profile(FOCUS_F1, { includes: [ONTO_PERSONAL] }),
+        profile(KNOWLEDGE_K1, { includes: [ONTO_KITELEV, ONTO_TBANK] }),
+      ],
+      settings: { activeKnowledgeProfileUid: KNOWLEDGE_K1 },
+    });
+    await mgr.softSwitchFocusProfile(FOCUS_F1);
+
+    expect(rdf.refreshCalls[0].size).toBe(0); // no-filter
+    expect(warnSpy).toHaveBeenCalled();
+    expect(String(warnSpy.mock.calls[0][0])).toMatch(
+      /subset violation|outside the active/,
+    );
+    expect(notifyCalls.some((n) => /full vault/i.test(n))).toBe(true);
+  });
+
+  it("compatible — includes references a TS-floor ontology even if Knowledge omits it", async () => {
+    const { mgr, rdf } = makeMgr({
+      profiles: [
+        // F1 includes $exocmd (a TS-floor ontology) — always in effective set.
+        profile(FOCUS_F1, { includes: [ONTO_EXOCMD] }),
+        profile(KNOWLEDGE_K1, { includes: [ONTO_KITELEV] }),
+      ],
+      settings: { activeKnowledgeProfileUid: KNOWLEDGE_K1 },
+    });
+    await mgr.softSwitchFocusProfile(FOCUS_F1);
+
+    expect(rdf.refreshCalls[0].size).toBeGreaterThan(0); // applied, not no-filter
+  });
+
+  it("EC3 — active Knowledge has empty effective set (not materialized) → no-filter", async () => {
+    const { mgr, rdf, notifyCalls } = makeMgr({
+      profiles: [
+        profile(FOCUS_F1, { includes: [ONTO_KITELEV] }),
+        // Empty Knowledge profile — derived set is empty.
+        profile(KNOWLEDGE_EMPTY, { includes: [], alwaysOnOverlay: [] }),
+      ],
+      settings: { activeKnowledgeProfileUid: KNOWLEDGE_EMPTY },
+    });
+    await mgr.softSwitchFocusProfile(FOCUS_F1);
+
+    expect(rdf.refreshCalls[0].size).toBe(0); // no-filter
+    expect(warnSpy).toHaveBeenCalled();
+    expect(String(warnSpy.mock.calls[0][0])).toMatch(
+      /EC3|empty effective set|not materialised/,
+    );
+    expect(notifyCalls.some((n) => /full vault/i.test(n))).toBe(true);
+  });
+
+  it("never throws — compat evaluation error proceeds with the declared filter", async () => {
+    const { mgr, rdf } = makeMgr({
+      profiles: [profile(FOCUS_F1, { includes: [ONTO_TBANK] })],
+      settings: { activeKnowledgeProfileUid: KNOWLEDGE_THROW },
+      throwForUids: [KNOWLEDGE_THROW], // resolving the active Knowledge throws
+    });
+    // Must resolve (no throw) AND apply the declared filter (not no-filter).
+    await expect(mgr.softSwitchFocusProfile(FOCUS_F1)).resolves.toBeUndefined();
+    expect(rdf.refreshCalls).toHaveLength(1);
+    expect(rdf.refreshCalls[0].has(ONTO_TBANK)).toBe(true);
+    expect(rdf.refreshCalls[0].size).toBeGreaterThan(0);
+  });
+});

--- a/packages/obsidian-plugin/tests/unit/VaultProfileResolver.test.ts
+++ b/packages/obsidian-plugin/tests/unit/VaultProfileResolver.test.ts
@@ -1,5 +1,8 @@
 import { VaultProfileResolver } from "../../src/infrastructure/adapters/VaultProfileResolver";
-import { FOCUS_PROFILE_CLASS_UID } from "../../src/infrastructure/adapters/FocusProfileSwitchManager";
+import {
+  FOCUS_PROFILE_CLASS_UID,
+  KNOWLEDGE_PROFILE_CLASS_UID,
+} from "../../src/infrastructure/adapters/FocusProfileSwitchManager";
 
 interface FakeFile {
   path: string;
@@ -79,7 +82,9 @@ describe("VaultProfileResolver.listFocusProfileFiles", () => {
 
   it("findFocusProfileFileByUid returns null when UID is empty", () => {
     const app = makeApp([]);
-    expect(new VaultProfileResolver(app).findFocusProfileFileByUid("")).toBeNull();
+    expect(
+      new VaultProfileResolver(app).findFocusProfileFileByUid(""),
+    ).toBeNull();
   });
 
   it("findFocusProfileFileByUid matches by exo__Asset_uid", () => {
@@ -173,6 +178,102 @@ describe("VaultProfileResolver.resolve", () => {
     ]);
     const r = await new VaultProfileResolver(app).resolve("p1");
     expect(r?.extends).toBeNull();
+  });
+});
+
+describe("VaultProfileResolver.resolve — appliesTo (RFC 13da049f AC13)", () => {
+  it("reads exo__FocusProfile_appliesTo as a bare Knowledge UID", async () => {
+    const app = makeApp([
+      {
+        file: { path: "p.md", basename: "p" },
+        fm: {
+          exo__Instance_class: `[[${FOCUS_PROFILE_CLASS_UID}]]`,
+          exo__Asset_uid: "focus-1",
+          exo__FocusProfile_appliesTo: "[[knowledge-9|exo__KnowledgeProfile]]",
+        },
+      },
+    ]);
+    const r = await new VaultProfileResolver(app).resolve("focus-1");
+    expect(r?.appliesTo).toBe("knowledge-9");
+  });
+
+  it("accepts a single-element array form for appliesTo", async () => {
+    const app = makeApp([
+      {
+        file: { path: "p.md", basename: "p" },
+        fm: {
+          exo__Instance_class: `[[${FOCUS_PROFILE_CLASS_UID}]]`,
+          exo__Asset_uid: "focus-1",
+          exo__FocusProfile_appliesTo: ["[[knowledge-9]]"],
+        },
+      },
+    ]);
+    const r = await new VaultProfileResolver(app).resolve("focus-1");
+    expect(r?.appliesTo).toBe("knowledge-9");
+  });
+
+  it("returns appliesTo=null when the field is absent", async () => {
+    const app = makeApp([
+      {
+        file: { path: "p.md", basename: "p" },
+        fm: {
+          exo__Instance_class: `[[${FOCUS_PROFILE_CLASS_UID}]]`,
+          exo__Asset_uid: "focus-1",
+        },
+      },
+    ]);
+    const r = await new VaultProfileResolver(app).resolve("focus-1");
+    expect(r?.appliesTo).toBeNull();
+  });
+});
+
+describe("VaultProfileResolver.listKnowledgeProfileFiles (RFC 13da049f AC17)", () => {
+  it("returns files whose Instance_class contains the KnowledgeProfile UID", () => {
+    const app = makeApp([
+      {
+        file: { path: "k.md", basename: "k" },
+        fm: {
+          exo__Instance_class: `[[${KNOWLEDGE_PROFILE_CLASS_UID}|exo__KnowledgeProfile]]`,
+          exo__Asset_uid: "k1",
+        },
+      },
+      {
+        file: { path: "f.md", basename: "f" },
+        fm: {
+          exo__Instance_class: `[[${FOCUS_PROFILE_CLASS_UID}]]`,
+          exo__Asset_uid: "f1",
+        },
+      },
+    ]);
+    const resolver = new VaultProfileResolver(app);
+    expect(resolver.listKnowledgeProfileFiles().map((f) => f.path)).toEqual([
+      "k.md",
+    ]);
+    expect(resolver.listFocusProfileFiles().map((f) => f.path)).toEqual([
+      "f.md",
+    ]);
+  });
+
+  it("dual-class asset appears in BOTH Focus and Knowledge lists", () => {
+    const app = makeApp([
+      {
+        file: { path: "dual.md", basename: "dual" },
+        fm: {
+          exo__Instance_class: [
+            `[[${FOCUS_PROFILE_CLASS_UID}|exo__FocusProfile]]`,
+            `[[${KNOWLEDGE_PROFILE_CLASS_UID}|exo__KnowledgeProfile]]`,
+          ],
+          exo__Asset_uid: "dual-1",
+        },
+      },
+    ]);
+    const resolver = new VaultProfileResolver(app);
+    expect(resolver.listFocusProfileFiles().map((f) => f.path)).toEqual([
+      "dual.md",
+    ]);
+    expect(resolver.listKnowledgeProfileFiles().map((f) => f.path)).toEqual([
+      "dual.md",
+    ]);
   });
 });
 


### PR DESCRIPTION
## Summary

Completes **RFC 13da049f Phase 6.5b** UX layer (PR-C) — the final slice of the Knowledge/Focus profile split. Builds on AC14 (#3371, dual active-state) + AC15 (#3369, soft/hard method split), both already merged.

### AC13 — FocusProfile filter-only narrowing
- `exo__FocusProfile` JSDoc/semantics narrowed to **soft switch / RDF query-time filter only** (materialisation is `exo__KnowledgeProfile`'s job — hard switch).
- `VaultProfileResolver` now consumes `exo__FocusProfile_appliesTo` (UID `bd26037e-…`) → `ProfileResolution.appliesTo` (Knowledge compat anchor).
- Exported `KNOWLEDGE_PROFILE_CLASS_UID` (`b8884976-…`).

### AC16 — soft-switch compatibility check (WARN + fallback, **never throw**)
`softSwitchFocusProfile` validates the target against the active Knowledge profile (`activeKnowledgeProfileUid`, surfaced from `localDataStore.getActiveKnowledgeProfileUid()`):
- `_appliesTo` declared & ≠ active Knowledge → incompatible.
- target `_includes ⊄ active Knowledge effective set` → incompatible.
- **EC3** — active Knowledge has empty/not-materialised effective set → incompatible.

On incompatibility the **4 measurable actions** fire: `console.warn` → user `Notice` → RDF re-index with **no-filter** (empty set → full vault) → `softSwitchFocusProfile` **resolves successfully** (no throw). No active Knowledge + no `_appliesTo` stays a backward-compatible pass-through (the declared filter is applied — pre-AC16 behaviour preserved).

### AC17 — dual palette commands
- **«Exocortex: Switch knowledge profile»** (hard) → per-class picker filtered to KnowledgeProfile instances → `hardSwitchKnowledgeProfile`.
- **«Exocortex: Switch focus profile»** (soft) → per-class picker filtered to FocusProfile instances → `softSwitchFocusProfile`.
- **«Exocortex: Show current state»** → Notice with active Knowledge + Focus labels.
- Dual-class assets surface in **both** pickers (filter by `exo__Instance_class` membership). Legacy hard-switch entry preserved via deprecated `invokeHardSwitchProfile` alias.

## Test plan
- [x] `VaultProfileResolver` — `appliesTo` read (string/array/absent), `listKnowledgeProfileFiles`, dual-class in both lists
- [x] AC16 compat (`FocusProfileSwitchManager.compat.test.ts`) — appliesTo mismatch / includes-not-subset / EC3 / compatible / TS-floor exemption / backward-compat pass-through / never-throws
- [x] AC17 commands — per-class picker source, error mapping, Show current state ((none)/UID/(unknown)), deprecated alias delegation
- [x] Existing FocusProfile suites green (soft/hard/aliases) — no regressions
- [x] `check:types` clean · `eslint --max-warnings=0` clean · full plugin unit suite 5416 passed
- [ ] CI 14/14 + code-reviewer + advisor round-2

🤖 Generated with [Claude Code](https://claude.com/claude-code)