### PR TITLE
feat(plugin): RFC 0002 §3.8 diagnostics — Open logs + cold-start COMMANDS skeleton

### DIFF
--- a/docs/tutorials/Getting-Started.md
+++ b/docs/tutorials/Getting-Started.md
@@ -77,12 +77,12 @@ You describe your entities (tasks, projects, areas, or any custom type) in YAML 
 3. Click Install → Enable
 4. Open the command palette (**Cmd/Ctrl + P**) and run **"BRAT: Plugins: Add a beta plugin for testing"**.
 
-   > **Note — BRAT 2.x has no "Add beta plugin" button.** In current BRAT (2.0.8+), BRAT's own settings tab does *not* have an "Add beta plugin" button at the top — adding a plugin is a **command-palette** action, not a settings-tab button. If you were looking for a button in BRAT's settings, that flow is gone.
+   > **Note — BRAT 2.x has no "Add beta plugin" button.** In current BRAT (2.0.8+), BRAT's own settings tab does _not_ have an "Add beta plugin" button at the top — adding a plugin is a **command-palette** action, not a settings-tab button. If you were looking for a button in BRAT's settings, that flow is gone.
 
 5. In the **Add beta plugin** dialog, enter `kitelev/exocortex` in the **GitHub repository** field. Either the `owner/repo` form or the full GitHub URL works. Leave **Personal Access Token** empty.
 6. **Select a release from the "Select a version…" dropdown.**
 
-   > ⚠️ **This step is required.** The dialog will not add the plugin until you *explicitly* pick a version from the dropdown — the implied "latest" is **not** applied automatically, and clicking **Add Plugin** with the dropdown untouched appears to do nothing. Choose the newest version (top of the list).
+   > ⚠️ **This step is required.** The dialog will not add the plugin until you _explicitly_ pick a version from the dropdown — the implied "latest" is **not** applied automatically, and clicking **Add Plugin** with the dropdown untouched appears to do nothing. Choose the newest version (top of the list).
 
 7. Keep **Enable after installing the plugin** checked, then click **Add Plugin**.
 8. Confirm **Exocortex** is enabled under Settings → Community plugins (enable it if it isn't already).
@@ -458,7 +458,7 @@ These are the most common problems encountered by first-time users. Start here b
 **Fix**:
 
 1. Open Settings → Community plugins and confirm Exocortex is **toggled on** (not just installed).
-2. Open `exocortex-logs.txt` in your **vault root**. This file is written by the plugin and captures startup errors. Search for lines starting with `[ERROR]` or `Failed` to see why initialization failed.
+2. Run **Cmd/Ctrl+P → "Exocortex: Open logs"** to view `exocortex-logs.txt` and its real location. The file lives in the **plugin's data folder** (`<vault>/.obsidian/plugins/exocortex/exocortex-logs.txt`), _not_ the vault root — the command shows the exact path and content so you never have to hunt for it. Search for lines starting with `[ERROR]` or `Failed` to see why initialization failed. (By default only warnings and errors are written to the file; for a live stream of everything the plugin is doing, run **"Exocortex: Open activity log"**.)
 3. Open Obsidian's developer console: **Ctrl/Cmd + Shift + I → Console**. Exocortex logs initialization there as well.
 4. If the log mentions schema or RDF errors, a bootstrapped AssetSpace file may be corrupted — re-run **Cmd/Ctrl+P → "Exocortex: Bootstrap vault"** (or **"Exocortex: Add assetspace by URL"** for a single space) to re-download the AssetSpace.
 5. As a last resort, disable the plugin, restart Obsidian, re-enable it.
@@ -496,14 +496,22 @@ These are the most common problems encountered by first-time users. Start here b
 
 ### General diagnostic: `exocortex-logs.txt`
 
-Whenever something feels wrong, the **first file to read** is `exocortex-logs.txt` in your vault root. It contains:
+Whenever something feels wrong, the **first place to look** is `exocortex-logs.txt`. The quickest way to it is **Cmd/Ctrl+P → "Exocortex: Open logs"** — that opens the file's content _and_ shows its exact path. The file is written to the **plugin's data folder**, not the vault root:
+
+```
+<vault>/.obsidian/plugins/exocortex/exocortex-logs.txt
+```
+
+(The `.obsidian` part follows your Obsidian config folder — if you customised it, the path adjusts accordingly. The file is **not** part of your notes and is **not** indexed by SPARQL.) It contains:
 
 - Plugin initialization
 - Every DynamicCommands execution (button click)
 - IRI resolution results
 - Failed grounding calls
 
-Quick grep to find failures:
+By default only **warnings and errors** are written to the file. To capture everything, enable the **Info** row under **Settings → Exocortex → Log channels**. For a live, no-setup stream of plugin activity, run **"Exocortex: Open activity log"** instead.
+
+Quick grep to find failures (run from the folder above, or pass the full path):
 
 ```
 grep -iE "Failed|Error" exocortex-logs.txt
@@ -532,7 +540,8 @@ These are design decisions or rough edges that are **expected** in the current r
 ### First-run indexing takes a moment
 
 - When you bootstrap the AssetSpaces for the first time, the plugin needs a few seconds to index 150+ ontology files.
-- If buttons or class links look stale on the first opening of a note, switch tabs or run **Reload layout** once.
+- During that window the action-buttons area shows an **"indexing… buttons will appear shortly"** placeholder instead of a blank layout; the real buttons replace it automatically once indexing finishes.
+- If buttons or class links still look stale after indexing, switch tabs or run **Reload layout** once.
 
 ---
 
@@ -588,7 +597,7 @@ For the full diagnostic walkthrough see [Troubleshooting](#troubleshooting) abov
 | ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | Layout doesn't appear     | Switch to Reading Mode (Ctrl/Cmd + E)                                                                                                                                    |
 | No action buttons visible | Verify the AssetSpaces are bootstrapped (`exocmd/` folder exists in vault); if the folder is present, fully quit and reopen Obsidian (cold restart) to force re-indexing |
-| Action buttons don't work | Read `exocortex-logs.txt` in vault root; check console (Ctrl/Cmd + Shift + I)                                                                                            |
+| Action buttons don't work | Run **Exocortex: Open logs** (file lives in the plugin data folder, not vault root); check console (Ctrl/Cmd + Shift + I)                                                |
 | Wiki-links grey           | Reload app without saving (Cmd/Ctrl + P); re-run **Exocortex: Bootstrap vault** if folders missing                                                                       |
 | Daily tasks not showing   | Check task has `ems__Effort_plannedStartTimestamp` matching daily note's `pn__DailyNote_day`                                                                             |
 | Literal `$input` written  | Update the plugin via BRAT — current versions substitute `$input`/`$value` in `property_set` groundings                                                                  |

--- a/packages/obsidian-plugin/src/ExocortexPlugin.ts
+++ b/packages/obsidian-plugin/src/ExocortexPlugin.ts
@@ -16,6 +16,7 @@ import { FileLogChannel } from "./adapters/logging/FileLogChannel";
 import { ActivityLogService } from "./adapters/logging/ActivityLogService";
 import { journalEntryToActivity } from "./adapters/logging/activityFanIn";
 import { ActivityLogModal } from "./presentation/modals/ActivityLogModal";
+import { LogFileModal } from "./presentation/modals/LogFileModal";
 import { CommandManager } from "./application/services/CommandManager";
 import { IndexingCompleteNotifier } from "./application/services/IndexingCompleteNotifier";
 import {
@@ -693,6 +694,11 @@ export default class ExocortexPlugin extends Plugin {
             this.commandResolver.invalidateCache();
             this.preconditionEvaluator.invalidateCache();
           },
+          // RFC 0002 §3.8 P13 (#3588) — cold-start COMMANDS skeleton gate.
+          // `isReady()` flips true after the first `convertVault()`; while it
+          // is false the renderer shows an "indexing…" placeholder in place of
+          // an empty COMMANDS region instead of a blank layout.
+          isStoreReady: () => this.sparql.isReady(),
         },
       );
 
@@ -3088,6 +3094,20 @@ export default class ExocortexPlugin extends Plugin {
       name: "Open activity log",
       callback: () => {
         new ActivityLogModal(this.app, this.activityLog).open();
+      },
+    });
+
+    // RFC 0002 §3.8 P12 (#3588) — «Open logs»: surfaces the persisted
+    // `exocortex-logs.txt` and its REAL location (the plugin data folder, not
+    // the vault root — reconciling the long-standing docs mismatch). Reads via
+    // the DataAdapter + renders a pure-DOM modal → registered UNCONDITIONALLY
+    // so it works identically on desktop and mobile (Desktop↔Mobile Command
+    // Parity). Distinct from «Open activity log» (live in-memory stream).
+    this.addCommand({
+      id: "open-logs",
+      name: "Open logs",
+      callback: () => {
+        new LogFileModal(this.app, this.fileLogChannel).open();
       },
     });
 

--- a/packages/obsidian-plugin/src/adapters/logging/FileLogChannel.ts
+++ b/packages/obsidian-plugin/src/adapters/logging/FileLogChannel.ts
@@ -127,4 +127,32 @@ export class FileLogChannel {
       // Best-effort — if stat/rename fails, continue with append
     }
   }
+
+  /**
+   * The (vault-relative) path of the active log file, e.g.
+   * `.obsidian/plugins/exocortex/exocortex-logs.txt`. Surfaced by the
+   * «Exocortex: Open logs» command so users know exactly where the sink
+   * lives — it is the plugin data folder, NOT the vault root (P12).
+   */
+  getLogFilePath(): string {
+    return this.logFilePath;
+  }
+
+  /**
+   * Read the current log file content for display (the «Open logs» command).
+   *
+   * Returns "" when the file does not exist yet: info-level logging is off
+   * by default (only warn/error route to the file channel), so on a healthy
+   * startup the file may be absent or hold only warn/error lines. Best-effort
+   * — any adapter error yields "". Uses the DataAdapter (vault.adapter) so it
+   * works identically on desktop and mobile (Desktop↔Mobile Command Parity).
+   */
+  async read(): Promise<string> {
+    try {
+      if (!(await this.adapter.exists(this.logFilePath))) return "";
+      return await this.adapter.read(this.logFilePath);
+    } catch {
+      return "";
+    }
+  }
 }

--- a/packages/obsidian-plugin/src/presentation/modals/LogFileModal.ts
+++ b/packages/obsidian-plugin/src/presentation/modals/LogFileModal.ts
@@ -1,0 +1,127 @@
+import { App, Modal } from "obsidian";
+
+/**
+ * Minimal contract the modal needs from the file-log sink — kept narrow so
+ * the modal is unit-testable with a tiny fake (no full FileLogChannel / Obsidian
+ * DataAdapter required). Implemented by {@link FileLogChannel}.
+ */
+export interface LogFileSource {
+  /** Vault-relative path of the active log file (the plugin data folder). */
+  getLogFilePath(): string;
+  /** Current log file content; "" when the file is absent / unreadable. */
+  read(): Promise<string>;
+}
+
+/**
+ * Hint shown when the log file is empty/absent. File logging captures only
+ * warn/error by default, so a healthy startup frequently has no file content —
+ * this is not an error. Point the user at the live in-memory activity stream.
+ */
+export const EMPTY_LOG_HINT =
+  "No file logs yet. By default only warnings and errors are written to this " +
+  "file (enable Info under Settings → Exocortex → Log channels for verbose " +
+  "logging). For the live activity stream, run «Exocortex: Open activity log».";
+
+/**
+ * LogFileModal — surfaces the persisted `exocortex-logs.txt` (GitHub #3588 P12).
+ *
+ * The «Exocortex: Open logs» command opens this. It reconciles the long-standing
+ * docs mismatch (the file was documented as living in the vault root, but the
+ * sink is the plugin data folder, `FileLogChannel`): the modal shows the REAL
+ * path at the top and the file content below, so the user never has to hunt for
+ * it. Reads via the DataAdapter and renders pure DOM (no Node/fs/git) → works
+ * identically on desktop and mobile (Desktop↔Mobile Command Parity).
+ */
+export class LogFileModal extends Modal {
+  private readonly source: LogFileSource;
+  private bodyEl: HTMLElement | null = null;
+  private loadedText = "";
+
+  constructor(app: App, source: LogFileSource) {
+    super(app);
+    this.source = source;
+  }
+
+  override onOpen(): void {
+    const { contentEl } = this;
+    contentEl.createEl("h2", { text: "Exocortex logs" });
+
+    // The real sink location — the headline fix for P12. Monospace so the
+    // path is copy-pasteable verbatim.
+    contentEl.createEl("div", {
+      cls: "exocortex-log-file-path",
+      text: this.source.getLogFilePath(),
+    });
+
+    // Scrollable monospace body — reuses the activity-log scroller styling.
+    const body = contentEl.createEl("div", {
+      cls: "exocortex-activity-log-list",
+    });
+    this.bodyEl = body;
+    body.createEl("div", {
+      cls: "exocortex-activity-log-empty",
+      text: "Loading…",
+    });
+
+    const footer = contentEl.createEl("div", {
+      cls: "modal-button-container",
+    });
+    const copyBtn = footer.createEl("button", { cls: "mod-cta", text: "Copy" });
+    copyBtn.addEventListener("click", () => {
+      void this.copyToClipboard();
+    });
+    const doneBtn = footer.createEl("button", { text: "Done" });
+    doneBtn.addEventListener("click", () => {
+      this.close();
+    });
+
+    void this.load();
+  }
+
+  override onClose(): void {
+    this.bodyEl = null;
+    this.loadedText = "";
+    this.contentEl.empty();
+  }
+
+  /** Read the log file (best-effort) and render its content or the empty hint. */
+  private async load(): Promise<void> {
+    let text = "";
+    try {
+      text = await this.source.read();
+    } catch {
+      // read() is already best-effort, but guard the await for safety.
+      text = "";
+    }
+    this.loadedText = text;
+    const body = this.bodyEl;
+    if (!body) return; // modal closed before the read resolved
+    body.empty();
+    if (text.trim().length === 0) {
+      body.createEl("div", {
+        cls: "exocortex-activity-log-empty",
+        text: EMPTY_LOG_HINT,
+      });
+      return;
+    }
+    body.createEl("div", {
+      cls: "exocortex-activity-log-row",
+      text,
+    });
+    // Scroll to the newest lines (bottom) — they are the most relevant.
+    body.scrollTop = body.scrollHeight;
+  }
+
+  /** Copy the loaded log content to the clipboard. Best-effort. */
+  private async copyToClipboard(): Promise<void> {
+    const text =
+      this.loadedText.trim().length === 0
+        ? `${this.source.getLogFilePath()}\n${EMPTY_LOG_HINT}`
+        : this.loadedText;
+    try {
+      await navigator?.clipboard?.writeText(text);
+    } catch {
+      // Clipboard unavailable / denied — best-effort, no user-facing error.
+    }
+  }
+}

--- a/packages/obsidian-plugin/src/presentation/renderers/UniversalLayoutRenderer.ts
+++ b/packages/obsidian-plugin/src/presentation/renderers/UniversalLayoutRenderer.ts
@@ -32,6 +32,10 @@ import {
 } from "./helpers";
 import { ObsidianApp, ExocortexPluginInterface } from '@plugin/types';
 import { LRUCache } from '@plugin/infrastructure/cache';
+import {
+  resolveCommandsRegionState,
+  COMMANDS_SKELETON_TEXT,
+} from "./commandsRegionState";
 
 /**
  * Renders the UniversalLayout view with properties, buttons, daily sections, and relations.
@@ -77,6 +81,10 @@ export class UniversalLayoutRenderer {
   // class chain + prototype chain before resolving button visibility.
   private lazyAssetGraphLoader?: LazyAssetGraphLoader;
   private prepareForRefresh?: (file: TFile) => Promise<void>;
+  // RFC 0002 §3.8 P13 (#3588) — cold-start COMMANDS skeleton gate. Returns
+  // true once the triple store finished initial indexing (`SPARQLApi.isReady`).
+  // When omitted the renderer assumes "ready" → no skeleton (back-compat).
+  private isStoreReady?: () => boolean;
   private exoLayoutRenderer!: ExoLayoutRenderer;
 
   private dependencyResolver: PropertyDependencyResolver;
@@ -120,6 +128,14 @@ export class UniversalLayoutRenderer {
        * sections-update pass starts.
        */
       prepareForRefresh?: (file: TFile) => Promise<void>;
+      /**
+       * RFC 0002 §3.8 P13 (#3588) — readiness probe for the cold-start
+       * COMMANDS skeleton. Wire `() => sparql.isReady()`; while it returns
+       * false (initial indexing in flight) an empty COMMANDS region shows an
+       * "indexing… buttons will appear shortly" placeholder instead of a blank
+       * layout. Omit to keep the legacy behaviour (no skeleton).
+       */
+      isStoreReady?: () => boolean;
     },
   ) {
     this.app = app;
@@ -136,6 +152,7 @@ export class UniversalLayoutRenderer {
     this.panelResolver = rfc009Services?.panelResolver ?? null;
     this.lazyAssetGraphLoader = rfc009Services?.lazyAssetGraphLoader;
     this.prepareForRefresh = rfc009Services?.prepareForRefresh;
+    this.isStoreReady = rfc009Services?.isStoreReady;
     this.logger = LoggerFactory.create("UniversalLayoutRenderer");
 
     // Create ReactRenderer with ErrorBoundary enabled for graceful error handling.
@@ -248,6 +265,23 @@ export class UniversalLayoutRenderer {
     this.rootContainer = null;
   }
 
+  /**
+   * RFC 0002 §3.8 P13 (#3588) — cold-start COMMANDS placeholder. Rendered in
+   * place of the (empty) buttons section while initial indexing is in flight,
+   * so a first-run user is not staring at a blank layout. Pure DOM (no React,
+   * no Node/fs) → identical on desktop and mobile. Disappears on the next
+   * re-render once the store is ready and real buttons resolve.
+   */
+  private renderCommandsSkeleton(el: HTMLElement): void {
+    const container = el.createDiv({ cls: "exocortex-buttons-section" });
+    const skeleton = container.createDiv({
+      cls: "exocortex-commands-skeleton",
+      text: COMMANDS_SKELETON_TEXT,
+    });
+    skeleton.setAttribute("role", "status");
+    skeleton.setAttribute("aria-busy", "true");
+  }
+
   public async handleMetadataChange(filePath: string): Promise<void> {
     if (this.debounceTimeout) clearTimeout(this.debounceTimeout);
 
@@ -338,9 +372,19 @@ export class UniversalLayoutRenderer {
       }
 
       const buttonGroups = await this.buttonGroupsBuilder.build(currentFile);
-      if (buttonGroups.length > 0) {
+      // RFC 0002 §3.8 P13 (#3588) — when the COMMANDS region is empty AND the
+      // triple store is still indexing, render a transient "indexing…" skeleton
+      // instead of a blank layout. Once indexing completes an empty result is
+      // trusted as genuine (no skeleton). `isStoreReady` absent → assume ready.
+      const regionState = resolveCommandsRegionState(
+        buttonGroups.length,
+        this.isStoreReady ? this.isStoreReady() : true,
+      );
+      if (regionState === "buttons") {
         const buttonsContainer = el.createDiv({ cls: "exocortex-buttons-section" });
         this.reactRenderer.render(buttonsContainer, React.createElement(ActionButtonsGroup, { groups: buttonGroups }));
+      } else if (regionState === "skeleton") {
+        this.renderCommandsSkeleton(el);
       }
 
       await this.dailyTasksRenderer.render(el, currentFile, renderHeader, this.sectionStateManager.isCollapsed("daily-tasks"));

--- a/packages/obsidian-plugin/src/presentation/renderers/commandsRegionState.ts
+++ b/packages/obsidian-plugin/src/presentation/renderers/commandsRegionState.ts
@@ -1,0 +1,39 @@
+/**
+ * Cold-start COMMANDS region state (RFC 0002 §3.8 P13, GitHub #3588).
+ *
+ * Decides what the layout's COMMANDS region should render, given how many
+ * command button groups resolved and whether the triple store has finished its
+ * initial indexing.
+ *
+ * During the initial-indexing window the store is only partially populated, so
+ * a create-instance command can resolve to ZERO buttons purely because its
+ * binding/precondition triples have not landed yet (the #3588 partial-store
+ * race). Showing a transient "indexing…" skeleton there beats a blank layout.
+ * Once indexing completes we trust an empty result as genuine (no skeleton),
+ * so assets that legitimately have no commands render nothing rather than a
+ * permanent placeholder.
+ *
+ * Best-effort by design: this covers the big initial-`convertVault()` window
+ * (the 10–20 s the "Lazy bootstrap folders" setting warns about); the narrow
+ * residual where the store reports ready but a specific asset's commands still
+ * lag remains blocked on #3588 engine timing.
+ */
+export type CommandsRegionState = "buttons" | "skeleton" | "empty";
+
+/** User-facing skeleton copy (RFC §3.8 wording). */
+export const COMMANDS_SKELETON_TEXT = "indexing… buttons will appear shortly";
+
+/**
+ * @param resolvedGroupCount number of command button groups the builder
+ *   resolved for the active asset (0 when the COMMANDS region is empty).
+ * @param storeReady whether the triple store finished initial indexing
+ *   (`SPARQLApi.isReady()` — flips true after the first `convertVault()`).
+ */
+export function resolveCommandsRegionState(
+  resolvedGroupCount: number,
+  storeReady: boolean,
+): CommandsRegionState {
+  if (resolvedGroupCount > 0) return "buttons";
+  if (!storeReady) return "skeleton";
+  return "empty";
+}

--- a/packages/obsidian-plugin/styles.css
+++ b/packages/obsidian-plugin/styles.css
@@ -6176,3 +6176,37 @@
   color: var(--text-muted);
   font-style: italic;
 }
+
+/* #3588 §3.8 P12 — «Open logs» modal: the real log-file path (plugin data
+   folder), shown monospace so it is copy-pasteable verbatim. */
+.exocortex-log-file-path {
+  font-family: var(--font-monospace, monospace);
+  font-size: var(--font-smaller, 0.85em);
+  color: var(--text-muted);
+  word-break: break-all;
+  margin-bottom: var(--size-4-2, 8px);
+}
+
+/* #3588 §3.8 P13 — cold-start COMMANDS skeleton: a muted, gently pulsing
+   placeholder shown while initial indexing is in flight, so a first-run user
+   is not staring at a blank layout. Disappears once buttons resolve. */
+.exocortex-commands-skeleton {
+  color: var(--text-muted);
+  font-style: italic;
+  font-size: var(--font-smaller, 0.85em);
+  padding: var(--size-4-2, 8px) var(--size-4-3, 12px);
+  border: 1px dashed var(--background-modifier-border);
+  border-radius: var(--radius-s, 4px);
+  margin-bottom: var(--size-4-3, 12px);
+  animation: exocortex-commands-skeleton-pulse 1.4s ease-in-out infinite;
+}
+
+@keyframes exocortex-commands-skeleton-pulse {
+  0%,
+  100% {
+    opacity: 0.55;
+  }
+  50% {
+    opacity: 1;
+  }
+}

--- a/packages/obsidian-plugin/tests/unit/ExocortexPlugin.test.ts
+++ b/packages/obsidian-plugin/tests/unit/ExocortexPlugin.test.ts
@@ -276,6 +276,43 @@ describe("ExocortexPlugin", () => {
     });
   });
 
+  // RFC 0002 §3.8 P12 (#3588) — «Exocortex: Open logs». The command surfaces
+  // the persisted log file (plugin data folder). Per the Desktop↔Mobile
+  // Command Parity invariant it MUST register UNCONDITIONALLY — no
+  // `Platform.isMobile ? null` gating — because it reads via the DataAdapter
+  // and renders a pure-DOM modal that works on both platforms.
+  describe("Issue #3588 §3.8 — «Open logs» command (Desktop↔Mobile parity)", () => {
+    const registeredIds = (spy: jest.SpyInstance): (string | undefined)[] =>
+      spy.mock.calls.map((c) => (c[0] as { id?: string }).id);
+
+    it("registers `open-logs` on desktop", async () => {
+      const addCommandSpy = jest.spyOn(plugin, "addCommand");
+      await plugin.onload();
+      expect(registeredIds(addCommandSpy)).toContain("open-logs");
+    });
+
+    it("registers `open-logs` on mobile (no Platform gating)", async () => {
+      const obsidianMock = await import("obsidian");
+      const platform = (
+        obsidianMock as unknown as {
+          Platform: { isMobile: boolean; isDesktop: boolean };
+        }
+      ).Platform;
+      const originalIsMobile = platform.isMobile;
+      const originalIsDesktop = platform.isDesktop;
+      platform.isMobile = true;
+      platform.isDesktop = false;
+      const addCommandSpy = jest.spyOn(plugin, "addCommand");
+      try {
+        await plugin.onload();
+        expect(registeredIds(addCommandSpy)).toContain("open-logs");
+      } finally {
+        platform.isMobile = originalIsMobile;
+        platform.isDesktop = originalIsDesktop;
+      }
+    });
+  });
+
   // Issue #3554 — profile apply → next Obsidian load hangs at "Loading plugins…".
   // After an `Apply profile` sets `data.local.json.activeProfileUid`, the next
   // load deadlocked: `registerProfileCommands` (awaited by `onload`) awaited the

--- a/packages/obsidian-plugin/tests/unit/FileLogChannel.test.ts
+++ b/packages/obsidian-plugin/tests/unit/FileLogChannel.test.ts
@@ -14,6 +14,7 @@ interface MockAdapter {
   stat: jest.Mock;
   rename: jest.Mock;
   remove: jest.Mock;
+  read: jest.Mock;
 }
 
 describe("FileLogChannel", () => {
@@ -29,6 +30,7 @@ describe("FileLogChannel", () => {
       stat: jest.fn().mockResolvedValue({ size: 0, type: "file", ctime: 0, mtime: 0 }),
       rename: jest.fn().mockResolvedValue(undefined),
       remove: jest.fn().mockResolvedValue(undefined),
+      read: jest.fn().mockResolvedValue(""),
     };
     channel = new FileLogChannel(mockAdapter as any, PLUGIN_DIR);
   });
@@ -254,6 +256,42 @@ describe("FileLogChannel", () => {
       expect(mockAdapter.stat).not.toHaveBeenCalled();
       expect(mockAdapter.rename).not.toHaveBeenCalled();
       expect(mockAdapter.write).toHaveBeenCalledWith(LOG_FILE, expect.stringContaining("First line ever"));
+    });
+  });
+
+  // RFC 0002 §3.8 P12 (#3588) — surface API used by the «Open logs» command.
+  describe("getLogFilePath + read (Open logs source)", () => {
+    it("exposes the log path inside the plugin data folder, not the vault root", () => {
+      expect(channel.getLogFilePath()).toBe(LOG_FILE);
+      expect(channel.getLogFilePath()).toContain(".obsidian/plugins/exocortex");
+      expect(channel.getLogFilePath()).not.toBe("exocortex-logs.txt");
+    });
+
+    it("reads the current log file content via the adapter", async () => {
+      mockAdapter.exists.mockResolvedValue(true);
+      mockAdapter.read.mockResolvedValue("[ERROR] boom\n");
+
+      const content = await channel.read();
+
+      expect(mockAdapter.exists).toHaveBeenCalledWith(LOG_FILE);
+      expect(mockAdapter.read).toHaveBeenCalledWith(LOG_FILE);
+      expect(content).toBe("[ERROR] boom\n");
+    });
+
+    it("returns empty string when the log file does not exist yet", async () => {
+      mockAdapter.exists.mockResolvedValue(false);
+
+      const content = await channel.read();
+
+      expect(content).toBe("");
+      expect(mockAdapter.read).not.toHaveBeenCalled();
+    });
+
+    it("returns empty string (best-effort) when the adapter read throws", async () => {
+      mockAdapter.exists.mockResolvedValue(true);
+      mockAdapter.read.mockRejectedValue(new Error("EPERM"));
+
+      await expect(channel.read()).resolves.toBe("");
     });
   });
 });

--- a/packages/obsidian-plugin/tests/unit/presentation/modals/LogFileModal.test.ts
+++ b/packages/obsidian-plugin/tests/unit/presentation/modals/LogFileModal.test.ts
@@ -1,0 +1,153 @@
+/**
+ * Unit tests for LogFileModal — the «Exocortex: Open logs» modal (RFC 0002
+ * §3.8 P12, GitHub #3588). It surfaces the persisted `exocortex-logs.txt` and
+ * its REAL location (the plugin data folder, not the vault root).
+ *
+ * Local `jest.mock("obsidian")` mirrors ActivityLogModal.test.ts — a Modal that
+ * mounts `contentEl` into `document.body` on `open()` and a `createEl` helper.
+ */
+import { describe, it, expect, beforeEach, jest } from "@jest/globals";
+
+jest.mock("obsidian", () => {
+  interface CreateOpts {
+    cls?: string;
+    text?: string;
+    type?: string;
+    attr?: Record<string, string>;
+  }
+  function augment(el: HTMLElement): void {
+    (
+      el as unknown as { createEl: (tag: string, o?: CreateOpts) => HTMLElement }
+    ).createEl = function (tag: string, o?: CreateOpts): HTMLElement {
+      const child = document.createElement(tag);
+      if (o?.cls) child.className = o.cls;
+      if (o?.text !== undefined) child.textContent = o.text;
+      if (o?.type) child.setAttribute("type", o.type);
+      if (o?.attr) {
+        for (const [k, v] of Object.entries(o.attr)) child.setAttribute(k, v);
+      }
+      this.appendChild(child);
+      augment(child);
+      return child;
+    }.bind(el);
+    (el as unknown as { empty: () => void }).empty = function (): void {
+      while (this.firstChild) this.removeChild(this.firstChild);
+    }.bind(el);
+  }
+  class MockModal {
+    app: unknown;
+    contentEl: HTMLElement;
+    titleEl: HTMLElement;
+    constructor(app: unknown) {
+      this.app = app;
+      this.contentEl = document.createElement("div");
+      this.titleEl = document.createElement("div");
+      augment(this.contentEl);
+      augment(this.titleEl);
+    }
+    open(): void {
+      document.body.appendChild(this.contentEl);
+      this.onOpen();
+    }
+    close(): void {
+      this.onClose();
+      if (this.contentEl.parentNode) {
+        this.contentEl.parentNode.removeChild(this.contentEl);
+      }
+    }
+    onOpen(): void {}
+    onClose(): void {}
+  }
+  return { Modal: MockModal, App: class {} };
+});
+
+import type { App } from "obsidian";
+import {
+  LogFileModal,
+  EMPTY_LOG_HINT,
+  type LogFileSource,
+} from "@plugin/presentation/modals/LogFileModal";
+
+const LOG_PATH = ".obsidian/plugins/exocortex/exocortex-logs.txt";
+
+/** Production-shape fake: exposes the real LogFileSource contract. */
+function makeSource(content: string): LogFileSource {
+  return {
+    getLogFilePath: () => LOG_PATH,
+    read: jest.fn<() => Promise<string>>().mockResolvedValue(content),
+  };
+}
+
+/** Let the async load() in onOpen resolve before asserting. */
+const flush = () => new Promise((r) => setTimeout(r, 0));
+
+const fakeApp = {} as App;
+
+describe("LogFileModal", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("shows the REAL log path (plugin data folder, not vault root)", async () => {
+    const modal = new LogFileModal(fakeApp, makeSource("[INFO] ready\n"));
+    modal.open();
+    await flush();
+
+    const pathEl = document.body.querySelector(".exocortex-log-file-path");
+    expect(pathEl?.textContent).toBe(LOG_PATH);
+    expect(pathEl?.textContent).toContain(".obsidian/plugins/exocortex");
+  });
+
+  it("renders the log file content when present", async () => {
+    const content = "[2026-06-19T00:00:00Z] [ERROR] [Init] boom\n";
+    const modal = new LogFileModal(fakeApp, makeSource(content));
+    modal.open();
+    await flush();
+
+    const row = document.body.querySelector(".exocortex-activity-log-row");
+    expect(row?.textContent).toBe(content);
+    // No empty hint when content exists.
+    expect(document.body.querySelector(".exocortex-activity-log-empty")).toBeNull();
+  });
+
+  it("shows the empty hint (info logging off by default) when the file is empty/absent", async () => {
+    const modal = new LogFileModal(fakeApp, makeSource(""));
+    modal.open();
+    await flush();
+
+    const empty = document.body.querySelector(".exocortex-activity-log-empty");
+    expect(empty?.textContent).toBe(EMPTY_LOG_HINT);
+    expect(empty?.textContent).toContain("Open activity log");
+    expect(document.body.querySelector(".exocortex-activity-log-row")).toBeNull();
+  });
+
+  it("copies the loaded content to the clipboard via Copy", async () => {
+    const writeText = jest.fn<(t: string) => Promise<void>>().mockResolvedValue(undefined);
+    Object.defineProperty(globalThis, "navigator", {
+      value: { clipboard: { writeText } },
+      configurable: true,
+    });
+
+    const content = "[INFO] hello\n";
+    const modal = new LogFileModal(fakeApp, makeSource(content));
+    modal.open();
+    await flush();
+
+    const buttons = Array.from(document.body.querySelectorAll("button"));
+    const copyBtn = buttons.find((b) => b.textContent === "Copy");
+    copyBtn?.dispatchEvent(new Event("click"));
+    await flush();
+
+    expect(writeText).toHaveBeenCalledWith(content);
+  });
+
+  it("clears its DOM on close (no leaked rows)", async () => {
+    const modal = new LogFileModal(fakeApp, makeSource("[INFO] x\n"));
+    modal.open();
+    await flush();
+    modal.close();
+
+    expect(document.body.querySelector(".exocortex-activity-log-row")).toBeNull();
+    expect(document.body.querySelector(".exocortex-log-file-path")).toBeNull();
+  });
+});

--- a/packages/obsidian-plugin/tests/unit/presentation/renderers/commandsRegionState.test.ts
+++ b/packages/obsidian-plugin/tests/unit/presentation/renderers/commandsRegionState.test.ts
@@ -1,0 +1,39 @@
+/**
+ * Unit tests for `resolveCommandsRegionState` — the cold-start COMMANDS region
+ * decision (RFC 0002 §3.8 P13, GitHub #3588).
+ *
+ * The three-way contract:
+ *   - resolved buttons present            → "buttons"
+ *   - empty AND store still indexing       → "skeleton" (transient placeholder)
+ *   - empty AND store ready                → "empty"   (genuine: render nothing)
+ */
+import { describe, it, expect } from "@jest/globals";
+import {
+  resolveCommandsRegionState,
+  COMMANDS_SKELETON_TEXT,
+} from "@plugin/presentation/renderers/commandsRegionState";
+
+describe("resolveCommandsRegionState", () => {
+  it("renders buttons whenever any command group resolved — even mid-indexing", () => {
+    expect(resolveCommandsRegionState(1, true)).toBe("buttons");
+    expect(resolveCommandsRegionState(3, false)).toBe("buttons");
+  });
+
+  it("shows the skeleton when the region is empty AND the store is still indexing (partial-store window)", () => {
+    expect(resolveCommandsRegionState(0, false)).toBe("skeleton");
+  });
+
+  it("renders nothing (empty) when the region is empty AND the store is ready — genuine no-commands asset", () => {
+    expect(resolveCommandsRegionState(0, true)).toBe("empty");
+  });
+
+  it("never shows the skeleton once buttons exist, regardless of readiness", () => {
+    // Buttons present trumps readiness in both directions.
+    expect(resolveCommandsRegionState(5, false)).not.toBe("skeleton");
+    expect(resolveCommandsRegionState(5, true)).not.toBe("skeleton");
+  });
+
+  it("exposes the RFC §3.8 skeleton copy", () => {
+    expect(COMMANDS_SKELETON_TEXT).toBe("indexing… buttons will appear shortly");
+  });
+});


### PR DESCRIPTION
Implements **RFC 0002 §3.8 — Diagnostics & cold-start polish** ([P12, P13], #3588). WBS node \`b7231507\`.

## P12 — reconcile the logs path (don't fight it)
The file log sink is the **plugin data folder** (\`FileLogChannel\`: \`<vault>/.obsidian/plugins/exocortex/exocortex-logs.txt\`), **not** the vault root — but the tutorial said vault root, sending testers to a dead end.

- **New \`Exocortex: Open logs\` command** — opens a pure-DOM modal (\`LogFileModal\`) showing the **real path** + the file content, read via the \`DataAdapter\`. Empty/absent file → a helpful hint (info logging is off by default; only warn/error are written) pointing at the always-on activity log.
- **Docs reconcile** (\`docs/tutorials/Getting-Started.md\`): every "vault root" log reference now points at the plugin data folder + the \`Exocortex: Open logs\` / \`Exocortex: Open activity log\` (#3540) commands.
- ⛔ Does **not** create a vault-root file (that would contradict the actual sink).

## P13 — cold-start COMMANDS skeleton (best-effort, blocked on #3588)
During the initial-indexing window a create-instance button can resolve to zero buttons purely because its triples haven't landed yet. Instead of a blank layout, the COMMANDS region now shows an **"indexing… buttons will appear shortly"** placeholder.

- Gated on \`SPARQLApi.isReady()\` (flips true after the first \`convertVault()\`): empty region + store **not** ready → skeleton; once ready, an empty region is trusted as genuine (no skeleton) so assets with no commands render nothing.
- Decision extracted as a pure helper \`resolveCommandsRegionState()\` for unit testing.

## Desktop↔Mobile Command Parity
\`Open logs\` is registered **unconditionally** (no \`Platform.isMobile ? null\` gating) — it reads via the \`DataAdapter\` and renders pure DOM, so it works identically on desktop and mobile. The skeleton is likewise pure DOM. Verified by tests + archgate MOBILE-001/002/003 (bundle module-evals without Node).

## Tests (all green locally)
- \`FileLogChannel\` — \`getLogFilePath()\` (plugin data folder, not vault root) + \`read()\` (content / absent / error → "").
- \`LogFileModal\` — real path shown, content rendered, empty hint, Copy, close cleanup.
- \`resolveCommandsRegionState\` — buttons / skeleton / empty (3 states).
- \`ExocortexPlugin\` — \`open-logs\` registers on **desktop AND mobile**.
- typecheck ✅ · lint ✅ · archgate 20/20 ✅ · mobile-loadable ✅

## DoD
- [x] Docs point at the real logs location (plugin data folder) + activity log
- [x] \`Exocortex: Open logs\` command (mobile+desktop)
- [x] Cold-start "indexing…" placeholder in COMMANDS region (best-effort)
- [x] Unit tests; no broken doc links
- [ ] CI green (13 checks) + merge + release

🤖 Generated with [Claude Code](https://claude.com/claude-code)