### PR TITLE
docs(getting-started): document GitHub PAT setting + private/own AssetSpace path

### DIFF
--- a/docs/Getting-Started.md
+++ b/docs/Getting-Started.md
@@ -381,10 +381,20 @@ The Exocortex layout renders automatically in Reading Mode based on the note's `
 
 ## Plugin Settings
 
-Open **Settings → Exocortex** to configure the plugin. Two things worth knowing up front:
+Open **Settings → Exocortex** to configure the plugin. Three things worth knowing up front:
 
 - **Settings live in your vault.** After updating the plugin you will see an `exocortex-settings/` folder appear, with one `exo__Setting` note per setting. This is a one-shot migration (the plugin shows a Notice like *"Exocortex: migrated N setting(s) to vault assets"*); editing those notes is equivalent to changing the setting in the UI. See [Settings Homoiconization](settings-homoiconization.md).
 - **Excluded folders**: folder prefixes listed in this setting (default: `09 Templates/`) are skipped by RDF indexing and SHACL-lite validation — useful for template folders whose frontmatter is incomplete by design. Reload Obsidian after editing the list; the indexer snapshots it at startup.
+- **GitHub PAT** (Settings → Exocortex → *Profile: GitHub PAT*): a fine-grained Personal Access Token used to **push** AssetSpace changes and to **pull private** AssetSpaces. You do **not** need it for the public starter onboarding (Steps 2–2b are all public, no token). Set it only when you run **"Exocortex: Sync"** (push), the **"Push current assetspace"** command, or **"Apply profile"** on a profile that includes a private repository. It is stored in `data.local.json` (not `data.json`), so Obsidian Sync **excludes it from network replication**. Use **"Save PAT"** / **"Test connection"** to store and verify it; leave the field blank and click Save to clear it.
+
+### Adding your own / private AssetSpaces
+
+The starter onboarding (Step 2b) pulls only **public** repositories, so no token is involved. To add **your own** or a **private** AssetSpace:
+
+1. Configure your **GitHub PAT** in *Settings → Exocortex* (see the bullet above), scoped to the repositories you own (fine-grained PAT with a per-repository allowlist is recommended).
+2. Declare the AssetSpace in a profile (an `exo__Profile` asset that lists it under `exo__Profile_includes`) and run **"Exocortex: Apply profile"**. Apply uses your PAT to materialize private AssetSpaces.
+
+> The **"Add assetspace by URL"** command is for a single **public** repository (no token), and it does **not** pull that repo's dependencies automatically. For private content, or for a complete dependency-resolved set, prefer the profile path (**Apply profile**) over **Add assetspace by URL**.
 
 ---
 


### PR DESCRIPTION
## What

Closes a documentation gap found during the Alpha Launch UX-onboarding audit (subproject `ec01fc7d`, finding **F2**).

The `Getting-Started.md` **Plugin Settings** section listed only `exocortex-settings/` and *Excluded folders* — it **omitted the `Profile: GitHub PAT` setting**, even though the Sync section references it and Settings → Exocortex has a prominent PAT block. There was also **no guidance for adding your own / private AssetSpaces**.

## Changes (docs-only)

- **Plugin Settings**: add a **GitHub PAT** bullet — what it's for (push + private pull), that the **public starter onboarding does not need it**, where it's stored (`data.local.json`, sync-excluded), and the Save/Test buttons.
- New **"Adding your own / private AssetSpaces"** subsection: steer users to the **PAT + Apply-profile** path; note that **Add assetspace by URL** is public-only and does **not** auto-resolve dependencies.

## Why non-trivial / context

The UX-audit initially flagged a *missing onboarding guide* (CRITICAL) — that was a **stale-checkout false alarm**: `origin/main` already migrated `Getting-Started.md` to the Alpha bootstrap → registry → `Apply profile` flow. The real residual gap is this small PAT / private-AS documentation hole. No new guide needed.

## Scope

Docs-only. No code, no behavior change. The remaining UX findings (F2 modal-hint code change, F4 helper-text polish) are tracked as Backlog nodes under `ec01fc7d` and can be separate code PRs.