### PR TITLE
chore(cli): Phase 6 follow-ups — --profiles-dir flag + symlink test (PR #3359/#3367)

### DIFF
--- a/packages/cli/src/commands/migrate-shared-identities-profiles.ts
+++ b/packages/cli/src/commands/migrate-shared-identities-profiles.ts
@@ -46,7 +46,10 @@ export function migrateSharedIdentitiesProfilesCommand(): Command {
           throw new InvalidArgumentsError("--vault is required");
         }
         const profilesDir = options.profilesDir ?? "profiles";
-        if (profilesDir.includes("/") || profilesDir.includes("\\") || profilesDir.includes("..")) {
+        // Plain folder name only — allowlist defends against path traversal
+        // (`/`, `\`, `..`), NUL bytes, `~`/`$HOME` expansion, and empty / `.`
+        // values that would collapse the target onto assetspaces/ itself.
+        if (!/^[A-Za-z0-9._-]+$/.test(profilesDir) || profilesDir === "." || profilesDir.includes("..")) {
           throw new InvalidArgumentsError(
             `--profiles-dir must be a plain folder name (got "${profilesDir}")`,
           );

--- a/packages/cli/src/commands/migrate-shared-identities-profiles.ts
+++ b/packages/cli/src/commands/migrate-shared-identities-profiles.ts
@@ -9,6 +9,7 @@ interface MigrateOptions {
   vault: string;
   apply?: boolean;
   json?: boolean;
+  profilesDir: string;
 }
 
 /**
@@ -34,11 +35,23 @@ export function migrateSharedIdentitiesProfilesCommand(): Command {
     .requiredOption("--vault <path>", "Path to Obsidian vault root")
     .option("--apply", "Execute migration (default: dry-run)", false)
     .option("--json", "Emit plan / result as JSON", false)
+    .option(
+      "--profiles-dir <name>",
+      "Target AssetSpace folder name under assetspaces/ (default: profiles)",
+      "profiles",
+    )
     .action(async (options: MigrateOptions) => {
       try {
         if (!options.vault) {
           throw new InvalidArgumentsError("--vault is required");
         }
+        const profilesDir = options.profilesDir ?? "profiles";
+        if (profilesDir.includes("/") || profilesDir.includes("\\") || profilesDir.includes("..")) {
+          throw new InvalidArgumentsError(
+            `--profiles-dir must be a plain folder name (got "${profilesDir}")`,
+          );
+        }
+        const profilesDirRelative = `assetspaces/${profilesDir}`;
         const vaultPath = resolve(options.vault);
         if (!existsSync(vaultPath)) {
           throw new VaultNotFoundError(vaultPath);
@@ -47,7 +60,7 @@ export function migrateSharedIdentitiesProfilesCommand(): Command {
         const svc = new SharedIdentitiesProfileMigrationService();
 
         if (options.apply) {
-          const result = svc.apply({ vaultPath, apply: true });
+          const result = svc.apply({ vaultPath, apply: true, profilesDirRelative });
           if (options.json) {
             process.stdout.write(JSON.stringify(result, null, 2) + "\n");
           } else {
@@ -71,7 +84,7 @@ export function migrateSharedIdentitiesProfilesCommand(): Command {
           process.exit(result.errors.length > 0 ? 1 : 0);
         } else {
           // Dry-run.
-          const plan = svc.generatePlan({ vaultPath });
+          const plan = svc.generatePlan({ vaultPath, profilesDirRelative });
           if (options.json) {
             process.stdout.write(JSON.stringify(plan, null, 2) + "\n");
           } else {

--- a/packages/cli/tests/unit/BootstrapAssetSpaceService.test.ts
+++ b/packages/cli/tests/unit/BootstrapAssetSpaceService.test.ts
@@ -32,6 +32,43 @@ function buildFakeGitHubTarball(
   return gzipSync(Buffer.from(tar));
 }
 
+/**
+ * Hand-craft a single USTAR header block for a non-regular entry (symlink /
+ * hardlink). nanotar's `createTar` only emits regular-file (typeflag `0`)
+ * entries, so a malicious symlink tarball cannot be synthesized through it —
+ * we build the raw 512-byte header ourselves. typeflag `2` → symbolicLink,
+ * `1` → hardLink (per nanotar `tarItemTypeMap`).
+ */
+function tarLinkHeader(name: string, linkname: string, typeflag: "1" | "2"): Buffer {
+  const block = Buffer.alloc(512, 0);
+  block.write(name, 0, "utf8"); // name (≤100 bytes)
+  block.write("0000777\0", 100, "ascii"); // mode
+  block.write("0000000\0", 108, "ascii"); // uid
+  block.write("0000000\0", 116, "ascii"); // gid
+  block.write("00000000000\0", 124, "ascii"); // size = 0 (links carry no payload)
+  block.write("00000000000\0", 136, "ascii"); // mtime
+  block.write("        ", 148, "ascii"); // checksum placeholder (8 spaces)
+  block.write(typeflag, 156, "ascii"); // typeflag
+  block.write(linkname, 157, "utf8"); // linkname target (≤100 bytes)
+  block.write("ustar\0", 257, "ascii"); // magic
+  block.write("00", 263, "ascii"); // version
+  let sum = 0;
+  for (let i = 0; i < 512; i++) sum += block[i];
+  block.write(sum.toString(8).padStart(6, "0") + "\0 ", 148, "ascii"); // computed checksum
+  return block;
+}
+
+/**
+ * Build a gzipped tar containing a single link entry under a valid GitHub
+ * wrapper dir `<owner>-<repo>-<sha7>/` so the malicious entry survives the
+ * wrapper-prefix + SHA validation and reaches the symlink/hardlink reject gate.
+ */
+function buildLinkTarball(wrapper: string, typeflag: "1" | "2"): Uint8Array {
+  const header = tarLinkHeader(`${wrapper}/evil-link`, "/etc/passwd", typeflag);
+  const trailer = Buffer.alloc(1024, 0); // two zero blocks terminate the archive
+  return gzipSync(Buffer.concat([header, trailer]));
+}
+
 function fakeFetch(response: Uint8Array): typeof fetch {
   return (async (_url: string | URL | Request) => {
     return {
@@ -141,12 +178,35 @@ describe("BootstrapAssetSpaceService", () => {
       ).rejects.toThrow(/fetch failed.*404/);
     });
 
-    // Note: nanotar's createTar API does NOT support emitting symbolicLink/hardLink
-    // typed entries (only regular files). The production code's explicit
-    // `symbolicLink` / `hardLink` rejection (BootstrapAssetSpaceService.ts:166-171)
-    // is verified by code review + parity audit с plugin TarExtractor.validateEntry.
-    // Adversarial symlink tarball test deferred к future integration suite with
-    // hand-crafted tar bytes.
+    // PR #3367 follow-up: adversarial symlink/hardlink tarball rejection. nanotar's
+    // createTar can't emit link-typed entries, so we hand-craft raw tar bytes
+    // (tarLinkHeader) to synthesize a malicious upstream tarball.
+    it("rejects symbolicLink-typed tar entry (security)", async () => {
+      const tarball = buildLinkTarball("kitelev-evil-abc1234", "2");
+      const svc = new BootstrapAssetSpaceService({ fetchImpl: fakeFetch(tarball) });
+      await expect(
+        svc.pullAssetSpace("https://github.com/kitelev/evil", "main", path.join(tempBase, "t")),
+      ).rejects.toThrow(/symbolicLink entry .* rejected for security/);
+    });
+
+    it("rejects hardLink-typed tar entry (security)", async () => {
+      const tarball = buildLinkTarball("kitelev-evil-def5678", "1");
+      const svc = new BootstrapAssetSpaceService({ fetchImpl: fakeFetch(tarball) });
+      await expect(
+        svc.pullAssetSpace("https://github.com/kitelev/evil", "main", path.join(tempBase, "t")),
+      ).rejects.toThrow(/hardLink entry .* rejected for security/);
+    });
+
+    it("does not extract any file when a malicious symlink entry is present", async () => {
+      const tarball = buildLinkTarball("kitelev-evil-abc1234", "2");
+      const svc = new BootstrapAssetSpaceService({ fetchImpl: fakeFetch(tarball) });
+      const target = path.join(tempBase, "no-extract");
+      await expect(
+        svc.pullAssetSpace("https://github.com/kitelev/evil", "main", target),
+      ).rejects.toThrow(/rejected for security/);
+      // Target dir must not have been created with any contents (staging cleaned up).
+      expect(existsSync(path.join(target, "evil-link"))).toBe(false);
+    });
 
     it("MEDIUM-fix: accepts files с `..` в name (e.g. foo..bar.md) when no segment is `..`", async () => {
       const tarball = buildFakeGitHubTarball("kitelev", "test", "bbb2222", [

--- a/packages/cli/tests/unit/SharedIdentitiesProfileMigrationService.test.ts
+++ b/packages/cli/tests/unit/SharedIdentitiesProfileMigrationService.test.ts
@@ -134,6 +134,24 @@ describe("SharedIdentitiesProfileMigrationService", () => {
       const plan = svc.generatePlan({ vaultPath: setup.vaultPath });
       expect(plan.actions.length).toBe(0);
     });
+
+    it("custom profilesDirRelative is used as relocate target", () => {
+      setup = makeSyntheticVault();
+      const svc = new SharedIdentitiesProfileMigrationService();
+      const plan = svc.generatePlan({
+        vaultPath: setup.vaultPath,
+        profilesDirRelative: "assetspaces/custom-profiles",
+      });
+
+      const expectedDir = path.join(setup.vaultPath, "assetspaces", "custom-profiles");
+      expect(plan.profilesDirPath).toBe(expectedDir);
+
+      const relocations = plan.actions.filter((a) => a.kind === "relocate-and-dual-class");
+      expect(relocations.length).toBe(4);
+      for (const a of relocations) {
+        expect(a.kind === "relocate-and-dual-class" && a.profilesDirPath.startsWith(expectedDir)).toBe(true);
+      }
+    });
   });
 
   describe("apply mode", () => {

--- a/packages/cli/tests/unit/commands/migrate-shared-identities-profiles.test.ts
+++ b/packages/cli/tests/unit/commands/migrate-shared-identities-profiles.test.ts
@@ -97,9 +97,27 @@ describe("migrateSharedIdentitiesProfilesCommand --profiles-dir flag", () => {
   });
 
   describe("validation", () => {
-    it("rejects --profiles-dir containing a path separator", async () => {
+    it.each([
+      ["path separator", "evil/../escape"],
+      ["backslash", "a\\b"],
+      ["bare dot-dot", ".."],
+      ["single dot", "."],
+      ["empty string", ""],
+      ["NUL byte", "a\x00b"],
+      ["tilde", "~/escape"],
+    ])("rejects --profiles-dir with %s", async (_label, value) => {
       const vaultPath = makeVaultWithProfile();
       const exitSpy = jest.spyOn(process, "exit").mockImplementation((() => undefined) as never);
+      const cmd = migrateSharedIdentitiesProfilesCommand();
+      await cmd.parseAsync(["node", "test", "--vault", vaultPath, "--profiles-dir", value, "--json"]);
+      // ErrorHandler.handle → process.exit with non-zero (INVALID_ARGUMENTS=2).
+      expect(exitSpy).toHaveBeenCalled();
+      const codes = exitSpy.mock.calls.map((c) => c[0]);
+      expect(codes.some((c) => c !== 0)).toBe(true);
+    });
+
+    it("accepts a dotted folder name (e.g. profiles.v2)", async () => {
+      const vaultPath = makeVaultWithProfile();
       const cmd = migrateSharedIdentitiesProfilesCommand();
       await cmd.parseAsync([
         "node",
@@ -107,13 +125,11 @@ describe("migrateSharedIdentitiesProfilesCommand --profiles-dir flag", () => {
         "--vault",
         vaultPath,
         "--profiles-dir",
-        "evil/../escape",
+        "profiles.v2",
         "--json",
       ]);
-      // ErrorHandler.handle → process.exit with non-zero (INVALID_ARGUMENTS=2).
-      expect(exitSpy).toHaveBeenCalled();
-      const codes = exitSpy.mock.calls.map((c) => c[0]);
-      expect(codes.some((c) => c !== 0)).toBe(true);
+      const plan = JSON.parse(stdout.join(""));
+      expect(plan.profilesDirPath).toBe(path.join(vaultPath, "assetspaces", "profiles.v2"));
     });
   });
 });

--- a/packages/cli/tests/unit/commands/migrate-shared-identities-profiles.test.ts
+++ b/packages/cli/tests/unit/commands/migrate-shared-identities-profiles.test.ts
@@ -1,0 +1,119 @@
+/**
+ * @jest-environment node
+ *
+ * Unit tests для migrate-shared-identities-profiles command — focus on the
+ * `--profiles-dir` flag (PR #3359 code-reviewer follow-up). Verifies flag
+ * parsing + that the custom dir name flows through to the relocate plan.
+ */
+import { jest, describe, it, expect, beforeEach, afterAll } from "@jest/globals";
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync } from "node:fs";
+import * as path from "node:path";
+import * as os from "node:os";
+import { migrateSharedIdentitiesProfilesCommand } from "../../../src/commands/migrate-shared-identities-profiles";
+import { FOCUS_PROFILE_CLASS_UID } from "../../../src/services/SharedIdentitiesProfileMigrationService";
+
+const tmpVaults: string[] = [];
+
+function makeVaultWithProfile(): string {
+  const vaultPath = mkdtempSync(path.join(os.tmpdir(), "exo-migrate-cmd-"));
+  tmpVaults.push(vaultPath);
+  const sharedDir = path.join(vaultPath, "assetspaces", "shared-identities");
+  mkdirSync(sharedDir, { recursive: true });
+  writeFileSync(
+    path.join(sharedDir, "ae00f219-f50b-4fc1-b842-9ec1e03fefd6.md"),
+    `---
+exo__Asset_uid: ae00f219-f50b-4fc1-b842-9ec1e03fefd6
+exo__Asset_label: profile-base
+exo__Instance_class:
+  - "[[${FOCUS_PROFILE_CLASS_UID}]]"
+exo__FocusProfile_includes:
+  - "[[ontology-exo]]"
+---
+
+# profile-base
+`,
+  );
+  return vaultPath;
+}
+
+describe("migrateSharedIdentitiesProfilesCommand --profiles-dir flag", () => {
+  let stdout: string[];
+
+  beforeEach(() => {
+    stdout = [];
+    jest.spyOn(process, "exit").mockImplementation((() => undefined) as never);
+    jest.spyOn(process.stdout, "write").mockImplementation((chunk: unknown) => {
+      stdout.push(String(chunk));
+      return true;
+    });
+    jest.spyOn(process.stderr, "write").mockImplementation(() => true);
+    jest.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterAll(() => {
+    for (const v of tmpVaults) rmSync(v, { recursive: true, force: true });
+  });
+
+  describe("command setup", () => {
+    it("registers --profiles-dir option with default 'profiles'", () => {
+      const cmd = migrateSharedIdentitiesProfilesCommand();
+      const opt = cmd.options.find((o: { long?: string }) => o.long === "--profiles-dir");
+      expect(opt).toBeDefined();
+      expect(opt?.defaultValue).toBe("profiles");
+    });
+  });
+
+  describe("dry-run plan target", () => {
+    it("defaults target to assetspaces/profiles when flag omitted", async () => {
+      const vaultPath = makeVaultWithProfile();
+      const cmd = migrateSharedIdentitiesProfilesCommand();
+      await cmd.parseAsync(["node", "test", "--vault", vaultPath, "--json"]);
+
+      const plan = JSON.parse(stdout.join(""));
+      expect(plan.profilesDirPath).toBe(path.join(vaultPath, "assetspaces", "profiles"));
+    });
+
+    it("uses custom dir name in relocate plan when --profiles-dir given", async () => {
+      const vaultPath = makeVaultWithProfile();
+      const cmd = migrateSharedIdentitiesProfilesCommand();
+      await cmd.parseAsync([
+        "node",
+        "test",
+        "--vault",
+        vaultPath,
+        "--profiles-dir",
+        "custom-profiles",
+        "--json",
+      ]);
+
+      const plan = JSON.parse(stdout.join(""));
+      const expectedDir = path.join(vaultPath, "assetspaces", "custom-profiles");
+      expect(plan.profilesDirPath).toBe(expectedDir);
+      const relocate = plan.actions.find(
+        (a: { kind: string }) => a.kind === "relocate-and-dual-class",
+      );
+      expect(relocate.profilesDirPath.startsWith(expectedDir)).toBe(true);
+    });
+  });
+
+  describe("validation", () => {
+    it("rejects --profiles-dir containing a path separator", async () => {
+      const vaultPath = makeVaultWithProfile();
+      const exitSpy = jest.spyOn(process, "exit").mockImplementation((() => undefined) as never);
+      const cmd = migrateSharedIdentitiesProfilesCommand();
+      await cmd.parseAsync([
+        "node",
+        "test",
+        "--vault",
+        vaultPath,
+        "--profiles-dir",
+        "evil/../escape",
+        "--json",
+      ]);
+      // ErrorHandler.handle → process.exit with non-zero (INVALID_ARGUMENTS=2).
+      expect(exitSpy).toHaveBeenCalled();
+      const codes = exitSpy.mock.calls.map((c) => c[0]);
+      expect(codes.some((c) => c !== 0)).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Closes deferred code-reviewer follow-ups from PR #3359 (migration tool) + PR #3367 (bootstrap CLI). Cleanup PR, CLI-package only, low risk.

## Item 1 — `--profiles-dir` flag (PR #3359 follow-up) ✅

`migrate-shared-identities-profiles` previously hardcoded the relocate target to `assetspaces/profiles/`. The underlying `SharedIdentitiesProfileMigrationService` already accepted a `profilesDirRelative` option — the command just never exposed it.

- Added optional `--profiles-dir <name>` flag (default `profiles`). `--profiles-dir foo` → target `assetspaces/foo`.
- Plain-folder-name guard: rejects values containing `/`, `\`, or `..` (`InvalidArgumentsError`) — it's a folder *name*, not a path, so no traversal.
- Wired through to both dry-run (`generatePlan`) and `--apply` (`apply`) paths.

**Tests (+4):**
- Service: custom `profilesDirRelative` is used as the relocate target dir.
- Command: `--profiles-dir` registered with default `profiles`; default → `assetspaces/profiles`; custom value → `assetspaces/custom-profiles` in the relocate plan; path-separator value → non-zero exit.

## Item 2 — symlink tarball security test (PR #3367 follow-up) ✅

PR #3367 added explicit `symbolicLink`/`hardLink` rejection in tarball extraction (`BootstrapAssetSpaceService.pullAssetSpace`). The test was **deferred** because nanotar's `createTar` API only emits regular-file (typeflag `0`) entries — it cannot synthesize a malicious link entry.

Resolved via **option (b)**: hand-craft raw 512-byte USTAR header bytes with typeflag `2` (symbolicLink) / `1` (hardLink) under a valid GitHub wrapper dir (`<owner>-<repo>-<sha7>/`) so the entry survives wrapper-prefix + SHA validation and reaches the reject gate.

**Tests (+3):** rejects symbolicLink entry, rejects hardLink entry, no file extracted when a malicious symlink is present (staging cleaned up).

**Verification:** revert-fail/restore-pass — with the production `symbolicLink`/`hardLink` guard disabled, all 3 tests FAIL (entry passes through); restored → all PASS. The tests genuinely exercise the regression.

## Item 3 — `sparql-exo003` "flaky" (OPTIONAL) — SKIPPED, corrected diagnosis ⏭️

**Investigated and skipped per prompt** (optional, out of Phase 6 scope, no-block). **Corrected diagnosis:** the suite is **not flaky** — it is **deterministically broken**. `tests/integration/sparql-exo003.integration.test.ts` spawns the CLI with the `query` subcommand, which was **removed in CLI v16.0 (#3130)** in favor of `exoql` (and deprecated `sparql`). Running it produces `error: unknown command 'query'` → exit code 1 → all 10 tests fail.

It only appears green in CI because of `describeOrSkip = isCI ? describe.skip : describe` (line 28-30) — GitHub Actions sets `CI=true`, so the whole suite is skipped and never runs. That's why this PR's CI is unaffected.

Why not "fixed" or "@flaky-track"-tagged here:
- Not a race/ordering/shared-state issue (the prompt's "fix" criterion) — it's a stale test against a deleted command surface.
- `@flaky-track`/`retries` infra is **Playwright-only** (PR #3355); there is no jest equivalent.
- Porting all 10 tests from `query` → `exoql` + updating the expected JSON output shape is genuine scope, outside this cleanup PR.

**Recommended follow-up:** file an issue to either port `sparql-exo003.integration.test.ts` to the `exoql` command surface or delete it (its `describe.skip(CI)` masks a permanently-broken suite — false confidence).

## Items status
- 1 ✅ `--profiles-dir` flag + 4 unit tests
- 2 ✅ symlink/hardlink rejection test (real, raw tar bytes) + revert-verify
- 3 ⏭️ skipped (corrected: broken-not-flaky, CI-skipped, port = out-of-scope)

## Test plan
- [ ] CI 14/14 green (typecheck, test-coverage [CLI batch], etc.)
- [ ] `SharedIdentitiesProfileMigrationService` + `migrate-shared-identities-profiles` command + `BootstrapAssetSpaceService` suites green (33 tests locally)