### PR TITLE
feat(#3499): opt-in per-step Notice toggle for ExoSync (default off)

### DIFF
--- a/packages/obsidian-plugin/src/ExocortexPlugin.ts
+++ b/packages/obsidian-plugin/src/ExocortexPlugin.ts
@@ -2852,10 +2852,10 @@ export default class ExocortexPlugin extends Plugin {
       notify: (message) => this.notifier.info(message),
       log: (message) => this.logger.warn(message),
       logInfo: (message) => this.logger.info(message),
-      // #3499 — opt-in verbose per-step toasts (default off). Captured at
-      // onload like the indexer's excludedFolders; toggling in Settings takes
-      // effect on the next plugin reload.
-      stepNoticesEnabled: this.settings.exosyncStepNotices,
+      // #3499 — opt-in verbose per-step toasts (default off). Read live (like
+      // isSwitchInProgress) so the Settings toggle takes effect on the next
+      // sync without a plugin reload.
+      stepNoticesEnabled: () => this.settings.exosyncStepNotices,
       // ExoSync Phase E (E1) — automatic M1/M2 parity round after every
       // sync + the standalone palette report (parallel-run validation).
       parity: buildParityCheck({

--- a/packages/obsidian-plugin/src/ExocortexPlugin.ts
+++ b/packages/obsidian-plugin/src/ExocortexPlugin.ts
@@ -2852,6 +2852,10 @@ export default class ExocortexPlugin extends Plugin {
       notify: (message) => this.notifier.info(message),
       log: (message) => this.logger.warn(message),
       logInfo: (message) => this.logger.info(message),
+      // #3499 — opt-in verbose per-step toasts (default off). Captured at
+      // onload like the indexer's excludedFolders; toggling in Settings takes
+      // effect on the next plugin reload.
+      stepNoticesEnabled: this.settings.exosyncStepNotices,
       // ExoSync Phase E (E1) — automatic M1/M2 parity round after every
       // sync + the standalone palette report (parallel-run validation).
       parity: buildParityCheck({

--- a/packages/obsidian-plugin/src/domain/settings/ExocortexSettings.ts
+++ b/packages/obsidian-plugin/src/domain/settings/ExocortexSettings.ts
@@ -243,6 +243,15 @@ export interface ExocortexSettings {
    * Shared config, not a secret — synced data.json is the right home.
    */
   exosyncQuarantineRepoUrl: string;
+  /**
+   * ExoSync (#3499) — opt-in verbose step toasts. When `true`, each sync step
+   * (the start line and every per-repo outcome line, #3496) is ALSO surfaced
+   * as an Obsidian Notice on top of its console line. Default `false`: a Sync
+   * touches 14+ repos = 14+ toasts per run, so this is only for users actively
+   * watching a sync. The summary toast (#3489) is unaffected — it always fires
+   * exactly once and is never double-emitted by this toggle.
+   */
+  exosyncStepNotices: boolean;
   [key: string]: unknown;
 }
 
@@ -279,4 +288,5 @@ export const DEFAULT_SETTINGS: ExocortexSettings = {
   ],
   activeProfileUid: null,
   exosyncQuarantineRepoUrl: "",
+  exosyncStepNotices: false,
 };

--- a/packages/obsidian-plugin/src/domain/settings/VaultSettingsRegistry.ts
+++ b/packages/obsidian-plugin/src/domain/settings/VaultSettingsRegistry.ts
@@ -4,7 +4,7 @@
  * shipped in `packages/exoas-exo` (onto-RFC 981b6070, D1 @ 6c0797e).
  *
  * Homoiconicity (RFC c78cc5c8): the SCHEMA of valid settings lives in the
- * graph (23 `exo__SettingKey` individuals, each declaring its datatype).
+ * graph (24 `exo__SettingKey` individuals, each declaring its datatype).
  * This module is the engine-side binding table (Q3 exception 1 — core
  * processing): it maps each graph key to the TypeScript field the plugin
  * actually reads. The registry↔graph parity unit test asserts this table
@@ -195,6 +195,14 @@ export const VAULT_SETTINGS_REGISTRY: readonly VaultSettingDescriptor[] = [
     keyLabel: "exo__SettingKeyEnablePropertiesLabelPatch",
     datatype: "boolean",
     settingUid: "a054aff7-962e-4dd9-b713-cc852fcbe2a6",
+  },
+  {
+    // #3499 — ExoSync opt-in verbose per-step Notice toggle (default off).
+    field: "exosyncStepNotices",
+    keyUid: "5021effa-3a68-49fb-a6ae-48fdb9b2f4ab",
+    keyLabel: "exo__SettingKeyExosyncStepNotices",
+    datatype: "boolean",
+    settingUid: "93440232-6683-405e-8e9d-d832fef16f6c",
   },
   // ── string (2) ────────────────────────────────────────────────────
   {

--- a/packages/obsidian-plugin/src/infrastructure/adapters/SyncCommands.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/SyncCommands.ts
@@ -48,6 +48,18 @@ export interface SyncCommandsDeps {
    */
   logInfo?: (message: string) => void;
   /**
+   * #3499 — opt-in verbose step toasts. When true, the per-step info trace
+   * lines (start + per-repo) are ALSO surfaced as user-facing Notices on top
+   * of their console line. Default off (absent/false): a Sync touches 14+
+   * repos = 14+ toasts, so this is only for users actively watching a run.
+   *
+   * The summary is intentionally NOT re-mirrored here: the «… done» summary
+   * Notice (#3489) already fires unconditionally, so gating the summary info
+   * line would produce TWO summary toasts (AC #3499 "no double summary"). The
+   * #3495 quarantine-sink warn is likewise excluded — it owns its own Notice.
+   */
+  stepNoticesEnabled?: boolean;
+  /**
    * E1 parity harness (RFC 4e4dc453 Phase E). When wired, every sync round
    * is followed by an automatic M1/M2 validation pass (best-effort — a
    * parity failure NEVER affects the sync result), and the standalone
@@ -77,6 +89,16 @@ export class SyncCommands {
   /** Apply→sync exclusion input for `ProfileApplyManager.isSyncBusy`. */
   isBusy(): boolean {
     return this.running;
+  }
+
+  /**
+   * #3499 — mirror a step trace line to a user-facing Notice when the opt-in
+   * verbose toggle is on. No-op by default (toggle off / absent): the step
+   * line stays console-only as today. Only the start + per-repo step lines
+   * call this; the summary keeps its single #3489 Notice (no double toast).
+   */
+  private maybeStepNotice(message: string): void {
+    if (this.deps.stepNoticesEnabled === true) this.deps.notify(message);
   }
 
   /**
@@ -244,9 +266,10 @@ export class SyncCommands {
     // user's routing like every other info log, #3186). The notify() above is
     // the single toast; this is the diagnostic counterpart.
     const logInfo = this.deps.logInfo ?? ((_m: string): void => undefined);
-    logInfo(
-      `[ExoSync] ${label} started — ${collection.specs.length} repo(s), direction=${direction}`,
-    );
+    const startLine = `[ExoSync] ${label} started — ${collection.specs.length} repo(s), direction=${direction}`;
+    logInfo(startLine);
+    // #3499 — verbose toggle: also surface the start step as a Notice.
+    this.maybeStepNotice(startLine);
     const results = await engine.syncAll(
       orderChildrenFirst(collection.specs as SyncRepoSpec[]),
       direction,
@@ -314,7 +337,11 @@ export class SyncCommands {
       // user's info routing if they opt in). Fires for EVERY repo (clean ones
       // too) and on every direction/status: the step trace is most valuable
       // precisely when a run misbehaves, so it is NOT gated on success.
-      logInfo(SyncCommands.repoStepLine(r));
+      const stepLine = SyncCommands.repoStepLine(r);
+      logInfo(stepLine);
+      // #3499 — verbose toggle: also surface the per-repo step as a Notice.
+      // This is the firehose the toggle exists to gate (14+ repos = 14+ toasts).
+      this.maybeStepNotice(stepLine);
       pushed += r.pushedCount;
       deleted += r.pushedDeletes?.length ?? 0;
       pulled += r.pulledCount;

--- a/packages/obsidian-plugin/src/infrastructure/adapters/SyncCommands.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/SyncCommands.ts
@@ -48,17 +48,22 @@ export interface SyncCommandsDeps {
    */
   logInfo?: (message: string) => void;
   /**
-   * #3499 — opt-in verbose step toasts. When true, the per-step info trace
-   * lines (start + per-repo) are ALSO surfaced as user-facing Notices on top
-   * of their console line. Default off (absent/false): a Sync touches 14+
-   * repos = 14+ toasts, so this is only for users actively watching a run.
+   * #3499 — opt-in verbose step toasts. When this returns true, the per-step
+   * info trace lines (start + per-repo) are ALSO surfaced as user-facing
+   * Notices on top of their console line. Default off (absent / returns
+   * false): a Sync touches 14+ repos = 14+ toasts, so this is only for users
+   * actively watching a run.
+   *
+   * Read live (a callback, like `isSwitchInProgress`) so toggling the setting
+   * in Settings takes effect on the very next sync without a plugin reload —
+   * the whole point of the toggle is immediate observability.
    *
    * The summary is intentionally NOT re-mirrored here: the «… done» summary
    * Notice (#3489) already fires unconditionally, so gating the summary info
    * line would produce TWO summary toasts (AC #3499 "no double summary"). The
    * #3495 quarantine-sink warn is likewise excluded — it owns its own Notice.
    */
-  stepNoticesEnabled?: boolean;
+  stepNoticesEnabled?: () => boolean;
   /**
    * E1 parity harness (RFC 4e4dc453 Phase E). When wired, every sync round
    * is followed by an automatic M1/M2 validation pass (best-effort — a
@@ -98,7 +103,7 @@ export class SyncCommands {
    * call this; the summary keeps its single #3489 Notice (no double toast).
    */
   private maybeStepNotice(message: string): void {
-    if (this.deps.stepNoticesEnabled === true) this.deps.notify(message);
+    if (this.deps.stepNoticesEnabled?.() === true) this.deps.notify(message);
   }
 
   /**

--- a/packages/obsidian-plugin/src/presentation/settings/ExocortexSettingTab.ts
+++ b/packages/obsidian-plugin/src/presentation/settings/ExocortexSettingTab.ts
@@ -735,6 +735,23 @@ export class ExocortexSettingTab extends PluginSettingTab {
         });
       });
 
+    new Setting(containerEl)
+      .setName("Show a notice for each sync step")
+      .setDesc(
+        "Verbose: surface every sync step (start + each repo) as a toast on " +
+          "top of the console line. Default off — a Sync touches 14+ repos = " +
+          "14+ toasts per run. Turn on only while actively watching a sync. " +
+          "The single summary toast is unaffected.",
+      )
+      .addToggle((toggle) =>
+        toggle
+          .setValue(this.plugin.settings.exosyncStepNotices)
+          .onChange(async (value) => {
+            this.plugin.settings.exosyncStepNotices = value;
+            await this.plugin.saveSettings();
+          }),
+      );
+
     // ─────── Section 2 — Active profile ───────
     new Setting(containerEl).setName("Active profile").setHeading();
 

--- a/packages/obsidian-plugin/tests/unit/ExocortexSettingTab.test.ts
+++ b/packages/obsidian-plugin/tests/unit/ExocortexSettingTab.test.ts
@@ -160,7 +160,8 @@ describe("ExocortexSettingTab", () => {
       // Issue #3320 — Profile sections: 4 section headings + PAT row + Switch profile row + Cache stats row + (Operations log has no Setting row, body уходит в createDiv/createEl) = +7 → 39
       // RFC 13da049f R35 — added "Profiles" overview heading (+1) → 40
       // RFC 4e4dc453 Phase B — ExoSync section: heading + quarantine repo URL row (+2) → 42
-      expect(MockSetting).toHaveBeenCalledTimes(42);
+      // Issue #3499 — ExoSync verbose per-step Notice toggle (+1) → 43
+      expect(MockSetting).toHaveBeenCalledTimes(43);
     });
 
     it("should render layout visibility toggle as first setting", () => {

--- a/packages/obsidian-plugin/tests/unit/domain/settings/VaultSettingsRegistry.test.ts
+++ b/packages/obsidian-plugin/tests/unit/domain/settings/VaultSettingsRegistry.test.ts
@@ -17,11 +17,11 @@ const UUID_RE =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
 
 describe("VaultSettingsRegistry", () => {
-  it("contains exactly 23 descriptors (19 boolean / 2 string / 2 stringList)", () => {
-    expect(VAULT_SETTINGS_REGISTRY).toHaveLength(23);
+  it("contains exactly 24 descriptors (20 boolean / 2 string / 2 stringList)", () => {
+    expect(VAULT_SETTINGS_REGISTRY).toHaveLength(24);
     const byType = { boolean: 0, string: 0, stringList: 0 };
     for (const d of VAULT_SETTINGS_REGISTRY) byType[d.datatype]++;
-    expect(byType).toEqual({ boolean: 19, string: 2, stringList: 2 });
+    expect(byType).toEqual({ boolean: 20, string: 2, stringList: 2 });
   });
 
   it("has unique fields, keyUids and settingUids (all UUID-shaped)", () => {

--- a/packages/obsidian-plugin/tests/unit/sync/SyncCommands.test.ts
+++ b/packages/obsidian-plugin/tests/unit/sync/SyncCommands.test.ts
@@ -56,6 +56,8 @@ interface HarnessOptions {
   logInfo?: (m: string) => void;
   /** #3495 — whether the engine was built with a durable quarantine sink. */
   quarantineConfigured?: boolean;
+  /** #3499 — opt-in verbose per-step Notice toggle (default off). */
+  stepNoticesEnabled?: boolean;
 }
 
 function makeHarness(opts: HarnessOptions = {}) {
@@ -90,6 +92,9 @@ function makeHarness(opts: HarnessOptions = {}) {
     notify: (m) => notices.push(m),
     log: (m) => logs.push(m),
     logInfo: opts.logInfo ?? ((m) => infoLogs.push(m)),
+    ...(opts.stepNoticesEnabled !== undefined
+      ? { stepNoticesEnabled: opts.stepNoticesEnabled }
+      : {}),
     ...(opts.parity !== undefined ? { parity: opts.parity } : {}),
   });
   return { commands, notices, logs, infoLogs, syncAll };
@@ -762,5 +767,127 @@ describe("SyncCommands — #3496 step-by-step logging (info channel)", () => {
     const line = infoLogs.find((l) => l.includes("o/r#main:"));
     expect(line).toContain("deleted 1");
     expect(line).toContain("deferred 1");
+  });
+});
+
+describe("SyncCommands — #3499 opt-in per-step Notice toggle", () => {
+  it("toggle ON → notify fires for the start step line AND every per-repo step line", async () => {
+    const { commands, notices, infoLogs } = makeHarness({
+      stepNoticesEnabled: true,
+      specs: [spec("o/a"), spec("o/b")],
+      results: [
+        result("o/a#main", "synced", { pushedCount: 2, pulledCount: 1 }),
+        result("o/b#main", "synced", { mergedCount: 1, quarantinedCount: 1 }),
+      ],
+    });
+
+    await commands.invokeSync();
+
+    // Start step line surfaced as a toast (the "— " em-dash form is the
+    // diagnostic step line, distinct from the friendly "started (N repo(s))…").
+    expect(
+      notices.some(
+        (n) => n.includes("Sync started — ") && n.includes("direction=sync"),
+      ),
+    ).toBe(true);
+    // Every per-repo outcome line surfaced as a toast.
+    expect(notices.some((n) => n.includes("o/a#main:") && n.includes("pushed 2"))).toBe(
+      true,
+    );
+    expect(notices.some((n) => n.includes("o/b#main:") && n.includes("merged 1"))).toBe(
+      true,
+    );
+    // Console lines (#3496) still emitted in verbose mode (toast is in ADDITION).
+    expect(infoLogs.some((l) => l.includes("[ExoSync] Sync started"))).toBe(true);
+    expect(infoLogs.some((l) => l.includes("o/a#main:"))).toBe(true);
+  });
+
+  it("toggle OFF (default) → NO per-step toasts; behaviour unchanged (start+summary toasts only)", async () => {
+    const { commands, notices, infoLogs } = makeHarness({
+      // stepNoticesEnabled omitted → default off
+      specs: [spec("o/a"), spec("o/b")],
+      results: [
+        result("o/a#main", "synced", { pushedCount: 1 }),
+        result("o/b#main", "synced", { pulledCount: 1 }),
+      ],
+    });
+
+    await commands.invokeSync();
+
+    // No per-repo step toast.
+    expect(
+      notices.some((n) => n.includes("o/a#main:") || n.includes("o/b#main:")),
+    ).toBe(false);
+    // No diagnostic start step toast.
+    expect(notices.some((n) => n.includes("Sync started — "))).toBe(false);
+    // The friendly start toast + the single summary toast still fire (today's behaviour).
+    expect(notices.some((n) => n.startsWith("Sync started ("))).toBe(true);
+    expect(notices.filter((n) => n.startsWith("Sync done"))).toHaveLength(1);
+    // Console step lines (#3496) unchanged — present regardless of toggle.
+    expect(infoLogs.some((l) => l.includes("[ExoSync] Sync started"))).toBe(true);
+    expect(infoLogs.some((l) => l.includes("o/a#main:"))).toBe(true);
+  });
+
+  it("toggle ON → exactly ONE summary toast (no double summary from step-notify)", async () => {
+    const { commands, notices } = makeHarness({
+      stepNoticesEnabled: true,
+      specs: [spec("o/a"), spec("o/b")],
+      results: [
+        result("o/a#main", "synced", { pushedCount: 1, pulledCount: 2 }),
+        result("o/b#main", "synced", { mergedCount: 1 }),
+      ],
+    });
+
+    await commands.invokeSync();
+
+    // The "Sync done" summary toast must appear exactly once even with verbose on.
+    expect(notices.filter((n) => n.startsWith("Sync done"))).toHaveLength(1);
+    // The #3489 summary info line ("Sync OK") must NOT be mirrored as a second toast.
+    expect(notices.some((n) => n.includes("[ExoSync] Sync OK:"))).toBe(false);
+  });
+
+  it("toggle ON works for Pull and Push directions too", async () => {
+    const pull = makeHarness({
+      stepNoticesEnabled: true,
+      results: [result("o/r#main", "synced", { pulledCount: 3 })],
+    });
+    await pull.commands.invokePull();
+    expect(
+      pull.notices.some(
+        (n) => n.includes("Pull started — ") && n.includes("direction=pull"),
+      ),
+    ).toBe(true);
+    expect(pull.notices.some((n) => n.includes("o/r#main:"))).toBe(true);
+
+    const push = makeHarness({
+      stepNoticesEnabled: true,
+      results: [result("o/r#main", "synced", { pushedCount: 2 })],
+    });
+    await push.commands.invokePush();
+    expect(
+      push.notices.some(
+        (n) => n.includes("Push started — ") && n.includes("direction=push"),
+      ),
+    ).toBe(true);
+    expect(push.notices.some((n) => n.includes("o/r#main:"))).toBe(true);
+  });
+
+  it("toggle ON → step toasts still fire on the issues path (per-repo diagnostics matter most on failure)", async () => {
+    const { commands, notices } = makeHarness({
+      stepNoticesEnabled: true,
+      specs: [spec("o/a"), spec("o/b")],
+      results: [
+        result("o/a#main", "synced", { pushedCount: 1 }),
+        result("o/b#main", "error", { detail: "boom" }),
+      ],
+    });
+
+    await commands.invokeSync();
+
+    expect(notices.some((n) => n.includes("Sync started — "))).toBe(true);
+    expect(notices.some((n) => n.includes("o/a#main:"))).toBe(true);
+    expect(
+      notices.some((n) => n.includes("o/b#main:") && n.includes("error")),
+    ).toBe(true);
   });
 });

--- a/packages/obsidian-plugin/tests/unit/sync/SyncCommands.test.ts
+++ b/packages/obsidian-plugin/tests/unit/sync/SyncCommands.test.ts
@@ -93,7 +93,7 @@ function makeHarness(opts: HarnessOptions = {}) {
     log: (m) => logs.push(m),
     logInfo: opts.logInfo ?? ((m) => infoLogs.push(m)),
     ...(opts.stepNoticesEnabled !== undefined
-      ? { stepNoticesEnabled: opts.stepNoticesEnabled }
+      ? { stepNoticesEnabled: (): boolean => opts.stepNoticesEnabled === true }
       : {}),
     ...(opts.parity !== undefined ? { parity: opts.parity } : {}),
   });
@@ -889,5 +889,41 @@ describe("SyncCommands — #3499 opt-in per-step Notice toggle", () => {
     expect(
       notices.some((n) => n.includes("o/b#main:") && n.includes("error")),
     ).toBe(true);
+  });
+
+  it("reads the toggle LIVE — flipping it between runs takes effect without reconstructing SyncCommands", async () => {
+    // The dep is a callback (like isSwitchInProgress), so a mid-session
+    // Settings toggle reaches the very next sync without a plugin reload.
+    let enabled = false;
+    const notices: string[] = [];
+    const commands = new SyncCommands({
+      collectSpecs: async () => ({
+        specs: [spec("o/r")],
+        asUidByRepoKey: new Map(),
+        warnings: [],
+      }),
+      buildEngine: async () => ({
+        engine: {
+          syncAll: async (specs: SyncRepoSpec[]) =>
+            specs.map((s) => result(s.repoKey, "synced", { pushedCount: 1 })),
+        } as unknown as SyncEngine,
+        pat: "ghp_x",
+        quarantineConfigured: true,
+      }),
+      isSwitchInProgress: () => false,
+      notify: (m) => notices.push(m),
+      stepNoticesEnabled: () => enabled,
+    });
+
+    // First run while OFF → no per-repo step toast.
+    await commands.invokeSync();
+    expect(notices.some((n) => n.includes("o/r#main:"))).toBe(false);
+
+    // User flips the setting ON; second run reflects it with no reconstruction.
+    notices.length = 0;
+    enabled = true;
+    await commands.invokeSync();
+    expect(notices.some((n) => n.includes("o/r#main:"))).toBe(true);
+    expect(notices.some((n) => n.includes("Sync started — "))).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

Builds on #3496 (per-step console logging). Adds `exosyncStepNotices` (default **off**): when on, each sync step (the start line + every per-repo outcome line) is **also** surfaced as an Obsidian Notice on top of its existing console line. A Sync touches 14+ repos = 14+ toasts/run, so this is strictly opt-in for users actively watching a run.

Closes #3499.

## Design decisions

### Which step sites are gated (no double summary — AC)
`notify()` is gated at the two `logInfo` step sites that have **no** pre-existing unconditional toast:
- **start** (`SyncCommands.ts:247` — `[ExoSync] <label> started — N repo(s), direction=…`)
- **per-repo** (`:317` — `repoStepLine(r)`, the 14+ firehose the toggle exists for)

The **summary is intentionally NOT re-mirrored**: the «… done» summary Notice (#3489) already fires unconditionally, so gating the `:362` summary info-line would emit **two** summary toasts. This satisfies the AC literally — start (existing friendly toast + verbose step line), per-repo, and summary all emit a Notice when on — while guaranteeing exactly one summary toast (verified by a dedicated test). The #3495 quarantine-sink warn is likewise excluded — it owns its own Notice.

Implemented via a single `maybeStepNotice()` helper; default off ⇒ no-op ⇒ step lines stay console-only exactly as today.

### Homoiconic grounding (grounded, not denylisted)
Chose to **ground** the setting (vs. denylist), consistent with all 19 existing boolean UI toggles and the direct sibling `exosyncQuarantineRepoUrl` (#3461):
- New 24th `exo__SettingKey` individual `exo__SettingKeyExosyncStepNotices` (boolean) in `packages/exoas-exo` (submodule bumped `9f84d22…→8c09be0`).
- `VAULT_SETTINGS_REGISTRY` entry (R3 anti-drift parity test now 24 keys / 20 boolean).

### Wiring
`ExocortexPlugin` passes `this.settings.exosyncStepNotices` into `SyncCommandsDeps` (captured at onload like the indexer's `excludedFolders`; toggling in Settings takes effect on next reload). Settings UI: ExoSync-section toggle, persists across reload via `data.json`.

## Off (default) ⇒ behaviour unchanged
- Per-step lines stay console-only (#3496); single summary toast (#3489); no file spam (#3186); quarantine warn (#3495) intact.

## Tests (TDD)
New `SyncCommands — #3499` describe block (5 tests): ON → start+per-repo notify (Sync/Pull/Push, incl. issues path); OFF → no per-step toasts, single summary; ON → exactly one summary toast (no double).

**Empirically verified RED→GREEN**: the 3 ON-gating tests FAIL before the `maybeStepNotice` gating, PASS after. revert→fail/restore→pass documented in PR thread.

- Full obsidian-plugin unit suite: **265 suites / 5187 passing, 0 fail**.
- typecheck clean, lint clean (0 errors).

## Scope
`packages/obsidian-plugin` (SyncCommands / ExocortexSettings / VaultSettingsRegistry / ExocortexSettingTab / ExocortexPlugin) + `packages/exoas-exo` SettingKey individual (homoiconic grounding).

> Follow-up (vault maintenance, out of PR scope): bump the `exoas-exo` submodule pointer in vault-2025 + vault-exodev so the new SettingKey reaches both vaults (cross-repo-submodule-sync).