### PR TITLE
fix(validate): unify cross-vault class IRIs in --also so sh:class conforms (#3523)

### DIFF
--- a/packages/cli/src/commands/validate-schema.ts
+++ b/packages/cli/src/commands/validate-schema.ts
@@ -185,6 +185,21 @@ async function loadTriplesFromAllVaults(
   }
 
   if (alsoPaths.length > 0) {
+    // Issue #3523: a shared submodule (e.g. `exo`) mounted in BOTH the primary
+    // vault and an `--also` vault is parsed twice into byte-identical triples
+    // (same subject IRI — converters key off the per-vault-relative path). The
+    // duplicates inflate `values.length` for Single-cardinality predicates →
+    // false `sh:maxCount` violations. RDF triples are a set, so collapsing
+    // exact (subject, predicate, object) duplicates is loss-less. Scoped to the
+    // multi-vault path so single-vault loading is byte-for-byte unchanged.
+    const beforeDedup = triples.length;
+    triples = dedupeTriples(triples);
+    if (verbose && triples.length < beforeDedup) {
+      console.log(
+        `   🧹 Cross-vault dedup: removed ${beforeDedup - triples.length} duplicate triple(s) (shared-submodule double-load)`,
+      );
+    }
+
     const before = triples.length;
     triples = resolveCrossVaultInstanceClassWikilinks(triples);
     if (verbose) {
@@ -300,6 +315,41 @@ export function resolveCrossVaultInstanceClassWikilinks(
   }
 
   return additions.length > 0 ? triples.concat(additions) : triples;
+}
+
+/**
+ * Issue #3523: collapse exact-duplicate triples produced when a shared
+ * submodule is loaded more than once across `--vault` + `--also` paths.
+ *
+ * A triple's identity is (subject, predicate, object). Subject/predicate are
+ * always IRIs; the object is an IRI or a Literal (whose identity also includes
+ * datatype + language tag). Dual-storage predicates (e.g. exo__Asset_prototype
+ * → [fileIRI, uuidLiteral]) emit DISTINCT objects, so they are never collapsed
+ * into one — only byte-identical re-parses of the same file are removed.
+ */
+export function dedupeTriples(triples: DomainTriple[]): DomainTriple[] {
+  const seen = new Set<string>();
+  const out: DomainTriple[] = [];
+  for (const t of triples) {
+    const o = t.object;
+    let objKey: string;
+    if (o instanceof DomainIRI) {
+      objKey = `i ${o.value}`;
+    } else if (o instanceof DomainLiteral) {
+      objKey = `l ${o.value} ${o.datatype?.value ?? ""} ${o.language ?? ""}`;
+    } else {
+      // Unknown node shape — keep it (do not risk dropping a non-duplicate).
+      out.push(t);
+      continue;
+    }
+    const subjKey = t.subject instanceof DomainIRI ? t.subject.value : String(t.subject);
+    const predKey = t.predicate instanceof DomainIRI ? t.predicate.value : String(t.predicate);
+    const key = `${subjKey} ${predKey} ${objKey}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push(t);
+  }
+  return out;
 }
 
 const EXO_ASSET_LABEL_IRI = "https://exocortex.my/ontology/exo#Asset_label";

--- a/packages/cli/src/commands/validate-schema.ts
+++ b/packages/cli/src/commands/validate-schema.ts
@@ -301,7 +301,7 @@ export function resolveCrossVaultInstanceClassWikilinks(
     if (!classIRI) continue;
 
     const subjectIRI = t.subject.value;
-    const dedupKey = `${subjectIRI} ${classIRI}`;
+    const dedupKey = `${subjectIRI} ${classIRI}`;
     if (emitted.has(dedupKey)) continue;
     emitted.add(dedupKey);
 
@@ -330,21 +330,29 @@ export function resolveCrossVaultInstanceClassWikilinks(
 export function dedupeTriples(triples: DomainTriple[]): DomainTriple[] {
   const seen = new Set<string>();
   const out: DomainTriple[] = [];
+  // JSON-encode every field so a value/datatype/language that itself
+  // contains the join separator can never forge a collision with a distinct
+  // triple; the key must be injective for the dedup to stay loss-less.
+  const enc = (...parts: (string | undefined)[]): string =>
+    parts.map((p) => JSON.stringify(p ?? null)).join(" ");
   for (const t of triples) {
     const o = t.object;
     let objKey: string;
     if (o instanceof DomainIRI) {
-      objKey = `i ${o.value}`;
+      objKey = enc("i", o.value);
     } else if (o instanceof DomainLiteral) {
-      objKey = `l ${o.value} ${o.datatype?.value ?? ""} ${o.language ?? ""}`;
+      // datatype + language + direction all participate in Literal.equals().
+      objKey = enc("l", o.value, o.datatype?.value, o.language, o.direction);
     } else {
-      // Unknown node shape — keep it (do not risk dropping a non-duplicate).
+      // Unknown node shape: keep it (do not risk dropping a non-duplicate).
       out.push(t);
       continue;
     }
-    const subjKey = t.subject instanceof DomainIRI ? t.subject.value : String(t.subject);
-    const predKey = t.predicate instanceof DomainIRI ? t.predicate.value : String(t.predicate);
-    const key = `${subjKey} ${predKey} ${objKey}`;
+    const subjKey =
+      t.subject instanceof DomainIRI ? t.subject.value : String(t.subject);
+    const predKey =
+      t.predicate instanceof DomainIRI ? t.predicate.value : String(t.predicate);
+    const key = `${enc(subjKey, predKey)} ${objKey}`;
     if (seen.has(key)) continue;
     seen.add(key);
     out.push(t);

--- a/packages/cli/tests/integration/validate-schema-cross-vault-class-iri.integration.test.ts
+++ b/packages/cli/tests/integration/validate-schema-cross-vault-class-iri.integration.test.ts
@@ -1,0 +1,288 @@
+/**
+ * Issue #3523 — CLI integration test: `validate schema --shapes-mode --also <dep>`
+ * must NOT emit false `sh:class` violations for conformant cross-vault typed refs.
+ *
+ * Root cause (pre-fix): a typed property whose `exo__Property_range` points (by
+ * UID wikilink) at a class definition living in an `--also` dependency vault is
+ * emitted by the primary vault's converter as a *synthesized* UUID-only file IRI
+ * (`obsidian://vault/<uid>.md`, no directory) because the target is unresolvable
+ * in the primary vault. The dependency vault's converter, on the other hand,
+ * emits that same class's `rdfs:label` / superClass chain under its *full-path*
+ * subject IRI (`obsidian://vault/tbox/<uid>.md`) + symbolic ontology IRI
+ * (`https://exocortex.my/ontology/<ns>#<Local>`). `ShapeLoader.resolveClassIRI`
+ * looked up the label keyed on the *exact* (synthesized) IRI string, missed it,
+ * and left the range as the synth file IRI — which never unifies with the
+ * symbolic superClass chain, so `isSubClassOf` fails → false `sh:class`
+ * Violation. Standalone (no `--also`) and single-merged-vault both report 0.
+ *
+ * The fix gives `ShapeLoader` a UID-keyed label fallback so a synth/cross-vault
+ * range/domain file IRI resolves to the same symbolic class IRI as the merged
+ * single-vault case.
+ *
+ * Empirically verified to FAIL pre-fix (false sh:Violation) and PASS post-fix.
+ */
+import { describe, it, expect, beforeAll, afterAll } from "@jest/globals";
+import * as fs from "fs";
+import * as path from "path";
+import * as os from "os";
+
+const { runShapesValidation, resolveCrossVaultInstanceClassWikilinks, dedupeTriples } =
+  await import("../../src/commands/validate-schema.js");
+const { NoteToRDFConverter } = await import("exocortex");
+const { FileSystemVaultAdapter } = await import(
+  "../../src/adapters/FileSystemVaultAdapter.js"
+);
+
+// UID-canon TBox: filenames are UUIDs, labels carry the symbolic class name.
+const RANGE_UID = "c1000000-0000-4000-8000-000000000001"; // tst__Property (metaclass / range target)
+const META_UID = "c1000000-0000-4000-8000-000000000002"; // tst__MetaProperty (subClassOf tst__Property)
+const VALUE_OK_UID = "c1000000-0000-4000-8000-000000000003"; // typed tst__MetaProperty → conformant value
+const UNREL_UID = "c1000000-0000-4000-8000-000000000004"; // tst__Unrelated (NOT a subclass of tst__Property)
+const VALUE_BAD_UID = "c1000000-0000-4000-8000-000000000005"; // typed tst__Unrelated → genuinely wrong value
+const PROP_UID = "c1000000-0000-4000-8000-000000000010"; // xrule__sourceProp (range = RANGE_UID, lives in X)
+const DOMAIN_UID = "c1000000-0000-4000-8000-000000000011"; // xrule__Rule (domain class, lives in X)
+const INST_OK_UID = "c1000000-0000-4000-8000-000000000012"; // conformant rule instance
+const INST_BAD_UID = "c1000000-0000-4000-8000-000000000013"; // non-conformant rule instance
+
+let tmpRoot: string;
+let primaryVault: string; // X — references the dep by UID (exocmd-like)
+let alsoVault: string; // Y — owns the TBox class/property defs (exo-like)
+
+function write(vault: string, rel: string, body: string): void {
+  const full = path.join(vault, rel);
+  fs.mkdirSync(path.dirname(full), { recursive: true });
+  fs.writeFileSync(full, body);
+}
+
+beforeAll(() => {
+  tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "exocortex-xvault-class-"));
+  primaryVault = path.join(tmpRoot, "primary");
+  alsoVault = path.join(tmpRoot, "dep");
+
+  // ── Dependency vault Y (TBox lives in a `tbox/` SUBDIR so the owning
+  //    full-path subject IRI differs from the synth UUID-only form) ──────────
+
+  // Range metaclass: tst__Property (like exo__Property 38277bfa)
+  write(
+    alsoVault,
+    `tbox/${RANGE_UID}.md`,
+    `---
+exo__Asset_uid: ${RANGE_UID}
+exo__Instance_class:
+  - "[[exo__Class]]"
+exo__Asset_label: tst__Property
+---
+`,
+  );
+
+  // tst__MetaProperty — subClassOf tst__Property (like exo__MetaProperty 29c0c460)
+  write(
+    alsoVault,
+    `tbox/${META_UID}.md`,
+    `---
+exo__Asset_uid: ${META_UID}
+exo__Instance_class:
+  - "[[exo__Class]]"
+exo__Class_superClass:
+  - "[[${RANGE_UID}]]"
+exo__Asset_label: tst__MetaProperty
+---
+`,
+  );
+
+  // Conformant value subject: typed tst__MetaProperty (like exo__Asset_uid fada7446)
+  write(
+    alsoVault,
+    `tbox/${VALUE_OK_UID}.md`,
+    `---
+exo__Asset_uid: ${VALUE_OK_UID}
+exo__Instance_class:
+  - "[[${META_UID}]]"
+exo__Asset_label: tst__sourceField
+---
+`,
+  );
+
+  // Unrelated class: tst__Unrelated (NOT a subclass of tst__Property)
+  write(
+    alsoVault,
+    `tbox/${UNREL_UID}.md`,
+    `---
+exo__Asset_uid: ${UNREL_UID}
+exo__Instance_class:
+  - "[[exo__Class]]"
+exo__Asset_label: tst__Unrelated
+---
+`,
+  );
+
+  // Genuinely wrong value subject: typed tst__Unrelated
+  write(
+    alsoVault,
+    `tbox/${VALUE_BAD_UID}.md`,
+    `---
+exo__Asset_uid: ${VALUE_BAD_UID}
+exo__Instance_class:
+  - "[[${UNREL_UID}]]"
+exo__Asset_label: Some Unrelated Thing
+---
+`,
+  );
+
+  // ── Primary vault X (property decl + domain class + instances) ────────────
+
+  // Property declaration: range = RANGE_UID (cross-vault UID ref into Y)
+  write(
+    primaryVault,
+    `tbox/${PROP_UID}.md`,
+    `---
+exo__Asset_uid: ${PROP_UID}
+exo__Instance_class:
+  - "[[exo__Property]]"
+exo__Asset_label: xrule__sourceProp
+exo__Property_domain:
+  - "[[${DOMAIN_UID}]]"
+exo__Property_range: "[[${RANGE_UID}]]"
+exo__Property_cardinality: "[[exo__PropertyCardinalitySingle]]"
+exo__Property_severity: sh:Violation
+---
+`,
+  );
+
+  // Domain class: xrule__Rule (lives in X)
+  write(
+    primaryVault,
+    `tbox/${DOMAIN_UID}.md`,
+    `---
+exo__Asset_uid: ${DOMAIN_UID}
+exo__Instance_class:
+  - "[[exo__Class]]"
+exo__Asset_label: xrule__Rule
+---
+`,
+  );
+
+  // Conformant instance: xrule__sourceProp → VALUE_OK_UID (tst__MetaProperty ⊑ tst__Property)
+  write(
+    primaryVault,
+    `data/${INST_OK_UID}.md`,
+    `---
+exo__Asset_uid: ${INST_OK_UID}
+exo__Instance_class:
+  - "[[${DOMAIN_UID}]]"
+exo__Asset_label: Conformant Rule
+xrule__sourceProp: "[[${VALUE_OK_UID}]]"
+---
+`,
+  );
+
+  // Non-conformant instance: xrule__sourceProp → VALUE_BAD_UID (tst__Unrelated, NOT ⊑ tst__Property)
+  write(
+    primaryVault,
+    `data/${INST_BAD_UID}.md`,
+    `---
+exo__Asset_uid: ${INST_BAD_UID}
+exo__Instance_class:
+  - "[[${DOMAIN_UID}]]"
+exo__Asset_label: Broken Rule
+xrule__sourceProp: "[[${VALUE_BAD_UID}]]"
+---
+`,
+  );
+});
+
+afterAll(() => {
+  fs.rmSync(tmpRoot, { recursive: true, force: true });
+});
+
+async function loadRaw(...vaults: string[]): Promise<unknown[]> {
+  const all: unknown[] = [];
+  for (const v of vaults) {
+    const adapter = new FileSystemVaultAdapter(v);
+    const converter = new NoteToRDFConverter(adapter);
+    const triples = await converter.convertVault();
+    for (const t of triples) all.push(t);
+  }
+  return all;
+}
+
+async function loadMerged(...vaults: string[]): Promise<unknown[]> {
+  const all = await loadRaw(...vaults);
+  // Mirror loadTriplesFromAllVaults' cross-vault Instance_class literal pass.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return resolveCrossVaultInstanceClassWikilinks(all as any[]) as unknown[];
+}
+
+describe("BDD: validate schema --also cross-vault sh:class (Issue #3523)", () => {
+  it("Scenario: conformant cross-vault typed ref produces NO sh:Violation", async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const triples = (await loadMerged(primaryVault, alsoVault)) as any[];
+    const report = await runShapesValidation(primaryVault, triples, [alsoVault]);
+
+    const classViolations = report.violations.filter(
+      (v) => v.constraint === "class" && v.severity === "sh:Violation",
+    );
+    const conformantNode = classViolations.filter((v) =>
+      v.focusNode.includes(INST_OK_UID),
+    );
+    expect(conformantNode).toEqual([]);
+  });
+
+  it("Scenario: a genuinely wrong cross-vault class IS still caught (no over-suppression)", async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const triples = (await loadMerged(primaryVault, alsoVault)) as any[];
+    const report = await runShapesValidation(primaryVault, triples, [alsoVault]);
+
+    const badViolations = report.violations.filter(
+      (v) =>
+        v.constraint === "class" &&
+        v.severity === "sh:Violation" &&
+        v.focusNode.includes(INST_BAD_UID),
+    );
+    expect(badViolations.length).toBeGreaterThan(0);
+  });
+
+  it("Scenario: overall report conforms only because the single real violation is the BAD instance", async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const triples = (await loadMerged(primaryVault, alsoVault)) as any[];
+    const report = await runShapesValidation(primaryVault, triples, [alsoVault]);
+
+    const classErrorNodes = new Set(
+      report.violations
+        .filter((v) => v.constraint === "class" && v.severity === "sh:Violation")
+        .map((v) => v.focusNode),
+    );
+    // Exactly one node carries a real sh:class Violation, and it is the BAD one.
+    expect([...classErrorNodes].some((n) => n.includes(INST_BAD_UID))).toBe(true);
+    expect([...classErrorNodes].some((n) => n.includes(INST_OK_UID))).toBe(false);
+  });
+});
+
+describe("BDD: validate schema --also shared-submodule double-load dedup (Issue #3523)", () => {
+  it("Scenario: loading the SAME vault twice without dedup inflates Single-cardinality → false sh:maxCount", async () => {
+    // Pre-dedup behaviour: byte-identical re-parse duplicates every triple,
+    // so the Single-cardinality xrule__sourceProp reads as 2 values.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const doubled = (await loadRaw(primaryVault, primaryVault)) as any[];
+    const report = await runShapesValidation(primaryVault, doubled, [primaryVault]);
+    const maxCount = report.violations.filter((v) => v.constraint === "maxCount");
+    expect(maxCount.length).toBeGreaterThan(0);
+  });
+
+  it("Scenario: dedupeTriples collapses the double-load → no false sh:maxCount", async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const doubled = (await loadRaw(primaryVault, primaryVault)) as any[];
+    const deduped = dedupeTriples(doubled);
+    expect(deduped.length).toBeLessThan(doubled.length);
+    const report = await runShapesValidation(primaryVault, deduped, [primaryVault]);
+    const maxCount = report.violations.filter((v) => v.constraint === "maxCount");
+    expect(maxCount).toEqual([]);
+  });
+
+  it("Scenario: dedupeTriples is a no-op on an already-unique triple set", async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const single = (await loadRaw(primaryVault)) as any[];
+    const deduped = dedupeTriples(single);
+    expect(deduped.length).toBe(single.length);
+  });
+});

--- a/packages/exocortex/src/services/ShapeLoader.ts
+++ b/packages/exocortex/src/services/ShapeLoader.ts
@@ -59,6 +59,17 @@ export class ShapeLoader {
     const RDFS = Namespace.RDFS;
     const RDF = Namespace.RDF;
 
+    // Issue #3523: build a UID → canonical-class-IRI index once, so a
+    // domain/range value that arrived as a *synthesized* UUID-only file IRI
+    // (`obsidian://vault/<uid>.md`, no directory) — emitted by the primary
+    // vault's converter when an `--also` dependency's class def could not be
+    // resolved in the primary vault — still canonicalizes to the same symbolic
+    // ontology IRI as the merged single-vault case. The owning dep vault emits
+    // that class's `rdfs:label` under its *full-path* subject IRI
+    // (`obsidian://vault/tbox/<uid>.md`), so an exact-IRI label lookup misses;
+    // keying by the bare UID bridges the two file-IRI forms across `--also`.
+    const uidToClassIRI = await ShapeLoader.buildUidClassIndex(graph);
+
     // Find all property definition subjects (exo:Property or exo:ObjectProperty)
     const [objPropTriples, basePropTriples] = await Promise.all([
       graph.match(undefined, RDF.term("type"), EXO.term("ObjectProperty")),
@@ -134,7 +145,7 @@ export class ShapeLoader {
       const domainRaw = await Promise.all(
         domainTs.map(async (t) =>
           t.object instanceof IRI
-            ? await ShapeLoader.resolveClassIRI(t.object.value, graph)
+            ? await ShapeLoader.resolveClassIRI(t.object.value, graph, uidToClassIRI)
             : null,
         ),
       );
@@ -145,7 +156,7 @@ export class ShapeLoader {
       const rangeValuesRaw = await Promise.all(
         rangeTs.map(async (t) => {
           if (t.object instanceof IRI) {
-            return await ShapeLoader.resolveClassIRI(t.object.value, graph);
+            return await ShapeLoader.resolveClassIRI(t.object.value, graph, uidToClassIRI);
           }
           // Plain-string range values (e.g. `exo__Property_range:
           // "http://www.w3.org/2001/XMLSchema#integer"`) arrive as Literals
@@ -213,6 +224,51 @@ export class ShapeLoader {
 
   // ── Private helpers ───────────────────────────────────────────────────────
 
+  /** Matches `obsidian://vault/[<dirs>/]<uuid>.md` and captures the bare UUID. */
+  private static readonly FILE_IRI_UID_RE =
+    /\/([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\.md$/i;
+
+  /** Extracts the lowercase UUID from a `…/<uuid>.md` file IRI, or null. */
+  private static extractUidFromFileIRI(iri: string): string | null {
+    const m = ShapeLoader.FILE_IRI_UID_RE.exec(iri);
+    return m ? m[1].toLowerCase() : null;
+  }
+
+  /**
+   * Issue #3523: builds `uid → canonical-class-IRI` from every labelled subject
+   * in the merged graph (across the primary vault + all `--also` vaults). Used
+   * by {@link resolveClassIRI} to canonicalize a domain/range value that arrived
+   * as a synthesized UUID-only file IRI whose exact-IRI label lookup misses
+   * because the labelled subject lives under a full-path IRI in another vault.
+   *
+   * Only labels that parse to a `<prefix>__<Local>` ontology IRI are indexed —
+   * human-named (non-symbolic) class files are left to the validator's existing
+   * UID-twin / open-world handling. First-label-wins per UID (UIDs are unique).
+   */
+  private static async buildUidClassIndex(
+    graph: ITripleStore,
+  ): Promise<Map<string, string>> {
+    const RDFS = Namespace.RDFS;
+    const EXO = Namespace.EXO;
+    const [rdfsLabelTs, exoLabelTs] = await Promise.all([
+      graph.match(undefined, RDFS.term("label"), undefined),
+      graph.match(undefined, EXO.term("Asset_label"), undefined),
+    ]);
+    const map = new Map<string, string>();
+    for (const t of [...rdfsLabelTs, ...exoLabelTs]) {
+      if (!(t.subject instanceof IRI) || !(t.object instanceof Literal)) continue;
+      const uid = ShapeLoader.extractUidFromFileIRI(t.subject.value);
+      if (!uid || map.has(uid)) continue;
+      const labelValue = t.object.value.trim();
+      // labelToIRI splits on the first `__`; multi-word labels would yield an
+      // invalid IRI. Restrict to single-token labels for a safe namespace IRI.
+      if (/\s/.test(labelValue)) continue;
+      const classIRI = ShapeLoader.labelToIRI(labelValue);
+      if (classIRI) map.set(uid, classIRI);
+    }
+    return map;
+  }
+
   /**
    * Resolves a domain/range IRI to its canonical namespace form.
    *
@@ -238,6 +294,7 @@ export class ShapeLoader {
   private static async resolveClassIRI(
     iri: string,
     graph: ITripleStore,
+    uidToClassIRI?: ReadonlyMap<string, string>,
   ): Promise<string | null> {
     if (
       iri.startsWith("https://exocortex.my/ontology/") ||
@@ -266,6 +323,20 @@ export class ShapeLoader {
       if (t.object instanceof Literal) {
         const resolved = ShapeLoader.labelToIRI(t.object.value);
         if (resolved) return resolved;
+      }
+    }
+
+    // Issue #3523: the exact-IRI label lookup above misses for a synthesized
+    // UUID-only cross-vault file IRI (the labelled subject lives under a
+    // full-path IRI in the `--also` vault). Fall back to the UID-keyed index so
+    // the range/domain canonicalizes to the same symbolic class IRI the merged
+    // single-vault converter would have produced — letting the class-membership
+    // (`isSubClassOf`) check unify across the `--also` boundary.
+    if (uidToClassIRI) {
+      const uid = ShapeLoader.extractUidFromFileIRI(iri);
+      if (uid) {
+        const byUid = uidToClassIRI.get(uid);
+        if (byUid) return byUid;
       }
     }
 


### PR DESCRIPTION
## Summary

`validate schema --shapes-mode --also <dep>` emitted **false `sh:class` violations** for conformant cross-vault typed refs — directly violating #3513 Acceptance #4 ("Zero false-positives from unresolvable cross-repo refs"). On the issue's decisive reproduction (CLI 16.92.0): exocmd closure **30 → 0**, exodev leaf **2 → 0**, both **0 standalone & 0 in a merged single vault** (data is correct; the `--also` resolution was buggy).

## Root cause

A typed property whose `exo__Property_range` points (by UID wikilink) at a class def living in an `--also` dependency is emitted by the **primary** vault's converter as a *synthesized* UUID-only file IRI (`obsidian://vault/<uid>.md`, no directory) because the target is unresolvable in the primary vault. The **dependency** vault's converter emits that same class's `rdfs:label` / superClass chain under its *full-path* subject IRI **plus** the symbolic ontology IRI (`https://exocortex.my/ontology/<ns>#<Local>`).

`ShapeLoader.resolveClassIRI` looked up the label keyed on the **exact (synth) IRI**, missed it (the labelled subject lives under a full-path IRI), and left the range as a file IRI that never unifies with the symbolic superClass chain → `isSubClassOf` fails → false violation. The value side already resolved via the validator's UID-twin index, which is exactly why these surfaced as `sh:Violation` (resolved value) rather than `sh:Warning` (unresolvable).

## Fix

1. **sh:class IRI unification** (`ShapeLoader`): build a `uid → canonical-class-IRI` index once from all labelled subjects in the merged graph, and use it as a **UID-keyed fallback** in `resolveClassIRI`. A synth cross-vault range/domain IRI now canonicalizes to the same symbolic class IRI the merged single-vault case produces — so class membership unifies across the `--also` boundary. Single-vault loading is unchanged (synth IRIs only arise cross-vault).

2. **shared-submodule double-load** (`validate-schema.ts`): the sibling false `sh:maxCount` (e.g. `exo --also exo` → 3, when a shared submodule is mounted in both vaults) is fixed by collapsing exact-duplicate triples in the multi-vault load path. RDF triples are a set; dual-storage predicates emit distinct objects so are never collapsed. Single-vault loading is byte-for-byte unchanged.

## Verification (real repos, this PR's build)

| scenario | before | after |
|---|---|---|
| `exocmd --also exo --also w3c` | 30 violations | **0** (177 warnings) |
| `exodev` leaf `--also` closure | 2 violations | **0** |
| `exo --also exo` (double-load) | 3 sh:maxCount | **0** |
| `exocmd` / `exo` standalone | 0 | **0** (unchanged) |

## Tests — revert-verify, production-shape fixtures

New integration suite `validate-schema-cross-vault-class-iri.integration.test.ts` (UID-canon TBox, TBox in a subdir so full-path subject ≠ synth IRI — mirroring the real `exoas-exo/exo/<uid>.md` layout). **Empirically verified to FAIL pre-fix** (false `sh:Violation` on the conformant node + false `sh:maxCount` on double-load) **and PASS post-fix.** A **negative control** proves a genuinely wrong cross-vault class is still caught (no over-suppression).

Regression: 147 (ShapeLoader + ShaclLiteValidator) + 41 (validate-schema integration) + 84 (validate-schema unit) + 15 (cross-runtime parity) — all green. `npm run check:types` clean.

## Note on the gate workaround

The merge-time gate workaround (`exoas-ci`) is left in place — it still works. This is the root CLI fix that makes `--also` correct on its own; flipping the gate back to `--also` is optional follow-up.

Closes #3523