### PR TITLE
refactor(profile): rename manager hub Focus/Knowledge→Profile (Phase 5 T3-PR2)

### DIFF
--- a/packages/exocortex/src/domain/profile/TsFloorGuard.ts
+++ b/packages/exocortex/src/domain/profile/TsFloorGuard.ts
@@ -14,7 +14,7 @@
  *     that the plugin renders; tearing it down would self-brick the UI.
  *
  * EV8 mandate: this is the ONE named guard all profile-switch sites (plugin
- * {@link FocusProfileSwitchManager}, CLI {@link CliHardSwitchService} +
+ * {@link ProfileApplyManager}, CLI {@link CliHardSwitchService} +
  * {@link CliProfileResolver}) delegate to. The previous copy-pasted inline
  * guards drifted independently; consolidating here removes that drift surface.
  */

--- a/packages/obsidian-plugin/src/ExocortexPlugin.ts
+++ b/packages/obsidian-plugin/src/ExocortexPlugin.ts
@@ -95,7 +95,7 @@ import {
   type FocusProfileChoice,
   type IAssetSpacePusher,
 } from "./infrastructure/adapters/FocusProfileCommands";
-import { FocusProfileSwitchManager } from "./infrastructure/adapters/FocusProfileSwitchManager";
+import { ProfileApplyManager } from "./infrastructure/adapters/ProfileApplyManager";
 import { PluginLockManager } from "./infrastructure/adapters/PluginLockManager";
 import { VaultProfileResolver } from "./infrastructure/adapters/VaultProfileResolver";
 import { PluginRdfIndexerAdapter } from "./infrastructure/adapters/PluginRdfIndexerAdapter";
@@ -235,13 +235,13 @@ export default class ExocortexPlugin extends Plugin {
   private eagerInitPromise: Promise<void> | null = null;
 
   /**
-   * Issue #3320 — FocusProfileSwitchManager hoisted onto the plugin instance
+   * Issue #3320 — ProfileApplyManager hoisted onto the plugin instance
    * so onload recovery / reconcile reuse the single manager без re-constructing
    * a second one (which would race the original on the same persisted lock
    * file). Initialized in `registerFocusProfileCommands()`; null until that
    * call succeeds.
    */
-  public focusProfileSwitchManager: FocusProfileSwitchManager | null = null;
+  public profileApplyManager: ProfileApplyManager | null = null;
 
   /**
    * Issue #3320 — profile choice lister hoisted alongside the switch
@@ -1008,7 +1008,7 @@ export default class ExocortexPlugin extends Plugin {
           // clears+rebuilds the store from frontmatter), re-inject the
           // runtime-derived `exo:AssetSpace_materialized` triples via
           // `refreshAndInjectAssetSpaceMaterialization`. Soft- and hard-
-          // switch paths via `FocusProfileSwitchManager` are covered by
+          // switch paths via `ProfileApplyManager` are covered by
           // `PluginRdfIndexerAdapter.onAfterRefresh`; these onload chain
           // callsites use `sparql.refresh()` directly which bypasses the
           // adapter, so they call the helper explicitly.
@@ -2389,7 +2389,7 @@ export default class ExocortexPlugin extends Plugin {
    * («Switch focus profile», «Push current assetspace»). Wires the B.7
    * `FocusProfileCommands` handler with real adapters:
    *
-   *   - B.4 `FocusProfileSwitchManager`: persisted lock + journal + RDF
+   *   - B.4 `ProfileApplyManager`: persisted lock + journal + RDF
    *     re-index с effective ontology filter.
    *   - B.3 `AssetSpaceManager`: GitHub PAT-backed AssetSpace push (only
    *     constructed when PAT is configured in `data.local.json`; absent
@@ -2413,7 +2413,7 @@ export default class ExocortexPlugin extends Plugin {
    *  - `metadataCache.resolved` chain (initial cold-start + active-
    *    FocusProfile re-apply path),
    *  - `PluginRdfIndexerAdapter.onAfterRefresh` so soft- and hard-
-   *    switch paths via `FocusProfileSwitchManager` re-inject
+   *    switch paths via `ProfileApplyManager` re-inject
    *    automatically.
    *
    * Best-effort: tracker / injection failures are logged warn but do
@@ -2446,7 +2446,7 @@ export default class ExocortexPlugin extends Plugin {
     const resolver = new VaultProfileResolver(this.app);
     // RFC 22b50a17 Phase 4 (H1 cascade catch — advisor round-2) — wire
     // `refreshAndInjectAssetSpaceMaterialization` as the post-refresh
-    // hook so soft- + hard-switch paths via `FocusProfileSwitchManager`
+    // hook so soft- + hard-switch paths via `ProfileApplyManager`
     // re-inject `exo:AssetSpace_materialized` triples automatically after
     // every `rdfIndexer.refresh()`. Without this, profile switching
     // would silently drop the runtime-derived materialization triples
@@ -2536,7 +2536,7 @@ export default class ExocortexPlugin extends Plugin {
 
     // RFC 01a83de8 Phase 3 T2 — cross-platform (incl. iOS) REST/tarball mount.
     // Built on BOTH platforms: the mobile profile-switch path consumes it
-    // (`FocusProfileSwitchManager.restSwitchProfile`), and it's harmless on
+    // (`ProfileApplyManager.restSwitchProfile`), and it's harmless on
     // desktop (the desktop hard switch keeps the git-binary path). Best-effort
     // — a wiring failure logs + leaves restMount null (mobile switch then
     // surfaces a clear "not wired" error instead of crashing onload).
@@ -2554,7 +2554,7 @@ export default class ExocortexPlugin extends Plugin {
     const confirmGate =
       hardSwitchDeps?.confirmGate ?? new ModalConfirmGate(this.app);
 
-    const switchMgr = new FocusProfileSwitchManager({
+    const switchMgr = new ProfileApplyManager({
       app: this.app,
       lockMgr,
       resolver,
@@ -2577,10 +2577,10 @@ export default class ExocortexPlugin extends Plugin {
     // Issue #3320 — expose the manager на plugin instance so onload recovery /
     // reconcile reuse it. Re-constructing a second manager would race the
     // original on the same lock file.
-    this.focusProfileSwitchManager = switchMgr;
+    this.profileApplyManager = switchMgr;
 
     // Crash-recovery: если previous session left `_switchInProgress=true`
-    // в settings (FocusProfileSwitchManager docstring line 18), re-trigger
+    // в settings (ProfileApplyManager docstring line 18), re-trigger
     // the idempotent re-index so the flag self-clears. Failure swallowed —
     // user-facing recovery is а Phase D follow-up; the only side-effect
     // of skipping this is the «stuck switch in progress» footgun (code-
@@ -2739,7 +2739,7 @@ export default class ExocortexPlugin extends Plugin {
     // so any hotkey a user already bound survives the rename (Obsidian persists
     // hotkeys by command id). Only the user-facing name changes.
     // Register on desktop (git-binary hard switch) OR mobile when the REST
-    // mount is wired (FocusProfileSwitchManager dispatches to restSwitchProfile
+    // mount is wired (ProfileApplyManager dispatches to restSwitchProfile
     // on mobile). Without either, the filesystem materialisation can't run, so
     // the command stays hidden.
     if (hardSwitchDeps !== null || (Platform.isMobile && restMount !== null)) {

--- a/packages/obsidian-plugin/src/application/api/SPARQLApi.ts
+++ b/packages/obsidian-plugin/src/application/api/SPARQLApi.ts
@@ -336,7 +336,7 @@ export class SPARQLApi {
    * Returns an application-layer handle to the underlying RDF indexer.
    * Exposed for RFC 0a0791c1 B.4 wiring — `PluginRdfIndexerAdapter`
    * (Issue #3322) constructs an `IRdfIndexer` over this handle so
-   * `FocusProfileSwitchManager` can trigger a profile-switch reindex via
+   * `ProfileApplyManager` can trigger a profile-switch reindex via
    * `refresh()`. RFC 01a83de8 Phase 3 removed the query-time soft-filter;
    * profile switching is mount-state based, so the handle exposes only
    * `refresh()`.

--- a/packages/obsidian-plugin/src/application/services/SPARQLQueryService.ts
+++ b/packages/obsidian-plugin/src/application/services/SPARQLQueryService.ts
@@ -195,7 +195,7 @@ export class SPARQLQueryService {
 
   /**
    * Returns the underlying `VaultRDFIndexer`. Exposed to support B.4
-   * `FocusProfileSwitchManager` wiring (RFC 0a0791c1 #3322) — the
+   * `ProfileApplyManager` wiring (RFC 0a0791c1 #3322) — the
    * SwitchManager's `IRdfIndexer.refresh()` contract triggers a profile-switch
    * reindex via `VaultRDFIndexer.refresh()`. RFC 01a83de8 Phase 3 removed the
    * query-time soft-filter; profile switching is mount-state based. The adapter

--- a/packages/obsidian-plugin/src/infrastructure/VaultRDFIndexer.ts
+++ b/packages/obsidian-plugin/src/infrastructure/VaultRDFIndexer.ts
@@ -246,7 +246,7 @@ export class VaultRDFIndexer {
    * Clear the triple store and rebuild from the current vault state.
    *
    * Signature matches {@link IRdfIndexer.refresh} so a
-   * `FocusProfileSwitchManager` instance can drive a profile-switch reindex
+   * `ProfileApplyManager` instance can drive a profile-switch reindex
    * by calling `await rdfIndexer.refresh()` directly. Profile switching is
    * now mount-state based (RFC 01a83de8 Phase 3 — the query-time soft-filter
    * was removed); the refresh re-indexes whatever AssetSpace folders are

--- a/packages/obsidian-plugin/src/infrastructure/adapters/AssetSpaceManager.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/AssetSpaceManager.ts
@@ -142,7 +142,7 @@ export class AssetSpaceManager {
   private readonly branch: string;
   private readonly tarExtractor: TarExtractor;
   /**
-   * Public read-only accessor — `FocusProfileSwitchManager.hardSwitchProfile`
+   * Public read-only accessor — `ProfileApplyManager.hardSwitchProfile`
    * (RFC 22b50a17 Phase 3) needs to release staging dirs on partial-fail
    * cleanup (R26). Stays nullable to preserve `pullAssetSpace`'s explicit
    * throw on `null` from Phase 1.

--- a/packages/obsidian-plugin/src/infrastructure/adapters/FocusProfileCommands.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/FocusProfileCommands.ts
@@ -7,7 +7,7 @@
  *
  * Commands provided:
  *   1. `Exocortex: Apply profile` — fuzzy-picks an `exo__Profile` asset,
- *      invokes `FocusProfileSwitchManager.hardSwitchKnowledgeProfile` (the
+ *      invokes `ProfileApplyManager.applyProfile` (the
  *      mount-state strict-replace: materialise the profile's effective
  *      AssetSpace set, unmount the rest — TS-floor never unmounted).
  *   2. `Exocortex: Show current state` — Notice with the active profile label.
@@ -29,12 +29,12 @@
  * happens в B.11 plugin entry-point integration.
  */
 
-import type { FocusProfileSwitchManager } from "./FocusProfileSwitchManager";
+import type { ProfileApplyManager } from "./ProfileApplyManager";
 import {
   HardSwitchAbortedByUser,
   TsFloorViolationError,
   UncommittedChangesAbortError,
-} from "./FocusProfileSwitchManager";
+} from "./ProfileApplyManager";
 
 /** Minimal interface — full implementation in B.3 AssetSpaceManager. */
 export interface IAssetSpacePusher {
@@ -55,7 +55,7 @@ export interface FocusProfileChoice {
 }
 
 export interface FocusProfileCommandsDeps {
-  switchMgr: FocusProfileSwitchManager;
+  switchMgr: ProfileApplyManager;
   pushMgr: IAssetSpacePusher;
   /** Returns available `exo__Profile` assets (label + uid pairs) — the picker. */
   profileLister: () => Promise<FocusProfileChoice[]>;
@@ -80,7 +80,7 @@ export interface FocusProfileCommandsDeps {
 }
 
 export class FocusProfileCommands {
-  private readonly switchMgr: FocusProfileSwitchManager;
+  private readonly switchMgr: ProfileApplyManager;
   private readonly pushMgr: IAssetSpacePusher;
   private readonly profileLister: () => Promise<FocusProfileChoice[]>;
   private readonly fuzzyPick: FocusProfileCommandsDeps["fuzzyPick"];
@@ -104,7 +104,7 @@ export class FocusProfileCommands {
    * profile» (mount) commands into a single mount-state operation).
    *
    * Fuzzy-picks an `exo__Profile` asset, then invokes
-   * `FocusProfileSwitchManager.hardSwitchKnowledgeProfile` which:
+   * `ProfileApplyManager.applyProfile` which:
    *   1. R24 TS-floor assert (refuses targets that brick the plugin)
    *   2. Vision Lock #5 uncommitted abort (with file list)
    *   3. ModalConfirmGate (DI via switchMgr constructor)
@@ -133,7 +133,7 @@ export class FocusProfileCommands {
 
     this.notify(`Applying ${chosen.label}…`);
     try {
-      await this.switchMgr.hardSwitchKnowledgeProfile(chosen.uid);
+      await this.switchMgr.applyProfile(chosen.uid);
     } catch (e) {
       if (e instanceof HardSwitchAbortedByUser) {
         this.notify("Apply profile cancelled.");

--- a/packages/obsidian-plugin/src/infrastructure/adapters/FocusProfileOnloadWiring.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/FocusProfileOnloadWiring.ts
@@ -1,7 +1,7 @@
 /**
  * TS-floor AssetSpace UIDs (Vision Lock #17) — the AssetSpaces that are ALWAYS
  * part of any profile's effective set, regardless of profile config. The
- * mount-state hard/REST switch (`FocusProfileSwitchManager`) injects these so
+ * mount-state hard/REST switch (`ProfileApplyManager`) injects these so
  * the plugin's own TBox foundations can never be torn down by a profile that
  * omits them.
  *

--- a/packages/obsidian-plugin/src/infrastructure/adapters/GitSubmoduleOps.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/GitSubmoduleOps.ts
@@ -11,7 +11,7 @@ const execFile = promisify(execFileCb);
 
 /**
  * GitSubmoduleOps — security-hardened wrapper for the git subprocess calls
- * needed by `FocusProfileSwitchManager.hardSwitchProfile` per RFC 22b50a17
+ * needed by `ProfileApplyManager.hardSwitchProfile` per RFC 22b50a17
  * §Solution Architecture lines 127-137.
  *
  * Operations covered:

--- a/packages/obsidian-plugin/src/infrastructure/adapters/HardSwitchDepsFactory.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/HardSwitchDepsFactory.ts
@@ -16,7 +16,7 @@ import type { PluginLocalDataStore } from "./PluginLocalDataStore";
 
 /**
  * Desktop-only hard-switch dependency bundle consumed by
- * `FocusProfileSwitchManager` + the gated palette commands (hard
+ * `ProfileApplyManager` + the gated palette commands (hard
  * «Switch knowledge profile», «Bootstrap vault», «Add AssetSpace by URL»).
  *
  * When this is `null` the gated commands are NOT registered — so a wiring

--- a/packages/obsidian-plugin/src/infrastructure/adapters/OperationsLogReader.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/OperationsLogReader.ts
@@ -1,13 +1,13 @@
 import type { App } from "obsidian";
 
-import type { SwitchJournalEntry } from "./FocusProfileSwitchManager";
+import type { SwitchJournalEntry } from "./ProfileApplyManager";
 
 /**
  * OperationsLogReader — formats the B.4 switch journal для UI display
  * (RFC 0a0791c1 §B.8 Section 4 «Operations log»).
  *
  * Source data: \`.exocortex/switch-journal.jsonl\` (one JSON entry per line)
- * written by \`FocusProfileSwitchManager\` (B.4).
+ * written by \`ProfileApplyManager\` (B.4).
  *
  * UI requirement (Architect #11 / RFC §B.8 Section 4):
  *   «Last 10 switches displayed as `<timestamp> | <profile-label> | <elapsedMs>ms | <status>`»

--- a/packages/obsidian-plugin/src/infrastructure/adapters/PluginRdfIndexerAdapter.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/PluginRdfIndexerAdapter.ts
@@ -1,9 +1,9 @@
-import type { IRdfIndexer } from "./FocusProfileSwitchManager";
+import type { IRdfIndexer } from "./ProfileApplyManager";
 import type { IRdfIndexerHandle } from "@plugin/application/api/SPARQLApi";
 
 /**
  * `IRdfIndexer` adapter wrapping the plugin's live `VaultRDFIndexer`.
- * The B.4 `FocusProfileSwitchManager` calls `refresh()` after persisting
+ * The B.4 `ProfileApplyManager` calls `refresh()` after persisting
  * `activeProfileUid`; this adapter forwards to the indexer's `refresh()`
  * path so the existing cold-start pipeline runs identically.
  *
@@ -25,7 +25,7 @@ export class PluginRdfIndexerAdapter implements IRdfIndexer {
    *
    * The plugin wires this to a closure that re-runs the AssetSpace
    * materialization injection. Soft+hard switch paths via
-   * `FocusProfileSwitchManager` use this adapter, so the hook fires
+   * `ProfileApplyManager` use this adapter, so the hook fires
    * automatically without each switch callsite knowing about the
    * derived-triple discipline.
    *

--- a/packages/obsidian-plugin/src/infrastructure/adapters/PluginSettingsStoreAdapter.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/PluginSettingsStoreAdapter.ts
@@ -1,7 +1,7 @@
 import type {
   ISettingsStore,
   SwitchSettings,
-} from "./FocusProfileSwitchManager";
+} from "./ProfileApplyManager";
 import type { PluginLocalDataStore } from "./PluginLocalDataStore";
 
 /**
@@ -21,7 +21,7 @@ import type { PluginLocalDataStore } from "./PluginLocalDataStore";
  * one-time legacy-keys migration BEFORE constructing this adapter.
  *
  * The `ISettingsStore` interface contract is unchanged — `load()` /
- * `save()` shape matches what `FocusProfileSwitchManager` and tests
+ * `save()` shape matches what `ProfileApplyManager` and tests
  * already use.
  */
 export class PluginSettingsStoreAdapter implements ISettingsStore {

--- a/packages/obsidian-plugin/src/infrastructure/adapters/ProfileApplyManager.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/ProfileApplyManager.ts
@@ -18,7 +18,7 @@ import type { PluginLocalDataStore } from "./PluginLocalDataStore";
 import { TS_FLOOR_ASSETSPACE_UIDS } from "./FocusProfileOnloadWiring";
 
 /**
- * FocusProfileSwitchManager — coordinates profile switching:
+ * ProfileApplyManager — coordinates profile switching:
  *   1. acquire persistent lock (B.6)
  *   2. write journal entry «starting»
  *   3. compute effective ontology set (с TS-floor per Vision Lock #17)
@@ -38,16 +38,13 @@ import { TS_FLOOR_ASSETSPACE_UIDS } from "./FocusProfileOnloadWiring";
  */
 
 /**
- * `exo__FocusProfile` class UID (frozen by RFC b6ba5595).
+ * `exo__Profile` class UID (frozen by RFC b6ba5595).
  *
- * RFC 13da049f Phase 6.5b (AC13) — **filter-only narrowing**: a profile's soft
- * switch is a query-time RDF-graph filter; physical AssetSpace materialisation
- * is the hard / mount-state switch ({@link hardSwitchKnowledgeProfile}). Phase 2
- * (RFC 01a83de8) collapsed the former `exo__KnowledgeProfile` class into this
- * single `exo__Profile` (was `exo__FocusProfile`); both the soft and the
- * mount-state switch now operate on the same class.
+ * RFC 01a83de8 Phase 2 unified the profile model onto this single `exo__Profile`
+ * class; the mount-state switch ({@link applyProfile}) and effective-set
+ * resolution both operate on it.
  */
-export const FOCUS_PROFILE_CLASS_UID = "3de846cd-1f0e-4f98-8613-b8587aa15174";
+export const PROFILE_CLASS_UID = "3de846cd-1f0e-4f98-8613-b8587aa15174";
 
 /**
  * TS-floor (Vision Lock #17): ontology URIs that are ALWAYS in the effective
@@ -87,7 +84,7 @@ export interface ProfileResolution {
 }
 
 /**
- * Resolves a FocusProfile asset by UID. Production implementation reads via
+ * Resolves a Profile asset by UID. Production implementation reads via
  * Obsidian metadataCache + vault.adapter; tests provide an in-memory map.
  */
 export interface IProfileResolver {
@@ -159,7 +156,7 @@ export interface SwitchJournalEntry {
   error?: string;
 }
 
-export interface FocusProfileSwitchManagerOptions {
+export interface ProfileApplyManagerOptions {
   app: App;
   lockMgr: PluginLockManager;
   resolver: IProfileResolver;
@@ -184,7 +181,7 @@ export interface FocusProfileSwitchManagerOptions {
   /**
    * REST/tarball AssetSpace mount/unmount (RFC 01a83de8 Phase 3 T1). The
    * cross-platform (incl. iOS) materialisation path. When wired and running on
-   * mobile, `hardSwitchKnowledgeProfile` delegates to {@link restSwitchProfile}
+   * mobile, `applyProfile` delegates to {@link restSwitchProfile}
    * (no git binary / staging / cache). Desktop keeps the git-binary path.
    *
    * Captured at onload — used to gate command registration + as a fallback.
@@ -217,7 +214,7 @@ const DEFAULT_MAX_EXTENDS_DEPTH = 5;
  * ({@link ../../../../../exocortex/src/domain/profile/TsFloorGuard}) so the
  * single class identity is shared across plugin + CLI — `e instanceof
  * TsFloorViolationError` works regardless of import path. Retained as a named
- * export here for backward-compat with `FocusProfileCommands` et al.
+ * export here for backward-compat with the profile command palette et al.
  */
 export { TsFloorViolationError };
 
@@ -254,7 +251,7 @@ export class HardSwitchAbortedByUser extends Error {
   }
 }
 
-export class FocusProfileSwitchManager {
+export class ProfileApplyManager {
   private readonly app: App;
   private readonly lockMgr: PluginLockManager;
   private readonly resolver: IProfileResolver;
@@ -276,7 +273,7 @@ export class FocusProfileSwitchManager {
   private readonly localDataStore?: PluginLocalDataStore;
   private readonly vaultRootPath?: string;
 
-  constructor(options: FocusProfileSwitchManagerOptions) {
+  constructor(options: ProfileApplyManagerOptions) {
     this.app = options.app;
     this.lockMgr = options.lockMgr;
     this.resolver = options.resolver;
@@ -300,7 +297,7 @@ export class FocusProfileSwitchManager {
 
   /**
    * Reindex-only apply path (RFC 0a0791c1 Phase 5 T2 — replaces the retired
-   * public `softSwitchFocusProfile`). Records the target as the last-applied
+   * public soft-switch method). Records the target as the last-applied
    * profile cache (`activeProfileUid`) and rebuilds the RDF graph from the
    * currently-materialised mount-state. Does NOT mutate the filesystem.
    *
@@ -373,13 +370,13 @@ export class FocusProfileSwitchManager {
   }
 
   /**
-   * @deprecated Use {@link hardSwitchKnowledgeProfile}. Retained for backward
+   * @deprecated Use {@link applyProfile}. Retained for backward
    * compatibility (RFC 13da049f Phase 6.5b AC15 — Knowledge/Focus split).
    * Hard switch materialises filesystem state, so it is semantically a
    * Knowledge-profile operation.
    */
   async hardSwitchProfile(targetProfileUid: string): Promise<void> {
-    return this.hardSwitchKnowledgeProfile(targetProfileUid);
+    return this.applyProfile(targetProfileUid);
   }
 
   /**
@@ -481,9 +478,9 @@ export class FocusProfileSwitchManager {
    * @throws UncommittedChangesAbortError if dirty files in any to-destroy AS.
    * @throws HardSwitchAbortedByUser if confirmGate declines.
    */
-  async hardSwitchKnowledgeProfile(targetProfileUid: string): Promise<void> {
+  async applyProfile(targetProfileUid: string): Promise<void> {
     if (typeof targetProfileUid !== "string" || targetProfileUid.length === 0) {
-      throw new Error("hardSwitchKnowledgeProfile: targetProfileUid is required");
+      throw new Error("applyProfile: targetProfileUid is required");
     }
     // RFC 01a83de8 Phase 3 T2 — on mobile the git binary is unavailable, so
     // delegate to the REST/tarball mount/unmount path (no staging / cache /
@@ -870,7 +867,7 @@ export class FocusProfileSwitchManager {
    * Mobile-capable profile switch (RFC 01a83de8 Phase 3 T2). Materialises the
    * target profile's effective AssetSpace set via REST/tarball mount/unmount
    * (no git binary, staging dir, cache layer, or git commit). Delegated to by
-   * {@link hardSwitchKnowledgeProfile} when running on mobile with `restMount`
+   * {@link applyProfile} when running on mobile with `restMount`
    * wired; desktop keeps the git-binary path.
    *
    * Visibility is **mount-state**: an AssetSpace is "active" iff its derived
@@ -915,7 +912,7 @@ export class FocusProfileSwitchManager {
         : "<unknown>";
 
     // 1. Effective AssetSpace set (declared ontologies → AS UIDs + TS-floor).
-    // Mirrors hardSwitchKnowledgeProfile's R24 derivation (computeDerivedSet,
+    // Mirrors applyProfile's R24 derivation (computeDerivedSet,
     // NOT resolveEffectiveSet — the latter silently injects floor ontologies).
     const declaredOntologySet = await this.computeDerivedSet(targetProfileUid);
     const folderToAsUid = await this.scanFolderToAsUid();
@@ -1189,7 +1186,7 @@ export class FocusProfileSwitchManager {
    * Detection: parse `.gitmodules` to get currently-materialized AS folders,
    * compare to effective set derived from local `activeProfileUid`. Mismatch
    * → call confirmGate (reusing IConfirmGate plan shape) to get user OK
-   * before reconciling via hardSwitchKnowledgeProfile.
+   * before reconciling via applyProfile.
    *
    * Returns `null` if no divergence detected. Otherwise returns the action
    * taken: `"reconciled"` if user approved, `"declined"` if user declined.
@@ -1252,7 +1249,7 @@ export class FocusProfileSwitchManager {
       ? await this.confirmGate.confirmHardSwitch(reconcilePlan)
       : true; // No gate wired (tests / headless) — proceed.
     if (!approved) return { outcome: "declined" };
-    await this.hardSwitchKnowledgeProfile(activeProfileUid);
+    await this.applyProfile(activeProfileUid);
     return { outcome: "reconciled" };
   }
 
@@ -1319,7 +1316,7 @@ export class FocusProfileSwitchManager {
       this.vaultRootPath === undefined
     ) {
       throw new Error(
-        "hardSwitchKnowledgeProfile: dependencies not wired (assetSpaceManager, cacheLayer, gitOps, uncommittedGuard, confirmGate, localDataStore, vaultRootPath required)",
+        "applyProfile: dependencies not wired (assetSpaceManager, cacheLayer, gitOps, uncommittedGuard, confirmGate, localDataStore, vaultRootPath required)",
       );
     }
     return {
@@ -1521,7 +1518,7 @@ export class FocusProfileSwitchManager {
   ): Promise<void> {
     if (depth > this.maxExtendsDepth) {
       throw new Error(
-        `FocusProfile chain exceeds max depth ${this.maxExtendsDepth} at ${uid} — possible cycle`,
+        `Profile chain exceeds max depth ${this.maxExtendsDepth} at ${uid} — possible cycle`,
       );
     }
     if (visited.has(uid)) return; // cycle guard

--- a/packages/obsidian-plugin/src/infrastructure/adapters/VaultProfileResolver.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/VaultProfileResolver.ts
@@ -3,8 +3,8 @@ import type { App, TFile } from "obsidian";
 import type {
   IProfileResolver,
   ProfileResolution,
-} from "./FocusProfileSwitchManager";
-import { FOCUS_PROFILE_CLASS_UID } from "./FocusProfileSwitchManager";
+} from "./ProfileApplyManager";
+import { PROFILE_CLASS_UID } from "./ProfileApplyManager";
 
 /**
  * Vault-backed implementation of {@link IProfileResolver}. Reads
@@ -27,7 +27,7 @@ import { FOCUS_PROFILE_CLASS_UID } from "./FocusProfileSwitchManager";
  * Shared-ontology discovery: production scans the converter's RDF graph
  * для ontology IRIs matching the `shared-` prefix pattern. v3 backward-
  * compat scope omits the discovery hook — returns empty array so the
- * `FocusProfileSwitchManager`'s TS-floor pattern match falls through
+ * `ProfileApplyManager`'s TS-floor pattern match falls through
  * to the hardcoded floor.
  */
 export class VaultProfileResolver implements IProfileResolver {
@@ -104,7 +104,7 @@ export class VaultProfileResolver implements IProfileResolver {
    * fuzzy picker.
    */
   public listFocusProfileFiles(): TFile[] {
-    return this.listProfileFilesByClass(FOCUS_PROFILE_CLASS_UID);
+    return this.listProfileFilesByClass(PROFILE_CLASS_UID);
   }
 
   /**

--- a/packages/obsidian-plugin/src/presentation/settings/ExocortexSettingTab.ts
+++ b/packages/obsidian-plugin/src/presentation/settings/ExocortexSettingTab.ts
@@ -549,10 +549,10 @@ export class ExocortexSettingTab extends PluginSettingTab {
    *     empty in v3 — its docstring explicitly says «Settings UI wires
    *     getCacheStats() and shows zeros — acceptable»).
    *
-   *   - FocusProfileSwitchManager is NOT constructed here — it would race
+   *   - ProfileApplyManager is NOT constructed here — it would race
    *     the manager from registerFocusProfileCommands on the persisted
    *     lock file. Plugin exposes a hoisted instance via
-   *     `plugin.focusProfileSwitchManager`.
+   *     `plugin.profileApplyManager`.
    *
    *   - GitHubRestClient requires the PAT, so it cannot be a stable field;
    *     constructed inside the Test-connection callback against the freshly

--- a/packages/obsidian-plugin/tests/e2e/specs/focus-profile-picker.spec.ts
+++ b/packages/obsidian-plugin/tests/e2e/specs/focus-profile-picker.spec.ts
@@ -38,7 +38,7 @@ import * as path from "path";
  *   fixture-resolution gap. The profile picker has NO such gap:
  *   `VaultProfileResolver.listFocusProfileFiles` discovers profiles by a plain
  *   substring match on the raw `exo__Instance_class` frontmatter string
- *   (`instanceClassContains` → `c.includes(FOCUS_PROFILE_CLASS_UID)`), reading
+ *   (`instanceClassContains` → `c.includes(PROFILE_CLASS_UID)`), reading
  *   straight from `metadataCache` — no triple-store IRI expansion. The
  *   fixtures therefore carry the class in UUID form
  *   (`[[3de846cd-1f0e-4f98-8613-b8587aa15174]]`) and the picker list is
@@ -55,7 +55,7 @@ import * as path from "path";
  * `.suggestion-item` assertion then times out and this spec FAILS.
  */
 
-const FOCUS_PROFILE_CLASS_UID = "3de846cd-1f0e-4f98-8613-b8587aa15174";
+const PROFILE_CLASS_UID = "3de846cd-1f0e-4f98-8613-b8587aa15174";
 const APPLY_PROFILE_COMMAND_ID = "exocortex:hard-switch-focus-profile";
 const FIXTURE_LABELS = [
   "E2E Focus Profile Base",
@@ -163,7 +163,7 @@ test.describe("Focus profile picker — render smoke", () => {
               }
             }
             return count;
-          }, FOCUS_PROFILE_CLASS_UID),
+          }, PROFILE_CLASS_UID),
         {
           timeout: 30000,
           message: "FocusProfile fixtures not discoverable in metadataCache",

--- a/packages/obsidian-plugin/tests/unit/ExocortexSettingTab.focusProfile.test.ts
+++ b/packages/obsidian-plugin/tests/unit/ExocortexSettingTab.focusProfile.test.ts
@@ -12,7 +12,7 @@
  * The integration shape (real PAT persistence round-trip, real GitHub call,
  * real apply dispatch) is intentionally out of scope here — those are covered
  * by `LocalSecretsStore.test.ts`, `GitHubRestClient.test.ts`,
- * `FocusProfileSwitchManager.test.ts`. These tests only assert the UI
+ * `ProfileApplyManager.test.ts`. These tests only assert the UI
  * renders the expected scaffold so a future regression that drops one of
  * the sections fails CI loudly.
  */

--- a/packages/obsidian-plugin/tests/unit/FocusProfileCommands.test.ts
+++ b/packages/obsidian-plugin/tests/unit/FocusProfileCommands.test.ts
@@ -5,19 +5,19 @@ import {
   type IAssetSpacePusher,
 } from "../../src/infrastructure/adapters/FocusProfileCommands";
 import {
-  type FocusProfileSwitchManager,
+  type ProfileApplyManager,
   HardSwitchAbortedByUser,
   TsFloorViolationError,
   UncommittedChangesAbortError,
-} from "../../src/infrastructure/adapters/FocusProfileSwitchManager";
+} from "../../src/infrastructure/adapters/ProfileApplyManager";
 
 // ─── Test doubles ────────────────────────────────────────────────────────
 
 class FakeSwitchMgr {
   hardSwitchCalls: string[] = [];
-  /** Error to throw from the next hardSwitchKnowledgeProfile call (then cleared). */
+  /** Error to throw from the next applyProfile call (then cleared). */
   hardSwitchThrows: Error | null = null;
-  async hardSwitchKnowledgeProfile(uid: string): Promise<void> {
+  async applyProfile(uid: string): Promise<void> {
     this.hardSwitchCalls.push(uid);
     if (this.hardSwitchThrows) {
       const e = this.hardSwitchThrows;
@@ -70,7 +70,7 @@ function makeHarness(opts: {
   const notices: string[] = [];
   const pickCalls: { options: FocusProfileChoice[]; title: string }[] = [];
   const deps: FocusProfileCommandsDeps = {
-    switchMgr: switchMgr as unknown as FocusProfileSwitchManager,
+    switchMgr: switchMgr as unknown as ProfileApplyManager,
     pushMgr,
     profileLister: async () => {
       if (opts.listError) throw opts.listError;
@@ -237,7 +237,7 @@ describe("FocusProfileCommands.invokeSwitchKnowledgeProfile (Apply profile)", ()
     expect(h.pickCalls[0].title).toBe("Apply profile");
   });
 
-  it("invokes hardSwitchKnowledgeProfile with the chosen uid", async () => {
+  it("invokes applyProfile with the chosen uid", async () => {
     const profiles = [{ uid: "k1", label: "knowledge-one" }];
     const h = makeHarness({ profiles, pickResult: profiles[0] });
     await h.cmd.invokeSwitchKnowledgeProfile();

--- a/packages/obsidian-plugin/tests/unit/FocusProfileSwitch.regression.test.ts
+++ b/packages/obsidian-plugin/tests/unit/FocusProfileSwitch.regression.test.ts
@@ -19,7 +19,7 @@
 import type { App } from "obsidian";
 
 import {
-  FocusProfileSwitchManager,
+  ProfileApplyManager,
   TS_FLOOR_ONTOLOGY_URIS,
   TS_FLOOR_SHARED_PATTERN,
   type IProfileResolver,
@@ -27,14 +27,14 @@ import {
   type ISettingsStore,
   type ProfileResolution,
   type SwitchSettings,
-} from "../../src/infrastructure/adapters/FocusProfileSwitchManager";
+} from "../../src/infrastructure/adapters/ProfileApplyManager";
 import { PluginLockManager } from "../../src/infrastructure/adapters/PluginLockManager";
 
 // RFC 0a0791c1 Phase 5 T2 — the public soft `switchProfile` was removed; its
 // lock/journal/persist/reindex behavior lives on in the private
 // `reindexMountState` helper. These tests drive it directly via a typed cast.
 type Reindexable = { reindexMountState(uid: string): Promise<void> };
-const reindex = (mgr: FocusProfileSwitchManager, uid: string): Promise<void> =>
+const reindex = (mgr: ProfileApplyManager, uid: string): Promise<void> =>
   (mgr as unknown as Reindexable).reindexMountState(uid);
 
 // ─── Shared fakes — mirror real Obsidian API per test-fixture-realism ────
@@ -104,7 +104,7 @@ interface Harness {
   rdf: CapturingRdfIndexer;
   settings: FakeSettingsStore;
   lockMgr: PluginLockManager;
-  mgr: FocusProfileSwitchManager;
+  mgr: ProfileApplyManager;
   clock: { current: Date; advance: (ms: number) => void };
 }
 
@@ -126,7 +126,7 @@ function makeHarness(
   const rdf = new CapturingRdfIndexer();
   const settings = new FakeSettingsStore();
   const lockMgr = new PluginLockManager({ app, pid: "test-pid", now: () => current });
-  const mgr = new FocusProfileSwitchManager({
+  const mgr = new ProfileApplyManager({
     app,
     lockMgr,
     resolver,

--- a/packages/obsidian-plugin/tests/unit/ProfileApplyManager.aliases.test.ts
+++ b/packages/obsidian-plugin/tests/unit/ProfileApplyManager.aliases.test.ts
@@ -1,22 +1,22 @@
 import type { App } from "obsidian";
 
 import {
-  FocusProfileSwitchManager,
-  type FocusProfileSwitchManagerOptions,
+  ProfileApplyManager,
+  type ProfileApplyManagerOptions,
   type IProfileResolver,
   type IRdfIndexer,
   type ISettingsStore,
   type ProfileResolution,
   type SwitchSettings,
-} from "../../src/infrastructure/adapters/FocusProfileSwitchManager";
+} from "../../src/infrastructure/adapters/ProfileApplyManager";
 import { PluginLockManager } from "../../src/infrastructure/adapters/PluginLockManager";
 
 /**
  * RFC 0a0791c1 Phase 5 T2 — the soft RDF-filter path (`softSwitchFocusProfile`
  * + `switchProfile` / `softSwitchProfile` aliases) was removed. The mount-state
  * apply path remains:
- *   - hardSwitchKnowledgeProfile  (destructive filesystem materialize)
- *   - hardSwitchProfile → hardSwitchKnowledgeProfile (deprecated alias, kept)
+ *   - applyProfile  (destructive filesystem materialize)
+ *   - hardSwitchProfile → applyProfile (deprecated alias, kept)
  *
  * These tests verify:
  *   1. the canonical mount path throws when its deps are not wired
@@ -81,7 +81,7 @@ class FakeSettingsStore implements ISettingsStore {
 }
 
 interface Harness {
-  mgr: FocusProfileSwitchManager;
+  mgr: ProfileApplyManager;
   rdf: FakeRdfIndexer;
   settings: FakeSettingsStore;
   notifyCalls: string[];
@@ -109,7 +109,7 @@ function makeHarness(): Harness {
   const current = new Date("2026-06-04T00:00:00.000Z");
   const lockMgr = new PluginLockManager({ app, pid: "fixed-pid", now: () => current });
   const notifyCalls: string[] = [];
-  const opts: FocusProfileSwitchManagerOptions = {
+  const opts: ProfileApplyManagerOptions = {
     app,
     lockMgr,
     resolver,
@@ -118,20 +118,20 @@ function makeHarness(): Harness {
     now: () => current,
     notify: (m) => notifyCalls.push(m),
   };
-  const mgr = new FocusProfileSwitchManager(opts);
+  const mgr = new ProfileApplyManager(opts);
   return { mgr, rdf, settings, notifyCalls };
 }
 
 // ─── Deprecated alias delegation ─────────────────────────────────────────
 
-describe("FocusProfileSwitchManager — deprecated hard alias delegates to canonical", () => {
-  it("hardSwitchProfile delegates to hardSwitchKnowledgeProfile", async () => {
+describe("ProfileApplyManager — deprecated hard alias delegates to canonical", () => {
+  it("hardSwitchProfile delegates to applyProfile", async () => {
     const h = makeHarness();
     // Hard switch requires extra deps wired; without them, the canonical method
     // throws via assertHardSwitchWired(). What we verify here is that the alias
     // routes into the canonical method (not into soft-switch), so the very same
     // wiring error surfaces. Delegation proven by spy + identical throw signature.
-    const spy = jest.spyOn(h.mgr, "hardSwitchKnowledgeProfile");
+    const spy = jest.spyOn(h.mgr, "applyProfile");
     await expect(h.mgr.hardSwitchProfile(UID_BASE)).rejects.toThrow(
       /dependencies not wired/,
     );
@@ -140,13 +140,13 @@ describe("FocusProfileSwitchManager — deprecated hard alias delegates to canon
   });
 });
 
-// ─── Canonical hardSwitchKnowledgeProfile (wiring assertion) ─────────────
+// ─── Canonical applyProfile (wiring assertion) ─────────────
 
-describe("FocusProfileSwitchManager.hardSwitchKnowledgeProfile (canonical)", () => {
+describe("ProfileApplyManager.applyProfile (canonical)", () => {
   it("throws when hard-switch dependencies are not wired (assertHardSwitchWired)", async () => {
     const h = makeHarness();
-    await expect(h.mgr.hardSwitchKnowledgeProfile(UID_BASE)).rejects.toThrow(
-      /hardSwitchKnowledgeProfile: dependencies not wired/,
+    await expect(h.mgr.applyProfile(UID_BASE)).rejects.toThrow(
+      /applyProfile: dependencies not wired/,
     );
   });
 });

--- a/packages/obsidian-plugin/tests/unit/ProfileApplyManager.hardSwitch.test.ts
+++ b/packages/obsidian-plugin/tests/unit/ProfileApplyManager.hardSwitch.test.ts
@@ -1,5 +1,5 @@
 /**
- * FocusProfileSwitchManager.hardSwitchProfile() — unit tests covering RFC
+ * ProfileApplyManager.hardSwitchProfile() — unit tests covering RFC
  * 22b50a17 Phase 3 algorithm + Phase 0 findings (F2/F3/F5/R24/R26).
  *
  * Tests:
@@ -22,7 +22,7 @@ import type { App, TFile } from "obsidian";
 import type { HardSwitchPlan, IConfirmGate } from "exocortex";
 
 import {
-  FocusProfileSwitchManager,
+  ProfileApplyManager,
   HardSwitchAbortedByUser,
   TsFloorViolationError,
   UncommittedChangesAbortError,
@@ -32,7 +32,7 @@ import {
   type ProfileResolution,
   type SwitchJournalEntry,
   type SwitchSettings,
-} from "../../src/infrastructure/adapters/FocusProfileSwitchManager";
+} from "../../src/infrastructure/adapters/ProfileApplyManager";
 import { PluginLockManager } from "../../src/infrastructure/adapters/PluginLockManager";
 import {
   TS_FLOOR_AS_UID_EXO,
@@ -409,7 +409,7 @@ function setup(opts: SetupOptions) {
   const assetSpaceManager = new FakeAssetSpaceManager();
   const confirmGate = new FakeConfirmGate();
 
-  const mgr = new FocusProfileSwitchManager({
+  const mgr = new ProfileApplyManager({
     app,
     lockMgr,
     resolver,
@@ -442,7 +442,7 @@ function setup(opts: SetupOptions) {
 }
 
 // Patch FakeResolver to support adding more profiles after construction.
-declare module "../../src/infrastructure/adapters/FocusProfileSwitchManager" {
+declare module "../../src/infrastructure/adapters/ProfileApplyManager" {
   // (no-op — keeps TS happy)
 }
 interface FakeResolverExt extends FakeResolver {
@@ -471,7 +471,7 @@ async function readJournalEntries(app: App): Promise<SwitchJournalEntry[]> {
 
 // === Tests ===
 
-describe("FocusProfileSwitchManager.hardSwitchProfile", () => {
+describe("ProfileApplyManager.hardSwitchProfile", () => {
   describe("R24 — TS-floor guard", () => {
     it("throws TsFloorViolationError when target excludes any floor AS UID before any mutation", async () => {
       // Target profile includes ONLY ems — missing all 3 TS-floor AS.
@@ -903,7 +903,7 @@ describe("FocusProfileSwitchManager.hardSwitchProfile", () => {
   });
 });
 
-describe("FocusProfileSwitchManager.recoverIncompleteSwitch", () => {
+describe("ProfileApplyManager.recoverIncompleteSwitch", () => {
   it("restores destroyed-but-not-materialized AS from cache", async () => {
     const { mgr, cacheLayer, app } = setup({
       targetUid: "target",
@@ -987,7 +987,7 @@ describe("FocusProfileSwitchManager.recoverIncompleteSwitch", () => {
   });
 });
 
-describe("FocusProfileSwitchManager.reconcileToLocal", () => {
+describe("ProfileApplyManager.reconcileToLocal", () => {
   it("no-divergence when .gitmodules matches activeProfileUid effective set", async () => {
     const { mgr, localDataStore } = setup({
       targetUid: "target",

--- a/packages/obsidian-plugin/tests/unit/ProfileApplyManager.restSwitch.test.ts
+++ b/packages/obsidian-plugin/tests/unit/ProfileApplyManager.restSwitch.test.ts
@@ -1,5 +1,5 @@
 /**
- * FocusProfileSwitchManager.restSwitchProfile() — RFC 01a83de8 Phase 3 T2.
+ * ProfileApplyManager.restSwitchProfile() — RFC 01a83de8 Phase 3 T2.
  *
  * Mobile-capable profile switch via REST/tarball mount/unmount (no git binary,
  * staging, cache, or git commit). Visibility is mount-state: an AssetSpace is
@@ -14,7 +14,7 @@
  *   3. R24 TS-floor — target excluding a floor AS throws before any mutation.
  *   4. ConfirmGate decline → HardSwitchAbortedByUser, no mount/unmount.
  *   5. Not wired — missing restMount throws a clear error.
- *   6. Dispatch — hardSwitchKnowledgeProfile on mobile delegates to
+ *   6. Dispatch — applyProfile on mobile delegates to
  *      restSwitchProfile (REST path; gitOps never touched).
  *
  * Fakes mirror the desktop hardSwitch harness: in-memory vault.adapter
@@ -27,7 +27,7 @@ import type { App, TFile } from "obsidian";
 import type { HardSwitchPlan, IConfirmGate } from "exocortex";
 
 import {
-  FocusProfileSwitchManager,
+  ProfileApplyManager,
   HardSwitchAbortedByUser,
   TsFloorViolationError,
   type IProfileResolver,
@@ -35,7 +35,7 @@ import {
   type ISettingsStore,
   type ProfileResolution,
   type SwitchSettings,
-} from "../../src/infrastructure/adapters/FocusProfileSwitchManager";
+} from "../../src/infrastructure/adapters/ProfileApplyManager";
 import { PluginLockManager } from "../../src/infrastructure/adapters/PluginLockManager";
 import {
   TS_FLOOR_AS_UID_EXO,
@@ -273,7 +273,7 @@ function setup(opts: SetupOpts) {
   const factoryMount = new FakeRestMount();
   const gitOps = new FakeGitOps();
 
-  const mgr = new FocusProfileSwitchManager({
+  const mgr = new ProfileApplyManager({
     app,
     lockMgr,
     resolver,
@@ -304,7 +304,7 @@ const ALL_FLOOR_UIDS = TS_FLOOR.map((f) => f.uid);
 
 // ─── Tests ────────────────────────────────────────────────────────────────
 
-describe("FocusProfileSwitchManager.restSwitchProfile", () => {
+describe("ProfileApplyManager.restSwitchProfile", () => {
   it("unmounts to-destroy + mounts to-materialize, persists profile + re-indexes", async () => {
     // Currently materialised: floors + kpc. Target: floors + ems (NOT kpc).
     const { mgr, indexer, localDataStore, restMount } = setup({
@@ -409,7 +409,7 @@ describe("FocusProfileSwitchManager.restSwitchProfile", () => {
   });
 });
 
-describe("hardSwitchKnowledgeProfile dispatch (mobile → REST)", () => {
+describe("applyProfile dispatch (mobile → REST)", () => {
   const original = Platform.isMobile;
   afterEach(() => {
     (Platform as unknown as { isMobile: boolean }).isMobile = original;
@@ -423,7 +423,7 @@ describe("hardSwitchKnowledgeProfile dispatch (mobile → REST)", () => {
       wireGitOps: true,
     });
 
-    await mgr.hardSwitchKnowledgeProfile("target");
+    await mgr.applyProfile("target");
 
     // REST path exercised…
     expect(restMount.mounted.map((m) => m.submodulePath)).toEqual([

--- a/packages/obsidian-plugin/tests/unit/ProfileApplyManager.test.ts
+++ b/packages/obsidian-plugin/tests/unit/ProfileApplyManager.test.ts
@@ -1,7 +1,7 @@
 import type { App } from "obsidian";
 
 import {
-  FocusProfileSwitchManager,
+  ProfileApplyManager,
   TS_FLOOR_ONTOLOGY_URIS,
   type IProfileResolver,
   type IRdfIndexer,
@@ -9,7 +9,7 @@ import {
   type ProfileResolution,
   type SwitchJournalEntry,
   type SwitchSettings,
-} from "../../src/infrastructure/adapters/FocusProfileSwitchManager";
+} from "../../src/infrastructure/adapters/ProfileApplyManager";
 import { PluginLockManager } from "../../src/infrastructure/adapters/PluginLockManager";
 
 // RFC 0a0791c1 Phase 5 T2 — the public soft `switchProfile` was removed. Its
@@ -17,7 +17,7 @@ import { PluginLockManager } from "../../src/infrastructure/adapters/PluginLockM
 // `reindexMountState` helper (reached via the «Apply profile» no-op exit and
 // `recoverIfNeeded`). These tests drive that helper directly via a typed cast.
 type Reindexable = { reindexMountState(uid: string): Promise<void> };
-const reindex = (mgr: FocusProfileSwitchManager, uid: string): Promise<void> =>
+const reindex = (mgr: ProfileApplyManager, uid: string): Promise<void> =>
   (mgr as unknown as Reindexable).reindexMountState(uid);
 
 // ─── Fake App / vault.adapter ────────────────────────────────────────────
@@ -105,7 +105,7 @@ interface Harness {
   rdf: FakeRdfIndexer;
   settings: FakeSettingsStore;
   lockMgr: PluginLockManager;
-  mgr: FocusProfileSwitchManager;
+  mgr: ProfileApplyManager;
   notifyCalls: string[];
   clock: { current: Date; advance: (ms: number) => void };
 }
@@ -130,7 +130,7 @@ function makeHarness(opts: {
   };
   const lockMgr = new PluginLockManager({ app, pid: "fixed-pid", now: () => current });
   const notifyCalls: string[] = [];
-  const mgr = new FocusProfileSwitchManager({
+  const mgr = new ProfileApplyManager({
     app,
     lockMgr,
     resolver,
@@ -153,7 +153,7 @@ const ONTO_TBANK = "https://exocortex.my/ontology/tbank";
 
 // ─── resolveEffectiveSet + TS-floor ──────────────────────────────────────
 
-describe("FocusProfileSwitchManager.resolveEffectiveSet — TS-floor (Vision Lock #17)", () => {
+describe("ProfileApplyManager.resolveEffectiveSet — TS-floor (Vision Lock #17)", () => {
   it("includes TS-floor URIs even when profile has empty includes/overlay", async () => {
     const { mgr } = makeHarness({
       profiles: [
@@ -215,7 +215,7 @@ describe("FocusProfileSwitchManager.resolveEffectiveSet — TS-floor (Vision Loc
 
 // ─── computeDerivedSet — inheritance ─────────────────────────────────────
 
-describe("FocusProfileSwitchManager.computeDerivedSet — _extends chain", () => {
+describe("ProfileApplyManager.computeDerivedSet — _extends chain", () => {
   it("walks _imports transitively and accumulates parent _includes", async () => {
     // RFC 01a83de8 Phase 2 — the derived set is the union of _includes along
     // the single-parent _imports chain (base's library AssetSpaces are
@@ -307,7 +307,7 @@ describe("FocusProfileSwitchManager.computeDerivedSet — _extends chain", () =>
 
 // ─── reindexMountState happy path ────────────────────────────────────────────
 
-describe("FocusProfileSwitchManager.reindexMountState — happy path (apply reindex)", () => {
+describe("ProfileApplyManager.reindexMountState — happy path (apply reindex)", () => {
   it("persists settings BEFORE re-index (Architect #2 atomicity)", async () => {
     const h = makeHarness({
       profiles: [
@@ -382,7 +382,7 @@ describe("FocusProfileSwitchManager.reindexMountState — happy path (apply rein
 
 // ─── reindexMountState lock concurrency ──────────────────────────────────────
 
-describe("FocusProfileSwitchManager.reindexMountState — lock contention", () => {
+describe("ProfileApplyManager.reindexMountState — lock contention", () => {
   it("throws when lock already held by foreign holder", async () => {
     const h = makeHarness({
       profiles: [
@@ -421,7 +421,7 @@ describe("FocusProfileSwitchManager.reindexMountState — lock contention", () =
 
 // ─── reindexMountState failure journal ────────────────────────────────────────
 
-describe("FocusProfileSwitchManager.reindexMountState — failure path", () => {
+describe("ProfileApplyManager.reindexMountState — failure path", () => {
   it("writes failed journal entry when re-index throws", async () => {
     const h = makeHarness({
       profiles: [
@@ -469,7 +469,7 @@ describe("FocusProfileSwitchManager.reindexMountState — failure path", () => {
 
 // ─── recoverIfNeeded ──────────────────────────────────────────────────────
 
-describe("FocusProfileSwitchManager.recoverIfNeeded", () => {
+describe("ProfileApplyManager.recoverIfNeeded", () => {
   it("returns {recovered:false} when no journal exists", async () => {
     const h = makeHarness({ profiles: [] });
     const res = await h.mgr.recoverIfNeeded();

--- a/packages/obsidian-plugin/tests/unit/VaultProfileResolver.test.ts
+++ b/packages/obsidian-plugin/tests/unit/VaultProfileResolver.test.ts
@@ -1,5 +1,5 @@
 import { VaultProfileResolver } from "../../src/infrastructure/adapters/VaultProfileResolver";
-import { FOCUS_PROFILE_CLASS_UID } from "../../src/infrastructure/adapters/FocusProfileSwitchManager";
+import { PROFILE_CLASS_UID } from "../../src/infrastructure/adapters/ProfileApplyManager";
 
 interface FakeFile {
   path: string;
@@ -28,7 +28,7 @@ describe("VaultProfileResolver.listFocusProfileFiles", () => {
       {
         file: { path: "a.md", basename: "a" },
         fm: {
-          exo__Instance_class: `[[${FOCUS_PROFILE_CLASS_UID}|exo__FocusProfile]]`,
+          exo__Instance_class: `[[${PROFILE_CLASS_UID}|exo__FocusProfile]]`,
           exo__Asset_uid: "p1",
           exo__Asset_label: "Profile One",
         },
@@ -45,7 +45,7 @@ describe("VaultProfileResolver.listFocusProfileFiles", () => {
         fm: {
           exo__Instance_class: [
             "[[ems__Project]]",
-            `[[${FOCUS_PROFILE_CLASS_UID}|exo__FocusProfile]]`,
+            `[[${PROFILE_CLASS_UID}|exo__FocusProfile]]`,
           ],
           exo__Asset_uid: "p2",
         },
@@ -61,7 +61,7 @@ describe("VaultProfileResolver.listFocusProfileFiles", () => {
       {
         file: { path: "a.md", basename: "a" },
         fm: {
-          exo__Instance_class: `[[${FOCUS_PROFILE_CLASS_UID}]]`,
+          exo__Instance_class: `[[${PROFILE_CLASS_UID}]]`,
           exo__Asset_uid: "p1",
         },
       },
@@ -89,14 +89,14 @@ describe("VaultProfileResolver.listFocusProfileFiles", () => {
       {
         file: { path: "a.md", basename: "a" },
         fm: {
-          exo__Instance_class: `[[${FOCUS_PROFILE_CLASS_UID}]]`,
+          exo__Instance_class: `[[${PROFILE_CLASS_UID}]]`,
           exo__Asset_uid: "p1",
         },
       },
       {
         file: { path: "b.md", basename: "b" },
         fm: {
-          exo__Instance_class: `[[${FOCUS_PROFILE_CLASS_UID}]]`,
+          exo__Instance_class: `[[${PROFILE_CLASS_UID}]]`,
           exo__Asset_uid: "p2",
         },
       },
@@ -120,7 +120,7 @@ describe("VaultProfileResolver.resolve", () => {
       {
         file: { path: "p.md", basename: "p" },
         fm: {
-          exo__Instance_class: `[[${FOCUS_PROFILE_CLASS_UID}]]`,
+          exo__Instance_class: `[[${PROFILE_CLASS_UID}]]`,
           exo__Asset_uid: "p1",
           exo__Asset_label: "Personal",
           // RFC 01a83de8 Phase 2 — _includes now AssetSpace UID wikilinks
@@ -148,7 +148,7 @@ describe("VaultProfileResolver.resolve", () => {
       {
         file: { path: "p.md", basename: "p" },
         fm: {
-          exo__Instance_class: `[[${FOCUS_PROFILE_CLASS_UID}]]`,
+          exo__Instance_class: `[[${PROFILE_CLASS_UID}]]`,
           exo__Asset_uid: "p1",
           exo__Profile_imports: ["[[parent-uid]]"],
         },
@@ -163,7 +163,7 @@ describe("VaultProfileResolver.resolve", () => {
       {
         file: { path: "fallback.md", basename: "fallback" },
         fm: {
-          exo__Instance_class: `[[${FOCUS_PROFILE_CLASS_UID}]]`,
+          exo__Instance_class: `[[${PROFILE_CLASS_UID}]]`,
           exo__Asset_uid: "p1",
         },
       },
@@ -177,7 +177,7 @@ describe("VaultProfileResolver.resolve", () => {
       {
         file: { path: "p.md", basename: "p" },
         fm: {
-          exo__Instance_class: `[[${FOCUS_PROFILE_CLASS_UID}]]`,
+          exo__Instance_class: `[[${PROFILE_CLASS_UID}]]`,
           exo__Asset_uid: "p1",
         },
       },

--- a/packages/obsidian-plugin/tests/unit/integration/HardSwitchEndToEnd.integration.test.ts
+++ b/packages/obsidian-plugin/tests/unit/integration/HardSwitchEndToEnd.integration.test.ts
@@ -34,13 +34,13 @@ import type { App, TFile } from "obsidian";
 import type { HardSwitchPlan, IConfirmGate } from "exocortex";
 
 import {
-  FocusProfileSwitchManager,
+  ProfileApplyManager,
   type IProfileResolver,
   type IRdfIndexer,
   type ISettingsStore,
   type ProfileResolution,
   type SwitchSettings,
-} from "../../../src/infrastructure/adapters/FocusProfileSwitchManager";
+} from "../../../src/infrastructure/adapters/ProfileApplyManager";
 import { PluginLockManager } from "../../../src/infrastructure/adapters/PluginLockManager";
 import {
   TS_FLOOR_AS_UID_EXO,
@@ -441,7 +441,7 @@ describe("hardSwitchProfile E2E (real fs, mocked pull)", () => {
     const assetSpaceManager = new FakePullingAssetSpaceManager();
     const cacheLayer = new SwitchCacheLayer({ cacheDir: setup.cacheDir });
 
-    const mgr = new FocusProfileSwitchManager({
+    const mgr = new ProfileApplyManager({
       app,
       lockMgr,
       resolver: new FakeResolver(profiles),

--- a/packages/obsidian-plugin/tests/unit/wiring/FocusProfileWiring.integration.test.ts
+++ b/packages/obsidian-plugin/tests/unit/wiring/FocusProfileWiring.integration.test.ts
@@ -6,7 +6,7 @@
  *   (b) `createAssetSpacePusher` with valid PAT → real AssetSpaceManager
  *   (c) `createAssetSpacePusher` when GitHub client ctor throws → fallback stub
  *   (d) `lookupAssetSpaceUidByFolder` finds matching folder / returns null
- *   (e) `FocusProfileSwitchManager.recoverIfNeeded` fires when
+ *   (e) `ProfileApplyManager.recoverIfNeeded` fires when
  *       `_switchInProgress=true` and last journal entry is incomplete
  *
  * Per `~/dotfiles/.claude/rules/test-fixture-realism.md` — fakes mirror
@@ -25,8 +25,8 @@ import {
 import { lookupAssetSpaceUidByFolder } from "../../../src/infrastructure/adapters/AssetSpaceLookupHelper";
 import { ASSET_SPACE_CLASS_UID } from "../../../src/infrastructure/adapters/AssetSpaceManager";
 import {
-  FocusProfileSwitchManager,
-} from "../../../src/infrastructure/adapters/FocusProfileSwitchManager";
+  ProfileApplyManager,
+} from "../../../src/infrastructure/adapters/ProfileApplyManager";
 import { PluginLockManager } from "../../../src/infrastructure/adapters/PluginLockManager";
 import type {
   IProfileResolver,
@@ -34,7 +34,7 @@ import type {
   IRdfIndexer,
   ProfileResolution,
   SwitchSettings,
-} from "../../../src/infrastructure/adapters/FocusProfileSwitchManager";
+} from "../../../src/infrastructure/adapters/ProfileApplyManager";
 
 // ─── Real-shape fake App / vault / metadataCache ─────────────────────────
 
@@ -283,9 +283,9 @@ describe("lookupAssetSpaceUidByFolder — branch (d) integration", () => {
 
 // ─── (e) recoverIfNeeded triggered when _switchInProgress=true ────────────
 
-describe("FocusProfileSwitchManager.recoverIfNeeded — branch (e) onload trigger", () => {
+describe("ProfileApplyManager.recoverIfNeeded — branch (e) onload trigger", () => {
   // Minimal fakes mirroring the existing harness in
-  // tests/unit/FocusProfileSwitchManager.test.ts but focused on the
+  // tests/unit/ProfileApplyManager.test.ts but focused on the
   // onload recovery scenario.
 
   class FakeProfileResolver implements IProfileResolver {
@@ -334,7 +334,7 @@ describe("FocusProfileSwitchManager.recoverIfNeeded — branch (e) onload trigge
       now: () => new Date("2026-06-02T00:00:00.000Z"),
     });
     const notifyCalls: string[] = [];
-    const mgr = new FocusProfileSwitchManager({
+    const mgr = new ProfileApplyManager({
       app,
       lockMgr,
       resolver,


### PR DESCRIPTION
## Summary
PR **2 of 4** in the Phase 5 T3 symbol-rename sequence (RFC 0a0791c1). Mechanical, **zero-behavior-change** rename of the plugin profile-switch manager hub. No logic touched.

Renamed symbols (all occurrences, everywhere):
- `FocusProfileSwitchManager` → `ProfileApplyManager` (class + `…Options` interface + **file rename**, src + 4 unit-test files)
- `hardSwitchKnowledgeProfile` → `applyProfile` (public method + all call sites + internal self-calls)
- `FOCUS_PROFILE_CLASS_UID` → `PROFILE_CLASS_UID` (plugin copy + `VaultProfileResolver` importer; UPPER_SNAKE — not a gate hit, renamed for cross-package symmetry with PR1)
- `plugin.focusProfileSwitchManager` field → `plugin.profileApplyManager` (write-only; lowercase, not a gate hit, renamed for consistency per T2 follow-up note)
- manager-file dead-doc cleanup: `exo__FocusProfile`/`exo__KnowledgeProfile`/`softSwitchFocusProfile` references reworded (the class is `exo__Profile`; the soft method was removed in T2)

## Why this is zero-behavior-change
Pure identifier/file rename. The `applyProfile` public method is the former `hardSwitchKnowledgeProfile` verbatim (already the single public entry that branches GIT-desktop vs REST-mobile internally — no control-flow change). Command id `hard-switch-focus-profile` is **intentionally preserved** (Obsidian persists hotkeys by id; lowercase-hyphen, out of the CamelCase gate).

## File count note (cascade-cap)
27 files. The manager is an import hub (its module also exports `IRdfIndexer`, `SwitchJournalEntry`, etc. consumed by 6 adapters), so the **file rename is atomically coupled** to every importer + test — it cannot be subgroup-split without breaking the build/tests. The count reflects import-coupling, not logic complexity; the typecheck-coupled core is the manager + its importers, the rest are mechanical token edits.

## Verification
- `npm run check:types` (CI typecheck gate) — green
- `npm run lint` — 0 errors (2 pre-existing warnings in untouched files)
- 116 affected plugin tests pass across 10 suites (ProfileApplyManager.*, FocusProfileCommands, FocusProfileSwitch.regression, VaultProfileResolver, ExocortexSettingTab.focusProfile, HardSwitchEndToEnd, FocusProfileWiring)
- pre-commit archgate 16/16 pass

## Sequence
PR1 ✅ merged → **PR2 (this)** → PR3 (commands/pickers/settings) → PR4 (onload/storage/e2e). Remaining `FocusProfileCommands`/`FocusProfileChoice`/`FocusProfileOnloadWiring`/storage-slot residuals are PR3/PR4 scope; final gate-grep = 0 asserted after PR4.

## Test plan
- [ ] CI: 14 required checks green (incl. e2e-shard 1..6, test-coverage, parity-gate)