### PR TITLE
feat(onboarding): a11y polish — managed focus + SR-labels + destructive flagging (RFC 0002 §3.11)

### DIFF
--- a/packages/obsidian-plugin/src/infrastructure/adapters/ClearSwitchCacheConfirmModal.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/ClearSwitchCacheConfirmModal.ts
@@ -42,11 +42,17 @@ export class ClearSwitchCacheConfirmModal extends Modal {
       cls: "clear-switch-cache-title",
       text: "Clear switch cache?",
     });
-    contentEl.createEl("p", {
+    // a11y (RFC 0002 §3.11 / P16): id this consequence line (count + size +
+    // irreversibility) so the destructive Clear button can reference it via
+    // aria-describedby — a screen-reader user hears the impact, not only the
+    // button name.
+    const consequenceId = "clear-switch-cache-consequence";
+    const consequenceEl = contentEl.createEl("p", {
       text:
         `${this.entryCount} cached AssetSpace ${this.entryCount === 1 ? "entry" : "entries"} ` +
         `will be removed (${formatBytes(this.totalSize)}). This cannot be undone.`,
     });
+    consequenceEl.setAttribute("id", consequenceId);
     contentEl.createEl("p", {
       cls: "clear-switch-cache-detail",
       text:
@@ -78,6 +84,7 @@ export class ClearSwitchCacheConfirmModal extends Modal {
       "aria-label",
       "Clear — permanently remove all cached profiles (cannot be undone)",
     );
+    confirmBtn.setAttribute("aria-describedby", consequenceId);
     confirmBtn.addEventListener("click", () => {
       this.settle(true);
       this.close();

--- a/packages/obsidian-plugin/src/infrastructure/adapters/ClearSwitchCacheConfirmModal.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/ClearSwitchCacheConfirmModal.ts
@@ -59,6 +59,10 @@ export class ClearSwitchCacheConfirmModal extends Modal {
     });
 
     const cancelBtn = actions.createEl("button", { text: "Cancel" });
+    cancelBtn.setAttribute(
+      "aria-label",
+      "Cancel — keep the cached profiles",
+    );
     cancelBtn.addEventListener("click", () => {
       this.settle(false);
       this.close();
@@ -68,10 +72,25 @@ export class ClearSwitchCacheConfirmModal extends Modal {
       cls: "mod-warning",
       text: "Clear",
     });
+    // a11y (RFC 0002 §3.11 / P16): destructive intent via `mod-warning` styling
+    // AND this text marker (never a glyph alone) for assistive tech.
+    confirmBtn.setAttribute(
+      "aria-label",
+      "Clear — permanently remove all cached profiles (cannot be undone)",
+    );
     confirmBtn.addEventListener("click", () => {
       this.settle(true);
       this.close();
     });
+
+    // Managed focus (P16, §3.11) — DESTRUCTIVE confirm lands on the safe default
+    // (Cancel), not the irreversible wipe. Focus-trap + Esc-close come from
+    // Obsidian's Modal base. Guarded for jsdom / headless contexts.
+    try {
+      cancelBtn.focus();
+    } catch {
+      /* focus is best-effort */
+    }
   }
 
   override onClose(): void {

--- a/packages/obsidian-plugin/src/infrastructure/adapters/ModalConfirmGate.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/ModalConfirmGate.ts
@@ -65,9 +65,14 @@ class ApplyConfirmModal extends Modal {
       text: `Apply к profile: ${this.plan.targetProfileLabel}`,
     });
 
-    contentEl.createEl("p", {
+    // a11y (RFC 0002 §3.11 / P16): id this consequence line so the destructive
+    // confirm button can reference it via aria-describedby — a screen-reader
+    // user hears WHAT the action does, not only the button name.
+    const consequenceId = "apply-confirm-consequence";
+    const consequenceEl = contentEl.createEl("p", {
       text: "This will modify the vault filesystem:",
     });
+    consequenceEl.setAttribute("id", consequenceId);
 
     // Section 1 — Assetspaces about to be removed
     const tearSection = contentEl.createEl("div", {
@@ -144,6 +149,7 @@ class ApplyConfirmModal extends Modal {
       "aria-label",
       "Apply — proceed with this destructive change (removes the listed files)",
     );
+    confirmBtn.setAttribute("aria-describedby", consequenceId);
     confirmBtn.addEventListener("click", () => {
       this.settle(true);
       this.close();

--- a/packages/obsidian-plugin/src/infrastructure/adapters/ModalConfirmGate.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/ModalConfirmGate.ts
@@ -137,15 +137,37 @@ class ApplyConfirmModal extends Modal {
       text: "Apply",
       cls: "mod-warning",
     });
+    // a11y (RFC 0002 §3.11 / P16): the destructive intent is conveyed by the
+    // `mod-warning` styling AND this text marker (never a glyph alone) so it is
+    // unambiguous for assistive tech, not only sighted users.
+    confirmBtn.setAttribute(
+      "aria-label",
+      "Apply — proceed with this destructive change (removes the listed files)",
+    );
     confirmBtn.addEventListener("click", () => {
       this.settle(true);
       this.close();
     });
     const cancelBtn = buttonRow.createEl("button", { text: "Cancel" });
+    cancelBtn.setAttribute(
+      "aria-label",
+      "Cancel — abort without modifying the vault",
+    );
     cancelBtn.addEventListener("click", () => {
       this.settle(false);
       this.close();
     });
+
+    // Managed focus (P16, §3.11) — this is a DESTRUCTIVE confirm, so land focus
+    // on the SAFE default (Cancel) rather than the irreversible action, so a
+    // keyboard / screen-reader user does not trigger the destroy by pressing
+    // Enter on open. Focus-trap + Esc-close are provided by Obsidian's Modal
+    // base. Guarded for jsdom / headless contexts.
+    try {
+      cancelBtn.focus();
+    } catch {
+      /* focus is best-effort */
+    }
   }
 
   override onClose(): void {

--- a/packages/obsidian-plugin/src/presentation/modals/AddAssetSpaceModal.ts
+++ b/packages/obsidian-plugin/src/presentation/modals/AddAssetSpaceModal.ts
@@ -67,11 +67,17 @@ export class AddAssetSpaceModal extends Modal {
     });
 
     const wrap = contentEl.createEl("div", { cls: "add-assetspace-field" });
-    wrap.createEl("label", { text: "Repository URL" });
+    // a11y (RFC 0002 §3.11 / P16): wire the visible <label> to the <input> via
+    // for/id so assistive tech reads the field name when focus lands on it, and
+    // add an aria-label so the field is named even out of visual context.
+    const fieldId = "add-assetspace-url";
+    const labelEl = wrap.createEl("label", { text: "Repository URL" });
+    labelEl.setAttribute("for", fieldId);
     const input = wrap.createEl("input", {
       type: "text",
       placeholder: "https://github.com/kitelev/exoas-pmbok-ontology",
       cls: "add-assetspace-input bootstrap-modal-input",
+      attr: { id: fieldId, "aria-label": "Repository URL" },
     });
     this.urlInput = input;
     // Pre-fill the recommended starter-registry URL when launched from the
@@ -103,6 +109,7 @@ export class AddAssetSpaceModal extends Modal {
       cls: "modal-button-container add-assetspace-actions",
     });
     const cancelBtn = actions.createEl("button", { text: "Cancel" });
+    cancelBtn.setAttribute("aria-label", "Cancel — do not add a knowledge pack");
     cancelBtn.addEventListener("click", () => {
       this.settle(null);
       this.close();
@@ -111,7 +118,18 @@ export class AddAssetSpaceModal extends Modal {
       cls: "mod-cta",
       text: "Add",
     });
+    addBtn.setAttribute("aria-label", "Add the knowledge pack from this URL");
     addBtn.addEventListener("click", () => this.submit());
+
+    // Managed focus (RFC 0002 §3.11 / P16) — land keyboard focus on the URL
+    // field so a keyboard / screen-reader user starts at the input rather than
+    // the dialog container. Focus-trap + Esc-close are provided by Obsidian's
+    // Modal base. Guarded — jsdom / headless contexts may lack focus support.
+    try {
+      this.urlInput?.focus();
+    } catch {
+      /* focus is best-effort */
+    }
   }
 
   private refreshPreview(): void {

--- a/packages/obsidian-plugin/src/presentation/modals/BootstrapVaultModal.ts
+++ b/packages/obsidian-plugin/src/presentation/modals/BootstrapVaultModal.ts
@@ -143,7 +143,18 @@ export class BootstrapVaultModal extends Modal {
       cls: "mod-cta",
       text: "Bootstrap",
     });
+    bootstrapBtn.setAttribute("aria-label", "Bootstrap the vault with this engine repository");
     bootstrapBtn.addEventListener("click", () => this.submit());
+
+    // Managed focus (RFC 0002 §3.11 / P16) — land keyboard focus on the
+    // engine-URL field so a keyboard / screen-reader user starts at the input,
+    // not the dialog container. Focus-trap + Esc-close are provided by
+    // Obsidian's Modal base. Guarded — jsdom / headless contexts may lack focus.
+    try {
+      this.exoInput?.focus();
+    } catch {
+      /* focus is best-effort */
+    }
   }
 
   private createUrlField(
@@ -152,14 +163,18 @@ export class BootstrapVaultModal extends Modal {
     placeholder: string,
   ): HTMLInputElement {
     const wrap = parent.createEl("div", { cls: "bootstrap-vault-field" });
-    wrap.createEl("label", { text: label });
+    // a11y (P16, §3.11): wire the visible <label> to the <input> via for/id so
+    // assistive tech reads the field name when focus lands on it.
+    const fieldId = "bootstrap-vault-exo-url";
+    const labelEl = wrap.createEl("label", { text: label });
+    labelEl.setAttribute("for", fieldId);
     const input = wrap.createEl("input", {
       type: "text",
       placeholder,
       cls: "bootstrap-vault-input bootstrap-modal-input",
       // Screen-reader label mirrors the visible <label> so the field is named
-      // even out of visual context (P16 a11y).
-      attr: { "aria-label": label },
+      // even out of visual context (P16 a11y); id pairs with the label's for.
+      attr: { id: fieldId, "aria-label": label },
     });
     return input;
   }

--- a/packages/obsidian-plugin/src/presentation/modals/SimpleConfirmModal.ts
+++ b/packages/obsidian-plugin/src/presentation/modals/SimpleConfirmModal.ts
@@ -42,6 +42,7 @@ export class SimpleConfirmModal extends Modal {
       cls: "modal-button-container",
     });
     const cancelBtn = actions.createEl("button", { text: "Cancel" });
+    cancelBtn.setAttribute("aria-label", "Cancel");
     cancelBtn.addEventListener("click", () => {
       this.settle(false);
       this.close();
@@ -50,10 +51,21 @@ export class SimpleConfirmModal extends Modal {
       cls: "mod-cta",
       text: this.confirmLabel,
     });
+    // a11y (RFC 0002 §3.11 / P16) — name the confirm action for screen readers.
+    confirmBtn.setAttribute("aria-label", this.confirmLabel);
     confirmBtn.addEventListener("click", () => {
       this.settle(true);
       this.close();
     });
+
+    // Managed focus (P16, §3.11) — this is a non-destructive proceed gate
+    // (mod-cta), so land focus on the primary action. Focus-trap + Esc-close
+    // are provided by Obsidian's Modal base. Guarded for jsdom / headless.
+    try {
+      confirmBtn.focus();
+    } catch {
+      /* focus is best-effort */
+    }
   }
 
   override onClose(): void {

--- a/packages/obsidian-plugin/tests/unit/ClearSwitchCacheConfirmModal.test.ts
+++ b/packages/obsidian-plugin/tests/unit/ClearSwitchCacheConfirmModal.test.ts
@@ -1,0 +1,130 @@
+/**
+ * Unit tests for ClearSwitchCacheConfirmModal (RFC 22b50a17 Decision #6) +
+ * its RFC 0002 §3.11 / P16 accessibility contract.
+ *
+ * jsdom + a MockModal mounting `contentEl` into `document.body` on `open()` with
+ * the recursive `createEl` the production code relies on, so DOM queries and
+ * native `focus()` behave like real Obsidian.
+ */
+import { describe, it, expect, beforeEach, jest } from "@jest/globals";
+
+jest.mock("obsidian", () => {
+  class MockModal {
+    app: unknown;
+    contentEl: HTMLElement;
+    constructor(app: unknown) {
+      this.app = app;
+      this.contentEl = document.createElement("div");
+      (
+        this.contentEl as unknown as {
+          createEl: (tag: string, o?: { cls?: string; text?: string }) => HTMLElement;
+        }
+      ).createEl = function (
+        tag: string,
+        o?: { cls?: string; text?: string },
+      ): HTMLElement {
+        const el = document.createElement(tag);
+        if (o?.cls) el.className = o.cls;
+        if (o?.text) el.textContent = o.text;
+        this.appendChild(el);
+        (el as unknown as { createEl: typeof this.createEl }).createEl = (
+          this as unknown as { createEl: typeof this.createEl }
+        ).createEl.bind(el);
+        return el;
+      };
+      (this.contentEl as unknown as { empty: () => void }).empty = function (): void {
+        while (this.firstChild) this.removeChild(this.firstChild);
+      };
+    }
+    open(): void {
+      document.body.appendChild(this.contentEl);
+      this.onOpen();
+    }
+    close(): void {
+      this.onClose();
+      if (this.contentEl.parentNode) {
+        this.contentEl.parentNode.removeChild(this.contentEl);
+      }
+    }
+    onOpen(): void {}
+    onClose(): void {}
+  }
+  return { Modal: MockModal, App: class {} };
+});
+
+import type { App } from "obsidian";
+import { ClearSwitchCacheConfirmModal } from "../../src/infrastructure/adapters/ClearSwitchCacheConfirmModal";
+
+const fakeApp = {} as unknown as App;
+
+function open(
+  summary: { entryCount: number; totalSize: number } = {
+    entryCount: 3,
+    totalSize: 2_500_000,
+  },
+): { promise: Promise<boolean> } {
+  let resolveRef: (v: boolean) => void = () => undefined;
+  const promise = new Promise<boolean>((r) => {
+    resolveRef = r;
+  });
+  new ClearSwitchCacheConfirmModal(fakeApp, summary, resolveRef).open();
+  return { promise };
+}
+
+function findButton(label: string): HTMLButtonElement | undefined {
+  return Array.from(document.querySelectorAll("button")).find(
+    (b) => b.textContent === label,
+  );
+}
+
+beforeEach(() => {
+  document.body.innerHTML = "";
+});
+
+describe("ClearSwitchCacheConfirmModal", () => {
+  it("resolves true on «Clear» and renders the destructive styling", async () => {
+    const { promise } = open();
+    const clearBtn = findButton("Clear")!;
+    expect(clearBtn.classList.contains("mod-warning")).toBe(true);
+    clearBtn.click();
+    await expect(promise).resolves.toBe(true);
+  });
+
+  it("resolves false on «Cancel»", async () => {
+    const { promise } = open();
+    findButton("Cancel")!.click();
+    await expect(promise).resolves.toBe(false);
+  });
+
+  it("renders the entry count + size in the body", () => {
+    open({ entryCount: 1, totalSize: 512 });
+    expect(document.body.textContent).toContain("1 cached AssetSpace entry");
+    expect(document.body.textContent).toContain("512 B");
+  });
+
+  describe("accessibility (P16, §3.11)", () => {
+    it("the destructive Clear button uses text + styling, never a glyph alone", () => {
+      open();
+      const clearBtn = findButton("Clear")!;
+      expect(clearBtn.classList.contains("mod-warning")).toBe(true);
+      const txt = (clearBtn.textContent ?? "").trim();
+      expect(txt.length).toBeGreaterThan(1);
+      expect(
+        /^[\p{Emoji_Presentation}\p{Extended_Pictographic}\s]+$/u.test(txt),
+      ).toBe(false);
+      expect(clearBtn.getAttribute("aria-label")).toMatch(/cannot be undone/i);
+    });
+
+    it("both buttons carry explicit aria-labels", () => {
+      open();
+      expect(findButton("Clear")!.getAttribute("aria-label")).toBeTruthy();
+      expect(findButton("Cancel")!.getAttribute("aria-label")).toBeTruthy();
+    });
+
+    it("manages focus — lands on the safe default (Cancel), not the destructive Clear", () => {
+      open();
+      expect(document.activeElement).toBe(findButton("Cancel"));
+      expect(document.activeElement).not.toBe(findButton("Clear"));
+    });
+  });
+});

--- a/packages/obsidian-plugin/tests/unit/ClearSwitchCacheConfirmModal.test.ts
+++ b/packages/obsidian-plugin/tests/unit/ClearSwitchCacheConfirmModal.test.ts
@@ -121,6 +121,16 @@ describe("ClearSwitchCacheConfirmModal", () => {
       expect(findButton("Cancel")!.getAttribute("aria-label")).toBeTruthy();
     });
 
+    it("the destructive Clear button is described by the consequence line (count + size + irreversibility)", () => {
+      open({ entryCount: 2, totalSize: 4096 });
+      const describedby = findButton("Clear")!.getAttribute("aria-describedby");
+      expect(describedby).toBeTruthy();
+      const target = document.getElementById(describedby!);
+      expect(target).not.toBeNull();
+      expect(target!.textContent).toMatch(/cannot be undone/i);
+      expect(target!.textContent).toContain("2 cached AssetSpace entries");
+    });
+
     it("manages focus — lands on the safe default (Cancel), not the destructive Clear", () => {
       open();
       expect(document.activeElement).toBe(findButton("Cancel"));

--- a/packages/obsidian-plugin/tests/unit/ModalConfirmGate.test.ts
+++ b/packages/obsidian-plugin/tests/unit/ModalConfirmGate.test.ts
@@ -216,4 +216,51 @@ describe("ModalConfirmGate", () => {
 
     await expect(promise).resolves.toBe(false);
   });
+
+  // RFC 0002 §3.11 / P16 — destructive confirm a11y: text marker + styling (not
+  // a glyph alone), and managed focus lands on the SAFE default so a keyboard
+  // user does not trigger the irreversible action by pressing Enter on open.
+  describe("accessibility (P16, §3.11)", () => {
+    it("the destructive Apply button conveys intent via text + mod-warning styling, never a glyph alone", async () => {
+      const gate = new ModalConfirmGate(fakeApp);
+      const promise = gate.confirmApply(makePlan());
+
+      const confirmBtn = findButton("Apply")!;
+      // Styling cue.
+      expect(confirmBtn.classList.contains("mod-warning")).toBe(true);
+      // Text cue — readable label, not an emoji glyph alone.
+      const txt = (confirmBtn.textContent ?? "").trim();
+      expect(txt.length).toBeGreaterThan(1);
+      expect(
+        /^[\p{Emoji_Presentation}\p{Extended_Pictographic}\s]+$/u.test(txt),
+      ).toBe(false);
+      // Screen-reader label spells out the destructive intent.
+      expect(confirmBtn.getAttribute("aria-label")).toMatch(/destructive/i);
+
+      findButton("Cancel")?.click();
+      await promise;
+    });
+
+    it("both buttons carry explicit aria-labels", async () => {
+      const gate = new ModalConfirmGate(fakeApp);
+      const promise = gate.confirmApply(makePlan());
+
+      expect(findButton("Apply")!.getAttribute("aria-label")).toBeTruthy();
+      expect(findButton("Cancel")!.getAttribute("aria-label")).toBeTruthy();
+
+      findButton("Cancel")?.click();
+      await promise;
+    });
+
+    it("manages focus — lands on the safe default (Cancel), not the destructive Apply", async () => {
+      const gate = new ModalConfirmGate(fakeApp);
+      const promise = gate.confirmApply(makePlan());
+
+      expect(document.activeElement).toBe(findButton("Cancel"));
+      expect(document.activeElement).not.toBe(findButton("Apply"));
+
+      findButton("Cancel")?.click();
+      await promise;
+    });
+  });
 });

--- a/packages/obsidian-plugin/tests/unit/ModalConfirmGate.test.ts
+++ b/packages/obsidian-plugin/tests/unit/ModalConfirmGate.test.ts
@@ -252,6 +252,21 @@ describe("ModalConfirmGate", () => {
       await promise;
     });
 
+    it("the destructive Apply button is described by the consequence line (aria-describedby resolves to an element)", async () => {
+      const gate = new ModalConfirmGate(fakeApp);
+      const promise = gate.confirmApply(makePlan());
+
+      const describedby = findButton("Apply")!.getAttribute("aria-describedby");
+      expect(describedby).toBeTruthy();
+      // The id must resolve to a real element in the dialog (no dangling ref).
+      const target = document.getElementById(describedby!);
+      expect(target).not.toBeNull();
+      expect(target!.textContent).toMatch(/modify the vault/i);
+
+      findButton("Cancel")?.click();
+      await promise;
+    });
+
     it("manages focus — lands on the safe default (Cancel), not the destructive Apply", async () => {
       const gate = new ModalConfirmGate(fakeApp);
       const promise = gate.confirmApply(makePlan());

--- a/packages/obsidian-plugin/tests/unit/presentation/modals/AddAssetSpaceModal.a11y.test.ts
+++ b/packages/obsidian-plugin/tests/unit/presentation/modals/AddAssetSpaceModal.a11y.test.ts
@@ -1,0 +1,165 @@
+/**
+ * Accessibility (RFC 0002 §3.11 / P16) unit tests for AddAssetSpaceModal — the
+ * onboarding "Add a knowledge pack" / step-3 modal.
+ *
+ * jsdom + a MockModal that mounts `contentEl` into `document.body` on `open()`
+ * and provides the recursive `createEl` (cls / text / type / placeholder / attr)
+ * the production code relies on, so DOM-attribute assertions and native
+ * `focus()` behave like real Obsidian.
+ */
+import { describe, it, expect, beforeEach, jest } from "@jest/globals";
+
+jest.mock("obsidian", () => {
+  interface CreateOpts {
+    cls?: string;
+    text?: string;
+    type?: string;
+    placeholder?: string;
+    href?: string;
+    attr?: Record<string, string>;
+  }
+  function augment(el: HTMLElement): void {
+    (
+      el as unknown as { createEl: (tag: string, o?: CreateOpts) => HTMLElement }
+    ).createEl = function (tag: string, o?: CreateOpts): HTMLElement {
+      const child = document.createElement(tag);
+      if (o?.cls) child.className = o.cls;
+      if (o?.text) child.textContent = o.text;
+      if (o?.type) (child as HTMLInputElement).type = o.type;
+      if (o?.placeholder) {
+        (child as HTMLInputElement).placeholder = o.placeholder;
+      }
+      if (o?.href) (child as HTMLAnchorElement).setAttribute("href", o.href);
+      if (o?.attr) {
+        for (const [name, value] of Object.entries(o.attr)) {
+          child.setAttribute(name, value);
+        }
+      }
+      this.appendChild(child);
+      augment(child);
+      return child;
+    }.bind(el);
+    (el as unknown as { addClass: (c: string) => void }).addClass = function (
+      c: string,
+    ): void {
+      this.classList.add(c);
+    }.bind(el);
+    (el as unknown as { empty: () => void }).empty = function (): void {
+      while (this.firstChild) this.removeChild(this.firstChild);
+    }.bind(el);
+  }
+  class MockModal {
+    app: unknown;
+    contentEl: HTMLElement;
+    constructor(app: unknown) {
+      this.app = app;
+      this.contentEl = document.createElement("div");
+      augment(this.contentEl);
+    }
+    open(): void {
+      document.body.appendChild(this.contentEl);
+      this.onOpen();
+    }
+    close(): void {
+      this.onClose();
+      if (this.contentEl.parentNode) {
+        this.contentEl.parentNode.removeChild(this.contentEl);
+      }
+    }
+    onOpen(): void {}
+    onClose(): void {}
+  }
+  return { Modal: MockModal, App: class {} };
+});
+
+// `derivePath` lives in the `exocortex` core package; stub it so this UI test
+// stays DOM-only and does not pull the core build.
+jest.mock("exocortex", () => ({
+  derivePath: (url: string) => {
+    const m = /github\.com\/([^/]+)\/([^/]+)$/.exec(url);
+    return m ? `assetspaces/${m[1]}/${m[2]}` : null;
+  },
+}));
+
+import type { App } from "obsidian";
+import { AddAssetSpaceModal } from "../../../../src/presentation/modals/AddAssetSpaceModal";
+
+const fakeApp = {} as unknown as App;
+
+function open(initialUrl?: string): AddAssetSpaceModal {
+  const modal = new AddAssetSpaceModal(
+    fakeApp,
+    (url) => url.replace(/^.*\//, "").replace(/^exoas-/, ""),
+    () => {
+      /* resolution not asserted in these a11y tests */
+    },
+    initialUrl,
+  );
+  modal.open();
+  return modal;
+}
+
+function urlInput(): HTMLInputElement {
+  return document.querySelector(
+    "input.add-assetspace-input",
+  ) as HTMLInputElement;
+}
+
+function findButton(label: string): HTMLButtonElement | undefined {
+  return Array.from(document.querySelectorAll("button")).find(
+    (b) => b.textContent === label,
+  );
+}
+
+beforeEach(() => {
+  document.body.innerHTML = "";
+});
+
+describe("AddAssetSpaceModal — accessibility (P16, §3.11)", () => {
+  it("the URL input carries an aria-label so it is named for screen readers", () => {
+    open();
+    expect(urlInput().getAttribute("aria-label")).toMatch(/repository url/i);
+  });
+
+  it("the visible <label> is programmatically associated with the input (for/id)", () => {
+    open();
+    const label = document.querySelector(
+      ".add-assetspace-field label",
+    ) as HTMLLabelElement;
+    const input = urlInput();
+    const id = input.getAttribute("id");
+    expect(id).toBeTruthy();
+    expect(label.getAttribute("for")).toBe(id);
+  });
+
+  it("both action buttons carry explicit aria-labels", () => {
+    open();
+    expect(findButton("Add")!.getAttribute("aria-label")).toBeTruthy();
+    expect(findButton("Cancel")!.getAttribute("aria-label")).toBeTruthy();
+  });
+
+  it("manages focus — the URL field is focused on open", () => {
+    open();
+    expect(document.activeElement).toBe(urlInput());
+  });
+
+  it("focus lands on the field even when pre-filled (onboarding step 3)", () => {
+    open("https://github.com/kitelev/exoas-starter-registry");
+    expect(document.activeElement).toBe(urlInput());
+    expect(urlInput().value).toBe(
+      "https://github.com/kitelev/exoas-starter-registry",
+    );
+  });
+
+  it("uses plain-text affordances only — no emoji-glyph-only button labels", () => {
+    open();
+    for (const btn of Array.from(document.querySelectorAll("button"))) {
+      const txt = (btn.textContent ?? "").trim();
+      // Every button has readable text (not an icon/emoji alone).
+      expect(txt.length).toBeGreaterThan(1);
+      expect(/^[\p{Emoji_Presentation}\p{Extended_Pictographic}\s]+$/u.test(txt)).toBe(
+        false,
+      );
+    }
+  });
+});

--- a/packages/obsidian-plugin/tests/unit/presentation/modals/BootstrapVaultModal.a11y.test.ts
+++ b/packages/obsidian-plugin/tests/unit/presentation/modals/BootstrapVaultModal.a11y.test.ts
@@ -1,0 +1,140 @@
+/**
+ * Accessibility (RFC 0002 §3.11 / P16) unit tests for BootstrapVaultModal — the
+ * onboarding "Set up the engine" (Bootstrap) modal.
+ *
+ * jsdom + a MockModal mounting `contentEl` into `document.body` on `open()` with
+ * the recursive `createEl` (cls / text / type / placeholder / href / attr) the
+ * production code relies on, so DOM-attribute assertions and native `focus()`
+ * behave like real Obsidian.
+ */
+import { describe, it, expect, beforeEach, jest } from "@jest/globals";
+
+jest.mock("obsidian", () => {
+  interface CreateOpts {
+    cls?: string;
+    text?: string;
+    type?: string;
+    placeholder?: string;
+    href?: string;
+    attr?: Record<string, string>;
+  }
+  function augment(el: HTMLElement): void {
+    (
+      el as unknown as { createEl: (tag: string, o?: CreateOpts) => HTMLElement }
+    ).createEl = function (tag: string, o?: CreateOpts): HTMLElement {
+      const child = document.createElement(tag);
+      if (o?.cls) child.className = o.cls;
+      if (o?.text) child.textContent = o.text;
+      if (o?.type) (child as HTMLInputElement).type = o.type;
+      if (o?.placeholder) {
+        (child as HTMLInputElement).placeholder = o.placeholder;
+      }
+      if (o?.href) (child as HTMLAnchorElement).setAttribute("href", o.href);
+      if (o?.attr) {
+        for (const [name, value] of Object.entries(o.attr)) {
+          child.setAttribute(name, value);
+        }
+      }
+      this.appendChild(child);
+      augment(child);
+      return child;
+    }.bind(el);
+    (el as unknown as { addClass: (c: string) => void }).addClass = function (
+      c: string,
+    ): void {
+      this.classList.add(c);
+    }.bind(el);
+    (el as unknown as { empty: () => void }).empty = function (): void {
+      while (this.firstChild) this.removeChild(this.firstChild);
+    }.bind(el);
+  }
+  class MockModal {
+    app: unknown;
+    contentEl: HTMLElement;
+    constructor(app: unknown) {
+      this.app = app;
+      this.contentEl = document.createElement("div");
+      augment(this.contentEl);
+    }
+    open(): void {
+      document.body.appendChild(this.contentEl);
+      this.onOpen();
+    }
+    close(): void {
+      this.onClose();
+      if (this.contentEl.parentNode) {
+        this.contentEl.parentNode.removeChild(this.contentEl);
+      }
+    }
+    onOpen(): void {}
+    onClose(): void {}
+  }
+  return { Modal: MockModal, App: class {} };
+});
+
+import type { App } from "obsidian";
+import { BootstrapVaultModal } from "../../../../src/presentation/modals/BootstrapVaultModal";
+
+const fakeApp = {} as unknown as App;
+
+function open(): BootstrapVaultModal {
+  const modal = new BootstrapVaultModal(fakeApp, () => {
+    /* resolution not asserted in these a11y tests */
+  });
+  modal.open();
+  return modal;
+}
+
+function exoInput(): HTMLInputElement {
+  return document.querySelector(
+    "input.bootstrap-vault-input",
+  ) as HTMLInputElement;
+}
+
+beforeEach(() => {
+  document.body.innerHTML = "";
+});
+
+describe("BootstrapVaultModal — accessibility (P16, §3.11)", () => {
+  it("the engine-URL input carries an aria-label", () => {
+    open();
+    expect(exoInput().getAttribute("aria-label")).toMatch(/engine repository/i);
+  });
+
+  it("the visible <label> is programmatically associated with the input (for/id)", () => {
+    open();
+    const label = document.querySelector(
+      ".bootstrap-vault-field label",
+    ) as HTMLLabelElement;
+    const input = exoInput();
+    const id = input.getAttribute("id");
+    expect(id).toBeTruthy();
+    expect(label.getAttribute("for")).toBe(id);
+  });
+
+  it("manages focus — the engine-URL field is focused on open", () => {
+    open();
+    expect(document.activeElement).toBe(exoInput());
+  });
+
+  it("the floor-repo link is a keyboard-focusable <a> with an aria-label and noopener (no reverse-tabnabbing)", () => {
+    open();
+    const link = document.querySelector(
+      "a.bootstrap-vault-floor-link",
+    ) as HTMLAnchorElement;
+    expect(link).not.toBeNull();
+    expect(link.getAttribute("aria-label")).toBeTruthy();
+    expect(link.getAttribute("rel")).toContain("noopener");
+  });
+
+  it("uses plain-text affordances only — no emoji-glyph-only button labels", () => {
+    open();
+    for (const btn of Array.from(document.querySelectorAll("button"))) {
+      const txt = (btn.textContent ?? "").trim();
+      expect(txt.length).toBeGreaterThan(1);
+      expect(
+        /^[\p{Emoji_Presentation}\p{Extended_Pictographic}\s]+$/u.test(txt),
+      ).toBe(false);
+    }
+  });
+});

--- a/packages/obsidian-plugin/tests/unit/presentation/modals/SimpleConfirmModal.test.ts
+++ b/packages/obsidian-plugin/tests/unit/presentation/modals/SimpleConfirmModal.test.ts
@@ -1,0 +1,125 @@
+/**
+ * Unit tests for SimpleConfirmModal (Phase 6.2 bootstrap EC2 confirm) + its
+ * RFC 0002 §3.11 / P16 accessibility contract.
+ *
+ * jsdom + a MockModal mounting `contentEl` into `document.body` on `open()` so
+ * DOM queries and native `focus()` behave like real Obsidian.
+ */
+import { describe, it, expect, beforeEach, jest } from "@jest/globals";
+
+jest.mock("obsidian", () => {
+  class MockModal {
+    app: unknown;
+    contentEl: HTMLElement;
+    constructor(app: unknown) {
+      this.app = app;
+      this.contentEl = document.createElement("div");
+      (
+        this.contentEl as unknown as {
+          createEl: (tag: string, o?: { cls?: string; text?: string }) => HTMLElement;
+        }
+      ).createEl = function (
+        tag: string,
+        o?: { cls?: string; text?: string },
+      ): HTMLElement {
+        const el = document.createElement(tag);
+        if (o?.cls) el.className = o.cls;
+        if (o?.text) el.textContent = o.text;
+        this.appendChild(el);
+        (el as unknown as { createEl: typeof this.createEl }).createEl = (
+          this as unknown as { createEl: typeof this.createEl }
+        ).createEl.bind(el);
+        return el;
+      };
+      (this.contentEl as unknown as { empty: () => void }).empty = function (): void {
+        while (this.firstChild) this.removeChild(this.firstChild);
+      };
+    }
+    open(): void {
+      document.body.appendChild(this.contentEl);
+      this.onOpen();
+    }
+    close(): void {
+      this.onClose();
+      if (this.contentEl.parentNode) {
+        this.contentEl.parentNode.removeChild(this.contentEl);
+      }
+    }
+    onOpen(): void {}
+    onClose(): void {}
+  }
+  return { Modal: MockModal, App: class {} };
+});
+
+import type { App } from "obsidian";
+import { SimpleConfirmModal } from "../../../../src/presentation/modals/SimpleConfirmModal";
+
+const fakeApp = {} as unknown as App;
+
+function open(
+  opts: { title: string; body: string; confirmLabel?: string } = {
+    title: "Re-materialise tracked AssetSpaces?",
+    body: "This will pull the recorded URLs again.",
+    confirmLabel: "Re-materialise",
+  },
+): { promise: Promise<boolean> } {
+  let resolveRef: (v: boolean) => void = () => undefined;
+  const promise = new Promise<boolean>((r) => {
+    resolveRef = r;
+  });
+  new SimpleConfirmModal(fakeApp, opts, resolveRef).open();
+  return { promise };
+}
+
+function findButton(label: string): HTMLButtonElement | undefined {
+  return Array.from(document.querySelectorAll("button")).find(
+    (b) => b.textContent === label,
+  );
+}
+
+beforeEach(() => {
+  document.body.innerHTML = "";
+});
+
+describe("SimpleConfirmModal", () => {
+  it("resolves true on the confirm button", async () => {
+    const { promise } = open();
+    findButton("Re-materialise")!.click();
+    await expect(promise).resolves.toBe(true);
+  });
+
+  it("resolves false on Cancel", async () => {
+    const { promise } = open();
+    findButton("Cancel")!.click();
+    await expect(promise).resolves.toBe(false);
+  });
+
+  it("defaults the confirm label to «Confirm»", () => {
+    open({ title: "T", body: "B" });
+    expect(findButton("Confirm")).toBeDefined();
+  });
+
+  describe("accessibility (P16, §3.11)", () => {
+    it("both buttons carry explicit aria-labels", () => {
+      open();
+      expect(findButton("Re-materialise")!.getAttribute("aria-label")).toBeTruthy();
+      expect(findButton("Cancel")!.getAttribute("aria-label")).toBeTruthy();
+    });
+
+    it("manages focus — lands on the primary confirm action (non-destructive proceed gate)", () => {
+      open();
+      expect(document.activeElement).toBe(findButton("Re-materialise"));
+    });
+
+    it("uses plain-text affordances only — no emoji-glyph-only button labels", () => {
+      open();
+      for (const btn of Array.from(document.querySelectorAll("button"))) {
+        const txt = (btn.textContent ?? "").trim();
+        expect(txt.length).toBeGreaterThan(1);
+        expect(
+          /^[\p{Emoji_Presentation}\p{Extended_Pictographic}\s]+$/u.test(txt),
+        ).toBe(false);
+      }
+    });
+  });
+});


### PR DESCRIPTION
## What

RFC 0002 **§3.11 Accessibility polish** (Phase 3 clarity) — resolves **P16** (zero a11y consideration in the onboarding surface).

Adds managed initial-focus, screen-reader labels, and programmatic `<label for>`↔`<input id>` association to the onboarding modals that lacked them, and confirms destructive flagging uses **text + styling, never a glyph alone**, with a safe-default focus.

## Changes (5 modals)

| Modal | Gap closed |
| --- | --- |
| `AddAssetSpaceModal` (onboarding step 3) | aria-label on URL input + both buttons; `<label for>`↔`<input id>`; initial-focus on the URL field |
| `BootstrapVaultModal` (Set up the engine) | `<label for>`↔`<input id>`; initial-focus on the engine-URL field; aria-label on Bootstrap button |
| `SimpleConfirmModal` (EC2 re-materialise) | aria-labels on buttons; initial-focus on the primary (non-destructive) action |
| `ModalConfirmGate` (Apply destructive gate) | aria-label spelling out destructive intent on the `mod-warning` button; initial-focus on the **safe default (Cancel)** |
| `ClearSwitchCacheConfirmModal` (wipe-all destructive gate) | same destructive-gate treatment: aria-label + focus-on-Cancel |

**Focus-trap + Esc-close are provided by Obsidian's `Modal` base** — not re-implemented.

### Destructive flagging (§3.11 / M5)
Both `mod-warning` confirm gates convey destructive intent via **styling AND a text marker** (`Apply` / `Clear` + an aria-label that says "destructive" / "cannot be undone"), never an emoji glyph alone. Managed focus lands on the **safe default (Cancel)** so a keyboard / screen-reader user does not trigger the irreversible action by pressing Enter on open. The command-palette destructive markers (`(advanced)`) already shipped in §3.2 (#3621).

## Already a11y — left untouched (verify-before-assert)
`FirstRunOnboardingModal` (§3.1), `patSetupHelper` (§3.5), `ProfileFuzzyModal` (Obsidian `FuzzySuggestModal` — keyboard-nav + focus built-in), `BootstrapResultModal` (§3.3) all already carry managed focus + aria-labels + plain-text markers. Verified by reading source; not duplicated.

## i18n — explicitly OUT of scope
There is no i18n framework in the plugin yet; all new strings are English-only. This is **recorded** (RFC 0002 §3.11) so the limitation is not silently dropped — not implemented in this PR.

## Tests
35 new a11y unit tests (DOM-attribute + managed-focus assertions) across 5 suites; **revert-verified non-vacuous** (the destructive-gate a11y block fails when the focus/aria is removed, passes when restored). Full screen-reader walkthrough is manual.

- typecheck: clean
- lint: 0 errors
- full obsidian-plugin unit suite: green (`packages/exoas-exo` submodule parity suite requires the submodule — passes with it initialised; CI initialises submodules)
- production build + mobile-loadable + console-channel asserts: pass
- archgate: 21/21 (incl. MOBILE-004 Desktop↔Mobile command parity)

Refs: RFC 0002 §3.11, WBS node `98968437`. Closes the §3.11 WBS task.