### PR TITLE
test(eka-e2e): GUI-BDD-CI tail — Create-Project + Create-Meeting + apply-state/reload-no-hang + nit (fc83d482)

### DIFF
--- a/packages/obsidian-plugin/tests/e2e/eka-gui/create-instance-buttons.spec.ts
+++ b/packages/obsidian-plugin/tests/e2e/eka-gui/create-instance-buttons.spec.ts
@@ -5,6 +5,7 @@ import * as fs from "fs";
 import * as path from "path";
 import {
   SEED_AREA_UID,
+  SEED_MEETING_PROTO_UID,
   SEED_PROJECT_UID,
   createOnTarget,
   findByUid,
@@ -26,10 +27,12 @@ import {
  * (GUI-BDD-CI Ф4, project node a2e20c69) as repeatable e2e against a FRESH
  * ephemeral vault built from the REAL published `kitelev/exoas-*` ontology repos:
  *
- *   - Create Task on an ems__Area     → ems:Effort_area   = the area
- *   - Create child Area (#3555)       → ems:Area_parent   = the area  ⚠ REGRESSION
- *   - Create Task on an ems__Project  → ems:Effort_parent = the project
- *   - cleanup-idempotent              → created instances removed, ontologies intact
+ *   - Create Task on an ems__Area        → ems:Effort_area   = the area
+ *   - Create Project on an ems__Area     → ems:Effort_area   = the area
+ *   - Create child Area (#3555)          → ems:Area_parent   = the area  ⚠ REGRESSION
+ *   - Create Task on an ems__Project     → ems:Effort_parent = the project
+ *   - Create Meeting on a MeetingProto   → exo:Asset_prototype = the source
+ *   - cleanup-idempotent                 → created instances removed, ontologies intact
  *
  * Design (see eka-gui-helpers.ts header): one suite over ONE fresh vault per run
  * ("каждый прогон = новое хранилище"); the create-instance commands + the #3555
@@ -40,13 +43,22 @@ import {
  * open→click on any transient until the inherited backlink lands. Every
  * assertion checks REAL on-disk frontmatter — no stubs.
  *
- * Only the fast/reliable "Create Task" + "Create Area" buttons are exercised
- * here; the seed ems__Area + seed ems__Project are pre-placed so the scenarios
- * target them directly. The "Create Project" button is slow + variable to
- * resolve under Docker indexing (sometimes >2 min), which made it flaky, so the
- * Create-Project-on-Area + Create-Meeting scenarios (and apply-profile #1 /
- * reload-no-hang #3554) are tracked in the follow-up node — see
- * eka-gui-helpers.ts header.
+ * The "Create Project" + "Create Meeting Instance" commands additionally carry a
+ * `Command_confirmMessage`, so clicking them fires a native `window.confirm()`
+ * that {@link registerConfirmAutoAccept} (armed in beforeAll) accepts under CDP.
+ *
+ * Note on "Create Project" (follow-up node fc83d482, perf-investigation): an
+ * earlier hotfix (#3585) dropped Create-Project from the suite, suspecting a
+ * resolver perf bug ("many binding variants → resolves last"). An empirical
+ * source audit refuted that: an ems__Area resolves only its 3 area-targeted
+ * bindings + the universal exo__Asset ones (NOT the 14 ems__Project bindings —
+ * those match Project assets), ALL of an asset's buttons resolve together in one
+ * cached `resolveForAssetMulti`, and the Create-Project grounding (8748f8b0) is
+ * structurally LIGHTER than Create-Task's (a222094b has an extra targetPrototype)
+ * — so there is no per-button resolution-time difference. The only differentiator
+ * is the confirmMessage native dialog. The slowness was emulation/QEMU + a
+ * dialog-handling race, not a product perf bug — so the scenario is restored
+ * test-side (via createOnTarget's open→click retry), not "fixed" in the plugin.
  *
  * Relationship-key tolerance: published InheritanceRules emit the backlink in
  * EITHER prefixed (`ems__Effort_area`) OR expanded-IRI (`…/ems#Effort_area`)
@@ -61,6 +73,10 @@ const SEED_AREA_REL = path.posix.join(
 const SEED_PROJECT_REL = path.posix.join(
   "assetspaces/kitelev/exoas-public/ems",
   `${SEED_PROJECT_UID}.md`,
+);
+const SEED_MEETING_PROTO_REL = path.posix.join(
+  "assetspaces/kitelev/exoas-public/ems",
+  `${SEED_MEETING_PROTO_UID}.md`,
 );
 
 // Independent scenarios over a shared window (workers:1 keeps them ordered).
@@ -105,6 +121,26 @@ test.describe("EKA GUI — create-instance buttons (fresh real-content vault)", 
     );
   });
 
+  test("scenario 3 — Create Project on ems__Area sets Effort_area", async () => {
+    // Restored from the follow-up node (perf-investigation verdict: NOT a
+    // resolver perf bug — see file header). "Create Project" carries a
+    // confirmMessage → native confirm (auto-accepted in beforeAll). createOnTarget
+    // drives the real command + form and retries open→click until the inherited
+    // Effort_area backlink lands.
+    const { rel, fm } = await createOnTarget(
+      window,
+      vaultPath,
+      SEED_AREA_REL,
+      "Create Project",
+      "E2E Project on Area",
+      /Effort_area/,
+    );
+    log(`created project on area: ${rel}`);
+    expect(fm, "project must carry the source area in Effort_area").toContain(
+      SEED_AREA_UID,
+    );
+  });
+
   test("scenario 6 — Create child Area sets ems__Area_parent (#3555 regression)", async () => {
     const { rel, fm } = await createOnTarget(
       window,
@@ -139,9 +175,30 @@ test.describe("EKA GUI — create-instance buttons (fresh real-content vault)", 
     );
   });
 
+  test("scenario 5 — Create Meeting Instance on a MeetingPrototype sets prototype", async () => {
+    // The binding (22093ca1, targetClass ems__MeetingPrototype) renders on an
+    // INSTANCE of the prototype class — our seed `SEED_MEETING_PROTO`. The
+    // grounding (e01b025b) creates an ems__Meeting whose default linkBack
+    // (exo__Asset_prototype) points to the source asset. "Create Meeting
+    // Instance" carries a confirmMessage → native confirm (auto-accepted).
+    const { rel, fm } = await createOnTarget(
+      window,
+      vaultPath,
+      SEED_MEETING_PROTO_REL,
+      "Create Meeting",
+      "E2E Meeting on Proto",
+      /Asset_prototype/,
+    );
+    log(`created meeting: ${rel}`);
+    expect(
+      fm,
+      "meeting must carry the source MeetingPrototype instance in Asset_prototype",
+    ).toContain(SEED_MEETING_PROTO_UID);
+  });
+
   test("scenario 8 — cleanup removes created instances, leaves ontologies + seed intact", async () => {
     const isCreated = (fm: string): boolean =>
-      /exo__Asset_label:\s*"?E2E (Task on Area|Child Area|Task on Project)/.test(
+      /exo__Asset_label:\s*"?E2E (Task on Area|Project on Area|Child Area|Task on Project|Meeting on Proto)/.test(
         fm,
       );
 
@@ -171,6 +228,10 @@ test.describe("EKA GUI — create-instance buttons (fresh real-content vault)", 
     expect(
       findByUid(vaultPath, SEED_PROJECT_UID),
       "seed project must remain",
+    ).not.toBeNull();
+    expect(
+      findByUid(vaultPath, SEED_MEETING_PROTO_UID),
+      "seed meeting-prototype instance must remain",
     ).not.toBeNull();
     expect(
       findByUid(vaultPath, "82c74542-1b14-4217-b852-d84730484b25"),

--- a/packages/obsidian-plugin/tests/e2e/eka-gui/create-instance-buttons.spec.ts
+++ b/packages/obsidian-plugin/tests/e2e/eka-gui/create-instance-buttons.spec.ts
@@ -28,7 +28,7 @@ import {
  * ephemeral vault built from the REAL published `kitelev/exoas-*` ontology repos:
  *
  *   - Create Task on an ems__Area        → ems:Effort_area   = the area
- *   - Create Project on an ems__Area     → ems:Effort_area   = the area
+ *   - Create Project on an ems__Area     → ems:Effort_area   = the area  (test.fixme #3587)
  *   - Create child Area (#3555)          → ems:Area_parent   = the area  ⚠ REGRESSION
  *   - Create Task on an ems__Project     → ems:Effort_parent = the project
  *   - Create Meeting on a MeetingProto   → exo:Asset_prototype = the source
@@ -47,18 +47,16 @@ import {
  * `Command_confirmMessage`, so clicking them fires a native `window.confirm()`
  * that {@link registerConfirmAutoAccept} (armed in beforeAll) accepts under CDP.
  *
- * Note on "Create Project" (follow-up node fc83d482, perf-investigation): an
- * earlier hotfix (#3585) dropped Create-Project from the suite, suspecting a
- * resolver perf bug ("many binding variants → resolves last"). An empirical
- * source audit refuted that: an ems__Area resolves only its 3 area-targeted
- * bindings + the universal exo__Asset ones (NOT the 14 ems__Project bindings —
- * those match Project assets), ALL of an asset's buttons resolve together in one
- * cached `resolveForAssetMulti`, and the Create-Project grounding (8748f8b0) is
- * structurally LIGHTER than Create-Task's (a222094b has an extra targetPrototype)
- * — so there is no per-button resolution-time difference. The only differentiator
- * is the confirmMessage native dialog. The slowness was emulation/QEMU + a
- * dialog-handling race, not a product perf bug — so the scenario is restored
- * test-side (via createOnTarget's open→click retry), not "fixed" in the plugin.
+ * Note on "Create Project" (follow-up node fc83d482, perf-investigation → #3587):
+ * #3585 dropped Create-Project suspecting a resolver perf bug. The investigation
+ * REFUTED that AND found a real correctness bug: the "Create Project" button does
+ * NOT render on an ems__Area in the LIVE plugin (Create Task + Create Area do).
+ * It is NOT the resolver — a full-store repro of `resolveForAssetMulti` returns
+ * `Create Project [bind 9f787938]`, the CLI `apply create-project` resolves it,
+ * and `PreconditionEvaluator.evaluate(undefined)=true`. The drop is in the live
+ * render-path store (LazyAssetGraphLoader, PR #3257), root cause tracked in #3587.
+ * The scenario is therefore kept as `test.fixme` (a runnable regression gate that
+ * goes green when #3587 lands) rather than deleted-and-forgotten like #3585.
  *
  * Relationship-key tolerance: published InheritanceRules emit the backlink in
  * EITHER prefixed (`ems__Effort_area`) OR expanded-IRI (`…/ems#Effort_area`)
@@ -121,12 +119,17 @@ test.describe("EKA GUI — create-instance buttons (fresh real-content vault)", 
     );
   });
 
-  test("scenario 3 — Create Project on ems__Area sets Effort_area", async () => {
-    // Restored from the follow-up node (perf-investigation verdict: NOT a
-    // resolver perf bug — see file header). "Create Project" carries a
-    // confirmMessage → native confirm (auto-accepted in beforeAll). createOnTarget
-    // drives the real command + form and retries open→click until the inherited
-    // Effort_area backlink lands.
+  // KNOWN-BROKEN (#3587): the "Create Project" inline button does NOT render on
+  // an ems__Area in the live plugin, while sibling Create Task + Create Area
+  // (same targetClass, same group, no precondition) render fine. The
+  // perf-investigation (node fc83d482) PROVED this is NOT a resolver/content bug:
+  // a full-store repro of resolveForAssetMulti returns Create Project [bind
+  // 9f787938] correctly, the CLI `apply create-project` resolves it, and
+  // PreconditionEvaluator.evaluate(undefined)=true. The drop happens in the live
+  // render-path store (LazyAssetGraphLoader, PR #3257) — root cause TBD in #3587.
+  // Kept as test.fixme: a runnable regression gate that flips green when #3587
+  // lands (remove .fixme then). The scenario body is the correct assertion.
+  test.fixme("scenario 3 — Create Project on ems__Area sets Effort_area (#3587)", async () => {
     const { rel, fm } = await createOnTarget(
       window,
       vaultPath,

--- a/packages/obsidian-plugin/tests/e2e/eka-gui/eka-gui-helpers.ts
+++ b/packages/obsidian-plugin/tests/e2e/eka-gui/eka-gui-helpers.ts
@@ -62,7 +62,8 @@ export const UID = {
   emsTaskClass: "1b20a8f0-d745-4e93-91db-4531b3df120e", // ems__Task class
   emsProjectClass: "7db5eeff-718a-49b0-8d2b-39b084a356e3", // ems__Project class
   emsAnchor: "f6e01f7a-d727-494a-82a3-815597d33e86", // ems ontology anchor (isDefinedBy)
-  meetingPrototype: "7ab483c7-aafc-4ac8-8aca-0de52db34a93", // ems__MeetingPrototype
+  meetingPrototype: "7ab483c7-aafc-4ac8-8aca-0de52db34a93", // ems__MeetingPrototype (class)
+  emsMeetingClass: "1b0a5e34-dd7f-4ead-b43a-6c7c5a5ecaca", // ems__Meeting (created instance's class)
   // #3555: InheritanceRule uid→ems__Area_parent — exercised live, not seeded.
   areaParentInheritanceRule: "ba0ed3e9-9749-474f-b994-654d4dede2c5",
 } as const;
@@ -73,6 +74,16 @@ export const SEED_AREA_LABEL = "EKA E2E Seed Area";
 /** Stable UID of the seeded ems__Project (Task-on-Project scenario target). */
 export const SEED_PROJECT_UID = "e2e0a4ea-0000-4000-a000-000000000002";
 export const SEED_PROJECT_LABEL = "EKA E2E Seed Project";
+/**
+ * Stable UID of the seeded **ems__MeetingPrototype-classed** asset the
+ * "Create Meeting Instance" scenario targets. The binding (`22093ca1`,
+ * targetClass `ems__MeetingPrototype`) binds the command to an INSTANCE of the
+ * prototype class — NOT to the prototype class asset `7ab483c7` itself (that
+ * shows "Create Subclass"). So we seed an asset whose `exo__Instance_class` IS
+ * `ems__MeetingPrototype`.
+ */
+export const SEED_MEETING_PROTO_UID = "e2e0a4ea-0000-4000-a000-000000000003";
+export const SEED_MEETING_PROTO_LABEL = "EKA E2E Seed Meeting Prototype";
 
 export function log(msg: string): void {
   // eslint-disable-next-line no-console
@@ -191,6 +202,21 @@ export function setupGuiVault(): string {
       `exo__Asset_label: "${SEED_PROJECT_LABEL}"\n` +
       `exo__Asset_createdAt: 2026-06-16T00:00:00\n` +
       `---\n\nEphemeral e2e seed project. Recreated fresh every run.\n`,
+  );
+  // Seed ONE ems__MeetingPrototype-classed asset — the "Create Meeting Instance"
+  // scenario targets it. The command binds on the PROTOTYPE CLASS (targetClass
+  // ems__MeetingPrototype), so an instance whose class is ems__MeetingPrototype
+  // renders the button (the prototype class asset 7ab483c7 itself would render
+  // "Create Subclass" instead).
+  fs.writeFileSync(
+    path.join(seedDir, `${SEED_MEETING_PROTO_UID}.md`),
+    `---\n` +
+      `exo__Asset_uid: ${SEED_MEETING_PROTO_UID}\n` +
+      `exo__Instance_class:\n  - "[[${UID.meetingPrototype}]]"\n` +
+      `exo__Asset_isDefinedBy: "[[${UID.emsAnchor}]]"\n` +
+      `exo__Asset_label: "${SEED_MEETING_PROTO_LABEL}"\n` +
+      `exo__Asset_createdAt: 2026-06-16T00:00:00\n` +
+      `---\n\nEphemeral e2e seed meeting-prototype instance. Recreated fresh every run.\n`,
   );
 
   // A trivial note so Obsidian's waitForVaultReady (markdownFiles > 0) does not
@@ -577,9 +603,17 @@ export async function createOnTarget(
             (r) => `${r}: ${readVaultFile(vaultPath, r).replace(/\n/g, " | ")}`,
           )
           .join(" ;; ");
+      // Nit (code-reviewer #3583): delete ONLY the instance this attempt
+      // created — matched by its unique label `${labelBase} ${i}` — not every
+      // file in the snapshot diff. If a future grounding writes >1 file per
+      // create (e.g. a backlink-target asset alongside the instance), the blanket
+      // delete would clobber that collateral; label-scoping keeps cleanup precise.
+      const attemptLabel = `${labelBase} ${i}`;
       for (const rel of created) {
         try {
-          fs.rmSync(path.join(vaultPath, rel));
+          if (readVaultFile(vaultPath, rel).includes(attemptLabel)) {
+            fs.rmSync(path.join(vaultPath, rel));
+          }
         } catch {
           /* ignore */
         }

--- a/packages/obsidian-plugin/tests/e2e/eka/eka-obsidian-leg.spec.ts
+++ b/packages/obsidian-plugin/tests/e2e/eka/eka-obsidian-leg.spec.ts
@@ -861,7 +861,141 @@ test.describe("EKA Obsidian leg — bootstrap → add → apply-profile → crea
       `step 4 complete — asset ${ephemeralUid} created in exoas-exodev (via ${created.via})`,
     );
 
-    log("✅ EKA Obsidian leg PASS — bootstrap + add + apply-profile + create");
+    // ---- Step 5: applied-state assertion (follow-up node fc83d482 #1) ----
+    // The apply path persists the last-applied profile cache to the device-local
+    // data.local.json (PluginSettingsStoreAdapter → PluginLocalDataStore): a clean
+    // apply leaves activeProfileUid = the applied profile and _switchInProgress =
+    // false (set before the reindex, cleared after — ProfileApplyManager.applyProfile
+    // §510-519). This is the Gherkin scenario-1 "git-commit apply проходит
+    // (activeProfileUid set, switchInProgress=False)" gate, disk-asserted.
+    log(
+      "step 5: assert applied-state (activeProfileUid set, switch not in progress)",
+    );
+    const localDataPath = path.join(
+      vaultPath,
+      ".obsidian",
+      "plugins",
+      "exocortex",
+      "data.local.json",
+    );
+    await pollUntil(
+      "data.local.json records the applied profile",
+      () => {
+        if (!fs.existsSync(localDataPath)) return false;
+        try {
+          const d = JSON.parse(fs.readFileSync(localDataPath, "utf8")) as {
+            activeProfileUid?: unknown;
+            _switchInProgress?: unknown;
+          };
+          return (
+            d.activeProfileUid === PROFILE_UID && d._switchInProgress !== true
+          );
+        } catch {
+          return false;
+        }
+      },
+      30000,
+    );
+    const localData = JSON.parse(fs.readFileSync(localDataPath, "utf8")) as {
+      activeProfileUid?: unknown;
+      _switchInProgress?: unknown;
+    };
+    expect(
+      localData.activeProfileUid,
+      "applied profile must be cached as activeProfileUid",
+    ).toBe(PROFILE_UID);
+    expect(
+      localData._switchInProgress,
+      "switch must not be left in progress after a clean apply",
+    ).not.toBe(true);
+    // Materialized effective set: floor (exo + exocmd) + catalog (registry +
+    // profiles) + the exodev leaf, all on disk — closure-expansion proof.
+    expect(
+      countMarkdown(vaultPath, EXO_DIR),
+      "floor exo must be materialised",
+    ).toBeGreaterThan(0);
+    expect(
+      countMarkdown(vaultPath, EXOCMD_DIR),
+      "floor exocmd must be materialised",
+    ).toBeGreaterThan(0);
+    expect(
+      countMarkdown(vaultPath, EXODEV_DIR),
+      "exodev leaf must be materialised",
+    ).toBeGreaterThan(0);
+    log("step 5 complete — applied-state persisted, effective set on disk");
+
+    // ---- Step 6: reload-no-hang (#3554 regression, CRITICAL) ----
+    // #3554: profile crash-recovery + cross-device reconcile used to run INLINE in
+    // onload (before onLayoutReady). reconcileToLocal() can open a blocking
+    // ApplyConfirmModal; awaiting it during onload deadlocks Obsidian on "Loading
+    // plugins…" because the modal can never be confirmed (UI not interactive yet)
+    // → workspace.layoutReady never fires. The fix (ExocortexPlugin
+    // .runDeferredProfileRecovery) defers ALL recovery to onLayoutReady, detached
+    // (`void`), so onload returns promptly. Gate: arm the recovery path
+    // (_switchInProgress=true forces recoverIfNeeded/recoverIncompleteSwitch to
+    // run on next onload) then relaunch, and assert the plugin loads + the
+    // workspace becomes ready WITHOUT hanging — the Gherkin scenario-7 gate.
+    //
+    // Honest scope: this is a SMOKE gate (recovery-armed reload reaches
+    // layoutReady). The deterministic pre-#3554 hang needs reconcileToLocal to
+    // open a modal during onload, which requires a staged cross-device divergence
+    // that this single-profile fixture cannot set up; so it does not strictly
+    // revert-verify. launchObsidianWithPlugin additionally waits for the plugin to
+    // reach `loaded`, which is itself a coarse hang gate (a never-resolving onload
+    // would exhaust its relaunch retries).
+    log(
+      "step 6: reload-no-hang (#3554) — arm recovery, relaunch, assert layoutReady",
+    );
+    const armed = { ...localData, _switchInProgress: true };
+    fs.writeFileSync(localDataPath, JSON.stringify(armed, null, 2));
+    await launcher.close();
+    launcher = await launchObsidianWithPlugin(vaultPath, "eka-leg-3-reload");
+    window = await launcher.getWindow();
+    await expect
+      .poll(
+        () =>
+          window.evaluate(() => {
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            const app = (window as any).app;
+            return app?.workspace?.layoutReady === true;
+          }),
+        {
+          timeout: 60000,
+          message:
+            "workspace.layoutReady must become true after reload (#3554 — no onload hang)",
+        },
+      )
+      .toBe(true);
+    const reloadDiag = await window.evaluate(() => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const app = (window as any).app;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const files = app?.vault?.getMarkdownFiles?.() ?? [];
+      return {
+        loaded: !!app?.plugins?.plugins?.exocortex,
+        layoutReady: app?.workspace?.layoutReady === true,
+        markdownFiles: files.length,
+      };
+    });
+    expect(
+      reloadDiag.loaded,
+      "plugin must load after reload (no onload hang)",
+    ).toBe(true);
+    expect(
+      reloadDiag.layoutReady,
+      "workspace must be ready after reload",
+    ).toBe(true);
+    expect(
+      reloadDiag.markdownFiles,
+      "vault must be usable (markdown files indexed) after reload",
+    ).toBeGreaterThan(0);
+    log(
+      `step 6 complete — reload-no-hang: ${JSON.stringify(reloadDiag)} (#3554 gate)`,
+    );
+
+    log(
+      "✅ EKA Obsidian leg PASS — bootstrap + add + apply-profile + create + applied-state + reload-no-hang",
+    );
   });
 });
 


### PR DESCRIPTION
## Что

Завершает GUI-BDD-CI пайплайн (Ф4 follow-up, vault-нода `fc83d482`, проект `a2e20c69`). Только тесты + 1 nit — **никаких изменений в продакшн-коде плагина**.

### ✅ eka-obsidian-leg (`eka-obsidian-leg.spec.ts`, REGISTRY_TOKEN-gated) — CI GREEN (run 27623521836)
- **step 5 — applied-state (#1):** `activeProfileUid` set + `_switchInProgress=false` в `data.local.json` + floor/catalog/leaf материализованы (Gherkin scenario 1).
- **step 6 — reload-no-hang (#3554):** arm recovery (`_switchInProgress=true`), relaunch, assert `workspace.layoutReady=true` + plugin loaded + files>0 без зависания на "Loading plugins…" (Gherkin scenario 7).

### ✅ eka-gui (`create-instance-buttons.spec.ts` + `eka-gui-helpers.ts`)
- **scenario 5 — Create Meeting Instance** на seeded `ems__MeetingPrototype`-классованном ассете → `exo__Asset_prototype` = source (binding `22093ca1`, grounding `e01b025b`). **CI PASS (808ms).**
- **nit (code-reviewer #3583):** `createOnTarget` на retry удаляет только инстанс этой попытки (label-scoped), не весь snapshot-diff.
- cleanup (scenario 8) расширен + tolerant.

### ⚠ scenario 3 — Create Project on ems__Area → `test.fixme` (#3587)

Perf-investigation (приоритет ноды) выявил **реальный plugin-баг**, НЕ резолверный/emulation как подозревал #3585. Доказательства (в #3587):
- full-store `resolveForAssetMulti(area, …)` возвращает `Create Project [bind 9f787938]` корректно;
- CLI `apply create-project <area>` (16.98.0) резолвит; `PreconditionEvaluator.evaluate(undefined)=true`;
- кнопка дропается в **live render-path store** (LazyAssetGraphLoader, PR #3257) — Create Task/Area рендерятся, Create Project нет (детерминированно на native amd64, DOM-снапшот подтверждает).

Оставлен `test.fixme` → runnable regression-gate, зеленеет когда #3587 фиксится (vs delete-and-forget #3585).

## Verify (native amd64, ноль локального QEMU)
- `eka-gui-e2e.yml` — авто `pull_request`.
- `eka-obsidian-leg-e2e.yml` — `workflow_dispatch --ref` ветки (намеренно не PR-trigger; см. header workflow). **PASS.**

Suite вне `tests/e2e/specs` → не required shards → flake не блокирует merge.