### PR TITLE
fix(#3571): no false-alarm 'apply recovery failed' toast on fresh install

### DIFF
--- a/packages/obsidian-plugin/src/infrastructure/adapters/ProfileApplyManager.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/ProfileApplyManager.ts
@@ -1462,6 +1462,30 @@ export class ProfileApplyManager {
     if (cacheLayer === undefined || localDataStore === undefined || vaultRootPath === undefined) {
       throw new Error("recoverIncompleteSwitch: apply dependencies not wired");
     }
+
+    // Nothing-to-recover guard (#3571). On a vault that has never run a profile
+    // switch there is no journal on disk AND no persisted `_switchInProgress`
+    // flag, so recovery has nothing to do. Return early — skipping the
+    // side-effect `recovery-completed` journal write below, which on a fresh
+    // vault (where `.exocortex/` does not exist yet) throws ENOENT because
+    // `vault.adapter.write` never creates parent dirs. That throw used to
+    // propagate to the caller's catch and surface a scary
+    // "[ExocortexPlugin] apply recovery failed" Notice on first launch. A REAL
+    // incomplete switch always left a journal (and/or set the in-progress
+    // flag), so this guard never suppresses a genuine recovery — or its
+    // failure toast.
+    const journalExists = await this.app.vault.adapter.exists(this.journalPath);
+    if (!journalExists && !localDataStore.isSwitchInProgress()) {
+      return { restored: [] };
+    }
+
+    // Defensive (mirrors the apply paths at ll. 477/908/1334): we are past the
+    // guard, so a real recovery is in flight. A genuine incomplete switch left
+    // the journal — `.exocortex/` exists — but if `_switchInProgress` was set
+    // in the crash window before the first journal write, ensure the dir so the
+    // `recovery-completed` write can't ENOENT and mask the real outcome.
+    await this.ensureExocortexDir();
+
     const events = await this.readJournalTail(200);
     const destroyedAsUids = new Set<string>();
     const materializedAsUids = new Set<string>();

--- a/packages/obsidian-plugin/src/infrastructure/adapters/ProfileApplyManager.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/ProfileApplyManager.ts
@@ -1474,7 +1474,17 @@ export class ProfileApplyManager {
     // incomplete switch always left a journal (and/or set the in-progress
     // flag), so this guard never suppresses a genuine recovery — or its
     // failure toast.
-    const journalExists = await this.app.vault.adapter.exists(this.journalPath);
+    // Defensive: a rejecting `exists` (Obsidian's spec resolves false for
+    // missing paths, but be safe) must NOT itself surface the toast we're
+    // removing. On a throw, assume the journal might exist and fall through to
+    // the dir-ensured recovery path below (idempotent, never ENOENTs). Mirrors
+    // the try/catch wrapping in readJournalTail/appendJournal/ensureExocortexDir.
+    let journalExists = true;
+    try {
+      journalExists = await this.app.vault.adapter.exists(this.journalPath);
+    } catch {
+      journalExists = true;
+    }
     if (!journalExists && !localDataStore.isSwitchInProgress()) {
       return { restored: [] };
     }

--- a/packages/obsidian-plugin/tests/unit/ProfileApplyManager.apply.test.ts
+++ b/packages/obsidian-plugin/tests/unit/ProfileApplyManager.apply.test.ts
@@ -1307,6 +1307,33 @@ describe("ProfileApplyManager.applyProfile", () => {
   });
 });
 
+/**
+ * Make a fake adapter production-shape for the fresh-vault case: real Obsidian
+ * `vault.adapter.write` does NOT create parent directories, so a write into a
+ * dir that doesn't exist throws ENOENT (see ProfileApplyManager.ensureExocortexDir
+ * docstring). The shared makeFakeApp `write` is lenient (it just sets the file
+ * regardless of the parent), which is why the original #3571 fresh-install
+ * recovery bug slipped past the existing tests. This wrapper enforces the strict
+ * contract so the recovery path is exercised faithfully (test-fixture-realism).
+ */
+function makeAdapterWriteStrict(app: App): void {
+  const adapter = app.vault.adapter as unknown as {
+    write: (p: string, d: string) => Promise<void>;
+    exists: (p: string) => Promise<boolean>;
+  };
+  const origWrite = adapter.write.bind(adapter);
+  adapter.write = async (p: string, d: string): Promise<void> => {
+    const slash = p.lastIndexOf("/");
+    if (slash > 0) {
+      const dir = p.slice(0, slash);
+      if (!(await adapter.exists(dir))) {
+        throw new Error(`ENOENT: no such file or directory, open '${p}'`);
+      }
+    }
+    return origWrite(p, d);
+  };
+}
+
 describe("ProfileApplyManager.recoverIncompleteSwitch", () => {
   it("restores destroyed-but-not-materialized AS from cache", async () => {
     const { mgr, cacheLayer, app } = setup({
@@ -1388,6 +1415,111 @@ describe("ProfileApplyManager.recoverIncompleteSwitch", () => {
     await app.vault.adapter.write(".exocortex/switch-journal.jsonl", "");
     await mgr.recoverIncompleteSwitch();
     expect(localDataStore.isSwitchInProgress()).toBe(false);
+  });
+
+  // === #3571 — fresh-install false-alarm toast guard ===
+
+  it("#3571 — fresh install (no journal, no in-progress flag): no-op, no ENOENT toast", async () => {
+    const { mgr, app, notifyMessages } = setup({
+      targetUid: "target",
+      sourceUid: null,
+      targetIncludes: [
+        TS_FLOOR_AS_UID_EXO,
+        TS_FLOOR_AS_UID_EXOCMD,
+        TS_FLOOR_AS_UID_SHARED_IDENTITIES,
+      ],
+      materialized: [
+        TS_FLOOR_AS_UID_EXO,
+        TS_FLOOR_AS_UID_EXOCMD,
+        TS_FLOOR_AS_UID_SHARED_IDENTITIES,
+      ],
+    });
+    // Production-shape: on a fresh vault `.exocortex/` does not exist and the
+    // real adapter.write throws ENOENT (it never creates parent dirs).
+    makeAdapterWriteStrict(app);
+
+    // Fresh install: no journal file, no `_switchInProgress` flag, no
+    // `.exocortex/` dir. Pre-fix the unconditional `recovery-completed` journal
+    // write hit ENOENT → threw → caller surfaced the scary Notice. Post-fix the
+    // guard returns early.
+    await expect(mgr.recoverIncompleteSwitch()).resolves.toEqual({
+      restored: [],
+    });
+    // No journal entry was written (true no-op).
+    expect(
+      await app.vault.adapter.exists(".exocortex/switch-journal.jsonl"),
+    ).toBe(false);
+    // No user-facing Notice.
+    expect(notifyMessages).toEqual([]);
+  });
+
+  it("#3571 — _switchInProgress set but no journal yet (crash window): recovers without ENOENT", async () => {
+    const { mgr, app, localDataStore } = setup({
+      targetUid: "target",
+      sourceUid: null,
+      targetIncludes: [
+        TS_FLOOR_AS_UID_EXO,
+        TS_FLOOR_AS_UID_EXOCMD,
+        TS_FLOOR_AS_UID_SHARED_IDENTITIES,
+      ],
+      materialized: [
+        TS_FLOOR_AS_UID_EXO,
+        TS_FLOOR_AS_UID_EXOCMD,
+        TS_FLOOR_AS_UID_SHARED_IDENTITIES,
+      ],
+    });
+    makeAdapterWriteStrict(app);
+    // Crash window: the in-progress flag was persisted before the first journal
+    // write, so the flag is set but no journal / `.exocortex/` dir exists. The
+    // guard must NOT early-return here (there is a real interrupted switch), and
+    // the defensive ensureExocortexDir() must prevent the recovery-completed
+    // write from ENOENT-ing.
+    await localDataStore.save({ activeProfileUid: "x", _switchInProgress: true });
+
+    await expect(mgr.recoverIncompleteSwitch()).resolves.toEqual({
+      restored: [],
+    });
+    // Stuck flag cleared.
+    expect(localDataStore.isSwitchInProgress()).toBe(false);
+  });
+
+  it("#3571 — real incomplete switch + genuine recovery failure: still throws (toast preserved)", async () => {
+    const { mgr, app, localDataStore } = setup({
+      targetUid: "target",
+      sourceUid: null,
+      targetIncludes: [
+        TS_FLOOR_AS_UID_EXO,
+        TS_FLOOR_AS_UID_EXOCMD,
+        TS_FLOOR_AS_UID_SHARED_IDENTITIES,
+      ],
+      materialized: [
+        TS_FLOOR_AS_UID_EXO,
+        TS_FLOOR_AS_UID_EXOCMD,
+        TS_FLOOR_AS_UID_SHARED_IDENTITIES,
+      ],
+    });
+    // Real incomplete switch: in-progress flag + journal with a destroyed-not-
+    // materialized AS (so the guard passes and recovery work runs).
+    await localDataStore.save({ activeProfileUid: "x", _switchInProgress: true });
+    await app.vault.adapter.write(
+      ".exocortex/switch-journal.jsonl",
+      JSON.stringify({
+        phase: "phase2-destroy-cached",
+        targetUid: "t",
+        as: "ems-uid",
+        ts: "2026-06-02T00:00:00Z",
+      }) + "\n",
+    );
+    // Genuine recovery failure: the flag-clear save rejects. The guard must NOT
+    // swallow this — the caller relies on the throw to surface the legitimate
+    // "apply recovery failed" Notice.
+    (localDataStore as unknown as { save: unknown }).save = async (): Promise<void> => {
+      throw new Error("simulated localDataStore failure during recovery");
+    };
+
+    await expect(mgr.recoverIncompleteSwitch()).rejects.toThrow(
+      "simulated localDataStore failure during recovery",
+    );
   });
 });
 


### PR DESCRIPTION
## Problem

On a **fresh install** (vault that has never run a profile switch), the plugin shows a scary Notice on first launch:

```
[ExocortexPlugin] apply recovery failed
```

Nothing needs recovering — it's a false alarm that hurts a first-time tester's impression (found during the T-Bank fresh-tester journey, Exocortex Alpha Launch, WBS node `ff3c58e3`).

## Root cause (verified on origin/main)

`runDeferredProfileRecovery` (`ExocortexPlugin.ts`) calls `ProfileApplyManager.recoverIncompleteSwitch()` unconditionally on `onLayoutReady` whenever apply deps are wired. `recoverIncompleteSwitch()` reads the journal tail (returns `[]` on a fresh vault — no throw), finds nothing to restore, then **unconditionally** writes a `recovery-completed` journal entry via `app.vault.adapter.write(".exocortex/switch-journal.jsonl", …)`.

Unlike the apply paths (ll. 477/908/1334), `recoverIncompleteSwitch()` never called `ensureExocortexDir()`. Obsidian's `vault.adapter.write` does not create parent dirs, so on a fresh vault where `.exocortex/` doesn't exist the write throws `ENOENT`. The throw propagates to the caller's `catch` → `logger.warn("[ExocortexPlugin] apply recovery failed", …)` → the Notice.

## Fix

- **Nothing-to-recover guard**: if no journal on disk **and** `localDataStore.isSwitchInProgress()` is false → return `{ restored: [] }` early (true no-op, no journal write). A real incomplete switch always left a journal and/or set the in-progress flag, so the guard never suppresses a genuine recovery.
- **Defensive `ensureExocortexDir()`** before the recovery journal writes, for the crash-window case where `_switchInProgress` was set before the first journal write.
- Real recovery failures still throw → the legitimate "apply recovery failed" toast is **preserved**.

## Tests (revert-verify: FAIL pre-fix / PASS post-fix)

`packages/obsidian-plugin/tests/unit/ProfileApplyManager.apply.test.ts`:

- **fresh install** (no journal, no flag) → no-op, no throw, no journal written, no Notice. *(FAILs pre-fix with ENOENT)*
- **crash window** (flag set, no journal) → recovers without ENOENT, clears the stuck flag. *(FAILs pre-fix with ENOENT)*
- **real incomplete switch + genuine recovery failure** → still throws (toast preserved). *(guardrail — passes both ways by design)*

Production-shape: the fake `adapter.write` is made **strict** (throws ENOENT on a missing parent dir, mirroring real Obsidian) — the lenient shared fake is exactly why the original bug slipped past existing tests (`test-fixture-realism`).

## Local verification

- `npm run check:types` ✓
- `npm run lint` ✓ (0 errors)
- `ProfileApplyManager.apply.test.ts` — 44/44 ✓ (revert-verify confirmed: 2 tests FAIL pre-fix with `ENOENT … '.exocortex/switch-journal.jsonl'`, PASS post-fix)
- `npm run build` ✓ (mobile-loadable + console-channel asserts pass)

No Docker/QEMU e2e run (post-reboot constraint). UI smoke deferred to orchestrator.

Closes #3571
