### PR TITLE
feat(cli): audit ontology-imports — imports DAG invariant detector (RFC df39007b PR1)

### DIFF
--- a/packages/cli/src/adapters/CachingNodeFsAdapter.ts
+++ b/packages/cli/src/adapters/CachingNodeFsAdapter.ts
@@ -1,4 +1,3 @@
-import yaml from "js-yaml";
 import { NodeFsAdapter } from "./NodeFsAdapter.js";
 
 /**
@@ -56,7 +55,9 @@ export class CachingNodeFsAdapter extends NodeFsAdapter {
           // Single read serves both frontmatter and body — the audit hot loop
           // must not re-read 11k+ files from disk a second time.
           content = await super.readFile(rel);
-          metadata = CachingNodeFsAdapter.parseFrontmatter(content);
+          // Same parser as the base getFileMetadata path — two parse paths
+          // selected by a constructor flag must never drift.
+          metadata = this.extractFrontmatter(content);
         } else {
           metadata = await super.getFileMetadata(rel);
         }
@@ -112,20 +113,6 @@ export class CachingNodeFsAdapter extends NodeFsAdapter {
     const slash = rel.lastIndexOf("/");
     const name = slash === -1 ? rel : rel.slice(slash + 1);
     return name.endsWith(".md") ? name.slice(0, -3) : name;
-  }
-
-  /** Mirror base NodeFsAdapter.extractFrontmatter (private there). */
-  private static parseFrontmatter(content: string): Record<string, unknown> {
-    const match = content.match(/^---\n([\s\S]*?)\n---/);
-    if (!match) return {};
-    try {
-      const parsed = yaml.load(match[1]);
-      return typeof parsed === "object" && parsed !== null
-        ? (parsed as Record<string, unknown>)
-        : {};
-    } catch {
-      return {};
-    }
   }
 
   /** All indexed assets (path + frontmatter), reusing the single index pass. */

--- a/packages/cli/src/adapters/CachingNodeFsAdapter.ts
+++ b/packages/cli/src/adapters/CachingNodeFsAdapter.ts
@@ -1,11 +1,16 @@
+import yaml from "js-yaml";
 import { NodeFsAdapter } from "./NodeFsAdapter.js";
 
 /**
  * One indexed markdown asset: its vault-relative path and parsed frontmatter.
+ * `content` is populated only when the adapter was constructed with
+ * `cacheContent: true` (body-link audits need the raw text; plain
+ * frontmatter audits should not pay the memory cost).
  */
 export interface IndexedAsset {
   path: string;
   metadata: Record<string, unknown>;
+  content?: string;
 }
 
 /**
@@ -26,12 +31,15 @@ export interface IndexedAsset {
 export class CachingNodeFsAdapter extends NodeFsAdapter {
   private indexed = false;
   private readonly uidToPath = new Map<string, string>();
+  private readonly basenameToPaths = new Map<string, string[]>();
   private readonly allPaths: string[] = [];
   private readonly pathSet = new Set<string>();
   private readonly assets: IndexedAsset[] = [];
+  private readonly cacheContent: boolean;
 
-  constructor(rootPath: string) {
+  constructor(rootPath: string, options?: { cacheContent?: boolean }) {
     super(rootPath);
+    this.cacheContent = options?.cacheContent ?? false;
   }
 
   /** Build the index once (idempotent). One disk pass over all markdown files. */
@@ -42,8 +50,16 @@ export class CachingNodeFsAdapter extends NodeFsAdapter {
       this.allPaths.push(rel);
       this.pathSet.add(rel);
       let metadata: Record<string, unknown> = {};
+      let content: string | undefined;
       try {
-        metadata = await super.getFileMetadata(rel);
+        if (this.cacheContent) {
+          // Single read serves both frontmatter and body — the audit hot loop
+          // must not re-read 11k+ files from disk a second time.
+          content = await super.readFile(rel);
+          metadata = CachingNodeFsAdapter.parseFrontmatter(content);
+        } else {
+          metadata = await super.getFileMetadata(rel);
+        }
       } catch {
         metadata = {};
       }
@@ -57,9 +73,59 @@ export class CachingNodeFsAdapter extends NodeFsAdapter {
           this.uidToPath.set(key, rel);
         }
       }
-      this.assets.push({ path: rel, metadata });
+      // Basename index, symmetric to uidToPath (RFC df39007b §Шаг 1): the
+      // imports audit resolves ~50k+ wikilink targets — a per-link linear
+      // scan over all paths would be O(N·M). ALL paths sharing a basename are
+      // kept so callers can detect ambiguity instead of silently guessing.
+      const base = CachingNodeFsAdapter.basenameOf(rel);
+      const existing = this.basenameToPaths.get(base);
+      if (existing) {
+        existing.push(rel);
+      } else {
+        this.basenameToPaths.set(base, [rel]);
+      }
+      this.assets.push(
+        this.cacheContent ? { path: rel, metadata, content } : { path: rel, metadata },
+      );
     }
     this.indexed = true;
+  }
+
+  /**
+   * All vault-relative paths whose basename (filename without `.md`) equals
+   * `basename`. Empty array when none. Multiple entries = ambiguous basename —
+   * callers decide (the imports audit counts these separately per RFC R5).
+   */
+  async findPathsByBasename(basename: string): Promise<string[]> {
+    await this.buildIndex();
+    return this.basenameToPaths.get(basename) ?? [];
+  }
+
+  /** Whether an indexed markdown file exists at this exact vault-relative path. */
+  async hasIndexedPath(filePath: string): Promise<boolean> {
+    await this.buildIndex();
+    const norm = filePath.replace(/\\/g, "/").replace(/^\.\//, "");
+    return this.pathSet.has(norm);
+  }
+
+  private static basenameOf(rel: string): string {
+    const slash = rel.lastIndexOf("/");
+    const name = slash === -1 ? rel : rel.slice(slash + 1);
+    return name.endsWith(".md") ? name.slice(0, -3) : name;
+  }
+
+  /** Mirror base NodeFsAdapter.extractFrontmatter (private there). */
+  private static parseFrontmatter(content: string): Record<string, unknown> {
+    const match = content.match(/^---\n([\s\S]*?)\n---/);
+    if (!match) return {};
+    try {
+      const parsed = yaml.load(match[1]);
+      return typeof parsed === "object" && parsed !== null
+        ? (parsed as Record<string, unknown>)
+        : {};
+    } catch {
+      return {};
+    }
   }
 
   /** All indexed assets (path + frontmatter), reusing the single index pass. */

--- a/packages/cli/src/adapters/NodeFsAdapter.ts
+++ b/packages/cli/src/adapters/NodeFsAdapter.ts
@@ -124,7 +124,10 @@ export class NodeFsAdapter implements IFileSystemAdapter {
     return path.join(this.rootPath, filePath);
   }
 
-  private extractFrontmatter(content: string): Record<string, any> {
+  // protected (not private) so CachingNodeFsAdapter's content-caching path
+  // parses frontmatter through the SAME implementation — two parse paths
+  // selected by a constructor flag must never drift (audit #3384 H4 family).
+  protected extractFrontmatter(content: string): Record<string, any> {
     const frontmatterRegex = /^---\n([\s\S]*?)\n---/;
     const match = content.match(frontmatterRegex);
 

--- a/packages/cli/src/commands/audit-co-location.ts
+++ b/packages/cli/src/commands/audit-co-location.ts
@@ -10,6 +10,7 @@ import {
 } from "../executors/folderRepairHelpers.js";
 import { ErrorHandler, type OutputFormat } from "../utils/ErrorHandler.js";
 import { VaultNotFoundError } from "../utils/errors/index.js";
+import { isTemplatesPath } from "../utils/vaultPathFilters.js";
 
 /**
  * Reasons an asset is fail-open SKIPPED (not a violation, but also not proven
@@ -87,11 +88,12 @@ export async function scanVaultForCoLocation(
     // .git/.obsidian, but not node_modules). Never audit/report those.
     if (relPath.split("/").includes("node_modules")) continue;
 
-    // "09 Templates/" holds Templater templates (intentional <%* %> / {{…}}
+    // Templates folders hold Templater templates (intentional <%* %> / {{…}}
     // placeholder syntax), not real assets — they carry exo__Asset_isDefinedBy
-    // by pattern inheritance but must never move. Excluded from co-location the
-    // same way the pre-commit hook skips them (RFC 0b7a2fad CR-1).
-    if (relPath.split("/").includes("09 Templates")) continue;
+    // by pattern inheritance but must never move (RFC 0b7a2fad CR-1). The
+    // exclusion previously hardcoded the stale "09 Templates/" path; the live
+    // vault keeps templates under root-level "templates/" (RFC df39007b R6).
+    if (isTemplatesPath(relPath)) continue;
 
     const rawIsDefinedBy = metadata["exo__Asset_isDefinedBy"];
     const ref = extractAssetReference(rawIsDefinedBy);

--- a/packages/cli/src/commands/audit-ontology-imports.ts
+++ b/packages/cli/src/commands/audit-ontology-imports.ts
@@ -1,0 +1,704 @@
+import { Command } from "commander";
+import { existsSync, statSync } from "fs";
+import { resolve } from "path";
+import { extractAssetReference } from "exocortex";
+import { CachingNodeFsAdapter } from "../adapters/CachingNodeFsAdapter.js";
+import { findReferencedFile } from "../executors/folderRepairHelpers.js";
+import {
+  tarjanSCC,
+  transitiveClosure,
+  type AdjacencyMap,
+} from "../services/ontologyImportsGraph.js";
+import { extractFileWikilinkTargets } from "../services/wikilinkExtraction.js";
+import {
+  isNodeModulesPath,
+  isTemplatesPath,
+} from "../utils/vaultPathFilters.js";
+import { ErrorHandler, type OutputFormat } from "../utils/ErrorHandler.js";
+import { VaultNotFoundError } from "../utils/errors/index.js";
+
+/** `exo__Ontology` class UID — an ontology is any asset instancing it. */
+export const ONTOLOGY_CLASS_UID = "829b9b3b-6fc3-4276-be6a-27d3398c012e";
+
+/**
+ * Why an asset has no valid ontology. Per RFC df39007b VL#6 these are NOT
+ * fail-open skips (unlike broken wikilinks) — they are reported as a distinct
+ * data-gap category (closed by migration Phase 4), informational for the
+ * exit code of THIS audit (whose violations are link-level).
+ */
+export type NoOntologyReason =
+  | "empty-isDefinedBy"
+  | "bang-prefix"
+  | "unresolvable"
+  | "not-an-ontology";
+
+/**
+ * Fail-open link skips (RFC VL#6/R5): counted with reasons, never violations.
+ * - broken: target resolves nowhere in this vault (validate-wikilinks zone).
+ * - dup-basename: ≥2 files share the basename — ambiguity is counted, not
+ *   guessed (R5).
+ * - non-markdown: media/canvas embeds — not asset-graph edges.
+ */
+export type LinkSkipReason = "broken" | "dup-basename" | "non-markdown";
+
+export interface OntologyRef {
+  uid: string;
+  label: string;
+  path: string;
+}
+
+/** Per-ontology report entry (per-ontology stats are an AC of `--output json`). */
+export interface OntologyReport extends OntologyRef {
+  /** Resolved ontology UIDs declared via `exo__Ontology_imports`. */
+  declaredImports: string[];
+  /** Raw declared import refs that resolve to nothing / to a non-ontology (R7). */
+  unresolvedImports: string[];
+  /** R7: self-import declared — warning, excluded from the graph. */
+  selfImport: boolean;
+  /** Assets mapped to this ontology via isDefinedBy (templates excluded). */
+  assetCount: number;
+  /** Distinct incoming/outgoing derived edges. */
+  inDegree: number;
+  outDegree: number;
+  /** Link occurrences staying inside this ontology. */
+  internalLinks: number;
+  /** Cross-ontology occurrences out of / into this ontology (valid + violating). */
+  externalLinksOut: number;
+  externalLinksIn: number;
+  /** Violating subset of externalLinksOut. */
+  violatingOut: number;
+}
+
+export interface DerivedEdge {
+  source: string;
+  target: string;
+  occurrences: number;
+  /** true ⟺ target ∈ transitive closure of source's declared imports. */
+  valid: boolean;
+}
+
+export interface ViolationPair {
+  source: OntologyRef;
+  target: OntologyRef;
+  occurrences: number;
+  /** Up to {@link MAX_EXAMPLES} source files containing offending links. */
+  examples: string[];
+}
+
+export interface OntologyImportsResult {
+  vaultPath: string;
+  totalFiles: number;
+  /** Files actually scanned as link sources (templates/node_modules excluded). */
+  scannedFiles: number;
+  ontologies: OntologyReport[];
+  /** R7 hard error: same ontology UID on ≥2 files. Forces exit 1. */
+  duplicateOntologyUids: Array<{ uid: string; paths: string[] }>;
+  declared: {
+    edgeCount: number;
+    /** Cycles (SCCs of size ≥2) in the declared imports graph. */
+    sccs: string[][];
+    acyclic: boolean;
+  };
+  /** Full derived graph — every cross-ontology edge with occurrence count. */
+  derivedEdges: DerivedEdge[];
+  /** Violating pairs grouped src→tgt, sorted by occurrences desc (VL#8). */
+  violations: ViolationPair[];
+  /**
+   * Links to assets whose ontology lives only in another vault (VL#13).
+   * Classification requires `--also` (PR2) — always empty until then; without
+   * `--also` such links are indistinguishable from broken and counted there.
+   */
+  crossVault: ViolationPair[];
+  linkCounts: {
+    total: number;
+    internal: number;
+    crossOntologyValid: number;
+    crossOntologyViolation: number;
+    crossVault: number;
+    /** Occurrences whose source or target asset lacks a valid ontology. */
+    noOntology: number;
+  };
+  skips: Record<LinkSkipReason, number>;
+  skipExamples: Record<LinkSkipReason, string[]>;
+  noOntologyAssets: {
+    count: number;
+    byReason: Record<NoOntologyReason, number>;
+    examples: string[];
+  };
+  warnings: {
+    selfImports: string[];
+    multipleIsDefinedBy: number;
+    ontologiesWithoutUid: string[];
+  };
+  /**
+   * true ⟺ 0 violating occurrences AND 0 cross-vault AND declared graph
+   * acyclic AND no duplicate-UID hard errors. No-ontology assets and fail-open
+   * skips are reported but do not affect cleanliness (they are Phase-4 data
+   * gaps / validate-wikilinks territory, not imports-invariant violations).
+   */
+  clean: boolean;
+}
+
+const MAX_EXAMPLES = 5;
+const MAX_NO_ONTOLOGY_EXAMPLES = 10;
+
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+const NON_MARKDOWN_EXTENSIONS = new Set([
+  "png", "jpg", "jpeg", "gif", "svg", "webp", "bmp", "ico", "avif",
+  "pdf", "mp3", "wav", "m4a", "ogg", "flac",
+  "mp4", "mov", "webm", "avi", "mkv",
+  "zip", "gz", "tar",
+  "canvas", "base", "json", "css", "js", "ts", "html",
+]);
+
+function nonMarkdownExtension(target: string): boolean {
+  const dot = target.lastIndexOf(".");
+  if (dot === -1 || dot === target.length - 1) return false;
+  const ext = target.slice(dot + 1).toLowerCase();
+  return NON_MARKDOWN_EXTENSIONS.has(ext);
+}
+
+function firstString(value: unknown): { value: string | null; multiple: boolean } {
+  if (Array.isArray(value)) {
+    const strings = value.filter((v) => typeof v === "string");
+    return { value: (strings[0] as string) ?? null, multiple: strings.length > 1 };
+  }
+  return { value: typeof value === "string" ? value : null, multiple: false };
+}
+
+function asRefList(value: unknown): string[] {
+  const raw = Array.isArray(value) ? value : value === undefined || value === null ? [] : [value];
+  const refs: string[] = [];
+  for (const item of raw) {
+    const ref = extractAssetReference(item);
+    if (ref) refs.push(ref);
+  }
+  return refs;
+}
+
+function pushExample(list: string[], example: string, cap = MAX_EXAMPLES): void {
+  if (list.length < cap) list.push(example);
+}
+
+interface OntologyMeta extends OntologyRef {
+  metadata: Record<string, unknown>;
+}
+
+/**
+ * RFC df39007b §Решение Шаг 1 — ontology-imports invariant audit.
+ *
+ * Builds the asset→ontology map via `exo__Asset_isDefinedBy` (same
+ * {@link findReferencedFile} resolver as `audit co-location` / `apply
+ * repair-folder`), extracts every wikilink (frontmatter + body, fenced code
+ * blocks excluded per R10, templates excluded per R6), resolves targets
+ * UID-first with an ambiguous-basename counter (R5), and classifies each
+ * occurrence against the declared `exo__Ontology_imports` transitive closure
+ * (VL#2): internal / cross-ontology valid / cross-ontology violation /
+ * no-ontology, with broken links fail-open skip-accounted (VL#6).
+ *
+ * The declared graph itself is checked for acyclicity via Tarjan SCC; R7
+ * edge-cases: duplicate ontology UID = hard error, self-import = warning
+ * (excluded from the graph), unresolvable import = `unresolvedImports`.
+ */
+export async function scanVaultForOntologyImports(
+  vaultPath: string,
+): Promise<OntologyImportsResult> {
+  const adapter = new CachingNodeFsAdapter(vaultPath, { cacheContent: true });
+  const assets = await adapter.indexedAssets();
+
+  // ---- Phase B: ontology discovery (instances of exo__Ontology) ----
+  const ontologyByPath = new Map<string, string>(); // path → uid
+  const ontologyMeta = new Map<string, OntologyMeta>(); // uid → meta (first-wins)
+  const uidPaths = new Map<string, string[]>(); // uid → all ontology paths (dup detection)
+  const ontologiesWithoutUid: string[] = [];
+
+  for (const asset of assets) {
+    if (isNodeModulesPath(asset.path) || isTemplatesPath(asset.path)) continue;
+    const classRefs = asRefList(asset.metadata["exo__Instance_class"]);
+    if (!classRefs.includes(ONTOLOGY_CLASS_UID)) continue;
+
+    const { value: uid } = firstString(asset.metadata["exo__Asset_uid"]);
+    if (!uid) {
+      ontologiesWithoutUid.push(asset.path);
+      continue;
+    }
+    const { value: labelRaw } = firstString(asset.metadata["exo__Asset_label"]);
+    const label = labelRaw ?? asset.path;
+
+    const paths = uidPaths.get(uid);
+    if (paths) {
+      paths.push(asset.path);
+    } else {
+      uidPaths.set(uid, [asset.path]);
+    }
+    ontologyByPath.set(asset.path, uid);
+    if (!ontologyMeta.has(uid)) {
+      // first-wins so the report stays usable even under a dup-UID hard error
+      ontologyMeta.set(uid, { uid, label, path: asset.path, metadata: asset.metadata });
+    }
+  }
+
+  const duplicateOntologyUids = [...uidPaths.entries()]
+    .filter(([, paths]) => paths.length > 1)
+    .map(([uid, paths]) => ({ uid, paths }));
+
+  // ---- Phase C: asset→ontology map via isDefinedBy ----
+  const assetOntology = new Map<string, string | null>(); // path → ontology uid | null
+  const noOntologyByReason: Record<NoOntologyReason, number> = {
+    "empty-isDefinedBy": 0,
+    "bang-prefix": 0,
+    unresolvable: 0,
+    "not-an-ontology": 0,
+  };
+  const noOntologyExamples: string[] = [];
+  let noOntologyCount = 0;
+  let multipleIsDefinedBy = 0;
+  const assetCountByOntology = new Map<string, number>();
+  let scannedFiles = 0;
+
+  const markNoOntology = (path: string, reason: NoOntologyReason): void => {
+    assetOntology.set(path, null);
+    noOntologyByReason[reason]++;
+    noOntologyCount++;
+    pushExample(noOntologyExamples, `${path} (${reason})`, MAX_NO_ONTOLOGY_EXAMPLES);
+  };
+
+  for (const asset of assets) {
+    if (isNodeModulesPath(asset.path) || isTemplatesPath(asset.path)) continue;
+    scannedFiles++;
+
+    const rawIsDefinedBy = asset.metadata["exo__Asset_isDefinedBy"];
+    const { value: first, multiple } = firstString(rawIsDefinedBy);
+    if (multiple) multipleIsDefinedBy++; // R7: warning, first one is used
+
+    const ref = extractAssetReference(first);
+    if (!ref) {
+      markNoOntology(asset.path, "empty-isDefinedBy");
+      continue;
+    }
+    if (ref.startsWith("!")) {
+      markNoOntology(asset.path, "bang-prefix");
+      continue;
+    }
+    const ontologyPath = await findReferencedFile(adapter, ref, asset.path);
+    if (!ontologyPath) {
+      markNoOntology(asset.path, "unresolvable");
+      continue;
+    }
+    const uid = ontologyByPath.get(ontologyPath);
+    if (!uid) {
+      markNoOntology(asset.path, "not-an-ontology");
+      continue;
+    }
+    assetOntology.set(asset.path, uid);
+    assetCountByOntology.set(uid, (assetCountByOntology.get(uid) ?? 0) + 1);
+  }
+
+  // ---- Phase D: declared imports graph + SCC + closure ----
+  const ontologyUids = [...ontologyMeta.keys()];
+  const declaredEdges: AdjacencyMap = new Map();
+  const selfImports: string[] = [];
+  const declaredImportsByUid = new Map<string, string[]>();
+  const unresolvedImportsByUid = new Map<string, string[]>();
+  let declaredEdgeCount = 0;
+
+  for (const uid of ontologyUids) {
+    const meta = ontologyMeta.get(uid)!;
+    const refs = asRefList(meta.metadata["exo__Ontology_imports"]);
+    const resolved: string[] = [];
+    const unresolved: string[] = [];
+    let selfImport = false;
+
+    for (const ref of refs) {
+      let targetUid: string | null = null;
+      if (ontologyMeta.has(ref)) {
+        targetUid = ref;
+      } else {
+        // Non-UID-form declared import — resolve to a file and require it to
+        // be an ontology; anything else is an unresolved-import (R7 category).
+        const targetPath = await findReferencedFile(adapter, ref, meta.path);
+        targetUid = targetPath ? (ontologyByPath.get(targetPath) ?? null) : null;
+      }
+      if (targetUid === null) {
+        unresolved.push(ref);
+      } else if (targetUid === uid) {
+        selfImport = true; // R7: warning, never a graph edge
+      } else {
+        resolved.push(targetUid);
+        let set = declaredEdges.get(uid);
+        if (!set) {
+          set = new Set();
+          declaredEdges.set(uid, set);
+        }
+        if (!set.has(targetUid)) {
+          set.add(targetUid);
+          declaredEdgeCount++;
+        }
+      }
+    }
+
+    declaredImportsByUid.set(uid, resolved);
+    unresolvedImportsByUid.set(uid, unresolved);
+    if (selfImport) selfImports.push(uid);
+  }
+
+  const sccs = tarjanSCC(ontologyUids, declaredEdges);
+  const closure = transitiveClosure(ontologyUids, declaredEdges);
+
+  // ---- Phase E: link scan + classification ----
+  const linkCounts = {
+    total: 0,
+    internal: 0,
+    crossOntologyValid: 0,
+    crossOntologyViolation: 0,
+    crossVault: 0,
+    noOntology: 0,
+  };
+  const skips: Record<LinkSkipReason, number> = {
+    broken: 0,
+    "dup-basename": 0,
+    "non-markdown": 0,
+  };
+  const skipExamples: Record<LinkSkipReason, string[]> = {
+    broken: [],
+    "dup-basename": [],
+    "non-markdown": [],
+  };
+  const derivedEdgeMap = new Map<string, { source: string; target: string; occurrences: number; valid: boolean }>();
+  const violationMap = new Map<string, { source: string; target: string; occurrences: number; examples: string[] }>();
+  const internalByOntology = new Map<string, number>();
+  const externalOutByOntology = new Map<string, number>();
+  const externalInByOntology = new Map<string, number>();
+  const violatingOutByOntology = new Map<string, number>();
+
+  const resolveTargetPath = async (target: string): Promise<string | "ambiguous" | null> => {
+    // Path-form targets: exact vault-relative path first.
+    if (target.includes("/")) {
+      const cleaned = target.replace(/^\//, "");
+      const candidate = cleaned.endsWith(".md") ? cleaned : `${cleaned}.md`;
+      if (await adapter.hasIndexedPath(candidate)) return candidate;
+      // fall through to basename of the last segment (Obsidian shortest-path)
+      target = cleaned.slice(cleaned.lastIndexOf("/") + 1);
+    }
+    if (target.endsWith(".md")) target = target.slice(0, -3);
+    // UID-first (R5 normative order), then basename.
+    if (UUID_RE.test(target)) {
+      const byUid = await adapter.findFileByUID(target);
+      if (byUid) return byUid;
+    }
+    const byBasename = await adapter.findPathsByBasename(target);
+    if (byBasename.length === 1) return byBasename[0];
+    if (byBasename.length > 1) {
+      // R5: ambiguous basename — three resolution mechanisms could disagree;
+      // counted separately, never guessed.
+      const distinct = new Set(byBasename);
+      return distinct.size === 1 ? byBasename[0] : "ambiguous";
+    }
+    return null;
+  };
+
+  for (const asset of assets) {
+    if (isNodeModulesPath(asset.path) || isTemplatesPath(asset.path)) continue;
+    const sourceOntology = assetOntology.get(asset.path) ?? null;
+    const targets = extractFileWikilinkTargets(asset.metadata, asset.content ?? "");
+
+    for (const target of targets) {
+      linkCounts.total++;
+
+      if (nonMarkdownExtension(target)) {
+        skips["non-markdown"]++;
+        pushExample(skipExamples["non-markdown"], `${asset.path} → ${target}`);
+        continue;
+      }
+
+      const resolvedPath = await resolveTargetPath(target);
+      if (resolvedPath === "ambiguous") {
+        skips["dup-basename"]++;
+        pushExample(skipExamples["dup-basename"], `${asset.path} → ${target}`);
+        continue;
+      }
+      if (resolvedPath === null) {
+        // Fail-open (VL#6): broken link — validate-wikilinks territory. With
+        // --also (PR2) some of these reclassify as cross-vault violations.
+        skips.broken++;
+        pushExample(skipExamples.broken, `${asset.path} → ${target}`);
+        continue;
+      }
+
+      const targetOntology =
+        assetOntology.get(resolvedPath) ??
+        ontologyByPath.get(resolvedPath) ??
+        null;
+      if (sourceOntology === null || targetOntology === null) {
+        linkCounts.noOntology++;
+        continue;
+      }
+      if (sourceOntology === targetOntology) {
+        linkCounts.internal++;
+        internalByOntology.set(
+          sourceOntology,
+          (internalByOntology.get(sourceOntology) ?? 0) + 1,
+        );
+        continue;
+      }
+
+      const valid = closure.get(sourceOntology)?.has(targetOntology) ?? false;
+      const edgeKey = `${sourceOntology} ${targetOntology}`;
+      const edge = derivedEdgeMap.get(edgeKey);
+      if (edge) {
+        edge.occurrences++;
+      } else {
+        derivedEdgeMap.set(edgeKey, {
+          source: sourceOntology,
+          target: targetOntology,
+          occurrences: 1,
+          valid,
+        });
+      }
+      externalOutByOntology.set(
+        sourceOntology,
+        (externalOutByOntology.get(sourceOntology) ?? 0) + 1,
+      );
+      externalInByOntology.set(
+        targetOntology,
+        (externalInByOntology.get(targetOntology) ?? 0) + 1,
+      );
+
+      if (valid) {
+        linkCounts.crossOntologyValid++;
+      } else {
+        linkCounts.crossOntologyViolation++;
+        violatingOutByOntology.set(
+          sourceOntology,
+          (violatingOutByOntology.get(sourceOntology) ?? 0) + 1,
+        );
+        const pair = violationMap.get(edgeKey);
+        if (pair) {
+          pair.occurrences++;
+          pushExample(pair.examples, asset.path);
+        } else {
+          violationMap.set(edgeKey, {
+            source: sourceOntology,
+            target: targetOntology,
+            occurrences: 1,
+            examples: [asset.path],
+          });
+        }
+      }
+    }
+  }
+
+  // ---- Phase F: assemble report ----
+  const derivedEdges = [...derivedEdgeMap.values()].sort(
+    (a, b) => b.occurrences - a.occurrences,
+  );
+  const inDegree = new Map<string, number>();
+  const outDegree = new Map<string, number>();
+  for (const edge of derivedEdges) {
+    outDegree.set(edge.source, (outDegree.get(edge.source) ?? 0) + 1);
+    inDegree.set(edge.target, (inDegree.get(edge.target) ?? 0) + 1);
+  }
+
+  const toRef = (uid: string): OntologyRef => {
+    const meta = ontologyMeta.get(uid)!;
+    return { uid: meta.uid, label: meta.label, path: meta.path };
+  };
+
+  const ontologies: OntologyReport[] = ontologyUids
+    .map((uid) => ({
+      ...toRef(uid),
+      declaredImports: declaredImportsByUid.get(uid) ?? [],
+      unresolvedImports: unresolvedImportsByUid.get(uid) ?? [],
+      selfImport: selfImports.includes(uid),
+      assetCount: assetCountByOntology.get(uid) ?? 0,
+      inDegree: inDegree.get(uid) ?? 0,
+      outDegree: outDegree.get(uid) ?? 0,
+      internalLinks: internalByOntology.get(uid) ?? 0,
+      externalLinksOut: externalOutByOntology.get(uid) ?? 0,
+      externalLinksIn: externalInByOntology.get(uid) ?? 0,
+      violatingOut: violatingOutByOntology.get(uid) ?? 0,
+    }))
+    .sort((a, b) => a.label.localeCompare(b.label));
+
+  const violations: ViolationPair[] = [...violationMap.values()]
+    .map((v) => ({
+      source: toRef(v.source),
+      target: toRef(v.target),
+      occurrences: v.occurrences,
+      examples: v.examples,
+    }))
+    .sort((a, b) => b.occurrences - a.occurrences);
+
+  const acyclic = sccs.length === 0;
+  const clean =
+    violations.length === 0 &&
+    linkCounts.crossVault === 0 &&
+    acyclic &&
+    duplicateOntologyUids.length === 0;
+
+  return {
+    vaultPath,
+    totalFiles: assets.length,
+    scannedFiles,
+    ontologies,
+    duplicateOntologyUids,
+    declared: { edgeCount: declaredEdgeCount, sccs, acyclic },
+    derivedEdges,
+    violations,
+    crossVault: [],
+    linkCounts,
+    skips,
+    skipExamples,
+    noOntologyAssets: {
+      count: noOntologyCount,
+      byReason: noOntologyByReason,
+      examples: noOntologyExamples,
+    },
+    warnings: {
+      selfImports,
+      multipleIsDefinedBy,
+      ontologiesWithoutUid,
+    },
+    clean,
+  };
+}
+
+export interface AuditOntologyImportsOptions {
+  vault: string;
+  output?: OutputFormat;
+}
+
+function formatRef(ref: OntologyRef): string {
+  // UID is the grouping key (labels have had duplicates — R12); label+path
+  // are human context.
+  return `${ref.uid}|${ref.label}|${ref.path}`;
+}
+
+function printText(result: OntologyImportsResult): void {
+  const withImports = result.ontologies.filter(
+    (o) => o.declaredImports.length > 0 || o.unresolvedImports.length > 0,
+  ).length;
+  const log = result.clean ? console.log : console.error;
+
+  log(
+    `${result.clean ? "OK" : "FAIL"} ${result.vaultPath}: ontology-imports audit — ` +
+      `${result.linkCounts.crossOntologyViolation} violating occurrence(s) in ${result.violations.length} pair(s)`,
+  );
+  log(
+    `Ontologies: ${result.ontologies.length} (${withImports} with imports declared), ` +
+      `declared graph: ${result.declared.edgeCount} edge(s), ` +
+      (result.declared.acyclic
+        ? "acyclic"
+        : `NOT ACYCLIC — ${result.declared.sccs.length} SCC(s)`),
+  );
+
+  if (result.duplicateOntologyUids.length > 0) {
+    console.error(`\nHARD ERRORS — duplicate ontology UIDs (R7):`);
+    for (const dup of result.duplicateOntologyUids) {
+      console.error(`  ${dup.uid}: ${dup.paths.join(", ")}`);
+    }
+  }
+
+  if (!result.declared.acyclic) {
+    console.error(`\nDeclared-graph cycles (must be a DAG):`);
+    for (const scc of result.declared.sccs) {
+      console.error(
+        `  SCC[${scc.length}]: ${scc.map((uid) => formatRef(toRefSafe(result, uid))).join(" ⇄ ")}`,
+      );
+    }
+  }
+
+  if (result.violations.length > 0) {
+    console.error(`\nViolating pairs (src → tgt, occurrences desc):`);
+    for (const pair of result.violations) {
+      console.error(
+        `  ${formatRef(pair.source)} → ${formatRef(pair.target)}: ${pair.occurrences}`,
+      );
+    }
+  }
+
+  const unresolvedTotal = result.ontologies.reduce(
+    (sum, o) => sum + o.unresolvedImports.length,
+    0,
+  );
+  log(
+    `\nLinks: total=${result.linkCounts.total}, internal=${result.linkCounts.internal}, ` +
+      `cross-ontology-valid=${result.linkCounts.crossOntologyValid}, ` +
+      `cross-ontology-violation=${result.linkCounts.crossOntologyViolation}, ` +
+      `cross-vault=${result.linkCounts.crossVault}, no-ontology=${result.linkCounts.noOntology}`,
+  );
+  log(
+    `Skipped (fail-open, NOT verified): broken=${result.skips.broken}, ` +
+      `dup-basename=${result.skips["dup-basename"]}, non-markdown=${result.skips["non-markdown"]}`,
+  );
+  log(
+    `No-ontology assets (Phase-4 data gap): ${result.noOntologyAssets.count} — ` +
+      `empty=${result.noOntologyAssets.byReason["empty-isDefinedBy"]}, ` +
+      `bang-prefix=${result.noOntologyAssets.byReason["bang-prefix"]}, ` +
+      `unresolvable=${result.noOntologyAssets.byReason.unresolvable}, ` +
+      `not-an-ontology=${result.noOntologyAssets.byReason["not-an-ontology"]}`,
+  );
+  if (
+    result.warnings.selfImports.length > 0 ||
+    result.warnings.multipleIsDefinedBy > 0 ||
+    result.warnings.ontologiesWithoutUid.length > 0 ||
+    unresolvedTotal > 0
+  ) {
+    log(
+      `Warnings: self-imports=${result.warnings.selfImports.length}, ` +
+        `unresolved-imports=${unresolvedTotal}, ` +
+        `multiple-isDefinedBy=${result.warnings.multipleIsDefinedBy}, ` +
+        `ontologies-without-uid=${result.warnings.ontologiesWithoutUid.length}`,
+    );
+  }
+}
+
+function toRefSafe(result: OntologyImportsResult, uid: string): OntologyRef {
+  return (
+    result.ontologies.find((o) => o.uid === uid) ?? { uid, label: uid, path: "" }
+  );
+}
+
+/**
+ * RFC df39007b Phase 1 PR1 — ontology-imports invariant audit.
+ *
+ * `exocortex audit ontology-imports --vault <path>` walks the vault, derives
+ * the actual cross-ontology link graph, and reports every occurrence not
+ * covered by the declared `exo__Ontology_imports` transitive closure.
+ * Exit 0 = clean (0 violations, declared graph acyclic, no duplicate-UID hard
+ * errors); exit 1 otherwise. Fail-open skips (broken links, ambiguous
+ * basenames) and no-ontology assets never affect the exit code.
+ */
+export function auditOntologyImportsCommand(): Command {
+  return new Command("ontology-imports")
+    .description(
+      "Detect cross-ontology wikilinks not covered by the declared exo__Ontology_imports transitive closure (DAG check, per-pair grouping, fail-open skip-accounting)",
+    )
+    .requiredOption("--vault <path>", "Vault root directory")
+    .option("--output <type>", "Response format: text|json", "text")
+    .action(async (options: AuditOntologyImportsOptions) => {
+      const outputFormat = (options.output ?? "text") as OutputFormat;
+      ErrorHandler.setFormat(outputFormat);
+
+      try {
+        const vaultPath = resolve(options.vault);
+        if (!existsSync(vaultPath) || !statSync(vaultPath).isDirectory()) {
+          throw new VaultNotFoundError(vaultPath);
+        }
+
+        const result = await scanVaultForOntologyImports(vaultPath);
+
+        if (outputFormat === "json") {
+          console.log(JSON.stringify(result, null, 2));
+        } else {
+          printText(result);
+        }
+
+        if (!result.clean) process.exitCode = 1;
+      } catch (error) {
+        ErrorHandler.handle(error as Error);
+      }
+    });
+}

--- a/packages/cli/src/commands/audit.ts
+++ b/packages/cli/src/commands/audit.ts
@@ -1,16 +1,19 @@
 import { Command } from "commander";
 import { auditGroundingTypeLiteralFormCommand } from "./audit-grounding-type-literal-form.js";
 import { auditCoLocationCommand } from "./audit-co-location.js";
+import { auditOntologyImportsCommand } from "./audit-ontology-imports.js";
 
 /**
  * Creates the 'audit' parent command with regression-detection subcommands:
  * - audit grounding-type-literal-form — RFC 9d20c91f Phase 4+1 regression
  *   detector for `exocmd__Grounding_type` literal-string form.
  * - audit co-location — RFC 0b7a2fad asset–ontology co-location invariant.
+ * - audit ontology-imports — RFC df39007b ontology imports DAG invariant.
  *
  * @example
  * exocortex audit grounding-type-literal-form --vault /path/to/vault
  * exocortex audit co-location --vault /path/to/vault
+ * exocortex audit ontology-imports --vault /path/to/vault
  */
 export function auditCommand(): Command {
   const cmd = new Command("audit").description(
@@ -19,6 +22,7 @@ export function auditCommand(): Command {
 
   cmd.addCommand(auditGroundingTypeLiteralFormCommand());
   cmd.addCommand(auditCoLocationCommand());
+  cmd.addCommand(auditOntologyImportsCommand());
 
   return cmd;
 }

--- a/packages/cli/src/services/ontologyImportsGraph.ts
+++ b/packages/cli/src/services/ontologyImportsGraph.ts
@@ -1,0 +1,107 @@
+/**
+ * Pure graph algorithms for the ontology-imports audit
+ * (RFC df39007b §Решение Шаг 1): Tarjan strongly-connected components for the
+ * DAG check on the declared `exo__Ontology_imports` graph, and per-node
+ * transitive closure (reachability) used to classify cross-ontology links as
+ * valid (target ∈ closure of source's imports) vs violating.
+ *
+ * Self-loops are the caller's concern: per RFC R7 a self-import is a warning
+ * and must be excluded from the edge set BEFORE SCC detection, so a node
+ * importing itself does not register as a cycle.
+ */
+
+export type AdjacencyMap = Map<string, Set<string>>;
+
+/**
+ * Tarjan's strongly-connected components (iterative — vault graphs are small,
+ * but recursion depth must not depend on data). Returns ONLY components of
+ * size ≥ 2: in a graph without self-loops those are exactly the cycles, which
+ * is what the DAG check reports.
+ */
+export function tarjanSCC(nodes: string[], edges: AdjacencyMap): string[][] {
+  const index = new Map<string, number>();
+  const lowlink = new Map<string, number>();
+  const onStack = new Set<string>();
+  const stack: string[] = [];
+  const sccs: string[][] = [];
+  let counter = 0;
+
+  for (const root of nodes) {
+    if (index.has(root)) continue;
+
+    // Iterative DFS with an explicit work stack of [node, neighborIterator].
+    const work: Array<[string, Iterator<string>]> = [];
+    const pushNode = (v: string): void => {
+      index.set(v, counter);
+      lowlink.set(v, counter);
+      counter++;
+      stack.push(v);
+      onStack.add(v);
+      work.push([v, (edges.get(v) ?? new Set()).values()]);
+    };
+    pushNode(root);
+
+    while (work.length > 0) {
+      const [v, neighbors] = work[work.length - 1];
+      const next = neighbors.next();
+      if (!next.done) {
+        const w = next.value;
+        if (!index.has(w)) {
+          pushNode(w);
+        } else if (onStack.has(w)) {
+          lowlink.set(v, Math.min(lowlink.get(v)!, index.get(w)!));
+        }
+      } else {
+        work.pop();
+        if (work.length > 0) {
+          const parent = work[work.length - 1][0];
+          lowlink.set(parent, Math.min(lowlink.get(parent)!, lowlink.get(v)!));
+        }
+        if (lowlink.get(v) === index.get(v)) {
+          const component: string[] = [];
+          let w: string;
+          do {
+            w = stack.pop()!;
+            onStack.delete(w);
+            component.push(w);
+          } while (w !== v);
+          if (component.length >= 2) {
+            sccs.push(component);
+          }
+        }
+      }
+    }
+  }
+
+  return sccs;
+}
+
+/**
+ * Per-node transitive closure: `closure.get(a)` = every node reachable from
+ * `a` via one or more edges (NOT including `a` itself unless `a` lies on a
+ * cycle through itself). BFS per node — O(V·(V+E)), trivial at vault scale
+ * (≤ ~100 ontologies).
+ *
+ * The imports invariant check is then: link a→b is valid ⟺
+ * `a === b || closure.get(a)?.has(b)`.
+ */
+export function transitiveClosure(
+  nodes: string[],
+  edges: AdjacencyMap,
+): Map<string, Set<string>> {
+  const closure = new Map<string, Set<string>>();
+  for (const start of nodes) {
+    const reachable = new Set<string>();
+    const queue: string[] = [...(edges.get(start) ?? [])];
+    while (queue.length > 0) {
+      const current = queue.shift()!;
+      if (reachable.has(current)) continue;
+      reachable.add(current);
+      for (const next of edges.get(current) ?? []) {
+        if (!reachable.has(next)) queue.push(next);
+      }
+    }
+    closure.set(start, reachable);
+  }
+  return closure;
+}

--- a/packages/cli/src/services/wikilinkExtraction.ts
+++ b/packages/cli/src/services/wikilinkExtraction.ts
@@ -26,8 +26,15 @@ export function stripFencedCodeBlocks(text: string): string {
   let openFence: string | null = null;
   for (const line of lines) {
     const fenceMatch = line.match(/^[ \t]*(`{3,}|~{3,})/);
+    // CommonMark: a backtick-fence info string must not contain backticks —
+    // otherwise an inline ```code``` span at line start would open a phantom
+    // fence and silently drop the rest of the document from the link scan.
+    const validOpener =
+      fenceMatch &&
+      (fenceMatch[1][0] === "~" ||
+        !line.slice(line.indexOf(fenceMatch[1]) + fenceMatch[1].length).includes("`"));
     if (openFence === null) {
-      if (fenceMatch) {
+      if (validOpener) {
         openFence = fenceMatch[1];
       } else {
         out.push(line);

--- a/packages/cli/src/services/wikilinkExtraction.ts
+++ b/packages/cli/src/services/wikilinkExtraction.ts
@@ -1,0 +1,108 @@
+/**
+ * Wikilink target extraction for the ontology-imports audit
+ * (RFC df39007b §Решение Шаг 1).
+ *
+ * Scope decisions locked by the RFC review interview:
+ * - Frontmatter AND body wikilinks both count as graph edges (VL#3).
+ * - Wikilinks inside fenced code blocks do NOT count (R10) — Obsidian does
+ *   not treat them as graph edges; they are code examples in RFC/aiKnow
+ *   assets. Inline code spans are NOT excluded (R10 names fenced blocks only).
+ * - Anchors (`#heading`, `#^block`) and aliases (`|alias`) are stripped —
+ *   the edge target is the linkpath.
+ */
+
+/** Matches both `[[target]]` and `![[target]]` (embeds are edges too). */
+const WIKILINK_RE = /\[\[([^\]]+)\]\]/g;
+
+/**
+ * Remove fenced code blocks (``` or ~~~ fences, CommonMark semantics: the
+ * closer uses the same fence char with at least the opener's length; an
+ * unclosed fence runs to end of text). Line-based on purpose — a regex with
+ * a backreferenced closer cannot express "closer may be longer than opener".
+ */
+export function stripFencedCodeBlocks(text: string): string {
+  const lines = text.split("\n");
+  const out: string[] = [];
+  let openFence: string | null = null;
+  for (const line of lines) {
+    const fenceMatch = line.match(/^[ \t]*(`{3,}|~{3,})/);
+    if (openFence === null) {
+      if (fenceMatch) {
+        openFence = fenceMatch[1];
+      } else {
+        out.push(line);
+      }
+    } else if (
+      fenceMatch &&
+      fenceMatch[1][0] === openFence[0] &&
+      fenceMatch[1].length >= openFence.length &&
+      /^[ \t]*(?:`{3,}|~{3,})[ \t]*$/.test(line)
+    ) {
+      openFence = null;
+    }
+  }
+  return out.join("\n");
+}
+
+/**
+ * Extract normalized wikilink targets from a text chunk: alias stripped,
+ * anchor stripped, trimmed. Empty results (pure self-anchor links like
+ * `[[#heading]]`) are dropped — they reference the containing file and never
+ * form a cross-ontology edge.
+ */
+export function extractWikilinkTargets(text: string): string[] {
+  const targets: string[] = [];
+  let match: RegExpExecArray | null;
+  WIKILINK_RE.lastIndex = 0;
+  while ((match = WIKILINK_RE.exec(text)) !== null) {
+    let inner = match[1];
+    const pipeIdx = inner.indexOf("|");
+    if (pipeIdx !== -1) inner = inner.slice(0, pipeIdx);
+    const hashIdx = inner.indexOf("#");
+    if (hashIdx !== -1) inner = inner.slice(0, hashIdx);
+    const target = inner.trim();
+    if (target.length > 0) targets.push(target);
+  }
+  return targets;
+}
+
+/**
+ * Recursively collect every string value from parsed frontmatter so wikilinks
+ * in nested arrays/objects are found. Non-string scalars are ignored.
+ */
+export function collectFrontmatterStrings(value: unknown): string[] {
+  if (typeof value === "string") return [value];
+  if (Array.isArray(value)) return value.flatMap(collectFrontmatterStrings);
+  if (value !== null && typeof value === "object") {
+    return Object.values(value as Record<string, unknown>).flatMap(
+      collectFrontmatterStrings,
+    );
+  }
+  return [];
+}
+
+/**
+ * Body of a markdown file = everything after the frontmatter block (or the
+ * whole content when there is none). Mirrors NodeFsAdapter frontmatter regex.
+ */
+export function bodyOf(content: string): string {
+  const match = content.match(/^---\n[\s\S]*?\n---/);
+  return match ? content.slice(match[0].length) : content;
+}
+
+/**
+ * All wikilink edge targets of one file: frontmatter strings + body with
+ * fenced code blocks removed.
+ */
+export function extractFileWikilinkTargets(
+  metadata: Record<string, unknown>,
+  content: string,
+): string[] {
+  const fromFrontmatter = collectFrontmatterStrings(metadata).flatMap(
+    extractWikilinkTargets,
+  );
+  const fromBody = extractWikilinkTargets(
+    stripFencedCodeBlocks(bodyOf(content)),
+  );
+  return [...fromFrontmatter, ...fromBody];
+}

--- a/packages/cli/src/utils/vaultPathFilters.ts
+++ b/packages/cli/src/utils/vaultPathFilters.ts
@@ -1,0 +1,28 @@
+/**
+ * Shared vault-path exclusion predicates for audit commands (RFC df39007b R6,
+ * RFC 0b7a2fad CR-1).
+ *
+ * Templater template files carry `exo__Asset_isDefinedBy` / wikilinks by
+ * pattern inheritance (intentional `<%* %>` / `{{…}}` placeholder syntax) but
+ * are NOT assets — they must never be audited, moved, or counted as graph
+ * edges. The live vault keeps them under root-level `templates/`; the legacy
+ * location `09 Templates/` no longer exists on disk but stays excluded so the
+ * audits remain safe against older vault snapshots/clones.
+ */
+
+const TEMPLATE_SEGMENTS = new Set(["templates", "09 templates"]);
+
+/**
+ * True when any path segment is a templates folder (case-insensitive,
+ * current `templates/` or legacy `09 Templates/`).
+ */
+export function isTemplatesPath(relPath: string): boolean {
+  return relPath
+    .split("/")
+    .some((segment) => TEMPLATE_SEGMENTS.has(segment.toLowerCase()));
+}
+
+/** True when the path passes through node_modules (never vault content). */
+export function isNodeModulesPath(relPath: string): boolean {
+  return relPath.split("/").includes("node_modules");
+}

--- a/packages/cli/tests/integration/commands/audit-co-location.integration.test.ts
+++ b/packages/cli/tests/integration/commands/audit-co-location.integration.test.ts
@@ -104,6 +104,22 @@ describe("audit co-location — revert→fail / restore→pass (integration)", (
     expect(r.skips["empty-isDefinedBy"]).toBe(2);
   });
 
+  it("excludes the CURRENT 'templates/' path (RFC df39007b R6 — the exclusion previously hardcoded only the stale '09 Templates/')", async () => {
+    // The live vault keeps Templater templates under root-level templates/
+    // (e.g. templates/ems/…). WITHOUT the R6 fix this resolvable-but-misplaced
+    // file is reported as 1 violation; WITH it the file is dropped entirely.
+    const tmplDir = join(vault, "templates", "concepts");
+    writeAsset(
+      tmplDir,
+      "eeeeeeee-0000-0000-0000-000000000000",
+      `"[[${ONTO_UID}]]"`,
+    );
+    const r = await scanVaultForCoLocation(vault);
+    // Revert-verify: restore the stale `09 Templates`-only check → flips to 1.
+    expect(r.violations).toHaveLength(0);
+    expect(r.checked).toBe(0);
+  });
+
   it("excludes '09 Templates/' (Templater templates are not assets) — revert→fail proof", async () => {
     // A Templater template carries exo__Asset_isDefinedBy by pattern inheritance
     // but physically lives in 09 Templates/ and must never move. WITHOUT the

--- a/packages/cli/tests/integration/commands/audit-ontology-imports.integration.test.ts
+++ b/packages/cli/tests/integration/commands/audit-ontology-imports.integration.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect, beforeEach, afterEach } from "@jest/globals";
+import { mkdirSync, rmSync, writeFileSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import {
+  scanVaultForOntologyImports,
+  ONTOLOGY_CLASS_UID,
+} from "../../../src/commands/audit-ontology-imports.js";
+
+const ONTO_A = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+const ONTO_B = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
+const ASSET_A = "11111111-1111-4111-8111-111111111111";
+const ASSET_B = "22222222-2222-4222-8222-222222222222";
+
+function writeOntology(
+  dir: string,
+  uid: string,
+  label: string,
+  imports: string[],
+): string {
+  mkdirSync(dir, { recursive: true });
+  const importLines =
+    imports.length > 0
+      ? ["exo__Ontology_imports:", ...imports.map((i) => `  - "[[${i}]]"`)]
+      : [];
+  const file = join(dir, `${uid}.md`);
+  writeFileSync(
+    file,
+    [
+      "---",
+      `exo__Asset_uid: ${uid}`,
+      `exo__Asset_label: "${label}"`,
+      "exo__Instance_class:",
+      `  - "[[${ONTOLOGY_CLASS_UID}]]"`,
+      `exo__Asset_isDefinedBy: "[[${uid}]]"`,
+      ...importLines,
+      "---",
+      "",
+      "Ontology.",
+      "",
+    ].join("\n"),
+    "utf-8",
+  );
+  return file;
+}
+
+function writeAsset(
+  dir: string,
+  uid: string,
+  ontologyUid: string,
+  body: string,
+): string {
+  mkdirSync(dir, { recursive: true });
+  const file = join(dir, `${uid}.md`);
+  writeFileSync(
+    file,
+    [
+      "---",
+      `exo__Asset_uid: ${uid}`,
+      `exo__Asset_label: "Asset ${uid}"`,
+      `exo__Asset_isDefinedBy: "[[${ontologyUid}]]"`,
+      "---",
+      "",
+      body,
+      "",
+    ].join("\n"),
+    "utf-8",
+  );
+  return file;
+}
+
+/**
+ * Empirical revert→fail / restore→pass proof for `audit ontology-imports`
+ * (rule: integration-test-revert-verify). The verdict is driven purely by the
+ * vault data: a cross-ontology link is violating exactly while the declared
+ * `exo__Ontology_imports` closure does not cover it. We flip the declaration
+ * on disk: absent (FAIL=violation) → declared (PASS) → absent again (FAIL).
+ * If the audit reported clean in BOTH states it would be a false-positive
+ * guard — this test would catch that.
+ */
+describe("audit ontology-imports — revert→fail / restore→pass (integration)", () => {
+  let vault: string;
+
+  beforeEach(() => {
+    vault = join(
+      tmpdir(),
+      `onto-imports-integration-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    );
+    mkdirSync(vault, { recursive: true });
+    writeAsset(
+      join(vault, "alpha"),
+      ASSET_A,
+      ONTO_A,
+      `Cross-ontology link: [[${ASSET_B}]].`,
+    );
+    writeAsset(join(vault, "beta"), ASSET_B, ONTO_B, "Target body.");
+    writeOntology(join(vault, "beta"), ONTO_B, "$beta", []);
+  });
+
+  afterEach(() => {
+    rmSync(vault, { recursive: true, force: true });
+  });
+
+  it("FAIL without the import declaration, PASS with it, FAIL again without", async () => {
+    // --- State 1: no declared import A→B → the a→b link is a violation ---
+    writeOntology(join(vault, "alpha"), ONTO_A, "$alpha", []);
+    let r = await scanVaultForOntologyImports(vault);
+    expect(r.clean).toBe(false);
+    expect(r.violations).toHaveLength(1);
+    expect(r.violations[0].source.uid).toBe(ONTO_A);
+    expect(r.violations[0].target.uid).toBe(ONTO_B);
+
+    // --- State 2: declare the import (overwrite ontology file) → clean ---
+    writeOntology(join(vault, "alpha"), ONTO_A, "$alpha", [ONTO_B]);
+    r = await scanVaultForOntologyImports(vault);
+    expect(r.clean).toBe(true);
+    expect(r.violations).toHaveLength(0);
+    expect(r.linkCounts.crossOntologyValid).toBeGreaterThanOrEqual(1);
+
+    // --- State 3: revert the declaration → violation returns ---
+    writeOntology(join(vault, "alpha"), ONTO_A, "$alpha", []);
+    r = await scanVaultForOntologyImports(vault);
+    expect(r.clean).toBe(false);
+    expect(r.violations).toHaveLength(1);
+  });
+
+  it("declared-graph cycle flips the audit red and resolving it flips back", async () => {
+    // Cycle: A imports B, B imports A.
+    writeOntology(join(vault, "alpha"), ONTO_A, "$alpha", [ONTO_B]);
+    writeOntology(join(vault, "beta"), ONTO_B, "$beta", [ONTO_A]);
+    let r = await scanVaultForOntologyImports(vault);
+    expect(r.declared.acyclic).toBe(false);
+    expect(r.clean).toBe(false);
+
+    // Break the cycle: B no longer imports A.
+    writeOntology(join(vault, "beta"), ONTO_B, "$beta", []);
+    r = await scanVaultForOntologyImports(vault);
+    expect(r.declared.acyclic).toBe(true);
+    expect(r.clean).toBe(true);
+  });
+
+  it("fail-open skips never affect cleanliness", async () => {
+    writeOntology(join(vault, "alpha"), ONTO_A, "$alpha", [ONTO_B]);
+    // Asset with a broken link + an image embed: skips, not violations.
+    writeAsset(
+      join(vault, "alpha"),
+      "33333333-3333-4333-8333-333333333333",
+      ONTO_A,
+      "Broken [[99999999-9999-4999-8999-999999999999]] and ![[img.png]].",
+    );
+
+    const r = await scanVaultForOntologyImports(vault);
+    expect(r.skips.broken).toBeGreaterThanOrEqual(1);
+    expect(r.skips["non-markdown"]).toBe(1);
+    expect(r.clean).toBe(true);
+  });
+});

--- a/packages/cli/tests/unit/commands/audit-ontology-imports.test.ts
+++ b/packages/cli/tests/unit/commands/audit-ontology-imports.test.ts
@@ -1,0 +1,379 @@
+import { describe, it, expect, beforeEach, afterEach } from "@jest/globals";
+import { mkdirSync, rmSync, writeFileSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import {
+  scanVaultForOntologyImports,
+  auditOntologyImportsCommand,
+  ONTOLOGY_CLASS_UID,
+} from "../../../src/commands/audit-ontology-imports.js";
+import { auditCommand } from "../../../src/commands/audit.js";
+
+const ONTO_A = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+const ONTO_B = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
+const ONTO_C = "cccccccc-cccc-4ccc-8ccc-cccccccccccc";
+
+interface AssetSpec {
+  uid: string;
+  label?: string;
+  isDefinedBy?: string;
+  instanceClass?: string[];
+  imports?: string[];
+  body?: string;
+  filename?: string;
+}
+
+function writeAsset(dir: string, spec: AssetSpec): string {
+  mkdirSync(dir, { recursive: true });
+  const lines = [
+    "---",
+    `exo__Asset_uid: ${spec.uid}`,
+    `exo__Asset_label: "${spec.label ?? `Asset ${spec.uid}`}"`,
+  ];
+  if (spec.instanceClass) {
+    lines.push("exo__Instance_class:");
+    for (const c of spec.instanceClass) lines.push(`  - "[[${c}]]"`);
+  }
+  if (spec.isDefinedBy !== undefined) {
+    lines.push(`exo__Asset_isDefinedBy: "${spec.isDefinedBy}"`);
+  }
+  if (spec.imports) {
+    lines.push("exo__Ontology_imports:");
+    for (const i of spec.imports) lines.push(`  - "[[${i}]]"`);
+  }
+  lines.push("---", "", spec.body ?? "Body.", "");
+  const file = join(dir, `${spec.filename ?? spec.uid}.md`);
+  writeFileSync(file, lines.join("\n"), "utf-8");
+  return file;
+}
+
+function writeOntology(
+  dir: string,
+  uid: string,
+  label: string,
+  imports?: string[],
+): string {
+  return writeAsset(dir, {
+    uid,
+    label,
+    instanceClass: [ONTOLOGY_CLASS_UID],
+    isDefinedBy: `[[${uid}]]`, // namespace ontologies are self-referential
+    imports,
+  });
+}
+
+describe("audit ontology-imports — Commander wiring", () => {
+  it("registers under 'audit' parent command", () => {
+    const parent = auditCommand();
+    const sub = parent.commands.find((c) => c.name() === "ontology-imports");
+    expect(sub).toBeDefined();
+  });
+
+  it("subcommand declares --vault required + --output options", () => {
+    const sub = auditOntologyImportsCommand();
+    expect(sub.name()).toBe("ontology-imports");
+    const opts = sub.options.map((o) => o.long);
+    expect(opts).toContain("--vault");
+    expect(opts).toContain("--output");
+  });
+});
+
+describe("audit ontology-imports — scanVaultForOntologyImports", () => {
+  let vault: string;
+
+  beforeEach(() => {
+    vault = join(
+      tmpdir(),
+      `audit-onto-imports-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    );
+    mkdirSync(vault, { recursive: true });
+    // exo__Ontology class definition file — every ontology's
+    // exo__Instance_class wikilink resolves here (it has no isDefinedBy, so it
+    // is itself a no-ontology asset; those links classify as no-ontology).
+    writeAsset(join(vault, "exo"), {
+      uid: ONTOLOGY_CLASS_UID,
+      label: "exo__Ontology",
+    });
+  });
+
+  afterEach(() => {
+    rmSync(vault, { recursive: true, force: true });
+  });
+
+  it("classifies internal / cross-ontology-valid / violation occurrences", async () => {
+    // A imports C. a1 links: a2 (internal), c1 (valid via import), b1 (violation).
+    writeOntology(join(vault, "alpha"), ONTO_A, "$alpha", [ONTO_C]);
+    writeOntology(join(vault, "beta"), ONTO_B, "$beta");
+    writeOntology(join(vault, "gamma"), ONTO_C, "$gamma");
+    writeAsset(join(vault, "alpha"), {
+      uid: "11111111-1111-4111-8111-111111111111",
+      isDefinedBy: `[[${ONTO_A}]]`,
+      body: "Links: [[22222222-2222-4222-8222-222222222222]] and [[33333333-3333-4333-8333-333333333333]] and [[44444444-4444-4444-8444-444444444444]].",
+    });
+    writeAsset(join(vault, "alpha"), {
+      uid: "22222222-2222-4222-8222-222222222222",
+      isDefinedBy: `[[${ONTO_A}]]`,
+    });
+    writeAsset(join(vault, "beta"), {
+      uid: "33333333-3333-4333-8333-333333333333",
+      isDefinedBy: `[[${ONTO_B}]]`,
+    });
+    writeAsset(join(vault, "gamma"), {
+      uid: "44444444-4444-4444-8444-444444444444",
+      isDefinedBy: `[[${ONTO_C}]]`,
+    });
+
+    const r = await scanVaultForOntologyImports(vault);
+
+    expect(r.linkCounts.crossOntologyViolation).toBe(1);
+    expect(r.violations).toHaveLength(1);
+    expect(r.violations[0].source.uid).toBe(ONTO_A);
+    expect(r.violations[0].target.uid).toBe(ONTO_B);
+    expect(r.violations[0].occurrences).toBe(1);
+    // a1 → c1 plus A's own exo__Ontology_imports declaration link A → C
+    // (the declaration is itself a frontmatter wikilink, valid by construction).
+    expect(r.linkCounts.crossOntologyValid).toBe(2);
+    // 3 ontology self-isDefinedBy + 4 asset isDefinedBy + a1→a2 = 8
+    expect(r.linkCounts.internal).toBe(8);
+    expect(r.declared.acyclic).toBe(true);
+    expect(r.clean).toBe(false);
+
+    // Derived graph contains both the valid and the violating edge.
+    const edgeAB = r.derivedEdges.find(
+      (e) => e.source === ONTO_A && e.target === ONTO_B,
+    );
+    const edgeAC = r.derivedEdges.find(
+      (e) => e.source === ONTO_A && e.target === ONTO_C,
+    );
+    expect(edgeAB?.valid).toBe(false);
+    expect(edgeAC?.valid).toBe(true);
+    expect(edgeAC?.occurrences).toBe(2); // imports declaration + a1→c1
+
+    // Per-ontology stats (AC: --output json carries them).
+    const alpha = r.ontologies.find((o) => o.uid === ONTO_A)!;
+    expect(alpha.assetCount).toBe(3); // ontology file itself + a1 + a2
+    expect(alpha.outDegree).toBe(2);
+    expect(alpha.violatingOut).toBe(1);
+    expect(alpha.externalLinksOut).toBe(3); // imports decl + a1→c1 + a1→b1
+    const beta = r.ontologies.find((o) => o.uid === ONTO_B)!;
+    expect(beta.inDegree).toBe(1);
+    expect(beta.externalLinksIn).toBe(1);
+  });
+
+  it("honors TRANSITIVE closure: A→B→C declared makes A→C links valid (VL#2)", async () => {
+    writeOntology(join(vault, "alpha"), ONTO_A, "$alpha", [ONTO_B]);
+    writeOntology(join(vault, "beta"), ONTO_B, "$beta", [ONTO_C]);
+    writeOntology(join(vault, "gamma"), ONTO_C, "$gamma");
+    writeAsset(join(vault, "alpha"), {
+      uid: "11111111-1111-4111-8111-111111111111",
+      isDefinedBy: `[[${ONTO_A}]]`,
+      body: "Deep link [[55555555-5555-4555-8555-555555555555]].",
+    });
+    writeAsset(join(vault, "gamma"), {
+      uid: "55555555-5555-4555-8555-555555555555",
+      isDefinedBy: `[[${ONTO_C}]]`,
+    });
+
+    const r = await scanVaultForOntologyImports(vault);
+    expect(r.linkCounts.crossOntologyViolation).toBe(0);
+    // a1→c5 (transitively valid) + the two imports-declaration links A→B, B→C.
+    expect(r.linkCounts.crossOntologyValid).toBe(3);
+    expect(r.clean).toBe(true);
+  });
+
+  it("counts broken links as fail-open skips, never violations (VL#6)", async () => {
+    writeOntology(join(vault, "alpha"), ONTO_A, "$alpha");
+    writeAsset(join(vault, "alpha"), {
+      uid: "11111111-1111-4111-8111-111111111111",
+      isDefinedBy: `[[${ONTO_A}]]`,
+      body: "Dangling [[99999999-9999-4999-8999-999999999999]] and [[No Such Note]].",
+    });
+
+    const r = await scanVaultForOntologyImports(vault);
+    expect(r.skips.broken).toBe(2);
+    expect(r.skipExamples.broken).toHaveLength(2);
+    expect(r.linkCounts.crossOntologyViolation).toBe(0);
+    expect(r.clean).toBe(true);
+  });
+
+  it("counts ambiguous basenames separately without guessing (R5)", async () => {
+    writeOntology(join(vault, "alpha"), ONTO_A, "$alpha");
+    writeAsset(join(vault, "alpha"), {
+      uid: "11111111-1111-4111-8111-111111111111",
+      isDefinedBy: `[[${ONTO_A}]]`,
+      body: "Ambiguous [[Note]].",
+    });
+    writeAsset(join(vault, "alpha"), {
+      uid: "22222222-2222-4222-8222-222222222222",
+      isDefinedBy: `[[${ONTO_A}]]`,
+      filename: "Note",
+    });
+    writeAsset(join(vault, "beta"), {
+      uid: "33333333-3333-4333-8333-333333333333",
+      filename: "Note",
+    });
+
+    const r = await scanVaultForOntologyImports(vault);
+    expect(r.skips["dup-basename"]).toBe(1);
+    expect(r.linkCounts.crossOntologyViolation).toBe(0);
+  });
+
+  it("resolves UID-form targets UID-first even when the filename differs", async () => {
+    writeOntology(join(vault, "alpha"), ONTO_A, "$alpha");
+    writeOntology(join(vault, "beta"), ONTO_B, "$beta");
+    // Target lives under a label filename but carries the UID in frontmatter.
+    writeAsset(join(vault, "beta"), {
+      uid: "33333333-3333-4333-8333-333333333333",
+      isDefinedBy: `[[${ONTO_B}]]`,
+      filename: "Label Named Note",
+    });
+    writeAsset(join(vault, "alpha"), {
+      uid: "11111111-1111-4111-8111-111111111111",
+      isDefinedBy: `[[${ONTO_A}]]`,
+      body: "UID link [[33333333-3333-4333-8333-333333333333]].",
+    });
+
+    const r = await scanVaultForOntologyImports(vault);
+    expect(r.skips.broken).toBe(0);
+    expect(r.linkCounts.crossOntologyViolation).toBe(1); // resolved → A→B violating
+  });
+
+  it("ignores wikilinks in fenced code blocks (R10) and templates/ sources (R6)", async () => {
+    writeOntology(join(vault, "alpha"), ONTO_A, "$alpha");
+    writeOntology(join(vault, "beta"), ONTO_B, "$beta");
+    writeAsset(join(vault, "beta"), {
+      uid: "33333333-3333-4333-8333-333333333333",
+      isDefinedBy: `[[${ONTO_B}]]`,
+    });
+    writeAsset(join(vault, "alpha"), {
+      uid: "11111111-1111-4111-8111-111111111111",
+      isDefinedBy: `[[${ONTO_A}]]`,
+      body: [
+        "```",
+        "[[33333333-3333-4333-8333-333333333333]]",
+        "```",
+        "No live links.",
+      ].join("\n"),
+    });
+    // A template under templates/ links across ontologies — must not count.
+    writeAsset(join(vault, "templates", "ems"), {
+      uid: "77777777-7777-4777-8777-777777777777",
+      isDefinedBy: `[[${ONTO_A}]]`,
+      body: "Template link [[33333333-3333-4333-8333-333333333333]].",
+    });
+    // Legacy capitalized location stays excluded too.
+    writeAsset(join(vault, "09 Templates", "ems"), {
+      uid: "88888888-8888-4888-8888-888888888888",
+      isDefinedBy: `[[${ONTO_A}]]`,
+      body: "Template link [[33333333-3333-4333-8333-333333333333]].",
+    });
+
+    const r = await scanVaultForOntologyImports(vault);
+    expect(r.linkCounts.crossOntologyViolation).toBe(0);
+    expect(r.clean).toBe(true);
+  });
+
+  it("tracks no-ontology assets by reason; their links are no-ontology, not violations", async () => {
+    writeOntology(join(vault, "alpha"), ONTO_A, "$alpha");
+    writeAsset(join(vault, "alpha"), {
+      uid: "11111111-1111-4111-8111-111111111111",
+      isDefinedBy: `[[${ONTO_A}]]`,
+    });
+    // empty isDefinedBy
+    writeAsset(join(vault, "inbox"), {
+      uid: "22222222-2222-4222-8222-222222222222",
+      body: "Link [[11111111-1111-4111-8111-111111111111]].",
+    });
+    // bang-prefix
+    writeAsset(join(vault, "inbox"), {
+      uid: "33333333-3333-4333-8333-333333333333",
+      isDefinedBy: "[[!kitelev]]",
+    });
+    // unresolvable
+    writeAsset(join(vault, "inbox"), {
+      uid: "44444444-4444-4444-8444-444444444444",
+      isDefinedBy: "[[99999999-9999-4999-8999-999999999999]]",
+    });
+    // resolves to a non-ontology asset
+    writeAsset(join(vault, "inbox"), {
+      uid: "55555555-5555-4555-8555-555555555555",
+      isDefinedBy: "[[11111111-1111-4111-8111-111111111111]]",
+    });
+
+    const r = await scanVaultForOntologyImports(vault);
+    // +1 empty: the exo__Ontology class-definition fixture has no isDefinedBy.
+    expect(r.noOntologyAssets.byReason["empty-isDefinedBy"]).toBe(2);
+    expect(r.noOntologyAssets.byReason["bang-prefix"]).toBe(1);
+    expect(r.noOntologyAssets.byReason.unresolvable).toBe(1);
+    expect(r.noOntologyAssets.byReason["not-an-ontology"]).toBe(1);
+    expect(r.noOntologyAssets.count).toBe(5);
+    expect(r.linkCounts.noOntology).toBeGreaterThanOrEqual(1);
+    expect(r.linkCounts.crossOntologyViolation).toBe(0);
+    // Informational only — link-level invariant is clean.
+    expect(r.clean).toBe(true);
+  });
+
+  it("flags duplicate ontology UIDs as a hard error forcing clean=false (R7)", async () => {
+    writeOntology(join(vault, "alpha"), ONTO_A, "$alpha");
+    writeAsset(join(vault, "beta"), {
+      uid: ONTO_A, // same UID, different file
+      label: "$alpha-duplicate",
+      instanceClass: [ONTOLOGY_CLASS_UID],
+      isDefinedBy: `[[${ONTO_A}]]`,
+      filename: "duplicate-alpha",
+    });
+
+    const r = await scanVaultForOntologyImports(vault);
+    expect(r.duplicateOntologyUids).toHaveLength(1);
+    expect(r.duplicateOntologyUids[0].uid).toBe(ONTO_A);
+    expect(r.duplicateOntologyUids[0].paths).toHaveLength(2);
+    expect(r.clean).toBe(false);
+  });
+
+  it("treats self-import as a warning, not a cycle (R7)", async () => {
+    writeOntology(join(vault, "alpha"), ONTO_A, "$alpha", [ONTO_A]);
+
+    const r = await scanVaultForOntologyImports(vault);
+    expect(r.warnings.selfImports).toEqual([ONTO_A]);
+    expect(r.declared.acyclic).toBe(true);
+    expect(r.clean).toBe(true);
+  });
+
+  it("reports unresolvable declared imports as a category (R7)", async () => {
+    writeOntology(join(vault, "alpha"), ONTO_A, "$alpha", [
+      "99999999-9999-4999-8999-999999999999",
+    ]);
+
+    const r = await scanVaultForOntologyImports(vault);
+    const alpha = r.ontologies.find((o) => o.uid === ONTO_A)!;
+    expect(alpha.unresolvedImports).toEqual([
+      "99999999-9999-4999-8999-999999999999",
+    ]);
+    expect(alpha.declaredImports).toEqual([]);
+    expect(r.clean).toBe(true); // unresolved import alone is not a violation
+  });
+
+  it("detects declared-graph cycles via SCC and fails the audit", async () => {
+    writeOntology(join(vault, "alpha"), ONTO_A, "$alpha", [ONTO_B]);
+    writeOntology(join(vault, "beta"), ONTO_B, "$beta", [ONTO_A]);
+
+    const r = await scanVaultForOntologyImports(vault);
+    expect(r.declared.acyclic).toBe(false);
+    expect(r.declared.sccs).toHaveLength(1);
+    expect([...r.declared.sccs[0]].sort()).toEqual([ONTO_A, ONTO_B].sort());
+    expect(r.clean).toBe(false);
+  });
+
+  it("skips non-markdown embeds with a dedicated counter", async () => {
+    writeOntology(join(vault, "alpha"), ONTO_A, "$alpha");
+    writeAsset(join(vault, "alpha"), {
+      uid: "11111111-1111-4111-8111-111111111111",
+      isDefinedBy: `[[${ONTO_A}]]`,
+      body: "Image ![[diagram.png]] and [[notes.pdf]].",
+    });
+
+    const r = await scanVaultForOntologyImports(vault);
+    expect(r.skips["non-markdown"]).toBe(2);
+    expect(r.skips.broken).toBe(0);
+  });
+});

--- a/packages/cli/tests/unit/services/ontologyImportsGraph.test.ts
+++ b/packages/cli/tests/unit/services/ontologyImportsGraph.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect } from "@jest/globals";
+import {
+  tarjanSCC,
+  transitiveClosure,
+  type AdjacencyMap,
+} from "../../../src/services/ontologyImportsGraph.js";
+
+function adjacency(edges: Array<[string, string]>): AdjacencyMap {
+  const map: AdjacencyMap = new Map();
+  for (const [from, to] of edges) {
+    let set = map.get(from);
+    if (!set) {
+      set = new Set();
+      map.set(from, set);
+    }
+    set.add(to);
+  }
+  return map;
+}
+
+describe("tarjanSCC", () => {
+  it("returns no components for an empty graph", () => {
+    expect(tarjanSCC([], new Map())).toEqual([]);
+  });
+
+  it("returns no components for a DAG (chain + diamond)", () => {
+    const nodes = ["a", "b", "c", "d"];
+    const edges = adjacency([
+      ["a", "b"],
+      ["a", "c"],
+      ["b", "d"],
+      ["c", "d"],
+    ]);
+    expect(tarjanSCC(nodes, edges)).toEqual([]);
+  });
+
+  it("detects a simple 2-cycle", () => {
+    const sccs = tarjanSCC(["a", "b"], adjacency([["a", "b"], ["b", "a"]]));
+    expect(sccs).toHaveLength(1);
+    expect([...sccs[0]].sort()).toEqual(["a", "b"]);
+  });
+
+  it("detects a 3-cycle and leaves the tail out of the component", () => {
+    // a → b → c → a, plus c → d (tail)
+    const sccs = tarjanSCC(
+      ["a", "b", "c", "d"],
+      adjacency([
+        ["a", "b"],
+        ["b", "c"],
+        ["c", "a"],
+        ["c", "d"],
+      ]),
+    );
+    expect(sccs).toHaveLength(1);
+    expect([...sccs[0]].sort()).toEqual(["a", "b", "c"]);
+  });
+
+  it("detects multiple independent cycles", () => {
+    const sccs = tarjanSCC(
+      ["a", "b", "x", "y", "z", "lone"],
+      adjacency([
+        ["a", "b"],
+        ["b", "a"],
+        ["x", "y"],
+        ["y", "z"],
+        ["z", "x"],
+      ]),
+    );
+    expect(sccs).toHaveLength(2);
+    const sorted = sccs.map((c) => [...c].sort()).sort((a, b) => a.length - b.length);
+    expect(sorted).toEqual([
+      ["a", "b"],
+      ["x", "y", "z"],
+    ]);
+  });
+
+  it("ignores self-loops (caller excludes them per R7, but a stray one is not a cycle of size ≥2)", () => {
+    // Even if a self-edge leaks into the adjacency map, a single node is not
+    // reported: components of size 1 are filtered.
+    const sccs = tarjanSCC(["a", "b"], adjacency([["a", "a"], ["a", "b"]]));
+    expect(sccs).toEqual([]);
+  });
+
+  it("handles a large chain iteratively (no recursion-depth blowup)", () => {
+    const nodes = Array.from({ length: 10_000 }, (_, i) => `n${i}`);
+    const edges = adjacency(
+      nodes.slice(0, -1).map((n, i) => [n, `n${i + 1}`] as [string, string]),
+    );
+    expect(tarjanSCC(nodes, edges)).toEqual([]);
+  });
+});
+
+describe("transitiveClosure", () => {
+  it("computes reachability over a chain (transitive imports, VL#2)", () => {
+    const closure = transitiveClosure(
+      ["a", "b", "c"],
+      adjacency([
+        ["a", "b"],
+        ["b", "c"],
+      ]),
+    );
+    expect(closure.get("a")).toEqual(new Set(["b", "c"]));
+    expect(closure.get("b")).toEqual(new Set(["c"]));
+    expect(closure.get("c")).toEqual(new Set());
+  });
+
+  it("does not include the node itself when not on a cycle", () => {
+    const closure = transitiveClosure(["a", "b"], adjacency([["a", "b"]]));
+    expect(closure.get("a")!.has("a")).toBe(false);
+  });
+
+  it("includes the node itself when it lies on a cycle", () => {
+    const closure = transitiveClosure(
+      ["a", "b"],
+      adjacency([
+        ["a", "b"],
+        ["b", "a"],
+      ]),
+    );
+    expect(closure.get("a")!.has("a")).toBe(true);
+    expect(closure.get("a")!.has("b")).toBe(true);
+  });
+
+  it("merges reachability across a diamond", () => {
+    const closure = transitiveClosure(
+      ["a", "b", "c", "d"],
+      adjacency([
+        ["a", "b"],
+        ["a", "c"],
+        ["b", "d"],
+        ["c", "d"],
+      ]),
+    );
+    expect(closure.get("a")).toEqual(new Set(["b", "c", "d"]));
+  });
+
+  it("returns empty sets for isolated nodes", () => {
+    const closure = transitiveClosure(["a", "b"], new Map());
+    expect(closure.get("a")).toEqual(new Set());
+    expect(closure.get("b")).toEqual(new Set());
+  });
+});

--- a/packages/cli/tests/unit/services/wikilinkExtraction.test.ts
+++ b/packages/cli/tests/unit/services/wikilinkExtraction.test.ts
@@ -75,6 +75,15 @@ describe("stripFencedCodeBlocks (R10)", () => {
       "counted",
     ]);
   });
+
+  it("a line-leading inline triple-backtick span is NOT a fence opener (CommonMark: no backticks in info string)", () => {
+    const text = ["```[[in-span]]``` then [[keep-a]]", "[[keep-b]]"].join("\n");
+    expect(extractWikilinkTargets(stripFencedCodeBlocks(text))).toEqual([
+      "in-span",
+      "keep-a",
+      "keep-b",
+    ]);
+  });
 });
 
 describe("collectFrontmatterStrings", () => {

--- a/packages/cli/tests/unit/services/wikilinkExtraction.test.ts
+++ b/packages/cli/tests/unit/services/wikilinkExtraction.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect } from "@jest/globals";
+import {
+  stripFencedCodeBlocks,
+  extractWikilinkTargets,
+  collectFrontmatterStrings,
+  bodyOf,
+  extractFileWikilinkTargets,
+} from "../../../src/services/wikilinkExtraction.js";
+
+describe("extractWikilinkTargets", () => {
+  it("extracts bare, aliased, anchored, and embedded wikilinks", () => {
+    const text =
+      "See [[target-a]] and [[uid-b|Alias B]] plus [[uid-c#section]] and " +
+      "[[uid-d#^block|labeled]] and ![[embedded-note]].";
+    expect(extractWikilinkTargets(text)).toEqual([
+      "target-a",
+      "uid-b",
+      "uid-c",
+      "uid-d",
+      "embedded-note",
+    ]);
+  });
+
+  it("drops pure self-anchor links like [[#heading]]", () => {
+    expect(extractWikilinkTargets("Jump to [[#section]] here")).toEqual([]);
+  });
+
+  it("trims whitespace and returns empty array for no links", () => {
+    expect(extractWikilinkTargets("[[  spaced  ]]")).toEqual(["spaced"]);
+    expect(extractWikilinkTargets("no links here")).toEqual([]);
+  });
+});
+
+describe("stripFencedCodeBlocks (R10)", () => {
+  it("removes wikilinks inside ``` fences", () => {
+    const text = [
+      "before [[keep-me]]",
+      "```sparql",
+      "SELECT [[drop-me]]",
+      "```",
+      "after [[also-keep]]",
+    ].join("\n");
+    const targets = extractWikilinkTargets(stripFencedCodeBlocks(text));
+    expect(targets).toEqual(["keep-me", "also-keep"]);
+  });
+
+  it("removes ~~~ fences and honors closers longer than the opener", () => {
+    const text = [
+      "~~~",
+      "[[drop-1]]",
+      "~~~~",
+      "[[keep-1]]",
+      "````md",
+      "[[drop-2]]",
+      "```",
+      "still inside [[drop-3]]",
+      "`````",
+      "[[keep-2]]",
+    ].join("\n");
+    // The ``` closer is SHORTER than the ```` opener → not a closer (CommonMark).
+    const targets = extractWikilinkTargets(stripFencedCodeBlocks(text));
+    expect(targets).toEqual(["keep-1", "keep-2"]);
+  });
+
+  it("drops everything after an unclosed fence", () => {
+    const text = "[[keep]]\n```\n[[drop]]\nmore [[drop-too]]";
+    expect(extractWikilinkTargets(stripFencedCodeBlocks(text))).toEqual([
+      "keep",
+    ]);
+  });
+
+  it("does NOT strip inline code spans (R10 names fenced blocks only)", () => {
+    const text = "inline `[[counted]]` link";
+    expect(extractWikilinkTargets(stripFencedCodeBlocks(text))).toEqual([
+      "counted",
+    ]);
+  });
+});
+
+describe("collectFrontmatterStrings", () => {
+  it("collects strings recursively from nested arrays and objects", () => {
+    const metadata = {
+      a: "[[one]]",
+      b: ["[[two]]", { c: "[[three]]" }],
+      d: 42,
+      e: null,
+      f: true,
+    };
+    const targets = collectFrontmatterStrings(metadata).flatMap(
+      extractWikilinkTargets,
+    );
+    expect(targets).toEqual(["one", "two", "three"]);
+  });
+});
+
+describe("bodyOf", () => {
+  it("returns content after the frontmatter block", () => {
+    const content = "---\nkey: value\n---\n\nBody [[link]].";
+    expect(bodyOf(content)).toBe("\n\nBody [[link]].");
+  });
+
+  it("returns whole content when there is no frontmatter", () => {
+    expect(bodyOf("just text")).toBe("just text");
+  });
+});
+
+describe("extractFileWikilinkTargets", () => {
+  it("merges frontmatter + body targets, excluding fenced code", () => {
+    const metadata = {
+      exo__Asset_isDefinedBy: "[[onto-uid]]",
+      exo__Asset_relates: ["[[rel-1|Label]]"],
+    };
+    const content = [
+      "---",
+      'exo__Asset_isDefinedBy: "[[onto-uid]]"',
+      "---",
+      "Body [[body-target#anchor]].",
+      "```",
+      "[[fenced-ignored]]",
+      "```",
+    ].join("\n");
+    expect(extractFileWikilinkTargets(metadata, content)).toEqual([
+      "onto-uid",
+      "rel-1",
+      "body-target",
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

RFC df39007b («Ontology imports DAG — Low Coupling + High Cohesion инвариант») §Решение Шаг 1, Phase 1 **PR1 of 2**. New CLI command:

```
npx @kitelev/exocortex-cli audit ontology-imports --vault <path> [--output text|json]
```

Pattern: `audit co-location` (same family, same fail-open + skip-accounting discipline).

### What it does

- **Asset→ontology map** via `exo__Asset_isDefinedBy` through the shared `findReferencedFile` resolver (same path as `apply repair-folder` / co-location audit); ontology = instance of `exo__Ontology` (`829b9b3b`)
- **Wikilink extraction** from frontmatter AND body (VL#3). Fenced code blocks excluded (R10), `templates/` excluded by path (R6), anchors/aliases stripped. Body access via new opt-in content cache in `CachingNodeFsAdapter` — single disk pass serves both frontmatter and body
- **Target resolution UID-first** (R5) via new basename index (symmetric to `uidToPath`); ambiguous basenames counted separately, never guessed
- **Classification per occurrence**: `internal` / `cross-ontology valid` (target ∈ transitive closure of declared imports, VL#2) / `cross-ontology violation` / `no-ontology`; broken links fail-open skip-accounted (VL#6); `cross-vault` category is structural — it fills in PR2 when `--also` lands (VL#13), until then unresolvable targets count as `broken`
- **Declared graph**: Tarjan SCC DAG check + transitive closure. R7 edge cases: duplicate ontology UID = **hard error** (exit 1), self-import = warning (excluded from graph), unresolvable declared import = own category
- **Output**: violations grouped per src→tgt pair, key = UID (`UID|label|path` — labels have had duplicates, R12); `--output text|json` (R11); JSON carries the **full derived graph + per-ontology stats** (in/out-degree, internal/external links, violatingOut); exit 0 clean / exit 1 violations

### Side fix (R6)

`audit co-location` excluded only the stale `09 Templates/` path; the live vault keeps Templater templates under root-level `templates/`. Both audits now share `isTemplatesPath()` (case-insensitive, current + legacy). **Empirically verified to FAIL pre-fix and PASS post-fix** (new integration test red against origin/main code, green with the fix).

### Exit-code semantics decision

`clean` ⟺ 0 cross-ontology violations ∧ 0 cross-vault ∧ declared graph acyclic ∧ no duplicate-UID hard errors. **No-ontology assets are reported (count + by-reason + examples) but do not affect the exit code** — they are the Phase-4 data gap; RFC Phase-5 AC explicitly allows a user-accepted documented residue, which would be unreachable if they forced exit 1.

## Tests (40 new)

- `ontologyImportsGraph.test.ts` — Tarjan SCC (DAG, 2/3-cycles, multiple components, self-loop, 10k-chain iterative depth), transitive closure (chain, diamond, cycle, isolated)
- `wikilinkExtraction.test.ts` — aliases/anchors/embeds, fenced ``` and ~~~ semantics (closer ≥ opener length, unclosed fence, inline code NOT stripped), recursive frontmatter strings
- `audit-ontology-imports.test.ts` — full classification matrix incl. transitive validity, UID-first resolution, dup-basename, no-ontology reasons, dup-UID hard error, self-import, unresolved import, SCC detection, non-markdown skips
- `audit-ontology-imports.integration.test.ts` — **revert→fail / restore→pass driven by vault data**: violation present without the declared import → declare it on disk → clean → revert → red again; cycle detection flip; fail-open independence
- `audit-co-location.integration.test.ts` — new R6 test for current `templates/` path

Full CLI suite: 1875 passed, 25 skipped, **1 failed = pre-existing** (`sparql-exo003.integration.test.ts` «mixed format» — fails identically on unmodified origin/main code; orphan suite outside the CI allowlist).

## Live-vault verification (AC)

| Check | Result |
|---|---|
| vault-2025 (11 449 files) runtime | **2.7 s** (budget ≤60 s) |
| vault-2025 ontologies | 70 = ground truth (71 incl. the `templates/exo/{{exo__Ontology}}.md` Templater file correctly excluded; spike's 73 included 2 dups deduped by R12 after the spike) |
| vault-2025 declared graph | 18 with imports / 31 edges / acyclic — exact spike match |
| vault-2025 top violating pairs | `$kitelev→$ems`, `$kitelev→$shared-identities` — same order as spike, occurrence drift (live vault) |
| vault-exodev ontologies | 42 = **exact** ground-truth grep match |
| vault-exodev declared graph | 4 with imports / 6 edges / acyclic — exact spike match |
| exit codes | 1 on both vaults (violations present, expected until Phases 2–5) |

## RFC traceability

VL#2 transitive closure · VL#3 frontmatter+body · VL#6 fail-open only broken links · VL#8 per-pair grouping · VL#13 cross-vault category · R5 dup-basename counter · R6 templates exclusion + co-location stale-path fix · R7 dup-UID/self-import/unresolved-import · R10 fenced code · R11 `--output` · R12 UID as grouping key

PR2 (next): `--propose-imports` + `--also` multi-root classification.

Task: `d7bee57f` (project a68dd4ad, Phase 1 — Tooling)