### PR TITLE
feat(plugin): «Exocortex: Open activity log» real-time modal (#3540)

### DIFF
--- a/packages/obsidian-plugin/src/ExocortexPlugin.ts
+++ b/packages/obsidian-plugin/src/ExocortexPlugin.ts
@@ -13,6 +13,9 @@ import { ILogger } from "./adapters/logging/ILogger";
 import { LoggerFactory } from "./adapters/logging/LoggerFactory";
 import { Logger } from "./adapters/logging/Logger";
 import { FileLogChannel } from "./adapters/logging/FileLogChannel";
+import { ActivityLogService } from "./adapters/logging/ActivityLogService";
+import { journalEntryToActivity } from "./adapters/logging/activityFanIn";
+import { ActivityLogModal } from "./presentation/modals/ActivityLogModal";
 import { CommandManager } from "./application/services/CommandManager";
 import { IndexingCompleteNotifier } from "./application/services/IndexingCompleteNotifier";
 import {
@@ -239,6 +242,13 @@ export default class ExocortexPlugin extends Plugin {
   /** RFC 22b50a17 Phase 4 — AssetSpace status badge (✅/⏸). */
   private assetSpaceStatusIconPatch: AssetSpaceStatusIconPatch | null = null;
   private fileLogChannel!: FileLogChannel;
+  /**
+   * #3540 — in-memory activity stream (ring buffer + pub/sub) backing the
+   * «Open activity log» modal. Created in `onload()` and hoisted so every
+   * activity source (ExoSync, profile apply, mount/unmount, bootstrap) can
+   * `record(...)` from onload onward, independent of whether the modal is open.
+   */
+  private activityLog!: ActivityLogService;
   // Issue #3320 — promoted from private so the Settings UI can route its
   // Save / Test connection / Switch failure messages via the same notifier
   // that powers the rest of the plugin (lint `no-restricted-syntax` rule
@@ -330,6 +340,8 @@ export default class ExocortexPlugin extends Plugin {
       this.notifier = new ObsidianNotificationService();
       this.fileLogChannel = new FileLogChannel(this.app.vault.adapter, this.manifest.dir ?? `${this.app.vault.configDir}/plugins/${this.manifest.id}`);
       await this.fileLogChannel.ensureFileExists();
+      // #3540 — always-on activity buffer; sources fan in from onload onward.
+      this.activityLog = new ActivityLogService();
       this.configureLogChannels();
 
       this.printNameRuleService = new PrintNameRuleService(this.app);
@@ -2860,8 +2872,16 @@ export default class ExocortexPlugin extends Plugin {
         }),
       isSwitchInProgress: () => localDataStore.isSwitchInProgress(),
       notify: (message) => this.notifier.info(message),
-      log: (message) => this.logger.warn(message),
-      logInfo: (message) => this.logger.info(message),
+      log: (message) => {
+        this.logger.warn(message);
+        // #3540 — surface ExoSync warnings in the activity stream.
+        this.activityLog.record({ category: "exosync", level: "warn", message });
+      },
+      logInfo: (message) => {
+        this.logger.info(message);
+        // #3540 — always-on ExoSync step feed (onProgress info channel).
+        this.activityLog.record({ category: "exosync", level: "info", message });
+      },
       // #3498 — opt-in durable verbose FILE trace (default off). Appends the
       // step lines directly to the plugin file log, INDEPENDENT of
       // logChannels.info.file. Read live so the Settings toggle takes effect on
@@ -2890,6 +2910,8 @@ export default class ExocortexPlugin extends Plugin {
       rdfIndexer,
       settingsStore,
       notify: (message) => this.notifier.info(message),
+      // #3540 — fan profile apply / mount / unmount phases into the activity log.
+      onPhase: (entry) => this.activityLog.record(journalEntryToActivity(entry)),
       assetSpaceManager: applyDeps?.assetSpaceManager,
       gitOps: applyDeps?.gitOps,
       restMount: restMount ?? undefined,
@@ -3061,6 +3083,18 @@ export default class ExocortexPlugin extends Plugin {
       },
     });
 
+    // #3540 — «Open activity log»: real-time modal over the in-memory activity
+    // stream (ExoSync / profile apply / mount-unmount / bootstrap). Pure UI +
+    // in-memory buffer (no Node/fs/git) → registered UNCONDITIONALLY so it works
+    // identically on desktop and mobile (Desktop↔Mobile Command Parity).
+    this.addCommand({
+      id: "open-activity-log",
+      name: "Open activity log",
+      callback: () => {
+        new ActivityLogModal(this.app, this.activityLog).open();
+      },
+    });
+
     // RFC 0a0791c1 Phase 5 T2 — «Apply profile» (the single consolidated
     // profile command; the former soft «Switch focus profile» was removed and
     // the mount-state «Switch knowledge profile» was renamed here). Needs the
@@ -3190,7 +3224,11 @@ export default class ExocortexPlugin extends Plugin {
             resolve,
           ).open();
         }),
-      notify: (message) => this.notifier.info(message),
+      notify: (message) => {
+        this.notifier.info(message);
+        // #3540 — surface bootstrap / add-assetspace progress in the activity log.
+        this.activityLog.record({ category: "bootstrap", level: "info", message });
+      },
       onMaterialized: () => this.refreshAndInjectAssetSpaceMaterialization(),
     });
 

--- a/packages/obsidian-plugin/src/adapters/logging/ActivityLogService.ts
+++ b/packages/obsidian-plugin/src/adapters/logging/ActivityLogService.ts
@@ -1,0 +1,128 @@
+/**
+ * ActivityLogService — in-memory, event-driven activity stream for the
+ * «Exocortex: Open activity log» command (GitHub #3540).
+ *
+ * A bounded ring buffer of recent plugin activity (ExoSync steps, profile
+ * apply/materialize phases, AssetSpace mount/unmount, bootstrap) plus a
+ * pub/sub so an open {@link ActivityLogModal} can append rows in real time.
+ *
+ * Design notes:
+ *  - **Always-on from onload.** A single instance is created in
+ *    `ExocortexPlugin.onload()` and hoisted on the plugin so every activity
+ *    source can `record(...)` regardless of whether the modal is open. Opening
+ *    the modal later still shows the history of the current session (AC3).
+ *  - **Ephemeral.** No persistence — the buffer is cleared on plugin reload.
+ *    The durable `exocortex-logs.txt` file sink (#3498) stays an independent
+ *    opt-in concern; this service does not write to disk.
+ *  - **No Node/Obsidian dependency** — pure data structure, so the command
+ *    works identically on desktop and mobile (Desktop↔Mobile Command Parity).
+ *  - **Errors are a `level`, not a category** — an ExoSync failure stays
+ *    `category:"exosync"` with `level:"error"`.
+ */
+
+export type ActivityCategory = "exosync" | "profile" | "mount" | "bootstrap";
+export type ActivityLevel = "info" | "warn" | "error";
+
+export interface ActivityEntry {
+  /** Epoch millis the entry was recorded. */
+  ts: number;
+  category: ActivityCategory;
+  level: ActivityLevel;
+  message: string;
+}
+
+/** Caller-supplied fields; `ts` is stamped by the service. */
+export type ActivityRecordInput = Omit<ActivityEntry, "ts">;
+
+/** Default ring-buffer capacity (oldest entries evicted past this). */
+const DEFAULT_CAPACITY = 1000;
+
+export interface ActivityLogServiceOptions {
+  /** Ring-buffer capacity. Non-positive / missing → {@link DEFAULT_CAPACITY}. */
+  capacity?: number;
+  /** Injectable clock for deterministic tests. Defaults to `Date.now`. */
+  now?: () => number;
+}
+
+export class ActivityLogService {
+  private readonly buffer: ActivityEntry[] = [];
+  private readonly capacity: number;
+  private readonly clock: () => number;
+  private readonly subscribers = new Set<(entry: ActivityEntry) => void>();
+  private readonly clearSubscribers = new Set<() => void>();
+
+  constructor(options: ActivityLogServiceOptions = {}) {
+    this.capacity =
+      options.capacity && options.capacity > 0
+        ? options.capacity
+        : DEFAULT_CAPACITY;
+    this.clock = options.now ?? (() => Date.now());
+  }
+
+  /**
+   * Append an entry to the buffer (evicting the oldest past capacity) and
+   * notify subscribers. Subscriber errors are isolated so one bad listener
+   * cannot break recording or starve the others.
+   */
+  record(input: ActivityRecordInput): void {
+    const entry: ActivityEntry = {
+      ts: this.clock(),
+      category: input.category,
+      level: input.level,
+      message: input.message,
+    };
+    this.buffer.push(entry);
+    if (this.buffer.length > this.capacity) {
+      this.buffer.splice(0, this.buffer.length - this.capacity);
+    }
+    for (const cb of this.subscribers) {
+      try {
+        cb(entry);
+      } catch {
+        // Isolate subscriber failures — a broken modal listener must not
+        // break the activity stream for other listeners or the producer.
+      }
+    }
+  }
+
+  /**
+   * Subscribe to newly recorded entries. Returns an unsubscribe function.
+   * Does NOT replay the existing buffer — call {@link getSnapshot} for that.
+   */
+  subscribe(cb: (entry: ActivityEntry) => void): () => void {
+    this.subscribers.add(cb);
+    return () => {
+      this.subscribers.delete(cb);
+    };
+  }
+
+  /** Subscribe to `clear()` events. Returns an unsubscribe function. */
+  onClear(cb: () => void): () => void {
+    this.clearSubscribers.add(cb);
+    return () => {
+      this.clearSubscribers.delete(cb);
+    };
+  }
+
+  /** Current buffer as an immutable copy (for initial modal render). */
+  getSnapshot(): readonly ActivityEntry[] {
+    return this.buffer.slice();
+  }
+
+  /** Empty the buffer and notify clear-subscribers. */
+  clear(): void {
+    this.buffer.length = 0;
+    for (const cb of this.clearSubscribers) {
+      try {
+        cb();
+      } catch {
+        // Isolate subscriber failures (see record()).
+      }
+    }
+  }
+
+  /** Number of entries currently buffered. */
+  get size(): number {
+    return this.buffer.length;
+  }
+}

--- a/packages/obsidian-plugin/src/adapters/logging/activityFanIn.ts
+++ b/packages/obsidian-plugin/src/adapters/logging/activityFanIn.ts
@@ -1,0 +1,61 @@
+/**
+ * Fan-in adapters for the activity log (#3540) — pure mappers translating
+ * existing producer events into {@link ActivityRecordInput} so the wiring sites
+ * in `ExocortexPlugin.onload()` stay one-liners and the mapping is unit-testable
+ * without standing up the whole plugin.
+ */
+import type { SwitchJournalEntry } from "../../infrastructure/adapters/ProfileApplyManager";
+import type { ActivityLevel, ActivityRecordInput } from "./ActivityLogService";
+
+/** Human-friendly labels for ProfileApplyManager journal phases. */
+const PHASE_LABELS: Record<SwitchJournalEntry["phase"], string> = {
+  starting: "Apply starting",
+  completed: "Apply completed",
+  failed: "Apply failed",
+  "apply-starting": "Apply starting",
+  "phase1-pulling": "Pulling AssetSpaces",
+  "phase1-pulled": "Pulled AssetSpaces",
+  "phase1-done": "Staging complete (phase 1)",
+  "aborted-phase1": "Aborted before mutation (phase 1)",
+  "phase2-start": "Materialization started (phase 2)",
+  "phase2-destroy-cached": "Cached before unmount",
+  "phase2-destroyed": "Unmounted",
+  "phase2-materializing": "Materializing",
+  "phase2-materialized": "Mounted",
+  "phase2-done": "Materialization complete (phase 2)",
+  "git-commit-done": "Committed submodule pointers",
+  "apply-completed": "Apply completed",
+  "apply-failed": "Apply failed",
+  "recovery-restoring": "Recovering interrupted switch",
+  "recovery-completed": "Recovery complete",
+};
+
+function levelForPhase(phase: SwitchJournalEntry["phase"]): ActivityLevel {
+  if (phase.includes("failed") || phase.includes("aborted")) return "error";
+  return "info";
+}
+
+/**
+ * Map a ProfileApplyManager journal entry to an activity record.
+ *
+ * Per-AssetSpace phases (those carrying an `as` UID — mount/unmount/cache of a
+ * single AssetSpace) become `category:"mount"`; the overall apply lifecycle
+ * (starting / phase boundaries / completed / failed) becomes `category:"profile"`.
+ * The 8-char AssetSpace prefix, elapsed time, and error (when present) are
+ * appended to keep each line self-describing.
+ */
+export function journalEntryToActivity(
+  entry: SwitchJournalEntry,
+): ActivityRecordInput {
+  const category = entry.as ? "mount" : "profile";
+  const label = PHASE_LABELS[entry.phase] ?? entry.phase;
+  const asPart = entry.as ? ` ${entry.as.slice(0, 8)}` : "";
+  const elapsedPart =
+    entry.elapsedMs !== undefined ? ` (${entry.elapsedMs}ms)` : "";
+  const errorPart = entry.error ? `: ${entry.error}` : "";
+  return {
+    category,
+    level: levelForPhase(entry.phase),
+    message: `${label}${asPart}${elapsedPart}${errorPart}`,
+  };
+}

--- a/packages/obsidian-plugin/src/infrastructure/adapters/ProfileApplyManager.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/ProfileApplyManager.ts
@@ -177,6 +177,13 @@ export interface ProfileApplyManagerOptions {
   now?: () => Date;
   /** User-facing notifier (typically `new Notice()`). */
   notify?: (message: string) => void;
+  /**
+   * Observability hook (#3540) — invoked for EVERY journal entry written, so an
+   * in-memory activity stream can surface per-phase / per-AssetSpace progress in
+   * real time. Independent of {@link notify} (which is sparse + user-facing).
+   * Default no-op. Must not throw — failures are swallowed at the call site.
+   */
+  onPhase?: (entry: SwitchJournalEntry) => void;
 
   // --- Apply dependencies (RFC 22b50a17 Phase 3) ---
   /** AssetSpaceManager — provides pullAssetSpace + lookupAssetSpaceInfo. */
@@ -360,6 +367,7 @@ export class ProfileApplyManager {
   private readonly maxExtendsDepth: number;
   private readonly now: () => Date;
   private readonly notify: (message: string) => void;
+  private readonly onPhase: (entry: SwitchJournalEntry) => void;
 
   // Apply dependencies (may be undefined when only reindex wired).
   private readonly assetSpaceManager?: AssetSpaceManager;
@@ -392,6 +400,7 @@ export class ProfileApplyManager {
     this.maxExtendsDepth = options.maxExtendsDepth ?? DEFAULT_MAX_EXTENDS_DEPTH;
     this.now = options.now ?? (() => new Date());
     this.notify = options.notify ?? (() => undefined);
+    this.onPhase = options.onPhase ?? (() => undefined);
 
     this.assetSpaceManager = options.assetSpaceManager;
     this.cacheLayer = options.cacheLayer;
@@ -1928,6 +1937,14 @@ export class ProfileApplyManager {
   }
 
   private async appendJournal(entry: SwitchJournalEntry): Promise<void> {
+    // Observability fan-out (#3540) — surface every phase to the activity
+    // stream BEFORE the disk write so the modal updates even if the journal
+    // write later fails. Isolated: a bad observer must not break apply.
+    try {
+      this.onPhase(entry);
+    } catch {
+      // swallow — observability is best-effort, never blocks the switch.
+    }
     const line = JSON.stringify(entry) + "\n";
     let existing = "";
     try {

--- a/packages/obsidian-plugin/src/presentation/modals/ActivityLogModal.ts
+++ b/packages/obsidian-plugin/src/presentation/modals/ActivityLogModal.ts
@@ -1,0 +1,164 @@
+import { App, Modal } from "obsidian";
+import type {
+  ActivityEntry,
+  ActivityLogService,
+} from "../../adapters/logging/ActivityLogService";
+
+/**
+ * Render one activity entry as a single monospace line:
+ * `HH:MM:SS [category] message`, with an uppercased level marker for
+ * warn/error (info is unmarked to keep the common case clean).
+ */
+export function formatActivityEntry(e: ActivityEntry): string {
+  const d = new Date(e.ts);
+  const hh = String(d.getHours()).padStart(2, "0");
+  const mm = String(d.getMinutes()).padStart(2, "0");
+  const ss = String(d.getSeconds()).padStart(2, "0");
+  const lvl = e.level === "info" ? "" : ` ${e.level.toUpperCase()}`;
+  return `${hh}:${mm}:${ss} [${e.category}]${lvl} ${e.message}`;
+}
+
+/** Pixels of slack when deciding whether the list is "scrolled to bottom". */
+const AUTOSCROLL_THRESHOLD_PX = 4;
+
+/**
+ * Should a newly-appended row scroll the list to the bottom? True only when the
+ * user is already at (near) the bottom — a manual scroll-up pauses auto-scroll
+ * so they can read history without being yanked down. An empty/unscrollable
+ * list (clientHeight ≈ scrollHeight) counts as "at bottom".
+ */
+export function shouldAutoScroll(metrics: {
+  scrollTop: number;
+  clientHeight: number;
+  scrollHeight: number;
+}): boolean {
+  return (
+    metrics.scrollTop + metrics.clientHeight >=
+    metrics.scrollHeight - AUTOSCROLL_THRESHOLD_PX
+  );
+}
+
+/**
+ * ActivityLogModal — real-time view of plugin activity (GitHub #3540),
+ * structurally modelled on Obsidian Sync's «Sync log»: header + scrollable
+ * monospace list (oldest top, newest bottom) + Copy / Clear / Done footer.
+ *
+ * Backed by {@link ActivityLogService} (in-memory ring buffer + pub/sub):
+ * `onOpen` renders the current snapshot and subscribes for live appends;
+ * `onClose` unsubscribes. Pure DOM + in-memory buffer (no Node/fs/git) → works
+ * identically on desktop and mobile (Desktop↔Mobile Command Parity).
+ *
+ * MVP intentionally omits the Sync-style category dropdown + text filter
+ * (single chronological stream); they are a documented future enhancement.
+ */
+export class ActivityLogModal extends Modal {
+  private readonly svc: ActivityLogService;
+  private listEl: HTMLElement | null = null;
+  private unsub: (() => void) | null = null;
+  private unsubClear: (() => void) | null = null;
+
+  constructor(app: App, svc: ActivityLogService) {
+    super(app);
+    this.svc = svc;
+  }
+
+  override onOpen(): void {
+    const { contentEl } = this;
+    contentEl.createEl("h2", { text: "Activity log" });
+
+    // Bounded monospace scroller mirroring the Sync activity log body — styling
+    // lives in styles.css (.exocortex-activity-log-list); the lint rule forbids
+    // inline element.style assignments.
+    const list = contentEl.createEl("div", {
+      cls: "exocortex-activity-log-list",
+    });
+    this.listEl = list;
+
+    this.renderSnapshot();
+
+    const footer = contentEl.createEl("div", {
+      cls: "modal-button-container",
+    });
+    const copyBtn = footer.createEl("button", {
+      cls: "mod-cta",
+      text: "Copy",
+    });
+    copyBtn.addEventListener("click", () => {
+      void this.copyToClipboard();
+    });
+    const clearBtn = footer.createEl("button", { text: "Clear" });
+    clearBtn.addEventListener("click", () => {
+      // clear() fires the onClear subscription below → re-renders empty.
+      this.svc.clear();
+    });
+    const doneBtn = footer.createEl("button", { text: "Done" });
+    doneBtn.addEventListener("click", () => {
+      this.close();
+    });
+
+    // Live updates: append new entries; re-render on external clear.
+    this.unsub = this.svc.subscribe((entry) => this.appendRow(entry));
+    this.unsubClear = this.svc.onClear(() => this.renderSnapshot());
+  }
+
+  override onClose(): void {
+    this.unsub?.();
+    this.unsubClear?.();
+    this.unsub = null;
+    this.unsubClear = null;
+    this.listEl = null;
+    this.contentEl.empty();
+  }
+
+  /** Clear and repopulate the list from the current snapshot. */
+  private renderSnapshot(): void {
+    const list = this.listEl;
+    if (!list) return;
+    list.empty();
+    const snapshot = this.svc.getSnapshot();
+    if (snapshot.length === 0) {
+      list.createEl("div", {
+        cls: "exocortex-activity-log-empty",
+        text: "No activity recorded yet.",
+      });
+      return;
+    }
+    for (const entry of snapshot) {
+      this.appendRow(entry);
+    }
+  }
+
+  /** Append one row, auto-scrolling to bottom only if already at the bottom. */
+  private appendRow(entry: ActivityEntry): void {
+    const list = this.listEl;
+    if (!list) return;
+    // Drop the «no activity» placeholder once the first real row arrives.
+    const placeholder = list.querySelector(".exocortex-activity-log-empty");
+    if (placeholder) placeholder.remove();
+    const atBottom = shouldAutoScroll({
+      scrollTop: list.scrollTop,
+      clientHeight: list.clientHeight,
+      scrollHeight: list.scrollHeight,
+    });
+    list.createEl("div", {
+      cls: "exocortex-activity-log-row",
+      text: formatActivityEntry(entry),
+    });
+    if (atBottom) {
+      list.scrollTop = list.scrollHeight;
+    }
+  }
+
+  /** Copy the full buffered log (formatted) to the clipboard. Best-effort. */
+  private async copyToClipboard(): Promise<void> {
+    const text = this.svc
+      .getSnapshot()
+      .map(formatActivityEntry)
+      .join("\n");
+    try {
+      await navigator?.clipboard?.writeText(text);
+    } catch {
+      // Clipboard unavailable / denied — best-effort, no user-facing error.
+    }
+  }
+}

--- a/packages/obsidian-plugin/styles.css
+++ b/packages/obsidian-plugin/styles.css
@@ -6143,3 +6143,28 @@
 .exocortex-invalid-input {
   border-color: var(--text-error) !important;
 }
+
+/* #3540 — «Open activity log» modal: scrollable monospace activity stream
+   (modelled on the Obsidian Sync activity log body). */
+.exocortex-activity-log-list {
+  font-family: var(--font-monospace, monospace);
+  font-size: var(--font-smaller, 0.85em);
+  white-space: pre-wrap;
+  word-break: break-word;
+  max-height: 50vh;
+  min-height: 8em;
+  overflow-y: auto;
+  border: 1px solid var(--background-modifier-border);
+  border-radius: var(--radius-s, 4px);
+  padding: var(--size-4-2, 8px);
+  margin-bottom: var(--size-4-3, 12px);
+}
+
+.exocortex-activity-log-row {
+  line-height: 1.4;
+}
+
+.exocortex-activity-log-empty {
+  color: var(--text-muted);
+  font-style: italic;
+}

--- a/packages/obsidian-plugin/tests/unit/adapters/logging/ActivityLogService.test.ts
+++ b/packages/obsidian-plugin/tests/unit/adapters/logging/ActivityLogService.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Unit tests for ActivityLogService — the in-memory ring buffer + pub/sub that
+ * backs the «Exocortex: Open activity log» modal (GitHub #3540).
+ *
+ * No Obsidian dependency — pure data structure, runs in plain jsdom/node.
+ */
+import { describe, it, expect, jest } from "@jest/globals";
+import {
+  ActivityLogService,
+  type ActivityEntry,
+} from "../../../../src/adapters/logging/ActivityLogService";
+
+describe("ActivityLogService", () => {
+  it("record → getSnapshot returns recorded entries in order, stamping ts", () => {
+    let t = 1000;
+    const svc = new ActivityLogService({ now: () => (t += 5) });
+    svc.record({ category: "exosync", level: "info", message: "a" });
+    svc.record({ category: "profile", level: "warn", message: "b" });
+
+    const snap = svc.getSnapshot();
+    expect(snap).toHaveLength(2);
+    expect(snap[0]).toEqual({
+      ts: 1005,
+      category: "exosync",
+      level: "info",
+      message: "a",
+    });
+    expect(snap[1]).toEqual({
+      ts: 1010,
+      category: "profile",
+      level: "warn",
+      message: "b",
+    });
+  });
+
+  it("getSnapshot returns a copy — mutating it does not affect the buffer", () => {
+    const svc = new ActivityLogService();
+    svc.record({ category: "mount", level: "info", message: "x" });
+    const snap = svc.getSnapshot() as ActivityEntry[];
+    snap.push({ ts: 0, category: "bootstrap", level: "error", message: "z" });
+    expect(svc.getSnapshot()).toHaveLength(1);
+  });
+
+  it("evicts oldest entries when capacity is exceeded (ring buffer)", () => {
+    const svc = new ActivityLogService({ capacity: 3, now: () => 0 });
+    for (const m of ["1", "2", "3", "4", "5"]) {
+      svc.record({ category: "exosync", level: "info", message: m });
+    }
+    const snap = svc.getSnapshot();
+    expect(snap).toHaveLength(3);
+    expect(snap.map((e) => e.message)).toEqual(["3", "4", "5"]);
+  });
+
+  it("defaults capacity to ~1000 when not specified", () => {
+    const svc = new ActivityLogService({ now: () => 0 });
+    for (let i = 0; i < 1100; i++) {
+      svc.record({ category: "exosync", level: "info", message: String(i) });
+    }
+    expect(svc.getSnapshot()).toHaveLength(1000);
+    expect(svc.getSnapshot()[0].message).toBe("100"); // 0..99 evicted
+  });
+
+  it("invalid/zero/negative capacity falls back to default (not a broken buffer)", () => {
+    const svc = new ActivityLogService({ capacity: 0, now: () => 0 });
+    for (let i = 0; i < 1001; i++) {
+      svc.record({ category: "exosync", level: "info", message: String(i) });
+    }
+    expect(svc.getSnapshot()).toHaveLength(1000);
+  });
+
+  it("subscribe receives newly recorded entries", () => {
+    const svc = new ActivityLogService({ now: () => 42 });
+    const received: ActivityEntry[] = [];
+    svc.subscribe((e) => received.push(e));
+    svc.record({ category: "bootstrap", level: "info", message: "hello" });
+    expect(received).toEqual([
+      { ts: 42, category: "bootstrap", level: "info", message: "hello" },
+    ]);
+  });
+
+  it("unsubscribe stops further delivery", () => {
+    const svc = new ActivityLogService({ now: () => 0 });
+    const received: ActivityEntry[] = [];
+    const unsub = svc.subscribe((e) => received.push(e));
+    svc.record({ category: "exosync", level: "info", message: "1" });
+    unsub();
+    svc.record({ category: "exosync", level: "info", message: "2" });
+    expect(received.map((e) => e.message)).toEqual(["1"]);
+  });
+
+  it("supports multiple independent subscribers", () => {
+    const svc = new ActivityLogService({ now: () => 0 });
+    const a: string[] = [];
+    const b: string[] = [];
+    svc.subscribe((e) => a.push(e.message));
+    svc.subscribe((e) => b.push(e.message));
+    svc.record({ category: "mount", level: "info", message: "m" });
+    expect(a).toEqual(["m"]);
+    expect(b).toEqual(["m"]);
+  });
+
+  it("a throwing subscriber does not break recording or other subscribers", () => {
+    const svc = new ActivityLogService({ now: () => 0 });
+    const ok: string[] = [];
+    svc.subscribe(() => {
+      throw new Error("boom");
+    });
+    svc.subscribe((e) => ok.push(e.message));
+    expect(() =>
+      svc.record({ category: "exosync", level: "error", message: "still" }),
+    ).not.toThrow();
+    expect(ok).toEqual(["still"]);
+    expect(svc.getSnapshot()).toHaveLength(1); // entry still buffered
+  });
+
+  it("clear empties the buffer", () => {
+    const svc = new ActivityLogService({ now: () => 0 });
+    svc.record({ category: "exosync", level: "info", message: "1" });
+    svc.record({ category: "exosync", level: "info", message: "2" });
+    expect(svc.size).toBe(2);
+    svc.clear();
+    expect(svc.getSnapshot()).toEqual([]);
+    expect(svc.size).toBe(0);
+  });
+
+  it("clear notifies clear-subscribers", () => {
+    const svc = new ActivityLogService({ now: () => 0 });
+    const onClear = jest.fn();
+    svc.onClear(onClear);
+    svc.record({ category: "exosync", level: "info", message: "1" });
+    svc.clear();
+    expect(onClear).toHaveBeenCalledTimes(1);
+  });
+
+  it("size reflects buffer length", () => {
+    const svc = new ActivityLogService({ now: () => 0 });
+    expect(svc.size).toBe(0);
+    svc.record({ category: "exosync", level: "info", message: "1" });
+    expect(svc.size).toBe(1);
+  });
+});

--- a/packages/obsidian-plugin/tests/unit/adapters/logging/activityFanIn.test.ts
+++ b/packages/obsidian-plugin/tests/unit/adapters/logging/activityFanIn.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Unit tests for activityFanIn — pure mapping of ProfileApplyManager journal
+ * entries to activity-log records (#3540). The integration contract that the
+ * modal surfaces profile/mount events correctly hinges on this mapping.
+ */
+import { describe, it, expect } from "@jest/globals";
+import { journalEntryToActivity } from "../../../../src/adapters/logging/activityFanIn";
+import type { SwitchJournalEntry } from "../../../../src/infrastructure/adapters/ProfileApplyManager";
+
+const base = { targetUid: "profile-xyz-uid", ts: "2026-06-15T00:00:00.000Z" };
+
+describe("journalEntryToActivity", () => {
+  it("overall apply phases (no `as`) → category 'profile'", () => {
+    const e: SwitchJournalEntry = { ...base, phase: "starting" };
+    expect(journalEntryToActivity(e)).toEqual({
+      category: "profile",
+      level: "info",
+      message: "Apply starting",
+    });
+  });
+
+  it("per-AssetSpace phase (carries `as`) → category 'mount' with 8-char prefix", () => {
+    const e: SwitchJournalEntry = {
+      ...base,
+      phase: "phase2-materialized",
+      as: "1b20a8f0-d745-4e93-91db-4531b3df120e",
+    };
+    expect(journalEntryToActivity(e)).toEqual({
+      category: "mount",
+      level: "info",
+      message: "Mounted 1b20a8f0",
+    });
+  });
+
+  it("unmount (phase2-destroyed + as) → mount category, 'Unmounted'", () => {
+    const e: SwitchJournalEntry = {
+      ...base,
+      phase: "phase2-destroyed",
+      as: "abcd1234-5678-90ab-cdef-1234567890ab",
+    };
+    const r = journalEntryToActivity(e);
+    expect(r.category).toBe("mount");
+    expect(r.message).toBe("Unmounted abcd1234");
+  });
+
+  it("failed phases → level 'error', error text appended", () => {
+    const e: SwitchJournalEntry = {
+      ...base,
+      phase: "apply-failed",
+      error: "PAT rejected",
+    };
+    expect(journalEntryToActivity(e)).toEqual({
+      category: "profile",
+      level: "error",
+      message: "Apply failed: PAT rejected",
+    });
+  });
+
+  it("aborted phase → level 'error'", () => {
+    const e: SwitchJournalEntry = { ...base, phase: "aborted-phase1" };
+    expect(journalEntryToActivity(e).level).toBe("error");
+  });
+
+  it("completed phase appends elapsed time", () => {
+    const e: SwitchJournalEntry = {
+      ...base,
+      phase: "apply-completed",
+      elapsedMs: 1234,
+    };
+    expect(journalEntryToActivity(e)).toEqual({
+      category: "profile",
+      level: "info",
+      message: "Apply completed (1234ms)",
+    });
+  });
+
+  it("every declared journal phase maps to a non-empty info/error record", () => {
+    const phases: SwitchJournalEntry["phase"][] = [
+      "starting",
+      "completed",
+      "failed",
+      "apply-starting",
+      "phase1-pulling",
+      "phase1-pulled",
+      "phase1-done",
+      "aborted-phase1",
+      "phase2-start",
+      "phase2-destroy-cached",
+      "phase2-destroyed",
+      "phase2-materializing",
+      "phase2-materialized",
+      "phase2-done",
+      "git-commit-done",
+      "apply-completed",
+      "apply-failed",
+      "recovery-restoring",
+      "recovery-completed",
+    ];
+    for (const phase of phases) {
+      const r = journalEntryToActivity({ ...base, phase });
+      expect(r.message.length).toBeGreaterThan(0);
+      expect(["info", "error"]).toContain(r.level);
+      // phase string should not leak raw unless intentionally unmapped
+      expect(r.message).not.toBe(phase);
+    }
+  });
+});

--- a/packages/obsidian-plugin/tests/unit/adapters/logging/activityLog.integration.test.ts
+++ b/packages/obsidian-plugin/tests/unit/adapters/logging/activityLog.integration.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Integration test for the #3540 activity-log fan-in: composes the REAL
+ * collaborating units exactly as `ExocortexPlugin.onload()` wires them —
+ *   - ExoSync `logInfo`/`log` → activityLog.record({category:"exosync", ...})
+ *   - ProfileApplyManager `onPhase` → activityLog.record(journalEntryToActivity)
+ *   - bootstrap `notify` → activityLog.record({category:"bootstrap", ...})
+ * — feeds simulated producer events, then renders an ActivityLogModal over the
+ * resulting buffer and asserts the categories surface correctly (AC2/AC3/AC6).
+ *
+ * This is the contract the plugin relies on; it does not stand up the whole
+ * plugin (the wiring is one-liners verified here against the real mappers).
+ */
+import { describe, it, expect, beforeEach } from "@jest/globals";
+
+jest.mock("obsidian", () => {
+  interface CreateOpts {
+    cls?: string;
+    text?: string;
+  }
+  function augment(el: HTMLElement): void {
+    (
+      el as unknown as { createEl: (tag: string, o?: CreateOpts) => HTMLElement }
+    ).createEl = function (tag: string, o?: CreateOpts): HTMLElement {
+      const child = document.createElement(tag);
+      if (o?.cls) child.className = o.cls;
+      if (o?.text !== undefined) child.textContent = o.text;
+      this.appendChild(child);
+      augment(child);
+      return child;
+    }.bind(el);
+    (el as unknown as { empty: () => void }).empty = function (): void {
+      while (this.firstChild) this.removeChild(this.firstChild);
+    }.bind(el);
+  }
+  class MockModal {
+    app: unknown;
+    contentEl: HTMLElement;
+    constructor(app: unknown) {
+      this.app = app;
+      this.contentEl = document.createElement("div");
+      augment(this.contentEl);
+    }
+    open(): void {
+      document.body.appendChild(this.contentEl);
+      this.onOpen();
+    }
+    close(): void {
+      this.onClose();
+      this.contentEl.parentNode?.removeChild(this.contentEl);
+    }
+    onOpen(): void {}
+    onClose(): void {}
+  }
+  return { Modal: MockModal, App: class {} };
+});
+
+import type { App } from "obsidian";
+import { ActivityLogService } from "../../../../src/adapters/logging/ActivityLogService";
+import { journalEntryToActivity } from "../../../../src/adapters/logging/activityFanIn";
+import { ActivityLogModal } from "../../../../src/presentation/modals/ActivityLogModal";
+import type { SwitchJournalEntry } from "../../../../src/infrastructure/adapters/ProfileApplyManager";
+
+const fakeApp = {} as unknown as App;
+
+beforeEach(() => {
+  document.body.innerHTML = "";
+});
+
+describe("activity-log fan-in (integration)", () => {
+  it("fans ExoSync + profile + mount + bootstrap events into one categorized stream", () => {
+    const svc = new ActivityLogService({ now: () => 0 });
+
+    // Wire exactly as ExocortexPlugin.onload does.
+    const onSyncInfo = (message: string): void =>
+      svc.record({ category: "exosync", level: "info", message });
+    const onPhase = (entry: SwitchJournalEntry): void =>
+      svc.record(journalEntryToActivity(entry));
+    const onBootstrap = (message: string): void =>
+      svc.record({ category: "bootstrap", level: "info", message });
+
+    // --- Simulate producers (the events these sources actually emit) ---
+    onBootstrap("Bootstrapping vault...");
+    onSyncInfo("Detecting changes for exo");
+    onSyncInfo("Fully synced");
+    onPhase({ phase: "apply-starting", targetUid: "p1", ts: "t" });
+    onPhase({
+      phase: "phase2-materialized",
+      targetUid: "p1",
+      ts: "t",
+      as: "1b20a8f0-d745-4e93-91db-4531b3df120e",
+    });
+    onPhase({
+      phase: "phase2-destroyed",
+      targetUid: "p1",
+      ts: "t",
+      as: "abcd1234-0000-0000-0000-000000000000",
+    });
+    onPhase({ phase: "apply-completed", targetUid: "p1", ts: "t", elapsedMs: 50 });
+
+    const snap = svc.getSnapshot();
+    const byCategory = snap.reduce<Record<string, number>>((acc, e) => {
+      acc[e.category] = (acc[e.category] ?? 0) + 1;
+      return acc;
+    }, {});
+    expect(byCategory).toEqual({
+      bootstrap: 1,
+      exosync: 2,
+      profile: 2, // apply-starting + apply-completed
+      mount: 2, // materialized + destroyed (per-AS)
+    });
+
+    // --- Render the modal over the captured history (AC3) ---
+    new ActivityLogModal(fakeApp, svc).open();
+    const text = document.querySelector(
+      ".exocortex-activity-log-list",
+    )?.textContent;
+    expect(text).toMatch(/\[bootstrap\] Bootstrapping vault/);
+    expect(text).toMatch(/\[exosync\] Fully synced/);
+    expect(text).toMatch(/\[mount\] Mounted 1b20a8f0/);
+    expect(text).toMatch(/\[mount\] Unmounted abcd1234/);
+    expect(text).toMatch(/\[profile\] Apply completed \(50ms\)/);
+  });
+
+  it("AC2 — events recorded after the modal opens append live", () => {
+    const svc = new ActivityLogService({ now: () => 0 });
+    const onPhase = (entry: SwitchJournalEntry): void =>
+      svc.record(journalEntryToActivity(entry));
+
+    new ActivityLogModal(fakeApp, svc).open();
+    onPhase({
+      phase: "phase2-materializing",
+      targetUid: "p1",
+      ts: "t",
+      as: "deadbeef-0000-0000-0000-000000000000",
+    });
+    const text = document.querySelector(
+      ".exocortex-activity-log-list",
+    )?.textContent;
+    expect(text).toMatch(/\[mount\] Materializing deadbeef/);
+  });
+});

--- a/packages/obsidian-plugin/tests/unit/presentation/modals/ActivityLogModal.test.ts
+++ b/packages/obsidian-plugin/tests/unit/presentation/modals/ActivityLogModal.test.ts
@@ -1,0 +1,237 @@
+/**
+ * Unit tests for ActivityLogModal — the «Exocortex: Open activity log» modal
+ * (GitHub #3540). Mirrors the Obsidian Sync activity log shape: header +
+ * scrollable monospace list + Copy / Clear / Done footer, live-appending from
+ * an {@link ActivityLogService} pub/sub.
+ *
+ * Local `jest.mock("obsidian")` mirrors BootstrapModals.test.ts — a Modal that
+ * mounts `contentEl` into `document.body` on `open()` and a `createEl` helper
+ * copying the attributes the modal relies on (cls / text / type / attr).
+ */
+import { describe, it, expect, beforeEach, jest } from "@jest/globals";
+
+jest.mock("obsidian", () => {
+  interface CreateOpts {
+    cls?: string;
+    text?: string;
+    type?: string;
+    attr?: Record<string, string>;
+  }
+  function augment(el: HTMLElement): void {
+    (
+      el as unknown as { createEl: (tag: string, o?: CreateOpts) => HTMLElement }
+    ).createEl = function (tag: string, o?: CreateOpts): HTMLElement {
+      const child = document.createElement(tag);
+      if (o?.cls) child.className = o.cls;
+      if (o?.text !== undefined) child.textContent = o.text;
+      if (o?.type) child.setAttribute("type", o.type);
+      if (o?.attr) {
+        for (const [k, v] of Object.entries(o.attr)) child.setAttribute(k, v);
+      }
+      this.appendChild(child);
+      augment(child);
+      return child;
+    }.bind(el);
+    (el as unknown as { empty: () => void }).empty = function (): void {
+      while (this.firstChild) this.removeChild(this.firstChild);
+    }.bind(el);
+  }
+  class MockModal {
+    app: unknown;
+    contentEl: HTMLElement;
+    titleEl: HTMLElement;
+    constructor(app: unknown) {
+      this.app = app;
+      this.contentEl = document.createElement("div");
+      this.titleEl = document.createElement("div");
+      augment(this.contentEl);
+      augment(this.titleEl);
+    }
+    open(): void {
+      document.body.appendChild(this.contentEl);
+      this.onOpen();
+    }
+    close(): void {
+      this.onClose();
+      if (this.contentEl.parentNode) {
+        this.contentEl.parentNode.removeChild(this.contentEl);
+      }
+    }
+    onOpen(): void {}
+    onClose(): void {}
+  }
+  return { Modal: MockModal, App: class {} };
+});
+
+import type { App } from "obsidian";
+import {
+  ActivityLogModal,
+  formatActivityEntry,
+  shouldAutoScroll,
+} from "../../../../src/presentation/modals/ActivityLogModal";
+import {
+  ActivityLogService,
+  type ActivityEntry,
+} from "../../../../src/adapters/logging/ActivityLogService";
+
+const fakeApp = {} as unknown as App;
+
+function findButton(label: string): HTMLButtonElement | undefined {
+  return Array.from(document.querySelectorAll("button")).find(
+    (b) => b.textContent === label,
+  );
+}
+
+function listText(): string {
+  const list = document.querySelector(".exocortex-activity-log-list");
+  return list?.textContent ?? "";
+}
+
+beforeEach(() => {
+  document.body.innerHTML = "";
+});
+
+describe("formatActivityEntry", () => {
+  it("formats as HH:MM:SS [category] message for info", () => {
+    // 2026-06-15T09:08:07 local
+    const ts = new Date(2026, 5, 15, 9, 8, 7).getTime();
+    const e: ActivityEntry = {
+      ts,
+      category: "exosync",
+      level: "info",
+      message: "Fully synced",
+    };
+    expect(formatActivityEntry(e)).toBe("09:08:07 [exosync] Fully synced");
+  });
+
+  it("includes an uppercased level marker for warn/error", () => {
+    const ts = new Date(2026, 5, 15, 1, 2, 3).getTime();
+    expect(
+      formatActivityEntry({
+        ts,
+        category: "profile",
+        level: "error",
+        message: "apply failed",
+      }),
+    ).toBe("01:02:03 [profile] ERROR apply failed");
+    expect(
+      formatActivityEntry({
+        ts,
+        category: "mount",
+        level: "warn",
+        message: "slow",
+      }),
+    ).toBe("01:02:03 [mount] WARN slow");
+  });
+});
+
+describe("shouldAutoScroll", () => {
+  it("true when scrolled to (near) bottom", () => {
+    // scrollTop + clientHeight within threshold of scrollHeight
+    expect(shouldAutoScroll({ scrollTop: 80, clientHeight: 20, scrollHeight: 100 })).toBe(true);
+    expect(shouldAutoScroll({ scrollTop: 76, clientHeight: 20, scrollHeight: 100 })).toBe(true); // within 4px threshold
+  });
+
+  it("false when scrolled up (user is reading history)", () => {
+    expect(shouldAutoScroll({ scrollTop: 10, clientHeight: 20, scrollHeight: 100 })).toBe(false);
+  });
+
+  it("true for an empty/unscrollable list (clientHeight≈scrollHeight)", () => {
+    expect(shouldAutoScroll({ scrollTop: 0, clientHeight: 0, scrollHeight: 0 })).toBe(true);
+  });
+});
+
+describe("ActivityLogModal — render & controls", () => {
+  it("AC1 — renders header 'Activity log' and Copy/Clear/Done footer", () => {
+    const svc = new ActivityLogService({ now: () => 0 });
+    new ActivityLogModal(fakeApp, svc).open();
+    expect(document.body.textContent).toMatch(/Activity log/);
+    expect(findButton("Copy")).toBeDefined();
+    expect(findButton("Clear")).toBeDefined();
+    expect(findButton("Done")).toBeDefined();
+  });
+
+  it("AC3 — renders the pre-open snapshot (history captured before opening)", () => {
+    const ts = new Date(2026, 5, 15, 12, 0, 0).getTime();
+    const svc = new ActivityLogService({ now: () => ts });
+    svc.record({ category: "exosync", level: "info", message: "before-open-1" });
+    svc.record({ category: "profile", level: "info", message: "before-open-2" });
+
+    new ActivityLogModal(fakeApp, svc).open();
+    const text = listText();
+    expect(text).toMatch(/before-open-1/);
+    expect(text).toMatch(/before-open-2/);
+    expect(text).toMatch(/\[exosync\]/);
+  });
+
+  it("AC2 — a new entry recorded while open appends a row in real time", () => {
+    const svc = new ActivityLogService({ now: () => 0 });
+    new ActivityLogModal(fakeApp, svc).open();
+    expect(listText()).not.toMatch(/live-entry/);
+    svc.record({ category: "mount", level: "info", message: "live-entry" });
+    expect(listText()).toMatch(/live-entry/);
+  });
+
+  it("AC5 — Clear empties the list and the service buffer", () => {
+    const svc = new ActivityLogService({ now: () => 0 });
+    svc.record({ category: "exosync", level: "info", message: "row-x" });
+    new ActivityLogModal(fakeApp, svc).open();
+    expect(listText()).toMatch(/row-x/);
+    findButton("Clear")!.click();
+    expect(svc.size).toBe(0);
+    expect(listText()).not.toMatch(/row-x/);
+  });
+
+  it("AC4 — Copy writes the full formatted log to the clipboard", async () => {
+    const writeText = jest.fn<(t: string) => Promise<void>>().mockResolvedValue(undefined);
+    Object.defineProperty(globalThis, "navigator", {
+      value: { clipboard: { writeText } },
+      configurable: true,
+    });
+    const ts = new Date(2026, 5, 15, 8, 0, 0).getTime();
+    const svc = new ActivityLogService({ now: () => ts });
+    svc.record({ category: "exosync", level: "info", message: "one" });
+    svc.record({ category: "profile", level: "warn", message: "two" });
+
+    new ActivityLogModal(fakeApp, svc).open();
+    findButton("Copy")!.click();
+
+    expect(writeText).toHaveBeenCalledTimes(1);
+    const copied = writeText.mock.calls[0][0];
+    expect(copied).toBe(
+      "08:00:00 [exosync] one\n08:00:00 [profile] WARN two",
+    );
+  });
+
+  it("Done closes the modal (contentEl detached)", () => {
+    const svc = new ActivityLogService({ now: () => 0 });
+    new ActivityLogModal(fakeApp, svc).open();
+    expect(document.querySelector(".exocortex-activity-log-list")).not.toBeNull();
+    findButton("Done")!.click();
+    expect(document.querySelector(".exocortex-activity-log-list")).toBeNull();
+  });
+
+  it("unsubscribes on close — entries recorded after close do not throw / append", () => {
+    const svc = new ActivityLogService({ now: () => 0 });
+    const modal = new ActivityLogModal(fakeApp, svc);
+    modal.open();
+    modal.close();
+    // Recording after close must not throw (no dangling DOM writes).
+    expect(() =>
+      svc.record({ category: "exosync", level: "info", message: "after-close" }),
+    ).not.toThrow();
+    // Subscriber set drained — no live listeners remain.
+    expect((svc as unknown as { subscribers: Set<unknown> }).subscribers.size).toBe(0);
+    expect((svc as unknown as { clearSubscribers: Set<unknown> }).clearSubscribers.size).toBe(0);
+  });
+
+  it("AC6 — each rendered row carries timestamp + category + message", () => {
+    const ts = new Date(2026, 5, 15, 7, 30, 15).getTime();
+    const svc = new ActivityLogService({ now: () => ts });
+    svc.record({ category: "bootstrap", level: "info", message: "cold start" });
+    new ActivityLogModal(fakeApp, svc).open();
+    const rows = document.querySelectorAll(".exocortex-activity-log-row");
+    expect(rows).toHaveLength(1);
+    expect(rows[0].textContent).toBe("07:30:15 [bootstrap] cold start");
+  });
+});


### PR DESCRIPTION
Closes #3540.

## What

Adds an **`Exocortex: Open activity log`** command opening a modal modelled on Obsidian Sync's «Sync log» — a scrollable monospace stream of plugin activity (ExoSync push/pull/merge, profile apply/materialize phases, AssetSpace mount/unmount, bootstrap) with **Copy / Clear / Done** footer and auto-scroll.

Design asset: `vault-exodev/inbox/5d72634e-…` (interview-scoped MVP). Project: **Exocortex Alpha Launch** (WBS node `27116276`).

## How

- **New `ActivityLogService`** (`adapters/logging/`) — in-memory ring buffer (~1000, evict-oldest, ephemeral) + pub/sub (`record` / `subscribe` / `onClear` / `getSnapshot` / `clear`). No Node/fs/Obsidian deps. Instantiated in `onload()` and hoisted on the plugin → **always-on capture** so opening the modal *after* an action still shows history (AC3).
- **Fan-in** from existing producers (one-liners at the existing wiring sites):
  - ExoSync `logInfo` (always-on step feed) → `exosync`/info; `log` → `exosync`/warn.
  - `ProfileApplyManager` gains an **optional `onPhase` hook** invoked at the single `appendJournal` chokepoint (error-isolated, default no-op) → `journalEntryToActivity` maps phase→category (per-AssetSpace `as` ⇒ `mount`, lifecycle ⇒ `profile`), level (failed/aborted ⇒ error), message.
  - Bootstrap `notify` → `bootstrap`/info.
- **New `ActivityLogModal`** (`presentation/modals/`) — renders snapshot + subscribes for live appends; auto-scroll pauses on manual scroll-up; Copy → clipboard, Clear → `service.clear()`, Done → close; unsubscribes on close. Styling in `styles.css` (lint forbids inline styles).
- **Command registered UNCONDITIONALLY** (pure UI + in-memory buffer, no platform deps) → works identically on desktop and mobile per **Desktop↔Mobile Command Parity Invariant**.
- **Homoiconicity:** activity log = observability infrastructure (Q3 core/guard-rail exception) → TS, no RDF/ontology change.
- **MVP:** single chronological stream; Sync-style category dropdown + text filter intentionally deferred (documented in design).

## Tests (34 new)

- `ActivityLogService` (13): record→snapshot, eviction at cap, default cap, subscribe/unsubscribe, multi-subscriber, throwing-subscriber isolation, clear + onClear.
- `ActivityLogModal` (12): AC1 header+footer, AC3 pre-open snapshot, AC2 live append, AC4 Copy clipboard, AC5 Clear, AC6 row format, Done close, unsubscribe-on-close, `formatActivityEntry`, `shouldAutoScroll`.
- `journalEntryToActivity` (7): category routing, level, every declared phase maps.
- Integration (2): all 4 producers fan into one categorized stream + modal renders.

Local: typecheck ✓, lint ✓ (0 errors), build ✓ (+mobile-loadable ✓ no Node leak), archgate ✓ (0 failed). Regression: ProfileApplyManager 69 + ExocortexPlugin onload 92 green.