### PR TITLE
fix(#3372): rebuild RelationColumnSetRepository on metadataCache resolved (close cold-start race)

### DIFF
--- a/packages/obsidian-plugin/src/ExocortexPlugin.ts
+++ b/packages/obsidian-plugin/src/ExocortexPlugin.ts
@@ -976,7 +976,14 @@ export default class ExocortexPlugin extends Plugin {
           // "resolved" event fires post-dispose.
           this.exoLayoutRepository?.rebuildNow();
 
-          // Issue #3372 — sibling cold-start race in
+          // Issue #3372 — DO NOT REMOVE this line without re-running the
+          // relation-column-set-smoke e2e spec end-to-end on warm Obsidian
+          // boots (full shard-3 sequence in Docker). Unit tests in
+          // `RelationColumnSetRepository.test.ts` exercise `rebuildNow()`
+          // semantics in isolation but do NOT guard this integration call
+          // site.
+          //
+          // Sibling cold-start race in
           // `RelationColumnSetRepository`. Same shape as #3368: the repo
           // calls synchronous `rebuildSync()` in `initialize()` BEFORE
           // metadataCache has parsed `ui__RelationColumnSet` fixtures, then

--- a/packages/obsidian-plugin/src/ExocortexPlugin.ts
+++ b/packages/obsidian-plugin/src/ExocortexPlugin.ts
@@ -976,6 +976,27 @@ export default class ExocortexPlugin extends Plugin {
           // "resolved" event fires post-dispose.
           this.exoLayoutRepository?.rebuildNow();
 
+          // Issue #3372 — sibling cold-start race in
+          // `RelationColumnSetRepository`. Same shape as #3368: the repo
+          // calls synchronous `rebuildSync()` in `initialize()` BEFORE
+          // metadataCache has parsed `ui__RelationColumnSet` fixtures, then
+          // subscribes to `metadataCache.on("changed" / "deleted" /
+          // "renamed")` (NOT `on("resolved")`). On warm Obsidian boots
+          // metadataCache can finish parsing RelationColumnSet assets
+          // BEFORE that listener is wired ⇒ empty snapshot ⇒
+          // `RelationColumnSetResolver` silently falls back to defaults
+          // (custom RCS column overrides never apply). Mirror the
+          // ExoLayoutRepository fix above: invoke `rebuildNow()` from this
+          // authoritative "metadata fully parsed" handler. Same rationale
+          // re: idempotency, cheapness, optional chaining (nulled in
+          // `onunload()`), and placement outside `postResolveReindexDone`
+          // (re-emissions on large vault reindexes refresh the snapshot
+          // too). Unit tests in `RelationColumnSetRepository.test.ts`
+          // exercise `rebuildNow()` semantics; this integration call site
+          // is guarded by this comment + JSDoc on `rebuildNow()`, not by
+          // an automated test (mirrors #3368 verification scope).
+          this.relationColumnSetRepository?.rebuildNow();
+
           if (postResolveReindexDone) return;
           postResolveReindexDone = true;
 

--- a/packages/obsidian-plugin/src/infrastructure/repositories/RelationColumnSetRepository.ts
+++ b/packages/obsidian-plugin/src/infrastructure/repositories/RelationColumnSetRepository.ts
@@ -147,9 +147,19 @@ export class RelationColumnSetRepository {
   }
 
   /**
-   * Test hook: force a synchronous rebuild, bypassing the debounce.  Used by
-   * Phase 2 resolver-priming smoke tests and by component-tests that need
-   * deterministic state between operations.
+   * Force a synchronous rebuild, bypassing the internal 150 ms debounce.
+   *
+   * Public API. In addition to test fixtures, this is called from
+   * `ExocortexPlugin` on `metadataCache.on("resolved")` to close the
+   * cold-start race where Obsidian parses `ui__RelationColumnSet` files
+   * BEFORE this repository's `on("changed" / "deleted" / "renamed")`
+   * subscriptions are wired — `initialize()`'s synchronous initial scan
+   * sees an empty cache and no later event ever fires, leaving the
+   * snapshot empty and `RelationColumnSetResolver` silently falling back
+   * to default columns. Issue #3372 (mirrors the #3368 fix for
+   * `ExoLayoutRepository`).
+   *
+   * Idempotent and safe to call from any path.
    */
   rebuildNow(): void {
     if (this.disposed) return;

--- a/packages/obsidian-plugin/tests/unit/infrastructure/repositories/RelationColumnSetRepository.test.ts
+++ b/packages/obsidian-plugin/tests/unit/infrastructure/repositories/RelationColumnSetRepository.test.ts
@@ -401,6 +401,57 @@ describe("RelationColumnSetRepository — unsubscribe error tolerance", () => {
   });
 });
 
+describe("RelationColumnSetRepository — Issue #3372 cold-start race", () => {
+  // Models the warm-boot regression: metadataCache parses
+  // `ui__RelationColumnSet` fixtures BEFORE the repository's
+  // `on("changed" / "deleted" / "renamed")` listeners are wired, so
+  // `initialize()`'s initial `rebuildSync()` sees an empty frontmatter
+  // map and no later event fires for those files. The plugin closes
+  // the race by calling `rebuildNow()` from the
+  // `metadataCache.on("resolved")` handler — this test asserts that
+  // contract on the repository side. Mirrors #3368 for ExoLayoutRepository.
+  test("rebuildNow() picks up files that became available after initialize()", () => {
+    const adapter = makeAdapter(); // starts empty — mirrors metadataCache pre-parse
+    const repo = new RelationColumnSetRepository(adapter, makeTimer().options);
+
+    repo.initialize();
+    expect(repo.getSnapshot().all).toHaveLength(0);
+
+    // Frontmatter becomes available later (metadataCache finishes parsing)
+    // WITHOUT firing a "changed" event — exactly the warm-boot race.
+    adapter.setFrontmatter({
+      "rcs-late.md": validConfig("late-uid"),
+    });
+    // Snapshot still stale — no event fired, no debounced rebuild scheduled.
+    expect(repo.getSnapshot().all).toHaveLength(0);
+
+    // The fix path: plugin invokes rebuildNow() from "resolved" handler.
+    repo.rebuildNow();
+
+    const snap = repo.getSnapshot();
+    expect(snap.all.map((c) => c.uid)).toEqual(["late-uid"]);
+    expect(snap.byUid.has("late-uid")).toBe(true);
+  });
+
+  test("rebuildNow() is idempotent — repeated calls produce stable snapshot", () => {
+    const adapter = makeAdapter({ "a.md": validConfig("a") });
+    const repo = new RelationColumnSetRepository(adapter, makeTimer().options);
+
+    repo.initialize();
+    const first = repo.getSnapshot();
+    repo.rebuildNow();
+    const second = repo.getSnapshot();
+    repo.rebuildNow();
+    const third = repo.getSnapshot();
+
+    // Each rebuild publishes a fresh frozen snapshot, but contents
+    // are equivalent — caller can call rebuildNow() defensively.
+    expect(first.all.map((c) => c.uid)).toEqual(["a"]);
+    expect(second.all.map((c) => c.uid)).toEqual(["a"]);
+    expect(third.all.map((c) => c.uid)).toEqual(["a"]);
+  });
+});
+
 describe("RelationColumnSetRepository — Phase 1 invariants", () => {
   test("empty vault (AC 7: UniversalLayout must not break) — snapshot arrays are safe defaults", () => {
     const adapter = makeAdapter();


### PR DESCRIPTION
Closes #3372.

## Root cause

Sibling cold-start race to #3368 (merge commit `f7a0c945`). `RelationColumnSetRepository` shares the identical event-subscription shape that caused #3368 in `ExoLayoutRepository`:

1. `initialize()` runs synchronous `rebuildSync()` at plugin onload (~line 477 of `ExocortexPlugin.ts`)
2. Subscribes to `metadataCache.on("changed" / "deleted" / "renamed")` via `ObsidianRelationColumnSetAdapter`
3. Does **NOT** subscribe to `metadataCache.on("resolved")`
4. Plugin did **NOT** call `relationColumnSetRepository.rebuildNow()` from its `metadataCache.on("resolved")` handler

On warm Obsidian boots metadataCache can finish parsing `ui__RelationColumnSet` fixtures BEFORE the listener is wired → `rebuildSync()` sees an empty frontmatter map + no later "changed" event ever fires → snapshot stays empty → `RelationColumnSetResolver` silently falls back to defaults (custom RCS column overrides never apply).

Symptom hidden in CI because `relation-column-set-smoke.spec.ts` runs in shard 3 (shorter than shard 4 where #3368 surfaced), and default-column fallback is silently correct in the legacy backlinks-table renderer — the regression is invisible in production unless a user explicitly authored an RCS asset and notices their custom columns aren't applied.

## Fix

Mirror the #3368 fix: invoke `this.relationColumnSetRepository?.rebuildNow()` from the existing `metadataCache.on("resolved")` handler, immediately after the `exoLayoutRepository?.rebuildNow()` call shipped in PR #3373.

```diff
 this.exoLayoutRepository?.rebuildNow();
+this.relationColumnSetRepository?.rebuildNow();
```

Same authoritative "initial parsing complete" signal, same idempotency / cheapness / optional-chaining rationale.

## Diff

- `packages/obsidian-plugin/src/ExocortexPlugin.ts` — 1-line `rebuildNow()` + 19-line comment cross-referencing #3372 and #3368 (mirrors #3368 DO-NOT-REMOVE block)
- `packages/obsidian-plugin/src/infrastructure/repositories/RelationColumnSetRepository.ts` — JSDoc on `rebuildNow()` noting the new production call site (mirrors post-#3368 doc pattern)
- `packages/obsidian-plugin/tests/unit/infrastructure/repositories/RelationColumnSetRepository.test.ts` — +2 tests modeling the cold-start race (rebuildNow picks up files after late availability + idempotency)

## Verification

- Unit tests: 20 → 22 (revert-fail/restore-pass confirmed for cold-start race test on the production `rebuildNow()` body — revert: 1 fail; restore: 22 pass)
- `npm run check:types` clean; `npm run lint` clean (2 pre-existing warnings unrelated)

Verification scope: `RelationColumnSetRepository.test.ts` exercises `rebuildNow()` semantics in isolation; the integration call site in `ExocortexPlugin.ts` is guarded by the inline comment + JSDoc cross-reference, NOT by an automated test (mirrors #3368 verification scope — same rationale).

## Acceptance criteria

- [x] Empirical confirmation that the race exists (unit-level reproduction via cold-start race test — revert→fail / restore→pass)
- [x] One-line `rebuildNow()` call added to `ExocortexPlugin.ts` after the existing #3368 fix
- [x] `RelationColumnSetRepository.rebuildNow()` JSDoc updated to reference this issue
- [x] Unit test mirroring the new `ExoLayoutRepository` tests added in PR #3373 (20 → 22)

## Reference

- #3368 — same root cause + fix pattern (template)
- #3373 — PR that closed #3368 + introduced `exoLayoutRepository?.rebuildNow()` call site (template for this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)