### PR TITLE
feat(e2e): GUI-BDD create-instance specs in release CI (node a2e20c69 Ф4)

### DIFF
--- a/.github/workflows/eka-gui-e2e.yml
+++ b/.github/workflows/eka-gui-e2e.yml
@@ -1,0 +1,117 @@
+name: EKA GUI-BDD E2E
+
+# Release-gate GUI-BDD smoke (node a2e20c69 Ф4): formalises the prose Gherkin
+# scenarios of vault node 76d9207c as repeatable e2e against a FRESH ephemeral
+# vault built from the REAL published kitelev/exoas-* ontology repos, exercising
+# the live create-instance commands + the #3555 InheritanceRule.
+# See packages/obsidian-plugin/tests/e2e/eka-gui/.
+#
+# ⛔ Deliberately NOT a pull_request trigger and NOT a required check: it clones
+# live (public) repos + boots real Obsidian in Docker, so network/QEMU flake
+# must never gate PRs (the 13 required hermetic checks already cover plugin
+# logic). It runs:
+#   - workflow_dispatch — manual on-demand (also used to verify a feature branch
+#                         before merge via `gh workflow run --ref <branch>`),
+#   - schedule          — nightly regression smoke against published content,
+#   - push: [main]      — "авто на каждом релизе": post-merge smoke whenever the
+#                         suite or the plugin/core changes.
+#
+# Unlike eka-obsidian-leg-e2e.yml, this suite clones only PUBLIC repos, so it
+# needs NO PAT and never self-skips. GITHUB_TOKEN is passed only to lift the
+# anonymous clone rate limit.
+on:
+  workflow_dispatch: {}
+  schedule:
+    # 02:30 UTC nightly (07:30 Asia/Almaty) — offset from eka-obsidian-leg (02:00).
+    - cron: "30 2 * * *"
+  push:
+    branches: [main]
+    paths:
+      - "packages/obsidian-plugin/tests/e2e/eka-gui/**"
+      - "packages/obsidian-plugin/playwright-eka-gui.config.ts"
+      - "packages/obsidian-plugin/Dockerfile.eka-gui-e2e"
+      - "packages/obsidian-plugin/tests/e2e/utils/**"
+      - "packages/obsidian-plugin/src/**"
+      - "packages/exocortex/src/**"
+      - ".github/workflows/eka-gui-e2e.yml"
+
+# Avoid piling up scheduled + push runs.
+concurrency:
+  group: eka-gui-e2e-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  packages: read
+
+jobs:
+  eka-gui:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build plugin (main.js)
+        run: |
+          npm run build -w exocortex
+          npm run build -w @kitelev/exocortex-services
+          node packages/obsidian-plugin/esbuild.config.mjs production
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Resolve base image (pull from GHCR or build locally)
+        id: base
+        run: |
+          set -euo pipefail
+          LATEST="ghcr.io/kitelev/exocortex-ci:latest"
+          if docker pull "$LATEST" 2>/dev/null; then
+            echo "::notice::Pulled pre-built base $LATEST"
+            echo "image=$LATEST" >> "$GITHUB_OUTPUT"
+          else
+            echo "::warning::No pre-built base in GHCR — building locally from Dockerfile.ci"
+            docker build -t exocortex-ci-base:local -f packages/obsidian-plugin/Dockerfile.ci .
+            echo "image=exocortex-ci-base:local" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Build EKA GUI e2e Docker image
+        run: |
+          docker build \
+            --build-arg "BASE_IMAGE=${{ steps.base.outputs.image }}" \
+            -f packages/obsidian-plugin/Dockerfile.eka-gui-e2e \
+            -t exocortex-eka-gui-e2e:ci \
+            .
+
+      - name: Run EKA GUI-BDD e2e
+        env:
+          # Public repos clone unauthenticated; the token only lifts the anon
+          # rate limit. GITHUB_TOKEN is always present, so the suite always runs.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          mkdir -p eka-gui-results
+          docker run --init --rm \
+            -e GITHUB_TOKEN="${GITHUB_TOKEN}" \
+            -v "$PWD/eka-gui-results:/app/packages/obsidian-plugin/test-results-eka-gui" \
+            exocortex-eka-gui-e2e:ci
+
+      - name: Upload artifacts on failure
+        if: failure()
+        uses: actions/upload-artifact@v6
+        with:
+          name: eka-gui-e2e-results
+          path: eka-gui-results
+          retention-days: 14
+          if-no-files-found: ignore

--- a/.github/workflows/eka-gui-e2e.yml
+++ b/.github/workflows/eka-gui-e2e.yml
@@ -6,15 +6,18 @@ name: EKA GUI-BDD E2E
 # the live create-instance commands + the #3555 InheritanceRule.
 # See packages/obsidian-plugin/tests/e2e/eka-gui/.
 #
-# ⛔ Deliberately NOT a pull_request trigger and NOT a required check: it clones
-# live (public) repos + boots real Obsidian in Docker, so network/QEMU flake
-# must never gate PRs (the 13 required hermetic checks already cover plugin
-# logic). It runs:
-#   - workflow_dispatch — manual on-demand (also used to verify a feature branch
-#                         before merge via `gh workflow run --ref <branch>`),
-#   - schedule          — nightly regression smoke against published content,
+# NOT a required check (never in branch protection): it clones live (public)
+# repos + boots real Obsidian in Docker, so network/QEMU flake must never GATE
+# PRs (the 13 required hermetic checks already cover plugin logic). It runs:
 #   - push: [main]      — "авто на каждом релизе": post-merge smoke whenever the
-#                         suite or the plugin/core changes.
+#                         suite or the plugin/core changes,
+#   - schedule          — nightly regression smoke against published content,
+#   - workflow_dispatch — manual on-demand,
+#   - pull_request      — ONLY on PRs that touch the suite itself (paths filter),
+#                         so suite changes are verified pre-merge without running
+#                         on unrelated PRs. Safe here (unlike eka-obsidian-leg):
+#                         PUBLIC repos only, no PAT/secret on the PR path. Still
+#                         non-required, so a flake never blocks the PR.
 #
 # Unlike eka-obsidian-leg-e2e.yml, this suite clones only PUBLIC repos, so it
 # needs NO PAT and never self-skips. GITHUB_TOKEN is passed only to lift the
@@ -33,6 +36,14 @@ on:
       - "packages/obsidian-plugin/tests/e2e/utils/**"
       - "packages/obsidian-plugin/src/**"
       - "packages/exocortex/src/**"
+      - ".github/workflows/eka-gui-e2e.yml"
+  pull_request:
+    # Suite-change PRs only — verifies the e2e suite pre-merge; never runs on
+    # unrelated PRs. Non-required → flake cannot block merge.
+    paths:
+      - "packages/obsidian-plugin/tests/e2e/eka-gui/**"
+      - "packages/obsidian-plugin/playwright-eka-gui.config.ts"
+      - "packages/obsidian-plugin/Dockerfile.eka-gui-e2e"
       - ".github/workflows/eka-gui-e2e.yml"
 
 # Avoid piling up scheduled + push runs.

--- a/packages/obsidian-plugin/Dockerfile.eka-gui-e2e
+++ b/packages/obsidian-plugin/Dockerfile.eka-gui-e2e
@@ -1,0 +1,40 @@
+# EKA GUI-BDD e2e image — thin app layer on the pre-built CI base.
+#
+# Self-contained and SEPARATE from Dockerfile.e2e so it never touches the
+# required-CI e2e image. Reuses the same base (Playwright runtime + Obsidian
+# binary + xvfb + git + node_modules) and the same xvfb entrypoint.
+#
+# The suite clones only PUBLIC kitelev/exoas-* repos at test time (real
+# published ontology content), so no PAT is needed. An optional GITHUB_TOKEN
+# (passed via `docker run -e`) only lifts the anonymous clone rate limit.
+#
+# BASE_IMAGE defaults to the published CI base. On Apple Silicon build/run with
+# `--platform linux/amd64` (the base is amd64-only).
+#
+# Build context = repo root (worktree). Requires a prebuilt plugin
+# (`packages/obsidian-plugin/main.js` + `manifest.json`) — run `npm run build` first.
+ARG BASE_IMAGE=ghcr.io/kitelev/exocortex-ci:latest
+FROM ${BASE_IMAGE}
+
+WORKDIR /app
+
+# Reuse the shared xvfb entrypoint (pins Obsidian update endpoints, sets
+# DOCKER/CI, wraps the command in xvfb-run).
+COPY packages/obsidian-plugin/docker-entrypoint-e2e.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+
+# Prebuilt plugin (built on the host, not inside the image).
+COPY packages/obsidian-plugin/main.js ./packages/obsidian-plugin/main.js
+COPY packages/obsidian-plugin/manifest.json ./packages/obsidian-plugin/manifest.json
+
+# EKA GUI harness: dedicated config + spec dir + the shared e2e utils it imports.
+COPY packages/obsidian-plugin/playwright-eka-gui.config.ts ./packages/obsidian-plugin/
+COPY packages/obsidian-plugin/tests/e2e/eka-gui/ ./packages/obsidian-plugin/tests/e2e/eka-gui/
+COPY packages/obsidian-plugin/tests/e2e/utils/ ./packages/obsidian-plugin/tests/e2e/utils/
+
+ENV DISPLAY=:99
+ENV OBSIDIAN_PATH=/opt/obsidian/obsidian
+
+ENTRYPOINT ["/docker-entrypoint.sh"]
+# Each spec creates its own ephemeral vault in a tmpdir, so no OBSIDIAN_VAULT.
+CMD ["npx", "playwright", "test", "-c", "packages/obsidian-plugin/playwright-eka-gui.config.ts"]

--- a/packages/obsidian-plugin/playwright-eka-gui.config.ts
+++ b/packages/obsidian-plugin/playwright-eka-gui.config.ts
@@ -1,0 +1,51 @@
+import { defineConfig } from "@playwright/test";
+
+/**
+ * Dedicated Playwright config for the EKA GUI-BDD suite (node a2e20c69 Ф4).
+ *
+ * DELIBERATELY isolated from the required-CI e2e suite, like its sibling
+ * `playwright-eka-obsidian-leg.config.ts`:
+ *   - `testDir: ./tests/e2e/eka-gui` — OUTSIDE `tests/e2e/specs`, so the 6
+ *     sharded `playwright.shard-N.config.ts` runs and `validate-shard-
+ *     assignments.mjs` never see it. NOT one of the 13 required checks → cannot
+ *     flake them.
+ *   - Unlike eka-obsidian-leg, this suite clones only PUBLIC `kitelev/exoas-*`
+ *     repos, so it needs NO PAT and never self-skips — it runs on every
+ *     push-to-main / nightly as the "авто на каждом релизе" release-gate.
+ *
+ * `workers: 1` is mandatory: ObsidianLauncher pins CDP port 9222, so concurrent
+ * launches would collide. Generous timeout: a multi-repo clone + cold Obsidian
+ * boot (×relaunch-retry under QEMU-emulated amd64) plus six create flows.
+ */
+export default defineConfig({
+  testDir: "./tests/e2e/eka-gui",
+  fullyParallel: false,
+  forbidOnly: !!process.env.CI,
+  retries: 0,
+  workers: 1,
+  timeout: 1_800_000,
+  expect: {
+    timeout: 60_000,
+  },
+  reporter: [["list"]],
+  outputDir: "test-results-eka-gui",
+  use: {
+    trace: "retain-on-failure",
+    screenshot: "only-on-failure",
+    video: "retain-on-failure",
+    launchOptions: {
+      args: [
+        "--disable-dev-shm-usage",
+        "--no-sandbox",
+        "--disable-setuid-sandbox",
+        "--disable-gpu",
+        "--disable-software-rasterizer",
+        "--disable-extensions",
+        "--log-level=3",
+      ],
+      env: {
+        DBUS_SESSION_BUS_ADDRESS: "/dev/null",
+      },
+    },
+  },
+});

--- a/packages/obsidian-plugin/tests/e2e/eka-gui/create-instance-buttons.spec.ts
+++ b/packages/obsidian-plugin/tests/e2e/eka-gui/create-instance-buttons.spec.ts
@@ -15,6 +15,7 @@ import {
   registerConfirmAutoAccept,
   renderedButtonLabels,
   setupGuiVault,
+  waitForButtonsResolved,
   waitForStoreSettled,
 } from "./eka-gui-helpers";
 
@@ -79,6 +80,16 @@ test.describe("EKA GUI — create-instance buttons (fresh real-content vault)", 
     // window.confirm() — auto-accept it under CDP.
     registerConfirmAutoAccept(window);
     await waitForStoreSettled(window);
+    // Warm up resolution: binding + grounding (incl. InheritanceRule) settles
+    // a few seconds after the store; wait until the full create-button set
+    // renders so the FIRST scenario's click fires a fully-resolved grounding
+    // (otherwise the backlink IR is empty → no Effort_area). Create Project is
+    // the slowest to resolve, so its presence signals completion.
+    await waitForButtonsResolved(window, SEED_AREA_REL, [
+      "Create Task",
+      "Create Project",
+      "Create Area",
+    ]);
   });
 
   test.afterAll(async () => {

--- a/packages/obsidian-plugin/tests/e2e/eka-gui/create-instance-buttons.spec.ts
+++ b/packages/obsidian-plugin/tests/e2e/eka-gui/create-instance-buttons.spec.ts
@@ -5,17 +5,14 @@ import * as fs from "fs";
 import * as path from "path";
 import {
   SEED_AREA_UID,
-  clickCreateButtonAndFill,
+  createOnTarget,
   findByUid,
   launchObsidianWithPlugin,
   listMarkdown,
   log,
-  openAssetAndRender,
   readVaultFile,
   registerConfirmAutoAccept,
-  renderedButtonLabels,
   setupGuiVault,
-  waitForButtonsResolved,
   waitForStoreSettled,
 } from "./eka-gui-helpers";
 
@@ -28,34 +25,32 @@ import {
  * (GUI-BDD-CI Ф4, project node a2e20c69) as repeatable e2e against a FRESH
  * ephemeral vault built from the REAL published `kitelev/exoas-*` ontology repos:
  *
- *   - Create Task    on an ems__Area    → ems:Effort_area  = the area
- *   - Create Project on an ems__Area    → ems:Effort_area  = the area
- *   - Create child Area (#3555)         → ems:Area_parent  = the area  ⚠ REGRESSION
+ *   - Create Task    on an ems__Area    → ems:Effort_area   = the area
+ *   - Create Project on an ems__Area    → ems:Effort_area   = the area
+ *   - Create child Area (#3555)         → ems:Area_parent   = the area  ⚠ REGRESSION
  *   - Create Task    on an ems__Project → ems:Effort_parent = the project
  *   - cleanup-idempotent                → created instances removed, ontologies intact
  *
  * Design (see eka-gui-helpers.ts header): one suite over ONE fresh vault per run
  * ("каждый прогон = новое хранилище"); the create-instance commands + the #3555
  * InheritanceRule run LIVE from the published repos, so a regression of that
- * published content is caught (test-fixture-realism). Scenarios are independent
- * (each re-opens its target + clears modals first) so one failure does not mask
- * the others; `workers: 1` (config) keeps them ordered over the shared window.
+ * published content is caught (test-fixture-realism). Every create goes through
+ * {@link createOnTarget}, which drives the REAL command (CommandExecutionFlow +
+ * native window.confirm auto-accepted) + the DynamicFormModal, then retries
+ * open→click until the inherited backlink lands (the grounding's InheritanceRule
+ * resolution settles a few seconds after the store; first-click can race it).
+ * Every assertion checks REAL on-disk frontmatter — no stubs.
  *
- * The button click drives the REAL command (CommandExecutionFlow.run + native
- * window.confirm auto-accepted) and the resulting DynamicFormModal (a plain
- * React form). Every assertion checks REAL on-disk frontmatter — no stubs.
- *
- * Relationship-key tolerance: the published create-instance InheritanceRules
- * emit the backlink property in EITHER prefixed (`ems__Effort_area`) OR
- * expanded-IRI (`https://exocortex.my/ontology/ems#Effort_area`) form depending
- * on the grounding — observed empirically. Assertions match `/Effort_area/`,
- * `/Effort_parent/`, `/Area_parent/` to accept both; the VALUE (the source
- * asset's uid) is the real invariant under test.
+ * Relationship-key tolerance: published InheritanceRules emit the backlink in
+ * EITHER prefixed (`ems__Effort_area`) OR expanded-IRI
+ * (`https://exocortex.my/ontology/ems#Effort_area`) form per grounding (observed
+ * empirically). Match `/Effort_area/` etc.; the VALUE (source uid) is the
+ * invariant under test.
  *
  * apply-profile (#1), reload-no-hang (#3554) and Create-Meeting are owned by a
  * follow-up (the first two need the apply flow → extend eka-obsidian-leg; the
- * Meeting button renders on a MeetingPrototype-classed INSTANCE, not on the
- * prototype asset itself — separate fixture).
+ * Meeting button binds to a MeetingPrototype-classed INSTANCE, not the prototype
+ * asset itself — separate fixture).
  */
 
 const SEED_AREA_REL = path.posix.join(
@@ -80,16 +75,6 @@ test.describe("EKA GUI — create-instance buttons (fresh real-content vault)", 
     // window.confirm() — auto-accept it under CDP.
     registerConfirmAutoAccept(window);
     await waitForStoreSettled(window);
-    // Warm up resolution: binding + grounding (incl. InheritanceRule) settles
-    // a few seconds after the store; wait until the full create-button set
-    // renders so the FIRST scenario's click fires a fully-resolved grounding
-    // (otherwise the backlink IR is empty → no Effort_area). Create Project is
-    // the slowest to resolve, so its presence signals completion.
-    await waitForButtonsResolved(window, SEED_AREA_REL, [
-      "Create Task",
-      "Create Project",
-      "Create Area",
-    ]);
   });
 
   test.afterAll(async () => {
@@ -100,35 +85,15 @@ test.describe("EKA GUI — create-instance buttons (fresh real-content vault)", 
     }
   });
 
-  // Pick the created file matching a predicate from a click's snapshot diff.
-  const pickCreated = (
-    created: string[],
-    pred: (fm: string) => boolean,
-  ): { rel: string; fm: string } => {
-    for (const rel of created) {
-      const fm = readVaultFile(vaultPath, rel);
-      if (pred(fm)) return { rel, fm };
-    }
-    const dump = created
-      .map((r) => `  ${r}:\n${readVaultFile(vaultPath, r)}`)
-      .join("\n");
-    throw new Error(`No created file matched predicate. Candidates:\n${dump}`);
-  };
-
   test("scenario 2 — Create Task on ems__Area sets Effort_area", async () => {
-    await openAssetAndRender(window, SEED_AREA_REL);
-    log(
-      `buttons on Area: ${JSON.stringify(await renderedButtonLabels(window))}`,
-    );
-    const created = await clickCreateButtonAndFill(
+    const { rel, fm } = await createOnTarget(
       window,
       vaultPath,
+      SEED_AREA_REL,
       "Create Task",
       "E2E Task on Area",
+      /Effort_area/,
     );
-    // Backlink key may be prefixed OR expanded-IRI form — match the property
-    // segment; the source-area uid is the real invariant.
-    const { rel, fm } = pickCreated(created, (f) => /Effort_area/.test(f));
     log(`created task: ${rel}`);
     expect(fm, "task must carry the source area in Effort_area").toContain(
       SEED_AREA_UID,
@@ -136,14 +101,14 @@ test.describe("EKA GUI — create-instance buttons (fresh real-content vault)", 
   });
 
   test("scenario 3 — Create Project on ems__Area sets Effort_area", async () => {
-    await openAssetAndRender(window, SEED_AREA_REL);
-    const created = await clickCreateButtonAndFill(
+    const { rel, fm } = await createOnTarget(
       window,
       vaultPath,
+      SEED_AREA_REL,
       "Create Project",
       "E2E Project on Area",
+      /Effort_area/,
     );
-    const { rel, fm } = pickCreated(created, (f) => /Effort_area/.test(f));
     log(`created project: ${rel}`);
     expect(fm, "project must carry the source area in Effort_area").toContain(
       SEED_AREA_UID,
@@ -151,14 +116,14 @@ test.describe("EKA GUI — create-instance buttons (fresh real-content vault)", 
   });
 
   test("scenario 6 — Create child Area sets ems__Area_parent (#3555 regression)", async () => {
-    await openAssetAndRender(window, SEED_AREA_REL);
-    const created = await clickCreateButtonAndFill(
+    const { rel, fm } = await createOnTarget(
       window,
       vaultPath,
+      SEED_AREA_REL,
       "Create Area",
       "E2E Child Area",
+      /Area_parent/,
     );
-    const { rel, fm } = pickCreated(created, (f) => /Area_parent/.test(f));
     log(`created child area: ${rel}`);
     // #3555: without the published `InheritanceRule uid→ems__Area_parent`
     // (ba0ed3e9) the child area is orphaned (no parent). This is the LIVE
@@ -170,33 +135,27 @@ test.describe("EKA GUI — create-instance buttons (fresh real-content vault)", 
   });
 
   test("scenario 4 — Create Task on ems__Project sets Effort_parent", async () => {
-    // Self-contained: create the project first, then a task on it (no cross-test
-    // state — keeps scenarios independent).
-    await openAssetAndRender(window, SEED_AREA_REL);
-    const projCreated = await clickCreateButtonAndFill(
+    // Self-contained: create the project first, then a task on it.
+    const proj = await createOnTarget(
       window,
       vaultPath,
+      SEED_AREA_REL,
       "Create Project",
       "E2E Project for Task",
+      /Effort_area/,
     );
-    const proj = pickCreated(projCreated, (f) => /Effort_area/.test(f));
     const projUid =
       proj.fm.match(/exo__Asset_uid:\s*([0-9a-f-]{36})/)?.[1] ?? "";
     expect(projUid, "must capture created project uid").not.toBe("");
 
     const projAbs = findByUid(vaultPath, projUid) as string;
-    await openAssetAndRender(window, path.relative(vaultPath, projAbs));
-    log(
-      `buttons on Project: ${JSON.stringify(await renderedButtonLabels(window))}`,
-    );
-    const taskCreated = await clickCreateButtonAndFill(
+    const { rel, fm } = await createOnTarget(
       window,
       vaultPath,
+      path.relative(vaultPath, projAbs),
       "Create Task",
       "E2E Task on Project",
-    );
-    const { rel, fm } = pickCreated(taskCreated, (f) =>
-      /Effort_parent/.test(f),
+      /Effort_parent/,
     );
     log(`created task on project: ${rel}`);
     expect(fm, "task must carry the source project in Effort_parent").toContain(
@@ -205,15 +164,13 @@ test.describe("EKA GUI — create-instance buttons (fresh real-content vault)", 
   });
 
   test("scenario 8 — cleanup removes created instances, leaves ontologies + seed intact", async () => {
-    await openAssetAndRender(window, SEED_AREA_REL);
     const isCreated = (fm: string): boolean =>
       /exo__Asset_label:\s*"?E2E (Task on Area|Project on Area|Child Area|Project for Task|Task on Project)/.test(
         fm,
       );
 
-    const all = listMarkdown(vaultPath);
     let removed = 0;
-    for (const rel of all) {
+    for (const rel of listMarkdown(vaultPath)) {
       if (isCreated(readVaultFile(vaultPath, rel))) {
         fs.rmSync(path.join(vaultPath, rel));
         removed++;

--- a/packages/obsidian-plugin/tests/e2e/eka-gui/create-instance-buttons.spec.ts
+++ b/packages/obsidian-plugin/tests/e2e/eka-gui/create-instance-buttons.spec.ts
@@ -5,7 +5,6 @@ import * as fs from "fs";
 import * as path from "path";
 import {
   SEED_AREA_UID,
-  UID,
   clickCreateButtonAndFill,
   findByUid,
   launchObsidianWithPlugin,
@@ -24,31 +23,38 @@ import {
  *  EKA GUI BDD — create-instance buttons on a fresh, real-content vault
  * ============================================================================
  *
- * Formalises six of the eight Gherkin scenarios from vault node 76d9207c
- * (GUI-BDD-CI Ф4, node a2e20c69) as repeatable e2e against a FRESH ephemeral
- * vault built from the REAL published `kitelev/exoas-*` ontology repos:
+ * Formalises the create-flow Gherkin scenarios of vault node 76d9207c
+ * (GUI-BDD-CI Ф4, project node a2e20c69) as repeatable e2e against a FRESH
+ * ephemeral vault built from the REAL published `kitelev/exoas-*` ontology repos:
  *
- *   2. Create Task   on an ems__Area    → ems__Effort_area = the area
- *   3. Create Project on an ems__Area    → ems__Effort_area = the area
- *   6. Create child Area (#3555)         → ems__Area_parent = the area  ⚠ REGRESSION
- *   4. Create Task   on an ems__Project  → ems__Effort_parent = the project
- *   5. Create Meeting from MeetingPrototype → ems__Meeting (prototype back-link)
- *   8. Cleanup                            → created instances removed, vault clean
+ *   - Create Task    on an ems__Area    → ems:Effort_area  = the area
+ *   - Create Project on an ems__Area    → ems:Effort_area  = the area
+ *   - Create child Area (#3555)         → ems:Area_parent  = the area  ⚠ REGRESSION
+ *   - Create Task    on an ems__Project → ems:Effort_parent = the project
+ *   - cleanup-idempotent                → created instances removed, ontologies intact
  *
- * Design (see eka-gui-helpers.ts header): one serial suite over ONE fresh vault
- * per run ("каждый прогон = новое хранилище") — the create-instance commands +
- * #3555 InheritanceRule are exercised LIVE from the published repos, so a
- * regression of that published content is caught (test-fixture-realism). The
- * full private bootstrap→apply DAG is owned by the sibling eka-obsidian-leg.
+ * Design (see eka-gui-helpers.ts header): one suite over ONE fresh vault per run
+ * ("каждый прогон = новое хранилище"); the create-instance commands + the #3555
+ * InheritanceRule run LIVE from the published repos, so a regression of that
+ * published content is caught (test-fixture-realism). Scenarios are independent
+ * (each re-opens its target + clears modals first) so one failure does not mask
+ * the others; `workers: 1` (config) keeps them ordered over the shared window.
  *
- * One scenario = one `test()` block (a distinct reportable unit). They share a
- * single launched Obsidian over a single fresh vault rather than one fresh
- * vault + cold Obsidian boot per file, because eight cold boots × a multi-repo
- * clone would blow the CI budget — the per-run freshness invariant is preserved.
+ * The button click drives the REAL command (CommandExecutionFlow.run + native
+ * window.confirm auto-accepted) and the resulting DynamicFormModal (a plain
+ * React form). Every assertion checks REAL on-disk frontmatter — no stubs.
  *
- * The button click drives the REAL command (CommandExecutionFlow.run) and the
- * resulting DynamicFormModal (a plain React form, unlike the un-drivable fuzzy
- * picker). Every assertion checks REAL on-disk frontmatter — no stubs.
+ * Relationship-key tolerance: the published create-instance InheritanceRules
+ * emit the backlink property in EITHER prefixed (`ems__Effort_area`) OR
+ * expanded-IRI (`https://exocortex.my/ontology/ems#Effort_area`) form depending
+ * on the grounding — observed empirically. Assertions match `/Effort_area/`,
+ * `/Effort_parent/`, `/Area_parent/` to accept both; the VALUE (the source
+ * asset's uid) is the real invariant under test.
+ *
+ * apply-profile (#1), reload-no-hang (#3554) and Create-Meeting are owned by a
+ * follow-up (the first two need the apply flow → extend eka-obsidian-leg; the
+ * Meeting button renders on a MeetingPrototype-classed INSTANCE, not on the
+ * prototype asset itself — separate fixture).
  */
 
 const SEED_AREA_REL = path.posix.join(
@@ -56,34 +62,23 @@ const SEED_AREA_REL = path.posix.join(
   `${SEED_AREA_UID}.md`,
 );
 
-// Shared vault/window across steps (workers:1 in the config keeps them ordered).
-// NOTE: intentionally NOT `mode: "serial"` during bring-up — a single failing
-// scenario must not skip the rest, so one CI run surfaces every grounding's
-// real on-disk behaviour. (createCommandAndFill logs each created file.)
+// Independent scenarios over a shared window (workers:1 keeps them ordered).
 test.describe.configure({ mode: "default" });
 
 test.describe("EKA GUI — create-instance buttons (fresh real-content vault)", () => {
   let vaultPath = "";
   let launcher: ObsidianLauncher | null = null;
   let window: Page;
-  // Carried across the serial steps: the project created in scenario 3 is the
-  // target for scenario 4 (Create Task on Project).
-  let createdProjectUid = "";
 
   test.beforeAll(async () => {
     test.setTimeout(600_000);
     vaultPath = setupGuiVault();
     launcher = await launchObsidianWithPlugin(vaultPath, "eka-gui");
     window = await launcher.getWindow();
-    // Create commands with `confirmMessage` (Create Project / Create Meeting)
-    // call native window.confirm() — auto-accept it under CDP.
+    // Create commands with `confirmMessage` (Create Project) call native
+    // window.confirm() — auto-accept it under CDP.
     registerConfirmAutoAccept(window);
     await waitForStoreSettled(window);
-    await openAssetAndRender(window, SEED_AREA_REL);
-    // Diagnostic: surface the buttons the published bindings render on an Area.
-    log(
-      `buttons on seed Area: ${JSON.stringify(await renderedButtonLabels(window))}`,
-    );
   });
 
   test.afterAll(async () => {
@@ -94,7 +89,7 @@ test.describe("EKA GUI — create-instance buttons (fresh real-content vault)", 
     }
   });
 
-  // Extract the new instance file matching a predicate from the snapshot diff.
+  // Pick the created file matching a predicate from a click's snapshot diff.
   const pickCreated = (
     created: string[],
     pred: (fm: string) => boolean,
@@ -104,30 +99,32 @@ test.describe("EKA GUI — create-instance buttons (fresh real-content vault)", 
       if (pred(fm)) return { rel, fm };
     }
     const dump = created
-      .map((r) => `  ${r}:\n${readVaultFile(vaultPath, r).slice(0, 240)}`)
+      .map((r) => `  ${r}:\n${readVaultFile(vaultPath, r)}`)
       .join("\n");
     throw new Error(`No created file matched predicate. Candidates:\n${dump}`);
   };
 
-  test("scenario 2 — Create Task on ems__Area sets ems__Effort_area", async () => {
+  test("scenario 2 — Create Task on ems__Area sets Effort_area", async () => {
     await openAssetAndRender(window, SEED_AREA_REL);
+    log(
+      `buttons on Area: ${JSON.stringify(await renderedButtonLabels(window))}`,
+    );
     const created = await clickCreateButtonAndFill(
       window,
       vaultPath,
       "Create Task",
       "E2E Task on Area",
     );
-    const { rel, fm } = pickCreated(created, (f) =>
-      f.includes("ems__Effort_area"),
-    );
+    // Backlink key may be prefixed OR expanded-IRI form — match the property
+    // segment; the source-area uid is the real invariant.
+    const { rel, fm } = pickCreated(created, (f) => /Effort_area/.test(f));
     log(`created task: ${rel}`);
-    expect(fm, "task must carry the source area in ems__Effort_area").toContain(
+    expect(fm, "task must carry the source area in Effort_area").toContain(
       SEED_AREA_UID,
     );
-    expect(fm).toMatch(/ems__Effort_area/);
   });
 
-  test("scenario 3 — Create Project on ems__Area sets ems__Effort_area", async () => {
+  test("scenario 3 — Create Project on ems__Area sets Effort_area", async () => {
     await openAssetAndRender(window, SEED_AREA_REL);
     const created = await clickCreateButtonAndFill(
       window,
@@ -135,23 +132,11 @@ test.describe("EKA GUI — create-instance buttons (fresh real-content vault)", 
       "Create Project",
       "E2E Project on Area",
     );
-    // The create-Project button's own click-diff yields the project file; match
-    // on the area relationship (class may be expressed via prototype not a bare
-    // UID, so don't hard-require the class UID).
-    const { rel, fm } = pickCreated(created, (f) =>
-      f.includes("ems__Effort_area"),
-    );
+    const { rel, fm } = pickCreated(created, (f) => /Effort_area/.test(f));
     log(`created project: ${rel}`);
-    expect(
-      fm,
-      "project must carry the source area in ems__Effort_area",
-    ).toContain(SEED_AREA_UID);
-    const m = fm.match(/exo__Asset_uid:\s*([0-9a-f-]{36})/);
-    createdProjectUid = m?.[1] ?? "";
-    expect(
-      createdProjectUid,
-      "must capture created project uid for scenario 4",
-    ).not.toBe("");
+    expect(fm, "project must carry the source area in Effort_area").toContain(
+      SEED_AREA_UID,
+    );
   });
 
   test("scenario 6 — Create child Area sets ems__Area_parent (#3555 regression)", async () => {
@@ -162,91 +147,63 @@ test.describe("EKA GUI — create-instance buttons (fresh real-content vault)", 
       "Create Area",
       "E2E Child Area",
     );
-    // The #3555 signal (`ems__Area_parent`) is unambiguous within this click's
-    // diff — match on it directly (don't hard-require the class UID form).
-    const { rel, fm } = pickCreated(created, (f) =>
-      f.includes("ems__Area_parent"),
-    );
+    const { rel, fm } = pickCreated(created, (f) => /Area_parent/.test(f));
     log(`created child area: ${rel}`);
     // #3555: without the published `InheritanceRule uid→ems__Area_parent`
-    // (ba0ed3e9) the child area is orphaned (no parent). This is the live
+    // (ba0ed3e9) the child area is orphaned (no parent). This is the LIVE
     // regression gate — it fails if that rule regresses in exoas-exocmd.
     expect(
       fm,
-      "child area MUST set ems__Area_parent to the source area (#3555)",
+      "child area MUST set Area_parent to the source area (#3555)",
     ).toContain(SEED_AREA_UID);
-    expect(fm).toMatch(/ems__Area_parent/);
   });
 
-  test("scenario 4 — Create Task on ems__Project sets ems__Effort_parent", async () => {
-    expect(
-      createdProjectUid,
-      "scenario 3 must have produced a project",
-    ).not.toBe("");
-    const projAbs = findByUid(vaultPath, createdProjectUid);
-    expect(projAbs, "created project file must exist on disk").not.toBeNull();
-    const projRel = path.relative(vaultPath, projAbs as string);
-
-    await openAssetAndRender(window, projRel);
-    log(
-      `buttons on created Project: ${JSON.stringify(await renderedButtonLabels(window))}`,
+  test("scenario 4 — Create Task on ems__Project sets Effort_parent", async () => {
+    // Self-contained: create the project first, then a task on it (no cross-test
+    // state — keeps scenarios independent).
+    await openAssetAndRender(window, SEED_AREA_REL);
+    const projCreated = await clickCreateButtonAndFill(
+      window,
+      vaultPath,
+      "Create Project",
+      "E2E Project for Task",
     );
-    const created = await clickCreateButtonAndFill(
+    const proj = pickCreated(projCreated, (f) => /Effort_area/.test(f));
+    const projUid =
+      proj.fm.match(/exo__Asset_uid:\s*([0-9a-f-]{36})/)?.[1] ?? "";
+    expect(projUid, "must capture created project uid").not.toBe("");
+
+    const projAbs = findByUid(vaultPath, projUid) as string;
+    await openAssetAndRender(window, path.relative(vaultPath, projAbs));
+    log(
+      `buttons on Project: ${JSON.stringify(await renderedButtonLabels(window))}`,
+    );
+    const taskCreated = await clickCreateButtonAndFill(
       window,
       vaultPath,
       "Create Task",
       "E2E Task on Project",
     );
-    const { rel, fm } = pickCreated(created, (f) =>
-      f.includes("ems__Effort_parent"),
+    const { rel, fm } = pickCreated(taskCreated, (f) =>
+      /Effort_parent/.test(f),
     );
     log(`created task on project: ${rel}`);
-    expect(
-      fm,
-      "task must carry the source project in ems__Effort_parent",
-    ).toContain(createdProjectUid);
-    expect(fm).toMatch(/ems__Effort_parent/);
-  });
-
-  test("scenario 5 — Create Meeting from ems__MeetingPrototype", async () => {
-    const protoAbs = findByUid(vaultPath, UID.meetingPrototype);
-    expect(
-      protoAbs,
-      "MeetingPrototype must be present from exoas-public",
-    ).not.toBeNull();
-    const protoRel = path.relative(vaultPath, protoAbs as string);
-
-    await openAssetAndRender(window, protoRel);
-    log(
-      `buttons on MeetingPrototype: ${JSON.stringify(await renderedButtonLabels(window))}`,
-    );
-    const created = await clickCreateButtonAndFill(
-      window,
-      vaultPath,
-      "Create Meeting Instance",
-      "E2E Meeting",
-    );
-    // The prototype-binding executor writes a back-link prototype on the new file.
-    const { rel, fm } = pickCreated(created, (f) =>
-      f.includes(UID.meetingPrototype),
-    );
-    log(`created meeting: ${rel}`);
-    expect(fm, "meeting must reference its MeetingPrototype").toContain(
-      UID.meetingPrototype,
+    expect(fm, "task must carry the source project in Effort_parent").toContain(
+      projUid,
     );
   });
 
   test("scenario 8 — cleanup removes created instances, leaves ontologies + seed intact", async () => {
-    // Delete every test-created instance: anything carrying one of our e2e labels.
+    await openAssetAndRender(window, SEED_AREA_REL);
+    const isCreated = (fm: string): boolean =>
+      /exo__Asset_label:\s*"?E2E (Task on Area|Project on Area|Child Area|Project for Task|Task on Project)/.test(
+        fm,
+      );
+
     const all = listMarkdown(vaultPath);
     let removed = 0;
     for (const rel of all) {
-      const fm = readVaultFile(vaultPath, rel);
-      if (
-        /exo__Asset_label:\s*"?E2E (Task on Area|Project on Area|Child Area|Task on Project|Meeting)/.test(
-          fm,
-        )
-      ) {
+      if (isCreated(readVaultFile(vaultPath, rel))) {
         fs.rmSync(path.join(vaultPath, rel));
         removed++;
       }
@@ -254,19 +211,14 @@ test.describe("EKA GUI — create-instance buttons (fresh real-content vault)", 
     log(`cleanup removed ${removed} created instance(s)`);
     expect(
       removed,
-      "cleanup must have something to remove (created instances)",
+      "cleanup must remove the created instances",
     ).toBeGreaterThan(0);
 
-    // Idempotent: a second sweep removes nothing.
-    const second = listMarkdown(vaultPath).filter((rel) =>
-      /exo__Asset_label:\s*"?E2E (Task on Area|Project on Area|Child Area|Task on Project|Meeting)/.test(
-        readVaultFile(vaultPath, rel),
-      ),
+    // Idempotent: nothing matching remains.
+    const remaining = listMarkdown(vaultPath).filter((rel) =>
+      isCreated(readVaultFile(vaultPath, rel)),
     );
-    expect(
-      second.length,
-      "no created instances should remain after cleanup",
-    ).toBe(0);
+    expect(remaining.length, "no created instances should remain").toBe(0);
 
     // Seed + published ontology survive.
     expect(
@@ -274,12 +226,8 @@ test.describe("EKA GUI — create-instance buttons (fresh real-content vault)", 
       "seed area must remain",
     ).not.toBeNull();
     expect(
-      findByUid(vaultPath, UID.emsAreaClass),
+      findByUid(vaultPath, "82c74542-1b14-4217-b852-d84730484b25"),
       "ems__Area class must remain",
-    ).not.toBeNull();
-    expect(
-      findByUid(vaultPath, UID.meetingPrototype),
-      "MeetingPrototype must remain",
     ).not.toBeNull();
   });
 });

--- a/packages/obsidian-plugin/tests/e2e/eka-gui/create-instance-buttons.spec.ts
+++ b/packages/obsidian-plugin/tests/e2e/eka-gui/create-instance-buttons.spec.ts
@@ -1,0 +1,282 @@
+import { test, expect } from "@playwright/test";
+import type { Page } from "@playwright/test";
+import { ObsidianLauncher } from "../utils/obsidian-launcher";
+import * as fs from "fs";
+import * as path from "path";
+import {
+  SEED_AREA_UID,
+  UID,
+  clickCreateButtonAndFill,
+  findByUid,
+  launchObsidianWithPlugin,
+  listMarkdown,
+  log,
+  openAssetAndRender,
+  readVaultFile,
+  registerConfirmAutoAccept,
+  renderedButtonLabels,
+  setupGuiVault,
+  waitForStoreSettled,
+} from "./eka-gui-helpers";
+
+/**
+ * ============================================================================
+ *  EKA GUI BDD — create-instance buttons on a fresh, real-content vault
+ * ============================================================================
+ *
+ * Formalises six of the eight Gherkin scenarios from vault node 76d9207c
+ * (GUI-BDD-CI Ф4, node a2e20c69) as repeatable e2e against a FRESH ephemeral
+ * vault built from the REAL published `kitelev/exoas-*` ontology repos:
+ *
+ *   2. Create Task   on an ems__Area    → ems__Effort_area = the area
+ *   3. Create Project on an ems__Area    → ems__Effort_area = the area
+ *   6. Create child Area (#3555)         → ems__Area_parent = the area  ⚠ REGRESSION
+ *   4. Create Task   on an ems__Project  → ems__Effort_parent = the project
+ *   5. Create Meeting from MeetingPrototype → ems__Meeting (prototype back-link)
+ *   8. Cleanup                            → created instances removed, vault clean
+ *
+ * Design (see eka-gui-helpers.ts header): one serial suite over ONE fresh vault
+ * per run ("каждый прогон = новое хранилище") — the create-instance commands +
+ * #3555 InheritanceRule are exercised LIVE from the published repos, so a
+ * regression of that published content is caught (test-fixture-realism). The
+ * full private bootstrap→apply DAG is owned by the sibling eka-obsidian-leg.
+ *
+ * One scenario = one `test()` block (a distinct reportable unit). They share a
+ * single launched Obsidian over a single fresh vault rather than one fresh
+ * vault + cold Obsidian boot per file, because eight cold boots × a multi-repo
+ * clone would blow the CI budget — the per-run freshness invariant is preserved.
+ *
+ * The button click drives the REAL command (CommandExecutionFlow.run) and the
+ * resulting DynamicFormModal (a plain React form, unlike the un-drivable fuzzy
+ * picker). Every assertion checks REAL on-disk frontmatter — no stubs.
+ */
+
+const SEED_AREA_REL = path.posix.join(
+  "assetspaces/kitelev/exoas-public/ems",
+  `${SEED_AREA_UID}.md`,
+);
+
+// Configure the whole alpha-create path as a serial suite (shared vault/window).
+test.describe.configure({ mode: "serial" });
+
+test.describe("EKA GUI — create-instance buttons (fresh real-content vault)", () => {
+  let vaultPath = "";
+  let launcher: ObsidianLauncher | null = null;
+  let window: Page;
+  // Carried across the serial steps: the project created in scenario 3 is the
+  // target for scenario 4 (Create Task on Project).
+  let createdProjectUid = "";
+
+  test.beforeAll(async () => {
+    test.setTimeout(600_000);
+    vaultPath = setupGuiVault();
+    launcher = await launchObsidianWithPlugin(vaultPath, "eka-gui");
+    window = await launcher.getWindow();
+    // Create commands with `confirmMessage` (Create Project / Create Meeting)
+    // call native window.confirm() — auto-accept it under CDP.
+    registerConfirmAutoAccept(window);
+    await waitForStoreSettled(window);
+    await openAssetAndRender(window, SEED_AREA_REL);
+    // Diagnostic: surface the buttons the published bindings render on an Area.
+    log(
+      `buttons on seed Area: ${JSON.stringify(await renderedButtonLabels(window))}`,
+    );
+  });
+
+  test.afterAll(async () => {
+    if (launcher) await launcher.close().catch(() => undefined);
+    if (vaultPath && fs.existsSync(vaultPath)) {
+      fs.rmSync(vaultPath, { recursive: true, force: true });
+      log(`cleaned up vault ${vaultPath}`);
+    }
+  });
+
+  // Extract the new instance file matching a predicate from the snapshot diff.
+  const pickCreated = (
+    created: string[],
+    pred: (fm: string) => boolean,
+  ): { rel: string; fm: string } => {
+    for (const rel of created) {
+      const fm = readVaultFile(vaultPath, rel);
+      if (pred(fm)) return { rel, fm };
+    }
+    const dump = created
+      .map((r) => `  ${r}:\n${readVaultFile(vaultPath, r).slice(0, 240)}`)
+      .join("\n");
+    throw new Error(`No created file matched predicate. Candidates:\n${dump}`);
+  };
+
+  test("scenario 2 — Create Task on ems__Area sets ems__Effort_area", async () => {
+    await openAssetAndRender(window, SEED_AREA_REL);
+    const created = await clickCreateButtonAndFill(
+      window,
+      vaultPath,
+      "Create Task",
+      "E2E Task on Area",
+    );
+    const { rel, fm } = pickCreated(created, (f) =>
+      f.includes("ems__Effort_area"),
+    );
+    log(`created task: ${rel}`);
+    expect(fm, "task must carry the source area in ems__Effort_area").toContain(
+      SEED_AREA_UID,
+    );
+    expect(fm).toMatch(/ems__Effort_area/);
+  });
+
+  test("scenario 3 — Create Project on ems__Area sets ems__Effort_area", async () => {
+    await openAssetAndRender(window, SEED_AREA_REL);
+    const created = await clickCreateButtonAndFill(
+      window,
+      vaultPath,
+      "Create Project",
+      "E2E Project on Area",
+    );
+    // The create-Project button's own click-diff yields the project file; match
+    // on the area relationship (class may be expressed via prototype not a bare
+    // UID, so don't hard-require the class UID).
+    const { rel, fm } = pickCreated(created, (f) =>
+      f.includes("ems__Effort_area"),
+    );
+    log(`created project: ${rel}`);
+    expect(
+      fm,
+      "project must carry the source area in ems__Effort_area",
+    ).toContain(SEED_AREA_UID);
+    const m = fm.match(/exo__Asset_uid:\s*([0-9a-f-]{36})/);
+    createdProjectUid = m?.[1] ?? "";
+    expect(
+      createdProjectUid,
+      "must capture created project uid for scenario 4",
+    ).not.toBe("");
+  });
+
+  test("scenario 6 — Create child Area sets ems__Area_parent (#3555 regression)", async () => {
+    await openAssetAndRender(window, SEED_AREA_REL);
+    const created = await clickCreateButtonAndFill(
+      window,
+      vaultPath,
+      "Create Area",
+      "E2E Child Area",
+    );
+    // The #3555 signal (`ems__Area_parent`) is unambiguous within this click's
+    // diff — match on it directly (don't hard-require the class UID form).
+    const { rel, fm } = pickCreated(created, (f) =>
+      f.includes("ems__Area_parent"),
+    );
+    log(`created child area: ${rel}`);
+    // #3555: without the published `InheritanceRule uid→ems__Area_parent`
+    // (ba0ed3e9) the child area is orphaned (no parent). This is the live
+    // regression gate — it fails if that rule regresses in exoas-exocmd.
+    expect(
+      fm,
+      "child area MUST set ems__Area_parent to the source area (#3555)",
+    ).toContain(SEED_AREA_UID);
+    expect(fm).toMatch(/ems__Area_parent/);
+  });
+
+  test("scenario 4 — Create Task on ems__Project sets ems__Effort_parent", async () => {
+    expect(
+      createdProjectUid,
+      "scenario 3 must have produced a project",
+    ).not.toBe("");
+    const projAbs = findByUid(vaultPath, createdProjectUid);
+    expect(projAbs, "created project file must exist on disk").not.toBeNull();
+    const projRel = path.relative(vaultPath, projAbs as string);
+
+    await openAssetAndRender(window, projRel);
+    log(
+      `buttons on created Project: ${JSON.stringify(await renderedButtonLabels(window))}`,
+    );
+    const created = await clickCreateButtonAndFill(
+      window,
+      vaultPath,
+      "Create Task",
+      "E2E Task on Project",
+    );
+    const { rel, fm } = pickCreated(created, (f) =>
+      f.includes("ems__Effort_parent"),
+    );
+    log(`created task on project: ${rel}`);
+    expect(
+      fm,
+      "task must carry the source project in ems__Effort_parent",
+    ).toContain(createdProjectUid);
+    expect(fm).toMatch(/ems__Effort_parent/);
+  });
+
+  test("scenario 5 — Create Meeting from ems__MeetingPrototype", async () => {
+    const protoAbs = findByUid(vaultPath, UID.meetingPrototype);
+    expect(
+      protoAbs,
+      "MeetingPrototype must be present from exoas-public",
+    ).not.toBeNull();
+    const protoRel = path.relative(vaultPath, protoAbs as string);
+
+    await openAssetAndRender(window, protoRel);
+    log(
+      `buttons on MeetingPrototype: ${JSON.stringify(await renderedButtonLabels(window))}`,
+    );
+    const created = await clickCreateButtonAndFill(
+      window,
+      vaultPath,
+      "Create Meeting Instance",
+      "E2E Meeting",
+    );
+    // The prototype-binding executor writes a back-link prototype on the new file.
+    const { rel, fm } = pickCreated(created, (f) =>
+      f.includes(UID.meetingPrototype),
+    );
+    log(`created meeting: ${rel}`);
+    expect(fm, "meeting must reference its MeetingPrototype").toContain(
+      UID.meetingPrototype,
+    );
+  });
+
+  test("scenario 8 — cleanup removes created instances, leaves ontologies + seed intact", async () => {
+    // Delete every test-created instance: anything carrying one of our e2e labels.
+    const all = listMarkdown(vaultPath);
+    let removed = 0;
+    for (const rel of all) {
+      const fm = readVaultFile(vaultPath, rel);
+      if (
+        /exo__Asset_label:\s*"?E2E (Task on Area|Project on Area|Child Area|Task on Project|Meeting)/.test(
+          fm,
+        )
+      ) {
+        fs.rmSync(path.join(vaultPath, rel));
+        removed++;
+      }
+    }
+    log(`cleanup removed ${removed} created instance(s)`);
+    expect(
+      removed,
+      "cleanup must have something to remove (created instances)",
+    ).toBeGreaterThan(0);
+
+    // Idempotent: a second sweep removes nothing.
+    const second = listMarkdown(vaultPath).filter((rel) =>
+      /exo__Asset_label:\s*"?E2E (Task on Area|Project on Area|Child Area|Task on Project|Meeting)/.test(
+        readVaultFile(vaultPath, rel),
+      ),
+    );
+    expect(
+      second.length,
+      "no created instances should remain after cleanup",
+    ).toBe(0);
+
+    // Seed + published ontology survive.
+    expect(
+      findByUid(vaultPath, SEED_AREA_UID),
+      "seed area must remain",
+    ).not.toBeNull();
+    expect(
+      findByUid(vaultPath, UID.emsAreaClass),
+      "ems__Area class must remain",
+    ).not.toBeNull();
+    expect(
+      findByUid(vaultPath, UID.meetingPrototype),
+      "MeetingPrototype must remain",
+    ).not.toBeNull();
+  });
+});

--- a/packages/obsidian-plugin/tests/e2e/eka-gui/create-instance-buttons.spec.ts
+++ b/packages/obsidian-plugin/tests/e2e/eka-gui/create-instance-buttons.spec.ts
@@ -56,8 +56,11 @@ const SEED_AREA_REL = path.posix.join(
   `${SEED_AREA_UID}.md`,
 );
 
-// Configure the whole alpha-create path as a serial suite (shared vault/window).
-test.describe.configure({ mode: "serial" });
+// Shared vault/window across steps (workers:1 in the config keeps them ordered).
+// NOTE: intentionally NOT `mode: "serial"` during bring-up — a single failing
+// scenario must not skip the rest, so one CI run surfaces every grounding's
+// real on-disk behaviour. (createCommandAndFill logs each created file.)
+test.describe.configure({ mode: "default" });
 
 test.describe("EKA GUI — create-instance buttons (fresh real-content vault)", () => {
   let vaultPath = "";

--- a/packages/obsidian-plugin/tests/e2e/eka-gui/eka-gui-helpers.ts
+++ b/packages/obsidian-plugin/tests/e2e/eka-gui/eka-gui-helpers.ts
@@ -375,11 +375,33 @@ export function registerConfirmAutoAccept(window: Page): void {
   });
 }
 
+/**
+ * Dismiss any lingering modal (DynamicFormModal / confirm) via Escape, so a
+ * leftover overlay from a prior scenario doesn't hide the action buttons of the
+ * next. Idempotent: no-op when nothing is open.
+ */
+export async function clearModals(window: Page): Promise<void> {
+  for (let i = 0; i < 4; i++) {
+    const open = await window
+      .locator(".modal-container")
+      .isVisible()
+      .catch(() => false);
+    if (!open) return;
+    await window.keyboard.press("Escape");
+    await window
+      .locator(".modal-container")
+      .waitFor({ state: "hidden", timeout: 2000 })
+      .catch(() => undefined);
+  }
+}
+
 /** Open a vault file in a fresh leaf and force a layout render (buttons appear). */
 export async function openAssetAndRender(
   window: Page,
   relPath: string,
 ): Promise<void> {
+  // Clear any leftover modal first (prior scenario's create form / confirm).
+  await clearModals(window);
   // A just-created asset can lag the in-memory vault tree (fs-move bypasses the
   // create-event). Poll until Obsidian has indexed it before opening.
   await pollUntil(
@@ -454,6 +476,12 @@ export async function clickCreateButtonAndFill(
     .locator(".dynamic-form .modal-button-container button.mod-cta")
     .first()
     .click();
+
+  // The form modal closes on submit; wait so it can't shadow the next scenario.
+  await window
+    .locator(".dynamic-form")
+    .waitFor({ state: "hidden", timeout: 10_000 })
+    .catch(() => undefined);
 
   // The grounding writes to disk async. Poll for a NEW .md file to appear.
   let created: string[] = [];

--- a/packages/obsidian-plugin/tests/e2e/eka-gui/eka-gui-helpers.ts
+++ b/packages/obsidian-plugin/tests/e2e/eka-gui/eka-gui-helpers.ts
@@ -1,0 +1,477 @@
+import { expect } from "@playwright/test";
+import type { Page } from "@playwright/test";
+import { ObsidianLauncher } from "../utils/obsidian-launcher";
+import { waitForExocortexPluginViaPlaywright } from "../utils/waitForExocortexPlugin";
+import { execFileSync } from "child_process";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+
+/**
+ * ============================================================================
+ *  EKA GUI BDD — shared fresh-vault fixture + drive helpers
+ * ============================================================================
+ *
+ * Backs the GUI-BDD-CI suite (node a2e20c69 Ф4): the prose Gherkin scenarios in
+ * vault node 76d9207c, formalised as repeatable e2e specs that exercise the
+ * Exocortex *plugin* against a FRESH ephemeral vault built from the REAL
+ * published `kitelev/exoas-*` ontology repos.
+ *
+ * ---------------------------------------------------------------------------
+ * WHY "real published content" instead of hand-written fixtures
+ * ---------------------------------------------------------------------------
+ * The create-instance commands, their groundings/bindings, and especially the
+ * #3555 `InheritanceRule: uid→ems__Area_parent` live in the PUBLISHED
+ * `exoas-exocmd` / `exoas-public` repos — NOT in this codebase. A hand-seeded
+ * fixture would test a static COPY and give false confidence: a regression of
+ * the published command content (which is what #3554/#3555 guard) would be
+ * invisible. So this fixture `git clone`s the three PUBLIC repos
+ * (`exoas-exo` + `exoas-exocmd` + `exoas-public`) into the ephemeral vault, then
+ * exercises the live commands. (test-fixture-realism.)
+ *
+ * ---------------------------------------------------------------------------
+ * WHY this is NOT one of the 13 required CI checks
+ * ---------------------------------------------------------------------------
+ * It lives OUTSIDE `tests/e2e/specs`, so the 6 sharded configs + the
+ * `validate-shard-assignments.mjs` drift guard never see it. The three repos
+ * are PUBLIC, so the suite needs NO PAT and clones unauthenticated (an optional
+ * `GH_TOKEN`/`GITHUB_TOKEN` is used only to lift the anonymous API rate limit).
+ * It runs on push-to-main / nightly / dispatch — the "авто на каждом релизе"
+ * release-gate cadence the node DoD asks for — without ever PR-blocking on
+ * network/QEMU flake (perf-tests-dont-hard-gate-ci).
+ *
+ * Apply-profile fidelity (the full private bootstrap→add→apply DAG) is owned by
+ * the sibling `tests/e2e/eka/eka-obsidian-leg.spec.ts` (REGISTRY_TOKEN-gated).
+ */
+
+// ---- Published PUBLIC ontology repos (verified public 2026-06-16) ----------
+const EXO_URL = "https://github.com/kitelev/exoas-exo";
+const EXOCMD_URL = "https://github.com/kitelev/exoas-exocmd";
+const PUBLIC_URL = "https://github.com/kitelev/exoas-public";
+
+// Mount paths mirror the real Maven layout (`assetspaces/<owner>/<repo>`) so the
+// co-location resolver (`findReferencedFile`) finds the ontology anchors and the
+// create-instance grounding co-locates new assets next to them.
+const EXO_DIR = "assetspaces/kitelev/exoas-exo";
+const EXOCMD_DIR = "assetspaces/kitelev/exoas-exocmd";
+const PUBLIC_DIR = "assetspaces/kitelev/exoas-public";
+
+// ---- Fixture constants (verified against published exoas-public 2026-06-16) --
+export const UID = {
+  emsAreaClass: "82c74542-1b14-4217-b852-d84730484b25", // ems__Area class
+  emsTaskClass: "1b20a8f0-d745-4e93-91db-4531b3df120e", // ems__Task class
+  emsProjectClass: "7db5eeff-718a-49b0-8d2b-39b084a356e3", // ems__Project class
+  emsAnchor: "f6e01f7a-d727-494a-82a3-815597d33e86", // ems ontology anchor (isDefinedBy)
+  meetingPrototype: "7ab483c7-aafc-4ac8-8aca-0de52db34a93", // ems__MeetingPrototype
+  // #3555: InheritanceRule uid→ems__Area_parent — exercised live, not seeded.
+  areaParentInheritanceRule: "ba0ed3e9-9749-474f-b994-654d4dede2c5",
+} as const;
+
+/** Stable UID of the single seeded ems__Area the create-button scenarios target. */
+export const SEED_AREA_UID = "e2e0a4ea-0000-4000-a000-000000000001";
+export const SEED_AREA_LABEL = "EKA E2E Seed Area";
+
+export function log(msg: string): void {
+  // eslint-disable-next-line no-console
+  console.log(`[eka-gui] ${msg}`);
+}
+
+/** Run a git command in `cwd` (used only for ephemeral-vault setup). */
+function git(args: string[], cwd?: string): string {
+  return execFileSync("git", args, {
+    cwd,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  }).trim();
+}
+
+/** Optional token (CI `GITHUB_TOKEN`) lifts the anon clone rate limit; not required. */
+function cloneUrl(httpsUrl: string): string {
+  const tok = process.env.GH_TOKEN || process.env.GITHUB_TOKEN || "";
+  if (!tok) return httpsUrl;
+  return httpsUrl.replace(
+    "https://github.com/",
+    `https://x-access-token:${tok}@github.com/`,
+  );
+}
+
+/** Shallow-clone a public repo into `<vault>/<destRel>`. */
+function cloneAssetSpace(
+  httpsUrl: string,
+  vaultPath: string,
+  destRel: string,
+): void {
+  const dest = path.join(vaultPath, destRel);
+  fs.mkdirSync(path.dirname(dest), { recursive: true });
+  git(["clone", "--depth", "1", "--quiet", cloneUrl(httpsUrl), dest]);
+  // Drop the nested .git so the outer vault `git add -A` does not choke on an
+  // embedded repo / submodule-like gitlink — we only need the working tree.
+  fs.rmSync(path.join(dest, ".git"), { recursive: true, force: true });
+}
+
+/**
+ * Build a fresh ephemeral git vault:
+ *   - the prebuilt plugin (main.js + manifest.json) installed + community-enabled,
+ *   - the three PUBLIC ontology repos cloned in (real published commands),
+ *   - ONE seed ems__Area the create-button scenarios target,
+ *   - committed clean so any apply-style guard sees no dirt.
+ * Returns the absolute vault path (caller owns teardown).
+ */
+export function setupGuiVault(): string {
+  const vaultPath = fs.mkdtempSync(path.join(os.tmpdir(), "eka-gui-vault-"));
+
+  // __dirname = …/packages/obsidian-plugin/tests/e2e/eka-gui → up 4 to package.
+  const pluginSrcDir = path.join(__dirname, "..", "..", "..");
+  const mainJs = path.join(pluginSrcDir, "main.js");
+  const manifest = path.join(pluginSrcDir, "manifest.json");
+  if (!fs.existsSync(mainJs) || !fs.existsSync(manifest)) {
+    throw new Error(
+      `Prebuilt plugin not found (main.js/manifest.json). Run \`npm run build\` ` +
+        `before this suite. Looked in ${pluginSrcDir}`,
+    );
+  }
+
+  const obsidianDir = path.join(vaultPath, ".obsidian");
+  const pluginDir = path.join(obsidianDir, "plugins", "exocortex");
+  fs.mkdirSync(pluginDir, { recursive: true });
+  fs.copyFileSync(mainJs, path.join(pluginDir, "main.js"));
+  fs.copyFileSync(manifest, path.join(pluginDir, "manifest.json"));
+  fs.writeFileSync(
+    path.join(obsidianDir, "community-plugins.json"),
+    JSON.stringify(["exocortex"]),
+  );
+  fs.writeFileSync(
+    path.join(obsidianDir, "app.json"),
+    JSON.stringify({ promptDelete: false }),
+  );
+  // Keep .obsidian + plugin runtime dirs out of git so `git add -A` stays clean.
+  fs.writeFileSync(
+    path.join(vaultPath, ".gitignore"),
+    ".obsidian/\n.exocortex/\n",
+  );
+  // The plugin's lock manager + switch journal write into `.exocortex/`; a fresh
+  // vault lacks it, so adapter.write ENOENTs without a parent dir. Pre-create it.
+  fs.mkdirSync(path.join(vaultPath, ".exocortex"), { recursive: true });
+
+  // Real published ontology content → live create-instance commands + #3555 rule.
+  log("cloning public ontology repos (exo + exocmd + public)…");
+  cloneAssetSpace(EXO_URL, vaultPath, EXO_DIR);
+  cloneAssetSpace(EXOCMD_URL, vaultPath, EXOCMD_DIR);
+  cloneAssetSpace(PUBLIC_URL, vaultPath, PUBLIC_DIR);
+
+  // Seed exactly ONE ems__Area (the DoD's "seed одна ems__Area"). Co-located in
+  // the ems ontology folder (its isDefinedBy anchor) so discovery + the
+  // create-grounding's co-location resolve cleanly.
+  const seedDir = path.join(vaultPath, PUBLIC_DIR, "ems");
+  fs.mkdirSync(seedDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(seedDir, `${SEED_AREA_UID}.md`),
+    `---\n` +
+      `exo__Asset_uid: ${SEED_AREA_UID}\n` +
+      `exo__Instance_class:\n  - "[[${UID.emsAreaClass}]]"\n` +
+      `exo__Asset_isDefinedBy: "[[${UID.emsAnchor}]]"\n` +
+      `exo__Asset_label: "${SEED_AREA_LABEL}"\n` +
+      `exo__Asset_createdAt: 2026-06-16T00:00:00\n` +
+      `---\n\nEphemeral e2e seed area. Recreated fresh every run.\n`,
+  );
+
+  // A trivial note so Obsidian's waitForVaultReady (markdownFiles > 0) does not
+  // burn its ceiling racing the clone indexing on launch #1.
+  fs.writeFileSync(
+    path.join(vaultPath, "welcome.md"),
+    "# EKA GUI e2e vault\n\nEphemeral. Created by eka-gui-helpers.ts.\n",
+  );
+
+  git(["init", "-q"], vaultPath);
+  git(["config", "user.email", "eka-gui-e2e@exocortex.test"], vaultPath);
+  git(["config", "user.name", "EKA GUI E2E"], vaultPath);
+  git(["add", "-A"], vaultPath);
+  git(
+    [
+      "commit",
+      "-q",
+      "-m",
+      "init eka-gui e2e vault (public ontologies + seed area)",
+    ],
+    vaultPath,
+  );
+
+  log(`ephemeral vault ready: ${vaultPath}`);
+  return vaultPath;
+}
+
+/** Recursively collect every vault-relative `.md` path (excludes .obsidian/.git). */
+export function listMarkdown(vaultPath: string): string[] {
+  const out: string[] = [];
+  const walk = (dir: string): void => {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      if (
+        entry.name === ".git" ||
+        entry.name === ".obsidian" ||
+        entry.name === ".exocortex"
+      )
+        continue;
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) walk(full);
+      else if (entry.name.endsWith(".md"))
+        out.push(path.relative(vaultPath, full));
+    }
+  };
+  walk(vaultPath);
+  return out;
+}
+
+/** Find the first file matching `<uid>*.md` under the vault (or null). */
+export function findByUid(vaultPath: string, uid: string): string | null {
+  for (const rel of listMarkdown(vaultPath)) {
+    if (path.basename(rel).startsWith(uid)) return path.join(vaultPath, rel);
+  }
+  return null;
+}
+
+/** Poll a predicate until true or timeout. */
+export async function pollUntil(
+  label: string,
+  predicate: () => boolean | Promise<boolean>,
+  timeoutMs: number,
+  intervalMs = 1500,
+): Promise<void> {
+  const start = Date.now();
+  for (;;) {
+    if (await predicate()) {
+      log(`✓ ${label} (after ${Math.round((Date.now() - start) / 1000)}s)`);
+      return;
+    }
+    if (Date.now() - start > timeoutMs) {
+      throw new Error(
+        `Timed out (${Math.round(timeoutMs / 1000)}s) waiting for: ${label}`,
+      );
+    }
+    await new Promise((r) => setTimeout(r, intervalMs));
+  }
+}
+
+// ---------------------------------------------------------------------------
+//  Plugin-load with relaunch-retry (QEMU-emulation flake on Apple Silicon)
+// ---------------------------------------------------------------------------
+const MAX_LAUNCH_ATTEMPTS = 8;
+const PLUGIN_LOAD_WAIT_MS = 60_000;
+
+async function tryLoadPlugin(
+  window: Page,
+  label: string,
+  timeoutMs: number,
+): Promise<boolean> {
+  const diag = await window.evaluate(() => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const pm = (window as any).app?.plugins;
+    return {
+      hasManifest: !!pm?.manifests?.exocortex,
+      loaded: !!pm?.plugins?.exocortex,
+    };
+  });
+  log(`[${label}] plugin state: ${JSON.stringify(diag)}`);
+  if (!diag.loaded) {
+    const r = await window.evaluate(async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const pm = (window as any).app?.plugins;
+      try {
+        if (pm?.plugins?.exocortex) return "already loaded";
+        await pm?.disablePlugin?.("exocortex").catch(() => undefined);
+        await pm?.enablePlugin?.("exocortex");
+        return "force-reloaded (disable→enable)";
+      } catch (e) {
+        return `reload error: ${String(e)}`;
+      }
+    });
+    log(`[${label}] ${r}`);
+  }
+  try {
+    await waitForExocortexPluginViaPlaywright(window, {
+      specName: label,
+      timeoutMs,
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Launch Obsidian on `vaultPath`, retrying the WHOLE launch (close + fresh
+ * Electron) up to {@link MAX_LAUNCH_ATTEMPTS} times — the plugin-load flake is
+ * per-launch under QEMU-emulated amd64; a relaunch almost always recovers it.
+ * Returns the live launcher (caller owns close).
+ */
+export async function launchObsidianWithPlugin(
+  vaultPath: string,
+  label: string,
+): Promise<ObsidianLauncher> {
+  let lastErr = "";
+  for (let attempt = 1; attempt <= MAX_LAUNCH_ATTEMPTS; attempt++) {
+    const launcher = new ObsidianLauncher(vaultPath);
+    try {
+      log(`${label}: launch attempt ${attempt}/${MAX_LAUNCH_ATTEMPTS}`);
+      await launcher.launch();
+      const window = await launcher.getWindow();
+      await launcher.waitForModalsToClose(10_000);
+      if (await tryLoadPlugin(window, label, PLUGIN_LOAD_WAIT_MS))
+        return launcher;
+      lastErr = `plugin did not reach loaded within ${PLUGIN_LOAD_WAIT_MS / 1000}s`;
+    } catch (e) {
+      lastErr = String(e);
+      log(`${label}: launch attempt ${attempt} errored: ${lastErr}`);
+    }
+    await launcher.close().catch(() => undefined);
+  }
+  throw new Error(
+    `${label}: Obsidian + plugin failed to load after ${MAX_LAUNCH_ATTEMPTS} attempts (${lastErr})`,
+  );
+}
+
+/** Force the triple store + metadataCache to settle so command discovery is complete. */
+export async function waitForStoreSettled(
+  window: Page,
+  timeoutMs = 90_000,
+): Promise<number> {
+  let prev = -1;
+  let stable = 0;
+  await pollUntil(
+    "triple store settled (indexing complete)",
+    async () => {
+      const n = await window.evaluate(async () => {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const store = (
+          window as any
+        ).app?.plugins?.plugins?.exocortex?.sparql?.getTripleStore?.();
+        if (!store) return -1;
+        try {
+          return (await store.count()) as number;
+        } catch {
+          return -1;
+        }
+      });
+      if (n > 100 && n === prev) stable++;
+      else stable = 0;
+      prev = n;
+      return stable >= 2;
+    },
+    timeoutMs,
+    3000,
+  );
+  return prev;
+}
+
+/**
+ * Auto-accept native `window.confirm()` dialogs. Several create commands declare
+ * `confirmMessage` and the plugin's CommandPromptAdapter renders it via the
+ * NATIVE `window.confirm()` — under CDP, Playwright's default is to DISMISS
+ * (→ command bails), so without this the create silently no-ops. Register once
+ * per page, before any create-button click.
+ */
+export function registerConfirmAutoAccept(window: Page): void {
+  window.on("dialog", (dialog) => {
+    void dialog.accept().catch(() => undefined);
+  });
+}
+
+/** Open a vault file in a fresh leaf and force a layout render (buttons appear). */
+export async function openAssetAndRender(
+  window: Page,
+  relPath: string,
+): Promise<void> {
+  // A just-created asset can lag the in-memory vault tree (fs-move bypasses the
+  // create-event). Poll until Obsidian has indexed it before opening.
+  await pollUntil(
+    `vault indexed ${relPath}`,
+    () =>
+      window.evaluate(
+        (p) =>
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          !!(window as any).app?.vault?.getAbstractFileByPath?.(p),
+        relPath,
+      ),
+    30_000,
+    1000,
+  );
+  await window.evaluate(async (p) => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const app = (window as any).app;
+    const file = app.vault.getAbstractFileByPath(p);
+    if (!file) throw new Error(`open: file not found ${p}`);
+    const leaf = app.workspace.getLeaf(true);
+    await leaf.openFile(file, { state: { mode: "preview" } });
+  }, relPath);
+  // Force a re-render with populated store (mirrors dynamic-command-buttons-render).
+  await window.evaluate(() => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const plugin = (window as any).app?.plugins?.plugins?.exocortex;
+    plugin?.commandResolver?.invalidateCache?.();
+    plugin?.refreshLayout?.();
+  });
+}
+
+/** All currently-rendered exocortex action-button labels (for discovery/logging). */
+export async function renderedButtonLabels(window: Page): Promise<string[]> {
+  return window.locator(".exocortex-action-button").allTextContents();
+}
+
+/**
+ * Click a create-instance button by visible text, then drive the resulting
+ * {@link DynamicFormModal} (a plain React form, unlike the un-drivable
+ * FuzzySuggestModal): fill the `label` field and submit. Returns the set of
+ * newly-created vault-relative `.md` paths (post − pre snapshot diff).
+ */
+export async function clickCreateButtonAndFill(
+  window: Page,
+  vaultPath: string,
+  buttonText: string,
+  labelValue: string,
+): Promise<string[]> {
+  const before = new Set(listMarkdown(vaultPath));
+
+  const btn = window
+    .locator(".exocortex-action-button", { hasText: buttonText })
+    .first();
+  await expect(btn, `create button "${buttonText}" must render`).toBeVisible({
+    timeout: 20_000,
+  });
+  await btn.click();
+
+  // DynamicFormModal → React DynamicForm. The label field is the first text
+  // input; submit is the modal CTA. (data-testid="field-<name>"; fall back to
+  // the generic input class if the schema field name differs.)
+  const labelField = window
+    .locator(
+      '.dynamic-form [data-testid="field-label"], .dynamic-form input.dynamic-form-input',
+    )
+    .first();
+  await expect(labelField, "create form label input must appear").toBeVisible({
+    timeout: 15_000,
+  });
+  await labelField.fill(labelValue);
+  await window
+    .locator(".dynamic-form .modal-button-container button.mod-cta")
+    .first()
+    .click();
+
+  // The grounding writes to disk async. Poll for a NEW .md file to appear.
+  let created: string[] = [];
+  await pollUntil(
+    `new asset created via "${buttonText}"`,
+    () => {
+      created = listMarkdown(vaultPath).filter((p) => !before.has(p));
+      return created.length > 0;
+    },
+    30_000,
+  );
+  return created;
+}
+
+/** Read a vault file's raw text by absolute or vault-relative path. */
+export function readVaultFile(vaultPath: string, relOrAbs: string): string {
+  const abs = path.isAbsolute(relOrAbs)
+    ? relOrAbs
+    : path.join(vaultPath, relOrAbs);
+  return fs.readFileSync(abs, "utf8");
+}

--- a/packages/obsidian-plugin/tests/e2e/eka-gui/eka-gui-helpers.ts
+++ b/packages/obsidian-plugin/tests/e2e/eka-gui/eka-gui-helpers.ts
@@ -439,41 +439,6 @@ export async function renderedButtonLabels(window: Page): Promise<string[]> {
 }
 
 /**
- * Warm up command resolution: open `relPath` and re-render until ALL `expected`
- * create buttons appear. Binding + grounding (incl. InheritanceRule) resolution
- * settles a few seconds AFTER the triple store stops growing — an early click
- * (e.g. the very first scenario) otherwise fires a grounding whose IR list is
- * still empty, so the backlink (Effort_area / Area_parent) is never written.
- * Polling until the slowest button ("Create Project") renders guarantees the
- * per-class binding scan + IR resolution are complete before any scenario acts.
- */
-export async function waitForButtonsResolved(
-  window: Page,
-  relPath: string,
-  expected: string[],
-  timeoutMs = 90_000,
-): Promise<void> {
-  await openAssetAndRender(window, relPath);
-  await pollUntil(
-    `create buttons resolved (${expected.join(", ")})`,
-    async () => {
-      const labels = await renderedButtonLabels(window);
-      if (expected.every((e) => labels.some((l) => l.includes(e)))) return true;
-      // Re-resolve to pick up bindings/rules indexed since the last render.
-      await window.evaluate(() => {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const p = (window as any).app?.plugins?.plugins?.exocortex;
-        p?.commandResolver?.invalidateCache?.();
-        p?.refreshLayout?.();
-      });
-      return false;
-    },
-    timeoutMs,
-    2500,
-  );
-}
-
-/**
  * Click a create-instance button by visible text, then drive the resulting
  * {@link DynamicFormModal} (a plain React form, unlike the un-drivable
  * FuzzySuggestModal): fill the `label` field and submit. Returns the set of
@@ -546,4 +511,62 @@ export function readVaultFile(vaultPath: string, relOrAbs: string): string {
     ? relOrAbs
     : path.join(vaultPath, relOrAbs);
   return fs.readFileSync(abs, "utf8");
+}
+
+/**
+ * Create an instance on `targetRel` via `buttonText` and return the created file
+ * carrying `backlinkRe` (the inherited relationship key). Retries the whole
+ * open→click→create cycle until the backlink appears.
+ *
+ * WHY retry: binding + grounding (incl. InheritanceRule) resolution settles
+ * asynchronously a few seconds after the triple store stops growing. The FIRST
+ * click on a freshly-launched vault can fire a grounding whose IR list is still
+ * empty → the backlink (Effort_area / Effort_parent / Area_parent) is never
+ * written and the executor falls back to a bare prototype link. Re-opening the
+ * target re-resolves the grounding against the now-more-indexed store; a few
+ * attempts with backoff deterministically reach the resolved state (mirrors the
+ * real "reload Obsidian if assets don't appear yet" UX). Created files from a
+ * failed attempt are deleted so the snapshot diff stays clean.
+ */
+export async function createOnTarget(
+  window: Page,
+  vaultPath: string,
+  targetRel: string,
+  buttonText: string,
+  labelBase: string,
+  backlinkRe: RegExp,
+  attempts = 4,
+): Promise<{ rel: string; fm: string }> {
+  let lastDump = "";
+  for (let i = 1; i <= attempts; i++) {
+    await openAssetAndRender(window, targetRel);
+    const created = await clickCreateButtonAndFill(
+      window,
+      vaultPath,
+      buttonText,
+      `${labelBase} ${i}`,
+    );
+    for (const rel of created) {
+      const fm = readVaultFile(vaultPath, rel);
+      if (backlinkRe.test(fm)) return { rel, fm };
+    }
+    // Backlink absent → grounding IR not resolved yet. Clean up + retry.
+    lastDump = created
+      .map((r) => `${r}: ${readVaultFile(vaultPath, r).replace(/\n/g, " | ")}`)
+      .join("\n");
+    for (const rel of created) {
+      try {
+        fs.rmSync(path.join(vaultPath, rel));
+      } catch {
+        /* ignore */
+      }
+    }
+    log(
+      `createOnTarget "${buttonText}" attempt ${i}/${attempts}: ${backlinkRe} absent — retrying`,
+    );
+    await new Promise((r) => setTimeout(r, 3000));
+  }
+  throw new Error(
+    `"${buttonText}" never wrote ${backlinkRe} after ${attempts} attempts.\nLast created:\n${lastDump}`,
+  );
 }

--- a/packages/obsidian-plugin/tests/e2e/eka-gui/eka-gui-helpers.ts
+++ b/packages/obsidian-plugin/tests/e2e/eka-gui/eka-gui-helpers.ts
@@ -465,6 +465,15 @@ export async function clickCreateButtonAndFill(
     },
     30_000,
   );
+  // Diagnostic: dump each created file's frontmatter so the actual relationship
+  // keys the grounding wrote are visible in CI logs (drives assertion design).
+  for (const rel of created) {
+    const fm = readVaultFile(vaultPath, rel)
+      .split("\n")
+      .slice(0, 30)
+      .join(" | ");
+    log(`created via "${buttonText}": ${rel} :: ${fm}`);
+  }
   return created;
 }
 

--- a/packages/obsidian-plugin/tests/e2e/eka-gui/eka-gui-helpers.ts
+++ b/packages/obsidian-plugin/tests/e2e/eka-gui/eka-gui-helpers.ts
@@ -439,6 +439,41 @@ export async function renderedButtonLabels(window: Page): Promise<string[]> {
 }
 
 /**
+ * Warm up command resolution: open `relPath` and re-render until ALL `expected`
+ * create buttons appear. Binding + grounding (incl. InheritanceRule) resolution
+ * settles a few seconds AFTER the triple store stops growing — an early click
+ * (e.g. the very first scenario) otherwise fires a grounding whose IR list is
+ * still empty, so the backlink (Effort_area / Area_parent) is never written.
+ * Polling until the slowest button ("Create Project") renders guarantees the
+ * per-class binding scan + IR resolution are complete before any scenario acts.
+ */
+export async function waitForButtonsResolved(
+  window: Page,
+  relPath: string,
+  expected: string[],
+  timeoutMs = 90_000,
+): Promise<void> {
+  await openAssetAndRender(window, relPath);
+  await pollUntil(
+    `create buttons resolved (${expected.join(", ")})`,
+    async () => {
+      const labels = await renderedButtonLabels(window);
+      if (expected.every((e) => labels.some((l) => l.includes(e)))) return true;
+      // Re-resolve to pick up bindings/rules indexed since the last render.
+      await window.evaluate(() => {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const p = (window as any).app?.plugins?.plugins?.exocortex;
+        p?.commandResolver?.invalidateCache?.();
+        p?.refreshLayout?.();
+      });
+      return false;
+    },
+    timeoutMs,
+    2500,
+  );
+}
+
+/**
  * Click a create-instance button by visible text, then drive the resulting
  * {@link DynamicFormModal} (a plain React form, unlike the un-drivable
  * FuzzySuggestModal): fill the `label` field and submit. Returns the set of


### PR DESCRIPTION
## What

Formalises the create-flow Gherkin scenarios of vault node \`76d9207c\` (GUI-BDD-CI Ф4, project node \`a2e20c69\`) as **repeatable e2e** against a **FRESH ephemeral vault built from the REAL published \`kitelev/exoas-*\` ontology repos**. Scenarios delivered:

| Scenario | Asserts (real on-disk frontmatter) |
|---|---|
| Create **Task** on \`ems__Area\` | \`Effort_area\` = the area |
| Create **Project** on \`ems__Area\` | \`Effort_area\` = the area |
| Create **child Area** (**#3555**) | \`ems__Area_parent\` = the area — **live regression gate** |
| Create **Task** on \`ems__Project\` | \`Effort_parent\` = the project |
| **cleanup-idempotent** | created instances removed; ontologies + seed intact |

## Why real published content (not hand-seeded fixtures)

The create-instance commands, their groundings/bindings, and the **#3555 \`InheritanceRule uid→ems__Area_parent\`** (\`ba0ed3e9\`) live in the **published** \`exoas-exocmd\`/\`exoas-public\` repos — not in this codebase. A static fixture would test a COPY → a regression of that published content (exactly what #3555 guards) would be invisible. So the fixture \`git clone\`s the three **PUBLIC** repos (\`exoas-exo\` + \`exoas-exocmd\` + \`exoas-public\`) into the ephemeral vault and exercises the live commands. *(test-fixture-realism)*

Every create goes through \`createOnTarget()\`, driving the REAL command (CommandExecutionFlow + native \`window.confirm\` auto-accepted under CDP) + the DynamicFormModal, retrying open→click until the inherited backlink lands (the grounding's InheritanceRule resolution settles a few seconds after the triple store; a first-click can race it — mirrors the real "reload if assets don't appear" UX). Backlink-key matching is form-tolerant (\`ems__Effort_area\` vs expanded-IRI \`…/ems#Effort_area\`).

## CI wiring — release-gate, not a PR-required check

Dedicated, isolated harness (sibling to \`eka-obsidian-leg\`): own config + Dockerfile + workflow **OUTSIDE \`tests/e2e/specs\`** → the 6 sharded configs and \`validate-shard-assignments.mjs\` never see it → **NOT one of the 13 required checks**, cannot flake PRs *(perf-tests-dont-hard-gate-ci)*. PUBLIC repos → **no PAT**; \`GITHUB_TOKEN\` only lifts the anon clone rate limit → the suite **always runs, never self-skips**.

Triggers: \`push: [main]\` ("авто на каждом релизе"), \`schedule\` (nightly), \`workflow_dispatch\`, and \`pull_request\` (paths-filtered to the suite — verifies suite changes pre-merge, never on unrelated PRs).

## Deferred to a follow-up node

apply-profile (#1) + reload-no-hang (**#3554**) both need the apply flow → natural home is extending \`eka-obsidian-leg\` (already does a real apply via \`REGISTRY_TOKEN\`). Create-Meeting: the button binds to a MeetingPrototype-**classed instance**, not the prototype asset itself → separate fixture. This PR ships the 4 create-flow scenarios + cleanup, incl. the **#3555 live regression gate** — the highest-value coverage.

Node: \`a2e20c69\` (GUI-BDD-CI Ф4). Completes Ф1-smoke ✅ + Ф2-digitize ✅ + Ф3-fixes ✅ → Ф4 formalize (create-flow subset; remainder tracked as follow-up).