### PR TITLE
fix(#3578): align apply-profile reconcile-preview removal-set with actual mount-delta

### DIFF
--- a/packages/obsidian-plugin/src/infrastructure/adapters/ProfileApplyManager.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/ProfileApplyManager.ts
@@ -1751,14 +1751,28 @@ export class ProfileApplyManager {
       }
     }
 
-    // Materialized AS UIDs: .gitmodules ∩ working-tree-on-disk
-    // (Phase 6 Vision Lock #9 amendment: `.gitmodules` ≠ materialization state).
-    const submodulePaths = await gitOps.readGitmodulesPaths();
+    // Materialized AS UIDs: ALL AssetSpace descriptor folders ∩
+    // working-tree-on-disk — IDENTICAL to the apply paths
+    // (`applyProfile` / `applyProfileViaRest`, which key materialization on
+    // `allInfos.map(i => i.folderName)`). #D2 (GUI-BDD-CI Ф3, node c470f71d):
+    // the prior `.gitmodules`-only scan (`gitOps.readGitmodulesPaths()`)
+    // UNDER-reported materialization — a folder present on disk but absent from
+    // `.gitmodules` (desktop git-free REST mount whose `.gitmodules` is written
+    // via `vault.adapter`, or any unreadable/empty `.gitmodules`) was invisible
+    // to the reconcile preview yet still torn down by the subsequent
+    // `applyProfile`. The preview showed «Assetspaces to remove: (none)» while
+    // the apply unmounted a personal AssetSpace (privacy-boundary surprise). The
+    // on-disk descriptor-folder scan is the authoritative materialization signal
+    // both the preview and the actual apply MUST share so their removal-deltas
+    // agree. The `.gitmodules`-persists-post-destroy intersection (Phase 6
+    // Vision Lock #9) still holds — `derivePhysicallyMaterializedAsUids` ANDs
+    // each path with `vault.adapter.exists`, so a destroyed-but-stanza-preserved
+    // entry whose folder is gone is still correctly excluded.
     const allInfos = this.listAllAssetSpaceInfos();
     const infoByPath = new Map<string, AssetSpaceInfo>();
     for (const info of allInfos) infoByPath.set(info.folderName, info);
     const materializedAsUids = await this.derivePhysicallyMaterializedAsUids(
-      submodulePaths,
+      allInfos.map((i) => i.folderName),
       infoByPath,
     );
 

--- a/packages/obsidian-plugin/tests/unit/ProfileApplyManager.apply.test.ts
+++ b/packages/obsidian-plugin/tests/unit/ProfileApplyManager.apply.test.ts
@@ -1645,4 +1645,70 @@ describe("ProfileApplyManager.reconcileToLocal", () => {
     // The namespace reconciliation must NOT suppress a legitimately-missing floor.
     expect(result.outcome).toBe("declined");
   });
+
+  // === #D2 (GUI-BDD-CI Ф3, node c470f71d) — reconcile-preview removal-delta
+  // must equal the actual apply mount-delta ===
+  // GUI-smoke found the reconcile modal showing «Assetspaces to remove: (none)»
+  // while the subsequent apply unmounted a personal AssetSpace (privacy-boundary
+  // surprise). Root cause: the reconcile preview keyed "materialized" on
+  // `gitOps.readGitmodulesPaths()` (a `.gitmodules`-only scan), but the apply
+  // path (`applyProfile`/`applyProfileViaRest`) keys it on the on-disk
+  // descriptor-folder scan (`allInfos.map(folderName)`). A folder present on
+  // disk but ABSENT from `.gitmodules` — exactly what the desktop git-free REST
+  // mount (#3567) produces — was invisible to the preview yet still torn down by
+  // the apply. The fix aligns the preview scan with the apply scan.
+  it("#D2 — reports an on-disk AssetSpace folder ABSENT from .gitmodules as a removal (preview == apply delta)", async () => {
+    const { mgr, localDataStore, confirmGate, gitOps } = setup({
+      targetUid: "target",
+      sourceUid: null,
+      // Active profile includes ONLY the floor — the personal AssetSpace
+      // ("ems-uid", standing in for exoas-my) is NOT in the effective set.
+      targetIncludes: [
+        TS_FLOOR_AS_UID_EXO,
+        TS_FLOOR_AS_UID_EXOCMD,
+        TS_FLOOR_AS_UID_SHARED_IDENTITIES,
+      ],
+      // ems-uid IS materialized on disk (folder present) — like a personal
+      // AssetSpace mounted via the desktop git-free REST path.
+      materialized: [
+        "ems-uid",
+        TS_FLOOR_AS_UID_EXO,
+        TS_FLOOR_AS_UID_EXOCMD,
+        TS_FLOOR_AS_UID_SHARED_IDENTITIES,
+      ],
+    });
+    // Reproduce the production divergence: the on-disk folder exists (setup put
+    // it in `fsFolders`), but its `.gitmodules` stanza is ABSENT — the exact
+    // state a desktop git-free REST mount leaves when `.gitmodules` is written
+    // via `vault.adapter` and `gitOps.readGitmodulesPaths()` (Node fs) doesn't
+    // see it (or `.gitmodules` is unreadable / empty). Strip it from the git
+    // scan ONLY; the working-tree folder stays present.
+    gitOps.gitmodulesPaths.delete("assetspaces/kitelev/exoas-ems");
+
+    await localDataStore.save({
+      activeProfileUid: "target",
+      _switchInProgress: false,
+    });
+    // Decline → assert the PREVIEW only, no apply side effects.
+    confirmGate.approve = false;
+
+    const result = await mgr.reconcileToLocal();
+
+    // Pre-fix (.gitmodules-only scan): ems-uid invisible → extra = [] →
+    // outcome "no-divergence", confirmGate never called → preview misleads
+    // ("remove none"). Post-fix (on-disk descriptor-folder scan, matching the
+    // apply path): ems-uid surfaces → divergence → modal lists it for removal.
+    expect(result.outcome).toBe("declined");
+    expect(confirmGate.lastPlan).not.toBeNull();
+    const tornDown = confirmGate.lastPlan!.assetSpacesBeingTornDown.map(
+      (a) => a.asUid,
+    );
+    expect(tornDown).toContain("ems-uid");
+    // The preview now reflects the real on-disk content that the apply removes
+    // (folder has files → non-zero count, never a phantom "(none)" entry).
+    const emsEntry = confirmGate.lastPlan!.assetSpacesBeingTornDown.find(
+      (a) => a.asUid === "ems-uid",
+    );
+    expect(emsEntry?.fileCount).toBeGreaterThan(0);
+  });
 });


### PR DESCRIPTION
## Problem (GUI-BDD-CI Ф3, node c470f71d)

At apply-profile, the reconcile modal (`ApplyConfirmModal`, opened by onload `reconcileToLocal`) showed `Assetspaces to remove: (none)` pre-commit — yet the actual apply unmounted a personal AssetSpace (`exoas-my`, privacy boundary). The apply is correct (2-phase clean, atomicity #3548 holds); the **preview misrepresented the mount-delta**, so the user couldn't see a personal AssetSpace would leave the disk. MED (privacy-relevant, not data-loss).

## Root cause

The reconcile preview and the actual apply computed "currently materialized" via **different scans**:

| Path | Materialized scan |
|---|---|
| `reconcileToLocal` (preview → `extra`) | `gitOps.readGitmodulesPaths()` — **`.gitmodules`-only** |
| `applyProfile` / `applyProfileViaRest` (actual → `toDestroy`) | `allInfos.map(i => i.folderName)` — **on-disk descriptor folders** |

When a folder is present **on disk but absent from `.gitmodules`** — the desktop **git-free REST mount** state (#3567: `.gitmodules` written via `vault.adapter`, read back via Node `fs` in `gitOps`; or an unreadable/empty `.gitmodules`) — the reconcile preview is blind to it (`extra = []` → "remove none"), while the subsequent apply removes it via the on-disk scan.

## Fix

One-site change in `reconcileToLocal`: scan `allInfos.map(i => i.folderName)` (the authoritative on-disk descriptor-folder signal both paths share) instead of `gitOps.readGitmodulesPaths()`. Now the preview removal-set (`extra`) equals the apply removal-set (`toDestroy`).

The `.gitmodules`-persists-post-destroy intersection (Phase 6 Vision Lock #9) still holds — `derivePhysicallyMaterializedAsUids` ANDs each path with `vault.adapter.exists`, so a destroyed-but-stanza-preserved entry (folder gone) stays excluded. **Preview-accuracy only — apply atomicity (#3548) untouched.**

## Test (revert-verify)

Production-shape unit test: a materialized AssetSpace folder present on disk but absent from `.gitmodules`, active profile excluding it → reconcile preview must list it for removal.

- **Pre-fix**: FAILS — `outcome` is `"no-divergence"` (preview misses it → "remove none").
- **Post-fix**: PASSES — divergence surfaced, `assetSpacesBeingTornDown` contains the AS with non-zero `fileCount`.

Empirically verified to FAIL pre-fix and PASS post-fix. All 104 profile-apply/switch tests pass; typecheck + lint + build green.

Closes #3578