### PR TITLE
refactor(grounding): extract frontmatter→GroundingDefinition mapping into core (#3384 H5)

### DIFF
--- a/packages/cli/specs/step_definitions/grounding.steps.ts
+++ b/packages/cli/specs/step_definitions/grounding.steps.ts
@@ -17,7 +17,7 @@ import {
   GroundingExecutor,
   ServiceRegistry,
   GroundingType,
-  resolveGroundingTypeFromWikilinkLiteral,
+  parseGroundingDefinitionFromFrontmatter,
   type GroundingDefinition,
   ArchiveAssetService,
   FixMissingLabelService,
@@ -107,13 +107,14 @@ function parseFrontmatter(text: string): Record<string, unknown> {
   }
 }
 
-function normalizeWikilink(value: unknown): string {
-  if (typeof value !== "string") return "";
-  const stripped = value.replace(/["'[\]]/g, "").trim();
-  const pipe = stripped.indexOf("|");
-  return pipe >= 0 ? stripped.slice(0, pipe).trim() : stripped;
-}
-
+// Thin fs-wrapper: index lookup + read + frontmatter parse + recursion-depth
+// guard. The pure `Record → GroundingDefinition` field-mapping (type resolve,
+// service_call serviceId fallback, incrementBy parse, targetValueRef unwrap,
+// full key mapping) lives in core `parseGroundingDefinitionFromFrontmatter`
+// (audit epic #3384 H5) — single source of the raw-frontmatter contract,
+// removing the previously-duplicated per-key mapping that had to be manually
+// re-synced on every RFC migration. Composite sub-steps recurse back through
+// this wrapper so fs / depth-guard stay here.
 function readGroundingDef(uid: string, depth = 0): GroundingDefinition {
   if (depth > 20) {
     throw new Error(`Composite recursion depth exceeded resolving ${uid}`);
@@ -121,66 +122,9 @@ function readGroundingDef(uid: string, depth = 0): GroundingDefinition {
   const path = UID_INDEX.get(uid);
   if (!path) throw new Error(`Grounding ${uid} not found in fixture vault`);
   const fm = parseFrontmatter(readFileSync(path, "utf8"));
-  // RFC 9d20c91f Phase 4+1: wikilink-only. The env-flag escape hatch was
-  // removed (Phase 4 introduced; Phase 4+1 retires). Legacy literal-form
-  // throws — fixtures surface as test failure rather than silent acceptance.
-  const rawType = fm["exocmd__Grounding_type"];
-  const type = (() => {
-    if (typeof rawType !== "string") return rawType as GroundingType;
-    const resolved = resolveGroundingTypeFromWikilinkLiteral(rawType);
-    if (resolved !== null) return resolved;
-    throw new Error(
-      `[exocmd-grounding-type-literal-form] legacy literal-string '${rawType}' for exocmd__Grounding_type in fixture ${uid}. Migrate to wikilink form per RFC 9d20c91f Phase 3.`,
-    );
-  })();
-  const targetProperty =
-    type === "service_call"
-      ? (fm["exocmd__Grounding_serviceId"] as string | undefined) ??
-        (fm["exocmd__Grounding_targetProperty"] as string | undefined)
-      : (fm["exocmd__Grounding_targetProperty"] as string | undefined);
-  let steps: GroundingDefinition[] | undefined;
-  if (type === "composite") {
-    const rawSteps = fm["exocmd__Grounding_steps"];
-    if (Array.isArray(rawSteps)) {
-      steps = rawSteps.map((ref) => readGroundingDef(normalizeWikilink(ref), depth + 1));
-    }
-  }
-  const incrementByRaw = fm["exocmd__Grounding_incrementBy"];
-  let incrementBy: number | undefined;
-  if (incrementByRaw !== undefined && incrementByRaw !== null && incrementByRaw !== "") {
-    const parsed = Number.parseInt(String(incrementByRaw), 10);
-    if (Number.isFinite(parsed)) incrementBy = parsed;
-  }
-  // RFC v2 Phase 5 (#3167): legacy JSON-literal `exocmd__Grounding_propertyDefaults`
-  // (plural) parser removed. Ref-form `_propertyDefault` is read by the real
-  // CommandResolver at runtime; CLI BDD fixtures only need the parser-stripped
-  // GroundingDefinition shape.
-  // RFC 31c1a0be Phase 5a — typed predicates required for property_set.
-  // targetValueRef stored as wikilink-form `"[[uuid]]"` in frontmatter;
-  // unwrap to bare UID so executor re-wraps for emission.
-  const rawTargetValueRef = fm["exocmd__Grounding_targetValueRef"] as string | undefined;
-  const targetValueRef = rawTargetValueRef ? normalizeWikilink(rawTargetValueRef) : undefined;
-  return {
-    id: uid,
-    label: (fm["exo__Asset_label"] as string) ?? "",
-    type,
-    targetProperty,
-    // RFC 918a2b65 Phase 4 (#3243): legacy `Grounding_targetValue` removed from
-    // GroundingDefinition. Replaced by `serviceCallPayload` for service_call +
-    // `appendExpression` for property_append.
-    targetValueRef,
-    targetValueLiteral: fm["exocmd__Grounding_targetValueLiteral"] as string | undefined,
-    targetValueSubstitution: fm["exocmd__Grounding_targetValueSubstitution"] as string | undefined,
-    serviceCallPayload: fm["exocmd__Grounding_serviceCallPayload"] as string | undefined,
-    appendExpression: fm["exocmd__Grounding_appendExpression"] as string | undefined,
-    targetClass: fm["exocmd__Grounding_targetClass"] as string | undefined,
-    targetPrototype: fm["exocmd__Grounding_targetPrototype"] as string | undefined,
-    targetFolder: fm["exocmd__Grounding_targetFolder"] as string | undefined,
-    shiftDelta: fm["exocmd__Grounding_shiftDelta"] as string | undefined,
-    incrementBy,
-    linkBackProperty: fm["exocmd__Grounding_linkBackProperty"] as string | undefined,
-    steps,
-  };
+  return parseGroundingDefinitionFromFrontmatter(uid, fm, (stepUid) =>
+    readGroundingDef(stepUid, depth + 1),
+  );
 }
 
 interface ExpectedFixture {

--- a/packages/exocortex/src/domain/models/GroundingFrontmatterParser.ts
+++ b/packages/exocortex/src/domain/models/GroundingFrontmatterParser.ts
@@ -1,0 +1,138 @@
+import { GroundingType } from "../constants/GroundingType";
+import { resolveGroundingTypeFromWikilinkLiteral } from "../constants/GroundingTypeUIDs";
+import type { GroundingDefinition } from "./CommandDefinition";
+
+/**
+ * Normalize a raw `exocmd__Grounding_*` wikilink/ref value to the bare
+ * identifier used to look the referenced asset up by UID.
+ *
+ * Strips surrounding quote + bracket characters, trims, and keeps the portion
+ * BEFORE any `|` alias separator (i.e. the wikilink target). Non-string input
+ * yields `""`.
+ *
+ * ⚠️ Intentionally NOT `WikiLinkHelpers.normalize`. Two behaviours diverge:
+ *   1. For UUID-alias form `"[[<uuid>|<alias>]]"`, `WikiLinkHelpers.normalize`
+ *      returns the ALIAS (the uuid is treated as an opaque pointer), whereas
+ *      grounding refs need the TARGET uuid to resolve the step / value asset
+ *      by UID — so this helper returns the part before `|`.
+ *   2. This helper also strips surrounding quote chars (`"` / `'`), which
+ *      `WikiLinkHelpers.normalize` does not.
+ * Sharing the helper would silently change grounding-parsing behaviour, so the
+ * grounding-specific normalization is kept local and identical to the form the
+ * CLI BDD parser relied on.
+ */
+function normalizeGroundingRef(value: unknown): string {
+  if (typeof value !== "string") return "";
+  const stripped = value.replace(/["'[\]]/g, "").trim();
+  const pipe = stripped.indexOf("|");
+  return pipe >= 0 ? stripped.slice(0, pipe).trim() : stripped;
+}
+
+/**
+ * Map a raw `exocmd__Grounding` frontmatter record (read directly via
+ * `parseFrontmatter` / `getFileCache(file).frontmatter`, NOT through the triple
+ * store) to a {@link GroundingDefinition}.
+ *
+ * This is the canonical, pure field-mapping for the **raw-frontmatter** path.
+ * It is deliberately separate from `CommandResolver`, which builds a
+ * `GroundingDefinition` from the **triple store** (async, RDF graph) — a
+ * different mechanism. This function owns only the synchronous
+ * `Record<string, unknown> → GroundingDefinition` contract used by CLI / BDD
+ * parsers that bypass the triple store, eliminating the previously-duplicated
+ * ~16-key mapping that had to be manually re-synced on every RFC migration.
+ *
+ * Composite sub-step resolution is delegated to the caller via {@link resolveStep}
+ * (which receives an already-normalized step UID); all filesystem / index
+ * lookup and recursion-depth guarding stay in the caller.
+ *
+ * Mapping nuances preserved verbatim:
+ * - `type` resolves via {@link resolveGroundingTypeFromWikilinkLiteral}; a
+ *   non-string value passes through untouched; a legacy literal-string form
+ *   throws (RFC 9d20c91f Phase 4 — wikilink-only).
+ * - For `service_call`, `targetProperty` reads `exocmd__Grounding_serviceId`
+ *   first, falling back to `exocmd__Grounding_targetProperty`.
+ * - `incrementBy` is `parseInt`-ed (finite-guarded; blank/null/undefined skip).
+ * - `targetValueRef` is unwrapped via {@link normalizeGroundingRef}.
+ *
+ * @param uid asset UID of the grounding (becomes `id`).
+ * @param fm raw frontmatter record.
+ * @param resolveStep resolves a composite sub-step from its normalized UID.
+ */
+export function parseGroundingDefinitionFromFrontmatter(
+  uid: string,
+  fm: Record<string, unknown>,
+  resolveStep: (stepUid: string) => GroundingDefinition,
+): GroundingDefinition {
+  const rawType = fm["exocmd__Grounding_type"];
+  const type = ((): GroundingType => {
+    if (typeof rawType !== "string") return rawType as GroundingType;
+    const resolved = resolveGroundingTypeFromWikilinkLiteral(rawType);
+    if (resolved !== null) return resolved;
+    throw new Error(
+      `[exocmd-grounding-type-literal-form] legacy literal-string '${rawType}' for exocmd__Grounding_type in fixture ${uid}. Migrate to wikilink form per RFC 9d20c91f Phase 3.`,
+    );
+  })();
+
+  const targetProperty =
+    type === "service_call"
+      ? (fm["exocmd__Grounding_serviceId"] as string | undefined) ??
+        (fm["exocmd__Grounding_targetProperty"] as string | undefined)
+      : (fm["exocmd__Grounding_targetProperty"] as string | undefined);
+
+  let steps: GroundingDefinition[] | undefined;
+  if (type === "composite") {
+    const rawSteps = fm["exocmd__Grounding_steps"];
+    if (Array.isArray(rawSteps)) {
+      steps = rawSteps.map((ref) => resolveStep(normalizeGroundingRef(ref)));
+    }
+  }
+
+  const incrementByRaw = fm["exocmd__Grounding_incrementBy"];
+  let incrementBy: number | undefined;
+  if (
+    incrementByRaw !== undefined &&
+    incrementByRaw !== null &&
+    incrementByRaw !== ""
+  ) {
+    const parsed = Number.parseInt(String(incrementByRaw), 10);
+    if (Number.isFinite(parsed)) incrementBy = parsed;
+  }
+
+  const rawTargetValueRef = fm["exocmd__Grounding_targetValueRef"] as
+    | string
+    | undefined;
+  const targetValueRef = rawTargetValueRef
+    ? normalizeGroundingRef(rawTargetValueRef)
+    : undefined;
+
+  return {
+    id: uid,
+    label: (fm["exo__Asset_label"] as string) ?? "",
+    type,
+    targetProperty,
+    targetValueRef,
+    targetValueLiteral: fm["exocmd__Grounding_targetValueLiteral"] as
+      | string
+      | undefined,
+    targetValueSubstitution: fm["exocmd__Grounding_targetValueSubstitution"] as
+      | string
+      | undefined,
+    serviceCallPayload: fm["exocmd__Grounding_serviceCallPayload"] as
+      | string
+      | undefined,
+    appendExpression: fm["exocmd__Grounding_appendExpression"] as
+      | string
+      | undefined,
+    targetClass: fm["exocmd__Grounding_targetClass"] as string | undefined,
+    targetPrototype: fm["exocmd__Grounding_targetPrototype"] as
+      | string
+      | undefined,
+    targetFolder: fm["exocmd__Grounding_targetFolder"] as string | undefined,
+    shiftDelta: fm["exocmd__Grounding_shiftDelta"] as string | undefined,
+    incrementBy,
+    linkBackProperty: fm["exocmd__Grounding_linkBackProperty"] as
+      | string
+      | undefined,
+    steps,
+  };
+}

--- a/packages/exocortex/src/index.ts
+++ b/packages/exocortex/src/index.ts
@@ -42,6 +42,7 @@ export {
   isGroundingFrontmatter,
   isCommandBindingFrontmatter,
 } from "./domain/models/CommandDefinition";
+export { parseGroundingDefinitionFromFrontmatter } from "./domain/models/GroundingFrontmatterParser";
 export * from "./domain/models/GraphNode";
 export * from "./domain/models/GraphData";
 export * from "./domain/models/GraphEdge";

--- a/packages/exocortex/tests/domain/models/GroundingFrontmatterParser.test.ts
+++ b/packages/exocortex/tests/domain/models/GroundingFrontmatterParser.test.ts
@@ -1,0 +1,283 @@
+import { parseGroundingDefinitionFromFrontmatter } from "../../../src/domain/models/GroundingFrontmatterParser";
+import type { GroundingDefinition } from "../../../src/domain/models/CommandDefinition";
+import { GroundingType } from "../../../src/domain/constants/GroundingType";
+import { GROUNDING_TYPE_UIDS } from "../../../src/domain/constants/GroundingTypeUIDs";
+
+// Wikilink-literal form for a given grounding type (the only accepted shape
+// post RFC 9d20c91f Phase 4).
+const typeLink = (t: GroundingType): string => `[[${GROUNDING_TYPE_UIDS[t]}]]`;
+
+// A resolveStep that never gets called (non-composite scenarios).
+const failingResolveStep = (): GroundingDefinition => {
+  throw new Error("resolveStep should not be invoked");
+};
+
+describe("parseGroundingDefinitionFromFrontmatter", () => {
+  describe("full field mapping", () => {
+    it("maps every exocmd__Grounding_* key to its GroundingDefinition field", () => {
+      const fm: Record<string, unknown> = {
+        exo__Asset_label: "Set status to Done",
+        exocmd__Grounding_type: typeLink(GroundingType.PROPERTY_SET),
+        exocmd__Grounding_targetProperty: "ems__Effort_status",
+        exocmd__Grounding_targetValueRef: "[[7b9b3116-7c3c-438c-9618-94fe301320a6]]",
+        exocmd__Grounding_targetValueLiteral: "literal-value",
+        exocmd__Grounding_targetValueSubstitution: "8f111111-2222-3333-4444-555555555555",
+        exocmd__Grounding_serviceCallPayload: '{"a":1}',
+        exocmd__Grounding_appendExpression: "$target.exo__Asset_label",
+        exocmd__Grounding_targetClass: "gtd__InboxItem",
+        exocmd__Grounding_targetPrototype: "proto-uid",
+        exocmd__Grounding_targetFolder: "01 Inbox",
+        exocmd__Grounding_shiftDelta: "P1D",
+        exocmd__Grounding_incrementBy: "3",
+        exocmd__Grounding_linkBackProperty: "exo__Asset_source",
+      };
+
+      const def = parseGroundingDefinitionFromFrontmatter(
+        "grounding-uid",
+        fm,
+        failingResolveStep,
+      );
+
+      expect(def.id).toBe("grounding-uid");
+      expect(def.label).toBe("Set status to Done");
+      expect(def.type).toBe(GroundingType.PROPERTY_SET);
+      expect(def.targetProperty).toBe("ems__Effort_status");
+      // targetValueRef unwrapped to bare UID.
+      expect(def.targetValueRef).toBe("7b9b3116-7c3c-438c-9618-94fe301320a6");
+      expect(def.targetValueLiteral).toBe("literal-value");
+      expect(def.targetValueSubstitution).toBe(
+        "8f111111-2222-3333-4444-555555555555",
+      );
+      expect(def.serviceCallPayload).toBe('{"a":1}');
+      expect(def.appendExpression).toBe("$target.exo__Asset_label");
+      expect(def.targetClass).toBe("gtd__InboxItem");
+      expect(def.targetPrototype).toBe("proto-uid");
+      expect(def.targetFolder).toBe("01 Inbox");
+      expect(def.shiftDelta).toBe("P1D");
+      expect(def.incrementBy).toBe(3);
+      expect(def.linkBackProperty).toBe("exo__Asset_source");
+      // Non-composite → no steps.
+      expect(def.steps).toBeUndefined();
+    });
+
+    it("defaults label to empty string when exo__Asset_label is absent", () => {
+      const def = parseGroundingDefinitionFromFrontmatter(
+        "uid",
+        { exocmd__Grounding_type: typeLink(GroundingType.PROPERTY_DELETE) },
+        failingResolveStep,
+      );
+      expect(def.label).toBe("");
+      expect(def.type).toBe(GroundingType.PROPERTY_DELETE);
+    });
+
+    it("leaves unset optional keys undefined", () => {
+      const def = parseGroundingDefinitionFromFrontmatter(
+        "uid",
+        { exocmd__Grounding_type: typeLink(GroundingType.SPARQL_UPDATE) },
+        failingResolveStep,
+      );
+      expect(def.targetProperty).toBeUndefined();
+      expect(def.targetValueRef).toBeUndefined();
+      expect(def.targetValueLiteral).toBeUndefined();
+      expect(def.serviceCallPayload).toBeUndefined();
+      expect(def.appendExpression).toBeUndefined();
+      expect(def.targetClass).toBeUndefined();
+      expect(def.incrementBy).toBeUndefined();
+      expect(def.steps).toBeUndefined();
+    });
+  });
+
+  describe("type resolution", () => {
+    it("resolves wikilink-literal form to the GroundingType enum", () => {
+      for (const t of Object.values(GroundingType)) {
+        const def = parseGroundingDefinitionFromFrontmatter(
+          "uid",
+          { exocmd__Grounding_type: typeLink(t) },
+          failingResolveStep,
+        );
+        expect(def.type).toBe(t);
+      }
+    });
+
+    it("throws on legacy literal-string type form (RFC 9d20c91f Phase 4)", () => {
+      expect(() =>
+        parseGroundingDefinitionFromFrontmatter(
+          "fixture-uid",
+          { exocmd__Grounding_type: "property_set" },
+          failingResolveStep,
+        ),
+      ).toThrow(/legacy literal-string 'property_set'/);
+    });
+
+    it("passes a non-string type value through unchanged", () => {
+      const def = parseGroundingDefinitionFromFrontmatter(
+        "uid",
+        { exocmd__Grounding_type: undefined },
+        failingResolveStep,
+      );
+      expect(def.type).toBeUndefined();
+    });
+  });
+
+  describe("service_call serviceId fallback", () => {
+    it("reads targetProperty from Grounding_serviceId for service_call", () => {
+      const def = parseGroundingDefinitionFromFrontmatter(
+        "uid",
+        {
+          exocmd__Grounding_type: typeLink(GroundingType.SERVICE_CALL),
+          exocmd__Grounding_serviceId: "archiveAsset",
+          exocmd__Grounding_targetProperty: "should-be-ignored",
+        },
+        failingResolveStep,
+      );
+      expect(def.targetProperty).toBe("archiveAsset");
+    });
+
+    it("falls back to Grounding_targetProperty when serviceId absent (service_call)", () => {
+      const def = parseGroundingDefinitionFromFrontmatter(
+        "uid",
+        {
+          exocmd__Grounding_type: typeLink(GroundingType.SERVICE_CALL),
+          exocmd__Grounding_targetProperty: "fallback-prop",
+        },
+        failingResolveStep,
+      );
+      expect(def.targetProperty).toBe("fallback-prop");
+    });
+
+    it("ignores Grounding_serviceId for non-service_call types", () => {
+      const def = parseGroundingDefinitionFromFrontmatter(
+        "uid",
+        {
+          exocmd__Grounding_type: typeLink(GroundingType.PROPERTY_SET),
+          exocmd__Grounding_serviceId: "archiveAsset",
+          exocmd__Grounding_targetProperty: "ems__Effort_status",
+        },
+        failingResolveStep,
+      );
+      expect(def.targetProperty).toBe("ems__Effort_status");
+    });
+  });
+
+  describe("composite steps", () => {
+    it("resolves each step via the resolveStep callback with normalized UIDs", () => {
+      const calls: string[] = [];
+      const resolveStep = (stepUid: string): GroundingDefinition => {
+        calls.push(stepUid);
+        return {
+          id: stepUid,
+          label: `step-${stepUid}`,
+          type: GroundingType.PROPERTY_DELETE,
+        };
+      };
+
+      const def = parseGroundingDefinitionFromFrontmatter(
+        "composite-uid",
+        {
+          exocmd__Grounding_type: typeLink(GroundingType.COMPOSITE),
+          exocmd__Grounding_steps: [
+            "[[aaaaaaaa-1111-2222-3333-444444444444]]",
+            "[[bbbbbbbb-5555-6666-7777-888888888888|Step Two Alias]]",
+          ],
+        },
+        resolveStep,
+      );
+
+      // Step refs normalized: wikilink brackets stripped, UUID-alias collapses
+      // to the TARGET uid (not the alias).
+      expect(calls).toEqual([
+        "aaaaaaaa-1111-2222-3333-444444444444",
+        "bbbbbbbb-5555-6666-7777-888888888888",
+      ]);
+      expect(def.steps).toHaveLength(2);
+      expect(def.steps?.[0].id).toBe("aaaaaaaa-1111-2222-3333-444444444444");
+      expect(def.steps?.[1].label).toBe(
+        "step-bbbbbbbb-5555-6666-7777-888888888888",
+      );
+    });
+
+    it("leaves steps undefined when Grounding_steps is absent on composite", () => {
+      const def = parseGroundingDefinitionFromFrontmatter(
+        "uid",
+        { exocmd__Grounding_type: typeLink(GroundingType.COMPOSITE) },
+        failingResolveStep,
+      );
+      expect(def.steps).toBeUndefined();
+    });
+
+    it("does not resolve steps for non-composite types even if present", () => {
+      const def = parseGroundingDefinitionFromFrontmatter(
+        "uid",
+        {
+          exocmd__Grounding_type: typeLink(GroundingType.PROPERTY_SET),
+          exocmd__Grounding_steps: ["[[aaaaaaaa-1111-2222-3333-444444444444]]"],
+        },
+        failingResolveStep,
+      );
+      expect(def.steps).toBeUndefined();
+    });
+  });
+
+  describe("incrementBy parsing", () => {
+    const cases: Array<[unknown, number | undefined]> = [
+      ["3", 3],
+      [5, 5],
+      ["-2", -2],
+      ["", undefined],
+      [null, undefined],
+      [undefined, undefined],
+      ["not-a-number", undefined],
+    ];
+
+    it.each(cases)("parses incrementBy %p → %p", (raw, expected) => {
+      const def = parseGroundingDefinitionFromFrontmatter(
+        "uid",
+        {
+          exocmd__Grounding_type: typeLink(GroundingType.PROPERTY_INCREMENT),
+          exocmd__Grounding_incrementBy: raw,
+        },
+        failingResolveStep,
+      );
+      expect(def.incrementBy).toBe(expected);
+    });
+  });
+
+  describe("targetValueRef normalization", () => {
+    it("unwraps plain wikilink to bare UID", () => {
+      const def = parseGroundingDefinitionFromFrontmatter(
+        "uid",
+        {
+          exocmd__Grounding_type: typeLink(GroundingType.PROPERTY_SET),
+          exocmd__Grounding_targetValueRef: "[[abc-123]]",
+        },
+        failingResolveStep,
+      );
+      expect(def.targetValueRef).toBe("abc-123");
+    });
+
+    it("collapses UUID-alias form to the TARGET uid (not the alias)", () => {
+      const def = parseGroundingDefinitionFromFrontmatter(
+        "uid",
+        {
+          exocmd__Grounding_type: typeLink(GroundingType.PROPERTY_SET),
+          exocmd__Grounding_targetValueRef:
+            "[[7b9b3116-7c3c-438c-9618-94fe301320a6|ems__EffortStatusDone]]",
+        },
+        failingResolveStep,
+      );
+      expect(def.targetValueRef).toBe("7b9b3116-7c3c-438c-9618-94fe301320a6");
+    });
+
+    it("strips surrounding quote chars while normalizing", () => {
+      const def = parseGroundingDefinitionFromFrontmatter(
+        "uid",
+        {
+          exocmd__Grounding_type: typeLink(GroundingType.PROPERTY_SET),
+          exocmd__Grounding_targetValueRef: '"[[abc-123]]"',
+        },
+        failingResolveStep,
+      );
+      expect(def.targetValueRef).toBe("abc-123");
+    });
+  });
+});

--- a/scripts/test-ci-batched.sh
+++ b/scripts/test-ci-batched.sh
@@ -115,7 +115,10 @@ echo "📦 Running exocortex grounding + RFC regression tests..."
 # (workflow_transition, status_uid_integrity, property_shift, property_append,
 # property_increment) — previously only the bare `GroundingExecutor.test.ts`
 # was gated.
-EXOCORTEX_JEST_ARGS="--config packages/exocortex/jest.config.js --testPathPatterns=(services/(GroundingExecutor(\.[a-zA-Z0-9_-]+)?|AssetConversionService|NoteToRDFConverter\.(issue-2959|rfc-31c1a0be-grounding-ref|asset-filename|issue-3242-labelless-class)|ShapeRegistry|ShapeLoader)\.test|application/services/RelationColumnSetResolver(\.property)?\.test|performance/RelationColumnSetResolverPerformance\.test|infrastructure/sparql/executors/BGPExecutor\.issue-2997\.test|integration/dynamic-commands/(grounding-resolve-execute|grounding-phase3b-pipeline|grounding-type-vault-fixture-parity)\.test)\.ts --forceExit"
+# Audit epic #3384 H5 (2026-06-05): domain/models/GroundingFrontmatterParser.test
+# — gates the extracted pure raw-frontmatter→GroundingDefinition mapping (the
+# field-mapping the CLI BDD parser delegates to).
+EXOCORTEX_JEST_ARGS="--config packages/exocortex/jest.config.js --testPathPatterns=(services/(GroundingExecutor(\.[a-zA-Z0-9_-]+)?|AssetConversionService|NoteToRDFConverter\.(issue-2959|rfc-31c1a0be-grounding-ref|asset-filename|issue-3242-labelless-class)|ShapeRegistry|ShapeLoader)\.test|application/services/RelationColumnSetResolver(\.property)?\.test|performance/RelationColumnSetResolverPerformance\.test|infrastructure/sparql/executors/BGPExecutor\.issue-2997\.test|integration/dynamic-commands/(grounding-resolve-execute|grounding-phase3b-pipeline|grounding-type-vault-fixture-parity)\.test|domain/models/GroundingFrontmatterParser\.test)\.ts --forceExit"
 if [ "$CI" = "true" ]; then
     if timeout 60 node ./node_modules/jest/bin/jest.js $EXOCORTEX_JEST_ARGS; then
         echo "✅ Exocortex grounding regression tests passed!"


### PR DESCRIPTION
## Summary

Audit epic #3384, finding **H5**: the CLI BDD step definitions
(`packages/cli/specs/step_definitions/grounding.steps.ts`) held a **parallel
hand-written parser** for ~16 raw `exocmd__Grounding_*` frontmatter keys that
(per its own comments) had to be **manually re-synced to every RFC migration** —
a recurring drift surface.

This PR extracts the **pure** `Record<string, unknown> → GroundingDefinition`
field-mapping into core as
`parseGroundingDefinitionFromFrontmatter`
(`packages/exocortex/src/domain/models/GroundingFrontmatterParser.ts`). The BDD
`readGroundingDef` becomes a thin fs-wrapper (index lookup + read + parse +
recursion-depth guard) that delegates to it. The duplicated 16-key mapping in
the test file is deleted (−69 lines).

## Key design decision — behavior-preserving *partial*, not single-source

`CommandResolver` builds `GroundingDefinition` from the **triple store** (async,
RDF graph); the BDD path builds it from **raw frontmatter** (sync, `fm[key]`).
These are **genuinely different mechanisms**. A full single-source would require
a parser-refactor of `CommandResolver` (parser-touching, risky — a separate
question). This PR does the safe behavior-preserving partial: it consolidates
**only** the synchronous raw-frontmatter contract, giving core ownership of the
canonical `frontmatter → GroundingDefinition` mapping and removing the recurring
manual re-sync drift. **`CommandResolver` and `NoteToRDFConverter` are NOT
touched.**

## Why the new core function is test-only *today* (anticipating review)

`parseGroundingDefinitionFromFrontmatter` is currently consumed only by the CLI
BDD parser — `CommandResolver` does not call it (it uses the triple-store path).
This is **intentional**, not dead/over-engineered code: it establishes a single
source for the raw-frontmatter → `GroundingDefinition` contract, eliminates the
duplicated per-key mapping that drifted on each RFC migration, and is the
natural seam any future non-triple-store consumer (audit scripts,
`extract-target-class.ts`) would adopt.

## Wikilink normalization — deliberately NOT shared with `WikiLinkHelpers.normalize`

The grounding ref normalization is kept **behavior-identical** to the BDD
original inside core (`normalizeGroundingRef`). It is **not** `WikiLinkHelpers.normalize`
because two behaviours diverge and sharing would silently change parsing:
1. For UUID-alias form `[[<uuid>|<alias>]]`, `WikiLinkHelpers.normalize`
   returns the **alias**, whereas grounding refs need the **target uuid** to
   resolve the step / value asset by UID.
2. `WikiLinkHelpers.normalize` does not strip surrounding quote chars; the
   grounding normalizer does.

## Mapping nuances preserved verbatim

- `type` via `resolveGroundingTypeFromWikilinkLiteral`; non-string passes
  through; legacy literal-string form **throws** (RFC 9d20c91f Phase 4).
- `service_call` reads `Grounding_serviceId` first, falling back to
  `Grounding_targetProperty`.
- `incrementBy` `parseInt` (finite-guarded; blank/null/undefined skipped).
- `targetValueRef` unwrapped via the grounding normalizer.
- Composite `steps` recurse via a `resolveStep` callback (fs + depth-guard stay
  in the BDD wrapper).

## Test plan

- [x] New focused unit suite `GroundingFrontmatterParser.test.ts` — **22 cases**:
      full 16-field mapping, label fallback, type resolution (all enum values +
      literal-form throw + non-string passthrough), service_call serviceId
      fallback (3 cases), composite steps via mock `resolveStep` (incl.
      normalization assertions), `incrementBy` parsing (7 cases), `targetValueRef`
      normalization (plain / UUID-alias→target / quote-strip).
- [x] Added the suite to the CI `test-coverage` allowlist
      (`scripts/test-ci-batched.sh`) so it is gated (not an orphan suite).
- [x] **Revert-verify** (per `integration-test-revert-verify` discipline):
      removing the `serviceCallPayload` mapping line in core → unit **FAILS**
      (1/22, on the `serviceCallPayload` assertion); restored → **PASSES**
      (22/22). Empirically verified to FAIL pre-fix and PASS post-fix.
- [x] Existing CLI BDD grounding suite: **53/53 scenarios green** (219 steps) —
      observable behavior unchanged (this is a pure refactor).
- [x] `npm run check:types` (root `tsc --noEmit`) clean.

### Note on local integration-suite runs
Two allowlist suites failed in a fresh worktree purely from environment, not
this change:
- `grounding-type-vault-fixture-parity` — needed `git submodule update --init`
  (reads `exoas-exocmd` submodule); **passes** after init.
- `grounding-resolve-execute` Fixture 1 — **pre-existing** on `origin/main`
  (proved via `git stash` of this PR's changes: still fails; it exercises the
  `CommandResolver` triple-store path, which this PR does not touch; green in CI).

Refs #3384.