### PR TITLE
fix(#3557,#3558,#3559): onboarding frictions — floor namespace-reconcile + PAT-after-onload + commit-first docs

### DIFF
--- a/docs/Getting-Started.md
+++ b/docs/Getting-Started.md
@@ -113,8 +113,10 @@ The fastest way to get a complete, working Areas → Projects → Tasks + Daily 
 > **⚠️ Git-backed vault? Commit before the first Apply.** If your vault is a git repository, Bootstrap + Add-AssetSpace leave the pulled `assetspaces/` as **untracked** files, and **Apply profile** refuses to unmount an AssetSpace with uncommitted changes (it never silently destroys un-pushed work) — you'll see `Apply aborted — N uncommitted file(s) …`. Before step 3, commit the vault once from a terminal at the vault root:
 >
 > ```bash
-> # First add a .gitignore so your PAT (data.local.json) is never committed:
-> printf '.obsidian/\n.exocortex/\n' > .gitignore
+> # First add a .gitignore so your PAT (data.local.json) is never committed.
+> # `>>` appends — if you already have a .gitignore it is preserved (just make
+> # sure these two lines are present; remove any duplicates afterwards):
+> printf '.obsidian/\n.exocortex/\n' >> .gitignore
 > git add -A && git commit -m "vault setup"
 > ```
 >

--- a/docs/Getting-Started.md
+++ b/docs/Getting-Started.md
@@ -8,12 +8,12 @@
 
 Exocortex has been verified to work with the following minimum versions. Older versions are known to miss critical fixes for grounding, createAsset, and IRI resolution.
 
-| Component            | Minimum version | Recommended    | Why                                                                |
-| -------------------- | --------------- | -------------- | ------------------------------------------------------------------ |
-| **Obsidian**         | 1.5.0           | 1.7.0 or newer | Plugin uses APIs available since 1.5.                              |
-| **Exocortex plugin** | v15.90.9        | Latest release | Fixes for createAsset, IRI resolution, targetValue.                |
+| Component            | Minimum version | Recommended    | Why                                                                                                                               |
+| -------------------- | --------------- | -------------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| **Obsidian**         | 1.5.0           | 1.7.0 or newer | Plugin uses APIs available since 1.5.                                                                                             |
+| **Exocortex plugin** | v15.90.9        | Latest release | Fixes for createAsset, IRI resolution, targetValue.                                                                               |
 | **git** (CLI)        | Optional        | Latest         | Only needed for git-backed vaults — used to register pulled AssetSpaces as git submodules. Non-git vaults work in file-only mode. |
-| **BRAT**             | Latest          | Latest         | Delivers plugin updates automatically.                             |
+| **BRAT**             | Latest          | Latest         | Delivers plugin updates automatically.                                                                                            |
 
 ### How to check your versions
 
@@ -109,6 +109,16 @@ The fastest way to get a complete, working Areas → Projects → Tasks + Daily 
 3. **Apply the profile**: **Cmd/Ctrl + P → "Exocortex: Apply profile"** → choose **`starter`**. The plugin materializes exactly the starter set — 7 AssetSpaces: `exo`, `exocmd`, `ems`, `ems-commands`, `period`, `period-commands`, `person` — and nothing else (no `shared-identities`, no personal data).
 
 > **Why this path**: the `starter` profile mounts only what a fresh vault needs (floor = `{exo}`), so first-run indexing is fast and your vault stays free of unrelated assets. You can still add more AssetSpaces later via **"Add assetspace by URL"** — dependencies are **not** pulled automatically.
+
+> **⚠️ Git-backed vault? Commit before the first Apply.** If your vault is a git repository, Bootstrap + Add-AssetSpace leave the pulled `assetspaces/` as **untracked** files, and **Apply profile** refuses to unmount an AssetSpace with uncommitted changes (it never silently destroys un-pushed work) — you'll see `Apply aborted — N uncommitted file(s) …`. Before step 3, commit the vault once from a terminal at the vault root:
+>
+> ```bash
+> # First add a .gitignore so your PAT (data.local.json) is never committed:
+> printf '.obsidian/\n.exocortex/\n' > .gitignore
+> git add -A && git commit -m "vault setup"
+> ```
+>
+> Then run **"Exocortex: Apply profile"**. (The starter profile is all-public, so no PAT is needed — but gitignoring `.obsidian/` is still the right habit for when you add a private profile later.) See [Profile → Apply on a git-backed vault](profile.md) for details.
 
 ### Step 3: Verify Installation
 
@@ -383,15 +393,15 @@ The Exocortex layout renders automatically in Reading Mode based on the note's `
 
 Open **Settings → Exocortex** to configure the plugin. Three things worth knowing up front:
 
-- **Settings live in your vault.** After updating the plugin you will see an `exocortex-settings/` folder appear, with one `exo__Setting` note per setting. This is a one-shot migration (the plugin shows a Notice like *"Exocortex: migrated N setting(s) to vault assets"*); editing those notes is equivalent to changing the setting in the UI. See [Settings Homoiconization](settings-homoiconization.md).
+- **Settings live in your vault.** After updating the plugin you will see an `exocortex-settings/` folder appear, with one `exo__Setting` note per setting. This is a one-shot migration (the plugin shows a Notice like _"Exocortex: migrated N setting(s) to vault assets"_); editing those notes is equivalent to changing the setting in the UI. See [Settings Homoiconization](settings-homoiconization.md).
 - **Excluded folders**: folder prefixes listed in this setting (default: `09 Templates/`) are skipped by RDF indexing and SHACL-lite validation — useful for template folders whose frontmatter is incomplete by design. Reload Obsidian after editing the list; the indexer snapshots it at startup.
-- **GitHub PAT** (Settings → Exocortex → *Profile: GitHub PAT*): a fine-grained Personal Access Token used to **push** AssetSpace changes and to **pull private** AssetSpaces. You do **not** need it for the public starter onboarding (Steps 2–2b are all public, no token). Set it only when you run **"Exocortex: Sync"** (push), the **"Push current assetspace"** command, or **"Apply profile"** on a profile that includes a private repository. It is stored in `data.local.json` (not `data.json`), so Obsidian Sync **excludes it from network replication**. Use **"Save PAT"** / **"Test connection"** to store and verify it; leave the field blank and click Save to clear it.
+- **GitHub PAT** (Settings → Exocortex → _Profile: GitHub PAT_): a fine-grained Personal Access Token used to **push** AssetSpace changes and to **pull private** AssetSpaces. You do **not** need it for the public starter onboarding (Steps 2–2b are all public, no token). Set it only when you run **"Exocortex: Sync"** (push), the **"Push current assetspace"** command, or **"Apply profile"** on a profile that includes a private repository. It is stored in `data.local.json` (not `data.json`), so Obsidian Sync **excludes it from network replication**. Use **"Save PAT"** / **"Test connection"** to store and verify it; leave the field blank and click Save to clear it.
 
 ### Adding your own / private AssetSpaces
 
 The starter onboarding (Step 2b) pulls only **public** repositories, so no token is involved. To add **your own** or a **private** AssetSpace:
 
-1. Configure your **GitHub PAT** in *Settings → Exocortex* (see the bullet above), scoped to the repositories you own (fine-grained PAT with a per-repository allowlist is recommended).
+1. Configure your **GitHub PAT** in _Settings → Exocortex_ (see the bullet above), scoped to the repositories you own (fine-grained PAT with a per-repository allowlist is recommended).
 2. Declare the AssetSpace in a profile (an `exo__Profile` asset that lists it under `exo__Profile_includes`) and run **"Exocortex: Apply profile"**. Apply uses your PAT to materialize private AssetSpaces.
 
 > The **"Add assetspace by URL"** command is for a single **public** repository (no token), and it does **not** pull that repo's dependencies automatically. For private content, or for a complete dependency-resolved set, prefer the profile path (**Apply profile**) over **Add assetspace by URL**.

--- a/docs/profile.md
+++ b/docs/profile.md
@@ -139,6 +139,51 @@ After a successful apply, the target profile UID is persisted as
 filter. It records "which profile this device last reconciled to"; the on-disk
 state is the source of truth.
 
+### Apply on a git-backed vault (commit first)
+
+On a **git-backed vault** (the recommended setup for submodule mode), apply
+**refuses to tear down an AssetSpace that has uncommitted changes** — it would
+otherwise destroy un-pushed work. This is the Vision Lock #5 _uncommitted abort_
+guard, surfaced as `UncommittedChangesAbortError`:
+
+```
+Apply aborted — N uncommitted file(s) in M AssetSpace(s) this profile would
+remove. Commit or stash the vault before applying.
+```
+
+This trips up a **fresh** onboarding flow, because the 3-step setup
+(**Bootstrap → Add registry/profiles → Apply profile**) pulls the AssetSpace
+folders into `assetspaces/` as **untracked** files. Git sees those untracked
+files as "uncommitted", so the very first apply that needs to unmount one of them
+aborts.
+
+**Fix — commit the vault once before the first apply:**
+
+```bash
+# From the vault root, after Bootstrap + Add-AssetSpace, before Apply profile:
+git add -A
+git commit -m "vault setup"
+```
+
+Then re-run **`Exocortex: Apply profile`**.
+
+> **⚠️ Protect your PAT.** A fresh vault has no `.gitignore`, so `git add -A`
+> would commit `.obsidian/data.local.json` — which holds your GitHub **personal
+> access token**. Before committing, add a `.gitignore` at the vault root:
+>
+> ```gitignore
+> .obsidian/
+> .exocortex/
+> ```
+>
+> (`.obsidian/` keeps the PAT + device-local plugin state out of git;
+> `.exocortex/` is the local switch-cache / journal, also device-local.)
+
+Apply does **not** auto-commit for you — committing is an explicit, user-owned
+git action (auto-commit-then-apply would blur the apply atomicity boundary; see
+_Partial-failure boundary_ below). The guard is intentional: it never silently
+destroys uncommitted work.
+
 ### Floor policy (R24) — refuse, don't rescue
 
 Apply is destructive, so it requires **explicit intent**. Before any mutation, a

--- a/packages/obsidian-plugin/src/ExocortexPlugin.ts
+++ b/packages/obsidian-plugin/src/ExocortexPlugin.ts
@@ -2867,6 +2867,16 @@ export default class ExocortexPlugin extends Plugin {
       // Fresh-PAT rebuild at switch time (Issue #3382 pattern) so a PAT set
       // after onload is honoured without a reload — the primary mobile flow.
       restMountFactory: () => buildRestAssetSpaceMount({ app: this.app }),
+      // Issue #3557 — desktop analogue: rebuild the apply puller from the CURRENT
+      // PAT at switch time so a PAT configured after onload authenticates a
+      // PRIVATE-AssetSpace apply without a reload (lazy closure — only invoked on
+      // the desktop materialize path, never on mobile's REST path).
+      assetSpaceManagerFactory: () =>
+        buildAssetSpacePuller({
+          app: this.app,
+          localDataStore,
+          notifier: this.notifier,
+        }),
       uncommittedGuard: applyDeps?.uncommittedGuard,
       confirmGate,
       cacheLayer: applyDeps?.cacheLayer,
@@ -2960,6 +2970,10 @@ export default class ExocortexPlugin extends Plugin {
     const commandsHandler = new ProfileCommands({
       switchMgr,
       pushMgr,
+      // Issue #3557 — rebuild the pusher from the current PAT per push so a PAT
+      // set after onload authenticates without a reload (desktop + mobile both
+      // read the same stored PAT via buildAssetSpacePusher).
+      pushMgrFactory: () => this.buildAssetSpacePusher(),
       profileLister,
       fuzzyPick,
       getActiveFilePath: () =>

--- a/packages/obsidian-plugin/src/infrastructure/adapters/ProfileApplyManager.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/ProfileApplyManager.ts
@@ -20,7 +20,6 @@ import type { GitSubmoduleOps } from "./GitSubmoduleOps";
 import type { RestAssetSpaceMount } from "./RestAssetSpaceMount";
 import type { UncommittedChangesGuard } from "./UncommittedChangesGuard";
 import type { PluginLocalDataStore } from "./PluginLocalDataStore";
-import { TS_FLOOR_ASSETSPACE_UIDS } from "./ProfileOnloadWiring";
 
 /**
  * ProfileApplyManager — coordinates profile switching:
@@ -211,6 +210,18 @@ export interface ProfileApplyManagerOptions {
    * captured {@link restMount} when absent.
    */
   restMountFactory?: () => Promise<RestAssetSpaceMount>;
+  /**
+   * Factory building an {@link AssetSpaceManager} (the desktop REST tarball
+   * puller) with the CURRENTLY stored GitHub PAT. Preferred over the captured
+   * {@link assetSpaceManager} inside the DESKTOP apply materialize path so a PAT
+   * configured AFTER onload is honoured without a reload — the desktop analogue
+   * of {@link restMountFactory} and the same Issue #3382 fix already applied to
+   * Bootstrap / Add-AssetSpace. Falls back to the captured {@link assetSpaceManager}
+   * when absent (tests / legacy wiring). Fixes Issue #3557: applying a profile
+   * with PRIVATE AssetSpaces right after configuring the PAT (no reload) hit an
+   * anonymous tarball request → HTTP 404.
+   */
+  assetSpaceManagerFactory?: () => Promise<AssetSpaceManager>;
   /** Uncommitted-changes guard (Vision Lock #5). */
   uncommittedGuard?: UncommittedChangesGuard;
   /** Confirmation gate — ModalConfirmGate в plugin runtime. */
@@ -297,6 +308,12 @@ interface DesktopApplyMutationContext {
   }>;
   infoBySubmodulePath: Map<string, AssetSpaceInfo>;
   deps: ResolvedApplyDeps;
+  /**
+   * The AssetSpace puller for Phase-1 materialize — rebuilt from the CURRENT
+   * PAT per apply (Issue #3557) so a PAT set after onload is honoured without a
+   * reload. Falls back to the onload-captured `deps.assetSpaceManager`.
+   */
+  puller: AssetSpaceManager;
 }
 
 /** Post-confirm REST/mobile apply mutation context (Issue #3532 watchdog parity). */
@@ -376,6 +393,7 @@ export class ProfileApplyManager {
   private readonly gitOps?: GitSubmoduleOps;
   private readonly restMount?: RestAssetSpaceMount;
   private readonly restMountFactory?: () => Promise<RestAssetSpaceMount>;
+  private readonly assetSpaceManagerFactory?: () => Promise<AssetSpaceManager>;
   private readonly uncommittedGuard?: UncommittedChangesGuard;
   private readonly confirmGate?: IConfirmGate;
   private readonly localDataStore?: PluginLocalDataStore;
@@ -408,6 +426,7 @@ export class ProfileApplyManager {
     this.gitOps = options.gitOps;
     this.restMount = options.restMount;
     this.restMountFactory = options.restMountFactory;
+    this.assetSpaceManagerFactory = options.assetSpaceManagerFactory;
     this.uncommittedGuard = options.uncommittedGuard;
     this.confirmGate = options.confirmGate;
     this.localDataStore = options.localDataStore;
@@ -673,6 +692,16 @@ export class ProfileApplyManager {
       return this.applyProfileViaRest(targetProfileUid);
     }
     const deps = this.assertApplyDepsWired();
+    // #3557 — rebuild the puller from the CURRENTLY stored PAT so a PAT
+    // configured AFTER onload is honoured on the desktop apply materialize path
+    // without a reload (mirrors restMountFactory on mobile + the #3382
+    // Bootstrap/Add fix). The onload-captured `deps.assetSpaceManager` froze an
+    // empty-PAT client when the vault had no PAT at load — applying a profile
+    // with PRIVATE AssetSpaces then made an anonymous tarball request → HTTP 404.
+    // Falls back to the captured manager when no factory is wired (tests/legacy).
+    const puller = this.assetSpaceManagerFactory
+      ? await this.assetSpaceManagerFactory()
+      : deps.assetSpaceManager;
 
     const startedAt = this.now().getTime();
     const prevActiveProfileUid = deps.localDataStore.getActiveProfileUid();
@@ -752,7 +781,10 @@ export class ProfileApplyManager {
       if (!uncommitted.clean) {
         const total = uncommitted.affectedFiles.reduce((s, a) => s + a.files.length, 0);
         throw new UncommittedChangesAbortError(
-          `Apply aborted — ${total} uncommitted file(s) in ${uncommitted.affectedFiles.length} to-destroy AssetSpace(s). Commit or stash first.`,
+          `Apply aborted — ${total} uncommitted file(s) in ${uncommitted.affectedFiles.length} AssetSpace(s) this profile would remove. ` +
+            `Commit or stash the vault before applying. On a fresh git-backed vault, Bootstrap / Add-AssetSpace leave the pulled ` +
+            `assetspaces/ untracked — run \`git add -A && git commit -m "vault setup"\` first (and gitignore \`.obsidian/\` + ` +
+            `\`.exocortex/\` so your PAT is never committed). See docs/profile.md → "Apply on a git-backed vault (commit first)".`,
           uncommitted.affectedFiles,
         );
       }
@@ -837,6 +869,7 @@ export class ProfileApplyManager {
           toMaterialize,
           infoBySubmodulePath,
           deps,
+          puller,
         }),
       targetProfileLabel,
       () => this.clearStuckLocalState(deps.localDataStore),
@@ -864,6 +897,7 @@ export class ProfileApplyManager {
       toMaterialize,
       infoBySubmodulePath,
       deps,
+      puller,
     } = ctx;
     // Ensure `.exocortex/` exists before the lock/journal writes (Issue #3532) —
     // under the watchdog so even a stalled mkdir/exists is bounded.
@@ -921,7 +955,7 @@ export class ProfileApplyManager {
         try {
           // R28 — SHA-aware cache lookup. We don't know upstream SHA up-front,
           // so we pull. (R28 future optimization: HEAD probe before pull.)
-          const result = await deps.assetSpaceManager.pullAssetSpace(
+          const result = await puller.pullAssetSpace(
             target.asUid,
             target.gitUrl,
             target.ref,
@@ -1515,15 +1549,16 @@ export class ProfileApplyManager {
     const folderMapValues = new Set(folderToAsUid.values());
     // `_includes` are AssetSpace UIDs (RFC 01a83de8 Phase 2) → resolve directly
     // against the folder map. The TS-floor ontology URIs added by
-    // resolveEffectiveSet are not AS UIDs and are re-injected at AS level just
-    // below. The former Ontology→AS translation (containsOntology) is dead —
-    // removed in Phase 3 T3b-cleanup.
+    // resolveEffectiveSet are not AS UIDs; the AS-level floor is re-injected
+    // AFTER materializedAsUids is computed (see addReconciledFloor below — issue
+    // #3558: the floor must be resolved against the UIDs actually mounted). The
+    // former Ontology→AS translation (containsOntology) is dead — removed in
+    // Phase 3 T3b-cleanup.
     for (const uid of declared) {
       if (folderMapValues.has(uid)) {
         expectedAsUids.add(uid);
       }
     }
-    for (const floor of TS_FLOOR_ASSETSPACE_UIDS) expectedAsUids.add(floor);
 
     // Materialized AS UIDs: .gitmodules ∩ working-tree-on-disk
     // (Phase 6 Vision Lock #9 amendment: `.gitmodules` ≠ materialization state).
@@ -1550,6 +1585,22 @@ export class ProfileApplyManager {
       expectedAsUids.add(uid);
     }
     this.keepMaterializedCatalog(expectedAsUids, allInfos, materializedAsUids);
+
+    // Floor reconcile (issue #3558): the plugin-UI floor ({exo}) is anchored by a
+    // hardcoded legacy AssetSpace UID, but an EKA central-registry vault mounts
+    // $exo under a DIFFERENT descriptor UID (same fork-safe namespace "exo").
+    // Represent the floor by the UID actually materialized for its namespace so a
+    // floor mounted under a registry UID is neither reported "missing" (the
+    // perpetual false-positive «materialize exo» modal on every reload) nor torn
+    // down as "extra" — falling back to the legacy anchor only when genuinely
+    // absent (so a truly-missing floor still triggers reconcile).
+    const namespaceByUid = new Map<string, string>();
+    for (const info of allInfos) namespaceByUid.set(info.uid, info.namespace);
+    ProfileApplyManager.addReconciledFloor(
+      expectedAsUids,
+      materializedAsUids,
+      namespaceByUid,
+    );
 
     // Diff.
     const missing = Array.from(expectedAsUids).filter((u) => !materializedAsUids.has(u));
@@ -1655,6 +1706,51 @@ export class ProfileApplyManager {
   }
 
   /**
+   * Add the plugin-UI TS-floor to a diff `target` set, reconciled by namespace
+   * (issue #3558) — the AS-level analogue of {@link assertTsFloorReconciled}.
+   *
+   * The floor ({exo}) is anchored by a hardcoded legacy AssetSpace UID
+   * ({@link TS_FLOOR_AS_UID_EXO}), but an EKA central-registry vault mints a
+   * DISTINCT descriptor UID for the same `$exo` AssetSpace (same
+   * `exo__AssetSpace_namespace: "exo"`, different `exo__Asset_uid`). Injecting
+   * the raw anchor into an apply/reconcile diff makes a floor mounted under the
+   * registry UID look "missing"/"to-materialize" (or its registry twin look
+   * "extra"/"to-destroy") — the perpetual false-positive reconcile modal.
+   *
+   * For each floor identity, adds to `target`:
+   *   - its hardcoded UID, when that UID is itself `present` (legacy
+   *     self-describing vault — the anchor descriptor IS the one mounted/declared);
+   *   - else the `present` UID whose namespace matches the floor (the registry
+   *     twin actually mounted/declared for that namespace);
+   *   - else the hardcoded UID (the floor is genuinely absent — keep the legacy
+   *     anchor so a truly-missing floor still surfaces in the diff).
+   *
+   * `present` are the UIDs that exist in the relevant world (materialized AS for
+   * reconcile, declared closure for apply); `namespaceByUid` maps every scanned
+   * AssetSpace UID to its `exo__AssetSpace_namespace`.
+   */
+  private static addReconciledFloor(
+    target: Set<string>,
+    present: ReadonlySet<string>,
+    namespaceByUid: ReadonlyMap<string, string>,
+  ): void {
+    const presentUidByNamespace = new Map<string, string>();
+    for (const uid of present) {
+      const ns = namespaceByUid.get(uid);
+      if (ns !== undefined && ns.length > 0 && !presentUidByNamespace.has(ns)) {
+        presentUidByNamespace.set(ns, uid);
+      }
+    }
+    for (const f of PLUGIN_UI_FLOOR) {
+      if (present.has(f.uid)) {
+        target.add(f.uid);
+      } else {
+        target.add(presentUidByNamespace.get(f.namespace) ?? f.uid);
+      }
+    }
+  }
+
+  /**
    * Resolve the target profile's declared AssetSpace set, expanded by its
    * transitive `exo__AssetSpace_dependsOn` closure (EKA Alpha D18, issue #3511),
    * intersected with the known (scanned) AssetSpaces. Asserts the R24 TS-floor
@@ -1703,7 +1799,21 @@ export class ProfileApplyManager {
     // intent. Apply is destructive, so we require explicit intent.
     this.assertTsFloor(declaredAsUids, declaredNamespaces);
     const effectiveAsUids = new Set(declaredAsUids);
-    for (const floor of TS_FLOOR_ASSETSPACE_UIDS) effectiveAsUids.add(floor);
+    // Floor reconcile (issue #3558) — represent the floor by the declared
+    // registry UID for its namespace instead of always injecting the hardcoded
+    // legacy anchor. On an EKA central-registry vault the $exo descriptor UID
+    // differs from the anchor (namespace "exo" stays fork-safe), so injecting the
+    // raw anchor would add a second, never-mounted floor UID to the effective set
+    // and apply would try to re-materialize the already-mounted floor (duplicate
+    // mount). assertTsFloor above guarantees the floor IS declared (UID OR
+    // namespace), so this only normalises which UID represents it.
+    const namespaceByUid = new Map<string, string>();
+    for (const info of allInfos) namespaceByUid.set(info.uid, info.namespace);
+    ProfileApplyManager.addReconciledFloor(
+      effectiveAsUids,
+      declaredAsUids,
+      namespaceByUid,
+    );
     return { declaredAsUids, declaredNamespaces, effectiveAsUids };
   }
 

--- a/packages/obsidian-plugin/src/infrastructure/adapters/ProfileCommands.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/ProfileCommands.ts
@@ -206,10 +206,19 @@ export class ProfileCommands {
 
     // #3557 — rebuild the pusher from the CURRENT PAT so a PAT configured after
     // onload authenticates the push without a reload. Falls back to the
-    // onload-captured pushMgr when no factory is wired (tests / legacy).
-    const pushMgr = this.pushMgrFactory
-      ? await this.pushMgrFactory()
-      : this.pushMgr;
+    // onload-captured pushMgr when no factory is wired (tests / legacy). The
+    // factory does async PAT I/O that can reject; this command is invoked
+    // fire-and-forget, so surface a failure as a Notice rather than leaving an
+    // unhandled rejection (code-reviewer LOW).
+    let pushMgr: IAssetSpacePusher;
+    try {
+      pushMgr = this.pushMgrFactory
+        ? await this.pushMgrFactory()
+        : this.pushMgr;
+    } catch (e) {
+      this.notify(`Push failed: ${this.safeMessage(e)}`);
+      return;
+    }
 
     const asUid = pushMgr.lookupAssetSpaceForPath(folderName);
     if (asUid === null) {

--- a/packages/obsidian-plugin/src/infrastructure/adapters/ProfileCommands.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/ProfileCommands.ts
@@ -57,6 +57,15 @@ export interface ProfileChoice {
 export interface ProfileCommandsDeps {
   switchMgr: ProfileApplyManager;
   pushMgr: IAssetSpacePusher;
+  /**
+   * Factory rebuilding the pusher from the CURRENTLY stored GitHub PAT, per
+   * invocation. Preferred over the onload-captured {@link pushMgr} inside
+   * {@link ProfileCommands.invokePushCurrentAssetSpace} so a PAT configured AFTER
+   * onload authenticates a push without a reload (Issue #3557 — same fix as the
+   * apply path's `assetSpaceManagerFactory`). Falls back to {@link pushMgr} when
+   * absent (tests / legacy wiring).
+   */
+  pushMgrFactory?: () => Promise<IAssetSpacePusher>;
   /** Returns available `exo__Profile` assets (label + uid pairs) — the picker. */
   profileLister: () => Promise<ProfileChoice[]>;
   /**
@@ -82,6 +91,7 @@ export interface ProfileCommandsDeps {
 export class ProfileCommands {
   private readonly switchMgr: ProfileApplyManager;
   private readonly pushMgr: IAssetSpacePusher;
+  private readonly pushMgrFactory?: () => Promise<IAssetSpacePusher>;
   private readonly profileLister: () => Promise<ProfileChoice[]>;
   private readonly fuzzyPick: ProfileCommandsDeps["fuzzyPick"];
   private readonly getActiveFilePath: () => string | null;
@@ -91,6 +101,7 @@ export class ProfileCommands {
   constructor(deps: ProfileCommandsDeps) {
     this.switchMgr = deps.switchMgr;
     this.pushMgr = deps.pushMgr;
+    this.pushMgrFactory = deps.pushMgrFactory;
     this.profileLister = deps.profileLister;
     this.fuzzyPick = deps.fuzzyPick;
     this.getActiveFilePath = deps.getActiveFilePath;
@@ -146,7 +157,10 @@ export class ProfileCommands {
       if (e instanceof UncommittedChangesAbortError) {
         const total = e.affectedFiles.reduce((s, a) => s + a.files.length, 0);
         this.notify(
-          `Apply profile aborted — ${total} uncommitted file(s) в ${e.affectedFiles.length} AssetSpace(s). Commit or stash first.`,
+          `Apply profile aborted — ${total} uncommitted file(s) in ${e.affectedFiles.length} AssetSpace(s) this profile would remove. ` +
+            `Commit (or stash) the vault first, then re-apply. Fresh git-backed vault? The pulled assetspaces/ are untracked — run ` +
+            `\`git add -A && git commit -m "vault setup"\` (and gitignore \`.obsidian/\` + \`.exocortex/\` to keep your PAT out of git). ` +
+            `See docs/profile.md.`,
         );
         return;
       }
@@ -190,7 +204,14 @@ export class ProfileCommands {
       return;
     }
 
-    const asUid = this.pushMgr.lookupAssetSpaceForPath(folderName);
+    // #3557 — rebuild the pusher from the CURRENT PAT so a PAT configured after
+    // onload authenticates the push without a reload. Falls back to the
+    // onload-captured pushMgr when no factory is wired (tests / legacy).
+    const pushMgr = this.pushMgrFactory
+      ? await this.pushMgrFactory()
+      : this.pushMgr;
+
+    const asUid = pushMgr.lookupAssetSpaceForPath(folderName);
     if (asUid === null) {
       this.notify(
         `Folder \`${folderName}\` is not declared as an AssetSpace ABox`,
@@ -200,7 +221,7 @@ export class ProfileCommands {
 
     this.notify(`Pushing \`${folderName}\`…`);
     try {
-      const sha = await this.pushMgr.pushAssetSpace(asUid);
+      const sha = await pushMgr.pushAssetSpace(asUid);
       if (sha === "" || sha === undefined) {
         // Empty sha indicates «no dirty files» — pushAssetSpace already
         // emitted a Notice. Avoid duplicate user message.

--- a/packages/obsidian-plugin/tests/unit/ProfileApplyManager.apply.test.ts
+++ b/packages/obsidian-plugin/tests/unit/ProfileApplyManager.apply.test.ts
@@ -314,17 +314,40 @@ interface SetupOptions {
    * resolves, reproducing the «hang before the mutation phase» smoking gun).
    */
   lockMgrOverride?: unknown;
+  /**
+   * #3558 — override the `$exo` floor AssetSpace descriptor's uid + namespace to
+   * simulate an EKA central-registry vault: the registry mints a DISTINCT
+   * descriptor uid for `$exo` while the fork-safe namespace stays "exo". When
+   * set, the `assetspaces/kitelev/exoas-exo` descriptor uses
+   * `{uid, namespace}` instead of the default
+   * `{TS_FLOOR_AS_UID_EXO, "exoas-exo"}`. The floor must then be recognised by
+   * namespace, not by the hardcoded anchor uid.
+   */
+  exoDescriptor?: { uid: string; namespace: string };
+  /**
+   * #3557 — wire an `assetSpaceManagerFactory` (the fresh-PAT puller rebuilt per
+   * apply). When set, the desktop apply materialize path pulls via the factory
+   * result instead of the onload-captured `assetSpaceManager`, so a PAT
+   * configured after onload is honoured without a reload.
+   */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  assetSpaceManagerFactory?: () => Promise<any>;
 }
 
 function setup(opts: SetupOptions) {
   // Vault contains AssetSpace ABox assets for each TS-floor + extras.
-  const tsFloorFolders: Array<{ uid: string; folder: string }> = [
-    { uid: TS_FLOOR_AS_UID_EXO, folder: "assetspaces/kitelev/exoas-exo" },
+  const tsFloorFolders: Array<{ uid: string; folder: string; namespace?: string }> = [
+    {
+      // #3558 — exoDescriptor override simulates an EKA central-registry vault.
+      uid: opts.exoDescriptor?.uid ?? TS_FLOOR_AS_UID_EXO,
+      folder: "assetspaces/kitelev/exoas-exo",
+      namespace: opts.exoDescriptor?.namespace,
+    },
     { uid: TS_FLOOR_AS_UID_EXOCMD, folder: "assetspaces/kitelev/exoas-exocmd" },
     { uid: TS_FLOOR_AS_UID_SHARED_IDENTITIES, folder: "assetspaces/kitelev/exoas-shared-identities" },
   ];
 
-  const extraAs: Array<{ uid: string; folder: string }> = [
+  const extraAs: Array<{ uid: string; folder: string; namespace?: string }> = [
     { uid: "ems-uid", folder: "assetspaces/kitelev/exoas-ems" },
     { uid: "kpc-uid", folder: "assetspaces/kitelev/exoas-kpc" },
     { uid: "ims-uid", folder: "assetspaces/kitelev/exoas-ims" },
@@ -348,7 +371,7 @@ function setup(opts: SetupOptions) {
     // these AS UIDs directly, so the R24 guard resolves them against the folder
     // map without any Ontology→AS translation (removed in Phase 3 T3b-cleanup).
     ...allAs.map((as) => {
-      const ns = as.folder.split("/").pop();
+      const ns = as.namespace ?? as.folder.split("/").pop();
       return {
         path: `${as.folder}/${as.uid}.md`,
         basename: as.uid,
@@ -455,6 +478,10 @@ function setup(opts: SetupOptions) {
     ...(opts.isSyncBusy !== undefined ? { isSyncBusy: opts.isSyncBusy } : {}),
     ...(opts.applyTimeoutMs !== undefined
       ? { applyTimeoutMs: opts.applyTimeoutMs }
+      : {}),
+    ...(opts.assetSpaceManagerFactory !== undefined
+      ? /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
+        { assetSpaceManagerFactory: opts.assetSpaceManagerFactory as any }
       : {}),
   });
   return {
@@ -1007,6 +1034,50 @@ describe("ProfileApplyManager.applyProfile", () => {
     });
   });
 
+  describe("#3557 — PAT-after-onload: desktop apply rebuilds the puller per invocation", () => {
+    function freshPullerSetupOpts(extra: Partial<SetupOptions>): SetupOptions {
+      return {
+        targetUid: "target",
+        sourceUid: null,
+        // Floor present + one extra AS to materialise (so Phase 1 pull runs).
+        targetIncludes: [
+          TS_FLOOR_AS_UID_EXO,
+          TS_FLOOR_AS_UID_EXOCMD,
+          TS_FLOOR_AS_UID_SHARED_IDENTITIES,
+          "ems-uid",
+        ],
+        // ems-uid is NOT materialised → it lands in toMaterialize → pulled.
+        materialized: [
+          TS_FLOOR_AS_UID_EXO,
+          TS_FLOOR_AS_UID_EXOCMD,
+          TS_FLOOR_AS_UID_SHARED_IDENTITIES,
+        ],
+        ...extra,
+      };
+    }
+
+    it("pulls via assetSpaceManagerFactory (current PAT), NOT the onload-captured manager", async () => {
+      const freshPuller = new FakeAssetSpaceManager();
+      const { mgr, assetSpaceManager } = setup(
+        freshPullerSetupOpts({ assetSpaceManagerFactory: async () => freshPuller }),
+      );
+      await mgr.applyProfile("target");
+      // The fresh (current-PAT) puller did the materialize pull. Pre-fix the
+      // apply used the onload-captured `deps.assetSpaceManager` — frozen with an
+      // empty PAT when none was set at load → anonymous tarball → HTTP 404 on a
+      // private repo (Issue #3557).
+      expect(freshPuller.pullCalls.map((c) => c.asUid)).toContain("ems-uid");
+      expect(assetSpaceManager.pullCalls).toHaveLength(0);
+    });
+
+    it("sibling (revert-verify) — falls back to the onload manager when no factory is wired", async () => {
+      const { mgr, assetSpaceManager } = setup(freshPullerSetupOpts({}));
+      await mgr.applyProfile("target");
+      // No factory wired (tests/legacy) → the onload-captured manager pulls.
+      expect(assetSpaceManager.pullCalls.map((c) => c.asUid)).toContain("ems-uid");
+    });
+  });
+
   describe("Never-hang watchdog — bounds the WHOLE post-confirm path (Issue #3532)", () => {
     // #3531 bounded only the requestUrl / git-clone steps. #3532: macOS desktop
     // STILL hung after confirm — `_switchInProgress` never flipped, no journal,
@@ -1401,6 +1472,45 @@ describe("ProfileApplyManager.reconcileToLocal", () => {
     await localDataStore.save({ activeProfileUid: "target", _switchInProgress: false });
     confirmGate.approve = false;
     const result = await mgr.reconcileToLocal();
+    expect(result.outcome).toBe("declined");
+  });
+
+  // === #3558 — central-registry floor UID reconciliation ===
+  // An EKA central-registry vault mounts $exo under a descriptor UID that
+  // DIFFERS from the hardcoded TS_FLOOR_AS_UID_EXO anchor (fork-safe namespace
+  // "exo" stays the same). The floor must be recognised by namespace, otherwise
+  // every reload injects the hardcoded anchor into the expected set → reports the
+  // already-mounted floor "missing" → perpetual false-positive reconcile modal.
+  const REGISTRY_EXO_UID = "e5c47526-e72f-42e3-8535-3d243dd2db94";
+
+  it("#3558 — no-divergence when $exo floor is mounted under a registry UID (namespace match)", async () => {
+    const { mgr, localDataStore } = setup({
+      targetUid: "target",
+      sourceUid: null,
+      // Profile + vault key the exo floor on the registry UID, namespace "exo".
+      targetIncludes: [REGISTRY_EXO_UID],
+      materialized: [REGISTRY_EXO_UID],
+      exoDescriptor: { uid: REGISTRY_EXO_UID, namespace: "exo" },
+    });
+    await localDataStore.save({ activeProfileUid: "target", _switchInProgress: false });
+    const result = await mgr.reconcileToLocal();
+    // Pre-fix: hardcoded TS_FLOOR_AS_UID_EXO injected → floor "missing" → modal
+    // → outcome "reconciled". Post-fix: namespace "exo" satisfies the floor.
+    expect(result.outcome).toBe("no-divergence");
+  });
+
+  it("#3558 sibling (revert-verify) — still detects divergence when $exo floor is genuinely absent", async () => {
+    const { mgr, localDataStore, confirmGate } = setup({
+      targetUid: "target",
+      sourceUid: null,
+      targetIncludes: [REGISTRY_EXO_UID],
+      materialized: [], // $exo NOT mounted at all — a real divergence.
+      exoDescriptor: { uid: REGISTRY_EXO_UID, namespace: "exo" },
+    });
+    await localDataStore.save({ activeProfileUid: "target", _switchInProgress: false });
+    confirmGate.approve = false; // decline → no applyProfile side effects.
+    const result = await mgr.reconcileToLocal();
+    // The namespace reconciliation must NOT suppress a legitimately-missing floor.
     expect(result.outcome).toBe("declined");
   });
 });

--- a/packages/obsidian-plugin/tests/unit/ProfileCommands.test.ts
+++ b/packages/obsidian-plugin/tests/unit/ProfileCommands.test.ts
@@ -174,6 +174,35 @@ describe("ProfileCommands.invokePushCurrentAssetSpace", () => {
     await expect(h.cmd.invokePushCurrentAssetSpace()).resolves.not.toThrow();
     expect(h.notices.some((n) => /Push failed.*rate limit/.test(n))).toBe(true);
   });
+
+  it("#3557 — uses pushMgrFactory (current PAT) over the onload-captured pushMgr", async () => {
+    // The onload-captured pushMgr froze with whatever PAT existed at load (empty
+    // on a fresh vault). A PAT set after onload must authenticate the push
+    // without a reload → the command rebuilds the pusher per invocation.
+    const stale = new FakePushMgr(); // no lookup entry — would no-op if used
+    const fresh = new FakePushMgr();
+    fresh.lookups.set("assetspaces/exo", "as-uid-1");
+    fresh.pushReturn = "feedface00112233445566778899aabbccddeeff";
+    const notices: string[] = [];
+    const cmd = new ProfileCommands({
+      switchMgr: new FakeSwitchMgr() as unknown as ProfileApplyManager,
+      pushMgr: stale,
+      pushMgrFactory: async () => fresh,
+      profileLister: async () => [],
+      fuzzyPick: async () => null,
+      getActiveFilePath: () => "assetspaces/exo/foo.md",
+      getActiveProfileUid: () => null,
+      notify: (m) => notices.push(m),
+    });
+
+    await cmd.invokePushCurrentAssetSpace();
+
+    // The fresh (current-PAT) pusher handled the push; the stale onload one was
+    // never touched. Pre-fix: stale.lookupAssetSpaceForPath → null → no-op.
+    expect(fresh.pushedAs).toEqual(["as-uid-1"]);
+    expect(stale.pushedAs).toHaveLength(0);
+    expect(notices.some((n) => /feedfac/.test(n))).toBe(true);
+  });
 });
 
 // ═══════════════════════════════════════════════════════════════════════════

--- a/packages/obsidian-plugin/tests/unit/ProfileCommands.test.ts
+++ b/packages/obsidian-plugin/tests/unit/ProfileCommands.test.ts
@@ -203,6 +203,27 @@ describe("ProfileCommands.invokePushCurrentAssetSpace", () => {
     expect(stale.pushedAs).toHaveLength(0);
     expect(notices.some((n) => /feedfac/.test(n))).toBe(true);
   });
+
+  it("#3557 — surfaces a Notice (no unhandled rejection) when pushMgrFactory rejects", async () => {
+    const notices: string[] = [];
+    const cmd = new ProfileCommands({
+      switchMgr: new FakeSwitchMgr() as unknown as ProfileApplyManager,
+      pushMgr: new FakePushMgr(),
+      pushMgrFactory: async () => {
+        throw new Error("PAT read failed");
+      },
+      profileLister: async () => [],
+      fuzzyPick: async () => null,
+      getActiveFilePath: () => "assetspaces/exo/foo.md",
+      getActiveProfileUid: () => null,
+      notify: (m) => notices.push(m),
+    });
+
+    // Fire-and-forget callsite — a factory rejection must degrade to a Notice,
+    // not an unhandled promise rejection.
+    await expect(cmd.invokePushCurrentAssetSpace()).resolves.not.toThrow();
+    expect(notices.some((n) => /Push failed.*PAT read failed/.test(n))).toBe(true);
+  });
 });
 
 // ═══════════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
Three alpha-day onboarding frictions in the **profile apply / PAT** subsystem (found in the fresh-vault `$$kitelev-tbank` onboarding journey, al-fresh-onboarding 2026-06-15). Bundled — heavily overlapping files (`ProfileApplyManager.ts`, `ProfileCommands.ts`).

## #3558 (MED) — TS-floor UID hardcode mismatch → perpetual false-positive reconcile
An EKA central-registry vault mounts `$exo` under a descriptor UID `e5c47526` (namespace `"exo"`) that differs from the hardcoded `TS_FLOOR_AS_UID_EXO` anchor `49fd2e56`. Both the reconcile-on-reload and the apply diff injected the **raw hardcoded anchor**, so a floor mounted under the registry UID looked **"missing"** → "materialize exo" modal **every reload**; on apply it would try to **re-materialize** the already-mounted floor (duplicate-mount risk).

**Fix:** new `addReconciledFloor()` resolves the floor by **UID-OR-namespace** (mirrors the existing `assertTsFloorReconciled`) in both `reconcileToLocal` and `resolveDeclaredAndEffective`. Falls back to the legacy anchor only when the floor is genuinely absent (so a truly-missing floor still triggers reconcile). CLI is unaffected (it already tracks materialization per-descriptor, not folder-deduped).

## #3557 (HIGH) — PAT configured after onload → HTTP 404 on private-profile apply
`ApplyDepsFactory` captured the `GitHubRestClient` (PAT) **once at onload**; a PAT set later made apply pull **anonymously** → 404 on private repos, with no reload hint. Mobile already rebuilt fresh via `restMountFactory`; **desktop did not**.

**Fix:** added `assetSpaceManagerFactory` (desktop apply puller) + `pushMgrFactory` (push), rebuilt from the **current** PAT per invocation — the same #3382 pattern already used for Bootstrap/Add. A PAT set after onload now authenticates **apply + push** without a reload, on **both** platforms.

## #3559 (docs/UX) — git-vault apply commit-first undocumented
Improved `UncommittedChangesAbortError` message + the user-facing Notice with an actionable **commit-first** guide (+ gitignore `.obsidian/` to protect the PAT). Documented in `docs/profile.md` ("Apply on a git-backed vault") and the Getting-Started 3-step onboarding flow. **No auto-commit** (out of scope — #3548 territory).

## Tests
Regression + **revert-verify** for #3558 (reconcile) and #3557 (apply puller + push) — each FAILS pre-fix, PASSES post-fix.
- `231` profile/plugin unit tests green · typecheck + lint clean · build green (mobile-loadable + console-channel assertions pass).

Closes #3557
Closes #3558
Closes #3559