### PR TITLE
docs: document the UI/CLI Parity Invariant as a first-class principle

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -43,6 +43,12 @@ Exocortex is a **knowledge management technology** that provides:
 
 **Key Insight**: All business logic (frontmatter generation, status transitions, property validation) should be storage-agnostic. The plugin currently mixes business logic with Obsidian-specific UI code, which will be refactored in Issue #122.
 
+### UI/CLI Parity Invariant (enforced)
+
+> The shared `exocortex` package contains all domain/engine logic behind platform-agnostic ports (`IFileSystemAdapter`, `IVaultAdapter`, `HttpClient`, etc.). The Obsidian plugin and CLI are **thin adapters** that inject platform-specific I/O (Obsidian Vault API vs Node `fs`/`fetch`). New user-facing capabilities must be implemented in the core first, then bound in **both** clients. Plugin-only or CLI-only implementations are invariant violations.
+
+This is the architectural enforcement of Exocortex's no-lock-in north star: the product is the vault (data) plus the SDK (engine), and every client must be able to drive the full system. See [VISION.md](./VISION.md) for the full rationale and its complementary pairing with the Homoiconicity Invariant, and [docs/CROSS_RUNTIME_PARITY.md](./docs/CROSS_RUNTIME_PARITY.md) for a validator-specific enforcement example (a byte-identical-report parity test between the CLI and plugin runtimes).
+
 ---
 
 ## 🛠️ Technology Stack

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Compared to existing tools:
 - **Everything as Knowledge** — commands, workflows, property schemas, and layouts defined as vault assets, not hardcoded
 - **Ontology plugins** — extend the system with installable ontology packages (e.g. [GTD + Jedi Techniques](https://github.com/kitelev/gtd-jedi))
 - **FocusProfile** (production-ready, v16.51+) — vault-declared homoiconic profiles that drive **both** runtime filtering of the RDF graph (soft switch) and on-disk submodule materialization (hard switch). One vault, multiple contexts, selective sync. See [docs/focus-profile.md](./docs/focus-profile.md).
+- **UI/CLI Parity** — every capability is reachable from the Obsidian plugin and the CLI; neither client holds exclusive features. The complement of homoiconicity: it keeps the *invocation* layer open just as homoiconicity keeps the *data* layer open. See [VISION.md](./VISION.md#uicli-parity-invariant).
 - **Local-first** — all data stays on your device, no cloud required
 
 ---

--- a/VISION.md
+++ b/VISION.md
@@ -117,6 +117,25 @@ FocusProfile **inhabits the same git substrate** as Obsidian Git but manages sub
 
 The deep architectural pitch and the 2-phase commit safety model live in **[docs/focus-profile.md](./docs/focus-profile.md)**.
 
+### UI/CLI Parity Invariant
+
+> **UI/CLI Parity Invariant:** Every user-facing Exocortex capability MUST be invokable through BOTH clients — the Obsidian plugin (UI) and the CLI (`@kitelev/exocortex-cli`). Neither client is privileged; neither holds exclusive features. Enforced architecturally: all domain/engine logic lives in the platform-agnostic shared core (`exocortex` package) behind ports (FileSystem, Http, etc.); the plugin and CLI are thin adapters that inject platform-specific I/O (Obsidian `DataAdapter`/`requestUrl` vs Node `fs`/`fetch`). New features land in the core first, then get thin bindings in BOTH clients.
+
+**Why it is a killer feature — the no-lock-in north star.** The user's knowledge system is not locked to one application. The *product* is the vault (data) plus the SDK (engine) — the Obsidian plugin is just one frontend. Any client — the current plugin, the CLI, a future mobile/web/agent — can drive the full system. This is what makes Exocortex an **SDK / platform, not merely a plugin**. Parallel reimplementations *without* this principle have already caused real regressions (`extractReference` triplication; mount/unmount logic split between plugin and a CLI scaffold — see [#3416](https://github.com/kitelev/exocortex/issues/3416)). The invariant names the force that prevents these.
+
+#### Complementary pair with Homoiconicity
+
+Exocortex removes lock-in at **two** layers, governed by two distinct, complementary invariants. **Homoiconicity** (RFC `c78cc5c8`, also codified in `CLAUDE.md`) keeps the *data layer* open; **UI/CLI Parity** keeps the *invocation layer* open. Document and reason about them as a pair:
+
+| Invariant          | What it governs                                                                                      | One-line framing                                  |
+| ------------------ | ---------------------------------------------------------------------------------------------------- | ------------------------------------------------- |
+| **Homoiconicity**  | User-configurable *semantics* are vault data (RDF), readable/writable by any RDF-capable client      | *What* the system does is data, not code          |
+| **UI/CLI Parity**  | The *engine behaviour* that processes that data is reachable from any client via shared core + ports | *How* you invoke it is client-agnostic            |
+
+Together they guarantee neither the meaning of your knowledge nor the ability to act on it is captive to a single application.
+
+**See also:** the enforced ports/adapters statement in [ARCHITECTURE.md](./ARCHITECTURE.md); the validator-specific enforcement instance in [docs/CROSS_RUNTIME_PARITY.md](./docs/CROSS_RUNTIME_PARITY.md); the SDK-platform program *"AssetSpace + Profile platform — exo as SDK"* (vault UID `ea93b829`, RFC `01a83de8`) that this invariant formalizes. A full capability-by-capability parity audit across all features is future work, tracked under that program.
+
 ---
 
 ## 42 Unique IT Ideas

--- a/docs/CROSS_RUNTIME_PARITY.md
+++ b/docs/CROSS_RUNTIME_PARITY.md
@@ -1,5 +1,7 @@
 # Cross-Runtime Parity Contract (P1.13)
 
+> **Scope note.** This document describes **one specific enforcement instance** of the broader **UI/CLI Parity Invariant** — namely, the SHACL-lite *validator* parity contract between the CLI and plugin runtimes. It is not the definition of the invariant. For the principle itself (every user-facing capability must be invokable from both the Obsidian plugin and the CLI, enforced via a shared platform-agnostic core behind ports), see [VISION.md](../VISION.md#uicli-parity-invariant) and the enforced ports/adapters statement in [ARCHITECTURE.md](../ARCHITECTURE.md). This file stays focused on the validator contract.
+
 ## Overview
 
 The Exocortex SHACL-lite validator runs in two runtimes:


### PR DESCRIPTION
## Summary

Documents the **UI/CLI Parity Invariant** as a named, first-class architectural principle of Exocortex — placed alongside the existing Homoiconicity Invariant. Docs only; no code changes.

> **UI/CLI Parity Invariant:** Every user-facing Exocortex capability MUST be invokable through BOTH clients — the Obsidian plugin (UI) and the CLI (`@kitelev/exocortex-cli`). Neither client is privileged; neither holds exclusive features. Enforced architecturally: all domain/engine logic lives in the platform-agnostic shared core behind ports; the plugin and CLI are thin adapters injecting platform-specific I/O. New features land in the core first, then get thin bindings in BOTH clients.

It is the **complement of Homoiconicity** — together they remove lock-in at both layers: data (homoiconicity → semantics are RDF) and invocation (parity → engine reachable from any client).

## Changes

- **`VISION.md`** (primary) — named principle section with killer-feature / no-lock-in rationale + complementary-pair table with Homoiconicity.
- **`ARCHITECTURE.md`** — enforced ports/adapters invariant statement (shared core + thin plugin/CLI adapters; new features land in core first; plugin-only or CLI-only = violation).
- **`README.md`** — one-line UI/CLI Parity headline next to the homoiconic FocusProfile bullet.
- **`docs/CROSS_RUNTIME_PARITY.md`** — scope note framing it as the *validator-specific* enforcement instance of the broader invariant (not its definition); cross-linked to `VISION.md`. Content otherwise preserved.

## Cross-references

- Motivating violation: #3416 (CLI hard-switch scaffold — profile switch plugin-only)
- PMBOK program `ea93b829` ("AssetSpace + Profile platform — exo as SDK")
- RFC `01a83de8` (SDK framing)
- Homoiconicity Invariant: RFC `c78cc5c8`

## Notes

- The optional `CLAUDE.md` Q4 parallel mention (issue AC #5) is **out of scope for this PR**: the Homoiconicity Invariant + its Q1/Q2/Q3 decision tree are codified in a contributor-instructions file *outside* this repo, not in the repo's own `CLAUDE.md`. Adding a Q4 next to the Homoiconicity tree therefore belongs in that file, not here.
- A full capability-by-capability parity audit is noted as future work under program `ea93b829`.

## Validation

- `node scripts/validate-docs-properties.js` → 0 missing.
- All added markdown links resolve to existing files/anchors; code fences balanced.

Closes #3417