### PR TITLE
feat(settings): section the settings tab + strip internal IDs (RFC 0002 §3.6)

### DIFF
--- a/packages/obsidian-plugin/src/presentation/settings/ExocortexSettingTab.ts
+++ b/packages/obsidian-plugin/src/presentation/settings/ExocortexSettingTab.ts
@@ -38,6 +38,54 @@ export class ExocortexSettingTab extends PluginSettingTab {
 
     containerEl.empty();
 
+    // RFC 0002 §3.6 (P8) — settings information architecture. The settings tab
+    // used to be a single ~25-toggle flat scroll with the onboarding-critical
+    // GitHub PAT / profile / sync controls buried at the very bottom. It is now
+    // split into three top-level sections, rendered in this order:
+    //
+    //   1. «Onboarding & sync» — PAT, profiles, ExoSync (what a new tester
+    //      needs first), moved to the TOP so PAT is no longer buried.
+    //   2. «Display» — visual / label / layout toggles + display-name templates.
+    //   3. «Advanced» — power-user behaviour, experimental flags, the free-text
+    //      path editors (gated with a caution), and the log-channel matrix.
+    //
+    // Every user-facing string here is also stripped of internal IDs (issue
+    // numbers, design-decision tags, security-requirement tags) per the §7
+    // grep gate (M4) — see ExocortexSettingTab.informationArchitecture.test.ts.
+    this.renderOnboardingAndSyncSection(containerEl);
+    this.renderDisplaySection(containerEl);
+    this.renderAdvancedSection(containerEl);
+  }
+
+  /**
+   * RFC 0002 §3.6 — «Onboarding & sync» section (top of the tab).
+   *
+   * Surfaces the onboarding-critical GitHub PAT, profiles, and ExoSync
+   * controls first — previously they were the last thing rendered, so a
+   * first-run tester had to scroll past every power-user toggle to find the
+   * PAT field the Getting Started flow needs.
+   */
+  private renderOnboardingAndSyncSection(containerEl: HTMLElement): void {
+    new Setting(containerEl).setName("Onboarding & sync").setHeading();
+
+    const intro = containerEl.createDiv({ cls: "setting-item-description" });
+    intro.appendText(
+      "Set up GitHub access, profiles, and sync here — start with these when " +
+        "you first install the plugin.",
+    );
+
+    // Profiles overview, GitHub PAT, ExoSync, Active profile, Switch cache,
+    // and the Operations log. Moved to the top of the tab (RFC 0002 §3.6).
+    this.renderProfileSections(containerEl);
+  }
+
+  /**
+   * RFC 0002 §3.6 — «Display» section: the visual / label / layout toggles a
+   * user changes day-to-day, plus the display-name template editor.
+   */
+  private renderDisplaySection(containerEl: HTMLElement): void {
+    new Setting(containerEl).setName("Display").setHeading();
+
     new Setting(containerEl)
       .setName("Show layout")
       .setDesc("Display the automatic layout below metadata in reading mode")
@@ -63,21 +111,6 @@ export class ExocortexSettingTab extends PluginSettingTab {
             this.plugin.settings.showArchivedAssets = value;
             await this.plugin.saveSettings();
             this.plugin.refreshLayout();
-          }),
-      );
-
-    new Setting(containerEl)
-      .setName("Auto-adjust planned end time")
-      .setDesc(
-        "Automatically shift plannedEndTimestamp when plannedStartTimestamp changes. " +
-          "Disable if using Obsidian Sync to prevent duplicate shifts.",
-      )
-      .addToggle((toggle) =>
-        toggle
-          .setValue(this.plugin.settings.autoAdjustPlannedEndTimestamp)
-          .onChange(async (value) => {
-            this.plugin.settings.autoAdjustPlannedEndTimestamp = value;
-            await this.plugin.saveSettings();
           }),
       );
 
@@ -166,90 +199,6 @@ export class ExocortexSettingTab extends PluginSettingTab {
       );
 
     new Setting(containerEl)
-      // eslint-disable-next-line obsidianmd/ui/sentence-case -- "SPARQL" is an established acronym
-      .setName("Auto-execute SPARQL code blocks")
-      .setDesc(
-        "When enabled, sparql and exoql code blocks are executed as queries " +
-          "during note rendering. When disabled (default), those code blocks " +
-          "render as plain code so SPARQL snippets can be pasted for " +
-          "documentation or reference without side effects. Issue #2992.",
-      )
-      .addToggle((toggle) =>
-        toggle
-          .setValue(this.plugin.settings.enableSparqlAutoExecute)
-          .onChange(async (value) => {
-            this.plugin.settings.enableSparqlAutoExecute = value;
-            await this.plugin.saveSettings();
-          }),
-      );
-
-    new Setting(containerEl)
-      .setName("Settings homoiconization")
-      .setDesc(
-        "When enabled, plugin settings are materialised as vault assets in an " +
-          'exocortex-settings/ folder so they are editable as notes and synced ' +
-          "alongside other assets. When disabled (default), settings live only " +
-          "in data.json and that folder is never created. Turning this off " +
-          "leaves any already-migrated assets on disk untouched (never deleted). " +
-          "Change applies on the next plugin reload. Issue #3539.",
-      )
-      .addToggle((toggle) =>
-        toggle
-          .setValue(this.plugin.settings.settingsHomoiconizationEnabled)
-          .onChange(async (value) => {
-            this.plugin.settings.settingsHomoiconizationEnabled = value;
-            await this.plugin.saveSettings();
-          }),
-      );
-
-    new Setting(containerEl)
-      .setName("Lazy bootstrap folders")
-      .setDesc(
-        "Path prefixes (one per line, trailing slash required) walked eagerly " +
-          "at plugin load so exocmd Commands/Bindings/Groundings and exo Classes/Properties " +
-          "are indexed before first render. Add extra submodules here " +
-          "(e.g. assetspaces/kitelev/, assetspaces/pmbok-ontology/) — change applies on next plugin reload. " +
-          "Empty list = bootstrap skips all folders (buttons may take 10-20s to appear on mobile).",
-      )
-      .addTextArea((textarea) => {
-        textarea
-          // eslint-disable-next-line obsidianmd/ui/sentence-case -- example shows literal vault-relative folder paths, not prose UI text
-          .setPlaceholder("assetspaces/exo/\nassetspaces/ems/")
-          .setValue((this.plugin.settings.lazyBootstrapFolders ?? []).join("\n"))
-          .onChange(async (value) => {
-            // Auto-append trailing slash to prevent `assetspaces/ems`
-            // over-matching `assetspaces/ems-commands/...` (the exact
-            // failure mode this PR fixes — see ExocortexPlugin Phase 5
-            // comment block). Code-reviewer MED catch.
-            this.plugin.settings.lazyBootstrapFolders = value
-              .split("\n")
-              .map((line) => line.trim())
-              .filter((line) => line.length > 0)
-              .map((line) => (line.endsWith("/") ? line : line + "/"));
-            await this.plugin.saveSettings();
-          });
-        textarea.inputEl.rows = 6;
-        textarea.inputEl.cols = 50;
-      });
-
-    new Setting(containerEl)
-      // eslint-disable-next-line obsidianmd/ui/sentence-case -- "SHACL" is an established acronym
-      .setName("Enable SHACL validation (experimental)")
-      .setDesc(
-        "When enabled, validates frontmatter properties against SHACL shapes " +
-          "on every file save (50ms debounce). Violations are logged as warnings. " +
-          "Default off in v15.x.0; will be enabled by default after soak period.",
-      )
-      .addToggle((toggle) =>
-        toggle
-          .setValue(this.plugin.settings.enableShaclValidation)
-          .onChange(async (value) => {
-            this.plugin.settings.enableShaclValidation = value;
-            await this.plugin.saveSettings();
-          }),
-      );
-
-    new Setting(containerEl)
       .setName("Auto reading mode for exocortex assets")
       .setDesc(
         "When opening a note with the `exo__Instance_class` frontmatter property, automatically switch to reading mode so the exocortex layout (create / status / planning panels) is visible. Disable to keep obsidian's default view mode.",
@@ -309,14 +258,15 @@ export class ExocortexSettingTab extends PluginSettingTab {
           }),
       );
 
-    // Excluded folders section — files inside these folders are skipped
-    // entirely by the RDF indexer and SHACL-lite validation.
-    this.renderExcludedFoldersSection(containerEl);
+    this.renderDisplayNameTemplatesSection(containerEl);
+  }
 
-    // Logging section
-    this.renderLogChannelsSection(containerEl);
-
-    // Display Name Template section
+  /**
+   * Display-name template editor (default + per-class templates + preview +
+   * placeholder help). Extracted from the old flat `display()` so it lives
+   * under the «Display» section (RFC 0002 §3.6).
+   */
+  private renderDisplayNameTemplatesSection(containerEl: HTMLElement): void {
     new Setting(containerEl).setName("Display name templates").setHeading();
 
     // Ensure displayNameSettings is initialized
@@ -409,11 +359,6 @@ export class ExocortexSettingTab extends PluginSettingTab {
         }),
       );
 
-    // Issue #3320 — RFC 0a0791c1 §B.8 — 4 Profile-related sections
-    // (PAT, Active profile, Switch cache, Operations log). Rendered after
-    // the existing sections so the diff stays additive.
-    this.renderProfileSections(containerEl);
-
     // Template syntax help
     const helpEl = containerEl.createDiv({
       cls: "setting-item-description",
@@ -438,6 +383,135 @@ export class ExocortexSettingTab extends PluginSettingTab {
       li.createEl("code", { text: code });
       li.appendText(` - ${desc}`);
     }
+  }
+
+  /**
+   * RFC 0002 §3.6 — «Advanced» section: power-user behaviour, experimental
+   * flags, the free-text path editors (gated behind a caution), and the
+   * log-channel routing matrix (now with labeled columns).
+   */
+  private renderAdvancedSection(containerEl: HTMLElement): void {
+    new Setting(containerEl).setName("Advanced").setHeading();
+
+    new Setting(containerEl)
+      .setName("Auto-adjust planned end time")
+      .setDesc(
+        "Automatically shift plannedEndTimestamp when plannedStartTimestamp changes. " +
+          "Disable if using Obsidian Sync to prevent duplicate shifts.",
+      )
+      .addToggle((toggle) =>
+        toggle
+          .setValue(this.plugin.settings.autoAdjustPlannedEndTimestamp)
+          .onChange(async (value) => {
+            this.plugin.settings.autoAdjustPlannedEndTimestamp = value;
+            await this.plugin.saveSettings();
+          }),
+      );
+
+    new Setting(containerEl)
+      // eslint-disable-next-line obsidianmd/ui/sentence-case -- "SPARQL" is an established acronym
+      .setName("Auto-execute SPARQL code blocks")
+      .setDesc(
+        "When enabled, sparql and exoql code blocks are executed as queries " +
+          "during note rendering. When disabled (default), those code blocks " +
+          "render as plain code so SPARQL snippets can be pasted for " +
+          "documentation or reference without side effects.",
+      )
+      .addToggle((toggle) =>
+        toggle
+          .setValue(this.plugin.settings.enableSparqlAutoExecute)
+          .onChange(async (value) => {
+            this.plugin.settings.enableSparqlAutoExecute = value;
+            await this.plugin.saveSettings();
+          }),
+      );
+
+    new Setting(containerEl)
+      .setName("Settings homoiconization")
+      .setDesc(
+        "When enabled, plugin settings are materialised as vault assets in an " +
+          'exocortex-settings/ folder so they are editable as notes and synced ' +
+          "alongside other assets. When disabled (default), settings live only " +
+          "in data.json and that folder is never created. Turning this off " +
+          "leaves any already-migrated assets on disk untouched (never deleted). " +
+          "Change applies on the next plugin reload.",
+      )
+      .addToggle((toggle) =>
+        toggle
+          .setValue(this.plugin.settings.settingsHomoiconizationEnabled)
+          .onChange(async (value) => {
+            this.plugin.settings.settingsHomoiconizationEnabled = value;
+            await this.plugin.saveSettings();
+          }),
+      );
+
+    new Setting(containerEl)
+      // eslint-disable-next-line obsidianmd/ui/sentence-case -- "SHACL" is an established acronym
+      .setName("Enable SHACL validation (experimental)")
+      .setDesc(
+        "When enabled, validates frontmatter properties against SHACL shapes " +
+          "on every file save (50ms debounce). Violations are logged as warnings. " +
+          "Default off in v15.x.0; will be enabled by default after soak period.",
+      )
+      .addToggle((toggle) =>
+        toggle
+          .setValue(this.plugin.settings.enableShaclValidation)
+          .onChange(async (value) => {
+            this.plugin.settings.enableShaclValidation = value;
+            await this.plugin.saveSettings();
+          }),
+      );
+
+    // RFC 0002 §3.6 — gate the free-text path editors behind a caution. A
+    // wrong vault-relative path here silently stops files from being indexed,
+    // so warn the user before they reach the two textareas below.
+    const pathCaution = containerEl.createDiv({
+      cls: "setting-item-description exocortex-settings-caution",
+    });
+    pathCaution.createEl("strong", { text: "Caution: " });
+    pathCaution.appendText(
+      "the folder-path fields below control which files get indexed. A wrong " +
+        "path can break indexing — assets may stop loading or vanish from " +
+        "search. Leave the defaults unless you know the exact vault-relative " +
+        "paths you want to change.",
+    );
+
+    new Setting(containerEl)
+      .setName("Lazy bootstrap folders")
+      .setDesc(
+        "Path prefixes (one per line, trailing slash required) walked eagerly " +
+          "at plugin load so exocmd Commands/Bindings/Groundings and exo Classes/Properties " +
+          "are indexed before first render. Add extra submodules here " +
+          "(e.g. assetspaces/kitelev/, assetspaces/pmbok-ontology/) — change applies on next plugin reload. " +
+          "Empty list = bootstrap skips all folders (buttons may take 10-20s to appear on mobile).",
+      )
+      .addTextArea((textarea) => {
+        textarea
+          // eslint-disable-next-line obsidianmd/ui/sentence-case -- example shows literal vault-relative folder paths, not prose UI text
+          .setPlaceholder("assetspaces/exo/\nassetspaces/ems/")
+          .setValue((this.plugin.settings.lazyBootstrapFolders ?? []).join("\n"))
+          .onChange(async (value) => {
+            // Auto-append trailing slash to prevent `assetspaces/ems`
+            // over-matching `assetspaces/ems-commands/...` (the exact
+            // failure mode this PR fixes — see ExocortexPlugin Phase 5
+            // comment block). Code-reviewer MED catch.
+            this.plugin.settings.lazyBootstrapFolders = value
+              .split("\n")
+              .map((line) => line.trim())
+              .filter((line) => line.length > 0)
+              .map((line) => (line.endsWith("/") ? line : line + "/"));
+            await this.plugin.saveSettings();
+          });
+        textarea.inputEl.rows = 6;
+        textarea.inputEl.cols = 50;
+      });
+
+    // Excluded folders section — files inside these folders are skipped
+    // entirely by the RDF indexer and SHACL-lite validation.
+    this.renderExcludedFoldersSection(containerEl);
+
+    // Logging section
+    this.renderLogChannelsSection(containerEl);
   }
 
   /**
@@ -542,19 +616,41 @@ export class ExocortexSettingTab extends PluginSettingTab {
       { key: "file", label: "File" },
     ];
 
+    // RFC 0002 §3.6 — label the matrix columns. Each level row below renders 3
+    // otherwise-unlabeled toggles; this header (plus per-toggle aria-labels)
+    // tells the user which toggle routes to Notice / Console / File.
+    const header = containerEl.createDiv({
+      cls: "exocortex-log-channel-header",
+    });
+    header.createEl("span", {
+      cls: "exocortex-log-channel-level-label",
+      text: "Level",
+    });
+    for (const channel of channels) {
+      header.createEl("span", {
+        cls: "exocortex-log-channel-col-label",
+        text: channel.label,
+      });
+    }
+
     for (const level of levels) {
       const setting = new Setting(containerEl).setName(level.label);
 
       for (const channel of channels) {
-        setting.addToggle((toggle) =>
+        setting.addToggle((toggle) => {
           toggle
             .setValue(this.plugin.settings.logChannels[level.key][channel.key])
             .onChange(async (value) => {
               this.plugin.settings.logChannels[level.key][channel.key] = value;
               await this.plugin.saveSettings();
               this.plugin.configureLogChannels();
-            }),
-        );
+            });
+          // a11y — name the otherwise-anonymous toggle by its (level, channel)
+          // so screen readers and hover tooltips identify which column it is.
+          const ariaLabel = `${level.label}: route to ${channel.label} channel`;
+          toggle.toggleEl?.setAttribute("aria-label", ariaLabel);
+          toggle.toggleEl?.setAttribute("title", ariaLabel);
+        });
       }
     }
   }
@@ -644,10 +740,9 @@ export class ExocortexSettingTab extends PluginSettingTab {
     const patDesc = containerEl.createDiv({ cls: "setting-item-description" });
     patDesc.appendText(
       "Fine-grained Personal Access Token used to push AssetSpace " +
-        "submodules to GitHub. Stored в data.local.json (NOT data.json) so " +
-        "Obsidian Sync excludes it from network replication (Vision Lock #1, " +
-        "Security #1). Required for the «Push current assetspace» and " +
-        "«Apply profile» commands.",
+        "submodules to GitHub. Stored in data.local.json (not data.json) so " +
+        "Obsidian Sync never replicates it over the network. Required for the " +
+        "«Push current assetspace» and «Apply profile» commands.",
     );
     // RFC 0002 §3.9 (P14) — mobile onboarding parity. Typing a long
     // fine-grained token on a phone keyboard is painful, so point users at the
@@ -671,7 +766,7 @@ export class ExocortexSettingTab extends PluginSettingTab {
       // eslint-disable-next-line obsidianmd/ui/sentence-case -- "PAT" is an established acronym for Personal Access Token
       .setName("Personal Access Token")
       .setDesc(
-        "Recommended: fine-grained PAT с per-repository allowlist scoped " +
+        "Recommended: fine-grained PAT with a per-repository allowlist scoped " +
           "to your exoas-* repos. Leave blank and click Save to clear.",
       )
       .addText((text) => {
@@ -776,7 +871,7 @@ export class ExocortexSettingTab extends PluginSettingTab {
       .setDesc(
         "Optional dedicated GitHub repo (https://github.com/<owner>/<repo>) " +
           "where unresolvable sync conflicts are preserved as both-versions " +
-          "entries (D17). Leave empty to skip the durable quarantine sink — " +
+          "entries. Leave empty to skip the durable quarantine sink — " +
           "conflicts still re-derive on every sync until resolved.",
       )
       .addText((text) => {

--- a/packages/obsidian-plugin/styles.css
+++ b/packages/obsidian-plugin/styles.css
@@ -6406,3 +6406,33 @@
 .dynamic-form-assetref-option.is-active {
   background: var(--background-modifier-hover);
 }
+
+/* RFC 0002 §3.6 — settings information architecture.
+   Log-channel matrix column header: labels the 3 otherwise-anonymous toggles
+   (Notice / Console / File) per level row. */
+.exocortex-log-channel-header {
+  display: flex;
+  align-items: center;
+  padding: 4px 0;
+  margin-bottom: 2px;
+  font-size: var(--font-ui-smaller);
+  color: var(--text-muted);
+  border-bottom: 1px solid var(--background-modifier-border);
+}
+
+.exocortex-log-channel-header .exocortex-log-channel-level-label {
+  flex: 1 1 auto;
+  font-weight: var(--font-semibold);
+}
+
+.exocortex-log-channel-header .exocortex-log-channel-col-label {
+  flex: 0 0 auto;
+  width: 44px;
+  text-align: center;
+}
+
+/* Caution callout gating the free-text path editors in the Advanced section. */
+.exocortex-settings-caution {
+  border-left: 3px solid var(--text-warning, var(--color-orange));
+  padding-left: 8px;
+}

--- a/packages/obsidian-plugin/tests/unit/ExocortexSettingTab.informationArchitecture.test.ts
+++ b/packages/obsidian-plugin/tests/unit/ExocortexSettingTab.informationArchitecture.test.ts
@@ -1,0 +1,431 @@
+/**
+ * RFC 0002 §3.6 — Settings information architecture + strip internal references.
+ *
+ * Pins the four DoD predicates of §3.6 (resolves P8 flat-list / leaked internal
+ * IDs / buried PAT / unlabeled log matrix, plus P3 jargon):
+ *
+ *   1. The tab is sectioned into «Onboarding & sync» (top) / «Display» /
+ *      «Advanced», in that order, with the GitHub PAT in the top section
+ *      (no longer buried at the bottom).
+ *   2. GREP GATE (M4): no user-facing string rendered by the tab contains
+ *      `Vision Lock`, `Security #`, `(D<n>)`, or `Issue #<n>`.
+ *   3. The log-channel matrix columns are labeled (Notice / Console / File),
+ *      and each toggle carries an accessible name.
+ *   4. The free-text path editors (Lazy bootstrap folders / Excluded folders)
+ *      render after the «Advanced» heading, behind a "you can break indexing"
+ *      caution.
+ *
+ * Strategy: a render-capture harness records every user-facing string the tab
+ * emits (Setting names/descs/headings, button labels, placeholders) plus the
+ * real-DOM text built via createDiv/createEl/appendText, so the grep gate runs
+ * against the actual rendered surface — not the source file (comments citing
+ * issue numbers for traceability are intentionally out of scope, per §7).
+ */
+
+import { ExocortexSettingTab } from "../../src/presentation/settings/ExocortexSettingTab";
+import { Setting } from "obsidian";
+import { createMockApp, createMockPlugin } from "./helpers/testHelpers";
+
+// ─── Obsidian DOM helpers on HTMLElement (jsdom lacks them) ───
+function installObsidianDomHelpers(): void {
+  const proto = HTMLElement.prototype as any;
+  const applyOptions = (el: HTMLElement, options?: any): void => {
+    if (options?.text) el.textContent = options.text;
+    if (options?.cls) el.className = options.cls;
+    if (options?.href) (el as HTMLAnchorElement).href = options.href;
+    if (options?.attr) {
+      for (const [key, value] of Object.entries(options.attr)) {
+        el.setAttribute(key, String(value));
+      }
+    }
+  };
+  if (!proto.createEl) {
+    proto.createEl = function (tag: string, options?: any) {
+      const el = document.createElement(tag);
+      applyOptions(el, options);
+      this.appendChild(el);
+      return el;
+    };
+  }
+  if (!proto.createDiv) {
+    proto.createDiv = function (options?: any) {
+      const el = document.createElement("div");
+      applyOptions(el, options);
+      this.appendChild(el);
+      return el;
+    };
+  }
+  if (!proto.createSpan) {
+    proto.createSpan = function (options?: any) {
+      const el = document.createElement("span");
+      applyOptions(el, options);
+      this.appendChild(el);
+      return el;
+    };
+  }
+  if (!proto.appendText) {
+    proto.appendText = function (text: string) {
+      this.appendChild(document.createTextNode(text));
+    };
+  }
+  if (!proto.empty) {
+    proto.empty = function () {
+      while (this.firstChild) this.removeChild(this.firstChild);
+    };
+  }
+  if (!proto.addClass) {
+    proto.addClass = function (cls: string) {
+      this.classList.add(cls);
+    };
+  }
+  if (!proto.toggleClass) {
+    proto.toggleClass = function (cls: string, on: boolean) {
+      this.classList.toggle(cls, on);
+    };
+  }
+  if (!proto.setText) {
+    proto.setText = function (t: string) {
+      this.textContent = t;
+    };
+  }
+}
+installObsidianDomHelpers();
+
+// Shared capture state (jest hoists jest.mock above imports; the factory may
+// only reference out-of-scope identifiers prefixed with `mock`).
+interface MockSettingRecord {
+  name?: string;
+  heading: boolean;
+}
+const mockCapture: {
+  settings: MockSettingRecord[];
+  userFacing: string[];
+  toggleEls: HTMLElement[];
+  reset: () => void;
+} = {
+  settings: [],
+  userFacing: [],
+  toggleEls: [],
+  reset() {
+    this.settings = [];
+    this.userFacing = [];
+    this.toggleEls = [];
+  },
+};
+
+jest.mock("obsidian", () => {
+  class MockPluginSettingTab {
+    containerEl: any;
+    app: any;
+    plugin: any;
+    constructor(app: any, plugin: any) {
+      this.app = app;
+      this.plugin = plugin;
+      this.containerEl = document.createElement("div");
+    }
+  }
+
+  class MockSetting {
+    private record: { name?: string; heading: boolean };
+    controlEl: HTMLElement;
+    constructor(_containerEl: HTMLElement) {
+      this.record = { heading: false };
+      mockCapture.settings.push(this.record);
+      this.controlEl = document.createElement("div");
+    }
+    setName(name: string): this {
+      this.record.name = name;
+      mockCapture.userFacing.push(name);
+      return this;
+    }
+    setDesc(desc: unknown): this {
+      if (typeof desc === "string") mockCapture.userFacing.push(desc);
+      return this;
+    }
+    setHeading(): this {
+      this.record.heading = true;
+      return this;
+    }
+    addToggle(cb: (toggle: any) => void): this {
+      const toggleEl = document.createElement("input");
+      mockCapture.toggleEls.push(toggleEl);
+      const toggle: any = {
+        setValue: jest.fn(() => toggle),
+        onChange: jest.fn(() => toggle),
+        toggleEl,
+      };
+      cb(toggle);
+      return this;
+    }
+    addText(cb: (text: any) => void): this {
+      const text: any = {
+        setPlaceholder: jest.fn((p: string) => {
+          mockCapture.userFacing.push(p);
+          return text;
+        }),
+        setValue: jest.fn(() => text),
+        onChange: jest.fn(() => text),
+        inputEl: { type: "" } as Record<string, unknown>,
+      };
+      cb(text);
+      return this;
+    }
+    addTextArea(cb: (text: any) => void): this {
+      const textArea: any = {
+        setPlaceholder: jest.fn((p: string) => {
+          mockCapture.userFacing.push(p);
+          return textArea;
+        }),
+        setValue: jest.fn(() => textArea),
+        onChange: jest.fn(() => textArea),
+        inputEl: { rows: 0, cols: 0 } as Record<string, unknown>,
+      };
+      cb(textArea);
+      return this;
+    }
+    addButton(cb: (button: any) => void): this {
+      const button: any = {
+        setButtonText: jest.fn((t: string) => {
+          mockCapture.userFacing.push(t);
+          return button;
+        }),
+        setTooltip: jest.fn((t: string) => {
+          mockCapture.userFacing.push(t);
+          return button;
+        }),
+        onClick: jest.fn(() => button),
+        setCta: jest.fn(() => button),
+      };
+      cb(button);
+      return this;
+    }
+    addDropdown(cb: (d: any) => void): this {
+      cb({
+        addOption: jest.fn().mockReturnThis(),
+        setValue: jest.fn().mockReturnThis(),
+        onChange: jest.fn().mockReturnThis(),
+      });
+      return this;
+    }
+  }
+
+  return {
+    App: jest.fn(),
+    PluginSettingTab: MockPluginSettingTab,
+    Setting: MockSetting,
+  };
+});
+
+// Profile-section dependencies (mirror ExocortexSettingTab.focusProfile.test).
+const __secretsBacking = new Map<string, string>();
+jest.mock("@plugin/infrastructure/adapters/LocalSecretsStore", () => ({
+  LocalSecretsStore: class {
+    async getSecret(key: string): Promise<string | null> {
+      return __secretsBacking.get(key) ?? null;
+    }
+    async setSecret(key: string, value: string | null): Promise<void> {
+      if (value === null || value === "") __secretsBacking.delete(key);
+      else __secretsBacking.set(key, value);
+    }
+  },
+}));
+jest.mock("@plugin/infrastructure/adapters/GitHubRestClient", () => ({
+  GitHubRestClient: class {
+    static validateRepoURL(): void {}
+    async checkRateLimit(): Promise<{ remaining: number; resetAt: Date }> {
+      return { remaining: 4999, resetAt: new Date("2026-06-02T03:00:00Z") };
+    }
+    async listRepos(): Promise<string[]> {
+      return ["kitelev/exoas-test"];
+    }
+  },
+}));
+jest.mock("@plugin/infrastructure/adapters/OperationsLogReader", () => {
+  const real = jest.requireActual(
+    "@plugin/infrastructure/adapters/OperationsLogReader",
+  );
+  class MockOperationsLogReader {
+    async readLast(): Promise<unknown[]> {
+      return [];
+    }
+    static formatEntry = real.OperationsLogReader.formatEntry;
+  }
+  return { OperationsLogReader: MockOperationsLogReader };
+});
+jest.mock("@plugin/infrastructure/adapters/SwitchCacheLayer", () => ({
+  SwitchCacheLayer: class {
+    getCacheStats(): {
+      count: number;
+      totalSize: number;
+      oldestEntry: string | null;
+    } {
+      return { count: 0, totalSize: 0, oldestEntry: null };
+    }
+  },
+}));
+
+const INTERNAL_ID_PATTERNS: { label: string; re: RegExp }[] = [
+  { label: "Vision Lock", re: /Vision Lock/ },
+  { label: "Security #", re: /Security #/ },
+  { label: "(D<n>)", re: /\(D[0-9]+\)/ },
+  { label: "Issue #<n>", re: /Issue #[0-9]+/ },
+];
+
+describe("ExocortexSettingTab — RFC 0002 §3.6 information architecture", () => {
+  let settingTab: ExocortexSettingTab;
+  let mockPlugin: any;
+
+  /** All user-facing text rendered by the tab (Setting strings + DOM text). */
+  function renderedText(): string {
+    return (
+      mockCapture.userFacing.join("\n") +
+      "\n" +
+      (settingTab.containerEl.textContent ?? "")
+    );
+  }
+  function headingNames(): string[] {
+    return mockCapture.settings
+      .filter((s) => s.heading)
+      .map((s) => s.name ?? "");
+  }
+  function settingIndex(name: string): number {
+    return mockCapture.settings.findIndex((s) => s.name === name);
+  }
+
+  beforeEach(() => {
+    mockCapture.reset();
+    __secretsBacking.clear();
+    const mockApp = createMockApp();
+    mockPlugin = createMockPlugin({
+      app: mockApp,
+      settings: {
+        layoutVisible: true,
+        showArchivedAssets: false,
+        autoAdjustPlannedEndTimestamp: true,
+        showLabelsInTabTitles: true,
+        showLabelsInProperties: true,
+        enablePropertiesLabelPatch: true,
+        enableExoLayoutRenderer: true,
+        showIconsInFileExplorer: false,
+        autoReadingModeForExocortexAssets: true,
+        showLabelsInBody: true,
+        showLabelsInGraphView: true,
+        showLabelsInLivePreview: true,
+        enableSparqlAutoExecute: false,
+        settingsHomoiconizationEnabled: false,
+        enableShaclValidation: false,
+        lazyBootstrapFolders: ["assetspaces/exo/"],
+        excludedFolders: ["09 Templates/"],
+        exosyncQuarantineRepoUrl: "",
+        exosyncStepNotices: false,
+        verboseSyncLogging: false,
+        displayNameSettings: {
+          defaultTemplate: "{{exo__Asset_label}}",
+          classTemplates: {},
+        },
+        logChannels: {
+          debug: { notice: false, console: true, file: false },
+          info: { notice: false, console: true, file: false },
+          warn: { notice: true, console: true, file: true },
+          error: { notice: true, console: true, file: true },
+        },
+      },
+      saveSettings: jest.fn().mockResolvedValue(undefined),
+      refreshLayout: jest.fn(),
+      toggleTabTitleLabels: jest.fn(),
+      togglePropertiesLabels: jest.fn(),
+      togglePropertiesLabelPatch: jest.fn(),
+      toggleFileExplorerIcons: jest.fn(),
+      toggleBodyLabels: jest.fn(),
+      toggleGraphViewLabels: jest.fn(),
+      applyDisplayNameTemplate: jest.fn(),
+      configureLogChannels: jest.fn(),
+      listProfileChoices: jest.fn().mockResolvedValue([]),
+      localDataStore: { getActiveProfileUid: jest.fn().mockReturnValue(null) },
+      notifier: { info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+    });
+
+    settingTab = new ExocortexSettingTab(mockApp, mockPlugin);
+    settingTab.containerEl = document.createElement("div");
+    settingTab.display();
+  });
+
+  it("renders the three top-level sections in order: Onboarding & sync → Display → Advanced", () => {
+    const headings = headingNames();
+    const onboarding = headings.indexOf("Onboarding & sync");
+    const display = headings.indexOf("Display");
+    const advanced = headings.indexOf("Advanced");
+
+    expect(onboarding).toBeGreaterThanOrEqual(0);
+    expect(display).toBeGreaterThan(onboarding);
+    expect(advanced).toBeGreaterThan(display);
+  });
+
+  it("renders «Onboarding & sync» as the very first heading (no longer last)", () => {
+    expect(headingNames()[0]).toBe("Onboarding & sync");
+  });
+
+  it("places the GitHub PAT field in the top section, before «Display» (PAT not buried)", () => {
+    const patIdx = settingIndex("Personal Access Token");
+    const displayIdx = settingIndex("Display");
+    expect(patIdx).toBeGreaterThanOrEqual(0);
+    expect(displayIdx).toBeGreaterThan(patIdx);
+  });
+
+  describe("grep gate (M4) — no internal IDs in user-facing strings", () => {
+    for (const { label, re } of INTERNAL_ID_PATTERNS) {
+      it(`no rendered string contains ${label}`, () => {
+        const text = renderedText();
+        const offending = text
+          .split("\n")
+          .filter((line) => re.test(line));
+        expect(offending).toEqual([]);
+      });
+    }
+  });
+
+  it("retains the user-facing copy after stripping the internal IDs", () => {
+    const text = renderedText();
+    // The SPARQL desc kept its content, lost "Issue #2992".
+    expect(text).toContain("without side effects");
+    // The PAT desc kept the privacy explanation, lost "Vision Lock #1, Security #1".
+    expect(text).toContain("Obsidian Sync never replicates it over the network");
+  });
+
+  describe("log-channel matrix columns labeled", () => {
+    it("renders Notice / Console / File column header labels", () => {
+      const text = settingTab.containerEl.textContent ?? "";
+      expect(text).toContain("Notice");
+      expect(text).toContain("Console");
+      expect(text).toContain("File");
+    });
+
+    it("gives every matrix toggle an accessible name (4 levels × 3 channels)", () => {
+      const labeled = mockCapture.toggleEls.filter((el) =>
+        (el.getAttribute("aria-label") ?? "").includes("route to"),
+      );
+      // 4 log levels × 3 channels.
+      expect(labeled.length).toBe(12);
+      const labels = labeled.map((el) => el.getAttribute("aria-label"));
+      expect(labels).toContain("Debug: route to Notice channel");
+      expect(labels).toContain("Error: route to File channel");
+    });
+  });
+
+  describe("free-text path editors gated behind Advanced + caution", () => {
+    it("renders both path editors after the «Advanced» heading", () => {
+      const advancedIdx = settingIndex("Advanced");
+      const lazyIdx = settingIndex("Lazy bootstrap folders");
+      const excludedIdx = settingIndex("Excluded folders");
+      expect(advancedIdx).toBeGreaterThanOrEqual(0);
+      expect(lazyIdx).toBeGreaterThan(advancedIdx);
+      expect(excludedIdx).toBeGreaterThan(advancedIdx);
+    });
+
+    it("shows a caution warning the user a wrong path can break indexing", () => {
+      const text = renderedText();
+      expect(text).toContain("Caution");
+      expect(text).toContain("break indexing");
+    });
+  });
+});

--- a/packages/obsidian-plugin/tests/unit/ExocortexSettingTab.test.ts
+++ b/packages/obsidian-plugin/tests/unit/ExocortexSettingTab.test.ts
@@ -2,7 +2,24 @@ import { ExocortexSettingTab } from "../../src/presentation/settings/ExocortexSe
 import { Setting } from "obsidian";
 import { createMockApp, createMockPlugin } from "./helpers/testHelpers";
 
-// Two-step mock pattern for constructor functions
+// RFC 0002 §3.6 — the tab is now sectioned (Onboarding & sync / Display /
+// Advanced) and the toggles are no longer in a fixed positional order, so
+// these tests look up a Setting by NAME (via the capture harness below) rather
+// than by array index. The structural section assertions live in
+// ExocortexSettingTab.informationArchitecture.test.ts.
+
+interface CapturedToggle {
+  setValueArg?: boolean;
+  onChangeCb?: (value: boolean) => void | Promise<void>;
+}
+interface CapturedSetting {
+  name?: string;
+  heading: boolean;
+  toggles: CapturedToggle[];
+}
+
+const capture: { settings: CapturedSetting[] } = { settings: [] };
+
 jest.mock("obsidian", () => ({
   App: jest.fn(),
   PluginSettingTab: class MockPluginSettingTab {
@@ -25,14 +42,26 @@ describe("ExocortexSettingTab", () => {
   let mockContainerEl: any;
   let MockSetting: any;
 
+  const findSetting = (name: string): CapturedSetting | undefined =>
+    capture.settings.find((s) => s.name === name);
+
   beforeEach(() => {
-    // Create a mock element that has Obsidian's methods (recursive)
+    capture.settings = [];
+
+    // A recursive mock element that supports the Obsidian DOM helpers the
+    // settings tab uses (createEl/createDiv/createSpan/appendText/empty).
     const createMockElement: () => any = () => {
       const el = document.createElement("div");
-      // Add Obsidian-specific methods that return mock elements
       (el as any).empty = jest.fn();
-      (el as any).createEl = jest.fn().mockImplementation(() => createMockElement());
-      (el as any).createDiv = jest.fn().mockImplementation(() => createMockElement());
+      (el as any).createEl = jest
+        .fn()
+        .mockImplementation(() => createMockElement());
+      (el as any).createDiv = jest
+        .fn()
+        .mockImplementation(() => createMockElement());
+      (el as any).createSpan = jest
+        .fn()
+        .mockImplementation(() => createMockElement());
       (el as any).appendText = jest.fn();
       return el;
     };
@@ -40,13 +69,32 @@ describe("ExocortexSettingTab", () => {
       empty: jest.fn(),
       createEl: jest.fn().mockImplementation(() => createMockElement()),
       createDiv: jest.fn().mockImplementation(() => createMockElement()),
+      createSpan: jest.fn().mockImplementation(() => createMockElement()),
+      appendText: jest.fn(),
     };
 
     mockPlugin = createMockPlugin({
       settings: {
         layoutVisible: true,
         showArchivedAssets: false,
+        autoAdjustPlannedEndTimestamp: true,
         showLabelsInTabTitles: true,
+        showLabelsInProperties: true,
+        enablePropertiesLabelPatch: true,
+        enableExoLayoutRenderer: true,
+        showIconsInFileExplorer: false,
+        autoReadingModeForExocortexAssets: true,
+        showLabelsInBody: true,
+        showLabelsInGraphView: true,
+        showLabelsInLivePreview: true,
+        enableSparqlAutoExecute: false,
+        settingsHomoiconizationEnabled: false,
+        enableShaclValidation: false,
+        lazyBootstrapFolders: [],
+        excludedFolders: [],
+        exosyncQuarantineRepoUrl: "",
+        exosyncStepNotices: false,
+        verboseSyncLogging: false,
         displayNameTemplate: "{{exo__Asset_label}}",
         displayNameSettings: {
           defaultTemplate: "{{exo__Asset_label}}",
@@ -65,79 +113,89 @@ describe("ExocortexSettingTab", () => {
       saveSettings: jest.fn().mockResolvedValue(undefined),
       refreshLayout: jest.fn(),
       toggleTabTitleLabels: jest.fn(),
+      togglePropertiesLabels: jest.fn(),
+      togglePropertiesLabelPatch: jest.fn(),
+      toggleFileExplorerIcons: jest.fn(),
+      toggleBodyLabels: jest.fn(),
+      toggleGraphViewLabels: jest.fn(),
       applyDisplayNameTemplate: jest.fn(),
       configureLogChannels: jest.fn(),
+      listProfileChoices: jest.fn().mockResolvedValue([]),
+      localDataStore: { getActiveProfileUid: jest.fn().mockReturnValue(null) },
+      notifier: { info: jest.fn(), warn: jest.fn(), error: jest.fn() },
     });
 
     mockApp = createMockApp();
+    mockPlugin.app = mockApp;
 
-    // Setup Setting mock implementation
-    MockSetting = (Setting as jest.Mock);
+    MockSetting = Setting as jest.Mock;
     MockSetting.mockImplementation((containerEl: any) => {
-      const setting = {
+      const record: CapturedSetting = { heading: false, toggles: [] };
+      capture.settings.push(record);
+      const setting: any = {
         containerEl,
-        setName: jest.fn().mockReturnThis(),
+        setName: jest.fn((n: string) => {
+          record.name = n;
+          return setting;
+        }),
         setDesc: jest.fn().mockReturnThis(),
-        setHeading: jest.fn().mockReturnThis(),
-        addDropdown: jest.fn().mockImplementation((callback) => {
-          const dropdown = {
+        setHeading: jest.fn(() => {
+          record.heading = true;
+          return setting;
+        }),
+        addDropdown: jest.fn().mockImplementation((cb: any) => {
+          cb({
             addOption: jest.fn().mockReturnThis(),
             setValue: jest.fn().mockReturnThis(),
             onChange: jest.fn().mockReturnThis(),
-          };
-          callback(dropdown);
+          });
           return setting;
         }),
-        addToggle: jest.fn().mockImplementation((callback) => {
-          const toggle = {
-            setValue: jest.fn().mockReturnThis(),
-            onChange: jest.fn().mockReturnThis(),
+        addToggle: jest.fn().mockImplementation((cb: any) => {
+          const captured: CapturedToggle = {};
+          const toggle: any = {
+            setValue: jest.fn((v: boolean) => {
+              captured.setValueArg = v;
+              return toggle;
+            }),
+            onChange: jest.fn((fn: any) => {
+              captured.onChangeCb = fn;
+              return toggle;
+            }),
+            toggleEl: document.createElement("input"),
           };
-          callback(toggle);
+          record.toggles.push(captured);
+          cb(toggle);
           return setting;
         }),
-        addText: jest.fn().mockImplementation((callback) => {
-          const text = {
-            setPlaceholder: jest.fn().mockReturnThis(),
-            setValue: jest.fn().mockReturnThis(),
-            onChange: jest.fn().mockReturnThis(),
-            // Issue #3320 — PAT field sets inputEl.type = "password".
-            // Mock must expose an inputEl object с writable properties.
+        addText: jest.fn().mockImplementation((cb: any) => {
+          const text: any = {
+            setPlaceholder: jest.fn(() => text),
+            setValue: jest.fn(() => text),
+            onChange: jest.fn(() => text),
             inputEl: { type: "" } as Record<string, unknown>,
           };
-          callback(text);
+          cb(text);
           return setting;
         }),
-        addTextArea: jest.fn().mockImplementation((callback) => {
-          const textArea = {
-            setPlaceholder: jest.fn().mockReturnThis(),
-            setValue: jest.fn().mockReturnThis(),
-            onChange: jest.fn().mockReturnThis(),
-            // `inputEl` is mutated by the production code (rows/cols).
-            // A plain object is enough — production code only sets properties.
-            inputEl: {} as Record<string, unknown>,
+        addTextArea: jest.fn().mockImplementation((cb: any) => {
+          const textarea: any = {
+            setPlaceholder: jest.fn(() => textarea),
+            setValue: jest.fn(() => textarea),
+            onChange: jest.fn(() => textarea),
+            inputEl: { rows: 0, cols: 0 } as Record<string, unknown>,
           };
-          callback(textArea);
+          cb(textarea);
           return setting;
         }),
-        addButton: jest.fn().mockImplementation((callback) => {
-          const button = {
-            setButtonText: jest.fn().mockReturnThis(),
-            onClick: jest.fn().mockReturnThis(),
-            setCta: jest.fn().mockReturnThis(),
-            setTooltip: jest.fn().mockReturnThis(),
+        addButton: jest.fn().mockImplementation((cb: any) => {
+          const button: any = {
+            setButtonText: jest.fn(() => button),
+            onClick: jest.fn(() => button),
+            setCta: jest.fn(() => button),
+            setTooltip: jest.fn(() => button),
           };
-          callback(button);
-          return setting;
-        }),
-        addTextArea: jest.fn().mockImplementation((callback) => {
-          const textarea = {
-            setPlaceholder: jest.fn().mockReturnThis(),
-            setValue: jest.fn().mockReturnThis(),
-            onChange: jest.fn().mockReturnThis(),
-            inputEl: { rows: 0, cols: 0 },
-          };
-          callback(textarea);
+          cb(button);
           return setting;
         }),
       };
@@ -153,216 +211,44 @@ describe("ExocortexSettingTab", () => {
       settingTab.display();
 
       expect(mockContainerEl.empty).toHaveBeenCalled();
-      // 9 toggle settings + 1 autoReadingMode toggle + 1 enableExoLayoutRenderer toggle + 1 showIconsInFileExplorer toggle + 1 enableSparqlAutoExecute toggle (#2992) + 1 lazyBootstrapFolders TextArea (RFC c7da0bca Phase 5) + 1 enableShaclValidation toggle (P1.12) + 1 enablePropertiesLabelPatch toggle (RFC-030) + 3 headings + 1 default template + 6 per-class templates + 1 reset button + 4 log level rows = 30
-      // RFC c7da0bca Phase 3c-3 — deleted `exocmdBindingsCacheEnabledOnMobile` toggle (-1) once its indexer was deleted in 3c-2.
-      // RFC c7da0bca Phase 5 — added `lazyBootstrapFolders` TextArea (+1).
-      // Log channels section: 1 heading + 4 log level rows = 5
-      // Excluded folders section (#3278): 1 heading + 1 textarea row = +2 → 32
-      // Issue #3320 — Profile sections: 4 section headings + PAT row + Switch profile row + Cache stats row + (Operations log has no Setting row, body уходит в createDiv/createEl) = +7 → 39
-      // RFC 13da049f R35 — added "Profiles" overview heading (+1) → 40
-      // RFC 4e4dc453 Phase B — ExoSync section: heading + quarantine repo URL row (+2) → 42
-      // Issue #3499 — ExoSync verbose per-step Notice toggle (+1) → 43
-      // Issue #3498 — ExoSync verbose file-log toggle (+1) → 44
-      // Issue #3539 — settings-homoiconization master toggle (+1) → 45
-      expect(MockSetting).toHaveBeenCalledTimes(45);
+      // RFC 0002 §3.6 — count = 45 (pre-§3.6) + 3 section headings
+      // («Onboarding & sync» / «Display» / «Advanced») = 48.
+      expect(MockSetting).toHaveBeenCalledTimes(48);
     });
 
-    it("renders the settings-homoiconization toggle (Issue #3539)", () => {
+    it("renders the settings-homoiconization toggle", () => {
       settingTab.display();
-
-      const names = (MockSetting as jest.Mock).mock.results
-        .map((r) => {
-          const calls = (r.value.setName as jest.Mock).mock.calls;
-          return calls.length > 0 ? (calls[0][0] as string) : undefined;
-        })
-        .filter((n): n is string => typeof n === "string");
-      expect(names).toContain("Settings homoiconization");
+      expect(findSetting("Settings homoiconization")).toBeDefined();
     });
 
-    it("should render layout visibility toggle as first setting", () => {
+    it("renders the layout-visibility toggle wired to layoutVisible", async () => {
       settingTab.display();
 
-      const firstSetting = (MockSetting as jest.Mock).mock.results[0].value;
-      expect(firstSetting.setName).toHaveBeenCalledWith("Show layout");
-      expect(firstSetting.setDesc).toHaveBeenCalledWith(
-        "Display the automatic layout below metadata in reading mode"
-      );
-    });
+      const layout = findSetting("Show layout");
+      expect(layout).toBeDefined();
+      const toggle = layout!.toggles[0];
+      expect(toggle.setValueArg).toBe(true);
 
-    it("should handle layout visibility toggle change", async () => {
-      let toggleCallbacks: any[] = [];
-      MockSetting.mockImplementation((containerEl: any) => {
-        const setting = {
-          containerEl,
-          setName: jest.fn().mockReturnThis(),
-          setDesc: jest.fn().mockReturnThis(),
-          setHeading: jest.fn().mockReturnThis(),
-          addDropdown: jest.fn().mockReturnThis(),
-          addToggle: jest.fn().mockImplementation((callback) => {
-            const toggle = {
-              setValue: jest.fn().mockReturnThis(),
-              onChange: jest.fn().mockReturnThis(),
-            };
-            toggleCallbacks.push({ toggle, callback, onChange: null });
-            toggle.onChange.mockImplementation((cb: any) => {
-              toggleCallbacks[toggleCallbacks.length - 1].onChange = cb;
-              return toggle;
-            });
-            callback(toggle);
-            return setting;
-          }),
-          addText: jest.fn().mockImplementation((callback) => {
-            const text = {
-              setPlaceholder: jest.fn().mockReturnThis(),
-              setValue: jest.fn().mockReturnThis(),
-              onChange: jest.fn().mockReturnThis(),
-              // Issue #3320 — PAT field sets inputEl.type = "password"
-              inputEl: { type: "" } as Record<string, unknown>,
-            };
-            callback(text);
-            return setting;
-          }),
-          addTextArea: jest.fn().mockImplementation((callback) => {
-            const textArea = {
-              setPlaceholder: jest.fn().mockReturnThis(),
-              setValue: jest.fn().mockReturnThis(),
-              onChange: jest.fn().mockReturnThis(),
-              inputEl: {} as Record<string, unknown>,
-            };
-            callback(textArea);
-            return setting;
-          }),
-          addButton: jest.fn().mockImplementation((callback) => {
-            const button = {
-              setButtonText: jest.fn().mockReturnThis(),
-              onClick: jest.fn().mockReturnThis(),
-              setCta: jest.fn().mockReturnThis(),
-              setTooltip: jest.fn().mockReturnThis(),
-            };
-            callback(button);
-            return setting;
-          }),
-          addTextArea: jest.fn().mockImplementation((callback) => {
-            const textarea = {
-              setPlaceholder: jest.fn().mockReturnThis(),
-              setValue: jest.fn().mockReturnThis(),
-              onChange: jest.fn().mockReturnThis(),
-              inputEl: { rows: 0, cols: 0 },
-            };
-            callback(textarea);
-            return setting;
-          }),
-        };
-        return setting;
-      });
-
-      settingTab.display();
-
-      // First setting's toggle (layout visibility)
-      const layoutToggle = toggleCallbacks[0];
-      expect(layoutToggle.toggle.setValue).toHaveBeenCalledWith(true);
-
-      // Trigger onChange
-      if (layoutToggle.onChange) {
-        await layoutToggle.onChange(false);
-      }
+      await toggle.onChangeCb?.(false);
 
       expect(mockPlugin.settings.layoutVisible).toBe(false);
       expect(mockPlugin.saveSettings).toHaveBeenCalled();
       expect(mockPlugin.refreshLayout).toHaveBeenCalled();
     });
 
-    it("should render archived assets toggle", () => {
+    it("renders the archived-assets toggle wired to showArchivedAssets", async () => {
       settingTab.display();
 
-      const secondSetting = (MockSetting as jest.Mock).mock.results[1].value;
-      expect(secondSetting.setName).toHaveBeenCalledWith("Show archived assets");
-      expect(secondSetting.setDesc).toHaveBeenCalledWith(
-        "Display archived assets in relations table with visual distinction"
-      );
-    });
+      const archived = findSetting("Show archived assets");
+      expect(archived).toBeDefined();
+      const toggle = archived!.toggles[0];
+      expect(toggle.setValueArg).toBe(false);
 
-    it("should handle archived assets toggle change", async () => {
-      let toggleCallbacks: any[] = [];
-      MockSetting.mockImplementation((containerEl: any) => {
-        const setting = {
-          containerEl,
-          setName: jest.fn().mockReturnThis(),
-          setDesc: jest.fn().mockReturnThis(),
-          setHeading: jest.fn().mockReturnThis(),
-          addDropdown: jest.fn().mockReturnThis(),
-          addToggle: jest.fn().mockImplementation((callback) => {
-            const toggle = {
-              setValue: jest.fn().mockReturnThis(),
-              onChange: jest.fn().mockReturnThis(),
-            };
-            toggleCallbacks.push({ toggle, callback, onChange: null });
-            toggle.onChange.mockImplementation((cb: any) => {
-              toggleCallbacks[toggleCallbacks.length - 1].onChange = cb;
-              return toggle;
-            });
-            callback(toggle);
-            return setting;
-          }),
-          addText: jest.fn().mockImplementation((callback) => {
-            const text = {
-              setPlaceholder: jest.fn().mockReturnThis(),
-              setValue: jest.fn().mockReturnThis(),
-              onChange: jest.fn().mockReturnThis(),
-              // Issue #3320 — PAT field sets inputEl.type = "password"
-              inputEl: { type: "" } as Record<string, unknown>,
-            };
-            callback(text);
-            return setting;
-          }),
-          addTextArea: jest.fn().mockImplementation((callback) => {
-            const textArea = {
-              setPlaceholder: jest.fn().mockReturnThis(),
-              setValue: jest.fn().mockReturnThis(),
-              onChange: jest.fn().mockReturnThis(),
-              inputEl: {} as Record<string, unknown>,
-            };
-            callback(textArea);
-            return setting;
-          }),
-          addButton: jest.fn().mockImplementation((callback) => {
-            const button = {
-              setButtonText: jest.fn().mockReturnThis(),
-              onClick: jest.fn().mockReturnThis(),
-              setCta: jest.fn().mockReturnThis(),
-              setTooltip: jest.fn().mockReturnThis(),
-            };
-            callback(button);
-            return setting;
-          }),
-          addTextArea: jest.fn().mockImplementation((callback) => {
-            const textarea = {
-              setPlaceholder: jest.fn().mockReturnThis(),
-              setValue: jest.fn().mockReturnThis(),
-              onChange: jest.fn().mockReturnThis(),
-              inputEl: { rows: 0, cols: 0 },
-            };
-            callback(textarea);
-            return setting;
-          }),
-        };
-        return setting;
-      });
-
-      settingTab.display();
-
-      // Second setting's toggle (archived assets — was third before properties removal)
-      const archivedToggle = toggleCallbacks[1];
-      expect(archivedToggle.toggle.setValue).toHaveBeenCalledWith(false);
-
-      if (archivedToggle.onChange) {
-        await archivedToggle.onChange(true);
-      }
+      await toggle.onChangeCb?.(true);
 
       expect(mockPlugin.settings.showArchivedAssets).toBe(true);
       expect(mockPlugin.saveSettings).toHaveBeenCalled();
       expect(mockPlugin.refreshLayout).toHaveBeenCalled();
     });
-
   });
 });


### PR DESCRIPTION
## What & why

RFC 0002 §3.6 — Settings information architecture + strip internal references (Phase 3 clarity). Resolves **P8** (flat ~25-toggle list with leaked internal IDs, dangerous free-text editors, onboarding-critical PAT buried at the bottom) and **P3** (jargon). WBS node `6ad8f316`.

## Changes

1. **Three top-level sections** (`ExocortexSettingTab.display()` → `renderOnboardingAndSyncSection` / `renderDisplaySection` / `renderAdvancedSection`):
   - **Onboarding & sync** (top) — GitHub PAT, profiles, ExoSync. The PAT a first-run tester needs is no longer the last thing rendered.
   - **Display** — visual/label/layout toggles + display-name templates.
   - **Advanced** — power-user behaviour, experimental flags, free-text path editors, log-channel matrix.
2. **Strip internal IDs** from every user-facing string (grep gate, M4 / §7): removed `Issue #2992`, `Issue #3539`, `Vision Lock #1, Security #1`, `(D17)`. Also fixed two mixed-language (Cyrillic `в`/`с`) user-facing strings. Engineering-traceability **comments** keep their issue references (out of scope — the gate is on the *rendered* surface).
3. **Label the log-channel matrix columns** (Notice / Console / File) with a header row + a per-toggle `aria-label`/`title` (a11y; the matrix previously exposed 3 anonymous toggles per row).
4. **Gate the free-text path editors** (Lazy bootstrap folders / Excluded folders) behind the Advanced section with a "a wrong path can **break indexing**" caution.

## Tests

- New `ExocortexSettingTab.informationArchitecture.test.ts` (12 tests): section order, PAT-in-top-section, grep gate (one test per internal-ID pattern, **revert-verified**: reintroducing `Issue #2992` makes the gate fail), column labels + 12 aria-labels, path-editors-after-Advanced + caution.
- Rewrote `ExocortexSettingTab.test.ts` to name-based (order-robust) Setting lookups — the old positional/count assertions broke on the section reorder by design.
- Full obsidian-plugin unit suite green locally (the one unrelated red is the `exoas-exo` submodule-presence parity test, which needs the data submodule checked out — passes in CI).

## DoD (RFC 0002 §7 Phase 3)
- [x] Settings sectioned (Onboarding & sync / Display / Advanced) with PAT+sync at top; log-channel matrix columns labeled.
- [x] Grep gate: no user-facing string contains `Vision Lock`, `Security #`, `(D[0-9]`, `Issue #[0-9]`.

a11y preserved (aria-labels on matrix toggles); Desktop↔Mobile parity unaffected (no command gating touched; archgate MOBILE-004 pass).

Resolves P8/P3 — WBS `6ad8f316`.