### PR TITLE
feat(c5): «Archive Ontologically» homoiconic composite + validator query/exoql prefix fix (RFC 78c2b7d0 C5)

### DIFF
--- a/packages/cli/src/commands/validate-schema.ts
+++ b/packages/cli/src/commands/validate-schema.ts
@@ -61,6 +61,17 @@ export const NAMESPACE_PREFIX_MAP: ReadonlyMap<string, string> = new Map([
   ["ems__", "https://exocortex.my/ontology/ems#"],
   ["exocmd__", "https://exocortex.my/ontology/exocmd#"],
   ["ims__", "https://exocortex.my/ontology/ims#"],
+  // RFC 78c2b7d0 C4 — read-side query ontology (exoql__Query) + its C4
+  // refinement (query__NamedQuery). Without these, TripleClassHierarchy's
+  // labelToOntologyIRI returns null for query__/exoql__ class labels, so the
+  // ontology-URI subClassOf edges (query#NamedQuery → exoql#Query → exo#Asset)
+  // are never built — making `sh:class exo__Asset` range checks on a
+  // `targetValueQuery → query__NamedQuery` reference (C5 «Archive Ontologically»)
+  // a false violation even though NamedQuery IS-A exo__Asset via that chain.
+  // NoteToRDFConverter already derives these IRIs dynamically (Namespace.fromPropertyKey);
+  // this keeps the validator's curated prefix registry in sync.
+  ["exoql__", "https://exocortex.my/ontology/exoql#"],
+  ["query__", "https://exocortex.my/ontology/query#"],
   ["ztlk__", "https://exocortex.my/ontology/ztlk#"],
   ["ptms__", "https://exocortex.my/ontology/ptms#"],
   ["lit__", "https://exocortex.my/ontology/lit#"],

--- a/packages/cli/tests/integration/apply-ontological-archive.integration.test.ts
+++ b/packages/cli/tests/integration/apply-ontological-archive.integration.test.ts
@@ -1,0 +1,308 @@
+/**
+ * RFC 78c2b7d0 C5 — «Archive Ontologically» end-to-end (homoiconic composition).
+ *
+ * This is the empirical proof that C5's archive mechanism is an *emergent
+ * composition* of already-shipped primitives — no bespoke "archive subsystem":
+ *
+ *   composite[
+ *     step-1 = property_set isDefinedBy via targetValueQuery → NamedQuery   (C4)
+ *     step-2 = service_call serviceId=repairFolder                          (co-location)
+ *   ]
+ *
+ * Step-1 re-anchors `exo__Asset_isDefinedBy` to the archive ontology computed
+ * by a 1-hop NamedQuery (`$currentAsset --isDefinedBy→ srcOnto --archiveOntology→
+ * archiveOnto`). Step-2 then physically relocates the file into the archive
+ * ontology's folder (the co-location invariant). The two run in document order
+ * inside the composite, sharing file state.
+ *
+ * Exercised against the REAL `apply` pipeline on a temp vault (no --dry-run; we
+ * read the moved file back — `~/dotfiles/.claude/rules/dry-run-preview-not-real-output.md`).
+ *
+ * Idempotency: a second apply is a no-op because the command's SPARQL-ASK
+ * precondition (`archived:true` AND current ontology HAS an archiveOntology)
+ * fails once the asset already lives in the archive ontology (archive
+ * ontologies declare no archiveOntology of their own).
+ */
+import { jest, describe, it, expect, beforeEach, afterEach } from "@jest/globals";
+import * as fs from "fs";
+import * as path from "path";
+import * as os from "os";
+
+const { applyCommand } = await import("../../src/commands/apply.js");
+
+// Command-system assets
+const COMMAND_UID = "c5000000-0000-0000-0000-0000000000a1";
+const COMPOSITE_UID = "c5000000-0000-0000-0000-0000000000a2";
+const STEP1_UID = "c5000000-0000-0000-0000-0000000000a3";
+const STEP2_UID = "c5000000-0000-0000-0000-0000000000a4";
+const QUERY_UID = "c5000000-0000-0000-0000-0000000000a5";
+const PRECOND_UID = "c5000000-0000-0000-0000-0000000000a6";
+// Domain data
+const TARGET_UID = "c5000000-0000-0000-0000-0000000000b1";
+const SRC_ONTO_UID = "c5000000-0000-0000-0000-0000000000b2";
+const ARCHIVE_ONTO_UID = "c5000000-0000-0000-0000-0000000000b3";
+
+// Grounding-type UIDs (GroundingTypeUIDs.ts)
+const TYPE_COMPOSITE = "8f9a57db-3865-4886-92fb-c5ab7f3c3fa3";
+const TYPE_PROPERTY_SET = "cf3bb923-f1f1-40be-b728-782844402426";
+const TYPE_SERVICE_CALL = "9bf9fc99-ac37-4e51-b9f5-bd920099947c";
+
+const ISDEFINEDBY = "https://exocortex.my/ontology/exo#Asset_isDefinedBy";
+const ARCHIVE_PRED = "https://exocortex.my/ontology/exo#Ontology_archiveOntology";
+
+// Folders: target+srcOnto co-located in space/, archiveOnto in space-archive/.
+const SPACE = "space";
+const ARCHIVE_SPACE = "space-archive";
+
+const COMMAND_MD = [
+  "---",
+  `exo__Asset_uid: ${COMMAND_UID}`,
+  `exo__Asset_label: "Archive Ontologically"`,
+  `exo__Asset_isDefinedBy: "[[!kitelev]]"`,
+  `exo__Instance_class:`,
+  `  - "[[exocmd__Command]]"`,
+  `exocmd__Command_grounding: "[[${COMPOSITE_UID}|grounding]]"`,
+  `exocmd__Command_precondition: "[[${PRECOND_UID}|precondition]]"`,
+  "---",
+  "",
+].join("\n");
+
+const COMPOSITE_MD = [
+  "---",
+  `exo__Asset_uid: ${COMPOSITE_UID}`,
+  `exo__Asset_label: "Archive Ontologically (composite)"`,
+  `exo__Asset_isDefinedBy: "[[!kitelev]]"`,
+  `exo__Instance_class:`,
+  `  - "[[exocmd__Grounding]]"`,
+  `exocmd__Grounding_type: "[[${TYPE_COMPOSITE}]]"`,
+  `exocmd__Grounding_steps:`,
+  `  - "[[${STEP1_UID}|set isDefinedBy]]"`,
+  `  - "[[${STEP2_UID}|repair folder]]"`,
+  "---",
+  "",
+].join("\n");
+
+const STEP1_MD = [
+  "---",
+  `exo__Asset_uid: ${STEP1_UID}`,
+  `exo__Asset_label: "Re-anchor isDefinedBy to archive ontology"`,
+  `exo__Asset_isDefinedBy: "[[!kitelev]]"`,
+  `exo__Instance_class:`,
+  `  - "[[exocmd__Grounding]]"`,
+  `exocmd__Grounding_type: "[[${TYPE_PROPERTY_SET}]]"`,
+  `exocmd__Grounding_targetProperty: "exo__Asset_isDefinedBy"`,
+  `exocmd__Grounding_targetValueQuery: "[[${QUERY_UID}|archive query]]"`,
+  "---",
+  "",
+].join("\n");
+
+const STEP2_MD = [
+  "---",
+  `exo__Asset_uid: ${STEP2_UID}`,
+  `exo__Asset_label: "Relocate to archive ontology folder"`,
+  `exo__Asset_isDefinedBy: "[[!kitelev]]"`,
+  `exo__Instance_class:`,
+  `  - "[[exocmd__Grounding]]"`,
+  `exocmd__Grounding_type: "[[${TYPE_SERVICE_CALL}]]"`,
+  // service_call overloads targetProperty as the serviceId.
+  `exocmd__Grounding_targetProperty: "repairFolder"`,
+  "---",
+  "",
+].join("\n");
+
+const QUERY_MD = [
+  "---",
+  `exo__Asset_uid: ${QUERY_UID}`,
+  `exo__Asset_label: "Resolve archive ontology"`,
+  `exo__Asset_isDefinedBy: "[[!kitelev]]"`,
+  `exo__Instance_class:`,
+  `  - "[[query__NamedQuery]]"`,
+  "---",
+  "",
+  "# Resolve archive ontology",
+  "",
+  "```sparql",
+  `SELECT ?archiveOnto WHERE { $currentAsset <${ISDEFINEDBY}> ?o . ?o <${ARCHIVE_PRED}> ?archiveOnto }`,
+  "```",
+  "",
+].join("\n");
+
+const PRECOND_MD = [
+  "---",
+  `exo__Asset_uid: ${PRECOND_UID}`,
+  `exo__Asset_label: "Archived and not yet ontologically archived"`,
+  `exo__Asset_isDefinedBy: "[[!kitelev]]"`,
+  `exo__Instance_class:`,
+  `  - "[[exocmd__Precondition]]"`,
+  // Compound gate in one ASK: (1) user flagged archived:true (stage-1
+  // toggle-archived → exo:Asset_archived "true"), (2) current ontology HAS an
+  // archive target. Once relocated, isDefinedBy→archiveOnto which declares no
+  // archiveOntology → ASK false → idempotent no-op.
+  `exocmd__Precondition_sparqlAsk: |-`,
+  `  PREFIX exo: <https://exocortex.my/ontology/exo#> ASK {`,
+  `    $target exo:Asset_archived "true" .`,
+  `    $target exo:Asset_isDefinedBy ?onto .`,
+  `    ?onto exo:Ontology_archiveOntology ?archiveOnto .`,
+  `  }`,
+  "---",
+  "",
+].join("\n");
+
+const TARGET_MD = [
+  "---",
+  `exo__Asset_uid: ${TARGET_UID}`,
+  `exo__Asset_label: "Some domain asset"`,
+  `exo__Asset_isDefinedBy: "[[${SRC_ONTO_UID}|src ontology]]"`,
+  `archived: true`,
+  `exo__Instance_class:`,
+  `  - "[[ims__Concept]]"`,
+  "---",
+  "",
+].join("\n");
+
+const SRC_ONTO_MD = [
+  "---",
+  `exo__Asset_uid: ${SRC_ONTO_UID}`,
+  `exo__Asset_label: "Source ontology"`,
+  `exo__Asset_isDefinedBy: "[[!kitelev]]"`,
+  `exo__Instance_class:`,
+  `  - "[[exo__Ontology]]"`,
+  `exo__Ontology_archiveOntology: "[[${ARCHIVE_ONTO_UID}|archive ontology]]"`,
+  "---",
+  "",
+].join("\n");
+
+const ARCHIVE_ONTO_MD = [
+  "---",
+  `exo__Asset_uid: ${ARCHIVE_ONTO_UID}`,
+  `exo__Asset_label: "Source ontology (archive)"`,
+  `exo__Asset_isDefinedBy: "[[!kitelev]]"`,
+  `exo__Instance_class:`,
+  `  - "[[exo__Ontology]]"`,
+  "---",
+  "",
+].join("\n");
+
+function buildVault(): {
+  root: string;
+  targetRel: string;
+  archivedTargetRel: string;
+} {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "exo-c5-onto-archive-"));
+  const writeRoot = (uid: string, md: string) =>
+    fs.writeFileSync(path.join(root, `${uid}.md`), md, "utf-8");
+  // Command-system assets at vault root.
+  writeRoot(COMMAND_UID, COMMAND_MD);
+  writeRoot(COMPOSITE_UID, COMPOSITE_MD);
+  writeRoot(STEP1_UID, STEP1_MD);
+  writeRoot(STEP2_UID, STEP2_MD);
+  writeRoot(QUERY_UID, QUERY_MD);
+  writeRoot(PRECOND_UID, PRECOND_MD);
+
+  // Domain data: target + srcOnto co-located in space/, archiveOnto in space-archive/.
+  fs.mkdirSync(path.join(root, SPACE), { recursive: true });
+  fs.mkdirSync(path.join(root, ARCHIVE_SPACE), { recursive: true });
+  fs.writeFileSync(path.join(root, SPACE, `${TARGET_UID}.md`), TARGET_MD, "utf-8");
+  fs.writeFileSync(path.join(root, SPACE, `${SRC_ONTO_UID}.md`), SRC_ONTO_MD, "utf-8");
+  fs.writeFileSync(
+    path.join(root, ARCHIVE_SPACE, `${ARCHIVE_ONTO_UID}.md`),
+    ARCHIVE_ONTO_MD,
+    "utf-8",
+  );
+
+  return {
+    root,
+    targetRel: `${SPACE}/${TARGET_UID}.md`,
+    archivedTargetRel: `${ARCHIVE_SPACE}/${TARGET_UID}.md`,
+  };
+}
+
+describe("RFC 78c2b7d0 C5 — Archive Ontologically (homoiconic composite)", () => {
+  let root: string;
+  let processExitSpy: jest.SpiedFunction<typeof process.exit>;
+  let consoleLogSpy: jest.SpiedFunction<typeof console.log>;
+  let consoleErrorSpy: jest.SpiedFunction<typeof console.error>;
+
+  beforeEach(() => {
+    processExitSpy = jest
+      .spyOn(process, "exit")
+      .mockImplementation(((code?: number) => {
+        throw new Error(`__process_exit_${code ?? 0}__`);
+      }) as never);
+    consoleLogSpy = jest.spyOn(console, "log").mockImplementation(() => {});
+    consoleErrorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    processExitSpy.mockRestore();
+    consoleLogSpy.mockRestore();
+    consoleErrorSpy.mockRestore();
+    if (root) fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  async function runApply(vaultRoot: string, targetRel: string): Promise<void> {
+    // Fresh Command instance per call → re-hydrates the triple store from the
+    // current on-disk vault state (so the idempotency re-run sees the moved file).
+    const cmd = applyCommand();
+    const args = [
+      "node",
+      "apply",
+      COMMAND_UID,
+      targetRel,
+      "--vault",
+      vaultRoot,
+      "--yes",
+    ];
+    try {
+      await cmd.parseAsync(args);
+    } catch (err) {
+      if (!/^__process_exit_/.test(String((err as Error)?.message))) throw err;
+    }
+  }
+
+  it("relocates the asset into the archive ontology folder and re-anchors isDefinedBy (real mutation)", async () => {
+    const vault = buildVault();
+    root = vault.root;
+
+    await runApply(root, vault.targetRel);
+
+    const oldPath = path.join(root, vault.targetRel);
+    const newPath = path.join(root, vault.archivedTargetRel);
+
+    // Step-2 (repairFolder) physically moved the file into space-archive/.
+    expect(fs.existsSync(oldPath)).toBe(false);
+    expect(fs.existsSync(newPath)).toBe(true);
+
+    // Step-1 re-anchored isDefinedBy to the NamedQuery-computed archive ontology.
+    const written = fs.readFileSync(newPath, "utf-8");
+    expect(written).toContain(`exo__Asset_isDefinedBy: "[[${ARCHIVE_ONTO_UID}]]"`);
+    expect(written).not.toContain(SRC_ONTO_UID);
+    // archived:true survives (we don't unset it).
+    expect(written).toContain("archived: true");
+  });
+
+  it("is idempotent — re-applying to an already-archived asset is a precondition no-op", async () => {
+    const vault = buildVault();
+    root = vault.root;
+
+    await runApply(root, vault.targetRel);
+    const archivedPath = path.join(root, vault.archivedTargetRel);
+    expect(fs.existsSync(archivedPath)).toBe(true);
+    const afterFirst = fs.readFileSync(archivedPath, "utf-8");
+
+    // Second apply on the now-archived file: precondition (current ontology has
+    // an archiveOntology) fails → no-op. File stays put, content unchanged
+    // (no double relocation, no double isDefinedBy rewrite).
+    await runApply(root, vault.archivedTargetRel);
+
+    expect(fs.existsSync(archivedPath)).toBe(true);
+    const afterSecond = fs.readFileSync(archivedPath, "utf-8");
+    expect(afterSecond).toBe(afterFirst);
+    // The archive ontology has no folder named "<archive>-archive": no further move.
+    expect(
+      fs.existsSync(
+        path.join(root, `${ARCHIVE_SPACE}-archive`, `${TARGET_UID}.md`),
+      ),
+    ).toBe(false);
+  });
+});

--- a/packages/cli/tests/integration/validate-schema-namedquery-range.integration.test.ts
+++ b/packages/cli/tests/integration/validate-schema-namedquery-range.integration.test.ts
@@ -1,0 +1,159 @@
+/**
+ * RFC 78c2b7d0 C5 — regression: a `property_set` grounding whose
+ * `exocmd__Grounding_targetValueQuery` points at a `query__NamedQuery` must NOT
+ * raise a false `sh:class` violation against the property's `exo__Asset` range.
+ *
+ * NamedQuery IS-A exo__Asset via the chain
+ *   query#NamedQuery → exoql#Query → exo#Asset
+ * but `TripleClassHierarchy.labelToOntologyIRI` only builds ontology-URI
+ * subClassOf edges for prefixes present in `NAMESPACE_PREFIX_MAP`. Before the
+ * fix, `query__` and `exoql__` were absent, so the chain was never materialised
+ * in ontology-URI space and `isSubClassOf("query#NamedQuery", "exo#Asset")`
+ * returned false — a false violation that blocks authoring C5's homoiconic
+ * «Archive Ontologically» command assets.
+ *
+ * Production-shape: the REAL NoteToRDFConverter emits the triples and the REAL
+ * shapes-mode validator (runShapesValidation → TripleClassHierarchy → shaclValidate)
+ * runs — exactly the path the pre-write SHACL hook uses. Empirically verified to
+ * FAIL pre-fix (sh:class violation fires) and PASS post-fix.
+ */
+import { describe, it, expect, beforeAll, afterAll } from "@jest/globals";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+
+const { runShapesValidation } = await import(
+  "../../src/commands/validate-schema.js"
+);
+const { NoteToRDFConverter } = await import("exocortex");
+const { FileSystemVaultAdapter } = await import(
+  "../../src/adapters/FileSystemVaultAdapter.js"
+);
+
+const EXO_CLASS_UID = "2b45f716-12c0-46de-891d-8a488c487424";
+const EXO_ASSET_UID = "0f837190-c443-4c7a-b04c-a603c7a2f0c1";
+const GROUNDING_CLASS_UID = "6035376d-06d6-4c2b-b13a-8636ebbf183a";
+const EXOQL_QUERY_UID = "facdd3c1-2317-433f-87da-9c3125da058c";
+const NAMED_QUERY_CLASS_UID = "c68419a7-6352-46e3-beea-c626a4f2f032";
+const TVQ_SHAPE_UID = "943d2bc5-9101-49db-a5ce-a86d750e55c4";
+const NAMED_QUERY_INSTANCE_UID = "4680e591-05d6-4f9f-b996-24977855eb68";
+const GROUNDING_INSTANCE_UID = "4fa0b84b-2609-4b15-bd70-5b8b38bfe51e";
+
+const TVQ_PATH = "https://exocortex.my/ontology/exocmd#Grounding_targetValueQuery";
+const EXO_ASSET_IRI = "https://exocortex.my/ontology/exo#Asset";
+
+let fixtureDir: string;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let violations: any[];
+
+beforeAll(async () => {
+  fixtureDir = fs.mkdtempSync(path.join(os.tmpdir(), "exo-c5-nq-range-"));
+  fs.mkdirSync(path.join(fixtureDir, "exo"), { recursive: true });
+  fs.mkdirSync(path.join(fixtureDir, "exoql"), { recursive: true });
+  fs.mkdirSync(path.join(fixtureDir, "exocmd"), { recursive: true });
+  const w = (rel: string, body: string) =>
+    fs.writeFileSync(path.join(fixtureDir, rel), body);
+
+  // exo__Class metaclass → exo__Asset
+  w(`exo/${EXO_CLASS_UID}.md`, `---
+exo__Asset_uid: ${EXO_CLASS_UID}
+exo__Asset_label: exo__Class
+exo__Instance_class:
+  - "[[exo__Class]]"
+exo__Class_superClass:
+  - "[[${EXO_ASSET_UID}]]"
+---
+`);
+  // exo__Asset root
+  w(`exo/${EXO_ASSET_UID}.md`, `---
+exo__Asset_uid: ${EXO_ASSET_UID}
+exo__Asset_label: exo__Asset
+exo__Instance_class:
+  - "[[exo__Class]]"
+---
+`);
+  // exocmd__Grounding class (domain of the shape) → exo__Asset
+  w(`exocmd/${GROUNDING_CLASS_UID}.md`, `---
+exo__Asset_uid: ${GROUNDING_CLASS_UID}
+exo__Asset_label: exocmd__Grounding
+exo__Instance_class:
+  - "[[exo__Class]]"
+exo__Class_superClass:
+  - "[[${EXO_ASSET_UID}]]"
+---
+`);
+  // exoql__Query → exo__Asset
+  w(`exoql/${EXOQL_QUERY_UID}.md`, `---
+exo__Asset_uid: ${EXOQL_QUERY_UID}
+exo__Asset_label: exoql__Query
+exo__Instance_class:
+  - "[[exo__Class]]"
+exo__Class_superClass:
+  - "[[${EXO_ASSET_UID}]]"
+---
+`);
+  // query__NamedQuery → exoql__Query (the 2-hop chain to exo__Asset)
+  w(`exoql/${NAMED_QUERY_CLASS_UID}.md`, `---
+exo__Asset_uid: ${NAMED_QUERY_CLASS_UID}
+exo__Asset_label: query__NamedQuery
+exo__Instance_class:
+  - "[[exo__Class]]"
+exo__Class_superClass:
+  - "[[${EXOQL_QUERY_UID}]]"
+---
+`);
+  // exocmd__Grounding_targetValueQuery shape: domain=Grounding, range=exo__Asset
+  w(`exocmd/${TVQ_SHAPE_UID}.md`, `---
+exo__Asset_uid: ${TVQ_SHAPE_UID}
+exo__Asset_label: exocmd__Grounding_targetValueQuery
+exo__Instance_class:
+  - "[[exo__Property]]"
+exo__Property_domain:
+  - "[[${GROUNDING_CLASS_UID}]]"
+exo__Property_range:
+  - "[[${EXO_ASSET_UID}]]"
+---
+`);
+  // A NamedQuery instance
+  w(`${NAMED_QUERY_INSTANCE_UID}.md`, `---
+exo__Asset_uid: ${NAMED_QUERY_INSTANCE_UID}
+exo__Asset_label: "Resolve archive ontology"
+exo__Instance_class:
+  - "[[${NAMED_QUERY_CLASS_UID}]]"
+---
+`);
+  // A grounding referencing the NamedQuery via targetValueQuery
+  w(`${GROUNDING_INSTANCE_UID}.md`, `---
+exo__Asset_uid: ${GROUNDING_INSTANCE_UID}
+exo__Asset_label: "Re-anchor isDefinedBy"
+exo__Instance_class:
+  - "[[${GROUNDING_CLASS_UID}]]"
+exocmd__Grounding_targetValueQuery: "[[${NAMED_QUERY_INSTANCE_UID}|q]]"
+---
+`);
+
+  const adapter = new FileSystemVaultAdapter(fixtureDir);
+  const converter = new NoteToRDFConverter(adapter);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const triples = (await converter.convertVault()) as any[];
+  const report = await runShapesValidation(fixtureDir, triples);
+  violations = report.violations;
+});
+
+afterAll(() => {
+  if (fixtureDir) fs.rmSync(fixtureDir, { recursive: true, force: true });
+});
+
+describe("RFC 78c2b7d0 C5 — targetValueQuery → query__NamedQuery range resolution", () => {
+  it("does NOT emit a sh:class violation against exo__Asset for a NamedQuery-valued targetValueQuery", () => {
+    const groundingIRI = `obsidian://vault/${GROUNDING_INSTANCE_UID}.md`;
+    const falsePositives = violations.filter(
+      (v) =>
+        v.propertyPath === TVQ_PATH &&
+        v.focusNode === groundingIRI &&
+        v.severity === "sh:Violation" &&
+        v.message.includes(EXO_ASSET_IRI),
+    );
+    expect(falsePositives).toEqual([]);
+  });
+});


### PR DESCRIPTION
## RFC 78c2b7d0 — Phase C, C5 «Ontological archive»

Ships the **mechanism** for «Archive Ontologically» as an **emergent composition** of already-shipped primitives — no bespoke archive subsystem code.

### Mechanism (homoiconic, single-asset, idempotent)
```
composite[
  step-1 = property_set  exo__Asset_isDefinedBy  via targetValueQuery → NamedQuery   (C4)
  step-2 = service_call  serviceId=repairFolder                                       (co-location)
]
+ sparqlAsk precondition: archived:true  AND  current ontology HAS Ontology_archiveOntology
```
- **Step-1** re-anchors `exo__Asset_isDefinedBy` to the archive ontology computed by a 1-hop NamedQuery (`$currentAsset --isDefinedBy→ srcOnto --archiveOntology→ archiveOnto`) — the C4 CQRS bridge (`property_set.targetValueQuery`).
- **Step-2** physically relocates the file into the archive ontology's folder via the existing `repairFolder` service (co-location invariant). They run in document order inside the composite, sharing file state.
- **Idempotency** is a precondition no-op: once the asset lives in the archive ontology (which declares no `archiveOntology` of its own), the ASK fails → command hidden / apply returns false. No double relocation, no double rewrite.

### This PR (code)
Adds `packages/cli/tests/integration/apply-ontological-archive.integration.test.ts` — exercises the **real** CLI `apply` pipeline (no `--dry-run`; reads the moved file back):
1. `relocates ... + re-anchors isDefinedBy` — asserts the file physically moves into `space-archive/` AND `exo__Asset_isDefinedBy` is re-anchored to the archive-ontology UID (RFC §186: physical move, not just frontmatter).
2. `is idempotent` — second apply on the archived asset is a precondition no-op (file/content unchanged).

**Passes 2/2 with ZERO new executor code** — proving C5 is pure composition of C3/C4.
**Non-vacuity verified**: reversing the composite step order fails the relocation assertions (step-2 before step-1 leaves the file in its source folder).

### ⚠️ Spec-staleness finding (deletion scope already satisfied by C1)
The RFC/prompt asked C5 to also **delete the cross-vault archive subsystem** (6 service classes, `archive`/`unarchive` CLI, `migrate-relcolset`/`backfill`/`.ts.disabled`). Verified on `origin/main` (1080a14f): **all of this was already removed in EKA Phase A C1** (#3501/#3500, commits `46ba9515`, `e1cf4dcd`, `20852ab6`). `ArchiveAssetService` (toggle-archived stage-1 platform) is correctly retained; `BatchExecutor.executeArchive` is a local batch flag (not cross-vault) and is kept. So the C5 deletion DoD bullet is **satisfied-by-C1** — nothing to delete here. `/Users/kitelev/vault-2025-archive` data untouched (no code in this repo touches it).

### Companion vault-asset deliverable (separate repos)
The homoiconic «Archive Ontologically» assets + greenfield property `exo__Ontology_archiveOntology` ship to the `exoas-exo` / `exoas-exocmd` submodules (not this code repo) with the same shape as the test fixtures.

CI: CLI integration tests auto-discovered by `packages/cli/jest.config.js` (`tests/**/*.test.ts`).

---

### Added: CLI validator namespace-map fix (commit 07083c2b)

Authoring the real `query__NamedQuery` + `property_set targetValueQuery` vault assets surfaced a **latent C4 gap**: the SHACL hook raised a false `sh:class` violation against the `exo__Asset` range of `exocmd__Grounding_targetValueQuery` when it points at a NamedQuery.

Root cause: `NoteToRDFConverter` derives class IRIs dynamically (`Namespace.fromPropertyKey`, any `<prefix>__` → `<prefix>#`), but `validate-schema.ts` `TripleClassHierarchy.labelToOntologyIRI` uses the FIXED `NAMESPACE_PREFIX_MAP`, which lacked `query__`/`exoql__` (the C4 ontologies). So the ontology-URI subClassOf edges `query#NamedQuery → exoql#Query → exo#Asset` were never built and `isSubClassOf(query#NamedQuery, exo#Asset)` returned false.

Fix: register `query__`/`exoql__` in the curated prefix registry (additive). New production-shape regression test `validate-schema-namedquery-range.integration.test.ts` (real converter + `runShapesValidation` = the exact SHACL-hook path) — **empirically FAILS pre-fix, PASSES post-fix**. 97/97 existing validate-schema tests stay green.
