### PR TITLE
fix(exosync): #3475 — drop already-in-HEAD files before push; never land phantom/empty commits

### DIFF
--- a/packages/exocortex/src/services/sync/SyncEngine.ts
+++ b/packages/exocortex/src/services/sync/SyncEngine.ts
@@ -343,6 +343,13 @@ type PushLoopOutcome =
       merge: MergeResolution;
       /** REMOTE paths excluded by the size cap (file mode) — pinned by the caller. */
       remoteOversized: Set<string>;
+      /**
+       * Detected-but-NOT-pushed paths whose bytes were already identical in
+       * the examined head tree (#3475 phantom-commit guard). Non-empty ⇒ the
+       * per-file watermark snapshot is stale for these paths — the caller
+       * must fall through to the full watermark rebuild so they converge.
+       */
+      alreadyInHead: string[];
     };
 
 const EMPTY_MERGE: MergeResolution = {
@@ -354,6 +361,11 @@ const EMPTY_MERGE: MergeResolution = {
   mergedPaths: [],
   warnings: [],
 };
+
+/** path → blobSha lookup over a (raw) remote tree listing. */
+function treeByPath(entries: RemoteTreeEntry[]): Map<string, string> {
+  return new Map(entries.map((e) => [e.path, e.blobSha]));
+}
 
 /** Per-path quarantine identity for `RepoSyncResult.quarantinedPaths` (E1). */
 function quarantinedPathsOf(merge: MergeResolution): string[] {
@@ -757,6 +769,10 @@ export class SyncEngine {
         merge.quarantineEntries.length === 0 &&
         merge.resolvedQuarantineEntries.length === 0 &&
         (watermark.pinnedPaths?.length ?? 0) === 0 &&
+        // Dropped already-in-HEAD paths (#3475) mean the per-file snapshot
+        // is stale — fall through so the rebuild converges it (otherwise
+        // the phantom re-derives on every sync).
+        loop.alreadyInHead.length === 0 &&
         // First-sync synthetic base (file mode) must still PERSIST the
         // watermark even when nothing changed — otherwise every sync
         // re-runs first-sync discovery.
@@ -790,7 +806,9 @@ export class SyncEngine {
         // edits on the NEXT sync — a silent revert of the concurrent change.
         // Keeping the old watermark is safe: the next sync re-pulls the
         // concurrent change and drops our own pushed files as convergent
-        // edits.
+        // edits. Convergence for `alreadyInHead` paths (#3475) is equally
+        // deferred — their stale entries re-derive next sync and resolve
+        // through the same convergent-edit drop.
         warnings.push(
           `race-window: watermark NOT advanced (pushed commit's parent ${newCommit.parents[0]} != examined head ${examinedHead}) — next sync reconciles the concurrent change`,
         );
@@ -1157,6 +1175,7 @@ export class SyncEngine {
     let applyDeletes: RemoteChange[] = [];
     let pushFiles = new Map<string, SyncContent>();
     let merge: MergeResolution = EMPTY_MERGE;
+    let alreadyInHead: string[] = [];
     const remoteOversized = new Set<string>();
 
     for (;;) {
@@ -1172,6 +1191,10 @@ export class SyncEngine {
       // Merge resolution is recomputed per iteration — a re-pull changes the
       // remote side, so a previous iteration's verdicts are stale.
       merge = EMPTY_MERGE;
+      // Per-iteration like the merge verdicts: a retry re-reads the head, so
+      // the previous iteration's tree (and drops) are stale (#3475).
+      alreadyInHead = [];
+      let headTreeByPath: Map<string, string> | undefined;
       const convergedPushPaths = new Set<string>();
 
       // Pinned paths diverge from the lastSyncedSha tree by construction —
@@ -1194,11 +1217,12 @@ export class SyncEngine {
           warnings,
           remoteOversized,
         );
+        headTreeByPath = remote.headTreeByPath;
         const verdict = this.matchLocalVsRemote(
           localChanges,
           localDeletedPaths,
           disk,
-          remote,
+          remote.changes,
           convergedPushPaths,
         );
         if (verdict.conflicts.length > 0) {
@@ -1237,6 +1261,50 @@ export class SyncEngine {
         ...[...pushFilesAll].filter(([p]) => !convergedPushPaths.has(p)),
         ...merge.mergedFiles,
       ]);
+
+      // #3475 phantom-commit guard: drop pushFiles whose bytes are ALREADY
+      // identical in the examined head tree. Parallel-run state: another
+      // device pushed the same content and this device's PER-FILE watermark
+      // snapshot is stale (D22 validates only rootTreeSha) — without the
+      // guard, restCreateCommit lands an empty or partially-identical commit
+      // with an inflated `sync N file(s)` message. In the remote-diff branch
+      // above this is expected to be a no-op (the convergent-edit drop covers
+      // disk-sourced phantoms; the merge layer excludes remote-equal merged
+      // content) — the fast path (head unmoved, no pins) is the one that
+      // needs it. Runs BEFORE the R5 secret scan: bytes already durable in
+      // HEAD must not trigger a push refusal.
+      if (pushFiles.size > 0) {
+        if (headTreeByPath === undefined) {
+          // Fast path: `examinedHead === watermark.lastSyncedSha`, and
+          // `rootTreeSha` was D22-verified against the actual commit this
+          // very cycle (detectChanges) — one tree GET, and only when there
+          // is something to push (the no-change happy path never gets here).
+          headTreeByPath = treeByPath(
+            await getTree(
+              this.transport,
+              spec.owner,
+              spec.repo,
+              watermark.rootTreeSha,
+              this.deps.baseURL,
+            ),
+          );
+        }
+        for (const [path, content] of pushFiles) {
+          const headBlobSha = headTreeByPath.get(path);
+          if (
+            headBlobSha !== undefined &&
+            headBlobSha === (await gitBlobSha(content, this.deps.sha1))
+          ) {
+            pushFiles.delete(path);
+            alreadyInHead.push(path);
+          }
+        }
+        if (alreadyInHead.length > 0) {
+          warnings.push(
+            `phantom push skipped: ${alreadyInHead.length} file(s) already identical in remote HEAD (${alreadyInHead.join(", ")}) — excluded from the commit (#3475)`,
+          );
+        }
+      }
       if (pushFiles.size === 0) break;
 
       // R5 secret-scan — refuse the WHOLE push (a partial set could ship an
@@ -1304,6 +1372,7 @@ export class SyncEngine {
       pushFiles,
       merge,
       remoteOversized,
+      alreadyInHead,
     };
   }
 
@@ -1737,7 +1806,11 @@ export class SyncEngine {
     return result("synced");
   }
 
-  /** Fetch base..head remote changes with contents + uids. */
+  /**
+   * Fetch base..head remote changes with contents + uids. Also returns the
+   * RAW head tree as a path→blobSha lookup so the push phase can reuse it
+   * for the #3475 phantom-commit guard without a second tree GET.
+   */
   private async collectRemoteChanges(
     spec: SyncRepoSpec,
     watermark: WatermarkRecord,
@@ -1746,7 +1819,10 @@ export class SyncEngine {
     sizeExcluded: ReadonlySet<string> = new Set(),
     warnings: string[] = [],
     remoteOversized: Set<string> = new Set(),
-  ): Promise<RemoteChange[]> {
+  ): Promise<{
+    changes: RemoteChange[];
+    headTreeByPath: Map<string, string>;
+  }> {
     const headCommit = await getCommitInfo(
       this.transport,
       spec.owner,
@@ -1826,7 +1902,7 @@ export class SyncEngine {
     for (const d of deleted) {
       changes.push({ path: d.path, kind: "delete", uid: d.uid });
     }
-    return changes;
+    return { changes, headTreeByPath: treeByPath(rawTree) };
   }
 
   /**

--- a/packages/exocortex/tests/unit/services/sync/SyncEngine.test.ts
+++ b/packages/exocortex/tests/unit/services/sync/SyncEngine.test.ts
@@ -1077,3 +1077,106 @@ describe("SyncEngine — A3: D11 one-operation guard, R8 auth, R5 secret-scan", 
     expect(gh.headSha()).toBe(headBefore); // nothing pushed
   });
 });
+
+describe("SyncEngine — #3475 phantom/empty commits (detected content already in HEAD)", () => {
+  /**
+   * Parallel-run state (#3475): the other device already pushed the same
+   * bytes (Obsidian Sync replicated the files), but THIS device's watermark
+   * never recorded them — its per-file entry still carries an older blob.
+   * `lastSyncedSha`/`rootTreeSha` stay CURRENT: D22 validates only the root
+   * tree integrity, not the per-file snapshot (see advanceWatermark
+   * docstring), so detection derives a phantom "local change" whose content
+   * is byte-identical to the remote HEAD entry.
+   */
+  async function staleWatermarkEntry(
+    watermarks: FakeWatermarkStore,
+    repoKey: string,
+    path: string,
+    staleContent: string,
+  ): Promise<void> {
+    const record = watermarks.records.get(repoKey)!;
+    const staleBlobSha = await gitBlobSha(staleContent, sha1Hex);
+    watermarks.records.set(repoKey, {
+      ...record,
+      files: record.files.map((f) =>
+        f.path === path ? { ...f, blobSha: staleBlobSha } : f,
+      ),
+    });
+  }
+
+  it("does NOT create a commit when the detected content is already in HEAD; watermark converges", async () => {
+    const alreadyPushed = mdAsset("u1", "v2 — already pushed by the other device");
+    const gh = new FakeGitHubRepo({ [FILE_A]: alreadyPushed, [FILE_B]: mdAsset("u2") });
+    const local = new FakeLocalFiles({ [FILE_A]: alreadyPushed, [FILE_B]: mdAsset("u2") });
+    const { engine, watermarks } = makeEngine(gh, local);
+    await bootstrap(engine, gh.spec());
+    await staleWatermarkEntry(
+      watermarks,
+      gh.spec().repoKey,
+      FILE_A,
+      mdAsset("u1", "v1 — stale base"),
+    );
+
+    const headBefore = gh.headSha();
+    const commitsBefore = gh.commits.size;
+    const result = await engine.sync(gh.spec());
+
+    expect(result.status).toBe("synced");
+    expect(result.pushedSha).toBeUndefined();
+    expect(result.pushedCount).toBe(0);
+    expect(gh.headSha()).toBe(headBefore); // no commit landed
+    expect(gh.commits.size).toBe(commitsBefore); // not even an unreferenced one
+    expect(result.warnings.join(" ")).toMatch(/already identical in remote HEAD/);
+
+    // Watermark converged: the stale entry now records the actual blob —
+    // the phantom does NOT re-derive on the next sync.
+    const after = watermarks.records.get(gh.spec().repoKey)!;
+    expect(after.files.find((f) => f.path === FILE_A)!.blobSha).toBe(
+      await gitBlobSha(alreadyPushed, sha1Hex),
+    );
+    const second = await engine.sync(gh.spec());
+    expect(second.status).toBe("synced");
+    expect(second.pushedCount).toBe(0);
+    expect(second.warnings.join(" ")).not.toMatch(/already identical/);
+    expect(gh.headSha()).toBe(headBefore);
+  });
+
+  it("pushes ONLY the real delta when one of two detected files is already in HEAD; counter is exact", async () => {
+    const alreadyPushed = mdAsset("u1", "already in HEAD");
+    const gh = new FakeGitHubRepo({ [FILE_A]: alreadyPushed, [FILE_B]: mdAsset("u2") });
+    const local = new FakeLocalFiles({ [FILE_A]: alreadyPushed, [FILE_B]: mdAsset("u2") });
+    const { engine, watermarks } = makeEngine(gh, local);
+    await bootstrap(engine, gh.spec());
+    await staleWatermarkEntry(
+      watermarks,
+      gh.spec().repoKey,
+      FILE_A,
+      mdAsset("u1", "stale base"),
+    );
+    const realEdit = mdAsset("u2", "genuinely new content");
+    local.files.set(FILE_B, realEdit);
+
+    const headBefore = gh.headSha();
+    const result = await engine.sync(gh.spec());
+
+    expect(result.status).toBe("synced");
+    expect(result.pushedCount).toBe(1); // the real delta only — NOT 2 (#3475 inflated counter)
+    expect(result.pushedSha).toBe(gh.headSha());
+    expect(gh.headFiles().get(FILE_B)).toBe(realEdit);
+    expect(gh.headFiles().get(FILE_A)).toBe(alreadyPushed); // untouched in the tree
+    // Commit message reports the FILTERED count.
+    const head = gh.commits.get(gh.headSha())!;
+    expect(head.message).toBe("chore(exosync): sync 1 file(s)");
+    expect(head.parents).toEqual([headBefore]); // exactly one commit, no phantom sibling
+
+    // Watermark converged for BOTH paths — nothing re-derives.
+    const after = watermarks.records.get(gh.spec().repoKey)!;
+    expect(after.lastSyncedSha).toBe(gh.headSha());
+    expect(after.files.find((f) => f.path === FILE_A)!.blobSha).toBe(
+      await gitBlobSha(alreadyPushed, sha1Hex),
+    );
+    const second = await engine.sync(gh.spec());
+    expect(second.pushedCount).toBe(0);
+    expect(gh.headSha()).toBe(result.pushedSha);
+  });
+});


### PR DESCRIPTION
Closes #3475

## Problem

In the parallel-run setup (Obsidian Sync active alongside ExoSync), a device's detected local changes may already be byte-identical to remote HEAD entries — the other device pushed the same bytes earlier. `SyncEngine.runPushLoop`'s fast path (`examinedHead === watermark.lastSyncedSha && !hasPins`) skips the remote-diff (and with it the convergent-edit drop) entirely, so detected files were committed without any blobSha comparison against the actual HEAD tree → empty / partially-identical commits with inflated `chore(exosync): sync N file(s)` messages and inflated `pushed N` Notices (live evidence in #3475: 2 fully-empty commits + a «sync 4 file(s)» commit with 1 real change).

Mechanism verified at source level before the fix: the per-file watermark snapshot can go stale while `lastSyncedSha`/`rootTreeSha` stay current — D22 validates only root-tree integrity, by design (see `advanceWatermark` docstring).

## Fix (TDD — RED first, see commit history)

- **RED** (84e06235): 2 failing tests on the production-shape `FakeGitHubRepo` reproducing the exact #3475 state (stale per-file entry, content already in HEAD): full phantom → empty commit landed; partial → `sync 2 file(s)` for 1 real change.
- **GREEN** (eb3e7f06): pre-push guard in `runPushLoop` — every `pushFiles` entry whose `gitBlobSha` equals the corresponding examined-head-tree entry is dropped (`alreadyInHead` + warning). Empty filtered set → **no commit object is created at all**. Commit message and `pushedCount` report the filtered count.

### Tree reuse — no second GET on the remote-diff path; one tree GET on the fast path only when pushing
- Remote-diff branch: `collectRemoteChanges` now also returns its already-fetched RAW head tree (`path→blobSha`) — reused, no second GET.
- Fast path: one `getTree(watermark.rootTreeSha)` (D22-verified against the actual commit this same cycle), and only when there is something to push. The no-change happy path performs zero additional calls.

### Watermark convergence
The no-op early return is additionally gated on `alreadyInHead.length === 0`: a cycle that dropped phantoms falls through to `advanceWatermark`, so the stale per-file entries converge and nothing re-derives on the next sync (asserted by the tests via a second sync).

### Untouched (issue constraints)
Convergent-edit drop in `matchLocalVsRemote`, D16 retry semantics (guard state resets per iteration), watermark pinning, file-mode C2, `restCreateCommit` primitive (D3).

### Honest scoping
The guard eliminates the stale-watermark phantom class (the #3475 evidence) and the inflated counters. Residual race classes (e.g. a stale ref read or two overlapping cycles racing the same content) are reconciled by the existing race-window path: watermark not advanced, next sync converges via convergent-edit drop — and post-fix such a cycle can no longer silently revert a concurrent change with stale content, since identical-to-examined-head paths are absent from the commit's tree update.

## Verification

- **Empirically verified to FAIL pre-fix and PASS post-fix**: `git checkout HEAD~1 -- SyncEngine.ts` → 2/2 FAIL; restore → 2/2 PASS (independently reproduced by the code-reviewer agent against origin/main).
- Full sync suite: **218/218 green** (14 suites), `tsc --noEmit` clean.
- Advisor design round-1: APPROVED (1 MEDIUM — per-iteration reset in the D16 loop, applied).
- code-reviewer agent: **APPROVE, 0 findings** (CRITICAL/HIGH/MEDIUM/LOW all zero); noted the fix also closes a pre-existing D9 race hazard (phantom paths silently reverting concurrent commits) as a side effect.
