### PR TITLE
feat(profile): picker descriptions, recommended badge, user-scope, label not UUID (RFC 0002 §3.4)

### DIFF
--- a/packages/obsidian-plugin/src/ExocortexPlugin.ts
+++ b/packages/obsidian-plugin/src/ExocortexPlugin.ts
@@ -121,6 +121,7 @@ import { PluginSettingsStoreAdapter } from "./infrastructure/adapters/PluginSett
 import { PluginLocalDataStore } from "./infrastructure/adapters/PluginLocalDataStore";
 import { StagingDirTracker } from "./infrastructure/adapters/StagingDirTracker";
 import { ProfileFuzzyModal } from "./infrastructure/adapters/ProfileFuzzyModal";
+import { buildProfileChoice } from "./infrastructure/adapters/profileChoiceFactory";
 import { lookupAssetSpaceUidByFolder } from "./infrastructure/adapters/AssetSpaceLookupHelper";
 import { createAssetSpacePusher } from "./infrastructure/adapters/AssetSpacePusherFactory";
 import { LocalSecretsStore } from "./infrastructure/adapters/LocalSecretsStore";
@@ -2799,6 +2800,24 @@ export default class ExocortexPlugin extends Plugin {
     }
   }
 
+  /**
+   * RFC 0002 §3.4 P7b — collect every `exo__Asset_uid` present in the vault so
+   * the profile picker can decide which profiles are locally relevant (their
+   * `exo__Profile_includes` AssetSpaces resolve to assets on disk). One
+   * in-memory `metadataCache` pass; called per picker open (infrequent).
+   */
+  private collectPresentAssetUids(): Set<string> {
+    const uids = new Set<string>();
+    for (const file of this.app.vault.getMarkdownFiles()) {
+      const fm = this.app.metadataCache.getFileCache(file)?.frontmatter as
+        | Record<string, unknown>
+        | undefined;
+      const uid = fm?.["exo__Asset_uid"];
+      if (typeof uid === "string" && uid.length > 0) uids.add(uid);
+    }
+    return uids;
+  }
+
   private async registerProfileCommands(): Promise<void> {
     const lockMgr = new PluginLockManager({ app: this.app });
     const resolver = new VaultProfileResolver(this.app);
@@ -3044,25 +3063,31 @@ export default class ExocortexPlugin extends Plugin {
 
     // Shared choice-builder for the per-class palette pickers (RFC 13da049f
     // AC17). `activeUid` drives the `isActive` flag the picker surfaces.
+    //
+    // RFC 0002 §3.4 — also surfaces, per profile asset (all RDF-sourced;
+    // Homoiconicity — never hardcoded):
+    //   - `exo__Profile_description` → one-line description (P7)
+    //   - `exo__Profile_recommended: true` → «recommended» badge (P7, starter)
+    //   - locality (P7b): a profile is locally relevant when EVERY
+    //     `exo__Profile_includes` AssetSpace UID resolves to an asset present
+    //     on disk (`presentUids`). Empty includes ⇒ vacuously relevant.
     const buildProfileChoices = (
       files: TFile[],
       activeUid: string | null,
+      presentUids: Set<string>,
     ): ProfileChoice[] => {
       const choices: ProfileChoice[] = [];
       for (const file of files) {
         const cache = this.app.metadataCache.getFileCache(file);
         const fm = cache?.frontmatter as Record<string, unknown> | undefined;
         if (!fm) continue;
-        const uid =
-          typeof fm["exo__Asset_uid"] === "string"
-            ? (fm["exo__Asset_uid"] as string)
-            : null;
-        if (uid === null) continue;
-        const label =
-          typeof fm["exo__Asset_label"] === "string"
-            ? (fm["exo__Asset_label"] as string)
-            : file.basename;
-        choices.push({ uid, label, isActive: uid === activeUid });
+        const choice = buildProfileChoice(
+          fm,
+          file.basename,
+          activeUid,
+          presentUids,
+        );
+        if (choice !== null) choices.push(choice);
       }
       // Sort alphabetically by label so picker order is stable across
       // vault scans (vault.getMarkdownFiles() is filesystem-order, not
@@ -3078,6 +3103,7 @@ export default class ExocortexPlugin extends Plugin {
       buildProfileChoices(
         resolver.listProfileFiles(),
         localDataStore.getActiveProfileUid(),
+        this.collectPresentAssetUids(),
       );
 
     // Issue #3320 — share the same lister с Settings UI so its dropdown

--- a/packages/obsidian-plugin/src/infrastructure/adapters/ProfileCommands.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/ProfileCommands.ts
@@ -42,6 +42,15 @@ export interface IAssetSpacePusher {
   pushAssetSpace(asUid: string): Promise<string>;
 }
 
+/**
+ * Sentinel UID for the synthetic «Show all profiles…» picker entry. The
+ * default picker view is scoped to locally-relevant profiles (RFC 0002 §3.4
+ * P7b); when some profiles are hidden, this entry is appended so the user can
+ * broaden the list to every profile. Selecting it re-opens the picker
+ * unscoped — it is NEVER passed to `applyProfile`.
+ */
+export const SHOW_ALL_PROFILES_UID = "__exocortex_show_all_profiles__";
+
 export interface ProfileChoice {
   uid: string;
   label: string;
@@ -52,6 +61,37 @@ export interface ProfileChoice {
    * the active selection is unknown.
    */
   isActive?: boolean;
+  /**
+   * One-line, human-readable description of what the profile mounts / who it
+   * is for (RFC 0002 §3.4 P7). Sourced from the `exo__Profile_description`
+   * RDF property in the vault (Homoiconicity invariant — descriptions live in
+   * RDF, never hardcoded in TS). Optional — absent when the asset omits it.
+   */
+  description?: string;
+  /**
+   * `true` when the profile carries `exo__Profile_recommended: true` (RDF) —
+   * the picker decorates it with a «recommended for new users» badge
+   * (RFC 0002 §3.4 P7, the `starter` profile). RDF-driven, NOT a hardcoded
+   * label match, so any profile can be marked recommended without a code
+   * change (Homoiconicity invariant).
+   */
+  isRecommended?: boolean;
+  /**
+   * Whether this profile is relevant to the current vault — i.e. all of its
+   * `exo__Profile_includes` AssetSpaces resolve to assets present on disk
+   * (RFC 0002 §3.4 P7b). The picker shows locally-relevant profiles by
+   * default and hides the rest behind «Show all profiles», so a tester is not
+   * choosing among other testers' profiles (`$$levina-tbank` …). `undefined`
+   * / `true` ⇒ shown by default; `false` ⇒ hidden behind the expander.
+   */
+  isLocallyRelevant?: boolean;
+  /**
+   * Internal sentinel kind. `"show-all"` marks the synthetic «Show all
+   * profiles…» entry (see {@link SHOW_ALL_PROFILES_UID}); absent for real
+   * profiles. Selecting a `"show-all"` entry re-opens the picker unscoped
+   * rather than applying anything.
+   */
+  kind?: "show-all";
 }
 
 export interface ProfileCommandsDeps {
@@ -146,7 +186,10 @@ export class ProfileCommands {
       return;
     }
 
-    const chosen = await this.fuzzyPick(profiles, "Apply profile", initialQuery);
+    // RFC 0002 §3.4 P7b — scope the default view to locally-relevant profiles
+    // (hide other testers' profiles behind «Show all profiles»). Returns the
+    // chosen real profile, or null on cancel.
+    const chosen = await this.pickProfileScoped(profiles, initialQuery);
     if (chosen === null) return; // user cancelled
 
     this.notify(`Applying ${chosen.label}…`);
@@ -250,6 +293,56 @@ export class ProfileCommands {
   }
 
   // === Helpers ===
+
+  /**
+   * RFC 0002 §3.4 P7b — open the picker scoped to locally-relevant profiles,
+   * with a synthetic «Show all profiles…» entry when some are hidden.
+   *
+   * Default view = profiles whose `isLocallyRelevant !== false` (an undefined
+   * flag is treated as relevant, so callers that do not compute relevance keep
+   * the full list). If NOTHING is locally relevant (e.g. a fresh vault where no
+   * AssetSpace resolves yet) the full list is shown directly — the picker is
+   * never empty when profiles exist. Selecting the «Show all profiles…» entry
+   * re-opens the picker with every profile, unscoped.
+   *
+   * The fuzzy-pick wrapper is the {@link ProfileFuzzyModal}, which carries the
+   * picker-selection fix (#3561 — record-in-choose, resolve-in-close-microtask);
+   * this method only chooses which list to hand it.
+   */
+  private async pickProfileScoped(
+    profiles: ProfileChoice[],
+    initialQuery?: string,
+  ): Promise<ProfileChoice | null> {
+    const relevant = profiles.filter((p) => p.isLocallyRelevant !== false);
+    // Fallback — never present an empty picker. When no profile resolves
+    // locally, show all rather than the «Show all» expander alone.
+    const scoped = relevant.length > 0 ? relevant : profiles;
+    const hasHidden = scoped.length < profiles.length;
+
+    const firstList = hasHidden
+      ? [...scoped, ProfileCommands.showAllEntry(profiles.length - scoped.length)]
+      : scoped;
+
+    const first = await this.fuzzyPick(firstList, "Apply profile", initialQuery);
+    if (first === null) return null;
+    if (first.kind === "show-all") {
+      // User broadened the list — re-open unscoped (no pre-narrow query).
+      const all = await this.fuzzyPick(profiles, "Apply profile");
+      // A nested «show-all» is impossible (the full list contains no sentinel),
+      // but guard against accidental re-selection so it never reaches apply.
+      return all !== null && all.kind === "show-all" ? null : all;
+    }
+    return first;
+  }
+
+  /** Build the synthetic «Show all profiles…» picker entry. */
+  private static showAllEntry(hiddenCount: number): ProfileChoice {
+    return {
+      uid: SHOW_ALL_PROFILES_UID,
+      label: `Show all profiles… (${hiddenCount} more)`,
+      kind: "show-all",
+    };
+  }
 
   /**
    * Extract the AssetSpace folder name from a vault-relative path.

--- a/packages/obsidian-plugin/src/infrastructure/adapters/ProfileFuzzyModal.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/ProfileFuzzyModal.ts
@@ -1,6 +1,9 @@
-import { App, FuzzySuggestModal } from "obsidian";
+import { App, FuzzySuggestModal, type FuzzyMatch } from "obsidian";
 
 import type { ProfileChoice } from "./ProfileCommands";
+
+/** Badge text for `exo__Profile_recommended` profiles (RFC 0002 §3.4 P7). */
+export const RECOMMENDED_BADGE_TEXT = "Recommended for new users";
 
 /**
  * ProfileFuzzyModal — thin Obsidian `FuzzySuggestModal` wrapper used by
@@ -89,8 +92,74 @@ export class ProfileFuzzyModal extends FuzzySuggestModal<ProfileChoice> {
     return this.options;
   }
 
+  /**
+   * Fuzzy-searchable text for an item. Includes the description and the
+   * «recommended» marker so a user can type either to find a profile (the
+   * description is searchable, not just decorative). The «show all» sentinel
+   * returns its label verbatim. Order — label first — so the existing
+   * label-only assertions and the e2e `allTextContents` label check still hold.
+   */
   getItemText(item: ProfileChoice): string {
-    return item.isActive ? `${item.label} ✓ (active)` : item.label;
+    if (item.kind === "show-all") return item.label;
+    let text = item.label;
+    if (item.isRecommended) text += " (recommended)";
+    if (item.description !== undefined && item.description.length > 0) {
+      text += ` — ${item.description}`;
+    }
+    if (item.isActive) text += " ✓ (active)";
+    return text;
+  }
+
+  /**
+   * Render a structured, accessible suggestion row: a title line (label +
+   * active marker + «recommended» badge) and, when present, a muted
+   * description line (RFC 0002 §3.4 P7/P10 — human label + description, never
+   * the raw UID). The «show all profiles» sentinel renders as a single muted
+   * line. Overriding `renderSuggestion` replaces Obsidian's default
+   * fuzzy-highlight rendering, which is acceptable for this small, curated
+   * list; `getItemText` still drives the fuzzy match.
+   */
+  override renderSuggestion(match: FuzzyMatch<ProfileChoice>, el: HTMLElement): void {
+    const item = match.item;
+    el.addClass("exocortex-profile-suggestion");
+
+    if (item.kind === "show-all") {
+      el.addClass("exocortex-profile-suggestion--show-all");
+      el.createDiv({
+        cls: "exocortex-profile-suggestion__title",
+        text: item.label,
+      });
+      return;
+    }
+
+    const titleEl = el.createDiv({ cls: "exocortex-profile-suggestion__title" });
+    // Human label, never the UID (P10).
+    titleEl.createSpan({
+      cls: "exocortex-profile-suggestion__label",
+      text: item.label,
+    });
+    if (item.isActive) {
+      titleEl.createSpan({
+        cls: "exocortex-profile-suggestion__active",
+        text: " ✓ (active)",
+      });
+    }
+    if (item.isRecommended) {
+      titleEl.createSpan({
+        cls: "exocortex-profile-suggestion__badge",
+        text: RECOMMENDED_BADGE_TEXT,
+        // a11y — the visual badge already reads as text; aria-label keeps the
+        // semantic explicit for assistive tech even if styling hides glyphs.
+        attr: { "aria-label": RECOMMENDED_BADGE_TEXT },
+      });
+    }
+
+    if (item.description !== undefined && item.description.length > 0) {
+      el.createDiv({
+        cls: "exocortex-profile-suggestion__desc",
+        text: item.description,
+      });
+    }
   }
 
   onChooseItem(item: ProfileChoice): void {

--- a/packages/obsidian-plugin/src/infrastructure/adapters/profileChoiceFactory.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/profileChoiceFactory.ts
@@ -1,0 +1,97 @@
+import type { ProfileChoice } from "./ProfileCommands";
+
+/**
+ * Pure factory turning an `exo__Profile` asset's frontmatter into a
+ * {@link ProfileChoice} for the picker (RFC 0002 §3.4). Extracted from
+ * `ExocortexPlugin` so the RDF-shape parsing — description, the
+ * `recommended` flag, and the locality computation — is unit-testable against
+ * the real Obsidian frontmatter shapes (string vs string[], boolean vs
+ * `"true"`, `[[uid]]` vs `[[uid|alias]]`) without a Docker e2e.
+ *
+ * Homoiconicity invariant: every surfaced property is read from RDF — nothing
+ * is hardcoded in TS (no magic `label === "starter"` match).
+ */
+
+/**
+ * Parse an RDF boolean frontmatter value. Obsidian surfaces it as a real
+ * boolean or as the string `"true"`/`"false"` depending on how the YAML was
+ * written; only an explicit truthy value yields `true`.
+ */
+export function parseProfileRecommended(value: unknown): boolean {
+  if (value === true) return true;
+  if (typeof value === "string") return value.trim().toLowerCase() === "true";
+  return false;
+}
+
+/**
+ * Extract bare AssetSpace UIDs from an `exo__Profile_includes` frontmatter
+ * value (string | string[]), stripping `[[`/`]]` wrappers and `|alias`
+ * suffixes. Mirrors `VaultProfileResolver.extractWikilinkList`.
+ */
+export function extractIncludeUids(value: unknown): string[] {
+  const items: unknown[] = Array.isArray(value)
+    ? value
+    : value !== undefined && value !== null
+      ? [value]
+      : [];
+  const out: string[] = [];
+  for (const raw of items) {
+    if (typeof raw !== "string") continue;
+    const cleaned = raw
+      .trim()
+      .replace(/^\[\[/, "")
+      .replace(/\]\]$/, "")
+      .split("|")[0]
+      .trim();
+    if (cleaned.length > 0) out.push(cleaned);
+  }
+  return out;
+}
+
+/** Read the optional one-line description, trimmed; `undefined` when blank. */
+export function parseProfileDescription(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+/**
+ * Build a {@link ProfileChoice} from a Profile asset's frontmatter. Returns
+ * `null` when the asset has no `exo__Asset_uid` (cannot be applied).
+ *
+ * @param fm           the asset's frontmatter record
+ * @param basename     fallback label when `exo__Asset_label` is absent
+ * @param activeUid    the currently-applied profile UID (drives `isActive`)
+ * @param presentUids  every `exo__Asset_uid` present in the vault; a profile
+ *                     is locally relevant when every included AssetSpace UID
+ *                     is in this set (empty includes ⇒ vacuously relevant).
+ */
+export function buildProfileChoice(
+  fm: Record<string, unknown>,
+  basename: string,
+  activeUid: string | null,
+  presentUids: Set<string>,
+): ProfileChoice | null {
+  const uid =
+    typeof fm["exo__Asset_uid"] === "string"
+      ? (fm["exo__Asset_uid"] as string)
+      : null;
+  if (uid === null) return null;
+
+  const label =
+    typeof fm["exo__Asset_label"] === "string"
+      ? (fm["exo__Asset_label"] as string)
+      : basename;
+
+  const includeUids = extractIncludeUids(fm["exo__Profile_includes"]);
+  const isLocallyRelevant = includeUids.every((u) => presentUids.has(u));
+
+  return {
+    uid,
+    label,
+    isActive: uid === activeUid,
+    description: parseProfileDescription(fm["exo__Profile_description"]),
+    isRecommended: parseProfileRecommended(fm["exo__Profile_recommended"]),
+    isLocallyRelevant,
+  };
+}

--- a/packages/obsidian-plugin/src/infrastructure/adapters/profileChoiceFactory.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/profileChoiceFactory.ts
@@ -84,6 +84,11 @@ export function buildProfileChoice(
       : basename;
 
   const includeUids = extractIncludeUids(fm["exo__Profile_includes"]);
+  // Scope check on DIRECT includes only. `exo__Profile_imports` (transitive
+  // parent composition, RFC-deferred 0..1 MVP) is intentionally not walked
+  // here: at worst a profile whose imported parent is absent shows as relevant
+  // — it never HIDES a relevant profile, so the picker stays safe. The
+  // apply-time effective set (VaultProfileResolver) still resolves `_imports`.
   const isLocallyRelevant = includeUids.every((u) => presentUids.has(u));
 
   return {

--- a/packages/obsidian-plugin/src/presentation/settings/ExocortexSettingTab.ts
+++ b/packages/obsidian-plugin/src/presentation/settings/ExocortexSettingTab.ts
@@ -857,9 +857,30 @@ export class ExocortexSettingTab extends PluginSettingTab {
     const profileStatusEl = containerEl.createDiv({
       cls: "setting-item-description",
     });
-    profileStatusEl.appendText(
-      `Last applied: ${activeProfileUid ?? "(none — full vault on disk)"}`,
-    );
+    if (activeProfileUid === null) {
+      profileStatusEl.appendText("Last applied: (none — full vault on disk)");
+    } else {
+      // RFC 0002 §3.4 P10 — show the human label, not the raw UID. The lister
+      // is async (it scans the vault), so render the UID synchronously and
+      // upgrade to the label once resolved (same pattern as Operations log
+      // below). Falls back to the UID for a since-deleted profile / lister
+      // failure.
+      profileStatusEl.appendText(`Last applied: ${activeProfileUid}`);
+      void (async () => {
+        const lister = this.plugin.listProfileChoices;
+        if (lister === null || lister === undefined) return;
+        try {
+          const choices = await lister();
+          const match = choices.find((c) => c.uid === activeProfileUid);
+          if (match !== undefined) {
+            profileStatusEl.empty();
+            profileStatusEl.appendText(`Last applied: ${match.label}`);
+          }
+        } catch {
+          // Keep the UID fallback already rendered — not fatal.
+        }
+      })();
+    }
 
     new Setting(containerEl)
       .setName("Apply profile")

--- a/packages/obsidian-plugin/styles.css
+++ b/packages/obsidian-plugin/styles.css
@@ -2470,6 +2470,45 @@
   border-radius: 3px;
 }
 
+/* Profile picker suggestion rows (RFC 0002 §3.4 — descriptions, recommended
+   badge, human label). Rendered by ProfileFuzzyModal.renderSuggestion. */
+.exocortex-profile-suggestion__title {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+
+.exocortex-profile-suggestion__active {
+  color: var(--text-success);
+  font-size: 0.85em;
+}
+
+.exocortex-profile-suggestion__badge {
+  font-size: 0.7em;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  color: var(--text-on-accent);
+  background-color: var(--interactive-accent);
+  padding: 1px 7px;
+  border-radius: 10px;
+  white-space: nowrap;
+}
+
+.exocortex-profile-suggestion__desc {
+  font-size: 0.8em;
+  color: var(--text-muted);
+  margin-top: 2px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.exocortex-profile-suggestion--show-all .exocortex-profile-suggestion__title {
+  color: var(--text-faint);
+  font-style: italic;
+}
+
 /* Required indicator */
 .required-indicator {
   color: var(--text-error);

--- a/packages/obsidian-plugin/styles.css
+++ b/packages/obsidian-plugin/styles.css
@@ -2500,6 +2500,8 @@
   font-size: 0.8em;
   color: var(--text-muted);
   margin-top: 2px;
+  /* Single-line truncate — ellipsis needs nowrap to take effect. */
+  white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
 }

--- a/packages/obsidian-plugin/tests/unit/ExocortexSettingTab.focusProfile.test.ts
+++ b/packages/obsidian-plugin/tests/unit/ExocortexSettingTab.focusProfile.test.ts
@@ -118,9 +118,11 @@ describe("ExocortexSettingTab — Issue #3320 Profile sections", () => {
     warn: jest.Mock;
     error: jest.Mock;
   };
+  let createdEls: any[];
 
   beforeEach(() => {
     settingCalls = [];
+    createdEls = [];
     mockNotifier = {
       info: jest.fn(),
       warn: jest.fn(),
@@ -133,6 +135,7 @@ describe("ExocortexSettingTab — Issue #3320 Profile sections", () => {
       (el as any).createEl = jest.fn().mockImplementation(() => createMockElement());
       (el as any).createDiv = jest.fn().mockImplementation(() => createMockElement());
       (el as any).appendText = jest.fn();
+      createdEls.push(el);
       return el;
     };
     mockContainerEl = {
@@ -289,6 +292,42 @@ describe("ExocortexSettingTab — Issue #3320 Profile sections", () => {
     settingTab.display();
 
     expect(getActiveProfileUid).toHaveBeenCalled();
+  });
+
+  it("Active profile status resolves the UID to the human label (RFC 0002 §3.4 P10)", async () => {
+    // listProfileChoices (mock) maps uid-b → "Work". The status line should
+    // upgrade from the raw UID to the label once the async lister resolves.
+    mockPlugin.localDataStore = {
+      getActiveProfileUid: jest.fn().mockReturnValue("uid-b"),
+    };
+
+    settingTab.display();
+    // Flush the IIFE's async lister + microtasks.
+    await Promise.resolve();
+    await Promise.resolve();
+
+    const appendCalls = createdEls.flatMap((el) =>
+      (el.appendText as jest.Mock).mock.calls.map((c: any[]) => c[0]),
+    );
+    // Human label rendered (P10), NOT left as the raw UID.
+    expect(appendCalls).toContain("Last applied: Work");
+    expect(appendCalls).not.toContain("Last applied: uid-b ✓");
+  });
+
+  it("Active profile status falls back to the raw UID for an unknown profile", async () => {
+    mockPlugin.localDataStore = {
+      getActiveProfileUid: jest.fn().mockReturnValue("uid-deleted"),
+    };
+
+    settingTab.display();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    const appendCalls = createdEls.flatMap((el) =>
+      (el.appendText as jest.Mock).mock.calls.map((c: any[]) => c[0]),
+    );
+    // No lister match → keeps the UID fallback (never blank).
+    expect(appendCalls).toContain("Last applied: uid-deleted");
   });
 
   it("renders the Switch cache stats row with Clear button", () => {

--- a/packages/obsidian-plugin/tests/unit/ProfileCommands.test.ts
+++ b/packages/obsidian-plugin/tests/unit/ProfileCommands.test.ts
@@ -1,5 +1,6 @@
 import {
   ProfileCommands,
+  SHOW_ALL_PROFILES_UID,
   type ProfileChoice,
   type ProfileCommandsDeps,
   type IAssetSpacePusher,
@@ -378,6 +379,130 @@ describe("ProfileCommands.invokeApplyProfile (Apply profile)", () => {
 
     await expect(h.cmd.invokeApplyProfile()).resolves.not.toThrow();
     expect(h.notices.some((n) => /failed.*boom/.test(n))).toBe(true);
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// invokeApplyProfile — user-scope (RFC 0002 §3.4 P7b «Show all profiles»)
+// ═══════════════════════════════════════════════════════════════════════════
+
+/**
+ * Harness with a queued fuzzyPick so a test can script the show-all → re-open
+ * sequence (first call returns the sentinel, second returns a real profile).
+ */
+function makeScopedHarness(
+  profiles: ProfileChoice[],
+  pickResults: (ProfileChoice | null)[],
+): {
+  switchMgr: FakeSwitchMgr;
+  notices: string[];
+  pickCalls: { options: ProfileChoice[]; title: string; initialQuery?: string }[];
+  cmd: ProfileCommands;
+} {
+  const switchMgr = new FakeSwitchMgr();
+  const notices: string[] = [];
+  const pickCalls: {
+    options: ProfileChoice[];
+    title: string;
+    initialQuery?: string;
+  }[] = [];
+  let i = 0;
+  const cmd = new ProfileCommands({
+    switchMgr: switchMgr as unknown as ProfileApplyManager,
+    pushMgr: new FakePushMgr(),
+    profileLister: async () => profiles,
+    fuzzyPick: async (options, title, initialQuery) => {
+      pickCalls.push({ options, title, initialQuery });
+      return pickResults[i++] ?? null;
+    },
+    getActiveFilePath: () => null,
+    getActiveProfileUid: () => null,
+    notify: (m) => notices.push(m),
+  });
+  return { switchMgr, notices, pickCalls, cmd };
+}
+
+describe("ProfileCommands.invokeApplyProfile — user-scope (P7b)", () => {
+  const RELEVANT: ProfileChoice = {
+    uid: "rel",
+    label: "$$kitelev-my",
+    isLocallyRelevant: true,
+  };
+  const HIDDEN: ProfileChoice = {
+    uid: "hid",
+    label: "$$mudriy-tbank",
+    isLocallyRelevant: false,
+  };
+
+  it("default picker shows only locally-relevant profiles + a «Show all» entry", async () => {
+    const h = makeScopedHarness([RELEVANT, HIDDEN], [RELEVANT]);
+    await h.cmd.invokeApplyProfile();
+
+    const firstOptions = h.pickCalls[0].options;
+    // Relevant profile present; hidden one NOT in the default view.
+    expect(firstOptions.some((o) => o.uid === "rel")).toBe(true);
+    expect(firstOptions.some((o) => o.uid === "hid")).toBe(false);
+    // A «Show all profiles…» sentinel is appended (because one is hidden).
+    const sentinel = firstOptions.find((o) => o.kind === "show-all");
+    expect(sentinel?.uid).toBe(SHOW_ALL_PROFILES_UID);
+    expect(sentinel?.label).toMatch(/Show all profiles.*1 more/);
+    // Chose the relevant one → applied.
+    expect(h.switchMgr.applyCalls).toEqual(["rel"]);
+  });
+
+  it("selecting «Show all» re-opens the picker with EVERY profile, unscoped", async () => {
+    const showAll: ProfileChoice = {
+      uid: SHOW_ALL_PROFILES_UID,
+      label: "Show all profiles… (1 more)",
+      kind: "show-all",
+    };
+    const h = makeScopedHarness([RELEVANT, HIDDEN], [showAll, HIDDEN]);
+    await h.cmd.invokeApplyProfile();
+
+    expect(h.pickCalls).toHaveLength(2);
+    // Second pick offers the FULL list (no sentinel, both profiles).
+    const secondOptions = h.pickCalls[1].options;
+    expect(secondOptions.map((o) => o.uid).sort()).toEqual(["hid", "rel"]);
+    expect(secondOptions.some((o) => o.kind === "show-all")).toBe(false);
+    expect(h.pickCalls[1].initialQuery).toBeUndefined();
+    // The previously-hidden profile is now applicable.
+    expect(h.switchMgr.applyCalls).toEqual(["hid"]);
+  });
+
+  it("never applies the «Show all» sentinel itself", async () => {
+    const showAll: ProfileChoice = {
+      uid: SHOW_ALL_PROFILES_UID,
+      label: "Show all profiles…",
+      kind: "show-all",
+    };
+    // User selects show-all, then cancels the unscoped picker.
+    const h = makeScopedHarness([RELEVANT, HIDDEN], [showAll, null]);
+    await h.cmd.invokeApplyProfile();
+
+    expect(h.switchMgr.applyCalls).toHaveLength(0);
+    expect(
+      h.notices.some((n) => n.includes(SHOW_ALL_PROFILES_UID)),
+    ).toBe(false);
+  });
+
+  it("no «Show all» entry when every profile is locally relevant", async () => {
+    const h = makeScopedHarness([RELEVANT], [RELEVANT]);
+    await h.cmd.invokeApplyProfile();
+
+    expect(
+      h.pickCalls[0].options.some((o) => o.kind === "show-all"),
+    ).toBe(false);
+  });
+
+  it("fallback — shows ALL profiles directly when NONE is locally relevant (fresh vault)", async () => {
+    const h = makeScopedHarness([HIDDEN], [HIDDEN]);
+    await h.cmd.invokeApplyProfile();
+
+    // No empty picker, no lone «Show all» — the single profile is shown.
+    const opts = h.pickCalls[0].options;
+    expect(opts.some((o) => o.kind === "show-all")).toBe(false);
+    expect(opts.map((o) => o.uid)).toEqual(["hid"]);
+    expect(h.switchMgr.applyCalls).toEqual(["hid"]);
   });
 });
 

--- a/packages/obsidian-plugin/tests/unit/ProfileFuzzyModal.test.ts
+++ b/packages/obsidian-plugin/tests/unit/ProfileFuzzyModal.test.ts
@@ -1,5 +1,9 @@
-import { ProfileFuzzyModal } from "../../src/infrastructure/adapters/ProfileFuzzyModal";
+import {
+  ProfileFuzzyModal,
+  RECOMMENDED_BADGE_TEXT,
+} from "../../src/infrastructure/adapters/ProfileFuzzyModal";
 import type { ProfileChoice } from "../../src/infrastructure/adapters/ProfileCommands";
+import type { FuzzyMatch } from "obsidian";
 
 const fakeApp = {} as any;
 
@@ -37,6 +41,106 @@ describe("ProfileFuzzyModal", () => {
     expect(modal.getItemText(profiles[0])).toBe("Personal");
     expect(modal.getItemText(profiles[1])).toBe("Work ✓ (active)");
     expect(modal.getItemText(profiles[2])).toBe("Reading");
+  });
+
+  // ── RFC 0002 §3.4 — description / recommended / show-all in getItemText ────
+  it("getItemText appends the description (searchable) — P7", () => {
+    const modal = new ProfileFuzzyModal(fakeApp, [], "Pick", () => {});
+    expect(
+      modal.getItemText({
+        uid: "u",
+        label: "$$starter",
+        description: "A safe starting point",
+      }),
+    ).toBe("$$starter — A safe starting point");
+  });
+
+  it("getItemText marks recommended profiles (searchable «recommended») — P7", () => {
+    const modal = new ProfileFuzzyModal(fakeApp, [], "Pick", () => {});
+    expect(
+      modal.getItemText({
+        uid: "u",
+        label: "$$starter",
+        isRecommended: true,
+        description: "Start here",
+        isActive: true,
+      }),
+    ).toBe("$$starter (recommended) — Start here ✓ (active)");
+  });
+
+  it("getItemText returns the «show all» sentinel label verbatim — P7b", () => {
+    const modal = new ProfileFuzzyModal(fakeApp, [], "Pick", () => {});
+    expect(
+      modal.getItemText({
+        uid: "__exocortex_show_all_profiles__",
+        label: "Show all profiles… (3 more)",
+        kind: "show-all",
+      }),
+    ).toBe("Show all profiles… (3 more)");
+  });
+
+  // ── renderSuggestion structured a11y DOM ──────────────────────────────────
+  function fuzzy(item: ProfileChoice): FuzzyMatch<ProfileChoice> {
+    return { item, match: { score: 0, matches: [] } };
+  }
+
+  it("renderSuggestion renders human label, description and recommended badge — P7/P10", () => {
+    const modal = new ProfileFuzzyModal(fakeApp, [], "Pick", () => {});
+    const el = document.createElement("div");
+    modal.renderSuggestion(
+      fuzzy({
+        uid: "97c0…",
+        label: "$$kitelev-my",
+        description: "Your personal knowledge.",
+        isRecommended: true,
+      }),
+      el,
+    );
+    // Human label, never the UID (P10).
+    expect(el.textContent).toContain("$$kitelev-my");
+    expect(el.textContent).not.toContain("97c0…");
+    // Description line (P7).
+    expect(
+      el.querySelector(".exocortex-profile-suggestion__desc")?.textContent,
+    ).toBe("Your personal knowledge.");
+    // Recommended badge with a11y label (P7).
+    const badge = el.querySelector(".exocortex-profile-suggestion__badge");
+    expect(badge?.textContent).toBe(RECOMMENDED_BADGE_TEXT);
+    expect(badge?.getAttribute("aria-label")).toBe(RECOMMENDED_BADGE_TEXT);
+  });
+
+  it("renderSuggestion omits badge/description when absent; shows active marker", () => {
+    const modal = new ProfileFuzzyModal(fakeApp, [], "Pick", () => {});
+    const el = document.createElement("div");
+    modal.renderSuggestion(
+      fuzzy({ uid: "u", label: "Plain", isActive: true }),
+      el,
+    );
+    expect(el.textContent).toContain("Plain");
+    expect(el.textContent).toContain("✓ (active)");
+    expect(
+      el.querySelector(".exocortex-profile-suggestion__badge"),
+    ).toBeNull();
+    expect(
+      el.querySelector(".exocortex-profile-suggestion__desc"),
+    ).toBeNull();
+  });
+
+  it("renderSuggestion renders the «show all» sentinel as a muted row", () => {
+    const modal = new ProfileFuzzyModal(fakeApp, [], "Pick", () => {});
+    const el = document.createElement("div");
+    modal.renderSuggestion(
+      fuzzy({
+        uid: "__exocortex_show_all_profiles__",
+        label: "Show all profiles… (2 more)",
+        kind: "show-all",
+      }),
+      el,
+    );
+    expect(el.classList.contains("exocortex-profile-suggestion--show-all")).toBe(
+      true,
+    );
+    expect(el.textContent).toContain("Show all profiles… (2 more)");
   });
 
   // ── Regression: picker selection NO-OP (Issue #3561) ──────────────────────

--- a/packages/obsidian-plugin/tests/unit/profileChoiceFactory.test.ts
+++ b/packages/obsidian-plugin/tests/unit/profileChoiceFactory.test.ts
@@ -1,0 +1,139 @@
+/**
+ * RFC 0002 §3.4 — profile-choice factory parsing tests.
+ *
+ * Production-shape: every input mirrors a real Obsidian frontmatter value
+ * (string vs string[], boolean vs `"true"`, `[[uid]]` vs `[[uid|alias]]`).
+ * The factory is the single place the picker reads the description /
+ * recommended flag / locality from RDF (Homoiconicity — nothing hardcoded).
+ */
+
+import {
+  buildProfileChoice,
+  parseProfileRecommended,
+  parseProfileDescription,
+  extractIncludeUids,
+} from "../../src/infrastructure/adapters/profileChoiceFactory";
+
+describe("parseProfileRecommended", () => {
+  it("true for boolean true", () => {
+    expect(parseProfileRecommended(true)).toBe(true);
+  });
+  it('true for the string "true" (YAML may stringify)', () => {
+    expect(parseProfileRecommended("true")).toBe(true);
+    expect(parseProfileRecommended(" TRUE ")).toBe(true);
+  });
+  it("false for boolean false / string false / absent / other types", () => {
+    expect(parseProfileRecommended(false)).toBe(false);
+    expect(parseProfileRecommended("false")).toBe(false);
+    expect(parseProfileRecommended(undefined)).toBe(false);
+    expect(parseProfileRecommended(null)).toBe(false);
+    expect(parseProfileRecommended(1)).toBe(false);
+  });
+});
+
+describe("parseProfileDescription", () => {
+  it("returns the trimmed string when present", () => {
+    expect(parseProfileDescription("  A safe starting point  ")).toBe(
+      "A safe starting point",
+    );
+  });
+  it("returns undefined for blank / non-string", () => {
+    expect(parseProfileDescription("   ")).toBeUndefined();
+    expect(parseProfileDescription(undefined)).toBeUndefined();
+    expect(parseProfileDescription(42)).toBeUndefined();
+  });
+});
+
+describe("extractIncludeUids", () => {
+  it("strips wikilink wrappers from a single string", () => {
+    expect(extractIncludeUids("[[uid-1]]")).toEqual(["uid-1"]);
+  });
+  it("strips wrappers + alias from an array", () => {
+    expect(
+      extractIncludeUids(["[[uid-1]]", "[[uid-2|exoas-ems]]", "uid-3"]),
+    ).toEqual(["uid-1", "uid-2", "uid-3"]);
+  });
+  it("empty for undefined / null / non-strings", () => {
+    expect(extractIncludeUids(undefined)).toEqual([]);
+    expect(extractIncludeUids(null)).toEqual([]);
+    expect(extractIncludeUids([123, {}])).toEqual([]);
+  });
+});
+
+describe("buildProfileChoice", () => {
+  const PRESENT = new Set(["as-a", "as-b"]);
+
+  it("returns null when the asset has no uid (cannot be applied)", () => {
+    expect(
+      buildProfileChoice({ exo__Asset_label: "x" }, "base", null, PRESENT),
+    ).toBeNull();
+  });
+
+  it("maps label, active flag, description and recommended from RDF", () => {
+    const fm = {
+      exo__Asset_uid: "p1",
+      exo__Asset_label: "$$starter",
+      exo__Profile_description: "A safe starting point for new users.",
+      exo__Profile_recommended: true,
+      exo__Profile_includes: ["[[as-a]]"],
+    };
+    const choice = buildProfileChoice(fm, "base", "p1", PRESENT);
+    expect(choice).toEqual({
+      uid: "p1",
+      label: "$$starter",
+      isActive: true,
+      description: "A safe starting point for new users.",
+      isRecommended: true,
+      isLocallyRelevant: true,
+    });
+  });
+
+  it("falls back to basename when label absent; no description/badge by default", () => {
+    const choice = buildProfileChoice(
+      { exo__Asset_uid: "p2", exo__Profile_includes: "[[as-a]]" },
+      "fallback-base",
+      null,
+      PRESENT,
+    );
+    expect(choice?.label).toBe("fallback-base");
+    expect(choice?.description).toBeUndefined();
+    expect(choice?.isRecommended).toBe(false);
+    expect(choice?.isActive).toBe(false);
+  });
+
+  // ── P7b locality — the core scoping gate ──────────────────────────────────
+  it("locally relevant when EVERY included AssetSpace resolves on disk", () => {
+    const choice = buildProfileChoice(
+      { exo__Asset_uid: "p3", exo__Profile_includes: ["[[as-a]]", "[[as-b]]"] },
+      "b",
+      null,
+      PRESENT,
+    );
+    expect(choice?.isLocallyRelevant).toBe(true);
+  });
+
+  it("NOT relevant when an included AssetSpace is absent (cross-tester profile)", () => {
+    const choice = buildProfileChoice(
+      {
+        exo__Asset_uid: "p4",
+        exo__Asset_label: "$$mudriy-tbank",
+        // exoas-mudriy not on this disk
+        exo__Profile_includes: ["[[as-a]]", "[[as-mudriy]]"],
+      },
+      "b",
+      null,
+      PRESENT,
+    );
+    expect(choice?.isLocallyRelevant).toBe(false);
+  });
+
+  it("empty includes ⇒ vacuously relevant (minimum-load profile)", () => {
+    const choice = buildProfileChoice(
+      { exo__Asset_uid: "p5" },
+      "b",
+      null,
+      PRESENT,
+    );
+    expect(choice?.isLocallyRelevant).toBe(true);
+  });
+});


### PR DESCRIPTION
## RFC 0002 §3.4 — Profile picker: descriptions, recommended badge, scope to user, label not UUID

Phase 2 (discoverability & recovery). Resolves **P7** (cryptic `$$`-prefixed names, no descriptions), **P7b** (cross-tester profile leak), **P10** (active profile shown as raw UUID).

### What changed
- **Per-profile description + «recommended» badge (P7).** The picker now shows a one-line description per profile and a «Recommended for new users» badge — **both read from RDF**, never hardcoded in TS:
  - `exo__Profile_description` (new `exo__DatatypeProperty`)
  - `exo__Profile_recommended: true` (new `exo__BooleanProperty`) drives the badge — RDF-flag, **not** a `label === "starter"` magic match, so any profile can be marked recommended without a code change (Homoiconicity invariant).
  - `ProfileFuzzyModal.renderSuggestion` renders a structured, accessible row: label · badge (with `aria-label`) · muted description line. `getItemText` keeps the description searchable.
- **User-scope (P7b).** The picker defaults to **locally-relevant** profiles (every `exo__Profile_includes` AssetSpace resolves to an asset on disk). The rest hide behind a synthetic **«Show all profiles…»** entry that re-opens the picker unscoped — so a tester is not choosing among `$$levina-tbank` / `$$mudriy-tbank`. Fallback: shows all directly when **none** is locally relevant (never an empty picker).
- **Human label, not UUID (P10).** The picker is already label-based; the settings **«Active profile»** line now resolves the active UID to its label (async lister, UID fallback for a deleted profile).
- The picker-selection fix (#3561 — record-in-choose, resolve-in-close-microtask) is **untouched**.

### Homoiconicity
New TBox properties `exo__Profile_description` + `exo__Profile_recommended` added in `kitelev/exoas-exo` (`e3b2207`); submodule pointers bumped in **vault-2025** + **vault-exodev**; `validate schema --shapes-mode` → **0 violations** in both. The plugin reads the properties from frontmatter — descriptions/recommendation are vault data.

### Tests (production-shape)
- `profileChoiceFactory.test.ts` — RDF parsing across real frontmatter shapes (string vs string[], boolean vs `"true"`, `[[uid]]` vs `[[uid|alias]]`) + locality gate.
- `ProfileFuzzyModal.test.ts` — `getItemText` (description/recommended/show-all) + `renderSuggestion` DOM (label/badge/description/a11y); existing #3561 regression tests still pass.
- `ProfileCommands.test.ts` — user-scope default view, «Show all» re-open, sentinel never applied, fallback-when-none-relevant.
- `ExocortexSettingTab.focusProfile.test.ts` — Active-profile UID→label resolution + UID fallback.
- 70 unit tests green; `tsc --noEmit`, `eslint src`, production build, mobile-loadable + console-channel gates all green.

**Revert-verify (P7b scope):** neutering the locality filter (`relevant = profiles`) makes `ProfileCommands.test.ts` «default picker shows only locally-relevant + Show all» FAIL (the hidden profile leaks in, no sentinel). Restored → green.

### Not Docker (per task constraint)
E2E verified via CI `e2e-shard`, not local Docker. The existing `focus-profile-picker.spec.ts` fixtures have non-resolving includes → both non-relevant → the fallback (show-all-when-none-relevant) renders both, so the spec's by-label assertions still hold.

### Desktop↔Mobile parity
Pure render + list-scoping logic — no platform-gated code; works identically on desktop and mobile.

### Follow-up (out of scope, additive/low-risk)
- exocortex `packages/exoas-exo` submodule pointer can ride its own bump (the two new property declarations are additive — no fixture coupling).
- Populating actual profile assets (`exoas-profiles`, public `starter` registry) with `exo__Profile_description` / `exo__Profile_recommended` is vault data in separate repos.
