### PR TITLE
refactor(folder-repair): dedupe triplicated reference resolution into core (#3384)

### DIFF
--- a/packages/cli/src/executors/BatchExecutor.ts
+++ b/packages/cli/src/executors/BatchExecutor.ts
@@ -1,7 +1,12 @@
 import path from "path";
 import { NodeFsAdapter } from "../adapters/NodeFsAdapter.js";
 import { PathResolver } from "../utils/PathResolver.js";
-import { FrontmatterService, DateFormatter } from "exocortex";
+import {
+  FrontmatterService,
+  DateFormatter,
+  extractAssetReference,
+} from "exocortex";
+import { findReferencedFile, normalizePath } from "./folderRepairHelpers.js";
 import { TransactionManager } from "../utils/TransactionManager.js";
 import { InvalidArgumentsError } from "../utils/errors/index.js";
 
@@ -673,7 +678,7 @@ export class BatchExecutor {
     }
 
     // Extract reference from various formats
-    const reference = this.extractReference(isDefinedBy);
+    const reference = extractAssetReference(isDefinedBy);
     if (!reference) {
       return {
         success: false,
@@ -684,7 +689,11 @@ export class BatchExecutor {
     }
 
     // Find the referenced file
-    const referencedFilePath = await this.findReferencedFile(reference, relativePath);
+    const referencedFilePath = await findReferencedFile(
+      this.fsAdapter,
+      reference,
+      relativePath,
+    );
     if (!referencedFilePath) {
       return {
         success: false,
@@ -701,7 +710,7 @@ export class BatchExecutor {
     const currentFolder = rawCurrentFolder === "." ? "" : rawCurrentFolder;
 
     // Check if already in correct folder
-    if (this.normalizePath(currentFolder) === this.normalizePath(expectedFolder)) {
+    if (normalizePath(currentFolder) === normalizePath(expectedFolder)) {
       return {
         success: true,
         command: operation.command,
@@ -743,85 +752,4 @@ export class BatchExecutor {
     };
   }
 
-  /**
-   * Extract reference from various formats:
-   * - [[Reference]] -> Reference
-   * - [[uid|alias]] -> uid (alias suffix stripped — getFirstLinkpathDest rejects pipe-aliased linkpath)
-   * - "[[Reference]]" -> Reference
-   * - Reference -> Reference
-   */
-  private extractReference(value: unknown): string | null {
-    if (typeof value !== "string") {
-      return null;
-    }
-
-    // Remove quotes if present
-    let cleaned = value.trim().replace(/^["']|["']$/g, "");
-
-    // Remove wiki-link brackets if present
-    cleaned = cleaned.replace(/^\[\[|\]\]$/g, "");
-
-    // Strip alias suffix (everything after first `|`) — getFirstLinkpathDest
-    // returns null for pipe-aliased linkpaths, breaking alias-form refs.
-    const pipeIdx = cleaned.indexOf("|");
-    if (pipeIdx !== -1) {
-      cleaned = cleaned.slice(0, pipeIdx).trim();
-    }
-
-    return cleaned || null;
-  }
-
-  /**
-   * Find the referenced file by resolving the reference
-   */
-  private async findReferencedFile(
-    reference: string,
-    sourceFilePath: string,
-  ): Promise<string | null> {
-    // Normalize reference (add .md extension if not present)
-    const normalizedRef = reference.endsWith(".md")
-      ? reference
-      : `${reference}.md`;
-
-    // Try 1: Direct path (if reference looks like a path)
-    if (reference.includes("/")) {
-      const exists = await this.fsAdapter.fileExists(normalizedRef);
-      if (exists) {
-        return normalizedRef;
-      }
-    }
-
-    // Try 2: Same folder as source file
-    const sourceDir = path.dirname(sourceFilePath);
-    const sameFolderPath = sourceDir !== "."
-      ? `${sourceDir}/${normalizedRef}`
-      : normalizedRef;
-    const sameFolderExists = await this.fsAdapter.fileExists(sameFolderPath);
-    if (sameFolderExists) {
-      return sameFolderPath;
-    }
-
-    // Try 3: Search by UID
-    const uidPath = await this.fsAdapter.findFileByUID(reference);
-    if (uidPath) {
-      return uidPath;
-    }
-
-    // Try 4: Search by filename across vault
-    const allFiles = await this.fsAdapter.getMarkdownFiles();
-    const matchingFile = allFiles.find((file) => {
-      const baseName = path.basename(file, ".md");
-      const refBaseName = path.basename(normalizedRef, ".md");
-      return baseName === refBaseName;
-    });
-
-    return matchingFile || null;
-  }
-
-  /**
-   * Normalize path for comparison
-   */
-  private normalizePath(filePath: string): string {
-    return filePath.replace(/\\/g, "/").replace(/^\.\//, "").replace(/\/$/, "");
-  }
 }

--- a/packages/cli/src/executors/commands/FolderRepairExecutor.ts
+++ b/packages/cli/src/executors/commands/FolderRepairExecutor.ts
@@ -1,7 +1,9 @@
 import path from "path";
+import { extractAssetReference } from "exocortex";
 import { BaseCommandExecutor, CommandContext } from "./BaseCommandExecutor.js";
 import { ErrorHandler } from "../../utils/ErrorHandler.js";
 import { ExitCodes } from "../../utils/ExitCodes.js";
+import { findReferencedFile, normalizePath } from "../folderRepairHelpers.js";
 
 /**
  * Result of folder repair operation
@@ -42,7 +44,7 @@ export class FolderRepairExecutor extends BaseCommandExecutor {
       }
 
       // Extract reference from various formats
-      const reference = this.extractReference(isDefinedBy);
+      const reference = extractAssetReference(isDefinedBy);
       if (!reference) {
         throw new Error(
           "Cannot determine expected folder: invalid exo__Asset_isDefinedBy format",
@@ -50,7 +52,11 @@ export class FolderRepairExecutor extends BaseCommandExecutor {
       }
 
       // Find the referenced file
-      const referencedFilePath = await this.findReferencedFile(reference, relativePath);
+      const referencedFilePath = await findReferencedFile(
+        this.fsAdapter,
+        reference,
+        relativePath,
+      );
       if (!referencedFilePath) {
         throw new Error(
           `Cannot determine expected folder: referenced asset not found: ${reference}`,
@@ -65,7 +71,7 @@ export class FolderRepairExecutor extends BaseCommandExecutor {
       const currentFolder = rawCurrentFolder === "." ? "" : rawCurrentFolder;
 
       // Check if already in correct folder
-      if (this.normalizePath(currentFolder) === this.normalizePath(expectedFolder)) {
+      if (normalizePath(currentFolder) === normalizePath(expectedFolder)) {
         console.log(`✅ Already in correct folder`);
         console.log(`   File: ${filepath}`);
         console.log(`   Folder: ${expectedFolder || "(root)"}`);
@@ -134,92 +140,5 @@ export class FolderRepairExecutor extends BaseCommandExecutor {
     } catch (error) {
       ErrorHandler.handle(error as Error);
     }
-  }
-
-  /**
-   * Extract reference from various formats:
-   * - [[Reference]] -> Reference
-   * - [[uid|alias]] -> uid (alias suffix stripped — getFirstLinkpathDest rejects pipe-aliased linkpath)
-   * - "[[Reference]]" -> Reference
-   * - Reference -> Reference
-   */
-  private extractReference(value: unknown): string | null {
-    if (typeof value !== "string") {
-      return null;
-    }
-
-    // Remove quotes if present
-    let cleaned = value.trim().replace(/^["']|["']$/g, "");
-
-    // Remove wiki-link brackets if present
-    cleaned = cleaned.replace(/^\[\[|\]\]$/g, "");
-
-    // Strip alias suffix (everything after first `|`) — getFirstLinkpathDest
-    // returns null for pipe-aliased linkpaths, breaking alias-form refs.
-    const pipeIdx = cleaned.indexOf("|");
-    if (pipeIdx !== -1) {
-      cleaned = cleaned.slice(0, pipeIdx).trim();
-    }
-
-    return cleaned || null;
-  }
-
-  /**
-   * Find the referenced file by resolving the reference
-   *
-   * Handles various reference formats:
-   * - Full path: "03 Knowledge/project/task.md"
-   * - Filename only: "task.md" or "task"
-   * - UID: "abc123-def456"
-   */
-  private async findReferencedFile(
-    reference: string,
-    sourceFilePath: string,
-  ): Promise<string | null> {
-    // Normalize reference (remove .md extension if present for comparison)
-    const normalizedRef = reference.endsWith(".md")
-      ? reference
-      : `${reference}.md`;
-
-    // Try 1: Direct path (if reference looks like a path)
-    if (reference.includes("/")) {
-      const exists = await this.fsAdapter.fileExists(normalizedRef);
-      if (exists) {
-        return normalizedRef;
-      }
-    }
-
-    // Try 2: Same folder as source file
-    const sourceDir = path.dirname(sourceFilePath);
-    const sameFolderPath = sourceDir
-      ? `${sourceDir}/${normalizedRef}`
-      : normalizedRef;
-    const sameFolderExists = await this.fsAdapter.fileExists(sameFolderPath);
-    if (sameFolderExists) {
-      return sameFolderPath;
-    }
-
-    // Try 3: Search by UID
-    const uidPath = await this.fsAdapter.findFileByUID(reference);
-    if (uidPath) {
-      return uidPath;
-    }
-
-    // Try 4: Search by filename across vault
-    const allFiles = await this.fsAdapter.getMarkdownFiles();
-    const matchingFile = allFiles.find((file) => {
-      const baseName = path.basename(file, ".md");
-      const refBaseName = path.basename(normalizedRef, ".md");
-      return baseName === refBaseName;
-    });
-
-    return matchingFile || null;
-  }
-
-  /**
-   * Normalize path for comparison (handle empty string for root, normalize separators)
-   */
-  private normalizePath(filePath: string): string {
-    return filePath.replace(/\\/g, "/").replace(/^\.\//, "").replace(/\/$/, "");
   }
 }

--- a/packages/cli/src/executors/folderRepairHelpers.ts
+++ b/packages/cli/src/executors/folderRepairHelpers.ts
@@ -1,0 +1,80 @@
+import path from "path";
+import type { NodeFsAdapter } from "../adapters/NodeFsAdapter.js";
+
+/**
+ * Shared CLI-side folder-repair helpers. Consumed by both
+ * `FolderRepairExecutor` (single-file `repair-folder` command) and
+ * `BatchExecutor` (batch `repair-folder` operation). Previously duplicated in
+ * each executor (audit #3384 finding H4).
+ *
+ * These implement the CLI's Node-fs reference-resolution strategy, which is
+ * deliberately distinct from the plugin/grounding path (core
+ * `FolderRepairService` → `IVaultAdapter.getFirstLinkpathDest`). That
+ * divergence is pre-existing and intentionally NOT unified here — this change
+ * is a pure dedup, not a behavior change.
+ */
+
+/**
+ * Resolve a `exo__Asset_isDefinedBy` reference to the vault-relative path of
+ * the referenced asset. Tries, in order:
+ *   1. direct path (when the reference contains a `/`)
+ *   2. same folder as the source file
+ *   3. UID index lookup (`findFileByUID`)
+ *   4. basename scan across all markdown files
+ * Returns `null` when none match.
+ */
+export async function findReferencedFile(
+  fsAdapter: NodeFsAdapter,
+  reference: string,
+  sourceFilePath: string,
+): Promise<string | null> {
+  // Normalize reference (add .md extension if not present)
+  const normalizedRef = reference.endsWith(".md")
+    ? reference
+    : `${reference}.md`;
+
+  // Try 1: Direct path (if reference looks like a path)
+  if (reference.includes("/")) {
+    const exists = await fsAdapter.fileExists(normalizedRef);
+    if (exists) {
+      return normalizedRef;
+    }
+  }
+
+  // Try 2: Same folder as source file. `path.dirname` returns "." for a
+  // root-level source; both prior copies resolved identically here —
+  // FolderRepairExecutor produced "./<ref>.md" and BatchExecutor produced
+  // "<ref>.md", which `NodeFsAdapter.resolvePath` (path.join) and the
+  // downstream `path.dirname` collapse to the same value.
+  const sourceDir = path.dirname(sourceFilePath);
+  const sameFolderPath =
+    sourceDir !== "." ? `${sourceDir}/${normalizedRef}` : normalizedRef;
+  const sameFolderExists = await fsAdapter.fileExists(sameFolderPath);
+  if (sameFolderExists) {
+    return sameFolderPath;
+  }
+
+  // Try 3: Search by UID
+  const uidPath = await fsAdapter.findFileByUID(reference);
+  if (uidPath) {
+    return uidPath;
+  }
+
+  // Try 4: Search by filename across vault
+  const allFiles = await fsAdapter.getMarkdownFiles();
+  const matchingFile = allFiles.find((file) => {
+    const baseName = path.basename(file, ".md");
+    const refBaseName = path.basename(normalizedRef, ".md");
+    return baseName === refBaseName;
+  });
+
+  return matchingFile || null;
+}
+
+/**
+ * Normalize a vault-relative path for equality comparison: backslashes → `/`,
+ * strip a leading `./`, strip a trailing `/`.
+ */
+export function normalizePath(filePath: string): string {
+  return filePath.replace(/\\/g, "/").replace(/^\.\//, "").replace(/\/$/, "");
+}

--- a/packages/cli/tests/unit/executors/BatchExecutor.repair-folder.test.ts
+++ b/packages/cli/tests/unit/executors/BatchExecutor.repair-folder.test.ts
@@ -68,6 +68,16 @@ jest.unstable_mockModule("../../../src/adapters/NodeFsAdapter.js", () => ({
 jest.unstable_mockModule("exocortex", () => ({
   FrontmatterService: jest.fn(() => mockFrontmatterService),
   DateFormatter: mockDateFormatter,
+  // Faithful pure stub mirroring exocortex's extractAssetReference (the
+  // canonical shared helper consumed by BatchExecutor — audit #3384).
+  extractAssetReference: (value: unknown): string | null => {
+    if (typeof value !== "string") return null;
+    let cleaned = value.trim().replace(/^["']|["']$/g, "");
+    cleaned = cleaned.replace(/^\[\[|\]\]$/g, "");
+    const pipeIdx = cleaned.indexOf("|");
+    if (pipeIdx !== -1) cleaned = cleaned.slice(0, pipeIdx).trim();
+    return cleaned || null;
+  },
 }));
 
 jest.unstable_mockModule("../../../src/utils/TransactionManager.js", () => ({

--- a/packages/cli/tests/unit/executors/BatchExecutor.test.ts
+++ b/packages/cli/tests/unit/executors/BatchExecutor.test.ts
@@ -75,6 +75,16 @@ jest.unstable_mockModule("../../../src/adapters/NodeFsAdapter.js", () => ({
 jest.unstable_mockModule("exocortex", () => ({
   FrontmatterService: jest.fn(() => mockFrontmatterService),
   DateFormatter: mockDateFormatter,
+  // Faithful pure stub mirroring exocortex's extractAssetReference (the
+  // canonical shared helper consumed by BatchExecutor — audit #3384).
+  extractAssetReference: (value: unknown): string | null => {
+    if (typeof value !== "string") return null;
+    let cleaned = value.trim().replace(/^["']|["']$/g, "");
+    cleaned = cleaned.replace(/^\[\[|\]\]$/g, "");
+    const pipeIdx = cleaned.indexOf("|");
+    if (pipeIdx !== -1) cleaned = cleaned.slice(0, pipeIdx).trim();
+    return cleaned || null;
+  },
 }));
 
 jest.unstable_mockModule("../../../src/utils/TransactionManager.js", () => ({

--- a/packages/cli/tests/unit/executors/CommandExecutor.error.test.ts
+++ b/packages/cli/tests/unit/executors/CommandExecutor.error.test.ts
@@ -123,6 +123,16 @@ jest.unstable_mockModule("exocortex", () => ({
   FrontmatterService: jest.fn(() => mockFrontmatterService),
   DateFormatter: mockDateFormatter,
   MetadataHelpers: mockMetadataHelpers,
+  // Faithful pure stub mirroring exocortex's extractAssetReference (the
+  // canonical shared helper consumed by FolderRepairExecutor — audit #3384).
+  extractAssetReference: (value: unknown): string | null => {
+    if (typeof value !== "string") return null;
+    let cleaned = value.trim().replace(/^["']|["']$/g, "");
+    cleaned = cleaned.replace(/^\[\[|\]\]$/g, "");
+    const pipeIdx = cleaned.indexOf("|");
+    if (pipeIdx !== -1) cleaned = cleaned.slice(0, pipeIdx).trim();
+    return cleaned || null;
+  },
   FileNotFoundError: MockFileNotFoundError,
   FileAlreadyExistsError: MockFileAlreadyExistsError,
 }));

--- a/packages/cli/tests/unit/executors/CommandExecutor.test.ts
+++ b/packages/cli/tests/unit/executors/CommandExecutor.test.ts
@@ -92,6 +92,16 @@ jest.unstable_mockModule("exocortex", () => ({
   FrontmatterService: jest.fn(() => mockFrontmatterService),
   DateFormatter: mockDateFormatter,
   MetadataHelpers: mockMetadataHelpers,
+  // Faithful pure stub mirroring exocortex's extractAssetReference (the
+  // canonical shared helper consumed by FolderRepairExecutor — audit #3384).
+  extractAssetReference: (value: unknown): string | null => {
+    if (typeof value !== "string") return null;
+    let cleaned = value.trim().replace(/^["']|["']$/g, "");
+    cleaned = cleaned.replace(/^\[\[|\]\]$/g, "");
+    const pipeIdx = cleaned.indexOf("|");
+    if (pipeIdx !== -1) cleaned = cleaned.slice(0, pipeIdx).trim();
+    return cleaned || null;
+  },
   FileNotFoundError: class FileNotFoundError extends Error {},
   FileAlreadyExistsError: class FileAlreadyExistsError extends Error {
     constructor(msg: string) {

--- a/packages/cli/tests/unit/executors/FolderRepairExecutor.test.ts
+++ b/packages/cli/tests/unit/executors/FolderRepairExecutor.test.ts
@@ -71,6 +71,16 @@ jest.unstable_mockModule("exocortex", () => ({
   FrontmatterService: jest.fn(() => mockFrontmatterService),
   DateFormatter: mockDateFormatter,
   MetadataHelpers: mockMetadataHelpers,
+  // Faithful pure stub mirroring exocortex's extractAssetReference (the
+  // canonical shared helper consumed by FolderRepairExecutor — audit #3384).
+  extractAssetReference: (value: unknown): string | null => {
+    if (typeof value !== "string") return null;
+    let cleaned = value.trim().replace(/^["']|["']$/g, "");
+    cleaned = cleaned.replace(/^\[\[|\]\]$/g, "");
+    const pipeIdx = cleaned.indexOf("|");
+    if (pipeIdx !== -1) cleaned = cleaned.slice(0, pipeIdx).trim();
+    return cleaned || null;
+  },
   FileNotFoundError: class FileNotFoundError extends Error {},
   FileAlreadyExistsError: class FileAlreadyExistsError extends Error {
     constructor(msg: string) {

--- a/packages/cli/tests/unit/executors/folderRepairHelpers.test.ts
+++ b/packages/cli/tests/unit/executors/folderRepairHelpers.test.ts
@@ -1,0 +1,158 @@
+import { jest, describe, it, expect } from "@jest/globals";
+import { extractAssetReference } from "exocortex";
+import type { NodeFsAdapter } from "../../../src/adapters/NodeFsAdapter.js";
+import {
+  findReferencedFile,
+  normalizePath,
+} from "../../../src/executors/folderRepairHelpers.js";
+
+/**
+ * Dedup regression guard for audit #3384 finding H4: folder-repair reference
+ * resolution was triplicated (`extractAssetReference` byte-for-byte in core +
+ * both CLI executors) and the two CLI copies of `findReferencedFile` /
+ * `normalizePath` had begun to drift.
+ *
+ * After the dedup, both CLI executors consume the canonical
+ * `extractAssetReference` (exported from `exocortex`) and the shared
+ * `folderRepairHelpers` module. This suite imports those single sources
+ * directly:
+ *   - `import { extractAssetReference } from "exocortex"` fails to resolve
+ *     pre-fix (no such export — it was a private method on three classes).
+ *   - `import { findReferencedFile, normalizePath } from
+ *     "../../../src/executors/folderRepairHelpers.js"` fails to resolve
+ *     pre-fix (the module did not exist).
+ * Either broken import fails the whole suite, so it FAILS pre-fix and PASSES
+ * post-fix (revert-verify per ~/dotfiles/.claude/rules/integration-test-revert-verify.md).
+ */
+
+type FakeFs = Pick<
+  NodeFsAdapter,
+  "fileExists" | "findFileByUID" | "getMarkdownFiles"
+>;
+
+function makeFs(overrides: Partial<FakeFs> = {}): NodeFsAdapter {
+  const base: FakeFs = {
+    fileExists: jest.fn(async () => false),
+    findFileByUID: jest.fn(async () => null),
+    getMarkdownFiles: jest.fn(async () => []),
+  };
+  return { ...base, ...overrides } as unknown as NodeFsAdapter;
+}
+
+describe("folderRepairHelpers — extractAssetReference (canonical, shared)", () => {
+  it("strips wiki-link brackets: [[Reference]] -> Reference", () => {
+    expect(extractAssetReference("[[projects/my-project]]")).toBe(
+      "projects/my-project",
+    );
+  });
+
+  it('strips surrounding YAML quotes: "[[Reference]]" -> Reference', () => {
+    expect(extractAssetReference('"[[projects/my-project]]"')).toBe(
+      "projects/my-project",
+    );
+  });
+
+  it("strips alias suffix to the TARGET: [[uid|alias]] -> uid", () => {
+    expect(
+      extractAssetReference(
+        "[[e4bc670e-2618-41fc-87f8-9e3422f91514|$tbank-areas]]",
+      ),
+    ).toBe("e4bc670e-2618-41fc-87f8-9e3422f91514");
+  });
+
+  it("handles surrounding whitespace", () => {
+    expect(extractAssetReference("  [[TestAsset]]  ")).toBe("TestAsset");
+  });
+
+  it("returns a plain reference unchanged", () => {
+    expect(extractAssetReference("projects/my-project")).toBe(
+      "projects/my-project",
+    );
+  });
+
+  it("returns null for non-string input", () => {
+    expect(extractAssetReference({ invalid: "object" })).toBeNull();
+    expect(extractAssetReference(undefined)).toBeNull();
+  });
+
+  it("returns null for an empty result", () => {
+    expect(extractAssetReference("")).toBeNull();
+    expect(extractAssetReference("[[]]")).toBeNull();
+  });
+});
+
+describe("folderRepairHelpers — normalizePath (shared)", () => {
+  it("converts backslashes to forward slashes", () => {
+    expect(normalizePath("a\\b\\c")).toBe("a/b/c");
+  });
+
+  it("strips a leading ./ and a trailing /", () => {
+    expect(normalizePath("./folder/")).toBe("folder");
+  });
+
+  it("leaves a clean path and the root ('') unchanged", () => {
+    expect(normalizePath("projects")).toBe("projects");
+    expect(normalizePath("")).toBe("");
+  });
+});
+
+describe("folderRepairHelpers — findReferencedFile (shared)", () => {
+  it("Try 1: resolves a direct path reference containing '/'", async () => {
+    const fs = makeFs({
+      fileExists: jest.fn(async (p: string) => p === "projects/my-project.md"),
+    });
+    expect(
+      await findReferencedFile(fs, "projects/my-project", "tasks/task.md"),
+    ).toBe("projects/my-project.md");
+  });
+
+  it("Try 2: resolves in the same folder as the source file", async () => {
+    const fs = makeFs({
+      fileExists: jest.fn(async (p: string) => p === "tasks/def.md"),
+    });
+    expect(await findReferencedFile(fs, "def", "tasks/task.md")).toBe(
+      "tasks/def.md",
+    );
+  });
+
+  it("Try 2: root-level source resolves without a './' prefix", async () => {
+    const seen: string[] = [];
+    const fs = makeFs({
+      fileExists: jest.fn(async (p: string) => {
+        seen.push(p);
+        return p === "def.md";
+      }),
+    });
+    expect(await findReferencedFile(fs, "def", "task.md")).toBe("def.md");
+    // Behavior-preserving unification: no "./def.md" form is probed.
+    expect(seen).toContain("def.md");
+    expect(seen).not.toContain("./def.md");
+  });
+
+  it("Try 3: resolves by UID lookup", async () => {
+    const fs = makeFs({
+      findFileByUID: jest.fn(async () => "projects/abc123-def456.md"),
+    });
+    expect(await findReferencedFile(fs, "abc123-def456", "tasks/task.md")).toBe(
+      "projects/abc123-def456.md",
+    );
+  });
+
+  it("Try 4: resolves by basename scan across the vault", async () => {
+    const fs = makeFs({
+      getMarkdownFiles: jest.fn(async () => [
+        "projects/my-project.md",
+        "other/some-file.md",
+      ]),
+    });
+    expect(await findReferencedFile(fs, "my-project", "tasks/task.md")).toBe(
+      "projects/my-project.md",
+    );
+  });
+
+  it("returns null when nothing matches", async () => {
+    expect(
+      await findReferencedFile(makeFs(), "ghost", "tasks/task.md"),
+    ).toBeNull();
+  });
+});

--- a/packages/exocortex/src/index.ts
+++ b/packages/exocortex/src/index.ts
@@ -116,6 +116,7 @@ export type {
 } from "./domain/models/WorkflowDefinition";
 export { EffortVotingService } from "./services/EffortVotingService";
 export { FolderRepairService } from "./services/FolderRepairService";
+export { extractAssetReference } from "./utilities/extractAssetReference";
 export { LabelToAliasService } from "./services/LabelToAliasService";
 export { LoggingService } from "./services/LoggingService";
 export { PropertyCleanupService } from "./services/PropertyCleanupService";

--- a/packages/exocortex/src/services/FolderRepairService.ts
+++ b/packages/exocortex/src/services/FolderRepairService.ts
@@ -1,6 +1,7 @@
 import { injectable, inject } from "tsyringe";
 import type { IVaultAdapter, IFile } from "../interfaces/IVaultAdapter";
 import { DI_TOKENS } from "../interfaces/tokens";
+import { extractAssetReference } from "../utilities/extractAssetReference";
 
 /**
  * Service for repairing asset folder locations based on exo__Asset_isDefinedBy references
@@ -38,7 +39,7 @@ export class FolderRepairService {
       return null;
     }
 
-    const reference = this.extractReference(isDefinedBy);
+    const reference = extractAssetReference(isDefinedBy);
     if (!reference) {
       return null;
     }
@@ -81,34 +82,6 @@ export class FolderRepairService {
   private getFileFolder(file: IFile): string {
     const folderPath = file.parent?.path || "";
     return folderPath;
-  }
-
-  /**
-   * Extract reference from various formats:
-   * - [[Reference]] -> Reference
-   * - [[uid|alias]] -> uid (alias suffix stripped — getFirstLinkpathDest rejects pipe-aliased linkpath)
-   * - "[[Reference]]" -> Reference
-   * - Reference -> Reference
-   */
-  private extractReference(value: unknown): string | null {
-    if (typeof value !== "string") {
-      return null;
-    }
-
-    // Remove quotes if present
-    let cleaned = value.trim().replace(/^["']|["']$/g, "");
-
-    // Remove wiki-link brackets if present
-    cleaned = cleaned.replace(/^\[\[|\]\]$/g, "");
-
-    // Strip alias suffix (everything after first `|`) — getFirstLinkpathDest
-    // returns null for pipe-aliased linkpaths, breaking alias-form refs.
-    const pipeIdx = cleaned.indexOf("|");
-    if (pipeIdx !== -1) {
-      cleaned = cleaned.slice(0, pipeIdx).trim();
-    }
-
-    return cleaned || null;
   }
 
   /**

--- a/packages/exocortex/src/utilities/extractAssetReference.ts
+++ b/packages/exocortex/src/utilities/extractAssetReference.ts
@@ -1,0 +1,44 @@
+/**
+ * Extract the bare linkpath reference from a frontmatter property value
+ * (typically `exo__Asset_isDefinedBy`), normalizing the forms that appear in
+ * Exocortex frontmatter:
+ *
+ * - `[[Reference]]`     → `Reference`
+ * - `"[[Reference]]"`   → `Reference` (surrounding YAML quotes stripped)
+ * - `[[uid|alias]]`     → `uid`        (alias suffix dropped)
+ * - `Reference`         → `Reference`
+ *
+ * Returns `null` for non-string input or an empty result.
+ *
+ * The single canonical implementation consumed by `FolderRepairService`
+ * (plugin/grounding path) and the CLI `FolderRepairExecutor` / `BatchExecutor`
+ * (audit #3384 finding H4 — was triplicated byte-for-byte).
+ *
+ * NOTE: intentionally distinct from {@link WikiLinkHelpers.normalize}. For a
+ * UUID-aliased wikilink `[[uuid|ems__Area]]`, `normalize` keeps the *alias*
+ * (`ems__Area`) because its consumers compare against symbolic class names,
+ * whereas `extractAssetReference` keeps the *target* (`uuid`) because its only
+ * consumer feeds the result to `getFirstLinkpathDest`, which resolves the
+ * target linkpath and returns null for the pipe-aliased form. Do not merge the
+ * two.
+ */
+export function extractAssetReference(value: unknown): string | null {
+  if (typeof value !== "string") {
+    return null;
+  }
+
+  // Remove quotes if present
+  let cleaned = value.trim().replace(/^["']|["']$/g, "");
+
+  // Remove wiki-link brackets if present
+  cleaned = cleaned.replace(/^\[\[|\]\]$/g, "");
+
+  // Strip alias suffix (everything after first `|`) — getFirstLinkpathDest
+  // returns null for pipe-aliased linkpaths, breaking alias-form refs.
+  const pipeIdx = cleaned.indexOf("|");
+  if (pipeIdx !== -1) {
+    cleaned = cleaned.slice(0, pipeIdx).trim();
+  }
+
+  return cleaned || null;
+}

--- a/packages/obsidian-plugin/tests/unit/FolderRepairService.test.ts
+++ b/packages/obsidian-plugin/tests/unit/FolderRepairService.test.ts
@@ -228,7 +228,7 @@ describe("FolderRepairService", () => {
     });
   });
 
-  describe("extractReference", () => {
+  describe("getExpectedFolder reference extraction", () => {
     test("should extract reference from [[Name]]", async () => {
       const file = { path: "file.md" } as IFile;
       const metadata = { exo__Asset_isDefinedBy: "[[TestAsset]]" };


### PR DESCRIPTION
## Summary

Audit epic #3384, finding **H4**: folder-repair reference resolution was triplicated and drifting. Two CLI executors (`FolderRepairExecutor`, `BatchExecutor`) forked the core logic, including a **byte-for-byte** copy of `extractReference`. This PR collapses the duplication to a single source. **Pure dedup — no observable behavior change.**

### Changes

- **`extractReference` (3 → 1):** promoted to a single canonical pure function `extractAssetReference`, exported from the `exocortex` core package. Core `FolderRepairService` and both CLI executors now consume it. Removed the two private CLI copies + core's private method.
- **`findReferencedFile` + `normalizePath` (2 → 1 each):** extracted into a new shared CLI module `packages/cli/src/executors/folderRepairHelpers.ts`, consumed by both CLI executors. These stay CLI-side (Node-fs resolution) — they are **not** in core.

### CLI semantics preserved

`FolderRepairExecutor` keeps its `process.exit()` codes + `console.log` UX; `BatchExecutor` keeps its `BatchOperationResult` shaping. Core delegation is limited to the pure `extractAssetReference` helper; the executors still own their exit/IO/result wrapping.

## Findings documented (not silently fixed)

Per scope ("if you find a bug in a copy, document it, don't fix it silently"):

1. **`findReferencedFile` root-file edge divergence.** The two CLI copies differed in one line: `FolderRepairExecutor` used `sourceDir ? ... : ...` (always truthy — `path.dirname` returns `"."` for root, never `""`), producing `"./<ref>.md"`; `BatchExecutor` used `sourceDir !== "." ? ...`, producing `"<ref>.md"`. These are **observably identical**: `NodeFsAdapter.resolvePath` (`path.join`) collapses `./x.md`→`x.md`, and the downstream `path.dirname` collapses both to `.`. Unified to the `BatchExecutor` form. A unit test (`Try 2: root-level source resolves without a './' prefix`) pins this.
2. **Pre-existing resolution divergence (NOT unified).** The CLI direct-command path (`findReferencedFile`, Node-fs 4-step search) differs from the plugin/grounding path (core `FolderRepairService.getExpectedFolder` → `IVaultAdapter.getFirstLinkpathDest`, a 5-step strategy incl. alias/UUID-index/cross-vault). Fully delegating the CLI executors to `getExpectedFolder` would **change** observable CLI behavior, so it is deliberately out of scope for this pure dedup. (The `service_call repair-folder` grounding already routes through core via `createRepairFolderService`.) Candidate follow-up if unification is desired.

## Tests

- **Revert-verify** (`packages/cli/tests/unit/executors/folderRepairHelpers.test.ts`, 16 cases): imports the single sources (`extractAssetReference` from `exocortex` + the shared `folderRepairHelpers` module). **Empirically verified: FAILS pre-fix** (those imports don't resolve — `extractAssetReference` was a private method, `folderRepairHelpers` didn't exist) **and PASSES post-fix** (16/16). Confirmed by moving the shared module away → `Configuration error` suite failure → restore → 16 pass.
- Existing repair-folder suites stay green: core `FolderRepairService.test.ts` (23), plugin `FolderRepairService.test.ts` (16), CLI `FolderRepairExecutor` / `BatchExecutor.repair-folder` / `repairFolder` (53).
- Full CLI suite: **2004 passed / 0 failed** (excl. `sparql-exo003.integration` which fails identically on clean `main` — it spawns an unbuilt local `dist/`).
- `npm run check:types` (CI `typecheck`): clean. Archgate 13/13 + BDD coverage 100% (pre-commit).

> Test mocks: 5 CLI suites mock `exocortex`; those importing the touched executors (`FolderRepairExecutor`, `BatchExecutor`, `CommandExecutor` × 2) gain a faithful `extractAssetReference` stub so the ESM static-import link check passes.

## Test plan

- [x] Core + plugin + CLI repair-folder unit suites green
- [x] Revert-verify: FAILS pre-fix / PASSES post-fix (documented above)
- [x] `check:types` clean; no observable behavior change
- [ ] CI green (14 required checks)