### PR TITLE
test(#3555): bump exoas-exocmd pointer + recursive vault-fixture parity walk

### DIFF
--- a/packages/exocortex/tests/integration/dynamic-commands/grounding-type-vault-fixture-parity.test.ts
+++ b/packages/exocortex/tests/integration/dynamic-commands/grounding-type-vault-fixture-parity.test.ts
@@ -1,12 +1,13 @@
 /**
  * @file Vault-fixture parity test for RFC 9d20c91f Phase 2.
  *
- * Walks `packages/exoas-exocmd/` (the shared submodule clone) and finds
- * every asset whose `exo__Instance_class` points to the `exocmd__GroundingType`
- * class (UID `708604a5-a682-4ff6-9391-c2e80ab78ca5`). Asserts:
+ * Recursively walks `packages/exoas-exocmd/` (the shared submodule clone) and
+ * finds every asset whose `exo__Instance_class` points to the
+ * `exocmd__GroundingType` class (UID `708604a5-a682-4ff6-9391-c2e80ab78ca5`).
+ * Asserts:
  *
- * 1. Exactly 9 instances (matches `GroundingType` TS enum cardinality)
- * 2. The 9 vault UIDs are exactly the values in `GROUNDING_TYPE_UIDS`
+ * 1. Exactly 10 instances (matches `GroundingType` TS enum cardinality)
+ * 2. The 10 vault UIDs are exactly the values in `GROUNDING_TYPE_UIDS`
  * 3. Each vault asset's `exo__Asset_label` matches the expected naming
  *    convention X (e.g., `exocmd__GroundingTypePropertySet` for
  *    `GroundingType.PROPERTY_SET`)
@@ -14,6 +15,10 @@
  * If a vault asset is renamed, removed, or has its UID changed without
  * coordinated TS update, this test fails before any runtime regression
  * propagates to production.
+ *
+ * The walk is recursive so it is robust to the co-location invariant (CR-1):
+ * assets now live under per-namespace subfolders (e.g. `exoas-exocmd/exocmd/`)
+ * rather than flat at the submodule root.
  */
 
 import * as fs from "fs";
@@ -87,28 +92,36 @@ function scanGroundingTypeInstances(): VaultAsset[] {
     );
   }
   const instances: VaultAsset[] = [];
-  for (const entry of fs.readdirSync(SUBMODULE_PATH, { withFileTypes: true })) {
-    if (!entry.isFile() || !entry.name.endsWith(".md")) continue;
-    const fullPath = path.join(SUBMODULE_PATH, entry.name);
-    const content = fs.readFileSync(fullPath, "utf8");
-    const fm = parseFrontmatter(content);
-    const instanceClass = fm["exo__Instance_class"];
-    const refs: string[] = Array.isArray(instanceClass)
-      ? (instanceClass as string[])
-      : typeof instanceClass === "string"
-        ? [instanceClass]
-        : [];
-    const classUids = refs
-      .map(extractWikilinkUid)
-      .filter((uid): uid is string => uid !== null);
-    if (classUids.includes(GROUNDING_TYPE_CLASS_UID)) {
-      instances.push({
-        uid: (fm["exo__Asset_uid"] as string | undefined) ?? "",
-        label: (fm["exo__Asset_label"] as string | undefined) ?? "",
-        instanceClassRefs: refs,
-      });
+  const walk = (dir: string): void => {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      if (entry.name.startsWith(".")) continue;
+      const fullPath = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        walk(fullPath);
+        continue;
+      }
+      if (!entry.isFile() || !entry.name.endsWith(".md")) continue;
+      const content = fs.readFileSync(fullPath, "utf8");
+      const fm = parseFrontmatter(content);
+      const instanceClass = fm["exo__Instance_class"];
+      const refs: string[] = Array.isArray(instanceClass)
+        ? (instanceClass as string[])
+        : typeof instanceClass === "string"
+          ? [instanceClass]
+          : [];
+      const classUids = refs
+        .map(extractWikilinkUid)
+        .filter((uid): uid is string => uid !== null);
+      if (classUids.includes(GROUNDING_TYPE_CLASS_UID)) {
+        instances.push({
+          uid: (fm["exo__Asset_uid"] as string | undefined) ?? "",
+          label: (fm["exo__Asset_label"] as string | undefined) ?? "",
+          instanceClassRefs: refs,
+        });
+      }
     }
-  }
+  };
+  walk(SUBMODULE_PATH);
   return instances;
 }
 


### PR DESCRIPTION
## What

Coupled cross-repo-submodule-sync follow-up for **#3555** (already closed by the vault-side fix). Brings the exocortex `packages/exoas-exocmd` submodule pointer into sync with the vault clones and fixes the directory-walking parity test so it survives the CR-1 co-location reorg.

- **Submodule pointer**: `packages/exoas-exocmd` `ad75454` → `5f9c1fe` (linear forward; vault-2025 + vault-exodev already point at `5f9c1fe`). The bumped commit carries:
  1. The **#3555** fix — InheritanceRule `ba0ed3e9` (uid → `ems__Area_parent`) attached to Create-Area grounding `e72a5fa1`, so "Create child Area" links the new area into the hierarchy.
  2. The **CR-1 co-location reorg** — assets moved from flat submodule root into the per-namespace `exocmd/` subfolder.
- **Test fix**: `grounding-type-vault-fixture-parity.test.ts` did a non-recursive `readdirSync` at the submodule root. After the flat→subfolder reorg that root has 0 `.md` files → 0 GroundingType instances → red. Made the walk **recursive** (mirrors the `OracleVaultAdapter` walk in `cli-plugin-triple-parity`), so it is robust to per-namespace subfolders.

## Why coupled (not a bare pointer bump)

Per `cross-repo-submodule-sync` discipline, exocortex's `packages/exoas-exocmd` is a **fixture-coupled** consumer: bumping the pointer without the coupled code change goes red. The real coupling here was **not** a golden `expected.json` (none exists in the repo) — it was the directory-walking parity test's hardcoded flat-structure assumption.

## Verification

- **Revert-verify (parity test)**: FAILS **3/3** pre-fix (flat-root read finds 0 instances) → PASSES **3/3** post-fix (recursive walk finds the 10 GroundingType instances under `exocmd/`).
- `parity-gate` (`cli-plugin-triple-parity.integration.test.ts`): **5/5** green (synthetic vaults, unaffected).
- `dynamic-commands` + `GroundingTypeParity` + `create-instance-grounding` suites: **60/60** green.
- `npm run check:types`: clean.
- `exoas-exo` submodule **not** touched.

Addresses #3555 (closed; exocortex-side parity follow-up).