### PR TITLE
fix(#3561): suppress legacy exo__Asset_prototype fallback when an IR already links to the target

### DIFF
--- a/packages/exocortex/src/services/GroundingExecutor.ts
+++ b/packages/exocortex/src/services/GroundingExecutor.ts
@@ -1187,6 +1187,11 @@ export class GroundingExecutor {
     target: string,
   ): boolean {
     if (!target) return false;
+    // `target` is the fully-bracketed wikilink inner emitted by
+    // extractBacklinkTarget (a full UUID under UID-canon, or a whitelisted path
+    // form). Because the needle is fully bracketed, `[[A]]` is a substring of
+    // `[[B]]` only when A === B — substring match cannot alias one target onto
+    // another.
     const needle = `[[${target}]]`;
     const refs = (v: unknown): boolean =>
       typeof v === "string" && v.includes(needle);

--- a/packages/exocortex/src/services/GroundingExecutor.ts
+++ b/packages/exocortex/src/services/GroundingExecutor.ts
@@ -1151,10 +1151,50 @@ export class GroundingExecutor {
       targetIRI,
       targetFilePath,
     );
+    // Issue #3561: the legacy exo__Asset_prototype default is a degraded-mode
+    // safety net — it must fire ONLY when the new instance has no link back to
+    // its creation target at all. An InheritanceRule may already have linked it
+    // under a relationship key the two named checks above don't enumerate:
+    // ems__Effort_area (Task/Project created on an Area) or ems__Area_parent
+    // (child Area created on an Area). Maintaining a hard-coded key list is
+    // exactly what went stale and produced #3561 (area IRs fire correctly, the
+    // instance IS linked, yet the legacy default still wrote a spurious
+    // exo__Asset_prototype=[[area]] + a red "No backlink rule fired" error).
+    // Detect the link by VALUE instead: if any property already references the
+    // target, the asset is not orphaned, so the legacy default (and its noisy
+    // Bug #5 warning) must not fire. Future relationship keys are covered for
+    // free, eliminating the stale-list bug class.
+    if (GroundingExecutor.propertiesReferenceTarget(properties, backLinkTarget)) {
+      return;
+    }
     properties.exo__Asset_prototype = `"[[${backLinkTarget}]]"`;
     LoggingService.error(
       "[GroundingExecutor] No backlink rule fired (Universal IRs absent or no class match). Falling back to legacy exo__Asset_prototype default. Bug #5 may surface if target is not a prototype-instance.",
     );
+  }
+
+  /**
+   * Issue #3561 — true when any property value already references `target` in
+   * wikilink form (`[[<target>]]`), under ANY property name. Lets
+   * {@link applyMissingBacklinkTopUp} recognise that an InheritanceRule already
+   * linked the new instance to its creation target (ems__Effort_area /
+   * ems__Area_parent / ems__Effort_parent / exo__Asset_prototype, or any future
+   * relationship key) so the legacy prototype default is not written redundantly.
+   * Multi-valued (array) properties are scanned element-wise.
+   */
+  private static propertiesReferenceTarget(
+    properties: Record<string, unknown>,
+    target: string,
+  ): boolean {
+    if (!target) return false;
+    const needle = `[[${target}]]`;
+    const refs = (v: unknown): boolean =>
+      typeof v === "string" && v.includes(needle);
+    for (const value of Object.values(properties)) {
+      if (refs(value)) return true;
+      if (Array.isArray(value) && value.some(refs)) return true;
+    }
+    return false;
   }
 
   /**

--- a/packages/exocortex/tests/unit/services/GroundingExecutor.test.ts
+++ b/packages/exocortex/tests/unit/services/GroundingExecutor.test.ts
@@ -3849,4 +3849,148 @@ describe("GroundingExecutor — RFC v2 Phase 3b 5-step pipeline", () => {
       errorSpy.mockRestore();
     });
   });
+
+  // =========================================================================
+  // Issue #3561 — area-targeted creates must NOT emit the legacy
+  // exo__Asset_prototype fallback (+ red "No backlink rule fired" error) when an
+  // InheritanceRule already linked the new instance back to the target Area.
+  //
+  // Root cause: applyMissingBacklinkTopUp recognised ONLY exo__Asset_prototype
+  // and ems__Effort_parent as "backlink already written". Area creates link via
+  // ems__Effort_area (Task/Project-on-Area) or ems__Area_parent (Area-on-Area),
+  // which the named-key guard missed → a spurious exo__Asset_prototype=[[area]]
+  // + console error, even though the area relationship was set correctly.
+  // Fix detects the link by VALUE (any property already pointing at the target).
+  // =========================================================================
+  describe("Issue #3561 — area-targeted create backlink detection", () => {
+    // UID-canon fixture mirrors the real vault: the target Area's file is named
+    // <area-uid>.md and its exo__Asset_uid equals that uid, so the IR-copied
+    // value ("[[<area-uid>]]") and extractBacklinkTarget (<area-uid>) coincide.
+    const AREA_UID = "a1b2c3d4-1111-4222-8333-444455556666";
+    const AREA_FILE_PATH = `assetspaces/areas/${AREA_UID}.md`;
+    // UID-canon vaults store exo__Asset_uid BARE (verified against real
+    // ems__Area assets), so the InheritanceRule wraps it into a wikilink
+    // ("[[<uid>]]") via formatInheritedScalar — which is what makes the area
+    // relationship coincide with the back-link target.
+    const AREA_TARGET_FM = [
+      "---",
+      `exo__Asset_uid: ${AREA_UID}`,
+      'exo__Asset_label: "My Area"',
+      "exo__Instance_class:",
+      '  - "[[ems__Area]]"',
+      "---",
+      "Body",
+    ].join("\n");
+
+    function spyOnError() {
+      return jest
+        .spyOn(
+          require("../../../src/services/LoggingService").LoggingService,
+          "error",
+        )
+        .mockImplementation();
+    }
+
+    it("Task created on an Area: ems__Effort_area IR fires → NO exo__Asset_prototype, NO 'No backlink rule fired' error", async () => {
+      reader.readFile.mockResolvedValue(AREA_TARGET_FM);
+      const errorSpy = spyOnError();
+
+      const grounding = makeGrounding({
+        type: GroundingType.CREATE_INSTANCE,
+        targetClass: "ems__Task",
+        targetFolder: "01 Inbox",
+        inheritanceRule: [
+          {
+            sourcePropertyName: "exo__Asset_uid",
+            targetPropertyName: "ems__Effort_area",
+            targetClassCondition: "ems__Area",
+            targetClassExclusion: [],
+            priority: 100,
+          },
+        ],
+      });
+
+      const result = await executor.execute(
+        grounding,
+        TARGET_IRI,
+        AREA_FILE_PATH,
+        { label: "Task on Area" },
+      );
+
+      expect(result.success).toBe(true);
+      const [, content] = writer.createFile.mock.calls[0];
+      // Correct relationship is set ...
+      expect(content).toContain(`ems__Effort_area: "[[${AREA_UID}]]"`);
+      // ... and the spurious legacy fallback is gone.
+      expect(content).not.toContain("exo__Asset_prototype:");
+      const calls = errorSpy.mock.calls.flat().map(String);
+      expect(calls.some((s) => s.includes("No backlink rule fired"))).toBe(false);
+
+      errorSpy.mockRestore();
+    });
+
+    it("child Area created on an Area: ems__Area_parent IR fires → NO exo__Asset_prototype, NO error", async () => {
+      reader.readFile.mockResolvedValue(AREA_TARGET_FM);
+      const errorSpy = spyOnError();
+
+      const grounding = makeGrounding({
+        type: GroundingType.CREATE_INSTANCE,
+        targetClass: "ems__Area",
+        targetFolder: "01 Inbox",
+        inheritanceRule: [
+          {
+            sourcePropertyName: "exo__Asset_uid",
+            targetPropertyName: "ems__Area_parent",
+            targetClassCondition: "ems__Area",
+            targetClassExclusion: [],
+            priority: 100,
+          },
+        ],
+      });
+
+      const result = await executor.execute(
+        grounding,
+        TARGET_IRI,
+        AREA_FILE_PATH,
+        { label: "Sub-area" },
+      );
+
+      expect(result.success).toBe(true);
+      const [, content] = writer.createFile.mock.calls[0];
+      expect(content).toContain(`ems__Area_parent: "[[${AREA_UID}]]"`);
+      expect(content).not.toContain("exo__Asset_prototype:");
+      const calls = errorSpy.mock.calls.flat().map(String);
+      expect(calls.some((s) => s.includes("No backlink rule fired"))).toBe(false);
+
+      errorSpy.mockRestore();
+    });
+
+    it("regression: genuine degraded mode (no IR, nothing links to target) STILL writes legacy exo__Asset_prototype + error", async () => {
+      // No inheritanceRule → no backlink established → the degraded-mode safety
+      // net must remain intact (the asset would otherwise be orphaned).
+      reader.readFile.mockResolvedValue(AREA_TARGET_FM);
+      const errorSpy = spyOnError();
+
+      const grounding = makeGrounding({
+        type: GroundingType.CREATE_INSTANCE,
+        targetClass: "ems__Task",
+        targetFolder: "01 Inbox",
+      });
+
+      const result = await executor.execute(
+        grounding,
+        TARGET_IRI,
+        AREA_FILE_PATH,
+        { label: "Orphan" },
+      );
+
+      expect(result.success).toBe(true);
+      const [, content] = writer.createFile.mock.calls[0];
+      expect(content).toContain(`exo__Asset_prototype: "[[${AREA_UID}]]"`);
+      const calls = errorSpy.mock.calls.flat().map(String);
+      expect(calls.some((s) => s.includes("No backlink rule fired"))).toBe(true);
+
+      errorSpy.mockRestore();
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Area-targeted creates (Create Task / Project / Area **on an `ems__Area`**) logged a red console error and wrote a spurious `exo__Asset_prototype: [[area]]` on top of the correctly-set `ems__Effort_area` / `ems__Area_parent` relationship:

```
[Exocortex ERROR] [GroundingExecutor] No backlink rule fired (Universal IRs absent or no class match). Falling back to legacy exo__Asset_prototype default. Bug #5 may surface if target is not a prototype-instance.
```

## Root cause (verify-before-assert)

The issue hypothesised "the area backlink-rule does not match". **It actually matches fine** — the area InheritanceRule fires and sets `ems__Effort_area` / `ems__Area_parent` correctly (the issue itself confirms the relationship is set).

The real bug is in `GroundingExecutor.applyMissingBacklinkTopUp` — the degraded-mode legacy safety net. It recognised **only** `exo__Asset_prototype` and `ems__Effort_parent` as "backlink already written". Area creates link via:
- `ems__Effort_area` — Task/Project created **on an Area**
- `ems__Area_parent` — child Area created **on an Area**

Neither was in the hard-coded key list, so the legacy `exo__Asset_prototype` default fired **redundantly on top of** the already-correct relationship, and emitted the noisy Bug #5 error. Maintaining a hard-coded key list is exactly what went stale here.

**Not overtaken by #3562/#3569** (that fix addressed conditional-IR pre-reload UID-canon matching — a different mechanism; this redundant-fallback path was untouched).

## Fix

Detect the established link **by VALUE** rather than by a hard-coded key list: if any property already references the creation target (`[[<target>]]`), the new instance is not orphaned, so the legacy prototype default (and its noisy warning) must not fire. This covers `ems__Effort_area` / `ems__Area_parent` **and any future relationship key for free**, eliminating the stale-list bug class. The two named-key fast-path checks are kept for behavioural continuity (strict superset — never removes a suppression case).

In a UID-canon vault the area's `exo__Asset_uid` is stored bare, so the IR wraps it into `"[[<uid>]]"`, which coincides with `extractBacklinkTarget` (basename of the `<uid>.md` file) — verified against real `ems__Area` assets.

## Tests (revert-verify: FAILS pre-fix / PASSES post-fix)

New `Issue #3561` describe block in `GroundingExecutor.test.ts` with production-shape UID-canon fixtures:
1. **Task-on-Area** (`ems__Effort_area` IR) → NO `exo__Asset_prototype`, NO "No backlink rule fired" error.
2. **child-Area-on-Area** (`ems__Area_parent` IR) → NO `exo__Asset_prototype`, NO error.
3. **Regression guard** — genuine degraded mode (no IR, nothing links to target) **still** writes the legacy `exo__Asset_prototype` + error (safety net intact).

Empirically verified: tests 1+2 FAIL with the fix reverted and PASS with it restored.

- Full `GroundingExecutor.test.ts`: **153/153**
- Related grounding integration suites (`create-instance-grounding`, `asset-creation-flow`, `grounding-resolve-execute`, `grounding-phase3b-pipeline`): **41/41**
- typecheck clean, src lint clean, archgate 20/20.

Closes #3561

🤖 Generated with [Claude Code](https://claude.com/claude-code)