### PR TITLE
fix(layout): non-table layout in code block shows a notice, not an error (UX audit F6)

### DIFF
--- a/packages/obsidian-plugin/src/application/processors/LayoutCodeBlockProcessor.ts
+++ b/packages/obsidian-plugin/src/application/processors/LayoutCodeBlockProcessor.ts
@@ -367,12 +367,10 @@ export class LayoutCodeBlockProcessor {
     if (isTableLayout(result.layout)) {
       this.renderTableLayout(result.layout, result.rows, container);
     } else {
-      // For non-table layouts, show a placeholder for now
-      this.showErrorState(
-        container,
-        `Layout type "${result.layout.type}" is not yet supported in code blocks`,
-        ""
-      );
+      // Non-table layouts inside a code block are a documented limitation, not
+      // an error — surface an informational notice instead of the red
+      // "Error loading layout" state (UX audit finding F6).
+      this.showUnsupportedLayoutState(container, result.layout.type);
     }
   }
 
@@ -421,6 +419,35 @@ export class LayoutCodeBlockProcessor {
     loadingDiv.className = "exo-layout-loading";
     loadingDiv.textContent = message;
     container.appendChild(loadingDiv);
+  }
+
+  /**
+   * Show an informational notice for layout types that cannot yet be rendered
+   * inside a code block (e.g. graph / calendar / list layouts). This is a
+   * documented limitation — NOT a failure — so it deliberately avoids the
+   * "Error loading layout" error state, which would tell the user something
+   * went wrong when nothing did (UX audit finding F6).
+   */
+  private showUnsupportedLayoutState(
+    container: HTMLElement,
+    layoutType: string
+  ): void {
+    const noticeDiv = document.createElement("div");
+    noticeDiv.className = "exo-layout-notice";
+
+    const titleEl = document.createElement("div");
+    titleEl.className = "exo-layout-notice-title";
+    titleEl.textContent = "Layout not available in code blocks";
+    noticeDiv.appendChild(titleEl);
+
+    const messageEl = document.createElement("div");
+    messageEl.className = "exo-layout-notice-message";
+    messageEl.textContent =
+      `Code blocks currently support table layouts only — the "${layoutType}" ` +
+      `layout isn't available here yet.`;
+    noticeDiv.appendChild(messageEl);
+
+    container.appendChild(noticeDiv);
   }
 
   /**

--- a/packages/obsidian-plugin/tests/unit/application/processors/LayoutCodeBlockProcessor.test.ts
+++ b/packages/obsidian-plugin/tests/unit/application/processors/LayoutCodeBlockProcessor.test.ts
@@ -142,6 +142,60 @@ describe("LayoutCodeBlockProcessor", () => {
     });
   });
 
+  describe("Unsupported layout notice (non-table in code block)", () => {
+    it("renders an informational notice, NOT the error state, for non-table layouts", () => {
+      const container = document.createElement("div");
+
+      // A non-table layout (e.g. graph) referenced inside an exo-layout code
+      // block is a documented limitation, not an error.
+      (processor as any).renderLayoutResult(
+        { success: true, layout: { type: "exo__GraphLayout" }, rows: [] },
+        container
+      );
+
+      // It must NOT use the "Error loading layout" error state — that frames a
+      // known limitation as a failure (finding F5/F6 — UX audit).
+      expect(container.querySelector(".exo-layout-error")).toBeFalsy();
+
+      const noticeDiv = container.querySelector(".exo-layout-notice");
+      expect(noticeDiv).toBeTruthy();
+
+      const titleEl = container.querySelector(".exo-layout-notice-title");
+      expect(titleEl?.textContent).not.toBe("Error loading layout");
+      expect(titleEl?.textContent?.toLowerCase()).not.toContain("error");
+
+      const messageEl = container.querySelector(".exo-layout-notice-message");
+      // The message names the layout type so the user understands what is unsupported.
+      expect(messageEl?.textContent).toContain("exo__GraphLayout");
+    });
+
+    it("showUnsupportedLayoutState builds a neutral notice naming the layout type", () => {
+      const container = document.createElement("div");
+
+      (processor as any).showUnsupportedLayoutState(container, "exo__CalendarLayout");
+
+      const noticeDiv = container.querySelector(".exo-layout-notice");
+      expect(noticeDiv).toBeTruthy();
+      expect(container.querySelector(".exo-layout-error")).toBeFalsy();
+
+      const messageEl = container.querySelector(".exo-layout-notice-message");
+      expect(messageEl?.textContent).toContain("exo__CalendarLayout");
+    });
+
+    it("still uses the error state for a genuine missing-layout failure (regression guard)", () => {
+      const container = document.createElement("div");
+
+      // No layout/rows => a real failure, must stay an error.
+      (processor as any).renderLayoutResult({ success: false }, container);
+
+      const errorDiv = container.querySelector(".exo-layout-error");
+      expect(errorDiv).toBeTruthy();
+      const titleEl = container.querySelector(".exo-layout-error-title");
+      expect(titleEl?.textContent).toBe("Error loading layout");
+      expect(container.querySelector(".exo-layout-notice")).toBeFalsy();
+    });
+  });
+
   describe("Refresh Indicator", () => {
     it("should show refresh indicator", () => {
       const container = document.createElement("div");


### PR DESCRIPTION
## What

A non-table layout referenced inside an `exo-layout` code block (e.g. a graph / calendar / list layout) is a **documented limitation, not a failure** — but `LayoutCodeBlockProcessor.renderLayoutResult()` routed it through `showErrorState`, rendering the **"Error loading layout"** title. A user who put a valid non-table layout in a code block was told something went wrong when nothing did.

This adds `showUnsupportedLayoutState()` — a neutral informational notice (`.exo-layout-notice`, title "Layout not available in code blocks") naming the unsupported layout type. **Genuine** failures (missing layout/rows, exceptions) still use the error state.

## Resolves

UX audit finding **F6** (Alpha Launch UX/functionality audit, code-review-based). Disjoint surface — `LayoutCodeBlockProcessor` untouched for 30+ days, no overlapping in-flight work.

## Empirically verified (revert→fail / restore→pass)

- **Pre-fix:** the new test asserts `.exo-layout-error` is absent for a non-table layout → **FAILS** (renders `<div class="exo-layout-error"><div class="exo-layout-error-title">Error loading layout</div>…`).
- **Post-fix:** renders `.exo-layout-notice` with a neutral title → **PASSES** (27/27 in the suite).
- Regression guard: a `{ success:false }` result with no layout/rows still renders the **error** state ("Error loading layout") — genuine failures unaffected.

## Scope

Presentation-only, plugin `application/processors`. `npm run check:types` 0 errors; `npm run lint` 0 errors. No CSS change (the existing `.exo-layout-error`/`.exo-layout-loading` classes have no dedicated CSS either; the fix is the text framing + a semantic class name).