### PR TITLE
feat(profile): reconciliation counts + no-op feedback in apply notices (#3448)

### DIFF
--- a/packages/obsidian-plugin/src/infrastructure/adapters/ProfileApplyManager.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/ProfileApplyManager.ts
@@ -310,7 +310,10 @@ export class ProfileApplyManager {
    * soft RDF filter was removed); this method indexes whatever AssetSpace
    * folders are currently on disk.
    */
-  private async reindexMountState(targetProfileUid: string): Promise<void> {
+  private async reindexMountState(
+    targetProfileUid: string,
+    noticeOverride?: string,
+  ): Promise<void> {
     const acquired = await this.lockMgr.acquireLock(`switch-profile-${targetProfileUid}`);
     if (!acquired) {
       throw new Error(`Another switch is in progress (lock held). Try again shortly.`);
@@ -353,8 +356,12 @@ export class ProfileApplyManager {
         elapsedMs,
       });
 
-      const profileLabel = await this.profileLabel(targetProfileUid);
-      this.notify(`Applied ${profileLabel} (${elapsedMs}ms)`);
+      if (noticeOverride !== undefined) {
+        this.notify(noticeOverride);
+      } else {
+        const profileLabel = await this.profileLabel(targetProfileUid);
+        this.notify(`Applied ${profileLabel} (${elapsedMs}ms)`);
+      }
     } catch (e) {
       await this.appendJournal({
         phase: "failed",
@@ -367,6 +374,18 @@ export class ProfileApplyManager {
       if (heartbeatTimer !== null) clearInterval(heartbeatTimer);
       await this.lockMgr.releaseLock();
     }
+  }
+
+  /**
+   * Builds the user-facing notice for the no-op (empty-diff) apply branch.
+   * Distinguishes a genuine «already matches» no-op from the case where the
+   * vault layout yields 0 recognized mounted AssetSpaces (a likely
+   * derivePath/layout mismatch where the strict-replace had nothing to act on).
+   */
+  private noChangeNotice(profileLabel: string, recognizedCount: number): string {
+    return recognizedCount === 0
+      ? `Apply "${profileLabel}": no changes — 0 AssetSpaces recognized as mounted (check vault layout).`
+      : `Applied "${profileLabel}": no changes (${recognizedCount} AssetSpace(s) already match).`;
   }
 
   /**
@@ -616,7 +635,10 @@ export class ProfileApplyManager {
         targetUid: targetProfileUid,
         ts: new Date(startedAt).toISOString(),
       });
-      await this.reindexMountState(targetProfileUid);
+      await this.reindexMountState(
+        targetProfileUid,
+        this.noChangeNotice(targetProfileLabel, currentAsUids.size),
+      );
       await this.appendJournal({
         phase: "apply-completed",
         targetUid: targetProfileUid,
@@ -814,7 +836,9 @@ export class ProfileApplyManager {
         ts: this.now().toISOString(),
         elapsedMs,
       });
-      this.notify(`Applied к ${targetProfileLabel} (${elapsedMs}ms)`);
+      this.notify(
+        `Applied "${targetProfileLabel}": ${toMaterialize.length} mounted, ${toDestroy.length} unmounted (${elapsedMs}ms).`,
+      );
     } catch (e) {
       // Rollback attempt: best-effort cache restore previously-destroyed AS.
       // This is partial — anything that was already added via `submodule add`
@@ -988,7 +1012,10 @@ export class ProfileApplyManager {
     // No-op early exit — mount-state already matches the target. Re-index +
     // record the selection (reindex-only path).
     if (toDestroy.length === 0 && toMaterialize.length === 0) {
-      await this.reindexMountState(targetProfileUid);
+      await this.reindexMountState(
+        targetProfileUid,
+        this.noChangeNotice(targetProfileLabel, currentAsUids.size),
+      );
       return;
     }
 
@@ -1049,7 +1076,9 @@ export class ProfileApplyManager {
         ts: this.now().toISOString(),
         elapsedMs,
       });
-      this.notify(`Switched to ${targetProfileLabel} (${elapsedMs}ms, REST mount)`);
+      this.notify(
+        `Applied "${targetProfileLabel}": ${toMaterialize.length} mounted, ${toDestroy.length} unmounted (${elapsedMs}ms, REST).`,
+      );
     } catch (e) {
       await this.appendJournal({
         phase: "apply-failed",

--- a/packages/obsidian-plugin/tests/unit/ProfileApplyManager.restApply.test.ts
+++ b/packages/obsidian-plugin/tests/unit/ProfileApplyManager.restApply.test.ts
@@ -272,6 +272,7 @@ function setup(opts: SetupOpts) {
   const restMount = new FakeRestMount();
   const factoryMount = new FakeRestMount();
   const gitOps = new FakeGitOps();
+  const notifyCalls: string[] = [];
 
   const mgr = new ProfileApplyManager({
     app,
@@ -279,6 +280,7 @@ function setup(opts: SetupOpts) {
     resolver,
     rdfIndexer: indexer,
     settingsStore,
+    notify: (m) => notifyCalls.push(m),
     /* eslint-disable @typescript-eslint/no-explicit-any */
     confirmGate,
     localDataStore: localDataStore as any,
@@ -297,6 +299,7 @@ function setup(opts: SetupOpts) {
     restMount,
     factoryMount,
     gitOps,
+    notifyCalls,
   };
 }
 
@@ -351,6 +354,34 @@ describe("ProfileApplyManager.applyProfileViaRest", () => {
     // No mount-state mutation, but the reindex-only fall-through still triggers
     // a single full-vault reindex.
     expect(indexer.refreshCalls).toBe(1);
+  });
+
+  it("notifies reconciliation counts on a real apply (#3448)", async () => {
+    // ems mounted (1), kpc unmounted (1).
+    const { mgr, notifyCalls } = setup({
+      targetIncludes: [...ALL_FLOOR_UIDS, "ems-uid"],
+      materialized: [...ALL_FLOOR_UIDS, "kpc-uid"],
+    });
+
+    await mgr.applyProfileViaRest("target");
+
+    expect(notifyCalls.length).toBe(1);
+    expect(notifyCalls[0]).toContain("1 mounted");
+    expect(notifyCalls[0]).toContain("1 unmounted");
+    expect(notifyCalls[0]).toContain("REST");
+  });
+
+  it("notifies a distinct no-change message on the no-op path (#3448)", async () => {
+    const { mgr, notifyCalls } = setup({
+      targetIncludes: ALL_FLOOR_UIDS,
+      materialized: ALL_FLOOR_UIDS,
+    });
+
+    await mgr.applyProfileViaRest("target");
+
+    expect(notifyCalls.length).toBe(1);
+    expect(notifyCalls[0]).toContain("no changes");
+    expect(notifyCalls[0]).toMatch(/\d+ AssetSpace\(s\) already match/);
   });
 
   it("throws TsFloorViolationError before any mount/unmount when target excludes a floor AS", async () => {

--- a/packages/obsidian-plugin/tests/unit/ProfileApplyManager.test.ts
+++ b/packages/obsidian-plugin/tests/unit/ProfileApplyManager.test.ts
@@ -366,6 +366,22 @@ describe("ProfileApplyManager.reindexMountState — happy path (apply reindex)",
     expect(h.notifyCalls[0]).toMatch(/\d+ms/);
   });
 
+  it("uses noticeOverride verbatim when provided (no-op apply branch — #3448)", async () => {
+    const h = makeHarness({
+      profiles: [
+        [UID_BASE, { uid: UID_BASE, includes: [], extends: null, label: "profile-base" }],
+      ],
+    });
+    const override = 'Applied "profile-base": no changes (3 AssetSpace(s) already match).';
+    await (
+      h.mgr as unknown as {
+        reindexMountState(uid: string, noticeOverride?: string): Promise<void>;
+      }
+    ).reindexMountState(UID_BASE, override);
+    expect(h.notifyCalls.length).toBe(1);
+    expect(h.notifyCalls[0]).toBe(override);
+  });
+
   it("invokes rdf.refresh once on reindex (RFC 01a83de8 — soft-filter removed)", async () => {
     const h = makeHarness({
       profiles: [


### PR DESCRIPTION
## Summary
- Apply notices now report reconciliation counts: `Applied "<profile>": N mounted, M unmounted (…ms[, REST])` (both desktop git + REST/mobile paths).
- The no-op (empty-diff) branch now emits a **distinct** message instead of the same generic `Applied <profile> (Nms)`:
  - `Applied "<profile>": no changes (K AssetSpace(s) already match)` when the mount-state genuinely matches;
  - `Apply "<profile>": no changes — 0 AssetSpaces recognized as mounted (check vault layout)` when 0 AssetSpaces are recognized (a likely derivePath/layout mismatch).
- `reindexMountState` gains an optional `noticeOverride` so the no-op branches pass a tailored message while crash-recovery + direct callers keep the default.

## ⚠️ Issue premise corrected (verify-before-assert)
#3448 originally claimed `applyProfile` "silently no-ops … returns WITHOUT any user-facing Notice". Source reading disproved this: the no-op early-exit calls `reindexMountState`, which **already** emits `this.notify("Applied <profile> (Nms)")` (`ProfileApplyManager.ts:357`), and `notify` is wired in production (`ExocortexPlugin.ts:2563`). The real, verifiable gaps were (1) notices lacked reconciliation counts and (2) the no-op was indistinguishable from a real apply. The issue body has been updated accordingly; scope narrowed to these two improvements (no speculative "silent no-op" fix).

## Test plan
- [x] `ProfileApplyManager.test.ts` — new test: `reindexMountState` uses `noticeOverride` verbatim; existing default-notice test still green.
- [x] `ProfileApplyManager.restApply.test.ts` — new tests: real apply notice contains `1 mounted` / `1 unmounted` / `REST`; no-op notice contains `no changes` + `N AssetSpace(s) already match`. Harness now captures `notify`.
- [x] `npm run check:types` clean.
- [x] `npm run lint` — 0 errors (2 pre-existing warnings in unrelated files).
- [x] Affected suites: 32 passed.

Closes #3448