### PR TITLE
feat(settings): homoiconic plugin settings — vault exo__Setting loader, one-shot migration, UI write-through (onto-RFC 981b6070 Phase 5, ExoSync D2)

### DIFF
--- a/docs/settings-homoiconization.md
+++ b/docs/settings-homoiconization.md
@@ -1,0 +1,91 @@
+# Settings homoiconization (`exo__Setting`)
+
+> onto-RFC `981b6070` Phase 5 · ExoSync Phase D (D2) · Homoiconicity Invariant `c78cc5c8` (VL#17 «настройки → ассеты»)
+
+The plugin's user-configurable settings are first-class vault assets of
+class `exo__Setting`. Each setting is one markdown file whose frontmatter
+carries a key reference and a typed value:
+
+```yaml
+---
+exo__Asset_uid: a6ccb161-b5b7-4660-ad25-685e4afab364
+exo__Instance_class:
+  - "[[88b938af-1a55-451c-b3cc-2f03e5115fcf]]" # exo__Setting
+exo__Asset_label: "Setting: showArchivedAssets"
+exo__Setting_key: "[[aa14f04c-0fc3-4d93-9f50-ea08e37d583d]]" # exo__SettingKeyShowArchivedAssets
+exo__Setting_value: false
+---
+```
+
+The schema of valid settings lives **in the graph**: 23 `exo__SettingKey`
+individuals (shipped in the `exoas-exo` ontology submodule) each declare
+their `exo__SettingKey_datatype` (`boolean` | `string` | `stringList`).
+The TypeScript binding table
+(`packages/obsidian-plugin/src/domain/settings/VaultSettingsRegistry.ts`)
+is pinned to the graph by a parity unit test — adding a settings field
+without deciding its homoiconization fails CI.
+
+## Architecture: data.json as write-through mirror
+
+- **Boot:** `loadSettings()` reads `data.json` exactly as before —
+  instant, no flicker. Vault values overlay once `metadataCache` is
+  fully resolved; because every change is mirrored back into
+  `data.json`, the overlay is a no-op except after real cross-device
+  drift.
+- **Source of truth:** the vault asset, when it exists. A field without
+  an asset falls back to `data.json` (migration period, deleted files).
+- **UI writes:** every surface funnels through `saveSettings()`; changed
+  homoiconizable fields are written to their assets (debounced,
+  sequential, echo-suppressed).
+- **Remote changes:** a watcher applies edits arriving via sync (or
+  hand-editing the asset) to the live settings and runs the same
+  side-effect hooks the Settings tab uses.
+
+## One-shot migration
+
+On the first resolved-scan that finds no asset for a registry key, the
+plugin creates `exocortex-settings/<uid>.md` seeded with the current
+`data.json` value and shows a Notice. Asset UIDs and basenames are fixed
+constants, so independent migrations on two devices produce identical
+paths and file-level sync converges instead of duplicating. Re-runs are
+no-ops (per-key skip-existing). Migration is skipped while a profile
+switch is in flight.
+
+Assets are **discovered by class, not by folder** — you may move them
+anywhere, including into a materialized AssetSpace mount
+(`assetspaces/<owner>/<repo>/…`), where ExoSync Phase A syncs them like
+any other asset with zero extra sync code.
+
+## What is NOT homoiconized
+
+| Field                                   | Why                                                 | Where it lives                          |
+| --------------------------------------- | --------------------------------------------------- | --------------------------------------- |
+| `activeProfileUid`, `_switchInProgress` | per-device state (Issue #3327)                      | `data.local.json`                       |
+| GitHub PAT                              | secret                                              | `data.local.json` (`LocalSecretsStore`) |
+| `displayNameSettings`, `logChannels`    | structural nested objects — deferred (onto-RFC D26) | `data.json`                             |
+
+The migration iterates an explicit allowlist (the registry), so these can
+never leak into vault assets regardless of what `data.json` contains.
+
+## Field-specific semantics
+
+- `lazyBootstrapFolders` — applied as `union(defaults, asset value)`
+  without write-back, so a stale asset cannot shadow defaults added by
+  future releases (anti-regression #3279).
+- `excludedFolders` — normalised (trailing slash) before comparison and
+  write.
+- Both lists are snapshotted by indexer components at startup — changes
+  (from UI or vault) take effect after an Obsidian reload, same as
+  before.
+
+## Known limitations
+
+- **Sync-vs-UI race (vault wins):** if an ExoSync pull rewrites a
+  setting asset in the same instant the user toggles it in the UI, the
+  remote value can win. The window is sub-second (manual on-command
+  sync × 1 s write debounce); acceptable for MVP.
+- `exo__Setting_value` carries three datatypes under one property name —
+  Obsidian's Properties UI assigns a single widget type per property
+  name, so the property panel may show a type-mismatch hint on some
+  setting files. Values remain correct; edit via the plugin settings tab
+  or source mode.

--- a/packages/obsidian-plugin/src/ExocortexPlugin.ts
+++ b/packages/obsidian-plugin/src/ExocortexPlugin.ts
@@ -20,6 +20,11 @@ import {
 } from "./domain/settings/ExocortexSettings";
 import { ExocortexSettingTab } from "./presentation/settings/ExocortexSettingTab";
 import {
+  DEFAULT_SETTINGS_FOLDER,
+  VAULT_SETTINGS_REGISTRY,
+} from "./domain/settings/VaultSettingsRegistry";
+import { VaultSettingsStore } from "./infrastructure/adapters/VaultSettingsStore";
+import {
   TaskStatusService,
   CommandResolver,
   PreconditionEvaluator,
@@ -271,6 +276,23 @@ export default class ExocortexPlugin extends Plugin {
    * store, and any legacy keys are cleared in the same migration pass.
    */
   public localDataStore: PluginLocalDataStore | null = null;
+
+  /**
+   * onto-RFC 981b6070 Phase 5 (ExoSync Phase D / D2) — vault-asset
+   * settings store. Constructed lazily in the `metadataCache.resolved`
+   * one-shot init (scan before resolve misreads unparsed files as
+   * missing). Null until then; `saveSettings()` no-ops the vault push
+   * while null and the data.json mirror keeps working as before.
+   */
+  public vaultSettingsStore: VaultSettingsStore | null = null;
+
+  /**
+   * Registry-field snapshot taken at the end of `loadSettings()` —
+   * cold-start dirty-field detection input for the vault-settings
+   * overlay (user toggles between onload and the first scan win over
+   * stale asset values).
+   */
+  private settingsBaseline: Record<string, unknown> = {};
 
   /**
    * RFC 22b50a17 Phase 5 Phase 4 — runtime-derived AssetSpace materialization
@@ -1008,6 +1030,24 @@ export default class ExocortexPlugin extends Plugin {
           if (postResolveReindexDone) return;
           postResolveReindexDone = true;
 
+          // onto-RFC 981b6070 Phase 5 (D2) — vault-asset settings init,
+          // one-shot on the same authoritative "metadata fully parsed"
+          // signal (shares the postResolveReindexDone gate). Scanning
+          // earlier (e.g. onLayoutReady) reads null frontmatter for
+          // unparsed files, misclassifies existing Setting assets as
+          // missing, and the migration would create duplicates on every
+          // cold start (advisor F5). Because data.json is a
+          // write-through mirror, the late overlay produces a non-empty
+          // diff ONLY on real cross-device drift — the common boot path
+          // is a no-op. Fire-and-forget: settings init must not delay
+          // (or be delayed by) the reindex chain below.
+          void this.initVaultSettings().catch((err) => {
+            this.logger.error(
+              "Failed to initialize vault-asset settings (D2)",
+              err,
+            );
+          });
+
           const initPromise = this.eagerInitPromise ?? Promise.resolve();
           // RFC 22b50a17 Phase 4 — after each `sparql.refresh()` (which
           // clears+rebuilds the store from frontmatter), re-inject the
@@ -1719,6 +1759,17 @@ export default class ExocortexPlugin extends Plugin {
         ...savedLazyBootstrap,
       ]),
     );
+
+    // onto-RFC 981b6070 (D2) — snapshot registry fields for cold-start
+    // dirty detection: the vault-settings overlay (metadataCache
+    // resolved, possibly tens of seconds later) must not roll back
+    // toggles the user made in the meantime (advisor F12).
+    const baseline: Record<string, unknown> = {};
+    for (const d of VAULT_SETTINGS_REGISTRY) {
+      const v = (this.settings as Record<string, unknown>)[d.field];
+      baseline[d.field] = Array.isArray(v) ? [...v] : v;
+    }
+    this.settingsBaseline = baseline;
   }
 
   /**
@@ -1738,6 +1789,152 @@ export default class ExocortexPlugin extends Plugin {
 
   async saveSettings(): Promise<void> {
     await this.saveData(this.settings);
+    // onto-RFC 981b6070 (D2) — write-through to vault assets for
+    // homoiconizable fields. Every UI surface funnels through this
+    // method (SettingTab × 32 controls, palette commands,
+    // DailyTasksRenderer), so intercepting here covers them all without
+    // touching call sites. Diff-based + debounced inside the store;
+    // remote applies go through `saveData` directly, so this cannot
+    // loop.
+    this.vaultSettingsStore?.pushChangedFields();
+  }
+
+  /**
+   * One-shot init of the vault-asset settings layer (D2). Runs on the
+   * first `metadataCache.resolved`:
+   *  1. class-based scan of `exo__Setting` assets (location-independent
+   *     — assets moved into an AssetSpace mount keep working and get
+   *     ExoSync coverage for free);
+   *  2. overlay: vault values → live settings (+ side-effect hooks +
+   *     data.json mirror); dirty fields (user toggles since onload) are
+   *     pushed to the vault instead;
+   *  3. one-shot idempotent migration: data.json values → assets for
+   *     registry keys that have none (skipped mid profile-switch);
+   *  4. live watchers for cross-device changes arriving via sync.
+   */
+  private async initVaultSettings(): Promise<void> {
+    const store = new VaultSettingsStore({
+      app: this.app,
+      logger: this.logger,
+      getSettings: () => this.settings as Record<string, unknown>,
+      baseline: this.settingsBaseline,
+      applyRemote: async (field, value) => {
+        (this.settings as Record<string, unknown>)[field] = value;
+        this.applySettingSideEffect(field, value);
+        await this.saveData(this.settings);
+      },
+    });
+
+    const scan = store.scanAll();
+    const overlaid = await store.applyScan(scan);
+    if (overlaid.length > 0) {
+      this.logger.info(
+        `[D2] applied ${overlaid.length} vault setting(s) over data.json: ` +
+          overlaid.join(", "),
+      );
+    }
+
+    // Publish only after scan+overlay so saveSettings() cannot race a
+    // half-initialized store.
+    this.vaultSettingsStore = store;
+
+    // Migration is skipped while a profile switch is in flight —
+    // AssetSpace mounts (a legal home for relocated Setting assets) are
+    // being torn down/rebuilt and "missing" is not trustworthy (F2).
+    if (this.localDataStore?.isSwitchInProgress() !== true) {
+      const created = await store.migrateMissing();
+      if (created.length > 0) {
+        this.notifier.info(
+          `Exocortex: migrated ${created.length} setting(s) to vault assets in "${DEFAULT_SETTINGS_FOLDER}/"`,
+        );
+        this.logger.info(
+          `[D2] one-shot settings migration created ${created.length} asset(s): ` +
+            created.join(", "),
+        );
+      }
+    } else {
+      this.logger.info(
+        "[D2] settings migration deferred — profile switch in progress",
+      );
+    }
+
+    this.registerEvent(
+      this.app.metadataCache.on("changed", (file) => {
+        void store.onMetadataChanged(file).catch((err) => {
+          this.logger.warn(
+            `[D2] settings watcher failed for ${file.path}: ${
+              err instanceof Error ? err.message : String(err)
+            }`,
+          );
+        });
+      }),
+    );
+    this.registerEvent(
+      this.app.vault.on("delete", (file) => {
+        store.onFileDeleted(file.path);
+      }),
+    );
+    this.registerEvent(
+      this.app.vault.on("rename", (file, oldPath) => {
+        if (file instanceof TFile) {
+          store.onFileRenamed(file, oldPath);
+        }
+      }),
+    );
+  }
+
+  /**
+   * Side-effect hooks for settings applied from the vault (overlay /
+   * watcher) — mirrors what the SettingTab onChange handlers do after
+   * mutating the same field. Fields not listed are read-on-use
+   * (no immediate hook needed); `excludedFolders` /
+   * `lazyBootstrapFolders` are snapshotted by indexer components at
+   * startup — same reload-required semantics as editing them in the
+   * SettingTab (documented in ExocortexSettings.ts).
+   */
+  private applySettingSideEffect(field: string, value: unknown): void {
+    try {
+      switch (field) {
+        case "layoutVisible":
+        case "showArchivedAssets":
+        case "showEffortArea":
+        case "showEffortVotes":
+        case "showFullDateInEffortTimes":
+        case "showTimeEstimate":
+        case "enableExoLayoutRenderer":
+          this.refreshLayout();
+          break;
+        case "showLabelsInTabTitles":
+          this.toggleTabTitleLabels(value === true);
+          break;
+        case "showLabelsInProperties":
+          this.togglePropertiesLabels(value === true);
+          break;
+        case "enablePropertiesLabelPatch":
+          this.togglePropertiesLabelPatch(value === true);
+          break;
+        case "showIconsInFileExplorer":
+          this.toggleFileExplorerIcons(value === true);
+          break;
+        case "showLabelsInBody":
+          this.toggleBodyLabels(value === true);
+          break;
+        case "showLabelsInGraphView":
+          this.toggleGraphViewLabels(value === true);
+          break;
+        case "displayNameTemplate":
+          this.applyDisplayNameTemplate();
+          break;
+        default:
+          break;
+      }
+    } catch (err) {
+      this.logger.warn(
+        `[D2] side-effect for setting "${field}" failed: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
+    }
   }
 
   refreshLayout(): void {

--- a/packages/obsidian-plugin/src/domain/settings/VaultSettingsRegistry.ts
+++ b/packages/obsidian-plugin/src/domain/settings/VaultSettingsRegistry.ts
@@ -1,0 +1,272 @@
+/**
+ * VaultSettingsRegistry — allowlist binding between `ExocortexSettings`
+ * fields (data.json keys) and the `exo__Setting` / `exo__SettingKey` TBox
+ * shipped in `packages/exoas-exo` (onto-RFC 981b6070, D1 @ 6c0797e).
+ *
+ * Homoiconicity (RFC c78cc5c8): the SCHEMA of valid settings lives in the
+ * graph (23 `exo__SettingKey` individuals, each declaring its datatype).
+ * This module is the engine-side binding table (Q3 exception 1 — core
+ * processing): it maps each graph key to the TypeScript field the plugin
+ * actually reads. The registry↔graph parity unit test asserts this table
+ * never drifts from the submodule TBox (onto-RFC R3).
+ *
+ * ## Allowlist by construction (0-leakage, onto-RFC R2)
+ *
+ * Migration and the vault write-path iterate ONLY over this registry.
+ * Per-device state (`activeProfileUid`, `_switchInProgress` —
+ * `data.local.json`), secrets (`pat` — `LocalSecretsStore`) and structural
+ * settings (`displayNameSettings`, `logChannels` — deferred per onto-RFC
+ * Scope OUT / D26) are not listed here and therefore can never become
+ * vault assets, regardless of what extra keys a user's data.json carries
+ * (the `[key: string]: unknown` index signature admits arbitrary keys).
+ */
+
+/** `exo__Setting` class asset UID (exoas-exo, D1). */
+export const SETTING_CLASS_UID = "88b938af-1a55-451c-b3cc-2f03e5115fcf";
+
+/** `exo__SettingKey` class asset UID (exoas-exo, D1). */
+export const SETTING_KEY_CLASS_UID = "a37d39ec-413d-4d9c-8cf2-da9b6025b00c";
+
+/** Frontmatter property names of the exo__Setting shape. */
+export const SETTING_KEY_PROP = "exo__Setting_key";
+export const SETTING_VALUE_PROP = "exo__Setting_value";
+
+/**
+ * Default vault folder where the one-shot migration materialises Setting
+ * assets. Discovery is class-based and location-independent — users may
+ * relocate the files anywhere (e.g. into a materialized AssetSpace mount
+ * under `assetspaces/<owner>/<repo>/` so ExoSync Phase A syncs them for
+ * free); the loader keeps finding them by `exo__Instance_class`.
+ */
+export const DEFAULT_SETTINGS_FOLDER = "exocortex-settings";
+
+export type VaultSettingDatatype = "boolean" | "string" | "stringList";
+
+export interface VaultSettingDescriptor {
+  /** `ExocortexSettings` field name (data.json key). */
+  readonly field: string;
+  /** `exo__SettingKey` individual asset UID (exoas-exo, D1). */
+  readonly keyUid: string;
+  /** `exo__SettingKey` label, e.g. `exo__SettingKeyShowArchivedAssets`. */
+  readonly keyLabel: string;
+  /** Declared value datatype — mirrors `exo__SettingKey_datatype`. */
+  readonly datatype: VaultSettingDatatype;
+  /**
+   * Canonical `exo__Asset_uid` AND basename of the Setting instance.
+   * Fixed (not generated at runtime) so independent migrations on two
+   * devices/vaults produce byte-identical paths — file-level sync
+   * (Obsidian Sync, ExoSync, git) then converges on one file instead of
+   * spawning per-device duplicates (advisor F7).
+   */
+  readonly settingUid: string;
+}
+
+export const VAULT_SETTINGS_REGISTRY: readonly VaultSettingDescriptor[] = [
+  // ── boolean (19) ──────────────────────────────────────────────────
+  {
+    field: "layoutVisible",
+    keyUid: "db21761d-a3d9-4db6-9bcc-b3fab60557b3",
+    keyLabel: "exo__SettingKeyLayoutVisible",
+    datatype: "boolean",
+    settingUid: "4085fe6e-dba6-4be1-b996-2e23e90b9a0a",
+  },
+  {
+    field: "showArchivedAssets",
+    keyUid: "aa14f04c-0fc3-4d93-9f50-ea08e37d583d",
+    keyLabel: "exo__SettingKeyShowArchivedAssets",
+    datatype: "boolean",
+    settingUid: "a6ccb161-b5b7-4660-ad25-685e4afab364",
+  },
+  {
+    field: "showEffortArea",
+    keyUid: "ac5ea9fa-06e1-4987-a705-67366dc4b486",
+    keyLabel: "exo__SettingKeyShowEffortArea",
+    datatype: "boolean",
+    settingUid: "ce10ebba-6e8f-431f-8a90-a4c72022857b",
+  },
+  {
+    field: "showEffortVotes",
+    keyUid: "ed0ed49a-bd53-4520-979f-ae0dadfd7731",
+    keyLabel: "exo__SettingKeyShowEffortVotes",
+    datatype: "boolean",
+    settingUid: "fc6be572-ba50-4d2b-830e-588b5dcbeb8e",
+  },
+  {
+    field: "showFullDateInEffortTimes",
+    keyUid: "23e7cda6-6ec4-4782-80f5-dcfd95e9b49c",
+    keyLabel: "exo__SettingKeyShowFullDateInEffortTimes",
+    datatype: "boolean",
+    settingUid: "a5372600-04f4-4f5a-8e5d-2c18b93e1e97",
+  },
+  {
+    field: "showTimeEstimate",
+    keyUid: "22c1d0a8-0c73-423f-bddc-83bac6b0baef",
+    keyLabel: "exo__SettingKeyShowTimeEstimate",
+    datatype: "boolean",
+    settingUid: "a2152041-c7b7-4e46-8c11-86966166ee77",
+  },
+  {
+    field: "showLabelsInTabTitles",
+    keyUid: "cb74f759-c1ed-4fcc-bcf3-77656c4ede37",
+    keyLabel: "exo__SettingKeyShowLabelsInTabTitles",
+    datatype: "boolean",
+    settingUid: "9aafe724-6ab7-44ea-8496-16e1afd3990d",
+  },
+  {
+    field: "showLabelsInProperties",
+    keyUid: "575f2e31-3c09-40a5-8da6-8e41e05379b2",
+    keyLabel: "exo__SettingKeyShowLabelsInProperties",
+    datatype: "boolean",
+    settingUid: "2a348086-8be4-442e-946e-84f1abe7f612",
+  },
+  {
+    field: "showLabelsInBody",
+    keyUid: "0992a51a-b894-4a20-870d-3ec5b6b93d25",
+    keyLabel: "exo__SettingKeyShowLabelsInBody",
+    datatype: "boolean",
+    settingUid: "a36ac50f-661e-450c-81a6-4a9a69bb0b32",
+  },
+  {
+    field: "showLabelsInGraphView",
+    keyUid: "89680350-5c36-4bac-ad28-e7875b9b026d",
+    keyLabel: "exo__SettingKeyShowLabelsInGraphView",
+    datatype: "boolean",
+    settingUid: "5e4e4519-ebf9-4724-9f47-2faf8faa8e07",
+  },
+  {
+    field: "showLabelsInLivePreview",
+    keyUid: "d18ce074-b428-4082-8993-f29ec4f019d9",
+    keyLabel: "exo__SettingKeyShowLabelsInLivePreview",
+    datatype: "boolean",
+    settingUid: "3e491f6d-ee07-4283-872b-bf56f2fa2ca0",
+  },
+  {
+    field: "autoAdjustPlannedEndTimestamp",
+    keyUid: "23ace457-15c5-4d92-aa51-3bbf9247ccdc",
+    keyLabel: "exo__SettingKeyAutoAdjustPlannedEndTimestamp",
+    datatype: "boolean",
+    settingUid: "f2cc1fc1-5dae-49b0-bf72-9dbe345896c6",
+  },
+  {
+    field: "autoReadingModeForExocortexAssets",
+    keyUid: "1c73fbe6-f3a0-4022-9e66-ea6e6dc0b148",
+    keyLabel: "exo__SettingKeyAutoReadingModeForExocortexAssets",
+    datatype: "boolean",
+    settingUid: "2c5195c7-94c2-4d10-a694-c44a45513188",
+  },
+  {
+    field: "enableRelationColumnSetResolver",
+    keyUid: "626da39d-eda9-4b51-a847-94cc0d78185d",
+    keyLabel: "exo__SettingKeyEnableRelationColumnSetResolver",
+    datatype: "boolean",
+    settingUid: "d33d7369-2ecb-475b-906e-be21d3e2d48c",
+  },
+  {
+    field: "enableExoLayoutRenderer",
+    keyUid: "83a97247-135f-4e09-a4a7-60a0c1d8cb7a",
+    keyLabel: "exo__SettingKeyEnableExoLayoutRenderer",
+    datatype: "boolean",
+    settingUid: "ca01b399-09e6-4ad1-94c0-80b96ac98503",
+  },
+  {
+    field: "showIconsInFileExplorer",
+    keyUid: "d87f2805-1f3a-4f01-97b4-53df81633e9f",
+    keyLabel: "exo__SettingKeyShowIconsInFileExplorer",
+    datatype: "boolean",
+    settingUid: "fd52049e-cb58-449b-a0d3-a0d9cc2cd986",
+  },
+  {
+    field: "enableSparqlAutoExecute",
+    keyUid: "fcd1ecb0-56cf-4d7e-b097-a8db80b90d9f",
+    keyLabel: "exo__SettingKeyEnableSparqlAutoExecute",
+    datatype: "boolean",
+    settingUid: "bdf8a359-30ef-40d2-9ddc-94cdbf81a1e2",
+  },
+  {
+    field: "enableShaclValidation",
+    keyUid: "ecea90cb-b0eb-45d3-8ce2-97d7e4f1a793",
+    keyLabel: "exo__SettingKeyEnableShaclValidation",
+    datatype: "boolean",
+    settingUid: "9b00b471-7321-4c49-85cc-2e14367b0617",
+  },
+  {
+    field: "enablePropertiesLabelPatch",
+    keyUid: "c9d9cf68-30c6-4543-9c3d-f34cd1f91052",
+    keyLabel: "exo__SettingKeyEnablePropertiesLabelPatch",
+    datatype: "boolean",
+    settingUid: "a054aff7-962e-4dd9-b713-cc852fcbe2a6",
+  },
+  // ── string (2) ────────────────────────────────────────────────────
+  {
+    // @deprecated in ExocortexSettings but still a live data.json field;
+    // D1 grounded its SettingKey deliberately — kept for 1:1 mirroring.
+    field: "displayNameTemplate",
+    keyUid: "30ec5489-364d-43f9-ba0a-e63be10f18ad",
+    keyLabel: "exo__SettingKeyDisplayNameTemplate",
+    datatype: "string",
+    settingUid: "33c8270e-4ba0-4e67-b6f1-ad31493d6387",
+  },
+  {
+    field: "exosyncQuarantineRepoUrl",
+    keyUid: "4657ef5e-bf12-486b-a114-3c5236a91d89",
+    keyLabel: "exo__SettingKeyExosyncQuarantineRepoUrl",
+    datatype: "string",
+    settingUid: "23a3b26c-0dd1-4a89-a251-7c0470cd7c21",
+  },
+  // ── stringList (2) ────────────────────────────────────────────────
+  {
+    field: "excludedFolders",
+    keyUid: "4ab4ae78-a248-4e50-b5de-bfd420e39570",
+    keyLabel: "exo__SettingKeyExcludedFolders",
+    datatype: "stringList",
+    settingUid: "43282d2c-a936-48f3-b62c-9e7384fe3909",
+  },
+  {
+    field: "lazyBootstrapFolders",
+    keyUid: "8f4a0dc8-dbc3-4961-af0b-7c38f660d3d6",
+    keyLabel: "exo__SettingKeyLazyBootstrapFolders",
+    datatype: "stringList",
+    settingUid: "4a540d00-ac1b-485f-86cb-14426c134292",
+  },
+];
+
+/**
+ * Fields that must NEVER be homoiconized (onto-RFC R2 denylist, D24/D26).
+ * Exported for the 0-leakage unit test — the registry above is the
+ * mechanism (allowlist); this list documents the intent and lets the test
+ * assert the two sets stay disjoint.
+ */
+export const NON_HOMOICONIZABLE_FIELDS: readonly string[] = [
+  "activeProfileUid", // per-device (data.local.json, Issue #3327)
+  "_switchInProgress", // per-device crash-recovery flag (data.local.json)
+  "pat", // secret (LocalSecretsStore) — never even in data.json
+  "displayNameSettings", // structural (nested object) — deferred (D26)
+  "logChannels", // structural (nested object) — deferred (D26)
+];
+
+const byField = new Map(VAULT_SETTINGS_REGISTRY.map((d) => [d.field, d]));
+const byKeyUid = new Map(VAULT_SETTINGS_REGISTRY.map((d) => [d.keyUid, d]));
+const byKeyLabel = new Map(
+  VAULT_SETTINGS_REGISTRY.map((d) => [d.keyLabel, d]),
+);
+
+export function descriptorByField(
+  field: string,
+): VaultSettingDescriptor | undefined {
+  return byField.get(field);
+}
+
+/**
+ * Resolve a descriptor from the raw `exo__Setting_key` frontmatter value.
+ * Accepts UID-form wikilinks (`[[<keyUid>]]`, `[[<keyUid>|alias]]`) and
+ * label-form (`[[exo__SettingKeyShowArchivedAssets]]`) for hand-authored
+ * assets. Returns undefined for unknown keys (caller warn-logs — R3).
+ */
+export function descriptorByKeyRef(
+  raw: unknown,
+): VaultSettingDescriptor | undefined {
+  if (typeof raw !== "string") return undefined;
+  const inner = raw.replace(/^\s*\[\[/, "").replace(/\]\]\s*$/, "");
+  const target = inner.split("|")[0].split("#")[0].trim();
+  return byKeyUid.get(target) ?? byKeyLabel.get(target);
+}

--- a/packages/obsidian-plugin/src/infrastructure/adapters/VaultSettingsStore.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/VaultSettingsStore.ts
@@ -1,0 +1,702 @@
+import type { App, TFile } from "obsidian";
+import { normaliseExcludedFolders } from "exocortex";
+import type { ILogger } from "@plugin/adapters/logging/ILogger";
+import { DEFAULT_SETTINGS } from "@plugin/domain/settings/ExocortexSettings";
+import {
+  DEFAULT_SETTINGS_FOLDER,
+  NON_HOMOICONIZABLE_FIELDS,
+  SETTING_CLASS_UID,
+  SETTING_KEY_PROP,
+  SETTING_VALUE_PROP,
+  VAULT_SETTINGS_REGISTRY,
+  descriptorByKeyRef,
+  type VaultSettingDescriptor,
+} from "@plugin/domain/settings/VaultSettingsRegistry";
+
+/**
+ * VaultSettingsStore — reads/writes `exo__Setting` vault assets
+ * (onto-RFC 981b6070 Phase 5 / ExoSync Phase D, task D2).
+ *
+ * Architecture: data.json stays a write-through mirror (instant boot
+ * baseline + fallback for non-homoiconized keys); the vault asset is the
+ * source of truth once it exists. Discovery is class-based and
+ * location-independent — users may move Setting assets into a
+ * materialized AssetSpace mount so ExoSync Phase A syncs them with zero
+ * extra sync code.
+ *
+ * Concurrency discipline (advisor round-1):
+ *  - All vault writes flow through ONE sequential promise chain
+ *    (`writeChain`) with a per-field trailing debounce — no interleaved
+ *    `processFrontMatter` calls, no per-keystroke write storms (F1/F10).
+ *  - `pendingWrites` records the value each in-flight write is expected
+ *    to land; `metadataCache.changed` echoes are swallowed while a
+ *    pending entry exists (stale intermediate reads can NEVER roll a
+ *    newer UI action back — F1). Entries expire after
+ *    {@link PENDING_TTL_MS} so a failed write cannot mute remote changes
+ *    forever.
+ *  - `writeValue` never creates missing assets (F2): transient
+ *    disappearance is normal here (ExoSync writeAtomic delete+rename
+ *    window, profile-apply unmounts, Obsidian Sync lag). Creation happens
+ *    only in the explicit {@link migrateMissing} route, which the caller
+ *    gates on a completed full scan + `_switchInProgress === false`.
+ *  - Comparisons run on canonicalized values (F4): `excludedFolders`
+ *    via `normaliseExcludedFolders`, `lazyBootstrapFolders` via
+ *    trim/trailing-slash — a hand-edited un-canonical asset does not
+ *    cause a rewrite war; write-back happens only on real UI changes.
+ *  - `lazyBootstrapFolders` applies as `union(defaults, assetValue)`
+ *    WITHOUT write-back (F8) so a stale vault asset cannot shadow
+ *    defaults added by future releases (anti-regression #3279).
+ *
+ * Deterministic identity (F7): each Setting instance has a fixed
+ * `exo__Asset_uid` + basename from the registry, so two devices that
+ * migrate independently produce byte-identical paths and file-level sync
+ * converges instead of duplicating.
+ */
+
+const PENDING_TTL_MS = 10_000;
+
+export interface VaultSettingsStoreOptions {
+  app: App;
+  logger: ILogger;
+  /** Live settings accessor (post-`loadSettings` object on the plugin). */
+  getSettings: () => Record<string, unknown>;
+  /**
+   * Snapshot of registry-field values taken right after `loadSettings()`
+   * (data.json baseline). Used for cold-start dirty-field detection
+   * (F12): a field the user changed between onload and the first scan is
+   * pushed to the vault instead of being overlaid by a stale asset value.
+   */
+  baseline: Record<string, unknown>;
+  /**
+   * Applies a remote (vault-originated) change: mutate plugin settings,
+   * run the field's side-effect hook, mirror to data.json via saveData
+   * (NOT saveSettings — avoids the push-back loop).
+   */
+  applyRemote: (field: string, value: unknown) => Promise<void>;
+  /** Trailing debounce for vault writes. Default 1000 ms; 0 in tests. */
+  writeDebounceMs?: number;
+  /** Folder where migrateMissing materialises assets. */
+  settingsFolder?: string;
+}
+
+interface ScanEntry {
+  descriptor: VaultSettingDescriptor;
+  path: string;
+  /** Coerced (NOT yet merged) asset value; undefined = invalid/uncoercible. */
+  assetValue: unknown;
+}
+
+export interface ScanResult {
+  /** field → winning entry. */
+  entries: Map<string, ScanEntry>;
+  /** Registry fields with no asset found. */
+  missing: VaultSettingDescriptor[];
+}
+
+interface PendingWrite {
+  /** Canonical JSON of the value the in-flight write should land. */
+  canonical: string;
+  ts: number;
+}
+
+export class VaultSettingsStore {
+  private readonly app: App;
+  private readonly logger: ILogger;
+  private readonly getSettings: () => Record<string, unknown>;
+  private readonly baseline: Record<string, unknown>;
+  private readonly applyRemote: (
+    field: string,
+    value: unknown,
+  ) => Promise<void>;
+  private readonly writeDebounceMs: number;
+  private readonly settingsFolder: string;
+
+  /** field → vault path of the winning asset. */
+  private readonly knownFiles = new Map<string, string>();
+  /** path → field (reverse index for O(1) watcher checks). */
+  private readonly knownPaths = new Map<string, string>();
+  /**
+   * field → canonical JSON of the last effective value applied to (or
+   * pushed from) plugin settings. Echo/diff baseline.
+   */
+  private readonly lastApplied = new Map<string, string>();
+  private readonly pendingWrites = new Map<string, PendingWrite>();
+  private readonly debounceTimers = new Map<
+    string,
+    ReturnType<typeof setTimeout>
+  >();
+  private readonly latestDesired = new Map<string, unknown>();
+  private readonly warnedUnknownKeys = new Set<string>();
+  private writeChain: Promise<void> = Promise.resolve();
+  private scanned = false;
+
+  constructor(options: VaultSettingsStoreOptions) {
+    this.app = options.app;
+    this.logger = options.logger;
+    this.getSettings = options.getSettings;
+    this.baseline = options.baseline;
+    this.applyRemote = options.applyRemote;
+    this.writeDebounceMs = options.writeDebounceMs ?? 1000;
+    this.settingsFolder = options.settingsFolder ?? DEFAULT_SETTINGS_FOLDER;
+  }
+
+  // ────────────────────────────────────────────────────────────────
+  // Scan + overlay
+  // ────────────────────────────────────────────────────────────────
+
+  /**
+   * Full class-based scan. Caller MUST invoke this only after
+   * `metadataCache.on("resolved")` — earlier, unparsed files yield null
+   * frontmatter and existing assets would be misread as missing (F5).
+   */
+  scanAll(): ScanResult {
+    const entries = new Map<string, ScanEntry>();
+    for (const file of this.app.vault.getMarkdownFiles()) {
+      const entry = this.classify(file);
+      if (!entry) continue;
+      const existing = entries.get(entry.descriptor.field);
+      if (existing) {
+        // Deterministic winner: lexicographically smallest path (stable
+        // across devices — never timestamps, device clocks lie).
+        const winner = existing.path <= entry.path ? existing : entry;
+        const loser = winner === existing ? entry : existing;
+        this.logger.warn(
+          `[VaultSettingsStore] duplicate exo__Setting for "${entry.descriptor.field}": ` +
+            `keeping ${winner.path}, ignoring ${loser.path}`,
+        );
+        entries.set(entry.descriptor.field, winner);
+        continue;
+      }
+      entries.set(entry.descriptor.field, entry);
+    }
+
+    this.knownFiles.clear();
+    this.knownPaths.clear();
+    for (const [field, entry] of entries) {
+      this.knownFiles.set(field, entry.path);
+      this.knownPaths.set(entry.path, field);
+    }
+
+    const missing = VAULT_SETTINGS_REGISTRY.filter(
+      (d) => !entries.has(d.field),
+    );
+    this.scanned = true;
+    return { entries, missing };
+  }
+
+  /**
+   * Applies scan results to live settings:
+   *  - dirty fields (changed by the user since onload, F12) are NOT
+   *    overlaid — their current value is queued for a vault write;
+   *  - clean fields whose effective asset value differs from settings
+   *    are applied via `applyRemote`.
+   *
+   * Returns the fields that were overlaid (changed in settings).
+   */
+  async applyScan(result: ScanResult): Promise<string[]> {
+    const settings = this.getSettings();
+    const overlaid: string[] = [];
+
+    for (const [field, entry] of result.entries) {
+      const effective = this.toEffective(entry.descriptor, entry.assetValue);
+      if (effective === undefined) {
+        // Invalid/uncoercible asset value — keep data.json fallback,
+        // never overwrite the asset with defaults (F8/F11).
+        this.logger.warn(
+          `[VaultSettingsStore] asset value for "${field}" at ${entry.path} ` +
+            `is not coercible to ${entry.descriptor.datatype}; keeping data.json value`,
+        );
+        this.lastApplied.set(field, this.canonicalOf(field, settings[field]));
+        continue;
+      }
+      const effectiveCanonical = this.canonicalOf(field, effective);
+      const currentCanonical = this.canonicalOf(field, settings[field]);
+      const baselineCanonical = this.canonicalOf(field, this.baseline[field]);
+      const isDirty = currentCanonical !== baselineCanonical;
+
+      if (isDirty) {
+        // User acted before the scan landed — their change wins; push it.
+        this.lastApplied.set(field, currentCanonical);
+        if (effectiveCanonical !== currentCanonical) {
+          this.queueWrite(field, settings[field]);
+        }
+        continue;
+      }
+
+      if (effectiveCanonical !== currentCanonical) {
+        await this.applyRemote(field, effective);
+        overlaid.push(field);
+      }
+      this.lastApplied.set(field, effectiveCanonical);
+    }
+
+    // Fields with no asset: fallback to data.json (current value), which
+    // becomes the diff baseline so a later UI change is still detected.
+    for (const d of result.missing) {
+      this.lastApplied.set(
+        d.field,
+        this.canonicalOf(d.field, settings[d.field]),
+      );
+    }
+    return overlaid;
+  }
+
+  // ────────────────────────────────────────────────────────────────
+  // Migration (one-shot, idempotent)
+  // ────────────────────────────────────────────────────────────────
+
+  /**
+   * Creates assets for registry fields that have none, seeding each with
+   * the CURRENT settings value (data.json). Idempotent: per-key
+   * skip-existing; deterministic uid/basename means a re-run — or an
+   * independent run on another device — converges on the same file.
+   *
+   * Caller gates: full scan completed + `_switchInProgress === false`.
+   */
+  async migrateMissing(): Promise<string[]> {
+    if (!this.scanned) {
+      throw new Error(
+        "VaultSettingsStore.migrateMissing: scanAll() must run first",
+      );
+    }
+    const settings = this.getSettings();
+    const created: string[] = [];
+
+    for (const d of VAULT_SETTINGS_REGISTRY) {
+      if (this.knownFiles.has(d.field)) continue;
+      const path = `${this.settingsFolder}/${d.settingUid}.md`;
+
+      const existing = this.app.vault.getAbstractFileByPath(path);
+      if (existing) {
+        // File exists but didn't classify in scan (e.g. Obsidian Sync
+        // delivered it mid-session) — adopt, don't duplicate.
+        this.register(d.field, path);
+        continue;
+      }
+
+      try {
+        await this.ensureFolder();
+        await this.app.vault.create(
+          path,
+          this.renderAssetContent(d, settings[d.field]),
+        );
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        if (/already exists/i.test(msg)) {
+          // Sync race — another writer materialised it first. Adopt.
+          this.register(d.field, path);
+          continue;
+        }
+        this.logger.warn(
+          `[VaultSettingsStore] failed to create setting asset ${path}: ${msg}`,
+        );
+        continue;
+      }
+      this.register(d.field, path);
+      this.lastApplied.set(
+        d.field,
+        this.canonicalOf(d.field, settings[d.field]),
+      );
+      created.push(d.field);
+    }
+    return created;
+  }
+
+  // ────────────────────────────────────────────────────────────────
+  // UI → vault push
+  // ────────────────────────────────────────────────────────────────
+
+  /**
+   * Called from the `saveSettings()` funnel: diffs registry fields
+   * against the last applied/pushed value and queues vault writes for
+   * the changed ones. Cheap no-op when nothing relevant changed.
+   */
+  pushChangedFields(): void {
+    if (!this.scanned) return; // pre-scan changes handled as dirty fields
+    const settings = this.getSettings();
+    for (const d of VAULT_SETTINGS_REGISTRY) {
+      const canonical = this.canonicalOf(d.field, settings[d.field]);
+      if (this.lastApplied.get(d.field) === canonical) continue;
+      this.lastApplied.set(d.field, canonical);
+      this.queueWrite(d.field, settings[d.field]);
+    }
+  }
+
+  /** Trailing-debounced, sequential vault write (F1/F10). */
+  private queueWrite(field: string, value: unknown): void {
+    this.latestDesired.set(field, value);
+    const timer = this.debounceTimers.get(field);
+    if (timer) clearTimeout(timer);
+    this.debounceTimers.set(
+      field,
+      setTimeout(() => {
+        this.debounceTimers.delete(field);
+        const desired = this.latestDesired.get(field);
+        this.latestDesired.delete(field);
+        this.writeChain = this.writeChain
+          .then(() => this.writeValue(field, desired))
+          .catch((err) => {
+            this.logger.warn(
+              `[VaultSettingsStore] vault write for "${field}" failed: ${
+                err instanceof Error ? err.message : String(err)
+              }`,
+            );
+            this.pendingWrites.delete(field);
+          });
+      }, this.writeDebounceMs),
+    );
+  }
+
+  /** Awaitable settling point for tests and orderly shutdown. */
+  async flushWrites(): Promise<void> {
+    // Fire any armed debounce timers immediately.
+    for (const [field, timer] of this.debounceTimers) {
+      clearTimeout(timer);
+      this.debounceTimers.delete(field);
+      const desired = this.latestDesired.get(field);
+      this.latestDesired.delete(field);
+      this.writeChain = this.writeChain
+        .then(() => this.writeValue(field, desired))
+        .catch(() => {
+          this.pendingWrites.delete(field);
+        });
+    }
+    await this.writeChain;
+  }
+
+  private async writeValue(field: string, value: unknown): Promise<void> {
+    const path = this.knownFiles.get(field);
+    if (!path) {
+      // No asset (not yet migrated / unmounted / deleted): data.json
+      // mirror already holds the value — never auto-create here (F2).
+      return;
+    }
+    const file = this.app.vault.getAbstractFileByPath(path);
+    if (!file || !this.isTFile(file)) {
+      // Transient disappearance (ExoSync atomic-write window, profile
+      // apply, Sync lag) — mirror-only, asset will resurface (F2).
+      return;
+    }
+    const descriptor = VAULT_SETTINGS_REGISTRY.find((d) => d.field === field);
+    if (!descriptor) return;
+    const assetValue = this.toAssetValue(descriptor, value);
+    this.pendingWrites.set(field, {
+      canonical: this.canonicalOf(field, assetValue),
+      ts: Date.now(),
+    });
+    await this.app.fileManager.processFrontMatter(
+      file,
+      (fm: Record<string, unknown>) => {
+        fm[SETTING_VALUE_PROP] = assetValue;
+        fm["exo__Asset_updatedAt"] = this.localTimestamp();
+      },
+    );
+  }
+
+  // ────────────────────────────────────────────────────────────────
+  // Watcher handlers (registered by the plugin)
+  // ────────────────────────────────────────────────────────────────
+
+  /**
+   * `metadataCache.on("changed")` handler. O(1) for non-setting files
+   * (F15). Applies remote changes; swallows echoes of own writes (F1).
+   */
+  async onMetadataChanged(file: TFile): Promise<void> {
+    if (!this.scanned) return;
+    let field = this.knownPaths.get(file.path);
+    let entry: ScanEntry | null = null;
+
+    if (field === undefined) {
+      // New file might be a setting asset (Sync delivery, user move).
+      entry = this.classify(file);
+      if (!entry) return;
+      field = entry.descriptor.field;
+      const existingPath = this.knownFiles.get(field);
+      if (existingPath && existingPath !== file.path) {
+        const winner = existingPath <= file.path ? existingPath : file.path;
+        if (winner === existingPath) return; // incoming file loses dedup
+      }
+      this.register(field, file.path);
+    } else {
+      entry = this.classify(file);
+      if (!entry) {
+        // Frontmatter became unparseable / key removed — treat as
+        // transient damage, keep current settings value (F11).
+        return;
+      }
+      if (entry.descriptor.field !== field) {
+        // Key was re-pointed to another setting — re-register.
+        this.unregisterPath(file.path);
+        this.register(entry.descriptor.field, file.path);
+        field = entry.descriptor.field;
+      }
+    }
+
+    const descriptor = entry.descriptor;
+    const effective = this.toEffective(descriptor, entry.assetValue);
+    if (effective === undefined) return;
+    const effectiveCanonical = this.canonicalOf(field, effective);
+    const assetCanonical = this.canonicalOf(field, entry.assetValue);
+
+    const pending = this.pendingWrites.get(field);
+    if (pending) {
+      if (
+        pending.canonical === assetCanonical ||
+        pending.canonical === effectiveCanonical
+      ) {
+        this.pendingWrites.delete(field); // own echo landed
+        return;
+      }
+      if (Date.now() - pending.ts < PENDING_TTL_MS) {
+        // A newer write is still in flight — never let a stale
+        // intermediate state roll the user's action back (F1).
+        return;
+      }
+      this.pendingWrites.delete(field); // expired (failed write)
+    }
+
+    const settings = this.getSettings();
+    const currentCanonical = this.canonicalOf(field, settings[field]);
+    if (effectiveCanonical === currentCanonical) {
+      this.lastApplied.set(field, effectiveCanonical);
+      return;
+    }
+    this.lastApplied.set(field, effectiveCanonical);
+    await this.applyRemote(field, effective);
+  }
+
+  /** `vault.on("delete")` handler — value persists via data.json mirror. */
+  onFileDeleted(path: string): void {
+    this.unregisterPath(path);
+  }
+
+  /** `vault.on("rename")` handler — keep tracking relocated assets. */
+  onFileRenamed(file: TFile, oldPath: string): void {
+    const field = this.knownPaths.get(oldPath);
+    if (field === undefined) return;
+    this.knownPaths.delete(oldPath);
+    this.register(field, file.path);
+  }
+
+  // ────────────────────────────────────────────────────────────────
+  // Internals
+  // ────────────────────────────────────────────────────────────────
+
+  private classify(file: TFile): ScanEntry | null {
+    if (!file.path.endsWith(".md")) return null;
+    const fm = this.app.metadataCache.getFileCache(file)?.frontmatter as
+      | Record<string, unknown>
+      | undefined;
+    if (!fm) return null;
+    if (!this.hasSettingClass(fm["exo__Instance_class"])) return null;
+    const descriptor = descriptorByKeyRef(fm[SETTING_KEY_PROP]);
+    if (!descriptor) {
+      const rawKey = String(fm[SETTING_KEY_PROP] ?? "<missing>");
+      if (!this.warnedUnknownKeys.has(rawKey)) {
+        this.warnedUnknownKeys.add(rawKey);
+        this.logger.warn(
+          `[VaultSettingsStore] exo__Setting at ${file.path} references ` +
+            `unknown key ${rawKey} — ignored (newer plugin version may know it)`,
+        );
+      }
+      return null;
+    }
+    return {
+      descriptor,
+      path: file.path,
+      assetValue: this.coerce(descriptor, fm[SETTING_VALUE_PROP]),
+    };
+  }
+
+  private hasSettingClass(raw: unknown): boolean {
+    const refs = Array.isArray(raw) ? raw : raw !== undefined ? [raw] : [];
+    return refs.some(
+      (r) =>
+        typeof r === "string" &&
+        (r.includes(SETTING_CLASS_UID) || /\[\[\s*exo__Setting\s*(\||\]\])/.test(r)),
+    );
+  }
+
+  /** Tolerant datatype coercion (F9). Returns undefined when impossible. */
+  private coerce(d: VaultSettingDescriptor, raw: unknown): unknown {
+    switch (d.datatype) {
+      case "boolean": {
+        if (typeof raw === "boolean") return raw;
+        if (typeof raw === "string") {
+          const s = raw.trim().toLowerCase();
+          if (s === "true") return true;
+          if (s === "false") return false;
+        }
+        return undefined;
+      }
+      case "string": {
+        if (typeof raw === "string") return raw;
+        if (typeof raw === "number") return String(raw);
+        return undefined;
+      }
+      case "stringList": {
+        if (Array.isArray(raw)) {
+          return raw.filter((e): e is string => typeof e === "string");
+        }
+        if (typeof raw === "string") return [raw]; // scalar → 1-elem list
+        return undefined;
+      }
+    }
+  }
+
+  /**
+   * Asset value → effective settings value (per-field merge policy).
+   *  - excludedFolders: canonical normalisation (trailing slash).
+   *  - lazyBootstrapFolders: union(defaults, asset) WITHOUT write-back —
+   *    anti-regression #3279 (F8).
+   */
+  private toEffective(
+    d: VaultSettingDescriptor,
+    assetValue: unknown,
+  ): unknown {
+    if (assetValue === undefined) return undefined;
+    if (d.field === "excludedFolders") {
+      return normaliseExcludedFolders(assetValue as string[]);
+    }
+    if (d.field === "lazyBootstrapFolders") {
+      const canonical = (assetValue as string[])
+        .map((s) => s.trim())
+        .filter((s) => s.length > 0)
+        .map((s) => (s.endsWith("/") ? s : s + "/"));
+      return Array.from(
+        new Set([
+          ...(DEFAULT_SETTINGS.lazyBootstrapFolders ?? []),
+          ...canonical,
+        ]),
+      );
+    }
+    return assetValue;
+  }
+
+  /** Settings value → value persisted in the asset. */
+  private toAssetValue(d: VaultSettingDescriptor, value: unknown): unknown {
+    if (d.field === "excludedFolders") {
+      return normaliseExcludedFolders(value as string[]);
+    }
+    return value;
+  }
+
+  /**
+   * Canonical JSON for comparisons: runs the field's effective
+   * normalisation over already-effective values so semantically equal
+   * shapes compare equal (F4).
+   */
+  private canonicalOf(field: string, value: unknown): string {
+    const d = VAULT_SETTINGS_REGISTRY.find((x) => x.field === field);
+    if (d && d.datatype === "stringList" && Array.isArray(value)) {
+      const normalised =
+        field === "excludedFolders"
+          ? normaliseExcludedFolders(value as string[])
+          : (value as string[])
+              .map((s) => s.trim())
+              .filter((s) => s.length > 0)
+              .map((s) => (s.endsWith("/") ? s : s + "/"));
+      return JSON.stringify(normalised);
+    }
+    return JSON.stringify(value ?? null);
+  }
+
+  private register(field: string, path: string): void {
+    this.knownFiles.set(field, path);
+    this.knownPaths.set(path, field);
+  }
+
+  private unregisterPath(path: string): void {
+    const field = this.knownPaths.get(path);
+    if (field === undefined) return;
+    this.knownPaths.delete(path);
+    if (this.knownFiles.get(field) === path) {
+      this.knownFiles.delete(field);
+    }
+  }
+
+  private async ensureFolder(): Promise<void> {
+    try {
+      await this.app.vault.createFolder(this.settingsFolder);
+    } catch {
+      // Already exists — fine.
+    }
+  }
+
+  private renderAssetContent(
+    d: VaultSettingDescriptor,
+    value: unknown,
+  ): string {
+    const ts = this.localTimestamp();
+    const lines = [
+      "---",
+      `exo__Asset_uid: ${d.settingUid}`,
+      `exo__Asset_createdAt: ${ts}`,
+      "exo__Instance_class:",
+      `  - "[[${SETTING_CLASS_UID}]]"`,
+      `exo__Asset_label: "Setting: ${d.field}"`,
+      `${SETTING_KEY_PROP}: "[[${d.keyUid}]]"`,
+      ...this.renderValueYaml(d, value),
+      "---",
+      "",
+      `User-configurable Exocortex plugin setting \`${d.field}\` ` +
+        `(${d.datatype}). Managed by the plugin per onto-RFC 981b6070; ` +
+        "edit the value here or via the plugin settings tab.",
+      "",
+    ];
+    return lines.join("\n");
+  }
+
+  private renderValueYaml(
+    d: VaultSettingDescriptor,
+    value: unknown,
+  ): string[] {
+    const v = this.toAssetValue(d, value);
+    switch (d.datatype) {
+      case "boolean":
+        return [`${SETTING_VALUE_PROP}: ${v === true ? "true" : "false"}`];
+      case "string":
+        return [`${SETTING_VALUE_PROP}: ${JSON.stringify(String(v ?? ""))}`];
+      case "stringList": {
+        const list = Array.isArray(v) ? (v as string[]) : [];
+        if (list.length === 0) return [`${SETTING_VALUE_PROP}: []`];
+        return [
+          `${SETTING_VALUE_PROP}:`,
+          ...list.map((e) => `  - ${JSON.stringify(e)}`),
+        ];
+      }
+    }
+  }
+
+  private localTimestamp(): string {
+    const d = new Date();
+    const p = (n: number) => String(n).padStart(2, "0");
+    return (
+      `${d.getFullYear()}-${p(d.getMonth() + 1)}-${p(d.getDate())}` +
+      `T${p(d.getHours())}:${p(d.getMinutes())}:${p(d.getSeconds())}`
+    );
+  }
+
+  private isTFile(f: unknown): f is TFile {
+    return (
+      !!f &&
+      typeof f === "object" &&
+      "path" in f &&
+      typeof (f as { path: unknown }).path === "string" &&
+      !("children" in f)
+    );
+  }
+}
+
+/**
+ * Compile-time guard: the allowlist and denylist must stay disjoint.
+ * (Runtime no-op; the unit test asserts the same empirically.)
+ */
+const _denySet = new Set(NON_HOMOICONIZABLE_FIELDS);
+for (const d of VAULT_SETTINGS_REGISTRY) {
+  if (_denySet.has(d.field)) {
+    throw new Error(
+      `VaultSettingsRegistry: field "${d.field}" is in NON_HOMOICONIZABLE_FIELDS`,
+    );
+  }
+}

--- a/packages/obsidian-plugin/src/infrastructure/adapters/VaultSettingsStore.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/VaultSettingsStore.ts
@@ -396,6 +396,10 @@ export class VaultSettingsStore {
     }
     const descriptor = VAULT_SETTINGS_REGISTRY.find((d) => d.field === field);
     if (!descriptor) return;
+    // The local value is about to land — any earlier deferral is moot
+    // (advisor round-2 #1: a stale deferred flag could otherwise clobber
+    // a later genuine remote change once).
+    this.deferredPushFields.delete(field);
     const assetValue = this.toAssetValue(descriptor, value);
     this.pendingWrites.set(field, {
       canonical: this.canonicalOf(field, assetValue),

--- a/packages/obsidian-plugin/src/infrastructure/adapters/VaultSettingsStore.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/VaultSettingsStore.ts
@@ -127,6 +127,14 @@ export class VaultSettingsStore {
   >();
   private readonly latestDesired = new Map<string, unknown>();
   private readonly warnedUnknownKeys = new Set<string>();
+  /**
+   * Fields whose vault write was skipped because the asset was missing
+   * (deleted / unmounted during a profile switch). When the asset
+   * resurfaces, the LOCAL value is re-pushed instead of applying the
+   * asset's stale value — the user's newer intent must not be silently
+   * rolled back (reviewer MEDIUM-2).
+   */
+  private readonly deferredPushFields = new Set<string>();
   private writeChain: Promise<void> = Promise.resolve();
   private scanned = false;
 
@@ -357,7 +365,12 @@ export class VaultSettingsStore {
       this.latestDesired.delete(field);
       this.writeChain = this.writeChain
         .then(() => this.writeValue(field, desired))
-        .catch(() => {
+        .catch((err) => {
+          this.logger.warn(
+            `[VaultSettingsStore] vault write for "${field}" failed during flush: ${
+              err instanceof Error ? err.message : String(err)
+            }`,
+          );
           this.pendingWrites.delete(field);
         });
     }
@@ -369,12 +382,16 @@ export class VaultSettingsStore {
     if (!path) {
       // No asset (not yet migrated / unmounted / deleted): data.json
       // mirror already holds the value — never auto-create here (F2).
+      // Remember the field so the local value wins when the asset
+      // resurfaces (MEDIUM-2).
+      this.deferredPushFields.add(field);
       return;
     }
     const file = this.app.vault.getAbstractFileByPath(path);
     if (!file || !this.isTFile(file)) {
       // Transient disappearance (ExoSync atomic-write window, profile
       // apply, Sync lag) — mirror-only, asset will resurface (F2).
+      this.deferredPushFields.add(field);
       return;
     }
     const descriptor = VAULT_SETTINGS_REGISTRY.find((d) => d.field === field);
@@ -415,6 +432,11 @@ export class VaultSettingsStore {
       if (existingPath && existingPath !== file.path) {
         const winner = existingPath <= file.path ? existingPath : file.path;
         if (winner === existingPath) return; // incoming file loses dedup
+        // Incoming file wins — evict the loser from the reverse index
+        // so its future changed-events cannot keep feeding the field
+        // (reviewer MEDIUM-1: two live sources → cross-device
+        // ping-pong).
+        this.knownPaths.delete(existingPath);
       }
       this.register(field, file.path);
     } else {
@@ -429,6 +451,12 @@ export class VaultSettingsStore {
         this.unregisterPath(file.path);
         this.register(entry.descriptor.field, file.path);
         field = entry.descriptor.field;
+      }
+      if (this.knownFiles.get(field) !== file.path) {
+        // Stale reverse-index entry (this path lost a dedup since) —
+        // never apply a non-winner file (reviewer MEDIUM-1 guard).
+        this.knownPaths.delete(file.path);
+        return;
       }
     }
 
@@ -457,6 +485,25 @@ export class VaultSettingsStore {
 
     const settings = this.getSettings();
     const currentCanonical = this.canonicalOf(field, settings[field]);
+
+    if (this.deferredPushFields.has(field)) {
+      // The asset resurfaced after a write was skipped while it was
+      // missing — the LOCAL value is newer than whatever the asset
+      // carries; re-push it instead of rolling the user back
+      // (MEDIUM-2).
+      this.deferredPushFields.delete(field);
+      if (effectiveCanonical !== currentCanonical) {
+        this.logger.info(
+          `[VaultSettingsStore] re-pushing local value for "${field}" — ` +
+            "its asset resurfaced with a stale value",
+        );
+        this.lastApplied.set(field, currentCanonical);
+        this.queueWrite(field, settings[field]);
+        return;
+      }
+      // Values agree — fall through to the normal bookkeeping below.
+    }
+
     if (effectiveCanonical === currentCanonical) {
       this.lastApplied.set(field, effectiveCanonical);
       return;
@@ -577,6 +624,31 @@ export class VaultSettingsStore {
   private toAssetValue(d: VaultSettingDescriptor, value: unknown): unknown {
     if (d.field === "excludedFolders") {
       return normaliseExcludedFolders(value as string[]);
+    }
+    if (
+      d.field === "exosyncQuarantineRepoUrl" &&
+      typeof value === "string" &&
+      value.length > 0
+    ) {
+      // The vault asset syncs further than data.json — never let a URL
+      // with embedded credentials (https://user:token@github.com/...)
+      // materialise into it (reviewer LOW-2). The PAT channel proper is
+      // LocalSecretsStore; this guards user misuse.
+      try {
+        const u = new URL(value);
+        if (u.username || u.password) {
+          u.username = "";
+          u.password = "";
+          this.logger.warn(
+            "[VaultSettingsStore] stripped embedded credentials from " +
+              "exosyncQuarantineRepoUrl before writing the vault asset",
+          );
+          return u.toString();
+        }
+      } catch {
+        // Not a parseable URL — persist as-is; the sync engine validates
+        // the URL shape on use.
+      }
     }
     return value;
   }

--- a/packages/obsidian-plugin/tests/unit/domain/settings/VaultSettingsRegistry.test.ts
+++ b/packages/obsidian-plugin/tests/unit/domain/settings/VaultSettingsRegistry.test.ts
@@ -1,0 +1,206 @@
+import * as fs from "fs";
+import * as path from "path";
+
+import {
+  DEFAULT_SETTINGS,
+  type ExocortexSettings,
+} from "../../../../src/domain/settings/ExocortexSettings";
+import {
+  NON_HOMOICONIZABLE_FIELDS,
+  SETTING_KEY_CLASS_UID,
+  VAULT_SETTINGS_REGISTRY,
+  descriptorByField,
+  descriptorByKeyRef,
+} from "../../../../src/domain/settings/VaultSettingsRegistry";
+
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
+
+describe("VaultSettingsRegistry", () => {
+  it("contains exactly 23 descriptors (19 boolean / 2 string / 2 stringList)", () => {
+    expect(VAULT_SETTINGS_REGISTRY).toHaveLength(23);
+    const byType = { boolean: 0, string: 0, stringList: 0 };
+    for (const d of VAULT_SETTINGS_REGISTRY) byType[d.datatype]++;
+    expect(byType).toEqual({ boolean: 19, string: 2, stringList: 2 });
+  });
+
+  it("has unique fields, keyUids and settingUids (all UUID-shaped)", () => {
+    const fields = VAULT_SETTINGS_REGISTRY.map((d) => d.field);
+    const keyUids = VAULT_SETTINGS_REGISTRY.map((d) => d.keyUid);
+    const settingUids = VAULT_SETTINGS_REGISTRY.map((d) => d.settingUid);
+    expect(new Set(fields).size).toBe(fields.length);
+    expect(new Set(keyUids).size).toBe(keyUids.length);
+    expect(new Set(settingUids).size).toBe(settingUids.length);
+    for (const uid of [...keyUids, ...settingUids]) {
+      expect(uid).toMatch(UUID_RE);
+    }
+    // Setting-instance UIDs must not collide with SettingKey UIDs.
+    for (const uid of settingUids) {
+      expect(keyUids).not.toContain(uid);
+    }
+  });
+
+  it("0-leakage: allowlist and denylist are disjoint; denylist covers per-device + structural fields", () => {
+    const fields = new Set(VAULT_SETTINGS_REGISTRY.map((d) => d.field));
+    for (const denied of NON_HOMOICONIZABLE_FIELDS) {
+      expect(fields.has(denied)).toBe(false);
+    }
+    for (const required of [
+      "activeProfileUid",
+      "_switchInProgress",
+      "pat",
+      "displayNameSettings",
+      "logChannels",
+    ]) {
+      expect(NON_HOMOICONIZABLE_FIELDS).toContain(required);
+    }
+  });
+
+  it("covers every ExocortexSettings field except the denylisted ones (anti-drift, onto-RFC R3)", () => {
+    // DEFAULT_SETTINGS enumerates every concrete field of the interface
+    // (the index signature admits more, but defaults define the schema).
+    const allFields = Object.keys(DEFAULT_SETTINGS);
+    const registryFields = new Set(VAULT_SETTINGS_REGISTRY.map((d) => d.field));
+    const denySet = new Set(NON_HOMOICONIZABLE_FIELDS);
+    for (const field of allFields) {
+      const covered = registryFields.has(field) || denySet.has(field);
+      if (!covered) {
+        throw new Error(
+          `ExocortexSettings field "${field}" is neither in ` +
+            "VAULT_SETTINGS_REGISTRY nor in NON_HOMOICONIZABLE_FIELDS — " +
+            "a new setting was added without deciding its homoiconization " +
+            "(add a SettingKey individual to exoas-exo + a registry entry, " +
+            "or denylist it explicitly; onto-RFC 981b6070 R3)",
+        );
+      }
+    }
+  });
+
+  it("registry fields exist in DEFAULT_SETTINGS (no phantom fields)", () => {
+    for (const d of VAULT_SETTINGS_REGISTRY) {
+      expect(
+        Object.prototype.hasOwnProperty.call(DEFAULT_SETTINGS, d.field),
+      ).toBe(true);
+    }
+  });
+
+  it("datatype matches the DEFAULT_SETTINGS value shape", () => {
+    for (const d of VAULT_SETTINGS_REGISTRY) {
+      const v = DEFAULT_SETTINGS[d.field as keyof ExocortexSettings];
+      if (d.datatype === "boolean") expect(typeof v).toBe("boolean");
+      if (d.datatype === "string") expect(typeof v).toBe("string");
+      if (d.datatype === "stringList") expect(Array.isArray(v)).toBe(true);
+    }
+  });
+
+  describe("descriptorByKeyRef", () => {
+    const show = VAULT_SETTINGS_REGISTRY.find(
+      (d) => d.field === "showArchivedAssets",
+    )!;
+
+    it("resolves UID-form wikilinks with and without alias/anchor", () => {
+      expect(descriptorByKeyRef(`[[${show.keyUid}]]`)).toBe(show);
+      expect(descriptorByKeyRef(`[[${show.keyUid}|любой алиас]]`)).toBe(show);
+      expect(descriptorByKeyRef(`[[${show.keyUid}#section]]`)).toBe(show);
+    });
+
+    it("resolves label-form wikilinks (hand-authored assets)", () => {
+      expect(descriptorByKeyRef(`[[${show.keyLabel}]]`)).toBe(show);
+    });
+
+    it("returns undefined for unknown keys and non-strings", () => {
+      expect(descriptorByKeyRef("[[deadbeef-0000-0000-0000-000000000000]]")).toBeUndefined();
+      expect(descriptorByKeyRef(42)).toBeUndefined();
+      expect(descriptorByKeyRef(undefined)).toBeUndefined();
+      expect(descriptorByKeyRef(["[[x]]"])).toBeUndefined();
+    });
+  });
+
+  it("descriptorByField round-trips", () => {
+    for (const d of VAULT_SETTINGS_REGISTRY) {
+      expect(descriptorByField(d.field)).toBe(d);
+    }
+    expect(descriptorByField("activeProfileUid")).toBeUndefined();
+  });
+});
+
+describe("registry ↔ graph parity (exoas-exo submodule, onto-RFC R3)", () => {
+  // CI checks out submodules recursively for the unit-test jobs; a missing
+  // or empty submodule must FAIL (not skip) — a silent skip would let the
+  // registry drift from the graph unnoticed.
+  const exoDir = path.resolve(
+    __dirname,
+    "../../../../..",
+    "exoas-exo",
+    "exo",
+  );
+
+  interface GraphKey {
+    uid: string;
+    label: string;
+    datatype: string;
+  }
+
+  function readGraphSettingKeys(): GraphKey[] {
+    const out: GraphKey[] = [];
+    for (const fn of fs.readdirSync(exoDir)) {
+      if (!fn.endsWith(".md")) continue;
+      const text = fs.readFileSync(path.join(exoDir, fn), "utf8");
+      // SettingKey individuals: typed by the exo__SettingKey class AND
+      // carrying a datatype declaration (the class/property TBox files
+      // mention the class UID too, but have no _datatype of their own
+      // in instance position — they re both filtered by requiring the
+      // Instance_class line).
+      if (
+        !text.includes(
+          `exo__Instance_class:\n  - "[[${SETTING_KEY_CLASS_UID}]]"`,
+        )
+      ) {
+        continue;
+      }
+      const dt = /exo__SettingKey_datatype: (\S+)/.exec(text);
+      if (!dt) continue;
+      const uid = /exo__Asset_uid: (\S+)/.exec(text);
+      const label = /exo__Asset_label: (\S+)/.exec(text);
+      if (!uid || !label) continue;
+      out.push({ uid: uid[1], label: label[1], datatype: dt[1] });
+    }
+    return out;
+  }
+
+  it("submodule TBox is present (packages/exoas-exo @ ≥6c0797e)", () => {
+    expect(fs.existsSync(exoDir)).toBe(true);
+    expect(fs.readdirSync(exoDir).length).toBeGreaterThan(0);
+  });
+
+  it("every registry entry matches a graph SettingKey individual 1:1 (uid + label + datatype)", () => {
+    const graph = readGraphSettingKeys();
+    expect(graph).toHaveLength(VAULT_SETTINGS_REGISTRY.length);
+
+    const graphByUid = new Map(graph.map((g) => [g.uid, g]));
+    for (const d of VAULT_SETTINGS_REGISTRY) {
+      const g = graphByUid.get(d.keyUid);
+      if (!g) {
+        throw new Error(
+          `registry field "${d.field}" references keyUid ${d.keyUid} ` +
+            "that has no SettingKey individual in packages/exoas-exo/exo",
+        );
+      }
+      expect(g.label).toBe(d.keyLabel);
+      expect(g.datatype).toBe(d.datatype);
+    }
+  });
+
+  it("no graph SettingKey individual is missing from the registry (reverse direction)", () => {
+    const graph = readGraphSettingKeys();
+    const registryUids = new Set(VAULT_SETTINGS_REGISTRY.map((d) => d.keyUid));
+    for (const g of graph) {
+      if (!registryUids.has(g.uid)) {
+        throw new Error(
+          `graph SettingKey ${g.label} (${g.uid}) has no registry entry — ` +
+            "D1 added a key the loader does not bind (onto-RFC R3 drift)",
+        );
+      }
+    }
+  });
+});

--- a/packages/obsidian-plugin/tests/unit/infrastructure/adapters/VaultSettingsStore.test.ts
+++ b/packages/obsidian-plugin/tests/unit/infrastructure/adapters/VaultSettingsStore.test.ts
@@ -654,6 +654,81 @@ describe("VaultSettingsStore", () => {
       );
     });
 
+    it("evicts the loser file when a lexicographically-smaller asset is adopted mid-session (MEDIUM-1)", async () => {
+      const { fake, settings, store, applyRemote } = await setupMigrated();
+      const d = descriptorByField("showArchivedAssets")!;
+      const migratedPath = `${DEFAULT_SETTINGS_FOLDER}/${d.settingUid}.md`;
+      // Deliver a duplicate at a smaller path — it wins adoption.
+      const winnerPath = fake.seedSettingAsset("showArchivedAssets", true, {
+        path: "assetspaces/kitelev/exoas-kitelev/dup.md",
+      });
+      await store.onMetadataChanged(tfileOf(winnerPath));
+      expect(settings.showArchivedAssets).toBe(true);
+      applyRemote.mockClear();
+
+      // The loser (old migrated path) keeps emitting changed events with
+      // a different value — it must be ignored, not applied.
+      fake.files.get(migratedPath)!.frontmatter!.exo__Setting_value = false;
+      await store.onMetadataChanged(tfileOf(migratedPath));
+
+      expect(applyRemote).not.toHaveBeenCalled();
+      expect(settings.showArchivedAssets).toBe(true);
+
+      // And UI pushes go to the winner, not the loser.
+      settings.showArchivedAssets = false;
+      store.pushChangedFields();
+      await store.flushWrites();
+      expect(
+        fake.files.get(winnerPath)!.frontmatter!.exo__Setting_value,
+      ).toBe(false);
+    });
+
+    it("re-pushes the local value when the asset resurfaces after a skipped write (MEDIUM-2)", async () => {
+      const { fake, settings, store, applyRemote } = await setupMigrated();
+      const d = descriptorByField("enableShaclValidation")!;
+      const path = `${DEFAULT_SETTINGS_FOLDER}/${d.settingUid}.md`;
+
+      // Asset disappears (profile unmount / sync lag)…
+      fake.files.delete(path);
+      store.onFileDeleted(path);
+      // …user toggles meanwhile — write is skipped (no asset).
+      settings.enableShaclValidation = true;
+      store.pushChangedFields();
+      await store.flushWrites();
+      applyRemote.mockClear();
+
+      // Asset resurfaces with the STALE value (false).
+      const resurfaced = fake.seedSettingAsset("enableShaclValidation", false);
+      await store.onMetadataChanged(tfileOf(resurfaced));
+      await store.flushWrites();
+
+      // The user's newer intent wins: no rollback, asset got the local value.
+      expect(applyRemote).not.toHaveBeenCalled();
+      expect(settings.enableShaclValidation).toBe(true);
+      expect(
+        fake.files.get(resurfaced)!.frontmatter!.exo__Setting_value,
+      ).toBe(true);
+    });
+
+    it("strips embedded credentials from exosyncQuarantineRepoUrl before persisting (LOW-2)", async () => {
+      const fake = new FakeApp();
+      const settings = freshSettings();
+      settings.exosyncQuarantineRepoUrl =
+        "https://user:ghp_SECRETTOKEN@github.com/owner/repo";
+      const { store } = makeStore(fake, settings);
+      store.scanAll();
+      await store.migrateMissing();
+
+      const d = descriptorByField("exosyncQuarantineRepoUrl")!;
+      const file = fake.files.get(
+        `${DEFAULT_SETTINGS_FOLDER}/${d.settingUid}.md`,
+      )!;
+      expect(file.body).not.toContain("ghp_SECRETTOKEN");
+      expect(file.frontmatter!.exo__Setting_value).toBe(
+        "https://github.com/owner/repo",
+      );
+    });
+
     it("a broken-YAML change event does not unregister or reset the setting (F11)", async () => {
       const { fake, settings, store, applyRemote } = await setupMigrated();
       const d = descriptorByField("showArchivedAssets")!;

--- a/packages/obsidian-plugin/tests/unit/infrastructure/adapters/VaultSettingsStore.test.ts
+++ b/packages/obsidian-plugin/tests/unit/infrastructure/adapters/VaultSettingsStore.test.ts
@@ -1,0 +1,670 @@
+import type { App, TFile } from "obsidian";
+
+import { DEFAULT_SETTINGS } from "../../../../src/domain/settings/ExocortexSettings";
+import {
+  DEFAULT_SETTINGS_FOLDER,
+  SETTING_CLASS_UID,
+  VAULT_SETTINGS_REGISTRY,
+  descriptorByField,
+} from "../../../../src/domain/settings/VaultSettingsRegistry";
+import { VaultSettingsStore } from "../../../../src/infrastructure/adapters/VaultSettingsStore";
+
+// ─── Fake App (real-shape per test-fixture-realism rule) ──────────────
+//
+// Mirrors the real Obsidian contracts the store depends on:
+//  - getFileCache returns null for files metadataCache does not know;
+//  - vault.create THROWS "file already exists" on duplicate paths;
+//  - processFrontMatter mutates the stored frontmatter in place;
+//  - getAbstractFileByPath returns null for missing paths.
+
+interface FakeFile {
+  path: string;
+  frontmatter: Record<string, unknown> | null; // null = unparseable YAML
+  body: string;
+}
+
+class FakeApp {
+  files = new Map<string, FakeFile>();
+  folders = new Set<string>();
+  createCalls: string[] = [];
+  processCalls: string[] = [];
+
+  private tfile(path: string): TFile {
+    return { path } as unknown as TFile;
+  }
+
+  asApp(): App {
+    const self = this;
+    return {
+      vault: {
+        getMarkdownFiles: () =>
+          Array.from(self.files.keys()).map((p) => self.tfile(p)),
+        getAbstractFileByPath: (p: string) =>
+          self.files.has(p)
+            ? self.tfile(p)
+            : self.folders.has(p)
+              ? { path: p, children: [] }
+              : null,
+        create: async (p: string, content: string) => {
+          if (self.files.has(p)) {
+            throw new Error(`File already exists: ${p}`);
+          }
+          self.createCalls.push(p);
+          self.files.set(p, {
+            path: p,
+            frontmatter: parseFrontmatter(content),
+            body: content,
+          });
+          return self.tfile(p);
+        },
+        createFolder: async (p: string) => {
+          if (self.folders.has(p)) {
+            throw new Error(`Folder already exists: ${p}`);
+          }
+          self.folders.add(p);
+        },
+      },
+      metadataCache: {
+        getFileCache: (file: TFile) => {
+          const f = self.files.get(file.path);
+          if (!f) return null;
+          if (f.frontmatter === null) return {}; // parsed, no frontmatter
+          return { frontmatter: f.frontmatter };
+        },
+      },
+      fileManager: {
+        processFrontMatter: async (
+          file: TFile,
+          fn: (fm: Record<string, unknown>) => void,
+        ) => {
+          const f = self.files.get(file.path);
+          if (!f) throw new Error(`File not found: ${file.path}`);
+          const fm = f.frontmatter ?? {};
+          fn(fm);
+          f.frontmatter = fm;
+          self.processCalls.push(file.path);
+        },
+      },
+    } as unknown as App;
+  }
+
+  seedSettingAsset(
+    field: string,
+    value: unknown,
+    opts: { path?: string; keyRef?: string } = {},
+  ): string {
+    const d = descriptorByField(field);
+    if (!d) throw new Error(`unknown field ${field}`);
+    const path = opts.path ?? `${DEFAULT_SETTINGS_FOLDER}/${d.settingUid}.md`;
+    this.files.set(path, {
+      path,
+      frontmatter: {
+        exo__Asset_uid: d.settingUid,
+        exo__Instance_class: [`[[${SETTING_CLASS_UID}]]`],
+        exo__Setting_key: opts.keyRef ?? `[[${d.keyUid}]]`,
+        exo__Setting_value: value,
+      },
+      body: "",
+    });
+    return path;
+  }
+}
+
+// Minimal frontmatter parser for vault.create output — handles exactly
+// the shapes renderAssetContent emits (scalars, quoted strings, block
+// lists). Good enough for asserting created content.
+function parseFrontmatter(content: string): Record<string, unknown> | null {
+  const m = /^---\n([\s\S]*?)\n---/.exec(content);
+  if (!m) return null;
+  const fm: Record<string, unknown> = {};
+  let currentList: string | null = null;
+  for (const line of m[1].split("\n")) {
+    const listItem = /^ {2}- (.*)$/.exec(line);
+    if (listItem && currentList) {
+      const arr = (fm[currentList] as unknown[]) ?? [];
+      let v = listItem[1];
+      if (v.startsWith('"')) v = JSON.parse(v);
+      arr.push(v);
+      fm[currentList] = arr;
+      continue;
+    }
+    const kv = /^([A-Za-z_][^:]*):(.*)$/.exec(line);
+    if (!kv) continue;
+    const key = kv[1];
+    const raw = kv[2].trim();
+    if (raw === "") {
+      fm[key] = [];
+      currentList = key;
+      continue;
+    }
+    currentList = null;
+    if (raw === "true") fm[key] = true;
+    else if (raw === "false") fm[key] = false;
+    else if (raw === "[]") fm[key] = [];
+    else if (raw.startsWith('"')) fm[key] = JSON.parse(raw);
+    else fm[key] = raw;
+  }
+  return fm;
+}
+
+const noopLogger = {
+  debug: jest.fn(),
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+} as never;
+
+function makeStore(
+  fake: FakeApp,
+  settings: Record<string, unknown>,
+  overrides: {
+    baseline?: Record<string, unknown>;
+    applyRemote?: jest.Mock;
+  } = {},
+) {
+  const applyRemote =
+    overrides.applyRemote ??
+    jest.fn(async (field: string, value: unknown) => {
+      settings[field] = value;
+    });
+  const store = new VaultSettingsStore({
+    app: fake.asApp(),
+    logger: noopLogger,
+    getSettings: () => settings,
+    baseline: overrides.baseline ?? snapshot(settings),
+    applyRemote,
+    writeDebounceMs: 0,
+  });
+  return { store, applyRemote };
+}
+
+function snapshot(settings: Record<string, unknown>): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const d of VAULT_SETTINGS_REGISTRY) {
+    const v = settings[d.field];
+    out[d.field] = Array.isArray(v) ? [...v] : v;
+  }
+  return out;
+}
+
+function freshSettings(): Record<string, unknown> {
+  const s: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(DEFAULT_SETTINGS)) {
+    s[k] = Array.isArray(v) ? [...v] : v;
+  }
+  return s;
+}
+
+describe("VaultSettingsStore", () => {
+  describe("scan + overlay", () => {
+    it("applies a vault boolean over the data.json baseline", async () => {
+      const fake = new FakeApp();
+      fake.seedSettingAsset("showArchivedAssets", true); // default false
+      const settings = freshSettings();
+      const { store, applyRemote } = makeStore(fake, settings);
+
+      const overlaid = await store.applyScan(store.scanAll());
+
+      expect(overlaid).toEqual(["showArchivedAssets"]);
+      expect(applyRemote).toHaveBeenCalledWith("showArchivedAssets", true);
+      expect(settings.showArchivedAssets).toBe(true);
+    });
+
+    it("falls back to data.json when no asset exists (AC#1 fallback)", async () => {
+      const fake = new FakeApp();
+      const settings = freshSettings();
+      settings.showArchivedAssets = true; // user's data.json value
+      const { store, applyRemote } = makeStore(fake, settings);
+
+      const result = store.scanAll();
+      const overlaid = await store.applyScan(result);
+
+      expect(overlaid).toEqual([]);
+      expect(applyRemote).not.toHaveBeenCalled();
+      expect(settings.showArchivedAssets).toBe(true);
+      expect(result.missing.map((d) => d.field)).toContain(
+        "showArchivedAssets",
+      );
+    });
+
+    it("finds assets ANYWHERE in the vault (location-independent — AssetSpace mounts sync via ExoSync)", async () => {
+      const fake = new FakeApp();
+      fake.seedSettingAsset("layoutVisible", false, {
+        path: "assetspaces/kitelev/exoas-kitelev/settings/some-name.md",
+      });
+      const settings = freshSettings();
+      const { store } = makeStore(fake, settings);
+
+      await store.applyScan(store.scanAll());
+
+      expect(settings.layoutVisible).toBe(false);
+    });
+
+    it("does NOT overlay dirty fields (user toggled before scan) and pushes them to the vault instead", async () => {
+      const fake = new FakeApp();
+      const path = fake.seedSettingAsset("showArchivedAssets", false);
+      const settings = freshSettings();
+      const baseline = snapshot(settings); // baseline: false
+      settings.showArchivedAssets = true; // user toggled pre-scan
+      const { store, applyRemote } = makeStore(fake, settings, { baseline });
+
+      await store.applyScan(store.scanAll());
+      await store.flushWrites();
+
+      expect(applyRemote).not.toHaveBeenCalled();
+      expect(settings.showArchivedAssets).toBe(true);
+      expect(fake.files.get(path)!.frontmatter!.exo__Setting_value).toBe(true);
+    });
+
+    it("keeps data.json value and never rewrites the asset when the value is uncoercible", async () => {
+      const fake = new FakeApp();
+      const path = fake.seedSettingAsset("showArchivedAssets", {
+        nested: "object",
+      });
+      const settings = freshSettings();
+      const { store, applyRemote } = makeStore(fake, settings);
+
+      await store.applyScan(store.scanAll());
+      await store.flushWrites();
+
+      expect(applyRemote).not.toHaveBeenCalled();
+      expect(fake.processCalls).toEqual([]);
+      expect(
+        fake.files.get(path)!.frontmatter!.exo__Setting_value,
+      ).toEqual({ nested: "object" });
+    });
+
+    it("dedups duplicate assets deterministically (lexicographically smallest path wins)", async () => {
+      const fake = new FakeApp();
+      fake.seedSettingAsset("showArchivedAssets", true, { path: "b/dup.md" });
+      fake.seedSettingAsset("showArchivedAssets", false, { path: "a/dup.md" });
+      const settings = freshSettings();
+      const { store } = makeStore(fake, settings);
+
+      await store.applyScan(store.scanAll());
+
+      // a/dup.md (false) wins; default is false → no overlay applied.
+      expect(settings.showArchivedAssets).toBe(false);
+    });
+
+    it("warns and ignores assets referencing unknown SettingKeys (R3 forward-compat)", async () => {
+      const fake = new FakeApp();
+      fake.seedSettingAsset("showArchivedAssets", true, {
+        keyRef: "[[deadbeef-0000-4000-8000-000000000000]]",
+      });
+      const settings = freshSettings();
+      const { store } = makeStore(fake, settings);
+
+      const result = store.scanAll();
+
+      expect(result.entries.size).toBe(0);
+      expect((noopLogger as { warn: jest.Mock }).warn).toHaveBeenCalled();
+    });
+  });
+
+  describe("coercion matrix (F9)", () => {
+    it.each([
+      ["boolean", true, true],
+      ["boolean", "true", true],
+      ["boolean", "False", false],
+      ["boolean", 1, undefined],
+    ])("boolean: %p → %p", async (_dt, raw, expected) => {
+      const fake = new FakeApp();
+      fake.seedSettingAsset("showArchivedAssets", raw);
+      const settings = freshSettings();
+      settings.showArchivedAssets = "SENTINEL";
+      const { store } = makeStore(fake, settings);
+      await store.applyScan(store.scanAll());
+      if (expected === undefined) {
+        expect(settings.showArchivedAssets).toBe("SENTINEL");
+      } else {
+        expect(settings.showArchivedAssets).toBe(expected);
+      }
+    });
+
+    it("string: number coerces, object does not", async () => {
+      const fake = new FakeApp();
+      fake.seedSettingAsset("displayNameTemplate", 42);
+      const settings = freshSettings();
+      const { store } = makeStore(fake, settings);
+      await store.applyScan(store.scanAll());
+      expect(settings.displayNameTemplate).toBe("42");
+    });
+
+    it("stringList: scalar string becomes a 1-element list; non-string entries are dropped", async () => {
+      const fake = new FakeApp();
+      fake.seedSettingAsset("excludedFolders", "09 Templates");
+      const settings = freshSettings();
+      settings.excludedFolders = [];
+      const { store } = makeStore(fake, settings);
+      await store.applyScan(store.scanAll());
+      // normaliseExcludedFolders appends the trailing slash.
+      expect(settings.excludedFolders).toEqual(["09 Templates/"]);
+    });
+  });
+
+  describe("lazyBootstrapFolders merge policy (F8 / anti-#3279)", () => {
+    it("applies union(defaults, asset) and does NOT write the union back", async () => {
+      const fake = new FakeApp();
+      const path = fake.seedSettingAsset("lazyBootstrapFolders", [
+        "assetspaces/kitelev",
+      ]);
+      const settings = freshSettings();
+      const { store } = makeStore(fake, settings);
+
+      await store.applyScan(store.scanAll());
+      await store.flushWrites();
+
+      expect(settings.lazyBootstrapFolders).toEqual([
+        ...DEFAULT_SETTINGS.lazyBootstrapFolders,
+        "assetspaces/kitelev/",
+      ]);
+      // No write-back: asset keeps the user's short list.
+      expect(fake.processCalls).toEqual([]);
+      expect(
+        fake.files.get(path)!.frontmatter!.exo__Setting_value,
+      ).toEqual(["assetspaces/kitelev"]);
+    });
+
+    it("a stale asset cannot shadow newly-added defaults", async () => {
+      const fake = new FakeApp();
+      fake.seedSettingAsset("lazyBootstrapFolders", ["assetspaces/exo/"]);
+      const settings = freshSettings();
+      const { store } = makeStore(fake, settings);
+
+      await store.applyScan(store.scanAll());
+
+      for (const def of DEFAULT_SETTINGS.lazyBootstrapFolders) {
+        expect(settings.lazyBootstrapFolders).toContain(def);
+      }
+    });
+  });
+
+  describe("migration (one-shot, idempotent, 0-leakage)", () => {
+    it("creates assets for all missing registry fields with current data.json values", async () => {
+      const fake = new FakeApp();
+      const settings = freshSettings();
+      settings.showArchivedAssets = true;
+      const { store } = makeStore(fake, settings);
+
+      store.scanAll();
+      const created = await store.migrateMissing();
+
+      expect(created).toHaveLength(VAULT_SETTINGS_REGISTRY.length);
+      const d = descriptorByField("showArchivedAssets")!;
+      const file = fake.files.get(
+        `${DEFAULT_SETTINGS_FOLDER}/${d.settingUid}.md`,
+      )!;
+      expect(file.frontmatter!.exo__Setting_value).toBe(true);
+      expect(file.frontmatter!.exo__Asset_uid).toBe(d.settingUid);
+      expect(file.frontmatter!.exo__Setting_key).toBe(`[[${d.keyUid}]]`);
+      expect(file.frontmatter!.exo__Instance_class).toEqual([
+        `[[${SETTING_CLASS_UID}]]`,
+      ]);
+    });
+
+    it("is idempotent: second run creates nothing (per-key skip-existing)", async () => {
+      const fake = new FakeApp();
+      const settings = freshSettings();
+      const { store } = makeStore(fake, settings);
+
+      store.scanAll();
+      const first = await store.migrateMissing();
+      expect(first).toHaveLength(VAULT_SETTINGS_REGISTRY.length);
+
+      // Re-scan (as a fresh session would) and migrate again.
+      const { store: store2 } = makeStore(fake, settings);
+      store2.scanAll();
+      const second = await store2.migrateMissing();
+      expect(second).toHaveLength(0);
+      expect(fake.createCalls).toHaveLength(VAULT_SETTINGS_REGISTRY.length);
+    });
+
+    it("skips fields that already have an asset (partial migration)", async () => {
+      const fake = new FakeApp();
+      fake.seedSettingAsset("showArchivedAssets", true);
+      const settings = freshSettings();
+      const { store } = makeStore(fake, settings);
+
+      store.scanAll();
+      const created = await store.migrateMissing();
+
+      expect(created).toHaveLength(VAULT_SETTINGS_REGISTRY.length - 1);
+      expect(created).not.toContain("showArchivedAssets");
+    });
+
+    it("0-leakage: never creates assets for denylisted/per-device/unknown data.json keys", async () => {
+      const fake = new FakeApp();
+      const settings = freshSettings();
+      // Simulate a legacy/hostile data.json with per-device + secret keys.
+      settings.activeProfileUid = "some-uid";
+      settings._switchInProgress = true;
+      settings.pat = "ghp_SECRET";
+      settings.randomGarbageKey = "x";
+      const { store } = makeStore(fake, settings);
+
+      store.scanAll();
+      await store.migrateMissing();
+
+      expect(fake.createCalls).toHaveLength(VAULT_SETTINGS_REGISTRY.length);
+      const allBodies = Array.from(fake.files.values())
+        .map((f) => f.body)
+        .join("\n");
+      expect(allBodies).not.toContain("ghp_SECRET");
+      expect(allBodies).not.toContain("some-uid");
+      expect(allBodies).not.toContain("activeProfileUid");
+      expect(allBodies).not.toContain("_switchInProgress");
+    });
+
+    it("adopts a file that exists at the canonical path but was not classified (Sync race)", async () => {
+      const fake = new FakeApp();
+      const d = descriptorByField("showArchivedAssets")!;
+      const path = `${DEFAULT_SETTINGS_FOLDER}/${d.settingUid}.md`;
+      // File exists but with null frontmatter (e.g. cache not refreshed).
+      fake.files.set(path, { path, frontmatter: null, body: "" });
+      const settings = freshSettings();
+      const { store } = makeStore(fake, settings);
+
+      store.scanAll();
+      const created = await store.migrateMissing();
+
+      expect(created).not.toContain("showArchivedAssets");
+      expect(fake.createCalls).not.toContain(path);
+    });
+
+    it("throws when called before scanAll (F5 guard)", async () => {
+      const fake = new FakeApp();
+      const settings = freshSettings();
+      const { store } = makeStore(fake, settings);
+      await expect(store.migrateMissing()).rejects.toThrow(/scanAll/);
+    });
+  });
+
+  describe("UI → vault push (write-through)", () => {
+    async function setupMigrated() {
+      const fake = new FakeApp();
+      const settings = freshSettings();
+      const { store, applyRemote } = makeStore(fake, settings);
+      store.scanAll();
+      await store.migrateMissing();
+      return { fake, settings, store, applyRemote };
+    }
+
+    it("pushChangedFields writes the changed field to the asset", async () => {
+      const { fake, settings, store } = await setupMigrated();
+      const d = descriptorByField("enableShaclValidation")!;
+
+      settings.enableShaclValidation = true;
+      store.pushChangedFields();
+      await store.flushWrites();
+
+      const file = fake.files.get(
+        `${DEFAULT_SETTINGS_FOLDER}/${d.settingUid}.md`,
+      )!;
+      expect(file.frontmatter!.exo__Setting_value).toBe(true);
+      expect(file.frontmatter!.exo__Asset_updatedAt).toBeDefined();
+    });
+
+    it("no-ops when nothing changed", async () => {
+      const { fake, store } = await setupMigrated();
+      const callsBefore = fake.processCalls.length;
+
+      store.pushChangedFields();
+      await store.flushWrites();
+
+      expect(fake.processCalls.length).toBe(callsBefore);
+    });
+
+    it("never creates a missing asset on push (F2 — no duplicate factory)", async () => {
+      const fake = new FakeApp();
+      const settings = freshSettings();
+      const { store } = makeStore(fake, settings);
+      store.scanAll(); // no assets at all, no migration
+
+      settings.showArchivedAssets = true;
+      store.pushChangedFields();
+      await store.flushWrites();
+
+      expect(fake.createCalls).toHaveLength(0);
+    });
+
+    it("skips the write when the asset transiently disappeared (ExoSync atomic-write window)", async () => {
+      const { fake, settings, store } = await setupMigrated();
+      const d = descriptorByField("enableShaclValidation")!;
+      const path = `${DEFAULT_SETTINGS_FOLDER}/${d.settingUid}.md`;
+      fake.files.delete(path); // transient disappearance
+
+      settings.enableShaclValidation = true;
+      store.pushChangedFields();
+      await store.flushWrites();
+
+      expect(fake.createCalls.filter((p) => p === path)).toHaveLength(1); // only the original migrate
+      expect(fake.files.has(path)).toBe(false);
+    });
+  });
+
+  describe("watcher (remote changes + echo suppression)", () => {
+    async function setupMigrated() {
+      const fake = new FakeApp();
+      const settings = freshSettings();
+      const { store, applyRemote } = makeStore(fake, settings);
+      store.scanAll();
+      await store.migrateMissing();
+      return { fake, settings, store, applyRemote };
+    }
+
+    function tfileOf(path: string): TFile {
+      return { path } as unknown as TFile;
+    }
+
+    it("applies a remote change arriving via sync", async () => {
+      const { fake, settings, store, applyRemote } = await setupMigrated();
+      const d = descriptorByField("showArchivedAssets")!;
+      const path = `${DEFAULT_SETTINGS_FOLDER}/${d.settingUid}.md`;
+      fake.files.get(path)!.frontmatter!.exo__Setting_value = true;
+
+      await store.onMetadataChanged(tfileOf(path));
+
+      expect(applyRemote).toHaveBeenCalledWith("showArchivedAssets", true);
+      expect(settings.showArchivedAssets).toBe(true);
+    });
+
+    it("swallows the echo of its own write (F1)", async () => {
+      const { fake, settings, store, applyRemote } = await setupMigrated();
+      const d = descriptorByField("enableShaclValidation")!;
+      const path = `${DEFAULT_SETTINGS_FOLDER}/${d.settingUid}.md`;
+
+      settings.enableShaclValidation = true;
+      store.pushChangedFields();
+      await store.flushWrites();
+      applyRemote.mockClear();
+
+      // The processFrontMatter write triggers metadataCache.changed.
+      await store.onMetadataChanged(tfileOf(path));
+
+      expect(applyRemote).not.toHaveBeenCalled();
+      expect(settings.enableShaclValidation).toBe(true);
+    });
+
+    it("ignores a stale intermediate state while a newer write is in flight (F1 double-toggle)", async () => {
+      const { fake, settings, store, applyRemote } = await setupMigrated();
+      const d = descriptorByField("enableShaclValidation")!;
+      const path = `${DEFAULT_SETTINGS_FOLDER}/${d.settingUid}.md`;
+
+      // First write lands (true)…
+      settings.enableShaclValidation = true;
+      store.pushChangedFields();
+      await store.flushWrites();
+      // …user immediately toggles back (false); write queued (pending=false).
+      settings.enableShaclValidation = false;
+      store.pushChangedFields();
+      await store.flushWrites();
+      applyRemote.mockClear();
+
+      // A stale changed-event replays the OLD on-disk state (true) — must
+      // NOT roll the user's newer action back. (Simulate by flipping the
+      // file back to true without going through the store.)
+      fake.files.get(path)!.frontmatter!.exo__Setting_value = true;
+      // Re-arm pending as if the second write were still in flight:
+      settings.enableShaclValidation = true;
+      store.pushChangedFields(); // pending=true queued
+      settings.enableShaclValidation = false;
+      fake.files.get(path)!.frontmatter!.exo__Setting_value = false;
+      await store.flushWrites();
+      fake.files.get(path)!.frontmatter!.exo__Setting_value = true; // stale echo state
+
+      await store.onMetadataChanged(tfileOf(path));
+      // pending was false→…; stale "true" ≠ pending → swallowed, no rollback
+      expect(settings.enableShaclValidation).toBe(false);
+      expect(applyRemote).not.toHaveBeenCalled();
+    });
+
+    it("adopts a setting asset file that appears mid-session (Sync delivery)", async () => {
+      const { fake, settings, store, applyRemote } = await setupMigrated();
+      const d = descriptorByField("layoutVisible")!;
+      // Remove the migrated asset and deliver a relocated one.
+      fake.files.delete(`${DEFAULT_SETTINGS_FOLDER}/${d.settingUid}.md`);
+      store.onFileDeleted(`${DEFAULT_SETTINGS_FOLDER}/${d.settingUid}.md`);
+      const newPath = fake.seedSettingAsset("layoutVisible", false, {
+        path: "assetspaces/kitelev/exoas-kitelev/settings/relocated.md",
+      });
+
+      await store.onMetadataChanged(tfileOf(newPath));
+
+      expect(applyRemote).toHaveBeenCalledWith("layoutVisible", false);
+      expect(settings.layoutVisible).toBe(false);
+    });
+
+    it("keeps tracking across rename (user moves asset into an AssetSpace)", async () => {
+      const { fake, settings, store } = await setupMigrated();
+      const d = descriptorByField("enableShaclValidation")!;
+      const oldPath = `${DEFAULT_SETTINGS_FOLDER}/${d.settingUid}.md`;
+      const newPath = `assetspaces/kitelev/exoas-kitelev/${d.settingUid}.md`;
+      const f = fake.files.get(oldPath)!;
+      fake.files.delete(oldPath);
+      fake.files.set(newPath, { ...f, path: newPath });
+
+      store.onFileRenamed(tfileOf(newPath), oldPath);
+      settings.enableShaclValidation = true;
+      store.pushChangedFields();
+      await store.flushWrites();
+
+      expect(fake.files.get(newPath)!.frontmatter!.exo__Setting_value).toBe(
+        true,
+      );
+    });
+
+    it("a broken-YAML change event does not unregister or reset the setting (F11)", async () => {
+      const { fake, settings, store, applyRemote } = await setupMigrated();
+      const d = descriptorByField("showArchivedAssets")!;
+      const path = `${DEFAULT_SETTINGS_FOLDER}/${d.settingUid}.md`;
+      settings.showArchivedAssets = true;
+      fake.files.get(path)!.frontmatter = null; // YAML broke under hand-edit
+
+      await store.onMetadataChanged(tfileOf(path));
+
+      expect(applyRemote).not.toHaveBeenCalled();
+      expect(settings.showArchivedAssets).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Implements **onto-RFC `981b6070` Phase 5** (= ExoSync Phase D, task D2): the plugin's 23 homoiconizable settings become first-class vault assets of class `exo__Setting`, with `data.json` retained as a write-through mirror / fallback.

### What's in

- **`packages/exoas-exo` bump `23f25d8` → `6c0797e`** — D1 TBox (classes `exo__Setting` `88b938af` / `exo__SettingKey` `a37d39ec`, 3 properties, 23 SettingKey individuals). Precedent: C2 bumped for C1 (#3462).
- **`VaultSettingsRegistry`** (domain): allowlist of 23 field↔SettingKey bindings (19 boolean / 2 string / 2 stringList) + **fixed deterministic `exo__Asset_uid` per Setting instance** — independent migrations on two devices produce byte-identical paths, so file-level sync (Obsidian Sync / ExoSync / git) converges instead of duplicating.
- **`VaultSettingsStore`** (infrastructure):
  - class-based, **location-independent** discovery — users may move Setting assets into a materialized AssetSpace mount (`assetspaces/<owner>/<repo>/`) and **ExoSync Phase A syncs them with zero new sync code** (the engine already syncs every file under a mount);
  - tolerant datatype coercion ("true"/"false"→bool, scalar→1-elem list, …), canonicalized diffing (no rewrite war with hand-edited un-canonical assets);
  - sequential debounced (1 s) write queue + pending-echo suppression — a stale `metadataCache.changed` echo can never roll back a newer UI action;
  - one-shot **idempotent** migration (per-key skip-existing, adopt-on-exists for Sync races), gated on `_switchInProgress === false`; `writeValue` NEVER auto-creates (transient disappearance during ExoSync atomic writes / profile apply is normal);
  - `lazyBootstrapFolders` applied as `union(defaults, asset)` **without write-back** — a stale asset cannot shadow newly-added defaults (anti-regression #3279).
- **`ExocortexPlugin` wiring**: init inside the existing #2780 `metadataCache.resolved` one-shot (scanning earlier reads null frontmatter → would mis-create duplicates on cold start); cold-start dirty-field protection (user toggles before the scan win and are pushed to the vault); `saveSettings()` funnel intercept covers all 32 SettingTab controls + palette commands + DailyTasksRenderer without touching call sites; remote applies run the same side-effect hooks as the SettingTab.
- **Docs**: `docs/settings-homoiconization.md`.

### Per-device denylist (0 leakage)

Migration iterates the **allowlist only**: `activeProfileUid` / `_switchInProgress` (data.local.json, #3327), PAT (`LocalSecretsStore`), structural `displayNameSettings` / `logChannels` (deferred per onto-RFC D26) can never become vault assets, regardless of what extra keys data.json carries. Unit test seeds a hostile data.json with `pat`/`activeProfileUid` and asserts zero leakage into created assets.

### Tests

- 44 new unit tests across 2 suites:
  - **registry↔graph parity** against `packages/exoas-exo/exo/*.md` (23 individuals: uid+label+datatype 1:1, both directions) — onto-RFC R3 anti-drift CI check; a new `ExocortexSettings` field not present in registry-or-denylist fails CI with an actionable message;
  - store: coercion matrix, dedup (lexicographic winner), echo races (incl. double-toggle stale-echo), migration idempotency (2nd run = 0 created), 0-leakage, transient-delete (no auto-create), rename/relocation tracking, broken-YAML tolerance.
- **Empirically verified to FAIL pre-fix and PASS post-fix**: with overlay+migration logic temporarily reverted — 18/31 store tests fail; restored — 44/44 pass.
- Full plugin unit suite: **260 suites / 5121 passed, 0 failed** locally.

### Known limitations (documented)

- Sync-vs-UI TOCTOU (vault wins, sub-second window on manual on-command sync) — accepted for MVP, documented in docs.
- `exo__Setting_value` carries 3 datatypes under one property name — Obsidian Properties UI may show a widget type-mismatch hint (cemented by D1 TBox; tolerant coercion + docs).
- Pre-existing engine quirk (D1 finding): CLI SHACL validator synthesizes `uid:` focus-nodes → each Setting instance yields a phantom `sh:minCount` on CLI validate runs. Engine-side, predates this PR; follow-up issue to be filed.

### Refs

- onto-RFC: vault `981b6070-c226-4e30-bb3a-9c44952a327b` (Phase 5)
- Parent RFC ExoSync: `4e4dc453` (D6/D23/D24/D26, VL#17)
- Prereqs: D1 TBox (exoas-exo `6c0797e`), Phase A v16.75-77.0, Phase B v16.78.0 (#3461), C2 v16.79.0 (#3462)