### PR TITLE
feat(onboarding): de-jargon Bootstrap dialog + durable result panel (RFC 0002 §3.3)

### DIFF
--- a/packages/obsidian-plugin/src/ExocortexPlugin.ts
+++ b/packages/obsidian-plugin/src/ExocortexPlugin.ts
@@ -134,6 +134,7 @@ import {
   type UnmountableAssetSpace,
 } from "./infrastructure/adapters/UnmountAssetSpaceCommand";
 import { BootstrapVaultModal } from "./presentation/modals/BootstrapVaultModal";
+import { BootstrapResultModal } from "./presentation/modals/BootstrapResultModal";
 import { AddAssetSpaceModal } from "./presentation/modals/AddAssetSpaceModal";
 import { SimpleConfirmModal } from "./presentation/modals/SimpleConfirmModal";
 import { FirstRunOnboardingModal } from "./presentation/modals/FirstRunOnboardingModal";
@@ -3553,6 +3554,17 @@ export default class ExocortexPlugin extends Plugin {
       // #3540 follow-up — `notifier.info` now fans every toast into the
       // activity log itself (category "notice"), so no manual record() here.
       notify: (message) => this.notifier.info(message),
+      // Durable, in-context result panel (RFC 0002 §3.3, resolves P5) — opens
+      // ON TOP of the (transient) toast + (always-on) activity-log entry, so the
+      // user can read "what happened + what next" after the toast fades. The
+      // next-step nudge routes to the same Add-AssetSpace flow the onboarding
+      // panel's step 2 uses, pre-filled with the public starter registry
+      // (`bootstrapCommands` is in scope by the time this closure runs).
+      showResult: (result) =>
+        new BootstrapResultModal(this.app, result, {
+          onAddStarterContent: () =>
+            void bootstrapCommands.invokeAddAssetSpace(STARTER_REGISTRY_URL),
+        }).open(),
       onMaterialized: () => this.refreshAndInjectAssetSpaceMaterialization(),
     });
 

--- a/packages/obsidian-plugin/src/infrastructure/adapters/BootstrapAssetSpaceCommands.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/BootstrapAssetSpaceCommands.ts
@@ -121,6 +121,21 @@ export interface MaterializeResult {
   sha: string;
 }
 
+/**
+ * Terminal bootstrap outcome reported to the durable result panel (RFC 0002
+ * §3.3, resolves P5). Emitted via {@link BootstrapAssetSpaceCommandsDeps.showResult}
+ * IN ADDITION TO the existing transient toast + activity-log entry — this adds a
+ * persistent, in-context "what happened + what to do next" surface, it does not
+ * replace the (already firing) feedback.
+ *
+ * Only the three outcomes with a meaningful "next step" are reported; hard
+ * failures / cancels are NOT (the toast covers them; error-recovery is P15).
+ */
+export type BootstrapResultInfo =
+  | { kind: "bootstrapped"; folderName: string; sha: string }
+  | { kind: "fetched"; fetched: number; total: number }
+  | { kind: "already-bootstrapped" };
+
 export interface BootstrapAssetSpaceCommandsDeps {
   /**
    * Lazily resolve the REST tarball puller. Invoked once per materialise (i.e.
@@ -184,6 +199,16 @@ export interface BootstrapAssetSpaceCommandsDeps {
   /** User-facing Notice. */
   notify: (message: string) => void;
   /**
+   * Optional durable, in-context result panel (RFC 0002 §3.3, resolves P5).
+   * Called on the three terminal bootstrap outcomes that have a meaningful
+   * "what next" ({@link BootstrapResultInfo}) IN ADDITION TO `notify` — the
+   * toast still fires; this adds a persistent surface the user can read after it
+   * fades. Optional + best-effort: the plugin wires it to open a
+   * `BootstrapResultModal`; when omitted (or it throws) the command still
+   * completes normally.
+   */
+  showResult?: (result: BootstrapResultInfo) => void;
+  /**
    * Optional hook fired after a successful materialisation so the plugin can
    * re-index the freshly added assets. Failures are swallowed (best-effort).
    */
@@ -240,6 +265,10 @@ export class BootstrapAssetSpaceCommands {
       this.d.notify(
         "Vault already has AssetSpaces materialised — use «Exocortex: Add AssetSpace by URL» to add more.",
       );
+      // Durable result (RFC 0002 §3.3 / P5): the already-bootstrapped guard
+      // surfaces a persistent "what happened + what next" panel, not just a
+      // transient toast.
+      this.emitResult({ kind: "already-bootstrapped" });
       return;
     }
 
@@ -286,6 +315,13 @@ export class BootstrapAssetSpaceCommands {
         `Bootstrap complete — ${exo.folderName}@${exo.sha}. ` +
           "Reload Obsidian if the new assets do not appear. Add exocmd (UI commands) or any further AssetSpaces later via «Add assetspace by URL», or by applying a profile — dependencies are not auto-resolved.",
       );
+      // Durable result + next-step nudge (RFC 0002 §3.3 / P5) — survives the
+      // transient toast. Only on success (hard failure below keeps the toast).
+      this.emitResult({
+        kind: "bootstrapped",
+        folderName: exo.folderName,
+        sha: exo.sha,
+      });
     } catch (e) {
       this.d.notify(`Bootstrap failed: ${this.msg(e)}`);
     }
@@ -393,7 +429,13 @@ export class BootstrapAssetSpaceCommands {
     this.d.notify(
       `Fetched ${fetched}/${entries.length} AssetSpace(s) from recorded URLs.`,
     );
-    if (fetched > 0) await this.runOnMaterialized();
+    if (fetched > 0) {
+      // Durable result for the EC2 restore path (RFC 0002 §3.3 / P5) — fire only
+      // when something was actually restored (an all-failed fetch is an error
+      // surfaced per-entry, not a "what next" success).
+      this.emitResult({ kind: "fetched", fetched, total: entries.length });
+      await this.runOnMaterialized();
+    }
   }
 
   /**
@@ -516,6 +558,21 @@ export class BootstrapAssetSpaceCommands {
       await this.d.onMaterialized();
     } catch {
       // Best-effort re-index; failure must not surface as a bootstrap error.
+    }
+  }
+
+  /**
+   * Surface a durable result panel (RFC 0002 §3.3 / P5). Best-effort — when no
+   * `showResult` is wired (CLI / tests that don't need it) or it throws, the
+   * command still completes; the toast already carried the feedback.
+   */
+  private emitResult(result: BootstrapResultInfo): void {
+    if (this.d.showResult === undefined) return;
+    try {
+      this.d.showResult(result);
+    } catch {
+      // The durable panel is additive; a render failure must not surface as a
+      // bootstrap error (the toast + activity log already recorded the outcome).
     }
   }
 

--- a/packages/obsidian-plugin/src/presentation/modals/BootstrapResultModal.ts
+++ b/packages/obsidian-plugin/src/presentation/modals/BootstrapResultModal.ts
@@ -1,0 +1,170 @@
+import { App, Modal } from "obsidian";
+import type { BootstrapResultInfo } from "../../infrastructure/adapters/BootstrapAssetSpaceCommands";
+
+/**
+ * Action callbacks for the durable bootstrap-result panel. The panel owns no
+ * business logic — its single forward action fires the injected callback, which
+ * the plugin wires to the Add-AssetSpace flow pre-filled with the starter
+ * registry (RFC 0002 §3.3 next-step nudge → §3.1 step 2).
+ */
+export interface BootstrapResultModalActions {
+  /**
+   * Next-step nudge — open «Add AssetSpace by URL» pre-filled with the public
+   * starter-registry URL so the user can pull the starter content right away.
+   * The user still reviews + confirms in that modal.
+   */
+  onAddStarterContent: () => void;
+}
+
+/**
+ * BootstrapResultModal — the **durable, in-context** bootstrap result panel
+ * (RFC 0002 §3.3, resolves P5).
+ *
+ * The bootstrap flow already fires an unconditional toast (`notifier.info` →
+ * `new Notice`) plus an always-on activity-log entry, so feedback is NOT
+ * missing. The residual UX gap (P5, rev-2-corrected) is that the toast is
+ * **transient (~4-5 s)** and easy to miss mid-action, and the activity log is a
+ * surface a first-run user won't think to open. This panel adds **durability**:
+ * a persistent result the user can read after the toast fades, stating what
+ * happened **and what to do next** — so the action dead-ends nowhere.
+ *
+ * It fires on the three terminal bootstrap outcomes that have a meaningful
+ * "what next" (driven by {@link BootstrapResultInfo}):
+ *   - `bootstrapped` — a cold bootstrap materialised the engine floor.
+ *   - `fetched` — the EC2 clone-needs-fetch path restored tracked AssetSpaces.
+ *   - `already-bootstrapped` — the guard fired on an already-set-up vault.
+ *
+ * It deliberately does NOT fire on hard failures / cancels — those are surfaced
+ * by the toast, and a "next step" nudge would be wrong there (error-recovery is
+ * P15, a separate scope).
+ *
+ * ## Accessibility (P16, §3.11)
+ * - Native `<button>`s (keyboard-navigable, Enter/Space activation) with explicit
+ *   `aria-label`s.
+ * - Managed focus: the forward action (the most likely next move) is focused on
+ *   open, guarded for jsdom / headless contexts.
+ * - No icon/emoji-only signalling — every cue is plain text.
+ */
+export class BootstrapResultModal extends Modal {
+  private readonly result: BootstrapResultInfo;
+  private readonly actions: BootstrapResultModalActions;
+  private firstFocusable: HTMLElement | null = null;
+
+  constructor(
+    app: App,
+    result: BootstrapResultInfo,
+    actions: BootstrapResultModalActions,
+  ) {
+    super(app);
+    this.result = result;
+    this.actions = actions;
+  }
+
+  override onOpen(): void {
+    const { contentEl } = this;
+    contentEl.addClass("bootstrap-result");
+
+    const copy = resultCopy(this.result);
+
+    contentEl.createEl("h2", {
+      cls: "bootstrap-result-title",
+      text: copy.title,
+    });
+
+    // The durable "what happened" line — survives the toast fade.
+    contentEl.createEl("p", {
+      cls: "bootstrap-result-summary",
+      text: copy.summary,
+    });
+
+    // The "what to do next" nudge + a one-click forward action.
+    contentEl.createEl("p", {
+      cls: "bootstrap-result-next",
+      text: copy.nextHint,
+    });
+
+    const actions = contentEl.createEl("div", {
+      cls: "modal-button-container bootstrap-result-actions",
+    });
+
+    const nextBtn = actions.createEl("button", {
+      cls: "mod-cta bootstrap-result-next-action",
+      text: "Add the starter content",
+    });
+    nextBtn.setAttribute(
+      "aria-label",
+      "Add the starter content (opens a dialog pre-filled with the recommended starter registry)",
+    );
+    nextBtn.addEventListener("click", () => {
+      // Close the panel first, then hand off — the Add-AssetSpace modal stacks
+      // cleanly on its own rather than under a now-stale result panel.
+      this.close();
+      this.actions.onAddStarterContent();
+    });
+    this.firstFocusable = nextBtn;
+
+    const doneBtn = actions.createEl("button", {
+      cls: "bootstrap-result-done",
+      text: "Done",
+    });
+    doneBtn.setAttribute("aria-label", "Close the setup result");
+    doneBtn.addEventListener("click", () => this.close());
+
+    // Managed focus (P16) — land on the forward action. Guarded: jsdom /
+    // headless contexts may lack focus support.
+    try {
+      this.firstFocusable?.focus();
+    } catch {
+      /* focus is best-effort */
+    }
+  }
+
+  override onClose(): void {
+    this.contentEl.empty();
+  }
+}
+
+interface ResultCopy {
+  title: string;
+  summary: string;
+  nextHint: string;
+}
+
+/**
+ * Map a {@link BootstrapResultInfo} to durable, plain-language panel copy. Pure
+ * (no DOM / Obsidian) so the per-outcome wording is unit-testable in isolation.
+ */
+export function resultCopy(result: BootstrapResultInfo): ResultCopy {
+  switch (result.kind) {
+    case "bootstrapped":
+      return {
+        title: "Engine ready",
+        summary:
+          `The engine floor landed — ${result.folderName} @ ${result.sha}. ` +
+          "Reload Obsidian if the new assets do not appear yet.",
+        nextHint:
+          "Next: add the starter content — a ready-to-use Areas → Projects → " +
+          "Tasks structure.",
+      };
+    case "fetched":
+      return {
+        title: "Content restored",
+        summary:
+          `Restored ${result.fetched} of ${result.total} tracked AssetSpace(s) ` +
+          "from their recorded URLs.",
+        nextHint:
+          "Next: add the starter content, or apply a profile to mount what you " +
+          "need.",
+      };
+    case "already-bootstrapped":
+      return {
+        title: "Vault already set up",
+        summary:
+          "This vault already has AssetSpaces materialised — there is nothing " +
+          "to bootstrap.",
+        nextHint:
+          "Next: add the starter content, or use «Add AssetSpace by URL» to " +
+          "pull another AssetSpace.",
+      };
+  }
+}

--- a/packages/obsidian-plugin/src/presentation/modals/BootstrapVaultModal.ts
+++ b/packages/obsidian-plugin/src/presentation/modals/BootstrapVaultModal.ts
@@ -5,6 +5,19 @@ export interface BootstrapVaultUrls {
 }
 
 /**
+ * The public exo *engine floor* repository, surfaced as the field's placeholder
+ * example AND linked from the inline explainer (RFC 0002 §3.3 — "a link to the
+ * floor repo"). Single source so the placeholder and the link never drift.
+ *
+ * EC7 note: this is a LINK + a greyed-out placeholder example, NOT a pre-fill.
+ * The field starts empty (the `kitelev/exoas-*` repos materialise a specific
+ * ontology and are not auto-filled as a generic default — see EC7 below); the
+ * link only lets a user *view / fork* the public floor before they decide what
+ * to enter.
+ */
+export const PUBLIC_EXO_FLOOR_URL = "https://github.com/kitelev/exoas-exo";
+
+/**
  * BootstrapVaultModal — input gate for the `Exocortex: Bootstrap vault` palette
  * command (RFC 13da049f Phase 6.2).
  *
@@ -56,24 +69,54 @@ export class BootstrapVaultModal extends Modal {
 
   override onOpen(): void {
     const { contentEl } = this;
+    contentEl.addClass("bootstrap-vault");
     contentEl.createEl("h2", {
       cls: "bootstrap-vault-title",
-      text: "Bootstrap vault",
+      text: "Set up the engine",
     });
+    // De-jargoned intro (RFC 0002 §3.3 / P6): plain language; drops the
+    // "SDK/engine floor" framing the old copy led with. The only term-of-art
+    // kept is the literal «Add AssetSpace by URL» command name (a pointer to a
+    // real command the user can run next), not an unexplained concept.
     contentEl.createEl("p", {
       text:
-        "Cold-start this empty vault with the foundational exo AssetSpace " +
-        "(the SDK/engine floor), pulled from a public GitHub repository. " +
-        "That is all a clean start needs — add any further AssetSpaces " +
-        "(such as the exocmd UI-command library) afterwards via «Add " +
-        "AssetSpace by URL», or by applying a profile.",
+        "Get this empty vault running by pulling the engine — the minimal " +
+        "foundation an Exocortex vault needs — from a GitHub repository. That " +
+        "is all a clean start needs; you can add more content afterwards from " +
+        "«Add AssetSpace by URL» or by applying a profile.",
     });
 
+    // Plain-language field label (was "exo ontology URL (required)" — jargon).
     this.exoInput = this.createUrlField(
       contentEl,
-      "exo ontology URL (required)",
-      "https://github.com/kitelev/exoas-exo",
+      "Engine repository URL (required)",
+      PUBLIC_EXO_FLOOR_URL,
     );
+
+    // Inline explainer + link to the floor repo (RFC 0002 §3.3): tells the user
+    // what the field wants and where to get a floor repo, without pre-filling it
+    // (EC7). The link is a native <a> with an explicit aria-label that states it
+    // leaves Obsidian (P16 a11y), and target=_blank paired with
+    // rel="noopener noreferrer" (no reverse-tabnabbing).
+    const explainer = contentEl.createEl("p", {
+      cls: "bootstrap-vault-explainer",
+    });
+    explainer.createEl("span", {
+      text:
+        "This is the engine floor — use the public floor repo, or your own " +
+        "fork. ",
+    });
+    explainer.createEl("a", {
+      cls: "bootstrap-vault-floor-link",
+      text: "View the public floor repo on GitHub",
+      href: PUBLIC_EXO_FLOOR_URL,
+      attr: {
+        target: "_blank",
+        rel: "noopener noreferrer",
+        "aria-label":
+          "View the public floor repository (opens GitHub in your browser)",
+      },
+    });
 
     contentEl.createEl("p", {
       cls: "bootstrap-vault-note",
@@ -114,6 +157,9 @@ export class BootstrapVaultModal extends Modal {
       type: "text",
       placeholder,
       cls: "bootstrap-vault-input bootstrap-modal-input",
+      // Screen-reader label mirrors the visible <label> so the field is named
+      // even out of visual context (P16 a11y).
+      attr: { "aria-label": label },
     });
     return input;
   }

--- a/packages/obsidian-plugin/styles.css
+++ b/packages/obsidian-plugin/styles.css
@@ -6147,6 +6147,32 @@
   display: block;
 }
 
+/* RFC 0002 §3.3 — Bootstrap dialog de-jargon: inline floor-field explainer + link. */
+.bootstrap-vault-explainer {
+  color: var(--text-muted, #6e7681);
+  font-size: var(--font-ui-smaller, 0.8em);
+  margin: 0.25em 0 0.6em;
+}
+
+.bootstrap-vault-floor-link {
+  font-weight: var(--font-semibold, 600);
+}
+
+/* RFC 0002 §3.3 — durable, in-context bootstrap result panel (P5). */
+.bootstrap-result-summary {
+  margin: 0.5em 0;
+}
+
+.bootstrap-result-next {
+  color: var(--text-muted, #6e7681);
+  font-size: var(--font-ui-smaller, 0.8em);
+  margin: 0 0 0.75em;
+}
+
+.bootstrap-result-next-action {
+  margin-right: 0.5em;
+}
+
 /* RFC 0002 §3.1 — first-run onboarding panel (3-step starter checklist). */
 .exocortex-onboarding-intro {
   color: var(--text-muted, #6e7681);

--- a/packages/obsidian-plugin/tests/e2e/eka/eka-obsidian-leg.spec.ts
+++ b/packages/obsidian-plugin/tests/e2e/eka/eka-obsidian-leg.spec.ts
@@ -485,6 +485,16 @@ test.describe("EKA Obsidian leg — bootstrap → add → apply-profile → crea
     const gm1 = readGitmodules(vaultPath);
     expect(gm1).toContain("exoas-exo");
 
+    // Bootstrap success now opens a durable result panel (RFC 0002 §3.3 / P5).
+    // Dismiss it before Step 2 so its overlay doesn't intercept the next
+    // command's modal (Esc, mirroring the profile-picker dismissal below).
+    await window
+      .locator(".bootstrap-result")
+      .first()
+      .waitFor({ state: "visible", timeout: 15000 })
+      .catch(() => undefined);
+    await window.keyboard.press("Escape");
+
     // ---- Step 2: Add assetspace — exocmd, registry, then profiles ----
     // exocmd is no longer a bootstrap floor field; the user adds it explicitly
     // here (the «либо явно командой add-assetspace» path of the 2026-06-20

--- a/packages/obsidian-plugin/tests/unit/infrastructure/adapters/BootstrapAssetSpaceCommands.test.ts
+++ b/packages/obsidian-plugin/tests/unit/infrastructure/adapters/BootstrapAssetSpaceCommands.test.ts
@@ -1,6 +1,7 @@
 import {
   BootstrapAssetSpaceCommands,
   type BootstrapAssetSpaceCommandsDeps,
+  type BootstrapResultInfo,
   type IAssetSpacePuller,
   type IGitSubmoduleOps,
   type IFileOnlyAssetSpaceStore,
@@ -26,6 +27,8 @@ interface Harness {
    * empty after a successful materialise WITHOUT a reload.
    */
   activeStagingDirs: string[];
+  /** Durable result panel emissions (RFC 0002 §3.3 / P5). */
+  results: BootstrapResultInfo[];
   deps: BootstrapAssetSpaceCommandsDeps;
 }
 
@@ -94,6 +97,8 @@ function makeHarness(opts: {
     return repo.startsWith("exoas-") ? repo.slice("exoas-".length) : repo;
   };
 
+  const results: BootstrapResultInfo[] = [];
+
   const deps: BootstrapAssetSpaceCommandsDeps = {
     getPuller: async () => puller,
     gitOps,
@@ -117,6 +122,7 @@ function makeHarness(opts: {
     ),
     confirm: jest.fn(async () => opts.confirm ?? true),
     notify: (m: string) => notices.push(m),
+    showResult: (r: BootstrapResultInfo) => results.push(r),
   };
 
   const vaultFolders = new Map<
@@ -132,6 +138,7 @@ function makeHarness(opts: {
     vaultFiles: new Set<string>(),
     vaultFolders,
     activeStagingDirs,
+    results,
     deps,
   };
 }
@@ -303,6 +310,72 @@ describe("BootstrapAssetSpaceCommands.invokeBootstrap — guards", () => {
     );
     // Exo-only: the single exo pull was attempted and failed — nothing else.
     expect(h.puller.pullAssetSpace).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("BootstrapAssetSpaceCommands — durable result panel (RFC 0002 §3.3 / P5)", () => {
+  // The durable panel fires ON TOP of the toast — `notify` still carries the
+  // message (asserted elsewhere); these assert the ADDITIONAL `showResult`
+  // emission. Revert-verify: deleting each `this.emitResult(...)` call in
+  // `BootstrapAssetSpaceCommands` makes the matching assertion below FAIL.
+  it("cold bootstrap success → emits a `bootstrapped` result with folder + sha", async () => {
+    const h = makeHarness({ isGitVault: true });
+    await h.cmds.invokeBootstrap();
+    expect(h.results).toEqual([
+      {
+        kind: "bootstrapped",
+        folderName: "assetspaces/kitelev/exoas-exo",
+        sha: "abc1234",
+      },
+    ]);
+  });
+
+  it("already-bootstrapped guard → emits an `already-bootstrapped` result", async () => {
+    const h = makeHarness({ materializedFolders: { exo: ["a.md"] } });
+    await h.cmds.invokeBootstrap();
+    expect(h.results).toEqual([{ kind: "already-bootstrapped" }]);
+  });
+
+  it("EC2 fetch (>0 restored) → emits a `fetched` result with the count", async () => {
+    const h = makeHarness({
+      gitmodulesEntries: [
+        { submodulePath: "assetspaces/exo", url: EXO_URL },
+        { submodulePath: "assetspaces/exocmd", url: EXOCMD_URL },
+      ],
+      materializedFolders: {},
+      confirm: true,
+    });
+    await h.cmds.invokeBootstrap();
+    expect(h.results).toEqual([{ kind: "fetched", fetched: 2, total: 2 }]);
+  });
+
+  it("hard failure / cancel / invalid URL → NO durable result (toast only)", async () => {
+    // Bootstrap pull failure.
+    const fail = makeHarness({ isGitVault: true });
+    fail.puller.pullAssetSpace.mockRejectedValueOnce(new Error("network down"));
+    await fail.cmds.invokeBootstrap();
+    expect(fail.results).toEqual([]);
+
+    // User cancelled the URL prompt.
+    const cancel = makeHarness({ bootstrapUrls: null });
+    await cancel.cmds.invokeBootstrap();
+    expect(cancel.results).toEqual([]);
+
+    // Invalid URL.
+    const invalid = makeHarness({
+      bootstrapUrls: { exoUrl: "http://evil.example/x" },
+    });
+    await invalid.cmds.invokeBootstrap();
+    expect(invalid.results).toEqual([]);
+  });
+
+  it("showResult absent → command still completes (best-effort, optional dep)", async () => {
+    const h = makeHarness({ isGitVault: true });
+    // Drop the optional dep entirely — mirrors a wiring that doesn't surface a panel.
+    delete (h.deps as { showResult?: unknown }).showResult;
+    const cmds = new BootstrapAssetSpaceCommands(h.deps);
+    await expect(cmds.invokeBootstrap()).resolves.toBeUndefined();
+    expect(h.notices.some((n) => /Bootstrap complete/.test(n))).toBe(true);
   });
 });
 

--- a/packages/obsidian-plugin/tests/unit/presentation/modals/BootstrapModals.test.ts
+++ b/packages/obsidian-plugin/tests/unit/presentation/modals/BootstrapModals.test.ts
@@ -15,6 +15,8 @@ jest.mock("obsidian", () => {
     text?: string;
     type?: string;
     placeholder?: string;
+    href?: string;
+    attr?: Record<string, string>;
   }
   function augment(el: HTMLElement): void {
     (el as unknown as { createEl: (tag: string, o?: CreateOpts) => HTMLElement }).createEl =
@@ -24,13 +26,27 @@ jest.mock("obsidian", () => {
         if (o?.text) child.textContent = o.text;
         if (o?.type) child.setAttribute("type", o.type);
         if (o?.placeholder) child.setAttribute("placeholder", o.placeholder);
+        // Mirror Obsidian's createEl `href` + `attr` support so links and
+        // aria-labels are queryable (RFC 0002 §3.3 floor-link + a11y).
+        if (o?.href) child.setAttribute("href", o.href);
+        if (o?.attr) {
+          for (const [k, v] of Object.entries(o.attr)) {
+            child.setAttribute(k, v);
+          }
+        }
         this.appendChild(child);
         augment(child);
         return child;
       }.bind(el);
-    // Obsidian augments HTMLElement with `.empty()`; mirror it for onClose.
+    // Obsidian augments HTMLElement with `.empty()` and `.addClass()`; mirror
+    // them for onOpen/onClose.
     (el as unknown as { empty: () => void }).empty = function (): void {
       while (this.firstChild) this.removeChild(this.firstChild);
+    }.bind(el);
+    (el as unknown as { addClass: (c: string) => void }).addClass = function (
+      c: string,
+    ): void {
+      this.classList.add(c);
     }.bind(el);
   }
   class MockModal {
@@ -61,7 +77,13 @@ import type { App } from "obsidian";
 import {
   BootstrapVaultModal,
   isLikelyGitHubUrl,
+  PUBLIC_EXO_FLOOR_URL,
 } from "../../../../src/presentation/modals/BootstrapVaultModal";
+import {
+  BootstrapResultModal,
+  resultCopy,
+} from "../../../../src/presentation/modals/BootstrapResultModal";
+import type { BootstrapResultInfo } from "../../../../src/infrastructure/adapters/BootstrapAssetSpaceCommands";
 import { AddAssetSpaceModal } from "../../../../src/presentation/modals/AddAssetSpaceModal";
 import { SimpleConfirmModal } from "../../../../src/presentation/modals/SimpleConfirmModal";
 
@@ -121,6 +143,51 @@ describe("BootstrapVaultModal", () => {
     );
   });
 
+  // RFC 0002 §3.3 / P6 — de-jargon the floor-field copy. The old jargon
+  // ("exo ontology URL", "SDK/engine floor") must be gone, replaced with plain
+  // language. Revert-verify: restoring the "exo ontology URL" label / "SDK"
+  // intro makes these assertions FAIL.
+  it("de-jargon — plain-language label + intro, no «SDK» / «ontology URL» jargon", () => {
+    new BootstrapVaultModal(fakeApp, () => undefined).open();
+    const text = document.body.textContent ?? "";
+    // Plain-language field label replaces the jargon "exo ontology URL".
+    expect(text).toMatch(/Engine repository URL \(required\)/);
+    expect(text).not.toMatch(/ontology URL/i);
+    expect(text).not.toMatch(/SDK/);
+  });
+
+  // RFC 0002 §3.3 — inline explainer + a link to the floor repo guide the user
+  // on what to enter and where to get a floor, WITHOUT pre-filling (EC7).
+  it("inline explainer + floor-repo link present, field still empty (EC7)", () => {
+    new BootstrapVaultModal(fakeApp, () => undefined).open();
+    // Explainer text guides the floor field in plain language.
+    expect(document.body.textContent).toMatch(/engine floor/i);
+    expect(document.body.textContent).toMatch(/public floor repo/i);
+    // A real, focusable link to the floor repo (not a pre-fill).
+    const link = document.querySelector(
+      "a.bootstrap-vault-floor-link",
+    ) as HTMLAnchorElement | null;
+    expect(link).not.toBeNull();
+    expect(link!.getAttribute("href")).toBe(PUBLIC_EXO_FLOOR_URL);
+    // Opens GitHub safely (no reverse-tabnabbing) + screen-reader labelled (P16).
+    expect(link!.getAttribute("rel")).toBe("noopener noreferrer");
+    expect(link!.getAttribute("target")).toBe("_blank");
+    expect(link!.getAttribute("aria-label")).toMatch(/opens GitHub/i);
+    // EC7 — the link/placeholder are pointers; the field itself is NOT pre-filled.
+    const input = document.querySelector("input") as HTMLInputElement;
+    expect(input.value).toBe("");
+  });
+
+  // P16 a11y — the URL field carries a screen-reader label matching its visible
+  // <label>, so it is named out of visual context.
+  it("a11y — the URL input has an aria-label", () => {
+    new BootstrapVaultModal(fakeApp, () => undefined).open();
+    const input = document.querySelector("input") as HTMLInputElement;
+    expect(input.getAttribute("aria-label")).toBe(
+      "Engine repository URL (required)",
+    );
+  });
+
   it("empty field → Bootstrap shows error, does not settle", () => {
     let result: unknown = "sentinel";
     new BootstrapVaultModal(fakeApp, (r) => {
@@ -160,6 +227,120 @@ describe("BootstrapVaultModal", () => {
     }).open();
     findButton("Cancel")!.click();
     expect(result).toBeNull();
+  });
+});
+
+// RFC 0002 §3.3 / P5 — the durable, in-context bootstrap result panel. Adds a
+// persistent surface ON TOP of the (already-firing) toast + activity log, with a
+// next-step nudge. Revert-verify: removing the panel's next-step button (or its
+// `onAddStarterContent` wiring) makes the next-step assertions FAIL.
+describe("BootstrapResultModal", () => {
+  const BOOTSTRAPPED: BootstrapResultInfo = {
+    kind: "bootstrapped",
+    folderName: "assetspaces/kitelev/exoas-exo",
+    sha: "abc1234",
+  };
+
+  it("bootstrapped — durable summary states what landed + a next-step nudge", () => {
+    new BootstrapResultModal(fakeApp, BOOTSTRAPPED, {
+      onAddStarterContent: () => undefined,
+    }).open();
+    const text = document.body.textContent ?? "";
+    // Durable "what happened" — folder + sha survive the toast fade.
+    expect(text).toMatch(/assetspaces\/kitelev\/exoas-exo/);
+    expect(text).toMatch(/abc1234/);
+    // "What next" nudge points at the starter content.
+    expect(text).toMatch(/Next:/);
+    expect(text).toMatch(/starter content/i);
+  });
+
+  it("next-step button fires onAddStarterContent and closes the panel", () => {
+    let nextCalls = 0;
+    new BootstrapResultModal(fakeApp, BOOTSTRAPPED, {
+      onAddStarterContent: () => {
+        nextCalls++;
+      },
+    }).open();
+    findButton("Add the starter content")!.click();
+    expect(nextCalls).toBe(1);
+    // Panel closed (handed off to the Add-AssetSpace flow) — content torn down.
+    expect(document.querySelector(".bootstrap-result-title")).toBeNull();
+  });
+
+  it("Done button closes without firing the next step", () => {
+    let nextCalls = 0;
+    new BootstrapResultModal(fakeApp, BOOTSTRAPPED, {
+      onAddStarterContent: () => {
+        nextCalls++;
+      },
+    }).open();
+    findButton("Done")!.click();
+    expect(nextCalls).toBe(0);
+    expect(document.querySelector(".bootstrap-result-title")).toBeNull();
+  });
+
+  it("already-bootstrapped — durable «already set up» result + next-step nudge", () => {
+    new BootstrapResultModal(
+      fakeApp,
+      { kind: "already-bootstrapped" },
+      { onAddStarterContent: () => undefined },
+    ).open();
+    const text = document.body.textContent ?? "";
+    expect(text).toMatch(/already/i);
+    expect(text).toMatch(/Next:/);
+    // The forward action is still offered.
+    expect(findButton("Add the starter content")).toBeDefined();
+  });
+
+  it("fetched — durable restore summary with the count + next-step nudge", () => {
+    new BootstrapResultModal(
+      fakeApp,
+      { kind: "fetched", fetched: 2, total: 3 },
+      { onAddStarterContent: () => undefined },
+    ).open();
+    const text = document.body.textContent ?? "";
+    expect(text).toMatch(/2 of 3/);
+    expect(text).toMatch(/Next:/);
+  });
+
+  it("a11y — both buttons carry explicit aria-labels (P16)", () => {
+    new BootstrapResultModal(fakeApp, BOOTSTRAPPED, {
+      onAddStarterContent: () => undefined,
+    }).open();
+    expect(
+      findButton("Add the starter content")!.getAttribute("aria-label"),
+    ).toMatch(/Add the starter content/i);
+    expect(findButton("Done")!.getAttribute("aria-label")).toMatch(
+      /Close the setup result/i,
+    );
+  });
+});
+
+// resultCopy is the pure per-outcome wording — unit-testable without DOM.
+describe("resultCopy", () => {
+  it("every BootstrapResultInfo kind yields a title, summary and next-step hint", () => {
+    const kinds: BootstrapResultInfo[] = [
+      { kind: "bootstrapped", folderName: "assetspaces/x", sha: "deadbee" },
+      { kind: "fetched", fetched: 1, total: 4 },
+      { kind: "already-bootstrapped" },
+    ];
+    for (const k of kinds) {
+      const copy = resultCopy(k);
+      expect(copy.title.length).toBeGreaterThan(0);
+      expect(copy.summary.length).toBeGreaterThan(0);
+      // Every outcome dead-ends nowhere — there is always a "Next:" hint.
+      expect(copy.nextHint).toMatch(/Next:/);
+    }
+  });
+
+  it("bootstrapped copy embeds the folder + sha", () => {
+    const copy = resultCopy({
+      kind: "bootstrapped",
+      folderName: "assetspaces/kitelev/exoas-exo",
+      sha: "abc1234",
+    });
+    expect(copy.summary).toMatch(/assetspaces\/kitelev\/exoas-exo/);
+    expect(copy.summary).toMatch(/abc1234/);
   });
 });
 


### PR DESCRIPTION
## Summary
RFC 0002 §3.3 — de-jargon the Bootstrap dialog floor-field copy and add a **durable, in-context result panel** with a next-step nudge. Resolves **P6** (URL friction + jargon) and **P5** (transient-toast-only, no durable result).

Builds on the fresh exo-only modal (PR #3613, v16.104.0) and the §3.1 onboarding panel (reuses `STARTER_REGISTRY_URL`).

## Changes
- **`BootstrapVaultModal`** — plain-language intro + field label (`Engine repository URL`, was `exo ontology URL`), an inline explainer ("the engine floor — use the public floor repo or your own fork"), and a link to the public floor repo. **Honors EC7**: the field is **NOT** pre-filled — the link + placeholder are pointers only. Input gains an `aria-label` (P16).
- **`BootstrapResultModal` (new)** — a persistent panel surfaced on the three terminal bootstrap outcomes (`bootstrapped` / `fetched` / `already-bootstrapped`) **on top of** the existing (already-firing) toast + activity-log entry, so the result survives the toast fade and dead-ends nowhere. Next-step nudge opens Add-AssetSpace pre-filled with the starter registry (§3.1 step 2). a11y: native buttons, aria-labels, managed focus.
- **`BootstrapAssetSpaceCommands`** — optional best-effort `showResult` dep + `BootstrapResultInfo` union; emitted on success/guard, never on hard failure/cancel.
- **`ExocortexPlugin`** — wires `showResult` **unconditionally** (Desktop↔Mobile parity — the panel shows on both platforms).

## EC7 honored
The floor field stays **empty** (`kitelev/exoas-*` is not a generic pre-fill). The de-jargon adds copy + a link + a placeholder example only — no pre-fill. Test: `field still empty (EC7)`.

## Tests (TDD)
- De-jargon copy present (`Engine repository URL`), jargon gone (`ontology URL`/`SDK`); inline explainer + floor-repo link (href + rel/target + aria-label); field empty (EC7); input aria-label.
- `BootstrapResultModal` per-outcome copy + next-step button fires `onAddStarterContent` + closes; Done closes without firing; a11y aria-labels; `resultCopy` pure-fn.
- `showResult` emission **revert-verified**: success/guard fire the right `BootstrapResultInfo`; hard failure / cancel / invalid URL fire **none**; absent dep → command still completes.
- `eka-obsidian-leg` e2e dismisses the new result panel before step 2.

Local: typecheck ✓, lint ✓ (0 errors), archgate ✓ (0 failed), mobile-loadable ✓, 72 + 51 related unit tests green.

Closes WBS node `65dde213` (RFC 0002 §3.3).