### PR TITLE
fix(#3587): gate eka-gui scenarios on store completeness; un-fixme Create-Project scenario 3

### DIFF
--- a/packages/obsidian-plugin/tests/e2e/eka-gui/create-instance-buttons.spec.ts
+++ b/packages/obsidian-plugin/tests/e2e/eka-gui/create-instance-buttons.spec.ts
@@ -138,70 +138,77 @@ test.describe("EKA GUI — create-instance buttons (fresh real-content vault)", 
     await new Promise((r) => setTimeout(r, 4000));
 
     const diag = await window.evaluate(
-      async ({ areaRel, areaClass, cmd, gnd, bind }) => {
+      async ({ projCmd, projGnd, taskCmd, taskGnd }) => {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         const plugin = (window as any).app?.plugins?.plugins?.exocortex;
-        const areaIRI = `obsidian://vault/${encodeURI(areaRel)}`;
         const store = plugin?.sparql?.getTripleStore?.();
-        const count = store ? await store.count() : -1;
-        const out: Record<string, unknown> = { count };
+        const out: Record<string, unknown> = { count: await store.count() };
+        const all = await store.match(undefined, undefined, undefined);
+        const short = (v: string) =>
+          typeof v === "string" ? v.split(/[#/]/).pop() || v : String(v);
 
-        // subject-triple presence in the LIVE store (by UID substring in subject IRI)
-        const countSubj = async (uid: string) => {
+        // dump triples whose subject contains the UID (predicate => object)
+        const dumpSubj = (uid: string) =>
+          all
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            .filter((t: any) => t.subject?.value?.includes?.(uid))
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            .map((t: any) => {
+              const o = t.object?.value ?? t.object;
+              const oForm =
+                t.object?.constructor?.name === "IRI"
+                  ? `IRI(${short(o)})`
+                  : `Lit(${o})`;
+              return `${short(t.predicate?.value)} => ${oForm}`;
+            });
+
+        out.projCmdTriples = dumpSubj(projCmd);
+        out.projGndTriples = dumpSubj(projGnd);
+        out.taskCmdTriples = dumpSubj(taskCmd);
+        out.taskGndTriples = dumpSubj(taskGnd);
+
+        // subject IRI as stored (full form) for cmd + gnd of both
+        const subjIRI = (uid: string) => {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          const t = all.find((x: any) => x.subject?.value?.includes(uid));
+          return t?.subject?.value ?? null;
+        };
+        out.projCmdSubjectIRI = subjIRI(projCmd);
+        out.projGndSubjectIRI = subjIRI(projGnd);
+        out.taskGndSubjectIRI = subjIRI(taskGnd);
+
+        // loadGroundingByUid isolates the grounding itself from the command→grounding link
+        const lg = async (uid: string) => {
           try {
-            const all = await store.match(undefined, undefined, undefined);
-            return all.filter(
-              // eslint-disable-next-line @typescript-eslint/no-explicit-any
-              (t: any) =>
-                typeof t.subject?.value === "string" &&
-                t.subject.value.includes(uid),
-            ).length;
+            const g = await plugin.commandResolver.loadGroundingByUid(uid);
+            return g ? `OK type=${g.type} targetClass=${g.targetClass}` : "NULL";
           } catch (e) {
             return `err:${String(e)}`;
           }
         };
-        out.subjCmd = await countSubj(cmd);
-        out.subjGnd = await countSubj(gnd);
-        out.subjBind = await countSubj(bind);
+        out.loadGroundingProj = await lg(projGnd);
+        out.loadGroundingTask = await lg(taskGnd);
 
-        try {
-          const resolved = await plugin.commandResolver.resolveForAssetMulti(
-            areaIRI,
-            [areaClass, "ems__Area", "exo__Asset"],
-          );
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          out.resolveMulti = resolved.map(
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            (rc: any) => `${rc.command?.name} [bind ${rc.binding?.id}]`,
-          );
-        } catch (e) {
-          out.resolveMultiErr = String(e);
-        }
-
-        try {
-          const c = await plugin.commandResolver.loadCommand(cmd, {
-            targetClass: "ems__Area",
-          });
-          out.loadCommand = c
-            ? `OK name=${c.name} grounding=${!!c.grounding} confirm=${c.confirmMessage}`
-            : "NULL";
-        } catch (e) {
-          out.loadCommandErr = String(e);
-        }
-
-        // rendered buttons
-        out.renderedButtons = Array.from(
-          document.querySelectorAll(".exocortex-action-button"),
-        ).map((el) => (el.textContent || "").trim());
+        const lc = async (uid: string) => {
+          try {
+            const c = await plugin.commandResolver.loadCommand(uid, {
+              targetClass: "ems__Area",
+            });
+            return c ? `OK name=${c.name} grounding=${!!c.grounding}` : "NULL";
+          } catch (e) {
+            return `err:${String(e)}`;
+          }
+        };
+        out.loadCommandProj = await lc(projCmd);
+        out.loadCommandTask = await lc(taskCmd);
 
         return out;
       },
       {
-        areaRel: SEED_AREA_REL,
-        areaClass: "82c74542-1b14-4217-b852-d84730484b25",
-        cmd: "3520c214-abe4-4ada-9a2d-04516b957ba2",
-        gnd: "8748f8b0-989b-45a0-88a9-155bc5126f3c",
-        bind: "9f787938-5ee8-484d-ba3f-f1d1e1a0b337",
+        projCmd: "3520c214-abe4-4ada-9a2d-04516b957ba2",
+        projGnd: "8748f8b0-989b-45a0-88a9-155bc5126f3c",
+        taskCmd: "dec97198-a458-4273-b081-7b250e0a9031",
+        taskGnd: "a222094b-f499-4342-aec0-65c4ba99c657",
       },
     );
     log(`DIAG #3587 LIVE STORE TRUTH ===> ${JSON.stringify(diag, null, 2)}`);

--- a/packages/obsidian-plugin/tests/e2e/eka-gui/create-instance-buttons.spec.ts
+++ b/packages/obsidian-plugin/tests/e2e/eka-gui/create-instance-buttons.spec.ts
@@ -119,6 +119,94 @@ test.describe("EKA GUI — create-instance buttons (fresh real-content vault)", 
     );
   });
 
+  // TEMP DIAGNOSTIC (#3587 root-cause) — dumps live render-path store truth so
+  // CI logs pinpoint store-vs-resolver-vs-render. Removed before merge.
+  test("DIAG #3587 — live store truth for Create Project on ems__Area", async () => {
+    await window.evaluate(async (p) => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const app = (window as any).app;
+      const file = app.vault.getAbstractFileByPath(p);
+      const leaf = app.workspace.getLeaf(true);
+      await leaf.openFile(file, { state: { mode: "preview" } });
+    }, SEED_AREA_REL);
+    await window.evaluate(() => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const plugin = (window as any).app?.plugins?.plugins?.exocortex;
+      plugin?.commandResolver?.invalidateCache?.();
+      plugin?.refreshLayout?.();
+    });
+    await new Promise((r) => setTimeout(r, 4000));
+
+    const diag = await window.evaluate(
+      async ({ areaRel, areaClass, cmd, gnd, bind }) => {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const plugin = (window as any).app?.plugins?.plugins?.exocortex;
+        const areaIRI = `obsidian://vault/${encodeURI(areaRel)}`;
+        const store = plugin?.sparql?.getTripleStore?.();
+        const count = store ? await store.count() : -1;
+        const out: Record<string, unknown> = { count };
+
+        // subject-triple presence in the LIVE store (by UID substring in subject IRI)
+        const countSubj = async (uid: string) => {
+          try {
+            const all = await store.match(undefined, undefined, undefined);
+            return all.filter(
+              // eslint-disable-next-line @typescript-eslint/no-explicit-any
+              (t: any) =>
+                typeof t.subject?.value === "string" &&
+                t.subject.value.includes(uid),
+            ).length;
+          } catch (e) {
+            return `err:${String(e)}`;
+          }
+        };
+        out.subjCmd = await countSubj(cmd);
+        out.subjGnd = await countSubj(gnd);
+        out.subjBind = await countSubj(bind);
+
+        try {
+          const resolved = await plugin.commandResolver.resolveForAssetMulti(
+            areaIRI,
+            [areaClass, "ems__Area", "exo__Asset"],
+          );
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          out.resolveMulti = resolved.map(
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            (rc: any) => `${rc.command?.name} [bind ${rc.binding?.id}]`,
+          );
+        } catch (e) {
+          out.resolveMultiErr = String(e);
+        }
+
+        try {
+          const c = await plugin.commandResolver.loadCommand(cmd, {
+            targetClass: "ems__Area",
+          });
+          out.loadCommand = c
+            ? `OK name=${c.name} grounding=${!!c.grounding} confirm=${c.confirmMessage}`
+            : "NULL";
+        } catch (e) {
+          out.loadCommandErr = String(e);
+        }
+
+        // rendered buttons
+        out.renderedButtons = Array.from(
+          document.querySelectorAll(".exocortex-action-button"),
+        ).map((el) => (el.textContent || "").trim());
+
+        return out;
+      },
+      {
+        areaRel: SEED_AREA_REL,
+        areaClass: "82c74542-1b14-4217-b852-d84730484b25",
+        cmd: "3520c214-abe4-4ada-9a2d-04516b957ba2",
+        gnd: "8748f8b0-989b-45a0-88a9-155bc5126f3c",
+        bind: "9f787938-5ee8-484d-ba3f-f1d1e1a0b337",
+      },
+    );
+    log(`DIAG #3587 LIVE STORE TRUTH ===> ${JSON.stringify(diag, null, 2)}`);
+  });
+
   // KNOWN-BROKEN (#3587): the "Create Project" inline button does NOT render on
   // an ems__Area in the live plugin, while sibling Create Task + Create Area
   // (same targetClass, same group, no precondition) render fine. The

--- a/packages/obsidian-plugin/tests/e2e/eka-gui/create-instance-buttons.spec.ts
+++ b/packages/obsidian-plugin/tests/e2e/eka-gui/create-instance-buttons.spec.ts
@@ -15,8 +15,12 @@ import {
   readVaultFile,
   registerConfirmAutoAccept,
   setupGuiVault,
+  waitForCreateCommandsResolvable,
   waitForStoreSettled,
 } from "./eka-gui-helpers";
+
+/** ems__Area class UID — the seed area's `exo__Instance_class`. */
+const EMS_AREA_CLASS_UID = "82c74542-1b14-4217-b852-d84730484b25";
 
 /**
  * ============================================================================
@@ -94,6 +98,16 @@ test.describe("EKA GUI — create-instance buttons (fresh real-content vault)", 
     // auto-accept it under CDP.
     registerConfirmAutoAccept(window);
     await waitForStoreSettled(window);
+    // #3587: count-plateau ≠ store complete. Gate every scenario on the store
+    // being complete enough to resolve ALL create commands on the seed area —
+    // otherwise a scenario can assert inside the transient convertVault-load
+    // window (partial store → Create Project / Create Task subgraph not yet
+    // landed). See waitForCreateCommandsResolvable for the full rationale.
+    await waitForCreateCommandsResolvable(window, SEED_AREA_REL, EMS_AREA_CLASS_UID, [
+      "Create Task",
+      "Create Area",
+      "Create Project",
+    ]);
   });
 
   test.afterAll(async () => {
@@ -119,112 +133,22 @@ test.describe("EKA GUI — create-instance buttons (fresh real-content vault)", 
     );
   });
 
-  // TEMP DIAGNOSTIC (#3587 root-cause) — dumps live render-path store truth so
-  // CI logs pinpoint store-vs-resolver-vs-render. Removed before merge.
-  test("DIAG #3587 — live store truth for Create Project on ems__Area", async () => {
-    await window.evaluate(async (p) => {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const app = (window as any).app;
-      const file = app.vault.getAbstractFileByPath(p);
-      const leaf = app.workspace.getLeaf(true);
-      await leaf.openFile(file, { state: { mode: "preview" } });
-    }, SEED_AREA_REL);
-    await window.evaluate(() => {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const plugin = (window as any).app?.plugins?.plugins?.exocortex;
-      plugin?.commandResolver?.invalidateCache?.();
-      plugin?.refreshLayout?.();
-    });
-    await new Promise((r) => setTimeout(r, 4000));
-
-    const diag = await window.evaluate(
-      async ({ projCmd, projGnd, taskCmd, taskGnd }) => {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const plugin = (window as any).app?.plugins?.plugins?.exocortex;
-        const store = plugin?.sparql?.getTripleStore?.();
-        const out: Record<string, unknown> = { count: await store.count() };
-        const all = await store.match(undefined, undefined, undefined);
-        const short = (v: string) =>
-          typeof v === "string" ? v.split(/[#/]/).pop() || v : String(v);
-
-        // dump triples whose subject contains the UID (predicate => object)
-        const dumpSubj = (uid: string) =>
-          all
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            .filter((t: any) => t.subject?.value?.includes?.(uid))
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            .map((t: any) => {
-              const o = t.object?.value ?? t.object;
-              const oForm =
-                t.object?.constructor?.name === "IRI"
-                  ? `IRI(${short(o)})`
-                  : `Lit(${o})`;
-              return `${short(t.predicate?.value)} => ${oForm}`;
-            });
-
-        out.projCmdTriples = dumpSubj(projCmd);
-        out.projGndTriples = dumpSubj(projGnd);
-        out.taskCmdTriples = dumpSubj(taskCmd);
-        out.taskGndTriples = dumpSubj(taskGnd);
-
-        // subject IRI as stored (full form) for cmd + gnd of both
-        const subjIRI = (uid: string) => {
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          const t = all.find((x: any) => x.subject?.value?.includes(uid));
-          return t?.subject?.value ?? null;
-        };
-        out.projCmdSubjectIRI = subjIRI(projCmd);
-        out.projGndSubjectIRI = subjIRI(projGnd);
-        out.taskGndSubjectIRI = subjIRI(taskGnd);
-
-        // loadGroundingByUid isolates the grounding itself from the command→grounding link
-        const lg = async (uid: string) => {
-          try {
-            const g = await plugin.commandResolver.loadGroundingByUid(uid);
-            return g ? `OK type=${g.type} targetClass=${g.targetClass}` : "NULL";
-          } catch (e) {
-            return `err:${String(e)}`;
-          }
-        };
-        out.loadGroundingProj = await lg(projGnd);
-        out.loadGroundingTask = await lg(taskGnd);
-
-        const lc = async (uid: string) => {
-          try {
-            const c = await plugin.commandResolver.loadCommand(uid, {
-              targetClass: "ems__Area",
-            });
-            return c ? `OK name=${c.name} grounding=${!!c.grounding}` : "NULL";
-          } catch (e) {
-            return `err:${String(e)}`;
-          }
-        };
-        out.loadCommandProj = await lc(projCmd);
-        out.loadCommandTask = await lc(taskCmd);
-
-        return out;
-      },
-      {
-        projCmd: "3520c214-abe4-4ada-9a2d-04516b957ba2",
-        projGnd: "8748f8b0-989b-45a0-88a9-155bc5126f3c",
-        taskCmd: "dec97198-a458-4273-b081-7b250e0a9031",
-        taskGnd: "a222094b-f499-4342-aec0-65c4ba99c657",
-      },
-    );
-    log(`DIAG #3587 LIVE STORE TRUTH ===> ${JSON.stringify(diag, null, 2)}`);
-  });
-
-  // KNOWN-BROKEN (#3587): the "Create Project" inline button does NOT render on
-  // an ems__Area in the live plugin, while sibling Create Task + Create Area
-  // (same targetClass, same group, no precondition) render fine. The
-  // perf-investigation (node fc83d482) PROVED this is NOT a resolver/content bug:
-  // a full-store repro of resolveForAssetMulti returns Create Project [bind
-  // 9f787938] correctly, the CLI `apply create-project` resolves it, and
-  // PreconditionEvaluator.evaluate(undefined)=true. The drop happens in the live
-  // render-path store (LazyAssetGraphLoader, PR #3257) — root cause TBD in #3587.
-  // Kept as test.fixme: a runnable regression gate that flips green when #3587
-  // lands (remove .fixme then). The scenario body is the correct assertion.
-  test.fixme("scenario 3 — Create Project on ems__Area sets Effort_area (#3587)", async () => {
+  // #3587 RESOLVED — was a transient store-load TIMING RACE, NOT a Create-Project
+  // render-path logic drop. Two CI DIAG rounds + a Node convertVault repro proved
+  // the resolver + converter are correct (full store → resolveForAssetMulti returns
+  // Create Project; CLI `apply create-project` resolves it). The live failure was
+  // the harness asserting inside the transient store-load window: `waitForStoreSettled`
+  // declared "settled" at the first count plateau (~15060 of ~16512 triples) while
+  // convertVault was still incrementally populating, so Create Project's binding→
+  // command→grounding subgraph (and sometimes Create Task's backlink InheritanceRule)
+  // had not yet landed — round-1 caught loadCommand(Project)=NULL, round-2 caught it
+  // OK. Fix: `waitForStoreSettled` now also polls resolveForAssetMulti(seed area)
+  // until {Create Task, Create Area, Create Project} all resolve, so every scenario
+  // asserts against a complete store. The product is eventually-consistent
+  // (re-render on store-settle wired post-#3580/v16.97.4) — no permanent miss.
+  // Follow-up #3588 tracks the EKA-layout lazyBootstrapFolders preload gap (bigger,
+  // design trade-off, post-alpha). Now un-fixme'd → live regression gate (8/8).
+  test("scenario 3 — Create Project on ems__Area sets Effort_area (#3587)", async () => {
     const { rel, fm } = await createOnTarget(
       window,
       vaultPath,

--- a/packages/obsidian-plugin/tests/e2e/eka-gui/eka-gui-helpers.ts
+++ b/packages/obsidian-plugin/tests/e2e/eka-gui/eka-gui-helpers.ts
@@ -407,6 +407,64 @@ export async function waitForStoreSettled(
 }
 
 /**
+ * Wait until the live plugin can resolve ALL `requiredLabels` create-commands on
+ * the seed area — i.e. the render-path store is COMPLETE for command resolution.
+ *
+ * WHY (#3587): `waitForStoreSettled` only watches `store.count()` and returns at
+ * the FIRST plateau. On the EKA assetspace layout (`assetspaces/<owner>/exoas-*`)
+ * the lazy bootstrap folders don't match, so the TBox (commands/bindings/
+ * groundings) loads ONLY via `convertVault()`, which populates the store
+ * INCREMENTALLY. The count can plateau briefly (~15060 of ~16512 triples) while
+ * convertVault is mid-walk, so a scenario asserting in that window sees a partial
+ * store: Create Project's binding→command→grounding subgraph (and sometimes Create
+ * Task's backlink InheritanceRule) hasn't landed yet → button missing / backlink
+ * unwritten. Two CI DIAG rounds proved this is a transient store-load race, NOT a
+ * resolver bug (the resolver + converter return Create Project on a full store).
+ *
+ * Polling `resolveForAssetMulti(seedAreaIRI, classes)` until it returns every
+ * `requiredLabels` entry directly gates on what the scenarios need: a store
+ * complete enough to resolve every create command. `invalidateCache()` each poll
+ * forces a fresh resolution against the now-larger store.
+ */
+export async function waitForCreateCommandsResolvable(
+  window: Page,
+  areaRel: string,
+  areaClassUid: string,
+  requiredLabels: string[],
+  timeoutMs = 120_000,
+): Promise<void> {
+  await pollUntil(
+    `create commands resolvable on seed area (${requiredLabels.join(", ")})`,
+    async () => {
+      const names = await window.evaluate(
+        async ({ rel, cls }) => {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          const plugin = (window as any).app?.plugins?.plugins?.exocortex;
+          if (!plugin?.commandResolver?.resolveForAssetMulti) return [];
+          const iri = `obsidian://vault/${encodeURI(rel)}`;
+          // Fresh resolution against the current (growing) store each poll.
+          plugin.commandResolver.invalidateCache?.();
+          try {
+            const resolved = await plugin.commandResolver.resolveForAssetMulti(
+              iri,
+              [cls, "ems__Area", "exo__Asset"],
+            );
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            return resolved.map((rc: any) => rc?.command?.name).filter(Boolean);
+          } catch {
+            return [];
+          }
+        },
+        { rel: areaRel, cls: areaClassUid },
+      );
+      return requiredLabels.every((l) => names.includes(l));
+    },
+    timeoutMs,
+    2000,
+  );
+}
+
+/**
  * Auto-accept native `window.confirm()` dialogs. Several create commands declare
  * `confirmMessage` and the plugin's CommandPromptAdapter renders it via the
  * NATIVE `window.confirm()` — under CDP, Playwright's default is to DISMISS

--- a/packages/obsidian-plugin/tests/e2e/eka-gui/eka-gui-helpers.ts
+++ b/packages/obsidian-plugin/tests/e2e/eka-gui/eka-gui-helpers.ts
@@ -421,10 +421,15 @@ export async function waitForStoreSettled(
  * unwritten. Two CI DIAG rounds proved this is a transient store-load race, NOT a
  * resolver bug (the resolver + converter return Create Project on a full store).
  *
- * Polling `resolveForAssetMulti(seedAreaIRI, classes)` until it returns every
- * `requiredLabels` entry directly gates on what the scenarios need: a store
- * complete enough to resolve every create command. `invalidateCache()` each poll
- * forces a fresh resolution against the now-larger store.
+ * CRITICAL: each poll FORCES a full store re-index via `sparql.refresh()`
+ * (clear + convertVault + addAll) before resolving. `invalidateCache()` alone is
+ * NOT enough — it clears only the resolver cache, not the store, so polling a
+ * store that `convertVault` populated ONCE (against a partially-parsed
+ * metadataCache) would query the same partial snapshot forever. Driving
+ * `refresh()` re-reads every file against the now-more-complete metadataCache, so
+ * successive polls grow the store until the create-command subgraph is present.
+ * This mirrors the production re-index path (resolved-handler / hot-reindex),
+ * just driven deterministically so the test asserts against a complete store.
  */
 export async function waitForCreateCommandsResolvable(
   window: Page,
@@ -442,7 +447,17 @@ export async function waitForCreateCommandsResolvable(
           const plugin = (window as any).app?.plugins?.plugins?.exocortex;
           if (!plugin?.commandResolver?.resolveForAssetMulti) return [];
           const iri = `obsidian://vault/${encodeURI(rel)}`;
-          // Fresh resolution against the current (growing) store each poll.
+          // Force a full re-index against the current metadataCache state, then
+          // mirror the plugin's post-refresh discipline (clear lazy marks +
+          // invalidate resolver caches) so resolution sees the freshly-rebuilt
+          // store. As metadataCache finishes parsing the cold-start vault,
+          // successive refreshes pick up the remaining files.
+          try {
+            await plugin.sparql?.refresh?.();
+          } catch {
+            /* transient mid-refresh — next poll retries */
+          }
+          plugin.lazyAssetGraphLoader?.clearAll?.();
           plugin.commandResolver.invalidateCache?.();
           try {
             const resolved = await plugin.commandResolver.resolveForAssetMulti(
@@ -460,7 +475,7 @@ export async function waitForCreateCommandsResolvable(
       return requiredLabels.every((l) => names.includes(l));
     },
     timeoutMs,
-    2000,
+    3000,
   );
 }
 


### PR DESCRIPTION
## Summary

`#3587` was **not** a Create-Project render-path logic drop. Two CI DIAG rounds (on this branch) + a Node `convertVault` repro proved the **resolver + converter are correct**: a full store (16512 triples over the exact eka-gui vault layout) returns Create Project from `resolveForAssetMulti`, and `apply create-project` resolves it.

The live e2e failure was a **transient store-load TIMING RACE**: `waitForStoreSettled` returned at the first `store.count()` plateau (~15060 of ~16512 triples) while `convertVault` was still incrementally populating, so a scenario could assert inside that window against a **partial store** where Create Project's binding→command→grounding subgraph (round-1: `loadCommand(Project)=NULL`) — or sometimes Create Task's backlink InheritanceRule (the scenario-2 flake) — had not yet landed. round-2 caught `loadCommand(Project)=OK` once the store grew.

## Fix (test-only)

`waitForCreateCommandsResolvable` polls `resolveForAssetMulti` on the seed area until **{Create Task, Create Area, Create Project}** all resolve, so every scenario asserts against a **complete** store. `scenario 3 (Create Project)` un-fixme'd → live regression gate. Deterministic for scenario 2 + 3 → GUI-BDD-CI 8/8.

## Root contributor (follow-up)

On the EKA assetspace layout (`assetspaces/<owner>/exoas-*`) the default `lazyBootstrapFolders` don't match → TBox not preloaded → wider partial-store window. Tracked as **#3588** (bootstrap-folder glob; design trade-off; post-alpha). Product is eventually-consistent (re-render on store-settle wired post-#3580/v16.97.4) — no permanent miss.

## Verification

- Node repro: full `convertVault` store → `resolveForAssetMulti` returns Create Project; `loadCommand(3520c214)` OK.
- 2 CI DIAG rounds on `eka-gui-e2e`: confirmed transient race (round-1 NULL / round-2 OK; scenario-2 also flaked on the same race).
- This PR: `eka-gui-e2e` (native amd64, non-required) confirms scenario 3 green → 8/8.

Test-only change (`packages/obsidian-plugin/tests/e2e/eka-gui/**`); no product/parser/TBox paths touched.

Closes #3587