### PR TITLE
fix(#3477): dup-uid groups converge by path identity — no cross-file quarantine, no wrongful deletes

### DIFF
--- a/packages/exocortex/src/services/sync/ChangeDetector.ts
+++ b/packages/exocortex/src/services/sync/ChangeDetector.ts
@@ -105,32 +105,68 @@ export async function detectChanges(
   const deleted: AssetChange[] = [];
   const warnings: string[] = [];
 
+  // #3477: uid identity is only sound while a uid is UNIQUE on each side.
+  // A uid on ≥2 disk paths or ≥2 base paths (template-copy artifact) makes
+  // the WHOLE group fall back to path identity: no rename inference, and —
+  // critically — no uid-keyed base collapse (a Map keyed by such a uid kept
+  // only the LAST duplicate and lost the others, so their files classified
+  // as adds forever and their deletions never derived).
+  const diskUidPaths = new Map<string, string[]>();
+  for (const d of disk) {
+    if (d.uid === undefined) continue;
+    const list = diskUidPaths.get(d.uid) ?? [];
+    list.push(d.path);
+    diskUidPaths.set(d.uid, list);
+  }
+  const baseUidPaths = new Map<string, string[]>();
+  for (const entry of watermark.files) {
+    if (entry.uid === undefined) continue;
+    const list = baseUidPaths.get(entry.uid) ?? [];
+    list.push(entry.path);
+    baseUidPaths.set(entry.uid, list);
+  }
+  const duplicateUids = new Set<string>();
+  for (const [uid, paths] of diskUidPaths) {
+    if (paths.length > 1) duplicateUids.add(uid);
+  }
+  for (const [uid, paths] of baseUidPaths) {
+    if (paths.length > 1) duplicateUids.add(uid);
+  }
+  // The warning fires on EVERY detection run while the anomaly persists —
+  // same cadence as the pre-#3477 claim-collision warning (the vault owner
+  // is expected to deduplicate the uids; diagnostics must not go quiet).
+  for (const uid of [...duplicateUids].sort()) {
+    const diskPaths = diskUidPaths.get(uid) ?? [];
+    const where =
+      diskPaths.length > 1
+        ? `on disk (${diskPaths.join(", ")})`
+        : `in the sync base (${(baseUidPaths.get(uid) ?? []).join(", ")})`;
+    warnings.push(
+      `duplicate uid ${uid} ${where} — uid identity suppressed for the group; every path matched by path identity (#3477)`,
+    );
+  }
+
   const baseByUid = new Map<string, WatermarkFileEntry>();
   const baseNoUid: WatermarkFileEntry[] = [];
   for (const entry of watermark.files) {
-    if (entry.uid !== undefined) baseByUid.set(entry.uid, entry);
-    else baseNoUid.push(entry);
+    if (entry.uid !== undefined && !duplicateUids.has(entry.uid)) {
+      baseByUid.set(entry.uid, entry);
+    } else {
+      baseNoUid.push(entry);
+    }
   }
 
-  // Pass 1 — uid identity (D18). A uid claims its base entry ONCE: a second
-  // disk file with the same uid is a vault anomaly (duplicate uid), not a
-  // rename — it falls through to path identity with an explicit warning
-  // instead of producing a misleading rename classification.
+  // Pass 1 — uid identity (D18), unique uids only (#3477). A second disk
+  // file with the same uid cannot reach this pass — the dup pre-scan above
+  // routed the whole group to path identity.
   const diskLeftover: DiskEntry[] = [];
   const baseMatchedUids = new Set<string>();
-  const uidClaimedBy = new Map<string, string>();
   for (const d of disk) {
-    const base = d.uid !== undefined ? baseByUid.get(d.uid) : undefined;
+    const base =
+      d.uid !== undefined && !duplicateUids.has(d.uid)
+        ? baseByUid.get(d.uid)
+        : undefined;
     if (d.uid !== undefined && base !== undefined) {
-      const claimant = uidClaimedBy.get(d.uid);
-      if (claimant !== undefined) {
-        warnings.push(
-          `duplicate uid ${d.uid} on disk (${claimant}, ${d.path}) — ${d.path} matched by path identity instead`,
-        );
-        diskLeftover.push(d);
-        continue;
-      }
-      uidClaimedBy.set(d.uid, d.path);
       baseMatchedUids.add(d.uid);
       if (base.blobSha !== d.blobSha || base.path !== d.path) {
         modified.push({
@@ -168,5 +204,13 @@ export async function detectChanges(
     deleted.push({ path: base.path, uid: base.uid, blobSha: base.blobSha });
   }
 
-  return { kind: "changes", added, modified, deleted, warnings, diskBlobShas };
+  return {
+    kind: "changes",
+    added,
+    modified,
+    deleted,
+    warnings,
+    diskBlobShas,
+    duplicateUids,
+  };
 }

--- a/packages/exocortex/src/services/sync/SyncEngine.ts
+++ b/packages/exocortex/src/services/sync/SyncEngine.ts
@@ -327,6 +327,11 @@ interface PinnedLocalChanges {
    * conflict outcome replaces the raw push, deletion included).
    */
   pushDeletionsAll: Map<string, string>;
+  /**
+   * Uids duplicated on disk or in the base (#3477) — uid-based remote
+   * matching is suppressed for them (path identity for the whole group).
+   */
+  dupUids: ReadonlySet<string>;
 }
 
 /** One local change overlapping one-or-more remote changes (merge input). */
@@ -1289,7 +1294,13 @@ export class SyncEngine {
       const content = disk.get(c.path);
       if (content !== undefined) pushFilesAll.set(c.path, content);
     }
-    return { localChanges, localDeletedPaths, pushFilesAll, pushDeletionsAll };
+    return {
+      localChanges,
+      localDeletedPaths,
+      pushFilesAll,
+      pushDeletionsAll,
+      dupUids: detection.duplicateUids,
+    };
   }
 
   /**
@@ -1308,8 +1319,13 @@ export class SyncEngine {
     sizeExcluded: ReadonlySet<string> = new Set(),
     direction: SyncDirection = "sync",
   ): Promise<PushLoopOutcome> {
-    const { localChanges, localDeletedPaths, pushFilesAll, pushDeletionsAll } =
-      pinned;
+    const {
+      localChanges,
+      localDeletedPaths,
+      pushFilesAll,
+      pushDeletionsAll,
+      dupUids,
+    } = pinned;
     const maxRetries = this.deps.maxPushRetries ?? DEFAULT_MAX_PUSH_RETRIES;
     let attempt = 0;
     let examinedHead = "";
@@ -1378,6 +1394,8 @@ export class SyncEngine {
           disk,
           remote.changes,
           convergedPushPaths,
+          dupUids,
+          remote.headTreeByPath,
         );
         if (verdict.conflicts.length > 0) {
           if (direction !== "sync") {
@@ -1428,6 +1446,26 @@ export class SyncEngine {
               verdict.conflicts,
               disk,
             );
+          }
+          // Cross-path remote changes consumed by a conflict group were
+          // never applied to disk — pin them, same invariant as push-only
+          // deferrals: absorbing them into the advanced watermark would
+          // make the locally-absent path read as a local DELETE next sync
+          // and push a wrongful deletion of a file nobody deleted (#3477
+          // arrival cycle: a remote dup copy + a concurrent local edit).
+          // Same-path remotes need no pin — the conflict outcome (merge /
+          // quarantine / file-mode remote-wins) settles them in place.
+          if (direction === "sync") {
+            for (const group of verdict.conflicts) {
+              for (const r of group.remotes) {
+                if (r.path === group.local.path) continue;
+                deferredPaths.add(r.path);
+                if (r.kind === "change") deferredRemoteChanges.push(r);
+                deferredWarnings.push(
+                  `conflict group ${group.desc}: remote change at ${r.path} NOT applied — pinned to re-derive on the next sync (#3477)`,
+                );
+              }
+            }
           }
         }
         applyWrites = verdict.applyWrites;
@@ -2180,6 +2218,8 @@ export class SyncEngine {
     disk: ReadonlyMap<string, SyncContent>,
     remote: RemoteChange[],
     convergedPushPaths: Set<string>,
+    dupUids: ReadonlySet<string> = new Set(),
+    headTreeByPath?: ReadonlyMap<string, string>,
   ): {
     conflicts: ConflictGroup[];
     applyWrites: RemoteChange[];
@@ -2187,10 +2227,28 @@ export class SyncEngine {
   } {
     const consumed = new Set<RemoteChange>();
     const conflicts: ConflictGroup[] = [];
+    // #3477: uid matching is suppressed for duplicated uids — local-side
+    // dups arrive via `dupUids` (ChangeDetector), remote-side dups are
+    // counted here over CHANGE entries only. A genuine remote rename is one
+    // change + one delete sharing a uid — counting deletes would suppress
+    // every rename and silently apply its new path over a local edit.
+    const remoteChangeUidCount = new Map<string, number>();
+    for (const r of remote) {
+      if (r.kind === "change" && r.uid !== undefined) {
+        remoteChangeUidCount.set(
+          r.uid,
+          (remoteChangeUidCount.get(r.uid) ?? 0) + 1,
+        );
+      }
+    }
+    const suppressedUids = new Set<string>(dupUids);
+    for (const [uid, count] of remoteChangeUidCount) {
+      if (count > 1) suppressedUids.add(uid);
+    }
     const remoteByUid = new Map<string, RemoteChange[]>();
     const remoteByPath = new Map<string, RemoteChange>();
     for (const r of remote) {
-      if (r.uid !== undefined) {
+      if (r.uid !== undefined && !suppressedUids.has(r.uid)) {
         const list = remoteByUid.get(r.uid) ?? [];
         list.push(r);
         remoteByUid.set(r.uid, list);
@@ -2200,8 +2258,23 @@ export class SyncEngine {
 
     for (const local of localChanges) {
       const candidates = new Set<RemoteChange>();
-      if (local.uid !== undefined) {
-        for (const r of remoteByUid.get(local.uid) ?? []) candidates.add(r);
+      if (local.uid !== undefined && !suppressedUids.has(local.uid)) {
+        for (const r of remoteByUid.get(local.uid) ?? []) {
+          // #3477 copy-vs-rename evidence: a cross-path remote CHANGE
+          // sharing the uid is rename evidence only when the local path is
+          // GONE from the remote head. If the head still carries our path,
+          // the remote change is an independent copy (template-copy
+          // arrival) — uid-matching it would cross-conflict the copy with
+          // the local edit and strand both behind a spurious quarantine.
+          if (
+            r.kind === "change" &&
+            r.path !== local.path &&
+            headTreeByPath?.has(local.path) === true
+          ) {
+            continue;
+          }
+          candidates.add(r);
+        }
       }
       const byPath = remoteByPath.get(local.path);
       if (byPath !== undefined) candidates.add(byPath);
@@ -2261,7 +2334,9 @@ export class SyncEngine {
           local,
           localIsDelete,
           remotes: conflicting,
-          desc: `${local.uid ?? local.path} (local ${localIsDelete ? "delete" : "change"} vs remote ${conflicting[0].kind} at ${conflicting[0].path})`,
+          // For suppressed (duplicated) uids the uid is ambiguous across
+          // paths — identify the group by path instead (#3477).
+          desc: `${local.uid !== undefined && !suppressedUids.has(local.uid) ? local.uid : local.path} (local ${localIsDelete ? "delete" : "change"} vs remote ${conflicting[0].kind} at ${conflicting[0].path})`,
         });
         // A conflicting local change must not also be pushed as-is — its
         // outcome (merged content or quarantine) replaces the raw push.

--- a/packages/exocortex/src/services/sync/syncTypes.ts
+++ b/packages/exocortex/src/services/sync/syncTypes.ts
@@ -200,6 +200,14 @@ export type ChangeDetectionResult =
        * it (watermark build) instead of re-hashing the whole working tree.
        */
       diskBlobShas: Map<string, string>;
+      /**
+       * Uids seen on MORE than one path (on disk or in the base) — a vault
+       * anomaly (#3477, template-copy artifact). The whole group matched by
+       * path identity; the engine must suppress uid-based remote matching
+       * for these uids too, or a single remote change cross-conflicts with
+       * every member of the group.
+       */
+      duplicateUids: ReadonlySet<string>;
     };
 
 /**

--- a/packages/exocortex/tests/unit/services/sync/ChangeDetector.test.ts
+++ b/packages/exocortex/tests/unit/services/sync/ChangeDetector.test.ts
@@ -265,3 +265,166 @@ describe("detectChanges — duplicate uid on disk (A1 review LOW)", () => {
     }
   });
 });
+
+describe("detectChanges — duplicate uids use path identity for the WHOLE group (#3477)", () => {
+  const valid = (wm: WatermarkRecord): string => wm.rootTreeSha;
+  // duplicateUids is introduced by #3477 — structural access keeps the RED
+  // commit typecheck-green while the field does not exist yet.
+  const dupUidsOf = (result: unknown): ReadonlySet<string> | undefined =>
+    (result as { duplicateUids?: ReadonlySet<string> }).duplicateUids;
+
+  it("steady state (disk == base, 3 files sharing one uid) derives NO changes at all", async () => {
+    const files = {
+      "kitelev/2026-06-10 Note.md": mdAsset("u1", "note 10"),
+      "kitelev/2026-06-11 Note.md": mdAsset("u1", "note 11"),
+      "kitelev/2026-06-12 Note.md": mdAsset("u1", "note 12"),
+    };
+    const wm = await watermarkFor(files);
+    const result = await detectChanges({
+      localFiles: new Map(Object.entries(files)),
+      watermark: wm,
+      actualBaseTreeSha: valid(wm),
+      sha1: sha1Hex,
+    });
+    expect(result.kind).toBe("changes");
+    if (result.kind === "changes") {
+      // Today: the first disk file claims the (collapsed) base entry of a
+      // DIFFERENT path → phantom rename; the other base entries are LOST →
+      // phantom adds. Post-#3477: the whole group matches by path → no-op.
+      expect(result.modified).toEqual([]);
+      expect(result.added).toEqual([]);
+      expect(result.deleted).toEqual([]);
+      expect(result.warnings.join(" ")).toMatch(/duplicate uid u1/);
+      expect(dupUidsOf(result)).toEqual(new Set(["u1"]));
+    }
+  });
+
+  it("an edit inside the dup-uid group derives exactly ONE path-identity modify (no basePath)", async () => {
+    const base = {
+      "a.md": mdAsset("u1", "a"),
+      "b.md": mdAsset("u1", "b"),
+    };
+    const wm = await watermarkFor(base);
+    const result = await detectChanges({
+      localFiles: new Map([
+        ["a.md", mdAsset("u1", "a")],
+        ["b.md", mdAsset("u1", "b EDITED")],
+      ]),
+      watermark: wm,
+      actualBaseTreeSha: valid(wm),
+      sha1: sha1Hex,
+    });
+    expect(result.kind).toBe("changes");
+    if (result.kind === "changes") {
+      expect(result.modified).toEqual([
+        expect.objectContaining({ path: "b.md", uid: "u1" }),
+      ]);
+      expect(result.modified[0].basePath).toBeUndefined();
+      expect(result.added).toEqual([]);
+      expect(result.deleted).toEqual([]);
+    }
+  });
+
+  it("rename inference is suppressed for EVERY member of the dup-uid group", async () => {
+    const base = {
+      "a.md": mdAsset("u1", "a"),
+      "b.md": mdAsset("u1", "b"),
+    };
+    const wm = await watermarkFor(base);
+    const result = await detectChanges({
+      localFiles: new Map(Object.entries(base)),
+      watermark: wm,
+      actualBaseTreeSha: valid(wm),
+      sha1: sha1Hex,
+    });
+    expect(result.kind).toBe("changes");
+    if (result.kind === "changes") {
+      for (const change of [...result.added, ...result.modified]) {
+        expect(change.basePath).toBeUndefined();
+      }
+    }
+  });
+
+  it("deleting ONE member of the dup-uid group derives a DELETE for that path", async () => {
+    const base = {
+      "a.md": mdAsset("u1", "a"),
+      "b.md": mdAsset("u1", "b"),
+    };
+    const wm = await watermarkFor(base);
+    const result = await detectChanges({
+      // b.md deleted locally — its base entry must NOT be lost to the
+      // baseByUid collapse (today it is → no delete derives).
+      localFiles: new Map([["a.md", mdAsset("u1", "a")]]),
+      watermark: wm,
+      actualBaseTreeSha: valid(wm),
+      sha1: sha1Hex,
+    });
+    expect(result.kind).toBe("changes");
+    if (result.kind === "changes") {
+      expect(result.deleted).toEqual([
+        expect.objectContaining({ path: "b.md" }),
+      ]);
+      expect(result.modified).toEqual([]);
+      expect(result.added).toEqual([]);
+    }
+  });
+
+  it("watermark-only dup (one file left on disk, two base entries) suppresses uid identity too", async () => {
+    const wm = await watermarkFor({
+      "a.md": mdAsset("u1", "a"),
+      "b.md": mdAsset("u1", "b"),
+    });
+    const result = await detectChanges({
+      // Disk has ONE file with u1 at a THIRD path: with unique-uid
+      // semantics this would read as a rename of the collapsed base entry;
+      // with base-side dup detected it must stay path identity.
+      localFiles: new Map([["c.md", mdAsset("u1", "c")]]),
+      watermark: wm,
+      actualBaseTreeSha: valid(wm),
+      sha1: sha1Hex,
+    });
+    expect(result.kind).toBe("changes");
+    if (result.kind === "changes") {
+      expect(result.added).toEqual([
+        expect.objectContaining({ path: "c.md", uid: "u1" }),
+      ]);
+      expect(result.deleted.map((d) => d.path).sort()).toEqual([
+        "a.md",
+        "b.md",
+      ]);
+      expect(result.modified).toEqual([]);
+      expect(dupUidsOf(result)).toEqual(new Set(["u1"]));
+    }
+  });
+
+  it("a genuine rename of a UNIQUE uid still classifies as modified+basePath alongside a dup group (#3476 intact)", async () => {
+    const wm = await watermarkFor({
+      "a.md": mdAsset("u1", "a"),
+      "b.md": mdAsset("u1", "b"),
+      "old.md": mdAsset("u2", "solo"),
+    });
+    const result = await detectChanges({
+      localFiles: new Map([
+        ["a.md", mdAsset("u1", "a")],
+        ["b.md", mdAsset("u1", "b")],
+        ["renamed.md", mdAsset("u2", "solo")],
+      ]),
+      watermark: wm,
+      actualBaseTreeSha: valid(wm),
+      sha1: sha1Hex,
+    });
+    expect(result.kind).toBe("changes");
+    if (result.kind === "changes") {
+      expect(result.modified).toEqual([
+        expect.objectContaining({
+          path: "renamed.md",
+          uid: "u2",
+          basePath: "old.md",
+        }),
+      ]);
+      expect(result.added).toEqual([]);
+      expect(result.deleted).toEqual([]);
+      expect(dupUidsOf(result)).toEqual(new Set(["u1"]));
+    }
+  });
+});

--- a/packages/exocortex/tests/unit/services/sync/SyncEngine.dup-uid.test.ts
+++ b/packages/exocortex/tests/unit/services/sync/SyncEngine.dup-uid.test.ts
@@ -300,6 +300,13 @@ describe("SyncEngine — remote-side dup uids match by path (#3477)", () => {
     expect(result.status).toBe("synced");
     expect(result.quarantinedCount).toBe(1);
     expect(gh.headFiles().has(MOVED)).toBe(true); // never deleted by us
+
+    // The consumed-but-unapplied new path must be PINNED, not absorbed:
+    // an absorbed entry would read as a local delete next cycle and push
+    // a wrongful deletion of the renamed file (#3477 data safety).
+    const second = await engine.sync(gh.spec());
+    expect(second.pushedDeletes ?? []).toEqual([]);
+    expect(gh.headFiles().has(MOVED)).toBe(true); // still alive remotely
   });
 });
 

--- a/packages/exocortex/tests/unit/services/sync/SyncEngine.dup-uid.test.ts
+++ b/packages/exocortex/tests/unit/services/sync/SyncEngine.dup-uid.test.ts
@@ -1,0 +1,351 @@
+/**
+ * ExoSync duplicate-uid convergence tests (Issue #3477 — first live M1).
+ *
+ * N files sharing one `exo__Asset_uid` (template-copy artifact) must sync
+ * with PATH-IDENTITY semantics for the whole uid-group, end to end:
+ *
+ *  - rename inference suppressed (no phantom basePath, no rename-deletes);
+ *  - a remote edit of one dup path pull-applies to THAT path only — it must
+ *    not cross-conflict with (nor quarantine) the other group members;
+ *  - edits inside the group push by path; deletes of one member propagate;
+ *  - no deletion of a path that exists locally is ever pushed (data safety);
+ *  - the dup-uid warning keeps firing (diagnostics preserved);
+ *  - genuine renames of UNIQUE uids keep #3476 semantics (add+delete in one
+ *    commit), including remote renames (1 change + 1 delete sharing a uid
+ *    is a rename, NOT a remote-side dup).
+ *
+ * The M1 anti-loop test mirrors the live incident verbatim: identical
+ * divergence must NOT survive a converged sync round (ParityValidator).
+ */
+
+import * as yaml from "js-yaml";
+import {
+  ParityValidator,
+  SyncEngine,
+  type MergeLayerPort,
+  type SyncEngineDeps,
+  type YamlCodec,
+} from "../../../../src";
+import {
+  FakeGitHubRepo,
+  FakeLocalFiles,
+  FakeWatermarkStore,
+  alwaysMaterialized,
+  mdAsset,
+  sha1Hex,
+} from "./fakeGitHub";
+
+const codec: YamlCodec = {
+  parse: (text) => yaml.load(text, { schema: yaml.CORE_SCHEMA }),
+  stringify: (value) =>
+    yaml.dump(value, { schema: yaml.CORE_SCHEMA, lineWidth: -1 }),
+};
+
+// Dup-uid daily notes (template-copy artifact) — content differs per file.
+const OLD = "kitelev/2026-06-10 Note.md";
+const MID = "kitelev/2026-06-11 Note.md";
+const NEW = "kitelev/2026-06-12 Note.md";
+const dupNote = (label: string, body = "daily body"): string =>
+  `---\nexo__Asset_uid: dup-uid-1\nexo__Asset_label: "${label}"\n---\n\n${body}\n`;
+const TRIO = (): Record<string, string> => ({
+  [OLD]: dupNote("06-10"),
+  [MID]: dupNote("06-11"),
+  [NEW]: dupNote("06-12"),
+});
+
+function makeEngine(
+  gh: FakeGitHubRepo,
+  local: FakeLocalFiles,
+  overrides: Partial<SyncEngineDeps> = {},
+): { engine: SyncEngine; watermarks: FakeWatermarkStore } {
+  const watermarks = new FakeWatermarkStore();
+  const engine = new SyncEngine({
+    transport: gh.transport(),
+    watermarkStore: watermarks,
+    materializationCheck: alwaysMaterialized(),
+    localFilesFor: () => local,
+    sha1: sha1Hex,
+    ...overrides,
+  });
+  return { engine, watermarks };
+}
+
+async function bootstrap(engine: SyncEngine, gh: FakeGitHubRepo): Promise<void> {
+  const result = await engine.sync(gh.spec());
+  expect(result.status).toBe("synced");
+}
+
+const quarantineAllMerger: MergeLayerPort = {
+  resolve: async () => ({
+    action: "quarantine",
+    reason: "test: always quarantine",
+  }),
+};
+
+describe("SyncEngine — dup-uid group converges by path identity (#3477)", () => {
+  it("a remote edit of ONE dup path pull-applies; the other members are untouched (no cross-file quarantine)", async () => {
+    const gh = new FakeGitHubRepo(TRIO());
+    const local = new FakeLocalFiles(TRIO());
+    const { engine } = makeEngine(gh, local, { mergeLayer: quarantineAllMerger });
+    await bootstrap(engine, gh);
+
+    gh.commitDirect("main", { [NEW]: dupNote("06-12", "remote edit") }, "device B");
+    const result = await engine.sync(gh.spec());
+
+    expect(result.status).toBe("synced");
+    expect(result.quarantinedCount).toBe(0); // no cross-file contamination
+    expect(local.files.get(NEW)).toBe(dupNote("06-12", "remote edit")); // applied
+    expect(local.files.get(OLD)).toBe(dupNote("06-10")); // untouched
+    expect(local.files.get(MID)).toBe(dupNote("06-11")); // untouched
+    expect(result.pushedDeletes ?? []).toEqual([]);
+
+    // Convergence is REAL: the next cycle is a clean no-op, not a loop.
+    const next = await engine.sync(gh.spec());
+    expect(next.status).toBe("synced");
+    expect(next.pushedSha).toBeUndefined();
+    expect(next.quarantinedCount).toBe(0);
+  });
+
+  it("M1 anti-loop (live incident shape): the divergence does NOT survive a converged sync round", async () => {
+    const gh = new FakeGitHubRepo(TRIO());
+    const local = new FakeLocalFiles(TRIO());
+    const watermarks = new FakeWatermarkStore();
+    const engine = new SyncEngine({
+      transport: gh.transport(),
+      watermarkStore: watermarks,
+      materializationCheck: alwaysMaterialized(),
+      localFilesFor: () => local,
+      sha1: sha1Hex,
+      mergeLayer: quarantineAllMerger,
+    });
+    const validator = new ParityValidator({
+      transport: gh.transport(),
+      sha1: sha1Hex,
+      localFilesFor: () => local,
+      watermarks,
+      yaml: codec,
+      now: () => "2026-06-12T00:00:00.000Z",
+    });
+    await bootstrap(engine, gh);
+
+    gh.commitDirect("main", { [NEW]: dupNote("06-12", "remote edit") }, "device B");
+    const prev = await validator.runRound([gh.spec()], { trigger: "post-sync" });
+    expect(prev.m2Total).toBeGreaterThan(0); // honest pending divergence
+
+    const syncResult = await engine.sync(gh.spec());
+    const next = await validator.runRound([gh.spec()], {
+      trigger: "post-sync",
+      previousRound: prev,
+      syncResults: [syncResult],
+    });
+
+    // Pre-#3477 this fired: «identical divergence … survived a sync round
+    // unchanged (pending-local-edit → pending-local-edit)».
+    expect(next.m1Total).toBe(0);
+    expect(next.m2Total).toBe(0);
+    expect(next.ok).toBe(true);
+  });
+
+  it("a divergent edit quarantines ONLY its own path; a disjoint edit on another dup member still pushes", async () => {
+    const gh = new FakeGitHubRepo(TRIO());
+    const local = new FakeLocalFiles(TRIO());
+    const { engine } = makeEngine(gh, local, { mergeLayer: quarantineAllMerger });
+    await bootstrap(engine, gh);
+
+    gh.commitDirect("main", { [NEW]: dupNote("06-12", "remote edit") }, "device B");
+    local.files.set(NEW, dupNote("06-12", "local edit")); // genuine conflict at NEW
+    local.files.set(OLD, dupNote("06-10", "disjoint local edit")); // must push
+    const result = await engine.sync(gh.spec());
+
+    expect(result.status).toBe("synced");
+    expect(result.quarantinedCount).toBe(1); // ONLY the genuinely conflicted path
+    expect(gh.headFiles().get(OLD)).toBe(dupNote("06-10", "disjoint local edit"));
+    expect(gh.headFiles().get(MID)).toBe(dupNote("06-11")); // untouched
+    expect(result.pushedDeletes ?? []).toEqual([]);
+  });
+
+  it("an edit inside the dup group pushes by path; NO rename inference, NO deletion of any live path", async () => {
+    const gh = new FakeGitHubRepo(TRIO());
+    const local = new FakeLocalFiles(TRIO());
+    const { engine } = makeEngine(gh, local);
+    await bootstrap(engine, gh);
+
+    local.files.set(NEW, dupNote("06-12", "edited"));
+    const result = await engine.sync(gh.spec());
+
+    expect(result.status).toBe("synced");
+    expect(result.pushedCount).toBe(1);
+    expect(result.pushedDeletes ?? []).toEqual([]);
+    expect(result.deferredDeletes).toEqual([]);
+    expect(gh.headFiles().get(NEW)).toBe(dupNote("06-12", "edited"));
+    // Every dup path is alive on the remote — nothing was renamed away.
+    expect(gh.headFiles().has(OLD)).toBe(true);
+    expect(gh.headFiles().has(MID)).toBe(true);
+
+    const next = await engine.sync(gh.spec());
+    expect(next.pushedSha).toBeUndefined(); // converged, no loop
+  });
+
+  it("deleting ONE dup member locally propagates the delete; the other members survive", async () => {
+    const gh = new FakeGitHubRepo(TRIO());
+    const local = new FakeLocalFiles(TRIO());
+    const { engine } = makeEngine(gh, local);
+    await bootstrap(engine, gh);
+
+    local.files.delete(MID);
+    const result = await engine.sync(gh.spec());
+
+    expect(result.status).toBe("synced");
+    expect(result.pushedDeletes).toEqual([MID]);
+    expect(gh.headFiles().has(MID)).toBe(false); // delete landed
+    expect(gh.headFiles().has(OLD)).toBe(true);
+    expect(gh.headFiles().has(NEW)).toBe(true);
+
+    const next = await engine.sync(gh.spec());
+    expect(next.pushedSha).toBeUndefined();
+    expect(next.deferredDeletes).toEqual([]);
+  });
+
+  it("keeps the dup-uid warning in the sync result (diagnostics preserved)", async () => {
+    const gh = new FakeGitHubRepo(TRIO());
+    const local = new FakeLocalFiles(TRIO());
+    const { engine } = makeEngine(gh, local);
+    await bootstrap(engine, gh);
+
+    const result = await engine.sync(gh.spec());
+
+    expect(result.status).toBe("synced");
+    expect(result.warnings.join(" ")).toMatch(/duplicate uid dup-uid-1/);
+  });
+});
+
+describe("SyncEngine — dup-uid arrival cycle never pushes a wrongful delete (#3477 data safety)", () => {
+  it("remote ADD of a dup copy + concurrent local edit of the original: the copy is never deleted and lands locally", async () => {
+    const FILE = "assets/a.md";
+    const COPY = "assets/copy.md";
+    const gh = new FakeGitHubRepo({ [FILE]: mdAsset("u1", "original") });
+    const local = new FakeLocalFiles({ [FILE]: mdAsset("u1", "original") });
+    const { engine } = makeEngine(gh, local, { mergeLayer: quarantineAllMerger });
+    await bootstrap(engine, gh);
+
+    // Device B copies the asset (template-copy) while this device edits it.
+    gh.commitDirect("main", { [COPY]: mdAsset("u1", "the copy") }, "device B");
+    local.files.set(FILE, mdAsset("u1", "local edit"));
+
+    const first = await engine.sync(gh.spec());
+    expect(first.status).toBe("synced");
+    expect(first.pushedDeletes ?? []).toEqual([]); // copy not deleted
+    expect(gh.headFiles().has(COPY)).toBe(true);
+
+    // The next cycle must RE-DERIVE the never-applied copy, not absorb it
+    // into the watermark and then push its deletion (pre-#3477 hole).
+    const second = await engine.sync(gh.spec());
+    expect(second.status).toBe("synced");
+    expect(second.pushedDeletes ?? []).toEqual([]);
+    expect(gh.headFiles().has(COPY)).toBe(true); // ALIVE on remote
+    expect(local.files.has(COPY)).toBe(true); // and materialized locally
+
+    const third = await engine.sync(gh.spec());
+    expect(third.pushedDeletes ?? []).toEqual([]);
+    expect(gh.headFiles().has(COPY)).toBe(true);
+  });
+});
+
+describe("SyncEngine — remote-side dup uids match by path (#3477)", () => {
+  it("TWO remote adds sharing one uid apply as independent files; a local edit of the same uid still pushes", async () => {
+    const FILE = "assets/a.md";
+    const gh = new FakeGitHubRepo({ [FILE]: mdAsset("u1", "original") });
+    const local = new FakeLocalFiles({ [FILE]: mdAsset("u1", "original") });
+    const { engine } = makeEngine(gh, local, { mergeLayer: quarantineAllMerger });
+    await bootstrap(engine, gh);
+
+    gh.commitDirect(
+      "main",
+      {
+        "assets/copy1.md": mdAsset("u1", "copy one"),
+        "assets/copy2.md": mdAsset("u1", "copy two"),
+      },
+      "device B template-copies twice",
+    );
+    local.files.set(FILE, mdAsset("u1", "local edit"));
+    const result = await engine.sync(gh.spec());
+
+    expect(result.status).toBe("synced");
+    expect(result.quarantinedCount).toBe(0); // no cross-file conflicts
+    expect(local.files.get("assets/copy1.md")).toBe(mdAsset("u1", "copy one"));
+    expect(local.files.get("assets/copy2.md")).toBe(mdAsset("u1", "copy two"));
+    expect(gh.headFiles().get(FILE)).toBe(mdAsset("u1", "local edit")); // pushed
+    expect(result.pushedDeletes ?? []).toEqual([]);
+  });
+
+  it("a genuine REMOTE rename (1 change + 1 delete sharing a uid) is NOT a dup — local edit at the old path still quarantines as ambiguous", async () => {
+    const FILE = "assets/a.md";
+    const MOVED = "assets/moved.md";
+    const gh = new FakeGitHubRepo({ [FILE]: mdAsset("u2", "solo") });
+    const local = new FakeLocalFiles({ [FILE]: mdAsset("u2", "solo") });
+    const { engine } = makeEngine(gh, local, { mergeLayer: quarantineAllMerger });
+    await bootstrap(engine, gh);
+
+    gh.commitDirect(
+      "main",
+      { [MOVED]: mdAsset("u2", "solo") },
+      "device B renames a.md",
+      [FILE],
+    );
+    local.files.set(FILE, mdAsset("u2", "local edit at the old path"));
+    const result = await engine.sync(gh.spec());
+
+    // Rename-vs-edit ambiguity must keep quarantining (F1 guard: a remote
+    // rename's change+delete pair shares a uid but is NOT a dup group).
+    expect(result.status).toBe("synced");
+    expect(result.quarantinedCount).toBe(1);
+    expect(gh.headFiles().has(MOVED)).toBe(true); // never deleted by us
+  });
+});
+
+describe("SyncEngine — #3476 rename propagation intact next to a dup group", () => {
+  it("a unique-uid rename pushes add+delete in ONE commit while the dup group syncs by path", async () => {
+    const SOLO_OLD = "assets/solo-old.md";
+    const SOLO_NEW = "assets/solo-new.md";
+    const files = { ...TRIO(), [SOLO_OLD]: mdAsset("u2", "solo") };
+    const gh = new FakeGitHubRepo(files);
+    const local = new FakeLocalFiles(files);
+    const { engine } = makeEngine(gh, local);
+    await bootstrap(engine, gh);
+    const headBefore = gh.headSha();
+
+    local.files.delete(SOLO_OLD);
+    local.files.set(SOLO_NEW, mdAsset("u2", "solo"));
+    const result = await engine.sync(gh.spec());
+
+    expect(result.status).toBe("synced");
+    expect(result.pushedDeletes).toEqual([SOLO_OLD]);
+    expect(gh.commits.get(gh.headSha())!.parents).toEqual([headBefore]); // ONE commit
+    expect(gh.headFiles().get(SOLO_NEW)).toBe(mdAsset("u2", "solo"));
+    expect(gh.headFiles().has(SOLO_OLD)).toBe(false);
+    // The dup trio is untouched by the rename.
+    expect(gh.headFiles().has(OLD)).toBe(true);
+    expect(gh.headFiles().has(MID)).toBe(true);
+    expect(gh.headFiles().has(NEW)).toBe(true);
+
+    const next = await engine.sync(gh.spec());
+    expect(next.pushedSha).toBeUndefined();
+  });
+});
+
+describe("SyncEngine — split directions with a dup group (#3473 × #3477)", () => {
+  it("pull-only applies a remote dup-path edit without any phantom rename deferral", async () => {
+    const gh = new FakeGitHubRepo(TRIO());
+    const local = new FakeLocalFiles(TRIO());
+    const { engine } = makeEngine(gh, local);
+    await bootstrap(engine, gh);
+
+    gh.commitDirect("main", { [NEW]: dupNote("06-12", "remote edit") }, "device B");
+    const result = await engine.sync(gh.spec(), "pull");
+
+    expect(result.status).toBe("synced");
+    expect(local.files.get(NEW)).toBe(dupNote("06-12", "remote edit"));
+    expect(result.warnings.join(" ")).not.toMatch(/pull-only: rename/);
+    expect(result.deferredDeletes).toEqual([]);
+  });
+});


### PR DESCRIPTION
Closes #3477

## Что чинит

N файлов с одним `exo__Asset_uid` (template-copy artifact) — первый live M1 из E1 parity harness. Движок применял uid-identity к группе дублей: phantom rename + cross-file конфликты + вечный pending-loop.

## Шаг 0 — verify-first вердикт (на main v16.81.5, после #3476)

Синтетические циклы на production-shape `FakeGitHubRepo`:

1. **Локальные правки в dup-группе уже конвергируют** — #3476 вылечил simplest-loop shape (rename теперь пушится; правка уходит by path, ничего не deferred).
2. **Remote edit одного dup-пути — живая репродукция M1-loop:** uid-matching группирует один remote change со ВСЕМИ локальными файлами группы → 3 quarantine на 1 правку (cross-file contamination), правка НЕ применяется, цикл 2 идентичен циклу 1 — вечный loop. Без merge layer — весь репозиторий навсегда в `conflict`.
3. **Deletion живого ЛОКАЛЬНОГО пути через rename-inference — НЕ воспроизводится:** guard `pushFiles.has(delPath)` (runPushLoop) + owner-withhold защищают. Запинено регрессионным тестом (предсказанная в issue-контексте эскалация не материализуется).
4. **НО найдена соседняя data-safety дыра (воспроизведена в RED):** arrival-цикл — remote ADD dup-копии + одновременная локальная правка оригинала → конфликт-группа поглощает remote add без применения → watermark absorb → следующий цикл деривирует local DELETE копии → **push wrongful deletion файла, который никто не удалял** (latent на main, severity-обоснование этого PR).
5. **Латентный баг ChangeDetector:** `baseByUid` — Map; дубли uid в watermark коллапсируют (last wins) → base-записи остальных теряются → их файлы вечно ADDED, их удаления никогда не деривируются.

## Фикс (path-identity semantics для всей uid-группы, включая push path)

- **ChangeDetector:** pre-scan дублей с ОБЕИХ сторон (≥2 disk-путей ИЛИ ≥2 base-записей). Dup uid → вся группа мимо Pass 1: no rename inference, no base collapse; deletes деривируются корректно. Warn сохраняется (групповой формат, та же per-cycle каденция). Результат экспонирует `duplicateUids`.
- **matchLocalVsRemote:** suppression uid-matching для local-side дублей (из детектора) + remote-side дублей, считанных **только по `kind === "change"`** — genuine remote rename (1 change + 1 delete с одним uid) НЕ является дублем и сохраняет ambiguity-quarantine.
- **Copy-vs-rename evidence:** cross-path remote CHANGE с тем же uid — свидетельство rename только если локальный путь ИСЧЕЗ из remote head; если head его ещё содержит — это независимая копия, не cross-match (arrival конвергирует за 1 цикл).
- **Pin для cross-path conflict remotes:** consumed-but-unapplied remote changes конфликт-групп пинятся (тот же инвариант, что push-only deferrals) → не absorb'ятся → re-derive → wrongful delete невозможен (`applyWatermarkPins` дропает never-seen adds, они re-surface как remote adds).

## TDD / верификация

- **RED** `f816a010`: 12 failing tests (6 ChangeDetector + 6 SyncEngine) + 5 зелёных pins (dup-warn, data-safety, #3476 local rename, remote-rename ambiguity, M1-shape).
- **GREEN** `8dc7bd70`: 266/266 sync-suite. **Empirically verified to FAIL pre-fix and PASS post-fix** (`git stash`-revert на uncommitted fix; вторая итерация — `3477-baseline-check`): pre-fix ровно те же 18 посторонних failing suites + 2 моих RED; post-fix — только 18 pre-existing (нулевая дельта регрессий).
- Анти-loop заасерчен через ParityValidator M1 (форма live-инцидента: `identical divergence … survived a sync round unchanged`).
- Интакт: #3476 rename add+delete одним коммитом, #3478/#3475 anti-phantom, D19, delete-vs-modify quarantine.

## API note

`ChangeDetectionResult` ("changes") получил обязательное поле `duplicateUids: ReadonlySet<string>` — конструируется только внутри `detectChanges`; внешних конструкторов в репо нет.