### PR TITLE
feat(cli): co-locate `create` asset by exo__Asset_isDefinedBy (#3520)

### DIFF
--- a/packages/cli/src/commands/create.ts
+++ b/packages/cli/src/commands/create.ts
@@ -254,6 +254,11 @@ export function createCommand(): Command {
             fsAdapter,
             isDefinedBy,
           );
+          // Truthy → a resolved subfolder. The empty string "" (root-level
+          // ontology, dirname → ".") is intentionally falsy here, so a brand
+          // new asset is kept in the inbox rather than written to the vault
+          // root — a degenerate case that does not occur under CR-1 (ontologies
+          // live under assetspaces/<ns>/).
           if (coLocatedFolder) {
             folderPath = coLocatedFolder;
           }

--- a/packages/cli/src/commands/create.ts
+++ b/packages/cli/src/commands/create.ts
@@ -15,6 +15,14 @@ import { WikilinkValidator } from "../services/WikilinkValidator.js";
 import { ErrorHandler } from "../utils/ErrorHandler.js";
 import { VaultNotFoundError } from "../utils/errors/index.js";
 import { registerOrderSpecFromVault } from "../services/registerOrderSpec.js";
+import { resolveCoLocationFolder } from "../executors/folderRepairHelpers.js";
+
+/**
+ * Fallback folder for new assets whose `exo__Asset_isDefinedBy` cannot be
+ * co-located (missing/`!`-prefixed/unresolvable). Matches the historical
+ * `cli create` default.
+ */
+const DEFAULT_INBOX_FOLDER = "01 Inbox";
 
 /**
  * Default timezone for `cli create` timestamps. The core service stays
@@ -234,6 +242,23 @@ export function createCommand(): Command {
           await wikilinkValidator.validatePropertyValues(propertyValues);
         }
 
+        // Co-location placement (RFC 0b7a2fad CR-1, issue #3520): when
+        // `exo__Asset_isDefinedBy` resolves to an on-disk ontology file, place
+        // the new asset in that ontology's folder — the same resolver used by
+        // `apply repair-folder` / `audit co-location`. Fail-open to the inbox
+        // default when isDefinedBy is missing / `!`-prefixed / unresolvable.
+        let folderPath = DEFAULT_INBOX_FOLDER;
+        const isDefinedBy = propertyValues?.["exo__Asset_isDefinedBy"];
+        if (isDefinedBy) {
+          const coLocatedFolder = await resolveCoLocationFolder(
+            fsAdapter,
+            isDefinedBy,
+          );
+          if (coLocatedFolder) {
+            folderPath = coLocatedFolder;
+          }
+        }
+
         // Load SHACL-lite shape registry from vault for cardinality-aware
         // property serialization (issues #3099, #3179). Failure here is
         // non-fatal — fall back to an EMPTY registry (not undefined) so the
@@ -252,7 +277,8 @@ export function createCommand(): Command {
         // `cli create` opts into the domain fields the plugin/apply omit:
         //  - classRefForm 'uuid' → `[[<uuid>]]` strip-canon
         //  - createdBy passed through verbatim (no implicit default)
-        //  - folder `01 Inbox`, aliases, timezone (Asia/Almaty default), body
+        //  - folder = co-located ontology folder (or `01 Inbox` fail-open),
+        //    aliases, timezone (Asia/Almaty default), body
         //  - shapeRegistry → cardinality-aware property emission
         const vaultAdapter = new FileSystemVaultAdapter(vaultPath);
         const creationService = new GenericAssetCreationService(vaultAdapter);
@@ -263,7 +289,7 @@ export function createCommand(): Command {
           classUid,
           label: trimmedLabel,
           aliases: options.aliases,
-          folderPath: "01 Inbox",
+          folderPath,
           createdBy: options.createdBy,
           timezone: options.timezone || DEFAULT_TIMEZONE,
           body,

--- a/packages/cli/src/executors/folderRepairHelpers.ts
+++ b/packages/cli/src/executors/folderRepairHelpers.ts
@@ -1,4 +1,5 @@
 import path from "path";
+import { extractAssetReference } from "exocortex";
 import type { NodeFsAdapter } from "../adapters/NodeFsAdapter.js";
 
 /**
@@ -77,4 +78,45 @@ export async function findReferencedFile(
  */
 export function normalizePath(filePath: string): string {
   return filePath.replace(/\\/g, "/").replace(/^\.\//, "").replace(/\/$/, "");
+}
+
+/**
+ * Resolve the co-location target folder for a NEW asset from its
+ * `exo__Asset_isDefinedBy` value, using the same resolver as `apply
+ * repair-folder` / `audit co-location` (RFC 0b7a2fad CR-1). Returns the
+ * vault-relative folder where the asset should be placed, or `null` when
+ * placement cannot be determined — fail-open by design, matching the audit's
+ * skip-accounting:
+ *   - missing / empty / non-string `isDefinedBy`  → null (empty-isDefinedBy)
+ *   - `!`-prefixed reference (intentional anchor)  → null (bang-prefix)
+ *   - reference that doesn't resolve in this vault → null (unresolvable)
+ *
+ * On `null`, the caller keeps its default folder (`01 Inbox`).
+ *
+ * The asset doesn't exist on disk yet, so an empty source path is passed to
+ * {@link findReferencedFile}; this makes its "same folder as source" heuristic
+ * (Try 2) probe only the vault root, which never spuriously matches a
+ * UID-named ontology file living under `assetspaces/`. Resolution therefore
+ * comes from the direct-path (Try 1), UID-index (Try 3) or basename-scan
+ * (Try 4) branches — exactly as it does for `apply repair-folder`.
+ *
+ * A root-level ontology (`path.dirname` → ".") returns "" so the caller writes
+ * to the vault root, matching FolderRepairExecutor's expected-folder convention.
+ */
+export async function resolveCoLocationFolder(
+  fsAdapter: NodeFsAdapter,
+  isDefinedBy: unknown,
+): Promise<string | null> {
+  const reference = extractAssetReference(isDefinedBy);
+  if (!reference || reference.startsWith("!")) {
+    return null;
+  }
+
+  const ontologyPath = await findReferencedFile(fsAdapter, reference, "");
+  if (!ontologyPath) {
+    return null;
+  }
+
+  const dir = path.dirname(ontologyPath);
+  return dir === "." ? "" : dir;
 }

--- a/packages/cli/tests/integration/create-co-location.integration.test.ts
+++ b/packages/cli/tests/integration/create-co-location.integration.test.ts
@@ -1,0 +1,176 @@
+/**
+ * Issue #3520 — `cli create` must co-locate a new asset in the folder of its
+ * `exo__Asset_isDefinedBy` ontology file (RFC 0b7a2fad CR-1), instead of
+ * unconditionally writing to `01 Inbox/`.
+ *
+ * Exercises the REAL `createCommand()` action end-to-end against a temp fixture
+ * vault (no service-level shortcut): parses CLI args, resolves the class UID,
+ * resolves co-location placement via the shared `folderRepairHelpers`
+ * resolver, and writes the file. Asserts where the file physically lands by
+ * parsing the command's JSON stdout (`{ uuid, path, label }`) and stat-ing the
+ * file.
+ *
+ * Revert-verify (~/dotfiles/.claude/rules/integration-test-revert-verify.md):
+ * the "resolvable → co-located" case FAILS pre-fix (the asset landed in
+ * `01 Inbox/`) and PASSES post-fix. The fail-open cases (no / `!`-prefixed /
+ * unresolvable isDefinedBy) keep the historical inbox default in both states.
+ */
+import { jest, describe, it, expect, beforeEach, afterEach } from "@jest/globals";
+import * as fs from "fs";
+import * as path from "path";
+import * as os from "os";
+
+const { createCommand } = await import("../../src/commands/create.js");
+
+// Full-UUID ontology + class so the resolver's UID-index branch (Try 3) and the
+// `--class` UID pass-through both fire deterministically.
+const ONTOLOGY_UID = "32d2374c-aaaa-bbbb-cccc-000000000000";
+const CLASS_UID = "b0474610-1111-2222-3333-444444444444";
+const ONTOLOGY_DIR = "assetspaces/kitelev/exoas-exodev/exodev";
+
+function md(frontmatter: Record<string, string>): string {
+  const lines = ["---"];
+  for (const [k, v] of Object.entries(frontmatter)) {
+    lines.push(`${k}: ${v}`);
+  }
+  lines.push("---");
+  lines.push("");
+  return lines.join("\n");
+}
+
+describe("Issue #3520: `cli create` co-locates by exo__Asset_isDefinedBy", () => {
+  let vault: string;
+  let exitSpy: ReturnType<typeof jest.spyOn>;
+  let stdoutSpy: ReturnType<typeof jest.spyOn>;
+  let stderrSpy: ReturnType<typeof jest.spyOn>;
+  let logSpy: ReturnType<typeof jest.spyOn>;
+  let errorSpy: ReturnType<typeof jest.spyOn>;
+  let stdoutChunks: string[];
+  let exitCodes: number[];
+
+  beforeEach(() => {
+    vault = fs.mkdtempSync(path.join(os.tmpdir(), "cli-3520-"));
+
+    // Ontology file ($exodev anchor) — the co-location target.
+    const ontologyDir = path.join(vault, ONTOLOGY_DIR);
+    fs.mkdirSync(ontologyDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(ontologyDir, `${ONTOLOGY_UID}.md`),
+      md({
+        exo__Asset_uid: ONTOLOGY_UID,
+        exo__Asset_label: "$exodev",
+      }),
+    );
+
+    // Inbox default must already exist for the fail-open cases.
+    fs.mkdirSync(path.join(vault, "01 Inbox"), { recursive: true });
+
+    stdoutChunks = [];
+    exitCodes = [];
+    // `create`'s action calls `process.exit(0)` as the LAST statement inside
+    // its own try block, so a throwing spy would be caught by that try and
+    // re-handled as an error. Record the code as a NO-OP instead — the success
+    // JSON has already been written to stdout by that point.
+    exitSpy = jest
+      .spyOn(process, "exit")
+      .mockImplementation(((code?: number) => {
+        exitCodes.push(code ?? 0);
+        return undefined as never;
+      }) as never);
+    stdoutSpy = jest
+      .spyOn(process.stdout, "write")
+      .mockImplementation(((chunk: unknown) => {
+        stdoutChunks.push(String(chunk));
+        return true;
+      }) as never);
+    stderrSpy = jest
+      .spyOn(process.stderr, "write")
+      .mockImplementation((() => true) as never);
+    logSpy = jest.spyOn(console, "log").mockImplementation(() => {});
+    errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    exitSpy.mockRestore();
+    stdoutSpy.mockRestore();
+    stderrSpy.mockRestore();
+    logSpy.mockRestore();
+    errorSpy.mockRestore();
+    fs.rmSync(vault, { recursive: true, force: true });
+  });
+
+  /**
+   * Run the real create command action. Returns the parsed JSON result
+   * (`{ uuid, path, label }`). Asserts the command exited 0 and emitted JSON.
+   */
+  async function runCreate(extraArgs: string[]): Promise<{
+    uuid: string;
+    path: string;
+    label: string;
+  }> {
+    const cmd = createCommand();
+    const argv = [
+      "--class",
+      CLASS_UID,
+      "--label",
+      "E2E-TEST co-location",
+      "--vault",
+      vault,
+      "--skip-wikilink-validation",
+      ...extraArgs,
+    ];
+    await cmd.parseAsync(argv, { from: "user" });
+
+    const stderrLog = errorSpy.mock.calls.flat().join("\n");
+    expect(exitCodes).toContain(0);
+    expect(exitCodes).not.toContain(1);
+    const json = stdoutChunks.join("").trim();
+    if (!json) {
+      throw new Error(`create emitted no stdout JSON. stderr: ${stderrLog}`);
+    }
+    return JSON.parse(json);
+  }
+
+  it("resolvable isDefinedBy → asset placed in the ontology folder (not inbox)", async () => {
+    const result = await runCreate([
+      "--property",
+      `exo__Asset_isDefinedBy=[[${ONTOLOGY_UID}]]`,
+    ]);
+
+    expect(result.path).toBe(`${ONTOLOGY_DIR}/${result.uuid}.md`);
+    expect(result.path.startsWith("01 Inbox/")).toBe(false);
+
+    // File physically exists in the co-located folder…
+    expect(fs.existsSync(path.join(vault, result.path))).toBe(true);
+    // …and NOT in the inbox.
+    expect(
+      fs.existsSync(path.join(vault, "01 Inbox", `${result.uuid}.md`)),
+    ).toBe(false);
+  });
+
+  it("fail-open: unresolvable isDefinedBy → inbox default", async () => {
+    const result = await runCreate([
+      "--property",
+      "exo__Asset_isDefinedBy=[[ffffffff-dead-beef-cafe-000000000000]]",
+    ]);
+
+    expect(result.path).toBe(`01 Inbox/${result.uuid}.md`);
+    expect(fs.existsSync(path.join(vault, result.path))).toBe(true);
+  });
+
+  it("fail-open: `!`-prefixed anchor isDefinedBy → inbox default", async () => {
+    const result = await runCreate([
+      "--property",
+      "exo__Asset_isDefinedBy=[[!exodev]]",
+    ]);
+
+    expect(result.path).toBe(`01 Inbox/${result.uuid}.md`);
+  });
+
+  it("fail-open: no isDefinedBy → inbox default", async () => {
+    const result = await runCreate([]);
+
+    expect(result.path).toBe(`01 Inbox/${result.uuid}.md`);
+    expect(fs.existsSync(path.join(vault, result.path))).toBe(true);
+  });
+});

--- a/packages/cli/tests/unit/commands/create.test.ts
+++ b/packages/cli/tests/unit/commands/create.test.ts
@@ -14,6 +14,17 @@ jest.unstable_mockModule("exocortex", () => ({
   MetadataHelpers: { buildFileContent: jest.fn(() => "---\n---\n") },
   GenericAssetCreationService: class GenericAssetCreationService {},
   ShapeRegistry: class ShapeRegistry {},
+  // Transitively required: create.ts → folderRepairHelpers.ts imports this.
+  extractAssetReference: jest.fn((v: unknown) =>
+    typeof v === "string"
+      ? v
+          .trim()
+          .replace(/^["']|["']$/g, "")
+          .replace(/^\[\[|\]\]$/g, "")
+          .split("|")[0]
+          .trim() || null
+      : null,
+  ),
   IFileSystemAdapter: {},
   FileNotFoundError: class FileNotFoundError extends Error {},
   FileAlreadyExistsError: class FileAlreadyExistsError extends Error {},

--- a/packages/cli/tests/unit/executors/folderRepairHelpers.test.ts
+++ b/packages/cli/tests/unit/executors/folderRepairHelpers.test.ts
@@ -4,6 +4,7 @@ import type { NodeFsAdapter } from "../../../src/adapters/NodeFsAdapter.js";
 import {
   findReferencedFile,
   normalizePath,
+  resolveCoLocationFolder,
 } from "../../../src/executors/folderRepairHelpers.js";
 
 /**
@@ -154,5 +155,71 @@ describe("folderRepairHelpers — findReferencedFile (shared)", () => {
     expect(
       await findReferencedFile(makeFs(), "ghost", "tasks/task.md"),
     ).toBeNull();
+  });
+});
+
+describe("folderRepairHelpers — resolveCoLocationFolder (issue #3520)", () => {
+  it("resolves a UID isDefinedBy to its ontology folder", async () => {
+    const fs = makeFs({
+      findFileByUID: jest.fn(async () =>
+        "assetspaces/kitelev/exoas-exodev/exodev/32d2374c.md",
+      ),
+    });
+    expect(
+      await resolveCoLocationFolder(fs, "[[32d2374c]]"),
+    ).toBe("assetspaces/kitelev/exoas-exodev/exodev");
+  });
+
+  it("resolves a quoted alias-form isDefinedBy via its TARGET uid", async () => {
+    const fs = makeFs({
+      findFileByUID: jest.fn(async (uid: string) =>
+        uid === "32d2374c"
+          ? "assetspaces/kitelev/exoas-exodev/exodev/32d2374c.md"
+          : null,
+      ),
+    });
+    expect(
+      await resolveCoLocationFolder(fs, '"[[32d2374c|$exodev]]"'),
+    ).toBe("assetspaces/kitelev/exoas-exodev/exodev");
+  });
+
+  it("resolves a direct path-form isDefinedBy (Try 1)", async () => {
+    const fs = makeFs({
+      fileExists: jest.fn(
+        async (p: string) => p === "assetspaces/exo/exo.md",
+      ),
+    });
+    expect(
+      await resolveCoLocationFolder(fs, "[[assetspaces/exo/exo]]"),
+    ).toBe("assetspaces/exo");
+  });
+
+  it("fail-open: returns null for empty / missing isDefinedBy", async () => {
+    expect(await resolveCoLocationFolder(makeFs(), undefined)).toBeNull();
+    expect(await resolveCoLocationFolder(makeFs(), "")).toBeNull();
+    expect(await resolveCoLocationFolder(makeFs(), "[[]]")).toBeNull();
+  });
+
+  it("fail-open: returns null for a `!`-prefixed anchor reference", async () => {
+    // Even if a file happened to match, the bang-prefix short-circuits before
+    // any filesystem probe (mirrors audit co-location skip-accounting).
+    const findFileByUID = jest.fn(async () => "anywhere/!kitelev.md");
+    const fs = makeFs({ findFileByUID });
+    expect(await resolveCoLocationFolder(fs, "[[!kitelev]]")).toBeNull();
+    expect(findFileByUID).not.toHaveBeenCalled();
+  });
+
+  it("fail-open: returns null when the reference does not resolve in this vault", async () => {
+    // makeFs() resolves nothing → cross-vault / missing ontology.
+    expect(
+      await resolveCoLocationFolder(makeFs(), "[[ffffffff]]"),
+    ).toBeNull();
+  });
+
+  it("returns '' (root) for a root-level ontology file", async () => {
+    const fs = makeFs({
+      findFileByUID: jest.fn(async () => "32d2374c.md"),
+    });
+    expect(await resolveCoLocationFolder(fs, "[[32d2374c]]")).toBe("");
   });
 });


### PR DESCRIPTION
## Summary
Closes #3520. CLI `create` wrote every new asset to `01 Inbox/<uid>.md`, ignoring the co-location invariant (CLAUDE.md, RFC 0b7a2fad CR-1) enforced everywhere else (Obsidian-plugin Write hook, `/exocortex-asset` skill, `audit co-location`).

Now `create` resolves `exo__Asset_isDefinedBy` to its on-disk ontology folder via the **shared** `folderRepairHelpers` resolver — the same `findReferencedFile` + `extractAssetReference` pipeline used by `apply repair-folder` and `audit co-location` — and places the new asset there.

## Fail-open (matches audit skip-accounting)
Keeps the historical `01 Inbox` default when `exo__Asset_isDefinedBy` is:
- missing / empty / non-string → empty-isDefinedBy
- `!`-prefixed anchor (`[[!kitelev]]`) → bang-prefix
- unresolvable in this vault (cross-vault / missing ontology) → unresolvable

## Changes
- `packages/cli/src/executors/folderRepairHelpers.ts` — new `resolveCoLocationFolder` helper (extract ref → fail-open guards → `findReferencedFile` → `dirname`, `"." → ""` root collapse).
- `packages/cli/src/commands/create.ts` — wire it into placement (`folderPath` now resolved instead of hardcoded `"01 Inbox"`).
- `packages/cli/tests/unit/executors/folderRepairHelpers.test.ts` — 7 unit cases (resolvable UID / alias-form / direct-path + empty / bang / unresolvable / root-edge).
- `packages/cli/tests/integration/create-co-location.integration.test.ts` — **new**, drives the real `createCommand()` end-to-end against a fixture vault, asserts physical placement.
- `packages/cli/tests/unit/commands/create.test.ts` — add `extractAssetReference` to the mocked `exocortex` module (now a transitive import).

## Verification
- 41 targeted tests pass (unit + integration).
- **Revert-verify** (integration-test-revert-verify): the "resolvable → co-located" case FAILS pre-fix (asset lands in `01 Inbox/`) and PASSES post-fix (lands in the ontology folder). Confirmed by temporarily reverting `folderPath`.
- CI typecheck `npm run check:types` — 0 errors. Archgate 20/20.
- Resolution semantics verified identical to `audit co-location` / `apply repair-folder` (code-reviewer APPROVE, 0 CRITICAL/HIGH).

## Behavior unchanged
When `isDefinedBy` is absent/unresolvable, placement is byte-identical to before (inbox). The service-level path (`GenericAssetCreationService` with explicit `folderPath`) is untouched.