### PR TITLE
feat(onboarding): mobile onboarding parity contract + arch-gate (RFC 0002 §3.9)

### DIFF
--- a/.archgate/adrs/MOBILE-004-no-desktop-only-gated-addcommand.md
+++ b/.archgate/adrs/MOBILE-004-no-desktop-only-gated-addcommand.md
@@ -1,0 +1,72 @@
+---
+id: MOBILE-004
+title: No desktop-only-gated addCommand registration
+domain: frontend
+rules: true
+files:
+  [
+    "packages/obsidian-plugin/src/**/*.ts",
+    "packages/obsidian-plugin/src/**/*.tsx",
+  ]
+---
+
+# No Desktop-Only-Gated `addCommand` Registration
+
+## Context
+
+The **Desktop↔Mobile Command Parity** invariant (Developer/CLAUDE.md, user
+directive 2026-06-14): _EVERY plugin command must work on BOTH desktop and
+iPhone/mobile._ A command whose `addCommand(...)` is reachable only when the
+platform is NOT mobile — a desktop-only gate — is a **parity violation**:
+mobile users can never invoke it.
+
+On mobile there is no Node `fs` / git binary, so the correct shape routes the
+command's heavy work through the cross-platform `vault.adapter` / REST path
+(`RestAssetSpaceMount`, RFC `01a83de8`; first applied in #3535) and registers
+the command **unconditionally** — or on a condition that ALSO admits a positive
+mobile branch.
+
+This sits alongside the mobile-load cluster — #3464 module-eval imports
+(MOBILE-001), #3469 runtime `process` access (MOBILE-002), #3486 runtime
+`Buffer` access (MOBILE-003) — but covers a distinct failure mode: the bundle
+loads fine and the command is simply **absent** from the mobile palette. It is
+a preventive guard for RFC 0002 §3.9 (P14, mobile onboarding parity): the
+onboarding panel + `Setup` command and the Bootstrap / Add / Apply / Sync
+commands already register on both platforms; this rule keeps future commands
+from silently regressing the invariant.
+
+## Decision
+
+- An `addCommand(...)` registration that is lexically gated **desktop-only** is
+  FORBIDDEN in `packages/obsidian-plugin/src/**`. Canonical anti-patterns:
+
+  ```ts
+  if (!Platform.isMobile) { this.addCommand({...}); }   // block guard
+  if (Platform.isDesktopApp) plugin.addCommand({...});  // single-statement
+  ```
+
+- The **parity pattern** is explicitly allowed — its condition admits a
+  positive (non-negated) mobile branch, so the command registers on desktop OR
+  mobile:
+
+  ```ts
+  if (applyDeps !== null || (Platform.isMobile && restMount !== null)) {
+    this.addCommand({...});
+  }
+  ```
+
+- A genuinely desktop-only capability with no mobile analogue must still
+  register the command on both platforms and surface a clear "not available on
+  mobile" notice from the callback — never gate the registration away.
+
+## Detection
+
+Implemented in `.archgate/lint/desktopOnlyCommandGate.ts`, shared verbatim with
+the jest revert-verify test
+`packages/obsidian-plugin/tests/unit/desktopOnlyCommandGate.test.ts` (no drift
+between the gate and its test). Line/brace based, with the same documented
+heuristic trade-offs as MOBILE-001/002/003 (braces inside string literals can
+desync depth; data-flow gating via an intermediate `Platform.isMobile ? null`
+deps variable is not tracked — only a lexically-enclosing desktop-only `if`
+guard is). Scope is `packages/obsidian-plugin/src` — the only place a `Plugin`
+instance (and thus `Plugin.addCommand`) exists.

--- a/.archgate/adrs/MOBILE-004-no-desktop-only-gated-addcommand.md
+++ b/.archgate/adrs/MOBILE-004-no-desktop-only-gated-addcommand.md
@@ -65,8 +65,21 @@ Implemented in `.archgate/lint/desktopOnlyCommandGate.ts`, shared verbatim with
 the jest revert-verify test
 `packages/obsidian-plugin/tests/unit/desktopOnlyCommandGate.test.ts` (no drift
 between the gate and its test). Line/brace based, with the same documented
-heuristic trade-offs as MOBILE-001/002/003 (braces inside string literals can
-desync depth; data-flow gating via an intermediate `Platform.isMobile ? null`
-deps variable is not tracked — only a lexically-enclosing desktop-only `if`
-guard is). Scope is `packages/obsidian-plugin/src` — the only place a `Plugin`
-instance (and thus `Plugin.addCommand`) exists.
+heuristic trade-offs as MOBILE-001/002/003. Caught forms: a same-line braced
+block (`if (!Platform.isMobile) { addCommand(...) }`), an Allman-brace block,
+a brace-less single statement, and a same-line single statement.
+
+Defense-in-depth for the **likeliest** regression (literally wrapping
+`addCommand` in an `if (!Platform.isMobile)`). These desktop-only-gating shapes
+are NOT caught (honest false-negative boundary):
+
+- **data-flow gating** — `const deps = Platform.isMobile ? null : build();` then
+  `if (deps !== null) addCommand(...)` (no lexical Platform guard around the
+  registration);
+- **early-return guard** — `if (Platform.isMobile) return;` before `addCommand`;
+- **else-branch** — `if (Platform.isMobile) {...} else { addCommand(...) }`;
+- a **multi-line** `if (...)` condition (parens not balanced on one line);
+- braces inside string/regex literals can desync the depth counter.
+
+Scope is `packages/obsidian-plugin/src` — the only place a `Plugin` instance
+(and thus `Plugin.addCommand`) exists.

--- a/.archgate/adrs/MOBILE-004-no-desktop-only-gated-addcommand.rules.ts
+++ b/.archgate/adrs/MOBILE-004-no-desktop-only-gated-addcommand.rules.ts
@@ -1,0 +1,69 @@
+/// <reference path="../rules.d.ts" />
+
+import { findDesktopOnlyGatedAddCommands } from "../lint/desktopOnlyCommandGate";
+
+// MOBILE-004 — ban desktop-only-gated `addCommand` registration.
+//
+// Desktop↔Mobile Command Parity invariant (Developer/CLAUDE.md): EVERY plugin
+// command must work on both desktop AND iPhone/mobile. A command whose
+// `addCommand(...)` is reachable only when NOT on mobile — a desktop-only gate —
+// is a parity VIOLATION: mobile users can never invoke it. On mobile there is no
+// Node `fs`/git binary, so the correct shape routes the command through the
+// cross-platform `vault.adapter` / REST path and registers UNCONDITIONALLY (or
+// on a condition that ALSO admits a positive mobile branch).
+//
+// Canonical anti-patterns flagged:
+//   if (!Platform.isMobile) { this.addCommand({...}); }   // block guard
+//   if (Platform.isDesktopApp) plugin.addCommand({...});  // single-statement
+//
+// The PARITY pattern is NOT flagged — its condition admits a positive mobile
+// branch (registers on desktop OR mobile):
+//   if (applyDeps !== null || (Platform.isMobile && restMount !== null)) {
+//     this.addCommand({...});
+//   }
+//
+// Detection lives in `../lint/desktopOnlyCommandGate.ts` (shared verbatim with
+// the jest revert-verify test
+// `packages/obsidian-plugin/tests/unit/desktopOnlyCommandGate.test.ts` — no
+// drift between gate and test). Line/brace based, same documented heuristic
+// trade-offs as the MOBILE-001/002/003 sibling rules.
+//
+// Scope: packages/obsidian-plugin/src — the only place Obsidian's
+// `Plugin.addCommand` is callable (a `Plugin` instance exists only there).
+// Core/services `addCommand` mentions are JSDoc prose, not registrations.
+
+export default {
+  rules: {
+    "no-desktop-only-gated-addcommand": {
+      description:
+        "Plugin commands gated desktop-only (e.g. `if (!Platform.isMobile)`) never register on iPhone/mobile — violates the Desktop↔Mobile Command Parity invariant.",
+      severity: "error",
+      async check(ctx) {
+        const files = [
+          ...(await ctx.glob("packages/obsidian-plugin/src/**/*.{ts,tsx}")),
+        ];
+        for (const file of files) {
+          // Cheap pre-filter: only files that both register a command AND carry
+          // a desktop platform check can possibly violate.
+          const addHits = await ctx.grep(file, /\baddCommand\s*\(/);
+          if (addHits.length === 0) continue;
+          const platformHits = await ctx.grep(
+            file,
+            /Platform\s*\.\s*(isMobile|isDesktop)/,
+          );
+          if (platformHits.length === 0) continue;
+
+          const content = await ctx.readFile(file);
+          for (const hit of findDesktopOnlyGatedAddCommands(content)) {
+            ctx.report.violation({
+              message: `Desktop-only-gated \`addCommand\` (${hit.reason}) — this command never registers on iPhone/mobile, violating the Desktop↔Mobile Command Parity invariant (Developer/CLAUDE.md): \`${hit.snippet}\``,
+              file,
+              line: hit.line,
+              fix: "Register the command UNCONDITIONALLY (or gate on a condition that ALSO admits a positive mobile branch, e.g. `applyDeps !== null || (Platform.isMobile && restMount !== null)`), routing the mobile path through the git-free RestAssetSpaceMount / vault.adapter flow.",
+            });
+          }
+        }
+      },
+    },
+  },
+} satisfies RuleSet;

--- a/.archgate/lint/desktopOnlyCommandGate.ts
+++ b/.archgate/lint/desktopOnlyCommandGate.ts
@@ -15,11 +15,14 @@
  * Every plugin command must register on BOTH desktop and mobile. A command
  * whose `addCommand(...)` is reachable only when NOT on mobile (a desktop-only
  * gate) is a parity violation — mobile/iPhone users can never invoke it. The
- * canonical anti-patterns:
+ * caught anti-patterns:
  *
- *   if (!Platform.isMobile) { this.addCommand({...}); }   // block guard
- *   if (Platform.isDesktopApp) plugin.addCommand({...});  // single-statement
- *   if (!Platform.isMobile) this.addCommand({...});        // single-statement
+ *   if (!Platform.isMobile) { this.addCommand({...}); }   // braced block guard
+ *   if (Platform.isDesktopApp) plugin.addCommand({...});  // same-line statement
+ *   if (!Platform.isMobile)                                // Allman-brace block
+ *   { this.addCommand({...}); }
+ *   if (!Platform.isMobile)                                // no-brace single stmt
+ *     this.addCommand({...});
  *
  * The PARITY pattern — which registers on both platforms — is explicitly NOT
  * flagged, because its condition admits a positive (non-negated) mobile branch:
@@ -35,10 +38,14 @@
  *    is only ever opened by an `if (...)` whose condition is desktop-only, which
  *    is rare, so a stray string brace elsewhere cannot conjure a false guard.
  *  - A `//` sequence inside a string literal truncates the scanned line.
- *  - Data-flow gating (e.g. `const deps = Platform.isMobile ? null : build();`
- *    then `if (deps !== null) addCommand(...)`) is NOT tracked — only a
- *    lexically-enclosing desktop-only `if` guard is. The likeliest regression
- *    (literally wrapping `addCommand` in `if (!Platform.isMobile)`) IS caught.
+ *  - These desktop-only-gating shapes are NOT caught (documented false
+ *    negatives — the gate is defense-in-depth for the LIKELIEST regression,
+ *    literally wrapping `addCommand` in an `if (!Platform.isMobile)`):
+ *      · data-flow gating — `const deps = Platform.isMobile ? null : build();`
+ *        then `if (deps !== null) addCommand(...)` (no lexical Platform guard);
+ *      · early-return guard — `if (Platform.isMobile) return;` then addCommand;
+ *      · else-branch — `if (Platform.isMobile) {...} else { addCommand(...) }`;
+ *      · a multi-LINE `if (...)` condition (parens not balanced on one line).
  */
 
 export interface DesktopOnlyGateHit {
@@ -111,11 +118,15 @@ export function findDesktopOnlyGatedAddCommands(
   const hits: DesktopOnlyGateHit[] = [];
   // Brace depths at which an active desktop-only guard block was opened.
   const guardStartDepths: number[] = [];
+  // Set after a brace-less desktop-only `if (cond)` line: the guard applies to
+  // the next meaningful line (an Allman `{` block, or a single statement).
+  let pendingDesktopOnlyIf = false;
   let depth = 0;
 
   for (let i = 0; i < lines.length; i++) {
     const raw = lines[i];
     const trimmed = raw.trimStart();
+    const isBlank = trimmed.length === 0;
     const isComment =
       trimmed.startsWith("*") ||
       trimmed.startsWith("//") ||
@@ -131,9 +142,35 @@ export function findDesktopOnlyGatedAddCommands(
       guardStartDepths.pop();
     }
 
-    if (!isComment) {
-      const hasAdd = ADDCOMMAND.test(code);
+    // Blank / comment lines never resolve a pending guard or carry detection,
+    // but DO still feed brace counting (a `}` in a comment is rare; consistent
+    // with the documented heuristic).
+    if (isBlank || isComment) {
+      const o = (code.match(/\{/g) || []).length;
+      const c = (code.match(/\}/g) || []).length;
+      depth += o - c;
+      continue;
+    }
 
+    let resolvedPending = false;
+    if (pendingDesktopOnlyIf) {
+      pendingDesktopOnlyIf = false;
+      resolvedPending = true;
+      if (trimmed.startsWith("{")) {
+        // Allman-brace block opened by the previous desktop-only `if`.
+        guardStartDepths.push(depth);
+      } else if (ADDCOMMAND.test(code)) {
+        // Brace-less single statement guarded desktop-only.
+        hits.push({
+          line: i + 1,
+          reason: "addCommand gated desktop-only by a brace-less `if`",
+          snippet: trimmed.slice(0, 120),
+        });
+      }
+    }
+
+    if (!resolvedPending) {
+      const hasAdd = ADDCOMMAND.test(code);
       if (hasAdd) {
         if (guardStartDepths.length > 0) {
           // Inside an active desktop-only guard block.
@@ -155,12 +192,15 @@ export function findDesktopOnlyGatedAddCommands(
           }
         }
       } else {
-        // Detect a desktop-only block guard opening on this line:
-        //   if (<desktop-only-cond>) {
-        if (code.includes("{")) {
-          const cond = extractIfCondition(code);
-          if (cond !== null && isDesktopOnlyCondition(cond)) {
+        const cond = extractIfCondition(code);
+        if (cond !== null && isDesktopOnlyCondition(cond)) {
+          if (code.includes("{")) {
+            // Same-line braced block guard: `if (<desktop-only-cond>) {`.
             guardStartDepths.push(depth);
+          } else {
+            // Brace-less desktop-only `if` — the guard applies to the NEXT
+            // meaningful line (Allman block or single statement).
+            pendingDesktopOnlyIf = true;
           }
         }
       }

--- a/.archgate/lint/desktopOnlyCommandGate.ts
+++ b/.archgate/lint/desktopOnlyCommandGate.ts
@@ -1,0 +1,177 @@
+/**
+ * desktopOnlyCommandGate — shared scanner for the MOBILE-004 ADR rule
+ * (no desktop-only-gated `addCommand`) and its jest revert-verify test.
+ *
+ * Single source of truth so the archgate rule (the real CI gate, in
+ * `../adrs/MOBILE-004-no-desktop-only-gated-addcommand.rules.ts`) and the
+ * jest unit test (`packages/obsidian-plugin/tests/unit/desktopOnlyCommandGate.test.ts`)
+ * exercise the EXACT same detection logic — no drift between the gate and
+ * its test. Lives under `.archgate/lint/` (archgate's designated home for
+ * governance helpers) and is dependency-free so both consumers can import it
+ * by relative path without pulling in path aliases or the `obsidian` runtime.
+ *
+ * ## What it enforces (Desktop↔Mobile Command Parity invariant)
+ *
+ * Every plugin command must register on BOTH desktop and mobile. A command
+ * whose `addCommand(...)` is reachable only when NOT on mobile (a desktop-only
+ * gate) is a parity violation — mobile/iPhone users can never invoke it. The
+ * canonical anti-patterns:
+ *
+ *   if (!Platform.isMobile) { this.addCommand({...}); }   // block guard
+ *   if (Platform.isDesktopApp) plugin.addCommand({...});  // single-statement
+ *   if (!Platform.isMobile) this.addCommand({...});        // single-statement
+ *
+ * The PARITY pattern — which registers on both platforms — is explicitly NOT
+ * flagged, because its condition admits a positive (non-negated) mobile branch:
+ *
+ *   if (applyDeps !== null || (Platform.isMobile && restMount !== null)) {
+ *     this.addCommand({...});   // registers on desktop (applyDeps) OR mobile (restMount)
+ *   }
+ *
+ * ## Heuristic limitations (line/brace based — same trade-off as MOBILE-001/002/003)
+ *
+ *  - Brace depth is counted from `{`/`}` occurrences; braces inside string or
+ *    regex literals can desync the depth. The impact is bounded: a guard frame
+ *    is only ever opened by an `if (...)` whose condition is desktop-only, which
+ *    is rare, so a stray string brace elsewhere cannot conjure a false guard.
+ *  - A `//` sequence inside a string literal truncates the scanned line.
+ *  - Data-flow gating (e.g. `const deps = Platform.isMobile ? null : build();`
+ *    then `if (deps !== null) addCommand(...)`) is NOT tracked — only a
+ *    lexically-enclosing desktop-only `if` guard is. The likeliest regression
+ *    (literally wrapping `addCommand` in `if (!Platform.isMobile)`) IS caught.
+ */
+
+export interface DesktopOnlyGateHit {
+  /** 1-based line number of the offending `addCommand(` call. */
+  line: number;
+  /** Why it was flagged (block guard vs same-line gate). */
+  reason: string;
+  /** Trimmed source snippet (≤120 chars) for the violation message. */
+  snippet: string;
+}
+
+/**
+ * Desktop-only trigger tokens: a negated mobile check, or an explicit desktop
+ * check. `Platform.isDesktop\b` does not match `Platform.isDesktopApp` (the
+ * `\b` fails before `App`), so both are listed.
+ */
+const DESKTOP_TRIGGER =
+  /!\s*Platform\s*\.\s*isMobile|Platform\s*\.\s*isDesktopApp\b|Platform\s*\.\s*isDesktop\b/;
+
+/** `addCommand(` not preceded by an identifier char (so `myAddCommand(` is ignored). */
+const ADDCOMMAND = /(?<![\w$])addCommand\s*\(/;
+
+/**
+ * True when an `if` condition gates code DESKTOP-ONLY — it triggers on a
+ * desktop token AND does not also admit a positive (non-negated) mobile branch.
+ * Stripping every `!Platform.isMobile` occurrence and re-checking for a
+ * remaining `Platform.isMobile` is how the parity pattern (which keeps a
+ * positive `Platform.isMobile && restMount` disjunct) escapes the gate.
+ */
+export function isDesktopOnlyCondition(condition: string): boolean {
+  if (!DESKTOP_TRIGGER.test(condition)) return false;
+  const withoutNegated = condition.replace(/!\s*Platform\s*\.\s*isMobile/g, "");
+  // A surviving positive `Platform.isMobile` means the condition adds a mobile
+  // path → parity-correct, not desktop-only.
+  if (/Platform\s*\.\s*isMobile/.test(withoutNegated)) return false;
+  return true;
+}
+
+/**
+ * Extract the condition of the FIRST top-level `if (...)` on a line, balancing
+ * nested parens so `if (a || (b && c))` yields `a || (b && c)`, not `a || (b && c`.
+ * Returns null when the line has no `if (` or the parens never close on it.
+ */
+function extractIfCondition(code: string): string | null {
+  const m = code.match(/\bif\s*\(/);
+  if (m === null || m.index === undefined) return null;
+  let i = m.index + m[0].length;
+  let depth = 1;
+  const start = i;
+  for (; i < code.length; i++) {
+    const ch = code[i];
+    if (ch === "(") depth++;
+    else if (ch === ")") {
+      depth--;
+      if (depth === 0) return code.slice(start, i);
+    }
+  }
+  return null;
+}
+
+/**
+ * Find every `addCommand(` registration that is gated desktop-only. Pure +
+ * dependency-free so the archgate rule and its jest revert-verify test share
+ * it verbatim.
+ */
+export function findDesktopOnlyGatedAddCommands(
+  content: string,
+): DesktopOnlyGateHit[] {
+  const lines = content.split("\n");
+  const hits: DesktopOnlyGateHit[] = [];
+  // Brace depths at which an active desktop-only guard block was opened.
+  const guardStartDepths: number[] = [];
+  let depth = 0;
+
+  for (let i = 0; i < lines.length; i++) {
+    const raw = lines[i];
+    const trimmed = raw.trimStart();
+    const isComment =
+      trimmed.startsWith("*") ||
+      trimmed.startsWith("//") ||
+      trimmed.startsWith("/*");
+    // Drop trailing line comment so prose can't trip detection.
+    const code = raw.replace(/\/\/.*$/, "");
+
+    // 1. Pop guard frames whose block has closed (depth fell back to its start).
+    while (
+      guardStartDepths.length > 0 &&
+      depth <= guardStartDepths[guardStartDepths.length - 1]
+    ) {
+      guardStartDepths.pop();
+    }
+
+    if (!isComment) {
+      const hasAdd = ADDCOMMAND.test(code);
+
+      if (hasAdd) {
+        if (guardStartDepths.length > 0) {
+          // Inside an active desktop-only guard block.
+          hits.push({
+            line: i + 1,
+            reason: "addCommand inside a desktop-only guard block",
+            snippet: trimmed.slice(0, 120),
+          });
+        } else {
+          // Same-line single-statement gate, e.g.
+          //   if (!Platform.isMobile) plugin.addCommand({...});
+          const cond = extractIfCondition(code);
+          if (cond !== null && isDesktopOnlyCondition(cond)) {
+            hits.push({
+              line: i + 1,
+              reason: "addCommand gated desktop-only on the same line",
+              snippet: trimmed.slice(0, 120),
+            });
+          }
+        }
+      } else {
+        // Detect a desktop-only block guard opening on this line:
+        //   if (<desktop-only-cond>) {
+        if (code.includes("{")) {
+          const cond = extractIfCondition(code);
+          if (cond !== null && isDesktopOnlyCondition(cond)) {
+            guardStartDepths.push(depth);
+          }
+        }
+      }
+    }
+
+    // 2. Update brace depth (best-effort; braces in string literals can desync —
+    //    documented, low blast radius since guards are rare).
+    const opens = (code.match(/\{/g) || []).length;
+    const closes = (code.match(/\}/g) || []).length;
+    depth += opens - closes;
+  }
+
+  return hits;
+}

--- a/packages/obsidian-plugin/src/presentation/settings/ExocortexSettingTab.ts
+++ b/packages/obsidian-plugin/src/presentation/settings/ExocortexSettingTab.ts
@@ -13,6 +13,7 @@ import { GitHubRestClient } from "@plugin/infrastructure/adapters/GitHubRestClie
 import { LocalSecretsStore } from "@plugin/infrastructure/adapters/LocalSecretsStore";
 import { OperationsLogReader } from "@plugin/infrastructure/adapters/OperationsLogReader";
 import { SwitchCacheLayer } from "@plugin/infrastructure/adapters/SwitchCacheLayer";
+import { resolvePastedSecret } from "@plugin/presentation/settings/patClipboard";
 
 /**
  * Issue #3320 §1 — secret key used by buildAssetSpacePusher and now the
@@ -647,8 +648,18 @@ export class ExocortexSettingTab extends PluginSettingTab {
         "Security #1). Required for the «Push current assetspace» and " +
         "«Apply profile» commands.",
     );
+    // RFC 0002 §3.9 (P14) — mobile onboarding parity. Typing a long
+    // fine-grained token on a phone keyboard is painful, so point users at the
+    // Paste button (works on desktop AND mobile — no Platform gate).
+    patDesc.appendText(
+      " On mobile, use the Paste button to fill the field from your " +
+        "clipboard instead of typing the token by hand.",
+    );
 
     let patInputValue = "";
+    // Captured from `addText` below so the Paste button can write into the same
+    // input (and the password masking stays applied).
+    let patTextComponent: { setValue(value: string): void } | undefined;
     new Setting(containerEl)
       // eslint-disable-next-line obsidianmd/ui/sentence-case -- "PAT" is an established acronym for Personal Access Token
       .setName("Personal Access Token")
@@ -657,6 +668,7 @@ export class ExocortexSettingTab extends PluginSettingTab {
           "to your exoas-* repos. Leave blank and click Save to clear.",
       )
       .addText((text) => {
+        patTextComponent = text;
         text.inputEl.type = "password";
         // eslint-disable-next-line obsidianmd/ui/sentence-case -- placeholder shows literal PAT format
         text.setPlaceholder("github_pat_…");
@@ -664,6 +676,36 @@ export class ExocortexSettingTab extends PluginSettingTab {
           patInputValue = value;
         });
       })
+      // RFC 0002 §3.9 (P14) — paste-from-clipboard affordance. A native
+      // Obsidian button (keyboard-focusable, Enter/Space-activatable) so PAT
+      // entry is mobile-friendly without typing the whole token. Works on both
+      // platforms (`navigator.clipboard.readText()` resolves on a user gesture
+      // in Electron AND the mobile WebView) — no Platform gate, mobile parity.
+      .addButton((button) =>
+        button
+          .setButtonText("Paste")
+          .setTooltip("Paste a GitHub token from the clipboard")
+          .onClick(async () => {
+            try {
+              const raw = await navigator.clipboard.readText();
+              const outcome = resolvePastedSecret(raw);
+              if (outcome.kind === "empty") {
+                notifier.warn(
+                  "Clipboard is empty — copy your token first, then Paste.",
+                );
+                return;
+              }
+              patTextComponent?.setValue(outcome.value);
+              patInputValue = outcome.value;
+              notifier.info("Pasted from clipboard. Click Save PAT to store it.");
+            } catch (error) {
+              notifier.error(
+                `Couldn't read the clipboard (${errorMessage(error)}) — ` +
+                  "paste into the field manually instead.",
+              );
+            }
+          }),
+      )
       .addButton((button) =>
         // eslint-disable-next-line obsidianmd/ui/sentence-case -- "PAT" is an established acronym
         button.setButtonText("Save PAT").onClick(async () => {

--- a/packages/obsidian-plugin/src/presentation/settings/patClipboard.ts
+++ b/packages/obsidian-plugin/src/presentation/settings/patClipboard.ts
@@ -1,0 +1,31 @@
+/**
+ * PAT clipboard affordance — RFC 0002 §3.9 (mobile onboarding parity, P14).
+ *
+ * Typing a long fine-grained GitHub token on a phone keyboard is painful, so
+ * the PAT settings field offers a "Paste" button. This module holds the pure,
+ * platform-neutral decision logic (trim + empty detection) so it is unit-test
+ * covered independently of the Obsidian-facing button wiring in
+ * `ExocortexSettingTab`. `navigator.clipboard.readText()` works on both
+ * Electron desktop and the mobile WebView (under a user gesture — a button
+ * click qualifies), so the affordance is parity-correct: no `Platform.isMobile`
+ * gate, it simply helps most on mobile.
+ */
+
+/** Outcome of normalising a clipboard payload destined for the PAT field. */
+export type PastedSecretOutcome =
+  | { kind: "filled"; value: string }
+  | { kind: "empty" };
+
+/**
+ * Normalise a raw clipboard string into a PAT field action. Tokens are
+ * single-line opaque strings, so surrounding whitespace/newlines (common when
+ * a token is copied with a trailing newline) is always trimmed. An
+ * all-whitespace / empty clipboard yields `empty` so the caller can prompt the
+ * user to copy a token first rather than silently clearing the field.
+ */
+export function resolvePastedSecret(raw: string): PastedSecretOutcome {
+  const trimmed = raw.trim();
+  return trimmed.length === 0
+    ? { kind: "empty" }
+    : { kind: "filled", value: trimmed };
+}

--- a/packages/obsidian-plugin/tests/unit/ExocortexSettingTab.focusProfile.test.ts
+++ b/packages/obsidian-plugin/tests/unit/ExocortexSettingTab.focusProfile.test.ts
@@ -227,6 +227,7 @@ describe("ExocortexSettingTab — Issue #3320 Profile sections", () => {
             setButtonText: jest.fn().mockReturnThis(),
             onClick: jest.fn().mockReturnThis(),
             setCta: jest.fn().mockReturnThis(),
+            setTooltip: jest.fn().mockReturnThis(),
           });
           return setting;
         }),

--- a/packages/obsidian-plugin/tests/unit/ExocortexSettingTab.test.ts
+++ b/packages/obsidian-plugin/tests/unit/ExocortexSettingTab.test.ts
@@ -125,6 +125,7 @@ describe("ExocortexSettingTab", () => {
             setButtonText: jest.fn().mockReturnThis(),
             onClick: jest.fn().mockReturnThis(),
             setCta: jest.fn().mockReturnThis(),
+            setTooltip: jest.fn().mockReturnThis(),
           };
           callback(button);
           return setting;
@@ -236,6 +237,7 @@ describe("ExocortexSettingTab", () => {
               setButtonText: jest.fn().mockReturnThis(),
               onClick: jest.fn().mockReturnThis(),
               setCta: jest.fn().mockReturnThis(),
+              setTooltip: jest.fn().mockReturnThis(),
             };
             callback(button);
             return setting;
@@ -328,6 +330,7 @@ describe("ExocortexSettingTab", () => {
               setButtonText: jest.fn().mockReturnThis(),
               onClick: jest.fn().mockReturnThis(),
               setCta: jest.fn().mockReturnThis(),
+              setTooltip: jest.fn().mockReturnThis(),
             };
             callback(button);
             return setting;

--- a/packages/obsidian-plugin/tests/unit/desktopOnlyCommandGate.test.ts
+++ b/packages/obsidian-plugin/tests/unit/desktopOnlyCommandGate.test.ts
@@ -1,0 +1,133 @@
+import { readFileSync } from "fs";
+import { resolve } from "path";
+import {
+  findDesktopOnlyGatedAddCommands,
+  isDesktopOnlyCondition,
+} from "../../../../.archgate/lint/desktopOnlyCommandGate";
+
+/**
+ * Revert-verify for the MOBILE-004 archgate rule (Desktop↔Mobile Command
+ * Parity). The shared scanner in `.archgate/lint/desktopOnlyCommandGate.ts`
+ * is the SAME module the archgate rule imports, so these assertions exercise
+ * the actual CI gate logic verbatim:
+ *
+ *   - a desktop-only-gated `addCommand` fixture → the gate FAILS (hit found)
+ *   - clean / unconditional / parity-pattern fixtures → the gate PASSES (no hit)
+ *
+ * That FAIL-on-gated / PASS-on-clean pair is the integration-test-revert-verify
+ * discipline applied to an arch rule.
+ */
+describe("desktopOnlyCommandGate — MOBILE-004 detection", () => {
+  describe("FAILS (desktop-only gate → violation found)", () => {
+    it("flags addCommand inside an `if (!Platform.isMobile)` block", () => {
+      const src = `
+        function wire(plugin) {
+          if (!Platform.isMobile) {
+            plugin.addCommand({ id: "x", name: "X", callback: () => {} });
+          }
+        }
+      `;
+      const hits = findDesktopOnlyGatedAddCommands(src);
+      expect(hits).toHaveLength(1);
+      expect(hits[0].reason).toMatch(/desktop-only guard block/);
+    });
+
+    it("flags a single-statement `if (!Platform.isMobile) plugin.addCommand(...)`", () => {
+      const src = `
+        function wire(plugin) {
+          if (!Platform.isMobile) plugin.addCommand({ id: "x", name: "X" });
+        }
+      `;
+      const hits = findDesktopOnlyGatedAddCommands(src);
+      expect(hits).toHaveLength(1);
+      expect(hits[0].reason).toMatch(/same line/);
+    });
+
+    it("flags addCommand inside an `if (Platform.isDesktopApp)` block", () => {
+      const src = `
+        if (Platform.isDesktopApp) {
+          this.addCommand({ id: "y", name: "Y" });
+        }
+      `;
+      expect(findDesktopOnlyGatedAddCommands(src)).toHaveLength(1);
+    });
+
+    it("flags a `&& !Platform.isMobile` guarded block too", () => {
+      const src = `
+        if (ready && !Platform.isMobile) {
+          this.addCommand({ id: "z", name: "Z" });
+        }
+      `;
+      expect(findDesktopOnlyGatedAddCommands(src)).toHaveLength(1);
+    });
+  });
+
+  describe("PASSES (parity-correct / unconditional → no false positive)", () => {
+    it("does NOT flag an unconditional registration", () => {
+      const src = `
+        this.addCommand({ id: "always", name: "Always", callback: () => {} });
+      `;
+      expect(findDesktopOnlyGatedAddCommands(src)).toHaveLength(0);
+    });
+
+    it("does NOT flag the parity pattern `applyDeps !== null || (Platform.isMobile && restMount !== null)`", () => {
+      const src = `
+        if (applyDeps !== null || (Platform.isMobile && restMount !== null)) {
+          this.addCommand({ id: "apply-profile", name: "Apply profile" });
+        }
+      `;
+      expect(findDesktopOnlyGatedAddCommands(src)).toHaveLength(0);
+    });
+
+    it("does NOT flag a `Platform.isMobile && restMount` mobile-inclusive guard", () => {
+      const src = `
+        if (restMount !== null) {
+          this.addCommand({ id: "unmount", name: "Unmount" });
+        }
+      `;
+      expect(findDesktopOnlyGatedAddCommands(src)).toHaveLength(0);
+    });
+
+    it("does NOT flag a mobile-only block (mobile users are served)", () => {
+      const src = `
+        if (Platform.isMobile) {
+          this.addCommand({ id: "mob", name: "Mobile only" });
+        }
+      `;
+      expect(findDesktopOnlyGatedAddCommands(src)).toHaveLength(0);
+    });
+
+    it("does NOT flag addCommand mentioned only in a comment", () => {
+      const src = `
+        if (!Platform.isMobile) {
+          // historically this used to plugin.addCommand(...) here
+          doSomethingElse();
+        }
+      `;
+      expect(findDesktopOnlyGatedAddCommands(src)).toHaveLength(0);
+    });
+  });
+
+  describe("isDesktopOnlyCondition", () => {
+    it.each([
+      ["!Platform.isMobile", true],
+      ["Platform.isDesktopApp", true],
+      ["ready && !Platform.isMobile", true],
+      ["applyDeps !== null || (Platform.isMobile && restMount !== null)", false],
+      ["Platform.isMobile", false],
+      ["Platform.isMobile ? a : b", false],
+      ["someOtherCondition", false],
+    ])("%s → %s", (cond, expected) => {
+      expect(isDesktopOnlyCondition(cond as string)).toBe(expected);
+    });
+  });
+
+  describe("real plugin source is parity-clean", () => {
+    it("ExocortexPlugin.ts has zero desktop-only-gated addCommand", () => {
+      const file = resolve(__dirname, "../../src/ExocortexPlugin.ts");
+      const content = readFileSync(file, "utf8");
+      const hits = findDesktopOnlyGatedAddCommands(content);
+      expect(hits).toEqual([]);
+    });
+  });
+});

--- a/packages/obsidian-plugin/tests/unit/desktopOnlyCommandGate.test.ts
+++ b/packages/obsidian-plugin/tests/unit/desktopOnlyCommandGate.test.ts
@@ -60,6 +60,35 @@ describe("desktopOnlyCommandGate — MOBILE-004 detection", () => {
       `;
       expect(findDesktopOnlyGatedAddCommands(src)).toHaveLength(1);
     });
+
+    it("flags an Allman-brace `if (!Platform.isMobile)` block", () => {
+      const src = `
+        if (!Platform.isMobile)
+        {
+          this.addCommand({ id: "allman", name: "Allman" });
+        }
+      `;
+      expect(findDesktopOnlyGatedAddCommands(src)).toHaveLength(1);
+    });
+
+    it("flags a brace-less multi-line `if (!Platform.isMobile)` single statement", () => {
+      const src = `
+        if (!Platform.isMobile)
+          this.addCommand({ id: "nobrace", name: "No brace" });
+      `;
+      const hits = findDesktopOnlyGatedAddCommands(src);
+      expect(hits).toHaveLength(1);
+      expect(hits[0].reason).toMatch(/brace-less/);
+    });
+
+    it("flags a brace-less guard even across a comment line", () => {
+      const src = `
+        if (!Platform.isMobile)
+          // historical note
+          this.addCommand({ id: "c", name: "C" });
+      `;
+      expect(findDesktopOnlyGatedAddCommands(src)).toHaveLength(1);
+    });
   });
 
   describe("PASSES (parity-correct / unconditional → no false positive)", () => {
@@ -106,6 +135,52 @@ describe("desktopOnlyCommandGate — MOBILE-004 detection", () => {
       `;
       expect(findDesktopOnlyGatedAddCommands(src)).toHaveLength(0);
     });
+
+    it("does NOT flag a brace-less guard over a non-addCommand statement", () => {
+      const src = `
+        if (!Platform.isMobile)
+          doDesktopOnlyThing();
+        this.addCommand({ id: "after", name: "After (unconditional)" });
+      `;
+      expect(findDesktopOnlyGatedAddCommands(src)).toHaveLength(0);
+    });
+  });
+
+  // Honest false-negative boundary — these desktop-only-gating shapes are NOT
+  // caught (documented in the ADR). The gate is defense-in-depth for the
+  // likeliest regression; these assertions pin the current coverage limit so a
+  // future improvement that starts catching them updates the test deliberately.
+  describe("documented false-negatives (not yet caught)", () => {
+    it("does NOT catch an early-return `if (Platform.isMobile) return;` guard", () => {
+      const src = `
+        function wire(plugin) {
+          if (Platform.isMobile) return;
+          plugin.addCommand({ id: "early", name: "Early" });
+        }
+      `;
+      expect(findDesktopOnlyGatedAddCommands(src)).toHaveLength(0);
+    });
+
+    it("does NOT catch an else-branch desktop-only registration", () => {
+      const src = `
+        if (Platform.isMobile) {
+          doMobile();
+        } else {
+          this.addCommand({ id: "else", name: "Else" });
+        }
+      `;
+      expect(findDesktopOnlyGatedAddCommands(src)).toHaveLength(0);
+    });
+
+    it("does NOT catch data-flow gating through a deps variable", () => {
+      const src = `
+        const deps = Platform.isMobile ? null : build();
+        if (deps !== null) {
+          this.addCommand({ id: "dataflow", name: "Data flow" });
+        }
+      `;
+      expect(findDesktopOnlyGatedAddCommands(src)).toHaveLength(0);
+    });
   });
 
   describe("isDesktopOnlyCondition", () => {
@@ -123,11 +198,13 @@ describe("desktopOnlyCommandGate — MOBILE-004 detection", () => {
   });
 
   describe("real plugin source is parity-clean", () => {
-    it("ExocortexPlugin.ts has zero desktop-only-gated addCommand", () => {
-      const file = resolve(__dirname, "../../src/ExocortexPlugin.ts");
-      const content = readFileSync(file, "utf8");
-      const hits = findDesktopOnlyGatedAddCommands(content);
-      expect(hits).toEqual([]);
+    it.each([
+      "../../src/ExocortexPlugin.ts",
+      // RFC 0002 §3.9 subject — the onboarding command registration file.
+      "../../src/infrastructure/adapters/firstRunOnboarding.ts",
+    ])("%s has zero desktop-only-gated addCommand", (relPath) => {
+      const content = readFileSync(resolve(__dirname, relPath), "utf8");
+      expect(findDesktopOnlyGatedAddCommands(content)).toEqual([]);
     });
   });
 });

--- a/packages/obsidian-plugin/tests/unit/patClipboard.test.ts
+++ b/packages/obsidian-plugin/tests/unit/patClipboard.test.ts
@@ -1,0 +1,29 @@
+import { resolvePastedSecret } from "@plugin/presentation/settings/patClipboard";
+
+describe("resolvePastedSecret — RFC 0002 §3.9 PAT paste affordance", () => {
+  it("trims surrounding whitespace from a pasted token", () => {
+    expect(resolvePastedSecret("  github_pat_abc123  ")).toEqual({
+      kind: "filled",
+      value: "github_pat_abc123",
+    });
+  });
+
+  it("strips a trailing newline (common when copying a token)", () => {
+    expect(resolvePastedSecret("github_pat_abc123\n")).toEqual({
+      kind: "filled",
+      value: "github_pat_abc123",
+    });
+  });
+
+  it("reports an empty clipboard rather than clearing the field", () => {
+    expect(resolvePastedSecret("")).toEqual({ kind: "empty" });
+    expect(resolvePastedSecret("   \n\t ")).toEqual({ kind: "empty" });
+  });
+
+  it("preserves an already-clean token verbatim", () => {
+    expect(resolvePastedSecret("github_pat_XYZ")).toEqual({
+      kind: "filled",
+      value: "github_pat_XYZ",
+    });
+  });
+});


### PR DESCRIPTION
Resolves **RFC 0002 §3.9** (P14 — no mobile-specific onboarding). Implements the
**Desktop↔Mobile Command Parity** contract for onboarding and a preventive
arch-gate so it can never silently regress. WBS node `5965de4b` (Alpha Launch
UX onboarding subproject `fdc06a94`).

## Parity verdict (verified at code level on origin/main)

1. **§3.1 panel renders on mobile** — the panel + `Setup (getting started)`
   command register **UNCONDITIONALLY** (`registerOnboardingCommands`,
   `firstRunOnboarding.ts:97`; `registerOnboardingPanel` called unconditionally,
   `ExocortexPlugin.ts:3189`). First-run detection routes through the
   cross-platform `detectVaultState` (`vault.adapter`-based), so it works on mobile.
2. **Bootstrap / Add / Apply / Sync use the git-free route** — the apply-profile
   and bootstrap gate is `applyDeps !== null || (Platform.isMobile && restMount !== null)`
   (`ExocortexPlugin.ts:3140`, `:3174`) — registers on **both** platforms (mobile via
   the git-free `RestAssetSpaceMount`, #3535 / RFC 01a83de8). ExoSync registers
   unconditionally over the `requestUrl` transport (no git binary). **No onboarding
   command is desktop-only-gated** (asserted empirically — see the
   "real ExocortexPlugin.ts is parity-clean" test).

## Changes

- **PAT paste affordance (§3.9):** a keyboard-accessible **"Paste"** button +
  a mobile hint on the PAT settings field, so entering a long fine-grained token
  on a phone keyboard isn't required. `navigator.clipboard.readText()` works on
  desktop **and** the mobile WebView under a user gesture — no `Platform` gate.
  Pure normalize helper `patClipboard.ts` (trim + empty-detection), unit-tested.
- **MOBILE-004 archgate rule** — fails CI on any desktop-only-gated `addCommand`
  (`if (!Platform.isMobile) { addCommand(...) }`, `if (Platform.isDesktopApp) …`).
  The parity pattern (`applyDeps !== null || (Platform.isMobile && restMount !== null)`)
  is **not** flagged. The shared scanner `.archgate/lint/desktopOnlyCommandGate.ts`
  is imported verbatim by both the rule and a jest revert-verify test (no drift).
  Joins the mobile cluster MOBILE-001/002/003; runs in the existing `archgate`
  required check (`archgate check --ci`).

## Tests (revert-verify)

- `desktopOnlyCommandGate.test.ts` (17): synthetic gated fixture → violation found
  (gate FAILS); clean / unconditional / parity-pattern / mobile-only / comment
  fixtures → none (gate PASSES); plus a "real `ExocortexPlugin.ts` is parity-clean"
  assertion. Archgate-level revert-verify also confirmed manually
  (`if (!Platform.isMobile){ addCommand }` → `pass:false`; remove → `pass:true`).
- `patClipboard.test.ts` (4): trim / trailing-newline / empty / verbatim.
- Two existing settings-tab test mocks gained the missing `setTooltip`
  (mirrors the real Obsidian `ButtonComponent` — test-fixture-realism).
- Full plugin unit suite: 5328 passed; the only local failures are the
  `VaultSettingsRegistry` suite which reads the `packages/exoas-exo` submodule
  (not initialised in a bare worktree — passes in CI's `submodules: recursive`).

## Out of scope (follow-up)

Actual mobile visual smoke is a noted follow-up (user iPhone dogfood) — there is
no mobile device in CI, so parity here is proven at code level + arch-gate + unit.