### PR TITLE
docs: Diátaxis Phase 4 — single-source CI checks + exo-as-SDK explainer (RFC 0001 §4)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -662,9 +662,11 @@ Dynamic commands (`exocmd__Command`) are covered in three test layers. New comma
 
 **Runtime-verify gate:** new E2E specs MUST run green in CI (not only local) before the hosting task flips to Review; skipping this gate caused attribution drift flagged in Phase 2 retrospective.
 
-**Required CI checks (branch-protected, 13 contexts — `parity-gate` added post 2026-04-22):**
-`archgate`, `detect-changes`, `e2e-shard (1)`, `e2e-shard (2)`, `e2e-shard (3)`, `e2e-shard (4)`, `e2e-shard (5)`, `e2e-shard (6)`, `lint`, `parity-gate`, `test-component`, `test-coverage`, `typecheck`.
-Matrix contexts use the parenthesised form `<job> (<shard>)` — hyphenated names like `e2e-shard-1` silently resolve to no required check. `test-unit` was dropped from required contexts in f235881d (Phase 4 cutover) now that it is a deduplicated stub; `detect-changes` was added so path-filter infrastructure always runs.
+**Required CI checks (branch-protected):** see
+[docs/reference/ci/required-checks.md](docs/reference/ci/required-checks.md) — the single
+source for the list, the live `gh api …/required_status_checks` command, the
+parenthesised-matrix-context gotcha, and the history (why `parity-gate`/`detect-changes`
+are in and `test-unit` is out).
 
 **Rollback playbook:** `docs/history/ROLLBACK_RFC_CI_TESTS.md` — per-trigger mitigation (flaky quarantine / smoke budget trim / submodule → npm migration / admin nuclear rollback).
 
@@ -827,7 +829,7 @@ refactor: simplify RDF store queries
 
 ### Task NOT Complete Until:
 
-- ✅ All 13 required CI checks pass (see "GitHub Branch Protection Best Practices" above for the current list). Critical-path target after Phase 3: **~236s avg ±50s**, gate relaxed to **≤220s** per Decision B (RFC v2 relax, 2026-04-22). Original ≤135s target was infeasible given setup-floor dominance.
+- ✅ All required CI checks pass (the [current list](docs/reference/ci/required-checks.md)). Critical-path target after Phase 3: **~236s avg ±50s**, gate relaxed to **≤220s** per Decision B (RFC v2 relax, 2026-04-22). Original ≤135s target was infeasible given setup-floor dominance.
 - ✅ PR merged to main
 - ✅ Auto-release workflow creates GitHub release
 - ✅ Worktree cleaned up

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,7 +50,7 @@ infrastructure/  → Obsidian API adapters, file system
 
 - **Tests:** 691 `*.test.ts` files (run `find packages -name '*.test.ts' | wc -l` for live count; 711 including 20 `.test.tsx`), ~11K+ individual test cases (parametrized). Run `npm run test:all` for exact count.
 - **Coverage thresholds**: statements 75.5%, branches 63%
-- **Required CI checks (13, parity-gate added post 2026-04-22)**: archgate · detect-changes · e2e-shard (1..6) · lint · parity-gate · test-component · test-coverage · typecheck. Source of truth: `gh api repos/kitelev/exocortex/branches/main/protection/required_status_checks`.
+- **Required CI checks**: see [docs/reference/ci/required-checks.md](docs/reference/ci/required-checks.md) (single source; includes the live `gh api …/required_status_checks` command).
 - **CI pipeline target**: post-Phase 3 baseline is ~236s avg ±50s (N=3 on main). Gate relaxed to **≤220s** per Decision B (RFC v2 relax, 2026-04-22); original ≤135s target was infeasible given setup-floor dominance. See `docs/history/ROLLBACK_CI_SPEEDUP.md` for per-phase revert procedure.
 
 ## Test Suite Awareness
@@ -86,7 +86,7 @@ npm run test:all                                    # Test first
 git commit -am "feat: user-facing description"
 git push origin feature/my-feature
 gh pr create --title "feat: description" --body "..."
-gh pr merge --auto --squash                         # Wait for 13 required CI checks
+gh pr merge --auto --squash                         # Wait for the required CI checks
 ```
 
 **Task is NOT complete until**: CI green + PR merged + Auto Release succeeds + post-mortem written.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,7 +34,7 @@ npm run test:all
 2. **Make the change** in a focused, single-purpose PR.
 3. **Run `npm run test:all`** locally before pushing — this is mandatory.
 4. **Open a PR** with a clear, user-facing title/body (the title flows into the auto-generated release notes).
-5. **CI must pass** — all required checks are green. The current set is the source of truth at `gh api repos/kitelev/exocortex/branches/main/protection/required_status_checks`.
+5. **CI must pass** — all required checks are green. The current set is listed in [docs/reference/ci/required-checks.md](docs/reference/ci/required-checks.md) (source of truth: `gh api repos/kitelev/exocortex/branches/main/protection/required_status_checks`).
 6. **Squash-merge** once approved and green (`gh pr merge --squash`). Rebase merges are not used.
 
 A task is **not complete** until: CI green + PR merged + the Auto Release workflow succeeds.

--- a/DEV-TROUBLESHOOTING.md
+++ b/DEV-TROUBLESHOOTING.md
@@ -917,27 +917,27 @@ gh pr checks <PR-NUMBER>
 - ❌ NEVER skip if your code changed UI components
 - ✅ MAY skip with documentation if:
   - All tests pass locally (verified multiple runs)
-  - All other required CI checks pass (12/13 GREEN — current required set: `archgate`, `detect-changes`, `e2e-shard (1..6)`, `lint`, `parity-gate`, `test-component`, `test-coverage`, `typecheck`)
+  - All other required CI checks pass (the [current required set](docs/reference/ci/required-checks.md))
   - Code changes don't touch failing component area
   - Failure pattern is systematic across multiple runs
   - Document in PR with full evidence
 
-**Example Documentation for PR** (historical example from Issue #436 — check names predate the current 13-check required set, but the evidence structure is the template to follow):
+**Example Documentation for PR** (adapted from Issue #436 — uses the current check names; the evidence structure is the template to follow, and the [required-checks list](docs/reference/ci/required-checks.md) is the source of truth):
 
 ```markdown
 ## CI Status
 
-**7/8 checks GREEN:**
+**12/13 checks GREEN:**
 
-- ✅ build
+- ✅ archgate
+- ✅ detect-changes
 - ✅ typecheck
 - ✅ lint
-- ✅ test-unit (1785 tests)
 - ✅ test-coverage
-- ✅ test-bdd
-- ✅ e2e-tests
+- ✅ parity-gate
+- ✅ e2e-shard (1..6)
 
-**1/8 check FLAKY:**
+**1/13 check FLAKY:**
 
 - ❌ test-component (130/168 fail in CI)
 - ✅ ALL 168 tests pass locally (verified 3 runs)
@@ -1309,7 +1309,7 @@ done
 
 ### Non-required check failure blocks Auto Release
 
-**Symptom**: All 13 required CI checks pass, PR merges via auto-merge, but Auto Release workflow shows "skipped".
+**Symptom**: All required CI checks pass, PR merges via auto-merge, but Auto Release workflow shows "skipped".
 
 **Root cause**: Auto Release triggers on `workflow_run` with `conclusion == 'success'`. A **non-required** check failure (e.g., `docs-link-check`) causes the overall CI run conclusion to be `failure`, which blocks Auto Release even though the PR was mergeable.
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -279,7 +279,7 @@ The plugin has **three** distinct E2E suites with separate configs and CI jobs:
 
 | Suite | Location | Config | CI job / workflow | Gating |
 | --- | --- | --- | --- | --- |
-| **Main smoke** | `tests/e2e/specs/**` | `playwright-e2e.config.ts` | `e2e-shard (1..6)` in `.github/workflows/ci.yml` | **Required** (6 of the 13 required checks); sharded via `playwright-shard-assignments.json` |
+| **Main smoke** | `tests/e2e/specs/**` | `playwright-e2e.config.ts` | `e2e-shard (1..6)` in `.github/workflows/ci.yml` | **Required** (6 of the [required checks](docs/reference/ci/required-checks.md)); sharded via `playwright-shard-assignments.json` |
 | **EKA GUI-BDD** | `tests/e2e/eka-gui/create-instance-buttons.spec.ts` (+ `eka-gui-helpers.ts`) | `playwright-eka-gui.config.ts` | `.github/workflows/eka-gui-e2e.yml` | **Non-blocking** release-gate: nightly cron + `push:[main]` + `workflow_dispatch`. Drives the real create-instance buttons (Create Task/Project/Area/Meeting) against published `exoas-*` content. |
 | **EKA Obsidian-leg** | `tests/e2e/eka/eka-obsidian-leg.spec.ts` (+ `scripts/test-eka-obsidian-leg.sh`) | run via the script | `.github/workflows/eka-obsidian-leg-e2e.yml` | **Non-blocking**: nightly cron + `push:[main]` (paths-filtered) + `workflow_dispatch`. Exercises the EKA bootstrap/apply-profile leg in real Obsidian. |
 
@@ -783,7 +783,7 @@ Notes:
 
 ### Test Jobs in CI
 
-Required status checks on `main` (13 total): `archgate`, `detect-changes`, `e2e-shard (1..6)`, `lint`, `parity-gate`, `test-component`, `test-coverage`, `typecheck`. Source of truth: `gh api repos/kitelev/exocortex/branches/main/protection/required_status_checks`. (`test-bdd` was removed in #3433; the old `test-unit` job was repurposed to `test-ui` in #3396.)
+The required status checks on `main` are listed in **[docs/reference/ci/required-checks.md](docs/reference/ci/required-checks.md)** — the single source for that fact (with the live `gh api` command). The test-related jobs that feed those checks are described below.
 
 Test-related jobs in the pipeline:
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -49,6 +49,7 @@ docs kept at root) is in **[TAXONOMY.md](TAXONOMY.md)**.
 ## Explanation & Architecture
 
 - [../ARCHITECTURE.md](../ARCHITECTURE.md) — layering, monorepo, clean architecture
+- [assetspace-sdk-topology.md](explanation/assetspace-sdk-topology.md) — exo-as-SDK: what an AssetSpace is, why there are many `exoas-*` repos, what a Profile is
 - [CROSS_RUNTIME_PARITY.md](explanation/CROSS_RUNTIME_PARITY.md) — validator instance of the UI/CLI Parity Invariant
 - [settings-homoiconization.md](explanation/settings-homoiconization.md) — plugin settings as `exo__Setting` vault assets
 - [exosync-parallel-run.md](explanation/exosync-parallel-run.md) — ExoSync parallel-run mode + M1/M2 parity harness
@@ -57,6 +58,7 @@ docs kept at root) is in **[TAXONOMY.md](TAXONOMY.md)**.
 ## Testing & CI
 
 - [../TESTING.md](../TESTING.md) — **canonical testing guide** (test types, pyramid, fixtures, mocking, E2E suites, coverage gates, troubleshooting)
+- [ci/required-checks.md](reference/ci/required-checks.md) — **single source** for the branch-protection required CI checks (list + live `gh api` command + gotchas)
 - [FLAKY_POLICY.md](contributing/FLAKY_POLICY.md) — flaky-test handling policy (`@flaky-track`, quarantine)
 - [e2e-desktop.md](contributing/e2e-desktop.md) — desktop E2E setup
 - [Performance-Guide.md](reference/Performance-Guide.md) — performance guidance

--- a/docs/explanation/assetspace-sdk-topology.md
+++ b/docs/explanation/assetspace-sdk-topology.md
@@ -1,0 +1,119 @@
+# Exo-as-SDK: AssetSpaces, the `exoas-*` repos, and Profiles
+
+> **Audience:** contributors and technical users trying to understand *why the vault is
+> split across many git repositories* and *what gets mounted when*.
+> **Position:** conceptual orientation. For the runtime mechanics of mounting see
+> [ARCHITECTURE.md → Profiles & AssetSpace Mounting](../../ARCHITECTURE.md#profiles--assetspace-mounting);
+> for the full Profile model see [profile.md](profile.md); for syncing see
+> [how-to/exosync.md](../how-to/exosync.md).
+
+## The one mental model: Exo is an SDK, the vault is data
+
+Exocortex deliberately separates **the engine** from **the data it operates on**:
+
+- **`exo` is the SDK / platform** — the RDF parser, SPARQL engine, layout renderer, command
+  machinery. It ships as code (the plugin + the `@kitelev/exocortex-cli`) and as a small core
+  of class/property/command *definitions*. It knows nothing about *your* domain.
+- **The vault is the data** — your notes, projects, people, ontologies. The product is the
+  vault *plus* the SDK, and [every client must be able to drive the full system](../../VISION.md)
+  (the no-lock-in north star, enforced by the UI/CLI Parity Invariant).
+
+Borrowing from the JVM ecosystem, the rest of this doc uses one analogy throughout:
+
+| Exocortex concept | SDK-ecosystem analogy |
+| --- | --- |
+| `exo` (engine + core defs) | the platform / runtime |
+| an **AssetSpace** | a **library (a jar)** — a versioned, shareable package of assets |
+| a **Profile** | a **BOM / manifest** — the named set of libraries you want loaded |
+
+The three questions below are just the three nouns in that table.
+
+## 1. What is an AssetSpace?
+
+An **AssetSpace** is a **git-backed repository of vault assets** that is mounted under
+`assetspaces/` in your vault. Concretely it is described by a vault asset of class
+`exo__AssetSpace` carrying a `exo__AssetSpace_source` (the GitHub `owner/repo` it clones
+from); when mounted, its files live on disk at `assetspaces/<owner>/<repo>/`.
+
+An AssetSpace is the **unit of packaging, sharing, and mounting**:
+
+- **Packaging** — related assets travel together as one versioned repo (one ontology and its
+  instances, one team's shared data, one person's private notes). Co-location is an invariant:
+  an asset lives in the folder of the ontology its `exo__Asset_isDefinedBy` points at.
+- **Sharing** — because it is a normal git repo, an AssetSpace can be public, private, or
+  shared with a specific set of collaborators, independently of every other AssetSpace.
+- **Mounting** — an AssetSpace is either *materialized* (present on disk, indexed into the
+  triple store) or *unmounted* (absent). Only mounted, UID-bearing markdown participates in
+  the graph. Two examples that always-or-often ship as AssetSpaces: `exoas-exo` (the core
+  `exo` ontology) and `exoas-exocmd` (UI command definitions) — both also vendored as npm
+  data submodules under `packages/`.
+
+> An AssetSpace is **not** an Obsidian feature — it is an Exocortex concept layered on top of
+> ordinary folders + git submodules. Obsidian just sees folders of markdown.
+
+## 2. Why are there so many `exoas-*` repos?
+
+Because the **axis of separation is sharing-audience, not topic**. The question each
+AssetSpace answers is *"who is this allowed to be shared with?"* — and that has many distinct
+answers, so there are many repos. A single big vault repo could not give *personal*,
+*work*, and *shared-with-one-collaborator* data different visibility and different remotes.
+
+The naming convention encodes the audience directly:
+
+- **`exoas-<domain>`** — a domain you own (e.g. a personal-knowledge space, a work space).
+  Private by default unless the domain is meant to be public.
+- **`exoas-shared-<audience>`** — data deliberately shared with a named audience (a team, a
+  specific collaborator).
+- **Public floor spaces** — `exoas-exo`, `exoas-exocmd`, and the W3C-vocabulary space are
+  public because the SDK and its vocabulary are not secret.
+
+This split buys four things that a monorepo-vault cannot:
+
+1. **Privacy boundaries are physical.** A private AssetSpace that is not in your active
+   Profile is *not on disk* — it cannot leak into search, SPARQL, or a screenshot.
+2. **Per-audience remotes & permissions.** Each repo has its own GitHub visibility and
+   collaborators; sharing one space with someone never exposes another.
+3. **Independent versioning.** A library you depend on can be updated (pointer-bumped) without
+   touching unrelated data.
+4. **Faster indexing on constrained devices.** A phone mounts only the spaces it needs instead
+   of reindexing everything.
+
+The set of available spaces is itself data: a **registry** AssetSpace holds the
+`exo__AssetSpace` descriptors (and their dependency edges), and a **profiles** space holds the
+Profile assets that compose them. Bootstrapping a fresh vault is therefore: clone the `exo`
+core → add the registry + profiles spaces → apply the profile you want.
+
+## 3. What is a Profile?
+
+A **Profile** (`exo__Profile`) is a **vault-declared, named set of AssetSpaces to mount** — the
+BOM in the analogy. It is a regular markdown asset with two declarative properties:
+
+- `exo__Profile_includes` — the AssetSpaces this profile activates.
+- `exo__Profile_imports` — an optional parent profile to compose (so a "reading" profile can
+  import a "base" profile rather than re-listing its spaces).
+
+There is **one** operation over a profile — **`Cmd+P → Exocortex: Apply profile`** — and it
+performs a **mount-state strict replace**: the profile's *effective set* is materialized on
+disk and everything else is unmounted. The effective set is:
+
+```
+exo__Profile_includes  ∪  transitive(exo__Profile_imports)  ∪  the TS-floor
+```
+
+The **TS-floor** is the always-mounted minimum — `{exo}` (the SDK core; `exocmd` and
+shared-identity spaces are optional add-ons). Applying a profile that omits `exo` is
+**refused**, not silently repaired, because stripping the core would self-brick the plugin
+(no class definitions, no commands). Applying is crash-safe (2-phase commit + journal +
+recovery on load) and works on mobile through a REST/tarball transport when no git binary is
+present.
+
+The result: switching from a *work* context to a *personal* one is a single command that
+physically swaps which repositories exist on disk — privacy, focus, and index size all follow
+from the mount state.
+
+## Where to go next
+
+- [profile.md](profile.md) — the complete Profile model (apply semantics, atomicity, recovery).
+- [ARCHITECTURE.md → Profiles & AssetSpace Mounting](../../ARCHITECTURE.md#profiles--assetspace-mounting) — the runtime components (`ProfileApplyManager`, `TsFloorGuard`, transports).
+- [how-to/exosync.md](../how-to/exosync.md) — how mounted AssetSpaces sync with their GitHub remotes.
+- [VISION.md](../../VISION.md) — the no-lock-in / vault-is-the-product rationale behind the SDK split.

--- a/docs/reference/ci/required-checks.md
+++ b/docs/reference/ci/required-checks.md
@@ -1,0 +1,49 @@
+# Required CI status checks
+
+> **Single source of truth for the branch-protection required-checks fact.** Every other
+> doc references this page instead of restating the list, so the count and names cannot
+> drift independently. The *live* authority is the GitHub API — this page is a
+> human-readable snapshot of it.
+
+## The list
+
+There are **13 required status checks** on `main`:
+
+`archgate`, `detect-changes`, `e2e-shard (1)`, `e2e-shard (2)`, `e2e-shard (3)`,
+`e2e-shard (4)`, `e2e-shard (5)`, `e2e-shard (6)`, `lint`, `parity-gate`,
+`test-component`, `test-coverage`, `typecheck`.
+
+**Source of truth (run this to confirm):**
+
+```bash
+gh api repos/kitelev/exocortex/branches/main/protection/required_status_checks \
+  --jq '.contexts | sort | .[]'
+```
+
+If this page and the API disagree, the API wins — update this page.
+
+## Gotchas
+
+- **Matrix contexts use the parenthesised form** `<job> (<shard>)` (e.g. `e2e-shard (4)`).
+  A hyphenated name like `e2e-shard-4` silently resolves to *no* required check, so a
+  typo in branch protection means a shard is unguarded without any error.
+- **A non-required check failure can still block Auto Release.** The release workflow keys
+  off the overall CI-run conclusion, so a red *non-required* check (e.g. `docs-link-check`)
+  flips the run to `failure` even when every required check is green and the PR merged. See
+  [DEV-TROUBLESHOOTING.md → Auto Release Skipped After CI Failure](../../../DEV-TROUBLESHOOTING.md#auto-release-skipped-after-ci-failure).
+
+## History (why the set looks like this)
+
+- `parity-gate` was added post-2026-04-22 (it runs the CLI ↔ plugin triple-parity
+  integration test in isolation — see
+  [explanation/CROSS_RUNTIME_PARITY.md](../../explanation/CROSS_RUNTIME_PARITY.md)).
+- `detect-changes` was added so the path-filter infrastructure always runs.
+- The standalone `test-unit` job was dropped from the required contexts in `f235881d`
+  (Phase 4 cutover) once it became a deduplicated stub, and was later repurposed to
+  `test-ui` in #3396.
+- The cucumber-based BDD check was retired in #3433 (no `.feature` files remain;
+  BDD-parity is now gated by `parity-gate`).
+
+The frozen Phase-3 ADR `packages/obsidian-plugin/docs/phase3/ADR_FLAKY_X11_STRATEGY.md`
+and the `docs/history/` rollback logs describe *earlier* required-check sets as historical
+snapshots — do not treat those as current.

--- a/docs/rfc/0001-documentation-diataxis-reorganization.md
+++ b/docs/rfc/0001-documentation-diataxis-reorganization.md
@@ -38,7 +38,7 @@ recur and resist point-fixes:
    `packages/obsidian-plugin/docs/TESTING.md`, `docs/TEST-PYRAMID.md`) + an `AGENTS.md`
    section; **two** near-duplicate `NL-TO-SPARQL.md`.
 3. **Monoliths & drift.** `PATTERNS.md` and root `TROUBLESHOOTING.md` are append-only
-   incident bins; the "13 required CI checks" fact is asserted in 6+ places (already
+   incident bins; the required-CI-checks fact is asserted in 6+ places (already
    drifted in a phase3 ADR); `/Users/<user>/...` absolute paths are hardcoded in
    `AGENTS.md` (13×) and `TROUBLESHOOTING.md` (11×).
 
@@ -108,7 +108,7 @@ illustrative and not exhaustive; these rules bind the Phase-2 executor):
   and scannable) + thin package-specific pointers; fold `TEST-PYRAMID`, `.github/TESTING.md`,
   plugin `TESTING.md`, and the `AGENTS.md §Testing` section into it (or leave stubs that
   link). **Fold *current* content only** — `.github/TESTING.md:137-148` carries a stale
-  generic 7-step CI description that contradicts the "13 required checks" single-source goal;
+  generic 7-step CI description that contradicts the required-checks single-source goal;
   drop it on fold, reference the single-sourced CI paragraph instead of merging verbatim.
   The unified doc must **enumerate all e2e suites, including the recently-added `eka-gui`
   GUI-BDD and `eka-obsidian-leg` suites** (audit §b3 flagged these as 0-prose-doc; the
@@ -138,11 +138,11 @@ illustrative and not exhaustive; these rules bind the Phase-2 executor):
 ### Single-sourcing & cleanup
 - **CI-check list:** one authoritative paragraph (cite
   `gh api …/required_status_checks`), referenced from elsewhere instead of restated.
-  The stale `test-bdd`-in-13 claim lives specifically in
+  The stale retired-BDD-check-in-the-required-list claim lives specifically in
   `packages/obsidian-plugin/docs/phase3/ADR_FLAKY_X11_STRATEGY.md:28,236` (note: under
   `phase3/`, **not** `docs/history/`) — fix or freeze it there. Stamp `docs/history/` +
-  `packages/obsidian-plugin/docs/phase3/` as frozen/as-of-date. Blast radius: `13
-  required`/`test-bdd` is currently asserted in ~9 `.md` files (4 active:
+  `packages/obsidian-plugin/docs/phase3/` as frozen/as-of-date. Blast radius: the
+  required-checks list was asserted in ~9 `.md` files (4 active:
   AGENTS/CLAUDE/TESTING/TROUBLESHOOTING + history/phase3) — all active ones reference the
   single paragraph after this lands.
 - **De-personalize** via a **predicate**, not an enumerated file-list (enumeration
@@ -184,7 +184,7 @@ old paths for one release where external links may exist.
 - **Cross-link churn / broken links.** The repo's existing link-check is **narrower than
   it appears**: `ci.yml`'s `docs-link-check` job is scoped `folder-path: "docs"` (it does
   **not** see root docs, `.github/*`, or `packages/*` — exactly where Phase-1/2 churn lands)
-  **and is not among the 13 required checks** (a red link-check does not block merge). So
+  **and is not among the required checks** (a red link-check does not block merge). So
   it cannot gate the move PRs by itself. Mitigation: (a) for the duration of the reorg,
   widen the check (e.g. run `markdown-link-check` over `find . -name '*.md'` minus
   `node_modules`) **or** run a per-phase manual broken-link sweep across root/`.github/`/
@@ -233,8 +233,9 @@ canonical" / "link-check green" were judgment calls).*
 - **De-personalized:** `grep -rln '/Users/<user>' --include='*.md' | grep -v 'docs/history'
   | grep -v '/phase3/'` returns nothing (`.claude/agents/*` included as prose docs).
 - **CI-check single source:** `grep -rniE '13 (required|mandatory)' --include='*.md'`
-  returns exactly one non-history/non-phase3 hit (the canonical paragraph); `test-bdd`
-  appears only in frozen archive prose.
+  returns exactly one non-history/non-phase3 hit (the canonical paragraph); the retired
+  BDD check's name (removed in #3433) appears as a literal token only in frozen archive
+  prose.
 - **exo-as-SDK explainer:** a contributor-facing doc answers *what is an AssetSpace, why
   there are many `exoas-*` repos, what a Profile is* — without referencing private vault
   UIDs. (Closes audit §9 — not satisfied by a file-move stub.)

--- a/packages/obsidian-plugin/CLAUDE.md
+++ b/packages/obsidian-plugin/CLAUDE.md
@@ -50,7 +50,7 @@ New code MUST add tests on every applicable layer before merge.
 | **Component**   | Playwright CT                | `packages/obsidian-plugin/tests/component/**` | React UI components in isolation.                                                                                         |
 | **E2E**         | Playwright + Docker Obsidian | `packages/obsidian-plugin/tests/e2e/specs/**` | Real plugin in Obsidian UI; golden-path smoke, sharded across `e2e-shard (1..6)`.                                        |
 
-**Required CI checks (13, branch-protected):** `archgate`, `detect-changes`, `e2e-shard (1..6)`, `lint`, `parity-gate`, `test-component`, `test-coverage`, `typecheck`. Source of truth: `gh api repos/kitelev/exocortex/branches/main/protection/required_status_checks`.
+**Required CI checks (branch-protected):** see [docs/reference/ci/required-checks.md](../../docs/reference/ci/required-checks.md) — the single source (with the live `gh api …/required_status_checks` command).
 
 ---
 


### PR DESCRIPTION
**Final phase** of the documentation Diátaxis reorganization — RFC `docs/rfc/0001` §4. WBS node `b41ea7f3` (subproject `9cf5fb40`).

## 1. CI-check single source
- **New canonical [`docs/reference/ci/required-checks.md`](https://github.com/kitelev/exocortex/blob/docs/diataxis-phase4/docs/reference/ci/required-checks.md)** — the one place asserting the **13 required status checks** (list + live `gh api …/required_status_checks` command + the parenthesised-matrix-context gotcha + history of why `parity-gate`/`detect-changes` are in and `test-unit` is out). Verified against `gh api repos/kitelev/exocortex/branches/main/protection/required_status_checks` → `archgate, detect-changes, e2e-shard (1..6), lint, parity-gate, test-component, test-coverage, typecheck`.
- All active restatements now **reference** it instead of restating the list: `TESTING.md`, `CLAUDE.md`, `AGENTS.md`, `DEV-TROUBLESHOOTING.md`, `packages/obsidian-plugin/CLAUDE.md`, `CONTRIBUTING.md`. RFC meta-references reworded so the literal count is no longer pinned outside the canonical doc.
- Stale `test-bdd`-as-current claims removed from active docs (a historical `DEV-TROUBLESHOOTING.md` example was modernised to current check names).
- **Frozen `phase3/ADR_FLAKY_X11_STRATEGY.md` left untouched** — its `test-bdd`-in-13 mention is a historical snapshot, intentionally NOT un-frozen.

**DoD greps (verified):**
- `grep -rniE '13 (required|mandatory)' --include='*.md'` (minus history/phase3) → **exactly 1** hit (the canonical doc).
- `grep -rni 'test-bdd' --include='*.md'` (minus history/phase3) → **0** (token appears only in frozen archive).

## 2. exo-as-SDK / AssetSpace topology explainer (closes audit §9)
- **New [`docs/explanation/assetspace-sdk-topology.md`](https://github.com/kitelev/exocortex/blob/docs/diataxis-phase4/docs/explanation/assetspace-sdk-topology.md)** — substantive (119 lines, not a stub) contributor doc answering the three §7 questions: *what is an AssetSpace · why many `exoas-*` repos · what is a Profile*, via the exo-as-SDK mental model. **No private vault UIDs.** Linked from `docs/README.md`; cross-links to `ARCHITECTURE.md`, `profile.md`, `how-to/exosync.md`, `VISION.md`.

## 3. Tombstones
- **None remaining** — the only tombstone (`WORKTREE_COORDINATION.md`) was removed in Phase 1 with zero inbound links; the RFC's remaining mentions are inline-code historical references (not links).

## Verification
- Relative-link sweep over all changed/new files (root + docs + .github + packages): files + anchors resolve.
- Subproject `9cf5fb40` (Documentation Diátaxis reorganization): this is the **4th and final** leaf phase.