### PR TITLE
refactor: confirm-gate contract → Apply*, command-id apply-profile, Settings apply-model (Phase 5 T6 PR3/3)

### DIFF
--- a/packages/cli/src/commands/apply-profile.ts
+++ b/packages/cli/src/commands/apply-profile.ts
@@ -199,7 +199,7 @@ export async function runApplyProfile(
       verbose: opts.verbose ?? false,
       log: (msg) => err(msg),
     });
-  const approved = await gate.confirmHardSwitch(diff.plan);
+  const approved = await gate.confirmApply(diff.plan);
   if (!approved) {
     // Gate already logged "Refused: --yes required". Exit 0 — explicit decline.
     return { exitCode: ExitCodes.SUCCESS, stdout, stderr };

--- a/packages/cli/src/services/CliApplyProfileService.ts
+++ b/packages/cli/src/services/CliApplyProfileService.ts
@@ -26,7 +26,7 @@ import { existsSync, readdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import yaml from "js-yaml";
 
-import type { HardSwitchPlan } from "exocortex";
+import type { ApplyPlan } from "exocortex";
 import {
   derivePath,
   assertTsFloor as assertTsFloorGuard,
@@ -90,7 +90,7 @@ export interface MaterializeTarget {
 export interface ApplyProfileDiff {
   toDestroy: TearDownTarget[];
   toMaterialize: MaterializeTarget[];
-  plan: HardSwitchPlan;
+  plan: ApplyPlan;
 }
 
 /** Result of {@link CliApplyProfileService.execute}. */
@@ -248,7 +248,7 @@ export class CliApplyProfileService {
   }
 
   /**
-   * Compute the mount-state diff + the `HardSwitchPlan` from the resolver's
+   * Compute the mount-state diff + the `ApplyPlan` from the resolver's
    * engaged result. Pure (no filesystem mutation) — `existsSync` reads only.
    */
   buildDiff(params: {
@@ -323,7 +323,7 @@ export class CliApplyProfileService {
     const filesToDestroy = new Map<string, string[]>();
     for (const t of toDestroy) filesToDestroy.set(t.asUid, t.files);
 
-    const plan: HardSwitchPlan = {
+    const plan: ApplyPlan = {
       targetProfileUid,
       targetProfileLabel,
       sourceProfileUid,

--- a/packages/cli/src/services/HeadlessConfirmGate.ts
+++ b/packages/cli/src/services/HeadlessConfirmGate.ts
@@ -14,7 +14,7 @@
  * machine-readable output the Phase 3 orchestrator may emit.
  */
 
-import type { IConfirmGate, HardSwitchPlan } from "exocortex";
+import type { IConfirmGate, ApplyPlan } from "exocortex";
 
 export interface HeadlessConfirmGateOptions {
   /** Confirm apply (safety override). False by default. */
@@ -41,7 +41,7 @@ export class HeadlessConfirmGate implements IConfirmGate {
   }
 
   // eslint-disable-next-line @typescript-eslint/require-await
-  async confirmHardSwitch(plan: HardSwitchPlan): Promise<boolean> {
+  async confirmApply(plan: ApplyPlan): Promise<boolean> {
     if (this.verbose) {
       const totalFiles = Array.from(plan.filesToDestroy.values()).reduce(
         (sum, files) => sum + files.length,

--- a/packages/cli/tests/integration/commands/apply-profile.integration.test.ts
+++ b/packages/cli/tests/integration/commands/apply-profile.integration.test.ts
@@ -26,7 +26,7 @@ import os from "os";
 import path from "path";
 import { mkdirSync, writeFileSync, existsSync, readFileSync } from "node:fs";
 
-import type { HardSwitchPlan, IConfirmGate } from "exocortex";
+import type { ApplyPlan, IConfirmGate } from "exocortex";
 import { runApplyProfile, applyProfileCommand } from "../../../src/commands/apply-profile.js";
 import {
   ASSET_SPACE_CLASS_UID,
@@ -192,7 +192,7 @@ async function makeFixtureVault(
   await fs.writeFile(path.join(root, ".gitmodules"), gm, "utf-8");
 }
 
-const approvingGate: IConfirmGate = { confirmHardSwitch: async () => true };
+const approvingGate: IConfirmGate = { confirmApply: async () => true };
 
 describe("CLI — apply-profile real mount-state switch (Issue #3416)", () => {
   let vaultRoot: string;
@@ -364,9 +364,9 @@ describe("CLI — apply-profile real mount-state switch (Issue #3416)", () => {
 
   it("--verbose surfaces the real plan to the gate (tear-down count visible)", async () => {
     await setup(/* testlibMaterialised */ true);
-    const seen: { plan?: HardSwitchPlan } = {};
+    const seen: { plan?: ApplyPlan } = {};
     const recordingGate: IConfirmGate = {
-      confirmHardSwitch: async (plan) => {
+      confirmApply: async (plan) => {
         seen.plan = plan;
         return false; // decline so nothing mutates
       },

--- a/packages/cli/tests/unit/services/HeadlessConfirmGate.test.ts
+++ b/packages/cli/tests/unit/services/HeadlessConfirmGate.test.ts
@@ -2,10 +2,10 @@
  * Unit tests for HeadlessConfirmGate (RFC 22b50a17 Phase 1b).
  */
 import { describe, it, expect, jest } from "@jest/globals";
-import type { HardSwitchPlan } from "exocortex";
+import type { ApplyPlan } from "exocortex";
 import { HeadlessConfirmGate } from "../../../src/services/HeadlessConfirmGate.js";
 
-function makePlan(overrides: Partial<HardSwitchPlan> = {}): HardSwitchPlan {
+function makePlan(overrides: Partial<ApplyPlan> = {}): ApplyPlan {
   return {
     targetProfileUid: "target-uid",
     targetProfileLabel: "Work",
@@ -28,7 +28,7 @@ describe("HeadlessConfirmGate", () => {
   it("returns true when --yes is passed", async () => {
     const log = jest.fn<(m: string) => void>();
     const gate = new HeadlessConfirmGate({ yes: true, log });
-    const ok = await gate.confirmHardSwitch(makePlan());
+    const ok = await gate.confirmApply(makePlan());
     expect(ok).toBe(true);
     expect(log).not.toHaveBeenCalled();
   });
@@ -36,7 +36,7 @@ describe("HeadlessConfirmGate", () => {
   it("returns false (refuses) by default without --yes", async () => {
     const log = jest.fn<(m: string) => void>();
     const gate = new HeadlessConfirmGate({ yes: false, log });
-    const ok = await gate.confirmHardSwitch(makePlan());
+    const ok = await gate.confirmApply(makePlan());
     expect(ok).toBe(false);
     const lines = log.mock.calls.map((args) => args[0]);
     expect(lines.some((line) => line.includes("Refused"))).toBe(true);
@@ -46,7 +46,7 @@ describe("HeadlessConfirmGate", () => {
   it("emits verbose plan summary to log when verbose=true (regardless of yes)", async () => {
     const log = jest.fn<(m: string) => void>();
     const gate = new HeadlessConfirmGate({ yes: true, verbose: true, log });
-    await gate.confirmHardSwitch(makePlan());
+    await gate.confirmApply(makePlan());
     const joined = log.mock.calls.map((args) => args[0]).join("\n");
     expect(joined).toContain("Target: Work (target-uid)");
     expect(joined).toContain("Source: Personal");
@@ -58,7 +58,7 @@ describe("HeadlessConfirmGate", () => {
   it("verbose mode still refuses without --yes", async () => {
     const log = jest.fn<(m: string) => void>();
     const gate = new HeadlessConfirmGate({ yes: false, verbose: true, log });
-    const ok = await gate.confirmHardSwitch(makePlan());
+    const ok = await gate.confirmApply(makePlan());
     expect(ok).toBe(false);
     const lines = log.mock.calls.map((args) => args[0]);
     expect(lines.some((line) => line.includes("Refused"))).toBe(true);
@@ -68,7 +68,7 @@ describe("HeadlessConfirmGate", () => {
   it("counts files across multiple assetspaces correctly", async () => {
     const log = jest.fn<(m: string) => void>();
     const gate = new HeadlessConfirmGate({ yes: true, verbose: true, log });
-    await gate.confirmHardSwitch(
+    await gate.confirmApply(
       makePlan({
         filesToDestroy: new Map([
           ["as-a", ["a/1.md", "a/2.md", "a/3.md"]],
@@ -83,7 +83,7 @@ describe("HeadlessConfirmGate", () => {
   it("defaults verbose to false (no plan output)", async () => {
     const log = jest.fn<(m: string) => void>();
     const gate = new HeadlessConfirmGate({ yes: true, log });
-    await gate.confirmHardSwitch(makePlan());
+    await gate.confirmApply(makePlan());
     expect(log).not.toHaveBeenCalled();
   });
 });

--- a/packages/exocortex/src/index.ts
+++ b/packages/exocortex/src/index.ts
@@ -537,11 +537,11 @@ export {
   type DaemonResponse,
 } from "./services/ValidatorDaemon";
 
-// Profile hard switch confirmation contract (RFC 22b50a17 Phase 1b)
+// Profile apply confirmation contract (RFC 22b50a17 Phase 1b)
 export type {
   IConfirmGate,
-  HardSwitchPlan,
-} from "./services/focus-profile";
+  ApplyPlan,
+} from "./services/profile";
 export { ClassHierarchy as TripleClassHierarchy } from "./services/ClassHierarchy";
 
 // USTAR-aware tarball parser (honours the ustar `prefix` field that nanotar

--- a/packages/exocortex/src/services/focus-profile/index.ts
+++ b/packages/exocortex/src/services/focus-profile/index.ts
@@ -1,1 +1,0 @@
-export type { IConfirmGate, HardSwitchPlan } from "./IConfirmGate";

--- a/packages/exocortex/src/services/profile/IConfirmGate.ts
+++ b/packages/exocortex/src/services/profile/IConfirmGate.ts
@@ -1,7 +1,7 @@
 /**
- * Confirmation gate for hard switch operations (RFC 22b50a17 Phase 1b).
+ * Confirmation gate for apply operations (RFC 22b50a17 Phase 1b).
  *
- * The hard switch path mutates the vault filesystem (destroys assetspace
+ * The apply path mutates the vault filesystem (destroys assetspace
  * directories not in the target profile's effective set, materializes new
  * ones). Both runtimes must DI a confirmation gate before executing such a
  * destructive operation:
@@ -13,18 +13,18 @@
  *     scripted scenarios (Decision #2 in the source RFC).
  *
  * Phase 1b ships the interface + adapters + a CLI command scaffold; the
- * actual `hardSwitchProfile()` orchestration lands in Phase 3 and consumes
+ * actual `applyProfile()` orchestration lands in Phase 3 and consumes
  * the gate via DI from both runtimes — no further interface change required.
  */
 
 /**
- * Hard switch plan — payload passed to the confirmation gate.
+ * Apply plan — payload passed to the confirmation gate.
  *
  * Aggregates everything a UI surface (modal or stderr summary) needs to
  * describe the impending mutation without re-querying the vault. Maps are
  * `ReadonlyMap` / `ReadonlyArray` so adapters cannot mutate them.
  */
-export interface HardSwitchPlan {
+export interface ApplyPlan {
   /** Target profile UID — the profile the user wants to switch INTO. */
   targetProfileUid: string;
   /** Target profile human label (used in modal title / verbose log). */
@@ -60,7 +60,7 @@ export interface HardSwitchPlan {
 }
 
 /**
- * Contract: caller awaits `confirmHardSwitch(plan)`; the gate either
+ * Contract: caller awaits `confirmApply(plan)`; the gate either
  * resolves `true` (user approved → orchestrator proceeds) or `false` (user
  * declined / Esc / CLI without `--yes` → orchestrator aborts before any
  * filesystem mutation).
@@ -70,5 +70,5 @@ export interface HardSwitchPlan {
  */
 export interface IConfirmGate {
   /** Render plan to the user and await approve/decline. */
-  confirmHardSwitch(plan: HardSwitchPlan): Promise<boolean>;
+  confirmApply(plan: ApplyPlan): Promise<boolean>;
 }

--- a/packages/exocortex/src/services/profile/index.ts
+++ b/packages/exocortex/src/services/profile/index.ts
@@ -1,0 +1,1 @@
+export type { IConfirmGate, ApplyPlan } from "./IConfirmGate";

--- a/packages/obsidian-plugin/src/ExocortexPlugin.ts
+++ b/packages/obsidian-plugin/src/ExocortexPlugin.ts
@@ -2735,16 +2735,16 @@ export default class ExocortexPlugin extends Plugin {
     // the mount-state «Switch knowledge profile» was renamed here). Needs the
     // apply deps wired (filesystem materialisation).
     //
-    // Command id is intentionally kept as the legacy `hard-switch-focus-profile`
-    // so any hotkey a user already bound survives the rename (Obsidian persists
-    // hotkeys by command id). Only the user-facing name changes.
+    // Command id `apply-profile` matches the apply-model (Phase 5 T6). The
+    // previous command id is dropped, so any hotkey bound to
+    // the old id must be re-bound (Obsidian persists hotkeys by command id).
     // Register on desktop (git-binary apply) OR mobile when the REST
     // mount is wired (ProfileApplyManager dispatches to applyProfileViaRest
     // on mobile). Without either, the filesystem materialisation can't run, so
     // the command stays hidden.
     if (applyDeps !== null || (Platform.isMobile && restMount !== null)) {
       this.addCommand({
-        id: "hard-switch-focus-profile",
+        id: "apply-profile",
         name: "Apply profile",
         callback: () => {
           void commandsHandler.invokeApplyProfile();

--- a/packages/obsidian-plugin/src/infrastructure/adapters/ModalConfirmGate.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/ModalConfirmGate.ts
@@ -1,5 +1,5 @@
 import { App, Modal } from "obsidian";
-import type { IConfirmGate, HardSwitchPlan } from "exocortex";
+import type { IConfirmGate, ApplyPlan } from "exocortex";
 
 /**
  * ModalConfirmGate — plugin-side implementation of `IConfirmGate`
@@ -21,7 +21,7 @@ import type { IConfirmGate, HardSwitchPlan } from "exocortex";
 export class ModalConfirmGate implements IConfirmGate {
   constructor(private readonly app: App) {}
 
-  confirmHardSwitch(plan: HardSwitchPlan): Promise<boolean> {
+  confirmApply(plan: ApplyPlan): Promise<boolean> {
     return new Promise<boolean>((resolve) => {
       const modal = new ApplyConfirmModal(this.app, plan, resolve);
       modal.open();
@@ -37,12 +37,12 @@ export const MODAL_FILE_LIST_CAP = 100;
 
 class ApplyConfirmModal extends Modal {
   private resolved = false;
-  private readonly plan: HardSwitchPlan;
+  private readonly plan: ApplyPlan;
   private readonly resolve: (approved: boolean) => void;
 
   constructor(
     app: App,
-    plan: HardSwitchPlan,
+    plan: ApplyPlan,
     resolve: (approved: boolean) => void,
   ) {
     super(app);

--- a/packages/obsidian-plugin/src/infrastructure/adapters/ProfileApplyManager.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/ProfileApplyManager.ts
@@ -1,6 +1,6 @@
 import { Platform } from "obsidian";
 import type { App } from "obsidian";
-import type { HardSwitchPlan, IConfirmGate } from "exocortex";
+import type { ApplyPlan, IConfirmGate } from "exocortex";
 import {
   derivePath,
   assertTsFloor as assertTsFloorGuard,
@@ -443,7 +443,7 @@ export class ProfileApplyManager {
    *   2. R24 TS-floor assert (refuse if target excludes any floor AS).
    *   3. Compute toDestroy / toMaterialize via .gitmodules diff.
    *   4. Vision Lock #5 — abort if uncommitted changes in any to-destroy AS.
-   *   5. Build HardSwitchPlan + confirmGate.confirmHardSwitch(plan) — abort
+   *   5. Build ApplyPlan + confirmGate.confirmApply(plan) — abort
    *      on user-decline.
    *   6. lockMgr.acquireLock + localDataStore.save({_switchInProgress: true}).
    *   7. Phase 1 — for each toMaterialize, pull tarball (or cache restore)
@@ -581,13 +581,13 @@ export class ProfileApplyManager {
       }
     }
 
-    // Build HardSwitchPlan + ConfirmGate.
+    // Build ApplyPlan + ConfirmGate.
     const filesToDestroyMap = new Map<string, string[]>();
     for (const target of toDestroy) {
       const files = await this.enumerateFilesUnder(target.submodulePath);
       filesToDestroyMap.set(target.asUid, files);
     }
-    const plan: HardSwitchPlan = {
+    const plan: ApplyPlan = {
       targetProfileUid,
       targetProfileLabel,
       sourceProfileUid: prevActiveProfileUid,
@@ -603,7 +603,7 @@ export class ProfileApplyManager {
         asLabel: t.label,
       })),
     };
-    const approved = await deps.confirmGate.confirmHardSwitch(plan);
+    const approved = await deps.confirmGate.confirmApply(plan);
     if (!approved) throw new ApplyAbortedByUser();
 
     // No-op early exit: no destroy + no materialize == mount-state already
@@ -966,7 +966,7 @@ export class ProfileApplyManager {
         await this.enumerateFilesUnder(target.submodulePath),
       );
     }
-    const plan: HardSwitchPlan = {
+    const plan: ApplyPlan = {
       targetProfileUid,
       targetProfileLabel,
       sourceProfileUid: prevActiveProfileUid,
@@ -982,7 +982,7 @@ export class ProfileApplyManager {
         asLabel: t.label,
       })),
     };
-    const approved = await confirmGate.confirmHardSwitch(plan);
+    const approved = await confirmGate.confirmApply(plan);
     if (!approved) throw new ApplyAbortedByUser();
 
     // No-op early exit — mount-state already matches the target. Re-index +
@@ -1228,7 +1228,7 @@ export class ProfileApplyManager {
       return { outcome: "no-divergence" };
     }
 
-    // Surface modal — reuse HardSwitchPlan shape so ModalConfirmGate renders.
+    // Surface modal — reuse ApplyPlan shape so ModalConfirmGate renders.
     const reconcilePlan = await this.buildReconcilePlan(
       activeProfileUid,
       missing,
@@ -1236,7 +1236,7 @@ export class ProfileApplyManager {
       allInfos,
     );
     const approved = this.confirmGate !== undefined
-      ? await this.confirmGate.confirmHardSwitch(reconcilePlan)
+      ? await this.confirmGate.confirmApply(reconcilePlan)
       : true; // No gate wired (tests / headless) — proceed.
     if (!approved) return { outcome: "declined" };
     await this.applyProfile(activeProfileUid);
@@ -1244,7 +1244,7 @@ export class ProfileApplyManager {
   }
 
   /**
-   * Build a HardSwitchPlan describing the reconcile operation — vault has
+   * Build a ApplyPlan describing the reconcile operation — vault has
    * extra AS that local profile doesn't include OR missing AS that local
    * profile expects. Used for the confirm modal in `reconcileToLocal`.
    */
@@ -1253,7 +1253,7 @@ export class ProfileApplyManager {
     missing: ReadonlyArray<string>,
     extra: ReadonlyArray<string>,
     allInfos: ReadonlyArray<AssetSpaceInfo>,
-  ): Promise<HardSwitchPlan> {
+  ): Promise<ApplyPlan> {
     const targetLabel = await this.profileLabel(activeProfileUid);
     const infoByUid = new Map<string, AssetSpaceInfo>();
     for (const i of allInfos) infoByUid.set(i.uid, i);

--- a/packages/obsidian-plugin/src/presentation/settings/ExocortexSettingTab.ts
+++ b/packages/obsidian-plugin/src/presentation/settings/ExocortexSettingTab.ts
@@ -578,49 +578,41 @@ export class ExocortexSettingTab extends PluginSettingTab {
     const switchCache = new SwitchCacheLayer();
     const operationsLog = new OperationsLogReader({ app });
 
-    // ─────── Section 0 — Knowledge vs Focus overview (RFC 13da049f R35) ───────
-    // R35: users were confused about «which profile do I edit?». The two
-    // profile types are independent slots with different mechanisms; this
-    // overview block names them up-front so the sections below read clearly.
-    new Setting(containerEl).setName("Knowledge and focus profiles").setHeading();
+    // ─────── Section 0 — Profile overview (Phase 5 apply-model) ───────
+    // A profile is a named group of AssetSpaces. Applying it makes the vault's
+    // on-disk mount-state match the profile (materialize what it includes,
+    // tear down the rest), so users edit ONE thing — the profile's AssetSpace
+    // list — and run ONE operation, «Apply profile».
+    new Setting(containerEl).setName("Profiles").setHeading();
 
     const profilesOverviewEl = containerEl.createDiv({
       cls: "setting-item-description",
     });
     profilesOverviewEl.createEl("p", {
       text:
-        "Two independent profile types control what you see. They are " +
-        "separate slots — a Knowledge profile and a Focus profile can be " +
-        "active at the same time, and switching one never touches the other.",
+        "A profile (an exo__Profile asset) is a named group of AssetSpaces. " +
+        "Applying a profile makes the vault's on-disk mount-state match it: " +
+        "the AssetSpaces it includes are materialized, everything else " +
+        "(except the always-on floor) is torn down — a strict replace.",
     });
-    const profilesOverviewList = profilesOverviewEl.createEl("ul");
-    const knowledgeLi = profilesOverviewList.createEl("li");
-    knowledgeLi.createEl("strong", { text: "Knowledge profile — storage." });
-    knowledgeLi.appendText(
-      " A hard switch that physically materializes or tears down AssetSpace " +
-        "submodules on disk (and rewrites .gitmodules). Heavyweight: a " +
-        "confirmation gate, an uncommitted-changes guard, and ~30 s per " +
-        "freshly-pulled AssetSpace. Pick a Profile asset via the " +
-        "«Exocortex: Switch knowledge profile (filesystem destroy + " +
-        "materialize)» command (Cmd+P). Use it to " +
+    const applyLi = profilesOverviewEl.createEl("ul").createEl("li");
+    applyLi.createEl("strong", { text: "Apply profile." });
+    applyLi.appendText(
+      " Pick a Profile asset via the «Exocortex: Apply profile» command " +
+        "(Cmd+P). It physically materializes or tears down AssetSpace " +
+        "submodules on disk (and rewrites .gitmodules), so it is gated by a " +
+        "confirmation prompt and an uncommitted-changes guard, and costs " +
+        "~30 s per freshly-pulled AssetSpace. The floor AssetSpaces " +
+        "(exo, exocmd, shared-identities) are never torn down. Use it to " +
         "install or remove whole ontology bundles and to keep " +
         "privacy-sensitive content physically off the device.",
-    );
-    const focusLi = profilesOverviewList.createEl("li");
-    focusLi.createEl("strong", { text: "Focus profile — filter." });
-    focusLi.appendText(
-      " A soft switch that applies a query-time RDF filter; nothing changes " +
-        "on disk. Lightweight: ~1–2 s reindex, instantly reversible. Pick a " +
-        "Profile asset via the dropdown below or the «Exocortex: Switch " +
-        "focus profile» command. Use it to narrow search / SPARQL / graph " +
-        "view to the slice you are working in right now.",
     );
     profilesOverviewEl.createEl("p", {
       text:
         "Adding an ontology to a profile is NOT transitive — listing pmbok " +
         "does not auto-add ems. Add each AssetSpace the profile needs " +
-        "explicitly. See docs/profile.md for the full distinction, " +
-        "examples, and composition rules.",
+        "explicitly. See docs/profile.md for the full model, examples, and " +
+        "composition rules.",
     });
 
     // ─────── Section 1 — PAT (GitHub Personal Access Token) ───────
@@ -718,7 +710,7 @@ export class ExocortexSettingTab extends PluginSettingTab {
     // RFC 0a0791c1 Phase 5 T2 — single last-applied slot. Switching is the
     // «Exocortex: Apply profile» Cmd+P command (mount-state strict replace,
     // gated behind a confirmation prompt because it mutates the filesystem);
-    // the former soft-switch dropdown was removed with the soft RDF filter.
+    // the former soft-filter dropdown was removed with the query-time RDF filter.
     const activeProfileUid = this.plugin.localDataStore
       ? this.plugin.localDataStore.getActiveProfileUid()
       : null;

--- a/packages/obsidian-plugin/tests/e2e/specs/focus-profile-picker.spec.ts
+++ b/packages/obsidian-plugin/tests/e2e/specs/focus-profile-picker.spec.ts
@@ -6,18 +6,18 @@ import * as path from "path";
 
 /**
  * E2E render smoke for the «Exocortex: Apply profile» command
- * (`hard-switch-focus-profile`, wired in
+ * (`apply-profile`, wired in
  * `ExocortexPlugin.registerProfileCommands`).
  *
  * RFC 0a0791c1 Phase 5 T2 consolidated the former soft «Switch focus profile»
  * (`switch-focus-profile`) + mount-state «Switch knowledge profile» commands
  * into the single «Apply profile» command. The command id is kept as the legacy
- * `hard-switch-focus-profile` (Obsidian persists hotkeys by id). This spec
+ * `apply-profile` (Obsidian persists hotkeys by id). This spec
  * exercises the picker render only (Escape without selecting), so the
  * destructive mount path never runs. Tracking issue #3434.
  *
  * What this asserts (deliberately NON-vacuous — see below):
- *   1. The plugin loads and the `hard-switch-focus-profile` command is registered.
+ *   1. The plugin loads and the `apply-profile` command is registered.
  *   2. Executing the command opens the `ProfileFuzzyModal`
  *      (`FuzzySuggestModal`) and renders the **fixture profile assets by
  *      label** — i.e. NOT the «No profiles found in vault» empty state.
@@ -26,7 +26,7 @@ import * as path from "path";
  *      focus-profile surface this spec owns). The load-phase `console.error`
  *      count is logged as a diagnostic (observed 0 in local Docker) but NOT
  *      hard-asserted — it would otherwise couple this spec to unrelated
- *      load-path catch branches (e.g. hard-switch / SHACL wiring), per
+ *      load-path catch branches (e.g. apply / SHACL wiring), per
  *      code-reviewer MEDIUM. `create-fleeting-note-palette.spec.ts` omits the
  *      console check entirely for the same reason; here it is kept but scoped.
  *
@@ -56,7 +56,7 @@ import * as path from "path";
  */
 
 const PROFILE_CLASS_UID = "3de846cd-1f0e-4f98-8613-b8587aa15174";
-const APPLY_PROFILE_COMMAND_ID = "exocortex:hard-switch-focus-profile";
+const APPLY_PROFILE_COMMAND_ID = "exocortex:apply-profile";
 const FIXTURE_LABELS = [
   "E2E Focus Profile Base",
   "E2E Focus Profile Work",
@@ -213,7 +213,7 @@ test.describe("Focus profile picker — render smoke", () => {
     expect(placeholder).toBe("Apply profile");
 
     // Zero console errors during the picker surface (trigger → modal open) —
-    // scoped so unrelated load-path catch branches (hard-switch / SHACL wiring)
+    // scoped so unrelated load-path catch branches (apply / SHACL wiring)
     // cannot red this spec (code-reviewer MEDIUM).
     const pickerConsoleErrors = consoleErrors.slice(loadPhaseConsoleErrors);
     expect(
@@ -234,7 +234,7 @@ test.describe("Focus profile picker — render smoke", () => {
       `[focus-profile-picker smoke] loadPhaseConsoleErrors=${loadPhaseConsoleErrors} items=${JSON.stringify(itemTexts)}`,
     );
 
-    // Render-only smoke — dismiss without selecting (no soft switch → no
+    // Render-only smoke — dismiss without selecting (no soft-filter → no
     // test-vault mutation, keeps the fixture-drift reporter quiet).
     await window.keyboard.press("Escape");
     await window

--- a/packages/obsidian-plugin/tests/unit/ExocortexSettingTab.focusProfile.test.ts
+++ b/packages/obsidian-plugin/tests/unit/ExocortexSettingTab.focusProfile.test.ts
@@ -5,7 +5,7 @@
  * each section's Setting builder is invoked с the expected name / heading
  * sequence: PAT → Active profile → Switch cache → Operations log.
  *
- * RFC 0a0791c1 Phase 5 T2 — the soft-switch dropdown was removed; profile
+ * RFC 0a0791c1 Phase 5 T2 — the soft-filter dropdown was removed; profile
  * switching is the «Exocortex: Apply profile» Cmd+P command. Section 2 now
  * surfaces the single last-applied profile (read-only status + hint).
  *
@@ -269,10 +269,10 @@ describe("ExocortexSettingTab — Issue #3320 Profile sections", () => {
     expect(profileRow).toBeDefined();
   });
 
-  it("renders the Knowledge and focus profiles overview heading (RFC 13da049f R35)", () => {
+  it("renders the Profiles overview heading (RFC 13da049f R35)", () => {
     settingTab.display();
     const overview = settingCalls.find(
-      (c) => c.name === "Knowledge and focus profiles" && c.heading,
+      (c) => c.name === "Profiles" && c.heading,
     );
     expect(overview).toBeDefined();
   });

--- a/packages/obsidian-plugin/tests/unit/ExocortexSettingTab.test.ts
+++ b/packages/obsidian-plugin/tests/unit/ExocortexSettingTab.test.ts
@@ -158,7 +158,7 @@ describe("ExocortexSettingTab", () => {
       // Log channels section: 1 heading + 4 log level rows = 5
       // Excluded folders section (#3278): 1 heading + 1 textarea row = +2 → 32
       // Issue #3320 — Profile sections: 4 section headings + PAT row + Switch profile row + Cache stats row + (Operations log has no Setting row, body уходит в createDiv/createEl) = +7 → 39
-      // RFC 13da049f R35 — added "Knowledge and focus profiles" overview heading (+1) → 40
+      // RFC 13da049f R35 — added "Profiles" overview heading (+1) → 40
       expect(MockSetting).toHaveBeenCalledTimes(40);
     });
 

--- a/packages/obsidian-plugin/tests/unit/ModalConfirmGate.test.ts
+++ b/packages/obsidian-plugin/tests/unit/ModalConfirmGate.test.ts
@@ -48,7 +48,7 @@ jest.mock("obsidian", () => {
 });
 
 import type { App } from "obsidian";
-import type { HardSwitchPlan } from "exocortex";
+import type { ApplyPlan } from "exocortex";
 import {
   ModalConfirmGate,
   MODAL_FILE_LIST_CAP,
@@ -56,7 +56,7 @@ import {
 
 const fakeApp = {} as unknown as App;
 
-function makePlan(overrides: Partial<HardSwitchPlan> = {}): HardSwitchPlan {
+function makePlan(overrides: Partial<ApplyPlan> = {}): ApplyPlan {
   return {
     targetProfileUid: "target-uid",
     targetProfileLabel: "Work",
@@ -88,7 +88,7 @@ describe("ModalConfirmGate", () => {
 
   it("resolves true when «Apply» button is clicked", async () => {
     const gate = new ModalConfirmGate(fakeApp);
-    const promise = gate.confirmHardSwitch(makePlan());
+    const promise = gate.confirmApply(makePlan());
 
     const confirmBtn = findButton("Apply");
     expect(confirmBtn).toBeDefined();
@@ -100,7 +100,7 @@ describe("ModalConfirmGate", () => {
 
   it("resolves false when «Cancel» button is clicked", async () => {
     const gate = new ModalConfirmGate(fakeApp);
-    const promise = gate.confirmHardSwitch(makePlan());
+    const promise = gate.confirmApply(makePlan());
 
     const cancelBtn = findButton("Cancel");
     expect(cancelBtn).toBeDefined();
@@ -111,7 +111,7 @@ describe("ModalConfirmGate", () => {
 
   it("renders torn-down AS list with file counts", async () => {
     const gate = new ModalConfirmGate(fakeApp);
-    const promise = gate.confirmHardSwitch(makePlan());
+    const promise = gate.confirmApply(makePlan());
 
     const tearSection = document.querySelector(".apply-confirm-tear-section");
     expect(tearSection).not.toBeNull();
@@ -124,7 +124,7 @@ describe("ModalConfirmGate", () => {
 
   it("renders materialize AS list", async () => {
     const gate = new ModalConfirmGate(fakeApp);
-    const promise = gate.confirmHardSwitch(makePlan());
+    const promise = gate.confirmApply(makePlan());
 
     const matSection = document.querySelector(".apply-confirm-mat-section");
     expect(matSection).not.toBeNull();
@@ -136,7 +136,7 @@ describe("ModalConfirmGate", () => {
 
   it("renders title with target profile label", async () => {
     const gate = new ModalConfirmGate(fakeApp);
-    const promise = gate.confirmHardSwitch(makePlan());
+    const promise = gate.confirmApply(makePlan());
 
     const title = document.querySelector(".apply-confirm-title");
     expect(title).not.toBeNull();
@@ -152,7 +152,7 @@ describe("ModalConfirmGate", () => {
       huge.push(`assetspaces/big/file-${i}.md`);
     }
     const gate = new ModalConfirmGate(fakeApp);
-    const promise = gate.confirmHardSwitch(
+    const promise = gate.confirmApply(
       makePlan({ filesToDestroy: new Map([["as-big", huge]]) }),
     );
 
@@ -169,7 +169,7 @@ describe("ModalConfirmGate", () => {
 
   it("renders «(none)» placeholders when sections are empty", async () => {
     const gate = new ModalConfirmGate(fakeApp);
-    const promise = gate.confirmHardSwitch(
+    const promise = gate.confirmApply(
       makePlan({
         filesToDestroy: new Map(),
         assetSpacesBeingTornDown: [],
@@ -187,7 +187,7 @@ describe("ModalConfirmGate", () => {
 
   it("settles exactly once when confirm is clicked twice", async () => {
     const gate = new ModalConfirmGate(fakeApp);
-    const promise = gate.confirmHardSwitch(makePlan());
+    const promise = gate.confirmApply(makePlan());
 
     const confirmBtn = findButton("Apply")!;
     confirmBtn.click();
@@ -202,7 +202,7 @@ describe("ModalConfirmGate", () => {
     const gate = new ModalConfirmGate(fakeApp);
     // Capture promise but force close before any button click. The Modal
     // mock's close() calls onClose() which our impl uses to settle(false).
-    const promise = gate.confirmHardSwitch(makePlan());
+    const promise = gate.confirmApply(makePlan());
     // We can't access the modal instance directly; simulate Esc by
     // dispatching a synthetic close — finding the modal via DOM:
     const contentEl = document.body.firstElementChild as HTMLElement | null;

--- a/packages/obsidian-plugin/tests/unit/ProfileApplyManager.apply.test.ts
+++ b/packages/obsidian-plugin/tests/unit/ProfileApplyManager.apply.test.ts
@@ -19,7 +19,7 @@
  * executed (no false positives).
  */
 import type { App, TFile } from "obsidian";
-import type { HardSwitchPlan, IConfirmGate } from "exocortex";
+import type { ApplyPlan, IConfirmGate } from "exocortex";
 
 import {
   ProfileApplyManager,
@@ -268,8 +268,8 @@ class FakeAssetSpaceManager {
 
 class FakeConfirmGate implements IConfirmGate {
   approve = true;
-  lastPlan: HardSwitchPlan | null = null;
-  async confirmHardSwitch(plan: HardSwitchPlan): Promise<boolean> {
+  lastPlan: ApplyPlan | null = null;
+  async confirmApply(plan: ApplyPlan): Promise<boolean> {
     this.lastPlan = plan;
     return this.approve;
   }

--- a/packages/obsidian-plugin/tests/unit/ProfileApplyManager.restApply.test.ts
+++ b/packages/obsidian-plugin/tests/unit/ProfileApplyManager.restApply.test.ts
@@ -24,7 +24,7 @@
  */
 import { Platform } from "obsidian";
 import type { App, TFile } from "obsidian";
-import type { HardSwitchPlan, IConfirmGate } from "exocortex";
+import type { ApplyPlan, IConfirmGate } from "exocortex";
 
 import {
   ProfileApplyManager,
@@ -149,8 +149,8 @@ class FakeLocalDataStore {
 
 class FakeConfirmGate implements IConfirmGate {
   approve = true;
-  lastPlan: HardSwitchPlan | null = null;
-  async confirmHardSwitch(plan: HardSwitchPlan): Promise<boolean> {
+  lastPlan: ApplyPlan | null = null;
+  async confirmApply(plan: ApplyPlan): Promise<boolean> {
     this.lastPlan = plan;
     return this.approve;
   }

--- a/packages/obsidian-plugin/tests/unit/integration/ApplyEndToEnd.integration.test.ts
+++ b/packages/obsidian-plugin/tests/unit/integration/ApplyEndToEnd.integration.test.ts
@@ -31,7 +31,7 @@ import * as os from "node:os";
 /* eslint-enable no-restricted-imports, import/no-nodejs-modules */
 
 import type { App, TFile } from "obsidian";
-import type { HardSwitchPlan, IConfirmGate } from "exocortex";
+import type { ApplyPlan, IConfirmGate } from "exocortex";
 
 import {
   ProfileApplyManager,
@@ -330,7 +330,7 @@ class FakeLocalDataStore {
 }
 
 class AlwaysApproveGate implements IConfirmGate {
-  async confirmHardSwitch(_plan: HardSwitchPlan): Promise<boolean> {
+  async confirmApply(_plan: ApplyPlan): Promise<boolean> {
     return true;
   }
 }


### PR DESCRIPTION
## Summary

Phase 5 apply-model convergence — **T6 PR3 of 3 (final)**. Brings the program gate **«dual-switch code refs = 0»** to 0. Mechanical rename + Settings UI text; **zero behavior change**. Builds on PR1 (#3445) + PR2 (#3446), both merged.

**Core contract (`exocortex`):**
- `HardSwitchPlan`→`ApplyPlan`, `IConfirmGate.confirmHardSwitch`→`confirmApply` — interface + both impls (`HeadlessConfirmGate`, `ModalConfirmGate`) + all callers (CLI `apply-profile`, plugin `ProfileApplyManager`).
- Dir `services/focus-profile/`→`services/profile/` (only deep-importer is the package barrel).

**Plugin command id:**
- `hard-switch-focus-profile`→**`apply-profile`** (user-facing name was already «Apply profile»). ⚠️ **BREAKING for hotkeys**: a binding to the old id must be re-bound — Obsidian persists hotkeys by command id (single user, acceptable). e2e command-id constant updated.

**Settings UI (`ExocortexSettingTab`):**
- Section 0 rewritten from the dual «Knowledge profile (hard switch) / Focus profile (soft switch)» model to the **unified apply-model**: a profile is a named group of AssetSpaces; one «Apply profile» operation = mount-state strict replace; floor AssetSpaces never torn down; adding an ontology is not transitive. Heading «Knowledge and focus profiles»→«Profiles». Settings tests updated.

### Gate result
```
git grep -ilE "hard.?switch|soft.?switch|HardSwitch|softSwitch|restSwitch|FocusProfile|KnowledgeProfile" -- 'packages/**/src/**'  →  0
```

### Out of scope (intentional)
`ProfileFuzzyModal`'s "Switch focus profile" placeholder is **not** gate-flagged (no hard/soft/rest-switch token) and not part of the DOD — left untouched to avoid scope creep.

## Test plan
- [x] `npm run check:types` green; `npm run lint` clean (2 pre-existing warnings).
- [x] **src gate = 0** (output above).
- [x] Affected suites: 86 plugin + 25 CLI + 19 settings + 5 integration pass.
- [x] Pre-commit archgate 16/16; lint-staged + related tests green.
- [ ] CI 14 checks green (incl. e2e `apply-profile` command-id registration).