### PR TITLE
fix(profile): stop vacuous recovery-completed write on clean reload

### DIFF
--- a/packages/obsidian-plugin/src/infrastructure/adapters/ProfileApplyManager.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/ProfileApplyManager.ts
@@ -1786,14 +1786,45 @@ export class ProfileApplyManager {
       return { restored: [], resumed: false, resumedTo: null };
     }
 
+    const interrupted = await this.classifyInterruptedSwitch();
+
+    // Extended nothing-to-recover guard (#7c9074ce). The #3571 guard above only
+    // short-circuits a FRESH vault (journal absent). On an established vault the
+    // journal always exists, so a CLEAN reload used to fall through to the
+    // unconditional `recovery-completed` write below — appending a vacuous
+    // terminal on EVERY onload (the live journal grew to 95 such records), which
+    // (a) grows without bound and (b) masks real recovery events. Short-circuit
+    // when there is no actual recovery work for THIS worker to do:
+    //   - no REST apply to resume (`rest-apply` target + REST wired), and
+    //   - no destroyed-but-not-materialized AssetSpace to restore from cache
+    //     (the only git-path work — `kind: none`/`reindex` never destroys; and a
+    //     `reindex` resume is a SEPARATE worker, never re-run here), and
+    //   - no stuck `_switchInProgress` flag to clear.
+    // A genuine interrupted switch always leaves the in-progress flag set (a
+    // crash skips the flag-clearing finally) OR a destroyed-not-materialized AS
+    // in the journal, so this never suppresses a real recovery — it only stops
+    // the no-op terminal that a clean reload kept appending.
+    const destroyedToRestore = [...interrupted.destroyed].filter(
+      (uid) => !interrupted.materialized.has(uid),
+    );
+    const needsRestResume =
+      interrupted.kind === "rest-apply" &&
+      interrupted.targetUid !== null &&
+      this.restWired();
+    if (
+      !needsRestResume &&
+      destroyedToRestore.length === 0 &&
+      !localDataStore.isSwitchInProgress()
+    ) {
+      return { restored: [], resumed: false, resumedTo: null };
+    }
+
     // Defensive (mirrors the apply paths at ll. 477/908/1334): we are past the
     // guard, so a real recovery is in flight. A genuine incomplete switch left
     // the journal — `.exocortex/` exists — but if `_switchInProgress` was set
     // in the crash window before the first journal write, ensure the dir so the
     // `recovery-completed` write can't ENOENT and mask the real outcome.
     await this.ensureExocortexDir();
-
-    const interrupted = await this.classifyInterruptedSwitch();
 
     // #1d1bcde0 (F1) — REST-aware resume. An interrupted REST apply is driven to
     // the target idempotently by re-running the REST apply (skip the confirm

--- a/packages/obsidian-plugin/tests/unit/ProfileApplyManager.apply.test.ts
+++ b/packages/obsidian-plugin/tests/unit/ProfileApplyManager.apply.test.ts
@@ -1550,6 +1550,134 @@ describe("ProfileApplyManager.recoverIncompleteSwitch", () => {
       "simulated localDataStore failure during recovery",
     );
   });
+
+  // === #7c9074ce — vacuous recovery-completed guard ===
+  //
+  // The #3571 nothing-to-recover guard only fires on a FRESH vault (journal
+  // absent). On an established vault the journal always exists, so a clean
+  // reload fell through to the unconditional `recovery-completed` write —
+  // appending a vacuous terminal on EVERY onload (the live journal grew to 95
+  // such records). The fix extends the guard to short-circuit when there is no
+  // actual recovery work: no REST resume, no destroyed-not-materialized AS to
+  // restore, and no stuck `_switchInProgress` flag.
+  describe("#7c9074ce — vacuous recovery-completed guard", () => {
+    const FLOOR = [
+      TS_FLOOR_AS_UID_EXO,
+      TS_FLOOR_AS_UID_EXOCMD,
+      TS_FLOOR_AS_UID_SHARED_IDENTITIES,
+    ];
+
+    it("REVERT-VERIFY: established vault, clean reindex tail (`completed`) + flag=false → does NOT append vacuous recovery-completed", async () => {
+      // The live smoking gun: a clean reindex-only switch ends `starting`→
+      // `completed`. `classifyInterruptedSwitch` yields kind=`reindex` (NOT
+      // `none`, since `completed` is not a reset terminal), but
+      // recoverIncompleteSwitch has nothing to do for a reindex — its resume is
+      // a SEPARATE worker. Pre-fix it still wrote a vacuous `recovery-completed`.
+      const { mgr, app, localDataStore } = setup({
+        targetUid: "target",
+        sourceUid: null,
+        targetIncludes: FLOOR,
+        materialized: FLOOR,
+      });
+      await localDataStore.save({ activeProfileUid: "target", _switchInProgress: false });
+      await app.vault.adapter.write(
+        ".exocortex/switch-journal.jsonl",
+        [
+          JSON.stringify({ phase: "starting", targetUid: "target", ts: "2026-06-02T00:00:00Z" }),
+          JSON.stringify({ phase: "completed", targetUid: "target", ts: "2026-06-02T00:00:05Z" }),
+        ].join("\n") + "\n",
+      );
+
+      const before = await readJournalEntries(app);
+      const result = await mgr.recoverIncompleteSwitch();
+      const after = await readJournalEntries(app);
+
+      expect(result).toEqual({ restored: [], resumed: false, resumedTo: null });
+      // No new entry — journal is byte-stable across the no-op recovery.
+      expect(after.length).toBe(before.length);
+      expect(after.filter((e) => e.phase === "recovery-completed")).toEqual([]);
+    });
+
+    it("REVERT-VERIFY: established vault, clean apply tail (`apply-completed`) + flag=false → does NOT append vacuous recovery-completed", async () => {
+      // Clean apply terminal resets the classifier to kind=`none`. Pre-fix the
+      // git-apply restore loop ran with an empty destroyed set and still wrote
+      // a vacuous `recovery-completed`.
+      const { mgr, app, localDataStore } = setup({
+        targetUid: "target",
+        sourceUid: null,
+        targetIncludes: FLOOR,
+        materialized: FLOOR,
+      });
+      await localDataStore.save({ activeProfileUid: "target", _switchInProgress: false });
+      await app.vault.adapter.write(
+        ".exocortex/switch-journal.jsonl",
+        [
+          JSON.stringify({ phase: "apply-starting", targetUid: "target", ts: "2026-06-02T00:00:00Z" }),
+          JSON.stringify({ phase: "apply-completed", targetUid: "target", ts: "2026-06-02T00:00:05Z" }),
+        ].join("\n") + "\n",
+      );
+
+      const before = await readJournalEntries(app);
+      await mgr.recoverIncompleteSwitch();
+      const after = await readJournalEntries(app);
+
+      expect(after.length).toBe(before.length);
+      expect(after.filter((e) => e.phase === "recovery-completed")).toEqual([]);
+    });
+
+    it("REGRESSION: real interrupted switch (destroyed-not-materialized) STILL restores + writes recovery-completed", async () => {
+      // Guard must NOT over-suppress: a genuine incomplete git-apply left a
+      // destroyed-but-not-materialized AS in the journal. Recovery must restore
+      // it from cache and write its terminal `recovery-completed`.
+      const { mgr, cacheLayer, app, localDataStore } = setup({
+        targetUid: "target",
+        sourceUid: null,
+        targetIncludes: FLOOR,
+        materialized: FLOOR,
+      });
+      await localDataStore.save({ activeProfileUid: "x", _switchInProgress: true });
+      await app.vault.adapter.write(
+        ".exocortex/switch-journal.jsonl",
+        JSON.stringify({
+          phase: "phase2-destroy-cached",
+          targetUid: "t",
+          as: "ems-uid",
+          ts: "2026-06-02T00:00:00Z",
+        }) + "\n",
+      );
+
+      const result = await mgr.recoverIncompleteSwitch();
+
+      expect(result.restored).toContain("ems-uid");
+      expect(cacheLayer.restoreCalls.map((r) => r.asUid)).toContain("ems-uid");
+      const after = await readJournalEntries(app);
+      expect(after.some((e) => e.phase === "recovery-completed")).toBe(true);
+      // Flag cleared after the genuine recovery.
+      expect(localDataStore.isSwitchInProgress()).toBe(false);
+    });
+
+    it("REGRESSION: clean tail but `_switchInProgress` STUCK true → still clears flag + writes recovery-completed (no over-suppress)", async () => {
+      // The guard keys on actual recovery NEED — a stuck in-progress flag IS
+      // recovery work (clear it) even when the journal tail looks terminal.
+      const { mgr, app, localDataStore } = setup({
+        targetUid: "target",
+        sourceUid: null,
+        targetIncludes: FLOOR,
+        materialized: FLOOR,
+      });
+      await localDataStore.save({ activeProfileUid: "target", _switchInProgress: true });
+      await app.vault.adapter.write(
+        ".exocortex/switch-journal.jsonl",
+        JSON.stringify({ phase: "apply-completed", targetUid: "target", ts: "2026-06-02T00:00:05Z" }) + "\n",
+      );
+
+      await mgr.recoverIncompleteSwitch();
+
+      expect(localDataStore.isSwitchInProgress()).toBe(false);
+      const after = await readJournalEntries(app);
+      expect(after.some((e) => e.phase === "recovery-completed")).toBe(true);
+    });
+  });
 });
 
 // ============================================================================


### PR DESCRIPTION
## Problem (#7c9074ce)

`recoverIncompleteSwitch()` (`ProfileApplyManager.ts`) has a #3571 nothing-to-recover guard that only short-circuits when the **journal file is absent** (fresh install). On an established vault the journal always exists, so a **clean reload** fell through to the unconditional `recovery-completed` journal write — appending a **vacuous terminal on EVERY onload**.

Live evidence: `vault-2025/.exocortex/switch-journal.jsonl` had grown to **95 `recovery-completed` records** (vs 2 `apply-completed`, 3 `completed`). Functionally harmless, but: (a) unbounded growth, (b) noise masks real recovery events during diagnosis, (c) falsely implies recovery "ran".

## Fix

After classifying the journal tail, short-circuit when there is **no actual recovery work** for this worker:
- no REST apply to resume (`rest-apply` target + REST wired),
- no destroyed-but-not-materialized AssetSpace to restore from cache (`kind: none`/`reindex` never destroy; reindex resume is a **separate** worker, never re-run here),
- no stuck `_switchInProgress` flag to clear.

A genuine interrupted switch always leaves the in-progress flag set (a crash skips the flag-clearing `finally`) **or** a destroyed-not-materialized AS in the journal, so this **never suppresses a real recovery** — it only stops the no-op terminal a clean reload kept appending.

Note: the simpler `kind === "none"` check would NOT have sufficed — the live smoking gun (a clean reindex `starting`→`completed` tail) classifies as `kind: reindex`, which the precise "no work" condition correctly treats as nothing-to-recover.

## Tests (revert-verify, `ProfileApplyManager.apply.test.ts`)

- **REVERT-VERIFY** clean reindex tail (`completed`) + `flag=false` → no vacuous `recovery-completed` (FAIL pre-fix: journal grows 2→3; PASS post-fix).
- **REVERT-VERIFY** clean apply tail (`apply-completed`) + `flag=false` → no vacuous write.
- **REGRESSION** real interrupted switch (destroyed-not-materialized, flag=true) → STILL restores from cache + writes terminal + clears flag.
- **REGRESSION** clean tail but `_switchInProgress` STUCK true → still clears flag + writes `recovery-completed` (no over-suppress).

Empirically verified to FAIL pre-fix and PASS post-fix. Full ProfileApplyManager suites: 125/125 green. typecheck 0, lint 0 errors.

Closes #7c9074ce (WBS node, child of Alpha Launch M3).