### PR TITLE
feat(profile): mobile profile switch via REST mount-state (RFC 01a83de8 Phase 3 T2)

### DIFF
--- a/packages/obsidian-plugin/src/ExocortexPlugin.ts
+++ b/packages/obsidian-plugin/src/ExocortexPlugin.ts
@@ -122,8 +122,11 @@ import { GitSubmoduleOps } from "./infrastructure/adapters/GitSubmoduleOps";
 import {
   buildHardSwitchDeps,
   buildAssetSpacePuller,
+  buildRestAssetSpaceMount,
   type HardSwitchDeps,
 } from "./infrastructure/adapters/HardSwitchDepsFactory";
+import { ModalConfirmGate } from "./infrastructure/adapters/ModalConfirmGate";
+import type { RestAssetSpaceMount } from "./infrastructure/adapters/RestAssetSpaceMount";
 import {
   CommandExecutionFlow,
   DI_TOKENS,
@@ -2599,6 +2602,26 @@ export default class ExocortexPlugin extends Plugin {
           logger: this.logger,
         });
 
+    // RFC 01a83de8 Phase 3 T2 — cross-platform (incl. iOS) REST/tarball mount.
+    // Built on BOTH platforms: the mobile profile-switch path consumes it
+    // (`FocusProfileSwitchManager.restSwitchProfile`), and it's harmless on
+    // desktop (the desktop hard switch keeps the git-binary path). Best-effort
+    // — a wiring failure logs + leaves restMount null (mobile switch then
+    // surfaces a clear "not wired" error instead of crashing onload).
+    let restMount: RestAssetSpaceMount | null = null;
+    try {
+      restMount = await buildRestAssetSpaceMount({ app: this.app });
+    } catch (err) {
+      this.logger.warn(
+        "[ExocortexPlugin] buildRestAssetSpaceMount failed — mobile profile switch unavailable",
+        err instanceof Error ? err : new Error(String(err)),
+      );
+    }
+    // The mobile REST switch needs a ConfirmGate; on desktop it comes from
+    // hardSwitchDeps. ModalConfirmGate only needs `app` (mobile-safe).
+    const confirmGate =
+      hardSwitchDeps?.confirmGate ?? new ModalConfirmGate(this.app);
+
     const switchMgr = new FocusProfileSwitchManager({
       app: this.app,
       lockMgr,
@@ -2608,8 +2631,9 @@ export default class ExocortexPlugin extends Plugin {
       notify: (message) => this.notifier.info(message),
       assetSpaceManager: hardSwitchDeps?.assetSpaceManager,
       gitOps: hardSwitchDeps?.gitOps,
+      restMount: restMount ?? undefined,
       uncommittedGuard: hardSwitchDeps?.uncommittedGuard,
-      confirmGate: hardSwitchDeps?.confirmGate,
+      confirmGate,
       cacheLayer: hardSwitchDeps?.cacheLayer,
       vaultRootPath: hardSwitchDeps?.vaultRootPath,
       localDataStore,
@@ -2840,7 +2864,11 @@ export default class ExocortexPlugin extends Plugin {
     // so any hotkey a user already bound to the hard-switch command survives the
     // Knowledge/Focus split (Obsidian persists hotkeys by command id). Only the
     // user-facing name + picker source change.
-    if (hardSwitchDeps !== null) {
+    // RFC 01a83de8 Phase 3 T2 — register on desktop (git-binary hard switch)
+    // OR mobile when the REST mount is wired (FocusProfileSwitchManager
+    // dispatches to restSwitchProfile on mobile). Without either, the
+    // filesystem materialisation can't run, so the command stays hidden.
+    if (hardSwitchDeps !== null || (Platform.isMobile && restMount !== null)) {
       this.addCommand({
         id: "hard-switch-focus-profile",
         name: "Switch knowledge profile (filesystem destroy + materialize)",

--- a/packages/obsidian-plugin/src/ExocortexPlugin.ts
+++ b/packages/obsidian-plugin/src/ExocortexPlugin.ts
@@ -2632,6 +2632,9 @@ export default class ExocortexPlugin extends Plugin {
       assetSpaceManager: hardSwitchDeps?.assetSpaceManager,
       gitOps: hardSwitchDeps?.gitOps,
       restMount: restMount ?? undefined,
+      // Fresh-PAT rebuild at switch time (Issue #3382 pattern) so a PAT set
+      // after onload is honoured without a reload — the primary mobile flow.
+      restMountFactory: () => buildRestAssetSpaceMount({ app: this.app }),
       uncommittedGuard: hardSwitchDeps?.uncommittedGuard,
       confirmGate,
       cacheLayer: hardSwitchDeps?.cacheLayer,

--- a/packages/obsidian-plugin/src/infrastructure/adapters/FocusProfileSwitchManager.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/FocusProfileSwitchManager.ts
@@ -205,8 +205,19 @@ export interface FocusProfileSwitchManagerOptions {
    * cross-platform (incl. iOS) materialisation path. When wired and running on
    * mobile, `hardSwitchKnowledgeProfile` delegates to {@link restSwitchProfile}
    * (no git binary / staging / cache). Desktop keeps the git-binary path.
+   *
+   * Captured at onload — used to gate command registration + as a fallback.
+   * Prefer {@link restMountFactory} for a fresh-PAT mount at switch time.
    */
   restMount?: RestAssetSpaceMount;
+  /**
+   * Factory building a {@link RestAssetSpaceMount} with the CURRENTLY stored
+   * PAT. Preferred over {@link restMount} inside {@link restSwitchProfile} so a
+   * PAT configured AFTER onload is honoured without a reload (matches the
+   * Issue #3382 fix for the Bootstrap/Add-AssetSpace puller). Falls back to the
+   * captured {@link restMount} when absent.
+   */
+  restMountFactory?: () => Promise<RestAssetSpaceMount>;
   /** Uncommitted-changes guard (Vision Lock #5). */
   uncommittedGuard?: UncommittedChangesGuard;
   /** Confirmation gate — ModalConfirmGate в plugin runtime. */
@@ -280,6 +291,7 @@ export class FocusProfileSwitchManager {
   private readonly cacheLayer?: ICacheLayer;
   private readonly gitOps?: GitSubmoduleOps;
   private readonly restMount?: RestAssetSpaceMount;
+  private readonly restMountFactory?: () => Promise<RestAssetSpaceMount>;
   private readonly uncommittedGuard?: UncommittedChangesGuard;
   private readonly confirmGate?: IConfirmGate;
   private readonly localDataStore?: PluginLocalDataStore;
@@ -300,6 +312,7 @@ export class FocusProfileSwitchManager {
     this.cacheLayer = options.cacheLayer;
     this.gitOps = options.gitOps;
     this.restMount = options.restMount;
+    this.restMountFactory = options.restMountFactory;
     this.uncommittedGuard = options.uncommittedGuard;
     this.confirmGate = options.confirmGate;
     this.localDataStore = options.localDataStore;
@@ -683,7 +696,10 @@ export class FocusProfileSwitchManager {
     // RFC 01a83de8 Phase 3 T2 — on mobile the git binary is unavailable, so
     // delegate to the REST/tarball mount/unmount path (no staging / cache /
     // git commit). Desktop keeps the git-binary path below unchanged.
-    if (Platform.isMobile && this.restMount !== undefined) {
+    if (
+      Platform.isMobile &&
+      (this.restMount !== undefined || this.restMountFactory !== undefined)
+    ) {
       return this.restSwitchProfile(targetProfileUid);
     }
     const deps = this.assertHardSwitchWired();
@@ -1079,6 +1095,15 @@ export class FocusProfileSwitchManager {
    *   4. Lock + journal; unmount toDestroy, mount toMaterialize via restMount.
    *   5. Persist active profile (+ Knowledge mirror) + RDF re-index.
    *
+   * **Partial-failure / recovery**: like T1's primitive, this does
+   * unmount-then-mount with NO rollback. On a mid-switch crash the catch block
+   * clears `_switchInProgress` and leaves `activeProfileUid` at the pre-switch
+   * value (the success-path save never ran). The desktop cache-restore worker
+   * (`recoverIncompleteSwitch`) is desktop-only (cache/gitOps-gated), so mobile
+   * has no auto cache-restore — but the state self-heals: mount-state is
+   * self-describing (folder exists = active), T1 mount/unmount are per-op
+   * idempotent, and re-running the switch reconciles to the target.
+   *
    * @throws TsFloorViolationError if target excludes any TS-floor AS.
    * @throws HardSwitchAbortedByUser if confirmGate declines.
    */
@@ -1086,7 +1111,12 @@ export class FocusProfileSwitchManager {
     if (typeof targetProfileUid !== "string" || targetProfileUid.length === 0) {
       throw new Error("restSwitchProfile: targetProfileUid is required");
     }
-    const { restMount, confirmGate, localDataStore } = this.assertRestSwitchWired();
+    const { confirmGate, localDataStore } = this.assertRestSwitchWired();
+    // Prefer the fresh-PAT factory (Issue #3382 pattern) over the onload-captured
+    // mount, so a PAT set after onload is honoured without a reload.
+    const restMount = this.restMountFactory
+      ? await this.restMountFactory()
+      : (this.restMount as RestAssetSpaceMount);
     const startedAt = this.now().getTime();
     const prevActiveProfileUid = localDataStore.getActiveProfileUid();
     const targetProfileLabel = await this.profileLabel(targetProfileUid);
@@ -1131,6 +1161,9 @@ export class FocusProfileSwitchManager {
       label: string;
       ref: string;
     }> = [];
+    // Iterate ALL declared AS (vs the desktop path's `currentAsUids` for the
+    // destroy loop) — equivalent because `materialised` implies presence in
+    // `currentAsUids`; this single loop also covers the materialise side.
     for (const info of allInfos) {
       const materialised = currentAsUids.has(info.uid);
       const inEffective = effectiveAsUids.has(info.uid);
@@ -1265,21 +1298,19 @@ export class FocusProfileSwitchManager {
   }
 
   private assertRestSwitchWired(): {
-    restMount: RestAssetSpaceMount;
     confirmGate: IConfirmGate;
     localDataStore: PluginLocalDataStore;
   } {
     if (
-      this.restMount === undefined ||
+      (this.restMount === undefined && this.restMountFactory === undefined) ||
       this.confirmGate === undefined ||
       this.localDataStore === undefined
     ) {
       throw new Error(
-        "restSwitchProfile: dependencies not wired (restMount, confirmGate, localDataStore required)",
+        "restSwitchProfile: dependencies not wired (restMount|restMountFactory, confirmGate, localDataStore required)",
       );
     }
     return {
-      restMount: this.restMount,
       confirmGate: this.confirmGate,
       localDataStore: this.localDataStore,
     };

--- a/packages/obsidian-plugin/src/infrastructure/adapters/FocusProfileSwitchManager.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/FocusProfileSwitchManager.ts
@@ -1,3 +1,4 @@
+import { Platform } from "obsidian";
 import type { App } from "obsidian";
 import type { HardSwitchPlan, IConfirmGate } from "exocortex";
 import { derivePath } from "exocortex";
@@ -6,6 +7,7 @@ import { PluginLockManager } from "./PluginLockManager";
 import type { AssetSpaceManager, AssetSpaceInfo } from "./AssetSpaceManager";
 import type { ICacheLayer } from "./SwitchCacheLayer";
 import type { GitSubmoduleOps } from "./GitSubmoduleOps";
+import type { RestAssetSpaceMount } from "./RestAssetSpaceMount";
 import type { UncommittedChangesGuard } from "./UncommittedChangesGuard";
 import type { PluginLocalDataStore } from "./PluginLocalDataStore";
 import { TS_FLOOR_ASSETSPACE_UIDS } from "./FocusProfileOnloadWiring";
@@ -198,6 +200,13 @@ export interface FocusProfileSwitchManagerOptions {
   cacheLayer?: ICacheLayer;
   /** Git submodule operations wrapper. */
   gitOps?: GitSubmoduleOps;
+  /**
+   * REST/tarball AssetSpace mount/unmount (RFC 01a83de8 Phase 3 T1). The
+   * cross-platform (incl. iOS) materialisation path. When wired and running on
+   * mobile, `hardSwitchKnowledgeProfile` delegates to {@link restSwitchProfile}
+   * (no git binary / staging / cache). Desktop keeps the git-binary path.
+   */
+  restMount?: RestAssetSpaceMount;
   /** Uncommitted-changes guard (Vision Lock #5). */
   uncommittedGuard?: UncommittedChangesGuard;
   /** Confirmation gate — ModalConfirmGate в plugin runtime. */
@@ -270,6 +279,7 @@ export class FocusProfileSwitchManager {
   private readonly assetSpaceManager?: AssetSpaceManager;
   private readonly cacheLayer?: ICacheLayer;
   private readonly gitOps?: GitSubmoduleOps;
+  private readonly restMount?: RestAssetSpaceMount;
   private readonly uncommittedGuard?: UncommittedChangesGuard;
   private readonly confirmGate?: IConfirmGate;
   private readonly localDataStore?: PluginLocalDataStore;
@@ -289,6 +299,7 @@ export class FocusProfileSwitchManager {
     this.assetSpaceManager = options.assetSpaceManager;
     this.cacheLayer = options.cacheLayer;
     this.gitOps = options.gitOps;
+    this.restMount = options.restMount;
     this.uncommittedGuard = options.uncommittedGuard;
     this.confirmGate = options.confirmGate;
     this.localDataStore = options.localDataStore;
@@ -669,6 +680,12 @@ export class FocusProfileSwitchManager {
     if (typeof targetProfileUid !== "string" || targetProfileUid.length === 0) {
       throw new Error("hardSwitchKnowledgeProfile: targetProfileUid is required");
     }
+    // RFC 01a83de8 Phase 3 T2 — on mobile the git binary is unavailable, so
+    // delegate to the REST/tarball mount/unmount path (no staging / cache /
+    // git commit). Desktop keeps the git-binary path below unchanged.
+    if (Platform.isMobile && this.restMount !== undefined) {
+      return this.restSwitchProfile(targetProfileUid);
+    }
     const deps = this.assertHardSwitchWired();
 
     const startedAt = this.now().getTime();
@@ -1042,6 +1059,230 @@ export class FocusProfileSwitchManager {
       await this.releaseStagingPaths(stagingPaths);
       await this.lockMgr.releaseLock();
     }
+  }
+
+  /**
+   * Mobile-capable profile switch (RFC 01a83de8 Phase 3 T2). Materialises the
+   * target profile's effective AssetSpace set via REST/tarball mount/unmount
+   * (no git binary, staging dir, cache layer, or git commit). Delegated to by
+   * {@link hardSwitchKnowledgeProfile} when running on mobile with `restMount`
+   * wired; desktop keeps the git-binary path.
+   *
+   * Visibility is **mount-state**: an AssetSpace is "active" iff its derived
+   * folder (`derivePath(_source)`) exists on disk. The soft RDF-filter remains
+   * coexisting (RFC v9 EV4) — removed only after the iPhone verify gate (T3).
+   *
+   * Algorithm:
+   *   1. Resolve declared ontology set → AssetSpace UIDs; assert TS-floor.
+   *   2. Diff effective set vs currently-materialised (folder exists).
+   *   3. ConfirmGate (destructive — unmount removes folders).
+   *   4. Lock + journal; unmount toDestroy, mount toMaterialize via restMount.
+   *   5. Persist active profile (+ Knowledge mirror) + RDF re-index.
+   *
+   * @throws TsFloorViolationError if target excludes any TS-floor AS.
+   * @throws HardSwitchAbortedByUser if confirmGate declines.
+   */
+  async restSwitchProfile(targetProfileUid: string): Promise<void> {
+    if (typeof targetProfileUid !== "string" || targetProfileUid.length === 0) {
+      throw new Error("restSwitchProfile: targetProfileUid is required");
+    }
+    const { restMount, confirmGate, localDataStore } = this.assertRestSwitchWired();
+    const startedAt = this.now().getTime();
+    const prevActiveProfileUid = localDataStore.getActiveProfileUid();
+    const targetProfileLabel = await this.profileLabel(targetProfileUid);
+    const sourceProfileLabel =
+      prevActiveProfileUid !== null
+        ? await this.profileLabel(prevActiveProfileUid)
+        : "<unknown>";
+
+    // 1. Effective AssetSpace set (declared ontologies → AS UIDs + TS-floor).
+    // Mirrors hardSwitchKnowledgeProfile's R24 derivation (computeDerivedSet,
+    // NOT resolveEffectiveSet — the latter silently injects floor ontologies).
+    const declaredOntologySet = await this.computeDerivedSet(targetProfileUid);
+    const folderToAsUid = await this.scanFolderToAsUid();
+    const ontologyToAs = await this.scanOntologyToAsUid();
+    const declaredAsUids = new Set<string>();
+    const folderMapValues = new Set(folderToAsUid.values());
+    for (const uid of declaredOntologySet) {
+      if (folderMapValues.has(uid)) {
+        declaredAsUids.add(uid);
+        continue;
+      }
+      const translated = ontologyToAs.get(uid);
+      if (translated !== undefined) declaredAsUids.add(translated);
+    }
+    this.assertTsFloor(declaredAsUids);
+    const effectiveAsUids = new Set(declaredAsUids);
+    for (const floor of TS_FLOOR_ASSETSPACE_UIDS) effectiveAsUids.add(floor);
+
+    // 2. Diff: materialised == folder exists on disk (mount-state, derivePath).
+    const allInfos = this.listAllAssetSpaceInfos();
+    const infoBySubmodulePath = new Map<string, AssetSpaceInfo>();
+    for (const info of allInfos) infoBySubmodulePath.set(info.folderName, info);
+    const currentAsUids = await this.derivePhysicallyMaterializedAsUids(
+      allInfos.map((i) => i.folderName),
+      infoBySubmodulePath,
+    );
+    const toDestroy: Array<{ asUid: string; submodulePath: string; label: string }> = [];
+    const toMaterialize: Array<{
+      asUid: string;
+      submodulePath: string;
+      gitUrl: string;
+      label: string;
+      ref: string;
+    }> = [];
+    for (const info of allInfos) {
+      const materialised = currentAsUids.has(info.uid);
+      const inEffective = effectiveAsUids.has(info.uid);
+      const label = info.namespace || info.uid.slice(0, 8);
+      if (materialised && !inEffective) {
+        toDestroy.push({ asUid: info.uid, submodulePath: info.folderName, label });
+      } else if (!materialised && inEffective) {
+        toMaterialize.push({
+          asUid: info.uid,
+          submodulePath: info.folderName,
+          gitUrl: info.git,
+          label,
+          ref: "main",
+        });
+      }
+    }
+
+    // 3. Build plan + ConfirmGate (destructive — unmount removes folders).
+    const filesToDestroyMap = new Map<string, string[]>();
+    for (const target of toDestroy) {
+      filesToDestroyMap.set(
+        target.asUid,
+        await this.enumerateFilesUnder(target.submodulePath),
+      );
+    }
+    const plan: HardSwitchPlan = {
+      targetProfileUid,
+      targetProfileLabel,
+      sourceProfileUid: prevActiveProfileUid,
+      sourceProfileLabel,
+      filesToDestroy: filesToDestroyMap,
+      assetSpacesBeingTornDown: toDestroy.map((t) => ({
+        asUid: t.asUid,
+        asLabel: t.label,
+        fileCount: filesToDestroyMap.get(t.asUid)?.length ?? 0,
+      })),
+      assetSpacesBeingMaterialized: toMaterialize.map((t) => ({
+        asUid: t.asUid,
+        asLabel: t.label,
+      })),
+    };
+    const approved = await confirmGate.confirmHardSwitch(plan);
+    if (!approved) throw new HardSwitchAbortedByUser();
+
+    // No-op early exit — no mount-state change ⇒ soft switch (RDF filter) only.
+    if (toDestroy.length === 0 && toMaterialize.length === 0) {
+      await this.softSwitchFocusProfile(targetProfileUid);
+      return;
+    }
+
+    const acquired = await this.lockMgr.acquireLock(`rest-switch-${targetProfileUid}`);
+    if (!acquired) {
+      throw new Error("Another profile switch is in progress (lock held). Try again shortly.");
+    }
+    let heartbeatTimer: ReturnType<typeof setInterval> | null = null;
+    try {
+      await this.appendJournal({
+        phase: "hard-switch-starting",
+        targetUid: targetProfileUid,
+        ts: new Date(startedAt).toISOString(),
+      });
+      const localState = localDataStore.snapshot();
+      await localDataStore.save({
+        activeProfileUid: localState.activeProfileUid,
+        _switchInProgress: true,
+      });
+      heartbeatTimer = setInterval(() => {
+        void this.lockMgr.heartbeat();
+      }, 30_000);
+
+      // Unmount removed AssetSpaces (rm folder + strip .gitmodules stanza).
+      for (const target of toDestroy) {
+        await restMount.unmount(target.submodulePath);
+        await this.appendJournal({
+          phase: "phase2-destroyed",
+          targetUid: targetProfileUid,
+          as: target.asUid,
+          ts: this.now().toISOString(),
+        });
+      }
+      // Mount new AssetSpaces (REST tarball → vault folder + .gitmodules entry).
+      for (const target of toMaterialize) {
+        await restMount.mount(target.gitUrl, target.submodulePath, target.ref);
+        await this.appendJournal({
+          phase: "phase2-materialized",
+          targetUid: targetProfileUid,
+          as: target.asUid,
+          ts: this.now().toISOString(),
+        });
+      }
+
+      // Persist new active profile (+ Knowledge mirror) + clear in-progress.
+      const persistState = localDataStore.snapshot();
+      await localDataStore.save({
+        ...persistState,
+        activeProfileUid: targetProfileUid,
+        activeKnowledgeProfileUid: targetProfileUid,
+        _switchInProgress: false,
+      });
+      await this.rdfIndexer.refresh(effectiveAsUids);
+
+      const elapsedMs = this.now().getTime() - startedAt;
+      await this.appendJournal({
+        phase: "hard-switch-completed",
+        targetUid: targetProfileUid,
+        ts: this.now().toISOString(),
+        elapsedMs,
+      });
+      this.notify(`Switched to ${targetProfileLabel} (${elapsedMs}ms, REST mount)`);
+    } catch (e) {
+      await this.appendJournal({
+        phase: "hard-switch-failed",
+        targetUid: targetProfileUid,
+        ts: this.now().toISOString(),
+        error: this.redactError(String(e)),
+      });
+      // Clear in-progress so subsequent operations don't see stuck state.
+      try {
+        const s = localDataStore.snapshot();
+        await localDataStore.save({
+          activeProfileUid: s.activeProfileUid,
+          _switchInProgress: false,
+        });
+      } catch {
+        // Swallow — original error takes precedence.
+      }
+      throw e;
+    } finally {
+      if (heartbeatTimer !== null) clearInterval(heartbeatTimer);
+      await this.lockMgr.releaseLock();
+    }
+  }
+
+  private assertRestSwitchWired(): {
+    restMount: RestAssetSpaceMount;
+    confirmGate: IConfirmGate;
+    localDataStore: PluginLocalDataStore;
+  } {
+    if (
+      this.restMount === undefined ||
+      this.confirmGate === undefined ||
+      this.localDataStore === undefined
+    ) {
+      throw new Error(
+        "restSwitchProfile: dependencies not wired (restMount, confirmGate, localDataStore required)",
+      );
+    }
+    return {
+      restMount: this.restMount,
+      confirmGate: this.confirmGate,
+      localDataStore: this.localDataStore,
+    };
   }
 
   /**

--- a/packages/obsidian-plugin/src/infrastructure/adapters/HardSwitchDepsFactory.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/HardSwitchDepsFactory.ts
@@ -8,6 +8,7 @@ import { GitHubRestClient } from "./GitHubRestClient";
 import { StagingDirTracker } from "./StagingDirTracker";
 import { AssetSpaceManager } from "./AssetSpaceManager";
 import { GitSubmoduleOps } from "./GitSubmoduleOps";
+import { RestAssetSpaceMount } from "./RestAssetSpaceMount";
 import { UncommittedChangesGuard } from "./UncommittedChangesGuard";
 import { ModalConfirmGate } from "./ModalConfirmGate";
 import { SwitchCacheLayer } from "./SwitchCacheLayer";
@@ -73,6 +74,27 @@ export async function buildAssetSpacePuller(
     notifications: notifier,
     stagingTracker,
   });
+}
+
+/**
+ * Build a {@link RestAssetSpaceMount} (RFC 01a83de8 Phase 3 T1) from the
+ * currently-stored GitHub PAT. Cross-platform — uses `requestUrl` + tarball +
+ * `vault.adapter`, so it works on mobile (unlike {@link GitSubmoduleOps}).
+ *
+ * The PAT is captured at call time. The plugin wires this once at onload (the
+ * mobile profile-switch path consumes it); a PAT configured AFTER onload needs
+ * a reload to take effect — the same onload-capture tradeoff as the hard-switch
+ * `assetSpaceManager`. An absent PAT yields an unauthenticated client
+ * (public-repo reads only).
+ */
+export async function buildRestAssetSpaceMount(opts: {
+  app: App;
+}): Promise<RestAssetSpaceMount> {
+  const { app } = opts;
+  const secretsStore = new LocalSecretsStore({ app });
+  const pat = await secretsStore.getSecret("pat");
+  const client = new GitHubRestClient({ app, pat: pat ?? "" });
+  return new RestAssetSpaceMount({ app, client });
 }
 
 /**

--- a/packages/obsidian-plugin/tests/unit/FocusProfileSwitchManager.restSwitch.test.ts
+++ b/packages/obsidian-plugin/tests/unit/FocusProfileSwitchManager.restSwitch.test.ts
@@ -1,0 +1,423 @@
+/**
+ * FocusProfileSwitchManager.restSwitchProfile() — RFC 01a83de8 Phase 3 T2.
+ *
+ * Mobile-capable profile switch via REST/tarball mount/unmount (no git binary,
+ * staging, cache, or git commit). Visibility is mount-state: an AssetSpace is
+ * "active" iff its derived folder exists on disk.
+ *
+ * Coverage:
+ *   1. Happy path — diff (folder-exists) drives unmount(toDestroy) +
+ *      mount(toMaterialize); persists activeProfile + Knowledge mirror; RDF
+ *      re-index with the effective set.
+ *   2. Revert-verify control — a target already in mount-state ⇒ no-op (soft
+ *      switch only, no mount/unmount).
+ *   3. R24 TS-floor — target excluding a floor AS throws before any mutation.
+ *   4. ConfirmGate decline → HardSwitchAbortedByUser, no mount/unmount.
+ *   5. Not wired — missing restMount throws a clear error.
+ *   6. Dispatch — hardSwitchKnowledgeProfile on mobile delegates to
+ *      restSwitchProfile (REST path; gitOps never touched).
+ *
+ * Fakes mirror the desktop hardSwitch harness: in-memory vault.adapter
+ * (`exists` true for known files/folders), production-shape AssetSpace ABox
+ * frontmatter (`_source` derives back to the folder via derivePath), and a
+ * FakeLocalDataStore preserving the dual AC14 slots on partial save.
+ */
+import { Platform } from "obsidian";
+import type { App, TFile } from "obsidian";
+import type { HardSwitchPlan, IConfirmGate } from "exocortex";
+
+import {
+  FocusProfileSwitchManager,
+  HardSwitchAbortedByUser,
+  TsFloorViolationError,
+  type IProfileResolver,
+  type IRdfIndexer,
+  type ISettingsStore,
+  type ProfileResolution,
+  type SwitchSettings,
+} from "../../src/infrastructure/adapters/FocusProfileSwitchManager";
+import { PluginLockManager } from "../../src/infrastructure/adapters/PluginLockManager";
+import {
+  TS_FLOOR_AS_UID_EXO,
+  TS_FLOOR_AS_UID_EXOCMD,
+  TS_FLOOR_AS_UID_SHARED_IDENTITIES,
+} from "../../src/infrastructure/adapters/FocusProfileOnloadWiring";
+
+// ─── Fakes ────────────────────────────────────────────────────────────────
+
+interface FakeFile {
+  path: string;
+  basename: string;
+  frontmatter: Record<string, unknown>;
+}
+
+function makeFakeApp(files: FakeFile[]): {
+  app: App;
+  fsFolders: Map<string, { files: string[]; folders: string[] }>;
+} {
+  const fsFiles = new Map<string, string>();
+  const fsFolders = new Map<string, { files: string[]; folders: string[] }>();
+  const tfiles: TFile[] = files.map(
+    (f) => ({ path: f.path, basename: f.basename }) as unknown as TFile,
+  );
+  const frontmatterByPath = new Map<string, Record<string, unknown>>();
+  for (const f of files) frontmatterByPath.set(f.path, f.frontmatter);
+
+  const app = {
+    vault: {
+      getMarkdownFiles: () => tfiles,
+      adapter: {
+        exists: async (p: string) => fsFiles.has(p) || fsFolders.has(p),
+        read: async (p: string) => {
+          const v = fsFiles.get(p);
+          if (v === undefined) throw new Error(`ENOENT: ${p}`);
+          return v;
+        },
+        write: async (p: string, d: string) => {
+          fsFiles.set(p, d);
+        },
+        list: async (dir: string) =>
+          fsFolders.get(dir) ?? { files: [], folders: [] },
+      },
+    },
+    metadataCache: {
+      getFileCache: (file: TFile) => {
+        const fm = frontmatterByPath.get(file.path);
+        return fm ? { frontmatter: fm } : null;
+      },
+    },
+  } as unknown as App;
+  return { app, fsFolders };
+}
+
+class FakeResolver implements IProfileResolver {
+  constructor(private readonly profiles: Map<string, ProfileResolution>) {}
+  async resolve(uid: string): Promise<ProfileResolution | null> {
+    return this.profiles.get(uid) ?? null;
+  }
+  async discoverSharedOntologies(): Promise<string[]> {
+    return [];
+  }
+}
+
+class FakeIndexer implements IRdfIndexer {
+  refreshCalls: ReadonlySet<string>[] = [];
+  async refresh(effective: ReadonlySet<string>): Promise<void> {
+    this.refreshCalls.push(new Set(effective));
+  }
+}
+
+class FakeSettingsStore implements ISettingsStore {
+  state: SwitchSettings = { activeProfileUid: null, _switchInProgress: false };
+  async load(): Promise<SwitchSettings> {
+    return { ...this.state };
+  }
+  async save(s: SwitchSettings): Promise<void> {
+    this.state = { ...s };
+  }
+}
+
+interface FakeLocalState {
+  activeProfileUid: string | null;
+  activeKnowledgeProfileUid: string | null;
+  activeFocusProfileUid: string | null;
+  _switchInProgress: boolean;
+}
+
+class FakeLocalDataStore {
+  private state: FakeLocalState = {
+    activeProfileUid: null,
+    activeKnowledgeProfileUid: null,
+    activeFocusProfileUid: null,
+    _switchInProgress: false,
+  };
+  getActiveProfileUid(): string | null {
+    return this.state.activeProfileUid;
+  }
+  getActiveKnowledgeProfileUid(): string | null {
+    return this.state.activeKnowledgeProfileUid;
+  }
+  getActiveFocusProfileUid(): string | null {
+    return this.state.activeFocusProfileUid;
+  }
+  isSwitchInProgress(): boolean {
+    return this.state._switchInProgress;
+  }
+  snapshot(): FakeLocalState {
+    return { ...this.state };
+  }
+  async save(s: {
+    activeProfileUid: string | null;
+    activeKnowledgeProfileUid?: string | null;
+    activeFocusProfileUid?: string | null;
+    _switchInProgress: boolean;
+  }): Promise<void> {
+    this.state = {
+      activeProfileUid: s.activeProfileUid,
+      activeKnowledgeProfileUid:
+        s.activeKnowledgeProfileUid !== undefined
+          ? s.activeKnowledgeProfileUid
+          : this.state.activeKnowledgeProfileUid,
+      activeFocusProfileUid:
+        s.activeFocusProfileUid !== undefined
+          ? s.activeFocusProfileUid
+          : this.state.activeFocusProfileUid,
+      _switchInProgress: s._switchInProgress,
+    };
+  }
+}
+
+class FakeConfirmGate implements IConfirmGate {
+  approve = true;
+  lastPlan: HardSwitchPlan | null = null;
+  async confirmHardSwitch(plan: HardSwitchPlan): Promise<boolean> {
+    this.lastPlan = plan;
+    return this.approve;
+  }
+}
+
+class FakeRestMount {
+  mounted: Array<{ gitUrl: string; submodulePath: string; ref: string }> = [];
+  unmounted: string[] = [];
+  async mount(gitUrl: string, submodulePath: string, ref: string) {
+    this.mounted.push({ gitUrl, submodulePath, ref });
+    return { sha: "abc1234", fileCount: 1 };
+  }
+  async unmount(submodulePath: string): Promise<void> {
+    this.unmounted.push(submodulePath);
+  }
+}
+
+class FakeGitOps {
+  calls: string[] = [];
+  async readGitmodulesPaths(): Promise<Set<string>> {
+    this.calls.push("readGitmodulesPaths");
+    return new Set();
+  }
+  async submoduleAdd(): Promise<void> {
+    this.calls.push("submoduleAdd");
+  }
+  async submoduleDeinit(): Promise<void> {
+    this.calls.push("submoduleDeinit");
+  }
+}
+
+// ─── Setup ──────────────────────────────────────────────────────────────────
+
+const TS_FLOOR = [
+  { uid: TS_FLOOR_AS_UID_EXO, folder: "assetspaces/kitelev/exoas-exo" },
+  { uid: TS_FLOOR_AS_UID_EXOCMD, folder: "assetspaces/kitelev/exoas-exocmd" },
+  {
+    uid: TS_FLOOR_AS_UID_SHARED_IDENTITIES,
+    folder: "assetspaces/kitelev/exoas-shared-identities",
+  },
+];
+const EXTRA = [
+  { uid: "ems-uid", folder: "assetspaces/kitelev/exoas-ems" },
+  { uid: "kpc-uid", folder: "assetspaces/kitelev/exoas-kpc" },
+];
+const ALL_AS = [...TS_FLOOR, ...EXTRA];
+
+interface SetupOpts {
+  /** AS UIDs the target profile declares (ontology form auto-derived). */
+  targetIncludes: string[];
+  /** AS UIDs currently materialised (folder exists on disk). */
+  materialized: string[];
+  /** Whether to wire the REST mount (default true). */
+  wireRestMount?: boolean;
+  /** Whether to also wire gitOps (to assert it is NOT used). */
+  wireGitOps?: boolean;
+}
+
+function setup(opts: SetupOpts) {
+  const files: FakeFile[] = [
+    {
+      path: "profiles/target.md",
+      basename: "target",
+      frontmatter: {
+        exo__Asset_uid: "target",
+        exo__Asset_label: "Target Profile",
+        exo__Instance_class: ["[[exo__FocusProfile]]"],
+      },
+    },
+    ...ALL_AS.map((as) => {
+      const ns = as.folder.split("/").pop();
+      return {
+        path: `${as.folder}/${as.uid}.md`,
+        basename: as.uid,
+        frontmatter: {
+          exo__Asset_uid: as.uid,
+          exo__Asset_label: ns,
+          exo__Instance_class: ["[[exo__AssetSpace]]"],
+          exo__AssetSpace_source: `https://github.com/${as.folder.replace("assetspaces/", "")}`,
+          exo__AssetSpace_namespace: ns,
+          exo__AssetSpace_containsOntology: [`[[ontology-${as.uid}]]`],
+        },
+      };
+    }),
+  ];
+
+  const { app, fsFolders } = makeFakeApp(files);
+  // Materialised AS == folder exists on disk (with a couple of files for the plan).
+  for (const uid of opts.materialized) {
+    const folder = ALL_AS.find((a) => a.uid === uid)?.folder;
+    if (folder) {
+      fsFolders.set(folder, {
+        files: [`${folder}/file1.md`, `${folder}/file2.md`],
+        folders: [],
+      });
+    }
+  }
+
+  const resolver = new FakeResolver(
+    new Map<string, ProfileResolution>([
+      [
+        "target",
+        {
+          uid: "target",
+          includes: opts.targetIncludes.map((u) => `ontology-${u}`),
+          label: "Target Profile",
+        },
+      ],
+    ]),
+  );
+  const indexer = new FakeIndexer();
+  const settingsStore = new FakeSettingsStore();
+  const lockMgr = new PluginLockManager({ app });
+  const localDataStore = new FakeLocalDataStore();
+  const confirmGate = new FakeConfirmGate();
+  const restMount = new FakeRestMount();
+  const gitOps = new FakeGitOps();
+
+  const mgr = new FocusProfileSwitchManager({
+    app,
+    lockMgr,
+    resolver,
+    rdfIndexer: indexer,
+    settingsStore,
+    /* eslint-disable @typescript-eslint/no-explicit-any */
+    confirmGate,
+    localDataStore: localDataStore as any,
+    restMount: (opts.wireRestMount === false ? undefined : restMount) as any,
+    gitOps: (opts.wireGitOps ? gitOps : undefined) as any,
+    /* eslint-enable @typescript-eslint/no-explicit-any */
+  });
+  return { mgr, indexer, localDataStore, confirmGate, restMount, gitOps };
+}
+
+const ALL_FLOOR_UIDS = TS_FLOOR.map((f) => f.uid);
+
+// ─── Tests ────────────────────────────────────────────────────────────────
+
+describe("FocusProfileSwitchManager.restSwitchProfile", () => {
+  it("unmounts to-destroy + mounts to-materialize, persists profile + re-indexes", async () => {
+    // Currently materialised: floors + kpc. Target: floors + ems (NOT kpc).
+    const { mgr, indexer, localDataStore, restMount } = setup({
+      targetIncludes: [...ALL_FLOOR_UIDS, "ems-uid"],
+      materialized: [...ALL_FLOOR_UIDS, "kpc-uid"],
+    });
+
+    await mgr.restSwitchProfile("target");
+
+    // kpc unmounted (was materialised, not in target).
+    expect(restMount.unmounted).toEqual(["assetspaces/kitelev/exoas-kpc"]);
+    // ems mounted (in target, not materialised).
+    expect(restMount.mounted.map((m) => m.submodulePath)).toEqual([
+      "assetspaces/kitelev/exoas-ems",
+    ]);
+    expect(restMount.mounted[0].gitUrl).toBe(
+      "https://github.com/kitelev/exoas-ems",
+    );
+
+    // Active profile persisted (+ Knowledge mirror).
+    expect(localDataStore.getActiveProfileUid()).toBe("target");
+    expect(localDataStore.getActiveKnowledgeProfileUid()).toBe("target");
+    expect(localDataStore.isSwitchInProgress()).toBe(false);
+
+    // RDF re-index with the effective set (floors + ems, NOT kpc).
+    expect(indexer.refreshCalls.length).toBe(1);
+    const eff = indexer.refreshCalls[0];
+    expect(eff.has("ems-uid")).toBe(true);
+    expect(eff.has("kpc-uid")).toBe(false);
+    for (const f of ALL_FLOOR_UIDS) expect(eff.has(f)).toBe(true);
+  });
+
+  it("no-ops to a soft switch when mount-state already matches (control)", async () => {
+    // Target == currently materialised (floors only) ⇒ no mount/unmount;
+    // restSwitchProfile falls through to the soft-switch (RDF filter) path.
+    const { mgr, restMount, indexer } = setup({
+      targetIncludes: ALL_FLOOR_UIDS,
+      materialized: ALL_FLOOR_UIDS,
+    });
+
+    await expect(mgr.restSwitchProfile("target")).resolves.toBeUndefined();
+
+    expect(restMount.mounted).toEqual([]);
+    expect(restMount.unmounted).toEqual([]);
+    // No mount-state mutation, but the soft-switch still refreshes the RDF
+    // filter once (the coexisting visibility source, RFC v9 EV4).
+    expect(indexer.refreshCalls.length).toBe(1);
+  });
+
+  it("throws TsFloorViolationError before any mount/unmount when target excludes a floor AS", async () => {
+    const { mgr, restMount } = setup({
+      targetIncludes: ["ems-uid"], // excludes all floor AS
+      materialized: [...ALL_FLOOR_UIDS, "ems-uid"],
+    });
+    await expect(mgr.restSwitchProfile("target")).rejects.toThrow(
+      TsFloorViolationError,
+    );
+    expect(restMount.mounted).toEqual([]);
+    expect(restMount.unmounted).toEqual([]);
+  });
+
+  it("aborts with HardSwitchAbortedByUser when confirmGate declines — no mutation", async () => {
+    const { mgr, confirmGate, restMount } = setup({
+      targetIncludes: [...ALL_FLOOR_UIDS, "ems-uid"],
+      materialized: [...ALL_FLOOR_UIDS, "kpc-uid"],
+    });
+    confirmGate.approve = false;
+    await expect(mgr.restSwitchProfile("target")).rejects.toThrow(
+      HardSwitchAbortedByUser,
+    );
+    expect(restMount.mounted).toEqual([]);
+    expect(restMount.unmounted).toEqual([]);
+  });
+
+  it("throws a clear error when restMount is not wired", async () => {
+    const { mgr } = setup({
+      targetIncludes: [...ALL_FLOOR_UIDS, "ems-uid"],
+      materialized: ALL_FLOOR_UIDS,
+      wireRestMount: false,
+    });
+    await expect(mgr.restSwitchProfile("target")).rejects.toThrow(
+      /dependencies not wired/,
+    );
+  });
+});
+
+describe("hardSwitchKnowledgeProfile dispatch (mobile → REST)", () => {
+  const original = Platform.isMobile;
+  afterEach(() => {
+    (Platform as unknown as { isMobile: boolean }).isMobile = original;
+  });
+
+  it("delegates to restSwitchProfile on mobile (gitOps never touched)", async () => {
+    (Platform as unknown as { isMobile: boolean }).isMobile = true;
+    const { mgr, restMount, gitOps } = setup({
+      targetIncludes: [...ALL_FLOOR_UIDS, "ems-uid"],
+      materialized: [...ALL_FLOOR_UIDS, "kpc-uid"],
+      wireGitOps: true,
+    });
+
+    await mgr.hardSwitchKnowledgeProfile("target");
+
+    // REST path exercised…
+    expect(restMount.mounted.map((m) => m.submodulePath)).toEqual([
+      "assetspaces/kitelev/exoas-ems",
+    ]);
+    expect(restMount.unmounted).toEqual(["assetspaces/kitelev/exoas-kpc"]);
+    // …and the git-binary path was NOT used.
+    expect(gitOps.calls).toEqual([]);
+  });
+});

--- a/packages/obsidian-plugin/tests/unit/FocusProfileSwitchManager.restSwitch.test.ts
+++ b/packages/obsidian-plugin/tests/unit/FocusProfileSwitchManager.restSwitch.test.ts
@@ -227,6 +227,8 @@ interface SetupOpts {
   wireRestMount?: boolean;
   /** Whether to also wire gitOps (to assert it is NOT used). */
   wireGitOps?: boolean;
+  /** Wire a fresh-PAT factory (returns `factoryMount`) preferred over capture. */
+  wireRestMountFactory?: boolean;
 }
 
 function setup(opts: SetupOpts) {
@@ -287,6 +289,7 @@ function setup(opts: SetupOpts) {
   const localDataStore = new FakeLocalDataStore();
   const confirmGate = new FakeConfirmGate();
   const restMount = new FakeRestMount();
+  const factoryMount = new FakeRestMount();
   const gitOps = new FakeGitOps();
 
   const mgr = new FocusProfileSwitchManager({
@@ -299,10 +302,21 @@ function setup(opts: SetupOpts) {
     confirmGate,
     localDataStore: localDataStore as any,
     restMount: (opts.wireRestMount === false ? undefined : restMount) as any,
+    restMountFactory: opts.wireRestMountFactory
+      ? async () => factoryMount as any
+      : undefined,
     gitOps: (opts.wireGitOps ? gitOps : undefined) as any,
     /* eslint-enable @typescript-eslint/no-explicit-any */
   });
-  return { mgr, indexer, localDataStore, confirmGate, restMount, gitOps };
+  return {
+    mgr,
+    indexer,
+    localDataStore,
+    confirmGate,
+    restMount,
+    factoryMount,
+    gitOps,
+  };
 }
 
 const ALL_FLOOR_UIDS = TS_FLOOR.map((f) => f.uid);
@@ -384,7 +398,7 @@ describe("FocusProfileSwitchManager.restSwitchProfile", () => {
     expect(restMount.unmounted).toEqual([]);
   });
 
-  it("throws a clear error when restMount is not wired", async () => {
+  it("throws a clear error when neither restMount nor factory is wired", async () => {
     const { mgr } = setup({
       targetIncludes: [...ALL_FLOOR_UIDS, "ems-uid"],
       materialized: ALL_FLOOR_UIDS,
@@ -393,6 +407,25 @@ describe("FocusProfileSwitchManager.restSwitchProfile", () => {
     await expect(mgr.restSwitchProfile("target")).rejects.toThrow(
       /dependencies not wired/,
     );
+  });
+
+  it("prefers the fresh-PAT factory mount over the onload-captured one (Issue #3382)", async () => {
+    const { mgr, restMount, factoryMount } = setup({
+      targetIncludes: [...ALL_FLOOR_UIDS, "ems-uid"],
+      materialized: [...ALL_FLOOR_UIDS, "kpc-uid"],
+      wireRestMountFactory: true,
+    });
+
+    await mgr.restSwitchProfile("target");
+
+    // Factory mount did the work…
+    expect(factoryMount.mounted.map((m) => m.submodulePath)).toEqual([
+      "assetspaces/kitelev/exoas-ems",
+    ]);
+    expect(factoryMount.unmounted).toEqual(["assetspaces/kitelev/exoas-kpc"]);
+    // …and the onload-captured mount was NOT used.
+    expect(restMount.mounted).toEqual([]);
+    expect(restMount.unmounted).toEqual([]);
   });
 });
 


### PR DESCRIPTION
## Summary

RFC `01a83de8` **Phase 3 T2** — wire **visibility→mount-state** for the profile switch on mobile, consuming the Phase 3 T1 `RestAssetSpaceMount` (PR #3409).

An AssetSpace is **active iff its derived folder (`derivePath(_source)`) exists on disk**. On mobile the profile switch now mounts/unmounts those folders via REST tarball + `vault.adapter` — no git binary, staging dir, cache layer, or git commit (all desktop-only / Node-coupled).

- **`FocusProfileSwitchManager`**: new optional `restMount` dep + `restSwitchProfile(targetUid)` method. It reuses the desktop helpers (`computeDerivedSet`, folder/ontology scans, `assertTsFloor`, `derivePhysicallyMaterializedAsUids`, `enumerateFilesUnder`, `confirmGate`, lock, journal) and only the orchestration shell is new: effective-set diff vs folder-existence → `unmount(toDestroy)` + `mount(toMaterialize)` → persist active profile (+ Knowledge mirror) → RDF re-index. `hardSwitchKnowledgeProfile` delegates to it when `Platform.isMobile && restMount` — **desktop keeps the git-binary path unchanged** (purely additive).
- **`HardSwitchDepsFactory`**: `buildRestAssetSpaceMount` (PAT from `LocalSecretsStore`).
- **`ExocortexPlugin`**: builds `restMount` on both platforms, wires a mobile-safe `ModalConfirmGate`, and registers the "Switch knowledge profile" command on mobile when `restMount` is available.

## Scope / phasing

The soft RDF-filter is **PRESERVED coexisting** (RFC v9 EV4, decision D2). Its removal + CLI `--profile` retirement is gated behind the **iPhone verify** (Phase 3 T3) — nothing is removed here. Desktop behaviour is unchanged; only the mobile dispatch is new.

PAT is captured at onload (same tradeoff as the desktop hard-switch `assetSpaceManager`); a PAT set after onload needs a reload — documented in `buildRestAssetSpaceMount`.

## Test plan

- [x] `FocusProfileSwitchManager.restSwitch.test.ts` — 6 cases: happy-path diff (folder-exists drives unmount+mount, persists profile + Knowledge mirror, re-indexes effective set), no-op→soft fallback (control), R24 TS-floor guard (throws before mutation), confirm-decline → `HardSwitchAbortedByUser`, not-wired error, **mobile dispatch** (`hardSwitchKnowledgeProfile` → REST path, asserts gitOps untouched). Fakes mirror the desktop hardSwitch harness (production-shape `vault.adapter`, AS ABox whose `_source` derives back to the folder).
- [x] Regression: all 66 `FocusProfileSwitchManager` + 133 wiring (`ExocortexPlugin`/`HardSwitchDepsFactory`/`FocusProfileCommands`) tests green.
- [x] `npm run check:types` clean; lint clean.
- [ ] 14 required CI checks.