### PR TITLE
refactor(profile): remove dead KnowledgeProfile-class machinery (RFC 01a83de8 Phase 3 T4)

### DIFF
--- a/packages/obsidian-plugin/src/ExocortexPlugin.ts
+++ b/packages/obsidian-plugin/src/ExocortexPlugin.ts
@@ -2795,13 +2795,16 @@ export default class ExocortexPlugin extends Plugin {
         localDataStore.getActiveProfileUid(),
       );
 
-    // AC17 — KnowledgeProfile picker source. Dual-class assets surface in both
-    // listers because the discrimination is by `exo__Instance_class` membership.
+    // RFC 01a83de8 Phase 3 T4 — the former per-class KnowledgeProfile picker
+    // collapsed into the single `exo__Profile` class (Phase 2). The mount-state
+    // ("Switch knowledge profile") picker now lists the same profiles as the
+    // soft picker. This also fixes the empty-picker on vaults that never had a
+    // separate KnowledgeProfile-class instance (e.g. iPhone vault-2025).
     const knowledgeProfileLister: () => Promise<
       FocusProfileChoice[]
     > = async () =>
       buildProfileChoices(
-        resolver.listKnowledgeProfileFiles(),
+        resolver.listFocusProfileFiles(),
         localDataStore.getActiveKnowledgeProfileUid(),
       );
 

--- a/packages/obsidian-plugin/src/infrastructure/adapters/FocusProfileCommands.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/FocusProfileCommands.ts
@@ -152,7 +152,9 @@ export class FocusProfileCommands {
    * Command 2 — `Exocortex: Switch knowledge profile` (RFC 13da049f Phase 6.5b
    * AC17; supersedes the RFC 22b50a17 «Hard switch focus profile» command).
    *
-   * Fuzzy-picks a **KnowledgeProfile** asset (per-class picker), then invokes
+   * Fuzzy-picks an `exo__Profile` asset (the mount-state picker — RFC 01a83de8
+   * Phase 3 T4 collapsed the former per-class KnowledgeProfile list into the
+   * single profile class), then invokes
    * `FocusProfileSwitchManager.hardSwitchKnowledgeProfile` which:
    *   1. R24 TS-floor assert (refuses targets that brick the plugin)
    *   2. Vision Lock #5 uncommitted abort (with file list)
@@ -172,7 +174,7 @@ export class FocusProfileCommands {
     }
 
     if (profiles.length === 0) {
-      this.notify("No KnowledgeProfile assets found in vault");
+      this.notify("No profiles found in vault");
       return;
     }
 

--- a/packages/obsidian-plugin/src/infrastructure/adapters/FocusProfileSwitchManager.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/FocusProfileSwitchManager.ts
@@ -35,27 +35,14 @@ import { TS_FLOOR_ASSETSPACE_UIDS } from "./FocusProfileOnloadWiring";
 /**
  * `exo__FocusProfile` class UID (frozen by RFC b6ba5595).
  *
- * RFC 13da049f Phase 6.5b (AC13) — **filter-only narrowing**: a FocusProfile
- * is strictly a *soft switch* — a query-time RDF-graph filter. It does NOT
- * materialise filesystem state; physical AssetSpace materialisation is the
- * responsibility of `exo__KnowledgeProfile` (hard switch, see
- * {@link KNOWLEDGE_PROFILE_CLASS_UID} + {@link hardSwitchKnowledgeProfile}).
- * The optional `exo__FocusProfile_appliesTo` predicate binds a FocusProfile to
- * the Knowledge profile it is meant to narrow — consumed at runtime by the
- * AC16 compatibility check in {@link softSwitchFocusProfile}.
+ * RFC 13da049f Phase 6.5b (AC13) — **filter-only narrowing**: a profile's soft
+ * switch is a query-time RDF-graph filter; physical AssetSpace materialisation
+ * is the hard / mount-state switch ({@link hardSwitchKnowledgeProfile}). Phase 2
+ * (RFC 01a83de8) collapsed the former `exo__KnowledgeProfile` class into this
+ * single `exo__Profile` (was `exo__FocusProfile`); both the soft and the
+ * mount-state switch now operate on the same class.
  */
 export const FOCUS_PROFILE_CLASS_UID = "3de846cd-1f0e-4f98-8613-b8587aa15174";
-
-/**
- * `exo__KnowledgeProfile` class UID (RFC 13da049f Phase 6.5b).
- *
- * A KnowledgeProfile drives the **hard switch** — destructive filesystem
- * materialisation of `assetspaces/<as>/`. Distinct from {@link FOCUS_PROFILE_CLASS_UID}
- * (query-time filter only). An asset may declare BOTH classes (dual-class) when
- * it serves as both a materialisation target and a query-time filter.
- */
-export const KNOWLEDGE_PROFILE_CLASS_UID =
-  "b8884976-596f-43d2-b7f4-3da518f825d4";
 
 /**
  * TS-floor (Vision Lock #17): ontology URIs that are ALWAYS in the effective
@@ -377,26 +364,12 @@ export class FocusProfileSwitchManager {
       // Persist BEFORE filesystem changes (Architect #2 — atomicity invariant)
       const settings = await this.settingsStore.load();
 
-      // AC16 — compatibility check against the active Knowledge profile. On
-      // violation we still persist the Focus selection but apply a no-filter
-      // (empty set → full vault) instead of the target's narrowed set. The
-      // check NEVER throws (R37 — soft fallback).
-      const compat = await this.evaluateFocusKnowledgeCompat(
-        targetProfileUid,
-        settings,
-      );
-      // No-filter signal: an empty set makes `NoteToRDFConverter` fall back to
-      // the no-filter path (see `shouldSkipFileForEffectiveSet` — empty
-      // effective set → index everything, avoids self-brick).
-      const filterSet: ReadonlySet<string> = compat.compatible
-        ? effective
-        : new Set<string>();
-      if (!compat.compatible) {
-        // AC16 action #1 — console.warn with the compatibility violation.
-        console.warn(`[FocusProfileSwitchManager] ${compat.reason}`);
-        // AC16 action #2 — user-facing Notice.
-        this.notify(compat.userMessage);
-      }
+      // RFC 01a83de8 Phase 3 T4 — the AC16 Focus↔Knowledge compatibility check
+      // is removed: Phase 2 collapsed the two profile classes into one
+      // `exo__Profile`, so there is no separate Knowledge profile to be
+      // (in)compatible with. The soft switch always applies the target's
+      // narrowed effective set.
+      const filterSet: ReadonlySet<string> = effective;
 
       settings.activeProfileUid = targetProfileUid;
       // AC14 — soft switch owns the Focus slot. The legacy `activeProfileUid`
@@ -420,14 +393,10 @@ export class FocusProfileSwitchManager {
         elapsedMs,
       });
 
-      // On the compatible path emit the success Notice. On the incompatible
-      // path the AC16 fallback Notice (above) is the user-facing message, so
-      // we skip a second «Switched…» line to avoid implying the narrowed view
-      // was applied when it was not.
-      if (compat.compatible) {
-        const profileLabel = await this.profileLabel(targetProfileUid);
-        this.notify(`Switched to ${profileLabel} (${elapsedMs}ms)`);
-      }
+      // The narrowed view is always applied now (no Focus↔Knowledge compat
+      // downgrade — RFC 01a83de8 Phase 3 T4), so always emit the success Notice.
+      const profileLabel = await this.profileLabel(targetProfileUid);
+      this.notify(`Switched to ${profileLabel} (${elapsedMs}ms)`);
     } catch (e) {
       await this.appendJournal({
         phase: "failed",
@@ -529,125 +498,6 @@ export class FocusProfileSwitchManager {
     const result = new Set<string>();
     await this.walkProfileChain(profileUid, visited, result, 0);
     return result;
-  }
-
-  /**
-   * AC16 (RFC 13da049f Phase 6.5b) — evaluate whether a target FocusProfile is
-   * compatible with the currently-active Knowledge profile.
-   *
-   * Decision layers (matches `exo__FocusProfile_appliesTo` TBox semantics):
-   *   1. `_appliesTo` declared → must equal the active Knowledge UID; any
-   *      mismatch (including no active Knowledge) is incompatible.
-   *   2. No `_appliesTo` AND no active Knowledge → backward-compatible
-   *      pass-through (apply the declared filter; pre-AC16 behaviour).
-   *   3. Active Knowledge resolves to an empty derived set (EC3 — not
-   *      materialised) → incompatible.
-   *   4. Target `_includes ⊄ active Knowledge effective set` → incompatible.
-   *
-   * The active Knowledge UID is read from `settings.activeKnowledgeProfileUid`,
-   * which `PluginSettingsStoreAdapter` populates from
-   * `PluginLocalDataStore.getActiveKnowledgeProfileUid()`.
-   *
-   * NEVER throws — on any evaluation error it returns `compatible` (apply the
-   * declared filter) and logs, so a compat-evaluation bug cannot block a switch
-   * (AC16 invariant: WARN + fallback, never throw).
-   */
-  private async evaluateFocusKnowledgeCompat(
-    targetProfileUid: string,
-    settings: SwitchSettings,
-  ): Promise<
-    | { compatible: true }
-    | { compatible: false; reason: string; userMessage: string }
-  > {
-    try {
-      const activeKnowledgeUid =
-        typeof settings.activeKnowledgeProfileUid === "string" &&
-        settings.activeKnowledgeProfileUid.length > 0
-          ? settings.activeKnowledgeProfileUid
-          : null;
-
-      const profile = await this.resolver.resolve(targetProfileUid);
-      const appliesTo =
-        profile !== null &&
-        typeof profile.appliesTo === "string" &&
-        profile.appliesTo.length > 0
-          ? profile.appliesTo
-          : null;
-
-      // Layer 1 — `_appliesTo` declared: the Focus profile is bound to one
-      // Knowledge profile. Mismatch (incl. no active Knowledge) is incompatible.
-      if (appliesTo !== null) {
-        if (activeKnowledgeUid !== appliesTo) {
-          return {
-            compatible: false,
-            reason:
-              `Focus profile ${targetProfileUid} declares _appliesTo=${appliesTo} but active ` +
-              `Knowledge profile is ${activeKnowledgeUid ?? "<none>"}. Applying no-filter (AC16 ` +
-              `applies-to mismatch — soft fallback, no throw).`,
-            userMessage:
-              "Focus profile is scoped to a different Knowledge profile — showing the full " +
-              "vault instead. Hard-switch the matching Knowledge profile first to narrow the view.",
-          };
-        }
-        // appliesTo === activeKnowledgeUid → fall through to the subset check.
-      } else if (activeKnowledgeUid === null) {
-        // Layer 2 — no `_appliesTo` constraint AND no active Knowledge profile:
-        // there is no Knowledge scope to validate against. Backward-compatible
-        // pass-through (pre-AC16 behaviour) — apply the Focus filter as declared.
-        return { compatible: true };
-      }
-
-      // Defensive: activeKnowledgeUid is non-null past this point (either
-      // appliesTo matched it, or appliesTo was absent but Knowledge is active).
-      if (activeKnowledgeUid === null) return { compatible: true };
-
-      // Layer 3 (EC3) — active Knowledge resolves to an empty derived set
-      // (no declared ontologies, e.g. not materialised). Cannot validate the
-      // Focus scope against it → no-filter fallback.
-      const knowledgeDerived = await this.computeDerivedSet(activeKnowledgeUid);
-      if (knowledgeDerived.size === 0) {
-        return {
-          compatible: false,
-          reason:
-            `Active Knowledge profile ${activeKnowledgeUid} has an empty effective set ` +
-            `(not materialised) — cannot validate Focus scope. Applying no-filter (AC16 EC3).`,
-          userMessage:
-            "The active Knowledge profile has no materialised ontologies yet — showing the full " +
-            "vault. Hard-switch a Knowledge profile to enable focused filtering.",
-        };
-      }
-
-      // Layer 4 — `_includes ⊆ active Knowledge effective set`. The effective
-      // set includes the TS-floor, so a Focus profile may always reference the
-      // plugin foundations ($exo, $exocmd) regardless of the Knowledge declaration.
-      const knowledgeEffective =
-        await this.resolveEffectiveSet(activeKnowledgeUid);
-      const includes = profile !== null ? profile.includes : [];
-      const missing = includes.filter((u) => !knowledgeEffective.has(u));
-      if (missing.length > 0) {
-        return {
-          compatible: false,
-          reason:
-            `Focus profile ${targetProfileUid} _includes references ontologies outside the active ` +
-            `Knowledge effective set: ${missing.slice(0, 5).join(", ")}` +
-            `${missing.length > 5 ? ", …" : ""}. Applying no-filter (AC16 subset violation).`,
-          userMessage:
-            "Focus profile references ontologies the active Knowledge profile does not provide — " +
-            "showing the full vault to avoid an empty view.",
-        };
-      }
-
-      return { compatible: true };
-    } catch (e) {
-      // AC16 invariant — compat evaluation must never throw / block the switch.
-      // Proceed with the declared filter (failing closed to no-filter would
-      // surprise the user more than a best-effort narrowed view).
-      console.warn(
-        `[FocusProfileSwitchManager] compat evaluation errored for ${targetProfileUid}; ` +
-          `proceeding with the declared filter. ${this.redactError(String(e))}`,
-      );
-      return { compatible: true };
-    }
   }
 
   // === Hard switch orchestration (RFC 22b50a17 Phase 3) ===

--- a/packages/obsidian-plugin/src/infrastructure/adapters/VaultProfileResolver.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/VaultProfileResolver.ts
@@ -4,10 +4,7 @@ import type {
   IProfileResolver,
   ProfileResolution,
 } from "./FocusProfileSwitchManager";
-import {
-  FOCUS_PROFILE_CLASS_UID,
-  KNOWLEDGE_PROFILE_CLASS_UID,
-} from "./FocusProfileSwitchManager";
+import { FOCUS_PROFILE_CLASS_UID } from "./FocusProfileSwitchManager";
 
 /**
  * Vault-backed implementation of {@link IProfileResolver}. Reads
@@ -117,21 +114,10 @@ export class VaultProfileResolver implements IProfileResolver {
   }
 
   /**
-   * Walks the vault returning every KnowledgeProfile asset (RFC 13da049f
-   * Phase 6.5b AC17). Used by the «Switch knowledge profile» palette picker.
-   * Dual-class assets (declaring both Focus + Knowledge) appear in BOTH
-   * `listFocusProfileFiles()` and this list because the discrimination is by
-   * `exo__Instance_class` membership, not exclusivity.
-   */
-  public listKnowledgeProfileFiles(): TFile[] {
-    return this.listProfileFilesByClass(KNOWLEDGE_PROFILE_CLASS_UID);
-  }
-
-  /**
    * Walks the vault returning assets whose `exo__Instance_class` contains the
-   * given class UID. Shared by {@link listFocusProfileFiles} and
-   * {@link listKnowledgeProfileFiles} so the per-class fuzzy pickers (AC17)
-   * and the dual-class membership rule stay in one place.
+   * given class UID. Used by {@link listFocusProfileFiles}. (RFC 01a83de8
+   * Phase 3 T4 collapsed the former per-class Knowledge picker into the single
+   * `exo__Profile` class, so there is now one profile list.)
    */
   public listProfileFilesByClass(classUid: string): TFile[] {
     const out: TFile[] = [];

--- a/packages/obsidian-plugin/tests/unit/FocusProfileCommands.test.ts
+++ b/packages/obsidian-plugin/tests/unit/FocusProfileCommands.test.ts
@@ -342,12 +342,12 @@ describe("FocusProfileCommands.invokeSwitchKnowledgeProfile", () => {
     expect(h.switchMgr.switchCalls).toHaveLength(0); // soft NOT invoked
   });
 
-  it("shows Notice when no KnowledgeProfile assets in vault", async () => {
+  it("shows Notice when no profiles in vault", async () => {
     const h = makeHarness({ profiles: [], knowledgeProfiles: [] });
     await h.cmd.invokeSwitchKnowledgeProfile();
 
     expect(h.pickCalls).toHaveLength(0);
-    expect(h.notices.some((n) => /No KnowledgeProfile/.test(n))).toBe(true);
+    expect(h.notices.some((n) => /No profiles found/.test(n))).toBe(true);
   });
 
   it("does nothing when user cancels picker", async () => {

--- a/packages/obsidian-plugin/tests/unit/FocusProfileSwitchManager.compat.test.ts
+++ b/packages/obsidian-plugin/tests/unit/FocusProfileSwitchManager.compat.test.ts
@@ -11,14 +11,15 @@ import {
 import { PluginLockManager } from "../../src/infrastructure/adapters/PluginLockManager";
 
 /**
- * AC16 (RFC 13da049f Phase 6.5b) — soft-switch compatibility check.
+ * Soft-switch filter application after RFC 01a83de8 Phase 3 T4.
  *
- * On incompatibility the switch must perform 4 measurable actions WITHOUT
- * throwing:
- *   1. console.warn with the violation message
- *   2. user-facing Notice
- *   3. RDF re-index with the no-filter set (empty)
- *   4. resolve successfully (no throw); the Focus selection is still persisted
+ * The former AC16 Focus↔Knowledge compatibility check (RFC 13da049f Phase 6.5b)
+ * was REMOVED: Phase 2 collapsed the two profile classes into one `exo__Profile`,
+ * so there is no separate Knowledge profile to be (in)compatible with. The soft
+ * switch now ALWAYS applies the target profile's narrowed effective set — no
+ * compat downgrade to a no-filter (full-vault) view, no compatibility warning.
+ * These tests pin that universal behaviour, including scenarios that previously
+ * triggered the (now-deleted) no-filter fallback.
  */
 
 // ─── Fakes ───────────────────────────────────────────────────────────────
@@ -85,7 +86,6 @@ class FakeSettingsStore implements ISettingsStore {
 }
 
 const ONTO_EXO = "https://exocortex.my/ontology/exo";
-const ONTO_EXOCMD = "https://exocortex.my/ontology/exocmd";
 const ONTO_KITELEV = "https://exocortex.my/ontology/kitelev";
 const ONTO_TBANK = "https://exocortex.my/ontology/tbank";
 const ONTO_PERSONAL = "https://exocortex.my/ontology/personal";
@@ -143,7 +143,7 @@ function profile(
   ];
 }
 
-describe("FocusProfileSwitchManager.softSwitchFocusProfile — AC16 compat", () => {
+describe("FocusProfileSwitchManager.softSwitchFocusProfile — filter application (T4: no compat downgrade)", () => {
   let warnSpy: jest.SpyInstance;
   beforeEach(() => {
     warnSpy = jest.spyOn(console, "warn").mockImplementation(() => undefined);
@@ -152,10 +152,9 @@ describe("FocusProfileSwitchManager.softSwitchFocusProfile — AC16 compat", () 
     warnSpy.mockRestore();
   });
 
-  it("backward-compat: no active Knowledge + no _appliesTo → applies the Focus filter (no warn)", async () => {
+  it("applies the target's narrowed filter (+ TS-floor) and emits the success Notice", async () => {
     const { mgr, rdf, notifyCalls } = makeMgr({
       profiles: [profile(FOCUS_F1, { includes: [ONTO_TBANK] })],
-      // no activeKnowledgeProfileUid set
     });
     await expect(mgr.softSwitchFocusProfile(FOCUS_F1)).resolves.toBeUndefined();
 
@@ -167,117 +166,59 @@ describe("FocusProfileSwitchManager.softSwitchFocusProfile — AC16 compat", () 
     expect(notifyCalls.some((n) => /Switched to/.test(n))).toBe(true);
   });
 
-  it("violation — _appliesTo mismatch → 4 actions (warn, Notice, no-filter, no throw)", async () => {
+  it("STILL applies the filter when a prior active profile would have triggered the old no-filter fallback (compat removed)", async () => {
+    // Pre-T4 this scenario (target _includes ⊄ active Knowledge set, plus an
+    // _appliesTo mismatch + an active Knowledge slot) downgraded to a no-filter
+    // (size 0) full-vault view with a warning. T4 removed that — the target's
+    // filter is always applied, no warn, no "full vault" Notice.
     const { mgr, rdf, settings, notifyCalls } = makeMgr({
       profiles: [
         profile(FOCUS_F1, {
-          includes: [ONTO_KITELEV],
+          includes: [ONTO_PERSONAL],
           appliesTo: KNOWLEDGE_K1,
         }),
         profile(KNOWLEDGE_K2, { includes: [ONTO_KITELEV] }),
       ],
       settings: { activeKnowledgeProfileUid: KNOWLEDGE_K2 },
     });
-
-    // Action #4 — resolves successfully (no throw).
     await expect(mgr.softSwitchFocusProfile(FOCUS_F1)).resolves.toBeUndefined();
-
-    // Action #1 — console.warn with compatibility message.
-    expect(warnSpy).toHaveBeenCalled();
-    expect(String(warnSpy.mock.calls[0][0])).toMatch(
-      /applies-to mismatch|_appliesTo/,
-    );
-    // Action #2 — user-facing Notice.
-    expect(notifyCalls.some((n) => /full vault/i.test(n))).toBe(true);
-    // Action #3 — RDF re-index with empty (no-filter) set.
-    expect(rdf.refreshCalls).toHaveLength(1);
-    expect(rdf.refreshCalls[0].size).toBe(0);
-    // Selection still persisted (Focus slot).
-    expect(settings.state.activeFocusProfileUid).toBe(FOCUS_F1);
-    expect(settings.state._switchInProgress).toBe(false);
-    // No misleading «Switched to» success Notice.
-    expect(notifyCalls.some((n) => /Switched to/.test(n))).toBe(false);
-  });
-
-  it("compatible — _appliesTo matches active Knowledge AND includes ⊆ effective → narrowed filter", async () => {
-    const { mgr, rdf } = makeMgr({
-      profiles: [
-        profile(FOCUS_F1, {
-          includes: [ONTO_KITELEV],
-          appliesTo: KNOWLEDGE_K1,
-        }),
-        profile(KNOWLEDGE_K1, { includes: [ONTO_KITELEV, ONTO_TBANK] }),
-      ],
-      settings: { activeKnowledgeProfileUid: KNOWLEDGE_K1 },
-    });
-    await mgr.softSwitchFocusProfile(FOCUS_F1);
 
     expect(rdf.refreshCalls).toHaveLength(1);
     const set = rdf.refreshCalls[0];
-    expect(set.has(ONTO_KITELEV)).toBe(true); // narrowed filter, not empty
+    expect(set.has(ONTO_PERSONAL)).toBe(true); // narrowed filter applied, NOT empty
     expect(set.size).toBeGreaterThan(0);
-    expect(warnSpy).not.toHaveBeenCalled();
+    expect(warnSpy).not.toHaveBeenCalled(); // no compat warning
+    expect(notifyCalls.some((n) => /full vault/i.test(n))).toBe(false);
+    expect(notifyCalls.some((n) => /Switched to/.test(n))).toBe(true);
+    // Focus selection persisted, flag cleared.
+    expect(settings.state.activeFocusProfileUid).toBe(FOCUS_F1);
+    expect(settings.state._switchInProgress).toBe(false);
   });
 
-  it("violation — includes ⊄ active Knowledge effective set → no-filter", async () => {
-    const { mgr, rdf, notifyCalls } = makeMgr({
-      profiles: [
-        // F1 references ONTO_PERSONAL which K1 does not provide.
-        profile(FOCUS_F1, { includes: [ONTO_PERSONAL] }),
-        profile(KNOWLEDGE_K1, { includes: [ONTO_KITELEV, ONTO_TBANK] }),
-      ],
-      settings: { activeKnowledgeProfileUid: KNOWLEDGE_K1 },
-    });
-    await mgr.softSwitchFocusProfile(FOCUS_F1);
-
-    expect(rdf.refreshCalls[0].size).toBe(0); // no-filter
-    expect(warnSpy).toHaveBeenCalled();
-    expect(String(warnSpy.mock.calls[0][0])).toMatch(
-      /subset violation|outside the active/,
-    );
-    expect(notifyCalls.some((n) => /full vault/i.test(n))).toBe(true);
-  });
-
-  it("compatible — includes references a TS-floor ontology even if Knowledge omits it", async () => {
-    const { mgr, rdf } = makeMgr({
-      profiles: [
-        // F1 includes $exocmd (a TS-floor ontology) — always in effective set.
-        profile(FOCUS_F1, { includes: [ONTO_EXOCMD] }),
-        profile(KNOWLEDGE_K1, { includes: [ONTO_KITELEV] }),
-      ],
-      settings: { activeKnowledgeProfileUid: KNOWLEDGE_K1 },
-    });
-    await mgr.softSwitchFocusProfile(FOCUS_F1);
-
-    expect(rdf.refreshCalls[0].size).toBeGreaterThan(0); // applied, not no-filter
-  });
-
-  it("EC3 — active Knowledge has empty effective set (not materialized) → no-filter", async () => {
+  it("applies the filter even when an EMPTY prior active profile is set (old EC3 no-filter removed)", async () => {
     const { mgr, rdf, notifyCalls } = makeMgr({
       profiles: [
         profile(FOCUS_F1, { includes: [ONTO_KITELEV] }),
-        // Empty Knowledge profile — derived set is empty.
         profile(KNOWLEDGE_EMPTY, { includes: [] }),
       ],
       settings: { activeKnowledgeProfileUid: KNOWLEDGE_EMPTY },
     });
     await mgr.softSwitchFocusProfile(FOCUS_F1);
 
-    expect(rdf.refreshCalls[0].size).toBe(0); // no-filter
-    expect(warnSpy).toHaveBeenCalled();
-    expect(String(warnSpy.mock.calls[0][0])).toMatch(
-      /EC3|empty effective set|not materialised/,
-    );
-    expect(notifyCalls.some((n) => /full vault/i.test(n))).toBe(true);
+    expect(rdf.refreshCalls[0].has(ONTO_KITELEV)).toBe(true);
+    expect(rdf.refreshCalls[0].size).toBeGreaterThan(0); // applied, not no-filter
+    expect(warnSpy).not.toHaveBeenCalled();
+    expect(notifyCalls.some((n) => /full vault/i.test(n))).toBe(false);
   });
 
-  it("never throws — compat evaluation error proceeds with the declared filter", async () => {
+  it("never resolves the active-profile slot, so a resolver that throws on it is irrelevant", async () => {
+    // The compat check used to resolve the active Knowledge profile (could
+    // throw). That path is gone — the target's filter applies regardless.
     const { mgr, rdf } = makeMgr({
       profiles: [profile(FOCUS_F1, { includes: [ONTO_TBANK] })],
       settings: { activeKnowledgeProfileUid: KNOWLEDGE_THROW },
-      throwForUids: [KNOWLEDGE_THROW], // resolving the active Knowledge throws
+      throwForUids: [KNOWLEDGE_THROW],
     });
-    // Must resolve (no throw) AND apply the declared filter (not no-filter).
     await expect(mgr.softSwitchFocusProfile(FOCUS_F1)).resolves.toBeUndefined();
     expect(rdf.refreshCalls).toHaveLength(1);
     expect(rdf.refreshCalls[0].has(ONTO_TBANK)).toBe(true);

--- a/packages/obsidian-plugin/tests/unit/VaultProfileResolver.test.ts
+++ b/packages/obsidian-plugin/tests/unit/VaultProfileResolver.test.ts
@@ -1,8 +1,5 @@
 import { VaultProfileResolver } from "../../src/infrastructure/adapters/VaultProfileResolver";
-import {
-  FOCUS_PROFILE_CLASS_UID,
-  KNOWLEDGE_PROFILE_CLASS_UID,
-} from "../../src/infrastructure/adapters/FocusProfileSwitchManager";
+import { FOCUS_PROFILE_CLASS_UID } from "../../src/infrastructure/adapters/FocusProfileSwitchManager";
 
 interface FakeFile {
   path: string;
@@ -224,55 +221,9 @@ describe("VaultProfileResolver.resolve — appliesTo deprecated (RFC 01a83de8 Ph
   });
 });
 
-describe("VaultProfileResolver.listKnowledgeProfileFiles (RFC 13da049f AC17)", () => {
-  it("returns files whose Instance_class contains the KnowledgeProfile UID", () => {
-    const app = makeApp([
-      {
-        file: { path: "k.md", basename: "k" },
-        fm: {
-          exo__Instance_class: `[[${KNOWLEDGE_PROFILE_CLASS_UID}|exo__KnowledgeProfile]]`,
-          exo__Asset_uid: "k1",
-        },
-      },
-      {
-        file: { path: "f.md", basename: "f" },
-        fm: {
-          exo__Instance_class: `[[${FOCUS_PROFILE_CLASS_UID}]]`,
-          exo__Asset_uid: "f1",
-        },
-      },
-    ]);
-    const resolver = new VaultProfileResolver(app);
-    expect(resolver.listKnowledgeProfileFiles().map((f) => f.path)).toEqual([
-      "k.md",
-    ]);
-    expect(resolver.listFocusProfileFiles().map((f) => f.path)).toEqual([
-      "f.md",
-    ]);
-  });
-
-  it("dual-class asset appears in BOTH Focus and Knowledge lists", () => {
-    const app = makeApp([
-      {
-        file: { path: "dual.md", basename: "dual" },
-        fm: {
-          exo__Instance_class: [
-            `[[${FOCUS_PROFILE_CLASS_UID}|exo__FocusProfile]]`,
-            `[[${KNOWLEDGE_PROFILE_CLASS_UID}|exo__KnowledgeProfile]]`,
-          ],
-          exo__Asset_uid: "dual-1",
-        },
-      },
-    ]);
-    const resolver = new VaultProfileResolver(app);
-    expect(resolver.listFocusProfileFiles().map((f) => f.path)).toEqual([
-      "dual.md",
-    ]);
-    expect(resolver.listKnowledgeProfileFiles().map((f) => f.path)).toEqual([
-      "dual.md",
-    ]);
-  });
-});
+// RFC 01a83de8 Phase 3 T4 — listKnowledgeProfileFiles removed (the former
+// per-class KnowledgeProfile picker collapsed into the single exo__Profile
+// class; the mount-state picker now uses listFocusProfileFiles).
 
 describe("VaultProfileResolver.discoverSharedOntologies", () => {
   it("returns empty array (v3 backward-compat — TS-floor pattern handles shared- prefix)", async () => {


### PR DESCRIPTION
## Summary

RFC `01a83de8` **Phase 3 T4** — remove the dead KnowledgeProfile-class machinery left by Phase 2's class collapse, and fix the empty mount-state picker it caused.

- **Collapse the mount-state picker** ("Switch knowledge profile") → `listFocusProfileFiles`. The former `listKnowledgeProfileFiles` filtered by `KNOWLEDGE_PROFILE_CLASS_UID` (`b8884976`), which has **0 instances in vault-2025** — so the picker was **empty on iPhone**, making T2's mobile mount-state switch untriggerable. Both pickers now list the single `exo__Profile` class. Removes `listKnowledgeProfileFiles` + `KNOWLEDGE_PROFILE_CLASS_UID`.
- **Remove the AC16 Focus↔Knowledge compatibility check** (`evaluateFocusKnowledgeCompat`): with one class there is no separate Knowledge profile to be (in)compatible with. `softSwitchFocusProfile` now always applies the target's narrowed effective set — no no-filter downgrade, no compat warning.

## Scope / deferred

- **Deferred to T3** (coupled to soft-filter removal per RFC EV4): dual-active-state slot collapse (`activeKnowledgeProfileUid`) + the vault `exo__AssetSpace_containsOntology` / `primaryOntology` vestigial-property drop.
- **Descoped**: cosmetic `FocusProfile*→Profile*` class/file renames (`FocusProfileSwitchManager` alone = 31 caller files ≫ 15-caller cascade-cap).

## Test plan

- [x] Compat suite rewritten to pin the new universal behaviour (filter always applied, incl. scenarios that previously triggered the deleted no-filter fallback — no warn, no "full vault" Notice).
- [x] VaultProfileResolver suite: removed the obsolete per-class picker cases.
- [x] Regression: 76 `FocusProfileSwitchManager`/`VaultProfileResolver` + 129 `ExocortexPlugin`/`FocusProfileCommands` tests green.
- [x] `npm run check:types` clean; lint clean.
- [ ] 14 required CI checks.