### PR TITLE
feat(exosync): A3 — synced quarantine, 422 terminal-quarantine, credential & watermark stores (RFC 4e4dc453)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -440,13 +440,15 @@ jobs:
         #   tests (issue-2997-repro / issue-2997-loader-2pc) run via test-coverage-cli;
         #   BGP unit suite needs explicit allow-list entry here because exocortex
         #   jest.config.js is otherwise unreachable from CI (see scripts/test-ci-batched.sh).
-        # - RFC 4e4dc453 A1+A2 (ExoSync): services/sync/*.test incl. StructuredMerger/MergeShaclGate/diff3
-        #   — platform-free sync core; this inline list (NOT test-ci-batched.sh,
-        #   which no workflow invokes) is the actual CI gate for exocortex suites.
+        # - RFC 4e4dc453 A1+A2+A3 (ExoSync): services/sync/*.test incl. StructuredMerger/
+        #   MergeShaclGate/diff3 + A3 SyncedQuarantineStore/FileWatermarkStore/
+        #   transportBackoff/secretScan — platform-free sync core; this inline list
+        #   (NOT test-ci-batched.sh, which no workflow invokes) is the actual CI gate
+        #   for exocortex suites.
         run: |
           node ./node_modules/jest/bin/jest.js \
             --config packages/exocortex/jest.config.js \
-            --testPathPatterns='(services/(GroundingExecutor(\.[a-zA-Z0-9_-]+)?|AssetConversionService|NoteToRDFConverter\.issue-2959)\.test|services/sync/(ChangeDetector|SyncEngine|StructuredMerger|GatedStructuredMerger|MergeShaclGate|diff3)\.test|application/services/RelationColumnSetResolver(\.property)?\.test|performance/RelationColumnSetResolverPerformance\.test|infrastructure/sparql/executors/BGPExecutor\.issue-2997\.test|integration/dynamic-commands/grounding-phase3b-pipeline\.test)\.ts' \
+            --testPathPatterns='(services/(GroundingExecutor(\.[a-zA-Z0-9_-]+)?|AssetConversionService|NoteToRDFConverter\.issue-2959)\.test|services/sync/(ChangeDetector|SyncEngine|StructuredMerger|GatedStructuredMerger|MergeShaclGate|diff3|SyncedQuarantineStore|FileWatermarkStore|transportBackoff|secretScan)\.test|application/services/RelationColumnSetResolver(\.property)?\.test|performance/RelationColumnSetResolverPerformance\.test|infrastructure/sparql/executors/BGPExecutor\.issue-2997\.test|integration/dynamic-commands/grounding-phase3b-pipeline\.test)\.ts' \
             --forceExit
 
   test-coverage:

--- a/packages/exocortex/src/index.ts
+++ b/packages/exocortex/src/index.ts
@@ -650,3 +650,32 @@ export {
 // ExoSync A2 — production MergeLayerPort composition: StructuredMerger +
 // optional SHACL gate; unresolvable/invalid merges quarantine (D17).
 export { GatedStructuredMerger } from "./services/sync/GatedStructuredMerger";
+// ExoSync A3 — durable stores + engineering baseline (RFC 4e4dc453):
+// synced quarantine repo (D17), durable watermark (D8/D22), credential
+// contract + auth detection (VL#10/R8), rate-limit backoff (R6),
+// secret-scan (R5).
+export {
+  FileWatermarkStore,
+  WATERMARK_STORE_FILENAME,
+  type WatermarkFileIO,
+} from "./services/sync/FileWatermarkStore";
+export {
+  isAuthError,
+  type CredentialStorePort,
+} from "./services/sync/CredentialStore";
+export {
+  isRateLimitError,
+  withRateLimitBackoff,
+  type BackoffOptions,
+} from "./services/sync/transportBackoff";
+export {
+  redactSecrets,
+  scanForSecrets,
+  type SecretFinding,
+} from "./services/sync/secretScan";
+export {
+  SyncedQuarantineStore,
+  type OpenQuarantineEntry,
+  type QuarantineEntryRecord,
+  type SyncedQuarantineStoreDeps,
+} from "./services/sync/SyncedQuarantineStore";

--- a/packages/exocortex/src/services/sync/CredentialStore.ts
+++ b/packages/exocortex/src/services/sync/CredentialStore.ts
@@ -1,0 +1,46 @@
+/**
+ * ExoSync credential contract (RFC 4e4dc453 VL#10 + R8, A3).
+ *
+ * The PAT lives in per-device secure storage and is NEVER committed:
+ *
+ *  - Obsidian plugin: `LocalSecretsStore` (key `"pat"`,
+ *    `.obsidian/plugins/exocortex/data.local.json` — the `.local.` infix is
+ *    Obsidian-Sync-excluded by convention).
+ *  - CLI / desktop: `gh auth token` (GitHub CLI's OS-keychain-backed
+ *    storage; see `RestPushService.resolveToken`).
+ *
+ * Both already satisfy this port shape; the formal adapter classes land
+ * with the Phase B wiring that actually composes a SyncEngine. A3 ships
+ * the contract + the auth-failure detector the engine uses for the R8
+ * "update your PAT" signal (`auth-required` status — never treated as
+ * success).
+ */
+
+/** Per-device secure credential storage (VL#10). */
+export interface CredentialStorePort {
+  /** Resolve the PAT, or null when none is stored (→ prompt, R8). */
+  getToken(): Promise<string | null>;
+  /** Store a new PAT; null/empty clears the stored value. */
+  setToken(token: string | null): Promise<void>;
+}
+
+/**
+ * Auth-failure detection over the transport error-message contract
+ * (`GitHub request {METHOD} {url} → HTTP {status}: {body}`): HTTP 401, or
+ * HTTP 403 WITHOUT rate-limit markers (403 + "rate limit"/"abuse
+ * detection" is throttling, not auth — see `isRateLimitError`).
+ *
+ * KNOWN BLIND SPOT: a fine-grained / under-scoped PAT gets **404** from
+ * GitHub on private-repo refs (existence-hiding), indistinguishable from
+ * repo-not-found — that misconfiguration surfaces as a generic error, not
+ * `auth-required`. Document in user-facing troubleshooting (R8).
+ */
+export function isAuthError(err: unknown): boolean {
+  const msg = err instanceof Error ? err.message : String(err);
+  if (/HTTP 401/.test(msg)) return true;
+  return (
+    /HTTP 403/.test(msg) &&
+    !/rate limit/i.test(msg) &&
+    !/abuse detection/i.test(msg)
+  );
+}

--- a/packages/exocortex/src/services/sync/FileWatermarkStore.ts
+++ b/packages/exocortex/src/services/sync/FileWatermarkStore.ts
@@ -1,0 +1,90 @@
+/**
+ * ExoSync durable per-device watermark store (RFC 4e4dc453 D8/D22, A3).
+ *
+ * One JSON file holds every repo's {@link WatermarkRecord}, keyed by
+ * `repoKey` — the `data.local.json` pattern: the file carries the `.local.`
+ * infix (convention: `exosync-watermarks.local.json`), which Obsidian Sync
+ * excludes by convention AND `isSyncablePath` refuses symmetrically
+ * (gitignore allowlist — the watermark must never be committed).
+ *
+ * Platform-free: file access goes through the injected
+ * {@link WatermarkFileIO}; the adapter is trivial on both platforms
+ * (plugin: `app.vault.adapter`; CLI: `node:fs` + temp+rename).
+ *
+ * Corruption tolerance (R10): a missing or unparseable file yields
+ * `get() === null` for every repo — the engine then takes the
+ * first-sync/full-conflict path (D22), never a silent overwrite. The store
+ * itself never throws on read.
+ *
+ * Writes are serialized through an internal promise chain (lossless RMW —
+ * concurrent `set` calls for different repos cannot clobber each other)
+ * and MUST be atomic at the IO layer (temp file + rename) so a crash
+ * mid-write cannot leave a torn store — torn watermark = wrong 3-way base.
+ */
+
+import type { WatermarkRecord, WatermarkStorePort } from "./syncTypes";
+
+/** Single-file IO port. `writeAtomic` MUST be temp-file + rename. */
+export interface WatermarkFileIO {
+  /** File content, or null when the file does not exist. */
+  read(): Promise<string | null>;
+  writeAtomic(content: string): Promise<void>;
+}
+
+/** Recommended store filename — `.local.` infix is Sync-excluded. */
+export const WATERMARK_STORE_FILENAME = "exosync-watermarks.local.json";
+
+interface StoreShape {
+  version: 1;
+  repos: Record<string, WatermarkRecord>;
+}
+
+function isWatermarkRecord(v: unknown): v is WatermarkRecord {
+  if (v === null || typeof v !== "object") return false;
+  const r = v as Record<string, unknown>;
+  return (
+    typeof r.lastSyncedSha === "string" &&
+    typeof r.rootTreeSha === "string" &&
+    Array.isArray(r.files)
+  );
+}
+
+export class FileWatermarkStore implements WatermarkStorePort {
+  private writeChain: Promise<void> = Promise.resolve();
+
+  constructor(private readonly io: WatermarkFileIO) {}
+
+  async get(repoKey: string): Promise<WatermarkRecord | null> {
+    const repos = await this.readRepos();
+    const record = repos[repoKey];
+    return isWatermarkRecord(record) ? record : null;
+  }
+
+  async set(repoKey: string, record: WatermarkRecord): Promise<void> {
+    const task = this.writeChain.then(async () => {
+      const repos = await this.readRepos();
+      repos[repoKey] = record;
+      const store: StoreShape = { version: 1, repos };
+      await this.io.writeAtomic(JSON.stringify(store, null, 2));
+    });
+    // Keep the chain alive even when a write fails — the NEXT set must
+    // still run; the failure propagates to THIS caller only.
+    this.writeChain = task.catch(() => undefined);
+    return task;
+  }
+
+  /** Tolerant read: absent/corrupt file → empty store (R10, never throws). */
+  private async readRepos(): Promise<Record<string, WatermarkRecord>> {
+    try {
+      const raw = await this.io.read();
+      if (raw === null) return {};
+      const parsed = JSON.parse(raw) as unknown;
+      if (parsed === null || typeof parsed !== "object") return {};
+      const repos = (parsed as { repos?: unknown }).repos;
+      if (repos === null || typeof repos !== "object") return {};
+      return { ...(repos as Record<string, WatermarkRecord>) };
+    } catch {
+      return {};
+    }
+  }
+}

--- a/packages/exocortex/src/services/sync/StructuredMerger.ts
+++ b/packages/exocortex/src/services/sync/StructuredMerger.ts
@@ -54,6 +54,22 @@ const FM_RE = /^---\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)/;
 
 const INSTANCE_CLASS_KEY = "exo__Instance_class";
 
+/**
+ * Plain-data guard (A2 deferred finding): the YAML codec contract requires
+ * scalars to round-trip as strings (CORE_SCHEMA), but a consumer codec
+ * violating it produces Date instances — and two DIFFERENT Dates have zero
+ * enumerable keys each, so a structural deepEqual silently treats them as
+ * equal, collapsing divergent timestamps. Non-plain values are therefore
+ * rejected fail-loud (conflict) before any per-key merge logic runs.
+ */
+function isPlainValue(v: unknown): boolean {
+  if (v === null || typeof v !== "object") return true;
+  if (Array.isArray(v)) return v.every(isPlainValue);
+  const proto: unknown = Object.getPrototypeOf(v);
+  if (proto !== Object.prototype && proto !== null) return false;
+  return Object.values(v as Record<string, unknown>).every(isPlainValue);
+}
+
 function deepEqual(a: unknown, b: unknown): boolean {
   if (a === b) return true;
   if (
@@ -148,6 +164,13 @@ function mergeFrontmatter(
     const b = base[key];
     const l = local[key];
     const r = remote[key];
+
+    if (!isPlainValue(b) || !isPlainValue(l) || !isPlainValue(r)) {
+      return {
+        ok: false,
+        reason: `frontmatter key "${key}" contains a non-plain value (Date?) — the codec must round-trip scalars as strings (CORE_SCHEMA contract)`,
+      };
+    }
 
     if (Array.isArray(b) || Array.isArray(l) || Array.isArray(r)) {
       if (!(key in local) && !(key in remote)) continue; // deleted both sides

--- a/packages/exocortex/src/services/sync/SyncEngine.ts
+++ b/packages/exocortex/src/services/sync/SyncEngine.ts
@@ -46,6 +46,9 @@ import {
 } from "./githubRepoReader";
 import { detectChanges, extractAssetUid } from "./ChangeDetector";
 import { gitBlobSha } from "./gitBlobSha";
+import { isAuthError } from "./CredentialStore";
+import { scanForSecrets } from "./secretScan";
+import { withRateLimitBackoff, type BackoffOptions } from "./transportBackoff";
 import {
   isSyncablePath,
   type AssetChange,
@@ -91,12 +94,18 @@ export interface SyncEngineDeps {
    */
   mergeLayer?: MergeLayerPort;
   /**
-   * Quarantine sink for unresolvable / SHACL-invalid merges (D17). Optional —
-   * skipping it loses no data: the file stays untouched on disk and the
-   * watermark pin re-derives the conflict every sync (durable synced store is
-   * A3 scope).
+   * Quarantine sink for unresolvable / SHACL-invalid merges (D17) and for
+   * D16 terminal-quarantine (contended files after retry exhaustion).
+   * Production: `SyncedQuarantineStore`. Optional — skipping it loses no
+   * data: the file stays untouched on disk and the watermark pin (or the
+   * non-advanced watermark) re-derives the conflict every sync.
    */
   quarantine?: QuarantinePort;
+  /**
+   * Rate-limit backoff tuning (R6). The engine always wraps the transport
+   * with `withRateLimitBackoff`; inject `sleep`/`random` in tests.
+   */
+  backoff?: BackoffOptions;
 }
 
 /** Reject absolute, backslash, empty-segment, `.`/`..` paths (zip-slip guard). */
@@ -226,7 +235,15 @@ interface MergeResolution {
 /** Outcome of the pull→check→push retry loop. */
 type PushLoopOutcome =
   | { kind: "conflict"; detail: string }
-  | { kind: "retry-exhausted"; detail: string }
+  | {
+      kind: "retry-exhausted";
+      detail: string;
+      /** The contended payload of the LAST attempt — terminal-quarantine input (D16→D17). */
+      pushFiles: Map<string, string>;
+      /** Last iteration's merge resolution — its quarantine entries must not be lost. */
+      merge: MergeResolution;
+    }
+  | { kind: "secret-detected"; detail: string }
   | {
       kind: "done";
       examinedHead: string;
@@ -247,27 +264,65 @@ const EMPTY_MERGE: MergeResolution = {
 
 export class SyncEngine {
   private readonly deps: SyncEngineDeps;
+  /** Backoff-wrapped transport (R6) — ALL remote calls go through it. */
+  private readonly transport: RestCommitTransport;
+  /** D11 — one sync/apply operation at a time. */
+  private opInProgress = false;
 
   constructor(deps: SyncEngineDeps) {
     this.deps = deps;
+    this.transport = withRateLimitBackoff(deps.transport, deps.backoff);
+  }
+
+  /** D11 busy verdict — the caller retries after the running op finishes. */
+  private busyResult(spec: SyncRepoSpec): RepoSyncResult {
+    return {
+      repoKey: spec.repoKey,
+      status: "busy",
+      pulledCount: 0,
+      pushedCount: 0,
+      mergedCount: 0,
+      quarantinedCount: 0,
+      warnings: [],
+      deferredDeletes: [],
+      detail:
+        "another sync/apply operation is in progress (D11 guard) — retry after it finishes",
+    };
   }
 
   /**
    * Sync every repo of the materialized set, best-effort (D12): a per-repo
    * failure becomes that repo's `error` result, never an exception. Specs are
    * processed in the given order — pass children before parents (use
-   * {@link orderChildrenFirst}).
+   * {@link orderChildrenFirst}). Acquires the D11 guard ONCE for the whole
+   * run — per-repo cycles inside never see their own guard.
    */
   async syncAll(specs: SyncRepoSpec[]): Promise<RepoSyncResult[]> {
-    const results: RepoSyncResult[] = [];
-    for (const spec of specs) {
-      results.push(await this.sync(spec));
+    if (this.opInProgress) return specs.map((spec) => this.busyResult(spec));
+    this.opInProgress = true;
+    try {
+      const results: RepoSyncResult[] = [];
+      for (const spec of specs) {
+        results.push(await this.syncLocked(spec));
+      }
+      return results;
+    } finally {
+      this.opInProgress = false;
     }
-    return results;
   }
 
   /** Sync one repo. Never throws — failures map to a result status (CQ5). */
   async sync(spec: SyncRepoSpec): Promise<RepoSyncResult> {
+    if (this.opInProgress) return this.busyResult(spec);
+    this.opInProgress = true;
+    try {
+      return await this.syncLocked(spec);
+    } finally {
+      this.opInProgress = false;
+    }
+  }
+
+  private async syncLocked(spec: SyncRepoSpec): Promise<RepoSyncResult> {
     const warnings: string[] = [];
     const deferredDeletes: string[] = [];
     const result = (
@@ -337,8 +392,26 @@ export class SyncEngine {
       if (loop.kind === "conflict") {
         return result("conflict", { detail: loop.detail });
       }
+      if (loop.kind === "secret-detected") {
+        return result("error", { detail: loop.detail });
+      }
       if (loop.kind === "retry-exhausted") {
-        return result("retry-exhausted", { detail: loop.detail });
+        // D16 terminal-quarantine: the contended files of the last attempt
+        // PLUS any pending merge-quarantine entries (they would otherwise be
+        // lost — the loop recomputes the merge per iteration). The watermark
+        // is NOT advanced, so everything re-derives next sync regardless.
+        const terminal = await this.buildTerminalQuarantineEntries(
+          spec,
+          watermark,
+          loop.pushFiles,
+          loop.merge.quarantineEntries,
+        );
+        const entries = [...loop.merge.quarantineEntries, ...terminal];
+        await this.flushQuarantine(entries, warnings);
+        return result("retry-exhausted", {
+          detail: loop.detail,
+          quarantinedCount: entries.length,
+        });
       }
       const { examinedHead, pushedSha, applyWrites, applyDeletes, pushFiles } =
         loop;
@@ -347,12 +420,7 @@ export class SyncEngine {
 
       // Quarantine sink fires ONCE, after the retry loop settled (D17). The
       // entries' paths are pinned below so the conflict re-derives next sync.
-      for (const entry of merge.quarantineEntries) {
-        await this.deps.quarantine?.quarantine(entry);
-        warnings.push(
-          `quarantined ${entry.path}: ${entry.reason} — both versions preserved; conflict re-derives until resolved (D17)`,
-        );
-      }
+      await this.flushQuarantine(merge.quarantineEntries, warnings);
 
       // No-op fast path: nothing pushed, head unmoved, nothing to apply —
       // the watermark is already exact; skip the head-tree fetch and the
@@ -373,7 +441,7 @@ export class SyncEngine {
 
       const newHead = pushedSha ?? examinedHead;
       const newCommit = await getCommitInfo(
-        this.deps.transport,
+        this.transport,
         spec.owner,
         spec.repo,
         newHead,
@@ -428,11 +496,18 @@ export class SyncEngine {
         newHead,
         newCommit.treeSha,
         disk,
-        applyWrites,
+        // Merged writes carry their precomputed blob SHA (A2 deferred LOW) —
+        // the watermark rebuild must not re-fetch blobs it already knows.
+        [...applyWrites, ...merge.mergedWrites],
         watermark,
         pinnedPaths,
         detection.diskBlobShas,
       );
+
+      // A pin that existed on the PREVIOUS watermark and cleared in this
+      // cycle means its conflict resolved convergently — best-effort close
+      // the matching quarantine entry (CQ4 unresolved-count accuracy).
+      await this.resolveClearedPins(spec, watermark, pinnedPaths, warnings);
 
       return result("synced", {
         pushedSha,
@@ -443,8 +518,152 @@ export class SyncEngine {
       });
     } catch (err) {
       const redact = this.deps.redact ?? ((m: string): string => m);
+      if (isAuthError(err)) {
+        return result("auth-required", {
+          detail: redact(
+            `authentication failed: ${errMsg(err)} — the PAT is expired, revoked or under-scoped; update it in the per-device secure storage (R8). Never treated as success.`,
+          ),
+        });
+      }
       warnings.push(`sync failed: ${redact(errMsg(err))}`);
       return result("error", { detail: redact(errMsg(err)) });
+    }
+  }
+
+  /**
+   * Flush quarantine entries to the sink (D17), preferring the batched
+   * `quarantineAll` (one commit per flush — a terminal flush can carry
+   * dozens of files). A sink failure degrades to a WARNING, never an error
+   * status: the file stays untouched on disk and the pin / non-advanced
+   * watermark re-derives the conflict next sync.
+   */
+  private async flushQuarantine(
+    entries: QuarantineEntry[],
+    warnings: string[],
+  ): Promise<void> {
+    if (entries.length === 0) return;
+    for (const entry of entries) {
+      warnings.push(
+        `quarantined ${entry.path}: ${entry.reason} — both versions preserved; conflict re-derives until resolved (D17)`,
+      );
+    }
+    const sink = this.deps.quarantine;
+    if (sink === undefined) return;
+    try {
+      if (sink.quarantineAll !== undefined) {
+        await sink.quarantineAll(entries);
+      } else {
+        for (const entry of entries) {
+          await sink.quarantine(entry);
+        }
+      }
+    } catch (err) {
+      const redact = this.deps.redact ?? ((m: string): string => m);
+      warnings.push(
+        `quarantine sink failed: ${redact(errMsg(err))} — files untouched on disk; the conflict re-derives next sync (D17 degradation)`,
+      );
+    }
+  }
+
+  /**
+   * Terminal-quarantine input (D16): one entry per contended push file,
+   * with the current remote head version attached best-effort (the base is
+   * recoverable from git history via the watermark SHA — not fetched, to
+   * keep the flush cheap). Paths already covered by merge-quarantine
+   * entries are skipped (disjoint by construction; defensive anyway).
+   */
+  private async buildTerminalQuarantineEntries(
+    spec: SyncRepoSpec,
+    watermark: WatermarkRecord,
+    pushFiles: Map<string, string>,
+    alreadyQuarantined: QuarantineEntry[],
+  ): Promise<QuarantineEntry[]> {
+    const covered = new Set(alreadyQuarantined.map((e) => e.path));
+    const remoteByPath = new Map<string, string>();
+    try {
+      const head = await getHeadSha(
+        this.transport,
+        spec.owner,
+        spec.repo,
+        spec.branch,
+        this.deps.baseURL,
+      );
+      const headTree = (
+        await getTree(
+          this.transport,
+          spec.owner,
+          spec.repo,
+          (
+            await getCommitInfo(
+              this.transport,
+              spec.owner,
+              spec.repo,
+              head,
+              this.deps.baseURL,
+            )
+          ).treeSha,
+          this.deps.baseURL,
+        )
+      ).filter((e) => pushFiles.has(e.path));
+      for (const e of headTree) {
+        remoteByPath.set(
+          e.path,
+          await getBlobText(
+            this.transport,
+            spec.owner,
+            spec.repo,
+            e.blobSha,
+            this.deps.baseURL,
+          ),
+        );
+      }
+    } catch {
+      // best-effort — entries still carry the local version
+    }
+
+    const entries: QuarantineEntry[] = [];
+    for (const [path, content] of pushFiles) {
+      if (covered.has(path)) continue;
+      const uid = extractAssetUid(content);
+      const remoteContent = remoteByPath.get(path);
+      entries.push({
+        repoKey: spec.repoKey,
+        path,
+        ...(uid !== undefined ? { uid } : {}),
+        reason: `non-fast-forward push failed after ${this.deps.maxPushRetries ?? DEFAULT_MAX_PUSH_RETRIES} retries (D16) — a concurrent writer keeps moving ${spec.branch}; base recoverable from git history at ${watermark.lastSyncedSha}`,
+        localContent: content,
+        ...(remoteContent !== undefined ? { remoteContent } : {}),
+      });
+    }
+    return entries;
+  }
+
+  /**
+   * Best-effort `markResolved` for pins that cleared in this cycle (the
+   * conflict converged) — keeps the cross-device unresolved-count honest
+   * (CQ4). No-ops when the port lacks `markResolved` or the pin came from
+   * a TOCTOU skip (no entry exists — the store treats that as a no-op).
+   */
+  private async resolveClearedPins(
+    spec: SyncRepoSpec,
+    previous: WatermarkRecord,
+    newPins: ReadonlySet<string>,
+    warnings: string[],
+  ): Promise<void> {
+    const sink = this.deps.quarantine;
+    if (sink === undefined || sink.markResolved === undefined) return;
+    const cleared = (previous.pinnedPaths ?? []).filter(
+      (p) => !newPins.has(p),
+    );
+    for (const path of cleared) {
+      try {
+        await sink.markResolved?.(spec.repoKey, path);
+      } catch (err) {
+        const redact = this.deps.redact ?? ((m: string): string => m);
+        warnings.push(
+          `quarantine markResolved failed for ${path}: ${redact(errMsg(err))} — unresolved-count may overcount until the resolver UI reconciles (CQ4)`,
+        );
+      }
     }
   }
 
@@ -459,7 +678,7 @@ export class SyncEngine {
     try {
       return (
         await getCommitInfo(
-          this.deps.transport,
+          this.transport,
           spec.owner,
           spec.repo,
           watermark.lastSyncedSha,
@@ -544,7 +763,7 @@ export class SyncEngine {
 
     for (;;) {
       examinedHead = await getHeadSha(
-        this.deps.transport,
+        this.transport,
         spec.owner,
         spec.repo,
         spec.branch,
@@ -598,8 +817,20 @@ export class SyncEngine {
       ]);
       if (pushFiles.size === 0) break;
 
+      // R5 secret-scan — refuse the WHOLE push (a partial set could ship an
+      // inconsistent asset graph). Findings carry path+kind, never the secret.
+      const findings = scanForSecrets(pushFiles);
+      if (findings.length > 0) {
+        return {
+          kind: "secret-detected",
+          detail: `secret-scan: refusing to push — ${findings
+            .map((f) => `${f.path} (${f.kind})`)
+            .join(", ")} (R5); remove the secret and re-sync`,
+        };
+      }
+
       try {
-        pushedSha = await restCreateCommit(this.deps.transport, {
+        pushedSha = await restCreateCommit(this.transport, {
           owner: spec.owner,
           repo: spec.repo,
           branch: spec.branch,
@@ -617,7 +848,9 @@ export class SyncEngine {
         if (attempt > maxRetries) {
           return {
             kind: "retry-exhausted",
-            detail: `non-fast-forward push failed after ${maxRetries} retries (D16 cap) — quarantine convergence is A3 scope`,
+            detail: `non-fast-forward push failed after ${maxRetries} retries (D16 cap) — contended files routed to quarantine (D17)`,
+            pushFiles,
+            merge,
           };
         }
         warnings.push(
@@ -686,7 +919,7 @@ export class SyncEngine {
       let base: string | undefined;
       if (baseEntry !== undefined) {
         base = await getBlobText(
-          this.deps.transport,
+          this.transport,
           spec.owner,
           spec.repo,
           baseEntry.blobSha,
@@ -735,11 +968,15 @@ export class SyncEngine {
         mergedFiles.set(group.local.path, decision.content);
       }
       if (decision.content !== disk.get(group.local.path)) {
+        const uid = extractAssetUid(decision.content) ?? group.local.uid;
         mergedWrites.push({
           path: group.local.path,
           kind: "change",
           content: decision.content,
-          ...(group.local.uid !== undefined ? { uid: group.local.uid } : {}),
+          // Precomputed so the watermark rebuild reuses it instead of
+          // re-fetching the merged blob (A2 deferred LOW).
+          blobSha: await gitBlobSha(decision.content, this.deps.sha1),
+          ...(uid !== undefined ? { uid } : {}),
         });
       }
     }
@@ -836,7 +1073,7 @@ export class SyncEngine {
   ): Promise<void> {
     const newTree = (
       await getTree(
-        this.deps.transport,
+        this.transport,
         spec.owner,
         spec.repo,
         newTreeSha,
@@ -879,14 +1116,14 @@ export class SyncEngine {
     ) => RepoSyncResult,
   ): Promise<RepoSyncResult> {
     const head = await getHeadSha(
-      this.deps.transport,
+      this.transport,
       spec.owner,
       spec.repo,
       spec.branch,
       this.deps.baseURL,
     );
     const headCommit = await getCommitInfo(
-      this.deps.transport,
+      this.transport,
       spec.owner,
       spec.repo,
       head,
@@ -894,7 +1131,7 @@ export class SyncEngine {
     );
     const headTree = (
       await getTree(
-        this.deps.transport,
+        this.transport,
         spec.owner,
         spec.repo,
         headCommit.treeSha,
@@ -942,7 +1179,7 @@ export class SyncEngine {
     head: string,
   ): Promise<RemoteChange[]> {
     const headCommit = await getCommitInfo(
-      this.deps.transport,
+      this.transport,
       spec.owner,
       spec.repo,
       head,
@@ -950,7 +1187,7 @@ export class SyncEngine {
     );
     const headTree = (
       await getTree(
-        this.deps.transport,
+        this.transport,
         spec.owner,
         spec.repo,
         headCommit.treeSha,
@@ -962,7 +1199,7 @@ export class SyncEngine {
     const changes: RemoteChange[] = [];
     for (const c of changed) {
       const content = await getBlobText(
-        this.deps.transport,
+        this.transport,
         spec.owner,
         spec.repo,
         c.blobSha,
@@ -1048,6 +1285,28 @@ export class SyncEngine {
           convergedPushPaths.add(local.path);
           continue;
         }
+        if (
+          r.kind === "delete" &&
+          local.basePath !== undefined &&
+          r.path === local.basePath
+        ) {
+          // Convergent rename (A2 deferred MEDIUM): both sides renamed
+          // basePath → path. The remote delete of the OLD path is only
+          // convergent when the remote also carries the SAME content at the
+          // NEW path — anything weaker (a genuine remote delete, or a rename
+          // with an edit) must keep conflicting: silently consuming it would
+          // let the next sync push the renamed copy and resurrect a
+          // remotely-deleted asset.
+          const remoteAtNewPath = remoteByPath.get(local.path);
+          if (
+            remoteAtNewPath !== undefined &&
+            remoteAtNewPath.kind === "change" &&
+            remoteAtNewPath.blobSha === local.blobSha
+          ) {
+            consumed.add(r); // old path gone on both sides
+            continue;
+          }
+        }
         conflicting.push(r);
         consumed.add(r); // conflicting remote is owned by the merge layer
       }
@@ -1089,7 +1348,7 @@ export class SyncEngine {
   ): Promise<void> {
     try {
       const parentCommit = await getCommitInfo(
-        this.deps.transport,
+        this.transport,
         spec.owner,
         spec.repo,
         actualParent,
@@ -1097,7 +1356,7 @@ export class SyncEngine {
       );
       const parentTree = (
         await getTree(
-          this.deps.transport,
+          this.transport,
           spec.owner,
           spec.repo,
           parentCommit.treeSha,
@@ -1109,12 +1368,12 @@ export class SyncEngine {
           ? watermark.files
           : (
               await getTree(
-                this.deps.transport,
+                this.transport,
                 spec.owner,
                 spec.repo,
                 (
                   await getCommitInfo(
-                    this.deps.transport,
+                    this.transport,
                     spec.owner,
                     spec.repo,
                     examinedHead,
@@ -1184,7 +1443,7 @@ export class SyncEngine {
         uid = uidByBlobSha.get(entry.blobSha);
       } else {
         const content = await getBlobText(
-          this.deps.transport,
+          this.transport,
           spec.owner,
           spec.repo,
           entry.blobSha,

--- a/packages/exocortex/src/services/sync/SyncEngine.ts
+++ b/packages/exocortex/src/services/sync/SyncEngine.ts
@@ -274,7 +274,13 @@ export class SyncEngine {
     this.transport = withRateLimitBackoff(deps.transport, deps.backoff);
   }
 
-  /** D11 busy verdict — the caller retries after the running op finishes. */
+  /**
+   * D11 busy verdict — the caller retries after the running op finishes.
+   * Scope note: the guard currently covers SYNC operations of this engine
+   * instance only; wiring the profile-APPLY side into the same exclusion
+   * is Phase B composition scope (the apply path has its own
+   * `_switchInProgress` journal today).
+   */
   private busyResult(spec: SyncRepoSpec): RepoSyncResult {
     return {
       repoKey: spec.repoKey,
@@ -286,7 +292,7 @@ export class SyncEngine {
       warnings: [],
       deferredDeletes: [],
       detail:
-        "another sync/apply operation is in progress (D11 guard) — retry after it finishes",
+        "another sync operation is in progress (D11 guard) — retry after it finishes",
     };
   }
 
@@ -400,11 +406,13 @@ export class SyncEngine {
         // PLUS any pending merge-quarantine entries (they would otherwise be
         // lost — the loop recomputes the merge per iteration). The watermark
         // is NOT advanced, so everything re-derives next sync regardless.
+        warnings.push(...loop.merge.warnings);
         const terminal = await this.buildTerminalQuarantineEntries(
           spec,
           watermark,
           loop.pushFiles,
           loop.merge.quarantineEntries,
+          disk,
         );
         const entries = [...loop.merge.quarantineEntries, ...terminal];
         await this.flushQuarantine(entries, warnings);
@@ -542,9 +550,12 @@ export class SyncEngine {
     warnings: string[],
   ): Promise<void> {
     if (entries.length === 0) return;
+    const redact = this.deps.redact ?? ((m: string): string => m);
     for (const entry of entries) {
       warnings.push(
-        `quarantined ${entry.path}: ${entry.reason} — both versions preserved; conflict re-derives until resolved (D17)`,
+        redact(
+          `quarantined ${entry.path}: ${entry.reason} — both versions preserved; conflict re-derives until resolved (D17)`,
+        ),
       );
     }
     const sink = this.deps.quarantine;
@@ -571,12 +582,18 @@ export class SyncEngine {
    * recoverable from git history via the watermark SHA — not fetched, to
    * keep the flush cheap). Paths already covered by merge-quarantine
    * entries are skipped (disjoint by construction; defensive anyway).
+   *
+   * `localContent` is the ON-DISK version (the durable record must show
+   * what the user actually has) — for a merge-resolved-but-contended path
+   * the push payload is a merged PROPOSAL that was never applied to disk;
+   * it is dropped (the merge re-derives next sync) and the reason notes it.
    */
   private async buildTerminalQuarantineEntries(
     spec: SyncRepoSpec,
     watermark: WatermarkRecord,
     pushFiles: Map<string, string>,
     alreadyQuarantined: QuarantineEntry[],
+    disk: ReadonlyMap<string, string>,
   ): Promise<QuarantineEntry[]> {
     const covered = new Set(alreadyQuarantined.map((e) => e.path));
     const remoteByPath = new Map<string, string>();
@@ -624,14 +641,18 @@ export class SyncEngine {
     const entries: QuarantineEntry[] = [];
     for (const [path, content] of pushFiles) {
       if (covered.has(path)) continue;
-      const uid = extractAssetUid(content);
+      const diskContent = disk.get(path);
+      const localContent = diskContent ?? content;
+      const wasMergedProposal =
+        diskContent !== undefined && diskContent !== content;
+      const uid = extractAssetUid(localContent);
       const remoteContent = remoteByPath.get(path);
       entries.push({
         repoKey: spec.repoKey,
         path,
         ...(uid !== undefined ? { uid } : {}),
-        reason: `non-fast-forward push failed after ${this.deps.maxPushRetries ?? DEFAULT_MAX_PUSH_RETRIES} retries (D16) — a concurrent writer keeps moving ${spec.branch}; base recoverable from git history at ${watermark.lastSyncedSha}`,
-        localContent: content,
+        reason: `non-fast-forward push failed after ${this.deps.maxPushRetries ?? DEFAULT_MAX_PUSH_RETRIES} retries (D16) — a concurrent writer keeps moving ${spec.branch}; base recoverable from git history at ${watermark.lastSyncedSha}${wasMergedProposal ? "; the contended push payload was a merged proposal (never applied to disk) — the merge re-derives next sync" : ""}`,
+        localContent,
         ...(remoteContent !== undefined ? { remoteContent } : {}),
       });
     }

--- a/packages/exocortex/src/services/sync/SyncedQuarantineStore.ts
+++ b/packages/exocortex/src/services/sync/SyncedQuarantineStore.ts
@@ -1,0 +1,341 @@
+/**
+ * ExoSync synced quarantine store (RFC 4e4dc453 D17, A3).
+ *
+ * Durable QuarantinePort: conflict copies are committed to a SEPARATE
+ * synced quarantine repo through the same `restCreateCommit` primitive
+ * (D3 — no new write path). Entries survive reinstall / device loss, are
+ * visible cross-device, and give the real unresolved-count (CQ4).
+ *
+ * Deliberate non-ontology design (interaction-fix in the RFC):
+ *
+ *  - The quarantine repo is a PLAIN synced dir, NOT an `exo__FileSpace` —
+ *    A3 does not depend on the Phase C ontology.
+ *  - Entries are `.json` files: the RDF walker only parses `.md`, so the
+ *    quarantine is automatically excluded from the triple store (no UID,
+ *    no SHACL), and `isSyncablePath` refuses `.json` symmetrically, so
+ *    entries never leak into the canonical sync cycle.
+ *  - Always-mounted floor, EXEMPT from the D19 full-materialization gate:
+ *    this store writes straight through the transport and never passes
+ *    through `SyncEngine`'s gate — a quarantine flush is never skipped,
+ *    and delete-from-absence never applies to it.
+ *
+ * Idempotency & churn control: one entry = ONE stable filename
+ * (slug + 8-hex sha1 of `repoKey\0path`). Re-quarantining preserves the
+ * original `quarantinedAt` and SKIPS the push when the entry is
+ * semantically identical — an unresolved conflict that re-derives every
+ * sync produces zero commits until its content actually changes.
+ *
+ * Deletion: the write primitive cannot delete files, so resolution is a
+ * tombstone-by-overwrite — `markResolved` rewrites the entry with
+ * `status: "resolved"`. Open entries are the ones that count (CQ4).
+ *
+ * Secrets: entry contents are REDACTED (not refused) — a conflict copy
+ * embedding a PAT is still preserved durably, minus the secret.
+ */
+
+import {
+  restCreateCommit,
+  type RestCommitTransport,
+} from "../../infrastructure/github/restCommit";
+import {
+  getBlobText,
+  getCommitInfo,
+  getHeadSha,
+  getTree,
+} from "./githubRepoReader";
+import { isNonFastForwardError } from "./SyncEngine";
+import { redactSecrets } from "./secretScan";
+import type { QuarantineEntry, QuarantinePort, Sha1Fn } from "./syncTypes";
+
+/** Persisted shape of one quarantine entry file. */
+export interface QuarantineEntryRecord {
+  version: 1;
+  repoKey: string;
+  path: string;
+  uid?: string;
+  reason: string;
+  status: "open" | "resolved";
+  quarantinedAt: string;
+  resolvedAt?: string;
+  baseContent?: string;
+  localContent?: string;
+  remoteContent?: string;
+}
+
+export interface SyncedQuarantineStoreDeps {
+  /**
+   * Transport for the quarantine repo. Pass the SAME rate-limit-backoff-
+   * wrapped transport the engine uses (`withRateLimitBackoff`) — the
+   * quarantine flush is the highest-volume caller.
+   */
+  transport: RestCommitTransport;
+  sha1: Sha1Fn;
+  /** The dedicated quarantine repo (always-mounted floor, D19-exempt). */
+  owner: string;
+  repo: string;
+  branch: string;
+  baseURL?: string;
+  redact?: (message: string) => string;
+  /** Injected clock (ISO string) — deterministic tests. */
+  now?: () => string;
+  /** Direct retries on a 422 concurrent-push race. Default 3. */
+  maxPushRetries?: number;
+}
+
+const ENTRIES_PREFIX = "entries/";
+const MAX_SLUG_LENGTH = 80;
+
+/** Filesystem-safe, length-bounded slug (collision-proofed by the hash). */
+function slug(value: string): string {
+  return value.replace(/[^A-Za-z0-9._-]/g, "_").slice(0, MAX_SLUG_LENGTH);
+}
+
+function parseRecord(raw: string): QuarantineEntryRecord | null {
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    if (parsed === null || typeof parsed !== "object") return null;
+    const r = parsed as Record<string, unknown>;
+    if (
+      typeof r.repoKey !== "string" ||
+      typeof r.path !== "string" ||
+      typeof r.reason !== "string" ||
+      (r.status !== "open" && r.status !== "resolved")
+    ) {
+      return null;
+    }
+    return parsed as QuarantineEntryRecord;
+  } catch {
+    return null;
+  }
+}
+
+/** Open-entry summary (CQ4). */
+export interface OpenQuarantineEntry {
+  entryPath: string;
+  repoKey: string;
+  path: string;
+  uid?: string;
+  reason: string;
+  quarantinedAt: string;
+}
+
+export class SyncedQuarantineStore implements QuarantinePort {
+  private readonly deps: SyncedQuarantineStoreDeps;
+
+  constructor(deps: SyncedQuarantineStoreDeps) {
+    this.deps = deps;
+  }
+
+  async quarantine(entry: QuarantineEntry): Promise<void> {
+    await this.quarantineAll([entry]);
+  }
+
+  /**
+   * Persist many entries in ONE commit (a D16 terminal flush can carry
+   * dozens of contended files). Unchanged entries are skipped; when every
+   * entry is unchanged, no commit happens at all.
+   */
+  async quarantineAll(entries: QuarantineEntry[]): Promise<void> {
+    if (entries.length === 0) return;
+    const existing = await this.readEntries(
+      await Promise.all(entries.map((e) => this.entryPath(e.repoKey, e.path))),
+    );
+
+    const files = new Map<string, string>();
+    for (const entry of entries) {
+      const entryPath = await this.entryPath(entry.repoKey, entry.path);
+      const prior = existing.get(entryPath) ?? null;
+      // Reopening a resolved entry is a NEW conflict event → fresh
+      // timestamp; an entry that is already open keeps its original one.
+      const quarantinedAt =
+        prior !== null && prior.status === "open"
+          ? prior.quarantinedAt
+          : (this.deps.now ?? (() => new Date().toISOString()))();
+      const record: QuarantineEntryRecord = {
+        version: 1,
+        repoKey: entry.repoKey,
+        path: entry.path,
+        ...(entry.uid !== undefined ? { uid: entry.uid } : {}),
+        reason: entry.reason,
+        status: "open",
+        quarantinedAt,
+        ...(entry.baseContent !== undefined
+          ? { baseContent: redactSecrets(entry.baseContent) }
+          : {}),
+        ...(entry.localContent !== undefined
+          ? { localContent: redactSecrets(entry.localContent) }
+          : {}),
+        ...(entry.remoteContent !== undefined
+          ? { remoteContent: redactSecrets(entry.remoteContent) }
+          : {}),
+      };
+      const serialized = JSON.stringify(record, null, 2);
+      if (prior !== null && JSON.stringify(prior, null, 2) === serialized) {
+        continue; // semantically identical — zero commit churn
+      }
+      files.set(entryPath, serialized);
+    }
+    if (files.size === 0) return;
+
+    await this.push(
+      files,
+      `chore(exosync): quarantine ${files.size} conflict entr${files.size === 1 ? "y" : "ies"} (D17)`,
+    );
+  }
+
+  /**
+   * Tombstone-by-overwrite resolution (the primitive cannot delete).
+   * No-op when the entry does not exist or is already resolved.
+   */
+  async markResolved(repoKey: string, path: string): Promise<void> {
+    const entryPath = await this.entryPath(repoKey, path);
+    const prior = (await this.readEntries([entryPath])).get(entryPath);
+    if (prior === undefined || prior === null || prior.status === "resolved") {
+      return;
+    }
+    const resolved: QuarantineEntryRecord = {
+      ...prior,
+      status: "resolved",
+      resolvedAt: (this.deps.now ?? (() => new Date().toISOString()))(),
+    };
+    await this.push(
+      new Map([[entryPath, JSON.stringify(resolved, null, 2)]]),
+      `chore(exosync): resolve quarantine entry for ${path}`,
+    );
+  }
+
+  /** Open entries across all devices (CQ4). */
+  async listOpen(): Promise<OpenQuarantineEntry[]> {
+    const tree = await this.headTree();
+    if (tree === null) return [];
+    const out: OpenQuarantineEntry[] = [];
+    for (const e of tree) {
+      if (!e.path.startsWith(ENTRIES_PREFIX) || !e.path.endsWith(".json")) {
+        continue;
+      }
+      const record = parseRecord(
+        await getBlobText(
+          this.deps.transport,
+          this.deps.owner,
+          this.deps.repo,
+          e.blobSha,
+          this.deps.baseURL,
+        ),
+      );
+      if (record === null || record.status !== "open") continue;
+      out.push({
+        entryPath: e.path,
+        repoKey: record.repoKey,
+        path: record.path,
+        ...(record.uid !== undefined ? { uid: record.uid } : {}),
+        reason: record.reason,
+        quarantinedAt: record.quarantinedAt,
+      });
+    }
+    return out;
+  }
+
+  /** Cross-device unresolved-count (CQ4). */
+  async unresolvedCount(): Promise<number> {
+    return (await this.listOpen()).length;
+  }
+
+  private async entryPath(repoKey: string, path: string): Promise<string> {
+    const hash = (
+      await this.deps.sha1(new TextEncoder().encode(`${repoKey}\0${path}`))
+    ).slice(0, 8);
+    return `${ENTRIES_PREFIX}${slug(repoKey)}/${slug(path)}-${hash}.json`;
+  }
+
+  /** Head tree of the quarantine repo, or null when the branch is empty/absent. */
+  private async headTree(): Promise<
+    Array<{ path: string; blobSha: string }> | null
+  > {
+    const { transport, owner, repo, branch, baseURL } = this.deps;
+    let head: string;
+    try {
+      head = await getHeadSha(transport, owner, repo, branch, baseURL);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      if (/HTTP 404/.test(msg)) return null;
+      throw err;
+    }
+    const commit = await getCommitInfo(transport, owner, repo, head, baseURL);
+    return getTree(transport, owner, repo, commit.treeSha, baseURL);
+  }
+
+  private async readEntries(
+    entryPaths: string[],
+  ): Promise<Map<string, QuarantineEntryRecord | null>> {
+    const out = new Map<string, QuarantineEntryRecord | null>();
+    const tree = await this.headTreeOrThrowInitHint();
+    const byPath = new Map(tree.map((e) => [e.path, e.blobSha]));
+    for (const p of entryPaths) {
+      const blobSha = byPath.get(p);
+      if (blobSha === undefined) {
+        out.set(p, null);
+        continue;
+      }
+      out.set(
+        p,
+        parseRecord(
+          await getBlobText(
+            this.deps.transport,
+            this.deps.owner,
+            this.deps.repo,
+            blobSha,
+            this.deps.baseURL,
+          ),
+        ),
+      );
+    }
+    return out;
+  }
+
+  /**
+   * Writes need a base commit: `restCreateCommit` cannot create an initial
+   * commit on an empty repo (GET ref 404s). Bootstrapping the quarantine
+   * repo (one initial commit) is the mount layer's job — surface a clear
+   * hint instead of a bare 404.
+   */
+  private async headTreeOrThrowInitHint(): Promise<
+    Array<{ path: string; blobSha: string }>
+  > {
+    const tree = await this.headTree();
+    if (tree === null) {
+      throw new Error(
+        `SyncedQuarantineStore: branch ${this.deps.branch} not found on ${this.deps.owner}/${this.deps.repo} — initialize the quarantine repo (one initial commit) before syncing`,
+      );
+    }
+    return tree;
+  }
+
+  /** Push with direct 422 retries (fresh GET-ref per attempt — no CAS). */
+  private async push(files: Map<string, string>, message: string): Promise<void> {
+    const maxRetries = this.deps.maxPushRetries ?? 3;
+    let attempt = 0;
+    for (;;) {
+      try {
+        await restCreateCommit(this.deps.transport, {
+          owner: this.deps.owner,
+          repo: this.deps.repo,
+          branch: this.deps.branch,
+          files,
+          message,
+          ...(this.deps.baseURL !== undefined
+            ? { baseURL: this.deps.baseURL }
+            : {}),
+          ...(this.deps.redact !== undefined
+            ? { redact: this.deps.redact }
+            : {}),
+        });
+        return;
+      } catch (err) {
+        attempt++;
+        if (!isNonFastForwardError(err) || attempt > maxRetries) throw err;
+        // Concurrent quarantine push from another device — entry files are
+        // independent overwrites, so a plain retry (fresh ref) converges.
+      }
+    }
+  }
+}

--- a/packages/exocortex/src/services/sync/SyncedQuarantineStore.ts
+++ b/packages/exocortex/src/services/sync/SyncedQuarantineStore.ts
@@ -137,13 +137,15 @@ export class SyncedQuarantineStore implements QuarantinePort {
    */
   async quarantineAll(entries: QuarantineEntry[]): Promise<void> {
     if (entries.length === 0) return;
-    const existing = await this.readEntries(
-      await Promise.all(entries.map((e) => this.entryPath(e.repoKey, e.path))),
+    const entryPaths = await Promise.all(
+      entries.map((e) => this.entryPath(e.repoKey, e.path)),
     );
+    const existing = await this.readEntries(entryPaths);
 
     const files = new Map<string, string>();
-    for (const entry of entries) {
-      const entryPath = await this.entryPath(entry.repoKey, entry.path);
+    for (let i = 0; i < entries.length; i++) {
+      const entry = entries[i];
+      const entryPath = entryPaths[i];
       const prior = existing.get(entryPath) ?? null;
       // Reopening a resolved entry is a NEW conflict event → fresh
       // timestamp; an entry that is already open keeps its original one.
@@ -156,7 +158,9 @@ export class SyncedQuarantineStore implements QuarantinePort {
         repoKey: entry.repoKey,
         path: entry.path,
         ...(entry.uid !== undefined ? { uid: entry.uid } : {}),
-        reason: entry.reason,
+        // Redacted like the contents: SHACL-gate reasons can quote
+        // frontmatter values (defence-in-depth symmetry).
+        reason: redactSecrets(entry.reason),
         status: "open",
         quarantinedAt,
         ...(entry.baseContent !== undefined

--- a/packages/exocortex/src/services/sync/secretScan.ts
+++ b/packages/exocortex/src/services/sync/secretScan.ts
@@ -1,0 +1,67 @@
+/**
+ * ExoSync secret-scan (RFC 4e4dc453 A3 engineering baseline, R5).
+ *
+ * Last-line defence against accidentally committing a credential: the
+ * engine scans every push payload (canonical sync pushes AND quarantine
+ * entry contents) and refuses to ship anything that matches a known
+ * secret shape. Reported findings carry the PATH and the pattern KIND
+ * only — never the matched secret itself.
+ *
+ * The PAT patterns intentionally mirror the redaction regexes in the two
+ * production transports (`GitHubRestClient.PAT_REGEX` in the plugin,
+ * `RestPushService` in the CLI) — keep all three in sync:
+ *   - classic tokens: `gh[pousr]_…` (ghp_/gho_/ghu_/ghs_/ghr_), ≥36 chars
+ *   - fine-grained tokens: `github_pat_<22+ id>_<59+ secret>`
+ */
+
+export interface SecretFinding {
+  path: string;
+  /** Pattern family that matched — safe to log/surface. */
+  kind: string;
+}
+
+const SECRET_PATTERNS: ReadonlyArray<{ kind: string; re: RegExp }> = [
+  {
+    kind: "github-token",
+    re: /gh[pousr]_[A-Za-z0-9_]{36,}/,
+  },
+  {
+    kind: "github-fine-grained-token",
+    re: /github_pat_[A-Za-z0-9_]{22,}_[A-Za-z0-9_]{59,}/,
+  },
+  {
+    kind: "private-key",
+    re: /-----BEGIN [A-Z ]*PRIVATE KEY-----/,
+  },
+];
+
+/**
+ * Scan file contents for secret shapes. Returns one finding per
+ * (path, kind) pair; an empty array means the payload is clean.
+ */
+export function scanForSecrets(
+  files: ReadonlyMap<string, string>,
+): SecretFinding[] {
+  const findings: SecretFinding[] = [];
+  for (const [path, content] of files) {
+    for (const { kind, re } of SECRET_PATTERNS) {
+      if (re.test(content)) findings.push({ path, kind });
+    }
+  }
+  return findings;
+}
+
+/**
+ * Replace every secret match with `[REDACTED:<kind>]`. Used for quarantine
+ * entry contents (D17): a conflict copy whose text embeds a credential is
+ * still preserved durably — minus the secret — instead of being dropped
+ * (the canonical sync push, by contrast, REFUSES outright via
+ * {@link scanForSecrets}).
+ */
+export function redactSecrets(text: string): string {
+  let out = text;
+  for (const { kind, re } of SECRET_PATTERNS) {
+    out = out.replace(new RegExp(re.source, "g"), `[REDACTED:${kind}]`);
+  }
+  return out;
+}

--- a/packages/exocortex/src/services/sync/syncTypes.ts
+++ b/packages/exocortex/src/services/sync/syncTypes.ts
@@ -74,6 +74,12 @@ export interface LocalFilesPort {
   /** List repo-relative paths of all currently materialized files. */
   list(): Promise<string[]>;
   read(path: string): Promise<string>;
+  /**
+   * Write a file. Implementations MUST write atomically (temp file +
+   * rename) — a crash mid-write must never leave a torn file on disk
+   * (engineering baseline, RFC 4e4dc453 A3). The engine routes merged
+   * contents and pulled remote changes through this method.
+   */
   write(path: string, content: string): Promise<void>;
   /** Remove a file. MUST be a no-op if the path does not exist. */
   delete(path: string): Promise<void>;
@@ -152,6 +158,14 @@ export interface RepoSyncResult {
     | "full-conflict"
     | "conflict"
     | "retry-exhausted"
+    /** Another sync/apply operation is already running (D11 guard). */
+    | "busy"
+    /**
+     * Push/pull failed with HTTP 401/403 (NOT rate-limit) — the PAT is
+     * expired, revoked or under-scoped. Consumers must surface an explicit
+     * "update your PAT" prompt (R8) and never treat this as success.
+     */
+    | "auth-required"
     | "error";
   /** New commit SHA when a push happened. */
   pushedSha?: string;
@@ -219,14 +233,31 @@ export interface QuarantineEntry {
 }
 
 /**
- * Quarantine persistence port (D17). A2 ships {@link InMemoryQuarantineStore}
- * only — the durable SYNCED quarantine repo is A3 scope. Skipping the port
- * loses no data: the conflicting file stays untouched on disk, the remote
- * version stays in git history, and the watermark pin re-derives the
- * conflict on every subsequent sync.
+ * Quarantine persistence port (D17). The durable SYNCED store is
+ * {@link SyncedQuarantineStore} (A3); {@link InMemoryQuarantineStore} remains
+ * for tests/compositions without a quarantine repo. Skipping the port loses
+ * no data: the conflicting file stays untouched on disk, the remote version
+ * stays in git history, and the watermark pin re-derives the conflict on
+ * every subsequent sync.
  */
 export interface QuarantinePort {
   quarantine(entry: QuarantineEntry): Promise<void>;
+  /**
+   * Persist MANY entries in one operation. Synced implementations SHOULD
+   * batch this into a single commit — a terminal-quarantine flush (D16) can
+   * carry dozens of contended files, and one commit per entry would burn
+   * 4 API calls each. The engine prefers this method when present.
+   */
+  quarantineAll?(entries: QuarantineEntry[]): Promise<void>;
+  /**
+   * Mark an entry resolved (best-effort; MUST be a no-op when the entry
+   * does not exist). The engine calls this when a previously pinned path
+   * clears — the conflict resolved convergently, so the quarantine record
+   * no longer counts as open (CQ4). Terminal-quarantine entries (D16) have
+   * no pin and are NOT auto-resolved — reconciling them is the resolver
+   * UI's job (Phase B).
+   */
+  markResolved?(repoKey: string, path: string): Promise<void>;
 }
 
 /** In-memory QuarantinePort stub (A2) — durable synced store lands in A3. */
@@ -240,11 +271,21 @@ export class InMemoryQuarantineStore implements QuarantinePort {
 /**
  * A1 sync text allowlist: only UID-bearing markdown assets participate in
  * sync. Binary/non-UTF8 content (attachments) is Phase C scope (D4/VL#3) —
- * reading a binary as a string and pushing/writing it back would silently
- * corrupt it, so non-allowlisted paths are excluded SYMMETRICALLY: from the
- * local snapshot, from the remote diff, from pull-apply, and from
- * delete-inference.
+ * reading a binary as a string and pushing it back would silently corrupt
+ * it, so non-allowlisted paths are excluded SYMMETRICALLY: from the local
+ * snapshot, from the remote diff, from pull-apply, and from delete-inference.
+ *
+ * A3 gitignore-allowlist defence: paths containing the `.local.` infix
+ * (watermark/journal device-local artifacts) or `.conflict.` (quarantine
+ * conflict copies) are excluded even when they end in `.md` — they must
+ * never be pushed nor pulled. NOTE the substring match also silently
+ * excludes legitimately-named user notes like `server.local.setup.md`;
+ * symmetric exclusion means no corruption, just non-sync of such paths.
  */
 export function isSyncablePath(path: string): boolean {
-  return path.endsWith(".md");
+  return (
+    path.endsWith(".md") &&
+    !path.includes(".local.") &&
+    !path.includes(".conflict.")
+  );
 }

--- a/packages/exocortex/src/services/sync/transportBackoff.ts
+++ b/packages/exocortex/src/services/sync/transportBackoff.ts
@@ -1,0 +1,86 @@
+/**
+ * ExoSync rate-limit backoff (RFC 4e4dc453 A3 engineering baseline, R6).
+ *
+ * Transport decorator: retries a request that failed on a GitHub
+ * rate-limit signal with bounded exponential backoff + jitter. Everything
+ * else (404, 401/403 auth, 422 non-fast-forward — the D16 loop's job)
+ * is rethrown immediately, so the decorator never masks the engine's own
+ * error handling.
+ *
+ * `Retry-After` is unrecoverable through the thrown-Error transport
+ * contract (response headers are lost) — jittered exponential is the
+ * deliberate fallback. Retrying failed POSTs is safe: a 403/429 response
+ * means nothing was created server-side.
+ *
+ * Sleep and random are injected for deterministic tests; per-call retry
+ * state means failures in one repo's cycle never delay another repo
+ * (per-repo backoff semantics).
+ */
+
+import type {
+  RestCommitRequest,
+  RestCommitResponse,
+  RestCommitTransport,
+} from "../../infrastructure/github/restCommit";
+
+/**
+ * GitHub rate-limit detection over the transport error-message contract
+ * (`GitHub request {METHOD} {url} → HTTP {status}: {body}`): HTTP 429, or
+ * HTTP 403 whose body mentions rate limiting / abuse detection (GitHub's
+ * secondary limit historically used "abuse detection mechanism" wording
+ * without the words "rate limit"). A plain 403 without those markers is an
+ * auth problem, not a rate limit — see `isAuthError`.
+ */
+export function isRateLimitError(err: unknown): boolean {
+  const msg = err instanceof Error ? err.message : String(err);
+  if (/HTTP 429/.test(msg)) return true;
+  return (
+    /HTTP 403/.test(msg) &&
+    (/rate limit/i.test(msg) || /abuse detection/i.test(msg))
+  );
+}
+
+export interface BackoffOptions {
+  /** Retries AFTER the first rate-limited failure. Default 3. */
+  maxRetries?: number;
+  /** First delay; doubles each retry. Default 1000 ms. */
+  baseDelayMs?: number;
+  /** Injected for tests. Default: real setTimeout. */
+  sleep?: (ms: number) => Promise<void>;
+  /** Injected for tests. Defaults to Math.random — jitter source. */
+  random?: () => number;
+}
+
+const defaultSleep = (ms: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, ms));
+
+/**
+ * Wrap a transport with per-request exponential backoff on rate-limit
+ * errors. After `maxRetries` rate-limited attempts the last error is
+ * rethrown — the per-repo sync cycle then fails warn-not-block (D12).
+ */
+export function withRateLimitBackoff(
+  transport: RestCommitTransport,
+  options: BackoffOptions = {},
+): RestCommitTransport {
+  const maxRetries = options.maxRetries ?? 3;
+  const baseDelayMs = options.baseDelayMs ?? 1000;
+  const sleep = options.sleep ?? defaultSleep;
+  // SECURITY CONTEXT: jitter source for retry timing only — deliberately
+  // not cryptographically secure (no IDs/tokens are derived from it).
+  const random = options.random ?? Math.random;
+
+  return async (req: RestCommitRequest): Promise<RestCommitResponse> => {
+    let attempt = 0;
+    for (;;) {
+      try {
+        return await transport(req);
+      } catch (err) {
+        if (!isRateLimitError(err) || attempt >= maxRetries) throw err;
+        const delay = baseDelayMs * 2 ** attempt * (1 + random());
+        attempt++;
+        await sleep(delay);
+      }
+    }
+  };
+}

--- a/packages/exocortex/tests/unit/services/sync/FileWatermarkStore.test.ts
+++ b/packages/exocortex/tests/unit/services/sync/FileWatermarkStore.test.ts
@@ -1,0 +1,96 @@
+/** ExoSync A3 — durable per-device watermark store (D8/D22/R10). */
+
+import {
+  FileWatermarkStore,
+  WATERMARK_STORE_FILENAME,
+  isSyncablePath,
+  type WatermarkFileIO,
+  type WatermarkRecord,
+} from "../../../../src";
+
+class FakeIO implements WatermarkFileIO {
+  content: string | null = null;
+  writes = 0;
+  failNextWrite = false;
+  async read(): Promise<string | null> {
+    return this.content;
+  }
+  async writeAtomic(content: string): Promise<void> {
+    if (this.failNextWrite) {
+      this.failNextWrite = false;
+      throw new Error("disk full");
+    }
+    this.writes++;
+    this.content = content;
+  }
+}
+
+const record = (sha: string): WatermarkRecord => ({
+  lastSyncedSha: sha,
+  rootTreeSha: `tree-${sha}`,
+  files: [{ path: "a.md", blobSha: `blob-${sha}`, uid: "u1" }],
+});
+
+describe("FileWatermarkStore", () => {
+  it("round-trips records per repoKey through one JSON file", async () => {
+    const io = new FakeIO();
+    const store = new FileWatermarkStore(io);
+
+    await store.set("o/r1#main", record("s1"));
+    await store.set("o/r2#main", record("s2"));
+
+    expect(await store.get("o/r1#main")).toEqual(record("s1"));
+    expect(await store.get("o/r2#main")).toEqual(record("s2"));
+    expect(await store.get("o/unknown#main")).toBeNull();
+    expect(JSON.parse(io.content ?? "")).toMatchObject({ version: 1 });
+  });
+
+  it("missing file → null for every repo (first-sync path, D22)", async () => {
+    const store = new FileWatermarkStore(new FakeIO());
+    expect(await store.get("o/r#main")).toBeNull();
+  });
+
+  it("corrupt JSON → null, never throws (R10 — full-conflict, not overwrite)", async () => {
+    const io = new FakeIO();
+    io.content = "{ not json !!!";
+    const store = new FileWatermarkStore(io);
+    expect(await store.get("o/r#main")).toBeNull();
+
+    io.content = JSON.stringify({ version: 1, repos: { "o/r#main": "junk" } });
+    expect(await store.get("o/r#main")).toBeNull();
+  });
+
+  it("serializes concurrent sets — both records survive (lossless RMW)", async () => {
+    const io = new FakeIO();
+    const store = new FileWatermarkStore(io);
+
+    await Promise.all([
+      store.set("o/r1#main", record("s1")),
+      store.set("o/r2#main", record("s2")),
+    ]);
+
+    expect(await store.get("o/r1#main")).toEqual(record("s1"));
+    expect(await store.get("o/r2#main")).toEqual(record("s2"));
+  });
+
+  it("a failed write rejects its caller but does not poison later sets", async () => {
+    const io = new FakeIO();
+    const store = new FileWatermarkStore(io);
+    io.failNextWrite = true;
+
+    await expect(store.set("o/r1#main", record("s1"))).rejects.toThrow(
+      "disk full",
+    );
+    await store.set("o/r2#main", record("s2"));
+    expect(await store.get("o/r2#main")).toEqual(record("s2"));
+  });
+
+  it("the recommended filename is excluded from sync (gitignore allowlist)", () => {
+    expect(WATERMARK_STORE_FILENAME).toContain(".local.");
+    expect(isSyncablePath(WATERMARK_STORE_FILENAME)).toBe(false);
+    // even a hypothetical .md variant stays excluded via the .local. infix
+    expect(isSyncablePath("notes/exosync-journal.local.md")).toBe(false);
+    expect(isSyncablePath("notes/asset.conflict.md")).toBe(false);
+    expect(isSyncablePath("notes/asset.md")).toBe(true);
+  });
+});

--- a/packages/exocortex/tests/unit/services/sync/StructuredMerger.test.ts
+++ b/packages/exocortex/tests/unit/services/sync/StructuredMerger.test.ts
@@ -201,6 +201,32 @@ describe("StructuredMerger — multi-valued set-union with tombstones (D20)", ()
       expect(r.content).toMatch(/2026-06-09T15:46:48/);
     }
   });
+
+  it("non-plain values (Date from a DEFAULT_SCHEMA codec) conflict fail-loud, never merge silently", () => {
+    // A consumer codec violating the CORE_SCHEMA contract turns date-like
+    // scalars into Date objects. deepEqual must NOT treat two DIFFERENT
+    // Dates as equal (both have zero enumerable keys) — that would silently
+    // collapse divergent timestamps into one side.
+    const defaultSchemaMerger = new StructuredMerger({
+      parse: (text) => yaml.load(text), // DEFAULT_SCHEMA → Date objects
+      stringify: (value) => yaml.dump(value, { lineWidth: -1 }),
+    });
+    const doc = (ts: string): string =>
+      `---\nexo__Asset_uid: u1\nexo__Asset_createdAt: ${ts}\n---\nbody\n`;
+
+    const r = defaultSchemaMerger.mergeAsset({
+      path: "a.md",
+      base: doc("2026-06-09T15:46:48"),
+      local: doc("2026-06-10T11:00:00"),
+      remote: doc("2026-06-10T22:00:00"),
+    });
+
+    expect(r.status).toBe("conflict");
+    if (r.status === "conflict") {
+      expect(r.reason).toMatch(/non-plain value/);
+      expect(r.reason).toMatch(/exo__Asset_createdAt/);
+    }
+  });
 });
 
 describe("StructuredMerger — body section merge (D21, not LWW)", () => {

--- a/packages/exocortex/tests/unit/services/sync/SyncEngine.test.ts
+++ b/packages/exocortex/tests/unit/services/sync/SyncEngine.test.ts
@@ -12,11 +12,13 @@ import {
   InMemoryQuarantineStore,
   StructuredMerger,
   SyncEngine,
+  gitBlobSha,
   orderChildrenFirst,
   isNonFastForwardError,
   type MergeConflictInput,
   type MergeDecision,
   type MergeLayerPort,
+  type RestCommitTransport,
   type SyncEngineDeps,
   type SyncRepoSpec,
   type YamlCodec,
@@ -762,5 +764,280 @@ describe("SyncEngine — A2 merge layer integration", () => {
     expect(result.status).toBe("conflict");
     expect(result.mergedCount).toBe(0);
     expect(result.quarantinedCount).toBe(0);
+  });
+});
+
+describe("SyncEngine — A3: convergent rename (A2 deferred MEDIUM)", () => {
+  const stubMergeLayer = (
+    fn: (input: MergeConflictInput) => MergeDecision,
+  ): MergeLayerPort => ({ resolve: async (i) => fn(i) });
+  const RENAMED = "assets/renamed.md";
+
+  it("identical rename a→b on both sides is consumed — no false delete-vs-modify quarantine", async () => {
+    const gh = new FakeGitHubRepo({ [FILE_A]: mdAsset("u1"), [FILE_B]: mdAsset("u2") });
+    const local = new FakeLocalFiles({ [FILE_A]: mdAsset("u1"), [FILE_B]: mdAsset("u2") });
+    const store = new InMemoryQuarantineStore();
+    const { engine } = makeEngine(gh, local, {
+      mergeLayer: stubMergeLayer(() => ({
+        action: "quarantine",
+        reason: "merge layer must not be consulted for a convergent rename",
+      })),
+      quarantine: store,
+    });
+    await bootstrap(engine, gh.spec());
+
+    // Both devices ran the SAME rename (rename-to-uid / co-location case).
+    gh.commitDirect("main", { [RENAMED]: mdAsset("u1") }, "remote rename", [FILE_A]);
+    local.files.delete(FILE_A);
+    local.files.set(RENAMED, mdAsset("u1"));
+    const result = await engine.sync(gh.spec());
+
+    expect(result.status).toBe("synced");
+    expect(result.quarantinedCount).toBe(0);
+    expect(store.entries).toHaveLength(0);
+    expect(gh.headFiles().has(FILE_A)).toBe(false);
+    expect(gh.headFiles().get(RENAMED)).toBe(mdAsset("u1"));
+    expect(local.files.get(RENAMED)).toBe(mdAsset("u1"));
+  });
+
+  it("GENUINE remote delete vs local rename still quarantines (never silently resurrects)", async () => {
+    const gh = new FakeGitHubRepo({ [FILE_A]: mdAsset("u1"), [FILE_B]: mdAsset("u2") });
+    const local = new FakeLocalFiles({ [FILE_A]: mdAsset("u1"), [FILE_B]: mdAsset("u2") });
+    const store = new InMemoryQuarantineStore();
+    const { engine } = makeEngine(gh, local, {
+      mergeLayer: stubMergeLayer(() => ({
+        action: "quarantine",
+        reason: "delete-vs-rename needs a human",
+      })),
+      quarantine: store,
+    });
+    await bootstrap(engine, gh.spec());
+
+    gh.commitDirect("main", {}, "remote genuine delete", [FILE_A]);
+    local.files.delete(FILE_A);
+    local.files.set(RENAMED, mdAsset("u1"));
+    const result = await engine.sync(gh.spec());
+
+    expect(result.status).toBe("synced");
+    expect(result.quarantinedCount).toBe(1);
+    expect(store.entries).toHaveLength(1);
+    expect(gh.headFiles().has(RENAMED)).toBe(false); // renamed copy NOT pushed
+  });
+});
+
+describe("SyncEngine — A3: merged blob not re-fetched (A2 deferred LOW)", () => {
+  it("passes mergedWrites' blob SHA into the watermark rebuild", async () => {
+    const gh = new FakeGitHubRepo({ [FILE_A]: mdAsset("u1") });
+    const local = new FakeLocalFiles({ [FILE_A]: mdAsset("u1") });
+    const inner = gh.transport();
+    const blobGets: string[] = [];
+    const transport: RestCommitTransport = async (req) => {
+      const m = /git\/blobs\/([0-9a-f]+)/.exec(req.url);
+      if (m !== null && req.method === "GET") blobGets.push(m[1]);
+      return inner(req);
+    };
+    const merged = mdAsset("u1", "merged by layer");
+    const { engine } = makeEngine(gh, local, {
+      transport,
+      mergeLayer: {
+        resolve: async () => ({ action: "use-merged", content: merged }),
+      },
+    });
+    await bootstrap(engine, gh.spec());
+
+    gh.commitDirect("main", { [FILE_A]: mdAsset("u1", "remote edit") }, "B");
+    local.files.set(FILE_A, mdAsset("u1", "local edit"));
+    blobGets.length = 0;
+    const result = await engine.sync(gh.spec());
+
+    expect(result.status).toBe("synced");
+    expect(result.mergedCount).toBe(1);
+    const mergedBlobSha = await gitBlobSha(merged, sha1Hex);
+    expect(gh.headFiles().get(FILE_A)).toBe(merged);
+    expect(blobGets).not.toContain(mergedBlobSha); // watermark rebuild reuses the known SHA
+  });
+});
+
+describe("SyncEngine — A3: D16 terminal-quarantine", () => {
+  it("retry exhaustion routes contended files AND pending merge entries to quarantine", async () => {
+    const gh = new FakeGitHubRepo({ [FILE_A]: mdAsset("u1"), [FILE_B]: mdAsset("u2") });
+    const local = new FakeLocalFiles({ [FILE_A]: mdAsset("u1"), [FILE_B]: mdAsset("u2") });
+    const store = new InMemoryQuarantineStore();
+    const { engine } = makeEngine(gh, local, {
+      maxPushRetries: 1,
+      quarantine: store,
+      // FILE_A conflicts and the layer says quarantine; FILE_B is a plain
+      // local edit that keeps losing the push race.
+      mergeLayer: {
+        resolve: async () => ({
+          action: "quarantine",
+          reason: "unresolvable overlap",
+        }),
+      },
+    });
+    await bootstrap(engine, gh.spec());
+
+    gh.commitDirect("main", { [FILE_A]: mdAsset("u1", "remote edit") }, "B");
+    local.files.set(FILE_A, mdAsset("u1", "local edit"));
+    local.files.set(FILE_B, mdAsset("u2", "contended edit"));
+    let n = 0;
+    gh.onBeforePatch = (): void => {
+      n++;
+      gh.commitDirect("main", { [`assets/race-${n}.md`]: mdAsset(`r${n}`) }, "race");
+    };
+    const result = await engine.sync(gh.spec());
+
+    expect(result.status).toBe("retry-exhausted");
+    expect(result.quarantinedCount).toBe(2);
+    const byPath = new Map(store.entries.map((e) => [e.path, e]));
+    expect(byPath.get(FILE_A)).toMatchObject({
+      reason: "unresolvable overlap",
+      localContent: mdAsset("u1", "local edit"),
+      remoteContent: mdAsset("u1", "remote edit"),
+    });
+    expect(byPath.get(FILE_B)).toMatchObject({
+      uid: "u2",
+      reason: expect.stringMatching(/non-fast-forward push failed after 1 retr/),
+      localContent: mdAsset("u2", "contended edit"),
+      remoteContent: mdAsset("u2"), // best-effort current head version
+    });
+    // M1: canonical files untouched anywhere.
+    expect(local.files.get(FILE_B)).toBe(mdAsset("u2", "contended edit"));
+    expect(gh.headFiles().get(FILE_B)).toBe(mdAsset("u2"));
+  });
+
+  it("a failing quarantine sink degrades to a warning, never an error status", async () => {
+    const gh = new FakeGitHubRepo({ [FILE_A]: mdAsset("u1") });
+    const local = new FakeLocalFiles({ [FILE_A]: mdAsset("u1") });
+    const { engine } = makeEngine(gh, local, {
+      mergeLayer: {
+        resolve: async () => ({ action: "quarantine", reason: "overlap" }),
+      },
+      quarantine: {
+        quarantine: async () => {
+          throw new Error("quarantine repo unreachable");
+        },
+      },
+    });
+    await bootstrap(engine, gh.spec());
+
+    gh.commitDirect("main", { [FILE_A]: mdAsset("u1", "remote edit") }, "B");
+    local.files.set(FILE_A, mdAsset("u1", "local edit"));
+    const result = await engine.sync(gh.spec());
+
+    expect(result.status).toBe("synced"); // pin still re-derives — D17 degradation
+    expect(result.quarantinedCount).toBe(1);
+    expect(result.warnings.join(" ")).toMatch(/quarantine sink failed/);
+    expect(local.files.get(FILE_A)).toBe(mdAsset("u1", "local edit"));
+  });
+
+  it("a cleared pin auto-resolves its quarantine entry (markResolved)", async () => {
+    const gh = new FakeGitHubRepo({ [FILE_A]: mdAsset("u1") });
+    const local = new FakeLocalFiles({ [FILE_A]: mdAsset("u1") });
+    const resolved: string[] = [];
+    let verdict: MergeDecision = { action: "quarantine", reason: "overlap" };
+    const { engine } = makeEngine(gh, local, {
+      mergeLayer: { resolve: async () => verdict },
+      quarantine: {
+        quarantine: async () => {},
+        markResolved: async (repoKey, path) => {
+          resolved.push(`${repoKey}:${path}`);
+        },
+      },
+    });
+    await bootstrap(engine, gh.spec());
+
+    gh.commitDirect("main", { [FILE_A]: mdAsset("u1", "remote edit") }, "B");
+    local.files.set(FILE_A, mdAsset("u1", "local edit"));
+    expect((await engine.sync(gh.spec())).quarantinedCount).toBe(1); // pinned
+
+    // User resolves: merge layer now converges the conflict.
+    verdict = { action: "use-merged", content: mdAsset("u1", "resolved") };
+    const second = await engine.sync(gh.spec());
+
+    expect(second.status).toBe("synced");
+    expect(resolved).toEqual([`${gh.spec().repoKey}:${FILE_A}`]);
+  });
+});
+
+describe("SyncEngine — A3: D11 one-operation guard, R8 auth, R5 secret-scan", () => {
+  it("a second concurrent operation returns `busy` (D11), syncAll has no self-deadlock", async () => {
+    const gh = new FakeGitHubRepo({ [FILE_A]: mdAsset("u1") });
+    const local = new FakeLocalFiles({ [FILE_A]: mdAsset("u1") });
+    const inner = gh.transport();
+    let release: (() => void) | null = null;
+    const gate = new Promise<void>((r) => {
+      release = r;
+    });
+    const transport: RestCommitTransport = async (req) => {
+      await gate;
+      return inner(req);
+    };
+    const { engine } = makeEngine(gh, local, { transport });
+
+    const first = engine.sync(gh.spec());
+    const second = await engine.sync(gh.spec()); // while first is in flight
+    expect(second.status).toBe("busy");
+
+    release!();
+    expect((await first).status).toBe("synced");
+
+    // syncAll acquires ONCE — inner repos never see their own guard.
+    const all = await engine.syncAll([gh.spec(), gh.spec()]);
+    expect(all.map((r) => r.status)).toEqual(["synced", "synced"]);
+  });
+
+  it("HTTP 401 → `auth-required` with an update-PAT hint, never treated as success (R8)", async () => {
+    const gh = new FakeGitHubRepo({ [FILE_A]: mdAsset("u1") });
+    const local = new FakeLocalFiles({ [FILE_A]: mdAsset("u1") });
+    const transport: RestCommitTransport = async (req) => {
+      throw new Error(`GitHub request ${req.method} ${req.url} → HTTP 401: Bad credentials`);
+    };
+    const { engine } = makeEngine(gh, local, { transport });
+
+    const result = await engine.sync(gh.spec());
+
+    expect(result.status).toBe("auth-required");
+    expect(result.detail).toMatch(/PAT/);
+  });
+
+  it("rate-limited requests are retried transparently via the wrapped transport (R6)", async () => {
+    const gh = new FakeGitHubRepo({ [FILE_A]: mdAsset("u1") });
+    const local = new FakeLocalFiles({ [FILE_A]: mdAsset("u1") });
+    const inner = gh.transport();
+    let failures = 2;
+    const transport: RestCommitTransport = async (req) => {
+      if (failures > 0) {
+        failures--;
+        throw new Error(`GitHub request ${req.method} ${req.url} → HTTP 403: API rate limit exceeded`);
+      }
+      return inner(req);
+    };
+    const { engine } = makeEngine(gh, local, {
+      transport,
+      backoff: { sleep: async () => {} },
+    });
+
+    const result = await engine.sync(gh.spec());
+
+    expect(result.status).toBe("synced"); // bootstrap survived the throttle
+  });
+
+  it("a push payload containing a PAT is refused outright (R5) — secret never leaves the device", async () => {
+    const gh = new FakeGitHubRepo({ [FILE_A]: mdAsset("u1") });
+    const local = new FakeLocalFiles({ [FILE_A]: mdAsset("u1") });
+    const { engine } = makeEngine(gh, local);
+    await bootstrap(engine, gh.spec());
+    const headBefore = gh.headSha();
+
+    const pat = `ghp_${"a1B2".repeat(10)}`;
+    local.files.set(FILE_A, mdAsset("u1", `oops, pasted a token: ${pat}`));
+    const result = await engine.sync(gh.spec());
+
+    expect(result.status).toBe("error");
+    expect(result.detail).toMatch(/secret-scan/);
+    expect(result.detail).toMatch(/github-token/);
+    expect(result.detail).not.toContain(pat); // path+kind only, never the secret
+    expect(gh.headSha()).toBe(headBefore); // nothing pushed
   });
 });

--- a/packages/exocortex/tests/unit/services/sync/SyncEngine.test.ts
+++ b/packages/exocortex/tests/unit/services/sync/SyncEngine.test.ts
@@ -906,6 +906,38 @@ describe("SyncEngine — A3: D16 terminal-quarantine", () => {
     expect(gh.headFiles().get(FILE_B)).toBe(mdAsset("u2"));
   });
 
+  it("terminal entry for a merge-resolved-but-contended path records the DISK version, not the merged proposal", async () => {
+    const gh = new FakeGitHubRepo({ [FILE_A]: mdAsset("u1") });
+    const local = new FakeLocalFiles({ [FILE_A]: mdAsset("u1") });
+    const store = new InMemoryQuarantineStore();
+    const merged = mdAsset("u1", "merged proposal");
+    const { engine } = makeEngine(gh, local, {
+      maxPushRetries: 1,
+      quarantine: store,
+      mergeLayer: {
+        resolve: async () => ({ action: "use-merged", content: merged }),
+      },
+    });
+    await bootstrap(engine, gh.spec());
+
+    gh.commitDirect("main", { [FILE_A]: mdAsset("u1", "remote edit") }, "B");
+    local.files.set(FILE_A, mdAsset("u1", "local edit"));
+    let n = 0;
+    gh.onBeforePatch = (): void => {
+      n++;
+      gh.commitDirect("main", { [`assets/race-${n}.md`]: mdAsset(`r${n}`) }, "race");
+    };
+    const result = await engine.sync(gh.spec());
+
+    expect(result.status).toBe("retry-exhausted");
+    expect(store.entries).toHaveLength(1);
+    // The durable record shows what the user actually has on disk; the
+    // merged proposal was never applied and re-derives next sync.
+    expect(store.entries[0].localContent).toBe(mdAsset("u1", "local edit"));
+    expect(store.entries[0].reason).toMatch(/merged proposal/);
+    expect(local.files.get(FILE_A)).toBe(mdAsset("u1", "local edit"));
+  });
+
   it("a failing quarantine sink degrades to a warning, never an error status", async () => {
     const gh = new FakeGitHubRepo({ [FILE_A]: mdAsset("u1") });
     const local = new FakeLocalFiles({ [FILE_A]: mdAsset("u1") });

--- a/packages/exocortex/tests/unit/services/sync/SyncedQuarantineStore.test.ts
+++ b/packages/exocortex/tests/unit/services/sync/SyncedQuarantineStore.test.ts
@@ -1,0 +1,189 @@
+/**
+ * ExoSync A3 — synced quarantine store (D17/CQ4) against the
+ * production-shape FakeGitHubRepo (real blob SHAs, force:false 422).
+ */
+
+import {
+  SyncedQuarantineStore,
+  type QuarantineEntry,
+  type QuarantineEntryRecord,
+} from "../../../../src";
+import { FakeGitHubRepo, sha1Hex } from "./fakeGitHub";
+
+function makeStore(
+  gh: FakeGitHubRepo,
+  overrides: Partial<ConstructorParameters<typeof SyncedQuarantineStore>[0]> = {},
+): { store: SyncedQuarantineStore; clock: { n: number } } {
+  const clock = { n: 0 };
+  const store = new SyncedQuarantineStore({
+    transport: gh.transport(),
+    sha1: sha1Hex,
+    owner: gh.owner,
+    repo: gh.repo,
+    branch: gh.branch,
+    now: () => `2026-06-10T00:00:0${clock.n++}`,
+    ...overrides,
+  });
+  return { store, clock };
+}
+
+const ENTRY: QuarantineEntry = {
+  repoKey: "o/canonical#main",
+  path: "assets/a.md",
+  uid: "u1",
+  reason: "frontmatter key changed differently on both sides",
+  baseContent: "base",
+  localContent: "local",
+  remoteContent: "remote",
+};
+
+function entryFiles(gh: FakeGitHubRepo): Map<string, QuarantineEntryRecord> {
+  const out = new Map<string, QuarantineEntryRecord>();
+  for (const [path, content] of gh.headFiles()) {
+    if (path.startsWith("entries/") && path.endsWith(".json")) {
+      out.set(path, JSON.parse(content) as QuarantineEntryRecord);
+    }
+  }
+  return out;
+}
+
+describe("SyncedQuarantineStore — D17 durable synced entries", () => {
+  it("commits one stable JSON entry per conflict (no UID, no .md — never RDF-indexed)", async () => {
+    const gh = new FakeGitHubRepo({ "README.md": "init" });
+    const { store } = makeStore(gh);
+
+    await store.quarantine(ENTRY);
+
+    const entries = entryFiles(gh);
+    expect(entries.size).toBe(1);
+    const [path, record] = [...entries.entries()][0];
+    expect(path).toMatch(/^entries\/o_canonical_main\/assets_a\.md-[0-9a-f]{8}\.json$/);
+    expect(record).toMatchObject({
+      version: 1,
+      repoKey: ENTRY.repoKey,
+      path: ENTRY.path,
+      uid: "u1",
+      reason: ENTRY.reason,
+      status: "open",
+      quarantinedAt: "2026-06-10T00:00:00",
+      baseContent: "base",
+      localContent: "local",
+      remoteContent: "remote",
+    });
+    expect(gh.headFiles().get("README.md")).toBe("init"); // neighbours intact
+  });
+
+  it("is idempotent — re-quarantining an identical conflict produces ZERO new commits", async () => {
+    const gh = new FakeGitHubRepo({ "README.md": "init" });
+    const { store } = makeStore(gh);
+
+    await store.quarantine(ENTRY);
+    const headAfterFirst = gh.headSha();
+    await store.quarantine(ENTRY); // same conflict re-derives next sync
+    await store.quarantine(ENTRY);
+
+    expect(gh.headSha()).toBe(headAfterFirst); // no commit churn
+    expect(await store.unresolvedCount()).toBe(1);
+  });
+
+  it("a changed conflict updates the entry but preserves the original quarantinedAt", async () => {
+    const gh = new FakeGitHubRepo({ "README.md": "init" });
+    const { store } = makeStore(gh);
+
+    await store.quarantine(ENTRY);
+    await store.quarantine({ ...ENTRY, localContent: "local v2" });
+
+    const [record] = [...entryFiles(gh).values()];
+    expect(record.localContent).toBe("local v2");
+    expect(record.quarantinedAt).toBe("2026-06-10T00:00:00"); // original kept
+  });
+
+  it("quarantineAll batches many entries into ONE commit", async () => {
+    const gh = new FakeGitHubRepo({ "README.md": "init" });
+    const { store } = makeStore(gh);
+    const before = gh.commits.size;
+
+    await store.quarantineAll([
+      ENTRY,
+      { ...ENTRY, path: "assets/b.md", uid: "u2" },
+      { ...ENTRY, repoKey: "o/other#main", path: "assets/c.md", uid: "u3" },
+    ]);
+
+    expect(gh.commits.size).toBe(before + 1); // single commit
+    expect(entryFiles(gh).size).toBe(3);
+    expect(await store.unresolvedCount()).toBe(3);
+  });
+
+  it("markResolved tombstones by overwrite; absent/resolved entries are no-ops", async () => {
+    const gh = new FakeGitHubRepo({ "README.md": "init" });
+    const { store } = makeStore(gh);
+    await store.quarantine(ENTRY);
+
+    await store.markResolved(ENTRY.repoKey, ENTRY.path);
+
+    const [record] = [...entryFiles(gh).values()];
+    expect(record.status).toBe("resolved");
+    expect(record.resolvedAt).toBe("2026-06-10T00:00:01");
+    expect(await store.unresolvedCount()).toBe(0);
+
+    const head = gh.headSha();
+    await store.markResolved(ENTRY.repoKey, ENTRY.path); // already resolved
+    await store.markResolved("o/none#main", "ghost.md"); // never existed
+    expect(gh.headSha()).toBe(head); // both no-ops, zero commits
+  });
+
+  it("re-quarantining a RESOLVED entry reopens it with a fresh timestamp", async () => {
+    const gh = new FakeGitHubRepo({ "README.md": "init" });
+    const { store } = makeStore(gh);
+    await store.quarantine(ENTRY); // t0
+    await store.markResolved(ENTRY.repoKey, ENTRY.path); // t1
+
+    await store.quarantine(ENTRY); // new conflict event → t2
+
+    const [record] = [...entryFiles(gh).values()];
+    expect(record.status).toBe("open");
+    expect(record.quarantinedAt).toBe("2026-06-10T00:00:02");
+    expect(record.resolvedAt).toBeUndefined();
+    expect(await store.unresolvedCount()).toBe(1);
+  });
+
+  it("redacts secrets inside conflict copies instead of dropping the entry", async () => {
+    const gh = new FakeGitHubRepo({ "README.md": "init" });
+    const { store } = makeStore(gh);
+    const pat = `ghp_${"a1B2".repeat(10)}`;
+
+    await store.quarantine({ ...ENTRY, localContent: `token: ${pat}` });
+
+    const [record] = [...entryFiles(gh).values()];
+    expect(record.localContent).toBe("token: [REDACTED:github-token]");
+    expect(JSON.stringify([...gh.blobs.values()])).not.toContain(pat);
+  });
+
+  it("retries a 422 concurrent-push race and converges (no CAS)", async () => {
+    const gh = new FakeGitHubRepo({ "README.md": "init" });
+    const { store } = makeStore(gh);
+    let raced = false;
+    gh.onBeforePatch = () => {
+      if (!raced) {
+        raced = true;
+        gh.commitDirect(gh.branch, { "other-device.md": "concurrent" }, "device B");
+      }
+    };
+
+    await store.quarantine(ENTRY);
+
+    expect(entryFiles(gh).size).toBe(1);
+    expect(gh.headFiles().get("other-device.md")).toBe("concurrent"); // both survive
+  });
+
+  it("missing branch → clear init hint on write, empty list on read", async () => {
+    const gh = new FakeGitHubRepo({ "README.md": "init" });
+    const { store } = makeStore(gh, { branch: "quarantine-branch-missing" });
+
+    await expect(store.quarantine(ENTRY)).rejects.toThrow(
+      /initialize the quarantine repo/,
+    );
+    expect(await store.listOpen()).toEqual([]);
+    expect(await store.unresolvedCount()).toBe(0);
+  });
+});

--- a/packages/exocortex/tests/unit/services/sync/secretScan.test.ts
+++ b/packages/exocortex/tests/unit/services/sync/secretScan.test.ts
@@ -1,0 +1,56 @@
+/** ExoSync A3 — secret-scan (R5 engineering baseline). */
+
+import { redactSecrets, scanForSecrets } from "../../../../src";
+
+const CLASSIC_PAT = `ghp_${"a1B2".repeat(10)}`; // 40 chars after prefix
+const FINE_GRAINED_PAT = `github_pat_${"A".repeat(22)}_${"b".repeat(59)}`;
+
+describe("scanForSecrets", () => {
+  it("flags classic and fine-grained GitHub tokens by path + kind only", () => {
+    const files = new Map<string, string>([
+      ["a.md", `body with token ${CLASSIC_PAT} embedded`],
+      ["b.md", `---\nkey: ${FINE_GRAINED_PAT}\n---\n`],
+      ["clean.md", "nothing to see"],
+    ]);
+
+    const findings = scanForSecrets(files);
+
+    expect(findings).toEqual([
+      { path: "a.md", kind: "github-token" },
+      { path: "b.md", kind: "github-fine-grained-token" },
+    ]);
+    // findings never embed the secret itself
+    expect(JSON.stringify(findings)).not.toContain(CLASSIC_PAT);
+  });
+
+  it("flags private key blocks", () => {
+    const files = new Map([
+      ["key.md", "-----BEGIN OPENSSH PRIVATE KEY-----\nxxx"],
+    ]);
+    expect(scanForSecrets(files)).toEqual([
+      { path: "key.md", kind: "private-key" },
+    ]);
+  });
+
+  it("passes clean payloads and short token-like strings", () => {
+    const files = new Map([
+      ["a.md", "ghp_tooShort and github_pat_short_short are not tokens"],
+    ]);
+    expect(scanForSecrets(files)).toEqual([]);
+  });
+});
+
+describe("redactSecrets", () => {
+  it("replaces every secret with a kind marker, preserving the rest", () => {
+    const text = `before ${CLASSIC_PAT} middle ${FINE_GRAINED_PAT} after`;
+    const out = redactSecrets(text);
+    expect(out).toBe(
+      "before [REDACTED:github-token] middle [REDACTED:github-fine-grained-token] after",
+    );
+    expect(out).not.toContain(CLASSIC_PAT);
+  });
+
+  it("is a no-op on clean text", () => {
+    expect(redactSecrets("plain text")).toBe("plain text");
+  });
+});

--- a/packages/exocortex/tests/unit/services/sync/transportBackoff.test.ts
+++ b/packages/exocortex/tests/unit/services/sync/transportBackoff.test.ts
@@ -1,0 +1,112 @@
+/** ExoSync A3 — rate-limit backoff transport decorator (R6). */
+
+import {
+  isAuthError,
+  isRateLimitError,
+  withRateLimitBackoff,
+  type RestCommitRequest,
+  type RestCommitTransport,
+} from "../../../../src";
+
+const REQ: RestCommitRequest = {
+  method: "GET",
+  url: "https://api.github.com/repos/o/r/git/refs/heads/main",
+};
+
+function failingTransport(
+  errors: string[],
+  finalJson: unknown = { ok: true },
+): { transport: RestCommitTransport; calls: () => number } {
+  let n = 0;
+  return {
+    transport: async () => {
+      n++;
+      const err = errors.shift();
+      if (err !== undefined) throw new Error(err);
+      return { status: 200, json: finalJson };
+    },
+    calls: () => n,
+  };
+}
+
+const http = (status: number, body: string): string =>
+  `GitHub request GET ${REQ.url} → HTTP ${status}: ${body}`;
+
+describe("isRateLimitError / isAuthError discrimination", () => {
+  it("429 and 403+rate-limit/abuse are rate limits, not auth errors", () => {
+    for (const msg of [
+      http(429, "too many requests"),
+      http(403, "API rate limit exceeded"),
+      http(403, "You have triggered an abuse detection mechanism"),
+    ]) {
+      expect(isRateLimitError(new Error(msg))).toBe(true);
+      expect(isAuthError(new Error(msg))).toBe(false);
+    }
+  });
+
+  it("401 and plain 403 are auth errors, not rate limits", () => {
+    for (const msg of [http(401, "Bad credentials"), http(403, "Forbidden")]) {
+      expect(isAuthError(new Error(msg))).toBe(true);
+      expect(isRateLimitError(new Error(msg))).toBe(false);
+    }
+  });
+
+  it("422 non-fast-forward is neither (the D16 loop owns it)", () => {
+    const msg = `GitHub request PATCH ${REQ.url} → HTTP 422: Update is not a fast forward`;
+    expect(isRateLimitError(new Error(msg))).toBe(false);
+    expect(isAuthError(new Error(msg))).toBe(false);
+  });
+});
+
+describe("withRateLimitBackoff", () => {
+  it("retries rate-limited requests with exponential delays + jitter", async () => {
+    const delays: number[] = [];
+    const { transport, calls } = failingTransport([
+      http(403, "API rate limit exceeded"),
+      http(429, "slow down"),
+    ]);
+    const wrapped = withRateLimitBackoff(transport, {
+      baseDelayMs: 100,
+      sleep: async (ms) => {
+        delays.push(ms);
+      },
+      random: () => 0.5,
+    });
+
+    const resp = await wrapped(REQ);
+
+    expect(resp.json).toEqual({ ok: true });
+    expect(calls()).toBe(3);
+    expect(delays).toEqual([150, 300]); // 100*2^0*1.5, 100*2^1*1.5
+  });
+
+  it("rethrows after the retry cap", async () => {
+    const { transport, calls } = failingTransport(
+      Array(5).fill(http(429, "still limited")),
+    );
+    const wrapped = withRateLimitBackoff(transport, {
+      maxRetries: 2,
+      sleep: async () => {},
+    });
+
+    await expect(wrapped(REQ)).rejects.toThrow(/HTTP 429/);
+    expect(calls()).toBe(3); // initial + 2 retries
+  });
+
+  it("passes non-rate-limit errors through immediately (422, 404, 401)", async () => {
+    for (const msg of [
+      `GitHub request PATCH ${REQ.url} → HTTP 422: Update is not a fast forward`,
+      http(404, "Not Found"),
+      http(401, "Bad credentials"),
+    ]) {
+      const { transport, calls } = failingTransport([msg]);
+      const wrapped = withRateLimitBackoff(transport, {
+        sleep: async () => {
+          throw new Error("sleep must not be called");
+        },
+      });
+      await expect(wrapped(REQ)).rejects.toThrow(msg.slice(-20));
+      expect(calls()).toBe(1);
+    }
+  });
+});

--- a/scripts/test-ci-batched.sh
+++ b/scripts/test-ci-batched.sh
@@ -123,12 +123,14 @@ echo "📦 Running exocortex grounding + RFC regression tests..."
 # transforms) that the plugin RestAssetSpaceMount + CLI BootstrapAssetSpaceService
 # both delegate to. Without it the core would rot silently (jest roots vs CI
 # allowlist gotcha — see packages/obsidian-plugin/CLAUDE.md "Test Suite Awareness").
-# RFC 4e4dc453 A1+A2 (ExoSync, 2026-06-10): services/sync/*.test (ChangeDetector,
-# SyncEngine, StructuredMerger, MergeShaclGate, diff3)
+# RFC 4e4dc453 A1+A2+A3 (ExoSync, 2026-06-10): services/sync/*.test (ChangeDetector,
+# SyncEngine, StructuredMerger, MergeShaclGate, diff3, SyncedQuarantineStore,
+# FileWatermarkStore, transportBackoff, secretScan)
 # — gates the platform-free sync core (uid-keyed change detection D18/D22 +
-# pull→no-conflict→push orchestration over restCreateCommit, D16 422-retry,
-# D19 materialization gate).
-EXOCORTEX_JEST_ARGS="--config packages/exocortex/jest.config.js --testPathPatterns=(services/(GroundingExecutor(\.[a-zA-Z0-9_-]+)?|AssetConversionService|NoteToRDFConverter\.(issue-2959|rfc-31c1a0be-grounding-ref|asset-filename|issue-3242-labelless-class)|ShapeRegistry|ShapeLoader)\.test|services/assetspace/AssetSpaceMount\.test|services/sync/(ChangeDetector|SyncEngine|StructuredMerger|GatedStructuredMerger|MergeShaclGate|diff3)\.test|application/services/RelationColumnSetResolver(\.property)?\.test|performance/RelationColumnSetResolverPerformance\.test|infrastructure/sparql/executors/BGPExecutor\.issue-2997\.test|integration/dynamic-commands/(grounding-resolve-execute|grounding-phase3b-pipeline|grounding-type-vault-fixture-parity)\.test|domain/models/GroundingFrontmatterParser\.test|domain/profile/TsFloorGuard\.test)\.ts --forceExit"
+# pull→merge→push orchestration over restCreateCommit, D16 422-retry +
+# terminal-quarantine, D19 materialization gate, D17 synced quarantine,
+# D8/D22 durable watermark, R5 secret-scan, R6 backoff).
+EXOCORTEX_JEST_ARGS="--config packages/exocortex/jest.config.js --testPathPatterns=(services/(GroundingExecutor(\.[a-zA-Z0-9_-]+)?|AssetConversionService|NoteToRDFConverter\.(issue-2959|rfc-31c1a0be-grounding-ref|asset-filename|issue-3242-labelless-class)|ShapeRegistry|ShapeLoader)\.test|services/assetspace/AssetSpaceMount\.test|services/sync/(ChangeDetector|SyncEngine|StructuredMerger|GatedStructuredMerger|MergeShaclGate|diff3|SyncedQuarantineStore|FileWatermarkStore|transportBackoff|secretScan)\.test|application/services/RelationColumnSetResolver(\.property)?\.test|performance/RelationColumnSetResolverPerformance\.test|infrastructure/sparql/executors/BGPExecutor\.issue-2997\.test|integration/dynamic-commands/(grounding-resolve-execute|grounding-phase3b-pipeline|grounding-type-vault-fixture-parity)\.test|domain/models/GroundingFrontmatterParser\.test|domain/profile/TsFloorGuard\.test)\.ts --forceExit"
 if [ "$CI" = "true" ]; then
     if timeout 60 node ./node_modules/jest/bin/jest.js $EXOCORTEX_JEST_ARGS; then
         echo "✅ Exocortex grounding regression tests passed!"


### PR DESCRIPTION
## Summary

Phase A task **A3** of RFC `4e4dc453` (ExoSync): durable stores + engineering baseline over the A1/A2 sync core. Core package only (platform-free, injected ports) — plugin/CLI wiring is Phase B.

- **SyncedQuarantineStore (D17):** conflict copies committed to a SEPARATE synced quarantine repo via the existing `restCreateCommit` primitive (no new write path). Plain synced dir, **NOT** `exo__FileSpace` — `.json` entries are invisible to the RDF walker (`.md`-only) and to `isSyncablePath`, so no UID/SHACL/index pollution. Always-mounted floor, exempt from the D19 materialization gate (writes go straight through the transport). Survives reinstall, cross-device `unresolvedCount()`/`listOpen()` (CQ4). Idempotent: stable filename (slug+hash), read-compare-skip (zero commit churn while a conflict stays unresolved), `quarantinedAt` preserved; resolution = tombstone-by-overwrite (`markResolved` — the primitive cannot delete). Batched `quarantineAll` = one commit per flush.
- **D16 terminal-quarantine:** retry exhaustion (cap 3, no CAS) now routes the contended files **plus** the last iteration's pending merge-quarantine entries to the sink, instead of dropping them with a bare `retry-exhausted`. Watermark not advanced → idempotent re-derive.
- **CredentialStore (VL#10/R8):** core port + `isAuthError` (401, or 403 without rate-limit markers). Engine maps auth failures to a distinct **`auth-required`** status with an update-PAT hint — never treated as success. Existing impls documented: plugin `LocalSecretsStore` (key `pat`, `data.local.json`), CLI `gh auth token` (OS keychain). Known blind spot documented: under-scoped fine-grained PAT yields 404 (existence-hiding).
- **FileWatermarkStore (D8/D22):** durable per-device `lastSyncedSha[repo]` + tree-hash in ONE `.local.`-infix JSON file (Sync-excluded) via injected atomic IO (temp+rename). Corrupt/missing → `null` → first-sync/full-conflict path (R10) — never a silent overwrite. Serialized RMW.
- **Engineering baseline:** `withRateLimitBackoff` transport decorator (R6: 429/403-rate-limit/abuse-detection, exponential+jitter, never touches 422/auth); `scanForSecrets` refuses the whole push on PAT/private-key shapes (R5; findings = path+kind, never the secret; quarantine contents are REDACTED instead — entry preserved minus the secret); `isSyncablePath` excludes `.local.`/`.conflict.` paths symmetrically (gitignore allowlist); `LocalFilesPort.write` atomic contract documented; minimal one-operation-at-a-time guard (D11, `busy` status, `syncAll` acquires once — no self-deadlock).
- **Deferred A2 review findings closed:**
  - [MEDIUM] convergent rename (both sides `a→b`) no longer false-quarantines as delete-vs-modify. Stricter than the deferred finding's literal text: the remote delete of the old path is consumed **only** when the remote also carries the identical blob at the new path — naive consumption would silently resurrect a remotely-deleted asset on the next sync (test covers both directions).
  - [LOW] `StructuredMerger.deepEqual` blind to non-plain objects: two different `Date`s compared equal (zero enumerable keys) → divergent timestamps silently collapsed. Now fail-loud conflict (`CORE_SCHEMA` contract).
  - [LOW] `advanceWatermark` now receives `mergedWrites` with precomputed `gitBlobSha` — no extra GET-blob per merged file; cleared pins best-effort `markResolved` (CQ4 accuracy).

## Test plan

- [x] 47 new unit tests across 5 suites (SyncedQuarantineStore, FileWatermarkStore, transportBackoff, secretScan, SyncEngine/StructuredMerger additions) against the production-shape `FakeGitHubRepo` (real blob SHAs, force:false 422 semantics)
- [x] Regression fixes empirically verified: revert → 2 FAIL / restore → 132 PASS (sync suites); StructuredMerger non-plain red→green
- [x] Full exocortex unit run: 59 pre-existing failures **identical on base commit `1d241fd4`** (verified in a separate worktree) — zero new regressions
- [x] CI allowlists updated in BOTH gates (`.github/workflows/ci.yml` + `scripts/test-ci-batched.sh`)
- [ ] CI green (13 required checks)
- [ ] code-reviewer agent + advisor round-2 before manual squash merge (parser-adjacent: no `--auto`)

## Design notes

Advisor (Plan agent) pre-implementation review: GO-WITH-CHANGES — all 7 changes applied (merge-entries carried through retry exhaustion, commit-churn guard, D11 self-deadlock fix, batched flush, markResolved on cleared pins, secret handling for quarantine contents, slug length bound). Deviation from advisor: quarantine contents are **redacted** rather than skip-and-warn — the entry stays durable minus the secret (strictly better for M1).

RFC: `4e4dc453` (vault-exodev). Task: `5c7ee17c-4216-409f-9618-3e8f90d1a7b2`. Prereqs: A1 #3457, A2 #3459.