### PR TITLE
feat(bootstrap): exo-only clean bootstrap — remove misleading exocmd-URL field

### DIFF
--- a/docs/tutorials/Getting-Started.md
+++ b/docs/tutorials/Getting-Started.md
@@ -96,15 +96,14 @@ The plugin needs ontology files in your vault to enable layouts, action buttons,
 1. Open the command palette: **Cmd/Ctrl + P**
 2. Run **"Exocortex: Bootstrap vault"**
 3. In the dialog:
-   - **exo ontology URL** (required): `https://github.com/kitelev/exoas-exo` — the core engine floor (classes, properties, IRI resolution).
-   - **exocmd ontology URL** (optional): `https://github.com/kitelev/exoas-exocmd` — the UI command library that generates the action buttons. **Leave it blank** for a knowledge-only / SPARQL-only vault, or fill it for the full button experience.
-4. Click **Bootstrap**. The plugin downloads each repository as a tarball via the GitHub REST API, extracts it safely into your vault, and indexes it automatically — no restart needed. In a git-backed vault the pulled AssetSpaces are additionally registered as git submodules (this is the only step that uses `git`).
+   - **exo ontology URL** (required): `https://github.com/kitelev/exoas-exo` — the core engine floor (classes, properties, IRI resolution). This is all a clean start needs.
+4. Click **Bootstrap**. The plugin downloads the repository as a tarball via the GitHub REST API, extracts it safely into your vault, and indexes it automatically — no restart needed. In a git-backed vault the pulled AssetSpace is additionally registered as a git submodule (this is the only step that uses `git`).
 
 > **Notes**
 >
-> - The repositories are **public**, so no GitHub token is required.
-> - Since plugin **v16.74.0**, only the **exo** URL is required — `exocmd` is an optional UI-command library (floor = `{exo}`). A bare engine vault is a first-class configuration; add `exocmd` later if you want the action buttons.
-> - The URLs above are placeholders — you can point the fields at your own forks.
+> - The repository is **public**, so no GitHub token is required.
+> - A clean bootstrap is **exo-only** (floor = `{exo}`) — the misleading second «exocmd» field was removed. The `exocmd` UI-command library (which generates the action buttons) is added afterwards: either explicitly via **"Add assetspace by URL"** (Step 2b below) or transitively when you **Apply** a profile.
+> - The URL above is a placeholder — you can point the field at your own fork.
 
 ### Step 2b: Add the starter registry, then apply the starter profile (recommended)
 
@@ -154,9 +153,9 @@ exo__Asset_label: Test Area
 
 **If action buttons are missing but the layout appears:**
 
-> **What are "action buttons"?** They are clickable controls — Create Task, Set Status Doing, Plan on Today, etc. — that the plugin generates from the **exocmd AssetSpace** you bootstrapped. They are different from the small **filter/toggle buttons** at the top of widgets (Show Effort Area, Show Votes, Hide Empty Slots), which are built into the plugin and work without any AssetSpace.
+> **What are "action buttons"?** They are clickable controls — Create Task, Set Status Doing, Plan on Today, etc. — that the plugin generates from the **exocmd AssetSpace**. Since a clean bootstrap is exo-only, you get the action buttons once `exocmd` is present — added via **"Add assetspace by URL"** (Step 2b) or pulled transitively when you **Apply** a profile. They are different from the small **filter/toggle buttons** at the top of widgets (Show Effort Area, Show Votes, Hide Empty Slots), which are built into the plugin and work without any AssetSpace.
 
-- Verify the AssetSpaces were mounted (look for an `exocmd/` folder in your vault — created by **Bootstrap vault** in Step 2)
+- Verify `exocmd` was mounted (look for an `exocmd` folder under `assetspaces/` in your vault — added via **"Add assetspace by URL"** or by **Apply profile**, not by the exo-only **Bootstrap vault**)
 - If the `exocmd/` folder is present and the plugin loads cleanly, fully **quit and reopen Obsidian** (cold restart) to force re-indexing
 - Try Cmd/Ctrl+P → "Reload layout"
 

--- a/packages/obsidian-plugin/src/infrastructure/adapters/BootstrapAssetSpaceCommands.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/BootstrapAssetSpaceCommands.ts
@@ -23,13 +23,19 @@
  * both platforms — Desktop↔Mobile Command Parity invariant.
  *
  * Commands provided:
- *   1. `Exocortex: Bootstrap vault` — cold-start an empty vault with the TS-floor
- *      AssetSpaces (exo + exocmd). Handles three vault states:
- *        - empty → prompt for exo + exocmd URLs (EC7: fields empty, kitelev URLs
- *          shown as placeholder examples only) → materialise both.
+ *   1. `Exocortex: Bootstrap vault` — cold-start an empty vault with the exo
+ *      TS-floor AssetSpace. A clean bootstrap is **exo-only** (decision
+ *      2026-06-20): exo is the SDK/engine floor and is all a minimal clean
+ *      start needs. exocmd (and any other AssetSpace) is added later via «Add
+ *      AssetSpace by URL» or transitively via a profile — NOT during bootstrap.
+ *      Handles three vault states:
+ *        - empty → prompt for the exo URL (EC7: field empty, kitelev URL shown
+ *          as a placeholder example only) → materialise exo.
  *        - clone-needs-fetch (EC2) → `.gitmodules` populated but folders empty
  *          (cloned without `--recurse-submodules`) → confirm → re-materialise
- *          each tracked AssetSpace from its preserved URL.
+ *          each tracked AssetSpace from its preserved URL (this re-fetch path
+ *          still restores every tracked space, exocmd included if it was added
+ *          later).
  *        - bootstrapped → no-op notice (use «Add AssetSpace» for more spaces).
  *      Non-git vaults (AC10 / M19): file-only mode — REST pulls without
  *      `.gitmodules`, tracked device-locally.
@@ -157,12 +163,12 @@ export interface BootstrapAssetSpaceCommandsDeps {
    */
   deriveFolderName: (url: string) => string;
   /**
-   * Open the bootstrap modal (two empty URL fields + example placeholders).
-   * Resolves the entered URLs, or null if the user cancelled.
+   * Open the bootstrap modal (one empty URL field + example placeholder).
+   * Resolves the entered exo URL, or null if the user cancelled. Exo-only
+   * (decision 2026-06-20): exocmd is no longer collected here.
    */
   promptBootstrapUrls: () => Promise<{
     exoUrl: string;
-    exocmdUrl: string;
   } | null>;
   /**
    * Open the add-AssetSpace modal (single URL field). Resolves the entered
@@ -186,10 +192,9 @@ export interface BootstrapAssetSpaceCommandsDeps {
   ref?: string;
 }
 
-/** TS-floor folders materialised by a cold bootstrap (fixed, mirrors CLI). */
+/** TS-floor folder materialised by a cold (exo-only) bootstrap. */
 const ASSETSPACES_DIR = "assetspaces";
 const TS_FLOOR_EXO_PATH = `${ASSETSPACES_DIR}/exo`;
-const TS_FLOOR_EXOCMD_PATH = `${ASSETSPACES_DIR}/exocmd`;
 
 export type VaultBootstrapState =
   | "empty"
@@ -243,17 +248,17 @@ export class BootstrapAssetSpaceCommands {
       return;
     }
 
-    // state === "empty" — prompt for the TS-floor URLs.
+    // state === "empty" — prompt for the exo TS-floor URL.
     const urls = await this.d.promptBootstrapUrls();
     if (urls === null) return; // user cancelled
 
-    // Core-only (RFC 5aa2a73a B3 / alt-G #3426): exo is the SDK floor; exocmd is
-    // an OPTIONAL UI-command library. An empty exocmd URL yields a knowledge-only
-    // vault and must be accepted as a first-class configuration.
-    const wantExocmd = urls.exocmdUrl.trim().length > 0;
+    // Exo-only clean bootstrap (decision 2026-06-20): exo is the SDK/engine
+    // floor and is all a minimal clean start needs. exocmd (UI commands) — and
+    // any other AssetSpace — is added later via «Add AssetSpace by URL» or
+    // transitively when a profile is applied (effective set / dependsOn DAG),
+    // NOT during bootstrap.
     try {
       this.d.validateUrl(urls.exoUrl);
-      if (wantExocmd) this.d.validateUrl(urls.exocmdUrl);
     } catch (e) {
       this.d.notify(`Bootstrap: invalid URL — ${this.msg(e)}`);
       return;
@@ -269,50 +274,20 @@ export class BootstrapAssetSpaceCommands {
       );
     }
 
-    // Materialise exo then exocmd. If exocmd fails after exo succeeded, the
-    // vault is half-bootstrapped: a re-run of «Bootstrap vault» would now
-    // classify it as `bootstrapped` and refuse, so the recovery path (use
-    // «Add assetspace by URL» for the missing floor) must be surfaced
-    // explicitly here. Re-index either way so the part that landed is picked up.
     // RFC 5aa2a73a B4: mount the TS-floor at the Maven path
     // `assetspaces/<owner>/<repo>` — the SAME path `apply-profile` derives via
     // `derivePath`. Flat paths (`assetspaces/exo`) caused a later `apply-profile`
     // to re-materialize the same AssetSpace UID at the Maven path → double mount.
     // Fallback to the flat constant only when the URL is un-derivable.
     const exoPath = derivePath(urls.exoUrl) ?? TS_FLOOR_EXO_PATH;
-    const exocmdPath = wantExocmd
-      ? (derivePath(urls.exocmdUrl) ?? TS_FLOOR_EXOCMD_PATH)
-      : TS_FLOOR_EXOCMD_PATH;
-    let exo: MaterializeResult | null = null;
     try {
-      exo = await this.materialize(urls.exoUrl, exoPath, isGit);
-      if (wantExocmd) {
-        const exocmd = await this.materialize(
-          urls.exocmdUrl,
-          exocmdPath,
-          isGit,
-        );
-        this.d.notify(
-          `Bootstrap complete — ${exo.folderName}@${exo.sha} + ${exocmd.folderName}@${exocmd.sha}. ` +
-            "Reload Obsidian if the new assets do not appear. Add any further AssetSpaces manually — dependencies are not auto-resolved.",
-        );
-      } else {
-        this.d.notify(
-          `Bootstrap complete — ${exo.folderName}@${exo.sha} (knowledge-only, no exocmd). ` +
-            "Reload Obsidian if the new assets do not appear. Add exocmd or any further AssetSpaces later via «Add assetspace by URL».",
-        );
-      }
+      const exo = await this.materialize(urls.exoUrl, exoPath, isGit);
+      this.d.notify(
+        `Bootstrap complete — ${exo.folderName}@${exo.sha}. ` +
+          "Reload Obsidian if the new assets do not appear. Add exocmd (UI commands) or any further AssetSpaces later via «Add assetspace by URL», or by applying a profile — dependencies are not auto-resolved.",
+      );
     } catch (e) {
-      if (exo !== null) {
-        this.d.notify(
-          `Bootstrap partially completed — ${exoPath} materialised, but ${exocmdPath} failed: ${this.msg(e)}. ` +
-            "Use «Add assetspace by URL» to add the missing exocmd assetspace.",
-        );
-      } else {
-        this.d.notify(`Bootstrap failed: ${this.msg(e)}`);
-      }
-      await this.runOnMaterialized();
-      return;
+      this.d.notify(`Bootstrap failed: ${this.msg(e)}`);
     }
     await this.runOnMaterialized();
   }

--- a/packages/obsidian-plugin/src/presentation/modals/BootstrapVaultModal.ts
+++ b/packages/obsidian-plugin/src/presentation/modals/BootstrapVaultModal.ts
@@ -2,31 +2,35 @@ import { App, Modal } from "obsidian";
 
 export interface BootstrapVaultUrls {
   exoUrl: string;
-  exocmdUrl: string;
 }
 
 /**
  * BootstrapVaultModal — input gate for the `Exocortex: Bootstrap vault` palette
  * command (RFC 13da049f Phase 6.2).
  *
- * Collects the exo TS-floor AssetSpace URL (required) and, optionally, the
- * exocmd UI-command library URL needed to cold-start an empty vault. exocmd is
- * optional (RFC 5aa2a73a B3 / alt-G #3426): leaving it blank yields a
- * knowledge-only / SPARQL-only vault.
+ * Collects ONLY the exo TS-floor AssetSpace URL (required) needed to cold-start
+ * an empty vault. A clean bootstrap is **exo-only** — exo is the SDK/engine
+ * floor and is all that is needed for a minimal clean start (decision
+ * 2026-06-20, project Exocortex Alpha Launch). The exocmd UI-command library is
+ * NOT part of the initial bootstrap: it (and any other AssetSpace) is added
+ * afterwards, either explicitly via «Add AssetSpace by URL» or transitively
+ * when a profile is applied (effective set / dependsOn DAG). The previous
+ * second «exocmd URL» field was misleading (it implied exocmd was required for
+ * a clean start) and has been removed.
  *
  * ## UX decisions
  *
- * - **EC7 — fields start EMPTY.** The `kitelev/exoas-*` repos are NOT pre-filled
- *   (they materialise Andrey's own ontology and do not work as a generic floor
- *   for other users). They appear only as greyed-out placeholder examples.
+ * - **EC7 — the field starts EMPTY.** The `kitelev/exoas-*` repos are NOT
+ *   pre-filled (they materialise Andrey's own ontology and do not work as a
+ *   generic floor for other users). It appears only as a greyed-out
+ *   placeholder example.
  * - **R31 — no transitive auto-add.** A note tells the user they must add any
  *   further required AssetSpaces manually; dependencies are not resolved
  *   automatically.
  *
- * Resolves `{ exoUrl, exocmdUrl }` when the user clicks «Bootstrap» with a
- * plausible exo URL (exocmd may be left blank → resolves `exocmdUrl: ""`).
- * Esc / Cancel / any close path resolves `null`. The promise resolves exactly
- * once.
+ * Resolves `{ exoUrl }` when the user clicks «Bootstrap» with a plausible exo
+ * URL. Esc / Cancel / any close path resolves `null`. The promise resolves
+ * exactly once.
  *
  * Authoritative URL validation (allowlist, traversal) happens downstream in
  * `BootstrapAssetSpaceCommands` / `GitHubRestClient.validateRepoURL`; this modal
@@ -37,7 +41,6 @@ export class BootstrapVaultModal extends Modal {
   private resolved = false;
   private readonly resolveFn: (urls: BootstrapVaultUrls | null) => void;
   private exoInput: HTMLInputElement | null = null;
-  private exocmdInput: HTMLInputElement | null = null;
   private errorEl: HTMLElement | null = null;
 
   constructor(app: App, resolve: (urls: BootstrapVaultUrls | null) => void) {
@@ -61,8 +64,9 @@ export class BootstrapVaultModal extends Modal {
       text:
         "Cold-start this empty vault with the foundational exo AssetSpace " +
         "(the SDK/engine floor), pulled from a public GitHub repository. " +
-        "exocmd (the optional UI-command library) can be added too, or left " +
-        "blank for a knowledge-only / SPARQL-only vault.",
+        "That is all a clean start needs — add any further AssetSpaces " +
+        "(such as the exocmd UI-command library) afterwards via «Add " +
+        "AssetSpace by URL», or by applying a profile.",
     });
 
     this.exoInput = this.createUrlField(
@@ -70,16 +74,11 @@ export class BootstrapVaultModal extends Modal {
       "exo ontology URL (required)",
       "https://github.com/kitelev/exoas-exo",
     );
-    this.exocmdInput = this.createUrlField(
-      contentEl,
-      "exocmd ontology URL (optional)",
-      "https://github.com/kitelev/exoas-exocmd",
-    );
 
     contentEl.createEl("p", {
       cls: "bootstrap-vault-note",
       text:
-        "The example URLs above are placeholders only — enter the repositories " +
+        "The example URL above is a placeholder only — enter the repository " +
         "you want to use. Add any further AssetSpaces afterwards via " +
         "«Add AssetSpace by URL»; dependencies are not added automatically.",
     });
@@ -121,13 +120,12 @@ export class BootstrapVaultModal extends Modal {
 
   private submit(): void {
     const exoUrl = (this.exoInput?.value ?? "").trim();
-    const exocmdUrl = (this.exocmdInput?.value ?? "").trim();
-    const problem = firstUrlProblem(exoUrl, exocmdUrl);
+    const problem = firstUrlProblem(exoUrl);
     if (problem !== null) {
       this.showError(problem);
       return;
     }
-    this.settle({ exoUrl, exocmdUrl });
+    this.settle({ exoUrl });
     this.close();
   }
 
@@ -145,27 +143,21 @@ export class BootstrapVaultModal extends Modal {
 }
 
 /**
- * Light shape check for the bootstrap URLs. Returns a human-readable problem
- * string, or null when the inputs look plausible. Authoritative validation is
+ * Light shape check for the bootstrap URL. Returns a human-readable problem
+ * string, or null when the input looks plausible. Authoritative validation is
  * downstream.
  *
- * Core-only (RFC 5aa2a73a B3 / alt-G rejection #3426): only the exo URL is
- * required. exocmd is the optional UI-command library — an empty exocmd field
- * yields a knowledge-only / SPARQL-only vault and is a first-class config. When
- * exocmd IS provided it must still be a plausible GitHub URL.
+ * Exo-only (decision 2026-06-20): a clean bootstrap requires only the exo URL.
+ * The exocmd library — and any other AssetSpace — is added later via «Add
+ * AssetSpace by URL» or transitively via a profile, so this modal no longer
+ * collects an exocmd URL.
  */
-export function firstUrlProblem(
-  exoUrl: string,
-  exocmdUrl: string,
-): string | null {
+export function firstUrlProblem(exoUrl: string): string | null {
   if (exoUrl.length === 0) {
     return "The exo URL is required.";
   }
   if (!isLikelyGitHubUrl(exoUrl)) {
     return "exo URL must look like https://github.com/<owner>/<repo>.";
-  }
-  if (exocmdUrl.length > 0 && !isLikelyGitHubUrl(exocmdUrl)) {
-    return "exocmd URL must look like https://github.com/<owner>/<repo>.";
   }
   return null;
 }

--- a/packages/obsidian-plugin/tests/e2e/eka/eka-obsidian-leg.spec.ts
+++ b/packages/obsidian-plugin/tests/e2e/eka/eka-obsidian-leg.spec.ts
@@ -15,8 +15,10 @@ import * as path from "path";
  * Drives the FULL alpha-tester path through the Exocortex **plugin** (not the
  * CLI) against LIVE GitHub, in a fresh ephemeral vault:
  *
- *   1. Bootstrap vault   → floor `exoas-exo` + `exoas-exocmd` (public).
- *   2. Add assetspace    → central `exoas-registry` + `exoas-profiles` (public).
+ *   1. Bootstrap vault   → exo-only floor `exoas-exo` (public). exocmd is no
+ *                          longer a bootstrap field (2026-06-20 decision).
+ *   2. Add assetspace    → `exoas-exocmd` + central `exoas-registry` +
+ *                          `exoas-profiles` (public).
  *   3. Apply profile     → `$$kitelev-exodev` (62338881-…) — materialises the
  *                          full transitive effective set (PRIVATE `exoas-exodev`
  *                          leaf + deps + floor), with NO degraded refuse. This
@@ -457,37 +459,39 @@ test.describe("EKA Obsidian leg — bootstrap → add → apply-profile → crea
     launcher = await launchObsidianWithPlugin(vaultPath, "eka-leg-1");
     let window = await launcher.getWindow();
 
-    // ---- Step 1: Bootstrap vault (exo + exocmd floor) ----
-    log("step 1: bootstrap-vault");
+    // ---- Step 1: Bootstrap vault (exo-only clean bootstrap, 2026-06-20) ----
+    log("step 1: bootstrap-vault (exo-only)");
     await waitForCommand(window, COMMAND.bootstrap);
     await executeCommand(window, COMMAND.bootstrap);
-    // BootstrapVaultModal: two text inputs (exo, exocmd) + «Bootstrap» CTA.
+    // BootstrapVaultModal: ONE text input (exo) + «Bootstrap» CTA. The misleading
+    // exocmd-URL field was removed — exocmd is added in Step 2 via add-assetspace
+    // (it would otherwise arrive transitively when a profile is applied).
     await window.waitForSelector(".bootstrap-vault-input", { timeout: 15000 });
-    const bootInputs = window.locator(".bootstrap-vault-input");
-    await bootInputs.nth(0).fill(EXO_URL);
-    await bootInputs.nth(1).fill(EXOCMD_URL);
+    await window.locator(".bootstrap-vault-input").fill(EXO_URL);
     await window
       .locator(".bootstrap-vault-actions button.mod-cta")
       .click();
-    // Materialisation (2 tarball pulls) runs async. Bootstrap writes the
-    // `.gitmodules` entry AFTER moving files into place, so gate on BOTH entries
+    // Materialisation (1 tarball pull) runs async. Bootstrap writes the
+    // `.gitmodules` entry AFTER moving files into place, so gate on the entry
     // being registered (not just the .md on disk) — otherwise a fast disk poll
-    // races the second `appendGitmodulesEntry` and the assertion below flakes.
+    // races `appendGitmodulesEntry` and the assertion below flakes.
     await pollUntil(
-      "floor materialised + registered (exo + exocmd)",
+      "exo floor materialised + registered",
       () =>
         countMarkdown(vaultPath, EXO_DIR) > 0 &&
-        countMarkdown(vaultPath, EXOCMD_DIR) > 0 &&
-        readGitmodules(vaultPath).includes("exoas-exo") &&
-        readGitmodules(vaultPath).includes("exoas-exocmd"),
+        readGitmodules(vaultPath).includes("exoas-exo"),
       180000,
     );
     const gm1 = readGitmodules(vaultPath);
     expect(gm1).toContain("exoas-exo");
-    expect(gm1).toContain("exoas-exocmd");
 
-    // ---- Step 2: Add assetspace — registry then profiles ----
+    // ---- Step 2: Add assetspace — exocmd, registry, then profiles ----
+    // exocmd is no longer a bootstrap floor field; the user adds it explicitly
+    // here (the «либо явно командой add-assetspace» path of the 2026-06-20
+    // decision). It is also part of the profile effective set, so a later
+    // apply-profile keeps it materialised.
     for (const [label, url, dir] of [
+      ["exocmd", EXOCMD_URL, EXOCMD_DIR],
       ["registry", REGISTRY_URL, REGISTRY_DIR],
       ["profiles", PROFILES_URL, PROFILES_DIR],
     ] as const) {
@@ -515,6 +519,7 @@ test.describe("EKA Obsidian leg — bootstrap → add → apply-profile → crea
       "profile 62338881 must exist on disk after add-assetspace profiles",
     ).not.toBeNull();
     const gm2 = readGitmodules(vaultPath);
+    expect(gm2).toContain("exoas-exocmd"); // added explicitly in Step 2 now
     expect(gm2).toContain("exoas-registry");
     expect(gm2).toContain("exoas-profiles");
 

--- a/packages/obsidian-plugin/tests/unit/infrastructure/adapters/BootstrapAssetSpaceCommands.test.ts
+++ b/packages/obsidian-plugin/tests/unit/infrastructure/adapters/BootstrapAssetSpaceCommands.test.ts
@@ -33,7 +33,7 @@ function makeHarness(opts: {
   gitmodulesEntries?: Array<{ submodulePath: string; url: string }>;
   materializedFolders?: Record<string, string[]>; // folder → files
   isGitVault?: boolean;
-  bootstrapUrls?: { exoUrl: string; exocmdUrl: string } | null;
+  bootstrapUrls?: { exoUrl: string } | null;
   addUrl?: { url: string } | null;
   confirm?: boolean;
 } = {}): Harness {
@@ -109,7 +109,7 @@ function makeHarness(opts: {
     deriveFolderName,
     promptBootstrapUrls: jest.fn(async () =>
       opts.bootstrapUrls === undefined
-        ? { exoUrl: EXO_URL, exocmdUrl: EXOCMD_URL }
+        ? { exoUrl: EXO_URL }
         : opts.bootstrapUrls,
     ),
     promptAddAssetSpaceUrl: jest.fn(async () =>
@@ -171,51 +171,15 @@ describe("BootstrapAssetSpaceCommands.detectVaultState", () => {
 });
 
 describe("BootstrapAssetSpaceCommands.invokeBootstrap — empty vault (git)", () => {
-  it("pulls exo + exocmd into fixed folders and appends .gitmodules", async () => {
+  // Exo-only clean bootstrap (decision 2026-06-20): the modal no longer collects
+  // an exocmd URL, and invokeBootstrap materialises ONLY exo. exocmd is added
+  // later via «Add AssetSpace by URL» or transitively via a profile.
+  //
+  // Revert-verify: restoring the exocmd materialise branch (a second
+  // `materialize(urls.exocmdUrl, …)` call) makes the `toHaveBeenCalledTimes(1)`
+  // assertions FAIL (a second pull/rename/append fires).
+  it("pulls exo only into the Maven folder and appends a single .gitmodules entry", async () => {
     const h = makeHarness({ isGitVault: true });
-    await h.cmds.invokeBootstrap();
-
-    expect(h.puller.pullAssetSpace).toHaveBeenCalledTimes(2);
-    expect(h.puller.pullAssetSpace).toHaveBeenNthCalledWith(
-      1,
-      "bootstrap-exoas-exo",
-      EXO_URL,
-      "main",
-    );
-    expect(h.puller.pullAssetSpace).toHaveBeenNthCalledWith(
-      2,
-      "bootstrap-exoas-exocmd",
-      EXOCMD_URL,
-      "main",
-    );
-    // RFC 5aa2a73a B4: floor mounts at the Maven path `assetspaces/<owner>/<repo>`.
-    expect(h.gitOps.renameIntoVault).toHaveBeenNthCalledWith(
-      1,
-      "/tmp/staging-bootstrap-exoas-exo",
-      "assetspaces/kitelev/exoas-exo",
-    );
-    expect(h.gitOps.renameIntoVault).toHaveBeenNthCalledWith(
-      2,
-      "/tmp/staging-bootstrap-exoas-exocmd",
-      "assetspaces/kitelev/exoas-exocmd",
-    );
-    expect(h.gitOps.appendGitmodulesEntry).toHaveBeenCalledWith(
-      "assetspaces/kitelev/exoas-exo",
-      EXO_URL,
-    );
-    expect(h.gitOps.appendGitmodulesEntry).toHaveBeenCalledWith(
-      "assetspaces/kitelev/exoas-exocmd",
-      EXOCMD_URL,
-    );
-    expect(h.localStore.upsertFileOnlyAssetSpace).not.toHaveBeenCalled();
-    expect(h.notices.some((n) => /Bootstrap complete/.test(n))).toBe(true);
-  });
-
-  it("B3 core-only — empty exocmd URL → pulls exo only, no exocmd pull/.gitmodules", async () => {
-    const h = makeHarness({
-      isGitVault: true,
-      bootstrapUrls: { exoUrl: EXO_URL, exocmdUrl: "" },
-    });
     await h.cmds.invokeBootstrap();
 
     expect(h.puller.pullAssetSpace).toHaveBeenCalledTimes(1);
@@ -225,6 +189,7 @@ describe("BootstrapAssetSpaceCommands.invokeBootstrap — empty vault (git)", ()
       EXO_URL,
       "main",
     );
+    // RFC 5aa2a73a B4: floor mounts at the Maven path `assetspaces/<owner>/<repo>`.
     expect(h.gitOps.renameIntoVault).toHaveBeenCalledTimes(1);
     expect(h.gitOps.renameIntoVault).toHaveBeenNthCalledWith(
       1,
@@ -236,19 +201,26 @@ describe("BootstrapAssetSpaceCommands.invokeBootstrap — empty vault (git)", ()
       "assetspaces/kitelev/exoas-exo",
       EXO_URL,
     );
-    expect(h.notices.some((n) => /knowledge-only/.test(n))).toBe(true);
+    // exocmd is NOT pulled during bootstrap.
+    expect(h.puller.pullAssetSpace).not.toHaveBeenCalledWith(
+      "bootstrap-exoas-exocmd",
+      EXOCMD_URL,
+      "main",
+    );
+    expect(h.localStore.upsertFileOnlyAssetSpace).not.toHaveBeenCalled();
+    expect(h.notices.some((n) => /Bootstrap complete/.test(n))).toBe(true);
   });
 });
 
 describe("BootstrapAssetSpaceCommands.invokeBootstrap — empty vault (file-only / non-git, AC10)", () => {
-  it("materializes without .gitmodules and tracks device-locally", async () => {
+  it("materializes exo only without .gitmodules and tracks device-locally", async () => {
     const h = makeHarness({ isGitVault: false });
     await h.cmds.invokeBootstrap();
 
-    expect(h.puller.pullAssetSpace).toHaveBeenCalledTimes(2);
-    expect(h.gitOps.renameIntoVault).toHaveBeenCalledTimes(2);
+    expect(h.puller.pullAssetSpace).toHaveBeenCalledTimes(1);
+    expect(h.gitOps.renameIntoVault).toHaveBeenCalledTimes(1);
     expect(h.gitOps.appendGitmodulesEntry).not.toHaveBeenCalled();
-    expect(h.localStore.upsertFileOnlyAssetSpace).toHaveBeenCalledTimes(2);
+    expect(h.localStore.upsertFileOnlyAssetSpace).toHaveBeenCalledTimes(1);
     expect(h.localStore.upsertFileOnlyAssetSpace).toHaveBeenCalledWith(
       expect.objectContaining({
         folderName: "assetspaces/kitelev/exoas-exo",
@@ -315,42 +287,22 @@ describe("BootstrapAssetSpaceCommands.invokeBootstrap — guards", () => {
 
   it("invalid URL → notify, no pull", async () => {
     const h = makeHarness({
-      bootstrapUrls: { exoUrl: "http://evil.example/x", exocmdUrl: EXOCMD_URL },
+      bootstrapUrls: { exoUrl: "http://evil.example/x" },
     });
     await h.cmds.invokeBootstrap();
     expect(h.puller.pullAssetSpace).not.toHaveBeenCalled();
     expect(h.notices.some((n) => /invalid URL/i.test(n))).toBe(true);
   });
 
-  it("pull failure surfaces a notice and stops", async () => {
+  it("exo pull failure surfaces a notice and stops", async () => {
     const h = makeHarness({ isGitVault: true });
     h.puller.pullAssetSpace.mockRejectedValueOnce(new Error("network down"));
     await h.cmds.invokeBootstrap();
     expect(h.notices.some((n) => /Bootstrap failed.*network down/.test(n))).toBe(
       true,
     );
-    // exocmd pull never attempted after exo failed
+    // Exo-only: the single exo pull was attempted and failed — nothing else.
     expect(h.puller.pullAssetSpace).toHaveBeenCalledTimes(1);
-  });
-
-  it("partial failure (exo ok, exocmd fails) → actionable recovery notice", async () => {
-    const h = makeHarness({ isGitVault: true });
-    h.puller.pullAssetSpace
-      .mockResolvedValueOnce({
-        asUid: "bootstrap-exo",
-        stagingPath: "/tmp/staging-bootstrap-exo",
-        sha: "abc1234",
-      })
-      .mockRejectedValueOnce(new Error("exocmd boom"));
-    await h.cmds.invokeBootstrap();
-    expect(h.puller.pullAssetSpace).toHaveBeenCalledTimes(2);
-    // exo materialised, exocmd did not
-    expect(h.gitOps.renameIntoVault).toHaveBeenCalledTimes(1);
-    expect(
-      h.notices.some(
-        (n) => /partially completed/i.test(n) && /Add assetspace by URL/i.test(n),
-      ),
-    ).toBe(true);
   });
 });
 
@@ -538,29 +490,26 @@ describe("BootstrapAssetSpaceCommands — staging-dir release (Issue #3391)", ()
    * (`activeStagingDirs` keeps the 1–2 entries the pulls registered);
    * restoring it makes them PASS.
    */
-  it("bootstrap (git) — releases both staging dirs, no leftover entry", async () => {
+  it("bootstrap (git) — releases the exo staging dir, no leftover entry", async () => {
     const h = makeHarness({ isGitVault: true });
     await h.cmds.invokeBootstrap();
 
-    expect(h.puller.pullAssetSpace).toHaveBeenCalledTimes(2);
-    // Released for each pulled staging path, after the move into the vault.
-    expect(h.puller.releaseStaging).toHaveBeenCalledTimes(2);
+    // Exo-only: a single pull + a single release after the move into the vault.
+    expect(h.puller.pullAssetSpace).toHaveBeenCalledTimes(1);
+    expect(h.puller.releaseStaging).toHaveBeenCalledTimes(1);
     expect(h.puller.releaseStaging).toHaveBeenCalledWith(
       "/tmp/staging-bootstrap-exoas-exo",
-    );
-    expect(h.puller.releaseStaging).toHaveBeenCalledWith(
-      "/tmp/staging-bootstrap-exoas-exocmd",
     );
     // The tracker registry is empty post-success — no reload needed.
     expect(h.activeStagingDirs).toEqual([]);
   });
 
-  it("bootstrap (file-only / non-git) — releases staging dirs too", async () => {
+  it("bootstrap (file-only / non-git) — releases the exo staging dir too", async () => {
     const h = makeHarness({ isGitVault: false });
     await h.cmds.invokeBootstrap();
 
-    expect(h.puller.pullAssetSpace).toHaveBeenCalledTimes(2);
-    expect(h.puller.releaseStaging).toHaveBeenCalledTimes(2);
+    expect(h.puller.pullAssetSpace).toHaveBeenCalledTimes(1);
+    expect(h.puller.releaseStaging).toHaveBeenCalledTimes(1);
     expect(h.activeStagingDirs).toEqual([]);
   });
 
@@ -613,7 +562,7 @@ interface MobileHarness {
 function makeMobileHarness(opts: {
   gitmodulesEntries?: Array<{ submodulePath: string; url: string }>;
   materializedFolders?: Record<string, string[]>;
-  bootstrapUrls?: { exoUrl: string; exocmdUrl: string } | null;
+  bootstrapUrls?: { exoUrl: string } | null;
   addUrl?: { url: string } | null;
   confirm?: boolean;
 } = {}): MobileHarness {
@@ -671,7 +620,7 @@ function makeMobileHarness(opts: {
     deriveFolderName,
     promptBootstrapUrls: jest.fn(async () =>
       opts.bootstrapUrls === undefined
-        ? { exoUrl: EXO_URL, exocmdUrl: EXOCMD_URL }
+        ? { exoUrl: EXO_URL }
         : opts.bootstrapUrls,
     ),
     promptAddAssetSpaceUrl: jest.fn(async () =>
@@ -685,22 +634,22 @@ function makeMobileHarness(opts: {
 }
 
 describe("BootstrapAssetSpaceCommands — mobile restMount strategy (#3535)", () => {
-  it("empty vault → bootstrap materialises exo + exocmd via restMount.mount (Maven paths), writes .gitmodules, no Node-fs deps", async () => {
+  it("empty vault → bootstrap materialises exo only via restMount.mount (Maven path), writes .gitmodules, no Node-fs deps", async () => {
     const h = makeMobileHarness();
     await h.cmds.invokeBootstrap();
 
     // detectVaultState read .gitmodules via the mobile vault.adapter path.
     expect(h.restMount.readGitmodulesEntries).toHaveBeenCalled();
-    // One combined cross-platform op per floor AssetSpace, at the Maven path.
-    expect(h.restMount.mount).toHaveBeenCalledTimes(2);
+    // Exo-only clean bootstrap (2026-06-20): a single combined cross-platform op
+    // for exo, at the Maven path. exocmd is added later (Add AssetSpace / profile).
+    expect(h.restMount.mount).toHaveBeenCalledTimes(1);
     expect(h.restMount.mount).toHaveBeenNthCalledWith(
       1,
       EXO_URL,
       "assetspaces/kitelev/exoas-exo",
       "main",
     );
-    expect(h.restMount.mount).toHaveBeenNthCalledWith(
-      2,
+    expect(h.restMount.mount).not.toHaveBeenCalledWith(
       EXOCMD_URL,
       "assetspaces/kitelev/exoas-exocmd",
       "main",
@@ -709,22 +658,6 @@ describe("BootstrapAssetSpaceCommands — mobile restMount strategy (#3535)", ()
     // The misleading desktop "file-only mode" notice MUST NOT fire on mobile,
     // even though there is no `.git` — restMount writes .gitmodules regardless.
     expect(h.notices.some((n) => /file-only mode/.test(n))).toBe(false);
-  });
-
-  it("empty vault, core-only (empty exocmd URL) → mounts exo only", async () => {
-    const h = makeMobileHarness({
-      bootstrapUrls: { exoUrl: EXO_URL, exocmdUrl: "" },
-    });
-    await h.cmds.invokeBootstrap();
-
-    expect(h.restMount.mount).toHaveBeenCalledTimes(1);
-    expect(h.restMount.mount).toHaveBeenNthCalledWith(
-      1,
-      EXO_URL,
-      "assetspaces/kitelev/exoas-exo",
-      "main",
-    );
-    expect(h.notices.some((n) => /knowledge-only/.test(n))).toBe(true);
   });
 
   it("addAssetSpace → mounts the single URL-derived AssetSpace at the canonical Maven path via restMount.mount (#3538)", async () => {

--- a/packages/obsidian-plugin/tests/unit/integration/BootstrapAssetSpace.integration.test.ts
+++ b/packages/obsidian-plugin/tests/unit/integration/BootstrapAssetSpace.integration.test.ts
@@ -5,9 +5,10 @@
  * the REAL `GitSubmoduleOps` `.gitmodules` text manipulation + `renameIntoVault`
  * against a real tmpdir vault. The tarball pull is faked (no network) but the
  * staging→vault move + `.gitmodules` write are real filesystem operations, so
- * this proves the end-to-end materialisation contract:
- *   empty vault → bootstrap → `.gitmodules` has 2 entries + assetspaces/exo +
- *   assetspaces/exocmd populated.
+ * this proves the end-to-end materialisation contract (exo-only clean bootstrap,
+ * 2026-06-20):
+ *   empty vault → bootstrap → `.gitmodules` has 1 entry + assetspaces/exo
+ *   populated (exocmd added later via «Add AssetSpace by URL» / profile).
  */
 
 /* eslint-disable no-restricted-imports, import/no-nodejs-modules */
@@ -115,7 +116,7 @@ describe("Bootstrap integration — real GitSubmoduleOps + tmpdir vault (git mod
     if (vaultRoot) await fs.rm(vaultRoot, { recursive: true, force: true });
   });
 
-  it("empty vault → bootstrap → 2 .gitmodules entries + assetspaces/exo + assetspaces/exocmd populated", async () => {
+  it("empty vault → bootstrap → 1 .gitmodules entry + assetspaces/exo populated (exo-only)", async () => {
     vaultRoot = await makeTmpVault();
     const gitOps = new GitSubmoduleOps({ vaultRootPath: vaultRoot });
     const probes = makeVaultProbes(vaultRoot);
@@ -132,10 +133,8 @@ describe("Bootstrap integration — real GitSubmoduleOps + tmpdir vault (git mod
       isGitVault: async () => true,
       validateUrl: () => undefined,
       deriveFolderName: (u) => u.split("/").pop() ?? "x",
-      promptBootstrapUrls: async () => ({
-        exoUrl: EXO_URL,
-        exocmdUrl: EXOCMD_URL,
-      }),
+      // Exo-only clean bootstrap (2026-06-20): the modal yields only the exo URL.
+      promptBootstrapUrls: async () => ({ exoUrl: EXO_URL }),
       promptAddAssetSpaceUrl: async () => null,
       confirm: async () => true,
       notify: (m) => notices.push(m),
@@ -143,24 +142,22 @@ describe("Bootstrap integration — real GitSubmoduleOps + tmpdir vault (git mod
 
     await cmds.invokeBootstrap();
 
-    // Both folders materialised with the fake AssetSpace file — at the Maven
-    // mount path `assetspaces/<owner>/<repo>` (RFC 5aa2a73a B4).
+    // exo materialised with the fake AssetSpace file — at the Maven mount path
+    // `assetspaces/<owner>/<repo>` (RFC 5aa2a73a B4). exocmd is NOT materialised
+    // by bootstrap (added later via «Add AssetSpace by URL» / profile).
     const exoFile = path.join(
       vaultRoot,
       "assetspaces/kitelev/exoas-exo/73bd00e4-ccc0-4f3f-b20d-c4388c4588fb.md",
     );
-    const exocmdFile = path.join(
-      vaultRoot,
-      "assetspaces/kitelev/exoas-exocmd/73bd00e4-ccc0-4f3f-b20d-c4388c4588fb.md",
-    );
     await expect(fs.access(exoFile)).resolves.toBeUndefined();
-    await expect(fs.access(exocmdFile)).resolves.toBeUndefined();
+    await expect(
+      fs.access(path.join(vaultRoot, "assetspaces/kitelev/exoas-exocmd")),
+    ).rejects.toThrow();
 
-    // `.gitmodules` has exactly the two TS-floor entries (Maven paths).
+    // `.gitmodules` has exactly the one exo TS-floor entry (Maven path).
     const entries = await gitOps.readGitmodulesEntries();
     expect(entries).toEqual([
       { submodulePath: "assetspaces/kitelev/exoas-exo", url: EXO_URL },
-      { submodulePath: "assetspaces/kitelev/exoas-exocmd", url: EXOCMD_URL },
     ]);
 
     expect(notices.some((n) => /Bootstrap complete/.test(n))).toBe(true);
@@ -192,10 +189,7 @@ describe("Bootstrap integration — real GitSubmoduleOps + tmpdir vault (git mod
       isGitVault: async () => true,
       validateUrl: () => undefined,
       deriveFolderName: (u) => u.split("/").pop() ?? "x",
-      promptBootstrapUrls: async () => ({
-        exoUrl: EXO_URL,
-        exocmdUrl: EXOCMD_URL,
-      }),
+      promptBootstrapUrls: async () => ({ exoUrl: EXO_URL }),
       promptAddAssetSpaceUrl: async () => null,
       confirm: async () => true,
       notify: () => undefined,
@@ -233,10 +227,7 @@ describe("Bootstrap integration — real GitSubmoduleOps + tmpdir vault (git mod
       isGitVault: async () => true,
       validateUrl: () => undefined,
       deriveFolderName: (u) => u.split("/").pop() ?? "x",
-      promptBootstrapUrls: async () => ({
-        exoUrl: EXO_URL,
-        exocmdUrl: EXOCMD_URL,
-      }),
+      promptBootstrapUrls: async () => ({ exoUrl: EXO_URL }),
       promptAddAssetSpaceUrl: async () => null,
       confirm: async () => true,
       notify: () => undefined,
@@ -412,7 +403,7 @@ describe("Bootstrap integration — staging-dir release (Issue #3391, real track
       isGitVault: async () => true,
       validateUrl: () => undefined,
       deriveFolderName: (u) => u.split("/").pop() ?? "x",
-      promptBootstrapUrls: async () => ({ exoUrl: EXO_URL, exocmdUrl: EXOCMD_URL }),
+      promptBootstrapUrls: async () => ({ exoUrl: EXO_URL }),
       promptAddAssetSpaceUrl: async () => null,
       confirm: async () => true,
       notify: () => undefined,
@@ -420,8 +411,8 @@ describe("Bootstrap integration — staging-dir release (Issue #3391, real track
 
     await cmds.invokeBootstrap();
 
-    // Both pulled, both moved into the vault, both staging entries released.
-    expect((mgr.pullAssetSpace as jest.Mock).mock.calls).toHaveLength(2);
+    // Exo-only: exo pulled, moved into the vault, its staging entry released.
+    expect((mgr.pullAssetSpace as jest.Mock).mock.calls).toHaveLength(1);
     await expect(fs.access(
       path.join(vaultRoot, "assetspaces/kitelev/exoas-exo/73bd00e4-ccc0-4f3f-b20d-c4388c4588fb.md"),
     )).resolves.toBeUndefined();

--- a/packages/obsidian-plugin/tests/unit/integration/BootstrapAssetSpaceMobile.integration.test.ts
+++ b/packages/obsidian-plugin/tests/unit/integration/BootstrapAssetSpaceMobile.integration.test.ts
@@ -16,10 +16,10 @@
  * the GitHub HTTP client (real gzipped tarball, per test-fixture-realism).
  *
  * Proves the end-to-end mobile contract a fresh iPhone vault relies on:
- *   empty vault → bootstrap → exo + exocmd materialised via vault.adapter +
- *   `.gitmodules` written; then add-assetspace → a third entry — all readable
- *   back via `RestAssetSpaceMount.readGitmodulesEntries`, which is exactly what
- *   apply-profile (`listAllAssetSpaceInfos`) consumes next.
+ *   empty vault → bootstrap → exo materialised via vault.adapter (exo-only clean
+ *   bootstrap, 2026-06-20) + `.gitmodules` written; then add-assetspace → a
+ *   second entry — all readable back via `RestAssetSpaceMount.readGitmodulesEntries`,
+ *   which is exactly what apply-profile (`listAllAssetSpaceInfos`) consumes next.
  *
  * Revert-verify (mobile): remove the `restMount` branch from
  * `BootstrapAssetSpaceCommands.materialize` / `listTrackedEntries` and these
@@ -34,7 +34,6 @@ import type { GitHubRestClient } from "../../../src/infrastructure/adapters/GitH
 import { BootstrapAssetSpaceCommands } from "../../../src/infrastructure/adapters/BootstrapAssetSpaceCommands";
 
 const EXO_URL = "https://github.com/kitelev/exoas-exo";
-const EXOCMD_URL = "https://github.com/kitelev/exoas-exocmd";
 const PMBOK_URL = "https://github.com/kitelev/exoas-pmbok-ontology";
 
 // ─── Fakes ────────────────────────────────────────────────────────────────
@@ -179,7 +178,7 @@ function makeCmds(
   adapter: InMemoryAdapter,
   notices: string[],
   prompts: {
-    bootstrapUrls?: { exoUrl: string; exocmdUrl: string } | null;
+    bootstrapUrls?: { exoUrl: string } | null;
     addUrl?: { url: string } | null;
   },
 ): { cmds: BootstrapAssetSpaceCommands; restMount: RestAssetSpaceMount } {
@@ -207,7 +206,7 @@ function makeCmds(
     deriveFolderName,
     promptBootstrapUrls: async () =>
       prompts.bootstrapUrls === undefined
-        ? { exoUrl: EXO_URL, exocmdUrl: EXOCMD_URL }
+        ? { exoUrl: EXO_URL }
         : prompts.bootstrapUrls,
     promptAddAssetSpaceUrl: async () =>
       prompts.addUrl === undefined ? { url: PMBOK_URL } : prompts.addUrl,
@@ -220,35 +219,36 @@ function makeCmds(
 // ─── Tests ──────────────────────────────────────────────────────────────────
 
 describe("Mobile bootstrap integration — real RestAssetSpaceMount + vault.adapter (#3535)", () => {
-  it("empty vault → bootstrap materialises exo + exocmd via vault.adapter + writes .gitmodules", async () => {
+  it("empty vault → bootstrap materialises exo only via vault.adapter + writes .gitmodules", async () => {
     const adapter = new InMemoryAdapter();
     const notices: string[] = [];
     const { cmds, restMount } = makeCmds(adapter, notices, {});
 
     await cmds.invokeBootstrap();
 
-    // Content materialised at the Maven path, wrapper stripped — via writeBinary
-    // (vault.adapter), never Node fs.
+    // Exo-only clean bootstrap (2026-06-20): exo content materialised at the
+    // Maven path, wrapper stripped — via writeBinary (vault.adapter), never Node
+    // fs. exocmd is NOT materialised by bootstrap (added later).
     expect(adapter.files.has("assetspaces/kitelev/exoas-exo/exoas-exo.md")).toBe(
       true,
     );
     expect(
       adapter.files.has("assetspaces/kitelev/exoas-exocmd/exoas-exocmd.md"),
-    ).toBe(true);
+    ).toBe(false);
     expect(adapter.orphanWrites).toEqual([]);
 
-    // .gitmodules written via vault.adapter (text file), readable back.
+    // .gitmodules written via vault.adapter (text file), readable back — just the
+    // single exo entry.
     const entries = await restMount.readGitmodulesEntries();
     expect(entries).toEqual([
       { submodulePath: "assetspaces/kitelev/exoas-exo", url: EXO_URL },
-      { submodulePath: "assetspaces/kitelev/exoas-exocmd", url: EXOCMD_URL },
     ]);
 
     expect(notices.some((n) => /Bootstrap complete/.test(n))).toBe(true);
     expect(notices.some((n) => /file-only mode/.test(n))).toBe(false);
   });
 
-  it("after bootstrap, add-assetspace appends a third .gitmodules entry at the canonical Maven path + materialises it (#3538)", async () => {
+  it("after exo-only bootstrap, add-assetspace appends a second .gitmodules entry at the canonical Maven path + materialises it (#3538)", async () => {
     const adapter = new InMemoryAdapter();
     const notices: string[] = [];
     const { cmds, restMount } = makeCmds(adapter, notices, {});
@@ -265,10 +265,10 @@ describe("Mobile bootstrap integration — real RestAssetSpaceMount + vault.adap
       ),
     ).toBe(true);
 
+    // Bootstrap wrote exo only; add-assetspace appends pmbok as the 2nd entry.
     const entries = await restMount.readGitmodulesEntries();
     expect(entries.map((e) => e.submodulePath)).toEqual([
       "assetspaces/kitelev/exoas-exo",
-      "assetspaces/kitelev/exoas-exocmd",
       "assetspaces/kitelev/exoas-pmbok-ontology",
     ]);
     expect(notices.some((n) => /AssetSpace added/.test(n))).toBe(true);

--- a/packages/obsidian-plugin/tests/unit/presentation/modals/BootstrapModals.test.ts
+++ b/packages/obsidian-plugin/tests/unit/presentation/modals/BootstrapModals.test.ts
@@ -93,7 +93,7 @@ describe("isLikelyGitHubUrl", () => {
 });
 
 describe("BootstrapVaultModal", () => {
-  it("EC7 — URL fields start empty with kitelev example placeholders", () => {
+  it("exo-only — exactly one URL field, starts empty with the kitelev example placeholder", () => {
     let result: unknown;
     new BootstrapVaultModal(fakeApp, (r) => {
       result = r;
@@ -102,15 +102,15 @@ describe("BootstrapVaultModal", () => {
     const inputs = Array.from(
       document.querySelectorAll("input"),
     ) as HTMLInputElement[];
-    expect(inputs).toHaveLength(2);
+    // Exo-only clean bootstrap (2026-06-20): the misleading exocmd-URL field is
+    // gone — a single exo field remains.
+    expect(inputs).toHaveLength(1);
     expect(inputs[0].value).toBe("");
-    expect(inputs[1].value).toBe("");
     expect(inputs[0].getAttribute("placeholder")).toBe(
       "https://github.com/kitelev/exoas-exo",
     );
-    expect(inputs[1].getAttribute("placeholder")).toBe(
-      "https://github.com/kitelev/exoas-exocmd",
-    );
+    // No exocmd placeholder anywhere — the field was removed, not just blanked.
+    expect(document.body.textContent).not.toMatch(/exoas-exocmd/);
     expect(result).toBeUndefined(); // not settled yet
   });
 
@@ -121,14 +121,14 @@ describe("BootstrapVaultModal", () => {
     );
   });
 
-  it("empty fields → Bootstrap shows error, does not settle", () => {
+  it("empty field → Bootstrap shows error, does not settle", () => {
     let result: unknown = "sentinel";
     new BootstrapVaultModal(fakeApp, (r) => {
       result = r;
     }).open();
     findButton("Bootstrap")!.click();
     expect(result).toBe("sentinel"); // unchanged — not resolved
-    expect(document.body.textContent).toMatch(/required/i);
+    expect(document.body.textContent).toMatch(/exo URL is required/i);
   });
 
   it("invalid URL → error, does not settle", () => {
@@ -138,64 +138,19 @@ describe("BootstrapVaultModal", () => {
     }).open();
     const inputs = document.querySelectorAll("input");
     (inputs[0] as HTMLInputElement).value = "not-a-url";
-    (inputs[1] as HTMLInputElement).value =
-      "https://github.com/kitelev/exoas-exocmd";
     findButton("Bootstrap")!.click();
     expect(result).toBe("sentinel");
   });
 
-  it("valid URLs → resolves the entered pair", () => {
-    let result: { exoUrl: string; exocmdUrl: string } | null | undefined;
+  it("valid exo URL → resolves { exoUrl } (exo-only, no exocmd in the result)", () => {
+    let result: { exoUrl: string } | null | undefined;
     new BootstrapVaultModal(fakeApp, (r) => {
       result = r;
     }).open();
     const inputs = document.querySelectorAll("input");
     (inputs[0] as HTMLInputElement).value = "https://github.com/me/exo";
-    (inputs[1] as HTMLInputElement).value = "https://github.com/me/exocmd";
     findButton("Bootstrap")!.click();
-    expect(result).toEqual({
-      exoUrl: "https://github.com/me/exo",
-      exocmdUrl: "https://github.com/me/exocmd",
-    });
-  });
-
-  it("B3 core-only — exo filled, exocmd blank → resolves knowledge-only (empty exocmdUrl)", () => {
-    let result: { exoUrl: string; exocmdUrl: string } | null | undefined;
-    new BootstrapVaultModal(fakeApp, (r) => {
-      result = r;
-    }).open();
-    const inputs = document.querySelectorAll("input");
-    (inputs[0] as HTMLInputElement).value = "https://github.com/me/exo";
-    (inputs[1] as HTMLInputElement).value = ""; // knowledge-only
-    findButton("Bootstrap")!.click();
-    expect(result).toEqual({
-      exoUrl: "https://github.com/me/exo",
-      exocmdUrl: "",
-    });
-  });
-
-  it("B3 core-only — exo blank → still errors (exo required even when exocmd given)", () => {
-    let result: unknown = "sentinel";
-    new BootstrapVaultModal(fakeApp, (r) => {
-      result = r;
-    }).open();
-    const inputs = document.querySelectorAll("input");
-    (inputs[1] as HTMLInputElement).value = "https://github.com/me/exocmd";
-    findButton("Bootstrap")!.click();
-    expect(result).toBe("sentinel");
-    expect(document.body.textContent).toMatch(/exo URL is required/i);
-  });
-
-  it("B3 core-only — exocmd present but malformed → errors", () => {
-    let result: unknown = "sentinel";
-    new BootstrapVaultModal(fakeApp, (r) => {
-      result = r;
-    }).open();
-    const inputs = document.querySelectorAll("input");
-    (inputs[0] as HTMLInputElement).value = "https://github.com/me/exo";
-    (inputs[1] as HTMLInputElement).value = "not-a-url";
-    findButton("Bootstrap")!.click();
-    expect(result).toBe("sentinel");
+    expect(result).toEqual({ exoUrl: "https://github.com/me/exo" });
   });
 
   it("Cancel → resolves null", () => {


### PR DESCRIPTION
## What

The **Bootstrap vault** modal had two URL fields — `exo` (required) + `exocmd` (optional). The second field was **misleading**: it implied exocmd was needed for a clean start. A clean bootstrap only needs **exo** (the SDK/engine floor). exocmd (UI commands) — and any other AssetSpace — is added afterwards, either explicitly via **«Add AssetSpace by URL»** or transitively when a profile is applied (effective set / dependsOn DAG).

This removes the exocmd-URL field entirely (absent, not empty-but-present), cancelling EC7 for exocmd specifically; the exo field is unchanged.

WBS node `625fca82` (project **Exocortex Alpha Launch** → UX onboarding improvements).

## Changes

- **`BootstrapVaultModal`**: `BootstrapVaultUrls` is now `{ exoUrl }`; the exocmd input field + its `firstUrlProblem` check are removed. `isLikelyGitHubUrl` export kept (consumed by `AddAssetSpaceModal`).
- **`BootstrapAssetSpaceCommands`**: `promptBootstrapUrls` returns `{ exoUrl }`; the empty-vault branch materialises **exo only** (no exocmd pull, no partial-failure path). The EC2 *clone-needs-fetch* path still re-fetches every tracked AssetSpace (exocmd included, if it was added later). `TS_FLOOR_EXOCMD_PATH` removed.
- **No wiring change** in `ExocortexPlugin` (the modal→deps types stay compatible).
- **Tests**: modal + commands + both integration suites (desktop `GitSubmoduleOps` + mobile `RestAssetSpaceMount`) updated to assert the single exo field and exo-only materialise (1 pull, 1 `.gitmodules` entry). `BootstrapPatRefresh` unaffected.
- **`eka-obsidian-leg` e2e** (nightly/post-merge, **not** a required PR check): bootstrap is exo-only; exocmd is added via `add-assetspace` (the explicit-later path). Effective-set assertion intact. *Not run locally — Docker/QEMU forbidden in this environment; faithful edit verified by reasoning.*
- **`Getting-Started.md`**: bootstrap step + action-button troubleshooting updated for the exo-only floor.

## Verification

- `npm run check:types` → 0 errors; `npm run lint` → 0 errors.
- Affected unit + integration suites green (modal, commands, both bootstrap integration suites, PAT-refresh).
- **Revert-verify** (integration-test-revert-verify): with source reverted to `origin/main` + the new tests → **9 tests FAIL**; restored to HEAD → **56/56 PASS**. Empirically proves the tests exercise the exo-only behaviour.
- Desktop↔Mobile parity preserved (Archgate `MOBILE-004` pass; command still registered on both platforms).

## Out of scope

- §3.3 *Bootstrap dialog de-jargon* (`65dde213` / `ef3bd9a2`) — same modal, distinct copy/UX work. This PR only removes the exocmd field; the exo field label/copy de-jargon is left for §3.3.