### PR TITLE
fix(shacl/hierarchy): resolve person__Person (any unlisted prefix) as subclass of ems__Agent (#3512)

### DIFF
--- a/packages/cli/src/commands/validate-schema.ts
+++ b/packages/cli/src/commands/validate-schema.ts
@@ -624,17 +624,44 @@ const RDFS_LABEL = "http://www.w3.org/2000/01/rdf-schema#label";
 
 /**
  * Converts a frontmatter label string (e.g. "ims__Concept") to its ontology URI
- * (e.g. "https://exocortex.my/ontology/ims#Concept") using NAMESPACE_PREFIX_MAP.
- * Returns null if no matching namespace prefix is found.
+ * (e.g. "https://exocortex.my/ontology/ims#Concept").
+ *
+ * Resolution is namespace-agnostic (Issue #3512): the curated NAMESPACE_PREFIX_MAP
+ * is consulted first (it carries the non-exocortex.my namespaces — rdf/rdfs/owl —
+ * whose URIs do NOT follow the standard ontology pattern), then ANY well-formed
+ * lowercase-leading prefix falls back to the canonical
+ * `https://exocortex.my/ontology/<prefix>#<Local>` form. This mirrors
+ * Namespace.forPrefix / NoteToRDFConverter, which already derive ad-hoc namespaces
+ * for unlisted prefixes.
+ *
+ * Returns null if the label is not a well-formed `<prefix>__<Local>` token.
  */
 export function labelToOntologyIRI(label: string): string | null {
   const dunderIdx = label.indexOf("__");
   if (dunderIdx === -1) return null;
-  const prefix = label.slice(0, dunderIdx + 2);
-  const local = label.slice(dunderIdx + 2);
-  const ns = NAMESPACE_PREFIX_MAP.get(prefix);
-  if (!ns || !local) return null;
-  return ns + local;
+  const prefixWithDunder = label.slice(0, dunderIdx + 2); // e.g. "ims__"
+  const prefix = label.slice(0, dunderIdx); // e.g. "ims"
+  const local = label.slice(dunderIdx + 2); // e.g. "Concept"
+  if (!local) return null;
+
+  // 1. Curated map first — preserves the non-standard namespaces (rdf/rdfs/owl)
+  //    and the canonical exocortex prefixes verbatim.
+  const ns = NAMESPACE_PREFIX_MAP.get(prefixWithDunder);
+  if (ns) return ns + local;
+
+  // 2. Namespace-agnostic fallback (Issue #3512): derive the canonical ontology
+  //    IRI for any well-formed lowercase prefix not in the curated map. Without
+  //    this, ontology-URI subClassOf edges for classes in namespaces like
+  //    `person__` were never materialised in TripleClassHierarchy, so
+  //    isSubClassOf("person#Person", "ems#Agent") returned false — a false
+  //    sh:class violation even though person__Person IS-A ems__Agent via
+  //    exo__Class_superClass. (The legacy `ims__Person` bridged only because
+  //    `ims__` happened to be in the curated map; the only difference between the
+  //    two classes is the prefix.) Prefix shape mirrors Namespace.forPrefix.
+  if (/^[a-z][a-zA-Z0-9]*$/.test(prefix)) {
+    return `https://exocortex.my/ontology/${prefix}#${local}`;
+  }
+  return null;
 }
 
 /**

--- a/packages/cli/src/commands/validate-schema.ts
+++ b/packages/cli/src/commands/validate-schema.ts
@@ -657,8 +657,11 @@ export function labelToOntologyIRI(label: string): string | null {
   //    sh:class violation even though person__Person IS-A ems__Agent via
   //    exo__Class_superClass. (The legacy `ims__Person` bridged only because
   //    `ims__` happened to be in the curated map; the only difference between the
-  //    two classes is the prefix.) Prefix shape mirrors Namespace.forPrefix.
-  if (/^[a-z][a-zA-Z0-9]*$/.test(prefix)) {
+  //    two classes is the prefix.) Prefix shape mirrors Namespace.forPrefix; the
+  //    local-name guard mirrors NoteToRDFConverter.expandClassValue (which rejects
+  //    `[\s()]` local names) so the derived IRI always matches the converter's
+  //    emitted rdf:type — never an inert, unmatchable hierarchy entry.
+  if (/^[a-z][a-zA-Z0-9]*$/.test(prefix) && !/[\s()]/.test(local)) {
     return `https://exocortex.my/ontology/${prefix}#${local}`;
   }
   return null;

--- a/packages/cli/tests/integration/validate-schema-person-subclass.integration.test.ts
+++ b/packages/cli/tests/integration/validate-schema-person-subclass.integration.test.ts
@@ -1,0 +1,211 @@
+/**
+ * Issue #3512 — regression: an instance typed as the canonical `person__Person`
+ * class (a namespace NOT in the curated `NAMESPACE_PREFIX_MAP`) must resolve as a
+ * subclass of `ems__Agent` when referenced by a property whose range is
+ * `ems__Agent`, exactly as the legacy deprecated `ims__Person` (a whitelisted
+ * namespace) always did.
+ *
+ * Root cause: `TripleClassHierarchy.labelToOntologyIRI` derived ontology URIs
+ * only for prefixes present in the hardcoded `NAMESPACE_PREFIX_MAP`. `person__`
+ * was absent, so the ontology-URI subClassOf edge
+ *   person#Person → ems#Agent
+ * was never materialised. `isSubClassOf("person#Person", "ems#Agent")` returned
+ * false → false `sh:class` violation. EKA M2 reverted the person re-prefix
+ * (deprecated 1bd359f1 → canonical 1ba807ee) because consolidating instances
+ * produced 81 such violations. `ims__Person` bridged only because `ims__` was in
+ * the curated map — the only difference between the two classes is the prefix.
+ *
+ * Fix: `labelToOntologyIRI` derives the canonical `https://exocortex.my/ontology/
+ * <prefix>#<Local>` IRI for ANY well-formed lowercase prefix (mirrors
+ * Namespace.forPrefix / NoteToRDFConverter's namespace-agnostic emission),
+ * keeping the curated map only for the non-exocortex.my namespaces (rdf/rdfs/owl).
+ *
+ * Production-shape: the REAL NoteToRDFConverter emits the triples and the REAL
+ * shapes-mode validator (runShapesValidation → TripleClassHierarchy → shaclValidate)
+ * runs — exactly the path `validate schema --shapes-mode` uses. Empirically
+ * verified to FAIL pre-fix (sh:class violation fires on the person__Person case)
+ * and PASS post-fix, while the ims__Person case passes both (no regression).
+ */
+import { describe, it, expect, beforeAll, afterAll } from "@jest/globals";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+
+const { runShapesValidation } = await import(
+  "../../src/commands/validate-schema.js"
+);
+const { NoteToRDFConverter } = await import("exocortex");
+const { FileSystemVaultAdapter } = await import(
+  "../../src/adapters/FileSystemVaultAdapter.js"
+);
+
+// Class TBox (UUID-named, production-shape)
+const EXO_CLASS_UID = "2b45f716-12c0-46de-891d-8a488c487424";
+const EXO_ASSET_UID = "0f837190-c443-4c7a-b04c-a603c7a2f0c1";
+const AGENT_CLASS_UID = "86bd3cde-0000-4000-8000-000000000001"; // ems__Agent (issue refs 86bd3cde)
+const PERSON_CLASS_UID = "1ba807ee-c235-4e1e-aa98-1ee301f60163"; // person__Person (canonical, D9-clean)
+const IMS_PERSON_CLASS_UID = "1bd359f1-0000-4000-8000-000000000002"; // ims__Person (legacy deprecated)
+const AREA_CLASS_UID = "0c0c0c0c-0000-4000-8000-00000000000a"; // ems__Area (property domain)
+
+// Property shape: ems__Area_responsible, range = ems__Agent
+const RESP_SHAPE_UID = "9a9a9a9a-0000-4000-8000-00000000000b";
+
+// ABox instances
+const PERSON_INSTANCE_UID = "0aa339bc-9b56-400a-8148-cbde57bbf0b6"; // a.kitelev analog, typed person__Person
+const LEGACY_PERSON_INSTANCE_UID = "002eb099-0000-4000-8000-00000000000c"; // typed ims__Person
+const AREA_PERSON_UID = "0a1e0001-0000-4000-8000-00000000000d"; // ems__Area, responsible → person__Person instance
+const AREA_LEGACY_UID = "0a1e0002-0000-4000-8000-00000000000e"; // ems__Area, responsible → ims__Person instance
+
+const RESP_PATH = "https://exocortex.my/ontology/ems#Area_responsible";
+const AGENT_IRI = "https://exocortex.my/ontology/ems#Agent";
+
+let fixtureDir: string;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let violations: any[];
+
+beforeAll(async () => {
+  fixtureDir = fs.mkdtempSync(path.join(os.tmpdir(), "exo-3512-person-subclass-"));
+  fs.mkdirSync(path.join(fixtureDir, "exo"), { recursive: true });
+  fs.mkdirSync(path.join(fixtureDir, "ems"), { recursive: true });
+  fs.mkdirSync(path.join(fixtureDir, "person"), { recursive: true });
+  fs.mkdirSync(path.join(fixtureDir, "ims"), { recursive: true });
+  const w = (rel: string, body: string) =>
+    fs.writeFileSync(path.join(fixtureDir, rel), body);
+
+  // exo__Class metaclass → exo__Asset
+  w(`exo/${EXO_CLASS_UID}.md`, `---
+exo__Asset_uid: ${EXO_CLASS_UID}
+exo__Asset_label: exo__Class
+exo__Instance_class:
+  - "[[exo__Class]]"
+exo__Class_superClass:
+  - "[[${EXO_ASSET_UID}]]"
+---
+`);
+  // exo__Asset root
+  w(`exo/${EXO_ASSET_UID}.md`, `---
+exo__Asset_uid: ${EXO_ASSET_UID}
+exo__Asset_label: exo__Asset
+exo__Instance_class:
+  - "[[exo__Class]]"
+---
+`);
+  // ems__Agent → exo__Asset
+  w(`ems/${AGENT_CLASS_UID}.md`, `---
+exo__Asset_uid: ${AGENT_CLASS_UID}
+exo__Asset_label: ems__Agent
+exo__Instance_class:
+  - "[[exo__Class]]"
+exo__Class_superClass:
+  - "[[${EXO_ASSET_UID}]]"
+---
+`);
+  // person__Person → ems__Agent  (KEY: non-whitelisted namespace, D9-clean canonical)
+  w(`person/${PERSON_CLASS_UID}.md`, `---
+exo__Asset_uid: ${PERSON_CLASS_UID}
+exo__Asset_label: person__Person
+exo__Instance_class:
+  - "[[exo__Class]]"
+exo__Class_superClass:
+  - "[[${AGENT_CLASS_UID}|ems__Agent]]"
+---
+`);
+  // ims__Person → ems__Agent  (regression: whitelisted namespace, legacy deprecated)
+  w(`ims/${IMS_PERSON_CLASS_UID}.md`, `---
+exo__Asset_uid: ${IMS_PERSON_CLASS_UID}
+exo__Asset_label: ims__Person
+exo__Instance_class:
+  - "[[exo__Class]]"
+exo__Class_superClass:
+  - "[[${AGENT_CLASS_UID}|ems__Agent]]"
+---
+`);
+  // ems__Area → exo__Asset  (domain of responsible property)
+  w(`ems/${AREA_CLASS_UID}.md`, `---
+exo__Asset_uid: ${AREA_CLASS_UID}
+exo__Asset_label: ems__Area
+exo__Instance_class:
+  - "[[exo__Class]]"
+exo__Class_superClass:
+  - "[[${EXO_ASSET_UID}]]"
+---
+`);
+  // ems__Area_responsible property: domain=ems__Area, range=ems__Agent
+  w(`ems/${RESP_SHAPE_UID}.md`, `---
+exo__Asset_uid: ${RESP_SHAPE_UID}
+exo__Asset_label: ems__Area_responsible
+exo__Instance_class:
+  - "[[exo__Property]]"
+exo__Property_domain:
+  - "[[${AREA_CLASS_UID}]]"
+exo__Property_range:
+  - "[[${AGENT_CLASS_UID}]]"
+---
+`);
+  // person__Person instance (a.kitelev analog)
+  w(`${PERSON_INSTANCE_UID}.md`, `---
+exo__Asset_uid: ${PERSON_INSTANCE_UID}
+exo__Asset_label: "a.kitelev"
+exo__Instance_class:
+  - "[[${PERSON_CLASS_UID}]]"
+---
+`);
+  // ims__Person instance (legacy)
+  w(`${LEGACY_PERSON_INSTANCE_UID}.md`, `---
+exo__Asset_uid: ${LEGACY_PERSON_INSTANCE_UID}
+exo__Asset_label: "legacy person"
+exo__Instance_class:
+  - "[[${IMS_PERSON_CLASS_UID}]]"
+---
+`);
+  // Area asset referencing the person__Person instance as responsible
+  w(`${AREA_PERSON_UID}.md`, `---
+exo__Asset_uid: ${AREA_PERSON_UID}
+exo__Asset_label: "Area (person responsible)"
+exo__Instance_class:
+  - "[[${AREA_CLASS_UID}]]"
+ems__Area_responsible: "[[${PERSON_INSTANCE_UID}|a.kitelev]]"
+---
+`);
+  // Area asset referencing the ims__Person instance as responsible (regression)
+  w(`${AREA_LEGACY_UID}.md`, `---
+exo__Asset_uid: ${AREA_LEGACY_UID}
+exo__Asset_label: "Area (legacy responsible)"
+exo__Instance_class:
+  - "[[${AREA_CLASS_UID}]]"
+ems__Area_responsible: "[[${LEGACY_PERSON_INSTANCE_UID}|legacy person]]"
+---
+`);
+
+  const adapter = new FileSystemVaultAdapter(fixtureDir);
+  const converter = new NoteToRDFConverter(adapter);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const triples = (await converter.convertVault()) as any[];
+  const report = await runShapesValidation(fixtureDir, triples);
+  violations = report.violations;
+});
+
+afterAll(() => {
+  if (fixtureDir) fs.rmSync(fixtureDir, { recursive: true, force: true });
+});
+
+const agentClassViolations = (focusUid: string) => {
+  const focusNode = `obsidian://vault/${focusUid}.md`;
+  return violations.filter(
+    (v) =>
+      v.propertyPath === RESP_PATH &&
+      v.focusNode === focusNode &&
+      v.severity === "sh:Violation" &&
+      v.message.includes(AGENT_IRI),
+  );
+};
+
+describe("Issue #3512 — person__Person resolves as subclass of ems__Agent", () => {
+  it("does NOT emit a sh:class violation for a person__Person-typed responsible (KEY: fails pre-fix)", () => {
+    expect(agentClassViolations(AREA_PERSON_UID)).toEqual([]);
+  });
+
+  it("does NOT emit a sh:class violation for a legacy ims__Person-typed responsible (no regression)", () => {
+    expect(agentClassViolations(AREA_LEGACY_UID)).toEqual([]);
+  });
+});

--- a/packages/cli/tests/unit/commands/validate-schema.test.ts
+++ b/packages/cli/tests/unit/commands/validate-schema.test.ts
@@ -508,8 +508,19 @@ describe("P1.6 labelToOntologyIRI", () => {
     expect(labelToOntologyIRI("SomePlainLabel")).toBeNull();
   });
 
-  it("returns null for label with unknown prefix", () => {
-    expect(labelToOntologyIRI("unknown__Foo")).toBeNull();
+  it("derives the canonical ontology URI for an unlisted lowercase prefix (Issue #3512)", () => {
+    // Namespace-agnostic: prefixes absent from the curated NAMESPACE_PREFIX_MAP
+    // resolve via the standard exocortex ontology pattern, mirroring
+    // Namespace.forPrefix / NoteToRDFConverter's ad-hoc namespace derivation.
+    expect(labelToOntologyIRI("unknown__Foo")).toBe("https://exocortex.my/ontology/unknown#Foo");
+  });
+
+  it("resolves the canonical person__Person to person#Person (Issue #3512)", () => {
+    expect(labelToOntologyIRI("person__Person")).toBe("https://exocortex.my/ontology/person#Person");
+  });
+
+  it("returns null for a malformed (non-lowercase-leading) prefix", () => {
+    expect(labelToOntologyIRI("Unknown__Foo")).toBeNull();
   });
 
   it("returns null for label with prefix only (no local name)", () => {


### PR DESCRIPTION
## Summary
Fixes #3512. The SHACL-lite validator's `TripleClassHierarchy` failed to resolve the canonical `person__Person` class (UID `1ba807ee`, `exo__Class_superClass: [[86bd3cde|ems__Agent]]`) as a subclass of `ems#Agent`, even though the legacy deprecated `ims__Person` (UID `1bd359f1`, identical superClass) resolved correctly. This blocked the EKA M2 person re-prefix (consolidating instances `1bd359f1`→`1ba807ee` produced **81 sh:class violations**, e.g. `0aa339bc` a.kitelev ×80 as PMBOK responsible + `002eb099` as `ems__Area_responsible`).

## Root cause
`labelToOntologyIRI()` (`packages/cli/src/commands/validate-schema.ts`) derived ontology URIs **only** for prefixes present in the hardcoded `NAMESPACE_PREFIX_MAP`. `person__` was absent, so the ontology-URI subClassOf edge `person#Person → ems#Agent` was never materialised in `TripleClassHierarchy`, and `isSubClassOf("person#Person", "ems#Agent")` returned `false`.

The legacy `ims__Person` bridged **only** because `ims__` happened to be in the curated map — the sole difference between the two classes is the namespace prefix. (Same bug-class as the earlier `query__`/`exoql__` additions, but those were patched by hand-adding entries; this is the general fix.)

`NoteToRDFConverter` already emits the instance `rdf:type` namespace-agnostically (`person#Person`) via `Namespace.fromPropertyKey`; only the validator's curated registry lagged.

## Fix
`labelToOntologyIRI` now:
1. Consults the curated `NAMESPACE_PREFIX_MAP` first (preserves the non-exocortex.my namespaces `rdf`/`rdfs`/`owl` whose URIs do not follow the standard pattern).
2. Falls back to deriving the canonical `https://exocortex.my/ontology/<prefix>#<Local>` IRI for **any** well-formed lowercase prefix — mirroring `Namespace.forPrefix` / `NoteToRDFConverter`'s ad-hoc namespace derivation. Malformed prefixes (non-lowercase-leading) still return `null`.

Blast radius is limited to class-hierarchy bridging. Property-key validation (`keyToURI`/`hasKnownPrefix`/`uriToKey`) is untouched and still uses the curated map.

## Tests — empirically verified FAILS pre-fix / PASSES post-fix
- New **production-shape** integration test `validate-schema-person-subclass.integration.test.ts`: real `NoteToRDFConverter` → `runShapesValidation` → `TripleClassHierarchy` → `shaclValidate` (the exact `validate schema --shapes-mode` path).
  - KEY: a `person__Person`-typed instance referenced via `ems__Area_responsible` (range `ems__Agent`) → **0 sh:class violations**. Reverting the fix → the exact issue violation (`<0aa339bc> does not conform to expected class ems#Agent`); restoring → green.
  - Regression: an `ims__Person`-typed instance referenced the same way → 0 violations (passes pre- and post-fix).
- Updated the unit test that codified the old whitelist-only behaviour (`unknown__Foo` now resolves; added explicit `person__Person` case + malformed-prefix null guard).
- Revert→fail / restore→pass confirmed via `git checkout origin/main -- validate-schema.ts`.

## Scope note (CLI ∥ plugin)
The whitelist lives only in the CLI's `TripleClassHierarchy.labelToOntologyIRI`. The plugin/ExoSync SHACL path uses the exocortex `ClassHierarchy` (plain rdfs:subClassOf adjacency, no prefix whitelist) — it does not share this code and is not affected by this bug.

## AC (#3512)
- [x] `person__Person` (1ba807ee) instances conform to `ems#Agent` via subclass.
- [x] Legacy `ims__Person` (1bd359f1) still resolves (no regression).
- [x] Revert-verify: integration test FAILS pre-fix, PASSES post-fix.