### PR TITLE
feat(cli): GitHub token auth for private-repo tarball pull

### DIFF
--- a/packages/cli/src/commands/assetspace-add.ts
+++ b/packages/cli/src/commands/assetspace-add.ts
@@ -60,8 +60,10 @@ export function assetSpaceAddCommand(): Command {
         }
 
         // Token precedence: --token flag > GITHUB_TOKEN env > GH_TOKEN env.
-        // Undefined → anonymous mode (public repos only), unchanged behaviour.
-        const token = options.token ?? process.env.GITHUB_TOKEN ?? process.env.GH_TOKEN;
+        // `||` (not `??`) so an empty-string env var (`GITHUB_TOKEN=""`) falls
+        // through to the next source instead of pinning anonymous mode.
+        // All-empty → undefined → anonymous mode (public repos), unchanged.
+        const token = options.token || process.env.GITHUB_TOKEN || process.env.GH_TOKEN || undefined;
         const svc = new BootstrapAssetSpaceService({ token });
         const ref = options.ref ?? "main";
         const folder = options.folder ?? BootstrapAssetSpaceService.deriveFolderName(options.url);

--- a/packages/cli/src/commands/assetspace-add.ts
+++ b/packages/cli/src/commands/assetspace-add.ts
@@ -11,6 +11,7 @@ interface AssetSpaceAddOptions {
   folder?: string;
   ref?: string;
   json?: boolean;
+  token?: string;
 }
 
 /**
@@ -40,6 +41,10 @@ export function assetSpaceAddCommand(): Command {
       "Local folder name под assetspaces/. Defaults к URL-derived (strips exoas- prefix)",
     )
     .option("--ref <branch>", "Branch ref к pull from", "main")
+    .option(
+      "--token <pat>",
+      "GitHub PAT for private repos (or env GITHUB_TOKEN / GH_TOKEN). Optional — anonymous for public repos.",
+    )
     .option("--json", "Emit result as JSON", false)
     .action(async (options: AssetSpaceAddOptions) => {
       try {
@@ -54,7 +59,10 @@ export function assetSpaceAddCommand(): Command {
           throw new VaultNotFoundError(vaultPath);
         }
 
-        const svc = new BootstrapAssetSpaceService();
+        // Token precedence: --token flag > GITHUB_TOKEN env > GH_TOKEN env.
+        // Undefined → anonymous mode (public repos only), unchanged behaviour.
+        const token = options.token ?? process.env.GITHUB_TOKEN ?? process.env.GH_TOKEN;
+        const svc = new BootstrapAssetSpaceService({ token });
         const ref = options.ref ?? "main";
         const folder = options.folder ?? BootstrapAssetSpaceService.deriveFolderName(options.url);
         const targetDir = join(vaultPath, "assetspaces", folder);

--- a/packages/cli/src/commands/bootstrap.ts
+++ b/packages/cli/src/commands/bootstrap.ts
@@ -11,6 +11,7 @@ interface BootstrapOptions {
   exocmd?: string;
   ref?: string;
   json?: boolean;
+  token?: string;
 }
 
 /**
@@ -44,6 +45,10 @@ export function bootstrapCommand(): Command {
       "Public GitHub URL для exocmd TBox AssetSpace (e.g. https://github.com/kitelev/exoas-exocmd)",
     )
     .option("--ref <branch>", "Branch ref к pull from", "main")
+    .option(
+      "--token <pat>",
+      "GitHub PAT for private repos (or env GITHUB_TOKEN / GH_TOKEN). Optional — anonymous for public repos.",
+    )
     .option("--json", "Emit result as JSON", false)
     .action(async (options: BootstrapOptions) => {
       try {
@@ -67,7 +72,10 @@ export function bootstrapCommand(): Command {
           );
         }
 
-        const svc = new BootstrapAssetSpaceService();
+        // Token precedence: --token flag > GITHUB_TOKEN env > GH_TOKEN env.
+        // Undefined → anonymous mode (public repos only), unchanged behaviour.
+        const token = options.token ?? process.env.GITHUB_TOKEN ?? process.env.GH_TOKEN;
+        const svc = new BootstrapAssetSpaceService({ token });
         const ref = options.ref ?? "main";
 
         const results: Array<{ folder: string; url: string; sha: string; fileCount: number }> = [];

--- a/packages/cli/src/commands/bootstrap.ts
+++ b/packages/cli/src/commands/bootstrap.ts
@@ -73,8 +73,10 @@ export function bootstrapCommand(): Command {
         }
 
         // Token precedence: --token flag > GITHUB_TOKEN env > GH_TOKEN env.
-        // Undefined → anonymous mode (public repos only), unchanged behaviour.
-        const token = options.token ?? process.env.GITHUB_TOKEN ?? process.env.GH_TOKEN;
+        // `||` (not `??`) so an empty-string env var (`GITHUB_TOKEN=""`) falls
+        // through to the next source instead of pinning anonymous mode.
+        // All-empty → undefined → anonymous mode (public repos), unchanged.
+        const token = options.token || process.env.GITHUB_TOKEN || process.env.GH_TOKEN || undefined;
         const svc = new BootstrapAssetSpaceService({ token });
         const ref = options.ref ?? "main";
 

--- a/packages/cli/src/services/BootstrapAssetSpaceService.ts
+++ b/packages/cli/src/services/BootstrapAssetSpaceService.ts
@@ -31,7 +31,7 @@ const REPO_URL_REGEX = /^https:\/\/github\.com\/([a-zA-Z0-9_-]+)\/([a-zA-Z0-9_.-
 const MAX_TARBALL_BYTES = 50 * 1024 * 1024; // 50 MB cap (matches plugin)
 
 export interface PullResult {
-  /** Wrapper dir SHA from GitHub tarball (7-char hex). */
+  /** Wrapper dir SHA from GitHub tarball — abbreviated (anonymous, 7-char) or full (authenticated, 40-char) hex. */
   sha: string;
   /** Number of files extracted (excludes directories). */
   fileCount: number;

--- a/packages/cli/src/services/BootstrapAssetSpaceService.ts
+++ b/packages/cli/src/services/BootstrapAssetSpaceService.ts
@@ -40,13 +40,40 @@ export interface PullResult {
 export interface BootstrapServiceOptions {
   /** Override fetch implementation for tests. Defaults to global fetch. */
   fetchImpl?: typeof fetch;
+  /**
+   * GitHub PAT for authenticated tarball pulls (private repos). When empty /
+   * undefined the service stays in anonymous mode (public repos only) — the
+   * exact behaviour shipped before token support. Resolved by the commands
+   * from `--token` flag OR `GITHUB_TOKEN`/`GH_TOKEN` env (option > env).
+   */
+  token?: string;
 }
 
 export class BootstrapAssetSpaceService {
   private readonly fetchImpl: typeof fetch;
+  private readonly token: string;
+
+  // PAT redaction (mirrors plugin GitHubRestClient.PAT_REGEX) — replaces any
+  // PAT-shaped substring that may leak into an error message / underlying
+  // fetch error before it reaches stderr / --json. Covers classic family
+  // (ghp_/gho_/ghu_/ghs_/ghr_, 36+ urlsafe chars) + fine-grained
+  // github_pat_<22+ id>_<59+ secret> tokens.
+  private static readonly PAT_REGEX =
+    /(?:gh[pousr]_[A-Za-z0-9_]{36,}|github_pat_[A-Za-z0-9_]{22,}_[A-Za-z0-9_]{59,})/g;
 
   constructor(opts: BootstrapServiceOptions = {}) {
     this.fetchImpl = opts.fetchImpl ?? globalThis.fetch;
+    this.token = opts.token ?? "";
+  }
+
+  /**
+   * Replace any PAT-shaped substring with ***REDACTED***. Idempotent. Defends
+   * against a token leaking via a third-party fetch-error formatter that
+   * echoes request headers. Non-string inputs coerced via String().
+   */
+  private redact(message: unknown): string {
+    const s = typeof message === "string" ? message : String(message);
+    return s.replace(BootstrapAssetSpaceService.PAT_REGEX, "***REDACTED***");
   }
 
   /**
@@ -99,11 +126,33 @@ export class BootstrapAssetSpaceService {
     // plugin's AssetSpaceManager.pullAssetSpace contract). Codeload tarball
     // uses `<repo>-<branch>` wrapper which loses SHA — use API endpoint.
     const tarballUrl = `https://api.github.com/repos/${owner}/${repo}/tarball/${ref}`;
+    // Authenticated mode: attach Authorization + GitHub-required headers ONLY
+    // when a token is present. Empty token → anonymous request shape is left
+    // byte-identical to the pre-token behaviour (public repos, no headers).
+    // The authenticated endpoint returns a full-40-char-SHA wrapper which the
+    // SHA matcher (7..40 hex) and #3390 ustar-prefix parser already handle.
+    const init: RequestInit = { signal: AbortSignal.timeout(60_000) };
+    if (this.token.length > 0) {
+      init.headers = {
+        Authorization: `Bearer ${this.token}`,
+        "User-Agent": "exocortex-cli",
+        "X-GitHub-Api-Version": "2022-11-28",
+      };
+    }
     // Code-reviewer MEDIUM: fetch timeout (60s) prevents indefinite hang
     // on slow/stalled GitHub response. Cap matches typical CI test timeouts.
-    const response = await this.fetchImpl(tarballUrl, {
-      signal: AbortSignal.timeout(60_000),
-    });
+    let response: Awaited<ReturnType<typeof fetch>>;
+    try {
+      response = await this.fetchImpl(tarballUrl, init);
+    } catch (err) {
+      // Redact before re-throw: some fetch implementations embed the request
+      // (incl. Authorization header) in the thrown error.
+      throw new Error(
+        this.redact(
+          `pullAssetSpace: fetch error for ${tarballUrl}: ${err instanceof Error ? err.message : String(err)}`,
+        ),
+      );
+    }
     if (!response.ok) {
       // Code-reviewer MEDIUM: surface GitHub anonymous rate-limit (60 req/hour)
       // с actionable message instead of generic "fetch failed".
@@ -119,8 +168,24 @@ export class BootstrapAssetSpaceService {
           );
         }
       }
+      // GitHub returns 404 (not 403) for private repos the caller can't see —
+      // it deliberately hides existence. If we pulled anonymously, hint that a
+      // token may be required. With a token, 404 means genuinely-missing repo
+      // OR the token lacks access — surface both possibilities.
+      if (response.status === 404) {
+        const hint = this.token.length > 0
+          ? "repo not found, or the provided token lacks access to it"
+          : "if this is a private repo, pass --token <pat> (or set GITHUB_TOKEN / GH_TOKEN)";
+        throw new Error(
+          this.redact(
+            `pullAssetSpace: fetch failed (404 Not Found) for ${tarballUrl} — ${hint}`,
+          ),
+        );
+      }
       throw new Error(
-        `pullAssetSpace: fetch failed (${response.status} ${response.statusText}) for ${tarballUrl}`,
+        this.redact(
+          `pullAssetSpace: fetch failed (${response.status} ${response.statusText}) for ${tarballUrl}`,
+        ),
       );
     }
     const arrayBuf = await response.arrayBuffer();

--- a/packages/cli/tests/unit/BootstrapAssetSpaceService.test.ts
+++ b/packages/cli/tests/unit/BootstrapAssetSpaceService.test.ts
@@ -157,6 +157,63 @@ function fakeFetchError(status: number, statusText: string): typeof fetch {
   }) as typeof fetch;
 }
 
+/**
+ * Fetch fake that records the RequestInit it was called with (so tests can
+ * assert on the Authorization / GitHub headers the service attaches), then
+ * returns `response` as a 200.
+ */
+function fakeFetchCapturing(response: Uint8Array, sink: { init?: RequestInit }): typeof fetch {
+  return (async (_url: string | URL | Request, init?: RequestInit) => {
+    sink.init = init;
+    return {
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      arrayBuffer: async () =>
+        response.buffer.slice(response.byteOffset, response.byteOffset + response.byteLength),
+    } as unknown as Response;
+  }) as typeof fetch;
+}
+
+/**
+ * Fetch fake mimicking a PRIVATE GitHub repo: requires a `Bearer` Authorization
+ * header. Without it → 404 (GitHub hides private-repo existence rather than 403).
+ * With it → returns the tarball. Models the real auth gate end-to-end.
+ */
+function fakeFetchRequiringAuth(response: Uint8Array): typeof fetch {
+  return (async (_url: string | URL | Request, init?: RequestInit) => {
+    const headers = (init?.headers ?? {}) as Record<string, string>;
+    const auth = headers.Authorization ?? headers.authorization;
+    if (!auth || !auth.startsWith("Bearer ")) {
+      return {
+        ok: false,
+        status: 404,
+        statusText: "Not Found",
+        arrayBuffer: async () => new ArrayBuffer(0),
+      } as unknown as Response;
+    }
+    return {
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      arrayBuffer: async () =>
+        response.buffer.slice(response.byteOffset, response.byteOffset + response.byteLength),
+    } as unknown as Response;
+  }) as typeof fetch;
+}
+
+/**
+ * Fetch fake that throws an error embedding the request headers (incl. the
+ * Authorization PAT) — models a third-party fetch impl that echoes the request
+ * on network failure. Used to verify the service redacts leaked PATs.
+ */
+function fakeFetchThrowingWithAuth(): typeof fetch {
+  return (async (_url: string | URL | Request, init?: RequestInit) => {
+    const headers = (init?.headers ?? {}) as Record<string, string>;
+    throw new Error(`network down; request headers: ${JSON.stringify(headers)}`);
+  }) as typeof fetch;
+}
+
 describe("BootstrapAssetSpaceService", () => {
   let tempBase: string;
 
@@ -338,6 +395,128 @@ describe("BootstrapAssetSpaceService", () => {
       await expect(
         svc.pullAssetSpace("not-a-github-url", "main", path.join(tempBase, "t")),
       ).rejects.toThrow(/invalid URL shape/);
+    });
+  });
+
+  describe("token auth (private-repo support)", () => {
+    // Classic PAT shape: ghp_ + 36 urlsafe chars → matches the service's
+    // redaction PAT_REGEX (gh[pousr]_[A-Za-z0-9_]{36,}).
+    const TOKEN = "ghp_0123456789abcdefghijklmnopqrstuvwxyz";
+
+    it("attaches Authorization: Bearer + GitHub headers when token provided", async () => {
+      const tarball = buildFakeGitHubTarball("kitelev", "exoas-priv", "abc1234", [
+        { path: "README.md", content: "# priv" },
+      ]);
+      const sink: { init?: RequestInit } = {};
+      const svc = new BootstrapAssetSpaceService({
+        fetchImpl: fakeFetchCapturing(tarball, sink),
+        token: TOKEN,
+      });
+      await svc.pullAssetSpace(
+        "https://github.com/kitelev/exoas-priv",
+        "main",
+        path.join(tempBase, "priv"),
+      );
+      const headers = (sink.init?.headers ?? {}) as Record<string, string>;
+      expect(headers.Authorization).toBe(`Bearer ${TOKEN}`);
+      expect(headers["User-Agent"]).toBe("exocortex-cli");
+      expect(headers["X-GitHub-Api-Version"]).toBe("2022-11-28");
+    });
+
+    it("omits Authorization header when no token (anonymous path unchanged)", async () => {
+      const tarball = buildFakeGitHubTarball("kitelev", "exoas-pub", "def5678", [
+        { path: "README.md", content: "# pub" },
+      ]);
+      const sink: { init?: RequestInit } = {};
+      const svc = new BootstrapAssetSpaceService({
+        fetchImpl: fakeFetchCapturing(tarball, sink),
+      });
+      await svc.pullAssetSpace(
+        "https://github.com/kitelev/exoas-pub",
+        "main",
+        path.join(tempBase, "pub"),
+      );
+      // No headers attached at all — request shape byte-identical to pre-token.
+      expect(sink.init?.headers).toBeUndefined();
+    });
+
+    it("treats empty-string token as anonymous (no Authorization header)", async () => {
+      const tarball = buildFakeGitHubTarball("kitelev", "exoas-pub", "aaa1111", [
+        { path: "README.md", content: "# pub" },
+      ]);
+      const sink: { init?: RequestInit } = {};
+      const svc = new BootstrapAssetSpaceService({
+        fetchImpl: fakeFetchCapturing(tarball, sink),
+        token: "",
+      });
+      await svc.pullAssetSpace(
+        "https://github.com/kitelev/exoas-pub",
+        "main",
+        path.join(tempBase, "pub-empty"),
+      );
+      expect(sink.init?.headers).toBeUndefined();
+    });
+
+    // Integration: private-shape AUTHENTICATED tarball (full-40-char-SHA wrapper
+    // + ustar prefix-split UUID asset, the #3390 shape) behind an auth gate.
+    it("materializes a private-shape tarball WITH token (40-char SHA wrapper)", async () => {
+      const SHA40 = "306f656e6159944a4ae18beeb618d13611826b9b";
+      const UUID = "b2c3d4e5-f6a7-8901-bcde-f01234567890";
+      const tarball = buildAuthGitHubTarball("kitelev", "exoas-priv", SHA40, UUID, "private asset body");
+      const svc = new BootstrapAssetSpaceService({
+        fetchImpl: fakeFetchRequiringAuth(tarball),
+        token: TOKEN,
+      });
+      const target = path.join(tempBase, "assetspaces", "priv");
+
+      const result = await svc.pullAssetSpace(
+        "https://github.com/kitelev/exoas-priv",
+        "main",
+        target,
+      );
+
+      expect(result.sha).toBe(SHA40);
+      expect(result.fileCount).toBe(2);
+      expect(existsSync(path.join(target, `${UUID}.md`))).toBe(true);
+      expect(readFileSync(path.join(target, `${UUID}.md`), "utf8")).toBe("private asset body");
+    });
+
+    // revert-verify anchor: removing the header-injection block in the service
+    // makes THIS test fail (no auth → 404). Verified empirically pre-merge.
+    it("fails gracefully on private repo WITHOUT token — 404, no partial state", async () => {
+      const SHA40 = "306f656e6159944a4ae18beeb618d13611826b9b";
+      const UUID = "c3d4e5f6-a7b8-9012-cdef-012345678901";
+      const tarball = buildAuthGitHubTarball("kitelev", "exoas-priv", SHA40, UUID, "private asset body");
+      const svc = new BootstrapAssetSpaceService({
+        fetchImpl: fakeFetchRequiringAuth(tarball),
+      }); // no token → anonymous → 404
+      const target = path.join(tempBase, "assetspaces", "priv-noauth");
+
+      await expect(
+        svc.pullAssetSpace("https://github.com/kitelev/exoas-priv", "main", target),
+      ).rejects.toThrow(/fetch failed \(404 Not Found\).*--token/);
+      // No partial state: target dir never created (fetch fails before staging).
+      expect(existsSync(target)).toBe(false);
+    });
+
+    it("redacts a leaked PAT from fetch-error messages (security)", async () => {
+      const svc = new BootstrapAssetSpaceService({
+        fetchImpl: fakeFetchThrowingWithAuth(),
+        token: TOKEN,
+      });
+      let caught: Error | undefined;
+      try {
+        await svc.pullAssetSpace(
+          "https://github.com/kitelev/exoas-priv",
+          "main",
+          path.join(tempBase, "redact"),
+        );
+      } catch (e) {
+        caught = e as Error;
+      }
+      expect(caught).toBeDefined();
+      expect(caught!.message).not.toContain(TOKEN);
+      expect(caught!.message).toContain("***REDACTED***");
     });
   });
 


### PR DESCRIPTION
## Summary

CLI `@kitelev/exocortex-cli` can now pull **private** GitHub repos. Previously `bootstrap` / `assetspace-add` pulled the tarball anonymously (no `Authorization` header) → 404 on private repos. This threads an optional GitHub token through.

- **`BootstrapAssetSpaceService`**: new optional `token` in `BootstrapServiceOptions`. When non-empty, the tarball fetch attaches `Authorization: Bearer <token>` + `User-Agent: exocortex-cli` + `X-GitHub-Api-Version: 2022-11-28`. When empty/undefined the request shape is **byte-identical to before** (anonymous, public-only) — the public path is untouched.
- **Commands** `bootstrap` + `assetspace-add`: new `--token <pat>` option. Resolution precedence: `--token` > `GITHUB_TOKEN` env > `GH_TOKEN` env. Help text + this option document private support.
- **404 hint**: GitHub returns 404 (not 403) for private repos the caller can't see. The error now carries an actionable hint to pass `--token` (anonymous) or notes the token may lack access (authenticated).

The tar fix #3390 (v16.60.13) already handles the authenticated 40-char-SHA wrapper + ustar-prefix split — no tar/parser changes here.

## hard-switch — token N/A (verified)

`grep` confirms `pullAssetSpace` is only constructed in `bootstrap.ts` + `assetspace-add.ts`. `hard-switch` is a Phase-3-pending scaffold (`runHardSwitch` only resolves the profile locally via `CliFocusProfileResolver` + builds a stub plan; `assetSpacesBeingMaterialized` is empty, no remote pull). No token wiring needed; will revisit when Phase 3 lands real materialization.

## Security (token redaction)

- Added `PAT_REGEX` + `redact()` mirroring the plugin's `GitHubRestClient` (covers classic `ghp_/gho_/ghu_/ghs_/ghr_` + fine-grained `github_pat_…`).
- All error paths that could echo the request — the `fetch` catch (a third-party fetch impl may embed request headers in the thrown error), the generic `fetch failed`, and the 404 path — run through `redact()` so a token never reaches stderr / `--json`.
- Token is never printed by the commands (no stdout/stderr echo, not in `--json`).

## Tests (production-shape + revert-verify)

Added to `BootstrapAssetSpaceService.test.ts` (27/27 green):
- Header capture: token → `Authorization: Bearer <token>` + GitHub headers present.
- No token / empty-string token → **no headers** (anonymous shape preserved).
- Integration: private-shape tarball (full-40-char-SHA wrapper + ustar prefix-split UUID asset, the #3390 shape) behind an auth-requiring fake fetch → materializes **with** token.
- Without token on the private repo → graceful 404, **no partial state** (target dir never created).
- Redaction: a fetch error embedding the PAT → message contains `***REDACTED***`, not the token.

**revert-verify (empirical):** disabling the header-injection block (`if (false && …)`) → exactly the **3 auth-dependent tests FAIL** (header capture, private materialize, redaction) while the anonymous-path tests stay green. Restoring → 27/27 PASS.

## Verification

- `npm run check:types` — clean.
- `npm run lint` — 0 errors (2 pre-existing warnings in unrelated obsidian-plugin files).
- `BootstrapAssetSpaceService` suite — 27/27.
- Full `npx jest` shows 10 pre-existing `sparql-exo003.integration` failures + ESM suite-load noise — **confirmed pre-existing on baseline** (stash → same 10 fail), unrelated to this diff. BDD/e2e via CI.
- No CLI runbook references `bootstrap`/`assetspace-add` (searched README + docs/) — `--help` text is the doc surface, updated.

Unblocks CLI×private in the Phase 6 test plan. Vault task `b16e2370` (no GitHub `Closes`).