### PR TITLE
fix(#3565): asset-mode first-sync deadlock on additive local divergence

### DIFF
--- a/packages/exocortex/src/services/sync/SyncEngine.ts
+++ b/packages/exocortex/src/services/sync/SyncEngine.ts
@@ -236,9 +236,7 @@ function isSafeRepoRelativePath(path: string): boolean {
   if (path.length === 0 || path.startsWith("/") || path.includes("\\")) {
     return false;
   }
-  return path
-    .split("/")
-    .every((s) => s.length > 0 && s !== "." && s !== "..");
+  return path.split("/").every((s) => s.length > 0 && s !== "." && s !== "..");
 }
 
 /**
@@ -449,6 +447,21 @@ type PushLoopOutcome =
        */
       deferredWarnings: string[];
     };
+
+/**
+ * Outcome of the ASSET-mode first-sync probe ({@link SyncEngine.bootstrapWatermark}).
+ *  - `settled`: the cycle is fully decided here — a clean mount (local tree
+ *    identical to remote) was seeded → `synced`, or a GENUINE divergence (a
+ *    remote-head file absent locally, or a same-path content difference) →
+ *    `full-conflict` (A2/A3, D22 — never a silent overwrite).
+ *  - `additive-base`: the local tree is a pure SUPERSET of the remote head
+ *    (R ⊆ L by path+blob — only local-only new files diverge, #3565). The
+ *    caller continues the normal cycle with this synthetic base so the
+ *    local-only files derive as pushable adds (a clean fast-forward).
+ */
+type FirstSyncBootstrap =
+  | { kind: "settled"; outcome: RepoSyncResult }
+  | { kind: "additive-base"; base: WatermarkRecord };
 
 const EMPTY_MERGE: MergeResolution = {
   mergedFiles: new Map(),
@@ -759,23 +772,41 @@ export class SyncEngine {
       let syntheticFirstSyncBase = false;
       if (watermark === null) {
         if (!mode.fileMode) {
-          return await this.bootstrapWatermark(spec, disk, warnings, result);
+          // Asset-mode first-sync (#3565). A clean mount (local tree identical
+          // to remote) seeds the watermark and no-ops. A PURELY ADDITIVE
+          // divergence — local-only new files, every remote-head file still
+          // present on disk byte-identical (R ⊆ L) — hands back a synthetic
+          // base so those locals derive as pushable adds (a clean
+          // fast-forward, no remote changes to reconcile). A GENUINE
+          // divergence (a remote file absent locally, or a same-path content
+          // difference) stays `full-conflict` — routed to the merge/quarantine
+          // layer (A2/A3, D22), never a silent overwrite.
+          const bootstrap = await this.bootstrapWatermark(
+            spec,
+            disk,
+            warnings,
+            result,
+          );
+          if (bootstrap.kind === "settled") return bootstrap.outcome;
+          syntheticFirstSyncBase = true;
+          watermark = bootstrap.base;
+        } else {
+          syntheticFirstSyncBase = true;
+          // Phase C file-mode first-sync (advisor C1): there is no exact-match
+          // requirement — divergence resolves through the remote-wins layer,
+          // which IS the file-mode merge/quarantine layer (D22-compatible).
+          // The synthetic base = the intersection of disk and remote head
+          // where blobs already match; everything else derives as local adds
+          // (pushed — may re-create files another device deleted; data
+          // resurrection is the accepted first-sync trade-off, M1 zero-loss
+          // wins) or remote changes (pulled / conflicting → remote-wins).
+          watermark = await this.buildFileModeFirstSyncBase(
+            spec,
+            disk,
+            mode,
+            warnings,
+          );
         }
-        syntheticFirstSyncBase = true;
-        // Phase C file-mode first-sync (advisor C1): there is no exact-match
-        // requirement — divergence resolves through the remote-wins layer,
-        // which IS the file-mode merge/quarantine layer (D22-compatible).
-        // The synthetic base = the intersection of disk and remote head
-        // where blobs already match; everything else derives as local adds
-        // (pushed — may re-create files another device deleted; data
-        // resurrection is the accepted first-sync trade-off, M1 zero-loss
-        // wins) or remote changes (pulled / conflicting → remote-wins).
-        watermark = await this.buildFileModeFirstSyncBase(
-          spec,
-          disk,
-          mode,
-          warnings,
-        );
       }
 
       // A size-excluded LOCAL path must also vanish from the diff base —
@@ -1640,10 +1671,7 @@ export class SyncEngine {
         // fails HTTP 404 — empirically verified). A deletion set wiping
         // EVERY entry of the head tree with nothing pushed alongside is
         // deferred loudly instead of failing the whole repo.
-        if (
-          pushFiles.size === 0 &&
-          pushDeletions.size >= headTreeByPath.size
-        ) {
+        if (pushFiles.size === 0 && pushDeletions.size >= headTreeByPath.size) {
           withheldDeletions.push(...pushDeletions);
           deferredWarnings.push(
             `deletion of ALL ${pushDeletions.size} remaining file(s) deferred — GitHub cannot create an empty tree; the deletes re-derive and propagate once the repo has at least one surviving file`,
@@ -1687,7 +1715,11 @@ export class SyncEngine {
           ),
           deletions: [...pushDeletions],
           message:
-            this.deps.commitMessage?.(spec, pushFiles.size, pushDeletions.size) ??
+            this.deps.commitMessage?.(
+              spec,
+              pushFiles.size,
+              pushDeletions.size,
+            ) ??
             `chore(exosync): sync ${pushFiles.size} file(s)${pushDeletions.size > 0 ? `, ${pushDeletions.size} deletion(s)` : ""}`,
           baseURL: this.deps.baseURL,
           redact: this.deps.redact,
@@ -2084,10 +2116,24 @@ export class SyncEngine {
   }
 
   /**
-   * First-sync bootstrap (safe subset): when no watermark exists but the
-   * local working tree EXACTLY equals the remote head tree (fresh mount), the
-   * watermark is seeded and the sync is a no-op. Any difference is a genuine
-   * first-sync divergence → full-conflict (A2/A3, D22).
+   * Asset-mode first-sync probe (no watermark). Classifies the local working
+   * tree against the remote head into one of three outcomes (see
+   * {@link FirstSyncBootstrap}):
+   *
+   *  - **clean mount** — local tree identical to remote: seed the watermark,
+   *    no-op (`settled` → `synced`).
+   *  - **purely additive** (#3565) — every remote-head file is present on disk
+   *    byte-identical (R ⊆ L) and disk has extra local-only files: return a
+   *    synthetic base = the remote head tree (`additive-base`). The normal
+   *    cycle then derives the local-only files as pushable adds — a clean
+   *    fast-forward, no remote changes to reconcile, M1 zero-loss intact
+   *    (no overwrite, no merge needed). The real watermark is persisted by
+   *    `advanceWatermark` at the end of the successful cycle.
+   *  - **genuine divergence** — a remote-head file absent locally, OR a
+   *    same-path content difference (overlapping edit): `settled` →
+   *    `full-conflict`. Routed to the merge/quarantine layer (A2/A3, D22),
+   *    NEVER a silent overwrite. Reserving `full-conflict` for real overlaps
+   *    is what distinguishes this from the additive case.
    */
   private async bootstrapWatermark(
     spec: SyncRepoSpec,
@@ -2097,7 +2143,7 @@ export class SyncEngine {
       status: RepoSyncResult["status"],
       extra?: Partial<RepoSyncResult>,
     ) => RepoSyncResult,
-  ): Promise<RepoSyncResult> {
+  ): Promise<FirstSyncBootstrap> {
     const head = await getHeadSha(
       this.transport,
       spec.owner,
@@ -2122,23 +2168,29 @@ export class SyncEngine {
       )
     ).filter((e) => isSyncablePath(e.path));
 
-    if (headTree.length !== disk.size) {
-      return result("full-conflict", {
-        detail: `first-sync: no watermark and local tree (${disk.size} files) differs from remote head (${headTree.length} files) — A2/A3 scope`,
-      });
-    }
+    // Verify R ⊆ L: every remote-head file must be present on disk with an
+    // identical blob. A remote file absent locally, or a same-path content
+    // difference, is a GENUINE first-sync divergence (remote-side edits/files
+    // to reconcile, or an overlapping edit) → full-conflict (A2/A3, D22 —
+    // never a silent overwrite). #3565: the count check that used to gate
+    // this is GONE — a pure local-only superset (disk.size > headTree.length)
+    // is no longer a conflict; it is the additive case handled below.
     for (const entry of headTree) {
       const content = disk.get(entry.path);
       if (
         content === undefined ||
         (await gitBlobSha(content, this.deps.sha1)) !== entry.blobSha
       ) {
-        return result("full-conflict", {
-          detail: `first-sync: no watermark and local content diverges from remote head at ${entry.path} — A2/A3 scope`,
-        });
+        return {
+          kind: "settled",
+          outcome: result("full-conflict", {
+            detail: `first-sync: no watermark and local content diverges from remote head at ${entry.path} — A2/A3 scope`,
+          }),
+        };
       }
     }
 
+    // R ⊆ L holds. The base = the remote head tree (every entry matches disk).
     const files: WatermarkFileEntry[] = headTree.map((e) => {
       const content = disk.get(e.path);
       // Asset-mode-only path (file-mode first-sync goes through the
@@ -2147,15 +2199,33 @@ export class SyncEngine {
         typeof content === "string" ? extractAssetUid(content) : undefined;
       return { path: e.path, blobSha: e.blobSha, ...(uid ? { uid } : {}) };
     });
-    await this.deps.watermarkStore.set(spec.repoKey, {
+    const base: WatermarkRecord = {
       lastSyncedSha: head,
       rootTreeSha: headCommit.treeSha,
       files,
-    });
+    };
+
+    if (disk.size === headTree.length) {
+      // Clean mount — local tree identical to remote: seed + no-op (fast path,
+      // avoids the synthetic-base cycle + its extra remote diff for the common
+      // 12/13 unchanged repos on every apply-profile).
+      await this.deps.watermarkStore.set(spec.repoKey, base);
+      warnings.push(
+        `watermark bootstrapped from head ${head} (local tree identical to remote)`,
+      );
+      return { kind: "settled", outcome: result("synced") };
+    }
+
+    // disk.size > headTree.length → PURELY ADDITIVE first-sync (#3565): the
+    // only divergence is local-only new files (R ⊆ L by path+blob, verified
+    // above). Hand the head-tree base back so the normal cycle derives those
+    // locals as pushable adds. Without this, the canonical onboarding
+    // (apply profile → create asset → Sync) deadlocked: every direction
+    // returned `full-conflict — first-sync` and pushed nothing.
     warnings.push(
-      `watermark bootstrapped from head ${head} (local tree identical to remote)`,
+      `first-sync (asset mode): local tree (${disk.size} files) is a pure superset of remote head ${head} (${headTree.length} files) — ${disk.size - headTree.length} local-only addition(s) derive as pushable adds (#3565)`,
     );
-    return result("synced");
+    return { kind: "additive-base", base };
   }
 
   /**

--- a/packages/exocortex/tests/unit/services/sync/SyncEngine.test.ts
+++ b/packages/exocortex/tests/unit/services/sync/SyncEngine.test.ts
@@ -99,7 +99,9 @@ describe("SyncEngine — first-sync bootstrap (D22)", () => {
 
   it("returns full-conflict when disk diverges and no watermark exists (never overwrites)", async () => {
     const gh = new FakeGitHubRepo({ [FILE_A]: mdAsset("u1", "remote") });
-    const local = new FakeLocalFiles({ [FILE_A]: mdAsset("u1", "local-divergent") });
+    const local = new FakeLocalFiles({
+      [FILE_A]: mdAsset("u1", "local-divergent"),
+    });
     const { engine } = makeEngine(gh, local);
 
     const result = await engine.sync(gh.spec());
@@ -111,10 +113,105 @@ describe("SyncEngine — first-sync bootstrap (D22)", () => {
   });
 });
 
+// #3565 — the canonical onboarding (apply profile → create asset → Sync) used
+// to DEADLOCK on an asset-mode AssetSpace: a purely ADDITIVE local divergence
+// (local-only new files, every remote-head file still present byte-identical)
+// returned `full-conflict — first-sync` and pushed nothing, with no watermark
+// ever established. The fix gives asset-mode first-sync the additive-tolerant
+// synthetic base file-mode already had, while RESERVING full-conflict for
+// genuine overlapping edits/deletes (zero-loss intact).
+describe("SyncEngine — first-sync additive divergence (#3565)", () => {
+  it("pushes local-only additions when local is a pure superset of remote head", async () => {
+    // Profile applied (remote materialized byte-identical), then the tester
+    // created a new asset → local = remote ∪ {new file}, no watermark yet.
+    const gh = new FakeGitHubRepo({ [FILE_A]: mdAsset("u1") });
+    const local = new FakeLocalFiles({
+      [FILE_A]: mdAsset("u1"),
+      [FILE_B]: mdAsset("u2"),
+    });
+    const { engine, watermarks } = makeEngine(gh, local);
+
+    const result = await engine.sync(gh.spec());
+
+    expect(result.status).toBe("synced");
+    expect(result.pushedCount).toBe(1); // the local-only add — a clean ff
+    expect(gh.headFiles().get(FILE_B)).toBe(mdAsset("u2")); // landed on remote
+    expect(gh.headFiles().get(FILE_A)).toBe(mdAsset("u1")); // neighbour intact
+    expect(result.warnings.join(" ")).toMatch(/pure superset/);
+
+    // The deadlock is gone: a watermark is established, so a re-sync no-ops
+    // (pre-fix every re-run reproduced full-conflict indefinitely).
+    const record = watermarks.records.get(gh.spec().repoKey)!;
+    expect(record.files.map((f) => f.path).sort()).toEqual([FILE_A, FILE_B]);
+    const again = await engine.sync(gh.spec());
+    expect(again.status).toBe("synced");
+    expect(again.pushedCount).toBe(0);
+  });
+
+  it("pushes several local-only additions in one first sync", async () => {
+    const gh = new FakeGitHubRepo({ [FILE_A]: mdAsset("u1") });
+    const local = new FakeLocalFiles({
+      [FILE_A]: mdAsset("u1"),
+      ["assets/c.md"]: mdAsset("u3"),
+      ["assets/d.md"]: mdAsset("u4"),
+    });
+    const { engine } = makeEngine(gh, local);
+
+    const result = await engine.sync(gh.spec());
+
+    expect(result.status).toBe("synced");
+    expect(result.pushedCount).toBe(2);
+    expect(gh.headFiles().get("assets/c.md")).toBe(mdAsset("u3"));
+    expect(gh.headFiles().get("assets/d.md")).toBe(mdAsset("u4"));
+  });
+
+  it("stays full-conflict when a remote-head file is absent locally (not purely additive)", async () => {
+    // R ⊄ L: a remote file is missing on disk — ambiguous (remote add vs local
+    // delete) with no watermark, so the conservative zero-loss answer holds.
+    const gh = new FakeGitHubRepo({
+      [FILE_A]: mdAsset("u1"),
+      [FILE_B]: mdAsset("u2"),
+    });
+    const local = new FakeLocalFiles({ [FILE_A]: mdAsset("u1") });
+    const { engine, watermarks } = makeEngine(gh, local);
+
+    const result = await engine.sync(gh.spec());
+
+    expect(result.status).toBe("full-conflict");
+    expect(result.detail).toMatch(/first-sync/);
+    expect(gh.headFiles().get(FILE_B)).toBe(mdAsset("u2")); // remote untouched
+    expect(watermarks.records.size).toBe(0); // no watermark on conflict
+  });
+
+  it("stays full-conflict when an addition coincides with a same-path edit (genuine overlap)", async () => {
+    // Local both edits FILE_A and adds FILE_B. The FILE_A edit breaks R ⊆ L,
+    // so the whole first sync stays full-conflict — the add is NOT pushed,
+    // preserving M1 zero-loss for the overlapping edit.
+    const gh = new FakeGitHubRepo({ [FILE_A]: mdAsset("u1", "remote") });
+    const local = new FakeLocalFiles({
+      [FILE_A]: mdAsset("u1", "local-edit"),
+      [FILE_B]: mdAsset("u2"),
+    });
+    const { engine } = makeEngine(gh, local);
+
+    const result = await engine.sync(gh.spec());
+
+    expect(result.status).toBe("full-conflict");
+    expect(gh.headFiles().get(FILE_A)).toBe(mdAsset("u1", "remote")); // untouched
+    expect(gh.headFiles().has(FILE_B)).toBe(false); // add NOT pushed amid overlap
+  });
+});
+
 describe("SyncEngine — push-only happy path (VL#7, D3)", () => {
   it("pushes a local edit via restCreateCommit and advances the watermark", async () => {
-    const gh = new FakeGitHubRepo({ [FILE_A]: mdAsset("u1"), [FILE_B]: mdAsset("u2") });
-    const local = new FakeLocalFiles({ [FILE_A]: mdAsset("u1"), [FILE_B]: mdAsset("u2") });
+    const gh = new FakeGitHubRepo({
+      [FILE_A]: mdAsset("u1"),
+      [FILE_B]: mdAsset("u2"),
+    });
+    const local = new FakeLocalFiles({
+      [FILE_A]: mdAsset("u1"),
+      [FILE_B]: mdAsset("u2"),
+    });
     const { engine, watermarks } = makeEngine(gh, local);
     await bootstrap(engine, gh.spec());
 
@@ -146,7 +243,10 @@ describe("SyncEngine — push-only happy path (VL#7, D3)", () => {
   });
 
   it("non-.md files are excluded symmetrically (binary safety)", async () => {
-    const gh = new FakeGitHubRepo({ [FILE_A]: mdAsset("u1"), "img/pic.png": "PNGBYTES" });
+    const gh = new FakeGitHubRepo({
+      [FILE_A]: mdAsset("u1"),
+      "img/pic.png": "PNGBYTES",
+    });
     const local = new FakeLocalFiles({ [FILE_A]: mdAsset("u1") }); // png absent locally
     const { engine } = makeEngine(gh, local);
     await bootstrap(engine, gh.spec()); // bootstrap ignores the png
@@ -167,19 +267,31 @@ describe("SyncEngine — pull phase (no-conflict remote changes)", () => {
     const { engine, watermarks } = makeEngine(gh, local);
     await bootstrap(engine, gh.spec());
 
-    gh.commitDirect("main", { [FILE_B]: mdAsset("u2", "from device B") }, "device B");
+    gh.commitDirect(
+      "main",
+      { [FILE_B]: mdAsset("u2", "from device B") },
+      "device B",
+    );
     const result = await engine.sync(gh.spec());
 
     expect(result.status).toBe("synced");
     expect(result.pushedCount).toBe(0);
     expect(result.pulledCount).toBe(1);
     expect(local.files.get(FILE_B)).toBe(mdAsset("u2", "from device B"));
-    expect(watermarks.records.get(gh.spec().repoKey)!.lastSyncedSha).toBe(gh.headSha());
+    expect(watermarks.records.get(gh.spec().repoKey)!.lastSyncedSha).toBe(
+      gh.headSha(),
+    );
   });
 
   it("applies a remote delete locally when the file is locally untouched", async () => {
-    const gh = new FakeGitHubRepo({ [FILE_A]: mdAsset("u1"), [FILE_B]: mdAsset("u2") });
-    const local = new FakeLocalFiles({ [FILE_A]: mdAsset("u1"), [FILE_B]: mdAsset("u2") });
+    const gh = new FakeGitHubRepo({
+      [FILE_A]: mdAsset("u1"),
+      [FILE_B]: mdAsset("u2"),
+    });
+    const local = new FakeLocalFiles({
+      [FILE_A]: mdAsset("u1"),
+      [FILE_B]: mdAsset("u2"),
+    });
     const { engine } = makeEngine(gh, local);
     await bootstrap(engine, gh.spec());
 
@@ -191,12 +303,22 @@ describe("SyncEngine — pull phase (no-conflict remote changes)", () => {
   });
 
   it("pushes local + applies remote when changes are disjoint", async () => {
-    const gh = new FakeGitHubRepo({ [FILE_A]: mdAsset("u1"), [FILE_B]: mdAsset("u2") });
-    const local = new FakeLocalFiles({ [FILE_A]: mdAsset("u1"), [FILE_B]: mdAsset("u2") });
+    const gh = new FakeGitHubRepo({
+      [FILE_A]: mdAsset("u1"),
+      [FILE_B]: mdAsset("u2"),
+    });
+    const local = new FakeLocalFiles({
+      [FILE_A]: mdAsset("u1"),
+      [FILE_B]: mdAsset("u2"),
+    });
     const { engine } = makeEngine(gh, local);
     await bootstrap(engine, gh.spec());
 
-    gh.commitDirect("main", { [FILE_B]: mdAsset("u2", "remote v2") }, "device B");
+    gh.commitDirect(
+      "main",
+      { [FILE_B]: mdAsset("u2", "remote v2") },
+      "device B",
+    );
     local.files.set(FILE_A, mdAsset("u1", "local v2"));
     const result = await engine.sync(gh.spec());
 
@@ -217,7 +339,11 @@ describe("SyncEngine — conflicts (A2/A3 deferral, never overwrite)", () => {
     await bootstrap(engine, gh.spec());
     const wmBefore = watermarks.records.get(gh.spec().repoKey)!.lastSyncedSha;
 
-    gh.commitDirect("main", { [FILE_A]: mdAsset("u1", "remote edit") }, "device B");
+    gh.commitDirect(
+      "main",
+      { [FILE_A]: mdAsset("u1", "remote edit") },
+      "device B",
+    );
     local.files.set(FILE_A, mdAsset("u1", "local edit"));
     const result = await engine.sync(gh.spec());
 
@@ -225,16 +351,28 @@ describe("SyncEngine — conflicts (A2/A3 deferral, never overwrite)", () => {
     expect(result.detail).toMatch(/u1/);
     expect(gh.headFiles().get(FILE_A)).toBe(mdAsset("u1", "remote edit")); // remote untouched
     expect(local.files.get(FILE_A)).toBe(mdAsset("u1", "local edit")); // disk untouched
-    expect(watermarks.records.get(gh.spec().repoKey)!.lastSyncedSha).toBe(wmBefore); // watermark frozen
+    expect(watermarks.records.get(gh.spec().repoKey)!.lastSyncedSha).toBe(
+      wmBefore,
+    ); // watermark frozen
   });
 
   it("local delete vs remote modify → conflict", async () => {
-    const gh = new FakeGitHubRepo({ [FILE_A]: mdAsset("u1"), [FILE_B]: mdAsset("u2") });
-    const local = new FakeLocalFiles({ [FILE_A]: mdAsset("u1"), [FILE_B]: mdAsset("u2") });
+    const gh = new FakeGitHubRepo({
+      [FILE_A]: mdAsset("u1"),
+      [FILE_B]: mdAsset("u2"),
+    });
+    const local = new FakeLocalFiles({
+      [FILE_A]: mdAsset("u1"),
+      [FILE_B]: mdAsset("u2"),
+    });
     const { engine } = makeEngine(gh, local);
     await bootstrap(engine, gh.spec());
 
-    gh.commitDirect("main", { [FILE_B]: mdAsset("u2", "remote edit") }, "device B");
+    gh.commitDirect(
+      "main",
+      { [FILE_B]: mdAsset("u2", "remote edit") },
+      "device B",
+    );
     local.files.delete(FILE_B);
     const result = await engine.sync(gh.spec());
 
@@ -256,14 +394,22 @@ describe("SyncEngine — conflicts (A2/A3 deferral, never overwrite)", () => {
     expect(result.status).toBe("synced");
     expect(result.pushedCount).toBe(0);
     expect(result.pushedSha).toBeUndefined();
-    expect(watermarks.records.get(gh.spec().repoKey)!.lastSyncedSha).toBe(gh.headSha());
+    expect(watermarks.records.get(gh.spec().repoKey)!.lastSyncedSha).toBe(
+      gh.headSha(),
+    );
   });
 });
 
 describe("SyncEngine — deletes & renames propagate (#3476; full coverage in SyncEngine.delete-propagation.test.ts)", () => {
   it("local delete is pushed; nothing deferred, remote drops the file", async () => {
-    const gh = new FakeGitHubRepo({ [FILE_A]: mdAsset("u1"), [FILE_B]: mdAsset("u2") });
-    const local = new FakeLocalFiles({ [FILE_A]: mdAsset("u1"), [FILE_B]: mdAsset("u2") });
+    const gh = new FakeGitHubRepo({
+      [FILE_A]: mdAsset("u1"),
+      [FILE_B]: mdAsset("u2"),
+    });
+    const local = new FakeLocalFiles({
+      [FILE_A]: mdAsset("u1"),
+      [FILE_B]: mdAsset("u2"),
+    });
     const { engine } = makeEngine(gh, local);
     await bootstrap(engine, gh.spec());
 
@@ -306,20 +452,30 @@ describe("SyncEngine — D16 non-fast-forward retry loop", () => {
     ).toBe(true);
     expect(
       isNonFastForwardError(
-        new Error("GitHub createCommit: ref update mismatch (expected a, got b)"),
+        new Error(
+          "GitHub createCommit: ref update mismatch (expected a, got b)",
+        ),
       ),
     ).toBe(true);
     expect(
       isNonFastForwardError(
-        new Error("GitHub request POST https://api.github.com/repos/o/r/git/trees → HTTP 422: bad tree"),
+        new Error(
+          "GitHub request POST https://api.github.com/repos/o/r/git/trees → HTTP 422: bad tree",
+        ),
       ),
     ).toBe(false);
     expect(isNonFastForwardError(new Error("network down"))).toBe(false);
   });
 
   it("recovers from a concurrent push racing the PATCH (re-pull → retry)", async () => {
-    const gh = new FakeGitHubRepo({ [FILE_A]: mdAsset("u1"), [FILE_B]: mdAsset("u2") });
-    const local = new FakeLocalFiles({ [FILE_A]: mdAsset("u1"), [FILE_B]: mdAsset("u2") });
+    const gh = new FakeGitHubRepo({
+      [FILE_A]: mdAsset("u1"),
+      [FILE_B]: mdAsset("u2"),
+    });
+    const local = new FakeLocalFiles({
+      [FILE_A]: mdAsset("u1"),
+      [FILE_B]: mdAsset("u2"),
+    });
     const { engine } = makeEngine(gh, local);
     await bootstrap(engine, gh.spec());
 
@@ -329,14 +485,20 @@ describe("SyncEngine — D16 non-fast-forward retry loop", () => {
     gh.onBeforePatch = (): void => {
       if (!injected) {
         injected = true;
-        gh.commitDirect("main", { [FILE_B]: mdAsset("u2", "raced in") }, "device B race");
+        gh.commitDirect(
+          "main",
+          { [FILE_B]: mdAsset("u2", "raced in") },
+          "device B race",
+        );
       }
     };
     local.files.set(FILE_A, mdAsset("u1", "local edit"));
     const result = await engine.sync(gh.spec());
 
     expect(result.status).toBe("synced");
-    expect(result.warnings.join(" ")).toMatch(/non-fast-forward push \(attempt 1\/3\)/);
+    expect(result.warnings.join(" ")).toMatch(
+      /non-fast-forward push \(attempt 1\/3\)/,
+    );
     expect(gh.headFiles().get(FILE_A)).toBe(mdAsset("u1", "local edit"));
     expect(gh.headFiles().get(FILE_B)).toBe(mdAsset("u2", "raced in"));
     expect(local.files.get(FILE_B)).toBe(mdAsset("u2", "raced in")); // pulled on retry
@@ -351,7 +513,11 @@ describe("SyncEngine — D16 non-fast-forward retry loop", () => {
     let counter = 0;
     gh.onBeforePatch = (): void => {
       counter++;
-      gh.commitDirect("main", { [`assets/race-${counter}.md`]: mdAsset(`race-${counter}`) }, "race");
+      gh.commitDirect(
+        "main",
+        { [`assets/race-${counter}.md`]: mdAsset(`race-${counter}`) },
+        "race",
+      );
     };
     local.files.set(FILE_A, mdAsset("u1", "local edit"));
     const result = await engine.sync(gh.spec());
@@ -362,8 +528,14 @@ describe("SyncEngine — D16 non-fast-forward retry loop", () => {
   });
 
   it("race on a NON-pushed path: watermark is not advanced and the next sync does NOT revert the concurrent change", async () => {
-    const gh = new FakeGitHubRepo({ [FILE_A]: mdAsset("u1"), [FILE_B]: mdAsset("u2") });
-    const local = new FakeLocalFiles({ [FILE_A]: mdAsset("u1"), [FILE_B]: mdAsset("u2") });
+    const gh = new FakeGitHubRepo({
+      [FILE_A]: mdAsset("u1"),
+      [FILE_B]: mdAsset("u2"),
+    });
+    const local = new FakeLocalFiles({
+      [FILE_A]: mdAsset("u1"),
+      [FILE_B]: mdAsset("u2"),
+    });
     const { engine, watermarks } = makeEngine(gh, local);
     await bootstrap(engine, gh.spec());
     const baseSha = watermarks.records.get(gh.spec().repoKey)!.lastSyncedSha;
@@ -386,7 +558,9 @@ describe("SyncEngine — D16 non-fast-forward retry loop", () => {
 
     expect(first.status).toBe("synced");
     expect(first.warnings.join(" ")).toMatch(/watermark NOT advanced/);
-    expect(watermarks.records.get(gh.spec().repoKey)!.lastSyncedSha).toBe(baseSha);
+    expect(watermarks.records.get(gh.spec().repoKey)!.lastSyncedSha).toBe(
+      baseSha,
+    );
 
     gh.onGetRef = undefined;
     const second = await engine.sync(gh.spec());
@@ -395,7 +569,9 @@ describe("SyncEngine — D16 non-fast-forward retry loop", () => {
     expect(second.pushedCount).toBe(0); // own pushed edit converges, nothing re-pushed
     expect(gh.headFiles().get(FILE_B)).toBe(concurrent); // concurrent change NOT reverted
     expect(local.files.get(FILE_B)).toBe(concurrent); // pulled to disk
-    expect(watermarks.records.get(gh.spec().repoKey)!.lastSyncedSha).toBe(gh.headSha());
+    expect(watermarks.records.get(gh.spec().repoKey)!.lastSyncedSha).toBe(
+      gh.headSha(),
+    );
   });
 
   it("warns on the residual race window (concurrent commit between conflict check and the primitive's GET-ref)", async () => {
@@ -412,7 +588,11 @@ describe("SyncEngine — D16 non-fast-forward retry loop", () => {
     gh.onGetRef = (): void => {
       refCalls++;
       if (refCalls === 2) {
-        gh.commitDirect("main", { [FILE_A]: mdAsset("u1", "raced overwrite") }, "race");
+        gh.commitDirect(
+          "main",
+          { [FILE_A]: mdAsset("u1", "raced overwrite") },
+          "race",
+        );
       }
     };
     const result = await engine.sync(gh.spec());
@@ -474,7 +654,9 @@ describe("SyncEngine — error paths (D12 warn-not-block)", () => {
     const engine = new SyncEngine({
       transport: async (req) => {
         if (req.url.includes("broken-owner")) {
-          throw new Error(`GitHub request ${req.method} ${req.url} → HTTP 500: boom`);
+          throw new Error(
+            `GitHub request ${req.method} ${req.url} → HTTP 500: boom`,
+          );
         }
         return ghOk.transport()(req);
       },
@@ -539,14 +721,21 @@ describe("SyncEngine — TOCTOU guard on pull-apply (A1 review MEDIUM)", () => {
       FILE_B,
       mdAsset("u2", "user edit mid-sync"),
     );
-    const gh = new FakeGitHubRepo({ [FILE_A]: mdAsset("u1"), [FILE_B]: mdAsset("u2") });
+    const gh = new FakeGitHubRepo({
+      [FILE_A]: mdAsset("u1"),
+      [FILE_B]: mdAsset("u2"),
+    });
     const { engine, watermarks } = makeEngine(gh, local);
     await bootstrap(engine, gh.spec());
     const oldEntry = watermarks.records
       .get(gh.spec().repoKey)!
       .files.find((f) => f.path === FILE_B)!;
 
-    gh.commitDirect("main", { [FILE_B]: mdAsset("u2", "remote edit") }, "device B");
+    gh.commitDirect(
+      "main",
+      { [FILE_B]: mdAsset("u2", "remote edit") },
+      "device B",
+    );
     local.armed = true;
     const result = await engine.sync(gh.spec());
 
@@ -576,7 +765,10 @@ describe("SyncEngine — TOCTOU guard on pull-apply (A1 review MEDIUM)", () => {
       FILE_B,
       mdAsset("u2", "user edit mid-sync"),
     );
-    const gh = new FakeGitHubRepo({ [FILE_A]: mdAsset("u1"), [FILE_B]: mdAsset("u2") });
+    const gh = new FakeGitHubRepo({
+      [FILE_A]: mdAsset("u1"),
+      [FILE_B]: mdAsset("u2"),
+    });
     const { engine, watermarks } = makeEngine(gh, local);
     await bootstrap(engine, gh.spec());
     const oldEntry = watermarks.records
@@ -720,9 +912,9 @@ describe("SyncEngine — A2 merge layer integration", () => {
     expect(gh.headFiles().get(FILE_A)).toBe(mdAsset("u1", "remote edit"));
     expect(local.files.get(FILE_A)).toBe(mdAsset("u1", "local edit"));
     // Watermark pinned → the same conflict re-derives on the next sync.
-    expect(
-      watermarks.records.get(gh.spec().repoKey)!.pinnedPaths,
-    ).toContain(FILE_A);
+    expect(watermarks.records.get(gh.spec().repoKey)!.pinnedPaths).toContain(
+      FILE_A,
+    );
     const second = await engine.sync(gh.spec());
     expect(second.quarantinedCount).toBe(1);
     expect(store.entries).toHaveLength(2);
@@ -743,7 +935,11 @@ describe("SyncEngine — A2 merge layer integration", () => {
     });
     await bootstrap(engine, gh.spec());
 
-    gh.commitDirect("main", { [FILE_A]: yamlAsset("Base", "remote-value") }, "B");
+    gh.commitDirect(
+      "main",
+      { [FILE_A]: yamlAsset("Base", "remote-value") },
+      "B",
+    );
     local.files.set(FILE_A, yamlAsset("Local"));
     const result = await engine.sync(gh.spec());
 
@@ -778,8 +974,14 @@ describe("SyncEngine — A3: convergent rename (A2 deferred MEDIUM)", () => {
   const RENAMED = "assets/renamed.md";
 
   it("identical rename a→b on both sides is consumed — no false delete-vs-modify quarantine", async () => {
-    const gh = new FakeGitHubRepo({ [FILE_A]: mdAsset("u1"), [FILE_B]: mdAsset("u2") });
-    const local = new FakeLocalFiles({ [FILE_A]: mdAsset("u1"), [FILE_B]: mdAsset("u2") });
+    const gh = new FakeGitHubRepo({
+      [FILE_A]: mdAsset("u1"),
+      [FILE_B]: mdAsset("u2"),
+    });
+    const local = new FakeLocalFiles({
+      [FILE_A]: mdAsset("u1"),
+      [FILE_B]: mdAsset("u2"),
+    });
     const store = new InMemoryQuarantineStore();
     const { engine } = makeEngine(gh, local, {
       mergeLayer: stubMergeLayer(() => ({
@@ -791,7 +993,9 @@ describe("SyncEngine — A3: convergent rename (A2 deferred MEDIUM)", () => {
     await bootstrap(engine, gh.spec());
 
     // Both devices ran the SAME rename (rename-to-uid / co-location case).
-    gh.commitDirect("main", { [RENAMED]: mdAsset("u1") }, "remote rename", [FILE_A]);
+    gh.commitDirect("main", { [RENAMED]: mdAsset("u1") }, "remote rename", [
+      FILE_A,
+    ]);
     local.files.delete(FILE_A);
     local.files.set(RENAMED, mdAsset("u1"));
     const result = await engine.sync(gh.spec());
@@ -805,8 +1009,14 @@ describe("SyncEngine — A3: convergent rename (A2 deferred MEDIUM)", () => {
   });
 
   it("GENUINE remote delete vs local rename still quarantines (never silently resurrects)", async () => {
-    const gh = new FakeGitHubRepo({ [FILE_A]: mdAsset("u1"), [FILE_B]: mdAsset("u2") });
-    const local = new FakeLocalFiles({ [FILE_A]: mdAsset("u1"), [FILE_B]: mdAsset("u2") });
+    const gh = new FakeGitHubRepo({
+      [FILE_A]: mdAsset("u1"),
+      [FILE_B]: mdAsset("u2"),
+    });
+    const local = new FakeLocalFiles({
+      [FILE_A]: mdAsset("u1"),
+      [FILE_B]: mdAsset("u2"),
+    });
     const store = new InMemoryQuarantineStore();
     const { engine } = makeEngine(gh, local, {
       mergeLayer: stubMergeLayer(() => ({
@@ -864,8 +1074,14 @@ describe("SyncEngine — A3: merged blob not re-fetched (A2 deferred LOW)", () =
 
 describe("SyncEngine — A3: D16 terminal-quarantine", () => {
   it("retry exhaustion routes contended files AND pending merge entries to quarantine", async () => {
-    const gh = new FakeGitHubRepo({ [FILE_A]: mdAsset("u1"), [FILE_B]: mdAsset("u2") });
-    const local = new FakeLocalFiles({ [FILE_A]: mdAsset("u1"), [FILE_B]: mdAsset("u2") });
+    const gh = new FakeGitHubRepo({
+      [FILE_A]: mdAsset("u1"),
+      [FILE_B]: mdAsset("u2"),
+    });
+    const local = new FakeLocalFiles({
+      [FILE_A]: mdAsset("u1"),
+      [FILE_B]: mdAsset("u2"),
+    });
     const store = new InMemoryQuarantineStore();
     const { engine } = makeEngine(gh, local, {
       maxPushRetries: 1,
@@ -887,7 +1103,11 @@ describe("SyncEngine — A3: D16 terminal-quarantine", () => {
     let n = 0;
     gh.onBeforePatch = (): void => {
       n++;
-      gh.commitDirect("main", { [`assets/race-${n}.md`]: mdAsset(`r${n}`) }, "race");
+      gh.commitDirect(
+        "main",
+        { [`assets/race-${n}.md`]: mdAsset(`r${n}`) },
+        "race",
+      );
     };
     const result = await engine.sync(gh.spec());
 
@@ -901,7 +1121,9 @@ describe("SyncEngine — A3: D16 terminal-quarantine", () => {
     });
     expect(byPath.get(FILE_B)).toMatchObject({
       uid: "u2",
-      reason: expect.stringMatching(/non-fast-forward push failed after 1 retr/),
+      reason: expect.stringMatching(
+        /non-fast-forward push failed after 1 retr/,
+      ),
       localContent: mdAsset("u2", "contended edit"),
       remoteContent: mdAsset("u2"), // best-effort current head version
     });
@@ -929,7 +1151,11 @@ describe("SyncEngine — A3: D16 terminal-quarantine", () => {
     let n = 0;
     gh.onBeforePatch = (): void => {
       n++;
-      gh.commitDirect("main", { [`assets/race-${n}.md`]: mdAsset(`r${n}`) }, "race");
+      gh.commitDirect(
+        "main",
+        { [`assets/race-${n}.md`]: mdAsset(`r${n}`) },
+        "race",
+      );
     };
     const result = await engine.sync(gh.spec());
 
@@ -1027,7 +1253,9 @@ describe("SyncEngine — A3: D11 one-operation guard, R8 auth, R5 secret-scan", 
     const gh = new FakeGitHubRepo({ [FILE_A]: mdAsset("u1") });
     const local = new FakeLocalFiles({ [FILE_A]: mdAsset("u1") });
     const transport: RestCommitTransport = async (req) => {
-      throw new Error(`GitHub request ${req.method} ${req.url} → HTTP 401: Bad credentials`);
+      throw new Error(
+        `GitHub request ${req.method} ${req.url} → HTTP 401: Bad credentials`,
+      );
     };
     const { engine } = makeEngine(gh, local, { transport });
 
@@ -1045,7 +1273,9 @@ describe("SyncEngine — A3: D11 one-operation guard, R8 auth, R5 secret-scan", 
     const transport: RestCommitTransport = async (req) => {
       if (failures > 0) {
         failures--;
-        throw new Error(`GitHub request ${req.method} ${req.url} → HTTP 403: API rate limit exceeded`);
+        throw new Error(
+          `GitHub request ${req.method} ${req.url} → HTTP 403: API rate limit exceeded`,
+        );
       }
       return inner(req);
     };
@@ -1105,9 +1335,18 @@ describe("SyncEngine — #3475 phantom/empty commits (detected content already i
   }
 
   it("does NOT create a commit when the detected content is already in HEAD; watermark converges", async () => {
-    const alreadyPushed = mdAsset("u1", "v2 — already pushed by the other device");
-    const gh = new FakeGitHubRepo({ [FILE_A]: alreadyPushed, [FILE_B]: mdAsset("u2") });
-    const local = new FakeLocalFiles({ [FILE_A]: alreadyPushed, [FILE_B]: mdAsset("u2") });
+    const alreadyPushed = mdAsset(
+      "u1",
+      "v2 — already pushed by the other device",
+    );
+    const gh = new FakeGitHubRepo({
+      [FILE_A]: alreadyPushed,
+      [FILE_B]: mdAsset("u2"),
+    });
+    const local = new FakeLocalFiles({
+      [FILE_A]: alreadyPushed,
+      [FILE_B]: mdAsset("u2"),
+    });
     const { engine, watermarks } = makeEngine(gh, local);
     await bootstrap(engine, gh.spec());
     await staleWatermarkEntry(
@@ -1126,7 +1365,9 @@ describe("SyncEngine — #3475 phantom/empty commits (detected content already i
     expect(result.pushedCount).toBe(0);
     expect(gh.headSha()).toBe(headBefore); // no commit landed
     expect(gh.commits.size).toBe(commitsBefore); // not even an unreferenced one
-    expect(result.warnings.join(" ")).toMatch(/already identical in remote HEAD/);
+    expect(result.warnings.join(" ")).toMatch(
+      /already identical in remote HEAD/,
+    );
 
     // Watermark converged: the stale entry now records the actual blob —
     // the phantom does NOT re-derive on the next sync.
@@ -1143,8 +1384,14 @@ describe("SyncEngine — #3475 phantom/empty commits (detected content already i
 
   it("pushes ONLY the real delta when one of two detected files is already in HEAD; counter is exact", async () => {
     const alreadyPushed = mdAsset("u1", "already in HEAD");
-    const gh = new FakeGitHubRepo({ [FILE_A]: alreadyPushed, [FILE_B]: mdAsset("u2") });
-    const local = new FakeLocalFiles({ [FILE_A]: alreadyPushed, [FILE_B]: mdAsset("u2") });
+    const gh = new FakeGitHubRepo({
+      [FILE_A]: alreadyPushed,
+      [FILE_B]: mdAsset("u2"),
+    });
+    const local = new FakeLocalFiles({
+      [FILE_A]: alreadyPushed,
+      [FILE_B]: mdAsset("u2"),
+    });
     const { engine, watermarks } = makeEngine(gh, local);
     await bootstrap(engine, gh.spec());
     await staleWatermarkEntry(


### PR DESCRIPTION
## Summary

Fixes #3565 — an **ALPHA-blocker** for the core write-back flow.

A freshly-applied **asset-mode** AssetSpace with any local divergence from its remote `HEAD` — even a purely **additive** one (N new files, zero edits/deletes) — deadlocked: every ExoSync direction (`Sync`/`Pull`/`Push`) returned `full-conflict — first-sync`, pushed nothing, and **never established a watermark**, so re-running reproduced the conflict indefinitely. The canonical onboarding (**Apply profile → Create Area → Sync**) could not push the tester's first creation.

## Root cause (source-traced)

- `SyncEngine.bootstrapWatermark` (asset-mode first-sync) gated on `local == remote` **exactly**: a file-count check (`headTree.length !== disk.size`) + per-path content equality. Any divergence → `full-conflict`, with **no synthetic-base fallback**.
- File-mode already had the additive-tolerant synthetic base (`buildFileModeFirstSyncBase`); asset-mode took `bootstrapWatermark` instead (`if (!mode.fileMode) …`).

## Fix

`bootstrapWatermark` now classifies the first-sync into three outcomes:

1. **Clean mount** (local tree identical to remote) → seed watermark + no-op (unchanged cheap fast path).
2. **Purely additive** (`R ⊆ L` — every remote-head file present on disk byte-identical, plus local-only extras) → return a synthetic base = the remote head tree. The normal cycle derives the local-only files as **pushable adds** (a clean fast-forward — no remote changes to reconcile).
3. **Genuine divergence** (a remote-head file absent locally, OR a same-path content difference) → still `full-conflict`, routed to the merge/quarantine layer (A2/A3, D22).

**M1 zero-loss is intact** — `full-conflict` is reserved for real overlapping edits/deletes; only the clean local-only-superset case auto-pushes (it has nothing to reconcile). The count-check that blocked the additive case is removed; `R ⊆ L` is verified by the existing content loop.

## Tests (revert-verified)

5 production-shape tests added (real git-blob-SHA `FakeGitHubRepo`):
- additive superset → pushes local-only adds, watermark established, re-sync no-ops (deadlock gone);
- multiple local-only adds;
- remote-file-absent-locally → stays `full-conflict` (no watermark);
- addition + same-path edit → stays `full-conflict` (add NOT pushed — zero-loss boundary).

**Empirically revert-verified** (`integration-test-revert-verify`): the 2 additive tests **FAIL** against `origin/main` (reproduce the deadlock) and **PASS** with the fix; the 2 zero-loss-boundary tests guard the reserved-conflict path. Full sync suite: **280/280 green**. Repo typecheck + prettier clean.

## Both-platform

Engine-level (`SyncEngine.bootstrapWatermark`) — the single first-sync path shared by **desktop** (plugin + CLI) and **mobile** (plugin). The plugin's `SyncDepsFactory` builds one `SyncEngine` over `GitHubRestClient.restTransport()` (Obsidian `requestUrl`, identical on both platforms); no platform-branched first-sync exists to diverge. The `FakeGitHubRepo` test transport mirrors that REST contract.

Closes #3565