### PR TITLE
feat(rdf): emit Obsidian aliases as exo:Asset_aliases (RFC 1b1c21b2 D1)

### DIFF
--- a/packages/exocortex/src/services/NoteToRDFConverter.ts
+++ b/packages/exocortex/src/services/NoteToRDFConverter.ts
@@ -47,6 +47,7 @@ const UNPREFIXED_ASSET_FIELDS: ReadonlySet<string> = new Set([
   "archived",
   "draft",
   "pinned",
+  "aliases",
 ]);
 
 /**
@@ -301,12 +302,15 @@ export class NoteToRDFConverter {
       const values = Array.isArray(value) ? value : [value];
 
       for (const val of values) {
-        // Skip empty-string exo__Asset_label values — Literal() rejects empty
-        // strings. Basename fallback below will synthesise the label triple.
+        // Skip empty-string / null values for exo__Asset_label and whitelisted
+        // unprefixed fields. `new Literal("")` throws (Literal.ts) and null
+        // would emit a junk "null" literal; a single bad alias must not discard
+        // the whole asset's triples. Boolean flags (archived/draft/pinned:false)
+        // are NOT skipped — only null/undefined/blank-string. For exo__Asset_label
+        // the basename fallback below still synthesises the label triple.
         if (
-          key === "exo__Asset_label" &&
-          typeof val === "string" &&
-          val.trim() === ""
+          (key === "exo__Asset_label" || UNPREFIXED_ASSET_FIELDS.has(key)) &&
+          (val == null || (typeof val === "string" && val.trim() === ""))
         ) {
           continue;
         }

--- a/packages/exocortex/tests/unit/services/NoteToRDFConverter.namespace-relax.test.ts
+++ b/packages/exocortex/tests/unit/services/NoteToRDFConverter.namespace-relax.test.ts
@@ -82,8 +82,10 @@ describe("NoteToRDFConverter — namespace whitelist relaxation", () => {
   });
 
   it("ignores keys without the <prefix>__<local> shape", async () => {
+    // `aliases` moved to the UNPREFIXED_ASSET_FIELDS whitelist (RFC 1b1c21b2) —
+    // it is now emitted as exo:Asset_aliases and covered in NoteToRDFConverter.test.ts.
+    // `tags` / `cssclasses` remain non-whitelisted and must stay ignored.
     const frontmatter: IFrontmatter = {
-      aliases: ["foo", "bar"],
       tags: ["x"],
       cssclasses: "muted",
     };

--- a/packages/exocortex/tests/unit/services/NoteToRDFConverter.test.ts
+++ b/packages/exocortex/tests/unit/services/NoteToRDFConverter.test.ts
@@ -467,6 +467,18 @@ describe("NoteToRDFConverter", () => {
         expect(aliasTriples).toHaveLength(1);
         expect((aliasTriples[0].object as Literal).value).toBe("Valid");
       });
+
+      it("emits a numeric alias as a sane literal without throwing", async () => {
+        // aliases are normally strings; a stray number must not crash the
+        // converter (it falls through the null/blank guard to valueToRDFObject).
+        mockVault.getFrontmatter.mockReturnValue({ aliases: [42] });
+
+        const triples = await converter.convertNote(aliasFile);
+
+        const aliasTriples = aliasTriplesOf(triples);
+        expect(aliasTriples).toHaveLength(1);
+        expect((aliasTriples[0].object as Literal).value).toBe("42");
+      });
     });
 
     // Issue #666: Add Asset_filename predicate for all assets

--- a/packages/exocortex/tests/unit/services/NoteToRDFConverter.test.ts
+++ b/packages/exocortex/tests/unit/services/NoteToRDFConverter.test.ts
@@ -4,6 +4,7 @@ import { IVaultAdapter, IFile, IFrontmatter } from "../../../src/interfaces/IVau
 import type { ILogger } from "../../../src/interfaces/ILogger";
 import { IRI } from "../../../src/domain/models/rdf/IRI";
 import { Literal } from "../../../src/domain/models/rdf/Literal";
+import { Triple } from "../../../src/domain/models/rdf/Triple";
 import { BlankNode } from "../../../src/domain/models/rdf/BlankNode";
 import { Namespace } from "../../../src/domain/models/rdf/Namespace";
 import { Exo003MetadataType } from "../../../src/domain/models/exo003";
@@ -400,6 +401,71 @@ describe("NoteToRDFConverter", () => {
           return p.includes("Asset_color") || p.includes("Asset_priority");
         });
         expect(leaked).toBeUndefined();
+      });
+
+      // RFC 1b1c21b2: aliases emitted as exo:Asset_aliases so SPARQL can query
+      // them (e.g. the homoiconic Copy-Label precondition: label ∉ aliases).
+      const aliasFile: IFile = {
+        path: "test.md",
+        basename: "test",
+        name: "test.md",
+        parent: null,
+      };
+      const aliasTriplesOf = (triples: Triple[]): Triple[] =>
+        triples.filter((t) =>
+          (t.predicate as IRI).value.endsWith("exo#Asset_aliases"),
+        );
+
+      it("emits exo:Asset_aliases triples for each alias (multi-value, verbatim)", async () => {
+        mockVault.getFrontmatter.mockReturnValue({
+          aliases: ["First Alias", "Second Alias"],
+        });
+
+        const triples = await converter.convertNote(aliasFile);
+
+        const aliasTriples = aliasTriplesOf(triples);
+        expect(aliasTriples).toHaveLength(2);
+        expect(
+          aliasTriples.map((t) => (t.object as Literal).value).sort(),
+        ).toEqual(["First Alias", "Second Alias"]);
+      });
+
+      it("emits an alias byte-identical to the label (Copy-Label precondition round-trip)", async () => {
+        mockVault.getFrontmatter.mockReturnValue({
+          exo__Asset_label: "My Label",
+          aliases: ["My Label"],
+        });
+
+        const triples = await converter.convertNote(aliasFile);
+
+        const labelTriple = triples.find((t) =>
+          (t.predicate as IRI).value.endsWith("exo#Asset_label"),
+        );
+        const aliasTriple = aliasTriplesOf(triples)[0];
+        expect((labelTriple!.object as Literal).value).toBe("My Label");
+        expect((aliasTriple!.object as Literal).value).toBe("My Label");
+      });
+
+      it("skips empty-string aliases without throwing (new Literal('') guard)", async () => {
+        mockVault.getFrontmatter.mockReturnValue({ aliases: ["", "   ", "Valid"] });
+
+        const triples = await converter.convertNote(aliasFile);
+
+        const aliasTriples = aliasTriplesOf(triples);
+        expect(aliasTriples).toHaveLength(1);
+        expect((aliasTriples[0].object as Literal).value).toBe("Valid");
+      });
+
+      it("skips null/undefined aliases without emitting a 'null' literal", async () => {
+        mockVault.getFrontmatter.mockReturnValue({
+          aliases: [null, "Valid", undefined],
+        });
+
+        const triples = await converter.convertNote(aliasFile);
+
+        const aliasTriples = aliasTriplesOf(triples);
+        expect(aliasTriples).toHaveLength(1);
+        expect((aliasTriples[0].object as Literal).value).toBe("Valid");
       });
     });
 


### PR DESCRIPTION
## Summary

Makes the Obsidian-native `aliases` frontmatter list **queryable in SPARQL** by emitting `exo:Asset_aliases` triples — materialising the ABox for the already-declared `exo` aliases `DatatypeProperty` (`abdb56bc`). Unblocks the homoiconic **Copy Label to Aliases** precondition (`label ∉ aliases`).

Part of RFC `1b1c21b2` (v2, 3-agent reviewed), project `f9b52c35`, deliverable **D1**.

## Changes
- `UNPREFIXED_ASSET_FIELDS` += `"aliases"` (single chokepoint — shared converter, plugin + CLI parity).
- **empty/null guard**: skip empty-string / null values for `exo__Asset_label` + whitelisted unprefixed fields. `new Literal("")` throws (`Literal.ts`) and `null` emits a junk `"null"` literal; a single malformed alias must not discard the asset's whole triple set (two-phase atomic commit) or fail a strict reindex. Boolean flags (`archived:false`) are **not** skipped.
- Tests: multi-value emission, label==alias byte-identical round-trip, empty-string `[""]`/`["   "]` skip, `null`/`undefined` skip.
- `namespace-relax` test: `aliases` moved off the "ignored keys" list (`tags`/`cssclasses` stay ignored per RFC scope).

## Why the guard (review finding)
The parser/converter reviewer (3-agent RFC review) flagged that `aliases:[""]` reaches `new Literal("")` → throws → asset's triples discarded (non-strict) or strict reindex fails. Guard closes this.

## Test plan
- [x] `check:types` green
- [x] `NoteToRDFConverter.*` suites — 270 pass (15 suites)
- [x] `GroundingExecutor` — 148 pass
- [x] **revert-verify**: the 4 new aliases tests FAIL without the whitelist line, PASS with it
- [x] archgate 16/16 (pre-commit)
- [ ] CI (14 checks) — incl. test-bdd / test-coverage / e2e / parity-gate
- [ ] code-reviewer + advisor (strict-parser auto-merge discipline)

## Out of scope (per RFC)
- Predicate-reconciliation retag of `abdb56bc` → vault submodule (D1b, separate).
- Precondition asset + wire to `a04a9129` (D3).
- `tags`/`cssclasses` emission.