### PR TITLE
docs: index package-level docs from the top-level docs/README

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -59,3 +59,31 @@ active guidance:
 
 - `examples/rfc-009/` — dynamic-command pipeline fixtures (referenced by `packages/cli/README.md` and unit tests)
 - `rfc-94e520da/starter-kit-grounding-status.json` — grounding-audit data (read by `scripts/audit-starter-kit-groundings.mjs`)
+
+## Package documentation
+
+Some docs live alongside their package rather than in this top-level tree. They
+are listed here for discoverability. The process/historical ones below are kept
+in place (not archived) because CI workflows, scripts, and tests reference them
+by path.
+
+### CLI — `packages/cli/docs/`
+
+- [CLI_API_REFERENCE.md](../packages/cli/docs/CLI_API_REFERENCE.md) — full command/flag reference
+- [ONTOLOGY_REFERENCE.md](../packages/cli/docs/ONTOLOGY_REFERENCE.md) — ontology reference for CLI users
+- [SPARQL_GUIDE.md](../packages/cli/docs/SPARQL_GUIDE.md), [SPARQL_COOKBOOK.md](../packages/cli/docs/SPARQL_COOKBOOK.md) — querying from the CLI
+- [RCA_DYNCOMMAND_SHOW_VS_EXEC.md](../packages/cli/docs/RCA_DYNCOMMAND_SHOW_VS_EXEC.md) — _(process)_ root-cause analysis, referenced by the CLI README
+- [SUNSET_LEGACY_COMMAND_START.md](../packages/cli/docs/SUNSET_LEGACY_COMMAND_START.md) — _(process)_ sunset checklist for legacy `command start`
+
+### Obsidian plugin — `packages/obsidian-plugin/docs/`
+
+- [EXO_LAYOUT.md](../packages/obsidian-plugin/docs/EXO_LAYOUT.md) — layout engine
+- [RELATION_COLUMN_SET.md](../packages/obsidian-plugin/docs/RELATION_COLUMN_SET.md) — relation column sets
+- [TESTING.md](../packages/obsidian-plugin/docs/TESTING.md) — plugin testing guide
+- [release-checklist-mobile.md](../packages/obsidian-plugin/docs/release-checklist-mobile.md) — mobile release checklist
+- [FLAKY_DASHBOARD.md](../packages/obsidian-plugin/docs/FLAKY_DASHBOARD.md) — flaky-test dashboard (drives `flaky-aggregate`/`flaky-render-markdown` scripts)
+- `phase3/` — _(historical)_ Phase-3 CI/X11 stabilization ADR + spikes. Completed program; the [ADR](../packages/obsidian-plugin/docs/phase3/ADR_FLAKY_X11_STRATEGY.md) is referenced by `docker-entrypoint-e2e.sh` and `ci.yml`, so the folder is kept in place.
+
+### Core engine — `packages/exocortex/docs/`
+
+- [NL-TO-SPARQL.md](../packages/exocortex/docs/NL-TO-SPARQL.md) — engine internals for NL→SPARQL (distinct from the user-facing [NL-TO-SPARQL.md](NL-TO-SPARQL.md) above)


### PR DESCRIPTION
## Summary

Follow-up to #3420. Addresses the package-doc **sprawl** (the "lots of excess" concern) by making the 18 docs under `packages/{cli,obsidian-plugin,exocortex}/docs/` discoverable from the single top-level `docs/README.md` index — they were previously findable only by browsing each package directory.

## Why index, not delete

I investigated each package-docs tree for removable excess (same approach as #3420). Unlike the top-level tree, **almost nothing is safe to remove** — the package docs are either active reference or wired into tooling:

| Doc | Why it stays |
|---|---|
| `phase3/ADR_FLAKY_X11_STRATEGY.md` + spikes | Referenced by `docker-entrypoint-e2e.sh` and `.github/workflows/ci.yml` |
| `RCA_DYNCOMMAND_SHOW_VS_EXEC.md` | Referenced by `packages/cli/README.md` + compiled CLI bundle |
| `FLAKY_DASHBOARD.md` | Drives `flaky-aggregate` / `flaky-render-markdown` scripts + tests |
| `SUNSET_LEGACY_COMMAND_START.md` | `executeStart` still present in CLI source → sunset not confirmably complete |
| `NL-TO-SPARQL.md` (exocortex) | Not a duplicate of the top-level one (375 diff lines — engine internals vs user-facing) |

Mass-archiving these would have broken CI/scripts/tests. Instead they're **labelled in place** (`_(process)_` / `_(historical)_`) in the index.

## Change

Additive only — adds a "Package documentation" section to `docs/README.md` (CLI / Obsidian plugin / Core engine subsections). Single file, +28 lines.

## Validation

- All `[](...)` links (incl. new `../packages/...` paths) verified to resolve.
- `node scripts/validate-docs-properties.js` → 0 missing.
- No moves, no deletions → no risk to `docs-link-check`, CI, scripts, or tests.

Docs-only.