### PR TITLE
fix(profile): invalidate command caches + re-render on mount-state apply (D1)

### DIFF
--- a/packages/exocortex/tests/unit/services/CommandResolver.mountStateStaleness.test.ts
+++ b/packages/exocortex/tests/unit/services/CommandResolver.mountStateStaleness.test.ts
@@ -1,0 +1,122 @@
+/**
+ * GUI-smoke D1 — mount-state cache staleness (production-shape regression).
+ *
+ * Reproduces the root cause of "inline create-buttons on `ems__Project` /
+ * `ems__MeetingPrototype` render only after the full mount + reload":
+ *
+ * A profile apply / mount-state change rebuilds the triple store
+ * (`rdfIndexer.refresh()` = clear + convertVault) so it gains the
+ * CommandBindings / class definitions that the newly-materialised
+ * AssetSpaces bring in. But the `CommandResolver` memoises its resolution
+ * per (subjectIRI, classes, prototype). A button resolved BEFORE the
+ * relevant binding was in the store caches an EMPTY result; without
+ * `invalidateCache()` that empty stays — buttons never appear until a full
+ * plugin reload re-fires `metadataCache.on("resolved")`.
+ *
+ * The D1 fix wires `CommandResolver.invalidateCache()` into the
+ * profile-apply refresh hook (`createProfileApplyRefreshHook` →
+ * `PluginRdfIndexerAdapter.onAfterRefresh`). This test exercises the
+ * resolver-level mechanism that fix depends on, through the real
+ * `CommandResolver` + `InMemoryTripleStore` with production-shape triples
+ * (the "Create Task → Project" binding from `exoas-exocmd`).
+ *
+ * Revert-verify: drop the `resolver.invalidateCache()` call in the
+ * "recovers" step and the recovery assertion FAILS (stale empty cache
+ * persists) — proving the test exercises the regression, not a tautology.
+ */
+import { CommandResolver } from "../../../src/services/CommandResolver";
+import { InMemoryTripleStore } from "../../../src/infrastructure/rdf/InMemoryTripleStore";
+import { Triple } from "../../../src/domain/models/rdf/Triple";
+import { IRI } from "../../../src/domain/models/rdf/IRI";
+import { Literal } from "../../../src/domain/models/rdf/Literal";
+import { Namespace } from "../../../src/domain/models/rdf/Namespace";
+
+// Production UIDs from exoas-exocmd (floor) — the real D1 binding/command.
+const BIND_UID = "0efec799-2bc4-42e5-a1db-2865f5a88ab5"; // Create Task → Project binding
+const CMD_UID = "dec97198-a458-4273-b081-7b250e0a9031"; // Create Task command
+const GND_UID = "a222094b-f499-4342-aec0-65c4ba99c657"; // Create task grounding
+// 4367e2d6 = GroundingType.CREATE_INSTANCE (Create Task's real grounding type).
+const GND_TYPE_REF = "[[4367e2d6-6c92-450a-becb-abce1fb07682]]";
+
+const PROJECT_IRI = "obsidian://vault/my-project.md";
+const PROJECT_CLASSES = ["ems__Project", "exo__Asset"];
+
+/**
+ * Add the "Create Task → Project" binding + command + grounding triples,
+ * representing the moment the exocmd AssetSpace becomes mounted and the
+ * store rebuild picks it up.
+ */
+async function mountCreateTaskBinding(store: InMemoryTripleStore): Promise<void> {
+  const gndSub = new IRI(`obsidian://vault/${GND_UID}.md`);
+  const cmdSub = new IRI(`obsidian://vault/${CMD_UID}.md`);
+  const bindSub = new IRI(`obsidian://vault/${BIND_UID}.md`);
+
+  await store.addAll([
+    // Grounding
+    new Triple(gndSub, Namespace.RDF.term("type"), Namespace.EXOCMD.term("Grounding")),
+    new Triple(gndSub, Namespace.EXO.term("Asset_uid"), new Literal(GND_UID)),
+    new Triple(gndSub, Namespace.EXO.term("Asset_label"), new Literal("Create task")),
+    new Triple(gndSub, Namespace.EXOCMD.term("Grounding_type"), new Literal(GND_TYPE_REF)),
+    new Triple(gndSub, Namespace.EXOCMD.term("Grounding_targetClass"), new Literal("1b20a8f0-d745-4e93-91db-4531b3df120e|ems__Task")),
+
+    // Command (no precondition — "always available")
+    new Triple(cmdSub, Namespace.RDF.term("type"), Namespace.EXOCMD.term("Command")),
+    new Triple(cmdSub, Namespace.EXO.term("Asset_uid"), new Literal(CMD_UID)),
+    new Triple(cmdSub, Namespace.EXO.term("Asset_label"), new Literal("Create Task")),
+    new Triple(cmdSub, Namespace.EXOCMD.term("Command_icon"), new Literal("plus-circle")),
+    new Triple(cmdSub, Namespace.EXOCMD.term("Command_category"), new Literal("creation")),
+    new Triple(cmdSub, Namespace.EXOCMD.term("Command_grounding"), gndSub),
+
+    // Binding → targetClass ems__Project
+    new Triple(bindSub, Namespace.RDF.term("type"), Namespace.EXOCMD.term("CommandBinding")),
+    new Triple(bindSub, Namespace.EXO.term("Asset_uid"), new Literal(BIND_UID)),
+    new Triple(bindSub, Namespace.EXO.term("Asset_label"), new Literal("Create Task → Project binding")),
+    new Triple(bindSub, Namespace.EXOCMD.term("CommandBinding_command"), cmdSub),
+    new Triple(bindSub, Namespace.EXOCMD.term("CommandBinding_targetClass"), new Literal("ems__Project")),
+    new Triple(bindSub, Namespace.EXOCMD.term("CommandBinding_position"), new Literal("inline")),
+    new Triple(bindSub, Namespace.EXOCMD.term("CommandBinding_order"), new Literal("231")),
+  ]);
+}
+
+describe("CommandResolver — mount-state cache staleness (GUI-smoke D1)", () => {
+  let store: InMemoryTripleStore;
+  let resolver: CommandResolver;
+
+  beforeEach(() => {
+    store = new InMemoryTripleStore();
+    resolver = new CommandResolver(store);
+  });
+
+  it("baseline: resolves the Create-Task button once the binding is in the store", async () => {
+    await mountCreateTaskBinding(store);
+    const commands = await resolver.resolveForAssetMulti(PROJECT_IRI, PROJECT_CLASSES);
+    expect(commands).toHaveLength(1);
+    expect(commands[0].command.name).toBe("Create Task");
+  });
+
+  it("regression: a button resolved before the mount stays STALE after the store rebuild — until invalidateCache()", async () => {
+    // 1. Pre-mount: the exocmd binding AssetSpace is not yet materialised.
+    //    Resolving the Project's inline commands yields nothing — and the
+    //    empty result is cached by the resolver (multiCache).
+    const preMount = await resolver.resolveForAssetMulti(PROJECT_IRI, PROJECT_CLASSES);
+    expect(preMount).toHaveLength(0);
+
+    // 2. Mount happens: the store rebuild (rdfIndexer.refresh) now contains
+    //    the Create Task → Project binding + command + grounding.
+    await mountCreateTaskBinding(store);
+
+    // 3. Without cache invalidation, the resolver returns the STALE empty
+    //    result — this is exactly the D1 symptom (buttons stay hidden after
+    //    a partial→full mount, no reload).
+    const staleRead = await resolver.resolveForAssetMulti(PROJECT_IRI, PROJECT_CLASSES);
+    expect(staleRead).toHaveLength(0); // regression demonstrated
+
+    // 4. The D1 fix: the profile-apply refresh hook calls invalidateCache()
+    //    after the store rebuild. Now the binding resolves and the button
+    //    appears — without a plugin reload.
+    resolver.invalidateCache();
+    const afterInvalidate = await resolver.resolveForAssetMulti(PROJECT_IRI, PROJECT_CLASSES);
+    expect(afterInvalidate).toHaveLength(1);
+    expect(afterInvalidate[0].command.name).toBe("Create Task");
+  });
+});

--- a/packages/obsidian-plugin/src/ExocortexPlugin.ts
+++ b/packages/obsidian-plugin/src/ExocortexPlugin.ts
@@ -107,6 +107,7 @@ import { ProfileApplyManager } from "./infrastructure/adapters/ProfileApplyManag
 import { PluginLockManager } from "./infrastructure/adapters/PluginLockManager";
 import { VaultProfileResolver } from "./infrastructure/adapters/VaultProfileResolver";
 import { PluginRdfIndexerAdapter } from "./infrastructure/adapters/PluginRdfIndexerAdapter";
+import { createProfileApplyRefreshHook } from "./infrastructure/adapters/profileApplyRefreshHook";
 import { PluginSettingsStoreAdapter } from "./infrastructure/adapters/PluginSettingsStoreAdapter";
 import { PluginLocalDataStore } from "./infrastructure/adapters/PluginLocalDataStore";
 import { StagingDirTracker } from "./infrastructure/adapters/StagingDirTracker";
@@ -2704,16 +2705,33 @@ export default class ExocortexPlugin extends Plugin {
   private async registerProfileCommands(): Promise<void> {
     const lockMgr = new PluginLockManager({ app: this.app });
     const resolver = new VaultProfileResolver(this.app);
-    // RFC 22b50a17 Phase 4 (H1 cascade catch — advisor round-2) — wire
-    // `refreshAndInjectAssetSpaceMaterialization` as the post-refresh
-    // hook so apply paths via `ProfileApplyManager`
-    // re-inject `exo:AssetSpace_materialized` triples automatically after
-    // every `rdfIndexer.refresh()`. Without this, profile switching
-    // would silently drop the runtime-derived materialization triples
-    // until the next `metadataCache.resolved` event.
+    // RFC 22b50a17 Phase 4 (H1 cascade catch — advisor round-2) — wire a
+    // post-refresh hook so apply paths via `ProfileApplyManager` re-inject
+    // `exo:AssetSpace_materialized` triples automatically after every
+    // `rdfIndexer.refresh()`. Without this, profile switching would
+    // silently drop the runtime-derived materialization triples until the
+    // next `metadataCache.resolved` event.
+    //
+    // GUI-smoke D1 — the hook ALSO invalidates the command/precondition
+    // resolver caches + lazy-loader marks and re-renders active layouts.
+    // A mount-state rebuild leaves the store complete but the resolver
+    // caches stale: inline create-buttons resolved (and cached empty)
+    // against the pre-mount store otherwise stay hidden on
+    // `ems__Project` / `ems__MeetingPrototype` until a full plugin reload.
+    // This mirrors the cold-start (`metadataCache.on("resolved")`) and
+    // hot-reindex (`scheduleHotReindex`) paths, which already do this.
     const rdfIndexer = new PluginRdfIndexerAdapter(
       this.sparql.getRdfIndexer(),
-      () => this.refreshAndInjectAssetSpaceMaterialization(),
+      createProfileApplyRefreshHook({
+        refreshAndInject: () =>
+          this.refreshAndInjectAssetSpaceMaterialization(),
+        clearLazyLoader: () => this.lazyAssetGraphLoader?.clearAll(),
+        invalidateCommandResolverCache: () =>
+          this.commandResolver.invalidateCache(),
+        invalidatePreconditionCache: () =>
+          this.preconditionEvaluator.invalidateCache(),
+        rerenderLayouts: () => this.autoRenderLayout(),
+      }),
     );
 
     // Issue #3327 Item #3 — initialize device-local switch state store and

--- a/packages/obsidian-plugin/src/infrastructure/adapters/profileApplyRefreshHook.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/profileApplyRefreshHook.ts
@@ -1,0 +1,73 @@
+/**
+ * Post-refresh duties that MUST run after a profile apply / mount-state
+ * change rebuilds the triple store.
+ *
+ * A profile apply (or any `ProfileApplyManager.reindexMountState` /
+ * `applyProfile` / `applyProfileViaRest` path) calls
+ * `rdfIndexer.refresh()`, which clears the store and re-runs
+ * `convertVault()` over the AssetSpace folders that are now materialised
+ * on disk. The store is therefore COMPLETE for the new mount-state — but
+ * three in-memory follow-ups are needed for the UI to reflect it, exactly
+ * mirroring the cold-start (`metadataCache.on("resolved")`) and
+ * hot-reindex (`scheduleHotReindex`) paths:
+ *
+ *  1. **Re-inject derived materialization triples.** The runtime-derived
+ *     `exo:AssetSpace_materialized` triples live only in memory and are
+ *     wiped by the store rebuild — `refreshAndInject` re-adds them
+ *     (RFC 22b50a17 Phase 4 H1).
+ *  2. **Invalidate resolver caches + lazy-loader marks.** The
+ *     `CommandResolver` / `PreconditionEvaluator` caches and the
+ *     `LazyAssetGraphLoader` load-marks are keyed by subject/class and
+ *     persist across the rebuild. Without invalidation, inline command
+ *     buttons resolved (and CACHED — frequently as an EMPTY result)
+ *     against the PRE-mount store stay stale: a `ems__Project` /
+ *     `ems__MeetingPrototype` opened before its class AssetSpace was
+ *     mounted caches zero buttons and never recovers until a full plugin
+ *     reload. This is GUI-smoke defect D1 — create-buttons render only
+ *     after the registry/full mount + reload.
+ *  3. **Re-render active layouts.** Even with clean caches the layout DOM
+ *     is not refreshed by the store rebuild; `rerenderLayouts` makes the
+ *     freshly-resolvable buttons appear without an Obsidian restart.
+ *
+ * The cold-start + hot-reindex paths already perform (2)+(3); the
+ * apply path previously did only (1), which is the D1 root cause.
+ *
+ * Returned as an `async () => Promise<void>` so it can be wired directly
+ * as the `PluginRdfIndexerAdapter` `onAfterRefresh` hook. The materialize
+ * re-injection is awaited (it is async + store-touching); the cache
+ * invalidations + re-render are synchronous fire-after.
+ */
+export interface ProfileApplyRefreshDeps {
+  /** Re-inject `exo:AssetSpace_materialized` triples (async, store-touching). */
+  refreshAndInject: () => Promise<void>;
+  /** Drop the `LazyAssetGraphLoader` monotonic load-marks. */
+  clearLazyLoader: () => void;
+  /** Clear `CommandResolver` resolution + ancestor caches. */
+  invalidateCommandResolverCache: () => void;
+  /** Clear `PreconditionEvaluator` evaluation cache. */
+  invalidatePreconditionCache: () => void;
+  /** Re-render active layouts so refreshed button visibility shows. */
+  rerenderLayouts: () => void;
+}
+
+export function createProfileApplyRefreshHook(
+  deps: ProfileApplyRefreshDeps,
+): () => Promise<void> {
+  return async () => {
+    // (1) Re-inject derived materialization triples first — it is the
+    // only async, store-touching step and the badge/status surfaces
+    // depend on it.
+    await deps.refreshAndInject();
+
+    // (2) Invalidate caches that survived the store rebuild. Order
+    // mirrors the cold-start chain (lazy-loader marks → resolver caches)
+    // so a concurrent render cannot re-populate a cache from a
+    // half-cleared state.
+    deps.clearLazyLoader();
+    deps.invalidateCommandResolverCache();
+    deps.invalidatePreconditionCache();
+
+    // (3) Re-render so the now-resolvable buttons appear without a reload.
+    deps.rerenderLayouts();
+  };
+}

--- a/packages/obsidian-plugin/tests/unit/profileApplyRefreshHook.test.ts
+++ b/packages/obsidian-plugin/tests/unit/profileApplyRefreshHook.test.ts
@@ -1,0 +1,93 @@
+import { createProfileApplyRefreshHook } from "../../src/infrastructure/adapters/profileApplyRefreshHook";
+
+/**
+ * GUI-smoke D1 regression guard.
+ *
+ * The apply-profile / mount-state path funnels through
+ * `PluginRdfIndexerAdapter.onAfterRefresh`. Before the D1 fix that hook
+ * only re-injected materialization triples; it did NOT invalidate the
+ * command/precondition caches or re-render, so inline create-buttons
+ * resolved (and cached empty) against the pre-mount store stayed hidden
+ * on `ems__Project` / `ems__MeetingPrototype` until a full plugin reload.
+ *
+ * Revert-verify: delete the `invalidateCommandResolverCache` /
+ * `invalidatePreconditionCache` / `clearLazyLoader` / `rerenderLayouts`
+ * lines from `createProfileApplyRefreshHook` and the
+ * "invalidates caches + re-renders" tests below FAIL; restore → PASS.
+ */
+describe("createProfileApplyRefreshHook", () => {
+  function makeDeps() {
+    return {
+      refreshAndInject: jest.fn().mockResolvedValue(undefined),
+      clearLazyLoader: jest.fn(),
+      invalidateCommandResolverCache: jest.fn(),
+      invalidatePreconditionCache: jest.fn(),
+      rerenderLayouts: jest.fn(),
+    };
+  }
+
+  it("re-injects materialization triples (preserves H1 behaviour)", async () => {
+    const deps = makeDeps();
+    await createProfileApplyRefreshHook(deps)();
+    expect(deps.refreshAndInject).toHaveBeenCalledTimes(1);
+  });
+
+  it("invalidates the command + precondition caches after a mount-state rebuild (D1)", async () => {
+    const deps = makeDeps();
+    await createProfileApplyRefreshHook(deps)();
+    expect(deps.invalidateCommandResolverCache).toHaveBeenCalledTimes(1);
+    expect(deps.invalidatePreconditionCache).toHaveBeenCalledTimes(1);
+  });
+
+  it("clears the lazy-loader load-marks after a mount-state rebuild (D1)", async () => {
+    const deps = makeDeps();
+    await createProfileApplyRefreshHook(deps)();
+    expect(deps.clearLazyLoader).toHaveBeenCalledTimes(1);
+  });
+
+  it("re-renders active layouts so refreshed buttons appear without a reload (D1)", async () => {
+    const deps = makeDeps();
+    await createProfileApplyRefreshHook(deps)();
+    expect(deps.rerenderLayouts).toHaveBeenCalledTimes(1);
+  });
+
+  it("re-injects BEFORE invalidating + re-rendering (store must be rebuilt first)", async () => {
+    const order: string[] = [];
+    const deps = {
+      refreshAndInject: jest.fn(async () => {
+        order.push("refreshAndInject");
+      }),
+      clearLazyLoader: jest.fn(() => order.push("clearLazyLoader")),
+      invalidateCommandResolverCache: jest.fn(() =>
+        order.push("invalidateCommandResolverCache"),
+      ),
+      invalidatePreconditionCache: jest.fn(() =>
+        order.push("invalidatePreconditionCache"),
+      ),
+      rerenderLayouts: jest.fn(() => order.push("rerenderLayouts")),
+    };
+
+    await createProfileApplyRefreshHook(deps)();
+
+    expect(order).toEqual([
+      "refreshAndInject",
+      "clearLazyLoader",
+      "invalidateCommandResolverCache",
+      "invalidatePreconditionCache",
+      "rerenderLayouts",
+    ]);
+  });
+
+  it("re-renders only AFTER caches are invalidated (fresh resolution)", async () => {
+    const order: string[] = [];
+    const deps = makeDeps();
+    deps.invalidateCommandResolverCache.mockImplementation(() =>
+      order.push("invalidate"),
+    );
+    deps.rerenderLayouts.mockImplementation(() => order.push("rerender"));
+
+    await createProfileApplyRefreshHook(deps)();
+
+    expect(order).toEqual(["invalidate", "rerender"]);
+  });
+});


### PR DESCRIPTION
Closes #3580

## Symptom (GUI-smoke D1, MED)
On a fresh vault, inline create-buttons on `ems__Project` / `ems__MeetingPrototype` render intermittently — absent under partial mount (floor+public), appearing only after mounting the full profile + reload. `ems__Area` renders stably. Vault GUI-smoke node `9d350ca1`.

## Root cause
A profile apply / mount-state change rebuilds the triple store via `ProfileApplyManager` → `PluginRdfIndexerAdapter.refresh()` (clear + convertVault). The store is then complete, but the `onAfterRefresh` hook only re-injected `exo:AssetSpace_materialized` triples. Unlike the cold-start (`metadataCache.on("resolved")`) and hot-reindex (`scheduleHotReindex`) paths, the apply path did **not** invalidate the `CommandResolver`/`PreconditionEvaluator` caches, clear the `LazyAssetGraphLoader` marks, or call `autoRenderLayout()`.

So an inline button resolved (and cached **empty**) against the pre-mount store stays stale until a full plugin reload re-fires the cold-start chain. All three apply paths (reindexMountState, desktop apply, REST/mobile apply) funnel through `rdfIndexer.refresh()` → the gap affects desktop **and** mobile (Desktop↔Mobile parity).

## Fix
Extract `createProfileApplyRefreshHook` (pure factory) and wire it as the adapter's `onAfterRefresh` so the apply path mirrors the cold-start + hot-reindex discipline:
re-inject materialization → clear lazy-loader marks → invalidate command/precondition caches → re-render active layouts.

## Tests (both revert-verified)
- `profileApplyRefreshHook.test.ts` (plugin unit) — hook invalidates caches + clears lazy-loader + re-renders, in order. Pre-fix body (refreshAndInject only) → **5/6 fail**.
- `CommandResolver.mountStateStaleness.test.ts` (exocortex integration, production-shape: real `CommandResolver` + `InMemoryTripleStore`, real `0efec799` Create Task → Project binding) — a button resolved before the mount stays stale after the rebuild until `invalidateCache()`. Removing the `invalidateCache()` → recovery assertion **fails** (stale empty persists).

## Verification
- typecheck (root `tsc -noEmit -skipLibCheck`) ✓ · lint ✓ · full `npm run build` ✓ (mobile-loadable + console-channel assertions pass)
- No regression: `ExocortexPlugin.test.ts` (137) · `ProfileApplyManager.apply` · `PluginRdfIndexerAdapter` (7) green.

No Docker e2e (GUI-BDD-CI Ф4 separate).