### PR TITLE
fix(sparql): subquery ORDER BY+LIMIT respected in join — OrderBy before Project (#3542)

### DIFF
--- a/packages/exocortex/src/infrastructure/sparql/algebra/AlgebraTranslator.ts
+++ b/packages/exocortex/src/infrastructure/sparql/algebra/AlgebraTranslator.ts
@@ -132,6 +132,9 @@ export class ExoQLAlgebraTranslator {
       };
     }
 
+    // SELECT expressions (Extend) — computed bindings (e.g. `(?a + ?b AS ?sum)`)
+    // must be materialised BEFORE ORDER BY (which may sort by them) and BEFORE
+    // projection drops non-selected variables.
     if (selectVars.length > 0) {
       for (const v of selectVars) {
         if (isVariableExpression(v)) {
@@ -152,7 +155,25 @@ export class ExoQLAlgebraTranslator {
           };
         }
       }
+    }
 
+    // ORDER BY — applied on the full (pre-projection) solution sequence so it can
+    // sort by variables that are NOT in the SELECT list (e.g. a subquery
+    // `SELECT ?person … ORDER BY ?age`). SPARQL 1.1 §18.2.4.2 places OrderBy
+    // strictly before Project. Projecting first would drop the sort key and
+    // silently turn ORDER BY into a no-op — the rows then leak through in
+    // triple-store insertion order, which surfaces most visibly when the
+    // subquery is joined with an outer pattern (kitelev/exocortex#3542).
+    if (query.order && query.order.length > 0) {
+      operation = {
+        type: "orderby",
+        comparators: query.order.map((o: Ordering) => this.aggregateTranslator.translateOrderComparator(o)),
+        input: operation,
+      };
+    }
+
+    // Projection — AFTER ORDER BY, so the sort key stays visible to OrderBy.
+    if (selectVars.length > 0) {
       const varNames = selectVars
         .filter((v: SparqljsVariable) => isVariableTerm(v) || isVariableExpression(v))
         .map((v: SparqljsVariable) => isVariableTerm(v) ? v.value : (v as import("sparqljs").VariableExpression).variable.value);
@@ -168,14 +189,6 @@ export class ExoQLAlgebraTranslator {
 
     if (query.reduced) {
       operation = { type: "reduced", input: operation };
-    }
-
-    if (query.order && query.order.length > 0) {
-      operation = {
-        type: "orderby",
-        comparators: query.order.map((o: Ordering) => this.aggregateTranslator.translateOrderComparator(o)),
-        input: operation,
-      };
     }
 
     if (query.limit !== undefined || query.offset !== undefined) {

--- a/packages/exocortex/tests/unit/infrastructure/sparql/AlgebraTranslator.test.ts
+++ b/packages/exocortex/tests/unit/infrastructure/sparql/AlgebraTranslator.test.ts
@@ -411,11 +411,12 @@ describe("AlgebraTranslator", () => {
       const ast = parser.parse(query);
       const algebra = translator.translate(ast);
 
-      // ORDER BY wraps REDUCED
-      expect(algebra.type).toBe("orderby");
-      const reduced = (algebra as any).input;
-      expect(reduced.type).toBe("reduced");
-      expect(reduced.input.type).toBe("project");
+      // SPARQL 1.1 §18.2.4.2 nesting (outer→inner): REDUCED → Project → OrderBy.
+      // OrderBy sits INSIDE Project so it can sort by non-selected vars (#3542).
+      expect(algebra.type).toBe("reduced");
+      const project = (algebra as any).input;
+      expect(project.type).toBe("project");
+      expect(project.input.type).toBe("orderby");
     });
 
     it("translates SELECT REDUCED with LIMIT", () => {
@@ -439,9 +440,12 @@ describe("AlgebraTranslator", () => {
       const ast = parser.parse(query);
       const algebra = translator.translate(ast);
 
-      expect(algebra.type).toBe("orderby");
-      expect((algebra as any).comparators).toHaveLength(1);
-      expect((algebra as any).comparators[0].descending).toBe(false);
+      // Project wraps OrderBy (OrderBy before Project per SPARQL 1.1, #3542).
+      expect(algebra.type).toBe("project");
+      const orderby = (algebra as any).input;
+      expect(orderby.type).toBe("orderby");
+      expect(orderby.comparators).toHaveLength(1);
+      expect(orderby.comparators[0].descending).toBe(false);
     });
 
     it("translates SELECT with ORDER BY DESC", () => {
@@ -453,8 +457,11 @@ describe("AlgebraTranslator", () => {
       const ast = parser.parse(query);
       const algebra = translator.translate(ast);
 
-      expect(algebra.type).toBe("orderby");
-      expect((algebra as any).comparators[0].descending).toBe(true);
+      // Project wraps OrderBy (OrderBy before Project per SPARQL 1.1, #3542).
+      expect(algebra.type).toBe("project");
+      const orderby = (algebra as any).input;
+      expect(orderby.type).toBe("orderby");
+      expect(orderby.comparators[0].descending).toBe(true);
     });
 
     it("translates SELECT with LIMIT", () => {
@@ -499,14 +506,16 @@ describe("AlgebraTranslator", () => {
       expect((algebra as any).limit).toBe(20);
       expect((algebra as any).offset).toBe(10);
 
+      // SPARQL 1.1 §18.2.4.2 nesting (outer→inner):
+      // Slice → Distinct → Project → OrderBy (#3542).
       let current = (algebra as any).input;
-      expect(current.type).toBe("orderby");
-
-      current = current.input;
       expect(current.type).toBe("distinct");
 
       current = current.input;
       expect(current.type).toBe("project");
+
+      current = current.input;
+      expect(current.type).toBe("orderby");
     });
   });
 
@@ -1054,9 +1063,11 @@ describe("AlgebraTranslator", () => {
       const input = (algebra as any).input;
       expect(input.left.type).toBe("subquery");
       const innerQuery = input.left.query;
-      // OrderBy wraps the project
-      expect(innerQuery.type).toBe("orderby");
-      expect(innerQuery.comparators[0].descending).toBe(true);
+      // Project wraps OrderBy — OrderBy executes before projection drops the
+      // sort key (?score is not in SELECT ?x), SPARQL 1.1 §18.2.4.2 (#3542).
+      expect(innerQuery.type).toBe("project");
+      expect(innerQuery.input.type).toBe("orderby");
+      expect(innerQuery.input.comparators[0].descending).toBe(true);
     });
 
     it("translates subquery with LIMIT", () => {

--- a/packages/exocortex/tests/unit/infrastructure/sparql/executors/QueryExecutor.branch.test.ts
+++ b/packages/exocortex/tests/unit/infrastructure/sparql/executors/QueryExecutor.branch.test.ts
@@ -41,6 +41,22 @@ describe("QueryExecutor branch coverage", () => {
 
   describe("executeService", () => {
     it("executes SERVICE operation (federated query)", async () => {
+      // Deterministic offline executor: inject an immediately-failing httpClient
+      // with no retries so a SILENT service returns empty WITHOUT any real network
+      // round-trip. The original test hit a LIVE public endpoint (dbpedia), which
+      // made it timing-fragile under parallel CI load — the 30s service timeout +
+      // 2×1s retry delays could blow past jest's 5s default and flake the gate
+      // (the QueryExecutor.branch flake observed post-TF-gate, kitelev/exocortex
+      // #3542 secondary scope). Asserting the same behaviour (SILENT on an
+      // unreachable endpoint → empty) without network keeps the test fast + stable.
+      const offlineExecutor = new QueryExecutor(tripleStore, {
+        serviceConfig: {
+          httpClient: () => Promise.reject(new Error("offline endpoint (test)")),
+          maxRetries: 0,
+          retryDelay: 0,
+        },
+      });
+
       const algebra: AlgebraOperation = {
         type: "service",
         endpoint: "http://dbpedia.org/sparql",
@@ -49,7 +65,7 @@ describe("QueryExecutor branch coverage", () => {
       };
 
       // SERVICE with silent=true should not throw even if endpoint is unreachable
-      const results = await executor.executeAll(algebra);
+      const results = await offlineExecutor.executeAll(algebra);
       // Silent service returns empty on failure
       expect(results).toHaveLength(0);
     });

--- a/packages/exocortex/tests/unit/sparql/subquery-acceptance.test.ts
+++ b/packages/exocortex/tests/unit/sparql/subquery-acceptance.test.ts
@@ -279,12 +279,12 @@ describe("Issue #2600: Subquery execution in ExoQLQueryExecutor", () => {
   // AC-4: ORDER BY + LIMIT in inner query
   // ---------------------------------------------------------------
   describe("AC-4: ORDER BY + LIMIT in inner query", () => {
-    // SKIPPED — kitelev/exocortex#3542: a subquery's inner ORDER BY … LIMIT/OFFSET
-    // is dropped when the subquery is JOINed with an outer pattern (rows return in
-    // insertion order). The inner query alone is correct; the bug is in the
-    // executeJoin × executeSubquery interaction. These two cases encode the correct
-    // SPARQL semantics and double as the regression test — un-skip when #3542 lands.
-    it.skip("should return only the N youngest people via subquery", async () => {
+    // kitelev/exocortex#3542 (FIXED): a subquery's inner ORDER BY … LIMIT/OFFSET
+    // was dropped when the subquery is JOINed with an outer pattern (rows returned
+    // in triple-store insertion order). Root cause: AlgebraTranslator nested Project
+    // INSIDE OrderBy, so ORDER BY on a non-selected variable (?age) lost its sort
+    // key. Fixed by ordering OrderBy before Project (SPARQL 1.1 §18.2.4.2).
+    it("should return only the N youngest people via subquery", async () => {
       const query = `
         PREFIX exo: <https://exocortex.my/ontology/exo#>
 
@@ -312,8 +312,8 @@ describe("Issue #2600: Subquery execution in ExoQLQueryExecutor", () => {
       expect(names).not.toContain("Carol");
     });
 
-    // SKIPPED — kitelev/exocortex#3542 (same join × subquery ORDER BY defect).
-    it.skip("should respect OFFSET in inner query", async () => {
+    // kitelev/exocortex#3542 (FIXED) — same OrderBy-before-Project root cause.
+    it("should respect OFFSET in inner query", async () => {
       const query = `
         PREFIX exo: <https://exocortex.my/ontology/exo#>
 


### PR DESCRIPTION
## Summary

Fixes kitelev/exocortex#3542. A nested `SELECT` subquery's inner `ORDER BY … LIMIT/OFFSET` was silently dropped when the subquery is joined with an outer pattern — rows leaked through in triple-store **insertion order** instead of the ordered/limited set ("top-N joined with details" returned wrong rows).

## Root cause (NOT executeJoin — empirically verified)

The issue hypothesised the defect was in `executeJoin × executeSubquery`. Empirical algebra dump + execution traces (Alice=30/Bob=25/Carol=35/Dave=28) showed the real cause is in **`AlgebraTranslator.translateSelect`**: it nested `Project` **inside** `OrderBy` → `slice(orderby(project(bgp)))`.

When `ORDER BY` references a variable that is **not** in the `SELECT` list (a subquery `SELECT ?person … ORDER BY ?age`), `executeProject` drops the sort key (`?age`) **before** `executeOrderBy` reads it → ORDER BY degrades to a no-op → `slice` takes the first N rows in insertion order.

This also affected **standalone** queries: `SELECT ?person … ORDER BY ?age LIMIT 2` (age not selected) returned `[Alice, Bob]`, not `[Bob, Dave]` — the issue's claim that "standalone is correct" only held when the order variable was in `SELECT`.

| Case | Before | After |
|---|---|---|
| standalone `SELECT ?person … ORDER BY ?age LIMIT 2` | Alice, Bob ❌ | Bob, Dave ✅ |
| subquery + join (LIMIT 2) | Alice, Bob ❌ | Bob, Dave ✅ |
| subquery + join (OFFSET 1 LIMIT 2) | Bob, Carol ❌ | Dave, Alice ✅ |

## Fix

Apply solution modifiers in SPARQL 1.1 §18.2.4.2 order — `slice(distinct(project(orderby(extend(…)))))` — so `OrderBy` runs on the full pre-projection solution sequence and can sort by non-selected variables.

## Tests

- **Un-skipped the 2 AC-4 cases** in `subquery-acceptance.test.ts` (they double as the regression test). Revert-verify: both FAIL pre-fix (`[Alice, Bob]`), PASS post-fix (`[Bob, Dave]`) — verified empirically in-session.
- Updated `AlgebraTranslator.test.ts` assertions (5 cases) that codified the old, buggy `OrderBy`-outside-`Project` nesting.
- Full sparql regression: **222 suites / 5896 tests green**, full exocortex package green except the pre-existing submodule-fixture-dependent `grounding-type-vault-fixture-parity` false-local-fail (documented, orthogonal).

## Secondary: QueryExecutor.branch federated flake (#3542 scope)

The TF-gate exposed a timing-fragile federated-`SERVICE` test that hit a **live** public endpoint (dbpedia) → under parallel CI load the 30s service timeout + 2×1s retries could exceed jest's 5s default and flake. Made it **deterministic**: inject an immediately-failing `httpClient` with `maxRetries:0` so a SILENT service returns empty without any network round-trip (1092ms → 3ms). Same assertion, no network dependency.

## Scope

`packages/exocortex/src/infrastructure/sparql/algebra/AlgebraTranslator.ts` + 3 test files. SPARQL-engine only — disjoint from settings / apply-engine.