### PR TITLE
fix(sync): backfill 3-way base for repos mounted before mount-base recording (#3590 full fix)

### DIFF
--- a/packages/cli/src/commands/exosync-sync.ts
+++ b/packages/cli/src/commands/exosync-sync.ts
@@ -34,6 +34,8 @@
 import { Command } from "commander";
 import { promises as fsp, existsSync } from "node:fs";
 import { webcrypto } from "node:crypto";
+import { execFile as execFileCb } from "node:child_process";
+import { promisify } from "node:util";
 import * as path from "node:path";
 import yaml from "js-yaml";
 import {
@@ -259,6 +261,41 @@ export function nodeMountBaseStore(
   return new FileMountBaseStore(nodeWatermarkFileIO(filePath));
 }
 
+const execFile = promisify(execFileCb);
+
+/**
+ * #3590 FULL fix — node-backed base BACKFILL source for AssetSpaces mounted
+ * BEFORE the mount layer recorded their base (no `exosync-mountbase.local.json`
+ * entry). Returns the commit SHA the submodule's working tree is checked out at
+ * (`git submodule status <path>` → leading 40-hex SHA) — the genuine 3-way merge
+ * base (local edits sit uncommitted on top; a true remote-head ancestor, which
+ * the engine re-verifies before trusting — M1-safe). Returns `null` — never
+ * throws — when the path is not an initialized submodule, git is unavailable, or
+ * the output is unparseable; the engine then keeps its conservative
+ * full-conflict fallback. Read-only `execFile` (no shell — injection-safe).
+ */
+export function nodeLocalBaseShaProvider(
+  vaultPath: string,
+): (spec: SyncRepoSpec) => Promise<string | null> {
+  return async (spec) => {
+    // A leading-dash localPath could be misread by git as an option — refuse it.
+    if (spec.localPath.length === 0 || spec.localPath.startsWith("-")) {
+      return null;
+    }
+    try {
+      const { stdout } = await execFile(
+        "git",
+        ["-C", vaultPath, "submodule", "status", spec.localPath],
+        { timeout: 30_000, maxBuffer: 4 * 1024 * 1024 },
+      );
+      const m = stdout.match(/^[ +\-U]?([0-9a-f]{40})\b/m);
+      return m ? m[1] : null;
+    } catch {
+      return null;
+    }
+  };
+}
+
 /**
  * CLI full-materialization gate (D19). The CLI has no plugin profile-apply /
  * staging state to consult, so the floor check is: mount folder exists +
@@ -390,6 +427,7 @@ export async function runExosyncSync(
     transport,
     watermarkStore: new FileWatermarkStore(nodeWatermarkFileIO(watermarkPath)),
     mountBaseStore: nodeMountBaseStore(vaultPath, configDir),
+    localBaseShaProvider: nodeLocalBaseShaProvider(vaultPath),
     materializationCheck: nodeMaterializationCheck(vaultPath),
     localFilesFor: (spec) =>
       nodeLocalFilesPort(path.join(vaultPath, spec.localPath)),

--- a/packages/cli/tests/unit/commands/exosync-sync.test.ts
+++ b/packages/cli/tests/unit/commands/exosync-sync.test.ts
@@ -17,6 +17,7 @@
  *     disk composition + direction plumbing + exit codes.
  */
 import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, existsSync, rmSync } from "node:fs";
+import { execFileSync } from "node:child_process";
 import { tmpdir } from "node:os";
 import * as path from "node:path";
 import { FakeGitHubRepo, mdAsset } from "../../../../exocortex/tests/unit/services/sync/fakeGitHub";
@@ -24,6 +25,7 @@ import {
   nodeLocalFilesPort,
   nodeWatermarkFileIO,
   nodeMaterializationCheck,
+  nodeLocalBaseShaProvider,
   runExosyncSync,
   type ExosyncSyncOptions,
 } from "../../../src/commands/exosync-sync";
@@ -241,5 +243,92 @@ describe("runExosyncSync — wiring", () => {
     } finally {
       fx.cleanup();
     }
+  });
+});
+
+// #3590 FULL fix — the CLI backfill source: the genuine 3-way base for a repo
+// mounted before the mount layer recorded one is the submodule's checked-out
+// HEAD. Real git fixture (test-fixture-realism — not a mock): a desktop vault
+// with a real submodule must yield the checked-out commit; non-submodule / not-
+// a-git-repo / hostile paths must degrade to null (engine then full-conflicts).
+describe("nodeLocalBaseShaProvider (#3590 base backfill source)", () => {
+  let workdir: string;
+  beforeEach(() => {
+    workdir = mkTmp("exosync-backfill-");
+  });
+  afterEach(() => rmSync(workdir, { recursive: true, force: true }));
+
+  function git(cwd: string, args: string[]): string {
+    return execFileSync("git", args, {
+      cwd,
+      encoding: "utf-8",
+      env: {
+        ...process.env,
+        GIT_TERMINAL_PROMPT: "0",
+        GIT_AUTHOR_NAME: "t",
+        GIT_AUTHOR_EMAIL: "t@t.io",
+        GIT_COMMITTER_NAME: "t",
+        GIT_COMMITTER_EMAIL: "t@t.io",
+      },
+    }).trim();
+  }
+
+  function spec(localPath: string): SyncRepoSpec {
+    return {
+      owner: OWNER,
+      repo: REPO,
+      branch: "main",
+      repoKey: `${OWNER}/${REPO}#main`,
+      localPath,
+    };
+  }
+
+  it("returns the submodule's checked-out HEAD SHA (real git submodule)", async () => {
+    // 'remote' repo with one commit — the genuine mount base.
+    const remote = path.join(workdir, "remote");
+    mkdirSync(remote);
+    git(remote, ["init", "-q", "-b", "main"]);
+    writeFileSync(path.join(remote, "a.md"), "x");
+    git(remote, ["add", "-A"]);
+    git(remote, ["commit", "-q", "-m", "init"]);
+    const remoteHead = git(remote, ["rev-parse", "HEAD"]);
+
+    // 'vault' superproject with the remote added as a submodule.
+    const vault = path.join(workdir, "vault");
+    mkdirSync(vault);
+    git(vault, ["init", "-q", "-b", "main"]);
+    git(vault, [
+      "-c",
+      "protocol.file.allow=always",
+      "submodule",
+      "add",
+      `file://${remote}`,
+      "assetspaces/o/r",
+    ]);
+
+    const sha = await nodeLocalBaseShaProvider(vault)(spec("assetspaces/o/r"));
+    expect(sha).toBe(remoteHead);
+  });
+
+  it("returns null for a path that is NOT a submodule", async () => {
+    const vault = path.join(workdir, "plain");
+    mkdirSync(vault);
+    git(vault, ["init", "-q", "-b", "main"]);
+    expect(
+      await nodeLocalBaseShaProvider(vault)(spec("assetspaces/o/r")),
+    ).toBeNull();
+  });
+
+  it("returns null when the vault is not a git repo (git unavailable analogue)", async () => {
+    const notGit = path.join(workdir, "notgit");
+    mkdirSync(notGit);
+    expect(
+      await nodeLocalBaseShaProvider(notGit)(spec("assetspaces/o/r")),
+    ).toBeNull();
+  });
+
+  it("refuses a leading-dash localPath (never lets git misread it as an option)", async () => {
+    expect(await nodeLocalBaseShaProvider(workdir)(spec("--upload-pack=x"))).toBeNull();
+    expect(await nodeLocalBaseShaProvider(workdir)(spec(""))).toBeNull();
   });
 });

--- a/packages/exocortex/src/services/sync/SyncEngine.ts
+++ b/packages/exocortex/src/services/sync/SyncEngine.ts
@@ -115,6 +115,24 @@ export interface SyncEngineDeps {
    * (M1 zero-loss intact). See {@link MountBaseStorePort}.
    */
   mountBaseStore?: MountBaseStorePort;
+  /**
+   * #3590 full fix — base BACKFILL source for repos MOUNTED BEFORE the mount
+   * layer began recording the base (or by any path that never recorded one):
+   * those have no `mountBaseStore` entry, so the v16.98.7 fix could not fire and
+   * every first-sync on an advanced remote false-conflicted. When the store has
+   * no entry for a repo, the engine asks this provider for the commit SHA the
+   * LOCAL working tree is based on — the platform's AUTHORITATIVE checked-out
+   * commit (desktop: the git submodule's HEAD). The returned SHA is NOT trusted
+   * blindly: it goes through the SAME genuine-ancestor verification as a recorded
+   * mount base (non-ancestor / unresolvable → conservative `full-conflict`,
+   * never a guessed base / silent overwrite, M1 zero-loss). Returns `null` when
+   * no authoritative source exists (mobile/REST mount, non-submodule, git
+   * unavailable) → the conservative fallback is unchanged (no regression). On a
+   * verified hit the engine persists the SHA into `mountBaseStore` (backfill), so
+   * subsequent first-syncs reuse it without re-invoking the provider. Absent ⇒
+   * pre-fix behaviour (only recorded mount bases are honoured).
+   */
+  localBaseShaProvider?: (spec: SyncRepoSpec) => Promise<string | null>;
   sha1: Sha1Fn;
   baseURL?: string;
   /** Cap on 422 re-pull→retry cycles (D16). Default {@link DEFAULT_MAX_PUSH_RETRIES}. */
@@ -2153,15 +2171,43 @@ export class SyncEngine {
     warnings: string[],
   ): Promise<FirstSyncBootstrap | null> {
     const store = this.deps.mountBaseStore;
-    if (store === undefined) return null;
 
-    let mountSha: string | null;
-    try {
-      mountSha = await store.get(spec.repoKey);
-    } catch {
-      return null; // store read failure → conservative fallback
+    let mountSha: string | null = null;
+    if (store !== undefined) {
+      try {
+        mountSha = await store.get(spec.repoKey);
+      } catch {
+        return null; // store read failure → conservative fallback
+      }
     }
-    // No record, or the remote has not advanced since the mount (the cheaper
+
+    // #3590 FULL fix — base BACKFILL. A repo MOUNTED BEFORE the mount layer
+    // started recording its base (or by any path that never recorded one) has no
+    // store entry → the v16.98.7 recording fix could not fire for it, and every
+    // first-sync on an advanced remote false-conflicted (the work-MacBook
+    // trigger). Recover the base from the platform's AUTHORITATIVE checked-out
+    // commit (desktop: the git submodule HEAD via `localBaseShaProvider`). It is
+    // NOT trusted blindly — it goes through the EXACT same genuine-ancestor
+    // verification below as a recorded base (non-ancestor → conservative
+    // fallback, never a silent merge on a guessed base, M1 zero-loss). `null`
+    // (mobile/REST, non-submodule, git unavailable) → conservative fallback
+    // unchanged. A verified hit is persisted (backfilled) so subsequent
+    // first-syncs reuse it without re-invoking the provider.
+    let backfilled = false;
+    if (mountSha === null && this.deps.localBaseShaProvider !== undefined) {
+      try {
+        const candidate = await this.deps.localBaseShaProvider(spec);
+        if (typeof candidate === "string" && candidate.length > 0) {
+          mountSha = candidate;
+          backfilled = true;
+        }
+      } catch {
+        // provider failure (git unavailable, not a submodule) → no candidate →
+        // conservative fallback, never a guess.
+      }
+    }
+
+    // No record/candidate, or the remote has not advanced since the mount (the cheaper
     // R⊆L clean-mount / additive path below handles head == mount exactly).
     // `head.startsWith(mountSha)` (not `===`) so an ABBREVIATED mount SHA
     // (anonymous tarballs carry a 7-char wrapper SHA — extractShaFromWrapper)
@@ -2235,8 +2281,22 @@ export class SyncEngine {
       rootTreeSha: baseCommit.treeSha,
       files,
     };
+    // #3590 FULL fix — persist the BACKFILLED (now ancestor-VERIFIED) base so a
+    // subsequent first-sync (e.g. after an overlapping full-conflict that wrote
+    // no watermark) reuses it without re-invoking the provider. Only the verified
+    // canonical SHA reaches this point — never an unverified guess (M1).
+    // Best-effort: a store-write failure must NOT fail the sync.
+    if (backfilled && store !== undefined) {
+      try {
+        await store.set(spec.repoKey, baseCommit.sha);
+      } catch {
+        /* non-fatal — next first-sync re-derives the base via the provider */
+      }
+    }
     warnings.push(
-      `first-sync (asset mode): reconciling against the recorded mount base ${baseCommit.sha} — remote head ${head} advanced since mount; local edits 3-way merge against it instead of false-conflicting (#3590)`,
+      backfilled
+        ? `first-sync (asset mode): BACKFILLED the 3-way base from the locally checked-out commit ${baseCommit.sha} (no recorded mount base) — remote head ${head} advanced since; local edits 3-way merge against it instead of false-conflicting (#3590)`
+        : `first-sync (asset mode): reconciling against the recorded mount base ${baseCommit.sha} — remote head ${head} advanced since mount; local edits 3-way merge against it instead of false-conflicting (#3590)`,
     );
     return { kind: "additive-base", base };
   }

--- a/packages/exocortex/tests/unit/services/sync/SyncEngine.test.ts
+++ b/packages/exocortex/tests/unit/services/sync/SyncEngine.test.ts
@@ -354,6 +354,184 @@ describe("SyncEngine — first-sync cleanly-mergeable divergence (#3590)", () =>
   });
 });
 
+// #3590 FULL fix — backfill the 3-way base for repos MOUNTED BEFORE the mount
+// layer started recording it (v16.98.7) OR by any path that never recorded a
+// base. Such a repo has NO `mountBaseStore` entry, so the v16.98.7 fix could
+// not fire — every first-sync on a remote that advanced since the (un-recorded)
+// mount false-conflicted (the empirical work-MacBook trigger). The engine now
+// asks `localBaseShaProvider` for the commit the local working tree is based on
+// (desktop: the git submodule's checked-out HEAD) and runs it through the SAME
+// genuine-ancestor verification + 3-way machinery — a disjoint divergence
+// cleanly merges, a real overlap still conflicts (M1), a non-ancestor / absent
+// source falls back to the conservative full-conflict (never a guessed base).
+describe("SyncEngine — first-sync base BACKFILL for mounted-but-baseless repos (#3590 full fix)", () => {
+  it("REGRESSION: empty mountBaseStore + provider recovers the base → clean 3-way merge (not false full-conflict), and the base is backfilled", async () => {
+    // Mount base: FILE_A + CONFIG + FILE_C, all byte-identical to remote — but
+    // NOTHING is recorded in mountBaseStore (pre-fix mount).
+    const gh = new FakeGitHubRepo({
+      [FILE_A]: mdAsset("u1", "orig-a"),
+      [CONFIG]: mdAsset("u9", "orig-x"),
+      [FILE_C]: mdAsset("u3", "orig-c"),
+    });
+    const mountSha = gh.headSha(); // the genuine base — provider will recover it
+
+    // Another device advances the remote on a DISJOINT file (CONFIG only).
+    gh.commitDirect(
+      gh.branch,
+      { [CONFIG]: mdAsset("u9", "remote-x") },
+      "remote ahead (disjoint)",
+    );
+
+    // Local working tree diverges on disjoint files (edits FILE_A, adds FILE_B,
+    // deletes FILE_C, still holds the un-pulled CONFIG).
+    const local = new FakeLocalFiles({
+      [FILE_A]: mdAsset("u1", "local-a"),
+      [CONFIG]: mdAsset("u9", "orig-x"),
+      [FILE_B]: mdAsset("u2"),
+    });
+
+    // EMPTY store (no recorded base) + a provider returning the real mount SHA
+    // — this is the mounted-but-baseless shape v16.98.7 could not fix.
+    const mountBaseStore = new FakeMountBaseStore(); // empty!
+    const provider = jest.fn(async () => mountSha);
+    const { engine, watermarks } = makeEngine(gh, local, {
+      mountBaseStore,
+      localBaseShaProvider: provider,
+    });
+
+    const result = await engine.sync(gh.spec());
+
+    // Clean merge — the backfilled base prevents the false full-conflict.
+    expect(result.status).toBe("synced");
+    expect(provider).toHaveBeenCalledTimes(1);
+    expect(result.pulledCount).toBe(1);
+    expect(local.files.get(CONFIG)).toBe(mdAsset("u9", "remote-x"));
+    expect(result.pushedCount).toBe(2);
+    expect(gh.headFiles().get(FILE_A)).toBe(mdAsset("u1", "local-a"));
+    expect(gh.headFiles().get(FILE_B)).toBe(mdAsset("u2"));
+    expect(gh.headFiles().get(CONFIG)).toBe(mdAsset("u9", "remote-x"));
+    expect(gh.headFiles().has(FILE_C)).toBe(false);
+    // The recovered, ancestor-VERIFIED base is persisted (backfilled) so a later
+    // first-sync reuses it without re-invoking the provider.
+    expect(mountBaseStore.shas.get(gh.spec().repoKey)).toBe(mountSha);
+    // A real watermark is established → re-sync no-ops.
+    expect(watermarks.records.size).toBe(1);
+    const again = await engine.sync(gh.spec());
+    expect(again.status).toBe("synced");
+    expect(again.pushedCount).toBe(0);
+    expect(again.pulledCount).toBe(0);
+  });
+
+  it("M1 HARD FLOOR: a backfilled base still conflicts on a REAL overlapping edit (never silently overwrites)", async () => {
+    const gh = new FakeGitHubRepo({ [CONFIG]: mdAsset("u9", "orig-x") });
+    const mountSha = gh.headSha();
+    gh.commitDirect(
+      gh.branch,
+      { [CONFIG]: mdAsset("u9", "remote-x") },
+      "remote edits CONFIG",
+    );
+    const local = new FakeLocalFiles({ [CONFIG]: mdAsset("u9", "local-x") }); // local ALSO edited CONFIG
+    const mountBaseStore = new FakeMountBaseStore(); // empty
+    const { engine, watermarks } = makeEngine(gh, local, {
+      mountBaseStore,
+      localBaseShaProvider: async () => mountSha,
+    });
+
+    const result = await engine.sync(gh.spec());
+
+    expect(result.status).not.toBe("synced");
+    expect(gh.headFiles().get(CONFIG)).toBe(mdAsset("u9", "remote-x")); // remote untouched
+    expect(local.files.get(CONFIG)).toBe(mdAsset("u9", "local-x")); // disk untouched
+    expect(watermarks.records.size).toBe(0); // no watermark on conflict
+  });
+
+  it("M1: a provider SHA that is NOT a remote ancestor is rejected → conservative full-conflict, base NOT persisted", async () => {
+    // A wrong/foreign/stale recovered SHA must go through the same ancestor walk
+    // as a recorded base — a non-ancestor is never trusted as a merge base.
+    const gh = new FakeGitHubRepo({ [FILE_A]: mdAsset("u1", "orig-a") });
+    gh.commitDirect(
+      gh.branch,
+      { [CONFIG]: mdAsset("u9", "remote-x") },
+      "remote ahead",
+    );
+    const local = new FakeLocalFiles({
+      [FILE_A]: mdAsset("u1", "local-a"),
+      [CONFIG]: mdAsset("u9", "orig-x"),
+    });
+    const mountBaseStore = new FakeMountBaseStore(); // empty
+    const { engine, watermarks } = makeEngine(gh, local, {
+      mountBaseStore,
+      localBaseShaProvider: async () =>
+        "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+    });
+
+    const result = await engine.sync(gh.spec());
+
+    expect(result.status).toBe("full-conflict");
+    expect(result.detail).toMatch(/first-sync/);
+    expect(gh.headFiles().get(FILE_A)).toBe(mdAsset("u1", "orig-a")); // untouched
+    expect(watermarks.records.size).toBe(0);
+    // An UNVERIFIED guess is never persisted.
+    expect(mountBaseStore.shas.has(gh.spec().repoKey)).toBe(false);
+  });
+
+  it("mobile/REST parity: NO provider source (returns null) → conservative full-conflict preserved (no regression)", async () => {
+    // On mobile (no git) the provider returns null — the engine keeps the exact
+    // pre-fix conservative behaviour: a divergent first-sync full-conflicts,
+    // never a silent merge on an absent base. Same engine code path, both
+    // platforms — no Platform.isMobile branch.
+    const gh = new FakeGitHubRepo({ [FILE_A]: mdAsset("u1", "orig-a") });
+    gh.commitDirect(
+      gh.branch,
+      { [CONFIG]: mdAsset("u9", "remote-x") },
+      "remote ahead",
+    );
+    const local = new FakeLocalFiles({
+      [FILE_A]: mdAsset("u1", "local-a"),
+      [CONFIG]: mdAsset("u9", "orig-x"),
+    });
+    const { engine, watermarks } = makeEngine(gh, local, {
+      mountBaseStore: new FakeMountBaseStore(),
+      localBaseShaProvider: async () => null, // no authoritative source (mobile)
+    });
+
+    const result = await engine.sync(gh.spec());
+
+    expect(result.status).toBe("full-conflict");
+    expect(result.detail).toMatch(/first-sync/);
+    expect(watermarks.records.size).toBe(0);
+  });
+
+  it("the RECORDED base wins: a present mountBaseStore entry short-circuits the provider (backfill is a fallback only)", async () => {
+    const gh = new FakeGitHubRepo({
+      [FILE_A]: mdAsset("u1", "orig-a"),
+      [CONFIG]: mdAsset("u9", "orig-x"),
+    });
+    const recordedSha = gh.headSha();
+    gh.commitDirect(
+      gh.branch,
+      { [CONFIG]: mdAsset("u9", "remote-x") },
+      "remote ahead (disjoint)",
+    );
+    const local = new FakeLocalFiles({
+      [FILE_A]: mdAsset("u1", "local-a"),
+      [CONFIG]: mdAsset("u9", "orig-x"),
+    });
+    const provider = jest.fn(async () => recordedSha);
+    const { engine } = makeEngine(gh, local, {
+      mountBaseStore: new FakeMountBaseStore({
+        [gh.spec().repoKey]: recordedSha,
+      }),
+      localBaseShaProvider: provider,
+    });
+
+    const result = await engine.sync(gh.spec());
+
+    expect(result.status).toBe("synced");
+    expect(provider).not.toHaveBeenCalled(); // recorded base used, provider untouched
+  });
+});
+
 describe("SyncEngine — push-only happy path (VL#7, D3)", () => {
   it("pushes a local edit via restCreateCommit and advances the watermark", async () => {
     const gh = new FakeGitHubRepo({

--- a/packages/obsidian-plugin/src/infrastructure/adapters/GitSubmoduleOps.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/GitSubmoduleOps.ts
@@ -304,6 +304,33 @@ export class GitSubmoduleOps {
   }
 
   /**
+   * #3590 — the commit SHA the submodule's working tree is CHECKED OUT at
+   * (`git submodule status <path>` → the leading 40-hex SHA, independent of any
+   * uncommitted edits inside it). This is the genuine 3-way merge base for
+   * ExoSync's FIRST sync of a repo mounted before the mount layer recorded its
+   * base: local edits sit uncommitted on top of this commit, and it is a true
+   * ancestor of the remote head (the sync engine re-verifies ancestry before
+   * trusting it — M1-safe). Returns `null` — never throws — when the path is not
+   * an initialized submodule, git is unavailable (mobile → {@link assertDesktop}
+   * throws), or the output cannot be parsed; the engine then keeps its
+   * conservative full-conflict fallback. Read-only, fast, run only on first sync.
+   */
+  async submoduleHeadSha(submodulePath: string): Promise<string | null> {
+    try {
+      const safe = validateVaultPathArg(submodulePath);
+      const { stdout } = await this.run(["submodule", "status", safe]);
+      // Format per submodule: "[ +-U]<40-hex-sha> <path> (<describe>)". The
+      // optional leading status char ('+' diverges from the superproject
+      // gitlink, 'U' merge conflicts, '-' uninitialized) precedes the SHA; the
+      // SHA is always the submodule's checked-out HEAD.
+      const m = stdout.match(/^[ +\-U]?([0-9a-f]{40})\b/m);
+      return m ? m[1] : null;
+    } catch {
+      return null;
+    }
+  }
+
+  /**
    * `git status --porcelain <pathspec>` — returns raw porcelain output.
    * Caller parses for non-empty lines == dirty.
    */

--- a/packages/obsidian-plugin/src/infrastructure/adapters/SyncDepsFactory.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/SyncDepsFactory.ts
@@ -23,6 +23,7 @@ import {
 } from "exocortex";
 
 import { GitHubRestClient } from "./GitHubRestClient";
+import { GitSubmoduleOps } from "./GitSubmoduleOps";
 import { LocalSecretsStore } from "./LocalSecretsStore";
 import { parseGitHubURL } from "./AssetSpaceManager";
 import type { PluginLocalDataStore } from "./PluginLocalDataStore";
@@ -422,6 +423,32 @@ export async function buildSyncEngine(
     });
   }
 
+  // #3590 FULL fix — base BACKFILL source for AssetSpaces mounted BEFORE the
+  // mount layer began recording their base (or by any path that never recorded
+  // one): they have no `exosync-mountbase.local.json` entry, so the v16.98.7
+  // recording fix could not fire and every first-sync false-conflicted (the
+  // work-MacBook trigger). The provider returns the commit the local working
+  // tree is based on — read AUTHORITATIVELY from the git submodule's checked-out
+  // HEAD on desktop. On mobile (no git binary / no filesystem root → empty
+  // basePath) it is simply absent: the engine keeps the conservative
+  // full-conflict fallback (no regression). Same engine code path on both
+  // platforms — the source degrades to null, no Platform.isMobile branch. The
+  // engine verifies the SHA is a genuine ancestor before trusting it (M1-safe).
+  let localBaseShaProvider:
+    | ((spec: SyncRepoSpec) => Promise<string | null>)
+    | undefined;
+  const vaultRootPath =
+    (adapter as unknown as { basePath?: string }).basePath ?? "";
+  if (vaultRootPath.length > 0) {
+    try {
+      const gitOps = new GitSubmoduleOps({ vaultRootPath });
+      localBaseShaProvider = (spec) => gitOps.submoduleHeadSha(spec.localPath);
+    } catch {
+      // git/node primitives unavailable → no backfill source (conservative).
+      localBaseShaProvider = undefined;
+    }
+  }
+
   const engine = new SyncEngine({
     transport,
     watermarkStore: new FileWatermarkStore(
@@ -430,6 +457,7 @@ export async function buildSyncEngine(
     mountBaseStore: new FileMountBaseStore(
       vaultWatermarkFileIO(adapter, mountBasePath),
     ),
+    ...(localBaseShaProvider !== undefined ? { localBaseShaProvider } : {}),
     materializationCheck: vaultMaterializationCheck({
       adapter,
       isSwitchInProgress: () => localDataStore.isSwitchInProgress(),

--- a/packages/obsidian-plugin/tests/unit/infrastructure/adapters/GitSubmoduleOps.test.ts
+++ b/packages/obsidian-plugin/tests/unit/infrastructure/adapters/GitSubmoduleOps.test.ts
@@ -188,6 +188,54 @@ describe("parseGitmodulesEntries", () => {
   });
 });
 
+// ─── #3590 base backfill — submodule checked-out HEAD ────────────────────────
+describe("GitSubmoduleOps.submoduleHeadSha (#3590 base backfill source)", () => {
+  const SHA = "a".repeat(40);
+
+  it("parses the checked-out SHA from a clean `git submodule status` line", async () => {
+    const execFileFn = jest.fn().mockResolvedValue({
+      stdout: ` ${SHA} assetspaces/kitelev/exoas-tbank (heads/main)\n`,
+      stderr: "",
+    }) as never;
+    const ops = new GitSubmoduleOps({ vaultRootPath: "/fake", execFileFn });
+    const got = await ops.submoduleHeadSha("assetspaces/kitelev/exoas-tbank");
+    expect(got).toBe(SHA);
+    // Read-only `submodule status`, never a mutation.
+    expect((execFileFn as jest.Mock).mock.calls[0][1]).toEqual([
+      "submodule",
+      "status",
+      "assetspaces/kitelev/exoas-tbank",
+    ]);
+  });
+
+  it("parses the SHA even with a '+' status prefix (checked-out differs from gitlink)", async () => {
+    const execFileFn = jest.fn().mockResolvedValue({
+      stdout: `+${SHA} assetspaces/kitelev/exoas-tbank (heads/main-2)\n`,
+      stderr: "",
+    }) as never;
+    const ops = new GitSubmoduleOps({ vaultRootPath: "/fake", execFileFn });
+    expect(await ops.submoduleHeadSha("assetspaces/kitelev/exoas-tbank")).toBe(
+      SHA,
+    );
+  });
+
+  it("returns null when git fails (not a submodule / git unavailable / mobile) — never throws", async () => {
+    const execFileFn = jest
+      .fn()
+      .mockRejectedValue(new Error("not a git repository")) as never;
+    const ops = new GitSubmoduleOps({ vaultRootPath: "/fake", execFileFn });
+    expect(await ops.submoduleHeadSha("assetspaces/x")).toBeNull();
+  });
+
+  it("returns null on unparseable output (no SHA present)", async () => {
+    const execFileFn = jest
+      .fn()
+      .mockResolvedValue({ stdout: "garbage\n", stderr: "" }) as never;
+    const ops = new GitSubmoduleOps({ vaultRootPath: "/fake", execFileFn });
+    expect(await ops.submoduleHeadSha("assetspaces/x")).toBeNull();
+  });
+});
+
 describe("GitSubmoduleOps.run security", () => {
   it("rejects unknown leading-dash args", async () => {
     const ops = new GitSubmoduleOps({


### PR DESCRIPTION
## #3590 full fix — no-base first-sync false-conflict on already-mounted repos (backfill base)

### Problem (empirical trigger)
On a **work MacBook** (plugin latest, vault initialized 5 days ago) ExoSync reported:
```
kitelev/exoas-tbank#main: full-conflict — first-sync: no watermark and local content
diverges from remote head at og/48a1b9f0-…md — A2/A3 scope
```
The v16.98.7 fix (#3596) records the first-sync 3-way merge base **only at mount time** (`RestAssetSpaceMount.mount` + `BootstrapAssetSpaceService.pullAssetSpace` → `FileMountBaseStore`). Repos **mounted before that fix shipped** (or by any path that never recorded a base) have **no `FileMountBaseStore` entry**, so `SyncEngine.bootstrapWatermark` finds no base and falls back to a conservative **full-conflict** on every first ExoSync — blocking the user on real work-data.

### Fix — backfill the base for mounted-but-baseless repos
When the mount-base store has no entry for a repo, the engine asks a new optional `localBaseShaProvider` for the commit the **local working tree is based on** — the platform's **authoritative** checked-out commit (desktop: the git submodule's HEAD). The recovered SHA is **not trusted blindly**: it goes through the **same genuine-ancestor verification** as a recorded mount base.

- Non-ancestor / unresolvable / absent → conservative **full-conflict** (never a guessed base or silent overwrite) — **M1 zero-loss intact**.
- A verified hit is **persisted** (backfilled) so later first-syncs skip the provider.
- Disjoint divergence → clean 3-way merge; real overlapping edit → still conflicts.

### Changes
- **engine** `SyncEngine.tryMountBaseBootstrap` consults `localBaseShaProvider` on empty store, reuses the existing ancestor-verify, persists the verified base.
- **plugin** `GitSubmoduleOps.submoduleHeadSha` (`git submodule status`) wired in `SyncDepsFactory`; mobile/REST → `null` → conservative fallback. No `Platform.isMobile` gating — same engine code path on both platforms; mobile-loadable assertion passes.
- **cli** `nodeLocalBaseShaProvider` (`git submodule status`) wired in `exosync-sync`.

### Tests (13, revert-verified)
- 5 engine: regression (empty store + provider → clean 3-way merge, **FAILS pre-fix / PASSES post-fix**), M1 overlapping-conflict guard, non-ancestor rejection (base not persisted), mobile/REST null → conservative fallback, recorded-base-wins (provider not consulted).
- 4 `GitSubmoduleOps.submoduleHeadSha` (parse SHA incl. `+` prefix; null on git-fail / unparseable).
- 4 CLI `nodeLocalBaseShaProvider` (real-git submodule fixture → checked-out HEAD; null for non-submodule / not-a-repo / leading-dash path).

### Invariants
- **Zero-data-loss / M1-safe**: backfilled base must be a genuine ancestor (same ancestor-verify as v16.98.7) — else fallback to full-conflict, never a silent merge on a wrong base.
- **Desktop↔Mobile parity**: same engine code path; the git source degrades to `null` where unavailable, preserving the exact pre-fix conservative behaviour.

Builds on v16.98.7 (#3596, `al-3590-exosync`). Closes the residual #3590 for pre-fix mounts.
