### PR TITLE
docs(profiles): Knowledge/Focus Settings labels + profiles.md (RFC 13da049f R35/AC13)

### DIFF
--- a/docs/focus-profile.md
+++ b/docs/focus-profile.md
@@ -5,6 +5,15 @@
 > **Audience:** Engineers and technical Obsidian users.
 > **Position:** Architectural cornerstone — the feature that makes Exocortex genuinely multi-context.
 
+> ⚠️ **Terminology update (v16.59, RFC 13da049f).** This page predates the
+> **Knowledge profile vs Focus profile** split. Since then the two switch modes
+> are first-class, separately-named profile types: the **hard switch** described
+> below is now the **Knowledge profile** (`exo__KnowledgeProfile`), and the
+> **soft switch** is the **Focus profile** (`exo__FocusProfile`). For the
+> distinction, examples, and which one to edit, start with
+> **[profiles.md](./profiles.md)**; read the "hard switch" sections here as the
+> Knowledge-profile machinery.
+
 ---
 
 ## What FocusProfile is

--- a/docs/profiles.md
+++ b/docs/profiles.md
@@ -24,7 +24,7 @@ is the one-paragraph answer plus the details.
 | Changes how often?  | Rarely (weeks / months)                                                         | Often (hours / days)                        |
 | Active state        | `data.local.json.activeKnowledgeProfileUid`                                     | `data.local.json.activeFocusProfileUid`     |
 | Class               | `exo__KnowledgeProfile`                                                         | `exo__FocusProfile`                         |
-| Palette command     | `Exocortex: Switch knowledge profile`                                           | `Exocortex: Switch focus profile`           |
+| Palette command     | `Exocortex: Switch knowledge profile (filesystem destroy + materialize)`        | `Exocortex: Switch focus profile`           |
 | Guarded by          | Confirmation prompt + uncommitted-changes abort                                 | Nothing — safe, non-destructive             |
 
 The two are **separate slots**. You can have a Knowledge profile and a Focus
@@ -62,7 +62,7 @@ and rewrites `.gitmodules`.
 
 - **Semantic:** "What knowledge IS materialized in the vault right now."
 - **Controls:** filesystem materialization — the actual `assetspaces/<as>/` content presence.
-- **Persistence:** permanent vault state (`.gitmodules` + materialized AS dirs), so it survives reloads and is the same across devices that synced the vault.
+- **Persistence:** the materialized content is permanent vault state (`.gitmodules` + materialized AS dirs) and syncs across devices that share the vault. The _active-profile pointer_ itself (`activeKnowledgeProfileUid`) lives in `data.local.json` and is **per-device** (Sync-excluded by the `.local.` infix), so "which Knowledge profile is active" can differ between phone and laptop even though the on-disk content is shared.
 - **User intent:** _"Install the pmbok ontology bundle — I'm starting project work."_
 - **Properties:**
   - `exo__KnowledgeProfile_includes` — Ontology / AssetSpace UIDs to materialize.

--- a/docs/profiles.md
+++ b/docs/profiles.md
@@ -1,0 +1,227 @@
+# Knowledge Profiles vs Focus Profiles
+
+> **Status:** Production since v16.59 (Knowledge/Focus split, RFC 13da049f Phase 6.5b).
+> **RFC:** [13da049f](https://github.com/kitelev/exocortex) — Knowledge/Focus profile split (AC13–AC17).
+> **Class declaration:** [52f2acdd](https://github.com/kitelev/exocortex) — `exo__KnowledgeProfile` TBox class + properties (sibling onto-RFC).
+> **Audience:** Anyone who saw two profile commands in the palette and asked "which profile do I edit?".
+
+Exocortex has **two independent profile types**. They sound similar but do
+completely different things, and confusing them is the single most common
+source of "why didn't my switch do anything?" (RFC 13da049f R35). This page
+is the one-paragraph answer plus the details.
+
+---
+
+## TL;DR
+
+|                     | **Knowledge profile**                                                           | **Focus profile**                           |
+| ------------------- | ------------------------------------------------------------------------------- | ------------------------------------------- |
+| Question it answers | "What knowledge **exists on disk** right now?"                                  | "What am I **looking at** right now?"       |
+| Mechanism           | Hard switch — materializes / tears down AssetSpace submodules on the filesystem | Soft switch — query-time RDF filter         |
+| Touches disk?       | **Yes** — writes/deletes files, rewrites `.gitmodules`                          | **No** — in-memory triple-store filter only |
+| Speed               | Heavyweight (~30 s per freshly-pulled AssetSpace)                               | Lightweight (~1–2 s reindex)                |
+| Reversible?         | Yes, but re-materializing costs time                                            | Instantly                                   |
+| Changes how often?  | Rarely (weeks / months)                                                         | Often (hours / days)                        |
+| Active state        | `data.local.json.activeKnowledgeProfileUid`                                     | `data.local.json.activeFocusProfileUid`     |
+| Class               | `exo__KnowledgeProfile`                                                         | `exo__FocusProfile`                         |
+| Palette command     | `Exocortex: Switch knowledge profile`                                           | `Exocortex: Switch focus profile`           |
+| Guarded by          | Confirmation prompt + uncommitted-changes abort                                 | Nothing — safe, non-destructive             |
+
+The two are **separate slots**. You can have a Knowledge profile and a Focus
+profile active at the same time, and switching one never touches the other.
+`Exocortex: Show current state` reports both, e.g. `Knowledge: Work · Focus: Sprint-23`.
+
+---
+
+## Industry analogs
+
+If you have used any of these tools, you already understand the split — it is
+the same "what is installed" vs "what am I filtering to" distinction (RFC 13da049f v1.3).
+
+| System    | "Knowledge layout" (hard switch)      | "Focus filter" (soft switch) |
+| --------- | ------------------------------------- | ---------------------------- |
+| VS Code   | workspace folders (`.code-workspace`) | file / symbol search filter  |
+| Browser   | installed extensions                  | active tabs / tab groups     |
+| Music     | library / albums on disk              | playlist / current queue     |
+| Linux     | `apt install` packages                | `grep` / `ps` filter         |
+| Git       | branch checkout (materialized files)  | `git log --grep` filter      |
+| Exocortex | `exo__KnowledgeProfile`               | `exo__FocusProfile`          |
+
+Installing a VS Code extension changes what code exists in your environment;
+typing in the search box only changes what you currently see. Knowledge and
+Focus profiles are exactly that pair.
+
+---
+
+## Knowledge profile — storage
+
+A **Knowledge profile** (`exo__KnowledgeProfile`) declares **what knowledge is
+materialized in the vault**. Switching it is a _hard switch_: the plugin
+physically pulls in or tears down AssetSpace submodules under `assetspaces/`
+and rewrites `.gitmodules`.
+
+- **Semantic:** "What knowledge IS materialized in the vault right now."
+- **Controls:** filesystem materialization — the actual `assetspaces/<as>/` content presence.
+- **Persistence:** permanent vault state (`.gitmodules` + materialized AS dirs), so it survives reloads and is the same across devices that synced the vault.
+- **User intent:** _"Install the pmbok ontology bundle — I'm starting project work."_
+- **Properties:**
+  - `exo__KnowledgeProfile_includes` — Ontology / AssetSpace UIDs to materialize.
+  - `exo__KnowledgeProfile_extends` — another KnowledgeProfile to inherit from (materialization is unioned).
+  - `exo__KnowledgeProfile_alwaysOnOverlay` — AssetSpaces always materialized regardless of which profile is active (the TS-floor).
+
+**When to reach for it:** installing or removing whole ontology bundles;
+shrinking the vault so an iPhone reindex is fast; keeping privacy-sensitive
+content physically off a device (a forensic snapshot in the wrong profile
+contains _zero bytes_ of the other profile's content).
+
+Because a hard switch deletes local files, it is deliberately gated:
+
+1. A **TS-floor assertion** refuses targets that would brick the plugin (no `exo` / `exocmd` / `profiles` → no class definitions, no commands).
+2. An **uncommitted-changes abort** stops the switch and lists affected files if any AssetSpace has unsaved work — commit or stash first.
+3. A **confirmation prompt** (the `ModalConfirmGate`) requires explicit consent before any destruction.
+
+The full 2-phase-commit mechanics, crash recovery, and cache layer are
+documented in [focus-profile.md](./focus-profile.md) (written before the
+terminology split — read its "hard switch" sections as the **Knowledge
+profile** machinery).
+
+---
+
+## Focus profile — filter
+
+A **Focus profile** (`exo__FocusProfile`) declares **what slice of the
+already-materialized vault you want to see**. Switching it is a _soft switch_:
+a query-time RDF filter. Nothing on disk changes.
+
+- **Semantic:** "What I'm focused on right NOW, within the materialized vault."
+- **Controls:** an RDF filter applied at query time — search, SPARQL, graph view, and command palette only surface the included slice.
+- **Persistence:** ephemeral, per-device session state. Switching focus on the laptop does not drag the phone along.
+- **User intent:** _"Show only the ems\_\_Task instances of this sprint."_
+- **Properties:**
+  - `exo__FocusProfile_includes` — Ontology / AssetSpace UIDs to filter to. Must be a subset of the active Knowledge profile's effective set (you can only focus on things that are actually on disk).
+  - `exo__FocusProfile_extends` — another FocusProfile to inherit from.
+  - `exo__FocusProfile_appliesTo` — the KnowledgeProfile this focus is designed for (a compatibility hint; see "Compatibility" below).
+
+**When to reach for it:** narrowing the noise during work hours without losing
+the option to switch back instantly. It is the daily driver; the Knowledge
+profile is the occasional escalation.
+
+You can drive the Focus slot from the **Settings → "Active focus profile"
+dropdown** as well as the palette command.
+
+---
+
+## Composition — Focus slices within Knowledge
+
+A Knowledge profile defines the **container universe on disk**. A Focus profile
+**slices within** that container. They stack:
+
+```
+KnowledgeProfile  P-work  materializes:  {exo, exocmd, profiles, ems, pmbok, kitelev-work}
+                                          ↑ container universe ON DISK (hard switch)
+
+  FocusProfile  F-sprint-23  filters to:  {ems-tasks-current-sprint}
+  FocusProfile  F-pmbok-risks filters to: {pmbok-risks-active}
+  FocusProfile  F-mentoring   filters to: {ems-meetings-with-juniors}
+                                          ↑ slices WITHIN P-work's materialized container (soft switch)
+```
+
+Active dual state at any moment:
+
+- `activeKnowledgeProfileUid: <P-work-uid>` — rarely changes.
+- `activeFocusProfileUid: <F-sprint-23-uid>` — changes frequently.
+
+A Focus profile can only include AssetSpaces present in the active Knowledge
+profile's effective set. Focusing on `pmbok` while the active Knowledge profile
+hasn't materialized `pmbok` has nothing to filter — materialize it first.
+
+---
+
+## ⚠️ No transitive expansion (R31)
+
+**Adding an ontology to a profile is NOT transitive.** Listing `pmbok` in a
+profile's `_includes` does **not** auto-add `ems`, even though `pmbok`
+references `ems`. You must add **every** AssetSpace the profile needs,
+explicitly, by hand.
+
+```yaml
+# WRONG — assumes pmbok pulls in its dependencies. It does not.
+exo__KnowledgeProfile_includes:
+  - "[[<pmbok-uid>]]"
+
+# RIGHT — list each AssetSpace the profile actually needs.
+exo__KnowledgeProfile_includes:
+  - "[[<pmbok-uid>]]"
+  - "[[<ems-uid>]]"
+  - "[[<shared-identities-uid>]]"
+```
+
+This is a deliberate Phase 6 limitation (RFC 13da049f R31, BLOCKER-level):
+`.gitmodules` is a flat manifest and cannot express the semver-range /
+transitive-resolution graph that an `npm`-style `package.json` would. A future
+"Phase 7 transitive" RFC may lift this once an ecosystem need emerges. Until
+then: **if a switch leaves a query empty, check that you listed every
+AssetSpace it depends on.**
+
+---
+
+## Dual-class instances (backward compatibility)
+
+The profiles that existed before the split — `profile-base`,
+`profile-personal`, `profile-work`, `profile-reading` — were migrated to be
+**dual-class**: each carries _both_ `exo__KnowledgeProfile` and
+`exo__FocusProfile` in its `exo__Instance_class`.
+
+```yaml
+# Before the split — a single FocusProfile
+exo__Instance_class:
+  - "[[<exo__FocusProfile-class-uid>]]"
+exo__FocusProfile_includes: [Ontology UIDs]
+
+# After migration — dual-class (appears in BOTH palettes)
+exo__Instance_class:
+  - "[[<exo__KnowledgeProfile-class-uid>]]"   # NEW
+  - "[[<exo__FocusProfile-class-uid>]]"        # preserved
+exo__KnowledgeProfile_includes: [Ontology UIDs]   # copied from FocusProfile_includes
+exo__FocusProfile_includes: [Ontology UIDs]       # preserved (same list)
+```
+
+The same `_includes` list serves both roles initially, which preserves exactly
+the pre-split behavior. Practical consequences:
+
+- A dual-class profile shows up in **both** `Switch knowledge profile` and `Switch focus profile` pickers — that is expected, not a bug.
+- You can **demote** a dual-class profile to a single role anytime by editing the asset: drop the class you don't want and its matching `_includes` property. A profile you only ever filter with should be FocusProfile-only; a heavyweight on-disk bundle should be KnowledgeProfile-only.
+- Demotion is a plain vault edit — no migration tool, no plugin restart beyond the usual reindex.
+
+---
+
+## Compatibility (AC16) — WARN, don't break
+
+If a Focus profile's `_includes` is not a subset of the active Knowledge
+profile's effective set, the soft switch **does not throw and does not
+silently drop your filter**. It logs a WARN and applies no filter for the
+out-of-set AssetSpaces, matching the "graceful degradation" pattern that
+browser extensions (disable cleanly) and music apps (grey-out missing tracks)
+use. The `exo__FocusProfile_appliesTo` property documents the intended
+Knowledge profile so you can see the mismatch coming.
+
+---
+
+## Quick decision guide
+
+- "I want a whole ontology to **exist** / stop existing on disk" → **Knowledge profile** (`Switch knowledge profile`).
+- "I want to **see less** without changing what's installed" → **Focus profile** (`Switch focus profile`, or the Settings dropdown).
+- "My switch did nothing visible" → you probably edited the wrong slot, or hit the no-transitive gap. Run `Show current state` and re-check `_includes`.
+- "Which slot is active?" → `Exocortex: Show current state`, or Settings → Active focus profile (the status line shows both slots).
+
+---
+
+## See also
+
+- **[focus-profile.md](./focus-profile.md)** — deep mechanics of the soft / hard switch (2-phase commit, crash recovery, cross-device sync, CLI parity). Predates the terminology split: its "hard switch" is the Knowledge-profile machinery.
+- **[../README.md](../README.md)** — high-level feature blurb.
+- **[../VISION.md](../VISION.md)** — Vault-as-Graph + homoiconic profiles + UID-canon positioning.
+- **RFC `13da049f`** — Knowledge/Focus split (this distinction, R31 no-transitive, R35 confusion, AC13–AC17).
+- **RFC `52f2acdd`** — `exo__KnowledgeProfile` TBox class declaration.
+- **RFC `b6ba5595`** — original FocusProfile RFC (soft switch).
+- **RFC `22b50a17`** — Phase 5 RFC (hard switch, 2-phase commit, materialization tracker).

--- a/packages/obsidian-plugin/src/presentation/settings/ExocortexSettingTab.ts
+++ b/packages/obsidian-plugin/src/presentation/settings/ExocortexSettingTab.ts
@@ -601,7 +601,8 @@ export class ExocortexSettingTab extends PluginSettingTab {
         "submodules on disk (and rewrites .gitmodules). Heavyweight: a " +
         "confirmation gate, an uncommitted-changes guard, and ~30 s per " +
         "freshly-pulled AssetSpace. Pick a KnowledgeProfile asset via the " +
-        "«Exocortex: Switch knowledge profile» command (Cmd+P). Use it to " +
+        "«Exocortex: Switch knowledge profile (filesystem destroy + " +
+        "materialize)» command (Cmd+P). Use it to " +
         "install or remove whole ontology bundles and to keep " +
         "privacy-sensitive content physically off the device.",
     );

--- a/packages/obsidian-plugin/src/presentation/settings/ExocortexSettingTab.ts
+++ b/packages/obsidian-plugin/src/presentation/settings/ExocortexSettingTab.ts
@@ -578,6 +578,50 @@ export class ExocortexSettingTab extends PluginSettingTab {
     const switchCache = new SwitchCacheLayer();
     const operationsLog = new OperationsLogReader({ app });
 
+    // ─────── Section 0 — Knowledge vs Focus overview (RFC 13da049f R35) ───────
+    // R35: users were confused about «which profile do I edit?». The two
+    // profile types are independent slots with different mechanisms; this
+    // overview block names them up-front so the sections below read clearly.
+    new Setting(containerEl).setName("Knowledge and focus profiles").setHeading();
+
+    const profilesOverviewEl = containerEl.createDiv({
+      cls: "setting-item-description",
+    });
+    profilesOverviewEl.createEl("p", {
+      text:
+        "Two independent profile types control what you see. They are " +
+        "separate slots — a Knowledge profile and a Focus profile can be " +
+        "active at the same time, and switching one never touches the other.",
+    });
+    const profilesOverviewList = profilesOverviewEl.createEl("ul");
+    const knowledgeLi = profilesOverviewList.createEl("li");
+    knowledgeLi.createEl("strong", { text: "Knowledge profile — storage." });
+    knowledgeLi.appendText(
+      " A hard switch that physically materializes or tears down AssetSpace " +
+        "submodules on disk (and rewrites .gitmodules). Heavyweight: a " +
+        "confirmation gate, an uncommitted-changes guard, and ~30 s per " +
+        "freshly-pulled AssetSpace. Pick a KnowledgeProfile asset via the " +
+        "«Exocortex: Switch knowledge profile» command (Cmd+P). Use it to " +
+        "install or remove whole ontology bundles and to keep " +
+        "privacy-sensitive content physically off the device.",
+    );
+    const focusLi = profilesOverviewList.createEl("li");
+    focusLi.createEl("strong", { text: "Focus profile — filter." });
+    focusLi.appendText(
+      " A soft switch that applies a query-time RDF filter; nothing changes " +
+        "on disk. Lightweight: ~1–2 s reindex, instantly reversible. Pick a " +
+        "FocusProfile asset via the dropdown below or the «Exocortex: Switch " +
+        "focus profile» command. Use it to narrow search / SPARQL / graph " +
+        "view to the slice you are working in right now.",
+    );
+    profilesOverviewEl.createEl("p", {
+      text:
+        "Adding an ontology to a profile is NOT transitive — listing pmbok " +
+        "does not auto-add ems. Add each AssetSpace the profile needs " +
+        "explicitly. See docs/profiles.md for the full distinction, " +
+        "examples, and composition rules.",
+    });
+
     // ─────── Section 1 — PAT (GitHub Personal Access Token) ───────
     // eslint-disable-next-line obsidianmd/ui/sentence-case -- "GitHub" + "PAT" are proper noun + established acronym
     new Setting(containerEl).setName("FocusProfile: GitHub PAT").setHeading();
@@ -669,26 +713,37 @@ export class ExocortexSettingTab extends PluginSettingTab {
     // `registerFocusProfileCommands` resolves (and undefined in unit
     // tests с partial plugin mocks); treat as no-active-profile before
     // then, matching the previous fallback behaviour.
-    const activeProfileUid = this.plugin.localDataStore
-      ? this.plugin.localDataStore.getActiveProfileUid()
+    //
+    // RFC 13da049f AC14 — the two slots are independent. The dropdown below
+    // drives the FOCUS slot (soft switch); the KNOWLEDGE slot is set by the
+    // «Switch knowledge profile» palette command. Surface both so the user
+    // sees the full state, not just the slot this section edits.
+    const activeKnowledgeProfileUid = this.plugin.localDataStore
+      ? this.plugin.localDataStore.getActiveKnowledgeProfileUid()
+      : null;
+    const activeFocusProfileUid = this.plugin.localDataStore
+      ? this.plugin.localDataStore.getActiveFocusProfileUid()
       : null;
 
     const profileStatusEl = containerEl.createDiv({
       cls: "setting-item-description",
     });
     profileStatusEl.appendText(
-      activeProfileUid === null
-        ? "No active profile (full vault loaded)."
-        : `Currently: ${activeProfileUid}`,
+      `Active — Knowledge (storage): ${activeKnowledgeProfileUid ?? "(none — full vault on disk)"}` +
+        ` · Focus (filter): ${activeFocusProfileUid ?? "(none — no query filter)"}`,
     );
 
     const profileSetting = new Setting(containerEl)
       .setName("Switch profile")
       .setDesc(
-        "Dispatches FocusProfileSwitchManager — same code path as the " +
-          "Cmd+P «Switch focus profile» command. Triggers RDF re-index. " +
-          "v3 dropdown: no «none» option (softSwitchFocusProfile requires a target " +
-          "UID — clear via plugin reload).",
+        "Soft switch (FOCUS slot) — applies a query-time RDF filter; nothing " +
+          "changes on disk. Same code path as the Cmd+P «Switch focus " +
+          "profile» command. Triggers an RDF re-index. To change which " +
+          "ontologies are materialized on disk (the KNOWLEDGE slot, a hard " +
+          "switch), use the «Switch knowledge profile» palette command " +
+          "instead — it is gated behind a confirmation prompt because it " +
+          "mutates the filesystem. No «none» option here: clear the focus " +
+          "filter via plugin reload.",
       );
 
     profileSetting.addDropdown((dropdown) => {
@@ -722,8 +777,8 @@ export class ExocortexSettingTab extends PluginSettingTab {
             : choice.label;
           dropdown.addOption(choice.uid, label);
         }
-        if (activeProfileUid !== null) {
-          dropdown.setValue(activeProfileUid);
+        if (activeFocusProfileUid !== null) {
+          dropdown.setValue(activeFocusProfileUid);
         }
       })();
 

--- a/packages/obsidian-plugin/tests/unit/ExocortexSettingTab.focusProfile.test.ts
+++ b/packages/obsidian-plugin/tests/unit/ExocortexSettingTab.focusProfile.test.ts
@@ -268,6 +268,36 @@ describe("ExocortexSettingTab — Issue #3320 FocusProfile sections", () => {
     expect(profileRow).toBeDefined();
   });
 
+  it("renders the Knowledge and focus profiles overview heading (RFC 13da049f R35)", () => {
+    settingTab.display();
+    const overview = settingCalls.find(
+      (c) => c.name === "Knowledge and focus profiles" && c.heading,
+    );
+    expect(overview).toBeDefined();
+  });
+
+  it("reads both Knowledge and Focus active slots for the dual-state status (AC14)", () => {
+    // Provide a device-local store exposing both AC14 getters so the
+    // status line can surface the dual slot state. The legacy
+    // getActiveProfileUid() must NOT be consulted for the status anymore.
+    const getActiveKnowledgeProfileUid = jest
+      .fn()
+      .mockReturnValue("knowledge-uid");
+    const getActiveFocusProfileUid = jest.fn().mockReturnValue("focus-uid");
+    const getActiveProfileUid = jest.fn().mockReturnValue("legacy-uid");
+    mockPlugin.localDataStore = {
+      getActiveKnowledgeProfileUid,
+      getActiveFocusProfileUid,
+      getActiveProfileUid,
+    };
+
+    settingTab.display();
+
+    expect(getActiveKnowledgeProfileUid).toHaveBeenCalled();
+    expect(getActiveFocusProfileUid).toHaveBeenCalled();
+    expect(getActiveProfileUid).not.toHaveBeenCalled();
+  });
+
   it("renders the Switch cache stats row with Clear button", () => {
     settingTab.display();
     const cacheRow = settingCalls.find((c) => c.name === "Cache stats");

--- a/packages/obsidian-plugin/tests/unit/ExocortexSettingTab.test.ts
+++ b/packages/obsidian-plugin/tests/unit/ExocortexSettingTab.test.ts
@@ -158,7 +158,8 @@ describe("ExocortexSettingTab", () => {
       // Log channels section: 1 heading + 4 log level rows = 5
       // Excluded folders section (#3278): 1 heading + 1 textarea row = +2 → 32
       // Issue #3320 — FocusProfile sections: 4 section headings + PAT row + Switch profile row + Cache stats row + (Operations log has no Setting row, body уходит в createDiv/createEl) = +7 → 39
-      expect(MockSetting).toHaveBeenCalledTimes(39);
+      // RFC 13da049f R35 — added "Knowledge and focus profiles" overview heading (+1) → 40
+      expect(MockSetting).toHaveBeenCalledTimes(40);
     });
 
     it("should render layout visibility toggle as first setting", () => {


### PR DESCRIPTION
## Summary

Polish PR for the completed Knowledge/Focus profile split (RFC `13da049f`,
**R35** — user confusion about which profile to edit; **AC13/AC14**). Labels +
docs only — **no** change to switch methods, dual-state, or palette behaviour
(all merged in v16.57–v16.59).

### Settings UI (`ExocortexSettingTab.ts`)
- New **"Knowledge and focus profiles"** overview block names the two types up-front:
  - **Knowledge profile** — *storage* (hard switch, materializes/tears down AssetSpaces on disk, gated by confirmation; `Switch knowledge profile` palette command).
  - **Focus profile** — *filter* (soft switch, query-time RDF filter, no disk change; dropdown below or `Switch focus profile`).
- **Active focus profile** status now surfaces the **dual active state** (AC14), reading `getActiveKnowledgeProfileUid()` + `getActiveFocusProfileUid()` separately (was: legacy `getActiveProfileUid()`).
- **Switch profile** dropdown description clarifies it drives the soft *Focus* slot and points to the gated `Switch knowledge profile` command for hard switches.
- Inline R31 no-transitive reminder in the overview.

### Docs
- **New `docs/profiles.md`** — Knowledge vs Focus distinction: TL;DR table, industry-analog table (VS Code / Browser / Music / Linux / Git), examples ("install pmbok bundle" vs "show only this sprint's ems__Task"), composition (Knowledge materializes container, Focus slices within), **R31 no-transitive** note, AC16 graceful-degradation compat, and **dual-class migrated-instance** explanation.
- **`docs/focus-profile.md`** — terminology-update banner pointing to `profiles.md` (its old "FocusProfile has soft+hard switch" framing now maps onto the split: hard = Knowledge, soft = Focus).

## Tests
- 3 unit tests added in `ExocortexSettingTab.focusProfile.test.ts`: overview heading renders; dual-state reads both AC14 getters and **not** the legacy getter; + heading-count assertion bumped (39→40) in `ExocortexSettingTab.test.ts`.
- `check:types` ✅ · `lint` ✅ (0 errors) · directly-affected suites 16/16 ✅ · archgate 13/13 ✅.

## Test plan
- [ ] CI 14/14 green
- [ ] code-reviewer agent (labels+docs — expect minimal)
- [ ] Settings tab visually shows the two profile types distinctly (post-release BRAT smoke)

RFC `13da049f` (R35/AC13/AC14) · class decl RFC `52f2acdd`.