### PR TITLE
feat(#3472): one-shot 'Exocortex: indexing complete' notice after initial vault indexing

### DIFF
--- a/packages/obsidian-plugin/src/ExocortexPlugin.ts
+++ b/packages/obsidian-plugin/src/ExocortexPlugin.ts
@@ -2,6 +2,7 @@ import "reflect-metadata";
 import {
   MarkdownPostProcessorContext,
   MarkdownView,
+  MetadataCache,
   Platform,
   Plugin,
   TFile,
@@ -13,6 +14,7 @@ import { LoggerFactory } from "./adapters/logging/LoggerFactory";
 import { Logger } from "./adapters/logging/Logger";
 import { FileLogChannel } from "./adapters/logging/FileLogChannel";
 import { CommandManager } from "./application/services/CommandManager";
+import { IndexingCompleteNotifier } from "./application/services/IndexingCompleteNotifier";
 import {
   ExocortexSettings,
   DEFAULT_SETTINGS,
@@ -869,6 +871,24 @@ export default class ExocortexPlugin extends Plugin {
         }
       };
 
+      // Issue #3472 — one-shot «Exocortex: indexing complete (N files,
+      // M skipped, X.Xs)» notice, emitted when the initial full vault walk
+      // finishes and SPARQL / dynamic buttons / layouts are actually ready.
+      // Two callsites share this emitter (the internal latch dedupes):
+      //   1. the eager-init warm-up chain below (covers mid-session plugin
+      //      enable, where `metadataCache.on("resolved")` may not fire
+      //      again until the user edits a file);
+      //   2. the post-resolve one-shot reindex chain (covers cold boot,
+      //      where the eager walk runs against a partially-parsed
+      //      metadataCache and the resolved-chain refresh is the
+      //      authoritative initial pass).
+      // All later full refreshes (profile switch, FileSpace declaration
+      // edits) and incremental per-file updates never call the emitter —
+      // they stay quiet by design.
+      const indexingCompleteNotifier = new IndexingCompleteNotifier(
+        this.notifier,
+      );
+
       // GTD Capture: one-click fleeting note to inbox.
       // Triggers the same Obsidian Command Palette entry as Cmd-P → "Create
       // fleeting note". The command itself is registered by
@@ -1058,8 +1078,17 @@ export default class ExocortexPlugin extends Plugin {
           // `PluginRdfIndexerAdapter.onAfterRefresh`; these onload chain
           // callsites use `sparql.refresh()` directly which bypasses the
           // adapter, so they call the helper explicitly.
+          // Issue #3472 — taken right before refresh() is invoked (inside
+          // the chain, after the eager-init promise settles) so the
+          // stale-stats guard in `notifyOnce` can reject stats from a walk
+          // that finished before THIS refresh started (coalesced-refresh
+          // false-positive path — see IndexingCompleteNotifier JSDoc).
+          let postResolveRefreshStartedAt = 0;
           void initPromise
-            .then(() => this.sparql.refresh())
+            .then(() => {
+              postResolveRefreshStartedAt = Date.now();
+              return this.sparql.refresh();
+            })
             .then(() => this.refreshAndInjectAssetSpaceMaterialization())
             .then(() => {
               // RFC c7da0bca Phase 3b-main — drop the lazy loader's
@@ -1087,6 +1116,16 @@ export default class ExocortexPlugin extends Plugin {
               // attempt registered nothing.
               await initExocmdPalette();
               this.autoRenderLayout();
+              // Issue #3472 — the initial full reindex is done AND the
+              // dependent surfaces (palette, layouts) just re-rendered:
+              // this is the moment «indexing complete» is true for the
+              // user. On refresh failure the .catch below short-circuits
+              // this call — no false-positive notice. Quiet no-op when the
+              // eager-init callsite already emitted (one-shot latch).
+              indexingCompleteNotifier.notifyOnce(
+                this.sparql.getLastIndexWalkStats(),
+                postResolveRefreshStartedAt,
+              );
             })
             .catch((err) => {
               this.logger.error(
@@ -1371,6 +1410,10 @@ export default class ExocortexPlugin extends Plugin {
           performance.mark("exocmd-fastpath-start");
           performance.mark("exocmd-fullpath-start");
           setTimeout(() => {
+            // Issue #3472 — see the stale-stats guard note at the
+            // post-resolve callsite; the ASK below lazily triggers
+            // `VaultRDFIndexer.initialize()` (the walk being reported).
+            const eagerWarmupStartedAt = Date.now();
             void this.sparql
               .query("ASK { ?s ?p ?o }")
               .then(async () => {
@@ -1391,6 +1434,33 @@ export default class ExocortexPlugin extends Plugin {
                   "exocmd-fullpath-start",
                   "exocmd-fullpath-ready",
                 );
+
+                // Issue #3472 — emit «indexing complete» from the eager
+                // path ONLY when metadataCache had already finished its
+                // initial scan (mid-session plugin enable / first install:
+                // cache is warm, counts are honest, and the
+                // `metadataCache.on("resolved")` chain may not fire again
+                // until the user edits a file — without this callsite the
+                // notice would never appear for that persona). On a cold
+                // boot the flag is still false here, the guard skips, and
+                // the post-resolve chain emits after the authoritative
+                // refresh instead. `initialized` is undocumented-but-
+                // stable Obsidian API (Dataview relies on it); if it ever
+                // disappears the comparison is `undefined === true` →
+                // false → we safely fall back to the post-resolve
+                // callsite. One-shot latch dedupes the two callsites.
+                if (
+                  (
+                    this.app.metadataCache as MetadataCache & {
+                      initialized?: boolean;
+                    }
+                  ).initialized === true
+                ) {
+                  indexingCompleteNotifier.notifyOnce(
+                    this.sparql.getLastIndexWalkStats(),
+                    eagerWarmupStartedAt,
+                  );
+                }
 
                 // RFC c7da0bca Phase 3c-2 — deleted the post-convertVault
                 // indexer block. `ExocmdBindingsIndexer.runFullScan()`

--- a/packages/obsidian-plugin/src/ExocortexPlugin.ts
+++ b/packages/obsidian-plugin/src/ExocortexPlugin.ts
@@ -1413,7 +1413,23 @@ export default class ExocortexPlugin extends Plugin {
             // Issue #3472 — see the stale-stats guard note at the
             // post-resolve callsite; the ASK below lazily triggers
             // `VaultRDFIndexer.initialize()` (the walk being reported).
+            // The metadataCache warmth flag is captured HERE, at walk
+            // start — NOT at emit time. On a cold boot Obsidian's initial
+            // metadata scan can finish DURING the multi-second eager
+            // walk; reading the live flag after the walk would route a
+            // partially-parsed-cache walk to the eager notice instead of
+            // deferring to the authoritative post-resolve refresh.
+            // `initialized` is undocumented-but-stable Obsidian API
+            // (Dataview relies on it); if it ever disappears the
+            // comparison is `undefined === true` → false → safe fallback
+            // to the post-resolve callsite.
             const eagerWarmupStartedAt = Date.now();
+            const cacheWasWarmAtWalkStart =
+              (
+                this.app.metadataCache as MetadataCache & {
+                  initialized?: boolean;
+                }
+              ).initialized === true;
             void this.sparql
               .query("ASK { ?s ?p ?o }")
               .then(async () => {
@@ -1437,25 +1453,16 @@ export default class ExocortexPlugin extends Plugin {
 
                 // Issue #3472 — emit «indexing complete» from the eager
                 // path ONLY when metadataCache had already finished its
-                // initial scan (mid-session plugin enable / first install:
-                // cache is warm, counts are honest, and the
-                // `metadataCache.on("resolved")` chain may not fire again
-                // until the user edits a file — without this callsite the
-                // notice would never appear for that persona). On a cold
-                // boot the flag is still false here, the guard skips, and
-                // the post-resolve chain emits after the authoritative
-                // refresh instead. `initialized` is undocumented-but-
-                // stable Obsidian API (Dataview relies on it); if it ever
-                // disappears the comparison is `undefined === true` →
-                // false → we safely fall back to the post-resolve
-                // callsite. One-shot latch dedupes the two callsites.
-                if (
-                  (
-                    this.app.metadataCache as MetadataCache & {
-                      initialized?: boolean;
-                    }
-                  ).initialized === true
-                ) {
+                // initial scan BEFORE this walk started (mid-session
+                // plugin enable / first install: cache is warm, counts
+                // are honest, and the `metadataCache.on("resolved")`
+                // chain may not fire again until the user edits a file —
+                // without this callsite the notice would never appear for
+                // that persona). On a cold boot the flag was still false
+                // at walk start, the guard skips, and the post-resolve
+                // chain emits after the authoritative refresh instead.
+                // One-shot latch dedupes the two callsites.
+                if (cacheWasWarmAtWalkStart) {
                   indexingCompleteNotifier.notifyOnce(
                     this.sparql.getLastIndexWalkStats(),
                     eagerWarmupStartedAt,

--- a/packages/obsidian-plugin/src/application/api/SPARQLApi.ts
+++ b/packages/obsidian-plugin/src/application/api/SPARQLApi.ts
@@ -1,6 +1,7 @@
 import type { TFile } from "obsidian";
 import type { InMemoryTripleStore, SolutionMapping, Triple } from "exocortex";
 import { SPARQLQueryService } from '@plugin/application/services/SPARQLQueryService';
+import type { VaultWalkStats } from '@plugin/infrastructure/VaultRDFIndexer';
 import type ExocortexPlugin from '@plugin/ExocortexPlugin';
 
 /**
@@ -350,6 +351,16 @@ export class SPARQLApi {
    */
   getRdfIndexer(): IRdfIndexerHandle {
     return this.queryService.getIndexer();
+  }
+
+  /**
+   * Stats of the last completed FULL vault walk (Issue #3472), or null if
+   * no walk has succeeded yet. Read-only — intentionally a separate
+   * accessor instead of widening {@link IRdfIndexerHandle}, which stays
+   * narrowed to `refresh()` for the Profile wiring (Issue #3327).
+   */
+  getLastIndexWalkStats(): VaultWalkStats | null {
+    return this.queryService.getLastWalkStats();
   }
 
   /**

--- a/packages/obsidian-plugin/src/application/services/IndexingCompleteNotifier.ts
+++ b/packages/obsidian-plugin/src/application/services/IndexingCompleteNotifier.ts
@@ -1,0 +1,55 @@
+import type { INotificationService } from "exocortex";
+import type { VaultWalkStats } from "@plugin/infrastructure/VaultRDFIndexer";
+
+/**
+ * Issue #3472 — one-shot «Exocortex: indexing complete» notice.
+ *
+ * UX gap: the user has no signal when the initial RDF indexing of the vault
+ * finishes (i.e. when SPARQL / dynamic buttons / graph features are ready).
+ * This emitter shows exactly ONE notice per plugin load, right after the
+ * first authoritative full walk completes; all later full refreshes
+ * (profile switch, FileSpace declaration edits) and incremental per-file
+ * updates stay quiet — they never call this emitter.
+ *
+ * Counts reuse the Issue #3468 skip aggregation: `stats.skipped` is
+ * `convertVaultWithValidation().summary.skipped`.
+ */
+export class IndexingCompleteNotifier {
+  private notified = false;
+
+  constructor(private readonly notifier: INotificationService) {}
+
+  /**
+   * Emit the notice if it has not been emitted yet for this plugin load.
+   *
+   * Guards that intentionally do NOT latch the one-shot flag (a later call
+   * with valid stats must still be able to emit):
+   * - `stats === null` — no full walk has been recorded yet;
+   * - `stats.finishedAt < notBefore` — the stats belong to a walk that
+   *   finished BEFORE the caller initiated its own walk. This happens when
+   *   `VaultRDFIndexer.refresh()` coalesces into an in-flight refresh that
+   *   fails with a swallowed error: the caller's chain continues as if
+   *   successful while `getLastWalkStats()` still holds the stats of an
+   *   earlier (e.g. eager-init) walk. Reporting those would be a false
+   *   positive.
+   *
+   * @param stats - `VaultRDFIndexer.getLastWalkStats()` snapshot
+   * @param notBefore - timestamp taken by the caller right before it
+   *   triggered the walk it is reporting on
+   */
+  notifyOnce(stats: VaultWalkStats | null, notBefore: number): void {
+    if (this.notified) return;
+    if (stats === null) return;
+    if (stats.finishedAt < notBefore) return;
+    this.notified = true;
+
+    const files = `${stats.indexed} file${stats.indexed === 1 ? "" : "s"}`;
+    // Round half-up at the 0.1s grain BEFORE formatting — a bare
+    // `(ms / 1000).toFixed(1)` rounds 850 ms down to "0.8" because 0.85
+    // has no exact binary representation.
+    const seconds = (Math.round(stats.durationMs / 100) / 10).toFixed(1);
+    this.notifier.info(
+      `Exocortex: indexing complete (${files}, ${stats.skipped} skipped, ${seconds}s)`,
+    );
+  }
+}

--- a/packages/obsidian-plugin/src/application/services/SPARQLQueryService.ts
+++ b/packages/obsidian-plugin/src/application/services/SPARQLQueryService.ts
@@ -13,7 +13,7 @@ import {
   type ILogger,
   type INotificationService,
 } from "exocortex";
-import { VaultRDFIndexer } from '@plugin/infrastructure/VaultRDFIndexer';
+import { VaultRDFIndexer, type VaultWalkStats } from '@plugin/infrastructure/VaultRDFIndexer';
 import { LoggerFactory } from '@plugin/adapters/logging/LoggerFactory';
 
 export class SPARQLQueryService {
@@ -203,5 +203,14 @@ export class SPARQLQueryService {
    */
   getIndexer(): VaultRDFIndexer {
     return this.indexer;
+  }
+
+  /**
+   * Stats of the last completed FULL vault walk (Issue #3472), or null if
+   * no walk has succeeded yet. Read-only passthrough so consumers don't
+   * need the full `VaultRDFIndexer` handle.
+   */
+  getLastWalkStats(): VaultWalkStats | null {
+    return this.indexer.getLastWalkStats();
   }
 }

--- a/packages/obsidian-plugin/src/infrastructure/VaultRDFIndexer.ts
+++ b/packages/obsidian-plugin/src/infrastructure/VaultRDFIndexer.ts
@@ -31,18 +31,22 @@ import { LoggerFactory } from '@plugin/adapters/logging/LoggerFactory';
  * `NoteToRDFConverter.convertVaultWithValidation().summary` — `skipped` is
  * the Issue #3468 aggregated counter (invariant violations + invalid IRIs),
  * NOT a second parallel metric. `durationMs` covers the whole rebuild
- * (convertVault + addAll + inference), including retry attempts when
- * `executeWithRetry` re-runs the walk — it reports how long the user
- * actually waited, not how long the last attempt took. `finishedAt` lets
- * callers reject stats from a walk that completed before THEIR walk was
- * initiated (stale-stats guard for the coalesced-refresh path).
+ * (convertVault + addAll + inference), including retry attempts of the
+ * indexer-internal `executeWithRetry` — it reports how long the user
+ * actually waited, not how long the last attempt took. Known limitation:
+ * `SPARQLQueryService` wraps `initialize()`/`refresh()` in a SECOND
+ * `executeWithRetry`; if the inner layer exhausts its retries and the
+ * outer layer re-invokes, the timer restarts and only the last outer
+ * attempt is measured. `finishedAt` lets callers reject stats from a walk
+ * that completed before THEIR walk was initiated (stale-stats guard for
+ * the coalesced-refresh path).
  */
 export interface VaultWalkStats {
-  total: number;
-  indexed: number;
-  skipped: number;
-  durationMs: number;
-  finishedAt: number;
+  readonly total: number;
+  readonly indexed: number;
+  readonly skipped: number;
+  readonly durationMs: number;
+  readonly finishedAt: number;
 }
 
 export class VaultRDFIndexer {
@@ -448,7 +452,10 @@ export class VaultRDFIndexer {
    * succeeded yet. See {@link VaultWalkStats} for field semantics.
    */
   getLastWalkStats(): VaultWalkStats | null {
-    return this.lastWalkStats;
+    // Shallow copy — the accessor is re-exported through the public
+    // SPARQLApi; handing out the internal reference would let API
+    // consumers mutate plugin-internal state.
+    return this.lastWalkStats === null ? null : { ...this.lastWalkStats };
   }
 
   private recordWalkStats(

--- a/packages/obsidian-plugin/src/infrastructure/VaultRDFIndexer.ts
+++ b/packages/obsidian-plugin/src/infrastructure/VaultRDFIndexer.ts
@@ -24,6 +24,27 @@ import {
 import { ObsidianVaultAdapter } from '@plugin/adapters/ObsidianVaultAdapter';
 import { LoggerFactory } from '@plugin/adapters/logging/LoggerFactory';
 
+/**
+ * Outcome of the last FULL vault walk (Issue #3472).
+ *
+ * `total`/`indexed`/`skipped` come straight from
+ * `NoteToRDFConverter.convertVaultWithValidation().summary` — `skipped` is
+ * the Issue #3468 aggregated counter (invariant violations + invalid IRIs),
+ * NOT a second parallel metric. `durationMs` covers the whole rebuild
+ * (convertVault + addAll + inference), including retry attempts when
+ * `executeWithRetry` re-runs the walk — it reports how long the user
+ * actually waited, not how long the last attempt took. `finishedAt` lets
+ * callers reject stats from a walk that completed before THEIR walk was
+ * initiated (stale-stats guard for the coalesced-refresh path).
+ */
+export interface VaultWalkStats {
+  total: number;
+  indexed: number;
+  skipped: number;
+  durationMs: number;
+  finishedAt: number;
+}
+
 export class VaultRDFIndexer {
   private tripleStore: InMemoryTripleStore;
   private converter: NoteToRDFConverter;
@@ -58,12 +79,20 @@ export class VaultRDFIndexer {
    * their work is already covered.
    */
   private refreshInFlight: Promise<void> | null = null;
+  /**
+   * Stats of the last completed FULL walk (initialize/refresh) — null until
+   * the first walk succeeds. Incremental per-file updates do not touch it.
+   * Consumed by the one-shot «indexing complete» notice (Issue #3472).
+   */
+  private lastWalkStats: VaultWalkStats | null = null;
 
   constructor(
     private app: App,
     logger?: ILogger,
     notifier?: INotificationService,
     excludedFolders: string[] = [],
+    /** Injectable clock for deterministic duration tests. */
+    private readonly now: () => number = () => Date.now(),
   ) {
     this.tripleStore = new InMemoryTripleStore();
     this.vaultAdapter = new ObsidianVaultAdapter(
@@ -103,6 +132,7 @@ export class VaultRDFIndexer {
     }
 
     try {
+      const startedAt = this.now();
       const result = await this.errorHandler.executeWithRetry(
         async () => this.converter.convertVaultWithValidation({
           excludedFolders: this.excludedFolders,
@@ -112,6 +142,7 @@ export class VaultRDFIndexer {
       this.applyFileSpaceDiscovery(result.fileSpaces);
       await this.tripleStore.addAll(result.triples);
       await this.runInference();
+      this.recordWalkStats(result.summary, startedAt);
 
       this.registerEventListeners();
 
@@ -367,6 +398,7 @@ export class VaultRDFIndexer {
     if (this.refreshInFlight !== null) {
       return this.refreshInFlight;
     }
+    const startedAt = this.now();
     const run = this.errorHandler
       .executeWithRetry(
         async () => {
@@ -377,6 +409,7 @@ export class VaultRDFIndexer {
           this.applyFileSpaceDiscovery(result.fileSpaces);
           await this.tripleStore.addAll(result.triples);
           await this.runInference();
+          this.recordWalkStats(result.summary, startedAt);
         },
         { context: "VaultRDFIndexer.refresh", operation: "refresh" }
       )
@@ -408,6 +441,28 @@ export class VaultRDFIndexer {
 
   getTripleStore(): InMemoryTripleStore {
     return this.tripleStore;
+  }
+
+  /**
+   * Stats of the last completed FULL vault walk, or null if no walk has
+   * succeeded yet. See {@link VaultWalkStats} for field semantics.
+   */
+  getLastWalkStats(): VaultWalkStats | null {
+    return this.lastWalkStats;
+  }
+
+  private recordWalkStats(
+    summary: { total: number; indexed: number; skipped: number },
+    startedAt: number,
+  ): void {
+    const finishedAt = this.now();
+    this.lastWalkStats = {
+      total: summary.total,
+      indexed: summary.indexed,
+      skipped: summary.skipped,
+      durationMs: finishedAt - startedAt,
+      finishedAt,
+    };
   }
 
   dispose(): void {

--- a/packages/obsidian-plugin/tests/unit/application/services/IndexingCompleteNotifier.test.ts
+++ b/packages/obsidian-plugin/tests/unit/application/services/IndexingCompleteNotifier.test.ts
@@ -1,0 +1,161 @@
+import { IndexingCompleteNotifier } from "../../../../src/application/services/IndexingCompleteNotifier";
+import type { VaultWalkStats } from "../../../../src/infrastructure/VaultRDFIndexer";
+import type { INotificationService } from "exocortex";
+
+/**
+ * Issue #3472 — one-shot «indexing complete» notice.
+ *
+ * Production-shape fake: a full INotificationService implementation that
+ * records every call per channel, mirroring ObsidianNotificationService's
+ * contract (info() shows the message verbatim as a Notice; no prefix).
+ */
+class RecordingNotificationService implements INotificationService {
+  readonly infoCalls: Array<{ message: string; duration?: number }> = [];
+  readonly successCalls: string[] = [];
+  readonly errorCalls: string[] = [];
+  readonly warnCalls: string[] = [];
+
+  info(message: string, duration?: number): void {
+    this.infoCalls.push({ message, duration });
+  }
+  success(message: string): void {
+    this.successCalls.push(message);
+  }
+  error(message: string): void {
+    this.errorCalls.push(message);
+  }
+  warn(message: string): void {
+    this.warnCalls.push(message);
+  }
+  async confirm(): Promise<boolean> {
+    return false;
+  }
+}
+
+function makeStats(overrides: Partial<VaultWalkStats> = {}): VaultWalkStats {
+  return {
+    total: 100,
+    indexed: 97,
+    skipped: 3,
+    durationMs: 4230,
+    finishedAt: 1000,
+    ...overrides,
+  };
+}
+
+describe("IndexingCompleteNotifier (Issue #3472)", () => {
+  let notifier: RecordingNotificationService;
+  let emitter: IndexingCompleteNotifier;
+
+  beforeEach(() => {
+    notifier = new RecordingNotificationService();
+    emitter = new IndexingCompleteNotifier(notifier);
+  });
+
+  describe("first full indexing pass", () => {
+    it("emits exactly one info notice with N files / M skipped / duration", () => {
+      emitter.notifyOnce(makeStats(), 500);
+
+      expect(notifier.infoCalls).toHaveLength(1);
+      expect(notifier.infoCalls[0].message).toBe(
+        "Exocortex: indexing complete (97 files, 3 skipped, 4.2s)",
+      );
+    });
+
+    it("does not use warn/error/success channels", () => {
+      emitter.notifyOnce(makeStats(), 500);
+
+      expect(notifier.warnCalls).toHaveLength(0);
+      expect(notifier.errorCalls).toHaveLength(0);
+      expect(notifier.successCalls).toHaveLength(0);
+    });
+
+    it("uses singular 'file' when exactly one file was indexed", () => {
+      emitter.notifyOnce(makeStats({ indexed: 1, skipped: 0 }), 500);
+
+      expect(notifier.infoCalls).toHaveLength(1);
+      expect(notifier.infoCalls[0].message).toBe(
+        "Exocortex: indexing complete (1 file, 0 skipped, 4.2s)",
+      );
+    });
+
+    it("formats sub-second durations with one decimal", () => {
+      emitter.notifyOnce(makeStats({ durationMs: 850 }), 500);
+
+      expect(notifier.infoCalls[0].message).toBe(
+        "Exocortex: indexing complete (97 files, 3 skipped, 0.9s)",
+      );
+    });
+
+    it("reports an empty vault as 0 files, 0 skipped", () => {
+      emitter.notifyOnce(
+        makeStats({ total: 0, indexed: 0, skipped: 0, durationMs: 12 }),
+        500,
+      );
+
+      expect(notifier.infoCalls).toHaveLength(1);
+      expect(notifier.infoCalls[0].message).toBe(
+        "Exocortex: indexing complete (0 files, 0 skipped, 0.0s)",
+      );
+    });
+  });
+
+  describe("one-shot semantics", () => {
+    it("stays quiet on a second call (subsequent full refreshes are silent)", () => {
+      emitter.notifyOnce(makeStats(), 500);
+      emitter.notifyOnce(makeStats({ finishedAt: 9000 }), 500);
+
+      expect(notifier.infoCalls).toHaveLength(1);
+    });
+
+    it("stays quiet on every later call regardless of stats", () => {
+      emitter.notifyOnce(makeStats(), 500);
+      for (let i = 0; i < 5; i++) {
+        emitter.notifyOnce(makeStats({ finishedAt: 10_000 + i }), 0);
+      }
+
+      expect(notifier.infoCalls).toHaveLength(1);
+    });
+  });
+
+  describe("guards that must NOT latch the one-shot flag", () => {
+    it("does nothing when stats are null (no walk recorded yet)", () => {
+      emitter.notifyOnce(null, 500);
+
+      expect(notifier.infoCalls).toHaveLength(0);
+    });
+
+    it("still emits later after a null-stats call (null did not latch)", () => {
+      emitter.notifyOnce(null, 500);
+      emitter.notifyOnce(makeStats(), 500);
+
+      expect(notifier.infoCalls).toHaveLength(1);
+    });
+
+    it("does nothing when stats are stale (finished before the caller's walk started)", () => {
+      // Coalesced-refresh false-positive guard: the post-resolve chain's
+      // refresh() may coalesce into an in-flight refresh that fails with
+      // a swallowed error; getLastWalkStats() would then still hold the
+      // stats of the EARLIER eager-init walk. Those must not be reported.
+      emitter.notifyOnce(makeStats({ finishedAt: 400 }), 500);
+
+      expect(notifier.infoCalls).toHaveLength(0);
+    });
+
+    it("still emits later after a stale-stats call (stale did not latch)", () => {
+      emitter.notifyOnce(makeStats({ finishedAt: 400 }), 500);
+      emitter.notifyOnce(makeStats({ finishedAt: 600 }), 500);
+
+      expect(notifier.infoCalls).toHaveLength(1);
+      expect(notifier.infoCalls[0].message).toBe(
+        "Exocortex: indexing complete (97 files, 3 skipped, 4.2s)",
+      );
+    });
+
+    it("accepts stats that finished exactly at the notBefore boundary", () => {
+      emitter.notifyOnce(makeStats({ finishedAt: 500 }), 500);
+
+      expect(notifier.infoCalls).toHaveLength(1);
+    });
+  });
+});

--- a/packages/obsidian-plugin/tests/unit/infrastructure/VaultRDFIndexer.issue-3472-walk-stats.test.ts
+++ b/packages/obsidian-plugin/tests/unit/infrastructure/VaultRDFIndexer.issue-3472-walk-stats.test.ts
@@ -1,0 +1,169 @@
+import { VaultRDFIndexer } from "../../../src/infrastructure/VaultRDFIndexer";
+import type { App, TFile, EventRef } from "obsidian";
+import {
+  InMemoryTripleStore,
+  NoteToRDFConverter,
+  ApplicationErrorHandler,
+  Namespace,
+} from "exocortex";
+import { ObsidianVaultAdapter } from "../../../src/adapters/ObsidianVaultAdapter";
+
+jest.mock("exocortex");
+jest.mock("../../../src/adapters/ObsidianVaultAdapter");
+
+/**
+ * Issue #3472 — full-walk stats recording.
+ *
+ * The «indexing complete» notice needs N files / M skipped / duration from
+ * the last FULL vault walk. The skipped counter must be the one produced by
+ * the Issue #3468 aggregation (`convertVaultWithValidation().summary`), not
+ * a second parallel metric. Incremental per-file updates must not touch the
+ * recorded stats — they are quiet by design.
+ */
+describe("VaultRDFIndexer walk stats (Issue #3472)", () => {
+  let mockApp: App;
+  let mockTripleStore: jest.Mocked<InMemoryTripleStore>;
+  let mockConverter: jest.Mocked<NoteToRDFConverter>;
+  let now: jest.Mock<number, []>;
+
+  // Production-shape summary as produced by NoteToRDFConverter (#3468):
+  // summary.skipped === skippedFiles.length (invariant violations +
+  // invalid IRIs), summary.indexed === total - skipped.
+  const walkResult = {
+    triples: [],
+    skippedFiles: [
+      { path: "bad-iri.md", reason: "invalid IRI" },
+      { path: "violation.md", reason: "invariant violation" },
+      { path: "violation-2.md", reason: "invariant violation" },
+    ],
+    summary: { total: 100, indexed: 97, skipped: 3 },
+    fileSpaces: { prefixes: [], declarationPaths: [], warnings: [] },
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    (ApplicationErrorHandler as jest.MockedClass<typeof ApplicationErrorHandler>).mockImplementation(() => ({
+      executeWithRetry: jest.fn().mockImplementation(async (operation: () => Promise<unknown>) => {
+        return await operation();
+      }),
+      handle: jest.fn(),
+    } as any));
+
+    mockApp = {
+      vault: {
+        on: jest.fn(() => ({}) as unknown as EventRef),
+        off: jest.fn(),
+        offref: jest.fn(),
+        getAllFiles: jest.fn().mockReturnValue([]),
+      },
+      metadataCache: {
+        on: jest.fn(),
+        off: jest.fn(),
+        getFileCache: jest.fn().mockReturnValue(null),
+      },
+    } as unknown as App;
+
+    mockTripleStore = {
+      addAll: jest.fn().mockResolvedValue(undefined),
+      clear: jest.fn().mockResolvedValue(undefined),
+      clearGraph: jest.fn().mockResolvedValue(undefined),
+      match: jest.fn().mockResolvedValue([]),
+      removeAll: jest.fn().mockResolvedValue(0),
+    } as any;
+
+    mockConverter = {
+      convertVault: jest.fn().mockResolvedValue([]),
+      convertVaultWithValidation: jest.fn().mockResolvedValue(walkResult),
+      convertNote: jest.fn().mockResolvedValue([]),
+    } as any;
+
+    (InMemoryTripleStore as jest.MockedClass<typeof InMemoryTripleStore>).mockImplementation(() => mockTripleStore);
+    (NoteToRDFConverter as jest.MockedClass<typeof NoteToRDFConverter>).mockImplementation(() => mockConverter);
+    (ObsidianVaultAdapter as jest.MockedClass<typeof ObsidianVaultAdapter>).mockImplementation(() => ({}) as any);
+
+    const mockPrototypePredicate = { value: "https://exocortex.my/ontology/exo#Asset_prototype" };
+    (Namespace as any).EXO = { term: jest.fn().mockReturnValue(mockPrototypePredicate) };
+
+    now = jest.fn<number, []>();
+  });
+
+  function makeIndexer(): VaultRDFIndexer {
+    return new VaultRDFIndexer(mockApp, undefined, undefined, [], now);
+  }
+
+  it("returns null before any full walk has completed", () => {
+    const indexer = makeIndexer();
+
+    expect(indexer.getLastWalkStats()).toBeNull();
+  });
+
+  it("records stats of the initial walk from the #3468 summary (initialize)", async () => {
+    now.mockReturnValueOnce(1000).mockReturnValueOnce(4500);
+    const indexer = makeIndexer();
+
+    await indexer.initialize();
+
+    expect(indexer.getLastWalkStats()).toEqual({
+      total: 100,
+      indexed: 97,
+      skipped: 3,
+      durationMs: 3500,
+      finishedAt: 4500,
+    });
+  });
+
+  it("records fresh stats on a full refresh", async () => {
+    now
+      .mockReturnValueOnce(1000)
+      .mockReturnValueOnce(4500) // initialize walk
+      .mockReturnValueOnce(10_000)
+      .mockReturnValueOnce(12_000); // refresh walk
+    const indexer = makeIndexer();
+    await indexer.initialize();
+
+    mockConverter.convertVaultWithValidation.mockResolvedValueOnce({
+      ...walkResult,
+      summary: { total: 101, indexed: 99, skipped: 2 },
+    } as any);
+    await indexer.refresh();
+
+    expect(indexer.getLastWalkStats()).toEqual({
+      total: 101,
+      indexed: 99,
+      skipped: 2,
+      durationMs: 2000,
+      finishedAt: 12_000,
+    });
+  });
+
+  it("does NOT touch walk stats on incremental per-file updates", async () => {
+    now.mockReturnValueOnce(1000).mockReturnValueOnce(4500);
+    const indexer = makeIndexer();
+    await indexer.initialize();
+    const statsAfterInit = indexer.getLastWalkStats();
+
+    const mockFile = { path: "test.md", extension: "md" } as TFile;
+    await indexer.updateFile(mockFile);
+
+    expect(indexer.getLastWalkStats()).toEqual(statsAfterInit);
+  });
+
+  it("does not record stats when the walk fails", async () => {
+    now.mockReturnValue(1000);
+    mockConverter.convertVaultWithValidation.mockRejectedValueOnce(
+      new Error("walk failed"),
+    );
+    const indexer = makeIndexer();
+
+    let threw = false;
+    try {
+      await indexer.initialize();
+    } catch {
+      threw = true;
+    }
+
+    expect(threw).toBe(true);
+    expect(indexer.getLastWalkStats()).toBeNull();
+  });
+});


### PR DESCRIPTION
Closes #3472

## Problem

During ExoSync Phase B mobile smoke the user invoked Sync unsure whether RDF indexing had finished — there is **no signal when initial vault indexing completes** (when SPARQL / dynamic buttons / graph features are ready). CR \`d087047f\` (Approved): one Notice on initial-indexing completion; incremental updates stay quiet.

## Solution (TDD: RED 622b3e1a → GREEN daf003f4)

One-shot Notice per plugin load: **\`Exocortex: indexing complete (N files, M skipped, X.Xs)\`**

- **\`VaultRDFIndexer\`** records \`VaultWalkStats\` (\`total/indexed/skipped/durationMs/finishedAt\`) on every successful FULL walk (\`initialize\` + \`refresh\`). The \`skipped\` counter **reuses the #3468 aggregation** (\`convertVaultWithValidation().summary\`) — no second parallel metric. Incremental \`updateFile\`/\`removeFile\`/\`renameFile\` never touch the stats. Injectable clock for deterministic tests.
- **\`IndexingCompleteNotifier\`** (new, \`application/services\`): one-shot latch + formatting; emits via the existing \`INotificationService\` (\`ObsidianNotificationService\` — archgate forbids \`new Notice()\` elsewhere). Two guards intentionally do **not** latch the flag: null stats (no walk yet) and stale stats (\`finishedAt < notBefore\`) — the latter closes the coalesced-refresh false-positive path where \`VaultRDFIndexer.refresh()\` joins an in-flight refresh that fails with a swallowed error while \`getLastWalkStats()\` still holds the earlier eager-init walk.
- **\`ExocortexPlugin\`** wires two deduped callsites:
  1. **eager-init warm-up chain**, guarded by \`metadataCache.initialized === true\` — covers mid-session plugin enable / first install, where \`metadataCache.on("resolved")\` may not fire again until the user edits a file (the issue's primary persona). Fail-safe: if the undocumented-but-stable flag ever disappears, \`undefined === true\` → falls back to callsite 2.
  2. **post-resolve one-shot reindex chain** — covers cold boot; the resolved-chain refresh is the authoritative initial pass (eager init runs against a partially-parsed metadataCache). Emits **after** \`initExocmdPalette()\` + \`autoRenderLayout()\`, i.e. at the moment features are actually ready. On refresh failure the chain's \`.catch\` short-circuits the call — no false positive.
- **\`SPARQLApi.getLastIndexWalkStats()\`**: separate read-only accessor; \`IRdfIndexerHandle\` stays narrowed to \`refresh()\` (Issue #3327).

Anti-goal honoured: profile-switch / FileSpace-declaration refreshes and incremental per-file updates never reach the emitter — quiet by design.

## Why duration is the indexing walk, not perceived app-start wait

\`durationMs\` measures the reported walk (convertVault + addAll + inference, incl. retries) inside the indexer — deterministic and testable. Plugin-level timing would mostly measure Obsidian's own metadata parsing. On cold boot the reported walk is the second (warm-cache) pass, so the number is smaller than wall-clock from app launch — intentional.

## Tests

- \`IndexingCompleteNotifier.test.ts\` — 12 tests: exact message format (plural/singular, 0.1s-grain half-up rounding, empty vault), exactly-one-info-channel, one-shot semantics, null/stale guards don't latch, boundary \`finishedAt === notBefore\`.
- \`VaultRDFIndexer.issue-3472-walk-stats.test.ts\` — 5 tests: null before first walk; initialize/refresh record #3468 summary + duration; incremental \`updateFile\` leaves stats untouched; failed walk records nothing.

**Empirically verified to FAIL pre-fix and PASS post-fix**: production files stashed (\`git stash push -u\`, fix was uncommitted) → 5/5 fail; stash pop → 17/17 pass. Full plugin unit suite: 264 suites / 5157 tests green (with data submodules initialized). \`check:types\` + \`lint\` clean.

## Advisor design review (pre-implementation)

APPROVE-WITH-CHANGES; all findings incorporated: F1 HIGH (mid-session enable persona → eager callsite), F2 (\`IRdfIndexerHandle\` not widened → separate accessor), F3 (stale-stats guard), F6 (singular/plural, deterministic rounding).

🤖 Generated with [Claude Code](https://claude.com/claude-code)