### PR TITLE
fix(assetspace): pull private repos — honour ustar prefix + full-SHA wrapper

### DIFF
--- a/packages/cli/src/services/BootstrapAssetSpaceService.ts
+++ b/packages/cli/src/services/BootstrapAssetSpaceService.ts
@@ -24,7 +24,7 @@ import { mkdirSync, writeFileSync, existsSync, renameSync, rmSync, readFileSync,
 import { mkdtemp } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join, dirname, resolve, sep } from "node:path";
-import { parseTarGzip } from "nanotar";
+import { parseTarballGzip } from "exocortex";
 
 const REPO_URL_REGEX = /^https:\/\/github\.com\/([a-zA-Z0-9_-]+)\/([a-zA-Z0-9_.-]+?)(?:\.git)?$/;
 
@@ -130,7 +130,7 @@ export class BootstrapAssetSpaceService {
       );
     }
     const buffer = new Uint8Array(arrayBuf);
-    const entries = await parseTarGzip(buffer);
+    const entries = await parseTarballGzip(buffer);
     if (entries.length === 0) {
       throw new Error(`pullAssetSpace: empty tarball for ${owner}/${repo}@${ref}`);
     }
@@ -161,8 +161,10 @@ export class BootstrapAssetSpaceService {
       }
     }
 
-    // Extract SHA from wrapper.
-    const shaMatch = wrapper.match(/-([0-9a-f]{7})$/);
+    // Extract SHA from wrapper. Length is auth-dependent: anonymous tarballs
+    // carry a 7-char abbreviated SHA, authenticated ones the full 40-char SHA
+    // (matching only 7 broke private-repo pulls). Accept 7..40 hex.
+    const shaMatch = wrapper.match(/-([0-9a-fA-F]{7,40})$/);
     if (shaMatch === null) {
       throw new Error(
         `pullAssetSpace: cannot extract SHA from wrapper "${wrapper}"`,

--- a/packages/cli/src/services/BootstrapAssetSpaceService.ts
+++ b/packages/cli/src/services/BootstrapAssetSpaceService.ts
@@ -170,7 +170,7 @@ export class BootstrapAssetSpaceService {
         `pullAssetSpace: cannot extract SHA from wrapper "${wrapper}"`,
       );
     }
-    const sha = shaMatch[1];
+    const sha = shaMatch[1].toLowerCase(); // parity with plugin extractShaFromWrapper
 
     // Stage к temp dir, then atomic rename.
     const stagingDir = await mkdtemp(join(tmpdir(), `exo-bootstrap-${owner}-${repo}-`));

--- a/packages/cli/tests/unit/BootstrapAssetSpaceService.test.ts
+++ b/packages/cli/tests/unit/BootstrapAssetSpaceService.test.ts
@@ -69,6 +69,72 @@ function buildLinkTarball(wrapper: string, typeflag: "1" | "2"): Uint8Array {
   return gzipSync(Buffer.concat([header, trailer]));
 }
 
+/**
+ * Hand-craft a USTAR regular-file block whose full path is split across the
+ * `prefix` (offset 345) and `name` (offset 0) fields — the POSIX layout GitHub
+ * uses for paths > 100 bytes. Authenticated tarballs carry the FULL 40-char
+ * commit SHA in the wrapper, pushing a UUID-named file past 100 chars → ustar
+ * split. nanotar 0.3.0 dropped the prefix (Issue #3382); the fix restores it.
+ * `createTar` can't emit prefix-split entries, so we build the raw bytes.
+ */
+function tarFileWithPrefix(prefix: string, name: string, content: string): Buffer {
+  const data = Buffer.from(content, "utf8");
+  const block = Buffer.alloc(512, 0);
+  block.write(name, 0, "utf8"); // name field (≤100)
+  block.write("0000644\0", 100, "ascii"); // mode
+  block.write("0000000\0", 108, "ascii"); // uid
+  block.write("0000000\0", 116, "ascii"); // gid
+  block.write(data.length.toString(8).padStart(11, "0") + "\0", 124, "ascii"); // size
+  block.write("00000000000\0", 136, "ascii"); // mtime
+  block.write("        ", 148, "ascii"); // checksum placeholder
+  block.write("0", 156, "ascii"); // typeflag = regular file
+  block.write("ustar\0", 257, "ascii"); // magic
+  block.write("00", 263, "ascii"); // version
+  if (prefix) block.write(prefix, 345, "utf8"); // ustar prefix field (≤155)
+  let sum = 0;
+  for (let i = 0; i < 512; i++) sum += block[i];
+  block.write(sum.toString(8).padStart(6, "0") + "\0 ", 148, "ascii");
+  const padded = Buffer.alloc(Math.ceil(data.length / 512) * 512, 0);
+  data.copy(padded);
+  return Buffer.concat([block, padded]);
+}
+
+function tarDir(name: string): Buffer {
+  const block = Buffer.alloc(512, 0);
+  block.write(name, 0, "utf8");
+  block.write("0000755\0", 100, "ascii");
+  block.write("00000000000\0", 124, "ascii"); // size = 0
+  block.write("00000000000\0", 136, "ascii");
+  block.write("        ", 148, "ascii");
+  block.write("5", 156, "ascii"); // typeflag = directory
+  block.write("ustar\0", 257, "ascii");
+  block.write("00", 263, "ascii");
+  let sum = 0;
+  for (let i = 0; i < 512; i++) sum += block[i];
+  block.write(sum.toString(8).padStart(6, "0") + "\0 ", 148, "ascii");
+  return block;
+}
+
+/**
+ * Build a gzipped tarball mimicking GitHub's AUTHENTICATED REST tarball: a
+ * full-40-char-SHA wrapper dir + a UUID-named asset whose 100+ char path is
+ * ustar prefix-split. Reproduces the exact Issue #3382 failure shape.
+ */
+function buildAuthGitHubTarball(
+  owner: string,
+  repo: string,
+  sha40: string,
+  uuid: string,
+  content: string,
+): Uint8Array {
+  const wrapper = `${owner}-${repo}-${sha40}`;
+  const dir = tarDir(`${wrapper}/`);
+  const readme = tarFileWithPrefix("", `${wrapper}/README.md`, "# readme"); // 75c → name field
+  const asset = tarFileWithPrefix(wrapper, `${uuid}.md`, content); // prefix=wrapper, name=uuid → split
+  const trailer = Buffer.alloc(1024, 0);
+  return gzipSync(Buffer.concat([dir, readme, asset, trailer]));
+}
+
 function fakeFetch(response: Uint8Array): typeof fetch {
   return (async (_url: string | URL | Request) => {
     return {
@@ -158,6 +224,41 @@ describe("BootstrapAssetSpaceService", () => {
       expect(existsSync(path.join(target, "README.md"))).toBe(true);
       expect(readFileSync(path.join(target, "README.md"), "utf8")).toBe("# exo TBox");
       expect(existsSync(path.join(target, "schema/Asset.md"))).toBe(true);
+    });
+
+    // Issue #3382 e2e: end-to-end CLI pull of an AUTHENTICATED-shape tarball.
+    // The wrapper carries the full 40-char SHA, so the UUID asset's path
+    // exceeds 100 bytes and is ustar prefix-split. Before the fix the parser
+    // dropped the wrapper prefix → "not under wrapper" throw; and the 40-char
+    // SHA failed the 7-char wrapper match. This exercises both fixes through
+    // the real `pullAssetSpace` extract+materialise path.
+    it("materializes a prefix-split UUID asset from a full-40-char-SHA wrapper (#3382)", async () => {
+      const SHA40 = "306f656e6159944a4ae18beeb618d13611826b9b"; // full commit SHA
+      const UUID = "a1b2c3d4-e5f6-7890-abcd-ef0123456789";
+      const tarball = buildAuthGitHubTarball(
+        "kitelev",
+        "exoas-honesttest",
+        SHA40,
+        UUID,
+        "asset body",
+      );
+      const svc = new BootstrapAssetSpaceService({ fetchImpl: fakeFetch(tarball) });
+      const target = path.join(tempBase, "assetspaces", "honesttest");
+
+      const result = await svc.pullAssetSpace(
+        "https://github.com/kitelev/exoas-honesttest",
+        "main",
+        target,
+      );
+
+      // SHA extraction accepts the full 40-char authenticated wrapper.
+      expect(result.sha).toBe(SHA40);
+      expect(result.fileCount).toBe(2);
+      // The prefix-split UUID asset is materialised under the wrapper-stripped
+      // path (its full tarball path was 105 bytes → ustar prefix + name split).
+      expect(existsSync(path.join(target, `${UUID}.md`))).toBe(true);
+      expect(readFileSync(path.join(target, `${UUID}.md`), "utf8")).toBe("asset body");
+      expect(existsSync(path.join(target, "README.md"))).toBe(true);
     });
 
     it("refuses к overwrite non-empty target", async () => {

--- a/packages/exocortex/src/index.ts
+++ b/packages/exocortex/src/index.ts
@@ -533,3 +533,11 @@ export type {
   HardSwitchPlan,
 } from "./services/focus-profile";
 export { ClassHierarchy as TripleClassHierarchy } from "./services/ClassHierarchy";
+
+// USTAR-aware tarball parser (honours the ustar `prefix` field that nanotar
+// 0.3.0 drops — fixes private-repo AssetSpace pulls with full-SHA wrappers).
+export {
+  parseTarball,
+  parseTarballGzip,
+  type TarballEntry,
+} from "./infrastructure/tarball/parseTarball";

--- a/packages/exocortex/src/infrastructure/tarball/parseTarball.ts
+++ b/packages/exocortex/src/infrastructure/tarball/parseTarball.ts
@@ -1,0 +1,256 @@
+/**
+ * USTAR-aware tarball parser.
+ *
+ * ## Why this exists (Issue: private-repo AssetSpace pull broken)
+ *
+ * The previous implementation used `nanotar@0.3.0`'s `parseTarGzip`, which
+ * reads ONLY the 100-byte `name` field of each tar header and never reads the
+ * POSIX ustar `prefix` field (header bytes 345..499). When a tar entry's full
+ * path exceeds 100 bytes, the POSIX ustar format splits it across `prefix`
+ * (directory part) and `name` (file part); the real path is
+ * `prefix + "/" + name`. nanotar drops the `prefix`, yielding only the bare
+ * file name.
+ *
+ * GitHub's REST tarball endpoint wraps every entry under a single
+ * `<owner>-<repo>-<sha>/` directory. For **authenticated** requests the
+ * wrapper carries the FULL 40-char commit SHA, so a UUID-named asset
+ * (`<36-char-uuid>.md`) ends up with a 100+ char path → ustar prefix-split →
+ * nanotar drops the wrapper prefix → the entry looks like it lives outside the
+ * wrapper → `AssetSpaceManager.discoverWrapperDir` throws and the whole pull
+ * fails. (Anonymous requests get a 7-char abbreviated SHA, so the path stays
+ * under 100 bytes and the bug never triggers — which is why public-repo pulls
+ * worked but private ones did not.)
+ *
+ * This parser mirrors nanotar's header walk (so behaviour is identical for the
+ * cases nanotar already handled — PAX `path=` extended headers, GNU long
+ * names, octal sizes, the same type map and `..`/absolute sanitisation) and
+ * adds the one missing step: honour the ustar `prefix` field.
+ *
+ * Storage-agnostic: gunzip uses the web-standard `DecompressionStream`
+ * (available in Electron renderer, Node ≥18, and the Jest/Node test env), so
+ * no Node-only or Obsidian-only imports.
+ */
+
+export interface TarballEntry {
+  /** Full entry path (ustar `prefix` + `name` reconstructed when applicable). */
+  name: string;
+  /** nanotar-compatible type string (`"file"`, `"directory"`, `"symbolicLink"`, …). */
+  type: string;
+  /** Declared entry size in bytes. */
+  size: number;
+  /** File payload (omitted for zero-size entries and directories). */
+  data?: Uint8Array;
+}
+
+// Mirrors nanotar's tarItemTypeMap so downstream `entry.type` checks keep working.
+const TAR_TYPE_MAP: Record<string, string> = {
+  "0": "file",
+  "1": "hardLink",
+  "2": "symbolicLink",
+  "3": "characterDevice",
+  "4": "blockDevice",
+  "5": "directory",
+  "6": "fifo",
+  "7": "contiguousFile",
+  g: "globalExtendedHeader",
+  x: "extendedHeader",
+  D: "gnuDirectory",
+  I: "gnuInodeMetadata",
+  K: "gnuLongLinkName",
+  L: "gnuLongFileName",
+  N: "gnuOldLongFileName",
+  M: "gnuMultiVolume",
+  S: "gnuSparseFile",
+  E: "gnuExtendedSparse",
+};
+
+const HEADER_TYPES = new Set([
+  "extendedHeader",
+  "globalExtendedHeader",
+  "gnuLongFileName",
+  "gnuOldLongFileName",
+  "gnuLongLinkName",
+]);
+
+// Lazy singleton — constructing `TextDecoder` at module load fails in test
+// environments (jsdom) that only expose it at runtime. Matches nanotar's
+// per-call construction but reuses one instance.
+let _decoder: TextDecoder | undefined;
+function getDecoder(): TextDecoder {
+  return (_decoder ??= new TextDecoder());
+}
+
+function readString(bytes: Uint8Array, offset: number, size: number): string {
+  const slice = bytes.subarray(offset, offset + size);
+  const nul = slice.indexOf(0);
+  return getDecoder().decode(nul === -1 ? slice : slice.subarray(0, nul));
+}
+
+// Octal numeric field (POSIX ustar). parseInt stops at the first non-octal
+// byte (trailing NUL / space), matching nanotar's _readNumber semantics.
+function readNumber(bytes: Uint8Array, offset: number, size: number): number {
+  let str = "";
+  for (let i = 0; i < size; i++) {
+    str += String.fromCodePoint(bytes[offset + i]);
+  }
+  const n = Number.parseInt(str, 8);
+  return Number.isNaN(n) ? 0 : n;
+}
+
+// PAX extended-header payload: records like `<len> path=<value>\n`.
+function parseExtendedHeaders(payload: Uint8Array): Record<string, string> {
+  const text = getDecoder().decode(payload);
+  const headers: Record<string, string> = {};
+  for (const line of text.split("\n")) {
+    const eq = line.indexOf("=");
+    if (eq === -1) continue;
+    const key = line.slice(line.indexOf(" ") + 1, eq);
+    const value = line.slice(eq + 1);
+    if (key) headers[key] = value;
+  }
+  return headers;
+}
+
+// Identical to nanotar's _sanitizePath — drops drive letters, leading slashes,
+// resolves `.`/`..` segments. Defence-in-depth; consumers also validate.
+function sanitizePath(path: string): string {
+  let normalized = path.replace(/\\/g, "/");
+  normalized = normalized.replace(/^[a-zA-Z]:\//, "");
+  normalized = normalized.replace(/^\/+/, "");
+  const hasLeadingDotSlash = normalized.startsWith("./");
+  const parts = normalized.split("/");
+  const resolved: string[] = [];
+  for (const part of parts) {
+    if (part === "..") {
+      resolved.pop();
+    } else if (part !== "." && part !== "") {
+      resolved.push(part);
+    }
+  }
+  let result = resolved.join("/");
+  if (hasLeadingDotSlash && !result.startsWith("./")) {
+    result = "./" + result;
+  }
+  if (path.endsWith("/") && !result.endsWith("/")) {
+    result += "/";
+  }
+  return result;
+}
+
+/**
+ * Parse a raw (un-gzipped) tar archive.
+ *
+ * Header types `extendedHeader` / `globalExtendedHeader` / GNU long-name
+ * variants are consumed to override the next entry's path but are NOT emitted
+ * as entries (parity with nanotar).
+ */
+export function parseTarball(input: Uint8Array): TarballEntry[] {
+  // Copy into a fresh, zero-offset array so header offsets are absolute and we
+  // never depend on the caller's byteOffset (nanotar's `data.buffer` shortcut
+  // mis-reads sub-arrays — avoided here).
+  const bytes =
+    input.byteOffset === 0 && input.byteLength === input.buffer.byteLength
+      ? input
+      : input.slice();
+
+  const entries: TarballEntry[] = [];
+  let offset = 0;
+  let nextExtendedHeader: Record<string, string> | undefined;
+  let globalExtendedHeader: Record<string, string> | undefined;
+
+  while (offset + 512 <= bytes.byteLength) {
+    let name = readString(bytes, offset, 100);
+    if (name.length === 0) break; // zero-block terminator
+
+    let nameOverridden = false;
+    if (nextExtendedHeader) {
+      const longName = nextExtendedHeader.path ?? nextExtendedHeader.linkpath;
+      if (longName) {
+        name = longName;
+        nameOverridden = true;
+      }
+    }
+
+    const size = readNumber(bytes, offset + 124, 12);
+    const seek = 512 + 512 * Math.trunc(size / 512) + (size % 512 ? 512 : 0);
+    const typeChar = readString(bytes, offset + 156, 1) || "0";
+    const type = TAR_TYPE_MAP[typeChar] ?? typeChar;
+
+    if (type === "extendedHeader" || type === "globalExtendedHeader") {
+      const headers = parseExtendedHeaders(
+        bytes.subarray(offset + 512, offset + 512 + size),
+      );
+      if (type === "extendedHeader") {
+        nextExtendedHeader = headers;
+      } else {
+        nextExtendedHeader = undefined;
+        globalExtendedHeader = { ...globalExtendedHeader, ...headers };
+      }
+      offset += seek;
+      continue;
+    }
+
+    if (HEADER_TYPES.has(type)) {
+      // GNU long file/link name: payload is the long path for the next entry.
+      nextExtendedHeader = { path: readString(bytes, offset + 512, size) };
+      offset += seek;
+      continue;
+    }
+
+    // ── The fix: honour the ustar `prefix` field ──────────────────────────
+    // Only when the name came from the 100-byte `name` field (no PAX/GNU
+    // override). POSIX ustar splits paths > 100 bytes as prefix + "/" + name.
+    if (!nameOverridden) {
+      const magic = readString(bytes, offset + 257, 6);
+      if (magic.startsWith("ustar")) {
+        const prefix = readString(bytes, offset + 345, 155);
+        if (prefix.length > 0) {
+          name = `${prefix}/${name}`;
+        }
+      }
+    }
+
+    name = sanitizePath(name);
+    const data =
+      size === 0
+        ? undefined
+        : bytes.subarray(offset + 512, offset + 512 + size);
+
+    entries.push({ name, type, size, data });
+    nextExtendedHeader = undefined;
+    offset += seek;
+  }
+
+  // globalExtendedHeader is parsed for parity but not surfaced; reference it so
+  // strict lint/tsc does not flag it as unused.
+  void globalExtendedHeader;
+
+  return entries;
+}
+
+/**
+ * Gunzip + parse a gzipped tar archive (e.g. a GitHub REST tarball response).
+ */
+export async function parseTarballGzip(
+  input: Uint8Array | ArrayBuffer,
+): Promise<TarballEntry[]> {
+  // Normalise to a fresh ArrayBuffer-backed Uint8Array (matches the old
+  // nanotar `new Uint8Array(data)` copy and satisfies `BufferSource`, which
+  // excludes SharedArrayBuffer-backed views).
+  const u8 = new Uint8Array(
+    input instanceof Uint8Array ? input : new Uint8Array(input),
+  );
+  const ds = new DecompressionStream("gzip");
+  // Write to the writable side directly (the `ReadableStream(...).pipeThrough`
+  // form trips TS's `Uint8Array<ArrayBuffer>` vs `<ArrayBufferLike>` variance
+  // check on some lib.dom versions). `Promise.all` drains the read while the
+  // single write runs (no deadlock for our size-capped tarballs) AND ensures
+  // both sides are awaited so a decompression error (corrupt gzip) surfaces as
+  // a rejected promise here rather than an unhandled rejection.
+  const writer = ds.writable.getWriter();
+  const [, decompressed] = await Promise.all([
+    writer.write(u8).then(() => writer.close()),
+    new Response(ds.readable).arrayBuffer(),
+  ]);
+  return parseTarball(new Uint8Array(decompressed));
+}

--- a/packages/exocortex/tests/unit/infrastructure/tarball/parseTarball.test.ts
+++ b/packages/exocortex/tests/unit/infrastructure/tarball/parseTarball.test.ts
@@ -1,0 +1,187 @@
+import { gzipSync } from "node:zlib";
+import {
+  parseTarball,
+  parseTarballGzip,
+  type TarballEntry,
+} from "../../../../src/infrastructure/tarball/parseTarball";
+
+const enc = new TextEncoder();
+const dec = new TextDecoder();
+
+function field(h: Uint8Array, str: string, off: number, len: number): void {
+  h.set(enc.encode(str).subarray(0, len), off);
+}
+
+/**
+ * Build a single 512-byte POSIX ustar header. Only the fields the parser
+ * reads are populated (name, size, type, ustar magic, prefix); the checksum
+ * is intentionally left blank because the parser does not validate it (parity
+ * with nanotar).
+ */
+function ustarHeader(opts: {
+  name: string;
+  prefix?: string;
+  type?: string;
+  size?: number;
+  magic?: string;
+}): Uint8Array {
+  const h = new Uint8Array(512);
+  field(h, opts.name, 0, 100);
+  field(h, (opts.size ?? 0).toString(8).padStart(11, "0"), 124, 11);
+  h[156] = (opts.type ?? "0").charCodeAt(0);
+  field(h, opts.magic ?? "ustar", 257, 5); // "ustar\0"
+  field(h, "00", 263, 2); // version
+  if (opts.prefix) field(h, opts.prefix, 345, 155);
+  return h;
+}
+
+interface FixtureEntry {
+  name: string;
+  prefix?: string;
+  type?: string;
+  data?: Uint8Array;
+  magic?: string;
+  /** Raw 512-byte header override (for PAX/GNU extension blocks). */
+  rawHeader?: Uint8Array;
+  /** Raw payload for the override header (PAX records / GNU long name). */
+  rawPayload?: Uint8Array;
+}
+
+function tarball(entries: FixtureEntry[]): Uint8Array {
+  const blocks: Uint8Array[] = [];
+  const pushPadded = (data: Uint8Array): void => {
+    const padded = new Uint8Array(Math.ceil(data.length / 512) * 512);
+    padded.set(data);
+    blocks.push(padded);
+  };
+  for (const e of entries) {
+    if (e.rawHeader) {
+      blocks.push(e.rawHeader);
+      if (e.rawPayload && e.rawPayload.length > 0) pushPadded(e.rawPayload);
+      continue;
+    }
+    const data = e.data ?? new Uint8Array(0);
+    blocks.push(
+      ustarHeader({
+        name: e.name,
+        prefix: e.prefix,
+        type: e.type,
+        size: data.length,
+        magic: e.magic,
+      }),
+    );
+    if (data.length > 0) pushPadded(data);
+  }
+  blocks.push(new Uint8Array(1024)); // two zero blocks = end-of-archive
+  const total = blocks.reduce((n, b) => n + b.length, 0);
+  const out = new Uint8Array(total);
+  let off = 0;
+  for (const b of blocks) {
+    out.set(b, off);
+    off += b.length;
+  }
+  return out;
+}
+
+/** Build a PAX `x` extended-header block whose payload sets `path=<value>`. */
+function paxPathBlock(value: string): { rawHeader: Uint8Array; rawPayload: Uint8Array } {
+  const content = `path=${value}\n`;
+  // POSIX pax record: "<len> path=value\n" where len counts itself.
+  let len = content.length + 1 + 1; // space + at least 1 digit
+  // eslint-disable-next-line no-constant-condition
+  while (String(len).length + 1 + content.length !== len) {
+    len = String(len).length + 1 + content.length;
+  }
+  const payload = enc.encode(`${len} ${content}`);
+  const header = ustarHeader({ name: "pax_header", type: "x", size: payload.length });
+  return { rawHeader: header, rawPayload: payload };
+}
+
+const byName = (entries: TarballEntry[], name: string): TarballEntry | undefined =>
+  entries.find((e) => e.name === name);
+
+describe("parseTarball — ustar prefix reconstruction", () => {
+  const WRAPPER = "kitelev-exoas-honesttest-306f656e6159944a4ae18beeb618d13611826b9b"; // 65 chars
+  const UUID_FILE = "a1b2c3d4-e5f6-7890-abcd-ef0123456789.md"; // 39 chars
+  const FULL_PATH = `${WRAPPER}/${UUID_FILE}`; // 105 chars → ustar prefix-split
+
+  it("reconstructs a path split across ustar prefix + name (the bug)", () => {
+    // GitHub's authenticated tarball puts the 65-char wrapper into `prefix`
+    // and the 39-char file into `name`. nanotar 0.3.0 dropped the prefix and
+    // yielded the bare file name; the fix prepends the prefix.
+    const raw = tarball([
+      { name: `${WRAPPER}/`, type: "5" },
+      { name: UUID_FILE, prefix: WRAPPER, type: "0", data: enc.encode("# hi") },
+    ]);
+    const entries = parseTarball(raw);
+    expect(entries.map((e) => e.name)).toContain(FULL_PATH);
+    expect(entries.map((e) => e.name)).not.toContain(UUID_FILE);
+    const file = byName(entries, FULL_PATH);
+    expect(file?.type).toBe("file");
+    expect(dec.decode(file?.data)).toBe("# hi");
+  });
+
+  it("REVERT-VERIFY: ignoring the prefix field yields the bare (broken) name", () => {
+    // Mirrors the pre-fix nanotar behaviour to prove the test exercises the
+    // regression: a parser that reads only `name` returns the bare file name,
+    // which then fails any "all entries under wrapper" gate.
+    const raw = tarball([
+      { name: UUID_FILE, prefix: WRAPPER, type: "0", data: enc.encode("x") },
+    ]);
+    const nameOnly = (bytes: Uint8Array): string => {
+      const slice = bytes.subarray(0, 100);
+      const nul = slice.indexOf(0);
+      return dec.decode(nul === -1 ? slice : slice.subarray(0, nul));
+    };
+    expect(nameOnly(raw)).toBe(UUID_FILE); // broken parser result
+    expect(byName(parseTarball(raw), FULL_PATH)).toBeDefined(); // fixed result
+  });
+
+  it("leaves short paths (empty prefix) unchanged — no regression", () => {
+    const shortName = `${WRAPPER}/README.md`; // 75 chars, fits the 100-byte name field
+    const raw = tarball([
+      { name: shortName, type: "0", data: enc.encode("readme") },
+    ]);
+    const entries = parseTarball(raw);
+    expect(byName(entries, shortName)).toBeDefined();
+  });
+
+  it("classifies directory entries", () => {
+    const raw = tarball([{ name: `${WRAPPER}/`, type: "5" }]);
+    expect(parseTarball(raw)[0].type).toBe("directory");
+  });
+
+  it("PAX `path=` extended header takes precedence over the ustar prefix", () => {
+    const pax = paxPathBlock(`${WRAPPER}/pax-name.md`);
+    const raw = tarball([
+      { ...pax, name: "" },
+      // Decoy prefix/name that must be IGNORED in favour of the PAX path.
+      { name: "decoy.md", prefix: "decoy-prefix", type: "0", data: enc.encode("p") },
+    ]);
+    const entries = parseTarball(raw);
+    expect(byName(entries, `${WRAPPER}/pax-name.md`)).toBeDefined();
+    expect(byName(entries, "decoy-prefix/decoy.md")).toBeUndefined();
+  });
+
+  it("reproduces the full GitHub authenticated-tarball shape", () => {
+    const raw = tarball([
+      { name: `${WRAPPER}/`, type: "5" },
+      { name: `${WRAPPER}/README.md`, type: "0", data: enc.encode("readme") },
+      { name: UUID_FILE, prefix: WRAPPER, type: "0", data: enc.encode("asset") },
+    ]);
+    const entries = parseTarball(raw);
+    const files = entries.filter((e) => e.type === "file").map((e) => e.name);
+    // Every file shares the single wrapper prefix → discoverWrapperDir passes.
+    expect(files.every((n) => n.startsWith(`${WRAPPER}/`))).toBe(true);
+    expect(files).toContain(FULL_PATH);
+  });
+
+  it("parseTarballGzip decodes + reconstructs end-to-end", async () => {
+    const raw = tarball([
+      { name: UUID_FILE, prefix: WRAPPER, type: "0", data: enc.encode("gz") },
+    ]);
+    const gz = new Uint8Array(gzipSync(raw));
+    const entries = await parseTarballGzip(gz);
+    expect(byName(entries, FULL_PATH)).toBeDefined();
+  });
+});

--- a/packages/obsidian-plugin/src/infrastructure/adapters/AssetSpaceManager.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/AssetSpaceManager.ts
@@ -607,23 +607,26 @@ export function discoverWrapperDir(entries: ExtractedTarFile[]): string {
 }
 
 /**
- * Extract the 7-character SHA from a GitHub REST tarball wrapper name.
+ * Extract the commit SHA from a GitHub REST tarball wrapper name.
  *
- * GitHub-emitted wrapper names follow the pattern `<owner>-<repo>-<sha7>`
- * where `<sha7>` is the last `-`-delimited segment (always 7 lowercase
- * hex characters). Repo names CAN contain hyphens, so we anchor on the
- * trailing 7-hex-char segment to avoid `<owner>-<repo-with-dash>-<sha7>`
- * ambiguity.
+ * GitHub-emitted wrapper names follow the pattern `<owner>-<repo>-<sha>`
+ * where `<sha>` is the last `-`-delimited segment. **The SHA length depends on
+ * authentication:** ANONYMOUS tarball requests get a 7-char abbreviated SHA,
+ * but AUTHENTICATED requests (private repos, PAT supplied) get the FULL 40-char
+ * SHA. Accepting only 7 chars broke private-repo pulls — the full-SHA wrapper
+ * failed this match and the whole pull threw. Repo names CAN contain hyphens,
+ * so we anchor on the trailing hex segment (7..40 chars) to avoid
+ * `<owner>-<repo-with-dash>-<sha>` ambiguity.
  *
  * Exported for unit testing.
  */
 export function extractShaFromWrapper(wrapper: string): string {
-  // Match the trailing `-<7-hex>` suffix. Hex is case-insensitive in
-  // principle but GitHub emits lowercase; accept both для robustness.
-  const m = wrapper.match(/-([0-9a-fA-F]{7})$/);
+  // Trailing `-<hex>` suffix, 7 (abbreviated) to 40 (full) hex chars. Hex is
+  // case-insensitive in principle but GitHub emits lowercase.
+  const m = wrapper.match(/-([0-9a-fA-F]{7,40})$/);
   if (!m) {
     throw new Error(
-      `extractShaFromWrapper: wrapper "${wrapper}" does not match expected GitHub pattern <owner>-<repo>-<sha7>`,
+      `extractShaFromWrapper: wrapper "${wrapper}" does not match expected GitHub pattern <owner>-<repo>-<sha>`,
     );
   }
   return m[1].toLowerCase();

--- a/packages/obsidian-plugin/src/infrastructure/adapters/TarExtractor.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/TarExtractor.ts
@@ -1,5 +1,5 @@
-import { parseTarGzip } from "nanotar";
-import type { ParsedTarFileItem } from "nanotar";
+import { parseTarballGzip } from "exocortex";
+import type { TarballEntry } from "exocortex";
 
 export interface ExtractedTarFile {
   path: string;
@@ -142,7 +142,7 @@ export class TarExtractor {
     return {
       [Symbol.asyncIterator]:
         async function* (): AsyncIterableIterator<ExtractedTarFile> {
-          const parsed: ParsedTarFileItem[] = await parseTarGzip(blob);
+          const parsed: TarballEntry[] = await parseTarballGzip(blob);
           try {
             for (let i = 0; i < parsed.length; i++) {
               const entry = parsed[i];
@@ -150,7 +150,7 @@ export class TarExtractor {
               validateEntry(entry, prefix);
               // Skip directories — callers materialise dirs via file paths.
               if (entry.type === "directory") {
-                parsed[i] = undefined as unknown as ParsedTarFileItem;
+                parsed[i] = undefined as unknown as TarballEntry;
                 continue;
               }
               const content = entry.data ?? new Uint8Array(0);
@@ -159,7 +159,7 @@ export class TarExtractor {
               // Release the entry reference so the caller-processed Uint8Array
               // becomes GC-eligible (the parsed[] array would otherwise pin it
               // for the lifetime of the iteration).
-              parsed[i] = undefined as unknown as ParsedTarFileItem;
+              parsed[i] = undefined as unknown as TarballEntry;
             }
           } finally {
             // Final cleanup runs even on early-abort (caller breaks out of

--- a/packages/obsidian-plugin/tests/unit/infrastructure/adapters/AssetSpaceManager.pullAssetSpace.test.ts
+++ b/packages/obsidian-plugin/tests/unit/infrastructure/adapters/AssetSpaceManager.pullAssetSpace.test.ts
@@ -580,4 +580,13 @@ describe("extractShaFromWrapper", () => {
       /does not match/,
     );
   });
+
+  it("accepts the full 40-char SHA of an authenticated tarball wrapper (#3382)", () => {
+    // Authenticated GitHub tarballs carry the FULL commit SHA (anonymous ones
+    // are abbreviated to 7). Rejecting it broke private-repo pulls.
+    const sha40 = "306f656e6159944a4ae18beeb618d13611826b9b";
+    expect(extractShaFromWrapper(`kitelev-exoas-honesttest-${sha40}`)).toBe(
+      sha40,
+    );
+  });
 });


### PR DESCRIPTION
## Summary

Add-AssetSpace / Bootstrap pulls of **private** GitHub repos failed silently (no folder materialised, only a Notice toast). Root cause is two stacked bugs, both exposed by the **authenticated** GitHub REST tarball using a **full 40-char commit SHA** in its `<owner>-<repo>-<sha>/` wrapper (anonymous requests get a 7-char abbreviated SHA — which is exactly why **public**-repo pulls worked and private ones did not).

1. **nanotar drops the ustar `prefix` field.** A UUID-named asset (`<36-char-uuid>.md`) under a 65-char wrapper has a 105-char path > 100 bytes → POSIX ustar splits it across the header `prefix` (offset 345) + `name` (offset 0) fields. `nanotar@0.3.0` reads only `name`, yielding a bare filename → `discoverWrapperDir` threw `entry "…" not under wrapper "…"`.
2. **`extractShaFromWrapper` only matched a 7-char SHA**, so the 40-char authenticated wrapper failed even after (1) was fixed.

Empirically confirmed at the byte level against the real GitHub tarball (`name=a1b2c3d4-….md` + `prefix=kitelev-exoas-honesttest-<40-sha>`), and via `auth` vs `anon` download comparison (7-char vs 40-char SHA wrapper).

## Changes

- **New ustar-aware `parseTarball` / `parseTarballGzip`** (`packages/exocortex/src/infrastructure/tarball/`) — mirrors nanotar's header walk (PAX `path=`, GNU long names, octal sizes, type map, `..`/absolute sanitisation) and adds the missing **ustar prefix reconstruction**. Gunzip via web-standard `DecompressionStream` (Electron + Node + browser). Exported from `exocortex`.
- Wired into plugin `TarExtractor` and CLI `BootstrapAssetSpaceService` (both used the buggy nanotar parser; `createTar` still from nanotar).
- `extractShaFromWrapper` (plugin) + CLI SHA match now accept **7..40 hex**.

## Tests

- **Unit (`parseTarball.test.ts`)** — prefix-split reconstruction, PAX precedence, short-path regression guard, directory typing, gzip round-trip, full GitHub-auth-tarball shape.
- **CLI e2e (`BootstrapAssetSpaceService.test.ts`)** — `pullAssetSpace` materialises a prefix-split UUID asset from a **full 40-char-SHA wrapper** end-to-end (mocked fetch, real fs).
- **Plugin** — `extractShaFromWrapper` accepts the 40-char authenticated SHA.
- **Revert-verify** — temporarily disabled the prefix block → 4 parser tests + the CLI e2e failed with the **exact production error** (`entry "a1b2c3d4-….md" not under wrapper "kitelev-exoas-honesttest-306f656e…"`); restored → all green.

## Test plan

- [x] `parseTarball` unit suite (7) green; FAIL pre-fix / PASS post-fix verified
- [x] CLI `BootstrapAssetSpaceService` suite (21, +1 e2e) green
- [x] Plugin `TarExtractor` + `AssetSpaceManager` + `BootstrapAssetSpace` suites (131) green — no regression
- [x] `check:types` clean, lint 0 errors, BDD 100%, archgate 13/13
- [ ] UI smoke (live Obsidian private-repo Add-AssetSpace) — deferred to orchestrator post-merge