### PR TITLE
feat(cli): audit co-location subcommand (RFC 0b7a2fad Phase 1)

### DIFF
--- a/packages/cli/src/adapters/CachingNodeFsAdapter.ts
+++ b/packages/cli/src/adapters/CachingNodeFsAdapter.ts
@@ -47,13 +47,15 @@ export class CachingNodeFsAdapter extends NodeFsAdapter {
       } catch {
         metadata = {};
       }
-      const uid = metadata?.["exo__Asset_uid"];
-      if (
-        typeof uid === "string" &&
-        uid.length > 0 &&
-        !this.uidToPath.has(uid)
-      ) {
-        this.uidToPath.set(uid, rel);
+      // Mirror base NodeFsAdapter.findFileByUID semantics (normalizeValue +
+      // array support) so the cache resolves UIDs identically to migration.
+      const rawUid = metadata?.["exo__Asset_uid"];
+      const uidValues = Array.isArray(rawUid) ? rawUid : [rawUid];
+      for (const v of uidValues) {
+        const key = CachingNodeFsAdapter.normalizeUid(v);
+        if (key.length > 0 && !this.uidToPath.has(key)) {
+          this.uidToPath.set(key, rel);
+        }
       }
       this.assets.push({ path: rel, metadata });
     }
@@ -76,7 +78,15 @@ export class CachingNodeFsAdapter extends NodeFsAdapter {
 
   override async findFileByUID(uid: string): Promise<string | null> {
     await this.buildIndex();
-    return this.uidToPath.get(uid) ?? null;
+    return this.uidToPath.get(CachingNodeFsAdapter.normalizeUid(uid)) ?? null;
+  }
+
+  /** Match base NodeFsAdapter.normalizeValue: strip quotes/brackets + trim. */
+  private static normalizeUid(value: unknown): string {
+    if (value === null || value === undefined) return "";
+    return String(value)
+      .replace(/["'[\]]/g, "")
+      .trim();
   }
 
   override async fileExists(filePath: string): Promise<boolean> {

--- a/packages/cli/src/adapters/CachingNodeFsAdapter.ts
+++ b/packages/cli/src/adapters/CachingNodeFsAdapter.ts
@@ -1,0 +1,89 @@
+import { NodeFsAdapter } from "./NodeFsAdapter.js";
+
+/**
+ * One indexed markdown asset: its vault-relative path and parsed frontmatter.
+ */
+export interface IndexedAsset {
+  path: string;
+  metadata: Record<string, unknown>;
+}
+
+/**
+ * Read-side caching wrapper over {@link NodeFsAdapter}. Builds a single
+ * vault-wide index (one disk pass) and serves the read methods that
+ * {@link findReferencedFile} calls from memory, turning a naive O(N²) audit
+ * (every per-asset resolve re-walks + re-parses the whole vault) into O(N)
+ * build + O(1) UID lookups.
+ *
+ * Crucially this preserves resolver UNIFICATION: the co-location audit still
+ * resolves `exo__Asset_isDefinedBy` through the exact same `findReferencedFile`
+ * code path as `apply repair-folder`, so an audit violation is guaranteed to
+ * map to the same move target. Only the underlying fs lookups are memoized.
+ *
+ * Mutating methods (createFile/updateFile/...) are inherited unchanged — this
+ * adapter is intended for read-only audit use.
+ */
+export class CachingNodeFsAdapter extends NodeFsAdapter {
+  private indexed = false;
+  private readonly uidToPath = new Map<string, string>();
+  private readonly allPaths: string[] = [];
+  private readonly pathSet = new Set<string>();
+  private readonly assets: IndexedAsset[] = [];
+
+  constructor(rootPath: string) {
+    super(rootPath);
+  }
+
+  /** Build the index once (idempotent). One disk pass over all markdown files. */
+  async buildIndex(): Promise<void> {
+    if (this.indexed) return;
+    const files = await super.getMarkdownFiles();
+    for (const rel of files) {
+      this.allPaths.push(rel);
+      this.pathSet.add(rel);
+      let metadata: Record<string, unknown> = {};
+      try {
+        metadata = await super.getFileMetadata(rel);
+      } catch {
+        metadata = {};
+      }
+      const uid = metadata?.["exo__Asset_uid"];
+      if (
+        typeof uid === "string" &&
+        uid.length > 0 &&
+        !this.uidToPath.has(uid)
+      ) {
+        this.uidToPath.set(uid, rel);
+      }
+      this.assets.push({ path: rel, metadata });
+    }
+    this.indexed = true;
+  }
+
+  /** All indexed assets (path + frontmatter), reusing the single index pass. */
+  async indexedAssets(): Promise<IndexedAsset[]> {
+    await this.buildIndex();
+    return this.assets;
+  }
+
+  override async getMarkdownFiles(rootPath?: string): Promise<string[]> {
+    // A scoped sub-path query is rare and not part of the audit hot loop —
+    // delegate uncached to keep semantics identical.
+    if (rootPath) return super.getMarkdownFiles(rootPath);
+    await this.buildIndex();
+    return this.allPaths;
+  }
+
+  override async findFileByUID(uid: string): Promise<string | null> {
+    await this.buildIndex();
+    return this.uidToPath.get(uid) ?? null;
+  }
+
+  override async fileExists(filePath: string): Promise<boolean> {
+    await this.buildIndex();
+    const norm = filePath.replace(/\\/g, "/").replace(/^\.\//, "");
+    if (this.pathSet.has(norm)) return true;
+    // Non-indexed (absolute / non-md / outside-vault) paths fall back to disk.
+    return super.fileExists(filePath);
+  }
+}

--- a/packages/cli/src/commands/audit-co-location.ts
+++ b/packages/cli/src/commands/audit-co-location.ts
@@ -1,0 +1,218 @@
+import { Command } from "commander";
+import { existsSync, statSync } from "fs";
+import path from "path";
+import { resolve } from "path";
+import { extractAssetReference } from "exocortex";
+import { CachingNodeFsAdapter } from "../adapters/CachingNodeFsAdapter.js";
+import {
+  findReferencedFile,
+  normalizePath,
+} from "../executors/folderRepairHelpers.js";
+import { ErrorHandler, type OutputFormat } from "../utils/ErrorHandler.js";
+import { VaultNotFoundError } from "../utils/errors/index.js";
+
+/**
+ * Reasons an asset is fail-open SKIPPED (not a violation, but also not proven
+ * co-located). Reported explicitly so "0 violations" never masks "100%
+ * co-located" — per RFC 0b7a2fad skip-accounting requirement.
+ */
+export type CoLocationSkipReason =
+  | "empty-isDefinedBy"
+  | "bang-prefix"
+  | "unresolvable";
+
+export interface CoLocationViolation {
+  path: string;
+  isDefinedBy: string;
+  expectedFolder: string;
+  actualFolder: string;
+}
+
+export interface CoLocationResult {
+  vaultPath: string;
+  totalFiles: number;
+  /** Files where co-location was actually verified (ref resolved). */
+  checked: number;
+  violations: CoLocationViolation[];
+  skips: Record<CoLocationSkipReason, number>;
+  /** Up to a few example paths per skip reason, for human triage. */
+  skipExamples: Record<CoLocationSkipReason, string[]>;
+}
+
+const MAX_SKIP_EXAMPLES = 5;
+
+function addExample(
+  examples: Record<CoLocationSkipReason, string[]>,
+  reason: CoLocationSkipReason,
+  filePath: string,
+): void {
+  if (examples[reason].length < MAX_SKIP_EXAMPLES) {
+    examples[reason].push(filePath);
+  }
+}
+
+/**
+ * Audit a single vault for the asset–ontology co-location invariant: every
+ * asset with `exo__Asset_isDefinedBy` must physically live in the same folder
+ * as the ontology file that reference resolves to (FLAT, exact-match). Uses the
+ * shared {@link findReferencedFile} resolver (same path as `apply
+ * repair-folder`) over a cached adapter so the audit and migration agree.
+ *
+ * Fail-open: assets with no `isDefinedBy`, a `!`-prefixed (intentionally
+ * unresolvable) reference, or a reference that doesn't resolve in THIS vault
+ * (cross-vault or missing ontology file) are skipped and counted by reason —
+ * never reported as violations.
+ */
+export async function scanVaultForCoLocation(
+  vaultPath: string,
+): Promise<CoLocationResult> {
+  const adapter = new CachingNodeFsAdapter(vaultPath);
+  const assets = await adapter.indexedAssets();
+
+  const violations: CoLocationViolation[] = [];
+  const skips: Record<CoLocationSkipReason, number> = {
+    "empty-isDefinedBy": 0,
+    "bang-prefix": 0,
+    unresolvable: 0,
+  };
+  const skipExamples: Record<CoLocationSkipReason, string[]> = {
+    "empty-isDefinedBy": [],
+    "bang-prefix": [],
+    unresolvable: [],
+  };
+  let checked = 0;
+
+  for (const { path: relPath, metadata } of assets) {
+    // node_modules is not vault content (glob already excludes dotdirs like
+    // .git/.obsidian, but not node_modules). Never audit/report those.
+    if (relPath.split("/").includes("node_modules")) continue;
+
+    const rawIsDefinedBy = metadata["exo__Asset_isDefinedBy"];
+    const ref = extractAssetReference(rawIsDefinedBy);
+
+    if (!ref) {
+      skips["empty-isDefinedBy"]++;
+      addExample(skipExamples, "empty-isDefinedBy", relPath);
+      continue;
+    }
+    if (ref.startsWith("!")) {
+      skips["bang-prefix"]++;
+      addExample(skipExamples, "bang-prefix", relPath);
+      continue;
+    }
+
+    const ontologyPath = await findReferencedFile(adapter, ref, relPath);
+    if (!ontologyPath) {
+      // Unresolvable in this vault: cross-vault ontology OR genuinely missing.
+      skips.unresolvable++;
+      addExample(skipExamples, "unresolvable", relPath);
+      continue;
+    }
+
+    checked++;
+    const expectedFolder = normalizePath(path.dirname(ontologyPath));
+    const actualFolder = normalizePath(path.dirname(relPath));
+    if (expectedFolder !== actualFolder) {
+      violations.push({
+        path: relPath,
+        isDefinedBy: ref,
+        expectedFolder,
+        actualFolder,
+      });
+    }
+  }
+
+  return {
+    vaultPath,
+    totalFiles: assets.length,
+    checked,
+    violations,
+    skips,
+    skipExamples,
+  };
+}
+
+export interface AuditCoLocationOptions {
+  vault: string;
+  output?: OutputFormat;
+}
+
+/**
+ * RFC 0b7a2fad Phase 1 — co-location invariant audit (source of truth, CI).
+ *
+ * `exocortex audit co-location --vault <path>` walks the vault and reports any
+ * asset whose folder differs from its `isDefinedBy` ontology folder. Exit 0 =
+ * 0 violations (skips are still reported); exit 1 = ≥1 violation. Skips never
+ * affect the exit code — fail-open by design.
+ */
+export function auditCoLocationCommand(): Command {
+  return new Command("co-location")
+    .description(
+      "Detect asset–ontology co-location violations: any asset not in the folder of its exo__Asset_isDefinedBy ontology file (fail-open, skip-accounted)",
+    )
+    .requiredOption("--vault <path>", "Vault root directory")
+    .option("--output <type>", "Response format: text|json", "text")
+    .action(async (options: AuditCoLocationOptions) => {
+      const outputFormat = (options.output ?? "text") as OutputFormat;
+      ErrorHandler.setFormat(outputFormat);
+
+      try {
+        const vaultPath = resolve(options.vault);
+        if (!existsSync(vaultPath) || !statSync(vaultPath).isDirectory()) {
+          throw new VaultNotFoundError(vaultPath);
+        }
+
+        const result = await scanVaultForCoLocation(vaultPath);
+        const skipTotal =
+          result.skips["empty-isDefinedBy"] +
+          result.skips["bang-prefix"] +
+          result.skips.unresolvable;
+
+        if (outputFormat === "json") {
+          console.log(
+            JSON.stringify(
+              {
+                vaultPath: result.vaultPath,
+                totalFiles: result.totalFiles,
+                checked: result.checked,
+                violationCount: result.violations.length,
+                violations: result.violations,
+                skips: result.skips,
+                skipTotal,
+                skipExamples: result.skipExamples,
+                clean: result.violations.length === 0,
+              },
+              null,
+              2,
+            ),
+          );
+        } else {
+          if (result.violations.length === 0) {
+            console.log(
+              `OK ${vaultPath}: 0 co-location violations (${result.checked}/${result.totalFiles} checked)`,
+            );
+          } else {
+            console.error(
+              `FAIL ${vaultPath}: ${result.violations.length} co-location violation(s) (${result.checked}/${result.totalFiles} checked):`,
+            );
+            for (const v of result.violations) {
+              console.error(
+                `  ${v.path}\n      isDefinedBy=${v.isDefinedBy} expected=${v.expectedFolder}/ actual=${v.actualFolder}/`,
+              );
+            }
+          }
+          // Skip-accounting is always printed — "0 violations" ≠ "100% co-located".
+          console.error(
+            `\nSkipped (fail-open, NOT verified): ${skipTotal} — ` +
+              `empty-isDefinedBy=${result.skips["empty-isDefinedBy"]}, ` +
+              `bang-prefix=${result.skips["bang-prefix"]}, ` +
+              `unresolvable(cross-vault/missing)=${result.skips.unresolvable}`,
+          );
+        }
+
+        if (result.violations.length > 0) process.exitCode = 1;
+      } catch (error) {
+        ErrorHandler.handle(error as Error);
+      }
+    });
+}

--- a/packages/cli/src/commands/audit.ts
+++ b/packages/cli/src/commands/audit.ts
@@ -1,13 +1,16 @@
 import { Command } from "commander";
 import { auditGroundingTypeLiteralFormCommand } from "./audit-grounding-type-literal-form.js";
+import { auditCoLocationCommand } from "./audit-co-location.js";
 
 /**
  * Creates the 'audit' parent command with regression-detection subcommands:
  * - audit grounding-type-literal-form — RFC 9d20c91f Phase 4+1 regression
  *   detector for `exocmd__Grounding_type` literal-string form.
+ * - audit co-location — RFC 0b7a2fad asset–ontology co-location invariant.
  *
  * @example
  * exocortex audit grounding-type-literal-form --vault /path/to/vault
+ * exocortex audit co-location --vault /path/to/vault
  */
 export function auditCommand(): Command {
   const cmd = new Command("audit").description(
@@ -15,6 +18,7 @@ export function auditCommand(): Command {
   );
 
   cmd.addCommand(auditGroundingTypeLiteralFormCommand());
+  cmd.addCommand(auditCoLocationCommand());
 
   return cmd;
 }

--- a/packages/cli/tests/integration/commands/audit-co-location.integration.test.ts
+++ b/packages/cli/tests/integration/commands/audit-co-location.integration.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, beforeEach, afterEach } from "@jest/globals";
+import { mkdirSync, rmSync, writeFileSync, renameSync, existsSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import { scanVaultForCoLocation } from "../../../src/commands/audit-co-location.js";
+
+const ONTO_UID = "3618eb28-233b-4b49-98e8-65c8ce186a9f";
+const ASSET_UID = "11111111-2222-3333-4444-555555555555";
+
+function writeAsset(dir: string, uid: string, isDefinedBy?: string): string {
+  mkdirSync(dir, { recursive: true });
+  const idb =
+    isDefinedBy !== undefined ? `exo__Asset_isDefinedBy: ${isDefinedBy}\n` : "";
+  const file = join(dir, `${uid}.md`);
+  writeFileSync(
+    file,
+    `---
+exo__Asset_uid: ${uid}
+exo__Asset_label: Fixture ${uid}
+${idb}---
+
+Body.
+`,
+    "utf-8",
+  );
+  return file;
+}
+
+/**
+ * Empirical revert→fail / restore→pass proof for `audit co-location`.
+ *
+ * This is NOT a cyclic metric: the audit's verdict is driven purely by the
+ * asset's actual on-disk folder vs. its resolved ontology folder. We physically
+ * move the file out of co-location (audit must FAIL=1), then back (audit must
+ * PASS=0). If the audit reported 0 in BOTH states it would be a false-positive
+ * guard — this test would catch that.
+ */
+describe("audit co-location — revert→fail / restore→pass (integration)", () => {
+  let vault: string;
+  let ontoDir: string;
+  let wrongDir: string;
+
+  beforeEach(() => {
+    vault = join(
+      tmpdir(),
+      `coloc-integration-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    );
+    ontoDir = join(vault, "assetspaces", "concepts");
+    wrongDir = join(vault, "03 Knowledge", "inbox");
+    mkdirSync(vault, { recursive: true });
+    // Ontology file lives in assetspaces/concepts/
+    writeAsset(ontoDir, ONTO_UID);
+  });
+
+  afterEach(() => {
+    rmSync(vault, { recursive: true, force: true });
+  });
+
+  it("PASS when co-located, FAIL when moved away, PASS again when restored", async () => {
+    // --- State 1: co-located → audit PASS (0 violations) ---
+    const coLocated = writeAsset(ontoDir, ASSET_UID, `"[[${ONTO_UID}]]"`);
+    let r = await scanVaultForCoLocation(vault);
+    expect(r.violations).toHaveLength(0);
+    expect(r.checked).toBe(1);
+
+    // --- State 2: seed mismatch (move out of ontology folder) → audit FAIL (1) ---
+    mkdirSync(wrongDir, { recursive: true });
+    const moved = join(wrongDir, `${ASSET_UID}.md`);
+    renameSync(coLocated, moved);
+    expect(existsSync(coLocated)).toBe(false);
+    r = await scanVaultForCoLocation(vault);
+    expect(r.violations).toHaveLength(1);
+    expect(r.violations[0].actualFolder).toBe("03 Knowledge/inbox");
+    expect(r.violations[0].expectedFolder).toBe("assetspaces/concepts");
+
+    // --- State 3: restore (move back) → audit PASS (0 violations) ---
+    renameSync(moved, coLocated);
+    r = await scanVaultForCoLocation(vault);
+    expect(r.violations).toHaveLength(0);
+    expect(r.checked).toBe(1);
+  });
+
+  it("skip-accounting is independent of violations (fail-open assets never fail the audit)", async () => {
+    // Misplaced resolvable asset → 1 violation
+    writeAsset(wrongDir, ASSET_UID, `"[[${ONTO_UID}]]"`);
+    // Bang-prefix + dangling + empty → 3 skips, 0 extra violations
+    writeAsset(
+      wrongDir,
+      "aaaaaaaa-0000-0000-0000-000000000000",
+      `"[[!kitelev]]"`,
+    );
+    writeAsset(
+      wrongDir,
+      "bbbbbbbb-0000-0000-0000-000000000000",
+      `"[[deadbeef-0000-0000-0000-000000000000]]"`,
+    );
+    writeAsset(wrongDir, "cccccccc-0000-0000-0000-000000000000");
+
+    const r = await scanVaultForCoLocation(vault);
+    expect(r.violations).toHaveLength(1);
+    expect(r.skips["bang-prefix"]).toBe(1);
+    expect(r.skips.unresolvable).toBe(1);
+    // empty: the standalone empty asset + the ontology file
+    expect(r.skips["empty-isDefinedBy"]).toBe(2);
+  });
+});

--- a/packages/cli/tests/unit/adapters/CachingNodeFsAdapter.test.ts
+++ b/packages/cli/tests/unit/adapters/CachingNodeFsAdapter.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, beforeEach, afterEach } from "@jest/globals";
+import { mkdirSync, rmSync, writeFileSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import { NodeFsAdapter } from "../../../src/adapters/NodeFsAdapter.js";
+import { CachingNodeFsAdapter } from "../../../src/adapters/CachingNodeFsAdapter.js";
+
+/**
+ * The audit MUST resolve UIDs identically to migration, which uses the base
+ * NodeFsAdapter. These tests lock the cache's findFileByUID to base parity
+ * across the frontmatter UID forms that could diverge (quoted, array, numeric).
+ */
+describe("CachingNodeFsAdapter — findFileByUID parity with base NodeFsAdapter", () => {
+  let vault: string;
+
+  beforeEach(() => {
+    vault = join(
+      tmpdir(),
+      `caching-adapter-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    );
+    mkdirSync(vault, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(vault, { recursive: true, force: true });
+  });
+
+  function write(name: string, frontmatter: string): void {
+    writeFileSync(
+      join(vault, name),
+      `---\n${frontmatter}\n---\nBody.\n`,
+      "utf-8",
+    );
+  }
+
+  async function assertParity(uid: string): Promise<void> {
+    const base = new NodeFsAdapter(vault);
+    const cached = new CachingNodeFsAdapter(vault);
+    expect(await cached.findFileByUID(uid)).toBe(await base.findFileByUID(uid));
+  }
+
+  it("bare UUID", async () => {
+    write("a.md", "exo__Asset_uid: 11111111-1111-1111-1111-111111111111");
+    expect(
+      await new CachingNodeFsAdapter(vault).findFileByUID(
+        "11111111-1111-1111-1111-111111111111",
+      ),
+    ).toBe("a.md");
+    await assertParity("11111111-1111-1111-1111-111111111111");
+  });
+
+  it("quoted UID resolves same as base", async () => {
+    write("b.md", 'exo__Asset_uid: "22222222-2222-2222-2222-222222222222"');
+    await assertParity("22222222-2222-2222-2222-222222222222");
+    expect(
+      await new CachingNodeFsAdapter(vault).findFileByUID(
+        "22222222-2222-2222-2222-222222222222",
+      ),
+    ).toBe("b.md");
+  });
+
+  it("array-valued exo__Asset_uid — member resolves same as base", async () => {
+    write("c.md", "exo__Asset_uid:\n  - 33333333-3333-3333-3333-333333333333");
+    await assertParity("33333333-3333-3333-3333-333333333333");
+  });
+
+  it("missing UID → both return null", async () => {
+    write("d.md", "exo__Asset_label: no uid");
+    await assertParity("99999999-9999-9999-9999-999999999999");
+  });
+});

--- a/packages/cli/tests/unit/commands/audit-co-location.test.ts
+++ b/packages/cli/tests/unit/commands/audit-co-location.test.ts
@@ -1,0 +1,252 @@
+import {
+  describe,
+  it,
+  expect,
+  beforeEach,
+  afterEach,
+  jest,
+} from "@jest/globals";
+import { mkdirSync, rmSync, writeFileSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import {
+  scanVaultForCoLocation,
+  auditCoLocationCommand,
+} from "../../../src/commands/audit-co-location.js";
+import { auditCommand } from "../../../src/commands/audit.js";
+
+const ONTO_UID = "3618eb28-233b-4b49-98e8-65c8ce186a9f";
+
+/** Write an asset .md with the given uid + optional isDefinedBy line. */
+function writeAsset(
+  dir: string,
+  uid: string,
+  isDefinedBy?: string,
+  label = "Test Asset",
+): void {
+  mkdirSync(dir, { recursive: true });
+  const idbLine =
+    isDefinedBy !== undefined ? `exo__Asset_isDefinedBy: ${isDefinedBy}\n` : "";
+  const content = `---
+exo__Asset_uid: ${uid}
+exo__Asset_label: ${label}
+${idbLine}---
+
+Body.
+`;
+  writeFileSync(join(dir, `${uid}.md`), content, "utf-8");
+}
+
+describe("audit co-location — Commander wiring", () => {
+  it("registers under 'audit' parent command", () => {
+    const parent = auditCommand();
+    expect(parent.name()).toBe("audit");
+    const sub = parent.commands.find((c) => c.name() === "co-location");
+    expect(sub).toBeDefined();
+  });
+
+  it("subcommand declares --vault required + --output options", () => {
+    const sub = auditCoLocationCommand();
+    expect(sub.name()).toBe("co-location");
+    const opts = sub.options.map((o) => o.long);
+    expect(opts).toContain("--vault");
+    expect(opts).toContain("--output");
+  });
+
+  it("--help references co-location invariant semantics", () => {
+    const sub = auditCoLocationCommand();
+    expect(sub.helpInformation()).toMatch(/co-location|isDefinedBy/);
+  });
+});
+
+describe("audit co-location — scanVaultForCoLocation", () => {
+  let vault: string;
+
+  beforeEach(() => {
+    vault = join(
+      tmpdir(),
+      `audit-coloc-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    );
+    mkdirSync(vault, { recursive: true });
+    // Ontology file (no isDefinedBy → itself skipped) under assetspaces/concepts/
+    writeAsset(
+      join(vault, "assetspaces", "concepts"),
+      ONTO_UID,
+      undefined,
+      "$concepts",
+    );
+  });
+
+  afterEach(() => {
+    rmSync(vault, { recursive: true, force: true });
+  });
+
+  it("reports 0 violations when asset is co-located with its ontology folder", async () => {
+    writeAsset(
+      join(vault, "assetspaces", "concepts"),
+      "asset-co-located",
+      `"[[${ONTO_UID}]]"`,
+    );
+    const r = await scanVaultForCoLocation(vault);
+    expect(r.violations).toHaveLength(0);
+    expect(r.checked).toBe(1); // the asset; ontology file skipped (empty)
+  });
+
+  it("detects a violation when asset is in the wrong folder", async () => {
+    writeAsset(
+      join(vault, "03 Knowledge", "inbox"),
+      "asset-misplaced",
+      `"[[${ONTO_UID}]]"`,
+    );
+    const r = await scanVaultForCoLocation(vault);
+    expect(r.violations).toHaveLength(1);
+    expect(r.violations[0].path).toBe("03 Knowledge/inbox/asset-misplaced.md");
+    expect(r.violations[0].expectedFolder).toBe("assetspaces/concepts");
+    expect(r.violations[0].actualFolder).toBe("03 Knowledge/inbox");
+  });
+
+  it("resolves alias-form isDefinedBy (`[[uid|alias]]`)", async () => {
+    writeAsset(
+      join(vault, "assetspaces", "concepts"),
+      "asset-alias",
+      `"[[${ONTO_UID}|$concepts]]"`,
+    );
+    const r = await scanVaultForCoLocation(vault);
+    expect(r.violations).toHaveLength(0);
+    expect(r.checked).toBe(1);
+  });
+
+  it("skip-accounting: empty-isDefinedBy", async () => {
+    writeAsset(join(vault, "03 Knowledge"), "asset-no-idb"); // no isDefinedBy
+    const r = await scanVaultForCoLocation(vault);
+    // ontology file + this asset both lack isDefinedBy
+    expect(r.skips["empty-isDefinedBy"]).toBe(2);
+    expect(r.violations).toHaveLength(0);
+  });
+
+  it("skip-accounting: bang-prefix (intentionally unresolvable)", async () => {
+    writeAsset(
+      join(vault, "03 Knowledge", "inbox"),
+      "asset-bang",
+      `"[[!kitelev]]"`,
+    );
+    const r = await scanVaultForCoLocation(vault);
+    expect(r.skips["bang-prefix"]).toBe(1);
+    expect(r.violations).toHaveLength(0);
+  });
+
+  it("skip-accounting: unresolvable (cross-vault/missing ontology)", async () => {
+    writeAsset(
+      join(vault, "03 Knowledge", "inbox"),
+      "asset-dangling",
+      `"[[ffffffff-0000-0000-0000-000000000000]]"`,
+    );
+    const r = await scanVaultForCoLocation(vault);
+    expect(r.skips.unresolvable).toBe(1);
+    expect(r.violations).toHaveLength(0);
+  });
+
+  it("counts multiple violations across folders", async () => {
+    writeAsset(join(vault, "03 Knowledge", "inbox"), "m1", `"[[${ONTO_UID}]]"`);
+    writeAsset(
+      join(vault, "03 Knowledge", "tbank-public"),
+      "m2",
+      `"[[${ONTO_UID}]]"`,
+    );
+    writeAsset(
+      join(vault, "assetspaces", "concepts"),
+      "ok1",
+      `"[[${ONTO_UID}]]"`,
+    );
+    const r = await scanVaultForCoLocation(vault);
+    expect(r.violations).toHaveLength(2);
+    expect(r.checked).toBe(3);
+  });
+
+  it("does not flag misplaced .md inside .obsidian (glob) or node_modules (audit guard)", async () => {
+    // Both would resolve to the concepts ontology and thus look like violations
+    // if scanned — but .obsidian is excluded by glob (dot:false) and
+    // node_modules is skipped by the audit guard.
+    writeAsset(join(vault, ".obsidian"), "dot1", `"[[${ONTO_UID}]]"`);
+    writeAsset(join(vault, "node_modules", "pkg"), "nm1", `"[[${ONTO_UID}]]"`);
+    const r = await scanVaultForCoLocation(vault);
+    expect(r.violations).toHaveLength(0);
+    expect(r.checked).toBe(0); // only the ontology file (empty isDefinedBy) remains
+  });
+});
+
+describe("audit co-location — command action (output + exit code)", () => {
+  let vault: string;
+  let logSpy: ReturnType<typeof jest.spyOn>;
+  let errSpy: ReturnType<typeof jest.spyOn>;
+  let prevExit: number | undefined;
+
+  beforeEach(() => {
+    vault = join(
+      tmpdir(),
+      `audit-coloc-cmd-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    );
+    mkdirSync(vault, { recursive: true });
+    writeAsset(
+      join(vault, "assetspaces", "concepts"),
+      ONTO_UID,
+      undefined,
+      "$concepts",
+    );
+    logSpy = jest.spyOn(console, "log").mockImplementation(() => {});
+    errSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+    prevExit = process.exitCode;
+    process.exitCode = undefined;
+  });
+
+  afterEach(() => {
+    logSpy.mockRestore();
+    errSpy.mockRestore();
+    process.exitCode = prevExit;
+    rmSync(vault, { recursive: true, force: true });
+  });
+
+  it("text output, clean vault → exit 0", async () => {
+    writeAsset(
+      join(vault, "assetspaces", "concepts"),
+      "ok",
+      `"[[${ONTO_UID}]]"`,
+    );
+    const cmd = auditCoLocationCommand();
+    await cmd.parseAsync(["--vault", vault], { from: "user" });
+    expect(process.exitCode).toBeFalsy();
+    const out = logSpy.mock.calls.map((c) => c.join(" ")).join("\n");
+    expect(out).toMatch(/0 co-location violations/);
+  });
+
+  it("text output, dirty vault → exit 1 + skip-accounting printed", async () => {
+    writeAsset(
+      join(vault, "03 Knowledge", "inbox"),
+      "bad",
+      `"[[${ONTO_UID}]]"`,
+    );
+    const cmd = auditCoLocationCommand();
+    await cmd.parseAsync(["--vault", vault], { from: "user" });
+    expect(process.exitCode).toBe(1);
+    const err = errSpy.mock.calls.map((c) => c.join(" ")).join("\n");
+    expect(err).toMatch(/1 co-location violation/);
+    expect(err).toMatch(/Skipped \(fail-open/);
+  });
+
+  it("json output emits structured result", async () => {
+    writeAsset(
+      join(vault, "03 Knowledge", "inbox"),
+      "bad",
+      `"[[${ONTO_UID}]]"`,
+    );
+    const cmd = auditCoLocationCommand();
+    await cmd.parseAsync(["--vault", vault, "--output", "json"], {
+      from: "user",
+    });
+    const out = logSpy.mock.calls.map((c) => c.join(" ")).join("\n");
+    const parsed = JSON.parse(out);
+    expect(parsed.violationCount).toBe(1);
+    expect(parsed.clean).toBe(false);
+    expect(parsed.skips).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary
Implements the CLI half of **RFC 0b7a2fad Phase 1** — the asset–ontology co-location invariant audit (source of truth for CI + manual checks).

- New `exocortex audit co-location --vault <path>` subcommand: reports any asset whose folder differs from the folder of the ontology file its `exo__Asset_isDefinedBy` resolves to (same vault, **FLAT** exact-match).
- **Unified resolver**: reuses the existing `findReferencedFile` (the `apply repair-folder` path) rather than a divergent `getExpectedFolderSync`, so an audit violation maps to the same move target as migration.
- New `CachingNodeFsAdapter`: one O(N) index pass (uid→path / pathSet / metadata) wrapping the same resolver → eliminates the naive O(N²) blow-up. **Validated: vault-2025 (11 729 files) in ~1.7 s.**
- **Skip-accounting by reason** (`empty-isDefinedBy` / `bang-prefix` / `unresolvable`): "0 violations" never masks "100% co-located". Fail-open — skips never affect the exit code.
- Exit 0 = 0 violations; exit 1 = ≥1 violation (CI-friendly).

## Scope note
The PreToolUse enforcement hook + `/exocortex-asset` placement rewrite live in the user's `dotfiles` repo (deployed atomically there). This PR is the CLI audit only.

## Test plan
- [x] Unit: Commander wiring, scan (co-located/mismatch/alias-form/skip reasons/multi-violation), command action (text+json+exit-code) — `tests/unit/commands/audit-co-location.test.ts`
- [x] Integration: **revert→fail / restore→pass** empirical proof (move asset out of co-location → audit=1 → restore → 0) — `tests/integration/commands/audit-co-location.integration.test.ts`
- [x] 29/29 green locally; `check:types` clean; prettier clean
- [x] Scale: `audit co-location --vault /Users/kitelev/vault-2025` → 9207 violations, 553 skips (415 empty / 35 bang / 103 unresolvable), 1.7 s

🤖 Generated with [Claude Code](https://claude.com/claude-code)