### PR TITLE
refactor(profile): remove dead Ontology→AS translation (RFC 01a83de8 T3b-cleanup)

### DIFF
--- a/packages/cli/src/services/CliFocusProfileResolver.ts
+++ b/packages/cli/src/services/CliFocusProfileResolver.ts
@@ -5,17 +5,16 @@
  *
  * Walks the vault filesystem to:
  *   1. Build folderMap: `assetspaces/<folder>` → AssetSpace UID
- *   2. Build ontologyToAs: Ontology UID → owning AssetSpace UID (via
- *      `exo__AssetSpace_containsOntology` declarations)
- *   3. Resolve Profile chain (`_imports*` + `_includes`) to a declared UID set
- *      (`_includes` now AssetSpace UIDs per RFC 01a83de8 Phase 2; `_alwaysOnOverlay`
+ *   2. Resolve Profile chain (`_imports*` + `_includes`) to a declared UID set
+ *      (`_includes` are AssetSpace UIDs per RFC 01a83de8 Phase 2; `_alwaysOnOverlay`
  *      removed — folds into TS-floor)
- *   4. Translate declared Ontology UIDs → AssetSpace UIDs through ontologyToAs
- *      (AS UIDs pass through unchanged; covers TS-floor ontology URIs)
- *   5. Apply TS-floor AssetSpace UIDs (Vision Lock #17): $exo, $exocmd,
+ *   3. Resolve declared AssetSpace UIDs against folderMap (the former
+ *      Ontology→AS translation via `exo__AssetSpace_containsOntology` was removed
+ *      in Phase 3 T3b-cleanup — profiles declare AS UIDs directly)
+ *   4. Apply TS-floor AssetSpace UIDs (Vision Lock #17): $exo, $exocmd,
  *      $shared-identities — guarantees plugin/CLI keeps functioning regardless
  *      of profile config
- *   6. Safe-degrade: if effective set has zero AS-folder overlap, return null
+ *   5. Safe-degrade: if effective set has zero AS-folder overlap, return null
  *      (caller falls back to no-filter / full vault) to prevent self-brick
  *
  * **Phase 6 follow-up** (deferred): extract the shared resolver / translation
@@ -65,9 +64,9 @@ export interface ResolveFilterResult {
   effective: ReadonlySet<string>;
   /** `assetspaces/<folder>` → AS UID map the converter uses to look up file owners. */
   folderMap: ReadonlyMap<string, string>;
-  /** Diagnostic — declared Ontology UIDs the profile chain produced (pre-translation). */
+  /** Diagnostic — declared UIDs the profile chain produced (`_includes` ∪ floor). */
   declaredOntologies: ReadonlySet<string>;
-  /** Diagnostic — Ontology UIDs that had no AS owner in `containsOntology` (translation miss). */
+  /** Diagnostic — declared UIDs that matched no known AssetSpace folder. */
   untranslated: ReadonlyArray<string>;
 }
 
@@ -121,11 +120,11 @@ export class CliFocusProfileResolver {
   }
 
   /**
-   * Resolve `--profile <uid>` to the converter filter pair.
+   * Resolve a profile UID to its effective AssetSpace set.
    *
    * Outcomes:
-   * - `engaged` — filter computed; pass `result.effective` + `result.folderMap`
-   *   to `NoteToRDFConverter.convertVault({ effectiveOntologies, assetSpaceFolderToUid })`
+   * - `engaged` — effective set computed; `result.effective` is the AS-UID set
+   *   the CLI hard switch materialises (+ `result.folderMap` for diagnostics)
    * - `no-profile` — `profileUid` was null/undefined; caller indexes full vault
    * - `missing-profile` — UID provided but no asset with that UID found; caller
    *   indexes full vault (defensive; surface warn)
@@ -142,7 +141,6 @@ export class CliFocusProfileResolver {
 
     let scan: {
       folderMap: Map<string, string>;
-      ontologyToAs: Map<string, string>;
       profiles: Map<string, ProfileFrontmatter>;
     };
     try {
@@ -171,18 +169,18 @@ export class CliFocusProfileResolver {
       return { outcome: "error", reason };
     }
 
-    // Translate Ontology UIDs → AS UIDs
+    // Resolve declared UIDs against the AssetSpace folder map. RFC 01a83de8
+    // Phase 2 retargeted `_includes` to AssetSpace UIDs, so they match the
+    // folder map directly; the former Ontology→AS translation (via
+    // `exo__AssetSpace_containsOntology`) is dead and was removed in Phase 3
+    // T3b-cleanup. UIDs that don't resolve to a known AS folder are surfaced as
+    // `untranslated` for diagnostics.
     const folderMapValues = new Set(scan.folderMap.values());
     const effectiveAs = new Set<string>();
     const untranslated: string[] = [];
     for (const uid of declared) {
       if (folderMapValues.has(uid)) {
         effectiveAs.add(uid);
-        continue;
-      }
-      const translated = scan.ontologyToAs.get(uid);
-      if (translated !== undefined) {
-        effectiveAs.add(translated);
         continue;
       }
       untranslated.push(uid);
@@ -200,8 +198,8 @@ export class CliFocusProfileResolver {
     if (!hasOverlap) {
       const reason =
         `[CliFocusProfileResolver] profileUid=${profileUid} produced effective set with zero AssetSpace folder overlap ` +
-        `(${effectiveAs.size} AS UIDs after translation+floor; ${scan.folderMap.size} folders known). ` +
-        `Likely cause: profile declares Ontology UIDs not covered by containsOntology, or vault has no scanned AssetSpaces. ` +
+        `(${effectiveAs.size} AS UIDs incl. floor; ${scan.folderMap.size} folders known). ` +
+        `Likely cause: profile declares AssetSpace UIDs not present as descriptors, or vault has no scanned AssetSpaces. ` +
         `Falling back to no-filter (full vault indexed).`;
       this.warn(reason);
       return { outcome: "degraded", reason };
@@ -252,11 +250,9 @@ export class CliFocusProfileResolver {
 
   private async scanAllVaults(): Promise<{
     folderMap: Map<string, string>;
-    ontologyToAs: Map<string, string>;
     profiles: Map<string, ProfileFrontmatter>;
   }> {
     const folderMap = new Map<string, string>();
-    const ontologyToAs = new Map<string, string>();
     const profiles = new Map<string, ProfileFrontmatter>();
 
     for (const vaultRoot of this.vaultPaths) {
@@ -273,16 +269,12 @@ export class CliFocusProfileResolver {
         );
 
         if (classes.some((c) => c === ASSET_SPACE_CLASS_UID)) {
-          // AssetSpace asset — register folderMap + containsOntology
+          // AssetSpace asset — register folderMap. The former Ontology→AS
+          // translation map (built from `exo__AssetSpace_containsOntology`) was
+          // removed in Phase 3 T3b-cleanup — profiles declare AS UIDs directly.
           const folder = parentFolderRelative(asset.filePath, asset.vaultRoot);
           if (folder.length > 0) {
             folderMap.set(folder, asset.uid);
-          }
-          const declared = parseWikilinkArray(
-            asset.frontmatter["exo__AssetSpace_containsOntology"],
-          );
-          for (const ont of declared) {
-            ontologyToAs.set(ont, asset.uid);
           }
         }
 
@@ -307,7 +299,7 @@ export class CliFocusProfileResolver {
       }
     }
 
-    return { folderMap, ontologyToAs, profiles };
+    return { folderMap, profiles };
   }
 
   private async walkVault(vaultRoot: string): Promise<AssetMeta[]> {

--- a/packages/cli/tests/unit/services/CliFocusProfileResolver.test.ts
+++ b/packages/cli/tests/unit/services/CliFocusProfileResolver.test.ts
@@ -37,7 +37,8 @@ const AS_SHARED_UID = TS_FLOOR_AS_UID_SHARED_IDENTITIES;
 const AS_EMS_UID = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
 const AS_KITELEV_UID = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb";
 
-const ONTOLOGY_EMS_UID = "cccccccc-cccc-cccc-cccc-cccccccccccc";
+// A UID that matches no AssetSpace folder — used to exercise the `untranslated`
+// diagnostic path.
 const ONTOLOGY_KITELEV_UID = "dddddddd-dddd-dddd-dddd-dddddddddddd";
 
 interface AssetSpec {
@@ -65,19 +66,12 @@ async function makeVault(vaultRoot: string, assets: AssetSpec[]): Promise<void> 
   }
 }
 
-function asAssetSpace(uid: string, folder: string, containsOntologies: string[] = []): AssetSpec {
+function asAssetSpace(uid: string, folder: string): AssetSpec {
   return {
     relPath: `assetspaces/${folder}/${uid}.md`,
     frontmatter: {
       "exo__Asset_uid": uid,
       "exo__Instance_class": [`[[${ASSET_SPACE_CLASS_UID}|exo__AssetSpace]]`],
-      ...(containsOntologies.length > 0
-        ? {
-            "exo__AssetSpace_containsOntology": containsOntologies.map(
-              (o) => `[[${o}]]`,
-            ),
-          }
-        : {}),
     },
   };
 }
@@ -174,28 +168,31 @@ describe("CliFocusProfileResolver", () => {
       }
     });
 
-    it("translates declared Ontology UIDs to AS UIDs via containsOntology", async () => {
+    it("resolves declared AS UIDs against the folder map (RFC 01a83de8 Phase 2)", async () => {
       await makeVault(tmpRoot, [
         asAssetSpace(AS_EXO_UID, "exo"),
         asAssetSpace(AS_EXOCMD_UID, "exocmd"),
         asAssetSpace(AS_SHARED_UID, "shared-identities"),
-        asAssetSpace(AS_EMS_UID, "ems", [ONTOLOGY_EMS_UID]),
+        asAssetSpace(AS_EMS_UID, "ems"),
         asProfile(PROFILE_PERSONAL_UID, {
-          includes: [ONTOLOGY_EMS_UID],
+          // `_includes` declares the AssetSpace UID directly. The former
+          // Ontology→AS translation (via containsOntology) was removed in
+          // Phase 3 T3b-cleanup.
+          includes: [AS_EMS_UID],
         }),
       ]);
       const resolver = new CliFocusProfileResolver({ vaultPath: tmpRoot });
       const out = await resolver.resolveFilter(PROFILE_PERSONAL_UID);
       expect(out.outcome).toBe("engaged");
       if (out.outcome === "engaged") {
-        // Ontology UID got translated to its owning AS UID
+        // Declared AS UID resolved directly against the folder map.
         expect(out.result.effective.has(AS_EMS_UID)).toBe(true);
         // TS-floor present
         expect(out.result.effective.has(AS_EXO_UID)).toBe(true);
         expect(out.result.effective.has(AS_EXOCMD_UID)).toBe(true);
         expect(out.result.effective.has(AS_SHARED_UID)).toBe(true);
         // declared set surfaced for diagnostics
-        expect(out.result.declaredOntologies.has(ONTOLOGY_EMS_UID)).toBe(true);
+        expect(out.result.declaredOntologies.has(AS_EMS_UID)).toBe(true);
         // No untranslated entries
         expect(out.result.untranslated.length).toBe(0);
       }
@@ -219,15 +216,15 @@ describe("CliFocusProfileResolver", () => {
       }
     });
 
-    it("records untranslated UIDs when Ontology has no AssetSpace owner", async () => {
+    it("records untranslated UIDs when a declared UID matches no AssetSpace folder", async () => {
       await makeVault(tmpRoot, [
         asAssetSpace(AS_EXO_UID, "exo"),
         asAssetSpace(AS_EXOCMD_UID, "exocmd"),
         asAssetSpace(AS_SHARED_UID, "shared-identities"),
-        asAssetSpace(AS_EMS_UID, "ems", [ONTOLOGY_EMS_UID]),
+        asAssetSpace(AS_EMS_UID, "ems"),
         asProfile(PROFILE_PERSONAL_UID, {
-          // ONTOLOGY_EMS resolves; ONTOLOGY_KITELEV has no AS owner
-          includes: [ONTOLOGY_EMS_UID, ONTOLOGY_KITELEV_UID],
+          // AS_EMS resolves to a folder; ONTOLOGY_KITELEV matches no AssetSpace.
+          includes: [AS_EMS_UID, ONTOLOGY_KITELEV_UID],
         }),
       ]);
       const resolver = new CliFocusProfileResolver({ vaultPath: tmpRoot });
@@ -235,7 +232,7 @@ describe("CliFocusProfileResolver", () => {
       expect(out.outcome).toBe("engaged");
       if (out.outcome === "engaged") {
         expect(out.result.untranslated).toContain(ONTOLOGY_KITELEV_UID);
-        expect(out.result.untranslated).not.toContain(ONTOLOGY_EMS_UID);
+        expect(out.result.untranslated).not.toContain(AS_EMS_UID);
         expect(out.result.effective.has(AS_EMS_UID)).toBe(true);
       }
     });

--- a/packages/obsidian-plugin/src/infrastructure/adapters/FocusProfileSwitchManager.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/FocusProfileSwitchManager.ts
@@ -561,16 +561,17 @@ export class FocusProfileSwitchManager {
     // intent in the user's profile declaration.
     const declaredOntologySet = await this.computeDerivedSet(targetProfileUid);
     const folderToAsUid = await this.scanFolderToAsUid();
-    const ontologyToAs = await this.scanOntologyToAsUid();
     const declaredAsUids = new Set<string>();
     const folderMapValues = new Set(folderToAsUid.values());
+    // RFC 01a83de8 Phase 2 retargeted `_includes` to AssetSpace UIDs, so the
+    // derived set already contains AS UIDs that resolve directly against the
+    // folder map. The former Ontology→AS translation (via the
+    // `exo__AssetSpace_containsOntology` predicate) is dead and was removed in
+    // Phase 3 T3b-cleanup.
     for (const uid of declaredOntologySet) {
       if (folderMapValues.has(uid)) {
         declaredAsUids.add(uid);
-        continue;
       }
-      const translated = ontologyToAs.get(uid);
-      if (translated !== undefined) declaredAsUids.add(translated);
     }
     this.assertTsFloor(declaredAsUids);
 
@@ -971,16 +972,17 @@ export class FocusProfileSwitchManager {
     // NOT resolveEffectiveSet — the latter silently injects floor ontologies).
     const declaredOntologySet = await this.computeDerivedSet(targetProfileUid);
     const folderToAsUid = await this.scanFolderToAsUid();
-    const ontologyToAs = await this.scanOntologyToAsUid();
     const declaredAsUids = new Set<string>();
     const folderMapValues = new Set(folderToAsUid.values());
+    // RFC 01a83de8 Phase 2 retargeted `_includes` to AssetSpace UIDs, so the
+    // derived set already contains AS UIDs that resolve directly against the
+    // folder map. The former Ontology→AS translation (via the
+    // `exo__AssetSpace_containsOntology` predicate) is dead and was removed in
+    // Phase 3 T3b-cleanup.
     for (const uid of declaredOntologySet) {
       if (folderMapValues.has(uid)) {
         declaredAsUids.add(uid);
-        continue;
       }
-      const translated = ontologyToAs.get(uid);
-      if (translated !== undefined) declaredAsUids.add(translated);
     }
     this.assertTsFloor(declaredAsUids);
     const effectiveAsUids = new Set(declaredAsUids);
@@ -1260,16 +1262,17 @@ export class FocusProfileSwitchManager {
     // Compute expected AS set for activeProfileUid.
     const declared = await this.resolveEffectiveSet(activeProfileUid);
     const folderToAsUid = await this.scanFolderToAsUid();
-    const ontologyToAs = await this.scanOntologyToAsUid();
     const expectedAsUids = new Set<string>();
     const folderMapValues = new Set(folderToAsUid.values());
+    // `_includes` are AssetSpace UIDs (RFC 01a83de8 Phase 2) → resolve directly
+    // against the folder map. The TS-floor ontology URIs added by
+    // resolveEffectiveSet are not AS UIDs and are re-injected at AS level just
+    // below. The former Ontology→AS translation (containsOntology) is dead —
+    // removed in Phase 3 T3b-cleanup.
     for (const uid of declared) {
       if (folderMapValues.has(uid)) {
         expectedAsUids.add(uid);
-        continue;
       }
-      const t = ontologyToAs.get(uid);
-      if (t !== undefined) expectedAsUids.add(t);
     }
     for (const floor of TS_FLOOR_ASSETSPACE_UIDS) expectedAsUids.add(floor);
 
@@ -1448,29 +1451,6 @@ export class FocusProfileSwitchManager {
     const out = new Map<string, string>();
     for (const info of this.listAllAssetSpaceInfos()) {
       out.set(info.folderName, info.uid);
-    }
-    return out;
-  }
-
-  private async scanOntologyToAsUid(): Promise<Map<string, string>> {
-    const out = new Map<string, string>();
-    for (const file of this.app.vault.getMarkdownFiles()) {
-      const cache = this.app.metadataCache.getFileCache(file);
-      const fm = cache?.frontmatter as Record<string, unknown> | undefined;
-      if (!fm) continue;
-      const uid = typeof fm["exo__Asset_uid"] === "string" ? (fm["exo__Asset_uid"] as string) : null;
-      if (uid === null) continue;
-      const rawContains = fm["exo__AssetSpace_containsOntology"];
-      const declared: unknown[] = Array.isArray(rawContains)
-        ? rawContains
-        : rawContains !== undefined && rawContains !== null
-          ? [rawContains]
-          : [];
-      for (const raw of declared) {
-        if (typeof raw !== "string") continue;
-        const cleaned = raw.trim().replace(/^\[\[/, "").replace(/\]\]$/, "").split("|")[0].trim();
-        if (cleaned.length > 0) out.set(cleaned, uid);
-      }
     }
     return out;
   }

--- a/packages/obsidian-plugin/src/infrastructure/adapters/FocusProfileSwitchManager.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/FocusProfileSwitchManager.ts
@@ -553,12 +553,10 @@ export class FocusProfileSwitchManager {
       : "<unknown>";
 
     // R24 — assert TS-floor BEFORE any mutation. Use computeDerivedSet (NOT
-    // resolveEffectiveSet) because the latter silently injects TS_FLOOR_ONTOLOGY_URIS
-    // before returning — feeding that injected set into our translation step
-    // would auto-rescue the floor through containsOntology mapping and
-    // defeat the guard's purpose. Soft-switch (Phase 1 onload wiring) silently
-    // injects floor for UX; hard-switch is destructive so we require explicit
-    // intent in the user's profile declaration.
+    // resolveEffectiveSet) so the floor URIs that resolveEffectiveSet injects
+    // don't mask a profile that legitimately omits a floor AS — R24 must see
+    // the user's explicit `_includes`. Hard-switch is destructive, so we
+    // require explicit intent rather than the soft-path's UX-convenience floor.
     const declaredOntologySet = await this.computeDerivedSet(targetProfileUid);
     const folderToAsUid = await this.scanFolderToAsUid();
     const declaredAsUids = new Set<string>();

--- a/packages/obsidian-plugin/tests/unit/FocusProfileSwitchManager.hardSwitch.test.ts
+++ b/packages/obsidian-plugin/tests/unit/FocusProfileSwitchManager.hardSwitch.test.ts
@@ -303,10 +303,9 @@ interface SetupOptions {
   /** Profile UID currently active. */
   sourceUid: string | null;
   /**
-   * AS UIDs the target profile intends to include. The helper converts each
-   * to the production-shape Ontology URI form `ontology-<asUid>` matching
-   * the fixture's `exo__AssetSpace_containsOntology` declarations. Use raw
-   * AS UID for the test set — translation happens in the helper.
+   * AssetSpace UIDs the target profile declares in `_includes` (RFC 01a83de8
+   * Phase 2 — `_includes` are AS UIDs directly; the Ontology→AS translation
+   * was removed in Phase 3 T3b-cleanup).
    */
   targetIncludes: string[];
   /** AS UIDs included in source profile (used for source label display only). */
@@ -342,13 +341,10 @@ function setup(opts: SetupOptions) {
         "exo__Instance_class": ["[[exo__FocusProfile]]"],
       },
     },
-    // AssetSpace ABox assets — each has folder + git + namespace + class +
-    // containsOntology. Production-shape: AS ABox declares the Ontology
-    // URI it contains (per RFC b6ba5595 + FocusProfileOnloadWiring scan).
-    // Without this property, the R24 guard's translation step cannot map
-    // declared Ontology URIs back to AS UIDs and the guard fires for the
-    // wrong reason. Each AS declares one synthetic ontology URI named after
-    // the folder; profiles include those URIs in `_includes`.
+    // AssetSpace ABox assets — each has folder + source + namespace + class.
+    // Production-shape (RFC 01a83de8 Phase 2): profiles `_includes` reference
+    // these AS UIDs directly, so the R24 guard resolves them against the folder
+    // map without any Ontology→AS translation (removed in Phase 3 T3b-cleanup).
     ...allAs.map((as) => {
       const ns = as.folder.split("/").pop();
       return {
@@ -364,7 +360,6 @@ function setup(opts: SetupOptions) {
           // === `assetspaces/<owner>/<repo>` === as.folder).
           "exo__AssetSpace_source": `https://github.com/${as.folder.replace("assetspaces/", "")}`,
           "exo__AssetSpace_namespace": ns,
-          "exo__AssetSpace_containsOntology": [`[[ontology-${as.uid}]]`],
         },
       };
     }),
@@ -388,16 +383,16 @@ function setup(opts: SetupOptions) {
     fsFolders.set(folder, { files: [`${folder}/file1.md`, `${folder}/file2.md`], folders: [] });
   }
 
-  // Profile target resolution — production-shape: profile declares Ontology
-  // URIs (`ontology-<asUid>` per fixture containsOntology) NOT raw AS UIDs.
-  const includesAsOntology = opts.targetIncludes.map((u) => `ontology-${u}`);
+  // Profile target resolution — production-shape (RFC 01a83de8 Phase 2):
+  // profile `_includes` declares AssetSpace UIDs directly (no Ontology→AS
+  // translation; that indirection was removed in Phase 3 T3b-cleanup).
   const resolver = new FakeResolver(
     new Map<string, ProfileResolution>([
       [
         opts.targetUid,
         {
           uid: opts.targetUid,
-          includes: includesAsOntology,
+          includes: opts.targetIncludes,
           label: "Target Profile",
         },
       ],
@@ -513,22 +508,22 @@ describe("FocusProfileSwitchManager.hardSwitchProfile", () => {
     });
 
     it("passes guard via folderMapValues path when profile declares raw AS UIDs", async () => {
-      // Coverage gap: VaultProfileResolver can return raw AS UIDs (not
-      // Ontology URIs) when the user authored `_includes` с AS-UID wikilinks
-      // directly. The R24 translation step's `folderMapValues.has(uid)`
-      // branch covers this — this test asserts the branch works.
+      // VaultProfileResolver returns AS UIDs directly (RFC 01a83de8 Phase 2 —
+      // `_includes` are AssetSpace UIDs). The R24 derivation's
+      // `folderMapValues.has(uid)` branch resolves them — this test asserts the
+      // branch works (the empty `targetIncludes` is overridden below).
       const ctx = setup({
         targetUid: "target",
         sourceUid: null,
-        targetIncludes: [], // bypass helper's ontology- translation
+        targetIncludes: [],
         materialized: [
           TS_FLOOR_AS_UID_EXO,
           TS_FLOOR_AS_UID_EXOCMD,
           TS_FLOOR_AS_UID_SHARED_IDENTITIES,
         ],
       });
-      // Override resolver: profile._includes contains raw AS UIDs (not
-      // ontology- prefixed) — exercises folderMapValues path.
+      // Override resolver: profile._includes contains AS UIDs — exercises the
+      // folderMapValues path.
       const resolverInternal = (ctx.mgr as unknown as {
         resolver: { ["profiles"]: Map<string, ProfileResolution> };
       }).resolver;

--- a/packages/obsidian-plugin/tests/unit/FocusProfileSwitchManager.restSwitch.test.ts
+++ b/packages/obsidian-plugin/tests/unit/FocusProfileSwitchManager.restSwitch.test.ts
@@ -253,7 +253,6 @@ function setup(opts: SetupOpts) {
           exo__Instance_class: ["[[exo__AssetSpace]]"],
           exo__AssetSpace_source: `https://github.com/${as.folder.replace("assetspaces/", "")}`,
           exo__AssetSpace_namespace: ns,
-          exo__AssetSpace_containsOntology: [`[[ontology-${as.uid}]]`],
         },
       };
     }),
@@ -277,7 +276,9 @@ function setup(opts: SetupOpts) {
         "target",
         {
           uid: "target",
-          includes: opts.targetIncludes.map((u) => `ontology-${u}`),
+          // RFC 01a83de8 Phase 2 — `_includes` declares AssetSpace UIDs directly
+          // (Ontology→AS translation removed in Phase 3 T3b-cleanup).
+          includes: opts.targetIncludes,
           label: "Target Profile",
         },
       ],

--- a/packages/obsidian-plugin/tests/unit/integration/HardSwitchEndToEnd.integration.test.ts
+++ b/packages/obsidian-plugin/tests/unit/integration/HardSwitchEndToEnd.integration.test.ts
@@ -218,11 +218,9 @@ function buildVaultFiles(setup: VaultSetup): FakeFile[] {
         // real `git submodule add` clones from this `file://` _git.
         "exo__AssetSpace_git": as.git,
         "exo__AssetSpace_namespace": as.folder.split("/").pop(),
-        // Production-shape: AS ABox declares the Ontology UID it contains
-        // (per RFC 22b50a17 + FocusProfileOnloadWiring scan). The R24 guard
-        // depends on this declaration to translate profile-declared Ontology
-        // URIs → AS UIDs.
-        "exo__AssetSpace_containsOntology": [`[[ontology-${as.uid}]]`],
+        // Production-shape (RFC 01a83de8 Phase 2): profiles `_includes`
+        // reference this AS UID directly, so the R24 guard resolves it against
+        // the folder map — no Ontology→AS translation (removed in T3b-cleanup).
       },
     });
   }
@@ -401,20 +399,20 @@ describe("hardSwitchProfile E2E (real fs, mocked pull)", () => {
     const files = buildVaultFiles(setup);
     const { app } = makeFakeApp(files, setup.vaultPath);
 
-    // Profiles declare Ontology URIs (production shape per RFC b6ba5595);
-    // each AS ABox declares containsOntology, so R24 translation resolves
-    // them back to AS UIDs.
+    // Profiles declare AssetSpace UIDs directly (production shape per RFC
+    // 01a83de8 Phase 2); the R24 guard resolves them against the folder map —
+    // the former Ontology→AS translation was removed in Phase 3 T3b-cleanup.
     const profiles = new Map<string, ProfileResolution>([
       [
         "profile-a",
         {
           uid: "profile-a",
           includes: [
-            "ontology-as1",
-            "ontology-as2",
-            `ontology-${TS_FLOOR_AS_UID_EXO}`,
-            `ontology-${TS_FLOOR_AS_UID_EXOCMD}`,
-            `ontology-${TS_FLOOR_AS_UID_SHARED_IDENTITIES}`,
+            "as1",
+            "as2",
+            TS_FLOOR_AS_UID_EXO,
+            TS_FLOOR_AS_UID_EXOCMD,
+            TS_FLOOR_AS_UID_SHARED_IDENTITIES,
           ],
           label: "Profile A",
         },
@@ -424,11 +422,11 @@ describe("hardSwitchProfile E2E (real fs, mocked pull)", () => {
         {
           uid: "profile-b",
           includes: [
-            "ontology-as2",
-            "ontology-as3",
-            `ontology-${TS_FLOOR_AS_UID_EXO}`,
-            `ontology-${TS_FLOOR_AS_UID_EXOCMD}`,
-            `ontology-${TS_FLOOR_AS_UID_SHARED_IDENTITIES}`,
+            "as2",
+            "as3",
+            TS_FLOOR_AS_UID_EXO,
+            TS_FLOOR_AS_UID_EXOCMD,
+            TS_FLOOR_AS_UID_SHARED_IDENTITIES,
           ],
           label: "Profile B",
         },


### PR DESCRIPTION
## Summary

RFC 01a83de8 Phase 3 **T3b-cleanup** — removes the dead `Ontology→AssetSpace` translation that read `exo__AssetSpace_containsOntology`. This deletes the **last code readers** of that predicate, unblocking the T3c vault property drop.

**Why it's dead:** Phase 2 retargeted profile `_includes` to AssetSpace UIDs. Verified empirically — `profile-base`/`profile-work`/`profile-personal` `_includes` all resolve to AssetSpace descriptors (each carries `exo__AssetSpace_source`, label `kitelev/exoas-*`). So the `folderMapValues.has(uid)` branch already resolves every declared UID directly; the `ontologyToAs.get(uid)` fallback never fires.

## Changed (src)
- **`FocusProfileSwitchManager`** — delete `scanOntologyToAsUid` + drop the `ontologyToAs` map and the translation fallback in its 3 call sites (`hardSwitchKnowledgeProfile`, `restSwitchProfile`, `reconcileToLocal`). Kept the `folderMapValues.has` branch + the AS-level TS-floor injection.
- **`CliFocusProfileResolver`** — drop the `containsOntology` scan + `ontologyToAs` map + the `resolveFilter` translation fallback; effective set resolves declared AS UIDs directly.

After this PR, `exo__AssetSpace_containsOntology` has **zero functional code/test readers** (only explanatory comments remain).

## Tests
- hard/REST switch + `HardSwitchEndToEnd` + CLI resolver fixtures rewired to declare AS-UID `_includes` directly (production shape) instead of Ontology-URI `_includes` + `containsOntology` indirection.
- Deleted the obsolete CLI "translates via containsOntology" case (removed behaviour); the "passes through AS UIDs directly" + "untranslated diagnostics" cases now cover the canonical path.
- Local: `check:types` ✓, `lint` ✓ (0 errors), archgate ✓, CLI resolver (27) + plugin switch suites (65) green.

## Deferred (orthogonal — NOT a T3c prerequisite)
`activeKnowledgeProfileUid` → `activeProfileUid` dual-state collapse (handoff T3b step 4). Touches AC14 semantics broadly; descoped per cascade-cap discipline.

## Test plan
- [ ] CI green (14 required checks)
- [ ] code-reviewer (touches hard-switch destructive derivation)
- [ ] advisor round-2
- [ ] then T3c can drop containsOntology + primaryOntology from vault