### PR TITLE
feat(#3495,#3496): ExoSync quarantine-sink warn + step-by-step logging

### DIFF
--- a/packages/obsidian-plugin/src/infrastructure/adapters/SyncCommands.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/SyncCommands.ts
@@ -62,6 +62,13 @@ export class SyncCommands {
   private running = false;
   /** Label of the run holding the flag — busy notices name the real culprit. */
   private runningLabel = "Sync";
+  /**
+   * #3495 one-shot guard — the quarantine-sink-not-configured warn fires at
+   * most ONCE per plugin load (SyncCommands is a singleton per onload). A
+   * conflict re-derives every sync, so without the latch the warn would nag
+   * on every run; the latch keeps it to a single high-signal notice.
+   */
+  private quarantineSinkWarned = false;
 
   constructor(deps: SyncCommandsDeps) {
     this.deps = deps;
@@ -207,7 +214,7 @@ export class SyncCommands {
       return;
     }
 
-    const { engine, pat } = await this.deps.buildEngine(
+    const { engine, pat, quarantineConfigured } = await this.deps.buildEngine(
       collection.asUidByRepoKey,
     );
     if (pat === null || pat.length === 0) {
@@ -232,11 +239,25 @@ export class SyncCommands {
         : undefined;
 
     this.deps.notify(`${label} started (${collection.specs.length} repo(s))…`);
+    // #3496 — step trace start line on the info channel (console-only, no
+    // file/notice spam #3186). The notify() above is the single toast; this
+    // is the diagnostic counterpart.
+    const logInfo = this.deps.logInfo ?? ((_m: string): void => undefined);
+    logInfo(
+      `[ExoSync] ${label} started — ${collection.specs.length} repo(s), direction=${direction}`,
+    );
     const results = await engine.syncAll(
       orderChildrenFirst(collection.specs as SyncRepoSpec[]),
       direction,
     );
-    this.report(results, log, label);
+    const summary = this.report(results, log, label);
+
+    // #3495 — surface the silent degraded mode: a conflict was quarantined
+    // but no durable sink exists to save it. High-signal (only on an actual
+    // quarantined conflict, never on clean / deferred-only runs) and one-shot
+    // per session. Skipped on auth-required runs — the PAT prompt already
+    // owns that failure and the conflict re-surfaces on the next good run.
+    this.maybeWarnQuarantineSink(quarantineConfigured, summary);
 
     // E1 post-sync parity round (M1/M2). Best-effort: a parity failure is
     // logged + surfaced as its own Notice, never mutates the sync outcome.
@@ -259,11 +280,18 @@ export class SyncCommands {
     }
   }
 
+  /**
+   * Aggregate the per-repo results into the user-facing Notice + the #3489
+   * info summary, AND emit the #3496 per-repo step lines on the info channel.
+   * Returns the aggregate the caller needs for the #3495 degraded-mode warn —
+   * computed up front so it is available even on the auth-required early
+   * return.
+   */
   private report(
     results: RepoSyncResult[],
     log: (message: string) => void,
     label = "Sync",
-  ): void {
+  ): { quarantined: number; deferred: number; authRequired: boolean } {
     const logInfo = this.deps.logInfo ?? ((_m: string): void => undefined);
     let pushed = 0;
     let deleted = 0;
@@ -280,6 +308,11 @@ export class SyncCommands {
       if (r.detail !== undefined) {
         log(`[ExoSync] ${r.repoKey}: ${r.status} — ${r.detail}`);
       }
+      // #3496 — per-repo outcome line on the info channel (console-only, no
+      // notice/file spam #3186). Fires for EVERY repo (clean ones too) and on
+      // every direction/status: the step trace is most valuable precisely when
+      // a run misbehaves, so it is NOT gated on success.
+      logInfo(SyncCommands.repoStepLine(r));
       pushed += r.pushedCount;
       deleted += r.pushedDeletes?.length ?? 0;
       pulled += r.pulledCount;
@@ -303,12 +336,14 @@ export class SyncCommands {
       }
     }
 
+    const summary = { quarantined, deferred, authRequired };
+
     if (authRequired) {
       // R8 — explicit, never treated as success.
       this.deps.notify(
         `${label} failed: the GitHub PAT is expired, revoked or under-scoped — update it in Settings → Exocortex`,
       );
-      return;
+      return summary;
     }
 
     // Split-run deferrals (#3473) are surfaced in the Notice — without this
@@ -330,5 +365,54 @@ export class SyncCommands {
         `${label} finished with issues (${problems.join("; ")}) — ${counts}. See console for details.`,
       );
     }
+    return summary;
+  }
+
+  /**
+   * #3496 — one info-channel line per repo, summarising the phase outcomes
+   * (detect/pull/merge/push/watermark) the engine recorded for it. Pure
+   * formatting from {@link RepoSyncResult}; no engine plumbing. In-flight
+   * per-step progress (detecting…/pulling…/merging…) would need a SyncEngine
+   * progress callback — deferred to a follow-up to keep the sync engine
+   * untouched.
+   */
+  private static repoStepLine(r: RepoSyncResult): string {
+    const deletes = r.pushedDeletes?.length ?? 0;
+    const deferred = r.deferredPaths?.length ?? 0;
+    const parts = [
+      `pushed ${r.pushedCount}`,
+      `pulled ${r.pulledCount}`,
+      `merged ${r.mergedCount}`,
+      `quarantined ${r.quarantinedCount}`,
+    ];
+    if (deletes > 0) parts.push(`deleted ${deletes}`);
+    if (deferred > 0) parts.push(`deferred ${deferred}`);
+    return `[ExoSync] ${r.repoKey}: ${r.status} — ${parts.join(", ")}`;
+  }
+
+  /**
+   * #3495 — fire the degraded-mode warn exactly when it matters: the engine
+   * had no durable quarantine sink AND a conflict was actually quarantined
+   * (so both versions were lost and the conflict re-derives next sync). One
+   * Notice (toast) + one info-channel console echo (no file spam #3186),
+   * latched to once per session. Auth-required runs are skipped — the PAT
+   * prompt owns that failure and the conflict resurfaces on the next good run.
+   */
+  private maybeWarnQuarantineSink(
+    quarantineConfigured: boolean,
+    summary: { quarantined: number; authRequired: boolean },
+  ): void {
+    if (quarantineConfigured) return;
+    if (summary.authRequired) return;
+    if (summary.quarantined <= 0) return;
+    if (this.quarantineSinkWarned) return;
+    this.quarantineSinkWarned = true;
+    const message =
+      `Exocortex: quarantine sink not configured — ${summary.quarantined} conflict(s) ` +
+      `will re-derive but won't be saved. Set a quarantine repo in Settings → Exocortex.`;
+    this.deps.notify(message);
+    (this.deps.logInfo ?? ((_m: string): void => undefined))(
+      `[ExoSync] ${message}`,
+    );
   }
 }

--- a/packages/obsidian-plugin/src/infrastructure/adapters/SyncCommands.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/SyncCommands.ts
@@ -239,9 +239,10 @@ export class SyncCommands {
         : undefined;
 
     this.deps.notify(`${label} started (${collection.specs.length} repo(s))…`);
-    // #3496 — step trace start line on the info channel (console-only, no
-    // file/notice spam #3186). The notify() above is the single toast; this
-    // is the diagnostic counterpart.
+    // #3496 — step trace start line on the info channel (console-only on the
+    // default logChannels.info config = {notice:false,file:false}; honours the
+    // user's routing like every other info log, #3186). The notify() above is
+    // the single toast; this is the diagnostic counterpart.
     const logInfo = this.deps.logInfo ?? ((_m: string): void => undefined);
     logInfo(
       `[ExoSync] ${label} started — ${collection.specs.length} repo(s), direction=${direction}`,
@@ -308,10 +309,11 @@ export class SyncCommands {
       if (r.detail !== undefined) {
         log(`[ExoSync] ${r.repoKey}: ${r.status} — ${r.detail}`);
       }
-      // #3496 — per-repo outcome line on the info channel (console-only, no
-      // notice/file spam #3186). Fires for EVERY repo (clean ones too) and on
-      // every direction/status: the step trace is most valuable precisely when
-      // a run misbehaves, so it is NOT gated on success.
+      // #3496 — per-repo outcome line on the info channel (console-only on the
+      // default logChannels.info config, no file/notice spam #3186; honours the
+      // user's info routing if they opt in). Fires for EVERY repo (clean ones
+      // too) and on every direction/status: the step trace is most valuable
+      // precisely when a run misbehaves, so it is NOT gated on success.
       logInfo(SyncCommands.repoStepLine(r));
       pushed += r.pushedCount;
       deleted += r.pushedDeletes?.length ?? 0;
@@ -394,9 +396,10 @@ export class SyncCommands {
    * #3495 — fire the degraded-mode warn exactly when it matters: the engine
    * had no durable quarantine sink AND a conflict was actually quarantined
    * (so both versions were lost and the conflict re-derives next sync). One
-   * Notice (toast) + one info-channel console echo (no file spam #3186),
-   * latched to once per session. Auth-required runs are skipped — the PAT
-   * prompt owns that failure and the conflict resurfaces on the next good run.
+   * Notice (toast) + one info-channel console echo (console-only on the default
+   * info routing, no file spam #3186), latched to once per session.
+   * Auth-required runs are skipped — the PAT prompt owns that failure and the
+   * conflict resurfaces on the next good run.
    */
   private maybeWarnQuarantineSink(
     quarantineConfigured: boolean,

--- a/packages/obsidian-plugin/src/infrastructure/adapters/SyncDepsFactory.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/SyncDepsFactory.ts
@@ -370,6 +370,13 @@ export interface BuiltSyncEngine {
   engine: SyncEngine;
   /** PAT resolved at build time; null ⇒ caller surfaces the R8 prompt. */
   pat: string | null;
+  /**
+   * #3495 — whether the engine was built with a durable quarantine sink.
+   * `false` ⇒ conflicts are pinned and re-derive every sync but BOTH versions
+   * are never saved (silent degraded mode). The caller surfaces a one-shot
+   * warn when a conflict actually occurs without a sink.
+   */
+  quarantineConfigured: boolean;
 }
 
 /**
@@ -434,5 +441,5 @@ export async function buildSyncEngine(
     ...(quarantine !== undefined ? { quarantine } : {}),
   });
 
-  return { engine, pat };
+  return { engine, pat, quarantineConfigured: quarantine !== undefined };
 }

--- a/packages/obsidian-plugin/tests/unit/sync/SyncCommands.test.ts
+++ b/packages/obsidian-plugin/tests/unit/sync/SyncCommands.test.ts
@@ -54,6 +54,8 @@ interface HarnessOptions {
   parity?: ParityCheck;
   /** Optional info-level callback seam (success console signal, #3489). */
   logInfo?: (m: string) => void;
+  /** #3495 — whether the engine was built with a durable quarantine sink. */
+  quarantineConfigured?: boolean;
 }
 
 function makeHarness(opts: HarnessOptions = {}) {
@@ -79,6 +81,7 @@ function makeHarness(opts: HarnessOptions = {}) {
   const built: BuiltSyncEngine = {
     engine: { syncAll } as unknown as SyncEngine,
     pat: opts.pat === undefined ? "ghp_x" : opts.pat,
+    quarantineConfigured: opts.quarantineConfigured ?? true,
   };
   const commands = new SyncCommands({
     collectSpecs: async () => collection,
@@ -362,7 +365,7 @@ describe("SyncCommands — #3489 explicit success signal (info console + Notice)
     expect(push.infoLogs.some((l) => l.includes("[ExoSync] Push OK:"))).toBe(true);
   });
 
-  it("issues path: logInfo NOT called on error path — no regression to existing behaviour", async () => {
+  it("issues path: success SUMMARY line NOT emitted on error path (#3496 step lines still fire)", async () => {
     const { commands, notices, infoLogs } = makeHarness({
       results: [
         result("o/a#main", "synced"),
@@ -372,20 +375,25 @@ describe("SyncCommands — #3489 explicit success signal (info console + Notice)
 
     await commands.invokeSync();
 
-    // No info line emitted on the issues path
-    expect(infoLogs.filter((l) => l.includes("[ExoSync]"))).toHaveLength(0);
+    // The #3489 success SUMMARY ("Sync OK") must NOT fire on the issues path…
+    expect(infoLogs.filter((l) => l.includes("[ExoSync] Sync OK:"))).toHaveLength(0);
+    // …but #3496 step lines (start + per-repo) DO — diagnostics matter on failure.
+    expect(infoLogs.some((l) => l.includes("[ExoSync] Sync started"))).toBe(true);
     // Existing issues Notice still fires
     expect(notices.some((n) => n.includes("issues"))).toBe(true);
   });
 
-  it("auth-required path: logInfo NOT called — early return before success branch", async () => {
+  it("auth-required path: success SUMMARY NOT emitted — early return before success branch (#3496 step lines still fire)", async () => {
     const { commands, infoLogs } = makeHarness({
       results: [result("o/r#main", "auth-required")],
     });
 
     await commands.invokeSync();
 
-    expect(infoLogs).toHaveLength(0);
+    // No #3489 success summary on the auth-required early-return path…
+    expect(infoLogs.filter((l) => l.includes("[ExoSync] Sync OK:"))).toHaveLength(0);
+    // …but the #3496 start line fired before syncAll.
+    expect(infoLogs.some((l) => l.includes("[ExoSync] Sync started"))).toBe(true);
   });
 
   it("success path: no duplicate Notice (logInfo is info-only, no warn-channel Notice)", async () => {
@@ -409,6 +417,7 @@ describe("SyncCommands — #3489 explicit success signal (info console + Notice)
       buildEngine: async () => ({
         engine: { syncAll: async (specs: SyncRepoSpec[]) => specs.map((s) => result(s.repoKey, "synced")) } as unknown as import("exocortex").SyncEngine,
         pat: "ghp_x",
+        quarantineConfigured: true,
       }),
       isSwitchInProgress: () => false,
       notify: (m) => notices.push(m),
@@ -514,5 +523,244 @@ describe("SyncCommands — E1 parity harness integration", () => {
     expect(
       unwired.notices.some((n) => n.includes("not wired")),
     ).toBe(true);
+  });
+});
+
+describe("SyncCommands — #3495 quarantine-sink degraded-mode warn", () => {
+  const warnText = "quarantine sink not configured";
+
+  it("warns once (notify + logInfo) when the sink is unconfigured AND a conflict was quarantined", async () => {
+    const { commands, notices, infoLogs } = makeHarness({
+      quarantineConfigured: false,
+      results: [result("o/r#main", "synced", { quarantinedCount: 1 })],
+    });
+
+    await commands.invokeSync();
+
+    const warnNotices = notices.filter((n) => n.includes(warnText));
+    expect(warnNotices).toHaveLength(1);
+    expect(warnNotices[0]).toContain("1 conflict(s)");
+    expect(warnNotices[0]).toContain("Settings → Exocortex");
+    // Console echo on the info channel (no file spam, #3186) — exactly once.
+    expect(infoLogs.filter((l) => l.includes(warnText))).toHaveLength(1);
+  });
+
+  it("aggregates the conflict count across repos in the warn", async () => {
+    const { commands, notices } = makeHarness({
+      quarantineConfigured: false,
+      specs: [spec("o/a"), spec("o/b")],
+      results: [
+        result("o/a#main", "synced", { quarantinedCount: 2 }),
+        result("o/b#main", "synced", { quarantinedCount: 1 }),
+      ],
+    });
+
+    await commands.invokeSync();
+
+    expect(
+      notices.some((n) => n.includes(warnText) && n.includes("3 conflict(s)")),
+    ).toBe(true);
+  });
+
+  it("stays silent when the sink IS configured even with a conflict", async () => {
+    const { commands, notices, infoLogs } = makeHarness({
+      quarantineConfigured: true,
+      results: [result("o/r#main", "synced", { quarantinedCount: 2 })],
+    });
+
+    await commands.invokeSync();
+
+    expect(notices.some((n) => n.includes(warnText))).toBe(false);
+    expect(infoLogs.some((l) => l.includes(warnText))).toBe(false);
+  });
+
+  it("stays silent on a clean run (no conflict) when the sink is unconfigured", async () => {
+    const { commands, notices } = makeHarness({
+      quarantineConfigured: false,
+      results: [result("o/r#main", "synced", { pushedCount: 1 })],
+    });
+
+    await commands.invokeSync();
+
+    expect(notices.some((n) => n.includes(warnText))).toBe(false);
+  });
+
+  it("does NOT warn for deferred-only split runs (deferred is intentional, not a quarantined conflict)", async () => {
+    const { commands, notices } = makeHarness({
+      quarantineConfigured: false,
+      results: [
+        result("o/r#main", "synced", { deferredPaths: ["a.md", "b.md"] }),
+      ],
+    });
+
+    await commands.invokePull();
+
+    expect(notices.some((n) => n.includes(warnText))).toBe(false);
+  });
+
+  it("fires the warn at most once per session across multiple conflicted runs (one-shot)", async () => {
+    const { commands, notices } = makeHarness({
+      quarantineConfigured: false,
+      results: [result("o/r#main", "synced", { quarantinedCount: 1 })],
+    });
+
+    await commands.invokeSync();
+    await commands.invokeSync();
+
+    expect(notices.filter((n) => n.includes(warnText))).toHaveLength(1);
+  });
+
+  it("does NOT warn on an auth-required run even if another repo quarantined (PAT prompt only)", async () => {
+    const { commands, notices } = makeHarness({
+      quarantineConfigured: false,
+      specs: [spec("o/a"), spec("o/b")],
+      results: [
+        result("o/a#main", "synced", { quarantinedCount: 1 }),
+        result("o/b#main", "auth-required"),
+      ],
+    });
+
+    await commands.invokeSync();
+
+    expect(notices.some((n) => n.includes(warnText))).toBe(false);
+    expect(
+      notices.some((n) => n.includes("expired, revoked or under-scoped")),
+    ).toBe(true);
+  });
+
+  it("works without logInfo wired — warn still surfaces as a Notice (backward compat)", async () => {
+    const notices: string[] = [];
+    const commands = new SyncCommands({
+      collectSpecs: async () => ({
+        specs: [spec("o/r")],
+        asUidByRepoKey: new Map(),
+        warnings: [],
+      }),
+      buildEngine: async () => ({
+        engine: {
+          syncAll: async (specs: SyncRepoSpec[]) =>
+            specs.map((s) => result(s.repoKey, "synced", { quarantinedCount: 1 })),
+        } as unknown as SyncEngine,
+        pat: "ghp_x",
+        quarantineConfigured: false,
+      }),
+      isSwitchInProgress: () => false,
+      notify: (m) => notices.push(m),
+    });
+
+    await expect(commands.invokeSync()).resolves.toBeUndefined();
+    expect(notices.some((n) => n.includes(warnText))).toBe(true);
+  });
+});
+
+describe("SyncCommands — #3496 step-by-step logging (info channel)", () => {
+  it("emits a start line + per-repo outcome lines + the summary on the info channel", async () => {
+    const { commands, infoLogs } = makeHarness({
+      specs: [spec("o/a"), spec("o/b")],
+      results: [
+        result("o/a#main", "synced", { pushedCount: 2, pulledCount: 1 }),
+        result("o/b#main", "synced", { mergedCount: 1, quarantinedCount: 1 }),
+      ],
+    });
+
+    await commands.invokeSync();
+
+    // Start line — repo count + direction.
+    expect(
+      infoLogs.some(
+        (l) =>
+          l.includes("[ExoSync] Sync started") &&
+          l.includes("2 repo(s)") &&
+          l.includes("direction=sync"),
+      ),
+    ).toBe(true);
+
+    // Per-repo outcome lines — counts present.
+    const a = infoLogs.find((l) => l.includes("o/a#main:"));
+    expect(a).toContain("pushed 2");
+    expect(a).toContain("pulled 1");
+    const b = infoLogs.find((l) => l.includes("o/b#main:"));
+    expect(b).toContain("merged 1");
+    expect(b).toContain("quarantined 1");
+
+    // #3489 summary preserved.
+    expect(infoLogs.some((l) => l.includes("[ExoSync] Sync OK:"))).toBe(true);
+  });
+
+  it("per-repo step lines never become Notice toasts — only the summary toast", async () => {
+    const { commands, notices } = makeHarness({
+      specs: [spec("o/a"), spec("o/b")],
+      results: [
+        result("o/a#main", "synced", { pushedCount: 1 }),
+        result("o/b#main", "synced", { pulledCount: 1 }),
+      ],
+    });
+
+    await commands.invokeSync();
+
+    expect(notices.filter((n) => n.startsWith("Sync done"))).toHaveLength(1);
+    expect(
+      notices.some((n) => n.includes("o/a#main:") || n.includes("o/b#main:")),
+    ).toBe(false);
+    // The start line is console-only too — never a toast.
+    expect(notices.some((n) => n.includes("Sync started — "))).toBe(false);
+  });
+
+  it("emits start + per-repo lines even on the issues path (diagnostics matter most on failure)", async () => {
+    const { commands, infoLogs } = makeHarness({
+      specs: [spec("o/a"), spec("o/b")],
+      results: [
+        result("o/a#main", "synced", { pushedCount: 1 }),
+        result("o/b#main", "error", { detail: "boom" }),
+      ],
+    });
+
+    await commands.invokeSync();
+
+    expect(infoLogs.some((l) => l.includes("[ExoSync] Sync started"))).toBe(true);
+    expect(infoLogs.some((l) => l.includes("o/a#main:"))).toBe(true);
+    expect(
+      infoLogs.some((l) => l.includes("o/b#main:") && l.includes("error")),
+    ).toBe(true);
+  });
+
+  it("uses the correct direction label for Pull and Push start lines", async () => {
+    const pull = makeHarness({
+      results: [result("o/r#main", "synced", { pulledCount: 3 })],
+    });
+    await pull.commands.invokePull();
+    expect(
+      pull.infoLogs.some(
+        (l) => l.includes("[ExoSync] Pull started") && l.includes("direction=pull"),
+      ),
+    ).toBe(true);
+
+    const push = makeHarness({
+      results: [result("o/r#main", "synced", { pushedCount: 2 })],
+    });
+    await push.commands.invokePush();
+    expect(
+      push.infoLogs.some(
+        (l) => l.includes("[ExoSync] Push started") && l.includes("direction=push"),
+      ),
+    ).toBe(true);
+  });
+
+  it("per-repo line surfaces deletions and deferred counts when present", async () => {
+    const { commands, infoLogs } = makeHarness({
+      results: [
+        result("o/r#main", "synced", {
+          pushedCount: 1,
+          pushedDeletes: ["x.md"],
+          deferredPaths: ["y.md"],
+        }),
+      ],
+    });
+
+    await commands.invokePull();
+
+    const line = infoLogs.find((l) => l.includes("o/r#main:"));
+    expect(line).toContain("deleted 1");
+    expect(line).toContain("deferred 1");
   });
 });


### PR DESCRIPTION
## What

Two ExoSync observability FRs in one PR (same observability cluster as #3489 success signal / #3472 indexing notice).

### #3495 — warn when the quarantine sink is silently degraded
When `exosyncQuarantineRepoUrl` is empty, `buildSyncEngine` composes the engine with `quarantine = undefined`: conflicts are pinned and re-derive every sync but **both versions are never saved** — and nothing told the user. Now:
- `BuiltSyncEngine` exposes `quarantineConfigured: boolean` (`quarantine !== undefined`), set in `buildSyncEngine`.
- `SyncCommands.maybeWarnQuarantineSink` fires **exactly when it matters**: sink absent **AND** a conflict was actually quarantined (`quarantinedCount > 0`). One Notice (toast) + one info-channel console echo (no file spam, #3186), **latched once per session**.
- High-signal: silent on clean runs, on deferred-only split runs (deferred ≠ quarantined conflict), when the sink IS configured, and on auth-required runs (the PAT prompt owns that failure; the conflict resurfaces on the next good run).
- Message: `Exocortex: quarantine sink not configured — N conflict(s) will re-derive but won't be saved. Set a quarantine repo in Settings → Exocortex.`

### #3496 — step-by-step logging
- A run **start line** + a **per-repo outcome line** on the **info channel** (console-only — `{notice:false,console:true,file:false}`, no file/notice spam #3186). The existing #3489 summary stays the single toast.
- Step lines fire on **every** direction/status, **including the issues / auth-required paths** — diagnostics matter most when a run misbehaves. (Two pre-existing tests that asserted "no info line on issues/auth path" were updated: the #3489 success *summary* still does not fire there, but the new step lines do.)
- `report()` now returns the aggregate (`{quarantined, deferred, authRequired}`), computed up front so it survives the auth-required early return (advisor catch).
- Per-repo line example: `[ExoSync] o/r#main: synced — pushed 1, pulled 0, merged 0, quarantined 1, deleted 1, deferred 1`

## Design decisions (documented per AC)
- **#3496 channel choice:** info-only (option a), **not** a `verboseSyncLogging` setting (option b). Option (a) satisfies the AC ("either info-only OR opt-in") with the smallest blast radius — `VaultSettings*` is an elevated-regression path.
- **In-flight per-step progress deferred** (detecting…/pulling…/merging… *while running*). The per-repo line covers detect/pull/merge/push/watermark **results**, which is the actionable diagnostic; live in-flight progress needs a `SyncEngine` progress-callback (engine plumbing on the elevated-regression `sync/` path) and is out of scope for console-only observability. Follow-up to be filed.
- **#3495 trigger = `quarantinedCount` only, not `deferred`** — `deferredPaths` is intentional divergence on split pull/push, so including it would nag every split run. `quarantinedCount` is set from merge entry counts regardless of whether the sink durably saved them (`flushQuarantine` returns false when sink undefined but the count is unaffected), so `quarantinedCount > 0 && !quarantineConfigured` is precisely "a conflict occurred that had no durable home".

## Tests (TDD, revert-verified)
- 10 new/updated unit tests in `SyncCommands.test.ts` (+ `quarantineConfigured` in the harness/`BuiltSyncEngine`).
- **Empirically verified to FAIL pre-fix (10/10) and PASS post-fix (38/38)** via `git checkout origin/main -- SyncCommands.ts` → 10 fail → restore → 38 pass.
- Full plugin unit suite green: 5179 passed (the only 3 reds were `VaultSettingsRegistry` reading the uninitialized `exoas-exo` submodule in the worktree — env, not this change; 13/13 after `git submodule update --init`). Typecheck clean.

## No regression to
#3489 success summary · #3473 split semantics · #3478 anti-phantom · #3476 deletes · #3477 dup-uid · E1 parity round (all untouched; `report()` return is additive, callers ignored `void` before).

Closes #3495
Closes #3496
