### PR TITLE
fix(ux): add-assetspace «Target folder» helper clarity (F4)

### DIFF
--- a/packages/obsidian-plugin/src/presentation/modals/AddAssetSpaceModal.ts
+++ b/packages/obsidian-plugin/src/presentation/modals/AddAssetSpaceModal.ts
@@ -67,8 +67,8 @@ export class AddAssetSpaceModal extends Modal {
 
     this.previewEl = contentEl.createEl("p", {
       cls: "add-assetspace-preview",
-      text: this.previewText(""),
     });
+    this.refreshPreview();
     input.addEventListener("input", () => this.refreshPreview());
 
     contentEl.createEl("p", {
@@ -101,12 +101,27 @@ export class AddAssetSpaceModal extends Modal {
   private refreshPreview(): void {
     if (this.previewEl === null) return;
     const url = (this.urlInput?.value ?? "").trim();
-    this.previewEl.textContent = this.previewText(url);
+    const { text, isPlaceholder } = this.previewState(url);
+    this.previewEl.textContent = text;
+    // Empty / invalid states are hints, not a real path — render them as a
+    // muted placeholder so the auto-derived value reads as a live preview
+    // rather than an unfinished field (F4 UX polish).
+    this.previewEl.classList.toggle("is-placeholder", isPlaceholder);
   }
 
-  private previewText(url: string): string {
-    if (url.length === 0) return "Target folder: (enter a URL)";
-    if (!isLikelyGitHubUrl(url)) return "Target folder: (invalid URL)";
+  private previewState(url: string): { text: string; isPlaceholder: boolean } {
+    if (url.length === 0) {
+      return {
+        text: "Target folder: auto-derived from the repository URL",
+        isPlaceholder: true,
+      };
+    }
+    if (!isLikelyGitHubUrl(url)) {
+      return {
+        text: "Target folder: enter a valid GitHub URL",
+        isPlaceholder: true,
+      };
+    }
     let path = "(unknown)";
     try {
       // Mirror invokeAddAssetSpace (#3538): canonical Maven path
@@ -116,7 +131,7 @@ export class AddAssetSpaceModal extends Modal {
     } catch {
       path = "(unknown)";
     }
-    return `Target folder: ${path}`;
+    return { text: `Target folder: ${path}`, isPlaceholder: false };
   }
 
   private submit(): void {

--- a/packages/obsidian-plugin/styles.css
+++ b/packages/obsidian-plugin/styles.css
@@ -6131,6 +6131,14 @@
   font-size: var(--font-ui-smaller, 0.8em);
 }
 
+/* F4 UX polish — empty/invalid target-folder preview is a hint, not a value:
+   render it as a faded placeholder so the auto-derived path reads as a live
+   preview rather than an unfinished field. */
+.add-assetspace-preview.is-placeholder {
+  font-style: italic;
+  opacity: 0.7;
+}
+
 .bootstrap-modal-error {
   display: none;
 }

--- a/packages/obsidian-plugin/tests/unit/presentation/modals/BootstrapModals.test.ts
+++ b/packages/obsidian-plugin/tests/unit/presentation/modals/BootstrapModals.test.ts
@@ -227,6 +227,43 @@ describe("AddAssetSpaceModal", () => {
     );
   });
 
+  it("empty state — preview reads as an auto-derived placeholder hint (F4)", () => {
+    new AddAssetSpaceModal(fakeApp, derive, () => undefined).open();
+    const preview = document.querySelector(
+      ".add-assetspace-preview",
+    ) as HTMLElement;
+    // F4: the empty preview must read as a live auto-preview hint, not as an
+    // unfinished "(enter a URL)" placeholder field.
+    expect(preview.textContent).toBe(
+      "Target folder: auto-derived from the repository URL",
+    );
+    // Hint, not a real path → muted placeholder styling.
+    expect(preview.classList.contains("is-placeholder")).toBe(true);
+  });
+
+  it("invalid URL — preview shows a placeholder hint, not a path (F4)", () => {
+    new AddAssetSpaceModal(fakeApp, derive, () => undefined).open();
+    const input = document.querySelector("input") as HTMLInputElement;
+    input.value = "ftp://nope";
+    input.dispatchEvent(new Event("input"));
+    const preview = document.querySelector(
+      ".add-assetspace-preview",
+    ) as HTMLElement;
+    expect(preview.textContent).toBe("Target folder: enter a valid GitHub URL");
+    expect(preview.classList.contains("is-placeholder")).toBe(true);
+  });
+
+  it("valid URL clears the placeholder styling on the live preview (F4)", () => {
+    new AddAssetSpaceModal(fakeApp, derive, () => undefined).open();
+    const input = document.querySelector("input") as HTMLInputElement;
+    input.value = "https://github.com/kitelev/exoas-pmbok-ontology";
+    input.dispatchEvent(new Event("input"));
+    const preview = document.querySelector(
+      ".add-assetspace-preview",
+    ) as HTMLElement;
+    expect(preview.classList.contains("is-placeholder")).toBe(false);
+  });
+
   it("valid URL → resolves it", () => {
     let result: { url: string } | null | undefined;
     new AddAssetSpaceModal(fakeApp, derive, (r) => {


### PR DESCRIPTION
## What

UX-audit node **F4** (Alpha Launch NIGHT-2, WAVE D). LOW cosmetic — no separate issue.

In `Add assetspace by URL` (`AddAssetSpaceModal`), the live folder-path preview read **«Target folder: (enter a URL)»** before a URL was typed — an unfinished-looking placeholder rather than an obvious live auto-preview of the derived folder path.

## Change (bounded — text + one CSS class, no engine logic)

| State | Before | After |
|---|---|---|
| empty | `Target folder: (enter a URL)` | `Target folder: auto-derived from the repository URL` |
| invalid | `Target folder: (invalid URL)` | `Target folder: enter a valid GitHub URL` |
| filled | `Target folder: assetspaces/<owner>/<repo>` | _unchanged_ |

Empty/invalid states now carry an `.is-placeholder` cue (italic, faded `opacity: 0.7`) so the hint reads distinctly from a real path; once a valid URL is entered the live path preview shows without the placeholder styling.

## Tests

`BootstrapModals.test.ts` (existing suite covering this modal) gains 3 cases:
- empty-state label + `is-placeholder` class
- invalid-URL label + `is-placeholder` class
- placeholder cleared on valid URL

The pre-existing filled-state preview test (`/Target folder: assetspaces\/kitelev\/exoas-pmbok-ontology/`) is unchanged and stays green. Suite: 25/25 pass. Build green (typecheck + esbuild prod + mobile-loadable + console-channel assertions). Bundle verified: new strings present, old strings absent.

LOW cosmetic UI-text — no Docker/UI smoke required.