### PR TITLE
fix(plugin): bound requestUrl + git-clone so apply-profile never hangs on macOS desktop (#3530)

### DIFF
--- a/packages/obsidian-plugin/src/infrastructure/adapters/GitHubRestClient.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/GitHubRestClient.ts
@@ -15,6 +15,18 @@ export interface GitHubRestClientOptions {
    * held in memory; setting this very large can crash Obsidian renderer.
    */
   maxTarballBytes?: number;
+  /**
+   * Per-request deadline (ms) for the underlying Obsidian `requestUrl()` call.
+   * Obsidian's `requestUrl` exposes NO native timeout / abort, so a stalled
+   * desktop connection (e.g. a private-repo tarball whose codeload redirect
+   * never resolves — observed hanging the apply-profile path on macOS desktop
+   * while the identical call completes in Docker/Linux, Issue #3530) leaves the
+   * awaiter pending forever. Every request is raced against this deadline so the
+   * caller deterministically REJECTS instead of hanging. Default 120_000 (2 min)
+   * — generous for a 50 MB tarball over a slow link, finite enough to surface a
+   * stall well before the user gives up. Set `0` to disable the guard.
+   */
+  requestTimeoutMs?: number;
 }
 
 export interface GitHubBranchHead {
@@ -57,6 +69,11 @@ export class GitHubRestClient {
   // can crash Obsidian renderer. Override via constructor `maxTarballBytes` opt.
   private static readonly DEFAULT_MAX_TARBALL_BYTES = 50 * 1024 * 1024;
 
+  // Per-request deadline for the non-abortable `requestUrl` — 2 min default.
+  // Bounds the macOS-desktop apply-profile hang (Issue #3530) so a stalled
+  // connection rejects instead of pending forever. Override via ctor opt.
+  private static readonly DEFAULT_REQUEST_TIMEOUT_MS = 120_000;
+
   // Strict allowlist — anchored, no paths/queries/fragments, no scheme variants.
   private static readonly REPO_URL_REGEX =
     /^https:\/\/github\.com\/[a-zA-Z0-9_-]+\/[a-zA-Z0-9_.-]+$/;
@@ -69,6 +86,7 @@ export class GitHubRestClient {
   readonly #app: App;
   readonly #baseURL: string;
   readonly #maxTarballBytes: number;
+  readonly #requestTimeoutMs: number;
 
   constructor(opts: GitHubRestClientOptions) {
     // An EMPTY PAT is allowed and puts the client in unauthenticated mode
@@ -90,6 +108,12 @@ export class GitHubRestClient {
     this.#app = opts.app;
     this.#baseURL = (opts.baseURL ?? "https://api.github.com").replace(/\/$/, "");
     this.#maxTarballBytes = opts.maxTarballBytes ?? GitHubRestClient.DEFAULT_MAX_TARBALL_BYTES;
+    // A negative value is meaningless — clamp to 0 (disabled). 0 disables the
+    // guard entirely (used by tests that assert the pre-timeout behaviour).
+    this.#requestTimeoutMs = Math.max(
+      0,
+      opts.requestTimeoutMs ?? GitHubRestClient.DEFAULT_REQUEST_TIMEOUT_MS,
+    );
   }
 
   /** Obsidian App handle (needed by downstream consumers — TarExtractor, etc.). */
@@ -390,11 +414,15 @@ export class GitHubRestClient {
     }
     let resp: RequestUrlResponse;
     try {
-      resp = await requestUrl({
-        ...param,
-        headers,
-        throw: false,
-      });
+      resp = await this.withRequestTimeout(
+        requestUrl({
+          ...param,
+          headers,
+          throw: false,
+        }),
+        param.method ?? "GET",
+        param.url,
+      );
     } catch (err) {
       throw new Error(this.redact(`GitHub request failed: ${errMsg(err)}`));
     }
@@ -411,6 +439,49 @@ export class GitHubRestClient {
       );
     }
     return resp;
+  }
+
+  /**
+   * Race a non-abortable `requestUrl` promise against {@link #requestTimeoutMs}.
+   *
+   * Obsidian's `requestUrl` has no `signal`/`timeout` parameter, so a stalled
+   * desktop connection would hang the awaiter forever (the macOS-desktop
+   * apply-profile hang, Issue #3530 — a private-repo tarball pull that never
+   * resolves, while the same call completes in Docker/Linux). We reject after
+   * the deadline so the apply path unwinds (clearing `_switchInProgress`)
+   * instead of pending indefinitely.
+   *
+   * The underlying request cannot be cancelled (requestUrl exposes no abort),
+   * so on timeout it is left to settle and its eventual result is discarded —
+   * `clearTimeout` on the win path prevents the timer from leaking.
+   */
+  private withRequestTimeout(
+    p: Promise<RequestUrlResponse>,
+    method: string,
+    url: string,
+  ): Promise<RequestUrlResponse> {
+    if (this.#requestTimeoutMs <= 0) return p;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const deadline = new Promise<RequestUrlResponse>((_resolve, reject) => {
+      timer = setTimeout(() => {
+        reject(
+          new Error(
+            this.redact(
+              `GitHub request ${method} ${url} timed out after ` +
+                `${this.#requestTimeoutMs}ms (no response — stalled connection?)`,
+            ),
+          ),
+        );
+      }, this.#requestTimeoutMs);
+      // Unref so a pending timer never keeps a Node test process alive; guarded
+      // because Electron renderer / browser timers expose no `unref`.
+      (timer as unknown as { unref?: () => void }).unref?.();
+    });
+    // Promise.race forwards `p`'s own resolution/rejection verbatim (the request
+    // wins) or the deadline's Error (the stall loses) — no manual reject(e), so
+    // the original rejection reason is preserved. `.finally` clears the timer on
+    // every exit path so a pending timer never leaks.
+    return Promise.race([p, deadline]).finally(() => clearTimeout(timer));
   }
 
   /**

--- a/packages/obsidian-plugin/src/infrastructure/adapters/GitSubmoduleOps.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/GitSubmoduleOps.ts
@@ -593,6 +593,16 @@ export function stripGitEnv(): NodeJS.ProcessEnv {
   for (const k of Object.keys(env)) {
     if (STRIP.has(k)) delete env[k];
   }
+  // Disable git's interactive credential prompt. Obsidian spawns git with NO
+  // controlling TTY, so a private-repo `git submodule add` that can't resolve
+  // credentials non-interactively (no cached helper entry) would otherwise
+  // block on a prompt that can never be answered — contributing to the
+  // macOS-desktop apply-profile hang (Issue #3530). With this set, git fails
+  // fast («could not read Username … terminal prompts disabled») and the apply
+  // path surfaces a clear error instead of hanging. Cached credential helpers
+  // (osxkeychain, the e2e `url.insteadOf` PAT rewrite) are unaffected — this
+  // only suppresses the dead-end *terminal* fallback.
+  env.GIT_TERMINAL_PROMPT = "0";
   return env;
 }
 

--- a/packages/obsidian-plugin/tests/unit/GitHubRestClient.test.ts
+++ b/packages/obsidian-plugin/tests/unit/GitHubRestClient.test.ts
@@ -719,4 +719,66 @@ describe("GitHubRestClient", () => {
       expect(call.headers.Authorization).toBe(`Bearer ${FAKE_PAT}`);
     });
   });
+
+  // ─── requestUrl timeout guard (Issue #3530 — macOS desktop apply hang) ─────
+  describe("requestUrl timeout guard", () => {
+    // Root regression: Obsidian's `requestUrl` has no native timeout/abort, so a
+    // stalled desktop connection (private-repo tarball whose codeload redirect
+    // never resolves) left `applyProfile` pending forever. Every request is now
+    // raced against `requestTimeoutMs`; on stall it REJECTS deterministically so
+    // the apply path unwinds (clears `_switchInProgress`) instead of hanging.
+
+    it("rejects (does NOT hang) when requestUrl never resolves", async () => {
+      // The exact production failure: requestUrl returns a Promise that never
+      // settles. Pre-fix this hangs the awaiter forever; post-fix it rejects.
+      requestUrlMock.mockReturnValue(new Promise<never>(() => {}));
+      const c = new GitHubRestClient({
+        pat: FAKE_PAT,
+        app: fakeApp,
+        requestTimeoutMs: 40,
+      });
+      const err = await c.getRepoHead("o", "r").catch((e: Error) => e);
+      expect(err).toBeInstanceOf(Error);
+      expect((err as Error).message).toMatch(/timed out after 40ms/);
+    });
+
+    it("redacts a PAT that leaks into the timeout error message", async () => {
+      // The URL never carries a PAT, but the message is routed through redact()
+      // for defense-in-depth (parity with every other thrown error here).
+      requestUrlMock.mockReturnValue(new Promise<never>(() => {}));
+      const c = new GitHubRestClient({
+        pat: FAKE_PAT,
+        app: fakeApp,
+        requestTimeoutMs: 30,
+      });
+      const err = await c
+        .fetchTarballBuffer("o", "r", "main")
+        .catch((e: Error) => e);
+      expect((err as Error).message).not.toContain("ghp_");
+    });
+
+    it("resolves normally when requestUrl wins the race", async () => {
+      // A healthy fast response must NOT be aborted — only genuine stalls do.
+      requestUrlMock.mockResolvedValue(ok({ json: { commit: { sha: "abc" } } }));
+      const c = new GitHubRestClient({
+        pat: FAKE_PAT,
+        app: fakeApp,
+        requestTimeoutMs: 5000,
+      });
+      await expect(c.getRepoHead("o", "r")).resolves.toEqual({ sha: "abc" });
+    });
+
+    it("disables the guard when requestTimeoutMs is 0 (no spurious timer)", async () => {
+      // 0 opts out — used where a caller wants the raw pre-guard behaviour.
+      // A resolved request must still complete; the never-resolving case is the
+      // caller's responsibility when the guard is explicitly disabled.
+      requestUrlMock.mockResolvedValue(ok({ json: { commit: { sha: "z" } } }));
+      const c = new GitHubRestClient({
+        pat: FAKE_PAT,
+        app: fakeApp,
+        requestTimeoutMs: 0,
+      });
+      await expect(c.getRepoHead("o", "r")).resolves.toEqual({ sha: "z" });
+    });
+  });
 });

--- a/packages/obsidian-plugin/tests/unit/GitHubRestClient.test.ts
+++ b/packages/obsidian-plugin/tests/unit/GitHubRestClient.test.ts
@@ -743,18 +743,22 @@ describe("GitHubRestClient", () => {
     });
 
     it("redacts a PAT that leaks into the timeout error message", async () => {
-      // The URL never carries a PAT, but the message is routed through redact()
-      // for defense-in-depth (parity with every other thrown error here).
+      // Non-vacuous: embed a PAT-shaped token in the request URL (via baseURL)
+      // so the timeout message ("GitHub request GET <url> timed out…") WOULD
+      // contain it verbatim if redact() were skipped — proving the new timeout
+      // path scrubs PATs, not just that the URL happens to be PAT-free.
       requestUrlMock.mockReturnValue(new Promise<never>(() => {}));
       const c = new GitHubRestClient({
         pat: FAKE_PAT,
         app: fakeApp,
+        baseURL: `https://api.github.com/${FAKE_PAT}`,
         requestTimeoutMs: 30,
       });
-      const err = await c
-        .fetchTarballBuffer("o", "r", "main")
-        .catch((e: Error) => e);
-      expect((err as Error).message).not.toContain("ghp_");
+      const err = await c.getRepoHead("o", "r").catch((e: Error) => e);
+      // The raw URL embedded the token; the thrown message must have redacted it.
+      expect((err as Error).message).toMatch(/timed out after 30ms/);
+      expect((err as Error).message).not.toContain(FAKE_PAT);
+      expect((err as Error).message).toContain("***REDACTED***");
     });
 
     it("resolves normally when requestUrl wins the race", async () => {

--- a/packages/obsidian-plugin/tests/unit/ProfileApplyManager.apply.test.ts
+++ b/packages/obsidian-plugin/tests/unit/ProfileApplyManager.apply.test.ts
@@ -865,6 +865,50 @@ describe("ProfileApplyManager.applyProfile", () => {
     });
   });
 
+  describe("Phase-1 pull failure — never hangs (Issue #3530)", () => {
+    // The macOS-desktop hang root cause: a private-repo tarball pull never
+    // resolved (Obsidian `requestUrl` has no timeout), so `applyProfile` stayed
+    // pending forever with `_switchInProgress` stuck. The GitHubRestClient
+    // timeout guard now makes `pullAssetSpace` REJECT on a stalled connection;
+    // here we assert the apply orchestration honours that reject deterministically
+    // — it must settle (jest's default 5s test timeout would fail a real hang)
+    // and clear `_switchInProgress`. `failOnPull` stands in for the timeout reject.
+    function pullFailSetup() {
+      return setup({
+        targetUid: "target",
+        sourceUid: null,
+        // Floor present + one extra AS to materialise (so Phase 1 pull runs).
+        targetIncludes: [
+          TS_FLOOR_AS_UID_EXO,
+          TS_FLOOR_AS_UID_EXOCMD,
+          TS_FLOOR_AS_UID_SHARED_IDENTITIES,
+          "ems-uid",
+        ],
+        // ems-uid is NOT yet materialised → it lands in toMaterialize → pulled.
+        materialized: [
+          TS_FLOOR_AS_UID_EXO,
+          TS_FLOOR_AS_UID_EXOCMD,
+          TS_FLOOR_AS_UID_SHARED_IDENTITIES,
+        ],
+      });
+    }
+
+    it("rejects (does NOT hang) when the Phase-1 pull fails", async () => {
+      const { mgr, assetSpaceManager } = pullFailSetup();
+      assetSpaceManager.failOnPull = "ems-uid";
+      await expect(mgr.applyProfile("target")).rejects.toThrow(
+        /Simulated pull failure/,
+      );
+    });
+
+    it("clears _switchInProgress after a failed Phase-1 pull", async () => {
+      const { mgr, assetSpaceManager, localDataStore } = pullFailSetup();
+      assetSpaceManager.failOnPull = "ems-uid";
+      await expect(mgr.applyProfile("target")).rejects.toThrow();
+      expect(localDataStore.isSwitchInProgress()).toBe(false);
+    });
+  });
+
   describe("Successful switch", () => {
     it("activeProfileUid persisted к target after success", async () => {
       const { mgr, localDataStore } = setup({

--- a/packages/obsidian-plugin/tests/unit/infrastructure/adapters/GitSubmoduleOps.test.ts
+++ b/packages/obsidian-plugin/tests/unit/infrastructure/adapters/GitSubmoduleOps.test.ts
@@ -5,6 +5,7 @@ import {
   stripGitmodulesEntry,
   parseGitmodulesPaths,
   parseGitmodulesEntries,
+  stripGitEnv,
 } from "../../../../src/infrastructure/adapters/GitSubmoduleOps";
 
 describe("validateVaultPathArg", () => {
@@ -199,5 +200,40 @@ describe("GitSubmoduleOps.run security", () => {
   it("rejects empty arg list", async () => {
     const ops = new GitSubmoduleOps({ vaultRootPath: "/fake", execFileFn: jest.fn() as never });
     await expect(ops.run([])).rejects.toThrow();
+  });
+});
+
+// ─── GIT_TERMINAL_PROMPT guard (Issue #3530 — private-clone desktop hang) ────
+describe("stripGitEnv credential-prompt guard", () => {
+  // Obsidian spawns git with no controlling TTY; a private-repo `submodule add`
+  // that can't resolve creds non-interactively would block on a prompt that can
+  // never be answered. Setting GIT_TERMINAL_PROMPT=0 makes git fail fast instead
+  // of hanging — part of the macOS-desktop apply-profile hang fix.
+  it("sets GIT_TERMINAL_PROMPT=0", () => {
+    expect(stripGitEnv().GIT_TERMINAL_PROMPT).toBe("0");
+  });
+
+  it("preserves GIT_CONFIG_* (credential helpers / protocol overrides unaffected)", () => {
+    const prev = process.env.GIT_CONFIG_COUNT;
+    process.env.GIT_CONFIG_COUNT = "1";
+    try {
+      expect(stripGitEnv().GIT_CONFIG_COUNT).toBe("1");
+    } finally {
+      if (prev === undefined) delete process.env.GIT_CONFIG_COUNT;
+      else process.env.GIT_CONFIG_COUNT = prev;
+    }
+  });
+
+  it("passes GIT_TERMINAL_PROMPT=0 to the git subprocess env on run()", async () => {
+    const execFileFn = jest
+      .fn()
+      .mockResolvedValue({ stdout: "", stderr: "" }) as never;
+    const ops = new GitSubmoduleOps({ vaultRootPath: "/fake", execFileFn });
+    await ops.run(["status", "--porcelain"]);
+    const passedEnv = (execFileFn as jest.Mock).mock.calls[0][2].env as Record<
+      string,
+      string
+    >;
+    expect(passedEnv.GIT_TERMINAL_PROMPT).toBe("0");
   });
 });


### PR DESCRIPTION
Closes #3530

## Problem

On real macOS desktop Obsidian, `apply-profile $$kitelev-exodev` shows the correct confirm dialog (7 AS effective set, #3528 fix) but then **hangs** after clicking **Apply** — `applyProfile(uid)` stays `<pending>` forever (>3 min), 0 files cloned, 0 console errors. The **identical production path passes in the Docker e2e** (`eka-obsidian-leg.spec.ts`, docker-green ×2) on Linux → desktop-specific hang.

## Root cause

Two desktop hang vectors that the Docker e2e bypasses (fast network + injected git creds):

1. **`GitHubRestClient.request()` wraps Obsidian `requestUrl()` with NO timeout.** `requestUrl` exposes no `signal`/`timeout`; a stalled desktop connection (a private-repo tarball whose codeload redirect never resolves — a known desktop-vs-Linux divergence) leaves the Phase-1 pull pending **forever**. It is the only network op in the apply path with no deadline (`GitSubmoduleOps` already has a 5-min `execFile` timeout).
2. **`git submodule add` runs without `GIT_TERMINAL_PROMPT=0`.** Obsidian spawns git with no controlling TTY; a private clone that can't resolve credentials non-interactively can block on a credential prompt that can never be answered.

## Fix

- **`GitHubRestClient`**: race every `requestUrl` call against a configurable `requestTimeoutMs` (default **120 s**, `0` disables). On stall it **rejects deterministically** (PAT-redacted message) instead of hanging; the apply path then unwinds and clears `_switchInProgress`. `Promise.race` forwards a healthy request's result verbatim — only a genuine stall loses. Healthy/fast responses are never aborted (EKA repos are sub-MB; 120 s is hugely generous).
- **`GitSubmoduleOps.stripGitEnv()`**: set `GIT_TERMINAL_PROMPT=0` so a credential-less private clone fails fast with a clear error. Cached helpers (osxkeychain, the e2e `url.insteadOf` PAT rewrite) are unaffected — only the dead-end *terminal* fallback is suppressed.

Net: `applyProfile` / Phase-1 pull **always resolves or rejects — never hangs**, and `_switchInProgress` is always cleared.

## Tests (TDD + revert-verify)

- `GitHubRestClient.test.ts` — a never-resolving `requestUrl` now **rejects within the deadline** (revert-verified: without the guard the test hangs → jest timeout → fail); healthy response still resolves; `requestTimeoutMs: 0` opts out cleanly; PAT redaction on the timeout message.
- `ProfileApplyManager.apply.test.ts` — a failed Phase-1 pull **rejects (never hangs, bounded by jest's 5 s test timeout)** and clears `_switchInProgress`.
- `GitSubmoduleOps.test.ts` — `stripGitEnv` sets `GIT_TERMINAL_PROMPT=0`; preserves `GIT_CONFIG_*`; `run()` passes it to the git subprocess env.

Affected (146) + related (51, incl. real-`git submodule add` integration with `file://`) suites pass; `tsc --noEmit` + eslint clean.

## Verification note

The exact macOS-desktop `requestUrl` stall is environment-specific and not reproducible in unit/CI, so this is a **defensive timeout-guard + deterministic-error** fix (per the task fallback). The regression test reproduces the *hang shape* (never-resolving promise) and proves it now rejects. **A GUI re-smoke of apply-profile on macOS desktop after release is requested** to confirm end-to-end materialisation (or a clean error) instead of a hang.