### PR TITLE
fix(precondition): isInWrongFolder skips 09 Templates/ (CLI + plugin parity)

### DIFF
--- a/packages/cli/src/precondition/createIsInWrongFolderHostFunction.ts
+++ b/packages/cli/src/precondition/createIsInWrongFolderHostFunction.ts
@@ -32,6 +32,12 @@ export function createIsInWrongFolderHostFunction(
         : null;
     if (filePath === null) return false;
 
+    // Templater templates (09 Templates/) carry exo__Asset_isDefinedBy by
+    // pattern inheritance but are NOT assets and must never move — never report
+    // them as "in wrong folder" (mirror `audit co-location` +
+    // co-location-enforce hook exclusion, RFC 0b7a2fad CR-1).
+    if (filePath.split("/").includes("09 Templates")) return false;
+
     const node = vaultAdapter.getAbstractFileByPath(filePath);
     if (node === null || !("basename" in node)) return false;
     const file = node as IFile;

--- a/packages/cli/tests/unit/precondition/createIsInWrongFolderHostFunction.test.ts
+++ b/packages/cli/tests/unit/precondition/createIsInWrongFolderHostFunction.test.ts
@@ -186,6 +186,29 @@ describe("createIsInWrongFolderHostFunction (CLI parity)", () => {
     expect(service.getExpectedFolderSync).toHaveBeenCalledWith(file, metadata);
   });
 
+  it("returns false for '09 Templates/' files even when otherwise misplaced — revert→fail proof", () => {
+    // A Templater template carries isDefinedBy by pattern inheritance and the
+    // resolver reports it as misplaced (expected≠current), but it must never be
+    // flagged for repair. WITHOUT the 09 Templates skip this returns true;
+    // WITH it, false (RFC 0b7a2fad CR-1).
+    const file = buildFile("09 Templates/ts/tmpl.md", "tmpl", "09 Templates/ts");
+    const fn = createIsInWrongFolderHostFunction(
+      buildAdapter({
+        node: file,
+        frontmatter: { exo__Asset_isDefinedBy: "[[Class]]" },
+      }),
+      buildService("expected/folder"),
+    );
+    expect(
+      fn(
+        baseCtx({
+          filePath: "09 Templates/ts/tmpl.md",
+          currentFolder: "09 Templates/ts",
+        }),
+      ),
+    ).toBe(false);
+  });
+
   it("treats null frontmatter as empty metadata object", () => {
     const file = buildFile(
       "current/folder/asset.md",

--- a/packages/obsidian-plugin/src/infrastructure/precondition/createIsInWrongFolderHostFunction.ts
+++ b/packages/obsidian-plugin/src/infrastructure/precondition/createIsInWrongFolderHostFunction.ts
@@ -28,6 +28,12 @@ export function createIsInWrongFolderHostFunction(
         : null;
     if (filePath === null) return false;
 
+    // Templater templates (09 Templates/) carry exo__Asset_isDefinedBy by
+    // pattern inheritance but are NOT assets and must never move — never report
+    // them as "in wrong folder" (mirror `audit co-location` +
+    // co-location-enforce hook exclusion, RFC 0b7a2fad CR-1).
+    if (filePath.split("/").includes("09 Templates")) return false;
+
     const file = app.vault.getAbstractFileByPath(filePath);
     if (!(file instanceof TFile)) return false;
 

--- a/packages/obsidian-plugin/tests/unit/infrastructure/precondition/createIsInWrongFolderHostFunction.test.ts
+++ b/packages/obsidian-plugin/tests/unit/infrastructure/precondition/createIsInWrongFolderHostFunction.test.ts
@@ -116,6 +116,25 @@ describe("createIsInWrongFolderHostFunction", () => {
     expect(fn(baseCtx({ currentFolder: undefined }))).toBe(false);
   });
 
+  it("returns false for '09 Templates/' files even when otherwise misplaced — revert→fail proof", () => {
+    // Templater template carries isDefinedBy by inheritance; resolver says
+    // misplaced (expected≠current) but it must never get the Repair Folder
+    // button. WITHOUT the 09 Templates skip → true; WITH it → false (RFC 0b7a2fad CR-1).
+    const file = buildFile("09 Templates/ts/tmpl.md");
+    const fn = createIsInWrongFolderHostFunction(
+      buildApp({ file, metadata: { exo__Asset_isDefinedBy: "[[Class]]" } }),
+      buildService("expected/folder"),
+    );
+    expect(
+      fn(
+        baseCtx({
+          filePath: "09 Templates/ts/tmpl.md",
+          currentFolder: "09 Templates/ts",
+        }),
+      ),
+    ).toBe(false);
+  });
+
   it("passes file + metadata to FolderRepairService.getExpectedFolderSync", () => {
     const file = buildFile("current/folder/asset.md");
     const metadata = {


### PR DESCRIPTION
## Summary
Companion to #3419 (audit). The `isInWrongFolder` precondition (Repair Folder command) now also skips `09 Templates/` on BOTH surfaces:
- **CLI** `createIsInWrongFolderHostFunction` — `apply repair-folder` precondition gate.
- **Plugin** `createIsInWrongFolderHostFunction` — inline Repair Folder button + Cmd+P palette visibility.

Templater templates carry `exo__Asset_isDefinedBy` by pattern inheritance but are not assets and must never move. Mirrors `audit co-location` (#3419) + the `co-location-enforce.sh` pre-commit/PreToolUse hook. RFC 0b7a2fad CR-1.

## Test plan
- [x] Revert-verify unit tests on both surfaces — empirically verified FAIL without skip / PASS with (CLI 12/12, plugin 10/10).
- [ ] CI green (14 checks)