### PR TITLE
feat(onboarding): PAT-input as the first Welcome-panel step (cd9444bd)

### DIFF
--- a/packages/obsidian-plugin/src/ExocortexPlugin.ts
+++ b/packages/obsidian-plugin/src/ExocortexPlugin.ts
@@ -140,9 +140,11 @@ import { FirstRunOnboardingModal } from "./presentation/modals/FirstRunOnboardin
 import {
   registerOnboardingCommands,
   shouldShowFirstRunPanel,
+  persistOnboardingPat,
   STARTER_REGISTRY_URL,
   STARTER_PROFILE_QUERY,
 } from "./infrastructure/adapters/firstRunOnboarding";
+import { resolvePastedSecret } from "./presentation/settings/patClipboard";
 import { AssetSpaceMaterializationTracker } from "./infrastructure/adapters/AssetSpaceMaterializationTracker";
 import { injectAssetSpaceMaterializationTriples } from "./infrastructure/adapters/injectAssetSpaceMaterializationTriples";
 import { AssetSpaceStatusIconPatch } from "./presentation/asset-space/AssetSpaceStatusIconPatch";
@@ -3260,8 +3262,39 @@ export default class ExocortexPlugin extends Plugin {
         `${what} is unavailable in this environment — see the Getting Started guide.`,
       );
 
+    // Device-local secrets store for the optional token-first step (cd9444bd).
+    // The same store + canonical "pat" key the materialise steps read at
+    // command-execution time, so a token saved here is in place for them.
+    const secretsStore = new LocalSecretsStore({ app: this.app });
+
     const openPanel = (): void => {
       new FirstRunOnboardingModal(this.app, {
+        // Step 1 (optional, token-first): persist the PAT device-local BEFORE
+        // the materialise steps run (cd9444bd). Empty value clears it (skip
+        // path). A failure is surfaced as a notice but never blocks onboarding.
+        onSavePat: async (pat: string) => {
+          try {
+            await persistOnboardingPat(secretsStore, pat);
+            this.notifier.info(
+              pat.trim().length > 0
+                ? "Token saved. The next steps can now reach your private repos."
+                : "Token cleared.",
+            );
+          } catch (err) {
+            this.notifier.error(
+              "Saving the token failed: " +
+                (err instanceof Error ? err.message : String(err)),
+            );
+          }
+        },
+        // Step 1 paste affordance (mobile parity §3.9) — read + normalise the
+        // clipboard; works on desktop AND the mobile WebView under a user
+        // gesture (the button click), so no Platform gate.
+        onPastePat: async () => {
+          const raw = await navigator.clipboard.readText();
+          const outcome = resolvePastedSecret(raw);
+          return outcome.kind === "filled" ? outcome.value : null;
+        },
         onSetupEngine: () => {
           if (bootstrapCommands === null) {
             unavailable("Bootstrap");

--- a/packages/obsidian-plugin/src/infrastructure/adapters/firstRunOnboarding.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/firstRunOnboarding.ts
@@ -67,6 +67,54 @@ export function shouldShowFirstRunPanel(
   return markdownFileCount <= FRESH_VAULT_MAX_NOTES;
 }
 
+/**
+ * Canonical device-local secret key for the GitHub PAT (Issue #3320 §1).
+ *
+ * The same literal `"pat"` is read at command-execution time by the bootstrap /
+ * add-assetspace / apply-profile materialise paths (ApplyDepsFactory,
+ * SyncDepsFactory, ExoSyncParityFactory) and written by the Settings PAT field
+ * (`ExocortexSettingTab`). The Welcome panel's PAT step (cd9444bd) MUST write
+ * under this exact key so a token entered first-thing in onboarding is the same
+ * token those later steps read — mismatching it would silently break private
+ * `exoas-*` repo clone/pull. Kept as a named constant here so the onboarding
+ * save path can reuse it without re-typing the magic string.
+ */
+export const PAT_SECRET_KEY = "pat";
+
+/**
+ * Structural slice of {@link LocalSecretsStore} — keeps this module free of an
+ * `obsidian` runtime import (unit-testable with a plain fake), mirroring
+ * {@link OnboardingCommandRegistrar}. The real `LocalSecretsStore.setSecret`
+ * satisfies this shape (passing `null`/`""` clears the entry).
+ */
+export interface OnboardingSecretsStore {
+  setSecret(key: string, value: string | null): Promise<void>;
+}
+
+/**
+ * Persist the PAT entered in the Welcome panel's first (optional) step,
+ * device-local, BEFORE the bootstrap / add / apply steps run — so those steps
+ * (which read {@link PAT_SECRET_KEY} fresh at command-execution time, NOT at
+ * onload — Issue #3382) can authenticate private-repo clone/pull.
+ *
+ * Semantics mirror the Settings "Save PAT" button exactly so the two entry
+ * points never diverge:
+ *   - the raw token is trimmed (tokens are single-line opaque strings; copying
+ *     one often drags a trailing newline);
+ *   - an empty / all-whitespace value CLEARS the stored token (passes `null`),
+ *     never persists empty-PAT junk — this is the "skip" path: a public-only
+ *     tester who leaves the field blank and clicks through ends up with no PAT,
+ *     and the materialise steps tolerate an absent PAT (public repos pull
+ *     anonymously).
+ */
+export async function persistOnboardingPat(
+  store: OnboardingSecretsStore,
+  rawPat: string,
+): Promise<void> {
+  const trimmed = rawPat.trim();
+  await store.setSecret(PAT_SECRET_KEY, trimmed.length > 0 ? trimmed : null);
+}
+
 /** Stable command id for the guided Setup entry point (RFC 0002 §3.2). */
 export const SETUP_COMMAND_ID = "setup-getting-started";
 

--- a/packages/obsidian-plugin/src/presentation/modals/FirstRunOnboardingModal.ts
+++ b/packages/obsidian-plugin/src/presentation/modals/FirstRunOnboardingModal.ts
@@ -1,17 +1,34 @@
 import { App, Modal } from "obsidian";
+import { renderPatSetupHelper } from "../settings/patSetupHelper";
 
 /**
- * Action callbacks for the three onboarding steps + a one-time-close hook. The
+ * Action callbacks for the four onboarding steps + a one-time-close hook. The
  * panel is a thin, decoupled UI scaffold (RFC 0002 §3.1) — it owns no business
  * logic; each step just fires the injected action, which the plugin wires to the
- * existing Bootstrap / Add-AssetSpace / Apply-profile flows.
+ * existing Save-PAT / Bootstrap / Add-AssetSpace / Apply-profile flows.
  */
 export interface FirstRunOnboardingActions {
-  /** Step 1 — open the Bootstrap dialog (fields stay empty per EC7). */
+  /**
+   * Step 1 (PAT, optional) — persist the entered token device-local
+   * (`data.local.json`, Sync-excluded). Called with the raw field value; the
+   * wiring trims it and an empty value clears the stored token (the "skip"
+   * path). It MUST run before the materialise steps so a private-repo token is
+   * in place when Bootstrap/Add/Apply read it (cd9444bd, RFC 0002 §3.1). Async
+   * so the panel can surface a save failure.
+   */
+  onSavePat: (pat: string) => Promise<void>;
+  /**
+   * Step 1 (PAT, optional) — read a token from the clipboard for the Paste
+   * affordance (mobile onboarding parity, RFC 0002 §3.9 / P14). Returns the
+   * normalised token, or null when the clipboard is empty / unreadable. Omit to
+   * hide the Paste button (e.g. in a context with no clipboard).
+   */
+  onPastePat?: () => Promise<string | null>;
+  /** Step 2 — open the Bootstrap dialog (fields stay empty per EC7). */
   onSetupEngine: () => void;
-  /** Step 2 — open Add-AssetSpace pre-filled with the starter registry URL. */
+  /** Step 3 — open Add-AssetSpace pre-filled with the starter registry URL. */
   onAddStarter: () => void;
-  /** Step 3 — open the profile picker narrowed to the `starter` profile. */
+  /** Step 4 — open the profile picker narrowed to the `starter` profile. */
   onApplyStarterProfile: () => void;
   /**
    * Fired exactly once when the panel closes (any path: button, Esc, click-out).
@@ -35,10 +52,21 @@ interface StepSpec {
  * (RFC 0002 §3.1, resolves P1 first-run-has-zero-orientation + P2
  * sequence-not-discoverable).
  *
- * Renders a 3-step checklist that drives the canonical **starter** path:
- *   1. Set up the engine        → Bootstrap dialog (3.3)
- *   2. Add the starter content  → Add-AssetSpace pre-filled with the registry
- *   3. Apply the starter profile → profile picker on `starter` (3.4)
+ * Renders a 4-step checklist that drives the canonical **starter** path:
+ *   1. Add your GitHub token (OPTIONAL) → saves the PAT device-local FIRST so
+ *      the later steps can clone/pull private `exoas-*` repos (cd9444bd)
+ *   2. Set up the engine        → Bootstrap dialog (3.3)
+ *   3. Add the starter content  → Add-AssetSpace pre-filled with the registry
+ *   4. Apply the starter profile → profile picker on `starter` (3.4)
+ *
+ * ## Why the token step is FIRST (cd9444bd)
+ *
+ * Bootstrap / Add-AssetSpace / Apply-profile can pull **private** `exoas-*`
+ * repos, which need a GitHub PAT to clone/pull. The materialise paths read the
+ * token fresh at command-execution time (Issue #3382), so a token saved in
+ * step 1 is in place by the time steps 2-4 run. The step is **optional**: a
+ * public-only tester skips it (leaves it blank, moves to step 2) and the
+ * materialise steps pull anonymously — the public flow is never blocked.
  *
  * The step sub-dialogs stack ON TOP of this panel (Obsidian modal stacking), so
  * the panel stays open underneath and the user can walk the sequence without
@@ -48,16 +76,18 @@ interface StepSpec {
  *
  * ## Accessibility (P16, §3.11)
  *
- * - Steps are a semantic `<ol>` so assistive tech announces "list, 3 items".
+ * - Steps are a semantic `<ol>` so assistive tech announces "list, 4 items".
  * - Each action is a native `<button>` (keyboard-navigable + Enter/Space
- *   activation for free) with an explicit `aria-label`.
- * - Focus is managed: the first step's action button is focused on open.
+ *   activation for free) with an explicit `aria-label`; the token field is a
+ *   native `<input>` with an `aria-label`.
+ * - Focus is managed: the token input (the first actionable control) is focused
+ *   on open.
  * - Step order uses a text marker ("Step 1 —"), never an icon/emoji alone.
  */
 export class FirstRunOnboardingModal extends Modal {
   private readonly actions: FirstRunOnboardingActions;
   private closed = false;
-  private firstActionButton: HTMLButtonElement | null = null;
+  private firstFocusable: HTMLElement | null = null;
 
   constructor(app: App, actions: FirstRunOnboardingActions) {
     super(app);
@@ -76,14 +106,25 @@ export class FirstRunOnboardingModal extends Modal {
     contentEl.createEl("p", {
       cls: "exocortex-onboarding-intro",
       text:
-        "Let's get this vault set up in three steps. Run them in order — each " +
+        "Let's get this vault set up. Start with your GitHub token if you'll use " +
+        "private content (optional), then run the remaining steps in order — each " +
         "opens a dialog; this panel stays open so you can come back to the next " +
         "step. You can reopen this panel any time from the command palette.",
     });
 
+    const list = contentEl.createEl("ol", {
+      cls: "exocortex-onboarding-steps",
+    });
+    list.setAttribute("aria-label", "Exocortex setup steps");
+
+    // Step 1 — the optional, token-first step (cd9444bd). Rendered specially
+    // (input + paste/save + reusable §3.5 helper) BEFORE the generic action
+    // steps so it is unmistakably first.
+    this.renderPatStep(list);
+
     const steps: StepSpec[] = [
       {
-        marker: "Step 1",
+        marker: "Step 2",
         title: "Set up the engine",
         description:
           "Bootstrap this empty vault with the foundational exo AssetSpace — the " +
@@ -94,7 +135,7 @@ export class FirstRunOnboardingModal extends Modal {
         action: this.actions.onSetupEngine,
       },
       {
-        marker: "Step 2",
+        marker: "Step 3",
         title: "Add the starter content",
         description:
           "Pull the public starter registry — a curated set of AssetSpaces that gives " +
@@ -104,7 +145,7 @@ export class FirstRunOnboardingModal extends Modal {
         action: this.actions.onAddStarter,
       },
       {
-        marker: "Step 3",
+        marker: "Step 4",
         title: "Apply the starter profile",
         description:
           "Materialise the «starter» profile — it mounts the AssetSpaces the starter " +
@@ -114,45 +155,7 @@ export class FirstRunOnboardingModal extends Modal {
       },
     ];
 
-    const list = contentEl.createEl("ol", {
-      cls: "exocortex-onboarding-steps",
-    });
-    list.setAttribute("aria-label", "Exocortex setup steps");
-
-    steps.forEach((step, index) => {
-      const item = list.createEl("li", { cls: "exocortex-onboarding-step" });
-
-      const header = item.createEl("div", {
-        cls: "exocortex-onboarding-step-header",
-      });
-      header.createEl("span", {
-        cls: "exocortex-onboarding-step-marker",
-        text: `${step.marker} — `,
-      });
-      header.createEl("span", {
-        cls: "exocortex-onboarding-step-title",
-        text: step.title,
-      });
-
-      item.createEl("p", {
-        cls: "exocortex-onboarding-step-desc",
-        text: step.description,
-      });
-
-      const button = item.createEl("button", {
-        cls: "mod-cta exocortex-onboarding-step-action",
-        text: step.actionLabel,
-      });
-      // Screen-reader label spells out the step number so the action is
-      // unambiguous out of visual context (P16).
-      button.setAttribute(
-        "aria-label",
-        `${step.marker}: ${step.actionLabel}`,
-      );
-      button.addEventListener("click", () => step.action());
-
-      if (index === 0) this.firstActionButton = button;
-    });
+    steps.forEach((step) => this.renderActionStep(list, step));
 
     const footer = contentEl.createEl("div", {
       cls: "modal-button-container exocortex-onboarding-footer",
@@ -164,14 +167,128 @@ export class FirstRunOnboardingModal extends Modal {
     closeBtn.setAttribute("aria-label", "Close the setup panel");
     closeBtn.addEventListener("click", () => this.close());
 
-    // Managed focus (P16): land keyboard focus on the first actionable control
-    // so a keyboard / screen-reader user starts at step 1, not on the dialog
-    // container. Guarded — jsdom and headless contexts may lack focus support.
+    // Managed focus (P16): land keyboard focus on the first actionable control —
+    // the token input — so a keyboard / screen-reader user starts at step 1, not
+    // on the dialog container. Guarded — jsdom and headless contexts may lack
+    // focus support.
     try {
-      this.firstActionButton?.focus();
+      this.firstFocusable?.focus();
     } catch {
       /* focus is best-effort */
     }
+  }
+
+  /**
+   * Render the optional token-first step (cd9444bd, RFC 0002 §3.1): the §3.5
+   * create-token helper (deep-link + scope list, reused verbatim), a masked
+   * input, a Paste affordance (mobile parity §3.9) and an explicit Save button.
+   * Explicit Save (not keystroke-onChange) mirrors the Settings PAT field so a
+   * partial token is never persisted.
+   */
+  private renderPatStep(list: HTMLElement): void {
+    const item = list.createEl("li", {
+      cls: "exocortex-onboarding-step exocortex-onboarding-step-pat",
+    });
+
+    const header = item.createEl("div", {
+      cls: "exocortex-onboarding-step-header",
+    });
+    header.createEl("span", {
+      cls: "exocortex-onboarding-step-marker",
+      text: "Step 1 — ",
+    });
+    header.createEl("span", {
+      cls: "exocortex-onboarding-step-title",
+      text: "Add your GitHub token (optional)",
+    });
+
+    item.createEl("p", {
+      cls: "exocortex-onboarding-step-desc",
+      text:
+        "Only needed if you'll use private AssetSpaces — the later steps clone/pull " +
+        "your private exoas-* repos and need a token to do so. Add it first and the " +
+        "remaining steps can reach private content. Using only public content? Skip " +
+        "this and go straight to step 2.",
+    });
+
+    // §3.5 helper — identical create-token deep-link + permission list as the
+    // Settings PAT section (single source, no copy drift).
+    renderPatSetupHelper(item);
+
+    const row = item.createEl("div", { cls: "exocortex-onboarding-pat-row" });
+
+    const input = row.createEl("input", {
+      cls: "exocortex-onboarding-pat-input",
+    }) as HTMLInputElement;
+    input.type = "password";
+    // eslint-disable-next-line obsidianmd/ui/sentence-case -- placeholder shows the literal PAT format (matches the Settings PAT field)
+    input.placeholder = "github_pat_…";
+    input.setAttribute("aria-label", "GitHub personal access token (optional)");
+    this.firstFocusable = input;
+
+    // Paste affordance (mobile parity §3.9 / P14) — only when a clipboard
+    // reader is wired. Fills the field from the clipboard so a long token need
+    // not be typed on a phone.
+    if (this.actions.onPastePat) {
+      const pasteBtn = row.createEl("button", {
+        cls: "exocortex-onboarding-pat-paste",
+        text: "Paste",
+      });
+      pasteBtn.setAttribute("aria-label", "Paste a GitHub token from the clipboard");
+      pasteBtn.addEventListener("click", () => {
+        void (async () => {
+          try {
+            const pasted = await this.actions.onPastePat?.();
+            if (pasted) input.value = pasted;
+          } catch {
+            /* paste is best-effort; the user can still type the token */
+          }
+        })();
+      });
+    }
+
+    const saveBtn = row.createEl("button", {
+      cls: "mod-cta exocortex-onboarding-pat-save",
+      text: "Save token",
+    });
+    // eslint-disable-next-line obsidianmd/ui/sentence-case -- "Step 1:" a11y prefix (matches the step-numbered aria-labels above) + "GitHub" proper noun
+    saveBtn.setAttribute("aria-label", "Step 1: Save your GitHub token");
+    saveBtn.addEventListener("click", () => {
+      void this.actions.onSavePat(input.value).catch(() => {
+        /* save failure is surfaced by the wiring (notifier); never throw here */
+      });
+    });
+  }
+
+  /** Render a generic single-action step (steps 2-4). */
+  private renderActionStep(list: HTMLElement, step: StepSpec): void {
+    const item = list.createEl("li", { cls: "exocortex-onboarding-step" });
+
+    const header = item.createEl("div", {
+      cls: "exocortex-onboarding-step-header",
+    });
+    header.createEl("span", {
+      cls: "exocortex-onboarding-step-marker",
+      text: `${step.marker} — `,
+    });
+    header.createEl("span", {
+      cls: "exocortex-onboarding-step-title",
+      text: step.title,
+    });
+
+    item.createEl("p", {
+      cls: "exocortex-onboarding-step-desc",
+      text: step.description,
+    });
+
+    const button = item.createEl("button", {
+      cls: "mod-cta exocortex-onboarding-step-action",
+      text: step.actionLabel,
+    });
+    // Screen-reader label spells out the step number so the action is
+    // unambiguous out of visual context (P16).
+    button.setAttribute("aria-label", `${step.marker}: ${step.actionLabel}`);
+    button.addEventListener("click", () => step.action());
   }
 
   override onClose(): void {

--- a/packages/obsidian-plugin/styles.css
+++ b/packages/obsidian-plugin/styles.css
@@ -6195,6 +6195,19 @@
   margin-top: 1em;
 }
 
+/* cd9444bd — Welcome panel optional token-first step (input + paste/save row). */
+.exocortex-onboarding-pat-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5em;
+  align-items: center;
+}
+
+.exocortex-onboarding-pat-input {
+  flex: 1 1 12em;
+  min-width: 0;
+}
+
 /* RFC 0002 §3.5 — PAT setup create-token helper (deep-link + scope list). */
 .exocortex-pat-setup-helper {
   margin: 0.5em 0 1em;

--- a/packages/obsidian-plugin/tests/unit/firstRunOnboarding.test.ts
+++ b/packages/obsidian-plugin/tests/unit/firstRunOnboarding.test.ts
@@ -14,11 +14,14 @@ import { describe, it, expect } from "@jest/globals";
 import {
   shouldShowFirstRunPanel,
   registerOnboardingCommands,
+  persistOnboardingPat,
+  PAT_SECRET_KEY,
   SETUP_COMMAND_ID,
   STARTER_REGISTRY_URL,
   STARTER_PROFILE_QUERY,
   FRESH_VAULT_MAX_NOTES,
   type OnboardingCommandRegistrar,
+  type OnboardingSecretsStore,
 } from "../../src/infrastructure/adapters/firstRunOnboarding";
 import type { VaultBootstrapState } from "../../src/infrastructure/adapters/BootstrapAssetSpaceCommands";
 
@@ -89,6 +92,69 @@ describe("starter-path constants", () => {
 
   it("narrows the profile picker to the canonical starter profile", () => {
     expect(STARTER_PROFILE_QUERY).toBe("starter");
+  });
+});
+
+describe("persistOnboardingPat — token-first step save (cd9444bd, RFC 0002 §3.1)", () => {
+  /** Minimal device-local store fake mirroring LocalSecretsStore.setSecret. */
+  function makeStore(): {
+    store: OnboardingSecretsStore;
+    saved: Array<{ key: string; value: string | null }>;
+  } {
+    const saved: Array<{ key: string; value: string | null }> = [];
+    const store: OnboardingSecretsStore = {
+      setSecret: async (key, value) => {
+        saved.push({ key, value });
+      },
+    };
+    return { store, saved };
+  }
+
+  it("uses the canonical 'pat' key the materialise steps read", () => {
+    // Guards against key drift: the bootstrap/add/apply paths read getSecret("pat"),
+    // so the onboarding save MUST write under that exact key or it silently
+    // never reaches them (Issue #3320 §1).
+    expect(PAT_SECRET_KEY).toBe("pat");
+  });
+
+  it("persists a trimmed token under the canonical key (private-repo access)", async () => {
+    const { store, saved } = makeStore();
+    await persistOnboardingPat(store, "  github_pat_abc123  ");
+    expect(saved).toEqual([{ key: "pat", value: "github_pat_abc123" }]);
+  });
+
+  it("CLEARS the token (null) for an empty value — the public-only skip path", async () => {
+    const { store, saved } = makeStore();
+    await persistOnboardingPat(store, "");
+    // null → LocalSecretsStore deletes the entry → materialise steps see no PAT
+    // and pull public repos anonymously (public flow not broken).
+    expect(saved).toEqual([{ key: "pat", value: null }]);
+  });
+
+  it("CLEARS the token for an all-whitespace value (never persists junk)", async () => {
+    const { store, saved } = makeStore();
+    await persistOnboardingPat(store, "   \n  ");
+    expect(saved).toEqual([{ key: "pat", value: null }]);
+  });
+
+  it("a saved token round-trips: a later getSecret('pat') returns it", async () => {
+    // Simulate the real before/after: save in step 1, then a materialise step
+    // reads the same store. Without the save the read is null (private pull
+    // fails); with it the token is present (private pull authenticates).
+    const bag: Record<string, string | null> = {};
+    const store: OnboardingSecretsStore & {
+      getSecret: (k: string) => string | null;
+    } = {
+      setSecret: async (key, value) => {
+        if (value === null) delete bag[key];
+        else bag[key] = value;
+      },
+      getSecret: (k) => bag[k] ?? null,
+    };
+
+    expect(store.getSecret("pat")).toBeNull(); // before
+    await persistOnboardingPat(store, "github_pat_live");
+    expect(store.getSecret("pat")).toBe("github_pat_live"); // after
   });
 });
 

--- a/packages/obsidian-plugin/tests/unit/presentation/modals/FirstRunOnboardingModal.test.ts
+++ b/packages/obsidian-plugin/tests/unit/presentation/modals/FirstRunOnboardingModal.test.ts
@@ -12,6 +12,8 @@ jest.mock("obsidian", () => {
   interface CreateOpts {
     cls?: string;
     text?: string;
+    href?: string;
+    attr?: Record<string, string>;
   }
   function augment(el: HTMLElement): void {
     (
@@ -20,6 +22,14 @@ jest.mock("obsidian", () => {
       const child = document.createElement(tag);
       if (o?.cls) child.className = o.cls;
       if (o?.text) child.textContent = o.text;
+      // Mirror Obsidian's DomElementInfo so the reused §3.5 patSetupHelper
+      // (link href + target/rel/aria via `attr`) renders faithfully here.
+      if (o?.href) (child as HTMLAnchorElement).setAttribute("href", o.href);
+      if (o?.attr) {
+        for (const [name, value] of Object.entries(o.attr)) {
+          child.setAttribute(name, value);
+        }
+      }
       this.appendChild(child);
       augment(child);
       return child;
@@ -65,18 +75,32 @@ import {
 
 const fakeApp = {} as unknown as App;
 
-function makeActions(
-  over: Partial<FirstRunOnboardingActions> = {},
-): { actions: FirstRunOnboardingActions; calls: string[] } {
+function makeActions(over: Partial<FirstRunOnboardingActions> = {}): {
+  actions: FirstRunOnboardingActions;
+  calls: string[];
+  savedPats: string[];
+} {
   const calls: string[] = [];
+  const savedPats: string[] = [];
   const actions: FirstRunOnboardingActions = {
+    onSavePat: async (pat: string) => {
+      calls.push("savePat");
+      savedPats.push(pat);
+    },
+    onPastePat: async () => "github_pat_pasted",
     onSetupEngine: () => calls.push("engine"),
     onAddStarter: () => calls.push("starter"),
     onApplyStarterProfile: () => calls.push("profile"),
     onClosePanel: () => calls.push("close"),
     ...over,
   };
-  return { actions, calls };
+  return { actions, calls, savedPats };
+}
+
+function patInput(): HTMLInputElement {
+  return document.querySelector(
+    "input.exocortex-onboarding-pat-input",
+  ) as HTMLInputElement;
 }
 
 function findButton(label: string): HTMLButtonElement | undefined {
@@ -90,7 +114,7 @@ beforeEach(() => {
 });
 
 describe("FirstRunOnboardingModal", () => {
-  it("renders the welcome heading + a 3-step ordered checklist", () => {
+  it("renders the welcome heading + a 4-step ordered checklist (token-first)", () => {
     const { actions } = makeActions();
     new FirstRunOnboardingModal(fakeApp, actions).open();
 
@@ -101,13 +125,19 @@ describe("FirstRunOnboardingModal", () => {
     const list = document.querySelector("ol.exocortex-onboarding-steps");
     expect(list).not.toBeNull();
     const items = document.querySelectorAll("li.exocortex-onboarding-step");
-    expect(items).toHaveLength(3);
+    expect(items).toHaveLength(4);
 
-    // Each step has a plain-text marker (not a glyph) — P16.
+    // Each step has a plain-text marker (not a glyph) — P16. Step 1 is the
+    // optional token step (cd9444bd), then the three materialise steps.
     const markers = Array.from(
       document.querySelectorAll(".exocortex-onboarding-step-marker"),
     ).map((m) => m.textContent);
-    expect(markers).toEqual(["Step 1 — ", "Step 2 — ", "Step 3 — "]);
+    expect(markers).toEqual([
+      "Step 1 — ",
+      "Step 2 — ",
+      "Step 3 — ",
+      "Step 4 — ",
+    ]);
   });
 
   it("step 1 button fires onSetupEngine (opens Bootstrap)", () => {
@@ -131,24 +161,25 @@ describe("FirstRunOnboardingModal", () => {
     expect(calls).toEqual(["profile"]);
   });
 
-  it("each step action is a keyboard-navigable button with an aria-label (P16)", () => {
+  it("each materialise-step action is a keyboard-navigable button with an aria-label (P16)", () => {
     const { actions } = makeActions();
     new FirstRunOnboardingModal(fakeApp, actions).open();
     const actionButtons = Array.from(
       document.querySelectorAll("button.exocortex-onboarding-step-action"),
     ) as HTMLButtonElement[];
     expect(actionButtons).toHaveLength(3);
+    // Steps 2-4 (the token step is step 1 and has its own Save button).
     expect(actionButtons.map((b) => b.getAttribute("aria-label"))).toEqual([
-      "Step 1: Set up the engine",
-      "Step 2: Add the starter content",
-      "Step 3: Apply the starter profile",
+      "Step 2: Set up the engine",
+      "Step 3: Add the starter content",
+      "Step 4: Apply the starter profile",
     ]);
   });
 
-  it("manages focus — the first action button is focused on open (P16)", () => {
+  it("manages focus — the token input (first actionable control) is focused on open (P16)", () => {
     const { actions } = makeActions();
     new FirstRunOnboardingModal(fakeApp, actions).open();
-    expect(document.activeElement).toBe(findButton("Set up the engine"));
+    expect(document.activeElement).toBe(patInput());
   });
 
   it("clicking a step does NOT close the panel (sub-dialogs stack on top)", () => {
@@ -194,5 +225,134 @@ describe("FirstRunOnboardingModal", () => {
     const modal = new FirstRunOnboardingModal(fakeApp, actions);
     modal.open();
     expect(() => modal.close()).not.toThrow();
+  });
+});
+
+describe("FirstRunOnboardingModal — token-first step (cd9444bd, RFC 0002 §3.1)", () => {
+  it("renders the PAT step FIRST — before the Bootstrap (Set up the engine) step", () => {
+    const { actions } = makeActions();
+    new FirstRunOnboardingModal(fakeApp, actions).open();
+
+    const steps = Array.from(
+      document.querySelectorAll("li.exocortex-onboarding-step"),
+    );
+    // The first <li> is the token step; it carries the dedicated class and the
+    // password input, and the Bootstrap button lives in a LATER step.
+    expect(steps[0].classList.contains("exocortex-onboarding-step-pat")).toBe(
+      true,
+    );
+    expect(steps[0].querySelector("input.exocortex-onboarding-pat-input")).not.toBeNull();
+
+    const patIndex = steps.findIndex((li) =>
+      li.classList.contains("exocortex-onboarding-step-pat"),
+    );
+    const engineIndex = steps.findIndex(
+      (li) => li.querySelector("button")?.textContent === "Set up the engine",
+    );
+    expect(patIndex).toBe(0);
+    expect(engineIndex).toBeGreaterThan(patIndex);
+  });
+
+  it("the step is labelled optional and reuses the §3.5 create-token helper", () => {
+    const { actions } = makeActions();
+    new FirstRunOnboardingModal(fakeApp, actions).open();
+
+    const title = document.querySelector(
+      ".exocortex-onboarding-step-pat .exocortex-onboarding-step-title",
+    );
+    expect(title?.textContent).toMatch(/optional/i);
+
+    // §3.5 helper reuse — create-token deep-link + scope list rendered inside
+    // the step (single source; no copy drift with the Settings PAT section).
+    const link = document.querySelector(
+      ".exocortex-onboarding-step-pat a.exocortex-pat-setup-create-link",
+    ) as HTMLAnchorElement | null;
+    expect(link?.textContent).toBe("Create token on GitHub");
+    expect(link?.getAttribute("href")).toBe(
+      "https://github.com/settings/personal-access-tokens/new",
+    );
+    expect(
+      document.querySelector(
+        ".exocortex-onboarding-step-pat ul.exocortex-pat-setup-scopes",
+      ),
+    ).not.toBeNull();
+  });
+
+  it("the token input is a masked, keyboard-accessible field (a11y, P16)", () => {
+    const { actions } = makeActions();
+    new FirstRunOnboardingModal(fakeApp, actions).open();
+    const input = patInput();
+    expect(input).not.toBeNull();
+    expect(input.type).toBe("password");
+    expect(input.getAttribute("aria-label")).toMatch(/token/i);
+  });
+
+  it("Save token persists the entered token device-local (private-repo access)", async () => {
+    const { actions, calls, savedPats } = makeActions();
+    new FirstRunOnboardingModal(fakeApp, actions).open();
+
+    patInput().value = "github_pat_secret123";
+    findButton("Save token")!.click();
+    await Promise.resolve();
+
+    expect(calls).toContain("savePat");
+    expect(savedPats).toEqual(["github_pat_secret123"]);
+  });
+
+  it("Save token with an empty field passes '' (the clear / skip path)", async () => {
+    const { actions, savedPats } = makeActions();
+    new FirstRunOnboardingModal(fakeApp, actions).open();
+
+    // Field left blank — clicking Save clears any prior token; the wiring turns
+    // "" into a null setSecret, so a public-only tester ends up with no PAT.
+    findButton("Save token")!.click();
+    await Promise.resolve();
+
+    expect(savedPats).toEqual([""]);
+  });
+
+  it("is skippable — going straight to step 2 fires Bootstrap without any PAT save (public flow intact)", () => {
+    const { actions, calls } = makeActions();
+    new FirstRunOnboardingModal(fakeApp, actions).open();
+
+    // User ignores the optional token step and clicks the engine step directly.
+    findButton("Set up the engine")!.click();
+    expect(calls).toEqual(["engine"]);
+    expect(calls).not.toContain("savePat");
+  });
+
+  it("Save-token failure is swallowed in the modal (never throws into the click handler)", async () => {
+    const { actions } = makeActions({
+      onSavePat: async () => {
+        throw new Error("disk full");
+      },
+    });
+    new FirstRunOnboardingModal(fakeApp, actions).open();
+    patInput().value = "github_pat_x";
+    expect(() => findButton("Save token")!.click()).not.toThrow();
+    await Promise.resolve();
+  });
+
+  it("offers a Paste affordance (mobile parity §3.9) that fills the field", async () => {
+    const { actions } = makeActions({
+      onPastePat: async () => "github_pat_from_clipboard",
+    });
+    new FirstRunOnboardingModal(fakeApp, actions).open();
+
+    const paste = findButton("Paste");
+    expect(paste).toBeDefined();
+    paste!.click();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(patInput().value).toBe("github_pat_from_clipboard");
+  });
+
+  it("hides the Paste button when no clipboard reader is wired", () => {
+    const { actions } = makeActions({ onPastePat: undefined });
+    new FirstRunOnboardingModal(fakeApp, actions).open();
+    expect(findButton("Paste")).toBeUndefined();
+    // The Save button + input still render — paste is a pure nicety.
+    expect(findButton("Save token")).toBeDefined();
+    expect(patInput()).not.toBeNull();
   });
 });


### PR DESCRIPTION
## What

Adds an **optional, token-first step** to the first-run **"Welcome to Exocortex"** panel (RFC 0002 §3.1, shipped v16.100.0) so a GitHub PAT can be saved **before** the materialise steps run.

**Why first:** Bootstrap / Add-AssetSpace / Apply-profile can pull **private** `exoas-*` repos, which need a token to clone/pull. The materialise paths read the PAT **fresh at command-execution time** (Issue #3382), so a token entered in step 1 is in place by the time steps 2-4 run. Without it, private materialisation fails.

## Changes

- **New Step 1 (optional)** in `FirstRunOnboardingModal`: masked `<input>` + `Save token` + `Paste`, reusing the §3.5 `patSetupHelper` **verbatim** (create-token deep-link + scope list — single source, no copy drift with the Settings PAT section).
- **`persistOnboardingPat()`** (pure, in `firstRunOnboarding.ts`): saves the PAT **device-local** under the canonical `"pat"` key (`data.local.json`, Sync-excluded — same key the materialise steps read). Trims the token; an **empty value clears it** — the public-only **skip path** (anonymous pull still works, public flow never blocked).
- Existing Bootstrap / Add / Apply steps renumbered **Step 2/3/4**; focus now lands on the token input.
- **Wiring** in `ExocortexPlugin.registerOnboardingPanel`: `onSavePat` → `persistOnboardingPat`; `onPastePat` → clipboard + `resolvePastedSecret`.

## Accessibility (P16)
- Semantic `<ol>`; native `<input>`/`<button>` (keyboard-navigable + Enter/Space); explicit `aria-label`s; managed focus on the token input; plain-text step markers.

## Desktop↔Mobile parity
- Paste affordance preserved (§3.9 / P14); **no `Platform` gate**; `assert-mobile-loadable` build assert green.

## Security
- Input is `type="password"` (masked); the PAT is never logged or echoed (save/clear notices don't include it); stored only in Sync-excluded `data.local.json`.

## Tests
- `persistOnboardingPat`: trim / clear-on-empty / round-trip (before=null → after=token), canonical-key guard.
- Modal: token-step renders **first** (before Bootstrap), reuses the §3.5 helper, password input + aria-label, Save persists / empty-skip clears, **skippable** (engine step fires without any PAT save → public flow intact), Paste fills the field, Paste hidden when no reader wired, save-failure swallowed.
- **Revert-verified:** disabling `renderPatStep` fails the 10 token-step assertions; restored → green. typecheck + lint + full build all clean.

Closes WBS node cd9444bd (Alpha Launch → UX onboarding improvements).