### PR TITLE
feat(exosync): Phase B — mobile sync via requestUrl transport (RFC 4e4dc453)

### DIFF
--- a/packages/obsidian-plugin/src/ExocortexPlugin.ts
+++ b/packages/obsidian-plugin/src/ExocortexPlugin.ts
@@ -126,6 +126,11 @@ import {
 } from "./infrastructure/adapters/ApplyDepsFactory";
 import { ModalConfirmGate } from "./infrastructure/adapters/ModalConfirmGate";
 import type { RestAssetSpaceMount } from "./infrastructure/adapters/RestAssetSpaceMount";
+import { SyncCommands } from "./infrastructure/adapters/SyncCommands";
+import {
+  buildSyncEngine,
+  collectSyncRepoSpecs,
+} from "./infrastructure/adapters/SyncDepsFactory";
 import {
   CommandExecutionFlow,
   DI_TOKENS,
@@ -2554,6 +2559,24 @@ export default class ExocortexPlugin extends Plugin {
     const confirmGate =
       applyDeps?.confirmGate ?? new ModalConfirmGate(this.app);
 
+    // ExoSync Phase B (RFC 4e4dc453) — manual «Sync» over the requestUrl
+    // transport (iOS-capable, no git binary). Built BEFORE the apply manager
+    // so its busy flag feeds the D11 apply→sync exclusion below. The engine
+    // is composed fresh per invocation (fresh-PAT pattern, Issue #3382).
+    const syncCommands = new SyncCommands({
+      collectSpecs: () => collectSyncRepoSpecs(this.app),
+      buildEngine: (asUidByRepoKey) =>
+        buildSyncEngine({
+          app: this.app,
+          localDataStore,
+          asUidByRepoKey,
+          quarantineRepoUrl: this.settings.exosyncQuarantineRepoUrl,
+        }),
+      isSwitchInProgress: () => localDataStore.isSwitchInProgress(),
+      notify: (message) => this.notifier.info(message),
+      log: (message) => this.logger.warn(message),
+    });
+
     const switchMgr = new ProfileApplyManager({
       app: this.app,
       lockMgr,
@@ -2572,6 +2595,8 @@ export default class ExocortexPlugin extends Plugin {
       cacheLayer: applyDeps?.cacheLayer,
       vaultRootPath: applyDeps?.vaultRootPath,
       localDataStore,
+      // ExoSync D11 composition — apply refuses to start mid-sync.
+      isSyncBusy: () => syncCommands.isBusy(),
     });
 
     // Issue #3320 — expose the manager на plugin instance so onload recovery /
@@ -2751,6 +2776,19 @@ export default class ExocortexPlugin extends Plugin {
         },
       });
     }
+
+    // ExoSync Phase B (RFC 4e4dc453) — manual sync of the materialized
+    // AssetSpace set over requestUrl (works on BOTH platforms; the point is
+    // iOS, where no git binary exists). Registered unconditionally: with no
+    // PAT the handler surfaces the R8 "configure PAT" prompt instead of
+    // hiding the command.
+    this.addCommand({
+      id: "exosync-sync",
+      name: "Sync",
+      callback: () => {
+        void syncCommands.invokeSync();
+      },
+    });
 
     // RFC 22b50a17 Decision #6 — wipe-all switch cache clearing.
     this.addCommand({

--- a/packages/obsidian-plugin/src/domain/settings/ExocortexSettings.ts
+++ b/packages/obsidian-plugin/src/domain/settings/ExocortexSettings.ts
@@ -233,6 +233,15 @@ export interface ExocortexSettings {
    * Issue #3324 — onload wiring.
    */
   activeProfileUid: string | null;
+  /**
+   * ExoSync (RFC 4e4dc453 Phase B) — dedicated quarantine repo URL
+   * (`https://github.com/<owner>/<repo>`). Unresolvable merge conflicts are
+   * committed there as both-versions JSON entries (D17, durable cross-device).
+   * Empty string (default) ⇒ no durable quarantine sink; the engine still
+   * preserves data via watermark pins (conflicts re-derive every sync).
+   * Shared config, not a secret — synced data.json is the right home.
+   */
+  exosyncQuarantineRepoUrl: string;
   [key: string]: unknown;
 }
 
@@ -268,4 +277,5 @@ export const DEFAULT_SETTINGS: ExocortexSettings = {
     "assetspaces/exocmd/",
   ],
   activeProfileUid: null,
+  exosyncQuarantineRepoUrl: "",
 };

--- a/packages/obsidian-plugin/src/infrastructure/adapters/GitHubRestClient.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/GitHubRestClient.ts
@@ -270,6 +270,34 @@ export class GitHubRestClient {
   }
 
   /**
+   * Expose this client's `requestUrl`-backed HTTP layer as a
+   * {@link RestCommitTransport} (ExoSync Phase B wiring, RFC 4e4dc453).
+   *
+   * The returned closure is byte-identical to the one `createCommit` builds
+   * internally: it throws on non-2xx with the message shape
+   * `GitHub request {METHOD} {url} → HTTP {status}: {body}` (the informal
+   * contract `isNonFastForwardError` / `isRateLimitError` / `isAuthError`
+   * depend on), owns the Authorization header, and redacts PATs in error
+   * bodies.
+   *
+   * Transport-only by intent: consumers (SyncEngine, githubRepoReader,
+   * SyncedQuarantineStore) issue Git Data API calls through it. Do not use
+   * it as a general-purpose authenticated HTTP client.
+   */
+  public restTransport(): RestCommitTransport {
+    return (req) => this.request(req);
+  }
+
+  /**
+   * Static PAT redaction over the same token-shape regex the instance
+   * `redact()` uses — for consumers that need a redactor WITHOUT holding a
+   * client instance (e.g. `SyncEngineDeps.redact`). Idempotent.
+   */
+  public static redactTokens(message: string): string {
+    return message.replace(GitHubRestClient.PAT_REGEX, "***REDACTED***");
+  }
+
+  /**
    * GET /rate_limit → core resource remaining + reset.
    */
   public async checkRateLimit(): Promise<GitHubRateLimit> {

--- a/packages/obsidian-plugin/src/infrastructure/adapters/ProfileApplyManager.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/ProfileApplyManager.ts
@@ -506,10 +506,9 @@ export class ProfileApplyManager {
     // ExoSync D11 composition (RFC 4e4dc453 Phase B): refuse to start a
     // destructive mount-state switch while a sync run is reading/writing the
     // same folders. The sync side vetoes on `_switchInProgress` symmetrically.
+    // Throw only (no notify here) — the palette callsite catches and surfaces
+    // the message; notifying here too produced a double Notice.
     if (this.isSyncBusy?.() === true) {
-      this.notify(
-        "A sync is in progress — apply profile after it finishes (D11)",
-      );
       throw new Error(
         "applyProfile: ExoSync run in progress (D11 guard) — retry after it finishes",
       );
@@ -685,6 +684,15 @@ export class ProfileApplyManager {
     const cachedSuccessfully: Array<{ asUid: string; submodulePath: string }> = [];
 
     try {
+      // ExoSync D11 re-check (code-reviewer MEDIUM, PR #3461): the entry
+      // guard ran BEFORE the confirm gate + several awaits — a sync started
+      // in that window would otherwise race the destructive switch. Re-check
+      // immediately before the `_switchInProgress` flag is raised.
+      if (this.isSyncBusy?.() === true) {
+        throw new Error(
+          "applyProfile: ExoSync run started during apply pre-flight (D11 guard) — retry after it finishes",
+        );
+      }
       await this.appendJournal({
         phase: "apply-starting",
         targetUid: targetProfileUid,
@@ -1048,6 +1056,13 @@ export class ProfileApplyManager {
     }
     let heartbeatTimer: ReturnType<typeof setInterval> | null = null;
     try {
+      // ExoSync D11 re-check (code-reviewer MEDIUM, PR #3461) — same
+      // pre-flag window as the desktop path; see applyProfile.
+      if (this.isSyncBusy?.() === true) {
+        throw new Error(
+          "applyProfile: ExoSync run started during apply pre-flight (D11 guard) — retry after it finishes",
+        );
+      }
       await this.appendJournal({
         phase: "apply-starting",
         targetUid: targetProfileUid,

--- a/packages/obsidian-plugin/src/infrastructure/adapters/ProfileApplyManager.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/ProfileApplyManager.ts
@@ -207,6 +207,13 @@ export interface ProfileApplyManagerOptions {
   localDataStore?: PluginLocalDataStore;
   /** Absolute path к vault root — required for git operations. */
   vaultRootPath?: string;
+  /**
+   * ExoSync mutual exclusion (RFC 4e4dc453 D11, Phase B composition): a
+   * running sync vetoes apply — apply destroys/materialises the same folders
+   * the sync engine is reading/writing. The sync side already vetoes on
+   * `_switchInProgress`; this closes the opposite direction.
+   */
+  isSyncBusy?: () => boolean;
 }
 
 const DEFAULT_JOURNAL_PATH = ".exocortex/switch-journal.jsonl";
@@ -275,6 +282,7 @@ export class ProfileApplyManager {
   private readonly confirmGate?: IConfirmGate;
   private readonly localDataStore?: PluginLocalDataStore;
   private readonly vaultRootPath?: string;
+  private readonly isSyncBusy?: () => boolean;
 
   constructor(options: ProfileApplyManagerOptions) {
     this.app = options.app;
@@ -296,6 +304,7 @@ export class ProfileApplyManager {
     this.confirmGate = options.confirmGate;
     this.localDataStore = options.localDataStore;
     this.vaultRootPath = options.vaultRootPath;
+    this.isSyncBusy = options.isSyncBusy;
   }
 
   /**
@@ -493,6 +502,17 @@ export class ProfileApplyManager {
   async applyProfile(targetProfileUid: string): Promise<void> {
     if (typeof targetProfileUid !== "string" || targetProfileUid.length === 0) {
       throw new Error("applyProfile: targetProfileUid is required");
+    }
+    // ExoSync D11 composition (RFC 4e4dc453 Phase B): refuse to start a
+    // destructive mount-state switch while a sync run is reading/writing the
+    // same folders. The sync side vetoes on `_switchInProgress` symmetrically.
+    if (this.isSyncBusy?.() === true) {
+      this.notify(
+        "A sync is in progress — apply profile after it finishes (D11)",
+      );
+      throw new Error(
+        "applyProfile: ExoSync run in progress (D11 guard) — retry after it finishes",
+      );
     }
     // RFC 01a83de8 Phase 3 T2 — on mobile the git binary is unavailable, so
     // delegate to the REST/tarball mount/unmount path (no staging / cache /

--- a/packages/obsidian-plugin/src/infrastructure/adapters/SyncCommands.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/SyncCommands.ts
@@ -56,6 +56,14 @@ export class SyncCommands {
     this.running = true;
     try {
       await this.runSync();
+    } catch (err) {
+      // The palette callback fire-and-forgets this promise — surface the
+      // failure instead of leaking an unhandled rejection.
+      const msg = err instanceof Error ? err.message : String(err);
+      this.deps.notify(`Sync failed: ${msg}`);
+      (this.deps.log ?? ((m: string): void => console.warn(m)))(
+        `[ExoSync] sync run threw: ${msg}`,
+      );
     } finally {
       this.running = false;
     }

--- a/packages/obsidian-plugin/src/infrastructure/adapters/SyncCommands.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/SyncCommands.ts
@@ -18,6 +18,7 @@
 import type { RepoSyncResult, SyncRepoSpec } from "exocortex";
 import { orderChildrenFirst } from "exocortex";
 
+import { GitHubRestClient } from "./GitHubRestClient";
 import type { SyncSpecCollection, BuiltSyncEngine } from "./SyncDepsFactory";
 
 export interface SyncCommandsDeps {
@@ -58,8 +59,12 @@ export class SyncCommands {
       await this.runSync();
     } catch (err) {
       // The palette callback fire-and-forgets this promise — surface the
-      // failure instead of leaking an unhandled rejection.
-      const msg = err instanceof Error ? err.message : String(err);
+      // failure instead of leaking an unhandled rejection. Redacted as
+      // defence-in-depth: a credential-embedded URL error must not reach a
+      // Notice (code-reviewer LOW, PR #3461).
+      const msg = GitHubRestClient.redactTokens(
+        err instanceof Error ? err.message : String(err),
+      );
       this.deps.notify(`Sync failed: ${msg}`);
       (this.deps.log ?? ((m: string): void => console.warn(m)))(
         `[ExoSync] sync run threw: ${msg}`,

--- a/packages/obsidian-plugin/src/infrastructure/adapters/SyncCommands.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/SyncCommands.ts
@@ -1,0 +1,156 @@
+/**
+ * SyncCommands — «Exocortex: Sync» palette logic (RFC 4e4dc453 Phase B).
+ *
+ * Manual on-command sync (VL#1) of the materialized AssetSpace set (VL#4)
+ * through the Phase A `SyncEngine` composed by `SyncDepsFactory`. Pure
+ * logic — Obsidian wiring (plugin.addCommand + notifier) is injected.
+ *
+ * Cross-invocation exclusion (D11): the engine is built FRESH per invocation
+ * (Issue #3382 fresh-PAT pattern), so the engine-internal guard does not
+ * span invocations — this handler's `running` flag does. It is set
+ * synchronously before the first `await` so a double command invocation
+ * cannot slip past it. The same flag feeds `ProfileApplyManager.isSyncBusy`
+ * (apply→sync direction); the sync→apply direction is covered by the
+ * `_switchInProgress` veto inside the materialization gate AND the pre-run
+ * check here.
+ */
+
+import type { RepoSyncResult, SyncRepoSpec } from "exocortex";
+import { orderChildrenFirst } from "exocortex";
+
+import type { SyncSpecCollection, BuiltSyncEngine } from "./SyncDepsFactory";
+
+export interface SyncCommandsDeps {
+  /** Enumerate the materialized sync unit (collectSyncRepoSpecs). */
+  collectSpecs: () => Promise<SyncSpecCollection>;
+  /** Build a fresh engine from current PAT (buildSyncEngine). */
+  buildEngine: (
+    asUidByRepoKey: ReadonlyMap<string, string>,
+  ) => Promise<BuiltSyncEngine>;
+  /** D11 — profile apply in flight (PluginLocalDataStore). */
+  isSwitchInProgress: () => boolean;
+  /** User-facing Notice (route through ObsidianNotificationService). */
+  notify: (message: string) => void;
+  /** Diagnostic sink for per-repo warnings/details (default console). */
+  log?: (message: string) => void;
+}
+
+export class SyncCommands {
+  private readonly deps: SyncCommandsDeps;
+  private running = false;
+
+  constructor(deps: SyncCommandsDeps) {
+    this.deps = deps;
+  }
+
+  /** Apply→sync exclusion input for `ProfileApplyManager.isSyncBusy`. */
+  isBusy(): boolean {
+    return this.running;
+  }
+
+  async invokeSync(): Promise<void> {
+    if (this.running) {
+      this.deps.notify("Sync already in progress (D11) — wait for it to finish");
+      return;
+    }
+    this.running = true;
+    try {
+      await this.runSync();
+    } finally {
+      this.running = false;
+    }
+  }
+
+  private async runSync(): Promise<void> {
+    const log = this.deps.log ?? ((m: string): void => console.warn(m));
+
+    if (this.deps.isSwitchInProgress()) {
+      this.deps.notify(
+        "A profile apply is in progress — sync after it finishes (D11)",
+      );
+      return;
+    }
+
+    const collection = await this.deps.collectSpecs();
+    for (const w of collection.warnings) log(`[ExoSync] ${w}`);
+    if (collection.specs.length === 0) {
+      this.deps.notify(
+        "Nothing to sync — no materialized AssetSpaces with a GitHub source found",
+      );
+      return;
+    }
+
+    const { engine, pat } = await this.deps.buildEngine(
+      collection.asUidByRepoKey,
+    );
+    if (pat === null || pat.length === 0) {
+      // R8 — never silently degrade to unauthenticated pushes.
+      this.deps.notify(
+        "ExoSync needs a GitHub PAT — configure it in Settings → Exocortex",
+      );
+      return;
+    }
+
+    this.deps.notify(`Sync started (${collection.specs.length} repo(s))…`);
+    const results = await engine.syncAll(
+      orderChildrenFirst(collection.specs as SyncRepoSpec[]),
+    );
+    this.report(results, log);
+  }
+
+  private report(
+    results: RepoSyncResult[],
+    log: (message: string) => void,
+  ): void {
+    let pushed = 0;
+    let pulled = 0;
+    let merged = 0;
+    let quarantined = 0;
+    let synced = 0;
+    const problems: string[] = [];
+    let authRequired = false;
+
+    for (const r of results) {
+      for (const w of r.warnings) log(`[ExoSync] ${r.repoKey}: ${w}`);
+      if (r.detail !== undefined) {
+        log(`[ExoSync] ${r.repoKey}: ${r.status} — ${r.detail}`);
+      }
+      pushed += r.pushedCount;
+      pulled += r.pulledCount;
+      merged += r.mergedCount;
+      quarantined += r.quarantinedCount;
+      switch (r.status) {
+        case "synced":
+          synced++;
+          break;
+        case "auth-required":
+          authRequired = true;
+          problems.push(`${r.repoKey}: PAT rejected`);
+          break;
+        case "skipped-not-materialized":
+        case "busy":
+          // Skips are visible in the log; not a failure.
+          break;
+        default:
+          problems.push(`${r.repoKey}: ${r.status}`);
+      }
+    }
+
+    if (authRequired) {
+      // R8 — explicit, never treated as success.
+      this.deps.notify(
+        "Sync failed: the GitHub PAT is expired, revoked or under-scoped — update it in Settings → Exocortex",
+      );
+      return;
+    }
+
+    const counts = `pushed ${pushed}, pulled ${pulled}, merged ${merged}, quarantined ${quarantined}`;
+    if (problems.length === 0) {
+      this.deps.notify(`Sync done: ${synced}/${results.length} repo(s) — ${counts}`);
+    } else {
+      this.deps.notify(
+        `Sync finished with issues (${problems.join("; ")}) — ${counts}. See console for details.`,
+      );
+    }
+  }
+}

--- a/packages/obsidian-plugin/src/infrastructure/adapters/SyncDepsFactory.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/SyncDepsFactory.ts
@@ -1,0 +1,439 @@
+import type { App, DataAdapter } from "obsidian";
+import yaml from "js-yaml";
+import {
+  FileWatermarkStore,
+  GatedStructuredMerger,
+  StructuredMerger,
+  SyncEngine,
+  SyncedQuarantineStore,
+  WATERMARK_STORE_FILENAME,
+  withRateLimitBackoff,
+  derivePath,
+  type LocalFilesPort,
+  type MaterializationCheckPort,
+  type QuarantinePort,
+  type Sha1Fn,
+  type SyncRepoSpec,
+  type WatermarkFileIO,
+  type YamlCodec,
+} from "exocortex";
+
+import { GitHubRestClient } from "./GitHubRestClient";
+import { LocalSecretsStore } from "./LocalSecretsStore";
+import { isAssetSpaceFrontmatter } from "./AssetSpaceFrontmatter";
+import { parseGitHubURL } from "./AssetSpaceManager";
+import type { PluginLocalDataStore } from "./PluginLocalDataStore";
+
+/**
+ * SyncDepsFactory — ExoSync Phase B plugin wiring (RFC 4e4dc453).
+ *
+ * Composes the platform-free {@link SyncEngine} (Phase A) from Obsidian
+ * primitives, with ZERO engine edits (AC#2): the only platform-specific
+ * pieces are the injected ports below.
+ *
+ *  - transport — `GitHubRestClient.restTransport()` (Obsidian `requestUrl`,
+ *    iOS-capable, no git binary). The engine wraps it in rate-limit backoff
+ *    itself; only the quarantine store needs an explicit wrap.
+ *  - sha1 — WebCrypto `crypto.subtle.digest("SHA-1", …)` (available in the
+ *    Obsidian renderer on both desktop Electron and mobile Capacitor;
+ *    injectable for test environments without WebCrypto).
+ *  - watermark store — {@link FileWatermarkStore} over `vault.adapter` at
+ *    `<configDir>/plugins/<id>/exosync-watermarks.local.json` (the `.local.`
+ *    infix is Obsidian-Sync-excluded AND `isSyncablePath`-refused, D8).
+ *  - local files — `vault.adapter` scoped to the repo's mount path
+ *    (`assetspaces/<owner>/<repo>`), atomic writes (tmp + remove + rename —
+ *    `DataAdapter.rename` fails on an existing target on mobile, so the
+ *    target is removed first; same order as `FileLogChannel.rotateIfNeeded`).
+ *  - materialization gate (D19, degraded mobile form) — the REST/tarball
+ *    mount layer keeps no manifest ("mount-state visibility is folder
+ *    exists", `RestAssetSpaceMount`), so the check is: folder exists, is
+ *    non-empty, no profile apply in flight (`_switchInProgress`, D11
+ *    composition), and no staging dir is allocated for that AssetSpace
+ *    (desktop mid-pull signal). Weaker than the CLI's manifest check by
+ *    construction — documented in the RFC as the mobile floor.
+ *  - merge layer — `GatedStructuredMerger` over js-yaml CORE_SCHEMA
+ *    (date-like scalars MUST round-trip as strings per the YamlCodec
+ *    contract). The optional SHACL merge-gate is NOT wired in Phase B —
+ *    plugin-side ShapeRegistry/ClassHierarchy/triplesFor composition is a
+ *    follow-up; unresolvable merges still quarantine (D17).
+ *  - quarantine — `SyncedQuarantineStore` against the user-configured
+ *    quarantine repo (settings), absent ⇒ engine degrades safely (watermark
+ *    pins re-derive conflicts, no data loss).
+ */
+
+/** Per-repo sync branch. AssetSpace ABox declares no branch property and the
+ * REST mount layer pulls `ref="main"` — same constant here. NOTE: changing
+ * this later (e.g. API-resolved default branch) changes `repoKey` and resets
+ * watermarks → one-time first-sync full-conflict per repo. */
+export const SYNC_BRANCH = "main";
+
+/** Result of {@link collectSyncRepoSpecs}. */
+export interface SyncSpecCollection {
+  specs: SyncRepoSpec[];
+  /** AssetSpace ABox uid per repoKey — staging-dir veto input (D19). */
+  asUidByRepoKey: Map<string, string>;
+  /** Skipped AssetSpaces (unparseable / non-GitHub source). */
+  warnings: string[];
+}
+
+/** Dual-read `exo__AssetSpace_source ?? _git` (RFC 01a83de8 v10). */
+function readSource(fm: Record<string, unknown>): string | null {
+  const source = fm["exo__AssetSpace_source"];
+  if (typeof source === "string" && source.length > 0) return source;
+  const git = fm["exo__AssetSpace_git"];
+  if (typeof git === "string" && git.length > 0) return git;
+  return null;
+}
+
+/**
+ * Enumerate the sync unit (VL#4/D7): every AssetSpace ABox in the vault
+ * whose derived mount folder (`assetspaces/<owner>/<repo>`) currently exists
+ * on disk — i.e. the MATERIALIZED set. Unmounted AssetSpaces are excluded
+ * here (not via the D19 gate) so each sync run is not flooded with
+ * skipped-not-materialized warnings for spaces the device never mounted.
+ *
+ * Only `https://github.com/<owner>/<repo>` sources participate (the same
+ * allowlist as the REST mount path); other source forms are skipped with a
+ * warning.
+ */
+export async function collectSyncRepoSpecs(
+  app: App,
+): Promise<SyncSpecCollection> {
+  const specs: SyncRepoSpec[] = [];
+  const asUidByRepoKey = new Map<string, string>();
+  const warnings: string[] = [];
+  const seen = new Set<string>();
+
+  for (const file of app.vault.getMarkdownFiles()) {
+    const cache = app.metadataCache.getFileCache(file);
+    const fm = cache?.frontmatter as Record<string, unknown> | undefined;
+    if (!fm || !isAssetSpaceFrontmatter(fm)) continue;
+
+    const source = readSource(fm);
+    if (source === null) continue;
+
+    let owner: string;
+    let repo: string;
+    try {
+      GitHubRestClient.validateRepoURL(source.replace(/\.git$/i, ""));
+      ({ owner, repo } = parseGitHubURL(source));
+    } catch {
+      warnings.push(
+        `skipped AssetSpace at ${file.path}: source is not a plain https://github.com/<owner>/<repo> URL`,
+      );
+      continue;
+    }
+
+    const localPath = derivePath(source);
+    if (localPath === null) {
+      warnings.push(
+        `skipped AssetSpace at ${file.path}: cannot derive mount path from source`,
+      );
+      continue;
+    }
+
+    const repoKey = `${owner}/${repo}#${SYNC_BRANCH}`;
+    if (seen.has(repoKey)) continue;
+    seen.add(repoKey);
+
+    let exists = false;
+    try {
+      exists = await app.vault.adapter.exists(localPath);
+    } catch {
+      // adapter error → treat as not materialized (fail-closed, D19 spirit)
+    }
+    if (!exists) continue;
+
+    specs.push({
+      owner,
+      repo,
+      branch: SYNC_BRANCH,
+      repoKey,
+      localPath,
+    });
+    const asUid =
+      typeof fm["exo__Asset_uid"] === "string"
+        ? (fm["exo__Asset_uid"] as string).trim()
+        : "";
+    if (asUid.length > 0) asUidByRepoKey.set(repoKey, asUid);
+  }
+
+  return { specs, asUidByRepoKey, warnings };
+}
+
+/** Default `Sha1Fn` over WebCrypto (renderer-safe on desktop AND iOS). */
+export const webCryptoSha1: Sha1Fn = async (
+  bytes: Uint8Array,
+): Promise<string> => {
+  const digest = await crypto.subtle.digest(
+    "SHA-1",
+    bytes.buffer.slice(
+      bytes.byteOffset,
+      bytes.byteOffset + bytes.byteLength,
+    ) as ArrayBuffer,
+  );
+  return [...new Uint8Array(digest)]
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+};
+
+/**
+ * Atomic write over `vault.adapter`: write to a `.local.`-infixed temp path
+ * (Sync-excluded, non-`.md` so `isSyncablePath` refuses it symmetrically),
+ * remove the target if present, then rename. Target-removal-first mirrors
+ * `FileLogChannel.rotateIfNeeded` — `DataAdapter.rename` onto an existing
+ * path fails on mobile.
+ */
+async function writeAtomic(
+  adapter: DataAdapter,
+  path: string,
+  content: string,
+): Promise<void> {
+  const tmp = `${path}.local.tmp`;
+  await adapter.write(tmp, content);
+  if (await adapter.exists(path)) {
+    await adapter.remove(path);
+  }
+  await adapter.rename(tmp, path);
+}
+
+/** Parent directory of a vault-relative path; `""` if top-level. */
+function parentDir(p: string): string {
+  const i = p.lastIndexOf("/");
+  return i <= 0 ? "" : p.slice(0, i);
+}
+
+async function ensureDirChain(
+  adapter: DataAdapter,
+  dir: string,
+): Promise<void> {
+  if (dir.length === 0) return;
+  if (await adapter.exists(dir)) return;
+  const parent = parentDir(dir);
+  if (parent.length > 0) await ensureDirChain(adapter, parent);
+  await adapter.mkdir(dir);
+}
+
+/**
+ * `LocalFilesPort` over `vault.adapter`, scoped to one repo mount folder.
+ * Paths are repo-relative forward-slash (the engine's contract); the adapter
+ * joins them under `rootPath`. Writes are atomic and create parent folders
+ * (a pulled remote file may live in a brand-new subfolder).
+ */
+export function vaultLocalFilesPort(
+  adapter: DataAdapter,
+  rootPath: string,
+): LocalFilesPort {
+  const abs = (rel: string): string => `${rootPath}/${rel}`;
+  return {
+    async list(): Promise<string[]> {
+      const out: string[] = [];
+      const walk = async (dir: string): Promise<void> => {
+        const listing = await adapter.list(dir);
+        for (const f of listing.files) {
+          out.push(f.slice(rootPath.length + 1));
+        }
+        for (const sub of listing.folders) {
+          await walk(sub);
+        }
+      };
+      if (await adapter.exists(rootPath)) {
+        await walk(rootPath);
+      }
+      return out;
+    },
+    async read(path: string): Promise<string> {
+      return adapter.read(abs(path));
+    },
+    async write(path: string, content: string): Promise<void> {
+      const target = abs(path);
+      const parent = parentDir(target);
+      if (parent.length > 0) await ensureDirChain(adapter, parent);
+      await writeAtomic(adapter, target, content);
+    },
+    async delete(path: string): Promise<void> {
+      const target = abs(path);
+      if (await adapter.exists(target)) {
+        await adapter.remove(target);
+      }
+    },
+  };
+}
+
+/** Single-file `WatermarkFileIO` over `vault.adapter` (D8 store). */
+export function vaultWatermarkFileIO(
+  adapter: DataAdapter,
+  filePath: string,
+): WatermarkFileIO {
+  return {
+    async read(): Promise<string | null> {
+      if (!(await adapter.exists(filePath))) return null;
+      return adapter.read(filePath);
+    },
+    async writeAtomic(content: string): Promise<void> {
+      const parent = parentDir(filePath);
+      if (parent.length > 0) await ensureDirChain(adapter, parent);
+      await writeAtomic(adapter, filePath, content);
+    },
+  };
+}
+
+export interface MaterializationCheckOptions {
+  adapter: DataAdapter;
+  /** D11 composition — a profile apply in flight vetoes every repo. */
+  isSwitchInProgress: () => boolean;
+  /** AssetSpace uids with an allocated staging dir (desktop mid-pull). */
+  getStagingAsUids: () => Promise<ReadonlySet<string>>;
+  /** From {@link collectSyncRepoSpecs} — repoKey → AssetSpace ABox uid. */
+  asUidByRepoKey: ReadonlyMap<string, string>;
+}
+
+/**
+ * Degraded mobile D19 gate (see module docstring): folder exists + non-empty
+ * + no apply in flight + no staging allocation for this AssetSpace. Deletes
+ * are never inferred for a vetoed repo — the engine skips it with a warning.
+ */
+export function vaultMaterializationCheck(
+  opts: MaterializationCheckOptions,
+): MaterializationCheckPort {
+  return {
+    async check(spec: SyncRepoSpec) {
+      if (opts.isSwitchInProgress()) {
+        return {
+          fullyMaterialized: false,
+          reason: "profile apply in progress (D11) — sync after it finishes",
+        };
+      }
+      const asUid = opts.asUidByRepoKey.get(spec.repoKey);
+      if (asUid !== undefined) {
+        try {
+          const staging = await opts.getStagingAsUids();
+          if (staging.has(asUid)) {
+            return {
+              fullyMaterialized: false,
+              reason:
+                "a staging dir is allocated for this AssetSpace (mid-pull)",
+            };
+          }
+        } catch {
+          // staging registry unreadable → don't veto on it (best-effort)
+        }
+      }
+      let entries = 0;
+      try {
+        if (!(await opts.adapter.exists(spec.localPath))) {
+          return {
+            fullyMaterialized: false,
+            reason: `mount folder ${spec.localPath} does not exist`,
+          };
+        }
+        const listing = await opts.adapter.list(spec.localPath);
+        entries = listing.files.length + listing.folders.length;
+      } catch {
+        return {
+          fullyMaterialized: false,
+          reason: `mount folder ${spec.localPath} is not readable`,
+        };
+      }
+      if (entries === 0) {
+        return {
+          fullyMaterialized: false,
+          reason: `mount folder ${spec.localPath} is empty (mid-mount?)`,
+        };
+      }
+      return { fullyMaterialized: true };
+    },
+  };
+}
+
+/** js-yaml CORE_SCHEMA codec — date-like scalars round-trip as strings. */
+export const coreSchemaYamlCodec: YamlCodec = {
+  parse: (text) => yaml.load(text, { schema: yaml.CORE_SCHEMA }),
+  stringify: (value) =>
+    yaml.dump(value, { schema: yaml.CORE_SCHEMA, lineWidth: -1 }),
+};
+
+export interface BuildSyncEngineOptions {
+  app: App;
+  localDataStore: PluginLocalDataStore;
+  /** repoKey → AssetSpace uid map from {@link collectSyncRepoSpecs}. */
+  asUidByRepoKey: ReadonlyMap<string, string>;
+  /**
+   * Quarantine repo URL (`https://github.com/<owner>/<repo>`) from settings.
+   * Empty/undefined ⇒ no durable quarantine sink (engine pins re-derive).
+   */
+  quarantineRepoUrl?: string;
+  /** Test seam — defaults to {@link webCryptoSha1}. */
+  sha1?: Sha1Fn;
+}
+
+export interface BuiltSyncEngine {
+  engine: SyncEngine;
+  /** PAT resolved at build time; null ⇒ caller surfaces the R8 prompt. */
+  pat: string | null;
+}
+
+/**
+ * Build a fresh SyncEngine from the CURRENTLY stored PAT (Issue #3382
+ * fresh-credential pattern — a PAT configured after onload is honoured
+ * without a reload). NOTE: the engine instance is per-invocation, so its
+ * internal D11 guard does NOT span invocations — the command handler keeps
+ * its own `running` flag for cross-invocation exclusion.
+ */
+export async function buildSyncEngine(
+  opts: BuildSyncEngineOptions,
+): Promise<BuiltSyncEngine> {
+  const { app, localDataStore } = opts;
+  const sha1 = opts.sha1 ?? webCryptoSha1;
+  const secretsStore = new LocalSecretsStore({ app });
+  const pat = await secretsStore.getSecret("pat");
+  const client = new GitHubRestClient({ app, pat: pat ?? "" });
+  const transport = client.restTransport();
+  const adapter = app.vault.adapter;
+  const configDir = app.vault.configDir;
+  const watermarkPath = `${configDir}/plugins/exocortex/${WATERMARK_STORE_FILENAME}`;
+
+  let quarantine: QuarantinePort | undefined;
+  const quarantineUrl = opts.quarantineRepoUrl?.trim() ?? "";
+  if (quarantineUrl.length > 0) {
+    GitHubRestClient.validateRepoURL(quarantineUrl);
+    const { owner, repo } = parseGitHubURL(quarantineUrl);
+    quarantine = new SyncedQuarantineStore({
+      // The engine wraps ITS transport internally; the quarantine store
+      // needs its own backoff wrap (it is the highest-volume caller).
+      transport: withRateLimitBackoff(transport),
+      sha1,
+      owner,
+      repo,
+      branch: SYNC_BRANCH,
+      redact: (m) => GitHubRestClient.redactTokens(m),
+    });
+  }
+
+  const engine = new SyncEngine({
+    transport,
+    watermarkStore: new FileWatermarkStore(
+      vaultWatermarkFileIO(adapter, watermarkPath),
+    ),
+    materializationCheck: vaultMaterializationCheck({
+      adapter,
+      isSwitchInProgress: () => localDataStore.isSwitchInProgress(),
+      getStagingAsUids: async () => {
+        const entries = await localDataStore.readActiveStagingDirs();
+        return new Set(entries.map((e) => e.asUid));
+      },
+      asUidByRepoKey: opts.asUidByRepoKey,
+    }),
+    localFilesFor: (spec) => vaultLocalFilesPort(adapter, spec.localPath),
+    sha1,
+    redact: (m) => GitHubRestClient.redactTokens(m),
+    // SHACL merge-gate deferred (follow-up): GatedStructuredMerger without
+    // a gate still quarantines unresolvable merges (D17).
+    mergeLayer: new GatedStructuredMerger(
+      new StructuredMerger(coreSchemaYamlCodec),
+    ),
+    ...(quarantine !== undefined ? { quarantine } : {}),
+  });
+
+  return { engine, pat };
+}

--- a/packages/obsidian-plugin/src/infrastructure/adapters/SyncDepsFactory.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/SyncDepsFactory.ts
@@ -112,11 +112,16 @@ export async function collectSyncRepoSpecs(
     const source = readSource(fm);
     if (source === null) continue;
 
+    // Normalize ONCE and feed the SAME string everywhere — parseGitHubURL
+    // strips `.git` case-sensitively while derivePath strips it
+    // case-insensitively, so an unnormalized `.GIT` source would diverge
+    // repo vs mount path (code-reviewer LOW, PR #3461).
+    const normalized = source.replace(/\.git$/i, "");
     let owner: string;
     let repo: string;
     try {
-      GitHubRestClient.validateRepoURL(source.replace(/\.git$/i, ""));
-      ({ owner, repo } = parseGitHubURL(source));
+      GitHubRestClient.validateRepoURL(normalized);
+      ({ owner, repo } = parseGitHubURL(normalized));
     } catch {
       warnings.push(
         `skipped AssetSpace at ${file.path}: source is not a plain https://github.com/<owner>/<repo> URL`,
@@ -124,7 +129,7 @@ export async function collectSyncRepoSpecs(
       continue;
     }
 
-    const localPath = derivePath(source);
+    const localPath = derivePath(normalized);
     if (localPath === null) {
       warnings.push(
         `skipped AssetSpace at ${file.path}: cannot derive mount path from source`,
@@ -178,11 +183,17 @@ export const webCryptoSha1: Sha1Fn = async (
 };
 
 /**
- * Atomic write over `vault.adapter`: write to a `.local.`-infixed temp path
- * (Sync-excluded, non-`.md` so `isSyncablePath` refuses it symmetrically),
- * remove the target if present, then rename. Target-removal-first mirrors
+ * Atomic write over `vault.adapter`: write to a temp path, remove the
+ * target if present, then rename. Target-removal-first mirrors
  * `FileLogChannel.rotateIfNeeded` — `DataAdapter.rename` onto an existing
  * path fails on mobile.
+ *
+ * The `.local.tmp` suffix keeps a crash-leftover temp file out of the SYNC
+ * ENGINE via `isSyncablePath` (non-`.md` suffix AND `.local.` infix — both
+ * refused symmetrically). Obsidian Sync's own `.local.` exclusion applies
+ * to plugin-dir artifacts (data.local.json convention); inside the vault
+ * proper a leftover could replicate depending on the user's file-type sync
+ * settings — harmless, since it can never enter the sync cycle.
  */
 async function writeAtomic(
   adapter: DataAdapter,

--- a/packages/obsidian-plugin/src/presentation/settings/ExocortexSettingTab.ts
+++ b/packages/obsidian-plugin/src/presentation/settings/ExocortexSettingTab.ts
@@ -698,6 +698,37 @@ export class ExocortexSettingTab extends PluginSettingTab {
         }),
       );
 
+    // ─────── ExoSync (RFC 4e4dc453 Phase B) ───────
+    // eslint-disable-next-line obsidianmd/ui/sentence-case -- "ExoSync" is the feature's proper name
+    new Setting(containerEl).setName("ExoSync").setHeading();
+
+    new Setting(containerEl)
+      .setName("Quarantine repo URL")
+      .setDesc(
+        "Optional dedicated GitHub repo (https://github.com/<owner>/<repo>) " +
+          "where unresolvable sync conflicts are preserved as both-versions " +
+          "entries (D17). Leave empty to skip the durable quarantine sink — " +
+          "conflicts still re-derive on every sync until resolved.",
+      )
+      .addText((text) => {
+        text.setPlaceholder("https://github.com/owner/exosync-quarantine");
+        text.setValue(this.plugin.settings.exosyncQuarantineRepoUrl ?? "");
+        text.onChange(async (value) => {
+          const trimmed = value.trim();
+          if (trimmed.length > 0) {
+            try {
+              GitHubRestClient.validateRepoURL(trimmed);
+            } catch {
+              // Invalid shape — don't persist; the Sync command would throw
+              // on it anyway. The field keeps the user's draft text.
+              return;
+            }
+          }
+          this.plugin.settings.exosyncQuarantineRepoUrl = trimmed;
+          await this.plugin.saveSettings();
+        });
+      });
+
     // ─────── Section 2 — Active profile ───────
     new Setting(containerEl).setName("Active profile").setHeading();
 

--- a/packages/obsidian-plugin/src/presentation/settings/ExocortexSettingTab.ts
+++ b/packages/obsidian-plugin/src/presentation/settings/ExocortexSettingTab.ts
@@ -715,15 +715,20 @@ export class ExocortexSettingTab extends PluginSettingTab {
         text.setValue(this.plugin.settings.exosyncQuarantineRepoUrl ?? "");
         text.onChange(async (value) => {
           const trimmed = value.trim();
+          let valid = true;
           if (trimmed.length > 0) {
             try {
               GitHubRestClient.validateRepoURL(trimmed);
             } catch {
-              // Invalid shape — don't persist; the Sync command would throw
-              // on it anyway. The field keeps the user's draft text.
-              return;
+              valid = false;
             }
           }
+          // Visual cue instead of a silent no-persist (code-reviewer LOW,
+          // PR #3461): the field keeps the draft text, the red border tells
+          // the user the stored value did NOT change.
+          text.inputEl.toggleClass("exocortex-invalid-input", !valid);
+          text.inputEl.setAttribute("aria-invalid", valid ? "false" : "true");
+          if (!valid) return;
           this.plugin.settings.exosyncQuarantineRepoUrl = trimmed;
           await this.plugin.saveSettings();
         });

--- a/packages/obsidian-plugin/styles.css
+++ b/packages/obsidian-plugin/styles.css
@@ -6138,3 +6138,8 @@
 .bootstrap-modal-error.is-visible {
   display: block;
 }
+
+/* ExoSync (RFC 4e4dc453 Phase B) — invalid quarantine repo URL cue */
+.exocortex-invalid-input {
+  border-color: var(--text-error) !important;
+}

--- a/packages/obsidian-plugin/tests/__mocks__/obsidian.ts
+++ b/packages/obsidian-plugin/tests/__mocks__/obsidian.ts
@@ -31,6 +31,7 @@ declare global {
     addClass?: (cls: string) => void;
     removeClass?: (cls: string) => void;
     hasClass?: (cls: string) => boolean;
+    toggleClass?: (cls: string, value: boolean) => void;
     setText?: (text: string) => void;
   }
 }
@@ -95,6 +96,11 @@ if (typeof document !== "undefined") {
   if (!proto.hasClass) {
     proto.hasClass = function (cls: string) {
       return this.classList.contains(cls);
+    };
+  }
+  if (!proto.toggleClass) {
+    proto.toggleClass = function (cls: string, value: boolean) {
+      this.classList.toggle(cls, value);
     };
   }
   if (!proto.setText) {

--- a/packages/obsidian-plugin/tests/unit/ExocortexSettingTab.test.ts
+++ b/packages/obsidian-plugin/tests/unit/ExocortexSettingTab.test.ts
@@ -159,7 +159,8 @@ describe("ExocortexSettingTab", () => {
       // Excluded folders section (#3278): 1 heading + 1 textarea row = +2 → 32
       // Issue #3320 — Profile sections: 4 section headings + PAT row + Switch profile row + Cache stats row + (Operations log has no Setting row, body уходит в createDiv/createEl) = +7 → 39
       // RFC 13da049f R35 — added "Profiles" overview heading (+1) → 40
-      expect(MockSetting).toHaveBeenCalledTimes(40);
+      // RFC 4e4dc453 Phase B — ExoSync section: heading + quarantine repo URL row (+2) → 42
+      expect(MockSetting).toHaveBeenCalledTimes(42);
     });
 
     it("should render layout visibility toggle as first setting", () => {

--- a/packages/obsidian-plugin/tests/unit/ProfileApplyManager.apply.test.ts
+++ b/packages/obsidian-plugin/tests/unit/ProfileApplyManager.apply.test.ts
@@ -292,6 +292,8 @@ interface SetupOptions {
   sourceLabel?: string;
   /** AS UIDs currently materialized (subset of vault scan). */
   materialized: string[];
+  /** ExoSync D11 exclusion input (RFC 4e4dc453 Phase B). */
+  isSyncBusy?: () => boolean;
 }
 
 function setup(opts: SetupOptions) {
@@ -424,6 +426,7 @@ function setup(opts: SetupOptions) {
     localDataStore: localDataStore as any,
     /* eslint-enable @typescript-eslint/no-explicit-any */
     vaultRootPath: "/fake/vault",
+    ...(opts.isSyncBusy !== undefined ? { isSyncBusy: opts.isSyncBusy } : {}),
   });
   return {
     mgr,
@@ -612,6 +615,61 @@ describe("ProfileApplyManager.applyProfile", () => {
       await expect(mgr.applyProfile("target")).rejects.toThrow(ApplyAbortedByUser);
       expect(gitOps.calls.length).toBe(0);
       expect(cacheLayer.cachedCalls.length).toBe(0);
+    });
+  });
+
+  describe("ExoSync D11 exclusion (RFC 4e4dc453 Phase B)", () => {
+    const D11_SETUP = {
+      targetUid: "target",
+      sourceUid: null,
+      targetIncludes: [
+        TS_FLOOR_AS_UID_EXO,
+        TS_FLOOR_AS_UID_EXOCMD,
+        TS_FLOOR_AS_UID_SHARED_IDENTITIES,
+      ],
+      materialized: [
+        "ems-uid",
+        TS_FLOOR_AS_UID_EXO,
+        TS_FLOOR_AS_UID_EXOCMD,
+        TS_FLOOR_AS_UID_SHARED_IDENTITIES,
+      ],
+    };
+
+    it("entry guard: refuses to start while a sync is running, touching nothing", async () => {
+      const { mgr, gitOps, cacheLayer, app, localDataStore } = setup({
+        ...D11_SETUP,
+        isSyncBusy: () => true,
+      });
+
+      await expect(mgr.applyProfile("target")).rejects.toThrow(/D11/);
+
+      expect(gitOps.calls.length).toBe(0);
+      expect(cacheLayer.cachedCalls.length).toBe(0);
+      expect((await readJournalEntries(app)).length).toBe(0);
+      expect(localDataStore.snapshot()._switchInProgress).toBe(false);
+    });
+
+    it("pre-flag re-check: a sync starting during the confirm gate aborts before _switchInProgress is raised", async () => {
+      let busy = false;
+      const { mgr, gitOps, cacheLayer, app, localDataStore, confirmGate } =
+        setup({ ...D11_SETUP, isSyncBusy: () => busy });
+      // The user keeps the confirm modal open while a sync kicks off — the
+      // window the entry guard cannot see (code-reviewer MEDIUM, PR #3461).
+      const originalConfirm = confirmGate.confirmApply.bind(confirmGate);
+      confirmGate.confirmApply = async (plan) => {
+        busy = true;
+        return originalConfirm(plan);
+      };
+
+      await expect(mgr.applyProfile("target")).rejects.toThrow(/D11/);
+
+      // No mutation phase ran and the flag was never raised.
+      expect(gitOps.calls.length).toBe(0);
+      expect(cacheLayer.cachedCalls.length).toBe(0);
+      const phases = (await readJournalEntries(app)).map((e) => e.phase);
+      expect(phases).not.toContain("apply-starting");
+      expect(phases.filter((p) => p.startsWith("phase2"))).toEqual([]);
+      expect(localDataStore.snapshot()._switchInProgress).toBe(false);
     });
   });
 

--- a/packages/obsidian-plugin/tests/unit/sync/ExoSyncRequestUrlParity.integration.test.ts
+++ b/packages/obsidian-plugin/tests/unit/sync/ExoSyncRequestUrlParity.integration.test.ts
@@ -1,0 +1,275 @@
+/**
+ * ExoSync Phase B desktop-parity integration (RFC 4e4dc453, AC#3).
+ *
+ * Drives the REAL composition — `collectSyncRepoSpecs` → `buildSyncEngine`
+ * (real `GitHubRestClient` over a mocked `requestUrl`) → `SyncEngine` — and
+ * mirrors the engine-level scenarios of `SyncEngine.test.ts` through the
+ * `requestUrl` transport layer: push, pull, structured merge, quarantine
+ * (conflict-copy), durable quarantine repo, auth-required (R8).
+ *
+ * The remote is the same `FakeGitHubRepo` Git Data API state machine the
+ * Phase A engine tests use (production message-shape contract), adapted at
+ * the `requestUrl` level so the REAL `GitHubRestClient.request()` error path
+ * (`GitHub request {M} {url} → HTTP {N}: {body}`) is exercised end-to-end.
+ */
+
+jest.mock("obsidian", () => ({
+  ...jest.requireActual<Record<string, unknown>>("obsidian"),
+  requestUrl: jest.fn(),
+}));
+
+// jsdom lacks TextEncoder/TextDecoder — the engine's gitBlobSha needs them.
+import { TextDecoder, TextEncoder } from "node:util";
+if (typeof globalThis.TextEncoder === "undefined") {
+  globalThis.TextEncoder = TextEncoder as typeof globalThis.TextEncoder;
+}
+if (typeof globalThis.TextDecoder === "undefined") {
+  globalThis.TextDecoder = TextDecoder as unknown as typeof globalThis.TextDecoder;
+}
+
+import { requestUrl } from "obsidian";
+import type { App } from "obsidian";
+import {
+  FakeGitHubRepo,
+  sha1Hex,
+} from "../../../../exocortex/tests/unit/services/sync/fakeGitHub";
+import {
+  buildSyncEngine,
+  collectSyncRepoSpecs,
+} from "../../../src/infrastructure/adapters/SyncDepsFactory";
+import { PluginLocalDataStore } from "../../../src/infrastructure/adapters/PluginLocalDataStore";
+import {
+  InMemoryAdapter,
+  assetSpaceFm,
+  fakeRequestUrlRouter,
+  makeApp,
+} from "./syncTestHelpers";
+
+const requestUrlMock = requestUrl as unknown as jest.Mock;
+
+const OWNER = "test-owner";
+const REPO = "test-repo";
+const MOUNT = `assetspaces/${OWNER}/${REPO}`;
+const SOURCE = `https://github.com/${OWNER}/${REPO}`;
+const QUARANTINE_URL = `https://github.com/${OWNER}/quarantine`;
+const PAT = `ghp_${"x".repeat(36)}`;
+
+const asset = (uid: string, label: string, extra?: string): string =>
+  `---\nexo__Asset_uid: ${uid}\nexo__Asset_label: ${label}\n${
+    extra !== undefined ? `${extra}\n` : ""
+  }---\n\nbody\n`;
+
+interface Harness {
+  repo: FakeGitHubRepo;
+  quarantineRepo: FakeGitHubRepo;
+  adapter: InMemoryAdapter;
+  sync: () => Promise<
+    Awaited<ReturnType<import("exocortex").SyncEngine["syncAll"]>>
+  >;
+}
+
+async function makeHarness(opts: {
+  initialFiles: Record<string, string>;
+  withQuarantineRepo?: boolean;
+}): Promise<Harness> {
+  const repo = new FakeGitHubRepo(opts.initialFiles);
+  const quarantineRepo = new FakeGitHubRepo({});
+  requestUrlMock.mockImplementation(
+    fakeRequestUrlRouter({
+      [`${OWNER}/${REPO}`]: repo,
+      [`${OWNER}/quarantine`]: quarantineRepo,
+    }),
+  );
+
+  const adapter = new InMemoryAdapter();
+  adapter.mkdirAll(`.obsidian/plugins/exocortex`);
+  adapter.seedFile(
+    `.obsidian/plugins/exocortex/data.local.json`,
+    JSON.stringify({ pat: PAT }),
+  );
+  adapter.mkdirAll(MOUNT);
+  for (const [path, content] of Object.entries(opts.initialFiles)) {
+    adapter.seedFile(`${MOUNT}/${path}`, content);
+  }
+
+  const app = makeApp({
+    adapter,
+    mdFiles: [{ path: "as1.md" }],
+    frontmatters: new Map([["as1.md", assetSpaceFm("as-uid-1", SOURCE)]]),
+  }) as unknown as App;
+
+  const localDataStore = new PluginLocalDataStore({ app });
+  await localDataStore.init();
+
+  const sync = async () => {
+    const collection = await collectSyncRepoSpecs(app);
+    const { engine, pat } = await buildSyncEngine({
+      app,
+      localDataStore,
+      asUidByRepoKey: collection.asUidByRepoKey,
+      sha1: sha1Hex,
+      ...(opts.withQuarantineRepo === true
+        ? { quarantineRepoUrl: QUARANTINE_URL }
+        : {}),
+    });
+    expect(pat).toBe(PAT);
+    return engine.syncAll(collection.specs);
+  };
+
+  return { repo, quarantineRepo, adapter, sync };
+}
+
+describe("ExoSync over requestUrl (desktop parity, AC#3)", () => {
+  beforeEach(() => {
+    requestUrlMock.mockReset();
+  });
+
+  it("bootstraps the watermark when disk equals the remote head", async () => {
+    const h = await makeHarness({
+      initialFiles: { "a.md": asset("u1", "one") },
+    });
+
+    const results = await h.sync();
+
+    expect(results).toHaveLength(1);
+    expect(results[0].detail).toBeUndefined();
+    expect(results[0].status).toBe("synced");
+    expect(
+      results[0].warnings.some((w) => w.includes("bootstrapped")),
+    ).toBe(true);
+  });
+
+  it("pushes a local edit to the remote", async () => {
+    const h = await makeHarness({
+      initialFiles: { "a.md": asset("u1", "one") },
+    });
+    await h.sync(); // bootstrap
+
+    h.adapter.seedFile(`${MOUNT}/a.md`, asset("u1", "one-edited"));
+    const results = await h.sync();
+
+    expect(results[0].status).toBe("synced");
+    expect(results[0].pushedCount).toBe(1);
+    expect(results[0].pushedSha).toBeDefined();
+    expect(h.repo.headFiles().get("a.md")).toContain("one-edited");
+  });
+
+  it("pulls a remote change to disk", async () => {
+    const h = await makeHarness({
+      initialFiles: { "a.md": asset("u1", "one") },
+    });
+    await h.sync(); // bootstrap
+
+    h.repo.commitDirect(
+      "main",
+      { "a.md": asset("u1", "one-remote") },
+      "device B",
+    );
+    const results = await h.sync();
+
+    expect(results[0].status).toBe("synced");
+    expect(results[0].pulledCount).toBe(1);
+    expect(await h.adapter.read(`${MOUNT}/a.md`)).toContain("one-remote");
+  });
+
+  it("merges divergent frontmatter keys from both sides (A2 parity)", async () => {
+    const h = await makeHarness({
+      initialFiles: { "a.md": asset("u1", "one", "extra: base") },
+    });
+    await h.sync(); // bootstrap
+
+    // Local edits the label; device B edits the `extra` key.
+    h.adapter.seedFile(
+      `${MOUNT}/a.md`,
+      asset("u1", "one-local", "extra: base"),
+    );
+    h.repo.commitDirect(
+      "main",
+      { "a.md": asset("u1", "one", "extra: remote") },
+      "device B",
+    );
+    const results = await h.sync();
+
+    expect(results[0].status).toBe("synced");
+    expect(results[0].mergedCount).toBe(1);
+    const disk = await h.adapter.read(`${MOUNT}/a.md`);
+    expect(disk).toContain("one-local");
+    expect(disk).toContain("extra: remote");
+    const remote = h.repo.headFiles().get("a.md");
+    expect(remote).toContain("one-local");
+    expect(remote).toContain("extra: remote");
+  });
+
+  it("quarantines an unresolvable conflict, leaving disk and remote intact", async () => {
+    const h = await makeHarness({
+      initialFiles: { "a.md": asset("u1", "one") },
+    });
+    await h.sync(); // bootstrap
+
+    // Both sides change the SAME key to different values — no clean 3-way.
+    h.adapter.seedFile(`${MOUNT}/a.md`, asset("u1", "local-version"));
+    h.repo.commitDirect(
+      "main",
+      { "a.md": asset("u1", "remote-version") },
+      "device B",
+    );
+    const results = await h.sync();
+
+    expect(results[0].status).toBe("synced");
+    expect(results[0].quarantinedCount).toBe(1);
+    // Conflict-copy semantics: nothing overwritten on either side.
+    expect(await h.adapter.read(`${MOUNT}/a.md`)).toContain("local-version");
+    expect(h.repo.headFiles().get("a.md")).toContain("remote-version");
+  });
+
+  it("persists both versions to the synced quarantine repo (D17)", async () => {
+    const h = await makeHarness({
+      initialFiles: { "a.md": asset("u1", "one") },
+      withQuarantineRepo: true,
+    });
+    await h.sync(); // bootstrap
+
+    h.adapter.seedFile(`${MOUNT}/a.md`, asset("u1", "local-version"));
+    h.repo.commitDirect(
+      "main",
+      { "a.md": asset("u1", "remote-version") },
+      "device B",
+    );
+    const results = await h.sync();
+
+    expect(results[0].quarantinedCount).toBe(1);
+    const entries = [...h.quarantineRepo.headFiles().entries()].filter(
+      ([path]) => path.startsWith("entries/"),
+    );
+    expect(entries).toHaveLength(1);
+    const record = JSON.parse(entries[0][1]) as {
+      status: string;
+      localContent?: string;
+      remoteContent?: string;
+    };
+    expect(record.status).toBe("open");
+    expect(record.localContent).toContain("local-version");
+    expect(record.remoteContent).toContain("remote-version");
+  });
+
+  it("maps HTTP 401 to auth-required, never success (R8 — desktop parity)", async () => {
+    // Same scenario as the engine-level R8 test: every request rejects 401
+    // from the very first sync. Through the REAL GitHubRestClient.request()
+    // the non-2xx response becomes the production error message shape that
+    // `isAuthError` consumes.
+    const h = await makeHarness({
+      initialFiles: { "a.md": asset("u1", "one") },
+    });
+    requestUrlMock.mockResolvedValue({
+      status: 401,
+      text: "Bad credentials",
+      arrayBuffer: new ArrayBuffer(0),
+      headers: {},
+    });
+
+    const results = await h.sync();
+
+    expect(results[0].status).toBe("auth-required");
+    expect(results[0].detail).toMatch(/PAT/);
+  });
+});

--- a/packages/obsidian-plugin/tests/unit/sync/SyncCommands.test.ts
+++ b/packages/obsidian-plugin/tests/unit/sync/SyncCommands.test.ts
@@ -1,0 +1,201 @@
+/**
+ * SyncCommands unit tests (ExoSync Phase B, RFC 4e4dc453) — D11 guards
+ * (running flag, apply-in-flight), R8 PAT prompts, result aggregation.
+ */
+
+jest.mock("obsidian", () => ({
+  ...jest.requireActual<Record<string, unknown>>("obsidian"),
+  requestUrl: jest.fn(),
+}));
+
+import { SyncCommands } from "../../../src/infrastructure/adapters/SyncCommands";
+import type {
+  BuiltSyncEngine,
+  SyncSpecCollection,
+} from "../../../src/infrastructure/adapters/SyncDepsFactory";
+import type { RepoSyncResult, SyncEngine, SyncRepoSpec } from "exocortex";
+
+const spec = (key: string): SyncRepoSpec => {
+  const [owner, repo] = key.split("/");
+  return {
+    owner,
+    repo,
+    branch: "main",
+    repoKey: `${key}#main`,
+    localPath: `assetspaces/${key}`,
+  };
+};
+
+const result = (
+  repoKey: string,
+  status: RepoSyncResult["status"],
+  extra: Partial<RepoSyncResult> = {},
+): RepoSyncResult => ({
+  repoKey,
+  status,
+  pulledCount: 0,
+  pushedCount: 0,
+  mergedCount: 0,
+  quarantinedCount: 0,
+  warnings: [],
+  deferredDeletes: [],
+  ...extra,
+});
+
+interface HarnessOptions {
+  specs?: SyncRepoSpec[];
+  pat?: string | null;
+  results?: RepoSyncResult[];
+  isSwitchInProgress?: boolean;
+  /** Resolves to release a hanging syncAll (double-invoke test). */
+  syncAllGate?: Promise<void>;
+}
+
+function makeHarness(opts: HarnessOptions = {}) {
+  const notices: string[] = [];
+  const logs: string[] = [];
+  const syncAll = jest.fn(
+    async (specs: SyncRepoSpec[]): Promise<RepoSyncResult[]> => {
+      if (opts.syncAllGate !== undefined) await opts.syncAllGate;
+      return (
+        opts.results ?? specs.map((s) => result(s.repoKey, "synced"))
+      );
+    },
+  );
+  const collection: SyncSpecCollection = {
+    specs: opts.specs ?? [spec("o/r")],
+    asUidByRepoKey: new Map(),
+    warnings: [],
+  };
+  const built: BuiltSyncEngine = {
+    engine: { syncAll } as unknown as SyncEngine,
+    pat: opts.pat === undefined ? "ghp_x" : opts.pat,
+  };
+  const commands = new SyncCommands({
+    collectSpecs: async () => collection,
+    buildEngine: async () => built,
+    isSwitchInProgress: () => opts.isSwitchInProgress ?? false,
+    notify: (m) => notices.push(m),
+    log: (m) => logs.push(m),
+  });
+  return { commands, notices, logs, syncAll };
+}
+
+describe("SyncCommands", () => {
+  it("refuses a second invocation while one is running (D11 handler flag)", async () => {
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const { commands, notices, syncAll } = makeHarness({ syncAllGate: gate });
+
+    const first = commands.invokeSync();
+    expect(commands.isBusy()).toBe(true);
+    await commands.invokeSync();
+
+    expect(notices.some((n) => n.includes("already in progress"))).toBe(true);
+    release();
+    await first;
+    expect(commands.isBusy()).toBe(false);
+    expect(syncAll).toHaveBeenCalledTimes(1);
+  });
+
+  it("refuses to start while a profile apply is in flight (D11)", async () => {
+    const { commands, notices, syncAll } = makeHarness({
+      isSwitchInProgress: true,
+    });
+
+    await commands.invokeSync();
+
+    expect(notices.some((n) => n.includes("profile apply"))).toBe(true);
+    expect(syncAll).not.toHaveBeenCalled();
+  });
+
+  it("prompts for a PAT instead of syncing unauthenticated (R8)", async () => {
+    const { commands, notices, syncAll } = makeHarness({ pat: null });
+
+    await commands.invokeSync();
+
+    expect(notices.some((n) => n.includes("PAT"))).toBe(true);
+    expect(syncAll).not.toHaveBeenCalled();
+  });
+
+  it("reports nothing-to-sync when no materialized AssetSpaces exist", async () => {
+    const { commands, notices, syncAll } = makeHarness({ specs: [] });
+
+    await commands.invokeSync();
+
+    expect(notices.some((n) => n.includes("Nothing to sync"))).toBe(true);
+    expect(syncAll).not.toHaveBeenCalled();
+  });
+
+  it("aggregates counts across repos in the success notice", async () => {
+    const { commands, notices } = makeHarness({
+      specs: [spec("o/a"), spec("o/b")],
+      results: [
+        result("o/a#main", "synced", { pushedCount: 2, pulledCount: 1 }),
+        result("o/b#main", "synced", {
+          mergedCount: 1,
+          quarantinedCount: 1,
+        }),
+      ],
+    });
+
+    await commands.invokeSync();
+
+    const done = notices.find((n) => n.startsWith("Sync done"));
+    expect(done).toContain("2/2");
+    expect(done).toContain("pushed 2");
+    expect(done).toContain("pulled 1");
+    expect(done).toContain("merged 1");
+    expect(done).toContain("quarantined 1");
+  });
+
+  it("surfaces auth-required as an explicit PAT prompt, never success (R8)", async () => {
+    const { commands, notices } = makeHarness({
+      results: [result("o/r#main", "auth-required")],
+    });
+
+    await commands.invokeSync();
+
+    expect(
+      notices.some((n) => n.includes("expired, revoked or under-scoped")),
+    ).toBe(true);
+    expect(notices.some((n) => n.startsWith("Sync done"))).toBe(false);
+  });
+
+  it("reports per-repo failures in the finished-with-issues notice", async () => {
+    const { commands, notices, logs } = makeHarness({
+      specs: [spec("o/a"), spec("o/b")],
+      results: [
+        result("o/a#main", "synced"),
+        result("o/b#main", "error", { detail: "boom" }),
+      ],
+    });
+
+    await commands.invokeSync();
+
+    const issues = notices.find((n) => n.includes("issues"));
+    expect(issues).toContain("o/b#main: error");
+    expect(logs.some((l) => l.includes("boom"))).toBe(true);
+  });
+
+  it("surfaces a thrown sync as a Notice and releases the running flag", async () => {
+    const notices: string[] = [];
+    const commands = new SyncCommands({
+      collectSpecs: async () => {
+        throw new Error("collect blew up");
+      },
+      buildEngine: async () => {
+        throw new Error("unreachable");
+      },
+      isSwitchInProgress: () => false,
+      notify: (m) => notices.push(m),
+      log: () => undefined,
+    });
+
+    await expect(commands.invokeSync()).resolves.toBeUndefined();
+    expect(notices.some((n) => n.includes("collect blew up"))).toBe(true);
+    expect(commands.isBusy()).toBe(false);
+  });
+});

--- a/packages/obsidian-plugin/tests/unit/sync/SyncDepsFactory.test.ts
+++ b/packages/obsidian-plugin/tests/unit/sync/SyncDepsFactory.test.ts
@@ -1,0 +1,229 @@
+/**
+ * SyncDepsFactory unit tests (ExoSync Phase B, RFC 4e4dc453) — spec
+ * collection, LocalFilesPort/WatermarkFileIO adapters (atomic-write order),
+ * and the degraded mobile D19 materialization gate.
+ */
+
+jest.mock("obsidian", () => ({
+  ...jest.requireActual<Record<string, unknown>>("obsidian"),
+  requestUrl: jest.fn(),
+}));
+
+import {
+  collectSyncRepoSpecs,
+  vaultLocalFilesPort,
+  vaultWatermarkFileIO,
+  vaultMaterializationCheck,
+  SYNC_BRANCH,
+} from "../../../src/infrastructure/adapters/SyncDepsFactory";
+import type { App } from "obsidian";
+import type { SyncRepoSpec } from "exocortex";
+import {
+  InMemoryAdapter,
+  assetSpaceFm,
+  makeApp,
+} from "./syncTestHelpers";
+
+const spec = (over: Partial<SyncRepoSpec> = {}): SyncRepoSpec => ({
+  owner: "o",
+  repo: "r",
+  branch: SYNC_BRANCH,
+  repoKey: `o/r#${SYNC_BRANCH}`,
+  localPath: "assetspaces/o/r",
+  ...over,
+});
+
+describe("collectSyncRepoSpecs", () => {
+  it("collects materialized AssetSpaces with GitHub sources", async () => {
+    const adapter = new InMemoryAdapter();
+    adapter.mkdirAll("assetspaces/o/r");
+    const app = makeApp({
+      adapter,
+      mdFiles: [{ path: "as1.md" }],
+      frontmatters: new Map([
+        ["as1.md", assetSpaceFm("uid-1", "https://github.com/o/r")],
+      ]),
+    });
+
+    const result = await collectSyncRepoSpecs(app as unknown as App);
+
+    expect(result.specs).toEqual([spec()]);
+    expect(result.asUidByRepoKey.get(`o/r#${SYNC_BRANCH}`)).toBe("uid-1");
+    expect(result.warnings).toEqual([]);
+  });
+
+  it("excludes AssetSpaces whose mount folder is absent (VL#4)", async () => {
+    const adapter = new InMemoryAdapter();
+    const app = makeApp({
+      adapter,
+      mdFiles: [{ path: "as1.md" }],
+      frontmatters: new Map([
+        ["as1.md", assetSpaceFm("uid-1", "https://github.com/o/r")],
+      ]),
+    });
+
+    const result = await collectSyncRepoSpecs(app as unknown as App);
+
+    expect(result.specs).toEqual([]);
+  });
+
+  it("skips non-GitHub sources with a warning", async () => {
+    const adapter = new InMemoryAdapter();
+    const app = makeApp({
+      adapter,
+      mdFiles: [{ path: "as1.md" }],
+      frontmatters: new Map([
+        ["as1.md", assetSpaceFm("uid-1", "git@github.com:o/r.git")],
+      ]),
+    });
+
+    const result = await collectSyncRepoSpecs(app as unknown as App);
+
+    expect(result.specs).toEqual([]);
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0]).toContain("as1.md");
+  });
+
+  it("dedupes AssetSpaces sharing one repo and ignores non-AssetSpace files", async () => {
+    const adapter = new InMemoryAdapter();
+    adapter.mkdirAll("assetspaces/o/r");
+    const app = makeApp({
+      adapter,
+      mdFiles: [{ path: "a.md" }, { path: "b.md" }, { path: "plain.md" }],
+      frontmatters: new Map<string, Record<string, unknown>>([
+        ["a.md", assetSpaceFm("uid-a", "https://github.com/o/r")],
+        ["b.md", assetSpaceFm("uid-b", "https://github.com/o/r")],
+        ["plain.md", { exo__Asset_uid: "x" }],
+      ]),
+    });
+
+    const result = await collectSyncRepoSpecs(app as unknown as App);
+
+    expect(result.specs).toHaveLength(1);
+  });
+});
+
+describe("vaultLocalFilesPort", () => {
+  it("lists recursively with repo-relative paths", async () => {
+    const adapter = new InMemoryAdapter();
+    adapter.seedFile("assetspaces/o/r/top.md", "t");
+    adapter.seedFile("assetspaces/o/r/sub/inner.md", "i");
+    const port = vaultLocalFilesPort(
+      adapter as never,
+      "assetspaces/o/r",
+    );
+
+    const listing = await port.list();
+
+    expect(listing.sort()).toEqual(["sub/inner.md", "top.md"]);
+  });
+
+  it("returns empty list when the root folder is absent", async () => {
+    const adapter = new InMemoryAdapter();
+    const port = vaultLocalFilesPort(adapter as never, "assetspaces/o/r");
+
+    expect(await port.list()).toEqual([]);
+  });
+
+  it("writes atomically (no .local.tmp residue) creating parent folders", async () => {
+    const adapter = new InMemoryAdapter();
+    adapter.mkdirAll("assetspaces/o/r");
+    const port = vaultLocalFilesPort(adapter as never, "assetspaces/o/r");
+
+    await port.write("new/depth/file.md", "content");
+
+    expect(await adapter.read("assetspaces/o/r/new/depth/file.md")).toBe(
+      "content",
+    );
+    const residue = [...adapter.files.keys()].filter((f) =>
+      f.includes(".local.tmp"),
+    );
+    expect(residue).toEqual([]);
+  });
+
+  it("overwrites an existing file despite mobile rename-onto-existing failing", async () => {
+    const adapter = new InMemoryAdapter();
+    adapter.seedFile("assetspaces/o/r/a.md", "old");
+    const port = vaultLocalFilesPort(adapter as never, "assetspaces/o/r");
+
+    await port.write("a.md", "new");
+
+    expect(await adapter.read("assetspaces/o/r/a.md")).toBe("new");
+  });
+
+  it("delete is a no-op for absent paths", async () => {
+    const adapter = new InMemoryAdapter();
+    adapter.mkdirAll("assetspaces/o/r");
+    const port = vaultLocalFilesPort(adapter as never, "assetspaces/o/r");
+
+    await expect(port.delete("ghost.md")).resolves.toBeUndefined();
+  });
+});
+
+describe("vaultWatermarkFileIO", () => {
+  it("read returns null for an absent file, round-trips writeAtomic", async () => {
+    const adapter = new InMemoryAdapter();
+    const io = vaultWatermarkFileIO(
+      adapter as never,
+      ".obsidian/plugins/exocortex/exosync-watermarks.local.json",
+    );
+
+    expect(await io.read()).toBeNull();
+    await io.writeAtomic('{"version":1}');
+    expect(await io.read()).toBe('{"version":1}');
+  });
+});
+
+describe("vaultMaterializationCheck", () => {
+  const base = (adapter: InMemoryAdapter) => ({
+    adapter: adapter as never,
+    isSwitchInProgress: () => false,
+    getStagingAsUids: async () => new Set<string>(),
+    asUidByRepoKey: new Map([["o/r#main", "uid-1"]]),
+  });
+
+  it("vetoes every repo while a profile apply is in flight (D11)", async () => {
+    const adapter = new InMemoryAdapter();
+    adapter.seedFile("assetspaces/o/r/a.md", "x");
+    const check = vaultMaterializationCheck({
+      ...base(adapter),
+      isSwitchInProgress: () => true,
+    });
+
+    const verdict = await check.check(spec());
+
+    expect(verdict.fullyMaterialized).toBe(false);
+    expect(verdict.reason).toContain("apply in progress");
+  });
+
+  it("vetoes a repo whose AssetSpace has an allocated staging dir", async () => {
+    const adapter = new InMemoryAdapter();
+    adapter.seedFile("assetspaces/o/r/a.md", "x");
+    const check = vaultMaterializationCheck({
+      ...base(adapter),
+      getStagingAsUids: async () => new Set(["uid-1"]),
+    });
+
+    const verdict = await check.check(spec());
+
+    expect(verdict.fullyMaterialized).toBe(false);
+    expect(verdict.reason).toContain("staging");
+  });
+
+  it("vetoes a missing or empty mount folder (mid-mount)", async () => {
+    const adapter = new InMemoryAdapter();
+    const check = vaultMaterializationCheck(base(adapter));
+    expect((await check.check(spec())).fullyMaterialized).toBe(false);
+
+    adapter.mkdirAll("assetspaces/o/r");
+    expect((await check.check(spec())).fullyMaterialized).toBe(false);
+  });
+
+  it("passes a non-empty mount folder with no apply/staging in flight", async () => {
+    const adapter = new InMemoryAdapter();
+    adapter.seedFile("assetspaces/o/r/a.md", "x");
+    const check = vaultMaterializationCheck(base(adapter));
+
+    expect((await check.check(spec())).fullyMaterialized).toBe(true);
+  });
+});

--- a/packages/obsidian-plugin/tests/unit/sync/syncTestHelpers.ts
+++ b/packages/obsidian-plugin/tests/unit/sync/syncTestHelpers.ts
@@ -1,0 +1,246 @@
+/**
+ * ExoSync Phase B test helpers (RFC 4e4dc453).
+ *
+ * Production-shape by design (test-fixture-realism):
+ *
+ *  - {@link InMemoryAdapter} mirrors the REAL `DataAdapter` contracts the
+ *    wiring depends on: `list()` is NON-recursive, `write()` fails when the
+ *    parent folder does not exist (desktop fs ENOENT), and `rename()` fails
+ *    when the target exists (the mobile semantics that forced the
+ *    remove-target-first atomic-write order).
+ *  - {@link fakeRequestUrlRouter} adapts the existing `FakeGitHubRepo` Git
+ *    Data API state machine to the `requestUrl` layer: the fake transport
+ *    THROWS `GitHub request {M} {url} → HTTP {N}: {body}` on non-2xx, while
+ *    the real `requestUrl({throw:false})` RETURNS the non-2xx response — so
+ *    the router converts throw → `{status, text}` and the REAL
+ *    `GitHubRestClient.request()` re-builds the production error message
+ *    itself. The error-shape contract (`isNonFastForwardError`,
+ *    `isRateLimitError`, `isAuthError`) is therefore exercised end-to-end.
+ */
+
+import type { FakeGitHubRepo } from "../../../../exocortex/tests/unit/services/sync/fakeGitHub";
+
+/** Minimal `RequestUrlResponse`-shaped object. */
+export interface FakeRequestUrlResponse {
+  status: number;
+  json?: unknown;
+  text: string;
+  arrayBuffer: ArrayBuffer;
+  headers: Record<string, string>;
+}
+
+interface FakeRequestUrlParam {
+  url: string;
+  method?: string;
+  body?: string;
+  [key: string]: unknown;
+}
+
+/**
+ * In-memory `DataAdapter` stand-in with the real adapter's strictness (see
+ * module docstring). Paths are vault-relative forward-slash, no leading `/`.
+ */
+export class InMemoryAdapter {
+  readonly files = new Map<string, string>();
+  readonly dirs = new Set<string>([""]);
+
+  private parent(p: string): string {
+    const i = p.lastIndexOf("/");
+    return i < 0 ? "" : p.slice(0, i);
+  }
+
+  async exists(path: string): Promise<boolean> {
+    return this.files.has(path) || this.dirs.has(path);
+  }
+
+  async read(path: string): Promise<string> {
+    const content = this.files.get(path);
+    if (content === undefined) throw new Error(`ENOENT: ${path}`);
+    return content;
+  }
+
+  async write(path: string, content: string): Promise<void> {
+    if (!this.dirs.has(this.parent(path))) {
+      throw new Error(`ENOENT: parent folder of ${path} does not exist`);
+    }
+    this.files.set(path, content);
+  }
+
+  async remove(path: string): Promise<void> {
+    if (!this.files.delete(path)) {
+      throw new Error(`ENOENT: ${path}`);
+    }
+  }
+
+  async rename(from: string, to: string): Promise<void> {
+    const content = this.files.get(from);
+    if (content === undefined) throw new Error(`ENOENT: ${from}`);
+    // Mobile semantics — rename onto an existing target fails.
+    if (this.files.has(to)) {
+      throw new Error(`EEXIST: ${to}`);
+    }
+    if (!this.dirs.has(this.parent(to))) {
+      throw new Error(`ENOENT: parent folder of ${to} does not exist`);
+    }
+    this.files.delete(from);
+    this.files.set(to, content);
+  }
+
+  async mkdir(path: string): Promise<void> {
+    if (!this.dirs.has(this.parent(path))) {
+      throw new Error(`ENOENT: parent folder of ${path} does not exist`);
+    }
+    this.dirs.add(path);
+  }
+
+  /** NON-recursive listing, full paths — the real `DataAdapter.list` shape. */
+  async list(dir: string): Promise<{ files: string[]; folders: string[] }> {
+    if (!this.dirs.has(dir)) throw new Error(`ENOENT: ${dir}`);
+    const prefix = dir.length > 0 ? `${dir}/` : "";
+    const files: string[] = [];
+    const folders: string[] = [];
+    for (const f of this.files.keys()) {
+      if (f.startsWith(prefix) && !f.slice(prefix.length).includes("/")) {
+        files.push(f);
+      }
+    }
+    for (const d of this.dirs) {
+      if (
+        d.length > prefix.length &&
+        d.startsWith(prefix) &&
+        !d.slice(prefix.length).includes("/")
+      ) {
+        folders.push(d);
+      }
+    }
+    return { files, folders };
+  }
+
+  /** Test convenience — create a folder chain without parent checks. */
+  mkdirAll(path: string): void {
+    const segments = path.split("/").filter((s) => s.length > 0);
+    let current = "";
+    for (const s of segments) {
+      current = current.length === 0 ? s : `${current}/${s}`;
+      this.dirs.add(current);
+    }
+  }
+
+  /** Test convenience — write a file, creating parent folders. */
+  seedFile(path: string, content: string): void {
+    const i = path.lastIndexOf("/");
+    if (i > 0) this.mkdirAll(path.slice(0, i));
+    this.files.set(path, content);
+  }
+}
+
+/** Markdown file stub — only `path` is consumed by the wiring under test. */
+export interface FakeMdFile {
+  path: string;
+}
+
+export interface MakeAppOptions {
+  adapter: InMemoryAdapter;
+  /** Vault markdown files (collectSyncRepoSpecs walk). */
+  mdFiles?: FakeMdFile[];
+  /** path → frontmatter for `metadataCache.getFileCache`. */
+  frontmatters?: Map<string, Record<string, unknown>>;
+  configDir?: string;
+}
+
+/** Minimal `App`-shaped object covering exactly what the wiring reads. */
+export function makeApp(opts: MakeAppOptions): {
+  vault: {
+    adapter: InMemoryAdapter;
+    configDir: string;
+    getMarkdownFiles: () => FakeMdFile[];
+  };
+  metadataCache: {
+    getFileCache: (file: FakeMdFile) => {
+      frontmatter: Record<string, unknown>;
+    } | null;
+  };
+} {
+  const fms = opts.frontmatters ?? new Map<string, Record<string, unknown>>();
+  return {
+    vault: {
+      adapter: opts.adapter,
+      configDir: opts.configDir ?? ".obsidian",
+      getMarkdownFiles: () => opts.mdFiles ?? [],
+    },
+    metadataCache: {
+      getFileCache: (file: FakeMdFile) => {
+        const fm = fms.get(file.path);
+        return fm !== undefined ? { frontmatter: fm } : null;
+      },
+    },
+  };
+}
+
+/**
+ * Route `requestUrl` calls to per-repo {@link FakeGitHubRepo} state machines
+ * by the `/repos/<owner>/<repo>/` URL segment. Unknown repos → HTTP 404.
+ * Fake-transport throws are converted to non-2xx responses (the real
+ * `requestUrl({throw:false})` contract — see module docstring).
+ */
+export function fakeRequestUrlRouter(
+  repos: Record<string, FakeGitHubRepo>,
+): (param: FakeRequestUrlParam) => Promise<FakeRequestUrlResponse> {
+  const transports = new Map(
+    Object.entries(repos).map(([key, repo]) => [key, repo.transport()]),
+  );
+  return async (param) => {
+    const m = /\/repos\/([^/]+)\/([^/]+)\//.exec(param.url);
+    const key = m !== null ? `${m[1]}/${m[2]}` : "";
+    const transport = transports.get(key);
+    if (transport === undefined) {
+      return {
+        status: 404,
+        text: `no fake repo for ${key}`,
+        arrayBuffer: new ArrayBuffer(0),
+        headers: {},
+      };
+    }
+    try {
+      const resp = await transport({
+        method: (param.method ?? "GET") as "GET" | "POST" | "PATCH",
+        url: param.url,
+        ...(typeof param.body === "string" ? { body: param.body } : {}),
+      });
+      return {
+        status: resp.status ?? 200,
+        json: resp.json,
+        text: JSON.stringify(resp.json ?? null),
+        arrayBuffer: new ArrayBuffer(0),
+        headers: {},
+      };
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      const httpMatch = /HTTP (\d+): ([\s\S]*)$/.exec(msg);
+      if (httpMatch !== null) {
+        return {
+          status: Number(httpMatch[1]),
+          text: httpMatch[2],
+          arrayBuffer: new ArrayBuffer(0),
+          headers: {},
+        };
+      }
+      throw err;
+    }
+  };
+}
+
+/** AssetSpace class UID (exo__AssetSpace TBox root). */
+export const AS_CLASS_WIKILINK = "[[73bd00e4-ccc0-4f3f-b20d-c4388c4588fb]]";
+
+/** Frontmatter for one AssetSpace ABox pointing at a GitHub source. */
+export function assetSpaceFm(
+  asUid: string,
+  source: string,
+): Record<string, unknown> {
+  return {
+    exo__Instance_class: [AS_CLASS_WIKILINK],
+    exo__Asset_uid: asUid,
+    exo__AssetSpace_source: source,
+  };
+}


### PR DESCRIPTION
## Summary

ExoSync Phase B: the Phase A `SyncEngine` (A1-A3, pull→merge→push) now runs in the Obsidian plugin over the `requestUrl` transport (`GitHubRestClient`) — **zero engine edits** (AC#2), plugin-layer wiring only. This is the iOS path (M5): no git binary anywhere in the composition.

### What's wired (all plugin package)

- **`GitHubRestClient`** (additive): `restTransport(): RestCommitTransport` — the same closure `createCommit` already builds internally, exposing the production error-message contract (`GitHub request {M} {url} → HTTP {N}: {body}`) that `isNonFastForwardError` / `isRateLimitError` / `isAuthError` consume; static `redactTokens()` for `SyncEngineDeps.redact`.
- **`SyncDepsFactory`** — composes `SyncEngineDeps` from Obsidian primitives:
  - specs from AssetSpace ABox frontmatter (`_source ?? _git`) + `derivePath` → materialized set only (VL#4); branch pinned to `main` (same as `RestAssetSpaceMount`);
  - sha1 via WebCrypto `crypto.subtle` (iOS-safe, injectable test seam);
  - watermark: `FileWatermarkStore` over `vault.adapter` at `<configDir>/plugins/exocortex/exosync-watermarks.local.json` (`.local.` infix → Sync-excluded, D8);
  - `LocalFilesPort` over `vault.adapter` (recursive list, atomic writes via tmp + remove-target-first + rename — `DataAdapter.rename` onto an existing target fails on mobile; parent folders auto-created);
  - degraded mobile D19 gate: folder exists + non-empty + no `_switchInProgress` + no staging-dir allocation for the AssetSpace (mount layer keeps no manifest on mobile — "folder exists" is the documented visibility floor);
  - merge layer: `GatedStructuredMerger` over js-yaml `CORE_SCHEMA`; **SHACL merge-gate not wired** (follow-up — needs plugin-side ShapeRegistry/ClassHierarchy/triplesFor composition; unresolvable merges still quarantine per D17);
  - quarantine: `SyncedQuarantineStore` against the new optional `exosyncQuarantineRepoUrl` setting (validated by `validateRepoURL`); absent ⇒ engine degrades safely (watermark pins re-derive).
- **`SyncCommands`** + palette command **`Exocortex: Sync`** (manual, VL#1, both platforms): fresh engine per invocation (fresh-PAT pattern #3382) with a handler-level `running` flag restoring cross-invocation D11; R8 prompts (no PAT / `auth-required` → explicit "update your PAT", never success); aggregate Notice with pushed/pulled/merged/quarantined counts.
- **D11 both directions**: sync refuses during `_switchInProgress` (gate + pre-run check); `ProfileApplyManager.applyProfile` now refuses while sync is running (new optional `isSyncBusy` dep) — closes the apply-during-sync folder-destruction race flagged in design review.

### Tests (29 new, plugin package)

- `ExoSyncRequestUrlParity.integration.test.ts` (AC#3 desktop parity): REAL `GitHubRestClient` over mocked `requestUrl` routed into Phase A's `FakeGitHubRepo` Git Data API state machine — bootstrap, push, pull, structured merge of divergent keys, conflict-copy quarantine (disk + remote intact), durable quarantine-repo entries (D17), HTTP 401 → `auth-required` (R8, mirrors the engine-level scenario).
- `SyncDepsFactory.test.ts` / `SyncCommands.test.ts`: spec collection (dedupe, non-GitHub skip, unmounted exclusion), atomic-write order, recursive listing, D19 vetoes, D11 guards, R8 prompts, aggregation.
- **Revert-verified**: transport stubbed out → 7/7 integration fail; remove-target-first dropped → 6 fail; restored → 29/29 pass.
- Full plugin unit run: 1 failing suite (`cli/tests/integration/sparql-exo003`) **verified pre-existing** — identical 10/10 fail on clean base e0f4c75a in a separate worktree.

### AC status

- AC#2 ✅ zero edits under `packages/exocortex/src/services/sync/` (diff is plugin-only).
- AC#3 ✅ pull/merge/conflict-copy parity via requestUrl-level integration tests.
- AC#1 ⏳ awaiting user iPhone smoke (physical device required) — smoke checklist in the task asset Handoff.

RFC: `4e4dc453` (D1-D28). Task: `510526f9` (ems__Project ExoSync `b126f8ee`).

## Test plan

- [x] 29 new unit/integration tests green locally
- [x] revert→fail / restore→pass discipline on both load-bearing mechanisms
- [x] full plugin unit run — only pre-existing failure (verified on base)
- [ ] 13 required CI checks green
- [ ] code-reviewer agent + advisor round-2 before manual squash merge
- [ ] post-release: user iPhone smoke (AC#1)