### PR TITLE
fix(#3562): conditional inheritance rules apply pre-reload via UID-canon match

### DIFF
--- a/packages/exocortex/src/domain/models/CommandDefinition.ts
+++ b/packages/exocortex/src/domain/models/CommandDefinition.ts
@@ -273,8 +273,28 @@ export interface InheritanceRuleResolved {
   readonly targetPropertyName: string;
   /** Resolved `exo__Asset_label` of the class condition; absent = unconditional. */
   readonly targetClassCondition?: string;
+  /**
+   * UID-canon form of the class condition — the `exo__Asset_uid` that the
+   * `exocmd__InheritanceRule_targetClassCondition` wikilink points to, when it
+   * is authored as a UUID ref (the production UID-canon shape).
+   *
+   * Issue #3562: carried alongside the label so the executor can match the
+   * condition against a UID-canon target class **UID↔UID directly**, with no
+   * dependency on the label→UID resolver (Obsidian `metadataCache` in the
+   * plugin, fs scan in the CLI). That resolver lags right after
+   * `Apply profile` materialises the class TBox, which silently skipped
+   * conditional inheritance rules until the next reload. Absent for legacy
+   * label-form conditions (then matching falls back to the label + resolver).
+   */
+  readonly targetClassConditionUid?: string;
   /** Resolved labels of excluded classes; empty = no exclusion. */
   readonly targetClassExclusion: readonly string[];
+  /**
+   * UID-canon forms of excluded classes (Issue #3562 — same rationale as
+   * {@link targetClassConditionUid}). Treated as an independent set of UID-form
+   * exclusion refs, NOT a positional parallel to {@link targetClassExclusion}.
+   */
+  readonly targetClassExclusionUids?: readonly string[];
   /** Priority for ordering when Phase 3b engine applies multiple rules. */
   readonly priority: number;
 }

--- a/packages/exocortex/src/services/CommandResolver.ts
+++ b/packages/exocortex/src/services/CommandResolver.ts
@@ -2134,7 +2134,13 @@ export class CommandResolver {
           refSubject,
           Namespace.EXOCMD.term("InheritanceRule_targetClassCondition"),
         );
-        if (!refName) {
+        // A nameless/blank ref (no parseable name — e.g. an empty- or
+        // whitespace-only literal object) genuinely cannot anchor the
+        // condition; retaining it would make the rule unconditional (scope
+        // broadening), so skip the entire rule (PR #3224 safety). `.trim()`
+        // hardens against `unwrapWikilink` ever surfacing a whitespace-only
+        // name (today it already trims to "").
+        if (!refName || !refName.trim()) {
           this.logger.warn(
             `Grounding ${groundingUid}: InheritanceRule has exocmd__InheritanceRule_targetClassCondition triple but ref is unresolvable — entire rule skipped (would otherwise apply unconditionally, broadening scope).`,
           );

--- a/packages/exocortex/src/services/CommandResolver.ts
+++ b/packages/exocortex/src/services/CommandResolver.ts
@@ -2119,18 +2119,35 @@ export class CommandResolver {
         undefined,
       );
       let targetClassCondition: string | undefined = undefined;
+      let targetClassConditionUid: string | undefined = undefined;
       if (conditionTriples.length > 0) {
-        const resolved = await this.resolveLabelRef(
+        // Issue #3562: extract the condition ref directly (UID-canon when the
+        // wikilink points to a UUID-named class TBox). Previously this resolved
+        // straight to a label via `resolveLabelRef` and skipped the ENTIRE rule
+        // when label resolution failed — which happens right after
+        // `Apply profile` materialises the class TBox before the triple store
+        // / metadataCache have indexed it, masking the #3555 fix. We now keep
+        // the UID so the executor can match it UID↔UID without the lagging
+        // resolver; the label is resolved best-effort (for legacy label-form
+        // targets) and its failure no longer drops the rule.
+        const refName = await this.getObsidianName(
           refSubject,
           Namespace.EXOCMD.term("InheritanceRule_targetClassCondition"),
         );
-        if (!resolved) {
+        if (!refName) {
           this.logger.warn(
             `Grounding ${groundingUid}: InheritanceRule has exocmd__InheritanceRule_targetClassCondition triple but ref is unresolvable — entire rule skipped (would otherwise apply unconditionally, broadening scope).`,
           );
           continue;
         }
-        targetClassCondition = resolved;
+        if (this.looksLikeUUID(refName)) {
+          targetClassConditionUid = refName;
+          targetClassCondition =
+            (await this.resolveLabelByUID(refName)) ?? undefined;
+        } else {
+          // Legacy label-form condition (e.g. `[[ems__Area]]` / `ems__Area`).
+          targetClassCondition = refName;
+        }
       }
 
       const exclusionTriples = await this.tripleStore.match(
@@ -2139,6 +2156,7 @@ export class CommandResolver {
         undefined,
       );
       const targetClassExclusion: string[] = [];
+      const targetClassExclusionUids: string[] = [];
       let exclusionBroken = false;
       for (const triple of exclusionTriples) {
         let name: string | null = null;
@@ -2152,14 +2170,17 @@ export class CommandResolver {
           exclusionBroken = true;
           continue;
         }
-        const resolved = this.looksLikeUUID(name)
-          ? await this.resolveLabelByUID(name)
-          : name;
-        if (!resolved) {
-          exclusionBroken = true;
-          continue;
+        // Issue #3562: same UID-canon treatment as the condition. A UUID-form
+        // exclusion is enforced via its UID even when the label can't be
+        // resolved (post-apply lag) — dropping it would broaden the rule's
+        // scope, so keeping the UID-only exclusion is the safe direction.
+        if (this.looksLikeUUID(name)) {
+          targetClassExclusionUids.push(name);
+          const label = await this.resolveLabelByUID(name);
+          if (label) targetClassExclusion.push(label);
+        } else {
+          targetClassExclusion.push(name);
         }
-        targetClassExclusion.push(resolved);
       }
       if (exclusionBroken) {
         this.logger.warn(
@@ -2184,7 +2205,9 @@ export class CommandResolver {
         sourcePropertyName,
         targetPropertyName,
         targetClassCondition,
+        targetClassConditionUid,
         targetClassExclusion,
+        targetClassExclusionUids,
         priority,
       });
     }

--- a/packages/exocortex/src/services/GroundingExecutor.ts
+++ b/packages/exocortex/src/services/GroundingExecutor.ts
@@ -1273,11 +1273,13 @@ export class GroundingExecutor {
     for (const rule of inheritanceRule) {
       const conditionOk = await this.inheritanceConditionMatches(
         rule.targetClassCondition,
+        rule.targetClassConditionUid,
         targetClassNames,
       );
       if (!conditionOk) continue;
       const excluded = await this.inheritanceExclusionMatches(
         rule.targetClassExclusion,
+        rule.targetClassExclusionUids,
         targetClassNames,
       );
       if (excluded) continue;
@@ -1300,43 +1302,79 @@ export class GroundingExecutor {
 
   /**
    * Check if a class condition matches any of the target's classes. Absent
-   * condition = unconditional rule (always matches).
-   *
-   * Matching is dual-form: direct symbolic equality (target authored with
-   * `[[ems__Area]]` style) OR via the injected ClassLabelToUidResolver
-   * (target authored with UID-canon `[[82c74542-...]]`). Resolver absence /
-   * failure falls back to direct-only — backward-compatible with test/CLI
-   * harnesses that don't wire the Obsidian metadata-cache adapter.
+   * condition (no label AND no UID) = unconditional rule (always matches).
    */
   private async inheritanceConditionMatches(
-    condition: string | undefined,
+    conditionLabel: string | undefined,
+    conditionUid: string | undefined,
     targetClassNames: string[],
   ): Promise<boolean> {
-    if (!condition) return true;
-    return this.classMatchesAny(condition, targetClassNames);
+    if (!conditionLabel && !conditionUid) return true;
+    return this.classRefMatchesAny(conditionLabel, conditionUid, targetClassNames);
   }
 
+  /**
+   * A rule is excluded when ANY excluded class matches the target. The UID and
+   * label exclusion sets are checked independently (Issue #3562 — they are not
+   * a positional parallel; either set alone is sufficient to exclude).
+   */
   private async inheritanceExclusionMatches(
-    exclusions: readonly string[],
+    exclusionLabels: readonly string[],
+    exclusionUids: readonly string[] | undefined,
     targetClassNames: string[],
   ): Promise<boolean> {
-    for (const ex of exclusions) {
-      if (await this.classMatchesAny(ex, targetClassNames)) return true;
+    for (const uid of exclusionUids ?? []) {
+      if (uid && targetClassNames.includes(uid)) return true;
+    }
+    for (const label of exclusionLabels) {
+      if (await this.classRefMatchesAny(label, undefined, targetClassNames)) {
+        return true;
+      }
     }
     return false;
   }
 
-  private async classMatchesAny(
-    label: string,
+  /**
+   * Match a class ref — carried as an optional UID-canon form and/or an
+   * optional label — against the target's class names.
+   *
+   * Issue #3562: the UID-canon direct check runs FIRST and needs no external
+   * resolver, so a UID-canon condition (`[[82c74542-...]]`) matches a UID-canon
+   * target class immediately — even right after `Apply profile`, before the
+   * Obsidian `metadataCache` (which backs `classLabelToUid`) has indexed the
+   * freshly-mounted class TBox. Previously the only bridge was the label→UID
+   * resolver, which lags post-apply and silently skipped conditional
+   * inheritance rules (orphaning child areas/tasks) until the next reload.
+   *
+   * The label-direct and resolver paths remain as fallbacks for legacy
+   * label-form data (target authored `[[ems__Area]]`, or a condition that has
+   * no UID-canon form). Resolver absence / failure degrades gracefully.
+   */
+  private async classRefMatchesAny(
+    label: string | undefined,
+    uid: string | undefined,
     targetClassNames: string[],
   ): Promise<boolean> {
-    if (targetClassNames.includes(label)) return true;
-    if (!this.classLabelToUid) return false;
-    try {
-      const uid = await this.classLabelToUid(label);
-      if (uid && uid.length > 0 && targetClassNames.includes(uid)) return true;
-    } catch {
-      // Resolver failures degrade gracefully — direct-only match still applied.
+    // 1. UID-canon direct match — resolver-free, fresh immediately post-apply.
+    if (uid && targetClassNames.includes(uid)) return true;
+    // 2. Label-direct match — target authored in legacy label form.
+    if (label && targetClassNames.includes(label)) return true;
+    // 3. Fallback: bridge label→UID via the injected resolver (Obsidian
+    //    metadataCache in the plugin / fs scan in the CLI). Lags right after
+    //    apply, hence steps 1-2 above.
+    if (label && this.classLabelToUid) {
+      try {
+        const resolvedUid = await this.classLabelToUid(label);
+        if (
+          resolvedUid &&
+          resolvedUid.length > 0 &&
+          targetClassNames.includes(resolvedUid)
+        ) {
+          return true;
+        }
+      } catch {
+        // Resolver failures degrade gracefully — direct matches still applied.
+      }
     }
     return false;
   }

--- a/packages/exocortex/tests/unit/services/CommandResolver.inheritanceRule.test.ts
+++ b/packages/exocortex/tests/unit/services/CommandResolver.inheritanceRule.test.ts
@@ -265,6 +265,10 @@ describe("CommandResolver — RFC v2 Phase 3a resolveInheritanceRules", () => {
     expect(cond!.sourcePropertyName).toBe("ems__Effort_area");
     expect(cond!.targetPropertyName).toBe("ems__Effort_areaInherited");
     expect(cond!.targetClassCondition).toBe("ems__Area");
+    // Issue #3562: the UID-canon form of the condition is carried alongside the
+    // label, so the executor can match UID↔UID without the (post-apply lagging)
+    // label→UID resolver.
+    expect(cond!.targetClassConditionUid).toBe(COND_CLASS_AREA);
     expect(cond!.targetClassExclusion).toEqual([]);
 
     const excl = byPriority.get(50);
@@ -326,24 +330,100 @@ describe("CommandResolver — RFC v2 Phase 3a resolveInheritanceRules", () => {
     expect(rule.targetClassExclusion).toEqual(
       expect.arrayContaining(["ems__Task", "ems__Project"]),
     );
+    // Issue #3562: UID-canon forms carried alongside the labels for resolver-
+    // free matching.
+    expect(rule.targetClassExclusionUids).toEqual(
+      expect.arrayContaining([EXCL_CLASS_TASK, EXCL_CLASS_PROJ]),
+    );
     expect(rule.priority).toBe(25);
   });
 
-  // HIGH fix (PR #3224 code-review, 2026-05-22): broken condition/exclusion
-  // refs must skip the ENTIRE rule, not silently expand scope.
-  it("skips entire rule when targetClassCondition triple exists but ref unresolvable", async () => {
-    const BROKEN_CLASS_UID = "ffffffff-ffff-4fff-8fff-ffffffffffff";
-    // Add InheritanceRule that references a class UID that has no asset (no Asset_label triple).
+  // Issue #3562: a UID-form condition whose LABEL is unresolvable is now
+  // RETAINED with its UID (not dropped). The original "drop on unresolvable"
+  // behaviour (PR #3224) conflated "broken ref" with "label not yet indexed" —
+  // and the latter happens routinely right after `Apply profile` materialises
+  // the class TBox, silently skipping the conditional rule until reload. The
+  // rule still carries a condition (the UID), so scope is NOT broadened: it
+  // matches ONLY assets of that UID class (none, if the class is genuinely
+  // broken; the real class once its label later resolves). Still NOT
+  // unconditional.
+  it("retains rule with UID-only condition when targetClassCondition label is unresolvable (Issue #3562)", async () => {
+    const STALE_CLASS_UID = "ffffffff-ffff-4fff-8fff-ffffffffffff";
+    // InheritanceRule references a class UID that has no Asset_label triple
+    // (mirrors a freshly-materialised class TBox not yet indexed post-apply).
     await addInheritanceRuleAsset(store, {
       uid: RULE_UID_COND,
       sourcePropertyRefUid: SRC_PROP_UID,
       targetPropertyRefUid: TGT_PROP_UID,
-      targetClassConditionRefUid: BROKEN_CLASS_UID, // exists in triple but never labelled
+      targetClassConditionRefUid: STALE_CLASS_UID,
       priority: 100,
     });
     await addGroundingWithInheritanceRules(store, {
       uid: GROUNDING_UID,
-      label: "Grounding with broken condition ref",
+      label: "Grounding with UID-only (label-unresolvable) condition",
+      ruleRefUids: [RULE_UID_COND],
+    });
+    await addCommandForGrounding(store, COMMAND_UID, GROUNDING_UID);
+
+    const cmd = await resolver.loadCommand(COMMAND_UID);
+
+    // Rule retained — NOT dropped.
+    expect(cmd!.grounding.inheritanceRule).toHaveLength(1);
+    const rule = cmd!.grounding.inheritanceRule![0];
+    // Condition preserved as the UID (resolver-free match path); label absent.
+    expect(rule.targetClassConditionUid).toBe(STALE_CLASS_UID);
+    expect(rule.targetClassCondition).toBeUndefined();
+    // No "entire rule skipped" warn — retention is the correct, safe outcome.
+    expect(
+      logger.warnings.some((w) => w.includes("entire rule skipped")),
+    ).toBe(false);
+  });
+
+  // Issue #3562: a genuinely BROKEN condition ref — one whose triple object
+  // yields no name at all (not merely an unresolvable label) — still skips the
+  // entire rule. `getObsidianName` returns null only when there is no parseable
+  // ref to anchor the condition on, so retaining it WOULD make the rule
+  // unconditional (scope broadening). Preserve the PR #3224 safety for that
+  // case.
+  it("skips entire rule when targetClassCondition ref yields no parseable name", async () => {
+    const ruleSubject = new IRI(`obsidian://vault/${RULE_UID_COND}.md`);
+    await store.addAll([
+      new Triple(
+        ruleSubject,
+        Namespace.RDF.term("type"),
+        Namespace.EXOCMD.term("InheritanceRule"),
+      ),
+      new Triple(
+        ruleSubject,
+        Namespace.EXO.term("Asset_uid"),
+        new Literal(RULE_UID_COND),
+      ),
+      new Triple(
+        ruleSubject,
+        Namespace.EXOCMD.term("InheritanceRule_sourceProperty"),
+        new IRI(`obsidian://vault/${SRC_PROP_UID}.md`),
+      ),
+      new Triple(
+        ruleSubject,
+        Namespace.EXOCMD.term("InheritanceRule_targetProperty"),
+        new IRI(`obsidian://vault/${TGT_PROP_UID}.md`),
+      ),
+      // Condition triple present but its object is a whitespace-only literal →
+      // unwraps to the empty string → getObsidianName yields no usable name.
+      new Triple(
+        ruleSubject,
+        Namespace.EXOCMD.term("InheritanceRule_targetClassCondition"),
+        new Literal(" "),
+      ),
+      new Triple(
+        ruleSubject,
+        Namespace.EXOCMD.term("InheritanceRule_priority"),
+        new Literal("100"),
+      ),
+    ]);
+    await addGroundingWithInheritanceRules(store, {
+      uid: GROUNDING_UID,
+      label: "Grounding with nameless condition ref",
       ruleRefUids: [RULE_UID_COND],
     });
     await addCommandForGrounding(store, COMMAND_UID, GROUNDING_UID);
@@ -352,7 +432,6 @@ describe("CommandResolver — RFC v2 Phase 3a resolveInheritanceRules", () => {
 
     // Entire rule dropped — would-be unconditional rule is not silently applied.
     expect(cmd!.grounding.inheritanceRule).toBeUndefined();
-    // Warn surfaces the scope-broadening risk.
     expect(
       logger.warnings.some((w) =>
         w.includes("targetClassCondition triple but ref is unresolvable") &&
@@ -361,31 +440,36 @@ describe("CommandResolver — RFC v2 Phase 3a resolveInheritanceRules", () => {
     ).toBe(true);
   });
 
-  it("skips entire rule when one targetClassExclusion entry is unresolvable (asymmetric scope expansion)", async () => {
-    const BROKEN_EXCL_UID = "ffffffff-ffff-4fff-8fff-fffffffffff0";
-    // Two exclusion refs — one valid, one broken (no asset_label triple).
+  it("retains rule with UID-only exclusion when one exclusion label is unresolvable (Issue #3562)", async () => {
+    const STALE_EXCL_UID = "ffffffff-ffff-4fff-8fff-fffffffffff0";
+    // Two exclusion refs — one labelled, one whose label isn't indexed yet.
     await addInheritanceRuleAsset(store, {
       uid: RULE_UID_EXCL,
       sourcePropertyRefUid: SRC_PROP_UID,
       targetPropertyRefUid: TGT_PROP_UID,
-      targetClassExclusionRefUids: [EXCL_CLASS_TASK, BROKEN_EXCL_UID],
+      targetClassExclusionRefUids: [EXCL_CLASS_TASK, STALE_EXCL_UID],
       priority: 50,
     });
     await addGroundingWithInheritanceRules(store, {
       uid: GROUNDING_UID,
-      label: "Grounding with broken exclusion entry",
+      label: "Grounding with UID-only (label-unresolvable) exclusion",
       ruleRefUids: [RULE_UID_EXCL],
     });
     await addCommandForGrounding(store, COMMAND_UID, GROUNDING_UID);
 
     const cmd = await resolver.loadCommand(COMMAND_UID);
 
-    expect(cmd!.grounding.inheritanceRule).toBeUndefined();
+    // Rule retained — exclusion enforced via UID, not silently dropped.
+    expect(cmd!.grounding.inheritanceRule).toHaveLength(1);
+    const rule = cmd!.grounding.inheritanceRule![0];
+    // Both excluded class UIDs present (UID-canon enforcement path).
+    expect(rule.targetClassExclusionUids).toEqual(
+      expect.arrayContaining([EXCL_CLASS_TASK, STALE_EXCL_UID]),
+    );
+    // Only the resolvable label appears in the label-form list.
+    expect(rule.targetClassExclusion).toEqual(["ems__Task"]);
     expect(
-      logger.warnings.some((w) =>
-        w.includes("targetClassExclusion entry") &&
-        w.includes("entire rule skipped"),
-      ),
-    ).toBe(true);
+      logger.warnings.some((w) => w.includes("entire rule skipped")),
+    ).toBe(false);
   });
 });

--- a/packages/exocortex/tests/unit/services/CommandResolver.inheritanceRule.test.ts
+++ b/packages/exocortex/tests/unit/services/CommandResolver.inheritanceRule.test.ts
@@ -380,11 +380,12 @@ describe("CommandResolver — RFC v2 Phase 3a resolveInheritanceRules", () => {
   });
 
   // Issue #3562: a genuinely BROKEN condition ref — one whose triple object
-  // yields no name at all (not merely an unresolvable label) — still skips the
-  // entire rule. `getObsidianName` returns null only when there is no parseable
-  // ref to anchor the condition on, so retaining it WOULD make the rule
-  // unconditional (scope broadening). Preserve the PR #3224 safety for that
-  // case.
+  // yields no usable name (here a whitespace-only literal, which
+  // `getObsidianName`→`unwrapWikilink` trims to the empty string; the
+  // `!refName || !refName.trim()` guard then fires) — still skips the entire
+  // rule. Retaining it WOULD make the rule unconditional (scope broadening),
+  // so the PR #3224 safety is preserved for the truly-nameless case (distinct
+  // from a UID-form ref whose label merely isn't indexed yet).
   it("skips entire rule when targetClassCondition ref yields no parseable name", async () => {
     const ruleSubject = new IRI(`obsidian://vault/${RULE_UID_COND}.md`);
     await store.addAll([

--- a/packages/exocortex/tests/unit/services/GroundingExecutor.test.ts
+++ b/packages/exocortex/tests/unit/services/GroundingExecutor.test.ts
@@ -3309,6 +3309,101 @@ describe("GroundingExecutor — RFC v2 Phase 3b 5-step pipeline", () => {
       expect(labelToUid).toHaveBeenCalledWith("ems__Area");
     });
 
+    // -- Issue #3562: UID-canon condition matches UID-canon target WITHOUT the
+    //    label→UID resolver. Reproduces the post-`Apply profile` staleness where
+    //    the resolver (Obsidian metadataCache) has not yet indexed the freshly
+    //    materialised class TBox and returns null — previously skipping the
+    //    conditional rule and orphaning the new child Area (masking the #3555
+    //    fix). The fix carries `targetClassConditionUid` so the match is UID↔UID
+    //    direct. Revert-verify: FAILS pre-fix (condition matched only via the
+    //    null-returning resolver → ems__Area_parent absent), PASSES post-fix.
+    it("Issue #3562: UID-canon condition matches UID-canon target even when the label→UID resolver returns null (post-apply stale cache)", async () => {
+      const AREA_UID = "82c74542-1b14-4217-b852-d84730484b25";
+      // Simulate the post-apply lagging resolver: the class TBox is on disk but
+      // not yet in the metadataCache, so label→UID resolution returns null.
+      const staleResolver = jest.fn().mockResolvedValue(null);
+      const executorStaleResolver = new GroundingExecutor(
+        reader,
+        writer,
+        registry,
+        staleResolver,
+      );
+      const grounding = makeGrounding({
+        type: GroundingType.CREATE_INSTANCE,
+        targetClass: "ems__Area",
+        targetFolder: "03 Knowledge/areas",
+        inheritanceRule: [
+          {
+            sourcePropertyName: "exo__Asset_uid",
+            targetPropertyName: "ems__Area_parent",
+            // Production shape: condition carries the UID-canon form (resolved
+            // from the `[[82c74542-…]]` wikilink by CommandResolver). Label is
+            // best-effort and irrelevant to the UID-direct match.
+            targetClassCondition: "ems__Area",
+            targetClassConditionUid: AREA_UID,
+            targetClassExclusion: [],
+            priority: 100,
+          },
+        ],
+      });
+      // Source area authored UID-canon: exo__Instance_class → [[82c74542-…]].
+      reader.readFile.mockResolvedValue(buildTargetFm([AREA_UID]));
+
+      const result = await executorStaleResolver.execute(
+        grounding,
+        TARGET_AREA_IRI,
+        TARGET_AREA_PATH,
+        { label: "Child area pre-reload" },
+      );
+
+      expect(result.success).toBe(true);
+      const [, content] = writer.createFile.mock.calls[0];
+      // The conditional rule applied: child area is NOT orphaned.
+      expect(content).toContain(`ems__Area_parent: "[[${TARGET_AREA_UID}]]"`);
+    });
+
+    // -- Issue #3562: UID-canon EXCLUSION enforced even when the label is
+    //    unresolvable (resolver null). The new instance is an Area, so a rule
+    //    excluding ems__Area must NOT apply. --
+    it("Issue #3562: UID-canon exclusion is enforced via UID when the resolver returns null", async () => {
+      const AREA_UID = "82c74542-1b14-4217-b852-d84730484b25";
+      const staleResolver = jest.fn().mockResolvedValue(null);
+      const executorStaleResolver = new GroundingExecutor(
+        reader,
+        writer,
+        registry,
+        staleResolver,
+      );
+      const grounding = makeGrounding({
+        type: GroundingType.CREATE_INSTANCE,
+        targetClass: "ems__Area",
+        targetFolder: "03 Knowledge/areas",
+        inheritanceRule: [
+          {
+            sourcePropertyName: "exo__Asset_uid",
+            targetPropertyName: "ems__Effort_parent",
+            // Excludes ems__Area (UID-canon). Target IS an Area → must skip.
+            targetClassExclusion: [],
+            targetClassExclusionUids: [AREA_UID],
+            priority: 50,
+          },
+        ],
+      });
+      reader.readFile.mockResolvedValue(buildTargetFm([AREA_UID]));
+
+      const result = await executorStaleResolver.execute(
+        grounding,
+        TARGET_AREA_IRI,
+        TARGET_AREA_PATH,
+        { label: "Area must be excluded" },
+      );
+
+      expect(result.success).toBe(true);
+      const [, content] = writer.createFile.mock.calls[0];
+      // Exclusion held: ems__Effort_parent must NOT be inherited onto an Area.
+      expect(content).not.toContain("ems__Effort_parent:");
+    });
+
     // -- End-to-end Grounding `a6ef8fda` semantics — golden scenario --
 
     it("End-to-end (Grounding a6ef8fda semantics): Area target → Task with Draft status + area + isDefinedBy", async () => {

--- a/packages/exocortex/tests/unit/services/GroundingExecutor.test.ts
+++ b/packages/exocortex/tests/unit/services/GroundingExecutor.test.ts
@@ -3364,7 +3364,10 @@ describe("GroundingExecutor — RFC v2 Phase 3b 5-step pipeline", () => {
 
     // -- Issue #3562: UID-canon EXCLUSION enforced even when the label is
     //    unresolvable (resolver null). The new instance is an Area, so a rule
-    //    excluding ems__Area must NOT apply. --
+    //    excluding ems__Area must NOT apply. Revert-verified: pre-fix
+    //    `inheritanceExclusionMatches` ignored the UID-only set (empty label
+    //    list → no exclusion) → ems__Effort_parent inherited onto the Area
+    //    (FAIL); post-fix the UID set is checked independently → excluded. --
     it("Issue #3562: UID-canon exclusion is enforced via UID when the resolver returns null", async () => {
       const AREA_UID = "82c74542-1b14-4217-b852-d84730484b25";
       const staleResolver = jest.fn().mockResolvedValue(null);


### PR DESCRIPTION
## Summary

Conditional grounding inheritance rules (those carrying `exocmd__InheritanceRule_targetClassCondition`) were **silently skipped** when a "Create …" grounding ran **immediately after `Apply profile`**, before an Obsidian reload — orphaning child Areas/Tasks (no `ems__Area_parent` / `ems__Effort_area`) and masking the #3555 fix. Unconditional rules still applied. After a reload it worked.

## Root cause (verified against source)

The condition match bridges the class condition — authored as a UID-canon wikilink `[[82c74542-…]]`, resolved to the **label** `ems__Area` in `CommandResolver.resolveInheritanceRulesForSubject` — against the source asset's UID-canon class (`["82c74542-…"]`) via a **label→UID resolver** (`createObsidianClassLabelResolver`, backed by Obsidian `metadataCache`). That cache lags right after apply's bulk git materialization of the class TBox, so the resolver returned `null` → condition `false` → rule skipped.

Two skip points share this root:
- **(a) resolution** — `resolveInheritanceRulesForSubject` dropped the rule outright when the condition label was unresolvable;
- **(b) execution** — `GroundingExecutor.classMatchesAny` failed when the metadataCache resolver returned `null`.

## Fix — match UID↔UID directly (resolver-free)

Both the condition (authored UID-wikilink) and the source class (UID-canon) are UIDs, so they should match in UID-space with **no resolver** — which is fresh immediately post-apply.

- **`CommandDefinition`** — carry `targetClassConditionUid` / `targetClassExclusionUids` (UID-canon forms) alongside the labels.
- **`CommandResolver`** — populate the UID forms; no longer drop a UID-form rule when its label can't be resolved (rule keeps its UID condition → still conditional, **scope not broadened**). A genuinely nameless ref still skips the rule (PR #3224 safety preserved).
- **`GroundingExecutor`** — condition/exclusion matching checks the UID-canon form first (no resolver), then the label, then the resolver as a legacy fallback.

Robust to **both** skip points and independent of metadataCache freshness.

## Tests (revert-verified: FAIL pre-fix / PASS post-fix)

- `GroundingExecutor`: UID-canon condition matches + UID-canon exclusion enforced when the label→UID resolver returns `null` (post-apply stale cache).
- `CommandResolver`: rule retained with UID-only condition/exclusion when the label is unresolvable; genuinely nameless ref still skipped.

Verified: 4/4 #3562 tests FAIL on `origin/main` logic, PASS with the fix. All CommandResolver unit suites (161) + dynamic-commands integration (31, submodules initialized) + GroundingExecutor suite green. Root + repo typecheck clean.

Closes #3562