### PR TITLE
refactor(architecture): consolidate dual AssetSpace mount into shared ports-based core (#3423)

### DIFF
--- a/packages/cli/src/services/BootstrapAssetSpaceService.ts
+++ b/packages/cli/src/services/BootstrapAssetSpaceService.ts
@@ -4,27 +4,46 @@
  *
  * Per RFC 13da049f Phase 6.2 (Bootstrap UX) + Phase 6.3 (Add AssetSpace UX).
  *
+ * ## Thin adapter over the shared mount core (Issue #3423)
+ *
+ * The mount pipeline (fetch tarball → discover `<owner>-<repo>-<sha>/` wrapper
+ * → extract SHA → zip-slip validate → materialise → `.gitmodules` mutation)
+ * lives ONCE in `exocortex`'s {@link mountAssetSpaceFiles} + `.gitmodules` text
+ * transforms. This service supplies the two Node-coupled ports:
+ *
+ *   - **{@link FileSystemPort}** over Node `fs` — `materialize()` keeps the CLI's
+ *     historic **atomic stage-then-rename** strategy (temp dir → `renameSync`,
+ *     EXDEV copy fallback), refusing a non-empty target. No partial state on
+ *     failure.
+ *   - **{@link AssetSpaceHttpClient}** over Node `fetch` — anonymous or
+ *     PAT-authenticated tarball pull with 403 rate-limit / 404 hint handling
+ *     and a 50 MB size cap.
+ *
  * Scope (CLI-only, desktop-only):
  *  - Uses Node 18+ native `fetch` (no Obsidian deps)
- *  - Anonymous GitHub access (public repos only)
- *  - Tarball pull via `https://codeload.github.com/<owner>/<repo>/tar.gz/refs/heads/<ref>`
+ *  - Tarball pull via `https://api.github.com/repos/<owner>/<repo>/tarball/<ref>`
  *  - Atomic extraction: temp dir → rename к target (no partial state)
- *  - Idempotent `.gitmodules` mutation (text manipulation, no `git` binary needed)
+ *  - Idempotent `.gitmodules` mutation (text manipulation, no `git` binary)
  *
  * Security:
  *  - URL allowlist: strict `https://github.com/<owner>/<repo>` shape only
- *  - Zip-slip protection: all extracted paths verified к stay under target dir
- *  - Per-entry filesystem path validation
- *
- * Plugin-equivalent: AssetSpaceManager.pullAssetSpace (different runtime
- * constraints — plugin uses Obsidian's `requestUrl`, CLI uses native `fetch`).
+ *  - Zip-slip protection: core rejects sym/hard links + `..` + non-wrapper
+ *    entries; `materialize()` keeps a defense-in-depth resolve check
+ *  - PAT redaction on every error path
  */
 
 import { mkdirSync, writeFileSync, existsSync, renameSync, rmSync, readFileSync, readdirSync, appendFileSync } from "node:fs";
 import { mkdtemp } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join, dirname, resolve, sep } from "node:path";
-import { parseTarballGzip } from "exocortex";
+import { join, dirname, basename, resolve, sep } from "node:path";
+import {
+  mountAssetSpaceFiles,
+  appendGitmodulesEntry,
+  stripGitmodulesEntry as coreStripGitmodulesEntry,
+  type FileSystemPort,
+  type AssetSpaceHttpClient,
+  type MountFile,
+} from "exocortex";
 
 const REPO_URL_REGEX = /^https:\/\/github\.com\/([a-zA-Z0-9_-]+)\/([a-zA-Z0-9_.-]+?)(?:\.git)?$/;
 
@@ -101,7 +120,8 @@ export class BootstrapAssetSpaceService {
   }
 
   /**
-   * Pull tarball from public GitHub repo and extract к target dir.
+   * Pull tarball from a GitHub repo and extract к target dir, delegating the
+   * fetch → wrapper → SHA → zip-slip → materialise pipeline to the shared core.
    * Atomic: extracts к temp dir first, then renames к target.
    * Idempotent: if target dir already exists с non-empty content, throws
    * (caller should pass --force OR pick fresh target).
@@ -113,6 +133,8 @@ export class BootstrapAssetSpaceService {
   ): Promise<PullResult> {
     const { owner, repo } = BootstrapAssetSpaceService.parseGitHubURL(repoUrl);
 
+    // Refuse-non-empty BEFORE the network fetch (preserves original ordering —
+    // no wasted tarball download when the target is already populated).
     if (existsSync(targetDir)) {
       const contents = readdirSync(targetDir);
       if (contents.length > 0) {
@@ -122,187 +144,168 @@ export class BootstrapAssetSpaceService {
       }
     }
 
-    // GitHub API tarball — wrapper format `<owner>-<repo>-<sha7>` (matches
-    // plugin's AssetSpaceManager.pullAssetSpace contract). Codeload tarball
-    // uses `<repo>-<branch>` wrapper which loses SHA — use API endpoint.
-    const tarballUrl = `https://api.github.com/repos/${owner}/${repo}/tarball/${ref}`;
-    // Authenticated mode: attach Authorization + GitHub-required headers ONLY
-    // when a token is present. Empty token → anonymous request shape is left
-    // byte-identical to the pre-token behaviour (public repos, no headers).
-    // The authenticated endpoint returns a full-40-char-SHA wrapper which the
-    // SHA matcher (7..40 hex) and #3390 ustar-prefix parser already handle.
-    const init: RequestInit = { signal: AbortSignal.timeout(60_000) };
-    if (this.token.length > 0) {
-      init.headers = {
-        Authorization: `Bearer ${this.token}`,
-        "User-Agent": "exocortex-cli",
-        "X-GitHub-Api-Version": "2022-11-28",
-      };
-    }
-    // Code-reviewer MEDIUM: fetch timeout (60s) prevents indefinite hang
-    // on slow/stalled GitHub response. Cap matches typical CI test timeouts.
-    let response: Awaited<ReturnType<typeof fetch>>;
-    try {
-      response = await this.fetchImpl(tarballUrl, init);
-    } catch (err) {
-      // Redact before re-throw: some fetch implementations embed the request
-      // (incl. Authorization header) in the thrown error.
-      throw new Error(
-        this.redact(
-          `pullAssetSpace: fetch error for ${tarballUrl}: ${err instanceof Error ? err.message : String(err)}`,
-        ),
-      );
-    }
-    if (!response.ok) {
-      // Code-reviewer MEDIUM: surface GitHub anonymous rate-limit (60 req/hour)
-      // с actionable message instead of generic "fetch failed".
-      if (response.status === 403) {
-        const remaining = response.headers?.get?.("x-ratelimit-remaining");
-        const resetEpoch = response.headers?.get?.("x-ratelimit-reset");
-        if (remaining === "0" || (resetEpoch !== null && resetEpoch !== undefined)) {
-          const resetAt = resetEpoch !== null && resetEpoch !== undefined
-            ? new Date(Number(resetEpoch) * 1000).toISOString()
-            : "unknown";
-          throw new Error(
-            `pullAssetSpace: GitHub anonymous API rate-limit exceeded (60 req/hour). Reset at ${resetAt}. Wait or use authenticated CLI.`,
-          );
-        }
-      }
-      // GitHub returns 404 (not 403) for private repos the caller can't see —
-      // it deliberately hides existence. If we pulled anonymously, hint that a
-      // token may be required. With a token, 404 means genuinely-missing repo
-      // OR the token lacks access — surface both possibilities.
-      if (response.status === 404) {
-        const hint = this.token.length > 0
-          ? "repo not found, or the provided token lacks access to it"
-          : "if this is a private repo, pass --token <pat> (or set GITHUB_TOKEN / GH_TOKEN)";
-        throw new Error(
-          this.redact(
-            `pullAssetSpace: fetch failed (404 Not Found) for ${tarballUrl} — ${hint}`,
-          ),
-        );
-      }
-      throw new Error(
-        this.redact(
-          `pullAssetSpace: fetch failed (${response.status} ${response.statusText}) for ${tarballUrl}`,
-        ),
-      );
-    }
-    const arrayBuf = await response.arrayBuffer();
-    if (arrayBuf.byteLength > MAX_TARBALL_BYTES) {
-      throw new Error(
-        `pullAssetSpace: tarball too large (${arrayBuf.byteLength} bytes > ${MAX_TARBALL_BYTES})`,
-      );
-    }
-    const buffer = new Uint8Array(arrayBuf);
-    const entries = await parseTarballGzip(buffer);
-    if (entries.length === 0) {
-      throw new Error(`pullAssetSpace: empty tarball for ${owner}/${repo}@${ref}`);
-    }
-
-    // Discover wrapper dir (GitHub tarballs wrap all entries в <owner>-<repo>-<sha7>/).
-    // Code-reviewer HIGH: skip pax_global_header / extended-header entries when
-    // picking first wrapper-bearing entry — those don't share the wrapper prefix.
-    const isHeaderType = (t: string | undefined): boolean =>
-      t === "globalExtendedHeader" || t === "extendedHeader";
-    const firstContentEntry = entries.find(
-      (e) => !isHeaderType(e.type) && e.name.includes("/"),
-    );
-    if (firstContentEntry === undefined) {
-      throw new Error(`pullAssetSpace: no wrapper-bearing entry in tarball`);
-    }
-    const slashIdx = firstContentEntry.name.indexOf("/");
-    const wrapper = firstContentEntry.name.slice(0, slashIdx);
-    const wrapperPrefix = wrapper + "/";
-
-    // Verify all non-header entries share the wrapper.
-    for (const entry of entries) {
-      if (isHeaderType(entry.type)) continue;
-      if (entry.name === wrapper || entry.name === wrapperPrefix) continue;
-      if (!entry.name.startsWith(wrapperPrefix)) {
-        throw new Error(
-          `pullAssetSpace: entry "${entry.name}" not under wrapper "${wrapper}"`,
-        );
-      }
-    }
-
-    // Extract SHA from wrapper. Length is auth-dependent: anonymous tarballs
-    // carry a 7-char abbreviated SHA, authenticated ones the full 40-char SHA
-    // (matching only 7 broke private-repo pulls). Accept 7..40 hex.
-    const shaMatch = wrapper.match(/-([0-9a-fA-F]{7,40})$/);
-    if (shaMatch === null) {
-      throw new Error(
-        `pullAssetSpace: cannot extract SHA from wrapper "${wrapper}"`,
-      );
-    }
-    const sha = shaMatch[1].toLowerCase(); // parity with plugin extractShaFromWrapper
-
-    // Stage к temp dir, then atomic rename.
-    const stagingDir = await mkdtemp(join(tmpdir(), `exo-bootstrap-${owner}-${repo}-`));
-    let fileCount = 0;
-    try {
-      for (const entry of entries) {
-        // Code-reviewer HIGH: explicit symlink/hardlink rejection (parity с
-        // plugin TarExtractor.validateEntry). Tarballs from compromised
-        // upstream could embed symlinks pointing outside vault — security risk.
-        if (entry.type === "symbolicLink" || entry.type === "hardLink") {
-          throw new Error(
-            `pullAssetSpace: ${entry.type} entry "${entry.name}" rejected for security`,
-          );
-        }
-        // Skip extended headers (no payload to extract).
-        if (isHeaderType(entry.type)) continue;
-        const rel = entry.name.slice(wrapperPrefix.length);
-        if (rel.length === 0) continue;
-        // Skip directory-type entries; they'll be created on-demand.
-        if (entry.type === "directory") continue;
-        if (entry.data === undefined) continue;
-
-        // Code-reviewer MEDIUM: segment-based `..` check (substring rejects
-        // legitimate names like `foo..bar.md`).
-        if (rel.split("/").some((s) => s === "..")) {
-          throw new Error(`pullAssetSpace: path traversal detected for entry "${entry.name}"`);
-        }
-        // Zip-slip defense: resolve target, verify it stays under stagingDir.
-        const target = resolve(stagingDir, rel);
-        if (target !== stagingDir && !target.startsWith(stagingDir + sep)) {
-          throw new Error(`pullAssetSpace: zip-slip detected for entry "${entry.name}"`);
-        }
-        mkdirSync(dirname(target), { recursive: true });
-        writeFileSync(target, entry.data);
-        fileCount++;
-      }
-
-      // Atomic move к target.
-      mkdirSync(dirname(targetDir), { recursive: true });
-      try {
-        renameSync(stagingDir, targetDir);
-      } catch (err) {
-        // Code-reviewer LOW: EXDEV fallback. mkdtemp may put staging on different
-        // filesystem than vault (macOS /private/var/folders/ vs ~). Copy + rm.
-        if ((err as NodeJS.ErrnoException).code === "EXDEV") {
-          const { cpSync } = await import("node:fs");
-          cpSync(stagingDir, targetDir, { recursive: true });
-          rmSync(stagingDir, { recursive: true, force: true });
-        } else {
-          throw err;
-        }
-      }
-    } catch (err) {
-      // Cleanup staging on any failure.
-      rmSync(stagingDir, { recursive: true, force: true });
-      throw err;
-    }
-
-    return { sha, fileCount };
+    return mountAssetSpaceFiles({
+      http: this.httpPort(),
+      fs: this.fsPort(),
+      owner,
+      repo,
+      ref,
+      targetPath: targetDir,
+    });
   }
 
   /**
-   * Idempotent `.gitmodules` entry insertion via text manipulation.
-   * Uses standard git-submodule.git format (one `[submodule "..."]` stanza
-   * per entry с `path` + `url`).
-   *
-   * If entry already present (by `submodulePath` key), no change made.
+   * Node `fetch`-backed tarball port. Anonymous by default; attaches the PAT +
+   * GitHub-required headers ONLY when a token is present (anonymous request
+   * shape stays byte-identical to the pre-token behaviour). Surfaces actionable
+   * 403 rate-limit / 404 hint messages, redacts PATs, and enforces the 50 MB
+   * size cap.
+   */
+  private httpPort(): AssetSpaceHttpClient {
+    const fetchImpl = this.fetchImpl;
+    const token = this.token;
+    const redact = (m: unknown): string => this.redact(m);
+    return {
+      async fetchTarball(owner, repo, ref): Promise<Uint8Array> {
+        // GitHub API tarball — wrapper format `<owner>-<repo>-<sha>` (codeload
+        // tarball uses `<repo>-<branch>` which loses SHA — use API endpoint).
+        const tarballUrl = `https://api.github.com/repos/${owner}/${repo}/tarball/${ref}`;
+        const init: RequestInit = { signal: AbortSignal.timeout(60_000) };
+        if (token.length > 0) {
+          init.headers = {
+            Authorization: `Bearer ${token}`,
+            "User-Agent": "exocortex-cli",
+            "X-GitHub-Api-Version": "2022-11-28",
+          };
+        }
+        let response: Awaited<ReturnType<typeof fetch>>;
+        try {
+          response = await fetchImpl(tarballUrl, init);
+        } catch (err) {
+          // Redact before re-throw: some fetch implementations embed the request
+          // (incl. Authorization header) in the thrown error.
+          throw new Error(
+            redact(
+              `pullAssetSpace: fetch error for ${tarballUrl}: ${err instanceof Error ? err.message : String(err)}`,
+            ),
+          );
+        }
+        if (!response.ok) {
+          // Surface GitHub anonymous rate-limit (60 req/hour) with actionable
+          // message instead of generic "fetch failed".
+          if (response.status === 403) {
+            const remaining = response.headers?.get?.("x-ratelimit-remaining");
+            const resetEpoch = response.headers?.get?.("x-ratelimit-reset");
+            if (remaining === "0" || (resetEpoch !== null && resetEpoch !== undefined)) {
+              const resetAt = resetEpoch !== null && resetEpoch !== undefined
+                ? new Date(Number(resetEpoch) * 1000).toISOString()
+                : "unknown";
+              throw new Error(
+                `pullAssetSpace: GitHub anonymous API rate-limit exceeded (60 req/hour). Reset at ${resetAt}. Wait or use authenticated CLI.`,
+              );
+            }
+          }
+          // GitHub returns 404 (not 403) for private repos the caller can't see.
+          if (response.status === 404) {
+            const hint = token.length > 0
+              ? "repo not found, or the provided token lacks access to it"
+              : "if this is a private repo, pass --token <pat> (or set GITHUB_TOKEN / GH_TOKEN)";
+            throw new Error(
+              redact(
+                `pullAssetSpace: fetch failed (404 Not Found) for ${tarballUrl} — ${hint}`,
+              ),
+            );
+          }
+          throw new Error(
+            redact(
+              `pullAssetSpace: fetch failed (${response.status} ${response.statusText}) for ${tarballUrl}`,
+            ),
+          );
+        }
+        const arrayBuf = await response.arrayBuffer();
+        if (arrayBuf.byteLength > MAX_TARBALL_BYTES) {
+          throw new Error(
+            `pullAssetSpace: tarball too large (${arrayBuf.byteLength} bytes > ${MAX_TARBALL_BYTES})`,
+          );
+        }
+        return new Uint8Array(arrayBuf);
+      },
+    };
+  }
+
+  /**
+   * Node `fs`-backed file-system port. `materialize()` keeps the CLI's
+   * historic **atomic stage-then-rename** strategy: write every file under a
+   * fresh temp dir, then `renameSync` (EXDEV copy fallback) onto the target so
+   * a mid-write failure never leaves a partial tree. The core already rejected
+   * `..` / non-wrapper / link entries; the per-entry resolve check below is
+   * defense-in-depth against a regression in the core validation.
+   */
+  private fsPort(): FileSystemPort {
+    return {
+      async exists(p: string): Promise<boolean> {
+        return existsSync(p);
+      },
+      async read(p: string): Promise<string> {
+        return readFileSync(p, "utf8");
+      },
+      async write(p: string, content: string): Promise<void> {
+        writeFileSync(p, content, { encoding: "utf8" });
+      },
+      async removeDir(p: string): Promise<void> {
+        rmSync(p, { recursive: true, force: true });
+      },
+      async materialize(targetDir: string, files: MountFile[]): Promise<number> {
+        const stagingDir = await mkdtemp(join(tmpdir(), `exo-bootstrap-${basename(targetDir)}-`));
+        let fileCount = 0;
+        try {
+          for (const file of files) {
+            const rel = file.relPath;
+            // Segment-based `..` check (substring would reject legitimate names
+            // like `foo..bar.md`) — defense-in-depth over the core's check.
+            if (rel.split("/").some((s) => s === "..")) {
+              throw new Error(`pullAssetSpace: path traversal detected for entry "${rel}"`);
+            }
+            // Zip-slip defense: resolve target, verify it stays under stagingDir.
+            const target = resolve(stagingDir, rel);
+            if (target !== stagingDir && !target.startsWith(stagingDir + sep)) {
+              throw new Error(`pullAssetSpace: zip-slip detected for entry "${rel}"`);
+            }
+            mkdirSync(dirname(target), { recursive: true });
+            writeFileSync(target, file.content);
+            fileCount++;
+          }
+
+          // Atomic move к target.
+          mkdirSync(dirname(targetDir), { recursive: true });
+          try {
+            renameSync(stagingDir, targetDir);
+          } catch (err) {
+            // EXDEV fallback. mkdtemp may put staging on a different filesystem
+            // than the vault (macOS /private/var/folders/ vs ~). Copy + rm.
+            if ((err as NodeJS.ErrnoException).code === "EXDEV") {
+              const { cpSync } = await import("node:fs");
+              cpSync(stagingDir, targetDir, { recursive: true });
+              rmSync(stagingDir, { recursive: true, force: true });
+            } else {
+              throw err;
+            }
+          }
+        } catch (err) {
+          // Cleanup staging on any failure.
+          rmSync(stagingDir, { recursive: true, force: true });
+          throw err;
+        }
+        return fileCount;
+      },
+    };
+  }
+
+  /**
+   * Idempotent `.gitmodules` entry insertion via the shared
+   * {@link appendGitmodulesEntry} text transform. Appends only the new stanza
+   * (flag `a`, TOCTOU-safe single syscall chain) when absent; no-op when the
+   * `submodulePath` key is already present.
    */
   ensureGitmodulesEntry(
     vaultPath: string,
@@ -310,46 +313,26 @@ export class BootstrapAssetSpaceService {
     repoUrl: string,
   ): { added: boolean } {
     const gitmodulesPath = join(vaultPath, ".gitmodules");
-    const entryHeader = `[submodule "${submodulePath}"]`;
-    const newEntry = `${entryHeader}\n\tpath = ${submodulePath}\n\turl = ${repoUrl}\n`;
-    // Code-reviewer LOW: anchor regex avoids false-positive on commented-out
-    // headers (e.g. `# [submodule "..."]`).
-    const escaped = submodulePath.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-    const headerRegex = new RegExp(`^\\s*\\[submodule "${escaped}"\\]`, "m");
-
-    // CodeQL HIGH: avoid TOCTOU race between existsSync→writeFileSync.
-    // Open с flag `a` (append, creates if missing) gives single atomic call.
-    // Then re-read to check idempotency. If header already present, no-op;
-    // otherwise append the new entry. Using `a` instead of `w` preserves
-    // existing content if file appeared between calls.
     let existing = "";
     try {
       existing = readFileSync(gitmodulesPath, "utf8");
     } catch (err) {
       if ((err as NodeJS.ErrnoException).code !== "ENOENT") throw err;
     }
-    if (existing.length > 0 && headerRegex.test(existing)) {
-      return { added: false };
-    }
-    const sep = existing.length === 0 || existing.endsWith("\n") ? "" : "\n";
-    // appendFileSync = open(flag='a') + write + close — single syscall chain,
-    // no separate exists check needed. Created с 0o644 by default.
-    appendFileSync(gitmodulesPath, sep + newEntry, { encoding: "utf8" });
+    const { content, added } = appendGitmodulesEntry(existing, submodulePath, repoUrl);
+    if (!added) return { added: false };
+    // `content` is `existing + sep + newEntry`; append only the delta so the
+    // write stays an `appendFileSync` (open flag `a`) rather than a read-modify-
+    // write rewrite (CodeQL HIGH TOCTOU on the prior existsSync→writeFileSync).
+    appendFileSync(gitmodulesPath, content.slice(existing.length), { encoding: "utf8" });
     return { added: true };
   }
 
   /**
-   * Idempotent `.gitmodules` entry removal via text manipulation — the
-   * unmount counterpart of {@link ensureGitmodulesEntry}. Strips the
-   * `[submodule "<submodulePath>"]` stanza (header + all following lines until
-   * the next `[` header or EOF) and collapses the double-blank line the strip
-   * may leave behind.
-   *
-   * Mirrors the plugin's pure `stripGitmodulesEntry` text transform
-   * (`GitSubmoduleOps.ts`) so the CLI hard-switch produces byte-equivalent
-   * `.gitmodules` output to the Obsidian REST unmount path. No-op (returns
-   * `{ removed: false }`) when `.gitmodules` is absent or has no matching
-   * stanza.
+   * Idempotent `.gitmodules` entry removal via the shared
+   * {@link coreStripGitmodulesEntry} text transform — the unmount counterpart
+   * of {@link ensureGitmodulesEntry}. No-op (returns `{ removed: false }`) when
+   * `.gitmodules` is absent or has no matching stanza.
    */
   removeGitmodulesEntry(
     vaultPath: string,
@@ -365,52 +348,18 @@ export class BootstrapAssetSpaceService {
       }
       throw err;
     }
-    const rewritten = BootstrapAssetSpaceService.stripGitmodulesEntry(
-      original,
-      submodulePath,
-    );
+    const rewritten = coreStripGitmodulesEntry(original, submodulePath);
     if (rewritten === original) return { removed: false };
     writeFileSync(gitmodulesPath, rewritten, { encoding: "utf8" });
     return { removed: true };
   }
 
   /**
-   * Pure `.gitmodules` stanza strip — header + body lines up to the next
-   * `[…]` header or EOF, then double-blank collapse. Static + side-effect free
-   * for unit testing. Byte-parity with plugin `GitSubmoduleOps.stripGitmodulesEntry`.
+   * Pure `.gitmodules` stanza strip — delegates to the shared core transform.
+   * Static + side-effect free, retained for backward-compatible callers.
    */
   static stripGitmodulesEntry(content: string, submodulePath: string): string {
-    const escaped = submodulePath.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-    const lines = content.split(/\r?\n/);
-    const out: string[] = [];
-    let skipping = false;
-    const headerPattern = new RegExp(`^\\[submodule\\s+"${escaped}"\\]\\s*$`);
-    for (const line of lines) {
-      if (skipping) {
-        // Next stanza starts — stop skipping (do NOT consume the new header).
-        if (/^\[.+\]\s*$/.test(line)) {
-          skipping = false;
-          out.push(line);
-          continue;
-        }
-        continue;
-      }
-      if (headerPattern.test(line)) {
-        skipping = true;
-        continue;
-      }
-      out.push(line);
-    }
-    // Collapse double-blank lines created by the strip.
-    const collapsed: string[] = [];
-    let prevBlank = false;
-    for (const line of out) {
-      const blank = line.trim().length === 0;
-      if (blank && prevBlank) continue;
-      collapsed.push(line);
-      prevBlank = blank;
-    }
-    return collapsed.join("\n");
+    return coreStripGitmodulesEntry(content, submodulePath);
   }
 
   /**
@@ -418,10 +367,7 @@ export class BootstrapAssetSpaceService {
    * remove its vault folder. Idempotent — a missing folder or absent
    * `.gitmodules` stanza is a no-op.
    *
-   * Ordering (stanza-first) mirrors the plugin's `RestAssetSpaceMount.unmount`:
-   * if a step fails mid-unmount, a leftover empty folder (manifest already says
-   * "not mounted") is more benign than a dangling `[submodule …]` stanza
-   * pointing at a folder that no longer exists.
+   * Ordering (stanza-first) mirrors the plugin's `RestAssetSpaceMount.unmount`.
    *
    * Safety (defense-in-depth): the `rmSync` is recursive+force, so a bad
    * `submodulePath` (empty, traversal, or non-`assetspaces/`) could escape to
@@ -458,4 +404,3 @@ export class BootstrapAssetSpaceService {
     }
   }
 }
-

--- a/packages/cli/tests/integration/cross-runtime-mount-parity.test.ts
+++ b/packages/cli/tests/integration/cross-runtime-mount-parity.test.ts
@@ -1,0 +1,202 @@
+/**
+ * Cross-runtime AssetSpace MOUNT parity (Issue #3423).
+ *
+ * Mirrors the `docs/CROSS_RUNTIME_PARITY.md` validator-parity pattern, but for
+ * the mount pipeline. Both the CLI Node-`fs` adapter
+ * ({@link BootstrapAssetSpaceService.pullAssetSpace}) and a plugin-shape
+ * in-memory adapter drive the SAME shared core
+ * ({@link mountAssetSpaceFiles}) over a single tarball fixture and MUST produce
+ * equivalent results (same SHA, same file count, same wrapper-stripped
+ * {relPath → content} set) — the R2 mitigation against the dual-mount drift the
+ * issue eliminates.
+ *
+ * The two adapters differ ONLY in their genuinely platform-specific write
+ * strategy (CLI: atomic stage+rename onto disk; plugin: additive direct write).
+ * This test proves that divergence does not change the materialised outcome.
+ */
+
+import { mkdtempSync, rmSync, readdirSync, readFileSync, statSync } from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { gzipSync } from "node:zlib";
+import { createTar } from "nanotar";
+
+import {
+  mountAssetSpaceFiles,
+  appendGitmodulesEntry,
+  stripGitmodulesEntry,
+  type FileSystemPort,
+  type AssetSpaceHttpClient,
+  type MountFile,
+} from "exocortex";
+
+import { BootstrapAssetSpaceService } from "../../src/services/BootstrapAssetSpaceService";
+
+const OWNER = "kitelev";
+const REPO = "exoas-ems";
+const SHA7 = "abc1234";
+const WRAPPER = `${OWNER}-${REPO}-${SHA7}`;
+const REPO_URL = `https://github.com/${OWNER}/${REPO}`;
+
+/** Shared fixture content — multiple files incl. nested dirs. */
+const FIXTURE_FILES: Array<{ path: string; content: string }> = [
+  { path: "README.md", content: "# EMS\n" },
+  { path: "ontology/Task.md", content: "task body\n" },
+  { path: "ontology/sub/Deep.md", content: "deep\n" },
+];
+
+function buildTarball(): Uint8Array {
+  const entries = FIXTURE_FILES.map((f) => ({
+    name: `${WRAPPER}/${f.path}`,
+    data: new TextEncoder().encode(f.content),
+  }));
+  return gzipSync(Buffer.from(createTar(entries)));
+}
+
+function fakeFetch(blob: Uint8Array): typeof fetch {
+  return (async () =>
+    ({
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      arrayBuffer: async () =>
+        blob.buffer.slice(blob.byteOffset, blob.byteOffset + blob.byteLength),
+    }) as unknown as Response) as typeof fetch;
+}
+
+function fakeHttp(blob: Uint8Array): AssetSpaceHttpClient {
+  return { async fetchTarball() { return blob; } };
+}
+
+/** Plugin-shape additive in-memory FileSystemPort (mirrors RestAssetSpaceMount). */
+function inMemoryAdditiveFs(): FileSystemPort & { files: Map<string, Uint8Array> } {
+  const files = new Map<string, Uint8Array>();
+  const texts = new Map<string, string>();
+  return {
+    files,
+    async exists(p) { return files.has(p) || texts.has(p); },
+    async read(p) {
+      const t = texts.get(p);
+      if (t === undefined) throw new Error(`ENOENT ${p}`);
+      return t;
+    },
+    async write(p, c) { texts.set(p, c); },
+    async removeDir(p) {
+      for (const k of [...files.keys()]) if (k === p || k.startsWith(p + "/")) files.delete(k);
+    },
+    async materialize(targetPath: string, mountFiles: MountFile[]): Promise<number> {
+      let n = 0;
+      for (const f of mountFiles) { files.set(`${targetPath}/${f.relPath}`, f.content); n++; }
+      return n;
+    },
+  };
+}
+
+/** Recursively read a materialised tree into a {relPath → content} map. */
+function readTree(root: string): Map<string, string> {
+  const out = new Map<string, string>();
+  const walk = (dir: string): void => {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) walk(full);
+      else if (entry.isFile()) {
+        out.set(path.relative(root, full).split(path.sep).join("/"), readFileSync(full, "utf8"));
+      }
+    }
+  };
+  walk(root);
+  return out;
+}
+
+describe("cross-runtime mount parity (Issue #3423)", () => {
+  let tempBase: string;
+
+  beforeEach(() => {
+    tempBase = mkdtempSync(path.join(os.tmpdir(), "mount-parity-"));
+  });
+  afterEach(() => {
+    rmSync(tempBase, { recursive: true, force: true });
+  });
+
+  it("CLI Node-fs adapter and plugin-shape in-memory adapter materialise identical results", async () => {
+    const blob = buildTarball();
+
+    // CLI Node-fs path (atomic stage+rename onto disk).
+    const cliTarget = path.join(tempBase, "assetspaces", OWNER, REPO);
+    const cli = new BootstrapAssetSpaceService({ fetchImpl: fakeFetch(blob) });
+    const cliResult = await cli.pullAssetSpace(REPO_URL, "main", cliTarget);
+    const cliTree = readTree(cliTarget);
+
+    // Plugin-shape in-memory path (additive direct write).
+    const fs = inMemoryAdditiveFs();
+    const pluginTarget = "assetspaces/kitelev/exoas-ems";
+    const pluginResult = await mountAssetSpaceFiles({
+      http: fakeHttp(blob),
+      fs,
+      owner: OWNER,
+      repo: REPO,
+      ref: "main",
+      targetPath: pluginTarget,
+    });
+    const pluginTree = new Map<string, string>();
+    for (const [k, v] of fs.files) {
+      pluginTree.set(k.slice(pluginTarget.length + 1), new TextDecoder().decode(v));
+    }
+
+    // SHA + fileCount parity.
+    expect(cliResult.sha).toBe(pluginResult.sha);
+    expect(cliResult.sha).toBe(SHA7);
+    expect(cliResult.fileCount).toBe(pluginResult.fileCount);
+    expect(cliResult.fileCount).toBe(FIXTURE_FILES.length);
+
+    // Materialised {relPath → content} set parity.
+    expect([...cliTree.keys()].sort()).toEqual([...pluginTree.keys()].sort());
+    for (const [rel, content] of cliTree) {
+      expect(pluginTree.get(rel)).toBe(content);
+    }
+    // And both match the original fixture.
+    for (const f of FIXTURE_FILES) {
+      expect(cliTree.get(f.path)).toBe(f.content);
+      expect(pluginTree.get(f.path)).toBe(f.content);
+    }
+  });
+
+  it(".gitmodules append is byte-identical across the CLI adapter and the pure core transform", () => {
+    const submodulePath = "assetspaces/kitelev/exoas-ems";
+    // CLI adapter writes to disk via the shared transform.
+    const cli = new BootstrapAssetSpaceService({});
+    cli.ensureGitmodulesEntry(tempBase, submodulePath, REPO_URL);
+    const cliGitmodules = readFileSync(path.join(tempBase, ".gitmodules"), "utf8");
+
+    // Pure core transform from empty content.
+    const { content } = appendGitmodulesEntry("", submodulePath, REPO_URL);
+
+    expect(cliGitmodules).toBe(content);
+    expect(cliGitmodules).toContain(`[submodule "${submodulePath}"]`);
+    expect(cliGitmodules).toContain(`url = ${REPO_URL}`);
+  });
+
+  it("strip is byte-identical across the CLI static helper and the core transform", () => {
+    const content =
+      `[submodule "assetspaces/a"]\n\tpath = assetspaces/a\n\turl = u1\n` +
+      `[submodule "assetspaces/b"]\n\tpath = assetspaces/b\n\turl = u2\n`;
+    expect(BootstrapAssetSpaceService.stripGitmodulesEntry(content, "assetspaces/a")).toBe(
+      stripGitmodulesEntry(content, "assetspaces/a"),
+    );
+  });
+
+  it("unmount via the CLI adapter removes the materialised tree (round-trip)", async () => {
+    const blob = buildTarball();
+    const target = path.join(tempBase, "assetspaces", OWNER, REPO);
+    const cli = new BootstrapAssetSpaceService({ fetchImpl: fakeFetch(blob) });
+    await cli.pullAssetSpace(REPO_URL, "main", target);
+    cli.ensureGitmodulesEntry(tempBase, `assetspaces/${OWNER}/${REPO}`, REPO_URL);
+    expect(statSync(target).isDirectory()).toBe(true);
+
+    cli.unmountAssetSpace(tempBase, `assetspaces/${OWNER}/${REPO}`);
+    expect(() => statSync(target)).toThrow();
+    expect(readFileSync(path.join(tempBase, ".gitmodules"), "utf8")).not.toContain(
+      `assetspaces/${OWNER}/${REPO}`,
+    );
+  });
+});

--- a/packages/exocortex/src/index.ts
+++ b/packages/exocortex/src/index.ts
@@ -553,3 +553,23 @@ export {
   type RestCommitTransport,
   type RestCreateCommitParams,
 } from "./infrastructure/github/restCommit";
+
+// Platform-agnostic AssetSpace mount/unmount core (Issue #3423 — Option A
+// hexagonal consolidation). The single mount pipeline (fetch → wrapper → SHA →
+// zip-slip → materialize) + `.gitmodules` text transforms, shared by the plugin
+// (RestAssetSpaceMount: DataAdapter + requestUrl) and the CLI
+// (BootstrapAssetSpaceService: Node fs + fetch) via injected ports.
+export {
+  mountAssetSpaceFiles,
+  discoverWrapperDir as discoverAssetSpaceWrapperDir,
+  extractShaFromWrapper as extractAssetSpaceSha,
+  appendGitmodulesEntry,
+  stripGitmodulesEntry,
+  escapeGitmodulesRegex,
+  type FileSystemPort,
+  type HttpClient as AssetSpaceHttpClient,
+  type MountFile,
+  type MountResult,
+  type MountAssetSpaceParams,
+  type GitmodulesAppendResult,
+} from "./services/assetspace/AssetSpaceMount";

--- a/packages/exocortex/src/services/assetspace/AssetSpaceMount.ts
+++ b/packages/exocortex/src/services/assetspace/AssetSpaceMount.ts
@@ -1,0 +1,294 @@
+/**
+ * AssetSpace mount/unmount core (Issue #3423 — Option A hexagonal consolidation).
+ *
+ * ## Why this exists
+ *
+ * There were two parallel mount/unmount implementations of the same logic:
+ *
+ *   - `RestAssetSpaceMount` (plugin) — Obsidian `DataAdapter` + `requestUrl`.
+ *   - `BootstrapAssetSpaceService` (CLI) — Node `fs` + `fetch`.
+ *
+ * Both fetched a GitHub REST tarball, discovered the `<owner>-<repo>-<sha>/`
+ * wrapper, extracted the SHA, ran the same zip-slip checks, wrote each file, and
+ * mutated `.gitmodules` with byte-identical text transforms. That duplicated
+ * **pure** logic (wrapper discovery, SHA extraction, zip-slip validation,
+ * `.gitmodules` append/strip) is the exact drift pattern that has bitten this
+ * codebase before (`extractReference` triplication, PR #3296).
+ *
+ * This module is the **single platform-agnostic core**. The drift-prone pure
+ * logic lives here once; the genuinely platform-specific I/O (how bytes hit
+ * disk, how the tarball is fetched) is injected via two ports:
+ *
+ *   - {@link HttpClient}  — fetch the tarball bytes (plugin: `requestUrl` +
+ *     rate-limit gate; CLI: Node `fetch` + 403/404 hint handling).
+ *   - {@link FileSystemPort} — materialize the wrapper-stripped files and remove
+ *     a mount tree. The platform owns the **write strategy**: the plugin writes
+ *     additively (overwrite collisions, leave extant files), the CLI stages to a
+ *     temp dir and atomically renames, refusing a non-empty target. This
+ *     strategy divergence is genuine platform behaviour, so it stays in the
+ *     adapter's `materialize` — relocated verbatim, NOT rewritten.
+ *
+ * Precedent: `restCreateCommit` is a shared transport-agnostic core that both
+ * the plugin (`GitHubRestClient`) and CLI (`RestPushService`) consume via an
+ * injected transport. This extraction follows the same pattern.
+ */
+
+/** A single wrapper-stripped file to materialize under the mount target. */
+export interface MountFile {
+  /**
+   * Path relative to the mount target, wrapper-stripped, forward-slash
+   * normalised. Guaranteed by the core to contain no absolute prefix and no
+   * `..` segment before it reaches the {@link FileSystemPort}.
+   */
+  relPath: string;
+  content: Uint8Array;
+}
+
+/**
+ * Platform file-system port. Path convention is opaque to the core — the plugin
+ * passes vault-relative paths (its `DataAdapter` is rooted at the vault), the
+ * CLI passes absolute paths. The core only ever joins `targetPath` with a
+ * core-validated `relPath` (no `..`, no absolute) and reads/writes `.gitmodules`
+ * at a caller-supplied path.
+ */
+export interface FileSystemPort {
+  exists(path: string): Promise<boolean>;
+  read(path: string): Promise<string>;
+  write(path: string, content: string): Promise<void>;
+  /**
+   * Materialize `files` under `targetPath`. The platform owns the write
+   * strategy (plugin: additive direct write; CLI: atomic stage+rename refusing
+   * a non-empty target). Each `relPath` is already core-validated against
+   * zip-slip; the adapter MAY keep its own defense-in-depth resolve check.
+   * Returns the number of files written.
+   */
+  materialize(targetPath: string, files: MountFile[]): Promise<number>;
+  /** Recursively remove a mount tree. The platform owns any safety guards. */
+  removeDir(path: string): Promise<void>;
+}
+
+/** Platform HTTP port — fetch the GitHub REST tarball as raw gzipped bytes. */
+export interface HttpClient {
+  /**
+   * Fetch `GET /repos/{owner}/{repo}/tarball/{ref}` as raw gzipped bytes. The
+   * adapter owns auth, rate-limit gating, size caps, and HTTP-error messaging
+   * (rate-limit / 404 hints / PAT redaction).
+   */
+  fetchTarball(owner: string, repo: string, ref: string): Promise<Uint8Array>;
+}
+
+/** Outcome of {@link mountAssetSpaceFiles}. */
+export interface MountResult {
+  /** Commit SHA discovered from the GitHub tarball wrapper dir (lowercased). */
+  sha: string;
+  /** Number of files written into the mount target. */
+  fileCount: number;
+}
+
+import { parseTarballGzip, type TarballEntry } from "../../infrastructure/tarball/parseTarball";
+
+const GITMODULES_HEADER_TYPES = new Set(["globalExtendedHeader", "extendedHeader"]);
+
+/** Normalise a tar entry path: backslash→slash, collapse `//`, strip leading `./`. */
+function normalizeEntryPath(path: string): string {
+  let p = path.replace(/\\/g, "/").replace(/\/+/g, "/");
+  while (p.startsWith("./")) p = p.slice(2);
+  return p;
+}
+
+/**
+ * Discover the wrapper directory of a GitHub REST tarball
+ * (`<owner>-<repo>-<sha>/`). Skips ustar/pax header entries and reads the first
+ * content entry that carries a path separator, then verifies every other
+ * content entry shares the wrapper prefix.
+ */
+export function discoverWrapperDir(entries: TarballEntry[]): string {
+  const firstContent = entries.find(
+    (e) => !GITMODULES_HEADER_TYPES.has(e.type) && normalizeEntryPath(e.name).includes("/"),
+  );
+  if (firstContent === undefined) {
+    throw new Error("discoverWrapperDir: no wrapper-bearing entry in tarball");
+  }
+  const norm = normalizeEntryPath(firstContent.name);
+  const wrapper = norm.slice(0, norm.indexOf("/"));
+  if (wrapper.length === 0) {
+    throw new Error(`discoverWrapperDir: empty wrapper segment in entry "${firstContent.name}"`);
+  }
+  const wrapperPrefix = wrapper + "/";
+  for (const entry of entries) {
+    if (GITMODULES_HEADER_TYPES.has(entry.type)) continue;
+    const name = normalizeEntryPath(entry.name);
+    if (name === wrapper || name === wrapperPrefix) continue;
+    if (!name.startsWith(wrapperPrefix)) {
+      throw new Error(`discoverWrapperDir: entry "${entry.name}" not under wrapper "${wrapper}"`);
+    }
+  }
+  return wrapper;
+}
+
+/**
+ * Extract the commit SHA from a GitHub tarball wrapper name
+ * (`<owner>-<repo>-<sha>`). SHA length is auth-dependent: anonymous tarballs
+ * carry a 7-char abbreviated SHA, authenticated ones the full 40-char SHA, so
+ * the trailing hex segment is matched at 7..40 chars. Returned lowercased.
+ */
+export function extractShaFromWrapper(wrapper: string): string {
+  const m = wrapper.match(/-([0-9a-fA-F]{7,40})$/);
+  if (m === null) {
+    throw new Error(
+      `extractShaFromWrapper: wrapper "${wrapper}" does not match expected GitHub pattern <owner>-<repo>-<sha>`,
+    );
+  }
+  return m[1].toLowerCase();
+}
+
+/**
+ * Build the wrapper-stripped {@link MountFile} list from parsed tarball entries.
+ *
+ * Zip-slip + security checks (defense-in-depth — the adapter's `materialize`
+ * keeps its own platform resolve check too):
+ *   - reject `symbolicLink` / `hardLink` entries (host-fs link injection)
+ *   - skip header / directory / data-less entries
+ *   - require every entry under the wrapper prefix
+ *   - reject any `..` path segment after wrapper-strip
+ */
+function buildMountFiles(entries: TarballEntry[], wrapper: string): MountFile[] {
+  const wrapperPrefix = wrapper + "/";
+  const files: MountFile[] = [];
+  for (const entry of entries) {
+    if (entry.type === "symbolicLink" || entry.type === "hardLink") {
+      throw new Error(`${entry.type} entry "${entry.name}" rejected for security`);
+    }
+    if (GITMODULES_HEADER_TYPES.has(entry.type)) continue;
+    if (entry.type === "directory") continue;
+    const name = normalizeEntryPath(entry.name);
+    if (name === wrapper || name === wrapperPrefix) continue;
+    if (!name.startsWith(wrapperPrefix)) {
+      throw new Error(`entry "${entry.name}" not under wrapper "${wrapper}"`);
+    }
+    const rel = name.slice(wrapperPrefix.length);
+    if (rel.length === 0) continue;
+    if (rel.split("/").some((s) => s === "..")) {
+      throw new Error(`path traversal detected for entry "${entry.name}"`);
+    }
+    if (entry.data === undefined) continue;
+    files.push({ relPath: rel, content: entry.data });
+  }
+  return files;
+}
+
+/** Parameters for {@link mountAssetSpaceFiles}. */
+export interface MountAssetSpaceParams {
+  http: HttpClient;
+  fs: FileSystemPort;
+  owner: string;
+  repo: string;
+  ref: string;
+  /** Mount target in the port's path convention (vault-relative or absolute). */
+  targetPath: string;
+}
+
+/**
+ * Mount an AssetSpace's files: fetch its GitHub tarball, discover the wrapper +
+ * SHA, validate every entry against zip-slip, and materialize the
+ * wrapper-stripped files under `targetPath` via the injected
+ * {@link FileSystemPort}. Does NOT touch `.gitmodules` — callers compose
+ * {@link appendGitmodulesEntry} with their own port I/O (the plugin and CLI
+ * differ on whether the `.gitmodules` mutation is bundled with the file write).
+ *
+ * @throws on empty/malformed tarball, link entries, path traversal, or any
+ *   error surfaced by the injected ports (rate-limit, 404, refuse-non-empty).
+ */
+export async function mountAssetSpaceFiles(params: MountAssetSpaceParams): Promise<MountResult> {
+  const { http, fs, owner, repo, ref, targetPath } = params;
+  const blob = await http.fetchTarball(owner, repo, ref);
+  const entries = await parseTarballGzip(blob);
+  if (entries.length === 0) {
+    throw new Error(`tarball empty for ${owner}/${repo}@${ref}`);
+  }
+  const wrapper = discoverWrapperDir(entries);
+  const sha = extractShaFromWrapper(wrapper);
+  const files = buildMountFiles(entries, wrapper);
+  const fileCount = await fs.materialize(targetPath, files);
+  return { sha, fileCount };
+}
+
+// ───────────────────────────── .gitmodules transforms ─────────────────────────────
+
+/** Escape a string for safe interpolation into a RegExp. */
+export function escapeGitmodulesRegex(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/** Result of {@link appendGitmodulesEntry}. */
+export interface GitmodulesAppendResult {
+  /** New `.gitmodules` content (unchanged when the stanza already exists). */
+  content: string;
+  /** `true` when a new stanza was appended, `false` when it was already present. */
+  added: boolean;
+}
+
+/**
+ * Idempotently append a `[submodule "<path>"]` stanza to `.gitmodules` content.
+ * Pure text transform — no I/O. Re-appending an already-registered path is a
+ * no-op (`added: false`). The header detection tolerates extra whitespace
+ * (`[submodule  "x"]`); the emitted stanza uses the canonical single-space form
+ * so plugin + CLI produce byte-identical output.
+ */
+export function appendGitmodulesEntry(
+  existing: string,
+  submodulePath: string,
+  url: string,
+): GitmodulesAppendResult {
+  const headerRegex = new RegExp(
+    `^\\s*\\[submodule\\s+"${escapeGitmodulesRegex(submodulePath)}"\\]`,
+    "m",
+  );
+  if (existing.length > 0 && headerRegex.test(existing)) {
+    return { content: existing, added: false };
+  }
+  const sep = existing.length === 0 || existing.endsWith("\n") ? "" : "\n";
+  const newEntry = `[submodule "${submodulePath}"]\n\tpath = ${submodulePath}\n\turl = ${url}\n`;
+  return { content: existing + sep + newEntry, added: true };
+}
+
+/**
+ * Strip a `[submodule "<path>"]` stanza (header + body lines up to the next
+ * `[…]` header or EOF) from `.gitmodules` content, then collapse the
+ * double-blank line the strip may leave behind. Pure text transform — no I/O.
+ * Returns the input unchanged when no matching stanza exists.
+ */
+export function stripGitmodulesEntry(content: string, submodulePath: string): string {
+  const lines = content.split(/\r?\n/);
+  const out: string[] = [];
+  let skipping = false;
+  const headerPattern = new RegExp(
+    `^\\[submodule\\s+"${escapeGitmodulesRegex(submodulePath)}"\\]\\s*$`,
+  );
+  for (const line of lines) {
+    if (skipping) {
+      // Next stanza starts — stop skipping (do NOT consume the new header).
+      if (/^\[.+\]\s*$/.test(line)) {
+        skipping = false;
+        out.push(line);
+        continue;
+      }
+      continue;
+    }
+    if (headerPattern.test(line)) {
+      skipping = true;
+      continue;
+    }
+    out.push(line);
+  }
+  // Collapse double-blank lines created by the strip.
+  const collapsed: string[] = [];
+  let prevBlank = false;
+  for (const line of out) {
+    const blank = line.trim().length === 0;
+    if (blank && prevBlank) continue;
+    collapsed.push(line);
+    prevBlank = blank;
+  }
+  return collapsed.join("\n");
+}

--- a/packages/exocortex/tests/unit/services/assetspace/AssetSpaceMount.test.ts
+++ b/packages/exocortex/tests/unit/services/assetspace/AssetSpaceMount.test.ts
@@ -1,0 +1,218 @@
+/**
+ * Unit tests for the shared AssetSpace mount core (Issue #3423).
+ *
+ * Exercises the platform-agnostic pipeline + pure helpers via in-memory fake
+ * ports — no Obsidian, no Node fs, no network. The plugin- and CLI-specific
+ * write/HTTP strategies are tested in their own adapter suites + the
+ * cross-runtime parity test.
+ */
+
+import { gzipSync } from "node:zlib";
+import { createTar } from "nanotar";
+import {
+  mountAssetSpaceFiles,
+  discoverAssetSpaceWrapperDir,
+  extractAssetSpaceSha,
+  appendGitmodulesEntry,
+  stripGitmodulesEntry,
+  escapeGitmodulesRegex,
+  type FileSystemPort,
+  type AssetSpaceHttpClient,
+  type MountFile,
+} from "../../../../src/index";
+import {
+  parseTarballGzip,
+  type TarballEntry,
+} from "../../../../src/infrastructure/tarball/parseTarball";
+
+// ─── Fixtures ────────────────────────────────────────────────────────────────
+
+/** Build a gzipped GitHub-shape tarball wrapping `entries` under `wrapper`. */
+function makeTarball(
+  wrapper: string,
+  entries: Array<{ name: string; data?: Uint8Array }>,
+): Uint8Array {
+  const files = entries.map((e) => ({ name: `${wrapper}/${e.name}`, data: e.data }));
+  return gzipSync(Buffer.from(createTar(files)));
+}
+
+const enc = (s: string): Uint8Array => new TextEncoder().encode(s);
+const dec = (u: Uint8Array): string => new TextDecoder().decode(u);
+
+/** Records every materialised file; mirrors the plugin's additive write shape. */
+function inMemoryFs(): FileSystemPort & { files: Map<string, Uint8Array>; texts: Map<string, string> } {
+  const files = new Map<string, Uint8Array>();
+  const texts = new Map<string, string>();
+  return {
+    files,
+    texts,
+    async exists(p) {
+      return texts.has(p) || files.has(p);
+    },
+    async read(p) {
+      const t = texts.get(p);
+      if (t === undefined) throw new Error(`ENOENT: ${p}`);
+      return t;
+    },
+    async write(p, c) {
+      texts.set(p, c);
+    },
+    async removeDir(p) {
+      for (const k of [...files.keys()]) if (k === p || k.startsWith(p + "/")) files.delete(k);
+    },
+    async materialize(targetPath: string, mountFiles: MountFile[]): Promise<number> {
+      let n = 0;
+      for (const f of mountFiles) {
+        files.set(`${targetPath}/${f.relPath}`, f.content);
+        n++;
+      }
+      return n;
+    },
+  };
+}
+
+function fakeHttp(blob: Uint8Array): AssetSpaceHttpClient {
+  return { async fetchTarball() { return blob; } };
+}
+
+// ─── Pure helpers ────────────────────────────────────────────────────────────
+
+describe("discoverAssetSpaceWrapperDir", () => {
+  it("discovers the wrapper from real tarball entries", async () => {
+    const entries = await parseTarballGzip(
+      makeTarball("kitelev-exoas-ems-abc1234", [{ name: "README.md", data: enc("x") }]),
+    );
+    expect(discoverAssetSpaceWrapperDir(entries)).toBe("kitelev-exoas-ems-abc1234");
+  });
+
+  it("throws when no entry carries a wrapper path separator", () => {
+    const flat: TarballEntry[] = [{ name: "README.md", type: "file", size: 1, data: enc("x") }];
+    expect(() => discoverAssetSpaceWrapperDir(flat)).toThrow(/no wrapper-bearing entry/);
+  });
+
+  it("throws when an entry escapes the wrapper", () => {
+    const mixed: TarballEntry[] = [
+      { name: "wrap-abc1234/a.md", type: "file", size: 1, data: enc("x") },
+      { name: "other-dir/b.md", type: "file", size: 1, data: enc("y") },
+    ];
+    expect(() => discoverAssetSpaceWrapperDir(mixed)).toThrow(/not under wrapper/);
+  });
+});
+
+describe("extractAssetSpaceSha", () => {
+  it("extracts a 7-char abbreviated SHA (anonymous)", () => {
+    expect(extractAssetSpaceSha("kitelev-exoas-ems-abc1234")).toBe("abc1234");
+  });
+  it("extracts a 40-char full SHA (authenticated)", () => {
+    const full = "a".repeat(40);
+    expect(extractAssetSpaceSha(`kitelev-exoas-ems-${full}`)).toBe(full);
+  });
+  it("lowercases the SHA", () => {
+    expect(extractAssetSpaceSha("o-r-ABC1234")).toBe("abc1234");
+  });
+  it("throws on a wrapper without a trailing hex SHA", () => {
+    expect(() => extractAssetSpaceSha("kitelev-exoas-ems")).toThrow(/does not match expected GitHub pattern/);
+  });
+});
+
+describe("appendGitmodulesEntry", () => {
+  it("appends a stanza to empty content", () => {
+    const { content, added } = appendGitmodulesEntry("", "assetspaces/x", "https://github.com/o/x");
+    expect(added).toBe(true);
+    expect(content).toBe(
+      `[submodule "assetspaces/x"]\n\tpath = assetspaces/x\n\turl = https://github.com/o/x\n`,
+    );
+  });
+  it("is idempotent — no-op when the path key already exists", () => {
+    const first = appendGitmodulesEntry("", "assetspaces/x", "https://github.com/o/x").content;
+    const { content, added } = appendGitmodulesEntry(first, "assetspaces/x", "https://github.com/o/x");
+    expect(added).toBe(false);
+    expect(content).toBe(first);
+  });
+  it("inserts a newline separator when existing content lacks a trailing newline", () => {
+    const { content } = appendGitmodulesEntry("# header", "assetspaces/y", "https://github.com/o/y");
+    expect(content.startsWith("# header\n[submodule")).toBe(true);
+  });
+});
+
+describe("stripGitmodulesEntry", () => {
+  it("strips a stanza + collapses the resulting double blank", () => {
+    const content =
+      `[submodule "assetspaces/a"]\n\tpath = assetspaces/a\n\turl = u1\n` +
+      `[submodule "assetspaces/b"]\n\tpath = assetspaces/b\n\turl = u2\n`;
+    const out = stripGitmodulesEntry(content, "assetspaces/a");
+    expect(out).not.toContain("assetspaces/a");
+    expect(out).toContain(`[submodule "assetspaces/b"]`);
+  });
+  it("returns input unchanged when no matching stanza", () => {
+    const content = `[submodule "assetspaces/b"]\n\tpath = assetspaces/b\n\turl = u2\n`;
+    expect(stripGitmodulesEntry(content, "assetspaces/zzz")).toBe(content);
+  });
+});
+
+describe("escapeGitmodulesRegex", () => {
+  it("escapes regex metacharacters", () => {
+    expect(escapeGitmodulesRegex("a.b+c")).toBe("a\\.b\\+c");
+  });
+});
+
+// ─── mountAssetSpaceFiles orchestration ──────────────────────────────────────
+
+describe("mountAssetSpaceFiles", () => {
+  it("materialises wrapper-stripped files + returns sha/fileCount", async () => {
+    const fs = inMemoryFs();
+    const blob = makeTarball("kitelev-exoas-ems-abc1234", [
+      { name: "README.md", data: enc("# EMS\n") },
+      { name: "ontology/Task.md", data: enc("task body") },
+    ]);
+    const result = await mountAssetSpaceFiles({
+      http: fakeHttp(blob),
+      fs,
+      owner: "kitelev",
+      repo: "exoas-ems",
+      ref: "main",
+      targetPath: "assetspaces/kitelev/exoas-ems",
+    });
+
+    expect(result.sha).toBe("abc1234");
+    expect(result.fileCount).toBe(2);
+    expect(dec(fs.files.get("assetspaces/kitelev/exoas-ems/README.md")!)).toBe("# EMS\n");
+    expect(dec(fs.files.get("assetspaces/kitelev/exoas-ems/ontology/Task.md")!)).toBe("task body");
+  });
+
+  it("rejects an empty tarball before any materialise", async () => {
+    const fs = inMemoryFs();
+    await expect(
+      mountAssetSpaceFiles({
+        http: fakeHttp(gzipSync(Buffer.from(createTar([])))),
+        fs,
+        owner: "o",
+        repo: "r",
+        ref: "main",
+        targetPath: "assetspaces/x",
+      }),
+    ).rejects.toThrow(/tarball empty/);
+    expect(fs.files.size).toBe(0);
+  });
+
+  it("rejects a `..` traversal entry — no files written (revert-verify control)", async () => {
+    const fs = inMemoryFs();
+    const blob = makeTarball("o-r-abc1234", [
+      { name: "ok.md", data: enc("ok") },
+      { name: "../escape.md", data: enc("evil") },
+    ]);
+    await expect(
+      mountAssetSpaceFiles({
+        http: fakeHttp(blob),
+        fs,
+        owner: "o",
+        repo: "r",
+        ref: "main",
+        targetPath: "assetspaces/x",
+      }),
+    ).rejects.toThrow(/path traversal|not under wrapper/);
+    // Core validates the WHOLE entry list before calling fs.materialize, so a
+    // bad entry anywhere means zero files hit the port (all-or-nothing).
+    expect(fs.files.size).toBe(0);
+  });
+});

--- a/packages/obsidian-plugin/src/infrastructure/adapters/RestAssetSpaceMount.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/RestAssetSpaceMount.ts
@@ -1,38 +1,36 @@
 import type { App, DataAdapter } from "obsidian";
 import { GitHubRestClient } from "./GitHubRestClient";
-import { TarExtractor, type ExtractedTarFile } from "./TarExtractor";
+import { parseGitHubURL } from "./AssetSpaceManager";
+import { validateVaultPathArg } from "./GitSubmoduleOps";
 import {
-  parseGitHubURL,
-  discoverWrapperDir,
-  extractShaFromWrapper,
-} from "./AssetSpaceManager";
-import {
-  validateVaultPathArg,
+  mountAssetSpaceFiles,
+  appendGitmodulesEntry,
   stripGitmodulesEntry,
-  escapeRegex,
-} from "./GitSubmoduleOps";
+  type FileSystemPort,
+  type AssetSpaceHttpClient,
+  type MountFile,
+  type MountResult,
+} from "exocortex";
 
 /**
  * RestAssetSpaceMount — cross-platform (incl. iOS) AssetSpace mount/unmount
  * via the GitHub REST tarball API, RFC 01a83de8 Phase 3 (T1).
  *
- * ## Why this exists
+ * ## Thin adapter over the shared mount core (Issue #3423)
  *
- * The desktop hard-switch path materialises AssetSpaces through the `git`
- * binary (`git submodule add` / `deinit` — see {@link GitSubmoduleOps}). That
- * binary is unavailable on mobile Obsidian, so the whole hard-switch /
- * mount-state visibility model could not reach iOS. This adapter replaces the
- * single `execFile("git")` mount/unmount mechanics with a pure
- * `requestUrl` + tarball + `vault.adapter` pipeline that runs identically on
- * desktop and mobile:
+ * The mount/unmount pipeline (fetch tarball → discover `<owner>-<repo>-<sha>/`
+ * wrapper → extract SHA → zip-slip validate → materialise files → `.gitmodules`
+ * mutation) lives ONCE in `exocortex`'s {@link mountAssetSpaceFiles} +
+ * `.gitmodules` text transforms. This adapter supplies the two Obsidian-coupled
+ * ports:
  *
- *   - **mount**: `GitHubRestClient.fetchTarballBuffer` → `TarExtractor`
- *     (zip-slip safe) → write each file into `<submodulePath>/...` via
- *     `vault.adapter.writeBinary` → append a plain-text `[submodule …]` entry
- *     to `.gitmodules`. No `.git/modules` / `.git/config` state is created —
- *     mount-state visibility is "folder exists", not "git knows about it".
- *   - **unmount**: `vault.adapter.rmdir(path, recursive)` → strip the
- *     `.gitmodules` entry. No `git submodule deinit` needed.
+ *   - **{@link FileSystemPort}** over `vault.adapter` — `materialize()` writes
+ *     files **additively** (overwrite collisions, leave files absent from the
+ *     tarball; callers needing a pristine tree {@link unmount} first), the same
+ *     direct-write strategy this adapter has always used. No `.git/modules` /
+ *     `.git/config` state — mount-state visibility is "folder exists".
+ *   - **{@link AssetSpaceHttpClient}** over {@link GitHubRestClient} — a
+ *     rate-limit-gated `requestUrl` tarball fetch.
  *
  * Desktop keeps the git-binary path as a gated fallback (RFC v9 EV4); this
  * adapter is the mobile-capable path that Phase 3 T2 wires into the profile
@@ -40,39 +38,28 @@ import {
  *
  * ## Security shape (inherited + local)
  *
- *   - Repo URL allowlist via {@link GitHubRestClient.validateRepoURL}
- *     (rejects non-github hosts, path traversal, scheme injection).
- *   - Submodule path validated via {@link validateVaultPathArg}
- *     (`..` / absolute / shell-meta / leading-dash rejected).
+ *   - Repo URL allowlist via {@link GitHubRestClient.validateRepoURL}.
+ *   - Submodule path validated via {@link validateVaultPathArg}.
  *   - PAT redaction + rate-limit gate handled inside `GitHubRestClient`.
- *   - Tarball entries pass `TarExtractor`'s 4 zip-slip checks; a second
- *     defense-in-depth check confirms each resolved write target stays under
- *     the mount folder before any `writeBinary`.
+ *   - The core rejects sym/hard links + `..` traversal + non-wrapper entries;
+ *     `materialize()` adds a defense-in-depth check that each resolved target
+ *     stays under the mount folder before any `writeBinary`.
  *   - `.gitmodules` written as plain text (no shell) — the `[submodule "…"]`
- *     header path is constrained to the already-validated, metacharacter-free
- *     `submodulePath`.
+ *     header path is the already-validated, metacharacter-free `submodulePath`.
  */
 export interface RestAssetSpaceMountOptions {
   app: App;
   client: GitHubRestClient;
-  /** Optional injection — defaults to a fresh `new TarExtractor()`. */
-  tarExtractor?: TarExtractor;
 }
 
 /** Outcome of a successful {@link RestAssetSpaceMount.mount}. */
-export interface RestMountResult {
-  /** Commit SHA discovered from the GitHub tarball wrapper dir. */
-  sha: string;
-  /** Number of files written into the vault under the mount folder. */
-  fileCount: number;
-}
+export type RestMountResult = MountResult;
 
 const GITMODULES = ".gitmodules";
 
 export class RestAssetSpaceMount {
   private readonly app: App;
   private readonly client: GitHubRestClient;
-  private readonly tarExtractor: TarExtractor;
 
   constructor(opts: RestAssetSpaceMountOptions) {
     if (!opts || !opts.app) {
@@ -83,7 +70,6 @@ export class RestAssetSpaceMount {
     }
     this.app = opts.app;
     this.client = opts.client;
-    this.tarExtractor = opts.tarExtractor ?? new TarExtractor();
   }
 
   private get adapter(): DataAdapter {
@@ -97,9 +83,8 @@ export class RestAssetSpaceMount {
    *
    * The mount is **additive** at the file level — colliding paths are
    * overwritten, but files present locally yet absent from the tarball are
-   * left untouched. Callers that need a pristine tree should
-   * {@link unmount} first (the profile-switch orchestrator does
-   * destroy-then-materialise).
+   * left untouched. Callers that need a pristine tree should {@link unmount}
+   * first (the profile-switch orchestrator does destroy-then-materialise).
    *
    * @throws on invalid URL / path, rate-limit exhaustion, network/HTTP
    *   failure, empty or malformed tarball, or zip-slip violation. Partial
@@ -115,63 +100,17 @@ export class RestAssetSpaceMount {
     GitHubRestClient.validateRepoURL(gitUrl);
     const { owner, repo } = parseGitHubURL(gitUrl);
 
-    // Pre-flight rate-limit gate — fetchTarballBuffer is one REST call. The
-    // PAT (D3 REST-push reuse) lives inside `client`; an insufficient scope
-    // surfaces as a redacted HTTP 401/404 from fetchTarballBuffer below.
-    await this.client.ensureRateLimit(1);
-
-    const blob = await this.client.fetchTarballBuffer(owner, repo, ref);
-
-    // Collect entries so we can do the two-pass discover-wrapper-then-strip
-    // pattern (same shape as AssetSpaceManager.pullAssetSpace). Memory is
-    // already O(tarball.size) — nanotar buffers internally.
-    const entries: ExtractedTarFile[] = [];
-    for await (const entry of this.tarExtractor.extract(blob, {
-      // Wrapper prefix unknown until the first entry is read — let the prefix
-      // gate accept any path. Zip-slip protections 1-3 (absolute, `..`,
-      // sym/hard links) stay active.
-      stagingDirPrefix: "",
-    })) {
-      entries.push(entry);
-    }
-    if (entries.length === 0) {
-      throw new Error(
-        `RestAssetSpaceMount.mount: tarball empty for ${owner}/${repo}@${ref}`,
-      );
-    }
-
-    const wrapper = discoverWrapperDir(entries);
-    const sha = extractShaFromWrapper(wrapper);
-    const wrapperPrefix = wrapper + "/";
-
-    await this.ensureDir(safePath);
-    const createdDirs = new Set<string>([safePath]);
-    let fileCount = 0;
-
-    for (const entry of entries) {
-      if (!entry.path.startsWith(wrapperPrefix)) {
-        throw new Error(
-          `RestAssetSpaceMount.mount: tarball entry "${entry.path}" not under wrapper "${wrapper}"`,
-        );
-      }
-      const rel = entry.path.slice(wrapperPrefix.length);
-      if (rel.length === 0) continue;
-      const target = `${safePath}/${rel}`;
-      // Defense-in-depth — TarExtractor already rejected `..` / absolute, but
-      // confirm the joined target stays under the mount folder regardless.
-      if (target !== safePath && !target.startsWith(safePath + "/")) {
-        throw new Error(
-          `RestAssetSpaceMount.mount: entry "${rel}" escapes mount folder "${safePath}"`,
-        );
-      }
-      const parent = parentDir(target);
-      if (parent.length > 0) await this.ensureDirChain(parent, createdDirs);
-      await this.adapter.writeBinary(target, toArrayBuffer(entry.content));
-      fileCount++;
-    }
+    const result = await mountAssetSpaceFiles({
+      http: this.httpPort(),
+      fs: this.fsPort(),
+      owner,
+      repo,
+      ref,
+      targetPath: safePath,
+    });
 
     await this.appendGitmodulesEntry(safePath, gitUrl);
-    return { sha, fileCount };
+    return result;
   }
 
   /**
@@ -193,39 +132,79 @@ export class RestAssetSpaceMount {
     }
   }
 
-  // ───────────────────────────── internals ─────────────────────────────
-
-  /** Create one directory level if it does not already exist. */
-  private async ensureDir(dir: string): Promise<void> {
-    if (dir.length === 0) return;
-    if (!(await this.adapter.exists(dir))) {
-      await this.adapter.mkdir(dir);
-    }
-  }
+  // ───────────────────────────── ports ─────────────────────────────
 
   /**
-   * Create a directory and all its missing parents (Obsidian's
-   * `DataAdapter.mkdir` is NOT guaranteed recursive on every platform).
-   * `created` memoises already-ensured dirs to avoid redundant
-   * `exists`/`mkdir` round-trips during a multi-file mount.
+   * Rate-limit-gated `requestUrl` tarball fetch. The PAT (D3 REST-push reuse)
+   * lives inside `client`; an insufficient scope surfaces as a redacted HTTP
+   * 401/404 from `fetchTarballBuffer`.
    */
-  private async ensureDirChain(
-    dir: string,
-    created: Set<string>,
-  ): Promise<void> {
-    if (dir.length === 0 || created.has(dir)) return;
-    const parent = parentDir(dir);
-    if (parent.length > 0) await this.ensureDirChain(parent, created);
-    if (!created.has(dir)) {
-      await this.ensureDir(dir);
-      created.add(dir);
-    }
+  private httpPort(): AssetSpaceHttpClient {
+    const client = this.client;
+    return {
+      async fetchTarball(owner, repo, ref): Promise<Uint8Array> {
+        // Pre-flight rate-limit gate — fetchTarballBuffer is one REST call.
+        await client.ensureRateLimit(1);
+        const blob = await client.fetchTarballBuffer(owner, repo, ref);
+        return new Uint8Array(blob);
+      },
+    };
   }
 
   /**
-   * Idempotent `.gitmodules` stanza insertion over `vault.adapter` — the
-   * mobile-capable counterpart of {@link GitSubmoduleOps.appendGitmodulesEntry}
-   * (which uses `node:fs`). Re-mounting an already-registered path is a no-op.
+   * `vault.adapter`-backed file-system port. `materialize()` keeps this
+   * adapter's historic **additive direct-write** strategy verbatim (ensure the
+   * mount folder + each parent chain, then `writeBinary` each file).
+   */
+  private fsPort(): FileSystemPort {
+    const adapter = this.adapter;
+    return {
+      exists: (p) => adapter.exists(p),
+      read: (p) => adapter.read(p),
+      write: (p, c) => adapter.write(p, c),
+      removeDir: (p) => adapter.rmdir(p, true),
+      async materialize(targetPath: string, files: MountFile[]): Promise<number> {
+        const ensureDir = async (dir: string): Promise<void> => {
+          if (dir.length === 0) return;
+          if (!(await adapter.exists(dir))) await adapter.mkdir(dir);
+        };
+        const created = new Set<string>([targetPath]);
+        const ensureDirChain = async (dir: string): Promise<void> => {
+          if (dir.length === 0 || created.has(dir)) return;
+          const parent = parentDir(dir);
+          if (parent.length > 0) await ensureDirChain(parent);
+          if (!created.has(dir)) {
+            await ensureDir(dir);
+            created.add(dir);
+          }
+        };
+
+        await ensureDir(targetPath);
+        let count = 0;
+        for (const file of files) {
+          const target = `${targetPath}/${file.relPath}`;
+          // Defense-in-depth — the core already rejected `..` / non-wrapper
+          // entries; confirm the joined target stays under the mount folder.
+          if (target !== targetPath && !target.startsWith(targetPath + "/")) {
+            throw new Error(
+              `RestAssetSpaceMount.materialize: entry "${file.relPath}" escapes mount folder "${targetPath}"`,
+            );
+          }
+          const parent = parentDir(target);
+          if (parent.length > 0) await ensureDirChain(parent);
+          await adapter.writeBinary(target, toArrayBuffer(file.content));
+          count++;
+        }
+        return count;
+      },
+    };
+  }
+
+  // ───────────────────────────── .gitmodules I/O ─────────────────────────────
+
+  /**
+   * Idempotent `.gitmodules` stanza insertion over `vault.adapter` using the
+   * shared {@link appendGitmodulesEntry} text transform.
    */
   private async appendGitmodulesEntry(
     submodulePath: string,
@@ -235,20 +214,14 @@ export class RestAssetSpaceMount {
     if (await this.adapter.exists(GITMODULES)) {
       existing = await this.adapter.read(GITMODULES);
     }
-    const headerRegex = new RegExp(
-      `^\\s*\\[submodule\\s+"${escapeRegex(submodulePath)}"\\]`,
-      "m",
-    );
-    if (existing.length > 0 && headerRegex.test(existing)) return;
-    const sep = existing.length === 0 || existing.endsWith("\n") ? "" : "\n";
-    const newEntry = `[submodule "${submodulePath}"]\n\tpath = ${submodulePath}\n\turl = ${url}\n`;
-    await this.adapter.write(GITMODULES, existing + sep + newEntry);
+    const { content, added } = appendGitmodulesEntry(existing, submodulePath, url);
+    if (added) await this.adapter.write(GITMODULES, content);
   }
 
   /**
-   * Strip a `.gitmodules` stanza over `vault.adapter`, reusing the pure
-   * {@link stripGitmodulesEntry} text transform. No-op when `.gitmodules`
-   * is absent or has no matching stanza.
+   * Strip a `.gitmodules` stanza over `vault.adapter`, reusing the shared
+   * {@link stripGitmodulesEntry} text transform. No-op when `.gitmodules` is
+   * absent or has no matching stanza.
    */
   private async removeGitmodulesEntry(submodulePath: string): Promise<void> {
     if (!(await this.adapter.exists(GITMODULES))) return;
@@ -266,8 +239,8 @@ function parentDir(p: string): string {
 }
 
 /**
- * Convert a `Uint8Array` (possibly a view over a larger buffer, as nanotar
- * may emit) into a standalone `ArrayBuffer` for `DataAdapter.writeBinary`.
+ * Convert a `Uint8Array` (possibly a view over a larger buffer, as the tarball
+ * parser may emit) into a standalone `ArrayBuffer` for `DataAdapter.writeBinary`.
  */
 function toArrayBuffer(u8: Uint8Array): ArrayBuffer {
   return u8.buffer.slice(

--- a/scripts/test-ci-batched.sh
+++ b/scripts/test-ci-batched.sh
@@ -118,7 +118,12 @@ echo "📦 Running exocortex grounding + RFC regression tests..."
 # Audit epic #3384 H5 (2026-06-05): domain/models/GroundingFrontmatterParser.test
 # — gates the extracted pure raw-frontmatter→GroundingDefinition mapping (the
 # field-mapping the CLI BDD parser delegates to).
-EXOCORTEX_JEST_ARGS="--config packages/exocortex/jest.config.js --testPathPatterns=(services/(GroundingExecutor(\.[a-zA-Z0-9_-]+)?|AssetConversionService|NoteToRDFConverter\.(issue-2959|rfc-31c1a0be-grounding-ref|asset-filename|issue-3242-labelless-class)|ShapeRegistry|ShapeLoader)\.test|application/services/RelationColumnSetResolver(\.property)?\.test|performance/RelationColumnSetResolverPerformance\.test|infrastructure/sparql/executors/BGPExecutor\.issue-2997\.test|integration/dynamic-commands/(grounding-resolve-execute|grounding-phase3b-pipeline|grounding-type-vault-fixture-parity)\.test|domain/models/GroundingFrontmatterParser\.test)\.ts --forceExit"
+# Issue #3423 (2026-06-07): services/assetspace/AssetSpaceMount.test — gates the
+# shared mount/unmount core (fetch→wrapper→SHA→zip-slip→materialize + .gitmodules
+# transforms) that the plugin RestAssetSpaceMount + CLI BootstrapAssetSpaceService
+# both delegate to. Without it the core would rot silently (jest roots vs CI
+# allowlist gotcha — see packages/obsidian-plugin/CLAUDE.md "Test Suite Awareness").
+EXOCORTEX_JEST_ARGS="--config packages/exocortex/jest.config.js --testPathPatterns=(services/(GroundingExecutor(\.[a-zA-Z0-9_-]+)?|AssetConversionService|NoteToRDFConverter\.(issue-2959|rfc-31c1a0be-grounding-ref|asset-filename|issue-3242-labelless-class)|ShapeRegistry|ShapeLoader)\.test|services/assetspace/AssetSpaceMount\.test|application/services/RelationColumnSetResolver(\.property)?\.test|performance/RelationColumnSetResolverPerformance\.test|infrastructure/sparql/executors/BGPExecutor\.issue-2997\.test|integration/dynamic-commands/(grounding-resolve-execute|grounding-phase3b-pipeline|grounding-type-vault-fixture-parity)\.test|domain/models/GroundingFrontmatterParser\.test)\.ts --forceExit"
 if [ "$CI" = "true" ]; then
     if timeout 60 node ./node_modules/jest/bin/jest.js $EXOCORTEX_JEST_ARGS; then
         echo "✅ Exocortex grounding regression tests passed!"


### PR DESCRIPTION
## Summary

Option A (hexagonal core-extraction) deferred from #3416/#3421. Eliminates the **dual mount/unmount implementation** drift: the plugin `RestAssetSpaceMount` (Obsidian `DataAdapter` + `requestUrl`) and CLI `BootstrapAssetSpaceService` (Node `fs` + `fetch`) had byte-identical pure logic (wrapper discovery, SHA extraction, zip-slip, `.gitmodules` transforms) — the same `extractReference`-class drift caught in #3296.

Now there is **one** platform-agnostic core in `exocortex` (`services/assetspace/AssetSpaceMount.ts`) behind two ports:

- **`FileSystemPort`** — plugin injects an Obsidian `DataAdapter` (additive direct write); CLI injects Node `fs` (atomic stage+rename, refuse non-empty). The genuinely platform-specific write strategy stays in each adapter's `materialize`, **relocated verbatim** → zero behaviour change.
- **`HttpClient`** — plugin injects `requestUrl` + rate-limit gate; CLI injects Node `fetch` + 403/404 hint handling.

Both adapters become thin delegators. **Public APIs unchanged** → `FocusProfileSwitchManager`, `CliHardSwitchService`, `bootstrap`, `assetspace-add` are untouched. Follows the existing `restCreateCommit` shared-transport precedent.

## Invariants preserved (verified)

- TS-floor **R24** guard (never tear down exo/exocmd/shared-identities)
- `rmSync` **vault-root-escape** + unsafe-`submodulePath` guards
- PAT redaction, sym/hard-link rejection, atomic stage+rename, refuse-non-empty
- Plugin Phase-3 mount-state switch (#3409–#3414) + CLI hard-switch v16.70.0 behaviour

## Tests

- **New** core unit suite (16) — pipeline + pure helpers + revert-verify control (zero files written on a bad entry). Added to the CI exocortex allowlist (`scripts/test-ci-batched.sh`) so it doesn't rot silently.
- **New** cross-runtime mount parity (4) — CLI Node-`fs` adapter ≡ plugin-shape in-memory adapter materialise identical `{relPath→content}` + SHA + count on a shared fixture; `.gitmodules` append/strip byte-parity; unmount round-trip.
- All existing `RestAssetSpaceMount` (12) / `BootstrapAssetSpaceService` (42 incl. CliHardSwitch) / `FocusProfileSwitchManager` / `AssetSpaceManager` / `GitSubmoduleOps` / `TarExtractor` suites stay green (227 plugin + 106 CLI in the affected sweep). Typecheck 0 errors.

## Smoke (disposable only — never live vault)

- **CLI real-binary, TS-floor refuse**: `hard-switch <profile> --vault /vault-smoke` → R24 refusal (exit 5, correct floor UIDs), zero mutation.
- **CLI real-binary, real network materialize**: `assetspace-add --url https://github.com/kitelev/exoas-exo` into a throwaway vault → 191 files, sha `d5b294a`, `.gitmodules` written — real tarball fetch → wrapper → SHA → zip-slip → atomic stage+rename through the bundled core.
- **Plugin UI smoke** (Obsidian, hot-path) — handed to orchestrator (computer-control).

## Test plan

- [ ] CI 14 checks green
- [ ] code-reviewer (0 CRIT/HIGH; focus rmSync guards preservation)
- [ ] advisor round-2
- [ ] plugin UI smoke (orchestrator)
- [ ] manual squash merge (NO --auto — hot-path)

Closes #3423