### PR TITLE
fix(profile): REST-aware crash recovery resumes interrupted apply-profile (#1d1bcde0)

### DIFF
--- a/packages/obsidian-plugin/src/ExocortexPlugin.ts
+++ b/packages/obsidian-plugin/src/ExocortexPlugin.ts
@@ -3360,26 +3360,35 @@ export default class ExocortexPlugin extends Plugin {
       );
     }
 
-    // RFC 22b50a17 Phase 3 — apply recovery worker. Only fires when
-    // apply deps are wired AND the journal tail shows destroyed-not-
-    // materialized AS — covers the «plugin crashed mid-Phase 2» case where
-    // soft recoverIfNeeded() would re-trigger a no-op refresh but leave
-    // vault filesystem partial-destroyed.
-    if (hasApplyDeps) {
-      try {
-        const result = await switchMgr.recoverIncompleteSwitch();
-        if (result.restored.length > 0) {
-          this.logger.info(
-            `[ExocortexPlugin] apply recovery restored ${result.restored.length} AssetSpace(s): ${result.restored.join(", ")}`,
-          );
-        }
-      } catch (error) {
-        this.logger.warn(
-          "[ExocortexPlugin] apply recovery failed",
-          error instanceof Error ? error : new Error(String(error)),
+    // RFC 22b50a17 Phase 3 — apply recovery worker. Resolves an interrupted
+    // apply to a consistent state. #1d1bcde0 — runs on BOTH platforms (NOT
+    // gated by `hasApplyDeps`): the production REST apply path (#3567) is wired
+    // on desktop AND mobile, and an interrupted REST apply is resumed by driving
+    // the mount-delta to the target. The desktop-git cache-restore branch
+    // self-guards on the cache layer. Covers the «reload mid-apply» case where
+    // soft recoverIfNeeded() would (pre-fix) re-trigger a no-op refresh + leave
+    // the vault filesystem partial-applied while prematurely declaring it
+    // Applied.
+    try {
+      const result = await switchMgr.recoverIncompleteSwitch();
+      if (result.resumed) {
+        this.logger.info(
+          `[ExocortexPlugin] apply recovery resumed the interrupted REST apply to ${result.resumedTo}`,
         );
       }
+      if (result.restored.length > 0) {
+        this.logger.info(
+          `[ExocortexPlugin] apply recovery restored ${result.restored.length} AssetSpace(s): ${result.restored.join(", ")}`,
+        );
+      }
+    } catch (error) {
+      this.logger.warn(
+        "[ExocortexPlugin] apply recovery failed",
+        error instanceof Error ? error : new Error(String(error)),
+      );
+    }
 
+    if (hasApplyDeps) {
       // Cross-device divergence detection (RFC 22b50a17 §Cross-device).
       // Best-effort: failure не block onload; user can manually re-trigger
       // by switching profiles в Cmd+P.

--- a/packages/obsidian-plugin/src/adapters/logging/activityFanIn.ts
+++ b/packages/obsidian-plugin/src/adapters/logging/activityFanIn.ts
@@ -28,6 +28,7 @@ const PHASE_LABELS: Record<SwitchJournalEntry["phase"], string> = {
   "apply-failed": "Apply failed",
   "rest-rollback-unmounted": "Rolled back mount (apply failed)",
   "recovery-restoring": "Recovering interrupted switch",
+  "recovery-resuming": "Resuming interrupted apply",
   "recovery-completed": "Recovery complete",
 };
 

--- a/packages/obsidian-plugin/src/infrastructure/adapters/PluginLockManager.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/PluginLockManager.ts
@@ -135,6 +135,29 @@ export class PluginLockManager {
   }
 
   /**
+   * Crash-recovery helper — delete the lock file IFF it is NOT a live lock held
+   * by THIS session: i.e. it belongs to a different pid (a crashed/other
+   * session) OR it is stale. A fresh lock owned by this session (a concurrent
+   * same-session apply in progress) is left intact. Returns whether a lock was
+   * reclaimed.
+   *
+   * Used by {@link ProfileApplyManager.recoverIncompleteSwitch} to reclaim a
+   * crashed session's still-fresh foreign-pid lock (its heartbeat froze at
+   * crash time, so `acquireLock` would not yet treat it as stale) WITHOUT
+   * stomping a concurrent same-session apply the user may have just triggered.
+   */
+  async reclaimIfForeignOrStale(): Promise<boolean> {
+    const existing = await this.readLock();
+    if (existing === null) return false;
+    // Our own still-fresh lock = a live in-progress apply — do not reclaim.
+    if (existing.pid === this.pid && !this.snapshotIsStale(existing)) {
+      return false;
+    }
+    await this.deleteLock();
+    return true;
+  }
+
+  /**
    * Synchronous staleness probe against the in-memory snapshot OR latest disk
    * read (caller chooses). For most uses, prefer `checkOnPluginLoad()` which
    * does the read + verdict together.

--- a/packages/obsidian-plugin/src/infrastructure/adapters/ProfileApplyManager.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/ProfileApplyManager.ts
@@ -156,6 +156,9 @@ export interface SwitchJournalEntry {
     // unmounted to restore the pre-apply mount-state after a mid-apply failure.
     | "rest-rollback-unmounted"
     | "recovery-restoring"
+    // #1d1bcde0 — REST-aware crash recovery resumed an interrupted apply by
+    // re-running the idempotent REST apply to the target (mount-delta resume).
+    | "recovery-resuming"
     | "recovery-completed";
   targetUid: string;
   ts: string; // ISO
@@ -560,14 +563,127 @@ export class ProfileApplyManager {
       : `Applied "${profileLabel}": no changes (${recognizedCount} AssetSpace(s) already match).`;
   }
 
+  /** Whether the cross-platform REST mount is wired (desktop + mobile). */
+  private restWired(): boolean {
+    return this.restMount !== undefined || this.restMountFactory !== undefined;
+  }
+
   /**
-   * Plugin-load recovery: if last journal entry shows an incomplete switch
-   * AND settings._switchInProgress=true, re-trigger the re-index идempotently.
+   * #1d1bcde0 — classify the in-flight (interrupted) switch from the journal
+   * tail so recovery can route correctly:
+   *
+   *   - `reindex`   — a pure reindex-only switch (no filesystem mutation) was
+   *     interrupted mid-reindex (`runReindexMountState` lifecycle:
+   *     `starting`…`completed`). Safe to re-run {@link reindexMountState}.
+   *   - `rest-apply` — the PRODUCTION REST apply path (#3567) was interrupted
+   *     mid mount/unmount. Signature = `apply-starting` (+ `phase2-materialized`
+   *     / `phase2-destroyed`) with NO git-only phase. Resume = drive the
+   *     mount-delta to the target idempotently.
+   *   - `git-apply`  — the desktop-git apply mutation was interrupted. Signature
+   *     = any git-only phase (`phase2-start` / `phase2-destroy-cached` /
+   *     `phase2-materializing` / `phase2-done` / `git-commit-done` /
+   *     `phase1-done`). Recovery = cache-restore destroyed-not-materialized AS.
+   *   - `none`       — no in-flight switch (last terminal event closed the window).
+   *
+   * Only events SINCE the last terminal apply (`apply-completed` /
+   * `recovery-completed`) count — an earlier completed switch is irrelevant.
+   */
+  private async classifyInterruptedSwitch(): Promise<{
+    kind: "none" | "reindex" | "rest-apply" | "git-apply";
+    targetUid: string | null;
+    destroyed: Set<string>;
+    materialized: Set<string>;
+  }> {
+    // Git-only journal phases — present iff the desktop-git mutation ran. The
+    // REST mutation emits ONLY `apply-starting` / `phase2-materialized` /
+    // `phase2-destroyed`, so any of these uniquely marks the git path.
+    const GIT_ONLY_PHASES = new Set([
+      "phase1-done",
+      "phase2-start",
+      "phase2-destroy-cached",
+      "phase2-materializing",
+      "phase2-done",
+      "git-commit-done",
+    ]);
+    const events = await this.readJournalTail(200);
+    let applyStarted = false;
+    let reindexStarted = false;
+    let restMutation = false;
+    let gitMutation = false;
+    let targetUid: string | null = null;
+    const destroyed = new Set<string>();
+    const materialized = new Set<string>();
+    for (const e of events) {
+      if (e.phase === "apply-completed" || e.phase === "recovery-completed") {
+        // Terminal — anything before was a finished/recovered switch; reset.
+        applyStarted = reindexStarted = restMutation = gitMutation = false;
+        targetUid = null;
+        destroyed.clear();
+        materialized.clear();
+        continue;
+      }
+      if (GIT_ONLY_PHASES.has(e.phase)) {
+        gitMutation = true;
+        if (typeof e.targetUid === "string") targetUid = e.targetUid;
+        if (e.phase === "phase2-destroy-cached" && typeof e.as === "string") {
+          destroyed.add(e.as);
+        }
+      }
+      switch (e.phase) {
+        case "apply-starting":
+          applyStarted = true;
+          if (typeof e.targetUid === "string") targetUid = e.targetUid;
+          break;
+        case "starting":
+          reindexStarted = true;
+          if (typeof e.targetUid === "string") targetUid = e.targetUid;
+          break;
+        case "phase2-materialized":
+          restMutation = true;
+          if (typeof e.as === "string") materialized.add(e.as);
+          if (typeof e.targetUid === "string") targetUid = e.targetUid;
+          break;
+        case "phase2-destroyed":
+          restMutation = true;
+          if (typeof e.targetUid === "string") targetUid = e.targetUid;
+          break;
+        default:
+          break;
+      }
+    }
+    if (targetUid === null) return { kind: "none", targetUid: null, destroyed, materialized };
+    if (gitMutation) return { kind: "git-apply", targetUid, destroyed, materialized };
+    // An apply that started (with or without a recorded mount yet) but emitted
+    // no git-only phase is the REST path when the REST mount is wired (the
+    // production routing since #3567). `restMutation` covers the case where the
+    // first mount already landed; `applyStarted` covers a crash before it.
+    if ((applyStarted || restMutation) && this.restWired()) {
+      return { kind: "rest-apply", targetUid, destroyed, materialized };
+    }
+    if (applyStarted || restMutation) {
+      // Apply interrupted but REST not wired — legacy desktop-git fallback.
+      return { kind: "git-apply", targetUid, destroyed, materialized };
+    }
+    if (reindexStarted) return { kind: "reindex", targetUid, destroyed, materialized };
+    return { kind: "none", targetUid: null, destroyed, materialized };
+  }
+
+  /**
+   * Plugin-load recovery: if the last journal entry shows an incomplete
+   * reindex-only switch AND settings._switchInProgress=true, re-trigger the
+   * re-index idempotently.
    *
    * Re-index is pure (no filesystem state to roll back), so we simply
-   * re-run {@link reindexMountState} — it's safe and idempotent. Genuine
-   * filesystem-partial recovery (destroyed-not-materialized AssetSpaces)
-   * is handled separately by {@link recoverIncompleteSwitch}.
+   * re-run {@link reindexMountState} — it's safe and idempotent.
+   *
+   * #1d1bcde0 (F2) — an interrupted APPLY mutation (REST or desktop-git) is
+   * NOT re-indexed here: doing so would persist `activeProfileUid = TARGET` +
+   * clear the in-progress flag against a PARTIAL mount-state, prematurely
+   * declaring an incomplete switch "Applied" while the disk does not match the
+   * target. Apply-mutation interruptions are deferred to the dedicated
+   * apply-recovery worker ({@link recoverIncompleteSwitch}), which drives the
+   * mount-state to completion (REST resume / git cache-restore) and only then
+   * declares the target applied.
    */
   async recoverIfNeeded(): Promise<{ recovered: boolean; targetUid: string | null }> {
     const lastEntry = await this.readLastJournalEntry();
@@ -577,7 +693,13 @@ export class ProfileApplyManager {
     if (lastEntry.phase === "completed") return { recovered: false, targetUid: null };
     if (!settings._switchInProgress) return { recovered: false, targetUid: null };
 
-    // Incomplete: re-trigger
+    // F2 — defer apply-mutation interruptions to recoverIncompleteSwitch.
+    const interrupted = await this.classifyInterruptedSwitch();
+    if (interrupted.kind === "rest-apply" || interrupted.kind === "git-apply") {
+      return { recovered: false, targetUid: null };
+    }
+
+    // Pure reindex-only interruption: re-trigger the idempotent re-index.
     this.notify(`Recovering incomplete switch to ${lastEntry.targetUid}...`);
     await this.reindexMountState(lastEntry.targetUid);
     return { recovered: true, targetUid: lastEntry.targetUid };
@@ -1199,7 +1321,10 @@ export class ProfileApplyManager {
    * @throws TsFloorViolationError if target excludes any TS-floor AS.
    * @throws ApplyAbortedByUser if confirmGate declines.
    */
-  async applyProfileViaRest(targetProfileUid: string): Promise<void> {
+  async applyProfileViaRest(
+    targetProfileUid: string,
+    opts?: { skipConfirm?: boolean },
+  ): Promise<void> {
     if (typeof targetProfileUid !== "string" || targetProfileUid.length === 0) {
       throw new Error("applyProfileViaRest: targetProfileUid is required");
     }
@@ -1330,7 +1455,13 @@ export class ProfileApplyManager {
         asLabel: t.label,
       })),
     };
-    const approved = await confirmGate.confirmApply(plan);
+    // #1d1bcde0 — the onload crash-recovery resume passes `skipConfirm` because
+    // the user ALREADY approved this apply before the reload; re-prompting on a
+    // resume of an in-flight (interrupted) apply is wrong UX and the
+    // to-destroy set is exactly what they consented to remove. A normal apply
+    // always goes through the gate.
+    const approved =
+      opts?.skipConfirm === true ? true : await confirmGate.confirmApply(plan);
     if (!approved) throw new ApplyAbortedByUser();
 
     // No-op early exit — mount-state already matches the target. Re-index +
@@ -1600,18 +1731,33 @@ export class ProfileApplyManager {
   }
 
   /**
-   * Recovery worker — call from plugin onload when localDataStore reports
-   * `_switchInProgress=true`. Reads journal tail, identifies AS destroyed
-   * but not materialized, restores each from cache.
+   * Recovery worker — call from plugin onload when an interrupted switch may be
+   * pending. Resolves an incomplete apply to a consistent state:
    *
-   * @returns count of restored AS.
+   *   - **REST apply** (production path since #3567): re-run the idempotent REST
+   *     apply to the target so the mount-delta is driven to completion (mount
+   *     not-yet-materialised AssetSpaces + unmount leftover source AssetSpaces).
+   *     The user already approved the apply before the reload, so the confirm
+   *     gate is skipped. Runs on BOTH platforms (restMount is wired on both).
+   *   - **Desktop-git apply**: restore destroyed-but-not-materialized
+   *     AssetSpaces from the SwitchCacheLayer (the original Phase-3 behaviour).
+   *
+   * `activeProfileUid` is declared TARGET only AFTER the mount-state matches it
+   * (the resume's success save), so a partial disk never reports as Applied
+   * (#1d1bcde0 F2).
+   *
+   * @returns `restored` — AS UIDs restored from cache (git path); `resumed` —
+   *   whether an interrupted REST apply was resumed; `resumedTo` — the resumed
+   *   target profile UID (or null).
    */
-  async recoverIncompleteSwitch(): Promise<{ restored: ReadonlyArray<string> }> {
-    const cacheLayer = this.cacheLayer;
+  async recoverIncompleteSwitch(): Promise<{
+    restored: ReadonlyArray<string>;
+    resumed: boolean;
+    resumedTo: string | null;
+  }> {
     const localDataStore = this.localDataStore;
-    const vaultRootPath = this.vaultRootPath;
-    if (cacheLayer === undefined || localDataStore === undefined || vaultRootPath === undefined) {
-      throw new Error("recoverIncompleteSwitch: apply dependencies not wired");
+    if (localDataStore === undefined) {
+      throw new Error("recoverIncompleteSwitch: localDataStore not wired");
     }
 
     // Nothing-to-recover guard (#3571). On a vault that has never run a profile
@@ -1637,7 +1783,7 @@ export class ProfileApplyManager {
       journalExists = true;
     }
     if (!journalExists && !localDataStore.isSwitchInProgress()) {
-      return { restored: [] };
+      return { restored: [], resumed: false, resumedTo: null };
     }
 
     // Defensive (mirrors the apply paths at ll. 477/908/1334): we are past the
@@ -1647,20 +1793,53 @@ export class ProfileApplyManager {
     // `recovery-completed` write can't ENOENT and mask the real outcome.
     await this.ensureExocortexDir();
 
-    const events = await this.readJournalTail(200);
-    const destroyedAsUids = new Set<string>();
-    const materializedAsUids = new Set<string>();
-    for (const e of events) {
-      if (e.phase === "phase2-destroy-cached" && typeof e.as === "string") {
-        destroyedAsUids.add(e.as);
-      } else if (e.phase === "phase2-materialized" && typeof e.as === "string") {
-        materializedAsUids.add(e.as);
-      } else if (e.phase === "apply-completed") {
-        // Anything before a completed event was a finished switch — clear set.
-        destroyedAsUids.clear();
-        materializedAsUids.clear();
-      }
+    const interrupted = await this.classifyInterruptedSwitch();
+
+    // #1d1bcde0 (F1) — REST-aware resume. An interrupted REST apply is driven to
+    // the target idempotently by re-running the REST apply (skip the confirm
+    // gate — already approved pre-crash). applyProfileViaRest persists
+    // `activeProfileUid=target` + clears the in-progress flag + writes its own
+    // `apply-completed` ONLY after the mount-state matches the target, so a
+    // partial disk is never reported as Applied.
+    if (interrupted.kind === "rest-apply" && interrupted.targetUid !== null && this.restWired()) {
+      await this.appendJournal({
+        phase: "recovery-resuming",
+        targetUid: interrupted.targetUid,
+        ts: this.now().toISOString(),
+      });
+      // The crashed apply's persistent lock survives the reload (its heartbeat
+      // froze at crash time). A reload WITHIN the staleness window (5 min) leaves
+      // a not-yet-stale foreign-pid lock, so the resume's own `acquireLock` would
+      // falsely report "another switch in progress". We are recovering a
+      // CONFIRMED interrupted switch at onload (no concurrent apply can exist in
+      // this session yet), so reclaim it first — best-effort, idempotent.
+      await this.lockMgr.releaseLock({ force: true }).catch(() => {});
+      await this.applyProfileViaRest(interrupted.targetUid, { skipConfirm: true });
+      return { restored: [], resumed: true, resumedTo: interrupted.targetUid };
     }
+
+    // Desktop-git cache-restore path — requires the cache layer + vault root.
+    // When these are absent (mobile / REST-only wiring) there is no git apply to
+    // recover; the REST branch above already handled any production interruption.
+    // Just clear the stuck flag so the system never wedges in `_switchInProgress`.
+    const cacheLayer = this.cacheLayer;
+    const vaultRootPath = this.vaultRootPath;
+    if (cacheLayer === undefined || vaultRootPath === undefined) {
+      const snapshot = localDataStore.snapshot();
+      await localDataStore.save({
+        activeProfileUid: snapshot.activeProfileUid,
+        _switchInProgress: false,
+      });
+      await this.appendJournal({
+        phase: "recovery-completed",
+        targetUid: snapshot.activeProfileUid ?? "<none>",
+        ts: this.now().toISOString(),
+      });
+      return { restored: [], resumed: false, resumedTo: null };
+    }
+
+    const destroyedAsUids = interrupted.destroyed;
+    const materializedAsUids = interrupted.materialized;
 
     const restored: string[] = [];
     for (const asUid of destroyedAsUids) {
@@ -1707,7 +1886,7 @@ export class ProfileApplyManager {
     if (restored.length > 0) {
       this.notify(`Recovered ${restored.length} AssetSpace(s) from cache after interrupted switch`);
     }
-    return { restored };
+    return { restored, resumed: false, resumedTo: null };
   }
 
   /**

--- a/packages/obsidian-plugin/src/infrastructure/adapters/ProfileApplyManager.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/ProfileApplyManager.ts
@@ -1809,12 +1809,33 @@ export class ProfileApplyManager {
       });
       // The crashed apply's persistent lock survives the reload (its heartbeat
       // froze at crash time). A reload WITHIN the staleness window (5 min) leaves
-      // a not-yet-stale foreign-pid lock, so the resume's own `acquireLock` would
-      // falsely report "another switch in progress". We are recovering a
-      // CONFIRMED interrupted switch at onload (no concurrent apply can exist in
-      // this session yet), so reclaim it first — best-effort, idempotent.
-      await this.lockMgr.releaseLock({ force: true }).catch(() => {});
+      // a not-yet-stale FOREIGN-pid lock, so the resume's own `acquireLock` would
+      // falsely report "another switch in progress". Reclaim only a foreign /
+      // stale lock — a live same-session apply (this pid, fresh) is left intact
+      // so the resume can't stomp a concurrent user-triggered apply (it would
+      // instead fail to acquire and defer to the next reload — strictly safe).
+      await this.lockMgr.reclaimIfForeignOrStale().catch(() => {});
       await this.applyProfileViaRest(interrupted.targetUid, { skipConfirm: true });
+      // Close the recovery window + reconcile the last-applied cache to the
+      // resumed target. The mutation path of applyProfileViaRest already does
+      // this (writes `apply-completed` + persists `activeProfileUid=target`),
+      // but an EMPTY-delta resume (disk already matched the target at recovery
+      // time) takes its reindex-only exit, which writes `completed` (NOT a
+      // window-resetting terminal) and persists via the settings store only.
+      // Writing `recovery-completed` here prevents re-resume churn on every
+      // subsequent reload, and the explicit save guarantees `localDataStore`
+      // reflects the target regardless of which internal branch ran.
+      const resumedSnap = localDataStore.snapshot();
+      await localDataStore.save({
+        ...resumedSnap,
+        activeProfileUid: interrupted.targetUid,
+        _switchInProgress: false,
+      });
+      await this.appendJournal({
+        phase: "recovery-completed",
+        targetUid: interrupted.targetUid,
+        ts: this.now().toISOString(),
+      });
       return { restored: [], resumed: true, resumedTo: interrupted.targetUid };
     }
 

--- a/packages/obsidian-plugin/tests/unit/PluginLockManager.test.ts
+++ b/packages/obsidian-plugin/tests/unit/PluginLockManager.test.ts
@@ -221,6 +221,45 @@ describe("PluginLockManager.releaseLock", () => {
   });
 });
 
+describe("PluginLockManager.reclaimIfForeignOrStale (#1d1bcde0)", () => {
+  it("returns false (no reclaim) when no lock file exists", async () => {
+    const { mgr, store } = makeHarness();
+    expect(await mgr.reclaimIfForeignOrStale()).toBe(false);
+    expect(store.removes).toHaveLength(0);
+  });
+
+  it("does NOT reclaim our own still-fresh lock (a live same-session apply)", async () => {
+    const { mgr, store } = makeHarness();
+    await mgr.acquireLock("apply-rest-target");
+    // Same pid, fresh heartbeat → live in-progress apply, must survive.
+    expect(await mgr.reclaimIfForeignOrStale()).toBe(false);
+    expect(store.files.has(".exocortex/switch-lock.json")).toBe(true);
+  });
+
+  it("reclaims a FOREIGN-pid still-fresh lock (crashed/other session)", async () => {
+    const a = makeHarness({ pid: "pid-A" });
+    await a.mgr.acquireLock("op-A");
+
+    // A different session (the recovering one) reclaims the crashed pid-A lock
+    // even though its heartbeat is fresh.
+    const recovering = new PluginLockManager({
+      app: a.app,
+      pid: "pid-recover",
+      now: () => a.clock.current,
+    });
+    expect(await recovering.reclaimIfForeignOrStale()).toBe(true);
+    expect(readSnapshot(a.store)).toBeNull();
+  });
+
+  it("reclaims our OWN lock once it has gone stale", async () => {
+    const { mgr, store, clock } = makeHarness({ staleMs: 1000 });
+    await mgr.acquireLock("op");
+    clock.advance(2000); // heartbeat now older than staleMs
+    expect(await mgr.reclaimIfForeignOrStale()).toBe(true);
+    expect(store.files.has(".exocortex/switch-lock.json")).toBe(false);
+  });
+});
+
 describe("PluginLockManager.checkOnPluginLoad", () => {
   it("returns null holder when no lock file present", async () => {
     const { mgr } = makeHarness();

--- a/packages/obsidian-plugin/tests/unit/ProfileApplyManager.apply.test.ts
+++ b/packages/obsidian-plugin/tests/unit/ProfileApplyManager.apply.test.ts
@@ -1648,6 +1648,54 @@ describe("ProfileApplyManager.recoverIncompleteSwitch — REST apply resume (#1d
     expect(result.resumed).toBe(true);
   });
 
+  it("EMPTY-delta resume (disk already == target) reconciles localDataStore to target + closes the recovery window (no churn)", async () => {
+    // Crash in the window AFTER the last on-disk mount/unmount but BEFORE the
+    // success-save: disk already matches the target effective set, so the resume
+    // computes an empty diff and takes applyProfileViaRest's reindex-only exit
+    // (which writes `completed`, not `apply-completed`). The recovery must still
+    // reconcile localDataStore to target + write a terminal `recovery-completed`
+    // so it does not re-resume on every subsequent reload (HIGH review catch).
+    const { mgr, restMount, localDataStore, app } = setup({
+      targetUid: "target",
+      sourceUid: "source",
+      targetIncludes: [
+        TS_FLOOR_AS_UID_EXO,
+        TS_FLOOR_AS_UID_EXOCMD,
+        TS_FLOOR_AS_UID_SHARED_IDENTITIES,
+        "ems-uid",
+      ],
+      // Disk already == target effective set (floors + ems) — nothing to do.
+      materialized: [
+        TS_FLOOR_AS_UID_EXO,
+        TS_FLOOR_AS_UID_EXOCMD,
+        TS_FLOOR_AS_UID_SHARED_IDENTITIES,
+        "ems-uid",
+      ],
+      wireRestMount: true,
+    });
+    await localDataStore.save({ activeProfileUid: "source", _switchInProgress: true });
+    await app.vault.adapter.write(
+      ".exocortex/switch-journal.jsonl",
+      [
+        JSON.stringify({ phase: "apply-starting", targetUid: "target", ts: "2026-06-19T00:00:00Z" }),
+        JSON.stringify({ phase: "phase2-materialized", targetUid: "target", as: "ems-uid", ts: "2026-06-19T00:00:01Z" }),
+      ].join("\n") + "\n",
+    );
+
+    const result = await mgr.recoverIncompleteSwitch();
+
+    // Empty delta — no mount/unmount — but state reconciled to target.
+    expect(result.resumed).toBe(true);
+    expect(restMount.mounted).toEqual([]);
+    expect(restMount.unmounted).toEqual([]);
+    expect(localDataStore.getActiveProfileUid()).toBe("target");
+    expect(localDataStore.isSwitchInProgress()).toBe(false);
+
+    // Window closed: a second recovery pass does NOT re-resume (no churn loop).
+    const second = await mgr.recoverIncompleteSwitch();
+    expect(second.resumed).toBe(false);
+  });
+
   it("reclaims the crashed session's still-fresh lock so the resume is not blocked (fast reload)", async () => {
     // A reload WITHIN the lock staleness window leaves a foreign-pid lock whose
     // heartbeat is recent (not yet stale). The resume must reclaim it, else

--- a/packages/obsidian-plugin/tests/unit/ProfileApplyManager.apply.test.ts
+++ b/packages/obsidian-plugin/tests/unit/ProfileApplyManager.apply.test.ts
@@ -288,6 +288,21 @@ class FakeConfirmGate implements IConfirmGate {
   }
 }
 
+// REST mount fake (mirrors restApply harness) — records mount/unmount so the
+// REST-aware crash-recovery resume (#1d1bcde0) can be asserted against the
+// driven mount-delta.
+class FakeRestMount {
+  mounted: Array<{ gitUrl: string; submodulePath: string; ref: string }> = [];
+  unmounted: string[] = [];
+  async mount(gitUrl: string, submodulePath: string, ref: string) {
+    this.mounted.push({ gitUrl, submodulePath, ref });
+    return { sha: "abc1234", fileCount: 1 };
+  }
+  async unmount(submodulePath: string): Promise<void> {
+    this.unmounted.push(submodulePath);
+  }
+}
+
 // === Setup helpers ===
 
 interface SetupOptions {
@@ -332,6 +347,13 @@ interface SetupOptions {
    */
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   assetSpaceManagerFactory?: () => Promise<any>;
+  /**
+   * #1d1bcde0 — wire the cross-platform REST mount so the apply path routes
+   * through `applyProfileViaRest` (production path since #3567) and the
+   * REST-aware crash-recovery resume can drive the mount-delta. Default off so
+   * the existing desktop-git apply tests keep exercising the git path.
+   */
+  wireRestMount?: boolean;
 }
 
 function setup(opts: SetupOptions) {
@@ -455,6 +477,7 @@ function setup(opts: SetupOptions) {
   };
   const assetSpaceManager = new FakeAssetSpaceManager();
   const confirmGate = new FakeConfirmGate();
+  const restMount = new FakeRestMount();
 
   // Capture user-facing Notices (#3538 legacy flat-mount warn + others).
   const notifyMessages: string[] = [];
@@ -472,6 +495,7 @@ function setup(opts: SetupOptions) {
     uncommittedGuard: uncommittedGuard as any,
     confirmGate,
     localDataStore: localDataStore as any,
+    restMount: (opts.wireRestMount ? restMount : undefined) as any,
     /* eslint-enable @typescript-eslint/no-explicit-any */
     notify: (m: string) => notifyMessages.push(m),
     vaultRootPath: "/fake/vault",
@@ -494,6 +518,7 @@ function setup(opts: SetupOptions) {
     uncommittedGuard,
     assetSpaceManager,
     confirmGate,
+    restMount,
     notifyMessages,
     app,
     fsFiles,
@@ -1444,6 +1469,8 @@ describe("ProfileApplyManager.recoverIncompleteSwitch", () => {
     // guard returns early.
     await expect(mgr.recoverIncompleteSwitch()).resolves.toEqual({
       restored: [],
+      resumed: false,
+      resumedTo: null,
     });
     // No journal entry was written (true no-op).
     expect(
@@ -1478,6 +1505,8 @@ describe("ProfileApplyManager.recoverIncompleteSwitch", () => {
 
     await expect(mgr.recoverIncompleteSwitch()).resolves.toEqual({
       restored: [],
+      resumed: false,
+      resumedTo: null,
     });
     // Stuck flag cleared.
     expect(localDataStore.isSwitchInProgress()).toBe(false);
@@ -1520,6 +1549,296 @@ describe("ProfileApplyManager.recoverIncompleteSwitch", () => {
     await expect(mgr.recoverIncompleteSwitch()).rejects.toThrow(
       "simulated localDataStore failure during recovery",
     );
+  });
+});
+
+// ============================================================================
+// #1d1bcde0 — REST-aware crash recovery (reload mid-apply on the PRODUCTION
+// REST path since #3567). The dedicated apply-recovery worker previously keyed
+// on `phase2-destroy-cached` events that ONLY the desktop-git mutation emits,
+// so an interrupted REST apply (`apply-starting` + `phase2-materialized`, NO
+// `phase2-destroy-cached`) restored nothing — the vault stayed partially
+// applied with no auto-resume. The fix drives the mount-delta to the target
+// idempotently via `applyProfileViaRest` (mount missing + unmount leftover).
+// ============================================================================
+describe("ProfileApplyManager.recoverIncompleteSwitch — REST apply resume (#1d1bcde0)", () => {
+  it("REGRESSION: interrupted REST apply (phase2-materialized, NO phase2-destroy-cached) drives the mount-delta to target", async () => {
+    // Pre-apply: source = floors + kpc. Target = floors + ems. The user clicks
+    // Apply; runRestApplyMutation mounts ems (phase2-materialized) then CRASHES
+    // (reload) BEFORE unmounting kpc (mount-before-unmount ordering). Disk at
+    // recovery = floors + kpc + ems (partial); journal = apply-starting +
+    // phase2-materialized(ems), NO phase2-destroy-cached; _switchInProgress=true,
+    // activeProfileUid still = source (the success-save never ran).
+    const { mgr, restMount, localDataStore, app } = setup({
+      targetUid: "target",
+      sourceUid: "source",
+      targetIncludes: [
+        TS_FLOOR_AS_UID_EXO,
+        TS_FLOOR_AS_UID_EXOCMD,
+        TS_FLOOR_AS_UID_SHARED_IDENTITIES,
+        "ems-uid",
+      ],
+      materialized: [
+        TS_FLOOR_AS_UID_EXO,
+        TS_FLOOR_AS_UID_EXOCMD,
+        TS_FLOOR_AS_UID_SHARED_IDENTITIES,
+        "kpc-uid",
+        "ems-uid",
+      ],
+      wireRestMount: true,
+    });
+    await localDataStore.save({ activeProfileUid: "source", _switchInProgress: true });
+    await app.vault.adapter.write(
+      ".exocortex/switch-journal.jsonl",
+      [
+        JSON.stringify({ phase: "apply-starting", targetUid: "target", ts: "2026-06-19T00:00:00Z" }),
+        JSON.stringify({ phase: "phase2-materialized", targetUid: "target", as: "ems-uid", ts: "2026-06-19T00:00:01Z" }),
+      ].join("\n") + "\n",
+    );
+
+    const result = await mgr.recoverIncompleteSwitch();
+
+    // The leftover source AssetSpace (kpc) is unmounted; ems is already mounted
+    // so nothing is re-mounted — the mount-delta is reconciled to the target.
+    expect(restMount.unmounted).toEqual(["assetspaces/kitelev/exoas-kpc"]);
+    expect(restMount.mounted).toEqual([]);
+    // activeProfileUid is declared TARGET only AFTER the mount-state matches it
+    // (runRestApplyMutation's success save), and the stuck flag is cleared.
+    expect(localDataStore.getActiveProfileUid()).toBe("target");
+    expect(localDataStore.isSwitchInProgress()).toBe(false);
+    expect(result.resumed).toBe(true);
+    expect(result.resumedTo).toBe("target");
+  });
+
+  it("REGRESSION: interrupted REST apply BEFORE the first mount (apply-starting only) mounts missing + unmounts leftover", async () => {
+    // Crash right after apply-starting (before mounting ems, before unmounting
+    // kpc). Disk = floors + kpc (pre-apply state). Recovery drives to target
+    // (mount ems, unmount kpc).
+    const { mgr, restMount, localDataStore, app } = setup({
+      targetUid: "target",
+      sourceUid: "source",
+      targetIncludes: [
+        TS_FLOOR_AS_UID_EXO,
+        TS_FLOOR_AS_UID_EXOCMD,
+        TS_FLOOR_AS_UID_SHARED_IDENTITIES,
+        "ems-uid",
+      ],
+      materialized: [
+        TS_FLOOR_AS_UID_EXO,
+        TS_FLOOR_AS_UID_EXOCMD,
+        TS_FLOOR_AS_UID_SHARED_IDENTITIES,
+        "kpc-uid",
+      ],
+      wireRestMount: true,
+    });
+    await localDataStore.save({ activeProfileUid: "source", _switchInProgress: true });
+    await app.vault.adapter.write(
+      ".exocortex/switch-journal.jsonl",
+      JSON.stringify({ phase: "apply-starting", targetUid: "target", ts: "2026-06-19T00:00:00Z" }) + "\n",
+    );
+
+    const result = await mgr.recoverIncompleteSwitch();
+
+    expect(restMount.mounted.map((m) => m.submodulePath)).toEqual([
+      "assetspaces/kitelev/exoas-ems",
+    ]);
+    expect(restMount.unmounted).toEqual(["assetspaces/kitelev/exoas-kpc"]);
+    expect(localDataStore.getActiveProfileUid()).toBe("target");
+    expect(localDataStore.isSwitchInProgress()).toBe(false);
+    expect(result.resumed).toBe(true);
+  });
+
+  it("reclaims the crashed session's still-fresh lock so the resume is not blocked (fast reload)", async () => {
+    // A reload WITHIN the lock staleness window leaves a foreign-pid lock whose
+    // heartbeat is recent (not yet stale). The resume must reclaim it, else
+    // applyProfileViaRest's acquireLock would falsely report "another switch in
+    // progress" and the recovery would never run.
+    const { mgr, restMount, localDataStore, app } = setup({
+      targetUid: "target",
+      sourceUid: "source",
+      targetIncludes: [
+        TS_FLOOR_AS_UID_EXO,
+        TS_FLOOR_AS_UID_EXOCMD,
+        TS_FLOOR_AS_UID_SHARED_IDENTITIES,
+        "ems-uid",
+      ],
+      materialized: [
+        TS_FLOOR_AS_UID_EXO,
+        TS_FLOOR_AS_UID_EXOCMD,
+        TS_FLOOR_AS_UID_SHARED_IDENTITIES,
+        "kpc-uid",
+        "ems-uid",
+      ],
+      wireRestMount: true,
+    });
+    await localDataStore.save({ activeProfileUid: "source", _switchInProgress: true });
+    // Seed the crashed session's lock — foreign pid, FRESH heartbeat (now).
+    await app.vault.adapter.write(
+      ".exocortex/switch-lock.json",
+      JSON.stringify({
+        pid: "crashed-session-9999",
+        acquiredAt: new Date().toISOString(),
+        lastHeartbeat: new Date().toISOString(),
+        operation: "apply-rest-target",
+      }),
+    );
+    await app.vault.adapter.write(
+      ".exocortex/switch-journal.jsonl",
+      [
+        JSON.stringify({ phase: "apply-starting", targetUid: "target", ts: "2026-06-19T00:00:00Z" }),
+        JSON.stringify({ phase: "phase2-materialized", targetUid: "target", as: "ems-uid", ts: "2026-06-19T00:00:01Z" }),
+      ].join("\n") + "\n",
+    );
+
+    const result = await mgr.recoverIncompleteSwitch();
+
+    // The resume proceeded despite the foreign lock — mount-delta driven to target.
+    expect(result.resumed).toBe(true);
+    expect(restMount.unmounted).toEqual(["assetspaces/kitelev/exoas-kpc"]);
+    expect(localDataStore.getActiveProfileUid()).toBe("target");
+  });
+
+  it("does NOT skip the confirm gate for a normal apply — only the recovery resume auto-resumes", async () => {
+    // Sibling/control: a normal applyProfile still goes through the confirm gate
+    // (proves skipConfirm is scoped to the recovery resume, not leaked).
+    const { mgr, confirmGate, restMount } = setup({
+      targetUid: "target",
+      sourceUid: "source",
+      targetIncludes: [
+        TS_FLOOR_AS_UID_EXO,
+        TS_FLOOR_AS_UID_EXOCMD,
+        TS_FLOOR_AS_UID_SHARED_IDENTITIES,
+        "ems-uid",
+      ],
+      materialized: [
+        TS_FLOOR_AS_UID_EXO,
+        TS_FLOOR_AS_UID_EXOCMD,
+        TS_FLOOR_AS_UID_SHARED_IDENTITIES,
+        "kpc-uid",
+      ],
+      wireRestMount: true,
+    });
+    confirmGate.approve = false;
+    await expect(mgr.applyProfile("target")).rejects.toThrow(ApplyAbortedByUser);
+    // Declined → no mutation.
+    expect(restMount.mounted).toEqual([]);
+    expect(restMount.unmounted).toEqual([]);
+  });
+
+  it("CONTROL: the desktop-git journal (phase2-destroy-cached) still cache-restores — REST resume is path-scoped", async () => {
+    // Regression guard: the existing desktop-git cache-restore path is unchanged
+    // even with restMount wired — the journal's git signature
+    // (`phase2-destroy-cached`) routes to the cache-restore branch, NOT the REST
+    // resume.
+    const { mgr, cacheLayer, restMount, app, localDataStore } = setup({
+      targetUid: "target",
+      sourceUid: "source",
+      targetIncludes: [
+        TS_FLOOR_AS_UID_EXO,
+        TS_FLOOR_AS_UID_EXOCMD,
+        TS_FLOOR_AS_UID_SHARED_IDENTITIES,
+      ],
+      materialized: [
+        TS_FLOOR_AS_UID_EXO,
+        TS_FLOOR_AS_UID_EXOCMD,
+        TS_FLOOR_AS_UID_SHARED_IDENTITIES,
+      ],
+      wireRestMount: true,
+    });
+    await localDataStore.save({ activeProfileUid: "source", _switchInProgress: true });
+    await app.vault.adapter.write(
+      ".exocortex/switch-journal.jsonl",
+      [
+        JSON.stringify({ phase: "phase2-start", targetUid: "target", ts: "2026-06-19T00:00:00Z" }),
+        JSON.stringify({ phase: "phase2-destroy-cached", targetUid: "target", as: "kpc-uid", ts: "2026-06-19T00:00:01Z" }),
+        JSON.stringify({ phase: "phase2-destroyed", targetUid: "target", as: "kpc-uid", ts: "2026-06-19T00:00:02Z" }),
+      ].join("\n") + "\n",
+    );
+
+    const result = await mgr.recoverIncompleteSwitch();
+
+    // Cache-restore fired (desktop-git path); REST mount was NOT used.
+    expect(result.restored).toContain("kpc-uid");
+    expect(cacheLayer.restoreCalls.length).toBeGreaterThan(0);
+    expect(restMount.mounted).toEqual([]);
+    expect(restMount.unmounted).toEqual([]);
+    expect(result.resumed).toBe(false);
+  });
+});
+
+// #1d1bcde0 F2 — recoverIfNeeded must NOT prematurely declare an interrupted
+// APPLY mutation "Applied". A re-index would persist activeProfileUid=TARGET +
+// clear the in-progress flag against a PARTIAL mount-state. The apply-mutation
+// interruption is deferred to the apply-recovery worker (recoverIncompleteSwitch).
+describe("ProfileApplyManager.recoverIfNeeded — defers apply-mutation interruptions (#1d1bcde0 F2)", () => {
+  it("REGRESSION: interrupted REST apply does NOT re-index / declare target active (deferred to apply recovery)", async () => {
+    const { mgr, settingsStore, app, notifyMessages } = setup({
+      targetUid: "target",
+      sourceUid: "source",
+      targetIncludes: [
+        TS_FLOOR_AS_UID_EXO,
+        TS_FLOOR_AS_UID_EXOCMD,
+        TS_FLOOR_AS_UID_SHARED_IDENTITIES,
+        "ems-uid",
+      ],
+      materialized: [
+        TS_FLOOR_AS_UID_EXO,
+        TS_FLOOR_AS_UID_EXOCMD,
+        TS_FLOOR_AS_UID_SHARED_IDENTITIES,
+        "kpc-uid",
+        "ems-uid",
+      ],
+      wireRestMount: true,
+    });
+    // recoverIfNeeded reads `_switchInProgress` from the settingsStore.
+    await settingsStore.save({ activeProfileUid: "source", _switchInProgress: true });
+    await app.vault.adapter.write(
+      ".exocortex/switch-journal.jsonl",
+      [
+        JSON.stringify({ phase: "apply-starting", targetUid: "target", ts: "2026-06-19T00:00:00Z" }),
+        JSON.stringify({ phase: "phase2-materialized", targetUid: "target", as: "ems-uid", ts: "2026-06-19T00:00:01Z" }),
+      ].join("\n") + "\n",
+    );
+
+    const recovery = await mgr.recoverIfNeeded();
+
+    // Deferred — recoverIfNeeded did not re-index / declare anything.
+    expect(recovery.recovered).toBe(false);
+    expect(recovery.targetUid).toBe(null);
+    // activeProfileUid NOT prematurely flipped to target on a partial disk.
+    const settings = await settingsStore.load();
+    expect(settings.activeProfileUid).not.toBe("target");
+    // No premature "Applied <target>" / "Recovering" notice.
+    expect(notifyMessages).toEqual([]);
+  });
+
+  it("CONTROL: a pure reindex-only interruption (starting, no mutation) still re-indexes", async () => {
+    // A reindex-only switch (no filesystem mutation) interrupted mid-reindex —
+    // recoverIfNeeded SHOULD still re-trigger the idempotent re-index.
+    const { mgr, settingsStore, app } = setup({
+      targetUid: "target",
+      sourceUid: "source",
+      targetIncludes: [
+        TS_FLOOR_AS_UID_EXO,
+        TS_FLOOR_AS_UID_EXOCMD,
+        TS_FLOOR_AS_UID_SHARED_IDENTITIES,
+      ],
+      materialized: [
+        TS_FLOOR_AS_UID_EXO,
+        TS_FLOOR_AS_UID_EXOCMD,
+        TS_FLOOR_AS_UID_SHARED_IDENTITIES,
+      ],
+    });
+    await settingsStore.save({ activeProfileUid: "source", _switchInProgress: true });
+    await app.vault.adapter.write(
+      ".exocortex/switch-journal.jsonl",
+      JSON.stringify({ phase: "starting", targetUid: "target", ts: "2026-06-19T00:00:00Z" }) + "\n",
+    );
+
+    const recovery = await mgr.recoverIfNeeded();
+
+    expect(recovery.recovered).toBe(true);
+    expect(recovery.targetUid).toBe("target");
   });
 });
 


### PR DESCRIPTION
## Problem (HIGH alpha bug — #1d1bcde0)

Reloading Obsidian (`Reload app without saving`) **during** `Exocortex: Apply profile` left the vault in a partial mount-state with **no auto-resume** on the **production REST path** (git-free mount, #3567, active on desktop + mobile). The dedicated crash-recovery worker was a no-op for production.

### Root causes (verified: code + live journal + runnable test)

- **F1 (HIGH — core):** `recoverIncompleteSwitch()` collected destroyed AS **only** from the `phase2-destroy-cached` journal phase — which the desktop-git mutation emits but `runRestApplyMutation` **never** does (it writes `phase2-materialized`/`phase2-destroyed`). → interrupted REST apply restored nothing.
- **F2 (MED — premature "Applied"):** `recoverIfNeeded()` re-indexed the **partial** disk and persisted `activeProfileUid=TARGET` + cleared the in-progress flag, declaring an incomplete switch "Applied" while the disk did not match the target.
- **F3 (LOW/MED — mobile gap):** the apply-recovery worker was desktop-gated (`hasApplyDeps`) so mobile had no resume at all; the fallback `reconcileToLocal` was git-only + mislabeled.

## Fix

Classify the interrupted switch from the journal tail (git-only phases vs REST phases), then:

- **F1 — REST-aware resume:** for an interrupted REST apply, idempotently drive the mount-delta to the target by re-running `applyProfileViaRest(target, { skipConfirm })` — mount missing + unmount leftover source AS (per-op idempotent). The confirm gate is skipped because the user already approved the apply pre-crash. The crashed session's still-fresh lock is reclaimed so the resume isn't falsely blocked by "another switch in progress".
- **F2:** `recoverIfNeeded()` now **defers** apply-mutation interruptions to the apply-recovery worker (re-index is reserved for pure reindex-only switches). `activeProfileUid` is declared TARGET **only after** the mount-state matches it (the resume's success save).
- **F3:** the apply-recovery worker runs on **both platforms** (restMount is wired on desktop + mobile per the Desktop↔Mobile Command Parity invariant) — closing the mobile gap. After the resume reconciles the disk to the target, the cross-device `reconcileToLocal` sees no divergence (so its label is no longer reached for same-device crashes).

The desktop-git cache-restore branch is **unchanged** (regression-guarded).

## Invariants honored

- **Zero-data-loss / M1-safe:** mount-before-unmount + per-op-idempotent REST mount/unmount; the resume reuses the proven `runRestApplyMutation` machinery (watchdog, lock, uncommitted-guard). Only freshly-pulled AssetSpaces are ever removed on rollback; the to-destroy set is exactly what the user consented to remove.
- **Desktop↔Mobile Parity:** fix works on the REST path on both platforms; no `Platform.isMobile` gating of recovery (archgate MOBILE-004 pass).

## Tests (revert-verify — empirically FAIL pre-fix, PASS post-fix)

- **REGRESSION:** interrupted REST apply (`apply-starting` + `phase2-materialized`, NO `phase2-destroy-cached`) → recovery drives the mount-delta to target. **FAILS pre-fix** (`unmounted===[]`, target not reached); **PASSES post-fix** (kpc unmounted, `activeProfileUid=target`).
- interrupted REST apply **before the first mount** (`apply-starting` only) → mounts missing + unmounts leftover.
- **foreign-lock reclaim:** a fast reload leaves a still-fresh foreign-pid lock → the resume reclaims it and proceeds.
- **CONTROL (regression guard):** desktop-git journal (`phase2-destroy-cached`) still cache-restores — REST resume is path-scoped.
- **F2:** `recoverIfNeeded` defers apply-mutation interruptions (does not re-index / declare target); a pure reindex-only interruption still re-indexes (control).

Local: `ProfileApplyManager.*` + `ProfileSwitch.regression` + `ProfileWiring.integration` + `ExocortexPlugin` + `ApplyEndToEnd.integration` suites green; typecheck + lint + archgate clean.

### Visual smoke

Reload-mid-apply is supervision-required + screen-lock-fragile and the parallel Docker-e2e child precludes local Docker (kernel-panic rule); the bug was proven by a runnable test and the fix is verified by the same test now PASSing (revert-verify). Live reload-mid-apply UI smoke noted as a follow-up.

Closes #1d1bcde0 (vault node).