### PR TITLE
fix(assetspace): release StagingDirTracker entry after Bootstrap/Add-AssetSpace materialize

### DIFF
--- a/packages/obsidian-plugin/src/infrastructure/adapters/AssetSpaceManager.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/AssetSpaceManager.ts
@@ -382,6 +382,19 @@ export class AssetSpaceManager {
     }
   }
 
+  /**
+   * Release a staging dir previously returned by {@link pullAssetSpace}. The
+   * pull KEEPS the dir on success (caller owns its lifetime — see that method's
+   * docstring), so the Bootstrap / Add-AssetSpace orchestrator calls this after
+   * moving the dir into the vault (Issue #3391) so the tracker entry does not
+   * leak. Delegates to {@link StagingDirTracker.release}, which tolerates an
+   * already-removed dir. No-op when no tracker is wired (the pull path requires
+   * one, so a release without a tracker is a benign mismatch, not an error).
+   */
+  public async releaseStaging(stagingPath: string): Promise<void> {
+    await this.stagingTracker?.release(stagingPath);
+  }
+
   // ─────────────────────────── public — stubs (Phase 2+3) ─────────────────────
 
   /** STUB — destroy deferred to Phase 2 SwitchCacheLayer / Phase 3 hardSwitchProfile. */

--- a/packages/obsidian-plugin/src/infrastructure/adapters/BootstrapAssetSpaceCommands.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/BootstrapAssetSpaceCommands.ts
@@ -359,8 +359,12 @@ export class BootstrapAssetSpaceCommands {
     // `data.local.json` until the next reload. `release()` tolerates a missing
     // dir, so calling it after the move is safe; covers both this single-pull
     // path and the EC2 `fetchTrackedAssetSpaces` loop (which routes through
-    // `materialize` too).
-    await puller.releaseStaging(result.stagingPath);
+    // `materialize` too). Best-effort (`.catch`) — a release failure (e.g. a
+    // `data.local.json` write error) must not skip the `.gitmodules` /
+    // file-only registration below; a leaked tracker entry is benign and
+    // self-heals via `sweepOrphans` on reload. Mirrors `pullAssetSpace`'s own
+    // cleanup convention (`stagingTracker.release(...).catch(() => undefined)`).
+    await puller.releaseStaging(result.stagingPath).catch(() => undefined);
     if (isGit) {
       await this.d.gitOps.appendGitmodulesEntry(submodulePath, url);
     } else {

--- a/packages/obsidian-plugin/src/infrastructure/adapters/BootstrapAssetSpaceCommands.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/BootstrapAssetSpaceCommands.ts
@@ -41,6 +41,15 @@ export interface IAssetSpacePuller {
     asGitUrl: string,
     ref?: string,
   ): Promise<{ asUid: string; stagingPath: string; sha: string }>;
+  /**
+   * Release the staging dir returned by a prior {@link pullAssetSpace}. The
+   * pull deliberately KEEPS the dir on success (caller owns its lifetime — see
+   * `AssetSpaceManager.pullAssetSpace` docstring), so the caller MUST call this
+   * once it has consumed the dir (moved it into the vault). Issue #3391:
+   * without this the StagingDirTracker entry leaks into `data.local.json` until
+   * the next plugin reload. Idempotent / tolerant of an already-moved dir.
+   */
+  releaseStaging(stagingPath: string): Promise<void>;
 }
 
 /** Subset of {@link GitSubmoduleOps} used here (staging move + `.gitmodules`). */
@@ -343,6 +352,15 @@ export class BootstrapAssetSpaceCommands {
       this.ref,
     );
     await this.d.gitOps.renameIntoVault(result.stagingPath, submodulePath);
+    // Issue #3391: `renameIntoVault` MOVED the staging dir into the vault, so
+    // its StagingDirTracker entry now points at a path that no longer exists.
+    // `pullAssetSpace` keeps the dir alive on success by design (caller owns
+    // its lifetime) — release it here so the tracker entry does not linger in
+    // `data.local.json` until the next reload. `release()` tolerates a missing
+    // dir, so calling it after the move is safe; covers both this single-pull
+    // path and the EC2 `fetchTrackedAssetSpaces` loop (which routes through
+    // `materialize` too).
+    await puller.releaseStaging(result.stagingPath);
     if (isGit) {
       await this.d.gitOps.appendGitmodulesEntry(submodulePath, url);
     } else {

--- a/packages/obsidian-plugin/tests/unit/infrastructure/adapters/BootstrapAssetSpaceCommands.test.ts
+++ b/packages/obsidian-plugin/tests/unit/infrastructure/adapters/BootstrapAssetSpaceCommands.test.ts
@@ -18,6 +18,13 @@ interface Harness {
   notices: string[];
   vaultFiles: Set<string>;
   vaultFolders: Map<string, { files: string[]; folders: string[] }>;
+  /**
+   * Mirrors `data.local.json._activeStagingDirs`: `pullAssetSpace` pushes a
+   * staging path (like `StagingDirTracker.allocate`) and `releaseStaging`
+   * removes it (like `StagingDirTracker.release`). Issue #3391 asserts this is
+   * empty after a successful materialise WITHOUT a reload.
+   */
+  activeStagingDirs: string[];
   deps: BootstrapAssetSpaceCommandsDeps;
 }
 
@@ -33,14 +40,22 @@ function makeHarness(opts: {
   const gitmodulesEntries = opts.gitmodulesEntries ?? [];
   const materialized = opts.materializedFolders ?? {};
 
+  // Mirror the real StagingDirTracker contract: allocate registers a staging
+  // path, release removes it. The fake puller wires `pullAssetSpace` →
+  // allocate and `releaseStaging` → release so we can assert no leak (#3391).
+  const activeStagingDirs: string[] = [];
   const puller = {
     pullAssetSpace: jest.fn(
-      async (asUid: string, _url: string, _ref?: string) => ({
-        asUid,
-        stagingPath: `/tmp/staging-${asUid}`,
-        sha: "abc1234",
-      }),
+      async (asUid: string, _url: string, _ref?: string) => {
+        const stagingPath = `/tmp/staging-${asUid}`;
+        activeStagingDirs.push(stagingPath);
+        return { asUid, stagingPath, sha: "abc1234" };
+      },
     ),
+    releaseStaging: jest.fn(async (stagingPath: string) => {
+      const i = activeStagingDirs.indexOf(stagingPath);
+      if (i !== -1) activeStagingDirs.splice(i, 1);
+    }),
   } as jest.Mocked<IAssetSpacePuller>;
 
   const gitOps = {
@@ -115,6 +130,7 @@ function makeHarness(opts: {
     notices,
     vaultFiles: new Set<string>(),
     vaultFolders,
+    activeStagingDirs,
     deps,
   };
 }
@@ -373,6 +389,7 @@ describe("BootstrapAssetSpaceCommands — lazy per-invocation puller (Issue #338
             return { asUid, stagingPath: `/tmp/staging-${asUid}`, sha: "abc1234" };
           },
         ),
+        releaseStaging: jest.fn(async () => undefined),
       };
     });
 
@@ -426,5 +443,73 @@ describe("BootstrapAssetSpaceCommands — lazy per-invocation puller (Issue #338
     const h = makeLazyHarness();
     // Merely constructing the commands must not read the PAT / build a client.
     expect(h.getPuller).not.toHaveBeenCalled();
+  });
+});
+
+describe("BootstrapAssetSpaceCommands — staging-dir release (Issue #3391)", () => {
+  /**
+   * `pullAssetSpace` registers the staging dir (mirrors
+   * `StagingDirTracker.allocate` → `_activeStagingDirs`); `materialize` must
+   * call `releaseStaging` after the move so the entry does not linger until the
+   * next plugin reload.
+   *
+   * Revert-verify: deleting the `await puller.releaseStaging(...)` line in
+   * `BootstrapAssetSpaceCommands.materialize` makes every assertion below FAIL
+   * (`activeStagingDirs` keeps the 1–2 entries the pulls registered);
+   * restoring it makes them PASS.
+   */
+  it("bootstrap (git) — releases both staging dirs, no leftover entry", async () => {
+    const h = makeHarness({ isGitVault: true });
+    await h.cmds.invokeBootstrap();
+
+    expect(h.puller.pullAssetSpace).toHaveBeenCalledTimes(2);
+    // Released for each pulled staging path, after the move into the vault.
+    expect(h.puller.releaseStaging).toHaveBeenCalledTimes(2);
+    expect(h.puller.releaseStaging).toHaveBeenCalledWith(
+      "/tmp/staging-bootstrap-exo",
+    );
+    expect(h.puller.releaseStaging).toHaveBeenCalledWith(
+      "/tmp/staging-bootstrap-exocmd",
+    );
+    // The tracker registry is empty post-success — no reload needed.
+    expect(h.activeStagingDirs).toEqual([]);
+  });
+
+  it("bootstrap (file-only / non-git) — releases staging dirs too", async () => {
+    const h = makeHarness({ isGitVault: false });
+    await h.cmds.invokeBootstrap();
+
+    expect(h.puller.pullAssetSpace).toHaveBeenCalledTimes(2);
+    expect(h.puller.releaseStaging).toHaveBeenCalledTimes(2);
+    expect(h.activeStagingDirs).toEqual([]);
+  });
+
+  it("addAssetSpace — releases the single staging dir, no leftover entry", async () => {
+    const h = makeHarness({ isGitVault: true });
+    await h.cmds.invokeAddAssetSpace();
+
+    expect(h.puller.pullAssetSpace).toHaveBeenCalledTimes(1);
+    expect(h.puller.releaseStaging).toHaveBeenCalledTimes(1);
+    expect(h.puller.releaseStaging).toHaveBeenCalledWith(
+      "/tmp/staging-bootstrap-pmbok-ontology",
+    );
+    expect(h.activeStagingDirs).toEqual([]);
+  });
+
+  it("EC2 fetchTrackedAssetSpaces — releases each re-materialised staging dir", async () => {
+    const h = makeHarness({
+      gitmodulesEntries: [
+        { submodulePath: "assetspaces/exo", url: EXO_URL },
+        { submodulePath: "assetspaces/exocmd", url: EXOCMD_URL },
+      ],
+      materializedFolders: {},
+      confirm: true,
+    });
+    await h.cmds.invokeBootstrap();
+
+    expect(h.puller.pullAssetSpace).toHaveBeenCalledTimes(2);
+    expect(h.puller.releaseStaging).toHaveBeenCalledTimes(2);
+    expect(h.activeStagingDirs).toEqual([]);
+    expect(h.notices.some((n) => /Fetched 2\/2/.test(n))).toBe(true);
   });
 });

--- a/packages/obsidian-plugin/tests/unit/integration/BootstrapAssetSpace.integration.test.ts
+++ b/packages/obsidian-plugin/tests/unit/integration/BootstrapAssetSpace.integration.test.ts
@@ -16,7 +16,12 @@ import * as path from "node:path";
 import * as os from "node:os";
 /* eslint-enable no-restricted-imports, import/no-nodejs-modules */
 
+import type { App } from "obsidian";
+
 import { GitSubmoduleOps } from "../../../src/infrastructure/adapters/GitSubmoduleOps";
+import { AssetSpaceManager } from "../../../src/infrastructure/adapters/AssetSpaceManager";
+import { StagingDirTracker } from "../../../src/infrastructure/adapters/StagingDirTracker";
+import { PluginLocalDataStore } from "../../../src/infrastructure/adapters/PluginLocalDataStore";
 import {
   BootstrapAssetSpaceCommands,
   type IAssetSpacePuller,
@@ -47,6 +52,12 @@ function makeFakePuller(): IAssetSpacePuller {
         "utf8",
       );
       return { asUid, stagingPath: staging, sha: "deadbee" };
+    },
+    // Mirrors StagingDirTracker.release — tolerant best-effort removal.
+    releaseStaging: async (stagingPath: string) => {
+      await fs
+        .rm(stagingPath, { recursive: true, force: true })
+        .catch(() => undefined);
     },
   };
 }
@@ -239,5 +250,170 @@ describe("GitSubmoduleOps.appendGitmodulesEntry — real fs", () => {
     await expect(
       gitOps.appendGitmodulesEntry("assetspaces/x", "https://evil.com/a/b"),
     ).rejects.toThrow();
+  });
+});
+
+/**
+ * Fake App backed by real Node `fs` so PluginLocalDataStore actually persists
+ * `_activeStagingDirs` to disk (mirrors `AssetSpaceManager.pullAssetSpace.test`
+ * harness). Anchored under `diskRoot/` for test isolation.
+ */
+function makeFakeApp(diskRoot: string): App {
+  const resolve = (p: string) => path.join(diskRoot, p);
+  return {
+    vault: {
+      getMarkdownFiles: () => [],
+      adapter: {
+        read: async (p: string) => fs.readFile(resolve(p), "utf8"),
+        exists: async (p: string) =>
+          fs
+            .access(resolve(p))
+            .then(() => true)
+            .catch(() => false),
+        write: async (p: string, content: string) => {
+          const abs = resolve(p);
+          await fs.mkdir(path.dirname(abs), { recursive: true });
+          await fs.writeFile(abs, content);
+        },
+      },
+      configDir: ".obsidian",
+    },
+    metadataCache: { getFileCache: () => null },
+  } as unknown as App;
+}
+
+/**
+ * Issue #3391 — end-to-end proof that a successful materialise leaves NO
+ * leftover `_activeStagingDirs` entry WITHOUT a plugin reload.
+ *
+ * Maximally production-shape: a REAL {@link StagingDirTracker} (backed by a
+ * REAL {@link PluginLocalDataStore} on a tmpdir-backed fake App) wired into a
+ * REAL {@link AssetSpaceManager}. Only the network/extract step of
+ * `pullAssetSpace` is faked — and even that fake calls the REAL
+ * `tracker.allocate` so `_activeStagingDirs` is populated exactly like
+ * production. `releaseStaging` is the REAL `AssetSpaceManager.releaseStaging`
+ * delegate → REAL `StagingDirTracker.release`. The staging→vault move
+ * (`renameIntoVault`) is the REAL `GitSubmoduleOps` against a real tmpdir vault.
+ *
+ * Revert-verify: deleting `await puller.releaseStaging(...)` from
+ * `BootstrapAssetSpaceCommands.materialize` makes both assertions below FAIL
+ * (`readActiveStagingDirs()` returns the 1–2 entries `allocate` registered);
+ * restoring the line makes them PASS.
+ */
+describe("Bootstrap integration — staging-dir release (Issue #3391, real tracker)", () => {
+  let tmpdirBase: string;
+  let vaultRoot: string;
+  afterEach(async () => {
+    if (tmpdirBase)
+      await fs.rm(tmpdirBase, { recursive: true, force: true }).catch(() => {});
+    if (vaultRoot)
+      await fs.rm(vaultRoot, { recursive: true, force: true }).catch(() => {});
+  });
+
+  async function makeRealTrackerHarness(): Promise<{
+    store: PluginLocalDataStore;
+    mgr: AssetSpaceManager;
+  }> {
+    tmpdirBase = await fs.mkdtemp(path.join(os.tmpdir(), "exo-3391-base-"));
+    const diskRoot = path.join(tmpdirBase, "ldstore");
+    await fs.mkdir(diskRoot, { recursive: true });
+    const app = makeFakeApp(diskRoot);
+    const store = new PluginLocalDataStore({ app, path: "data.local.json" });
+    await store.init();
+    const tracker = new StagingDirTracker({ localDataStore: store, tmpdirBase });
+    const mgr = new AssetSpaceManager({
+      app,
+      // Unused: pullAssetSpace is mocked below to skip the GitHub REST path.
+      client: {} as never,
+      notifications: {
+        info: () => undefined,
+        success: () => undefined,
+        error: () => undefined,
+        warn: () => undefined,
+        confirm: async () => true,
+      } as never,
+      stagingTracker: tracker,
+    });
+    // Fake ONLY the network/extract: allocate a REAL staging dir (registers in
+    // `_activeStagingDirs` exactly like production) + drop a fake AssetSpace
+    // file. releaseStaging stays the REAL delegate to tracker.release.
+    jest
+      .spyOn(mgr, "pullAssetSpace")
+      .mockImplementation(async (asUid: string) => {
+        const staging = await tracker.allocate(asUid);
+        await fs.writeFile(
+          path.join(staging, "73bd00e4-ccc0-4f3f-b20d-c4388c4588fb.md"),
+          "---\nexo__Asset_uid: 73bd00e4\n---\n",
+          "utf8",
+        );
+        return { asUid, stagingPath: staging, sha: "deadbee" };
+      });
+    return { store, mgr };
+  }
+
+  it("empty vault → bootstrap → _activeStagingDirs is empty (no reload)", async () => {
+    vaultRoot = await makeTmpVault();
+    const { store, mgr } = await makeRealTrackerHarness();
+    const gitOps = new GitSubmoduleOps({ vaultRootPath: vaultRoot });
+    const probes = makeVaultProbes(vaultRoot);
+    const { store: fileStore } = makeFakeLocalStore();
+
+    const cmds = new BootstrapAssetSpaceCommands({
+      getPuller: async () => mgr,
+      gitOps,
+      localStore: fileStore,
+      vaultExists: probes.vaultExists,
+      listFolder: probes.listFolder,
+      isGitVault: async () => true,
+      validateUrl: () => undefined,
+      deriveFolderName: (u) => u.split("/").pop() ?? "x",
+      promptBootstrapUrls: async () => ({ exoUrl: EXO_URL, exocmdUrl: EXOCMD_URL }),
+      promptAddAssetSpaceUrl: async () => null,
+      confirm: async () => true,
+      notify: () => undefined,
+    });
+
+    await cmds.invokeBootstrap();
+
+    // Both pulled, both moved into the vault, both staging entries released.
+    expect((mgr.pullAssetSpace as jest.Mock).mock.calls).toHaveLength(2);
+    await expect(fs.access(
+      path.join(vaultRoot, "assetspaces/exo/73bd00e4-ccc0-4f3f-b20d-c4388c4588fb.md"),
+    )).resolves.toBeUndefined();
+    // The crux of #3391: registry empty WITHOUT a reload / sweepOrphans.
+    expect(await store.readActiveStagingDirs()).toEqual([]);
+  });
+
+  it("EC2 clone-needs-fetch → fetchTrackedAssetSpaces → _activeStagingDirs empty", async () => {
+    vaultRoot = await makeTmpVault();
+    // Seed .gitmodules with two tracked entries; folders stay empty so
+    // detectVaultState → clone-needs-fetch → fetchTrackedAssetSpaces.
+    const gitOps = new GitSubmoduleOps({ vaultRootPath: vaultRoot });
+    await gitOps.appendGitmodulesEntry("assetspaces/exo", EXO_URL);
+    await gitOps.appendGitmodulesEntry("assetspaces/exocmd", EXOCMD_URL);
+
+    const { store, mgr } = await makeRealTrackerHarness();
+    const probes = makeVaultProbes(vaultRoot);
+    const { store: fileStore } = makeFakeLocalStore();
+
+    const cmds = new BootstrapAssetSpaceCommands({
+      getPuller: async () => mgr,
+      gitOps,
+      localStore: fileStore,
+      vaultExists: probes.vaultExists,
+      listFolder: probes.listFolder,
+      isGitVault: async () => true,
+      validateUrl: () => undefined,
+      deriveFolderName: (u) => u.split("/").pop() ?? "x",
+      promptBootstrapUrls: async () => null,
+      promptAddAssetSpaceUrl: async () => null,
+      confirm: async () => true,
+      notify: () => undefined,
+    });
+
+    await cmds.invokeBootstrap();
+
+    expect((mgr.pullAssetSpace as jest.Mock).mock.calls).toHaveLength(2);
+    expect(await store.readActiveStagingDirs()).toEqual([]);
   });
 });


### PR DESCRIPTION
Closes #3391

## Problem

After a successful "Add AssetSpace by URL" / "Bootstrap vault" pull, `BootstrapAssetSpaceCommands.materialize` moved the staging dir into the vault via `renameIntoVault` but **never released** its `StagingDirTracker` entry. The result: an orphan record in `data.local.json` `_activeStagingDirs` pointing at a now-moved (nonexistent) temp dir, accumulating across operations within a session, only cleaned on the next plugin reload (`sweepOrphans`). Self-healing, no data loss — hygiene/cosmetic only (P3).

## Root cause

- `AssetSpaceManager.pullAssetSpace` registers the staging dir via `stagingTracker.allocate` and, **by design**, KEEPS it on success — the caller owns its lifetime (per the method's docstring) and releases only on the error path.
- `materialize` (the caller) called `renameIntoVault` but never released the staging entry. Same gap in the EC2 `fetchTrackedAssetSpaces` loop (routes through `materialize`).

## Fix — variant (a), clean interface contract

- Add `releaseStaging(stagingPath): Promise<void>` to `IAssetSpacePuller`, implemented on `AssetSpaceManager` as a thin delegate to `stagingTracker.release` (tolerant of an absent tracker / already-moved dir).
- Call `await puller.releaseStaging(result.stagingPath)` in `materialize` **right after** `renameIntoVault` succeeds. One callsite covers **both** the single-pull path (Bootstrap / Add-AssetSpace) **and** the EC2 `fetchTrackedAssetSpaces` loop.
- `pullAssetSpace`'s success path is **unchanged** — it still does NOT release (caller owns lifetime, by-design). Release added at the CALLER only.

## Tests (production-shape + revert-verify)

- **Unit** (`BootstrapAssetSpaceCommands.test.ts`): the fake puller now mirrors the real `StagingDirTracker` contract — `pullAssetSpace` registers a staging path (like `allocate`), `releaseStaging` removes it (like `release`). New `Issue #3391` describe asserts `releaseStaging` is called per pull and `_activeStagingDirs` is empty post-success for bootstrap (git + file-only), addAssetSpace, and the EC2 loop.
- **Integration** (`BootstrapAssetSpace.integration.test.ts`): maximally production-shape — a **REAL** `StagingDirTracker` backed by a **REAL** `PluginLocalDataStore` (tmpdir-backed fake App) wired into a **REAL** `AssetSpaceManager`. Only the GitHub REST/extract step of `pullAssetSpace` is faked, and even that calls the **real** `tracker.allocate`; `releaseStaging` is the real delegate → real `tracker.release`; the staging→vault move is the real `GitSubmoduleOps.renameIntoVault`. Asserts `store.readActiveStagingDirs()` is `[]` after a successful materialise WITHOUT a reload, for both the empty-vault bootstrap and the EC2 clone-needs-fetch path.

**Empirically verified** (revert→fail / restore→pass): commenting out `await puller.releaseStaging(...)` in `materialize` makes all 6 #3391 tests FAIL (releaseStaging not called / `_activeStagingDirs` retains 1–2 entries); restoring it makes them PASS.

## Local verification

- Affected suites green: `BootstrapAssetSpace AssetSpaceManager TarExtractor` → 137/137 (was 131; +6 new).
- `npm run check:types` clean.
- `npm run lint` (src) → 0 errors (2 pre-existing warnings in unrelated files).

## Acceptance criteria

- [x] After a successful Add-AssetSpace / Bootstrap materialize, `_activeStagingDirs` has no leftover entry (no reload required)
- [x] Covers both single-pull `materialize()` and EC2 `fetchTrackedAssetSpaces()`
- [x] Unit test on `materialize` asserting tracker empty post-success
- [x] EC2 loop path covered by a test
- [x] `pullAssetSpace` success path still does NOT release (by-design preserved)

## Notes

- `advisor` tool is unavailable in this environment — skipped per turnkey prompt; code-reviewer agent round will run before merge.