### PR TITLE
feat(settings): PAT create-token helper + inline scope list (RFC 0002 §3.5, P9)

### DIFF
--- a/packages/obsidian-plugin/src/presentation/settings/ExocortexSettingTab.ts
+++ b/packages/obsidian-plugin/src/presentation/settings/ExocortexSettingTab.ts
@@ -14,6 +14,7 @@ import { LocalSecretsStore } from "@plugin/infrastructure/adapters/LocalSecretsS
 import { OperationsLogReader } from "@plugin/infrastructure/adapters/OperationsLogReader";
 import { SwitchCacheLayer } from "@plugin/infrastructure/adapters/SwitchCacheLayer";
 import { resolvePastedSecret } from "@plugin/presentation/settings/patClipboard";
+import { renderPatSetupHelper } from "@plugin/presentation/settings/patSetupHelper";
 
 /**
  * Issue #3320 §1 — secret key used by buildAssetSpacePusher and now the
@@ -655,6 +656,12 @@ export class ExocortexSettingTab extends PluginSettingTab {
       " On mobile, use the Paste button to fill the field from your " +
         "clipboard instead of typing the token by hand.",
     );
+
+    // RFC 0002 §3.5 (P9) — create-token helper: a deep-link to GitHub's
+    // fine-grained token page + an inline list of the permissions the token
+    // needs. Reusable renderer (patSetupHelper) so the first-run Welcome PAT
+    // step (cd9444bd) shows identical guidance without copy drift.
+    renderPatSetupHelper(containerEl);
 
     let patInputValue = "";
     // Captured from `addText` below so the Paste button can write into the same

--- a/packages/obsidian-plugin/src/presentation/settings/patSetupHelper.ts
+++ b/packages/obsidian-plugin/src/presentation/settings/patSetupHelper.ts
@@ -84,17 +84,19 @@ export function renderPatSetupHelper(containerEl: HTMLElement): HTMLElement {
     cls: "exocortex-pat-setup-helper",
   });
 
-  const link = wrapper.createEl("a", {
+  wrapper.createEl("a", {
     cls: "exocortex-pat-setup-create-link",
     text: PAT_CREATE_TOKEN_LABEL,
     href: GITHUB_FINE_GRAINED_TOKEN_URL,
+    attr: {
+      // _blank + noopener/noreferrer: open GitHub without reverse-tabnabbing.
+      target: "_blank",
+      rel: "noopener noreferrer",
+      // Screen-reader label states the link leaves Obsidian (P16).
+      "aria-label":
+        "Create a fine-grained GitHub token (opens GitHub in your browser)",
+    },
   });
-  link.setAttribute("target", "_blank");
-  link.setAttribute("rel", "noopener noreferrer");
-  link.setAttribute(
-    "aria-label",
-    "Create a fine-grained GitHub token (opens GitHub in your browser)",
-  );
 
   wrapper.createEl("p", {
     cls: "exocortex-pat-setup-intro",

--- a/packages/obsidian-plugin/src/presentation/settings/patSetupHelper.ts
+++ b/packages/obsidian-plugin/src/presentation/settings/patSetupHelper.ts
@@ -1,0 +1,115 @@
+/**
+ * PAT setup create-token helper — RFC 0002 §3.5 (resolves P9: PAT setup has no
+ * inline "create token" helper or scope guidance).
+ *
+ * PAT creation is the single hardest onboarding step: a new tester must leave
+ * Obsidian, find GitHub's *fine-grained* token page (not the classic one), and
+ * guess which permissions Exocortex needs. This module scaffolds that step with:
+ *   1. a deep-link straight to GitHub's fine-grained token creation page, and
+ *   2. an inline list of the exact permissions the token needs.
+ *
+ * It is a **reusable, side-effect-free renderer** (no plugin/app coupling — it
+ * only writes DOM into a caller-supplied element) so the same guidance can be
+ * shown in two places without divergence:
+ *   - the Settings "GitHub PAT" section (`ExocortexSettingTab`), and
+ *   - the first-run Welcome panel's PAT step (cd9444bd, RFC 0002 §3.1).
+ *
+ * The deep-link URL and the permission list are exported as pure data so they
+ * can be unit-tested (and reused) independently of the Obsidian DOM wiring.
+ */
+
+/**
+ * Deep-link to GitHub's *fine-grained* personal-access-token creation page.
+ *
+ * Fine-grained (not classic) is required: ExoSync/Push needs a token with a
+ * per-repository allowlist scoped to the user's `exoas-*` repos. The classic
+ * token page (`/settings/tokens/new`) issues coarse `repo`-scoped tokens that
+ * the plugin's settings copy explicitly steers users away from.
+ */
+export const GITHUB_FINE_GRAINED_TOKEN_URL =
+  "https://github.com/settings/personal-access-tokens/new";
+
+/** Visible label of the create-token link. */
+export const PAT_CREATE_TOKEN_LABEL = "Create token on GitHub";
+
+/** One required permission line shown to the user. */
+export interface PatRequiredScope {
+  /** GitHub fine-grained permission name (e.g. "Contents"). */
+  readonly permission: string;
+  /** Access level to grant (e.g. "Read and write"). */
+  readonly access: string;
+  /** Plain-language reason the token needs it. */
+  readonly why: string;
+}
+
+/**
+ * The fine-grained permissions an Exocortex sync/push token needs, on the
+ * repositories the user pushes (their `exoas-*` AssetSpace repos).
+ *
+ * - **Contents: Read and write** — the load-bearing one (RFC 0002 §3.5):
+ *   pushing AssetSpace submodule commits writes repository contents.
+ * - **Metadata: Read-only** — GitHub auto-selects this for every fine-grained
+ *   token; listed so the user isn't surprised by it, and because the settings
+ *   "Test connection" button lists repos (which needs metadata read).
+ */
+export const PAT_REQUIRED_SCOPES: readonly PatRequiredScope[] = [
+  {
+    permission: "Contents",
+    access: "Read and write",
+    why: "push AssetSpace submodule commits to your exoas-* repos",
+  },
+  {
+    permission: "Metadata",
+    access: "Read-only",
+    why: "mandatory baseline (GitHub auto-selects it); also lets Test connection list your repos",
+  },
+];
+
+/**
+ * Render the create-token helper (deep-link + required-permissions list) into
+ * `containerEl` and return the wrapper element it created.
+ *
+ * Pure DOM, no plugin state — safe to call from any settings/modal context.
+ *
+ * ## Accessibility (RFC 0002 §3.11 / P16)
+ * - The create-token control is a native `<a>` (keyboard-focusable, activatable
+ *   with Enter) carrying an explicit `aria-label` that states it opens GitHub.
+ * - `target="_blank"` is paired with `rel="noopener noreferrer"` (security +
+ *   no reverse-tabnabbing).
+ * - The permissions are a semantic `<ul>` with an `aria-label`, so assistive
+ *   tech announces them as a labelled list rather than loose text.
+ */
+export function renderPatSetupHelper(containerEl: HTMLElement): HTMLElement {
+  const wrapper = containerEl.createEl("div", {
+    cls: "exocortex-pat-setup-helper",
+  });
+
+  const link = wrapper.createEl("a", {
+    cls: "exocortex-pat-setup-create-link",
+    text: PAT_CREATE_TOKEN_LABEL,
+    href: GITHUB_FINE_GRAINED_TOKEN_URL,
+  });
+  link.setAttribute("target", "_blank");
+  link.setAttribute("rel", "noopener noreferrer");
+  link.setAttribute(
+    "aria-label",
+    "Create a fine-grained GitHub token (opens GitHub in your browser)",
+  );
+
+  wrapper.createEl("p", {
+    cls: "exocortex-pat-setup-intro",
+    text:
+      "Create a fine-grained token scoped to your exoas-* repositories, grant " +
+      "these permissions, then paste it above and click Save PAT:",
+  });
+
+  const list = wrapper.createEl("ul", { cls: "exocortex-pat-setup-scopes" });
+  list.setAttribute("aria-label", "Required GitHub token permissions");
+  for (const scope of PAT_REQUIRED_SCOPES) {
+    const item = list.createEl("li", { cls: "exocortex-pat-setup-scope" });
+    item.createEl("strong", { text: `${scope.permission}: ${scope.access}` });
+    item.createEl("span", { text: ` — ${scope.why}` });
+  }
+
+  return wrapper;
+}

--- a/packages/obsidian-plugin/styles.css
+++ b/packages/obsidian-plugin/styles.css
@@ -6195,6 +6195,32 @@
   margin-top: 1em;
 }
 
+/* RFC 0002 §3.5 — PAT setup create-token helper (deep-link + scope list). */
+.exocortex-pat-setup-helper {
+  margin: 0.5em 0 1em;
+}
+
+.exocortex-pat-setup-create-link {
+  font-weight: var(--font-semibold, 600);
+}
+
+.exocortex-pat-setup-intro {
+  color: var(--text-muted, #6e7681);
+  font-size: var(--font-ui-smaller, 0.8em);
+  margin: 0.4em 0 0.4em;
+}
+
+.exocortex-pat-setup-scopes {
+  margin: 0;
+  padding-left: 1.4em;
+  color: var(--text-muted, #6e7681);
+  font-size: var(--font-ui-smaller, 0.8em);
+}
+
+.exocortex-pat-setup-scope {
+  margin-bottom: 0.2em;
+}
+
 /* ExoSync (RFC 4e4dc453 Phase B) — invalid quarantine repo URL cue */
 .exocortex-invalid-input {
   border-color: var(--text-error) !important;

--- a/packages/obsidian-plugin/tests/unit/presentation/settings/patSetupHelper.test.ts
+++ b/packages/obsidian-plugin/tests/unit/presentation/settings/patSetupHelper.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Unit tests for the RFC 0002 §3.5 PAT setup create-token helper (resolves P9).
+ *
+ * The helper renders into a caller-supplied element using Obsidian's `createEl`
+ * DOM extension, so the test augments a plain jsdom element with a recursive
+ * `createEl` (honouring `cls` / `text` / `href`) — mirroring the pattern used by
+ * FirstRunOnboardingModal.test.ts — and asserts the real resulting DOM
+ * (link href + target/rel/aria, permission list contents).
+ */
+import { describe, it, expect, beforeEach } from "@jest/globals";
+import {
+  renderPatSetupHelper,
+  GITHUB_FINE_GRAINED_TOKEN_URL,
+  PAT_CREATE_TOKEN_LABEL,
+  PAT_REQUIRED_SCOPES,
+} from "../../../../src/presentation/settings/patSetupHelper";
+
+interface CreateOpts {
+  cls?: string;
+  text?: string;
+  href?: string;
+}
+
+/** Give a jsdom element Obsidian's `createEl` (recursive, attribute-copying). */
+function augment(el: HTMLElement): HTMLElement {
+  (
+    el as unknown as { createEl: (tag: string, o?: CreateOpts) => HTMLElement }
+  ).createEl = function (tag: string, o?: CreateOpts): HTMLElement {
+    const child = document.createElement(tag);
+    if (o?.cls) child.className = o.cls;
+    if (o?.text) child.textContent = o.text;
+    if (o?.href) (child as HTMLAnchorElement).setAttribute("href", o.href);
+    this.appendChild(child);
+    augment(child);
+    return child;
+  }.bind(el);
+  return el;
+}
+
+function makeContainer(): HTMLElement {
+  return augment(document.createElement("div"));
+}
+
+beforeEach(() => {
+  document.body.innerHTML = "";
+});
+
+describe("patSetupHelper — data exports", () => {
+  it("deep-links to GitHub's fine-grained (not classic) token page", () => {
+    // Fine-grained path is required for per-repo allowlist scoping; the classic
+    // page is /settings/tokens/new and must NOT be used.
+    expect(GITHUB_FINE_GRAINED_TOKEN_URL).toBe(
+      "https://github.com/settings/personal-access-tokens/new",
+    );
+    expect(GITHUB_FINE_GRAINED_TOKEN_URL).toContain("personal-access-tokens");
+    expect(GITHUB_FINE_GRAINED_TOKEN_URL).not.toMatch(/\/settings\/tokens\/new/);
+  });
+
+  it("requires Contents: Read and write (the load-bearing push permission)", () => {
+    const contents = PAT_REQUIRED_SCOPES.find(
+      (s) => s.permission === "Contents",
+    );
+    expect(contents).toBeDefined();
+    expect(contents?.access).toBe("Read and write");
+    expect(contents?.why).toMatch(/exoas-\*/);
+  });
+
+  it("lists Metadata as the auto-selected baseline permission", () => {
+    const metadata = PAT_REQUIRED_SCOPES.find(
+      (s) => s.permission === "Metadata",
+    );
+    expect(metadata).toBeDefined();
+    expect(metadata?.access).toBe("Read-only");
+  });
+});
+
+describe("renderPatSetupHelper — DOM", () => {
+  it("renders a create-token link with the correct href + label", () => {
+    const container = makeContainer();
+    renderPatSetupHelper(container);
+
+    const link = container.querySelector(
+      "a.exocortex-pat-setup-create-link",
+    ) as HTMLAnchorElement | null;
+    expect(link).not.toBeNull();
+    expect(link?.textContent).toBe(PAT_CREATE_TOKEN_LABEL);
+    expect(link?.getAttribute("href")).toBe(GITHUB_FINE_GRAINED_TOKEN_URL);
+  });
+
+  it("opens the link safely in a new tab (a11y + security)", () => {
+    const container = makeContainer();
+    renderPatSetupHelper(container);
+
+    const link = container.querySelector(
+      "a.exocortex-pat-setup-create-link",
+    ) as HTMLAnchorElement;
+    expect(link.getAttribute("target")).toBe("_blank");
+    expect(link.getAttribute("rel")).toBe("noopener noreferrer");
+    // Screen-reader label states the link leaves Obsidian (P16).
+    expect(link.getAttribute("aria-label")).toMatch(/GitHub/i);
+  });
+
+  it("renders the required-permissions as a labelled list, one <li> per scope", () => {
+    const container = makeContainer();
+    renderPatSetupHelper(container);
+
+    const list = container.querySelector("ul.exocortex-pat-setup-scopes");
+    expect(list).not.toBeNull();
+    expect(list?.getAttribute("aria-label")).toMatch(/permission/i);
+
+    const items = container.querySelectorAll("li.exocortex-pat-setup-scope");
+    expect(items).toHaveLength(PAT_REQUIRED_SCOPES.length);
+  });
+
+  it("each scope <li> shows '<permission>: <access>' in <strong> + the reason", () => {
+    const container = makeContainer();
+    renderPatSetupHelper(container);
+
+    const items = Array.from(
+      container.querySelectorAll("li.exocortex-pat-setup-scope"),
+    );
+    items.forEach((li, index) => {
+      const scope = PAT_REQUIRED_SCOPES[index];
+      const strong = li.querySelector("strong");
+      expect(strong?.textContent).toBe(`${scope.permission}: ${scope.access}`);
+      expect(li.textContent).toContain(scope.why);
+    });
+  });
+
+  it("returns the wrapper element so callers can position it (reusable contract)", () => {
+    const container = makeContainer();
+    const wrapper = renderPatSetupHelper(container);
+
+    expect(wrapper.classList.contains("exocortex-pat-setup-helper")).toBe(true);
+    expect(wrapper.parentElement).toBe(container);
+  });
+});

--- a/packages/obsidian-plugin/tests/unit/presentation/settings/patSetupHelper.test.ts
+++ b/packages/obsidian-plugin/tests/unit/presentation/settings/patSetupHelper.test.ts
@@ -19,9 +19,15 @@ interface CreateOpts {
   cls?: string;
   text?: string;
   href?: string;
+  attr?: Record<string, string>;
 }
 
-/** Give a jsdom element Obsidian's `createEl` (recursive, attribute-copying). */
+/**
+ * Give a jsdom element Obsidian's `createEl` (recursive, attribute-copying).
+ * Honours `cls` / `text` / `href` AND the `attr` map, mirroring Obsidian's
+ * real `DomElementInfo` — so reusers of this fake (the cd9444bd Welcome panel)
+ * see attributes set via the idiomatic `attr` map, not just `setAttribute`.
+ */
 function augment(el: HTMLElement): HTMLElement {
   (
     el as unknown as { createEl: (tag: string, o?: CreateOpts) => HTMLElement }
@@ -30,6 +36,11 @@ function augment(el: HTMLElement): HTMLElement {
     if (o?.cls) child.className = o.cls;
     if (o?.text) child.textContent = o.text;
     if (o?.href) (child as HTMLAnchorElement).setAttribute("href", o.href);
+    if (o?.attr) {
+      for (const [name, value] of Object.entries(o.attr)) {
+        child.setAttribute(name, value);
+      }
+    }
     this.appendChild(child);
     augment(child);
     return child;


### PR DESCRIPTION
## What

Adds a **create-token helper** to the GitHub PAT settings section (RFC 0002 §3.5, resolves **P9** — *PAT setup has no inline "create token" helper or scope guidance*):

- A **"Create token on GitHub"** link deep-linking to GitHub's **fine-grained** token page (`https://github.com/settings/personal-access-tokens/new` — not the classic page, which issues coarse `repo`-scoped tokens the plugin steers away from).
- An **inline list of required permissions** rendered under the link:
  - **Contents: Read and write** — push AssetSpace submodule commits to your `exoas-*` repos (the load-bearing one).
  - **Metadata: Read-only** — mandatory baseline GitHub auto-selects; also lets *Test connection* list repos.
- **"Test connection"** is unchanged.

## Reusable by design (Welcome PAT step, cd9444bd)

The renderer lives in a new, side-effect-free module `patSetupHelper.ts` — no plugin/app coupling, it only writes DOM into a caller-supplied element. The first-run Welcome panel's PAT step (cd9444bd, RFC 0002 §3.1) can call `renderPatSetupHelper(container)` to show the **identical** guidance with zero copy drift. The deep-link URL and permission list are exported as pure data for reuse + testing.

## Parity & a11y

- **Desktop↔Mobile parity:** pure DOM, no `Platform` gate, no Node imports → renders identically on both platforms. Archgate `MOBILE-004` (no desktop-only-gated addCommand) + `MOBILE-001/002/003` pass.
- **a11y (P16):** native `<a>` (keyboard-focusable, Enter-activatable) with `target=_blank rel="noopener noreferrer"` + an `aria-label` stating it opens GitHub; permissions render as a labelled semantic `<ul>`.

## Tests

`packages/obsidian-plugin/tests/unit/presentation/settings/patSetupHelper.test.ts` — 8 unit tests:
- deep-link is the **fine-grained** path, not the classic `/settings/tokens/new`;
- `Contents: Read and write` + `Metadata: Read-only` scope data;
- rendered link href / `target` / `rel` / `aria-label`;
- one labelled `<li>` per scope with `<strong>permission: access</strong> — reason`;
- returns the wrapper element (reusable-contract).

Local: typecheck clean, lint clean, new suite 8/8 green, `ExocortexSettingTab.test.ts` 6/6 (regression — `Setting` count unchanged at 45).

Resolves **P9**. Part of RFC 0002 Phase 1 (TTFV core) §3.5.