### PR TITLE
fix(#3538-followup): detect + warn legacy flat-mounts on apply-profile

### DIFF
--- a/docs/profile.md
+++ b/docs/profile.md
@@ -244,7 +244,7 @@ fully atomic** on every partial failure. Know the exact boundary
 
 **Not yet atomic (desktop):** if a step **fails** mid-Phase-2 (e.g. a
 `git submodule add` errors out on the 2nd of several AssetSpaces), the in-process
-catch restores the *destroyed* AssetSpaces from cache (best-effort) but does **not**
+catch restores the _destroyed_ AssetSpaces from cache (best-effort) but does **not**
 git-reset the working tree. The vault is therefore left with **uncommitted
 `.gitmodules`/submodule changes** and possibly one **partially-added** AssetSpace —
 the apply git-commit only runs on success. The vault content is recoverable, but
@@ -279,6 +279,45 @@ To **minimize** the chance of hitting the window: commit (or stash) local change
 before applying — the desktop path aborts on uncommitted changes in any to-destroy
 AssetSpace (Vision Lock #5) — and prefer a stable network/power state for a large
 cold apply (many AssetSpaces pulled sequentially).
+
+### Legacy flat-mount migration
+
+Apply locates a materialized AssetSpace by its **canonical** mount path
+`assetspaces/<owner>/<repo>` (`derivePath`). Vaults set up before #3538 may have
+AssetSpaces mounted at the **legacy flat** path `assetspaces/<repo>` (the
+`exoas-` prefix stripped) — the old `add-assetspace` / `bootstrap` layout. Apply
+does **not** recognise a flat folder as materialized, so it would re-materialize
+the same AssetSpace at the canonical path → a **double mount** of one AssetSpace
+UID (duplicate triples, SHACL noise).
+
+Apply now **detects** this and shows a one-time Notice naming each affected
+AssetSpace as `<label> (assetspaces/<repo> → assetspaces/<owner>/<repo>)`. Apply
+does **not** auto-migrate (a runtime directory move on the destructive apply path
+is intentionally out of scope — see the
+[partial-failure boundary](#partial-failure-boundary--what-the-2-phase-commit-does-and-does-not-cover)).
+Migrate manually, once, per affected AssetSpace:
+
+1. **Commit or stash** any local changes in the vault first (treat this like the
+   recovery flow above).
+2. **Remove the legacy flat mount.** The goal is to delete the flat folder and
+   its stale `.gitmodules` entry, so apply re-creates the AssetSpace at the
+   canonical path.
+   - **Desktop** (vault root, the flat path is a real git submodule):
+     ```bash
+     git submodule deinit -f assetspaces/<repo>
+     git rm -f assetspaces/<repo>            # drops the .gitmodules entry + index
+     rm -rf .git/modules/assetspaces/<repo>  # clear the submodule git dir
+     git commit -m "chore: remove legacy flat-mount assetspaces/<repo>"
+     ```
+   - **Mobile** (no git binary): delete the `assetspaces/<repo>` folder (Files app,
+     or from a synced desktop), and remove its `[submodule "assetspaces/<repo>"]`
+     stanza from `.gitmodules`.
+3. **Re-run «Exocortex: Apply profile»** to your current profile. Apply now finds
+   no materialized copy and re-materializes the AssetSpace at the canonical
+   `assetspaces/<owner>/<repo>` path. The warn Notice no longer appears.
+
+Fresh vaults bootstrapped on #3538+ mount canonically from the start and never
+see this Notice.
 
 ---
 

--- a/packages/exocortex/src/index.ts
+++ b/packages/exocortex/src/index.ts
@@ -264,7 +264,7 @@ export {
   IRICanonicalizer,
   type CanonicalizationResult,
 } from "./services/IRICanonicalizer";
-export { derivePath } from "./services/AssetSpacePathDeriver";
+export { derivePath, deriveLegacyFlatPath } from "./services/AssetSpacePathDeriver";
 export {
   discoverFileSpaceExclusions,
   frontmatterDeclaresFileSpace,

--- a/packages/exocortex/src/services/AssetSpacePathDeriver.ts
+++ b/packages/exocortex/src/services/AssetSpacePathDeriver.ts
@@ -98,3 +98,37 @@ export function derivePath(source: unknown): string | null {
 
   return `${ASSET_SPACES_PREFIX}/${owner}/${repo}`;
 }
+
+/**
+ * Derive the LEGACY flat mount path `assetspaces/<repo>` (with an `exoas-`
+ * prefix stripped) that pre-#3538 `add-assetspace` / `bootstrap` mounted at,
+ * before the canonical Maven `derivePath` (`assetspaces/<owner>/<repo>`) was
+ * adopted. Mirrors the old `deriveFolderName` — both the plugin closure and the
+ * CLI `BootstrapAssetSpaceService.deriveFolderName` — which stripped the
+ * `exoas-` prefix and mounted a single level under `assetspaces/`.
+ *
+ * Used ONLY by flat-mount detection (#3538 follow-up): an AssetSpace
+ * materialized at this legacy path is invisible to apply-profile's canonical
+ * `derivePath` materialization check → it gets re-materialized at the canonical
+ * path → latent DOUBLE MOUNT of the same AssetSpace UID. Detection compares the
+ * two; they differ exactly when a manual migration is warranted.
+ *
+ * Reuses `derivePath` so it inherits the same normalisation (scheme/.git/
+ * trailing-slash/scp-form/credentials) and the path-traversal / out-of-charset
+ * segment guards — the returned `<repo>` is already validated. Returns `null`
+ * for the same un-derivable inputs as `derivePath` (no `<owner>/<repo>` pair)
+ * and when the stripped repo is empty (`exoas-` with nothing after it).
+ */
+export function deriveLegacyFlatPath(source: unknown): string | null {
+  const canonical = derivePath(source);
+  if (canonical === null) return null;
+  // canonical === `assetspaces/<owner>/<repo>` with validated segments — the
+  // third path component is the repo name.
+  const repo = canonical.split("/")[2];
+  if (repo === undefined || repo.length === 0) return null;
+  const flat = repo.startsWith("exoas-")
+    ? repo.slice("exoas-".length)
+    : repo;
+  if (flat.length === 0) return null;
+  return `${ASSET_SPACES_PREFIX}/${flat}`;
+}

--- a/packages/exocortex/tests/unit/services/AssetSpacePathDeriver.test.ts
+++ b/packages/exocortex/tests/unit/services/AssetSpacePathDeriver.test.ts
@@ -1,4 +1,7 @@
-import { derivePath } from "../../../src/services/AssetSpacePathDeriver";
+import {
+  derivePath,
+  deriveLegacyFlatPath,
+} from "../../../src/services/AssetSpacePathDeriver";
 
 describe("derivePath (RFC 01a83de8 v10 UD1)", () => {
   const EXPECTED = "assetspaces/kitelev/exoas-ems";
@@ -110,5 +113,82 @@ describe("derivePath (RFC 01a83de8 v10 UD1)", () => {
       expect(https).toBe(ssh);
       expect(https).toBe(EXPECTED);
     });
+  });
+});
+
+describe("deriveLegacyFlatPath (#3538 follow-up — flat-mount detection)", () => {
+  describe("strips the `exoas-` prefix to the pre-#3538 flat path", () => {
+    it.each([
+      ["HTTPS", "https://github.com/kitelev/exoas-ems", "assetspaces/ems"],
+      [
+        "HTTPS with .git",
+        "https://github.com/kitelev/exoas-registry.git",
+        "assetspaces/registry",
+      ],
+      [
+        "SSH scp-like",
+        "git@github.com:kitelev/exoas-kitelev-profiles.git",
+        "assetspaces/kitelev-profiles",
+      ],
+      [
+        "all forms normalise",
+        "  ssh://git@github.com:22/kitelev/exoas-testlib.git/  ",
+        "assetspaces/testlib",
+      ],
+    ])("%s → flat path", (_label, url, expected) => {
+      expect(deriveLegacyFlatPath(url)).toBe(expected);
+    });
+  });
+
+  it("repo WITHOUT an `exoas-` prefix keeps its name (single level)", () => {
+    expect(deriveLegacyFlatPath("https://github.com/alice/shared")).toBe(
+      "assetspaces/shared",
+    );
+  });
+
+  describe("legacy flat path DIFFERS from canonical — the migration signal", () => {
+    it("registry: flat (exoas- stripped) vs canonical owner/repo", () => {
+      // `deriveFolderName` stripped only the leading `exoas-` token, so
+      // `exoas-kitelev-registry` → `kitelev-registry` (NOT `registry`).
+      const url = "https://github.com/kitelev/exoas-kitelev-registry";
+      expect(deriveLegacyFlatPath(url)).toBe("assetspaces/kitelev-registry");
+      expect(derivePath(url)).toBe("assetspaces/kitelev/exoas-kitelev-registry");
+      // The two MUST differ — that inequality is exactly what apply-profile's
+      // flat-mount detection keys on.
+      expect(deriveLegacyFlatPath(url)).not.toBe(derivePath(url));
+    });
+
+    it("short repo: flat assetspaces/registry vs canonical owner/repo", () => {
+      const url = "https://github.com/kitelev/exoas-registry";
+      expect(deriveLegacyFlatPath(url)).toBe("assetspaces/registry");
+      expect(derivePath(url)).toBe("assetspaces/kitelev/exoas-registry");
+      expect(deriveLegacyFlatPath(url)).not.toBe(derivePath(url));
+    });
+  });
+
+  describe("null on un-derivable input (same cases as derivePath)", () => {
+    it.each([
+      ["empty string", ""],
+      ["non-string", 42 as unknown as string],
+      ["undefined", undefined as unknown as string],
+      ["host only, no repo", "https://github.com/kitelev"],
+      ["file:// local clone", "file:///tmp/abc/remote-as1"],
+      ["path traversal", "https://github.com/owner/.."],
+      // `exoas-` with nothing after the prefix → empty flat segment → null.
+      ["exoas- prefix only (empty stripped repo)", "https://github.com/o/exoas-"],
+    ])("%s → null", (_label, input) => {
+      expect(deriveLegacyFlatPath(input)).toBeNull();
+    });
+  });
+
+  it("inherits derivePath's traversal guard — never emits a `..` component", () => {
+    for (const input of [
+      "../../etc/passwd",
+      "https://github.com/owner/..",
+      "git@github.com:../escape.git",
+    ]) {
+      const out = deriveLegacyFlatPath(input);
+      if (out !== null) expect(out.split("/")).not.toContain("..");
+    }
   });
 });

--- a/packages/obsidian-plugin/src/infrastructure/adapters/ProfileApplyManager.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/ProfileApplyManager.ts
@@ -3,6 +3,7 @@ import type { App } from "obsidian";
 import type { ApplyPlan, IConfirmGate } from "exocortex";
 import {
   derivePath,
+  deriveLegacyFlatPath,
   assertTsFloorReconciled,
   PLUGIN_UI_FLOOR,
   CATALOG_KEEP_NAMESPACES,
@@ -651,6 +652,17 @@ export class ProfileApplyManager {
         "applyProfile: ExoSync run in progress (D11 guard) — retry after it finishes",
       );
     }
+    // #3538 follow-up — WARN (read-only, no FS mutation) when any AssetSpace is
+    // still materialized at a LEGACY FLAT path (`assetspaces/<repo>`, pre-#3538)
+    // whose canonical `derivePath` (`assetspaces/<owner>/<repo>`) differs. Both
+    // apply paths below key materialization on the canonical path, so a
+    // flat-mounted AS is invisible → re-materialized at the canonical path →
+    // latent DOUBLE MOUNT of the same UID. Auto-migration (runtime directory
+    // move + `.gitmodules` rewrite) is intentionally deferred (risky on the
+    // apply core — cf. partial-failure atomicity boundary, #3548); this only
+    // surfaces the gap and points to the manual migration guide. Placed before
+    // the mobile/desktop split so the single warn covers both platforms.
+    await this.warnLegacyFlatMounts();
     // RFC 01a83de8 Phase 3 T2 — on mobile the git binary is unavailable, so
     // delegate to the REST/tarball mount/unmount path (no staging / cache /
     // git commit). Desktop keeps the git-binary path below unchanged.
@@ -1793,6 +1805,79 @@ export class ProfileApplyManager {
       out.set(info.folderName, info.uid);
     }
     return out;
+  }
+
+  /**
+   * #3538 follow-up — detect AssetSpaces materialized at a LEGACY FLAT path
+   * (`assetspaces/<repo>`, pre-#3538 `deriveFolderName`) whose canonical
+   * `derivePath` (`assetspaces/<owner>/<repo>`) differs and which still has its
+   * flat folder on disk.
+   *
+   * Read-only (only `vault.adapter.exists`, no mutation). Both-platform — uses
+   * neither `gitOps` (desktop-only) nor `.gitmodules`; the on-disk flat folder
+   * is the authoritative signal regardless of how the entry was recorded.
+   *
+   * apply-profile keys materialization on the canonical `derivePath`
+   * (`derivePhysicallyMaterializedAsUids` on desktop; `vault.adapter.exists` of
+   * the canonical folder on mobile), so a flat-mounted AssetSpace is NOT
+   * recognised as materialized → re-materialized at the canonical path →
+   * latent DOUBLE MOUNT of the same AssetSpace UID. This surfaces the affected
+   * AssetSpaces so the user can migrate them manually (see docs/profile.md);
+   * auto-migration is deferred (risky runtime directory move).
+   */
+  private async detectLegacyFlatMounts(): Promise<
+    Array<{ flat: string; canonical: string; label: string }>
+  > {
+    const out: Array<{ flat: string; canonical: string; label: string }> = [];
+    const seenFlat = new Set<string>();
+    for (const info of this.listAllAssetSpaceInfos()) {
+      const flat = deriveLegacyFlatPath(info.git);
+      // No legacy form, or the canonical path IS the flat path (un-derivable
+      // source fell back to flat) → nothing to migrate.
+      if (flat === null || flat === info.folderName) continue;
+      if (seenFlat.has(flat)) continue;
+      let exists: boolean;
+      try {
+        exists = await this.app.vault.adapter.exists(flat);
+      } catch {
+        // Best-effort detection — never let a probe failure block apply.
+        continue;
+      }
+      if (!exists) continue;
+      seenFlat.add(flat);
+      out.push({
+        flat,
+        canonical: info.folderName,
+        label: info.namespace || info.uid.slice(0, 8),
+      });
+    }
+    return out;
+  }
+
+  /**
+   * Emit a single user-facing Notice (via {@link notify}) when
+   * {@link detectLegacyFlatMounts} finds any legacy flat-mount. No-op (no
+   * Notice) when none — so fresh vaults bootstrapped on the canonical layout
+   * never see this. Failures are swallowed: a detection problem must never
+   * abort the apply itself.
+   */
+  private async warnLegacyFlatMounts(): Promise<void> {
+    let legacy: Array<{ flat: string; canonical: string; label: string }>;
+    try {
+      legacy = await this.detectLegacyFlatMounts();
+    } catch {
+      return;
+    }
+    if (legacy.length === 0) return;
+    const list = legacy
+      .map((m) => `${m.label} (${m.flat} → ${m.canonical})`)
+      .join(", ");
+    this.notify(
+      `⚠ ${legacy.length} AssetSpace(s) mounted at a legacy flat path: ${list}. ` +
+        "apply-profile expects the canonical assetspaces/<owner>/<repo> layout — " +
+        "migrate manually to avoid a double mount (see docs/profile.md → " +
+        '"Legacy flat-mount migration").',
+    );
   }
 
   /**

--- a/packages/obsidian-plugin/tests/unit/ProfileApplyManager.apply.test.ts
+++ b/packages/obsidian-plugin/tests/unit/ProfileApplyManager.apply.test.ts
@@ -433,6 +433,9 @@ function setup(opts: SetupOptions) {
   const assetSpaceManager = new FakeAssetSpaceManager();
   const confirmGate = new FakeConfirmGate();
 
+  // Capture user-facing Notices (#3538 legacy flat-mount warn + others).
+  const notifyMessages: string[] = [];
+
   const mgr = new ProfileApplyManager({
     app,
     lockMgr,
@@ -447,6 +450,7 @@ function setup(opts: SetupOptions) {
     confirmGate,
     localDataStore: localDataStore as any,
     /* eslint-enable @typescript-eslint/no-explicit-any */
+    notify: (m: string) => notifyMessages.push(m),
     vaultRootPath: "/fake/vault",
     ...(opts.isSyncBusy !== undefined ? { isSyncBusy: opts.isSyncBusy } : {}),
     ...(opts.applyTimeoutMs !== undefined
@@ -463,6 +467,7 @@ function setup(opts: SetupOptions) {
     uncommittedGuard,
     assetSpaceManager,
     confirmGate,
+    notifyMessages,
     app,
     fsFiles,
     fsFolders,
@@ -561,6 +566,73 @@ describe("ProfileApplyManager.applyProfile", () => {
         materialized: [TS_FLOOR_AS_UID_EXO],
       });
       await expect(mgr.applyProfile("target")).resolves.toBeUndefined();
+    });
+  });
+
+  describe("#3538 follow-up — legacy flat-mount warn", () => {
+    // $exo's source `https://github.com/kitelev/exoas-exo` derives to canonical
+    // `assetspaces/kitelev/exoas-exo`; its pre-#3538 legacy flat path is
+    // `assetspaces/exo` (deriveFolderName strips `exoas-`).
+    const FLAT_EXO = "assetspaces/exo";
+
+    it("WARNS when an AssetSpace is materialized at the legacy flat path", async () => {
+      const ctx = setup({
+        targetUid: "target",
+        sourceUid: null,
+        targetIncludes: [TS_FLOOR_AS_UID_EXO], // floor={exo} — resolves OK
+        materialized: [TS_FLOOR_AS_UID_EXO],
+      });
+      // Simulate the legacy flat-mount on disk (the dogfood-iPhone state).
+      ctx.fsFolders.set(FLAT_EXO, { files: [`${FLAT_EXO}/file1.md`], folders: [] });
+
+      await expect(ctx.mgr.applyProfile("target")).resolves.toBeUndefined();
+
+      const warn = ctx.notifyMessages.find((m) =>
+        m.includes("legacy flat path"),
+      );
+      expect(warn).toBeDefined();
+      // Names the affected flat path → canonical migration target.
+      expect(warn).toContain(FLAT_EXO);
+      expect(warn).toContain("assetspaces/kitelev/exoas-exo");
+      expect(warn).toContain("docs/profile.md");
+    });
+
+    it("REVERT-VERIFY: no warn when no flat-mount folder exists on disk", async () => {
+      // Identical setup MINUS the flat folder → the guard must stay silent
+      // (no false positive on a canonically-mounted vault).
+      const ctx = setup({
+        targetUid: "target",
+        sourceUid: null,
+        targetIncludes: [TS_FLOOR_AS_UID_EXO],
+        materialized: [TS_FLOOR_AS_UID_EXO],
+      });
+
+      await expect(ctx.mgr.applyProfile("target")).resolves.toBeUndefined();
+
+      expect(
+        ctx.notifyMessages.find((m) => m.includes("legacy flat path")),
+      ).toBeUndefined();
+    });
+
+    it("does NOT abort apply if detection throws (best-effort, read-only)", async () => {
+      const ctx = setup({
+        targetUid: "target",
+        sourceUid: null,
+        targetIncludes: [TS_FLOOR_AS_UID_EXO],
+        materialized: [TS_FLOOR_AS_UID_EXO],
+      });
+      // Make the flat-mount existence probe throw — apply must still succeed.
+      const realExists = ctx.app.vault.adapter.exists.bind(
+        ctx.app.vault.adapter,
+      );
+      (ctx.app.vault.adapter as unknown as { exists: unknown }).exists = async (
+        p: string,
+      ) => {
+        if (p === FLAT_EXO) throw new Error("simulated adapter failure");
+        return realExists(p);
+      };
+
+      await expect(ctx.mgr.applyProfile("target")).resolves.toBeUndefined();
     });
   });
 

--- a/packages/obsidian-plugin/tests/unit/ProfileApplyManager.restApply.test.ts
+++ b/packages/obsidian-plugin/tests/unit/ProfileApplyManager.restApply.test.ts
@@ -300,6 +300,8 @@ function setup(opts: SetupOpts) {
     factoryMount,
     gitOps,
     notifyCalls,
+    app,
+    fsFolders,
   };
 }
 
@@ -564,5 +566,28 @@ describe("applyProfile dispatch (mobile → REST)", () => {
     expect(restMount.unmounted).toEqual(["assetspaces/kitelev/exoas-kpc"]);
     // …and the git-binary path was NOT used.
     expect(gitOps.calls).toEqual([]);
+  });
+
+  it("#3538 — warns about legacy flat-mount on the MOBILE dispatch path", async () => {
+    // Proves the both-platform claim end-to-end: the warn lives in the
+    // `applyProfile` dispatcher BEFORE the mobile/desktop split, so it must fire
+    // when mobile delegates to applyProfileViaRest (not just on desktop).
+    (Platform as unknown as { isMobile: boolean }).isMobile = true;
+    const { mgr, notifyCalls, fsFolders } = setup({
+      targetIncludes: [...ALL_FLOOR_UIDS, "ems-uid"],
+      materialized: [...ALL_FLOOR_UIDS],
+    });
+    // ems canonical = assetspaces/kitelev/exoas-ems; legacy flat = assetspaces/ems.
+    fsFolders.set("assetspaces/ems", {
+      files: ["assetspaces/ems/file1.md"],
+      folders: [],
+    });
+
+    await mgr.applyProfile("target");
+
+    const warn = notifyCalls.find((m) => m.includes("legacy flat path"));
+    expect(warn).toBeDefined();
+    expect(warn).toContain("assetspaces/ems");
+    expect(warn).toContain("assetspaces/kitelev/exoas-ems");
   });
 });


### PR DESCRIPTION
## Problem

#3538 (v16.95.3) aligned `add-assetspace`/`bootstrap` on the canonical Maven mount path `assetspaces/<owner>/<repo>` (`derivePath`) for **NEW** mounts. Gap left open: **existing** flat-mounts from pre-#3538 sessions — `assetspaces/<repo>` (old `deriveFolderName`, `exoas-` stripped) — are still on disk on the user's dogfood iPhone (registry/profiles).

apply-profile keys "is materialized" on the **canonical** path:
- desktop: `derivePhysicallyMaterializedAsUids` matches `.gitmodules` paths against `derivePath(git)`;
- mobile (`applyProfileViaRest`): probes `vault.adapter.exists(derivePath)`.

A flat-mounted AssetSpace matches neither → treated as not-materialized → re-materialized at the canonical path → **latent DOUBLE MOUNT** of the same AssetSpace UID (the exact failure #3538 closed for new mounts, still open for existing ones).

**Confirmed in code, not overtaken** (no existing flat-mount detection/migration anywhere). **Non-alpha-blocking** — fresh alpha testers bootstrap canonical on #3538+; affects only the existing dogfood device.

## Scope decision: detect + WARN + manual-fix guide (NOT auto-migrate)

Auto-migration would mean a **runtime directory move + `.gitmodules` rewrite** on the destructive apply path — intentionally deferred (risky; cf. the partial-failure atomicity boundary documented in #3548, and unverifiable end-to-end against the iPhone dogfood state from CI). Tracked as a nested follow-up. This PR ships read-only detection + a clean manual migration path, mirroring the #3548 docs-first precedent.

## Changes

- **`exocortex`** — new `deriveLegacyFlatPath(source)` (reuses `derivePath`, inheriting its normalization + path-traversal/charset guards) returning the pre-#3538 flat path `assetspaces/<repo>`; exported from the package index.
- **`obsidian-plugin`** — `detectLegacyFlatMounts()` (read-only; only `vault.adapter.exists`; both-platform — no `gitOps`/`.gitmodules` dependency) + `warnLegacyFlatMounts()` one-time Notice, wired in the `applyProfile` **dispatcher before the mobile/desktop split** so a single warn covers both platforms. Best-effort: a detection failure never aborts the apply.
- **`docs/profile.md`** — "Legacy flat-mount migration" section (desktop git-submodule + mobile steps).

## Tests (revert-verified per integration-test-revert-verify)

- `deriveLegacyFlatPath`: strip/no-strip, null on un-derivable, traversal guard, migration-signal (flat ≠ canonical). 53/53 in the suite.
- `ProfileApplyManager`: **warns** when a flat folder is on disk; **no warn** (no false positive) when only canonical; detection throw does **not** abort apply.
- **Revert-verify:** commenting out `warnLegacyFlatMounts()` makes the positive test FAIL (warn not emitted) while the negative/best-effort tests still pass; restoring → all green.

Full monorepo `npm run build` green (incl. mobile-loadable + console-channel asserts); all 4 ProfileApplyManager suites + AssetSpacePathDeriver suite pass.

Closes the detection half of the #3538 flat-mount gap (WBS node `9716c5ac`, Exocortex Alpha Launch M3). Auto-migrate → deferred follow-up.