### PR TITLE
fix(plugin-mobile): bootstrap-vault + add-assetspace on mobile via RestAssetSpaceMount (#3535)

### DIFF
--- a/packages/obsidian-plugin/src/ExocortexPlugin.ts
+++ b/packages/obsidian-plugin/src/ExocortexPlugin.ts
@@ -3099,11 +3099,15 @@ export default class ExocortexPlugin extends Plugin {
     });
 
     // RFC 13da049f Phase 6.2/6.3 — Bootstrap vault + Add AssetSpace by URL.
-    // Desktop-only: both reuse the Phase 5 apply deps (AssetSpaceManager
-    // REST pull + GitSubmoduleOps staging move / .gitmodules). Registered only
-    // when those deps are wired (desktop + vault.adapter.basePath available).
-    if (applyDeps !== null) {
-      this.registerBootstrapCommands(applyDeps, localDataStore);
+    // Desktop reuses the Phase 5 apply deps (AssetSpaceManager REST pull +
+    // GitSubmoduleOps staging move / .gitmodules). Mobile (#3535) reuses the
+    // cross-platform RestAssetSpaceMount (RFC 01a83de8) — the same adapter
+    // apply-profile already mounts through — so a fresh mobile vault can
+    // cold-start (bootstrap → add registry/profiles → apply-profile) without a
+    // desktop. The Desktop↔Mobile Command Parity invariant requires both
+    // surfaces; the gate mirrors the apply-profile gate above.
+    if (applyDeps !== null || (Platform.isMobile && restMount !== null)) {
+      this.registerBootstrapCommands(applyDeps, restMount, localDataStore);
     }
 
     this.logger.info(
@@ -3113,15 +3117,22 @@ export default class ExocortexPlugin extends Plugin {
 
   /**
    * Wire + register the RFC 13da049f Phase 6.2/6.3 palette commands
-   * («Bootstrap vault» + «Add AssetSpace by URL»). Reuses the Phase 5
-   * `AssetSpaceManager` (REST tarball pull) and `GitSubmoduleOps` (staging
-   * move + `.gitmodules` text manipulation) — no REST/security logic is
-   * duplicated. Desktop-only; the caller gates on `applyDeps !== null`.
+   * («Bootstrap vault» + «Add AssetSpace by URL»). On DESKTOP reuses the Phase 5
+   * `AssetSpaceManager` (REST tarball pull) + `GitSubmoduleOps` (staging move +
+   * `.gitmodules`) — no REST/security logic duplicated. On MOBILE (#3535,
+   * `applyDeps === null`) reuses the cross-platform `RestAssetSpaceMount`
+   * (RFC 01a83de8) — `vault.adapter` materialise, no Node `fs`. Both commands
+   * register on both platforms (Desktop↔Mobile Command Parity).
+   *
+   * Prefers the desktop git path when wired; falls back to the REST mount only
+   * when `applyDeps === null` (mobile — the gate guarantees `restMount !== null`
+   * there).
    */
   private registerBootstrapCommands(
     applyDeps: {
       gitOps: GitSubmoduleOps;
-    },
+    } | null,
+    restMount: RestAssetSpaceMount | null,
     localDataStore: PluginLocalDataStore,
   ): void {
     const deriveFolderName = (url: string): string => {
@@ -3129,19 +3140,30 @@ export default class ExocortexPlugin extends Plugin {
       return repo.startsWith("exoas-") ? repo.slice("exoas-".length) : repo;
     };
 
+    // Mobile path: desktop deps unavailable (`applyDeps === null`) but the
+    // cross-platform `RestAssetSpaceMount` is wired. `RestAssetSpaceMount`
+    // structurally satisfies `IRestBootstrapMount` (mount() → {sha},
+    // readGitmodulesEntries()).
+    const restStrategy =
+      applyDeps === null && restMount !== null ? restMount : undefined;
+
     const bootstrapCommands = new BootstrapAssetSpaceCommands({
       // Issue #3382 — rebuild the AssetSpaceManager per invocation from the
       // CURRENT stored PAT instead of reusing the onload-captured
       // `applyDeps.assetSpaceManager` (which froze an empty-PAT client
       // when the vault had no PAT at load time). A PAT configured after onload
       // now authenticates Bootstrap / Add-AssetSpace pulls without a reload.
-      getPuller: () =>
-        buildAssetSpacePuller({
-          app: this.app,
-          localDataStore,
-          notifier: this.notifier,
-        }),
-      gitOps: applyDeps.gitOps,
+      // Omitted on the mobile REST path (restStrategy handles materialise).
+      getPuller: restStrategy
+        ? undefined
+        : () =>
+            buildAssetSpacePuller({
+              app: this.app,
+              localDataStore,
+              notifier: this.notifier,
+            }),
+      gitOps: applyDeps?.gitOps,
+      restMount: restStrategy,
       localStore: localDataStore,
       vaultExists: (p) => this.app.vault.adapter.exists(p),
       listFolder: (dir) => this.app.vault.adapter.list(dir),

--- a/packages/obsidian-plugin/src/infrastructure/adapters/BootstrapAssetSpaceCommands.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/BootstrapAssetSpaceCommands.ts
@@ -15,9 +15,12 @@
  * is injected via {@link BootstrapAssetSpaceCommandsDeps} so the class is fully
  * unit-testable with fakes. Real wiring lives in `ExocortexPlugin`.
  *
- * Desktop-only (Phase 6 scope, like Phase 5): the injected puller / gitOps throw
- * on mobile, and the plugin registers these commands only when desktop deps are
- * available.
+ * Cross-platform (#3535): on DESKTOP the injected `getPuller` + `gitOps` run the
+ * staging-pull + `.gitmodules` path (Node `fs`); on MOBILE an injected
+ * {@link IRestBootstrapMount} (RFC 01a83de8 `RestAssetSpaceMount`) materialises
+ * via `vault.adapter` (no Node `fs`). The plugin wires whichever is available
+ * (`applyDeps` on desktop, `restMount` on mobile) and registers both commands on
+ * both platforms — Desktop↔Mobile Command Parity invariant.
  *
  * Commands provided:
  *   1. `Exocortex: Bootstrap vault` — cold-start an empty vault with the TS-floor
@@ -64,6 +67,36 @@ export interface IGitSubmoduleOps {
   ): Promise<{ added: boolean }>;
 }
 
+/**
+ * Cross-platform (incl. iOS) materialise + `.gitmodules` strategy — the
+ * mobile-capable counterpart of {@link IAssetSpacePuller} + {@link IGitSubmoduleOps}
+ * (#3535). A single combined op (pull tarball → materialise into the vault
+ * folder → write `.gitmodules`) over `vault.adapter`, with NO Node `fs` /
+ * staging dir / file-only registry split. Satisfied structurally by
+ * `RestAssetSpaceMount` (RFC 01a83de8) — the same adapter that `apply-profile`
+ * already mounts through on mobile.
+ *
+ * When injected, it fully replaces the desktop `getPuller` + `gitOps` path:
+ * `.gitmodules` becomes the single source of truth that `apply-profile`
+ * (`listAllAssetSpaceInfos`) reads, written regardless of `.git` presence (a
+ * fresh mobile vault has no `.git`).
+ */
+export interface IRestBootstrapMount {
+  /**
+   * Pull `gitUrl`'s tarball, materialise it into `submodulePath`, and write the
+   * `.gitmodules` entry — all via `vault.adapter`. Returns the tarball SHA.
+   */
+  mount(
+    gitUrl: string,
+    submodulePath: string,
+    ref: string,
+  ): Promise<{ sha: string }>;
+  /** Read the current `.gitmodules` (path, url) entries via `vault.adapter`. */
+  readGitmodulesEntries(): Promise<
+    Array<{ submodulePath: string; url: string }>
+  >;
+}
+
 /** Subset of {@link PluginLocalDataStore} used for AC10 file-only tracking. */
 export interface IFileOnlyAssetSpaceStore {
   upsertFileOnlyAssetSpace(entry: {
@@ -91,9 +124,16 @@ export interface BootstrapAssetSpaceCommandsDeps {
    * plugin loaded → 401/404 on private-repo pulls. Production wiring resolves
    * this to {@link ApplyDepsFactory.buildAssetSpacePuller}.
    */
-  getPuller: () => Promise<IAssetSpacePuller>;
-  gitOps: IGitSubmoduleOps;
-  localStore: IFileOnlyAssetSpaceStore;
+  getPuller?: () => Promise<IAssetSpacePuller>;
+  gitOps?: IGitSubmoduleOps;
+  localStore?: IFileOnlyAssetSpaceStore;
+  /**
+   * Mobile (#3535) cross-platform materialise strategy. When wired, it replaces
+   * the desktop `getPuller` + `gitOps` + `localStore` trio entirely. Exactly
+   * one of {desktop trio, `restMount`} must be present — desktop wiring passes
+   * the trio; mobile wiring passes `restMount`.
+   */
+  restMount?: IRestBootstrapMount;
   /** `vault.adapter.exists(path)` wrapper. */
   vaultExists: (path: string) => Promise<boolean>;
   /** `vault.adapter.list(dir)` wrapper. */
@@ -166,7 +206,7 @@ export class BootstrapAssetSpaceCommands {
    *   - `bootstrapped` — at least one `assetspaces/<ns>/` folder has content.
    */
   async detectVaultState(): Promise<VaultBootstrapState> {
-    const entries = await this.d.gitOps.readGitmodulesEntries();
+    const entries = await this.listTrackedEntries();
     const materialized = await this.hasMaterializedAssetSpaces();
     if (entries.length > 0) {
       return materialized ? "bootstrapped" : "clone-needs-fetch";
@@ -213,7 +253,10 @@ export class BootstrapAssetSpaceCommands {
     }
 
     const isGit = await this.d.isGitVault();
-    if (!isGit) {
+    // On mobile (restMount) the REST mount always writes `.gitmodules` via
+    // vault.adapter regardless of `.git` presence (apply-profile reads it), so
+    // the desktop "file-only mode" notice would be misleading — suppress it.
+    if (!isGit && this.d.restMount === undefined) {
       this.d.notify(
         "Vault is not a git repository — bootstrapping in file-only mode (no .gitmodules; AssetSpaces tracked device-locally).",
       );
@@ -288,7 +331,9 @@ export class BootstrapAssetSpaceCommands {
     }
 
     const isGit = await this.d.isGitVault();
-    if (!isGit) {
+    // See invokeBootstrap: the mobile REST path writes `.gitmodules` regardless,
+    // so the desktop "file-only mode" notice does not apply.
+    if (!isGit && this.d.restMount === undefined) {
       this.d.notify(
         "Vault is not a git repository — adding in file-only mode (no .gitmodules; tracked device-locally).",
       );
@@ -322,7 +367,7 @@ export class BootstrapAssetSpaceCommands {
   private async fetchTrackedAssetSpaces(): Promise<void> {
     let entries: Array<{ submodulePath: string; url: string }>;
     try {
-      entries = await this.d.gitOps.readGitmodulesEntries();
+      entries = await this.listTrackedEntries();
     } catch (e) {
       this.d.notify(`Bootstrap: could not read .gitmodules — ${this.msg(e)}`);
       return;
@@ -365,15 +410,44 @@ export class BootstrapAssetSpaceCommands {
     submodulePath: string,
     isGit: boolean,
   ): Promise<MaterializeResult> {
+    // Mobile (#3535 / RFC 01a83de8): one cross-platform op — pull the tarball,
+    // materialise it into the vault folder, and write the `.gitmodules` entry,
+    // all via `vault.adapter` (no Node fs, no staging dir, no file-only
+    // registry split). `.gitmodules` is the single source of truth that
+    // apply-profile (`listAllAssetSpaceInfos`) reads, so it is written
+    // regardless of the `isGit` flag (a fresh mobile vault has no `.git`).
+    if (this.d.restMount !== undefined) {
+      const { sha } = await this.d.restMount.mount(
+        url,
+        submodulePath,
+        this.ref,
+      );
+      return { folderName: submodulePath, sha };
+    }
+
+    // Desktop path — staging tarball pull + rename-into-vault + `.gitmodules`
+    // append (git vault) / file-only registry (AC10 non-git vault).
+    const getPuller = this.d.getPuller;
+    const gitOps = this.d.gitOps;
+    const localStore = this.d.localStore;
+    if (
+      getPuller === undefined ||
+      gitOps === undefined ||
+      localStore === undefined
+    ) {
+      throw new Error(
+        "BootstrapAssetSpaceCommands: desktop materialise requires getPuller + gitOps + localStore (or wire restMount for mobile)",
+      );
+    }
     // Resolve the puller lazily so the pull uses the PAT current at
     // command-execution time, not the one captured at plugin onload (#3382).
-    const puller = await this.d.getPuller();
+    const puller = await getPuller();
     const result = await puller.pullAssetSpace(
       `bootstrap-${basename(submodulePath)}`,
       url,
       this.ref,
     );
-    await this.d.gitOps.renameIntoVault(result.stagingPath, submodulePath);
+    await gitOps.renameIntoVault(result.stagingPath, submodulePath);
     // Issue #3391: `renameIntoVault` MOVED the staging dir into the vault, so
     // its StagingDirTracker entry now points at a path that no longer exists.
     // `pullAssetSpace` keeps the dir alive on success by design (caller owns
@@ -388,9 +462,9 @@ export class BootstrapAssetSpaceCommands {
     // cleanup convention (`stagingTracker.release(...).catch(() => undefined)`).
     await puller.releaseStaging(result.stagingPath).catch(() => undefined);
     if (isGit) {
-      await this.d.gitOps.appendGitmodulesEntry(submodulePath, url);
+      await gitOps.appendGitmodulesEntry(submodulePath, url);
     } else {
-      await this.d.localStore.upsertFileOnlyAssetSpace({
+      await localStore.upsertFileOnlyAssetSpace({
         folderName: submodulePath,
         url,
         sha: result.sha,
@@ -444,6 +518,25 @@ export class BootstrapAssetSpaceCommands {
     } catch {
       // Best-effort re-index; failure must not surface as a bootstrap error.
     }
+  }
+
+  /**
+   * Read the `.gitmodules` (path, url) entries via whichever strategy is wired —
+   * the mobile {@link IRestBootstrapMount} (vault.adapter) or the desktop
+   * {@link IGitSubmoduleOps} (Node fs). Throws if neither is wired.
+   */
+  private async listTrackedEntries(): Promise<
+    Array<{ submodulePath: string; url: string }>
+  > {
+    if (this.d.restMount !== undefined) {
+      return this.d.restMount.readGitmodulesEntries();
+    }
+    if (this.d.gitOps !== undefined) {
+      return this.d.gitOps.readGitmodulesEntries();
+    }
+    throw new Error(
+      "BootstrapAssetSpaceCommands: neither restMount (mobile) nor gitOps (desktop) wired",
+    );
   }
 
   private msg(e: unknown): string {

--- a/packages/obsidian-plugin/src/infrastructure/adapters/BootstrapAssetSpaceCommands.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/BootstrapAssetSpaceCommands.ts
@@ -129,9 +129,12 @@ export interface BootstrapAssetSpaceCommandsDeps {
   localStore?: IFileOnlyAssetSpaceStore;
   /**
    * Mobile (#3535) cross-platform materialise strategy. When wired, it replaces
-   * the desktop `getPuller` + `gitOps` + `localStore` trio entirely. Exactly
-   * one of {desktop trio, `restMount`} must be present — desktop wiring passes
-   * the trio; mobile wiring passes `restMount`.
+   * the desktop `getPuller` + `gitOps` path entirely (the REST mount does the
+   * pull + materialise + `.gitmodules` write itself). Desktop wiring passes the
+   * `getPuller` + `gitOps` + `localStore` trio (no `restMount`); mobile wiring
+   * passes `restMount` (and may still pass `localStore`, which is unused on the
+   * REST path). At least one of {`getPuller` + `gitOps`, `restMount`} must be
+   * present, else `materialize` / `listTrackedEntries` throw.
    */
   restMount?: IRestBootstrapMount;
   /** `vault.adapter.exists(path)` wrapper. */

--- a/packages/obsidian-plugin/src/infrastructure/adapters/RestAssetSpaceMount.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/RestAssetSpaceMount.ts
@@ -1,7 +1,11 @@
 import type { App, DataAdapter } from "obsidian";
 import { GitHubRestClient } from "./GitHubRestClient";
 import { parseGitHubURL } from "./AssetSpaceManager";
-import { validateVaultPathArg } from "./GitSubmoduleOps";
+import {
+  validateVaultPathArg,
+  parseGitmodulesEntries,
+  type GitmodulesEntry,
+} from "./GitSubmoduleOps";
 import {
   mountAssetSpaceFiles,
   appendGitmodulesEntry,
@@ -130,6 +134,24 @@ export class RestAssetSpaceMount {
     if (await this.adapter.exists(safePath)) {
       await this.adapter.rmdir(safePath, true);
     }
+  }
+
+  /**
+   * Read the current `.gitmodules` (path, url) entries via `vault.adapter` —
+   * the mobile-capable counterpart of
+   * {@link GitSubmoduleOps.readGitmodulesEntries} (#3535). Reuses the shared
+   * pure-text {@link parseGitmodulesEntries} parser (no Node `fs`). A missing
+   * `.gitmodules` yields `[]`.
+   *
+   * Used by the mobile Bootstrap / Add-AssetSpace flow
+   * ({@link BootstrapAssetSpaceCommands}) to classify the vault state (empty vs
+   * clone-needs-fetch vs bootstrapped) without the desktop-only
+   * `GitSubmoduleOps`.
+   */
+  public async readGitmodulesEntries(): Promise<GitmodulesEntry[]> {
+    if (!(await this.adapter.exists(GITMODULES))) return [];
+    const raw = await this.adapter.read(GITMODULES);
+    return parseGitmodulesEntries(raw);
   }
 
   // ───────────────────────────── ports ─────────────────────────────

--- a/packages/obsidian-plugin/tests/unit/infrastructure/adapters/BootstrapAssetSpaceCommands.test.ts
+++ b/packages/obsidian-plugin/tests/unit/infrastructure/adapters/BootstrapAssetSpaceCommands.test.ts
@@ -4,6 +4,7 @@ import {
   type IAssetSpacePuller,
   type IGitSubmoduleOps,
   type IFileOnlyAssetSpaceStore,
+  type IRestBootstrapMount,
 } from "../../../../src/infrastructure/adapters/BootstrapAssetSpaceCommands";
 
 const EXO_URL = "https://github.com/kitelev/exoas-exo";
@@ -543,5 +544,200 @@ describe("BootstrapAssetSpaceCommands — staging-dir release (Issue #3391)", ()
     expect(h.puller.releaseStaging).toHaveBeenCalledTimes(2);
     expect(h.activeStagingDirs).toEqual([]);
     expect(h.notices.some((n) => /Fetched 2\/2/.test(n))).toBe(true);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// Mobile (#3535) — the cross-platform `restMount` strategy. Constructed with
+// ONLY `restMount` (no getPuller / gitOps / localStore — those throw on mobile,
+// where there is no Node fs). This whole describe block is the revert-verify
+// anchor for the BootstrapAssetSpaceCommands mobile branch: remove the
+// `restMount` branch in `materialize` / `listTrackedEntries` and every test
+// here FAILS (the class falls through to the missing desktop deps and throws).
+// ─────────────────────────────────────────────────────────────────────────
+
+interface MobileHarness {
+  cmds: BootstrapAssetSpaceCommands;
+  restMount: jest.Mocked<IRestBootstrapMount>;
+  notices: string[];
+}
+
+function makeMobileHarness(opts: {
+  gitmodulesEntries?: Array<{ submodulePath: string; url: string }>;
+  materializedFolders?: Record<string, string[]>;
+  bootstrapUrls?: { exoUrl: string; exocmdUrl: string } | null;
+  addUrl?: { url: string } | null;
+  confirm?: boolean;
+} = {}): MobileHarness {
+  const notices: string[] = [];
+  const gitmodulesEntries = opts.gitmodulesEntries ?? [];
+  const materialized = opts.materializedFolders ?? {};
+
+  // Mobile materialise strategy — one combined op returning the sha (mirrors
+  // RestAssetSpaceMount.mount), plus the vault.adapter-backed .gitmodules read.
+  const restMount = {
+    mount: jest.fn(
+      async (_gitUrl: string, _submodulePath: string, _ref: string) => ({
+        sha: "deadbee",
+      }),
+    ),
+    readGitmodulesEntries: jest.fn(async () => [...gitmodulesEntries]),
+  } as jest.Mocked<IRestBootstrapMount>;
+
+  const folderHasContent = Object.keys(materialized).length > 0;
+  // Fresh mobile vault: NO `.git` (isGitVault → false) but restMount is wired.
+  const vaultExists = jest.fn(async (p: string) => {
+    if (p === "assetspaces") return folderHasContent;
+    if (p === ".git") return false;
+    return false;
+  });
+  const listFolder = jest.fn(async (dir: string) => {
+    if (dir === "assetspaces") {
+      return {
+        files: [],
+        folders: Object.keys(materialized).map((f) => `assetspaces/${f}`),
+      };
+    }
+    const ns = dir.replace(/^assetspaces\//, "");
+    const files = (materialized[ns] ?? []).map((f) => `${dir}/${f}`);
+    return { files, folders: [] };
+  });
+
+  const deriveFolderName = (url: string): string => {
+    const m = url.match(/github\.com\/[^/]+\/([^/]+)$/);
+    const repo = m ? m[1] : "unknown";
+    return repo.startsWith("exoas-") ? repo.slice("exoas-".length) : repo;
+  };
+
+  const deps: BootstrapAssetSpaceCommandsDeps = {
+    // Desktop trio deliberately OMITTED — only restMount is wired (mobile).
+    restMount,
+    vaultExists,
+    listFolder,
+    isGitVault: () => vaultExists(".git"),
+    validateUrl: (url) => {
+      if (!/^https:\/\/github\.com\/[^/]+\/[^/]+$/.test(url)) {
+        throw new Error(`invalid url: ${url}`);
+      }
+    },
+    deriveFolderName,
+    promptBootstrapUrls: jest.fn(async () =>
+      opts.bootstrapUrls === undefined
+        ? { exoUrl: EXO_URL, exocmdUrl: EXOCMD_URL }
+        : opts.bootstrapUrls,
+    ),
+    promptAddAssetSpaceUrl: jest.fn(async () =>
+      opts.addUrl === undefined ? { url: PMBOK_URL } : opts.addUrl,
+    ),
+    confirm: jest.fn(async () => opts.confirm ?? true),
+    notify: (m: string) => notices.push(m),
+  };
+
+  return { cmds: new BootstrapAssetSpaceCommands(deps), restMount, notices };
+}
+
+describe("BootstrapAssetSpaceCommands — mobile restMount strategy (#3535)", () => {
+  it("empty vault → bootstrap materialises exo + exocmd via restMount.mount (Maven paths), writes .gitmodules, no Node-fs deps", async () => {
+    const h = makeMobileHarness();
+    await h.cmds.invokeBootstrap();
+
+    // detectVaultState read .gitmodules via the mobile vault.adapter path.
+    expect(h.restMount.readGitmodulesEntries).toHaveBeenCalled();
+    // One combined cross-platform op per floor AssetSpace, at the Maven path.
+    expect(h.restMount.mount).toHaveBeenCalledTimes(2);
+    expect(h.restMount.mount).toHaveBeenNthCalledWith(
+      1,
+      EXO_URL,
+      "assetspaces/kitelev/exoas-exo",
+      "main",
+    );
+    expect(h.restMount.mount).toHaveBeenNthCalledWith(
+      2,
+      EXOCMD_URL,
+      "assetspaces/kitelev/exoas-exocmd",
+      "main",
+    );
+    expect(h.notices.some((n) => /Bootstrap complete/.test(n))).toBe(true);
+    // The misleading desktop "file-only mode" notice MUST NOT fire on mobile,
+    // even though there is no `.git` — restMount writes .gitmodules regardless.
+    expect(h.notices.some((n) => /file-only mode/.test(n))).toBe(false);
+  });
+
+  it("empty vault, core-only (empty exocmd URL) → mounts exo only", async () => {
+    const h = makeMobileHarness({
+      bootstrapUrls: { exoUrl: EXO_URL, exocmdUrl: "" },
+    });
+    await h.cmds.invokeBootstrap();
+
+    expect(h.restMount.mount).toHaveBeenCalledTimes(1);
+    expect(h.restMount.mount).toHaveBeenNthCalledWith(
+      1,
+      EXO_URL,
+      "assetspaces/kitelev/exoas-exo",
+      "main",
+    );
+    expect(h.notices.some((n) => /knowledge-only/.test(n))).toBe(true);
+  });
+
+  it("addAssetSpace → mounts the single URL-derived AssetSpace via restMount.mount", async () => {
+    const h = makeMobileHarness();
+    await h.cmds.invokeAddAssetSpace();
+
+    expect(h.restMount.mount).toHaveBeenCalledTimes(1);
+    expect(h.restMount.mount).toHaveBeenNthCalledWith(
+      1,
+      PMBOK_URL,
+      "assetspaces/pmbok-ontology",
+      "main",
+    );
+    expect(h.notices.some((n) => /AssetSpace added/.test(n))).toBe(true);
+    expect(h.notices.some((n) => /file-only mode/.test(n))).toBe(false);
+  });
+
+  it("already-bootstrapped vault → no mount (use Add AssetSpace)", async () => {
+    const h = makeMobileHarness({
+      materializedFolders: { "kitelev/exoas-exo": ["asset.md"] },
+    });
+    await h.cmds.invokeBootstrap();
+
+    expect(h.restMount.mount).not.toHaveBeenCalled();
+    expect(h.notices.some((n) => /already has AssetSpaces/.test(n))).toBe(true);
+  });
+
+  it("EC2 clone-needs-fetch → re-materialises each tracked entry via restMount.mount", async () => {
+    const h = makeMobileHarness({
+      gitmodulesEntries: [
+        { submodulePath: "assetspaces/kitelev/exoas-exo", url: EXO_URL },
+        { submodulePath: "assetspaces/kitelev/exoas-exocmd", url: EXOCMD_URL },
+      ],
+      materializedFolders: {},
+      confirm: true,
+    });
+    await h.cmds.invokeBootstrap();
+
+    expect(h.restMount.mount).toHaveBeenCalledTimes(2);
+    expect(h.restMount.mount).toHaveBeenCalledWith(
+      EXO_URL,
+      "assetspaces/kitelev/exoas-exo",
+      "main",
+    );
+    expect(h.restMount.mount).toHaveBeenCalledWith(
+      EXOCMD_URL,
+      "assetspaces/kitelev/exoas-exocmd",
+      "main",
+    );
+    expect(h.notices.some((n) => /Fetched 2\/2/.test(n))).toBe(true);
+  });
+
+  it("detectVaultState classifies via restMount.readGitmodulesEntries (no gitOps)", async () => {
+    const h = makeMobileHarness({
+      gitmodulesEntries: [
+        { submodulePath: "assetspaces/kitelev/exoas-exo", url: EXO_URL },
+      ],
+      materializedFolders: { "kitelev/exoas-exo": ["a.md"] },
+    });
+    const state = await h.cmds.detectVaultState();
+    expect(state).toBe("bootstrapped");
+    expect(h.restMount.readGitmodulesEntries).toHaveBeenCalled();
   });
 });

--- a/packages/obsidian-plugin/tests/unit/infrastructure/adapters/RestAssetSpaceMount.test.ts
+++ b/packages/obsidian-plugin/tests/unit/infrastructure/adapters/RestAssetSpaceMount.test.ts
@@ -344,3 +344,48 @@ describe("RestAssetSpaceMount.unmount", () => {
     );
   });
 });
+
+describe("RestAssetSpaceMount.readGitmodulesEntries (#3535 — mobile vault state)", () => {
+  it("returns [] when .gitmodules is absent", async () => {
+    const adapter = new InMemoryAdapter();
+    const mount = makeMount(adapter, makeFakeClient(new ArrayBuffer(0)));
+    await expect(mount.readGitmodulesEntries()).resolves.toEqual([]);
+  });
+
+  it("parses (path, url) entries from a vault.adapter .gitmodules", async () => {
+    const adapter = new InMemoryAdapter();
+    await adapter.write(
+      ".gitmodules",
+      `[submodule "assetspaces/kitelev/exoas-exo"]\n` +
+        `\tpath = assetspaces/kitelev/exoas-exo\n` +
+        `\turl = https://github.com/kitelev/exoas-exo\n` +
+        `[submodule "assetspaces/kitelev/exoas-exocmd"]\n` +
+        `\tpath = assetspaces/kitelev/exoas-exocmd\n` +
+        `\turl = https://github.com/kitelev/exoas-exocmd\n`,
+    );
+    const mount = makeMount(adapter, makeFakeClient(new ArrayBuffer(0)));
+    await expect(mount.readGitmodulesEntries()).resolves.toEqual([
+      {
+        submodulePath: "assetspaces/kitelev/exoas-exo",
+        url: "https://github.com/kitelev/exoas-exo",
+      },
+      {
+        submodulePath: "assetspaces/kitelev/exoas-exocmd",
+        url: "https://github.com/kitelev/exoas-exocmd",
+      },
+    ]);
+  });
+
+  it("round-trips an entry written by mount() (mount → read)", async () => {
+    const adapter = new InMemoryAdapter();
+    const tarball = await makeTarball("kitelev-exoas-ems-abc1234", [
+      { name: "README.md", data: new TextEncoder().encode("# EMS\n") },
+    ]);
+    const mount = makeMount(adapter, makeFakeClient(tarball));
+    await mount.mount(URL_OK, PATH_OK, "main");
+
+    await expect(mount.readGitmodulesEntries()).resolves.toEqual([
+      { submodulePath: PATH_OK, url: URL_OK },
+    ]);
+  });
+});

--- a/packages/obsidian-plugin/tests/unit/integration/BootstrapAssetSpaceMobile.integration.test.ts
+++ b/packages/obsidian-plugin/tests/unit/integration/BootstrapAssetSpaceMobile.integration.test.ts
@@ -1,0 +1,287 @@
+/**
+ * @jest-environment node
+ *
+ * Reason: the REST mount decompresses tarballs via Web Streams
+ * (CompressionStream/DecompressionStream) which jest-environment-jsdom does NOT
+ * expose. The `node` environment supplies both.
+ *
+ * Mobile (#3535) cold-start integration — exercises the REAL
+ * {@link RestAssetSpaceMount} wired into {@link BootstrapAssetSpaceCommands}
+ * through the `restMount` strategy (the cross-platform path), against an
+ * in-memory `vault.adapter` that mirrors the Obsidian DataAdapter contract.
+ *
+ * This is the mobile counterpart of `BootstrapAssetSpace.integration.test.ts`
+ * (which uses the REAL desktop `GitSubmoduleOps` + a tmpdir). Here NO Node `fs`
+ * is touched — every write goes through `vault.adapter`, and the only fake is
+ * the GitHub HTTP client (real gzipped tarball, per test-fixture-realism).
+ *
+ * Proves the end-to-end mobile contract a fresh iPhone vault relies on:
+ *   empty vault → bootstrap → exo + exocmd materialised via vault.adapter +
+ *   `.gitmodules` written; then add-assetspace → a third entry — all readable
+ *   back via `RestAssetSpaceMount.readGitmodulesEntries`, which is exactly what
+ *   apply-profile (`listAllAssetSpaceInfos`) consumes next.
+ *
+ * Revert-verify (mobile): remove the `restMount` branch from
+ * `BootstrapAssetSpaceCommands.materialize` / `listTrackedEntries` and these
+ * tests FAIL (the class falls through to the absent desktop deps and throws).
+ */
+
+import type { App } from "obsidian";
+import { createTar } from "nanotar";
+
+import { RestAssetSpaceMount } from "../../../src/infrastructure/adapters/RestAssetSpaceMount";
+import type { GitHubRestClient } from "../../../src/infrastructure/adapters/GitHubRestClient";
+import { BootstrapAssetSpaceCommands } from "../../../src/infrastructure/adapters/BootstrapAssetSpaceCommands";
+
+const EXO_URL = "https://github.com/kitelev/exoas-exo";
+const EXOCMD_URL = "https://github.com/kitelev/exoas-exocmd";
+const PMBOK_URL = "https://github.com/kitelev/exoas-pmbok-ontology";
+
+// ─── Fakes ────────────────────────────────────────────────────────────────
+
+/**
+ * In-memory DataAdapter mirroring the real Obsidian contract. `exists` is
+ * ANCESTOR-aware (a parent of an existing file/dir exists, like a real FS), so
+ * `hasMaterializedAssetSpaces` classifies a freshly materialised vault
+ * correctly. `writeBinary` does NOT auto-create parents (RestAssetSpaceMount
+ * ensures the dir chain itself).
+ */
+class InMemoryAdapter {
+  readonly files = new Map<string, Uint8Array>();
+  readonly textFiles = new Map<string, string>();
+  readonly dirs = new Set<string>();
+  readonly orphanWrites: string[] = [];
+
+  private allKeys(): string[] {
+    return [...this.files.keys(), ...this.textFiles.keys(), ...this.dirs];
+  }
+
+  async exists(p: string): Promise<boolean> {
+    if (this.files.has(p) || this.textFiles.has(p) || this.dirs.has(p)) {
+      return true;
+    }
+    // A directory exists if any known path is under it (real-FS semantics).
+    const prefix = p.replace(/\/+$/, "") + "/";
+    return this.allKeys().some((k) => k.startsWith(prefix));
+  }
+
+  async read(p: string): Promise<string> {
+    const t = this.textFiles.get(p);
+    if (t !== undefined) return t;
+    const b = this.files.get(p);
+    if (b !== undefined) return new TextDecoder().decode(b);
+    throw new Error(`ENOENT: ${p}`);
+  }
+
+  async write(p: string, data: string): Promise<void> {
+    this.textFiles.set(p, data);
+    this.files.delete(p);
+  }
+
+  async writeBinary(p: string, data: ArrayBuffer): Promise<void> {
+    const parent = p.slice(0, p.lastIndexOf("/"));
+    if (parent.length > 0 && !this.dirs.has(parent)) {
+      this.orphanWrites.push(p);
+    }
+    this.files.set(p, new Uint8Array(data));
+    this.textFiles.delete(p);
+  }
+
+  async mkdir(p: string): Promise<void> {
+    this.dirs.add(p);
+  }
+
+  async rmdir(p: string, recursive: boolean): Promise<void> {
+    this.dirs.delete(p);
+    if (!recursive) return;
+    const prefix = p + "/";
+    for (const k of [...this.files.keys()]) {
+      if (k.startsWith(prefix)) this.files.delete(k);
+    }
+    for (const k of [...this.textFiles.keys()]) {
+      if (k.startsWith(prefix)) this.textFiles.delete(k);
+    }
+    for (const k of [...this.dirs]) {
+      if (k.startsWith(prefix)) this.dirs.delete(k);
+    }
+  }
+
+  /** Obsidian DataAdapter.list — immediate children as full vault paths. */
+  async list(dir: string): Promise<{ files: string[]; folders: string[] }> {
+    const prefix = dir === "" ? "" : dir.replace(/\/+$/, "") + "/";
+    const files = new Set<string>();
+    const folders = new Set<string>();
+    const consider = (full: string, isDir: boolean): void => {
+      if (!full.startsWith(prefix)) return;
+      const rest = full.slice(prefix.length);
+      if (rest.length === 0) return;
+      const slash = rest.indexOf("/");
+      if (slash === -1) {
+        (isDir ? folders : files).add(prefix + rest);
+      } else {
+        folders.add(prefix + rest.slice(0, slash));
+      }
+    };
+    for (const k of this.files.keys()) consider(k, false);
+    for (const k of this.textFiles.keys()) consider(k, false);
+    for (const d of this.dirs) consider(d, true);
+    return { files: [...files], folders: [...folders] };
+  }
+}
+
+interface FakeClient {
+  fetchTarballBuffer: jest.Mock<Promise<ArrayBuffer>, [string, string, string]>;
+  ensureRateLimit: jest.Mock<Promise<void>, [number]>;
+}
+
+/**
+ * Per-repo tarball router — returns a real gzipped tarball whose single file is
+ * named after the repo so we can assert the right content landed in the right
+ * folder. The wrapper dir uses GitHub's `<owner>-<repo>-<sha7>/` convention.
+ */
+function makeRoutingClient(): FakeClient {
+  return {
+    ensureRateLimit: jest
+      .fn<Promise<void>, [number]>()
+      .mockResolvedValue(undefined),
+    fetchTarballBuffer: jest
+      .fn<Promise<ArrayBuffer>, [string, string, string]>()
+      .mockImplementation(async (owner, repo) => {
+        return makeTarball(`${owner}-${repo}-abc1234`, [
+          {
+            name: `${repo}.md`,
+            data: new TextEncoder().encode(`# ${repo}\n`),
+          },
+        ]);
+      }),
+  };
+}
+
+async function makeTarball(
+  wrapper: string,
+  entries: Array<{ name: string; data: Uint8Array }>,
+): Promise<ArrayBuffer> {
+  const files = entries.map((e) => ({
+    name: `${wrapper}/${e.name}`,
+    data: e.data,
+  }));
+  const tarBuf = createTar(files);
+  const stream = new ReadableStream<Uint8Array>({
+    start(c) {
+      c.enqueue(tarBuf);
+      c.close();
+    },
+  }).pipeThrough(new CompressionStream("gzip"));
+  return await new Response(stream).arrayBuffer();
+}
+
+function makeCmds(
+  adapter: InMemoryAdapter,
+  notices: string[],
+  prompts: {
+    bootstrapUrls?: { exoUrl: string; exocmdUrl: string } | null;
+    addUrl?: { url: string } | null;
+  },
+): { cmds: BootstrapAssetSpaceCommands; restMount: RestAssetSpaceMount } {
+  const app = { vault: { adapter } } as unknown as App;
+  const restMount = new RestAssetSpaceMount({
+    app,
+    client: makeRoutingClient() as unknown as GitHubRestClient,
+  });
+  const deriveFolderName = (url: string): string => {
+    const m = url.match(/github\.com\/[^/]+\/([^/]+)$/);
+    const repo = m ? m[1] : "unknown";
+    return repo.startsWith("exoas-") ? repo.slice("exoas-".length) : repo;
+  };
+  const cmds = new BootstrapAssetSpaceCommands({
+    // Mobile: ONLY restMount wired (no getPuller / gitOps / localStore).
+    restMount,
+    vaultExists: (p) => adapter.exists(p),
+    listFolder: (dir) => adapter.list(dir),
+    isGitVault: () => adapter.exists(".git"),
+    validateUrl: (url) => {
+      if (!/^https:\/\/github\.com\/[^/]+\/[^/]+$/.test(url)) {
+        throw new Error(`invalid url: ${url}`);
+      }
+    },
+    deriveFolderName,
+    promptBootstrapUrls: async () =>
+      prompts.bootstrapUrls === undefined
+        ? { exoUrl: EXO_URL, exocmdUrl: EXOCMD_URL }
+        : prompts.bootstrapUrls,
+    promptAddAssetSpaceUrl: async () =>
+      prompts.addUrl === undefined ? { url: PMBOK_URL } : prompts.addUrl,
+    confirm: async () => true,
+    notify: (m: string) => notices.push(m),
+  });
+  return { cmds, restMount };
+}
+
+// ─── Tests ──────────────────────────────────────────────────────────────────
+
+describe("Mobile bootstrap integration — real RestAssetSpaceMount + vault.adapter (#3535)", () => {
+  it("empty vault → bootstrap materialises exo + exocmd via vault.adapter + writes .gitmodules", async () => {
+    const adapter = new InMemoryAdapter();
+    const notices: string[] = [];
+    const { cmds, restMount } = makeCmds(adapter, notices, {});
+
+    await cmds.invokeBootstrap();
+
+    // Content materialised at the Maven path, wrapper stripped — via writeBinary
+    // (vault.adapter), never Node fs.
+    expect(adapter.files.has("assetspaces/kitelev/exoas-exo/exoas-exo.md")).toBe(
+      true,
+    );
+    expect(
+      adapter.files.has("assetspaces/kitelev/exoas-exocmd/exoas-exocmd.md"),
+    ).toBe(true);
+    expect(adapter.orphanWrites).toEqual([]);
+
+    // .gitmodules written via vault.adapter (text file), readable back.
+    const entries = await restMount.readGitmodulesEntries();
+    expect(entries).toEqual([
+      { submodulePath: "assetspaces/kitelev/exoas-exo", url: EXO_URL },
+      { submodulePath: "assetspaces/kitelev/exoas-exocmd", url: EXOCMD_URL },
+    ]);
+
+    expect(notices.some((n) => /Bootstrap complete/.test(n))).toBe(true);
+    expect(notices.some((n) => /file-only mode/.test(n))).toBe(false);
+  });
+
+  it("after bootstrap, add-assetspace appends a third .gitmodules entry + materialises it", async () => {
+    const adapter = new InMemoryAdapter();
+    const notices: string[] = [];
+    const { cmds, restMount } = makeCmds(adapter, notices, {});
+
+    await cmds.invokeBootstrap();
+    await cmds.invokeAddAssetSpace();
+
+    expect(
+      adapter.files.has("assetspaces/pmbok-ontology/exoas-pmbok-ontology.md"),
+    ).toBe(true);
+
+    const entries = await restMount.readGitmodulesEntries();
+    expect(entries.map((e) => e.submodulePath)).toEqual([
+      "assetspaces/kitelev/exoas-exo",
+      "assetspaces/kitelev/exoas-exocmd",
+      "assetspaces/pmbok-ontology",
+    ]);
+    expect(notices.some((n) => /AssetSpace added/.test(n))).toBe(true);
+  });
+
+  it("re-running bootstrap on the now-materialised vault is a no-op (idempotent)", async () => {
+    const adapter = new InMemoryAdapter();
+    const notices: string[] = [];
+    const { cmds, restMount } = makeCmds(adapter, notices, {});
+
+    await cmds.invokeBootstrap();
+    const before = await restMount.readGitmodulesEntries();
+    notices.length = 0;
+
+    await cmds.invokeBootstrap();
+    const after = await restMount.readGitmodulesEntries();
+
+    expect(after).toEqual(before);
+    expect(notices.some((n) => /already has AssetSpaces/.test(n))).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #3535. On Obsidian **mobile**, `bootstrap-vault` and `add-assetspace` were not registered (gated `applyDeps !== null` — desktop-only, because `GitSubmoduleOps` needs Node `fs`). A fresh empty mobile vault therefore could not mount registry/profiles, and `apply-profile` exited «No profiles found in vault». Mobile cold-start «from scratch» was blocked (discovered during the EKA Alpha real-iPhone dogfood, 2026-06-14).

This makes both commands **cross-platform** — the first fix under the new **Desktop↔Mobile Command Parity** invariant — reusing the existing `RestAssetSpaceMount` (RFC 01a83de8), the same `vault.adapter`/REST adapter that `apply-profile` already mounts through on mobile.

## What changed

- **`RestAssetSpaceMount.readGitmodulesEntries()`** — new `vault.adapter`-backed reader (reuses the shared pure-text `parseGitmodulesEntries`, no Node `fs`). The mobile counterpart of `GitSubmoduleOps.readGitmodulesEntries`.
- **`BootstrapAssetSpaceCommands`** — gains an optional `restMount` strategy. When wired (mobile), it replaces the desktop `getPuller` + `gitOps` + `localStore` trio with one combined op (pull tarball → materialise into the vault folder → write `.gitmodules`), all via `vault.adapter`. `.gitmodules` is written regardless of `.git` presence — it is the single source of truth `apply-profile` (`listAllAssetSpaceInfos`) reads next. The desktop path is unchanged; the misleading desktop "file-only mode" notice is suppressed on mobile.
- **`ExocortexPlugin`** — the registration gate now mirrors the apply-profile gate: `applyDeps !== null || (Platform.isMobile && restMount !== null)`. Desktop prefers the git path; mobile falls back to the REST mount. Both commands register on both platforms.

`RestAssetSpaceMount` structurally satisfies the new `IRestBootstrapMount` interface (`mount() → {sha}`, `readGitmodulesEntries()`), so it is wired directly with no adapter glue.

## Tests (integration-test-revert-verify, desktop + mobile)

- **Mobile unit** — `BootstrapAssetSpaceCommands` `restMount`-strategy block (6 cases): empty bootstrap (exo+exocmd at Maven paths, `.gitmodules` written, no Node-fs deps), core-only, add-assetspace, already-bootstrapped no-op, EC2 clone-needs-fetch, detectVaultState via `restMount.readGitmodulesEntries`.
- **Mobile integration** — full cold-start through the **REAL** `RestAssetSpaceMount` + in-memory `vault.adapter` + real gzip tarball (no Node `fs`): empty → bootstrap → add-assetspace → entries readable back; idempotent re-run.
- **`RestAssetSpaceMount.readGitmodulesEntries`** unit block (3 cases).
- **Revert-verified**: with the `restMount` branch removed, the mobile suites FAIL (7 tests) while the desktop suites stay green; restored → all pass.
- Existing desktop suites (`BootstrapAssetSpaceCommands`, `BootstrapAssetSpace.integration`, `BootstrapPatRefresh.integration`, `RestAssetSpaceMount.mount`) unchanged & green — **zero desktop regression**.

Local: lint ✅ · root typecheck ✅ · `npm run build` ✅ (incl. `assert-mobile-loadable` — bundle module-evals without Node) · archgate ✅ (MOBILE-001/002/003 pass).

## Acceptance

- `bootstrap-vault` + `add-assetspace` register on mobile when the REST mount is wired.
- Fresh mobile vault can complete `bootstrap → add registry → add profiles → apply-profile` (covered by the integration sequence; real-iPhone smoke to be confirmed via BRAT-update post-release).
- Desktop `GitSubmoduleOps` path intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)