### PR TITLE
fix(profile): reconcile URI-floor with AS-UID floor={exo} (#3450)

### DIFF
--- a/packages/cli/src/services/CliApplyProfileService.ts
+++ b/packages/cli/src/services/CliApplyProfileService.ts
@@ -237,9 +237,9 @@ export class CliApplyProfileService {
    * down and brick the engine.
    *
    * EV8 — delegates to the single named guard in `exocortex`. The CLI/headless
-   * engine enforces the **SDK floor** (`$exo` + `$shared-identities`), NOT the
-   * plugin-UI floor: a bare SDK vault legitimately omits `$exocmd` (issue
-   * #3426). Tests live in `packages/exocortex/tests/domain/profile/`.
+   * engine enforces the **SDK floor** = `{exo}` (RFC 5aa2a73a / #3440):
+   * `$shared-identities` and `$exocmd` are optional, so a bare SDK vault
+   * legitimately omits them. Tests live in `packages/exocortex/tests/domain/profile/`.
    *
    * @throws {TsFloorViolationError} if any SDK-floor AssetSpace is absent.
    */

--- a/packages/cli/src/services/CliProfileResolver.ts
+++ b/packages/cli/src/services/CliProfileResolver.ts
@@ -10,10 +10,10 @@
  *   3. Resolve declared AssetSpace UIDs against folderMap (the former
  *      Ontology→AS translation via `exo__AssetSpace_containsOntology` was removed
  *      in Phase 3 T3b-cleanup — profiles declare AS UIDs directly)
- *   4. Apply the SDK-floor AssetSpace UIDs (Vision Lock #17 / RFC 01a83de8 §3.4):
- *      $exo + $shared-identities — guarantees the CLI/headless engine keeps
- *      functioning regardless of profile config. `$exocmd` is NOT in the SDK
- *      floor (issue #3426 — it is the plugin-UI floor's concern only)
+ *   4. Apply the SDK-floor AssetSpace UIDs (Vision Lock #17 / floor={exo},
+ *      RFC 5aa2a73a / #3440): `$exo` only — guarantees the CLI/headless engine
+ *      keeps functioning regardless of profile config. `$shared-identities`
+ *      and `$exocmd` are OPTIONAL (not in any floor tier post-#3440)
  *   5. Safe-degrade: if effective set has zero AS-folder overlap, return null
  *      (caller falls back to no-filter / full vault) to prevent self-brick
  *
@@ -40,9 +40,10 @@ export {
 
 /**
  * TS-floor AssetSpace UIDs the CLI/headless engine enforces — the **SDK floor**
- * (`$exo` + `$shared-identities`), WITHOUT `$exocmd`. RFC 01a83de8 alt-G
- * rejection: a bare SDK vault is a first-class config and never forces the
- * UI-command library. (The plugin uses the wider plugin-UI floor.)
+ * = `{exo}` (RFC 5aa2a73a / #3440). `$shared-identities` and `$exocmd` are
+ * OPTIONAL. A bare SDK vault is a first-class config and never forces the
+ * UI-command library. (The plugin uses the same `{exo}` floor — both tiers
+ * collapsed to `{exo}` in #3440.)
  */
 export const TS_FLOOR_ASSETSPACE_UIDS: ReadonlySet<string> =
   SDK_FLOOR_ASSETSPACE_UIDS;

--- a/packages/obsidian-plugin/src/infrastructure/adapters/ProfileApplyManager.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/ProfileApplyManager.ts
@@ -49,11 +49,14 @@ export const PROFILE_CLASS_UID = "3de846cd-1f0e-4f98-8613-b8587aa15174";
 /**
  * TS-floor (Vision Lock #17): ontology URIs that are ALWAYS in the effective
  * set, regardless of profile config. Hardcoded — never destroyable.
- * Prevents plugin self-brick если user accidentally removes $exo from a profile.
+ *
+ * floor = `{exo}` only (RFC 5aa2a73a / #3440 collapsed the floor to the SDK
+ * core). `exocmd` and `shared-identities` are OPTIONAL — a profile may omit
+ * them. Kept in sync with the AS-UID floor `TS_FLOOR_ASSETSPACE_UIDS={exo}`.
+ * Prevents plugin self-brick if a user accidentally removes $exo from a profile.
  */
 export const TS_FLOOR_ONTOLOGY_URIS: ReadonlySet<string> = new Set([
   "https://exocortex.my/ontology/exo",
-  "https://exocortex.my/ontology/exocmd",
 ]);
 
 /**
@@ -421,9 +424,9 @@ export class ProfileApplyManager {
    * mount-state hard/REST switch consumes these AssetSpace UIDs directly (the
    * query-time soft-filter consumer was removed in RFC 01a83de8 Phase 3 T3b).
    *
-   * TS-floor (Vision Lock #17) — hardcoded `[$exo, $exocmd]` + pattern match
-   * для shared-identities — guarantees the plugin keeps functioning regardless
-   * of profile config.
+   * TS-floor (Vision Lock #17) — hardcoded `[$exo]` (floor={exo}, #3440) +
+   * pattern match для shared-identities — guarantees the plugin keeps
+   * functioning regardless of profile config.
    */
   async resolveEffectiveSet(profileUid: string): Promise<Set<string>> {
     const derived = await this.computeDerivedSet(profileUid);
@@ -1351,8 +1354,8 @@ export class ProfileApplyManager {
 
   private assertTsFloor(effective: ReadonlySet<string>): void {
     // EV8 — delegate to the single named guard in `exocortex`. The plugin
-    // enforces the **plugin-UI floor** (SDK floor + `$exocmd`) so UI commands
-    // never self-brick.
+    // enforces the **plugin-UI floor** (= the SDK floor `{exo}`, #3440) so UI
+    // commands never self-brick.
     assertTsFloorGuard(effective, PLUGIN_UI_FLOOR_ASSETSPACE_UIDS);
   }
 

--- a/packages/obsidian-plugin/src/infrastructure/adapters/ProfileOnloadWiring.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/ProfileOnloadWiring.ts
@@ -8,12 +8,14 @@
  * RFC 01a83de8 Phase 3 (T3b) — the query-time soft-filter onload wiring was
  * removed; profile scoping is now mount-state based.
  *
- * RFC 01a83de8 §3.4 / EV8 (issue #3426) — the floor was split into two tiers
- * and re-homed to a single named guard in `exocortex`
- * ({@link ../../../../../exocortex/src/domain/profile/TsFloorGuard}). The plugin
- * mounts the **plugin-UI floor** (SDK floor + `$exocmd`), because exocmd
- * provides the vault-side UI commands the plugin renders. The constants below
- * re-export the core guard so existing plugin imports keep working.
+ * RFC 01a83de8 §3.4 / EV8 (issue #3426) re-homed the floor to a single named
+ * guard in `exocortex`
+ * ({@link ../../../../../exocortex/src/domain/profile/TsFloorGuard}). RFC
+ * 5aa2a73a (#3440) then collapsed the floor to **`{exo}`** for both tiers: the
+ * plugin-UI floor is now just `$exo`. `exocmd` (the vault-side UI commands the
+ * plugin renders) and `shared-identities` are OPTIONAL — a profile may omit
+ * them without self-bricking. The constants below re-export the core guard so
+ * existing plugin imports keep working.
  */
 
 import { PLUGIN_UI_FLOOR_ASSETSPACE_UIDS } from "exocortex";
@@ -27,8 +29,9 @@ export {
 
 /**
  * TS-floor AssetSpace UIDs the plugin enforces (Vision Lock #17, AS-UID level).
- * The plugin uses the **plugin-UI floor** — SDK floor (`$exo` +
- * `$shared-identities`) plus `$exocmd` — so the UI commands never self-brick.
+ * The plugin uses the **plugin-UI floor** = `{exo}` (RFC 5aa2a73a / #3440).
+ * `exocmd` and `shared-identities` are optional; only `$exo` is load-bearing,
+ * so the engine never self-bricks while UI commands stay opt-in.
  */
 export const TS_FLOOR_ASSETSPACE_UIDS: ReadonlySet<string> =
   PLUGIN_UI_FLOOR_ASSETSPACE_UIDS;

--- a/packages/obsidian-plugin/tests/unit/ProfileApplyManager.apply.test.ts
+++ b/packages/obsidian-plugin/tests/unit/ProfileApplyManager.apply.test.ts
@@ -519,23 +519,17 @@ describe("ProfileApplyManager.applyProfile", () => {
       await expect(ctx.mgr.applyProfile("target")).resolves.toBeUndefined();
     });
 
-    it("passes guard when target profile explicitly includes all 3 floor AS UIDs", async () => {
-      // Target explicitly declares the 3 floor AS — R24 guard passes;
-      // algorithm proceeds. Apply refuses to silently auto-rescue
-      // missing floor (vs Phase 1 reindex onload wiring which does).
+    it("floor={exo}: accepts a profile that omits $exocmd and $shared-identities", async () => {
+      // floor={exo} (RFC 5aa2a73a / #3440): exocmd and shared-identities are
+      // OPTIONAL AssetSpaces. A profile declaring ONLY $exo passes the R24
+      // apply-layer guard — parity with the TsFloorGuard / CLI floor tests.
+      // Non-vacuous: pre-#3440 (floor = all 3) this would have thrown
+      // TsFloorViolationError; it now resolves because $exo is the whole floor.
       const { mgr } = setup({
         targetUid: "target",
         sourceUid: null,
-        targetIncludes: [
-          TS_FLOOR_AS_UID_EXO,
-          TS_FLOOR_AS_UID_EXOCMD,
-          TS_FLOOR_AS_UID_SHARED_IDENTITIES,
-        ],
-        materialized: [
-          TS_FLOOR_AS_UID_EXO,
-          TS_FLOOR_AS_UID_EXOCMD,
-          TS_FLOOR_AS_UID_SHARED_IDENTITIES,
-        ],
+        targetIncludes: [TS_FLOOR_AS_UID_EXO], // omits exocmd + shared-identities
+        materialized: [TS_FLOOR_AS_UID_EXO],
       });
       await expect(mgr.applyProfile("target")).resolves.toBeUndefined();
     });

--- a/packages/obsidian-plugin/tests/unit/ProfileApplyManager.test.ts
+++ b/packages/obsidian-plugin/tests/unit/ProfileApplyManager.test.ts
@@ -154,7 +154,7 @@ const ONTO_TBANK = "https://exocortex.my/ontology/tbank";
 // ─── resolveEffectiveSet + TS-floor ──────────────────────────────────────
 
 describe("ProfileApplyManager.resolveEffectiveSet — TS-floor (Vision Lock #17)", () => {
-  it("includes TS-floor URIs even when profile has empty includes/overlay", async () => {
+  it("floor={exo}: includes $exo but NOT $exocmd when profile has empty includes", async () => {
     const { mgr } = makeHarness({
       profiles: [
         [
@@ -170,7 +170,9 @@ describe("ProfileApplyManager.resolveEffectiveSet — TS-floor (Vision Lock #17)
     });
     const effective = await mgr.resolveEffectiveSet(UID_BASE);
     expect(effective.has(ONTO_EXO)).toBe(true);
-    expect(effective.has(ONTO_EXOCMD)).toBe(true);
+    // floor={exo} (RFC 5aa2a73a / #3440): exocmd is OPTIONAL — never auto-injected
+    // into the floor. A profile that omits exocmd gets no exocmd in its effective set.
+    expect(effective.has(ONTO_EXOCMD)).toBe(false);
   });
 
   it("includes shared-identities pattern matches via discoverSharedOntologies", async () => {
@@ -210,6 +212,10 @@ describe("ProfileApplyManager.resolveEffectiveSet — TS-floor (Vision Lock #17)
     for (const floorUri of TS_FLOOR_ONTOLOGY_URIS) {
       expect(effective.has(floorUri)).toBe(true);
     }
+    // Lock the floor boundary (#3450): the floor is exactly {exo} — exocmd is
+    // OPTIONAL and must NOT be silently injected.
+    expect(TS_FLOOR_ONTOLOGY_URIS.has(ONTO_EXOCMD)).toBe(false);
+    expect(effective.has(ONTO_EXOCMD)).toBe(false);
   });
 });
 

--- a/packages/obsidian-plugin/tests/unit/ProfileSwitch.regression.test.ts
+++ b/packages/obsidian-plugin/tests/unit/ProfileSwitch.regression.test.ts
@@ -168,8 +168,10 @@ describe("B.10 Scenario 1 — Filtered set with AS folder present", () => {
 
     const eff = await h.mgr.resolveEffectiveSet(UID_PERSONAL);
     expect(eff.has(ONTO_KITELEV)).toBe(true);
-    expect(eff.has(ONTO_EXO)).toBe(true);   // overlay via extends
-    expect(eff.has(ONTO_EXOCMD)).toBe(true); // overlay via extends + TS-floor
+    expect(eff.has(ONTO_EXO)).toBe(true);   // TS-floor ($exo)
+    // floor={exo} (#3450): no profile in the extends chain includes exocmd, and
+    // exocmd is no longer in the floor → it is NOT in the effective set.
+    expect(eff.has(ONTO_EXOCMD)).toBe(false);
 
     // The apply reindex path still fires exactly one (full-vault) reindex.
     await reindex(h.mgr, UID_PERSONAL);
@@ -222,7 +224,7 @@ describe("B.10 Scenario 3 — Empty effective_set survives via TS-floor", () => 
     }
   });
 
-  it("plugin can NEVER self-brick — \\$exo + \\$exocmd always in set", async () => {
+  it("plugin can NEVER self-brick — \\$exo always in set (floor={exo})", async () => {
     // Multiple pathological profiles
     const profiles: Array<[string, ProfileResolution]> = [
       ["empty", { uid: "empty", includes: [], extends: null }],
@@ -233,8 +235,10 @@ describe("B.10 Scenario 3 — Empty effective_set survives via TS-floor", () => 
     for (const [uid] of profiles) {
       const h = makeHarness(profiles);
       const eff = await h.mgr.resolveEffectiveSet(uid);
+      // floor={exo} (RFC 5aa2a73a / #3440): only $exo is always present.
       expect(eff.has(ONTO_EXO)).toBe(true);
-      expect(eff.has(ONTO_EXOCMD)).toBe(true);
+      // exocmd is OPTIONAL — none of these profiles include it, so it's absent.
+      expect(eff.has(ONTO_EXOCMD)).toBe(false);
     }
   });
 });
@@ -319,9 +323,11 @@ describe("B.10 Scenario 5 — TS-floor empirical revert/restore", () => {
     ]);
     const eff = await h.mgr.resolveEffectiveSet(UID_BASE);
 
-    // The exact production behavior includes the TS-floor; \$exo is present
+    // The exact production behavior includes the TS-floor; \$exo is present.
     expect(eff.has(ONTO_EXO)).toBe(true);
-    expect(eff.has(ONTO_EXOCMD)).toBe(true);
+    // floor={exo} (RFC 5aa2a73a / #3440): exocmd is OPTIONAL — not in the floor,
+    // so an empty profile does NOT auto-include it.
+    expect(eff.has(ONTO_EXOCMD)).toBe(false);
   });
 
   it("TS_FLOOR_SHARED_PATTERN matches shared-* ontology URIs", () => {


### PR DESCRIPTION
Closes #3450.

## Summary
PR #3440 collapsed the TS-floor to `{exo}` at the AssetSpace-UID level, but a second, ontology-URI-level floor (`TS_FLOOR_ONTOLOGY_URIS`) still listed `exocmd`. That was a **verified runtime no-op** (the exocmd URI is filtered out in `reconcileToLocal` because it's not an AS-UID, and the real floor `{exo}` is injected at the AS level), but it left two divergent floor definitions + stale docstrings. This PR makes both floor layers agree on `{exo}`.

## Changes
- **HIGH #1** — remove `…/ontology/exocmd` from `TS_FLOOR_ONTOLOGY_URIS` → single floor story `{exo}`.
- **MEDIUM (docstrings)** — update 4 stale docstrings to `floor = {exo}` (exocmd + shared-identities optional): `ProfileApplyManager.ts:54/:424/:1354`, `ProfileOnloadWiring.ts`, `CliProfileResolver.ts`.
- **MEDIUM (tests)** — retarget the URI-floor + apply-layer tests so they are **non-vacuous**:
  - `ProfileApplyManager.test.ts` / `ProfileSwitch.regression.test.ts`: empty/pathological profiles now assert exocmd is **NOT** auto-included (floor={exo}).
  - `ProfileApplyManager.apply.test.ts`: the vacuous "all 3 floor AS" test is retargeted to assert the apply layer **ACCEPTS an exocmd-omitting profile** (pre-#3440 this threw `TsFloorViolationError`).

## Verification
- 3 affected suites: **58/58 pass**.
- **Empirical non-vacuousness**: 5 assertions across the 3 suites FAILED while exocmd was still expected in the floor and PASS after removing it — proving the constant change has real effect on the effective set (exocmd present → absent).
- Lint clean on touched src; full typecheck + suite run in CI.

## Test plan
- [ ] CI green (13 required checks)
- [ ] code-reviewer pass
- [ ] UI smoke (per #3450 acceptance): apply an exocmd-omitting profile → exocmd buttons gone, no crash; apply an exocmd-including profile → buttons return