### PR TITLE
fix(cli): audit co-location skips 09 Templates/ (Templater templates not assets)

### DIFF
--- a/packages/cli/src/commands/audit-co-location.ts
+++ b/packages/cli/src/commands/audit-co-location.ts
@@ -87,6 +87,12 @@ export async function scanVaultForCoLocation(
     // .git/.obsidian, but not node_modules). Never audit/report those.
     if (relPath.split("/").includes("node_modules")) continue;
 
+    // "09 Templates/" holds Templater templates (intentional <%* %> / {{…}}
+    // placeholder syntax), not real assets — they carry exo__Asset_isDefinedBy
+    // by pattern inheritance but must never move. Excluded from co-location the
+    // same way the pre-commit hook skips them (RFC 0b7a2fad CR-1).
+    if (relPath.split("/").includes("09 Templates")) continue;
+
     const rawIsDefinedBy = metadata["exo__Asset_isDefinedBy"];
     const ref = extractAssetReference(rawIsDefinedBy);
 

--- a/packages/cli/tests/integration/commands/audit-co-location.integration.test.ts
+++ b/packages/cli/tests/integration/commands/audit-co-location.integration.test.ts
@@ -103,4 +103,23 @@ describe("audit co-location — revert→fail / restore→pass (integration)", (
     // empty: the standalone empty asset + the ontology file
     expect(r.skips["empty-isDefinedBy"]).toBe(2);
   });
+
+  it("excludes '09 Templates/' (Templater templates are not assets) — revert→fail proof", async () => {
+    // A Templater template carries exo__Asset_isDefinedBy by pattern inheritance
+    // but physically lives in 09 Templates/ and must never move. WITHOUT the
+    // exclusion in scanVaultForCoLocation this resolvable-but-misplaced file
+    // would be reported as 1 violation (expected=assetspaces/concepts,
+    // actual=09 Templates/concepts). WITH the exclusion it is dropped entirely.
+    const tmplDir = join(vault, "09 Templates", "concepts");
+    writeAsset(
+      tmplDir,
+      "dddddddd-0000-0000-0000-000000000000",
+      `"[[${ONTO_UID}]]"`,
+    );
+    const r = await scanVaultForCoLocation(vault);
+    // Revert-verify: remove the `09 Templates` skip → this assertion flips to 1.
+    expect(r.violations).toHaveLength(0);
+    // Template is excluded before counting: not checked, not a skip-reason either.
+    expect(r.checked).toBe(0);
+  });
 });


### PR DESCRIPTION
## Summary
- `audit co-location` flagged 17 false violations in vault-2025 — all Templater templates under `09 Templates/`. They carry `exo__Asset_isDefinedBy` by pattern inheritance but are NOT real assets and must never move.
- Add a skip for `09 Templates/` path segment in `scanVaultForCoLocation`, mirroring the pre-commit hook (`/09 Templates/`) and `AreaSelectionModal.ts` (`includes("09 Templates")`). Treated like the existing `node_modules` exclusion (silent continue, not a counted skip).
- Context: RFC 0b7a2fad CR-1 (co-location per-ontology subfolders).

## Test plan
- [x] New integration test `excludes '09 Templates/' … revert→fail proof` — **empirically verified**: FAILS without the skip (1 violation), PASSES with it (0). Run: `npx jest tests/integration/commands/audit-co-location.integration.test.ts` → 3/3 pass.
- [ ] CI green (14 checks)
- [ ] Post-merge: `audit co-location --vault vault-2025` drops 17 → 0; vault-exodev stays 0