### PR TITLE
feat(onboarding): first-run "Welcome to Exocortex" panel + Setup command (RFC 0002 §3.1)

### DIFF
--- a/packages/obsidian-plugin/src/ExocortexPlugin.ts
+++ b/packages/obsidian-plugin/src/ExocortexPlugin.ts
@@ -130,6 +130,13 @@ import {
 import { BootstrapVaultModal } from "./presentation/modals/BootstrapVaultModal";
 import { AddAssetSpaceModal } from "./presentation/modals/AddAssetSpaceModal";
 import { SimpleConfirmModal } from "./presentation/modals/SimpleConfirmModal";
+import { FirstRunOnboardingModal } from "./presentation/modals/FirstRunOnboardingModal";
+import {
+  registerOnboardingCommands,
+  shouldShowFirstRunPanel,
+  STARTER_REGISTRY_URL,
+  STARTER_PROFILE_QUERY,
+} from "./infrastructure/adapters/firstRunOnboarding";
 import { AssetSpaceMaterializationTracker } from "./infrastructure/adapters/AssetSpaceMaterializationTracker";
 import { injectAssetSpaceMaterializationTriples } from "./infrastructure/adapters/injectAssetSpaceMaterializationTriples";
 import { AssetSpaceStatusIconPatch } from "./presentation/asset-space/AssetSpaceStatusIconPatch";
@@ -3039,9 +3046,16 @@ export default class ExocortexPlugin extends Plugin {
     const fuzzyPick = (
       options: ProfileChoice[],
       title: string,
+      initialQuery?: string,
     ): Promise<ProfileChoice | null> => {
       return new Promise<ProfileChoice | null>((resolve) => {
-        const modal = new ProfileFuzzyModal(this.app, options, title, resolve);
+        const modal = new ProfileFuzzyModal(
+          this.app,
+          options,
+          title,
+          resolve,
+          initialQuery,
+        );
         modal.open();
       });
     };
@@ -3136,9 +3150,27 @@ export default class ExocortexPlugin extends Plugin {
     // cold-start (bootstrap → add registry/profiles → apply-profile) without a
     // desktop. The Desktop↔Mobile Command Parity invariant requires both
     // surfaces; the gate mirrors the apply-profile gate above.
+    let bootstrapCommands: BootstrapAssetSpaceCommands | null = null;
     if (applyDeps !== null || (Platform.isMobile && restMount !== null)) {
-      this.registerBootstrapCommands(applyDeps, restMount, localDataStore);
+      bootstrapCommands = this.registerBootstrapCommands(
+        applyDeps,
+        restMount,
+        localDataStore,
+      );
     }
+
+    // RFC 0002 §3.1/§3.2 — first-run onboarding panel + guided «Setup
+    // (Getting Started)» command. The Setup command registers UNCONDITIONALLY
+    // (no Platform gate) so the panel is reachable on desktop AND mobile
+    // (Desktop↔Mobile Command Parity). The panel auto-shows once, on a
+    // not-yet-bootstrapped vault, deferred to onLayoutReady. `bootstrapCommands`
+    // (cross-platform vault-state detector + Bootstrap/Add driver) and
+    // `commandsHandler` (Apply-profile) drive the canonical `starter` path.
+    this.registerOnboardingPanel(
+      bootstrapCommands,
+      commandsHandler,
+      localDataStore,
+    );
 
     // #e6b8827c — «Unmount assetspace»: the inverse of «Add assetspace by URL».
     // Unmount mechanics already existed only INSIDE apply-profile's strict
@@ -3154,6 +3186,106 @@ export default class ExocortexPlugin extends Plugin {
     this.logger.info(
       "[ExocortexPlugin] Profile palette commands registered",
     );
+  }
+
+  /**
+   * RFC 0002 §3.1/§3.2 — wire the first-run onboarding panel and its re-entry
+   * `Setup (Getting Started)` command.
+   *
+   * The Setup command is registered UNCONDITIONALLY (no `Platform.isMobile`
+   * gate) so the panel is reachable on both desktop and mobile (Desktop↔Mobile
+   * Command Parity). The panel auto-shows ONCE, on a not-yet-bootstrapped vault,
+   * deferred to `onLayoutReady` — opening a Modal during onload (before
+   * `layoutReady`) can wedge "Loading plugins…" (same hazard as the reconcile
+   * deferral above).
+   *
+   * `bootstrapCommands` is the cross-platform vault-state detector + Bootstrap /
+   * Add-AssetSpace driver (null only in a degenerate no-deps environment, where
+   * bootstrap itself is impossible — the step actions then surface a notice).
+   * `profileCommands` drives Apply-profile. Both are pre-narrowed to the
+   * canonical `starter` path.
+   */
+  private registerOnboardingPanel(
+    bootstrapCommands: BootstrapAssetSpaceCommands | null,
+    profileCommands: ProfileCommands,
+    localDataStore: PluginLocalDataStore,
+  ): void {
+    const unavailable = (what: string): void =>
+      this.notifier.info(
+        `${what} is unavailable in this environment — see the Getting Started guide.`,
+      );
+
+    const openPanel = (): void => {
+      new FirstRunOnboardingModal(this.app, {
+        onSetupEngine: () => {
+          if (bootstrapCommands === null) {
+            unavailable("Bootstrap");
+            return;
+          }
+          void bootstrapCommands.invokeBootstrap();
+        },
+        onAddStarter: () => {
+          if (bootstrapCommands === null) {
+            unavailable("Add starter content");
+            return;
+          }
+          void bootstrapCommands.invokeAddAssetSpace(STARTER_REGISTRY_URL);
+        },
+        onApplyStarterProfile: () => {
+          void profileCommands.invokeApplyProfile(STARTER_PROFILE_QUERY);
+        },
+        onClosePanel: () => {
+          void localDataStore.setOnboardingCompleted(true).catch((err) => {
+            this.logger.warn(
+              "[ExocortexPlugin] persisting onboarding-completed flag failed: " +
+                (err instanceof Error ? err.message : String(err)),
+            );
+          });
+        },
+      }).open();
+    };
+
+    // Guided Setup command — unconditional (parity); the re-entry point the
+    // first-run panel depends on (RFC 0002 §3.2 bullet 1).
+    registerOnboardingCommands(this, openPanel);
+
+    // First-run auto-show — deferred to layoutReady (a Modal during onload can
+    // wedge "Loading plugins…"). Best-effort: a detection failure must not
+    // break onload.
+    this.app.workspace.onLayoutReady(() => {
+      void this.maybeShowFirstRunPanel(
+        bootstrapCommands,
+        localDataStore,
+        openPanel,
+      );
+    });
+  }
+
+  /**
+   * Decide whether to auto-show the first-run panel and do so (RFC 0002 §3.1).
+   * Shows only on a not-yet-bootstrapped vault that the user has not already
+   * dismissed onboarding on this device. All reads are cross-platform
+   * (`vault.adapter`), so the check behaves identically on mobile. Best-effort
+   * — any failure is logged, never thrown.
+   */
+  private async maybeShowFirstRunPanel(
+    bootstrapCommands: BootstrapAssetSpaceCommands | null,
+    localDataStore: PluginLocalDataStore,
+    openPanel: () => void,
+  ): Promise<void> {
+    try {
+      // No bootstrap driver → cannot detect vault state (and bootstrap itself
+      // would be impossible), so there is nothing to guide.
+      if (bootstrapCommands === null) return;
+      const completed = await localDataStore.getOnboardingCompleted();
+      const state = await bootstrapCommands.detectVaultState();
+      if (shouldShowFirstRunPanel(state, completed)) openPanel();
+    } catch (err) {
+      this.logger.warn(
+        "[ExocortexPlugin] first-run onboarding check failed: " +
+          (err instanceof Error ? err.message : String(err)),
+      );
+    }
   }
 
   /**
@@ -3263,7 +3395,7 @@ export default class ExocortexPlugin extends Plugin {
     } | null,
     restMount: RestAssetSpaceMount | null,
     localDataStore: PluginLocalDataStore,
-  ): void {
+  ): BootstrapAssetSpaceCommands {
     const deriveFolderName = (url: string): string => {
       const { repo } = parseGitHubURL(url);
       return repo.startsWith("exoas-") ? repo.slice("exoas-".length) : repo;
@@ -3303,9 +3435,14 @@ export default class ExocortexPlugin extends Plugin {
         new Promise((resolve) => {
           new BootstrapVaultModal(this.app, resolve).open();
         }),
-      promptAddAssetSpaceUrl: () =>
+      promptAddAssetSpaceUrl: (prefillUrl?: string) =>
         new Promise((resolve) => {
-          new AddAssetSpaceModal(this.app, deriveFolderName, resolve).open();
+          new AddAssetSpaceModal(
+            this.app,
+            deriveFolderName,
+            resolve,
+            prefillUrl,
+          ).open();
         }),
       confirm: (message) =>
         new Promise((resolve) => {
@@ -3342,6 +3479,11 @@ export default class ExocortexPlugin extends Plugin {
         void bootstrapCommands.invokeAddAssetSpace();
       },
     });
+
+    // Returned so `registerProfileCommands` can wire the first-run onboarding
+    // panel's step-1 (Bootstrap) and step-2 (Add starter content, prefilled)
+    // actions to this same handler — RFC 0002 §3.1.
+    return bootstrapCommands;
   }
 
   /**

--- a/packages/obsidian-plugin/src/ExocortexPlugin.ts
+++ b/packages/obsidian-plugin/src/ExocortexPlugin.ts
@@ -3279,7 +3279,14 @@ export default class ExocortexPlugin extends Plugin {
       if (bootstrapCommands === null) return;
       const completed = await localDataStore.getOnboardingCompleted();
       const state = await bootstrapCommands.detectVaultState();
-      if (shouldShowFirstRunPanel(state, completed)) openPanel();
+      // Genuinely-fresh guard — `detectVaultState` reports "empty" for any vault
+      // without `assetspaces/`, including an established content-rich vault; the
+      // markdown-file count keeps the auto-show to actual first-run vaults (the
+      // Setup command remains the re-entry point for everyone else).
+      const markdownFileCount = this.app.vault.getMarkdownFiles().length;
+      if (shouldShowFirstRunPanel(state, completed, markdownFileCount)) {
+        openPanel();
+      }
     } catch (err) {
       this.logger.warn(
         "[ExocortexPlugin] first-run onboarding check failed: " +

--- a/packages/obsidian-plugin/src/infrastructure/adapters/BootstrapAssetSpaceCommands.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/BootstrapAssetSpaceCommands.ts
@@ -166,9 +166,13 @@ export interface BootstrapAssetSpaceCommandsDeps {
   } | null>;
   /**
    * Open the add-AssetSpace modal (single URL field). Resolves the entered
-   * URL, or null if the user cancelled.
+   * URL, or null if the user cancelled. `prefillUrl` (optional) pre-fills the
+   * field — used by the first-run onboarding panel to offer the recommended
+   * `exoas-starter-registry` URL (RFC 0002 §3.1 step 2); the user still confirms.
    */
-  promptAddAssetSpaceUrl: () => Promise<{ url: string } | null>;
+  promptAddAssetSpaceUrl: (
+    prefillUrl?: string,
+  ) => Promise<{ url: string } | null>;
   /** Yes/no confirmation gate (used by the EC2 clone-needs-fetch flow). */
   confirm: (message: string) => Promise<boolean>;
   /** User-facing Notice. */
@@ -313,9 +317,16 @@ export class BootstrapAssetSpaceCommands {
     await this.runOnMaterialized();
   }
 
-  /** Command 2 — `Exocortex: Add AssetSpace by URL`. */
-  async invokeAddAssetSpace(): Promise<void> {
-    const res = await this.d.promptAddAssetSpaceUrl();
+  /**
+   * Command 2 — `Exocortex: Add AssetSpace by URL`.
+   *
+   * `prefillUrl` (optional) pre-fills the modal field — the first-run
+   * onboarding panel passes the public `exoas-starter-registry` URL here
+   * (RFC 0002 §3.1 step 2). The user still reviews + confirms in the modal;
+   * the materialisation path below is unchanged.
+   */
+  async invokeAddAssetSpace(prefillUrl?: string): Promise<void> {
+    const res = await this.d.promptAddAssetSpaceUrl(prefillUrl);
     if (res === null) return; // user cancelled
 
     try {

--- a/packages/obsidian-plugin/src/infrastructure/adapters/PluginLocalDataStore.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/PluginLocalDataStore.ts
@@ -61,6 +61,7 @@ const KEY_ACTIVE_PROFILE_UID = "activeProfileUid";
 const KEY_SWITCH_IN_PROGRESS = "_switchInProgress";
 const KEY_ACTIVE_STAGING_DIRS = "_activeStagingDirs";
 const KEY_FILE_ONLY_ASSET_SPACES = "_fileOnlyAssetSpaces";
+const KEY_ONBOARDING_COMPLETED = "onboardingCompleted";
 
 export interface PluginLocalDataStoreOptions {
   app: App;
@@ -348,6 +349,34 @@ export class PluginLocalDataStore {
       sha: e.sha,
       addedAt: e.addedAt,
     }));
+    await this.persist(all);
+  }
+
+  /**
+   * Read the device-local first-run onboarding flag (RFC 0002 §3.1). `true`
+   * once the user has dismissed/completed the "Welcome to Exocortex" panel on
+   * this device, so it does not auto-show again (it stays re-openable via the
+   * `Setup` command).
+   *
+   * Device-local by design — onboarding is per-device UX state, NOT a vault
+   * fact to replicate via Sync (one device's "I've seen this" must not suppress
+   * the panel on a teammate's fresh device). Reads from disk on each call (the
+   * value lives outside {@link LocalSwitchState}, read once at onload), and is
+   * preserved across switch-state writes by their RMW. Defaults to `false` when
+   * absent or unreadable.
+   */
+  async getOnboardingCompleted(): Promise<boolean> {
+    const all = await this.readAllRaw();
+    return all[KEY_ONBOARDING_COMPLETED] === true;
+  }
+
+  /**
+   * Persist the first-run onboarding flag. RMW preserves unknown sibling keys
+   * (PAT, switch state, staging dirs) — see the class docstring.
+   */
+  async setOnboardingCompleted(completed: boolean): Promise<void> {
+    const all = await this.readAllRaw();
+    all[KEY_ONBOARDING_COMPLETED] = completed;
     await this.persist(all);
   }
 

--- a/packages/obsidian-plugin/src/infrastructure/adapters/ProfileCommands.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/ProfileCommands.ts
@@ -71,11 +71,14 @@ export interface ProfileCommandsDeps {
   /**
    * Open a fuzzy picker UI. Returns the user's choice, or null if the
    * picker was cancelled. Real implementation wraps Obsidian
-   * `FuzzySuggestModal`; tests provide a programmatic stub.
+   * `FuzzySuggestModal`; tests provide a programmatic stub. `initialQuery`
+   * (optional) pre-narrows the filter — the first-run onboarding panel passes
+   * `"starter"` so the recommended profile surfaces first (RFC 0002 §3.1 step 3).
    */
   fuzzyPick: (
     options: ProfileChoice[],
     title: string,
+    initialQuery?: string,
   ) => Promise<ProfileChoice | null>;
   /** Returns the currently-active file path, or null if no file is open. */
   getActiveFilePath: () => string | null;
@@ -124,8 +127,12 @@ export class ProfileCommands {
    *
    * User-facing error mapping: TsFloorViolationError, UncommittedChangesAbortError,
    * and ApplyAbortedByUser get clear notices distinct from generic «Apply failed».
+   *
+   * `initialQuery` (optional) pre-narrows the picker — the first-run onboarding
+   * panel passes `"starter"` so the recommended profile surfaces first
+   * (RFC 0002 §3.1 step 3). The full list is still shown.
    */
-  async invokeApplyProfile(): Promise<void> {
+  async invokeApplyProfile(initialQuery?: string): Promise<void> {
     let profiles: ProfileChoice[];
     try {
       profiles = await this.profileLister();
@@ -139,7 +146,7 @@ export class ProfileCommands {
       return;
     }
 
-    const chosen = await this.fuzzyPick(profiles, "Apply profile");
+    const chosen = await this.fuzzyPick(profiles, "Apply profile", initialQuery);
     if (chosen === null) return; // user cancelled
 
     this.notify(`Applying ${chosen.label}…`);

--- a/packages/obsidian-plugin/src/infrastructure/adapters/ProfileFuzzyModal.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/ProfileFuzzyModal.ts
@@ -51,16 +51,38 @@ export class ProfileFuzzyModal extends FuzzySuggestModal<ProfileChoice> {
   private chosen: ProfileChoice | null = null;
   private settled = false;
   private readonly resolve: (value: ProfileChoice | null) => void;
+  private readonly initialQuery: string;
 
   constructor(
     app: App,
     private readonly options: ProfileChoice[],
     title: string,
     resolve: (value: ProfileChoice | null) => void,
+    initialQuery?: string,
   ) {
     super(app);
     this.resolve = resolve;
+    this.initialQuery = (initialQuery ?? "").trim();
     this.setPlaceholder(title);
+  }
+
+  /**
+   * Pre-narrow the fuzzy filter when launched from the first-run onboarding
+   * panel (RFC 0002 §3.1 step 3 — open the picker on `starter`). Sets the
+   * search input and fires an `input` event so Obsidian re-filters. Best-effort
+   * — the full list is still present, so a context where the synthetic event is
+   * ignored just shows the unfiltered picker with the query pre-typed.
+   */
+  override onOpen(): void {
+    super.onOpen();
+    if (this.initialQuery.length > 0) {
+      try {
+        this.inputEl.value = this.initialQuery;
+        this.inputEl.dispatchEvent(new Event("input"));
+      } catch {
+        /* pre-narrow is best-effort; the picker still lists every profile */
+      }
+    }
   }
 
   getItems(): ProfileChoice[] {

--- a/packages/obsidian-plugin/src/infrastructure/adapters/firstRunOnboarding.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/firstRunOnboarding.ts
@@ -28,26 +28,43 @@ export const STARTER_REGISTRY_URL =
 export const STARTER_PROFILE_QUERY = "starter";
 
 /**
- * First-run detection (RFC 0002 §3.1 [P1, P2]). The panel auto-shows on plugin
- * enable when the vault is **not yet bootstrapped** AND the user has not already
- * dismissed/completed onboarding on this device.
+ * The most markdown notes a vault may hold and still count as a genuinely
+ * *fresh* first-run vault. The canonical fresh-tester flow (RFC 0002 §1)
+ * installs the plugin into a brand-new / empty vault; modern Obsidian seeds at
+ * most a single stock `Welcome.md`, so `<= 1` covers "empty" and "only the
+ * stock welcome note". Anything above that is an established vault, even if it
+ * has no `assetspaces/` yet.
+ */
+export const FRESH_VAULT_MAX_NOTES = 1;
+
+/**
+ * First-run detection (RFC 0002 §3.1 [P1, P2]). The panel **auto-shows** on
+ * plugin enable only for a genuinely fresh, not-yet-bootstrapped vault that the
+ * user has not already dismissed onboarding on (this device).
  *
- * `vaultState` comes from {@link BootstrapAssetSpaceCommands.detectVaultState}
- * (cross-platform — `vault.adapter` based, so it works identically on mobile,
- * satisfying the Desktop↔Mobile Command Parity invariant). Both `empty` and
- * `clone-needs-fetch` are pre-value states that still need the guided path;
- * only `bootstrapped` suppresses the panel.
- *
- * `onboardingCompleted` is the device-local flag persisted by the panel on
- * close (see {@link PluginLocalDataStore.getOnboardingCompleted}) so the panel
- * is genuinely one-time — re-openable only via the `Setup` command.
+ * Three gates, all must pass to auto-show:
+ *   1. `onboardingCompleted` is false — the device-local one-time flag persisted
+ *      by the panel on close ({@link PluginLocalDataStore.getOnboardingCompleted}).
+ *   2. `vaultState !== "bootstrapped"` — from
+ *      {@link BootstrapAssetSpaceCommands.detectVaultState} (cross-platform,
+ *      `vault.adapter`-based → identical on mobile, satisfying Desktop↔Mobile
+ *      Command Parity). Both `empty` and `clone-needs-fetch` are pre-value states
+ *      that still need the guided path.
+ *   3. `markdownFileCount <= FRESH_VAULT_MAX_NOTES` — the vault is genuinely
+ *      fresh. `detectVaultState` reports "empty" for ANY vault lacking
+ *      `assetspaces/` (including an established 100-note vault that simply uses a
+ *      non-bootstrap layout), so this guard prevents a false-positive auto-show
+ *      over a user's existing content. Anyone this skips can still open the panel
+ *      via the always-available `Setup` command (the re-entry point).
  */
 export function shouldShowFirstRunPanel(
   vaultState: VaultBootstrapState,
   onboardingCompleted: boolean,
+  markdownFileCount: number,
 ): boolean {
   if (onboardingCompleted) return false;
-  return vaultState !== "bootstrapped";
+  if (vaultState === "bootstrapped") return false;
+  return markdownFileCount <= FRESH_VAULT_MAX_NOTES;
 }
 
 /** Stable command id for the guided Setup entry point (RFC 0002 §3.2). */

--- a/packages/obsidian-plugin/src/infrastructure/adapters/firstRunOnboarding.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/firstRunOnboarding.ts
@@ -1,0 +1,93 @@
+/**
+ * First-run onboarding logic — RFC 0002 §3.1 ([P1, P2]).
+ *
+ * Pure (no `obsidian` runtime import) so the first-run detection predicate, the
+ * canonical starter-path constants, and the `Setup` command registration
+ * contract are all unit-testable with plain objects. The Obsidian-facing panel
+ * lives in `presentation/modals/FirstRunOnboardingModal`; the wiring lives in
+ * `ExocortexPlugin.registerProfileCommands`.
+ */
+
+import type { VaultBootstrapState } from "./BootstrapAssetSpaceCommands";
+
+/**
+ * The public, stable starter-content registry pre-filled into step 2 of the
+ * onboarding panel. Unlike the Bootstrap floor URL (kept empty per EC7 — the
+ * `kitelev/exoas-*` repos are Andrey's own ontology, not a generic floor), this
+ * registry IS genuinely recommended for every new tester, so pre-filling it is
+ * a deliberate UX affordance and not an EC7 conflict (RFC 0002 §3.1 / §3.3).
+ */
+export const STARTER_REGISTRY_URL =
+  "https://github.com/kitelev/exoas-starter-registry";
+
+/**
+ * Initial fuzzy-filter query for step 3's profile picker, so the canonical
+ * `starter` profile surfaces first (RFC 0002 §3.1 step 3 / §3.4). The picker
+ * still lists all profiles — the query just pre-narrows it.
+ */
+export const STARTER_PROFILE_QUERY = "starter";
+
+/**
+ * First-run detection (RFC 0002 §3.1 [P1, P2]). The panel auto-shows on plugin
+ * enable when the vault is **not yet bootstrapped** AND the user has not already
+ * dismissed/completed onboarding on this device.
+ *
+ * `vaultState` comes from {@link BootstrapAssetSpaceCommands.detectVaultState}
+ * (cross-platform — `vault.adapter` based, so it works identically on mobile,
+ * satisfying the Desktop↔Mobile Command Parity invariant). Both `empty` and
+ * `clone-needs-fetch` are pre-value states that still need the guided path;
+ * only `bootstrapped` suppresses the panel.
+ *
+ * `onboardingCompleted` is the device-local flag persisted by the panel on
+ * close (see {@link PluginLocalDataStore.getOnboardingCompleted}) so the panel
+ * is genuinely one-time — re-openable only via the `Setup` command.
+ */
+export function shouldShowFirstRunPanel(
+  vaultState: VaultBootstrapState,
+  onboardingCompleted: boolean,
+): boolean {
+  if (onboardingCompleted) return false;
+  return vaultState !== "bootstrapped";
+}
+
+/** Stable command id for the guided Setup entry point (RFC 0002 §3.2). */
+export const SETUP_COMMAND_ID = "setup-getting-started";
+
+/**
+ * Structural slice of Obsidian's `Plugin.addCommand` — keeps this module free
+ * of an `obsidian` runtime import (unit-testable with a plain object), mirroring
+ * {@link ExoSyncCommandRegistrar}.
+ */
+export interface OnboardingCommandRegistrar {
+  addCommand(command: {
+    id: string;
+    name: string;
+    callback: () => void;
+  }): unknown;
+}
+
+/**
+ * Register the guided `Exocortex: Setup (Getting Started)` command — the one
+ * command a new user can find by intuition and the re-entry point the first-run
+ * panel (§3.1) depends on (so it ships WITH the panel in Phase 1, §3.2 bullet 1).
+ *
+ * Registered **unconditionally** — there is deliberately NO `Platform.isMobile`
+ * gate, so the panel is reachable on both desktop and mobile (Desktop↔Mobile
+ * Command Parity invariant). The panel itself renders on both platforms; its
+ * step actions route through the cross-platform bootstrap / add-assetspace /
+ * apply-profile flows that already run on mobile via the REST path.
+ */
+export function registerOnboardingCommands(
+  plugin: OnboardingCommandRegistrar,
+  openPanel: () => void,
+): void {
+  plugin.addCommand({
+    id: SETUP_COMMAND_ID,
+    // Sentence case per the plugin's UI-text lint rule + RFC 0002 P3
+    // (de-jargon / consistent casing — the parenthetical follows the same
+    // lowercase convention as the RFC's «(advanced)» flags); surfaces as
+    // «Exocortex: Setup (getting started)».
+    name: "Setup (getting started)",
+    callback: () => openPanel(),
+  });
+}

--- a/packages/obsidian-plugin/src/presentation/modals/AddAssetSpaceModal.ts
+++ b/packages/obsidian-plugin/src/presentation/modals/AddAssetSpaceModal.ts
@@ -19,11 +19,17 @@ export interface AddAssetSpaceInput {
  * Resolves `{ url }` only when the user clicks «Add» with a plausible GitHub
  * URL. Esc / Cancel / any close path resolves `null`. The promise resolves
  * exactly once.
+ *
+ * An optional `initialUrl` pre-fills the field — used by the first-run
+ * onboarding panel (RFC 0002 §3.1 step 2) to offer the public, stable
+ * `exoas-starter-registry` URL one click away. The user still confirms; a
+ * pre-fill is a recommended default, not an auto-action.
  */
 export class AddAssetSpaceModal extends Modal {
   private resolved = false;
   private readonly resolveFn: (input: AddAssetSpaceInput | null) => void;
   private readonly deriveFolderName: (url: string) => string;
+  private readonly initialUrl: string;
   private urlInput: HTMLInputElement | null = null;
   private previewEl: HTMLElement | null = null;
   private errorEl: HTMLElement | null = null;
@@ -32,10 +38,12 @@ export class AddAssetSpaceModal extends Modal {
     app: App,
     deriveFolderName: (url: string) => string,
     resolve: (input: AddAssetSpaceInput | null) => void,
+    initialUrl?: string,
   ) {
     super(app);
     this.deriveFolderName = deriveFolderName;
     this.resolveFn = resolve;
+    this.initialUrl = (initialUrl ?? "").trim();
   }
 
   private settle(value: AddAssetSpaceInput | null): void {
@@ -64,6 +72,12 @@ export class AddAssetSpaceModal extends Modal {
       cls: "add-assetspace-input bootstrap-modal-input",
     });
     this.urlInput = input;
+    // Pre-fill the recommended starter-registry URL when launched from the
+    // first-run onboarding panel (RFC 0002 §3.1 step 2). The user still reviews
+    // + confirms; the preview reflects the pre-filled value immediately.
+    if (this.initialUrl.length > 0) {
+      input.value = this.initialUrl;
+    }
 
     this.previewEl = contentEl.createEl("p", {
       cls: "add-assetspace-preview",

--- a/packages/obsidian-plugin/src/presentation/modals/FirstRunOnboardingModal.ts
+++ b/packages/obsidian-plugin/src/presentation/modals/FirstRunOnboardingModal.ts
@@ -1,0 +1,191 @@
+import { App, Modal } from "obsidian";
+
+/**
+ * Action callbacks for the three onboarding steps + a one-time-close hook. The
+ * panel is a thin, decoupled UI scaffold (RFC 0002 §3.1) — it owns no business
+ * logic; each step just fires the injected action, which the plugin wires to the
+ * existing Bootstrap / Add-AssetSpace / Apply-profile flows.
+ */
+export interface FirstRunOnboardingActions {
+  /** Step 1 — open the Bootstrap dialog (fields stay empty per EC7). */
+  onSetupEngine: () => void;
+  /** Step 2 — open Add-AssetSpace pre-filled with the starter registry URL. */
+  onAddStarter: () => void;
+  /** Step 3 — open the profile picker narrowed to the `starter` profile. */
+  onApplyStarterProfile: () => void;
+  /**
+   * Fired exactly once when the panel closes (any path: button, Esc, click-out).
+   * Used to persist the device-local "onboarding completed" flag so the panel
+   * is genuinely one-time (re-openable only via the `Setup` command).
+   */
+  onClosePanel?: () => void;
+}
+
+interface StepSpec {
+  /** Plain-text step marker (NOT a glyph) so it is screen-reader reliable (P16). */
+  marker: string;
+  title: string;
+  description: string;
+  actionLabel: string;
+  action: () => void;
+}
+
+/**
+ * FirstRunOnboardingModal — the one-time "Welcome to Exocortex" panel
+ * (RFC 0002 §3.1, resolves P1 first-run-has-zero-orientation + P2
+ * sequence-not-discoverable).
+ *
+ * Renders a 3-step checklist that drives the canonical **starter** path:
+ *   1. Set up the engine        → Bootstrap dialog (3.3)
+ *   2. Add the starter content  → Add-AssetSpace pre-filled with the registry
+ *   3. Apply the starter profile → profile picker on `starter` (3.4)
+ *
+ * The step sub-dialogs stack ON TOP of this panel (Obsidian modal stacking), so
+ * the panel stays open underneath and the user can walk the sequence without
+ * losing their place. It is re-openable via the `Setup (Getting Started)`
+ * command (§3.2). On any close it fires `onClosePanel` once so the plugin can
+ * persist the one-time flag.
+ *
+ * ## Accessibility (P16, §3.11)
+ *
+ * - Steps are a semantic `<ol>` so assistive tech announces "list, 3 items".
+ * - Each action is a native `<button>` (keyboard-navigable + Enter/Space
+ *   activation for free) with an explicit `aria-label`.
+ * - Focus is managed: the first step's action button is focused on open.
+ * - Step order uses a text marker ("Step 1 —"), never an icon/emoji alone.
+ */
+export class FirstRunOnboardingModal extends Modal {
+  private readonly actions: FirstRunOnboardingActions;
+  private closed = false;
+  private firstActionButton: HTMLButtonElement | null = null;
+
+  constructor(app: App, actions: FirstRunOnboardingActions) {
+    super(app);
+    this.actions = actions;
+  }
+
+  override onOpen(): void {
+    const { contentEl } = this;
+    contentEl.addClass("exocortex-onboarding");
+
+    contentEl.createEl("h2", {
+      cls: "exocortex-onboarding-title",
+      // eslint-disable-next-line obsidianmd/ui/sentence-case -- "Exocortex" is the plugin's proper name (RFC 0002 §3.1 specifies this exact panel title)
+      text: "Welcome to Exocortex",
+    });
+    contentEl.createEl("p", {
+      cls: "exocortex-onboarding-intro",
+      text:
+        "Let's get this vault set up in three steps. Run them in order — each " +
+        "opens a dialog; this panel stays open so you can come back to the next " +
+        "step. You can reopen this panel any time from the command palette.",
+    });
+
+    const steps: StepSpec[] = [
+      {
+        marker: "Step 1",
+        title: "Set up the engine",
+        description:
+          "Bootstrap this empty vault with the foundational exo AssetSpace — the " +
+          "engine floor. The dialog's fields start empty on purpose: enter the public " +
+          "floor repo (or your own fork). Leave the optional exocmd field blank for a " +
+          "knowledge-only vault.",
+        actionLabel: "Set up the engine",
+        action: this.actions.onSetupEngine,
+      },
+      {
+        marker: "Step 2",
+        title: "Add the starter content",
+        description:
+          "Pull the public starter registry — a curated set of AssetSpaces that gives " +
+          "you a ready-to-use Areas → Projects → Tasks structure. The recommended URL is " +
+          "pre-filled for you; just confirm.",
+        actionLabel: "Add the starter content",
+        action: this.actions.onAddStarter,
+      },
+      {
+        marker: "Step 3",
+        title: "Apply the starter profile",
+        description:
+          "Materialise the «starter» profile — it mounts the AssetSpaces the starter " +
+          "content needs. The picker opens narrowed to «starter»; select it to finish.",
+        actionLabel: "Apply the starter profile",
+        action: this.actions.onApplyStarterProfile,
+      },
+    ];
+
+    const list = contentEl.createEl("ol", {
+      cls: "exocortex-onboarding-steps",
+    });
+    list.setAttribute("aria-label", "Exocortex setup steps");
+
+    steps.forEach((step, index) => {
+      const item = list.createEl("li", { cls: "exocortex-onboarding-step" });
+
+      const header = item.createEl("div", {
+        cls: "exocortex-onboarding-step-header",
+      });
+      header.createEl("span", {
+        cls: "exocortex-onboarding-step-marker",
+        text: `${step.marker} — `,
+      });
+      header.createEl("span", {
+        cls: "exocortex-onboarding-step-title",
+        text: step.title,
+      });
+
+      item.createEl("p", {
+        cls: "exocortex-onboarding-step-desc",
+        text: step.description,
+      });
+
+      const button = item.createEl("button", {
+        cls: "mod-cta exocortex-onboarding-step-action",
+        text: step.actionLabel,
+      });
+      // Screen-reader label spells out the step number so the action is
+      // unambiguous out of visual context (P16).
+      button.setAttribute(
+        "aria-label",
+        `${step.marker}: ${step.actionLabel}`,
+      );
+      button.addEventListener("click", () => step.action());
+
+      if (index === 0) this.firstActionButton = button;
+    });
+
+    const footer = contentEl.createEl("div", {
+      cls: "modal-button-container exocortex-onboarding-footer",
+    });
+    const closeBtn = footer.createEl("button", {
+      cls: "exocortex-onboarding-close",
+      text: "Close",
+    });
+    closeBtn.setAttribute("aria-label", "Close the setup panel");
+    closeBtn.addEventListener("click", () => this.close());
+
+    // Managed focus (P16): land keyboard focus on the first actionable control
+    // so a keyboard / screen-reader user starts at step 1, not on the dialog
+    // container. Guarded — jsdom and headless contexts may lack focus support.
+    try {
+      this.firstActionButton?.focus();
+    } catch {
+      /* focus is best-effort */
+    }
+  }
+
+  override onClose(): void {
+    // Persist the one-time flag exactly once, regardless of close path
+    // (button / Esc / click-outside). Best-effort — a throw here must not leave
+    // the modal half-torn-down.
+    if (!this.closed) {
+      this.closed = true;
+      try {
+        this.actions.onClosePanel?.();
+      } catch {
+        /* persistence is best-effort; never block teardown */
+      }
+    }
+    this.contentEl.empty();
+  }
+}

--- a/packages/obsidian-plugin/styles.css
+++ b/packages/obsidian-plugin/styles.css
@@ -6147,6 +6147,54 @@
   display: block;
 }
 
+/* RFC 0002 §3.1 — first-run onboarding panel (3-step starter checklist). */
+.exocortex-onboarding-intro {
+  color: var(--text-muted, #6e7681);
+  margin-bottom: 1em;
+}
+
+.exocortex-onboarding-steps {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75em;
+}
+
+.exocortex-onboarding-step {
+  border: 1px solid var(--background-modifier-border, #ddd);
+  border-radius: var(--radius-m, 6px);
+  padding: 0.75em 1em;
+}
+
+.exocortex-onboarding-step-header {
+  margin-bottom: 0.25em;
+}
+
+.exocortex-onboarding-step-marker {
+  color: var(--text-accent, #7b6cd9);
+  font-weight: var(--font-semibold, 600);
+}
+
+.exocortex-onboarding-step-title {
+  font-weight: var(--font-semibold, 600);
+}
+
+.exocortex-onboarding-step-desc {
+  color: var(--text-muted, #6e7681);
+  font-size: var(--font-ui-smaller, 0.8em);
+  margin: 0 0 0.6em;
+}
+
+.exocortex-onboarding-step-action {
+  width: 100%;
+}
+
+.exocortex-onboarding-footer {
+  margin-top: 1em;
+}
+
 /* ExoSync (RFC 4e4dc453 Phase B) — invalid quarantine repo URL cue */
 .exocortex-invalid-input {
   border-color: var(--text-error) !important;

--- a/packages/obsidian-plugin/tests/unit/PluginLocalDataStore.test.ts
+++ b/packages/obsidian-plugin/tests/unit/PluginLocalDataStore.test.ts
@@ -243,3 +243,65 @@ describe("PluginLocalDataStore.migrateFromLegacyIfNeeded", () => {
     expect(store.getActiveProfileUid()).toBe("p-once");
   });
 });
+
+describe("PluginLocalDataStore — first-run onboarding flag (RFC 0002 §3.1)", () => {
+  it("defaults to false when absent", async () => {
+    const { app } = makeFakeApp();
+    const store = new PluginLocalDataStore({ app });
+    expect(await store.getOnboardingCompleted()).toBe(false);
+  });
+
+  it("set then read round-trips true", async () => {
+    const { app } = makeFakeApp();
+    const store = new PluginLocalDataStore({ app });
+    await store.setOnboardingCompleted(true);
+    expect(await store.getOnboardingCompleted()).toBe(true);
+  });
+
+  it("set false clears the flag", async () => {
+    const { app } = makeFakeApp();
+    const store = new PluginLocalDataStore({ app });
+    await store.setOnboardingCompleted(true);
+    await store.setOnboardingCompleted(false);
+    expect(await store.getOnboardingCompleted()).toBe(false);
+  });
+
+  it("only `true` reads as completed (defensive against truthy junk)", async () => {
+    const { app } = makeFakeApp({
+      [PATH]: JSON.stringify({ onboardingCompleted: "yes" }),
+    });
+    const store = new PluginLocalDataStore({ app });
+    expect(await store.getOnboardingCompleted()).toBe(false);
+  });
+
+  it("device-local: RMW preserves sibling keys (PAT, switch state)", async () => {
+    const { app, files } = makeFakeApp({
+      [PATH]: JSON.stringify({
+        pat: "ghp_secret",
+        activeProfileUid: "p-x",
+        _switchInProgress: true,
+      }),
+    });
+    const store = new PluginLocalDataStore({ app });
+    await store.setOnboardingCompleted(true);
+
+    const onDisk = JSON.parse(files.get(PATH) as string) as Record<
+      string,
+      unknown
+    >;
+    expect(onDisk.onboardingCompleted).toBe(true);
+    // Sibling keys untouched (read-modify-write).
+    expect(onDisk.pat).toBe("ghp_secret");
+    expect(onDisk.activeProfileUid).toBe("p-x");
+    expect(onDisk._switchInProgress).toBe(true);
+  });
+
+  it("a switch-state save() preserves the onboarding flag (disjoint namespace)", async () => {
+    const { app } = makeFakeApp();
+    const store = new PluginLocalDataStore({ app });
+    await store.setOnboardingCompleted(true);
+    // A later, unrelated switch-state write must not clobber the flag.
+    await store.save({ activeProfileUid: "p-y", _switchInProgress: false });
+    expect(await store.getOnboardingCompleted()).toBe(true);
+  });
+});

--- a/packages/obsidian-plugin/tests/unit/ProfileCommands.test.ts
+++ b/packages/obsidian-plugin/tests/unit/ProfileCommands.test.ts
@@ -47,7 +47,11 @@ interface Harness {
   switchMgr: FakeSwitchMgr;
   pushMgr: FakePushMgr;
   notices: string[];
-  pickCalls: { options: ProfileChoice[]; title: string }[];
+  pickCalls: {
+    options: ProfileChoice[];
+    title: string;
+    initialQuery?: string;
+  }[];
   fuzzyResult: ProfileChoice | null;
   activeFilePath: string | null;
   cmd: ProfileCommands;
@@ -68,7 +72,11 @@ function makeHarness(opts: {
       pushMgr.lookups.set(folder, uid);
   }
   const notices: string[] = [];
-  const pickCalls: { options: ProfileChoice[]; title: string }[] = [];
+  const pickCalls: {
+    options: ProfileChoice[];
+    title: string;
+    initialQuery?: string;
+  }[] = [];
   const deps: ProfileCommandsDeps = {
     switchMgr: switchMgr as unknown as ProfileApplyManager,
     pushMgr,
@@ -76,8 +84,8 @@ function makeHarness(opts: {
       if (opts.listError) throw opts.listError;
       return opts.profiles;
     },
-    fuzzyPick: async (options, title) => {
-      pickCalls.push({ options, title });
+    fuzzyPick: async (options, title, initialQuery) => {
+      pickCalls.push({ options, title, initialQuery });
       return opts.pickResult === undefined ? null : opts.pickResult;
     },
     getActiveFilePath: () => opts.activeFilePath ?? null,
@@ -285,6 +293,23 @@ describe("ProfileCommands.invokeApplyProfile (Apply profile)", () => {
     expect(h.pickCalls).toHaveLength(1);
     expect(h.pickCalls[0].options).toEqual(profiles);
     expect(h.pickCalls[0].title).toBe("Apply profile");
+    // No pre-narrowing when invoked normally (palette command).
+    expect(h.pickCalls[0].initialQuery).toBeUndefined();
+  });
+
+  it("forwards an initialQuery to the picker (onboarding §3.1 step 3 — «starter»)", async () => {
+    const profiles = [
+      { uid: "k1", label: "knowledge-one" },
+      { uid: "starter-uid", label: "starter" },
+    ];
+    const h = makeHarness({ profiles, pickResult: profiles[1] });
+    await h.cmd.invokeApplyProfile("starter");
+
+    expect(h.pickCalls).toHaveLength(1);
+    expect(h.pickCalls[0].initialQuery).toBe("starter");
+    // The full list is still passed — the query only pre-narrows.
+    expect(h.pickCalls[0].options).toEqual(profiles);
+    expect(h.switchMgr.applyCalls).toEqual(["starter-uid"]);
   });
 
   it("invokes applyProfile with the chosen uid", async () => {

--- a/packages/obsidian-plugin/tests/unit/ProfileFuzzyModal.test.ts
+++ b/packages/obsidian-plugin/tests/unit/ProfileFuzzyModal.test.ts
@@ -102,4 +102,31 @@ describe("ProfileFuzzyModal", () => {
     );
     expect(modal.inputEl.placeholder).toBe("Switch focus profile");
   });
+
+  // RFC 0002 §3.1 step 3 — the onboarding panel opens the picker narrowed to
+  // `starter`. onOpen sets the search input + fires `input` so Obsidian
+  // re-filters.
+  it("onOpen pre-narrows the picker to the initialQuery (onboarding «starter»)", () => {
+    const modal = new ProfileFuzzyModal(
+      fakeApp,
+      profiles,
+      "Apply profile",
+      () => {},
+      "starter",
+    );
+    let inputEvents = 0;
+    modal.inputEl.addEventListener("input", () => {
+      inputEvents++;
+    });
+    modal.onOpen();
+    expect(modal.inputEl.value).toBe("starter");
+    // A synthetic `input` event is dispatched so Obsidian re-filters.
+    expect(inputEvents).toBe(1);
+  });
+
+  it("onOpen leaves the input untouched when no initialQuery", () => {
+    const modal = new ProfileFuzzyModal(fakeApp, profiles, "Apply profile", () => {});
+    modal.onOpen();
+    expect(modal.inputEl.value).toBe("");
+  });
 });

--- a/packages/obsidian-plugin/tests/unit/firstRunOnboarding.test.ts
+++ b/packages/obsidian-plugin/tests/unit/firstRunOnboarding.test.ts
@@ -17,6 +17,7 @@ import {
   SETUP_COMMAND_ID,
   STARTER_REGISTRY_URL,
   STARTER_PROFILE_QUERY,
+  FRESH_VAULT_MAX_NOTES,
   type OnboardingCommandRegistrar,
 } from "../../src/infrastructure/adapters/firstRunOnboarding";
 import type { VaultBootstrapState } from "../../src/infrastructure/adapters/BootstrapAssetSpaceCommands";
@@ -45,20 +46,36 @@ describe("shouldShowFirstRunPanel — first-run detection (RFC 0002 §3.1)", () 
   const notBootstrapped: VaultBootstrapState[] = ["empty", "clone-needs-fetch"];
 
   it.each(notBootstrapped)(
-    "shows on a not-yet-bootstrapped vault (%s) when onboarding not completed",
+    "shows on a genuinely-fresh not-yet-bootstrapped vault (%s)",
     (state) => {
-      expect(shouldShowFirstRunPanel(state, false)).toBe(true);
+      // 0 notes (brand-new) and 1 note (stock Welcome.md) both count as fresh.
+      expect(shouldShowFirstRunPanel(state, false, 0)).toBe(true);
+      expect(shouldShowFirstRunPanel(state, false, FRESH_VAULT_MAX_NOTES)).toBe(
+        true,
+      );
     },
   );
 
-  it("does NOT show on a bootstrapped vault even when not completed", () => {
-    expect(shouldShowFirstRunPanel("bootstrapped", false)).toBe(false);
+  it("does NOT show on a bootstrapped vault even when fresh + not completed", () => {
+    expect(shouldShowFirstRunPanel("bootstrapped", false, 0)).toBe(false);
   });
 
-  it.each<VaultBootstrapState>(["empty", "clone-needs-fetch", "bootstrapped"])(
-    "never shows once onboarding is completed (state %s)",
+  it.each(notBootstrapped)(
+    "does NOT show on a content-rich not-bootstrapped vault (%s) — false-positive guard",
     (state) => {
-      expect(shouldShowFirstRunPanel(state, true)).toBe(false);
+      // The e2e test-vault scenario: many notes but no assetspaces/ →
+      // detectVaultState reports "empty", yet it is NOT a first-run vault.
+      expect(shouldShowFirstRunPanel(state, false, 162)).toBe(false);
+      expect(
+        shouldShowFirstRunPanel(state, false, FRESH_VAULT_MAX_NOTES + 1),
+      ).toBe(false);
+    },
+  );
+
+  it.each<VaultBootstrapState>(["empty", "clone-needs-fetch", "bootstrapped"])(
+    "never shows once onboarding is completed (state %s, even when fresh)",
+    (state) => {
+      expect(shouldShowFirstRunPanel(state, true, 0)).toBe(false);
     },
   );
 });

--- a/packages/obsidian-plugin/tests/unit/firstRunOnboarding.test.ts
+++ b/packages/obsidian-plugin/tests/unit/firstRunOnboarding.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Unit tests for the pure first-run onboarding logic (RFC 0002 §3.1/§3.2):
+ *   - `shouldShowFirstRunPanel` detection truth table (bootstrapped vs not,
+ *     completed vs not).
+ *   - the canonical starter-path constants.
+ *   - `registerOnboardingCommands` — the `Setup (Getting Started)` command
+ *     registers UNCONDITIONALLY (no Platform gate), so the panel is reachable on
+ *     both desktop and mobile (Desktop↔Mobile Command Parity).
+ *
+ * No `obsidian` import — this module is deliberately pure (see firstRunOnboarding.ts).
+ */
+import { describe, it, expect } from "@jest/globals";
+
+import {
+  shouldShowFirstRunPanel,
+  registerOnboardingCommands,
+  SETUP_COMMAND_ID,
+  STARTER_REGISTRY_URL,
+  STARTER_PROFILE_QUERY,
+  type OnboardingCommandRegistrar,
+} from "../../src/infrastructure/adapters/firstRunOnboarding";
+import type { VaultBootstrapState } from "../../src/infrastructure/adapters/BootstrapAssetSpaceCommands";
+
+interface RegisteredCommand {
+  id: string;
+  name: string;
+  callback: () => void;
+}
+
+function makeRegistrar(): {
+  plugin: OnboardingCommandRegistrar;
+  added: RegisteredCommand[];
+} {
+  const added: RegisteredCommand[] = [];
+  const plugin: OnboardingCommandRegistrar = {
+    addCommand: (command) => {
+      added.push(command);
+      return command;
+    },
+  };
+  return { plugin, added };
+}
+
+describe("shouldShowFirstRunPanel — first-run detection (RFC 0002 §3.1)", () => {
+  const notBootstrapped: VaultBootstrapState[] = ["empty", "clone-needs-fetch"];
+
+  it.each(notBootstrapped)(
+    "shows on a not-yet-bootstrapped vault (%s) when onboarding not completed",
+    (state) => {
+      expect(shouldShowFirstRunPanel(state, false)).toBe(true);
+    },
+  );
+
+  it("does NOT show on a bootstrapped vault even when not completed", () => {
+    expect(shouldShowFirstRunPanel("bootstrapped", false)).toBe(false);
+  });
+
+  it.each<VaultBootstrapState>(["empty", "clone-needs-fetch", "bootstrapped"])(
+    "never shows once onboarding is completed (state %s)",
+    (state) => {
+      expect(shouldShowFirstRunPanel(state, true)).toBe(false);
+    },
+  );
+});
+
+describe("starter-path constants", () => {
+  it("pre-fills the public starter registry (no EC7 conflict)", () => {
+    expect(STARTER_REGISTRY_URL).toBe(
+      "https://github.com/kitelev/exoas-starter-registry",
+    );
+  });
+
+  it("narrows the profile picker to the canonical starter profile", () => {
+    expect(STARTER_PROFILE_QUERY).toBe("starter");
+  });
+});
+
+describe("registerOnboardingCommands — Setup (Getting Started)", () => {
+  it("registers exactly one command with the stable id + plain-language name", () => {
+    const { plugin, added } = makeRegistrar();
+    registerOnboardingCommands(plugin, () => undefined);
+
+    expect(added).toHaveLength(1);
+    expect(added[0].id).toBe(SETUP_COMMAND_ID);
+    expect(added[0].id).toBe("setup-getting-started");
+    // Sentence case per the UI-text lint rule (RFC 0002 P3 de-jargon).
+    expect(added[0].name).toBe("Setup (getting started)");
+  });
+
+  it("the command callback opens the panel", () => {
+    const { plugin, added } = makeRegistrar();
+    let opened = 0;
+    registerOnboardingCommands(plugin, () => {
+      opened++;
+    });
+
+    expect(opened).toBe(0); // registration alone does not open
+    added[0].callback();
+    expect(opened).toBe(1);
+  });
+
+  it("registration is platform-independent — no Platform gate (Desktop↔Mobile parity)", () => {
+    // The function reads no Platform flag; calling it always yields the Setup
+    // command. This guards against a future regression that adds a desktop-only
+    // gate (the parity invariant the RFC's §3.9 DoD requires).
+    const desktop = makeRegistrar();
+    const mobile = makeRegistrar();
+    registerOnboardingCommands(desktop.plugin, () => undefined);
+    registerOnboardingCommands(mobile.plugin, () => undefined);
+
+    expect(desktop.added.map((c) => c.id)).toEqual([SETUP_COMMAND_ID]);
+    expect(mobile.added.map((c) => c.id)).toEqual([SETUP_COMMAND_ID]);
+  });
+});

--- a/packages/obsidian-plugin/tests/unit/infrastructure/adapters/BootstrapAssetSpaceCommands.test.ts
+++ b/packages/obsidian-plugin/tests/unit/infrastructure/adapters/BootstrapAssetSpaceCommands.test.ts
@@ -427,6 +427,22 @@ describe("BootstrapAssetSpaceCommands.invokeAddAssetSpace", () => {
     expect(h.puller.pullAssetSpace).not.toHaveBeenCalled();
     expect(h.notices.some((n) => /invalid URL/i.test(n))).toBe(true);
   });
+
+  // RFC 0002 §3.1 step 2 — the onboarding panel calls
+  // invokeAddAssetSpace(prefillUrl) so the modal opens with the recommended
+  // `exoas-starter-registry` URL pre-filled. The prefill must reach the prompt.
+  it("forwards prefillUrl to the prompt (onboarding §3.1 step 2)", async () => {
+    const REGISTRY = "https://github.com/kitelev/exoas-starter-registry";
+    const h = makeHarness({ isGitVault: true });
+    await h.cmds.invokeAddAssetSpace(REGISTRY);
+    expect(h.deps.promptAddAssetSpaceUrl).toHaveBeenCalledWith(REGISTRY);
+  });
+
+  it("no prefill → prompt called with undefined (unchanged palette path)", async () => {
+    const h = makeHarness({ isGitVault: true });
+    await h.cmds.invokeAddAssetSpace();
+    expect(h.deps.promptAddAssetSpaceUrl).toHaveBeenCalledWith(undefined);
+  });
 });
 
 describe("BootstrapAssetSpaceCommands — lazy per-invocation puller (Issue #3382)", () => {

--- a/packages/obsidian-plugin/tests/unit/presentation/modals/BootstrapModals.test.ts
+++ b/packages/obsidian-plugin/tests/unit/presentation/modals/BootstrapModals.test.ts
@@ -275,6 +275,43 @@ describe("AddAssetSpaceModal", () => {
     expect(result).toEqual({ url: "https://github.com/me/thing" });
   });
 
+  it("initialUrl pre-fills the field + live-previews it (onboarding §3.1 step 2)", () => {
+    const REGISTRY = "https://github.com/kitelev/exoas-starter-registry";
+    new AddAssetSpaceModal(fakeApp, derive, () => undefined, REGISTRY).open();
+    const input = document.querySelector("input") as HTMLInputElement;
+    // The recommended registry URL is pre-filled; the user still confirms.
+    expect(input.value).toBe(REGISTRY);
+    // Preview reflects the pre-filled value immediately (not a placeholder hint).
+    const preview = document.querySelector(
+      ".add-assetspace-preview",
+    ) as HTMLElement;
+    expect(preview.classList.contains("is-placeholder")).toBe(false);
+    expect(preview.textContent).toMatch(
+      /Target folder: assetspaces\/kitelev\/exoas-starter-registry/,
+    );
+  });
+
+  it("pre-filled URL → Add resolves it without retyping", () => {
+    const REGISTRY = "https://github.com/kitelev/exoas-starter-registry";
+    let result: { url: string } | null | undefined;
+    new AddAssetSpaceModal(
+      fakeApp,
+      derive,
+      (r) => {
+        result = r;
+      },
+      REGISTRY,
+    ).open();
+    findButton("Add")!.click();
+    expect(result).toEqual({ url: REGISTRY });
+  });
+
+  it("no initialUrl → field starts empty (unchanged default)", () => {
+    new AddAssetSpaceModal(fakeApp, derive, () => undefined).open();
+    const input = document.querySelector("input") as HTMLInputElement;
+    expect(input.value).toBe("");
+  });
+
   it("invalid URL → error, no resolve", () => {
     let result: unknown = "sentinel";
     new AddAssetSpaceModal(fakeApp, derive, (r) => {

--- a/packages/obsidian-plugin/tests/unit/presentation/modals/FirstRunOnboardingModal.test.ts
+++ b/packages/obsidian-plugin/tests/unit/presentation/modals/FirstRunOnboardingModal.test.ts
@@ -1,0 +1,198 @@
+/**
+ * Unit tests for the RFC 0002 §3.1 first-run onboarding panel.
+ *
+ * Local `jest.mock("obsidian")` provides a Modal that mounts `contentEl` into
+ * `document.body` on `open()`, plus `addClass` and a recursive `createEl` that
+ * copies the attributes the panel relies on (cls / text), so DOM queries,
+ * `addEventListener`, `setAttribute`, and `focus()` behave like real Obsidian.
+ */
+import { describe, it, expect, beforeEach, jest } from "@jest/globals";
+
+jest.mock("obsidian", () => {
+  interface CreateOpts {
+    cls?: string;
+    text?: string;
+  }
+  function augment(el: HTMLElement): void {
+    (
+      el as unknown as { createEl: (tag: string, o?: CreateOpts) => HTMLElement }
+    ).createEl = function (tag: string, o?: CreateOpts): HTMLElement {
+      const child = document.createElement(tag);
+      if (o?.cls) child.className = o.cls;
+      if (o?.text) child.textContent = o.text;
+      this.appendChild(child);
+      augment(child);
+      return child;
+    }.bind(el);
+    (el as unknown as { addClass: (c: string) => void }).addClass = function (
+      c: string,
+    ): void {
+      this.classList.add(c);
+    }.bind(el);
+    (el as unknown as { empty: () => void }).empty = function (): void {
+      while (this.firstChild) this.removeChild(this.firstChild);
+    }.bind(el);
+  }
+  class MockModal {
+    app: unknown;
+    contentEl: HTMLElement;
+    constructor(app: unknown) {
+      this.app = app;
+      this.contentEl = document.createElement("div");
+      augment(this.contentEl);
+    }
+    open(): void {
+      document.body.appendChild(this.contentEl);
+      this.onOpen();
+    }
+    close(): void {
+      this.onClose();
+      if (this.contentEl.parentNode) {
+        this.contentEl.parentNode.removeChild(this.contentEl);
+      }
+    }
+    onOpen(): void {}
+    onClose(): void {}
+  }
+  return { Modal: MockModal, App: class {} };
+});
+
+import type { App } from "obsidian";
+import {
+  FirstRunOnboardingModal,
+  type FirstRunOnboardingActions,
+} from "../../../../src/presentation/modals/FirstRunOnboardingModal";
+
+const fakeApp = {} as unknown as App;
+
+function makeActions(
+  over: Partial<FirstRunOnboardingActions> = {},
+): { actions: FirstRunOnboardingActions; calls: string[] } {
+  const calls: string[] = [];
+  const actions: FirstRunOnboardingActions = {
+    onSetupEngine: () => calls.push("engine"),
+    onAddStarter: () => calls.push("starter"),
+    onApplyStarterProfile: () => calls.push("profile"),
+    onClosePanel: () => calls.push("close"),
+    ...over,
+  };
+  return { actions, calls };
+}
+
+function findButton(label: string): HTMLButtonElement | undefined {
+  return Array.from(document.querySelectorAll("button")).find(
+    (b) => b.textContent === label,
+  );
+}
+
+beforeEach(() => {
+  document.body.innerHTML = "";
+});
+
+describe("FirstRunOnboardingModal", () => {
+  it("renders the welcome heading + a 3-step ordered checklist", () => {
+    const { actions } = makeActions();
+    new FirstRunOnboardingModal(fakeApp, actions).open();
+
+    expect(
+      document.querySelector(".exocortex-onboarding-title")?.textContent,
+    ).toBe("Welcome to Exocortex");
+
+    const list = document.querySelector("ol.exocortex-onboarding-steps");
+    expect(list).not.toBeNull();
+    const items = document.querySelectorAll("li.exocortex-onboarding-step");
+    expect(items).toHaveLength(3);
+
+    // Each step has a plain-text marker (not a glyph) — P16.
+    const markers = Array.from(
+      document.querySelectorAll(".exocortex-onboarding-step-marker"),
+    ).map((m) => m.textContent);
+    expect(markers).toEqual(["Step 1 — ", "Step 2 — ", "Step 3 — "]);
+  });
+
+  it("step 1 button fires onSetupEngine (opens Bootstrap)", () => {
+    const { actions, calls } = makeActions();
+    new FirstRunOnboardingModal(fakeApp, actions).open();
+    findButton("Set up the engine")!.click();
+    expect(calls).toEqual(["engine"]);
+  });
+
+  it("step 2 button fires onAddStarter (Add starter content)", () => {
+    const { actions, calls } = makeActions();
+    new FirstRunOnboardingModal(fakeApp, actions).open();
+    findButton("Add the starter content")!.click();
+    expect(calls).toEqual(["starter"]);
+  });
+
+  it("step 3 button fires onApplyStarterProfile (Apply starter profile)", () => {
+    const { actions, calls } = makeActions();
+    new FirstRunOnboardingModal(fakeApp, actions).open();
+    findButton("Apply the starter profile")!.click();
+    expect(calls).toEqual(["profile"]);
+  });
+
+  it("each step action is a keyboard-navigable button with an aria-label (P16)", () => {
+    const { actions } = makeActions();
+    new FirstRunOnboardingModal(fakeApp, actions).open();
+    const actionButtons = Array.from(
+      document.querySelectorAll("button.exocortex-onboarding-step-action"),
+    ) as HTMLButtonElement[];
+    expect(actionButtons).toHaveLength(3);
+    expect(actionButtons.map((b) => b.getAttribute("aria-label"))).toEqual([
+      "Step 1: Set up the engine",
+      "Step 2: Add the starter content",
+      "Step 3: Apply the starter profile",
+    ]);
+  });
+
+  it("manages focus — the first action button is focused on open (P16)", () => {
+    const { actions } = makeActions();
+    new FirstRunOnboardingModal(fakeApp, actions).open();
+    expect(document.activeElement).toBe(findButton("Set up the engine"));
+  });
+
+  it("clicking a step does NOT close the panel (sub-dialogs stack on top)", () => {
+    const { actions, calls } = makeActions();
+    new FirstRunOnboardingModal(fakeApp, actions).open();
+    findButton("Add the starter content")!.click();
+    // No close persisted yet — the panel stays open underneath the sub-dialog.
+    expect(calls).toEqual(["starter"]);
+    expect(document.querySelector("ol.exocortex-onboarding-steps")).not.toBeNull();
+  });
+
+  it("persists the one-time flag exactly once on close", () => {
+    const { actions, calls } = makeActions();
+    const modal = new FirstRunOnboardingModal(fakeApp, actions);
+    modal.open();
+    modal.close();
+    expect(calls).toEqual(["close"]);
+    // Idempotent — a second close (Obsidian can double-fire) does not re-persist.
+    modal.close();
+    expect(calls).toEqual(["close"]);
+  });
+
+  it("the explicit Close button closes the panel and persists the flag", () => {
+    const { actions, calls } = makeActions();
+    new FirstRunOnboardingModal(fakeApp, actions).open();
+    findButton("Close")!.click();
+    expect(calls).toEqual(["close"]);
+  });
+
+  it("a throwing onClosePanel never breaks teardown", () => {
+    const { actions } = makeActions({
+      onClosePanel: () => {
+        throw new Error("disk full");
+      },
+    });
+    const modal = new FirstRunOnboardingModal(fakeApp, actions);
+    modal.open();
+    expect(() => modal.close()).not.toThrow();
+  });
+
+  it("works without an onClosePanel callback (optional)", () => {
+    const { actions } = makeActions({ onClosePanel: undefined });
+    const modal = new FirstRunOnboardingModal(fakeApp, actions);
+    modal.open();
+    expect(() => modal.close()).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary

Implements **RFC 0002 §3.1** (+ the minimal `Setup` command from §3.2 bullet 1) — the first-run onboarding panel. On plugin enable in a **not-yet-bootstrapped** vault, a one-time **"Welcome to Exocortex"** panel walks the new tester through the canonical **starter** path.

**Resolves:** **P1** (first-run empty-state has zero orientation) + **P2** (the Bootstrap→Add→Apply sequence is not discoverable in the palette).

### The 3-step panel
1. **Set up the engine** → opens the Bootstrap dialog. Fields stay **empty per EC7** (the `kitelev/exoas-*` repos are Andrey's own ontology, not a generic floor); the panel supplies the in-context guidance instead.
2. **Add the starter content** → opens `Add assetspace by URL` **pre-filled** with the public, stable **`exoas-starter-registry`** URL (genuinely recommended for everyone — no EC7 conflict). The user still confirms.
3. **Apply the starter profile** → opens the profile picker **narrowed to `starter`**.

Re-openable via the new **`Exocortex: Setup (getting started)`** command — the re-entry point the panel depends on (§3.2 bullet 1). A device-local `onboardingCompleted` flag (`data.local.json`) makes the panel genuinely one-time (auto-shows once; always reachable via the command).

### Scope
- **In scope:** §3.1 panel + **only** the minimal `Setup` command (it ships *with* the panel per RFC §3.2 bullet 1).
- **Out of scope (deliberately):** the full §3.2 (command renames / destructive-flagging), §3.3–§3.11. Separate tasks.

## Invariants honored
- **Desktop↔Mobile Command Parity:** the `Setup` command registers **unconditionally** (no `Platform.isMobile` gate — guarded by a dedicated test). First-run detection (`detectVaultState`) and all three step actions route through the cross-platform `vault.adapter` / REST flows that already run on mobile, so the panel works on both platforms. Verified mobile-loadable (`assert-mobile-loadable.mjs` green; no Node imports; archgate MOBILE-001/002/003 pass).
- **A11y (P16):** semantic `<ol>` checklist, native keyboard-navigable `<button>`s with `aria-label`s, **managed focus** (first action focused on open), plain-text step markers (`Step 1 —`, never a glyph-only marker).
- **Homoiconicity:** the panel is a thin UI scaffold; step actions reuse the existing Bootstrap / Add-AssetSpace / Apply-profile flows (no logic duplicated).

## Implementation
| File | Change |
|---|---|
| `infrastructure/adapters/firstRunOnboarding.ts` *(new)* | Pure detection predicate (`shouldShowFirstRunPanel`) + starter-path constants + `registerOnboardingCommands` helper (no `obsidian` import → unit-testable). |
| `presentation/modals/FirstRunOnboardingModal.ts` *(new)* | The panel. |
| `presentation/modals/AddAssetSpaceModal.ts` | Optional `initialUrl` prefill. |
| `infrastructure/adapters/BootstrapAssetSpaceCommands.ts` | `invokeAddAssetSpace(prefillUrl?)` threads the prefill to the prompt. |
| `infrastructure/adapters/ProfileFuzzyModal.ts` | Optional `initialQuery` — pre-narrows the picker in `onOpen`. |
| `infrastructure/adapters/ProfileCommands.ts` | `invokeApplyProfile(initialQuery?)` forwards to `fuzzyPick`. |
| `infrastructure/adapters/PluginLocalDataStore.ts` | Device-local `get/setOnboardingCompleted` (RMW-preserving). |
| `ExocortexPlugin.ts` | `registerOnboardingPanel` + `maybeShowFirstRunPanel` wiring (auto-show deferred to `onLayoutReady`, best-effort). |
| `styles.css` | Panel styles. |

## Tests (production-shape, all layers)
- Pure detection truth table + parity (no-Platform-gate) registration.
- Panel: renders 3-step checklist, each button fires the right action, aria-labels, managed focus, one-time close persistence, throwing-callback safety.
- `data.local.json` round-trip + RMW preserves sibling keys (PAT / switch state).
- Prefill threading (Add) + preselect threading (Apply) — both forward + default-undefined paths.
- 236 affected tests green locally; `npm run check:types` + `npm run lint` + `npm run build` (incl. mobile-loadable) green.

## Follow-up
- ⏭ **Recommend a `computer-control` visual smoke** of the panel in live Obsidian (managed-focus / keyboard nav / step sub-dialog stacking) — not run here (needs supervision); shipped on unit + CI + code-review. §3.9 mobile-parity verification of this panel is a separate task.

Each shipped item links back to its pain point (P1/P2) per RFC §7.