### PR TITLE
fix(activity-log): log ALL plugin Notices + selectable modal text (#3540)

### DIFF
--- a/packages/obsidian-plugin/src/ExocortexPlugin.ts
+++ b/packages/obsidian-plugin/src/ExocortexPlugin.ts
@@ -74,7 +74,11 @@ import { LayoutCodeBlockProcessor } from "./application/processors/LayoutCodeBlo
 import { SPARQLApi } from "./application/api/SPARQLApi";
 import { ExocortexAPI } from "./application/api/ExocortexAPI";
 import { PluginContainer } from "./infrastructure/di/PluginContainer";
-import { ObsidianNotificationService } from "./infrastructure/di/ObsidianNotificationService";
+import {
+  ObsidianNotificationService,
+  setDefaultNotificationActivityRecorder,
+  type NotificationActivityRecorder,
+} from "./infrastructure/di/ObsidianNotificationService";
 import {
   createAliasIconExtension,
   createWikilinkLabelExtension,
@@ -400,12 +404,25 @@ export default class ExocortexPlugin extends Plugin {
 
       await this.loadSettings();
 
-      // Initialize notification service and log channel routing
-      this.notifier = new ObsidianNotificationService();
+      // #3540 — always-on activity buffer; sources fan in from onload onward.
+      // Created BEFORE the notifier so every toast routed through the central
+      // INotificationService sink (ObsidianNotificationService) records here.
+      this.activityLog = new ActivityLogService();
+      // Initialize notification service + log channel routing. The notifier is
+      // the single `new Notice` sink (eslint forbids `new Notice` elsewhere),
+      // so wiring it to the activity log makes the log COMPLETE — every toast
+      // appears, not just the few structured producer feeds. The module-level
+      // default recorder also covers ObsidianNotificationService instances built
+      // inside command flows that never receive `activityLog` directly (the
+      // exocmd palette flow, CommandManager) — see #3540 follow-up.
+      const recordToast: NotificationActivityRecorder = ({ level, message }) =>
+        this.activityLog.record({ category: "notice", level, message });
+      setDefaultNotificationActivityRecorder(recordToast);
+      this.notifier = new ObsidianNotificationService({
+        recordActivity: recordToast,
+      });
       this.fileLogChannel = new FileLogChannel(this.app.vault.adapter, this.manifest.dir ?? `${this.app.vault.configDir}/plugins/${this.manifest.id}`);
       await this.fileLogChannel.ensureFileExists();
-      // #3540 — always-on activity buffer; sources fan in from onload onward.
-      this.activityLog = new ActivityLogService();
       this.configureLogChannels();
 
       this.printNameRuleService = new PrintNameRuleService(this.app);
@@ -1710,6 +1727,10 @@ export default class ExocortexPlugin extends Plugin {
   }
 
   override async onunload(): Promise<void> {
+    // #3540 follow-up — drop the module-level toast→activity-log recorder so a
+    // reloaded plugin's notifications don't fan into this (now-stale) buffer.
+    setDefaultNotificationActivityRecorder(undefined);
+
     // Dispose timer manager first to prevent any more timer callbacks from firing
     if (this.timerManager) {
       this.timerManager.dispose();
@@ -3483,11 +3504,9 @@ export default class ExocortexPlugin extends Plugin {
             resolve,
           ).open();
         }),
-      notify: (message) => {
-        this.notifier.info(message);
-        // #3540 — surface bootstrap / add-assetspace progress in the activity log.
-        this.activityLog.record({ category: "bootstrap", level: "info", message });
-      },
+      // #3540 follow-up — `notifier.info` now fans every toast into the
+      // activity log itself (category "notice"), so no manual record() here.
+      notify: (message) => this.notifier.info(message),
       onMaterialized: () => this.refreshAndInjectAssetSpaceMaterialization(),
     });
 
@@ -3576,10 +3595,8 @@ export default class ExocortexPlugin extends Plugin {
           ).open();
         }),
       unmount: (submodulePath) => restMount.unmount(submodulePath),
-      notify: (message) => {
-        this.notifier.info(message);
-        this.activityLog.record({ category: "bootstrap", level: "info", message });
-      },
+      // #3540 follow-up — toast auto-records into the activity log via notifier.
+      notify: (message) => this.notifier.info(message),
       onUnmounted: () => this.refreshAndInjectAssetSpaceMaterialization(),
     });
 

--- a/packages/obsidian-plugin/src/adapters/logging/ActivityLogService.ts
+++ b/packages/obsidian-plugin/src/adapters/logging/ActivityLogService.ts
@@ -24,6 +24,9 @@ export type ActivityCategory =
   | "exosync"
   | "profile"
   | "mount"
+  // Reserved: bootstrap/add-assetspace/unmount progress now flows through the
+  // central notifier as "notice" (#3540 follow-up), so no producer currently
+  // emits "bootstrap" — kept as a valid category a future feed may re-adopt.
   | "bootstrap"
   // #3540 follow-up — every user-facing toast (any `INotificationService`
   // call routed through ObsidianNotificationService) fans in here so the

--- a/packages/obsidian-plugin/src/adapters/logging/ActivityLogService.ts
+++ b/packages/obsidian-plugin/src/adapters/logging/ActivityLogService.ts
@@ -20,7 +20,15 @@
  *    `category:"exosync"` with `level:"error"`.
  */
 
-export type ActivityCategory = "exosync" | "profile" | "mount" | "bootstrap";
+export type ActivityCategory =
+  | "exosync"
+  | "profile"
+  | "mount"
+  | "bootstrap"
+  // #3540 follow-up — every user-facing toast (any `INotificationService`
+  // call routed through ObsidianNotificationService) fans in here so the
+  // activity log is complete, not just the few structured producer feeds.
+  | "notice";
 export type ActivityLevel = "info" | "warn" | "error";
 
 export interface ActivityEntry {

--- a/packages/obsidian-plugin/src/infrastructure/di/ObsidianNotificationService.ts
+++ b/packages/obsidian-plugin/src/infrastructure/di/ObsidianNotificationService.ts
@@ -1,26 +1,87 @@
 import { INotificationService } from "exocortex";
 import { Notice } from "obsidian";
+import type { ActivityLevel } from "../../adapters/logging/ActivityLogService";
+
+/**
+ * Sink that records a user-facing notification into the activity log (#3540).
+ * Receives the activity `level` + the plain message (no toast emoji prefix —
+ * the log renders its own level marker).
+ */
+export type NotificationActivityRecorder = (record: {
+  level: ActivityLevel;
+  message: string;
+}) => void;
+
+/**
+ * Module-level default recorder. Set once in `ExocortexPlugin.onload()` so that
+ * EVERY `ObsidianNotificationService` instance — including those constructed
+ * inside command flows that never receive the plugin's `activityLog` (the
+ * exocmd palette flow, `CommandManager`) — fans its toasts into the same
+ * always-on buffer. This is the safety net that makes the activity log
+ * complete: the bug it fixes was precisely that only a handful of producers
+ * recorded, while the central toast sink did not. Explicit constructor
+ * injection (used by unit tests) takes precedence over this default.
+ */
+let defaultActivityRecorder: NotificationActivityRecorder | undefined;
+
+/** Wire (or clear, on plugin unload) the module-level default recorder. */
+export function setDefaultNotificationActivityRecorder(
+  recorder: NotificationActivityRecorder | undefined,
+): void {
+  defaultActivityRecorder = recorder;
+}
 
 export class ObsidianNotificationService implements INotificationService {
   private readonly DEFAULT_DURATION = 4000;
+  private readonly recordActivity?: NotificationActivityRecorder;
+
+  /**
+   * @param options.recordActivity Explicit activity-log sink. When omitted the
+   *   instance falls back to the module-level default recorder (see
+   *   {@link setDefaultNotificationActivityRecorder}), so toasts are logged even
+   *   when this service is built without direct access to the plugin's
+   *   `activityLog`.
+   */
+  constructor(options?: { recordActivity?: NotificationActivityRecorder }) {
+    this.recordActivity = options?.recordActivity;
+  }
+
+  /**
+   * Fan one toast into the activity log. Resolves the explicit recorder first,
+   * then the module default. Isolated so a recorder failure can never break the
+   * user-facing Notice (the toast must still show).
+   */
+  private record(level: ActivityLevel, message: string): void {
+    const sink = this.recordActivity ?? defaultActivityRecorder;
+    if (!sink) return;
+    try {
+      sink({ level, message });
+    } catch {
+      // Recording must never break the toast — swallow listener failures.
+    }
+  }
 
   info(message: string, duration?: number): void {
     console.debug("[Exocortex] info:", message);
+    this.record("info", message);
     new Notice(message, duration || this.DEFAULT_DURATION);
   }
 
   success(message: string, duration?: number): void {
     console.debug("[Exocortex] success:", message);
+    this.record("info", message);
     new Notice(`✓ ${message}`, duration || this.DEFAULT_DURATION);
   }
 
   error(message: string, duration?: number): void {
     console.error("[Exocortex] error:", message);
+    this.record("error", message);
     new Notice(`✗ ${message}`, duration || this.DEFAULT_DURATION);
   }
 
   warn(message: string, duration?: number): void {
     console.warn("[Exocortex] warn:", message);
+    this.record("warn", message);
     new Notice(`⚠ ${message}`, duration || this.DEFAULT_DURATION);
   }
 

--- a/packages/obsidian-plugin/src/infrastructure/di/PluginContainer.ts
+++ b/packages/obsidian-plugin/src/infrastructure/di/PluginContainer.ts
@@ -28,7 +28,11 @@ export class PluginContainer {
     });
 
     container.register(DI_TOKENS.INotificationService, {
-      useClass: ObsidianNotificationService,
+      // useFactory (not useClass) — the service now has an optional constructor
+      // param (the activity-log recorder, #3540 follow-up), which tsyringe
+      // cannot auto-resolve. Construct it explicitly with no args; it falls back
+      // to the module-level default recorder set in ExocortexPlugin.onload().
+      useFactory: () => new ObsidianNotificationService(),
     });
 
     const vaultAdapter = new ObsidianVaultAdapter(

--- a/packages/obsidian-plugin/styles.css
+++ b/packages/obsidian-plugin/styles.css
@@ -6214,6 +6214,13 @@
   border-radius: var(--radius-s, 4px);
   padding: var(--size-4-2, 8px);
   margin-bottom: var(--size-4-3, 12px);
+  /* Bug fix — the log lines must be selectable + copyable with the mouse.
+     Obsidian/Electron app chrome defaults to user-select:none, so opt the
+     activity stream back in explicitly (webkit prefix for the WKWebView /
+     Chromium runtime). The Copy button stays as a "copy all" affordance. */
+  -webkit-user-select: text;
+  user-select: text;
+  cursor: text;
 }
 
 .exocortex-activity-log-row {

--- a/packages/obsidian-plugin/tests/unit/adapters/logging/activityLog.integration.test.ts
+++ b/packages/obsidian-plugin/tests/unit/adapters/logging/activityLog.integration.test.ts
@@ -78,7 +78,8 @@ beforeEach(() => {
 });
 
 describe("activity-log fan-in (integration)", () => {
-  it("fans ExoSync + profile + mount + bootstrap events into one categorized stream", () => {
+  it("fans ExoSync + profile + mount + notice events into one categorized stream", () => {
+    jest.spyOn(console, "debug").mockImplementation(() => undefined);
     const svc = new ActivityLogService({ now: () => 0 });
 
     // Wire exactly as ExocortexPlugin.onload does.
@@ -86,11 +87,16 @@ describe("activity-log fan-in (integration)", () => {
       svc.record({ category: "exosync", level: "info", message });
     const onPhase = (entry: SwitchJournalEntry): void =>
       svc.record(journalEntryToActivity(entry));
-    const onBootstrap = (message: string): void =>
-      svc.record({ category: "bootstrap", level: "info", message });
+    // Bootstrap / add-assetspace progress now flows through the central notifier
+    // (toast → category "notice"), NOT a dedicated bootstrap record — #3540
+    // follow-up. Use the REAL service so this mirrors onload faithfully.
+    const notifier = new ObsidianNotificationService({
+      recordActivity: ({ level, message }) =>
+        svc.record({ category: "notice", level, message }),
+    });
 
     // --- Simulate producers (the events these sources actually emit) ---
-    onBootstrap("Bootstrapping vault...");
+    notifier.info("Bootstrapping vault...");
     onSyncInfo("Detecting changes for exo");
     onSyncInfo("Fully synced");
     onPhase({ phase: "apply-starting", targetUid: "p1", ts: "t" });
@@ -114,7 +120,7 @@ describe("activity-log fan-in (integration)", () => {
       return acc;
     }, {});
     expect(byCategory).toEqual({
-      bootstrap: 1,
+      notice: 1, // bootstrap toast via the central notifier
       exosync: 2,
       profile: 2, // apply-starting + apply-completed
       mount: 2, // materialized + destroyed (per-AS)
@@ -125,11 +131,13 @@ describe("activity-log fan-in (integration)", () => {
     const text = document.querySelector(
       ".exocortex-activity-log-list",
     )?.textContent;
-    expect(text).toMatch(/\[bootstrap\] Bootstrapping vault/);
+    expect(text).toMatch(/\[notice\] Bootstrapping vault/);
     expect(text).toMatch(/\[exosync\] Fully synced/);
     expect(text).toMatch(/\[mount\] Mounted 1b20a8f0/);
     expect(text).toMatch(/\[mount\] Unmounted abcd1234/);
     expect(text).toMatch(/\[profile\] Apply completed \(50ms\)/);
+
+    jest.restoreAllMocks();
   });
 
   it("Bug 1 — the real notifier fans EVERY toast into the activity log (category 'notice')", () => {

--- a/packages/obsidian-plugin/tests/unit/adapters/logging/activityLog.integration.test.ts
+++ b/packages/obsidian-plugin/tests/unit/adapters/logging/activityLog.integration.test.ts
@@ -3,7 +3,9 @@
  * collaborating units exactly as `ExocortexPlugin.onload()` wires them —
  *   - ExoSync `logInfo`/`log` → activityLog.record({category:"exosync", ...})
  *   - ProfileApplyManager `onPhase` → activityLog.record(journalEntryToActivity)
- *   - bootstrap `notify` → activityLog.record({category:"bootstrap", ...})
+ *   - every toast via ObsidianNotificationService → record({category:"notice"})
+ *     (bootstrap / add-assetspace / unmount progress flow through here now —
+ *     the central notifier is the single sink, #3540 follow-up)
  * — feeds simulated producer events, then renders an ActivityLogModal over the
  * resulting buffer and asserts the categories surface correctly (AC2/AC3/AC6).
  *
@@ -51,13 +53,22 @@ jest.mock("obsidian", () => {
     onOpen(): void {}
     onClose(): void {}
   }
-  return { Modal: MockModal, App: class {} };
+  return {
+    Modal: MockModal,
+    App: class {},
+    // The real ObsidianNotificationService constructs `new Notice(...)`; a noop
+    // class is enough for the recording-path assertions below.
+    Notice: class {
+      constructor(_message?: string, _duration?: number) {}
+    },
+  };
 });
 
 import type { App } from "obsidian";
 import { ActivityLogService } from "../../../../src/adapters/logging/ActivityLogService";
 import { journalEntryToActivity } from "../../../../src/adapters/logging/activityFanIn";
 import { ActivityLogModal } from "../../../../src/presentation/modals/ActivityLogModal";
+import { ObsidianNotificationService } from "../../../../src/infrastructure/di/ObsidianNotificationService";
 import type { SwitchJournalEntry } from "../../../../src/infrastructure/adapters/ProfileApplyManager";
 
 const fakeApp = {} as unknown as App;
@@ -119,6 +130,52 @@ describe("activity-log fan-in (integration)", () => {
     expect(text).toMatch(/\[mount\] Mounted 1b20a8f0/);
     expect(text).toMatch(/\[mount\] Unmounted abcd1234/);
     expect(text).toMatch(/\[profile\] Apply completed \(50ms\)/);
+  });
+
+  it("Bug 1 — the real notifier fans EVERY toast into the activity log (category 'notice')", () => {
+    // Production-shape: wire the REAL ObsidianNotificationService to the REAL
+    // ActivityLogService exactly as ExocortexPlugin.onload does, then emit the
+    // four toast kinds and assert each lands in the stream. Pre-fix, these
+    // toasts bypassed the log entirely (the bug).
+    jest.spyOn(console, "debug").mockImplementation(() => undefined);
+    jest.spyOn(console, "warn").mockImplementation(() => undefined);
+    jest.spyOn(console, "error").mockImplementation(() => undefined);
+
+    const svc = new ActivityLogService({ now: () => 0 });
+    const notifier = new ObsidianNotificationService({
+      recordActivity: ({ level, message }) =>
+        svc.record({ category: "notice", level, message }),
+    });
+
+    notifier.info("Saved settings");
+    notifier.warn("PAT not set");
+    notifier.error("Sync failed: 403");
+    notifier.success("Applied profile");
+
+    expect(
+      svc.getSnapshot().map((e) => ({
+        category: e.category,
+        level: e.level,
+        message: e.message,
+      })),
+    ).toEqual([
+      { category: "notice", level: "info", message: "Saved settings" },
+      { category: "notice", level: "warn", message: "PAT not set" },
+      { category: "notice", level: "error", message: "Sync failed: 403" },
+      { category: "notice", level: "info", message: "Applied profile" },
+    ]);
+
+    // Surfaces in the modal with the level marker rendered (AC3).
+    new ActivityLogModal(fakeApp, svc).open();
+    const text = document.querySelector(
+      ".exocortex-activity-log-list",
+    )?.textContent;
+    expect(text).toMatch(/\[notice\] Saved settings/);
+    expect(text).toMatch(/\[notice\] WARN PAT not set/);
+    expect(text).toMatch(/\[notice\] ERROR Sync failed: 403/);
+    expect(text).toMatch(/\[notice\] Applied profile/);
+
+    jest.restoreAllMocks();
   });
 
   it("AC2 — events recorded after the modal opens append live", () => {

--- a/packages/obsidian-plugin/tests/unit/infrastructure/di/ObsidianNotificationService.test.ts
+++ b/packages/obsidian-plugin/tests/unit/infrastructure/di/ObsidianNotificationService.test.ts
@@ -1,4 +1,8 @@
-import { ObsidianNotificationService } from "../../../../src/infrastructure/di/ObsidianNotificationService";
+import {
+  ObsidianNotificationService,
+  setDefaultNotificationActivityRecorder,
+  type NotificationActivityRecorder,
+} from "../../../../src/infrastructure/di/ObsidianNotificationService";
 import { Notice } from "obsidian";
 
 jest.mock("obsidian", () => ({
@@ -13,11 +17,15 @@ describe("ObsidianNotificationService", () => {
     jest.spyOn(console, "debug").mockImplementation();
     jest.spyOn(console, "error").mockImplementation();
     jest.spyOn(console, "warn").mockImplementation();
+    // Reset the module-level default recorder so its presence/absence is
+    // controlled per-test, never leaked across tests.
+    setDefaultNotificationActivityRecorder(undefined);
     service = new ObsidianNotificationService();
   });
 
   afterEach(() => {
     jest.restoreAllMocks();
+    setDefaultNotificationActivityRecorder(undefined);
   });
 
   describe("info", () => {
@@ -103,6 +111,102 @@ describe("ObsidianNotificationService", () => {
       service.warn("Warning message", 5000);
 
       expect(Notice).toHaveBeenCalledWith("⚠ Warning message", 5000);
+    });
+  });
+
+  // #3540 follow-up — every toast must fan into the activity log so the
+  // «Open activity log» modal is complete (Bug 1: not all Notices were logged).
+  describe("activity-log recording", () => {
+    it("records info as level 'info' with the plain message (no toast prefix)", () => {
+      const records: Array<{ level: string; message: string }> = [];
+      const recorder: NotificationActivityRecorder = (r) => records.push(r);
+      const svc = new ObsidianNotificationService({ recordActivity: recorder });
+
+      svc.info("hello");
+
+      expect(records).toEqual([{ level: "info", message: "hello" }]);
+      // The toast still shows — recording is additive.
+      expect(Notice).toHaveBeenCalledWith("hello", 4000);
+    });
+
+    it("records success as level 'info' with the plain message (✓ stays toast-only)", () => {
+      const records: Array<{ level: string; message: string }> = [];
+      const svc = new ObsidianNotificationService({
+        recordActivity: (r) => records.push(r),
+      });
+
+      svc.success("done");
+
+      expect(records).toEqual([{ level: "info", message: "done" }]);
+      expect(Notice).toHaveBeenCalledWith("✓ done", 4000);
+    });
+
+    it("records warn as level 'warn' with the plain message (⚠ stays toast-only)", () => {
+      const records: Array<{ level: string; message: string }> = [];
+      const svc = new ObsidianNotificationService({
+        recordActivity: (r) => records.push(r),
+      });
+
+      svc.warn("careful");
+
+      expect(records).toEqual([{ level: "warn", message: "careful" }]);
+      expect(Notice).toHaveBeenCalledWith("⚠ careful", 4000);
+    });
+
+    it("records error as level 'error' with the plain message (✗ stays toast-only)", () => {
+      const records: Array<{ level: string; message: string }> = [];
+      const svc = new ObsidianNotificationService({
+        recordActivity: (r) => records.push(r),
+      });
+
+      svc.error("boom");
+
+      expect(records).toEqual([{ level: "error", message: "boom" }]);
+      expect(Notice).toHaveBeenCalledWith("✗ boom", 4000);
+    });
+
+    it("falls back to the module-level default recorder when none is injected", () => {
+      const records: Array<{ level: string; message: string }> = [];
+      setDefaultNotificationActivityRecorder((r) => records.push(r));
+      // No explicit recorder → must use the default (covers command-flow
+      // instances built without the plugin's activityLog).
+      const svc = new ObsidianNotificationService();
+
+      svc.info("from default");
+
+      expect(records).toEqual([{ level: "info", message: "from default" }]);
+    });
+
+    it("prefers the explicit recorder over the module default", () => {
+      const explicit: Array<{ message: string }> = [];
+      const fallback: Array<{ message: string }> = [];
+      setDefaultNotificationActivityRecorder((r) => fallback.push(r));
+      const svc = new ObsidianNotificationService({
+        recordActivity: (r) => explicit.push(r),
+      });
+
+      svc.info("routed");
+
+      expect(explicit).toEqual([{ level: "info", message: "routed" }]);
+      expect(fallback).toEqual([]);
+    });
+
+    it("records nothing when neither explicit nor default recorder is set", () => {
+      const svc = new ObsidianNotificationService();
+      // Must not throw, must still toast.
+      expect(() => svc.info("silent log")).not.toThrow();
+      expect(Notice).toHaveBeenCalledWith("silent log", 4000);
+    });
+
+    it("still shows the Notice when the recorder throws (recording is isolated)", () => {
+      const svc = new ObsidianNotificationService({
+        recordActivity: () => {
+          throw new Error("sink exploded");
+        },
+      });
+
+      expect(() => svc.error("must still toast")).not.toThrow();
+      expect(Notice).toHaveBeenCalledWith("✗ must still toast", 4000);
     });
   });
 

--- a/packages/obsidian-plugin/tests/unit/styles/activity-log-selectable.test.ts
+++ b/packages/obsidian-plugin/tests/unit/styles/activity-log-selectable.test.ts
@@ -1,0 +1,50 @@
+/**
+ * Bug 2 regression guard — the «Open activity log» modal text must be
+ * selectable + copyable with the mouse (#3540 follow-up).
+ *
+ * Root cause: `.exocortex-activity-log-list` shipped without an explicit
+ * `user-select`, so Obsidian/Electron app-chrome's default `user-select: none`
+ * prevented selecting the log lines (only the "Copy all" button worked).
+ *
+ * This locks the fix in styles.css so a future edit cannot silently regress it.
+ * Revert-verify: removing `user-select: text` from the list block fails this.
+ */
+import { describe, it, expect } from "@jest/globals";
+import { readFileSync } from "fs";
+import { resolve } from "path";
+
+const STYLES_CSS_PATH = resolve(__dirname, "../../../styles.css");
+const css = readFileSync(STYLES_CSS_PATH, "utf-8");
+
+/**
+ * Extract the declaration block (between the first `{` and its `}`) for a
+ * selector, with CSS comments stripped so prose inside `/* … *\/` can't satisfy
+ * or trip the assertions below.
+ */
+function ruleBlock(selector: string): string {
+  const escaped = selector.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const re = new RegExp(`${escaped}\\s*\\{([^}]*)\\}`);
+  const m = css.match(re);
+  if (!m) return "";
+  return m[1].replace(/\/\*[\s\S]*?\*\//g, "");
+}
+
+describe("Bug 2 — activity log modal text is selectable", () => {
+  const block = ruleBlock(".exocortex-activity-log-list");
+
+  it("declares a .exocortex-activity-log-list rule", () => {
+    expect(block).not.toBe("");
+  });
+
+  it("opts the list back into text selection (user-select: text)", () => {
+    expect(block).toMatch(/(?<!-)user-select:\s*text/);
+  });
+
+  it("includes the -webkit-user-select prefix for the Electron/WKWebView runtime", () => {
+    expect(block).toMatch(/-webkit-user-select:\s*text/);
+  });
+
+  it("does NOT set user-select: none on the list (would re-break selection)", () => {
+    expect(block).not.toMatch(/user-select:\s*none/);
+  });
+});


### PR DESCRIPTION
## Two user-reported bugs in the «Exocortex: Open activity log» modal (#3540)

### Bug 1 — not all Notices appear in the activity log
**Root cause:** the central `INotificationService` impl `ObsidianNotificationService.{info,success,warn,error}` shows `new Notice` but never recorded to the activity log. ESLint forbids `new Notice` outside this class, so it *is* the single toast sink — yet `ActivityLogService.record()` was only called from a handful of structured producer feeds (ExoSync step feed, ProfileApplyManager journal, bootstrap/unmount via manual pairing). So the vast majority of toasts — every command/service calling `notifier.*` — bypassed the stream → the log was incomplete.

**Fix:** route every toast through the single sink.
- `ObsidianNotificationService` now records each notification (category `"notice"`, level mapped info/success→`info`, warn→`warn`, error→`error`) **in addition to** showing the `Notice`. Recording is try/catch-isolated — a recorder failure can never break the toast.
- A **module-level default recorder** (`setDefaultNotificationActivityRecorder`, set once in `onload`, cleared in `onunload`) covers the `ObsidianNotificationService` instances built inside command flows that never receive `activityLog` directly: the exocmd palette flow, `CommandManager`, and the DI container. Explicit constructor injection (main `this.notifier`, unit tests) takes precedence.
- Removed the now-redundant manual `activityLog.record({category:"bootstrap"})` pairings at bootstrap/unmount (notifier auto-records → would have duplicated).
- `PluginContainer` registers the service via `useFactory` (not `useClass`) because tsyringe cannot auto-resolve the new optional constructor param.

### Bug 2 — modal text not selectable / copyable
**Root cause:** `.exocortex-activity-log-list` shipped without `user-select`, so Obsidian/Electron app-chrome's default `user-select: none` blocked mouse selection. (A "Copy all" button already existed but selecting individual lines didn't work.)

**Fix:** added `user-select: text` (+ `-webkit-user-select: text` for the Chromium/WKWebView runtime, + `cursor: text`) to the list. The "Copy" button stays.

## Tests (revert-verified per integration-test-revert-verify discipline)
- `ObsidianNotificationService.test.ts` — info/success/warn/error record with correct level+message; module default fallback; explicit-over-default precedence; no-recorder no-op; recorder-throws isolation.
- `activityLog.integration.test.ts` — **production-shape**: real `ObsidianNotificationService` → real `ActivityLogService` → all four toast kinds land as `[notice]` in the rendered modal.
- `activity-log-selectable.test.ts` (new) — styles.css guard: `.exocortex-activity-log-list` has `user-select: text` (+ webkit), no `user-select: none`.
- **Revert-verify:** disabling `record()` → 7 tests fail; removing `user-select: text` → CSS guard fails. typecheck (0), lint (0 errors), 236 related tests green.

## Notes
- Desktop↔Mobile parity preserved (in-memory + CSS only, no `Platform.isMobile` gating).
- The `"bootstrap"` `ActivityCategory` member is now unused by any producer (toasts → `"notice"`); kept as a valid domain category to avoid a gratuitous breaking type change + test churn.
- **Visual smoke (follow-up):** computer-control UI smoke (modal shows all toasts + text selects/copies) needs user-present supervision; unit + DOM/CSS tests are the primary gate here.

WBS: `ems__Task` `930e31c7` under M3 (Alpha Launch).