### PR TITLE
fix(#3588): lazy-tbox-bootstrap matches EKA audience-layered layout

### DIFF
--- a/packages/obsidian-plugin/src/ExocortexPlugin.ts
+++ b/packages/obsidian-plugin/src/ExocortexPlugin.ts
@@ -170,10 +170,34 @@ export default class ExocortexPlugin extends Plugin {
    * was previously empirically untested, which is exactly how the
    * `bb00efed → ems-commands/` migration silently stayed unindexed).
    *
-   * Match is `String.startsWith` against vault-relative path. Caller is
-   * responsible for ensuring each prefix in `folderPrefixes` ends with
-   * `/` so `assetspaces/ems/` does not over-match `assetspaces/ems-commands/`
-   * (Settings UI auto-appends — see ExocortexSettingTab).
+   * Two prefix dialects (mixed freely in one list):
+   *
+   *  1. **Plain prefix** (no `*`) — matched via `String.startsWith` against
+   *     the vault-relative path. Fast path; backward-compatible with the
+   *     legacy two-vault layout (`assetspaces/ems/`, `assetspaces/exocmd/`).
+   *     Caller must end each prefix with `/` so `assetspaces/ems/` does not
+   *     over-match `assetspaces/ems-commands/` (Settings UI auto-appends —
+   *     see ExocortexSettingTab).
+   *
+   *  2. **Segment-wildcard glob** (#3588) — a prefix containing a `*` is
+   *     matched segment-by-segment, where each `*` matches EXACTLY ONE path
+   *     segment. This reaches the EKA audience-layered layout, which mounts
+   *     assetspaces at `assetspaces/<owner>/<assetspace>/<namespace>/<uid>.md`
+   *     (e.g. `assetspaces/kitelev/exoas-exocmd/exocmd/<uid>.md`). A plain
+   *     `startsWith` never matches that depth → bootstrap walked 0 files →
+   *     command/binding/grounding triples arrived only via the slow
+   *     incremental `convertVault` cold-start (root of the #3587 partial-store
+   *     race). The glob `assetspaces/<star>/<star>/exocmd/` (two wildcard
+   *     segments, written `<star>` here only to avoid closing this comment)
+   *     reaches the namespace folder under ANY owner+assetspace while staying
+   *     scope-tight: it targets the SAME 5 TBox namespaces the legacy default
+   *     did (exo, ems, ems-commands, ims, exocmd), NOT every assetspace (no
+   *     leaf ABox like `exoas-my/pn`) and NOT the whole of `exoas-public` (its
+   *     30+ framework namespaces concept, person, ui, …). Folder semantics
+   *     preserved: the path must extend BEYOND the glob (a file lives inside
+   *     the namespace folder), and a wildcard never spans two segments, so a
+   *     single-wildcard `assetspaces/<star>/exocmd/` does NOT collapse the EKA
+   *     owner+assetspace nesting.
    *
    * Returns empty array if `folderPrefixes` is empty (degraded mode —
    * bootstrap walks nothing; buttons appear later via convertVault).
@@ -183,8 +207,37 @@ export default class ExocortexPlugin extends Plugin {
     folderPrefixes: string[],
   ): T[] {
     if (folderPrefixes.length === 0) return [];
-    return files.filter((f) =>
-      folderPrefixes.some((folder) => f.path.startsWith(folder)),
+    // Precompile matchers once (not per-file): plain prefixes keep the cheap
+    // startsWith; glob prefixes are pre-split into segments (trailing empty
+    // from the required trailing `/` dropped, so the segment array is the
+    // folder path the file must live inside).
+    const plainPrefixes: string[] = [];
+    const globSegmentSets: string[][] = [];
+    for (const prefix of folderPrefixes) {
+      if (prefix.includes("*")) {
+        const segs = prefix.split("/");
+        if (segs[segs.length - 1] === "") segs.pop();
+        globSegmentSets.push(segs);
+      } else {
+        plainPrefixes.push(prefix);
+      }
+    }
+    const matchesGlob = (path: string): boolean => {
+      if (globSegmentSets.length === 0) return false;
+      const pathSegs = path.split("/");
+      return globSegmentSets.some((glob) => {
+        // Folder prefix: the file must live INSIDE the folder, so it needs
+        // strictly more segments than the glob (the filename, at least).
+        if (pathSegs.length <= glob.length) return false;
+        for (let i = 0; i < glob.length; i++) {
+          if (glob[i] !== "*" && glob[i] !== pathSegs[i]) return false;
+        }
+        return true;
+      });
+    };
+    return files.filter(
+      (f) =>
+        plainPrefixes.some((p) => f.path.startsWith(p)) || matchesGlob(f.path),
     );
   }
 

--- a/packages/obsidian-plugin/src/domain/settings/ExocortexSettings.ts
+++ b/packages/obsidian-plugin/src/domain/settings/ExocortexSettings.ts
@@ -306,11 +306,25 @@ export const DEFAULT_SETTINGS: ExocortexSettings = {
   enablePropertiesLabelPatch: true,
   excludedFolders: ["09 Templates/"],
   lazyBootstrapFolders: [
+    // Legacy two-vault layout — `assetspaces/<namespace>/` (plain startsWith).
     "assetspaces/exo/",
     "assetspaces/ems/",
     "assetspaces/ems-commands/",
     "assetspaces/ims/",
     "assetspaces/exocmd/",
+    // EKA audience-layered layout (#3588) — `assetspaces/<owner>/<assetspace>/
+    // <namespace>/` (segment-wildcard glob; each `*` = exactly one segment).
+    // Targets the SAME 5 TBox namespaces as above under any owner+assetspace
+    // (e.g. `assetspaces/kitelev/exoas-exocmd/exocmd/`,
+    // `assetspaces/kitelev/exoas-public/ems/`), so create-command/binding/
+    // grounding triples are bootstrapped eagerly instead of waiting on the
+    // slow incremental convertVault cold-start. Scope-tight: does NOT pull
+    // leaf-ABox assetspaces or the 30+ framework namespaces of exoas-public.
+    "assetspaces/*/*/exo/",
+    "assetspaces/*/*/ems/",
+    "assetspaces/*/*/ems-commands/",
+    "assetspaces/*/*/ims/",
+    "assetspaces/*/*/exocmd/",
   ],
   activeProfileUid: null,
   exosyncQuarantineRepoUrl: "",

--- a/packages/obsidian-plugin/tests/unit/ExocortexPlugin.filterTBoxFiles.test.ts
+++ b/packages/obsidian-plugin/tests/unit/ExocortexPlugin.filterTBoxFiles.test.ts
@@ -96,4 +96,137 @@ describe("ExocortexPlugin.filterTBoxFiles (RFC c7da0bca Phase 5)", () => {
       ExocortexPlugin.filterTBoxFiles([], ["assetspaces/exo/"]),
     ).toEqual([]);
   });
+
+  // ----------------------------------------------------------------------
+  //  #3588 — EKA audience-layered layout: assetspaces are mounted under
+  //  `assetspaces/<owner>/<assetspace>/<namespace>/<uid>.md` (e.g.
+  //  `assetspaces/kitelev/exoas-exocmd/exocmd/<uid>.md`,
+  //  `assetspaces/kitelev/exoas-public/ems/<uid>.md`). A plain `startsWith`
+  //  prefix never matches that depth → bootstrap walked 0 files → command/
+  //  binding/grounding triples only arrived via the slow incremental
+  //  convertVault cold-start → create-buttons appeared late (root of the
+  //  #3587 eka-gui partial-store race). A single-segment `*` wildcard in a
+  //  prefix matches exactly one path segment, so `assetspaces/*/*/exocmd/`
+  //  reaches the namespace folder under ANY owner+assetspace WITHOUT pulling
+  //  unrelated assetspaces (leaf ABox like `exoas-my/pn/`) or the whole of
+  //  `exoas-public` (its 30+ framework namespaces concept/person/ui/…).
+  // ----------------------------------------------------------------------
+  describe("#3588 EKA layout — segment-wildcard prefixes", () => {
+    it("matches the EKA exocmd namespace folder under owner+assetspace via assetspaces/*/*/exocmd/", () => {
+      const files = [
+        { path: "assetspaces/kitelev/exoas-exocmd/exocmd/22093ca1.md" },
+        { path: "assetspaces/kitelev/exoas-public/ems/82c74542.md" },
+        { path: "assetspaces/kitelev/exoas-public/ems-commands/bb00efed.md" },
+        { path: "assetspaces/kitelev/exoas-exo/exo/Class.md" },
+      ];
+      const result = ExocortexPlugin.filterTBoxFiles(files, [
+        "assetspaces/*/*/exo/",
+        "assetspaces/*/*/ems/",
+        "assetspaces/*/*/ems-commands/",
+        "assetspaces/*/*/ims/",
+        "assetspaces/*/*/exocmd/",
+      ]);
+      expect(result.map((f) => f.path).sort()).toEqual([
+        "assetspaces/kitelev/exoas-exo/exo/Class.md",
+        "assetspaces/kitelev/exoas-exocmd/exocmd/22093ca1.md",
+        "assetspaces/kitelev/exoas-public/ems-commands/bb00efed.md",
+        "assetspaces/kitelev/exoas-public/ems/82c74542.md",
+      ]);
+    });
+
+    it("a `*` matches exactly one segment — does NOT collapse owner+assetspace into one", () => {
+      // `assetspaces/*/exocmd/` (single wildcard) must NOT match the
+      // two-level EKA nesting `assetspaces/<owner>/<assetspace>/exocmd/`.
+      const files = [
+        { path: "assetspaces/kitelev/exoas-exocmd/exocmd/x.md" },
+      ];
+      expect(
+        ExocortexPlugin.filterTBoxFiles(files, ["assetspaces/*/exocmd/"]),
+      ).toEqual([]);
+    });
+
+    it("EKA glob is scope-tight: does NOT pull leaf-ABox or unrelated exoas-public framework namespaces", () => {
+      const files = [
+        // wanted (TBox namespaces)
+        { path: "assetspaces/kitelev/exoas-public/ems/Area.md" },
+        { path: "assetspaces/kitelev/exoas-exocmd/exocmd/cmd.md" },
+        // NOT wanted: personal leaf ABox
+        { path: "assetspaces/kitelev/exoas-my/pn/2026-06-18.md" },
+        { path: "assetspaces/kitelev/exoas-my/ztlk/note.md" },
+        { path: "assetspaces/kitelev/exoas-tbank/og/secret.md" },
+        // NOT wanted: exoas-public framework namespaces unrelated to ems create-buttons
+        { path: "assetspaces/kitelev/exoas-public/concept/c.md" },
+        { path: "assetspaces/kitelev/exoas-public/person/p.md" },
+        { path: "assetspaces/kitelev/exoas-public/ui/layout.md" },
+      ];
+      const result = ExocortexPlugin.filterTBoxFiles(files, [
+        "assetspaces/*/*/exo/",
+        "assetspaces/*/*/ems/",
+        "assetspaces/*/*/ems-commands/",
+        "assetspaces/*/*/ims/",
+        "assetspaces/*/*/exocmd/",
+      ]);
+      expect(result.map((f) => f.path).sort()).toEqual([
+        "assetspaces/kitelev/exoas-exocmd/exocmd/cmd.md",
+        "assetspaces/kitelev/exoas-public/ems/Area.md",
+      ]);
+    });
+
+    it("matches files nested DEEPER than the namespace folder (prefix semantics preserved)", () => {
+      const files = [
+        { path: "assetspaces/kitelev/exoas-exocmd/exocmd/sub/deep.md" },
+      ];
+      expect(
+        ExocortexPlugin.filterTBoxFiles(files, ["assetspaces/*/*/exocmd/"]),
+      ).toHaveLength(1);
+    });
+
+    it("wildcard prefix still honours trailing-slash boundary (ems vs ems-commands)", () => {
+      const files = [
+        { path: "assetspaces/kitelev/exoas-public/ems/Effort.md" },
+        { path: "assetspaces/kitelev/exoas-public/ems-commands/bb00efed.md" },
+      ];
+      const result = ExocortexPlugin.filterTBoxFiles(files, [
+        "assetspaces/*/*/ems/",
+      ]);
+      expect(result.map((f) => f.path)).toEqual([
+        "assetspaces/kitelev/exoas-public/ems/Effort.md",
+      ]);
+    });
+
+    it("REGRESSION GUARD: legacy two-vault `assetspaces/<ns>/` prefixes still match (no wildcard)", () => {
+      const files = [
+        { path: "assetspaces/exo/Class.md" },
+        { path: "assetspaces/ems/Task.md" },
+        { path: "assetspaces/ems-commands/bb00efed.md" },
+        { path: "assetspaces/exocmd/22093ca1.md" },
+        { path: "03 Knowledge/foo.md" },
+      ];
+      const result = ExocortexPlugin.filterTBoxFiles(files, [
+        "assetspaces/exo/",
+        "assetspaces/ems/",
+        "assetspaces/ems-commands/",
+        "assetspaces/ims/",
+        "assetspaces/exocmd/",
+      ]);
+      expect(result.map((f) => f.path).sort()).toEqual([
+        "assetspaces/ems-commands/bb00efed.md",
+        "assetspaces/ems/Task.md",
+        "assetspaces/exo/Class.md",
+        "assetspaces/exocmd/22093ca1.md",
+      ]);
+    });
+
+    it("legacy + EKA prefixes coexist (mixed-layout vault during migration)", () => {
+      const files = [
+        { path: "assetspaces/ems/legacy.md" },
+        { path: "assetspaces/kitelev/exoas-public/ems/eka.md" },
+      ];
+      const result = ExocortexPlugin.filterTBoxFiles(files, [
+        "assetspaces/ems/",
+        "assetspaces/*/*/ems/",
+      ]);
+      expect(result).toHaveLength(2);
+    });
+  });
 });


### PR DESCRIPTION
## Problem (#3588)

`ExocortexPlugin.filterTBoxFiles` matched lazy-bootstrap folders with plain `String.startsWith`. The EKA audience-layered layout mounts assetspaces at `assetspaces/<owner>/<assetspace>/<namespace>/<uid>.md` (e.g. `assetspaces/kitelev/exoas-exocmd/exocmd/<uid>.md`, `assetspaces/kitelev/exoas-public/ems/<uid>.md`) — which matches **none** of the legacy `assetspaces/<ns>/` default prefixes.

Result on an EKA-layout vault: lazy-tbox-bootstrap walked **0 files** → command/binding/grounding triples landed only via the slow incremental `convertVault()` cold-start → an extended partial-store window → create-instance buttons appeared late. This is the root of the #3587 eka-gui `create Project` partial-store race.

Not a functional bug (product is eventually-consistent, re-renders on store-settle post-#3580/v16.97.4) — it is **cold-start latency / UX**.

## Fix

1. **`filterTBoxFiles` — segment-wildcard glob support.** A prefix containing `*` is matched segment-by-segment, where each `*` matches **exactly one** path segment. Plain prefixes (no `*`) keep the cheap `startsWith` fast path. Both dialects coexist in one list.
2. **`DEFAULT_SETTINGS.lazyBootstrapFolders` — 5 EKA glob defaults** added alongside the legacy 5, targeting the SAME 5 TBox namespaces under any owner+assetspace:
   - `assetspaces/<star>/<star>/exo/`, `…/ems/`, `…/ems-commands/`, `…/ims/`, `…/exocmd/`

## Design trade-off (bootstrap-scope vs cold-start)

The fix must match the EKA layout **without** inflating the very cold-start it optimizes. Two candidate patterns were considered:

| Candidate | Verdict |
|---|---|
| `assetspaces/*/exoas-*/` (whole-assetspace glob) | ❌ too broad — pulls leaf-ABox assetspaces (`exoas-my`, `exoas-tbank`) = personal/work data, AND all 30+ framework namespaces of `exoas-public` (concept/person/ui/…). Re-introduces the slow cold-start. |
| Extend `startsWith` defaults with EKA paths | ❌ impossible cleanly — the `<owner>` segment is variable (kitelev/kalashnikova/…) and the assetspace name ≠ namespace (`ems` lives in `exoas-public`, not `exoas-ems`). |
| **`assetspaces/<star>/<star>/<ns>/` (namespace-leaf glob)** | ✅ **chosen** — scope-tight: targets exactly the same 5 TBox namespaces the legacy default did, under any owner+assetspace, and nothing else. |

**Why namespace-leaf is correct & tight (empirically verified against the published `kitelev/exoas-*` repos):** the create-instance commands/bindings/groundings + the #3555 `InheritanceRule` live in `exoas-exocmd/exocmd/` (306 files) + `exoas-public/ems-commands/` (6) + `exoas-public/ems/` (ems classes) + `exoas-exo/exo/` — i.e. **exactly** the `exo/ems/ems-commands/ims/exocmd` namespace folders. The glob walks only those; it does **not** match `exoas-public/concept|person|ui|…/` (framework TBox unrelated to ems create-buttons) nor `exoas-my/pn|ztlk|lit/` (personal leaf ABox). Folder semantics are preserved (the path must extend beyond the glob), and a `*` never spans two segments so single-wildcard `assetspaces/<star>/exocmd/` does not collapse the EKA nesting.

## Tests (TDD + revert-verify)

New `describe("#3588 EKA layout …")` block in `ExocortexPlugin.filterTBoxFiles.test.ts` (7 cases) using production-shape `{ path }` records.

**Revert-verify (empirically captured, this branch):**
- Against the **pre-fix** `startsWith`-only `filterTBoxFiles`: **5/14 FAIL** (the EKA-match cases) — proves the tests detect absence of the fix.
- After the glob implementation: **14/14 PASS**.
- The **legacy regression-guard** case (`assetspaces/<ns>/` plain prefixes) passes in **both** states — confirms backward-compat is not coupled to the new path.

```
# pre-fix:  Tests: 5 failed, 9 passed, 14 total
# post-fix: Tests: 14 passed, 14 total
```

Adjacent suites green: `ExocortexSettingTab` + `ExocortexPlugin` + `VaultSettingsStore` + `VaultSettingsRegistry` (133 + 13). Typecheck (`tsc -noEmit -skipLibCheck`) clean; lint clean; archgate 20/20.

## Scope
- `packages/obsidian-plugin/src/ExocortexPlugin.ts` (`filterTBoxFiles`)
- `packages/obsidian-plugin/src/domain/settings/ExocortexSettings.ts` (`lazyBootstrapFolders` default)
- `packages/obsidian-plugin/tests/unit/ExocortexPlugin.filterTBoxFiles.test.ts`

Closes #3588.