### PR TITLE
docs(plugin): refresh stale testing conventions after starter-kit removal

### DIFF
--- a/packages/obsidian-plugin/CLAUDE.md
+++ b/packages/obsidian-plugin/CLAUDE.md
@@ -28,7 +28,7 @@ npx jest --config packages/obsidian-plugin/jest.config.js path/to/test.ts --runI
 | New Command             | Integration via CommandManager.test.ts      |
 
 ```bash
-npm run test:all   # MUST pass: unit + component + e2e + BDD ≥80%
+npm run test:all   # MUST pass: unit + component + e2e
 ```
 
 **Absolute prohibitions:**
@@ -39,27 +39,18 @@ npm run test:all   # MUST pass: unit + component + e2e + BDD ≥80%
 
 ---
 
-## Testing Conventions — RFC-CI-Tests L1/L2/L3 (Phase 4)
+## Test layers
 
-Starter-kit dynamic commands (`exocmd__Command`) are covered in three layers. New commands MUST add tests on every applicable layer before merge. Source of truth: `/Users/kitelev/Developer/rfc-ci-button-testing-2026-04-20.md` (RFC v5).
+New code MUST add tests on every applicable layer before merge.
 
-| Layer                | Runner                          | Location                                      | Purpose                                                                                                                                                                                                                                                                                    |
-| -------------------- | ------------------------------- | --------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| **L1 — Unit**        | Jest (ts-jest)                  | `packages/cli/tests/unit/**`                  | Helpers (`command-catalog`, `extract-target-class`, `predict-mutation`, `fixture-factory`, `user-input-factory`, `execute-command`) + per-command outcome assertions with mocked boundaries.                                                                                               |
-| **L2 — Integration** | Jest + real `GroundingExecutor` | `packages/cli/tests/integration/commands/**`  | Exercise dynamic commands end-to-end through `CommandResolver` / `PreconditionEvaluator` / `GroundingExecutor` against `packages/exoas-exocmd` fixtures. The legacy parametrized-catalogue + YAML contract gate was retired 2026-05-23 (replaced by RFC v2 byte-diff testing, `aaaa2dea`). |
-| **L3 — E2E**         | Playwright + Docker Obsidian    | `packages/obsidian-plugin/tests/e2e/specs/**` | Smoke subset (RFC §7.4.3) exercising the real plugin in Obsidian UI against fixture assets. Distributed across `e2e-shard-1..4`.                                                                                                                                                           |
+| Layer           | Runner                       | Location                                      | Purpose                                                                                                                   |
+| --------------- | ---------------------------- | --------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| **Unit**        | Jest (ts-jest)               | `packages/*/tests/unit/**`                    | Services, executors, command + visibility logic, helpers — mocked boundaries.                                            |
+| **Integration** | Jest + real services         | `packages/cli/tests/integration/**`           | End-to-end command flows through the real `GroundingExecutor` / adapters against fixtures (e.g. `packages/exoas-exocmd`). |
+| **Component**   | Playwright CT                | `packages/obsidian-plugin/tests/component/**` | React UI components in isolation.                                                                                         |
+| **E2E**         | Playwright + Docker Obsidian | `packages/obsidian-plugin/tests/e2e/specs/**` | Real plugin in Obsidian UI; golden-path smoke, sharded across `e2e-shard (1..6)`.                                        |
 
-**When to touch which layer:**
-
-- New helper → L1 unit test in `packages/cli/tests/unit/test-helpers/`.
-- New `exocmd__Command` or new grounding → L2 parametrized entry (+ contract invariants if structural) + L1 unit cases for any new dispatch branches.
-- New button flow users actually click → L3 smoke spec (or extend existing smoke spec) covering the golden path.
-
-**Required CI checks (branch-protected):** `test-unit`, `test-coverage`, `e2e-shard-1..4`, `archgate`, `test-component`, `typecheck`, `lint` (RFC v5 §8 Phase 4 amendment, 2026-04-21).
-
-**Rollback:** if a layer becomes destabilising (flaky >5%, budget overage, submodule friction), follow the per-trigger mitigation in `docs/history/ROLLBACK_RFC_CI_TESTS.md` before disabling a check.
-
-**Cross-project note (2026-04-21):** Phase 4 stability was established on top of Phase 3 EXIT (PR #2895) and benefited from the CI Speedup project (PR #2900 — `test-unit` ↔ `test-coverage` jest dedupe); both were counted toward the 5/5 pre-cutover green window.
+**Required CI checks (13, branch-protected):** `archgate`, `detect-changes`, `e2e-shard (1..6)`, `lint`, `parity-gate`, `test-component`, `test-coverage`, `typecheck`. Source of truth: `gh api repos/kitelev/exocortex/branches/main/protection/required_status_checks`.
 
 ---
 
@@ -103,9 +94,8 @@ packages/
 
 ## Quality Metrics
 
-- **Tests:** 803 unit + 8 component + 6 E2E = 817 total
+- **Tests:** unit (Jest) + component (Playwright CT) + E2E (Playwright/Docker). Run `npm run test:all` for live counts.
 - **Coverage:** ≥49% global, ≥78-80% domain layer
-- **BDD coverage:** ≥80%
 - **Build:** <2 min all packages
 - **Bundle:** ~206kb (React 171kb + Plugin 35kb)
 
@@ -139,5 +129,3 @@ See ../../PATTERNS.md for Docker E2E setup, debugging, and critical lessons.
 - `../../TROUBLESHOOTING.md` — Common issues and fixes
 - `ARCHITECTURE.md` — Detailed architecture docs
 - `docs/PROPERTY_SCHEMA.md` — Frontmatter vocabulary
-- `../../docs/history/ROLLBACK_RFC_CI_TESTS.md` — Per-trigger mitigation paths for RFC-CI-Tests suite
-- `/Users/kitelev/Developer/rfc-ci-button-testing-2026-04-20.md` — RFC v5 source of truth (starter-kit L1/L2/L3 coverage)


### PR DESCRIPTION
## Summary
Follow-up flagged in #3435. `packages/obsidian-plugin/CLAUDE.md`'s "Testing Conventions — RFC-CI-Tests L1/L2/L3" section documented the starter-kit dynamic-command test infrastructure **deleted in #3433** — the L1 helper files (`command-catalog`, `extract-target-class`, `predict-mutation`, `fixture-factory`, `user-input-factory`, `execute-command`) and the BDD grounding gate no longer exist, and the required-CI-check list was stale (`test-unit`, `e2e-shard-1..4`).

- Replaced the section with an accurate **Test layers** table: Unit (`packages/*/tests/unit/**`), Integration (`packages/cli/tests/integration/**` — the 2 surviving suites, against `exoas-exocmd`), Component (Playwright CT, `tests/component/**`), E2E (Playwright/Docker, `tests/e2e/specs/**`, `e2e-shard (1..6)`).
- Corrected **Required CI checks** to the current **13** (matches branch protection).
- Dropped the obsolete `BDD ≥80%` metric + the `# … BDD ≥80%` test:all comment.
- Removed dead **Key Resources** pointers to the retired RFC-CI-Tests rollback/RFC docs.

Verified against the actual tree (cli unit-test inventory, the `audit-co-location` + `hard-switch` integration suites, the existing `tests/component/` + `tests/e2e/specs/` dirs) — not assumed.

## Test plan
- [ ] CI green (single dev-doc change; no code/CI/schema)