### PR TITLE
feat(cli): exosync sync/pull/push — ExoSync CLI parity (EKA M3.7)

### DIFF
--- a/docs/exosync.md
+++ b/docs/exosync.md
@@ -40,6 +40,29 @@ mount paths first), best-effort: one failing repo never blocks the rest. A
 summary notice reports `pushed / pulled / merged / quarantined` counts;
 per-repo warnings and details go to the developer console (`[ExoSync] …`).
 
+### From the CLI (desktop)
+
+The same sync runs from `@kitelev/exocortex-cli`, driving the identical
+platform-free `SyncEngine` over `node:fs` ports instead of `vault.adapter`:
+
+```bash
+exocortex exosync sync  --vault <path> --token-from-gh   # full pull→merge→push
+exocortex exosync pull  --vault <path> --token-from-gh   # apply remote only
+exocortex exosync push  --vault <path> --token-from-gh   # send local delta only
+# FileSpaces additionally require --quarantine-repo https://github.com/<o>/<r>
+```
+
+The token resolves like `exosync-parity` / `experimental rest-push`
+(`--token-from-gh` → `--token` → `GITHUB_TOKEN` / `GH_TOKEN`). The CLI writes
+the same `exosync-watermarks.local.json` the plugin uses, so the two share one
+base. Exit codes: `0` all clean · `1` at least one repo unresolved/errored ·
+`2` vacuous (no materialized AssetSpaces found). For a read-only divergence
+check without writing, use `exosync-parity`.
+
+> ⚠ The engine's D11 in-flight guard is per-process: do NOT run the CLI sync
+> while the plugin is mid-sync on the same vault (watermark write is
+> last-writer-wins across processes).
+
 ### What gets synced
 
 The sync unit is collected from vault declarations

--- a/packages/cli/src/commands/exosync-sync.ts
+++ b/packages/cli/src/commands/exosync-sync.ts
@@ -1,0 +1,472 @@
+/**
+ * `exocortex exosync <sync|pull|push>` — ExoSync from the CLI (RFC 4e4dc453
+ * Phase B parity, EKA M3.7 PA-exosync).
+ *
+ * Desktop counterpart to the plugin's «Exocortex: Sync / Pull / Push»
+ * commands: it drives the SAME platform-free {@link SyncEngine} the plugin
+ * composes in `SyncDepsFactory.buildSyncEngine`, but wires it from `node:fs`
+ * instead of Obsidian's `vault.adapter`. ZERO engine edits — the only
+ * platform-specific pieces are the injected ports below
+ * (`nodeLocalFilesPort`, `nodeWatermarkFileIO`, `nodeMaterializationCheck`,
+ * `nodeSha1`). The merge layer (`GatedStructuredMerger` + `StructuredMerger`),
+ * quarantine sink (`SyncedQuarantineStore`), watermark store
+ * (`FileWatermarkStore`) and sync-unit collection (`collectVaultSpecs`, shared
+ * with `exosync-parity`) are reused verbatim from the core package.
+ *
+ * Directions (#3473): `sync` = full pull→merge→push cycle; `pull` applies
+ * remote changes only (nothing leaves the device); `push` sends the local
+ * delta only (remote changes are pinned to re-derive). Split runs never
+ * resolve conflicts — they defer to a full `sync`.
+ *
+ * Unlike `exosync-parity` (read-only by construction) this command WRITES:
+ *  - pulled remote changes land on disk through a writable `LocalFilesPort`
+ *    (atomic temp+rename, parent-dir creation, no-op delete);
+ *  - the per-device watermark (`exosync-watermarks.local.json`) is updated
+ *    through a writable IO at the SAME path the plugin uses, so a subsequent
+ *    plugin sync sees a consistent base.
+ *
+ * ⚠ Cross-process watermark caveat: the engine's D11 guard is per-process.
+ * Do NOT run this while the plugin is mid-sync on the same vault — the
+ * watermark write is last-writer-wins across processes (same limitation the
+ * `exosync-parity` read-only IO documents).
+ */
+
+import { Command } from "commander";
+import { promises as fsp, existsSync } from "node:fs";
+import { webcrypto } from "node:crypto";
+import * as path from "node:path";
+import yaml from "js-yaml";
+import {
+  FileWatermarkStore,
+  GatedStructuredMerger,
+  StructuredMerger,
+  SyncedQuarantineStore,
+  SyncEngine,
+  SYNC_BRANCH,
+  WATERMARK_STORE_FILENAME,
+  orderChildrenFirst,
+  withRateLimitBackoff,
+  type LocalFilesPort,
+  type MaterializationCheckPort,
+  type QuarantinePort,
+  type RepoSyncResult,
+  type RestCommitTransport,
+  type Sha1Fn,
+  type SyncDirection,
+  type SyncRepoSpec,
+  type WatermarkFileIO,
+  type YamlCodec,
+} from "exocortex";
+import { collectVaultSpecs } from "./exosync-parity.js";
+import { RestPushService } from "../services/RestPushService.js";
+import { ErrorHandler } from "../utils/ErrorHandler.js";
+
+export interface ExosyncSyncOptions {
+  vault: string;
+  /** Obsidian config dir NAME (watermark + plugin-data location). */
+  configDir?: string;
+  json?: boolean;
+  token?: string;
+  tokenFromGh?: boolean;
+  /**
+   * Quarantine repo URL (`https://github.com/<owner>/<repo>`). Optional for
+   * AssetSpaces (conflicts pin + re-derive). REQUIRED to sync FileSpaces
+   * (their remote-wins policy destroys the losing local bytes, whose only
+   * surviving copy is the quarantine entry).
+   */
+  quarantineRepo?: string;
+  apiBase?: string;
+}
+
+/** Injectable dependencies (tests). */
+export interface ExosyncSyncDeps {
+  transportFactory?: (token: string, apiBase?: string) => RestCommitTransport;
+  ghTokenRunner?: () => string;
+  env?: NodeJS.ProcessEnv;
+  out?: (line: string) => void;
+}
+
+/**
+ * Git blob content addressing (NOT a security context): the remote IS git,
+ * which addresses blobs by SHA-1. WebCrypto via `node:crypto`, mirroring the
+ * plugin's `webCryptoSha1` and `exosync-parity`'s `nodeSha1` (the CLI and
+ * plugin deliberately keep separate per-runtime impls of the same Sha1Fn).
+ */
+const nodeSha1: Sha1Fn = async (bytes) => {
+  const digest = await webcrypto.subtle.digest(
+    "SHA-1",
+    bytes.buffer.slice(
+      bytes.byteOffset,
+      bytes.byteOffset + bytes.byteLength,
+    ) as ArrayBuffer,
+  );
+  return [...new Uint8Array(digest)]
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+};
+
+/** js-yaml CORE_SCHEMA codec — date-like scalars MUST round-trip as strings
+ * (the YamlCodec contract the StructuredMerger relies on). Same codec the
+ * plugin's `coreSchemaYamlCodec` and `exosync-parity` use. */
+const coreSchemaYaml: YamlCodec = {
+  parse: (text) => yaml.load(text, { schema: yaml.CORE_SCHEMA }),
+  stringify: (value) =>
+    yaml.dump(value, { schema: yaml.CORE_SCHEMA, lineWidth: -1 }),
+};
+
+/** Token precedence mirrors `exosync-parity` / `experimental rest-push`.
+ * Sync touches PRIVATE repos (404-hidden without a PAT) and pushes commits,
+ * so a token is always required. */
+function resolveToken(opts: ExosyncSyncOptions, deps: ExosyncSyncDeps): string {
+  if (opts.tokenFromGh === true) {
+    return RestPushService.resolveGhToken(deps.ghTokenRunner);
+  }
+  const env = deps.env ?? process.env;
+  const token = opts.token || env.GITHUB_TOKEN || env.GH_TOKEN || "";
+  if (token.length === 0) {
+    throw new Error(
+      "A GitHub token is required (private sync units read as 404 and push needs write scope). Use --token-from-gh, --token <pat>, or set GITHUB_TOKEN / GH_TOKEN.",
+    );
+  }
+  return token;
+}
+
+/** Parse `https://github.com/<owner>/<repo>` → {owner, repo}; throws on a
+ * non-GitHub / malformed URL (same allowlist as the REST mount/quarantine
+ * path). */
+function parseGitHubRepoUrl(url: string): { owner: string; repo: string } {
+  const m = /^https:\/\/github\.com\/([^/]+)\/([^/]+?)(?:\.git)?\/?$/.exec(
+    url.trim(),
+  );
+  if (m === null) {
+    throw new Error(
+      `Invalid quarantine repo URL (expected https://github.com/<owner>/<repo>): ${url}`,
+    );
+  }
+  return { owner: m[1], repo: m[2] };
+}
+
+/** Parent directory of a forward-slash path; `""` if top-level. */
+function parentDir(p: string): string {
+  const i = p.lastIndexOf("/");
+  return i <= 0 ? "" : p.slice(0, i);
+}
+
+/**
+ * WRITABLE `LocalFilesPort` over `node:fs`, scoped to one repo mount folder.
+ * Repo-relative forward-slash paths (the engine's contract). Writes are
+ * atomic (temp + rename) and create parent folders; deletes are no-ops when
+ * the path is already absent — mirroring the plugin's `vaultLocalFilesPort`.
+ */
+export function nodeLocalFilesPort(root: string): LocalFilesPort {
+  const abs = (rel: string): string => path.join(root, rel);
+  const walk = async (dir: string, out: string[]): Promise<void> => {
+    let entries: Awaited<ReturnType<typeof fsp.readdir>>;
+    try {
+      entries = await fsp.readdir(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const entry of entries) {
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        if (entry.name === ".git") continue; // submodule plumbing, never content
+        await walk(full, out);
+      } else if (entry.isFile()) {
+        out.push(path.relative(root, full).split(path.sep).join("/"));
+      }
+    }
+  };
+  /** Atomic write: temp (`.local.tmp` — refused by isSyncablePath) → rename. */
+  const writeAtomic = async (
+    target: string,
+    write: (tmp: string) => Promise<void>,
+  ): Promise<void> => {
+    const parent = path.dirname(target);
+    await fsp.mkdir(parent, { recursive: true });
+    const tmp = `${target}.local.tmp`;
+    await write(tmp);
+    await fsp.rename(tmp, target);
+  };
+  return {
+    async list(): Promise<string[]> {
+      const out: string[] = [];
+      if (existsSync(root)) await walk(root, out);
+      return out;
+    },
+    read: (rel) => fsp.readFile(abs(rel), "utf-8"),
+    async write(rel, content): Promise<void> {
+      await writeAtomic(abs(rel), (tmp) => fsp.writeFile(tmp, content, "utf-8"));
+    },
+    async delete(rel): Promise<void> {
+      await fsp.rm(abs(rel), { force: true });
+    },
+    async readBinary(rel): Promise<Uint8Array> {
+      return new Uint8Array(await fsp.readFile(abs(rel)));
+    },
+    async writeBinary(rel, bytes): Promise<void> {
+      const buf = bytes.buffer.slice(
+        bytes.byteOffset,
+        bytes.byteOffset + bytes.byteLength,
+      ) as ArrayBuffer;
+      await writeAtomic(abs(rel), (tmp) => fsp.writeFile(tmp, Buffer.from(buf)));
+    },
+  };
+}
+
+/** WRITABLE single-file watermark IO over `node:fs` (atomic temp + rename),
+ * at the SAME `<configDir>/plugins/exocortex/exosync-watermarks.local.json`
+ * the plugin writes — so plugin and CLI share one consistent base. */
+export function nodeWatermarkFileIO(filePath: string): WatermarkFileIO {
+  return {
+    async read(): Promise<string | null> {
+      try {
+        return await fsp.readFile(filePath, "utf-8");
+      } catch {
+        return null;
+      }
+    },
+    async writeAtomic(content: string): Promise<void> {
+      await fsp.mkdir(path.dirname(filePath), { recursive: true });
+      const tmp = `${filePath}.local.tmp`;
+      await fsp.writeFile(tmp, content, "utf-8");
+      await fsp.rename(tmp, filePath);
+    },
+  };
+}
+
+/**
+ * CLI full-materialization gate (D19). The CLI has no plugin profile-apply /
+ * staging state to consult, so the floor check is: mount folder exists +
+ * (for non-file spaces) non-empty. An empty FileSpace folder is a legitimate
+ * first-sync state (remote-wins pulls everything; no delete is inferred from
+ * an empty synthetic base), so it is NOT vetoed.
+ */
+export function nodeMaterializationCheck(
+  vaultPath: string,
+): MaterializationCheckPort {
+  return {
+    async check(spec: SyncRepoSpec) {
+      const dir = path.join(vaultPath, spec.localPath);
+      if (!existsSync(dir)) {
+        return {
+          fullyMaterialized: false,
+          reason: `mount folder ${spec.localPath} does not exist`,
+        };
+      }
+      let entries = 0;
+      try {
+        entries = (await fsp.readdir(dir)).length;
+      } catch {
+        return {
+          fullyMaterialized: false,
+          reason: `mount folder ${spec.localPath} is not readable`,
+        };
+      }
+      if (entries === 0 && spec.spaceKind !== "file") {
+        return {
+          fullyMaterialized: false,
+          reason: `mount folder ${spec.localPath} is empty (mid-mount?)`,
+        };
+      }
+      return { fullyMaterialized: true };
+    },
+  };
+}
+
+function printRepoResult(
+  r: RepoSyncResult,
+  out: (line: string) => void,
+): void {
+  const head = r.pushedSha !== undefined ? ` →@${r.pushedSha.slice(0, 7)}` : "";
+  out(
+    `${r.repoKey}${head}: ${r.status} — pulled ${r.pulledCount}, pushed ${r.pushedCount}, merged ${r.mergedCount}, quarantined ${r.quarantinedCount}${(r.pushedDeletes?.length ?? 0) > 0 ? `, deleted ${r.pushedDeletes!.length}` : ""}`,
+  );
+  if (r.detail !== undefined) out(`  ${r.detail}`);
+  for (const w of r.warnings) out(`  warn: ${w}`);
+  if ((r.deferredPaths?.length ?? 0) > 0) {
+    out(`  deferred (→ full sync): ${r.deferredPaths!.join(", ")}`);
+  }
+  if ((r.deferredDeletes?.length ?? 0) > 0) {
+    out(`  deferred deletes: ${r.deferredDeletes.join(", ")}`);
+  }
+}
+
+/** A repo result is a FAILURE (non-zero exit) when it left unresolved
+ * divergence or could not run. `synced` and `skipped-not-materialized` are
+ * clean. */
+function isFailureStatus(status: RepoSyncResult["status"]): boolean {
+  return (
+    status === "conflict" ||
+    status === "full-conflict" ||
+    status === "retry-exhausted" ||
+    status === "busy" ||
+    status === "auth-required" ||
+    status === "error"
+  );
+}
+
+/** Core flow, exported for tests. Returns the intended exit code:
+ * 0 = all repos clean; 1 = at least one repo unresolved/errored;
+ * 2 = VACUOUS (no materialized sync units found — a green 0 here would be a
+ * false certificate). */
+export async function runExosyncSync(
+  direction: SyncDirection,
+  opts: ExosyncSyncOptions,
+  deps: ExosyncSyncDeps = {},
+): Promise<number> {
+  const out = deps.out ?? ((line: string): void => console.log(line));
+  const vaultPath = path.resolve(opts.vault);
+  if (!existsSync(vaultPath)) {
+    throw new Error(`Vault path does not exist: ${vaultPath}`);
+  }
+
+  const token = resolveToken(opts, deps);
+  const pushService = new RestPushService({
+    token,
+    ...(opts.apiBase !== undefined ? { apiBase: opts.apiBase } : {}),
+  });
+  const transport =
+    deps.transportFactory?.(token, opts.apiBase) ?? pushService.transport();
+
+  const { specs, warnings } = collectVaultSpecs(vaultPath);
+  for (const w of warnings) out(`warn: ${w}`);
+  if (specs.length === 0) {
+    out(
+      "Nothing to sync — no materialized AssetSpaces with a GitHub source found in this vault.",
+    );
+    return 2;
+  }
+
+  const configDir = opts.configDir ?? ".obsidian";
+  const watermarkPath = path.join(
+    vaultPath,
+    configDir,
+    "plugins",
+    "exocortex",
+    WATERMARK_STORE_FILENAME,
+  );
+
+  let quarantine: QuarantinePort | undefined;
+  const quarantineUrl = opts.quarantineRepo?.trim() ?? "";
+  if (quarantineUrl.length > 0) {
+    const { owner, repo } = parseGitHubRepoUrl(quarantineUrl);
+    quarantine = new SyncedQuarantineStore({
+      // The engine wraps ITS transport internally; the quarantine store is
+      // the highest-volume caller, so it needs its own backoff wrap.
+      transport: withRateLimitBackoff(transport),
+      sha1: nodeSha1,
+      owner,
+      repo,
+      branch: SYNC_BRANCH,
+      redact: (m) => pushService.redact(m),
+    });
+  }
+
+  const engine = new SyncEngine({
+    transport,
+    watermarkStore: new FileWatermarkStore(nodeWatermarkFileIO(watermarkPath)),
+    materializationCheck: nodeMaterializationCheck(vaultPath),
+    localFilesFor: (spec) =>
+      nodeLocalFilesPort(path.join(vaultPath, spec.localPath)),
+    sha1: nodeSha1,
+    redact: (m) => pushService.redact(m),
+    commitMessage: (_spec, fileCount, deleteCount = 0) =>
+      `exosync: ${fileCount} change(s)${deleteCount > 0 ? `, ${deleteCount} deletion(s)` : ""} (CLI)`,
+    // GatedStructuredMerger without a SHACL gate still quarantines
+    // unresolvable merges (D17) — parity with the plugin's Phase B wiring.
+    mergeLayer: new GatedStructuredMerger(new StructuredMerger(coreSchemaYaml)),
+    ...(quarantine !== undefined ? { quarantine } : {}),
+    ...(opts.apiBase !== undefined ? { baseURL: opts.apiBase } : {}),
+  });
+
+  out(
+    `ExoSync ${direction}: ${specs.length} repo(s), vault ${vaultPath}${quarantine !== undefined ? " (quarantine configured)" : ""}`,
+  );
+  // Children before parents (deeper mount paths first) — D12 ordering.
+  const ordered = orderChildrenFirst(specs);
+  const results = await engine.syncAll(ordered, direction);
+
+  if (opts.json === true) {
+    out(JSON.stringify(results, null, 2));
+  } else {
+    for (const r of results) printRepoResult(r, out);
+    const totals = results.reduce(
+      (acc, r) => ({
+        pulled: acc.pulled + r.pulledCount,
+        pushed: acc.pushed + r.pushedCount,
+        merged: acc.merged + r.mergedCount,
+        quarantined: acc.quarantined + r.quarantinedCount,
+      }),
+      { pulled: 0, pushed: 0, merged: 0, quarantined: 0 },
+    );
+    out(
+      `Summary: ${results.length} repo(s) — pulled ${totals.pulled}, pushed ${totals.pushed}, merged ${totals.merged}, quarantined ${totals.quarantined}`,
+    );
+  }
+
+  return results.some((r) => isFailureStatus(r.status)) ? 1 : 0;
+}
+
+/** Shared option wiring for the three direction subcommands. */
+function withSyncOptions(cmd: Command): Command {
+  return cmd
+    .requiredOption("--vault <path>", "Vault root path")
+    .option(
+      "--config-dir <name>",
+      "Obsidian config dir name (watermark location)",
+      ".obsidian",
+    )
+    .option(
+      "--quarantine-repo <url>",
+      "Quarantine repo URL (https://github.com/<owner>/<repo>) — required for FileSpaces",
+    )
+    .option(
+      "--token <pat>",
+      "GitHub PAT (or env GITHUB_TOKEN / GH_TOKEN). Prefer --token-from-gh.",
+    )
+    .option("--token-from-gh", "Resolve the PAT via `gh auth token`")
+    .option("--json", "Print the full per-repo result array as JSON")
+    .option("--api-base <url>", "GitHub API base (testing)");
+}
+
+function makeDirectionAction(direction: SyncDirection) {
+  return async (options: ExosyncSyncOptions): Promise<void> => {
+    try {
+      process.exitCode = await runExosyncSync(direction, options);
+    } catch (error) {
+      ErrorHandler.handle(error, { command: `exosync ${direction}` });
+      process.exitCode = 1;
+    }
+  };
+}
+
+export function exosyncCommand(): Command {
+  const cmd = new Command("exosync").description(
+    "ExoSync over the GitHub REST API: sync/pull/push the materialized AssetSpace set (CLI parity with the plugin; RFC 4e4dc453 Phase B). Read-only divergence check: `exosync-parity`.",
+  );
+
+  withSyncOptions(
+    cmd
+      .command("sync")
+      .description("Full pull→merge→push cycle for every materialized repo"),
+  ).action(makeDirectionAction("sync"));
+
+  withSyncOptions(
+    cmd
+      .command("pull")
+      .description(
+        "Apply remote changes only (nothing leaves the device; local changes re-derive)",
+      ),
+  ).action(makeDirectionAction("pull"));
+
+  withSyncOptions(
+    cmd
+      .command("push")
+      .description(
+        "Send the local delta only (remote changes are pinned to re-derive on the next pull/sync)",
+      ),
+  ).action(makeDirectionAction("push"));
+
+  return cmd;
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -22,6 +22,7 @@ import { assetSpaceAddCommand } from "./commands/assetspace-add.js";
 import { resolveDepsCommand } from "./commands/resolve-deps.js";
 import { experimentalCommand } from "./commands/experimental.js";
 import { exosyncParityCommand } from "./commands/exosync-parity.js";
+import { exosyncCommand } from "./commands/exosync-sync.js";
 
 // Version injected at build time by esbuild (see esbuild.config.mjs)
 declare const __CLI_VERSION__: string;
@@ -78,6 +79,9 @@ export function createProgram(version?: string): Command {
 
   // RFC 4e4dc453 Phase E (E1) — ExoSync M1/M2 parity report (read-only)
   program.addCommand(exosyncParityCommand());
+
+  // RFC 4e4dc453 Phase B parity (EKA M3.7) — ExoSync sync/pull/push from the CLI
+  program.addCommand(exosyncCommand());
 
   return program;
 }

--- a/packages/cli/tests/unit/commands/exosync-sync.test.ts
+++ b/packages/cli/tests/unit/commands/exosync-sync.test.ts
@@ -1,0 +1,245 @@
+/**
+ * @jest-environment node
+ *
+ * Unit tests for `exocortex exosync <sync|pull|push>` (EKA M3.7 PA-exosync,
+ * RFC 4e4dc453 Phase B CLI parity).
+ *
+ * Two layers:
+ *  1. The NEW node:fs ports the command introduces — writable
+ *     `nodeLocalFilesPort`, writable `nodeWatermarkFileIO`,
+ *     `nodeMaterializationCheck` — exercised directly against a real temp
+ *     dir (this is the genuinely-new code; the engine itself is exhaustively
+ *     tested in the exocortex package).
+ *  2. `runExosyncSync` wiring end-to-end against the production-shape
+ *     `FakeGitHubRepo` (real git blob SHAs, force:false 422 semantics) — a
+ *     bootstrap `sync` then a `pull` that must materialise a remote-added
+ *     file on disk THROUGH the real writable port, proving port → engine →
+ *     disk composition + direction plumbing + exit codes.
+ */
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, existsSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import * as path from "node:path";
+import { FakeGitHubRepo, mdAsset } from "../../../../exocortex/tests/unit/services/sync/fakeGitHub";
+import {
+  nodeLocalFilesPort,
+  nodeWatermarkFileIO,
+  nodeMaterializationCheck,
+  runExosyncSync,
+  type ExosyncSyncOptions,
+} from "../../../src/commands/exosync-sync";
+import type { SyncRepoSpec } from "exocortex";
+
+const ASSET_SPACE_CLASS_UID = "73bd00e4-ccc0-4f3f-b20d-c4388c4588fb";
+const OWNER = "test-owner";
+const REPO = "test-repo";
+const MOUNT = `assetspaces/${OWNER}/${REPO}`;
+const FILE_A = "assets/a.md";
+const FILE_B = "assets/b.md";
+const FAKE_PAT = "ghp_" + "C".repeat(36);
+
+function mkTmp(prefix: string): string {
+  return mkdtempSync(path.join(tmpdir(), prefix));
+}
+
+describe("nodeLocalFilesPort (writable)", () => {
+  let root: string;
+  beforeEach(() => {
+    root = mkTmp("exosync-port-");
+  });
+  afterEach(() => rmSync(root, { recursive: true, force: true }));
+
+  it("writes a file atomically, creating parent directories", async () => {
+    const port = nodeLocalFilesPort(root);
+    await port.write("nested/deep/x.md", "hello");
+    expect(readFileSync(path.join(root, "nested/deep/x.md"), "utf-8")).toBe("hello");
+    expect(await port.read("nested/deep/x.md")).toBe("hello");
+    // No temp leftover.
+    expect(existsSync(path.join(root, "nested/deep/x.md.local.tmp"))).toBe(false);
+  });
+
+  it("lists repo-relative forward-slash paths and skips .git", async () => {
+    const port = nodeLocalFilesPort(root);
+    await port.write("a/b.md", "1");
+    await port.write("c.md", "2");
+    mkdirSync(path.join(root, ".git"), { recursive: true });
+    writeFileSync(path.join(root, ".git", "HEAD"), "ref: x");
+    const listed = (await port.list()).sort();
+    expect(listed).toEqual(["a/b.md", "c.md"]);
+  });
+
+  it("delete is a no-op when the path does not exist", async () => {
+    const port = nodeLocalFilesPort(root);
+    await expect(port.delete("ghost.md")).resolves.toBeUndefined();
+    await port.write("real.md", "x");
+    await port.delete("real.md");
+    expect(existsSync(path.join(root, "real.md"))).toBe(false);
+  });
+
+  it("round-trips binary content through writeBinary/readBinary", async () => {
+    const port = nodeLocalFilesPort(root);
+    const bytes = new Uint8Array([0, 1, 2, 255, 254]);
+    await port.writeBinary!("blob.bin", bytes);
+    expect([...(await port.readBinary!("blob.bin"))]).toEqual([...bytes]);
+  });
+});
+
+describe("nodeWatermarkFileIO", () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = mkTmp("exosync-wm-");
+  });
+  afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+  it("returns null when the watermark file is absent", async () => {
+    const io = nodeWatermarkFileIO(path.join(dir, "sub", "wm.json"));
+    expect(await io.read()).toBeNull();
+  });
+
+  it("writes atomically (creating parents) and round-trips", async () => {
+    const file = path.join(dir, "plugins", "exocortex", "wm.json");
+    const io = nodeWatermarkFileIO(file);
+    await io.writeAtomic('{"version":1}');
+    expect(await io.read()).toBe('{"version":1}');
+    expect(existsSync(`${file}.local.tmp`)).toBe(false);
+  });
+});
+
+describe("nodeMaterializationCheck", () => {
+  let vault: string;
+  beforeEach(() => {
+    vault = mkTmp("exosync-mat-");
+  });
+  afterEach(() => rmSync(vault, { recursive: true, force: true }));
+
+  const spec = (localPath: string, kind?: "asset" | "file"): SyncRepoSpec => ({
+    owner: OWNER,
+    repo: REPO,
+    branch: "main",
+    repoKey: `${OWNER}/${REPO}#main`,
+    localPath,
+    ...(kind === "file" ? { spaceKind: kind } : {}),
+  });
+
+  it("flags a missing mount folder as not materialized", async () => {
+    const check = nodeMaterializationCheck(vault);
+    const r = await check.check(spec("assetspaces/x/y"));
+    expect(r.fullyMaterialized).toBe(false);
+    expect(r.reason).toMatch(/does not exist/);
+  });
+
+  it("flags an empty non-file mount folder as not materialized", async () => {
+    mkdirSync(path.join(vault, MOUNT), { recursive: true });
+    const r = await nodeMaterializationCheck(vault).check(spec(MOUNT));
+    expect(r.fullyMaterialized).toBe(false);
+    expect(r.reason).toMatch(/empty/);
+  });
+
+  it("accepts a non-empty mount folder", async () => {
+    mkdirSync(path.join(vault, MOUNT), { recursive: true });
+    writeFileSync(path.join(vault, MOUNT, "a.md"), "x");
+    const r = await nodeMaterializationCheck(vault).check(spec(MOUNT));
+    expect(r.fullyMaterialized).toBe(true);
+  });
+
+  it("accepts an empty FileSpace folder (legitimate first-sync state)", async () => {
+    mkdirSync(path.join(vault, MOUNT), { recursive: true });
+    const r = await nodeMaterializationCheck(vault).check(spec(MOUNT, "file"));
+    expect(r.fullyMaterialized).toBe(true);
+  });
+});
+
+/** Build a temp vault with one materialized AssetSpace declaration + mount. */
+function makeVault(mountFiles: Record<string, string>): {
+  vault: string;
+  cleanup: () => void;
+} {
+  const vault = mkTmp("exosync-sync-test-");
+  writeFileSync(
+    path.join(vault, "space-decl.md"),
+    `---\nexo__Asset_uid: decl-uid\nexo__Instance_class:\n  - "[[${ASSET_SPACE_CLASS_UID}]]"\nexo__AssetSpace_source: https://github.com/${OWNER}/${REPO}\n---\n\nDeclaration\n`,
+  );
+  for (const [rel, content] of Object.entries(mountFiles)) {
+    const full = path.join(vault, MOUNT, rel);
+    mkdirSync(path.dirname(full), { recursive: true });
+    writeFileSync(full, content);
+  }
+  return { vault, cleanup: () => rmSync(vault, { recursive: true, force: true }) };
+}
+
+describe("runExosyncSync — wiring", () => {
+  it("returns 2 (vacuous) when no materialized AssetSpaces are present", async () => {
+    const vault = mkTmp("exosync-empty-");
+    const lines: string[] = [];
+    try {
+      const code = await runExosyncSync(
+        "sync",
+        { vault, token: FAKE_PAT },
+        { out: (l) => lines.push(l), env: {} },
+      );
+      expect(code).toBe(2);
+      expect(lines.join("\n")).toMatch(/Nothing to sync/);
+    } finally {
+      rmSync(vault, { recursive: true, force: true });
+    }
+  });
+
+  it("throws when no token is available", async () => {
+    const fx = makeVault({ [FILE_A]: mdAsset("u1") });
+    try {
+      await expect(
+        runExosyncSync("sync", { vault: fx.vault }, { env: {} }),
+      ).rejects.toThrow(/GitHub token is required/);
+    } finally {
+      fx.cleanup();
+    }
+  });
+
+  it("pull materialises a remote-added file on disk (port → engine → disk)", async () => {
+    const gh = new FakeGitHubRepo({ [FILE_A]: mdAsset("u1") });
+    const fx = makeVault({ [FILE_A]: mdAsset("u1") });
+    const out = (over: Partial<ExosyncSyncOptions> = {}) => ({
+      transportFactory: () => gh.transport(),
+      out: () => {},
+      env: {},
+      ...over,
+    });
+    try {
+      // Bootstrap: local == remote → clean adopt, watermark established.
+      const bootstrap = await runExosyncSync(
+        "sync",
+        { vault: fx.vault, token: FAKE_PAT },
+        out(),
+      );
+      expect(bootstrap).toBe(0);
+      const wmPath = path.join(
+        fx.vault,
+        ".obsidian",
+        "plugins",
+        "exocortex",
+        "exosync-watermarks.local.json",
+      );
+      expect(existsSync(wmPath)).toBe(true);
+
+      // Device B adds FILE_B on the remote.
+      gh.commitDirect("main", { [FILE_B]: mdAsset("u2", "remote add") }, "device B");
+      expect(existsSync(path.join(fx.vault, MOUNT, FILE_B))).toBe(false);
+
+      // Pull applies it to disk through the real node:fs writable port.
+      const lines: string[] = [];
+      const pull = await runExosyncSync(
+        "pull",
+        { vault: fx.vault, token: FAKE_PAT },
+        out({ out: (l: string) => lines.push(l) }),
+      );
+      expect(pull).toBe(0);
+      const pulledPath = path.join(fx.vault, MOUNT, FILE_B);
+      expect(existsSync(pulledPath)).toBe(true);
+      expect(readFileSync(pulledPath, "utf-8")).toBe(mdAsset("u2", "remote add"));
+      expect(lines.join("\n")).toMatch(/pulled 1/);
+      // Pull pushes nothing — the remote head did not move further.
+      expect(gh.headFiles().has(FILE_B)).toBe(true);
+    } finally {
+      fx.cleanup();
+    }
+  });
+});


### PR DESCRIPTION
## What

Adds `exocortex exosync <sync|pull|push>` — the CLI counterpart to the plugin's «Exocortex: Sync / Pull / Push» commands. EKA M3.7 (PA-exosync); RFC `4e4dc453` Phase B parity.

Until now the CLI's only ExoSync surface was `exosync-parity` (**read-only** divergence report) + `experimental rest-push` (single-file write). There was no full bidirectional sync from the CLI.

## How

Drives the **same platform-free `SyncEngine`** the plugin composes in `SyncDepsFactory.buildSyncEngine`, but wired from `node:fs` instead of Obsidian's `vault.adapter`. **Zero engine edits** — the only platform-specific pieces are the new injected ports:

- `nodeLocalFilesPort` — **writable** `LocalFilesPort` (atomic temp+rename write, parent-dir creation, no-op delete, binary round-trip)
- `nodeWatermarkFileIO` — **writable** watermark IO at the *same* `exosync-watermarks.local.json` path the plugin uses (plugin + CLI share one base)
- `nodeMaterializationCheck` — D19 gate floor (mount folder exists + non-empty; empty FileSpace = legitimate first-sync)

The merge layer (`GatedStructuredMerger` + `StructuredMerger`), quarantine sink (`SyncedQuarantineStore`), watermark store (`FileWatermarkStore`) and sync-unit collection (`collectVaultSpecs`, shared with `exosync-parity`) are reused **verbatim** from the core package.

Directions (#3473): `sync` = full pull→merge→push; `pull` = apply remote only; `push` = send local delta only. Token precedence + exit-code semantics mirror `exosync-parity` (`0` clean · `1` unresolved/errored · `2` vacuous). FileSpaces require `--quarantine-repo` (D18 remote-wins).

## Scope

- `packages/cli/` only — **consumer wiring**, the `packages/exocortex/src/services/sync/` engine is untouched.

## Tests

13 unit tests (`exosync-sync.test.ts`):
- writable `nodeLocalFilesPort` (atomic write + parent dirs, `.git` skip, no-op delete, binary round-trip)
- `nodeWatermarkFileIO` (absent→null, atomic round-trip)
- `nodeMaterializationCheck` (missing / empty-non-file / non-empty / empty-FileSpace)
- `runExosyncSync` wiring: vacuous→exit 2, token-required throw, **e2e `pull` materialises a remote-added file on disk** through the real node:fs port + engine + production-shape `FakeGitHubRepo` (proves port → engine → disk).

`npm run check:types` clean · CLI bundle builds · `exosync-parity` test still green (9/9) · archgate 20/20.

## Docs

`docs/exosync.md` — new "From the CLI" section + cross-process watermark caveat.