### PR TITLE
fix(#3382): lazy per-invocation PAT for Bootstrap/Add-AssetSpace pulls

### DIFF
--- a/packages/obsidian-plugin/src/ExocortexPlugin.ts
+++ b/packages/obsidian-plugin/src/ExocortexPlugin.ts
@@ -109,10 +109,7 @@ import { createAssetSpacePusher } from "./infrastructure/adapters/AssetSpacePush
 import { LocalSecretsStore } from "./infrastructure/adapters/LocalSecretsStore";
 import { SwitchCacheLayer } from "./infrastructure/adapters/SwitchCacheLayer";
 import { ClearSwitchCacheConfirmModal } from "./infrastructure/adapters/ClearSwitchCacheConfirmModal";
-import {
-  AssetSpaceManager,
-  parseGitHubURL,
-} from "./infrastructure/adapters/AssetSpaceManager";
+import { parseGitHubURL } from "./infrastructure/adapters/AssetSpaceManager";
 import { BootstrapAssetSpaceCommands } from "./infrastructure/adapters/BootstrapAssetSpaceCommands";
 import { BootstrapVaultModal } from "./presentation/modals/BootstrapVaultModal";
 import { AddAssetSpaceModal } from "./presentation/modals/AddAssetSpaceModal";
@@ -124,6 +121,7 @@ import { GitHubRestClient } from "./infrastructure/adapters/GitHubRestClient";
 import { GitSubmoduleOps } from "./infrastructure/adapters/GitSubmoduleOps";
 import {
   buildHardSwitchDeps,
+  buildAssetSpacePuller,
   type HardSwitchDeps,
 } from "./infrastructure/adapters/HardSwitchDepsFactory";
 import {
@@ -2885,7 +2883,6 @@ export default class ExocortexPlugin extends Plugin {
    */
   private registerBootstrapCommands(
     hardSwitchDeps: {
-      assetSpaceManager: AssetSpaceManager;
       gitOps: GitSubmoduleOps;
     },
     localDataStore: PluginLocalDataStore,
@@ -2896,7 +2893,17 @@ export default class ExocortexPlugin extends Plugin {
     };
 
     const bootstrapCommands = new BootstrapAssetSpaceCommands({
-      puller: hardSwitchDeps.assetSpaceManager,
+      // Issue #3382 — rebuild the AssetSpaceManager per invocation from the
+      // CURRENT stored PAT instead of reusing the onload-captured
+      // `hardSwitchDeps.assetSpaceManager` (which froze an empty-PAT client
+      // when the vault had no PAT at load time). A PAT configured after onload
+      // now authenticates Bootstrap / Add-AssetSpace pulls without a reload.
+      getPuller: () =>
+        buildAssetSpacePuller({
+          app: this.app,
+          localDataStore,
+          notifier: this.notifier,
+        }),
       gitOps: hardSwitchDeps.gitOps,
       localStore: localDataStore,
       vaultExists: (p) => this.app.vault.adapter.exists(p),

--- a/packages/obsidian-plugin/src/infrastructure/adapters/BootstrapAssetSpaceCommands.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/BootstrapAssetSpaceCommands.ts
@@ -72,7 +72,15 @@ export interface MaterializeResult {
 }
 
 export interface BootstrapAssetSpaceCommandsDeps {
-  puller: IAssetSpacePuller;
+  /**
+   * Lazily resolve the REST tarball puller. Invoked once per materialise (i.e.
+   * at command-execution time, NOT at construction), so the puller is built
+   * from the CURRENT GitHub PAT. Issue #3382: the previous fixed `puller`
+   * captured an onload-time client, ignoring a PAT the user entered after the
+   * plugin loaded → 401/404 on private-repo pulls. Production wiring resolves
+   * this to {@link HardSwitchDepsFactory.buildAssetSpacePuller}.
+   */
+  getPuller: () => Promise<IAssetSpacePuller>;
   gitOps: IGitSubmoduleOps;
   localStore: IFileOnlyAssetSpaceStore;
   /** `vault.adapter.exists(path)` wrapper. */
@@ -326,7 +334,10 @@ export class BootstrapAssetSpaceCommands {
     submodulePath: string,
     isGit: boolean,
   ): Promise<MaterializeResult> {
-    const result = await this.d.puller.pullAssetSpace(
+    // Resolve the puller lazily so the pull uses the PAT current at
+    // command-execution time, not the one captured at plugin onload (#3382).
+    const puller = await this.d.getPuller();
+    const result = await puller.pullAssetSpace(
       `bootstrap-${basename(submodulePath)}`,
       url,
       this.ref,

--- a/packages/obsidian-plugin/src/infrastructure/adapters/HardSwitchDepsFactory.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/HardSwitchDepsFactory.ts
@@ -37,6 +37,44 @@ export interface BuildHardSwitchDepsOptions {
   logger: ILogger;
 }
 
+export interface BuildAssetSpacePullerOptions {
+  app: App;
+  localDataStore: PluginLocalDataStore;
+  notifier: INotificationService;
+}
+
+/**
+ * Build a fresh {@link AssetSpaceManager} (the REST tarball puller used by the
+ * Bootstrap / Add-AssetSpace commands and the hard-switch materialize path)
+ * from the CURRENTLY stored GitHub PAT.
+ *
+ * Reads `LocalSecretsStore.getSecret("pat")` at call time. Invoking this
+ * per command-execution — rather than caching the value captured at plugin
+ * onload — picks up a PAT the user configured AFTER load without a reload.
+ * This is the fix for Issue #3382: the onload-captured manager held a stale
+ * empty-PAT (unauthenticated) client, so a Bootstrap / Add-AssetSpace pull of
+ * a PRIVATE repo failed with 401/404 even though the user had since entered a
+ * valid PAT in Settings.
+ *
+ * An absent PAT (`getSecret` → null) yields an unauthenticated client (empty
+ * string) — `GitHubRestClient` accepts that for public-repo reads.
+ */
+export async function buildAssetSpacePuller(
+  opts: BuildAssetSpacePullerOptions,
+): Promise<AssetSpaceManager> {
+  const { app, localDataStore, notifier } = opts;
+  const secretsStore = new LocalSecretsStore({ app });
+  const pat = await secretsStore.getSecret("pat");
+  const githubClient = new GitHubRestClient({ app, pat: pat ?? "" });
+  const stagingTracker = new StagingDirTracker({ localDataStore });
+  return new AssetSpaceManager({
+    app,
+    client: githubClient,
+    notifications: notifier,
+    stagingTracker,
+  });
+}
+
 /**
  * Wire the desktop hard-switch dependencies. Extracted from
  * `ExocortexPlugin.onload` for testability (mirrors the
@@ -62,15 +100,16 @@ export async function buildHardSwitchDeps(
 ): Promise<HardSwitchDeps | null> {
   const { app, localDataStore, notifier, logger } = opts;
   try {
-    const secretsStore = new LocalSecretsStore({ app });
-    const pat = await secretsStore.getSecret("pat");
-    const githubClient = new GitHubRestClient({ app, pat: pat ?? "" });
-    const stagingTracker = new StagingDirTracker({ localDataStore });
-    const assetSpaceManager = new AssetSpaceManager({
+    // NOTE: this AssetSpaceManager is captured for the lifetime of the plugin
+    // (used by the hard-switch materialize + push paths). The Bootstrap /
+    // Add-AssetSpace commands deliberately do NOT reuse it — they rebuild a
+    // fresh one per invocation via {@link buildAssetSpacePuller} so a PAT set
+    // after onload is honoured (Issue #3382). Hard-switch / push keep onload
+    // capture (they surface a «Reload to activate» hint instead).
+    const assetSpaceManager = await buildAssetSpacePuller({
       app,
-      client: githubClient,
-      notifications: notifier,
-      stagingTracker,
+      localDataStore,
+      notifier,
     });
     const vaultRootPath =
       (app.vault.adapter as unknown as { basePath?: string }).basePath ?? "";

--- a/packages/obsidian-plugin/tests/unit/infrastructure/adapters/BootstrapAssetSpaceCommands.test.ts
+++ b/packages/obsidian-plugin/tests/unit/infrastructure/adapters/BootstrapAssetSpaceCommands.test.ts
@@ -79,7 +79,7 @@ function makeHarness(opts: {
   };
 
   const deps: BootstrapAssetSpaceCommandsDeps = {
-    puller,
+    getPuller: async () => puller,
     gitOps,
     localStore,
     vaultExists,
@@ -346,5 +346,85 @@ describe("BootstrapAssetSpaceCommands.invokeAddAssetSpace", () => {
     await h.cmds.invokeAddAssetSpace();
     expect(h.puller.pullAssetSpace).not.toHaveBeenCalled();
     expect(h.notices.some((n) => /invalid URL/i.test(n))).toBe(true);
+  });
+});
+
+describe("BootstrapAssetSpaceCommands — lazy per-invocation puller (Issue #3382)", () => {
+  /**
+   * The provider mirrors production wiring: it reads `currentPat` at the
+   * moment it is invoked and bakes that value into the puller it returns. A
+   * fixed-`puller` (pre-fix) design would have frozen the empty onload PAT;
+   * the fix calls `getPuller()` at command-execution time, so the PAT the user
+   * set AFTER construction is the one the pull observes.
+   *
+   * Revert-verify: pointing `materialize` at a puller captured in the deps
+   * (the old `puller` field, resolved once at construction with `currentPat`
+   * still "") makes both assertions below FAIL — the recorded PAT stays "".
+   */
+  function makeLazyHarness() {
+    const pullCalls: Array<{ patAtBuild: string; url: string }> = [];
+    let currentPat = ""; // empty at "onload"
+    const getPuller = jest.fn(async (): Promise<IAssetSpacePuller> => {
+      const patAtBuild = currentPat;
+      return {
+        pullAssetSpace: jest.fn(
+          async (asUid: string, url: string, _ref?: string) => {
+            pullCalls.push({ patAtBuild, url });
+            return { asUid, stagingPath: `/tmp/staging-${asUid}`, sha: "abc1234" };
+          },
+        ),
+      };
+    });
+
+    const deps: BootstrapAssetSpaceCommandsDeps = {
+      getPuller,
+      gitOps: {
+        renameIntoVault: jest.fn(async () => undefined),
+        readGitmodulesEntries: jest.fn(async () => []),
+        appendGitmodulesEntry: jest.fn(async () => ({ added: true })),
+      },
+      localStore: { upsertFileOnlyAssetSpace: jest.fn(async () => undefined) },
+      vaultExists: jest.fn(async (p: string) => p === ".git"),
+      listFolder: jest.fn(async () => ({ files: [], folders: [] })),
+      isGitVault: async () => true,
+      validateUrl: () => undefined,
+      deriveFolderName: () => "pmbok-ontology",
+      promptBootstrapUrls: jest.fn(async () => null),
+      promptAddAssetSpaceUrl: jest.fn(async () => ({
+        url: "https://github.com/kitelev/exoas-pmbok-ontology",
+      })),
+      confirm: jest.fn(async () => true),
+      notify: jest.fn(),
+    };
+
+    return {
+      cmds: new BootstrapAssetSpaceCommands(deps),
+      getPuller,
+      pullCalls,
+      setPat: (pat: string) => {
+        currentPat = pat;
+      },
+    };
+  }
+
+  it("resolves the puller at invocation, using a PAT set AFTER construction", async () => {
+    const h = makeLazyHarness();
+    // Plugin onload already happened (cmds constructed) with NO PAT.
+    // User configures the PAT afterwards, without reloading:
+    h.setPat("github_pat_AFTERONLOAD");
+
+    await h.cmds.invokeAddAssetSpace();
+
+    // Provider was invoked at command time (not frozen at construction)…
+    expect(h.getPuller).toHaveBeenCalledTimes(1);
+    // …and the pull observed the CURRENT PAT, not the empty onload value.
+    expect(h.pullCalls).toHaveLength(1);
+    expect(h.pullCalls[0].patAtBuild).toBe("github_pat_AFTERONLOAD");
+  });
+
+  it("does NOT resolve the puller until a command runs (no eager onload build)", () => {
+    const h = makeLazyHarness();
+    // Merely constructing the commands must not read the PAT / build a client.
+    expect(h.getPuller).not.toHaveBeenCalled();
   });
 });

--- a/packages/obsidian-plugin/tests/unit/integration/BootstrapAssetSpace.integration.test.ts
+++ b/packages/obsidian-plugin/tests/unit/integration/BootstrapAssetSpace.integration.test.ts
@@ -111,8 +111,9 @@ describe("Bootstrap integration — real GitSubmoduleOps + tmpdir vault (git mod
     const { store } = makeFakeLocalStore();
     const notices: string[] = [];
 
+    const fakePuller = makeFakePuller();
     const cmds = new BootstrapAssetSpaceCommands({
-      puller: makeFakePuller(),
+      getPuller: async () => fakePuller,
       gitOps,
       localStore: store,
       vaultExists: probes.vaultExists,

--- a/packages/obsidian-plugin/tests/unit/wiring/BootstrapPatRefresh.integration.test.ts
+++ b/packages/obsidian-plugin/tests/unit/wiring/BootstrapPatRefresh.integration.test.ts
@@ -1,0 +1,223 @@
+/**
+ * @jest-environment node
+ *
+ * Production-shape regression test for Issue #3382 — Bootstrap / Add-AssetSpace
+ * pulls must authenticate with the PAT current at COMMAND-EXECUTION time, not
+ * the one captured at plugin onload.
+ *
+ * Exercises the REAL wiring chain — `LocalSecretsStore` (data.local.json) →
+ * `GitHubRestClient` → `AssetSpaceManager` (via `buildAssetSpacePuller`) →
+ * `BootstrapAssetSpaceCommands` — against an in-memory `vault.adapter` that
+ * mirrors the Obsidian contract (per `test-fixture-realism`). The only seam is
+ * obsidian's `requestUrl`, spied to capture the outgoing Authorization header.
+ * NONE of the PAT-reading / client-building is stubbed — that is exactly the
+ * code path the bug lived in.
+ *
+ * The tarball fetch deliberately returns non-gzip bytes so the pull fails
+ * AFTER its REST request (carrying the Authorization header) has fired and
+ * the staging dir is released — the test asserts on the captured header, not
+ * on a materialised vault, and leaves no temp dirs behind.
+ *
+ * Discrimination (revert-verify): the lazy provider yields `Bearer <new PAT>`;
+ * an eager provider built BEFORE the PAT is stored (the pre-fix onload-capture
+ * behaviour) yields NO Authorization header. Both directions are asserted
+ * below, so the suite fails if the lazy wiring regresses to eager capture.
+ */
+
+import { describe, it, expect, jest, beforeEach, afterEach } from "@jest/globals";
+import * as obsidian from "obsidian";
+import type { App } from "obsidian";
+import type { INotificationService } from "exocortex";
+
+import { buildAssetSpacePuller } from "../../../src/infrastructure/adapters/HardSwitchDepsFactory";
+import { LocalSecretsStore } from "../../../src/infrastructure/adapters/LocalSecretsStore";
+import { PluginLocalDataStore } from "../../../src/infrastructure/adapters/PluginLocalDataStore";
+import { GitHubRestClient } from "../../../src/infrastructure/adapters/GitHubRestClient";
+import {
+  BootstrapAssetSpaceCommands,
+  type BootstrapAssetSpaceCommandsDeps,
+  type IAssetSpacePuller,
+} from "../../../src/infrastructure/adapters/BootstrapAssetSpaceCommands";
+
+// Synthetic, never-real classic token shape (ghp_ + 36 chars). Only ever
+// appears in the spied request headers — never sent to the network.
+const NEW_PAT = "ghp_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA3382";
+const PRIVATE_URL = "https://github.com/kitelev/exoas-private";
+
+interface CapturedRequest {
+  url: string;
+  auth: string | undefined;
+}
+
+function makeApp(): { app: App; files: Record<string, string> } {
+  const files: Record<string, string> = {};
+  const adapter = {
+    exists: async (p: string) =>
+      Object.prototype.hasOwnProperty.call(files, p),
+    read: async (p: string) => {
+      if (!Object.prototype.hasOwnProperty.call(files, p)) {
+        throw new Error(`ENOENT: ${p}`);
+      }
+      return files[p];
+    },
+    write: async (p: string, data: string) => {
+      files[p] = data;
+    },
+    list: async () => ({ files: [], folders: [] }),
+  };
+  const app = {
+    vault: {
+      adapter,
+      configDir: ".obsidian",
+      getMarkdownFiles: () => [],
+    },
+    metadataCache: { getFileCache: () => null },
+  } as unknown as App;
+  return { app, files };
+}
+
+function makeNotifier(): INotificationService {
+  return {
+    info: () => undefined,
+    success: () => undefined,
+    error: () => undefined,
+    warn: () => undefined,
+    confirm: async () => true,
+  };
+}
+
+function deriveFolderName(url: string): string {
+  const repo = url.split("/").pop() ?? "unknown";
+  return repo.startsWith("exoas-") ? repo.slice("exoas-".length) : repo;
+}
+
+function makeDeps(
+  getPuller: () => Promise<IAssetSpacePuller>,
+  notices: string[],
+): BootstrapAssetSpaceCommandsDeps {
+  return {
+    getPuller,
+    gitOps: {
+      renameIntoVault: async () => undefined,
+      readGitmodulesEntries: async () => [],
+      appendGitmodulesEntry: async () => ({ added: true }),
+    },
+    localStore: { upsertFileOnlyAssetSpace: async () => undefined },
+    vaultExists: async (p: string) => p === ".git",
+    listFolder: async () => ({ files: [], folders: [] }),
+    isGitVault: async () => true,
+    validateUrl: (url: string) => GitHubRestClient.validateRepoURL(url),
+    deriveFolderName,
+    promptBootstrapUrls: async () => null,
+    promptAddAssetSpaceUrl: async () => ({ url: PRIVATE_URL }),
+    confirm: async () => true,
+    notify: (m: string) => notices.push(m),
+  };
+}
+
+describe("Bootstrap/Add-AssetSpace PAT freshness (Issue #3382) — production-shape", () => {
+  let captured: CapturedRequest[];
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let requestUrlSpy: jest.SpiedFunction<any>;
+
+  beforeEach(() => {
+    captured = [];
+    requestUrlSpy = jest
+      .spyOn(obsidian, "requestUrl")
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      .mockImplementation(async (req: any) => {
+        captured.push({
+          url: req.url as string,
+          auth: req.headers?.Authorization as string | undefined,
+        });
+        if (/\/rate_limit$/.test(req.url)) {
+          return {
+            status: 200,
+            json: {
+              resources: {
+                core: {
+                  remaining: 5000,
+                  reset: Math.floor(Date.now() / 1000) + 3600,
+                },
+              },
+            },
+            text: "",
+            arrayBuffer: new ArrayBuffer(0),
+            headers: {},
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          } as any;
+        }
+        // Tarball endpoint — return non-gzip bytes so extraction fails AFTER
+        // this request (and its Authorization header) has been recorded.
+        return {
+          status: 200,
+          json: {},
+          text: "",
+          arrayBuffer: new Uint8Array([0, 1, 2, 3]).buffer,
+          headers: {},
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        } as any;
+      });
+  });
+
+  afterEach(() => {
+    requestUrlSpy.mockRestore();
+  });
+
+  it("lazy provider authenticates with the PAT set AFTER onload", async () => {
+    const { app } = makeApp();
+    const store = new PluginLocalDataStore({ app });
+    await store.init();
+    const notifier = makeNotifier();
+    const notices: string[] = [];
+
+    // Wiring exactly as ExocortexPlugin.registerBootstrapCommands does it:
+    // a lazy provider that rebuilds the puller from the CURRENT stored PAT.
+    const deps = makeDeps(
+      () => buildAssetSpacePuller({ app, localDataStore: store, notifier }),
+      notices,
+    );
+    const cmds = new BootstrapAssetSpaceCommands(deps);
+
+    // Onload already happened (cmds constructed) with NO PAT in the vault.
+    // The user now configures a PAT in Settings — WITHOUT reloading.
+    await new LocalSecretsStore({ app }).setSecret("pat", NEW_PAT);
+
+    await cmds.invokeAddAssetSpace();
+
+    const tarballCall = captured.find((c) => c.url.includes("/tarball/"));
+    expect(tarballCall).toBeDefined();
+    expect(tarballCall?.auth).toBe(`Bearer ${NEW_PAT}`);
+    // The pre-flight rate-limit gate used the same fresh client.
+    const rateCall = captured.find((c) => /\/rate_limit$/.test(c.url));
+    expect(rateCall?.auth).toBe(`Bearer ${NEW_PAT}`);
+  });
+
+  it("eager onload-captured provider sends NO PAT (the bug the lazy fix avoids)", async () => {
+    const { app } = makeApp();
+    const store = new PluginLocalDataStore({ app });
+    await store.init();
+    const notifier = makeNotifier();
+    const notices: string[] = [];
+
+    // Pre-fix behaviour: build the puller NOW, while the vault has no PAT
+    // (mirrors capturing `hardSwitchDeps.assetSpaceManager` at plugin onload).
+    const eagerPuller = await buildAssetSpacePuller({
+      app,
+      localDataStore: store,
+      notifier,
+    });
+    const deps = makeDeps(async () => eagerPuller, notices);
+    const cmds = new BootstrapAssetSpaceCommands(deps);
+
+    // User configures the PAT afterwards — the frozen client never sees it.
+    await new LocalSecretsStore({ app }).setSecret("pat", NEW_PAT);
+
+    await cmds.invokeAddAssetSpace();
+
+    const tarballCall = captured.find((c) => c.url.includes("/tarball/"));
+    expect(tarballCall).toBeDefined();
+    // Empty PAT → GitHubRestClient omits the Authorization header entirely.
+    expect(tarballCall?.auth).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

Closes #3382.

`hardSwitchDeps.assetSpaceManager` was built **once on plugin onload** with the GitHub PAT read at that moment (often empty, unauthenticated). If a user entered a PAT in Settings **after** onload — without reloading — and ran **Bootstrap vault** / **Add AssetSpace by URL** against a **private** repo, the captured client still held the stale empty PAT → HTTP 401/404. Fail-safe (no partial state — the 401 fires before `stagingTracker.allocate`) but UX-confusing.

## Fix (Option A — lazy per-invocation PAT)

- Extract `buildAssetSpacePuller(opts)` in `HardSwitchDepsFactory` — reads the **current** PAT from `LocalSecretsStore` and builds a fresh `GitHubRestClient` + `AssetSpaceManager`. `buildHardSwitchDeps` now reuses it (DRY).
- `BootstrapAssetSpaceCommands` takes a `getPuller: () => Promise<IAssetSpacePuller>` provider instead of a pre-built `puller`; `materialize` resolves it **at command-execution time**.
- `ExocortexPlugin.registerBootstrapCommands` wires `getPuller` to `buildAssetSpacePuller(...)`, so each invocation authenticates with the PAT current at that moment.

### Scope

Bootstrap / Add-AssetSpace **pull** path only (per issue). Hard-switch materialization + push keep onload-capture semantics (out of scope; push already shows a "Reload to activate" hint). The `hardSwitchDeps !== null` palette-registration gate is unchanged.

## Tests

- **Unit (laziness)** — `BootstrapAssetSpaceCommands.test.ts`: `getPuller` is resolved at invocation (not construction) and the pull observes a PAT set **after** construction; constructing alone resolves nothing.
- **Production-shape integration** — `BootstrapPatRefresh.integration.test.ts`: real `LocalSecretsStore → GitHubRestClient → AssetSpaceManager` chain (no stubbed wiring); spies obsidian `requestUrl` and asserts the outgoing `Authorization` header carries the post-onload PAT (`Bearer <pat>`). A companion case documents that an eager onload-captured provider sends **no** Authorization header (the bug).

### Revert-verify

Simulating the pre-fix onload-capture (resolve the puller in the constructor) makes **3 tests FAIL** (captured PAT empty / `getPuller` called at construction); the lazy fix makes them **PASS**. Restored to the lazy implementation before commit.

Local: typecheck clean, lint clean, 101 related tests green (BootstrapAssetSpaceCommands + BootstrapPatRefresh + HardSwitchDepsFactory + AssetSpaceManager + HardSwitch end-to-end + FocusProfileWiring + pullAssetSpace). BDD 100%, archgate 13/13.

## Test plan

- [ ] CI 14/14 green
- [ ] UI verify deferred to orchestrator: with no PAT at load, enter a PAT in Settings (no reload), run **Add AssetSpace by URL** on a private `exoas-*` repo → authenticates successfully.