### PR TITLE
feat(bootstrap): plugin bootstrap core-only — exocmd optional (RFC 5aa2a73a B3)

### DIFF
--- a/packages/obsidian-plugin/src/infrastructure/adapters/BootstrapAssetSpaceCommands.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/BootstrapAssetSpaceCommands.ts
@@ -198,9 +198,13 @@ export class BootstrapAssetSpaceCommands {
     const urls = await this.d.promptBootstrapUrls();
     if (urls === null) return; // user cancelled
 
+    // Core-only (RFC 5aa2a73a B3 / alt-G #3426): exo is the SDK floor; exocmd is
+    // an OPTIONAL UI-command library. An empty exocmd URL yields a knowledge-only
+    // vault and must be accepted as a first-class configuration.
+    const wantExocmd = urls.exocmdUrl.trim().length > 0;
     try {
       this.d.validateUrl(urls.exoUrl);
-      this.d.validateUrl(urls.exocmdUrl);
+      if (wantExocmd) this.d.validateUrl(urls.exocmdUrl);
     } catch (e) {
       this.d.notify(`Bootstrap: invalid URL — ${this.msg(e)}`);
       return;
@@ -221,15 +225,22 @@ export class BootstrapAssetSpaceCommands {
     let exo: MaterializeResult | null = null;
     try {
       exo = await this.materialize(urls.exoUrl, TS_FLOOR_EXO_PATH, isGit);
-      const exocmd = await this.materialize(
-        urls.exocmdUrl,
-        TS_FLOOR_EXOCMD_PATH,
-        isGit,
-      );
-      this.d.notify(
-        `Bootstrap complete — ${exo.folderName}@${exo.sha} + ${exocmd.folderName}@${exocmd.sha}. ` +
-          "Reload Obsidian if the new assets do not appear. Add any further AssetSpaces manually — dependencies are not auto-resolved.",
-      );
+      if (wantExocmd) {
+        const exocmd = await this.materialize(
+          urls.exocmdUrl,
+          TS_FLOOR_EXOCMD_PATH,
+          isGit,
+        );
+        this.d.notify(
+          `Bootstrap complete — ${exo.folderName}@${exo.sha} + ${exocmd.folderName}@${exocmd.sha}. ` +
+            "Reload Obsidian if the new assets do not appear. Add any further AssetSpaces manually — dependencies are not auto-resolved.",
+        );
+      } else {
+        this.d.notify(
+          `Bootstrap complete — ${exo.folderName}@${exo.sha} (knowledge-only, no exocmd). ` +
+            "Reload Obsidian if the new assets do not appear. Add exocmd or any further AssetSpaces later via «Add assetspace by URL».",
+        );
+      }
     } catch (e) {
       if (exo !== null) {
         this.d.notify(

--- a/packages/obsidian-plugin/src/presentation/modals/BootstrapVaultModal.ts
+++ b/packages/obsidian-plugin/src/presentation/modals/BootstrapVaultModal.ts
@@ -9,8 +9,10 @@ export interface BootstrapVaultUrls {
  * BootstrapVaultModal — input gate for the `Exocortex: Bootstrap vault` palette
  * command (RFC 13da049f Phase 6.2).
  *
- * Collects the two TS-floor AssetSpace URLs (exo + exocmd) needed to cold-start
- * an empty vault.
+ * Collects the exo TS-floor AssetSpace URL (required) and, optionally, the
+ * exocmd UI-command library URL needed to cold-start an empty vault. exocmd is
+ * optional (RFC 5aa2a73a B3 / alt-G #3426): leaving it blank yields a
+ * knowledge-only / SPARQL-only vault.
  *
  * ## UX decisions
  *
@@ -21,9 +23,10 @@ export interface BootstrapVaultUrls {
  *   further required AssetSpaces manually; dependencies are not resolved
  *   automatically.
  *
- * Resolves `{ exoUrl, exocmdUrl }` only when the user clicks «Bootstrap» with
- * both fields populated with a plausible GitHub URL. Esc / Cancel / any close
- * path resolves `null`. The promise resolves exactly once.
+ * Resolves `{ exoUrl, exocmdUrl }` when the user clicks «Bootstrap» with a
+ * plausible exo URL (exocmd may be left blank → resolves `exocmdUrl: ""`).
+ * Esc / Cancel / any close path resolves `null`. The promise resolves exactly
+ * once.
  *
  * Authoritative URL validation (allowlist, traversal) happens downstream in
  * `BootstrapAssetSpaceCommands` / `GitHubRestClient.validateRepoURL`; this modal

--- a/packages/obsidian-plugin/src/presentation/modals/BootstrapVaultModal.ts
+++ b/packages/obsidian-plugin/src/presentation/modals/BootstrapVaultModal.ts
@@ -56,18 +56,20 @@ export class BootstrapVaultModal extends Modal {
     });
     contentEl.createEl("p", {
       text:
-        "Cold-start this empty vault with the two foundational AssetSpaces " +
-        "(exo + exocmd). Each is pulled from a public GitHub repository.",
+        "Cold-start this empty vault with the foundational exo AssetSpace " +
+        "(the SDK/engine floor), pulled from a public GitHub repository. " +
+        "exocmd (the optional UI-command library) can be added too, or left " +
+        "blank for a knowledge-only / SPARQL-only vault.",
     });
 
     this.exoInput = this.createUrlField(
       contentEl,
-      "exo ontology URL",
+      "exo ontology URL (required)",
       "https://github.com/kitelev/exoas-exo",
     );
     this.exocmdInput = this.createUrlField(
       contentEl,
-      "exocmd ontology URL",
+      "exocmd ontology URL (optional)",
       "https://github.com/kitelev/exoas-exocmd",
     );
 
@@ -140,18 +142,26 @@ export class BootstrapVaultModal extends Modal {
 }
 
 /**
- * Light shape check for the two bootstrap URLs. Returns a human-readable problem
- * string, or null when both look plausible. Authoritative validation is
+ * Light shape check for the bootstrap URLs. Returns a human-readable problem
+ * string, or null when the inputs look plausible. Authoritative validation is
  * downstream.
+ *
+ * Core-only (RFC 5aa2a73a B3 / alt-G rejection #3426): only the exo URL is
+ * required. exocmd is the optional UI-command library — an empty exocmd field
+ * yields a knowledge-only / SPARQL-only vault and is a first-class config. When
+ * exocmd IS provided it must still be a plausible GitHub URL.
  */
-function firstUrlProblem(exoUrl: string, exocmdUrl: string): string | null {
-  if (exoUrl.length === 0 || exocmdUrl.length === 0) {
-    return "Both the exo and exocmd URLs are required.";
+export function firstUrlProblem(
+  exoUrl: string,
+  exocmdUrl: string,
+): string | null {
+  if (exoUrl.length === 0) {
+    return "The exo URL is required.";
   }
   if (!isLikelyGitHubUrl(exoUrl)) {
     return "exo URL must look like https://github.com/<owner>/<repo>.";
   }
-  if (!isLikelyGitHubUrl(exocmdUrl)) {
+  if (exocmdUrl.length > 0 && !isLikelyGitHubUrl(exocmdUrl)) {
     return "exocmd URL must look like https://github.com/<owner>/<repo>.";
   }
   return null;

--- a/packages/obsidian-plugin/tests/unit/infrastructure/adapters/BootstrapAssetSpaceCommands.test.ts
+++ b/packages/obsidian-plugin/tests/unit/infrastructure/adapters/BootstrapAssetSpaceCommands.test.ts
@@ -208,6 +208,34 @@ describe("BootstrapAssetSpaceCommands.invokeBootstrap — empty vault (git)", ()
     expect(h.localStore.upsertFileOnlyAssetSpace).not.toHaveBeenCalled();
     expect(h.notices.some((n) => /Bootstrap complete/.test(n))).toBe(true);
   });
+
+  it("B3 core-only — empty exocmd URL → pulls exo only, no exocmd pull/.gitmodules", async () => {
+    const h = makeHarness({
+      isGitVault: true,
+      bootstrapUrls: { exoUrl: EXO_URL, exocmdUrl: "" },
+    });
+    await h.cmds.invokeBootstrap();
+
+    expect(h.puller.pullAssetSpace).toHaveBeenCalledTimes(1);
+    expect(h.puller.pullAssetSpace).toHaveBeenNthCalledWith(
+      1,
+      "bootstrap-exo",
+      EXO_URL,
+      "main",
+    );
+    expect(h.gitOps.renameIntoVault).toHaveBeenCalledTimes(1);
+    expect(h.gitOps.renameIntoVault).toHaveBeenNthCalledWith(
+      1,
+      "/tmp/staging-bootstrap-exo",
+      "assetspaces/exo",
+    );
+    expect(h.gitOps.appendGitmodulesEntry).toHaveBeenCalledTimes(1);
+    expect(h.gitOps.appendGitmodulesEntry).toHaveBeenCalledWith(
+      "assetspaces/exo",
+      EXO_URL,
+    );
+    expect(h.notices.some((n) => /knowledge-only/.test(n))).toBe(true);
+  });
 });
 
 describe("BootstrapAssetSpaceCommands.invokeBootstrap — empty vault (file-only / non-git, AC10)", () => {

--- a/packages/obsidian-plugin/tests/unit/presentation/modals/BootstrapModals.test.ts
+++ b/packages/obsidian-plugin/tests/unit/presentation/modals/BootstrapModals.test.ts
@@ -159,6 +159,45 @@ describe("BootstrapVaultModal", () => {
     });
   });
 
+  it("B3 core-only — exo filled, exocmd blank → resolves knowledge-only (empty exocmdUrl)", () => {
+    let result: { exoUrl: string; exocmdUrl: string } | null | undefined;
+    new BootstrapVaultModal(fakeApp, (r) => {
+      result = r;
+    }).open();
+    const inputs = document.querySelectorAll("input");
+    (inputs[0] as HTMLInputElement).value = "https://github.com/me/exo";
+    (inputs[1] as HTMLInputElement).value = ""; // knowledge-only
+    findButton("Bootstrap")!.click();
+    expect(result).toEqual({
+      exoUrl: "https://github.com/me/exo",
+      exocmdUrl: "",
+    });
+  });
+
+  it("B3 core-only — exo blank → still errors (exo required even when exocmd given)", () => {
+    let result: unknown = "sentinel";
+    new BootstrapVaultModal(fakeApp, (r) => {
+      result = r;
+    }).open();
+    const inputs = document.querySelectorAll("input");
+    (inputs[1] as HTMLInputElement).value = "https://github.com/me/exocmd";
+    findButton("Bootstrap")!.click();
+    expect(result).toBe("sentinel");
+    expect(document.body.textContent).toMatch(/exo URL is required/i);
+  });
+
+  it("B3 core-only — exocmd present but malformed → errors", () => {
+    let result: unknown = "sentinel";
+    new BootstrapVaultModal(fakeApp, (r) => {
+      result = r;
+    }).open();
+    const inputs = document.querySelectorAll("input");
+    (inputs[0] as HTMLInputElement).value = "https://github.com/me/exo";
+    (inputs[1] as HTMLInputElement).value = "not-a-url";
+    findButton("Bootstrap")!.click();
+    expect(result).toBe("sentinel");
+  });
+
   it("Cancel → resolves null", () => {
     let result: unknown = "sentinel";
     new BootstrapVaultModal(fakeApp, (r) => {


### PR DESCRIPTION
## Summary
**RFC `5aa2a73a` Phase B3 (onboarding).** Brings the plugin's `Bootstrap vault` modal in line with **floor={exo}** (shipped in v16.73.0, #3440).

Previously `BootstrapVaultModal` forced **both** exo + exocmd URLs ("Both the exo and exocmd URLs are required"). But the CLI bootstrap already treats `exocmd` as an **OPTIONAL** UI-command library (alt-G rejection, #3426) — a bare SDK / knowledge-only / SPARQL-only vault is a first-class config. This PR makes the plugin modal match: **only the exo URL is required**; an empty exocmd field bootstraps exo alone.

## Changes
- **`BootstrapVaultModal.ts`**: exocmd field labelled `(optional)`; intro text updated; `firstUrlProblem` now requires only exo and validates exocmd only when non-empty; exported for unit testing.
- **`BootstrapAssetSpaceCommands.ts`** (`invokeBootstrap`): skip exocmd `validateUrl` + `materialize` + `.gitmodules` entry when the exocmd URL is blank; distinct "knowledge-only, no exocmd" completion notice.
- **Tests**: +3 modal cases (knowledge-only resolves with empty `exocmdUrl`; exo-required even when exocmd given; malformed exocmd still errors) + 1 command case (empty exocmd → exo-only pull, single `.gitmodules` entry, knowledge-only notice). The existing both-URL path is unchanged and still covered.

## Validation
- `tsc --noEmit` clean across the monorepo.
- `BootstrapModals` + `BootstrapAssetSpaceCommands` suites: **46/46 green** locally.
- No live-vault mutation; no parser/TBox path touched.

## Test plan
- [ ] CI green (13 checks)
- [x] typecheck + affected unit suites green locally