### PR TITLE
feat(commands): homoiconic Create Instance button — core (T1, project bbe40f8c)

### DIFF
--- a/packages/cli/src/commands/apply.ts
+++ b/packages/cli/src/commands/apply.ts
@@ -20,6 +20,7 @@ import {
   WorkflowResolver,
   NamedQueryRunner,
   createVaultFrontmatterClassLabelResolver,
+  createVaultFrontmatterRefToFolderResolver,
   registerDefaultHostFunctions,
   vaultPathToIRI,
   IRI,
@@ -307,6 +308,10 @@ async function executeOnTarget(
       workflowResolver,
       groundingLoader: (uid) => resolver.loadGroundingByUid(uid),
       namedQueryRunner,
+      // T1 "Create Instance" (project bbe40f8c) — co-locate new instances in
+      // their chosen ontology's folder via `$isDefinedByFolder` (UI/CLI parity,
+      // Issue #3417). Mirrors the plugin's createObsidianRefToFolderResolver.
+      refToFolder: createVaultFrontmatterRefToFolderResolver(nodeFsAdapter),
     },
   );
 

--- a/packages/exocortex/src/index.ts
+++ b/packages/exocortex/src/index.ts
@@ -102,8 +102,10 @@ export {
   type UserInput,
   type IGroundingService,
   type ClassLabelToUidResolver,
+  type RefToFolderResolver,
 } from "./services/GroundingExecutor";
 export { createVaultFrontmatterClassLabelResolver } from "./services/VaultFrontmatterClassLabelResolver";
+export { createVaultFrontmatterRefToFolderResolver } from "./services/VaultFrontmatterRefToFolderResolver";
 export {
   NamedQueryRunner,
   type NamedQueryRunnerPort,

--- a/packages/exocortex/src/services/CommandResolver.ts
+++ b/packages/exocortex/src/services/CommandResolver.ts
@@ -106,6 +106,10 @@ const KNOWN_SUBSTITUTION_RESOLVER_IDS: ReadonlySet<string> = new Set([
   "targetProperty",
   "labelAsArray",
   "groundingTargetClass",
+  // T1 "Create Instance" homoiconic button (project bbe40f8c): host page IS
+  // the class definition, so the new instance's exo__Instance_class points at
+  // the host's own UID (resolved from targetFilePath basename at exec time).
+  "targetClassSelf",
 ]);
 
 /**
@@ -1712,6 +1716,14 @@ export class CommandResolver {
             };
             if (rawDefault !== undefined && rawDefault !== null) {
               field.defaultValue = String(rawDefault);
+            }
+            // T1 "Create Instance" (project bbe40f8c): an `assetRef` field may
+            // declare `targetClassUid` so the form's fuzzy reference-picker can
+            // fetch candidate instances of that class (e.g. the ontology picker
+            // targets exo__Ontology). Generic — parameterises the reusable
+            // picker by class. Propagated verbatim for the plugin form layer.
+            if (typeof prop.targetClassUid === "string") {
+              field.targetClassUid = prop.targetClassUid;
             }
             return field;
           });

--- a/packages/exocortex/src/services/GroundingExecutor.ts
+++ b/packages/exocortex/src/services/GroundingExecutor.ts
@@ -167,6 +167,23 @@ export type ClassLabelToUidResolver = (
   label: string,
 ) => string | null | Promise<string | null>;
 
+/**
+ * T1 "Create Instance" homoiconic button (project bbe40f8c) — resolve a
+ * vault asset reference (bare UID or label) to the vault-relative folder of
+ * the file it points at. Powers the `$isDefinedByFolder` target-folder token
+ * so a `create_instance` grounding can place the new asset co-located with its
+ * chosen `exo__Asset_isDefinedBy` ontology (co-location invariant) WITHOUT a
+ * second relocation pass.
+ *
+ * Injected by the host (plugin via metadataCache, CLI via the folder-repair
+ * helpers). A `null` return — no resolver wired, ref not found — leaves the
+ * executor to fall back to the host folder, so the create never fails on a
+ * resolution gap.
+ */
+export type RefToFolderResolver = (
+  ref: string,
+) => string | null | Promise<string | null>;
+
 /** UUID-v4 sniff used to skip resolution for already-canonical class refs. */
 const UUID_V4_RE =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
@@ -287,6 +304,7 @@ export class GroundingExecutor {
   private readonly fileWriter: IFileSystemWriter;
   private readonly serviceRegistry: ServiceRegistry;
   private readonly classLabelToUid?: ClassLabelToUidResolver;
+  private readonly refToFolder?: RefToFolderResolver;
   private readonly workflowResolver?: WorkflowResolverPort;
   private readonly groundingLoader?: GroundingLoaderPort;
   private readonly namedQueryRunner?: NamedQueryRunnerPort;
@@ -312,6 +330,10 @@ export class GroundingExecutor {
       // RFC 78c2b7d0 C4 — read-side value-source for property_set
       // `targetValueQuery`. When absent, such groundings fail loud.
       namedQueryRunner?: NamedQueryRunnerPort;
+      // T1 "Create Instance" (project bbe40f8c) — resolve `$isDefinedByFolder`
+      // target-folder token to the chosen ontology's folder. When absent,
+      // create_instance falls back to the host folder (never fails).
+      refToFolder?: RefToFolderResolver;
     },
   ) {
     this.frontmatterService = new FrontmatterService();
@@ -319,6 +341,7 @@ export class GroundingExecutor {
     this.fileWriter = fileWriter;
     this.serviceRegistry = serviceRegistry;
     this.classLabelToUid = classLabelToUid;
+    this.refToFolder = options?.refToFolder;
     this.workflowResolver = options?.workflowResolver;
     this.groundingLoader = options?.groundingLoader;
     this.namedQueryRunner = options?.namedQueryRunner;
@@ -938,13 +961,22 @@ export class GroundingExecutor {
     // Issue #3136 (Q3.b closure): allow `$targetFolder` / `$target` tokens in
     // `grounding.targetFolder` so new instances can inherit the target's
     // parent folder declaratively (replacing legacy `createTaskForDailyNote`).
-    const resolvedFolder = this.substituteVariables(
-      grounding.targetFolder,
-      targetIRI,
-      userInput,
-      undefined,
-      targetFilePath,
-    );
+    //
+    // T1 "Create Instance" (project bbe40f8c): `$isDefinedByFolder` resolves
+    // to the folder of the instance's chosen `exo__Asset_isDefinedBy` ontology
+    // (co-location invariant). The host page is the class definition (which may
+    // live in a different ontology than the one the user picks), so we cannot
+    // reuse `$targetFolder` here. Falls back to the host folder when the ref
+    // cannot be resolved — a degraded location beats a failed create.
+    const resolvedFolder = grounding.targetFolder.includes("$isDefinedByFolder")
+      ? await this.resolveIsDefinedByFolder(properties, targetFilePath)
+      : this.substituteVariables(
+          grounding.targetFolder,
+          targetIRI,
+          userInput,
+          undefined,
+          targetFilePath,
+        );
     const filePath = resolvedFolder ? `${resolvedFolder}/${uid}.md` : `${uid}.md`;
 
     await this.fileWriter.createFile(filePath, content);
@@ -954,6 +986,63 @@ export class GroundingExecutor {
     // — actually opening the file is wired by the platform adapter through
     // CommandExecutionFlow's optional IFileOpener dependency.
     return { success: true, openPath: filePath };
+  }
+
+  /**
+   * T1 "Create Instance" (project bbe40f8c) — resolve the co-located folder for
+   * a new instance from its just-written `exo__Asset_isDefinedBy` value, using
+   * the injected {@link RefToFolderResolver}. The instance lives in the folder
+   * of the file its `isDefinedBy` ontology points at (co-location invariant).
+   *
+   * Falls back to the host (target) file's parent folder when:
+   *   - no `exo__Asset_isDefinedBy` was written (no ontology chosen),
+   *   - no resolver is wired (CLI/test harness without a vault index),
+   *   - the resolver returns null/throws (ontology file not found).
+   * A degraded-but-valid location is preferable to a failed create; the
+   * co-location audit (`audit co-location`) surfaces any drift.
+   */
+  private async resolveIsDefinedByFolder(
+    properties: Record<string, unknown>,
+    targetFilePath: string,
+  ): Promise<string> {
+    const hostFolder = GroundingExecutor.parentFolderOf(targetFilePath);
+    const rawIsDefinedBy = properties["exo__Asset_isDefinedBy"];
+    const ref = GroundingExecutor.extractBareRef(rawIsDefinedBy);
+    if (ref && this.refToFolder) {
+      try {
+        const folder = await this.refToFolder(ref);
+        if (folder !== null && folder !== undefined) return folder;
+      } catch (error) {
+        LoggingService.error(
+          `[GroundingExecutor] $isDefinedByFolder resolution failed for ref "${ref}" — falling back to host folder.`,
+          error instanceof Error ? error : new Error(String(error)),
+        );
+      }
+    }
+    return hostFolder;
+  }
+
+  /** Vault-relative parent folder of a file path (empty when at vault root). */
+  private static parentFolderOf(filePath: string): string {
+    const normalized = filePath.replace(/^\/+/, "");
+    const slashIdx = normalized.lastIndexOf("/");
+    return slashIdx >= 0 ? normalized.slice(0, slashIdx) : "";
+  }
+
+  /**
+   * Strip YAML quotes, wikilink brackets, and any `|alias` segment from a
+   * frontmatter ref value (`'"[[<uid>|Label]]"'` → `<uid>`). Returns null when
+   * the value is not a string or yields no bare ref.
+   */
+  private static extractBareRef(value: unknown): string | null {
+    if (typeof value !== "string") return null;
+    let ref = value.trim();
+    ref = ref.replace(/^["']|["']$/g, "").trim();
+    ref = ref.replace(/^\[\[/, "").replace(/\]\]$/, "");
+    const pipeIdx = ref.indexOf("|");
+    if (pipeIdx >= 0) ref = ref.slice(0, pipeIdx);
+    ref = ref.trim();
+    return ref.length > 0 ? ref : null;
   }
 
   /**

--- a/packages/exocortex/src/services/SubstitutionResolverRegistry.ts
+++ b/packages/exocortex/src/services/SubstitutionResolverRegistry.ts
@@ -160,4 +160,22 @@ export function installDefaultResolvers(): void {
     if (!ctx.groundingTargetClassUid) return null;
     return `"[[${ctx.groundingTargetClassUid}]]"`;
   });
+
+  // -- "Create Instance" homoiconic button (T1, project bbe40f8c) --
+  //
+  // `targetClassSelf` — the click-target IS the class definition (`exo__Class`
+  // instance), so the new asset's `exo__Instance_class` must point back at the
+  // host file's own UID. This inverts `groundingTargetClass` (which reads a
+  // class baked into the Grounding): here the class is the host, discovered
+  // from `targetFilePath` basename (UID-canon filenames guarantee
+  // basename === uid). Returns a quoted wikilink so it serialises identically
+  // to the other class-ref defaults. `null` when no target file path is in
+  // context (CLI/test harness without a click target).
+  registerResolver("targetClassSelf", (ctx) => {
+    if (!ctx.targetFilePath) return null;
+    const normalized = ctx.targetFilePath.replace(/^\/+/, "");
+    const fileName = normalized.slice(normalized.lastIndexOf("/") + 1);
+    const uid = fileName.replace(/\.md$/i, "");
+    return uid.length > 0 ? `"[[${uid}]]"` : null;
+  });
 }

--- a/packages/exocortex/src/services/VaultFrontmatterRefToFolderResolver.ts
+++ b/packages/exocortex/src/services/VaultFrontmatterRefToFolderResolver.ts
@@ -1,0 +1,40 @@
+import type { IFileSystemMetadataProvider } from "../interfaces/IFileSystemAdapter";
+import type { RefToFolderResolver } from "./GroundingExecutor";
+
+/**
+ * T1 "Create Instance" homoiconic button (project bbe40f8c) — filesystem-
+ * frontmatter-backed {@link RefToFolderResolver}, the CLI/headless counterpart
+ * of the plugin's metadata-cache resolver (`createObsidianRefToFolderResolver`).
+ *
+ * `GroundingExecutor.executeCreateInstance` co-locates a new instance in its
+ * chosen `exo__Asset_isDefinedBy` ontology's folder (co-location invariant)
+ * when the grounding's `targetFolder` is the `$isDefinedByFolder` token. The
+ * core executor is storage-agnostic, so the host injects this resolver to map
+ * a bare asset UID to the vault-relative folder of the file it points at.
+ *
+ * Wiring this in the CLI keeps `apply <create-instance> <class>` co-location-
+ * correct, matching the plugin button (UI/CLI parity, Issue #3417). Returns
+ * `null` when nothing matches; the executor then falls back to the host folder
+ * rather than failing the create.
+ */
+export function createVaultFrontmatterRefToFolderResolver(
+  metadataProvider: IFileSystemMetadataProvider,
+): RefToFolderResolver {
+  return async (ref: string): Promise<string | null> => {
+    if (!ref) return null;
+
+    const matches = await metadataProvider.findFilesByMetadata({
+      exo__Asset_uid: ref,
+    });
+    if (matches.length === 0) return null;
+
+    return parentFolderOf(matches[0]);
+  };
+}
+
+/** Vault-relative parent folder of a path (empty string at vault root). */
+function parentFolderOf(filePath: string): string {
+  const normalized = filePath.replace(/^\/+/, "");
+  const slashIdx = normalized.lastIndexOf("/");
+  return slashIdx >= 0 ? normalized.slice(0, slashIdx) : "";
+}

--- a/packages/exocortex/tests/unit/services/CommandResolver.test.ts
+++ b/packages/exocortex/tests/unit/services/CommandResolver.test.ts
@@ -612,6 +612,55 @@ describe("CommandResolver", () => {
       ]);
     });
 
+    it("T1: propagates `targetClassUid` on assetRef fields for the reusable fuzzy reference-picker", async () => {
+      const groundingSubject = new IRI("obsidian://vault/gnd-create-instance.md");
+      await store.addAll([
+        new Triple(groundingSubject, Namespace.RDF.term("type"), Namespace.EXOCMD.term("Grounding")),
+        new Triple(groundingSubject, Namespace.EXO.term("Asset_uid"), new Literal("gnd-create-instance")),
+        new Triple(groundingSubject, Namespace.EXO.term("Asset_label"), new Literal("Create Instance")),
+        new Triple(groundingSubject, Namespace.EXOCMD.term("Grounding_type"), new Literal("[[4367e2d6-6c92-450a-becb-abce1fb07682]]")),
+        new Triple(
+          groundingSubject,
+          Namespace.EXOCMD.term("Grounding_inputSchema"),
+          new Literal(
+            JSON.stringify({
+              type: "object",
+              properties: {
+                label: { type: "string", title: "Label" },
+                exo__Asset_isDefinedBy: {
+                  type: "assetRef",
+                  title: "Ontology",
+                  targetClassUid: "829b9b3b-6fc3-4276-be6a-27d3398c012e",
+                },
+              },
+              required: ["label", "exo__Asset_isDefinedBy"],
+            }),
+          ),
+        ),
+      ]);
+      await addCommandAsset(store, {
+        uid: "cmd-create-instance",
+        label: "Create Instance",
+        groundingRef: "gnd-create-instance",
+      });
+
+      const cmd = await resolver.loadCommand("cmd-create-instance");
+      const inputSchema = (cmd!.grounding as unknown as Record<string, unknown>)[
+        "inputSchema"
+      ] as Array<Record<string, unknown>>;
+
+      expect(inputSchema).toEqual([
+        { name: "label", type: "text", label: "Label", required: true },
+        {
+          name: "exo__Asset_isDefinedBy",
+          type: "assetRef",
+          label: "Ontology",
+          required: true,
+          targetClassUid: "829b9b3b-6fc3-4276-be6a-27d3398c012e",
+        },
+      ]);
+    });
+
     // RFC v2 Phase 5 (#3167): the legacy fail-loud-on-invalid-JSON test was
     // removed alongside the parser. Invalid JSON in the deprecated triple is
     // simply ignored — there is no longer a parser to throw.

--- a/packages/exocortex/tests/unit/services/GroundingExecutor.test.ts
+++ b/packages/exocortex/tests/unit/services/GroundingExecutor.test.ts
@@ -2,6 +2,10 @@ import {
   GroundingExecutor,
   ServiceRegistry,
 } from "../../../src/services/GroundingExecutor";
+import {
+  clearResolvers,
+  installDefaultResolvers,
+} from "../../../src/services/SubstitutionResolverRegistry";
 import { GroundingType } from "../../../src/domain/constants/GroundingType";
 import { GroundingDefinition } from "../../../src/domain/models/CommandDefinition";
 
@@ -967,6 +971,142 @@ describe("GroundingExecutor", () => {
       // (the class UID) is absent. The link references $target (the parent
       // file the user clicked on), not the class UID.
       expect(content).toContain('exo__Asset_prototype: "[[vault/test-asset]]"');
+    });
+
+    // -- T1 "Create Instance" homoiconic button (project bbe40f8c) --
+    //
+    // The host page IS the class definition. The new instance must:
+    //   - get `exo__Instance_class` = the host's own UID (via the
+    //     `targetClassSelf` SubstitutionToken resolver, NOT grounding.targetClass);
+    //   - get `exo__Asset_isDefinedBy` = the ontology the user picked in the form;
+    //   - land co-located in that ontology's folder (via `$isDefinedByFolder`).
+    describe("T1 homoiconic Create Instance (host IS the class)", () => {
+      const HOST_CLASS_PATH =
+        "assetspaces/kitelev/exoas-ems/ems/8619c4fc-64f1-4869-b17e-e34186cacca9.md";
+      const HOST_CLASS_IRI =
+        "obsidian://vault/8619c4fc-64f1-4869-b17e-e34186cacca9.md";
+      // Marker emitted by CommandResolver for a context-dependent
+      // SubstitutionToken (token-uid is a real UUID per SUBSTITUTION_MARKER_RE).
+      const TARGET_CLASS_SELF_MARKER =
+        "__SUBSTITUTE__targetClassSelf__11111111-1111-1111-1111-111111111111__";
+      const ONTOLOGY_UID = "086f71fa-dd30-4284-90cf-e609f2a6c461";
+      const ONTOLOGY_FOLDER = "assetspaces/kitelev/exoas-ems/ems";
+
+      beforeEach(() => {
+        clearResolvers();
+        installDefaultResolvers();
+      });
+
+      function makeCreateInstanceGrounding(): GroundingDefinition {
+        return makeGrounding({
+          type: GroundingType.CREATE_INSTANCE,
+          // NOTE: no targetClass — host is the class (resolved via PD below).
+          targetFolder: "$isDefinedByFolder",
+          propertyDefault: [
+            {
+              propertyName: "exo__Instance_class",
+              value: TARGET_CLASS_SELF_MARKER,
+            },
+          ],
+        });
+      }
+
+      it("instance_class = host UID, isDefinedBy = picked ontology, co-located in ontology folder", async () => {
+        const refToFolder = jest.fn(async (ref: string) =>
+          ref === ONTOLOGY_UID ? ONTOLOGY_FOLDER : null,
+        );
+        executor = new GroundingExecutor(reader, writer, registry, undefined, {
+          refToFolder,
+        });
+
+        const userInput = {
+          label: "My Instance",
+          exo__Asset_isDefinedBy: `"[[${ONTOLOGY_UID}]]"`,
+        };
+
+        const result = await executor.execute(
+          makeCreateInstanceGrounding(),
+          HOST_CLASS_IRI,
+          HOST_CLASS_PATH,
+          userInput,
+        );
+
+        expect(result.success).toBe(true);
+        const [path, content] = writer.createFile.mock.calls[0];
+        // Co-located in the chosen ontology's folder (NOT the host folder,
+        // which happens to differ only by being the same here — assert the
+        // resolver was consulted with the bare ontology UID).
+        expect(refToFolder).toHaveBeenCalledWith(ONTOLOGY_UID);
+        expect(path).toMatch(
+          new RegExp(`^${ONTOLOGY_FOLDER}/[a-f0-9-]{36}\\.md$`),
+        );
+        // instance_class points back at the HOST class file's own UID.
+        expect(content).toContain(
+          '"[[8619c4fc-64f1-4869-b17e-e34186cacca9]]"',
+        );
+        expect(content).toContain(`exo__Asset_isDefinedBy: "[[${ONTOLOGY_UID}]]"`);
+        expect(content).toContain("exo__Asset_label: My Instance");
+        expect(content).toContain("exo__Asset_uid:");
+        // openPath surfaced for open-after-create.
+        expect(result.openPath).toBe(path);
+      });
+
+      it("co-locates the new instance in a DIFFERENT ontology folder than the host", async () => {
+        const OTHER_FOLDER = "assetspaces/kitelev/exoas-exo/exo";
+        const OTHER_ONTOLOGY = "60967c6a-4e8a-4ee3-8922-db98b981e4f4";
+        const refToFolder = jest.fn(async (ref: string) =>
+          ref === OTHER_ONTOLOGY ? OTHER_FOLDER : null,
+        );
+        executor = new GroundingExecutor(reader, writer, registry, undefined, {
+          refToFolder,
+        });
+
+        const result = await executor.execute(
+          makeCreateInstanceGrounding(),
+          HOST_CLASS_IRI,
+          HOST_CLASS_PATH,
+          { label: "X", exo__Asset_isDefinedBy: `"[[${OTHER_ONTOLOGY}]]"` },
+        );
+
+        expect(result.success).toBe(true);
+        const [path] = writer.createFile.mock.calls[0];
+        // Lands in the picked ontology's folder, NOT the host's ems folder.
+        expect(path.startsWith(`${OTHER_FOLDER}/`)).toBe(true);
+        expect(path.startsWith("assetspaces/kitelev/exoas-ems/")).toBe(false);
+      });
+
+      it("falls back to host folder when no refToFolder resolver is wired", async () => {
+        // No refToFolder injected (CLI/test harness).
+        const result = await executor.execute(
+          makeCreateInstanceGrounding(),
+          HOST_CLASS_IRI,
+          HOST_CLASS_PATH,
+          { label: "Y", exo__Asset_isDefinedBy: `"[[${ONTOLOGY_UID}]]"` },
+        );
+
+        expect(result.success).toBe(true);
+        const [path] = writer.createFile.mock.calls[0];
+        // Host folder (parent of HOST_CLASS_PATH).
+        expect(path.startsWith("assetspaces/kitelev/exoas-ems/ems/")).toBe(true);
+      });
+
+      it("falls back to host folder when refToFolder returns null (ontology not found)", async () => {
+        const refToFolder = jest.fn(async () => null);
+        executor = new GroundingExecutor(reader, writer, registry, undefined, {
+          refToFolder,
+        });
+
+        const result = await executor.execute(
+          makeCreateInstanceGrounding(),
+          HOST_CLASS_IRI,
+          HOST_CLASS_PATH,
+          { label: "Z", exo__Asset_isDefinedBy: `"[[${ONTOLOGY_UID}]]"` },
+        );
+
+        expect(result.success).toBe(true);
+        const [path] = writer.createFile.mock.calls[0];
+        expect(path.startsWith("assetspaces/kitelev/exoas-ems/ems/")).toBe(true);
+      });
     });
 
     // RFC ce27e55d: labelTemplate fallback for one-click create_instance

--- a/packages/exocortex/tests/unit/services/SubstitutionResolverRegistry.test.ts
+++ b/packages/exocortex/tests/unit/services/SubstitutionResolverRegistry.test.ts
@@ -24,7 +24,7 @@ describe("SubstitutionResolverRegistry — RFC 727572d2 Phase A2 vocabulary", ()
     installDefaultResolvers();
   });
 
-  it("registers all 14 expected resolver-ids (4 legacy + 10 new)", () => {
+  it("registers all 15 expected resolver-ids (4 legacy + 10 new + targetClassSelf)", () => {
     const ids = getRegisteredResolverIds().sort();
     expect(ids).toEqual(
       [
@@ -36,6 +36,7 @@ describe("SubstitutionResolverRegistry — RFC 727572d2 Phase A2 vocabulary", ()
         "nowYear",
         "randomUUIDv4",
         "target",
+        "targetClassSelf",
         "targetFolder",
         "targetProperty",
         "today",
@@ -44,6 +45,35 @@ describe("SubstitutionResolverRegistry — RFC 727572d2 Phase A2 vocabulary", ()
         "userInputLabel",
       ].sort(),
     );
+  });
+
+  describe("targetClassSelf (T1 Create Instance — host IS the class)", () => {
+    it("returns a quoted wikilink to the host file's own UID (basename)", () => {
+      const fn = getResolver("targetClassSelf")!;
+      const result = fn({
+        targetFilePath:
+          "assetspaces/kitelev/exoas-ems/ems/1b20a8f0-d745-4e93-91db-4531b3df120e.md",
+      } as ResolverContext);
+      expect(result).toBe('"[[1b20a8f0-d745-4e93-91db-4531b3df120e]]"');
+    });
+
+    it("strips a leading slash from the path before extracting basename", () => {
+      const fn = getResolver("targetClassSelf")!;
+      const result = fn({
+        targetFilePath: "/8619c4fc-64f1-4869-b17e-e34186cacca9.md",
+      } as ResolverContext);
+      expect(result).toBe('"[[8619c4fc-64f1-4869-b17e-e34186cacca9]]"');
+    });
+
+    it("returns null when no target file path is in context (CLI/test harness)", () => {
+      const fn = getResolver("targetClassSelf")!;
+      expect(fn({} as ResolverContext)).toBeNull();
+    });
+
+    it("returns null when the path has no basename after stripping .md", () => {
+      const fn = getResolver("targetClassSelf")!;
+      expect(fn({ targetFilePath: ".md" } as ResolverContext)).toBeNull();
+    });
   });
 
   describe("randomUUIDv4", () => {

--- a/packages/exocortex/tests/unit/services/VaultFrontmatterRefToFolderResolver.test.ts
+++ b/packages/exocortex/tests/unit/services/VaultFrontmatterRefToFolderResolver.test.ts
@@ -1,0 +1,62 @@
+/**
+ * T1 "Create Instance" (project bbe40f8c) — unit tests for the CLI/headless
+ * {@link createVaultFrontmatterRefToFolderResolver}. Pure delegation over
+ * `findFilesByMetadata({exo__Asset_uid})`; the fake provider keeps the branch
+ * matrix focused. Real NodeFsAdapter integration is exercised via the apply
+ * CLI path.
+ */
+import { createVaultFrontmatterRefToFolderResolver } from "../../../src/services/VaultFrontmatterRefToFolderResolver";
+import type { IFileSystemMetadataProvider } from "../../../src/interfaces/IFileSystemAdapter";
+
+function makeProvider(
+  uidMatches: Record<string, string[]>,
+): IFileSystemMetadataProvider {
+  return {
+    async findFilesByMetadata(
+      query: Record<string, unknown>,
+    ): Promise<string[]> {
+      if ("exo__Asset_uid" in query) {
+        return uidMatches[String(query.exo__Asset_uid)] ?? [];
+      }
+      return [];
+    },
+    async getFileMetadata(): Promise<Record<string, unknown>> {
+      return {};
+    },
+    async findFileByUID(): Promise<string | null> {
+      return null;
+    },
+  } as IFileSystemMetadataProvider;
+}
+
+describe("createVaultFrontmatterRefToFolderResolver (T1 co-location)", () => {
+  it("resolves a UID to the parent folder of its file", async () => {
+    const provider = makeProvider({
+      "086f71fa-dd30-4284-90cf-e609f2a6c461": [
+        "assetspaces/kitelev/exoas-ems/ems/086f71fa-dd30-4284-90cf-e609f2a6c461.md",
+      ],
+    });
+    const resolve = createVaultFrontmatterRefToFolderResolver(provider);
+    expect(await resolve("086f71fa-dd30-4284-90cf-e609f2a6c461")).toBe(
+      "assetspaces/kitelev/exoas-ems/ems",
+    );
+  });
+
+  it("returns empty string for a file at the vault root", async () => {
+    const provider = makeProvider({ "root-uid": ["root-uid.md"] });
+    const resolve = createVaultFrontmatterRefToFolderResolver(provider);
+    expect(await resolve("root-uid")).toBe("");
+  });
+
+  it("returns null when the UID matches no file", async () => {
+    const provider = makeProvider({});
+    const resolve = createVaultFrontmatterRefToFolderResolver(provider);
+    expect(await resolve("missing")).toBeNull();
+  });
+
+  it("returns null for an empty ref", async () => {
+    const provider = makeProvider({});
+    const resolve = createVaultFrontmatterRefToFolderResolver(provider);
+    expect(await resolve("")).toBeNull();
+  });
+});

--- a/packages/obsidian-plugin/src/ExocortexPlugin.ts
+++ b/packages/obsidian-plugin/src/ExocortexPlugin.ts
@@ -101,6 +101,7 @@ import { ObsidianFileSystemAdapter } from "./adapters/ObsidianFileSystemAdapter"
 import { populateServiceRegistry } from "./infrastructure/services/ServiceRegistryPopulator";
 import { ObsidianFileOpener } from "./infrastructure/services/ObsidianFileOpener";
 import { createObsidianClassLabelResolver } from "./infrastructure/services/ObsidianClassLabelResolver";
+import { createObsidianRefToFolderResolver } from "./infrastructure/services/ObsidianRefToFolderResolver";
 import { ExocmdCommandPaletteRegistrar } from "./application/services/ExocmdCommandPaletteRegistrar";
 import { ObsidianCommandPromptAdapter } from "./infrastructure/adapters/ObsidianCommandPromptAdapter";
 import {
@@ -579,6 +580,9 @@ export default class ExocortexPlugin extends Plugin {
           workflowResolver: this.workflowResolver,
           groundingLoader: (uid) => this.commandResolver.loadGroundingByUid(uid),
           namedQueryRunner,
+          // T1 "Create Instance" (project bbe40f8c) — co-locate new instances in
+          // their chosen ontology's folder via the `$isDefinedByFolder` token.
+          refToFolder: createObsidianRefToFolderResolver(this.app),
         },
       );
 

--- a/packages/obsidian-plugin/src/infrastructure/services/ObsidianRefToFolderResolver.ts
+++ b/packages/obsidian-plugin/src/infrastructure/services/ObsidianRefToFolderResolver.ts
@@ -1,0 +1,65 @@
+import type { App, CachedMetadata, TFile } from "obsidian";
+import type { RefToFolderResolver } from "exocortex";
+
+/**
+ * T1 "Create Instance" homoiconic button (project bbe40f8c) — metadata-cache
+ * backed {@link RefToFolderResolver}.
+ *
+ * # Why this lives in the plugin layer
+ *
+ * `GroundingExecutor.executeCreateInstance` places a new instance co-located
+ * with its chosen `exo__Asset_isDefinedBy` ontology (co-location invariant)
+ * when the grounding's `targetFolder` is the `$isDefinedByFolder` token. The
+ * core executor is storage-agnostic and cannot scan the vault for the file a
+ * UID points at; the plugin injects this resolver, backed by the always-warm
+ * Obsidian metadata cache (mirrors {@link createObsidianClassLabelResolver}).
+ *
+ * # How it works
+ *
+ * Given a bare asset reference (a UID, after the executor strips quotes /
+ * `[[ ]]` / `|alias`), find the markdown file whose `exo__Asset_uid` equals it
+ * — or, as a fast path for UID-canon filenames, whose basename equals it — and
+ * return that file's vault-relative parent folder.
+ *
+ * Returns `null` when nothing matches or the metadata-cache API is unavailable;
+ * the executor then falls back to the host folder rather than failing the
+ * create. Runs on both desktop and mobile (no `Platform.isMobile` gating) —
+ * the metadata cache is available on every platform.
+ *
+ * Cost is O(N) per lookup over markdown files; create_instance executions are
+ * infrequent (one per button click), so an index is deferred unless profiling
+ * shows it is hot.
+ */
+export function createObsidianRefToFolderResolver(
+  app: App,
+): RefToFolderResolver {
+  return (ref: string): string | null => {
+    if (!ref) return null;
+
+    const metadataCache = app.metadataCache;
+    const vault = app.vault;
+    if (!metadataCache || !vault) return null;
+
+    const getFileCache = metadataCache.getFileCache?.bind(metadataCache);
+    const getMarkdownFiles = vault.getMarkdownFiles?.bind(vault);
+    if (!getFileCache || !getMarkdownFiles) return null;
+
+    const files: TFile[] = getMarkdownFiles();
+    for (const file of files) {
+      // Fast path: UID-canon filenames are `<uid>.md`, so the basename match
+      // avoids reading frontmatter for the common case.
+      if (file.basename === ref) {
+        return file.parent?.path ?? "";
+      }
+    }
+    for (const file of files) {
+      const cache: CachedMetadata | null = getFileCache(file);
+      const uid = cache?.frontmatter?.["exo__Asset_uid"];
+      if (typeof uid === "string" && uid === ref) {
+        return file.parent?.path ?? "";
+      }
+    }
+
+    return null;
+  };
+}

--- a/packages/obsidian-plugin/src/presentation/builders/button-groups/DynamicCommandButtonGroupBuilder.ts
+++ b/packages/obsidian-plugin/src/presentation/builders/button-groups/DynamicCommandButtonGroupBuilder.ts
@@ -84,6 +84,23 @@ export interface InputSchemaField {
   readonly rows?: number;
   /** SPARQL SELECT query returning candidate asset IRIs for assetRef fields. */
   readonly filterQuery?: string;
+  /**
+   * T1 "Create Instance" (project bbe40f8c) — for `assetRef` fields, the UID of
+   * the class whose instances populate the reusable fuzzy reference-picker.
+   * The form layer resolves candidate `{uid, label}` pairs of this class from
+   * the vault. Generic: parameterises the picker by class (ontology here;
+   * any range class for future commands).
+   */
+  readonly targetClassUid?: string;
+}
+
+/**
+ * A selectable asset for the fuzzy reference-picker — an instance of a field's
+ * `targetClassUid`, shown by `label`, committed as a wikilink to `uid`.
+ */
+export interface AssetRefCandidate {
+  readonly uid: string;
+  readonly label: string;
 }
 
 /**

--- a/packages/obsidian-plugin/src/presentation/components/dynamic-form/DynamicForm.tsx
+++ b/packages/obsidian-plugin/src/presentation/components/dynamic-form/DynamicForm.tsx
@@ -1,7 +1,8 @@
-import React, { useState, useCallback, useMemo } from "react";
+import React, { useState, useCallback, useMemo, useRef, useId } from "react";
 import type {
   InputSchemaField,
   EnumOption,
+  AssetRefCandidate,
 } from "@plugin/presentation/builders/button-groups/DynamicCommandButtonGroupBuilder";
 
 export interface DynamicFormProps {
@@ -9,6 +10,13 @@ export interface DynamicFormProps {
   readonly onSubmit: (values: Record<string, string>) => void;
   readonly onCancel: () => void;
   readonly submitLabel?: string;
+  /**
+   * T1 "Create Instance" (project bbe40f8c) — candidate assets for `assetRef`
+   * fuzzy reference-picker fields, keyed by field name. Resolved by the modal
+   * layer from the field's `targetClassUid`. Absent → the picker degrades to a
+   * plain text input (backward compatible).
+   */
+  readonly candidates?: Record<string, AssetRefCandidate[]>;
 }
 
 interface FieldError {
@@ -25,6 +33,7 @@ export const DynamicForm: React.FC<DynamicFormProps> = ({
   onSubmit,
   onCancel,
   submitLabel,
+  candidates,
 }) => {
   const initialValues = useMemo(() => {
     const values: Record<string, string> = {};
@@ -80,7 +89,16 @@ export const DynamicForm: React.FC<DynamicFormProps> = ({
             {field.label ?? field.name}
             {field.required && <span className="dynamic-form-required"> *</span>}
           </label>
-          {renderField(field, values[field.name] ?? "", handleChange)}
+          {field.type === "assetRef" ? (
+            <AssetRefPicker
+              field={field}
+              value={values[field.name] ?? ""}
+              candidates={candidates?.[field.name] ?? []}
+              onChange={handleChange}
+            />
+          ) : (
+            renderField(field, values[field.name] ?? "", handleChange)
+          )}
           {getFieldError(field.name) && (
             <div className="dynamic-form-error">{getFieldError(field.name)}</div>
           )}
@@ -95,6 +113,170 @@ export const DynamicForm: React.FC<DynamicFormProps> = ({
         </button>
       </div>
     </form>
+  );
+};
+
+/**
+ * T1 "Create Instance" — reusable fuzzy reference-picker for `assetRef` fields
+ * (project bbe40f8c, meta-requirement (a): a generic, parameterised-by-class
+ * component, not a one-off). Displays candidate `label`s, commits a quoted
+ * wikilink (`"[[<uid>]]"`) to the selected candidate. When no candidates are
+ * supplied (e.g. unparameterised field) it degrades to a free-text input so
+ * existing assetRef groundings keep working.
+ *
+ * Accessibility: ARIA combobox pattern with keyboard navigation —
+ * ArrowDown/ArrowUp move the active option, Enter selects, Escape closes.
+ */
+interface AssetRefPickerProps {
+  readonly field: InputSchemaField;
+  readonly value: string;
+  readonly candidates: ReadonlyArray<AssetRefCandidate>;
+  readonly onChange: (name: string, value: string) => void;
+}
+
+function toWikilink(uid: string): string {
+  return `"[[${uid}]]"`;
+}
+
+const AssetRefPicker: React.FC<AssetRefPickerProps> = ({
+  field,
+  value,
+  candidates,
+  onChange,
+}) => {
+  const [query, setQuery] = useState("");
+  const [open, setOpen] = useState(false);
+  const [activeIndex, setActiveIndex] = useState(-1);
+  const listboxId = useId();
+  const blurTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // No candidates supplied → behave like a plain text input (backward compat
+  // with assetRef fields that don't declare a targetClassUid).
+  const isPicker = candidates.length > 0 || field.targetClassUid !== undefined;
+
+  const filtered = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (q.length === 0) return candidates.slice(0, 50);
+    return candidates
+      .filter((c) => c.label.toLowerCase().includes(q))
+      .slice(0, 50);
+  }, [candidates, query]);
+
+  const commit = useCallback(
+    (candidate: AssetRefCandidate) => {
+      onChange(field.name, toWikilink(candidate.uid));
+      setQuery(candidate.label);
+      setOpen(false);
+      setActiveIndex(-1);
+    },
+    [field.name, onChange],
+  );
+
+  const handleInput = useCallback(
+    (text: string) => {
+      setQuery(text);
+      setOpen(true);
+      setActiveIndex(-1);
+      // Clear the committed selection until a candidate is chosen, so free
+      // text never leaks into frontmatter as a value.
+      if (value) onChange(field.name, "");
+    },
+    [field.name, onChange, value],
+  );
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLInputElement>) => {
+      if (!isPicker) return;
+      if (e.key === "ArrowDown") {
+        e.preventDefault();
+        setOpen(true);
+        setActiveIndex((i) => Math.min(i + 1, filtered.length - 1));
+      } else if (e.key === "ArrowUp") {
+        e.preventDefault();
+        setActiveIndex((i) => Math.max(i - 1, 0));
+      } else if (e.key === "Enter") {
+        if (open && activeIndex >= 0 && activeIndex < filtered.length) {
+          e.preventDefault();
+          commit(filtered[activeIndex]);
+        }
+      } else if (e.key === "Escape") {
+        setOpen(false);
+        setActiveIndex(-1);
+      }
+    },
+    [isPicker, filtered, open, activeIndex, commit],
+  );
+
+  if (!isPicker) {
+    // Plain text passthrough (legacy assetRef without candidates).
+    return (
+      <input
+        type="text"
+        className="dynamic-form-input"
+        placeholder="asset reference..."
+        value={value}
+        onChange={(e) => onChange(field.name, e.target.value)}
+        data-testid={`field-${field.name}`}
+      />
+    );
+  }
+
+  return (
+    <div className="dynamic-form-assetref">
+      <input
+        type="text"
+        role="combobox"
+        aria-expanded={open}
+        aria-controls={listboxId}
+        aria-autocomplete="list"
+        aria-activedescendant={
+          open && activeIndex >= 0
+            ? `${listboxId}-opt-${activeIndex}`
+            : undefined
+        }
+        className="dynamic-form-input"
+        placeholder="Type to search…"
+        value={query}
+        onChange={(e) => handleInput(e.target.value)}
+        onFocus={() => setOpen(true)}
+        onBlur={() => {
+          // Delay so an option's mousedown can commit before blur closes.
+          blurTimer.current = setTimeout(() => setOpen(false), 150);
+        }}
+        onKeyDown={handleKeyDown}
+        data-testid={`field-${field.name}`}
+      />
+      {open && filtered.length > 0 && (
+        <ul
+          id={listboxId}
+          role="listbox"
+          className="dynamic-form-assetref-options"
+        >
+          {filtered.map((candidate, idx) => (
+            <li
+              key={candidate.uid}
+              id={`${listboxId}-opt-${idx}`}
+              role="option"
+              aria-selected={idx === activeIndex}
+              className={
+                idx === activeIndex
+                  ? "dynamic-form-assetref-option is-active"
+                  : "dynamic-form-assetref-option"
+              }
+              // onMouseDown (not onClick) so it fires before the input blur.
+              onMouseDown={(e) => {
+                e.preventDefault();
+                if (blurTimer.current) clearTimeout(blurTimer.current);
+                commit(candidate);
+              }}
+              data-testid={`option-${field.name}-${candidate.uid}`}
+            >
+              {candidate.label}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
   );
 };
 
@@ -140,18 +322,6 @@ function renderField(
         <textarea
           className="dynamic-form-input"
           rows={field.rows ?? 4}
-          value={value}
-          onChange={(e) => onChange(field.name, e.target.value)}
-          data-testid={`field-${field.name}`}
-        />
-      );
-
-    case "assetRef":
-      return (
-        <input
-          type="text"
-          className="dynamic-form-input"
-          placeholder="asset reference..."
           value={value}
           onChange={(e) => onChange(field.name, e.target.value)}
           data-testid={`field-${field.name}`}

--- a/packages/obsidian-plugin/src/presentation/components/dynamic-form/DynamicForm.tsx
+++ b/packages/obsidian-plugin/src/presentation/components/dynamic-form/DynamicForm.tsx
@@ -1,4 +1,11 @@
-import React, { useState, useCallback, useMemo, useRef, useId } from "react";
+import React, {
+  useState,
+  useCallback,
+  useMemo,
+  useRef,
+  useId,
+  useEffect,
+} from "react";
 import type {
   InputSchemaField,
   EnumOption,
@@ -149,6 +156,15 @@ const AssetRefPicker: React.FC<AssetRefPickerProps> = ({
   const [activeIndex, setActiveIndex] = useState(-1);
   const listboxId = useId();
   const blurTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Clear any pending blur-close timer on unmount so it can't fire after the
+  // modal closes (harmless no-op in React 19, but tidy).
+  useEffect(
+    () => () => {
+      if (blurTimer.current) clearTimeout(blurTimer.current);
+    },
+    [],
+  );
 
   // No candidates supplied → behave like a plain text input (backward compat
   // with assetRef fields that don't declare a targetClassUid).

--- a/packages/obsidian-plugin/src/presentation/modals/DynamicFormModal.ts
+++ b/packages/obsidian-plugin/src/presentation/modals/DynamicFormModal.ts
@@ -1,11 +1,20 @@
 import { Modal, App } from "obsidian";
 import React from "react";
-import type { InputSchemaField } from "@plugin/presentation/builders/button-groups/DynamicCommandButtonGroupBuilder";
+import type {
+  InputSchemaField,
+  AssetRefCandidate,
+} from "@plugin/presentation/builders/button-groups/DynamicCommandButtonGroupBuilder";
 import { ReactRenderer } from "@plugin/presentation/utils/ReactRenderer";
 import { DynamicForm } from "@plugin/presentation/components/dynamic-form/DynamicForm";
 import { ErrorBoundary } from "@plugin/presentation/components/ErrorBoundary";
+import { findAssetRefCandidates } from "@plugin/presentation/utils/assetRefCandidates";
 
 export type UserInput = Record<string, string>;
+
+/** Resolves the picker candidates for an `assetRef` field's `targetClassUid`. */
+export type AssetRefCandidatesResolver = (
+  classUid: string,
+) => AssetRefCandidate[];
 
 export interface DynamicFormModalOptions {
   readonly title?: string;
@@ -16,13 +25,38 @@ export class DynamicFormModal extends Modal {
   private readonly schema: InputSchemaField[];
   private readonly options: DynamicFormModalOptions;
   private readonly reactRenderer: ReactRenderer;
+  private readonly candidatesResolver: AssetRefCandidatesResolver;
   private resolvePromise: ((value: UserInput | null) => void) | null = null;
 
-  constructor(app: App, schema: InputSchemaField[], options?: DynamicFormModalOptions) {
+  constructor(
+    app: App,
+    schema: InputSchemaField[],
+    options?: DynamicFormModalOptions,
+    // T1 "Create Instance" (project bbe40f8c) — injectable for unit tests;
+    // production wiring scans the vault metadata cache by class UID.
+    candidatesResolver?: AssetRefCandidatesResolver,
+  ) {
     super(app);
     this.schema = schema;
     this.options = options ?? {};
     this.reactRenderer = new ReactRenderer();
+    this.candidatesResolver =
+      candidatesResolver ?? ((classUid) => findAssetRefCandidates(app, classUid));
+  }
+
+  /**
+   * T1: build the per-field candidate lists for `assetRef` fuzzy-picker fields
+   * that declare a `targetClassUid`. Done once at open time so the React form
+   * receives a stable snapshot.
+   */
+  private buildCandidates(): Record<string, AssetRefCandidate[]> {
+    const candidates: Record<string, AssetRefCandidate[]> = {};
+    for (const field of this.schema) {
+      if (field.type === "assetRef" && field.targetClassUid) {
+        candidates[field.name] = this.candidatesResolver(field.targetClassUid);
+      }
+    }
+    return candidates;
   }
 
   override onOpen(): void {
@@ -35,6 +69,8 @@ export class DynamicFormModal extends Modal {
 
     const container = contentEl.createEl("div", { cls: "dynamic-form-container" });
 
+    const candidates = this.buildCandidates();
+
     this.reactRenderer.render(
       container,
       React.createElement(
@@ -42,6 +78,7 @@ export class DynamicFormModal extends Modal {
         {
           children: React.createElement(DynamicForm, {
             schema: this.schema,
+            candidates,
             submitLabel: this.options.submitLabel,
             onSubmit: (values: UserInput) => {
               this.resolvePromise?.(values);

--- a/packages/obsidian-plugin/src/presentation/utils/assetRefCandidates.ts
+++ b/packages/obsidian-plugin/src/presentation/utils/assetRefCandidates.ts
@@ -1,0 +1,92 @@
+import type { App, TFile } from "obsidian";
+import type { AssetRefCandidate } from "@plugin/presentation/builders/button-groups/DynamicCommandButtonGroupBuilder";
+
+/**
+ * T1 "Create Instance" homoiconic button (project bbe40f8c) — collect the
+ * candidate assets for a reusable fuzzy reference-picker field, i.e. every
+ * vault asset that is an instance of `classUid` (the field's `targetClassUid`).
+ *
+ * Matching tolerates the dual IRI scheme (UID-canon + legacy symbolic): an
+ * `exo__Instance_class` entry matches when its extracted target equals the
+ * class UID OR the class's `exo__Asset_label`. The class label is resolved
+ * once from the class file (`<classUid>.md` basename or `exo__Asset_uid`).
+ *
+ * Returns `{uid, label}` pairs sorted by label, so the picker shows a stable,
+ * human-ordered list. Empty array when the metadata-cache API is unavailable
+ * or nothing matches. Works on desktop and mobile (metadata cache only — no
+ * `Platform.isMobile` gating).
+ */
+export function findAssetRefCandidates(
+  app: App,
+  classUid: string,
+): AssetRefCandidate[] {
+  if (!classUid) return [];
+
+  const metadataCache = app.metadataCache;
+  const vault = app.vault;
+  if (!metadataCache?.getFileCache || !vault?.getMarkdownFiles) return [];
+
+  const getFileCache = metadataCache.getFileCache.bind(metadataCache);
+  const files: TFile[] = vault.getMarkdownFiles();
+
+  // Resolve the class label so symbolic-form `exo__Instance_class` values
+  // (`[[exo__Ontology]]`) match as well as UID-form (`[[<uid>]]`).
+  const matchTargets = new Set<string>([classUid.toLowerCase()]);
+  for (const file of files) {
+    if (file.basename === classUid) {
+      const label = getFileCache(file)?.frontmatter?.["exo__Asset_label"];
+      if (typeof label === "string" && label.length > 0) {
+        matchTargets.add(label.toLowerCase());
+      }
+      break;
+    }
+  }
+
+  const candidates: AssetRefCandidate[] = [];
+  for (const file of files) {
+    const fm = getFileCache(file)?.frontmatter;
+    if (!fm) continue;
+
+    const instanceClass = fm["exo__Instance_class"];
+    if (!isInstanceOfClass(instanceClass, matchTargets)) continue;
+
+    const uid =
+      typeof fm["exo__Asset_uid"] === "string"
+        ? (fm["exo__Asset_uid"] as string)
+        : file.basename;
+    const label =
+      typeof fm["exo__Asset_label"] === "string" &&
+      (fm["exo__Asset_label"] as string).length > 0
+        ? (fm["exo__Asset_label"] as string)
+        : file.basename;
+    candidates.push({ uid, label });
+  }
+
+  candidates.sort((a, b) => a.label.localeCompare(b.label));
+  return candidates;
+}
+
+function isInstanceOfClass(
+  instanceClass: unknown,
+  matchTargets: ReadonlySet<string>,
+): boolean {
+  if (instanceClass === undefined || instanceClass === null) return false;
+  const entries = Array.isArray(instanceClass)
+    ? instanceClass
+    : [instanceClass];
+  for (const entry of entries) {
+    if (typeof entry !== "string") continue;
+    const target = extractRefTarget(entry);
+    if (target && matchTargets.has(target.toLowerCase())) return true;
+  }
+  return false;
+}
+
+/** Strip quotes / `[[ ]]` / `|alias` from a frontmatter ref → bare target. */
+function extractRefTarget(value: string): string {
+  let ref = value.trim().replace(/^["']|["']$/g, "").trim();
+  ref = ref.replace(/^\[\[/, "").replace(/\]\]$/, "");
+  const pipeIdx = ref.indexOf("|");
+  if (pipeIdx >= 0) ref = ref.slice(0, pipeIdx);
+  return ref.trim();
+}

--- a/packages/obsidian-plugin/styles.css
+++ b/packages/obsidian-plugin/styles.css
@@ -6265,3 +6265,38 @@
     opacity: 1;
   }
 }
+
+/* T1 "Create Instance" (project bbe40f8c) — fuzzy reference-picker dropdown.
+   The picker input reuses .dynamic-form-input; these rules style the
+   candidate list and the keyboard-active option so sighted keyboard users
+   can see the current selection (a11y already covered by aria-activedescendant). */
+.dynamic-form-assetref {
+  position: relative;
+}
+
+.dynamic-form-assetref-options {
+  position: absolute;
+  z-index: var(--layer-popover, 30);
+  left: 0;
+  right: 0;
+  margin: 2px 0 0 0;
+  padding: 4px;
+  list-style: none;
+  max-height: 220px;
+  overflow-y: auto;
+  background: var(--background-primary);
+  border: 1px solid var(--background-modifier-border);
+  border-radius: var(--radius-s);
+  box-shadow: var(--shadow-s);
+}
+
+.dynamic-form-assetref-option {
+  padding: var(--size-2-1, 4px) var(--size-2-2, 8px);
+  border-radius: var(--radius-s);
+  cursor: pointer;
+}
+
+.dynamic-form-assetref-option:hover,
+.dynamic-form-assetref-option.is-active {
+  background: var(--background-modifier-hover);
+}

--- a/packages/obsidian-plugin/tests/unit/infrastructure/services/ObsidianRefToFolderResolver.test.ts
+++ b/packages/obsidian-plugin/tests/unit/infrastructure/services/ObsidianRefToFolderResolver.test.ts
@@ -1,0 +1,73 @@
+import { createObsidianRefToFolderResolver } from "@plugin/infrastructure/services/ObsidianRefToFolderResolver";
+
+// T1 "Create Instance" (project bbe40f8c) — uid → co-located ontology folder.
+
+interface FakeFile {
+  basename: string;
+  parent: { path: string } | null;
+}
+
+function makeApp(
+  files: Array<{ file: FakeFile; fm?: Record<string, unknown> }>,
+): any {
+  const list = files.map((f) => f.file);
+  const fmByBasename = new Map(files.map((f) => [f.file.basename, f.fm]));
+  return {
+    vault: { getMarkdownFiles: () => list },
+    metadataCache: {
+      getFileCache: (file: FakeFile) => ({
+        frontmatter: fmByBasename.get(file.basename),
+      }),
+    },
+  };
+}
+
+describe("createObsidianRefToFolderResolver (T1 co-location)", () => {
+  it("resolves a UID-canon filename to its parent folder (fast path)", () => {
+    const app = makeApp([
+      {
+        file: {
+          basename: "086f71fa-dd30-4284-90cf-e609f2a6c461",
+          parent: { path: "assetspaces/kitelev/exoas-ems/ems" },
+        },
+      },
+    ]);
+    const resolve = createObsidianRefToFolderResolver(app);
+    expect(resolve("086f71fa-dd30-4284-90cf-e609f2a6c461")).toBe(
+      "assetspaces/kitelev/exoas-ems/ems",
+    );
+  });
+
+  it("resolves by exo__Asset_uid frontmatter when filename is not UID-canon", () => {
+    const app = makeApp([
+      {
+        file: { basename: "ems__Ontology", parent: { path: "legacy/ontologies" } },
+        fm: { exo__Asset_uid: "the-uid-123" },
+      },
+    ]);
+    const resolve = createObsidianRefToFolderResolver(app);
+    expect(resolve("the-uid-123")).toBe("legacy/ontologies");
+  });
+
+  it("returns empty string for a file at the vault root", () => {
+    const app = makeApp([
+      { file: { basename: "root-onto", parent: null } },
+    ]);
+    const resolve = createObsidianRefToFolderResolver(app);
+    expect(resolve("root-onto")).toBe("");
+  });
+
+  it("returns null when the ref matches no file", () => {
+    const app = makeApp([
+      { file: { basename: "other", parent: { path: "x" } } },
+    ]);
+    const resolve = createObsidianRefToFolderResolver(app);
+    expect(resolve("missing-uid")).toBeNull();
+  });
+
+  it("returns null for empty ref or unavailable API", () => {
+    const app = makeApp([]);
+    expect(createObsidianRefToFolderResolver(app)("")).toBeNull();
+    expect(createObsidianRefToFolderResolver({} as any)("x")).toBeNull();
+  });
+});

--- a/packages/obsidian-plugin/tests/unit/presentation/components/DynamicForm.test.tsx
+++ b/packages/obsidian-plugin/tests/unit/presentation/components/DynamicForm.test.tsx
@@ -175,6 +175,101 @@ describe("DynamicForm", () => {
     });
   });
 
+  // T1 "Create Instance" (project bbe40f8c) — reusable fuzzy reference-picker.
+  describe("assetRef fuzzy reference-picker (targetClassUid)", () => {
+    const ONTOLOGY_FIELD: InputSchemaField = {
+      name: "exo__Asset_isDefinedBy",
+      type: "assetRef",
+      label: "Ontology",
+      required: true,
+      targetClassUid: "829b9b3b-6fc3-4276-be6a-27d3398c012e",
+    };
+    const CANDIDATES = {
+      exo__Asset_isDefinedBy: [
+        { uid: "uid-ems", label: "ems (Effort Management)" },
+        { uid: "uid-exo", label: "exo (Core)" },
+        { uid: "uid-ims", label: "ims (Identity)" },
+      ],
+    };
+
+    it("renders an ARIA combobox (not a plain text input) when candidates exist", () => {
+      renderForm([ONTOLOGY_FIELD], { candidates: CANDIDATES });
+      const input = screen.getByTestId("field-exo__Asset_isDefinedBy");
+      expect(input).toHaveAttribute("role", "combobox");
+      expect(input).toHaveAttribute("aria-expanded", "false");
+      expect(input).toHaveAttribute("placeholder", "Type to search…");
+    });
+
+    it("filters candidates by typed query (fuzzy/substring on label)", () => {
+      renderForm([ONTOLOGY_FIELD], { candidates: CANDIDATES });
+      const input = screen.getByTestId("field-exo__Asset_isDefinedBy");
+      fireEvent.focus(input);
+      fireEvent.change(input, { target: { value: "ems" } });
+      expect(screen.getByText("ems (Effort Management)")).toBeInTheDocument();
+      expect(screen.queryByText("exo (Core)")).not.toBeInTheDocument();
+    });
+
+    it("commits a quoted wikilink to the selected candidate on click", () => {
+      const { onSubmit } = renderForm([ONTOLOGY_FIELD], {
+        candidates: CANDIDATES,
+      });
+      const input = screen.getByTestId("field-exo__Asset_isDefinedBy");
+      fireEvent.focus(input);
+      fireEvent.change(input, { target: { value: "exo" } });
+      fireEvent.mouseDown(
+        screen.getByTestId("option-exo__Asset_isDefinedBy-uid-exo"),
+      );
+      fireEvent.click(screen.getByText("OK"));
+      expect(onSubmit).toHaveBeenCalledWith({
+        exo__Asset_isDefinedBy: '"[[uid-exo]]"',
+      });
+    });
+
+    it("supports keyboard nav: ArrowDown + Enter selects the active option", () => {
+      const { onSubmit } = renderForm([ONTOLOGY_FIELD], {
+        candidates: CANDIDATES,
+      });
+      const input = screen.getByTestId("field-exo__Asset_isDefinedBy");
+      fireEvent.focus(input);
+      fireEvent.keyDown(input, { key: "ArrowDown" }); // active = 0 (ems)
+      fireEvent.keyDown(input, { key: "Enter" });
+      fireEvent.click(screen.getByText("OK"));
+      expect(onSubmit).toHaveBeenCalledWith({
+        exo__Asset_isDefinedBy: '"[[uid-ems]]"',
+      });
+    });
+
+    it("required picker blocks submit until a candidate is selected", () => {
+      const { onSubmit } = renderForm([ONTOLOGY_FIELD], {
+        candidates: CANDIDATES,
+      });
+      // No selection yet → submit blocked with error.
+      fireEvent.click(screen.getByText("OK"));
+      expect(onSubmit).not.toHaveBeenCalled();
+      expect(screen.getByText("Ontology is required")).toBeInTheDocument();
+    });
+
+    it("typing free text without selecting does NOT commit a value", () => {
+      const { onSubmit } = renderForm([ONTOLOGY_FIELD], {
+        candidates: CANDIDATES,
+      });
+      const input = screen.getByTestId("field-exo__Asset_isDefinedBy");
+      fireEvent.focus(input);
+      fireEvent.change(input, { target: { value: "garbage typed text" } });
+      fireEvent.click(screen.getByText("OK"));
+      expect(onSubmit).not.toHaveBeenCalled();
+    });
+
+    it("degrades to a plain text input when a targetClassUid field has no candidates", () => {
+      renderForm([ONTOLOGY_FIELD], {
+        candidates: { exo__Asset_isDefinedBy: [] },
+      });
+      // Still a picker shell (targetClassUid present) — combobox role, empty list.
+      const input = screen.getByTestId("field-exo__Asset_isDefinedBy");
+      expect(input).toHaveAttribute("role", "combobox");
+    });
+  });
+
   describe("validation", () => {
     it("should show error for empty required text field", () => {
       renderForm([{ name: "title", type: "text", label: "Title", required: true }]);

--- a/packages/obsidian-plugin/tests/unit/presentation/modals/DynamicFormModal.test.ts
+++ b/packages/obsidian-plugin/tests/unit/presentation/modals/DynamicFormModal.test.ts
@@ -97,6 +97,63 @@ describe("DynamicFormModal", () => {
     expect(result).toBeNull();
   });
 
+  // T1 "Create Instance" (project bbe40f8c) — candidate wiring for assetRef
+  // fuzzy-picker fields.
+  describe("assetRef candidates wiring", () => {
+    const pickerSchema: InputSchemaField[] = [
+      { name: "label", type: "text", label: "Label", required: true },
+      {
+        name: "exo__Asset_isDefinedBy",
+        type: "assetRef",
+        label: "Ontology",
+        required: true,
+        targetClassUid: "829b9b3b-6fc3-4276-be6a-27d3398c012e",
+      },
+    ];
+
+    function candidatesPassedToForm(): Record<string, unknown> | undefined {
+      // mockRender(container, reactElement) — reactElement is the ErrorBoundary
+      // wrapping DynamicForm; dig into the DynamicForm props.
+      const reactEl = mockRender.mock.calls[0][1];
+      return reactEl.props.children.props.candidates;
+    }
+
+    it("resolves candidates by targetClassUid and passes them to DynamicForm", () => {
+      const resolver = jest.fn((classUid: string) =>
+        classUid === "829b9b3b-6fc3-4276-be6a-27d3398c012e"
+          ? [{ uid: "uid-ems", label: "ems" }]
+          : [],
+      );
+      const modal = new DynamicFormModal(
+        mockApp,
+        pickerSchema,
+        undefined,
+        resolver,
+      );
+      modal.onOpen();
+
+      expect(resolver).toHaveBeenCalledWith(
+        "829b9b3b-6fc3-4276-be6a-27d3398c012e",
+      );
+      expect(candidatesPassedToForm()).toEqual({
+        exo__Asset_isDefinedBy: [{ uid: "uid-ems", label: "ems" }],
+      });
+    });
+
+    it("does NOT resolve candidates for assetRef fields without targetClassUid", () => {
+      const resolver = jest.fn(() => []);
+      const modal = new DynamicFormModal(
+        mockApp,
+        [{ name: "parent", type: "assetRef", label: "Parent" }],
+        undefined,
+        resolver,
+      );
+      modal.onOpen();
+      expect(resolver).not.toHaveBeenCalled();
+      expect(candidatesPassedToForm()).toEqual({});
+    });
+  });
+
   it("should resolve with values when onSubmit is called", async () => {
     const modal = new DynamicFormModal(mockApp, schema);
 

--- a/packages/obsidian-plugin/tests/unit/presentation/utils/assetRefCandidates.test.ts
+++ b/packages/obsidian-plugin/tests/unit/presentation/utils/assetRefCandidates.test.ts
@@ -1,0 +1,121 @@
+import { findAssetRefCandidates } from "@plugin/presentation/utils/assetRefCandidates";
+
+// T1 "Create Instance" (project bbe40f8c) — candidate resolution for the
+// reusable fuzzy reference-picker (assetRef fields parameterised by class).
+
+const ONTOLOGY_CLASS_UID = "829b9b3b-6fc3-4276-be6a-27d3398c012e";
+
+interface FakeFile {
+  basename: string;
+  path: string;
+}
+
+function makeApp(
+  fileFrontmatters: Array<{ file: FakeFile; fm: Record<string, unknown> }>,
+): any {
+  const files = fileFrontmatters.map((f) => f.file);
+  const byBasename = new Map(
+    fileFrontmatters.map((f) => [f.file.basename, f.fm]),
+  );
+  return {
+    vault: { getMarkdownFiles: () => files },
+    metadataCache: {
+      getFileCache: (file: FakeFile) => ({
+        frontmatter: byBasename.get(file.basename),
+      }),
+    },
+  };
+}
+
+describe("findAssetRefCandidates (T1 fuzzy reference-picker)", () => {
+  it("returns instances of the target class as {uid, label}, sorted by label", () => {
+    const app = makeApp([
+      // The class definition itself (so its label can be resolved).
+      {
+        file: { basename: ONTOLOGY_CLASS_UID, path: `exo/${ONTOLOGY_CLASS_UID}.md` },
+        fm: { exo__Asset_uid: ONTOLOGY_CLASS_UID, exo__Asset_label: "exo__Ontology" },
+      },
+      // UID-form instance.
+      {
+        file: { basename: "uid-ems", path: "ems/uid-ems.md" },
+        fm: {
+          exo__Asset_uid: "uid-ems",
+          exo__Asset_label: "ems (Effort Management)",
+          exo__Instance_class: [`"[[${ONTOLOGY_CLASS_UID}]]"`],
+        },
+      },
+      // Symbolic-form instance (label-form wikilink).
+      {
+        file: { basename: "uid-exo", path: "exo/uid-exo.md" },
+        fm: {
+          exo__Asset_uid: "uid-exo",
+          exo__Asset_label: "exo (Core)",
+          exo__Instance_class: "[[exo__Ontology]]",
+        },
+      },
+      // Not an ontology — excluded.
+      {
+        file: { basename: "uid-task", path: "ems/uid-task.md" },
+        fm: {
+          exo__Asset_uid: "uid-task",
+          exo__Asset_label: "Some Task",
+          exo__Instance_class: ["[[1b20a8f0-d745-4e93-91db-4531b3df120e]]"],
+        },
+      },
+    ]);
+
+    const result = findAssetRefCandidates(app, ONTOLOGY_CLASS_UID);
+
+    expect(result).toEqual([
+      { uid: "uid-ems", label: "ems (Effort Management)" },
+      { uid: "uid-exo", label: "exo (Core)" },
+    ]);
+  });
+
+  it("matches UID-form even when the class label cannot be resolved", () => {
+    const app = makeApp([
+      {
+        file: { basename: "uid-a", path: "x/uid-a.md" },
+        fm: {
+          exo__Asset_uid: "uid-a",
+          exo__Asset_label: "A",
+          exo__Instance_class: `"[[${ONTOLOGY_CLASS_UID}]]"`,
+        },
+      },
+    ]);
+    const result = findAssetRefCandidates(app, ONTOLOGY_CLASS_UID);
+    expect(result).toEqual([{ uid: "uid-a", label: "A" }]);
+  });
+
+  it("falls back to basename when uid/label frontmatter is absent", () => {
+    const app = makeApp([
+      {
+        file: { basename: "raw-file", path: "x/raw-file.md" },
+        fm: { exo__Instance_class: `"[[${ONTOLOGY_CLASS_UID}]]"` },
+      },
+    ]);
+    const result = findAssetRefCandidates(app, ONTOLOGY_CLASS_UID);
+    expect(result).toEqual([{ uid: "raw-file", label: "raw-file" }]);
+  });
+
+  it("returns empty array when classUid is empty or API unavailable", () => {
+    expect(findAssetRefCandidates(makeApp([]), "")).toEqual([]);
+    expect(findAssetRefCandidates({} as any, ONTOLOGY_CLASS_UID)).toEqual([]);
+  });
+
+  it("tolerates piped wikilinks in exo__Instance_class", () => {
+    const app = makeApp([
+      {
+        file: { basename: "uid-p", path: "x/uid-p.md" },
+        fm: {
+          exo__Asset_uid: "uid-p",
+          exo__Asset_label: "Piped",
+          exo__Instance_class: `"[[${ONTOLOGY_CLASS_UID}|exo__Ontology]]"`,
+        },
+      },
+    ]);
+    expect(findAssetRefCandidates(app, ONTOLOGY_CLASS_UID)).toEqual([
+      { uid: "uid-p", label: "Piped" },
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

T1 (CORE) of project **bbe40f8c** (Exocortex Alpha Launch) — vertical slice for a vault-declared **«Create Instance»** command bound to the `exo__Class` metaclass, rendered on every class-definition page. Click → form (Label + Ontology fuzzy-picker) → valid UUID instance, co-located with its chosen ontology, opened.

The host page **IS** the class definition, so the new instance's `exo__Instance_class` points back at the host's own UID, and it lands co-located with the `exo__Asset_isDefinedBy` ontology the user picks.

## ⛔ Plan deviation (verify-before-assert)

The hand-off plan proposed co-location via a **composite [create_instance + service_call repairFolder]** grounding. Source inspection proved this **non-viable**:
- `repairFolder` resolves its file from `targetIRI` (the **host** class-def), reads ITS `isDefinedBy`, and would relocate the **host**, not the new instance.
- `executeComposite` passes the same `targetIRI`/`filePath` to every step and does **not** thread `openPath`, so the second step can't reach the newly created file.

**Correction:** a new `$isDefinedByFolder` target-folder token + an injectable `RefToFolderResolver` co-locate the instance in one create_instance pass (fallback to host folder when unresolved — never fails the create).

## Changes

**Core (`exocortex`)**
- `targetClassSelf` SubstitutionToken resolver — host's own UID from `targetFilePath` basename (inverts `groundingTargetClass`); added to `KNOWN_SUBSTITUTION_RESOLVER_IDS`.
- `CommandResolver` inputSchema parse propagates `targetClassUid` on `assetRef` fields (parameterises the reusable picker by class).
- `GroundingExecutor`: `$isDefinedByFolder` token + `RefToFolderResolver` injection → co-location.
- `createVaultFrontmatterRefToFolderResolver` — CLI/headless parity, wired into `apply`.

**Plugin (`obsidian-plugin`)**
- Reusable fuzzy **reference-picker** for `assetRef` fields (ARIA combobox, keyboard nav, label display / wikilink commit). Degrades to plain text without candidates (backward compatible).
- `DynamicFormModal` resolves candidates by `targetClassUid` from the metadata cache.
- `createObsidianRefToFolderResolver` wired into the plugin `GroundingExecutor`.

Desktop+mobile parity — metadata cache only, **no `Platform.isMobile` gating** (archgate MOBILE-004 green).

## Tests (TDD)
- `targetClassSelf` resolver unit (incl. fallback matrix).
- inputSchema `targetClassUid` parse.
- Executor co-location integration: host-as-class instance_class + `$isDefinedByFolder` co-location + different-ontology + 2× fallback.
- Picker CT: filter / click-select / keyboard ArrowDown+Enter / required-blocks / free-text-no-commit.
- Candidate + ref→folder resolvers (plugin + core).

## Follow-up (post-release)
Vault homoiconic assets (`exocmd__Command` «Create Instance» + `CommandBinding` targetClass=`exo__Class` + composite-free `create_instance` Grounding + `targetClassSelf` SubstitutionToken/PropertyDefault) ship to `exoas-exocmd` **after** this plugin release — they require this version to interpret the new token. Visual smoke follows.

Refs project bbe40f8c.