### PR TITLE
fix(focus-profile): hard-switch deps wiring exception hides Bootstrap/knowledge palette commands

### DIFF
--- a/packages/obsidian-plugin/src/ExocortexPlugin.ts
+++ b/packages/obsidian-plugin/src/ExocortexPlugin.ts
@@ -122,8 +122,10 @@ import { injectAssetSpaceMaterializationTriples } from "./infrastructure/adapter
 import { AssetSpaceStatusIconPatch } from "./presentation/asset-space/AssetSpaceStatusIconPatch";
 import { GitHubRestClient } from "./infrastructure/adapters/GitHubRestClient";
 import { GitSubmoduleOps } from "./infrastructure/adapters/GitSubmoduleOps";
-import { UncommittedChangesGuard } from "./infrastructure/adapters/UncommittedChangesGuard";
-import { ModalConfirmGate } from "./infrastructure/adapters/ModalConfirmGate";
+import {
+  buildHardSwitchDeps,
+  type HardSwitchDeps,
+} from "./infrastructure/adapters/HardSwitchDepsFactory";
 import {
   CommandExecutionFlow,
   DI_TOKENS,
@@ -2586,59 +2588,18 @@ export default class ExocortexPlugin extends Plugin {
     const settingsStore = new PluginSettingsStoreAdapter(localDataStore);
 
     // Phase 5 P3 — hard switch dependencies (desktop-only). On mobile, the
-    // palette command throws via the AssetSpaceManager pull guard; here we
-    // just leave the dependencies wired but inert.
-    let hardSwitchDeps: {
-      assetSpaceManager: AssetSpaceManager;
-      gitOps: GitSubmoduleOps;
-      uncommittedGuard: UncommittedChangesGuard;
-      confirmGate: ModalConfirmGate;
-      cacheLayer: SwitchCacheLayer;
-      vaultRootPath: string;
-    } | null = null;
-    if (!Platform.isMobile) {
-      try {
-        const secretsStore = new LocalSecretsStore({ app: this.app });
-        const pat = await secretsStore.getSecret("pat");
-        const githubClient = new GitHubRestClient({
+    // palette command throws via the AssetSpaceManager pull guard, so we skip
+    // wiring entirely. Extracted to `buildHardSwitchDeps` for testability —
+    // an empty-PAT GitHubRestClient ctor throw previously left this `null` and
+    // silently hid the gated Bootstrap / knowledge-switch palette commands.
+    const hardSwitchDeps: HardSwitchDeps | null = Platform.isMobile
+      ? null
+      : await buildHardSwitchDeps({
           app: this.app,
-          pat: pat ?? "",
+          localDataStore,
+          notifier: this.notifier,
+          logger: this.logger,
         });
-        const stagingTrackerHs = new StagingDirTracker({ localDataStore });
-        const assetSpaceManager = new AssetSpaceManager({
-          app: this.app,
-          client: githubClient,
-          notifications: this.notifier,
-          stagingTracker: stagingTrackerHs,
-        });
-        const vaultRootPath = (
-          this.app.vault.adapter as unknown as { basePath?: string }
-        ).basePath ?? "";
-        if (vaultRootPath.length > 0) {
-          const gitOps = new GitSubmoduleOps({ vaultRootPath });
-          const uncommittedGuard = new UncommittedChangesGuard({ gitOps });
-          const confirmGate = new ModalConfirmGate(this.app);
-          const cacheLayer = new SwitchCacheLayer();
-          hardSwitchDeps = {
-            assetSpaceManager,
-            gitOps,
-            uncommittedGuard,
-            confirmGate,
-            cacheLayer,
-            vaultRootPath,
-          };
-        } else {
-          this.logger.warn(
-            "[ExocortexPlugin] vault.adapter.basePath unavailable — hard switch palette will be hidden",
-          );
-        }
-      } catch (err) {
-        this.logger.warn(
-          "[ExocortexPlugin] failed to wire hard-switch deps; soft switch only",
-          err instanceof Error ? err : new Error(String(err)),
-        );
-      }
-    }
 
     const switchMgr = new FocusProfileSwitchManager({
       app: this.app,

--- a/packages/obsidian-plugin/src/infrastructure/adapters/GitHubRestClient.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/GitHubRestClient.ts
@@ -70,8 +70,17 @@ export class GitHubRestClient {
   readonly #maxTarballBytes: number;
 
   constructor(opts: GitHubRestClientOptions) {
-    if (!opts.pat || typeof opts.pat !== "string") {
-      throw new Error("GitHubRestClient: PAT is required");
+    // An EMPTY PAT is allowed and puts the client in unauthenticated mode
+    // (no Authorization header → public-repo reads only, lower rate limit).
+    // This is deliberate: plugin onload wires the hard-switch dependencies
+    // BEFORE the user has configured a PAT, so the ctor must not throw on an
+    // empty string. Authenticated operations (createCommit, private pulls)
+    // then surface a clear HTTP 401 instead of the whole hard-switch command
+    // palette silently disappearing. The previous «PAT is required» throw on
+    // an empty string broke that wiring (gated Bootstrap/knowledge-switch
+    // commands never registered on vaults without a stored PAT).
+    if (typeof opts.pat !== "string") {
+      throw new Error("GitHubRestClient: PAT must be a string");
     }
     if (!opts.app) {
       throw new Error("GitHubRestClient: Obsidian App is required");
@@ -387,16 +396,23 @@ export class GitHubRestClient {
   // ───────────────────────────── internals ─────────────────────────────
 
   private async request(param: RequestUrlParam): Promise<RequestUrlResponse> {
-    // Caller-provided headers spread FIRST so configured Authorization
-    // always wins — prevents a callsite from accidentally (or maliciously)
-    // overriding the PAT via headers passed in `param`.
-    const headers = {
+    // Caller-provided headers spread FIRST so the client always owns the
+    // Authorization header — prevents a callsite from accidentally (or
+    // maliciously) overriding the PAT via headers passed in `param`.
+    const headers: Record<string, string> = {
       ...(param.headers ?? {}),
-      Authorization: `Bearer ${this.#pat}`,
       Accept: "application/vnd.github+json",
       "X-GitHub-Api-Version": "2022-11-28",
       "User-Agent": "exocortex-plugin",
     };
+    if (this.#pat.length > 0) {
+      headers.Authorization = `Bearer ${this.#pat}`;
+    } else {
+      // Unauthenticated mode (empty PAT): omit Authorization entirely. Sending
+      // `Bearer ` with an empty token makes GitHub reject even public reads
+      // with 401, and a caller-provided Authorization must not leak through.
+      delete headers.Authorization;
+    }
     let resp: RequestUrlResponse;
     try {
       resp = await requestUrl({

--- a/packages/obsidian-plugin/src/infrastructure/adapters/HardSwitchDepsFactory.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/HardSwitchDepsFactory.ts
@@ -1,0 +1,106 @@
+import type { App } from "obsidian";
+import type { INotificationService } from "exocortex";
+
+import type { ILogger } from "../../adapters/logging/ILogger";
+
+import { LocalSecretsStore } from "./LocalSecretsStore";
+import { GitHubRestClient } from "./GitHubRestClient";
+import { StagingDirTracker } from "./StagingDirTracker";
+import { AssetSpaceManager } from "./AssetSpaceManager";
+import { GitSubmoduleOps } from "./GitSubmoduleOps";
+import { UncommittedChangesGuard } from "./UncommittedChangesGuard";
+import { ModalConfirmGate } from "./ModalConfirmGate";
+import { SwitchCacheLayer } from "./SwitchCacheLayer";
+import type { PluginLocalDataStore } from "./PluginLocalDataStore";
+
+/**
+ * Desktop-only hard-switch dependency bundle consumed by
+ * `FocusProfileSwitchManager` + the gated palette commands (hard
+ * «Switch knowledge profile», «Bootstrap vault», «Add AssetSpace by URL»).
+ *
+ * When this is `null` the gated commands are NOT registered — so a wiring
+ * exception here silently removes user-facing commands from the palette.
+ */
+export interface HardSwitchDeps {
+  assetSpaceManager: AssetSpaceManager;
+  gitOps: GitSubmoduleOps;
+  uncommittedGuard: UncommittedChangesGuard;
+  confirmGate: ModalConfirmGate;
+  cacheLayer: SwitchCacheLayer;
+  vaultRootPath: string;
+}
+
+export interface BuildHardSwitchDepsOptions {
+  app: App;
+  localDataStore: PluginLocalDataStore;
+  notifier: INotificationService;
+  logger: ILogger;
+}
+
+/**
+ * Wire the desktop hard-switch dependencies. Extracted from
+ * `ExocortexPlugin.onload` for testability (mirrors the
+ * {@link ./AssetSpacePusherFactory.createAssetSpacePusher} extraction).
+ *
+ * Callers MUST guard with `!Platform.isMobile` before invoking — mobile
+ * Obsidian has no Node `fs`/`child_process`, so StagingDirTracker /
+ * GitSubmoduleOps cannot run there.
+ *
+ * Returns `null` (and logs) when:
+ *   - `vault.adapter.basePath` is unavailable (no filesystem root → git ops
+ *     impossible), or
+ *   - any constructor in the chain throws.
+ *
+ * Crucially this tolerates an ABSENT GitHub PAT: `getSecret("pat")` returns
+ * `null` on a vault that has never configured one (the common case), and
+ * `GitHubRestClient` now accepts an empty PAT (unauthenticated mode) so the
+ * deps still wire. Before that fix, the empty-PAT ctor throw left
+ * `hardSwitchDeps === null` and the gated commands silently vanished.
+ */
+export async function buildHardSwitchDeps(
+  opts: BuildHardSwitchDepsOptions,
+): Promise<HardSwitchDeps | null> {
+  const { app, localDataStore, notifier, logger } = opts;
+  try {
+    const secretsStore = new LocalSecretsStore({ app });
+    const pat = await secretsStore.getSecret("pat");
+    const githubClient = new GitHubRestClient({ app, pat: pat ?? "" });
+    const stagingTracker = new StagingDirTracker({ localDataStore });
+    const assetSpaceManager = new AssetSpaceManager({
+      app,
+      client: githubClient,
+      notifications: notifier,
+      stagingTracker,
+    });
+    const vaultRootPath =
+      (app.vault.adapter as unknown as { basePath?: string }).basePath ?? "";
+    if (vaultRootPath.length === 0) {
+      logger.warn(
+        "[buildHardSwitchDeps] vault.adapter.basePath unavailable — hard switch palette will be hidden",
+      );
+      return null;
+    }
+    const gitOps = new GitSubmoduleOps({ vaultRootPath });
+    const uncommittedGuard = new UncommittedChangesGuard({ gitOps });
+    const confirmGate = new ModalConfirmGate(app);
+    const cacheLayer = new SwitchCacheLayer();
+    return {
+      assetSpaceManager,
+      gitOps,
+      uncommittedGuard,
+      confirmGate,
+      cacheLayer,
+      vaultRootPath,
+    };
+  } catch (err) {
+    // Visible diagnostics — `logger.warn` routes through a custom logger that
+    // is NOT printed to the DevTools console, so this exception was invisible
+    // in production for months. `console.error` makes it observable.
+    console.error("[Exocortex] hard-switch wiring failed:", err);
+    logger.warn(
+      "[buildHardSwitchDeps] failed to wire hard-switch deps; soft switch only",
+      err instanceof Error ? err : new Error(String(err)),
+    );
+    return null;
+  }
+}

--- a/packages/obsidian-plugin/tests/unit/GitHubRestClient.test.ts
+++ b/packages/obsidian-plugin/tests/unit/GitHubRestClient.test.ts
@@ -42,10 +42,23 @@ describe("GitHubRestClient", () => {
 
   // ─── constructor ──────────────────────────────────────────────────
   describe("constructor", () => {
-    it("requires PAT", () => {
+    it("accepts an empty PAT (unauthenticated mode) without throwing", () => {
+      // Regression: the empty-PAT ctor throw silently hid the hard-switch
+      // palette commands on every vault without a stored PAT. An empty PAT is
+      // a valid unauthenticated client (public reads only).
       expect(
         () => new GitHubRestClient({ pat: "", app: fakeApp }),
-      ).toThrow(/PAT is required/);
+      ).not.toThrow();
+    });
+
+    it("rejects a non-string PAT", () => {
+      expect(
+        () =>
+          new GitHubRestClient({
+            pat: undefined as unknown as string,
+            app: fakeApp,
+          }),
+      ).toThrow(/PAT must be a string/);
     });
 
     it("requires App", () => {
@@ -398,6 +411,18 @@ describe("GitHubRestClient", () => {
       await c.getRepoHead("o", "r");
       const call = requestUrlMock.mock.calls[0][0];
       expect(call.headers.Authorization).toBe(`Bearer ${FAKE_PAT}`);
+      expect(call.headers.Accept).toBe("application/vnd.github+json");
+    });
+
+    it("omits Authorization header in unauthenticated mode (empty PAT)", async () => {
+      // Empty PAT → unauthenticated. Sending `Bearer ` with an empty token
+      // makes GitHub 401 even public reads, so the header must be absent.
+      requestUrlMock.mockResolvedValue(ok({ json: { commit: { sha: "x" } } }));
+      const c = new GitHubRestClient({ pat: "", app: fakeApp });
+      await c.getRepoHead("o", "r");
+      const call = requestUrlMock.mock.calls[0][0];
+      expect(call.headers.Authorization).toBeUndefined();
+      // Non-auth headers still present.
       expect(call.headers.Accept).toBe("application/vnd.github+json");
     });
 

--- a/packages/obsidian-plugin/tests/unit/wiring/HardSwitchDepsFactory.integration.test.ts
+++ b/packages/obsidian-plugin/tests/unit/wiring/HardSwitchDepsFactory.integration.test.ts
@@ -1,0 +1,176 @@
+/**
+ * Production-shape regression test for `buildHardSwitchDeps`
+ * (Issue: hard-switch deps wiring exception hides Bootstrap/knowledge palette commands).
+ *
+ * This exercises the REAL constructor chain — LocalSecretsStore → getSecret →
+ * GitHubRestClient → StagingDirTracker → AssetSpaceManager → GitSubmoduleOps →
+ * UncommittedChangesGuard → ModalConfirmGate → SwitchCacheLayer — with fakes
+ * that mirror the real Obsidian `vault.adapter` contract (per
+ * `~/dotfiles/.claude/rules/test-fixture-realism.md`). NONE of the wiring is
+ * mocked — that is exactly why the bug slipped through: the prior tests stubbed
+ * the wiring, so the empty-PAT ctor throw was never exercised.
+ *
+ * Revert-verify (documented in PR): reverting the GitHubRestClient ctor change
+ * (restore `if (!opts.pat) throw`) makes the «no PAT → deps wire» case FAIL
+ * (returns null); restoring the fix makes it PASS.
+ */
+
+import { describe, it, expect, jest } from "@jest/globals";
+import type { App } from "obsidian";
+import type { INotificationService } from "exocortex";
+
+import type { ILogger } from "../../../src/adapters/logging/ILogger";
+
+import {
+  buildHardSwitchDeps,
+  type BuildHardSwitchDepsOptions,
+} from "../../../src/infrastructure/adapters/HardSwitchDepsFactory";
+import { PluginLocalDataStore } from "../../../src/infrastructure/adapters/PluginLocalDataStore";
+
+// ─── Real-shape fake App / vault.adapter ─────────────────────────────────
+
+interface FakeAppOptions {
+  basePath?: string;
+  /** Seeded file contents keyed by vault-relative path (data.local.json etc). */
+  files?: Record<string, string>;
+}
+
+function makeFakeApp(opts: FakeAppOptions = {}): App {
+  const files = opts.files ?? {};
+  const adapter: Record<string, unknown> = {
+    // Mirrors Obsidian desktop FileSystemAdapter — `basePath` is the absolute
+    // vault root used by GitSubmoduleOps. Absent on mobile (CapacitorAdapter).
+    exists: async (p: string) => Object.prototype.hasOwnProperty.call(files, p),
+    read: async (p: string) => {
+      if (!Object.prototype.hasOwnProperty.call(files, p)) {
+        throw new Error(`ENOENT: ${p}`);
+      }
+      return files[p];
+    },
+    write: async (p: string, data: string) => {
+      files[p] = data;
+    },
+  };
+  if (opts.basePath !== undefined) {
+    adapter.basePath = opts.basePath;
+  }
+  return {
+    vault: {
+      adapter,
+      configDir: ".obsidian",
+    },
+  } as unknown as App;
+}
+
+function makeFakeLogger(): { logger: ILogger; warns: string[] } {
+  const warns: string[] = [];
+  const logger = {
+    debug: () => undefined,
+    info: () => undefined,
+    warn: (msg: string) => {
+      warns.push(msg);
+    },
+    error: () => undefined,
+  } as unknown as ILogger;
+  return { logger, warns };
+}
+
+function makeFakeNotifier(): INotificationService {
+  return {
+    info: () => undefined,
+    success: () => undefined,
+    error: () => undefined,
+    warn: () => undefined,
+    confirm: async () => true,
+  };
+}
+
+function makeOptions(
+  app: App,
+  overrides: Partial<BuildHardSwitchDepsOptions> = {},
+): BuildHardSwitchDepsOptions {
+  return {
+    app,
+    localDataStore: new PluginLocalDataStore({ app }),
+    notifier: makeFakeNotifier(),
+    logger: makeFakeLogger().logger,
+    ...overrides,
+  };
+}
+
+const DATA_LOCAL_PATH = ".obsidian/plugins/exocortex/data.local.json";
+
+describe("buildHardSwitchDeps — production-shape wiring", () => {
+  it("wires all deps on a valid desktop vault WITHOUT a stored PAT (regression)", async () => {
+    // No data.local.json → getSecret('pat') === null → ctor receives "".
+    // Pre-fix this threw «PAT is required» → deps null → palette commands hidden.
+    const app = makeFakeApp({ basePath: "/Users/test/vault-2025" });
+    const deps = await buildHardSwitchDeps(makeOptions(app));
+
+    expect(deps).not.toBeNull();
+    expect(deps?.vaultRootPath).toBe("/Users/test/vault-2025");
+    // Every dep the gated commands depend on is present.
+    expect(deps?.assetSpaceManager).toBeDefined();
+    expect(deps?.gitOps).toBeDefined();
+    expect(deps?.uncommittedGuard).toBeDefined();
+    expect(deps?.confirmGate).toBeDefined();
+    expect(deps?.cacheLayer).toBeDefined();
+  });
+
+  it("wires all deps when a PAT IS stored", async () => {
+    const app = makeFakeApp({
+      basePath: "/Users/test/vault-2025",
+      files: {
+        [DATA_LOCAL_PATH]: JSON.stringify({
+          pat: "ghp_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+        }),
+      },
+    });
+    const deps = await buildHardSwitchDeps(makeOptions(app));
+
+    expect(deps).not.toBeNull();
+    expect(deps?.vaultRootPath).toBe("/Users/test/vault-2025");
+    expect(deps?.assetSpaceManager).toBeDefined();
+  });
+
+  it("returns null and warns when vault.adapter.basePath is unavailable", async () => {
+    // Empty basePath (e.g. an adapter without a filesystem root) → git ops
+    // impossible → wiring intentionally returns null.
+    const app = makeFakeApp({ basePath: "" });
+    const { logger, warns } = makeFakeLogger();
+    const deps = await buildHardSwitchDeps(makeOptions(app, { logger }));
+
+    expect(deps).toBeNull();
+    expect(warns.some((w) => w.includes("basePath unavailable"))).toBe(true);
+  });
+
+  it("returns null AND logs a visible console.error when a ctor throws", async () => {
+    // Force the catch branch: a null localDataStore makes StagingDirTracker's
+    // ctor throw. The visible console.error diagnostic must fire (logger.warn
+    // alone is invisible in the DevTools console).
+    const app = makeFakeApp({ basePath: "/Users/test/vault-2025" });
+    const { logger, warns } = makeFakeLogger();
+    const consoleErrorSpy = jest
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+    try {
+      const deps = await buildHardSwitchDeps(
+        makeOptions(app, {
+          logger,
+          localDataStore: null as unknown as PluginLocalDataStore,
+        }),
+      );
+
+      expect(deps).toBeNull();
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        "[Exocortex] hard-switch wiring failed:",
+        expect.any(Error),
+      );
+      expect(warns.some((w) => w.includes("failed to wire hard-switch deps"))).toBe(
+        true,
+      );
+    } finally {
+      consoleErrorSpy.mockRestore();
+    }
+  });
+});


### PR DESCRIPTION
## Finding (UI smoke, vault-2025 v16.60.2)

On a valid desktop vault, `hardSwitchDeps === null` despite `!Platform.isMobile` and a valid `basePath`. The palette commands gated on `if (hardSwitchDeps !== null)` never register:
- «Switch knowledge profile» (hard)
- «Bootstrap vault»
- «Add AssetSpace by URL»

This makes the Bootstrap Modal UX (Phase 6.2/6.3) unreachable via the palette.

## Root cause

The hard-switch wiring constructs a GitHub client with `pat ?? ""`:

```ts
const githubClient = new GitHubRestClient({ app: this.app, pat: pat ?? "" });
```

But `GitHubRestClient`'s ctor threw `"PAT is required"` on an **empty string**. On a vault that never configured a PAT (the common case — PAT is only needed for private remote AssetSpace pulls), `getSecret("pat")` returns `null` → `pat ?? ""` → ctor throws.

This is the **first throw in the chain**, *before* the `basePath` check at line ~2614 — so the orchestrator's observation that `basePath` is valid was a red herring (the code never reaches it). The `catch` logged only via `this.logger.warn`, which is invisible in the DevTools console, hiding the failure.

The remaining constructors in the chain (StagingDirTracker, AssetSpaceManager, GitSubmoduleOps, UncommittedChangesGuard, ModalConfirmGate, SwitchCacheLayer) were verified to NOT throw with valid inputs — `GitHubRestClient` was the sole offender.

## Fix

1. **`GitHubRestClient` ctor accepts an empty PAT** (unauthenticated mode) — public reads only, lower rate limit. Non-string PAT still throws. The `request()` path **omits the `Authorization` header when the PAT is empty** (sending `Bearer ` with an empty token makes GitHub 401 even public reads, and a caller-provided Authorization must not leak through). Authenticated ops (createCommit, private pulls) surface a clear 401 instead of the whole palette silently vanishing. All three other callsites already guard non-empty PAT (Settings «Test connection» early-returns; `createAssetSpacePusher` short-circuits empty PAT) — only the hard-switch wiring relied on the (broken) empty-PAT path.
2. **Extracted the wiring into a testable `buildHardSwitchDeps` factory** (mirrors the existing `createAssetSpacePusher` extraction) with a **visible `console.error` diagnostic** in the catch alongside `logger.warn` — so any future wiring exception is observable in DevTools.
3. The `if (hardSwitchDeps !== null)` gate is **kept** (by design — the commands need deps); the fix makes the deps non-null.

## Tests

- **Production-shape regression test** `HardSwitchDepsFactory.integration.test.ts` exercising the **real** ctor chain (LocalSecretsStore → getSecret → GitHubRestClient → … → SwitchCacheLayer) with fakes mirroring the real `vault.adapter` contract — **no mocked wiring** (that is exactly why the bug slipped through before). Cases: no-PAT → deps wire (regression), PAT-stored → deps wire, basePath-missing → null+warn, ctor-throws → null + visible console.error.
- **Empirically verified to FAIL pre-fix and PASS post-fix**: reverting the ctor change (`restore if (!opts.pat) throw`) makes the «no PAT → deps wire» case fail (deps null); restoring the fix makes it pass.
- `GitHubRestClient.test.ts` contract updated: empty PAT OK + `Authorization` omitted in unauthenticated mode.
- Local: `tsc --noEmit` 0 errors, `eslint` 0 errors, 246 affected unit tests pass, archgate 13/13.

## UI verify deferred to orchestrator

Headless child cannot click the palette. Orchestrator to verify live (Obsidian + BRAT) after merge that the 3 gated commands appear on vault-2025.