### PR TITLE
refactor(plugin): HardSwitch* machinery → Apply* rename (Phase 5 T6 PR2/3)

### DIFF
--- a/packages/obsidian-plugin/src/ExocortexPlugin.ts
+++ b/packages/obsidian-plugin/src/ExocortexPlugin.ts
@@ -119,11 +119,11 @@ import { AssetSpaceStatusIconPatch } from "./presentation/asset-space/AssetSpace
 import { GitHubRestClient } from "./infrastructure/adapters/GitHubRestClient";
 import { GitSubmoduleOps } from "./infrastructure/adapters/GitSubmoduleOps";
 import {
-  buildHardSwitchDeps,
+  buildApplyDeps,
   buildAssetSpacePuller,
   buildRestAssetSpaceMount,
-  type HardSwitchDeps,
-} from "./infrastructure/adapters/HardSwitchDepsFactory";
+  type ApplyDeps,
+} from "./infrastructure/adapters/ApplyDepsFactory";
 import { ModalConfirmGate } from "./infrastructure/adapters/ModalConfirmGate";
 import type { RestAssetSpaceMount } from "./infrastructure/adapters/RestAssetSpaceMount";
 import {
@@ -2446,7 +2446,7 @@ export default class ExocortexPlugin extends Plugin {
     const resolver = new VaultProfileResolver(this.app);
     // RFC 22b50a17 Phase 4 (H1 cascade catch — advisor round-2) — wire
     // `refreshAndInjectAssetSpaceMaterialization` as the post-refresh
-    // hook so soft- + hard-switch paths via `ProfileApplyManager`
+    // hook so apply paths via `ProfileApplyManager`
     // re-inject `exo:AssetSpace_materialized` triples automatically after
     // every `rdfIndexer.refresh()`. Without this, profile switching
     // would silently drop the runtime-derived materialization triples
@@ -2520,14 +2520,14 @@ export default class ExocortexPlugin extends Plugin {
 
     const settingsStore = new PluginSettingsStoreAdapter(localDataStore);
 
-    // Phase 5 P3 — hard switch dependencies (desktop-only). On mobile, the
+    // Phase 5 P3 — apply dependencies (desktop-only). On mobile, the
     // palette command throws via the AssetSpaceManager pull guard, so we skip
-    // wiring entirely. Extracted to `buildHardSwitchDeps` for testability —
+    // wiring entirely. Extracted to `buildApplyDeps` for testability —
     // an empty-PAT GitHubRestClient ctor throw previously left this `null` and
     // silently hid the gated Bootstrap / knowledge-switch palette commands.
-    const hardSwitchDeps: HardSwitchDeps | null = Platform.isMobile
+    const applyDeps: ApplyDeps | null = Platform.isMobile
       ? null
-      : await buildHardSwitchDeps({
+      : await buildApplyDeps({
           app: this.app,
           localDataStore,
           notifier: this.notifier,
@@ -2536,8 +2536,8 @@ export default class ExocortexPlugin extends Plugin {
 
     // RFC 01a83de8 Phase 3 T2 — cross-platform (incl. iOS) REST/tarball mount.
     // Built on BOTH platforms: the mobile profile-switch path consumes it
-    // (`ProfileApplyManager.restSwitchProfile`), and it's harmless on
-    // desktop (the desktop hard switch keeps the git-binary path). Best-effort
+    // (`ProfileApplyManager.applyProfileViaRest`), and it's harmless on
+    // desktop (the desktop apply keeps the git-binary path). Best-effort
     // — a wiring failure logs + leaves restMount null (mobile switch then
     // surfaces a clear "not wired" error instead of crashing onload).
     let restMount: RestAssetSpaceMount | null = null;
@@ -2550,9 +2550,9 @@ export default class ExocortexPlugin extends Plugin {
       );
     }
     // The mobile REST switch needs a ConfirmGate; on desktop it comes from
-    // hardSwitchDeps. ModalConfirmGate only needs `app` (mobile-safe).
+    // applyDeps. ModalConfirmGate only needs `app` (mobile-safe).
     const confirmGate =
-      hardSwitchDeps?.confirmGate ?? new ModalConfirmGate(this.app);
+      applyDeps?.confirmGate ?? new ModalConfirmGate(this.app);
 
     const switchMgr = new ProfileApplyManager({
       app: this.app,
@@ -2561,16 +2561,16 @@ export default class ExocortexPlugin extends Plugin {
       rdfIndexer,
       settingsStore,
       notify: (message) => this.notifier.info(message),
-      assetSpaceManager: hardSwitchDeps?.assetSpaceManager,
-      gitOps: hardSwitchDeps?.gitOps,
+      assetSpaceManager: applyDeps?.assetSpaceManager,
+      gitOps: applyDeps?.gitOps,
       restMount: restMount ?? undefined,
       // Fresh-PAT rebuild at switch time (Issue #3382 pattern) so a PAT set
       // after onload is honoured without a reload — the primary mobile flow.
       restMountFactory: () => buildRestAssetSpaceMount({ app: this.app }),
-      uncommittedGuard: hardSwitchDeps?.uncommittedGuard,
+      uncommittedGuard: applyDeps?.uncommittedGuard,
       confirmGate,
-      cacheLayer: hardSwitchDeps?.cacheLayer,
-      vaultRootPath: hardSwitchDeps?.vaultRootPath,
+      cacheLayer: applyDeps?.cacheLayer,
+      vaultRootPath: applyDeps?.vaultRootPath,
       localDataStore,
     });
 
@@ -2605,22 +2605,22 @@ export default class ExocortexPlugin extends Plugin {
       );
     }
 
-    // RFC 22b50a17 Phase 3 — hard-switch recovery worker. Only fires when
-    // hard-switch deps are wired AND the journal tail shows destroyed-not-
+    // RFC 22b50a17 Phase 3 — apply recovery worker. Only fires when
+    // apply deps are wired AND the journal tail shows destroyed-not-
     // materialized AS — covers the «plugin crashed mid-Phase 2» case where
     // soft recoverIfNeeded() would re-trigger a no-op refresh but leave
     // vault filesystem partial-destroyed.
-    if (hardSwitchDeps !== null) {
+    if (applyDeps !== null) {
       try {
         const result = await switchMgr.recoverIncompleteSwitch();
         if (result.restored.length > 0) {
           this.logger.info(
-            `[ExocortexPlugin] hard-switch recovery restored ${result.restored.length} AssetSpace(s): ${result.restored.join(", ")}`,
+            `[ExocortexPlugin] apply recovery restored ${result.restored.length} AssetSpace(s): ${result.restored.join(", ")}`,
           );
         }
       } catch (error) {
         this.logger.warn(
-          "[ExocortexPlugin] hard-switch recovery failed",
+          "[ExocortexPlugin] apply recovery failed",
           error instanceof Error ? error : new Error(String(error)),
         );
       }
@@ -2733,16 +2733,16 @@ export default class ExocortexPlugin extends Plugin {
     // RFC 0a0791c1 Phase 5 T2 — «Apply profile» (the single consolidated
     // profile command; the former soft «Switch focus profile» was removed and
     // the mount-state «Switch knowledge profile» was renamed here). Needs the
-    // hard-switch deps wired (filesystem materialisation).
+    // apply deps wired (filesystem materialisation).
     //
     // Command id is intentionally kept as the legacy `hard-switch-focus-profile`
     // so any hotkey a user already bound survives the rename (Obsidian persists
     // hotkeys by command id). Only the user-facing name changes.
-    // Register on desktop (git-binary hard switch) OR mobile when the REST
-    // mount is wired (ProfileApplyManager dispatches to restSwitchProfile
+    // Register on desktop (git-binary apply) OR mobile when the REST
+    // mount is wired (ProfileApplyManager dispatches to applyProfileViaRest
     // on mobile). Without either, the filesystem materialisation can't run, so
     // the command stays hidden.
-    if (hardSwitchDeps !== null || (Platform.isMobile && restMount !== null)) {
+    if (applyDeps !== null || (Platform.isMobile && restMount !== null)) {
       this.addCommand({
         id: "hard-switch-focus-profile",
         name: "Apply profile",
@@ -2762,11 +2762,11 @@ export default class ExocortexPlugin extends Plugin {
     });
 
     // RFC 13da049f Phase 6.2/6.3 — Bootstrap vault + Add AssetSpace by URL.
-    // Desktop-only: both reuse the Phase 5 hard-switch deps (AssetSpaceManager
+    // Desktop-only: both reuse the Phase 5 apply deps (AssetSpaceManager
     // REST pull + GitSubmoduleOps staging move / .gitmodules). Registered only
     // when those deps are wired (desktop + vault.adapter.basePath available).
-    if (hardSwitchDeps !== null) {
-      this.registerBootstrapCommands(hardSwitchDeps, localDataStore);
+    if (applyDeps !== null) {
+      this.registerBootstrapCommands(applyDeps, localDataStore);
     }
 
     this.logger.info(
@@ -2779,10 +2779,10 @@ export default class ExocortexPlugin extends Plugin {
    * («Bootstrap vault» + «Add AssetSpace by URL»). Reuses the Phase 5
    * `AssetSpaceManager` (REST tarball pull) and `GitSubmoduleOps` (staging
    * move + `.gitmodules` text manipulation) — no REST/security logic is
-   * duplicated. Desktop-only; the caller gates on `hardSwitchDeps !== null`.
+   * duplicated. Desktop-only; the caller gates on `applyDeps !== null`.
    */
   private registerBootstrapCommands(
-    hardSwitchDeps: {
+    applyDeps: {
       gitOps: GitSubmoduleOps;
     },
     localDataStore: PluginLocalDataStore,
@@ -2795,7 +2795,7 @@ export default class ExocortexPlugin extends Plugin {
     const bootstrapCommands = new BootstrapAssetSpaceCommands({
       // Issue #3382 — rebuild the AssetSpaceManager per invocation from the
       // CURRENT stored PAT instead of reusing the onload-captured
-      // `hardSwitchDeps.assetSpaceManager` (which froze an empty-PAT client
+      // `applyDeps.assetSpaceManager` (which froze an empty-PAT client
       // when the vault had no PAT at load time). A PAT configured after onload
       // now authenticates Bootstrap / Add-AssetSpace pulls without a reload.
       getPuller: () =>
@@ -2804,7 +2804,7 @@ export default class ExocortexPlugin extends Plugin {
           localDataStore,
           notifier: this.notifier,
         }),
-      gitOps: hardSwitchDeps.gitOps,
+      gitOps: applyDeps.gitOps,
       localStore: localDataStore,
       vaultExists: (p) => this.app.vault.adapter.exists(p),
       listFolder: (dir) => this.app.vault.adapter.list(dir),

--- a/packages/obsidian-plugin/src/infrastructure/adapters/ApplyDepsFactory.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/ApplyDepsFactory.ts
@@ -15,14 +15,14 @@ import { SwitchCacheLayer } from "./SwitchCacheLayer";
 import type { PluginLocalDataStore } from "./PluginLocalDataStore";
 
 /**
- * Desktop-only hard-switch dependency bundle consumed by
+ * Desktop-only apply dependency bundle consumed by
  * `ProfileApplyManager` + the gated palette commands (hard
  * «Switch knowledge profile», «Bootstrap vault», «Add AssetSpace by URL»).
  *
  * When this is `null` the gated commands are NOT registered — so a wiring
  * exception here silently removes user-facing commands from the palette.
  */
-export interface HardSwitchDeps {
+export interface ApplyDeps {
   assetSpaceManager: AssetSpaceManager;
   gitOps: GitSubmoduleOps;
   uncommittedGuard: UncommittedChangesGuard;
@@ -31,7 +31,7 @@ export interface HardSwitchDeps {
   vaultRootPath: string;
 }
 
-export interface BuildHardSwitchDepsOptions {
+export interface BuildApplyDepsOptions {
   app: App;
   localDataStore: PluginLocalDataStore;
   notifier: INotificationService;
@@ -46,7 +46,7 @@ export interface BuildAssetSpacePullerOptions {
 
 /**
  * Build a fresh {@link AssetSpaceManager} (the REST tarball puller used by the
- * Bootstrap / Add-AssetSpace commands and the hard-switch materialize path)
+ * Bootstrap / Add-AssetSpace commands and the apply materialize path)
  * from the CURRENTLY stored GitHub PAT.
  *
  * Reads `LocalSecretsStore.getSecret("pat")` at call time. Invoking this
@@ -83,7 +83,7 @@ export async function buildAssetSpacePuller(
  *
  * The PAT is captured at call time. The plugin wires this once at onload (the
  * mobile profile-switch path consumes it); a PAT configured AFTER onload needs
- * a reload to take effect — the same onload-capture tradeoff as the hard-switch
+ * a reload to take effect — the same onload-capture tradeoff as the apply
  * `assetSpaceManager`. An absent PAT yields an unauthenticated client
  * (public-repo reads only).
  */
@@ -98,7 +98,7 @@ export async function buildRestAssetSpaceMount(opts: {
 }
 
 /**
- * Wire the desktop hard-switch dependencies. Extracted from
+ * Wire the desktop apply dependencies. Extracted from
  * `ExocortexPlugin.onload` for testability (mirrors the
  * {@link ./AssetSpacePusherFactory.createAssetSpacePusher} extraction).
  *
@@ -115,18 +115,18 @@ export async function buildRestAssetSpaceMount(opts: {
  * `null` on a vault that has never configured one (the common case), and
  * `GitHubRestClient` now accepts an empty PAT (unauthenticated mode) so the
  * deps still wire. Before that fix, the empty-PAT ctor throw left
- * `hardSwitchDeps === null` and the gated commands silently vanished.
+ * `applyDeps === null` and the gated commands silently vanished.
  */
-export async function buildHardSwitchDeps(
-  opts: BuildHardSwitchDepsOptions,
-): Promise<HardSwitchDeps | null> {
+export async function buildApplyDeps(
+  opts: BuildApplyDepsOptions,
+): Promise<ApplyDeps | null> {
   const { app, localDataStore, notifier, logger } = opts;
   try {
     // NOTE: this AssetSpaceManager is captured for the lifetime of the plugin
-    // (used by the hard-switch materialize + push paths). The Bootstrap /
+    // (used by the apply materialize + push paths). The Bootstrap /
     // Add-AssetSpace commands deliberately do NOT reuse it — they rebuild a
     // fresh one per invocation via {@link buildAssetSpacePuller} so a PAT set
-    // after onload is honoured (Issue #3382). Hard-switch / push keep onload
+    // after onload is honoured (Issue #3382). Apply / push keep onload
     // capture (they surface a «Reload to activate» hint instead).
     const assetSpaceManager = await buildAssetSpacePuller({
       app,
@@ -137,7 +137,7 @@ export async function buildHardSwitchDeps(
       (app.vault.adapter as unknown as { basePath?: string }).basePath ?? "";
     if (vaultRootPath.length === 0) {
       logger.warn(
-        "[buildHardSwitchDeps] vault.adapter.basePath unavailable — hard switch palette will be hidden",
+        "[buildApplyDeps] vault.adapter.basePath unavailable — apply palette will be hidden",
       );
       return null;
     }
@@ -157,9 +157,9 @@ export async function buildHardSwitchDeps(
     // Visible diagnostics — `logger.warn` routes through a custom logger that
     // is NOT printed to the DevTools console, so this exception was invisible
     // in production for months. `console.error` makes it observable.
-    console.error("[Exocortex] hard-switch wiring failed:", err);
+    console.error("[Exocortex] apply wiring failed:", err);
     logger.warn(
-      "[buildHardSwitchDeps] failed to wire hard-switch deps; soft switch only",
+      "[buildApplyDeps] failed to wire apply deps; reindex only",
       err instanceof Error ? err : new Error(String(err)),
     );
     return null;

--- a/packages/obsidian-plugin/src/infrastructure/adapters/AssetSpaceManager.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/AssetSpaceManager.ts
@@ -1,4 +1,4 @@
-// Node.js builtins required for Phase 5 hard-switch staging dirs (RFC
+// Node.js builtins required for Phase 5 apply staging dirs (RFC
 // 22b50a17) — staging dirs live in `os.tmpdir()` OUTSIDE the vault so
 // Obsidian's vault.adapter API cannot reach them. The `pullAssetSpace`
 // entry point is guarded by `Platform.isMobile` throw — on mobile the
@@ -73,7 +73,7 @@ export interface AssetSpaceManagerOptions {
 /**
  * Outcome of a successful {@link AssetSpaceManager.pullAssetSpace} call —
  * tells the orchestrator (Phase 2 SwitchCacheLayer / Phase 3
- * `hardSwitchProfile`) where the freshly-materialised AssetSpace lives
+ * `applyProfile`) where the freshly-materialised AssetSpace lives
  * on disk plus the SHA the GitHub REST tarball claimed.
  */
 export interface PullAssetSpaceResult {
@@ -142,7 +142,7 @@ export class AssetSpaceManager {
   private readonly branch: string;
   private readonly tarExtractor: TarExtractor;
   /**
-   * Public read-only accessor — `ProfileApplyManager.hardSwitchProfile`
+   * Public read-only accessor — `ProfileApplyManager.applyProfile`
    * (RFC 22b50a17 Phase 3) needs to release staging dirs on partial-fail
    * cleanup (R26). Stays nullable to preserve `pullAssetSpace`'s explicit
    * throw on `null` from Phase 1.
@@ -398,7 +398,7 @@ export class AssetSpaceManager {
 
   // ─────────────────────────── public — stubs (Phase 2+3) ─────────────────────
 
-  /** STUB — destroy deferred to Phase 2 SwitchCacheLayer / Phase 3 hardSwitchProfile. */
+  /** STUB — destroy deferred to Phase 2 SwitchCacheLayer / Phase 3 applyProfile. */
   public async destroyAssetSpace(_asUid: string): Promise<void> {
     throw new Error(
       "AssetSpaceManager.destroyAssetSpace: deferred to Phase 2/3 (RFC 22b50a17)",

--- a/packages/obsidian-plugin/src/infrastructure/adapters/BootstrapAssetSpaceCommands.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/BootstrapAssetSpaceCommands.ts
@@ -87,7 +87,7 @@ export interface BootstrapAssetSpaceCommandsDeps {
    * from the CURRENT GitHub PAT. Issue #3382: the previous fixed `puller`
    * captured an onload-time client, ignoring a PAT the user entered after the
    * plugin loaded → 401/404 on private-repo pulls. Production wiring resolves
-   * this to {@link HardSwitchDepsFactory.buildAssetSpacePuller}.
+   * this to {@link ApplyDepsFactory.buildAssetSpacePuller}.
    */
   getPuller: () => Promise<IAssetSpacePuller>;
   gitOps: IGitSubmoduleOps;

--- a/packages/obsidian-plugin/src/infrastructure/adapters/GitHubRestClient.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/GitHubRestClient.ts
@@ -73,10 +73,10 @@ export class GitHubRestClient {
   constructor(opts: GitHubRestClientOptions) {
     // An EMPTY PAT is allowed and puts the client in unauthenticated mode
     // (no Authorization header → public-repo reads only, lower rate limit).
-    // This is deliberate: plugin onload wires the hard-switch dependencies
+    // This is deliberate: plugin onload wires the apply dependencies
     // BEFORE the user has configured a PAT, so the ctor must not throw on an
     // empty string. Authenticated operations (createCommit, private pulls)
-    // then surface a clear HTTP 401 instead of the whole hard-switch command
+    // then surface a clear HTTP 401 instead of the whole apply command
     // palette silently disappearing. The previous «PAT is required» throw on
     // an empty string broke that wiring (gated Bootstrap/knowledge-switch
     // commands never registered on vaults without a stored PAT).

--- a/packages/obsidian-plugin/src/infrastructure/adapters/GitSubmoduleOps.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/GitSubmoduleOps.ts
@@ -11,7 +11,7 @@ const execFile = promisify(execFileCb);
 
 /**
  * GitSubmoduleOps — security-hardened wrapper for the git subprocess calls
- * needed by `ProfileApplyManager.hardSwitchProfile` per RFC 22b50a17
+ * needed by `ProfileApplyManager.applyProfile` per RFC 22b50a17
  * §Solution Architecture lines 127-137.
  *
  * Operations covered:
@@ -33,7 +33,7 @@ const execFile = promisify(execFileCb);
  *   tarball / clone; short enough to surface hangs).
  * - Captures stderr for diagnostic propagation through thrown errors.
  *
- * Mobile guard: every public method throws — Phase 5 hard switch is
+ * Mobile guard: every public method throws — Phase 5 apply is
  * desktop-only (RFC R24 scope).
  */
 export interface GitSubmoduleOpsOptions {
@@ -106,7 +106,7 @@ export function validateVaultPathArg(arg: string): string {
  * `file://` URLs allowed ONLY in test mode (`NODE_ENV === "test"`). In
  * production они bypass the GitHub allowlist and would permit malicious
  * `exo__AssetSpace_git: file:///some/attacker/repo` declarations to
- * materialize local content into the vault on hard switch. Test code that
+ * materialize local content into the vault on apply. Test code that
  * legitimately needs file:// (offline integration smoke) gets it via the
  * automatic NODE_ENV that jest sets; production never sees it.
  */

--- a/packages/obsidian-plugin/src/infrastructure/adapters/ModalConfirmGate.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/ModalConfirmGate.ts
@@ -12,7 +12,7 @@ import type { IConfirmGate, HardSwitchPlan } from "exocortex";
  *      summary suffix).
  *   3. Assetspaces being materialized (newly added).
  *
- * Resolves `true` only when the user clicks the explicit «Hard switch»
+ * Resolves `true` only when the user clicks the explicit «Apply»
  * button (`mod-warning` class — red destructive variant). Esc / Cancel /
  * any close path resolves `false` to abort. Promise is guaranteed to
  * resolve exactly once, even if the user clicks before Obsidian's
@@ -23,7 +23,7 @@ export class ModalConfirmGate implements IConfirmGate {
 
   confirmHardSwitch(plan: HardSwitchPlan): Promise<boolean> {
     return new Promise<boolean>((resolve) => {
-      const modal = new HardSwitchConfirmModal(this.app, plan, resolve);
+      const modal = new ApplyConfirmModal(this.app, plan, resolve);
       modal.open();
     });
   }
@@ -35,7 +35,7 @@ export class ModalConfirmGate implements IConfirmGate {
  */
 export const MODAL_FILE_LIST_CAP = 100;
 
-class HardSwitchConfirmModal extends Modal {
+class ApplyConfirmModal extends Modal {
   private resolved = false;
   private readonly plan: HardSwitchPlan;
   private readonly resolve: (approved: boolean) => void;
@@ -61,8 +61,8 @@ class HardSwitchConfirmModal extends Modal {
     // Render title inside contentEl rather than relying on Modal.titleEl
     // — keeps the adapter testable without a custom Modal mock.
     contentEl.createEl("h2", {
-      cls: "hard-switch-title",
-      text: `Hard switch к profile: ${this.plan.targetProfileLabel}`,
+      cls: "apply-confirm-title",
+      text: `Apply к profile: ${this.plan.targetProfileLabel}`,
     });
 
     contentEl.createEl("p", {
@@ -71,7 +71,7 @@ class HardSwitchConfirmModal extends Modal {
 
     // Section 1 — Assetspaces about to be removed
     const tearSection = contentEl.createEl("div", {
-      cls: "hard-switch-tear-section",
+      cls: "apply-confirm-tear-section",
     });
     tearSection.createEl("h3", { text: "Assetspaces to remove" });
     if (this.plan.assetSpacesBeingTornDown.length === 0) {
@@ -91,7 +91,7 @@ class HardSwitchConfirmModal extends Modal {
       0,
     );
     const filesSection = contentEl.createEl("div", {
-      cls: "hard-switch-files-section",
+      cls: "apply-confirm-files-section",
     });
     filesSection.createEl("h3", {
       text: `Files to be removed (${totalFiles} total)`,
@@ -117,7 +117,7 @@ class HardSwitchConfirmModal extends Modal {
 
     // Section 3 — Assetspaces being materialized
     const matSection = contentEl.createEl("div", {
-      cls: "hard-switch-mat-section",
+      cls: "apply-confirm-mat-section",
     });
     matSection.createEl("h3", { text: "Assetspaces to materialize" });
     if (this.plan.assetSpacesBeingMaterialized.length === 0) {
@@ -131,10 +131,10 @@ class HardSwitchConfirmModal extends Modal {
 
     // Confirm / Cancel buttons
     const buttonRow = contentEl.createEl("div", {
-      cls: "hard-switch-buttons",
+      cls: "apply-confirm-buttons",
     });
     const confirmBtn = buttonRow.createEl("button", {
-      text: "Hard switch",
+      text: "Apply",
       cls: "mod-warning",
     });
     confirmBtn.addEventListener("click", () => {

--- a/packages/obsidian-plugin/src/infrastructure/adapters/PluginRdfIndexerAdapter.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/PluginRdfIndexerAdapter.ts
@@ -24,7 +24,7 @@ export class PluginRdfIndexerAdapter implements IRdfIndexer {
    * empty until the next `metadataCache.resolved` event.
    *
    * The plugin wires this to a closure that re-runs the AssetSpace
-   * materialization injection. Soft+hard switch paths via
+   * materialization injection. Apply paths via
    * `ProfileApplyManager` use this adapter, so the hook fires
    * automatically without each switch callsite knowing about the
    * derived-triple discipline.

--- a/packages/obsidian-plugin/src/infrastructure/adapters/ProfileApplyManager.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/ProfileApplyManager.ts
@@ -121,9 +121,9 @@ export interface ISettingsStore {
 }
 
 /**
- * Journal entry shape — widened для hard-switch phase events per RFC
- * 22b50a17 F2 (per-AS recovery granularity). Soft-switch continues using
- * the three base phases (`starting`/`completed`/`failed`); hard-switch
+ * Journal entry shape — widened для apply phase events per RFC
+ * 22b50a17 F2 (per-AS recovery granularity). Reindex-only path continues using
+ * the three base phases (`starting`/`completed`/`failed`); apply
  * emits the extended phase set with `as` field for per-AS events.
  */
 export interface SwitchJournalEntry {
@@ -131,8 +131,8 @@ export interface SwitchJournalEntry {
     | "starting"
     | "completed"
     | "failed"
-    // Hard-switch extended phases (RFC 22b50a17 §Solution Architecture):
-    | "hard-switch-starting"
+    // Apply extended phases (RFC 22b50a17 §Solution Architecture):
+    | "apply-starting"
     | "phase1-pulling"
     | "phase1-pulled"
     | "phase1-done"
@@ -144,8 +144,8 @@ export interface SwitchJournalEntry {
     | "phase2-materialized"
     | "phase2-done"
     | "git-commit-done"
-    | "hard-switch-completed"
-    | "hard-switch-failed"
+    | "apply-completed"
+    | "apply-failed"
     | "recovery-restoring"
     | "recovery-completed";
   targetUid: string;
@@ -171,7 +171,7 @@ export interface ProfileApplyManagerOptions {
   /** User-facing notifier (typically `new Notice()`). */
   notify?: (message: string) => void;
 
-  // --- Hard-switch dependencies (RFC 22b50a17 Phase 3) ---
+  // --- Apply dependencies (RFC 22b50a17 Phase 3) ---
   /** AssetSpaceManager — provides pullAssetSpace + lookupAssetSpaceInfo. */
   assetSpaceManager?: AssetSpaceManager;
   /** Filesystem cache layer — destroy/restore tarballs (RFC §B.5). */
@@ -181,7 +181,7 @@ export interface ProfileApplyManagerOptions {
   /**
    * REST/tarball AssetSpace mount/unmount (RFC 01a83de8 Phase 3 T1). The
    * cross-platform (incl. iOS) materialisation path. When wired and running on
-   * mobile, `applyProfile` delegates to {@link restSwitchProfile}
+   * mobile, `applyProfile` delegates to {@link applyProfileViaRest}
    * (no git binary / staging / cache). Desktop keeps the git-binary path.
    *
    * Captured at onload — used to gate command registration + as a fallback.
@@ -190,7 +190,7 @@ export interface ProfileApplyManagerOptions {
   restMount?: RestAssetSpaceMount;
   /**
    * Factory building a {@link RestAssetSpaceMount} with the CURRENTLY stored
-   * PAT. Preferred over {@link restMount} inside {@link restSwitchProfile} so a
+   * PAT. Preferred over {@link restMount} inside {@link applyProfileViaRest} so a
    * PAT configured AFTER onload is honoured without a reload (matches the
    * Issue #3382 fix for the Bootstrap/Add-AssetSpace puller). Falls back to the
    * captured {@link restMount} when absent.
@@ -242,12 +242,12 @@ export class UncommittedChangesAbortError extends Error {
 }
 
 /**
- * Custom error thrown when the user declines the hard-switch ConfirmGate.
+ * Custom error thrown when the user declines the apply ConfirmGate.
  */
-export class HardSwitchAbortedByUser extends Error {
-  constructor(message = "Hard switch aborted by user") {
+export class ApplyAbortedByUser extends Error {
+  constructor(message = "Apply aborted by user") {
     super(message);
-    this.name = "HardSwitchAbortedByUser";
+    this.name = "ApplyAbortedByUser";
   }
 }
 
@@ -262,7 +262,7 @@ export class ProfileApplyManager {
   private readonly now: () => Date;
   private readonly notify: (message: string) => void;
 
-  // Hard-switch dependencies (may be undefined when only soft switch wired).
+  // Apply dependencies (may be undefined when only reindex wired).
   private readonly assetSpaceManager?: AssetSpaceManager;
   private readonly cacheLayer?: ICacheLayer;
   private readonly gitOps?: GitSubmoduleOps;
@@ -297,7 +297,7 @@ export class ProfileApplyManager {
 
   /**
    * Reindex-only apply path (RFC 0a0791c1 Phase 5 T2 — replaces the retired
-   * public soft-switch method). Records the target as the last-applied
+   * public query-time RDF-filter method). Records the target as the last-applied
    * profile cache (`activeProfileUid`) and rebuilds the RDF graph from the
    * currently-materialised mount-state. Does NOT mutate the filesystem.
    *
@@ -370,16 +370,6 @@ export class ProfileApplyManager {
   }
 
   /**
-   * @deprecated Use {@link applyProfile}. Retained for backward
-   * compatibility (RFC 13da049f Phase 6.5b AC15 — Knowledge/Focus split).
-   * Hard switch materialises filesystem state, so it is semantically a
-   * Knowledge-profile operation.
-   */
-  async hardSwitchProfile(targetProfileUid: string): Promise<void> {
-    return this.applyProfile(targetProfileUid);
-  }
-
-  /**
    * Plugin-load recovery: if last journal entry shows an incomplete switch
    * AND settings._switchInProgress=true, re-trigger the re-index идempotently.
    *
@@ -439,10 +429,10 @@ export class ProfileApplyManager {
     return result;
   }
 
-  // === Hard switch orchestration (RFC 22b50a17 Phase 3) ===
+  // === Apply orchestration (RFC 22b50a17 Phase 3) ===
 
   /**
-   * Hard switch — destructive filesystem mutation of `assetspaces/<as>/`
+   * Apply — destructive filesystem mutation of `assetspaces/<as>/`
    * directories. Tears down AssetSpaces NOT in the target profile's effective
    * set, materialises new ones from cache or fresh GitHub pull, commits
    * the resulting `.gitmodules`/`assetspaces/` changes.
@@ -476,7 +466,7 @@ export class ProfileApplyManager {
    *
    * @throws TsFloorViolationError if target excludes any TS-floor AS.
    * @throws UncommittedChangesAbortError if dirty files in any to-destroy AS.
-   * @throws HardSwitchAbortedByUser if confirmGate declines.
+   * @throws ApplyAbortedByUser if confirmGate declines.
    */
   async applyProfile(targetProfileUid: string): Promise<void> {
     if (typeof targetProfileUid !== "string" || targetProfileUid.length === 0) {
@@ -489,9 +479,9 @@ export class ProfileApplyManager {
       Platform.isMobile &&
       (this.restMount !== undefined || this.restMountFactory !== undefined)
     ) {
-      return this.restSwitchProfile(targetProfileUid);
+      return this.applyProfileViaRest(targetProfileUid);
     }
-    const deps = this.assertHardSwitchWired();
+    const deps = this.assertApplyDepsWired();
 
     const startedAt = this.now().getTime();
     const prevActiveProfileUid = deps.localDataStore.getActiveProfileUid();
@@ -503,7 +493,7 @@ export class ProfileApplyManager {
     // R24 — assert TS-floor BEFORE any mutation. Use computeDerivedSet (NOT
     // resolveEffectiveSet) so the floor URIs that resolveEffectiveSet injects
     // don't mask a profile that legitimately omits a floor AS — R24 must see
-    // the user's explicit `_includes`. Hard-switch is destructive, so we
+    // the user's explicit `_includes`. Apply is destructive, so we
     // require explicit intent rather than the soft-path's UX-convenience floor.
     const declaredOntologySet = await this.computeDerivedSet(targetProfileUid);
     const folderToAsUid = await this.scanFolderToAsUid();
@@ -585,7 +575,7 @@ export class ProfileApplyManager {
       if (!uncommitted.clean) {
         const total = uncommitted.affectedFiles.reduce((s, a) => s + a.files.length, 0);
         throw new UncommittedChangesAbortError(
-          `Hard switch aborted — ${total} uncommitted file(s) in ${uncommitted.affectedFiles.length} to-destroy AssetSpace(s). Commit or stash first.`,
+          `Apply aborted — ${total} uncommitted file(s) in ${uncommitted.affectedFiles.length} to-destroy AssetSpace(s). Commit or stash first.`,
           uncommitted.affectedFiles,
         );
       }
@@ -614,21 +604,21 @@ export class ProfileApplyManager {
       })),
     };
     const approved = await deps.confirmGate.confirmHardSwitch(plan);
-    if (!approved) throw new HardSwitchAbortedByUser();
+    if (!approved) throw new ApplyAbortedByUser();
 
     // No-op early exit: no destroy + no materialize == mount-state already
     // matches the target. Re-index + record the selection (reindex-only path).
-    // Still emit hard-switch-completed so recoverIncompleteSwitch's tail-scan
+    // Still emit apply-completed so recoverIncompleteSwitch's tail-scan
     // has a clean cutoff for any prior aborted run (HIGH catch from review).
     if (toDestroy.length === 0 && toMaterialize.length === 0) {
       await this.appendJournal({
-        phase: "hard-switch-starting",
+        phase: "apply-starting",
         targetUid: targetProfileUid,
         ts: new Date(startedAt).toISOString(),
       });
       await this.reindexMountState(targetProfileUid);
       await this.appendJournal({
-        phase: "hard-switch-completed",
+        phase: "apply-completed",
         targetUid: targetProfileUid,
         ts: this.now().toISOString(),
         elapsedMs: this.now().getTime() - startedAt,
@@ -637,9 +627,9 @@ export class ProfileApplyManager {
     }
 
     // Acquire lock, set _switchInProgress.
-    const acquired = await this.lockMgr.acquireLock(`hard-switch-${targetProfileUid}`);
+    const acquired = await this.lockMgr.acquireLock(`apply-${targetProfileUid}`);
     if (!acquired) {
-      throw new Error("Another hard switch is in progress (lock held). Try again shortly.");
+      throw new Error("Another apply is in progress (lock held). Try again shortly.");
     }
     let heartbeatTimer: ReturnType<typeof setInterval> | null = null;
     const stagingPaths: Array<{ asUid: string; stagingPath: string }> = [];
@@ -651,7 +641,7 @@ export class ProfileApplyManager {
 
     try {
       await this.appendJournal({
-        phase: "hard-switch-starting",
+        phase: "apply-starting",
         targetUid: targetProfileUid,
         ts: new Date(startedAt).toISOString(),
       });
@@ -799,7 +789,7 @@ export class ProfileApplyManager {
       await deps.gitOps.add(".gitmodules");
       await deps.gitOps.add("assetspaces/");
       await deps.gitOps.commit(
-        `chore(profile): hard switch к ${targetProfileLabel}`,
+        `chore(profile): apply к ${targetProfileLabel}`,
       );
       await this.appendJournal({
         phase: "git-commit-done",
@@ -819,19 +809,19 @@ export class ProfileApplyManager {
 
       const elapsedMs = this.now().getTime() - startedAt;
       await this.appendJournal({
-        phase: "hard-switch-completed",
+        phase: "apply-completed",
         targetUid: targetProfileUid,
         ts: this.now().toISOString(),
         elapsedMs,
       });
-      this.notify(`Hard switched к ${targetProfileLabel} (${elapsedMs}ms)`);
+      this.notify(`Applied к ${targetProfileLabel} (${elapsedMs}ms)`);
     } catch (e) {
       // Rollback attempt: best-effort cache restore previously-destroyed AS.
       // This is partial — anything that was already added via `submodule add`
       // before commit will be untracked git state until the user manually
       // resets. We log + notify but rethrow.
       await this.appendJournal({
-        phase: "hard-switch-failed",
+        phase: "apply-failed",
         targetUid: targetProfileUid,
         ts: this.now().toISOString(),
         error: this.redactError(String(e)),
@@ -891,13 +881,13 @@ export class ProfileApplyManager {
    * idempotent, and re-running the switch reconciles to the target.
    *
    * @throws TsFloorViolationError if target excludes any TS-floor AS.
-   * @throws HardSwitchAbortedByUser if confirmGate declines.
+   * @throws ApplyAbortedByUser if confirmGate declines.
    */
-  async restSwitchProfile(targetProfileUid: string): Promise<void> {
+  async applyProfileViaRest(targetProfileUid: string): Promise<void> {
     if (typeof targetProfileUid !== "string" || targetProfileUid.length === 0) {
-      throw new Error("restSwitchProfile: targetProfileUid is required");
+      throw new Error("applyProfileViaRest: targetProfileUid is required");
     }
-    const { confirmGate, localDataStore } = this.assertRestSwitchWired();
+    const { confirmGate, localDataStore } = this.assertRestApplyWired();
     // Prefer the fresh-PAT factory (Issue #3382 pattern) over the onload-captured
     // mount, so a PAT set after onload is honoured without a reload.
     const restMount = this.restMountFactory
@@ -993,7 +983,7 @@ export class ProfileApplyManager {
       })),
     };
     const approved = await confirmGate.confirmHardSwitch(plan);
-    if (!approved) throw new HardSwitchAbortedByUser();
+    if (!approved) throw new ApplyAbortedByUser();
 
     // No-op early exit — mount-state already matches the target. Re-index +
     // record the selection (reindex-only path).
@@ -1009,7 +999,7 @@ export class ProfileApplyManager {
     let heartbeatTimer: ReturnType<typeof setInterval> | null = null;
     try {
       await this.appendJournal({
-        phase: "hard-switch-starting",
+        phase: "apply-starting",
         targetUid: targetProfileUid,
         ts: new Date(startedAt).toISOString(),
       });
@@ -1054,7 +1044,7 @@ export class ProfileApplyManager {
 
       const elapsedMs = this.now().getTime() - startedAt;
       await this.appendJournal({
-        phase: "hard-switch-completed",
+        phase: "apply-completed",
         targetUid: targetProfileUid,
         ts: this.now().toISOString(),
         elapsedMs,
@@ -1062,7 +1052,7 @@ export class ProfileApplyManager {
       this.notify(`Switched to ${targetProfileLabel} (${elapsedMs}ms, REST mount)`);
     } catch (e) {
       await this.appendJournal({
-        phase: "hard-switch-failed",
+        phase: "apply-failed",
         targetUid: targetProfileUid,
         ts: this.now().toISOString(),
         error: this.redactError(String(e)),
@@ -1084,7 +1074,7 @@ export class ProfileApplyManager {
     }
   }
 
-  private assertRestSwitchWired(): {
+  private assertRestApplyWired(): {
     confirmGate: IConfirmGate;
     localDataStore: PluginLocalDataStore;
   } {
@@ -1094,7 +1084,7 @@ export class ProfileApplyManager {
       this.localDataStore === undefined
     ) {
       throw new Error(
-        "restSwitchProfile: dependencies not wired (restMount|restMountFactory, confirmGate, localDataStore required)",
+        "applyProfileViaRest: dependencies not wired (restMount|restMountFactory, confirmGate, localDataStore required)",
       );
     }
     return {
@@ -1115,7 +1105,7 @@ export class ProfileApplyManager {
     const localDataStore = this.localDataStore;
     const vaultRootPath = this.vaultRootPath;
     if (cacheLayer === undefined || localDataStore === undefined || vaultRootPath === undefined) {
-      throw new Error("recoverIncompleteSwitch: hard switch dependencies not wired");
+      throw new Error("recoverIncompleteSwitch: apply dependencies not wired");
     }
     const events = await this.readJournalTail(200);
     const destroyedAsUids = new Set<string>();
@@ -1125,7 +1115,7 @@ export class ProfileApplyManager {
         destroyedAsUids.add(e.as);
       } else if (e.phase === "phase2-materialized" && typeof e.as === "string") {
         materializedAsUids.add(e.as);
-      } else if (e.phase === "hard-switch-completed") {
+      } else if (e.phase === "apply-completed") {
         // Anything before a completed event was a finished switch — clear set.
         destroyedAsUids.clear();
         materializedAsUids.clear();
@@ -1197,7 +1187,7 @@ export class ProfileApplyManager {
     const localDataStore = this.localDataStore;
     const gitOps = this.gitOps;
     if (localDataStore === undefined || gitOps === undefined) {
-      throw new Error("reconcileToLocal: hard switch dependencies not wired");
+      throw new Error("reconcileToLocal: apply dependencies not wired");
     }
     const activeProfileUid = localDataStore.getActiveProfileUid();
     if (activeProfileUid === null) {
@@ -1295,9 +1285,9 @@ export class ProfileApplyManager {
     };
   }
 
-  // === Hard-switch helpers ===
+  // === Apply helpers ===
 
-  private assertHardSwitchWired(): {
+  private assertApplyDepsWired(): {
     assetSpaceManager: AssetSpaceManager;
     cacheLayer: ICacheLayer;
     gitOps: GitSubmoduleOps;
@@ -1339,7 +1329,7 @@ export class ProfileApplyManager {
 
   private listAllAssetSpaceInfos(): AssetSpaceInfo[] {
     // Single vault scan — extracts AssetSpace ABox metadata directly from
-    // frontmatter. Independent of AssetSpaceManager (так hard switch tests
+    // frontmatter. Independent of AssetSpaceManager (так apply tests
     // and recovery-only flows can call this without a wired manager).
     const out: AssetSpaceInfo[] = [];
     const seen = new Set<string>();
@@ -1424,7 +1414,7 @@ export class ProfileApplyManager {
 
   private async enumerateFilesUnder(submodulePath: string): Promise<string[]> {
     // Recursive walk via Obsidian vault.adapter.list. Returns vault-relative
-    // paths. Hard switch needs total file counts up-front for the modal; can't
+    // paths. Apply needs total file counts up-front for the modal; can't
     // lazy-stream.
     const out: string[] = [];
     await this.walkVaultDir(submodulePath, out);

--- a/packages/obsidian-plugin/src/infrastructure/adapters/ProfileApplyManager.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/ProfileApplyManager.ts
@@ -992,7 +992,7 @@ export class ProfileApplyManager {
       return;
     }
 
-    const acquired = await this.lockMgr.acquireLock(`rest-switch-${targetProfileUid}`);
+    const acquired = await this.lockMgr.acquireLock(`apply-rest-${targetProfileUid}`);
     if (!acquired) {
       throw new Error("Another profile switch is in progress (lock held). Try again shortly.");
     }

--- a/packages/obsidian-plugin/src/infrastructure/adapters/ProfileCommands.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/ProfileCommands.ts
@@ -31,7 +31,7 @@
 
 import type { ProfileApplyManager } from "./ProfileApplyManager";
 import {
-  HardSwitchAbortedByUser,
+  ApplyAbortedByUser,
   TsFloorViolationError,
   UncommittedChangesAbortError,
 } from "./ProfileApplyManager";
@@ -112,7 +112,7 @@ export class ProfileCommands {
    *      REST mount/unmount (mobile)
    *
    * User-facing error mapping: TsFloorViolationError, UncommittedChangesAbortError,
-   * and HardSwitchAbortedByUser get clear notices distinct from generic «Apply failed».
+   * and ApplyAbortedByUser get clear notices distinct from generic «Apply failed».
    */
   async invokeApplyProfile(): Promise<void> {
     let profiles: ProfileChoice[];
@@ -135,7 +135,7 @@ export class ProfileCommands {
     try {
       await this.switchMgr.applyProfile(chosen.uid);
     } catch (e) {
-      if (e instanceof HardSwitchAbortedByUser) {
+      if (e instanceof ApplyAbortedByUser) {
         this.notify("Apply profile cancelled.");
         return;
       }

--- a/packages/obsidian-plugin/src/infrastructure/adapters/StagingDirTracker.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/StagingDirTracker.ts
@@ -1,4 +1,4 @@
-// Node.js builtins required for Phase 5 hard-switch staging dirs (RFC
+// Node.js builtins required for Phase 5 apply staging dirs (RFC
 // 22b50a17) — staging dirs live в `os.tmpdir()` OUTSIDE the vault so
 // Obsidian's vault.adapter API cannot reach them. This file is only
 // instantiated on desktop — callers (AssetSpaceManager.pullAssetSpace +
@@ -27,7 +27,7 @@ export interface StagingDirTrackerOptions {
  * StagingDirTracker — manage Phase 5 tarball-materialization staging dirs
  * (RFC 22b50a17 R26 mitigation).
  *
- * The Phase 5 hard-switch algorithm pulls one or more AssetSpace tarballs
+ * The Phase 5 apply algorithm pulls one or more AssetSpace tarballs
  * to a staging directory before atomically moving them into the vault.
  * If the plugin crashes (or Obsidian quits) mid-pull, the staging dir
  * lives under `os.tmpdir()` and would survive forever — OS-level temp

--- a/packages/obsidian-plugin/src/infrastructure/adapters/SwitchCacheLayer.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/SwitchCacheLayer.ts
@@ -3,7 +3,7 @@
 // is `~/Library/Caches/exocortex/switch-cache/` (macOS desktop). Obsidian's
 // `vault.adapter` API only addresses vault-relative paths, so OS-level
 // caches must use Node directly. Mobile is guarded by `Platform.isMobile`
-// throw at every public entry point — Phase 5 hard switch is desktop-only.
+// throw at every public entry point — Phase 5 apply is desktop-only.
 /* eslint-disable no-restricted-imports, import/no-nodejs-modules */
 import { promises as fsPromises } from "node:fs";
 import { existsSync, readdirSync, statSync, readFileSync } from "node:fs";
@@ -16,7 +16,7 @@ import { createTarGzip, parseTarGzip, type TarFileInput } from "nanotar";
 
 /**
  * SwitchCacheLayer — filesystem-backed AssetSpace snapshot cache for
- * Profile hard switch (RFC 22b50a17 §Key sub-systems B.5).
+ * Profile apply (RFC 22b50a17 §Key sub-systems B.5).
  *
  * Layout (Decision #6 — wipe-all retention model):
  *   <cacheDir>/<asUid>/<sha>.tar.gz   — gzip tarball (F1 content-root convention)
@@ -37,7 +37,7 @@ import { createTarGzip, parseTarGzip, type TarFileInput } from "nanotar";
  *         upstream HEAD moved.
  *
  * Mobile: every public entry point throws via `Platform.isMobile` — Phase 5
- * hard switch is desktop-only (depends on git submodule ops + Node fs).
+ * apply is desktop-only (depends on git submodule ops + Node fs).
  *
  * Sync `getCacheStats()` is preserved for the v3 Settings UI render-path
  * (`ExocortexSettingTab.renderProfileSections`). Reads cache dir

--- a/packages/obsidian-plugin/src/presentation/asset-space/AssetSpaceStatusIconPatch.ts
+++ b/packages/obsidian-plugin/src/presentation/asset-space/AssetSpaceStatusIconPatch.ts
@@ -15,7 +15,7 @@ import type { AssetSpaceMaterializationTracker } from "@plugin/infrastructure/ad
  *
  * Detects AssetSpace assets by frontmatter (`isAssetSpaceFrontmatter`) and
  * queries the runtime-derived `AssetSpaceMaterializationTracker` for status.
- * Re-applied on workspace events so the icon stays in sync with hard-switch
+ * Re-applied on workspace events so the icon stays in sync with apply
  * mutations: `active-leaf-change`, `layout-change`, `metadataCache.changed`.
  *
  * Idempotent — never adds a second icon to the same title element; updates
@@ -137,7 +137,7 @@ export class AssetSpaceStatusIconPatch {
     badge.textContent = materialized ? "✅" : "⏸";
     badge.title = materialized
       ? "AssetSpace materialized on disk (assetspaces/<namespace>/ exists)"
-      : "AssetSpace available but not materialized — run Hard Switch to populate";
+      : "AssetSpace available but not materialized — run Apply to populate";
     badge.setAttribute("aria-label", badge.title);
   }
 

--- a/packages/obsidian-plugin/tests/unit/GitHubRestClient.test.ts
+++ b/packages/obsidian-plugin/tests/unit/GitHubRestClient.test.ts
@@ -43,7 +43,7 @@ describe("GitHubRestClient", () => {
   // ─── constructor ──────────────────────────────────────────────────
   describe("constructor", () => {
     it("accepts an empty PAT (unauthenticated mode) without throwing", () => {
-      // Regression: the empty-PAT ctor throw silently hid the hard-switch
+      // Regression: the empty-PAT ctor throw silently hid the apply
       // palette commands on every vault without a stored PAT. An empty PAT is
       // a valid unauthenticated client (public reads only).
       expect(

--- a/packages/obsidian-plugin/tests/unit/ModalConfirmGate.test.ts
+++ b/packages/obsidian-plugin/tests/unit/ModalConfirmGate.test.ts
@@ -86,11 +86,11 @@ describe("ModalConfirmGate", () => {
     document.body.innerHTML = "";
   });
 
-  it("resolves true when «Hard switch» button is clicked", async () => {
+  it("resolves true when «Apply» button is clicked", async () => {
     const gate = new ModalConfirmGate(fakeApp);
     const promise = gate.confirmHardSwitch(makePlan());
 
-    const confirmBtn = findButton("Hard switch");
+    const confirmBtn = findButton("Apply");
     expect(confirmBtn).toBeDefined();
     expect(confirmBtn!.classList.contains("mod-warning")).toBe(true);
     confirmBtn!.click();
@@ -113,7 +113,7 @@ describe("ModalConfirmGate", () => {
     const gate = new ModalConfirmGate(fakeApp);
     const promise = gate.confirmHardSwitch(makePlan());
 
-    const tearSection = document.querySelector(".hard-switch-tear-section");
+    const tearSection = document.querySelector(".apply-confirm-tear-section");
     expect(tearSection).not.toBeNull();
     expect(tearSection?.textContent).toContain("personal (2 files)");
 
@@ -126,7 +126,7 @@ describe("ModalConfirmGate", () => {
     const gate = new ModalConfirmGate(fakeApp);
     const promise = gate.confirmHardSwitch(makePlan());
 
-    const matSection = document.querySelector(".hard-switch-mat-section");
+    const matSection = document.querySelector(".apply-confirm-mat-section");
     expect(matSection).not.toBeNull();
     expect(matSection?.textContent).toContain("work");
 
@@ -138,7 +138,7 @@ describe("ModalConfirmGate", () => {
     const gate = new ModalConfirmGate(fakeApp);
     const promise = gate.confirmHardSwitch(makePlan());
 
-    const title = document.querySelector(".hard-switch-title");
+    const title = document.querySelector(".apply-confirm-title");
     expect(title).not.toBeNull();
     expect(title?.textContent).toContain("Work");
 
@@ -156,7 +156,7 @@ describe("ModalConfirmGate", () => {
       makePlan({ filesToDestroy: new Map([["as-big", huge]]) }),
     );
 
-    const filesSection = document.querySelector(".hard-switch-files-section");
+    const filesSection = document.querySelector(".apply-confirm-files-section");
     expect(filesSection).not.toBeNull();
     const items = filesSection!.querySelectorAll("li");
     expect(items.length).toBe(MODAL_FILE_LIST_CAP);
@@ -177,9 +177,9 @@ describe("ModalConfirmGate", () => {
       }),
     );
 
-    expect(document.querySelector(".hard-switch-tear-section")?.textContent).toContain("(none)");
-    expect(document.querySelector(".hard-switch-files-section")?.textContent).toContain("(none)");
-    expect(document.querySelector(".hard-switch-mat-section")?.textContent).toContain("(none)");
+    expect(document.querySelector(".apply-confirm-tear-section")?.textContent).toContain("(none)");
+    expect(document.querySelector(".apply-confirm-files-section")?.textContent).toContain("(none)");
+    expect(document.querySelector(".apply-confirm-mat-section")?.textContent).toContain("(none)");
 
     findButton("Cancel")?.click();
     await promise;
@@ -189,7 +189,7 @@ describe("ModalConfirmGate", () => {
     const gate = new ModalConfirmGate(fakeApp);
     const promise = gate.confirmHardSwitch(makePlan());
 
-    const confirmBtn = findButton("Hard switch")!;
+    const confirmBtn = findButton("Apply")!;
     confirmBtn.click();
     // Second click on a now-detached button must not throw and must not
     // resolve the (already-settled) promise differently.

--- a/packages/obsidian-plugin/tests/unit/ProfileApplyManager.aliases.test.ts
+++ b/packages/obsidian-plugin/tests/unit/ProfileApplyManager.aliases.test.ts
@@ -12,15 +12,15 @@ import {
 import { PluginLockManager } from "../../src/infrastructure/adapters/PluginLockManager";
 
 /**
- * RFC 0a0791c1 Phase 5 T2 — the soft RDF-filter path (`softSwitchProfile`
- * + `switchProfile` / `softSwitchProfile` aliases) was removed. The mount-state
+ * RFC 0a0791c1 Phase 5 T2 — the soft RDF-filter path (the former public soft method
+ * + its aliases) was removed. The mount-state
  * apply path remains:
  *   - applyProfile  (destructive filesystem materialize)
- *   - hardSwitchProfile → applyProfile (deprecated alias, kept)
+ *   - applyProfile → applyProfile (deprecated alias, kept)
  *
  * These tests verify:
  *   1. the canonical mount path throws when its deps are not wired
- *   2. the deprecated `hardSwitchProfile` alias delegates to the canonical
+ *   2. the deprecated `applyProfile` alias delegates to the canonical
  *      method (proven via spyOn — alias body MUST call canonical method)
  */
 
@@ -125,14 +125,14 @@ function makeHarness(): Harness {
 // ─── Deprecated alias delegation ─────────────────────────────────────────
 
 describe("ProfileApplyManager — deprecated hard alias delegates to canonical", () => {
-  it("hardSwitchProfile delegates to applyProfile", async () => {
+  it("applyProfile delegates to applyProfile", async () => {
     const h = makeHarness();
-    // Hard switch requires extra deps wired; without them, the canonical method
-    // throws via assertHardSwitchWired(). What we verify here is that the alias
-    // routes into the canonical method (not into soft-switch), so the very same
+    // Apply requires extra deps wired; without them, the canonical method
+    // throws via assertApplyDepsWired(). What we verify here is that the alias
+    // routes into the canonical method (not into reindex), so the very same
     // wiring error surfaces. Delegation proven by spy + identical throw signature.
     const spy = jest.spyOn(h.mgr, "applyProfile");
-    await expect(h.mgr.hardSwitchProfile(UID_BASE)).rejects.toThrow(
+    await expect(h.mgr.applyProfile(UID_BASE)).rejects.toThrow(
       /dependencies not wired/,
     );
     expect(spy).toHaveBeenCalledTimes(1);
@@ -143,7 +143,7 @@ describe("ProfileApplyManager — deprecated hard alias delegates to canonical",
 // ─── Canonical applyProfile (wiring assertion) ─────────────
 
 describe("ProfileApplyManager.applyProfile (canonical)", () => {
-  it("throws when hard-switch dependencies are not wired (assertHardSwitchWired)", async () => {
+  it("throws when apply dependencies are not wired (assertApplyDepsWired)", async () => {
     const h = makeHarness();
     await expect(h.mgr.applyProfile(UID_BASE)).rejects.toThrow(
       /applyProfile: dependencies not wired/,

--- a/packages/obsidian-plugin/tests/unit/ProfileApplyManager.aliases.test.ts
+++ b/packages/obsidian-plugin/tests/unit/ProfileApplyManager.aliases.test.ts
@@ -12,16 +12,12 @@ import {
 import { PluginLockManager } from "../../src/infrastructure/adapters/PluginLockManager";
 
 /**
- * RFC 0a0791c1 Phase 5 T2 — the soft RDF-filter path (the former public soft method
- * + its aliases) was removed. The mount-state
- * apply path remains:
+ * RFC 0a0791c1 Phase 5 T2 — the soft RDF-filter path (the former public soft
+ * method + its aliases) was removed; the deprecated `hardSwitchProfile` alias
+ * was removed in Phase 5 T6. The mount-state apply path remains:
  *   - applyProfile  (destructive filesystem materialize)
- *   - applyProfile → applyProfile (deprecated alias, kept)
  *
- * These tests verify:
- *   1. the canonical mount path throws when its deps are not wired
- *   2. the deprecated `applyProfile` alias delegates to the canonical
- *      method (proven via spyOn — alias body MUST call canonical method)
+ * These tests verify the canonical mount path throws when its deps are not wired.
  */
 
 // ─── Fakes ───────────────────────────────────────────────────────────────
@@ -121,24 +117,6 @@ function makeHarness(): Harness {
   const mgr = new ProfileApplyManager(opts);
   return { mgr, rdf, settings, notifyCalls };
 }
-
-// ─── Deprecated alias delegation ─────────────────────────────────────────
-
-describe("ProfileApplyManager — deprecated hard alias delegates to canonical", () => {
-  it("applyProfile delegates to applyProfile", async () => {
-    const h = makeHarness();
-    // Apply requires extra deps wired; without them, the canonical method
-    // throws via assertApplyDepsWired(). What we verify here is that the alias
-    // routes into the canonical method (not into reindex), so the very same
-    // wiring error surfaces. Delegation proven by spy + identical throw signature.
-    const spy = jest.spyOn(h.mgr, "applyProfile");
-    await expect(h.mgr.applyProfile(UID_BASE)).rejects.toThrow(
-      /dependencies not wired/,
-    );
-    expect(spy).toHaveBeenCalledTimes(1);
-    expect(spy).toHaveBeenCalledWith(UID_BASE);
-  });
-});
 
 // ─── Canonical applyProfile (wiring assertion) ─────────────
 

--- a/packages/obsidian-plugin/tests/unit/ProfileApplyManager.apply.test.ts
+++ b/packages/obsidian-plugin/tests/unit/ProfileApplyManager.apply.test.ts
@@ -1,5 +1,5 @@
 /**
- * ProfileApplyManager.hardSwitchProfile() — unit tests covering RFC
+ * ProfileApplyManager.applyProfile() — unit tests covering RFC
  * 22b50a17 Phase 3 algorithm + Phase 0 findings (F2/F3/F5/R24/R26).
  *
  * Tests:
@@ -7,7 +7,7 @@
  *   - Vision Lock #5 — uncommitted abort with file list
  *   - F2 — journal events emitted in correct order (write-BEFORE-destroy)
  *   - F3 — 4 cardinal crash injection points
- *   - HardSwitchAbortedByUser when confirmGate returns false
+ *   - ApplyAbortedByUser when confirmGate returns false
  *   - Cache restore on Phase 2 catch (best-effort rollback)
  *   - recoverIncompleteSwitch identifies destroyed-not-materialized AS
  *   - reconcileToLocal detects .gitmodules vs activeProfileUid divergence
@@ -23,7 +23,7 @@ import type { HardSwitchPlan, IConfirmGate } from "exocortex";
 
 import {
   ProfileApplyManager,
-  HardSwitchAbortedByUser,
+  ApplyAbortedByUser,
   TsFloorViolationError,
   UncommittedChangesAbortError,
   type IProfileResolver,
@@ -124,7 +124,7 @@ class FakeSettingsStore implements ISettingsStore {
   }
 }
 
-// Minimal fakes for hard-switch dependencies.
+// Minimal fakes for apply dependencies.
 
 // Production-shape fake mirroring PluginLocalDataStore's single last-applied
 // slot (RFC 0a0791c1 Phase 5 T2 — the dual AC14 slots were retired).
@@ -471,7 +471,7 @@ async function readJournalEntries(app: App): Promise<SwitchJournalEntry[]> {
 
 // === Tests ===
 
-describe("ProfileApplyManager.hardSwitchProfile", () => {
+describe("ProfileApplyManager.applyProfile", () => {
   describe("R24 — TS-floor guard", () => {
     it("throws TsFloorViolationError when target excludes any floor AS UID before any mutation", async () => {
       // Target profile includes ONLY ems — missing all 3 TS-floor AS.
@@ -481,7 +481,7 @@ describe("ProfileApplyManager.hardSwitchProfile", () => {
         targetIncludes: ["ems-uid"], // Excludes exo / exocmd / shared-identities.
         materialized: ["ems-uid", TS_FLOOR_AS_UID_EXO],
       });
-      await expect(mgr.hardSwitchProfile("target")).rejects.toThrow(TsFloorViolationError);
+      await expect(mgr.applyProfile("target")).rejects.toThrow(TsFloorViolationError);
       // No mutation should have happened.
       expect(gitOps.calls.filter((c) => c.op === "submoduleDeinit").length).toBe(0);
       expect(cacheLayer.cachedCalls.length).toBe(0);
@@ -516,13 +516,13 @@ describe("ProfileApplyManager.hardSwitchProfile", () => {
         ],
         label: "Target Profile",
       });
-      await expect(ctx.mgr.hardSwitchProfile("target")).resolves.toBeUndefined();
+      await expect(ctx.mgr.applyProfile("target")).resolves.toBeUndefined();
     });
 
     it("passes guard when target profile explicitly includes all 3 floor AS UIDs", async () => {
       // Target explicitly declares the 3 floor AS — R24 guard passes;
-      // algorithm proceeds. Hard switch refuses to silently auto-rescue
-      // missing floor (vs Phase 1 soft-switch onload wiring which does).
+      // algorithm proceeds. Apply refuses to silently auto-rescue
+      // missing floor (vs Phase 1 reindex onload wiring which does).
       const { mgr } = setup({
         targetUid: "target",
         sourceUid: null,
@@ -537,7 +537,7 @@ describe("ProfileApplyManager.hardSwitchProfile", () => {
           TS_FLOOR_AS_UID_SHARED_IDENTITIES,
         ],
       });
-      await expect(mgr.hardSwitchProfile("target")).resolves.toBeUndefined();
+      await expect(mgr.applyProfile("target")).resolves.toBeUndefined();
     });
   });
 
@@ -564,7 +564,7 @@ describe("ProfileApplyManager.hardSwitchProfile", () => {
           { asUid: "ems-uid", submodulePath: "assetspaces/kitelev/exoas-ems", files: ["a.md", "b.md"] },
         ],
       });
-      await expect(mgr.hardSwitchProfile("target")).rejects.toThrow(UncommittedChangesAbortError);
+      await expect(mgr.applyProfile("target")).rejects.toThrow(UncommittedChangesAbortError);
       // No filesystem mutation.
       expect(gitOps.calls.filter((c) => c.op === "submoduleDeinit").length).toBe(0);
     });
@@ -588,7 +588,7 @@ describe("ProfileApplyManager.hardSwitchProfile", () => {
           TS_FLOOR_AS_UID_SHARED_IDENTITIES,
         ],
       });
-      await mgr.hardSwitchProfile("target");
+      await mgr.applyProfile("target");
       const checkCall = uncommittedGuard.check.mock.calls[0][0];
       // Only kpc passed — not ems.
       expect(checkCall).toEqual([
@@ -597,7 +597,7 @@ describe("ProfileApplyManager.hardSwitchProfile", () => {
     });
   });
 
-  describe("HardSwitchAbortedByUser", () => {
+  describe("ApplyAbortedByUser", () => {
     it("throws and writes no filesystem mutation if confirmGate declines", async () => {
       const { mgr, confirmGate, gitOps, cacheLayer } = setup({
         targetUid: "target",
@@ -615,7 +615,7 @@ describe("ProfileApplyManager.hardSwitchProfile", () => {
         ],
       });
       confirmGate.approve = false;
-      await expect(mgr.hardSwitchProfile("target")).rejects.toThrow(HardSwitchAbortedByUser);
+      await expect(mgr.applyProfile("target")).rejects.toThrow(ApplyAbortedByUser);
       expect(gitOps.calls.length).toBe(0);
       expect(cacheLayer.cachedCalls.length).toBe(0);
     });
@@ -638,7 +638,7 @@ describe("ProfileApplyManager.hardSwitchProfile", () => {
           TS_FLOOR_AS_UID_SHARED_IDENTITIES,
         ],
       });
-      await mgr.hardSwitchProfile("target");
+      await mgr.applyProfile("target");
       const entries = await readJournalEntries(app);
       const destroyCachedIdx = entries.findIndex(
         (e) => e.phase === "phase2-destroy-cached" && e.as === "ems-uid",
@@ -675,7 +675,7 @@ describe("ProfileApplyManager.hardSwitchProfile", () => {
           TS_FLOOR_AS_UID_SHARED_IDENTITIES,
         ],
       });
-      await mgr.hardSwitchProfile("target");
+      await mgr.applyProfile("target");
       // ems-uid was destroyed (deinit + remove gitmodules dir + remove working tree)
       const deinitCalls = gitOps.calls.filter(
         (c) => c.op === "submoduleDeinit" && (c.args[0] as string).includes("ems"),
@@ -697,7 +697,7 @@ describe("ProfileApplyManager.hardSwitchProfile", () => {
       expect(stripCalls.length).toBe(0);
     });
 
-    it("emits hard-switch-completed on successful switch", async () => {
+    it("emits apply-completed on successful switch", async () => {
       const { mgr, app } = setup({
         targetUid: "target",
         sourceUid: null,
@@ -713,9 +713,9 @@ describe("ProfileApplyManager.hardSwitchProfile", () => {
           TS_FLOOR_AS_UID_SHARED_IDENTITIES,
         ],
       });
-      await mgr.hardSwitchProfile("target");
+      await mgr.applyProfile("target");
       const entries = await readJournalEntries(app);
-      expect(entries.some((e) => e.phase === "hard-switch-completed")).toBe(true);
+      expect(entries.some((e) => e.phase === "apply-completed")).toBe(true);
     });
   });
 
@@ -737,7 +737,7 @@ describe("ProfileApplyManager.hardSwitchProfile", () => {
         ],
       });
       gitOps.failAt = "submoduleDeinit";
-      await expect(mgr.hardSwitchProfile("target")).rejects.toThrow();
+      await expect(mgr.applyProfile("target")).rejects.toThrow();
       // ems-uid was cached but never destroyed.
       expect(cacheLayer.cachedCalls.some((c) => c.asUid === "ems-uid")).toBe(true);
     });
@@ -760,7 +760,7 @@ describe("ProfileApplyManager.hardSwitchProfile", () => {
         ],
       });
       assetSpaceManager.failOnPull = "ims-uid"; // 2nd pull fails
-      await expect(mgr.hardSwitchProfile("target")).rejects.toThrow();
+      await expect(mgr.applyProfile("target")).rejects.toThrow();
       // Allocated staging for kpc should be released.
       expect(assetSpaceManager.stagingTracker.released).toContain("/tmp/staging/kpc-uid");
     });
@@ -786,7 +786,7 @@ describe("ProfileApplyManager.hardSwitchProfile", () => {
       });
       // Fail at commit — both AS destroyed but commit unable.
       gitOps.failAt = "commit";
-      await expect(mgr.hardSwitchProfile("target")).rejects.toThrow();
+      await expect(mgr.applyProfile("target")).rejects.toThrow();
       // restore() called for both destroyed AS.
       expect(cacheLayer.restoreCalls.length).toBeGreaterThanOrEqual(2);
     });
@@ -808,7 +808,7 @@ describe("ProfileApplyManager.hardSwitchProfile", () => {
         ],
       });
       gitOps.failAt = "commit";
-      await expect(mgr.hardSwitchProfile("target")).rejects.toThrow();
+      await expect(mgr.applyProfile("target")).rejects.toThrow();
       expect(localDataStore.isSwitchInProgress()).toBe(false);
     });
   });
@@ -830,7 +830,7 @@ describe("ProfileApplyManager.hardSwitchProfile", () => {
           TS_FLOOR_AS_UID_SHARED_IDENTITIES,
         ],
       });
-      await mgr.hardSwitchProfile("target");
+      await mgr.applyProfile("target");
       expect(localDataStore.getActiveProfileUid()).toBe("target");
       expect(localDataStore.isSwitchInProgress()).toBe(false);
     });
@@ -851,11 +851,11 @@ describe("ProfileApplyManager.hardSwitchProfile", () => {
           TS_FLOOR_AS_UID_SHARED_IDENTITIES,
         ],
       });
-      await mgr.hardSwitchProfile("target");
+      await mgr.applyProfile("target");
       expect(localDataStore.getActiveProfileUid()).toBe("target");
     });
 
-    it("rdfIndexer.refresh fired once after the hard switch (RFC 01a83de8 — soft-filter removed)", async () => {
+    it("rdfIndexer.refresh fired once after the apply (RFC 01a83de8 — soft-filter removed)", async () => {
       const { mgr, indexer } = setup({
         targetUid: "target",
         sourceUid: null,
@@ -871,8 +871,8 @@ describe("ProfileApplyManager.hardSwitchProfile", () => {
           TS_FLOOR_AS_UID_SHARED_IDENTITIES,
         ],
       });
-      await mgr.hardSwitchProfile("target");
-      // The hard switch still derives effectiveAsUids for the destroy/materialize
+      await mgr.applyProfile("target");
+      // The apply still derives effectiveAsUids for the destroy/materialize
       // diff (asserted elsewhere), but the query-time soft-filter was removed:
       // refresh() no longer receives an effective set — it just re-indexes the
       // now-materialised vault once.
@@ -895,10 +895,10 @@ describe("ProfileApplyManager.hardSwitchProfile", () => {
           TS_FLOOR_AS_UID_SHARED_IDENTITIES,
         ],
       });
-      await mgr.hardSwitchProfile("target");
+      await mgr.applyProfile("target");
       const commits = gitOps.calls.filter((c) => c.op === "commit");
       expect(commits.length).toBe(1);
-      expect((commits[0].args[0] as string)).toContain("hard switch");
+      expect((commits[0].args[0] as string)).toContain("apply");
     });
   });
 });

--- a/packages/obsidian-plugin/tests/unit/ProfileApplyManager.restApply.test.ts
+++ b/packages/obsidian-plugin/tests/unit/ProfileApplyManager.restApply.test.ts
@@ -1,5 +1,5 @@
 /**
- * ProfileApplyManager.restSwitchProfile() — RFC 01a83de8 Phase 3 T2.
+ * ProfileApplyManager.applyProfileViaRest() — RFC 01a83de8 Phase 3 T2.
  *
  * Mobile-capable profile switch via REST/tarball mount/unmount (no git binary,
  * staging, cache, or git commit). Visibility is mount-state: an AssetSpace is
@@ -12,12 +12,12 @@
  *   2. Revert-verify control — a target already in mount-state ⇒ no-op (soft
  *      switch only, no mount/unmount).
  *   3. R24 TS-floor — target excluding a floor AS throws before any mutation.
- *   4. ConfirmGate decline → HardSwitchAbortedByUser, no mount/unmount.
+ *   4. ConfirmGate decline → ApplyAbortedByUser, no mount/unmount.
  *   5. Not wired — missing restMount throws a clear error.
  *   6. Dispatch — applyProfile on mobile delegates to
- *      restSwitchProfile (REST path; gitOps never touched).
+ *      applyProfileViaRest (REST path; gitOps never touched).
  *
- * Fakes mirror the desktop hardSwitch harness: in-memory vault.adapter
+ * Fakes mirror the desktop apply harness: in-memory vault.adapter
  * (`exists` true for known files/folders), production-shape AssetSpace ABox
  * frontmatter (`_source` derives back to the folder via derivePath), and a
  * FakeLocalDataStore preserving the dual AC14 slots on partial save.
@@ -28,7 +28,7 @@ import type { HardSwitchPlan, IConfirmGate } from "exocortex";
 
 import {
   ProfileApplyManager,
-  HardSwitchAbortedByUser,
+  ApplyAbortedByUser,
   TsFloorViolationError,
   type IProfileResolver,
   type IRdfIndexer,
@@ -304,7 +304,7 @@ const ALL_FLOOR_UIDS = TS_FLOOR.map((f) => f.uid);
 
 // ─── Tests ────────────────────────────────────────────────────────────────
 
-describe("ProfileApplyManager.restSwitchProfile", () => {
+describe("ProfileApplyManager.applyProfileViaRest", () => {
   it("unmounts to-destroy + mounts to-materialize, persists profile + re-indexes", async () => {
     // Currently materialised: floors + kpc. Target: floors + ems (NOT kpc).
     const { mgr, indexer, localDataStore, restMount } = setup({
@@ -312,7 +312,7 @@ describe("ProfileApplyManager.restSwitchProfile", () => {
       materialized: [...ALL_FLOOR_UIDS, "kpc-uid"],
     });
 
-    await mgr.restSwitchProfile("target");
+    await mgr.applyProfileViaRest("target");
 
     // kpc unmounted (was materialised, not in target).
     expect(restMount.unmounted).toEqual(["assetspaces/kitelev/exoas-kpc"]);
@@ -338,13 +338,13 @@ describe("ProfileApplyManager.restSwitchProfile", () => {
 
   it("no-ops to a reindex-only path when mount-state already matches (control)", async () => {
     // Target == currently materialised (floors only) ⇒ no mount/unmount;
-    // restSwitchProfile falls through to the reindex-only path.
+    // applyProfileViaRest falls through to the reindex-only path.
     const { mgr, restMount, indexer } = setup({
       targetIncludes: ALL_FLOOR_UIDS,
       materialized: ALL_FLOOR_UIDS,
     });
 
-    await expect(mgr.restSwitchProfile("target")).resolves.toBeUndefined();
+    await expect(mgr.applyProfileViaRest("target")).resolves.toBeUndefined();
 
     expect(restMount.mounted).toEqual([]);
     expect(restMount.unmounted).toEqual([]);
@@ -358,21 +358,21 @@ describe("ProfileApplyManager.restSwitchProfile", () => {
       targetIncludes: ["ems-uid"], // excludes all floor AS
       materialized: [...ALL_FLOOR_UIDS, "ems-uid"],
     });
-    await expect(mgr.restSwitchProfile("target")).rejects.toThrow(
+    await expect(mgr.applyProfileViaRest("target")).rejects.toThrow(
       TsFloorViolationError,
     );
     expect(restMount.mounted).toEqual([]);
     expect(restMount.unmounted).toEqual([]);
   });
 
-  it("aborts with HardSwitchAbortedByUser when confirmGate declines — no mutation", async () => {
+  it("aborts with ApplyAbortedByUser when confirmGate declines — no mutation", async () => {
     const { mgr, confirmGate, restMount } = setup({
       targetIncludes: [...ALL_FLOOR_UIDS, "ems-uid"],
       materialized: [...ALL_FLOOR_UIDS, "kpc-uid"],
     });
     confirmGate.approve = false;
-    await expect(mgr.restSwitchProfile("target")).rejects.toThrow(
-      HardSwitchAbortedByUser,
+    await expect(mgr.applyProfileViaRest("target")).rejects.toThrow(
+      ApplyAbortedByUser,
     );
     expect(restMount.mounted).toEqual([]);
     expect(restMount.unmounted).toEqual([]);
@@ -384,7 +384,7 @@ describe("ProfileApplyManager.restSwitchProfile", () => {
       materialized: ALL_FLOOR_UIDS,
       wireRestMount: false,
     });
-    await expect(mgr.restSwitchProfile("target")).rejects.toThrow(
+    await expect(mgr.applyProfileViaRest("target")).rejects.toThrow(
       /dependencies not wired/,
     );
   });
@@ -396,7 +396,7 @@ describe("ProfileApplyManager.restSwitchProfile", () => {
       wireRestMountFactory: true,
     });
 
-    await mgr.restSwitchProfile("target");
+    await mgr.applyProfileViaRest("target");
 
     // Factory mount did the work…
     expect(factoryMount.mounted.map((m) => m.submodulePath)).toEqual([
@@ -415,7 +415,7 @@ describe("applyProfile dispatch (mobile → REST)", () => {
     (Platform as unknown as { isMobile: boolean }).isMobile = original;
   });
 
-  it("delegates to restSwitchProfile on mobile (gitOps never touched)", async () => {
+  it("delegates to applyProfileViaRest on mobile (gitOps never touched)", async () => {
     (Platform as unknown as { isMobile: boolean }).isMobile = true;
     const { mgr, restMount, gitOps } = setup({
       targetIncludes: [...ALL_FLOOR_UIDS, "ems-uid"],

--- a/packages/obsidian-plugin/tests/unit/ProfileApplyManager.test.ts
+++ b/packages/obsidian-plugin/tests/unit/ProfileApplyManager.test.ts
@@ -366,7 +366,7 @@ describe("ProfileApplyManager.reindexMountState — happy path (apply reindex)",
     expect(h.notifyCalls[0]).toMatch(/\d+ms/);
   });
 
-  it("invokes rdf.refresh once on soft switch (RFC 01a83de8 — soft-filter removed)", async () => {
+  it("invokes rdf.refresh once on reindex (RFC 01a83de8 — soft-filter removed)", async () => {
     const h = makeHarness({
       profiles: [
         [UID_BASE, { uid: UID_BASE, includes: [ONTO_TBANK], extends: null }],
@@ -374,7 +374,7 @@ describe("ProfileApplyManager.reindexMountState — happy path (apply reindex)",
     });
     await reindex(h.mgr, UID_BASE);
     // The query-time soft-filter was removed (RFC 01a83de8 Phase 3 T3b); the
-    // soft switch persists the active profile and triggers a single full-vault
+    // reindex persists the active profile and triggers a single full-vault
     // reindex — no effective set is threaded through refresh anymore.
     expect(h.rdf.refreshCalls).toBe(1);
   });

--- a/packages/obsidian-plugin/tests/unit/ProfileCommands.test.ts
+++ b/packages/obsidian-plugin/tests/unit/ProfileCommands.test.ts
@@ -6,7 +6,7 @@ import {
 } from "../../src/infrastructure/adapters/ProfileCommands";
 import {
   type ProfileApplyManager,
-  HardSwitchAbortedByUser,
+  ApplyAbortedByUser,
   TsFloorViolationError,
   UncommittedChangesAbortError,
 } from "../../src/infrastructure/adapters/ProfileApplyManager";
@@ -14,14 +14,14 @@ import {
 // ─── Test doubles ────────────────────────────────────────────────────────
 
 class FakeSwitchMgr {
-  hardSwitchCalls: string[] = [];
+  applyCalls: string[] = [];
   /** Error to throw from the next applyProfile call (then cleared). */
-  hardSwitchThrows: Error | null = null;
+  applyThrows: Error | null = null;
   async applyProfile(uid: string): Promise<void> {
-    this.hardSwitchCalls.push(uid);
-    if (this.hardSwitchThrows) {
-      const e = this.hardSwitchThrows;
-      this.hardSwitchThrows = null;
+    this.applyCalls.push(uid);
+    if (this.applyThrows) {
+      const e = this.applyThrows;
+      this.applyThrows = null;
       throw e;
     }
   }
@@ -242,7 +242,7 @@ describe("ProfileCommands.invokeApplyProfile (Apply profile)", () => {
     const h = makeHarness({ profiles, pickResult: profiles[0] });
     await h.cmd.invokeApplyProfile();
 
-    expect(h.switchMgr.hardSwitchCalls).toEqual(["k1"]);
+    expect(h.switchMgr.applyCalls).toEqual(["k1"]);
   });
 
   it("shows Notice when no profiles in vault", async () => {
@@ -258,13 +258,13 @@ describe("ProfileCommands.invokeApplyProfile (Apply profile)", () => {
     const h = makeHarness({ profiles, pickResult: null });
     await h.cmd.invokeApplyProfile();
 
-    expect(h.switchMgr.hardSwitchCalls).toHaveLength(0);
+    expect(h.switchMgr.applyCalls).toHaveLength(0);
   });
 
-  it("maps HardSwitchAbortedByUser to a cancelled Notice (no re-throw)", async () => {
+  it("maps ApplyAbortedByUser to a cancelled Notice (no re-throw)", async () => {
     const profiles = [{ uid: "k1", label: "k1" }];
     const h = makeHarness({ profiles, pickResult: profiles[0] });
-    h.switchMgr.hardSwitchThrows = new HardSwitchAbortedByUser();
+    h.switchMgr.applyThrows = new ApplyAbortedByUser();
 
     await expect(h.cmd.invokeApplyProfile()).resolves.not.toThrow();
     expect(h.notices.some((n) => /cancelled/i.test(n))).toBe(true);
@@ -273,7 +273,7 @@ describe("ProfileCommands.invokeApplyProfile (Apply profile)", () => {
   it("maps TsFloorViolationError to a refused Notice", async () => {
     const profiles = [{ uid: "k1", label: "k1" }];
     const h = makeHarness({ profiles, pickResult: profiles[0] });
-    h.switchMgr.hardSwitchThrows = new TsFloorViolationError(
+    h.switchMgr.applyThrows = new TsFloorViolationError(
       "missing $exo floor",
     );
 
@@ -286,7 +286,7 @@ describe("ProfileCommands.invokeApplyProfile (Apply profile)", () => {
   it("maps UncommittedChangesAbortError to an aborted Notice with file count", async () => {
     const profiles = [{ uid: "k1", label: "k1" }];
     const h = makeHarness({ profiles, pickResult: profiles[0] });
-    h.switchMgr.hardSwitchThrows = new UncommittedChangesAbortError("dirty", [
+    h.switchMgr.applyThrows = new UncommittedChangesAbortError("dirty", [
       { asUid: "as1", submodulePath: "assetspaces/x", files: ["a.md", "b.md"] },
     ]);
 
@@ -299,7 +299,7 @@ describe("ProfileCommands.invokeApplyProfile (Apply profile)", () => {
   it("surfaces generic apply failure as a Notice без re-throw", async () => {
     const profiles = [{ uid: "k1", label: "k1" }];
     const h = makeHarness({ profiles, pickResult: profiles[0] });
-    h.switchMgr.hardSwitchThrows = new Error("boom");
+    h.switchMgr.applyThrows = new Error("boom");
 
     await expect(h.cmd.invokeApplyProfile()).resolves.not.toThrow();
     expect(h.notices.some((n) => /failed.*boom/.test(n))).toBe(true);

--- a/packages/obsidian-plugin/tests/unit/infrastructure/adapters/AssetSpaceMaterializationTracker.test.ts
+++ b/packages/obsidian-plugin/tests/unit/infrastructure/adapters/AssetSpaceMaterializationTracker.test.ts
@@ -236,7 +236,7 @@ describe("AssetSpaceMaterializationTracker", () => {
     expect(tracker.isMaterialized("uid-ems")).toBe(true);
     expect(tracker.isMaterialized("uid-exo")).toBe(true);
 
-    // Simulate hard switch: exo folder destroyed.
+    // Simulate apply: exo folder destroyed.
     existingFolders.delete("assetspaces/exo");
     await tracker.refresh();
     expect(tracker.isMaterialized("uid-ems")).toBe(true);

--- a/packages/obsidian-plugin/tests/unit/integration/ApplyEndToEnd.integration.test.ts
+++ b/packages/obsidian-plugin/tests/unit/integration/ApplyEndToEnd.integration.test.ts
@@ -1,7 +1,7 @@
 /**
  * @jest-environment node
  *
- * End-to-end integration test for `hardSwitchProfile()` algorithm against
+ * End-to-end integration test for `applyProfile()` algorithm against
  * a real disposable git vault on the local filesystem.
  *
  * Scope:
@@ -17,7 +17,7 @@
  *   1. Init test vault with 3 AS submodules (file:// URLs)
  *   2. Two profiles — profile-A {AS1, AS2}, profile-B {AS2, AS3}
  *   3. Active = profile-A → vault has AS1 + AS2
- *   4. hardSwitchProfile(profile-B)
+ *   4. applyProfile(profile-B)
  *   5. Verify vault now has AS2 + AS3
  *   6. Verify .gitmodules correctly reflects new state
  *   7. Verify cache contains AS1 tarball
@@ -375,7 +375,7 @@ async function copyTree(src: string, dest: string): Promise<void> {
   }
 }
 
-describe("hardSwitchProfile E2E (real fs, mocked pull)", () => {
+describe("applyProfile E2E (real fs, mocked pull)", () => {
   let setup: VaultSetup;
 
   afterEach(async () => {
@@ -459,7 +459,7 @@ describe("hardSwitchProfile E2E (real fs, mocked pull)", () => {
     });
 
     // ---- ACT ----
-    await mgr.hardSwitchProfile("profile-b");
+    await mgr.applyProfile("profile-b");
 
     // ---- ASSERT vault state ----
     expect(existsSync(path.join(setup.vaultPath, "assetspaces/kitelev/exoas-as1"))).toBe(false);
@@ -488,7 +488,7 @@ describe("hardSwitchProfile E2E (real fs, mocked pull)", () => {
     // re-uses URL from `.gitmodules`». Switch profile-b → profile-a; as1 was
     // destroyed in profile-a→b transition but `.gitmodules` entry preserved.
     // Switch back must re-add as1 (URL recovered from `.gitmodules`).
-    await mgr.hardSwitchProfile("profile-a");
+    await mgr.applyProfile("profile-a");
 
     // After switch-back: as1 working tree restored, as3 destroyed.
     expect(existsSync(path.join(setup.vaultPath, "assetspaces/kitelev/exoas-as1"))).toBe(true);

--- a/packages/obsidian-plugin/tests/unit/integration/ApplyGitSubmoduleOps.integration.test.ts
+++ b/packages/obsidian-plugin/tests/unit/integration/ApplyGitSubmoduleOps.integration.test.ts
@@ -1,7 +1,7 @@
 /**
  * @jest-environment node
  *
- * Integration tests для hardSwitchProfile() real submodule operations using
+ * Integration tests для applyProfile() real submodule operations using
  * file:// URLs (fast offline, exercises real git subprocess).
  *
  * Coverage:

--- a/packages/obsidian-plugin/tests/unit/presentation/asset-space/AssetSpaceStatusIconPatch.test.ts
+++ b/packages/obsidian-plugin/tests/unit/presentation/asset-space/AssetSpaceStatusIconPatch.test.ts
@@ -179,7 +179,7 @@ describe("AssetSpaceStatusIconPatch (RFC 22b50a17 Phase 4)", () => {
       true,
     );
 
-    // Hard-switch destroys this AS — flip flag.
+    // Apply destroys this AS — flip flag.
     mockTracker.isMaterialized.mockReturnValue(false);
     patch.onTrackerRefreshed();
 

--- a/packages/obsidian-plugin/tests/unit/wiring/ApplyDepsFactory.integration.test.ts
+++ b/packages/obsidian-plugin/tests/unit/wiring/ApplyDepsFactory.integration.test.ts
@@ -1,6 +1,6 @@
 /**
- * Production-shape regression test for `buildHardSwitchDeps`
- * (Issue: hard-switch deps wiring exception hides Bootstrap/knowledge palette commands).
+ * Production-shape regression test for `buildApplyDeps`
+ * (Issue: apply deps wiring exception hides Bootstrap/knowledge palette commands).
  *
  * This exercises the REAL constructor chain — LocalSecretsStore → getSecret →
  * GitHubRestClient → StagingDirTracker → AssetSpaceManager → GitSubmoduleOps →
@@ -22,9 +22,9 @@ import type { INotificationService } from "exocortex";
 import type { ILogger } from "../../../src/adapters/logging/ILogger";
 
 import {
-  buildHardSwitchDeps,
-  type BuildHardSwitchDepsOptions,
-} from "../../../src/infrastructure/adapters/HardSwitchDepsFactory";
+  buildApplyDeps,
+  type BuildApplyDepsOptions,
+} from "../../../src/infrastructure/adapters/ApplyDepsFactory";
 import { PluginLocalDataStore } from "../../../src/infrastructure/adapters/PluginLocalDataStore";
 
 // ─── Real-shape fake App / vault.adapter ─────────────────────────────────
@@ -87,8 +87,8 @@ function makeFakeNotifier(): INotificationService {
 
 function makeOptions(
   app: App,
-  overrides: Partial<BuildHardSwitchDepsOptions> = {},
-): BuildHardSwitchDepsOptions {
+  overrides: Partial<BuildApplyDepsOptions> = {},
+): BuildApplyDepsOptions {
   return {
     app,
     localDataStore: new PluginLocalDataStore({ app }),
@@ -100,12 +100,12 @@ function makeOptions(
 
 const DATA_LOCAL_PATH = ".obsidian/plugins/exocortex/data.local.json";
 
-describe("buildHardSwitchDeps — production-shape wiring", () => {
+describe("buildApplyDeps — production-shape wiring", () => {
   it("wires all deps on a valid desktop vault WITHOUT a stored PAT (regression)", async () => {
     // No data.local.json → getSecret('pat') === null → ctor receives "".
     // Pre-fix this threw «PAT is required» → deps null → palette commands hidden.
     const app = makeFakeApp({ basePath: "/Users/test/vault-2025" });
-    const deps = await buildHardSwitchDeps(makeOptions(app));
+    const deps = await buildApplyDeps(makeOptions(app));
 
     expect(deps).not.toBeNull();
     expect(deps?.vaultRootPath).toBe("/Users/test/vault-2025");
@@ -126,7 +126,7 @@ describe("buildHardSwitchDeps — production-shape wiring", () => {
         }),
       },
     });
-    const deps = await buildHardSwitchDeps(makeOptions(app));
+    const deps = await buildApplyDeps(makeOptions(app));
 
     expect(deps).not.toBeNull();
     expect(deps?.vaultRootPath).toBe("/Users/test/vault-2025");
@@ -138,7 +138,7 @@ describe("buildHardSwitchDeps — production-shape wiring", () => {
     // impossible → wiring intentionally returns null.
     const app = makeFakeApp({ basePath: "" });
     const { logger, warns } = makeFakeLogger();
-    const deps = await buildHardSwitchDeps(makeOptions(app, { logger }));
+    const deps = await buildApplyDeps(makeOptions(app, { logger }));
 
     expect(deps).toBeNull();
     expect(warns.some((w) => w.includes("basePath unavailable"))).toBe(true);
@@ -154,7 +154,7 @@ describe("buildHardSwitchDeps — production-shape wiring", () => {
       .spyOn(console, "error")
       .mockImplementation(() => undefined);
     try {
-      const deps = await buildHardSwitchDeps(
+      const deps = await buildApplyDeps(
         makeOptions(app, {
           logger,
           localDataStore: null as unknown as PluginLocalDataStore,
@@ -163,10 +163,10 @@ describe("buildHardSwitchDeps — production-shape wiring", () => {
 
       expect(deps).toBeNull();
       expect(consoleErrorSpy).toHaveBeenCalledWith(
-        "[Exocortex] hard-switch wiring failed:",
+        "[Exocortex] apply wiring failed:",
         expect.any(Error),
       );
-      expect(warns.some((w) => w.includes("failed to wire hard-switch deps"))).toBe(
+      expect(warns.some((w) => w.includes("failed to wire apply deps"))).toBe(
         true,
       );
     } finally {

--- a/packages/obsidian-plugin/tests/unit/wiring/BootstrapPatRefresh.integration.test.ts
+++ b/packages/obsidian-plugin/tests/unit/wiring/BootstrapPatRefresh.integration.test.ts
@@ -29,7 +29,7 @@ import * as obsidian from "obsidian";
 import type { App } from "obsidian";
 import type { INotificationService } from "exocortex";
 
-import { buildAssetSpacePuller } from "../../../src/infrastructure/adapters/HardSwitchDepsFactory";
+import { buildAssetSpacePuller } from "../../../src/infrastructure/adapters/ApplyDepsFactory";
 import { LocalSecretsStore } from "../../../src/infrastructure/adapters/LocalSecretsStore";
 import { PluginLocalDataStore } from "../../../src/infrastructure/adapters/PluginLocalDataStore";
 import { GitHubRestClient } from "../../../src/infrastructure/adapters/GitHubRestClient";

--- a/packages/obsidian-plugin/tests/unit/wiring/BootstrapPatRefresh.integration.test.ts
+++ b/packages/obsidian-plugin/tests/unit/wiring/BootstrapPatRefresh.integration.test.ts
@@ -201,7 +201,7 @@ describe("Bootstrap/Add-AssetSpace PAT freshness (Issue #3382) — production-sh
     const notices: string[] = [];
 
     // Pre-fix behaviour: build the puller NOW, while the vault has no PAT
-    // (mirrors capturing `hardSwitchDeps.assetSpaceManager` at plugin onload).
+    // (mirrors capturing `applyDeps.assetSpaceManager` at plugin onload).
     const eagerPuller = await buildAssetSpacePuller({
       app,
       localDataStore: store,


### PR DESCRIPTION
## Summary

Phase 5 apply-model convergence — **T6 PR2 of 3** (plugin machinery). Mechanical rename, **zero behavior change**. Plugin-only (no core/CLI files touched). Builds on PR1 (#3445, merged).

- `HardSwitchDepsFactory`→`ApplyDepsFactory` (file), `buildHardSwitchDeps`→`buildApplyDeps`, `HardSwitchDeps`/`BuildHardSwitchDepsOptions`→`ApplyDeps*`, `hardSwitchDeps` var→`applyDeps`.
- `HardSwitchAbortedByUser`→`ApplyAbortedByUser`; `HardSwitchConfirmModal`→`ApplyConfirmModal` (+ inline `apply-confirm-*` CSS — verified **not referenced in any stylesheet**).
- `restSwitchProfile`→`applyProfileViaRest`; `assertHardSwitchWired`→`assertApplyDepsWired`; `assertRestSwitchWired`→`assertRestApplyWired`.
- **Deleted** the dead deprecated `hardSwitchProfile` alias method (zero production callers — it only delegated to `applyProfile`); JSDoc refs updated.
- Journal phase strings `"hard-switch-{starting,completed,failed}"`→`"apply-*"`. Self-contained: written + read **only** by `ProfileApplyManager`'s own recovery tail-scan (no cross-file/cross-package reader). The only cross-version effect is a crash-mid-apply journal written by an older build — negligible (single user; normal flow completes the journal).
- User-facing strings reworded to apply-model (modal title/button "Apply", error/notify/commit/lock-name strings, residual soft-switch prose).
- Test files renamed (`*.hardSwitch.test`→`.apply.test`, `HardSwitch*EndToEnd/GitSubmoduleOps/DepsFactory`→`Apply*`); deleted-alias callers redirected to `applyProfile`.

### Scope boundary (intentional)
Core shared `HardSwitchPlan` / `IConfirmGate.confirmHardSwitch`, the plugin command id `hard-switch-focus-profile`, and the Settings UI text are **left for PR3** (core contract + command-id + Settings UI rewrite).

## Test plan
- [x] `npm run check:types` green (monorepo).
- [x] `npm run lint` clean (2 pre-existing warnings on unrelated files).
- [x] 14 affected plugin unit suites → **195/195 pass** (incl. ApplyEndToEnd + ApplyGitSubmoduleOps integration).
- [x] Pre-commit archgate 16/16 pass; lint-staged + related-tests green.
- [ ] CI 14 checks green.