### PR TITLE
feat(#3384): plugin Create opts into UID-canon class ref + cardinality (H3 PR2/2)

### DIFF
--- a/packages/obsidian-plugin/src/application/commands/CreateAssetCommand.ts
+++ b/packages/obsidian-plugin/src/application/commands/CreateAssetCommand.ts
@@ -3,9 +3,12 @@ import { ICommand } from "./ICommand";
 import {
   GenericAssetCreationService,
   LoggingService,
+  ShapeLoader,
   type AssetPropertyDefinition,
   type INotificationService,
+  type ShapeRegistry,
 } from "exocortex";
+import type { SPARQLQueryService } from '@plugin/application/services/SPARQLQueryService';
 import {
   showClassSelectionModal,
   type ClassSelectionModalResult,
@@ -57,6 +60,7 @@ export class CreateAssetCommand implements ICommand {
     private classDiscoveryService: ClassDiscoveryService,
     private notifier: INotificationService,
     private schemaService?: OntologySchemaService,
+    private sparqlQueryService?: SPARQLQueryService,
   ) {}
 
   /**
@@ -85,12 +89,26 @@ export class CreateAssetCommand implements ICommand {
       // Step 3: Get property definitions for formatting
       const propertyDefinitions = await this.getPropertyDefinitions(selectedClass.className);
 
-      // Step 4: Create the asset
+      // Step 3.5: Lazily load SHACL-lite shapes (#3384 H3 PR2). Built ONLY here,
+      // on the Create command — never on plugin onload (the onload path is
+      // fragile; see FocusProfile bootstrap). The plugin already has the
+      // in-memory triple store populated by the class-discovery query above, so
+      // this is a cheap read of the existing graph. Failure is non-fatal: the
+      // core service falls back to scalar (label-form / scalar) emission.
+      const shapeRegistry = await this.loadShapeRegistry();
+
+      // Step 4: Create the asset. Opt in (#3384 H3 PR2) to UID-canon class refs
+      // (`exo__Instance_class: [[<uuid>]]`) and cardinality-aware property
+      // emission. `classUid` is resolved during class discovery; when absent
+      // the core service falls back to the legacy `[[<className>]]` label form.
       const createdFile = await this.genericAssetCreationService.createAsset(
         {
           className: selectedClass.className,
+          classRefForm: "uuid",
+          classUid: selectedClass.classUid,
           label: assetResult.label || undefined,
           propertyValues: assetResult.propertyValues,
+          shapeRegistry,
         },
         propertyDefinitions,
       );
@@ -164,6 +182,32 @@ export class CreateAssetCommand implements ICommand {
     } catch (error) {
       this.logger.warn(`Failed to get property definitions for ${className}`, error);
       return [];
+    }
+  }
+
+  /**
+   * Lazily build a SHACL-lite {@link ShapeRegistry} from the plugin's in-memory
+   * RDF triple store for cardinality-aware property emission (#3179, #3384 H3
+   * PR2).
+   *
+   * STRICT laziness: this runs only when the user executes the Create command,
+   * never on plugin onload. It reads the already-populated triple store (the
+   * class-discovery query ran first in the same flow), so no vault walk is
+   * triggered here. Any failure — store unavailable, not yet initialised, or a
+   * graph-walk error — is swallowed and `undefined` is returned, which makes
+   * the core service fall back to scalar property emission.
+   */
+  private async loadShapeRegistry(): Promise<ShapeRegistry | undefined> {
+    if (!this.sparqlQueryService || !this.sparqlQueryService.isReady()) {
+      return undefined;
+    }
+    try {
+      return await ShapeLoader.loadFromRDFGraph(
+        this.sparqlQueryService.getTripleStore(),
+      );
+    } catch (error) {
+      this.logger.warn("Failed to load shapes; falling back to scalar emission", error);
+      return undefined;
     }
   }
 

--- a/packages/obsidian-plugin/src/application/services/ClassDiscoveryService.ts
+++ b/packages/obsidian-plugin/src/application/services/ClassDiscoveryService.ts
@@ -17,6 +17,15 @@ export interface DiscoveredClass {
   deprecated: boolean;
   /** Whether instances of this class can be created (not abstract) */
   canCreateInstance: boolean;
+  /**
+   * The class definition's `exo__Asset_uid` (its UUID-canon filename stem).
+   * Populated from the ontology when discovered; absent for the hardcoded
+   * fallback classes. Consumed by the Create-asset flow (H3 PR2, #3384) to
+   * emit `exo__Instance_class: [[<uuid>]]` strip-canon instead of the legacy
+   * `[[<className>]]` label form. When absent the create path falls back to
+   * the label form.
+   */
+  classUid?: string;
 }
 
 /**
@@ -72,10 +81,24 @@ export class ClassDiscoveryService {
       }
     `;
 
+    // Issue #3384 (H3 PR2): a separate mandatory-join query for the class
+    // definition's UUID-canon stem (`exo__Asset_uid`). Kept distinct from the
+    // label query for the same robustness reason as #2810 — the engine's
+    // OPTIONAL does not reliably bind multiple properties alongside rdf:type in
+    // the in-memory store, so a single-pattern query + JS join is the safe path.
+    const uidQuery = `
+      PREFIX exo: <https://exocortex.my/ontology/exo#>
+
+      SELECT ?class ?uid WHERE {
+        ?class exo:Asset_uid ?uid .
+      }
+    `;
+
     try {
-      const [classResults, labelResults] = await Promise.all([
+      const [classResults, labelResults, uidResults] = await Promise.all([
         this.sparqlService.query(classQuery),
         this.sparqlService.query(labelQuery),
+        this.sparqlService.query(uidQuery),
       ]);
 
       // Build a label lookup: file IRI → exo__Asset_label value
@@ -85,6 +108,16 @@ export class ClassDiscoveryService {
         const label = binding.get("label")?.toString();
         if (iri && label) {
           labelByIRI.set(iri, label);
+        }
+      }
+
+      // Build a UID lookup: file IRI → exo__Asset_uid value (UID-canon stem)
+      const uidByIRI = new Map<string, string>();
+      for (const binding of uidResults) {
+        const iri = binding.get("class")?.toString();
+        const uid = binding.get("uid")?.toString();
+        if (iri && uid) {
+          uidByIRI.set(iri, uid);
         }
       }
 
@@ -126,6 +159,7 @@ export class ClassDiscoveryService {
           label,
           deprecated: false,
           canCreateInstance: this.canCreateInstance(className),
+          classUid: uidByIRI.get(classIRI),
         });
       }
 

--- a/packages/obsidian-plugin/src/application/services/ClassDiscoveryService.ts
+++ b/packages/obsidian-plugin/src/application/services/ClassDiscoveryService.ts
@@ -29,6 +29,24 @@ export interface DiscoveredClass {
 }
 
 /**
+ * Read the lexical value of a SPARQL binding term.
+ *
+ * RDF Literal `.toString()` serializes to the quoted N-Triples form
+ * (`"<value>"^^<datatype>`), so reading a Literal binding (e.g. an
+ * `exo__Asset_uid`) via `.toString()` yields a quote-wrapped string. RDF terms
+ * expose the bare lexical form via `.value`; fall back to `String(term)` for
+ * any term shape that lacks it.
+ */
+function literalValue(term: unknown): string | undefined {
+  if (term === null || term === undefined) return undefined;
+  if (typeof term === "object" && "value" in term) {
+    const value = (term as { value: unknown }).value;
+    return typeof value === "string" ? value : String(value);
+  }
+  return String(term);
+}
+
+/**
  * Service for discovering available classes from the RDF ontology.
  *
  * Queries the triple store to find all defined classes, including
@@ -111,11 +129,16 @@ export class ClassDiscoveryService {
         }
       }
 
-      // Build a UID lookup: file IRI → exo__Asset_uid value (UID-canon stem)
+      // Build a UID lookup: file IRI → exo__Asset_uid value (UID-canon stem).
+      // The uid binding is an RDF Literal; its `.toString()` wraps the lexical
+      // value in quotes (`"<uid>"`) which would corrupt the downstream
+      // `[[<uid>]]` wikilink. Read the LEXICAL value (`.value`) instead. The
+      // class binding is an IRI, whose `.toString()` is already the bare IRI,
+      // and must stay `.toString()` to match the join key built elsewhere.
       const uidByIRI = new Map<string, string>();
       for (const binding of uidResults) {
         const iri = binding.get("class")?.toString();
-        const uid = binding.get("uid")?.toString();
+        const uid = literalValue(binding.get("uid"));
         if (iri && uid) {
           uidByIRI.set(iri, uid);
         }

--- a/packages/obsidian-plugin/src/application/services/CommandManager.ts
+++ b/packages/obsidian-plugin/src/application/services/CommandManager.ts
@@ -70,7 +70,7 @@ export class CommandManager {
       new ToggleArchivedAssetsCommand(plugin, notifier),
       new OpenQueryBuilderCommand(this.app, plugin, notifier),
       new EditPropertiesCommand(this.app, plugin, notifier),
-      new CreateAssetCommand(this.app, genericAssetCreationService, this.vaultAdapter, classDiscoveryService, notifier, ontologySchemaService),
+      new CreateAssetCommand(this.app, genericAssetCreationService, this.vaultAdapter, classDiscoveryService, notifier, ontologySchemaService, sparqlQueryService),
     ];
 
     this.commandRegistry = new CommandRegistry(globalCommands);

--- a/packages/obsidian-plugin/tests/unit/commands/CreateAssetCommand.test.ts
+++ b/packages/obsidian-plugin/tests/unit/commands/CreateAssetCommand.test.ts
@@ -1,0 +1,247 @@
+import type { App } from "obsidian";
+import {
+  GenericAssetCreationService,
+  InMemoryTripleStore,
+  DomainTriple,
+  DomainIRI,
+  DomainLiteral,
+  Namespace,
+  type IVaultAdapter,
+  type INotificationService,
+} from "exocortex";
+import { CreateAssetCommand } from "../../../src/application/commands/CreateAssetCommand";
+import { showClassSelectionModal } from "@plugin/presentation/modals/modalSchemas";
+import { DynamicAssetCreationModal } from "@plugin/presentation/modals/DynamicAssetCreationModal";
+import type { SPARQLQueryService } from "../../../src/application/services/SPARQLQueryService";
+import type {
+  ClassDiscoveryService,
+  DiscoveredClass,
+} from "../../../src/application/services/ClassDiscoveryService";
+import type { ObsidianVaultAdapter } from "../../../src/adapters/ObsidianVaultAdapter";
+
+// Headless the two UI modals so the command callback can run in a unit test.
+jest.mock("@plugin/presentation/modals/modalSchemas", () => ({
+  showClassSelectionModal: jest.fn(),
+}));
+jest.mock("@plugin/presentation/modals/DynamicAssetCreationModal", () => ({
+  DynamicAssetCreationModal: jest.fn(),
+}));
+
+const EXO = "https://exocortex.my/ontology/exo#";
+
+/**
+ * Behavioral / golden test for the H3 PR2 (#3384) plugin opt-in.
+ *
+ * Exercises the FULL plugin Create-asset chain with REAL components:
+ *   CreateAssetCommand → GenericAssetCreationService (core) → emitted bytes
+ *   + ShapeLoader.loadFromRDFGraph(real InMemoryTripleStore) → ShapeRegistry.
+ *
+ * Asserts the two real-vault behaviour changes PR2 introduces:
+ *   1. `exo__Instance_class` is the UID strip-canon `[[<uuid>]]` form
+ *      (proves classRefForm='uuid' + classUid are wired through), NOT the
+ *      legacy `[[ems__Task]]` label form.
+ *   2. wikilink properties are cardinality-aware (proves the lazily-loaded
+ *      shapeRegistry is wired through): Single → scalar, Multiple → YAML array.
+ *
+ * Revert-verify (documented in the PR): reverting EITHER opt-in in
+ * CreateAssetCommand makes this suite fail —
+ *   - drop classRefForm/classUid  → assertion 1 fails (emits `[[ems__Task]]`),
+ *   - drop shapeRegistry          → assertion 2 fails (relatesTo emits scalar).
+ */
+describe("CreateAssetCommand — H3 PR2 plugin opt-in (#3384)", () => {
+  const TASK_UID = "1b20a8f0-d745-4e93-91db-4531b3df120e";
+  const STATUS_UID = "027e78f4-6e16-4b36-b8fb-5510507d5745";
+  const RELATES_UID = "7138261c-f964-4f10-a44e-cb153f14c217";
+
+  let created: Array<{ path: string; content: string }>;
+  let command: CreateAssetCommand;
+  let buildCommand: (sparql?: SPARQLQueryService) => CreateAssetCommand;
+
+  const triple = (
+    s: string,
+    p: string,
+    o: string | { lit: string },
+  ): DomainTriple =>
+    new DomainTriple(
+      new DomainIRI(s),
+      new DomainIRI(p),
+      typeof o === "string" ? new DomainIRI(o) : new DomainLiteral(o.lit),
+    );
+
+  /**
+   * Build an in-memory store holding two SHACL-lite property definitions:
+   * ems__Effort_status (Single) and ems__Effort_relatesTo (Multiple), mirroring
+   * the triple shape NoteToRDFConverter emits for exo:Property* assets.
+   */
+  async function buildStore(): Promise<InMemoryTripleStore> {
+    const RDF_TYPE = Namespace.RDF.term("type").value;
+    const RDFS_DOMAIN = Namespace.RDFS.term("domain").value;
+    const EXO_CARD = Namespace.EXO.term("Property_cardinality").value;
+    const EXO_LABEL = Namespace.EXO.term("Asset_label").value;
+    const OBJ_PROP = Namespace.EXO.term("ObjectProperty").value;
+    const EFFORT = Namespace.EMS.term("Effort").value;
+
+    const statusFile = "obsidian://vault/ems/status-prop.md";
+    const relatesFile = "obsidian://vault/ems/relates-prop.md";
+
+    const store = new InMemoryTripleStore();
+    await store.addAll([
+      // ems__Effort_status — Single cardinality
+      triple(statusFile, RDF_TYPE, OBJ_PROP),
+      triple(statusFile, RDFS_DOMAIN, EFFORT),
+      triple(statusFile, EXO_CARD, `${EXO}PropertyCardinalitySingle`),
+      triple(statusFile, EXO_LABEL, { lit: "ems__Effort_status" }),
+      // ems__Effort_relatesTo — Multiple cardinality
+      triple(relatesFile, RDF_TYPE, OBJ_PROP),
+      triple(relatesFile, RDFS_DOMAIN, EFFORT),
+      triple(relatesFile, EXO_CARD, `${EXO}PropertyCardinalityMultiple`),
+      triple(relatesFile, EXO_LABEL, { lit: "ems__Effort_relatesTo" }),
+    ]);
+    return store;
+  }
+
+  async function run(opts: {
+    selectedClass: DiscoveredClass;
+    sparql?: SPARQLQueryService;
+  }): Promise<void> {
+    (showClassSelectionModal as jest.Mock).mockResolvedValue({
+      selectedClass: opts.selectedClass,
+    });
+    (DynamicAssetCreationModal as unknown as jest.Mock).mockImplementation(
+      (_app: unknown, _className: unknown, resolve: (r: unknown) => void) => ({
+        open: () =>
+          resolve({
+            label: "Test Task",
+            openInNewTab: false,
+            propertyValues: {
+              ems__Effort_status: `[[${STATUS_UID}]]`,
+              ems__Effort_relatesTo: `[[${RELATES_UID}]]`,
+            },
+          }),
+      }),
+    );
+    await command.callback();
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    created = [];
+
+    const vault = {
+      getAbstractFileByPath: jest.fn().mockReturnValue(null),
+      createFolder: jest.fn().mockResolvedValue(undefined),
+      create: jest.fn().mockImplementation((path: string, content: string) => {
+        created.push({ path, content });
+        return Promise.resolve({
+          path,
+          basename: path.split("/").pop()?.replace(".md", "") ?? "",
+          name: path.split("/").pop() ?? "",
+          parent: { path: path.split("/").slice(0, -1).join("/") },
+        });
+      }),
+    } as unknown as IVaultAdapter;
+
+    const service = new GenericAssetCreationService(vault);
+
+    const fakeLeaf = { openFile: jest.fn().mockResolvedValue(undefined) };
+    const app = {
+      workspace: {
+        getLeaf: jest.fn().mockReturnValue(fakeLeaf),
+        setActiveLeaf: jest.fn(),
+      },
+    } as unknown as App;
+
+    const vaultAdapter = {
+      toTFile: jest.fn().mockReturnValue({ path: "x" }),
+    } as unknown as ObsidianVaultAdapter;
+
+    const classDiscoveryService = {
+      getCreatableClasses: jest.fn().mockResolvedValue([]),
+    } as unknown as ClassDiscoveryService;
+
+    const notifier = {
+      success: jest.fn(),
+      error: jest.fn(),
+    } as unknown as INotificationService;
+
+    // Build the command with a real core service + fakes for the Obsidian seams.
+    // The sparqlQueryService is supplied per-test (so we can also assert the
+    // graceful fallback when it is absent).
+    buildCommand = (sparql?: SPARQLQueryService) =>
+      new CreateAssetCommand(
+        app,
+        service,
+        vaultAdapter,
+        classDiscoveryService,
+        notifier,
+        undefined,
+        sparql,
+      );
+  });
+
+  const selectedTask = (classUid?: string): DiscoveredClass => ({
+    className: "ems__Task",
+    label: "Task",
+    deprecated: false,
+    canCreateInstance: true,
+    classUid,
+  });
+
+  it("emits exo__Instance_class as [[<uuid>]] strip-canon + cardinality-aware properties", async () => {
+    const store = await buildStore();
+    const sparql = {
+      isReady: () => true,
+      getTripleStore: () => store,
+    } as unknown as SPARQLQueryService;
+
+    command = buildCommand(sparql);
+    await run({ selectedClass: selectedTask(TASK_UID), sparql });
+
+    expect(created).toHaveLength(1);
+    const content = created[0].content;
+
+    // (1) UID strip-canon class ref — the real-vault behaviour change.
+    expect(content).toContain(`"[[${TASK_UID}]]"`);
+    expect(content).not.toContain('"[[ems__Task]]"');
+
+    // (2) cardinality-aware emission: Single → scalar, Multiple → YAML array.
+    expect(content).toContain(`ems__Effort_status: "[[${STATUS_UID}]]"`);
+    expect(content).toMatch(
+      new RegExp(`ems__Effort_relatesTo:\\n\\s+- "\\[\\[${RELATES_UID}\\]\\]"`),
+    );
+  });
+
+  it("falls back to label form when classUid is absent (discovery gave no uid)", async () => {
+    const store = await buildStore();
+    const sparql = {
+      isReady: () => true,
+      getTripleStore: () => store,
+    } as unknown as SPARQLQueryService;
+
+    command = buildCommand(sparql);
+    await run({ selectedClass: selectedTask(undefined), sparql });
+
+    const content = created[0].content;
+    expect(content).toContain('"[[ems__Task]]"');
+    expect(content).not.toContain(`"[[${TASK_UID}]]"`);
+  });
+
+  it("emits scalar (no array) when the triple store is not ready — non-fatal shape fallback", async () => {
+    const sparql = {
+      isReady: () => false,
+      getTripleStore: jest.fn(),
+    } as unknown as SPARQLQueryService;
+
+    command = buildCommand(sparql);
+    await run({ selectedClass: selectedTask(TASK_UID), sparql });
+
+    const content = created[0].content;
+    // classUid still applies (independent of shapes).
+    expect(content).toContain(`"[[${TASK_UID}]]"`);
+    // No shapes → relatesTo stays scalar (not wrapped in a YAML array).
+    expect(content).not.toMatch(/ems__Effort_relatesTo:\n\s+-/);
+    expect(content).toContain(`ems__Effort_relatesTo: "[[${RELATES_UID}]]"`);
+    // getTripleStore must NOT be touched when the store is not ready.
+    expect(sparql.getTripleStore as jest.Mock).not.toHaveBeenCalled();
+  });
+});

--- a/packages/obsidian-plugin/tests/unit/commands/CreateAssetCommand.test.ts
+++ b/packages/obsidian-plugin/tests/unit/commands/CreateAssetCommand.test.ts
@@ -244,4 +244,26 @@ describe("CreateAssetCommand — H3 PR2 plugin opt-in (#3384)", () => {
     // getTripleStore must NOT be touched when the store is not ready.
     expect(sparql.getTripleStore as jest.Mock).not.toHaveBeenCalled();
   });
+
+  it("swallows a shape-loader throw (non-fatal) — asset still created, scalar fallback", async () => {
+    // isReady() true but the store's match() rejects → ShapeLoader.loadFromRDFGraph
+    // throws → loadShapeRegistry's catch returns undefined → scalar emission, no crash.
+    const explodingStore = {
+      match: jest.fn().mockRejectedValue(new Error("graph walk failed")),
+    };
+    const sparql = {
+      isReady: () => true,
+      getTripleStore: () => explodingStore,
+    } as unknown as SPARQLQueryService;
+
+    command = buildCommand(sparql);
+    await run({ selectedClass: selectedTask(TASK_UID), sparql });
+
+    expect(created).toHaveLength(1);
+    const content = created[0].content;
+    // classUid still applies; property stays scalar (no array) after the fallback.
+    expect(content).toContain(`"[[${TASK_UID}]]"`);
+    expect(content).not.toMatch(/ems__Effort_relatesTo:\n\s+-/);
+    expect(content).toContain(`ems__Effort_relatesTo: "[[${RELATES_UID}]]"`);
+  });
 });

--- a/packages/obsidian-plugin/tests/unit/services/ClassDiscoveryService.test.ts
+++ b/packages/obsidian-plugin/tests/unit/services/ClassDiscoveryService.test.ts
@@ -1,5 +1,6 @@
 import { SPARQLQueryService } from "../../../src/application/services/SPARQLQueryService";
 import { ClassDiscoveryService } from "../../../src/application/services/ClassDiscoveryService";
+import { DomainLiteral as Literal } from "exocortex";
 
 jest.mock("../../../src/application/services/SPARQLQueryService");
 
@@ -37,13 +38,35 @@ describe("ClassDiscoveryService", () => {
         mockSparqlService.query,
         // classQuery results
         [
-          new Map([["class", "obsidian://vault/ems/1b20a8f0-d745-4e93-91db-4531b3df120e.md"]]),
-          new Map([["class", "obsidian://vault/ems/7138261c-f964-4f10-a44e-cb153f14c217.md"]]),
+          new Map([
+            [
+              "class",
+              "obsidian://vault/ems/1b20a8f0-d745-4e93-91db-4531b3df120e.md",
+            ],
+          ]),
+          new Map([
+            [
+              "class",
+              "obsidian://vault/ems/7138261c-f964-4f10-a44e-cb153f14c217.md",
+            ],
+          ]),
         ],
         // labelQuery results
         [
-          new Map([["class", "obsidian://vault/ems/1b20a8f0-d745-4e93-91db-4531b3df120e.md"], ["label", "ems__Task"]]),
-          new Map([["class", "obsidian://vault/ems/7138261c-f964-4f10-a44e-cb153f14c217.md"], ["label", "ems__Area"]]),
+          new Map([
+            [
+              "class",
+              "obsidian://vault/ems/1b20a8f0-d745-4e93-91db-4531b3df120e.md",
+            ],
+            ["label", "ems__Task"],
+          ]),
+          new Map([
+            [
+              "class",
+              "obsidian://vault/ems/7138261c-f964-4f10-a44e-cb153f14c217.md",
+            ],
+            ["label", "ems__Area"],
+          ]),
         ],
       );
 
@@ -66,22 +89,61 @@ describe("ClassDiscoveryService", () => {
       mockDiscoveryQueries(
         mockSparqlService.query,
         [
-          new Map([["class", "obsidian://vault/ems/1b20a8f0-d745-4e93-91db-4531b3df120e.md"]]),
-          new Map([["class", "obsidian://vault/ems/7138261c-f964-4f10-a44e-cb153f14c217.md"]]),
+          new Map([
+            [
+              "class",
+              "obsidian://vault/ems/1b20a8f0-d745-4e93-91db-4531b3df120e.md",
+            ],
+          ]),
+          new Map([
+            [
+              "class",
+              "obsidian://vault/ems/7138261c-f964-4f10-a44e-cb153f14c217.md",
+            ],
+          ]),
         ],
         [
-          new Map([["class", "obsidian://vault/ems/1b20a8f0-d745-4e93-91db-4531b3df120e.md"], ["label", "ems__Task"]]),
-          new Map([["class", "obsidian://vault/ems/7138261c-f964-4f10-a44e-cb153f14c217.md"], ["label", "ems__Area"]]),
+          new Map([
+            [
+              "class",
+              "obsidian://vault/ems/1b20a8f0-d745-4e93-91db-4531b3df120e.md",
+            ],
+            ["label", "ems__Task"],
+          ]),
+          new Map([
+            [
+              "class",
+              "obsidian://vault/ems/7138261c-f964-4f10-a44e-cb153f14c217.md",
+            ],
+            ["label", "ems__Area"],
+          ]),
         ],
-        // uidQuery results
+        // uidQuery results — the uid binding is a production-shaped RDF Literal,
+        // NOT a bare string. Literal.toString() serializes to the quoted
+        // N-Triples form (`"<uid>"`), so this fixture is what guards against the
+        // class ref being corrupted to `[[\"<uid>\"]]` — discoverClasses must
+        // read the lexical `.value`, not `.toString()`.
         [
-          new Map([["class", "obsidian://vault/ems/1b20a8f0-d745-4e93-91db-4531b3df120e.md"], ["uid", "1b20a8f0-d745-4e93-91db-4531b3df120e"]]),
-          new Map([["class", "obsidian://vault/ems/7138261c-f964-4f10-a44e-cb153f14c217.md"], ["uid", "7138261c-f964-4f10-a44e-cb153f14c217"]]),
+          new Map([
+            [
+              "class",
+              "obsidian://vault/ems/1b20a8f0-d745-4e93-91db-4531b3df120e.md",
+            ],
+            ["uid", new Literal("1b20a8f0-d745-4e93-91db-4531b3df120e")],
+          ]),
+          new Map([
+            [
+              "class",
+              "obsidian://vault/ems/7138261c-f964-4f10-a44e-cb153f14c217.md",
+            ],
+            ["uid", new Literal("7138261c-f964-4f10-a44e-cb153f14c217")],
+          ]),
         ],
       );
 
       const classes = await service.discoverClasses();
 
+      // Must be the bare uuid (no surrounding quotes from Literal.toString()).
       expect(classes.find((c) => c.className === "ems__Task")!.classUid).toBe(
         "1b20a8f0-d745-4e93-91db-4531b3df120e",
       );
@@ -93,8 +155,23 @@ describe("ClassDiscoveryService", () => {
     it("should leave classUid undefined when the uid query has no matching binding", async () => {
       mockDiscoveryQueries(
         mockSparqlService.query,
-        [new Map([["class", "obsidian://vault/ems/1b20a8f0-d745-4e93-91db-4531b3df120e.md"]])],
-        [new Map([["class", "obsidian://vault/ems/1b20a8f0-d745-4e93-91db-4531b3df120e.md"], ["label", "ems__Task"]])],
+        [
+          new Map([
+            [
+              "class",
+              "obsidian://vault/ems/1b20a8f0-d745-4e93-91db-4531b3df120e.md",
+            ],
+          ]),
+        ],
+        [
+          new Map([
+            [
+              "class",
+              "obsidian://vault/ems/1b20a8f0-d745-4e93-91db-4531b3df120e.md",
+            ],
+            ["label", "ems__Task"],
+          ]),
+        ],
         [], // no uid bindings → fall back to label form downstream
       );
 
@@ -113,9 +190,18 @@ describe("ClassDiscoveryService", () => {
           new Map([["class", "obsidian://vault/ems/uuid-project.md"]]),
         ],
         [
-          new Map([["class", "obsidian://vault/ems/uuid-task.md"], ["label", "ems__Task"]]),
-          new Map([["class", "obsidian://vault/ems/uuid-area.md"], ["label", "ems__Area"]]),
-          new Map([["class", "obsidian://vault/ems/uuid-project.md"], ["label", "ems__Project"]]),
+          new Map([
+            ["class", "obsidian://vault/ems/uuid-task.md"],
+            ["label", "ems__Task"],
+          ]),
+          new Map([
+            ["class", "obsidian://vault/ems/uuid-area.md"],
+            ["label", "ems__Area"],
+          ]),
+          new Map([
+            ["class", "obsidian://vault/ems/uuid-project.md"],
+            ["label", "ems__Project"],
+          ]),
         ],
       );
 
@@ -129,12 +215,34 @@ describe("ClassDiscoveryService", () => {
       mockDiscoveryQueries(
         mockSparqlService.query,
         [
-          new Map([["class", "obsidian://vault/ems/1b20a8f0-d745-4e93-91db-4531b3df120e.md"]]),
-          new Map([["class", "obsidian://vault/ems/82c74542-1b14-4217-b852-d84730484b25.md"]]),
+          new Map([
+            [
+              "class",
+              "obsidian://vault/ems/1b20a8f0-d745-4e93-91db-4531b3df120e.md",
+            ],
+          ]),
+          new Map([
+            [
+              "class",
+              "obsidian://vault/ems/82c74542-1b14-4217-b852-d84730484b25.md",
+            ],
+          ]),
         ],
         [
-          new Map([["class", "obsidian://vault/ems/1b20a8f0-d745-4e93-91db-4531b3df120e.md"], ["label", "https://exocortex.my/ontology/ems#Task"]]),
-          new Map([["class", "obsidian://vault/ems/82c74542-1b14-4217-b852-d84730484b25.md"], ["label", "https://exocortex.my/ontology/ems#Area"]]),
+          new Map([
+            [
+              "class",
+              "obsidian://vault/ems/1b20a8f0-d745-4e93-91db-4531b3df120e.md",
+            ],
+            ["label", "https://exocortex.my/ontology/ems#Task"],
+          ]),
+          new Map([
+            [
+              "class",
+              "obsidian://vault/ems/82c74542-1b14-4217-b852-d84730484b25.md",
+            ],
+            ["label", "https://exocortex.my/ontology/ems#Area"],
+          ]),
         ],
       );
 
@@ -167,7 +275,12 @@ describe("ClassDiscoveryService", () => {
       mockDiscoveryQueries(
         mockSparqlService.query,
         [new Map([["class", "https://exocortex.my/ontology/ems#Task"]])],
-        [new Map([["class", "https://exocortex.my/ontology/ems#Task"], ["label", "My Task Type"]])],
+        [
+          new Map([
+            ["class", "https://exocortex.my/ontology/ems#Task"],
+            ["label", "My Task Type"],
+          ]),
+        ],
       );
 
       const classes = await service.discoverClasses();
@@ -183,7 +296,12 @@ describe("ClassDiscoveryService", () => {
           new Map([["class", "obsidian://vault/ems/uuid-task.md"]]),
           new Map([["class", "obsidian://vault/ems/uuid-task.md"]]),
         ],
-        [new Map([["class", "obsidian://vault/ems/uuid-task.md"], ["label", "ems__Task"]])],
+        [
+          new Map([
+            ["class", "obsidian://vault/ems/uuid-task.md"],
+            ["label", "ems__Task"],
+          ]),
+        ],
       );
 
       const classes = await service.discoverClasses();
@@ -210,8 +328,14 @@ describe("ClassDiscoveryService", () => {
           new Map([["class", "obsidian://vault/exo/uuid-class.md"]]),
         ],
         [
-          new Map([["class", "obsidian://vault/ems/uuid-task.md"], ["label", "ems__Task"]]),
-          new Map([["class", "obsidian://vault/exo/uuid-class.md"], ["label", "exo__Class"]]),
+          new Map([
+            ["class", "obsidian://vault/ems/uuid-task.md"],
+            ["label", "ems__Task"],
+          ]),
+          new Map([
+            ["class", "obsidian://vault/exo/uuid-class.md"],
+            ["label", "exo__Class"],
+          ]),
         ],
       );
 

--- a/packages/obsidian-plugin/tests/unit/services/ClassDiscoveryService.test.ts
+++ b/packages/obsidian-plugin/tests/unit/services/ClassDiscoveryService.test.ts
@@ -15,18 +15,25 @@ describe("ClassDiscoveryService", () => {
     service = new ClassDiscoveryService(mockSparqlService);
   });
 
-  // Helper: mock two sequential SPARQL calls (classQuery, labelQuery)
-  function mockTwoQueries(
+  // Helper: mock the three sequential SPARQL calls discoverClasses fires in
+  // Promise.all order — classQuery, labelQuery, uidQuery (#3384 H3 PR2 added
+  // the uid query). uidBindings defaults to [] so pre-existing tests that don't
+  // assert classUid keep working (→ classUid undefined → label-form fallback).
+  function mockDiscoveryQueries(
     mock: jest.Mock,
     classBindings: Map<string, unknown>[],
     labelBindings: Map<string, unknown>[],
+    uidBindings: Map<string, unknown>[] = [],
   ): void {
-    mock.mockResolvedValueOnce(classBindings).mockResolvedValueOnce(labelBindings);
+    mock
+      .mockResolvedValueOnce(classBindings)
+      .mockResolvedValueOnce(labelBindings)
+      .mockResolvedValueOnce(uidBindings);
   }
 
   describe("discoverClasses (Issue #2807 + #2810)", () => {
     it("should use exo:Asset_label to resolve className for UUID file IRIs", async () => {
-      mockTwoQueries(
+      mockDiscoveryQueries(
         mockSparqlService.query,
         // classQuery results
         [
@@ -53,8 +60,52 @@ describe("ClassDiscoveryService", () => {
       expect(areaClass!.label).toBe("Area");
     });
 
+    // #3384 H3 PR2 — the uid query populates DiscoveredClass.classUid so the
+    // Create-asset flow can emit `exo__Instance_class: [[<uuid>]]` strip-canon.
+    it("should populate classUid from the uid query, joined by class IRI", async () => {
+      mockDiscoveryQueries(
+        mockSparqlService.query,
+        [
+          new Map([["class", "obsidian://vault/ems/1b20a8f0-d745-4e93-91db-4531b3df120e.md"]]),
+          new Map([["class", "obsidian://vault/ems/7138261c-f964-4f10-a44e-cb153f14c217.md"]]),
+        ],
+        [
+          new Map([["class", "obsidian://vault/ems/1b20a8f0-d745-4e93-91db-4531b3df120e.md"], ["label", "ems__Task"]]),
+          new Map([["class", "obsidian://vault/ems/7138261c-f964-4f10-a44e-cb153f14c217.md"], ["label", "ems__Area"]]),
+        ],
+        // uidQuery results
+        [
+          new Map([["class", "obsidian://vault/ems/1b20a8f0-d745-4e93-91db-4531b3df120e.md"], ["uid", "1b20a8f0-d745-4e93-91db-4531b3df120e"]]),
+          new Map([["class", "obsidian://vault/ems/7138261c-f964-4f10-a44e-cb153f14c217.md"], ["uid", "7138261c-f964-4f10-a44e-cb153f14c217"]]),
+        ],
+      );
+
+      const classes = await service.discoverClasses();
+
+      expect(classes.find((c) => c.className === "ems__Task")!.classUid).toBe(
+        "1b20a8f0-d745-4e93-91db-4531b3df120e",
+      );
+      expect(classes.find((c) => c.className === "ems__Area")!.classUid).toBe(
+        "7138261c-f964-4f10-a44e-cb153f14c217",
+      );
+    });
+
+    it("should leave classUid undefined when the uid query has no matching binding", async () => {
+      mockDiscoveryQueries(
+        mockSparqlService.query,
+        [new Map([["class", "obsidian://vault/ems/1b20a8f0-d745-4e93-91db-4531b3df120e.md"]])],
+        [new Map([["class", "obsidian://vault/ems/1b20a8f0-d745-4e93-91db-4531b3df120e.md"], ["label", "ems__Task"]])],
+        [], // no uid bindings → fall back to label form downstream
+      );
+
+      const classes = await service.discoverClasses();
+
+      expect(classes).toHaveLength(1);
+      expect(classes[0].classUid).toBeUndefined();
+    });
+
     it("should sort classes alphabetically by display label", async () => {
-      mockTwoQueries(
+      mockDiscoveryQueries(
         mockSparqlService.query,
         [
           new Map([["class", "obsidian://vault/ems/uuid-task.md"]]),
@@ -75,7 +126,7 @@ describe("ClassDiscoveryService", () => {
 
     it("should handle exo:Asset_label stored as namespace IRI (#2810)", async () => {
       // NoteToRDFConverter stores "ems__Task" as namespace IRI via isClassReference()
-      mockTwoQueries(
+      mockDiscoveryQueries(
         mockSparqlService.query,
         [
           new Map([["class", "obsidian://vault/ems/1b20a8f0-d745-4e93-91db-4531b3df120e.md"]]),
@@ -99,7 +150,7 @@ describe("ClassDiscoveryService", () => {
     });
 
     it("should fall back to toClassName when no label exists", async () => {
-      mockTwoQueries(
+      mockDiscoveryQueries(
         mockSparqlService.query,
         [new Map([["class", "https://exocortex.my/ontology/ems#Task"]])],
         [], // no labels
@@ -113,7 +164,7 @@ describe("ClassDiscoveryService", () => {
     });
 
     it("should ignore a label value that is not a prefixed class name", async () => {
-      mockTwoQueries(
+      mockDiscoveryQueries(
         mockSparqlService.query,
         [new Map([["class", "https://exocortex.my/ontology/ems#Task"]])],
         [new Map([["class", "https://exocortex.my/ontology/ems#Task"], ["label", "My Task Type"]])],
@@ -126,7 +177,7 @@ describe("ClassDiscoveryService", () => {
     });
 
     it("should dedupe duplicate classes emitted by UNION", async () => {
-      mockTwoQueries(
+      mockDiscoveryQueries(
         mockSparqlService.query,
         [
           new Map([["class", "obsidian://vault/ems/uuid-task.md"]]),
@@ -152,7 +203,7 @@ describe("ClassDiscoveryService", () => {
 
   describe("getCreatableClasses", () => {
     it("should exclude non-instantiable meta-classes", async () => {
-      mockTwoQueries(
+      mockDiscoveryQueries(
         mockSparqlService.query,
         [
           new Map([["class", "obsidian://vault/ems/uuid-task.md"]]),


### PR DESCRIPTION
## Summary

**PR2/2** of epic #3384 H3. The Obsidian **Create asset** command (the button users click) now **opts into** the gated domain fields PR1 (#3397) added to core `GenericAssetCreationService`. This is a **deliberate REAL VAULT change** — the on-disk frontmatter of button-created assets changes form.

⛔ **UI-smoke gated — NOT auto-merged.** Final merge is performed by the orchestrator **after the user smoke-tests** Create-asset in real Obsidian.

### What changed
1. **`exo__Instance_class` → `[[<uuid>]]` strip-canon** (was `[[<className>]]` label form). Wired via `classRefForm: 'uuid'` + `classUid`. `classUid` is resolved during class discovery — `ClassDiscoveryService.discoverClasses()` gained a separate mandatory-join uid query (`SELECT ?class ?uid WHERE { ?class exo:Asset_uid ?uid }`, same proven split-query pattern as the #2810 label query) populating new `DiscoveredClass.classUid`. When absent → core falls back to the label form.
2. **Cardinality-aware property emission** via a SHACL-lite `shapeRegistry`, loaded **lazily on the Create command** (`ShapeLoader.loadFromRDFGraph` over the plugin's already-populated in-memory triple store — `SPARQLQueryService.getTripleStore()`). Single → scalar, Multiple → YAML array.

### ⛔ Strictly lazy — never on onload
Shapes are loaded **only** when the user runs Create (`CreateAssetCommand.loadShapeRegistry()`), guarded by `sparqlQueryService.isReady()`. The onload path is deliberately untouched (it is fragile — recent FocusProfile bootstrap hang). Shape-load failure is **non-fatal** → `undefined` → core's scalar fallback.

### Untouched (byte-identical output)
- `cli apply`, grounding `create_instance`, `ServiceRegistryPopulator`'s `createRelatedTask/Project` — none pass `classRefForm`/`shapeRegistry`. `ClassDiscoveryService` is consumed **only** by the plugin Create button.
- onload.

## Empirical verification of the shapeRegistry side-effect
When `shapeRegistry` is present, core routes **all** property values through the cardinality formatter (`String(value)` passthrough for non-wikilinks) instead of the `PropertyFieldType` formatter. I verified the on-disk impact:
- **Number / Boolean / plain-text**: **byte-identical** (`num: 5`, `flag: true` emit the same unquoted YAML either way).
- **Date-typed only**: shapeRegistry path preserves the literal value (e.g. ISO-UTC `…Z` kept; bare `2026-01-02` kept) instead of `formatTimestamp` normalization. This is **the same emission `cli create` already produces**, narrow (Date fields are rare in the create form), and arguably more faithful to user input. Flagging for reviewer/advisor awareness.

## Test plan
- [x] Behavioral golden test (`CreateAssetCommand.test.ts`) — full chain plugin-config → **real** `GenericAssetCreationService` + **real** `ShapeLoader.loadFromRDFGraph(InMemoryTripleStore)` → asserts `exo__Instance_class: "[[1b20a8f0-…]]"` (NOT `[[ems__Task]]`) + Single→scalar / Multiple→array.
- [x] **Revert-verify**: reverting the opt-in (drop `classRefForm`/`classUid`/`shapeRegistry`) → 2 tests FAIL; restore → 13/13 PASS.
- [x] `ClassDiscoveryService.test.ts` extended: `classUid` populated from uid query; undefined when no uid binding.
- [x] Other paths green unchanged: core `GenericAssetCreationService` 110/110, grounding `create_instance` green, CommandManager 60/60, typecheck 0 errors, eslint(src) clean.
- [ ] **UI-smoke in real Obsidian** (orchestrator + user) — create an asset via the button, confirm `exo__Instance_class: "[[<uuid>]]"` + cardinality, then orchestrator merges.

Epic #3384 · H3 PR2/2.