### PR TITLE
refactor(profile): rename CLI Focus→Profile leaf symbols (Phase 5 T3-PR1)

### DIFF
--- a/packages/cli/src/commands/hard-switch.ts
+++ b/packages/cli/src/commands/hard-switch.ts
@@ -2,7 +2,7 @@ import { Command } from "commander";
 import { existsSync } from "fs";
 import { resolve } from "path";
 import type { IConfirmGate } from "exocortex";
-import { CliFocusProfileResolver } from "../services/CliFocusProfileResolver.js";
+import { CliProfileResolver } from "../services/CliProfileResolver.js";
 import {
   CliHardSwitchService,
   TsFloorViolationError,
@@ -39,9 +39,9 @@ export interface HardSwitchActionDeps {
   confirmGate?: IConfirmGate;
   /**
    * Override the resolver factory (test seam). Production omits and the
-   * action constructs `CliFocusProfileResolver` from CLI options.
+   * action constructs `CliProfileResolver` from CLI options.
    */
-  resolverFactory?: (opts: HardSwitchCommandOptions) => CliFocusProfileResolver;
+  resolverFactory?: (opts: HardSwitchCommandOptions) => CliProfileResolver;
   /**
    * Override the hard-switch service factory (test seam). Production omits and
    * the action constructs a `CliHardSwitchService` backed by a
@@ -117,7 +117,7 @@ export async function runHardSwitch(
   // for AssetSpace descriptor metadata (git URL + derived mount folder).
   const resolver =
     deps.resolverFactory?.(opts) ??
-    new CliFocusProfileResolver({
+    new CliProfileResolver({
       vaultPath,
       warn: (msg) => err(msg),
     });
@@ -126,7 +126,7 @@ export async function runHardSwitch(
   if (outcome.outcome === "missing-profile") {
     throw new InvalidArgumentsError(
       `Profile not found: ${profileUid}`,
-      "Run `exocortex find --class exo__FocusProfile` to list available profiles",
+      "Run `exocortex find --class exo__Profile` to list available profiles",
     );
   }
   if (outcome.outcome === "error") {
@@ -234,9 +234,9 @@ export async function runHardSwitch(
 export function hardSwitchCommand(): Command {
   const cmd = new Command("hard-switch")
     .description(
-      "Hard switch to specified FocusProfile (mount-state filesystem mutation). Requires --yes for headless mode.",
+      "Hard switch to specified Profile (mount-state filesystem mutation). Requires --yes for headless mode.",
     )
-    .argument("<profile-uid>", "Target FocusProfile UID")
+    .argument("<profile-uid>", "Target Profile UID")
     .requiredOption("--vault <path>", "Path to Obsidian vault")
     .option(
       "--yes",

--- a/packages/cli/src/services/CliHardSwitchService.ts
+++ b/packages/cli/src/services/CliHardSwitchService.ts
@@ -4,7 +4,7 @@
  * Turns the `hard-switch` scaffold into a real mount-state switch: tears down
  * AssetSpaces NOT in the target profile's effective set and materialises those
  * that ARE, via the GitHub REST tarball path (no `git` binary). Mirrors the
- * plugin's mount-state model (`FocusProfileSwitchManager.restSwitchProfile`):
+ * plugin's mount-state model (the profile-apply manager REST switch):
  *
  *   - "an AssetSpace is materialised iff its derived folder exists on disk"
  *     (`derivePath(_source)` → `assetspaces/<owner>/<repo>`)
@@ -36,10 +36,10 @@ import {
 
 import {
   ASSET_SPACE_CLASS_UID,
-  FOCUS_PROFILE_CLASS_UID,
+  PROFILE_CLASS_UID,
   parseWikilinkArray,
   type ResolveFilterResult,
-} from "./CliFocusProfileResolver.js";
+} from "./CliProfileResolver.js";
 import { BootstrapAssetSpaceService } from "./BootstrapAssetSpaceService.js";
 
 /**
@@ -145,7 +145,7 @@ export class CliHardSwitchService {
 
   /**
    * Single vault walk collecting AssetSpace descriptors (class match by UID,
-   * consistent with `CliFocusProfileResolver`) and FocusProfile labels. The
+   * consistent with `CliProfileResolver`) and Profile labels. The
    * descriptor's *location* is irrelevant to the mount folder — a registry-
    * hosted descriptor (e.g. `exoas-kitelev-registry`) still describes an
    * AssetSpace that mounts at `derivePath(_source)`, so the descriptor survives
@@ -219,7 +219,7 @@ export class CliHardSwitchService {
           infos.push({ uid, git, folderName, label });
         }
 
-        if (classes.includes(FOCUS_PROFILE_CLASS_UID)) {
+        if (classes.includes(PROFILE_CLASS_UID)) {
           const label = fm["exo__Asset_label"];
           if (typeof label === "string" && label.length > 0) {
             profileLabels.set(uid, label);

--- a/packages/cli/src/services/CliProfileResolver.ts
+++ b/packages/cli/src/services/CliProfileResolver.ts
@@ -1,6 +1,6 @@
 /**
- * CLI-side FocusProfile resolver — parity with plugin's
- * `FocusProfileSwitchManager.resolveEffectiveSet` + `FocusProfileOnloadWiring`
+ * CLI-side Profile resolver — parity with the plugin's profile-apply manager
+ * (effective-set resolution) + onload wiring
  * (Issue #3323, RFC 0a0791c1 Variant A MVP).
  *
  * Walks the vault filesystem to:
@@ -49,8 +49,8 @@ export const TS_FLOOR_ASSETSPACE_UIDS: ReadonlySet<string> =
 
 /** Class UID of `exo__AssetSpace` (TBox). Mirrors plugin's `AssetSpaceManager.ASSET_SPACE_CLASS_UID`. */
 export const ASSET_SPACE_CLASS_UID = "73bd00e4-ccc0-4f3f-b20d-c4388c4588fb";
-/** Class UID of `exo__FocusProfile` (TBox). Mirrors plugin's `FocusProfileSwitchManager.FOCUS_PROFILE_CLASS_UID`. */
-export const FOCUS_PROFILE_CLASS_UID = "3de846cd-1f0e-4f98-8613-b8587aa15174";
+/** Class UID of `exo__Profile` (TBox). Mirrors the plugin profile-apply manager PROFILE_CLASS_UID. */
+export const PROFILE_CLASS_UID = "3de846cd-1f0e-4f98-8613-b8587aa15174";
 
 /** Max `_extends` chain depth (matches plugin default). */
 const DEFAULT_MAX_EXTENDS_DEPTH = 5;
@@ -73,7 +73,7 @@ export type ResolveFilterOutcome =
   | { outcome: "degraded"; reason: string }
   | { outcome: "error"; reason: string };
 
-export interface CliFocusProfileResolverOptions {
+export interface CliProfileResolverOptions {
   /** Primary vault path. */
   vaultPath: string;
   /** Additional vault paths (mirrors CLI `--also`). */
@@ -99,16 +99,16 @@ interface ProfileFrontmatter {
 }
 
 /**
- * CLI-side FocusProfile resolver. Single-shot — instantiate, call
+ * CLI-side Profile resolver. Single-shot — instantiate, call
  * `resolveFilter(profileUid)`, discard. No internal mutable state to keep
  * concurrent CLI invocations safe.
  */
-export class CliFocusProfileResolver {
+export class CliProfileResolver {
   private readonly vaultPaths: ReadonlyArray<string>;
   private readonly maxExtendsDepth: number;
   private readonly warn: (msg: string) => void;
 
-  constructor(options: CliFocusProfileResolverOptions) {
+  constructor(options: CliProfileResolverOptions) {
     const also = options.alsoVaultPaths ?? [];
     this.vaultPaths = [options.vaultPath, ...also].map((p) => path.resolve(p));
     this.maxExtendsDepth = options.maxExtendsDepth ?? DEFAULT_MAX_EXTENDS_DEPTH;
@@ -142,7 +142,7 @@ export class CliFocusProfileResolver {
     try {
       scan = await this.scanAllVaults();
     } catch (e) {
-      const reason = `[CliFocusProfileResolver] vault scan threw — ${String(e)}`;
+      const reason = `[CliProfileResolver] vault scan threw — ${String(e)}`;
       this.warn(reason);
       return { outcome: "error", reason };
     }
@@ -150,7 +150,7 @@ export class CliFocusProfileResolver {
     const profile = scan.profiles.get(profileUid);
     if (profile === undefined) {
       this.warn(
-        `[CliFocusProfileResolver] profileUid=${profileUid} not found in any scanned vault — falling back to no-filter (full vault).`,
+        `[CliProfileResolver] profileUid=${profileUid} not found in any scanned vault — falling back to no-filter (full vault).`,
       );
       return { outcome: "missing-profile", profileUid };
     }
@@ -160,7 +160,7 @@ export class CliFocusProfileResolver {
     try {
       this.walkProfileChain(profileUid, scan.profiles, declared, new Set(), 0);
     } catch (e) {
-      const reason = `[CliFocusProfileResolver] profile chain walk threw — ${String(e)}`;
+      const reason = `[CliProfileResolver] profile chain walk threw — ${String(e)}`;
       this.warn(reason);
       return { outcome: "error", reason };
     }
@@ -193,7 +193,7 @@ export class CliFocusProfileResolver {
     );
     if (!hasOverlap) {
       const reason =
-        `[CliFocusProfileResolver] profileUid=${profileUid} produced effective set with zero AssetSpace folder overlap ` +
+        `[CliProfileResolver] profileUid=${profileUid} produced effective set with zero AssetSpace folder overlap ` +
         `(${effectiveAs.size} AS UIDs incl. floor; ${scan.folderMap.size} folders known). ` +
         `Likely cause: profile declares AssetSpace UIDs not present as descriptors, or vault has no scanned AssetSpaces. ` +
         `Falling back to no-filter (full vault indexed).`;
@@ -223,7 +223,7 @@ export class CliFocusProfileResolver {
   ): void {
     if (depth > this.maxExtendsDepth) {
       throw new Error(
-        `FocusProfile chain exceeds max depth ${this.maxExtendsDepth} at ${uid} — possible cycle`,
+        `Profile chain exceeds max depth ${this.maxExtendsDepth} at ${uid} — possible cycle`,
       );
     }
     if (visited.has(uid)) return; // cycle guard
@@ -252,7 +252,7 @@ export class CliFocusProfileResolver {
     for (const vaultRoot of this.vaultPaths) {
       if (!(await fs.pathExists(vaultRoot))) {
         this.warn(
-          `[CliFocusProfileResolver] vault path does not exist: ${vaultRoot} — skipping.`,
+          `[CliProfileResolver] vault path does not exist: ${vaultRoot} — skipping.`,
         );
         continue;
       }
@@ -272,7 +272,7 @@ export class CliFocusProfileResolver {
           }
         }
 
-        if (classes.some((c) => c === FOCUS_PROFILE_CLASS_UID)) {
+        if (classes.some((c) => c === PROFILE_CLASS_UID)) {
           const profile: ProfileFrontmatter = {
             uid: asset.uid,
             label: typeof asset.frontmatter["exo__Asset_label"] === "string"

--- a/packages/cli/tests/integration/commands/hard-switch.integration.test.ts
+++ b/packages/cli/tests/integration/commands/hard-switch.integration.test.ts
@@ -2,7 +2,7 @@
  * Integration tests for `exocortex hard-switch <profile-uid>` — the REAL
  * mount-state switch (Issue #3416, UI↔CLI parity).
  *
- * Uses a real on-disk fixture vault (matches `CliFocusProfileResolver`
+ * Uses a real on-disk fixture vault (matches `CliProfileResolver`
  * unit-test style) + the pure-logic seam `runHardSwitch` (returns a
  * `HardSwitchResult` rather than calling `process.exit`). Tear-down scenarios
  * need NO network (unmount is pure `fs`); the materialise scenario injects a
@@ -30,11 +30,11 @@ import type { HardSwitchPlan, IConfirmGate } from "exocortex";
 import { runHardSwitch, hardSwitchCommand } from "../../../src/commands/hard-switch.js";
 import {
   ASSET_SPACE_CLASS_UID,
-  FOCUS_PROFILE_CLASS_UID,
+  PROFILE_CLASS_UID,
   TS_FLOOR_AS_UID_EXO,
   TS_FLOOR_AS_UID_EXOCMD,
   TS_FLOOR_AS_UID_SHARED_IDENTITIES,
-} from "../../../src/services/CliFocusProfileResolver.js";
+} from "../../../src/services/CliProfileResolver.js";
 import { CliHardSwitchService } from "../../../src/services/CliHardSwitchService.js";
 import { BootstrapAssetSpaceService } from "../../../src/services/BootstrapAssetSpaceService.js";
 import { InvalidArgumentsError, VaultNotFoundError } from "../../../src/utils/errors/index.js";
@@ -99,7 +99,7 @@ function profile(
   return {
     exo__Asset_uid: uid,
     exo__Asset_label: label,
-    exo__Instance_class: [`[[${FOCUS_PROFILE_CLASS_UID}|exo__FocusProfile]]`],
+    exo__Instance_class: [`[[${PROFILE_CLASS_UID}|exo__Profile]]`],
     exo__Profile_includes: includes.map((u) => `[[${u}]]`),
   };
 }

--- a/packages/cli/tests/integration/rfc-01a83de8-cq-gate.integration.test.ts
+++ b/packages/cli/tests/integration/rfc-01a83de8-cq-gate.integration.test.ts
@@ -1,7 +1,7 @@
 /**
  * RFC `01a83de8` §5 (Competency Questions) + EV7 — STRICT-mode CQ gate.
  *
- * RFC 01a83de8 turns FocusProfile into a Maven-style Profile: `_includes` →
+ * RFC 01a83de8 makes the profile class Maven-style: `_includes` →
  * AssetSpace (direct lib) and `_imports` → Profile (BOM composition). The
  * effective classpath (CQ2) is the closure
  *   `_includes ∪ transitive(_imports*)`
@@ -56,7 +56,7 @@ import { FileSystemVaultAdapter } from "../../src/adapters/FileSystemVaultAdapte
 const AS_CLASS_UID = "73bd00e4-ccc0-4f3f-b20d-c4388c4588fb";
 /** Real TBox UID of `exo__Class` (metaclass — `exo__Instance_class` of the class defs). */
 const EXO_CLASS_METACLASS_UID = "8619c4fc-64f1-4869-b17e-e34186cacca9";
-/** Real TBox UID of `exo__Profile` (formerly `exo__FocusProfile`). */
+/** Real TBox UID of `exo__Profile`. */
 const PROFILE_CLASS_UID = "3de846cd-1f0e-4f98-8613-b8587aa15174";
 
 const AS_A_UID = "11111111-1111-4111-8111-111111111111";

--- a/packages/cli/tests/unit/CliHardSwitchService.test.ts
+++ b/packages/cli/tests/unit/CliHardSwitchService.test.ts
@@ -13,7 +13,7 @@ import {
   CliHardSwitchService,
   toHttpsGitHubUrl,
 } from "../../src/services/CliHardSwitchService";
-import { ASSET_SPACE_CLASS_UID } from "../../src/services/CliFocusProfileResolver";
+import { ASSET_SPACE_CLASS_UID } from "../../src/services/CliProfileResolver";
 
 describe("toHttpsGitHubUrl", () => {
   it("passes through canonical HTTPS form", () => {

--- a/packages/cli/tests/unit/services/CliProfileResolver.test.ts
+++ b/packages/cli/tests/unit/services/CliProfileResolver.test.ts
@@ -1,5 +1,5 @@
 /**
- * Unit tests for `CliFocusProfileResolver` (RFC 0a0791c1 Issue #3323).
+ * Unit tests for `CliProfileResolver` (RFC 0a0791c1 Issue #3323).
  *
  * Uses an on-disk temp vault for each test — exercises the real file walk,
  * yaml parse, and translation chain that production CLI hits. Faster and
@@ -14,15 +14,15 @@ import os from "os";
 import path from "path";
 
 import {
-  CliFocusProfileResolver,
+  CliProfileResolver,
   TS_FLOOR_AS_UID_EXO,
   TS_FLOOR_AS_UID_EXOCMD,
   TS_FLOOR_AS_UID_SHARED_IDENTITIES,
   ASSET_SPACE_CLASS_UID,
-  FOCUS_PROFILE_CLASS_UID,
+  PROFILE_CLASS_UID,
   parseWikilinkArray,
   extractUidFromWikilink,
-} from "../../../src/services/CliFocusProfileResolver.js";
+} from "../../../src/services/CliProfileResolver.js";
 
 /** Fixed UIDs the fixtures reuse — readable in test names. */
 const PROFILE_PERSONAL_UID = "11111111-1111-1111-1111-111111111111";
@@ -86,7 +86,7 @@ function asProfile(
 ): AssetSpec {
   const fm: Record<string, unknown> = {
     "exo__Asset_uid": uid,
-    "exo__Instance_class": [`[[${FOCUS_PROFILE_CLASS_UID}|exo__FocusProfile]]`],
+    "exo__Instance_class": [`[[${PROFILE_CLASS_UID}|exo__Profile]]`],
   };
   if (opts.label !== undefined) fm["exo__Asset_label"] = opts.label;
   // RFC 01a83de8 Phase 2 — _includes now AssetSpace UIDs; _extends → _imports.
@@ -102,7 +102,7 @@ function asProfile(
   };
 }
 
-describe("CliFocusProfileResolver", () => {
+describe("CliProfileResolver", () => {
   let tmpRoot: string;
 
   beforeEach(async () => {
@@ -119,19 +119,19 @@ describe("CliFocusProfileResolver", () => {
 
   describe("resolveFilter — outcome shapes", () => {
     it("returns no-profile when profileUid is null", async () => {
-      const resolver = new CliFocusProfileResolver({ vaultPath: tmpRoot });
+      const resolver = new CliProfileResolver({ vaultPath: tmpRoot });
       const out = await resolver.resolveFilter(null);
       expect(out.outcome).toBe("no-profile");
     });
 
     it("returns no-profile when profileUid is undefined", async () => {
-      const resolver = new CliFocusProfileResolver({ vaultPath: tmpRoot });
+      const resolver = new CliProfileResolver({ vaultPath: tmpRoot });
       const out = await resolver.resolveFilter(undefined);
       expect(out.outcome).toBe("no-profile");
     });
 
     it("returns no-profile when profileUid is empty string", async () => {
-      const resolver = new CliFocusProfileResolver({ vaultPath: tmpRoot });
+      const resolver = new CliProfileResolver({ vaultPath: tmpRoot });
       const out = await resolver.resolveFilter("");
       expect(out.outcome).toBe("no-profile");
     });
@@ -140,7 +140,7 @@ describe("CliFocusProfileResolver", () => {
       await makeVault(tmpRoot, [
         asAssetSpace(AS_EXO_UID, "exo"),
       ]);
-      const resolver = new CliFocusProfileResolver({ vaultPath: tmpRoot });
+      const resolver = new CliProfileResolver({ vaultPath: tmpRoot });
       const out = await resolver.resolveFilter("nonexistent-uid");
       expect(out.outcome).toBe("missing-profile");
       if (out.outcome === "missing-profile") {
@@ -157,7 +157,7 @@ describe("CliFocusProfileResolver", () => {
         asAssetSpace(AS_SHARED_UID, "shared-identities"),
         asProfile(PROFILE_BASE_UID, { label: "base" }),
       ]);
-      const resolver = new CliFocusProfileResolver({ vaultPath: tmpRoot });
+      const resolver = new CliProfileResolver({ vaultPath: tmpRoot });
       const out = await resolver.resolveFilter(PROFILE_BASE_UID);
       expect(out.outcome).toBe("engaged");
       if (out.outcome === "engaged") {
@@ -183,7 +183,7 @@ describe("CliFocusProfileResolver", () => {
           includes: [AS_EMS_UID],
         }),
       ]);
-      const resolver = new CliFocusProfileResolver({ vaultPath: tmpRoot });
+      const resolver = new CliProfileResolver({ vaultPath: tmpRoot });
       const out = await resolver.resolveFilter(PROFILE_PERSONAL_UID);
       expect(out.outcome).toBe("engaged");
       if (out.outcome === "engaged") {
@@ -211,7 +211,7 @@ describe("CliFocusProfileResolver", () => {
           includes: [AS_EMS_UID], // Profile points directly at AS UID
         }),
       ]);
-      const resolver = new CliFocusProfileResolver({ vaultPath: tmpRoot });
+      const resolver = new CliProfileResolver({ vaultPath: tmpRoot });
       const out = await resolver.resolveFilter(PROFILE_PERSONAL_UID);
       expect(out.outcome).toBe("engaged");
       if (out.outcome === "engaged") {
@@ -230,7 +230,7 @@ describe("CliFocusProfileResolver", () => {
           includes: [AS_EMS_UID, ONTOLOGY_KITELEV_UID],
         }),
       ]);
-      const resolver = new CliFocusProfileResolver({ vaultPath: tmpRoot });
+      const resolver = new CliProfileResolver({ vaultPath: tmpRoot });
       const out = await resolver.resolveFilter(PROFILE_PERSONAL_UID);
       expect(out.outcome).toBe("engaged");
       if (out.outcome === "engaged") {
@@ -257,7 +257,7 @@ describe("CliFocusProfileResolver", () => {
           extends_: PROFILE_BASE_UID,
         }),
       ]);
-      const resolver = new CliFocusProfileResolver({ vaultPath: tmpRoot });
+      const resolver = new CliProfileResolver({ vaultPath: tmpRoot });
       const out = await resolver.resolveFilter(PROFILE_PERSONAL_UID);
       expect(out.outcome).toBe("engaged");
       if (out.outcome === "engaged") {
@@ -277,7 +277,7 @@ describe("CliFocusProfileResolver", () => {
           includes: [AS_KITELEV_UID],
         }),
       ]);
-      const resolver = new CliFocusProfileResolver({ vaultPath: tmpRoot });
+      const resolver = new CliProfileResolver({ vaultPath: tmpRoot });
       const out = await resolver.resolveFilter(PROFILE_PERSONAL_UID);
       expect(out.outcome).toBe("engaged");
       if (out.outcome === "engaged") {
@@ -300,7 +300,7 @@ describe("CliFocusProfileResolver", () => {
           extends_: PROFILE_CYCLE_A_UID,
         }),
       ]);
-      const resolver = new CliFocusProfileResolver({ vaultPath: tmpRoot });
+      const resolver = new CliProfileResolver({ vaultPath: tmpRoot });
       const out = await resolver.resolveFilter(PROFILE_CYCLE_A_UID);
       // Either engaged with TS-floor only, or degraded — but must NOT hang and
       // must NOT throw.
@@ -326,7 +326,7 @@ describe("CliFocusProfileResolver", () => {
         );
       }
       await makeVault(tmpRoot, assets);
-      const resolver = new CliFocusProfileResolver({
+      const resolver = new CliProfileResolver({
         vaultPath: tmpRoot,
         maxExtendsDepth: 5,
       });
@@ -346,7 +346,7 @@ describe("CliFocusProfileResolver", () => {
           includes: ["some-random-ontology-uid"],
         }),
       ]);
-      const resolver = new CliFocusProfileResolver({ vaultPath: tmpRoot });
+      const resolver = new CliProfileResolver({ vaultPath: tmpRoot });
       const out = await resolver.resolveFilter(PROFILE_PERSONAL_UID);
       expect(out.outcome).toBe("degraded");
       if (out.outcome === "degraded") {
@@ -366,7 +366,7 @@ describe("CliFocusProfileResolver", () => {
           includes: [AS_EMS_UID],
         }),
       ]);
-      const resolver = new CliFocusProfileResolver({ vaultPath: tmpRoot });
+      const resolver = new CliProfileResolver({ vaultPath: tmpRoot });
       const out = await resolver.resolveFilter(PROFILE_PERSONAL_UID);
       expect(out.outcome).toBe("engaged");
       if (out.outcome === "engaged") {
@@ -399,7 +399,7 @@ describe("CliFocusProfileResolver", () => {
             includes: [AS_EMS_UID],
           }),
         ]);
-        const resolver = new CliFocusProfileResolver({
+        const resolver = new CliProfileResolver({
           vaultPath: tmpRoot,
           alsoVaultPaths: [secondaryRoot],
         });
@@ -422,7 +422,7 @@ describe("CliFocusProfileResolver", () => {
         asProfile(PROFILE_BASE_UID),
       ]);
       const warnings: string[] = [];
-      const resolver = new CliFocusProfileResolver({
+      const resolver = new CliProfileResolver({
         vaultPath: tmpRoot,
         alsoVaultPaths: ["/tmp/this-path-definitely-does-not-exist-test"],
         warn: (m) => warnings.push(m),
@@ -448,7 +448,7 @@ describe("CliFocusProfileResolver", () => {
         "# scratch\n\nnothing structured here\n",
         "utf-8",
       );
-      const resolver = new CliFocusProfileResolver({ vaultPath: tmpRoot });
+      const resolver = new CliProfileResolver({ vaultPath: tmpRoot });
       const out = await resolver.resolveFilter(PROFILE_BASE_UID);
       expect(out.outcome).toBe("engaged");
     });
@@ -467,7 +467,7 @@ describe("CliFocusProfileResolver", () => {
         "---\nthis is: \"not: valid:\n  yaml here\n---\n",
         "utf-8",
       );
-      const resolver = new CliFocusProfileResolver({ vaultPath: tmpRoot });
+      const resolver = new CliProfileResolver({ vaultPath: tmpRoot });
       const out = await resolver.resolveFilter(PROFILE_BASE_UID);
       expect(out.outcome).toBe("engaged");
     });
@@ -484,10 +484,10 @@ describe("CliFocusProfileResolver", () => {
       await fs.ensureDir(path.join(tmpRoot, ".obsidian"));
       await fs.writeFile(
         path.join(tmpRoot, ".obsidian", `${stowawayUid}.md`),
-        `---\nexo__Asset_uid: "${stowawayUid}"\nexo__Instance_class:\n  - "[[${FOCUS_PROFILE_CLASS_UID}|exo__FocusProfile]]"\n---\n`,
+        `---\nexo__Asset_uid: "${stowawayUid}"\nexo__Instance_class:\n  - "[[${PROFILE_CLASS_UID}|exo__Profile]]"\n---\n`,
         "utf-8",
       );
-      const resolver = new CliFocusProfileResolver({ vaultPath: tmpRoot });
+      const resolver = new CliProfileResolver({ vaultPath: tmpRoot });
       const out = await resolver.resolveFilter(stowawayUid);
       expect(out.outcome).toBe("missing-profile");
     });

--- a/packages/exocortex/src/domain/profile/TsFloorGuard.ts
+++ b/packages/exocortex/src/domain/profile/TsFloorGuard.ts
@@ -15,7 +15,7 @@
  *
  * EV8 mandate: this is the ONE named guard all profile-switch sites (plugin
  * {@link FocusProfileSwitchManager}, CLI {@link CliHardSwitchService} +
- * {@link CliFocusProfileResolver}) delegate to. The previous copy-pasted inline
+ * {@link CliProfileResolver}) delegate to. The previous copy-pasted inline
  * guards drifted independently; consolidating here removes that drift surface.
  */
 

--- a/packages/exocortex/src/index.ts
+++ b/packages/exocortex/src/index.ts
@@ -537,7 +537,7 @@ export {
   type DaemonResponse,
 } from "./services/ValidatorDaemon";
 
-// FocusProfile hard switch confirmation contract (RFC 22b50a17 Phase 1b)
+// Profile hard switch confirmation contract (RFC 22b50a17 Phase 1b)
 export type {
   IConfirmGate,
   HardSwitchPlan,


### PR DESCRIPTION
## Summary
PR **1 of 4** in the Phase 5 T3 symbol-rename sequence (RFC 0a0791c1). Mechanical, **zero-behavior-change** rename of the CLI-leaf `Focus`/`Knowledge`-named profile symbols → `Profile*`. No logic touched.

Cluster (CLI + core leaf, no plugin dependency):
- `CliFocusProfileResolver` → `CliProfileResolver` (class + `…Options` interface + file rename, src & test)
- `FOCUS_PROFILE_CLASS_UID` → `PROFILE_CLASS_UID` (CLI copy + its 2 usages)
- user-facing help/description strings: `exo__FocusProfile` → `exo__Profile`
- `TsFloorGuard` JSDoc `{@link CliFocusProfileResolver}` → `{@link CliProfileResolver}`

## Why this is zero-behavior-change
- The vault TBox class **was already renamed** to `exo__Profile` upstream (UID `3de846cd-…`, verified in both vaults). CLI runtime resolution keys on the **UID constant**, not the `exo__Profile` string — only help-text wording changes.
- `FOCUS_PROFILE_CLASS_UID` (UPPER_SNAKE) is not even a gate-grep hit; renamed for cross-package consistency with the plugin copy (PR2).
- Some prose comments that referenced plugin symbols renamed in later PRs were reworded to generic phrasing (no forward-dangling symbol names).

## Verification
- `npm run check:types` (CI typecheck gate) — green
- 54 CLI tests pass (`CliProfileResolver`, `CliHardSwitchService`, `hard-switch.integration`, `rfc-01a83de8-cq-gate`)
- `packages/cli` is fully gate-clean (`git grep -E "FocusProfile|KnowledgeProfile" packages/cli` → 0)

## Sequence
PR1 (this) → PR2 (manager hub) → PR3 (commands/pickers/settings) → PR4 (wiring/onload/storage/e2e). Final gate-grep = 0 asserted after PR4. Command id `hard-switch-focus-profile` (plugin) is intentionally preserved (hotkey compat) and is out of the CamelCase gate.

## Test plan
- [ ] CI: 14 required checks green (typecheck, lint, test-bdd, e2e-shard 1..6, test-component, test-coverage, archgate, parity-gate, detect-changes)