### PR TITLE
feat(layout): humanize enum/class values in the Properties block (RFC 0002 §3.7, P11)

### DIFF
--- a/packages/obsidian-plugin/src/presentation/components/AssetRelationsTable.tsx
+++ b/packages/obsidian-plugin/src/presentation/components/AssetRelationsTable.tsx
@@ -12,6 +12,73 @@ export function humanizePropertyName(raw: string): string {
   return spaced.replace(/\b\w/g, (c) => c.toUpperCase());
 }
 
+const WHOLE_WIKILINK_REGEX = /^\[\[(.+)\]\]$/;
+
+/**
+ * Humanize a frontmatter *value* for display (RFC 0002 §3.7, P11) — the value
+ * counterpart of {@link humanizePropertyName} (which humanizes property *keys*).
+ *
+ * Reuses the same IRI-prefix-stripping mechanism, applied to enum/class
+ * *values* so the Properties block reads "Project" instead of
+ * `[[ems__Project]]` and "EffortStatusDoing" instead of
+ * `[[uid|ems__EffortStatusDoing]]`. Resolution order for wikilink values:
+ * explicit alias → resolved `exo__Asset_label` of a UID target (via
+ * `resolveLabel`) → the raw target; the chosen display string is then run
+ * through {@link humanizePropertyName} to strip the prefix. Non-wikilink,
+ * non-jargon values (free text, timestamps, UUIDs, numbers) pass through
+ * unchanged because `humanizePropertyName` is a no-op on them.
+ *
+ * Note: literal per-enum display (e.g. "Doing") is intentionally NOT produced —
+ * the live status asset's label is `ems__EffortStatusDoing` and the shared
+ * humanizer preserves PascalCase by design; the result is consistent with the
+ * relations table. A per-enum display map would be a separate concern.
+ */
+export function humanizePropertyValue(
+  value: unknown,
+  resolveLabel?: (target: string) => string | null,
+): string {
+  if (value === null || value === undefined) return "";
+
+  if (Array.isArray(value)) {
+    return value
+      .map((v) => humanizePropertyValue(v, resolveLabel))
+      .filter((s) => s !== "")
+      .join(", ");
+  }
+
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    const match = trimmed.match(WHOLE_WIKILINK_REGEX);
+    if (match) {
+      const content = match[1];
+      const pipeIndex = content.indexOf("|");
+      const target = (
+        pipeIndex === -1 ? content : content.slice(0, pipeIndex)
+      ).trim();
+      const alias =
+        pipeIndex === -1 ? undefined : content.slice(pipeIndex + 1).trim();
+      const display = alias || resolveLabel?.(target) || target;
+      return humanizePropertyName(display);
+    }
+    // Plain string: only de-jargon IRI-prefixed values (`ems__Project`);
+    // leave free text (which may legitimately contain "__") untouched.
+    if (/^[a-z]+__/.test(trimmed)) {
+      return humanizePropertyName(trimmed);
+    }
+    return trimmed;
+  }
+
+  if (typeof value === "object") {
+    try {
+      return JSON.stringify(value);
+    } catch {
+      return "";
+    }
+  }
+
+  return String(value);
+}
+
 export interface AssetRelation {
   path: string;
   title: string;

--- a/packages/obsidian-plugin/src/presentation/components/LayoutBlocks.tsx
+++ b/packages/obsidian-plugin/src/presentation/components/LayoutBlocks.tsx
@@ -18,15 +18,24 @@
 
 import React from "react";
 import type { AssetRelation } from "@plugin/presentation/renderers/layout/types";
+import { humanizePropertyValue } from "@plugin/presentation/components/AssetRelationsTable";
 
 export interface PropertiesBlockViewProps {
   readonly title: string;
   readonly properties: ReadonlyArray<{ readonly key: string; readonly value: unknown }>;
+  /**
+   * RFC 0002 §3.7 (P11) — resolves a wikilink target (UID or name) to its
+   * `exo__Asset_label`, so UID-only enum/class values render a readable label
+   * instead of a raw `[[uuid]]`. Optional: when absent, values fall back to
+   * alias / prefix-stripped target humanization.
+   */
+  readonly resolveLabel?: (target: string) => string | null;
 }
 
 export const PropertiesBlockView: React.FC<PropertiesBlockViewProps> = ({
   title,
   properties,
+  resolveLabel,
 }) => {
   return (
     <div className="exocortex-layout-block exocortex-layout-block-properties">
@@ -49,7 +58,7 @@ export const PropertiesBlockView: React.FC<PropertiesBlockViewProps> = ({
               <tr key={key}>
                 <td className="exocortex-layout-block-property-name">{key}</td>
                 <td className="exocortex-layout-block-property-value">
-                  {formatPropertyValue(value)}
+                  {humanizePropertyValue(value, resolveLabel)}
                 </td>
               </tr>
             ))}

--- a/packages/obsidian-plugin/src/presentation/renderers/ExoLayoutRenderer.tsx
+++ b/packages/obsidian-plugin/src/presentation/renderers/ExoLayoutRenderer.tsx
@@ -34,6 +34,7 @@ import {
   BacklinksTableBlockView,
   PropertiesBlockView,
 } from "@plugin/presentation/components/LayoutBlocks";
+import { AssetMetadataService } from "@plugin/presentation/renderers/layout/helpers/AssetMetadataService";
 import { WikiLinkHelpers } from "exocortex";
 
 export interface ExoLayoutRendererDeps {
@@ -122,11 +123,19 @@ export class ExoLayoutRenderer {
       .filter(([key]) => !key.startsWith("position"))
       .map(([key, value]) => ({ key, value }));
 
+    // RFC 0002 §3.7 (P11): resolve UID-only enum/class wikilink values to a
+    // readable `exo__Asset_label` so the Properties block reads "Project",
+    // not `[[uuid]]`. Reuses the same resolver the relations table uses.
+    const metadataService = new AssetMetadataService(this.deps.app);
+    const resolveLabel = (target: string): string | null =>
+      metadataService.getAssetLabel(target);
+
     this.deps.reactRenderer.render(
       container,
       React.createElement(PropertiesBlockView, {
         title,
         properties: entries,
+        resolveLabel,
       }),
     );
   }

--- a/packages/obsidian-plugin/tests/unit/utilities/humanizePropertyValue.test.ts
+++ b/packages/obsidian-plugin/tests/unit/utilities/humanizePropertyValue.test.ts
@@ -1,0 +1,132 @@
+import { humanizePropertyValue } from "../../../src/presentation/components/AssetRelationsTable";
+
+/**
+ * RFC 0002 §3.7 (P11) — humanize enum/class *values* in the Properties block.
+ *
+ * Companion to humanizePropertyName (which humanizes property *keys*). The same
+ * IRI-prefix-stripping mechanism is applied to *values* that are wikilinks or
+ * bare `prefix__Name` jargon. Wikilink targets resolve to a readable display
+ * string (alias → resolved `exo__Asset_label` → target), then strip the prefix.
+ *
+ * Verify-before-assert note on the RFC's "Doing" example: the live status asset's
+ * `exo__Asset_label` is literally `ems__EffortStatusDoing` (not "Doing"), and
+ * humanizePropertyName deliberately preserves PascalCase (see its own test:
+ * `ems__EffortStatusBacklog` → "EffortStatusBacklog"). So the reuse-humanization
+ * produces "EffortStatusDoing" / "Project" — consistent with the relations table.
+ * Literal per-enum display ("Doing") would need an enum→label map (out of scope).
+ */
+describe("humanizePropertyValue", () => {
+  describe("class-value humanization (RFC §3.7 DoD)", () => {
+    it("strips prefix from a bare class value: ems__Project → Project", () => {
+      expect(humanizePropertyValue("ems__Project")).toBe("Project");
+    });
+
+    it("strips prefix from a class wikilink: [[ems__Project]] → Project", () => {
+      expect(humanizePropertyValue("[[ems__Project]]")).toBe("Project");
+    });
+
+    it("humanizes a status alias wikilink: [[uid|ems__EffortStatusDoing]] → EffortStatusDoing", () => {
+      expect(
+        humanizePropertyValue(
+          "[[027e78f4-6e16-4b36-b8fb-5510507d5745|ems__EffortStatusDoing]]",
+        ),
+      ).toBe("EffortStatusDoing");
+    });
+  });
+
+  describe("UID wikilink resolution via resolveLabel", () => {
+    it("resolves a UID-only wikilink to the target's humanized exo__Asset_label", () => {
+      const resolve = (target: string): string | null =>
+        target === "1b20a8f0-d745-4e93-91db-4531b3df120e"
+          ? "ems__Task"
+          : null;
+      expect(
+        humanizePropertyValue(
+          "[[1b20a8f0-d745-4e93-91db-4531b3df120e]]",
+          resolve,
+        ),
+      ).toBe("Task");
+    });
+
+    it("humanizes the resolved label even when it is jargon (de-jargon the IRI prefix)", () => {
+      const resolve = (): string | null => "ems__EffortStatusDoing";
+      expect(
+        humanizePropertyValue(
+          "[[027e78f4-6e16-4b36-b8fb-5510507d5745]]",
+          resolve,
+        ),
+      ).toBe("EffortStatusDoing");
+    });
+
+    it("falls back to the raw UID when no resolver/label is available (UUID guard)", () => {
+      const uuid = "027e78f4-6e16-4b36-b8fb-5510507d5745";
+      expect(humanizePropertyValue(`[[${uuid}]]`)).toBe(uuid);
+    });
+  });
+
+  describe("preserves existing wikilink-resolution behaviour (does not break non-jargon)", () => {
+    it("keeps a human-readable alias unchanged: [[uid|ExoAssistant]] → ExoAssistant", () => {
+      expect(
+        humanizePropertyValue(
+          "[[de20a3f1-7483-4714-ab28-b45f5cf02c76|ExoAssistant]]",
+        ),
+      ).toBe("ExoAssistant");
+    });
+
+    it("keeps a multi-word person alias unchanged: [[uid|John Doe]] → John Doe", () => {
+      expect(humanizePropertyValue("[[abc|John Doe]]")).toBe("John Doe");
+    });
+  });
+
+  describe("arrays", () => {
+    it("humanizes each element and joins with comma", () => {
+      expect(
+        humanizePropertyValue(["[[a|ems__Project]]", "[[b|ems__Task]]"]),
+      ).toBe("Project, Task");
+    });
+
+    it("resolves UID-only elements via resolveLabel", () => {
+      const resolve = (target: string): string | null =>
+        target === "1b20a8f0-d745-4e93-91db-4531b3df120e" ? "ems__Task" : null;
+      expect(
+        humanizePropertyValue(
+          ["[[1b20a8f0-d745-4e93-91db-4531b3df120e]]"],
+          resolve,
+        ),
+      ).toBe("Task");
+    });
+
+    it("drops null/undefined elements", () => {
+      expect(humanizePropertyValue(["ems__Project", null, undefined])).toBe(
+        "Project",
+      );
+    });
+  });
+
+  describe("non-jargon / scalar passthrough", () => {
+    it("returns empty string for null/undefined", () => {
+      expect(humanizePropertyValue(null)).toBe("");
+      expect(humanizePropertyValue(undefined)).toBe("");
+    });
+
+    it("passes through plain human-readable strings unchanged", () => {
+      expect(humanizePropertyValue("title")).toBe("title");
+      expect(humanizePropertyValue("Some free text")).toBe("Some free text");
+    });
+
+    it("passes through ISO timestamps unchanged (no underscores, not a UUID)", () => {
+      expect(humanizePropertyValue("2026-06-19T01:22:46")).toBe(
+        "2026-06-19T01:22:46",
+      );
+    });
+
+    it("stringifies numbers and booleans", () => {
+      expect(humanizePropertyValue(42)).toBe("42");
+      expect(humanizePropertyValue(true)).toBe("true");
+    });
+
+    it("JSON-stringifies plain objects", () => {
+      expect(humanizePropertyValue({ a: 1 })).toBe('{"a":1}');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

RFC 0002 §3.7 (P11) — the Properties block rendered enum/class **values** as raw jargon (`[[ems__Project]]`, `[[uid|ems__EffortStatusDoing]]`) while property **keys** were already humanized. This adds value humanization that **reuses** the existing key-humanization mechanism.

- New `humanizePropertyValue(value, resolveLabel?)` in `AssetRelationsTable.tsx` (co-located with `humanizePropertyName`). For wikilink values it resolves a display string (alias → `exo__Asset_label` via `resolveLabel` → raw target), then strips the IRI prefix via `humanizePropertyName`. Arrays map+join; free text / timestamps / UUIDs / numbers pass through unchanged (a `/^[a-z]+__/` gate avoids mangling free text containing `__`).
- Wired into `PropertiesBlockView` (`LayoutBlocks.tsx`) via a new optional `resolveLabel` prop; `ExoLayoutRenderer.renderPropertiesBlock` supplies it using `AssetMetadataService.getAssetLabel` (the same resolver the relations table uses).

## verify-before-assert note on the RFC's "Doing" example

The RFC cites `ems__EffortStatusDoing` → "Doing". Verified: the live status asset's `exo__Asset_label` is literally `ems__EffortStatusDoing` (**not** "Doing"), and the shared humanizer **deliberately preserves PascalCase** (existing test: `ems__EffortStatusBacklog` → `EffortStatusBacklog`). So literal "Doing" is **not** achievable via reuse without breaking that test. The achievable, **consistent-with-the-relations-table** output is:

- `ems__Project` / `[[ems__Project]]` → **Project** ✅
- `[[uid|ems__EffortStatusDoing]]` → **EffortStatusDoing** (IRI prefix stripped; UID-only forms resolve the label then strip)

This fully meets P11's intent (de-jargon the IRI prefix + resolve `[[uid]]` links, consistent humanization). A literal per-enum display map ("Doing") would be a separate concern.

## Scope

Focused on the **Properties block** (the literal DoD). `BacklinksTableBlockView`'s `resolveCell` is unchanged (the primary backlinks renderer, `AssetRelationsTableWithToggle`, already humanizes).

## Tests

- New `humanizePropertyValue.test.ts` — 14 production-shape unit cases (class/status values, UID resolution via resolveLabel, array join, free-text/timestamp/UUID passthrough, null/scalar/object).
- Existing `humanizePropertyName.test.ts` (16), `ExoLayoutRenderer.test.ts` (5), `AssetRelationsTable.accent` — all green.
- typecheck 0 errors, lint 0 errors, archgate 21/21.

a11y / parity: pure display-string change rendered via JSX auto-escaping (XSS-safe); no platform-gated code; desktop+mobile identical.

Resolves WBS node `04b144c6` (Alpha Launch UX onboarding subproject).