### PR TITLE
feat(profile): live per-AssetSpace progress in activity log during apply materialize

### DIFF
--- a/packages/obsidian-plugin/src/ExocortexPlugin.ts
+++ b/packages/obsidian-plugin/src/ExocortexPlugin.ts
@@ -14,7 +14,10 @@ import { LoggerFactory } from "./adapters/logging/LoggerFactory";
 import { Logger } from "./adapters/logging/Logger";
 import { FileLogChannel } from "./adapters/logging/FileLogChannel";
 import { ActivityLogService } from "./adapters/logging/ActivityLogService";
-import { journalEntryToActivity } from "./adapters/logging/activityFanIn";
+import {
+  journalEntryToActivity,
+  progressToActivity,
+} from "./adapters/logging/activityFanIn";
 import { ActivityLogModal } from "./presentation/modals/ActivityLogModal";
 import { LogFileModal } from "./presentation/modals/LogFileModal";
 import { CommandManager } from "./application/services/CommandManager";
@@ -2978,6 +2981,10 @@ export default class ExocortexPlugin extends Plugin {
       notify: (message) => this.notifier.info(message),
       // #3540 — fan profile apply / mount / unmount phases into the activity log.
       onPhase: (entry) => this.activityLog.record(journalEntryToActivity(entry)),
+      // Live per-AssetSpace "Mounting X (2 of 5)" progress during materialize —
+      // activity-log-only (never toasted), so a long apply visibly progresses.
+      onProgress: (event) =>
+        this.activityLog.record(progressToActivity(event)),
       assetSpaceManager: applyDeps?.assetSpaceManager,
       gitOps: applyDeps?.gitOps,
       restMount: restMount ?? undefined,

--- a/packages/obsidian-plugin/src/adapters/logging/ActivityLogService.ts
+++ b/packages/obsidian-plugin/src/adapters/logging/ActivityLogService.ts
@@ -24,6 +24,11 @@ export type ActivityCategory =
   | "exosync"
   | "profile"
   | "mount"
+  // Live per-AssetSpace "starting op N of M" feed during a profile-apply
+  // materialize (pull/mount/unmount). Activity-log-only — emitted BEFORE each
+  // op so a long apply shows it is progressing, distinct from the post-op
+  // "mount" journal feed. Never toasted (see ProfileApplyManager.onProgress).
+  | "progress"
   // Reserved: bootstrap/add-assetspace/unmount progress now flows through the
   // central notifier as "notice" (#3540 follow-up), so no producer currently
   // emits "bootstrap" — kept as a valid category a future feed may re-adopt.

--- a/packages/obsidian-plugin/src/adapters/logging/activityFanIn.ts
+++ b/packages/obsidian-plugin/src/adapters/logging/activityFanIn.ts
@@ -4,7 +4,10 @@
  * in `ExocortexPlugin.onload()` stay one-liners and the mapping is unit-testable
  * without standing up the whole plugin.
  */
-import type { SwitchJournalEntry } from "../../infrastructure/adapters/ProfileApplyManager";
+import type {
+  ApplyProgressEvent,
+  SwitchJournalEntry,
+} from "../../infrastructure/adapters/ProfileApplyManager";
 import type { ActivityLevel, ActivityRecordInput } from "./ActivityLogService";
 
 /** Human-friendly labels for ProfileApplyManager journal phases. */
@@ -62,5 +65,36 @@ export function journalEntryToActivity(
     category,
     level: levelForPhase(entry.phase),
     message: `${label}${asPart}${elapsedPart}${errorPart}`,
+  };
+}
+
+/** Present-tense verbs for the live per-AssetSpace progress feed. */
+const PROGRESS_VERBS: Record<ApplyProgressEvent["op"], string> = {
+  pull: "Pulling",
+  mount: "Mounting",
+  unmount: "Unmounting",
+};
+
+/**
+ * Map a live {@link ApplyProgressEvent} (emitted BEFORE each per-AssetSpace
+ * pull/mount/unmount) to a `category:"progress"` activity record so the log
+ * shows a long apply is actively progressing — e.g. `Mounting kpc abc12345
+ * (2 of 5)`. Always `info` level (progress is not a failure signal); the 8-char
+ * AssetSpace prefix and N-of-M count keep each line self-describing.
+ */
+export function progressToActivity(
+  event: ApplyProgressEvent,
+): ActivityRecordInput {
+  const verb = PROGRESS_VERBS[event.op] ?? event.op;
+  const asPrefix = event.as.slice(0, 8);
+  // Avoid a redundant prefix when the label IS just the UID prefix.
+  const labelPart =
+    event.label && event.label !== asPrefix
+      ? `${event.label} ${asPrefix}`
+      : asPrefix;
+  return {
+    category: "progress",
+    level: "info",
+    message: `${verb} ${labelPart} (${event.index} of ${event.total})`,
   };
 }

--- a/packages/obsidian-plugin/src/infrastructure/adapters/ProfileApplyManager.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/ProfileApplyManager.ts
@@ -168,6 +168,32 @@ export interface SwitchJournalEntry {
   error?: string;
 }
 
+/**
+ * Ephemeral per-AssetSpace progress event (activity-log materialize progress) —
+ * emitted BEFORE each pull/mount/unmount so the activity log shows the apply is
+ * actively progressing ("Mounting X (2 of 5)"), not just the post-completion
+ * summary. The {@link SwitchJournalEntry} feed already records each op AFTER it
+ * finishes; this adds the live "starting op N of M" feed in front of it.
+ *
+ * Deliberately DISTINCT from {@link SwitchJournalEntry}:
+ *  - NOT persisted to the switch journal → never read by crash-recovery
+ *    classification, so adding/removing it cannot change recovery semantics.
+ *  - NOT routed through `notify` → activity-log-only, so a long apply never
+ *    spams toasts (only the sparse final summary toasts).
+ */
+export interface ApplyProgressEvent {
+  /** Which per-AssetSpace operation is about to start. */
+  op: "pull" | "mount" | "unmount";
+  /** Target AssetSpace UID. */
+  as: string;
+  /** Human label of the AssetSpace (namespace / best-effort; may be the UID). */
+  label: string;
+  /** 1-based position within the current op batch. */
+  index: number;
+  /** Total count in the current op batch. */
+  total: number;
+}
+
 export interface ProfileApplyManagerOptions {
   app: App;
   lockMgr: PluginLockManager;
@@ -189,6 +215,15 @@ export interface ProfileApplyManagerOptions {
    * Default no-op. Must not throw — failures are swallowed at the call site.
    */
   onPhase?: (entry: SwitchJournalEntry) => void;
+  /**
+   * Live per-AssetSpace progress sink (activity-log materialize progress) —
+   * invoked BEFORE each pull/mount/unmount with N-of-M context so the activity
+   * log shows a long apply is actively progressing, not only its post-fact
+   * summary. Wire to the activity log; activity-log-only by design (NOT
+   * `notify`), so it never spams toasts. Default no-op; must not throw —
+   * failures are swallowed at the call site (mirrors {@link onPhase}).
+   */
+  onProgress?: (event: ApplyProgressEvent) => void;
 
   // --- Apply dependencies (RFC 22b50a17 Phase 3) ---
   /** AssetSpaceManager — provides pullAssetSpace + lookupAssetSpaceInfo. */
@@ -391,6 +426,7 @@ export class ProfileApplyManager {
   private readonly now: () => Date;
   private readonly notify: (message: string) => void;
   private readonly onPhase: (entry: SwitchJournalEntry) => void;
+  private readonly onProgress: (event: ApplyProgressEvent) => void;
 
   // Apply dependencies (may be undefined when only reindex wired).
   private readonly assetSpaceManager?: AssetSpaceManager;
@@ -425,6 +461,7 @@ export class ProfileApplyManager {
     this.now = options.now ?? (() => new Date());
     this.notify = options.notify ?? (() => undefined);
     this.onPhase = options.onPhase ?? (() => undefined);
+    this.onProgress = options.onProgress ?? (() => undefined);
 
     this.assetSpaceManager = options.assetSpaceManager;
     this.cacheLayer = options.cacheLayer;
@@ -1082,7 +1119,16 @@ export class ProfileApplyManager {
         targetUid: targetProfileUid,
         ts: this.now().toISOString(),
       });
-      for (const target of toMaterialize) {
+      for (let i = 0; i < toMaterialize.length; i++) {
+        const target = toMaterialize[i];
+        // Live progress BEFORE the pull (desktop parity with the REST path).
+        this.emitProgress({
+          op: "pull",
+          as: target.asUid,
+          label: target.label,
+          index: i + 1,
+          total: toMaterialize.length,
+        });
         try {
           // R28 — SHA-aware cache lookup. We don't know upstream SHA up-front,
           // so we pull. (R28 future optimization: HEAD probe before pull.)
@@ -1125,7 +1171,15 @@ export class ProfileApplyManager {
       });
 
       // F2 journal-write-BEFORE-destroy: cache first, journal, then destroy.
-      for (const target of toDestroy) {
+      for (let i = 0; i < toDestroy.length; i++) {
+        const target = toDestroy[i];
+        this.emitProgress({
+          op: "unmount",
+          as: target.asUid,
+          label: target.label,
+          index: i + 1,
+          total: toDestroy.length,
+        });
         const vaultAbsPath = deps.vaultRootPath + "/" + target.submodulePath;
         // F6 — cache verifies archive before returning; if cache fails,
         // throws CacheWriteError and destroy never starts.
@@ -1167,7 +1221,17 @@ export class ProfileApplyManager {
         await deps.gitOps.readGitmodulesPaths(),
       );
 
-      for (const target of toMaterialize) {
+      for (let i = 0; i < toMaterialize.length; i++) {
+        const target = toMaterialize[i];
+        // Live progress (N-of-M) BEFORE materializing — desktop parity with the
+        // REST path; the `phase2-materializing` journal entry below has no count.
+        this.emitProgress({
+          op: "mount",
+          as: target.asUid,
+          label: target.label,
+          index: i + 1,
+          total: toMaterialize.length,
+        });
         await this.appendJournal({
           phase: "phase2-materializing",
           targetUid: targetProfileUid,
@@ -1561,7 +1625,17 @@ export class ProfileApplyManager {
       // ordering whose mount-failure window left the to-destroy set already gone
       // with no rollback (REST has no SwitchCacheLayer).
       // Mount new AssetSpaces (REST tarball → vault folder + .gitmodules entry).
-      for (const target of toMaterialize) {
+      for (let i = 0; i < toMaterialize.length; i++) {
+        const target = toMaterialize[i];
+        // Live progress BEFORE the mount so a long apply shows "Mounting X
+        // (2 of 5)" as it runs — the journal entry below only fires AFTER.
+        this.emitProgress({
+          op: "mount",
+          as: target.asUid,
+          label: target.label,
+          index: i + 1,
+          total: toMaterialize.length,
+        });
         try {
           await restMount.mount(target.gitUrl, target.submodulePath, target.ref);
         } catch (mountErr) {
@@ -1592,7 +1666,15 @@ export class ProfileApplyManager {
       // the right actionable message.
       mountsComplete = true;
       // Unmount removed AssetSpaces (rm folder + strip .gitmodules stanza).
-      for (const target of toDestroy) {
+      for (let i = 0; i < toDestroy.length; i++) {
+        const target = toDestroy[i];
+        this.emitProgress({
+          op: "unmount",
+          as: target.asUid,
+          label: target.label,
+          index: i + 1,
+          total: toDestroy.length,
+        });
         await restMount.unmount(target.submodulePath);
         await this.appendJournal({
           phase: "phase2-destroyed",
@@ -2564,6 +2646,19 @@ export class ProfileApplyManager {
 
     if (typeof profile.extends === "string" && profile.extends.length > 0) {
       await this.walkProfileChain(profile.extends, visited, result, depth + 1);
+    }
+  }
+
+  /**
+   * Emit a live progress event (activity-log materialize progress). Isolated:
+   * a bad observer must never break the apply — mirrors the `onPhase` guard in
+   * {@link appendJournal}.
+   */
+  private emitProgress(event: ApplyProgressEvent): void {
+    try {
+      this.onProgress(event);
+    } catch {
+      // swallow — progress observability is best-effort, never blocks the apply.
     }
   }
 

--- a/packages/obsidian-plugin/tests/unit/ProfileApplyManager.applyProgress.test.ts
+++ b/packages/obsidian-plugin/tests/unit/ProfileApplyManager.applyProgress.test.ts
@@ -1,0 +1,370 @@
+/**
+ * ProfileApplyManager — live per-AssetSpace progress feed during a profile
+ * apply materialize (activity-log materialize progress, WBS 4b2bc60f).
+ *
+ * Requirement: during `applyProfile` materialize the activity log must show the
+ * apply is actively progressing — a "Mounting X (2 of 5)" entry BEFORE each
+ * per-AssetSpace pull/mount/unmount — not only the post-completion summary. The
+ * progress feed is `onProgress` (wired to the activity log), DISTINCT from
+ * `notify` (the sparse user-facing toast) so a long apply never spams toasts.
+ *
+ * These tests drive the PRODUCTION path (REST — desktop & mobile both route
+ * through it post-#3567) and assert:
+ *   1. onProgress fires once per mount, BEFORE the mount, with 1-based N-of-M.
+ *   2. onProgress fires once per unmount, BEFORE the unmount, with N-of-M.
+ *   3. Progress is activity-log-only — `notify` is NOT called with any progress
+ *      line (only the single final summary toast).
+ *   4. Ordering — every progress event precedes the op it announces.
+ *
+ * Revert-verify: remove the `emitProgress(...)` calls from the materialize loops
+ * and tests 1/2/4 fail (zero progress events); restore → pass.
+ *
+ * Fakes mirror ProfileApplyManager.restApply.test.ts (production-shape AS ABox
+ * frontmatter, in-memory vault.adapter, dual-slot FakeLocalDataStore).
+ */
+import { Platform } from "obsidian";
+import type { App, TFile } from "obsidian";
+import type { IConfirmGate } from "exocortex";
+
+import {
+  ProfileApplyManager,
+  type ApplyProgressEvent,
+  type IProfileResolver,
+  type IRdfIndexer,
+  type ISettingsStore,
+  type ProfileResolution,
+  type SwitchSettings,
+} from "../../src/infrastructure/adapters/ProfileApplyManager";
+import { PluginLockManager } from "../../src/infrastructure/adapters/PluginLockManager";
+import {
+  TS_FLOOR_AS_UID_EXO,
+  TS_FLOOR_AS_UID_EXOCMD,
+  TS_FLOOR_AS_UID_SHARED_IDENTITIES,
+} from "../../src/infrastructure/adapters/ProfileOnloadWiring";
+
+// ─── Fakes (mirror restApply.test.ts) ───────────────────────────────────────
+
+interface FakeFile {
+  path: string;
+  basename: string;
+  frontmatter: Record<string, unknown>;
+}
+
+function makeFakeApp(files: FakeFile[]): {
+  app: App;
+  fsFolders: Map<string, { files: string[]; folders: string[] }>;
+} {
+  const fsFiles = new Map<string, string>();
+  const fsFolders = new Map<string, { files: string[]; folders: string[] }>();
+  const tfiles: TFile[] = files.map(
+    (f) => ({ path: f.path, basename: f.basename }) as unknown as TFile,
+  );
+  const frontmatterByPath = new Map<string, Record<string, unknown>>();
+  for (const f of files) frontmatterByPath.set(f.path, f.frontmatter);
+
+  const app = {
+    vault: {
+      getMarkdownFiles: () => tfiles,
+      adapter: {
+        exists: async (p: string) => fsFiles.has(p) || fsFolders.has(p),
+        read: async (p: string) => {
+          const v = fsFiles.get(p);
+          if (v === undefined) throw new Error(`ENOENT: ${p}`);
+          return v;
+        },
+        write: async (p: string, d: string) => {
+          fsFiles.set(p, d);
+        },
+        list: async (dir: string) =>
+          fsFolders.get(dir) ?? { files: [], folders: [] },
+      },
+    },
+    metadataCache: {
+      getFileCache: (file: TFile) => {
+        const fm = frontmatterByPath.get(file.path);
+        return fm ? { frontmatter: fm } : null;
+      },
+    },
+  } as unknown as App;
+  return { app, fsFolders };
+}
+
+class FakeResolver implements IProfileResolver {
+  constructor(private readonly profiles: Map<string, ProfileResolution>) {}
+  async resolve(uid: string): Promise<ProfileResolution | null> {
+    return this.profiles.get(uid) ?? null;
+  }
+  async discoverSharedOntologies(): Promise<string[]> {
+    return [];
+  }
+}
+
+class FakeIndexer implements IRdfIndexer {
+  async refresh(): Promise<void> {}
+}
+
+class FakeSettingsStore implements ISettingsStore {
+  state: SwitchSettings = { activeProfileUid: null, _switchInProgress: false };
+  async load(): Promise<SwitchSettings> {
+    return { ...this.state };
+  }
+  async save(s: SwitchSettings): Promise<void> {
+    this.state = { ...s };
+  }
+}
+
+class FakeLocalDataStore {
+  private state = { activeProfileUid: null as string | null, _switchInProgress: false };
+  getActiveProfileUid(): string | null {
+    return this.state.activeProfileUid;
+  }
+  isSwitchInProgress(): boolean {
+    return this.state._switchInProgress;
+  }
+  snapshot() {
+    return { ...this.state };
+  }
+  async save(s: { activeProfileUid: string | null; _switchInProgress: boolean }) {
+    this.state = { activeProfileUid: s.activeProfileUid, _switchInProgress: s._switchInProgress };
+  }
+}
+
+class FakeConfirmGate implements IConfirmGate {
+  async confirmApply(): Promise<boolean> {
+    return true;
+  }
+}
+
+/** REST mount that appends to a SHARED trace so we can prove progress precedes the op. */
+class TracingRestMount {
+  mounted: string[] = [];
+  unmounted: string[] = [];
+  constructor(private readonly trace: string[]) {}
+  async mount(_gitUrl: string, submodulePath: string, _ref: string) {
+    this.trace.push(`mount:${submodulePath}`);
+    this.mounted.push(submodulePath);
+    return { sha: "abc1234", fileCount: 1 };
+  }
+  async unmount(submodulePath: string): Promise<void> {
+    this.trace.push(`unmount:${submodulePath}`);
+    this.unmounted.push(submodulePath);
+  }
+}
+
+// ─── AssetSpace topology ────────────────────────────────────────────────────
+
+const TS_FLOOR = [
+  { uid: TS_FLOOR_AS_UID_EXO, folder: "assetspaces/kitelev/exoas-exo" },
+  { uid: TS_FLOOR_AS_UID_EXOCMD, folder: "assetspaces/kitelev/exoas-exocmd" },
+  {
+    uid: TS_FLOOR_AS_UID_SHARED_IDENTITIES,
+    folder: "assetspaces/kitelev/exoas-shared-identities",
+  },
+];
+const EXTRA = [
+  { uid: "ems-uid", folder: "assetspaces/kitelev/exoas-ems" },
+  { uid: "kpc-uid", folder: "assetspaces/kitelev/exoas-kpc" },
+];
+const ALL_AS = [...TS_FLOOR, ...EXTRA];
+const FLOOR_UIDS = TS_FLOOR.map((f) => f.uid);
+
+interface SetupOpts {
+  targetIncludes: string[];
+  materialized: string[];
+  /** Wire a hostile onProgress that throws — proves emitProgress isolation. */
+  throwingProgress?: boolean;
+}
+
+function setup(opts: SetupOpts) {
+  const files: FakeFile[] = [
+    {
+      path: "profiles/target.md",
+      basename: "target",
+      frontmatter: {
+        exo__Asset_uid: "target",
+        exo__Asset_label: "Target Profile",
+        exo__Instance_class: ["[[exo__Profile]]"],
+      },
+    },
+    ...ALL_AS.map((as) => {
+      const ns = as.folder.split("/").pop();
+      return {
+        path: `${as.folder}/${as.uid}.md`,
+        basename: as.uid,
+        frontmatter: {
+          exo__Asset_uid: as.uid,
+          exo__Asset_label: ns,
+          exo__Instance_class: ["[[exo__AssetSpace]]"],
+          exo__AssetSpace_source: `https://github.com/${as.folder.replace("assetspaces/", "")}`,
+          exo__AssetSpace_namespace: ns,
+        },
+      };
+    }),
+  ];
+
+  const { app, fsFolders } = makeFakeApp(files);
+  for (const uid of opts.materialized) {
+    const folder = ALL_AS.find((a) => a.uid === uid)?.folder;
+    if (folder) {
+      fsFolders.set(folder, {
+        files: [`${folder}/file1.md`, `${folder}/file2.md`],
+        folders: [],
+      });
+    }
+  }
+
+  const resolver = new FakeResolver(
+    new Map<string, ProfileResolution>([
+      ["target", { uid: "target", includes: opts.targetIncludes, label: "Target Profile" }],
+    ]),
+  );
+  const trace: string[] = [];
+  const restMount = new TracingRestMount(trace);
+  const progressEvents: ApplyProgressEvent[] = [];
+  const notifyCalls: string[] = [];
+
+  const mgr = new ProfileApplyManager({
+    app,
+    lockMgr: new PluginLockManager({ app }),
+    resolver,
+    rdfIndexer: new FakeIndexer(),
+    settingsStore: new FakeSettingsStore(),
+    notify: (m) => notifyCalls.push(m),
+    onProgress: (e) => {
+      trace.push(`progress:${e.op}:${e.index}/${e.total}`);
+      progressEvents.push(e);
+      if (opts.throwingProgress) throw new Error("hostile observer");
+    },
+    /* eslint-disable @typescript-eslint/no-explicit-any */
+    confirmGate: new FakeConfirmGate(),
+    localDataStore: new FakeLocalDataStore() as any,
+    restMount: restMount as any,
+    /* eslint-enable @typescript-eslint/no-explicit-any */
+  });
+  return { mgr, restMount, progressEvents, notifyCalls, trace };
+}
+
+// ─── Tests ──────────────────────────────────────────────────────────────────
+
+describe("ProfileApplyManager — live materialize progress feed (WBS 4b2bc60f)", () => {
+  const original = Platform.isMobile;
+  afterEach(() => {
+    (Platform as unknown as { isMobile: boolean }).isMobile = original;
+  });
+
+  it("emits a 'mount' progress event with N-of-M BEFORE each mount (≥2 AS)", async () => {
+    // Materialised: floors only. Target: floors + ems + kpc ⇒ mount 2 AS.
+    const { mgr, restMount, progressEvents } = setup({
+      targetIncludes: [...FLOOR_UIDS, "ems-uid", "kpc-uid"],
+      materialized: FLOOR_UIDS,
+    });
+
+    await mgr.applyProfile("target");
+
+    // Both AS mounted…
+    expect(restMount.mounted.sort()).toEqual(
+      ["assetspaces/kitelev/exoas-ems", "assetspaces/kitelev/exoas-kpc"].sort(),
+    );
+    // …and a mount progress event fired for EACH, with 1-based N-of-M.
+    const mountProgress = progressEvents.filter((e) => e.op === "mount");
+    expect(mountProgress.length).toBe(2);
+    expect(mountProgress.map((e) => `${e.index}/${e.total}`)).toEqual([
+      "1/2",
+      "2/2",
+    ]);
+    // Labels are meaningful (namespace from the AS descriptor), not empty.
+    expect(mountProgress.map((e) => e.label).sort()).toEqual([
+      "exoas-ems",
+      "exoas-kpc",
+    ]);
+    expect(mountProgress.every((e) => e.label.length > 0)).toBe(true);
+  });
+
+  it("emits an 'unmount' progress event with N-of-M BEFORE each unmount (≥2 AS)", async () => {
+    // Materialised: floors + ems + kpc. Target: floors only ⇒ unmount 2 AS.
+    const { mgr, restMount, progressEvents } = setup({
+      targetIncludes: FLOOR_UIDS,
+      materialized: [...FLOOR_UIDS, "ems-uid", "kpc-uid"],
+    });
+
+    await mgr.applyProfile("target");
+
+    expect(restMount.unmounted.length).toBe(2);
+    const unmountProgress = progressEvents.filter((e) => e.op === "unmount");
+    expect(unmountProgress.length).toBe(2);
+    expect(unmountProgress.map((e) => `${e.index}/${e.total}`)).toEqual([
+      "1/2",
+      "2/2",
+    ]);
+  });
+
+  it("each progress event PRECEDES the op it announces (live, not post-fact)", async () => {
+    const { mgr, trace } = setup({
+      targetIncludes: [...FLOOR_UIDS, "ems-uid", "kpc-uid"],
+      materialized: FLOOR_UIDS,
+    });
+
+    await mgr.applyProfile("target");
+
+    // Trace interleaves progress + mount markers. For each mount marker there
+    // must be a preceding progress marker (the announce precedes the work).
+    const firstMount = trace.findIndex((t) => t.startsWith("mount:"));
+    const firstProgress = trace.findIndex((t) => t.startsWith("progress:mount"));
+    expect(firstProgress).toBeGreaterThanOrEqual(0);
+    expect(firstProgress).toBeLessThan(firstMount);
+    // Exactly one progress marker per mount marker, alternating progress→mount.
+    const markers = trace.filter(
+      (t) => t.startsWith("progress:mount") || t.startsWith("mount:"),
+    );
+    expect(markers).toEqual([
+      "progress:mount:1/2",
+      "mount:assetspaces/kitelev/exoas-ems",
+      "progress:mount:2/2",
+      "mount:assetspaces/kitelev/exoas-kpc",
+    ]);
+  });
+
+  it("progress is activity-log-only — NEVER toasted (notify gets only the summary)", async () => {
+    const { mgr, notifyCalls, progressEvents } = setup({
+      targetIncludes: [...FLOOR_UIDS, "ems-uid", "kpc-uid"],
+      materialized: FLOOR_UIDS,
+    });
+
+    await mgr.applyProfile("target");
+
+    // Progress DID happen (2 mounts) …
+    expect(progressEvents.filter((e) => e.op === "mount").length).toBe(2);
+    // … but the only toast is the single final reconciliation summary — no
+    // per-AssetSpace "Mounting … (N of M)" line ever reaches notify().
+    expect(notifyCalls.length).toBe(1);
+    expect(notifyCalls[0]).toContain("mounted");
+    expect(notifyCalls.some((m) => /\bof\b/.test(m) && /Mounting|Unmounting|Pulling/.test(m))).toBe(
+      false,
+    );
+  });
+
+  it("no progress events on a no-op apply (mount-state already matches)", async () => {
+    const { mgr, progressEvents, restMount } = setup({
+      targetIncludes: FLOOR_UIDS,
+      materialized: FLOOR_UIDS,
+    });
+
+    await mgr.applyProfile("target");
+
+    expect(restMount.mounted).toEqual([]);
+    expect(restMount.unmounted).toEqual([]);
+    expect(progressEvents).toEqual([]);
+  });
+
+  it("a throwing onProgress observer never breaks the apply (isolated)", async () => {
+    const { mgr, restMount } = setup({
+      targetIncludes: [...FLOOR_UIDS, "ems-uid"],
+      materialized: FLOOR_UIDS,
+      throwingProgress: true,
+    });
+    // The hostile observer throws on every emitProgress; emitProgress swallows
+    // it so the apply still completes and the mount still happens.
+    await expect(mgr.applyProfile("target")).resolves.toBeUndefined();
+    expect(restMount.mounted).toEqual(["assetspaces/kitelev/exoas-ems"]);
+  });
+});

--- a/packages/obsidian-plugin/tests/unit/adapters/logging/activityFanIn.test.ts
+++ b/packages/obsidian-plugin/tests/unit/adapters/logging/activityFanIn.test.ts
@@ -4,8 +4,14 @@
  * modal surfaces profile/mount events correctly hinges on this mapping.
  */
 import { describe, it, expect } from "@jest/globals";
-import { journalEntryToActivity } from "../../../../src/adapters/logging/activityFanIn";
-import type { SwitchJournalEntry } from "../../../../src/infrastructure/adapters/ProfileApplyManager";
+import {
+  journalEntryToActivity,
+  progressToActivity,
+} from "../../../../src/adapters/logging/activityFanIn";
+import type {
+  ApplyProgressEvent,
+  SwitchJournalEntry,
+} from "../../../../src/infrastructure/adapters/ProfileApplyManager";
 
 const base = { targetUid: "profile-xyz-uid", ts: "2026-06-15T00:00:00.000Z" };
 
@@ -103,5 +109,50 @@ describe("journalEntryToActivity", () => {
       // phase string should not leak raw unless intentionally unmapped
       expect(r.message).not.toBe(phase);
     }
+  });
+});
+
+describe("progressToActivity (live materialize progress feed)", () => {
+  const evt = (over: Partial<ApplyProgressEvent>): ApplyProgressEvent => ({
+    op: "mount",
+    as: "1b20a8f0-d745-4e93-91db-4531b3df120e",
+    label: "ems",
+    index: 1,
+    total: 3,
+    ...over,
+  });
+
+  it("mount → category 'progress', info level, 'Mounting <label> <prefix> (N of M)'", () => {
+    expect(progressToActivity(evt({ op: "mount", index: 2, total: 5 }))).toEqual(
+      {
+        category: "progress",
+        level: "info",
+        message: "Mounting ems 1b20a8f0 (2 of 5)",
+      },
+    );
+  });
+
+  it("unmount → 'Unmounting …'", () => {
+    expect(progressToActivity(evt({ op: "unmount", label: "kpc" })).message).toBe(
+      "Unmounting kpc 1b20a8f0 (1 of 3)",
+    );
+  });
+
+  it("pull → 'Pulling …'", () => {
+    expect(progressToActivity(evt({ op: "pull" })).message).toBe(
+      "Pulling ems 1b20a8f0 (1 of 3)",
+    );
+  });
+
+  it("progress is ALWAYS category 'progress' (never toasted — distinct from journal feed)", () => {
+    for (const op of ["pull", "mount", "unmount"] as const) {
+      expect(progressToActivity(evt({ op })).category).toBe("progress");
+    }
+  });
+
+  it("omits a redundant label when it equals the 8-char UID prefix", () => {
+    expect(
+      progressToActivity(evt({ label: "1b20a8f0", index: 1, total: 1 })).message,
+    ).toBe("Mounting 1b20a8f0 (1 of 1)");
   });
 });


### PR DESCRIPTION
## Что

Во время `profile-apply` materialize activity-log писал **только post-completion** сводку → долгий apply выглядел зависшим. Добавлен **живой per-AssetSpace progress-feed**: запись `Mounting X (2 of 5)` **ПЕРЕД** каждой операцией pull/mount/unmount → в модалке `Exocortex: Open activity log` видно, что apply идёт (WBS `4b2bc60f`).

## Как

- **`ProfileApplyManager`**: новый `ApplyProgressEvent` + опция `onProgress`. `emitProgress(...)` вызывается ПЕРЕД каждой per-AssetSpace операцией в **обеих** materialize-петлях:
  - **REST path** (production — desktop+mobile через #3567): mount-loop + unmount-loop.
  - **Desktop git path** (parity): pull / destroy / materialize loops.
  - Отличается от journal-feed: **НЕ персистится** (нет recovery-семантики → нулевой риск для crash-recovery) и **НЕ идёт через `notify`** (activity-log-only → не спамит toast'ами). Финальная сводка-toast остаётся.
- **`activityFanIn`**: mapper `progressToActivity` → `category:"progress"`, формат `Mounting <label> <prefix> (N of M)`.
- **`ActivityLogService`**: добавлена категория `progress` (модалка рендерит `[category]` как строку — purely additive, нет exhaustive switch).
- **`ExocortexPlugin`**: wired `onProgress → activityLog.record(progressToActivity(e))`.

## Тесты (TDD)

- **6 поведенческих** (`ProfileApplyManager.applyProgress.test.ts`, production REST path, ≥2 AS): mount-progress N-of-M ПЕРЕД каждым mount; unmount-progress N-of-M ПЕРЕД каждым unmount; ordering (progress предшествует op через shared-trace); **activity-log-only** (notify получает только финальную сводку, ни одной progress-строки); no-op apply → 0 progress; throwing observer не ломает apply (isolation).
- **5 mapper-тестов** (`activityFanIn.test.ts`): mount/unmount/pull verbs, всегда `category:"progress"`, redundant-label dedup.
- **Revert-verify ✓**: нейтрализация `emitProgress` → 4 теста падают (0 progress events); restore → pass.

## Verify

- typecheck (`tsc -noEmit`) ✓ · lint (src) ✓ · build + **mobile-loadable** + console-channel ✓ · **156** regression-тестов (все ProfileApplyManager + activity-log сьюты) + 144 (ExocortexPlugin/ProfileCommands) green · archgate 21/21.

DoD: `4b2bc60f-07cc-4a4f-9dec-b43a508fd55f`. Closes Alpha Launch W2 #4.