### PR TITLE
feat(bootstrap): plugin Bootstrap + Add-AssetSpace palette + modals (RFC 13da049f Phase 6.2/6.3)

### DIFF
--- a/packages/obsidian-plugin/src/ExocortexPlugin.ts
+++ b/packages/obsidian-plugin/src/ExocortexPlugin.ts
@@ -109,7 +109,14 @@ import { createAssetSpacePusher } from "./infrastructure/adapters/AssetSpacePush
 import { LocalSecretsStore } from "./infrastructure/adapters/LocalSecretsStore";
 import { SwitchCacheLayer } from "./infrastructure/adapters/SwitchCacheLayer";
 import { ClearSwitchCacheConfirmModal } from "./infrastructure/adapters/ClearSwitchCacheConfirmModal";
-import { AssetSpaceManager } from "./infrastructure/adapters/AssetSpaceManager";
+import {
+  AssetSpaceManager,
+  parseGitHubURL,
+} from "./infrastructure/adapters/AssetSpaceManager";
+import { BootstrapAssetSpaceCommands } from "./infrastructure/adapters/BootstrapAssetSpaceCommands";
+import { BootstrapVaultModal } from "./presentation/modals/BootstrapVaultModal";
+import { AddAssetSpaceModal } from "./presentation/modals/AddAssetSpaceModal";
+import { SimpleConfirmModal } from "./presentation/modals/SimpleConfirmModal";
 import { AssetSpaceMaterializationTracker } from "./infrastructure/adapters/AssetSpaceMaterializationTracker";
 import { injectAssetSpaceMaterializationTriples } from "./infrastructure/adapters/injectAssetSpaceMaterializationTriples";
 import { AssetSpaceStatusIconPatch } from "./presentation/asset-space/AssetSpaceStatusIconPatch";
@@ -2865,11 +2872,88 @@ export default class ExocortexPlugin extends Plugin {
       },
     });
 
+    // RFC 13da049f Phase 6.2/6.3 — Bootstrap vault + Add AssetSpace by URL.
+    // Desktop-only: both reuse the Phase 5 hard-switch deps (AssetSpaceManager
+    // REST pull + GitSubmoduleOps staging move / .gitmodules). Registered only
+    // when those deps are wired (desktop + vault.adapter.basePath available).
+    if (hardSwitchDeps !== null) {
+      this.registerBootstrapCommands(hardSwitchDeps, localDataStore);
+    }
+
     this.logger.info(
       "[ExocortexPlugin] FocusProfile palette commands registered",
     );
 
     return reapplyActiveProfileFilter;
+  }
+
+  /**
+   * Wire + register the RFC 13da049f Phase 6.2/6.3 palette commands
+   * («Bootstrap vault» + «Add AssetSpace by URL»). Reuses the Phase 5
+   * `AssetSpaceManager` (REST tarball pull) and `GitSubmoduleOps` (staging
+   * move + `.gitmodules` text manipulation) — no REST/security logic is
+   * duplicated. Desktop-only; the caller gates on `hardSwitchDeps !== null`.
+   */
+  private registerBootstrapCommands(
+    hardSwitchDeps: {
+      assetSpaceManager: AssetSpaceManager;
+      gitOps: GitSubmoduleOps;
+    },
+    localDataStore: PluginLocalDataStore,
+  ): void {
+    const deriveFolderName = (url: string): string => {
+      const { repo } = parseGitHubURL(url);
+      return repo.startsWith("exoas-") ? repo.slice("exoas-".length) : repo;
+    };
+
+    const bootstrapCommands = new BootstrapAssetSpaceCommands({
+      puller: hardSwitchDeps.assetSpaceManager,
+      gitOps: hardSwitchDeps.gitOps,
+      localStore: localDataStore,
+      vaultExists: (p) => this.app.vault.adapter.exists(p),
+      listFolder: (dir) => this.app.vault.adapter.list(dir),
+      isGitVault: () => this.app.vault.adapter.exists(".git"),
+      validateUrl: (url) => GitHubRestClient.validateRepoURL(url),
+      deriveFolderName,
+      promptBootstrapUrls: () =>
+        new Promise((resolve) => {
+          new BootstrapVaultModal(this.app, resolve).open();
+        }),
+      promptAddAssetSpaceUrl: () =>
+        new Promise((resolve) => {
+          new AddAssetSpaceModal(this.app, deriveFolderName, resolve).open();
+        }),
+      confirm: (message) =>
+        new Promise((resolve) => {
+          new SimpleConfirmModal(
+            this.app,
+            {
+              title: "Fetch tracked AssetSpaces?",
+              body: message,
+              confirmLabel: "Fetch",
+            },
+            resolve,
+          ).open();
+        }),
+      notify: (message) => this.notifier.info(message),
+      onMaterialized: () => this.refreshAndInjectAssetSpaceMaterialization(),
+    });
+
+    this.addCommand({
+      id: "bootstrap-vault",
+      name: "Bootstrap vault",
+      callback: () => {
+        void bootstrapCommands.invokeBootstrap();
+      },
+    });
+
+    this.addCommand({
+      id: "add-assetspace",
+      name: "Add assetspace by URL",
+      callback: () => {
+        void bootstrapCommands.invokeAddAssetSpace();
+      },
+    });
   }
 
   /**

--- a/packages/obsidian-plugin/src/infrastructure/adapters/BootstrapAssetSpaceCommands.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/BootstrapAssetSpaceCommands.ts
@@ -121,9 +121,9 @@ export interface BootstrapAssetSpaceCommandsDeps {
 }
 
 /** TS-floor folders materialised by a cold bootstrap (fixed, mirrors CLI). */
-const TS_FLOOR_EXO_FOLDER = "exo";
-const TS_FLOOR_EXOCMD_FOLDER = "exocmd";
 const ASSETSPACES_DIR = "assetspaces";
+const TS_FLOOR_EXO_PATH = `${ASSETSPACES_DIR}/exo`;
+const TS_FLOOR_EXOCMD_PATH = `${ASSETSPACES_DIR}/exocmd`;
 
 export type VaultBootstrapState =
   | "empty"
@@ -196,15 +196,17 @@ export class BootstrapAssetSpaceCommands {
       );
     }
 
+    // Materialise exo then exocmd. If exocmd fails after exo succeeded, the
+    // vault is half-bootstrapped: a re-run of «Bootstrap vault» would now
+    // classify it as `bootstrapped` and refuse, so the recovery path (use
+    // «Add assetspace by URL» for the missing floor) must be surfaced
+    // explicitly here. Re-index either way so the part that landed is picked up.
+    let exo: MaterializeResult | null = null;
     try {
-      const exo = await this.materialize(
-        urls.exoUrl,
-        TS_FLOOR_EXO_FOLDER,
-        isGit,
-      );
+      exo = await this.materialize(urls.exoUrl, TS_FLOOR_EXO_PATH, isGit);
       const exocmd = await this.materialize(
         urls.exocmdUrl,
-        TS_FLOOR_EXOCMD_FOLDER,
+        TS_FLOOR_EXOCMD_PATH,
         isGit,
       );
       this.d.notify(
@@ -212,7 +214,15 @@ export class BootstrapAssetSpaceCommands {
           "Reload Obsidian if the new assets do not appear. Add any further AssetSpaces manually — dependencies are not auto-resolved.",
       );
     } catch (e) {
-      this.d.notify(`Bootstrap failed: ${this.msg(e)}`);
+      if (exo !== null) {
+        this.d.notify(
+          `Bootstrap partially completed — ${TS_FLOOR_EXO_PATH} materialised, but ${TS_FLOOR_EXOCMD_PATH} failed: ${this.msg(e)}. ` +
+            "Use «Add assetspace by URL» to add the missing exocmd assetspace.",
+        );
+      } else {
+        this.d.notify(`Bootstrap failed: ${this.msg(e)}`);
+      }
+      await this.runOnMaterialized();
       return;
     }
     await this.runOnMaterialized();
@@ -246,7 +256,11 @@ export class BootstrapAssetSpaceCommands {
     }
 
     try {
-      const m = await this.materialize(res.url, folderName, isGit);
+      const m = await this.materialize(
+        res.url,
+        `${ASSETSPACES_DIR}/${folderName}`,
+        isGit,
+      );
       this.d.notify(
         `AssetSpace added — ${m.folderName}@${m.sha} ← ${res.url}. ` +
           "Add any AssetSpaces it depends on manually — dependencies are not auto-resolved.",
@@ -283,10 +297,11 @@ export class BootstrapAssetSpaceCommands {
 
     let fetched = 0;
     for (const entry of entries) {
-      const folderName = basename(entry.submodulePath);
-      if (folderName.length === 0) continue;
+      if (entry.submodulePath.length === 0) continue;
       try {
-        await this.materialize(entry.url, folderName, true);
+        // Materialise into the exact path `.gitmodules` declares (preserves
+        // any nested layout) rather than re-deriving from the basename.
+        await this.materialize(entry.url, entry.submodulePath, true);
         fetched++;
       } catch (e) {
         this.d.notify(`Fetch failed for ${entry.submodulePath}: ${this.msg(e)}`);
@@ -299,20 +314,20 @@ export class BootstrapAssetSpaceCommands {
   }
 
   /**
-   * Pull `url`'s tarball into a staging dir, move it into `assetspaces/<folder>`,
-   * then register it — append the `.gitmodules` entry (git vault) OR record the
-   * file-only registry entry (AC10 non-git vault). The staging-dir `asUid` label
-   * is synthetic (`bootstrap-<folder>`) since a cold bootstrap has no AssetSpace
-   * UID yet — it is only used to name the temp dir for orphan tracking.
+   * Pull `url`'s tarball into a staging dir, move it into the vault-relative
+   * `submodulePath` (e.g. `assetspaces/exo`), then register it — append the
+   * `.gitmodules` entry (git vault) OR record the file-only registry entry
+   * (AC10 non-git vault). The staging-dir `asUid` label is synthetic
+   * (`bootstrap-<basename>`) since a cold bootstrap has no AssetSpace UID yet —
+   * it only names the temp dir for orphan tracking.
    */
   private async materialize(
     url: string,
-    folderName: string,
+    submodulePath: string,
     isGit: boolean,
   ): Promise<MaterializeResult> {
-    const submodulePath = `${ASSETSPACES_DIR}/${folderName}`;
     const result = await this.d.puller.pullAssetSpace(
-      `bootstrap-${folderName}`,
+      `bootstrap-${basename(submodulePath)}`,
       url,
       this.ref,
     );

--- a/packages/obsidian-plugin/src/infrastructure/adapters/BootstrapAssetSpaceCommands.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/BootstrapAssetSpaceCommands.ts
@@ -1,0 +1,377 @@
+/**
+ * BootstrapAssetSpaceCommands — command-palette logic handler for RFC 13da049f
+ * Phase 6.2 (Bootstrap vault) + Phase 6.3 (Add AssetSpace by URL), plugin side.
+ *
+ * Mirrors the CLI equivalents (`exocortex bootstrap` + `exocortex assetspace-add`,
+ * v16.57.0) but runs inside Obsidian, reusing the Phase 5 plugin infrastructure
+ * instead of duplicating the REST/tarball/security logic:
+ *   - {@link IAssetSpacePuller.pullAssetSpace} (AssetSpaceManager) — REST tarball
+ *     pull + zip-slip-safe extraction into a staging dir.
+ *   - {@link IGitSubmoduleOps} (GitSubmoduleOps) — `renameIntoVault` (staging →
+ *     vault) + `.gitmodules` read/append text manipulation.
+ *
+ * Pure logic — does NOT import Obsidian's Modal / Plugin / vault runtime.
+ * Everything platform-specific (modal UI, vault.adapter probing, URL allowlist)
+ * is injected via {@link BootstrapAssetSpaceCommandsDeps} so the class is fully
+ * unit-testable with fakes. Real wiring lives in `ExocortexPlugin`.
+ *
+ * Desktop-only (Phase 6 scope, like Phase 5): the injected puller / gitOps throw
+ * on mobile, and the plugin registers these commands only when desktop deps are
+ * available.
+ *
+ * Commands provided:
+ *   1. `Exocortex: Bootstrap vault` — cold-start an empty vault with the TS-floor
+ *      AssetSpaces (exo + exocmd). Handles three vault states:
+ *        - empty → prompt for exo + exocmd URLs (EC7: fields empty, kitelev URLs
+ *          shown as placeholder examples only) → materialise both.
+ *        - clone-needs-fetch (EC2) → `.gitmodules` populated but folders empty
+ *          (cloned without `--recurse-submodules`) → confirm → re-materialise
+ *          each tracked AssetSpace from its preserved URL.
+ *        - bootstrapped → no-op notice (use «Add AssetSpace» for more spaces).
+ *      Non-git vaults (AC10 / M19): file-only mode — REST pulls without
+ *      `.gitmodules`, tracked device-locally.
+ *   2. `Exocortex: Add AssetSpace by URL` — pull a single AssetSpace into a
+ *      URL-derived folder, append the `.gitmodules` entry (idempotent).
+ */
+
+/** Subset of {@link AssetSpaceManager} used here (REST tarball pull). */
+export interface IAssetSpacePuller {
+  pullAssetSpace(
+    asUid: string,
+    asGitUrl: string,
+    ref?: string,
+  ): Promise<{ asUid: string; stagingPath: string; sha: string }>;
+}
+
+/** Subset of {@link GitSubmoduleOps} used here (staging move + `.gitmodules`). */
+export interface IGitSubmoduleOps {
+  renameIntoVault(stagingPath: string, submodulePath: string): Promise<void>;
+  readGitmodulesEntries(): Promise<Array<{ submodulePath: string; url: string }>>;
+  appendGitmodulesEntry(
+    submodulePath: string,
+    url: string,
+  ): Promise<{ added: boolean }>;
+}
+
+/** Subset of {@link PluginLocalDataStore} used for AC10 file-only tracking. */
+export interface IFileOnlyAssetSpaceStore {
+  upsertFileOnlyAssetSpace(entry: {
+    folderName: string;
+    url: string;
+    sha: string;
+    addedAt: string;
+  }): Promise<void>;
+}
+
+/** Result of a single AssetSpace materialisation. */
+export interface MaterializeResult {
+  /** Vault-relative folder the AssetSpace was materialised into. */
+  folderName: string;
+  /** 7-char tarball SHA recorded at pull time. */
+  sha: string;
+}
+
+export interface BootstrapAssetSpaceCommandsDeps {
+  puller: IAssetSpacePuller;
+  gitOps: IGitSubmoduleOps;
+  localStore: IFileOnlyAssetSpaceStore;
+  /** `vault.adapter.exists(path)` wrapper. */
+  vaultExists: (path: string) => Promise<boolean>;
+  /** `vault.adapter.list(dir)` wrapper. */
+  listFolder: (
+    dir: string,
+  ) => Promise<{ files: string[]; folders: string[] }>;
+  /** True when the vault root is a git repository (`.git` exists). */
+  isGitVault: () => Promise<boolean>;
+  /**
+   * Validate a GitHub repo URL against the canonical allowlist. Throws on
+   * invalid. Injected (not duplicated) so the single source of truth stays in
+   * `GitHubRestClient.validateRepoURL`.
+   */
+  validateUrl: (url: string) => void;
+  /**
+   * Derive a folder name from a repo URL — strips the `exoas-` prefix
+   * (`exoas-pmbok` → `pmbok`). Injected to avoid duplicating the URL parser.
+   */
+  deriveFolderName: (url: string) => string;
+  /**
+   * Open the bootstrap modal (two empty URL fields + example placeholders).
+   * Resolves the entered URLs, or null if the user cancelled.
+   */
+  promptBootstrapUrls: () => Promise<{
+    exoUrl: string;
+    exocmdUrl: string;
+  } | null>;
+  /**
+   * Open the add-AssetSpace modal (single URL field). Resolves the entered
+   * URL, or null if the user cancelled.
+   */
+  promptAddAssetSpaceUrl: () => Promise<{ url: string } | null>;
+  /** Yes/no confirmation gate (used by the EC2 clone-needs-fetch flow). */
+  confirm: (message: string) => Promise<boolean>;
+  /** User-facing Notice. */
+  notify: (message: string) => void;
+  /**
+   * Optional hook fired after a successful materialisation so the plugin can
+   * re-index the freshly added assets. Failures are swallowed (best-effort).
+   */
+  onMaterialized?: () => Promise<void>;
+  /** Branch ref to pull from. Default `"main"`. */
+  ref?: string;
+}
+
+/** TS-floor folders materialised by a cold bootstrap (fixed, mirrors CLI). */
+const TS_FLOOR_EXO_FOLDER = "exo";
+const TS_FLOOR_EXOCMD_FOLDER = "exocmd";
+const ASSETSPACES_DIR = "assetspaces";
+
+export type VaultBootstrapState =
+  | "empty"
+  | "bootstrapped"
+  | "clone-needs-fetch";
+
+export class BootstrapAssetSpaceCommands {
+  private readonly d: BootstrapAssetSpaceCommandsDeps;
+  private readonly ref: string;
+
+  constructor(deps: BootstrapAssetSpaceCommandsDeps) {
+    this.d = deps;
+    this.ref = deps.ref ?? "main";
+  }
+
+  /**
+   * Classify the current vault for the bootstrap command:
+   *   - `empty` — no `.gitmodules` entries AND no materialised `assetspaces/*`.
+   *   - `clone-needs-fetch` — `.gitmodules` has entries but no folder is
+   *     materialised (EC2: cloned without `--recurse-submodules`).
+   *   - `bootstrapped` — at least one `assetspaces/<ns>/` folder has content.
+   */
+  async detectVaultState(): Promise<VaultBootstrapState> {
+    const entries = await this.d.gitOps.readGitmodulesEntries();
+    const materialized = await this.hasMaterializedAssetSpaces();
+    if (entries.length > 0) {
+      return materialized ? "bootstrapped" : "clone-needs-fetch";
+    }
+    return materialized ? "bootstrapped" : "empty";
+  }
+
+  /** Command 1 — `Exocortex: Bootstrap vault`. */
+  async invokeBootstrap(): Promise<void> {
+    let state: VaultBootstrapState;
+    try {
+      state = await this.detectVaultState();
+    } catch (e) {
+      this.d.notify(`Bootstrap: could not inspect vault — ${this.msg(e)}`);
+      return;
+    }
+
+    if (state === "bootstrapped") {
+      this.d.notify(
+        "Vault already has AssetSpaces materialised — use «Exocortex: Add AssetSpace by URL» to add more.",
+      );
+      return;
+    }
+
+    if (state === "clone-needs-fetch") {
+      await this.fetchTrackedAssetSpaces();
+      return;
+    }
+
+    // state === "empty" — prompt for the TS-floor URLs.
+    const urls = await this.d.promptBootstrapUrls();
+    if (urls === null) return; // user cancelled
+
+    try {
+      this.d.validateUrl(urls.exoUrl);
+      this.d.validateUrl(urls.exocmdUrl);
+    } catch (e) {
+      this.d.notify(`Bootstrap: invalid URL — ${this.msg(e)}`);
+      return;
+    }
+
+    const isGit = await this.d.isGitVault();
+    if (!isGit) {
+      this.d.notify(
+        "Vault is not a git repository — bootstrapping in file-only mode (no .gitmodules; AssetSpaces tracked device-locally).",
+      );
+    }
+
+    try {
+      const exo = await this.materialize(
+        urls.exoUrl,
+        TS_FLOOR_EXO_FOLDER,
+        isGit,
+      );
+      const exocmd = await this.materialize(
+        urls.exocmdUrl,
+        TS_FLOOR_EXOCMD_FOLDER,
+        isGit,
+      );
+      this.d.notify(
+        `Bootstrap complete — ${exo.folderName}@${exo.sha} + ${exocmd.folderName}@${exocmd.sha}. ` +
+          "Reload Obsidian if the new assets do not appear. Add any further AssetSpaces manually — dependencies are not auto-resolved.",
+      );
+    } catch (e) {
+      this.d.notify(`Bootstrap failed: ${this.msg(e)}`);
+      return;
+    }
+    await this.runOnMaterialized();
+  }
+
+  /** Command 2 — `Exocortex: Add AssetSpace by URL`. */
+  async invokeAddAssetSpace(): Promise<void> {
+    const res = await this.d.promptAddAssetSpaceUrl();
+    if (res === null) return; // user cancelled
+
+    try {
+      this.d.validateUrl(res.url);
+    } catch (e) {
+      this.d.notify(`Add AssetSpace: invalid URL — ${this.msg(e)}`);
+      return;
+    }
+
+    let folderName: string;
+    try {
+      folderName = this.d.deriveFolderName(res.url);
+    } catch (e) {
+      this.d.notify(`Add AssetSpace: could not derive folder — ${this.msg(e)}`);
+      return;
+    }
+
+    const isGit = await this.d.isGitVault();
+    if (!isGit) {
+      this.d.notify(
+        "Vault is not a git repository — adding in file-only mode (no .gitmodules; tracked device-locally).",
+      );
+    }
+
+    try {
+      const m = await this.materialize(res.url, folderName, isGit);
+      this.d.notify(
+        `AssetSpace added — ${m.folderName}@${m.sha} ← ${res.url}. ` +
+          "Add any AssetSpaces it depends on manually — dependencies are not auto-resolved.",
+      );
+    } catch (e) {
+      this.d.notify(`Add AssetSpace failed: ${this.msg(e)}`);
+      return;
+    }
+    await this.runOnMaterialized();
+  }
+
+  // ─────────────────────────── internal ───────────────────────────
+
+  /**
+   * EC2 — re-materialise every `.gitmodules`-tracked AssetSpace whose folder is
+   * currently empty (vault was cloned without `--recurse-submodules`). A git
+   * clone always has a `.git` dir, so this path stays in git mode (the
+   * `.gitmodules` entries already exist; `appendGitmodulesEntry` is a no-op).
+   */
+  private async fetchTrackedAssetSpaces(): Promise<void> {
+    let entries: Array<{ submodulePath: string; url: string }>;
+    try {
+      entries = await this.d.gitOps.readGitmodulesEntries();
+    } catch (e) {
+      this.d.notify(`Bootstrap: could not read .gitmodules — ${this.msg(e)}`);
+      return;
+    }
+
+    const ok = await this.d.confirm(
+      `This vault tracks ${entries.length} AssetSpace(s) but none are materialised ` +
+        "(likely cloned without --recurse-submodules). Fetch them now from the recorded URLs?",
+    );
+    if (!ok) return;
+
+    let fetched = 0;
+    for (const entry of entries) {
+      const folderName = basename(entry.submodulePath);
+      if (folderName.length === 0) continue;
+      try {
+        await this.materialize(entry.url, folderName, true);
+        fetched++;
+      } catch (e) {
+        this.d.notify(`Fetch failed for ${entry.submodulePath}: ${this.msg(e)}`);
+      }
+    }
+    this.d.notify(
+      `Fetched ${fetched}/${entries.length} AssetSpace(s) from recorded URLs.`,
+    );
+    if (fetched > 0) await this.runOnMaterialized();
+  }
+
+  /**
+   * Pull `url`'s tarball into a staging dir, move it into `assetspaces/<folder>`,
+   * then register it — append the `.gitmodules` entry (git vault) OR record the
+   * file-only registry entry (AC10 non-git vault). The staging-dir `asUid` label
+   * is synthetic (`bootstrap-<folder>`) since a cold bootstrap has no AssetSpace
+   * UID yet — it is only used to name the temp dir for orphan tracking.
+   */
+  private async materialize(
+    url: string,
+    folderName: string,
+    isGit: boolean,
+  ): Promise<MaterializeResult> {
+    const submodulePath = `${ASSETSPACES_DIR}/${folderName}`;
+    const result = await this.d.puller.pullAssetSpace(
+      `bootstrap-${folderName}`,
+      url,
+      this.ref,
+    );
+    await this.d.gitOps.renameIntoVault(result.stagingPath, submodulePath);
+    if (isGit) {
+      await this.d.gitOps.appendGitmodulesEntry(submodulePath, url);
+    } else {
+      await this.d.localStore.upsertFileOnlyAssetSpace({
+        folderName: submodulePath,
+        url,
+        sha: result.sha,
+        addedAt: new Date().toISOString(),
+      });
+    }
+    return { folderName: submodulePath, sha: result.sha };
+  }
+
+  /**
+   * True when at least one `assetspaces/<ns>/` subfolder contains a `.md` file
+   * (a proxy for «a materialised AssetSpace exists»). Missing `assetspaces/`
+   * dir → false.
+   */
+  private async hasMaterializedAssetSpaces(): Promise<boolean> {
+    const exists = await this.d.vaultExists(ASSETSPACES_DIR);
+    if (!exists) return false;
+    let top: { files: string[]; folders: string[] };
+    try {
+      top = await this.d.listFolder(ASSETSPACES_DIR);
+    } catch {
+      return false;
+    }
+    for (const folder of top.folders) {
+      try {
+        const inner = await this.d.listFolder(folder);
+        if (inner.files.some((f) => f.endsWith(".md"))) return true;
+      } catch {
+        // Unreadable subfolder — ignore, keep scanning.
+      }
+    }
+    return false;
+  }
+
+  private async runOnMaterialized(): Promise<void> {
+    if (this.d.onMaterialized === undefined) return;
+    try {
+      await this.d.onMaterialized();
+    } catch {
+      // Best-effort re-index; failure must not surface as a bootstrap error.
+    }
+  }
+
+  private msg(e: unknown): string {
+    return e instanceof Error ? e.message : String(e);
+  }
+}
+
+/** Last path segment of a `/`-delimited vault path (`"assetspaces/exo"` → `"exo"`). */
+function basename(p: string): string {
+  const norm = p.replace(/\/+$/, "");
+  const idx = norm.lastIndexOf("/");
+  return idx < 0 ? norm : norm.slice(idx + 1);
+}

--- a/packages/obsidian-plugin/src/infrastructure/adapters/GitSubmoduleOps.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/GitSubmoduleOps.ts
@@ -383,6 +383,73 @@ export class GitSubmoduleOps {
     return parseGitmodulesPaths(raw);
   }
 
+  /**
+   * Read `.gitmodules` and parse the `(path, url)` pairs of all
+   * `[submodule "<path>"]` stanzas. Missing `.gitmodules` returns `[]`.
+   *
+   * Used by the Phase 6.2 bootstrap «clone-from-another-machine» (EC2) flow:
+   * a vault cloned without `--recurse-submodules` has a populated `.gitmodules`
+   * but empty `assetspaces/*` folders — the bootstrap command reads these
+   * preserved URLs to re-materialise each tracked AssetSpace.
+   */
+  async readGitmodulesEntries(): Promise<GitmodulesEntry[]> {
+    const gitmodulesPath = path.resolve(this.vaultRootPath, ".gitmodules");
+    let raw: string;
+    try {
+      raw = await fs.readFile(gitmodulesPath, "utf8");
+    } catch (err) {
+      const e = err as NodeJS.ErrnoException;
+      if (e?.code === "ENOENT") return [];
+      throw err;
+    }
+    return parseGitmodulesEntries(raw);
+  }
+
+  /**
+   * Idempotent `.gitmodules` entry insertion via text manipulation — the
+   * plugin-side counterpart of CLI `BootstrapAssetSpaceService.ensureGitmodulesEntry`.
+   * Adds a standard `[submodule "<path>"]` stanza (with `path` + `url`) without
+   * invoking the `git` binary, so it works in non-`submodule add` flows (cold
+   * bootstrap / add-by-URL where the content was already materialised via
+   * `renameIntoVault`).
+   *
+   * If a stanza for `submodulePath` already exists, this is a no-op
+   * (`{ added: false }`). Both args are validated (path-traversal / shell
+   * metacharacters / URL allowlist) before any filesystem mutation.
+   */
+  async appendGitmodulesEntry(
+    submodulePath: string,
+    url: string,
+  ): Promise<{ added: boolean }> {
+    this.assertDesktop("appendGitmodulesEntry");
+    const safePath = validateVaultPathArg(submodulePath);
+    const safeUrl = validateGitUrl(url);
+    const gitmodulesPath = path.resolve(this.vaultRootPath, ".gitmodules");
+
+    let existing = "";
+    try {
+      existing = await fs.readFile(gitmodulesPath, "utf8");
+    } catch (err) {
+      const e = err as NodeJS.ErrnoException;
+      if (e?.code !== "ENOENT") throw err;
+    }
+
+    // Anchor on a real `[submodule "<path>"]` header (line start) so a
+    // commented-out / quoted occurrence does not yield a false-positive.
+    const headerRegex = new RegExp(
+      `^\\s*\\[submodule\\s+"${escapeRegex(safePath)}"\\]`,
+      "m",
+    );
+    if (existing.length > 0 && headerRegex.test(existing)) {
+      return { added: false };
+    }
+
+    const sep = existing.length === 0 || existing.endsWith("\n") ? "" : "\n";
+    const newEntry = `[submodule "${safePath}"]\n\tpath = ${safePath}\n\turl = ${safeUrl}\n`;
+    await fs.appendFile(gitmodulesPath, sep + newEntry, { encoding: "utf8" });
+    return { added: true };
+  }
+
   private assertDesktop(op: string): void {
     if (isPlatformMobile()) {
       throw new Error(`GitSubmoduleOps.${op}: mobile not supported (RFC 22b50a17 desktop-only)`);
@@ -472,6 +539,57 @@ export function stripGitmodulesEntry(content: string, submodulePath: string): st
 
 function escapeRegex(s: string): string {
   return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/**
+ * A parsed `.gitmodules` stanza — the `path` + `url` of one submodule entry.
+ */
+export interface GitmodulesEntry {
+  submodulePath: string;
+  url: string;
+}
+
+/**
+ * Parse `.gitmodules` content into `(path, url)` pairs. Each
+ * `[submodule "<name>"]` header opens a stanza; the stanza's `path` and `url`
+ * key=value lines are collected until the next `[...]` header or EOF. A stanza
+ * missing either key is skipped (incomplete — cannot be materialised).
+ *
+ * Exported for unit testing.
+ */
+export function parseGitmodulesEntries(content: string): GitmodulesEntry[] {
+  const out: GitmodulesEntry[] = [];
+  const lines = content.split(/\r?\n/);
+  let inSubmodule = false;
+  let curPath: string | null = null;
+  let curUrl: string | null = null;
+  const flush = (): void => {
+    if (curPath !== null && curUrl !== null) {
+      out.push({ submodulePath: curPath, url: curUrl });
+    }
+    curPath = null;
+    curUrl = null;
+  };
+  for (const line of lines) {
+    if (/^\[.+\]\s*$/.test(line)) {
+      // New header of any kind — flush the previous stanza first.
+      flush();
+      inSubmodule = /^\[submodule\s+"[^"]+"\]\s*$/.test(line);
+      continue;
+    }
+    if (!inSubmodule) continue;
+    const pathMatch = line.match(/^\s*path\s*=\s*(.+?)\s*$/);
+    if (pathMatch !== null) {
+      curPath = pathMatch[1];
+      continue;
+    }
+    const urlMatch = line.match(/^\s*url\s*=\s*(.+?)\s*$/);
+    if (urlMatch !== null) {
+      curUrl = urlMatch[1];
+    }
+  }
+  flush();
+  return out;
 }
 
 /**

--- a/packages/obsidian-plugin/src/infrastructure/adapters/GitSubmoduleOps.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/GitSubmoduleOps.ts
@@ -63,6 +63,7 @@ export interface GitSubmoduleOpsOptions {
  *   - absolute paths (`/` prefix)
  *   - parent traversal (`..` segment)
  *   - shell metacharacters (`;`, `|`, `&`, `$`, `` ` ``, `(`, `)`, `<`, `>`)
+ *     plus `"`, `[`, `]` (also protect the `.gitmodules` quoted header)
  *   - leading `-` (would be parsed as flag by git)
  *
  * Throws on any violation. Otherwise returns the normalized path (forward
@@ -86,8 +87,11 @@ export function validateVaultPathArg(arg: string): string {
     }
   }
   // Disallow shell metas — execFile doesn't interpret them, но this is
-  // defense-in-depth in case the path leaks into a logged shell string.
-  if (/[;|&$`()<>\n\r]/.test(normalized)) {
+  // defense-in-depth in case the path leaks into a logged shell string. The
+  // `"` / `[` / `]` set additionally protects the `.gitmodules` writer
+  // (`appendGitmodulesEntry`) — these characters would otherwise let a path
+  // break out of the `[submodule "<path>"]` quoted header.
+  if (/[;|&$`()<>\n\r"[\]]/.test(normalized)) {
     throw new Error(`GitSubmoduleOps: shell metacharacter in path: ${arg}`);
   }
   return normalized;

--- a/packages/obsidian-plugin/src/infrastructure/adapters/PluginLocalDataStore.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/PluginLocalDataStore.ts
@@ -67,6 +67,7 @@ const KEY_ACTIVE_KNOWLEDGE_PROFILE_UID = "activeKnowledgeProfileUid";
 const KEY_ACTIVE_FOCUS_PROFILE_UID = "activeFocusProfileUid";
 const KEY_SWITCH_IN_PROGRESS = "_switchInProgress";
 const KEY_ACTIVE_STAGING_DIRS = "_activeStagingDirs";
+const KEY_FILE_ONLY_ASSET_SPACES = "_fileOnlyAssetSpaces";
 
 export interface PluginLocalDataStoreOptions {
   app: App;
@@ -118,6 +119,24 @@ export interface StagingDirEntry {
   asUid: string;
   path: string;
   allocatedAt: string;
+}
+
+/**
+ * File-only AssetSpace registry entry — recorded when a vault is bootstrapped
+ * WITHOUT a `.git` directory (RFC 13da049f Phase 6.2 AC10 / M19). Such vaults
+ * cannot track AssetSpaces via `.gitmodules`, so the materialised folder + its
+ * source URL are persisted device-locally instead. This lets the EC2
+ * «clone-from-another-machine» recovery and future re-fetch surfaces know
+ * which AssetSpaces exist even though git is unavailable.
+ */
+export interface FileOnlyAssetSpaceEntry {
+  /** Vault-relative folder where the AssetSpace was materialised. */
+  folderName: string;
+  /** GitHub repo URL the tarball was pulled from. */
+  url: string;
+  /** 7-char tarball SHA recorded at pull time (provenance). */
+  sha: string;
+  addedAt: string;
 }
 
 const EMPTY_STATE: LocalSwitchState = {
@@ -380,6 +399,58 @@ export class PluginLocalDataStore {
       asUid: e.asUid,
       path: e.path,
       allocatedAt: e.allocatedAt,
+    }));
+    await this.persist(all);
+  }
+
+  /**
+   * Read the file-only AssetSpace registry (RFC 13da049f AC10 / M19). Returns
+   * a fresh array — callers can mutate without affecting future reads. Reads
+   * from disk on each call (write-rare, lives outside `LocalSwitchState`).
+   */
+  async readFileOnlyAssetSpaces(): Promise<FileOnlyAssetSpaceEntry[]> {
+    const all = await this.readAllRaw();
+    const raw = all[KEY_FILE_ONLY_ASSET_SPACES];
+    if (!Array.isArray(raw)) return [];
+    const out: FileOnlyAssetSpaceEntry[] = [];
+    for (const item of raw) {
+      if (
+        item &&
+        typeof item === "object" &&
+        typeof (item as Record<string, unknown>).folderName === "string" &&
+        typeof (item as Record<string, unknown>).url === "string" &&
+        typeof (item as Record<string, unknown>).sha === "string" &&
+        typeof (item as Record<string, unknown>).addedAt === "string"
+      ) {
+        const e = item as Record<string, unknown>;
+        out.push({
+          folderName: e.folderName as string,
+          url: e.url as string,
+          sha: e.sha as string,
+          addedAt: e.addedAt as string,
+        });
+      }
+    }
+    return out;
+  }
+
+  /**
+   * Upsert a file-only AssetSpace entry (keyed by `folderName`). Preserves
+   * unknown sibling keys via RMW. Idempotent: re-recording the same folder
+   * replaces its prior entry rather than duplicating it.
+   */
+  async upsertFileOnlyAssetSpace(
+    entry: FileOnlyAssetSpaceEntry,
+  ): Promise<void> {
+    const existing = await this.readFileOnlyAssetSpaces();
+    const next = existing.filter((e) => e.folderName !== entry.folderName);
+    next.push(entry);
+    const all = await this.readAllRaw();
+    all[KEY_FILE_ONLY_ASSET_SPACES] = next.map((e) => ({
+      folderName: e.folderName,
+      url: e.url,
+      sha: e.sha,
+      addedAt: e.addedAt,
     }));
     await this.persist(all);
   }

--- a/packages/obsidian-plugin/src/infrastructure/adapters/PluginLocalDataStore.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/PluginLocalDataStore.ts
@@ -438,6 +438,12 @@ export class PluginLocalDataStore {
    * Upsert a file-only AssetSpace entry (keyed by `folderName`). Preserves
    * unknown sibling keys via RMW. Idempotent: re-recording the same folder
    * replaces its prior entry rather than duplicating it.
+   *
+   * Like the rest of this store, the read-modify-write is NOT serialized — it
+   * relies on callers invoking it sequentially (the bootstrap flow awaits each
+   * `materialize` fully before the next). Concurrent writes to
+   * `data.local.json` could clobber; if overlapping surfaces emerge, route
+   * through a shared write-chain like {@link StagingDirTracker}.
    */
   async upsertFileOnlyAssetSpace(
     entry: FileOnlyAssetSpaceEntry,

--- a/packages/obsidian-plugin/src/presentation/modals/AddAssetSpaceModal.ts
+++ b/packages/obsidian-plugin/src/presentation/modals/AddAssetSpaceModal.ts
@@ -1,0 +1,140 @@
+import { App, Modal } from "obsidian";
+import { isLikelyGitHubUrl } from "./BootstrapVaultModal";
+
+export interface AddAssetSpaceInput {
+  url: string;
+}
+
+/**
+ * AddAssetSpaceModal — input gate for the `Exocortex: Add AssetSpace by URL`
+ * palette command (RFC 13da049f Phase 6.3).
+ *
+ * Collects a single public GitHub repo URL and live-previews the folder it will
+ * be materialised into (`assetspaces/<folder>`, with the `exoas-` prefix
+ * stripped, mirroring the CLI `assetspace-add` default).
+ *
+ * Resolves `{ url }` only when the user clicks «Add» with a plausible GitHub
+ * URL. Esc / Cancel / any close path resolves `null`. The promise resolves
+ * exactly once.
+ */
+export class AddAssetSpaceModal extends Modal {
+  private resolved = false;
+  private readonly resolveFn: (input: AddAssetSpaceInput | null) => void;
+  private readonly deriveFolderName: (url: string) => string;
+  private urlInput: HTMLInputElement | null = null;
+  private previewEl: HTMLElement | null = null;
+  private errorEl: HTMLElement | null = null;
+
+  constructor(
+    app: App,
+    deriveFolderName: (url: string) => string,
+    resolve: (input: AddAssetSpaceInput | null) => void,
+  ) {
+    super(app);
+    this.deriveFolderName = deriveFolderName;
+    this.resolveFn = resolve;
+  }
+
+  private settle(value: AddAssetSpaceInput | null): void {
+    if (this.resolved) return;
+    this.resolved = true;
+    this.resolveFn(value);
+  }
+
+  override onOpen(): void {
+    const { contentEl } = this;
+    contentEl.createEl("h2", {
+      cls: "add-assetspace-title",
+      text: "Add assetspace by URL",
+    });
+    contentEl.createEl("p", {
+      text:
+        "Pull a single assetspace from a public GitHub repository into this " +
+        "vault. The folder name is derived from the repository name.",
+    });
+
+    const wrap = contentEl.createEl("div", { cls: "add-assetspace-field" });
+    wrap.createEl("label", { text: "Repository URL" });
+    const input = wrap.createEl("input", {
+      type: "text",
+      placeholder: "https://github.com/kitelev/exoas-pmbok-ontology",
+      cls: "add-assetspace-input bootstrap-modal-input",
+    });
+    this.urlInput = input;
+
+    this.previewEl = contentEl.createEl("p", {
+      cls: "add-assetspace-preview",
+      text: this.previewText(""),
+    });
+    input.addEventListener("input", () => this.refreshPreview());
+
+    contentEl.createEl("p", {
+      cls: "add-assetspace-note",
+      text:
+        "Add any AssetSpaces this one depends on manually — dependencies are " +
+        "not added automatically.",
+    });
+
+    this.errorEl = contentEl.createEl("p", {
+      cls: "add-assetspace-error mod-warning bootstrap-modal-error",
+      text: "",
+    });
+
+    const actions = contentEl.createEl("div", {
+      cls: "modal-button-container add-assetspace-actions",
+    });
+    const cancelBtn = actions.createEl("button", { text: "Cancel" });
+    cancelBtn.addEventListener("click", () => {
+      this.settle(null);
+      this.close();
+    });
+    const addBtn = actions.createEl("button", {
+      cls: "mod-cta",
+      text: "Add",
+    });
+    addBtn.addEventListener("click", () => this.submit());
+  }
+
+  private refreshPreview(): void {
+    if (this.previewEl === null) return;
+    const url = (this.urlInput?.value ?? "").trim();
+    this.previewEl.textContent = this.previewText(url);
+  }
+
+  private previewText(url: string): string {
+    if (url.length === 0) return "Target folder: (enter a URL)";
+    if (!isLikelyGitHubUrl(url)) return "Target folder: (invalid URL)";
+    let folder = "(unknown)";
+    try {
+      folder = this.deriveFolderName(url);
+    } catch {
+      folder = "(unknown)";
+    }
+    return `Target folder: assetspaces/${folder}`;
+  }
+
+  private submit(): void {
+    const url = (this.urlInput?.value ?? "").trim();
+    if (url.length === 0) {
+      this.showError("A GitHub URL is required.");
+      return;
+    }
+    if (!isLikelyGitHubUrl(url)) {
+      this.showError("URL must look like https://github.com/<owner>/<repo>.");
+      return;
+    }
+    this.settle({ url });
+    this.close();
+  }
+
+  private showError(message: string): void {
+    if (this.errorEl === null) return;
+    this.errorEl.textContent = message;
+    this.errorEl.classList.add("is-visible");
+  }
+
+  override onClose(): void {
+    this.settle(null);
+    this.contentEl.empty();
+  }
+}

--- a/packages/obsidian-plugin/src/presentation/modals/BootstrapVaultModal.ts
+++ b/packages/obsidian-plugin/src/presentation/modals/BootstrapVaultModal.ts
@@ -1,0 +1,162 @@
+import { App, Modal } from "obsidian";
+
+export interface BootstrapVaultUrls {
+  exoUrl: string;
+  exocmdUrl: string;
+}
+
+/**
+ * BootstrapVaultModal — input gate for the `Exocortex: Bootstrap vault` palette
+ * command (RFC 13da049f Phase 6.2).
+ *
+ * Collects the two TS-floor AssetSpace URLs (exo + exocmd) needed to cold-start
+ * an empty vault.
+ *
+ * ## UX decisions
+ *
+ * - **EC7 — fields start EMPTY.** The `kitelev/exoas-*` repos are NOT pre-filled
+ *   (they materialise Andrey's own ontology and do not work as a generic floor
+ *   for other users). They appear only as greyed-out placeholder examples.
+ * - **R31 — no transitive auto-add.** A note tells the user they must add any
+ *   further required AssetSpaces manually; dependencies are not resolved
+ *   automatically.
+ *
+ * Resolves `{ exoUrl, exocmdUrl }` only when the user clicks «Bootstrap» with
+ * both fields populated with a plausible GitHub URL. Esc / Cancel / any close
+ * path resolves `null`. The promise resolves exactly once.
+ *
+ * Authoritative URL validation (allowlist, traversal) happens downstream in
+ * `BootstrapAssetSpaceCommands` / `GitHubRestClient.validateRepoURL`; this modal
+ * only does a light non-empty + `https://github.com/` shape check so the user
+ * gets immediate feedback before a pull is attempted.
+ */
+export class BootstrapVaultModal extends Modal {
+  private resolved = false;
+  private readonly resolveFn: (urls: BootstrapVaultUrls | null) => void;
+  private exoInput: HTMLInputElement | null = null;
+  private exocmdInput: HTMLInputElement | null = null;
+  private errorEl: HTMLElement | null = null;
+
+  constructor(app: App, resolve: (urls: BootstrapVaultUrls | null) => void) {
+    super(app);
+    this.resolveFn = resolve;
+  }
+
+  private settle(value: BootstrapVaultUrls | null): void {
+    if (this.resolved) return;
+    this.resolved = true;
+    this.resolveFn(value);
+  }
+
+  override onOpen(): void {
+    const { contentEl } = this;
+    contentEl.createEl("h2", {
+      cls: "bootstrap-vault-title",
+      text: "Bootstrap vault",
+    });
+    contentEl.createEl("p", {
+      text:
+        "Cold-start this empty vault with the two foundational AssetSpaces " +
+        "(exo + exocmd). Each is pulled from a public GitHub repository.",
+    });
+
+    this.exoInput = this.createUrlField(
+      contentEl,
+      "exo ontology URL",
+      "https://github.com/kitelev/exoas-exo",
+    );
+    this.exocmdInput = this.createUrlField(
+      contentEl,
+      "exocmd ontology URL",
+      "https://github.com/kitelev/exoas-exocmd",
+    );
+
+    contentEl.createEl("p", {
+      cls: "bootstrap-vault-note",
+      text:
+        "The example URLs above are placeholders only — enter the repositories " +
+        "you want to use. Add any further AssetSpaces afterwards via " +
+        "«Add AssetSpace by URL»; dependencies are not added automatically.",
+    });
+
+    this.errorEl = contentEl.createEl("p", {
+      cls: "bootstrap-vault-error mod-warning bootstrap-modal-error",
+      text: "",
+    });
+
+    const actions = contentEl.createEl("div", {
+      cls: "modal-button-container bootstrap-vault-actions",
+    });
+    const cancelBtn = actions.createEl("button", { text: "Cancel" });
+    cancelBtn.addEventListener("click", () => {
+      this.settle(null);
+      this.close();
+    });
+    const bootstrapBtn = actions.createEl("button", {
+      cls: "mod-cta",
+      text: "Bootstrap",
+    });
+    bootstrapBtn.addEventListener("click", () => this.submit());
+  }
+
+  private createUrlField(
+    parent: HTMLElement,
+    label: string,
+    placeholder: string,
+  ): HTMLInputElement {
+    const wrap = parent.createEl("div", { cls: "bootstrap-vault-field" });
+    wrap.createEl("label", { text: label });
+    const input = wrap.createEl("input", {
+      type: "text",
+      placeholder,
+      cls: "bootstrap-vault-input bootstrap-modal-input",
+    });
+    return input;
+  }
+
+  private submit(): void {
+    const exoUrl = (this.exoInput?.value ?? "").trim();
+    const exocmdUrl = (this.exocmdInput?.value ?? "").trim();
+    const problem = firstUrlProblem(exoUrl, exocmdUrl);
+    if (problem !== null) {
+      this.showError(problem);
+      return;
+    }
+    this.settle({ exoUrl, exocmdUrl });
+    this.close();
+  }
+
+  private showError(message: string): void {
+    if (this.errorEl === null) return;
+    this.errorEl.textContent = message;
+    this.errorEl.classList.add("is-visible");
+  }
+
+  override onClose(): void {
+    // Dismissed without explicit Bootstrap → treat as cancel.
+    this.settle(null);
+    this.contentEl.empty();
+  }
+}
+
+/**
+ * Light shape check for the two bootstrap URLs. Returns a human-readable problem
+ * string, or null when both look plausible. Authoritative validation is
+ * downstream.
+ */
+function firstUrlProblem(exoUrl: string, exocmdUrl: string): string | null {
+  if (exoUrl.length === 0 || exocmdUrl.length === 0) {
+    return "Both the exo and exocmd URLs are required.";
+  }
+  if (!isLikelyGitHubUrl(exoUrl)) {
+    return "exo URL must look like https://github.com/<owner>/<repo>.";
+  }
+  if (!isLikelyGitHubUrl(exocmdUrl)) {
+    return "exocmd URL must look like https://github.com/<owner>/<repo>.";
+  }
+  return null;
+}
+
+export function isLikelyGitHubUrl(url: string): boolean {
+  return /^https:\/\/github\.com\/[^/\s]+\/[^/\s]+$/.test(url);
+}

--- a/packages/obsidian-plugin/src/presentation/modals/SimpleConfirmModal.ts
+++ b/packages/obsidian-plugin/src/presentation/modals/SimpleConfirmModal.ts
@@ -1,0 +1,63 @@
+import { App, Modal } from "obsidian";
+
+/**
+ * SimpleConfirmModal — a generic yes/no confirmation gate.
+ *
+ * Used by the Phase 6.2 bootstrap «clone-needs-fetch» (EC2) flow to confirm a
+ * batch re-materialisation. Resolves `true` only on the explicit confirm button;
+ * Esc / Cancel / any close path resolves `false`. The promise resolves exactly
+ * once.
+ */
+export class SimpleConfirmModal extends Modal {
+  private resolved = false;
+  private readonly title: string;
+  private readonly body: string;
+  private readonly confirmLabel: string;
+  private readonly resolveFn: (approved: boolean) => void;
+
+  constructor(
+    app: App,
+    opts: { title: string; body: string; confirmLabel?: string },
+    resolve: (approved: boolean) => void,
+  ) {
+    super(app);
+    this.title = opts.title;
+    this.body = opts.body;
+    this.confirmLabel = opts.confirmLabel ?? "Confirm";
+    this.resolveFn = resolve;
+  }
+
+  private settle(value: boolean): void {
+    if (this.resolved) return;
+    this.resolved = true;
+    this.resolveFn(value);
+  }
+
+  override onOpen(): void {
+    const { contentEl } = this;
+    contentEl.createEl("h2", { text: this.title });
+    contentEl.createEl("p", { text: this.body });
+
+    const actions = contentEl.createEl("div", {
+      cls: "modal-button-container",
+    });
+    const cancelBtn = actions.createEl("button", { text: "Cancel" });
+    cancelBtn.addEventListener("click", () => {
+      this.settle(false);
+      this.close();
+    });
+    const confirmBtn = actions.createEl("button", {
+      cls: "mod-cta",
+      text: this.confirmLabel,
+    });
+    confirmBtn.addEventListener("click", () => {
+      this.settle(true);
+      this.close();
+    });
+  }
+
+  override onClose(): void {
+    this.settle(false);
+    this.contentEl.empty();
+  }
+}

--- a/packages/obsidian-plugin/styles.css
+++ b/packages/obsidian-plugin/styles.css
@@ -6106,3 +6106,35 @@
   color: var(--text-muted, #6e7681);
   opacity: 0.85;
 }
+
+/* RFC 13da049f Phase 6.2/6.3 — Bootstrap / Add-assetspace modals. */
+.bootstrap-modal-input {
+  width: 100%;
+}
+
+.bootstrap-vault-field,
+.add-assetspace-field {
+  margin-bottom: 0.75em;
+}
+
+.bootstrap-vault-field label,
+.add-assetspace-field label {
+  display: block;
+  margin-bottom: 0.25em;
+  font-weight: var(--font-semibold, 600);
+}
+
+.bootstrap-vault-note,
+.add-assetspace-note,
+.add-assetspace-preview {
+  color: var(--text-muted, #6e7681);
+  font-size: var(--font-ui-smaller, 0.8em);
+}
+
+.bootstrap-modal-error {
+  display: none;
+}
+
+.bootstrap-modal-error.is-visible {
+  display: block;
+}

--- a/packages/obsidian-plugin/tests/unit/PluginLocalDataStore.test.ts
+++ b/packages/obsidian-plugin/tests/unit/PluginLocalDataStore.test.ts
@@ -67,6 +67,70 @@ describe("PluginLocalDataStore — initialization", () => {
   });
 });
 
+describe("PluginLocalDataStore — file-only AssetSpace registry (AC10)", () => {
+  const FILE_ONLY_ENTRY = {
+    folderName: "assetspaces/exo",
+    url: "https://github.com/kitelev/exoas-exo",
+    sha: "abc1234",
+    addedAt: "2026-06-05T00:00:00Z",
+  };
+
+  it("readFileOnlyAssetSpaces returns [] when absent", async () => {
+    const { app } = makeFakeApp();
+    const store = new PluginLocalDataStore({ app });
+    expect(await store.readFileOnlyAssetSpaces()).toEqual([]);
+  });
+
+  it("upsert then read round-trips the entry", async () => {
+    const { app } = makeFakeApp();
+    const store = new PluginLocalDataStore({ app });
+    await store.upsertFileOnlyAssetSpace(FILE_ONLY_ENTRY);
+    expect(await store.readFileOnlyAssetSpaces()).toEqual([FILE_ONLY_ENTRY]);
+  });
+
+  it("upsert is idempotent on folderName (replaces, no duplicate)", async () => {
+    const { app } = makeFakeApp();
+    const store = new PluginLocalDataStore({ app });
+    await store.upsertFileOnlyAssetSpace(FILE_ONLY_ENTRY);
+    await store.upsertFileOnlyAssetSpace({
+      ...FILE_ONLY_ENTRY,
+      sha: "newsha7",
+    });
+    const all = await store.readFileOnlyAssetSpaces();
+    expect(all).toHaveLength(1);
+    expect(all[0].sha).toBe("newsha7");
+  });
+
+  it("preserves sibling keys (switch state / pat) via RMW", async () => {
+    const { app, files } = makeFakeApp({
+      [PATH]: JSON.stringify({
+        activeProfileUid: "p-keep",
+        pat: "ghp_keep",
+      }),
+    });
+    const store = new PluginLocalDataStore({ app });
+    await store.upsertFileOnlyAssetSpace(FILE_ONLY_ENTRY);
+    const parsed = JSON.parse(files.get(PATH) ?? "{}");
+    expect(parsed.activeProfileUid).toBe("p-keep");
+    expect(parsed.pat).toBe("ghp_keep");
+    expect(parsed._fileOnlyAssetSpaces).toHaveLength(1);
+  });
+
+  it("ignores malformed registry items", async () => {
+    const { app } = makeFakeApp({
+      [PATH]: JSON.stringify({
+        _fileOnlyAssetSpaces: [
+          { folderName: "assetspaces/exo" }, // missing fields
+          FILE_ONLY_ENTRY,
+          "garbage",
+        ],
+      }),
+    });
+    const store = new PluginLocalDataStore({ app });
+    expect(await store.readFileOnlyAssetSpaces()).toEqual([FILE_ONLY_ENTRY]);
+  });
+});
+
 describe("PluginLocalDataStore — save", () => {
   it("save persists to disk and updates the cache", async () => {
     const { app, files } = makeFakeApp();

--- a/packages/obsidian-plugin/tests/unit/infrastructure/adapters/BootstrapAssetSpaceCommands.test.ts
+++ b/packages/obsidian-plugin/tests/unit/infrastructure/adapters/BootstrapAssetSpaceCommands.test.ts
@@ -1,0 +1,330 @@
+import {
+  BootstrapAssetSpaceCommands,
+  type BootstrapAssetSpaceCommandsDeps,
+  type IAssetSpacePuller,
+  type IGitSubmoduleOps,
+  type IFileOnlyAssetSpaceStore,
+} from "../../../../src/infrastructure/adapters/BootstrapAssetSpaceCommands";
+
+const EXO_URL = "https://github.com/kitelev/exoas-exo";
+const EXOCMD_URL = "https://github.com/kitelev/exoas-exocmd";
+const PMBOK_URL = "https://github.com/kitelev/exoas-pmbok-ontology";
+
+interface Harness {
+  cmds: BootstrapAssetSpaceCommands;
+  puller: jest.Mocked<IAssetSpacePuller>;
+  gitOps: jest.Mocked<IGitSubmoduleOps>;
+  localStore: jest.Mocked<IFileOnlyAssetSpaceStore>;
+  notices: string[];
+  vaultFiles: Set<string>;
+  vaultFolders: Map<string, { files: string[]; folders: string[] }>;
+  deps: BootstrapAssetSpaceCommandsDeps;
+}
+
+function makeHarness(opts: {
+  gitmodulesEntries?: Array<{ submodulePath: string; url: string }>;
+  materializedFolders?: Record<string, string[]>; // folder → files
+  isGitVault?: boolean;
+  bootstrapUrls?: { exoUrl: string; exocmdUrl: string } | null;
+  addUrl?: { url: string } | null;
+  confirm?: boolean;
+} = {}): Harness {
+  const notices: string[] = [];
+  const gitmodulesEntries = opts.gitmodulesEntries ?? [];
+  const materialized = opts.materializedFolders ?? {};
+
+  const puller = {
+    pullAssetSpace: jest.fn(
+      async (asUid: string, _url: string, _ref?: string) => ({
+        asUid,
+        stagingPath: `/tmp/staging-${asUid}`,
+        sha: "abc1234",
+      }),
+    ),
+  } as jest.Mocked<IAssetSpacePuller>;
+
+  const gitOps = {
+    renameIntoVault: jest.fn(async () => undefined),
+    readGitmodulesEntries: jest.fn(async () => [...gitmodulesEntries]),
+    appendGitmodulesEntry: jest.fn(async () => ({ added: true })),
+  } as jest.Mocked<IGitSubmoduleOps>;
+
+  const localStore = {
+    upsertFileOnlyAssetSpace: jest.fn(async () => undefined),
+  } as jest.Mocked<IFileOnlyAssetSpaceStore>;
+
+  // Vault probing fakes derived from `materialized`.
+  const folderHasContent = Object.keys(materialized).length > 0;
+  const vaultExists = jest.fn(async (p: string) => {
+    if (p === "assetspaces") return folderHasContent;
+    if (p === ".git") return opts.isGitVault ?? true;
+    return false;
+  });
+  const listFolder = jest.fn(async (dir: string) => {
+    if (dir === "assetspaces") {
+      return {
+        files: [],
+        folders: Object.keys(materialized).map((f) => `assetspaces/${f}`),
+      };
+    }
+    const ns = dir.replace(/^assetspaces\//, "");
+    const files = (materialized[ns] ?? []).map((f) => `${dir}/${f}`);
+    return { files, folders: [] };
+  });
+
+  const deriveFolderName = (url: string): string => {
+    const m = url.match(/github\.com\/[^/]+\/([^/]+)$/);
+    const repo = m ? m[1] : "unknown";
+    return repo.startsWith("exoas-") ? repo.slice("exoas-".length) : repo;
+  };
+
+  const deps: BootstrapAssetSpaceCommandsDeps = {
+    puller,
+    gitOps,
+    localStore,
+    vaultExists,
+    listFolder,
+    isGitVault: () => vaultExists(".git"),
+    validateUrl: (url) => {
+      if (!/^https:\/\/github\.com\/[^/]+\/[^/]+$/.test(url)) {
+        throw new Error(`invalid url: ${url}`);
+      }
+    },
+    deriveFolderName,
+    promptBootstrapUrls: jest.fn(async () =>
+      opts.bootstrapUrls === undefined
+        ? { exoUrl: EXO_URL, exocmdUrl: EXOCMD_URL }
+        : opts.bootstrapUrls,
+    ),
+    promptAddAssetSpaceUrl: jest.fn(async () =>
+      opts.addUrl === undefined ? { url: PMBOK_URL } : opts.addUrl,
+    ),
+    confirm: jest.fn(async () => opts.confirm ?? true),
+    notify: (m: string) => notices.push(m),
+  };
+
+  const vaultFolders = new Map<
+    string,
+    { files: string[]; folders: string[] }
+  >();
+  return {
+    cmds: new BootstrapAssetSpaceCommands(deps),
+    puller,
+    gitOps,
+    localStore,
+    notices,
+    vaultFiles: new Set<string>(),
+    vaultFolders,
+    deps,
+  };
+}
+
+describe("BootstrapAssetSpaceCommands.detectVaultState", () => {
+  it("empty — no .gitmodules entries, no materialized folders", async () => {
+    const h = makeHarness({ gitmodulesEntries: [], materializedFolders: {} });
+    expect(await h.cmds.detectVaultState()).toBe("empty");
+  });
+
+  it("bootstrapped — assetspaces folder has .md content", async () => {
+    const h = makeHarness({
+      gitmodulesEntries: [],
+      materializedFolders: { exo: ["73bd00e4.md"] },
+    });
+    expect(await h.cmds.detectVaultState()).toBe("bootstrapped");
+  });
+
+  it("clone-needs-fetch (EC2) — .gitmodules entries but folders empty", async () => {
+    const h = makeHarness({
+      gitmodulesEntries: [
+        { submodulePath: "assetspaces/exo", url: EXO_URL },
+        { submodulePath: "assetspaces/exocmd", url: EXOCMD_URL },
+      ],
+      materializedFolders: {},
+    });
+    expect(await h.cmds.detectVaultState()).toBe("clone-needs-fetch");
+  });
+
+  it("bootstrapped — folder content takes precedence over gitmodules", async () => {
+    const h = makeHarness({
+      gitmodulesEntries: [{ submodulePath: "assetspaces/exo", url: EXO_URL }],
+      materializedFolders: { exo: ["a.md"] },
+    });
+    expect(await h.cmds.detectVaultState()).toBe("bootstrapped");
+  });
+});
+
+describe("BootstrapAssetSpaceCommands.invokeBootstrap — empty vault (git)", () => {
+  it("pulls exo + exocmd into fixed folders and appends .gitmodules", async () => {
+    const h = makeHarness({ isGitVault: true });
+    await h.cmds.invokeBootstrap();
+
+    expect(h.puller.pullAssetSpace).toHaveBeenCalledTimes(2);
+    expect(h.puller.pullAssetSpace).toHaveBeenNthCalledWith(
+      1,
+      "bootstrap-exo",
+      EXO_URL,
+      "main",
+    );
+    expect(h.puller.pullAssetSpace).toHaveBeenNthCalledWith(
+      2,
+      "bootstrap-exocmd",
+      EXOCMD_URL,
+      "main",
+    );
+    expect(h.gitOps.renameIntoVault).toHaveBeenNthCalledWith(
+      1,
+      "/tmp/staging-bootstrap-exo",
+      "assetspaces/exo",
+    );
+    expect(h.gitOps.renameIntoVault).toHaveBeenNthCalledWith(
+      2,
+      "/tmp/staging-bootstrap-exocmd",
+      "assetspaces/exocmd",
+    );
+    expect(h.gitOps.appendGitmodulesEntry).toHaveBeenCalledWith(
+      "assetspaces/exo",
+      EXO_URL,
+    );
+    expect(h.gitOps.appendGitmodulesEntry).toHaveBeenCalledWith(
+      "assetspaces/exocmd",
+      EXOCMD_URL,
+    );
+    expect(h.localStore.upsertFileOnlyAssetSpace).not.toHaveBeenCalled();
+    expect(h.notices.some((n) => /Bootstrap complete/.test(n))).toBe(true);
+  });
+});
+
+describe("BootstrapAssetSpaceCommands.invokeBootstrap — empty vault (file-only / non-git, AC10)", () => {
+  it("materializes without .gitmodules and tracks device-locally", async () => {
+    const h = makeHarness({ isGitVault: false });
+    await h.cmds.invokeBootstrap();
+
+    expect(h.puller.pullAssetSpace).toHaveBeenCalledTimes(2);
+    expect(h.gitOps.renameIntoVault).toHaveBeenCalledTimes(2);
+    expect(h.gitOps.appendGitmodulesEntry).not.toHaveBeenCalled();
+    expect(h.localStore.upsertFileOnlyAssetSpace).toHaveBeenCalledTimes(2);
+    expect(h.localStore.upsertFileOnlyAssetSpace).toHaveBeenCalledWith(
+      expect.objectContaining({ folderName: "assetspaces/exo", url: EXO_URL }),
+    );
+    expect(h.notices.some((n) => /file-only mode/.test(n))).toBe(true);
+  });
+});
+
+describe("BootstrapAssetSpaceCommands.invokeBootstrap — already bootstrapped", () => {
+  it("is a no-op with an informative notice", async () => {
+    const h = makeHarness({ materializedFolders: { exo: ["a.md"] } });
+    await h.cmds.invokeBootstrap();
+    expect(h.puller.pullAssetSpace).not.toHaveBeenCalled();
+    expect(h.gitOps.renameIntoVault).not.toHaveBeenCalled();
+    expect(h.notices.some((n) => /already has AssetSpaces/.test(n))).toBe(true);
+  });
+});
+
+describe("BootstrapAssetSpaceCommands.invokeBootstrap — EC2 clone-needs-fetch", () => {
+  it("confirm=yes → re-materializes each tracked AssetSpace from .gitmodules URL", async () => {
+    const h = makeHarness({
+      gitmodulesEntries: [
+        { submodulePath: "assetspaces/exo", url: EXO_URL },
+        { submodulePath: "assetspaces/exocmd", url: EXOCMD_URL },
+      ],
+      materializedFolders: {},
+      confirm: true,
+    });
+    await h.cmds.invokeBootstrap();
+
+    expect(h.deps.promptBootstrapUrls).not.toHaveBeenCalled();
+    expect(h.puller.pullAssetSpace).toHaveBeenCalledTimes(2);
+    expect(h.puller.pullAssetSpace).toHaveBeenCalledWith(
+      "bootstrap-exo",
+      EXO_URL,
+      "main",
+    );
+    expect(h.gitOps.renameIntoVault).toHaveBeenCalledWith(
+      "/tmp/staging-bootstrap-exocmd",
+      "assetspaces/exocmd",
+    );
+    expect(h.notices.some((n) => /Fetched 2\/2/.test(n))).toBe(true);
+  });
+
+  it("confirm=no → does nothing", async () => {
+    const h = makeHarness({
+      gitmodulesEntries: [{ submodulePath: "assetspaces/exo", url: EXO_URL }],
+      materializedFolders: {},
+      confirm: false,
+    });
+    await h.cmds.invokeBootstrap();
+    expect(h.puller.pullAssetSpace).not.toHaveBeenCalled();
+  });
+});
+
+describe("BootstrapAssetSpaceCommands.invokeBootstrap — guards", () => {
+  it("user cancels the URL prompt → no pull", async () => {
+    const h = makeHarness({ bootstrapUrls: null });
+    await h.cmds.invokeBootstrap();
+    expect(h.puller.pullAssetSpace).not.toHaveBeenCalled();
+  });
+
+  it("invalid URL → notify, no pull", async () => {
+    const h = makeHarness({
+      bootstrapUrls: { exoUrl: "http://evil.example/x", exocmdUrl: EXOCMD_URL },
+    });
+    await h.cmds.invokeBootstrap();
+    expect(h.puller.pullAssetSpace).not.toHaveBeenCalled();
+    expect(h.notices.some((n) => /invalid URL/i.test(n))).toBe(true);
+  });
+
+  it("pull failure surfaces a notice and stops", async () => {
+    const h = makeHarness({ isGitVault: true });
+    h.puller.pullAssetSpace.mockRejectedValueOnce(new Error("network down"));
+    await h.cmds.invokeBootstrap();
+    expect(h.notices.some((n) => /Bootstrap failed.*network down/.test(n))).toBe(
+      true,
+    );
+    // exocmd pull never attempted after exo failed
+    expect(h.puller.pullAssetSpace).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("BootstrapAssetSpaceCommands.invokeAddAssetSpace", () => {
+  it("pulls into URL-derived folder and appends .gitmodules (git vault)", async () => {
+    const h = makeHarness({ isGitVault: true });
+    await h.cmds.invokeAddAssetSpace();
+
+    expect(h.puller.pullAssetSpace).toHaveBeenCalledWith(
+      "bootstrap-pmbok-ontology",
+      PMBOK_URL,
+      "main",
+    );
+    expect(h.gitOps.renameIntoVault).toHaveBeenCalledWith(
+      "/tmp/staging-bootstrap-pmbok-ontology",
+      "assetspaces/pmbok-ontology",
+    );
+    expect(h.gitOps.appendGitmodulesEntry).toHaveBeenCalledWith(
+      "assetspaces/pmbok-ontology",
+      PMBOK_URL,
+    );
+    expect(h.notices.some((n) => /AssetSpace added/.test(n))).toBe(true);
+  });
+
+  it("file-only vault → tracks device-locally, no .gitmodules", async () => {
+    const h = makeHarness({ isGitVault: false });
+    await h.cmds.invokeAddAssetSpace();
+    expect(h.gitOps.appendGitmodulesEntry).not.toHaveBeenCalled();
+    expect(h.localStore.upsertFileOnlyAssetSpace).toHaveBeenCalledWith(
+      expect.objectContaining({ folderName: "assetspaces/pmbok-ontology" }),
+    );
+  });
+
+  it("cancel → no pull", async () => {
+    const h = makeHarness({ addUrl: null });
+    await h.cmds.invokeAddAssetSpace();
+    expect(h.puller.pullAssetSpace).not.toHaveBeenCalled();
+  });
+
+  it("invalid URL → notify, no pull", async () => {
+    const h = makeHarness({ addUrl: { url: "https://gitlab.com/a/b" } });
+    await h.cmds.invokeAddAssetSpace();
+    expect(h.puller.pullAssetSpace).not.toHaveBeenCalled();
+    expect(h.notices.some((n) => /invalid URL/i.test(n))).toBe(true);
+  });
+});

--- a/packages/obsidian-plugin/tests/unit/infrastructure/adapters/BootstrapAssetSpaceCommands.test.ts
+++ b/packages/obsidian-plugin/tests/unit/infrastructure/adapters/BootstrapAssetSpaceCommands.test.ts
@@ -283,6 +283,26 @@ describe("BootstrapAssetSpaceCommands.invokeBootstrap — guards", () => {
     // exocmd pull never attempted after exo failed
     expect(h.puller.pullAssetSpace).toHaveBeenCalledTimes(1);
   });
+
+  it("partial failure (exo ok, exocmd fails) → actionable recovery notice", async () => {
+    const h = makeHarness({ isGitVault: true });
+    h.puller.pullAssetSpace
+      .mockResolvedValueOnce({
+        asUid: "bootstrap-exo",
+        stagingPath: "/tmp/staging-bootstrap-exo",
+        sha: "abc1234",
+      })
+      .mockRejectedValueOnce(new Error("exocmd boom"));
+    await h.cmds.invokeBootstrap();
+    expect(h.puller.pullAssetSpace).toHaveBeenCalledTimes(2);
+    // exo materialised, exocmd did not
+    expect(h.gitOps.renameIntoVault).toHaveBeenCalledTimes(1);
+    expect(
+      h.notices.some(
+        (n) => /partially completed/i.test(n) && /Add assetspace by URL/i.test(n),
+      ),
+    ).toBe(true);
+  });
 });
 
 describe("BootstrapAssetSpaceCommands.invokeAddAssetSpace", () => {

--- a/packages/obsidian-plugin/tests/unit/infrastructure/adapters/GitSubmoduleOps.test.ts
+++ b/packages/obsidian-plugin/tests/unit/infrastructure/adapters/GitSubmoduleOps.test.ts
@@ -4,6 +4,7 @@ import {
   validateGitUrl,
   stripGitmodulesEntry,
   parseGitmodulesPaths,
+  parseGitmodulesEntries,
 } from "../../../../src/infrastructure/adapters/GitSubmoduleOps";
 
 describe("validateVaultPathArg", () => {
@@ -125,6 +126,64 @@ no-path-here = whatever
     expect(paths.has("assetspaces/kpc")).toBe(true);
     // ems stanza had no `path =` line so it's not included.
     expect(paths.has("assetspaces/ems")).toBe(false);
+  });
+});
+
+describe("parseGitmodulesEntries", () => {
+  it("extracts (path, url) pairs for each submodule stanza", () => {
+    const content = `[submodule "assetspaces/exo"]
+\tpath = assetspaces/exo
+\turl = https://github.com/kitelev/exoas-exo
+[submodule "assetspaces/exocmd"]
+\tpath = assetspaces/exocmd
+\turl = https://github.com/kitelev/exoas-exocmd
+`;
+    const entries = parseGitmodulesEntries(content);
+    expect(entries).toEqual([
+      {
+        submodulePath: "assetspaces/exo",
+        url: "https://github.com/kitelev/exoas-exo",
+      },
+      {
+        submodulePath: "assetspaces/exocmd",
+        url: "https://github.com/kitelev/exoas-exocmd",
+      },
+    ]);
+  });
+
+  it("returns [] on empty input", () => {
+    expect(parseGitmodulesEntries("")).toEqual([]);
+  });
+
+  it("skips stanzas missing path or url", () => {
+    const content = `[submodule "assetspaces/exo"]
+\turl = https://github.com/kitelev/exoas-exo
+[submodule "assetspaces/exocmd"]
+\tpath = assetspaces/exocmd
+\turl = https://github.com/kitelev/exoas-exocmd
+`;
+    const entries = parseGitmodulesEntries(content);
+    expect(entries).toEqual([
+      {
+        submodulePath: "assetspaces/exocmd",
+        url: "https://github.com/kitelev/exoas-exocmd",
+      },
+    ]);
+  });
+
+  it("ignores non-submodule sections", () => {
+    const content = `[core]
+\tbare = false
+[submodule "assetspaces/ems"]
+\tpath = assetspaces/ems
+\turl = https://github.com/kitelev/exoas-ems
+`;
+    expect(parseGitmodulesEntries(content)).toEqual([
+      {
+        submodulePath: "assetspaces/ems",
+        url: "https://github.com/kitelev/exoas-ems",
+      },
+    ]);
   });
 });
 

--- a/packages/obsidian-plugin/tests/unit/integration/BootstrapAssetSpace.integration.test.ts
+++ b/packages/obsidian-plugin/tests/unit/integration/BootstrapAssetSpace.integration.test.ts
@@ -1,0 +1,242 @@
+/**
+ * @jest-environment node
+ *
+ * Integration tests for RFC 13da049f Phase 6.2/6.3 plugin bootstrap, exercising
+ * the REAL `GitSubmoduleOps` `.gitmodules` text manipulation + `renameIntoVault`
+ * against a real tmpdir vault. The tarball pull is faked (no network) but the
+ * staging→vault move + `.gitmodules` write are real filesystem operations, so
+ * this proves the end-to-end materialisation contract:
+ *   empty vault → bootstrap → `.gitmodules` has 2 entries + assetspaces/exo +
+ *   assetspaces/exocmd populated.
+ */
+
+/* eslint-disable no-restricted-imports, import/no-nodejs-modules */
+import { promises as fs } from "node:fs";
+import * as path from "node:path";
+import * as os from "node:os";
+/* eslint-enable no-restricted-imports, import/no-nodejs-modules */
+
+import { GitSubmoduleOps } from "../../../src/infrastructure/adapters/GitSubmoduleOps";
+import {
+  BootstrapAssetSpaceCommands,
+  type IAssetSpacePuller,
+  type IFileOnlyAssetSpaceStore,
+} from "../../../src/infrastructure/adapters/BootstrapAssetSpaceCommands";
+
+const EXO_URL = "https://github.com/kitelev/exoas-exo";
+const EXOCMD_URL = "https://github.com/kitelev/exoas-exocmd";
+
+async function makeTmpVault(): Promise<string> {
+  return fs.mkdtemp(path.join(os.tmpdir(), "exo-bootstrap-it-"));
+}
+
+/**
+ * Fake puller — materialises a fake AssetSpace into a fresh staging dir (a
+ * single `<sha>.md` file) and returns the real staging path so the real
+ * `renameIntoVault` can move it into the vault.
+ */
+function makeFakePuller(): IAssetSpacePuller {
+  return {
+    pullAssetSpace: async (asUid: string, _url: string, _ref?: string) => {
+      const staging = await fs.mkdtemp(
+        path.join(os.tmpdir(), `exo-staging-${asUid}-`),
+      );
+      await fs.writeFile(
+        path.join(staging, "73bd00e4-ccc0-4f3f-b20d-c4388c4588fb.md"),
+        "---\nexo__Asset_uid: 73bd00e4\n---\n",
+        "utf8",
+      );
+      return { asUid, stagingPath: staging, sha: "deadbee" };
+    },
+  };
+}
+
+function makeVaultProbes(vaultRoot: string) {
+  return {
+    vaultExists: async (p: string): Promise<boolean> => {
+      try {
+        await fs.access(path.join(vaultRoot, p));
+        return true;
+      } catch {
+        return false;
+      }
+    },
+    listFolder: async (
+      dir: string,
+    ): Promise<{ files: string[]; folders: string[] }> => {
+      const abs = path.join(vaultRoot, dir);
+      const files: string[] = [];
+      const folders: string[] = [];
+      let entries: import("node:fs").Dirent[];
+      try {
+        entries = await fs.readdir(abs, { withFileTypes: true });
+      } catch {
+        return { files, folders };
+      }
+      for (const e of entries) {
+        const rel = `${dir}/${e.name}`;
+        if (e.isDirectory()) folders.push(rel);
+        else files.push(rel);
+      }
+      return { files, folders };
+    },
+  };
+}
+
+function makeFakeLocalStore(): {
+  store: IFileOnlyAssetSpaceStore;
+  entries: Array<{ folderName: string; url: string; sha: string }>;
+} {
+  const entries: Array<{ folderName: string; url: string; sha: string }> = [];
+  return {
+    entries,
+    store: {
+      upsertFileOnlyAssetSpace: async (e) => {
+        entries.push({ folderName: e.folderName, url: e.url, sha: e.sha });
+      },
+    },
+  };
+}
+
+describe("Bootstrap integration — real GitSubmoduleOps + tmpdir vault (git mode)", () => {
+  let vaultRoot: string;
+  afterEach(async () => {
+    if (vaultRoot) await fs.rm(vaultRoot, { recursive: true, force: true });
+  });
+
+  it("empty vault → bootstrap → 2 .gitmodules entries + assetspaces/exo + assetspaces/exocmd populated", async () => {
+    vaultRoot = await makeTmpVault();
+    const gitOps = new GitSubmoduleOps({ vaultRootPath: vaultRoot });
+    const probes = makeVaultProbes(vaultRoot);
+    const { store } = makeFakeLocalStore();
+    const notices: string[] = [];
+
+    const cmds = new BootstrapAssetSpaceCommands({
+      puller: makeFakePuller(),
+      gitOps,
+      localStore: store,
+      vaultExists: probes.vaultExists,
+      listFolder: probes.listFolder,
+      isGitVault: async () => true,
+      validateUrl: () => undefined,
+      deriveFolderName: (u) => u.split("/").pop() ?? "x",
+      promptBootstrapUrls: async () => ({
+        exoUrl: EXO_URL,
+        exocmdUrl: EXOCMD_URL,
+      }),
+      promptAddAssetSpaceUrl: async () => null,
+      confirm: async () => true,
+      notify: (m) => notices.push(m),
+    });
+
+    await cmds.invokeBootstrap();
+
+    // Both folders materialised with the fake AssetSpace file.
+    const exoFile = path.join(
+      vaultRoot,
+      "assetspaces/exo/73bd00e4-ccc0-4f3f-b20d-c4388c4588fb.md",
+    );
+    const exocmdFile = path.join(
+      vaultRoot,
+      "assetspaces/exocmd/73bd00e4-ccc0-4f3f-b20d-c4388c4588fb.md",
+    );
+    await expect(fs.access(exoFile)).resolves.toBeUndefined();
+    await expect(fs.access(exocmdFile)).resolves.toBeUndefined();
+
+    // `.gitmodules` has exactly the two TS-floor entries.
+    const entries = await gitOps.readGitmodulesEntries();
+    expect(entries).toEqual([
+      { submodulePath: "assetspaces/exo", url: EXO_URL },
+      { submodulePath: "assetspaces/exocmd", url: EXOCMD_URL },
+    ]);
+
+    expect(notices.some((n) => /Bootstrap complete/.test(n))).toBe(true);
+  });
+
+  it("re-running bootstrap on a populated vault is a no-op", async () => {
+    vaultRoot = await makeTmpVault();
+    // Seed assetspaces/exo with content so detectVaultState → bootstrapped.
+    await fs.mkdir(path.join(vaultRoot, "assetspaces/exo"), {
+      recursive: true,
+    });
+    await fs.writeFile(
+      path.join(vaultRoot, "assetspaces/exo/seed.md"),
+      "x",
+      "utf8",
+    );
+    const gitOps = new GitSubmoduleOps({ vaultRootPath: vaultRoot });
+    const probes = makeVaultProbes(vaultRoot);
+    const { store } = makeFakeLocalStore();
+    const puller = makeFakePuller();
+    const pullSpy = jest.spyOn(puller, "pullAssetSpace");
+
+    const cmds = new BootstrapAssetSpaceCommands({
+      puller,
+      gitOps,
+      localStore: store,
+      vaultExists: probes.vaultExists,
+      listFolder: probes.listFolder,
+      isGitVault: async () => true,
+      validateUrl: () => undefined,
+      deriveFolderName: (u) => u.split("/").pop() ?? "x",
+      promptBootstrapUrls: async () => ({
+        exoUrl: EXO_URL,
+        exocmdUrl: EXOCMD_URL,
+      }),
+      promptAddAssetSpaceUrl: async () => null,
+      confirm: async () => true,
+      notify: () => undefined,
+    });
+
+    await cmds.invokeBootstrap();
+    expect(pullSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe("GitSubmoduleOps.appendGitmodulesEntry — real fs", () => {
+  let vaultRoot: string;
+  afterEach(async () => {
+    if (vaultRoot) await fs.rm(vaultRoot, { recursive: true, force: true });
+  });
+
+  it("creates .gitmodules when missing, then is idempotent", async () => {
+    vaultRoot = await makeTmpVault();
+    const gitOps = new GitSubmoduleOps({ vaultRootPath: vaultRoot });
+
+    const r1 = await gitOps.appendGitmodulesEntry("assetspaces/exo", EXO_URL);
+    expect(r1.added).toBe(true);
+    const r2 = await gitOps.appendGitmodulesEntry("assetspaces/exo", EXO_URL);
+    expect(r2.added).toBe(false); // idempotent — no duplicate stanza
+
+    const raw = await fs.readFile(
+      path.join(vaultRoot, ".gitmodules"),
+      "utf8",
+    );
+    const headerCount = (raw.match(/\[submodule "assetspaces\/exo"\]/g) ?? [])
+      .length;
+    expect(headerCount).toBe(1);
+  });
+
+  it("appends a second distinct entry preserving the first", async () => {
+    vaultRoot = await makeTmpVault();
+    const gitOps = new GitSubmoduleOps({ vaultRootPath: vaultRoot });
+    await gitOps.appendGitmodulesEntry("assetspaces/exo", EXO_URL);
+    await gitOps.appendGitmodulesEntry("assetspaces/exocmd", EXOCMD_URL);
+    const entries = await gitOps.readGitmodulesEntries();
+    expect(entries).toEqual([
+      { submodulePath: "assetspaces/exo", url: EXO_URL },
+      { submodulePath: "assetspaces/exocmd", url: EXOCMD_URL },
+    ]);
+  });
+
+  it("rejects path traversal / non-github URL", async () => {
+    vaultRoot = await makeTmpVault();
+    const gitOps = new GitSubmoduleOps({ vaultRootPath: vaultRoot });
+    await expect(
+      gitOps.appendGitmodulesEntry("../escape", EXO_URL),
+    ).rejects.toThrow();
+    await expect(
+      gitOps.appendGitmodulesEntry("assetspaces/x", "https://evil.com/a/b"),
+    ).rejects.toThrow();
+  });
+});

--- a/packages/obsidian-plugin/tests/unit/presentation/modals/BootstrapModals.test.ts
+++ b/packages/obsidian-plugin/tests/unit/presentation/modals/BootstrapModals.test.ts
@@ -1,0 +1,250 @@
+/**
+ * Unit tests for the RFC 13da049f Phase 6.2/6.3 modals (BootstrapVaultModal,
+ * AddAssetSpaceModal, SimpleConfirmModal).
+ *
+ * Local `jest.mock("obsidian")` provides a Modal that mounts `contentEl` into
+ * `document.body` on `open()` and a `createEl` helper that copies the
+ * attributes these modals rely on (type / placeholder / cls / text), so DOM
+ * queries and `.value` reads behave like real Obsidian.
+ */
+import { describe, it, expect, beforeEach, jest } from "@jest/globals";
+
+jest.mock("obsidian", () => {
+  interface CreateOpts {
+    cls?: string;
+    text?: string;
+    type?: string;
+    placeholder?: string;
+  }
+  function augment(el: HTMLElement): void {
+    (el as unknown as { createEl: (tag: string, o?: CreateOpts) => HTMLElement }).createEl =
+      function (tag: string, o?: CreateOpts): HTMLElement {
+        const child = document.createElement(tag);
+        if (o?.cls) child.className = o.cls;
+        if (o?.text) child.textContent = o.text;
+        if (o?.type) child.setAttribute("type", o.type);
+        if (o?.placeholder) child.setAttribute("placeholder", o.placeholder);
+        this.appendChild(child);
+        augment(child);
+        return child;
+      }.bind(el);
+    // Obsidian augments HTMLElement with `.empty()`; mirror it for onClose.
+    (el as unknown as { empty: () => void }).empty = function (): void {
+      while (this.firstChild) this.removeChild(this.firstChild);
+    }.bind(el);
+  }
+  class MockModal {
+    app: unknown;
+    contentEl: HTMLElement;
+    constructor(app: unknown) {
+      this.app = app;
+      this.contentEl = document.createElement("div");
+      augment(this.contentEl);
+    }
+    open(): void {
+      document.body.appendChild(this.contentEl);
+      this.onOpen();
+    }
+    close(): void {
+      this.onClose();
+      if (this.contentEl.parentNode) {
+        this.contentEl.parentNode.removeChild(this.contentEl);
+      }
+    }
+    onOpen(): void {}
+    onClose(): void {}
+  }
+  return { Modal: MockModal, App: class {} };
+});
+
+import type { App } from "obsidian";
+import {
+  BootstrapVaultModal,
+  isLikelyGitHubUrl,
+} from "../../../../src/presentation/modals/BootstrapVaultModal";
+import { AddAssetSpaceModal } from "../../../../src/presentation/modals/AddAssetSpaceModal";
+import { SimpleConfirmModal } from "../../../../src/presentation/modals/SimpleConfirmModal";
+
+const fakeApp = {} as unknown as App;
+
+function findButton(label: string): HTMLButtonElement | undefined {
+  return Array.from(document.querySelectorAll("button")).find(
+    (b) => b.textContent === label,
+  );
+}
+
+beforeEach(() => {
+  document.body.innerHTML = "";
+});
+
+describe("isLikelyGitHubUrl", () => {
+  it.each([
+    "https://github.com/kitelev/exoas-exo",
+    "https://github.com/a/b",
+  ])("accepts %s", (u) => expect(isLikelyGitHubUrl(u)).toBe(true));
+
+  it.each([
+    "",
+    "http://github.com/a/b",
+    "https://gitlab.com/a/b",
+    "https://github.com/a",
+    "https://github.com/a/b/c",
+  ])("rejects %s", (u) => expect(isLikelyGitHubUrl(u)).toBe(false));
+});
+
+describe("BootstrapVaultModal", () => {
+  it("EC7 — URL fields start empty with kitelev example placeholders", () => {
+    let result: unknown;
+    new BootstrapVaultModal(fakeApp, (r) => {
+      result = r;
+    }).open();
+
+    const inputs = Array.from(
+      document.querySelectorAll("input"),
+    ) as HTMLInputElement[];
+    expect(inputs).toHaveLength(2);
+    expect(inputs[0].value).toBe("");
+    expect(inputs[1].value).toBe("");
+    expect(inputs[0].getAttribute("placeholder")).toBe(
+      "https://github.com/kitelev/exoas-exo",
+    );
+    expect(inputs[1].getAttribute("placeholder")).toBe(
+      "https://github.com/kitelev/exoas-exocmd",
+    );
+    expect(result).toBeUndefined(); // not settled yet
+  });
+
+  it("R31 — shows the no-transitive note", () => {
+    new BootstrapVaultModal(fakeApp, () => undefined).open();
+    expect(document.body.textContent).toMatch(
+      /dependencies are not added automatically/i,
+    );
+  });
+
+  it("empty fields → Bootstrap shows error, does not settle", () => {
+    let result: unknown = "sentinel";
+    new BootstrapVaultModal(fakeApp, (r) => {
+      result = r;
+    }).open();
+    findButton("Bootstrap")!.click();
+    expect(result).toBe("sentinel"); // unchanged — not resolved
+    expect(document.body.textContent).toMatch(/required/i);
+  });
+
+  it("invalid URL → error, does not settle", () => {
+    let result: unknown = "sentinel";
+    new BootstrapVaultModal(fakeApp, (r) => {
+      result = r;
+    }).open();
+    const inputs = document.querySelectorAll("input");
+    (inputs[0] as HTMLInputElement).value = "not-a-url";
+    (inputs[1] as HTMLInputElement).value =
+      "https://github.com/kitelev/exoas-exocmd";
+    findButton("Bootstrap")!.click();
+    expect(result).toBe("sentinel");
+  });
+
+  it("valid URLs → resolves the entered pair", () => {
+    let result: { exoUrl: string; exocmdUrl: string } | null | undefined;
+    new BootstrapVaultModal(fakeApp, (r) => {
+      result = r;
+    }).open();
+    const inputs = document.querySelectorAll("input");
+    (inputs[0] as HTMLInputElement).value = "https://github.com/me/exo";
+    (inputs[1] as HTMLInputElement).value = "https://github.com/me/exocmd";
+    findButton("Bootstrap")!.click();
+    expect(result).toEqual({
+      exoUrl: "https://github.com/me/exo",
+      exocmdUrl: "https://github.com/me/exocmd",
+    });
+  });
+
+  it("Cancel → resolves null", () => {
+    let result: unknown = "sentinel";
+    new BootstrapVaultModal(fakeApp, (r) => {
+      result = r;
+    }).open();
+    findButton("Cancel")!.click();
+    expect(result).toBeNull();
+  });
+});
+
+describe("AddAssetSpaceModal", () => {
+  const derive = (u: string): string => {
+    const repo = u.split("/").pop() ?? "x";
+    return repo.startsWith("exoas-") ? repo.slice("exoas-".length) : repo;
+  };
+
+  it("live-previews the derived target folder", () => {
+    new AddAssetSpaceModal(fakeApp, derive, () => undefined).open();
+    const input = document.querySelector("input") as HTMLInputElement;
+    input.value = "https://github.com/kitelev/exoas-pmbok-ontology";
+    input.dispatchEvent(new Event("input"));
+    expect(document.body.textContent).toMatch(
+      /Target folder: assetspaces\/pmbok-ontology/,
+    );
+  });
+
+  it("valid URL → resolves it", () => {
+    let result: { url: string } | null | undefined;
+    new AddAssetSpaceModal(fakeApp, derive, (r) => {
+      result = r;
+    }).open();
+    const input = document.querySelector("input") as HTMLInputElement;
+    input.value = "https://github.com/me/thing";
+    findButton("Add")!.click();
+    expect(result).toEqual({ url: "https://github.com/me/thing" });
+  });
+
+  it("invalid URL → error, no resolve", () => {
+    let result: unknown = "sentinel";
+    new AddAssetSpaceModal(fakeApp, derive, (r) => {
+      result = r;
+    }).open();
+    const input = document.querySelector("input") as HTMLInputElement;
+    input.value = "ftp://nope";
+    findButton("Add")!.click();
+    expect(result).toBe("sentinel");
+  });
+
+  it("Cancel → resolves null", () => {
+    let result: unknown = "sentinel";
+    new AddAssetSpaceModal(fakeApp, derive, (r) => {
+      result = r;
+    }).open();
+    findButton("Cancel")!.click();
+    expect(result).toBeNull();
+  });
+});
+
+describe("SimpleConfirmModal", () => {
+  it("confirm button → resolves true", () => {
+    let result: boolean | undefined;
+    new SimpleConfirmModal(
+      fakeApp,
+      { title: "T", body: "B", confirmLabel: "Fetch" },
+      (r) => {
+        result = r;
+      },
+    ).open();
+    findButton("Fetch")!.click();
+    expect(result).toBe(true);
+  });
+
+  it("cancel / dismiss → resolves false exactly once", () => {
+    let calls = 0;
+    let result: boolean | undefined;
+    const modal = new SimpleConfirmModal(
+      fakeApp,
+      { title: "T", body: "B" },
+      (r) => {
+        calls++;
+        result = r;
+      },
+    );
+    modal.open();
+    findButton("Cancel")!.click();
+    expect(result).toBe(false);
+    expect(calls).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary

Plugin-side **Bootstrap vault** + **Add assetspace by URL** palette commands + modals for RFC `13da049f` Phase 6.2/6.3. Mirrors the v16.57.0 CLI (`bootstrap` / `assetspace-add`) but runs inside Obsidian, **reusing Phase 5 infra** (`AssetSpaceManager.pullAssetSpace` REST pull + `GitSubmoduleOps` staging-move/`.gitmodules`) — no REST/tarball/security logic duplicated.

Desktop-only (Phase 6 scope, like Phase 5): commands register only when the hard-switch deps are wired (`!Platform.isMobile` + `vault.adapter.basePath`).

## What's included

- **`BootstrapAssetSpaceCommands`** — pure-logic handler (Obsidian-free, fully injected deps):
  - `detectVaultState` → `empty` / `bootstrapped` / `clone-needs-fetch`.
  - `invokeBootstrap` — TS-floor (exo + exocmd) into fixed `assetspaces/exo` + `assetspaces/exocmd`.
  - `invokeAddAssetSpace` — single AssetSpace into URL-derived folder.
- **Modals**: `BootstrapVaultModal`, `AddAssetSpaceModal` (live folder preview), `SimpleConfirmModal` (EC2 gate).
- **`GitSubmoduleOps`**: idempotent `appendGitmodulesEntry` + `readGitmodulesEntries` (additive, `.gitmodules` text manipulation).
- **`PluginLocalDataStore`**: file-only AssetSpace registry (RMW-preserving sibling keys).

## Acceptance criteria

- **AC1/AC3** — Bootstrap vault (exo+exocmd) + Add AssetSpace by URL, via `AssetSpaceManager.pullAssetSpace` → `renameIntoVault` → `.gitmodules` append. ✅
- **AC10/M19** — non-git vault → file-only mode (no `.gitmodules`; tracked in `data.local.json`), with warning notice. ✅
- **EC2** (clone-from-another-machine) — `.gitmodules` populated but folders empty → confirm → re-materialise from preserved URLs. ✅
- **EC7** — URL fields **empty** by default; `kitelev/exoas-*` shown only as placeholder examples (not pre-filled). ✅
- **R31** — modal note: add each required AssetSpace manually (no transitive auto-add). ✅

## Tests

- Unit: 16 command (`detectVaultState`, bootstrap git/file-only, EC2 yes/no, cancel, invalid-URL, pull-failure, add-assetspace) + 4 `parseGitmodulesEntries` + 5 file-only registry + 18 modal (EC7 empty/placeholders, R31 note, validation, cancel, folder preview).
- Integration (real `GitSubmoduleOps` + tmpdir vault): empty vault → bootstrap → **`.gitmodules` 2 entries + `assetspaces/exo` + `assetspaces/exocmd` populated**; idempotent append; path-traversal/non-github rejection.
- `obsidian-plugin` suite **5467/5467 green** locally; lint (src) + typecheck clean.

> **UI smoke (live Obsidian) deferred** to orchestrator/user per prompt.
> One pre-existing local CLI flake (`sparql-exo003.integration` — untouched `packages/cli`, passes in isolation, fails only under batched resource pressure) is unrelated to this PR.

## Test plan

- [ ] CI 14/14 green
- [ ] code-reviewer + advisor round-2
- [ ] UI smoke in live Obsidian (orchestrator/user): empty vault → «Bootstrap vault» → exo+exocmd materialise + `.gitmodules` has 2 entries; «Add assetspace by URL» → folder preview + materialise