### PR TITLE
fix(#3590): first-sync 3-way merge base from recorded mount SHA (no false full-conflict)

### DIFF
--- a/packages/cli/src/commands/apply-profile.ts
+++ b/packages/cli/src/commands/apply-profile.ts
@@ -8,6 +8,7 @@ import {
   TsFloorViolationError,
 } from "../services/CliApplyProfileService.js";
 import { BootstrapAssetSpaceService } from "../services/BootstrapAssetSpaceService.js";
+import { nodeMountBaseStore } from "./exosync-sync.js";
 import { HeadlessConfirmGate } from "../services/HeadlessConfirmGate.js";
 import { ErrorHandler } from "../utils/ErrorHandler.js";
 import {
@@ -161,7 +162,12 @@ export async function runApplyProfile(
     new CliApplyProfileService({
       vaultPath,
       ref: opts.ref ?? "main",
-      mount: new BootstrapAssetSpaceService({ token }),
+      // #3590 — record each mounted AssetSpace's commit SHA as the first-sync
+      // 3-way merge base (same device-local file `exosync sync` reads).
+      mount: new BootstrapAssetSpaceService({
+        token,
+        mountBaseStore: nodeMountBaseStore(vaultPath),
+      }),
     });
 
   const { infos, profileLabels } = service.scanVault();

--- a/packages/cli/src/commands/assetspace-add.ts
+++ b/packages/cli/src/commands/assetspace-add.ts
@@ -3,6 +3,7 @@ import { resolve, join } from "node:path";
 import { existsSync } from "node:fs";
 import { derivePath } from "exocortex";
 import { BootstrapAssetSpaceService } from "../services/BootstrapAssetSpaceService.js";
+import { nodeMountBaseStore } from "./exosync-sync.js";
 import { ErrorHandler } from "../utils/ErrorHandler.js";
 import { InvalidArgumentsError, VaultNotFoundError } from "../utils/errors/index.js";
 
@@ -95,7 +96,12 @@ export function assetSpaceAddCommand(): Command {
         // through to the next source instead of pinning anonymous mode.
         // All-empty → undefined → anonymous mode (public repos), unchanged.
         const token = options.token || process.env.GITHUB_TOKEN || process.env.GH_TOKEN || undefined;
-        const svc = new BootstrapAssetSpaceService({ token });
+        // #3590 — record the mounted commit SHA as the first-sync 3-way merge
+        // base (same device-local file `exosync sync` reads).
+        const svc = new BootstrapAssetSpaceService({
+          token,
+          mountBaseStore: nodeMountBaseStore(vaultPath),
+        });
         const ref = options.ref ?? "main";
         // #3538: default to the canonical Maven path `assetspaces/<owner>/<repo>`
         // (parity with bootstrap + apply-profile). `--folder` still overrides to

--- a/packages/cli/src/commands/bootstrap.ts
+++ b/packages/cli/src/commands/bootstrap.ts
@@ -3,6 +3,7 @@ import { resolve, join } from "node:path";
 import { existsSync, mkdirSync, readdirSync } from "node:fs";
 import { derivePath } from "exocortex";
 import { BootstrapAssetSpaceService } from "../services/BootstrapAssetSpaceService.js";
+import { nodeMountBaseStore } from "./exosync-sync.js";
 import { ErrorHandler } from "../utils/ErrorHandler.js";
 import { InvalidArgumentsError } from "../utils/errors/index.js";
 
@@ -83,7 +84,12 @@ export function bootstrapCommand(): Command {
         // through to the next source instead of pinning anonymous mode.
         // All-empty → undefined → anonymous mode (public repos), unchanged.
         const token = options.token || process.env.GITHUB_TOKEN || process.env.GH_TOKEN || undefined;
-        const svc = new BootstrapAssetSpaceService({ token });
+        // #3590 — record each mounted commit SHA as the first-sync 3-way merge
+        // base (same device-local file `exosync sync` reads).
+        const svc = new BootstrapAssetSpaceService({
+          token,
+          mountBaseStore: nodeMountBaseStore(vaultPath),
+        });
         const ref = options.ref ?? "main";
 
         const results: Array<{ folder: string; url: string; sha: string; fileCount: number }> = [];

--- a/packages/cli/src/commands/exosync-sync.ts
+++ b/packages/cli/src/commands/exosync-sync.ts
@@ -37,8 +37,10 @@ import { webcrypto } from "node:crypto";
 import * as path from "node:path";
 import yaml from "js-yaml";
 import {
+  FileMountBaseStore,
   FileWatermarkStore,
   GatedStructuredMerger,
+  MOUNT_BASE_STORE_FILENAME,
   StructuredMerger,
   SyncedQuarantineStore,
   SyncEngine,
@@ -236,6 +238,28 @@ export function nodeWatermarkFileIO(filePath: string): WatermarkFileIO {
 }
 
 /**
+ * #3590 — node-backed mount-base store over the vault's device-local
+ * `exosync-mountbase.local.json`. SINGLE source of the path convention so the
+ * WRITE side (apply / mount commands) and the READ side (`exosync sync`) always
+ * agree on the file — a mismatch would silently lose the recorded merge base
+ * (safe, but the fix would not fire). `configDir` defaults to `.obsidian`,
+ * matching the sync command's default.
+ */
+export function nodeMountBaseStore(
+  vaultPath: string,
+  configDir = ".obsidian",
+): FileMountBaseStore {
+  const filePath = path.join(
+    vaultPath,
+    configDir,
+    "plugins",
+    "exocortex",
+    MOUNT_BASE_STORE_FILENAME,
+  );
+  return new FileMountBaseStore(nodeWatermarkFileIO(filePath));
+}
+
+/**
  * CLI full-materialization gate (D19). The CLI has no plugin profile-apply /
  * staging state to consult, so the floor check is: mount folder exists +
  * (for non-file spaces) non-empty. An empty FileSpace folder is a legitimate
@@ -346,7 +370,6 @@ export async function runExosyncSync(
     "exocortex",
     WATERMARK_STORE_FILENAME,
   );
-
   let quarantine: QuarantinePort | undefined;
   const quarantineUrl = opts.quarantineRepo?.trim() ?? "";
   if (quarantineUrl.length > 0) {
@@ -366,6 +389,7 @@ export async function runExosyncSync(
   const engine = new SyncEngine({
     transport,
     watermarkStore: new FileWatermarkStore(nodeWatermarkFileIO(watermarkPath)),
+    mountBaseStore: nodeMountBaseStore(vaultPath, configDir),
     materializationCheck: nodeMaterializationCheck(vaultPath),
     localFilesFor: (spec) =>
       nodeLocalFilesPort(path.join(vaultPath, spec.localPath)),

--- a/packages/cli/src/services/BootstrapAssetSpaceService.ts
+++ b/packages/cli/src/services/BootstrapAssetSpaceService.ts
@@ -40,8 +40,10 @@ import {
   mountAssetSpaceFiles,
   appendGitmodulesEntry,
   stripGitmodulesEntry as coreStripGitmodulesEntry,
+  SYNC_BRANCH,
   type FileSystemPort,
   type AssetSpaceHttpClient,
+  type MountBaseStorePort,
   type MountFile,
 } from "exocortex";
 
@@ -66,11 +68,21 @@ export interface BootstrapServiceOptions {
    * from `--token` flag OR `GITHUB_TOKEN`/`GH_TOKEN` env (option > env).
    */
   token?: string;
+  /**
+   * #3590 — records the mounted commit SHA (the first-sync 3-way merge base)
+   * keyed by `repoKey`, the instant an AssetSpace is pulled. Optional: absent ⇒
+   * no base recorded ⇒ first-sync of a diverged repo stays the conservative
+   * full-conflict (zero regression). The CLI commands build it over the vault's
+   * device-local `exosync-mountbase.local.json` (same file `exosync sync`
+   * reads). See {@link MountBaseStorePort}.
+   */
+  mountBaseStore?: MountBaseStorePort;
 }
 
 export class BootstrapAssetSpaceService {
   private readonly fetchImpl: typeof fetch;
   private readonly token: string;
+  private readonly mountBaseStore?: MountBaseStorePort;
 
   // PAT redaction (mirrors plugin GitHubRestClient.PAT_REGEX) — replaces any
   // PAT-shaped substring that may leak into an error message / underlying
@@ -83,6 +95,7 @@ export class BootstrapAssetSpaceService {
   constructor(opts: BootstrapServiceOptions = {}) {
     this.fetchImpl = opts.fetchImpl ?? globalThis.fetch;
     this.token = opts.token ?? "";
+    this.mountBaseStore = opts.mountBaseStore;
   }
 
   /**
@@ -144,7 +157,7 @@ export class BootstrapAssetSpaceService {
       }
     }
 
-    return mountAssetSpaceFiles({
+    const result = await mountAssetSpaceFiles({
       http: this.httpPort(),
       fs: this.fsPort(),
       owner,
@@ -152,6 +165,24 @@ export class BootstrapAssetSpaceService {
       ref,
       targetPath: targetDir,
     });
+
+    // #3590 — record the mounted commit SHA (correct-by-construction from the
+    // tarball wrapper) as the first-sync 3-way merge base, keyed by the SAME
+    // `repoKey` the sync engine reads. Best-effort: a store-write failure must
+    // NOT fail the pull (worst case is the conservative full-conflict on first
+    // sync, never data loss).
+    if (this.mountBaseStore !== undefined) {
+      try {
+        await this.mountBaseStore.set(
+          `${owner}/${repo}#${SYNC_BRANCH}`,
+          result.sha,
+        );
+      } catch {
+        /* non-fatal — first-sync falls back to full-conflict, never a loss */
+      }
+    }
+
+    return result;
   }
 
   /**

--- a/packages/exocortex/src/index.ts
+++ b/packages/exocortex/src/index.ts
@@ -634,6 +634,7 @@ export {
   type MergeConflictInput,
   type MergeDecision,
   type MergeLayerPort,
+  type MountBaseStorePort,
   type QuarantineEntry,
   type QuarantinePort,
   type RepoSyncResult,
@@ -676,6 +677,10 @@ export {
   WATERMARK_STORE_FILENAME,
   type WatermarkFileIO,
 } from "./services/sync/FileWatermarkStore";
+export {
+  FileMountBaseStore,
+  MOUNT_BASE_STORE_FILENAME,
+} from "./services/sync/FileMountBaseStore";
 export {
   isAuthError,
   type CredentialStorePort,

--- a/packages/exocortex/src/services/sync/FileMountBaseStore.ts
+++ b/packages/exocortex/src/services/sync/FileMountBaseStore.ts
@@ -1,0 +1,74 @@
+/**
+ * ExoSync durable per-device mount-base store (#3590).
+ *
+ * One JSON file holds, per `repoKey`, the commit SHA the AssetSpace was MOUNTED
+ * at — the true 3-way merge base for the FIRST sync (see
+ * {@link MountBaseStorePort}). Same `data.local.json` discipline as the
+ * watermark store: the `.local.` infix (`exosync-mountbase.local.json`) is
+ * Sync-excluded by Obsidian convention AND refused by `isSyncablePath`, so the
+ * device-specific base never leaks into a commit.
+ *
+ * Platform-free: file access goes through the same injected
+ * {@link WatermarkFileIO} both platforms already build for the watermark store
+ * (plugin: `app.vault.adapter`; CLI: `node:fs` temp+rename). Corruption-tolerant
+ * (R10): a missing/unparseable file yields `get() === null`, so the engine takes
+ * the conservative full-conflict path — never a silent overwrite. Writes are
+ * serialized through an internal promise chain (lossless RMW) and MUST be atomic
+ * at the IO layer.
+ */
+
+import type { MountBaseStorePort } from "./syncTypes";
+import type { WatermarkFileIO } from "./FileWatermarkStore";
+
+/** Recommended store filename — `.local.` infix is Sync-excluded. */
+export const MOUNT_BASE_STORE_FILENAME = "exosync-mountbase.local.json";
+
+interface MountBaseStoreShape {
+  version: 1;
+  /** repoKey → mounted commit SHA. */
+  repos: Record<string, string>;
+}
+
+export class FileMountBaseStore implements MountBaseStorePort {
+  private writeChain: Promise<void> = Promise.resolve();
+
+  constructor(private readonly io: WatermarkFileIO) {}
+
+  async get(repoKey: string): Promise<string | null> {
+    const repos = await this.readRepos();
+    const sha = repos[repoKey];
+    return typeof sha === "string" && sha.length > 0 ? sha : null;
+  }
+
+  async set(repoKey: string, sha: string): Promise<void> {
+    const task = this.writeChain.then(async () => {
+      const repos = await this.readRepos();
+      repos[repoKey] = sha;
+      const store: MountBaseStoreShape = { version: 1, repos };
+      await this.io.writeAtomic(JSON.stringify(store, null, 2));
+    });
+    // Keep the chain alive even when a write fails — the NEXT set must still
+    // run; the failure propagates to THIS caller only.
+    this.writeChain = task.catch(() => undefined);
+    return task;
+  }
+
+  /** Tolerant read: absent/corrupt file → empty store (R10, never throws). */
+  private async readRepos(): Promise<Record<string, string>> {
+    try {
+      const raw = await this.io.read();
+      if (raw === null) return {};
+      const parsed = JSON.parse(raw) as unknown;
+      if (parsed === null || typeof parsed !== "object") return {};
+      const repos = (parsed as { repos?: unknown }).repos;
+      if (repos === null || typeof repos !== "object") return {};
+      const out: Record<string, string> = {};
+      for (const [k, v] of Object.entries(repos as Record<string, unknown>)) {
+        if (typeof v === "string") out[k] = v;
+      }
+      return out;
+    } catch {
+      return {};
+    }
+  }
+}

--- a/packages/exocortex/src/services/sync/SyncEngine.ts
+++ b/packages/exocortex/src/services/sync/SyncEngine.ts
@@ -82,6 +82,7 @@ import {
   type LocalFilesPort,
   type MaterializationCheckPort,
   type MergeLayerPort,
+  type MountBaseStorePort,
   type QuarantineEntry,
   type QuarantinePort,
   type RepoSyncResult,
@@ -103,6 +104,17 @@ export interface SyncEngineDeps {
   materializationCheck: MaterializationCheckPort;
   /** Working-tree access for one repo of the materialized set. */
   localFilesFor: (spec: SyncRepoSpec) => LocalFilesPort;
+  /**
+   * Per-device record of the commit SHA each repo was MOUNTED at (#3590).
+   * Absent ⇒ no first-sync merge base is available, so a no-watermark
+   * divergence stays the conservative `full-conflict` (status quo, zero
+   * regression). When present, asset-mode first-sync uses the recorded SHA's
+   * tree as the true 3-way merge base — a remote that advanced on disjoint
+   * files since the mount cleanly merges instead of false-conflicting, while a
+   * real overlapping edit still routes through the merge/quarantine layer
+   * (M1 zero-loss intact). See {@link MountBaseStorePort}.
+   */
+  mountBaseStore?: MountBaseStorePort;
   sha1: Sha1Fn;
   baseURL?: string;
   /** Cap on 422 re-pull→retry cycles (D16). Default {@link DEFAULT_MAX_PUSH_RETRIES}. */
@@ -2116,6 +2128,113 @@ export class SyncEngine {
   }
 
   /**
+   * #3590 — build a first-sync 3-way base from the recorded MOUNT commit when
+   * the remote has advanced since the AssetSpace was mounted. Returns:
+   *  - `null` — no mount base recorded, the remote has NOT advanced
+   *    (mount === head; the cheaper R⊆L path handles it), the recorded SHA is
+   *    unresolvable (GC'd / rewritten), or it is NOT a genuine ancestor of the
+   *    current head. In every `null` case the caller falls back to the
+   *    conservative R⊆L bootstrap (full-conflict on a real divergence) — never
+   *    a guessed base, never a silent overwrite.
+   *  - `{ kind: "additive-base", base }` — the mount commit's tree, validated
+   *    as an ancestor of head. The normal cycle reconciles remote changes
+   *    (mount..head) against local changes (disk vs mount) through the SAME
+   *    3-way machinery the post-watermark path uses: disjoint → clean merge,
+   *    overlap → conflict/quarantine (M1 zero-loss intact).
+   *
+   * Ancestry is verified by walking head's first-parent chain (bounded) until
+   * the recorded SHA is found — a stale/foreign SHA whose tree happened to
+   * differ would otherwise mis-classify a remote change as a local edit and
+   * push a stale blob over a newer remote version.
+   */
+  private async tryMountBaseBootstrap(
+    spec: SyncRepoSpec,
+    head: string,
+    warnings: string[],
+  ): Promise<FirstSyncBootstrap | null> {
+    const store = this.deps.mountBaseStore;
+    if (store === undefined) return null;
+
+    let mountSha: string | null;
+    try {
+      mountSha = await store.get(spec.repoKey);
+    } catch {
+      return null; // store read failure → conservative fallback
+    }
+    // No record, or the remote has not advanced since the mount (the cheaper
+    // R⊆L clean-mount / additive path below handles head === mount exactly).
+    if (mountSha === null || mountSha === head) return null;
+
+    // Verify the recorded SHA is a GENUINE ancestor of the current head by
+    // walking the first-parent chain. The walk doubles as the fetch of the
+    // base commit (its treeSha) — no extra round-trip. Any transport failure
+    // (unresolvable SHA, truncated/GC'd history) → conservative fallback.
+    const MAX_ANCESTRY_WALK = 300;
+    let baseCommit: Awaited<ReturnType<typeof getCommitInfo>> | null = null;
+    try {
+      let cur = head;
+      for (let i = 0; i < MAX_ANCESTRY_WALK; i++) {
+        const info = await getCommitInfo(
+          this.transport,
+          spec.owner,
+          spec.repo,
+          cur,
+          this.deps.baseURL,
+        );
+        // `info.sha` is the canonical (full) SHA; the recorded mount SHA may be
+        // an abbreviated tarball-wrapper SHA (anonymous fetches) — match by
+        // prefix so both forms resolve to the same commit.
+        if (info.sha === mountSha || info.sha.startsWith(mountSha)) {
+          baseCommit = info;
+          break;
+        }
+        if (info.parents.length === 0) break; // root reached, not an ancestor
+        cur = info.parents[0];
+      }
+    } catch {
+      return null;
+    }
+    if (baseCommit === null) return null; // not an ancestor within the bound
+
+    // Fetch the base commit's tree → the 3-way merge base snapshot. A truncated
+    // tree throws (LOUD) → conservative fallback rather than a wrong diff.
+    let baseTree: RemoteTreeEntry[];
+    try {
+      baseTree = (
+        await getTree(
+          this.transport,
+          spec.owner,
+          spec.repo,
+          baseCommit.treeSha,
+          this.deps.baseURL,
+        )
+      ).filter((e) => isSyncablePath(e.path));
+    } catch {
+      return null;
+    }
+
+    // uid is intentionally omitted from the base snapshot here: it is only used
+    // for rename matching on the base side, and deriving it would require
+    // fetching every base blob. Both the local diff (disk uids) and the remote
+    // diff (head-blob uids) still carry uids, so uid-based conflict detection
+    // is unaffected — a base-side rename merely degrades to delete+add, never a
+    // data-loss path.
+    const files: WatermarkFileEntry[] = baseTree.map((e) => ({
+      path: e.path,
+      blobSha: e.blobSha,
+    }));
+    const base: WatermarkRecord = {
+      lastSyncedSha: baseCommit.sha,
+      rootTreeSha: baseCommit.treeSha,
+      files,
+    };
+    warnings.push(
+      `first-sync (asset mode): reconciling against the recorded mount base ${baseCommit.sha} — remote head ${head} advanced since mount; local edits 3-way merge against it instead of false-conflicting (#3590)`,
+    );
+    return { kind: "additive-base", base };
+  }
+
+  /**
    * Asset-mode first-sync probe (no watermark). Classifies the local working
    * tree against the remote head into one of three outcomes (see
    * {@link FirstSyncBootstrap}):
@@ -2151,6 +2270,19 @@ export class SyncEngine {
       spec.branch,
       this.deps.baseURL,
     );
+
+    // #3590 — true merge-base first-sync. If the mount layer recorded the
+    // commit this AssetSpace was mounted at, and the remote has ADVANCED since
+    // (head ≠ mount, mount is a genuine ancestor of head), use the mount
+    // commit's tree as the 3-way base. The normal cycle then reconciles remote
+    // changes (pull) against local changes (push): a divergence on DISJOINT
+    // paths cleanly merges instead of false full-conflict, while a real
+    // overlapping edit still routes through the merge/quarantine layer (M1
+    // zero-loss). Absent / stale / unresolvable / not-an-ancestor → null → the
+    // conservative R⊆L path below (full-conflict on overlap) is unchanged.
+    const mountBootstrap = await this.tryMountBaseBootstrap(spec, head, warnings);
+    if (mountBootstrap !== null) return mountBootstrap;
+
     const headCommit = await getCommitInfo(
       this.transport,
       spec.owner,

--- a/packages/exocortex/src/services/sync/SyncEngine.ts
+++ b/packages/exocortex/src/services/sync/SyncEngine.ts
@@ -2162,8 +2162,15 @@ export class SyncEngine {
       return null; // store read failure → conservative fallback
     }
     // No record, or the remote has not advanced since the mount (the cheaper
-    // R⊆L clean-mount / additive path below handles head === mount exactly).
-    if (mountSha === null || mountSha === head) return null;
+    // R⊆L clean-mount / additive path below handles head == mount exactly).
+    // `head.startsWith(mountSha)` (not `===`) so an ABBREVIATED mount SHA
+    // (anonymous tarballs carry a 7-char wrapper SHA — extractShaFromWrapper)
+    // still recognises the no-advance case and takes the cheap path instead of
+    // a needless reconcile round-trip + a misleading "advanced" warning. A
+    // false positive (a 7-char prefix collision between head and an older
+    // ancestor) is merely conservative — it routes to the R⊆L full-conflict
+    // path, never a silent overwrite.
+    if (mountSha === null || head.startsWith(mountSha)) return null;
 
     // Verify the recorded SHA is a GENUINE ancestor of the current head by
     // walking the first-parent chain. The walk doubles as the fetch of the

--- a/packages/exocortex/src/services/sync/syncTypes.ts
+++ b/packages/exocortex/src/services/sync/syncTypes.ts
@@ -109,6 +109,34 @@ export interface WatermarkStorePort {
 }
 
 /**
+ * Per-device, per-repo record of the commit SHA the AssetSpace was MOUNTED at
+ * (#3590). The mount/apply layer extracts this SHA correct-by-construction from
+ * the GitHub tarball wrapper dir (`<owner>-<repo>-<sha>/`) and records it the
+ * instant the working tree is materialized — BEFORE the user makes any local
+ * edits and BEFORE the remote head can advance.
+ *
+ * It is the true 3-way **merge base** for the FIRST sync (no watermark yet): the
+ * common ancestor of the local working tree and the remote head. Without it, a
+ * first-sync where the remote has advanced on DISJOINT files since the mount
+ * could only be classified as a `full-conflict` (the engine cannot tell a clean
+ * remote-only change from an overlapping edit), blocking onboarding (#3590).
+ *
+ * Lives in the SAME non-synced device-local store as the watermark
+ * (`.local.`-infix, Sync-excluded) — the merge base is device-specific. Like
+ * the watermark, it is never trusted blindly: the engine verifies the recorded
+ * SHA is a genuine ancestor of the current remote head before using its tree as
+ * the base, and falls back to the conservative `full-conflict` if it is absent,
+ * unresolvable (GC'd / rewritten), or not an ancestor — never a silent
+ * overwrite (M1 zero-loss).
+ */
+export interface MountBaseStorePort {
+  /** The commit SHA the repo was mounted at, or `null` if none recorded. */
+  get(repoKey: string): Promise<string | null>;
+  /** Record the mounted commit SHA (called by the apply/mount layer). */
+  set(repoKey: string, sha: string): Promise<void>;
+}
+
+/**
  * Local working-tree access for ONE repo, repo-relative forward-slash paths.
  * String content only — binary attachments are out of A1 scope (Phase C,
  * D4/VL#3); the engine additionally applies {@link isSyncablePath} so adapters

--- a/packages/exocortex/tests/unit/services/sync/FileMountBaseStore.test.ts
+++ b/packages/exocortex/tests/unit/services/sync/FileMountBaseStore.test.ts
@@ -1,0 +1,87 @@
+/** ExoSync #3590 — durable per-device mount-base store (first-sync merge base). */
+
+import {
+  FileMountBaseStore,
+  MOUNT_BASE_STORE_FILENAME,
+  isSyncablePath,
+  type WatermarkFileIO,
+} from "../../../../src";
+
+class FakeIO implements WatermarkFileIO {
+  content: string | null = null;
+  writes = 0;
+  failNextWrite = false;
+  async read(): Promise<string | null> {
+    return this.content;
+  }
+  async writeAtomic(content: string): Promise<void> {
+    if (this.failNextWrite) {
+      this.failNextWrite = false;
+      throw new Error("disk full");
+    }
+    this.writes++;
+    this.content = content;
+  }
+}
+
+describe("FileMountBaseStore", () => {
+  it("round-trips a mounted SHA per repoKey through one JSON file", async () => {
+    const io = new FakeIO();
+    const store = new FileMountBaseStore(io);
+
+    await store.set("o/r1#main", "sha-aaa");
+    await store.set("o/r2#main", "sha-bbb");
+
+    expect(await store.get("o/r1#main")).toBe("sha-aaa");
+    expect(await store.get("o/r2#main")).toBe("sha-bbb");
+    expect(await store.get("o/unknown#main")).toBeNull();
+    expect(JSON.parse(io.content ?? "")).toMatchObject({ version: 1 });
+  });
+
+  it("missing file → null for every repo (conservative first-sync, never a guess)", async () => {
+    const store = new FileMountBaseStore(new FakeIO());
+    expect(await store.get("o/r#main")).toBeNull();
+  });
+
+  it("corrupt JSON → null, never throws (R10 — full-conflict fallback, not overwrite)", async () => {
+    const io = new FakeIO();
+    io.content = "{ not json !!!";
+    const store = new FileMountBaseStore(io);
+    expect(await store.get("o/r#main")).toBeNull();
+  });
+
+  it("a later set overwrites the recorded SHA for the same repoKey", async () => {
+    const io = new FakeIO();
+    const store = new FileMountBaseStore(io);
+    await store.set("o/r#main", "old");
+    await store.set("o/r#main", "new");
+    expect(await store.get("o/r#main")).toBe("new");
+  });
+
+  it("ignores non-string / empty values in a hand-edited store (tolerant read)", async () => {
+    const io = new FakeIO();
+    io.content = JSON.stringify({
+      version: 1,
+      repos: { "o/good#main": "sha-ok", "o/bad#main": 42, "o/empty#main": "" },
+    });
+    const store = new FileMountBaseStore(io);
+    expect(await store.get("o/good#main")).toBe("sha-ok");
+    expect(await store.get("o/bad#main")).toBeNull();
+    expect(await store.get("o/empty#main")).toBeNull();
+  });
+
+  it("a failed write propagates to THIS caller but the chain survives for the NEXT set", async () => {
+    const io = new FakeIO();
+    const store = new FileMountBaseStore(io);
+    io.failNextWrite = true;
+    await expect(store.set("o/r#main", "s1")).rejects.toThrow(/disk full/);
+    // The store recovers — a subsequent set succeeds and persists.
+    await store.set("o/r#main", "s2");
+    expect(await store.get("o/r#main")).toBe("s2");
+  });
+
+  it("the store filename is Sync-excluded (`.local.` infix, refused by isSyncablePath)", () => {
+    expect(MOUNT_BASE_STORE_FILENAME).toContain(".local.");
+    expect(isSyncablePath(MOUNT_BASE_STORE_FILENAME)).toBe(false);
+  });
+});

--- a/packages/exocortex/tests/unit/services/sync/SyncEngine.test.ts
+++ b/packages/exocortex/tests/unit/services/sync/SyncEngine.test.ts
@@ -327,6 +327,31 @@ describe("SyncEngine — first-sync cleanly-mergeable divergence (#3590)", () =>
     expect(result.pushedCount).toBe(1); // the local-only add
     expect(gh.headFiles().get(FILE_B)).toBe(mdAsset("u2"));
   });
+
+  it("recognises a no-advance via an ABBREVIATED mount SHA (anonymous tarball) — cheap path, no false 'advanced' warning", async () => {
+    // Anonymous GitHub tarballs carry a 7-char wrapper SHA; head is the full
+    // 40-char SHA. The no-advance check must prefix-match, else the common
+    // anonymous case takes a needless reconcile round-trip + a misleading log.
+    const gh = new FakeGitHubRepo({ [FILE_A]: mdAsset("u1") });
+    const abbreviatedMountSha = gh.headSha().slice(0, 7);
+    const local = new FakeLocalFiles({
+      [FILE_A]: mdAsset("u1"),
+      [FILE_B]: mdAsset("u2"),
+    });
+    const { engine } = makeEngine(gh, local, {
+      mountBaseStore: new FakeMountBaseStore({
+        [gh.spec().repoKey]: abbreviatedMountSha,
+      }),
+    });
+
+    const result = await engine.sync(gh.spec());
+
+    expect(result.status).toBe("synced");
+    expect(result.pushedCount).toBe(1);
+    // Took the cheap #3565 additive path, NOT the mount-base reconcile.
+    expect(result.warnings.join(" ")).not.toMatch(/advanced since mount/);
+    expect(result.warnings.join(" ")).toMatch(/pure superset/);
+  });
 });
 
 describe("SyncEngine — push-only happy path (VL#7, D3)", () => {

--- a/packages/exocortex/tests/unit/services/sync/SyncEngine.test.ts
+++ b/packages/exocortex/tests/unit/services/sync/SyncEngine.test.ts
@@ -26,6 +26,7 @@ import {
 import {
   FakeGitHubRepo,
   FakeLocalFiles,
+  FakeMountBaseStore,
   FakeWatermarkStore,
   alwaysMaterialized,
   neverMaterialized,
@@ -199,6 +200,132 @@ describe("SyncEngine — first-sync additive divergence (#3565)", () => {
     expect(result.status).toBe("full-conflict");
     expect(gh.headFiles().get(FILE_A)).toBe(mdAsset("u1", "remote")); // untouched
     expect(gh.headFiles().has(FILE_B)).toBe(false); // add NOT pushed amid overlap
+  });
+});
+
+// #3590 — first-sync false full-conflict on a cleanly-mergeable divergence.
+// Sibling of #3565: that fix covered local ⊇ remote (pure additive). This one
+// covers the COMPLEMENTARY case — the remote has ADVANCED on disjoint files
+// since the device mounted the AssetSpace, while the user made local edits.
+// Pre-fix the engine had no merge base, so any remote-head file differing from
+// disk forced `full-conflict` (blocking onboarding). The mount layer now
+// records the mounted commit SHA (the true 3-way merge base); the engine uses
+// its tree as the base and the existing 3-way machinery cleanly merges a
+// disjoint divergence while still routing a real overlap to conflict (M1).
+const CONFIG = "config/x.md";
+const FILE_C = "assets/c.md";
+
+describe("SyncEngine — first-sync cleanly-mergeable divergence (#3590)", () => {
+  it("clean 3-way merges when the remote advanced on DISJOINT files since the mount", async () => {
+    // Mount base: FILE_A + CONFIG + FILE_C, all byte-identical to remote.
+    const gh = new FakeGitHubRepo({
+      [FILE_A]: mdAsset("u1", "orig-a"),
+      [CONFIG]: mdAsset("u9", "orig-x"),
+      [FILE_C]: mdAsset("u3", "orig-c"),
+    });
+    const mountSha = gh.headSha(); // recorded at mount, BEFORE any divergence
+
+    // Device B advances the remote, touching ONLY CONFIG (disjoint from the
+    // local edits below) — exactly the empirical #3590 shape.
+    gh.commitDirect(gh.branch, { [CONFIG]: mdAsset("u9", "remote-x") }, "remote ahead (disjoint)");
+
+    // Local working tree: edits FILE_A, adds FILE_B, deletes FILE_C, and still
+    // holds the OLD (un-pulled) CONFIG. None of these overlap the remote change.
+    const local = new FakeLocalFiles({
+      [FILE_A]: mdAsset("u1", "local-a"), // local edit
+      [CONFIG]: mdAsset("u9", "orig-x"), // un-pulled mount version
+      [FILE_B]: mdAsset("u2"), // local-only add
+      // FILE_C absent → local delete
+    });
+    const { engine, watermarks } = makeEngine(gh, local, {
+      mountBaseStore: new FakeMountBaseStore({ [gh.spec().repoKey]: mountSha }),
+    });
+
+    const result = await engine.sync(gh.spec());
+
+    // Clean merge, NOT a false full-conflict.
+    expect(result.status).toBe("synced");
+    // Remote-only change pulled to disk.
+    expect(result.pulledCount).toBe(1);
+    expect(local.files.get(CONFIG)).toBe(mdAsset("u9", "remote-x"));
+    // Local edit + add pushed; remote change NOT overwritten with the stale copy.
+    expect(result.pushedCount).toBe(2);
+    expect(gh.headFiles().get(FILE_A)).toBe(mdAsset("u1", "local-a"));
+    expect(gh.headFiles().get(FILE_B)).toBe(mdAsset("u2"));
+    expect(gh.headFiles().get(CONFIG)).toBe(mdAsset("u9", "remote-x"));
+    // Local delete propagated.
+    expect(gh.headFiles().has(FILE_C)).toBe(false);
+    expect(result.pushedDeletes ?? []).toContain(FILE_C);
+
+    // A real watermark is established → re-sync no-ops (no deadlock).
+    expect(watermarks.records.size).toBe(1);
+    const again = await engine.sync(gh.spec());
+    expect(again.status).toBe("synced");
+    expect(again.pushedCount).toBe(0);
+    expect(again.pulledCount).toBe(0);
+  });
+
+  it("M1 HARD FLOOR: a REAL overlapping edit still conflicts, never silently overwrites", async () => {
+    // Both sides edit CONFIG since the mount base → genuine overlap. With no A2
+    // merge layer wired the engine MUST refuse (conflict), touching neither the
+    // remote nor disk — zero silent data loss.
+    const gh = new FakeGitHubRepo({ [CONFIG]: mdAsset("u9", "orig-x") });
+    const mountSha = gh.headSha();
+    gh.commitDirect(gh.branch, { [CONFIG]: mdAsset("u9", "remote-x") }, "remote edits CONFIG");
+    const local = new FakeLocalFiles({ [CONFIG]: mdAsset("u9", "local-x") }); // local ALSO edited CONFIG
+    const { engine, watermarks } = makeEngine(gh, local, {
+      mountBaseStore: new FakeMountBaseStore({ [gh.spec().repoKey]: mountSha }),
+    });
+
+    const result = await engine.sync(gh.spec());
+
+    expect(result.status).not.toBe("synced");
+    expect(gh.headFiles().get(CONFIG)).toBe(mdAsset("u9", "remote-x")); // remote untouched
+    expect(local.files.get(CONFIG)).toBe(mdAsset("u9", "local-x")); // disk untouched
+    expect(watermarks.records.size).toBe(0); // no watermark advanced on conflict
+  });
+
+  it("falls back to full-conflict when the recorded mount SHA is not a remote ancestor (unresolvable)", async () => {
+    // A stale/foreign/GC'd mount SHA must NOT be trusted as a base — the engine
+    // falls back to the conservative full-conflict (status quo), never a guess.
+    const gh = new FakeGitHubRepo({ [FILE_A]: mdAsset("u1", "orig-a") });
+    gh.commitDirect(gh.branch, { [CONFIG]: mdAsset("u9", "remote-x") }, "remote ahead");
+    const local = new FakeLocalFiles({
+      [FILE_A]: mdAsset("u1", "local-a"),
+      [CONFIG]: mdAsset("u9", "orig-x"),
+    });
+    const { engine, watermarks } = makeEngine(gh, local, {
+      mountBaseStore: new FakeMountBaseStore({
+        [gh.spec().repoKey]: "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+      }),
+    });
+
+    const result = await engine.sync(gh.spec());
+
+    expect(result.status).toBe("full-conflict");
+    expect(result.detail).toMatch(/first-sync/);
+    expect(gh.headFiles().get(FILE_A)).toBe(mdAsset("u1", "orig-a")); // untouched
+    expect(watermarks.records.size).toBe(0);
+  });
+
+  it("keeps the #3565 additive fast path when the remote has NOT advanced (mount SHA == head)", async () => {
+    // mountSha == head → no remote divergence to reconcile; the recorded base
+    // must not perturb the pure-superset additive push (#3565 regression).
+    const gh = new FakeGitHubRepo({ [FILE_A]: mdAsset("u1") });
+    const mountSha = gh.headSha();
+    const local = new FakeLocalFiles({
+      [FILE_A]: mdAsset("u1"),
+      [FILE_B]: mdAsset("u2"),
+    });
+    const { engine } = makeEngine(gh, local, {
+      mountBaseStore: new FakeMountBaseStore({ [gh.spec().repoKey]: mountSha }),
+    });
+
+    const result = await engine.sync(gh.spec());
+
+    expect(result.status).toBe("synced");
+    expect(result.pushedCount).toBe(1); // the local-only add
+    expect(gh.headFiles().get(FILE_B)).toBe(mdAsset("u2"));
   });
 });
 

--- a/packages/exocortex/tests/unit/services/sync/fakeGitHub.ts
+++ b/packages/exocortex/tests/unit/services/sync/fakeGitHub.ts
@@ -20,6 +20,7 @@ import type {
 import type {
   LocalFilesPort,
   MaterializationCheckPort,
+  MountBaseStorePort,
   SyncRepoSpec,
   WatermarkRecord,
   WatermarkStorePort,
@@ -400,6 +401,20 @@ export class FakeWatermarkStore implements WatermarkStorePort {
   }
   async set(repoKey: string, record: WatermarkRecord): Promise<void> {
     this.records.set(repoKey, record);
+  }
+}
+
+/** In-memory MountBaseStorePort (#3590) — records the mounted commit SHA. */
+export class FakeMountBaseStore implements MountBaseStorePort {
+  readonly shas = new Map<string, string>();
+  constructor(initial: Record<string, string> = {}) {
+    for (const [k, v] of Object.entries(initial)) this.shas.set(k, v);
+  }
+  async get(repoKey: string): Promise<string | null> {
+    return this.shas.get(repoKey) ?? null;
+  }
+  async set(repoKey: string, sha: string): Promise<void> {
+    this.shas.set(repoKey, sha);
   }
 }
 

--- a/packages/obsidian-plugin/src/infrastructure/adapters/ApplyDepsFactory.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/ApplyDepsFactory.ts
@@ -1,5 +1,10 @@
 import type { App } from "obsidian";
-import type { INotificationService } from "exocortex";
+import {
+  FileMountBaseStore,
+  MOUNT_BASE_STORE_FILENAME,
+  type INotificationService,
+} from "exocortex";
+import { vaultWatermarkFileIO } from "./SyncDepsFactory";
 
 import type { ILogger } from "../../adapters/logging/ILogger";
 
@@ -94,7 +99,14 @@ export async function buildRestAssetSpaceMount(opts: {
   const secretsStore = new LocalSecretsStore({ app });
   const pat = await secretsStore.getSecret("pat");
   const client = new GitHubRestClient({ app, pat: pat ?? "" });
-  return new RestAssetSpaceMount({ app, client });
+  // #3590 — the mount records the first-sync 3-way merge base into the same
+  // device-local file (`exosync-mountbase.local.json`) the sync engine reads
+  // (built identically in `SyncDepsFactory`).
+  const mountBasePath = `${app.vault.configDir}/plugins/exocortex/${MOUNT_BASE_STORE_FILENAME}`;
+  const mountBaseStore = new FileMountBaseStore(
+    vaultWatermarkFileIO(app.vault.adapter, mountBasePath),
+  );
+  return new RestAssetSpaceMount({ app, client, mountBaseStore });
 }
 
 /**

--- a/packages/obsidian-plugin/src/infrastructure/adapters/RestAssetSpaceMount.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/RestAssetSpaceMount.ts
@@ -10,8 +10,10 @@ import {
   mountAssetSpaceFiles,
   appendGitmodulesEntry,
   stripGitmodulesEntry,
+  SYNC_BRANCH,
   type FileSystemPort,
   type AssetSpaceHttpClient,
+  type MountBaseStorePort,
   type MountFile,
   type MountResult,
 } from "exocortex";
@@ -54,6 +56,13 @@ import {
 export interface RestAssetSpaceMountOptions {
   app: App;
   client: GitHubRestClient;
+  /**
+   * #3590 — records the mounted commit SHA (the first-sync 3-way merge base)
+   * keyed by `repoKey`, the instant the working tree is materialized. Optional:
+   * absent ⇒ no base recorded ⇒ first-sync of a diverged repo stays the
+   * conservative full-conflict (zero regression). See {@link MountBaseStorePort}.
+   */
+  mountBaseStore?: MountBaseStorePort;
 }
 
 /** Outcome of a successful {@link RestAssetSpaceMount.mount}. */
@@ -64,6 +73,7 @@ const GITMODULES = ".gitmodules";
 export class RestAssetSpaceMount {
   private readonly app: App;
   private readonly client: GitHubRestClient;
+  private readonly mountBaseStore?: MountBaseStorePort;
 
   constructor(opts: RestAssetSpaceMountOptions) {
     if (!opts || !opts.app) {
@@ -74,6 +84,7 @@ export class RestAssetSpaceMount {
     }
     this.app = opts.app;
     this.client = opts.client;
+    this.mountBaseStore = opts.mountBaseStore;
   }
 
   private get adapter(): DataAdapter {
@@ -112,6 +123,21 @@ export class RestAssetSpaceMount {
       ref,
       targetPath: safePath,
     });
+
+    // #3590 — record the mounted commit SHA (correct-by-construction from the
+    // tarball wrapper) as the first-sync 3-way merge base, keyed by the SAME
+    // `repoKey` the sync engine reads (`<owner>/<repo>#<SYNC_BRANCH>`). Recorded
+    // NOW, before the user can edit or the remote can advance, so the very
+    // first ExoSync reconciles against a real base instead of false-conflicting.
+    // Best-effort: a store write failure must NOT fail the mount (the worst
+    // case is the conservative full-conflict on first sync, never data loss).
+    if (this.mountBaseStore !== undefined) {
+      try {
+        await this.mountBaseStore.set(`${owner}/${repo}#${SYNC_BRANCH}`, result.sha);
+      } catch {
+        /* non-fatal — first-sync falls back to full-conflict, never a loss */
+      }
+    }
 
     // Record the AssetSpace in `.gitmodules` (path + source URL). This is NOT a
     // git submodule registration — a git-free REST mount creates no gitlink

--- a/packages/obsidian-plugin/src/infrastructure/adapters/SyncDepsFactory.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/SyncDepsFactory.ts
@@ -1,8 +1,10 @@
 import type { App, DataAdapter } from "obsidian";
 import yaml from "js-yaml";
 import {
+  FileMountBaseStore,
   FileWatermarkStore,
   GatedStructuredMerger,
+  MOUNT_BASE_STORE_FILENAME,
   SYNC_BRANCH,
   SpaceSpecAccumulator,
   StructuredMerger,
@@ -398,6 +400,10 @@ export async function buildSyncEngine(
   const adapter = app.vault.adapter;
   const configDir = app.vault.configDir;
   const watermarkPath = `${configDir}/plugins/exocortex/${WATERMARK_STORE_FILENAME}`;
+  // #3590 — first-sync merge base, recorded at apply/mount time by
+  // `RestAssetSpaceMount` under the SAME path convention (same vault.adapter,
+  // same `.local.`-infix file).
+  const mountBasePath = `${configDir}/plugins/exocortex/${MOUNT_BASE_STORE_FILENAME}`;
 
   let quarantine: QuarantinePort | undefined;
   const quarantineUrl = opts.quarantineRepoUrl?.trim() ?? "";
@@ -420,6 +426,9 @@ export async function buildSyncEngine(
     transport,
     watermarkStore: new FileWatermarkStore(
       vaultWatermarkFileIO(adapter, watermarkPath),
+    ),
+    mountBaseStore: new FileMountBaseStore(
+      vaultWatermarkFileIO(adapter, mountBasePath),
     ),
     materializationCheck: vaultMaterializationCheck({
       adapter,

--- a/packages/obsidian-plugin/tests/unit/infrastructure/adapters/RestAssetSpaceMount.test.ts
+++ b/packages/obsidian-plugin/tests/unit/infrastructure/adapters/RestAssetSpaceMount.test.ts
@@ -198,6 +198,54 @@ describe("RestAssetSpaceMount.mount", () => {
     );
   });
 
+  it("#3590 — records the mounted commit SHA as the first-sync merge base keyed by repoKey", async () => {
+    const adapter = new InMemoryAdapter();
+    const tarball = await makeTarball("kitelev-exoas-ems-abc1234", [
+      { name: "README.md", data: new TextEncoder().encode("x") },
+    ]);
+    const recorded = new Map<string, string>();
+    const mountBaseStore = {
+      get: async (k: string) => recorded.get(k) ?? null,
+      set: async (k: string, sha: string) => {
+        recorded.set(k, sha);
+      },
+    };
+    const mount = new RestAssetSpaceMount({
+      app: makeApp(adapter),
+      client: makeFakeClient(tarball) as unknown as GitHubRestClient,
+      mountBaseStore,
+    });
+
+    await mount.mount(URL_OK, PATH_OK, "main");
+
+    // repoKey == `<owner>/<repo>#<SYNC_BRANCH>` — what the sync engine reads.
+    expect(recorded.get("kitelev/exoas-ems#main")).toBe("abc1234");
+  });
+
+  it("#3590 — a mount-base store write failure does NOT fail the mount (best-effort)", async () => {
+    const adapter = new InMemoryAdapter();
+    const tarball = await makeTarball("kitelev-exoas-ems-abc1234", [
+      { name: "README.md", data: new TextEncoder().encode("x") },
+    ]);
+    const mountBaseStore = {
+      get: async () => null,
+      set: async () => {
+        throw new Error("device-local store unwritable");
+      },
+    };
+    const mount = new RestAssetSpaceMount({
+      app: makeApp(adapter),
+      client: makeFakeClient(tarball) as unknown as GitHubRestClient,
+      mountBaseStore,
+    });
+
+    const result = await mount.mount(URL_OK, PATH_OK, "main");
+
+    // Mount succeeds despite the store failure — files materialised, no throw.
+    expect(result.sha).toBe("abc1234");
+    expect(adapter.files.has(`${PATH_OK}/README.md`)).toBe(true);
+  });
+
   it("does NOT materialise files when the writeBinary loop is skipped (revert-verify control)", async () => {
     // Control proving the happy-path assertions above are load-bearing:
     // an empty tarball produces zero files and throws before .gitmodules.


### PR DESCRIPTION
## Problem (#3590)

ExoSync **first-sync** (no watermark for a repo on this device) reported `full-conflict` on **any** `local ≠ remote` divergence — even a **cleanly-mergeable** one (local + remote touch DISJOINT files) — because the engine had no merge base and could not tell a clean remote-only change from an overlapping edit. This **blocked first-sync on a new device** for any user with local edits (the normal onboarding case).

Empirical: `vault-2025/assetspaces/kitelev/exoas-shared-private`, 2026-06-17 — local edited `concepts/X` + added 5 files + deleted one; remote was 3 commits ahead touching only `.github/workflows/ci.yml` + `kitelev-period/weeks/…` (disjoint). `git pull --rebase` integrated cleanly, yet ExoSync reported `full-conflict`.

## Root cause

The mount/apply layer extracts the mounted commit SHA from the GitHub tarball wrapper (`<owner>-<repo>-<sha>/`) but **discarded** it, so first-sync had no merge base. **#3565** covered `local ⊇ remote` (pure additive); this PR is the complementary `local ≠ remote but cleanly-mergeable` path.

## Fix — record-at-mount, reuse the existing 3-way machinery

1. **New `MountBaseStorePort` + shared `FileMountBaseStore`** (mirrors `FileWatermarkStore`; device-local `exosync-mountbase.local.json`, `.local.`-infix → Sync-excluded + `isSyncablePath`-refused).
2. **Apply/mount records the mounted SHA** (correct-by-construction from `MountResult.sha`), keyed by the SAME `repoKey` the engine reads (`<owner>/<repo>#<SYNC_BRANCH>`), the instant the tree is materialized — before the user edits or the remote advances. Plugin `RestAssetSpaceMount.mount` + CLI `BootstrapAssetSpaceService.pullAssetSpace` (covers apply-profile / bootstrap / assetspace-add). **Best-effort** — a store-write failure never fails the mount.
3. **`SyncEngine.bootstrapWatermark`**: when a mount SHA is recorded and the remote has advanced (SHA ≠ head **AND** a verified first-parent **ancestor** of head), build the 3-way base from that commit's tree and run the **existing** cycle (`collectRemoteChanges` + `matchLocalVsRemote` + `detectChanges`). Disjoint → clean merge; **real overlap → conflict/quarantine (M1 zero-loss)**. Absent / stale / unresolvable / not-an-ancestor → **conservative `full-conflict` fallback (zero regression)**.
4. **Both platforms** (desktop + mobile REST-equivalent) per the Desktop↔Mobile Command Parity Invariant.

No hand-rolled merge — the safety-critical 3-way logic is reused unchanged. D22 base-mismatch validation holds for the synthetic base (`rootTreeSha` = actual tree of `lastSyncedSha`).

## Tests (empirically revert-verified — **FAILS pre-fix `full-conflict`, PASSES post-fix `synced`**)

- **clean 3-way merge** when the remote advanced on disjoint files since mount (pull remote + push local edit/add, propagate delete; remote NOT overwritten);
- **M1 HARD FLOOR**: a real overlapping same-path edit still conflicts — remote + disk untouched, watermark not advanced (passes both pre/post — regression guard);
- stale/foreign mount SHA (not an ancestor) → `full-conflict` fallback;
- #3565 additive fast path preserved when mount SHA == head (incl. abbreviated 7-char SHA);
- `FileMountBaseStore` round-trip / corruption-tolerance / Sync-exclusion;
- `RestAssetSpaceMount` records the SHA + best-effort on store failure.

## Review

`code-reviewer` agent: **APPROVE** — 0 CRITICAL/HIGH/MEDIUM, 1 LOW (abbreviated-SHA no-advance prefix-match — fixed in 2nd commit + test). M1 zero-data-loss traced sound on every path. Per repo auto-merge discipline for `packages/exocortex/src/services/sync/`: **manual `--squash` after CI green** (no `--auto`).

Closes #3590