### PR TITLE
refactor(profile): rename commands/pickers/settings Focus→Profile (Phase 5 T3-PR3)

### DIFF
--- a/packages/obsidian-plugin/src/ExocortexPlugin.ts
+++ b/packages/obsidian-plugin/src/ExocortexPlugin.ts
@@ -91,10 +91,10 @@ import { createObsidianClassLabelResolver } from "./infrastructure/services/Obsi
 import { ExocmdCommandPaletteRegistrar } from "./application/services/ExocmdCommandPaletteRegistrar";
 import { ObsidianCommandPromptAdapter } from "./infrastructure/adapters/ObsidianCommandPromptAdapter";
 import {
-  FocusProfileCommands,
-  type FocusProfileChoice,
+  ProfileCommands,
+  type ProfileChoice,
   type IAssetSpacePusher,
-} from "./infrastructure/adapters/FocusProfileCommands";
+} from "./infrastructure/adapters/ProfileCommands";
 import { ProfileApplyManager } from "./infrastructure/adapters/ProfileApplyManager";
 import { PluginLockManager } from "./infrastructure/adapters/PluginLockManager";
 import { VaultProfileResolver } from "./infrastructure/adapters/VaultProfileResolver";
@@ -238,7 +238,7 @@ export default class ExocortexPlugin extends Plugin {
    * Issue #3320 — ProfileApplyManager hoisted onto the plugin instance
    * so onload recovery / reconcile reuse the single manager без re-constructing
    * a second one (which would race the original on the same persisted lock
-   * file). Initialized in `registerFocusProfileCommands()`; null until that
+   * file). Initialized in `registerProfileCommands()`; null until that
    * call succeeds.
    */
   public profileApplyManager: ProfileApplyManager | null = null;
@@ -247,16 +247,16 @@ export default class ExocortexPlugin extends Plugin {
    * Issue #3320 — profile choice lister hoisted alongside the switch
    * manager. Returns the same FuzzySuggestModal-shaped choices the palette
    * command uses, so the Settings dropdown matches Cmd+P ordering.
-   * Initialized in `registerFocusProfileCommands()`; null until that
+   * Initialized in `registerProfileCommands()`; null until that
    * call succeeds.
    */
-  public listFocusProfileChoices: (() => Promise<FocusProfileChoice[]>) | null = null;
+  public listProfileChoices: (() => Promise<ProfileChoice[]>) | null = null;
 
   /**
    * Issue #3327 Item #3 — device-local switch state store (Sync-excluded).
    * Holds `activeProfileUid` + `_switchInProgress` per-device so profile
    * selection does not replicate cross-device. Initialized в
-   * `registerFocusProfileCommands` after one-time legacy-keys migration;
+   * `registerProfileCommands` after one-time legacy-keys migration;
    * remains null before that point.
    *
    * Readers treat the null state as «no active profile» (matches the
@@ -784,16 +784,16 @@ export default class ExocortexPlugin extends Plugin {
         this.autoRenderLayout(),
       );
 
-      // RFC 0a0791c1 #3322 — register FocusProfile palette commands
+      // RFC 0a0791c1 #3322 — register Profile palette commands
       // (Switch / Push current assetspace). Wraps the B.7 handler with
       // real adapters. Wrapped в try/catch: any failure here должен NOT
       // abort the rest of onload — commands simply won't appear in
       // Cmd+P, but plugin remains usable.
       try {
-        await this.registerFocusProfileCommands();
+        await this.registerProfileCommands();
       } catch (error) {
         this.logger.error(
-          "[ExocortexPlugin] FocusProfile commands registration failed",
+          "[ExocortexPlugin] Profile commands registration failed",
           error instanceof Error ? error : new Error(String(error)),
         );
       }
@@ -2385,9 +2385,9 @@ export default class ExocortexPlugin extends Plugin {
   }
 
   /**
-   * RFC 0a0791c1 #3322 — register the two FocusProfile palette commands
+   * RFC 0a0791c1 #3322 — register the two Profile palette commands
    * («Switch focus profile», «Push current assetspace»). Wires the B.7
-   * `FocusProfileCommands` handler with real adapters:
+   * `ProfileCommands` handler with real adapters:
    *
    *   - B.4 `ProfileApplyManager`: persisted lock + journal + RDF
    *     re-index с effective ontology filter.
@@ -2411,7 +2411,7 @@ export default class ExocortexPlugin extends Plugin {
    *
    * Wired into:
    *  - `metadataCache.resolved` chain (initial cold-start + active-
-   *    FocusProfile re-apply path),
+   *    Profile re-apply path),
    *  - `PluginRdfIndexerAdapter.onAfterRefresh` so soft- and hard-
    *    switch paths via `ProfileApplyManager` re-inject
    *    automatically.
@@ -2441,7 +2441,7 @@ export default class ExocortexPlugin extends Plugin {
     }
   }
 
-  private async registerFocusProfileCommands(): Promise<void> {
+  private async registerProfileCommands(): Promise<void> {
     const lockMgr = new PluginLockManager({ app: this.app });
     const resolver = new VaultProfileResolver(this.app);
     // RFC 22b50a17 Phase 4 (H1 cascade catch — advisor round-2) — wire
@@ -2595,12 +2595,12 @@ export default class ExocortexPlugin extends Plugin {
       const recovery = await switchMgr.recoverIfNeeded();
       if (recovery.recovered) {
         this.logger.info(
-          `[ExocortexPlugin] FocusProfile switch recovery completed for ${recovery.targetUid}`,
+          `[ExocortexPlugin] Profile switch recovery completed for ${recovery.targetUid}`,
         );
       }
     } catch (error) {
       this.logger.warn(
-        "[ExocortexPlugin] FocusProfile switch recovery failed",
+        "[ExocortexPlugin] Profile switch recovery failed",
         error instanceof Error ? error : new Error(String(error)),
       );
     }
@@ -2654,8 +2654,8 @@ export default class ExocortexPlugin extends Plugin {
     const buildProfileChoices = (
       files: TFile[],
       activeUid: string | null,
-    ): FocusProfileChoice[] => {
-      const choices: FocusProfileChoice[] = [];
+    ): ProfileChoice[] => {
+      const choices: ProfileChoice[] = [];
       for (const file of files) {
         const cache = this.app.metadataCache.getFileCache(file);
         const fm = cache?.frontmatter as Record<string, unknown> | undefined;
@@ -2681,27 +2681,27 @@ export default class ExocortexPlugin extends Plugin {
     // RFC 0a0791c1 Phase 5 T2 — single `exo__Profile` picker (the former dual
     // soft/Knowledge listers collapsed into one). `activeProfileUid` is the
     // last-applied selection; Item #3 — device-local store (no Sync replication).
-    const profileLister: () => Promise<FocusProfileChoice[]> = async () =>
+    const profileLister: () => Promise<ProfileChoice[]> = async () =>
       buildProfileChoices(
-        resolver.listFocusProfileFiles(),
+        resolver.listProfileFiles(),
         localDataStore.getActiveProfileUid(),
       );
 
     // Issue #3320 — share the same lister с Settings UI so its dropdown
     // matches the Cmd+P fuzzy-pick ordering exactly.
-    this.listFocusProfileChoices = profileLister;
+    this.listProfileChoices = profileLister;
 
     const fuzzyPick = (
-      options: FocusProfileChoice[],
+      options: ProfileChoice[],
       title: string,
-    ): Promise<FocusProfileChoice | null> => {
-      return new Promise<FocusProfileChoice | null>((resolve) => {
+    ): Promise<ProfileChoice | null> => {
+      return new Promise<ProfileChoice | null>((resolve) => {
         const modal = new ProfileFuzzyModal(this.app, options, title, resolve);
         modal.open();
       });
     };
 
-    const commandsHandler = new FocusProfileCommands({
+    const commandsHandler = new ProfileCommands({
       switchMgr,
       pushMgr,
       profileLister,
@@ -2747,7 +2747,7 @@ export default class ExocortexPlugin extends Plugin {
         id: "hard-switch-focus-profile",
         name: "Apply profile",
         callback: () => {
-          void commandsHandler.invokeSwitchKnowledgeProfile();
+          void commandsHandler.invokeApplyProfile();
         },
       });
     }
@@ -2770,7 +2770,7 @@ export default class ExocortexPlugin extends Plugin {
     }
 
     this.logger.info(
-      "[ExocortexPlugin] FocusProfile palette commands registered",
+      "[ExocortexPlugin] Profile palette commands registered",
     );
   }
 
@@ -2897,7 +2897,7 @@ export default class ExocortexPlugin extends Plugin {
   }
 
   /**
-   * Constructs an `IAssetSpacePusher` for {@link registerFocusProfileCommands}.
+   * Constructs an `IAssetSpacePusher` for {@link registerProfileCommands}.
    *
    * When a GitHub PAT is configured в `data.local.json` (per RFC 0a0791c1
    * Vision Lock #1), returns a real `AssetSpaceManager` — push works

--- a/packages/obsidian-plugin/src/infrastructure/adapters/AssetSpacePusherFactory.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/AssetSpacePusherFactory.ts
@@ -6,7 +6,7 @@ import {
   GitHubRestClient,
   type GitHubRestClientOptions,
 } from "./GitHubRestClient";
-import type { IAssetSpacePusher } from "./FocusProfileCommands";
+import type { IAssetSpacePusher } from "./ProfileCommands";
 
 /**
  * Lookup-only helper from {@link AssetSpaceLookupHelper.lookupAssetSpaceUidByFolder}.

--- a/packages/obsidian-plugin/src/infrastructure/adapters/ProfileCommands.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/ProfileCommands.ts
@@ -1,5 +1,5 @@
 /**
- * FocusProfileCommands — command-palette logic handler для RFC 0a0791c1.
+ * ProfileCommands — command-palette logic handler для RFC 0a0791c1.
  *
  * RFC 0a0791c1 Phase 5 T2 consolidated the former dual «Switch focus profile»
  * (soft RDF filter) + «Switch knowledge profile» (mount-state) commands into a
@@ -42,7 +42,7 @@ export interface IAssetSpacePusher {
   pushAssetSpace(asUid: string): Promise<string>;
 }
 
-export interface FocusProfileChoice {
+export interface ProfileChoice {
   uid: string;
   label: string;
   /**
@@ -54,20 +54,20 @@ export interface FocusProfileChoice {
   isActive?: boolean;
 }
 
-export interface FocusProfileCommandsDeps {
+export interface ProfileCommandsDeps {
   switchMgr: ProfileApplyManager;
   pushMgr: IAssetSpacePusher;
   /** Returns available `exo__Profile` assets (label + uid pairs) — the picker. */
-  profileLister: () => Promise<FocusProfileChoice[]>;
+  profileLister: () => Promise<ProfileChoice[]>;
   /**
    * Open a fuzzy picker UI. Returns the user's choice, or null if the
    * picker was cancelled. Real implementation wraps Obsidian
    * `FuzzySuggestModal`; tests provide a programmatic stub.
    */
   fuzzyPick: (
-    options: FocusProfileChoice[],
+    options: ProfileChoice[],
     title: string,
-  ) => Promise<FocusProfileChoice | null>;
+  ) => Promise<ProfileChoice | null>;
   /** Returns the currently-active file path, or null if no file is open. */
   getActiveFilePath: () => string | null;
   /**
@@ -79,16 +79,16 @@ export interface FocusProfileCommandsDeps {
   notify: (message: string) => void;
 }
 
-export class FocusProfileCommands {
+export class ProfileCommands {
   private readonly switchMgr: ProfileApplyManager;
   private readonly pushMgr: IAssetSpacePusher;
-  private readonly profileLister: () => Promise<FocusProfileChoice[]>;
-  private readonly fuzzyPick: FocusProfileCommandsDeps["fuzzyPick"];
+  private readonly profileLister: () => Promise<ProfileChoice[]>;
+  private readonly fuzzyPick: ProfileCommandsDeps["fuzzyPick"];
   private readonly getActiveFilePath: () => string | null;
   private readonly getActiveProfileUid: () => string | null;
   private readonly notify: (message: string) => void;
 
-  constructor(deps: FocusProfileCommandsDeps) {
+  constructor(deps: ProfileCommandsDeps) {
     this.switchMgr = deps.switchMgr;
     this.pushMgr = deps.pushMgr;
     this.profileLister = deps.profileLister;
@@ -114,8 +114,8 @@ export class FocusProfileCommands {
    * User-facing error mapping: TsFloorViolationError, UncommittedChangesAbortError,
    * and HardSwitchAbortedByUser get clear notices distinct from generic «Apply failed».
    */
-  async invokeSwitchKnowledgeProfile(): Promise<void> {
-    let profiles: FocusProfileChoice[];
+  async invokeApplyProfile(): Promise<void> {
+    let profiles: ProfileChoice[];
     try {
       profiles = await this.profileLister();
     } catch (e) {
@@ -182,7 +182,7 @@ export class FocusProfileCommands {
       return;
     }
 
-    const folderName = FocusProfileCommands.extractAssetSpaceFolder(activePath);
+    const folderName = ProfileCommands.extractAssetSpaceFolder(activePath);
     if (folderName === null) {
       this.notify(
         "Not in an assetspace folder (expected path under `assetspaces/<as>/`)",
@@ -243,7 +243,7 @@ export class FocusProfileCommands {
    */
   private async resolveLabel(
     uid: string | null,
-    lister: () => Promise<FocusProfileChoice[]>,
+    lister: () => Promise<ProfileChoice[]>,
   ): Promise<string> {
     if (uid === null || uid.length === 0) return "(none)";
     try {

--- a/packages/obsidian-plugin/src/infrastructure/adapters/ProfileFuzzyModal.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/ProfileFuzzyModal.ts
@@ -1,10 +1,10 @@
 import { App, FuzzySuggestModal } from "obsidian";
 
-import type { FocusProfileChoice } from "./FocusProfileCommands";
+import type { ProfileChoice } from "./ProfileCommands";
 
 /**
  * ProfileFuzzyModal — thin Obsidian `FuzzySuggestModal` wrapper used by
- * `FocusProfileCommands.fuzzyPick` (RFC 0a0791c1 §B.11). Resolves the
+ * `ProfileCommands.fuzzyPick` (RFC 0a0791c1 §B.11). Resolves the
  * caller's Promise with the chosen profile, or `null` when the user
  * dismisses the picker without selecting anything.
  *
@@ -18,30 +18,30 @@ import type { FocusProfileChoice } from "./FocusProfileCommands";
  * Active profile is decorated с trailing «✓ (active)» so users can see
  * the current selection без duplicating the picker state.
  */
-export class ProfileFuzzyModal extends FuzzySuggestModal<FocusProfileChoice> {
+export class ProfileFuzzyModal extends FuzzySuggestModal<ProfileChoice> {
   private resolved = false;
-  private readonly resolve: (value: FocusProfileChoice | null) => void;
+  private readonly resolve: (value: ProfileChoice | null) => void;
 
   constructor(
     app: App,
-    private readonly options: FocusProfileChoice[],
+    private readonly options: ProfileChoice[],
     title: string,
-    resolve: (value: FocusProfileChoice | null) => void,
+    resolve: (value: ProfileChoice | null) => void,
   ) {
     super(app);
     this.resolve = resolve;
     this.setPlaceholder(title);
   }
 
-  getItems(): FocusProfileChoice[] {
+  getItems(): ProfileChoice[] {
     return this.options;
   }
 
-  getItemText(item: FocusProfileChoice): string {
+  getItemText(item: ProfileChoice): string {
     return item.isActive ? `${item.label} ✓ (active)` : item.label;
   }
 
-  onChooseItem(item: FocusProfileChoice): void {
+  onChooseItem(item: ProfileChoice): void {
     if (this.resolved) return;
     this.resolved = true;
     this.resolve(item);

--- a/packages/obsidian-plugin/src/infrastructure/adapters/SwitchCacheLayer.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/SwitchCacheLayer.ts
@@ -16,7 +16,7 @@ import { createTarGzip, parseTarGzip, type TarFileInput } from "nanotar";
 
 /**
  * SwitchCacheLayer — filesystem-backed AssetSpace snapshot cache for
- * FocusProfile hard switch (RFC 22b50a17 §Key sub-systems B.5).
+ * Profile hard switch (RFC 22b50a17 §Key sub-systems B.5).
  *
  * Layout (Decision #6 — wipe-all retention model):
  *   <cacheDir>/<asUid>/<sha>.tar.gz   — gzip tarball (F1 content-root convention)
@@ -40,7 +40,7 @@ import { createTarGzip, parseTarGzip, type TarFileInput } from "nanotar";
  * hard switch is desktop-only (depends on git submodule ops + Node fs).
  *
  * Sync `getCacheStats()` is preserved for the v3 Settings UI render-path
- * (`ExocortexSettingTab.renderFocusProfileSections`). Reads cache dir
+ * (`ExocortexSettingTab.renderProfileSections`). Reads cache dir
  * synchronously — fast enough for the small entry counts expected.
  */
 
@@ -482,7 +482,7 @@ export class SwitchCacheLayer implements ICacheLayer {
 
   /**
    * Synchronous stats snapshot for the v3 Settings UI display path
-   * (`ExocortexSettingTab.renderFocusProfileSections` builds its widget
+   * (`ExocortexSettingTab.renderProfileSections` builds its widget
    * synchronously per Obsidian's `PluginSettingTab` contract).
    *
    * On mobile: returns zeros without touching Node fs. The Settings UI

--- a/packages/obsidian-plugin/src/infrastructure/adapters/VaultProfileResolver.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/VaultProfileResolver.ts
@@ -8,11 +8,11 @@ import { PROFILE_CLASS_UID } from "./ProfileApplyManager";
 
 /**
  * Vault-backed implementation of {@link IProfileResolver}. Reads
- * `exo__FocusProfile` ABox assets через Obsidian metadataCache.
+ * `exo__Profile` ABox assets через Obsidian metadataCache.
  *
- * Profile identification: an asset is a FocusProfile when its
+ * Profile identification: an asset is a Profile when its
  * `exo__Instance_class` (string or array) contains a wikilink to the
- * FocusProfile class UID `3de846cd-...` (frozen by RFC b6ba5595).
+ * Profile class UID `3de846cd-...` (frozen by RFC b6ba5595).
  *
  * Frontmatter fields consumed:
  *   - `exo__Asset_uid` (string) — profile UID
@@ -40,7 +40,7 @@ export class VaultProfileResolver implements IProfileResolver {
 
   async resolve(profileUid: string): Promise<ProfileResolution | null> {
     if (typeof profileUid !== "string" || profileUid.length === 0) return null;
-    const file = this.findFocusProfileFileByUid(profileUid);
+    const file = this.findProfileFileByUid(profileUid);
     if (file === null) return null;
 
     const fm = this.readFrontmatter(file);
@@ -82,15 +82,15 @@ export class VaultProfileResolver implements IProfileResolver {
   }
 
   /**
-   * Walks the vault searching for the FocusProfile asset whose
+   * Walks the vault searching for the Profile asset whose
    * `exo__Asset_uid` matches. Returns `null` if absent.
    *
    * Exposed for `profileLister` reuse — the plugin's command-palette
-   * handler scans the vault для all FocusProfile assets, so the same
+   * handler scans the vault для all Profile assets, so the same
    * frontmatter discrimination logic lives here.
    */
-  public findFocusProfileFileByUid(uid: string): TFile | null {
-    for (const file of this.listFocusProfileFiles()) {
+  public findProfileFileByUid(uid: string): TFile | null {
+    for (const file of this.listProfileFiles()) {
       const fm = this.readFrontmatter(file);
       if (fm === null) continue;
       if (fm["exo__Asset_uid"] === uid) return file;
@@ -99,17 +99,17 @@ export class VaultProfileResolver implements IProfileResolver {
   }
 
   /**
-   * Walks the vault returning every FocusProfile asset. Caller filters
+   * Walks the vault returning every Profile asset. Caller filters
    * по UID / label as needed. Used by `profileLister` to populate the
    * fuzzy picker.
    */
-  public listFocusProfileFiles(): TFile[] {
+  public listProfileFiles(): TFile[] {
     return this.listProfileFilesByClass(PROFILE_CLASS_UID);
   }
 
   /**
    * Walks the vault returning assets whose `exo__Instance_class` contains the
-   * given class UID. Used by {@link listFocusProfileFiles}. (RFC 01a83de8
+   * given class UID. Used by {@link listProfileFiles}. (RFC 01a83de8
    * Phase 3 T4 collapsed the former per-class Knowledge picker into the single
    * `exo__Profile` class, so there is now one profile list.)
    */

--- a/packages/obsidian-plugin/src/presentation/settings/ExocortexSettingTab.ts
+++ b/packages/obsidian-plugin/src/presentation/settings/ExocortexSettingTab.ts
@@ -388,10 +388,10 @@ export class ExocortexSettingTab extends PluginSettingTab {
         }),
       );
 
-    // Issue #3320 — RFC 0a0791c1 §B.8 — 4 FocusProfile-related sections
+    // Issue #3320 — RFC 0a0791c1 §B.8 — 4 Profile-related sections
     // (PAT, Active profile, Switch cache, Operations log). Rendered after
     // the existing sections so the diff stays additive.
-    this.renderFocusProfileSections(containerEl);
+    this.renderProfileSections(containerEl);
 
     // Template syntax help
     const helpEl = containerEl.createDiv({
@@ -538,7 +538,7 @@ export class ExocortexSettingTab extends PluginSettingTab {
   }
 
   /**
-   * Issue #3320 — render the 4 FocusProfile sections (PAT, Active profile,
+   * Issue #3320 — render the 4 Profile sections (PAT, Active profile,
    * Switch cache, Operations log) per RFC 0a0791c1 §B.8.
    *
    * Architectural notes:
@@ -550,7 +550,7 @@ export class ExocortexSettingTab extends PluginSettingTab {
    *     getCacheStats() and shows zeros — acceptable»).
    *
    *   - ProfileApplyManager is NOT constructed here — it would race
-   *     the manager from registerFocusProfileCommands on the persisted
+   *     the manager from registerProfileCommands on the persisted
    *     lock file. Plugin exposes a hoisted instance via
    *     `plugin.profileApplyManager`.
    *
@@ -571,7 +571,7 @@ export class ExocortexSettingTab extends PluginSettingTab {
    *     created synchronously and populated via an IIFE so display() stays
    *     synchronous per Obsidian's PluginSettingTab contract.
    */
-  private renderFocusProfileSections(containerEl: HTMLElement): void {
+  private renderProfileSections(containerEl: HTMLElement): void {
     const app = this.plugin.app;
     const notifier = this.plugin.notifier;
     const secretsStore = new LocalSecretsStore({ app });
@@ -600,7 +600,7 @@ export class ExocortexSettingTab extends PluginSettingTab {
       " A hard switch that physically materializes or tears down AssetSpace " +
         "submodules on disk (and rewrites .gitmodules). Heavyweight: a " +
         "confirmation gate, an uncommitted-changes guard, and ~30 s per " +
-        "freshly-pulled AssetSpace. Pick a KnowledgeProfile asset via the " +
+        "freshly-pulled AssetSpace. Pick a Profile asset via the " +
         "«Exocortex: Switch knowledge profile (filesystem destroy + " +
         "materialize)» command (Cmd+P). Use it to " +
         "install or remove whole ontology bundles and to keep " +
@@ -611,7 +611,7 @@ export class ExocortexSettingTab extends PluginSettingTab {
     focusLi.appendText(
       " A soft switch that applies a query-time RDF filter; nothing changes " +
         "on disk. Lightweight: ~1–2 s reindex, instantly reversible. Pick a " +
-        "FocusProfile asset via the dropdown below or the «Exocortex: Switch " +
+        "Profile asset via the dropdown below or the «Exocortex: Switch " +
         "focus profile» command. Use it to narrow search / SPARQL / graph " +
         "view to the slice you are working in right now.",
     );
@@ -625,7 +625,7 @@ export class ExocortexSettingTab extends PluginSettingTab {
 
     // ─────── Section 1 — PAT (GitHub Personal Access Token) ───────
     // eslint-disable-next-line obsidianmd/ui/sentence-case -- "GitHub" + "PAT" are proper noun + established acronym
-    new Setting(containerEl).setName("FocusProfile: GitHub PAT").setHeading();
+    new Setting(containerEl).setName("Profile: GitHub PAT").setHeading();
 
     const patDesc = containerEl.createDiv({ cls: "setting-item-description" });
     patDesc.appendText(
@@ -711,7 +711,7 @@ export class ExocortexSettingTab extends PluginSettingTab {
 
     // Issue #3327 Item #3 — read switch state from device-local store
     // (data.local.json). `plugin.localDataStore` is null until
-    // `registerFocusProfileCommands` resolves (and undefined in unit
+    // `registerProfileCommands` resolves (and undefined in unit
     // tests с partial plugin mocks); treat as no-active-profile before
     // then, matching the previous fallback behaviour.
     //
@@ -779,7 +779,7 @@ export class ExocortexSettingTab extends PluginSettingTab {
         // UID → label lookup uses the same profile lister как the Cmd+P
         // picker, so labels match exactly. Fall back to UID[:8] when an
         // entry references a since-deleted profile.
-        const lister = this.plugin.listFocusProfileChoices;
+        const lister = this.plugin.listProfileChoices;
         const labelByUid: Map<string, string> = new Map();
         if (lister !== null) {
           try {

--- a/packages/obsidian-plugin/tests/e2e/specs/focus-profile-picker.spec.ts
+++ b/packages/obsidian-plugin/tests/e2e/specs/focus-profile-picker.spec.ts
@@ -7,7 +7,7 @@ import * as path from "path";
 /**
  * E2E render smoke for the «Exocortex: Apply profile» command
  * (`hard-switch-focus-profile`, wired in
- * `ExocortexPlugin.registerFocusProfileCommands`).
+ * `ExocortexPlugin.registerProfileCommands`).
  *
  * RFC 0a0791c1 Phase 5 T2 consolidated the former soft «Switch focus profile»
  * (`switch-focus-profile`) + mount-state «Switch knowledge profile» commands
@@ -36,7 +36,7 @@ import * as path from "path";
  *   SPARQL, which expects the expanded `exocmd:Command` IRI while the test
  *   vault uses symbolic `[[exocmd__Command]]` class wikilinks — a
  *   fixture-resolution gap. The profile picker has NO such gap:
- *   `VaultProfileResolver.listFocusProfileFiles` discovers profiles by a plain
+ *   `VaultProfileResolver.listProfileFiles` discovers profiles by a plain
  *   substring match on the raw `exo__Instance_class` frontmatter string
  *   (`instanceClassContains` → `c.includes(PROFILE_CLASS_UID)`), reading
  *   straight from `metadataCache` — no triple-store IRI expansion. The
@@ -50,7 +50,7 @@ import * as path from "path";
  *
  * Revert-verify (documented in the PR body): removing the fixtures (or
  * downgrading their class wikilink to symbolic form) makes `profileLister`
- * return `[]`, so `invokeSwitchKnowledgeProfile` early-returns with the
+ * return `[]`, so `invokeApplyProfile` early-returns with the
  * «No profiles found in vault» Notice and NEVER opens the modal — the
  * `.suggestion-item` assertion then times out and this spec FAILS.
  */
@@ -115,7 +115,7 @@ test.describe("Focus profile picker — render smoke", () => {
       specName: "focus-profile-picker",
     });
 
-    // The command is registered only after `registerFocusProfileCommands()`
+    // The command is registered only after `registerProfileCommands()`
     // runs during onload. Poll for it so the spec does not race the boot
     // pipeline. A missing command id here means a load-time regression.
     await expect
@@ -134,7 +134,7 @@ test.describe("Focus profile picker — render smoke", () => {
       )
       .toBe(true);
 
-    // Poll until metadataCache has the FocusProfile fixtures indexed the same
+    // Poll until metadataCache has the Profile fixtures indexed the same
     // way `VaultProfileResolver.instanceClassContains` discovers them — a
     // substring match on the raw `exo__Instance_class` string. This makes the
     // command trigger deterministic (Docker Obsidian populates the cache
@@ -166,7 +166,7 @@ test.describe("Focus profile picker — render smoke", () => {
           }, PROFILE_CLASS_UID),
         {
           timeout: 30000,
-          message: "FocusProfile fixtures not discoverable in metadataCache",
+          message: "Profile fixtures not discoverable in metadataCache",
         },
       )
       .toBeGreaterThanOrEqual(2);
@@ -177,7 +177,7 @@ test.describe("Focus profile picker — render smoke", () => {
     const loadPhaseConsoleErrors = consoleErrors.length;
 
     // Trigger the command. The callback is fire-and-forget (`void
-    // invokeSwitchKnowledgeProfile()`): it lists profiles then opens ProfileFuzzyModal.
+    // invokeApplyProfile()`): it lists profiles then opens ProfileFuzzyModal.
     await window.evaluate((id) => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const app = (window as any).app;

--- a/packages/obsidian-plugin/tests/unit/ExocortexSettingTab.focusProfile.test.ts
+++ b/packages/obsidian-plugin/tests/unit/ExocortexSettingTab.focusProfile.test.ts
@@ -1,7 +1,7 @@
 /**
  * Issue #3320 — Settings UI 4-section rendering tests.
  *
- * Verifies that `display()` calls `renderFocusProfileSections` and that
+ * Verifies that `display()` calls `renderProfileSections` and that
  * each section's Setting builder is invoked с the expected name / heading
  * sequence: PAT → Active profile → Switch cache → Operations log.
  *
@@ -106,7 +106,7 @@ jest.mock("@plugin/infrastructure/adapters/SwitchCacheLayer", () => ({
   },
 }));
 
-describe("ExocortexSettingTab — Issue #3320 FocusProfile sections", () => {
+describe("ExocortexSettingTab — Issue #3320 Profile sections", () => {
   let settingTab: ExocortexSettingTab;
   let mockApp: any;
   let mockPlugin: any;
@@ -163,7 +163,7 @@ describe("ExocortexSettingTab — Issue #3320 FocusProfile sections", () => {
       toggleTabTitleLabels: jest.fn(),
       applyDisplayNameTemplate: jest.fn(),
       configureLogChannels: jest.fn(),
-      listFocusProfileChoices: jest.fn().mockResolvedValue([
+      listProfileChoices: jest.fn().mockResolvedValue([
         { uid: "uid-a", label: "Personal", isActive: false },
         { uid: "uid-b", label: "Work", isActive: true },
       ]),
@@ -238,13 +238,13 @@ describe("ExocortexSettingTab — Issue #3320 FocusProfile sections", () => {
     settingTab.containerEl = mockContainerEl;
   });
 
-  it("renders all 4 FocusProfile section headings in expected order", () => {
+  it("renders all 4 Profile section headings in expected order", () => {
     settingTab.display();
     const headings = settingCalls.filter((c) => c.heading).map((c) => c.name);
     // The Display-Name section also contributes headings. We just assert
     // что 4 expected headings appear в the correct relative order.
     const expected = [
-      "FocusProfile: GitHub PAT",
+      "Profile: GitHub PAT",
       "Active profile",
       "Switch cache",
       "Operations log",

--- a/packages/obsidian-plugin/tests/unit/ProfileCommands.test.ts
+++ b/packages/obsidian-plugin/tests/unit/ProfileCommands.test.ts
@@ -1,9 +1,9 @@
 import {
-  FocusProfileCommands,
-  type FocusProfileChoice,
-  type FocusProfileCommandsDeps,
+  ProfileCommands,
+  type ProfileChoice,
+  type ProfileCommandsDeps,
   type IAssetSpacePusher,
-} from "../../src/infrastructure/adapters/FocusProfileCommands";
+} from "../../src/infrastructure/adapters/ProfileCommands";
 import {
   type ProfileApplyManager,
   HardSwitchAbortedByUser,
@@ -47,15 +47,15 @@ interface Harness {
   switchMgr: FakeSwitchMgr;
   pushMgr: FakePushMgr;
   notices: string[];
-  pickCalls: { options: FocusProfileChoice[]; title: string }[];
-  fuzzyResult: FocusProfileChoice | null;
+  pickCalls: { options: ProfileChoice[]; title: string }[];
+  fuzzyResult: ProfileChoice | null;
   activeFilePath: string | null;
-  cmd: FocusProfileCommands;
+  cmd: ProfileCommands;
 }
 
 function makeHarness(opts: {
-  profiles: FocusProfileChoice[];
-  pickResult?: FocusProfileChoice | null;
+  profiles: ProfileChoice[];
+  pickResult?: ProfileChoice | null;
   activeFilePath?: string | null;
   asLookups?: Array<[string, string]>;
   listError?: Error;
@@ -68,8 +68,8 @@ function makeHarness(opts: {
       pushMgr.lookups.set(folder, uid);
   }
   const notices: string[] = [];
-  const pickCalls: { options: FocusProfileChoice[]; title: string }[] = [];
-  const deps: FocusProfileCommandsDeps = {
+  const pickCalls: { options: ProfileChoice[]; title: string }[] = [];
+  const deps: ProfileCommandsDeps = {
     switchMgr: switchMgr as unknown as ProfileApplyManager,
     pushMgr,
     profileLister: async () => {
@@ -91,7 +91,7 @@ function makeHarness(opts: {
     pickCalls,
     fuzzyResult: opts.pickResult ?? null,
     activeFilePath: opts.activeFilePath ?? null,
-    cmd: new FocusProfileCommands(deps),
+    cmd: new ProfileCommands(deps),
   };
 }
 
@@ -99,7 +99,7 @@ function makeHarness(opts: {
 // invokePushCurrentAssetSpace
 // ═══════════════════════════════════════════════════════════════════════════
 
-describe("FocusProfileCommands.invokePushCurrentAssetSpace", () => {
+describe("ProfileCommands.invokePushCurrentAssetSpace", () => {
   it("Notice when no active file", async () => {
     const h = makeHarness({ profiles: [], activeFilePath: null });
     await h.cmd.invokePushCurrentAssetSpace();
@@ -180,16 +180,16 @@ describe("FocusProfileCommands.invokePushCurrentAssetSpace", () => {
 // extractAssetSpaceFolder helper
 // ═══════════════════════════════════════════════════════════════════════════
 
-describe("FocusProfileCommands.extractAssetSpaceFolder", () => {
+describe("ProfileCommands.extractAssetSpaceFolder", () => {
   it("extracts folder from typical path", () => {
     expect(
-      FocusProfileCommands.extractAssetSpaceFolder("assetspaces/exo/foo.md"),
+      ProfileCommands.extractAssetSpaceFolder("assetspaces/exo/foo.md"),
     ).toBe("assetspaces/exo");
   });
 
   it("extracts folder from deeply nested path", () => {
     expect(
-      FocusProfileCommands.extractAssetSpaceFolder(
+      ProfileCommands.extractAssetSpaceFolder(
         "assetspaces/ems/sub/dir/bar.md",
       ),
     ).toBe("assetspaces/ems");
@@ -198,7 +198,7 @@ describe("FocusProfileCommands.extractAssetSpaceFolder", () => {
   it("normalizes Windows backslash separators", () => {
     // Source `\\` = single backslash in actual string → regex /\\/ matches
     expect(
-      FocusProfileCommands.extractAssetSpaceFolder(
+      ProfileCommands.extractAssetSpaceFolder(
         "assetspaces\\shared-identities\\file.md",
       ),
     ).toBe("assetspaces/shared-identities");
@@ -206,31 +206,31 @@ describe("FocusProfileCommands.extractAssetSpaceFolder", () => {
 
   it("returns null for path outside assetspaces", () => {
     expect(
-      FocusProfileCommands.extractAssetSpaceFolder(
+      ProfileCommands.extractAssetSpaceFolder(
         "03 Knowledge/inbox/note.md",
       ),
     ).toBeNull();
     expect(
-      FocusProfileCommands.extractAssetSpaceFolder("inbox/note.md"),
+      ProfileCommands.extractAssetSpaceFolder("inbox/note.md"),
     ).toBeNull();
   });
 
   it("returns null when assetspaces/ has no sub-folder", () => {
     expect(
-      FocusProfileCommands.extractAssetSpaceFolder("assetspaces/loose.md"),
+      ProfileCommands.extractAssetSpaceFolder("assetspaces/loose.md"),
     ).toBeNull();
   });
 });
 
 // ═══════════════════════════════════════════════════════════════════════════
-// invokeSwitchKnowledgeProfile — «Apply profile» (RFC 0a0791c1 Phase 5 T2)
+// invokeApplyProfile — «Apply profile» (RFC 0a0791c1 Phase 5 T2)
 // ═══════════════════════════════════════════════════════════════════════════
 
-describe("FocusProfileCommands.invokeSwitchKnowledgeProfile (Apply profile)", () => {
+describe("ProfileCommands.invokeApplyProfile (Apply profile)", () => {
   it("opens the picker from the single profile lister with the «Apply profile» title", async () => {
     const profiles = [{ uid: "k1", label: "knowledge-one" }];
     const h = makeHarness({ profiles, pickResult: profiles[0] });
-    await h.cmd.invokeSwitchKnowledgeProfile();
+    await h.cmd.invokeApplyProfile();
 
     expect(h.pickCalls).toHaveLength(1);
     expect(h.pickCalls[0].options).toEqual(profiles);
@@ -240,14 +240,14 @@ describe("FocusProfileCommands.invokeSwitchKnowledgeProfile (Apply profile)", ()
   it("invokes applyProfile with the chosen uid", async () => {
     const profiles = [{ uid: "k1", label: "knowledge-one" }];
     const h = makeHarness({ profiles, pickResult: profiles[0] });
-    await h.cmd.invokeSwitchKnowledgeProfile();
+    await h.cmd.invokeApplyProfile();
 
     expect(h.switchMgr.hardSwitchCalls).toEqual(["k1"]);
   });
 
   it("shows Notice when no profiles in vault", async () => {
     const h = makeHarness({ profiles: [] });
-    await h.cmd.invokeSwitchKnowledgeProfile();
+    await h.cmd.invokeApplyProfile();
 
     expect(h.pickCalls).toHaveLength(0);
     expect(h.notices.some((n) => /No profiles found/.test(n))).toBe(true);
@@ -256,7 +256,7 @@ describe("FocusProfileCommands.invokeSwitchKnowledgeProfile (Apply profile)", ()
   it("does nothing when user cancels picker", async () => {
     const profiles = [{ uid: "k1", label: "k1" }];
     const h = makeHarness({ profiles, pickResult: null });
-    await h.cmd.invokeSwitchKnowledgeProfile();
+    await h.cmd.invokeApplyProfile();
 
     expect(h.switchMgr.hardSwitchCalls).toHaveLength(0);
   });
@@ -266,7 +266,7 @@ describe("FocusProfileCommands.invokeSwitchKnowledgeProfile (Apply profile)", ()
     const h = makeHarness({ profiles, pickResult: profiles[0] });
     h.switchMgr.hardSwitchThrows = new HardSwitchAbortedByUser();
 
-    await expect(h.cmd.invokeSwitchKnowledgeProfile()).resolves.not.toThrow();
+    await expect(h.cmd.invokeApplyProfile()).resolves.not.toThrow();
     expect(h.notices.some((n) => /cancelled/i.test(n))).toBe(true);
   });
 
@@ -277,7 +277,7 @@ describe("FocusProfileCommands.invokeSwitchKnowledgeProfile (Apply profile)", ()
       "missing $exo floor",
     );
 
-    await h.cmd.invokeSwitchKnowledgeProfile();
+    await h.cmd.invokeApplyProfile();
     expect(h.notices.some((n) => /refused.*missing \$exo floor/.test(n))).toBe(
       true,
     );
@@ -290,7 +290,7 @@ describe("FocusProfileCommands.invokeSwitchKnowledgeProfile (Apply profile)", ()
       { asUid: "as1", submodulePath: "assetspaces/x", files: ["a.md", "b.md"] },
     ]);
 
-    await h.cmd.invokeSwitchKnowledgeProfile();
+    await h.cmd.invokeApplyProfile();
     expect(h.notices.some((n) => /aborted.*2 uncommitted file/.test(n))).toBe(
       true,
     );
@@ -301,7 +301,7 @@ describe("FocusProfileCommands.invokeSwitchKnowledgeProfile (Apply profile)", ()
     const h = makeHarness({ profiles, pickResult: profiles[0] });
     h.switchMgr.hardSwitchThrows = new Error("boom");
 
-    await expect(h.cmd.invokeSwitchKnowledgeProfile()).resolves.not.toThrow();
+    await expect(h.cmd.invokeApplyProfile()).resolves.not.toThrow();
     expect(h.notices.some((n) => /failed.*boom/.test(n))).toBe(true);
   });
 });
@@ -310,7 +310,7 @@ describe("FocusProfileCommands.invokeSwitchKnowledgeProfile (Apply profile)", ()
 // invokeShowCurrentState (RFC 0a0791c1 Phase 5 T2 — single slot)
 // ═══════════════════════════════════════════════════════════════════════════
 
-describe("FocusProfileCommands.invokeShowCurrentState", () => {
+describe("ProfileCommands.invokeShowCurrentState", () => {
   it("reports the active profile label", async () => {
     const h = makeHarness({
       profiles: [{ uid: "k1", label: "knowledge-main" }],

--- a/packages/obsidian-plugin/tests/unit/ProfileFuzzyModal.test.ts
+++ b/packages/obsidian-plugin/tests/unit/ProfileFuzzyModal.test.ts
@@ -1,9 +1,9 @@
 import { ProfileFuzzyModal } from "../../src/infrastructure/adapters/ProfileFuzzyModal";
-import type { FocusProfileChoice } from "../../src/infrastructure/adapters/FocusProfileCommands";
+import type { ProfileChoice } from "../../src/infrastructure/adapters/ProfileCommands";
 
 const fakeApp = {} as any;
 
-const profiles: FocusProfileChoice[] = [
+const profiles: ProfileChoice[] = [
   { uid: "uid-personal", label: "Personal" },
   { uid: "uid-work", label: "Work", isActive: true },
   { uid: "uid-reading", label: "Reading" },

--- a/packages/obsidian-plugin/tests/unit/VaultProfileResolver.test.ts
+++ b/packages/obsidian-plugin/tests/unit/VaultProfileResolver.test.ts
@@ -22,13 +22,13 @@ function makeApp(files: { file: FakeFile; fm: Record<string, unknown> }[]) {
   } as any;
 }
 
-describe("VaultProfileResolver.listFocusProfileFiles", () => {
-  it("returns files whose Instance_class wikilink contains the FocusProfile UID", () => {
+describe("VaultProfileResolver.listProfileFiles", () => {
+  it("returns files whose Instance_class wikilink contains the Profile UID", () => {
     const app = makeApp([
       {
         file: { path: "a.md", basename: "a" },
         fm: {
-          exo__Instance_class: `[[${PROFILE_CLASS_UID}|exo__FocusProfile]]`,
+          exo__Instance_class: `[[${PROFILE_CLASS_UID}|exo__Profile]]`,
           exo__Asset_uid: "p1",
           exo__Asset_label: "Profile One",
         },
@@ -45,14 +45,14 @@ describe("VaultProfileResolver.listFocusProfileFiles", () => {
         fm: {
           exo__Instance_class: [
             "[[ems__Project]]",
-            `[[${PROFILE_CLASS_UID}|exo__FocusProfile]]`,
+            `[[${PROFILE_CLASS_UID}|exo__Profile]]`,
           ],
           exo__Asset_uid: "p2",
         },
       },
     ]);
     const resolver = new VaultProfileResolver(app);
-    const found = resolver.listFocusProfileFiles().map((f) => f.path);
+    const found = resolver.listProfileFiles().map((f) => f.path);
     expect(found.sort()).toEqual(["a.md", "c.md"]);
   });
 
@@ -72,19 +72,19 @@ describe("VaultProfileResolver.listFocusProfileFiles", () => {
       { path: "b.md", basename: "b" },
     ];
     const resolver = new VaultProfileResolver(app);
-    expect(resolver.listFocusProfileFiles().map((f) => f.path)).toEqual([
+    expect(resolver.listProfileFiles().map((f) => f.path)).toEqual([
       "a.md",
     ]);
   });
 
-  it("findFocusProfileFileByUid returns null when UID is empty", () => {
+  it("findProfileFileByUid returns null when UID is empty", () => {
     const app = makeApp([]);
     expect(
-      new VaultProfileResolver(app).findFocusProfileFileByUid(""),
+      new VaultProfileResolver(app).findProfileFileByUid(""),
     ).toBeNull();
   });
 
-  it("findFocusProfileFileByUid matches by exo__Asset_uid", () => {
+  it("findProfileFileByUid matches by exo__Asset_uid", () => {
     const app = makeApp([
       {
         file: { path: "a.md", basename: "a" },
@@ -102,7 +102,7 @@ describe("VaultProfileResolver.listFocusProfileFiles", () => {
       },
     ]);
     const resolver = new VaultProfileResolver(app);
-    const file = resolver.findFocusProfileFileByUid("p2");
+    const file = resolver.findProfileFileByUid("p2");
     expect(file?.path).toBe("b.md");
   });
 });
@@ -188,9 +188,9 @@ describe("VaultProfileResolver.resolve", () => {
 });
 
 
-// RFC 01a83de8 Phase 3 T4 — listKnowledgeProfileFiles removed (the former
-// per-class KnowledgeProfile picker collapsed into the single exo__Profile
-// class; the mount-state picker now uses listFocusProfileFiles).
+// RFC 01a83de8 Phase 3 T4 — the former per-class profile picker collapsed into
+// the single exo__Profile class; the mount-state picker now uses
+// listProfileFiles).
 
 describe("VaultProfileResolver.discoverSharedOntologies", () => {
   it("returns empty array (v3 backward-compat — TS-floor pattern handles shared- prefix)", async () => {


### PR DESCRIPTION
## Summary
PR **3 of 4** in the Phase 5 T3 symbol-rename sequence (RFC 0a0791c1). Mechanical, **zero-behavior-change** rename of the profile command-palette / picker / settings / resolver symbols. No logic touched.

Renamed (all occurrences):
- `FocusProfileCommands` → `ProfileCommands` (class + `FocusProfileCommandsDeps` interface + **file rename** + test file)
- `FocusProfileChoice` → `ProfileChoice`
- `registerFocusProfileCommands` → `registerProfileCommands`
- `invokeSwitchKnowledgeProfile` → `invokeApplyProfile`
- `listFocusProfileChoices` → `listProfileChoices`
- `renderFocusProfileSections` → `renderProfileSections`
- `findFocusProfileFileByUid` → `findProfileFileByUid`; `listFocusProfileFiles` → `listProfileFiles`
- standalone Focus/Knowledge-profile prose (settings help text, comments) → Profile

## Zero-behavior-change
Pure identifier/file rename. `invokeApplyProfile` is the former `invokeSwitchKnowledgeProfile` verbatim (lists profiles → opens `ProfileFuzzyModal` → calls `applyProfile`). The picker still discovers profiles by UID substring on `exo__Instance_class` (unchanged). Command id `hard-switch-focus-profile` and the lowercase e2e paths (`focus-profile-picker.spec.ts`, `test-vault/focus-profiles/`) are preserved (out of the CamelCase gate).

## Verification
- `npm run check:types` — green
- `npm run lint` — 0 errors (2 pre-existing warnings, untouched files)
- 56 affected tests pass (ProfileCommands, ProfileFuzzyModal, VaultProfileResolver, ExocortexSettingTab.focusProfile, FocusProfileWiring)
- pre-commit archgate 16/16

## Sequence
PR1 ✅ → PR2 ✅ → **PR3 (this)** → PR4 (FocusProfileOnloadWiring file rename + storage-slot comments + residual prose). Final gate-grep = 0 asserted after PR4.

## Test plan
- [ ] CI: 14 required checks green