### PR TITLE
fix(cli): remove duplicate '.' in scp-like clone-url char class (#3525)

### DIFF
--- a/packages/cli/src/services/RegistryDependencyResolver.ts
+++ b/packages/cli/src/services/RegistryDependencyResolver.ts
@@ -367,6 +367,6 @@ export function isSafeCloneUrl(source: string): boolean {
   if (/^ssh:\/\/[^\s]+$/i.test(source)) return true;
   if (/^git:\/\/[^\s]+$/i.test(source)) return true;
   // scp-like SSH: user@host:owner/repo (no leading dash already excluded above)
-  if (/^[A-Za-z0-9._-]+@[A-Za-z0-9._.-]+:[^\s]+$/.test(source)) return true;
+  if (/^[A-Za-z0-9._-]+@[A-Za-z0-9._-]+:[^\s]+$/.test(source)) return true;
   return false;
 }

--- a/packages/cli/tests/unit/services/RegistryDependencyResolver.test.ts
+++ b/packages/cli/tests/unit/services/RegistryDependencyResolver.test.ts
@@ -341,4 +341,13 @@ describe("isSafeCloneUrl", () => {
     expect(isSafeCloneUrl("https://github.com/o/r\n")).toBe(false);
     expect(isSafeCloneUrl("")).toBe(false);
   });
+
+  // Regression guard for #3525 (js/regex/duplicate-in-character-class): the
+  // scp-like host class `[A-Za-z0-9._-]` must still accept dotted subdomains.
+  it("accepts scp-like SSH with dotted/subdomain hosts", () => {
+    expect(isSafeCloneUrl("git@ssh.github.com:kitelev/exoas-exo.git")).toBe(
+      true,
+    );
+    expect(isSafeCloneUrl("user@my-host.example.co.uk:owner/repo")).toBe(true);
+  });
 });


### PR DESCRIPTION
## Summary

Resolves CodeQL alert **`js/regex/duplicate-in-character-class`** (alert 309, P1) at `packages/cli/src/services/RegistryDependencyResolver.ts:370`.

The scp-like SSH clone-URL validator in `isSafeCloneUrl` had a host character class `[A-Za-z0-9._.-]` that listed `.` **twice** (`._.`). Collapsed to `[A-Za-z0-9._-]` — matching the (correct) user-portion class on the same line.

## Semantics-preserving

A duplicate character inside a character class is redundant; the matched character set is **identical** before and after. Runtime-verified:

```
git@github.com:o/r              -> true (unchanged)
git@ssh.github.com:o/r.git      -> true (unchanged)
```

## Tests

- All 25 `RegistryDependencyResolver` unit tests pass (existing `git@github.com:...` scp-like cases unaffected).
- Added a regression guard asserting dotted/subdomain hosts (`git@ssh.github.com:...`, `user@my-host.example.co.uk:...`) still accepted.

## DoD

- [x] CodeQL alert source removed (semantics-preserving)
- [x] Tests pass (25/25)
- [x] No new alerts introduced
- [ ] PR merged → code scanning re-run auto-closes #3525

Closes #3525