### PR TITLE
refactor(cli): hard-switch → apply-profile rename (Phase 5 T6 PR1/3)

### DIFF
--- a/packages/cli/src/commands/apply-profile.ts
+++ b/packages/cli/src/commands/apply-profile.ts
@@ -4,9 +4,9 @@ import { resolve } from "path";
 import type { IConfirmGate } from "exocortex";
 import { CliProfileResolver } from "../services/CliProfileResolver.js";
 import {
-  CliHardSwitchService,
+  CliApplyProfileService,
   TsFloorViolationError,
-} from "../services/CliHardSwitchService.js";
+} from "../services/CliApplyProfileService.js";
 import { BootstrapAssetSpaceService } from "../services/BootstrapAssetSpaceService.js";
 import { HeadlessConfirmGate } from "../services/HeadlessConfirmGate.js";
 import { ErrorHandler } from "../utils/ErrorHandler.js";
@@ -17,9 +17,9 @@ import {
 import { ExitCodes } from "../utils/ExitCodes.js";
 
 /**
- * Options surface for `exocortex hard-switch <profile-uid>`.
+ * Options surface for `exocortex apply-profile <profile-uid>`.
  */
-export interface HardSwitchCommandOptions {
+export interface ApplyProfileCommandOptions {
   vault: string;
   yes?: boolean;
   verbose?: boolean;
@@ -34,28 +34,28 @@ export interface HardSwitchCommandOptions {
  * a fake `IConfirmGate` to verify the wiring without spinning a real CLI
  * subprocess.
  */
-export interface HardSwitchActionDeps {
+export interface ApplyProfileActionDeps {
   /** Override the confirm gate (test seam). */
   confirmGate?: IConfirmGate;
   /**
    * Override the resolver factory (test seam). Production omits and the
    * action constructs `CliProfileResolver` from CLI options.
    */
-  resolverFactory?: (opts: HardSwitchCommandOptions) => CliProfileResolver;
+  resolverFactory?: (opts: ApplyProfileCommandOptions) => CliProfileResolver;
   /**
-   * Override the hard-switch service factory (test seam). Production omits and
-   * the action constructs a `CliHardSwitchService` backed by a
+   * Override the apply-profile service factory (test seam). Production omits and
+   * the action constructs a `CliApplyProfileService` backed by a
    * `BootstrapAssetSpaceService` (Node `fetch` mount mechanics). Tests inject a
    * service with a fake `fetchImpl` so materialisation needs no network.
    */
-  hardSwitchServiceFactory?: (
-    opts: HardSwitchCommandOptions,
+  applyServiceFactory?: (
+    opts: ApplyProfileCommandOptions,
     vaultPath: string,
-  ) => CliHardSwitchService;
+  ) => CliApplyProfileService;
   /**
    * Override stdout sink. The default writes to `process.stdout`; tests
    * inject `() => {}` to silence. Either way, lines are also captured
-   * exactly once into the returned `HardSwitchResult.stdout`.
+   * exactly once into the returned `ApplyProfileResult.stdout`.
    */
   out?: (msg: string) => void;
   /** Override stderr sink — same capture-once contract as `out`. */
@@ -63,7 +63,7 @@ export interface HardSwitchActionDeps {
 }
 
 /**
- * Run the hard-switch flow. Throws typed `CLIError` subclasses on
+ * Run the apply-profile flow. Throws typed `CLIError` subclasses on
  * validation failure; the caller (commander action handler OR test) is
  * responsible for routing those through `ErrorHandler.handle` or capturing
  * them.
@@ -71,17 +71,17 @@ export interface HardSwitchActionDeps {
  * @returns A struct with the exit code and informational messages so
  *   tests can assert on outcomes without spying on process streams.
  */
-export interface HardSwitchResult {
+export interface ApplyProfileResult {
   exitCode: number;
   stdout: string[];
   stderr: string[];
 }
 
-export async function runHardSwitch(
+export async function runApplyProfile(
   profileUid: string,
-  opts: HardSwitchCommandOptions,
-  deps: HardSwitchActionDeps = {},
-): Promise<HardSwitchResult> {
+  opts: ApplyProfileCommandOptions,
+  deps: ApplyProfileActionDeps = {},
+): Promise<ApplyProfileResult> {
   const stdout: string[] = [];
   const stderr: string[] = [];
   const stdoutSink =
@@ -108,12 +108,12 @@ export async function runHardSwitch(
   if (!profileUid || profileUid.length === 0) {
     throw new InvalidArgumentsError(
       "profile-uid argument is required",
-      "exocortex hard-switch <profile-uid> --vault <path>",
+      "exocortex apply-profile <profile-uid> --vault <path>",
     );
   }
 
   // Validate + resolve the profile's effective AssetSpace set. The resolver
-  // scans the vault filesystem once; the hard-switch service does a second scan
+  // scans the vault filesystem once; the apply-profile service does a second scan
   // for AssetSpace descriptor metadata (git URL + derived mount folder).
   const resolver =
     deps.resolverFactory?.(opts) ??
@@ -130,35 +130,35 @@ export async function runHardSwitch(
     );
   }
   if (outcome.outcome === "error") {
-    err(`[hard-switch] Resolver error: ${outcome.reason}`);
+    err(`[apply-profile] Resolver error: ${outcome.reason}`);
     return { exitCode: ExitCodes.OPERATION_FAILED, stdout, stderr };
   }
   // `degraded` means the resolved effective set is empty (or overlaps nothing
-  // in the vault — R15 self-brick mitigation). Hard switch with a degraded
+  // in the vault — R15 self-brick mitigation). Apply with a degraded
   // outcome would destroy assetspaces against a profile that resolves to
   // nothing useful — refuse outright before touching the gate.
   if (outcome.outcome === "degraded") {
     err(
-      `[hard-switch] Refused: profile resolution degraded — ${outcome.reason}. Hard switch aborted to prevent vault corruption.`,
+      `[apply-profile] Refused: profile resolution degraded — ${outcome.reason}. Apply aborted to prevent vault corruption.`,
     );
     return { exitCode: ExitCodes.OPERATION_FAILED, stdout, stderr };
   }
   if (outcome.outcome !== "engaged") {
     // `no-profile` is unreachable (profileUid validated non-empty above);
     // guard defensively so TS narrows `outcome` to the engaged variant.
-    err(`[hard-switch] Unexpected resolver outcome: ${outcome.outcome}`);
+    err(`[apply-profile] Unexpected resolver outcome: ${outcome.outcome}`);
     return { exitCode: ExitCodes.OPERATION_FAILED, stdout, stderr };
   }
   const engaged = outcome.result;
 
-  // Build the hard-switch service. Token precedence: --token > GITHUB_TOKEN env
+  // Build the apply-profile service. Token precedence: --token > GITHUB_TOKEN env
   // > GH_TOKEN env (mirrors the `bootstrap` command). `||` not `??` so an empty
   // env var falls through.
   const token =
     opts.token || process.env.GITHUB_TOKEN || process.env.GH_TOKEN || undefined;
   const service =
-    deps.hardSwitchServiceFactory?.(opts, vaultPath) ??
-    new CliHardSwitchService({
+    deps.applyServiceFactory?.(opts, vaultPath) ??
+    new CliApplyProfileService({
       vaultPath,
       ref: opts.ref ?? "main",
       mount: new BootstrapAssetSpaceService({ token }),
@@ -185,7 +185,7 @@ export async function runHardSwitch(
     });
   } catch (e) {
     if (e instanceof TsFloorViolationError) {
-      err(`[hard-switch] Refused: ${e.message}`);
+      err(`[apply-profile] Refused: ${e.message}`);
       return { exitCode: ExitCodes.OPERATION_FAILED, stdout, stderr };
     }
     throw e;
@@ -208,7 +208,7 @@ export async function runHardSwitch(
   // Idempotent no-op: target already in mount-state ⇒ nothing to mutate.
   if (diff.toDestroy.length === 0 && diff.toMaterialize.length === 0) {
     out(
-      `[hard-switch] Already in target mount-state for ${targetProfileLabel} — no-op.`,
+      `[apply-profile] Already in target mount-state for ${targetProfileLabel} — no-op.`,
     );
     return { exitCode: ExitCodes.SUCCESS, stdout, stderr };
   }
@@ -218,7 +218,7 @@ export async function runHardSwitch(
     execResult = await service.execute(diff);
   } catch (e) {
     err(
-      `[hard-switch] Execution failed: ${
+      `[apply-profile] Execution failed: ${
         e instanceof Error ? e.message : String(e)
       }`,
     );
@@ -226,21 +226,21 @@ export async function runHardSwitch(
   }
 
   out(
-    `[hard-switch] Switched to ${targetProfileLabel}: ${execResult.destroyed.length} AssetSpace(s) torn down, ${execResult.materialized.length} materialized.`,
+    `[apply-profile] Switched to ${targetProfileLabel}: ${execResult.destroyed.length} AssetSpace(s) torn down, ${execResult.materialized.length} materialized.`,
   );
   return { exitCode: ExitCodes.SUCCESS, stdout, stderr };
 }
 
-export function hardSwitchCommand(): Command {
-  const cmd = new Command("hard-switch")
+export function applyProfileCommand(): Command {
+  const cmd = new Command("apply-profile")
     .description(
-      "Hard switch to specified Profile (mount-state filesystem mutation). Requires --yes for headless mode.",
+      "Apply the specified Profile (mount-state filesystem mutation). Requires --yes for headless mode.",
     )
     .argument("<profile-uid>", "Target Profile UID")
     .requiredOption("--vault <path>", "Path to Obsidian vault")
     .option(
       "--yes",
-      "Confirm hard switch (headless mode safety override per RFC 22b50a17 Decision #2)",
+      "Confirm apply (headless mode safety override per RFC 22b50a17 Decision #2)",
       false,
     )
     .option("--verbose", "Print plan summary to stderr before deciding", false)
@@ -249,9 +249,9 @@ export function hardSwitchCommand(): Command {
       "--token <pat>",
       "GitHub PAT for private-repo materialisation (or env GITHUB_TOKEN / GH_TOKEN)",
     )
-    .action(async (profileUid: string, opts: HardSwitchCommandOptions) => {
+    .action(async (profileUid: string, opts: ApplyProfileCommandOptions) => {
       try {
-        const result = await runHardSwitch(profileUid, opts);
+        const result = await runApplyProfile(profileUid, opts);
         process.exit(result.exitCode);
       } catch (e) {
         ErrorHandler.handle(e as Error);

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -20,7 +20,7 @@ import { recoverCommand } from "./commands/recover.js";
 import { findCommand } from "./commands/find.js";
 import { applyCommand } from "./commands/apply.js";
 import { auditCommand } from "./commands/audit.js";
-import { hardSwitchCommand } from "./commands/hard-switch.js";
+import { applyProfileCommand } from "./commands/apply-profile.js";
 import { bootstrapCommand } from "./commands/bootstrap.js";
 import { assetSpaceAddCommand } from "./commands/assetspace-add.js";
 import { experimentalCommand } from "./commands/experimental.js";
@@ -68,8 +68,8 @@ export function createProgram(version?: string): Command {
   // RFC 9d20c91f Phase 4+1 — regression-detection audits
   program.addCommand(auditCommand());
 
-  // RFC 22b50a17 Phase 1b — hard switch CLI scaffold (Phase 3 wires orchestrator)
-  program.addCommand(hardSwitchCommand());
+  // RFC 22b50a17 Phase 1b — apply CLI scaffold (Phase 3 wires orchestrator)
+  program.addCommand(applyProfileCommand());
 
   // RFC 13da049f Phase 6.2 + 6.3 — Bootstrap + Add AssetSpace CLI
   program.addCommand(bootstrapCommand());

--- a/packages/cli/src/services/CliApplyProfileService.ts
+++ b/packages/cli/src/services/CliApplyProfileService.ts
@@ -1,7 +1,7 @@
 /**
- * CLI-side hard-switch orchestrator (Issue #3416 — UI↔CLI parity).
+ * CLI-side apply-profile orchestrator (Issue #3416 — UI↔CLI parity).
  *
- * Turns the `hard-switch` scaffold into a real mount-state switch: tears down
+ * Turns the `apply-profile` scaffold into a real mount-state switch: tears down
  * AssetSpaces NOT in the target profile's effective set and materialises those
  * that ARE, via the GitHub REST tarball path (no `git` binary). Mirrors the
  * plugin's mount-state model (the profile-apply manager REST switch):
@@ -47,7 +47,7 @@ import { BootstrapAssetSpaceService } from "./BootstrapAssetSpaceService.js";
  * ({@link exocortex/src/domain/profile/TsFloorGuard}) so the single class
  * identity is shared across plugin + CLI — `e instanceof TsFloorViolationError`
  * works regardless of import path. Retained as a named export here for
- * backward-compat with the `hard-switch` command.
+ * backward-compat with the `apply-profile` command.
  */
 export { TsFloorViolationError };
 
@@ -86,20 +86,20 @@ export interface MaterializeTarget {
   label: string;
 }
 
-/** Result of {@link CliHardSwitchService.buildDiff}. */
-export interface HardSwitchDiff {
+/** Result of {@link CliApplyProfileService.buildDiff}. */
+export interface ApplyProfileDiff {
   toDestroy: TearDownTarget[];
   toMaterialize: MaterializeTarget[];
   plan: HardSwitchPlan;
 }
 
-/** Result of {@link CliHardSwitchService.execute}. */
-export interface HardSwitchExecResult {
+/** Result of {@link CliApplyProfileService.execute}. */
+export interface ApplyProfileExecResult {
   destroyed: string[];
   materialized: string[];
 }
 
-export interface CliHardSwitchServiceOptions {
+export interface CliApplyProfileServiceOptions {
   /** Absolute vault root. */
   vaultPath: string;
   /**
@@ -132,12 +132,12 @@ const SKIP_DIRS = new Set([
   ".git",
 ]);
 
-export class CliHardSwitchService {
+export class CliApplyProfileService {
   private readonly vaultPath: string;
   private readonly mount: BootstrapAssetSpaceService;
   private readonly ref: string;
 
-  constructor(opts: CliHardSwitchServiceOptions) {
+  constructor(opts: CliApplyProfileServiceOptions) {
     this.vaultPath = opts.vaultPath;
     this.mount = opts.mount ?? new BootstrapAssetSpaceService();
     this.ref = opts.ref ?? "main";
@@ -233,7 +233,7 @@ export class CliHardSwitchService {
   /**
    * R24 TS-floor guard. The profile's *declared* AssetSpace set (pre-floor —
    * `result.declaredOntologies` intersected with known AssetSpace UIDs) must
-   * contain every floor AssetSpace, otherwise the hard switch would tear one
+   * contain every floor AssetSpace, otherwise the apply would tear one
    * down and brick the engine.
    *
    * EV8 — delegates to the single named guard in `exocortex`. The CLI/headless
@@ -258,7 +258,7 @@ export class CliHardSwitchService {
     sourceProfileLabel: string;
     result: ResolveFilterResult;
     infos: AssetSpaceInfo[];
-  }): HardSwitchDiff {
+  }): ApplyProfileDiff {
     const { targetProfileUid, targetProfileLabel, sourceProfileUid, sourceProfileLabel, result, infos } =
       params;
 
@@ -352,7 +352,7 @@ export class CliHardSwitchService {
    * target). Idempotent at the per-AS level: a target already in the desired
    * state would not appear in the diff.
    */
-  async execute(diff: HardSwitchDiff): Promise<HardSwitchExecResult> {
+  async execute(diff: ApplyProfileDiff): Promise<ApplyProfileExecResult> {
     const destroyed: string[] = [];
     const materialized: string[] = [];
 

--- a/packages/cli/src/services/CliProfileResolver.ts
+++ b/packages/cli/src/services/CliProfileResolver.ts
@@ -120,7 +120,7 @@ export class CliProfileResolver {
    *
    * Outcomes:
    * - `engaged` — effective set computed; `result.effective` is the AS-UID set
-   *   the CLI hard switch materialises (+ `result.folderMap` for diagnostics)
+   *   the CLI apply materialises (+ `result.folderMap` for diagnostics)
    * - `no-profile` — `profileUid` was null/undefined; caller indexes full vault
    * - `missing-profile` — UID provided but no asset with that UID found; caller
    *   indexes full vault (defensive; surface warn)

--- a/packages/cli/src/services/HeadlessConfirmGate.ts
+++ b/packages/cli/src/services/HeadlessConfirmGate.ts
@@ -17,7 +17,7 @@
 import type { IConfirmGate, HardSwitchPlan } from "exocortex";
 
 export interface HeadlessConfirmGateOptions {
-  /** Confirm hard switch (safety override). False by default. */
+  /** Confirm apply (safety override). False by default. */
   yes: boolean;
   /** Echo the plan summary to stderr before deciding. False by default. */
   verbose?: boolean;
@@ -48,17 +48,17 @@ export class HeadlessConfirmGate implements IConfirmGate {
         0,
       );
       this.log(
-        `[hard-switch] Target: ${plan.targetProfileLabel} (${plan.targetProfileUid})`,
+        `[apply-profile] Target: ${plan.targetProfileLabel} (${plan.targetProfileUid})`,
       );
-      this.log(`[hard-switch] Source: ${plan.sourceProfileLabel}`);
+      this.log(`[apply-profile] Source: ${plan.sourceProfileLabel}`);
       this.log(
-        `[hard-switch] ${totalFiles} files to remove, ${plan.assetSpacesBeingTornDown.length} AS to tear down, ${plan.assetSpacesBeingMaterialized.length} AS to materialize`,
+        `[apply-profile] ${totalFiles} files to remove, ${plan.assetSpacesBeingTornDown.length} AS to tear down, ${plan.assetSpacesBeingMaterialized.length} AS to materialize`,
       );
     }
 
     if (!this.yes) {
       this.log(
-        "[hard-switch] Refused: --yes flag required for headless mode (Decision #2 safety).",
+        "[apply-profile] Refused: --yes flag required for headless mode (Decision #2 safety).",
       );
       return false;
     }

--- a/packages/cli/tests/integration/commands/apply-profile.integration.test.ts
+++ b/packages/cli/tests/integration/commands/apply-profile.integration.test.ts
@@ -1,10 +1,10 @@
 /**
- * Integration tests for `exocortex hard-switch <profile-uid>` — the REAL
+ * Integration tests for `exocortex apply-profile <profile-uid>` — the REAL
  * mount-state switch (Issue #3416, UI↔CLI parity).
  *
  * Uses a real on-disk fixture vault (matches `CliProfileResolver`
- * unit-test style) + the pure-logic seam `runHardSwitch` (returns a
- * `HardSwitchResult` rather than calling `process.exit`). Tear-down scenarios
+ * unit-test style) + the pure-logic seam `runApplyProfile` (returns a
+ * `ApplyProfileResult` rather than calling `process.exit`). Tear-down scenarios
  * need NO network (unmount is pure `fs`); the materialise scenario injects a
  * fake mount (`pullAssetSpace` stubbed) so no GitHub tarball is fetched.
  *
@@ -17,7 +17,7 @@
  * Revert-verify: the `[revert-verify] tear-down` scenario FAILS against the
  * pre-fix scaffold (which performed zero filesystem ops — the testlib folder
  * + `.gitmodules` entry would survive) and PASSES post-fix. Empirically
- * verified by stubbing `CliHardSwitchService.execute` to a no-op (mirrors the
+ * verified by stubbing `CliApplyProfileService.execute` to a no-op (mirrors the
  * scaffold): the assertion `existsSync(testlibMount) === false` fails.
  */
 import { describe, it, expect, beforeEach, afterEach, jest } from "@jest/globals";
@@ -27,7 +27,7 @@ import path from "path";
 import { mkdirSync, writeFileSync, existsSync, readFileSync } from "node:fs";
 
 import type { HardSwitchPlan, IConfirmGate } from "exocortex";
-import { runHardSwitch, hardSwitchCommand } from "../../../src/commands/hard-switch.js";
+import { runApplyProfile, applyProfileCommand } from "../../../src/commands/apply-profile.js";
 import {
   ASSET_SPACE_CLASS_UID,
   PROFILE_CLASS_UID,
@@ -35,7 +35,7 @@ import {
   TS_FLOOR_AS_UID_EXOCMD,
   TS_FLOOR_AS_UID_SHARED_IDENTITIES,
 } from "../../../src/services/CliProfileResolver.js";
-import { CliHardSwitchService } from "../../../src/services/CliHardSwitchService.js";
+import { CliApplyProfileService } from "../../../src/services/CliApplyProfileService.js";
 import { BootstrapAssetSpaceService } from "../../../src/services/BootstrapAssetSpaceService.js";
 import { InvalidArgumentsError, VaultNotFoundError } from "../../../src/utils/errors/index.js";
 import { ExitCodes } from "../../../src/utils/ExitCodes.js";
@@ -194,7 +194,7 @@ async function makeFixtureVault(
 
 const approvingGate: IConfirmGate = { confirmHardSwitch: async () => true };
 
-describe("CLI — hard-switch real mount-state switch (Issue #3416)", () => {
+describe("CLI — apply-profile real mount-state switch (Issue #3416)", () => {
   let vaultRoot: string;
 
   afterEach(async () => {
@@ -202,7 +202,7 @@ describe("CLI — hard-switch real mount-state switch (Issue #3416)", () => {
   });
 
   async function setup(testlibMaterialised: boolean): Promise<void> {
-    vaultRoot = await fs.mkdtemp(path.join(os.tmpdir(), "exocortex-cli-hardswitch-"));
+    vaultRoot = await fs.mkdtemp(path.join(os.tmpdir(), "exocortex-cli-apply-"));
     await makeFixtureVault(vaultRoot, testlibMaterialised);
   }
 
@@ -211,7 +211,7 @@ describe("CLI — hard-switch real mount-state switch (Issue #3416)", () => {
     const testlibMount = path.join(vaultRoot, MOUNT_TESTLIB);
     expect(existsSync(testlibMount)).toBe(true); // precondition
 
-    const result = await runHardSwitch(
+    const result = await runApplyProfile(
       PROFILE_MINIMAL,
       { vault: vaultRoot, yes: true, verbose: false },
       { confirmGate: approvingGate, out: () => {}, err: () => {} },
@@ -239,21 +239,21 @@ describe("CLI — hard-switch real mount-state switch (Issue #3416)", () => {
     const noopFactory = (
       _opts: unknown,
       vp: string,
-    ): CliHardSwitchService => {
-      const svc = new CliHardSwitchService({ vaultPath: vp });
+    ): CliApplyProfileService => {
+      const svc = new CliApplyProfileService({ vaultPath: vp });
       // Simulate the pre-fix scaffold: build a real plan but execute nothing.
       jest
         .spyOn(svc, "execute")
         .mockResolvedValue({ destroyed: [], materialized: [] });
       return svc;
     };
-    const result = await runHardSwitch(
+    const result = await runApplyProfile(
       PROFILE_MINIMAL,
       { vault: vaultRoot, yes: true, verbose: false },
       {
         confirmGate: approvingGate,
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        hardSwitchServiceFactory: noopFactory as any,
+        applyServiceFactory: noopFactory as any,
         out: () => {},
         err: () => {},
       },
@@ -279,16 +279,16 @@ describe("CLI — hard-switch real mount-state switch (Issue #3416)", () => {
         return { sha: "deadbeef", fileCount: 1 };
       });
 
-    const factory = (_opts: unknown, vp: string): CliHardSwitchService =>
-      new CliHardSwitchService({ vaultPath: vp, mount: realMount });
+    const factory = (_opts: unknown, vp: string): CliApplyProfileService =>
+      new CliApplyProfileService({ vaultPath: vp, mount: realMount });
 
-    const result = await runHardSwitch(
+    const result = await runApplyProfile(
       PROFILE_FULL,
       { vault: vaultRoot, yes: true, verbose: false },
       {
         confirmGate: approvingGate,
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        hardSwitchServiceFactory: factory as any,
+        applyServiceFactory: factory as any,
         out: () => {},
         err: () => {},
       },
@@ -305,7 +305,7 @@ describe("CLI — hard-switch real mount-state switch (Issue #3416)", () => {
 
   it("idempotent no-op: switching to a profile already in mount-state mutates nothing", async () => {
     await setup(/* testlibMaterialised */ true);
-    const result = await runHardSwitch(
+    const result = await runApplyProfile(
       PROFILE_FULL, // floor + testlib == current disk state
       { vault: vaultRoot, yes: true, verbose: false },
       { confirmGate: approvingGate, out: () => {}, err: () => {} },
@@ -321,7 +321,7 @@ describe("CLI — hard-switch real mount-state switch (Issue #3416)", () => {
   it("R24 TS-floor guard: excluding an SDK-floor AS refuses with OPERATION_FAILED + no mutation", async () => {
     await setup(/* testlibMaterialised */ true);
     const testlibMount = path.join(vaultRoot, MOUNT_TESTLIB);
-    const result = await runHardSwitch(
+    const result = await runApplyProfile(
       PROFILE_MISSING_FLOOR, // omits $shared-identities (SDK floor)
       { vault: vaultRoot, yes: true, verbose: false },
       { confirmGate: approvingGate, out: () => {}, err: () => {} },
@@ -335,7 +335,7 @@ describe("CLI — hard-switch real mount-state switch (Issue #3416)", () => {
 
   it("[#3426] CLI accepts a profile that omits exocmd — no R24 refusal (exocmd is NOT the SDK floor)", async () => {
     await setup(/* testlibMaterialised */ true);
-    const result = await runHardSwitch(
+    const result = await runApplyProfile(
       PROFILE_NO_EXOCMD, // declares the full SDK floor, omits exocmd
       { vault: vaultRoot, yes: true, verbose: false },
       { confirmGate: approvingGate, out: () => {}, err: () => {} },
@@ -353,7 +353,7 @@ describe("CLI — hard-switch real mount-state switch (Issue #3416)", () => {
   it("refuse without --yes: gate declines, exit 0, no mutation", async () => {
     await setup(/* testlibMaterialised */ true);
     const testlibMount = path.join(vaultRoot, MOUNT_TESTLIB);
-    const result = await runHardSwitch(
+    const result = await runApplyProfile(
       PROFILE_MINIMAL,
       { vault: vaultRoot, yes: false, verbose: false },
       { out: () => {}, err: () => {} }, // real HeadlessConfirmGate (refuses)
@@ -371,7 +371,7 @@ describe("CLI — hard-switch real mount-state switch (Issue #3416)", () => {
         return false; // decline so nothing mutates
       },
     };
-    await runHardSwitch(
+    await runApplyProfile(
       PROFILE_MINIMAL,
       { vault: vaultRoot, yes: false, verbose: true },
       { confirmGate: recordingGate, out: () => {}, err: () => {} },
@@ -386,7 +386,7 @@ describe("CLI — hard-switch real mount-state switch (Issue #3416)", () => {
   it("--vault <invalid-path> → throws VaultNotFoundError", async () => {
     await setup(true);
     await expect(
-      runHardSwitch(
+      runApplyProfile(
         PROFILE_MINIMAL,
         { vault: "/does/not/exist-xyz-123", yes: true, verbose: false },
         { confirmGate: approvingGate, out: () => {}, err: () => {} },
@@ -397,7 +397,7 @@ describe("CLI — hard-switch real mount-state switch (Issue #3416)", () => {
   it("unknown profile UID → throws InvalidArgumentsError", async () => {
     await setup(true);
     await expect(
-      runHardSwitch(
+      runApplyProfile(
         MISSING_UID,
         { vault: vaultRoot, yes: true, verbose: false },
         { confirmGate: approvingGate, out: () => {}, err: () => {} },
@@ -414,7 +414,7 @@ describe("CLI — hard-switch real mount-state switch (Issue #3416)", () => {
       }),
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } as any;
-    const result = await runHardSwitch(
+    const result = await runApplyProfile(
       PROFILE_MINIMAL,
       { vault: vaultRoot, yes: true, verbose: false },
       {
@@ -429,13 +429,13 @@ describe("CLI — hard-switch real mount-state switch (Issue #3416)", () => {
   });
 
   it("command surface registers --vault/--yes/--verbose/--ref/--token flags", () => {
-    const cmd = hardSwitchCommand();
+    const cmd = applyProfileCommand();
     const optionNames = cmd.options.map((o) => o.long);
     expect(optionNames).toContain("--vault");
     expect(optionNames).toContain("--yes");
     expect(optionNames).toContain("--verbose");
     expect(optionNames).toContain("--ref");
     expect(optionNames).toContain("--token");
-    expect(cmd.description()).toContain("Hard switch");
+    expect(cmd.description()).toContain("Apply");
   });
 });

--- a/packages/cli/tests/unit/CliApplyProfileService.test.ts
+++ b/packages/cli/tests/unit/CliApplyProfileService.test.ts
@@ -1,7 +1,7 @@
 /**
  * @jest-environment node
  *
- * Focused unit tests for CliHardSwitchService helpers not exercised by the
+ * Focused unit tests for CliApplyProfileService helpers not exercised by the
  * integration suite (SSH→HTTPS URL normalisation; namespace-less descriptor
  * scan).
  */
@@ -10,9 +10,9 @@ import * as path from "node:path";
 import * as os from "node:os";
 
 import {
-  CliHardSwitchService,
+  CliApplyProfileService,
   toHttpsGitHubUrl,
-} from "../../src/services/CliHardSwitchService";
+} from "../../src/services/CliApplyProfileService";
 import { ASSET_SPACE_CLASS_UID } from "../../src/services/CliProfileResolver";
 
 describe("toHttpsGitHubUrl", () => {
@@ -39,7 +39,7 @@ describe("toHttpsGitHubUrl", () => {
   });
 });
 
-describe("CliHardSwitchService.scanVault", () => {
+describe("CliApplyProfileService.scanVault", () => {
   let root: string;
   beforeEach(() => {
     root = mkdtempSync(path.join(os.tmpdir(), "exo-cli-hs-scan-"));
@@ -60,7 +60,7 @@ describe("CliHardSwitchService.scanVault", () => {
         `exo__AssetSpace_source: "https://github.com/kitelev/exoas-testlib"\n` +
         `---\n`,
     );
-    const svc = new CliHardSwitchService({ vaultPath: root });
+    const svc = new CliApplyProfileService({ vaultPath: root });
     const { infos } = svc.scanVault();
     expect(infos).toHaveLength(1);
     expect(infos[0].uid).toBe(uid);
@@ -78,7 +78,7 @@ describe("CliHardSwitchService.scanVault", () => {
       path.join(dir, `${uid}.md`),
       `---\nexo__Asset_uid: ${uid}\nexo__Instance_class:\n  - "[[${ASSET_SPACE_CLASS_UID}]]"\n---\n`,
     );
-    const svc = new CliHardSwitchService({ vaultPath: root });
+    const svc = new CliApplyProfileService({ vaultPath: root });
     expect(svc.scanVault().infos).toHaveLength(0);
   });
 
@@ -91,7 +91,7 @@ describe("CliHardSwitchService.scanVault", () => {
       path.join(root, `${uid}.md`),
       `---\nexo__Asset_uid: ${uid}\nexo__Instance_class:\n  - "[[${ASSET_SPACE_CLASS_UID}]]"\nexo__AssetSpace_source: "file:///tmp/local-clone"\n---\n`,
     );
-    const svc = new CliHardSwitchService({ vaultPath: root });
+    const svc = new CliApplyProfileService({ vaultPath: root });
     expect(svc.scanVault().infos).toHaveLength(0);
   });
 });

--- a/packages/exocortex/src/domain/profile/TsFloorGuard.ts
+++ b/packages/exocortex/src/domain/profile/TsFloorGuard.ts
@@ -14,7 +14,7 @@
  *     that the plugin renders; tearing it down would self-brick the UI.
  *
  * EV8 mandate: this is the ONE named guard all profile-switch sites (plugin
- * {@link ProfileApplyManager}, CLI {@link CliHardSwitchService} +
+ * {@link ProfileApplyManager}, CLI {@link CliApplyProfileService} +
  * {@link CliProfileResolver}) delegate to. The previous copy-pasted inline
  * guards drifted independently; consolidating here removes that drift surface.
  */
@@ -58,7 +58,7 @@ export const PLUGIN_UI_FLOOR_ASSETSPACE_UIDS: ReadonlySet<string> = new Set([
 /**
  * Thrown by {@link assertTsFloor} when a target profile's declared AssetSpace
  * set omits a floor AssetSpace. Distinguishable by `name` so callers (palette
- * command, CLI hard-switch command) can surface a clear refusal without any
+ * command, CLI apply-profile command) can surface a clear refusal without any
  * filesystem mutation having occurred.
  *
  * NOTE: there is exactly ONE such class (this one). Plugin and CLI re-export it


### PR DESCRIPTION
## Summary

Phase 5 apply-model convergence — **T6 PR1 of 3** (CLI cluster). Mechanical rename, **zero behavior change**. Removes the soft/hard-switch concept from the CLI surface.

- CLI command `hard-switch` → **`apply-profile`** (NO deprecation alias — single user; keeps the program `dual-switch code refs=0` gate clean).
- `CliHardSwitchService` → `CliApplyProfileService` (+ `…ServiceOptions`).
- `runHardSwitch`→`runApplyProfile`, `hardSwitchCommand`→`applyProfileCommand`, `HardSwitchCommandOptions/ActionDeps/Result/Diff/ExecResult` → `ApplyProfile*`, `hardSwitchServiceFactory`→`applyServiceFactory`.
- `[hard-switch]` stderr log prefixes → `[apply-profile]`; command description/usage reworded to apply-model.
- Files renamed: `commands/hard-switch.ts`→`apply-profile.ts`, `services/CliHardSwitchService.ts`→`CliApplyProfileService.ts` (+ matching test files).
- `TsFloorGuard` JSDoc `@link` updated to the renamed CLI symbol.

### Scope boundary (intentional)
Core shared symbols `HardSwitchPlan` / `IConfirmGate.confirmHardSwitch` and the `services/focus-profile/` dir are **left for PR3** (the cross-package confirm-gate-contract rename + command-id + Settings UI), to keep this PR CLI-scoped. PR2 = plugin machinery.

## Test plan
- [x] `npm run check:types` green (whole monorepo).
- [x] CLI suites: `CliApplyProfileService`, `apply-profile.integration`, `HeadlessConfirmGate` → 25/25 pass.
- [x] Pre-commit archgate 16/16 pass; lint-staged + related-tests green.
- [ ] CI 14 checks green.