### PR TITLE
feat(plugin): «Refresh link labels» command — re-resolve wikilink labels after materialize without restart

### DIFF
--- a/packages/obsidian-plugin/src/ExocortexPlugin.ts
+++ b/packages/obsidian-plugin/src/ExocortexPlugin.ts
@@ -117,6 +117,8 @@ import { PluginLockManager } from "./infrastructure/adapters/PluginLockManager";
 import { VaultProfileResolver } from "./infrastructure/adapters/VaultProfileResolver";
 import { PluginRdfIndexerAdapter } from "./infrastructure/adapters/PluginRdfIndexerAdapter";
 import { createProfileApplyRefreshHook } from "./infrastructure/adapters/profileApplyRefreshHook";
+import { LinkLabelRefreshService } from "./application/services/LinkLabelRefreshService";
+import { registerRefreshLinkLabelsCommand } from "./infrastructure/adapters/registerRefreshLinkLabelsCommand";
 import { PluginSettingsStoreAdapter } from "./infrastructure/adapters/PluginSettingsStoreAdapter";
 import { PluginLocalDataStore } from "./infrastructure/adapters/PluginLocalDataStore";
 import { StagingDirTracker } from "./infrastructure/adapters/StagingDirTracker";
@@ -907,6 +909,31 @@ export default class ExocortexPlugin extends Plugin {
       this.commandManager.registerAllCommands(this, () =>
         this.autoRenderLayout(),
       );
+
+      // Веха 1 / MVP (WBS bb1c98af + 844ced36) — «Exocortex: Refresh link
+      // labels». After materialising an AssetSpace, bare `[[uid]]` wikilinks
+      // whose target lived in the previously-unmounted space keep showing the
+      // raw `uid` until an Obsidian restart (open editor views hold a stale
+      // DecorationSet; nothing re-runs `buildDecorations`). This command
+      // re-resolves them in place — ensure the index is fresh
+      // (`sparql.refresh()` → `convertVault()`, so even NEW tabs resolve),
+      // reconfigure all open editor views (`updateOptions()` recreates the
+      // WikilinkLabelViewPlugin instances → fresh decorations), and re-render
+      // dynamic layouts. The same `LinkLabelRefreshService.refresh()` is the
+      // unit the Веха 2 auto-hook will reuse. Registered UNCONDITIONALLY (no
+      // Platform gate): pure in-memory re-resolve, no Node/fs/git
+      // (Desktop↔Mobile Command Parity). Graceful — never throws / shows a
+      // Notice; unresolvable links simply stay `uid`.
+      const linkLabelRefreshService = new LinkLabelRefreshService({
+        ensureIndexFresh: () => this.sparql.refresh(),
+        rebuildEditorViews: () => this.app.workspace.updateOptions(),
+        rerenderLayouts: () => this.autoRenderLayout(),
+        logger: {
+          debug: (message, ...args) => this.logger.debug(message, ...args),
+          warn: (message, ...args) => this.logger.warn(message, ...args),
+        },
+      });
+      registerRefreshLinkLabelsCommand(this, linkLabelRefreshService);
 
       // RFC 0a0791c1 #3322 — register Profile palette commands
       // (Switch / Push current assetspace). Wraps the B.7 handler with

--- a/packages/obsidian-plugin/src/application/services/LinkLabelRefreshService.ts
+++ b/packages/obsidian-plugin/src/application/services/LinkLabelRefreshService.ts
@@ -75,10 +75,15 @@ export interface LinkLabelRefreshDeps {
    */
   ensureIndexFresh: () => Promise<void> | void;
   /**
-   * Force every open Markdown editor view to reconfigure its editor
-   * extensions — recreates the `WikilinkLabelViewPlugin` instances → fresh
-   * `buildDecorations` against the current `metadataCache`. Maps to
-   * `app.workspace.updateOptions()`.
+   * Force every open Markdown editor view to reconfigure ALL of its editor
+   * extensions — recreating the `WikilinkLabelViewPlugin` instances among them
+   * → fresh `buildDecorations` against the current `metadataCache`. Maps to
+   * `app.workspace.updateOptions()`, which (per Obsidian's API docs)
+   * reconfigures all open Markdown views and is "fairly expensive". CodeMirror
+   * preserves cursor/scroll/selection across the reconfigure (they live in
+   * editor state, not the extensions), so there is no user-visible disruption.
+   * Acceptable for a rare, user-initiated command; the Веха 2 auto-hook that
+   * reuses `refresh()` should weigh this all-extensions cost per profile-apply.
    */
   rebuildEditorViews: () => void;
   /**

--- a/packages/obsidian-plugin/src/application/services/LinkLabelRefreshService.ts
+++ b/packages/obsidian-plugin/src/application/services/LinkLabelRefreshService.ts
@@ -1,0 +1,136 @@
+/**
+ * Re-resolve wikilink display labels (and triple-store-backed relation
+ * labels) without an Obsidian restart — the heart of the «Exocortex: Refresh
+ * link labels» command (Веха 1 / MVP, WBS `bb1c98af`).
+ *
+ * ## Why this exists (AS-IS bug, root-cause)
+ *
+ * A bare `[[uid]]` wikilink whose target `B` lives in a NOT-yet-materialised
+ * AssetSpace renders as the raw `uid`:
+ * `WikilinkLabelViewPlugin.resolveDisplayName` → `metadataCache
+ * .getFirstLinkpathDest(uid)` → `null` (file absent) → no `Decoration.replace`
+ * → Obsidian draws the raw `[[uid]]`.
+ *
+ * After the user materialises B's AssetSpace, B exists on disk, BUT the label
+ * STILL shows `uid` until an Obsidian restart, because:
+ *  - `WikilinkLabelViewPlugin.update()` rebuilds its `DecorationSet` only on
+ *    `docChanged / viewportChanged / selectionSet / geometryChanged`. It is
+ *    NOT subscribed to `metadataCache` events, so an already-open note holds a
+ *    stale `DecorationSet` (no decoration for `[[uid]]`).
+ *  - The materialize/apply path refreshes the triple store + re-renders
+ *    dynamic layouts, but never touches the CodeMirror editor views.
+ *
+ * A restart recreates the editor views → fresh `buildDecorations` already sees
+ * the indexed B → the label resolves.
+ *
+ * ## What this service does (without a restart)
+ *
+ * 1. **Ensure the index is fresh** (`ensureIndexFresh`) — re-run the same
+ *    vault index rebuild the apply path uses (`sparql.refresh()` →
+ *    `convertVault()`), so the triple store reflects the now-materialised B,
+ *    and new editor views (opened after this runs) resolve against an
+ *    up-to-date vault tree. This is the «index sees B» guarantee — the
+ *    requirement that even NEW tabs show fresh labels, not just a repaint of
+ *    the open ones.
+ * 2. **Force-rebuild open editor views** (`rebuildEditorViews`) — reconfigure
+ *    every open Markdown view (`app.workspace.updateOptions()`), which
+ *    recreates the `WikilinkLabelViewPlugin` instances and re-runs
+ *    `buildDecorations` against the current `metadataCache`. This is what a
+ *    restart does to the open views, minus the restart.
+ * 3. **Re-render dynamic layouts** (`rerenderLayouts`) — `autoRenderLayout()`,
+ *    for triple-store-backed relation labels in reading-mode layouts.
+ *
+ * ## Graceful by contract
+ *
+ * Each step is isolated: a failure in one is logged (debug/warn) and never
+ * aborts the others, never throws out of `refresh()`, and never shows a
+ * Notice. Links whose target is still unresolvable simply stay as their raw
+ * `uid` — the `WikilinkLabelViewPlugin` already degrades that way (no label →
+ * no decoration → raw text). There is no error path for the user.
+ *
+ * ## Reuse (Веха 2 — auto re-resolve on profile-apply)
+ *
+ * The same `refresh()` is the unit the auto-hook (`createProfileApplyRefresh\
+ * Hook`) will call so that materialise/apply re-resolves labels automatically,
+ * with no manual command. Keeping the orchestration here (deps injected) lets
+ * both the manual command and the future auto-hook share one implementation.
+ */
+
+/**
+ * Minimal structural logger — keeps this service free of a concrete logger
+ * import and trivially unit-testable. Both methods are optional; the plugin
+ * wires its `ILogger` (whose `debug`/`warn` accept `(message, ...args)`).
+ */
+export interface LinkLabelRefreshLogger {
+  debug?(message: string, ...args: unknown[]): void;
+  warn?(message: string, ...args: unknown[]): void;
+}
+
+export interface LinkLabelRefreshDeps {
+  /**
+   * Ensure the RDF index reflects the current on-disk vault state so a
+   * newly-materialised target resolves (including in NEW tabs). Maps to
+   * `sparql.refresh()` in production (the same rebuild the apply path runs).
+   * May be async + store-touching.
+   */
+  ensureIndexFresh: () => Promise<void> | void;
+  /**
+   * Force every open Markdown editor view to reconfigure its editor
+   * extensions — recreates the `WikilinkLabelViewPlugin` instances → fresh
+   * `buildDecorations` against the current `metadataCache`. Maps to
+   * `app.workspace.updateOptions()`.
+   */
+  rebuildEditorViews: () => void;
+  /**
+   * Re-render the triple-store-backed dynamic layouts (relation labels). Maps
+   * to `autoRenderLayout()`.
+   */
+  rerenderLayouts: () => void;
+  /** Optional logger for graceful per-step failure visibility. */
+  logger?: LinkLabelRefreshLogger;
+}
+
+export class LinkLabelRefreshService {
+  constructor(private readonly deps: LinkLabelRefreshDeps) {}
+
+  /**
+   * Re-resolve wikilink + relation display labels in place. Graceful: each
+   * step is isolated, nothing throws, nothing shows a Notice. Steps run in
+   * order — index-fresh first (so the subsequent view rebuild resolves
+   * against an up-to-date index), then editor-view rebuild, then layouts.
+   */
+  async refresh(): Promise<void> {
+    // (1) Ensure the index is fresh — async + store-touching. Isolated so a
+    // refresh failure still lets the open views + layouts rebuild against
+    // whatever the index currently holds.
+    try {
+      await this.deps.ensureIndexFresh();
+    } catch (err) {
+      this.deps.logger?.warn?.(
+        "[LinkLabelRefresh] ensureIndexFresh failed (continuing)",
+        err,
+      );
+    }
+
+    // (2) Force-rebuild open editor views → fresh wikilink-label decorations.
+    try {
+      this.deps.rebuildEditorViews();
+    } catch (err) {
+      this.deps.logger?.warn?.(
+        "[LinkLabelRefresh] rebuildEditorViews failed (continuing)",
+        err,
+      );
+    }
+
+    // (3) Re-render dynamic layouts → fresh triple-store-backed relation
+    // labels.
+    try {
+      this.deps.rerenderLayouts();
+    } catch (err) {
+      this.deps.logger?.warn?.(
+        "[LinkLabelRefresh] rerenderLayouts failed (continuing)",
+        err,
+      );
+    }
+  }
+}

--- a/packages/obsidian-plugin/src/infrastructure/adapters/registerRefreshLinkLabelsCommand.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/registerRefreshLinkLabelsCommand.ts
@@ -1,0 +1,43 @@
+/**
+ * Palette registration for the «Exocortex: Refresh link labels» command
+ * (Веха 1 / MVP, WBS `844ced36`). Extracted from `ExocortexPlugin.onload` so
+ * the registration contract is unit-testable: the command id MUST stay
+ * byte-exact (Obsidian persists hotkeys by command id).
+ *
+ * Obsidian renders palette labels as "<plugin name>: <command name>", so the
+ * name `Refresh link labels` surfaces as «Exocortex: Refresh link labels».
+ *
+ * Registered UNCONDITIONALLY (no `Platform.isMobile` gate): the handler is a
+ * pure in-memory re-resolve (index refresh + editor-view reconfigure + layout
+ * re-render) with no Node `fs` / git dependency, so it works identically on
+ * desktop and mobile (Desktop↔Mobile Command Parity invariant).
+ */
+
+import type { LinkLabelRefreshService } from "@plugin/application/services/LinkLabelRefreshService";
+
+/**
+ * Structural slice of Obsidian's `Plugin.addCommand` — keeps this module free
+ * of an `obsidian` runtime import (unit-testable with a plain object).
+ */
+export interface RefreshLinkLabelsCommandRegistrar {
+  addCommand(command: {
+    id: string;
+    name: string;
+    callback: () => void;
+  }): unknown;
+}
+
+export function registerRefreshLinkLabelsCommand(
+  plugin: RefreshLinkLabelsCommandRegistrar,
+  service: LinkLabelRefreshService,
+): void {
+  plugin.addCommand({
+    id: "refresh-link-labels",
+    name: "Refresh link labels",
+    callback: () => {
+      // Fire-and-forget: refresh() is graceful (never throws, never shows a
+      // Notice), so the palette callback needs no error handling.
+      void service.refresh();
+    },
+  });
+}

--- a/packages/obsidian-plugin/tests/unit/application/services/LinkLabelRefreshService.test.ts
+++ b/packages/obsidian-plugin/tests/unit/application/services/LinkLabelRefreshService.test.ts
@@ -1,0 +1,149 @@
+/**
+ * LinkLabelRefreshService unit tests (Веха 1 / MVP, WBS bb1c98af + 74cac7b0).
+ *
+ * The service orchestrates a wikilink-label re-resolve without an Obsidian
+ * restart: (1) ensure the index is fresh, (2) force-rebuild open editor views,
+ * (3) re-render dynamic layouts. Contract: graceful — each step is isolated,
+ * nothing throws out of `refresh()`, nothing shows a Notice, and a failure in
+ * one step never aborts the others.
+ *
+ * These are production-shape tests: the injected deps mirror the real wiring
+ * (`sparql.refresh()` is async + store-touching; `updateOptions()` and
+ * `autoRenderLayout()` are synchronous side-effects). No stub returns a
+ * "success" value that the real runtime wouldn't.
+ */
+
+import {
+  LinkLabelRefreshService,
+  type LinkLabelRefreshDeps,
+} from "@plugin/application/services/LinkLabelRefreshService";
+
+function makeDeps(
+  overrides: Partial<LinkLabelRefreshDeps> = {},
+): { deps: LinkLabelRefreshDeps; calls: string[]; warnings: string[] } {
+  const calls: string[] = [];
+  const warnings: string[] = [];
+  const deps: LinkLabelRefreshDeps = {
+    ensureIndexFresh: jest.fn(async () => {
+      calls.push("ensureIndexFresh");
+    }),
+    rebuildEditorViews: jest.fn(() => {
+      calls.push("rebuildEditorViews");
+    }),
+    rerenderLayouts: jest.fn(() => {
+      calls.push("rerenderLayouts");
+    }),
+    logger: {
+      debug: jest.fn(),
+      warn: jest.fn((message: string) => {
+        warnings.push(message);
+      }),
+    },
+    ...overrides,
+  };
+  return { deps, calls, warnings };
+}
+
+describe("LinkLabelRefreshService", () => {
+  it("runs all three re-resolve steps in order (index-fresh → views → layouts)", async () => {
+    const { deps, calls } = makeDeps();
+    const service = new LinkLabelRefreshService(deps);
+
+    await service.refresh();
+
+    expect(calls).toEqual([
+      "ensureIndexFresh",
+      "rebuildEditorViews",
+      "rerenderLayouts",
+    ]);
+    expect(deps.ensureIndexFresh).toHaveBeenCalledTimes(1);
+    expect(deps.rebuildEditorViews).toHaveBeenCalledTimes(1);
+    expect(deps.rerenderLayouts).toHaveBeenCalledTimes(1);
+  });
+
+  it("awaits the async ensureIndexFresh before rebuilding views (new tabs resolve a fresh index)", async () => {
+    const order: string[] = [];
+    let resolveFresh!: () => void;
+    const { deps } = makeDeps({
+      ensureIndexFresh: jest.fn(
+        () =>
+          new Promise<void>((resolve) => {
+            resolveFresh = () => {
+              order.push("ensureIndexFresh");
+              resolve();
+            };
+          }),
+      ),
+      rebuildEditorViews: jest.fn(() => {
+        order.push("rebuildEditorViews");
+      }),
+    });
+    const service = new LinkLabelRefreshService(deps);
+
+    const pending = service.refresh();
+    // rebuildEditorViews must NOT have fired before the async index refresh
+    // settles — otherwise open views rebuild against a stale index.
+    expect(order).toEqual([]);
+    resolveFresh();
+    await pending;
+
+    expect(order).toEqual(["ensureIndexFresh", "rebuildEditorViews"]);
+  });
+
+  describe("graceful — never throws, never aborts later steps", () => {
+    it("continues to rebuild views + layouts when ensureIndexFresh throws", async () => {
+      const { deps, calls, warnings } = makeDeps({
+        ensureIndexFresh: jest.fn(async () => {
+          throw new Error("index rebuild boom");
+        }),
+      });
+      const service = new LinkLabelRefreshService(deps);
+
+      await expect(service.refresh()).resolves.toBeUndefined();
+
+      // Index step failed but the load-bearing view rebuild + layouts still ran.
+      expect(calls).toEqual(["rebuildEditorViews", "rerenderLayouts"]);
+      expect(warnings.some((w) => w.includes("ensureIndexFresh"))).toBe(true);
+    });
+
+    it("continues to re-render layouts when rebuildEditorViews throws", async () => {
+      const { deps, calls, warnings } = makeDeps({
+        rebuildEditorViews: jest.fn(() => {
+          throw new Error("updateOptions boom");
+        }),
+      });
+      const service = new LinkLabelRefreshService(deps);
+
+      await expect(service.refresh()).resolves.toBeUndefined();
+
+      expect(calls).toEqual(["ensureIndexFresh", "rerenderLayouts"]);
+      expect(warnings.some((w) => w.includes("rebuildEditorViews"))).toBe(true);
+    });
+
+    it("never throws when rerenderLayouts throws (last step)", async () => {
+      const { deps, calls, warnings } = makeDeps({
+        rerenderLayouts: jest.fn(() => {
+          throw new Error("autoRenderLayout boom");
+        }),
+      });
+      const service = new LinkLabelRefreshService(deps);
+
+      await expect(service.refresh()).resolves.toBeUndefined();
+
+      expect(calls).toEqual(["ensureIndexFresh", "rebuildEditorViews"]);
+      expect(warnings.some((w) => w.includes("rerenderLayouts"))).toBe(true);
+    });
+
+    it("does not require a logger (optional dep) and still never throws", async () => {
+      const { deps } = makeDeps({
+        logger: undefined,
+        ensureIndexFresh: jest.fn(async () => {
+          throw new Error("boom");
+        }),
+      });
+      const service = new LinkLabelRefreshService(deps);
+
+      await expect(service.refresh()).resolves.toBeUndefined();
+    });
+  });
+});

--- a/packages/obsidian-plugin/tests/unit/infrastructure/registerRefreshLinkLabelsCommand.test.ts
+++ b/packages/obsidian-plugin/tests/unit/infrastructure/registerRefreshLinkLabelsCommand.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Palette registration for «Exocortex: Refresh link labels» (Веха 1 / MVP,
+ * WBS 844ced36). The command id MUST stay byte-exact (Obsidian persists
+ * hotkeys by command id). Obsidian renders palette labels as
+ * "<plugin name>: <command name>", so name "Refresh link labels" surfaces as
+ * «Exocortex: Refresh link labels».
+ *
+ * Registered UNCONDITIONALLY (no Platform gate) — verified here by the absence
+ * of any platform branch: the registrar always adds exactly one command.
+ */
+
+import {
+  registerRefreshLinkLabelsCommand,
+  type RefreshLinkLabelsCommandRegistrar,
+} from "@plugin/infrastructure/adapters/registerRefreshLinkLabelsCommand";
+import { LinkLabelRefreshService } from "@plugin/application/services/LinkLabelRefreshService";
+
+interface RegisteredCommand {
+  id: string;
+  name: string;
+  callback: () => void;
+}
+
+function makeRegistrar(): {
+  plugin: RefreshLinkLabelsCommandRegistrar;
+  added: RegisteredCommand[];
+} {
+  const added: RegisteredCommand[] = [];
+  const plugin: RefreshLinkLabelsCommandRegistrar = {
+    addCommand: (command) => {
+      added.push(command);
+      return command;
+    },
+  };
+  return { plugin, added };
+}
+
+function makeService(): {
+  service: LinkLabelRefreshService;
+  refreshSpy: jest.Mock;
+} {
+  const refreshSpy = jest.fn(async () => undefined);
+  const service = new LinkLabelRefreshService({
+    ensureIndexFresh: refreshSpy,
+    rebuildEditorViews: () => undefined,
+    rerenderLayouts: () => undefined,
+  });
+  return { service, refreshSpy };
+}
+
+describe("registerRefreshLinkLabelsCommand (Веха 1 / MVP)", () => {
+  it("registers exactly one command with the stable id/name", () => {
+    const { plugin, added } = makeRegistrar();
+    const { service } = makeService();
+
+    registerRefreshLinkLabelsCommand(plugin, service);
+
+    expect(added).toHaveLength(1);
+    expect(added[0].id).toBe("refresh-link-labels");
+    expect(added[0].name).toBe("Refresh link labels");
+  });
+
+  it("wires the palette callback to LinkLabelRefreshService.refresh()", () => {
+    const { plugin, added } = makeRegistrar();
+    const { service } = makeService();
+    const refreshSpy = jest
+      .spyOn(service, "refresh")
+      .mockResolvedValue(undefined);
+
+    registerRefreshLinkLabelsCommand(plugin, service);
+    // Invoking the palette callback must trigger the re-resolve.
+    added[0].callback();
+
+    expect(refreshSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("callback does not throw even when a re-resolve step fails (graceful, fire-and-forget)", async () => {
+    const { plugin, added } = makeRegistrar();
+    // Real service whose index-refresh step throws — refresh() is graceful and
+    // RESOLVES (never rejects), so `void service.refresh()` produces no
+    // unhandled rejection. (Mocking refresh() to reject would test an
+    // impossible contract; the service swallows step failures by design.)
+    const ensureIndexFresh = jest.fn(async () => {
+      throw new Error("index rebuild boom");
+    });
+    const rebuildEditorViews = jest.fn();
+    const service = new LinkLabelRefreshService({
+      ensureIndexFresh,
+      rebuildEditorViews,
+      rerenderLayouts: () => undefined,
+    });
+
+    registerRefreshLinkLabelsCommand(plugin, service);
+
+    expect(() => added[0].callback()).not.toThrow();
+    // Let the fire-and-forget promise settle; the later step still ran.
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(rebuildEditorViews).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/obsidian-plugin/tests/unit/presentation/editor-extensions/refresh-link-labels.integration.test.ts
+++ b/packages/obsidian-plugin/tests/unit/presentation/editor-extensions/refresh-link-labels.integration.test.ts
@@ -1,0 +1,189 @@
+/**
+ * Integration: «Exocortex: Refresh link labels» re-resolves a bare `[[uid]]`
+ * wikilink in an ALREADY-OPEN editor view after its target AssetSpace is
+ * materialised — without an Obsidian restart (Веха 1 / MVP, WBS 74cac7b0).
+ *
+ * Faithful model (test-fixture-realism):
+ *  - `metadataCache` is a production-shape fake: `getFirstLinkpathDest(uid)`
+ *    returns `null` when the file is absent (exactly Obsidian's contract), a
+ *    `TFile` only once it is present; `getFileCache` returns frontmatter only
+ *    for present files. It is parameterised by a mutable `indexedFiles` map
+ *    that models Obsidian's vault tree (what materialise + the file watcher
+ *    reconcile into).
+ *  - The "editor view" double drives the REAL label-resolution code path:
+ *    `WikilinkLabelViewPlugin.resolveLabel(metadataCache, uid)`. It caches its
+ *    rendered text exactly like `buildDecorations` does — a decoration (label)
+ *    is produced only when `label && label !== uid`; otherwise the raw `uid`
+ *    is shown. `reconfigure()` models `app.workspace.updateOptions()` recreating
+ *    the ViewPlugin → a fresh `buildDecorations`.
+ *
+ * Revert-verify (integration-test-revert-verify): a service variant whose
+ * `rebuildEditorViews` is a no-op leaves the open view stale → proves the
+ * editor-view rebuild step is load-bearing, not vacuous.
+ */
+
+import { WikilinkLabelViewPlugin } from "@plugin/presentation/editor-extensions/WikilinkLabelViewPlugin";
+import { LinkLabelRefreshService } from "@plugin/application/services/LinkLabelRefreshService";
+import { TFile } from "obsidian";
+
+const B_UID = "369c1b17-1296-4ec8-bdb9-c73fb74c0085";
+const B_LABEL = "Daily";
+const MISSING_UID = "ffffffff-0000-0000-0000-000000000000";
+
+/**
+ * Production-shape MetadataCache fake backed by a mutable `indexedFiles` map.
+ * Mirrors Obsidian: a linkpath the vault tree does not know about resolves to
+ * `null` (NOT a stub that always returns a file).
+ */
+function makeMetadataCache(indexedFiles: Map<string, { label?: string }>) {
+  return {
+    getFirstLinkpathDest: (linkpath: string): TFile | null => {
+      const key = linkpath.endsWith(".md") ? linkpath.slice(0, -3) : linkpath;
+      if (!indexedFiles.has(key)) return null;
+      const file = new TFile();
+      (file as unknown as { path: string }).path = `${key}.md`;
+      return file;
+    },
+    getFileCache: (file: TFile) => {
+      const key = file.path.replace(/\.md$/, "");
+      const entry = indexedFiles.get(key);
+      if (!entry) return null;
+      return {
+        frontmatter:
+          entry.label !== undefined
+            ? { exo__Asset_label: entry.label }
+            : {},
+      };
+    },
+  };
+}
+
+/**
+ * Drives the REAL `WikilinkLabelViewPlugin.resolveLabel` exactly as
+ * `buildDecorations` does: caches the rendered text for a single `[[uid]]`
+ * wikilink. A label is shown only when it resolves to a non-uid string.
+ */
+class WikilinkEditorViewDouble {
+  private rendered: string;
+
+  constructor(
+    private readonly uid: string,
+    private readonly metadataCache: ReturnType<typeof makeMetadataCache>,
+  ) {
+    this.rendered = this.compute();
+  }
+
+  /** Models `app.workspace.updateOptions()` recreating the ViewPlugin. */
+  reconfigure(): void {
+    this.rendered = this.compute();
+  }
+
+  /** What the user sees for the `[[uid]]` link. */
+  display(): string {
+    return this.rendered;
+  }
+
+  private compute(): string {
+    const label = WikilinkLabelViewPlugin.resolveLabel(
+      this.metadataCache as never,
+      this.uid,
+    );
+    // Mirror buildDecorations: decoration (label) only when label && != uid.
+    return label && label !== this.uid ? label : this.uid;
+  }
+}
+
+describe("Refresh link labels — re-resolve after materialize (integration)", () => {
+  it("AS-IS bug: an open view stays `uid` after materialize until something rebuilds it", () => {
+    const indexedFiles = new Map<string, { label?: string }>();
+    const metadataCache = makeMetadataCache(indexedFiles);
+
+    // Note A open BEFORE B's AssetSpace is materialised → raw uid.
+    const view = new WikilinkEditorViewDouble(B_UID, metadataCache);
+    expect(view.display()).toBe(B_UID);
+
+    // User materialises B's AssetSpace (now on disk + reconciled into the
+    // vault tree). The metadataCache CAN now resolve B...
+    indexedFiles.set(B_UID, { label: B_LABEL });
+
+    // ...but the already-open view holds a stale DecorationSet → still `uid`.
+    // (This is the bug: nothing re-runs buildDecorations.)
+    expect(view.display()).toBe(B_UID);
+  });
+
+  it("THE FIX: running the command re-resolves the open view to the label without a restart", async () => {
+    const indexedFiles = new Map<string, { label?: string }>();
+    const metadataCache = makeMetadataCache(indexedFiles);
+    const view = new WikilinkEditorViewDouble(B_UID, metadataCache);
+    indexedFiles.set(B_UID, { label: B_LABEL }); // materialise + reconcile
+
+    // Stale before the command.
+    expect(view.display()).toBe(B_UID);
+
+    const service = new LinkLabelRefreshService({
+      ensureIndexFresh: async () => undefined, // triple-store refresh (layouts)
+      rebuildEditorViews: () => view.reconfigure(), // updateOptions()
+      rerenderLayouts: () => undefined,
+    });
+    await service.refresh();
+
+    // Resolved to the label — no Obsidian restart needed.
+    expect(view.display()).toBe(B_LABEL);
+  });
+
+  it("REVERT-VERIFY: with the editor-view rebuild removed, the open view stays stale (`uid`)", async () => {
+    const indexedFiles = new Map<string, { label?: string }>();
+    const metadataCache = makeMetadataCache(indexedFiles);
+    const view = new WikilinkEditorViewDouble(B_UID, metadataCache);
+    indexedFiles.set(B_UID, { label: B_LABEL });
+
+    // Service variant with rebuildEditorViews neutered → models reverting the
+    // load-bearing re-resolve step. The view must NOT update.
+    const serviceWithoutRebuild = new LinkLabelRefreshService({
+      ensureIndexFresh: async () => undefined,
+      rebuildEditorViews: () => undefined, // <-- reverted step
+      rerenderLayouts: () => undefined,
+    });
+    await serviceWithoutRebuild.refresh();
+
+    expect(view.display()).toBe(B_UID); // FAILS to resolve → proves step matters
+
+    // Restore the step → resolves (PASS).
+    const serviceWithRebuild = new LinkLabelRefreshService({
+      ensureIndexFresh: async () => undefined,
+      rebuildEditorViews: () => view.reconfigure(),
+      rerenderLayouts: () => undefined,
+    });
+    await serviceWithRebuild.refresh();
+    expect(view.display()).toBe(B_LABEL);
+  });
+
+  it("new tabs resolve fresh once the index sees B (no command needed for a NEW view)", () => {
+    const indexedFiles = new Map<string, { label?: string }>([
+      [B_UID, { label: B_LABEL }],
+    ]);
+    const metadataCache = makeMetadataCache(indexedFiles);
+
+    // A view opened AFTER materialise builds fresh decorations immediately.
+    const freshView = new WikilinkEditorViewDouble(B_UID, metadataCache);
+    expect(freshView.display()).toBe(B_LABEL);
+  });
+
+  it("graceful: an unresolvable target stays `uid` after refresh (no throw, no label)", async () => {
+    const indexedFiles = new Map<string, { label?: string }>([
+      [B_UID, { label: B_LABEL }],
+    ]);
+    const metadataCache = makeMetadataCache(indexedFiles);
+    // Note links to a target whose AssetSpace is STILL not materialised.
+    const view = new WikilinkEditorViewDouble(MISSING_UID, metadataCache);
+
+    const service = new LinkLabelRefreshService({
+      ensureIndexFresh: async () => undefined,
+      rebuildEditorViews: () => view.reconfigure(),
+      rerenderLayouts: () => undefined,
+    });
+    await expect(service.refresh()).resolves.toBeUndefined();
+
+    expect(view.display()).toBe(MISSING_UID); // stays uid, gracefully
+  });
+});

--- a/packages/obsidian-plugin/tests/unit/presentation/editor-extensions/refresh-link-labels.integration.test.ts
+++ b/packages/obsidian-plugin/tests/unit/presentation/editor-extensions/refresh-link-labels.integration.test.ts
@@ -37,7 +37,11 @@ const MISSING_UID = "ffffffff-0000-0000-0000-000000000000";
  */
 function makeMetadataCache(indexedFiles: Map<string, { label?: string }>) {
   return {
-    getFirstLinkpathDest: (linkpath: string): TFile | null => {
+    // Mirror Obsidian's real 2-arg signature (linkpath, sourcePath).
+    getFirstLinkpathDest: (
+      linkpath: string,
+      _sourcePath: string,
+    ): TFile | null => {
       const key = linkpath.endsWith(".md") ? linkpath.slice(0, -3) : linkpath;
       if (!indexedFiles.has(key)) return null;
       const file = new TFile();


### PR DESCRIPTION
## Веха 1 / MVP — link-label re-resolution after AssetSpace materialize

WBS: `c9ab752e` (веха) = `844ced36` (MVP-1 command) + `bb1c98af` (MVP-2 re-resolve logic) + `74cac7b0` (MVP-3 tests). Parent study/interview: `438f6b7a`.

### Bug (AS-IS)
A bare `[[uid]]` wikilink whose target `B` lives in a **not-yet-materialised** AssetSpace renders as the raw `uid` (`metadataCache.getFirstLinkpathDest(uid)` → `null` → no `Decoration.replace`). After materialising B's AssetSpace, the label **keeps showing `uid` until an Obsidian restart**, because:
- `WikilinkLabelViewPlugin.update()` rebuilds its `DecorationSet` only on `docChanged / viewportChanged / selectionSet / geometryChanged` — it is **not** subscribed to `metadataCache` events, so an already-open note holds a stale `DecorationSet`.
- The materialize/apply path refreshes the triple store + re-renders dynamic layouts, but **never touches the CodeMirror editor views**.

### Fix
New palette command **«Exocortex: Refresh link labels»** → reusable `LinkLabelRefreshService.refresh()`:
1. **ensure index fresh** — `sparql.refresh()` → `convertVault()` (triple store + up-to-date vault tree, so **new tabs** resolve too);
2. **rebuild open editor views** — `app.workspace.updateOptions()` recreates the `WikilinkLabelViewPlugin` instances → fresh `buildDecorations` against the current `metadataCache` (what a restart does to open views, minus the restart);
3. **re-render layouts** — `autoRenderLayout()` for triple-store-backed relation labels.

**Graceful by contract**: each step isolated, never throws / shows a Notice; unresolvable links stay `uid`.
**Desktop↔Mobile Command Parity**: registered **unconditionally** (no `Platform` gate) — pure in-memory re-resolve, no Node/fs/git. Archgate `MOBILE-004` (no-desktop-only-gated-addcommand) passes. Build `assert-mobile-loadable` passes.
**Reuse**: the same `refresh()` is the unit the Веха 2 auto-hook will call (extending `createProfileApplyRefreshHook`).

### Tests (production-shape, revert-verify)
- `LinkLabelRefreshService.test.ts` — step order (index-fresh → views → layouts), async-await ordering, graceful no-throw when any step fails, optional-logger.
- `registerRefreshLinkLabelsCommand.test.ts` — stable id `refresh-link-labels` / name `Refresh link labels`, callback wired to `refresh()`, fire-and-forget never throws.
- `refresh-link-labels.integration.test.ts` — exercises the **real** `WikilinkLabelViewPlugin.resolveLabel` path with a production-shape `metadataCache` (returns `null` for absent files): open view stale after materialize → resolves after rebuild; **new-tab freshness**; unresolvable stays `uid`.
- **Revert-verify** (empirically confirmed): removing the production `rebuildEditorViews()` call makes «THE FIX» + service-order tests **FAIL**; restoring → **PASS**. The editor-view rebuild step is load-bearing, not vacuous.

Local gates green: `check:types` (0 errors), `eslint src` (0), `build` (+ mobile-loadable + console-channel asserts), 14 new tests, 137 related/regression tests (WikilinkLabelViewPlugin, registerExoSyncCommands, ExocortexPlugin, ProfileWiring).

🤖 Generated with [Claude Code](https://claude.com/claude-code)