### PR TITLE
feat(rest-push): transport-agnostic REST commit+push core (no git binary)

### DIFF
--- a/docs/REST_COMMIT_PUSH_POC.md
+++ b/docs/REST_COMMIT_PUSH_POC.md
@@ -1,0 +1,118 @@
+# REST commit+push (no `git` binary) — research note + PoC
+
+**RFC:** `01a83de8` (AssetSpace + Profile — exo as SDK platform) Phase 0 spike.
+**Goal:** prove that commit+push to a GitHub repo works **without the `git`
+binary** (pure GitHub REST API), runnable in the iOS Obsidian plugin runtime,
+shipped behind an opt-in experimental flag, and verified end-to-end.
+
+## TL;DR
+
+- **Use the Git Data API**, not the Contents API. It is the only way to put
+  **multiple files into one atomic commit**, and it is exactly what the plugin's
+  `GitHubRestClient.createCommit` already does.
+- **Transport is the only platform-specific piece.** The plugin uses Obsidian
+  `requestUrl` (iOS-safe); the CLI uses Node `fetch`. Both are valid HTTP
+  transports for the identical 4-call sequence.
+- **This PR extracts a transport-agnostic REST-commit core** (`restCreateCommit`
+  in `packages/exocortex`) and rewires **both** consumers onto it: the plugin
+  (`createCommit` delegates) and a new CLI `experimental rest-push` command.
+  One implementation, two transports — the production-grade, iOS-portable path.
+- **The remaining iOS gap is NOT push** — push is done. The iOS-incompatible
+  code is the `git`-binary **mount/unmount** layer (`GitSubmoduleOps`,
+  `execFile("git", …)`). That is **RFC Phase 3**, out of scope for this PoC.
+
+## Contents API vs Git Data API
+
+|                                                                                                     | Contents API (`PUT /repos/{o}/{r}/contents/{path}`)     | Git Data API (refs → trees → commits → refs) |
+| --------------------------------------------------------------------------------------------------- | ------------------------------------------------------- | -------------------------------------------- |
+| Files per commit                                                                                    | **1** (one PUT = one commit)                            | **N** (one tree = many blobs, one commit)    |
+| Atomicity for a multi-file change                                                                   | ✗ (N commits, partial-failure leaves repo half-written) | ✓ (single commit, all-or-nothing)            |
+| Round-trips                                                                                         | 1 per file (+ a GET for each existing file's blob SHA)  | 4 total regardless of file count             |
+| Commit-message control                                                                              | per-file                                                | one message for the whole change             |
+| Matches `AssetSpace.pushAssetSpace` semantics (push all dirty files of an AssetSpace as one commit) | ✗                                                       | ✓                                            |
+
+**Recommendation: Git Data API.** An AssetSpace push is inherently multi-file
+("push all dirty files as one commit"), so the Contents API's one-file-per-call
+model is both slower (N+ round-trips) and non-atomic (a mid-sequence failure
+leaves the branch in a partially-written state). The Git Data API commits the
+whole set atomically in a fixed 4 calls.
+
+### The 4-call chain (what `restCreateCommit` does)
+
+```
+1. GET   /repos/{o}/{r}/git/refs/heads/{branch}   → base ref SHA
+2. POST  /repos/{o}/{r}/git/trees                 → new tree SHA (base_tree + N blobs)
+3. POST  /repos/{o}/{r}/git/commits               → new commit SHA (parent = base)
+4. PATCH /repos/{o}/{r}/git/refs/heads/{branch}   → fast-forward ref (force:false)
+```
+
+Partial-failure contract: if 1–3 succeed but 4 fails (race / non-fast-forward),
+the remote holds an **orphan commit** reachable only by the returned SHA; git GC
+reaps it after ~30 days. Safe to retry. Not safe for concurrent writers without
+locking. (Single-writer assumption holds for the Exocortex AssetSpace use-case.)
+
+## Transport portability
+
+The 4-call chain is HTTP-only — no git binary, no filesystem. The only
+platform-specific dependency is _how an HTTP request is issued_:
+
+| Runtime                               | Transport                   | Notes                             |
+| ------------------------------------- | --------------------------- | --------------------------------- |
+| Obsidian plugin (desktop **and iOS**) | `requestUrl` (Obsidian API) | iOS-safe; no Node, no CORS issues |
+| CLI / Node                            | `fetch` (Node 18+ global)   | desktop only; no Obsidian dep     |
+
+So the **iOS-portable design** is: keep the 4-call orchestration + payload
+shapes + validation in one place, and **inject the transport**. That is exactly
+what this PR ships.
+
+## What this PR delivers (the extraction, not just a recommendation)
+
+- **`packages/exocortex/src/infrastructure/github/restCommit.ts`** —
+  `restCreateCommit(transport, { owner, repo, branch, files, message, baseURL?, redact? })`.
+  Pure, platform-free. The transport contract: **throw on non-2xx**; the core
+  only navigates successful-response JSON shapes.
+- **Plugin rewire:** `GitHubRestClient.createCommit` now delegates to the core,
+  supplying a `requestUrl`-backed transport + its PAT redactor. All 74 existing
+  `GitHubRestClient` tests stay green (the 7 `createCommit` behavioural tests are
+  the revert→fail/restore→pass safety net — breaking the core fails the plugin
+  tests, proving real delegation).
+- **CLI:** `RestPushService` (a `fetch`-backed transport with PAT redaction +
+  `gh auth token` resolution) + `exocortex experimental rest-push` command,
+  gated behind `EXOCORTEX_EXPERIMENTAL_REST_PUSH=1` or `--experimental`.
+- **Tests:** core 4-call sequence + payloads with production-shaped responses
+  (mock transport); CLI fetch-adapter (mock fetch: auth header, redaction,
+  error surfacing, gh-token); CLI command logic (gate, validation, DI fakes).
+
+## Security
+
+PAT handling mirrors the existing `GitHubRestClient` / `BootstrapAssetSpaceService`:
+classic + fine-grained token redaction on every error string, `Authorization`
+attached only when a token is present, token never logged. The CLI resolves the
+PAT at runtime via `gh auth token` (`--token-from-gh`) and never prints it.
+
+## Usage (experimental, opt-in)
+
+```bash
+EXOCORTEX_EXPERIMENTAL_REST_PUSH=1 \
+  npx @kitelev/exocortex-cli experimental rest-push \
+  --repo kitelev/exoas-restapi-poc \
+  --branch main \
+  --file poc.md \
+  --content "committed via pure REST, no git binary" \
+  --message "test: REST commit+push PoC" \
+  --token-from-gh
+# → prints commit SHA + https://github.com/<owner>/<repo>/commit/<sha>
+```
+
+Default OFF: without the env var or `--experimental`, the command refuses to run.
+Normal users are unaffected.
+
+## The remaining iOS gap (RFC Phase 3, NOT this PoC)
+
+Write-back (commit+push) is now proven iOS-portable. The piece that still
+requires the `git` binary — and therefore does **not** run on iOS — is
+**mount/unmount** of AssetSpaces (`GitSubmoduleOps`, `execFile("git", …)`,
+desktop-gated). RFC Phase 3 replaces that with REST/tarball:
+pull via `fetchTarballBuffer`, write via the vault adapter, `.gitmodules` /
+mount-manifest as plain-text edits (as `BootstrapAssetSpaceService` already
+does), and push via this same `restCreateCommit` core.

--- a/packages/cli/src/commands/experimental.ts
+++ b/packages/cli/src/commands/experimental.ts
@@ -236,8 +236,12 @@ export function restPushCommand(): Command {
         process.exit(0);
       } catch (e) {
         // Redact any PAT that slipped into the error before ErrorHandler prints.
+        // Both message AND stack: ErrorHandler prints err.stack in debug mode,
+        // and a frozen stack can retain the original unredacted message.
         const err = e instanceof Error ? e : new Error(String(e));
-        err.message = new RestPushService().redact(err.message);
+        const redactor = new RestPushService();
+        err.message = redactor.redact(err.message);
+        if (err.stack) err.stack = redactor.redact(err.stack);
         ErrorHandler.handle(err);
       }
     });

--- a/packages/cli/src/commands/experimental.ts
+++ b/packages/cli/src/commands/experimental.ts
@@ -1,0 +1,244 @@
+import { Command } from "commander";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { RestPushService } from "../services/RestPushService.js";
+import { ErrorHandler } from "../utils/ErrorHandler.js";
+import { InvalidArgumentsError } from "../utils/errors/index.js";
+
+/**
+ * `exocortex experimental` — opt-in unstable features.
+ *
+ * Everything under this verb is gated behind `EXOCORTEX_EXPERIMENTAL_REST_PUSH=1`
+ * (env) OR `--experimental` (flag). Default OFF — normal users are unaffected.
+ * APIs here may change or be removed without a major-version bump.
+ */
+export function experimentalCommand(): Command {
+  const cmd = new Command("experimental").description(
+    "Opt-in experimental features (gated by EXOCORTEX_EXPERIMENTAL_REST_PUSH=1 or --experimental). Unstable — may change or be removed.",
+  );
+  cmd.addCommand(restPushCommand());
+  return cmd;
+}
+
+export interface RestPushOptions {
+  repo: string;
+  branch: string;
+  file: string;
+  content?: string;
+  contentFile?: string;
+  message: string;
+  tokenFromGh?: boolean;
+  token?: string;
+  experimental?: boolean;
+  apiBase?: string;
+  json?: boolean;
+}
+
+/** Minimal push-capable surface — lets tests inject a fake service. */
+export interface RestPusher {
+  push(
+    owner: string,
+    repo: string,
+    branch: string,
+    files: Map<string, string>,
+    message: string,
+  ): Promise<string>;
+}
+
+/** Injectable dependencies for `runRestPush` (all default to real impls). */
+export interface RestPushDeps {
+  serviceFactory?: (opts: { token: string; apiBase?: string }) => RestPusher;
+  ghTokenRunner?: () => string;
+  readFileImpl?: (path: string) => string;
+  env?: NodeJS.ProcessEnv;
+}
+
+export interface RestPushResult {
+  ok: true;
+  repo: string;
+  branch: string;
+  file: string;
+  sha: string;
+  url: string;
+  transport: "fetch";
+  method: "git-data-api";
+}
+
+/** Flag gate: env var `=1` OR `--experimental`. */
+export function experimentalEnabled(
+  opts: RestPushOptions,
+  env: NodeJS.ProcessEnv = process.env,
+): boolean {
+  return (
+    opts.experimental === true || env.EXOCORTEX_EXPERIMENTAL_REST_PUSH === "1"
+  );
+}
+
+/** Split `owner/repo` into segments; throw on malformed input. */
+export function parseRepoSlug(slug: string): { owner: string; repo: string } {
+  if (typeof slug !== "string" || slug.length === 0) {
+    throw new InvalidArgumentsError("--repo is required (owner/repo)");
+  }
+  const parts = slug.split("/");
+  if (parts.length !== 2 || parts[0].length === 0 || parts[1].length === 0) {
+    throw new InvalidArgumentsError(
+      `--repo must be exactly <owner>/<repo>, got: ${slug}`,
+    );
+  }
+  const [owner, repo] = parts;
+  // Mirror plugin requireOwnerRepo allowlist — block path-traversal / flag shapes.
+  if (/[^a-zA-Z0-9_-]/.test(owner) || /[^a-zA-Z0-9_.-]/.test(repo)) {
+    throw new InvalidArgumentsError(
+      `--repo has invalid characters in owner/repo: ${slug}`,
+    );
+  }
+  if (
+    owner === ".." ||
+    repo === ".." ||
+    repo.startsWith(".") ||
+    repo.startsWith("-") ||
+    owner.startsWith("-")
+  ) {
+    throw new InvalidArgumentsError(
+      `--repo has path-traversal/flag pattern: ${slug}`,
+    );
+  }
+  return { owner, repo };
+}
+
+/**
+ * Pure (testable) core of the rest-push command: validate, resolve content +
+ * token, push via the (injectable) service, return a structured result. No
+ * `process.exit`, no direct env/fs/network coupling — all injected.
+ */
+export async function runRestPush(
+  options: RestPushOptions,
+  deps: RestPushDeps = {},
+): Promise<RestPushResult> {
+  const env = deps.env ?? process.env;
+  const readFileImpl =
+    deps.readFileImpl ?? ((p: string) => readFileSync(resolve(p), "utf8"));
+  const serviceFactory =
+    deps.serviceFactory ?? ((opts) => new RestPushService(opts));
+
+  if (!experimentalEnabled(options, env)) {
+    throw new InvalidArgumentsError(
+      "rest-push is experimental and opt-in. Enable with EXOCORTEX_EXPERIMENTAL_REST_PUSH=1 or pass --experimental.",
+    );
+  }
+
+  const { owner, repo } = parseRepoSlug(options.repo);
+  const branch = options.branch || "main";
+
+  if (typeof options.message !== "string" || options.message.length === 0) {
+    throw new InvalidArgumentsError("--message is required");
+  }
+  if (typeof options.file !== "string" || options.file.length === 0) {
+    throw new InvalidArgumentsError("--file is required");
+  }
+
+  // Resolve content: --content inline OR --content-file from disk. Exactly one.
+  if (options.content !== undefined && options.contentFile !== undefined) {
+    throw new InvalidArgumentsError(
+      "Pass exactly one of --content or --content-file, not both",
+    );
+  }
+  let content: string;
+  if (options.content !== undefined) {
+    content = options.content;
+  } else if (options.contentFile !== undefined) {
+    content = readFileImpl(options.contentFile);
+  } else {
+    throw new InvalidArgumentsError(
+      "Provide file content via --content <text> or --content-file <localPath>",
+    );
+  }
+
+  // Token precedence: --token-from-gh > --token > GITHUB_TOKEN > GH_TOKEN.
+  // `||` (not `??`) so an empty-string env var falls through.
+  let token: string | undefined;
+  if (options.tokenFromGh) {
+    token = RestPushService.resolveGhToken(deps.ghTokenRunner);
+  } else {
+    token = options.token || env.GITHUB_TOKEN || env.GH_TOKEN || undefined;
+  }
+  if (!token) {
+    throw new InvalidArgumentsError(
+      "A GitHub token is required to push. Use --token-from-gh, --token <pat>, or set GITHUB_TOKEN / GH_TOKEN.",
+    );
+  }
+
+  const svc = serviceFactory({ token, apiBase: options.apiBase });
+  const files = new Map<string, string>([[options.file, content]]);
+  const sha = await svc.push(owner, repo, branch, files, options.message);
+
+  return {
+    ok: true,
+    repo: `${owner}/${repo}`,
+    branch,
+    file: options.file,
+    sha,
+    url: `https://github.com/${owner}/${repo}/commit/${sha}`,
+    transport: "fetch",
+    method: "git-data-api",
+  };
+}
+
+/**
+ * `exocortex experimental rest-push` — commit+push a file to GitHub via pure
+ * REST (no `git` binary). RFC 01a83de8 Phase 0 PoC: de-risks iOS write-back.
+ */
+export function restPushCommand(): Command {
+  return new Command("rest-push")
+    .description(
+      "EXPERIMENTAL: commit+push a file to a GitHub repo via pure REST Git Data API (no git binary). Gated behind EXOCORTEX_EXPERIMENTAL_REST_PUSH=1 or --experimental.",
+    )
+    .requiredOption("--repo <owner/repo>", "Target repo as owner/repo")
+    .option("--branch <branch>", "Branch to commit on", "main")
+    .requiredOption("--file <repoPath>", "Path WITHIN the repo to write")
+    .option("--content <text>", "Inline file content")
+    .option("--content-file <localPath>", "Read file content from a local path")
+    .requiredOption("--message <msg>", "Commit message")
+    .option(
+      "--token-from-gh",
+      "Resolve PAT via `gh auth token` (GitHub CLI must be authenticated)",
+      false,
+    )
+    .option(
+      "--token <pat>",
+      "GitHub PAT (or env GITHUB_TOKEN / GH_TOKEN). Prefer --token-from-gh.",
+    )
+    .option(
+      "--experimental",
+      "Opt into experimental command (alternative to EXOCORTEX_EXPERIMENTAL_REST_PUSH=1)",
+      false,
+    )
+    .option("--api-base <url>", "GitHub API base URL", "https://api.github.com")
+    .option("--json", "Emit result as JSON", false)
+    .action(async (options: RestPushOptions) => {
+      try {
+        if (options.json) {
+          ErrorHandler.setFormat("json");
+        }
+        process.stderr.write(
+          `[rest-push] Committing ${options.file} → ${options.repo}@${options.branch} via REST (no git binary)...\n`,
+        );
+        const result = await runRestPush(options);
+        if (options.json) {
+          process.stdout.write(JSON.stringify(result, null, 2) + "\n");
+        } else {
+          process.stdout.write(`\n✓ Pushed via REST (no git binary)\n`);
+          process.stdout.write(`  Repo:   ${result.repo}@${result.branch}\n`);
+          process.stdout.write(`  File:   ${result.file}\n`);
+          process.stdout.write(`  Commit: ${result.sha}\n`);
+          process.stdout.write(`  URL:    ${result.url}\n`);
+        }
+        process.exit(0);
+      } catch (e) {
+        // Redact any PAT that slipped into the error before ErrorHandler prints.
+        const err = e instanceof Error ? e : new Error(String(e));
+        err.message = new RestPushService().redact(err.message);
+        ErrorHandler.handle(err);
+      }
+    });
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -23,6 +23,7 @@ import { auditCommand } from "./commands/audit.js";
 import { hardSwitchCommand } from "./commands/hard-switch.js";
 import { bootstrapCommand } from "./commands/bootstrap.js";
 import { assetSpaceAddCommand } from "./commands/assetspace-add.js";
+import { experimentalCommand } from "./commands/experimental.js";
 
 // Version injected at build time by esbuild (see esbuild.config.mjs)
 declare const __CLI_VERSION__: string;
@@ -73,6 +74,9 @@ export function createProgram(version?: string): Command {
   // RFC 13da049f Phase 6.2 + 6.3 — Bootstrap + Add AssetSpace CLI
   program.addCommand(bootstrapCommand());
   program.addCommand(assetSpaceAddCommand());
+
+  // RFC 01a83de8 Phase 0 — experimental REST commit+push PoC (opt-in, no git binary)
+  program.addCommand(experimentalCommand());
 
   return program;
 }

--- a/packages/cli/src/services/RestPushService.ts
+++ b/packages/cli/src/services/RestPushService.ts
@@ -1,0 +1,187 @@
+/**
+ * CLI REST commit+push service (experimental, RFC 01a83de8 Phase 0 PoC).
+ *
+ * Proves commit+push to a GitHub repo works WITHOUT the `git` binary — pure
+ * GitHub Git Data API over Node `fetch`. The 4-call orchestration lives in the
+ * shared transport-agnostic `restCreateCommit` core (`exocortex` package); this
+ * service only supplies the `fetch`-backed transport + PAT redaction + `gh
+ * auth token` resolution. The Obsidian plugin reuses the SAME core over a
+ * `requestUrl` transport (`GitHubRestClient.createCommit`) — single
+ * implementation, two platforms (iOS-portable path, de-risks RFC Phase 3).
+ *
+ * Security parity with plugin GitHubRestClient / BootstrapAssetSpaceService:
+ *  - PAT redaction on every error string (classic + fine-grained tokens).
+ *  - Token never logged; Authorization header attached only when present.
+ *  - 60s fetch timeout (no indefinite hang on stalled GitHub response).
+ */
+
+import { execFileSync } from "node:child_process";
+import {
+  restCreateCommit,
+  type RestCommitTransport,
+  type RestCommitResponse,
+} from "exocortex";
+
+export interface RestPushServiceOptions {
+  /** GitHub PAT. Empty/undefined → unauthenticated (push WILL fail — auth required). */
+  token?: string;
+  /** Override fetch implementation for tests. Defaults to global fetch. */
+  fetchImpl?: typeof fetch;
+  /** Override GitHub API base. Defaults to https://api.github.com. */
+  apiBase?: string;
+}
+
+/** Injectable runner for `gh auth token` (tests stub this). */
+export type GhTokenRunner = () => string;
+
+const FETCH_TIMEOUT_MS = 60_000;
+
+export class RestPushService {
+  // Mirrors plugin GitHubRestClient.PAT_REGEX + BootstrapAssetSpaceService.
+  // Classic family (ghp_/gho_/ghu_/ghs_/ghr_, 36+ urlsafe) + fine-grained
+  // github_pat_<22+ id>_<59+ secret>. Redacts tokens leaked into error text.
+  private static readonly PAT_REGEX =
+    /(?:gh[pousr]_[A-Za-z0-9_]{36,}|github_pat_[A-Za-z0-9_]{22,}_[A-Za-z0-9_]{59,})/g;
+
+  private readonly fetchImpl: typeof fetch;
+  private readonly token: string;
+  private readonly apiBase: string;
+
+  constructor(opts: RestPushServiceOptions = {}) {
+    this.fetchImpl = opts.fetchImpl ?? globalThis.fetch;
+    this.token = opts.token ?? "";
+    this.apiBase = (opts.apiBase ?? "https://api.github.com").replace(
+      /\/$/,
+      "",
+    );
+  }
+
+  /**
+   * Resolve a PAT via `gh auth token`. Injectable runner for tests. Trims
+   * trailing newline. Throws a redacted, actionable error if `gh` is missing
+   * or unauthenticated.
+   */
+  static resolveGhToken(runner?: GhTokenRunner): string {
+    const run: GhTokenRunner =
+      runner ??
+      ((): string =>
+        execFileSync("gh", ["auth", "token"], {
+          encoding: "utf8",
+          timeout: 15_000,
+        }));
+    let raw: string;
+    try {
+      raw = run();
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      throw new Error(
+        `RestPushService: \`gh auth token\` failed — is GitHub CLI installed and authenticated? (run \`gh auth login\`). Underlying: ${msg}`.replace(
+          RestPushService.PAT_REGEX,
+          "***REDACTED***",
+        ),
+      );
+    }
+    const token = raw.trim();
+    if (token.length === 0) {
+      throw new Error(
+        "RestPushService: `gh auth token` returned empty output — not authenticated. Run `gh auth login`.",
+      );
+    }
+    return token;
+  }
+
+  /** Replace any PAT-shaped substring with ***REDACTED***. Idempotent. */
+  redact(message: unknown): string {
+    const s = typeof message === "string" ? message : String(message);
+    return s.replace(RestPushService.PAT_REGEX, "***REDACTED***");
+  }
+
+  /**
+   * Commit+push the given files to `owner/repo@branch` via the shared 4-call
+   * REST core. Returns the new commit SHA.
+   */
+  async push(
+    owner: string,
+    repo: string,
+    branch: string,
+    files: Map<string, string>,
+    message: string,
+  ): Promise<string> {
+    return restCreateCommit(this.buildTransport(), {
+      owner,
+      repo,
+      branch,
+      files,
+      message,
+      baseURL: this.apiBase,
+      redact: (m) => this.redact(m),
+    });
+  }
+
+  /**
+   * Build a `fetch`-backed transport with plugin-parity semantics: throws on
+   * any non-2xx status (the core's transport contract), redacts PATs in all
+   * error strings, returns `{ status, json, text }`.
+   */
+  private buildTransport(): RestCommitTransport {
+    const token = this.token;
+    const fetchImpl = this.fetchImpl;
+    const redact = (m: string): string => this.redact(m);
+    return async (req): Promise<RestCommitResponse> => {
+      const headers: Record<string, string> = {
+        Accept: "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+        "User-Agent": "exocortex-cli",
+      };
+      if (token.length > 0) {
+        headers.Authorization = `Bearer ${token}`;
+      }
+      if (req.contentType) {
+        headers["Content-Type"] = req.contentType;
+      }
+      let resp: Awaited<ReturnType<typeof fetch>>;
+      try {
+        resp = await fetchImpl(req.url, {
+          method: req.method,
+          headers,
+          body: req.body,
+          signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+        });
+      } catch (err) {
+        throw new Error(redact(`GitHub request failed: ${errMsg(err)}`));
+      }
+      const text = await resp.text().catch(() => "");
+      if (resp.status < 200 || resp.status >= 300) {
+        throw new Error(
+          truncate(
+            redact(
+              `GitHub request ${req.method} ${req.url} → HTTP ${resp.status}: ${text}`,
+            ),
+            512,
+          ),
+        );
+      }
+      let json: unknown;
+      try {
+        json = text.length > 0 ? JSON.parse(text) : undefined;
+      } catch {
+        json = undefined;
+      }
+      return { status: resp.status, json, text };
+    };
+  }
+}
+
+function errMsg(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  if (typeof err === "string") return err;
+  try {
+    return JSON.stringify(err);
+  } catch {
+    return String(err);
+  }
+}
+
+function truncate(s: string, n: number): string {
+  return s.length > n ? s.slice(0, n) + "..." : s;
+}

--- a/packages/cli/tests/unit/commands/experimental.test.ts
+++ b/packages/cli/tests/unit/commands/experimental.test.ts
@@ -1,0 +1,203 @@
+/**
+ * @jest-environment node
+ *
+ * Unit tests for the `experimental rest-push` command logic (RFC 01a83de8
+ * Phase 0). Exercises the pure `runRestPush` core with an injected fake
+ * pusher + injected env/fs/gh-token — no process.exit, no network.
+ */
+import {
+  runRestPush,
+  parseRepoSlug,
+  experimentalEnabled,
+  type RestPushOptions,
+  type RestPusher,
+} from "../../../src/commands/experimental";
+
+const FAKE_PAT = "ghp_" + "B".repeat(36);
+const COMMIT_SHA = "1122334455667788990011223344556677889900";
+
+function baseOptions(over: Partial<RestPushOptions> = {}): RestPushOptions {
+  return {
+    repo: "kitelev/exoas-restapi-poc",
+    branch: "main",
+    file: "poc.md",
+    content: "hello from REST",
+    message: "test: poc commit",
+    token: FAKE_PAT,
+    experimental: true,
+    apiBase: "https://api.github.com",
+    ...over,
+  };
+}
+
+function fakePusher(): { pusher: RestPusher; calls: unknown[][] } {
+  const calls: unknown[][] = [];
+  const pusher: RestPusher = {
+    push: (...args) => {
+      calls.push(args);
+      return Promise.resolve(COMMIT_SHA);
+    },
+  };
+  return { pusher, calls };
+}
+
+describe("experimental rest-push", () => {
+  describe("experimentalEnabled gate", () => {
+    it("is false by default (no flag, no env)", () => {
+      expect(
+        experimentalEnabled(baseOptions({ experimental: false }), {}),
+      ).toBe(false);
+    });
+    it("is true via --experimental flag", () => {
+      expect(experimentalEnabled(baseOptions({ experimental: true }), {})).toBe(
+        true,
+      );
+    });
+    it("is true via EXOCORTEX_EXPERIMENTAL_REST_PUSH=1 env", () => {
+      expect(
+        experimentalEnabled(baseOptions({ experimental: false }), {
+          EXOCORTEX_EXPERIMENTAL_REST_PUSH: "1",
+        }),
+      ).toBe(true);
+    });
+  });
+
+  describe("parseRepoSlug", () => {
+    it("splits owner/repo", () => {
+      expect(parseRepoSlug("kitelev/exoas-restapi-poc")).toEqual({
+        owner: "kitelev",
+        repo: "exoas-restapi-poc",
+      });
+    });
+    it("rejects missing slash", () => {
+      expect(() => parseRepoSlug("kitelev")).toThrow(/exactly <owner>\/<repo>/);
+    });
+    it("rejects three segments", () => {
+      expect(() => parseRepoSlug("a/b/c")).toThrow(/exactly <owner>\/<repo>/);
+    });
+    it("rejects path-traversal", () => {
+      expect(() => parseRepoSlug("../x")).toThrow(
+        /invalid characters|path-traversal/,
+      );
+    });
+    it("rejects flag-shaped owner", () => {
+      expect(() => parseRepoSlug("-evil/repo")).toThrow(/path-traversal\/flag/);
+    });
+  });
+
+  describe("runRestPush", () => {
+    it("pushes inline --content and returns a structured result", async () => {
+      const { pusher, calls } = fakePusher();
+      const result = await runRestPush(baseOptions(), {
+        serviceFactory: () => pusher,
+        env: {},
+      });
+      expect(result).toEqual({
+        ok: true,
+        repo: "kitelev/exoas-restapi-poc",
+        branch: "main",
+        file: "poc.md",
+        sha: COMMIT_SHA,
+        url: `https://github.com/kitelev/exoas-restapi-poc/commit/${COMMIT_SHA}`,
+        transport: "fetch",
+        method: "git-data-api",
+      });
+      // Verify the file map carried path → content.
+      const [, , , filesArg] = calls[0] as [
+        string,
+        string,
+        string,
+        Map<string, string>,
+        string,
+      ];
+      expect(filesArg.get("poc.md")).toBe("hello from REST");
+    });
+
+    it("reads content from --content-file when --content absent", async () => {
+      const { pusher } = fakePusher();
+      const result = await runRestPush(
+        baseOptions({ content: undefined, contentFile: "/tmp/whatever.md" }),
+        {
+          serviceFactory: () => pusher,
+          readFileImpl: (p) => `from-file:${p}`,
+          env: {},
+        },
+      );
+      expect(result.sha).toBe(COMMIT_SHA);
+    });
+
+    it("resolves token via gh when --token-from-gh", async () => {
+      const { pusher } = fakePusher();
+      let capturedToken = "";
+      const result = await runRestPush(
+        baseOptions({ tokenFromGh: true, token: undefined }),
+        {
+          serviceFactory: (opts) => {
+            capturedToken = opts.token;
+            return pusher;
+          },
+          ghTokenRunner: () => `${FAKE_PAT}\n`,
+          env: {},
+        },
+      );
+      expect(result.sha).toBe(COMMIT_SHA);
+      expect(capturedToken).toBe(FAKE_PAT);
+    });
+
+    it("falls back to GITHUB_TOKEN env when no flags", async () => {
+      const { pusher } = fakePusher();
+      let capturedToken = "";
+      await runRestPush(baseOptions({ token: undefined }), {
+        serviceFactory: (opts) => {
+          capturedToken = opts.token;
+          return pusher;
+        },
+        env: { GITHUB_TOKEN: FAKE_PAT },
+      });
+      expect(capturedToken).toBe(FAKE_PAT);
+    });
+
+    it("rejects when experimental gate is off", async () => {
+      await expect(
+        runRestPush(baseOptions({ experimental: false }), { env: {} }),
+      ).rejects.toThrow(/experimental and opt-in/);
+    });
+
+    it("rejects both --content and --content-file", async () => {
+      await expect(
+        runRestPush(baseOptions({ content: "a", contentFile: "b" }), {
+          env: {},
+        }),
+      ).rejects.toThrow(/exactly one of --content or --content-file/);
+    });
+
+    it("rejects when no content source is given", async () => {
+      await expect(
+        runRestPush(
+          baseOptions({ content: undefined, contentFile: undefined }),
+          {
+            env: {},
+          },
+        ),
+      ).rejects.toThrow(/Provide file content/);
+    });
+
+    it("rejects when no token can be resolved", async () => {
+      await expect(
+        runRestPush(baseOptions({ token: undefined }), { env: {} }),
+      ).rejects.toThrow(/token is required to push/);
+    });
+
+    it("rejects an empty message", async () => {
+      await expect(
+        runRestPush(baseOptions({ message: "" }), { env: {} }),
+      ).rejects.toThrow(/--message is required/);
+    });
+
+    it("rejects an empty file path", async () => {
+      await expect(
+        runRestPush(baseOptions({ file: "" }), { env: {} }),
+      ).rejects.toThrow(/--file is required/);
+    });
+  });
+});

--- a/packages/cli/tests/unit/services/RestPushService.test.ts
+++ b/packages/cli/tests/unit/services/RestPushService.test.ts
@@ -1,0 +1,151 @@
+/**
+ * @jest-environment node
+ *
+ * Unit tests for RestPushService (CLI REST commit+push, RFC 01a83de8 Phase 0).
+ * Uses a mocked `fetch` returning production-shaped GitHub Git Data API
+ * responses — NOT stub-any — so the fetch transport adapter is exercised
+ * against the real response shapes the core navigates.
+ */
+import { describe, it, expect, jest } from "@jest/globals";
+import { RestPushService } from "../../../src/services/RestPushService";
+
+const BASE_SHA = "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0";
+const TREE_SHA = "0fedcba9876543210fedcba9876543210fedcba9";
+const COMMIT_SHA = "9988776655443322110099887766554433221100";
+const FAKE_PAT = "ghp_" + "A".repeat(36);
+
+/** Minimal Response-like object satisfying what the transport reads. */
+function res(status: number, body: unknown): Response {
+  const text = typeof body === "string" ? body : JSON.stringify(body);
+  return {
+    status,
+    ok: status >= 200 && status < 300,
+    text: () => Promise.resolve(text),
+  } as unknown as Response;
+}
+
+function happyFetch(): jest.Mock {
+  return jest
+    .fn()
+    .mockResolvedValueOnce(res(200, { object: { sha: BASE_SHA } }))
+    .mockResolvedValueOnce(res(201, { sha: TREE_SHA }))
+    .mockResolvedValueOnce(res(201, { sha: COMMIT_SHA }))
+    .mockResolvedValueOnce(res(200, { object: { sha: COMMIT_SHA } }));
+}
+
+describe("RestPushService", () => {
+  describe("push (4-call REST chain over fetch)", () => {
+    it("commits + returns the new commit sha", async () => {
+      const fetchImpl = happyFetch();
+      const svc = new RestPushService({ token: FAKE_PAT, fetchImpl });
+      const files = new Map([["docs/a.md", "hello"]]);
+      const sha = await svc.push("o", "r", "main", files, "msg");
+      expect(sha).toBe(COMMIT_SHA);
+      expect(fetchImpl).toHaveBeenCalledTimes(4);
+    });
+
+    it("attaches the Authorization + GitHub headers", async () => {
+      const fetchImpl = happyFetch();
+      const svc = new RestPushService({ token: FAKE_PAT, fetchImpl });
+      await svc.push("o", "r", "main", new Map([["f", "c"]]), "m");
+      const [, init] = fetchImpl.mock.calls[0];
+      expect(init.headers.Authorization).toBe(`Bearer ${FAKE_PAT}`);
+      expect(init.headers.Accept).toBe("application/vnd.github+json");
+      expect(init.headers["X-GitHub-Api-Version"]).toBe("2022-11-28");
+      expect(init.headers["User-Agent"]).toBe("exocortex-cli");
+      // GET ref has no body → no Content-Type.
+      expect(init.headers["Content-Type"]).toBeUndefined();
+      // POST tree DOES set Content-Type.
+      const [, treeInit] = fetchImpl.mock.calls[1];
+      expect(treeInit.headers["Content-Type"]).toBe("application/json");
+      expect(treeInit.method).toBe("POST");
+    });
+
+    it("omits Authorization when token is empty (anonymous)", async () => {
+      const fetchImpl = happyFetch();
+      const svc = new RestPushService({ token: "", fetchImpl });
+      await svc.push("o", "r", "main", new Map([["f", "c"]]), "m");
+      const [, init] = fetchImpl.mock.calls[0];
+      expect(init.headers.Authorization).toBeUndefined();
+    });
+
+    it("hits the configured api-base", async () => {
+      const fetchImpl = happyFetch();
+      const svc = new RestPushService({
+        token: FAKE_PAT,
+        fetchImpl,
+        apiBase: "https://ghe.example.com/api/v3",
+      });
+      await svc.push("o", "r", "main", new Map([["f", "c"]]), "m");
+      const [url] = fetchImpl.mock.calls[0];
+      expect(url).toBe(
+        "https://ghe.example.com/api/v3/repos/o/r/git/refs/heads/main",
+      );
+    });
+  });
+
+  describe("error handling + redaction", () => {
+    it("throws with the HTTP status on a non-2xx response", async () => {
+      const fetchImpl = jest.fn().mockResolvedValueOnce(res(404, "Not Found"));
+      const svc = new RestPushService({ token: FAKE_PAT, fetchImpl });
+      await expect(
+        svc.push("o", "r", "main", new Map([["f", "c"]]), "m"),
+      ).rejects.toThrow(/HTTP 404/);
+    });
+
+    it("redacts a PAT leaked into a non-2xx response body", async () => {
+      const leak = `unexpected error mentioning ${FAKE_PAT} in body`;
+      const fetchImpl = jest.fn().mockResolvedValueOnce(res(422, leak));
+      const svc = new RestPushService({ token: FAKE_PAT, fetchImpl });
+      await expect(
+        svc.push("o", "r", "main", new Map([["f", "c"]]), "m"),
+      ).rejects.toThrow(/\*\*\*REDACTED\*\*\*/);
+      await expect(
+        svc.push("o", "r", "main", new Map([["f", "c"]]), "m"),
+      ).rejects.not.toThrow(new RegExp(FAKE_PAT));
+    });
+
+    it("wraps a fetch network error (redacted)", async () => {
+      const fetchImpl = jest
+        .fn()
+        .mockRejectedValueOnce(new Error("ECONNRESET"));
+      const svc = new RestPushService({ token: FAKE_PAT, fetchImpl });
+      await expect(
+        svc.push("o", "r", "main", new Map([["f", "c"]]), "m"),
+      ).rejects.toThrow(/GitHub request failed: ECONNRESET/);
+    });
+
+    it("redact coerces non-string input", () => {
+      const svc = new RestPushService({ token: FAKE_PAT });
+      expect(svc.redact({ toString: () => `x ${FAKE_PAT} y` })).toContain(
+        "***REDACTED***",
+      );
+    });
+  });
+
+  describe("resolveGhToken", () => {
+    it("returns a trimmed token from the runner", () => {
+      const token = RestPushService.resolveGhToken(() => `  ${FAKE_PAT}\n`);
+      expect(token).toBe(FAKE_PAT);
+    });
+
+    it("throws on empty runner output", () => {
+      expect(() => RestPushService.resolveGhToken(() => "  \n")).toThrow(
+        /not authenticated/,
+      );
+    });
+
+    it("throws a redacted, actionable error when the runner throws", () => {
+      expect(() =>
+        RestPushService.resolveGhToken(() => {
+          throw new Error(`gh failed (had ${FAKE_PAT})`);
+        }),
+      ).toThrow(/gh auth token` failed/);
+      expect(() =>
+        RestPushService.resolveGhToken(() => {
+          throw new Error(`gh failed (had ${FAKE_PAT})`);
+        }),
+      ).not.toThrow(new RegExp(FAKE_PAT));
+    });
+  });
+});

--- a/packages/exocortex/src/index.ts
+++ b/packages/exocortex/src/index.ts
@@ -543,3 +543,14 @@ export {
   parseTarballGzip,
   type TarballEntry,
 } from "./infrastructure/tarball/parseTarball";
+
+// Transport-agnostic GitHub "create commit" core (Git Data API, 4-call chain).
+// Shared by the Obsidian plugin (requestUrl transport) and the CLI (fetch
+// transport) — the single iOS-portable commit+push implementation.
+export {
+  restCreateCommit,
+  type RestCommitRequest,
+  type RestCommitResponse,
+  type RestCommitTransport,
+  type RestCreateCommitParams,
+} from "./infrastructure/github/restCommit";

--- a/packages/exocortex/src/infrastructure/github/restCommit.ts
+++ b/packages/exocortex/src/infrastructure/github/restCommit.ts
@@ -27,11 +27,14 @@
  *
  * Partial-failure contract (unchanged from the plugin original): if steps 1-3
  * succeed but step 4 (PATCH ref) fails (network glitch, 422 non-fast-forward,
- * concurrent push race), the remote holds an **orphan commit** reachable only
- * by the SHA embedded in the thrown error message. Git GC reaps unreachable
- * commits after ~30 days. Callers MAY safely retry: a subsequent successful
- * call creates a new commit and leaves the orphan to expire. Do NOT use this
- * for branches with concurrent writers without coordinated retry/locking.
+ * concurrent push race), the remote holds an **orphan commit**. On the
+ * ref-mismatch path the new SHA is embedded in the thrown error message and the
+ * orphan is recoverable by it; on an HTTP-error PATCH failure (e.g. 422) the
+ * transport throws an error that does NOT surface the new commit SHA. Either
+ * way git GC reaps unreachable commits after ~30 days. Callers MAY safely retry:
+ * a subsequent successful call creates a new commit and leaves the orphan to
+ * expire. Do NOT use this for branches with concurrent writers without
+ * coordinated retry/locking.
  */
 
 /** Minimal HTTP request descriptor — transport-agnostic. */

--- a/packages/exocortex/src/infrastructure/github/restCommit.ts
+++ b/packages/exocortex/src/infrastructure/github/restCommit.ts
@@ -1,0 +1,202 @@
+/**
+ * Transport-agnostic GitHub "create commit" core (Git Data API, 4-call chain).
+ *
+ * Extracted from the plugin's `GitHubRestClient.createCommit` so BOTH the
+ * Obsidian plugin (Obsidian `requestUrl` transport) and the CLI (Node `fetch`
+ * transport) reuse ONE implementation of the commit+push sequence. This is the
+ * iOS-portable production path: the only platform-specific piece is the
+ * injected `transport` fn; the 4-call orchestration, payload shapes, ref
+ * fast-forward, and structural validation live here, platform-free.
+ *
+ * The 4 calls (GitHub Git Data API):
+ *   1. GET  git/refs/heads/{branch}  → base ref SHA
+ *   2. POST git/trees (recursive)    → new tree SHA (multi-file, atomic)
+ *   3. POST git/commits              → new commit SHA
+ *   4. PATCH git/refs/heads/{branch} → fast-forward ref to the new commit
+ *
+ * Contract with the injected transport:
+ *   - The transport MUST throw on any non-2xx HTTP status (the plugin's
+ *     `requestUrl` wrapper and the CLI's `fetch` wrapper both do). This core
+ *     only ever observes successful responses and validates their JSON shape.
+ *   - The transport returns `{ status?, json?, text? }`; only `json` is read.
+ *   - PAT handling (Authorization header) + redaction of leaked tokens in
+ *     HTTP-error bodies is the transport's responsibility. The optional
+ *     `redact` param below is a defence-in-depth pass over this core's own
+ *     structural error strings (which never embed a PAT, but are redacted
+ *     anyway for parity with the plugin original).
+ *
+ * Partial-failure contract (unchanged from the plugin original): if steps 1-3
+ * succeed but step 4 (PATCH ref) fails (network glitch, 422 non-fast-forward,
+ * concurrent push race), the remote holds an **orphan commit** reachable only
+ * by the SHA embedded in the thrown error message. Git GC reaps unreachable
+ * commits after ~30 days. Callers MAY safely retry: a subsequent successful
+ * call creates a new commit and leaves the orphan to expire. Do NOT use this
+ * for branches with concurrent writers without coordinated retry/locking.
+ */
+
+/** Minimal HTTP request descriptor — transport-agnostic. */
+export interface RestCommitRequest {
+  method: "GET" | "POST" | "PATCH";
+  url: string;
+  /** Set for POST/PATCH bodies. Adapter maps to `Content-Type` header. */
+  contentType?: string;
+  /** JSON-serialised request body for POST/PATCH. */
+  body?: string;
+}
+
+/**
+ * Minimal HTTP response shape both the Obsidian `requestUrl` response and a
+ * `fetch`-derived adapter can satisfy. Only `json` is consumed by the core.
+ */
+export interface RestCommitResponse {
+  status?: number;
+  json?: unknown;
+  text?: string;
+}
+
+/**
+ * Injected transport. Plugin → adapter over `requestUrl`; CLI → adapter over
+ * `fetch`. MUST throw on non-2xx (see contract above).
+ */
+export type RestCommitTransport = (
+  req: RestCommitRequest,
+) => Promise<RestCommitResponse>;
+
+export interface RestCreateCommitParams {
+  owner: string;
+  repo: string;
+  branch: string;
+  /** Map of repo-relative path → file content. Non-empty. */
+  files: Map<string, string>;
+  message: string;
+  /** Defaults to `https://api.github.com`. Trailing slash stripped. */
+  baseURL?: string;
+  /**
+   * Optional defence-in-depth redactor applied to this core's own structural
+   * error strings. Defaults to identity. The plugin injects its PAT redactor
+   * for parity with the original `createCommit` error semantics.
+   */
+  redact?: (message: string) => string;
+}
+
+const DEFAULT_BASE_URL = "https://api.github.com";
+
+/** Read `json.object.sha` defensively without `any`. */
+function readObjectSha(json: unknown): string | undefined {
+  if (json !== null && typeof json === "object" && "object" in json) {
+    const obj = (json as { object?: unknown }).object;
+    if (obj !== null && typeof obj === "object" && "sha" in obj) {
+      const sha = (obj as { sha?: unknown }).sha;
+      return typeof sha === "string" ? sha : undefined;
+    }
+  }
+  return undefined;
+}
+
+/** Read `json.sha` defensively without `any`. */
+function readSha(json: unknown): string | undefined {
+  if (json !== null && typeof json === "object" && "sha" in json) {
+    const sha = (json as { sha?: unknown }).sha;
+    return typeof sha === "string" ? sha : undefined;
+  }
+  return undefined;
+}
+
+/**
+ * Execute the 4-call Git Data API chain over an injected transport and return
+ * the new commit SHA. See module docstring for the full contract.
+ */
+export async function restCreateCommit(
+  transport: RestCommitTransport,
+  params: RestCreateCommitParams,
+): Promise<string> {
+  const { owner, repo, branch, files, message } = params;
+  const baseURL = (params.baseURL ?? DEFAULT_BASE_URL).replace(/\/$/, "");
+  const redact = params.redact ?? ((m: string): string => m);
+
+  if (typeof owner !== "string" || owner.length === 0) {
+    throw new Error("restCreateCommit: owner is required");
+  }
+  if (typeof repo !== "string" || repo.length === 0) {
+    throw new Error("restCreateCommit: repo is required");
+  }
+  if (typeof branch !== "string" || branch.length === 0) {
+    throw new Error("GitHub createCommit: branch is required");
+  }
+  if (!(files instanceof Map) || files.size === 0) {
+    throw new Error("GitHub createCommit: files map must be non-empty");
+  }
+  if (typeof message !== "string" || message.length === 0) {
+    throw new Error("GitHub createCommit: message is required");
+  }
+
+  const o = encodeURIComponent(owner);
+  const r = encodeURIComponent(repo);
+  const b = encodeURIComponent(branch);
+
+  // Step 1 — get current ref SHA.
+  const refResp = await transport({
+    method: "GET",
+    url: `${baseURL}/repos/${o}/${r}/git/refs/heads/${b}`,
+  });
+  const baseSha = readObjectSha(refResp?.json);
+  if (typeof baseSha !== "string" || baseSha.length === 0) {
+    throw new Error(
+      redact(`GitHub createCommit: missing object.sha for ref heads/${branch}`),
+    );
+  }
+
+  // Step 2 — create tree (recursive, multi-file atomic).
+  const tree = Array.from(files.entries()).map(([path, content]) => ({
+    path,
+    mode: "100644",
+    type: "blob",
+    content,
+  }));
+  const treeResp = await transport({
+    method: "POST",
+    url: `${baseURL}/repos/${o}/${r}/git/trees`,
+    contentType: "application/json",
+    body: JSON.stringify({ base_tree: baseSha, tree }),
+  });
+  const treeSha = readSha(treeResp?.json);
+  if (typeof treeSha !== "string" || treeSha.length === 0) {
+    throw new Error(redact(`GitHub createCommit: tree create returned no sha`));
+  }
+
+  // Step 3 — create commit.
+  const commitResp = await transport({
+    method: "POST",
+    url: `${baseURL}/repos/${o}/${r}/git/commits`,
+    contentType: "application/json",
+    body: JSON.stringify({
+      message,
+      tree: treeSha,
+      parents: [baseSha],
+    }),
+  });
+  const commitSha = readSha(commitResp?.json);
+  if (typeof commitSha !== "string" || commitSha.length === 0) {
+    throw new Error(
+      redact(`GitHub createCommit: commit create returned no sha`),
+    );
+  }
+
+  // Step 4 — fast-forward ref to new commit.
+  const patchResp = await transport({
+    method: "PATCH",
+    url: `${baseURL}/repos/${o}/${r}/git/refs/heads/${b}`,
+    contentType: "application/json",
+    body: JSON.stringify({ sha: commitSha, force: false }),
+  });
+  const patchedSha = readObjectSha(patchResp?.json);
+  if (patchedSha !== commitSha) {
+    throw new Error(
+      redact(
+        `GitHub createCommit: ref update mismatch (expected ${commitSha}, got ${patchedSha})`,
+      ),
+    );
+  }
+
+  return commitSha;
+}

--- a/packages/exocortex/tests/unit/infrastructure/github/restCommit.test.ts
+++ b/packages/exocortex/tests/unit/infrastructure/github/restCommit.test.ts
@@ -1,0 +1,402 @@
+import { describe, it, expect } from "@jest/globals";
+import {
+  restCreateCommit,
+  type RestCommitRequest,
+  type RestCommitResponse,
+  type RestCommitTransport,
+} from "../../../../src/infrastructure/github/restCommit";
+
+/**
+ * Production-shaped GitHub Git Data API responses. These mirror the real
+ * payload shapes (https://docs.github.com/en/rest/git) — NOT stub-any —
+ * so the test exercises the same JSON-navigation the core does in prod.
+ */
+const BASE_SHA = "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0";
+const TREE_SHA = "0fedcba9876543210fedcba9876543210fedcba9";
+const COMMIT_SHA = "9988776655443322110099887766554433221100";
+
+function refResponse(sha: string): RestCommitResponse {
+  return {
+    status: 200,
+    json: {
+      ref: "refs/heads/main",
+      node_id: "REF_kwDOabc",
+      url: "https://api.github.com/repos/o/r/git/refs/heads/main",
+      object: { sha, type: "commit", url: "https://api.github.com/..." },
+    },
+  };
+}
+function treeResponse(sha: string): RestCommitResponse {
+  return {
+    status: 201,
+    json: {
+      sha,
+      url: "https://api.github.com/...",
+      tree: [],
+      truncated: false,
+    },
+  };
+}
+function commitResponse(sha: string): RestCommitResponse {
+  return {
+    status: 201,
+    json: {
+      sha,
+      node_id: "C_kwDO",
+      url: "https://api.github.com/...",
+      message: "msg",
+      tree: { sha: TREE_SHA },
+      parents: [{ sha: BASE_SHA }],
+    },
+  };
+}
+
+/** Build a transport that returns queued responses and records every request. */
+function sequencedTransport(responses: RestCommitResponse[]): {
+  transport: RestCommitTransport;
+  calls: RestCommitRequest[];
+} {
+  const calls: RestCommitRequest[] = [];
+  let i = 0;
+  const transport: RestCommitTransport = (req) => {
+    calls.push(req);
+    const resp = responses[i++];
+    if (resp === undefined) {
+      return Promise.reject(
+        new Error(`unexpected call #${i}: ${req.method} ${req.url}`),
+      );
+    }
+    return Promise.resolve(resp);
+  };
+  return { transport, calls };
+}
+
+const happyResponses = (): RestCommitResponse[] => [
+  refResponse(BASE_SHA),
+  treeResponse(TREE_SHA),
+  commitResponse(COMMIT_SHA),
+  refResponse(COMMIT_SHA), // PATCH returns object.sha === new commit
+];
+
+describe("restCreateCommit (transport-agnostic core)", () => {
+  it("executes the 4-call Git Data API chain in order and returns the commit sha", async () => {
+    const { transport, calls } = sequencedTransport(happyResponses());
+    const files = new Map([
+      ["docs/a.md", "hello"],
+      ["docs/b.md", "world"],
+    ]);
+
+    const sha = await restCreateCommit(transport, {
+      owner: "o",
+      repo: "r",
+      branch: "main",
+      files,
+      message: "test commit",
+    });
+
+    expect(sha).toBe(COMMIT_SHA);
+    expect(calls).toHaveLength(4);
+
+    // Step 1 — GET ref.
+    expect(calls[0]).toMatchObject({
+      method: "GET",
+      url: "https://api.github.com/repos/o/r/git/refs/heads/main",
+    });
+    expect(calls[0].body).toBeUndefined();
+
+    // Step 2 — POST tree with base_tree + recursive blobs.
+    expect(calls[1]).toMatchObject({
+      method: "POST",
+      url: "https://api.github.com/repos/o/r/git/trees",
+      contentType: "application/json",
+    });
+    const treeBody = JSON.parse(calls[1].body as string);
+    expect(treeBody.base_tree).toBe(BASE_SHA);
+    expect(treeBody.tree).toHaveLength(2);
+    expect(treeBody.tree[0]).toEqual({
+      path: "docs/a.md",
+      mode: "100644",
+      type: "blob",
+      content: "hello",
+    });
+    expect(treeBody.tree[1]).toEqual({
+      path: "docs/b.md",
+      mode: "100644",
+      type: "blob",
+      content: "world",
+    });
+
+    // Step 3 — POST commit referencing tree + base parent.
+    expect(calls[2]).toMatchObject({
+      method: "POST",
+      url: "https://api.github.com/repos/o/r/git/commits",
+      contentType: "application/json",
+    });
+    const commitBody = JSON.parse(calls[2].body as string);
+    expect(commitBody.message).toBe("test commit");
+    expect(commitBody.tree).toBe(TREE_SHA);
+    expect(commitBody.parents).toEqual([BASE_SHA]);
+
+    // Step 4 — PATCH ref fast-forward (force:false).
+    expect(calls[3]).toMatchObject({
+      method: "PATCH",
+      url: "https://api.github.com/repos/o/r/git/refs/heads/main",
+      contentType: "application/json",
+    });
+    const patchBody = JSON.parse(calls[3].body as string);
+    expect(patchBody.sha).toBe(COMMIT_SHA);
+    expect(patchBody.force).toBe(false);
+  });
+
+  it("URL-encodes owner/repo/branch segments", async () => {
+    const { transport, calls } = sequencedTransport([
+      refResponse(BASE_SHA),
+      treeResponse(TREE_SHA),
+      commitResponse(COMMIT_SHA),
+      refResponse(COMMIT_SHA),
+    ]);
+    await restCreateCommit(transport, {
+      owner: "my org",
+      repo: "re po",
+      branch: "feat/x",
+      files: new Map([["f", "c"]]),
+      message: "m",
+    });
+    expect(calls[0].url).toContain(
+      "/repos/my%20org/re%20po/git/refs/heads/feat%2Fx",
+    );
+  });
+
+  it("honours a custom baseURL and strips its trailing slash", async () => {
+    const { transport, calls } = sequencedTransport(happyResponses());
+    await restCreateCommit(transport, {
+      owner: "o",
+      repo: "r",
+      branch: "main",
+      files: new Map([["f", "c"]]),
+      message: "m",
+      baseURL: "https://ghe.example.com/api/v3/",
+    });
+    expect(calls[0].url).toBe(
+      "https://ghe.example.com/api/v3/repos/o/r/git/refs/heads/main",
+    );
+  });
+
+  // ── validation ────────────────────────────────────────────────────
+  it("rejects an empty owner", async () => {
+    const { transport } = sequencedTransport([]);
+    await expect(
+      restCreateCommit(transport, {
+        owner: "",
+        repo: "r",
+        branch: "main",
+        files: new Map([["f", "c"]]),
+        message: "m",
+      }),
+    ).rejects.toThrow(/owner is required/);
+  });
+
+  it("rejects an empty repo", async () => {
+    const { transport } = sequencedTransport([]);
+    await expect(
+      restCreateCommit(transport, {
+        owner: "o",
+        repo: "",
+        branch: "main",
+        files: new Map([["f", "c"]]),
+        message: "m",
+      }),
+    ).rejects.toThrow(/repo is required/);
+  });
+
+  it("rejects an empty branch", async () => {
+    const { transport } = sequencedTransport([]);
+    await expect(
+      restCreateCommit(transport, {
+        owner: "o",
+        repo: "r",
+        branch: "",
+        files: new Map([["f", "c"]]),
+        message: "m",
+      }),
+    ).rejects.toThrow(/branch is required/);
+  });
+
+  it("rejects an empty file map", async () => {
+    const { transport } = sequencedTransport([]);
+    await expect(
+      restCreateCommit(transport, {
+        owner: "o",
+        repo: "r",
+        branch: "main",
+        files: new Map(),
+        message: "m",
+      }),
+    ).rejects.toThrow(/files map must be non-empty/);
+  });
+
+  it("rejects a non-Map files value", async () => {
+    const { transport } = sequencedTransport([]);
+    await expect(
+      restCreateCommit(transport, {
+        owner: "o",
+        repo: "r",
+        branch: "main",
+        // @ts-expect-error — deliberately wrong type to exercise the guard
+        files: { f: "c" },
+        message: "m",
+      }),
+    ).rejects.toThrow(/files map must be non-empty/);
+  });
+
+  it("rejects an empty message", async () => {
+    const { transport } = sequencedTransport([]);
+    await expect(
+      restCreateCommit(transport, {
+        owner: "o",
+        repo: "r",
+        branch: "main",
+        files: new Map([["f", "c"]]),
+        message: "",
+      }),
+    ).rejects.toThrow(/message is required/);
+  });
+
+  // ── structural response errors ────────────────────────────────────
+  it("throws when the ref response is missing object.sha", async () => {
+    const { transport } = sequencedTransport([{ status: 200, json: {} }]);
+    await expect(
+      restCreateCommit(transport, {
+        owner: "o",
+        repo: "r",
+        branch: "main",
+        files: new Map([["f", "c"]]),
+        message: "m",
+      }),
+    ).rejects.toThrow(/missing object\.sha for ref heads\/main/);
+  });
+
+  it("throws when object exists but sha is not a string", async () => {
+    const { transport } = sequencedTransport([
+      { status: 200, json: { object: { sha: 123 } } },
+    ]);
+    await expect(
+      restCreateCommit(transport, {
+        owner: "o",
+        repo: "r",
+        branch: "main",
+        files: new Map([["f", "c"]]),
+        message: "m",
+      }),
+    ).rejects.toThrow(/missing object\.sha/);
+  });
+
+  it("throws when object is null", async () => {
+    const { transport } = sequencedTransport([
+      { status: 200, json: { object: null } },
+    ]);
+    await expect(
+      restCreateCommit(transport, {
+        owner: "o",
+        repo: "r",
+        branch: "main",
+        files: new Map([["f", "c"]]),
+        message: "m",
+      }),
+    ).rejects.toThrow(/missing object\.sha/);
+  });
+
+  it("throws when json itself is null/undefined", async () => {
+    const { transport } = sequencedTransport([{ status: 200 }]);
+    await expect(
+      restCreateCommit(transport, {
+        owner: "o",
+        repo: "r",
+        branch: "main",
+        files: new Map([["f", "c"]]),
+        message: "m",
+      }),
+    ).rejects.toThrow(/missing object\.sha/);
+  });
+
+  it("throws when the tree response is missing sha", async () => {
+    const { transport } = sequencedTransport([
+      refResponse(BASE_SHA),
+      { status: 201, json: {} },
+    ]);
+    await expect(
+      restCreateCommit(transport, {
+        owner: "o",
+        repo: "r",
+        branch: "main",
+        files: new Map([["f", "c"]]),
+        message: "m",
+      }),
+    ).rejects.toThrow(/tree create returned no sha/);
+  });
+
+  it("throws when the commit response is missing sha", async () => {
+    const { transport } = sequencedTransport([
+      refResponse(BASE_SHA),
+      treeResponse(TREE_SHA),
+      { status: 201, json: {} },
+    ]);
+    await expect(
+      restCreateCommit(transport, {
+        owner: "o",
+        repo: "r",
+        branch: "main",
+        files: new Map([["f", "c"]]),
+        message: "m",
+      }),
+    ).rejects.toThrow(/commit create returned no sha/);
+  });
+
+  it("throws on ref update mismatch (PATCH returned a different sha)", async () => {
+    const { transport } = sequencedTransport([
+      refResponse(BASE_SHA),
+      treeResponse(TREE_SHA),
+      commitResponse(COMMIT_SHA),
+      refResponse("deadbeefdeadbeefdeadbeefdeadbeefdeadbeef"),
+    ]);
+    await expect(
+      restCreateCommit(transport, {
+        owner: "o",
+        repo: "r",
+        branch: "main",
+        files: new Map([["f", "c"]]),
+        message: "m",
+      }),
+    ).rejects.toThrow(/ref update mismatch \(expected .+, got deadbeef/);
+  });
+
+  // ── redaction + transport error propagation ───────────────────────
+  it("applies the injected redact fn to structural error strings", async () => {
+    const { transport } = sequencedTransport([{ status: 200, json: {} }]);
+    const redact = (m: string): string => m.replace(/heads\/main/, "***");
+    await expect(
+      restCreateCommit(transport, {
+        owner: "o",
+        repo: "r",
+        branch: "main",
+        files: new Map([["f", "c"]]),
+        message: "m",
+        redact,
+      }),
+    ).rejects.toThrow(/missing object\.sha for ref \*\*\*/);
+  });
+
+  it("propagates a transport-thrown error (non-2xx is the transport's job)", async () => {
+    const transport: RestCommitTransport = () =>
+      Promise.reject(new Error("GitHub request GET ... → HTTP 404: Not Found"));
+    await expect(
+      restCreateCommit(transport, {
+        owner: "o",
+        repo: "r",
+        branch: "main",
+        files: new Map([["f", "c"]]),
+        message: "m",
+      }),
+    ).rejects.toThrow(/HTTP 404/);
+  });
+});

--- a/packages/obsidian-plugin/src/infrastructure/adapters/GitHubRestClient.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/GitHubRestClient.ts
@@ -2,6 +2,7 @@ import type { App, RequestUrlParam, RequestUrlResponse } from "obsidian";
 import { requestUrl } from "obsidian";
 import { parseTarGzip } from "nanotar";
 import type { TarFileItem } from "nanotar";
+import { restCreateCommit, type RestCommitTransport } from "exocortex";
 
 export interface GitHubRestClientOptions {
   pat: string;
@@ -232,6 +233,13 @@ export class GitHubRestClient {
    * days. Callers MAY safely retry: a subsequent successful call creates a
    * new commit and leaves the orphan to expire. Do NOT use this method for
    * branches with concurrent writers without coordinated retry/locking.
+   *
+   * Implementation note: the 4-call orchestration + payload shapes + ref
+   * fast-forward + structural validation live in the transport-agnostic
+   * `restCreateCommit` core (`exocortex` package) so the CLI reuses the exact
+   * same logic over a `fetch` transport. This method only supplies the
+   * `requestUrl`-backed transport + PAT redactor; the contract above
+   * (validation order, error strings, partial-failure SHA) is unchanged.
    */
   public async createCommit(
     owner: string,
@@ -241,85 +249,21 @@ export class GitHubRestClient {
     message: string,
   ): Promise<string> {
     this.requireOwnerRepo(owner, repo);
-    if (typeof branch !== "string" || branch.length === 0) {
-      throw new Error("GitHub createCommit: branch is required");
-    }
-    if (!(files instanceof Map) || files.size === 0) {
-      throw new Error("GitHub createCommit: files map must be non-empty");
-    }
-    if (typeof message !== "string" || message.length === 0) {
-      throw new Error("GitHub createCommit: message is required");
-    }
-
-    const o = encodeURIComponent(owner);
-    const r = encodeURIComponent(repo);
-    const b = encodeURIComponent(branch);
-
-    // Step 1 — get current ref SHA.
-    const refResp = await this.request({
-      method: "GET",
-      url: `${this.#baseURL}/repos/${o}/${r}/git/refs/heads/${b}`,
+    // Adapter: the core's transport returns `{ status?, json?, text? }`; the
+    // `requestUrl`-backed `request()` already throws on non-2xx (the core's
+    // transport contract) and returns a RequestUrlResponse that satisfies that
+    // shape. Caller-owned Authorization header + HTTP-error-body redaction stay
+    // inside `request()`; the core's own structural errors get `this.redact`.
+    const transport: RestCommitTransport = (req) => this.request(req);
+    return restCreateCommit(transport, {
+      owner,
+      repo,
+      branch,
+      files,
+      message,
+      baseURL: this.#baseURL,
+      redact: (m) => this.redact(m),
     });
-    const baseSha = refResp?.json?.object?.sha;
-    if (typeof baseSha !== "string" || baseSha.length === 0) {
-      throw new Error(
-        this.redact(`GitHub createCommit: missing object.sha for ref heads/${branch}`),
-      );
-    }
-
-    // Step 2 — create tree (recursive).
-    const tree = Array.from(files.entries()).map(([path, content]) => ({
-      path,
-      mode: "100644",
-      type: "blob",
-      content,
-    }));
-    const treeResp = await this.request({
-      method: "POST",
-      url: `${this.#baseURL}/repos/${o}/${r}/git/trees`,
-      contentType: "application/json",
-      body: JSON.stringify({ base_tree: baseSha, tree }),
-    });
-    const treeSha = treeResp?.json?.sha;
-    if (typeof treeSha !== "string" || treeSha.length === 0) {
-      throw new Error(
-        this.redact(`GitHub createCommit: tree create returned no sha`),
-      );
-    }
-
-    // Step 3 — create commit.
-    const commitResp = await this.request({
-      method: "POST",
-      url: `${this.#baseURL}/repos/${o}/${r}/git/commits`,
-      contentType: "application/json",
-      body: JSON.stringify({
-        message,
-        tree: treeSha,
-        parents: [baseSha],
-      }),
-    });
-    const commitSha = commitResp?.json?.sha;
-    if (typeof commitSha !== "string" || commitSha.length === 0) {
-      throw new Error(
-        this.redact(`GitHub createCommit: commit create returned no sha`),
-      );
-    }
-
-    // Step 4 — update ref.
-    const patchResp = await this.request({
-      method: "PATCH",
-      url: `${this.#baseURL}/repos/${o}/${r}/git/refs/heads/${b}`,
-      contentType: "application/json",
-      body: JSON.stringify({ sha: commitSha, force: false }),
-    });
-    const patchedSha = patchResp?.json?.object?.sha;
-    if (patchedSha !== commitSha) {
-      throw new Error(
-        this.redact(`GitHub createCommit: ref update mismatch (expected ${commitSha}, got ${patchedSha})`),
-      );
-    }
-
-    return commitSha;
   }
 
   /**

--- a/packages/obsidian-plugin/src/infrastructure/adapters/GitHubRestClient.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/GitHubRestClient.ts
@@ -228,11 +228,14 @@ export class GitHubRestClient {
    *
    * Partial-failure contract: if steps 1–3 succeed but step 4 (PATCH ref)
    * fails (network glitch, 422 non-fast-forward, concurrent push race), the
-   * remote will have an **orphan commit** reachable only by the SHA embedded
-   * in the thrown error message. Git GC reaps unreachable commits after ~30
-   * days. Callers MAY safely retry: a subsequent successful call creates a
-   * new commit and leaves the orphan to expire. Do NOT use this method for
-   * branches with concurrent writers without coordinated retry/locking.
+   * remote will have an **orphan commit**. On the ref-mismatch path the new SHA
+   * is embedded in the thrown error message and the orphan is recoverable by
+   * it; on an HTTP-error PATCH failure (e.g. 422) the thrown error does NOT
+   * surface the new commit SHA. Either way git GC reaps unreachable commits
+   * after ~30 days. Callers MAY safely retry: a subsequent successful call
+   * creates a new commit and leaves the orphan to expire. Do NOT use this
+   * method for branches with concurrent writers without coordinated
+   * retry/locking. (See the `restCreateCommit` core docstring — same contract.)
    *
    * Implementation note: the 4-call orchestration + payload shapes + ref
    * fast-forward + structural validation live in the transport-agnostic


### PR DESCRIPTION
## Summary

RFC `01a83de8` **Phase 0 spike**: prove commit+push to GitHub works **without the `git` binary** (pure Git Data API), runnable in the iOS Obsidian plugin runtime, shipped behind an **opt-in experimental flag**. De-risks RFC Phase 3 (iOS write-back).

- **Extract `restCreateCommit`** (`packages/exocortex/src/infrastructure/github/restCommit.ts`) — the 4-call Git Data API chain (`GET ref → POST tree → POST commit → PATCH ref`) over an **injected transport**. The only platform-specific piece is the transport fn; orchestration + payloads + validation are platform-free.
- **Rewire plugin** `GitHubRestClient.createCommit` to delegate to the core (supplies a `requestUrl` transport + PAT redactor). All **74/74** existing `GitHubRestClient` tests stay green — the 7 `createCommit` behavioural tests are the revert→fail/restore→pass safety net (breaking the core fails the plugin tests, proving real delegation, verified locally).
- **CLI** `exocortex experimental rest-push` (`fetch` transport) gated behind `EXOCORTEX_EXPERIMENTAL_REST_PUSH=1` **or** `--experimental`. **Default OFF** — normal users unaffected.
- **Security:** PAT redaction (classic + fine-grained) on every error; `Authorization` only when present; token never logged; `gh auth token` resolution via `--token-from-gh`.

## Research note

`docs/REST_COMMIT_PUSH_POC.md` — **Contents API vs Git Data API** (recommend **Git Data API**: multi-file atomic, fixed 4 calls, matches `pushAssetSpace`); transport portability (`requestUrl` plugin/iOS, `fetch` CLI/Node); **transport-agnostic core extraction** (done here, not just recommended); remaining iOS gap = **mount/unmount** (`GitSubmoduleOps`, `execFile("git")`) → **RFC Phase 3**.

## Tests

- Core: 4-call sequence + payloads with **production-shaped** GitHub responses (mock transport) — 18 cases.
- CLI `RestPushService`: mock `fetch` — auth header, redaction, non-2xx/network errors, `gh` token resolution.
- CLI command: gate + validation + DI fakes (no network, no `process.exit`).
- Plugin: 74/74 `GitHubRestClient` + 33/33 `AssetSpaceManager` green post-rewire.

## Scope / discipline

- WORKTREE branch from fresh `origin/main`.
- Disjoint from open PR #3398 (plugin Create/ClassDiscovery path).
- Experimental = opt-in, default off.
- Auto-merge discipline: touches adapters + CLI → **no blind `--auto`**; code-reviewer + advisor round-2 before merge.

## Test plan

- [ ] 14 required CI checks green
- [ ] code-reviewer agent: 0 CRITICAL/HIGH
- [ ] advisor round-2
- [ ] Post-merge: experimental command pushes a real commit to `kitelev/exoas-restapi-poc` via REST (evidence captured)