### PR TITLE
fix(#3489): explicit ExoSync success signal — info-channel console line

### DIFF
--- a/packages/obsidian-plugin/src/ExocortexPlugin.ts
+++ b/packages/obsidian-plugin/src/ExocortexPlugin.ts
@@ -2851,6 +2851,7 @@ export default class ExocortexPlugin extends Plugin {
       isSwitchInProgress: () => localDataStore.isSwitchInProgress(),
       notify: (message) => this.notifier.info(message),
       log: (message) => this.logger.warn(message),
+      logInfo: (message) => this.logger.info(message),
       // ExoSync Phase E (E1) — automatic M1/M2 parity round after every
       // sync + the standalone palette report (parallel-run validation).
       parity: buildParityCheck({

--- a/packages/obsidian-plugin/src/infrastructure/adapters/SyncCommands.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/SyncCommands.ts
@@ -41,6 +41,13 @@ export interface SyncCommandsDeps {
   /** Diagnostic sink for per-repo warnings/details (default console). */
   log?: (message: string) => void;
   /**
+   * Info-level sink for the success summary (#3489). Info channel default
+   * is {notice:false, console:true, file:false}, so this produces exactly
+   * one console line without duplicating the existing notify() toast or
+   * writing to the file log. Optional — absent callers get no-op.
+   */
+  logInfo?: (message: string) => void;
+  /**
    * E1 parity harness (RFC 4e4dc453 Phase E). When wired, every sync round
    * is followed by an automatic M1/M2 validation pass (best-effort — a
    * parity failure NEVER affects the sync result), and the standalone
@@ -257,6 +264,7 @@ export class SyncCommands {
     log: (message: string) => void,
     label = "Sync",
   ): void {
+    const logInfo = this.deps.logInfo ?? ((_m: string): void => undefined);
     let pushed = 0;
     let deleted = 0;
     let pulled = 0;
@@ -313,6 +321,9 @@ export class SyncCommands {
     if (problems.length === 0) {
       this.deps.notify(
         `${label} done: ${synced}/${results.length} repo(s) — ${counts}`,
+      );
+      logInfo(
+        `[ExoSync] ${label} OK: ${synced}/${results.length} repo(s) — ${counts}`,
       );
     } else {
       this.deps.notify(

--- a/packages/obsidian-plugin/tests/unit/sync/SyncCommands.test.ts
+++ b/packages/obsidian-plugin/tests/unit/sync/SyncCommands.test.ts
@@ -378,6 +378,16 @@ describe("SyncCommands — #3489 explicit success signal (info console + Notice)
     expect(notices.some((n) => n.includes("issues"))).toBe(true);
   });
 
+  it("auth-required path: logInfo NOT called — early return before success branch", async () => {
+    const { commands, infoLogs } = makeHarness({
+      results: [result("o/r#main", "auth-required")],
+    });
+
+    await commands.invokeSync();
+
+    expect(infoLogs).toHaveLength(0);
+  });
+
   it("success path: no duplicate Notice (logInfo is info-only, no warn-channel Notice)", async () => {
     const { commands, notices } = makeHarness();
 

--- a/packages/obsidian-plugin/tests/unit/sync/SyncCommands.test.ts
+++ b/packages/obsidian-plugin/tests/unit/sync/SyncCommands.test.ts
@@ -52,11 +52,14 @@ interface HarnessOptions {
   syncAllGate?: Promise<void>;
   /** E1 parity harness seam. */
   parity?: ParityCheck;
+  /** Optional info-level callback seam (success console signal, #3489). */
+  logInfo?: (m: string) => void;
 }
 
 function makeHarness(opts: HarnessOptions = {}) {
   const notices: string[] = [];
   const logs: string[] = [];
+  const infoLogs: string[] = [];
   const syncAll = jest.fn(
     async (
       specs: SyncRepoSpec[],
@@ -83,9 +86,10 @@ function makeHarness(opts: HarnessOptions = {}) {
     isSwitchInProgress: () => opts.isSwitchInProgress ?? false,
     notify: (m) => notices.push(m),
     log: (m) => logs.push(m),
+    logInfo: opts.logInfo ?? ((m) => infoLogs.push(m)),
     ...(opts.parity !== undefined ? { parity: opts.parity } : {}),
   });
-  return { commands, notices, logs, syncAll };
+  return { commands, notices, logs, infoLogs, syncAll };
 }
 
 describe("SyncCommands", () => {
@@ -317,6 +321,91 @@ describe("SyncCommands — Pull/Push split (#3473)", () => {
 
     const done = notices.find((n) => n.startsWith("Pull done"));
     expect(done).toContain("deferred 2");
+  });
+});
+
+describe("SyncCommands — #3489 explicit success signal (info console + Notice)", () => {
+  it("success path: logInfo called exactly once with formatted summary, notify called exactly once for done", async () => {
+    const { commands, notices, infoLogs } = makeHarness({
+      specs: [spec("o/a"), spec("o/b")],
+      results: [
+        result("o/a#main", "synced", { pushedCount: 1, pulledCount: 2 }),
+        result("o/b#main", "synced", { mergedCount: 1, quarantinedCount: 1 }),
+      ],
+    });
+
+    await commands.invokeSync();
+
+    // Exactly ONE console info line for success summary
+    const infoSuccess = infoLogs.filter((l) => l.includes("[ExoSync] Sync OK:"));
+    expect(infoSuccess).toHaveLength(1);
+    const line = infoSuccess[0];
+    expect(line).toContain("2/2");
+    expect(line).toContain("pushed 1");
+    expect(line).toContain("pulled 2");
+    expect(line).toContain("merged 1");
+    expect(line).toContain("quarantined 1");
+
+    // Exactly ONE success Notice (the existing notify — no regression)
+    const doneNotices = notices.filter((n) => n.startsWith("Sync done"));
+    expect(doneNotices).toHaveLength(1);
+  });
+
+  it("success path: Pull and Push labels propagate into the info summary line", async () => {
+    const pull = makeHarness({ results: [result("o/r#main", "synced", { pulledCount: 3 })] });
+    await pull.commands.invokePull();
+    expect(pull.infoLogs.some((l) => l.includes("[ExoSync] Pull OK:"))).toBe(true);
+    expect(pull.infoLogs.filter((l) => l.includes("[ExoSync] Pull OK:"))).toHaveLength(1);
+
+    const push = makeHarness({ results: [result("o/r#main", "synced", { pushedCount: 2 })] });
+    await push.commands.invokePush();
+    expect(push.infoLogs.some((l) => l.includes("[ExoSync] Push OK:"))).toBe(true);
+  });
+
+  it("issues path: logInfo NOT called on error path — no regression to existing behaviour", async () => {
+    const { commands, notices, infoLogs } = makeHarness({
+      results: [
+        result("o/a#main", "synced"),
+        result("o/b#main", "error", { detail: "boom" }),
+      ],
+    });
+
+    await commands.invokeSync();
+
+    // No info line emitted on the issues path
+    expect(infoLogs.filter((l) => l.includes("[ExoSync]"))).toHaveLength(0);
+    // Existing issues Notice still fires
+    expect(notices.some((n) => n.includes("issues"))).toBe(true);
+  });
+
+  it("success path: no duplicate Notice (logInfo is info-only, no warn-channel Notice)", async () => {
+    const { commands, notices } = makeHarness();
+
+    await commands.invokeSync();
+
+    // There must NOT be two 'done' notices (no double-notice from warn-channel)
+    const doneNotices = notices.filter((n) => n.startsWith("Sync done"));
+    expect(doneNotices).toHaveLength(1);
+  });
+
+  it("works without logInfo wired (backward compat — optional dep)", async () => {
+    const notices: string[] = [];
+    const commands = new SyncCommands({
+      collectSpecs: async () => ({
+        specs: [spec("o/r")],
+        asUidByRepoKey: new Map(),
+        warnings: [],
+      }),
+      buildEngine: async () => ({
+        engine: { syncAll: async (specs: SyncRepoSpec[]) => specs.map((s) => result(s.repoKey, "synced")) } as unknown as import("exocortex").SyncEngine,
+        pat: "ghp_x",
+      }),
+      isSwitchInProgress: () => false,
+      notify: (m) => notices.push(m),
+    });
+
+    await expect(commands.invokeSync()).resolves.toBeUndefined();
+    expect(notices.some((n) => n.startsWith("Sync done"))).toBe(true);
   });
 });
 


### PR DESCRIPTION
## Summary

Closes #3489

After a clean ExoSync run the DevTools console was silent — only the UI Notice toast confirmed success. This PR adds an explicit `[ExoSync] <Label> OK: N/M repo(s) — <counts>` console line on the info channel, which has `{notice:false, console:true, file:false}` defaults.

## Design

The existing `log?` dep routes to `logger.warn` (warn channel: `{notice:true, console:true, file:true}`). Routing success through `log()` would produce a **double Notice + file-log spam** (issue #3186). Instead a dedicated optional `logInfo?` callback is added to `SyncCommandsDeps`:

- Absent callers (existing tests, other compositions) get a no-op `(_m) => undefined` — backward compat preserved.
- Production wiring: `logInfo: (message) => this.logger.info(message)`.

## Changes

- **`SyncCommandsDeps`** — new optional `logInfo?: (message: string) => void`
- **`SyncCommands.report()`** — reads `logInfo` with no-op fallback; calls it on success path only (not on auth-required early-return, not on issues path)
- **`ExocortexPlugin.ts`** — wires `logInfo: (m) => this.logger.info(m)`
- **`SyncCommands.test.ts`** — 6 new tests (TDD RED → GREEN):
  - success path: info line emitted exactly once with formatted counts
  - Pull/Push label propagation into info summary
  - issues path: no info line
  - no duplicate Notice
  - auth-required path: no info line (early-return before success branch)
  - backward compat: works without `logInfo` wired

## Revert-verify (per `integration-test-revert-verify.md` Update 2026-06-12)

Since the fix is committed, used `git checkout origin/main -- SyncCommands.ts` (NOT stash) to restore pre-fix state:

- **Pre-fix (origin/main):** 2/25 FAIL ✅
- **Post-fix (HEAD):** 25/25 PASS ✅

Empirically verified to FAIL pre-fix and PASS post-fix.

## Review

- Code-reviewer: **APPROVE** — 0 CRITICAL/HIGH/MEDIUM, 2 LOW
- Advisor round-2: **APPROVE** — 0 findings after LOW #1 fix (auth-required negative coverage)