### PR TITLE
fix(#3554): defer profile recovery/reconcile to onLayoutReady (onload hang)

### DIFF
--- a/docs/profile.md
+++ b/docs/profile.md
@@ -280,6 +280,37 @@ before applying — the desktop path aborts on uncommitted changes in any to-des
 AssetSpace (Vision Lock #5) — and prefer a stable network/power state for a large
 cold apply (many AssetSpaces pulled sequentially).
 
+### Obsidian hangs at "Loading plugins…" after an apply
+
+> **Fixed in the #3554 build.** Recovery/reconcile now runs after the workspace is
+> ready, so onload can no longer deadlock. The steps below are the manual recovery
+> for anyone still on a pre-#3554 build (e.g. an older BRAT install).
+
+**Symptom:** right after a successful `Apply profile`, the _next_ Obsidian load (a
+`Reload app without saving`, or a full quit + relaunch) gets stuck on
+"Loading plugins…" forever — the workspace never finishes loading and the vault is
+unusable. `Reload app in Restricted Mode` (community plugins off) loads fine, which
+points at the Exocortex plugin's load path.
+
+**Cause (pre-#3554):** a successful apply records the chosen profile in
+`data.local.json` (`activeProfileUid`). On the next load, the plugin's onload
+recovery/reconcile step ran **before** the UI was ready and could open a confirm
+dialog that can never be answered while Obsidian is still loading — so plugin load
+never finished and `layoutReady` never fired.
+
+**Recovery (manual, one-time):**
+
+1. Quit Obsidian.
+2. Edit `<vault>/.obsidian/plugins/exocortex/data.local.json` and set
+   `"activeProfileUid": null` (or delete that key). This does **not** undo the
+   apply — the reduced mount stays exactly as applied; the profile just becomes
+   "untracked" (no longer cached as the active selection).
+3. Relaunch Obsidian. The vault loads normally.
+
+After updating to the #3554 build the cache is safe again — you can re-select the
+profile via `Apply profile` and `activeProfileUid` will be honoured on the next
+load without any hang.
+
 ### Legacy flat-mount migration
 
 Apply locates a materialized AssetSpace by its **canonical** mount path

--- a/packages/obsidian-plugin/src/ExocortexPlugin.ts
+++ b/packages/obsidian-plugin/src/ExocortexPlugin.ts
@@ -2881,73 +2881,27 @@ export default class ExocortexPlugin extends Plugin {
     // original on the same lock file.
     this.profileApplyManager = switchMgr;
 
-    // Crash-recovery: если previous session left `_switchInProgress=true`
-    // в settings (ProfileApplyManager docstring line 18), re-trigger
-    // the idempotent re-index so the flag self-clears. Failure swallowed —
-    // user-facing recovery is а Phase D follow-up; the only side-effect
-    // of skipping this is the «stuck switch in progress» footgun (code-
-    // reviewer HIGH catch).
-    try {
-      const initialSettings = await settingsStore.load();
-      if (initialSettings._switchInProgress) {
-        this.logger.warn(
-          "[ExocortexPlugin] previous session left _switchInProgress=true — attempting idempotent recovery",
-        );
-      }
-      const recovery = await switchMgr.recoverIfNeeded();
-      if (recovery.recovered) {
-        this.logger.info(
-          `[ExocortexPlugin] Profile switch recovery completed for ${recovery.targetUid}`,
-        );
-      }
-    } catch (error) {
-      this.logger.warn(
-        "[ExocortexPlugin] Profile switch recovery failed",
-        error instanceof Error ? error : new Error(String(error)),
+    // Issue #3554 — DEFER crash-recovery + cross-device reconcile to
+    // `onLayoutReady`. These best-effort ops were previously awaited INLINE here,
+    // and `registerProfileCommands` is itself awaited by `onload`. When an applied
+    // profile leaves `activeProfileUid` set, `reconcileToLocal()` can compute a
+    // divergence and open a blocking `ApplyConfirmModal` (via
+    // `confirmGate.confirmApply`). During onload — BEFORE `layoutReady` — that modal
+    // can never be confirmed, so the `await` deadlocked: `onload` never resolved and
+    // Obsidian hung forever at "Loading plugins…" (`layoutReady` never fired, the
+    // vault stayed unusable; clearing `activeProfileUid → null` was the only
+    // recovery). Running them AFTER `layoutReady` lets onload return promptly AND
+    // lets the reconcile confirm modal (if any) be shown + confirmed normally once
+    // the UI is interactive. All three ops are idempotent best-effort (each its own
+    // try/catch) and none gate the command registration below, so deferral is safe
+    // on both desktop and mobile.
+    this.app.workspace.onLayoutReady(() => {
+      void this.runDeferredProfileRecovery(
+        settingsStore,
+        switchMgr,
+        applyDeps !== null,
       );
-    }
-
-    // RFC 22b50a17 Phase 3 — apply recovery worker. Only fires when
-    // apply deps are wired AND the journal tail shows destroyed-not-
-    // materialized AS — covers the «plugin crashed mid-Phase 2» case where
-    // soft recoverIfNeeded() would re-trigger a no-op refresh but leave
-    // vault filesystem partial-destroyed.
-    if (applyDeps !== null) {
-      try {
-        const result = await switchMgr.recoverIncompleteSwitch();
-        if (result.restored.length > 0) {
-          this.logger.info(
-            `[ExocortexPlugin] apply recovery restored ${result.restored.length} AssetSpace(s): ${result.restored.join(", ")}`,
-          );
-        }
-      } catch (error) {
-        this.logger.warn(
-          "[ExocortexPlugin] apply recovery failed",
-          error instanceof Error ? error : new Error(String(error)),
-        );
-      }
-
-      // Cross-device divergence detection (RFC 22b50a17 §Cross-device).
-      // Best-effort: failure не block onload; user can manually re-trigger
-      // by switching profiles в Cmd+P.
-      try {
-        const reconcile = await switchMgr.reconcileToLocal();
-        if (reconcile.outcome === "reconciled") {
-          this.logger.info(
-            "[ExocortexPlugin] cross-device profile divergence reconciled to local activeProfileUid",
-          );
-        } else if (reconcile.outcome === "declined") {
-          this.logger.info(
-            "[ExocortexPlugin] cross-device divergence detected, user declined reconcile",
-          );
-        }
-      } catch (error) {
-        this.logger.warn(
-          "[ExocortexPlugin] cross-device reconcile failed",
-          error instanceof Error ? error : new Error(String(error)),
-        );
-      }
-    }
+    });
 
     const pushMgr = await this.buildAssetSpacePusher();
 
@@ -3096,6 +3050,94 @@ export default class ExocortexPlugin extends Plugin {
     this.logger.info(
       "[ExocortexPlugin] Profile palette commands registered",
     );
+  }
+
+  /**
+   * Issue #3554 — crash-recovery + cross-device reconcile, run AFTER
+   * `onLayoutReady` (never inline in `onload`).
+   *
+   * `reconcileToLocal()` can open a blocking `ApplyConfirmModal`; awaiting it
+   * during onload (before `layoutReady`) deadlocks Obsidian on "Loading plugins…"
+   * because the modal can never be confirmed. Deferred to `onLayoutReady`, onload
+   * returns promptly and the modal — if a divergence is found — is shown only once
+   * the UI is interactive.
+   *
+   * All three steps are best-effort: each is independently try/catch'd so a single
+   * failure (or a never-terminating reconcile) can't take down the others, and the
+   * whole thing runs detached (`void`) so it never blocks layout.
+   */
+  private async runDeferredProfileRecovery(
+    settingsStore: PluginSettingsStoreAdapter,
+    switchMgr: ProfileApplyManager,
+    hasApplyDeps: boolean,
+  ): Promise<void> {
+    // Crash-recovery: если previous session left `_switchInProgress=true`
+    // в settings (ProfileApplyManager docstring line 18), re-trigger
+    // the idempotent re-index so the flag self-clears. Failure swallowed —
+    // user-facing recovery is а Phase D follow-up; the only side-effect
+    // of skipping this is the «stuck switch in progress» footgun (code-
+    // reviewer HIGH catch).
+    try {
+      const initialSettings = await settingsStore.load();
+      if (initialSettings._switchInProgress) {
+        this.logger.warn(
+          "[ExocortexPlugin] previous session left _switchInProgress=true — attempting idempotent recovery",
+        );
+      }
+      const recovery = await switchMgr.recoverIfNeeded();
+      if (recovery.recovered) {
+        this.logger.info(
+          `[ExocortexPlugin] Profile switch recovery completed for ${recovery.targetUid}`,
+        );
+      }
+    } catch (error) {
+      this.logger.warn(
+        "[ExocortexPlugin] Profile switch recovery failed",
+        error instanceof Error ? error : new Error(String(error)),
+      );
+    }
+
+    // RFC 22b50a17 Phase 3 — apply recovery worker. Only fires when
+    // apply deps are wired AND the journal tail shows destroyed-not-
+    // materialized AS — covers the «plugin crashed mid-Phase 2» case where
+    // soft recoverIfNeeded() would re-trigger a no-op refresh but leave
+    // vault filesystem partial-destroyed.
+    if (hasApplyDeps) {
+      try {
+        const result = await switchMgr.recoverIncompleteSwitch();
+        if (result.restored.length > 0) {
+          this.logger.info(
+            `[ExocortexPlugin] apply recovery restored ${result.restored.length} AssetSpace(s): ${result.restored.join(", ")}`,
+          );
+        }
+      } catch (error) {
+        this.logger.warn(
+          "[ExocortexPlugin] apply recovery failed",
+          error instanceof Error ? error : new Error(String(error)),
+        );
+      }
+
+      // Cross-device divergence detection (RFC 22b50a17 §Cross-device).
+      // Best-effort: failure не block onload; user can manually re-trigger
+      // by switching profiles в Cmd+P.
+      try {
+        const reconcile = await switchMgr.reconcileToLocal();
+        if (reconcile.outcome === "reconciled") {
+          this.logger.info(
+            "[ExocortexPlugin] cross-device profile divergence reconciled to local activeProfileUid",
+          );
+        } else if (reconcile.outcome === "declined") {
+          this.logger.info(
+            "[ExocortexPlugin] cross-device divergence detected, user declined reconcile",
+          );
+        }
+      } catch (error) {
+        this.logger.warn(
+          "[ExocortexPlugin] cross-device reconcile failed",
+          error instanceof Error ? error : new Error(String(error)),
+        );
+      }
+    }
   }
 
   /**

--- a/packages/obsidian-plugin/tests/unit/ExocortexPlugin.test.ts
+++ b/packages/obsidian-plugin/tests/unit/ExocortexPlugin.test.ts
@@ -13,6 +13,7 @@ import { AliasSyncService } from "../../src/application/services/AliasSyncServic
 import { SPARQLCodeBlockProcessor } from "../../src/application/processors/SPARQLCodeBlockProcessor";
 import { ExocortexSettingTab } from "../../src/presentation/settings/ExocortexSettingTab";
 import { DEFAULT_SETTINGS } from "../../src/domain/settings/ExocortexSettings";
+import { ProfileApplyManager } from "../../src/infrastructure/adapters/ProfileApplyManager";
 
 // Mock all dependencies
 jest.mock("../../src/adapters/logging/LoggerFactory");
@@ -272,6 +273,64 @@ describe("ExocortexPlugin", () => {
       expect(mockWorkspace.getActiveFile).toHaveBeenCalled();
       // Layout should not be rendered
       expect(mockLayoutRenderer.render).not.toHaveBeenCalled();
+    });
+  });
+
+  // Issue #3554 — profile apply → next Obsidian load hangs at "Loading plugins…".
+  // After an `Apply profile` sets `data.local.json.activeProfileUid`, the next
+  // load deadlocked: `registerProfileCommands` (awaited by `onload`) awaited the
+  // profile recovery/reconcile block inline, and `ProfileApplyManager.reconcileToLocal`
+  // can open a blocking confirm modal (`confirmGate.confirmApply`). During onload,
+  // BEFORE `workspace.onLayoutReady` fires, that modal never resolves → the inline
+  // `await` never returns → `onload` never resolves → Obsidian hangs forever at
+  // "Loading plugins…" (`layoutReady` never fires, vault unusable). The fix defers
+  // the whole recovery/reconcile block to `onLayoutReady`, so onload returns promptly
+  // and any reconcile modal is shown only after the UI is interactive.
+  describe("Issue #3554 — profile recovery must not block onload (deferred to onLayoutReady)", () => {
+    beforeEach(() => {
+      // Give the device-local store a working adapter so registerProfileCommands
+      // reaches the recovery block (PluginLocalDataStore reads data.local.json).
+      mockApp.vault.adapter = {
+        exists: jest.fn().mockResolvedValue(false),
+        read: jest.fn().mockResolvedValue("{}"),
+        write: jest.fn().mockResolvedValue(undefined),
+      };
+    });
+
+    it("onload completes even when a profile recovery op never resolves (deferred past layoutReady)", async () => {
+      // `onLayoutReady` CAPTURES callbacks without running them — faithfully
+      // simulates the real onload window where `layoutReady` has NOT fired yet.
+      const deferred: Array<() => void> = [];
+      mockWorkspace.onLayoutReady = jest.fn((cb: () => void) => {
+        deferred.push(cb);
+      });
+
+      // Stand-in for the reconcile confirm-modal deadlock: a recovery op whose
+      // promise NEVER resolves. If onload awaits it inline (the bug), onload hangs
+      // forever. recoverIfNeeded() runs unconditionally in the recovery block, so
+      // it is a reliable probe regardless of desktop/mobile applyDeps wiring.
+      const neverResolves = new Promise<{
+        recovered: boolean;
+        targetUid: string | null;
+      }>(() => {
+        /* never settles */
+      });
+      const recoverSpy = jest
+        .spyOn(ProfileApplyManager.prototype, "recoverIfNeeded")
+        .mockReturnValue(neverResolves);
+
+      // onload MUST resolve promptly despite the hanging recovery op.
+      const outcome = await Promise.race([
+        plugin.onload().then(() => "resolved" as const),
+        new Promise<"hung">((resolve) => setTimeout(() => resolve("hung"), 2000)),
+      ]);
+      expect(outcome).toBe("resolved");
+
+      // The recovery block was DEFERRED, not awaited inline: recoverIfNeeded is
+      // not invoked during onload (it would run only after layoutReady fires)…
+      expect(recoverSpy).not.toHaveBeenCalled();
+      // …and it was scheduled via onLayoutReady.
+      expect(mockWorkspace.onLayoutReady).toHaveBeenCalled();
     });
   });
 


### PR DESCRIPTION
## Summary

Fixes **#3554** (CRITICAL, alpha-blocking): after a successful `Apply profile`, the next Obsidian load **hangs forever at "Loading plugins…"** — `layoutReady` never fires and the vault is unusable. Clearing `activeProfileUid → null` was the only recovery.

## Root cause

`ExocortexPlugin.onload` awaits `registerProfileCommands()`, which awaited the crash-recovery + cross-device reconcile block **inline**. `ProfileApplyManager.reconcileToLocal()` (gated on `applyDeps !== null` AND `activeProfileUid !== null`) can compute a divergence and open a **blocking `ApplyConfirmModal`** via `confirmGate.confirmApply()`. During onload — **before `layoutReady`** — that modal can never be confirmed, so the `await` never returns → `onload` never resolves → Obsidian deadlocks on "Loading plugins…".

This precisely matches the issue evidence:
- `activeProfileUid = null` loads fine → `reconcileToLocal` returns `no-active-profile` early.
- Restricted Mode loads fine → community plugin (exocortex) onload is the cause.
- Console stops right after the legacy-switch-keys migration log → the next awaited step (recovery/reconcile) is where it hangs.

## Fix

Extract the recovery/reconcile block into `runDeferredProfileRecovery()` and schedule it via `app.workspace.onLayoutReady(...)`. `onload` now returns promptly; the reconcile confirm modal (if any) is shown only **after** the UI is interactive. All three ops (`recoverIfNeeded`, `recoverIncompleteSwitch`, `reconcileToLocal`) are best-effort (each independently `try/catch`'d) and don't gate command registration, so deferral is safe.

**Both platforms:** the deferral is platform-agnostic. On mobile (`applyDeps === null`) only `recoverIfNeeded` runs (unchanged behaviour, now deferred); desktop's full reconcile is deferred. Mobile never hung (no `reconcileToLocal`), but deferral is consistent and harmless.

## Tests (TDD revert-verify)

New unit test `Issue #3554 — profile recovery must not block onload`: a never-resolving recovery op makes `onload` time out **if awaited inline**.

- **FAILS pre-fix** (`Received: "hung"`) ✓
- **PASSES post-fix** (`"resolved"`) ✓

All 93 `ExocortexPlugin.test.ts` tests green; `tsc --noEmit` + `eslint src` clean.

## Docs

`docs/profile.md` gains a "Obsidian hangs at Loading plugins… after an apply" troubleshooting section (manual `activeProfileUid → null` workaround) for anyone still on a pre-#3554 build.

## Out of scope (documented in #3554, lower severity, same domain)

The two apply-robustness observations in the issue (stale `HEAD.lock` resilience; cache-restore NFC/NFD filename normalization) touch the high-regression apply/git/SwitchCacheLayer subsystems and are left for a separate change to keep this critical hang-fix tight.

Closes #3554