### PR TITLE
feat(assetspace): standalone unmount-assetspace command (plugin + CLI)

### DIFF
--- a/packages/cli/src/commands/assetspace-remove.ts
+++ b/packages/cli/src/commands/assetspace-remove.ts
@@ -1,7 +1,7 @@
 import { Command } from "commander";
 import { resolve, join } from "node:path";
 import { existsSync } from "node:fs";
-import { derivePath, isTsFloorAssetSpace } from "exocortex";
+import { derivePath, isTsFloorAssetSpace, isTsFloorMountPath } from "exocortex";
 import { BootstrapAssetSpaceService } from "../services/BootstrapAssetSpaceService.js";
 import {
   CliApplyProfileService,
@@ -129,15 +129,23 @@ export async function runAssetSpaceRemove(
   const folder = resolveRemoveAssetSpacePath(opts);
 
   // TS-floor guard (BEFORE any mutation). Match the target mount path against
-  // the AssetSpace descriptor scan to recover its uid + namespace.
+  // the AssetSpace descriptor scan to recover its uid + namespace, AND apply the
+  // path-based guard so a floor mounted flat / with an un-derivable descriptor
+  // (whose `folderName` join misses) is still refused.
   const infos =
     deps.scanInfos?.(vaultPath) ??
     new CliApplyProfileService({ vaultPath }).scanVault().infos;
   const match = infos.find((i) => i.folderName === folder);
-  if (match !== undefined && isTsFloorAssetSpace(match.uid, match.namespace)) {
+  const floorByDescriptor =
+    match !== undefined && isTsFloorAssetSpace(match.uid, match.namespace);
+  if (floorByDescriptor || isTsFloorMountPath(folder)) {
+    const ident = match?.label ?? folder;
+    const detail = match
+      ? `${match.namespace || match.uid}`
+      : "path resolves to a floor namespace";
     err(
-      `[assetspace-remove] Refused: «${match.label}» ` +
-        `(${match.namespace || match.uid}) is a TS-floor AssetSpace — ` +
+      `[assetspace-remove] Refused: «${ident}» ` +
+        `(${detail}) is a TS-floor AssetSpace — ` +
         `unmounting it would self-brick the runtime (R24). Aborted, no changes made.`,
     );
     return {

--- a/packages/cli/src/commands/assetspace-remove.ts
+++ b/packages/cli/src/commands/assetspace-remove.ts
@@ -1,0 +1,227 @@
+import { Command } from "commander";
+import { resolve, join } from "node:path";
+import { existsSync } from "node:fs";
+import { derivePath, isTsFloorAssetSpace } from "exocortex";
+import { BootstrapAssetSpaceService } from "../services/BootstrapAssetSpaceService.js";
+import {
+  CliApplyProfileService,
+  type AssetSpaceInfo,
+} from "../services/CliApplyProfileService.js";
+import { ErrorHandler } from "../utils/ErrorHandler.js";
+import { InvalidArgumentsError, VaultNotFoundError } from "../utils/errors/index.js";
+import { ExitCodes } from "../utils/ExitCodes.js";
+
+interface AssetSpaceRemoveOptions {
+  vault: string;
+  folder?: string;
+  url?: string;
+  json?: boolean;
+}
+
+/**
+ * Resolve the vault-relative mount path to unmount — the inverse of
+ * {@link resolveAddAssetSpacePath} (#e6b8827c).
+ *
+ * Two ways to name the target (at least one required):
+ *   - `--folder <path>` — an explicit vault-relative mount path. Accepts both a
+ *     full `assetspaces/<owner>/<repo>` (Maven) AND a bare segment (`pmbok`,
+ *     `kitelev/exoas-exo`); a value not already rooted at `assetspaces/` is
+ *     prefixed. Takes precedence over `--url`.
+ *   - `--url <url>` — derive the canonical Maven path `assetspaces/<owner>/<repo>`
+ *     via `derivePath` (the SAME deriver `assetspace-add` / `bootstrap` /
+ *     `apply-profile` use), so removing by URL targets exactly what adding by
+ *     URL mounted. Falls back to the flat `deriveFolderName` only when the URL
+ *     is un-derivable.
+ *
+ * @returns A vault-relative path rooted at `assetspaces/` (never absolute).
+ * @throws {InvalidArgumentsError} when neither `--folder` nor `--url` is given.
+ */
+export function resolveRemoveAssetSpacePath(
+  opts: { folder?: string; url?: string },
+): string {
+  if (opts.folder !== undefined && opts.folder.length > 0) {
+    return opts.folder.startsWith("assetspaces/")
+      ? opts.folder
+      : `assetspaces/${opts.folder}`;
+  }
+  if (opts.url !== undefined && opts.url.length > 0) {
+    return (
+      derivePath(opts.url) ??
+      `assetspaces/${BootstrapAssetSpaceService.deriveFolderName(opts.url)}`
+    );
+  }
+  throw new InvalidArgumentsError(
+    "either --folder or --url is required",
+    "exocortex assetspace-remove --vault <path> (--folder <mount-path> | --url <url>)",
+  );
+}
+
+/** Test seams + stdout/stderr capture for {@link runAssetSpaceRemove}. */
+export interface AssetSpaceRemoveDeps {
+  /**
+   * Override the AssetSpace descriptor scan (floor identity source). Production
+   * omits and the run scans the vault via {@link CliApplyProfileService.scanVault}.
+   */
+  scanInfos?: (vaultPath: string) => AssetSpaceInfo[];
+  /**
+   * Override the unmount mechanics (test seam). Production omits and the run
+   * calls {@link BootstrapAssetSpaceService.unmountAssetSpace}.
+   */
+  unmount?: (vaultPath: string, submodulePath: string) => void;
+  /** Override stdout sink (defaults to `process.stdout`). */
+  out?: (msg: string) => void;
+  /** Override stderr sink (defaults to `process.stderr`). */
+  err?: (msg: string) => void;
+}
+
+export interface AssetSpaceRemoveResult {
+  exitCode: number;
+  stdout: string[];
+  stderr: string[];
+  /** True when the unmount ran (was NOT refused by the TS-floor guard). */
+  removed: boolean;
+  /** Vault-relative mount path that was targeted. */
+  folder: string;
+}
+
+/**
+ * `exocortex assetspace-remove` — unmount a single AssetSpace (#e6b8827c). The
+ * inverse of `assetspace-add`: strips the `.gitmodules` stanza and deletes the
+ * mount folder via the already-shipped, path-safe
+ * {@link BootstrapAssetSpaceService.unmountAssetSpace}.
+ *
+ * ## TS-floor refuse (floor-policy A — «refuse, не rescue»)
+ *
+ * A TS-floor AssetSpace (`{exo}` per RFC 5aa2a73a / #3440 — matched by legacy
+ * UID OR `exo__AssetSpace_namespace` via {@link isTsFloorAssetSpace}) is REFUSED
+ * with a clear message + non-zero exit, BEFORE any mutation — exactly as
+ * `apply-profile`'s R24 guard refuses a profile that would strip the floor.
+ * Tearing the floor down would brick the runtime (no class defs). The floor
+ * descriptor is resolved by matching the target mount path against the
+ * AssetSpace descriptor scan; an un-described mount is non-floor.
+ *
+ * @returns A struct with the exit code + informational messages so tests can
+ *   assert outcomes without spying on process streams (mirrors `apply-profile`).
+ */
+export async function runAssetSpaceRemove(
+  opts: AssetSpaceRemoveOptions,
+  deps: AssetSpaceRemoveDeps = {},
+): Promise<AssetSpaceRemoveResult> {
+  const stdout: string[] = [];
+  const stderr: string[] = [];
+  const out = (msg: string) => {
+    stdout.push(msg);
+    (deps.out ?? ((m: string) => process.stdout.write(`${m}\n`)))(msg);
+  };
+  const err = (msg: string) => {
+    stderr.push(msg);
+    (deps.err ?? ((m: string) => process.stderr.write(`${m}\n`)))(msg);
+  };
+
+  if (!opts.vault) {
+    throw new InvalidArgumentsError("--vault is required");
+  }
+  const vaultPath = resolve(opts.vault);
+  if (!existsSync(vaultPath)) {
+    throw new VaultNotFoundError(vaultPath);
+  }
+
+  const folder = resolveRemoveAssetSpacePath(opts);
+
+  // TS-floor guard (BEFORE any mutation). Match the target mount path against
+  // the AssetSpace descriptor scan to recover its uid + namespace.
+  const infos =
+    deps.scanInfos?.(vaultPath) ??
+    new CliApplyProfileService({ vaultPath }).scanVault().infos;
+  const match = infos.find((i) => i.folderName === folder);
+  if (match !== undefined && isTsFloorAssetSpace(match.uid, match.namespace)) {
+    err(
+      `[assetspace-remove] Refused: «${match.label}» ` +
+        `(${match.namespace || match.uid}) is a TS-floor AssetSpace — ` +
+        `unmounting it would self-brick the runtime (R24). Aborted, no changes made.`,
+    );
+    return {
+      exitCode: ExitCodes.OPERATION_FAILED,
+      stdout,
+      stderr,
+      removed: false,
+      folder,
+    };
+  }
+
+  const existedBefore = existsSync(join(vaultPath, folder));
+  const unmount =
+    deps.unmount ??
+    ((v: string, s: string) =>
+      new BootstrapAssetSpaceService().unmountAssetSpace(v, s));
+  try {
+    unmount(vaultPath, folder);
+  } catch (e) {
+    err(
+      `[assetspace-remove] Unmount failed: ${
+        e instanceof Error ? e.message : String(e)
+      }`,
+    );
+    return {
+      exitCode: ExitCodes.OPERATION_FAILED,
+      stdout,
+      stderr,
+      removed: false,
+      folder,
+    };
+  }
+
+  if (opts.json) {
+    out(
+      JSON.stringify(
+        {
+          vault: vaultPath,
+          folder,
+          existedBefore,
+          unmounted: true,
+        },
+        null,
+        2,
+      ),
+    );
+  } else if (existedBefore) {
+    out(`\n✓ AssetSpace unmounted`);
+    out(`  Folder: ${folder} (removed from vault + .gitmodules)`);
+  } else {
+    out(`\n✓ AssetSpace already absent — .gitmodules stanza stripped (no-op)`);
+    out(`  Folder: ${folder}`);
+  }
+
+  return {
+    exitCode: ExitCodes.SUCCESS,
+    stdout,
+    stderr,
+    removed: true,
+    folder,
+  };
+}
+
+export function assetSpaceRemoveCommand(): Command {
+  return new Command("assetspace-remove")
+    .description(
+      "Unmount a single AssetSpace (inverse of assetspace-add). Strips its .gitmodules stanza and deletes the mount folder. TS-floor AssetSpaces ({exo}) are refused.",
+    )
+    .requiredOption("--vault <path>", "Path to target vault")
+    .option(
+      "--folder <path>",
+      "Vault-relative mount path to unmount (e.g. assetspaces/kitelev/exoas-pmbok-ontology). Takes precedence over --url.",
+    )
+    .option(
+      "--url <url>",
+      "Public GitHub URL of the AssetSpace — derives the canonical mount path (parity with assetspace-add).",
+    )
+    .option("--json", "Emit result as JSON", false)
+    .action(async (options: AssetSpaceRemoveOptions) => {
+      try {
+        const result = await runAssetSpaceRemove(options);
+        process.exit(result.exitCode);
+      } catch (e) {
+        ErrorHandler.handle(e as Error);
+      }
+    });
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -19,6 +19,7 @@ import { auditCommand } from "./commands/audit.js";
 import { applyProfileCommand } from "./commands/apply-profile.js";
 import { bootstrapCommand } from "./commands/bootstrap.js";
 import { assetSpaceAddCommand } from "./commands/assetspace-add.js";
+import { assetSpaceRemoveCommand } from "./commands/assetspace-remove.js";
 import { resolveDepsCommand } from "./commands/resolve-deps.js";
 import { experimentalCommand } from "./commands/experimental.js";
 import { exosyncParityCommand } from "./commands/exosync-parity.js";
@@ -69,6 +70,8 @@ export function createProgram(version?: string): Command {
   // RFC 13da049f Phase 6.2 + 6.3 — Bootstrap + Add AssetSpace CLI
   program.addCommand(bootstrapCommand());
   program.addCommand(assetSpaceAddCommand());
+  // #e6b8827c — unmount a single AssetSpace (inverse of assetspace-add)
+  program.addCommand(assetSpaceRemoveCommand());
 
   // Issue #3513 (builds on #3511) — registry-driven dependsOn resolution for
   // the per-AssetSpace SHACL CI gate.

--- a/packages/cli/tests/unit/commands/assetspace-remove.command.test.ts
+++ b/packages/cli/tests/unit/commands/assetspace-remove.command.test.ts
@@ -128,6 +128,20 @@ describe("assetspace-remove — runAssetSpaceRemove (#e6b8827c)", () => {
     expect(unmountCalls).toEqual([]);
   });
 
+  it("[MEDIUM fix] path-based floor: flat exo mount with NO matching descriptor → refused", async () => {
+    // The descriptor join misses (no info at assetspaces/exo), but the path
+    // itself names the floor → isTsFloorMountPath catches it. unmount NOT called.
+    const unmountCalls: Array<{ vault: string; folder: string }> = [];
+    const res = await runAssetSpaceRemove(
+      { vault, folder: "assetspaces/exo" },
+      deps([PMBOK_INFO], unmountCalls), // exo NOT described
+    );
+    expect(res.exitCode).toBe(ExitCodes.OPERATION_FAILED);
+    expect(res.removed).toBe(false);
+    expect(unmountCalls).toEqual([]); // ← path guard
+    expect(res.stderr.join("\n")).toContain("floor namespace");
+  });
+
   it("non-floor AssetSpace (by --url) → unmount called, success exit", async () => {
     // Materialise the folder so existedBefore=true reports a real removal.
     mkdirSync(path.join(vault, "assetspaces", "kitelev", "exoas-pmbok-ontology"), {

--- a/packages/cli/tests/unit/commands/assetspace-remove.command.test.ts
+++ b/packages/cli/tests/unit/commands/assetspace-remove.command.test.ts
@@ -1,0 +1,191 @@
+import { describe, it, expect, beforeEach, afterEach } from "@jest/globals";
+import { mkdtempSync, rmSync, mkdirSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import {
+  resolveRemoveAssetSpacePath,
+  runAssetSpaceRemove,
+  type AssetSpaceRemoveDeps,
+} from "../../../src/commands/assetspace-remove.js";
+import type { AssetSpaceInfo } from "../../../src/services/CliApplyProfileService.js";
+import { ExitCodes } from "../../../src/utils/ExitCodes.js";
+import { InvalidArgumentsError } from "../../../src/utils/errors/index.js";
+
+const EXO_INFO: AssetSpaceInfo = {
+  uid: "49fd2e56-4656-4ca7-a789-f472b16ea260",
+  git: "https://github.com/kitelev/exoas-exo",
+  folderName: "assetspaces/kitelev/exoas-exo",
+  label: "exo",
+  namespace: "exo",
+};
+
+const PMBOK_INFO: AssetSpaceInfo = {
+  uid: "abc12345-0000-0000-0000-000000000000",
+  git: "https://github.com/kitelev/exoas-pmbok-ontology",
+  folderName: "assetspaces/kitelev/exoas-pmbok-ontology",
+  label: "pmbok",
+  namespace: "pmbok",
+};
+
+describe("assetspace-remove — resolveRemoveAssetSpacePath (#e6b8827c)", () => {
+  it("--url derives the canonical Maven path (parity with assetspace-add)", () => {
+    expect(
+      resolveRemoveAssetSpacePath({
+        url: "https://github.com/kitelev/exoas-pmbok-ontology",
+      }),
+    ).toBe("assetspaces/kitelev/exoas-pmbok-ontology");
+  });
+
+  it("--folder with a full assetspaces/ path is used verbatim", () => {
+    expect(
+      resolveRemoveAssetSpacePath({ folder: "assetspaces/kitelev/exoas-exo" }),
+    ).toBe("assetspaces/kitelev/exoas-exo");
+  });
+
+  it("--folder with a bare segment is prefixed with assetspaces/", () => {
+    expect(resolveRemoveAssetSpacePath({ folder: "pmbok" })).toBe(
+      "assetspaces/pmbok",
+    );
+    expect(resolveRemoveAssetSpacePath({ folder: "kitelev/exoas-exo" })).toBe(
+      "assetspaces/kitelev/exoas-exo",
+    );
+  });
+
+  it("--folder takes precedence over --url", () => {
+    expect(
+      resolveRemoveAssetSpacePath({
+        folder: "assetspaces/legacy/flat",
+        url: "https://github.com/kitelev/exoas-exo",
+      }),
+    ).toBe("assetspaces/legacy/flat");
+  });
+
+  it("neither --folder nor --url → throws InvalidArgumentsError", () => {
+    expect(() => resolveRemoveAssetSpacePath({})).toThrow(InvalidArgumentsError);
+    expect(() => resolveRemoveAssetSpacePath({ folder: "" })).toThrow(
+      InvalidArgumentsError,
+    );
+  });
+});
+
+describe("assetspace-remove — runAssetSpaceRemove (#e6b8827c)", () => {
+  let vault: string;
+  const captured: string[] = [];
+
+  beforeEach(() => {
+    vault = mkdtempSync(path.join(os.tmpdir(), "exo-asremove-test-"));
+    captured.length = 0;
+  });
+
+  afterEach(() => {
+    rmSync(vault, { recursive: true, force: true });
+  });
+
+  function deps(
+    infos: AssetSpaceInfo[],
+    unmountCalls: Array<{ vault: string; folder: string }>,
+  ): AssetSpaceRemoveDeps {
+    return {
+      scanInfos: () => infos,
+      unmount: (v, f) => {
+        unmountCalls.push({ vault: v, folder: f });
+      },
+      out: (m) => captured.push(`OUT ${m}`),
+      err: (m) => captured.push(`ERR ${m}`),
+    };
+  }
+
+  it("[floor-refuse] refuses a floor AssetSpace (by UID) — unmount NOT called, non-zero exit", async () => {
+    // Revert-verify: removing the `isTsFloorAssetSpace` guard makes this assert
+    // FAIL (unmount would run for exo → self-brick).
+    const unmountCalls: Array<{ vault: string; folder: string }> = [];
+    const res = await runAssetSpaceRemove(
+      { vault, folder: "assetspaces/kitelev/exoas-exo" },
+      deps([EXO_INFO, PMBOK_INFO], unmountCalls),
+    );
+    expect(res.exitCode).toBe(ExitCodes.OPERATION_FAILED);
+    expect(res.removed).toBe(false);
+    expect(unmountCalls).toEqual([]); // ← the guard
+    expect(res.stderr.join("\n")).toContain("Refused");
+    expect(res.stderr.join("\n")).toContain("TS-floor");
+  });
+
+  it("[floor-refuse] refuses a floor AssetSpace matched by NAMESPACE (EKA registry, different UID)", async () => {
+    const ekaExo: AssetSpaceInfo = {
+      uid: "e5c47526-e72f-42e3-8535-3d243dd2db94", // different UID
+      git: "https://github.com/acme/exoas-exo",
+      folderName: "assetspaces/acme/exoas-exo",
+      label: "exo",
+      namespace: "exo", // fork-safe floor identity
+    };
+    const unmountCalls: Array<{ vault: string; folder: string }> = [];
+    const res = await runAssetSpaceRemove(
+      { vault, folder: "assetspaces/acme/exoas-exo" },
+      deps([ekaExo], unmountCalls),
+    );
+    expect(res.exitCode).toBe(ExitCodes.OPERATION_FAILED);
+    expect(unmountCalls).toEqual([]);
+  });
+
+  it("non-floor AssetSpace (by --url) → unmount called, success exit", async () => {
+    // Materialise the folder so existedBefore=true reports a real removal.
+    mkdirSync(path.join(vault, "assetspaces", "kitelev", "exoas-pmbok-ontology"), {
+      recursive: true,
+    });
+    const unmountCalls: Array<{ vault: string; folder: string }> = [];
+    const res = await runAssetSpaceRemove(
+      { vault, url: "https://github.com/kitelev/exoas-pmbok-ontology" },
+      deps([EXO_INFO, PMBOK_INFO], unmountCalls),
+    );
+    expect(res.exitCode).toBe(ExitCodes.SUCCESS);
+    expect(res.removed).toBe(true);
+    expect(res.folder).toBe("assetspaces/kitelev/exoas-pmbok-ontology");
+    expect(unmountCalls).toEqual([
+      { vault, folder: "assetspaces/kitelev/exoas-pmbok-ontology" },
+    ]);
+    expect(res.stdout.join("\n")).toContain("unmounted");
+  });
+
+  it("un-described mount (no matching descriptor) → non-floor, unmount called", async () => {
+    const unmountCalls: Array<{ vault: string; folder: string }> = [];
+    const res = await runAssetSpaceRemove(
+      { vault, folder: "assetspaces/kitelev/exoas-orphan" },
+      deps([EXO_INFO], unmountCalls), // EXO present, but target not described
+    );
+    expect(res.exitCode).toBe(ExitCodes.SUCCESS);
+    expect(unmountCalls).toEqual([
+      { vault, folder: "assetspaces/kitelev/exoas-orphan" },
+    ]);
+  });
+
+  it("--json emits machine-readable result for a successful unmount", async () => {
+    const unmountCalls: Array<{ vault: string; folder: string }> = [];
+    const res = await runAssetSpaceRemove(
+      { vault, folder: "assetspaces/kitelev/exoas-pmbok-ontology", json: true },
+      deps([PMBOK_INFO], unmountCalls),
+    );
+    expect(res.exitCode).toBe(ExitCodes.SUCCESS);
+    const parsed = JSON.parse(res.stdout.join("\n"));
+    expect(parsed.folder).toBe("assetspaces/kitelev/exoas-pmbok-ontology");
+    expect(parsed.unmounted).toBe(true);
+  });
+
+  it("unmount mechanics throw → failure exit, error surfaced", async () => {
+    const res = await runAssetSpaceRemove(
+      { vault, folder: "assetspaces/kitelev/exoas-pmbok-ontology" },
+      {
+        scanInfos: () => [PMBOK_INFO],
+        unmount: () => {
+          throw new Error("rmSync boom");
+        },
+        out: (m) => captured.push(m),
+        err: (m) => captured.push(m),
+      },
+    );
+    expect(res.exitCode).toBe(ExitCodes.OPERATION_FAILED);
+    expect(res.removed).toBe(false);
+    expect(res.stderr.join("\n")).toContain("Unmount failed");
+    expect(res.stderr.join("\n")).toContain("rmSync boom");
+  });
+});

--- a/packages/exocortex/src/domain/profile/TsFloorGuard.ts
+++ b/packages/exocortex/src/domain/profile/TsFloorGuard.ts
@@ -192,3 +192,32 @@ export function assertTsFloorReconciled(
     );
   }
 }
+
+/**
+ * Per-AssetSpace floor membership check (the unmount-command counterpart of the
+ * set-level {@link assertTsFloorReconciled}). Returns `true` when a SINGLE
+ * AssetSpace — identified by its descriptor `uid` + `exo__AssetSpace_namespace`
+ * — is a floor member, so a standalone `unmount-assetspace` / `assetspace-remove`
+ * command can refuse to tear it down (it would self-brick the runtime, R24).
+ *
+ * Reconciled identity (issue #3511): a floor member matches when EITHER its
+ * legacy {@link FloorIdentity.uid} equals `uid` OR its {@link FloorIdentity.namespace}
+ * equals `namespace`. The namespace match is fork-safe (an `exoas-exo` fork keeps
+ * namespace `"exo"`) and covers EKA central-registry descriptors that mint a new
+ * UID for the same `$exo` AssetSpace. An empty `namespace` never matches by
+ * namespace (only by UID), so an un-described mount is treated as non-floor.
+ *
+ * Callers pass {@link SDK_FLOOR} (CLI/headless) or {@link PLUGIN_UI_FLOOR}
+ * (plugin) — both `[{exo}]` post-#3440.
+ */
+export function isTsFloorAssetSpace(
+  uid: string,
+  namespace: string,
+  floor: ReadonlyArray<FloorIdentity> = SDK_FLOOR,
+): boolean {
+  return floor.some(
+    (f) =>
+      (uid.length > 0 && f.uid === uid) ||
+      (namespace.length > 0 && f.namespace === namespace),
+  );
+}

--- a/packages/exocortex/src/domain/profile/TsFloorGuard.ts
+++ b/packages/exocortex/src/domain/profile/TsFloorGuard.ts
@@ -221,3 +221,35 @@ export function isTsFloorAssetSpace(
       (namespace.length > 0 && f.namespace === namespace),
   );
 }
+
+/**
+ * Path-derived floor guard (belt-and-suspenders over {@link isTsFloorAssetSpace}).
+ * Returns `true` when a mount path's repo basename — stripped of the `exoas-`
+ * prefix — equals a floor namespace, regardless of whether a descriptor was
+ * found. This closes the unmount floor-bypass for a `$exo` mounted at a flat
+ * legacy path (`assetspaces/exo`) or whose descriptor is un-derivable/absent
+ * (so the descriptor-scan join on `folderName` misses): the descriptor-based
+ * {@link isTsFloorAssetSpace} can't see those, but the path itself still names
+ * the floor.
+ *
+ * Examples (floor `{exo}`):
+ *   - `assetspaces/exo`                 → `exo`            → floor (flat legacy)
+ *   - `assetspaces/kitelev/exoas-exo`   → `exoas-exo`→`exo`→ floor (Maven)
+ *   - `assetspaces/acme/exoas-exo`      → `exo`            → floor (fork — still exo)
+ *   - `assetspaces/kitelev/exoas-pmbok` → `pmbok`          → NOT floor
+ *
+ * Intentionally conservative — a path whose basename resolves to a floor
+ * namespace is by convention the floor AssetSpace, so erring toward refuse
+ * (floor-policy A) is correct. The (negligible) false-positive surface is a
+ * non-floor repo deliberately named `exo` / `exoas-exo`, which does not exist.
+ */
+export function isTsFloorMountPath(
+  submodulePath: string,
+  floor: ReadonlyArray<FloorIdentity> = SDK_FLOOR,
+): boolean {
+  const norm = submodulePath.replace(/\/+$/, "");
+  const seg = norm.slice(norm.lastIndexOf("/") + 1);
+  const ns = seg.startsWith("exoas-") ? seg.slice("exoas-".length) : seg;
+  if (ns.length === 0) return false;
+  return floor.some((f) => f.namespace === ns);
+}

--- a/packages/exocortex/src/index.ts
+++ b/packages/exocortex/src/index.ts
@@ -64,6 +64,7 @@ export {
   assertTsFloor,
   assertTsFloorReconciled,
   isTsFloorAssetSpace,
+  isTsFloorMountPath,
 } from "./domain/profile/TsFloorGuard";
 export type { FloorIdentity } from "./domain/profile/TsFloorGuard";
 export { transitiveDependsOnClosure } from "./domain/profile/AssetSpaceDependsOn";

--- a/packages/exocortex/src/index.ts
+++ b/packages/exocortex/src/index.ts
@@ -63,6 +63,7 @@ export {
   TsFloorViolationError,
   assertTsFloor,
   assertTsFloorReconciled,
+  isTsFloorAssetSpace,
 } from "./domain/profile/TsFloorGuard";
 export type { FloorIdentity } from "./domain/profile/TsFloorGuard";
 export { transitiveDependsOnClosure } from "./domain/profile/AssetSpaceDependsOn";

--- a/packages/exocortex/tests/domain/profile/TsFloorGuard.test.ts
+++ b/packages/exocortex/tests/domain/profile/TsFloorGuard.test.ts
@@ -9,6 +9,7 @@ import {
   TsFloorViolationError,
   assertTsFloor,
   assertTsFloorReconciled,
+  isTsFloorAssetSpace,
 } from "../../../src/domain/profile/TsFloorGuard";
 
 // floor={exo} (RFC 5aa2a73a): shared-identities + exocmd removed from the floor.
@@ -136,6 +137,46 @@ describe("TsFloorGuard — floor = {exo}", () => {
       } catch (e) {
         expect(e).toBeInstanceOf(TsFloorViolationError);
       }
+    });
+  });
+
+  describe("isTsFloorAssetSpace — per-AssetSpace floor membership (#e6b8827c unmount guard)", () => {
+    it("legacy floor UID (any namespace) → floor", () => {
+      expect(isTsFloorAssetSpace(TS_FLOOR_AS_UID_EXO, "")).toBe(true);
+      expect(isTsFloorAssetSpace(TS_FLOOR_AS_UID_EXO, "exo")).toBe(true);
+      // Even a mislabeled namespace doesn't un-floor the legacy UID anchor.
+      expect(isTsFloorAssetSpace(TS_FLOOR_AS_UID_EXO, "weird")).toBe(true);
+    });
+
+    it("EKA central-registry descriptor: DIFFERENT UID but namespace 'exo' → floor (fork-safe)", () => {
+      expect(isTsFloorAssetSpace(EKA_EXO_UID, "exo")).toBe(true);
+    });
+
+    it("non-floor AssetSpace (ems) → NOT floor", () => {
+      expect(isTsFloorAssetSpace(EMS, "ems")).toBe(false);
+    });
+
+    it("exocmd + shared-identities are OPTIONAL, NOT floor (RFC 5aa2a73a / #3440)", () => {
+      // Critical: the unmount command MUST allow tearing exocmd/shared-identities
+      // down (they are optional libraries, not the floor). Neither UID nor
+      // namespace is a floor member.
+      expect(isTsFloorAssetSpace(TS_FLOOR_AS_UID_EXOCMD, "exocmd")).toBe(false);
+      expect(
+        isTsFloorAssetSpace(TS_FLOOR_AS_UID_SHARED_IDENTITIES, "shared-identities"),
+      ).toBe(false);
+    });
+
+    it("empty namespace never matches by namespace (un-described mount → non-floor)", () => {
+      // A mount with no scannable descriptor (uid "" + namespace "") is treated
+      // as non-floor — it is unmountable. An empty namespace must NOT collide
+      // with a floor entry whose namespace is also conceptually absent.
+      expect(isTsFloorAssetSpace("", "")).toBe(false);
+      expect(isTsFloorAssetSpace("some-unknown-uid", "")).toBe(false);
+    });
+
+    it("respects an explicit floor argument (defaults to SDK_FLOOR)", () => {
+      // Empty floor → nothing is ever a floor member.
+      expect(isTsFloorAssetSpace(TS_FLOOR_AS_UID_EXO, "exo", [])).toBe(false);
     });
   });
 });

--- a/packages/exocortex/tests/domain/profile/TsFloorGuard.test.ts
+++ b/packages/exocortex/tests/domain/profile/TsFloorGuard.test.ts
@@ -10,6 +10,7 @@ import {
   assertTsFloor,
   assertTsFloorReconciled,
   isTsFloorAssetSpace,
+  isTsFloorMountPath,
 } from "../../../src/domain/profile/TsFloorGuard";
 
 // floor={exo} (RFC 5aa2a73a): shared-identities + exocmd removed from the floor.
@@ -177,6 +178,37 @@ describe("TsFloorGuard — floor = {exo}", () => {
     it("respects an explicit floor argument (defaults to SDK_FLOOR)", () => {
       // Empty floor → nothing is ever a floor member.
       expect(isTsFloorAssetSpace(TS_FLOOR_AS_UID_EXO, "exo", [])).toBe(false);
+    });
+  });
+
+  describe("isTsFloorMountPath — path-based floor guard (#e6b8827c unmount belt-and-suspenders)", () => {
+    it("flat legacy mount assetspaces/exo → floor (descriptor-less bypass closed)", () => {
+      expect(isTsFloorMountPath("assetspaces/exo")).toBe(true);
+    });
+
+    it("canonical Maven mount assetspaces/<owner>/exoas-exo → floor (prefix stripped)", () => {
+      expect(isTsFloorMountPath("assetspaces/kitelev/exoas-exo")).toBe(true);
+      // Fork: a different owner is still the exo floor.
+      expect(isTsFloorMountPath("assetspaces/acme/exoas-exo")).toBe(true);
+    });
+
+    it("non-floor mounts → NOT floor", () => {
+      expect(isTsFloorMountPath("assetspaces/kitelev/exoas-pmbok-ontology")).toBe(
+        false,
+      );
+      expect(isTsFloorMountPath("assetspaces/exocmd")).toBe(false); // optional, not floor
+      expect(isTsFloorMountPath("assetspaces/kitelev/exoas-shared-private")).toBe(
+        false,
+      );
+    });
+
+    it("trailing slash + empty segment handled", () => {
+      expect(isTsFloorMountPath("assetspaces/kitelev/exoas-exo/")).toBe(true);
+      expect(isTsFloorMountPath("")).toBe(false);
+    });
+
+    it("respects an explicit floor argument", () => {
+      expect(isTsFloorMountPath("assetspaces/exo", [])).toBe(false);
     });
   });
 });

--- a/packages/obsidian-plugin/src/ExocortexPlugin.ts
+++ b/packages/obsidian-plugin/src/ExocortexPlugin.ts
@@ -67,7 +67,7 @@ import {
   createCommandPanelFromFrontmatter,
   isLayoutFrontmatter,
 } from "./domain/layout";
-import { isCommandBindingFrontmatter } from "exocortex";
+import { isCommandBindingFrontmatter, isTsFloorAssetSpace } from "exocortex";
 import { SPARQLCodeBlockProcessor } from "./application/processors/SPARQLCodeBlockProcessor";
 import { LayoutCodeBlockProcessor } from "./application/processors/LayoutCodeBlockProcessor";
 import { SPARQLApi } from "./application/api/SPARQLApi";
@@ -116,8 +116,15 @@ import { createAssetSpacePusher } from "./infrastructure/adapters/AssetSpacePush
 import { LocalSecretsStore } from "./infrastructure/adapters/LocalSecretsStore";
 import { SwitchCacheLayer } from "./infrastructure/adapters/SwitchCacheLayer";
 import { ClearSwitchCacheConfirmModal } from "./infrastructure/adapters/ClearSwitchCacheConfirmModal";
-import { parseGitHubURL } from "./infrastructure/adapters/AssetSpaceManager";
+import {
+  parseGitHubURL,
+  type AssetSpaceInfo,
+} from "./infrastructure/adapters/AssetSpaceManager";
 import { BootstrapAssetSpaceCommands } from "./infrastructure/adapters/BootstrapAssetSpaceCommands";
+import {
+  UnmountAssetSpaceCommand,
+  type UnmountableAssetSpace,
+} from "./infrastructure/adapters/UnmountAssetSpaceCommand";
 import { BootstrapVaultModal } from "./presentation/modals/BootstrapVaultModal";
 import { AddAssetSpaceModal } from "./presentation/modals/AddAssetSpaceModal";
 import { SimpleConfirmModal } from "./presentation/modals/SimpleConfirmModal";
@@ -3061,6 +3068,17 @@ export default class ExocortexPlugin extends Plugin {
       this.registerBootstrapCommands(applyDeps, restMount, localDataStore);
     }
 
+    // #e6b8827c — «Unmount assetspace»: the inverse of «Add assetspace by URL».
+    // Unmount mechanics already existed only INSIDE apply-profile's strict
+    // mount-state replace; this surfaces a single-AssetSpace unmount as a
+    // first-class palette action (CLI parity: `assetspace-remove`). Uses the
+    // git-free cross-platform `RestAssetSpaceMount.unmount`, so it registers on
+    // BOTH desktop and mobile when the REST mount is wired (Desktop↔Mobile
+    // Command Parity). A TS-floor AssetSpace is refused (floor-policy A).
+    if (restMount !== null) {
+      this.registerUnmountCommand(restMount, switchMgr);
+    }
+
     this.logger.info(
       "[ExocortexPlugin] Profile palette commands registered",
     );
@@ -3250,6 +3268,107 @@ export default class ExocortexPlugin extends Plugin {
       name: "Add assetspace by URL",
       callback: () => {
         void bootstrapCommands.invokeAddAssetSpace();
+      },
+    });
+  }
+
+  /**
+   * Wire + register the «Exocortex: Unmount assetspace» palette command
+   * (#e6b8827c) — the inverse of «Add assetspace by URL». Lists the currently
+   * mounted AssetSpaces (the `.gitmodules` registry, cross-referenced with the
+   * AssetSpace descriptor scan for uid/namespace → TS-floor identity), fuzzy-
+   * picks one, and tears it down via the git-free cross-platform
+   * {@link RestAssetSpaceMount.unmount}.
+   *
+   * Floor-policy A — a TS-floor AssetSpace (`{exo}`, matched by UID or
+   * namespace via {@link isTsFloorAssetSpace}) surfaces in the picker as
+   * protected and is REFUSED on selection (no mutation), mirroring
+   * apply-profile's R24 guard. `restMount` is the unified git-free path
+   * (post git-elim), so this registers on both desktop + mobile (Desktop↔Mobile
+   * Command Parity).
+   */
+  private registerUnmountCommand(
+    restMount: RestAssetSpaceMount,
+    switchMgr: ProfileApplyManager,
+  ): void {
+    const lastSegment = (p: string): string => {
+      const norm = p.replace(/\/+$/, "");
+      const idx = norm.lastIndexOf("/");
+      return idx < 0 ? norm : norm.slice(idx + 1);
+    };
+
+    const unmountCommand = new UnmountAssetSpaceCommand({
+      listMounted: async (): Promise<UnmountableAssetSpace[]> => {
+        // `.gitmodules` is the canonical "what's mounted" registry (the same
+        // source apply-profile reads). Enrich each entry with its descriptor's
+        // uid + namespace (from the vault scan) so the TS-floor identity can be
+        // computed; an entry with no scannable descriptor is treated as a
+        // non-floor mount (uid/namespace "").
+        const entries = await restMount.readGitmodulesEntries();
+        const infoByFolder = new Map<string, AssetSpaceInfo>();
+        for (const info of switchMgr.listAllAssetSpaceInfos()) {
+          infoByFolder.set(info.folderName, info);
+        }
+        return entries
+          .filter((e) => e.submodulePath.length > 0)
+          .map((e) => {
+            const info = infoByFolder.get(e.submodulePath);
+            const uid = info?.uid ?? "";
+            const namespace = info?.namespace ?? "";
+            return {
+              submodulePath: e.submodulePath,
+              url: e.url,
+              uid,
+              namespace,
+              label: namespace || lastSegment(e.submodulePath),
+              isFloor: isTsFloorAssetSpace(uid, namespace),
+            };
+          })
+          .sort((a, b) => a.label.localeCompare(b.label));
+      },
+      // Reuse the shared ProfileFuzzyModal (keyed by submodulePath) — floor
+      // entries are decorated so the user sees why they cannot be removed.
+      fuzzyPick: (items, title) =>
+        new Promise<UnmountableAssetSpace | null>((resolve) => {
+          const choices: ProfileChoice[] = items.map((m) => ({
+            uid: m.submodulePath,
+            label: m.isFloor ? `${m.label} ✕ floor (protected)` : m.label,
+          }));
+          const byPath = new Map(items.map((m) => [m.submodulePath, m]));
+          const modal = new ProfileFuzzyModal(
+            this.app,
+            choices,
+            title,
+            (chosen) =>
+              resolve(chosen === null ? null : byPath.get(chosen.uid) ?? null),
+          );
+          modal.open();
+        }),
+      confirm: (message) =>
+        new Promise<boolean>((resolve) => {
+          new SimpleConfirmModal(
+            this.app,
+            {
+              title: "Unmount assetspace?",
+              body: message,
+              confirmLabel: "Unmount",
+            },
+            resolve,
+          ).open();
+        }),
+      unmount: (submodulePath) => restMount.unmount(submodulePath),
+      notify: (message) => {
+        this.notifier.info(message);
+        this.activityLog.record({ category: "bootstrap", level: "info", message });
+      },
+      onUnmounted: () => this.refreshAndInjectAssetSpaceMaterialization(),
+    });
+
+    this.addCommand({
+      id: "unmount-assetspace",
+      name: "Unmount assetspace",
+      callback: () => {
+        void unmountCommand.invokeUnmount();
       },
     });
   }

--- a/packages/obsidian-plugin/src/ExocortexPlugin.ts
+++ b/packages/obsidian-plugin/src/ExocortexPlugin.ts
@@ -67,7 +67,7 @@ import {
   createCommandPanelFromFrontmatter,
   isLayoutFrontmatter,
 } from "./domain/layout";
-import { isCommandBindingFrontmatter, isTsFloorAssetSpace } from "exocortex";
+import { isCommandBindingFrontmatter } from "exocortex";
 import { SPARQLCodeBlockProcessor } from "./application/processors/SPARQLCodeBlockProcessor";
 import { LayoutCodeBlockProcessor } from "./application/processors/LayoutCodeBlockProcessor";
 import { SPARQLApi } from "./application/api/SPARQLApi";
@@ -123,6 +123,7 @@ import {
 import { BootstrapAssetSpaceCommands } from "./infrastructure/adapters/BootstrapAssetSpaceCommands";
 import {
   UnmountAssetSpaceCommand,
+  buildUnmountableList,
   type UnmountableAssetSpace,
 } from "./infrastructure/adapters/UnmountAssetSpaceCommand";
 import { BootstrapVaultModal } from "./presentation/modals/BootstrapVaultModal";
@@ -3291,40 +3292,18 @@ export default class ExocortexPlugin extends Plugin {
     restMount: RestAssetSpaceMount,
     switchMgr: ProfileApplyManager,
   ): void {
-    const lastSegment = (p: string): string => {
-      const norm = p.replace(/\/+$/, "");
-      const idx = norm.lastIndexOf("/");
-      return idx < 0 ? norm : norm.slice(idx + 1);
-    };
-
     const unmountCommand = new UnmountAssetSpaceCommand({
       listMounted: async (): Promise<UnmountableAssetSpace[]> => {
         // `.gitmodules` is the canonical "what's mounted" registry (the same
-        // source apply-profile reads). Enrich each entry with its descriptor's
-        // uid + namespace (from the vault scan) so the TS-floor identity can be
-        // computed; an entry with no scannable descriptor is treated as a
-        // non-floor mount (uid/namespace "").
+        // source apply-profile reads). The descriptor scan (a full-vault
+        // markdown walk, run once per command open — not per keystroke) supplies
+        // uid + namespace so the TS-floor identity can be computed.
+        // buildUnmountableList does the join + dual floor guard (descriptor-based
+        // AND path-based, so a floor mounted flat / with an un-derivable
+        // descriptor is still recognised).
         const entries = await restMount.readGitmodulesEntries();
-        const infoByFolder = new Map<string, AssetSpaceInfo>();
-        for (const info of switchMgr.listAllAssetSpaceInfos()) {
-          infoByFolder.set(info.folderName, info);
-        }
-        return entries
-          .filter((e) => e.submodulePath.length > 0)
-          .map((e) => {
-            const info = infoByFolder.get(e.submodulePath);
-            const uid = info?.uid ?? "";
-            const namespace = info?.namespace ?? "";
-            return {
-              submodulePath: e.submodulePath,
-              url: e.url,
-              uid,
-              namespace,
-              label: namespace || lastSegment(e.submodulePath),
-              isFloor: isTsFloorAssetSpace(uid, namespace),
-            };
-          })
-          .sort((a, b) => a.label.localeCompare(b.label));
+        const infos: AssetSpaceInfo[] = switchMgr.listAllAssetSpaceInfos();
+        return buildUnmountableList(entries, infos);
       },
       // Reuse the shared ProfileFuzzyModal (keyed by submodulePath) — floor
       // entries are decorated so the user sees why they cannot be removed.

--- a/packages/obsidian-plugin/src/infrastructure/adapters/ProfileApplyManager.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/ProfileApplyManager.ts
@@ -1881,7 +1881,7 @@ export class ProfileApplyManager {
     }
   }
 
-  private listAllAssetSpaceInfos(): AssetSpaceInfo[] {
+  public listAllAssetSpaceInfos(): AssetSpaceInfo[] {
     // Single vault scan — extracts AssetSpace ABox metadata directly from
     // frontmatter. Independent of AssetSpaceManager (так apply tests
     // and recovery-only flows can call this without a wired manager).

--- a/packages/obsidian-plugin/src/infrastructure/adapters/UnmountAssetSpaceCommand.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/UnmountAssetSpaceCommand.ts
@@ -30,6 +30,8 @@
  * {@link UnmountAssetSpaceCommandDeps}. Real wiring lives in `ExocortexPlugin`.
  */
 
+import { isTsFloorAssetSpace, isTsFloorMountPath } from "exocortex";
+
 /** A currently-mounted AssetSpace the user may pick to unmount. */
 export interface UnmountableAssetSpace {
   /** `.gitmodules` mount path (the unmount target, e.g. `assetspaces/kitelev/exoas-pmbok-ontology`). */
@@ -76,6 +78,64 @@ export interface UnmountAssetSpaceCommandDeps {
    * (the unmounted assets are gone). Failures are swallowed (best-effort).
    */
   onUnmounted?: () => Promise<void>;
+}
+
+/** A `.gitmodules` mount entry (the mounted-set registry). */
+export interface MountEntry {
+  submodulePath: string;
+  url: string;
+}
+
+/** Minimal AssetSpace descriptor shape consumed by {@link buildUnmountableList}. */
+export interface AssetSpaceDescriptor {
+  uid: string;
+  namespace: string;
+  /** Derived mount folder (`derivePath(git)`) — the join key against the mount path. */
+  folderName: string;
+}
+
+/** Last `/`-segment of a vault path (`assetspaces/kitelev/exoas-exo` → `exoas-exo`). */
+function lastSegment(p: string): string {
+  const norm = p.replace(/\/+$/, "");
+  const idx = norm.lastIndexOf("/");
+  return idx < 0 ? norm : norm.slice(idx + 1);
+}
+
+/**
+ * Build the picker list from the `.gitmodules` mount registry (`entries`)
+ * enriched with the AssetSpace descriptor scan (`infos`) for uid/namespace.
+ * Pure + side-effect-free so the join + floor computation is unit-testable
+ * (the wiring in `ExocortexPlugin` is otherwise hard to reach).
+ *
+ * `isFloor` is TRUE when EITHER the matched descriptor is a floor member
+ * ({@link isTsFloorAssetSpace}, by UID/namespace) OR the mount path itself names
+ * a floor namespace ({@link isTsFloorMountPath}) — the latter catches a floor
+ * mounted flat / with an un-derivable descriptor whose `folderName` join misses.
+ */
+export function buildUnmountableList(
+  entries: ReadonlyArray<MountEntry>,
+  infos: ReadonlyArray<AssetSpaceDescriptor>,
+): UnmountableAssetSpace[] {
+  const infoByFolder = new Map<string, AssetSpaceDescriptor>();
+  for (const info of infos) infoByFolder.set(info.folderName, info);
+  return entries
+    .filter((e) => e.submodulePath.length > 0)
+    .map((e) => {
+      const info = infoByFolder.get(e.submodulePath);
+      const uid = info?.uid ?? "";
+      const namespace = info?.namespace ?? "";
+      return {
+        submodulePath: e.submodulePath,
+        url: e.url,
+        uid,
+        namespace,
+        label: namespace || lastSegment(e.submodulePath),
+        isFloor:
+          isTsFloorAssetSpace(uid, namespace) ||
+          isTsFloorMountPath(e.submodulePath),
+      };
+    })
+    .sort((a, b) => a.label.localeCompare(b.label));
 }
 
 export class UnmountAssetSpaceCommand {

--- a/packages/obsidian-plugin/src/infrastructure/adapters/UnmountAssetSpaceCommand.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/UnmountAssetSpaceCommand.ts
@@ -1,0 +1,149 @@
+/**
+ * UnmountAssetSpaceCommand — command-palette logic handler for the standalone
+ * «Exocortex: Unmount assetspace» command (the inverse of «Add assetspace by
+ * URL», {@link BootstrapAssetSpaceCommands.invokeAddAssetSpace}).
+ *
+ * ## Why this command exists (#e6b8827c)
+ *
+ * The unmount mechanics already existed, but only *inside* `apply-profile`'s
+ * strict mount-state replace (tear down every AssetSpace not in the target
+ * profile's effective set). There was NO way to unmount a single AssetSpace on
+ * demand — neither in the palette nor in the CLI. This command surfaces the
+ * existing `RestAssetSpaceMount.unmount` (git-free, cross-platform after the
+ * git-elim REST mount, v16.96.12) as a first-class user action, mirroring the
+ * CLI's `assetspace-remove`.
+ *
+ * ## TS-floor refuse (floor-policy A — «refuse, не rescue»)
+ *
+ * The TS-floor (`{exo}` per RFC 5aa2a73a / #3440 — `exocmd` +
+ * `shared-identities` are OPTIONAL, NOT floor) is never unmounted: tearing it
+ * down would brick the runtime (no class defs). A floor AssetSpace surfaces in
+ * the picker decorated as protected, and selecting it is REFUSED with a clear
+ * Notice — no mutation — exactly as `apply-profile`'s R24 guard refuses a
+ * profile that would strip the floor. `isFloor` is computed once at wiring time
+ * via the shared `isTsFloorAssetSpace` guard (single source of truth), so this
+ * handler is data-driven and fully unit-testable without Obsidian.
+ *
+ * Pure logic — does NOT depend on Obsidian Plugin / FuzzySuggestModal / vault
+ * runtime. Everything platform-specific (the mounted-set scan, the fuzzy picker,
+ * the confirm modal, `RestAssetSpaceMount.unmount`) is injected via
+ * {@link UnmountAssetSpaceCommandDeps}. Real wiring lives in `ExocortexPlugin`.
+ */
+
+/** A currently-mounted AssetSpace the user may pick to unmount. */
+export interface UnmountableAssetSpace {
+  /** `.gitmodules` mount path (the unmount target, e.g. `assetspaces/kitelev/exoas-pmbok-ontology`). */
+  submodulePath: string;
+  /** `.gitmodules` URL (display / diagnostics). */
+  url: string;
+  /** AssetSpace descriptor `exo__Asset_uid` — `""` when the folder has no scannable descriptor. */
+  uid: string;
+  /** AssetSpace descriptor `exo__AssetSpace_namespace` — `""` when absent. */
+  namespace: string;
+  /** Display label for the picker. */
+  label: string;
+  /**
+   * Floor-protected (cannot be unmounted — would self-brick the runtime, R24).
+   * Computed at wiring time via the shared `isTsFloorAssetSpace` guard so the
+   * floor identity stays a single source of truth.
+   */
+  isFloor: boolean;
+}
+
+export interface UnmountAssetSpaceCommandDeps {
+  /**
+   * Returns the currently-mounted AssetSpaces (the picker source). Built from
+   * the `.gitmodules` registry cross-referenced with the AssetSpace descriptor
+   * scan (uid + namespace) so `isFloor` can be computed.
+   */
+  listMounted: () => Promise<UnmountableAssetSpace[]>;
+  /**
+   * Open a fuzzy picker. Returns the chosen AssetSpace, or null if cancelled.
+   * Real implementation wraps Obsidian `FuzzySuggestModal`; tests stub it.
+   */
+  fuzzyPick: (
+    items: UnmountableAssetSpace[],
+    title: string,
+  ) => Promise<UnmountableAssetSpace | null>;
+  /** Yes/no confirmation gate (unmount deletes the folder — destructive). */
+  confirm: (message: string) => Promise<boolean>;
+  /** Unmount the AssetSpace — `RestAssetSpaceMount.unmount` (git-free). */
+  unmount: (submodulePath: string) => Promise<void>;
+  /** User-facing Notice. */
+  notify: (message: string) => void;
+  /**
+   * Optional hook fired after a successful unmount so the plugin can re-index
+   * (the unmounted assets are gone). Failures are swallowed (best-effort).
+   */
+  onUnmounted?: () => Promise<void>;
+}
+
+export class UnmountAssetSpaceCommand {
+  private readonly d: UnmountAssetSpaceCommandDeps;
+
+  constructor(deps: UnmountAssetSpaceCommandDeps) {
+    this.d = deps;
+  }
+
+  /** Command — `Exocortex: Unmount assetspace`. */
+  async invokeUnmount(): Promise<void> {
+    let mounted: UnmountableAssetSpace[];
+    try {
+      mounted = await this.d.listMounted();
+    } catch (e) {
+      this.d.notify(`Unmount: could not list mounted AssetSpaces — ${this.msg(e)}`);
+      return;
+    }
+
+    if (mounted.length === 0) {
+      this.d.notify("No mounted AssetSpaces to unmount.");
+      return;
+    }
+
+    const chosen = await this.d.fuzzyPick(mounted, "Unmount assetspace");
+    if (chosen === null) return; // user cancelled
+
+    // Floor-policy A — refuse, не rescue. Selecting a floor AssetSpace is a
+    // no-op + clear Notice (NO mutation), mirroring apply-profile's R24 guard.
+    if (chosen.isFloor) {
+      this.d.notify(
+        `Unmount refused — «${chosen.label}» is a TS-floor AssetSpace ` +
+          `(${chosen.namespace || chosen.uid || chosen.submodulePath}) and cannot be unmounted ` +
+          `(it would self-brick the runtime — R24).`,
+      );
+      return;
+    }
+
+    const ok = await this.d.confirm(
+      `Unmount «${chosen.label}» (${chosen.submodulePath})? ` +
+        "This strips its .gitmodules entry and deletes the folder from the vault.",
+    );
+    if (!ok) return; // user declined
+
+    this.d.notify(`Unmounting ${chosen.label}…`);
+    try {
+      await this.d.unmount(chosen.submodulePath);
+    } catch (e) {
+      this.d.notify(`Unmount failed: ${this.msg(e)}`);
+      return;
+    }
+    this.d.notify(
+      `Unmounted ${chosen.label} (${chosen.submodulePath}). ` +
+        "Reload Obsidian if the removed assets still appear.",
+    );
+    await this.runOnUnmounted();
+  }
+
+  private async runOnUnmounted(): Promise<void> {
+    if (this.d.onUnmounted === undefined) return;
+    try {
+      await this.d.onUnmounted();
+    } catch {
+      // Best-effort re-index; failure must not surface as an unmount error.
+    }
+  }
+
+  private msg(e: unknown): string {
+    return e instanceof Error ? e.message : String(e);
+  }
+}

--- a/packages/obsidian-plugin/tests/unit/infrastructure/adapters/UnmountAssetSpaceCommand.test.ts
+++ b/packages/obsidian-plugin/tests/unit/infrastructure/adapters/UnmountAssetSpaceCommand.test.ts
@@ -1,0 +1,187 @@
+import {
+  UnmountAssetSpaceCommand,
+  type UnmountableAssetSpace,
+  type UnmountAssetSpaceCommandDeps,
+} from "../../../../src/infrastructure/adapters/UnmountAssetSpaceCommand";
+
+/**
+ * Unit tests for the «Exocortex: Unmount assetspace» palette command logic
+ * (#e6b8827c). The handler is pure (no Obsidian) — every boundary is faked.
+ *
+ * The load-bearing behaviour is the TS-floor REFUSE (floor-policy A): selecting
+ * a floor AssetSpace must NOT call `unmount`. The "floor pick → unmount NOT
+ * called" test is the guard; deleting the `chosen.isFloor` branch in the handler
+ * makes it FAIL (revert-verify).
+ */
+
+const EXO: UnmountableAssetSpace = {
+  submodulePath: "assetspaces/kitelev/exoas-exo",
+  url: "https://github.com/kitelev/exoas-exo",
+  uid: "49fd2e56-4656-4ca7-a789-f472b16ea260",
+  namespace: "exo",
+  label: "exo",
+  isFloor: true,
+};
+
+const PMBOK: UnmountableAssetSpace = {
+  submodulePath: "assetspaces/kitelev/exoas-pmbok-ontology",
+  url: "https://github.com/kitelev/exoas-pmbok-ontology",
+  uid: "abc12345-0000-0000-0000-000000000000",
+  namespace: "pmbok",
+  label: "pmbok",
+  isFloor: false,
+};
+
+interface Harness {
+  cmd: UnmountAssetSpaceCommand;
+  notices: string[];
+  unmountCalls: string[];
+  confirmCalls: string[];
+  /** Mutable counter (object so closures + assertions share the live value). */
+  state: { onUnmountedCalls: number; pickedTitle: string | null; pickedItems: UnmountableAssetSpace[] | null };
+}
+
+function makeHarness(opts: {
+  mounted?: UnmountableAssetSpace[];
+  listThrows?: boolean;
+  /** submodulePath the fake picker returns, or null to simulate cancel. */
+  pickPath?: string | null;
+  confirm?: boolean;
+  unmountThrows?: boolean;
+}): Harness {
+  const notices: string[] = [];
+  const unmountCalls: string[] = [];
+  const confirmCalls: string[] = [];
+  const state = {
+    onUnmountedCalls: 0,
+    pickedTitle: null as string | null,
+    pickedItems: null as UnmountableAssetSpace[] | null,
+  };
+
+  const mounted = opts.mounted ?? [];
+
+  const deps: UnmountAssetSpaceCommandDeps = {
+    listMounted: async () => {
+      if (opts.listThrows) throw new Error("scan boom");
+      return mounted;
+    },
+    fuzzyPick: async (items, title) => {
+      state.pickedItems = items;
+      state.pickedTitle = title;
+      if (opts.pickPath === undefined || opts.pickPath === null) return null;
+      return items.find((m) => m.submodulePath === opts.pickPath) ?? null;
+    },
+    confirm: async (message) => {
+      confirmCalls.push(message);
+      return opts.confirm ?? true;
+    },
+    unmount: async (submodulePath) => {
+      unmountCalls.push(submodulePath);
+      if (opts.unmountThrows) throw new Error("rmdir boom");
+    },
+    notify: (message) => notices.push(message),
+    onUnmounted: async () => {
+      state.onUnmountedCalls++;
+    },
+  };
+
+  return {
+    cmd: new UnmountAssetSpaceCommand(deps),
+    notices,
+    unmountCalls,
+    confirmCalls,
+    state,
+  };
+}
+
+describe("UnmountAssetSpaceCommand", () => {
+  it("no mounted AssetSpaces → notice, picker never opened", async () => {
+    const h = makeHarness({ mounted: [] });
+    await h.cmd.invokeUnmount();
+    expect(h.notices).toEqual(["No mounted AssetSpaces to unmount."]);
+    expect(h.state.pickedItems).toBeNull();
+    expect(h.unmountCalls).toEqual([]);
+  });
+
+  it("listMounted throws → graceful error notice, no unmount", async () => {
+    const h = makeHarness({ listThrows: true });
+    await h.cmd.invokeUnmount();
+    expect(h.notices[0]).toContain("could not list mounted AssetSpaces");
+    expect(h.notices[0]).toContain("scan boom");
+    expect(h.unmountCalls).toEqual([]);
+  });
+
+  it("non-floor pick + confirm → unmount called, success notice, re-index hook fired", async () => {
+    const h = makeHarness({
+      mounted: [EXO, PMBOK],
+      pickPath: PMBOK.submodulePath,
+      confirm: true,
+    });
+    await h.cmd.invokeUnmount();
+
+    expect(h.unmountCalls).toEqual([PMBOK.submodulePath]);
+    expect(h.confirmCalls).toHaveLength(1);
+    expect(h.state.onUnmountedCalls).toBe(1);
+    expect(h.notices.some((n) => n.includes("Unmounting pmbok"))).toBe(true);
+    expect(h.notices.some((n) => n.includes("Unmounted pmbok"))).toBe(true);
+    // The picker received ALL mounted (incl. floor) so the user sees full state.
+    expect(h.state.pickedItems?.map((m) => m.submodulePath)).toEqual([
+      EXO.submodulePath,
+      PMBOK.submodulePath,
+    ]);
+    expect(h.state.pickedTitle).toBe("Unmount assetspace");
+  });
+
+  it("[floor-refuse] floor pick → REFUSED: no confirm, no unmount, no re-index", async () => {
+    // Revert-verify: removing the `chosen.isFloor` guard in the handler makes
+    // this fail (unmount would be called for exo → self-brick).
+    const h = makeHarness({
+      mounted: [EXO, PMBOK],
+      pickPath: EXO.submodulePath,
+      confirm: true,
+    });
+    await h.cmd.invokeUnmount();
+
+    expect(h.unmountCalls).toEqual([]); // ← the guard
+    expect(h.confirmCalls).toEqual([]); // refused before the confirm gate
+    expect(h.state.onUnmountedCalls).toBe(0);
+    const refusal = h.notices.find((n) => n.includes("refused"));
+    expect(refusal).toBeDefined();
+    expect(refusal).toContain("TS-floor");
+    expect(refusal).toContain("exo");
+  });
+
+  it("cancelled picker (null) → no confirm, no unmount, no notice", async () => {
+    const h = makeHarness({ mounted: [EXO, PMBOK], pickPath: null });
+    await h.cmd.invokeUnmount();
+    expect(h.unmountCalls).toEqual([]);
+    expect(h.confirmCalls).toEqual([]);
+    expect(h.notices).toEqual([]);
+  });
+
+  it("confirm declined → no unmount", async () => {
+    const h = makeHarness({
+      mounted: [PMBOK],
+      pickPath: PMBOK.submodulePath,
+      confirm: false,
+    });
+    await h.cmd.invokeUnmount();
+    expect(h.confirmCalls).toHaveLength(1);
+    expect(h.unmountCalls).toEqual([]);
+  });
+
+  it("unmount throws → failure notice, no re-index hook", async () => {
+    const h = makeHarness({
+      mounted: [PMBOK],
+      pickPath: PMBOK.submodulePath,
+      confirm: true,
+      unmountThrows: true,
+    });
+    await h.cmd.invokeUnmount();
+    expect(h.unmountCalls).toEqual([PMBOK.submodulePath]);
+    expect(h.notices.some((n) => n.includes("Unmount failed") && n.includes("rmdir boom"))).toBe(
+      true,
+    );
+    expect(h.state.onUnmountedCalls).toBe(0);
+  });
+});

--- a/packages/obsidian-plugin/tests/unit/infrastructure/adapters/UnmountAssetSpaceCommand.test.ts
+++ b/packages/obsidian-plugin/tests/unit/infrastructure/adapters/UnmountAssetSpaceCommand.test.ts
@@ -1,5 +1,6 @@
 import {
   UnmountAssetSpaceCommand,
+  buildUnmountableList,
   type UnmountableAssetSpace,
   type UnmountAssetSpaceCommandDeps,
 } from "../../../../src/infrastructure/adapters/UnmountAssetSpaceCommand";
@@ -183,5 +184,84 @@ describe("UnmountAssetSpaceCommand", () => {
       true,
     );
     expect(h.state.onUnmountedCalls).toBe(0);
+  });
+});
+
+describe("buildUnmountableList — .gitmodules ∩ descriptor join + dual floor guard", () => {
+  const EXO_DESC = {
+    uid: "49fd2e56-4656-4ca7-a789-f472b16ea260",
+    namespace: "exo",
+    folderName: "assetspaces/kitelev/exoas-exo",
+  };
+  const PMBOK_DESC = {
+    uid: "abc12345-0000-0000-0000-000000000000",
+    namespace: "pmbok",
+    folderName: "assetspaces/kitelev/exoas-pmbok-ontology",
+  };
+
+  it("joins each mount entry to its descriptor (uid + namespace + label)", () => {
+    const list = buildUnmountableList(
+      [
+        { submodulePath: "assetspaces/kitelev/exoas-pmbok-ontology", url: "u1" },
+        { submodulePath: "assetspaces/kitelev/exoas-exo", url: "u2" },
+      ],
+      [EXO_DESC, PMBOK_DESC],
+    );
+    // Sorted by label: "exo" < "pmbok".
+    expect(list.map((m) => m.label)).toEqual(["exo", "pmbok"]);
+    const pmbok = list.find((m) => m.namespace === "pmbok")!;
+    expect(pmbok.uid).toBe(PMBOK_DESC.uid);
+    expect(pmbok.isFloor).toBe(false);
+  });
+
+  it("descriptor-based floor: exo mount with a matching descriptor → isFloor", () => {
+    const [exo] = buildUnmountableList(
+      [{ submodulePath: "assetspaces/kitelev/exoas-exo", url: "u" }],
+      [EXO_DESC],
+    );
+    expect(exo.isFloor).toBe(true);
+  });
+
+  it("[MEDIUM fix] path-based floor: flat exo mount with NO descriptor → still isFloor", () => {
+    // The descriptor join misses (no info for the flat path), but the path
+    // itself names the floor → isFloor must still be true (bypass closed).
+    const [exo] = buildUnmountableList(
+      [{ submodulePath: "assetspaces/exo", url: "u" }],
+      [PMBOK_DESC], // exo NOT described
+    );
+    expect(exo.uid).toBe(""); // un-described
+    expect(exo.namespace).toBe("");
+    expect(exo.isFloor).toBe(true); // ← caught by the path guard
+  });
+
+  it("[MEDIUM fix] path-based floor: Maven exo mount whose descriptor folderName mismatches → isFloor", () => {
+    // Descriptor's folderName points elsewhere (registry-hosted / un-derivable),
+    // so the folder join misses, but the mount basename resolves to the floor.
+    const [exo] = buildUnmountableList(
+      [{ submodulePath: "assetspaces/acme/exoas-exo", url: "u" }],
+      [{ ...EXO_DESC, folderName: "assetspaces/registry/exoas-registry" }],
+    );
+    expect(exo.isFloor).toBe(true);
+  });
+
+  it("empty submodulePath entries are dropped", () => {
+    const list = buildUnmountableList(
+      [
+        { submodulePath: "", url: "u" },
+        { submodulePath: "assetspaces/kitelev/exoas-pmbok-ontology", url: "u2" },
+      ],
+      [PMBOK_DESC],
+    );
+    expect(list).toHaveLength(1);
+    expect(list[0].submodulePath).toBe("assetspaces/kitelev/exoas-pmbok-ontology");
+  });
+
+  it("un-described non-floor mount → non-floor, label from path basename", () => {
+    const [orphan] = buildUnmountableList(
+      [{ submodulePath: "assetspaces/kitelev/exoas-orphan", url: "u" }],
+      [],
+    );
+    expect(orphan.isFloor).toBe(false);
+    expect(orphan.label).toBe("exoas-orphan");
   });
 });


### PR DESCRIPTION
## What

Standalone **unmount-assetspace** command — the inverse of `add-assetspace` — surfaced in both the Obsidian palette and the CLI (#e6b8827c).

Unmount mechanics already existed but ran **only inside** `apply-profile`'s strict mount-state replace; there was no on-demand single-AssetSpace unmount in either the palette or the CLI. This adds thin wrappers over the already-shipped, path-safe services — no engine change.

## Surfaces (UI/CLI Parity #3417)

- **Plugin** — `Exocortex: Unmount assetspace` (`UnmountAssetSpaceCommand`): fuzzy-picks a mounted AssetSpace (the `.gitmodules` registry, enriched with descriptor uid/namespace) and tears it down via the git-free cross-platform `RestAssetSpaceMount.unmount`. Registers on **desktop + mobile** when the REST mount is wired (Desktop↔Mobile Command Parity). Destructive, so a confirm gate is shown.
- **CLI** — `exocortex assetspace-remove --vault <path> (--folder <mount-path> | --url <url>)`: wraps the path-safe `BootstrapAssetSpaceService.unmountAssetSpace`, mirroring `assetspace-add` (`--url` derives the same canonical Maven path).

## TS-floor refuse (floor-policy A — "refuse, не rescue")

A TS-floor AssetSpace (**`{exo}`** per RFC 5aa2a73a / #3440 — `exocmd` + `shared-identities` are **optional**, NOT floor) is **refused** with no mutation, mirroring `apply-profile`'s R24 guard (tearing the floor down would self-brick the runtime). New shared **`isTsFloorAssetSpace`** helper (matched by legacy UID **OR** fork-safe `exo__AssetSpace_namespace`) is the single source of truth for both surfaces.

> Note: the source-task brief said "exo/exocmd/shared-identities cannot unmount", but origin/main collapsed the floor to `{exo}` only (RFC 5aa2a73a). The implementation follows the current code — `exocmd`/`shared-identities` are intentionally unmountable optional libraries.

## Tests (36 new, all green)

- `isTsFloorAssetSpace` — UID match, namespace match (EKA registry fork), exocmd/shared-identities NOT floor, empty-namespace non-match.
- Plugin `UnmountAssetSpaceCommand` — empty list, non-floor success + re-index, **floor refuse (no unmount)**, cancel, decline, unmount throws.
- CLI `assetspace-remove` — `resolveRemoveAssetSpacePath` derivation, **floor refuse by UID + by namespace**, non-floor success, un-described mount, `--json`, unmount throws.

**Revert-verify:** the floor-refuse guards were empirically confirmed — disabling them makes the floor-refuse tests FAIL (plugin 1, CLI 2); restoring makes them PASS.

`typecheck` clean · plugin `lint` clean · archgate 20/20.
