### PR TITLE
feat(plugin): feature-toggle for settings-homoiconization — default OFF (#3539)

### DIFF
--- a/packages/obsidian-plugin/src/ExocortexPlugin.ts
+++ b/packages/obsidian-plugin/src/ExocortexPlugin.ts
@@ -1914,6 +1914,22 @@ export default class ExocortexPlugin extends Plugin {
    *  4. live watchers for cross-device changes arriving via sync.
    */
   private async initVaultSettings(): Promise<void> {
+    // Issue #3539 — master switch (default OFF). When disabled, skip the
+    // entire D2 pipeline: no scanAll / applyScan / migrateMissing and no
+    // metadataCache watcher. `vaultSettingsStore` stays null, so
+    // `saveSettings()` write-back is a no-op (optional-chained) and the
+    // plugin behaves exactly as pre-D2 (reads/writes only data.json). No
+    // `exocortex-settings/` folder is created for new users; any already-
+    // migrated assets are left on disk untouched (re-adopted on re-enable).
+    // The gate is checked once here on load, so flipping the toggle in the
+    // SettingTab takes effect on the next plugin reload.
+    if (this.settings.settingsHomoiconizationEnabled !== true) {
+      this.logger.info(
+        "[D2] settings-homoiconization disabled (settingsHomoiconizationEnabled=false) — skipping vault-asset settings init",
+      );
+      return;
+    }
+
     const store = new VaultSettingsStore({
       app: this.app,
       logger: this.logger,

--- a/packages/obsidian-plugin/src/domain/settings/ExocortexSettings.ts
+++ b/packages/obsidian-plugin/src/domain/settings/ExocortexSettings.ts
@@ -263,6 +263,30 @@ export interface ExocortexSettings {
    * file logging for every channel.
    */
   verboseSyncLogging: boolean;
+  /**
+   * Issue #3539 — master switch for the settings-homoiconization feature
+   * (onto-RFC 981b6070, ExoSync Phase D2). When `true`, plugin settings are
+   * mirrored as `exo__Setting` vault assets: on plugin load (after
+   * `metadataCache` `"resolved"`) `initVaultSettings` runs a one-shot
+   * migration that creates an `exocortex-settings/` folder with one asset per
+   * registry setting, overlays vault values over `data.json`, installs a
+   * cross-device watcher, and write-backs UI changes. When `false` (default)
+   * the feature is **off**: `initVaultSettings` early-returns before any
+   * scan/overlay/migrate/watcher, so the plugin behaves exactly as pre-D2
+   * (reads/writes only `data.json`) and no `exocortex-settings/` folder is
+   * created for new users.
+   *
+   * ⛔ This flag is itself **NOT homoiconized** — it cannot live as a vault
+   * asset because it gates the very feature that materialises those assets (a
+   * master switch must not depend on the thing it controls). It lives only in
+   * `data.json`, is absent from `VAULT_SETTINGS_REGISTRY`, and is listed in
+   * `NON_HOMOICONIZABLE_FIELDS`. Turning the toggle off leaves any
+   * already-migrated `exocortex-settings/` assets on disk untouched (zero
+   * data-loss); turning it back on re-adopts them via `migrateMissing`
+   * (no duplicates). The gate runs once on plugin load, so a change applies
+   * on the next plugin reload.
+   */
+  settingsHomoiconizationEnabled: boolean;
   [key: string]: unknown;
 }
 
@@ -301,4 +325,7 @@ export const DEFAULT_SETTINGS: ExocortexSettings = {
   exosyncQuarantineRepoUrl: "",
   exosyncStepNotices: false,
   verboseSyncLogging: false,
+  // Issue #3539 — settings-homoiconization is opt-in; default OFF so a fresh
+  // install reads/writes only data.json and never creates exocortex-settings/.
+  settingsHomoiconizationEnabled: false,
 };

--- a/packages/obsidian-plugin/src/domain/settings/VaultSettingsRegistry.ts
+++ b/packages/obsidian-plugin/src/domain/settings/VaultSettingsRegistry.ts
@@ -258,6 +258,9 @@ export const NON_HOMOICONIZABLE_FIELDS: readonly string[] = [
   "pat", // secret (LocalSecretsStore) — never even in data.json
   "displayNameSettings", // structural (nested object) — deferred (D26)
   "logChannels", // structural (nested object) — deferred (D26)
+  "settingsHomoiconizationEnabled", // Issue #3539 — master switch that GATES
+  // the homoiconization feature; cannot itself be a vault asset (would depend
+  // on the thing it controls). data.json-only, never migrated.
 ];
 
 const byField = new Map(VAULT_SETTINGS_REGISTRY.map((d) => [d.field, d]));

--- a/packages/obsidian-plugin/src/presentation/settings/ExocortexSettingTab.ts
+++ b/packages/obsidian-plugin/src/presentation/settings/ExocortexSettingTab.ts
@@ -182,6 +182,25 @@ export class ExocortexSettingTab extends PluginSettingTab {
       );
 
     new Setting(containerEl)
+      .setName("Settings homoiconization")
+      .setDesc(
+        "When enabled, plugin settings are materialised as vault assets in an " +
+          'exocortex-settings/ folder so they are editable as notes and synced ' +
+          "alongside other assets. When disabled (default), settings live only " +
+          "in data.json and that folder is never created. Turning this off " +
+          "leaves any already-migrated assets on disk untouched (never deleted). " +
+          "Change applies on the next plugin reload. Issue #3539.",
+      )
+      .addToggle((toggle) =>
+        toggle
+          .setValue(this.plugin.settings.settingsHomoiconizationEnabled)
+          .onChange(async (value) => {
+            this.plugin.settings.settingsHomoiconizationEnabled = value;
+            await this.plugin.saveSettings();
+          }),
+      );
+
+    new Setting(containerEl)
       .setName("Lazy bootstrap folders")
       .setDesc(
         "Path prefixes (one per line, trailing slash required) walked eagerly " +

--- a/packages/obsidian-plugin/tests/unit/ExocortexPlugin.settingsHomoiconizationGate.test.ts
+++ b/packages/obsidian-plugin/tests/unit/ExocortexPlugin.settingsHomoiconizationGate.test.ts
@@ -1,0 +1,151 @@
+/**
+ * Issue #3539 — behavioural test for the `initVaultSettings` master-switch
+ * gate (settings-homoiconization, default OFF).
+ *
+ * Exercises the real private `initVaultSettings` method against the real
+ * `VaultSettingsStore` class (its public pipeline methods are spied so the
+ * test never touches a real vault). The plugin instance is built with
+ * `Object.create(prototype)` and the exact `this.*` fields `initVaultSettings`
+ * reads — avoiding the heavy DI/onload setup, which is irrelevant to the gate.
+ *
+ * Contract under test:
+ *  - OFF (default): no scanAll / applyScan / migrateMissing, no metadataCache
+ *    watcher registered, `vaultSettingsStore` stays null (saveSettings
+ *    write-back becomes a no-op → data.json-only, pre-D2 behaviour).
+ *  - ON: the full pipeline runs and the store + watchers are wired.
+ *
+ * Revert→fail / restore→pass: deleting the early-return in
+ * `initVaultSettings` makes the OFF test fail (scanAll IS called,
+ * vaultSettingsStore IS set) — empirically verified, see PR body.
+ */
+import ExocortexPlugin from "../../src/ExocortexPlugin";
+import { VaultSettingsStore } from "../../src/infrastructure/adapters/VaultSettingsStore";
+
+type AnyPlugin = Record<string, unknown> & {
+  initVaultSettings: () => Promise<void>;
+  vaultSettingsStore: VaultSettingsStore | null;
+};
+
+function makePlugin(
+  settingsHomoiconizationEnabled: boolean,
+): {
+  plugin: AnyPlugin;
+  registerEvent: jest.Mock;
+  metadataOn: jest.Mock;
+  vaultOn: jest.Mock;
+  notifierInfo: jest.Mock;
+  loggerInfo: jest.Mock;
+} {
+  const metadataOn = jest.fn().mockReturnValue({});
+  const vaultOn = jest.fn().mockReturnValue({});
+  const registerEvent = jest.fn();
+  const notifierInfo = jest.fn();
+  const loggerInfo = jest.fn();
+
+  const plugin = Object.create(ExocortexPlugin.prototype) as AnyPlugin;
+  Object.assign(plugin, {
+    settings: {
+      settingsHomoiconizationEnabled,
+    } as Record<string, unknown>,
+    settingsBaseline: {},
+    vaultSettingsStore: null,
+    localDataStore: null,
+    logger: {
+      info: loggerInfo,
+      warn: jest.fn(),
+      error: jest.fn(),
+      debug: jest.fn(),
+    },
+    notifier: { info: notifierInfo, warn: jest.fn() },
+    app: {
+      vault: {
+        getMarkdownFiles: jest.fn().mockReturnValue([]),
+        on: vaultOn,
+      },
+      metadataCache: { on: metadataOn },
+    },
+    registerEvent,
+    saveData: jest.fn().mockResolvedValue(undefined),
+  });
+
+  return { plugin, registerEvent, metadataOn, vaultOn, notifierInfo, loggerInfo };
+}
+
+describe("ExocortexPlugin.initVaultSettings — #3539 master-switch gate", () => {
+  let scanAll: jest.SpyInstance;
+  let applyScan: jest.SpyInstance;
+  let migrateMissing: jest.SpyInstance;
+
+  beforeEach(() => {
+    scanAll = jest
+      .spyOn(VaultSettingsStore.prototype, "scanAll")
+      .mockReturnValue({ overlay: [], missing: [] } as never);
+    applyScan = jest
+      .spyOn(VaultSettingsStore.prototype, "applyScan")
+      .mockResolvedValue([]);
+    migrateMissing = jest
+      .spyOn(VaultSettingsStore.prototype, "migrateMissing")
+      .mockResolvedValue([]);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe("OFF (default)", () => {
+    it("skips the entire D2 pipeline — no scan/overlay/migrate", async () => {
+      const { plugin } = makePlugin(false);
+
+      await plugin.initVaultSettings();
+
+      expect(scanAll).not.toHaveBeenCalled();
+      expect(applyScan).not.toHaveBeenCalled();
+      expect(migrateMissing).not.toHaveBeenCalled();
+    });
+
+    it("installs no watcher and leaves vaultSettingsStore null", async () => {
+      const { plugin, registerEvent, metadataOn } = makePlugin(false);
+
+      await plugin.initVaultSettings();
+
+      // No settings watcher registered (nothing wired through registerEvent).
+      expect(registerEvent).not.toHaveBeenCalled();
+      expect(metadataOn).not.toHaveBeenCalledWith("changed", expect.any(Function));
+      // Store never published → saveSettings() write-back is a no-op.
+      expect(plugin.vaultSettingsStore).toBeNull();
+    });
+
+    it("creates no exocortex-settings/ assets (no migration Notice)", async () => {
+      const { plugin, notifierInfo } = makePlugin(false);
+
+      await plugin.initVaultSettings();
+
+      expect(notifierInfo).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("ON", () => {
+    it("runs the full D2 pipeline (scan + overlay + migrate)", async () => {
+      const { plugin } = makePlugin(true);
+
+      await plugin.initVaultSettings();
+
+      expect(scanAll).toHaveBeenCalledTimes(1);
+      expect(applyScan).toHaveBeenCalledTimes(1);
+      expect(migrateMissing).toHaveBeenCalledTimes(1);
+    });
+
+    it("publishes the store and registers the cross-device watchers", async () => {
+      const { plugin, registerEvent, metadataOn, vaultOn } = makePlugin(true);
+
+      await plugin.initVaultSettings();
+
+      expect(plugin.vaultSettingsStore).toBeInstanceOf(VaultSettingsStore);
+      // metadataCache "changed" watcher + vault "delete"/"rename" watchers.
+      expect(metadataOn).toHaveBeenCalledWith("changed", expect.any(Function));
+      expect(vaultOn).toHaveBeenCalledWith("delete", expect.any(Function));
+      expect(vaultOn).toHaveBeenCalledWith("rename", expect.any(Function));
+      expect(registerEvent).toHaveBeenCalledTimes(3);
+    });
+  });
+});

--- a/packages/obsidian-plugin/tests/unit/ExocortexSettingTab.test.ts
+++ b/packages/obsidian-plugin/tests/unit/ExocortexSettingTab.test.ts
@@ -162,7 +162,20 @@ describe("ExocortexSettingTab", () => {
       // RFC 4e4dc453 Phase B — ExoSync section: heading + quarantine repo URL row (+2) → 42
       // Issue #3499 — ExoSync verbose per-step Notice toggle (+1) → 43
       // Issue #3498 — ExoSync verbose file-log toggle (+1) → 44
-      expect(MockSetting).toHaveBeenCalledTimes(44);
+      // Issue #3539 — settings-homoiconization master toggle (+1) → 45
+      expect(MockSetting).toHaveBeenCalledTimes(45);
+    });
+
+    it("renders the settings-homoiconization toggle (Issue #3539)", () => {
+      settingTab.display();
+
+      const names = (MockSetting as jest.Mock).mock.results
+        .map((r) => {
+          const calls = (r.value.setName as jest.Mock).mock.calls;
+          return calls.length > 0 ? (calls[0][0] as string) : undefined;
+        })
+        .filter((n): n is string => typeof n === "string");
+      expect(names).toContain("Settings homoiconization");
     });
 
     it("should render layout visibility toggle as first setting", () => {

--- a/packages/obsidian-plugin/tests/unit/SettingsHomoiconizationToggle.test.ts
+++ b/packages/obsidian-plugin/tests/unit/SettingsHomoiconizationToggle.test.ts
@@ -1,0 +1,44 @@
+/**
+ * Issue #3539 — feature-toggle for settings-homoiconization (default OFF).
+ *
+ * These assertions pin the master-switch contract at the schema level:
+ *  - it exists in DEFAULT_SETTINGS with default `false` (fresh install is OFF);
+ *  - it is a boolean;
+ *  - it is NOT homoiconized — it must be denylisted (NON_HOMOICONIZABLE_FIELDS)
+ *    and absent from VAULT_SETTINGS_REGISTRY, because a master switch cannot
+ *    depend on the very feature it gates.
+ *
+ * The anti-drift test in VaultSettingsRegistry.test.ts ("covers every
+ * ExocortexSettings field except the denylisted ones") would already fail if
+ * the field were neither registered nor denylisted; these tests state the
+ * intent explicitly so a future contributor cannot "fix" the drift test by
+ * homoiconizing the master switch.
+ */
+import { DEFAULT_SETTINGS } from "../../src/domain/settings/ExocortexSettings";
+import {
+  NON_HOMOICONIZABLE_FIELDS,
+  VAULT_SETTINGS_REGISTRY,
+} from "../../src/domain/settings/VaultSettingsRegistry";
+
+describe("settingsHomoiconizationEnabled master switch (Issue #3539)", () => {
+  it("defaults to false (opt-in — fresh install is OFF)", () => {
+    expect(DEFAULT_SETTINGS.settingsHomoiconizationEnabled).toBe(false);
+  });
+
+  it("is a boolean field", () => {
+    expect(typeof DEFAULT_SETTINGS.settingsHomoiconizationEnabled).toBe(
+      "boolean",
+    );
+  });
+
+  it("is denylisted as non-homoiconizable (cannot gate-depend on itself)", () => {
+    expect(NON_HOMOICONIZABLE_FIELDS).toContain(
+      "settingsHomoiconizationEnabled",
+    );
+  });
+
+  it("is NOT in the homoiconization registry (never a vault asset)", () => {
+    const fields = VAULT_SETTINGS_REGISTRY.map((d) => d.field);
+    expect(fields).not.toContain("settingsHomoiconizationEnabled");
+  });
+});


### PR DESCRIPTION
Closes #3539.

## Summary

Adds a user-facing master switch `settingsHomoiconizationEnabled` (data.json, **default `false`**) that gates the entire settings-homoiconization pipeline (onto-RFC `981b6070`, ExoSync Phase D2). The feature was previously **always on** — on plugin load (after `metadataCache` `"resolved"`) `initVaultSettings` ran a one-shot migration that created an `exocortex-settings/` folder with one `exo__Setting` asset per registry setting + overlay + cross-device watcher + write-back. It is now **opt-in**.

## Changes

- **`ExocortexSettings.ts`** — new boolean field + `DEFAULT_SETTINGS: false`.
- **`VaultSettingsRegistry.ts`** — `settingsHomoiconizationEnabled` added to `NON_HOMOICONIZABLE_FIELDS`. The master switch is **not** itself homoiconized — it cannot live as a vault asset because it gates the very feature that materialises those assets. This also keeps the anti-drift registry parity test green (every `DEFAULT_SETTINGS` field must be either registered or denylisted).
- **`ExocortexPlugin.ts` `initVaultSettings`** — early-return when OFF: no `scanAll` / `applyScan` / `migrateMissing`, no metadataCache watcher. `vaultSettingsStore` stays `null`, so `saveSettings()` write-back is a no-op → pre-D2 `data.json`-only behaviour. No `exocortex-settings/` folder for new users.
- **`ExocortexSettingTab.ts`** — "Settings homoiconization" toggle (applies on next plugin reload, since the gate is checked once on load).

## Acceptance criteria

- [x] Fresh install → `settingsHomoiconizationEnabled` default `false` in data.json; master switch, never a vault asset.
- [x] OFF (default) → `initVaultSettings` runs no scan/overlay/migrate, installs no watcher; behaves exactly as pre-D2 (data.json only); no folder created.
- [x] ON → current behavior preserved (scan + overlay + migrate + watcher + write-back).
- [x] OFF leaves existing `exocortex-settings/` assets on disk untouched (never deleted).
- [x] ON re-adopts existing assets via `migrateMissing` (no duplicates — unchanged code path, just not invoked when off).
- [x] SettingTab toggle with description of what it enables + OFF-default consequence.

## Desktop↔Mobile parity (CLAUDE.md invariant)

Pure settings-gate, **no `Platform` gating** — works identically on desktop and mobile. archgate MOBILE-001/002/003 green; `assert-mobile-loadable` passes (bundle evals without Node, Plugin class exported).

## Out of scope (per #3539)

- Auto-delete of `exocortex-settings/` on disable (explicitly rejected by user).
- Manual cleanup command (possible follow-up).
- Any `exo__Setting` / `exo__SettingKey` TBox change — this is pure plugin code, not an onto-change.

## Tests

- `SettingsHomoiconizationToggle.test.ts` — default-`false`, boolean, denylisted, not in registry.
- `ExocortexPlugin.settingsHomoiconizationGate.test.ts` — behavioural OFF/ON gate against the real `VaultSettingsStore` (pipeline methods spied). **Revert→fail / restore→pass empirically verified**: neutralising the early-return makes the OFF tests fail (scanAll called, watchers registered, store published); restoring makes them pass.
- `ExocortexSettingTab.test.ts` — toggle count 44→45 + "Settings homoiconization" rendered.
- Local: 6 affected suites 127/127 green; `VaultSettingsRegistry` parity 13/13 (with submodule); typecheck + lint + full build (incl. mobile-loadable) green.