### PR TITLE
feat(exosync): ChangeDetector + SyncEngine push-only happy-path (RFC 4e4dc453 A1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -440,10 +440,13 @@ jobs:
         #   tests (issue-2997-repro / issue-2997-loader-2pc) run via test-coverage-cli;
         #   BGP unit suite needs explicit allow-list entry here because exocortex
         #   jest.config.js is otherwise unreachable from CI (see scripts/test-ci-batched.sh).
+        # - RFC 4e4dc453 A1 (ExoSync): services/sync/(ChangeDetector|SyncEngine).test
+        #   — platform-free sync core; this inline list (NOT test-ci-batched.sh,
+        #   which no workflow invokes) is the actual CI gate for exocortex suites.
         run: |
           node ./node_modules/jest/bin/jest.js \
             --config packages/exocortex/jest.config.js \
-            --testPathPatterns='(services/(GroundingExecutor(\.[a-zA-Z0-9_-]+)?|AssetConversionService|NoteToRDFConverter\.issue-2959)\.test|application/services/RelationColumnSetResolver(\.property)?\.test|performance/RelationColumnSetResolverPerformance\.test|infrastructure/sparql/executors/BGPExecutor\.issue-2997\.test|integration/dynamic-commands/grounding-phase3b-pipeline\.test)\.ts' \
+            --testPathPatterns='(services/(GroundingExecutor(\.[a-zA-Z0-9_-]+)?|AssetConversionService|NoteToRDFConverter\.issue-2959)\.test|services/sync/(ChangeDetector|SyncEngine)\.test|application/services/RelationColumnSetResolver(\.property)?\.test|performance/RelationColumnSetResolverPerformance\.test|infrastructure/sparql/executors/BGPExecutor\.issue-2997\.test|integration/dynamic-commands/grounding-phase3b-pipeline\.test)\.ts' \
             --forceExit
 
   test-coverage:

--- a/packages/exocortex/src/index.ts
+++ b/packages/exocortex/src/index.ts
@@ -582,3 +582,44 @@ export {
   type MountAssetSpaceParams,
   type GitmodulesAppendResult,
 } from "./services/assetspace/AssetSpaceMount";
+
+// ExoSync A1 — platform-free sync core (RFC 4e4dc453): ChangeDetector
+// (uid-keyed diff vs per-device watermark, D8/D18/D22) + SyncEngine
+// (pull→no-conflict→push orchestration over the existing restCreateCommit
+// primitive, D3/D12/D16/D19). Consumed via injected ports (transport,
+// local files, watermark store, materialization gate, sha1).
+export {
+  detectChanges,
+  extractAssetUid,
+  type DetectChangesParams,
+} from "./services/sync/ChangeDetector";
+export { gitBlobSha } from "./services/sync/gitBlobSha";
+export {
+  getBlobText,
+  getCommitInfo,
+  getHeadSha,
+  getTree,
+  type RemoteCommitInfo,
+  type RemoteTreeEntry,
+} from "./services/sync/githubRepoReader";
+export {
+  DEFAULT_MAX_PUSH_RETRIES,
+  SyncEngine,
+  isNonFastForwardError,
+  orderChildrenFirst,
+  type SyncEngineDeps,
+} from "./services/sync/SyncEngine";
+export {
+  isSyncablePath,
+  type AssetChange,
+  type ChangeDetectionResult,
+  type LocalFilesPort,
+  type MaterializationCheck,
+  type MaterializationCheckPort,
+  type RepoSyncResult,
+  type Sha1Fn,
+  type SyncRepoSpec,
+  type WatermarkFileEntry,
+  type WatermarkRecord,
+  type WatermarkStorePort,
+} from "./services/sync/syncTypes";

--- a/packages/exocortex/src/services/sync/ChangeDetector.ts
+++ b/packages/exocortex/src/services/sync/ChangeDetector.ts
@@ -31,7 +31,9 @@ import { gitBlobSha } from "./gitBlobSha";
  * scalar by vault convention — UID-canon, CLAUDE.md).
  */
 export function extractAssetUid(content: string): string | undefined {
-  const fm = /^---\r?\n([\s\S]*?)\r?\n---/.exec(content);
+  // Close delimiter anchored to line end — a frontmatter line merely
+  // STARTING with `---` (e.g. `----` scalar) must not end the block early.
+  const fm = /^---\r?\n([\s\S]*?)\r?\n---(?=\r?\n|$)/.exec(content);
   if (!fm) return undefined;
   const m = /^exo__Asset_uid:[ \t]*["']?([^\s"']+)["']?[ \t]*$/m.exec(fm[1]);
   return m ? m[1] : undefined;

--- a/packages/exocortex/src/services/sync/ChangeDetector.ts
+++ b/packages/exocortex/src/services/sync/ChangeDetector.ts
@@ -1,0 +1,147 @@
+/**
+ * ExoSync ChangeDetector (RFC 4e4dc453 — D8/D18/D22, CQ2).
+ *
+ * Pure (no I/O) diff of the local working tree against the per-device
+ * watermark base. Identity is `exo__Asset_uid` from frontmatter where present
+ * (D18) — a renamed asset (same uid, new path) classifies as MODIFIED with a
+ * `basePath`, not as delete+add. Files without a uid match by path.
+ *
+ * D22 base validation: the watermark is never trusted blindly. The caller
+ * passes the ACTUAL root tree SHA of the `lastSyncedSha` commit (fetched from
+ * the remote); a missing watermark (first sync) or a mismatch (backup-restore,
+ * history rewrite, corrupt store — R10) yields `full-conflict`, which the
+ * caller must hand to the merge/quarantine layer (A2/A3) — NEVER a silent
+ * overwrite.
+ */
+
+import type {
+  AssetChange,
+  ChangeDetectionResult,
+  Sha1Fn,
+  WatermarkFileEntry,
+  WatermarkRecord,
+} from "./syncTypes";
+import { gitBlobSha } from "./gitBlobSha";
+
+/**
+ * Extract `exo__Asset_uid` from a markdown asset's YAML frontmatter.
+ *
+ * Narrow by design: sync identity needs ONE scalar key, so a bounded
+ * frontmatter-block regex is used instead of a YAML parser (the uid is a plain
+ * scalar by vault convention — UID-canon, CLAUDE.md).
+ */
+export function extractAssetUid(content: string): string | undefined {
+  const fm = /^---\r?\n([\s\S]*?)\r?\n---/.exec(content);
+  if (!fm) return undefined;
+  const m = /^exo__Asset_uid:[ \t]*["']?([^\s"']+)["']?[ \t]*$/m.exec(fm[1]);
+  return m ? m[1] : undefined;
+}
+
+export interface DetectChangesParams {
+  /** Allowlist-scoped disk snapshot: repo-relative path → content. */
+  localFiles: ReadonlyMap<string, string>;
+  watermark: WatermarkRecord | null;
+  /**
+   * Actual root tree SHA of the `watermark.lastSyncedSha` commit on the
+   * remote, or `null` when it could not be resolved (commit GC'd / history
+   * rewritten / 404). Ignored when `watermark` is null.
+   */
+  actualBaseTreeSha: string | null;
+  sha1: Sha1Fn;
+}
+
+interface DiskEntry {
+  path: string;
+  blobSha: string;
+  uid?: string;
+}
+
+/** Diff disk vs watermark base. See module docstring for identity rules. */
+export async function detectChanges(
+  params: DetectChangesParams,
+): Promise<ChangeDetectionResult> {
+  const { localFiles, watermark, actualBaseTreeSha, sha1 } = params;
+
+  if (watermark === null) {
+    return { kind: "full-conflict", reason: "first-sync" };
+  }
+  if (actualBaseTreeSha === null) {
+    return {
+      kind: "full-conflict",
+      reason: "base-mismatch",
+      detail: `watermark commit ${watermark.lastSyncedSha} not resolvable on remote`,
+    };
+  }
+  if (actualBaseTreeSha !== watermark.rootTreeSha) {
+    return {
+      kind: "full-conflict",
+      reason: "base-mismatch",
+      detail: `stored root tree ${watermark.rootTreeSha} != actual ${actualBaseTreeSha} at ${watermark.lastSyncedSha}`,
+    };
+  }
+
+  const disk: DiskEntry[] = [];
+  for (const [path, content] of localFiles) {
+    disk.push({
+      path,
+      blobSha: await gitBlobSha(content, sha1),
+      uid: extractAssetUid(content),
+    });
+  }
+
+  const added: AssetChange[] = [];
+  const modified: AssetChange[] = [];
+  const deleted: AssetChange[] = [];
+
+  const baseByUid = new Map<string, WatermarkFileEntry>();
+  const baseNoUid: WatermarkFileEntry[] = [];
+  for (const entry of watermark.files) {
+    if (entry.uid !== undefined) baseByUid.set(entry.uid, entry);
+    else baseNoUid.push(entry);
+  }
+
+  // Pass 1 — uid identity (D18).
+  const diskLeftover: DiskEntry[] = [];
+  const baseMatchedUids = new Set<string>();
+  for (const d of disk) {
+    const base = d.uid !== undefined ? baseByUid.get(d.uid) : undefined;
+    if (d.uid !== undefined && base !== undefined) {
+      baseMatchedUids.add(d.uid);
+      if (base.blobSha !== d.blobSha || base.path !== d.path) {
+        modified.push({
+          path: d.path,
+          uid: d.uid,
+          blobSha: d.blobSha,
+          ...(base.path !== d.path ? { basePath: base.path } : {}),
+        });
+      }
+    } else {
+      diskLeftover.push(d);
+    }
+  }
+
+  // Pass 2 — path identity for leftovers (uid-less files; in-place uid edits).
+  const baseLeftover = new Map<string, WatermarkFileEntry>();
+  for (const entry of baseNoUid) baseLeftover.set(entry.path, entry);
+  for (const [uid, entry] of baseByUid) {
+    if (!baseMatchedUids.has(uid)) baseLeftover.set(entry.path, entry);
+  }
+  for (const d of diskLeftover) {
+    const base = baseLeftover.get(d.path);
+    if (base !== undefined) {
+      baseLeftover.delete(d.path);
+      if (base.blobSha !== d.blobSha) {
+        modified.push({ path: d.path, uid: d.uid, blobSha: d.blobSha });
+      }
+    } else {
+      added.push({ path: d.path, uid: d.uid, blobSha: d.blobSha });
+    }
+  }
+
+  // Remaining base entries have no uid match and no path match → deleted.
+  for (const base of baseLeftover.values()) {
+    deleted.push({ path: base.path, uid: base.uid, blobSha: base.blobSha });
+  }
+
+  return { kind: "changes", added, modified, deleted };
+}

--- a/packages/exocortex/src/services/sync/SyncEngine.ts
+++ b/packages/exocortex/src/services/sync/SyncEngine.ts
@@ -68,6 +68,23 @@ export interface SyncEngineDeps {
   /** Cap on 422 re-pull→retry cycles (D16). Default {@link DEFAULT_MAX_PUSH_RETRIES}. */
   maxPushRetries?: number;
   commitMessage?: (spec: SyncRepoSpec, fileCount: number) => string;
+  /**
+   * Defence-in-depth PAT redactor applied to error details/warnings and
+   * forwarded to `restCreateCommit` (parity with the plugin's createCommit
+   * path). Both production transports already redact their own error
+   * strings; defaults to identity.
+   */
+  redact?: (message: string) => string;
+}
+
+/** Reject absolute, backslash, empty-segment, `.`/`..` paths (zip-slip guard). */
+function isSafeRepoRelativePath(path: string): boolean {
+  if (path.length === 0 || path.startsWith("/") || path.includes("\\")) {
+    return false;
+  }
+  return path
+    .split("/")
+    .every((s) => s.length > 0 && s !== "." && s !== "..");
 }
 
 /**
@@ -231,6 +248,10 @@ export class SyncEngine {
         );
       }
       for (const d of detection.deleted) {
+        // Known cosmetic: a CONVERGENT delete (remote deleted it too) is
+        // consumed later in matchLocalVsRemote but still reported here as
+        // deferred for this cycle; the watermark drops it, so it self-heals
+        // on the next sync.
         deferredDeletes.push(d.path);
         warnings.push(
           `deferred delete: ${d.path} not pushed (write primitive cannot delete; merge layer A2/A3)`,
@@ -307,6 +328,7 @@ export class SyncEngine {
               this.deps.commitMessage?.(spec, pushFiles.size) ??
               `chore(exosync): sync ${pushFiles.size} file(s)`,
             baseURL: this.deps.baseURL,
+            redact: this.deps.redact,
           });
           break;
         } catch (err) {
@@ -341,6 +363,20 @@ export class SyncEngine {
           pushFiles,
           warnings,
         );
+        // Do NOT absorb the concurrent commit into the watermark: its changes
+        // were never examined nor written to disk, and a watermark built from
+        // the new head tree would make the stale local copies look like local
+        // edits on the NEXT sync — a silent revert of the concurrent change.
+        // Keeping the old watermark is safe: the next sync re-pulls the
+        // concurrent change and drops our own pushed files as convergent
+        // edits.
+        warnings.push(
+          `race-window: watermark NOT advanced (pushed commit's parent ${newCommit.parents[0]} != examined head ${examinedHead}) — next sync reconciles the concurrent change`,
+        );
+        return result("synced", {
+          pushedSha,
+          pushedCount: pushFiles.size,
+        });
       }
 
       // Apply remote changes to disk AFTER the push succeeded — a failed push
@@ -349,10 +385,18 @@ export class SyncEngine {
       let pulledCount = 0;
       for (const w of applyWrites) {
         if (w.content === undefined) continue; // change entries always carry content
+        if (!isSafeRepoRelativePath(w.path)) {
+          warnings.push(`unsafe remote path skipped on pull-apply: ${w.path}`);
+          continue;
+        }
         await localFiles.write(w.path, w.content);
         pulledCount++;
       }
       for (const d of applyDeletes) {
+        if (!isSafeRepoRelativePath(d.path)) {
+          warnings.push(`unsafe remote path skipped on pull-delete: ${d.path}`);
+          continue;
+        }
         if (disk.has(d.path)) {
           await localFiles.delete(d.path);
           pulledCount++;
@@ -387,8 +431,9 @@ export class SyncEngine {
         pushedCount: pushFiles.size,
       });
     } catch (err) {
-      warnings.push(`sync failed: ${errMsg(err)}`);
-      return result("error", { detail: errMsg(err) });
+      const redact = this.deps.redact ?? ((m: string): string => m);
+      warnings.push(`sync failed: ${redact(errMsg(err))}`);
+      return result("error", { detail: redact(errMsg(err)) });
     }
   }
 
@@ -653,7 +698,8 @@ export class SyncEngine {
         }
       }
     } catch (err) {
-      warnings.push(`race-window check failed: ${errMsg(err)}`);
+      const redact = this.deps.redact ?? ((m: string): string => m);
+      warnings.push(`race-window check failed: ${redact(errMsg(err))}`);
     }
   }
 

--- a/packages/exocortex/src/services/sync/SyncEngine.ts
+++ b/packages/exocortex/src/services/sync/SyncEngine.ts
@@ -1,0 +1,713 @@
+/**
+ * ExoSync SyncEngine — push-only happy-path orchestrator (RFC 4e4dc453, A1).
+ *
+ * Per-repo cycle (VL#7): pull → no-conflict check → push, orchestrating the
+ * EXISTING write primitive `restCreateCommit` (D3 — no new write path, no
+ * modification of the primitive). What A1 deliberately does NOT do:
+ *
+ *  - NO merge. Any overlap between local and remote changes (same uid or same
+ *    path, including delete-vs-modify) returns `conflict` and touches nothing
+ *    — the StructuredMerger (A2) and quarantine (A3) own that territory.
+ *  - NO pushed deletions/renames. The write primitive's `files` map cannot
+ *    express deletions; local deletes and renames are reported as
+ *    `deferredDeletes` warnings and re-surface every sync until A2/A3 land.
+ *  - NO binary content. Only {@link isSyncablePath} files participate,
+ *    symmetrically (local snapshot, remote diff, pull-apply, delete
+ *    inference) — attachments are Phase C (D4/VL#3).
+ *
+ * Convergence without CAS (D9/D16): the primitive has no expected-head
+ * parameter; a concurrent push surfaces as HTTP 422 on the final PATCH
+ * (`force:false` non-fast-forward) and is handled by re-pull → re-check →
+ * retry, capped at {@link DEFAULT_MAX_PUSH_RETRIES}. The residual window
+ * between this engine's conflict check and the primitive's internal fresh
+ * GET-ref is detected post-push (parent != examined head) and reported as a
+ * `race-window` warning when it overlaps pushed paths.
+ *
+ * Ordering & isolation (D12): `syncAll` is best-effort per repo —
+ * warn-not-block, one failing repo never blocks the rest; callers supply
+ * children-before-parent order (or use {@link orderChildrenFirst}).
+ */
+
+import {
+  restCreateCommit,
+  type RestCommitTransport,
+} from "../../infrastructure/github/restCommit";
+import {
+  getBlobText,
+  getCommitInfo,
+  getHeadSha,
+  getTree,
+  type RemoteTreeEntry,
+} from "./githubRepoReader";
+import { detectChanges, extractAssetUid } from "./ChangeDetector";
+import { gitBlobSha } from "./gitBlobSha";
+import {
+  isSyncablePath,
+  type AssetChange,
+  type LocalFilesPort,
+  type MaterializationCheckPort,
+  type RepoSyncResult,
+  type Sha1Fn,
+  type SyncRepoSpec,
+  type WatermarkFileEntry,
+  type WatermarkRecord,
+  type WatermarkStorePort,
+} from "./syncTypes";
+
+/** D16: retries after the first non-fast-forward failure. */
+export const DEFAULT_MAX_PUSH_RETRIES = 3;
+
+export interface SyncEngineDeps {
+  transport: RestCommitTransport;
+  watermarkStore: WatermarkStorePort;
+  materializationCheck: MaterializationCheckPort;
+  /** Working-tree access for one repo of the materialized set. */
+  localFilesFor: (spec: SyncRepoSpec) => LocalFilesPort;
+  sha1: Sha1Fn;
+  baseURL?: string;
+  /** Cap on 422 re-pull→retry cycles (D16). Default {@link DEFAULT_MAX_PUSH_RETRIES}. */
+  maxPushRetries?: number;
+  commitMessage?: (spec: SyncRepoSpec, fileCount: number) => string;
+}
+
+/**
+ * Non-fast-forward detection. Both production transports (plugin
+ * `GitHubRestClient`, CLI `RestPushService`) throw HTTP errors with the
+ * message shape `GitHub request {METHOD} {url} → HTTP {status}: {body}` —
+ * an informal contract this matcher depends on (kept loose on purpose).
+ * The structural `ref update mismatch` error from the primitive (PATCH
+ * succeeded but the ref moved elsewhere) is treated as retryable too.
+ */
+export function isNonFastForwardError(err: unknown): boolean {
+  const msg = err instanceof Error ? err.message : String(err);
+  return (
+    (/HTTP 422/.test(msg) && /git\/refs/.test(msg)) ||
+    /ref update mismatch/.test(msg)
+  );
+}
+
+/** Sort children before parents (D12): deeper localPath syncs first. */
+export function orderChildrenFirst(specs: SyncRepoSpec[]): SyncRepoSpec[] {
+  const depth = (p: string): number =>
+    p.split("/").filter((s) => s.length > 0).length;
+  return [...specs].sort((a, b) => depth(b.localPath) - depth(a.localPath));
+}
+
+/** Remote change derived from the base..head tree diff. */
+interface RemoteChange {
+  path: string;
+  kind: "change" | "delete";
+  /** For `change`: blob SHA + fetched content + parsed uid. */
+  blobSha?: string;
+  content?: string;
+  uid?: string;
+}
+
+function diffTrees(
+  base: WatermarkFileEntry[],
+  head: RemoteTreeEntry[],
+): { changed: RemoteTreeEntry[]; deleted: WatermarkFileEntry[] } {
+  const baseByPath = new Map(base.map((e) => [e.path, e]));
+  const headPaths = new Set<string>();
+  const changed: RemoteTreeEntry[] = [];
+  for (const h of head) {
+    headPaths.add(h.path);
+    const b = baseByPath.get(h.path);
+    if (b === undefined || b.blobSha !== h.blobSha) changed.push(h);
+  }
+  const deleted = base.filter((b) => !headPaths.has(b.path));
+  return { changed, deleted };
+}
+
+function errMsg(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+export class SyncEngine {
+  private readonly deps: SyncEngineDeps;
+
+  constructor(deps: SyncEngineDeps) {
+    this.deps = deps;
+  }
+
+  /**
+   * Sync every repo of the materialized set, best-effort (D12): a per-repo
+   * failure becomes that repo's `error` result, never an exception. Specs are
+   * processed in the given order — pass children before parents (use
+   * {@link orderChildrenFirst}).
+   */
+  async syncAll(specs: SyncRepoSpec[]): Promise<RepoSyncResult[]> {
+    const results: RepoSyncResult[] = [];
+    for (const spec of specs) {
+      results.push(await this.sync(spec));
+    }
+    return results;
+  }
+
+  /** Sync one repo. Never throws — failures map to a result status (CQ5). */
+  async sync(spec: SyncRepoSpec): Promise<RepoSyncResult> {
+    const warnings: string[] = [];
+    const deferredDeletes: string[] = [];
+    const result = (
+      status: RepoSyncResult["status"],
+      extra: Partial<RepoSyncResult> = {},
+    ): RepoSyncResult => ({
+      repoKey: spec.repoKey,
+      status,
+      pulledCount: 0,
+      pushedCount: 0,
+      warnings,
+      deferredDeletes,
+      ...extra,
+    });
+
+    try {
+      // D19 — full-materialization gate. Skipped repo: no diff, no push, and
+      // critically NO delete inference from local absence.
+      const gate = await this.deps.materializationCheck.check(spec);
+      if (!gate.fullyMaterialized) {
+        warnings.push(
+          `skipped: repo not fully materialized${gate.reason ? ` (${gate.reason})` : ""} — deletes NOT inferred (D19)`,
+        );
+        return result("skipped-not-materialized");
+      }
+
+      const localFiles = this.deps.localFilesFor(spec);
+      const disk = new Map<string, string>();
+      for (const path of (await localFiles.list()).filter(isSyncablePath)) {
+        disk.set(path, await localFiles.read(path));
+      }
+
+      const watermark = await this.deps.watermarkStore.get(spec.repoKey);
+      if (watermark === null) {
+        return await this.bootstrapWatermark(spec, disk, warnings, result);
+      }
+
+      // D22 — resolve the ACTUAL base tree on the remote; never trust the
+      // stored watermark blindly (R10).
+      let actualBaseTreeSha: string | null;
+      try {
+        actualBaseTreeSha = (
+          await getCommitInfo(
+            this.deps.transport,
+            spec.owner,
+            spec.repo,
+            watermark.lastSyncedSha,
+            this.deps.baseURL,
+          )
+        ).treeSha;
+      } catch {
+        actualBaseTreeSha = null;
+      }
+
+      const detection = await detectChanges({
+        localFiles: disk,
+        watermark,
+        actualBaseTreeSha,
+        sha1: this.deps.sha1,
+      });
+      if (detection.kind === "full-conflict") {
+        return result("full-conflict", {
+          detail: `${detection.reason}${detection.detail ? `: ${detection.detail}` : ""} — divergence must go through merge/quarantine (A2/A3), not overwrite`,
+        });
+      }
+
+      // Pin the local change-set for the whole retry loop (recomputing
+      // mid-retry would misclassify just-applied remote files as local edits).
+      const renames = detection.modified.filter(
+        (c) => c.basePath !== undefined,
+      );
+      const pushable = [
+        ...detection.added,
+        ...detection.modified.filter((c) => c.basePath === undefined),
+      ];
+      for (const r of renames) {
+        // Pushing the new path while the primitive cannot delete the old one
+        // would leave two files with the same uid on the remote — defer the
+        // whole rename pair to the merge layer.
+        if (r.basePath !== undefined) deferredDeletes.push(r.basePath);
+        warnings.push(
+          `deferred rename (uid ${r.uid ?? "?"}): ${r.basePath} → ${r.path} not pushed (write primitive cannot delete; merge layer A2/A3)`,
+        );
+      }
+      for (const d of detection.deleted) {
+        deferredDeletes.push(d.path);
+        warnings.push(
+          `deferred delete: ${d.path} not pushed (write primitive cannot delete; merge layer A2/A3)`,
+        );
+      }
+      const localChanges: AssetChange[] = [
+        ...pushable,
+        ...renames,
+        ...detection.deleted.map((d) => ({ ...d })),
+      ];
+      const localDeletedPaths = new Set(detection.deleted.map((d) => d.path));
+      const pushFilesAll = new Map<string, string>();
+      for (const c of pushable) {
+        const content = disk.get(c.path);
+        if (content !== undefined) pushFilesAll.set(c.path, content);
+      }
+
+      // Pull → no-conflict check → push, with the D16 422 retry loop.
+      const maxRetries =
+        this.deps.maxPushRetries ?? DEFAULT_MAX_PUSH_RETRIES;
+      let attempt = 0;
+      let examinedHead = "";
+      let pushedSha: string | undefined;
+      let applyWrites: RemoteChange[] = [];
+      let applyDeletes: RemoteChange[] = [];
+      let pushFiles = new Map<string, string>();
+
+      for (;;) {
+        examinedHead = await getHeadSha(
+          this.deps.transport,
+          spec.owner,
+          spec.repo,
+          spec.branch,
+          this.deps.baseURL,
+        );
+        applyWrites = [];
+        applyDeletes = [];
+        const convergedPushPaths = new Set<string>();
+
+        if (examinedHead !== watermark.lastSyncedSha) {
+          const remote = await this.collectRemoteChanges(
+            spec,
+            watermark,
+            examinedHead,
+          );
+          const verdict = this.matchLocalVsRemote(
+            localChanges,
+            localDeletedPaths,
+            disk,
+            remote,
+            convergedPushPaths,
+          );
+          if (verdict.conflict !== undefined) {
+            return result("conflict", {
+              detail: `overlapping change on ${verdict.conflict} — merge layer (A2/A3) required; nothing pushed, nothing written`,
+            });
+          }
+          applyWrites = verdict.applyWrites;
+          applyDeletes = verdict.applyDeletes;
+        }
+
+        pushFiles = new Map(
+          [...pushFilesAll].filter(([p]) => !convergedPushPaths.has(p)),
+        );
+        if (pushFiles.size === 0) break;
+
+        try {
+          pushedSha = await restCreateCommit(this.deps.transport, {
+            owner: spec.owner,
+            repo: spec.repo,
+            branch: spec.branch,
+            files: pushFiles,
+            message:
+              this.deps.commitMessage?.(spec, pushFiles.size) ??
+              `chore(exosync): sync ${pushFiles.size} file(s)`,
+            baseURL: this.deps.baseURL,
+          });
+          break;
+        } catch (err) {
+          if (!isNonFastForwardError(err)) throw err;
+          attempt++;
+          if (attempt > maxRetries) {
+            return result("retry-exhausted", {
+              detail: `non-fast-forward push failed after ${maxRetries} retries (D16 cap) — quarantine convergence is A3 scope`,
+            });
+          }
+          warnings.push(
+            `non-fast-forward push (attempt ${attempt}/${maxRetries}) — re-pulling and retrying (D16)`,
+          );
+        }
+      }
+
+      const newHead = pushedSha ?? examinedHead;
+      const newCommit = await getCommitInfo(
+        this.deps.transport,
+        spec.owner,
+        spec.repo,
+        newHead,
+        this.deps.baseURL,
+      );
+
+      if (pushedSha !== undefined && newCommit.parents[0] !== examinedHead) {
+        await this.checkRaceWindow(
+          spec,
+          watermark,
+          examinedHead,
+          newCommit.parents[0],
+          pushFiles,
+          warnings,
+        );
+      }
+
+      // Apply remote changes to disk AFTER the push succeeded — a failed push
+      // must leave the working tree pristine, or the next run misclassifies
+      // remote content as local edits.
+      let pulledCount = 0;
+      for (const w of applyWrites) {
+        if (w.content === undefined) continue; // change entries always carry content
+        await localFiles.write(w.path, w.content);
+        pulledCount++;
+      }
+      for (const d of applyDeletes) {
+        if (disk.has(d.path)) {
+          await localFiles.delete(d.path);
+          pulledCount++;
+        }
+      }
+
+      const newTree = (
+        await getTree(
+          this.deps.transport,
+          spec.owner,
+          spec.repo,
+          newCommit.treeSha,
+          this.deps.baseURL,
+        )
+      ).filter((e) => isSyncablePath(e.path));
+      const newRecord: WatermarkRecord = {
+        lastSyncedSha: newHead,
+        rootTreeSha: newCommit.treeSha,
+        files: await this.buildWatermarkFiles(
+          spec,
+          newTree,
+          disk,
+          applyWrites,
+          watermark,
+        ),
+      };
+      await this.deps.watermarkStore.set(spec.repoKey, newRecord);
+
+      return result("synced", {
+        pushedSha,
+        pulledCount,
+        pushedCount: pushFiles.size,
+      });
+    } catch (err) {
+      warnings.push(`sync failed: ${errMsg(err)}`);
+      return result("error", { detail: errMsg(err) });
+    }
+  }
+
+  /**
+   * First-sync bootstrap (safe subset): when no watermark exists but the
+   * local working tree EXACTLY equals the remote head tree (fresh mount), the
+   * watermark is seeded and the sync is a no-op. Any difference is a genuine
+   * first-sync divergence → full-conflict (A2/A3, D22).
+   */
+  private async bootstrapWatermark(
+    spec: SyncRepoSpec,
+    disk: Map<string, string>,
+    warnings: string[],
+    result: (
+      status: RepoSyncResult["status"],
+      extra?: Partial<RepoSyncResult>,
+    ) => RepoSyncResult,
+  ): Promise<RepoSyncResult> {
+    const head = await getHeadSha(
+      this.deps.transport,
+      spec.owner,
+      spec.repo,
+      spec.branch,
+      this.deps.baseURL,
+    );
+    const headCommit = await getCommitInfo(
+      this.deps.transport,
+      spec.owner,
+      spec.repo,
+      head,
+      this.deps.baseURL,
+    );
+    const headTree = (
+      await getTree(
+        this.deps.transport,
+        spec.owner,
+        spec.repo,
+        headCommit.treeSha,
+        this.deps.baseURL,
+      )
+    ).filter((e) => isSyncablePath(e.path));
+
+    if (headTree.length !== disk.size) {
+      return result("full-conflict", {
+        detail: `first-sync: no watermark and local tree (${disk.size} files) differs from remote head (${headTree.length} files) — A2/A3 scope`,
+      });
+    }
+    for (const entry of headTree) {
+      const content = disk.get(entry.path);
+      if (
+        content === undefined ||
+        (await gitBlobSha(content, this.deps.sha1)) !== entry.blobSha
+      ) {
+        return result("full-conflict", {
+          detail: `first-sync: no watermark and local content diverges from remote head at ${entry.path} — A2/A3 scope`,
+        });
+      }
+    }
+
+    const files: WatermarkFileEntry[] = headTree.map((e) => {
+      const content = disk.get(e.path);
+      const uid = content !== undefined ? extractAssetUid(content) : undefined;
+      return { path: e.path, blobSha: e.blobSha, ...(uid ? { uid } : {}) };
+    });
+    await this.deps.watermarkStore.set(spec.repoKey, {
+      lastSyncedSha: head,
+      rootTreeSha: headCommit.treeSha,
+      files,
+    });
+    warnings.push(
+      `watermark bootstrapped from head ${head} (local tree identical to remote)`,
+    );
+    return result("synced");
+  }
+
+  /** Fetch base..head remote changes with contents + uids. */
+  private async collectRemoteChanges(
+    spec: SyncRepoSpec,
+    watermark: WatermarkRecord,
+    head: string,
+  ): Promise<RemoteChange[]> {
+    const headCommit = await getCommitInfo(
+      this.deps.transport,
+      spec.owner,
+      spec.repo,
+      head,
+      this.deps.baseURL,
+    );
+    const headTree = (
+      await getTree(
+        this.deps.transport,
+        spec.owner,
+        spec.repo,
+        headCommit.treeSha,
+        this.deps.baseURL,
+      )
+    ).filter((e) => isSyncablePath(e.path));
+    const { changed, deleted } = diffTrees(watermark.files, headTree);
+
+    const changes: RemoteChange[] = [];
+    for (const c of changed) {
+      const content = await getBlobText(
+        this.deps.transport,
+        spec.owner,
+        spec.repo,
+        c.blobSha,
+        this.deps.baseURL,
+      );
+      changes.push({
+        path: c.path,
+        kind: "change",
+        blobSha: c.blobSha,
+        content,
+        uid: extractAssetUid(content),
+      });
+    }
+    for (const d of deleted) {
+      changes.push({ path: d.path, kind: "delete", uid: d.uid });
+    }
+    return changes;
+  }
+
+  /**
+   * No-conflict check (push-only happy path): any shared identity — same uid,
+   * or same path — between pinned local changes and remote changes is a
+   * conflict, EXCEPT convergent edits (identical blob both sides) and
+   * convergent deletes, which are dropped from the push/apply sets.
+   */
+  private matchLocalVsRemote(
+    localChanges: AssetChange[],
+    localDeletedPaths: Set<string>,
+    disk: Map<string, string>,
+    remote: RemoteChange[],
+    convergedPushPaths: Set<string>,
+  ): {
+    conflict?: string;
+    applyWrites: RemoteChange[];
+    applyDeletes: RemoteChange[];
+  } {
+    const consumed = new Set<RemoteChange>();
+    const remoteByUid = new Map<string, RemoteChange[]>();
+    const remoteByPath = new Map<string, RemoteChange>();
+    for (const r of remote) {
+      if (r.uid !== undefined) {
+        const list = remoteByUid.get(r.uid) ?? [];
+        list.push(r);
+        remoteByUid.set(r.uid, list);
+      }
+      remoteByPath.set(r.path, r);
+    }
+
+    for (const local of localChanges) {
+      const candidates = new Set<RemoteChange>();
+      if (local.uid !== undefined) {
+        for (const r of remoteByUid.get(local.uid) ?? []) candidates.add(r);
+      }
+      const byPath = remoteByPath.get(local.path);
+      if (byPath !== undefined) candidates.add(byPath);
+      if (local.basePath !== undefined) {
+        const byBasePath = remoteByPath.get(local.basePath);
+        if (byBasePath !== undefined) candidates.add(byBasePath);
+      }
+
+      for (const r of candidates) {
+        const localIsDelete = localDeletedPaths.has(local.path) && !disk.has(local.path);
+        if (localIsDelete && r.kind === "delete") {
+          consumed.add(r); // convergent delete — already gone on both sides
+          continue;
+        }
+        if (
+          !localIsDelete &&
+          r.kind === "change" &&
+          r.path === local.path &&
+          r.blobSha === local.blobSha
+        ) {
+          // Convergent edit: identical content already on remote — drop from
+          // push, drop from apply.
+          consumed.add(r);
+          convergedPushPaths.add(local.path);
+          continue;
+        }
+        return {
+          conflict: `${local.uid ?? local.path} (local ${localIsDelete ? "delete" : "change"} vs remote ${r.kind} at ${r.path})`,
+          applyWrites: [],
+          applyDeletes: [],
+        };
+      }
+    }
+
+    const remaining = remote.filter((r) => !consumed.has(r));
+    return {
+      applyWrites: remaining.filter((r) => r.kind === "change"),
+      applyDeletes: remaining.filter((r) => r.kind === "delete"),
+    };
+  }
+
+  /**
+   * Post-push race-window detection (the primitive has no CAS, D9): if the
+   * pushed commit's parent is not the head this engine examined, a concurrent
+   * commit slipped between the conflict check and the primitive's internal
+   * fresh GET-ref. Only an overlap with pushed paths is a potential lost
+   * update — warn per file (recoverable from git history).
+   */
+  private async checkRaceWindow(
+    spec: SyncRepoSpec,
+    watermark: WatermarkRecord,
+    examinedHead: string,
+    actualParent: string,
+    pushFiles: Map<string, string>,
+    warnings: string[],
+  ): Promise<void> {
+    try {
+      const parentCommit = await getCommitInfo(
+        this.deps.transport,
+        spec.owner,
+        spec.repo,
+        actualParent,
+        this.deps.baseURL,
+      );
+      const parentTree = (
+        await getTree(
+          this.deps.transport,
+          spec.owner,
+          spec.repo,
+          parentCommit.treeSha,
+          this.deps.baseURL,
+        )
+      ).filter((e) => isSyncablePath(e.path));
+      const examinedFiles: WatermarkFileEntry[] =
+        examinedHead === watermark.lastSyncedSha
+          ? watermark.files
+          : (
+              await getTree(
+                this.deps.transport,
+                spec.owner,
+                spec.repo,
+                (
+                  await getCommitInfo(
+                    this.deps.transport,
+                    spec.owner,
+                    spec.repo,
+                    examinedHead,
+                    this.deps.baseURL,
+                  )
+                ).treeSha,
+                this.deps.baseURL,
+              )
+            ).filter((e) => isSyncablePath(e.path));
+      const { changed, deleted } = diffTrees(examinedFiles, parentTree);
+      for (const c of changed) {
+        if (pushFiles.has(c.path)) {
+          warnings.push(
+            `race-window: concurrent commit ${actualParent} changed ${c.path} between conflict check (head ${examinedHead}) and push — local version won; previous version recoverable from git history`,
+          );
+        }
+      }
+      for (const d of deleted) {
+        if (pushFiles.has(d.path)) {
+          warnings.push(
+            `race-window: concurrent commit ${actualParent} deleted ${d.path}; push re-created it`,
+          );
+        }
+      }
+    } catch (err) {
+      warnings.push(`race-window check failed: ${errMsg(err)}`);
+    }
+  }
+
+  /**
+   * Build the watermark snapshot for the new head tree, resolving uids from
+   * already-known contents (disk, just-pulled remote blobs, previous
+   * watermark) and fetching the rare unknown blob.
+   */
+  private async buildWatermarkFiles(
+    spec: SyncRepoSpec,
+    newTree: RemoteTreeEntry[],
+    disk: Map<string, string>,
+    applied: RemoteChange[],
+    previous: WatermarkRecord,
+  ): Promise<WatermarkFileEntry[]> {
+    const uidByBlobSha = new Map<string, string | undefined>();
+    for (const r of applied) {
+      if (r.kind === "change" && r.blobSha !== undefined) {
+        uidByBlobSha.set(r.blobSha, r.uid);
+      }
+    }
+    for (const content of disk.values()) {
+      uidByBlobSha.set(
+        await gitBlobSha(content, this.deps.sha1),
+        extractAssetUid(content),
+      );
+    }
+    for (const prev of previous.files) {
+      if (!uidByBlobSha.has(prev.blobSha)) {
+        uidByBlobSha.set(prev.blobSha, prev.uid);
+      }
+    }
+
+    const files: WatermarkFileEntry[] = [];
+    for (const entry of newTree) {
+      let uid: string | undefined;
+      if (uidByBlobSha.has(entry.blobSha)) {
+        uid = uidByBlobSha.get(entry.blobSha);
+      } else {
+        const content = await getBlobText(
+          this.deps.transport,
+          spec.owner,
+          spec.repo,
+          entry.blobSha,
+          this.deps.baseURL,
+        );
+        uid = extractAssetUid(content);
+      }
+      files.push({
+        path: entry.path,
+        blobSha: entry.blobSha,
+        ...(uid ? { uid } : {}),
+      });
+    }
+    return files;
+  }
+}

--- a/packages/exocortex/src/services/sync/gitBlobSha.ts
+++ b/packages/exocortex/src/services/sync/gitBlobSha.ts
@@ -1,0 +1,23 @@
+/**
+ * Git blob SHA computation over an injected SHA-1 (ExoSync A1, D8/D22).
+ *
+ * Git addresses a blob as `sha1("blob <byte-length>\0" + content)`. Computing
+ * this locally lets the ChangeDetector compare disk files against remote tree
+ * entries WITHOUT a git binary — the same content-addressing GitHub reports in
+ * `GET git/trees`.
+ */
+
+import type { Sha1Fn } from "./syncTypes";
+
+export async function gitBlobSha(
+  content: string,
+  sha1: Sha1Fn,
+): Promise<string> {
+  const encoder = new TextEncoder();
+  const body = encoder.encode(content);
+  const header = encoder.encode(`blob ${body.byteLength}\0`);
+  const framed = new Uint8Array(header.byteLength + body.byteLength);
+  framed.set(header, 0);
+  framed.set(body, header.byteLength);
+  return sha1(framed);
+}

--- a/packages/exocortex/src/services/sync/githubRepoReader.ts
+++ b/packages/exocortex/src/services/sync/githubRepoReader.ts
@@ -1,0 +1,148 @@
+/**
+ * Read-side GitHub Git Data API helpers (ExoSync A1).
+ *
+ * Reuses the SAME injected `RestCommitTransport` contract as the existing
+ * write primitive `restCreateCommit` (D3) — transport throws on any non-2xx,
+ * only `json` is consumed. No new port is introduced (D3: no SyncTransport
+ * abstraction for MVP).
+ */
+
+import type { RestCommitTransport } from "../../infrastructure/github/restCommit";
+
+export interface RemoteTreeEntry {
+  path: string;
+  blobSha: string;
+}
+
+export interface RemoteCommitInfo {
+  sha: string;
+  treeSha: string;
+  parents: string[];
+}
+
+const DEFAULT_BASE_URL = "https://api.github.com";
+
+function api(baseURL: string | undefined): string {
+  return (baseURL ?? DEFAULT_BASE_URL).replace(/\/$/, "");
+}
+
+function asRecord(v: unknown): Record<string, unknown> | undefined {
+  return v !== null && typeof v === "object"
+    ? (v as Record<string, unknown>)
+    : undefined;
+}
+
+function readString(obj: unknown, key: string): string | undefined {
+  const rec = asRecord(obj);
+  const v = rec?.[key];
+  return typeof v === "string" ? v : undefined;
+}
+
+/** GET git/refs/heads/{branch} → current head commit SHA. */
+export async function getHeadSha(
+  transport: RestCommitTransport,
+  owner: string,
+  repo: string,
+  branch: string,
+  baseURL?: string,
+): Promise<string> {
+  const resp = await transport({
+    method: "GET",
+    url: `${api(baseURL)}/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/git/refs/heads/${encodeURIComponent(branch)}`,
+  });
+  const sha = readString(asRecord(resp?.json)?.object, "sha");
+  if (typeof sha !== "string" || sha.length === 0) {
+    throw new Error(`ExoSync: missing object.sha for ref heads/${branch}`);
+  }
+  return sha;
+}
+
+/** GET git/commits/{sha} → tree SHA + parents (race check + D22 validation). */
+export async function getCommitInfo(
+  transport: RestCommitTransport,
+  owner: string,
+  repo: string,
+  commitSha: string,
+  baseURL?: string,
+): Promise<RemoteCommitInfo> {
+  const resp = await transport({
+    method: "GET",
+    url: `${api(baseURL)}/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/git/commits/${encodeURIComponent(commitSha)}`,
+  });
+  const json = asRecord(resp?.json);
+  const sha = readString(json, "sha");
+  const treeSha = readString(json?.tree, "sha");
+  if (!sha || !treeSha) {
+    throw new Error(`ExoSync: malformed commit response for ${commitSha}`);
+  }
+  const parentsRaw = json?.parents;
+  const parents: string[] = Array.isArray(parentsRaw)
+    ? parentsRaw
+        .map((p) => readString(p, "sha"))
+        .filter((s): s is string => typeof s === "string")
+    : [];
+  return { sha, treeSha, parents };
+}
+
+/**
+ * GET git/trees/{treeSha}?recursive=1 → blob entries (path + sha).
+ *
+ * Fails LOUD on `truncated: true` (GitHub truncates past ~100k entries /
+ * 7 MB) — a truncated tree would produce wrong diffs and phantom deletes, so
+ * the caller must skip the repo with a warning instead.
+ */
+export async function getTree(
+  transport: RestCommitTransport,
+  owner: string,
+  repo: string,
+  treeSha: string,
+  baseURL?: string,
+): Promise<RemoteTreeEntry[]> {
+  const resp = await transport({
+    method: "GET",
+    url: `${api(baseURL)}/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/git/trees/${encodeURIComponent(treeSha)}?recursive=1`,
+  });
+  const json = asRecord(resp?.json);
+  if (json?.truncated === true) {
+    throw new Error(
+      `ExoSync: tree ${treeSha} is truncated by GitHub (repo too large for recursive listing) — refusing to diff`,
+    );
+  }
+  const treeRaw = json?.tree;
+  if (!Array.isArray(treeRaw)) {
+    throw new Error(`ExoSync: malformed tree response for ${treeSha}`);
+  }
+  const entries: RemoteTreeEntry[] = [];
+  for (const item of treeRaw) {
+    const rec = asRecord(item);
+    if (rec?.type !== "blob") continue;
+    const path = readString(rec, "path");
+    const blobSha = readString(rec, "sha");
+    if (path && blobSha) entries.push({ path, blobSha });
+  }
+  return entries;
+}
+
+/** GET git/blobs/{sha} → UTF-8 text content (base64-decoded). */
+export async function getBlobText(
+  transport: RestCommitTransport,
+  owner: string,
+  repo: string,
+  blobSha: string,
+  baseURL?: string,
+): Promise<string> {
+  const resp = await transport({
+    method: "GET",
+    url: `${api(baseURL)}/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/git/blobs/${encodeURIComponent(blobSha)}`,
+  });
+  const json = asRecord(resp?.json);
+  const content = readString(json, "content");
+  if (typeof content !== "string") {
+    throw new Error(`ExoSync: malformed blob response for ${blobSha}`);
+  }
+  const encoding = readString(json, "encoding");
+  if (encoding === "utf-8") return content;
+  // GitHub returns base64 with embedded newlines. Buffer is the established
+  // base64 path in this package (see GroundingExecutor.decodeBase64Param).
+  return Buffer.from(content.replace(/\s/g, ""), "base64").toString("utf-8");
+}

--- a/packages/exocortex/src/services/sync/syncTypes.ts
+++ b/packages/exocortex/src/services/sync/syncTypes.ts
@@ -1,0 +1,166 @@
+/**
+ * ExoSync A1 — shared types & ports (RFC 4e4dc453, decisions D3/D8/D12/D16/D18/D19/D22).
+ *
+ * Platform-free hexagonal core, following the `restCommit.ts` (injected
+ * transport) and `AssetSpaceMount.ts` (injected FileSystemPort/HttpClient)
+ * precedents. The genuinely platform-specific pieces — how local files hit
+ * disk, where the per-device watermark persists, how SHA-1 is computed — are
+ * injected via the ports below; the sync orchestration itself is platform-free
+ * (iOS-portable, same as the write primitive it reuses).
+ */
+
+/** One repo of the active profile's materialized set (sync unit, D7/VL#4). */
+export interface SyncRepoSpec {
+  owner: string;
+  repo: string;
+  branch: string;
+  /** Stable key for watermark storage (convention: `owner/repo#branch`). */
+  repoKey: string;
+  /**
+   * Local mount path inside the vault/superproject. Used only for
+   * children-before-parent ordering (D12) — deeper paths sync first.
+   */
+  localPath: string;
+}
+
+/** One file of the watermark snapshot (remote tree at lastSyncedSha). */
+export interface WatermarkFileEntry {
+  /** Repo-relative path, forward-slash normalised. */
+  path: string;
+  /** Git blob SHA (as reported by the remote tree). */
+  blobSha: string;
+  /** `exo__Asset_uid` parsed from frontmatter at last sync, if present (D18). */
+  uid?: string;
+}
+
+/**
+ * Per-device, per-repo sync base (D8). Lives in a NON-synced store
+ * (`data.local.json`-style, `.local.`-infix Sync-excluded). The snapshot is the
+ * REMOTE tree at `lastSyncedSha`, scoped to the sync text allowlist — it is the
+ * 3-way base for change detection. It is never trusted blindly: D22 validates
+ * `rootTreeSha` against the actual remote commit before any diff.
+ */
+export interface WatermarkRecord {
+  /** Commit SHA of the last fully-synced state. */
+  lastSyncedSha: string;
+  /** Root tree SHA of that commit — O(1) D22 base validation. */
+  rootTreeSha: string;
+  /** Allowlist-scoped snapshot of the remote tree at `lastSyncedSha`. */
+  files: WatermarkFileEntry[];
+}
+
+/** Per-device watermark persistence port (D8; production impl is A3 scope). */
+export interface WatermarkStorePort {
+  get(repoKey: string): Promise<WatermarkRecord | null>;
+  set(repoKey: string, record: WatermarkRecord): Promise<void>;
+}
+
+/**
+ * Local working-tree access for ONE repo, repo-relative forward-slash paths.
+ * String content only — binary attachments are out of A1 scope (Phase C,
+ * D4/VL#3); the engine additionally applies {@link isSyncablePath} so adapters
+ * may list everything.
+ */
+export interface LocalFilesPort {
+  /** List repo-relative paths of all currently materialized files. */
+  list(): Promise<string[]>;
+  read(path: string): Promise<string>;
+  write(path: string, content: string): Promise<void>;
+  /** Remove a file. MUST be a no-op if the path does not exist. */
+  delete(path: string): Promise<void>;
+}
+
+/** Result of the full-materialization gate check (D19). */
+export interface MaterializationCheck {
+  fullyMaterialized: boolean;
+  reason?: string;
+}
+
+/**
+ * Full-materialization gate (D19). The MOUNT layer owns the knowledge of
+ * whether a repo is 100% materialized (working-tree file-set == manifest,
+ * superproject pointer resolvable); the engine only enforces the semantics:
+ * a non-fully-materialized repo is SKIPPED with a warning and deletes are
+ * NEVER inferred from local absence.
+ */
+export interface MaterializationCheckPort {
+  check(spec: SyncRepoSpec): Promise<MaterializationCheck>;
+}
+
+/**
+ * Injected SHA-1 over raw bytes, hex-encoded lowercase. CLI: `node:crypto`;
+ * plugin: `crypto.subtle.digest("SHA-1", …)`. Used ONLY for git blob-sha
+ * computation (content addressing parity with the remote tree) — not for
+ * security.
+ */
+export type Sha1Fn = (bytes: Uint8Array) => Promise<string>;
+
+/** One locally changed asset, matched by `exo__Asset_uid` where present (D18). */
+export interface AssetChange {
+  /** Current path on disk (for deletions — the base path). */
+  path: string;
+  uid?: string;
+  /** Disk blob SHA for added/modified; base blob SHA for deleted. */
+  blobSha: string;
+  /** For uid-matched renames: the path the asset had in the base snapshot. */
+  basePath?: string;
+}
+
+/** Outcome of {@link detectChanges} (CQ2). */
+export type ChangeDetectionResult =
+  | {
+      kind: "full-conflict";
+      /**
+       * `first-sync`: no watermark exists (D22) — the divergence must go
+       * through the merge/quarantine layer (A2/A3), never silent overwrite.
+       * `base-mismatch`: the stored watermark does not match the actual remote
+       * tree at `lastSyncedSha` (backup-restore, history rewrite, corrupt
+       * store — R10).
+       */
+      reason: "first-sync" | "base-mismatch";
+      detail?: string;
+    }
+  | {
+      kind: "changes";
+      added: AssetChange[];
+      modified: AssetChange[];
+      deleted: AssetChange[];
+    };
+
+/** Per-repo sync outcome (CQ5). `syncAll` never throws — D12 warn-not-block. */
+export interface RepoSyncResult {
+  repoKey: string;
+  status:
+    | "synced"
+    | "skipped-not-materialized"
+    | "full-conflict"
+    | "conflict"
+    | "retry-exhausted"
+    | "error";
+  /** New commit SHA when a push happened. */
+  pushedSha?: string;
+  /** Remote changes applied to local disk (pull phase). */
+  pulledCount: number;
+  /** Files pushed to remote. */
+  pushedCount: number;
+  warnings: string[];
+  /**
+   * Local deletes/renames detected but NOT pushed in A1 (the write primitive
+   * cannot express deletions; propagating them is merge-layer scope, A2/A3).
+   * They re-surface on every sync until that layer lands.
+   */
+  deferredDeletes: string[];
+  detail?: string;
+}
+
+/**
+ * A1 sync text allowlist: only UID-bearing markdown assets participate in
+ * sync. Binary/non-UTF8 content (attachments) is Phase C scope (D4/VL#3) —
+ * reading a binary as a string and pushing/writing it back would silently
+ * corrupt it, so non-allowlisted paths are excluded SYMMETRICALLY: from the
+ * local snapshot, from the remote diff, from pull-apply, and from
+ * delete-inference.
+ */
+export function isSyncablePath(path: string): boolean {
+  return path.endsWith(".md");
+}

--- a/packages/exocortex/tests/integration/sync/syncEngine.real-github.integration.test.ts
+++ b/packages/exocortex/tests/integration/sync/syncEngine.real-github.integration.test.ts
@@ -1,0 +1,314 @@
+/**
+ * ExoSync A1 integration test — SyncEngine against REAL GitHub
+ * (RFC 4e4dc453, AC: "non-conflict цикл pull→push против реального GitHub").
+ *
+ * Talks to the dedicated sandbox repo `kitelev/exosync-test-sandbox` on a
+ * disposable per-run branch (created in beforeAll, deleted in afterAll —
+ * `main` is never touched). Auth: `EXOSYNC_TEST_TOKEN` env var or
+ * `gh auth token`; when neither resolves the suite self-skips so CI and
+ * unauthenticated environments stay green.
+ *
+ * NOT in the CI allowlist (scripts/test-ci-batched.sh) by design: it needs
+ * network + a PAT with write access to the sandbox. Run manually:
+ *
+ *   node ./node_modules/jest/bin/jest.js --config packages/exocortex/jest.config.js \
+ *     --testPathPatterns="integration/sync/" --forceExit
+ */
+
+import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { mkdtempSync, rmSync, mkdirSync, readFileSync, writeFileSync, unlinkSync, readdirSync, statSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, dirname, relative } from "node:path";
+import {
+  SyncEngine,
+  restCreateCommit,
+  getHeadSha,
+  getBlobText,
+  getTree,
+  getCommitInfo,
+  type LocalFilesPort,
+  type RestCommitTransport,
+  type SyncRepoSpec,
+  type WatermarkRecord,
+  type WatermarkStorePort,
+} from "../../../src";
+
+const OWNER = "kitelev";
+const REPO = "exosync-test-sandbox";
+const SOURCE_BRANCH = "main";
+
+function resolveToken(): string | null {
+  if (process.env.EXOSYNC_TEST_TOKEN) return process.env.EXOSYNC_TEST_TOKEN;
+  try {
+    const token = execFileSync("gh", ["auth", "token"], {
+      encoding: "utf8",
+      timeout: 15_000,
+    }).trim();
+    return token.length > 0 ? token : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Same contract as the production transports (throw non-2xx, same message shape). */
+function makeTransport(token: string): RestCommitTransport {
+  return async (req) => {
+    const headers: Record<string, string> = {
+      Accept: "application/vnd.github+json",
+      "X-GitHub-Api-Version": "2022-11-28",
+      "User-Agent": "exosync-a1-integration-test",
+      Authorization: `Bearer ${token}`,
+    };
+    if (req.contentType) headers["Content-Type"] = req.contentType;
+    const resp = await fetch(req.url, {
+      method: req.method,
+      headers,
+      body: req.body,
+      signal: AbortSignal.timeout(60_000),
+    });
+    const text = await resp.text().catch(() => "");
+    if (resp.status < 200 || resp.status >= 300) {
+      throw new Error(
+        `GitHub request ${req.method} ${req.url} → HTTP ${resp.status}: ${text.slice(0, 300)}`,
+      );
+    }
+    return {
+      status: resp.status,
+      json: text.length > 0 ? JSON.parse(text) : undefined,
+      text,
+    };
+  };
+}
+
+const sha1Hex = async (bytes: Uint8Array): Promise<string> =>
+  createHash("sha1").update(bytes).digest("hex");
+
+/** Real-filesystem LocalFilesPort rooted at a temp dir. */
+class FsLocalFiles implements LocalFilesPort {
+  constructor(private readonly root: string) {}
+  async list(): Promise<string[]> {
+    const out: string[] = [];
+    const walk = (dir: string): void => {
+      for (const name of readdirSync(dir)) {
+        const full = join(dir, name);
+        if (statSync(full).isDirectory()) walk(full);
+        else out.push(relative(this.root, full).split("\\").join("/"));
+      }
+    };
+    if (existsSync(this.root)) walk(this.root);
+    return out;
+  }
+  async read(path: string): Promise<string> {
+    return readFileSync(join(this.root, path), "utf8");
+  }
+  async write(path: string, content: string): Promise<void> {
+    const full = join(this.root, path);
+    mkdirSync(dirname(full), { recursive: true });
+    writeFileSync(full, content, "utf8");
+  }
+  async delete(path: string): Promise<void> {
+    const full = join(this.root, path);
+    if (existsSync(full)) unlinkSync(full);
+  }
+}
+
+class MemWatermarks implements WatermarkStorePort {
+  readonly records = new Map<string, WatermarkRecord>();
+  async get(key: string): Promise<WatermarkRecord | null> {
+    return this.records.get(key) ?? null;
+  }
+  async set(key: string, record: WatermarkRecord): Promise<void> {
+    this.records.set(key, record);
+  }
+}
+
+function asset(uid: string, body: string): string {
+  return `---\nexo__Asset_uid: ${uid}\nexo__Asset_label: "Integration asset ${uid}"\n---\n\n${body}\n`;
+}
+
+const token = resolveToken();
+const describeIfToken = token === null ? describe.skip : describe;
+
+describeIfToken("SyncEngine — real GitHub integration (sandbox)", () => {
+  jest.setTimeout(180_000);
+
+  const transport = makeTransport(token ?? "");
+  const branch = `a1-run-${Date.now()}`;
+  const spec: SyncRepoSpec = {
+    owner: OWNER,
+    repo: REPO,
+    branch,
+    repoKey: `${OWNER}/${REPO}#${branch}`,
+    localPath: "assetspaces/sandbox",
+  };
+  const FILE_A = "assets/integration-a.md";
+  const FILE_B = "assets/integration-b.md";
+
+  let tmpRoot: string;
+  let local: FsLocalFiles;
+  let watermarks: MemWatermarks;
+  let engine: SyncEngine;
+
+  beforeAll(async () => {
+    // Disposable branch off main — the test NEVER touches main.
+    const mainSha = await getHeadSha(transport, OWNER, REPO, SOURCE_BRANCH);
+    await transport({
+      method: "POST",
+      url: `https://api.github.com/repos/${OWNER}/${REPO}/git/refs`,
+      contentType: "application/json",
+      body: JSON.stringify({ ref: `refs/heads/${branch}`, sha: mainSha }),
+    });
+
+    // Seed the branch through the SAME production write primitive.
+    await restCreateCommit(transport, {
+      owner: OWNER,
+      repo: REPO,
+      branch,
+      files: new Map([
+        [FILE_A, asset("int-u1", "seed A")],
+        [FILE_B, asset("int-u2", "seed B")],
+      ]),
+      message: "test(exosync-a1): seed integration branch",
+    });
+
+    // Materialize the FULL head tree locally (what a real mount produces) —
+    // the branch also carries main's README.md etc.
+    tmpRoot = mkdtempSync(join(tmpdir(), "exosync-a1-"));
+    local = new FsLocalFiles(tmpRoot);
+    const head = await getHeadSha(transport, OWNER, REPO, branch);
+    const headTree = await getTree(
+      transport,
+      OWNER,
+      REPO,
+      (await getCommitInfo(transport, OWNER, REPO, head)).treeSha,
+    );
+    for (const entry of headTree) {
+      if (!entry.path.endsWith(".md")) continue;
+      await local.write(
+        entry.path,
+        await getBlobText(transport, OWNER, REPO, entry.blobSha),
+      );
+    }
+
+    watermarks = new MemWatermarks();
+    engine = new SyncEngine({
+      transport,
+      watermarkStore: watermarks,
+      materializationCheck: { check: async () => ({ fullyMaterialized: true }) },
+      localFilesFor: () => local,
+      sha1: sha1Hex,
+      commitMessage: (s, n) => `test(exosync-a1): sync ${n} file(s) [${s.repoKey}]`,
+    });
+  });
+
+  afterAll(async () => {
+    try {
+      // Raw fetch: the RestCommitTransport contract is GET/POST/PATCH only.
+      await fetch(
+        `https://api.github.com/repos/${OWNER}/${REPO}/git/refs/heads/${branch}`,
+        {
+          method: "DELETE",
+          headers: {
+            Accept: "application/vnd.github+json",
+            Authorization: `Bearer ${token ?? ""}`,
+            "User-Agent": "exosync-a1-integration-test",
+          },
+        },
+      );
+    } catch {
+      // best-effort cleanup; sandbox branches are disposable by convention
+    }
+    if (tmpRoot) rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  it("bootstraps the watermark from a disk identical to the remote head", async () => {
+    const result = await engine.sync(spec);
+    expect(result.status).toBe("synced");
+    expect(result.pushedCount).toBe(0);
+    expect(watermarks.records.get(spec.repoKey)?.lastSyncedSha).toBe(
+      await getHeadSha(transport, OWNER, REPO, branch),
+    );
+  });
+
+  it("pushes a local edit — the commit lands on the real remote", async () => {
+    const edited = asset("int-u1", "edited locally on device A");
+    await local.write(FILE_A, edited);
+
+    const result = await engine.sync(spec);
+
+    expect(result.status).toBe("synced");
+    expect(result.pushedCount).toBe(1);
+    const head = await getHeadSha(transport, OWNER, REPO, branch);
+    expect(head).toBe(result.pushedSha);
+    const tree = await getTree(
+      transport,
+      OWNER,
+      REPO,
+      (await getCommitInfo(transport, OWNER, REPO, head)).treeSha,
+    );
+    const entry = tree.find((e) => e.path === FILE_A);
+    expect(entry).toBeDefined();
+    expect(await getBlobText(transport, OWNER, REPO, entry?.blobSha ?? "")).toBe(edited);
+  });
+
+  it("pull→push: applies a disjoint device-B change and pushes the local one", async () => {
+    // Device B — direct production-primitive push of a DIFFERENT file.
+    const deviceB = asset("int-u2", "device B edit");
+    await restCreateCommit(transport, {
+      owner: OWNER,
+      repo: REPO,
+      branch,
+      files: new Map([[FILE_B, deviceB]]),
+      message: "test(exosync-a1): device B disjoint edit",
+    });
+
+    const deviceA = asset("int-u1", "device A second edit");
+    await local.write(FILE_A, deviceA);
+
+    const result = await engine.sync(spec);
+
+    expect(result.status).toBe("synced");
+    expect(result.pushedCount).toBe(1);
+    expect(result.pulledCount).toBe(1);
+    expect(await local.read(FILE_B)).toBe(deviceB); // pulled to disk
+    const head = await getHeadSha(transport, OWNER, REPO, branch);
+    const tree = await getTree(
+      transport,
+      OWNER,
+      REPO,
+      (await getCommitInfo(transport, OWNER, REPO, head)).treeSha,
+    );
+    const a = tree.find((e) => e.path === FILE_A);
+    const b = tree.find((e) => e.path === FILE_B);
+    expect(await getBlobText(transport, OWNER, REPO, a?.blobSha ?? "")).toBe(deviceA);
+    expect(await getBlobText(transport, OWNER, REPO, b?.blobSha ?? "")).toBe(deviceB);
+  });
+
+  it("conflict: overlapping edits → nothing pushed, nothing overwritten", async () => {
+    const remoteEdit = asset("int-u1", "device B CONFLICTING edit");
+    await restCreateCommit(transport, {
+      owner: OWNER,
+      repo: REPO,
+      branch,
+      files: new Map([[FILE_A, remoteEdit]]),
+      message: "test(exosync-a1): device B conflicting edit",
+    });
+    const headBefore = await getHeadSha(transport, OWNER, REPO, branch);
+
+    const localEdit = asset("int-u1", "device A CONFLICTING edit");
+    await local.write(FILE_A, localEdit);
+
+    const result = await engine.sync(spec);
+
+    expect(result.status).toBe("conflict");
+    expect(await getHeadSha(transport, OWNER, REPO, branch)).toBe(headBefore); // remote untouched
+    expect(await local.read(FILE_A)).toBe(localEdit); // disk untouched
+  });
+});
+
+if (token === null) {
+  it("integration suite skipped — no GitHub token (EXOSYNC_TEST_TOKEN / gh auth token)", () => {
+    expect(token).toBeNull();
+  });
+}

--- a/packages/exocortex/tests/integration/sync/syncEngine.real-github.integration.test.ts
+++ b/packages/exocortex/tests/integration/sync/syncEngine.real-github.integration.test.ts
@@ -4,14 +4,16 @@
  *
  * Talks to the dedicated sandbox repo `kitelev/exosync-test-sandbox` on a
  * disposable per-run branch (created in beforeAll, deleted in afterAll —
- * `main` is never touched). Auth: `EXOSYNC_TEST_TOKEN` env var or
- * `gh auth token`; when neither resolves the suite self-skips so CI and
- * unauthenticated environments stay green.
+ * `main` is never touched). Auth is OPT-IN: `EXOSYNC_TEST_TOKEN` env var, or
+ * `EXOSYNC_IT=1` to allow the `gh auth token` fallback. Without either the
+ * suite self-skips — so CI, unauthenticated environments AND routine local
+ * `npm run test:all` runs stay green and network-free.
  *
- * NOT in the CI allowlist (scripts/test-ci-batched.sh) by design: it needs
- * network + a PAT with write access to the sandbox. Run manually:
+ * NOT in any CI allowlist by design: it needs network + a PAT with write
+ * access to the sandbox. Run manually:
  *
- *   node ./node_modules/jest/bin/jest.js --config packages/exocortex/jest.config.js \
+ *   EXOSYNC_IT=1 node ./node_modules/jest/bin/jest.js \
+ *     --config packages/exocortex/jest.config.js \
  *     --testPathPatterns="integration/sync/" --forceExit
  */
 
@@ -40,6 +42,10 @@ const SOURCE_BRANCH = "main";
 
 function resolveToken(): string | null {
   if (process.env.EXOSYNC_TEST_TOKEN) return process.env.EXOSYNC_TEST_TOKEN;
+  // The `gh auth token` fallback is OPT-IN (EXOSYNC_IT=1): a routine
+  // `npm run test:all` on a gh-authenticated dev machine must NOT silently
+  // mutate the real sandbox repo / inherit network flakiness.
+  if (process.env.EXOSYNC_IT !== "1") return null;
   try {
     const token = execFileSync("gh", ["auth", "token"], {
       encoding: "utf8",
@@ -308,7 +314,7 @@ describeIfToken("SyncEngine — real GitHub integration (sandbox)", () => {
 });
 
 if (token === null) {
-  it("integration suite skipped — no GitHub token (EXOSYNC_TEST_TOKEN / gh auth token)", () => {
+  it("integration suite skipped — no token (set EXOSYNC_TEST_TOKEN, or EXOSYNC_IT=1 for gh auth token)", () => {
     expect(token).toBeNull();
   });
 }

--- a/packages/exocortex/tests/unit/services/sync/ChangeDetector.test.ts
+++ b/packages/exocortex/tests/unit/services/sync/ChangeDetector.test.ts
@@ -1,0 +1,210 @@
+/**
+ * ExoSync ChangeDetector unit tests (RFC 4e4dc453 A1 — D8/D18/D22, CQ2).
+ */
+
+import {
+  detectChanges,
+  extractAssetUid,
+  gitBlobSha,
+  type WatermarkRecord,
+} from "../../../../src";
+import { mdAsset, sha1Hex } from "./fakeGitHub";
+
+async function watermarkFor(
+  files: Record<string, string>,
+  sha = "base-commit-sha",
+  rootTreeSha = "base-tree-sha",
+): Promise<WatermarkRecord> {
+  const entries = [];
+  for (const [path, content] of Object.entries(files)) {
+    entries.push({
+      path,
+      blobSha: await gitBlobSha(content, sha1Hex),
+      ...(extractAssetUid(content) ? { uid: extractAssetUid(content) } : {}),
+    });
+  }
+  return { lastSyncedSha: sha, rootTreeSha, files: entries };
+}
+
+describe("extractAssetUid", () => {
+  it("extracts a plain scalar uid from frontmatter", () => {
+    expect(extractAssetUid(mdAsset("7097576a-148d-468f-98e9-ef8428829765"))).toBe(
+      "7097576a-148d-468f-98e9-ef8428829765",
+    );
+  });
+
+  it("extracts a quoted uid", () => {
+    expect(
+      extractAssetUid('---\nexo__Asset_uid: "abc-123"\n---\nbody'),
+    ).toBe("abc-123");
+  });
+
+  it("returns undefined without frontmatter or without the key", () => {
+    expect(extractAssetUid("# no frontmatter")).toBeUndefined();
+    expect(extractAssetUid("---\nexo__Asset_label: x\n---\n")).toBeUndefined();
+  });
+
+  it("does not match the key outside the frontmatter block", () => {
+    expect(
+      extractAssetUid("---\nkey: v\n---\nexo__Asset_uid: not-frontmatter\n"),
+    ).toBeUndefined();
+  });
+});
+
+describe("gitBlobSha", () => {
+  it("matches git's well-known empty-blob SHA", async () => {
+    expect(await gitBlobSha("", sha1Hex)).toBe(
+      "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391",
+    );
+  });
+
+  it("matches git hash-object for known content", async () => {
+    // $ printf 'hello\n' | git hash-object --stdin
+    expect(await gitBlobSha("hello\n", sha1Hex)).toBe(
+      "ce013625030ba8dba906f756967f9e9ca394464a",
+    );
+  });
+});
+
+describe("detectChanges — D22 base validation", () => {
+  it("first-sync: null watermark → full-conflict", async () => {
+    const result = await detectChanges({
+      localFiles: new Map([["a.md", mdAsset("u1")]]),
+      watermark: null,
+      actualBaseTreeSha: "anything",
+      sha1: sha1Hex,
+    });
+    expect(result).toEqual({ kind: "full-conflict", reason: "first-sync" });
+  });
+
+  it("unresolvable base commit (null actual tree) → base-mismatch", async () => {
+    const wm = await watermarkFor({ "a.md": mdAsset("u1") });
+    const result = await detectChanges({
+      localFiles: new Map([["a.md", mdAsset("u1")]]),
+      watermark: wm,
+      actualBaseTreeSha: null,
+      sha1: sha1Hex,
+    });
+    expect(result.kind).toBe("full-conflict");
+    if (result.kind === "full-conflict") {
+      expect(result.reason).toBe("base-mismatch");
+    }
+  });
+
+  it("stored root tree != actual root tree → base-mismatch (R10: corrupt watermark never trusted)", async () => {
+    const wm = await watermarkFor({ "a.md": mdAsset("u1") });
+    const result = await detectChanges({
+      localFiles: new Map([["a.md", mdAsset("u1")]]),
+      watermark: wm,
+      actualBaseTreeSha: "some-other-tree",
+      sha1: sha1Hex,
+    });
+    expect(result.kind).toBe("full-conflict");
+    if (result.kind === "full-conflict") {
+      expect(result.reason).toBe("base-mismatch");
+    }
+  });
+});
+
+describe("detectChanges — uid-keyed diff (D18)", () => {
+  const valid = (wm: WatermarkRecord): string => wm.rootTreeSha;
+
+  it("unchanged tree → empty change sets", async () => {
+    const files = { "a.md": mdAsset("u1"), "b.md": mdAsset("u2") };
+    const wm = await watermarkFor(files);
+    const result = await detectChanges({
+      localFiles: new Map(Object.entries(files)),
+      watermark: wm,
+      actualBaseTreeSha: valid(wm),
+      sha1: sha1Hex,
+    });
+    expect(result).toEqual({ kind: "changes", added: [], modified: [], deleted: [] });
+  });
+
+  it("content edit → modified, matched by uid", async () => {
+    const wm = await watermarkFor({ "a.md": mdAsset("u1", "old") });
+    const result = await detectChanges({
+      localFiles: new Map([["a.md", mdAsset("u1", "NEW")]]),
+      watermark: wm,
+      actualBaseTreeSha: valid(wm),
+      sha1: sha1Hex,
+    });
+    expect(result.kind).toBe("changes");
+    if (result.kind === "changes") {
+      expect(result.modified).toHaveLength(1);
+      expect(result.modified[0]).toMatchObject({ path: "a.md", uid: "u1" });
+      expect(result.added).toHaveLength(0);
+      expect(result.deleted).toHaveLength(0);
+    }
+  });
+
+  it("rename: same uid at a new path → modified with basePath, NOT delete+add", async () => {
+    const content = mdAsset("u1");
+    const wm = await watermarkFor({ "old/a.md": content });
+    const result = await detectChanges({
+      localFiles: new Map([["new/b.md", content]]),
+      watermark: wm,
+      actualBaseTreeSha: valid(wm),
+      sha1: sha1Hex,
+    });
+    expect(result.kind).toBe("changes");
+    if (result.kind === "changes") {
+      expect(result.modified).toEqual([
+        expect.objectContaining({ path: "new/b.md", basePath: "old/a.md", uid: "u1" }),
+      ]);
+      expect(result.added).toHaveLength(0);
+      expect(result.deleted).toHaveLength(0);
+    }
+  });
+
+  it("new uid → added; uid gone from disk → deleted", async () => {
+    const wm = await watermarkFor({ "a.md": mdAsset("u1") });
+    const result = await detectChanges({
+      localFiles: new Map([["b.md", mdAsset("u2")]]),
+      watermark: wm,
+      actualBaseTreeSha: valid(wm),
+      sha1: sha1Hex,
+    });
+    expect(result.kind).toBe("changes");
+    if (result.kind === "changes") {
+      expect(result.added).toEqual([expect.objectContaining({ path: "b.md", uid: "u2" })]);
+      expect(result.deleted).toEqual([
+        expect.objectContaining({ path: "a.md", uid: "u1" }),
+      ]);
+    }
+  });
+
+  it("uid-less files match by path", async () => {
+    const wm = await watermarkFor({ "notes.md": "# plain note v1\n" });
+    const result = await detectChanges({
+      localFiles: new Map([["notes.md", "# plain note v2\n"]]),
+      watermark: wm,
+      actualBaseTreeSha: valid(wm),
+      sha1: sha1Hex,
+    });
+    expect(result.kind).toBe("changes");
+    if (result.kind === "changes") {
+      expect(result.modified).toEqual([
+        expect.objectContaining({ path: "notes.md" }),
+      ]);
+    }
+  });
+
+  it("in-place uid edit (same path, different uid) → modified via path pass, not delete+add", async () => {
+    const wm = await watermarkFor({ "a.md": mdAsset("u1") });
+    const result = await detectChanges({
+      localFiles: new Map([["a.md", mdAsset("u9")]]),
+      watermark: wm,
+      actualBaseTreeSha: valid(wm),
+      sha1: sha1Hex,
+    });
+    expect(result.kind).toBe("changes");
+    if (result.kind === "changes") {
+      expect(result.modified).toEqual([
+        expect.objectContaining({ path: "a.md", uid: "u9" }),
+      ]);
+      expect(result.added).toHaveLength(0);
+      expect(result.deleted).toHaveLength(0);
+    }
+  });
+});

--- a/packages/exocortex/tests/unit/services/sync/SyncEngine.test.ts
+++ b/packages/exocortex/tests/unit/services/sync/SyncEngine.test.ts
@@ -351,6 +351,43 @@ describe("SyncEngine — D16 non-fast-forward retry loop", () => {
     expect(local.files.get(FILE_A)).toBe(mdAsset("u1", "local edit")); // disk pristine
   });
 
+  it("race on a NON-pushed path: watermark is not advanced and the next sync does NOT revert the concurrent change", async () => {
+    const gh = new FakeGitHubRepo({ [FILE_A]: mdAsset("u1"), [FILE_B]: mdAsset("u2") });
+    const local = new FakeLocalFiles({ [FILE_A]: mdAsset("u1"), [FILE_B]: mdAsset("u2") });
+    const { engine, watermarks } = makeEngine(gh, local);
+    await bootstrap(engine, gh.spec());
+    const baseSha = watermarks.records.get(gh.spec().repoKey)!.lastSyncedSha;
+
+    // Concurrent commit touching FILE_B (NOT pushed by us) lands inside the
+    // unguarded window: after the engine's head check, on the primitive's
+    // internal GET-ref. Absorbing its blob into the watermark without writing
+    // it to disk would make the stale local FILE_B look like a local edit on
+    // the NEXT sync — a silent revert of the concurrent change.
+    const concurrent = mdAsset("u2", "concurrent non-overlapping edit");
+    let refCalls = 0;
+    gh.onGetRef = (): void => {
+      refCalls++;
+      if (refCalls === 2) {
+        gh.commitDirect("main", { [FILE_B]: concurrent }, "race non-overlap");
+      }
+    };
+    local.files.set(FILE_A, mdAsset("u1", "local edit"));
+    const first = await engine.sync(gh.spec());
+
+    expect(first.status).toBe("synced");
+    expect(first.warnings.join(" ")).toMatch(/watermark NOT advanced/);
+    expect(watermarks.records.get(gh.spec().repoKey)!.lastSyncedSha).toBe(baseSha);
+
+    gh.onGetRef = undefined;
+    const second = await engine.sync(gh.spec());
+
+    expect(second.status).toBe("synced");
+    expect(second.pushedCount).toBe(0); // own pushed edit converges, nothing re-pushed
+    expect(gh.headFiles().get(FILE_B)).toBe(concurrent); // concurrent change NOT reverted
+    expect(local.files.get(FILE_B)).toBe(concurrent); // pulled to disk
+    expect(watermarks.records.get(gh.spec().repoKey)!.lastSyncedSha).toBe(gh.headSha());
+  });
+
   it("warns on the residual race window (concurrent commit between conflict check and the primitive's GET-ref)", async () => {
     const gh = new FakeGitHubRepo({ [FILE_A]: mdAsset("u1") });
     const local = new FakeLocalFiles({ [FILE_A]: mdAsset("u1") });

--- a/packages/exocortex/tests/unit/services/sync/SyncEngine.test.ts
+++ b/packages/exocortex/tests/unit/services/sync/SyncEngine.test.ts
@@ -1,0 +1,467 @@
+/**
+ * ExoSync SyncEngine unit tests (RFC 4e4dc453 A1 — D3/D12/D16/D19).
+ *
+ * The GitHub side is the production-shape `FakeGitHubRepo` (real git blob
+ * SHAs, transport error contract, force:false 422 semantics) — see
+ * fakeGitHub.ts module docstring.
+ */
+
+import {
+  SyncEngine,
+  orderChildrenFirst,
+  isNonFastForwardError,
+  type SyncEngineDeps,
+  type SyncRepoSpec,
+} from "../../../../src";
+import {
+  FakeGitHubRepo,
+  FakeLocalFiles,
+  FakeWatermarkStore,
+  alwaysMaterialized,
+  neverMaterialized,
+  mdAsset,
+  sha1Hex,
+} from "./fakeGitHub";
+
+function makeEngine(
+  gh: FakeGitHubRepo,
+  local: FakeLocalFiles,
+  overrides: Partial<SyncEngineDeps> = {},
+): { engine: SyncEngine; watermarks: FakeWatermarkStore } {
+  const watermarks = new FakeWatermarkStore();
+  const engine = new SyncEngine({
+    transport: gh.transport(),
+    watermarkStore: watermarks,
+    materializationCheck: alwaysMaterialized(),
+    localFilesFor: () => local,
+    sha1: sha1Hex,
+    ...overrides,
+  });
+  return { engine, watermarks };
+}
+
+/** Bootstrap the watermark from a disk that mirrors the remote head. */
+async function bootstrap(
+  engine: SyncEngine,
+  spec: SyncRepoSpec,
+): Promise<void> {
+  const result = await engine.sync(spec);
+  expect(result.status).toBe("synced");
+}
+
+const FILE_A = "assets/a.md";
+const FILE_B = "assets/b.md";
+
+describe("SyncEngine — D19 full-materialization gate", () => {
+  it("skips a non-fully-materialized repo with a warning and infers nothing", async () => {
+    const gh = new FakeGitHubRepo({ [FILE_A]: mdAsset("u1") });
+    const local = new FakeLocalFiles({}); // empty disk — absence must NOT become deletes
+    const { engine, watermarks } = makeEngine(gh, local, {
+      materializationCheck: neverMaterialized("mid-mount"),
+    });
+
+    const result = await engine.sync(gh.spec());
+
+    expect(result.status).toBe("skipped-not-materialized");
+    expect(result.warnings.join(" ")).toMatch(/deletes NOT inferred/);
+    expect(result.deferredDeletes).toEqual([]);
+    expect(watermarks.records.size).toBe(0);
+    expect(gh.headFiles().has(FILE_A)).toBe(true); // remote untouched
+  });
+});
+
+describe("SyncEngine — first-sync bootstrap (D22)", () => {
+  it("seeds the watermark when disk exactly equals the remote head", async () => {
+    const gh = new FakeGitHubRepo({ [FILE_A]: mdAsset("u1") });
+    const local = new FakeLocalFiles({ [FILE_A]: mdAsset("u1") });
+    const { engine, watermarks } = makeEngine(gh, local);
+
+    const result = await engine.sync(gh.spec());
+
+    expect(result.status).toBe("synced");
+    expect(result.pushedCount).toBe(0);
+    const record = watermarks.records.get(gh.spec().repoKey)!;
+    expect(record.lastSyncedSha).toBe(gh.headSha());
+    expect(record.files).toEqual([
+      expect.objectContaining({ path: FILE_A, uid: "u1" }),
+    ]);
+  });
+
+  it("returns full-conflict when disk diverges and no watermark exists (never overwrites)", async () => {
+    const gh = new FakeGitHubRepo({ [FILE_A]: mdAsset("u1", "remote") });
+    const local = new FakeLocalFiles({ [FILE_A]: mdAsset("u1", "local-divergent") });
+    const { engine } = makeEngine(gh, local);
+
+    const result = await engine.sync(gh.spec());
+
+    expect(result.status).toBe("full-conflict");
+    expect(result.detail).toMatch(/first-sync/);
+    expect(gh.headFiles().get(FILE_A)).toBe(mdAsset("u1", "remote")); // remote untouched
+    expect(local.files.get(FILE_A)).toBe(mdAsset("u1", "local-divergent")); // disk untouched
+  });
+});
+
+describe("SyncEngine — push-only happy path (VL#7, D3)", () => {
+  it("pushes a local edit via restCreateCommit and advances the watermark", async () => {
+    const gh = new FakeGitHubRepo({ [FILE_A]: mdAsset("u1"), [FILE_B]: mdAsset("u2") });
+    const local = new FakeLocalFiles({ [FILE_A]: mdAsset("u1"), [FILE_B]: mdAsset("u2") });
+    const { engine, watermarks } = makeEngine(gh, local);
+    await bootstrap(engine, gh.spec());
+
+    const edited = mdAsset("u1", "edited locally");
+    local.files.set(FILE_A, edited);
+    const result = await engine.sync(gh.spec());
+
+    expect(result.status).toBe("synced");
+    expect(result.pushedCount).toBe(1);
+    expect(result.pushedSha).toBe(gh.headSha());
+    expect(gh.headFiles().get(FILE_A)).toBe(edited); // commit landed on remote
+    expect(gh.headFiles().get(FILE_B)).toBe(mdAsset("u2")); // untouched neighbour intact
+    expect(watermarks.records.get(gh.spec().repoKey)!.lastSyncedSha).toBe(
+      result.pushedSha,
+    );
+  });
+
+  it("adds a brand-new asset", async () => {
+    const gh = new FakeGitHubRepo({ [FILE_A]: mdAsset("u1") });
+    const local = new FakeLocalFiles({ [FILE_A]: mdAsset("u1") });
+    const { engine } = makeEngine(gh, local);
+    await bootstrap(engine, gh.spec());
+
+    local.files.set(FILE_B, mdAsset("u2", "new asset"));
+    const result = await engine.sync(gh.spec());
+
+    expect(result.status).toBe("synced");
+    expect(gh.headFiles().get(FILE_B)).toBe(mdAsset("u2", "new asset"));
+  });
+
+  it("non-.md files are excluded symmetrically (binary safety)", async () => {
+    const gh = new FakeGitHubRepo({ [FILE_A]: mdAsset("u1"), "img/pic.png": "PNGBYTES" });
+    const local = new FakeLocalFiles({ [FILE_A]: mdAsset("u1") }); // png absent locally
+    const { engine } = makeEngine(gh, local);
+    await bootstrap(engine, gh.spec()); // bootstrap ignores the png
+
+    local.files.set(FILE_A, mdAsset("u1", "v2"));
+    const result = await engine.sync(gh.spec());
+
+    expect(result.status).toBe("synced");
+    expect(result.deferredDeletes).toEqual([]); // png absence is NOT a delete
+    expect(gh.headFiles().get("img/pic.png")).toBe("PNGBYTES"); // remote binary intact
+  });
+});
+
+describe("SyncEngine — pull phase (no-conflict remote changes)", () => {
+  it("applies remote-only changes to disk without pushing", async () => {
+    const gh = new FakeGitHubRepo({ [FILE_A]: mdAsset("u1") });
+    const local = new FakeLocalFiles({ [FILE_A]: mdAsset("u1") });
+    const { engine, watermarks } = makeEngine(gh, local);
+    await bootstrap(engine, gh.spec());
+
+    gh.commitDirect("main", { [FILE_B]: mdAsset("u2", "from device B") }, "device B");
+    const result = await engine.sync(gh.spec());
+
+    expect(result.status).toBe("synced");
+    expect(result.pushedCount).toBe(0);
+    expect(result.pulledCount).toBe(1);
+    expect(local.files.get(FILE_B)).toBe(mdAsset("u2", "from device B"));
+    expect(watermarks.records.get(gh.spec().repoKey)!.lastSyncedSha).toBe(gh.headSha());
+  });
+
+  it("applies a remote delete locally when the file is locally untouched", async () => {
+    const gh = new FakeGitHubRepo({ [FILE_A]: mdAsset("u1"), [FILE_B]: mdAsset("u2") });
+    const local = new FakeLocalFiles({ [FILE_A]: mdAsset("u1"), [FILE_B]: mdAsset("u2") });
+    const { engine } = makeEngine(gh, local);
+    await bootstrap(engine, gh.spec());
+
+    gh.commitDirect("main", {}, "device B deletes b", [FILE_B]);
+    const result = await engine.sync(gh.spec());
+
+    expect(result.status).toBe("synced");
+    expect(local.files.has(FILE_B)).toBe(false);
+  });
+
+  it("pushes local + applies remote when changes are disjoint", async () => {
+    const gh = new FakeGitHubRepo({ [FILE_A]: mdAsset("u1"), [FILE_B]: mdAsset("u2") });
+    const local = new FakeLocalFiles({ [FILE_A]: mdAsset("u1"), [FILE_B]: mdAsset("u2") });
+    const { engine } = makeEngine(gh, local);
+    await bootstrap(engine, gh.spec());
+
+    gh.commitDirect("main", { [FILE_B]: mdAsset("u2", "remote v2") }, "device B");
+    local.files.set(FILE_A, mdAsset("u1", "local v2"));
+    const result = await engine.sync(gh.spec());
+
+    expect(result.status).toBe("synced");
+    expect(result.pushedCount).toBe(1);
+    expect(result.pulledCount).toBe(1);
+    expect(gh.headFiles().get(FILE_A)).toBe(mdAsset("u1", "local v2"));
+    expect(gh.headFiles().get(FILE_B)).toBe(mdAsset("u2", "remote v2"));
+    expect(local.files.get(FILE_B)).toBe(mdAsset("u2", "remote v2"));
+  });
+});
+
+describe("SyncEngine — conflicts (A2/A3 deferral, never overwrite)", () => {
+  it("same uid changed on both sides → conflict, nothing pushed, nothing written", async () => {
+    const gh = new FakeGitHubRepo({ [FILE_A]: mdAsset("u1") });
+    const local = new FakeLocalFiles({ [FILE_A]: mdAsset("u1") });
+    const { engine, watermarks } = makeEngine(gh, local);
+    await bootstrap(engine, gh.spec());
+    const wmBefore = watermarks.records.get(gh.spec().repoKey)!.lastSyncedSha;
+
+    gh.commitDirect("main", { [FILE_A]: mdAsset("u1", "remote edit") }, "device B");
+    local.files.set(FILE_A, mdAsset("u1", "local edit"));
+    const result = await engine.sync(gh.spec());
+
+    expect(result.status).toBe("conflict");
+    expect(result.detail).toMatch(/u1/);
+    expect(gh.headFiles().get(FILE_A)).toBe(mdAsset("u1", "remote edit")); // remote untouched
+    expect(local.files.get(FILE_A)).toBe(mdAsset("u1", "local edit")); // disk untouched
+    expect(watermarks.records.get(gh.spec().repoKey)!.lastSyncedSha).toBe(wmBefore); // watermark frozen
+  });
+
+  it("local delete vs remote modify → conflict", async () => {
+    const gh = new FakeGitHubRepo({ [FILE_A]: mdAsset("u1"), [FILE_B]: mdAsset("u2") });
+    const local = new FakeLocalFiles({ [FILE_A]: mdAsset("u1"), [FILE_B]: mdAsset("u2") });
+    const { engine } = makeEngine(gh, local);
+    await bootstrap(engine, gh.spec());
+
+    gh.commitDirect("main", { [FILE_B]: mdAsset("u2", "remote edit") }, "device B");
+    local.files.delete(FILE_B);
+    const result = await engine.sync(gh.spec());
+
+    expect(result.status).toBe("conflict");
+    expect(gh.headFiles().get(FILE_B)).toBe(mdAsset("u2", "remote edit"));
+  });
+
+  it("convergent edit (identical content both sides) is NOT a conflict and is not re-pushed", async () => {
+    const gh = new FakeGitHubRepo({ [FILE_A]: mdAsset("u1") });
+    const local = new FakeLocalFiles({ [FILE_A]: mdAsset("u1") });
+    const { engine, watermarks } = makeEngine(gh, local);
+    await bootstrap(engine, gh.spec());
+
+    const same = mdAsset("u1", "identical on both sides");
+    gh.commitDirect("main", { [FILE_A]: same }, "device B");
+    local.files.set(FILE_A, same);
+    const result = await engine.sync(gh.spec());
+
+    expect(result.status).toBe("synced");
+    expect(result.pushedCount).toBe(0);
+    expect(result.pushedSha).toBeUndefined();
+    expect(watermarks.records.get(gh.spec().repoKey)!.lastSyncedSha).toBe(gh.headSha());
+  });
+});
+
+describe("SyncEngine — deferred deletes & renames (A1: primitive cannot delete)", () => {
+  it("local delete is deferred with a warning; remote keeps the file", async () => {
+    const gh = new FakeGitHubRepo({ [FILE_A]: mdAsset("u1"), [FILE_B]: mdAsset("u2") });
+    const local = new FakeLocalFiles({ [FILE_A]: mdAsset("u1"), [FILE_B]: mdAsset("u2") });
+    const { engine } = makeEngine(gh, local);
+    await bootstrap(engine, gh.spec());
+
+    local.files.delete(FILE_B);
+    const result = await engine.sync(gh.spec());
+
+    expect(result.status).toBe("synced");
+    expect(result.deferredDeletes).toContain(FILE_B);
+    expect(result.warnings.join(" ")).toMatch(/deferred delete/);
+    expect(gh.headFiles().has(FILE_B)).toBe(true); // never deleted remotely in A1
+  });
+
+  it("rename is deferred whole (no uid duplicate on remote)", async () => {
+    const gh = new FakeGitHubRepo({ [FILE_A]: mdAsset("u1") });
+    const local = new FakeLocalFiles({ [FILE_A]: mdAsset("u1") });
+    const { engine } = makeEngine(gh, local);
+    await bootstrap(engine, gh.spec());
+
+    local.files.delete(FILE_A);
+    local.files.set("assets/renamed.md", mdAsset("u1"));
+    const result = await engine.sync(gh.spec());
+
+    expect(result.status).toBe("synced");
+    expect(result.pushedCount).toBe(0); // new path NOT pushed — would duplicate uid u1
+    expect(result.deferredDeletes).toContain(FILE_A);
+    expect(result.warnings.join(" ")).toMatch(/deferred rename/);
+    expect(gh.headFiles().has("assets/renamed.md")).toBe(false);
+    expect(gh.headFiles().has(FILE_A)).toBe(true);
+  });
+});
+
+describe("SyncEngine — D16 non-fast-forward retry loop", () => {
+  it("classifies the production 422 message and the structural mismatch as retryable", () => {
+    expect(
+      isNonFastForwardError(
+        new Error(
+          "GitHub request PATCH https://api.github.com/repos/o/r/git/refs/heads/main → HTTP 422: Update is not a fast forward",
+        ),
+      ),
+    ).toBe(true);
+    expect(
+      isNonFastForwardError(
+        new Error("GitHub createCommit: ref update mismatch (expected a, got b)"),
+      ),
+    ).toBe(true);
+    expect(
+      isNonFastForwardError(
+        new Error("GitHub request POST https://api.github.com/repos/o/r/git/trees → HTTP 422: bad tree"),
+      ),
+    ).toBe(false);
+    expect(isNonFastForwardError(new Error("network down"))).toBe(false);
+  });
+
+  it("recovers from a concurrent push racing the PATCH (re-pull → retry)", async () => {
+    const gh = new FakeGitHubRepo({ [FILE_A]: mdAsset("u1"), [FILE_B]: mdAsset("u2") });
+    const local = new FakeLocalFiles({ [FILE_A]: mdAsset("u1"), [FILE_B]: mdAsset("u2") });
+    const { engine } = makeEngine(gh, local);
+    await bootstrap(engine, gh.spec());
+
+    // Device B lands a DISJOINT commit between this engine's tree/commit
+    // creation and its PATCH — the exact force:false race (D9).
+    let injected = false;
+    gh.onBeforePatch = (): void => {
+      if (!injected) {
+        injected = true;
+        gh.commitDirect("main", { [FILE_B]: mdAsset("u2", "raced in") }, "device B race");
+      }
+    };
+    local.files.set(FILE_A, mdAsset("u1", "local edit"));
+    const result = await engine.sync(gh.spec());
+
+    expect(result.status).toBe("synced");
+    expect(result.warnings.join(" ")).toMatch(/non-fast-forward push \(attempt 1\/3\)/);
+    expect(gh.headFiles().get(FILE_A)).toBe(mdAsset("u1", "local edit"));
+    expect(gh.headFiles().get(FILE_B)).toBe(mdAsset("u2", "raced in"));
+    expect(local.files.get(FILE_B)).toBe(mdAsset("u2", "raced in")); // pulled on retry
+  });
+
+  it("gives up after the retry cap (D16 cap, quarantine is A3 scope)", async () => {
+    const gh = new FakeGitHubRepo({ [FILE_A]: mdAsset("u1") });
+    const local = new FakeLocalFiles({ [FILE_A]: mdAsset("u1") });
+    const { engine } = makeEngine(gh, local, { maxPushRetries: 2 });
+    await bootstrap(engine, gh.spec());
+
+    let counter = 0;
+    gh.onBeforePatch = (): void => {
+      counter++;
+      gh.commitDirect("main", { [`assets/race-${counter}.md`]: mdAsset(`race-${counter}`) }, "race");
+    };
+    local.files.set(FILE_A, mdAsset("u1", "local edit"));
+    const result = await engine.sync(gh.spec());
+
+    expect(result.status).toBe("retry-exhausted");
+    expect(result.detail).toMatch(/after 2 retries/);
+    expect(local.files.get(FILE_A)).toBe(mdAsset("u1", "local edit")); // disk pristine
+  });
+
+  it("warns on the residual race window (concurrent commit between conflict check and the primitive's GET-ref)", async () => {
+    const gh = new FakeGitHubRepo({ [FILE_A]: mdAsset("u1") });
+    const local = new FakeLocalFiles({ [FILE_A]: mdAsset("u1") });
+    const { engine } = makeEngine(gh, local);
+    await bootstrap(engine, gh.spec());
+
+    // The engine's pull examines head on GET-ref call N; the primitive
+    // re-GETs the ref afterwards. Injecting a commit touching the SAME file
+    // on the primitive's GET lands the race inside the unguarded window.
+    local.files.set(FILE_A, mdAsset("u1", "local edit"));
+    let refCalls = 0;
+    gh.onGetRef = (): void => {
+      refCalls++;
+      if (refCalls === 2) {
+        gh.commitDirect("main", { [FILE_A]: mdAsset("u1", "raced overwrite") }, "race");
+      }
+    };
+    const result = await engine.sync(gh.spec());
+
+    expect(result.status).toBe("synced");
+    expect(result.warnings.join(" ")).toMatch(/race-window/);
+    expect(gh.headFiles().get(FILE_A)).toBe(mdAsset("u1", "local edit")); // local won; history holds both
+  });
+});
+
+describe("SyncEngine — error paths (D12 warn-not-block)", () => {
+  it("truncated remote tree → loud error result, repo skipped", async () => {
+    const gh = new FakeGitHubRepo({ [FILE_A]: mdAsset("u1") });
+    const local = new FakeLocalFiles({ [FILE_A]: mdAsset("u1") });
+    const { engine } = makeEngine(gh, local);
+    await bootstrap(engine, gh.spec());
+
+    gh.commitDirect("main", { [FILE_B]: mdAsset("u2") }, "device B");
+    gh.truncatedTrees = true;
+    local.files.set(FILE_A, mdAsset("u1", "v2"));
+    const result = await engine.sync(gh.spec());
+
+    expect(result.status).toBe("error");
+    expect(result.detail).toMatch(/truncated/);
+    expect(gh.headFiles().get(FILE_A)).toBe(mdAsset("u1")); // nothing pushed
+  });
+
+  it("watermark pointing at a rewritten/GC'd commit → full-conflict (base-mismatch)", async () => {
+    const gh = new FakeGitHubRepo({ [FILE_A]: mdAsset("u1") });
+    const local = new FakeLocalFiles({ [FILE_A]: mdAsset("u1") });
+    const { engine, watermarks } = makeEngine(gh, local);
+    await bootstrap(engine, gh.spec());
+
+    const record = watermarks.records.get(gh.spec().repoKey)!;
+    watermarks.records.set(gh.spec().repoKey, {
+      ...record,
+      lastSyncedSha: "deadbeef".repeat(5), // commit unknown to the remote
+    });
+    const result = await engine.sync(gh.spec());
+
+    expect(result.status).toBe("full-conflict");
+    expect(result.detail).toMatch(/base-mismatch/);
+  });
+
+  it("syncAll is best-effort: a failing repo yields `error` and does not block the next one", async () => {
+    const ghOk = new FakeGitHubRepo({ [FILE_A]: mdAsset("u1") });
+    const localOk = new FakeLocalFiles({ [FILE_A]: mdAsset("u1") });
+    const watermarks = new FakeWatermarkStore();
+
+    const brokenSpec: SyncRepoSpec = {
+      owner: "broken-owner",
+      repo: "broken-repo",
+      branch: "main",
+      repoKey: "broken",
+      localPath: "a/b",
+    };
+    const okSpec = { ...ghOk.spec(), repoKey: "ok", localPath: "a" };
+
+    const engine = new SyncEngine({
+      transport: async (req) => {
+        if (req.url.includes("broken-owner")) {
+          throw new Error(`GitHub request ${req.method} ${req.url} → HTTP 500: boom`);
+        }
+        return ghOk.transport()(req);
+      },
+      watermarkStore: watermarks,
+      materializationCheck: alwaysMaterialized(),
+      localFilesFor: (spec) =>
+        spec.repoKey === "broken" ? new FakeLocalFiles({}) : localOk,
+      sha1: sha1Hex,
+    });
+
+    const results = await engine.syncAll([brokenSpec, okSpec]);
+    expect(results.map((r) => r.status)).toEqual(["error", "synced"]);
+    expect(results[0].detail).toMatch(/HTTP 500/);
+  });
+});
+
+describe("orderChildrenFirst (D12 children-before-parent)", () => {
+  it("orders deeper localPaths first", () => {
+    const mk = (localPath: string): SyncRepoSpec => ({
+      owner: "o",
+      repo: "r",
+      branch: "main",
+      repoKey: localPath,
+      localPath,
+    });
+    const ordered = orderChildrenFirst([
+      mk("assetspaces"),
+      mk("assetspaces/kitelev/exoas-exodev"),
+      mk("assetspaces/exo"),
+    ]);
+    expect(ordered.map((s) => s.localPath)).toEqual([
+      "assetspaces/kitelev/exoas-exodev",
+      "assetspaces/exo",
+      "assetspaces",
+    ]);
+  });
+});

--- a/packages/exocortex/tests/unit/services/sync/fakeGitHub.ts
+++ b/packages/exocortex/tests/unit/services/sync/fakeGitHub.ts
@@ -1,0 +1,316 @@
+/**
+ * In-memory GitHub Git Data API fake for ExoSync tests.
+ *
+ * Production-shape by design (test-fixture-realism): it implements the SAME
+ * transport contract as the real adapters (throws on non-2xx with the message
+ * shape `GitHub request {METHOD} {url} → HTTP {status}: {body}`), computes
+ * REAL git blob SHAs (so disk-side `gitBlobSha` comparisons behave exactly as
+ * against GitHub), returns base64 blob content with embedded newlines (as
+ * GitHub does), and enforces `force:false` fast-forward semantics on PATCH —
+ * a non-fast-forward ref update throws HTTP 422, which is the production race
+ * signal the engine's D16 retry loop consumes.
+ */
+
+import { createHash } from "node:crypto";
+import type {
+  RestCommitRequest,
+  RestCommitResponse,
+  RestCommitTransport,
+} from "../../../../src";
+import type {
+  LocalFilesPort,
+  MaterializationCheckPort,
+  SyncRepoSpec,
+  WatermarkRecord,
+  WatermarkStorePort,
+} from "../../../../src";
+
+export const sha1Hex = async (bytes: Uint8Array): Promise<string> =>
+  createHash("sha1").update(bytes).digest("hex");
+
+function gitBlobShaSync(content: string): string {
+  const body = Buffer.from(content, "utf-8");
+  return createHash("sha1")
+    .update(Buffer.concat([Buffer.from(`blob ${body.byteLength}\0`), body]))
+    .digest("hex");
+}
+
+function chunkBase64(content: string): string {
+  const b64 = Buffer.from(content, "utf-8").toString("base64");
+  return b64.replace(/(.{60})/g, "$1\n");
+}
+
+interface FakeCommit {
+  sha: string;
+  treeSha: string;
+  parents: string[];
+  message: string;
+}
+
+function httpError(method: string, url: string, status: number, body: string): Error {
+  return new Error(`GitHub request ${method} ${url} → HTTP ${status}: ${body}`);
+}
+
+export class FakeGitHubRepo {
+  readonly owner = "test-owner";
+  readonly repo = "test-repo";
+  readonly branch = "main";
+
+  /** blobSha → content */
+  readonly blobs = new Map<string, string>();
+  /** treeSha → (path → blobSha) */
+  readonly trees = new Map<string, Map<string, string>>();
+  readonly commits = new Map<string, FakeCommit>();
+  /** branch → head commit sha */
+  readonly refs = new Map<string, string>();
+
+  /** When true, recursive tree GETs report `truncated: true`. */
+  truncatedTrees = false;
+  /** Race-injection hook — fires before every PATCH refs validation. */
+  onBeforePatch?: () => void;
+  /** Race-injection hook — fires on every GET refs (1-based call count). */
+  onGetRef?: (count: number) => void;
+  private getRefCount = 0;
+  private commitCounter = 0;
+
+  constructor(initialFiles: Record<string, string> = {}) {
+    this.commitDirect(this.branch, initialFiles, "init");
+  }
+
+  spec(): SyncRepoSpec {
+    return {
+      owner: this.owner,
+      repo: this.repo,
+      branch: this.branch,
+      repoKey: `${this.owner}/${this.repo}#${this.branch}`,
+      localPath: "assetspaces/test",
+    };
+  }
+
+  headSha(): string {
+    return this.refs.get(this.branch)!;
+  }
+
+  headFiles(): Map<string, string> {
+    const tree = this.trees.get(this.commits.get(this.headSha())!.treeSha)!;
+    const out = new Map<string, string>();
+    for (const [path, blobSha] of tree) out.set(path, this.blobs.get(blobSha)!);
+    return out;
+  }
+
+  /**
+   * Test-side direct commit ("device B"): applies `files` (and `deletes`) on
+   * top of the current head and moves the ref. Bypasses the transport.
+   */
+  commitDirect(
+    branch: string,
+    files: Record<string, string>,
+    message: string,
+    deletes: string[] = [],
+  ): string {
+    const parent = this.refs.get(branch);
+    const baseTree =
+      parent !== undefined
+        ? new Map(this.trees.get(this.commits.get(parent)!.treeSha)!)
+        : new Map<string, string>();
+    for (const [path, content] of Object.entries(files)) {
+      const blobSha = gitBlobShaSync(content);
+      this.blobs.set(blobSha, content);
+      baseTree.set(path, blobSha);
+    }
+    for (const path of deletes) baseTree.delete(path);
+    const treeSha = this.storeTree(baseTree);
+    const sha = this.newCommitSha(treeSha, parent ? [parent] : [], message);
+    this.commits.set(sha, {
+      sha,
+      treeSha,
+      parents: parent ? [parent] : [],
+      message,
+    });
+    this.refs.set(branch, sha);
+    return sha;
+  }
+
+  private storeTree(entries: Map<string, string>): string {
+    const serialized = [...entries.entries()]
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([p, s]) => `${p}:${s}`)
+      .join("\n");
+    const treeSha = createHash("sha1").update(`tree:${serialized}`).digest("hex");
+    this.trees.set(treeSha, new Map(entries));
+    return treeSha;
+  }
+
+  private newCommitSha(treeSha: string, parents: string[], message: string): string {
+    return createHash("sha1")
+      .update(`commit:${treeSha}:${parents.join(",")}:${message}:${this.commitCounter++}`)
+      .digest("hex");
+  }
+
+  transport(): RestCommitTransport {
+    return async (req: RestCommitRequest): Promise<RestCommitResponse> => {
+      const { method, url } = req;
+      const path = url.replace(/^https?:\/\/[^/]+/, "");
+      const m = (re: RegExp): RegExpExecArray | null => re.exec(path);
+
+      let match: RegExpExecArray | null;
+
+      if (method === "GET" && (match = m(/^\/repos\/[^/]+\/[^/]+\/git\/refs\/heads\/(.+)$/))) {
+        this.getRefCount++;
+        this.onGetRef?.(this.getRefCount);
+        const sha = this.refs.get(decodeURIComponent(match[1]));
+        if (sha === undefined) throw httpError(method, url, 404, "Not Found");
+        return { status: 200, json: { ref: `refs/heads/${match[1]}`, object: { sha } } };
+      }
+
+      if (method === "GET" && (match = m(/^\/repos\/[^/]+\/[^/]+\/git\/commits\/([^/?]+)$/))) {
+        const commit = this.commits.get(decodeURIComponent(match[1]));
+        if (commit === undefined) throw httpError(method, url, 404, "Not Found");
+        return {
+          status: 200,
+          json: {
+            sha: commit.sha,
+            tree: { sha: commit.treeSha },
+            parents: commit.parents.map((sha) => ({ sha })),
+            message: commit.message,
+          },
+        };
+      }
+
+      if (method === "GET" && (match = m(/^\/repos\/[^/]+\/[^/]+\/git\/trees\/([^/?]+)(\?.*)?$/))) {
+        const treeSha = decodeURIComponent(match[1]);
+        const tree = this.trees.get(treeSha);
+        if (tree === undefined) throw httpError(method, url, 404, "Not Found");
+        return {
+          status: 200,
+          json: {
+            sha: treeSha,
+            truncated: this.truncatedTrees,
+            tree: [...tree.entries()].map(([p, s]) => ({
+              path: p,
+              type: "blob",
+              mode: "100644",
+              sha: s,
+            })),
+          },
+        };
+      }
+
+      if (method === "GET" && (match = m(/^\/repos\/[^/]+\/[^/]+\/git\/blobs\/([^/?]+)$/))) {
+        const content = this.blobs.get(decodeURIComponent(match[1]));
+        if (content === undefined) throw httpError(method, url, 404, "Not Found");
+        return {
+          status: 200,
+          json: { sha: match[1], content: chunkBase64(content), encoding: "base64" },
+        };
+      }
+
+      if (method === "POST" && m(/^\/repos\/[^/]+\/[^/]+\/git\/trees$/)) {
+        const body = JSON.parse(req.body ?? "{}") as {
+          base_tree?: string;
+          tree?: Array<{ path: string; content: string }>;
+        };
+        // GitHub accepts a commitish base_tree (peels commit → tree).
+        let base = new Map<string, string>();
+        if (body.base_tree !== undefined) {
+          const viaCommit = this.commits.get(body.base_tree);
+          const baseTree = this.trees.get(viaCommit?.treeSha ?? body.base_tree);
+          if (baseTree === undefined) {
+            throw httpError(method, url, 404, "base_tree not found");
+          }
+          base = new Map(baseTree);
+        }
+        for (const entry of body.tree ?? []) {
+          if (typeof entry.content !== "string") {
+            throw httpError(method, url, 422, "tree entry without content");
+          }
+          const blobSha = gitBlobShaSync(entry.content);
+          this.blobs.set(blobSha, entry.content);
+          base.set(entry.path, blobSha);
+        }
+        return { status: 201, json: { sha: this.storeTree(base) } };
+      }
+
+      if (method === "POST" && m(/^\/repos\/[^/]+\/[^/]+\/git\/commits$/)) {
+        const body = JSON.parse(req.body ?? "{}") as {
+          message: string;
+          tree: string;
+          parents: string[];
+        };
+        if (!this.trees.has(body.tree)) {
+          throw httpError(method, url, 422, "tree not found");
+        }
+        const sha = this.newCommitSha(body.tree, body.parents, body.message);
+        this.commits.set(sha, {
+          sha,
+          treeSha: body.tree,
+          parents: body.parents,
+          message: body.message,
+        });
+        return { status: 201, json: { sha } };
+      }
+
+      if (method === "PATCH" && (match = m(/^\/repos\/[^/]+\/[^/]+\/git\/refs\/heads\/(.+)$/))) {
+        this.onBeforePatch?.();
+        const branch = decodeURIComponent(match[1]);
+        const body = JSON.parse(req.body ?? "{}") as { sha: string; force?: boolean };
+        const commit = this.commits.get(body.sha);
+        if (commit === undefined) throw httpError(method, url, 422, "object does not exist");
+        const current = this.refs.get(branch);
+        if (body.force !== true && commit.parents[0] !== current) {
+          // force:false fast-forward enforcement — the production 422 signal.
+          throw httpError(method, url, 422, "Update is not a fast forward");
+        }
+        this.refs.set(branch, body.sha);
+        return { status: 200, json: { object: { sha: body.sha } } };
+      }
+
+      throw httpError(method, url, 404, `unhandled fake route`);
+    };
+  }
+}
+
+/** In-memory LocalFilesPort. */
+export class FakeLocalFiles implements LocalFilesPort {
+  readonly files: Map<string, string>;
+  constructor(initial: Record<string, string> = {}) {
+    this.files = new Map(Object.entries(initial));
+  }
+  async list(): Promise<string[]> {
+    return [...this.files.keys()];
+  }
+  async read(path: string): Promise<string> {
+    const content = this.files.get(path);
+    if (content === undefined) throw new Error(`ENOENT: ${path}`);
+    return content;
+  }
+  async write(path: string, content: string): Promise<void> {
+    this.files.set(path, content);
+  }
+  async delete(path: string): Promise<void> {
+    this.files.delete(path); // no-op when absent, per port contract
+  }
+}
+
+/** In-memory WatermarkStorePort. */
+export class FakeWatermarkStore implements WatermarkStorePort {
+  readonly records = new Map<string, WatermarkRecord>();
+  async get(repoKey: string): Promise<WatermarkRecord | null> {
+    return this.records.get(repoKey) ?? null;
+  }
+  async set(repoKey: string, record: WatermarkRecord): Promise<void> {
+    this.records.set(repoKey, record);
+  }
+}
+
+export function alwaysMaterialized(): MaterializationCheckPort {
+  return { check: async () => ({ fullyMaterialized: true }) };
+}
+
+export function neverMaterialized(reason: string): MaterializationCheckPort {
+  return { check: async () => ({ fullyMaterialized: false, reason }) };
+}
+
+export function mdAsset(uid: string, body = "body"): string {
+  return `---\nexo__Asset_uid: ${uid}\nexo__Asset_label: "Asset ${uid}"\n---\n\n${body}\n`;
+}

--- a/scripts/test-ci-batched.sh
+++ b/scripts/test-ci-batched.sh
@@ -123,7 +123,11 @@ echo "📦 Running exocortex grounding + RFC regression tests..."
 # transforms) that the plugin RestAssetSpaceMount + CLI BootstrapAssetSpaceService
 # both delegate to. Without it the core would rot silently (jest roots vs CI
 # allowlist gotcha — see packages/obsidian-plugin/CLAUDE.md "Test Suite Awareness").
-EXOCORTEX_JEST_ARGS="--config packages/exocortex/jest.config.js --testPathPatterns=(services/(GroundingExecutor(\.[a-zA-Z0-9_-]+)?|AssetConversionService|NoteToRDFConverter\.(issue-2959|rfc-31c1a0be-grounding-ref|asset-filename|issue-3242-labelless-class)|ShapeRegistry|ShapeLoader)\.test|services/assetspace/AssetSpaceMount\.test|application/services/RelationColumnSetResolver(\.property)?\.test|performance/RelationColumnSetResolverPerformance\.test|infrastructure/sparql/executors/BGPExecutor\.issue-2997\.test|integration/dynamic-commands/(grounding-resolve-execute|grounding-phase3b-pipeline|grounding-type-vault-fixture-parity)\.test|domain/models/GroundingFrontmatterParser\.test|domain/profile/TsFloorGuard\.test)\.ts --forceExit"
+# RFC 4e4dc453 A1 (ExoSync, 2026-06-10): services/sync/(ChangeDetector|SyncEngine).test
+# — gates the platform-free sync core (uid-keyed change detection D18/D22 +
+# pull→no-conflict→push orchestration over restCreateCommit, D16 422-retry,
+# D19 materialization gate).
+EXOCORTEX_JEST_ARGS="--config packages/exocortex/jest.config.js --testPathPatterns=(services/(GroundingExecutor(\.[a-zA-Z0-9_-]+)?|AssetConversionService|NoteToRDFConverter\.(issue-2959|rfc-31c1a0be-grounding-ref|asset-filename|issue-3242-labelless-class)|ShapeRegistry|ShapeLoader)\.test|services/assetspace/AssetSpaceMount\.test|services/sync/(ChangeDetector|SyncEngine)\.test|application/services/RelationColumnSetResolver(\.property)?\.test|performance/RelationColumnSetResolverPerformance\.test|infrastructure/sparql/executors/BGPExecutor\.issue-2997\.test|integration/dynamic-commands/(grounding-resolve-execute|grounding-phase3b-pipeline|grounding-type-vault-fixture-parity)\.test|domain/models/GroundingFrontmatterParser\.test|domain/profile/TsFloorGuard\.test)\.ts --forceExit"
 if [ "$CI" = "true" ]; then
     if timeout 60 node ./node_modules/jest/bin/jest.js $EXOCORTEX_JEST_ARGS; then
         echo "✅ Exocortex grounding regression tests passed!"


### PR DESCRIPTION
## Summary

ExoSync A1 (RFC `4e4dc453`, task `7097576a`): platform-free sync core — the first walking-skeleton slice of git-backed bidirectional knowledge sync. **Orchestrates the EXISTING `restCreateCommit` primitive (D3); no new write path, primitive untouched.**

- **`ChangeDetector`** (D8/D18/D22, CQ2): pure uid-keyed diff of the local working tree against the per-device watermark (`lastSyncedSha[repo]` + remote-tree snapshot). Rename = same uid at new path → `modified` with `basePath`, not delete+add. D22 base validation: first-sync or stored-vs-actual root-tree mismatch (backup-restore / history rewrite / corrupt store, R10) → `full-conflict`, never silent overwrite.
- **`SyncEngine`** (VL#7, D12/D16/D19): per-repo pull → no-conflict check → push.
  - **D19 gate**: non-fully-materialized repo → skipped with warning, deletes NEVER inferred from local absence.
  - **No-conflict check**: any shared uid/path between pinned local changes and remote changes (incl. delete-vs-modify) → `conflict`, nothing pushed, nothing written (merge layer = A2/A3). Convergent edits (identical blob both sides) and convergent deletes are exempted.
  - **D16 retry**: PATCH-422 non-fast-forward → re-pull → re-check → retry, cap 3 → `retry-exhausted`.
  - **Deferred deletes/renames**: the primitive's `files` map cannot express deletions; pushing only the new path of a rename would duplicate the uid on remote — both are deferred with warnings until A2/A3.
  - **Binary safety**: `.md`-only allowlist applied symmetrically (local snapshot / remote diff / pull-apply / delete inference) — attachments are Phase C (D4/VL#3).
  - **Race window** (primitive has no CAS, D9): post-push parent≠examined-head detection, per-file warning only when overlapping pushed paths.
  - **D12**: `syncAll` best-effort warn-not-block, children-before-parent ordering helper.
- **`githubRepoReader`**: read-side Git Data API helpers over the SAME `RestCommitTransport` contract; loud failure on truncated trees.
- Watermark store / materialization check / sha1 / local-files are injected ports (production impls = A3 scope) — same hexagonal pattern as `restCommit.ts` / `AssetSpaceMount.ts`.

## Tests

- **37 unit tests** over a production-shape in-memory Git Data API fake (real git blob SHAs, transport error contract `→ HTTP {status}:`, `force:false` 422 semantics, race-injection hooks). Added to the CI allowlist (`scripts/test-ci-batched.sh`).
- **4 integration tests against REAL GitHub** (`kitelev/exosync-test-sandbox`, disposable per-run branch, created for this purpose): watermark bootstrap, push (commit verified on remote via ref+blob), disjoint pull→push convergence, conflict refusal (remote+disk untouched). Self-skips without a token; intentionally NOT in the CI allowlist (network+PAT).
- **Empirically verified to FAIL pre-fix and PASS post-fix** (integration-test-revert-verify): TEMP-REVERT A (push disabled) → push tests fail 2/4; TEMP-REVERT B (conflict detection disabled) → conflict test fails; restore → 41/41 pass.

## Test plan

- [x] Unit suite green locally (37/37)
- [x] Integration suite green vs real GitHub (4/4)
- [x] revert→fail / restore→pass both directions
- [ ] CI 13 required checks green
- [ ] code-reviewer agent pass on diff

RFC: vault-exodev `inbox/4e4dc453-9193-411c-8fdb-9e7dff3e63d9.md` · Task: `7097576a-148d-468f-98e9-ef8428829765` (ExoSync Phase A)