### PR TITLE
feat(onboarding): de-jargon + flag command palette (RFC 0002 §3.2)

### DIFF
--- a/docs/explanation/exosync-parallel-run.md
+++ b/docs/explanation/exosync-parallel-run.md
@@ -42,7 +42,7 @@ never a vault setting (it must not replicate).
   Notice summary (`ExoSync parity: M1=0, M2=∅ (N repo(s) checked)`) +
   journal append. Best-effort: a parity failure never affects the sync
   result.
-- **On demand** — palette command `Exocortex: Sync parity report`
+- **On demand** — palette command `Exocortex: Check sync status`
   (standalone round, same journal), or from a desktop shell:
 
   ```bash

--- a/docs/tutorials/Getting-Started.md
+++ b/docs/tutorials/Getting-Started.md
@@ -19,7 +19,7 @@ Exocortex has been verified to work with the following minimum versions. Older v
 
 - **Obsidian**: Settings → About → "Current version".
 - **Exocortex plugin**: Settings → Community plugins → Exocortex → "Installed" line. You can also open `.obsidian/plugins/exocortex/manifest.json` in your vault — the `version` field is authoritative.
-- **git** (optional): run `git --version` in a terminal. git is only used when your vault is itself a git repository — the «Bootstrap vault» command then registers the pulled AssetSpaces as git submodules. If your vault is not a git repository (or git is missing), the AssetSpaces are still downloaded and tracked in file-only mode.
+- **git** (optional): run `git --version` in a terminal. git is only used when your vault is itself a git repository — the «Set up the engine» command then registers the pulled AssetSpaces as git submodules. If your vault is not a git repository (or git is missing), the AssetSpaces are still downloaded and tracked in file-only mode.
 
 If any component is below the minimum, update it before continuing.
 
@@ -91,10 +91,10 @@ BRAT will automatically keep the plugin updated with new releases.
 
 ### Step 2: Bootstrap your vault (the engine floor)
 
-The plugin needs ontology files in your vault to enable layouts, action buttons, and commands. Rather than downloading anything by hand, the plugin pulls them straight from public GitHub repositories using its built-in **Bootstrap vault** command.
+The plugin needs ontology files in your vault to enable layouts, action buttons, and commands. Rather than downloading anything by hand, the plugin pulls them straight from public GitHub repositories using its built-in **Set up the engine** command.
 
 1. Open the command palette: **Cmd/Ctrl + P**
-2. Run **"Exocortex: Bootstrap vault"**
+2. Run **"Exocortex: Set up the engine"**
 3. In the dialog:
    - **exo ontology URL** (required): `https://github.com/kitelev/exoas-exo` — the core engine floor (classes, properties, IRI resolution). This is all a clean start needs.
 4. Click **Bootstrap**. The plugin downloads the repository as a tarball via the GitHub REST API, extracts it safely into your vault, and indexes it automatically — no restart needed. In a git-backed vault the pulled AssetSpace is additionally registered as a git submodule (this is the only step that uses `git`).
@@ -102,19 +102,19 @@ The plugin needs ontology files in your vault to enable layouts, action buttons,
 > **Notes**
 >
 > - The repository is **public**, so no GitHub token is required.
-> - A clean bootstrap is **exo-only** (floor = `{exo}`) — the misleading second «exocmd» field was removed. The `exocmd` UI-command library (which generates the action buttons) is added afterwards: either explicitly via **"Add assetspace by URL"** (Step 2b below) or transitively when you **Apply** a profile.
+> - A clean bootstrap is **exo-only** (floor = `{exo}`) — the misleading second «exocmd» field was removed. The `exocmd` UI-command library (which generates the action buttons) is added afterwards: either explicitly via **"Add a knowledge pack"** (Step 2b below) or transitively when you **Apply** a profile.
 > - The URL above is a placeholder — you can point the field at your own fork.
 
 ### Step 2b: Add the starter registry, then apply the starter profile (recommended)
 
 The fastest way to get a complete, working Areas → Projects → Tasks + Daily vault — **without** loading anyone's personal notes — is the **3-step onboarding** built on the **starter registry**:
 
-1. **Bootstrap vault** → `exoas-exo` (Step 2 above; `exocmd` optional, since the profile pulls it).
-2. **Add the registry**: **Cmd/Ctrl + P → "Exocortex: Add assetspace by URL"** → enter
+1. **Set up the engine** → `exoas-exo` (Step 2 above; `exocmd` optional, since the profile pulls it).
+2. **Add the registry**: **Cmd/Ctrl + P → "Exocortex: Add a knowledge pack"** → enter
    `https://github.com/kitelev/exoas-starter-registry`. This is a small public registry — it declares the starter AssetSpaces and a `starter` knowledge profile; it does **not** pull them yet.
 3. **Apply the profile**: **Cmd/Ctrl + P → "Exocortex: Apply profile"** → choose **`starter`**. The plugin materializes exactly the starter set — 7 AssetSpaces: `exo`, `exocmd`, `ems`, `ems-commands`, `period`, `period-commands`, `person` — and nothing else (no `shared-identities`, no personal data).
 
-> **Why this path**: the `starter` profile mounts only what a fresh vault needs (floor = `{exo}`), so first-run indexing is fast and your vault stays free of unrelated assets. You can still add more AssetSpaces later via **"Add assetspace by URL"** — dependencies are **not** pulled automatically.
+> **Why this path**: the `starter` profile mounts only what a fresh vault needs (floor = `{exo}`), so first-run indexing is fast and your vault stays free of unrelated assets. You can still add more AssetSpaces later via **"Add a knowledge pack"** — dependencies are **not** pulled automatically.
 
 > **⚠️ Git-backed vault? Commit before the first Apply.** If your vault is a git repository, Bootstrap + Add-AssetSpace leave the pulled `assetspaces/` as **untracked** files, and **Apply profile** refuses to unmount an AssetSpace with uncommitted changes (it never silently destroys un-pushed work) — you'll see `Apply aborted — N uncommitted file(s) …`. Before step 3, commit the vault once from a terminal at the vault root:
 >
@@ -153,9 +153,9 @@ exo__Asset_label: Test Area
 
 **If action buttons are missing but the layout appears:**
 
-> **What are "action buttons"?** They are clickable controls — Create Task, Set Status Doing, Plan on Today, etc. — that the plugin generates from the **exocmd AssetSpace**. Since a clean bootstrap is exo-only, you get the action buttons once `exocmd` is present — added via **"Add assetspace by URL"** (Step 2b) or pulled transitively when you **Apply** a profile. They are different from the small **filter/toggle buttons** at the top of widgets (Show Effort Area, Show Votes, Hide Empty Slots), which are built into the plugin and work without any AssetSpace.
+> **What are "action buttons"?** They are clickable controls — Create Task, Set Status Doing, Plan on Today, etc. — that the plugin generates from the **exocmd AssetSpace**. Since a clean bootstrap is exo-only, you get the action buttons once `exocmd` is present — added via **"Add a knowledge pack"** (Step 2b) or pulled transitively when you **Apply** a profile. They are different from the small **filter/toggle buttons** at the top of widgets (Show Effort Area, Show Votes, Hide Empty Slots), which are built into the plugin and work without any AssetSpace.
 
-- Verify `exocmd` was mounted (look for an `exocmd` folder under `assetspaces/` in your vault — added via **"Add assetspace by URL"** or by **Apply profile**, not by the exo-only **Bootstrap vault**)
+- Verify `exocmd` was mounted (look for an `exocmd` folder under `assetspaces/` in your vault — added via **"Add a knowledge pack"** or by **Apply profile**, not by the exo-only **Set up the engine**)
 - If the `exocmd/` folder is present and the plugin loads cleanly, fully **quit and reopen Obsidian** (cold restart) to force re-indexing
 - Try Cmd/Ctrl+P → "Reload layout"
 
@@ -403,7 +403,7 @@ Open **Settings → Exocortex** to configure the plugin. Three things worth know
 
 - **Settings live in your vault.** After updating the plugin you will see an `exocortex-settings/` folder appear, with one `exo__Setting` note per setting. This is a one-shot migration (the plugin shows a Notice like _"Exocortex: migrated N setting(s) to vault assets"_); editing those notes is equivalent to changing the setting in the UI. See [Settings Homoiconization](../explanation/settings-homoiconization.md).
 - **Excluded folders**: folder prefixes listed in this setting (default: `09 Templates/`) are skipped by RDF indexing and SHACL-lite validation — useful for template folders whose frontmatter is incomplete by design. Reload Obsidian after editing the list; the indexer snapshots it at startup.
-- **GitHub PAT** (Settings → Exocortex → _Profile: GitHub PAT_): a fine-grained Personal Access Token used to **push** AssetSpace changes and to **pull private** AssetSpaces. You do **not** need it for the public starter onboarding (Steps 2–2b are all public, no token). Set it only when you run **"Exocortex: Sync"** (push), the **"Push current assetspace"** command, or **"Apply profile"** on a profile that includes a private repository. It is stored in `data.local.json` (not `data.json`), so Obsidian Sync **excludes it from network replication**. Use **"Save PAT"** / **"Test connection"** to store and verify it; leave the field blank and click Save to clear it.
+- **GitHub PAT** (Settings → Exocortex → _Profile: GitHub PAT_): a fine-grained Personal Access Token used to **push** AssetSpace changes and to **pull private** AssetSpaces. You do **not** need it for the public starter onboarding (Steps 2–2b are all public, no token). Set it only when you run **"Exocortex: Sync"** (push), the **"Push current knowledge pack"** command, or **"Apply profile"** on a profile that includes a private repository. It is stored in `data.local.json` (not `data.json`), so Obsidian Sync **excludes it from network replication**. Use **"Save PAT"** / **"Test connection"** to store and verify it; leave the field blank and click Save to clear it.
 
 ### Adding your own / private AssetSpaces
 
@@ -412,7 +412,7 @@ The starter onboarding (Step 2b) pulls only **public** repositories, so no token
 1. Configure your **GitHub PAT** in _Settings → Exocortex_ (see the bullet above), scoped to the repositories you own (fine-grained PAT with a per-repository allowlist is recommended).
 2. Declare the AssetSpace in a profile (an `exo__Profile` asset that lists it under `exo__Profile_includes`) and run **"Exocortex: Apply profile"**. Apply uses your PAT to materialize private AssetSpaces.
 
-> The **"Add assetspace by URL"** command is for a single **public** repository (no token), and it does **not** pull that repo's dependencies automatically. For private content, or for a complete dependency-resolved set, prefer the profile path (**Apply profile**) over **Add assetspace by URL**.
+> The **"Add a knowledge pack"** command is for a single **public** repository (no token), and it does **not** pull that repo's dependencies automatically. For private content, or for a complete dependency-resolved set, prefer the profile path (**Apply profile**) over **Add a knowledge pack**.
 
 ---
 
@@ -448,7 +448,7 @@ These are the most common problems encountered by first-time users. Start here b
 
 1. Confirm the `exocmd/`, `ems/`, `exo/`, and `period/` folders exist somewhere in your vault (any location works).
 2. Reload the vault: **Cmd/Ctrl + P → "Reload app without saving"**.
-3. If the folders are missing, re-run **Cmd/Ctrl+P → "Exocortex: Bootstrap vault"** (or **"Exocortex: Add assetspace by URL"** for a single space) to re-download the AssetSpace.
+3. If the folders are missing, re-run **Cmd/Ctrl+P → "Exocortex: Set up the engine"** (or **"Exocortex: Add a knowledge pack"** for a single space) to re-download the AssetSpace.
 
 ### "The Exocortex plugin is not loading"
 
@@ -459,7 +459,7 @@ These are the most common problems encountered by first-time users. Start here b
 1. Open Settings → Community plugins and confirm Exocortex is **toggled on** (not just installed).
 2. Run **Cmd/Ctrl+P → "Exocortex: Open logs"** to view `exocortex-logs.txt` and its real location. The file lives in the **plugin's data folder** (`<vault>/.obsidian/plugins/exocortex/exocortex-logs.txt`), _not_ the vault root — the command shows the exact path and content so you never have to hunt for it. Search for lines starting with `[ERROR]` or `Failed` to see why initialization failed. (By default only warnings and errors are written to the file; for a live stream of everything the plugin is doing, run **"Exocortex: Open activity log"**.)
 3. Open Obsidian's developer console: **Ctrl/Cmd + Shift + I → Console**. Exocortex logs initialization there as well.
-4. If the log mentions schema or RDF errors, a bootstrapped AssetSpace file may be corrupted — re-run **Cmd/Ctrl+P → "Exocortex: Bootstrap vault"** (or **"Exocortex: Add assetspace by URL"** for a single space) to re-download the AssetSpace.
+4. If the log mentions schema or RDF errors, a bootstrapped AssetSpace file may be corrupted — re-run **Cmd/Ctrl+P → "Exocortex: Set up the engine"** (or **"Exocortex: Add a knowledge pack"** for a single space) to re-download the AssetSpace.
 5. As a last resort, disable the plugin, restart Obsidian, re-enable it.
 
 ### "BRAT URL `obsidian://brat?plugin=...` does nothing (Windows)"
@@ -491,7 +491,7 @@ These are the most common problems encountered by first-time users. Start here b
 
 **Cause**: Your plugin is out of date. Current plugin versions substitute `$input` / `$value` directly in `property_set` groundings, and fail with an explicit error instead of silently writing the literal when no input was provided.
 
-**Fix**: Update the plugin (BRAT: **Cmd/Ctrl+P → "BRAT: Check for updates to all beta plugins"**) and restart Obsidian. If the problem persists, re-run **Cmd/Ctrl+P → "Exocortex: Bootstrap vault"** to refresh the exocmd command definitions.
+**Fix**: Update the plugin (BRAT: **Cmd/Ctrl+P → "BRAT: Check for updates to all beta plugins"**) and restart Obsidian. If the problem persists, re-run **Cmd/Ctrl+P → "Exocortex: Set up the engine"** to refresh the exocmd command definitions.
 
 ### General diagnostic: `exocortex-logs.txt`
 
@@ -554,7 +554,7 @@ Exocortex is in active development and feedback from early users is highly valua
 
 When reporting a broken button or grounding, the most useful data is:
 
-1. Plugin version (`manifest.json`) and the date you last ran **Bootstrap vault** (or the pulled `exocmd/` commit).
+1. Plugin version (`manifest.json`) and the date you last ran **Set up the engine** (or the pulled `exocmd/` commit).
 2. The exact button label you clicked.
 3. The target note's full frontmatter.
 4. The last 30 lines of `exocortex-logs.txt` around the click.
@@ -597,7 +597,7 @@ For the full diagnostic walkthrough see [Troubleshooting](#troubleshooting) abov
 | Layout doesn't appear     | Switch to Reading Mode (Ctrl/Cmd + E)                                                                                                                                    |
 | No action buttons visible | Verify the AssetSpaces are bootstrapped (`exocmd/` folder exists in vault); if the folder is present, fully quit and reopen Obsidian (cold restart) to force re-indexing |
 | Action buttons don't work | Run **Exocortex: Open logs** (file lives in the plugin data folder, not vault root); check console (Ctrl/Cmd + Shift + I)                                                |
-| Wiki-links grey           | Reload app without saving (Cmd/Ctrl + P); re-run **Exocortex: Bootstrap vault** if folders missing                                                                       |
+| Wiki-links grey           | Reload app without saving (Cmd/Ctrl + P); re-run **Exocortex: Set up the engine** if folders missing                                                                     |
 | Daily tasks not showing   | Check task has `ems__Effort_plannedStartTimestamp` matching daily note's `pn__DailyNote_day`                                                                             |
 | Literal `$input` written  | Update the plugin via BRAT — current versions substitute `$input`/`$value` in `property_set` groundings                                                                  |
 

--- a/packages/obsidian-plugin/src/ExocortexPlugin.ts
+++ b/packages/obsidian-plugin/src/ExocortexPlugin.ts
@@ -148,6 +148,11 @@ import {
   STARTER_REGISTRY_URL,
   STARTER_PROFILE_QUERY,
 } from "./infrastructure/adapters/firstRunOnboarding";
+import {
+  GROOMED_COMMAND_NAMES,
+  REMOVE_PACK_CONFIRM_TITLE,
+  REMOVE_PACK_CONFIRM_LABEL,
+} from "./application/services/commandPaletteContract";
 import { resolvePastedSecret } from "./presentation/settings/patClipboard";
 import { AssetSpaceMaterializationTracker } from "./infrastructure/adapters/AssetSpaceMaterializationTracker";
 import { injectAssetSpaceMaterializationTriples } from "./infrastructure/adapters/injectAssetSpaceMaterializationTriples";
@@ -396,7 +401,8 @@ export default class ExocortexPlugin extends Plugin {
    *  - `SPARQLApi.injectMaterializationTriples` (filter by status)
    *  - markdown post-processor (✅/⏸ status icon)
    */
-  public assetSpaceMaterializationTracker: AssetSpaceMaterializationTracker | null = null;
+  public assetSpaceMaterializationTracker: AssetSpaceMaterializationTracker | null =
+    null;
 
   override async onload(): Promise<void> {
     try {
@@ -428,7 +434,11 @@ export default class ExocortexPlugin extends Plugin {
       this.notifier = new ObsidianNotificationService({
         recordActivity: recordToast,
       });
-      this.fileLogChannel = new FileLogChannel(this.app.vault.adapter, this.manifest.dir ?? `${this.app.vault.configDir}/plugins/${this.manifest.id}`);
+      this.fileLogChannel = new FileLogChannel(
+        this.app.vault.adapter,
+        this.manifest.dir ??
+          `${this.app.vault.configDir}/plugins/${this.manifest.id}`,
+      );
       await this.fileLogChannel.ensureFileExists();
       this.configureLogChannels();
 
@@ -584,7 +594,8 @@ export default class ExocortexPlugin extends Plugin {
         createObsidianClassLabelResolver(this.app),
         {
           workflowResolver: this.workflowResolver,
-          groundingLoader: (uid) => this.commandResolver.loadGroundingByUid(uid),
+          groundingLoader: (uid) =>
+            this.commandResolver.loadGroundingByUid(uid),
           namedQueryRunner,
           // T1 "Create Instance" (project bbe40f8c) — co-locate new instances in
           // their chosen ontology's folder via the `$isDefinedByFolder` token.
@@ -2679,24 +2690,40 @@ export default class ExocortexPlugin extends Plugin {
               const subj = t.subject;
               const pred = t.predicate;
               const obj = t.object;
-              if (!(subj instanceof DomainIRI) || !(pred instanceof DomainIRI)) continue;
-              let algObj: { type: 'iri'; value: string } | { type: 'literal'; value: string; datatype?: string } | null = null;
+              if (!(subj instanceof DomainIRI) || !(pred instanceof DomainIRI))
+                continue;
+              let algObj:
+                | { type: "iri"; value: string }
+                | { type: "literal"; value: string; datatype?: string }
+                | null = null;
               if (obj instanceof DomainIRI) {
-                algObj = { type: 'iri', value: obj.value };
+                algObj = { type: "iri", value: obj.value };
               } else if (obj instanceof DomainLiteral) {
-                algObj = { type: 'literal', value: obj.value, datatype: obj.datatype?.value };
+                algObj = {
+                  type: "literal",
+                  value: obj.value,
+                  datatype: obj.datatype?.value,
+                };
               }
               if (!algObj) continue;
               algebraTriples.push({
-                subject: { type: 'iri', value: subj.value },
-                predicate: { type: 'iri', value: pred.value },
+                subject: { type: "iri", value: subj.value },
+                predicate: { type: "iri", value: pred.value },
                 object: algObj,
               });
             }
 
-            const shaclRegistry = new ShaclShapeRegistry(shapeRegistry.getAll());
-            const hierarchy: ShaclClassHierarchy = { isSubClassOf: (c, p) => c === p };
-            const report = shaclValidate(algebraTriples, shaclRegistry, hierarchy);
+            const shaclRegistry = new ShaclShapeRegistry(
+              shapeRegistry.getAll(),
+            );
+            const hierarchy: ShaclClassHierarchy = {
+              isSubClassOf: (c, p) => c === p,
+            };
+            const report = shaclValidate(
+              algebraTriples,
+              shaclRegistry,
+              hierarchy,
+            );
 
             const violations = report.violations.filter(
               (v) => v.severity === "sh:Violation",
@@ -2725,7 +2752,9 @@ export default class ExocortexPlugin extends Plugin {
             }
 
             for (const v of infos) {
-              console.debug(`[Exocortex SHACL] Info in ${file.path}: ${v.message}`);
+              console.debug(
+                `[Exocortex SHACL] Info in ${file.path}: ${v.message}`,
+              );
             }
           } catch (err) {
             console.error("[Exocortex] SHACL engine error", err);
@@ -2947,12 +2976,20 @@ export default class ExocortexPlugin extends Plugin {
       log: (message) => {
         this.logger.warn(message);
         // #3540 — surface ExoSync warnings in the activity stream.
-        this.activityLog.record({ category: "exosync", level: "warn", message });
+        this.activityLog.record({
+          category: "exosync",
+          level: "warn",
+          message,
+        });
       },
       logInfo: (message) => {
         this.logger.info(message);
         // #3540 — always-on ExoSync step feed (onProgress info channel).
-        this.activityLog.record({ category: "exosync", level: "info", message });
+        this.activityLog.record({
+          category: "exosync",
+          level: "info",
+          message,
+        });
       },
       // #3498 — opt-in durable verbose FILE trace (default off). Appends the
       // step lines directly to the plugin file log, INDEPENDENT of
@@ -2983,11 +3020,11 @@ export default class ExocortexPlugin extends Plugin {
       settingsStore,
       notify: (message) => this.notifier.info(message),
       // #3540 — fan profile apply / mount / unmount phases into the activity log.
-      onPhase: (entry) => this.activityLog.record(journalEntryToActivity(entry)),
+      onPhase: (entry) =>
+        this.activityLog.record(journalEntryToActivity(entry)),
       // Live per-AssetSpace "Mounting X (2 of 5)" progress during materialize —
       // activity-log-only (never toasted), so a long apply visibly progresses.
-      onProgress: (event) =>
-        this.activityLog.record(progressToActivity(event)),
+      onProgress: (event) => this.activityLog.record(progressToActivity(event)),
       assetSpaceManager: applyDeps?.assetSpaceManager,
       gitOps: applyDeps?.gitOps,
       restMount: restMount ?? undefined,
@@ -3110,25 +3147,27 @@ export default class ExocortexPlugin extends Plugin {
       pushMgrFactory: () => this.buildAssetSpacePusher(),
       profileLister,
       fuzzyPick,
-      getActiveFilePath: () =>
-        this.app.workspace.getActiveFile()?.path ?? null,
+      getActiveFilePath: () => this.app.workspace.getActiveFile()?.path ?? null,
       getActiveProfileUid: () => localDataStore.getActiveProfileUid(),
       notify: (message) => this.notifier.info(message),
     });
 
+    // RFC 0002 §3.2 (P3) — de-jargon: «Push current assetspace» → «Push current
+    // knowledge pack». Name sourced from the palette grooming contract.
     this.addCommand({
       id: "push-current-assetspace",
-      name: "Push current assetspace",
+      name: GROOMED_COMMAND_NAMES["push-current-assetspace"],
       callback: () => {
         void commandsHandler.invokePushCurrentAssetSpace();
       },
     });
 
-    // «Show current state» — reports the last-applied profile (RFC 0a0791c1
-    // Phase 5 T2 — single slot). Available regardless of platform / wiring.
+    // RFC 0002 §3.2 (P3) — de-jargon: «Show current state» → «Show active
+    // profile». Reports the last-applied profile (RFC 0a0791c1 Phase 5 T2 —
+    // single slot). Available regardless of platform / wiring.
     this.addCommand({
       id: "show-profile-state",
-      name: "Show current state",
+      name: GROOMED_COMMAND_NAMES["show-profile-state"],
       callback: () => {
         void commandsHandler.invokeShowCurrentState();
       },
@@ -3188,10 +3227,12 @@ export default class ExocortexPlugin extends Plugin {
     // (stable ids, Sync first) is unit-tested.
     registerExoSyncCommands(this, syncCommands);
 
-    // RFC 22b50a17 Decision #6 — wipe-all switch cache clearing.
+    // RFC 22b50a17 Decision #6 — wipe-all switch cache clearing. RFC 0002 §3.2
+    // (P3/P4) — de-jargon + destructive flag: «Clear switch cache (wipe-all)» →
+    // «Reset profile cache (advanced)». Name sourced from the grooming contract.
     this.addCommand({
       id: "clear-switch-cache",
-      name: "Clear switch cache (wipe-all)",
+      name: GROOMED_COMMAND_NAMES["clear-switch-cache"],
       callback: () => {
         void this.invokeClearSwitchCache();
       },
@@ -3238,9 +3279,7 @@ export default class ExocortexPlugin extends Plugin {
       this.registerUnmountCommand(restMount, switchMgr);
     }
 
-    this.logger.info(
-      "[ExocortexPlugin] Profile palette commands registered",
-    );
+    this.logger.info("[ExocortexPlugin] Profile palette commands registered");
   }
 
   /**
@@ -3575,17 +3614,22 @@ export default class ExocortexPlugin extends Plugin {
       onMaterialized: () => this.refreshAndInjectAssetSpaceMaterialization(),
     });
 
+    // RFC 0002 §3.2 (P3) — de-jargon: «Bootstrap vault» → «Set up the engine»
+    // (matches the §3.1 panel step 1 + §3.3 dialog title). Name sourced from the
+    // palette grooming contract.
     this.addCommand({
       id: "bootstrap-vault",
-      name: "Bootstrap vault",
+      name: GROOMED_COMMAND_NAMES["bootstrap-vault"],
       callback: () => {
         void bootstrapCommands.invokeBootstrap();
       },
     });
 
+    // RFC 0002 §3.2 (P3) — de-jargon: «Add assetspace by URL» → «Add a knowledge
+    // pack» (pairs with «Remove knowledge pack»). Name from the grooming contract.
     this.addCommand({
       id: "add-assetspace",
-      name: "Add assetspace by URL",
+      name: GROOMED_COMMAND_NAMES["add-assetspace"],
       callback: () => {
         void bootstrapCommands.invokeAddAssetSpace();
       },
@@ -3643,7 +3687,9 @@ export default class ExocortexPlugin extends Plugin {
             choices,
             title,
             (chosen) =>
-              resolve(chosen === null ? null : byPath.get(chosen.uid) ?? null),
+              resolve(
+                chosen === null ? null : (byPath.get(chosen.uid) ?? null),
+              ),
           );
           modal.open();
         }),
@@ -3652,9 +3698,11 @@ export default class ExocortexPlugin extends Plugin {
           new SimpleConfirmModal(
             this.app,
             {
-              title: "Unmount assetspace?",
+              // RFC 0002 §3.2 — coherent plain-language flow copy (no jargon
+              // re-entry after the «Remove knowledge pack (advanced)» palette name).
+              title: REMOVE_PACK_CONFIRM_TITLE,
               body: message,
-              confirmLabel: "Unmount",
+              confirmLabel: REMOVE_PACK_CONFIRM_LABEL,
             },
             resolve,
           ).open();
@@ -3665,9 +3713,12 @@ export default class ExocortexPlugin extends Plugin {
       onUnmounted: () => this.refreshAndInjectAssetSpaceMaterialization(),
     });
 
+    // RFC 0002 §3.2 (P3/P4) — de-jargon + destructive flag: «Unmount assetspace»
+    // → «Remove knowledge pack (advanced)». Name sourced from the grooming
+    // contract; id stays stable (Obsidian persists hotkeys by id).
     this.addCommand({
       id: "unmount-assetspace",
-      name: "Unmount assetspace",
+      name: GROOMED_COMMAND_NAMES["unmount-assetspace"],
       callback: () => {
         void unmountCommand.invokeUnmount();
       },
@@ -3709,9 +3760,7 @@ export default class ExocortexPlugin extends Plugin {
 
     try {
       const result = await cache.clear();
-      this.notifier.info(
-        `Cleared ${result.entriesRemoved} cache entries.`,
-      );
+      this.notifier.info(`Cleared ${result.entriesRemoved} cache entries.`);
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       this.notifier.error(`Clear switch cache failed: ${msg}`);
@@ -3742,5 +3791,4 @@ export default class ExocortexPlugin extends Plugin {
         lookupAssetSpaceUidByFolder(this.app, folderName),
     });
   }
-
 }

--- a/packages/obsidian-plugin/src/application/commands/EditPropertiesCommand.ts
+++ b/packages/obsidian-plugin/src/application/commands/EditPropertiesCommand.ts
@@ -1,12 +1,15 @@
 import type { App, TFile } from "obsidian";
 import { ICommand } from "./ICommand";
-import { ExocortexPluginInterface } from '@plugin/types';
-import { PropertyEditorModal } from '@plugin/presentation/modals/PropertyEditorModal';
+import { ExocortexPluginInterface } from "@plugin/types";
+import { PropertyEditorModal } from "@plugin/presentation/modals/PropertyEditorModal";
+import { GROOMED_COMMAND_NAMES } from "@plugin/application/services/commandPaletteContract";
 import type { CommandVisibilityContext, INotificationService } from "exocortex";
 
 export class EditPropertiesCommand implements ICommand {
   id = "edit-properties";
-  name = "edit properties";
+  // RFC 0002 §3.2 (P3) — casing fix: was lowercase «edit properties». Sourced
+  // from the palette grooming contract so production + test never drift.
+  name = GROOMED_COMMAND_NAMES["edit-properties"];
 
   constructor(
     private app: App,

--- a/packages/obsidian-plugin/src/application/services/commandPaletteContract.ts
+++ b/packages/obsidian-plugin/src/application/services/commandPaletteContract.ts
@@ -1,0 +1,84 @@
+/**
+ * Command-palette grooming contract — RFC 0002 §3.2 ([P2, P3, P4, P16]).
+ *
+ * Single source of truth for the **display `name`** of every command groomed in
+ * §3.2, so the de-jargon renames (P3), the casing fix (P3), and the destructive
+ * «(advanced)» text markers (P4/P16) are unit-testable and the production
+ * registration sites can never drift from the contract. Each registration site
+ * (`ExocortexPlugin`, `EditPropertiesCommand`, `registerExoSyncCommands`,
+ * `UnmountAssetSpaceCommand`) imports its name from here rather than re-typing a
+ * literal — so the jest contract test asserts the exact strings users see.
+ *
+ * ⛔ Command **ids are immutable**. Obsidian persists hotkeys + automation by
+ * command id, and `addCommand({ id, name })` treats them as independent keys
+ * with no id-from-name derivation (`CommandManager.ts:66`). §3.2 changes the
+ * display `name` ONLY; the keys of {@link GROOMED_COMMAND_NAMES} are the stable
+ * ids and must stay byte-exact.
+ *
+ * Scope: only the commands §3.2 grooms. Untouched commands (`reload-layout`,
+ * `sync`/`pull`/`push`, `apply-profile`, `open-activity-log`, `open-logs`, …)
+ * are deliberately absent — their names are already plain and benign.
+ */
+
+/** The user-facing text marker that flags a destructive / power-user command. */
+export const ADVANCED_MARKER = "(advanced)";
+
+/**
+ * Canonical de-jargoned display names, keyed by stable (immutable) command id.
+ *
+ * Naming convention: sentence case (matching the existing `Reload layout` /
+ * `Setup (getting started)` siblings — first word capitalised, the rest lower
+ * except proper nouns; the parenthetical marker stays lowercase, consistent
+ * with `(advanced)`).
+ */
+export const GROOMED_COMMAND_NAMES = {
+  // — De-jargon renames (P3) —
+  "bootstrap-vault": "Set up the engine",
+  "add-assetspace": "Add a knowledge pack",
+  "push-current-assetspace": "Push current knowledge pack",
+  "show-profile-state": "Show active profile",
+  "exosync-parity-report": "Check sync status",
+  // — Casing fix (P3): was lowercase «edit properties» —
+  "edit-properties": "Edit properties",
+  // — Destructive, flagged with the «(advanced)» text marker (P4/P16:
+  //   never an emoji glyph alone — assistive-tech reliable) —
+  "unmount-assetspace": "Remove knowledge pack (advanced)",
+  "clear-switch-cache": "Reset profile cache (advanced)",
+} as const;
+
+export type GroomedCommandId = keyof typeof GROOMED_COMMAND_NAMES;
+
+/**
+ * Commands that mutate / destroy user state and therefore MUST carry the
+ * {@link ADVANCED_MARKER} text marker in their display name (RFC 0002 §3.2 P4 /
+ * M5 — 100% of destructive commands carry a text marker, not a glyph alone).
+ */
+export const DESTRUCTIVE_COMMAND_IDS: readonly GroomedCommandId[] = [
+  "unmount-assetspace",
+  "clear-switch-cache",
+];
+
+/**
+ * Action-language titles for the «Remove knowledge pack» (unmount) flow's
+ * picker + confirm step, kept coherent with the groomed palette name so the
+ * de-jargon doesn't reappear mid-flow. The «(advanced)» marker lives only on
+ * the palette entry (a pre-invocation warning); once the user is in the flow the
+ * copy is plain action language.
+ */
+export const REMOVE_PACK_PICKER_TITLE = "Remove knowledge pack";
+export const REMOVE_PACK_CONFIRM_TITLE = "Remove knowledge pack?";
+export const REMOVE_PACK_CONFIRM_LABEL = "Remove";
+
+/**
+ * Rough emoji / pictographic detection — a name that is ONLY such glyphs (plus
+ * whitespace) fails accessibility (screen readers cannot reliably announce a
+ * lone glyph; RFC 0002 P16). Used by the contract test to assert no groomed
+ * name relies on a glyph alone.
+ */
+export function isGlyphOnly(name: string): boolean {
+  const stripped = name.replace(
+    /[\p{Extended_Pictographic}\p{Emoji_Presentation}️‍\s]/gu,
+    "",
+  );
+  return stripped.length === 0;
+}

--- a/packages/obsidian-plugin/src/infrastructure/adapters/SyncCommands.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/SyncCommands.ts
@@ -152,7 +152,8 @@ export class SyncCommands {
       return;
     }
     this.running = true;
-    this.runningLabel = "Sync parity report";
+    // RFC 0002 §3.2 (P3) — coherent with the «Check sync status» command name.
+    this.runningLabel = "Check sync status";
     try {
       if (this.deps.isSwitchInProgress()) {
         this.deps.notify(
@@ -175,9 +176,7 @@ export class SyncCommands {
       this.deps.notify(
         `ExoSync parity check started (${collection.specs.length} repo(s))…`,
       );
-      this.deps.notify(
-        await this.deps.parity.runStandalone(collection.specs),
-      );
+      this.deps.notify(await this.deps.parity.runStandalone(collection.specs));
     } catch (err) {
       const msg = GitHubRestClient.redactTokens(
         err instanceof Error ? err.message : String(err),
@@ -428,7 +427,9 @@ export class SyncCommands {
     const counts =
       `pushed ${pushed}, pulled ${pulled}, merged ${merged}, quarantined ${quarantined}` +
       (deleted > 0 ? `, deleted ${deleted}` : "") +
-      (deferred > 0 ? `, deferred ${deferred} (a full Sync resolves them)` : "");
+      (deferred > 0
+        ? `, deferred ${deferred} (a full Sync resolves them)`
+        : "");
     if (problems.length === 0) {
       this.deps.notify(
         `${label} done: ${synced}/${results.length} repo(s) — ${counts}`,

--- a/packages/obsidian-plugin/src/infrastructure/adapters/UnmountAssetSpaceCommand.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/UnmountAssetSpaceCommand.ts
@@ -1,7 +1,9 @@
 /**
  * UnmountAssetSpaceCommand — command-palette logic handler for the standalone
- * «Exocortex: Unmount assetspace» command (the inverse of «Add assetspace by
- * URL», {@link BootstrapAssetSpaceCommands.invokeAddAssetSpace}).
+ * «Exocortex: Remove knowledge pack (advanced)» command (id `unmount-assetspace`,
+ * stable; display name de-jargoned + destructive-flagged per RFC 0002 §3.2). It
+ * is the inverse of «Add a knowledge pack» (id `add-assetspace`,
+ * {@link BootstrapAssetSpaceCommands.invokeAddAssetSpace}).
  *
  * ## Why this command exists (#e6b8827c)
  *
@@ -31,6 +33,7 @@
  */
 
 import { isTsFloorAssetSpace, isTsFloorMountPath } from "exocortex";
+import { REMOVE_PACK_PICKER_TITLE } from "@plugin/application/services/commandPaletteContract";
 
 /** A currently-mounted AssetSpace the user may pick to unmount. */
 export interface UnmountableAssetSpace {
@@ -145,13 +148,15 @@ export class UnmountAssetSpaceCommand {
     this.d = deps;
   }
 
-  /** Command — `Exocortex: Unmount assetspace`. */
+  /** Command — `Exocortex: Remove knowledge pack (advanced)` (RFC 0002 §3.2). */
   async invokeUnmount(): Promise<void> {
     let mounted: UnmountableAssetSpace[];
     try {
       mounted = await this.d.listMounted();
     } catch (e) {
-      this.d.notify(`Unmount: could not list mounted AssetSpaces — ${this.msg(e)}`);
+      this.d.notify(
+        `Unmount: could not list mounted AssetSpaces — ${this.msg(e)}`,
+      );
       return;
     }
 
@@ -160,7 +165,7 @@ export class UnmountAssetSpaceCommand {
       return;
     }
 
-    const chosen = await this.d.fuzzyPick(mounted, "Unmount assetspace");
+    const chosen = await this.d.fuzzyPick(mounted, REMOVE_PACK_PICKER_TITLE);
     if (chosen === null) return; // user cancelled
 
     // Floor-policy A — refuse, не rescue. Selecting a floor AssetSpace is a

--- a/packages/obsidian-plugin/src/infrastructure/adapters/registerExoSyncCommands.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/registerExoSyncCommands.ts
@@ -8,10 +8,12 @@
  *
  * Obsidian renders palette labels as "<plugin name>: <command name>", so
  * the names below surface as «Exocortex: Sync» / «Exocortex: Pull» /
- * «Exocortex: Push» / «Exocortex: Sync parity report».
+ * «Exocortex: Push» / «Exocortex: Check sync status» (the parity report,
+ * de-jargoned per RFC 0002 §3.2 P3).
  */
 
 import type { SyncCommands } from "./SyncCommands";
+import { GROOMED_COMMAND_NAMES } from "@plugin/application/services/commandPaletteContract";
 
 /**
  * Structural slice of Obsidian's `Plugin.addCommand` — keeps this module
@@ -65,9 +67,11 @@ export function registerExoSyncCommands(
   // over the same materialized set (the post-sync round runs automatically
   // after a full Sync; this command is the on-demand probe — also the
   // manual divergence check for split-only usage, which skips the round).
+  // RFC 0002 §3.2 (P3) — de-jargon: «Sync parity report» → «Check sync status».
+  // Sourced from the palette grooming contract so production + test never drift.
   plugin.addCommand({
     id: "exosync-parity-report",
-    name: "Sync parity report",
+    name: GROOMED_COMMAND_NAMES["exosync-parity-report"],
     callback: () => {
       void syncCommands.invokeParityReport();
     },

--- a/packages/obsidian-plugin/src/presentation/modals/AddAssetSpaceModal.ts
+++ b/packages/obsidian-plugin/src/presentation/modals/AddAssetSpaceModal.ts
@@ -54,13 +54,15 @@ export class AddAssetSpaceModal extends Modal {
 
   override onOpen(): void {
     const { contentEl } = this;
+    // RFC 0002 §3.2 (P3) — coherent plain-language copy with the «Add a
+    // knowledge pack» palette command (no «assetspace» jargon re-entry mid-flow).
     contentEl.createEl("h2", {
       cls: "add-assetspace-title",
-      text: "Add assetspace by URL",
+      text: "Add a knowledge pack",
     });
     contentEl.createEl("p", {
       text:
-        "Pull a single assetspace from a public GitHub repository into this " +
+        "Pull a single knowledge pack from a public GitHub repository into this " +
         "vault. The folder name is derived from the repository name.",
     });
 

--- a/packages/obsidian-plugin/tests/unit/EditPropertiesCommand.test.ts
+++ b/packages/obsidian-plugin/tests/unit/EditPropertiesCommand.test.ts
@@ -71,7 +71,8 @@ describe("EditPropertiesCommand", () => {
     });
 
     it("should have correct name", () => {
-      expect(command.name).toBe("edit properties");
+      // RFC 0002 §3.2 (P3) — casing fix: was lowercase «edit properties».
+      expect(command.name).toBe("Edit properties");
     });
   });
 

--- a/packages/obsidian-plugin/tests/unit/commandPaletteContract.test.ts
+++ b/packages/obsidian-plugin/tests/unit/commandPaletteContract.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Contract tests for the command-palette grooming — RFC 0002 §3.2
+ * ([P2, P3, P4, P16]).
+ *
+ * These lock the single source of truth that the production registration sites
+ * import (`commandPaletteContract`), so the assertions here ARE the strings
+ * users see in the palette — no fixture/production drift (test-fixture-realism).
+ *
+ * Regression-verify discipline: the de-jargon assertions name the exact NEW
+ * strings, so a revert to the old jargon names ("Bootstrap vault", "Unmount
+ * assetspace", lowercase "edit properties", …) turns these tests red.
+ */
+import {
+  ADVANCED_MARKER,
+  GROOMED_COMMAND_NAMES,
+  DESTRUCTIVE_COMMAND_IDS,
+  REMOVE_PACK_PICKER_TITLE,
+  REMOVE_PACK_CONFIRM_TITLE,
+  REMOVE_PACK_CONFIRM_LABEL,
+  isGlyphOnly,
+  type GroomedCommandId,
+} from "@plugin/application/services/commandPaletteContract";
+
+describe("commandPaletteContract — RFC 0002 §3.2 palette grooming", () => {
+  describe("id stability (P3 — ids immutable, only display name changes)", () => {
+    it("keys are exactly the known stable command ids", () => {
+      // If a key is renamed, an Obsidian hotkey / automation bound to the old id
+      // silently breaks (Obsidian persists by id). Lock the id set byte-exact.
+      expect(Object.keys(GROOMED_COMMAND_NAMES).sort()).toEqual(
+        [
+          "add-assetspace",
+          "bootstrap-vault",
+          "clear-switch-cache",
+          "edit-properties",
+          "exosync-parity-report",
+          "push-current-assetspace",
+          "show-profile-state",
+          "unmount-assetspace",
+        ].sort(),
+      );
+    });
+  });
+
+  describe("de-jargon renames (P3)", () => {
+    it.each<[GroomedCommandId, string]>([
+      ["bootstrap-vault", "Set up the engine"],
+      ["add-assetspace", "Add a knowledge pack"],
+      ["push-current-assetspace", "Push current knowledge pack"],
+      ["show-profile-state", "Show active profile"],
+      ["exosync-parity-report", "Check sync status"],
+    ])("%s → plain-language %j", (id, expected) => {
+      expect(GROOMED_COMMAND_NAMES[id]).toBe(expected);
+    });
+
+    it("no groomed name still contains the internal jargon terms", () => {
+      const jargon = /assetspace|bootstrap|parity|switch cache|wipe-all/i;
+      for (const name of Object.values(GROOMED_COMMAND_NAMES)) {
+        expect(name).not.toMatch(jargon);
+      }
+    });
+  });
+
+  describe("casing fix (P3 — `edit properties` was lowercase)", () => {
+    it("edit-properties is sentence case", () => {
+      expect(GROOMED_COMMAND_NAMES["edit-properties"]).toBe("Edit properties");
+    });
+
+    it("every groomed name starts with an uppercase letter (sentence case)", () => {
+      for (const name of Object.values(GROOMED_COMMAND_NAMES)) {
+        expect(name[0]).toBe(name[0].toUpperCase());
+        expect(name[0]).toMatch(/[A-Z]/); // not a glyph / lowercase / digit
+      }
+    });
+  });
+
+  describe("destructive flagging (P4 / P16 / M5)", () => {
+    it("every destructive command id is a known groomed command", () => {
+      for (const id of DESTRUCTIVE_COMMAND_IDS) {
+        expect(GROOMED_COMMAND_NAMES[id]).toBeDefined();
+      }
+    });
+
+    it("100% of destructive commands carry the «(advanced)» text marker (M5)", () => {
+      for (const id of DESTRUCTIVE_COMMAND_IDS) {
+        expect(GROOMED_COMMAND_NAMES[id]).toContain(ADVANCED_MARKER);
+      }
+    });
+
+    it("the marker is real text, not an emoji glyph (P16 — AT-reliable)", () => {
+      // Stripping all glyphs from the marker must leave the literal word.
+      expect(isGlyphOnly(ADVANCED_MARKER)).toBe(false);
+      expect(ADVANCED_MARKER).toBe("(advanced)");
+    });
+
+    it("non-destructive groomed commands do NOT carry the «(advanced)» marker", () => {
+      const destructive = new Set<string>(DESTRUCTIVE_COMMAND_IDS);
+      for (const [id, name] of Object.entries(GROOMED_COMMAND_NAMES)) {
+        if (!destructive.has(id)) {
+          expect(name).not.toContain(ADVANCED_MARKER);
+        }
+      }
+    });
+  });
+
+  describe("accessibility (P16 — no glyph-only name)", () => {
+    it("no groomed command name is glyph-only", () => {
+      for (const name of Object.values(GROOMED_COMMAND_NAMES)) {
+        expect(isGlyphOnly(name)).toBe(false);
+      }
+    });
+
+    it("isGlyphOnly flags a lone emoji and clears plain text", () => {
+      expect(isGlyphOnly("⚠️")).toBe(true);
+      expect(isGlyphOnly("  🗑️ ")).toBe(true);
+      expect(isGlyphOnly("Remove knowledge pack (advanced)")).toBe(false);
+    });
+  });
+
+  describe("unmount flow stays coherent with the groomed palette name", () => {
+    it("picker + confirm copy use the plain «Remove knowledge pack» language", () => {
+      expect(REMOVE_PACK_PICKER_TITLE).toBe("Remove knowledge pack");
+      expect(REMOVE_PACK_CONFIRM_TITLE).toBe("Remove knowledge pack?");
+      expect(REMOVE_PACK_CONFIRM_LABEL).toBe("Remove");
+    });
+
+    it("flow titles carry no «(advanced)» marker (marker is palette-only)", () => {
+      expect(REMOVE_PACK_PICKER_TITLE).not.toContain(ADVANCED_MARKER);
+      expect(REMOVE_PACK_CONFIRM_TITLE).not.toContain(ADVANCED_MARKER);
+    });
+
+    it("flow titles share the palette command's base wording (no jargon re-entry)", () => {
+      expect(GROOMED_COMMAND_NAMES["unmount-assetspace"]).toContain(
+        REMOVE_PACK_PICKER_TITLE,
+      );
+    });
+  });
+});

--- a/packages/obsidian-plugin/tests/unit/infrastructure/adapters/UnmountAssetSpaceCommand.test.ts
+++ b/packages/obsidian-plugin/tests/unit/infrastructure/adapters/UnmountAssetSpaceCommand.test.ts
@@ -130,7 +130,9 @@ describe("UnmountAssetSpaceCommand", () => {
       EXO.submodulePath,
       PMBOK.submodulePath,
     ]);
-    expect(h.state.pickedTitle).toBe("Unmount assetspace");
+    // RFC 0002 §3.2 — picker title de-jargoned, coherent with the «Remove
+    // knowledge pack (advanced)» palette command name.
+    expect(h.state.pickedTitle).toBe("Remove knowledge pack");
   });
 
   it("[floor-refuse] floor pick → REFUSED: no confirm, no unmount, no re-index", async () => {

--- a/packages/obsidian-plugin/tests/unit/property-editor/EditPropertiesCommand.test.ts
+++ b/packages/obsidian-plugin/tests/unit/property-editor/EditPropertiesCommand.test.ts
@@ -41,7 +41,8 @@ describe("EditPropertiesCommand", () => {
     });
 
     it("should have correct name", () => {
-      expect(command.name).toBe("edit properties");
+      // RFC 0002 §3.2 (P3) — casing fix: was lowercase «edit properties».
+      expect(command.name).toBe("Edit properties");
     });
   });
 

--- a/packages/obsidian-plugin/tests/unit/sync/registerExoSyncCommands.test.ts
+++ b/packages/obsidian-plugin/tests/unit/sync/registerExoSyncCommands.test.ts
@@ -64,7 +64,8 @@ describe("registerExoSyncCommands (#3473)", () => {
       ["exosync-sync", "Sync"],
       ["exosync-pull", "Pull"],
       ["exosync-push", "Push"],
-      ["exosync-parity-report", "Sync parity report"],
+      // RFC 0002 §3.2 (P3) — de-jargon: was «Sync parity report». Id stable.
+      ["exosync-parity-report", "Check sync status"],
     ]);
   });
 


### PR DESCRIPTION
## RFC 0002 §3.2 — guided Setup command + palette grooming ([P2, P3, P4, P16])

WBS node: \`873a9b24-da61-4d0a-89a5-8c7a0c92d04d\` · Project: Exocortex Alpha Launch.

Phase 1 (TTFV) palette grooming so a new user meets plain language, not internal jargon, and destructive ops are flagged. **Command ids are immutable** (Obsidian persists hotkeys/automation by id — `CommandManager.ts:66` confirms `id`/`name` are independent keys); **only display `name` strings change**.

### What changed
**De-jargon renames (P3)** — display name only, id stable:
| id (stable) | before | after |
|---|---|---|
| `bootstrap-vault` | Bootstrap vault | **Set up the engine** (matches §3.1 panel step 1 + §3.3 dialog title) |
| `add-assetspace` | Add assetspace by URL | **Add a knowledge pack** |
| `push-current-assetspace` | Push current assetspace | **Push current knowledge pack** |
| `show-profile-state` | Show current state | **Show active profile** |
| `exosync-parity-report` | Sync parity report | **Check sync status** |

**Casing fix (P3)** — `edit-properties`: `edit properties` → **`Edit properties`** (was the lone lowercase name vs sentence-case siblings).

**Destructive flagging (P4 / P16 / M5)** — a text **`(advanced)`** marker (never a glyph alone — assistive-tech reliable):
| id (stable) | before | after |
|---|---|---|
| `unmount-assetspace` | Unmount assetspace | **Remove knowledge pack (advanced)** |
| `clear-switch-cache` | Clear switch cache (wipe-all) | **Reset profile cache (advanced)** |

**Coherent flow copy** (so jargon never re-enters *mid-flow* after the renamed palette entry): the unmount picker + confirm titles, the AddAssetSpace modal title/body, and the parity running-label.

### Already shipped (DoD item 1)
`Exocortex: Setup (getting started)` (id `setup-getting-started`, the re-entry point into the §3.1 first-run panel) shipped **with §3.1** (v16.100.0) and is tested in `firstRunOnboarding.test.ts`. No change needed here.

### Design — single source of truth
New `commandPaletteContract.ts` holds every groomed name keyed by stable id + the destructive set; every registration site imports from it (no production↔test drift — test-fixture-realism). New `commandPaletteContract.test.ts` (18 tests) asserts the exact user-facing strings, id-stability, the destructive-marker invariant (M5: 100% of destructive commands carry the text marker), and no glyph-only name (P16). Regression-verify: a revert to the old jargon names turns the contract test red.

### Safety
- **Desktop↔Mobile parity** unaffected — no `Platform` gates added; MOBILE-004 archgate green.
- **e2e-safe** — eka specs drive these commands by **id** (`exocortex:bootstrap-vault`, …) + CSS selectors (`.add-assetspace-input`), not display names. CSS class names unchanged.
- **parity-gate** (CLI↔plugin *triple* parity) unaffected — display-only change, no RDF impact.

### Tests
- typecheck (`check:types`) ✅ · lint ✅ · prettier ✅ · archgate 21/21 ✅
- Full obsidian-plugin unit suite: 280 suites, 5465+ pass (the only red was `VaultSettingsRegistry` requiring the `exoas-exo` submodule — passes once submodules init; CI uses `submodules: recursive`).