### PR TITLE
docs(rest-mount): clarify `.gitmodules` write is by-design URL registry (D6 triage)

### DIFF
--- a/packages/obsidian-plugin/src/infrastructure/adapters/RestAssetSpaceMount.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/RestAssetSpaceMount.ts
@@ -113,6 +113,21 @@ export class RestAssetSpaceMount {
       targetPath: safePath,
     });
 
+    // Record the AssetSpace in `.gitmodules` (path + source URL). This is NOT a
+    // git submodule registration — a git-free REST mount creates no gitlink
+    // (`.git/config` / index stay untouched; mount-state visibility is
+    // folder-presence, see class doc). The stanza is an INTENTIONAL, load-bearing
+    // URL registry — NOT vestigial (D6 triage, node 794a95ae) — consumed by the
+    // git-free rediscovery flows that have no other source for the remote URLs:
+    //   - Bootstrap «clone-needs-fetch» — after a vault is cloned/synced without
+    //     `--recurse-submodules` the `assetspaces/*` folders are empty but the
+    //     URLs survive here, so {@link BootstrapAssetSpaceCommands}'s
+    //     `fetchTrackedAssetSpaces()` re-materialises each AssetSpace from its
+    //     recorded URL.
+    //   - «Unmount assetspace» — {@link readGitmodulesEntries} is the canonical
+    //     "what's mounted" registry the command lists.
+    // The live apply path keys mount-state on folder presence, but neither it nor
+    // ExoSync (descriptor-sourced URLs) read this — so do not "clean up" the write.
     await this.appendGitmodulesEntry(safePath, gitUrl);
     return result;
   }


### PR DESCRIPTION
## Context — D6 triage (GUI-BDD-CI Ф3 Wave2, node \`794a95ae\`)

GUI-smoke **D6** observed that after a git-free REST mount (git-elim #3567) the plugin writes a \`.gitmodules\` stanza **without a corresponding gitlink** and asked: is this a vestigial leftover, or by-design?

## Verdict: **by-design URL registry, NOT vestigial**

Grepped every \`.gitmodules\` reader (prod + tests):

| Reader | Live? | Reads |
|---|---|---|
| `BootstrapAssetSpaceCommands.fetchTrackedAssetSpaces()` (clone-needs-fetch) | ✅ LIVE | path **+ URL** → re-materialises each AssetSpace from the recorded URL |
| `Unmount assetspace` → `readGitmodulesEntries()` | ✅ LIVE | path + url — canonical "what's mounted" registry |
| CLI bootstrap / assetspace-add / assetspace-remove | ✅ LIVE | path + url |
| `ProfileApplyManager` desktop-git apply (`readGitmodulesPaths`) | ❌ DEAD in prod | path — fallback only; `restMount` always wired → early return (git-elim #3567) |
| ExoSync (`sync/`) | — | does **not** read `.gitmodules` (remote URLs come from AssetSpace descriptors) |

Key load-bearing case: **`clone-needs-fetch`** — when a vault is cloned/synced **without `--recurse-submodules`**, the \`assetspaces/*\` folders are empty but the URLs survive in \`.gitmodules\`, so Bootstrap can re-fetch each AssetSpace. There is **no other source** for those remote URLs after a fresh clone.

The "without gitlinks" observation is correct and intentional: a git-free REST mount creates no gitlink (`.git/config`/index untouched) — mount-state visibility is folder-presence. The live apply path (`applyProfileViaRest`) keys mount-state on folder presence, so the only \`.gitmodules\` reader in apply (the desktop git path) is dead in prod since #3567.

## Change

**Comment-only.** Documents the rationale at the write site (`RestAssetSpaceMount.mount()`) so the registry write is not later removed as "vestigial cleanup". No behaviour change → no new tests (nothing to revert-verify).

Disposition for node \`794a95ae\`: **not-a-bug** (by-design), closed with this reasoning.