### PR TITLE
fix(bootstrap): mount TS-floor at Maven path — prevent double-mount (RFC 5aa2a73a B4)

### DIFF
--- a/packages/cli/src/commands/bootstrap.ts
+++ b/packages/cli/src/commands/bootstrap.ts
@@ -1,6 +1,7 @@
 import { Command } from "commander";
 import { resolve, join } from "node:path";
 import { existsSync, mkdirSync, readdirSync } from "node:fs";
+import { derivePath } from "exocortex";
 import { BootstrapAssetSpaceService } from "../services/BootstrapAssetSpaceService.js";
 import { ErrorHandler } from "../utils/ErrorHandler.js";
 import { InvalidArgumentsError } from "../utils/errors/index.js";
@@ -87,29 +88,33 @@ export function bootstrapCommand(): Command {
 
         const results: Array<{ folder: string; url: string; sha: string; fileCount: number }> = [];
 
-        // Pull exo → assetspaces/exo
-        const exoFolder = "exo";
-        const exoTarget = join(vaultPath, "assetspaces", exoFolder);
-        process.stderr.write(`[bootstrap] Pulling ${options.exo}@${ref} → assetspaces/${exoFolder}/...\n`);
+        // Pull exo → Maven mount path `assetspaces/<owner>/<repo>` (RFC 5aa2a73a
+        // B4). MUST match `derivePath`, which is what `apply-profile` derives —
+        // otherwise a later `apply-profile` re-materializes exo at the Maven path
+        // alongside the flat one (double mount of the same AssetSpace UID).
+        // Fallback to flat `assetspaces/exo` only if the URL is un-derivable.
+        const exoRel = derivePath(options.exo!) ?? "assetspaces/exo";
+        const exoTarget = join(vaultPath, exoRel);
+        process.stderr.write(`[bootstrap] Pulling ${options.exo}@${ref} → ${exoRel}/...\n`);
         const exoResult = await svc.pullAssetSpace(options.exo!, ref, exoTarget);
-        svc.ensureGitmodulesEntry(vaultPath, `assetspaces/${exoFolder}`, options.exo!);
+        svc.ensureGitmodulesEntry(vaultPath, exoRel, options.exo!);
         results.push({
-          folder: `assetspaces/${exoFolder}`,
+          folder: exoRel,
           url: options.exo!,
           sha: exoResult.sha,
           fileCount: exoResult.fileCount,
         });
 
-        // Pull exocmd → assetspaces/exocmd — OPTIONAL (RFC 01a83de8 alt-G
+        // Pull exocmd → Maven mount path — OPTIONAL (RFC 01a83de8 alt-G
         // rejection, issue #3426). Omit `--exocmd` for a bare SDK/headless vault.
         if (options.exocmd) {
-          const exocmdFolder = "exocmd";
-          const exocmdTarget = join(vaultPath, "assetspaces", exocmdFolder);
-          process.stderr.write(`[bootstrap] Pulling ${options.exocmd}@${ref} → assetspaces/${exocmdFolder}/...\n`);
+          const exocmdRel = derivePath(options.exocmd) ?? "assetspaces/exocmd";
+          const exocmdTarget = join(vaultPath, exocmdRel);
+          process.stderr.write(`[bootstrap] Pulling ${options.exocmd}@${ref} → ${exocmdRel}/...\n`);
           const exocmdResult = await svc.pullAssetSpace(options.exocmd, ref, exocmdTarget);
-          svc.ensureGitmodulesEntry(vaultPath, `assetspaces/${exocmdFolder}`, options.exocmd);
+          svc.ensureGitmodulesEntry(vaultPath, exocmdRel, options.exocmd);
           results.push({
-            folder: `assetspaces/${exocmdFolder}`,
+            folder: exocmdRel,
             url: options.exocmd,
             sha: exocmdResult.sha,
             fileCount: exocmdResult.fileCount,

--- a/packages/obsidian-plugin/src/infrastructure/adapters/BootstrapAssetSpaceCommands.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/BootstrapAssetSpaceCommands.ts
@@ -34,6 +34,8 @@
  *      URL-derived folder, append the `.gitmodules` entry (idempotent).
  */
 
+import { derivePath } from "exocortex";
+
 /** Subset of {@link AssetSpaceManager} used here (REST tarball pull). */
 export interface IAssetSpacePuller {
   pullAssetSpace(
@@ -222,13 +224,22 @@ export class BootstrapAssetSpaceCommands {
     // classify it as `bootstrapped` and refuse, so the recovery path (use
     // «Add assetspace by URL» for the missing floor) must be surfaced
     // explicitly here. Re-index either way so the part that landed is picked up.
+    // RFC 5aa2a73a B4: mount the TS-floor at the Maven path
+    // `assetspaces/<owner>/<repo>` — the SAME path `apply-profile` derives via
+    // `derivePath`. Flat paths (`assetspaces/exo`) caused a later `apply-profile`
+    // to re-materialize the same AssetSpace UID at the Maven path → double mount.
+    // Fallback to the flat constant only when the URL is un-derivable.
+    const exoPath = derivePath(urls.exoUrl) ?? TS_FLOOR_EXO_PATH;
+    const exocmdPath = wantExocmd
+      ? (derivePath(urls.exocmdUrl) ?? TS_FLOOR_EXOCMD_PATH)
+      : TS_FLOOR_EXOCMD_PATH;
     let exo: MaterializeResult | null = null;
     try {
-      exo = await this.materialize(urls.exoUrl, TS_FLOOR_EXO_PATH, isGit);
+      exo = await this.materialize(urls.exoUrl, exoPath, isGit);
       if (wantExocmd) {
         const exocmd = await this.materialize(
           urls.exocmdUrl,
-          TS_FLOOR_EXOCMD_PATH,
+          exocmdPath,
           isGit,
         );
         this.d.notify(
@@ -244,7 +255,7 @@ export class BootstrapAssetSpaceCommands {
     } catch (e) {
       if (exo !== null) {
         this.d.notify(
-          `Bootstrap partially completed — ${TS_FLOOR_EXO_PATH} materialised, but ${TS_FLOOR_EXOCMD_PATH} failed: ${this.msg(e)}. ` +
+          `Bootstrap partially completed — ${exoPath} materialised, but ${exocmdPath} failed: ${this.msg(e)}. ` +
             "Use «Add assetspace by URL» to add the missing exocmd assetspace.",
         );
       } else {
@@ -390,8 +401,9 @@ export class BootstrapAssetSpaceCommands {
   }
 
   /**
-   * True when at least one `assetspaces/<ns>/` subfolder contains a `.md` file
-   * (a proxy for «a materialised AssetSpace exists»). Missing `assetspaces/`
+   * True when a materialised AssetSpace exists — at least one `.md` under either
+   * the flat layout (`assetspaces/<ns>/*.md`) or the Maven layout
+   * (`assetspaces/<owner>/<repo>/*.md`, RFC 5aa2a73a B4). Missing `assetspaces/`
    * dir → false.
    */
   private async hasMaterializedAssetSpaces(): Promise<boolean> {
@@ -406,7 +418,18 @@ export class BootstrapAssetSpaceCommands {
     for (const folder of top.folders) {
       try {
         const inner = await this.d.listFolder(folder);
+        // Flat layout: `assetspaces/<ns>/*.md`.
         if (inner.files.some((f) => f.endsWith(".md"))) return true;
+        // Maven layout (B4): the `.md` live one level deeper, under
+        // `assetspaces/<owner>/<repo>/` — scan the owner folder's children too.
+        for (const sub of inner.folders) {
+          try {
+            const deep = await this.d.listFolder(sub);
+            if (deep.files.some((f) => f.endsWith(".md"))) return true;
+          } catch {
+            // Unreadable nested subfolder — ignore, keep scanning.
+          }
+        }
       } catch {
         // Unreadable subfolder — ignore, keep scanning.
       }

--- a/packages/obsidian-plugin/tests/unit/infrastructure/adapters/BootstrapAssetSpaceCommands.test.ts
+++ b/packages/obsidian-plugin/tests/unit/infrastructure/adapters/BootstrapAssetSpaceCommands.test.ts
@@ -177,32 +177,33 @@ describe("BootstrapAssetSpaceCommands.invokeBootstrap — empty vault (git)", ()
     expect(h.puller.pullAssetSpace).toHaveBeenCalledTimes(2);
     expect(h.puller.pullAssetSpace).toHaveBeenNthCalledWith(
       1,
-      "bootstrap-exo",
+      "bootstrap-exoas-exo",
       EXO_URL,
       "main",
     );
     expect(h.puller.pullAssetSpace).toHaveBeenNthCalledWith(
       2,
-      "bootstrap-exocmd",
+      "bootstrap-exoas-exocmd",
       EXOCMD_URL,
       "main",
     );
+    // RFC 5aa2a73a B4: floor mounts at the Maven path `assetspaces/<owner>/<repo>`.
     expect(h.gitOps.renameIntoVault).toHaveBeenNthCalledWith(
       1,
-      "/tmp/staging-bootstrap-exo",
-      "assetspaces/exo",
+      "/tmp/staging-bootstrap-exoas-exo",
+      "assetspaces/kitelev/exoas-exo",
     );
     expect(h.gitOps.renameIntoVault).toHaveBeenNthCalledWith(
       2,
-      "/tmp/staging-bootstrap-exocmd",
-      "assetspaces/exocmd",
+      "/tmp/staging-bootstrap-exoas-exocmd",
+      "assetspaces/kitelev/exoas-exocmd",
     );
     expect(h.gitOps.appendGitmodulesEntry).toHaveBeenCalledWith(
-      "assetspaces/exo",
+      "assetspaces/kitelev/exoas-exo",
       EXO_URL,
     );
     expect(h.gitOps.appendGitmodulesEntry).toHaveBeenCalledWith(
-      "assetspaces/exocmd",
+      "assetspaces/kitelev/exoas-exocmd",
       EXOCMD_URL,
     );
     expect(h.localStore.upsertFileOnlyAssetSpace).not.toHaveBeenCalled();
@@ -219,19 +220,19 @@ describe("BootstrapAssetSpaceCommands.invokeBootstrap — empty vault (git)", ()
     expect(h.puller.pullAssetSpace).toHaveBeenCalledTimes(1);
     expect(h.puller.pullAssetSpace).toHaveBeenNthCalledWith(
       1,
-      "bootstrap-exo",
+      "bootstrap-exoas-exo",
       EXO_URL,
       "main",
     );
     expect(h.gitOps.renameIntoVault).toHaveBeenCalledTimes(1);
     expect(h.gitOps.renameIntoVault).toHaveBeenNthCalledWith(
       1,
-      "/tmp/staging-bootstrap-exo",
-      "assetspaces/exo",
+      "/tmp/staging-bootstrap-exoas-exo",
+      "assetspaces/kitelev/exoas-exo",
     );
     expect(h.gitOps.appendGitmodulesEntry).toHaveBeenCalledTimes(1);
     expect(h.gitOps.appendGitmodulesEntry).toHaveBeenCalledWith(
-      "assetspaces/exo",
+      "assetspaces/kitelev/exoas-exo",
       EXO_URL,
     );
     expect(h.notices.some((n) => /knowledge-only/.test(n))).toBe(true);
@@ -248,7 +249,10 @@ describe("BootstrapAssetSpaceCommands.invokeBootstrap — empty vault (file-only
     expect(h.gitOps.appendGitmodulesEntry).not.toHaveBeenCalled();
     expect(h.localStore.upsertFileOnlyAssetSpace).toHaveBeenCalledTimes(2);
     expect(h.localStore.upsertFileOnlyAssetSpace).toHaveBeenCalledWith(
-      expect.objectContaining({ folderName: "assetspaces/exo", url: EXO_URL }),
+      expect.objectContaining({
+        folderName: "assetspaces/kitelev/exoas-exo",
+        url: EXO_URL,
+      }),
     );
     expect(h.notices.some((n) => /file-only mode/.test(n))).toBe(true);
   });
@@ -494,10 +498,10 @@ describe("BootstrapAssetSpaceCommands — staging-dir release (Issue #3391)", ()
     // Released for each pulled staging path, after the move into the vault.
     expect(h.puller.releaseStaging).toHaveBeenCalledTimes(2);
     expect(h.puller.releaseStaging).toHaveBeenCalledWith(
-      "/tmp/staging-bootstrap-exo",
+      "/tmp/staging-bootstrap-exoas-exo",
     );
     expect(h.puller.releaseStaging).toHaveBeenCalledWith(
-      "/tmp/staging-bootstrap-exocmd",
+      "/tmp/staging-bootstrap-exoas-exocmd",
     );
     // The tracker registry is empty post-success — no reload needed.
     expect(h.activeStagingDirs).toEqual([]);

--- a/packages/obsidian-plugin/tests/unit/integration/BootstrapAssetSpace.integration.test.ts
+++ b/packages/obsidian-plugin/tests/unit/integration/BootstrapAssetSpace.integration.test.ts
@@ -143,23 +143,24 @@ describe("Bootstrap integration — real GitSubmoduleOps + tmpdir vault (git mod
 
     await cmds.invokeBootstrap();
 
-    // Both folders materialised with the fake AssetSpace file.
+    // Both folders materialised with the fake AssetSpace file — at the Maven
+    // mount path `assetspaces/<owner>/<repo>` (RFC 5aa2a73a B4).
     const exoFile = path.join(
       vaultRoot,
-      "assetspaces/exo/73bd00e4-ccc0-4f3f-b20d-c4388c4588fb.md",
+      "assetspaces/kitelev/exoas-exo/73bd00e4-ccc0-4f3f-b20d-c4388c4588fb.md",
     );
     const exocmdFile = path.join(
       vaultRoot,
-      "assetspaces/exocmd/73bd00e4-ccc0-4f3f-b20d-c4388c4588fb.md",
+      "assetspaces/kitelev/exoas-exocmd/73bd00e4-ccc0-4f3f-b20d-c4388c4588fb.md",
     );
     await expect(fs.access(exoFile)).resolves.toBeUndefined();
     await expect(fs.access(exocmdFile)).resolves.toBeUndefined();
 
-    // `.gitmodules` has exactly the two TS-floor entries.
+    // `.gitmodules` has exactly the two TS-floor entries (Maven paths).
     const entries = await gitOps.readGitmodulesEntries();
     expect(entries).toEqual([
-      { submodulePath: "assetspaces/exo", url: EXO_URL },
-      { submodulePath: "assetspaces/exocmd", url: EXOCMD_URL },
+      { submodulePath: "assetspaces/kitelev/exoas-exo", url: EXO_URL },
+      { submodulePath: "assetspaces/kitelev/exoas-exocmd", url: EXOCMD_URL },
     ]);
 
     expect(notices.some((n) => /Bootstrap complete/.test(n))).toBe(true);
@@ -378,7 +379,7 @@ describe("Bootstrap integration — staging-dir release (Issue #3391, real track
     // Both pulled, both moved into the vault, both staging entries released.
     expect((mgr.pullAssetSpace as jest.Mock).mock.calls).toHaveLength(2);
     await expect(fs.access(
-      path.join(vaultRoot, "assetspaces/exo/73bd00e4-ccc0-4f3f-b20d-c4388c4588fb.md"),
+      path.join(vaultRoot, "assetspaces/kitelev/exoas-exo/73bd00e4-ccc0-4f3f-b20d-c4388c4588fb.md"),
     )).resolves.toBeUndefined();
     // The crux of #3391: registry empty WITHOUT a reload / sweepOrphans.
     expect(await store.readActiveStagingDirs()).toEqual([]);

--- a/packages/obsidian-plugin/tests/unit/integration/BootstrapAssetSpace.integration.test.ts
+++ b/packages/obsidian-plugin/tests/unit/integration/BootstrapAssetSpace.integration.test.ts
@@ -204,6 +204,50 @@ describe("Bootstrap integration — real GitSubmoduleOps + tmpdir vault (git mod
     await cmds.invokeBootstrap();
     expect(pullSpy).not.toHaveBeenCalled();
   });
+
+  it("re-running bootstrap on a Maven-layout vault is a no-op (B4 deep-scan)", async () => {
+    vaultRoot = await makeTmpVault();
+    // Seed the Maven layout `assetspaces/<owner>/<repo>/*.md` (one level deeper
+    // than flat) so detectVaultState → bootstrapped only if hasMaterialized-
+    // AssetSpaces scans deep. Reverting the B4 deep-scan makes this re-bootstrap.
+    await fs.mkdir(path.join(vaultRoot, "assetspaces/kitelev/exoas-exo"), {
+      recursive: true,
+    });
+    await fs.writeFile(
+      path.join(vaultRoot, "assetspaces/kitelev/exoas-exo/seed.md"),
+      "x",
+      "utf8",
+    );
+    const gitOps = new GitSubmoduleOps({ vaultRootPath: vaultRoot });
+    const probes = makeVaultProbes(vaultRoot);
+    const { store } = makeFakeLocalStore();
+    const fakePuller = makeFakePuller();
+    const pullSpy = jest.spyOn(fakePuller, "pullAssetSpace");
+
+    const cmds = new BootstrapAssetSpaceCommands({
+      getPuller: async () => fakePuller,
+      gitOps,
+      localStore: store,
+      vaultExists: probes.vaultExists,
+      listFolder: probes.listFolder,
+      isGitVault: async () => true,
+      validateUrl: () => undefined,
+      deriveFolderName: (u) => u.split("/").pop() ?? "x",
+      promptBootstrapUrls: async () => ({
+        exoUrl: EXO_URL,
+        exocmdUrl: EXOCMD_URL,
+      }),
+      promptAddAssetSpaceUrl: async () => null,
+      confirm: async () => true,
+      notify: () => undefined,
+    });
+
+    // No-op via the B4 deep-scan: the seeded Maven layout must be detected as
+    // already-bootstrapped, so NO pull happens. Reverting the deep-scan makes
+    // detectVaultState → "empty" → bootstrap pulls → this assertion fails.
+    await cmds.invokeBootstrap();
+    expect(pullSpy).not.toHaveBeenCalled();
+  });
 });
 
 describe("GitSubmoduleOps.appendGitmodulesEntry — real fs", () => {


### PR DESCRIPTION
## Summary
**RFC `5aa2a73a` Phase B4.** Bootstrap mounted the TS-floor at the **flat** path `assetspaces/exo`, but `apply-profile` derives the **Maven** path `assetspaces/<owner>/<repo>` via `derivePath`. In the 3-step onboarding (bootstrap → add registry → apply profile) this made `apply-profile` re-materialize the **same AssetSpace UID** at the Maven path alongside the flat one — a **double mount** (191 files × 2 + two `.gitmodules` entries for UID `49fd2e56`).

## How it was found
An F2 CLI smoke of the 3-step flow (with the new `exoas-starter-registry`) caught it empirically: `apply-profile` reported `6 materialized` (re-mounting exo) and both `assetspaces/exo` (flat) **and** `assetspaces/kitelev/exoas-exo` (Maven) existed. A prior static-analysis pass had wrongly judged this cosmetic (because `apply-profile`'s `scanFolderToAsUid` is UID-keyed) — but it still derives a fresh Maven path for *materialization*, so the flat copy isn't reconciled. **The smoke was right; static analysis was wrong.**

## Fix
- **CLI `bootstrap.ts`** + **plugin `BootstrapAssetSpaceCommands`**: mount `exo`/`exocmd` at `derivePath(url)` (Maven), matching `apply-profile`. Fallback to the flat constant when the URL is un-derivable.
- **`hasMaterializedAssetSpaces`** now scans one level deeper so the Maven layout (`assetspaces/<owner>/<repo>/*.md`) is still detected as "bootstrapped".

## Validation
- **F2 CLI re-smoke (fixed CLI)**: `apply-profile` now reports **`5 materialized`** (exo detected at its Maven path, not re-mounted); a **single** `assetspaces/kitelev/exoas-exo` folder + single `.gitmodules` entry; all 6 starter members at Maven paths; `shared-identities` absent.
- **53 plugin bootstrap tests** (unit + integration + modals) + **39 CLI bootstrap tests** green; `tsc --noEmit` clean.
- `detectVaultState` / EC2 clone-needs-fetch / already-bootstrapped paths unchanged (re-materialize from stored `.gitmodules` paths; legacy flat vaults still detected).

## Test plan
- [ ] CI green (13 checks)
- [x] typecheck + 53 plugin + 39 CLI bootstrap tests green; F2 smoke confirms single mount