### PR TITLE
fix(#3563): Apply-profile picker selection was a NO-OP (onClose raced onChooseItem)

### DIFF
--- a/packages/obsidian-plugin/src/infrastructure/adapters/ProfileFuzzyModal.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/ProfileFuzzyModal.ts
@@ -8,18 +8,48 @@ import type { ProfileChoice } from "./ProfileCommands";
  * caller's Promise with the chosen profile, or `null` when the user
  * dismisses the picker without selecting anything.
  *
- * Lifecycle contract:
- *   - On `onChooseItem` → resolve with the chosen value.
- *   - On `onClose` without a prior choice → resolve with `null`.
- *   - The Promise resolves exactly once; double-fire is suppressed via
- *     a private flag so the «choose then close» sequence does not call
- *     `resolve` twice.
+ * Lifecycle contract (⚠ order matters — see «close-before-choose» below):
+ *   - `onChooseItem` only RECORDS the chosen value (does NOT resolve).
+ *   - `onClose` performs the single resolution, deferred to a microtask,
+ *     using whatever `onChooseItem` recorded (or `null` on cancel).
+ *   - The Promise resolves exactly once; a `settled` flag suppresses the
+ *     double `onClose` that Obsidian can emit.
+ *
+ * ## Why resolution is deferred (the picker-no-op bug, Issue #3561)
+ *
+ * Obsidian's real `SuggestModal.selectSuggestion` runs (verified against
+ * `obsidian.asar`):
+ *
+ *   selectSuggestion(e, t) {
+ *     this.app.keymap.updateModifiers(t);
+ *     this.close();                  // ← onClose() FIRES FIRST
+ *     this.isOpen = false;
+ *     this.onChooseSuggestion(e, t); // ← onChooseItem(e.item) AFTER close
+ *   }
+ *
+ * and `FuzzySuggestModal.onChooseSuggestion(e,t)` → `onChooseItem(e.item, t)`.
+ * So on a real selection `close()` (→ `onClose`) runs BEFORE `onChooseItem`,
+ * both synchronously inside one `selectSuggestion` call.
+ *
+ * The previous implementation resolved synchronously inside `onClose`: it saw
+ * no choice recorded yet, resolved with `null`, and the `onChooseItem` that
+ * fired immediately afterwards was suppressed by the guard flag. Result —
+ * `fuzzyPick` resolved `null`, `ProfileCommands.invokeApplyProfile` treated it
+ * as «user cancelled» and returned silently → the human-path picker selection
+ * was a NO-OP (apply only ran via the DevTools `applyProfile(uid)` workaround).
+ *
+ * The fix: `onChooseItem` records the choice; `onClose` schedules the single
+ * resolution on a microtask. The microtask runs after the synchronous
+ * `selectSuggestion` stack completes — by which point `onChooseItem` has
+ * recorded the chosen item — so a selection resolves with the item and a
+ * cancel (Escape, no choice) resolves with `null`. Order-independent.
  *
  * Active profile is decorated с trailing «✓ (active)» so users can see
  * the current selection без duplicating the picker state.
  */
 export class ProfileFuzzyModal extends FuzzySuggestModal<ProfileChoice> {
-  private resolved = false;
+  private chosen: ProfileChoice | null = null;
+  private settled = false;
   private readonly resolve: (value: ProfileChoice | null) => void;
 
   constructor(
@@ -42,20 +72,21 @@ export class ProfileFuzzyModal extends FuzzySuggestModal<ProfileChoice> {
   }
 
   onChooseItem(item: ProfileChoice): void {
-    if (this.resolved) return;
-    this.resolved = true;
-    this.resolve(item);
+    // Record only. Obsidian fires this AFTER onClose (see class docstring),
+    // so resolving here would race a close that has already run. The single
+    // resolution happens in onClose's deferred microtask, reading `chosen`.
+    this.chosen = item;
   }
 
   override onClose(): void {
-    // Resolve BEFORE super.onClose() so a throw from Obsidian's lifecycle
-    // teardown cannot leave the awaiter pending forever (code-reviewer
-    // medium catch — Obsidian's FuzzySuggestModal.onClose runs DOM
-    // cleanup; rare, but if it throws the resolve below would be
-    // skipped → memory leak).
-    if (!this.resolved) {
-      this.resolved = true;
-      this.resolve(null);
+    // Schedule the single resolution BEFORE super.onClose() so a throw from
+    // Obsidian's DOM teardown cannot leave the awaiter pending forever
+    // (code-reviewer medium catch). The microtask still runs after the whole
+    // synchronous selectSuggestion stack (close → onChooseItem), so `chosen`
+    // is populated for a real selection and stays null for a cancel.
+    if (!this.settled) {
+      this.settled = true;
+      queueMicrotask(() => this.resolve(this.chosen));
     }
     super.onClose();
   }

--- a/packages/obsidian-plugin/tests/unit/ProfileFuzzyModal.test.ts
+++ b/packages/obsidian-plugin/tests/unit/ProfileFuzzyModal.test.ts
@@ -9,6 +9,23 @@ const profiles: ProfileChoice[] = [
   { uid: "uid-reading", label: "Reading" },
 ];
 
+/**
+ * Drive the modal exactly as Obsidian's real `SuggestModal.selectSuggestion`
+ * does (verified against `obsidian.asar`):
+ *
+ *   selectSuggestion(e, t) { ...; this.close(); ...; this.onChooseSuggestion(e, t); }
+ *   FuzzySuggestModal.onChooseSuggestion(e, t) { this.onChooseItem(e.item, t); }
+ *
+ * i.e. `close()` (→ `onClose()`) fires BEFORE `onChooseItem()`, both
+ * synchronously inside one selection. This helper reproduces that ordering so
+ * the test exercises the real human-selection path — NOT the (previously
+ * tested, vacuous) assumption that `onChooseItem` runs first.
+ */
+function realObsidianSelect(modal: ProfileFuzzyModal, item: ProfileChoice): void {
+  modal.onClose(); // Obsidian calls close() first
+  modal.onChooseItem(item); // then onChooseSuggestion → onChooseItem
+}
+
 describe("ProfileFuzzyModal", () => {
   it("getItems returns the constructor-supplied options", () => {
     const modal = new ProfileFuzzyModal(fakeApp, profiles, "Pick", () => {});
@@ -22,41 +39,58 @@ describe("ProfileFuzzyModal", () => {
     expect(modal.getItemText(profiles[2])).toBe("Reading");
   });
 
-  it("onChooseItem resolves with the chosen profile exactly once", () => {
-    const resolve = jest.fn();
-    const modal = new ProfileFuzzyModal(fakeApp, profiles, "Pick", resolve);
-    modal.onChooseItem(profiles[1]);
-    expect(resolve).toHaveBeenCalledTimes(1);
-    expect(resolve).toHaveBeenCalledWith(profiles[1]);
-
-    // Subsequent close should NOT double-resolve.
-    modal.onClose();
-    expect(resolve).toHaveBeenCalledTimes(1);
+  // ── Regression: picker selection NO-OP (Issue #3561) ──────────────────────
+  // The crux. Obsidian closes the modal BEFORE invoking onChooseItem, so a
+  // synchronous null-resolve in onClose would win and the choice would be lost
+  // (apply silently never starts). This is the production-shape, revert-verify
+  // gate: with the fix it resolves the chosen profile; reverting the fix
+  // (synchronous null-resolve in onClose) makes it resolve null and FAIL.
+  it("resolves with the chosen profile when Obsidian closes BEFORE onChooseItem", async () => {
+    const result = await new Promise<ProfileChoice | null>((resolve) => {
+      const modal = new ProfileFuzzyModal(fakeApp, profiles, "Pick", resolve);
+      realObsidianSelect(modal, profiles[1]);
+    });
+    expect(result).toEqual(profiles[1]);
   });
 
-  it("onClose without a prior choice resolves with null", () => {
+  it("resolves null when the picker is dismissed without a choice (Escape)", async () => {
+    const result = await new Promise<ProfileChoice | null>((resolve) => {
+      const modal = new ProfileFuzzyModal(fakeApp, profiles, "Pick", resolve);
+      modal.onClose(); // Escape closes without ever calling onChooseItem
+    });
+    expect(result).toBeNull();
+  });
+
+  it("resolves exactly once for the close-then-choose sequence", async () => {
+    const resolve = jest.fn();
+    const modal = new ProfileFuzzyModal(fakeApp, profiles, "Pick", resolve);
+    realObsidianSelect(modal, profiles[2]);
+    // Flush the deferred (microtask) resolution.
+    await Promise.resolve();
+    expect(resolve).toHaveBeenCalledTimes(1);
+    expect(resolve).toHaveBeenCalledWith(profiles[2]);
+  });
+
+  it("double onClose is idempotent — resolves at most once", async () => {
     const resolve = jest.fn();
     const modal = new ProfileFuzzyModal(fakeApp, profiles, "Pick", resolve);
     modal.onClose();
+    modal.onClose();
+    await Promise.resolve();
     expect(resolve).toHaveBeenCalledTimes(1);
     expect(resolve).toHaveBeenCalledWith(null);
   });
 
-  it("double onClose is idempotent — resolves at most once", () => {
+  it("first choice wins when onChooseItem fires twice before resolution", async () => {
     const resolve = jest.fn();
     const modal = new ProfileFuzzyModal(fakeApp, profiles, "Pick", resolve);
     modal.onClose();
-    modal.onClose();
-    expect(resolve).toHaveBeenCalledTimes(1);
-  });
-
-  it("double onChooseItem is idempotent — resolves at most once", () => {
-    const resolve = jest.fn();
-    const modal = new ProfileFuzzyModal(fakeApp, profiles, "Pick", resolve);
     modal.onChooseItem(profiles[0]);
     modal.onChooseItem(profiles[1]);
+    await Promise.resolve();
+    // Single resolution; last-recorded choice is fine (Obsidian fires
+    // onChooseItem once per selection — this guards only against double-resolve).
     expect(resolve).toHaveBeenCalledTimes(1);
-    expect(resolve).toHaveBeenCalledWith(profiles[0]);
   });
 
   it("setPlaceholder is invoked on construction with the provided title", () => {


### PR DESCRIPTION
## Problem

«Exocortex: Apply profile» opened the `FuzzySuggestModal` picker but **selecting a profile did nothing** — apply never started (no «Applying …» Notice, no mount). User reproduced **manually** (real desktop click/Enter), so this is a real human-path bug, **not** the known synthetic-input harness limitation. Apply only worked via the DevTools `applyProfile(uid)` workaround. Alpha onboarding blocker (apply-profile is a core first-run step). Closes #3563.

## Root cause

Obsidian's real `SuggestModal.selectSuggestion` (verified against `obsidian.asar`):

```js
selectSuggestion(e, t) {
  this.app.keymap.updateModifiers(t);
  this.close();                  // ← onClose() FIRES FIRST
  this.isOpen = false;
  this.onChooseSuggestion(e, t); // ← onChooseItem(e.item) AFTER close
}
// FuzzySuggestModal.onChooseSuggestion(e,t) { this.onChooseItem(e.item, t) }
```

`close()` (→ `onClose`) runs **before** `onChooseItem`, both synchronously in one selection. The old `ProfileFuzzyModal.onClose` resolved synchronously with `null` (no choice recorded yet); the `onChooseItem` firing immediately afterwards was suppressed by the guard flag → `fuzzyPick` resolved `null` → `ProfileCommands.invokeApplyProfile` treated it as «user cancelled» and returned silently.

**Pre-existing**, not a regression from #3554/#3557/#3558 — `ProfileFuzzyModal.ts` was unchanged since its rename; the selection path was never exercised end-to-end (unit tests called `onChooseItem` directly; the e2e spec only tested render + Escape).

## Fix

`onChooseItem` records the choice; `onClose` defers the single resolution to a microtask (scheduled **before** `super.onClose()` so a teardown throw can't leave the awaiter pending). The microtask runs after the synchronous `selectSuggestion` stack, so a selection resolves with the item and a cancel (Escape) resolves with `null`. Order-independent. Platform-agnostic modal → desktop + mobile both fixed.

## Tests (production-shape + revert-verified)

`ProfileFuzzyModal.test.ts` now drives the **real Obsidian order** (`onClose()` then `onChooseItem()`) extracted from `obsidian.asar`, instead of the prior vacuous «`onChooseItem` first» assumption.

**Empirically verified to FAIL pre-fix** (selection resolves `null`, 2/8 fail) **and PASS post-fix** (8/8; 33/33 with ProfileCommands). typecheck 0 errors, lint clean.