### PR TITLE
fix(cli): update stale 'sparql' subcommand hints to current command names

### DIFF
--- a/packages/cli/src/cache/CombinedCacheManager.ts
+++ b/packages/cli/src/cache/CombinedCacheManager.ts
@@ -68,7 +68,7 @@ export interface CombinedCacheStats {
 /**
  * Manages a persistent triple cache that spans multiple vaults.
  *
- * Issue #3281: cross-vault SPARQL recall was ~19% because (a) `sparql index`
+ * Issue #3281: cross-vault SPARQL recall was ~19% because (a) `index`
  * had no `--also` flag and (b) `query --use-cache --also` could only load
  * per-vault caches that materialize inferences within each vault individually,
  * missing cross-vault RDFS subClass chains and prototype inheritance.

--- a/packages/cli/src/cache/buildCombinedTriples.ts
+++ b/packages/cli/src/cache/buildCombinedTriples.ts
@@ -51,7 +51,7 @@ export interface BuildCombinedTriplesResult {
  * applies cross-vault wikilink resolution, and runs RDFS + prototype-chain
  * materialization on the combined triple store.
  *
- * This is the orchestration shared by `sparql index --also` (Issue #3281)
+ * This is the orchestration shared by `index --also` (Issue #3281)
  * and any future caller that needs a cross-vault materialized triple set.
  *
  * Behaviour:
@@ -99,7 +99,7 @@ export async function buildCombinedTriples(
   // primary adapter is then configured with these siblings so its
   // `getFirstLinkpathDest` (Step 5) resolves label-form wikilinks whose
   // target lives in an `--also` vault. Keeps the combined-cache path
-  // symmetric with the non-cached `sparql query --also` path.
+  // symmetric with the non-cached `query --also` path.
   const alsoAdapters: FileSystemVaultAdapter[] = [];
   const alsoPrefixes: string[] = [];
   for (const alsoPath of resolvedAlsos) {

--- a/packages/cli/src/commands/sparql-index.ts
+++ b/packages/cli/src/commands/sparql-index.ts
@@ -28,7 +28,7 @@ function collectAlso(value: string, previous: string[]): string[] {
 }
 
 /**
- * Creates the 'sparql index' subcommand for building/managing the triple cache.
+ * Creates the 'index' command for building/managing the triple cache.
  *
  * The index command creates a persistent cache of RDF triples from the vault,
  * enabling fast subsequent SPARQL queries without re-parsing all files.
@@ -37,16 +37,16 @@ function collectAlso(value: string, previous: string[]): string[] {
  * cross-vault cache materialized over the union of the primary and `--also`
  * vaults (Issue #3281). The combined cache lives at
  * `<primary>/.exocortex/cache/combined-<hash>.json` and is consumed by
- * `sparql query --use-cache --also` when the same set of vaults is queried.
+ * `query --use-cache --also` when the same set of vaults is queried.
  *
  * @returns Commander Command instance configured for cache management
  *
  * @example
- * exocortex sparql index --vault /path/to/vault
- * exocortex sparql index --vault /path/to/vault --stats
- * exocortex sparql index --vault /path/to/vault --force
- * exocortex sparql index --vault /path/to/vault --strict
- * exocortex sparql index --vault /path/to/primary --also /path/to/other
+ * exocortex index --vault /path/to/vault
+ * exocortex index --vault /path/to/vault --stats
+ * exocortex index --vault /path/to/vault --force
+ * exocortex index --vault /path/to/vault --strict
+ * exocortex index --vault /path/to/primary --also /path/to/other
  */
 export function sparqlIndexCommand(): Command {
   return new Command("index")
@@ -208,7 +208,7 @@ export function sparqlIndexCommand(): Command {
  * from `primary` and every `alsoVaults` path. The resulting triple set is
  * persisted under `<primary>/.exocortex/cache/combined-<hash>.json` where
  * `<hash>` is a stable hash of the sorted vault-path set, so subsequent
- * `sparql query --use-cache --also` calls with the same vault set hit the
+ * `query --use-cache --also` calls with the same vault set hit the
  * combined cache directly.
  */
 async function runCombinedIndex(

--- a/packages/cli/src/commands/sparql-query.ts
+++ b/packages/cli/src/commands/sparql-query.ts
@@ -161,7 +161,7 @@ export function parseCacheTtl(ttlStr: string | undefined): number {
   if (isNaN(value) || value <= 0) {
     throw new InvalidArgumentsError(
       `Invalid cache TTL: "${ttlStr}". Must be a positive number (seconds).`,
-      'exocortex sparql query --cache-ttl 600 "SELECT * WHERE { ?s ?p ?o }"'
+      'exocortex query --cache-ttl 600 "SELECT * WHERE { ?s ?p ?o }"'
     );
   }
   return value;
@@ -180,7 +180,7 @@ export function parseTimeout(timeoutStr: string): number {
     if (isNaN(value) || value <= 0) {
       throw new InvalidArgumentsError(
         `Invalid timeout format: "${timeoutStr}". Value must be a positive number.`,
-        'exocortex sparql query --timeout "30s" or --timeout "5000ms"'
+        'exocortex query --timeout "30s" or --timeout "5000ms"'
       );
     }
     return value;
@@ -192,7 +192,7 @@ export function parseTimeout(timeoutStr: string): number {
     if (isNaN(value) || value <= 0) {
       throw new InvalidArgumentsError(
         `Invalid timeout format: "${timeoutStr}". Value must be a positive number.`,
-        'exocortex sparql query --timeout "30s" or --timeout "5000ms"'
+        'exocortex query --timeout "30s" or --timeout "5000ms"'
       );
     }
     return value * 1000;
@@ -203,7 +203,7 @@ export function parseTimeout(timeoutStr: string): number {
   if (isNaN(value) || value <= 0) {
     throw new InvalidArgumentsError(
       `Invalid timeout format: "${timeoutStr}". Use formats like "30s", "5000ms", or just a number (seconds).`,
-      'exocortex sparql query --timeout "30s" or --timeout "5000ms"'
+      'exocortex query --timeout "30s" or --timeout "5000ms"'
     );
   }
   return value * 1000;
@@ -319,7 +319,7 @@ export function sparqlQueryCommand(): Command {
         } else {
           throw new InvalidArgumentsError(
             "Either a query argument or --template flag is required.",
-            'exocortex sparql query "SELECT * WHERE { ?s ?p ?o }" or exocortex sparql query --template tasks-by-date --param date=2024-01-15'
+            'exocortex query "SELECT * WHERE { ?s ?p ?o }" or exocortex query --template tasks-by-date --param date=2024-01-15'
           );
         }
 
@@ -405,7 +405,7 @@ export function sparqlQueryCommand(): Command {
           } else {
             if (outputFormat === "text") {
               console.log(
-                `ℹ️  Combined cache miss (or invalid). Falling back to per-vault load. Run \`exocortex sparql index --vault <primary> --also <...>\` to build the cross-vault index.`,
+                `ℹ️  Combined cache miss (or invalid). Falling back to per-vault load. Run \`exocortex index --vault <primary> --also <...>\` to build the cross-vault index.`,
               );
             }
           }
@@ -442,7 +442,7 @@ export function sparqlQueryCommand(): Command {
             // Note (#3352): siblingAdapters cannot retro-fix wikilinks that
             // were already serialised as bare Literals at cache build time.
             // Users who need cross-vault label-form resolution on the cached
-            // path should rebuild the index via `sparql index --also` (which
+            // path should rebuild the index via `index --also` (which
             // routes through `buildCombinedTriples`).
             const cacheManager = new CacheManager(vaultPath);
             const cacheResult = await cacheManager.loadOrBuild();

--- a/packages/cli/src/commands/validate.ts
+++ b/packages/cli/src/commands/validate.ts
@@ -64,7 +64,7 @@ function validateIriCommand(): Command {
             console.log("   - Rename files to remove spaces and special characters");
             console.log("   - Use dashes (-) or underscores (_) instead of spaces");
             console.log("   - Avoid angle brackets (<>) and other special characters");
-            console.log("\n💡 Run 'exocortex sparql index --strict' to fail on first issue");
+            console.log("\n💡 Run 'exocortex index --strict' to fail on first issue");
           }
         }
 

--- a/packages/cli/src/utils/AlsoVaultMountPrefix.ts
+++ b/packages/cli/src/utils/AlsoVaultMountPrefix.ts
@@ -1,6 +1,6 @@
 /**
  * Issue #3219 — when a user invokes
- *   `exocortex sparql query --vault <primary> --also <root>/assetspaces/<sub>`
+ *   `exocortex query --vault <primary> --also <root>/assetspaces/<sub>`
  * the `--also` path is rooted at an AssetSpace subdirectory. Without a mount
  * prefix the synthesised subject IRIs lose the `assetspaces/<sub>/` segment
  * (file.path is relative to the adapter root → bare `<file>.md`) and cannot

--- a/packages/cli/src/utils/errors/QueryTimeoutError.ts
+++ b/packages/cli/src/utils/errors/QueryTimeoutError.ts
@@ -41,7 +41,7 @@ export class QueryTimeoutError extends CLIError {
       },
       {
         message: `Increase timeout with --timeout <duration> (e.g., --timeout 60s)`,
-        suggestion: `exocortex sparql query --timeout ${timeoutSec * 2}s "..."`,
+        suggestion: `exocortex query --timeout ${timeoutSec * 2}s "..."`,
       },
     );
 


### PR DESCRIPTION
## Summary

The CLI registers top-level `query` and `index` commands (the `sparql` parent was removed), but 8 user-facing hints and several doc comments still told users to run `exocortex sparql query|index ...` — which fails verbatim with `error: unknown command 'sparql'`.

**User-facing fixes:**
- `sparql-query.ts` :164 (cache-ttl hint), :183/:195/:206 (timeout hints), :322 (usage examples ×2), :408 (combined cache-miss hint)
- `validate.ts:67` — now points to `exocortex index --strict` (the `--strict` flag is registered on the `index` command, `sparql-index.ts:59` — the issue body guessed `validate iri --strict`, verified wrong)
- `QueryTimeoutError.ts:44` — timeout suggestion in structured error

**Doc-comment cleanup:** `AlsoVaultMountPrefix.ts`, `sparql-index.ts` (JSDoc examples), `sparql-query.ts:445`, `buildCombinedTriples.ts`, `CombinedCacheManager.ts`.

**Scope notes:**
- Fresh worktree grep found 2 user-facing spots beyond the issue table (`QueryTimeoutError.ts:44`, `sparql-query.ts:322`) — included.
- `find.ts:139` untouched — refers to the `--sparql` flag of `find`, not the removed subcommand.
- No tests assert the old hint text (verified by grep over `tests/` + `specs/`).

Closes #3455

## Test plan
- [x] `npm run lint` — 0 errors (2 pre-existing warnings in obsidian-plugin, untouched)
- [x] `npm run check:types` — clean
- [x] lint-staged `--findRelatedTests` on the 7 files — passed (pre-commit)
- [x] `grep -rn "sparql query\|sparql index" packages/cli/src/` → only the legitimate `find.ts:139` (`--sparql` flag) remains
- [ ] CI 13 required checks
- [ ] Post-release smoke: `npx -y @kitelev/exocortex-cli@<new>` combined cache-miss hint shows `exocortex index ...`