### PR TITLE
fix(#3479): keep console.* in release builds — Logger console channel live

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "scripts": {
     "dev": "npm run dev -w @exocortex/obsidian-plugin",
-    "build": "npm run build -w exocortex && npm run build -w @kitelev/exocortex-services && npm run build --workspaces --if-present && tsc -noEmit -skipLibCheck && node packages/obsidian-plugin/esbuild.config.mjs production && node scripts/assert-mobile-loadable.mjs",
+    "build": "npm run build -w exocortex && npm run build -w @kitelev/exocortex-services && npm run build --workspaces --if-present && tsc -noEmit -skipLibCheck && node packages/obsidian-plugin/esbuild.config.mjs production && node scripts/assert-mobile-loadable.mjs && node scripts/assert-console-channel.mjs",
     "lint": "eslint packages/obsidian-plugin/src --ext .ts,.tsx",
     "lint:fix": "eslint packages/obsidian-plugin/src --ext .ts,.tsx --fix",
     "format": "prettier --write 'packages/**/*.{ts,tsx}'",

--- a/packages/exocortex/src/services/LoggingService.ts
+++ b/packages/exocortex/src/services/LoggingService.ts
@@ -49,20 +49,20 @@ export class LoggingService {
    * plugin's esbuild config no longer drops them); output is gated by
    * the isVerbose flag below.
    */
-   
+
   static debug(_message: string, _context?: unknown): void {
     if (this.isVerbose) {
       console.debug(`[Exocortex] ${_message}`, _context ?? "");
     }
   }
 
-   
+
   static info(_message: string, _context?: unknown): void {
     // eslint-disable-next-line no-console
     console.log(`[Exocortex] ${_message}`, _context ?? "");
   }
 
-   
+
   static warn(_message: string, _context?: unknown): void {
     console.warn(`[Exocortex] ${_message}`, _context ?? "");
   }

--- a/packages/exocortex/src/services/LoggingService.ts
+++ b/packages/exocortex/src/services/LoggingService.ts
@@ -45,33 +45,31 @@ export class LoggingService {
 
   /**
    * Log debug message.
-   * Note: These methods intentionally have empty bodies in production builds
-   * when console calls are dropped by esbuild. The function signature remains
-   * for API compatibility, but the bodies are no-ops.
+   * Note: console calls survive production builds (Issue #3479 — the
+   * plugin's esbuild config no longer drops them); output is gated by
+   * the isVerbose flag below.
    */
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+   
   static debug(_message: string, _context?: unknown): void {
-    // Verbose check with console.debug inside keeps the method usable
-    // When console is dropped, the entire body becomes a no-op
     if (this.isVerbose) {
       console.debug(`[Exocortex] ${_message}`, _context ?? "");
     }
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+   
   static info(_message: string, _context?: unknown): void {
     // eslint-disable-next-line no-console
     console.log(`[Exocortex] ${_message}`, _context ?? "");
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+   
   static warn(_message: string, _context?: unknown): void {
     console.warn(`[Exocortex] ${_message}`, _context ?? "");
   }
 
   /**
    * Log an error with environment-aware stack trace handling.
-   * Note: In production builds, console calls may be dropped by esbuild.
+   * Note: console calls survive production builds (Issue #3479).
    * Stack trace is included in single console.error call to avoid orphaned expressions.
    *
    * @param message - User-friendly error message

--- a/packages/exocortex/src/services/LoggingService.ts
+++ b/packages/exocortex/src/services/LoggingService.ts
@@ -49,19 +49,16 @@ export class LoggingService {
    * plugin's esbuild config no longer drops them); output is gated by
    * the isVerbose flag below.
    */
-
   static debug(_message: string, _context?: unknown): void {
     if (this.isVerbose) {
       console.debug(`[Exocortex] ${_message}`, _context ?? "");
     }
   }
 
-
   static info(_message: string, _context?: unknown): void {
     // eslint-disable-next-line no-console
     console.log(`[Exocortex] ${_message}`, _context ?? "");
   }
-
 
   static warn(_message: string, _context?: unknown): void {
     console.warn(`[Exocortex] ${_message}`, _context ?? "");

--- a/packages/obsidian-plugin/esbuild.config.mjs
+++ b/packages/obsidian-plugin/esbuild.config.mjs
@@ -189,11 +189,16 @@ const productionConfig = {
   },
   // Advanced production optimizations
   metafile: true,
-  // Drop debug code in production
-  drop: ["console", "debugger"],
+  // Drop debugger statements only. console.* MUST survive release builds:
+  // Logger routes log events to the DevTools console per-level via the
+  // settings-facing logChannels.<level>.console toggles (Issue #3479).
+  // Dropping "console" here (or marking console methods pure) silently
+  // turns that channel into a no-op — gated by
+  // tests/unit/build/esbuild-console-channel.test.ts +
+  // scripts/assert-console-channel.mjs (root build).
+  drop: ["debugger"],
   // Additional size optimizations
   legalComments: "none", // Remove license comments to save space
-  pure: ["console.log", "console.debug", "console.info"], // Mark as pure for tree-shaking
   ignoreAnnotations: false, // Respect pure annotations
 };
 

--- a/packages/obsidian-plugin/src/adapters/logging/Logger.ts
+++ b/packages/obsidian-plugin/src/adapters/logging/Logger.ts
@@ -161,7 +161,8 @@ export class Logger implements ILogger {
 
   /**
    * Log error with ErrorLogOptions for structured logging
-   * Note: In production builds, console calls are dropped by esbuild.
+   * Note: console calls survive production builds (Issue #3479) and are
+   * gated at runtime by the logChannels.<level>.console settings toggles.
    * To avoid "expression has no effect" warnings, we consolidate
    * conditional logging into single console.error calls.
    */

--- a/packages/obsidian-plugin/tests/unit/build/esbuild-console-channel.test.ts
+++ b/packages/obsidian-plugin/tests/unit/build/esbuild-console-channel.test.ts
@@ -1,0 +1,48 @@
+import { readFileSync } from "fs";
+import * as path from "path";
+
+/**
+ * Issue #3479 — config-level regression gate for the Logger console channel.
+ *
+ * The release build used to strip every console.* call via esbuild
+ * `drop: ["console"]` plus `pure: ["console.log", "console.debug",
+ * "console.info"]`, which silently turned the settings-facing
+ * logChannels.<level>.console toggles into a no-op (v16.81.1 main.js:
+ * 0 occurrences of console.warn).
+ *
+ * esbuild.config.mjs is a build SCRIPT (it invokes esbuild at module-eval
+ * time), so it cannot be imported here — assertions run on the file text,
+ * with comments stripped first so documentation cannot satisfy or trip them.
+ * The bundle-level twin gate is scripts/assert-console-channel.mjs, wired
+ * into the root `npm run build` (gates the Auto Release artifact).
+ */
+describe("esbuild production config — Logger console channel (Issue #3479)", () => {
+  const configPath = path.resolve(__dirname, "../../../esbuild.config.mjs");
+  const configText = readFileSync(configPath, "utf8");
+
+  const stripComments = (src: string): string =>
+    src.replace(/\/\*[\s\S]*?\*\//g, "").replace(/\/\/[^\n]*/g, "");
+
+  const code = stripComments(configText);
+  const dropArrays = [...code.matchAll(/drop:\s*\[([^\]]*)\]/g)];
+  const pureArrays = [...code.matchAll(/pure:\s*\[([^\]]*)\]/g)];
+
+  it("does not drop console.* calls (no 'console' entry in any drop list)", () => {
+    expect(dropArrays.length).toBeGreaterThan(0);
+    for (const match of dropArrays) {
+      expect(match[1]).not.toMatch(/["']console["']/);
+    }
+  });
+
+  it("keeps dropping debugger statements", () => {
+    expect(
+      dropArrays.some((match) => /["']debugger["']/.test(match[1])),
+    ).toBe(true);
+  });
+
+  it("does not mark console methods as pure (pure-list tree-shakes them under minify)", () => {
+    for (const match of pureArrays) {
+      expect(match[1]).not.toMatch(/console\s*\./);
+    }
+  });
+});

--- a/scripts/assert-console-channel.mjs
+++ b/scripts/assert-console-channel.mjs
@@ -36,17 +36,18 @@ try {
   process.exit(1);
 }
 
-const requiredCallSites = [
-  "console.debug",
-  "console.info",
-  "console.warn",
-  "console.error",
-];
-const missing = requiredCallSites.filter((site) => !code.includes(site));
+// Call-site regex (`console.<method>(`), NOT a bare substring — a string
+// literal like "console.warn" in an error message must not satisfy the gate.
+const requiredMethods = ["debug", "info", "warn", "error"];
+const callSiteRegex = (method) =>
+  new RegExp(String.raw`console\.${method}\s*\(`, "g");
+const missing = requiredMethods.filter(
+  (method) => !callSiteRegex(method).test(code),
+);
 
 if (missing.length > 0) {
   console.error(
-    `❌ [console-channel] bundle ${bundlePath} is missing call sites: ${missing.join(", ")}.\n` +
+    `❌ [console-channel] bundle ${bundlePath} is missing call sites: ${missing.map((m) => `console.${m}`).join(", ")}.\n` +
       `   The Logger console channel (settings logChannels.<level>.console) is a\n` +
       `   no-op in this build — DevTools console receives nothing while Notices\n` +
       `   and the file log still flood (Issue #3479 regression class).\n` +
@@ -56,8 +57,11 @@ if (missing.length > 0) {
   process.exit(1);
 }
 
-const counts = requiredCallSites
-  .map((site) => `${site} ×${code.split(site).length - 1}`)
+const counts = requiredMethods
+  .map(
+    (method) =>
+      `console.${method} ×${[...code.matchAll(callSiteRegex(method))].length}`,
+  )
   .join(", ");
 console.log(
   `✅ [console-channel] ${bundlePath} retains console call sites (${counts}). ` +

--- a/scripts/assert-console-channel.mjs
+++ b/scripts/assert-console-channel.mjs
@@ -1,0 +1,65 @@
+#!/usr/bin/env node
+/**
+ * assert-console-channel.mjs — Issue #3479 release-gate.
+ *
+ * Asserts the built plugin bundle (main.js) retains console.* call sites for
+ * every Logger level (debug/info/warn/error). The Logger console channel is a
+ * settings-facing feature (logChannels.<level>.console toggles, default true),
+ * but esbuild `drop: ["console"]` + `pure: ["console.log", "console.debug",
+ * "console.info"]` used to strip every console call from release builds,
+ * silently turning the channel into a no-op (verified on v16.81.1 main.js:
+ * 0 occurrences of console.warn while ~100 [ExoSync] WARN events flooded
+ * Notices and the file log).
+ *
+ * Checking all four methods guards both regression vectors independently:
+ * `drop: ["console"]` strips everything; a re-introduced console `pure`-list
+ * tree-shakes debug/info under minify even without `drop`.
+ *
+ * Wired into the root `build` script (after assert-mobile-loadable), so every
+ * production build — incl. the Auto Release artifact — is gated against the
+ * strip being silently re-introduced. Companion config-level PR-time gate:
+ * packages/obsidian-plugin/tests/unit/build/esbuild-console-channel.test.ts
+ *
+ * Usage: node scripts/assert-console-channel.mjs [path/to/main.js]
+ */
+import { readFileSync } from "node:fs";
+
+const bundlePath = process.argv[2] ?? "packages/obsidian-plugin/main.js";
+
+let code;
+try {
+  code = readFileSync(bundlePath, "utf8");
+} catch (err) {
+  console.error(
+    `❌ [console-channel] cannot read bundle ${bundlePath}: ${err.message}`,
+  );
+  process.exit(1);
+}
+
+const requiredCallSites = [
+  "console.debug",
+  "console.info",
+  "console.warn",
+  "console.error",
+];
+const missing = requiredCallSites.filter((site) => !code.includes(site));
+
+if (missing.length > 0) {
+  console.error(
+    `❌ [console-channel] bundle ${bundlePath} is missing call sites: ${missing.join(", ")}.\n` +
+      `   The Logger console channel (settings logChannels.<level>.console) is a\n` +
+      `   no-op in this build — DevTools console receives nothing while Notices\n` +
+      `   and the file log still flood (Issue #3479 regression class).\n` +
+      `   Likely cause: drop:["console"] or a console pure-list re-introduced in\n` +
+      `   packages/obsidian-plugin/esbuild.config.mjs.`,
+  );
+  process.exit(1);
+}
+
+const counts = requiredCallSites
+  .map((site) => `${site} ×${code.split(site).length - 1}`)
+  .join(", ");
+console.log(
+  `✅ [console-channel] ${bundlePath} retains console call sites (${counts}). ` +
+    `Logger console channel live in release build.`,
+);


### PR DESCRIPTION
Closes #3479

## Problem

`Logger` has per-level channel routing (console / notice / file) exposed in settings as `logChannels` with console toggles (defaults `true` for all four levels). But the release build stripped **all** `console.*` calls:

- `packages/obsidian-plugin/esbuild.config.mjs` — `drop: ["console", "debugger"]`
- `pure: ["console.log", "console.debug", "console.info"]` (tree-shakes those calls under minify even without `drop`)

Verified on v16.81.1 `main.js`: **0 occurrences** of `console.warn` while ~100 `[ExoSync]` WARN events flooded Notices and the file log during PR #3478 UI smoke. The settings UI promised a channel that physically did not exist in any release build.

## Fix (TDD: RED → GREEN)

**RED (commit 1):** two regression gates, both empirically failing on main:
- Config-level unit test `packages/obsidian-plugin/tests/unit/build/esbuild-console-channel.test.ts` — asserts no `"console"` in any `drop` list (keeps `"debugger"`), no console `pure`-list. The esbuild config is a build *script* (invokes esbuild at module-eval), so assertions run on comment-stripped file text. **2/3 FAIL on main.**
- Bundle-level gate `scripts/assert-console-channel.mjs` (mirrors `assert-mobile-loadable.mjs`) — asserts built `main.js` retains `console.debug/info/warn/error` call sites; wired into root `npm run build`, so the Auto Release artifact is gated. **FAIL on main: 0/4 call sites present.**

**GREEN (commit 2):**
- `drop: ["console", "debugger"]` → `drop: ["debugger"]`; `pure` console-list removed. Logger's runtime gating (`isChannelEnabled(level, "console")` + settings `logChannels` toggles) is now the sole console gate. **No Logger logic change.**
- Stale comments updated: `Logger.ts` `logWithOptions` docstring + `LoggingService.ts` debug/error docstrings ("console calls are dropped by esbuild" — no longer true). Repo-wide grep confirms no other stale mentions remain.

## Empirical verification

**Revert→fail / restore→pass** (fix was committed → used `git checkout origin/main -- esbuild.config.mjs`, not stash, per integration-test-revert-verify discipline):

| State | Config unit test | Bundle smoke |
|---|---|---|
| origin/main config | **2 failed** / 1 passed | **exit 1** (0/4 call sites) |
| fixed config (HEAD) | 3/3 passed | exit 0 |

**Rebuilt production bundle (manual grep):** `console.debug ×8, console.info ×2, console.warn ×26, console.error ×30` — Logger console channel live.

**Sibling gates intact:** `assert-mobile-loadable.mjs` still ✅ on the new bundle; Logger channel suites (`Logger`, `FileLogChannel`, `LogChannelSettings`, `LoggerFactory`) 101/101 green; archgate 19/19 pass.

## AC mapping (issue #3479)

- [x] Release bundle contains `console.*`; `drop` keeps only `"debugger"`
- [x] WARN reaches DevTools console when `logChannels.warn.console=true` — bundle grep `console.warn ×26` + Logger channel unit tests green (runtime gating unchanged, already covered by existing suites)
- [x] Build smoke-check added (`scripts/assert-console-channel.mjs`, wired into root `build` → gates Auto Release artifact)
- [x] No minify/sourcemap/build-option changes beyond `drop`/`pure`

## Out of scope (per issue)

Logger routing/defaults untouched; file-channel routing for debug/info (#3186) untouched; #3472/#3473 not included.

## Note for future contributors (review LOW finding)

`drop: ["console"]` previously silenced console output from **all** bundled code — 123 bundled node_modules inputs (tsyringe, preact, sparqljs, …) and ~36 src files with direct console calls outside Logger. Those now reach the user's DevTools console in release builds. This is the intended design of this fix (user directive: all plugin log events to console), but do not rely on the build stripping debug output anymore — route new logging through `Logger` so it stays settings-gated.

## Review trail

- code-reviewer round-1: **APPROVE** — 0 CRITICAL / 0 HIGH / 1 MEDIUM / 2 LOW. MEDIUM (substring → call-site regex in bundle gate) + LOW (JSDoc reattach) applied in d14b6f4c; hardened gate re-verified revert→fail (exit 1) / restore→pass (exit 0).
