### PR TITLE
test(e2e): focus-profile picker render smoke (#3434)

### DIFF
--- a/packages/obsidian-plugin/playwright-shard-assignments.json
+++ b/packages/obsidian-plugin/playwright-shard-assignments.json
@@ -17,7 +17,8 @@
       "brat-installation-compatibility.spec.ts",
       "exo-layout-smoke.spec.ts",
       "featured-binding-promotion.spec.ts",
-      "create-fleeting-note-palette.spec.ts"
+      "create-fleeting-note-palette.spec.ts",
+      "focus-profile-picker.spec.ts"
     ],
     [
       "area-tree-collapsible.spec.ts",
@@ -36,9 +37,9 @@
     "shard_1": 10432,
     "shard_2": 6922,
     "shard_3": 6894,
-    "shard_4": 5397,
+    "shard_4": 5745,
     "shard_5": 6341,
     "shard_6": 6113,
-    "max_minus_min_ms": 5035
+    "max_minus_min_ms": 4687
   }
 }

--- a/packages/obsidian-plugin/tests/e2e/specs/focus-profile-picker.spec.ts
+++ b/packages/obsidian-plugin/tests/e2e/specs/focus-profile-picker.spec.ts
@@ -19,9 +19,14 @@ import * as path from "path";
  *      (`FuzzySuggestModal`) and renders the **fixture FocusProfile assets by
  *      label** — i.e. NOT the «No FocusProfile assets found in vault» empty
  *      state.
- *   3. No `console.error` and no `pageerror` (uncaught exception) fire across
- *      load + picker open (empirically clean — local Docker run reports
- *      `loadPhaseConsoleErrors=0`).
+ *   3. No `pageerror` (uncaught exception) fires across load + picker open, and
+ *      no `console.error` fires during the trigger → modal-open window (the
+ *      focus-profile surface this spec owns). The load-phase `console.error`
+ *      count is logged as a diagnostic (observed 0 in local Docker) but NOT
+ *      hard-asserted — it would otherwise couple this spec to unrelated
+ *      load-path catch branches (e.g. hard-switch / SHACL wiring), per
+ *      code-reviewer MEDIUM. `create-fleeting-note-palette.spec.ts` omits the
+ *      console check entirely for the same reason; here it is kept but scoped.
  *
  * Why this is NOT vacuous (contrast with `create-fleeting-note-palette.spec.ts`):
  *   That sibling spec is intentionally lenient («plugin loads without
@@ -86,13 +91,24 @@ test.describe("Focus profile picker — render smoke", () => {
   });
 
   test("switch-focus-profile opens picker rendering fixture profiles", async () => {
+    // The in-test waits stack four 30s ceilings (plugin-wait,
+    // command-registration poll, discoverability poll) plus a 15s modal wait.
+    // Each resolves in <1s normally, but shard-4 has documented slow
+    // plugin-load incidents (Issue #3216) and the e2e config runs with
+    // retries: 0, so raise the per-test ceiling above the 60s default to keep
+    // a slow plugin-load from tripping a compounding-timeout flake
+    // (code-reviewer LOW).
+    test.setTimeout(120000);
+
     const window = await launcher.getWindow();
 
     // Drain any leftover startup notices before probing (mirrors the sibling
     // flake-mitigation in vault-commands-smoke / create-fleeting-note-palette).
     await launcher.waitForModalsToClose(10000);
 
-    // Plugin must be loaded before its commands are registered.
+    // Plugin must be loaded before its commands are registered. Uses the
+    // shared 30s default (PLUGIN_WAIT_TIMEOUT_MS_DEFAULT) — same budget all
+    // sibling e2e specs rely on; CI P99 plugin-load is ~11s.
     await waitForExocortexPluginViaPlaywright(window, {
       specName: "focus-profile-picker",
     });
@@ -194,18 +210,23 @@ test.describe("Focus profile picker — render smoke", () => {
       .getAttribute("placeholder");
     expect(placeholder).toBe("Switch focus profile");
 
-    // Zero console errors AND zero uncaught exceptions across load + open.
+    // Zero console errors during the picker surface (trigger → modal open) —
+    // scoped so unrelated load-path catch branches (hard-switch / SHACL wiring)
+    // cannot red this spec (code-reviewer MEDIUM).
+    const pickerConsoleErrors = consoleErrors.slice(loadPhaseConsoleErrors);
     expect(
-      consoleErrors,
-      `console errors during load + picker open: ${JSON.stringify(consoleErrors)}`,
+      pickerConsoleErrors,
+      `console errors during picker open: ${JSON.stringify(pickerConsoleErrors)}`,
     ).toEqual([]);
+    // Zero uncaught exceptions across the WHOLE session (load + open) — a
+    // pageerror is unambiguous and owned by no other subsystem.
     expect(
       pageErrors,
       `pageerrors during load + picker open: ${JSON.stringify(pageErrors)}`,
     ).toEqual([]);
 
-    // Diagnostic: surface the load-phase console-error count (subset of the
-    // assertion above) so the CI/revert-verify run shows the split.
+    // Diagnostic: surface the load-phase console-error count (not hard-asserted
+    // — see the file docstring). Observed 0 in local Docker.
     // eslint-disable-next-line no-console
     console.log(
       `[focus-profile-picker smoke] loadPhaseConsoleErrors=${loadPhaseConsoleErrors} items=${JSON.stringify(itemTexts)}`,

--- a/packages/obsidian-plugin/tests/e2e/specs/focus-profile-picker.spec.ts
+++ b/packages/obsidian-plugin/tests/e2e/specs/focus-profile-picker.spec.ts
@@ -1,0 +1,221 @@
+import { test, expect } from "@playwright/test";
+import type { ConsoleMessage } from "@playwright/test";
+import { ObsidianLauncher } from "../utils/obsidian-launcher";
+import { waitForExocortexPluginViaPlaywright } from "../utils/waitForExocortexPlugin";
+import * as path from "path";
+
+/**
+ * E2E render smoke for the «Exocortex: Switch focus profile» command
+ * (`switch-focus-profile`, wired in `ExocortexPlugin.registerFocusProfileCommands`).
+ *
+ * Closes the CI coverage gap surfaced during RFC v10 (exo-as-SDK) Phase 3.5
+ * closure — the picker was covered ONLY by unit tests
+ * (`FocusProfileSwitchManager.*`, `FocusProfileCommands.test.ts`); no e2e
+ * exercised it against a real Obsidian runtime. Tracking issue #3434.
+ *
+ * What this asserts (deliberately NON-vacuous — see below):
+ *   1. The plugin loads and the `switch-focus-profile` command is registered.
+ *   2. Executing the command opens the `ProfileFuzzyModal`
+ *      (`FuzzySuggestModal`) and renders the **fixture FocusProfile assets by
+ *      label** — i.e. NOT the «No FocusProfile assets found in vault» empty
+ *      state.
+ *   3. No `console.error` and no `pageerror` (uncaught exception) fire across
+ *      load + picker open (empirically clean — local Docker run reports
+ *      `loadPhaseConsoleErrors=0`).
+ *
+ * Why this is NOT vacuous (contrast with `create-fleeting-note-palette.spec.ts`):
+ *   That sibling spec is intentionally lenient («plugin loads without
+ *   throwing») because `ExocmdCommandPaletteRegistrar` resolves commands via
+ *   SPARQL, which expects the expanded `exocmd:Command` IRI while the test
+ *   vault uses symbolic `[[exocmd__Command]]` class wikilinks — a
+ *   fixture-resolution gap. The FocusProfile picker has NO such gap:
+ *   `VaultProfileResolver.listFocusProfileFiles` discovers profiles by a plain
+ *   substring match on the raw `exo__Instance_class` frontmatter string
+ *   (`instanceClassContains` → `c.includes(FOCUS_PROFILE_CLASS_UID)`), reading
+ *   straight from `metadataCache` — no triple-store IRI expansion. The
+ *   fixtures therefore carry the class in UUID form
+ *   (`[[3de846cd-1f0e-4f98-8613-b8587aa15174]]`) and the picker list is
+ *   asserted strictly by label.
+ *
+ * Fixtures (added in this PR):
+ *   - `focus-profiles/5326e715-…md` — "E2E Focus Profile Base"
+ *   - `focus-profiles/cb6a3c63-…md` — "E2E Focus Profile Work" (imports base)
+ *
+ * Revert-verify (documented in the PR body): removing the fixtures (or
+ * downgrading their class wikilink to symbolic form) makes `profileLister`
+ * return `[]`, so `invokeSwitchProfile` early-returns with the
+ * «No FocusProfile assets found» Notice and NEVER opens the modal — the
+ * `.suggestion-item` assertion then times out and this spec FAILS.
+ */
+
+const FOCUS_PROFILE_CLASS_UID = "3de846cd-1f0e-4f98-8613-b8587aa15174";
+const SWITCH_FOCUS_PROFILE_COMMAND_ID = "exocortex:switch-focus-profile";
+const FIXTURE_LABELS = [
+  "E2E Focus Profile Base",
+  "E2E Focus Profile Work",
+];
+
+test.describe("Focus profile picker — render smoke", () => {
+  let launcher: ObsidianLauncher;
+  const consoleErrors: string[] = [];
+  const pageErrors: string[] = [];
+
+  test.beforeAll(async () => {
+    const vaultPath = path.join(__dirname, "../test-vault");
+    launcher = new ObsidianLauncher(vaultPath);
+    await launcher.launch();
+
+    // Attach error listeners as early as the page exists (immediately after
+    // launch). Captures the post-load idle, the command trigger, and the
+    // modal-open phase. A boot crash would have prevented `launch()` from
+    // resolving (plugin / app would be absent), so load-phase fatal errors are
+    // additionally guarded by the plugin-loaded + command-registered asserts.
+    const window = await launcher.getWindow();
+    window.on("console", (msg: ConsoleMessage) => {
+      if (msg.type() === "error") consoleErrors.push(msg.text());
+    });
+    window.on("pageerror", (err: Error) => {
+      pageErrors.push(err.message);
+    });
+  });
+
+  test.afterAll(async () => {
+    if (launcher) {
+      await launcher.close();
+    }
+  });
+
+  test("switch-focus-profile opens picker rendering fixture profiles", async () => {
+    const window = await launcher.getWindow();
+
+    // Drain any leftover startup notices before probing (mirrors the sibling
+    // flake-mitigation in vault-commands-smoke / create-fleeting-note-palette).
+    await launcher.waitForModalsToClose(10000);
+
+    // Plugin must be loaded before its commands are registered.
+    await waitForExocortexPluginViaPlaywright(window, {
+      specName: "focus-profile-picker",
+    });
+
+    // The command is registered only after `registerFocusProfileCommands()`
+    // runs during onload. Poll for it so the spec does not race the boot
+    // pipeline. A missing command id here means a load-time regression.
+    await expect
+      .poll(
+        async () =>
+          window.evaluate((id) => {
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            const app = (window as any).app;
+            const commands = app?.commands?.commands ?? {};
+            return Object.prototype.hasOwnProperty.call(commands, id);
+          }, SWITCH_FOCUS_PROFILE_COMMAND_ID),
+        {
+          timeout: 30000,
+          message: `command ${SWITCH_FOCUS_PROFILE_COMMAND_ID} not registered`,
+        },
+      )
+      .toBe(true);
+
+    // Poll until metadataCache has the FocusProfile fixtures indexed the same
+    // way `VaultProfileResolver.instanceClassContains` discovers them — a
+    // substring match on the raw `exo__Instance_class` string. This makes the
+    // command trigger deterministic (Docker Obsidian populates the cache
+    // asynchronously after file load). Asserting >= 2 here proves the fixtures
+    // are discoverable BEFORE we open the picker.
+    await expect
+      .poll(
+        async () =>
+          window.evaluate((classUid) => {
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            const app = (window as any).app;
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            const files = app?.vault?.getMarkdownFiles?.() ?? [];
+            let count = 0;
+            for (const file of files) {
+              const cache = app.metadataCache.getFileCache(file);
+              const raw = cache?.frontmatter?.["exo__Instance_class"];
+              const classes = Array.isArray(raw) ? raw : raw ? [raw] : [];
+              if (
+                classes.some(
+                  (c: unknown) =>
+                    typeof c === "string" && c.includes(classUid),
+                )
+              ) {
+                count++;
+              }
+            }
+            return count;
+          }, FOCUS_PROFILE_CLASS_UID),
+        {
+          timeout: 30000,
+          message: "FocusProfile fixtures not discoverable in metadataCache",
+        },
+      )
+      .toBeGreaterThanOrEqual(2);
+
+    // Record the load-phase console-error count (everything captured between
+    // launch and the command trigger) for the diagnostic log below. The hard
+    // assertion further down covers the WHOLE session (load + open).
+    const loadPhaseConsoleErrors = consoleErrors.length;
+
+    // Trigger the command. The callback is fire-and-forget (`void
+    // invokeSwitchProfile()`): it lists profiles then opens ProfileFuzzyModal.
+    await window.evaluate((id) => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const app = (window as any).app;
+      app.commands.executeCommandById(id);
+    }, SWITCH_FOCUS_PROFILE_COMMAND_ID);
+
+    // The FuzzySuggestModal renders suggestions as `.suggestion-item` rows.
+    // If the picker had hit the empty-state path, no modal (and no suggestion
+    // items) would ever appear and this would time out → non-vacuous gate.
+    const suggestionItems = window.locator(".suggestion-item");
+    await expect(suggestionItems.first()).toBeVisible({ timeout: 15000 });
+
+    const itemTexts = await suggestionItems.allTextContents();
+    const joined = itemTexts.join(" | ");
+
+    // STRICT, non-vacuous assertions: both fixture profiles render by label.
+    for (const label of FIXTURE_LABELS) {
+      expect(
+        itemTexts.some((t) => t.includes(label)),
+        `picker must render profile "${label}". Rendered items: [${joined}]`,
+      ).toBe(true);
+    }
+
+    // The empty-state Notice text must never be a rendered suggestion.
+    expect(joined).not.toContain("No FocusProfile assets found");
+
+    // The picker placeholder confirms this is the focus-profile modal
+    // (set via ProfileFuzzyModal → setPlaceholder("Switch focus profile")).
+    const placeholder = await window
+      .locator(".prompt-input")
+      .first()
+      .getAttribute("placeholder");
+    expect(placeholder).toBe("Switch focus profile");
+
+    // Zero console errors AND zero uncaught exceptions across load + open.
+    expect(
+      consoleErrors,
+      `console errors during load + picker open: ${JSON.stringify(consoleErrors)}`,
+    ).toEqual([]);
+    expect(
+      pageErrors,
+      `pageerrors during load + picker open: ${JSON.stringify(pageErrors)}`,
+    ).toEqual([]);
+
+    // Diagnostic: surface the load-phase console-error count (subset of the
+    // assertion above) so the CI/revert-verify run shows the split.
+    // eslint-disable-next-line no-console
+    console.log(
+      `[focus-profile-picker smoke] loadPhaseConsoleErrors=${loadPhaseConsoleErrors} items=${JSON.stringify(itemTexts)}`,
+    );
+
+    // Render-only smoke — dismiss without selecting (no soft switch → no
+    // test-vault mutation, keeps the fixture-drift reporter quiet).
+    await window.keyboard.press("Escape");
+    await window
+      .waitForSelector(".suggestion-item", { state: "hidden", timeout: 5000 })
+      .catch(() => {});
+  });
+});

--- a/packages/obsidian-plugin/tests/e2e/specs/focus-profile-picker.spec.ts
+++ b/packages/obsidian-plugin/tests/e2e/specs/focus-profile-picker.spec.ts
@@ -91,13 +91,13 @@ test.describe("Focus profile picker — render smoke", () => {
   });
 
   test("switch-focus-profile opens picker rendering fixture profiles", async () => {
-    // The in-test waits stack four 30s ceilings (plugin-wait,
-    // command-registration poll, discoverability poll) plus a 15s modal wait.
-    // Each resolves in <1s normally, but shard-4 has documented slow
-    // plugin-load incidents (Issue #3216) and the e2e config runs with
-    // retries: 0, so raise the per-test ceiling above the 60s default to keep
-    // a slow plugin-load from tripping a compounding-timeout flake
-    // (code-reviewer LOW).
+    // The in-test waits stack three 30s ceilings (plugin-wait,
+    // command-registration poll, discoverability poll) plus a 10s modal-drain
+    // and a 15s modal-visible wait (~115s worst case). Each resolves in <1s
+    // normally, but shard-4 has documented slow plugin-load incidents
+    // (Issue #3216) and the e2e config runs with retries: 0, so raise the
+    // per-test ceiling above the 60s default to keep a slow plugin-load from
+    // tripping a compounding-timeout flake (code-reviewer LOW).
     test.setTimeout(120000);
 
     const window = await launcher.getWindow();

--- a/packages/obsidian-plugin/tests/e2e/test-vault/focus-profiles/5326e715-fe49-4d52-acaf-fd2fec329efe.md
+++ b/packages/obsidian-plugin/tests/e2e/test-vault/focus-profiles/5326e715-fe49-4d52-acaf-fd2fec329efe.md
@@ -1,0 +1,22 @@
+---
+exo__Asset_uid: 5326e715-fe49-4d52-acaf-fd2fec329efe
+exo__Asset_label: "E2E Focus Profile Base"
+exo__Asset_isDefinedBy: "[[!kitelev]]"
+exo__Instance_class:
+  - "[[3de846cd-1f0e-4f98-8613-b8587aa15174]]"
+exo__Profile_includes:
+  - "[[112b28f1-6197-4605-a181-6c9d86b841bf]]"
+aliases:
+  - "E2E Focus Profile Base"
+---
+
+# E2E Focus Profile Base
+
+E2E smoke fixture for the «Exocortex: Switch focus profile» picker
+(`switch-focus-profile`). Modelled on the production PoC `profile-base`
+(`vault-2025/.../shared-identities`).
+
+`exo__Instance_class` MUST carry the FocusProfile class UID in **UUID form**
+(`3de846cd-…`) — `VaultProfileResolver.instanceClassContains` matches the class
+via substring on the raw `exo__Instance_class` string, so a symbolic
+`[[exo__FocusProfile]]` wikilink would not be discovered.

--- a/packages/obsidian-plugin/tests/e2e/test-vault/focus-profiles/cb6a3c63-e320-4531-bb0b-3ac162374c60.md
+++ b/packages/obsidian-plugin/tests/e2e/test-vault/focus-profiles/cb6a3c63-e320-4531-bb0b-3ac162374c60.md
@@ -1,0 +1,22 @@
+---
+exo__Asset_uid: cb6a3c63-e320-4531-bb0b-3ac162374c60
+exo__Asset_label: "E2E Focus Profile Work"
+exo__Asset_isDefinedBy: "[[!kitelev]]"
+exo__Instance_class:
+  - "[[3de846cd-1f0e-4f98-8613-b8587aa15174]]"
+exo__Profile_imports:
+  - "[[5326e715-fe49-4d52-acaf-fd2fec329efe]]"
+exo__Profile_includes:
+  - "[[564778b6-1ad6-4dcf-88ad-0c98432d40ca]]"
+aliases:
+  - "E2E Focus Profile Work"
+---
+
+# E2E Focus Profile Work
+
+E2E smoke fixture for the «Exocortex: Switch focus profile» picker
+(`switch-focus-profile`). Modelled on the production PoC `profile-work`
+(imports `profile-base`).
+
+See the sibling `E2E Focus Profile Base` fixture for why `exo__Instance_class`
+uses the UUID-form class wikilink (`3de846cd-…`).


### PR DESCRIPTION
## Summary

Closes the CI coverage gap surfaced during RFC v10 (exo-as-SDK) Phase 3.5 closure: the «Exocortex: Switch focus profile» command (`switch-focus-profile`, wired in `ExocortexPlugin.registerFocusProfileCommands`) was covered **only by unit tests** (`FocusProfileSwitchManager.*`, `FocusProfileCommands.test.ts`) — no e2e exercised the picker against a real Obsidian runtime.

- New Playwright e2e spec `tests/e2e/specs/focus-profile-picker.spec.ts` — triggers the command and asserts the `ProfileFuzzyModal` (`FuzzySuggestModal`) renders the fixture FocusProfile assets **by label** (NOT the «No FocusProfile assets found» empty state), with zero console errors on the picker surface and zero uncaught exceptions across load + open.
- 2 UUID-named `exo__FocusProfile` fixtures in the e2e test-vault (`focus-profiles/`), modelled on the production PoC `profile-base` / `profile-work`.
- Spec assigned to e2e **shard 4** in `playwright-shard-assignments.json` (the drift validator `scripts/validate-shard-assignments.mjs` requires every spec assigned exactly once — ran it → green; load-balance improved: `max_minus_min_ms` 5035 → 4687).

Closes #3434.

## Why it is NOT vacuous (contrast with `create-fleeting-note-palette.spec.ts`)

The sibling palette spec is intentionally lenient because `ExocmdCommandPaletteRegistrar` resolves via SPARQL (expects the expanded `exocmd:Command` IRI) while the test-vault uses symbolic `[[exocmd__Command]]` wikilinks — a fixture-resolution gap. **FocusProfile discovery has no such gap**: `VaultProfileResolver.instanceClassContains` is a plain substring match (`c.includes(FOCUS_PROFILE_CLASS_UID)`) on the raw `exo__Instance_class` frontmatter read via `metadataCache` — no triple-store IRI expansion. The fixtures therefore use the **UUID-form** class wikilink `[[3de846cd-1f0e-4f98-8613-b8587aa15174]]` and the picker list is asserted strictly by label.

## Revert-verify (local Docker e2e)

Verified empirically against the Docker-Obsidian harness (`Dockerfile.e2e` on the cached CI base):

| State | Result |
|---|---|
| **With fixtures** (final variant) | **PASS** (10.5s) — `items=["E2E Focus Profile Base","E2E Focus Profile Work"]` logged from `.suggestion-item` text; `loadPhaseConsoleErrors=0`; fixture-drift 0/1 (render-only, Escape dismiss) |
| **Fixtures removed** | **FAIL** — discoverability poll `received 0` (plugin loaded fine in ~35ms), modal never opens → spec errors |

This proves the spec is coupled to the fixtures actually rendering in the picker — it cannot pass vacuously.

> Note: several local runs flaked at the `waitForExocortexPlugin` step (30s timeout) under QEMU amd64 emulation on a loaded machine; on a quiet machine the plugin registers in ~34ms. Confirmed **environmental** (bimodal 34ms vs >30s by machine contention), not a spec defect. Sibling e2e specs share the same 30s budget and pass in native CI.

## Review

- code-reviewer round-1: **APPROVE** (0 CRITICAL/HIGH; 1 MEDIUM + 2 LOW addressed).
- code-reviewer round-2 (after fixes): **APPROVE** (0 CRITICAL/HIGH/MEDIUM; 1 LOW comment-nit addressed).
- Fixes applied: scoped the console-error assertion to the trigger→modal-open window (so unrelated load-path `console.error` in hard-switch/SHACL catch branches can't red this `retries:0` spec; `pageError` check kept whole-session strict); `test.setTimeout(120000)` for compounding-timeout headroom.

## Test plan

- [ ] 14 required CI checks green — especially `e2e-shard (4)` (where this spec lives), `parity-gate` (shard-assignment validator), `archgate`, `typecheck`, `lint`.