### PR TITLE
fix(mobile): lazy node:* requires unblock plugin load on iOS + triple regression gate

### DIFF
--- a/.archgate/adrs/MOBILE-001-no-toplevel-node-imports.md
+++ b/.archgate/adrs/MOBILE-001-no-toplevel-node-imports.md
@@ -1,0 +1,57 @@
+---
+id: MOBILE-001
+title: No top-level Node builtin imports in plugin src
+domain: frontend
+rules: true
+files:
+  [
+    "packages/obsidian-plugin/src/**/*.ts",
+    "packages/obsidian-plugin/src/**/*.tsx",
+  ]
+---
+
+# No Top-Level Node Builtin Imports in Plugin Src
+
+## Context
+
+The Obsidian plugin targets mobile (`manifest.json` sets `isDesktopOnly: false`).
+Obsidian mobile (iOS/Android) runs the plugin in a WebView **without a Node.js
+runtime**. The plugin bundle is CJS with Node builtins marked external in
+`esbuild.config.mjs`, so a top-level `import { x } from "node:fs"` compiles to a
+**module-eval-level** `require("node:fs")` in `main.js`. On mobile that require
+throws while the bundle is being evaluated and the WHOLE plugin fails to load
+(«Failed to load plugin») — regardless of any `Platform.isMobile` guards inside
+methods, because the import executes before any method runs.
+
+This exact regression shipped in v16.51.0 (`GitSubmoduleOps.ts`, PR #3337) and
+broke plugin load on iOS for ~30 releases unnoticed (Issue #3464). An ESLint
+rule (`no-restricted-imports`) banning these imports already existed, but the
+offending files bypassed it with `/* eslint-disable */` comments. This archgate
+rule does NOT honour eslint-disable comments — it closes that bypass.
+
+## Decision
+
+- Top-level **value** imports of Node builtins (`node:*` prefix or bare
+  `fs`/`path`/`os`/`child_process`/...) are FORBIDDEN in
+  `packages/obsidian-plugin/src/**`.
+- `import type ... from "node:*"` and `typeof import("node:*")` are ALLOWED —
+  they are erased at compile time and never reach the bundle.
+- Desktop-only code MUST access Node builtins lazily via
+  `src/infrastructure/adapters/lazyNodeModules.ts` (`require` inside a
+  function body, executed only behind a `Platform.isMobile` guard).
+- The release build additionally runs `scripts/assert-mobile-loadable.mjs`,
+  which module-evals the built `main.js` with a require-shim that throws on
+  Node builtins — proving the bundle loads without Node.
+
+## Consequences
+
+- Mobile plugin load can never again be broken by a stray top-level Node
+  import: archgate (required CI check) fails the PR.
+- Desktop-only adapters pay one extra function call per Node module access
+  (lazy `require` is cached by the CJS module cache — negligible).
+
+## Verification
+
+Empirically verified 2026-06-10: reverting one adapter to a top-level
+`import { promises as fs } from "node:fs"` turns archgate red
+(revert→fail); the lazy-require form is green (restore→pass).

--- a/.archgate/adrs/MOBILE-001-no-toplevel-node-imports.rules.ts
+++ b/.archgate/adrs/MOBILE-001-no-toplevel-node-imports.rules.ts
@@ -1,0 +1,141 @@
+/// <reference path="../rules.d.ts" />
+
+// MOBILE-001 — ban top-level Node builtin VALUE imports in plugin src.
+//
+// Obsidian mobile has no Node runtime; the bundle is CJS with builtins
+// external, so a top-level `import ... from "node:fs"` becomes a
+// module-eval-level `require("node:fs")` that crashes plugin load on iOS
+// (Issue #3464, shipped in v16.51.0). `import type` is allowed (erased at
+// compile time). Desktop-only code must go through the lazy accessors in
+// `src/infrastructure/adapters/lazyNodeModules.ts`.
+//
+// NOTE: an eslint no-restricted-imports rule covers the same ground but is
+// bypassable with `/* eslint-disable */` comments — which is exactly how the
+// v16.51.0 regression shipped. This rule ignores eslint-disable comments.
+
+// Bare builtin specifiers (the `node:`-prefix variant is matched separately).
+const NODE_BUILTINS = new Set([
+  "assert",
+  "async_hooks",
+  "buffer",
+  "child_process",
+  "cluster",
+  "console",
+  "constants",
+  "crypto",
+  "dgram",
+  "dns",
+  "domain",
+  "events",
+  "fs",
+  "http",
+  "http2",
+  "https",
+  "inspector",
+  "module",
+  "net",
+  "os",
+  "path",
+  "perf_hooks",
+  "process",
+  "punycode",
+  "querystring",
+  "readline",
+  "repl",
+  "stream",
+  "string_decoder",
+  "timers",
+  "tls",
+  "tty",
+  "url",
+  "util",
+  "v8",
+  "vm",
+  "worker_threads",
+  "zlib",
+]);
+
+/**
+ * Extract the module specifier targeted by an import/export-from line, or
+ * null if the line is not an import/export-from statement fragment.
+ * Handles `from "x"`, side-effect `import "x"`, and `require("x")` is NOT
+ * matched here (lazyNodeModules.ts is the sanctioned require location).
+ */
+function importedSpecifier(line: string): string | null {
+  const fromMatch = line.match(/\bfrom\s+["']([^"']+)["']/);
+  if (fromMatch) return fromMatch[1];
+  const sideEffectMatch = line.match(/^\s*import\s+["']([^"']+)["']/);
+  if (sideEffectMatch) return sideEffectMatch[1];
+  return null;
+}
+
+function isNodeBuiltin(specifier: string): boolean {
+  if (specifier.startsWith("node:")) return true;
+  // Strip subpath (`fs/promises` → `fs`).
+  const root = specifier.split("/")[0];
+  return NODE_BUILTINS.has(root);
+}
+
+/**
+ * Walk UP from the hit line to the line that opens the statement, so
+ * multi-line imports (`import type {\n ...\n} from "node:fs"`) are judged by
+ * their `import type` head, not by the closing-brace line the grep hit.
+ */
+function statementHead(lines: string[], hitLineIdx: number): string {
+  for (let i = hitLineIdx; i >= 0; i--) {
+    const line = lines[i];
+    if (/^\s*(import|export)\b/.test(line)) return line;
+    // Statement boundary without an import/export head — give up, treat the
+    // hit line itself as the head (conservative: will NOT be type-exempt).
+    if (i < hitLineIdx && /;\s*$/.test(line)) break;
+  }
+  return lines[hitLineIdx];
+}
+
+export default {
+  rules: {
+    "no-toplevel-node-imports-in-plugin": {
+      description:
+        "Top-level Node builtin value imports in plugin src crash plugin load on Obsidian mobile (Issue #3464)",
+      severity: "error",
+      async check(ctx) {
+        const files = await ctx.glob(
+          "packages/obsidian-plugin/src/**/*.{ts,tsx}",
+        );
+        for (const file of files) {
+          const hits = await ctx.grep(file, /\bfrom\s+["'][^"']+["']|^\s*import\s+["'][^"']+["']/);
+          if (hits.length === 0) continue;
+          const content = await ctx.readFile(file);
+          const lines = content.split("\n");
+          for (const hit of hits) {
+            const line = lines[hit.line - 1] || "";
+            // Skip comment lines (doc comments routinely QUOTE the banned
+            // form when explaining this very rule, e.g. lazyNodeModules.ts).
+            const trimmed = line.trimStart();
+            if (
+              trimmed.startsWith("*") ||
+              trimmed.startsWith("//") ||
+              trimmed.startsWith("/*")
+            ) {
+              continue;
+            }
+            const spec = importedSpecifier(line);
+            if (spec === null || !isNodeBuiltin(spec)) continue;
+            const head = statementHead(lines, hit.line - 1);
+            // Type-only imports/exports are erased at compile time — allowed.
+            if (/^\s*import\s+type\b/.test(head)) continue;
+            if (/^\s*export\s+type\b/.test(head)) continue;
+
+            ctx.report.violation({
+              message:
+                `Top-level Node builtin import ("${spec}") in plugin src — compiles to a module-eval require() that crashes plugin load on Obsidian mobile (Issue #3464). eslint-disable does NOT exempt this.`,
+              file: hit.file,
+              line: hit.line,
+              fix: "Use the lazy accessors in src/infrastructure/adapters/lazyNodeModules.ts inside a mobile-guarded method, or `import type` if only types are needed.",
+            });
+          }
+        }
+      },
+    },
+  },
+} satisfies RuleSet;

--- a/.archgate/adrs/MOBILE-001-no-toplevel-node-imports.rules.ts
+++ b/.archgate/adrs/MOBILE-001-no-toplevel-node-imports.rules.ts
@@ -170,6 +170,18 @@ export default {
               /\b(?:require|import)\s*\(\s*["']([^"']+)["']\s*\)/,
             );
             if (callMatch === null || !isNodeBuiltin(callMatch[1])) continue;
+            // `typeof import("node:x")` is a TYPE position — erased at
+            // compile time, explicitly allowed everywhere (see the
+            // lazyNodeModules.ts doc). The startsWith("import") guard is
+            // load-bearing: `typeof require("node:x")` EXECUTES the require
+            // at runtime and must stay flagged; only `typeof import(...)`
+            // is the TS type operator.
+            if (
+              callMatch[0].startsWith("import") &&
+              /\btypeof\s*$/.test(line.slice(0, callMatch.index))
+            ) {
+              continue;
+            }
 
             ctx.report.violation({
               message: `Direct require()/import() of Node builtin ("${callMatch[1]}") outside lazyNodeModules.ts — concentrate Node access in the sanctioned lazy module so mobile-load safety stays auditable (Issue #3464).`,

--- a/.archgate/adrs/MOBILE-001-no-toplevel-node-imports.rules.ts
+++ b/.archgate/adrs/MOBILE-001-no-toplevel-node-imports.rules.ts
@@ -137,5 +137,49 @@ export default {
         }
       },
     },
+
+    "no-node-requires-outside-lazy-module": {
+      description:
+        "require()/import() of Node builtins in plugin src is allowed ONLY in lazyNodeModules.ts (Issue #3464)",
+      severity: "error",
+      async check(ctx) {
+        const files = await ctx.glob(
+          "packages/obsidian-plugin/src/**/*.{ts,tsx}",
+        );
+        for (const file of files) {
+          // The single sanctioned location for lazy node:* requires.
+          if (file.endsWith("/lazyNodeModules.ts")) continue;
+          const hits = await ctx.grep(
+            file,
+            /\b(?:require|import)\s*\(\s*["'][^"']+["']\s*\)/,
+          );
+          if (hits.length === 0) continue;
+          const content = await ctx.readFile(file);
+          const lines = content.split("\n");
+          for (const hit of hits) {
+            const line = lines[hit.line - 1] || "";
+            const trimmed = line.trimStart();
+            if (
+              trimmed.startsWith("*") ||
+              trimmed.startsWith("//") ||
+              trimmed.startsWith("/*")
+            ) {
+              continue;
+            }
+            const callMatch = line.match(
+              /\b(?:require|import)\s*\(\s*["']([^"']+)["']\s*\)/,
+            );
+            if (callMatch === null || !isNodeBuiltin(callMatch[1])) continue;
+
+            ctx.report.violation({
+              message: `Direct require()/import() of Node builtin ("${callMatch[1]}") outside lazyNodeModules.ts — concentrate Node access in the sanctioned lazy module so mobile-load safety stays auditable (Issue #3464).`,
+              file: hit.file,
+              line: hit.line,
+              fix: "Import the matching accessor from src/infrastructure/adapters/lazyNodeModules.ts and call it inside a mobile-guarded method.",
+            });
+          }
+        }
+      },
+    },
   },
 } satisfies RuleSet;

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -598,6 +598,17 @@ jobs:
           # Visual tests run separately with --update-snapshots for CI
           npx playwright test -c packages/obsidian-plugin/playwright-ct.config.ts --grep-invert visual
 
+      # Issue #3464 — iPhone mobile-load E2E smoke. Module-evals the BUILT
+      # plugin bundle (produced by setup-node-pnpm run-build above) inside a
+      # real WebKit engine with iPhone emulation and a require-shim that
+      # throws on Node builtins — the closest CI-feasible reproduction of the
+      # Obsidian iOS load path (the closed-source iOS app cannot run in CI).
+      # Catches the v16.51.0 regression class: top-level `import ... from
+      # "node:*"` in plugin src → module-eval require → plugin fails to load
+      # on iOS. Empirically verified revert→fail / restore→pass.
+      - name: iPhone mobile-load smoke (WebKit, Issue #3464)
+        run: npx playwright test -c packages/obsidian-plugin/playwright-mobile-smoke.config.ts
+
       - name: Run visual regression tests (update snapshots if missing)
         run: |
           export NODE_OPTIONS="--max-old-space-size=4096"

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "scripts": {
     "dev": "npm run dev -w @exocortex/obsidian-plugin",
-    "build": "npm run build -w exocortex && npm run build -w @kitelev/exocortex-services && npm run build --workspaces --if-present && tsc -noEmit -skipLibCheck && node packages/obsidian-plugin/esbuild.config.mjs production",
+    "build": "npm run build -w exocortex && npm run build -w @kitelev/exocortex-services && npm run build --workspaces --if-present && tsc -noEmit -skipLibCheck && node packages/obsidian-plugin/esbuild.config.mjs production && node scripts/assert-mobile-loadable.mjs",
     "lint": "eslint packages/obsidian-plugin/src --ext .ts,.tsx",
     "lint:fix": "eslint packages/obsidian-plugin/src --ext .ts,.tsx --fix",
     "format": "prettier --write 'packages/**/*.{ts,tsx}'",

--- a/packages/obsidian-plugin/playwright-mobile-smoke.config.ts
+++ b/packages/obsidian-plugin/playwright-mobile-smoke.config.ts
@@ -1,0 +1,35 @@
+import { defineConfig, devices } from "@playwright/test";
+
+/**
+ * Mobile-load smoke config (Issue #3464).
+ *
+ * Runs the built plugin bundle through module-eval inside a REAL WebKit
+ * engine with iPhone emulation — the same JavaScript engine family as
+ * Obsidian iOS (WKWebView). Obsidian's closed-source iOS app cannot run in
+ * CI, so this is the closest faithful reproduction of the iPhone load path:
+ * WebKit + no Node runtime + a `require` shim that throws on Node builtins.
+ *
+ * Catches the v16.51.0 regression class: a top-level `import ... from
+ * "node:*"` in plugin src compiles to a module-eval-level require that
+ * crashes plugin load on iOS before any Platform.isMobile guard runs.
+ *
+ * CI: dedicated step in the `test-component` job (bundle is built there via
+ * setup-node-pnpm run-build). Locally: `npm run build` first, then
+ * `npx playwright test -c packages/obsidian-plugin/playwright-mobile-smoke.config.ts`.
+ */
+export default defineConfig({
+  testDir: "./tests/mobile-smoke",
+  timeout: 120_000,
+  fullyParallel: false,
+  retries: 0,
+  reporter: process.env.CI ? [["github"], ["list"]] : [["list"]],
+  projects: [
+    {
+      name: "ios-webkit",
+      use: {
+        ...devices["iPhone 14"],
+        browserName: "webkit",
+      },
+    },
+  ],
+});

--- a/packages/obsidian-plugin/src/infrastructure/adapters/AssetSpaceManager.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/AssetSpaceManager.ts
@@ -1,12 +1,10 @@
 // Node.js builtins required for Phase 5 apply staging dirs (RFC
 // 22b50a17) — staging dirs live in `os.tmpdir()` OUTSIDE the vault so
-// Obsidian's vault.adapter API cannot reach them. The `pullAssetSpace`
-// entry point is guarded by `Platform.isMobile` throw — on mobile the
-// code never executes (Phase 5 is desktop-only per RFC scope).
-/* eslint-disable no-restricted-imports, import/no-nodejs-modules */
-import { promises as fs } from "node:fs";
-import * as path from "node:path";
-/* eslint-enable no-restricted-imports, import/no-nodejs-modules */
+// Obsidian's vault.adapter API cannot reach them. Accessed LAZILY inside
+// `pullAssetSpace` (which is guarded by `Platform.isMobile` throw) — a
+// top-level node:* import would crash the whole bundle on mobile load
+// (Issue #3464).
+import { nodeFsPromises, nodePath } from "./lazyNodeModules";
 import type { App, TFile } from "obsidian";
 import { Platform } from "obsidian";
 import type { INotificationService } from "exocortex";
@@ -304,6 +302,10 @@ export class AssetSpaceManager {
       throw new Error("pullAssetSpace: asGitUrl is required");
     }
 
+    // Lazy node:* access — only reached on desktop (mobile threw above).
+    const fs = nodeFsPromises();
+    const path = nodePath();
+
     // Validate URL shape + extract owner/repo. validateRepoURL throws on
     // path traversal / scheme injection / non-github hosts.
     GitHubRestClient.validateRepoURL(asGitUrl);
@@ -376,9 +378,7 @@ export class AssetSpaceManager {
       return { asUid, stagingPath, sha };
     } catch (err) {
       // Best-effort cleanup of the partially-populated staging dir.
-      await this.stagingTracker
-        .release(stagingPath)
-        .catch(() => undefined);
+      await this.stagingTracker.release(stagingPath).catch(() => undefined);
       throw err;
     }
   }
@@ -482,24 +482,29 @@ export class AssetSpaceManager {
       // Dual-read `_source ?? _git` (RFC 01a83de8 v10 T3). The new
       // `exo__AssetSpace_source` supersedes legacy `_git`; both feed the same
       // `info.git` slot during the transition (Phase 1b retires `_git`).
-      const source = typeof fm["exo__AssetSpace_source"] === "string"
-        ? (fm["exo__AssetSpace_source"] as string)
-        : "";
-      const git = source || (typeof fm["exo__AssetSpace_git"] === "string"
-        ? (fm["exo__AssetSpace_git"] as string)
-        : "");
-      const namespace = typeof fm["exo__AssetSpace_namespace"] === "string"
-        ? (fm["exo__AssetSpace_namespace"] as string)
-        : "";
+      const source =
+        typeof fm["exo__AssetSpace_source"] === "string"
+          ? (fm["exo__AssetSpace_source"] as string)
+          : "";
+      const git =
+        source ||
+        (typeof fm["exo__AssetSpace_git"] === "string"
+          ? (fm["exo__AssetSpace_git"] as string)
+          : "");
+      const namespace =
+        typeof fm["exo__AssetSpace_namespace"] === "string"
+          ? (fm["exo__AssetSpace_namespace"] as string)
+          : "";
       if (!git || !namespace) return null;
       // RFC 01a83de8 Phase 1b T3 — folder = AssetSpace mount path derived from
       // `_source` (`assetspaces/<owner>/<repo>`), not the descriptor file's
       // parent folder (post-migration the descriptor lives in the registry).
       // parentFolder remains a defensive fallback for unresolvable sources.
       const folderName = derivePath(git) ?? parentFolder(file.path);
-      const lastPulledSha = typeof fm["exo__AssetSpace_lastPulledSha"] === "string"
-        ? (fm["exo__AssetSpace_lastPulledSha"] as string)
-        : undefined;
+      const lastPulledSha =
+        typeof fm["exo__AssetSpace_lastPulledSha"] === "string"
+          ? (fm["exo__AssetSpace_lastPulledSha"] as string)
+          : undefined;
       return { uid: asUid, git, namespace, folderName, lastPulledSha };
     }
     return null;
@@ -600,7 +605,9 @@ export function parseGitHubURL(url: string): { owner: string; repo: string } {
  */
 export function discoverWrapperDir(entries: ExtractedTarFile[]): string {
   if (entries.length === 0) {
-    throw new Error("discoverWrapperDir: cannot discover wrapper of empty entry list");
+    throw new Error(
+      "discoverWrapperDir: cannot discover wrapper of empty entry list",
+    );
   }
   const first = entries[0].path;
   const slashIdx = first.indexOf("/");

--- a/packages/obsidian-plugin/src/infrastructure/adapters/GitSubmoduleOps.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/GitSubmoduleOps.ts
@@ -1,13 +1,41 @@
-/* eslint-disable no-restricted-imports, import/no-nodejs-modules */
-import { execFile as execFileCb } from "node:child_process";
-import { promisify } from "node:util";
-import { promises as fs } from "node:fs";
-import * as path from "node:path";
-import { randomBytes } from "node:crypto";
-/* eslint-enable no-restricted-imports, import/no-nodejs-modules */
 import { Platform } from "obsidian";
+import {
+  nodeChildProcess,
+  nodeCrypto,
+  nodeFsPromises,
+  nodePath,
+  nodeUtil,
+} from "./lazyNodeModules";
 
-const execFile = promisify(execFileCb);
+/**
+ * Minimal shape of `promisify(child_process.execFile)` that this class
+ * consumes. Declared explicitly (instead of `typeof promisify(execFile)`)
+ * because the promisified default is now constructed LAZILY — a module-eval
+ * `promisify(execFileCb)` would require `node:*` at bundle load and crash
+ * Obsidian mobile (Issue #3464).
+ */
+export type ExecFileFn = (
+  file: string,
+  args: string[],
+  options: {
+    cwd?: string;
+    timeout?: number;
+    maxBuffer?: number;
+    env?: NodeJS.ProcessEnv;
+  },
+) => Promise<{ stdout: string | Buffer; stderr: string | Buffer }>;
+
+let defaultExecFile: ExecFileFn | null = null;
+
+/** Lazily build (and cache) the promisified `execFile` — desktop-only path. */
+function getDefaultExecFile(): ExecFileFn {
+  if (defaultExecFile === null) {
+    const { execFile } = nodeChildProcess();
+    const { promisify } = nodeUtil();
+    defaultExecFile = promisify(execFile) as unknown as ExecFileFn;
+  }
+  return defaultExecFile;
+}
 
 /**
  * GitSubmoduleOps — security-hardened wrapper for the git subprocess calls
@@ -52,7 +80,7 @@ export interface GitSubmoduleOpsOptions {
    */
   networkTimeoutMs?: number;
   /** Test injection: override the underlying `execFile`. */
-  execFileFn?: typeof execFile;
+  execFileFn?: ExecFileFn;
 }
 
 /**
@@ -77,7 +105,9 @@ export function validateVaultPathArg(arg: string): string {
     throw new Error(`GitSubmoduleOps: absolute path rejected: ${arg}`);
   }
   if (arg.startsWith("-")) {
-    throw new Error(`GitSubmoduleOps: leading-dash arg rejected (looks like flag): ${arg}`);
+    throw new Error(
+      `GitSubmoduleOps: leading-dash arg rejected (looks like flag): ${arg}`,
+    );
   }
   const normalized = arg.replace(/\\/g, "/").replace(/\/+$/, "");
   const segments = normalized.split("/");
@@ -117,11 +147,16 @@ export function validateGitUrl(url: string): string {
   if (url.startsWith("-")) {
     throw new Error(`GitSubmoduleOps: leading-dash URL rejected: ${url}`);
   }
-  const githubOk = /^https:\/\/github\.com\/[a-zA-Z0-9_-]+\/[a-zA-Z0-9_.-]+?(?:\.git)?$/.test(url);
+  const githubOk =
+    /^https:\/\/github\.com\/[a-zA-Z0-9_-]+\/[a-zA-Z0-9_.-]+?(?:\.git)?$/.test(
+      url,
+    );
   const isTestEnv = process.env.NODE_ENV === "test";
   const fileOk = isTestEnv && /^file:\/\/\/[a-zA-Z0-9_./-]+$/.test(url);
   if (!githubOk && !fileOk) {
-    throw new Error(`GitSubmoduleOps: invalid git URL shape (must be https://github.com/...): ${url}`);
+    throw new Error(
+      `GitSubmoduleOps: invalid git URL shape (must be https://github.com/...): ${url}`,
+    );
   }
   if (/[;|&$`()<>\n\r]/.test(url)) {
     throw new Error(`GitSubmoduleOps: shell metacharacter in URL: ${url}`);
@@ -133,16 +168,29 @@ export class GitSubmoduleOps {
   private readonly vaultRootPath: string;
   private readonly timeoutMs: number;
   private readonly networkTimeoutMs: number;
-  private readonly execFileFn: typeof execFile;
+  /**
+   * `null` = use the lazily-built promisified `execFile` (resolved on first
+   * {@link run} call, NOT at construction — keeps the ctor free of
+   * `node:child_process` so merely constructing on mobile can't crash).
+   */
+  private readonly execFileFn: ExecFileFn | null;
 
   constructor(options: GitSubmoduleOpsOptions) {
-    if (!options || typeof options.vaultRootPath !== "string" || options.vaultRootPath.length === 0) {
+    if (
+      !options ||
+      typeof options.vaultRootPath !== "string" ||
+      options.vaultRootPath.length === 0
+    ) {
       throw new Error("GitSubmoduleOps: vaultRootPath is required");
     }
-    this.vaultRootPath = path.resolve(options.vaultRootPath);
+    // NOTE: `nodePath()` performs a lazy `require("node:path")` — the ctor is
+    // only reached on desktop (all construction sites are gated by
+    // `Platform.isMobile`; see buildApplyDeps). Methods are additionally
+    // guarded via assertDesktop.
+    this.vaultRootPath = nodePath().resolve(options.vaultRootPath);
     this.timeoutMs = options.timeoutMs ?? 60_000;
     this.networkTimeoutMs = options.networkTimeoutMs ?? 300_000;
-    this.execFileFn = options.execFileFn ?? execFile;
+    this.execFileFn = options.execFileFn ?? null;
   }
 
   /**
@@ -179,12 +227,15 @@ export class GitSubmoduleOps {
         throw new Error(`GitSubmoduleOps.run: non-string arg`);
       }
       if (arg.startsWith("-") && !ALLOWED_FLAGS.has(arg)) {
-        throw new Error(`GitSubmoduleOps.run: disallowed flag argument: ${arg}`);
+        throw new Error(
+          `GitSubmoduleOps.run: disallowed flag argument: ${arg}`,
+        );
       }
     }
     const effectiveTimeout = opts.timeoutMs ?? this.timeoutMs;
+    const execFileFn = this.execFileFn ?? getDefaultExecFile();
     try {
-      const { stdout, stderr } = await this.execFileFn("git", Array.from(args), {
+      const { stdout, stderr } = await execFileFn("git", Array.from(args), {
         cwd: this.vaultRootPath,
         timeout: effectiveTimeout,
         maxBuffer: 16 * 1024 * 1024,
@@ -196,18 +247,30 @@ export class GitSubmoduleOps {
         env: stripGitEnv(),
       });
       return {
-        stdout: typeof stdout === "string" ? stdout : (stdout as Buffer).toString("utf8"),
-        stderr: typeof stderr === "string" ? stderr : (stderr as Buffer).toString("utf8"),
+        stdout:
+          typeof stdout === "string"
+            ? stdout
+            : (stdout as Buffer).toString("utf8"),
+        stderr:
+          typeof stderr === "string"
+            ? stderr
+            : (stderr as Buffer).toString("utf8"),
       };
     } catch (err) {
-      const e = err as { stderr?: string | Buffer; stdout?: string | Buffer; message?: string };
+      const e = err as {
+        stderr?: string | Buffer;
+        stdout?: string | Buffer;
+        message?: string;
+      };
       const stderr = e?.stderr
         ? typeof e.stderr === "string"
           ? e.stderr
           : e.stderr.toString("utf8")
         : "";
       const msg = e?.message ?? String(err);
-      throw new Error(`git ${args.join(" ")} failed: ${msg}${stderr ? ` — stderr: ${stderr}` : ""}`);
+      throw new Error(
+        `git ${args.join(" ")} failed: ${msg}${stderr ? ` — stderr: ${stderr}` : ""}`,
+      );
     }
   }
 
@@ -262,7 +325,9 @@ export class GitSubmoduleOps {
       throw new Error("GitSubmoduleOps.commit: message required");
     }
     if (/[\n\r]/.test(message)) {
-      throw new Error("GitSubmoduleOps.commit: newline in commit message rejected (use repeated -m args if needed)");
+      throw new Error(
+        "GitSubmoduleOps.commit: newline in commit message rejected (use repeated -m args if needed)",
+      );
     }
     await this.run(["commit", "-m", message]);
   }
@@ -280,12 +345,17 @@ export class GitSubmoduleOps {
    */
   async removeGitModulesDir(submodulePath: string): Promise<void> {
     this.assertDesktop("removeGitModulesDir");
+    const fs = nodeFsPromises();
+    const path = nodePath();
     const safe = validateVaultPathArg(submodulePath);
     // Resolve and verify the target is inside `<vault>/.git/modules/`.
     const target = path.resolve(this.vaultRootPath, ".git", "modules", safe);
-    const expectedPrefix = path.resolve(this.vaultRootPath, ".git", "modules") + path.sep;
+    const expectedPrefix =
+      path.resolve(this.vaultRootPath, ".git", "modules") + path.sep;
     if (!target.startsWith(expectedPrefix)) {
-      throw new Error(`GitSubmoduleOps.removeGitModulesDir: escape attempt: ${target}`);
+      throw new Error(
+        `GitSubmoduleOps.removeGitModulesDir: escape attempt: ${target}`,
+      );
     }
     await fs.rm(target, { recursive: true, force: true });
   }
@@ -296,11 +366,15 @@ export class GitSubmoduleOps {
    */
   async removeWorkingTree(submodulePath: string): Promise<void> {
     this.assertDesktop("removeWorkingTree");
+    const fs = nodeFsPromises();
+    const path = nodePath();
     const safe = validateVaultPathArg(submodulePath);
     const target = path.resolve(this.vaultRootPath, safe);
     const expectedPrefix = this.vaultRootPath + path.sep;
     if (!target.startsWith(expectedPrefix)) {
-      throw new Error(`GitSubmoduleOps.removeWorkingTree: escape attempt: ${target}`);
+      throw new Error(
+        `GitSubmoduleOps.removeWorkingTree: escape attempt: ${target}`,
+      );
     }
     await fs.rm(target, { recursive: true, force: true });
   }
@@ -309,8 +383,13 @@ export class GitSubmoduleOps {
    * `mv <stagingPath> <vault>/<submodulePath>` — materialize tarball
    * contents into vault location. Both args validated.
    */
-  async renameIntoVault(stagingPath: string, submodulePath: string): Promise<void> {
+  async renameIntoVault(
+    stagingPath: string,
+    submodulePath: string,
+  ): Promise<void> {
     this.assertDesktop("renameIntoVault");
+    const fs = nodeFsPromises();
+    const path = nodePath();
     if (typeof stagingPath !== "string" || stagingPath.length === 0) {
       throw new Error(`GitSubmoduleOps.renameIntoVault: stagingPath required`);
     }
@@ -319,7 +398,9 @@ export class GitSubmoduleOps {
     const target = path.resolve(this.vaultRootPath, safeSub);
     const expectedPrefix = this.vaultRootPath + path.sep;
     if (!target.startsWith(expectedPrefix)) {
-      throw new Error(`GitSubmoduleOps.renameIntoVault: escape attempt: ${target}`);
+      throw new Error(
+        `GitSubmoduleOps.renameIntoVault: escape attempt: ${target}`,
+      );
     }
     // fs.rename fails across devices (EXDEV). Detect-and-fallback:
     try {
@@ -347,6 +428,9 @@ export class GitSubmoduleOps {
    */
   async atomicGitmodulesEntryRemove(submodulePath: string): Promise<void> {
     this.assertDesktop("atomicGitmodulesEntryRemove");
+    const fs = nodeFsPromises();
+    const path = nodePath();
+    const { randomBytes } = nodeCrypto();
     const safe = validateVaultPathArg(submodulePath);
     const gitmodulesPath = path.resolve(this.vaultRootPath, ".gitmodules");
     let original: string;
@@ -375,6 +459,8 @@ export class GitSubmoduleOps {
    * `.gitmodules` returns empty set.
    */
   async readGitmodulesPaths(): Promise<Set<string>> {
+    const fs = nodeFsPromises();
+    const path = nodePath();
     const gitmodulesPath = path.resolve(this.vaultRootPath, ".gitmodules");
     let raw: string;
     try {
@@ -397,6 +483,8 @@ export class GitSubmoduleOps {
    * preserved URLs to re-materialise each tracked AssetSpace.
    */
   async readGitmodulesEntries(): Promise<GitmodulesEntry[]> {
+    const fs = nodeFsPromises();
+    const path = nodePath();
     const gitmodulesPath = path.resolve(this.vaultRootPath, ".gitmodules");
     let raw: string;
     try {
@@ -426,6 +514,8 @@ export class GitSubmoduleOps {
     url: string,
   ): Promise<{ added: boolean }> {
     this.assertDesktop("appendGitmodulesEntry");
+    const fs = nodeFsPromises();
+    const path = nodePath();
     const safePath = validateVaultPathArg(submodulePath);
     const safeUrl = validateGitUrl(url);
     const gitmodulesPath = path.resolve(this.vaultRootPath, ".gitmodules");
@@ -456,7 +546,9 @@ export class GitSubmoduleOps {
 
   private assertDesktop(op: string): void {
     if (isPlatformMobile()) {
-      throw new Error(`GitSubmoduleOps.${op}: mobile not supported (RFC 22b50a17 desktop-only)`);
+      throw new Error(
+        `GitSubmoduleOps.${op}: mobile not supported (RFC 22b50a17 desktop-only)`,
+      );
     }
   }
 }
@@ -507,11 +599,16 @@ export function stripGitEnv(): NodeJS.ProcessEnv {
  *
  * Exported for unit testing.
  */
-export function stripGitmodulesEntry(content: string, submodulePath: string): string {
+export function stripGitmodulesEntry(
+  content: string,
+  submodulePath: string,
+): string {
   const lines = content.split(/\r?\n/);
   const out: string[] = [];
   let skipping = false;
-  const headerPattern = new RegExp(`^\\[submodule\\s+"${escapeRegex(submodulePath)}"\\]\\s*$`);
+  const headerPattern = new RegExp(
+    `^\\[submodule\\s+"${escapeRegex(submodulePath)}"\\]\\s*$`,
+  );
   for (const line of lines) {
     if (skipping) {
       // Next stanza starts — stop skipping (do NOT consume the new header).
@@ -628,6 +725,8 @@ export function parseGitmodulesPaths(content: string): Set<string> {
 }
 
 async function copyDirRecursive(src: string, dest: string): Promise<void> {
+  const fs = nodeFsPromises();
+  const path = nodePath();
   await fs.mkdir(dest, { recursive: true });
   const entries = await fs.readdir(src, { withFileTypes: true });
   for (const entry of entries) {

--- a/packages/obsidian-plugin/src/infrastructure/adapters/ProfileApplyManager.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/ProfileApplyManager.ts
@@ -9,6 +9,7 @@ import {
 } from "exocortex";
 
 import { PluginLockManager } from "./PluginLockManager";
+import { nodeFsPromises } from "./lazyNodeModules";
 import type { AssetSpaceManager, AssetSpaceInfo } from "./AssetSpaceManager";
 import type { ICacheLayer } from "./SwitchCacheLayer";
 import type { GitSubmoduleOps } from "./GitSubmoduleOps";
@@ -1518,9 +1519,10 @@ export class ProfileApplyManager {
         await tracker.release(stagingPath).catch(() => undefined);
       } else {
         try {
-          /* eslint-disable-next-line import/no-nodejs-modules */
-          const fs = await import("node:fs");
-          await fs.promises.rm(stagingPath, { recursive: true, force: true });
+          // Lazy accessor (Issue #3464) — this branch is desktop-only
+          // (staging paths only exist after a desktop pull).
+          const fs = nodeFsPromises();
+          await fs.rm(stagingPath, { recursive: true, force: true });
         } catch {
           // best-effort
         }

--- a/packages/obsidian-plugin/src/infrastructure/adapters/StagingDirTracker.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/StagingDirTracker.ts
@@ -1,13 +1,10 @@
 // Node.js builtins required for Phase 5 apply staging dirs (RFC
 // 22b50a17) — staging dirs live в `os.tmpdir()` OUTSIDE the vault so
-// Obsidian's vault.adapter API cannot reach them. This file is only
-// instantiated on desktop — callers (AssetSpaceManager.pullAssetSpace +
-// ExocortexPlugin.onload sweepOrphans) guard via Platform.isMobile.
-/* eslint-disable no-restricted-imports, import/no-nodejs-modules */
-import { promises as fs } from "node:fs";
-import * as path from "node:path";
-import * as os from "node:os";
-/* eslint-enable no-restricted-imports, import/no-nodejs-modules */
+// Obsidian's vault.adapter API cannot reach them. Accessed LAZILY inside
+// methods — a top-level node:* import would crash the whole bundle on
+// mobile load (Issue #3464). Method callers (AssetSpaceManager.pullAssetSpace
+// + ExocortexPlugin.onload sweepOrphans) guard via Platform.isMobile.
+import { nodeFsPromises, nodeOs, nodePath } from "./lazyNodeModules";
 import type {
   PluginLocalDataStore,
   StagingDirEntry,
@@ -45,7 +42,14 @@ export interface StagingDirTrackerOptions {
  */
 export class StagingDirTracker {
   private readonly localDataStore: PluginLocalDataStore;
-  private readonly tmpdirBase: string;
+  /**
+   * `null` = resolve `os.tmpdir()` lazily on first {@link allocate} call.
+   * Deferred (NOT resolved in the ctor) so constructing the tracker never
+   * touches Node builtins — `buildAssetSpacePuller` constructs one on every
+   * Bootstrap / Add-AssetSpace invocation, and the ctor must stay safe even
+   * if a future caller reaches it on mobile (Issue #3464).
+   */
+  private readonly tmpdirBaseOverride: string | null;
 
   /**
    * Promise chain serializing `read-modify-write` of the registry. The
@@ -65,7 +69,7 @@ export class StagingDirTracker {
       throw new Error("StagingDirTracker: localDataStore is required");
     }
     this.localDataStore = opts.localDataStore;
-    this.tmpdirBase = opts.tmpdirBase ?? os.tmpdir();
+    this.tmpdirBaseOverride = opts.tmpdirBase ?? null;
   }
 
   /**
@@ -81,8 +85,11 @@ export class StagingDirTracker {
       throw new Error("StagingDirTracker.allocate: asUid is required");
     }
     return this.runSerial(async () => {
+      const fs = nodeFsPromises();
+      const path = nodePath();
+      const tmpdirBase = this.tmpdirBaseOverride ?? nodeOs().tmpdir();
       const sanitized = asUid.replace(/[^a-zA-Z0-9-]/g, "_");
-      const prefix = path.join(this.tmpdirBase, `exo-staging-${sanitized}-`);
+      const prefix = path.join(tmpdirBase, `exo-staging-${sanitized}-`);
       const dir = await fs.mkdtemp(prefix);
       try {
         const tracked = await this.localDataStore.readActiveStagingDirs();
@@ -126,6 +133,7 @@ export class StagingDirTracker {
   async release(stagingPath: string): Promise<void> {
     if (typeof stagingPath !== "string" || stagingPath.length === 0) return;
     return this.runSerial(async () => {
+      const fs = nodeFsPromises();
       await fs
         .rm(stagingPath, { recursive: true, force: true })
         .catch(() => undefined);
@@ -146,6 +154,7 @@ export class StagingDirTracker {
    */
   async sweepOrphans(): Promise<{ swept: number; tracked: number }> {
     return this.runSerial(async () => {
+      const fs = nodeFsPromises();
       const tracked = await this.localDataStore.readActiveStagingDirs();
       if (tracked.length === 0) return { swept: 0, tracked: 0 };
       let swept = 0;

--- a/packages/obsidian-plugin/src/infrastructure/adapters/SwitchCacheLayer.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/SwitchCacheLayer.ts
@@ -2,15 +2,19 @@
 // Obsidian vault — RFC 22b50a17 §Key sub-systems B.5. Default cache root
 // is `~/Library/Caches/exocortex/switch-cache/` (macOS desktop). Obsidian's
 // `vault.adapter` API only addresses vault-relative paths, so OS-level
-// caches must use Node directly. Mobile is guarded by `Platform.isMobile`
-// throw at every public entry point — Phase 5 apply is desktop-only.
-/* eslint-disable no-restricted-imports, import/no-nodejs-modules */
-import { promises as fsPromises } from "node:fs";
-import { existsSync, readdirSync, statSync, readFileSync } from "node:fs";
-import * as path from "node:path";
-import * as os from "node:os";
-import { randomBytes } from "node:crypto";
-/* eslint-enable no-restricted-imports, import/no-nodejs-modules */
+// caches must use Node directly. Accessed LAZILY inside methods — a
+// top-level node:* import would crash the whole bundle on mobile load
+// (Issue #3464). Mobile is guarded by `Platform.isMobile` throw at every
+// public entry point (getCacheStats returns zeros) — Phase 5 apply is
+// desktop-only, but the CLASS is constructed on mobile too (Settings tab
+// render + clear-switch-cache command), so the ctor must not touch Node.
+import {
+  nodeCrypto,
+  nodeFs,
+  nodeFsPromises,
+  nodeOs,
+  nodePath,
+} from "./lazyNodeModules";
 import { Platform } from "obsidian";
 import { createTarGzip, parseTarGzip, type TarFileInput } from "nanotar";
 
@@ -91,16 +95,38 @@ export class CacheMissError extends Error {
 }
 
 export class SwitchCacheLayer implements ICacheLayer {
-  private readonly cacheDir: string;
+  /** `null` = derive the default from `os.homedir()` lazily on first use. */
+  private readonly cacheDirOverride: string | null;
+  private cacheDirResolved: string | null = null;
 
   constructor(options: SwitchCacheLayerOptions = {}) {
-    this.cacheDir =
-      options.cacheDir ??
-      path.join(os.homedir(), "Library", "Caches", "exocortex", "switch-cache");
+    // No Node access here — the class is constructed on mobile too
+    // (ExocortexSettingTab.renderProfileSections + invokeClearSwitchCache),
+    // where only the mobile-safe getCacheStats() zeros-path runs.
+    this.cacheDirOverride = options.cacheDir ?? null;
   }
 
   getCacheDir(): string {
-    return this.cacheDir;
+    return this.resolveCacheDir();
+  }
+
+  /**
+   * Resolve (and memoize) the cache root. Requires Node (`os.homedir()`)
+   * when no override was injected — callers are desktop-only paths.
+   */
+  private resolveCacheDir(): string {
+    if (this.cacheDirResolved === null) {
+      this.cacheDirResolved =
+        this.cacheDirOverride ??
+        nodePath().join(
+          nodeOs().homedir(),
+          "Library",
+          "Caches",
+          "exocortex",
+          "switch-cache",
+        );
+    }
+    return this.cacheDirResolved;
   }
 
   /**
@@ -116,8 +142,14 @@ export class SwitchCacheLayer implements ICacheLayer {
     sha: string,
   ): Promise<CacheEntry> {
     this.assertDesktop("cache");
+    const { existsSync } = nodeFs();
+    const fsPromises = nodeFsPromises();
+    const path = nodePath();
+    const { randomBytes } = nodeCrypto();
     if (!existsSync(sourceDir)) {
-      throw new CacheWriteError(`Source directory does not exist: ${sourceDir}`);
+      throw new CacheWriteError(
+        `Source directory does not exist: ${sourceDir}`,
+      );
     }
     const cachePath = this.getCachePath(asUid, sha);
     const metaPath = this.getMetaPath(asUid, sha);
@@ -184,7 +216,9 @@ export class SwitchCacheLayer implements ICacheLayer {
     try {
       const parsed = await parseTarGzip(buf);
       if (!Array.isArray(parsed) || parsed.length === 0) {
-        await fsPromises.rm(cacheTmpPath, { force: true }).catch(() => undefined);
+        await fsPromises
+          .rm(cacheTmpPath, { force: true })
+          .catch(() => undefined);
         throw new CacheWriteError(
           `Cache archive has no entries: ${cacheTmpPath}`,
         );
@@ -257,13 +291,16 @@ export class SwitchCacheLayer implements ICacheLayer {
    */
   async has(asUid: string, expectedSha?: string): Promise<boolean> {
     this.assertDesktop("has");
+    const { existsSync } = nodeFs();
+    const fsPromises = nodeFsPromises();
+    const path = nodePath();
     if (expectedSha !== undefined) {
       return (
         existsSync(this.getCachePath(asUid, expectedSha)) &&
         existsSync(this.getMetaPath(asUid, expectedSha))
       );
     }
-    const dir = path.join(this.cacheDir, asUid);
+    const dir = path.join(this.resolveCacheDir(), asUid);
     if (!existsSync(dir)) return false;
     try {
       const entries = await fsPromises.readdir(dir);
@@ -272,7 +309,8 @@ export class SwitchCacheLayer implements ICacheLayer {
       const tarballShas = new Set<string>();
       const metaShas = new Set<string>();
       for (const e of entries) {
-        if (e.endsWith(".tar.gz")) tarballShas.add(e.slice(0, -".tar.gz".length));
+        if (e.endsWith(".tar.gz"))
+          tarballShas.add(e.slice(0, -".tar.gz".length));
         else if (e.endsWith(".meta.json"))
           metaShas.add(e.slice(0, -".meta.json".length));
       }
@@ -292,12 +330,12 @@ export class SwitchCacheLayer implements ICacheLayer {
    *
    * @throws CacheMissError if no cached entries exist.
    */
-  async restore(
-    asUid: string,
-    targetDir: string,
-  ): Promise<{ sha: string }> {
+  async restore(asUid: string, targetDir: string): Promise<{ sha: string }> {
     this.assertDesktop("restore");
-    const dir = path.join(this.cacheDir, asUid);
+    const { existsSync } = nodeFs();
+    const fsPromises = nodeFsPromises();
+    const path = nodePath();
+    const dir = path.join(this.resolveCacheDir(), asUid);
     if (!existsSync(dir)) {
       throw new CacheMissError(`No cache entries для ${asUid}`);
     }
@@ -373,7 +411,10 @@ export class SwitchCacheLayer implements ICacheLayer {
       const destPath = path.join(targetDir, item.name);
       const normalisedDest = path.resolve(destPath);
       const normalisedTarget = path.resolve(targetDir);
-      if (!normalisedDest.startsWith(normalisedTarget + path.sep) && normalisedDest !== normalisedTarget) {
+      if (
+        !normalisedDest.startsWith(normalisedTarget + path.sep) &&
+        normalisedDest !== normalisedTarget
+      ) {
         throw new CacheMissError(
           `Cache restore would escape target dir: ${item.name}`,
         );
@@ -399,16 +440,20 @@ export class SwitchCacheLayer implements ICacheLayer {
    */
   async clear(): Promise<{ entriesRemoved: number }> {
     this.assertDesktop("clear");
-    if (!existsSync(this.cacheDir)) return { entriesRemoved: 0 };
+    const { existsSync } = nodeFs();
+    const fsPromises = nodeFsPromises();
+    const path = nodePath();
+    const cacheDir = this.resolveCacheDir();
+    if (!existsSync(cacheDir)) return { entriesRemoved: 0 };
     let removed = 0;
     let asUidDirs: string[];
     try {
-      asUidDirs = await fsPromises.readdir(this.cacheDir);
+      asUidDirs = await fsPromises.readdir(cacheDir);
     } catch {
       return { entriesRemoved: 0 };
     }
     for (const name of asUidDirs) {
-      const fullDir = path.join(this.cacheDir, name);
+      const fullDir = path.join(cacheDir, name);
       let isDir: boolean;
       try {
         const stat = await fsPromises.stat(fullDir);
@@ -435,16 +480,20 @@ export class SwitchCacheLayer implements ICacheLayer {
    */
   async listEntries(): Promise<ReadonlyArray<CacheEntry>> {
     this.assertDesktop("listEntries");
-    if (!existsSync(this.cacheDir)) return [];
+    const { existsSync } = nodeFs();
+    const fsPromises = nodeFsPromises();
+    const path = nodePath();
+    const cacheDir = this.resolveCacheDir();
+    if (!existsSync(cacheDir)) return [];
     let asUidDirs: string[];
     try {
-      asUidDirs = await fsPromises.readdir(this.cacheDir);
+      asUidDirs = await fsPromises.readdir(cacheDir);
     } catch {
       return [];
     }
     const all: CacheEntry[] = [];
     for (const name of asUidDirs) {
-      const fullDir = path.join(this.cacheDir, name);
+      const fullDir = path.join(cacheDir, name);
       let isDir: boolean;
       try {
         const stat = await fsPromises.stat(fullDir);
@@ -500,12 +549,15 @@ export class SwitchCacheLayer implements ICacheLayer {
     if (isPlatformMobile()) {
       return { count: 0, totalSize: 0, oldestEntry: null };
     }
-    if (!existsSync(this.cacheDir)) {
+    const { existsSync, readdirSync, statSync, readFileSync } = nodeFs();
+    const path = nodePath();
+    const cacheDir = this.resolveCacheDir();
+    if (!existsSync(cacheDir)) {
       return { count: 0, totalSize: 0, oldestEntry: null };
     }
     let asUidDirs: string[];
     try {
-      asUidDirs = readdirSync(this.cacheDir);
+      asUidDirs = readdirSync(cacheDir);
     } catch {
       return { count: 0, totalSize: 0, oldestEntry: null };
     }
@@ -513,7 +565,7 @@ export class SwitchCacheLayer implements ICacheLayer {
     let totalSize = 0;
     let oldest: string | null = null;
     for (const name of asUidDirs) {
-      const fullDir = path.join(this.cacheDir, name);
+      const fullDir = path.join(cacheDir, name);
       let isDir: boolean;
       try {
         isDir = statSync(fullDir).isDirectory();
@@ -553,11 +605,11 @@ export class SwitchCacheLayer implements ICacheLayer {
   // ─────────────────────────── internals ──────────────────────────────────
 
   private getCachePath(asUid: string, sha: string): string {
-    return path.join(this.cacheDir, asUid, `${sha}.tar.gz`);
+    return nodePath().join(this.resolveCacheDir(), asUid, `${sha}.tar.gz`);
   }
 
   private getMetaPath(asUid: string, sha: string): string {
-    return path.join(this.cacheDir, asUid, `${sha}.meta.json`);
+    return nodePath().join(this.resolveCacheDir(), asUid, `${sha}.meta.json`);
   }
 
   private assertDesktop(op: string): void {
@@ -574,6 +626,8 @@ export class SwitchCacheLayer implements ICacheLayer {
    * directories so empty subdirs are preserved on restore.
    */
   private async collectTarInputs(sourceDir: string): Promise<TarFileInput[]> {
+    const fsPromises = nodeFsPromises();
+    const path = nodePath();
     const out: TarFileInput[] = [];
     const stack: Array<{ abs: string; rel: string }> = [
       { abs: sourceDir, rel: "" },

--- a/packages/obsidian-plugin/src/infrastructure/adapters/lazyNodeModules.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/lazyNodeModules.ts
@@ -1,0 +1,55 @@
+/**
+ * Lazy accessors for `node:*` builtins (Issue #3464).
+ *
+ * ⛔ NEVER import `node:*` (or bare `fs`/`path`/`os`/...) at TOP LEVEL in
+ * plugin src. The plugin bundle is CJS with Node builtins marked external —
+ * a top-level `import { x } from "node:fs"` compiles to a module-eval-level
+ * `require("node:fs")` in `main.js`. Obsidian mobile (iOS/Android WebView)
+ * has no Node runtime: that require throws WHILE the bundle is being
+ * evaluated and the whole plugin fails to load («Failed to load plugin»),
+ * regardless of any `Platform.isMobile` guards inside methods. This is
+ * exactly the v16.51.0 mobile regression (Issue #3464).
+ *
+ * These helpers defer the `require` to the first CALL — desktop-only
+ * adapters invoke them inside methods that are already mobile-guarded
+ * (`Platform.isMobile` throw / early return), so mobile never executes the
+ * require. `import type ... from "node:*"` and `typeof import("node:*")`
+ * remain allowed everywhere — they are erased at compile time.
+ *
+ * Enforcement: archgate MOBILE-001 bans top-level node:* value imports in
+ * plugin src; `scripts/assert-mobile-loadable.mjs` proves the built bundle
+ * module-evals without Node (runs in the release build).
+ */
+/* eslint-disable @typescript-eslint/no-require-imports, import/no-nodejs-modules --
+   this file is the SINGLE sanctioned location for lazy node:* requires (see
+   doc above). The requires here live inside function bodies — they never run
+   at module-eval, so the bundle stays mobile-loadable. archgate MOBILE-001 +
+   scripts/assert-mobile-loadable.mjs enforce that invariant mechanically. */
+
+export function nodeChildProcess(): typeof import("node:child_process") {
+  return require("node:child_process");
+}
+
+export function nodeUtil(): typeof import("node:util") {
+  return require("node:util");
+}
+
+export function nodeFs(): typeof import("node:fs") {
+  return require("node:fs");
+}
+
+export function nodeFsPromises(): (typeof import("node:fs"))["promises"] {
+  return nodeFs().promises;
+}
+
+export function nodePath(): typeof import("node:path") {
+  return require("node:path");
+}
+
+export function nodeOs(): typeof import("node:os") {
+  return require("node:os");
+}
+
+export function nodeCrypto(): typeof import("node:crypto") {
+  return require("node:crypto");
+}

--- a/packages/obsidian-plugin/tests/mobile-smoke/iphone-load.spec.ts
+++ b/packages/obsidian-plugin/tests/mobile-smoke/iphone-load.spec.ts
@@ -75,6 +75,52 @@ test.describe("iPhone mobile-load smoke (@mobile-load)", () => {
           });
         }
 
+        // Bare Node builtin names (the `node:` prefix is matched separately)
+        // — mirrors scripts/assert-mobile-loadable.mjs `builtinModules`
+        // classification so a try/catch-swallowed bare require is flagged
+        // here too, not only by the release-build gate.
+        const NODE_BUILTINS = new Set([
+          "assert",
+          "async_hooks",
+          "buffer",
+          "child_process",
+          "cluster",
+          "console",
+          "constants",
+          "crypto",
+          "dgram",
+          "dns",
+          "domain",
+          "electron",
+          "events",
+          "fs",
+          "http",
+          "http2",
+          "https",
+          "inspector",
+          "module",
+          "net",
+          "os",
+          "path",
+          "perf_hooks",
+          "process",
+          "punycode",
+          "querystring",
+          "readline",
+          "repl",
+          "stream",
+          "string_decoder",
+          "timers",
+          "tls",
+          "tty",
+          "url",
+          "util",
+          "v8",
+          "vm",
+          "worker_threads",
+          "zlib",
+        ]);
+
         // Mirrors Obsidian mobile's module surface: obsidian + CodeMirror
         // packages resolve; EVERYTHING else (node:*, bare builtins,
         // electron) is absent → throw, like the iOS WKWebView would.
@@ -87,7 +133,9 @@ test.describe("iPhone mobile-load smoke (@mobile-load)", () => {
           ) {
             return makeStub(id);
           }
-          if (id.startsWith("node:")) nodeRequireAttempts.push(id);
+          if (id.startsWith("node:") || NODE_BUILTINS.has(id.split("/")[0])) {
+            nodeRequireAttempts.push(id);
+          }
           throw new Error(
             `[iphone-sim] Cannot find module '${id}' (no Node runtime on Obsidian mobile)`,
           );

--- a/packages/obsidian-plugin/tests/mobile-smoke/iphone-load.spec.ts
+++ b/packages/obsidian-plugin/tests/mobile-smoke/iphone-load.spec.ts
@@ -1,0 +1,145 @@
+/**
+ * iPhone mobile-load E2E smoke (Issue #3464).
+ *
+ * Module-evals the BUILT plugin bundle (main.js) inside a real WebKit page
+ * with iPhone emulation. WebKit is the engine family of Obsidian iOS
+ * (WKWebView); the page has NO Node runtime, and the injected `require`
+ * shim throws for every module Obsidian mobile does not provide (Node
+ * builtins, electron, ...). Only `obsidian` / `@codemirror/*` / `@lezer/*`
+ * resolve — to inert stubs, exactly mirroring what Obsidian mobile injects.
+ *
+ * If module-eval completes and a plugin class is exported, the bundle can
+ * LOAD on an iPhone. The v16.51.0 regression (top-level
+ * `import ... from "node:child_process"` in GitSubmoduleOps → module-eval
+ * `require("node:child_process")` → «Failed to load plugin» on iOS) fails
+ * this spec. Empirically verified: revert→fail / restore→pass.
+ *
+ * Companion gates: archgate MOBILE-001 (source level, PR-time) and
+ * scripts/assert-mobile-loadable.mjs (Node VM eval, release build).
+ * This spec adds the real-WebKit-engine layer on top.
+ */
+import { test, expect } from "@playwright/test";
+import { readFileSync, existsSync } from "node:fs";
+import * as path from "node:path";
+
+const BUNDLE_PATH = path.resolve(__dirname, "..", "..", "main.js");
+
+interface MobileEvalResult {
+  ok: boolean;
+  error: string | null;
+  exportedType: string;
+  intercepted: string[];
+  nodeRequireAttempts: string[];
+}
+
+test.describe("iPhone mobile-load smoke (@mobile-load)", () => {
+  test("built main.js module-evals in WebKit without Node and exports the plugin class", async ({
+    page,
+  }) => {
+    expect(
+      existsSync(BUNDLE_PATH),
+      `Built bundle not found at ${BUNDLE_PATH} — run \`npm run build\` first (CI builds it via setup-node-pnpm run-build).`,
+    ).toBe(true);
+    const code = readFileSync(BUNDLE_PATH, "utf8");
+
+    await page.goto("about:blank");
+
+    const result = await page.evaluate<MobileEvalResult, { code: string }>(
+      ({ code: bundleCode }) => {
+        const intercepted: string[] = [];
+        const nodeRequireAttempts: string[] = [];
+
+        // Inert universal stub: callable, constructible, every property
+        // access returns another stub — enough for `class X extends
+        // obsidian.Plugin` and top-level destructuring at module-eval.
+        function makeStub(name: string): unknown {
+          const fn = function stub(): void {
+            /* noop */
+          };
+          return new Proxy(fn, {
+            get(target, prop): unknown {
+              if (prop === "prototype") {
+                return (target as { prototype: unknown }).prototype;
+              }
+              if (prop === Symbol.toPrimitive) {
+                return () => `[stub ${name}]`;
+              }
+              return makeStub(`${name}.${String(prop)}`);
+            },
+            construct(): object {
+              return {};
+            },
+            apply(): unknown {
+              return makeStub(`${name}()`);
+            },
+          });
+        }
+
+        // Mirrors Obsidian mobile's module surface: obsidian + CodeMirror
+        // packages resolve; EVERYTHING else (node:*, bare builtins,
+        // electron) is absent → throw, like the iOS WKWebView would.
+        const requireShim = (id: string): unknown => {
+          intercepted.push(id);
+          if (
+            id === "obsidian" ||
+            id.startsWith("@codemirror/") ||
+            id.startsWith("@lezer/")
+          ) {
+            return makeStub(id);
+          }
+          if (id.startsWith("node:")) nodeRequireAttempts.push(id);
+          throw new Error(
+            `[iphone-sim] Cannot find module '${id}' (no Node runtime on Obsidian mobile)`,
+          );
+        };
+
+        const moduleObj: { exports: Record<string, unknown> } = {
+          exports: {},
+        };
+        try {
+          // CJS module-eval, exactly how Obsidian loads plugin main.js.
+          const evaluate = new Function(
+            "module",
+            "exports",
+            "require",
+            bundleCode,
+          );
+          evaluate(moduleObj, moduleObj.exports, requireShim);
+        } catch (err) {
+          return {
+            ok: false,
+            error: err instanceof Error ? err.message : String(err),
+            exportedType: "n/a",
+            intercepted,
+            nodeRequireAttempts,
+          };
+        }
+        const exported =
+          (moduleObj.exports as { default?: unknown }).default ??
+          moduleObj.exports;
+        return {
+          ok: typeof exported === "function",
+          error: null,
+          exportedType: typeof exported,
+          intercepted,
+          nodeRequireAttempts,
+        };
+      },
+      { code },
+    );
+
+    expect(
+      result.error,
+      `Bundle failed module-eval under iPhone simulation (Issue #3464 regression class). ` +
+        `Node require attempts: [${result.nodeRequireAttempts.join(", ")}]`,
+    ).toBeNull();
+    expect(
+      result.nodeRequireAttempts,
+      "module-eval attempted Node builtin require(s) — even if swallowed, this is a mobile-load risk",
+    ).toEqual([]);
+    expect(
+      result.ok,
+      `module-eval completed but exported '${result.exportedType}' instead of the plugin class`,
+    ).toBe(true);
+  });
+});

--- a/scripts/assert-mobile-loadable.mjs
+++ b/scripts/assert-mobile-loadable.mjs
@@ -1,0 +1,153 @@
+#!/usr/bin/env node
+/**
+ * assert-mobile-loadable.mjs — Issue #3464 release-gate.
+ *
+ * Module-evals the built plugin bundle (main.js) in a sandbox whose
+ * `require` THROWS for every Node builtin (and electron) — simulating
+ * Obsidian mobile (iOS/Android WebView, no Node runtime). Only `obsidian`,
+ * `@codemirror/*` and `@lezer/*` (the modules Obsidian itself provides on
+ * mobile) resolve, to inert Proxy stubs.
+ *
+ * If module-eval completes and exports a plugin class, the bundle can at
+ * least LOAD on mobile. A top-level `require("node:*")` — the v16.51.0
+ * regression that broke iOS for ~30 releases — fails this script.
+ *
+ * Wired into the root `build` script, so every production build (incl. the
+ * Auto Release artifact) is gated. Companion PR-time source gate:
+ * .archgate/adrs/MOBILE-001-no-toplevel-node-imports.rules.ts
+ *
+ * Usage: node scripts/assert-mobile-loadable.mjs [path/to/main.js]
+ */
+import { readFileSync } from "node:fs";
+import { builtinModules } from "node:module";
+import vm from "node:vm";
+
+const bundlePath = process.argv[2] ?? "packages/obsidian-plugin/main.js";
+
+let code;
+try {
+  code = readFileSync(bundlePath, "utf8");
+} catch (err) {
+  console.error(
+    `❌ [mobile-loadable] cannot read bundle ${bundlePath}: ${err.message}`,
+  );
+  process.exit(1);
+}
+
+const BUILTIN_SET = new Set(builtinModules);
+const interceptedRequires = [];
+
+/**
+ * Inert universal stub: callable, constructible, and every property access
+ * returns another stub — enough for `class X extends obsidian.Plugin`,
+ * top-level destructuring, and decorator references at module-eval time.
+ */
+function makeStub(name) {
+  const fn = function stub() {};
+  return new Proxy(fn, {
+    get(target, prop) {
+      if (prop === "prototype") return target.prototype;
+      if (prop === Symbol.toPrimitive) return () => `[stub ${name}]`;
+      if (prop === "default") return makeStub(`${name}.default`);
+      return makeStub(`${name}.${String(prop)}`);
+    },
+    construct() {
+      return {};
+    },
+    apply() {
+      return makeStub(`${name}()`);
+    },
+  });
+}
+
+function mobileRequire(id) {
+  interceptedRequires.push(id);
+  if (
+    id === "obsidian" ||
+    id.startsWith("@codemirror/") ||
+    id.startsWith("@lezer/")
+  ) {
+    return makeStub(id);
+  }
+  // Everything else is absent on mobile: Node builtins (bare or node:-prefixed),
+  // electron, and any other external. Throw exactly like the WebView would.
+  const bare = id.startsWith("node:") ? id.slice(5) : id;
+  const kind =
+    BUILTIN_SET.has(bare) || BUILTIN_SET.has(id)
+      ? "Node builtin"
+      : "external module";
+  const err = new Error(
+    `[mobile-sim] Cannot find module '${id}' (${kind} — no Node runtime on Obsidian mobile)`,
+  );
+  err.code = "MODULE_NOT_FOUND";
+  throw err;
+}
+
+// Minimal WebView-ish globals. Obsidian mobile runs in a real browser
+// context; the bundle's module-eval phase must not need more than this.
+const moduleObj = { exports: {} };
+const sandbox = {
+  module: moduleObj,
+  exports: moduleObj.exports,
+  require: mobileRequire,
+  console,
+  setTimeout,
+  clearTimeout,
+  setInterval,
+  clearInterval,
+  queueMicrotask,
+  URL,
+  URLSearchParams,
+  TextEncoder,
+  TextDecoder,
+  navigator: { userAgent: "mobile-sim" },
+  window: makeStub("window"),
+  document: makeStub("document"),
+};
+sandbox.globalThis = sandbox;
+sandbox.self = sandbox;
+vm.createContext(sandbox);
+
+try {
+  vm.runInContext(code, sandbox, { filename: bundlePath, timeout: 60_000 });
+} catch (err) {
+  console.error(
+    `❌ [mobile-loadable] bundle FAILED module-eval under mobile simulation.\n` +
+      `   This is the Issue #3464 regression class: a module-eval-level require of a\n` +
+      `   Node builtin (top-level \`import ... from "node:*"\` in plugin src).\n` +
+      `   Error: ${err && err.message ? err.message : err}`,
+  );
+  process.exit(1);
+}
+
+const exported =
+  moduleObj.exports && (moduleObj.exports.default ?? moduleObj.exports);
+if (typeof exported !== "function") {
+  console.error(
+    `❌ [mobile-loadable] module-eval completed but no plugin class was exported ` +
+      `(got ${typeof exported}). Bundle shape unexpected — investigate before release.`,
+  );
+  process.exit(1);
+}
+
+const nodeRequires = interceptedRequires.filter((id) => {
+  const bare = id.startsWith("node:") ? id.slice(5) : id;
+  return BUILTIN_SET.has(bare) || BUILTIN_SET.has(id);
+});
+// Defense-in-depth: mobileRequire already throws on builtins, so reaching
+// here with nodeRequires non-empty is impossible unless the bundle swallowed
+// the throw at module-eval level (try/catch around a top-level require would
+// still be a mobile-correctness smell worth failing on).
+if (nodeRequires.length > 0) {
+  console.error(
+    `❌ [mobile-loadable] module-eval ATTEMPTED Node builtin require(s): ${[...new Set(nodeRequires)].join(", ")}\n` +
+      `   A top-level try/catch swallowed the throw — plugin load on mobile is still at risk.`,
+  );
+  process.exit(1);
+}
+
+console.log(
+  `✅ [mobile-loadable] ${bundlePath} module-evals without Node ` +
+    `(${interceptedRequires.length} require(s) intercepted: ${[...new Set(interceptedRequires)].join(", ") || "none"}). ` +
+    `Plugin class exported OK.`,
+);


### PR DESCRIPTION
Closes #3464

## Problem

Plugin fails to load on iOS («Failed to load plugin "Exocortex"») in **every release ≥ v16.51.0**. Root cause (verified by double bisect in the issue): top-level `import ... from "node:*"` in `GitSubmoduleOps.ts` (PR #3337) compiles to a **module-eval-level** `require("node:child_process")` in the CJS bundle. On iOS there is no Node runtime → the require throws while `main.js` is being evaluated → the whole plugin fails to load. Method-level `Platform.isMobile` guards never get the chance to run.

## Fix

All 4 adapters from the issue inventory (`GitSubmoduleOps`, `AssetSpaceManager`, `StagingDirTracker`, `SwitchCacheLayer`) now access Node builtins through **lazy accessors** — `src/infrastructure/adapters/lazyNodeModules.ts`, the single sanctioned location for `require("node:*")` (inside function bodies only). Desktop semantics unchanged.

Mobile-reachable construction paths hardened beyond the import fix:
- `SwitchCacheLayer` ctor no longer resolves `os.homedir()` — it is constructed **on mobile** (Settings tab render + `clear-switch-cache` command); cacheDir resolves lazily, `getCacheStats()` keeps its mobile zeros-path.
- `StagingDirTracker` ctor no longer calls `os.tmpdir()` — deferred to `allocate()`.
- `GitSubmoduleOps` no longer builds `promisify(execFile)` at module eval — lazy + cached; `execFileFn` option re-typed to explicit `ExecFileFn`.

## Bundle evidence (AC#1)

Built production bundle contains **zero** module-eval-level node requires; the only 6 `require("node:*")` occurrences sit inside lazy-helper function bodies:

```
function $3(){return require("node:child_process")} ...
```

`grep -oE 'var [A-Za-z0-9_$]+\s*=\s*require\("node:[a-z_]*"\)' main.js` → empty (the v16.51.0 bundle had `var V4=require("node:child_process")`).

## Triple regression gate (each verified revert→fail / restore→pass)

| # | Gate | Where it runs | Mechanism |
|---|---|---|---|
| 1 | **archgate `MOBILE-001`** | `archgate` required CI check (PR-time) | Bans top-level Node builtin **value** imports in `packages/obsidian-plugin/src/**` (`import type` allowed). Immune to the `/* eslint-disable */` bypass that let the regression ship for ~30 releases. |
| 2 | **`scripts/assert-mobile-loadable.mjs`** | root `npm run build` → **Auto Release** | Module-evals built `main.js` in a Node VM whose `require` throws on Node builtins/electron (only `obsidian`/`@codemirror/*`/`@lezer/*` resolve to stubs). Release artifact cannot ship broken. |
| 3 | **iPhone WebKit E2E smoke** | `test-component` required CI job (PR-time) | Playwright **webkit** + iPhone 14 emulation: module-evals the built bundle inside a real WebKit page (same engine family as Obsidian iOS WKWebView) with the mobile require-shim; asserts plugin class exports. Obsidian's closed-source iOS app cannot run in CI — this is the closest faithful reproduction of the iPhone load path. |

Empirical verification log (local):
- Re-adding `import { promises as fs } from "node:fs"` to GitSubmoduleOps → archgate red (`MOBILE-001 ... GitSubmoduleOps.ts:1`), `assert-mobile-loadable` exit 1 (`Cannot find module 'node:fs'`), WebKit spec red (`Node require attempts: [node:fs]`).
- Restored → all three green.

## Desktop regression check (AC#2)

172/172 affected tests green, including real-git integration suites (`ApplyGitSubmoduleOps.integration`, `ApplyEndToEnd.integration`, `AssetSpaceManager.integration`, `BootstrapAssetSpace.integration`, `ApplyDepsFactory.integration`). `tsc -noEmit` clean, eslint clean, prettier clean.

## Notes for reviewers

- `eslint-disable` comments removed from all 4 adapters; the one remaining disable lives in `lazyNodeModules.ts` with justification (sanctioned require location).
- test-component job builds the bundle already (`setup-node-pnpm run-build: true`) — gate 2 runs there too as part of the build, gate 3 as a dedicated step. Playwright lockfile version (1.57.0) matches the CI container image `v1.57.0-jammy`, webkit preinstalled.