### PR TITLE
docs(profile): rename exo__FocusProfile_includes → exo__Profile_includes (CR-4)

### DIFF
--- a/docs/profiles.md
+++ b/docs/profiles.md
@@ -182,18 +182,24 @@ The profiles that existed before the split — `profile-base`,
 **dual-class**: each carries _both_ `exo__KnowledgeProfile` and
 `exo__FocusProfile` in its `exo__Instance_class`.
 
+> **Note (RFC 01a83de8 Phase 2):** the `exo__FocusProfile` / `exo__KnowledgeProfile`
+> split below was superseded by the unified `exo__Profile` class. The legacy
+> per-class include predicate was renamed to `exo__Profile_includes` and its range
+> retargeted Ontology → AssetSpace. The migration example is kept for historical
+> context; current profiles use `exo__Profile_includes: [AssetSpace UIDs]`.
+
 ```yaml
 # Before the split — a single FocusProfile
 exo__Instance_class:
   - "[[<exo__FocusProfile-class-uid>]]"
-exo__FocusProfile_includes: [Ontology UIDs]
+exo__Profile_includes: [AssetSpace UIDs]
 
 # After migration — dual-class (appears in BOTH palettes)
 exo__Instance_class:
   - "[[<exo__KnowledgeProfile-class-uid>]]"   # NEW
   - "[[<exo__FocusProfile-class-uid>]]"        # preserved
-exo__KnowledgeProfile_includes: [Ontology UIDs]   # copied from FocusProfile_includes
-exo__FocusProfile_includes: [Ontology UIDs]       # preserved (same list)
+exo__KnowledgeProfile_includes: [Ontology UIDs]   # copied from Profile_includes
+exo__Profile_includes: [AssetSpace UIDs]          # preserved (same list)
 ```
 
 The same `_includes` list serves both roles initially, which preserves exactly

--- a/scripts/validate-docs-properties.js
+++ b/scripts/validate-docs-properties.js
@@ -40,7 +40,6 @@ const KNOWN_EXCEPTIONS = new Set([
   "exo__KnowledgeProfile_includes", // docs/profiles.md — documented exo__KnowledgeProfile (hard-switch) property; its sole literal-string reference in packages/ was the migrate-shared-identities-profiles migration service, removed in PR #3394 (YAGNI). No literal-token code ref remains by design.
   "exo__KnowledgeProfile_extends", // docs/profiles.md — see exo__KnowledgeProfile_includes (same PR #3394 removal)
   "exo__KnowledgeProfile_alwaysOnOverlay", // docs/profiles.md — see exo__KnowledgeProfile_includes (same PR #3394 removal)
-  "exo__FocusProfile_includes", // docs/profiles.md — pre-Phase-2 FocusProfile name (RFC 01a83de8 Phase 2 renamed FocusProfile→Profile; code uses exo__Profile_includes). Its sole literal-string reference in packages/ was a test comment in FocusProfileWiring.integration.test.ts, removed in the Phase 3 T3b soft-filter PR. Historical migration-narrative reference; no literal-token code ref remains by design.
 ]);
 
 function extractPropertiesFromDocs() {


### PR DESCRIPTION
## Summary

Closes **CR-4** (Phase 3 review). `docs/profiles.md` still referenced the pre-Phase-2 predicate `exo__FocusProfile_includes`, kept green only by a `KNOWN_EXCEPTIONS` whitelist entry added in the T3b PR — a permanently-masked stale doc.

RFC 01a83de8 Phase 2 renamed the include predicate `FocusProfile→Profile` and retargeted its range Ontology→AssetSpace. `exo__Profile_includes` has a **live code anchor** (Phase-2 #3408: `VaultProfileResolver` / `FocusProfileSwitchManager` / `CliFocusProfileResolver`), so `docs-property-validation` stays green WITHOUT the whitelist.

## Changed
- **`docs/profiles.md`** — rename the 2 migration-example keys `exo__FocusProfile_includes` → `exo__Profile_includes`, update range annotation `[Ontology UIDs]` → `[AssetSpace UIDs]`, add a Phase-2-supersession note (historical dual-class example retained for context, not derailed).
- **`scripts/validate-docs-properties.js`** — drop the `exo__FocusProfile_includes` whitelist entry (no longer needed).

## Verification
- `node scripts/validate-docs-properties.js` → **0 missing** ("All property names in docs/ exist in code").
- Docs-only + whitelist-line removal; no code logic touched.

## Test plan
- [ ] CI green (docs-property-validation + required checks)