### PR TITLE
feat(cli): audit ontology-imports --structural-only / --exclude-predicate (EKA Phase B, VL#30)

### DIFF
--- a/packages/cli/src/commands/audit-ontology-imports.ts
+++ b/packages/cli/src/commands/audit-ontology-imports.ts
@@ -30,6 +30,25 @@ import { VaultNotFoundError } from "../utils/errors/index.js";
 export const ONTOLOGY_CLASS_UID = "829b9b3b-6fc3-4276-be6a-27d3398c012e";
 
 /**
+ * EKA Phase B / Vision de77fe27 VL#30 — curated associative (Zettelkasten /
+ * provenance) frontmatter predicates excluded from edge extraction under
+ * `--structural-only`. These are an orthogonal linking layer, NOT
+ * import/dependency edges, so they should not constitute the import-DAG nor
+ * the SCC. Excluding them isolates the STRUCTURAL backbone (superClass,
+ * Instance_class, domain/range, isDefinedBy, …) for re-layering analysis.
+ *
+ * Opt-in only — never applied by default, so the default audit output stays
+ * byte-identical. The set is extensible at the CLI via `--exclude-predicate`.
+ */
+export const ASSOCIATIVE_PREDICATES: readonly string[] = [
+  "exo__Asset_relates",
+  "ims__Concept_related",
+  "ims__Concept_broader",
+  "ims__Concept_synonym",
+  "exo__Asset_createdBy",
+];
+
+/**
  * Why an asset has no valid ontology. Per RFC df39007b VL#6 these are NOT
  * fail-open skips (unlike broken wikilinks) — they are reported as a distinct
  * data-gap category (closed by migration Phase 4), informational for the
@@ -147,6 +166,12 @@ export interface OntologyImportsResult {
    * gaps / validate-wikilinks territory, not imports-invariant violations).
    */
   clean: boolean;
+  /**
+   * EKA Phase B / VL#30 — present only when edge extraction excluded one or
+   * more associative predicates (`--structural-only` / `--exclude-predicate`).
+   * Absent in the default run, so the default JSON output is byte-identical.
+   */
+  excludedPredicates?: string[];
   /**
    * Import-additions proposal — present only with `--propose-imports`
    * ({@link computeImportProposal}). Read-only suggestion; the audit verdict
@@ -273,6 +298,15 @@ export interface ScanOntologyImportsOptions {
    * genuinely broken. Never legitimizes the link.
    */
   alsoPaths?: string[];
+  /**
+   * EKA Phase B / Vision VL#30 (opt-in): top-level frontmatter keys
+   * (predicates) whose wikilinks are NOT counted as import/dependency edges —
+   * associative Zettelkasten / provenance links. Body wikilinks are never
+   * predicate-attributed and stay counted (conservative). Empty/undefined ⟹
+   * default behaviour (every wikilink counts), byte-identical to pre-flag
+   * output. See {@link ASSOCIATIVE_PREDICATES} for the `--structural-only` set.
+   */
+  excludePredicates?: Iterable<string>;
 }
 
 export async function scanVaultForOntologyImports(
@@ -281,6 +315,10 @@ export async function scanVaultForOntologyImports(
 ): Promise<OntologyImportsResult> {
   const adapter = new CachingNodeFsAdapter(vaultPath, { cacheContent: true });
   const assets = await adapter.indexedAssets();
+
+  // EKA Phase B / VL#30 (opt-in): predicates excluded from edge extraction.
+  // Empty ⟹ default behaviour (byte-identical pre-flag output).
+  const excludeSet = new Set(options.excludePredicates ?? []);
 
   // ---- Phase A: --also cross-vault classifier (VL#13) ----
   const alsoPaths = options.alsoPaths ?? [];
@@ -487,7 +525,11 @@ export async function scanVaultForOntologyImports(
   for (const asset of assets) {
     if (isNodeModulesPath(asset.path) || isTemplatesPath(asset.path)) continue;
     const sourceOntology = assetOntology.get(asset.path) ?? null;
-    const targets = extractFileWikilinkTargets(asset.metadata, asset.content ?? "");
+    const targets = extractFileWikilinkTargets(
+      asset.metadata,
+      asset.content ?? "",
+      excludeSet,
+    );
 
     for (const target of targets) {
       linkCounts.total++;
@@ -670,6 +712,9 @@ export async function scanVaultForOntologyImports(
       ontologiesWithoutUid,
     },
     clean,
+    // VL#30: surface the exclusion only when active — keeps the default
+    // (no-flag) result object byte-identical to the pre-flag version.
+    ...(excludeSet.size > 0 ? { excludedPredicates: [...excludeSet] } : {}),
   };
 }
 
@@ -878,6 +923,10 @@ export interface AuditOntologyImportsOptions {
   output?: OutputFormat;
   also?: string[];
   proposeImports?: boolean;
+  /** VL#30: exclude the curated {@link ASSOCIATIVE_PREDICATES} set. */
+  structuralOnly?: boolean;
+  /** VL#30: additional predicate(s) to exclude (repeatable). */
+  excludePredicate?: string[];
 }
 
 function formatRef(ref: OntologyRef): string {
@@ -903,6 +952,13 @@ function printText(result: OntologyImportsResult): void {
         ? "acyclic"
         : `NOT ACYCLIC — ${result.declared.sccs.length} SCC(s)`),
   );
+
+  if (result.excludedPredicates && result.excludedPredicates.length > 0) {
+    log(
+      `Structural-only mode (VL#30): excluded ${result.excludedPredicates.length} associative ` +
+        `predicate(s) from edge extraction — ${result.excludedPredicates.join(", ")}`,
+    );
+  }
 
   if (result.duplicateOntologyUids.length > 0) {
     console.error(`\nHARD ERRORS — duplicate ontology UIDs (R7):`);
@@ -1082,6 +1138,16 @@ export function auditOntologyImportsCommand(): Command {
       "--propose-imports",
       "Emit a minimal additions-only import proposal (SCC condensation + transitive reduction + suggested feedback-arc-set)",
     )
+    .option(
+      "--structural-only",
+      "Exclude curated associative predicates (exo__Asset_relates, ims__Concept_related/broader/synonym, exo__Asset_createdBy) from edge extraction to measure the structural backbone import-DAG (EKA Phase B, Vision VL#30). Default: every wikilink counts.",
+    )
+    .option(
+      "--exclude-predicate <name>",
+      "Additional frontmatter predicate (top-level key) to exclude from edge extraction (repeatable; combines with --structural-only)",
+      collectExcludePredicate,
+      [],
+    )
     .action(async (options: AuditOntologyImportsOptions) => {
       const outputFormat = (options.output ?? "text") as OutputFormat;
       ErrorHandler.setFormat(outputFormat);
@@ -1101,8 +1167,17 @@ export function auditOntologyImportsCommand(): Command {
           }
         }
 
+        // VL#30 opt-in exclusion set: curated associative predicates (when
+        // --structural-only) plus any explicit --exclude-predicate entries.
+        // Empty when neither flag is given ⟹ default byte-identical output.
+        const excludePredicates = [
+          ...(options.structuralOnly ? ASSOCIATIVE_PREDICATES : []),
+          ...(options.excludePredicate ?? []),
+        ];
+
         const result = await scanVaultForOntologyImports(vaultPath, {
           alsoPaths,
+          excludePredicates,
         });
 
         if (options.proposeImports) {
@@ -1128,5 +1203,13 @@ export function auditOntologyImportsCommand(): Command {
  * find / sparql-index commands).
  */
 function collectAlso(value: string, previous: string[]): string[] {
+  return previous.concat([value]);
+}
+
+/**
+ * Commander.js accumulator for the repeatable `--exclude-predicate` flag
+ * (VL#30). Same pattern as {@link collectAlso}.
+ */
+function collectExcludePredicate(value: string, previous: string[]): string[] {
   return previous.concat([value]);
 }

--- a/packages/cli/src/services/wikilinkExtraction.ts
+++ b/packages/cli/src/services/wikilinkExtraction.ts
@@ -100,14 +100,34 @@ export function bodyOf(content: string): string {
 /**
  * All wikilink edge targets of one file: frontmatter strings + body with
  * fenced code blocks removed.
+ *
+ * `excludePredicates` (EKA Phase B / Vision VL#30, opt-in) lists top-level
+ * frontmatter keys (predicates) whose wikilinks are NOT emitted as edges —
+ * used by `audit ontology-imports --structural-only / --exclude-predicate` to
+ * measure the structural backbone import-DAG while ignoring associative
+ * Zettelkasten links (e.g. `exo__Asset_relates`). The exclusion is attributed
+ * to the TOP-LEVEL key only; body wikilinks are never predicate-attributed and
+ * are always kept (conservative — see RFC note). When `excludePredicates` is
+ * undefined or empty the output is byte-identical to the no-exclusion path:
+ * `collectFrontmatterStrings(metadata)` is exactly
+ * `Object.values(metadata).flatMap(collectFrontmatterStrings)`, so iterating
+ * the entries and concatenating yields the same string sequence in the same
+ * order.
  */
 export function extractFileWikilinkTargets(
   metadata: Record<string, unknown>,
   content: string,
+  excludePredicates?: ReadonlySet<string>,
 ): string[] {
-  const fromFrontmatter = collectFrontmatterStrings(metadata).flatMap(
-    extractWikilinkTargets,
-  );
+  const fromFrontmatter: string[] = [];
+  for (const [key, value] of Object.entries(metadata)) {
+    if (excludePredicates?.has(key)) continue;
+    for (const str of collectFrontmatterStrings(value)) {
+      for (const target of extractWikilinkTargets(str)) {
+        fromFrontmatter.push(target);
+      }
+    }
+  }
   const fromBody = extractWikilinkTargets(
     stripFencedCodeBlocks(bodyOf(content)),
   );

--- a/packages/cli/tests/unit/commands/audit-ontology-imports.test.ts
+++ b/packages/cli/tests/unit/commands/audit-ontology-imports.test.ts
@@ -7,6 +7,7 @@ import {
   auditOntologyImportsCommand,
   computeImportProposal,
   ONTOLOGY_CLASS_UID,
+  ASSOCIATIVE_PREDICATES,
   type OntologyImportsResult,
   type DerivedEdge,
 } from "../../../src/commands/audit-ontology-imports.js";
@@ -24,6 +25,12 @@ interface AssetSpec {
   imports?: string[];
   body?: string;
   filename?: string;
+  /**
+   * Arbitrary list-valued frontmatter predicates (each value wrapped in
+   * `[[…]]`) — used to exercise VL#30 predicate-attributed exclusion
+   * (e.g. `{ exo__Asset_relates: [uidB] }`).
+   */
+  listProps?: Record<string, string[]>;
 }
 
 function writeAsset(dir: string, spec: AssetSpec): string {
@@ -43,6 +50,12 @@ function writeAsset(dir: string, spec: AssetSpec): string {
   if (spec.imports) {
     lines.push("exo__Ontology_imports:");
     for (const i of spec.imports) lines.push(`  - "[[${i}]]"`);
+  }
+  if (spec.listProps) {
+    for (const [key, values] of Object.entries(spec.listProps)) {
+      lines.push(`${key}:`);
+      for (const v of values) lines.push(`  - "[[${v}]]"`);
+    }
   }
   lines.push("---", "", spec.body ?? "Body.", "");
   const file = join(dir, `${spec.filename ?? spec.uid}.md`);
@@ -72,7 +85,7 @@ describe("audit ontology-imports — Commander wiring", () => {
     expect(sub).toBeDefined();
   });
 
-  it("subcommand declares --vault required + --output + --also + --propose-imports", () => {
+  it("subcommand declares --vault required + --output + --also + --propose-imports + VL#30 flags", () => {
     const sub = auditOntologyImportsCommand();
     expect(sub.name()).toBe("ontology-imports");
     const opts = sub.options.map((o) => o.long);
@@ -80,6 +93,8 @@ describe("audit ontology-imports — Commander wiring", () => {
     expect(opts).toContain("--output");
     expect(opts).toContain("--also");
     expect(opts).toContain("--propose-imports");
+    expect(opts).toContain("--structural-only");
+    expect(opts).toContain("--exclude-predicate");
   });
 });
 
@@ -562,5 +577,107 @@ describe("audit ontology-imports — scanVaultForOntologyImports", () => {
     const r = await scanVaultForOntologyImports(vault);
     expect(r.skips["non-markdown"]).toBe(2);
     expect(r.skips.broken).toBe(0);
+  });
+});
+
+/**
+ * EKA Phase B / Vision VL#30 — opt-in `--structural-only` / `--exclude-predicate`
+ * exclusion of associative predicates from edge extraction. The default run must
+ * stay byte-identical (no-regret); the flag must drop only the named predicates'
+ * frontmatter edges and leave body / structural edges intact.
+ */
+describe("audit ontology-imports — structural-only predicate exclusion (VL#30)", () => {
+  let vault: string;
+
+  beforeEach(() => {
+    vault = join(
+      tmpdir(),
+      `audit-onto-structural-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    );
+    mkdirSync(vault, { recursive: true });
+    writeAsset(join(vault, "exo"), {
+      uid: ONTOLOGY_CLASS_UID,
+      label: "exo__Ontology",
+    });
+  });
+
+  afterEach(() => rmSync(vault, { recursive: true, force: true }));
+
+  // Shared fixture: A imports C (A→C valid). a1 in A has an associative
+  // `exo__Asset_relates` → b1 in B (cross-ontology, NOT imported ⇒ violation by
+  // default) AND a body link → c1 in C (structural, valid). The relates edge is
+  // the only violation; the body edge must survive under --structural-only.
+  function buildAssociativeViolationVault(): void {
+    writeOntology(join(vault, "alpha"), ONTO_A, "$alpha", [ONTO_C]);
+    writeOntology(join(vault, "beta"), ONTO_B, "$beta");
+    writeOntology(join(vault, "gamma"), ONTO_C, "$gamma");
+    writeAsset(join(vault, "alpha"), {
+      uid: "11111111-1111-4111-8111-111111111111",
+      isDefinedBy: `[[${ONTO_A}]]`,
+      listProps: {
+        exo__Asset_relates: ["33333333-3333-4333-8333-333333333333"], // → b1 (B)
+      },
+      body: "Structural [[44444444-4444-4444-8444-444444444444]].", // → c1 (C, valid)
+    });
+    writeAsset(join(vault, "beta"), {
+      uid: "33333333-3333-4333-8333-333333333333",
+      isDefinedBy: `[[${ONTO_B}]]`,
+    });
+    writeAsset(join(vault, "gamma"), {
+      uid: "44444444-4444-4444-8444-444444444444",
+      isDefinedBy: `[[${ONTO_C}]]`,
+    });
+  }
+
+  it("counts an associative relates edge as a violation by DEFAULT", async () => {
+    buildAssociativeViolationVault();
+    const r = await scanVaultForOntologyImports(vault);
+    expect(r.linkCounts.crossOntologyViolation).toBe(1);
+    expect(r.violations).toHaveLength(1);
+    expect(r.violations[0].source.uid).toBe(ONTO_A);
+    expect(r.violations[0].target.uid).toBe(ONTO_B);
+    expect(r.clean).toBe(false);
+    // Default run carries no exclusion metadata.
+    expect(r.excludedPredicates).toBeUndefined();
+  });
+
+  it("drops the associative relates edge under --structural-only, keeps the structural body edge", async () => {
+    buildAssociativeViolationVault();
+    const r = await scanVaultForOntologyImports(vault, {
+      excludePredicates: ASSOCIATIVE_PREDICATES,
+    });
+    // relates A→B excluded ⇒ no violation; body A→C (valid) still counted.
+    expect(r.linkCounts.crossOntologyViolation).toBe(0);
+    expect(r.violations).toHaveLength(0);
+    expect(
+      r.derivedEdges.find((e) => e.source === ONTO_A && e.target === ONTO_B),
+    ).toBeUndefined();
+    expect(
+      r.derivedEdges.find((e) => e.source === ONTO_A && e.target === ONTO_C),
+    ).toBeDefined();
+    expect(r.clean).toBe(true);
+    expect(r.excludedPredicates).toEqual([...ASSOCIATIVE_PREDICATES]);
+  });
+
+  it("--exclude-predicate alone (just exo__Asset_relates) drops the same edge", async () => {
+    buildAssociativeViolationVault();
+    const r = await scanVaultForOntologyImports(vault, {
+      excludePredicates: ["exo__Asset_relates"],
+    });
+    expect(r.linkCounts.crossOntologyViolation).toBe(0);
+    expect(r.excludedPredicates).toEqual(["exo__Asset_relates"]);
+  });
+
+  // Revert-verify (no-regret): an EMPTY exclusion set yields a result
+  // byte-identical to the no-options call. A regression that let the flag leak
+  // into the default path would break this deep-equality.
+  it("default behaviour is byte-identical: empty exclusion deep-equals no-options run", async () => {
+    buildAssociativeViolationVault();
+    const baseline = await scanVaultForOntologyImports(vault);
+    const emptyExclusion = await scanVaultForOntologyImports(vault, {
+      excludePredicates: [],
+    });
+    expect(JSON.stringify(emptyExclusion)).toBe(JSON.stringify(baseline));
+    expect(emptyExclusion.excludedPredicates).toBeUndefined();
   });
 });

--- a/packages/cli/tests/unit/services/wikilinkExtraction.test.ts
+++ b/packages/cli/tests/unit/services/wikilinkExtraction.test.ts
@@ -135,3 +135,35 @@ describe("extractFileWikilinkTargets", () => {
     ]);
   });
 });
+
+describe("extractFileWikilinkTargets — predicate exclusion (VL#30)", () => {
+  const metadata = {
+    exo__Asset_isDefinedBy: "[[onto-uid]]",
+    exo__Asset_relates: ["[[rel-1|Label]]", "[[rel-2]]"],
+    ims__Concept_broader: "[[broad-1]]",
+  };
+  const content = ["---", "x: y", "---", "Body [[body-target#anchor]]."].join(
+    "\n",
+  );
+
+  it("an empty exclusion set is byte-identical to the 2-arg call (default unchanged)", () => {
+    expect(extractFileWikilinkTargets(metadata, content, new Set())).toEqual(
+      extractFileWikilinkTargets(metadata, content),
+    );
+  });
+
+  it("excludes only the named top-level frontmatter keys; body links always kept", () => {
+    const exclude = new Set(["exo__Asset_relates", "ims__Concept_broader"]);
+    expect(extractFileWikilinkTargets(metadata, content, exclude)).toEqual([
+      "onto-uid", // exo__Asset_isDefinedBy is not excluded
+      "body-target", // body links are never predicate-attributed (conservative)
+    ]);
+  });
+
+  it("an exclusion set matching no key leaves every target intact", () => {
+    const exclude = new Set(["some__Unrelated_predicate"]);
+    expect(extractFileWikilinkTargets(metadata, content, exclude)).toEqual(
+      extractFileWikilinkTargets(metadata, content),
+    );
+  });
+});


### PR DESCRIPTION
## Phase B EKA — opt-in structural-only ontology-imports measurement (VL#30 associative-exclusion). Default unchanged.

### Why
Combined `audit ontology-imports` reports ONE giant SCC[29] (29 ontologies, 156 edges, ~16824 violations). Analysis shows the SCC is dominated by **associative** predicates (`exo__Asset_relates` occ 2992, `ims__Concept_related` 2050, `ims__Concept_broader` 1462). Per Vision `de77fe27` **VL#30**, linking is an orthogonal Zettelkasten layer — associative links should NOT constitute the import/dependency DAG. We need a way to **measure the true structural SCC** (backbone: superClass / Instance_class / domain / range / isDefinedBy) to plan re-layering.

This is an **additive, opt-in** flag — the default audit output is **byte-identical** (no-regret: safe even if the re-layering decision is later reverted).

### What
- `extractFileWikilinkTargets(metadata, content, excludePredicates?)` — optional exclusion set, attributed to the **top-level frontmatter key** only. Body wikilinks are never predicate-attributed and stay counted (conservative — documented limitation). With no/empty set the output is byte-identical to before.
- `audit ontology-imports --structural-only` — excludes the curated `ASSOCIATIVE_PREDICATES` set: `exo__Asset_relates`, `ims__Concept_related`, `ims__Concept_broader`, `ims__Concept_synonym`, `exo__Asset_createdBy`.
- `--exclude-predicate <name>` — repeatable; adds custom keys; composes with `--structural-only`.
- `excludedPredicates` surfaced in text + JSON output **only when active** (absent in default run → JSON byte-identical).

### Default = byte-identical (no-regret)
- `scanVaultForOntologyImports(vault, { excludePredicates: [] })` **deep-equals** the no-options run (revert-verify test).
- Empty `Set` short-circuits every `.has(key)` → same edge graph.
- `extractFileWikilinkTargets` unified loop is provably identical to `collectFrontmatterStrings(metadata).flatMap(...)` when nothing is excluded.

### Tests
- `wikilinkExtraction.test.ts`: empty-exclusion = 2-arg call; excludes only named top-level keys (body kept); non-matching set = no-op.
- `audit-ontology-imports.test.ts`: Commander wiring (`--structural-only` + `--exclude-predicate` present); associative relates edge counts as violation by DEFAULT; `--structural-only` drops it while keeping the structural body edge; `--exclude-predicate` alone drops it; **empty-exclusion deep-equals no-options run** (byte-identity guard).
- 45 affected tests green (unit + integration); `npm run check:types` clean.

### End-to-end smoke (synthetic vault)
```
DEFAULT          → FAIL, 1 violating occurrence, total=12 links
--structural-only → OK,   0 violating, total=11 (relates dropped), banner lists 5 excluded predicates
JSON default      → no `excludedPredicates` key (byte-identity preserved)
```

Scope: CLI only (`packages/cli`). No change to plugin / TBox / parser-critical paths. Default audit behaviour unchanged.