### PR TITLE
fix(#3548): harden apply-profile partial-failure atomicity on the REST path (zero-loss)

### DIFF
--- a/docs/profile.md
+++ b/docs/profile.md
@@ -279,28 +279,44 @@ The 2-phase design makes the **common** failure modes safe, but apply is **not
 fully atomic** on every partial failure. Know the exact boundary
 (tracked for hardening in [issue #3548](https://github.com/kitelev/exocortex/issues/3548)):
 
+> **Which path runs?** Since the git-elim cutover ([#3567](https://github.com/kitelev/exocortex/issues/3567))
+> apply routes through the **REST/tarball path on BOTH desktop and mobile**
+> (`restMountFactory` is wired unconditionally). The git-binary path below is a
+> legacy fallback only reached when neither `restMount` nor `restMountFactory`
+> is wired — in practice, tests.
+
 **Covered (safe):**
 
 - A failure **during Phase 1** (any pull fails) leaves the vault byte-identical
   to before the attempt — nothing is destroyed.
-- A **crash** mid-Phase-2 is reconciled on next onload: `recoverIncompleteSwitch()`
-  restores every destroyed-but-not-materialized AssetSpace from `SwitchCacheLayer`.
-- A cache-verify gate prevents a corrupt/zero-byte archive from authorizing a destroy.
+- **REST path (production, both platforms) — mount-before-unmount + rollback
+  ([#3548](https://github.com/kitelev/exocortex/issues/3548)):** the new
+  AssetSpaces are materialized **first**; the old set is torn down only once
+  every new one is confirmed present. A **mount failure** mid-apply rolls back
+  exactly what was added (`unmount` is idempotent — also clears a partially-pulled
+  folder), restoring the **exact pre-apply mount-state** with **zero data loss**
+  (only freshly-pulled content is removed) and leaving `activeProfileUid` at the
+  previous profile. The destructive unmount of the old set runs only after that,
+  so a failure **after** all mounts succeed leaves a benign **superset**
+  (target ∪ not-yet-removed) — never lost data; a re-run reconciles.
+- On a git-backed vault the REST path also honours the **uncommitted-changes
+  abort** (Vision Lock #5) for any to-destroy AssetSpace; on a git-free vault
+  (mobile / a vault never `git init`-ed) the check degrades gracefully and the
+  reorder provides the guarantee instead.
+- A **crash** mid-Phase-2 on the git path is reconciled on next onload:
+  `recoverIncompleteSwitch()` restores every destroyed-but-not-materialized
+  AssetSpace from `SwitchCacheLayer`. A cache-verify gate prevents a
+  corrupt/zero-byte archive from authorizing a destroy.
 
-**Not yet atomic (desktop):** if a step **fails** mid-Phase-2 (e.g. a
-`git submodule add` errors out on the 2nd of several AssetSpaces), the in-process
-catch restores the _destroyed_ AssetSpaces from cache (best-effort) but does **not**
-git-reset the working tree. The vault is therefore left with **uncommitted
-`.gitmodules`/submodule changes** and possibly one **partially-added** AssetSpace —
-the apply git-commit only runs on success. The vault content is recoverable, but
-not in a clean committed state until you re-run apply (which reconciles) or reload
-(which runs the recovery worker).
-
-**Not yet atomic (mobile / REST):** the mobile path does unmount-then-mount with
-**no rollback and no cache** — if a mount fails after an unmount, that AssetSpace
-is simply absent until you re-run apply. The state self-heals on re-run (mount-state
-is self-describing: folder-exists = active; REST mount/unmount are idempotent), but
-there is no automatic restore of an interrupted unmount.
+**Legacy git path only — not fully atomic:** if a step **fails** mid-Phase-2 on
+the git-binary fallback (e.g. a `git submodule add` errors out on the 2nd of
+several AssetSpaces), the in-process catch restores the _destroyed_ AssetSpaces
+from cache (best-effort) but does **not** git-reset the working tree. The vault is
+therefore left with **uncommitted `.gitmodules`/submodule changes** and possibly
+one **partially-added** AssetSpace — the apply git-commit only runs on success.
+The vault content is recoverable, but not in a clean committed state until you
+re-run apply (which reconciles) or reload (which runs the recovery worker). This
+path is no longer reached in production (see the routing note above).
 
 ### If an apply fails or is interrupted — recovery ordering
 
@@ -321,9 +337,10 @@ database write. In order:
    the vault manually once the mount-state is correct.
 
 To **minimize** the chance of hitting the window: commit (or stash) local changes
-before applying — the desktop path aborts on uncommitted changes in any to-destroy
-AssetSpace (Vision Lock #5) — and prefer a stable network/power state for a large
-cold apply (many AssetSpaces pulled sequentially).
+before applying — apply aborts on uncommitted changes in any to-destroy
+AssetSpace on a git-backed vault (Vision Lock #5; enforced on both the REST and
+git paths) — and prefer a stable network/power state for a large cold apply (many
+AssetSpaces pulled sequentially).
 
 ### Obsidian hangs at "Loading plugins…" after an apply
 

--- a/packages/obsidian-plugin/src/adapters/logging/activityFanIn.ts
+++ b/packages/obsidian-plugin/src/adapters/logging/activityFanIn.ts
@@ -26,6 +26,7 @@ const PHASE_LABELS: Record<SwitchJournalEntry["phase"], string> = {
   "git-commit-done": "Committed submodule pointers",
   "apply-completed": "Apply completed",
   "apply-failed": "Apply failed",
+  "rest-rollback-unmounted": "Rolled back mount (apply failed)",
   "recovery-restoring": "Recovering interrupted switch",
   "recovery-completed": "Recovery complete",
 };

--- a/packages/obsidian-plugin/src/adapters/logging/activityFanIn.ts
+++ b/packages/obsidian-plugin/src/adapters/logging/activityFanIn.ts
@@ -33,6 +33,9 @@ const PHASE_LABELS: Record<SwitchJournalEntry["phase"], string> = {
 
 function levelForPhase(phase: SwitchJournalEntry["phase"]): ActivityLevel {
   if (phase.includes("failed") || phase.includes("aborted")) return "error";
+  // #3548 — a rollback unmount is a recovery action on a failure path: surface
+  // it above plain "info" (the paired `apply-failed` entry carries "error").
+  if (phase === "rest-rollback-unmounted") return "warn";
   return "info";
 }
 

--- a/packages/obsidian-plugin/src/infrastructure/adapters/ProfileApplyManager.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/ProfileApplyManager.ts
@@ -152,6 +152,9 @@ export interface SwitchJournalEntry {
     | "git-commit-done"
     | "apply-completed"
     | "apply-failed"
+    // #3548 — REST partial-failure rollback: a freshly-mounted AssetSpace was
+    // unmounted to restore the pre-apply mount-state after a mid-apply failure.
+    | "rest-rollback-unmounted"
     | "recovery-restoring"
     | "recovery-completed";
   targetUid: string;
@@ -1133,6 +1136,17 @@ export class ProfileApplyManager {
       } catch {
         // Swallow — original error takes precedence.
       }
+      // #3548 — actionable user-facing failure message (legacy git path; in
+      // production #3567 routes desktop through the REST path, but this remains
+      // the tested fallback for wiring that omits restMount). Unlike the REST
+      // path this is NOT a full transactional rollback (cache-restore is
+      // best-effort + any submodule added before the failure stays untracked),
+      // so point the user at the recovery worker (reload) or a reconciling
+      // re-run rather than promising a clean tree.
+      this.notify(
+        `Apply failed — the vault may be partially applied. Reload Obsidian ` +
+          `(recovery restores unmounted AssetSpaces from cache) or re-run Apply to reconcile.`,
+      );
       // Clear in-progress flag so subsequent operations не see stuck state.
       try {
         const s = deps.localDataStore.snapshot();
@@ -1253,6 +1267,38 @@ export class ProfileApplyManager {
       }
     }
 
+    // Vision Lock #5 parity (#3548) — uncommitted-changes abort on the REST
+    // path. Post-#3567 the REST path runs on desktop too (git-backed vaults),
+    // so honour the same uncommitted-edits guard the desktop git path enforces.
+    // Scope = only the to-destroy AssetSpaces (their folders will be removed).
+    // Guarded: the guard is desktop-only (gitOps-backed) and absent on mobile,
+    // and even on desktop a vault the user never `git init`-ed makes
+    // `git status` throw `fatal: not a git repository` — in either case we
+    // cannot determine dirtiness, so we degrade gracefully and proceed (the
+    // mount-before-unmount reorder below provides the atomicity guarantee on
+    // git-free vaults). A genuine dirty result still aborts before any mutation.
+    if (this.uncommittedGuard !== undefined && toDestroy.length > 0) {
+      try {
+        const uncommitted = await this.uncommittedGuard.check(
+          toDestroy.map((t) => ({ asUid: t.asUid, submodulePath: t.submodulePath })),
+        );
+        if (!uncommitted.clean) {
+          const total = uncommitted.affectedFiles.reduce((s, a) => s + a.files.length, 0);
+          throw new UncommittedChangesAbortError(
+            `Apply aborted — ${total} uncommitted file(s) in ${uncommitted.affectedFiles.length} AssetSpace(s) this profile would remove. ` +
+              `Commit or stash the vault before applying. On a fresh git-backed vault, Bootstrap / Add-AssetSpace leave the pulled ` +
+              `assetspaces/ untracked — run \`git add -A && git commit -m "vault setup"\` first (and gitignore \`.obsidian/\` + ` +
+              `\`.exocortex/\` so your PAT is never committed). See docs/profile.md → "Apply on a git-backed vault (commit first)".`,
+            uncommitted.affectedFiles,
+          );
+        }
+      } catch (e) {
+        // A real dirty-tree abort must propagate; a git-unavailable error
+        // (mobile / non-git desktop vault) must NOT — proceed (reorder covers it).
+        if (e instanceof UncommittedChangesAbortError) throw e;
+      }
+    }
+
     // 3. Build plan + ConfirmGate (destructive — unmount removes folders).
     const filesToDestroyMap = new Map<string, string[]>();
     for (const target of toDestroy) {
@@ -1340,6 +1386,11 @@ export class ProfileApplyManager {
     // Generation claim AFTER acquire (code-review LOW) — see runApplyMutation.
     const myGen = ++this.applyGeneration;
     let heartbeatTimer: ReturnType<typeof setInterval> | null = null;
+    // #3548 atomicity bookkeeping: AssetSpaces mounted THIS run (for rollback on
+    // mount-failure) + whether the mount loop completed (so the catch surfaces
+    // "rolled back to previous profile" vs "partially applied — re-run").
+    const mountedThisRun: Array<{ asUid: string; submodulePath: string }> = [];
+    let mountsComplete = false;
     try {
       // ExoSync D11 re-check (code-reviewer MEDIUM, PR #3461) — same
       // pre-flag window as the desktop path; see applyProfile.
@@ -1363,21 +1414,50 @@ export class ProfileApplyManager {
         void this.lockMgr.heartbeat();
       }, 30_000);
 
-      // Unmount removed AssetSpaces (rm folder + strip .gitmodules stanza).
-      for (const target of toDestroy) {
-        await restMount.unmount(target.submodulePath);
+      // #3548 — MOUNT-BEFORE-UNMOUNT for partial-failure atomicity. The new set
+      // is materialized FIRST; the old set is torn down only once every new
+      // AssetSpace is confirmed present. On a mount failure mid-loop nothing has
+      // been unmounted yet, so the pre-apply mount-state is fully recoverable by
+      // unmounting just what we added (zero data loss — only freshly-pulled
+      // AssetSpaces are removed). This replaces the prior unmount-then-mount
+      // ordering whose mount-failure window left the to-destroy set already gone
+      // with no rollback (REST has no SwitchCacheLayer).
+      // Mount new AssetSpaces (REST tarball → vault folder + .gitmodules entry).
+      for (const target of toMaterialize) {
+        try {
+          await restMount.mount(target.gitUrl, target.submodulePath, target.ref);
+        } catch (mountErr) {
+          // Roll back EVERY AssetSpace mounted this run (incl. the partial
+          // failed one — `unmount` is idempotent: it strips the `.gitmodules`
+          // stanza and removes the folder even if `mount` threw before its
+          // `.gitmodules` append). `toDestroy` was never touched, so this
+          // restores the EXACT pre-apply mount-state.
+          await this.rollbackRestMounts(
+            restMount,
+            [...mountedThisRun, { asUid: target.asUid, submodulePath: target.submodulePath }],
+            targetProfileUid,
+          );
+          throw mountErr;
+        }
+        mountedThisRun.push({ asUid: target.asUid, submodulePath: target.submodulePath });
         await this.appendJournal({
-          phase: "phase2-destroyed",
+          phase: "phase2-materialized",
           targetUid: targetProfileUid,
           as: target.asUid,
           ts: this.now().toISOString(),
         });
       }
-      // Mount new AssetSpaces (REST tarball → vault folder + .gitmodules entry).
-      for (const target of toMaterialize) {
-        await restMount.mount(target.gitUrl, target.submodulePath, target.ref);
+      // Every new AssetSpace is present — now safe to unmount the old set. A
+      // failure HERE leaves a SUPERSET (target ∪ not-yet-removed) — never data
+      // loss (the un-removed AssetSpaces were slated for removal anyway), and
+      // re-running Apply reconciles. Mark the boundary so the catch can surface
+      // the right actionable message.
+      mountsComplete = true;
+      // Unmount removed AssetSpaces (rm folder + strip .gitmodules stanza).
+      for (const target of toDestroy) {
+        await restMount.unmount(target.submodulePath);
         await this.appendJournal({
-          phase: "phase2-materialized",
+          phase: "phase2-destroyed",
           targetUid: targetProfileUid,
           as: target.asUid,
           ts: this.now().toISOString(),
@@ -1410,6 +1490,17 @@ export class ProfileApplyManager {
         ts: this.now().toISOString(),
         error: this.redactError(String(e)),
       });
+      // #3548 — actionable user-facing failure message describing the
+      // partial-applied state + recovery action. `mountsComplete` distinguishes
+      // the two outcomes: pre-unmount failure → rolled back to the previous
+      // profile (nothing lost); post-mount failure → superset left mounted.
+      this.notify(
+        mountsComplete
+          ? `Apply failed during cleanup of "${targetProfileLabel}" — the new AssetSpaces are mounted but the old set was not fully removed. ` +
+              `No data was lost; re-run Apply to reconcile.`
+          : `Apply failed — vault rolled back to the previous profile (no changes applied). ` +
+              `Check your connection / GitHub token and re-run Apply.`,
+      );
       // Clear in-progress so subsequent operations don't see stuck state.
       try {
         const s = localDataStore.snapshot();
@@ -1426,6 +1517,43 @@ export class ProfileApplyManager {
       // Release only if still the active generation (code-review LOW) — see
       // runApplyMutation.
       if (this.applyGeneration === myGen) await this.lockMgr.releaseLock();
+    }
+  }
+
+  /**
+   * #3548 — roll back AssetSpaces freshly mounted during a REST apply that then
+   * failed. Each {@link RestAssetSpaceMount.unmount} is idempotent (strips the
+   * `.gitmodules` stanza + removes the folder, no-op if absent), so this safely
+   * cleans up both fully-mounted and partially-materialized AssetSpaces. Since
+   * the to-destroy set is never touched until ALL mounts succeed, unmounting
+   * only what we added restores the EXACT pre-apply mount-state. Best-effort: a
+   * failed rollback unmount is journalled but never masks the original error
+   * (leaving a freshly-pulled AssetSpace in place is a benign superset that a
+   * re-run reconciles — never user data loss).
+   */
+  private async rollbackRestMounts(
+    restMount: RestAssetSpaceMount,
+    mounted: ReadonlyArray<{ asUid: string; submodulePath: string }>,
+    targetProfileUid: string,
+  ): Promise<void> {
+    for (const target of mounted) {
+      try {
+        await restMount.unmount(target.submodulePath);
+        await this.appendJournal({
+          phase: "rest-rollback-unmounted",
+          targetUid: targetProfileUid,
+          as: target.asUid,
+          ts: this.now().toISOString(),
+        });
+      } catch (err) {
+        await this.appendJournal({
+          phase: "rest-rollback-unmounted",
+          targetUid: targetProfileUid,
+          as: target.asUid,
+          ts: this.now().toISOString(),
+          error: this.redactError(String(err)),
+        });
+      }
     }
   }
 

--- a/packages/obsidian-plugin/src/infrastructure/adapters/ProfileApplyManager.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/ProfileApplyManager.ts
@@ -1293,9 +1293,16 @@ export class ProfileApplyManager {
           );
         }
       } catch (e) {
-        // A real dirty-tree abort must propagate; a git-unavailable error
-        // (mobile / non-git desktop vault) must NOT — proceed (reorder covers it).
+        // A real dirty-tree abort must always propagate.
         if (e instanceof UncommittedChangesAbortError) throw e;
+        // Otherwise: ONLY a git-unavailable error (the vault is not a git repo,
+        // or no `git` binary) means "no commit concept → can't check → proceed"
+        // (the mount-before-unmount reorder is the atomicity guarantee there).
+        // Any OTHER error (e.g. transient `index.lock`, an unexpected guard bug)
+        // leaves cleanliness INDETERMINATE — and silently proceeding could
+        // discard uncommitted edits in a to-destroy AssetSpace. Per the zero-loss
+        // mandate we fail loud instead so the user retries rather than lose work.
+        if (!ProfileApplyManager.isGitUnavailableError(e)) throw e;
       }
     }
 
@@ -1518,6 +1525,22 @@ export class ProfileApplyManager {
       // runApplyMutation.
       if (this.applyGeneration === myGen) await this.lockMgr.releaseLock();
     }
+  }
+
+  /**
+   * #3548 — classify an {@link UncommittedChangesGuard} failure: was git simply
+   * UNAVAILABLE (the vault is not a git repo, or no `git` binary on PATH), in
+   * which case "uncommitted relative to HEAD" is undefined and the REST apply
+   * proceeds (the mount-before-unmount reorder is the guarantee)? Any OTHER
+   * error is treated as indeterminate → fail loud (caller re-throws). The guard
+   * surfaces git stderr inside the thrown message (`… — stderr: fatal: not a git
+   * repository …`), and a missing binary surfaces as `spawn git ENOENT`.
+   */
+  private static isGitUnavailableError(e: unknown): boolean {
+    const msg = e instanceof Error ? e.message : String(e);
+    return /not a git repository|spawn git|git:? not found|command not found|ENOENT/i.test(
+      msg,
+    );
   }
 
   /**

--- a/packages/obsidian-plugin/tests/unit/ProfileApplyManager.restAtomicity.test.ts
+++ b/packages/obsidian-plugin/tests/unit/ProfileApplyManager.restAtomicity.test.ts
@@ -1,0 +1,556 @@
+/**
+ * ProfileApplyManager — REST apply partial-failure atomicity (Issue #3548).
+ *
+ * Since the git-elim cutover (#3567) `applyProfile` routes BOTH platforms
+ * through the REST path (`applyProfileViaRest` → `runRestApplyMutation`) whenever
+ * `restMount`/`restMountFactory` is wired — which production does
+ * unconditionally (ExocortexPlugin wires `restMountFactory` with no platform
+ * gate). So the REST path is the SOLE production atomicity surface; the git
+ * path (`runApplyMutation`) is a legacy/test-only fallback.
+ *
+ * This suite pins the partial-failure hardening:
+ *
+ *   1. MOUNT-BEFORE-UNMOUNT — materialize the new set FIRST; only tear down the
+ *      old set once every new AssetSpace is confirmed present. On a mount
+ *      failure mid-loop nothing has been unmounted yet → the to-destroy set is
+ *      untouched (zero data loss).
+ *   2. ROLLBACK on mount-failure — the freshly-mounted AssetSpaces (incl. the
+ *      partial failed one) are unmounted, restoring the EXACT pre-apply
+ *      mount-state. `activeProfileUid` stays at the pre-apply value.
+ *   3. uncommittedGuard PARITY — when wired (desktop git-backed vault) a dirty
+ *      to-destroy AssetSpace aborts before any mutation (Vision Lock #5 parity);
+ *      when git is unavailable (mobile / non-git desktop vault) the check
+ *      degrades gracefully (proceeds — the reorder provides the guarantee).
+ *   4. UNMOUNT-failure after all mounts → SUPERSET (target ∪ not-yet-removed) —
+ *      never data loss; re-running Apply reconciles.
+ *   5. Actionable user-facing failure message on the failure path.
+ *
+ * Each test is a revert-verify control: with the previous unmount-then-mount,
+ * no-rollback ordering the atomicity assertions FAIL; with the fix they PASS.
+ *
+ * Fakes mirror ProfileApplyManager.restApply.test.ts: in-memory vault.adapter,
+ * production-shape AssetSpace ABox frontmatter (`_source` derives back to the
+ * folder via derivePath), a FakeLocalDataStore preserving the dual AC14 slots.
+ */
+import type { App, TFile } from "obsidian";
+import type { ApplyPlan, IConfirmGate } from "exocortex";
+
+import {
+  ProfileApplyManager,
+  UncommittedChangesAbortError,
+  type IProfileResolver,
+  type IRdfIndexer,
+  type ISettingsStore,
+  type ProfileResolution,
+  type SwitchSettings,
+} from "../../src/infrastructure/adapters/ProfileApplyManager";
+import { PluginLockManager } from "../../src/infrastructure/adapters/PluginLockManager";
+import {
+  TS_FLOOR_AS_UID_EXO,
+  TS_FLOOR_AS_UID_EXOCMD,
+  TS_FLOOR_AS_UID_SHARED_IDENTITIES,
+} from "../../src/infrastructure/adapters/ProfileOnloadWiring";
+
+// ─── Fakes ────────────────────────────────────────────────────────────────
+
+interface FakeFile {
+  path: string;
+  basename: string;
+  frontmatter: Record<string, unknown>;
+}
+
+function makeFakeApp(files: FakeFile[]): {
+  app: App;
+  fsFolders: Map<string, { files: string[]; folders: string[] }>;
+} {
+  const fsFiles = new Map<string, string>();
+  const fsFolders = new Map<string, { files: string[]; folders: string[] }>();
+  const tfiles: TFile[] = files.map(
+    (f) => ({ path: f.path, basename: f.basename }) as unknown as TFile,
+  );
+  const frontmatterByPath = new Map<string, Record<string, unknown>>();
+  for (const f of files) frontmatterByPath.set(f.path, f.frontmatter);
+
+  const app = {
+    vault: {
+      getMarkdownFiles: () => tfiles,
+      adapter: {
+        exists: async (p: string) => fsFiles.has(p) || fsFolders.has(p),
+        read: async (p: string) => {
+          const v = fsFiles.get(p);
+          if (v === undefined) throw new Error(`ENOENT: ${p}`);
+          return v;
+        },
+        write: async (p: string, d: string) => {
+          fsFiles.set(p, d);
+        },
+        list: async (dir: string) =>
+          fsFolders.get(dir) ?? { files: [], folders: [] },
+      },
+    },
+    metadataCache: {
+      getFileCache: (file: TFile) => {
+        const fm = frontmatterByPath.get(file.path);
+        return fm ? { frontmatter: fm } : null;
+      },
+    },
+  } as unknown as App;
+  return { app, fsFolders };
+}
+
+class FakeResolver implements IProfileResolver {
+  constructor(private readonly profiles: Map<string, ProfileResolution>) {}
+  async resolve(uid: string): Promise<ProfileResolution | null> {
+    return this.profiles.get(uid) ?? null;
+  }
+  async discoverSharedOntologies(): Promise<string[]> {
+    return [];
+  }
+}
+
+class FakeIndexer implements IRdfIndexer {
+  refreshCalls = 0;
+  async refresh(): Promise<void> {
+    this.refreshCalls++;
+  }
+}
+
+class FakeSettingsStore implements ISettingsStore {
+  state: SwitchSettings = { activeProfileUid: null, _switchInProgress: false };
+  async load(): Promise<SwitchSettings> {
+    return { ...this.state };
+  }
+  async save(s: SwitchSettings): Promise<void> {
+    this.state = { ...s };
+  }
+}
+
+interface FakeLocalState {
+  activeProfileUid: string | null;
+  _switchInProgress: boolean;
+}
+
+class FakeLocalDataStore {
+  private state: FakeLocalState = {
+    activeProfileUid: null,
+    _switchInProgress: false,
+  };
+  setActiveProfileUid(uid: string | null): void {
+    this.state.activeProfileUid = uid;
+  }
+  getActiveProfileUid(): string | null {
+    return this.state.activeProfileUid;
+  }
+  isSwitchInProgress(): boolean {
+    return this.state._switchInProgress;
+  }
+  snapshot(): FakeLocalState {
+    return { ...this.state };
+  }
+  async save(s: {
+    activeProfileUid: string | null;
+    _switchInProgress: boolean;
+  }): Promise<void> {
+    this.state = {
+      activeProfileUid: s.activeProfileUid,
+      _switchInProgress: s._switchInProgress,
+    };
+  }
+}
+
+class FakeConfirmGate implements IConfirmGate {
+  approve = true;
+  lastPlan: ApplyPlan | null = null;
+  async confirmApply(plan: ApplyPlan): Promise<boolean> {
+    this.lastPlan = plan;
+    return this.approve;
+  }
+}
+
+/**
+ * REST mount fake with an ordered op log + failure injection. Mirrors the real
+ * RestAssetSpaceMount contract closely enough for atomicity testing:
+ *   - mount: appends the folder to `fsFolders` (so a subsequent
+ *     `derivePhysicallyMaterializedAsUids` sees it present) THEN records.
+ *     A failed mount may leave a partial folder (mirrors files-then-.gitmodules).
+ *   - unmount: removes the folder from `fsFolders` (idempotent — no-op if absent).
+ */
+class FakeRestMount {
+  ops: Array<{ op: "mount" | "unmount"; path: string }> = [];
+  mounted: string[] = [];
+  unmounted: string[] = [];
+  /** submodulePath → throw on mount. */
+  failMountOn = new Set<string>();
+  /** submodulePath → throw on unmount. */
+  failUnmountOn = new Set<string>();
+  /** Whether a failed mount leaves a partial folder behind (real-world). */
+  partialFolderOnFailedMount = true;
+
+  constructor(
+    private readonly fsFolders: Map<
+      string,
+      { files: string[]; folders: string[] }
+    >,
+  ) {}
+
+  async mount(gitUrl: string, submodulePath: string, ref: string) {
+    if (this.failMountOn.has(submodulePath)) {
+      if (this.partialFolderOnFailedMount) {
+        // Partial materialize: files written, folder exists, but the mount
+        // threw before the `.gitmodules` append completed.
+        this.fsFolders.set(submodulePath, {
+          files: [`${submodulePath}/partial.md`],
+          folders: [],
+        });
+      }
+      this.ops.push({ op: "mount", path: submodulePath });
+      throw new Error(`mount failed: ${submodulePath} (injected)`);
+    }
+    this.fsFolders.set(submodulePath, {
+      files: [`${submodulePath}/f1.md`],
+      folders: [],
+    });
+    this.ops.push({ op: "mount", path: submodulePath });
+    this.mounted.push(submodulePath);
+    return { sha: "abc1234", fileCount: 1 };
+  }
+
+  async unmount(submodulePath: string): Promise<void> {
+    if (this.failUnmountOn.has(submodulePath)) {
+      this.ops.push({ op: "unmount", path: submodulePath });
+      throw new Error(`unmount failed: ${submodulePath} (injected)`);
+    }
+    this.fsFolders.delete(submodulePath);
+    this.ops.push({ op: "unmount", path: submodulePath });
+    this.unmounted.push(submodulePath);
+  }
+}
+
+/** uncommittedGuard fake — configurable clean/dirty/throwing. */
+class FakeUncommittedGuard {
+  dirtyPaths = new Set<string>();
+  throwOnCheck = false;
+  checkCalls = 0;
+  async check(
+    toDestroy: ReadonlyArray<{ asUid: string; submodulePath: string }>,
+  ): Promise<{
+    clean: boolean;
+    affectedFiles: ReadonlyArray<{
+      asUid: string;
+      submodulePath: string;
+      files: ReadonlyArray<string>;
+    }>;
+  }> {
+    this.checkCalls++;
+    if (this.throwOnCheck) {
+      // Mirrors a non-git vault: `git status` → `fatal: not a git repository`.
+      throw new Error("fatal: not a git repository (injected)");
+    }
+    const affected = toDestroy
+      .filter((t) => this.dirtyPaths.has(t.submodulePath))
+      .map((t) => ({
+        asUid: t.asUid,
+        submodulePath: t.submodulePath,
+        files: [`${t.submodulePath}/dirty.md`],
+      }));
+    return { clean: affected.length === 0, affectedFiles: affected };
+  }
+}
+
+// ─── AssetSpace fixtures ────────────────────────────────────────────────────
+
+const TS_FLOOR = [
+  { uid: TS_FLOOR_AS_UID_EXO, folder: "assetspaces/kitelev/exoas-exo" },
+  { uid: TS_FLOOR_AS_UID_EXOCMD, folder: "assetspaces/kitelev/exoas-exocmd" },
+  {
+    uid: TS_FLOOR_AS_UID_SHARED_IDENTITIES,
+    folder: "assetspaces/kitelev/exoas-shared-identities",
+  },
+];
+const EXTRA = [
+  { uid: "ems-uid", folder: "assetspaces/kitelev/exoas-ems" },
+  { uid: "kpc-uid", folder: "assetspaces/kitelev/exoas-kpc" },
+  { uid: "lit-uid", folder: "assetspaces/kitelev/exoas-lit" },
+  { uid: "pn-uid", folder: "assetspaces/kitelev/exoas-pn" },
+];
+const ALL_AS = [...TS_FLOOR, ...EXTRA];
+const ALL_FLOOR_UIDS = TS_FLOOR.map((f) => f.uid);
+const folderOf = (uid: string) =>
+  ALL_AS.find((a) => a.uid === uid)?.folder ?? `assetspaces/kitelev/${uid}`;
+
+interface SetupOpts {
+  targetIncludes: string[];
+  materialized: string[];
+  /** Pre-apply active profile (defaults to a "source" sentinel). */
+  activeProfileUid?: string | null;
+  /** Wire the uncommittedGuard (desktop git-backed). Default: not wired. */
+  wireUncommittedGuard?: boolean;
+}
+
+function setup(opts: SetupOpts) {
+  const files: FakeFile[] = [
+    {
+      path: "profiles/target.md",
+      basename: "target",
+      frontmatter: {
+        exo__Asset_uid: "target",
+        exo__Asset_label: "Target Profile",
+        exo__Instance_class: ["[[exo__Profile]]"],
+      },
+    },
+    ...ALL_AS.map((as) => {
+      const ns = as.folder.split("/").pop();
+      return {
+        path: `${as.folder}/${as.uid}.md`,
+        basename: as.uid,
+        frontmatter: {
+          exo__Asset_uid: as.uid,
+          exo__Asset_label: ns,
+          exo__Instance_class: ["[[exo__AssetSpace]]"],
+          exo__AssetSpace_source: `https://github.com/${as.folder.replace("assetspaces/", "")}`,
+          exo__AssetSpace_namespace: ns,
+        },
+      };
+    }),
+  ];
+
+  const { app, fsFolders } = makeFakeApp(files);
+  for (const uid of opts.materialized) {
+    const folder = folderOf(uid);
+    fsFolders.set(folder, {
+      files: [`${folder}/file1.md`, `${folder}/file2.md`],
+      folders: [],
+    });
+  }
+
+  const resolver = new FakeResolver(
+    new Map<string, ProfileResolution>([
+      [
+        "target",
+        { uid: "target", includes: opts.targetIncludes, label: "Target Profile" },
+      ],
+    ]),
+  );
+  const indexer = new FakeIndexer();
+  const settingsStore = new FakeSettingsStore();
+  const lockMgr = new PluginLockManager({ app });
+  const localDataStore = new FakeLocalDataStore();
+  localDataStore.setActiveProfileUid(
+    opts.activeProfileUid === undefined ? "source" : opts.activeProfileUid,
+  );
+  const confirmGate = new FakeConfirmGate();
+  const restMount = new FakeRestMount(fsFolders);
+  const uncommittedGuard = new FakeUncommittedGuard();
+  const notifyCalls: string[] = [];
+
+  const mgr = new ProfileApplyManager({
+    app,
+    lockMgr,
+    resolver,
+    rdfIndexer: indexer,
+    settingsStore,
+    notify: (m) => notifyCalls.push(m),
+    /* eslint-disable @typescript-eslint/no-explicit-any */
+    confirmGate,
+    localDataStore: localDataStore as any,
+    restMount: restMount as any,
+    uncommittedGuard: (opts.wireUncommittedGuard
+      ? uncommittedGuard
+      : undefined) as any,
+    /* eslint-enable @typescript-eslint/no-explicit-any */
+  });
+  return {
+    mgr,
+    indexer,
+    localDataStore,
+    confirmGate,
+    restMount,
+    uncommittedGuard,
+    notifyCalls,
+    app,
+    fsFolders,
+  };
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────
+
+describe("ProfileApplyManager REST apply atomicity (#3548)", () => {
+  describe("mount-before-unmount ordering", () => {
+    it("mounts the new set BEFORE unmounting the old set (revert-verify)", async () => {
+      const { mgr, restMount } = setup({
+        targetIncludes: [...ALL_FLOOR_UIDS, "ems-uid"],
+        materialized: [...ALL_FLOOR_UIDS, "kpc-uid"],
+      });
+
+      await mgr.applyProfileViaRest("target");
+
+      // ems mounted, kpc unmounted.
+      expect(restMount.mounted).toEqual([folderOf("ems-uid")]);
+      expect(restMount.unmounted).toEqual([folderOf("kpc-uid")]);
+      // Ordering invariant: the mount happens before the unmount.
+      const mountIdx = restMount.ops.findIndex((o) => o.op === "mount");
+      const unmountIdx = restMount.ops.findIndex((o) => o.op === "unmount");
+      expect(mountIdx).toBeGreaterThanOrEqual(0);
+      expect(unmountIdx).toBeGreaterThanOrEqual(0);
+      // Pre-fix (unmount-then-mount): unmountIdx < mountIdx → FAILS here.
+      expect(mountIdx).toBeLessThan(unmountIdx);
+    });
+  });
+
+  describe("mount-failure → rollback to exact pre-apply set (zero data loss)", () => {
+    it("never tears down the to-destroy set when a mount fails mid-loop (revert-verify)", async () => {
+      // toMaterialize = [ems, lit]; toDestroy = [kpc]. Fail on the 2nd mount.
+      const { mgr, restMount, localDataStore, fsFolders } = setup({
+        targetIncludes: [...ALL_FLOOR_UIDS, "ems-uid", "lit-uid"],
+        materialized: [...ALL_FLOOR_UIDS, "kpc-uid"],
+      });
+      restMount.failMountOn.add(folderOf("lit-uid"));
+
+      await expect(mgr.applyProfileViaRest("target")).rejects.toThrow(
+        /mount failed/,
+      );
+
+      // CORE INVARIANT (flips pre↔post fix): the to-destroy AssetSpace must
+      // NEVER be unmounted on a mount-failure. Pre-fix (unmount-first) kpc is
+      // gone → FAILS. Post-fix kpc is untouched → PASSES.
+      expect(restMount.unmounted).not.toContain(folderOf("kpc-uid"));
+      // kpc folder still on disk → still materialized (pre-apply state intact).
+      expect(fsFolders.has(folderOf("kpc-uid"))).toBe(true);
+
+      // The freshly-mounted set is rolled back → exact pre-apply mount-state.
+      expect(fsFolders.has(folderOf("ems-uid"))).toBe(false);
+      expect(fsFolders.has(folderOf("lit-uid"))).toBe(false);
+
+      // Active profile unchanged + in-progress flag cleared.
+      expect(localDataStore.getActiveProfileUid()).toBe("source");
+      expect(localDataStore.isSwitchInProgress()).toBe(false);
+    });
+
+    it("rolls back the partial folder of the failed mount itself", async () => {
+      const { mgr, restMount, fsFolders } = setup({
+        targetIncludes: [...ALL_FLOOR_UIDS, "ems-uid"],
+        materialized: [...ALL_FLOOR_UIDS, "kpc-uid"],
+      });
+      // The single to-materialize mount fails, leaving a partial folder.
+      restMount.failMountOn.add(folderOf("ems-uid"));
+      restMount.partialFolderOnFailedMount = true;
+
+      await expect(mgr.applyProfileViaRest("target")).rejects.toThrow(
+        /mount failed/,
+      );
+
+      // The partial folder left by the failed mount is cleaned up by rollback.
+      expect(fsFolders.has(folderOf("ems-uid"))).toBe(false);
+      // kpc (to-destroy) untouched.
+      expect(restMount.unmounted).not.toContain(folderOf("kpc-uid"));
+      expect(fsFolders.has(folderOf("kpc-uid"))).toBe(true);
+    });
+
+    it("surfaces an actionable rollback failure message", async () => {
+      const { mgr, restMount, notifyCalls } = setup({
+        targetIncludes: [...ALL_FLOOR_UIDS, "ems-uid"],
+        materialized: [...ALL_FLOOR_UIDS, "kpc-uid"],
+      });
+      restMount.failMountOn.add(folderOf("ems-uid"));
+
+      await expect(mgr.applyProfileViaRest("target")).rejects.toThrow();
+
+      const msg = notifyCalls.find((m) => /re-run/i.test(m));
+      expect(msg).toBeDefined();
+      // Rolled-back path → reassures the previous profile is intact.
+      expect(msg).toMatch(/previous profile|rolled back|no changes/i);
+    });
+  });
+
+  describe("unmount-failure after all mounts → superset, no data loss", () => {
+    it("keeps the target set mounted and surfaces an actionable message", async () => {
+      // toMaterialize = [ems]; toDestroy = [kpc, lit]. Unmount fails on lit.
+      const { mgr, restMount, notifyCalls, fsFolders } = setup({
+        targetIncludes: [...ALL_FLOOR_UIDS, "ems-uid"],
+        materialized: [...ALL_FLOOR_UIDS, "kpc-uid", "lit-uid"],
+      });
+      restMount.failUnmountOn.add(folderOf("lit-uid"));
+
+      await expect(mgr.applyProfileViaRest("target")).rejects.toThrow(
+        /unmount failed/,
+      );
+
+      // Target AssetSpace mounted (all mounts completed before any unmount).
+      expect(restMount.mounted).toContain(folderOf("ems-uid"));
+      expect(fsFolders.has(folderOf("ems-uid"))).toBe(true);
+      // kpc unmounted (succeeded); lit still present (its unmount threw) — NOT
+      // a data loss: lit was slated for removal; re-running Apply reconciles.
+      expect(restMount.unmounted).toContain(folderOf("kpc-uid"));
+      expect(fsFolders.has(folderOf("lit-uid"))).toBe(true);
+      // The newly-mounted set is NOT rolled back (mounts completed).
+      expect(restMount.unmounted).not.toContain(folderOf("ems-uid"));
+
+      const msg = notifyCalls.find((m) => /re-run/i.test(m));
+      expect(msg).toBeDefined();
+    });
+  });
+
+  describe("uncommittedGuard parity (Vision Lock #5)", () => {
+    it("aborts before any mutation when a to-destroy AssetSpace is dirty (git-backed)", async () => {
+      const { mgr, restMount, uncommittedGuard, localDataStore } = setup({
+        targetIncludes: [...ALL_FLOOR_UIDS, "ems-uid"],
+        materialized: [...ALL_FLOOR_UIDS, "kpc-uid"],
+        wireUncommittedGuard: true,
+      });
+      uncommittedGuard.dirtyPaths.add(folderOf("kpc-uid"));
+
+      await expect(mgr.applyProfileViaRest("target")).rejects.toThrow(
+        UncommittedChangesAbortError,
+      );
+
+      // Revert-verify: pre-fix the REST path never calls the guard → no abort →
+      // it proceeds to mount/unmount → this `rejects(UncommittedChangesAbortError)`
+      // FAILS. Post-fix the guard is consulted → abort BEFORE any mutation.
+      expect(uncommittedGuard.checkCalls).toBe(1);
+      expect(restMount.mounted).toEqual([]);
+      expect(restMount.unmounted).toEqual([]);
+      expect(localDataStore.getActiveProfileUid()).toBe("source");
+    });
+
+    it("proceeds when the to-destroy set is clean (git-backed, parity happy path)", async () => {
+      const { mgr, restMount, uncommittedGuard } = setup({
+        targetIncludes: [...ALL_FLOOR_UIDS, "ems-uid"],
+        materialized: [...ALL_FLOOR_UIDS, "kpc-uid"],
+        wireUncommittedGuard: true,
+      });
+
+      await mgr.applyProfileViaRest("target");
+
+      expect(uncommittedGuard.checkCalls).toBe(1);
+      expect(restMount.mounted).toEqual([folderOf("ems-uid")]);
+      expect(restMount.unmounted).toEqual([folderOf("kpc-uid")]);
+    });
+
+    it("degrades gracefully when git is unavailable (mobile / non-git vault)", async () => {
+      const { mgr, restMount, uncommittedGuard } = setup({
+        targetIncludes: [...ALL_FLOOR_UIDS, "ems-uid"],
+        materialized: [...ALL_FLOOR_UIDS, "kpc-uid"],
+        wireUncommittedGuard: true,
+      });
+      uncommittedGuard.throwOnCheck = true; // `fatal: not a git repository`
+
+      // A git-unavailable check must NOT hard-fail the apply — the mount-before
+      // -unmount reorder provides the atomicity guarantee on git-free vaults.
+      await expect(mgr.applyProfileViaRest("target")).resolves.toBeUndefined();
+      expect(restMount.mounted).toEqual([folderOf("ems-uid")]);
+      expect(restMount.unmounted).toEqual([folderOf("kpc-uid")]);
+    });
+
+    it("does not require uncommittedGuard to be wired (mobile path)", async () => {
+      const { mgr, restMount } = setup({
+        targetIncludes: [...ALL_FLOOR_UIDS, "ems-uid"],
+        materialized: [...ALL_FLOOR_UIDS, "kpc-uid"],
+        // wireUncommittedGuard omitted → undefined (mobile reality).
+      });
+
+      await mgr.applyProfileViaRest("target");
+      expect(restMount.mounted).toEqual([folderOf("ems-uid")]);
+      expect(restMount.unmounted).toEqual([folderOf("kpc-uid")]);
+    });
+  });
+});

--- a/packages/obsidian-plugin/tests/unit/ProfileApplyManager.restAtomicity.test.ts
+++ b/packages/obsidian-plugin/tests/unit/ProfileApplyManager.restAtomicity.test.ts
@@ -230,6 +230,8 @@ class FakeRestMount {
 class FakeUncommittedGuard {
   dirtyPaths = new Set<string>();
   throwOnCheck = false;
+  /** When set, `check` throws this exact message (to test error classification). */
+  throwMessage = "fatal: not a git repository (injected)";
   checkCalls = 0;
   async check(
     toDestroy: ReadonlyArray<{ asUid: string; submodulePath: string }>,
@@ -243,8 +245,9 @@ class FakeUncommittedGuard {
   }> {
     this.checkCalls++;
     if (this.throwOnCheck) {
-      // Mirrors a non-git vault: `git status` → `fatal: not a git repository`.
-      throw new Error("fatal: not a git repository (injected)");
+      // Default mirrors a non-git vault: `git status` → `fatal: not a git
+      // repository`. Override `throwMessage` to test a non-git-unavailable error.
+      throw new Error(this.throwMessage);
     }
     const affected = toDestroy
       .filter((t) => this.dirtyPaths.has(t.submodulePath))
@@ -539,6 +542,26 @@ describe("ProfileApplyManager REST apply atomicity (#3548)", () => {
       await expect(mgr.applyProfileViaRest("target")).resolves.toBeUndefined();
       expect(restMount.mounted).toEqual([folderOf("ems-uid")]);
       expect(restMount.unmounted).toEqual([folderOf("kpc-uid")]);
+    });
+
+    it("fails loud on an UNEXPECTED guard error (indeterminate cleanliness — no silent proceed)", async () => {
+      const { mgr, restMount, uncommittedGuard, localDataStore } = setup({
+        targetIncludes: [...ALL_FLOOR_UIDS, "ems-uid"],
+        materialized: [...ALL_FLOOR_UIDS, "kpc-uid"],
+        wireUncommittedGuard: true,
+      });
+      // NOT a git-unavailable signature — e.g. transient index.lock / guard bug.
+      uncommittedGuard.throwOnCheck = true;
+      uncommittedGuard.throwMessage =
+        "fatal: Unable to create '.git/index.lock': File exists";
+
+      // Cleanliness is indeterminate → per the zero-loss mandate we must NOT
+      // silently proceed (a to-destroy AssetSpace could hold uncommitted edits).
+      await expect(mgr.applyProfileViaRest("target")).rejects.toThrow(/index\.lock/);
+      // No mutation occurred (failed before the mount/unmount loops).
+      expect(restMount.mounted).toEqual([]);
+      expect(restMount.unmounted).toEqual([]);
+      expect(localDataStore.getActiveProfileUid()).toBe("source");
     });
 
     it("does not require uncommittedGuard to be wired (mobile path)", async () => {


### PR DESCRIPTION
## Summary

Hardens **apply-profile partial-failure atomicity** (#3548). Since the git-elim cutover (**#3567**) `applyProfile` routes through the **REST/tarball path** (`applyProfileViaRest` → `runRestApplyMutation`) on **BOTH platforms** — `restMountFactory` is wired unconditionally in `ExocortexPlugin`. So the REST path is the **sole production atomicity surface**; the git path (`runApplyMutation`) is now a legacy/test-only fallback (reached only when neither `restMount` nor `restMountFactory` is wired).

This closes #3548's **Gap 2** (the REST path "no rollback at all + no uncommitted guard") — which post-#3567 is the production gap for **both** desktop and mobile.

## What changed (`ProfileApplyManager`)

1. **MOUNT-BEFORE-UNMOUNT** — materialize the new AssetSpace set **first**; tear down the old set only once every new one is confirmed present. Replaces the prior unmount-then-mount ordering whose mount-failure window left the to-destroy set gone with no rollback (REST has no `SwitchCacheLayer`).
2. **ROLLBACK on mount-failure** — unmount every AssetSpace mounted this run (incl. the partial failed folder — `unmount` is idempotent: strips the `.gitmodules` stanza + removes the folder even if `mount` threw before its `.gitmodules` append), restoring the **EXACT pre-apply mount-state** with **zero data loss** (only freshly-pulled content is removed). `activeProfileUid` stays at the previous profile. A failure **after** all mounts succeed leaves a benign **superset** (target ∪ not-yet-removed) — never lost data; a re-run reconciles.
3. **uncommittedGuard PARITY** (Vision Lock #5, AC item 2) — the REST path now consults the guard **when wired** (desktop git-backed vault), aborting before any mutation on a dirty to-destroy AssetSpace; on a **git-free** vault (mobile / a vault never `git init`-ed, where `git status` throws `fatal: not a git repository`) the check **degrades gracefully** and the reorder provides the guarantee instead.
4. **Actionable user-facing failure message** on both paths (AC item 4): rolled-back ("vault rolled back to the previous profile — re-run Apply") vs superset ("new AssetSpaces mounted, old set not fully removed — re-run to reconcile"); the legacy git path points at reload/recovery-worker.

## Scope decision (bounded, not a refactor)

The issue proposes 5 incremental steps and flags this as "engine-work". Post-#3567 the **bounded zero-loss fix is the reorder** (it sidesteps needing a whole REST cache subsystem). AC item 1 ("**Desktop**: a Phase-2 materialize failure leaves the vault clean / fully rolled back to the pre-apply set") is satisfied **because desktop now uses the REST path**, which the reorder makes fully-rollback-on-mount-failure.

**Deliberately out of scope** (documented in `docs/profile.md`): the legacy git path's *materialize-before-destroy reorder + git-reset* (issue proposal steps 1–2). That path is no longer reached in production and its reorder would require changing the `recoverIncompleteSwitch` journal semantics (the bigger refactor the issue itself flags). It receives the actionable failure message only.

## Tests — revert-verify (production-shape, both platforms via the shared REST path)

New `tests/unit/ProfileApplyManager.restAtomicity.test.ts` (9 tests). Empirically verified: **7/9 FAIL pre-fix, 9/9 PASS post-fix** (the 2 that pass both ways are invariants — graceful-degradation + no-guard-wired). Covers:
- mount-before-unmount ordering
- mount-failure → never tears down the to-destroy set + rolls back the freshly-mounted set + partial-folder cleanup → exact pre-apply state, `activeProfileUid` unchanged
- unmount-failure after all mounts → superset, no data loss, actionable message
- uncommittedGuard parity (abort on dirty / proceed on clean / graceful on git-unavailable / not-required-when-unwired)

Regression: all **164** existing Profile/apply/activity-log tests green (13 suites, incl. `ApplyEndToEnd.integration.test.ts` which clones real repos). `npm run check:types` clean, `npm run lint` exit 0.

## Acceptance criteria

- [x] **Desktop**: Phase-2 materialize failure leaves the vault fully rolled back to the pre-apply set — desktop uses the REST path; revert-verify unit test.
- [x] **Mobile**: `applyProfileViaRest` calls `uncommittedGuard` before unmount (when wired; graceful on git-free).
- [x] **Mobile**: a mount-failure after/around unmount restores the pre-apply set (REST mount-before-unmount + rollback) — stronger than the "document + surface" alternative.
- [x] Both paths surface an actionable user-facing failure message describing the partial-applied state + recovery action.

Closes #3548