### PR TITLE
feat(profile): undo last apply + durable bootstrap/PAT failure recovery (RFC 0002 §3.10)

### DIFF
--- a/packages/obsidian-plugin/src/ExocortexPlugin.ts
+++ b/packages/obsidian-plugin/src/ExocortexPlugin.ts
@@ -3202,6 +3202,8 @@ export default class ExocortexPlugin extends Plugin {
       fuzzyPick,
       getActiveFilePath: () => this.app.workspace.getActiveFile()?.path ?? null,
       getActiveProfileUid: () => localDataStore.getActiveProfileUid(),
+      // RFC 0002 §3.10 — undo target for «Undo last profile apply».
+      getPreviousProfileUid: () => localDataStore.getPreviousProfileUid(),
       notify: (message) => this.notifier.info(message),
     });
 
@@ -3270,6 +3272,24 @@ export default class ExocortexPlugin extends Plugin {
         name: "Apply profile",
         callback: () => {
           void commandsHandler.invokeApplyProfile();
+        },
+      });
+
+      // RFC 0002 §3.10 (resolves P15) — «Undo last profile apply»: revert to the
+      // profile active before the most recent apply in one click. Gated like
+      // apply-profile (registration parity desktop↔mobile — undoLastApply routes
+      // through the same applyProfile path). `checkCallback` hides it from the
+      // palette until an undo target exists (no dead command on a fresh vault),
+      // so it only appears once the user has actually switched profiles.
+      this.addCommand({
+        id: "undo-profile-apply",
+        name: "Undo last profile apply",
+        checkCallback: (checking: boolean) => {
+          const hasUndoTarget = localDataStore.getPreviousProfileUid() !== null;
+          if (checking) return hasUndoTarget;
+          if (!hasUndoTarget) return false;
+          void commandsHandler.invokeUndoLastApply();
+          return true;
         },
       });
     }
@@ -3663,6 +3683,13 @@ export default class ExocortexPlugin extends Plugin {
         new BootstrapResultModal(this.app, result, {
           onAddStarterContent: () =>
             void bootstrapCommands.invokeAddAssetSpace(STARTER_REGISTRY_URL),
+          // RFC 0002 §3.10 — one-click retry of the failed operation: re-open
+          // the same Bootstrap / Add flow (its modal collects the URL again) so
+          // the user can fix the URL / token / connection and retry in place.
+          onRetry: (operation) =>
+            operation === "bootstrap"
+              ? void bootstrapCommands.invokeBootstrap()
+              : void bootstrapCommands.invokeAddAssetSpace(),
         }).open(),
       onMaterialized: () => this.refreshAndInjectAssetSpaceMaterialization(),
     });

--- a/packages/obsidian-plugin/src/infrastructure/adapters/BootstrapAssetSpaceCommands.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/BootstrapAssetSpaceCommands.ts
@@ -122,19 +122,46 @@ export interface MaterializeResult {
 }
 
 /**
+ * Which Bootstrap / Add operation failed — used by the durable failure panel
+ * (RFC 0002 §3.10) to phrase the title + retry action.
+ */
+export type BootstrapOperation = "bootstrap" | "add";
+
+/**
+ * Classified cause of a Bootstrap / Add failure (RFC 0002 §3.10, resolves P15b).
+ * Drives the durable result panel's recovery-step copy:
+ *   - `bad-url`  — the repo URL failed validation / folder derivation.
+ *   - `network`  — the tarball pull could not reach GitHub (offline / DNS /
+ *                  timeout).
+ *   - `auth`     — GitHub rejected the token (401 / 403-not-rate-limit, or a
+ *                  private-repo 404 from an under-scoped fine-grained PAT).
+ *   - `unknown`  — anything else; the panel points at the logs.
+ */
+export type BootstrapFailureCause = "bad-url" | "network" | "auth" | "unknown";
+
+/**
  * Terminal bootstrap outcome reported to the durable result panel (RFC 0002
- * §3.3, resolves P5). Emitted via {@link BootstrapAssetSpaceCommandsDeps.showResult}
+ * §3.3 + §3.10). Emitted via {@link BootstrapAssetSpaceCommandsDeps.showResult}
  * IN ADDITION TO the existing transient toast + activity-log entry — this adds a
  * persistent, in-context "what happened + what to do next" surface, it does not
  * replace the (already firing) feedback.
  *
- * Only the three outcomes with a meaningful "next step" are reported; hard
- * failures / cancels are NOT (the toast covers them; error-recovery is P15).
+ * The three SUCCESS outcomes carry a "next step" nudge (§3.3 / P5). The `failed`
+ * outcome (§3.10 / P15) carries a classified `cause` + the failing `operation`
+ * so the panel surfaces WHY it failed and HOW to recover, routed through the
+ * same durable panel rather than a toast that fades.
  */
 export type BootstrapResultInfo =
   | { kind: "bootstrapped"; folderName: string; sha: string }
   | { kind: "fetched"; fetched: number; total: number }
-  | { kind: "already-bootstrapped" };
+  | { kind: "already-bootstrapped" }
+  | {
+      kind: "failed";
+      operation: BootstrapOperation;
+      cause: BootstrapFailureCause;
+      /** Raw error detail (already redaction-safe — a message, not a token). */
+      detail: string;
+    };
 
 export interface BootstrapAssetSpaceCommandsDeps {
   /**
@@ -199,11 +226,12 @@ export interface BootstrapAssetSpaceCommandsDeps {
   /** User-facing Notice. */
   notify: (message: string) => void;
   /**
-   * Optional durable, in-context result panel (RFC 0002 §3.3, resolves P5).
-   * Called on the three terminal bootstrap outcomes that have a meaningful
-   * "what next" ({@link BootstrapResultInfo}) IN ADDITION TO `notify` — the
-   * toast still fires; this adds a persistent surface the user can read after it
-   * fades. Optional + best-effort: the plugin wires it to open a
+   * Optional durable, in-context result panel (RFC 0002 §3.3 + §3.10). Called on
+   * the terminal bootstrap outcomes ({@link BootstrapResultInfo}) IN ADDITION TO
+   * `notify` — the toast still fires; this adds a persistent surface the user can
+   * read after it fades. Success outcomes carry a "what next" nudge (§3.3 / P5);
+   * the `failed` outcome carries the classified cause + recovery step (§3.10 /
+   * P15b). Optional + best-effort: the plugin wires it to open a
    * `BootstrapResultModal`; when omitted (or it throws) the command still
    * completes normally.
    */
@@ -290,6 +318,8 @@ export class BootstrapAssetSpaceCommands {
       this.d.validateUrl(urls.exoUrl);
     } catch (e) {
       this.d.notify(`Bootstrap: invalid URL — ${this.msg(e)}`);
+      // Durable failure panel (RFC 0002 §3.10 / P15b) — cause is known (bad URL).
+      this.emitFailure("bootstrap", e, "bad-url");
       return;
     }
 
@@ -324,6 +354,10 @@ export class BootstrapAssetSpaceCommands {
       });
     } catch (e) {
       this.d.notify(`Bootstrap failed: ${this.msg(e)}`);
+      // Durable failure panel (RFC 0002 §3.10 / P15b) — classify the pull failure
+      // (network / PAT / unknown) so the user sees the cause + recovery step,
+      // not just a transient toast.
+      this.emitFailure("bootstrap", e);
     }
     await this.runOnMaterialized();
   }
@@ -344,6 +378,7 @@ export class BootstrapAssetSpaceCommands {
       this.d.validateUrl(res.url);
     } catch (e) {
       this.d.notify(`Add AssetSpace: invalid URL — ${this.msg(e)}`);
+      this.emitFailure("add", e, "bad-url");
       return;
     }
 
@@ -366,6 +401,7 @@ export class BootstrapAssetSpaceCommands {
         `${ASSETSPACES_DIR}/${this.d.deriveFolderName(res.url)}`;
     } catch (e) {
       this.d.notify(`Add AssetSpace: could not derive folder — ${this.msg(e)}`);
+      this.emitFailure("add", e, "bad-url");
       return;
     }
 
@@ -386,6 +422,8 @@ export class BootstrapAssetSpaceCommands {
       );
     } catch (e) {
       this.d.notify(`Add AssetSpace failed: ${this.msg(e)}`);
+      // Durable failure panel (RFC 0002 §3.10 / P15b).
+      this.emitFailure("add", e);
       return;
     }
     await this.runOnMaterialized();
@@ -577,6 +615,27 @@ export class BootstrapAssetSpaceCommands {
   }
 
   /**
+   * Emit a durable FAILURE result (RFC 0002 §3.10, resolves P15b) — classifies
+   * the error (or uses an explicit `causeOverride` when the cause is already
+   * known, e.g. URL validation) and routes it through the same durable panel as
+   * success outcomes, so a pull failure surfaces "what went wrong + how to
+   * recover" persistently rather than only via the transient toast. Best-effort
+   * via {@link emitResult}.
+   */
+  private emitFailure(
+    operation: BootstrapOperation,
+    error: unknown,
+    causeOverride?: BootstrapFailureCause,
+  ): void {
+    this.emitResult({
+      kind: "failed",
+      operation,
+      cause: causeOverride ?? classifyBootstrapFailure(error),
+      detail: this.msg(error),
+    });
+  }
+
+  /**
    * Read the `.gitmodules` (path, url) entries via whichever strategy is wired —
    * the mobile {@link IRestBootstrapMount} (vault.adapter) or the desktop
    * {@link IGitSubmoduleOps} (Node fs). Throws if neither is wired.
@@ -605,4 +664,50 @@ function basename(p: string): string {
   const norm = p.replace(/\/+$/, "");
   const idx = norm.lastIndexOf("/");
   return idx < 0 ? norm : norm.slice(idx + 1);
+}
+
+/**
+ * Classify a Bootstrap / Add failure into a {@link BootstrapFailureCause}
+ * (RFC 0002 §3.10, resolves P15b) for the durable result panel. Pure (string
+ * pattern-match over the error message) so the per-cause routing is
+ * unit-testable in isolation. Order matters — auth (HTTP status) is checked
+ * before the generic patterns so an "HTTP 403" never falls through to
+ * `unknown`.
+ *
+ * The HTTP-status detection mirrors the core `isAuthError` contract
+ * (`GitHub request {METHOD} {url} → HTTP {status}: {body}`): 401, or 403 WITHOUT
+ * rate-limit markers (a 403 + "rate limit"/"abuse detection" is throttling, not
+ * auth). A private-repo 404 from an under-scoped fine-grained PAT is GitHub's
+ * existence-hiding behaviour — for a new tester far more often a token-scope
+ * problem than a typo, so it routes to the auth recovery copy (which also says
+ * "or check the URL").
+ */
+export function classifyBootstrapFailure(
+  error: unknown,
+): BootstrapFailureCause {
+  const msg = error instanceof Error ? error.message : String(error);
+  if (/HTTP 401/.test(msg)) return "auth";
+  if (
+    /HTTP 403/.test(msg) &&
+    !/rate limit/i.test(msg) &&
+    !/abuse detection/i.test(msg)
+  ) {
+    return "auth";
+  }
+  if (/HTTP 404/.test(msg)) return "auth";
+  if (
+    /invalid (github repo )?url|could not derive folder|path-traversal|extra path segments/i.test(
+      msg,
+    )
+  ) {
+    return "bad-url";
+  }
+  if (
+    /network|offline|ENOTFOUND|ECONNREFUSED|ECONNRESET|ETIMEDOUT|EAI_AGAIN|timed ?out|fetch failed|getaddrinfo|request failed|net::/i.test(
+      msg,
+    )
+  ) {
+    return "network";
+  }
+  return "unknown";
 }

--- a/packages/obsidian-plugin/src/infrastructure/adapters/PluginLocalDataStore.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/PluginLocalDataStore.ts
@@ -58,6 +58,7 @@ import type { App } from "obsidian";
  */
 
 const KEY_ACTIVE_PROFILE_UID = "activeProfileUid";
+const KEY_PREVIOUS_PROFILE_UID = "previousProfileUid";
 const KEY_SWITCH_IN_PROGRESS = "_switchInProgress";
 const KEY_ACTIVE_STAGING_DIRS = "_activeStagingDirs";
 const KEY_FILE_ONLY_ASSET_SPACES = "_fileOnlyAssetSpaces";
@@ -82,16 +83,30 @@ export interface LocalSwitchState {
    * slots were retired with the soft RDF filter in Phase 5 T2.
    */
   activeProfileUid: string | null;
+  /**
+   * Undo target — the profile that was active IMMEDIATELY BEFORE the most
+   * recent successful apply (RFC 0002 §3.10, resolves P15). «Undo last profile
+   * apply» re-applies this so a wrong profile choice is one click to revert.
+   * Recorded only when the apply actually switched profile (old ≠ new); `null`
+   * before any switch has ever happened. Device-local like `activeProfileUid`.
+   */
+  previousProfileUid: string | null;
   _switchInProgress: boolean;
 }
 
 /**
  * Input shape for {@link PluginLocalDataStore.save}.
+ *
+ * `previousProfileUid` is OPTIONAL: callers that only touch the active /
+ * in-progress slots omit it, and its persisted value is preserved via
+ * read-modify-write — so adding it is backward compatible with every prior
+ * `save()` call site (none of which pass it). The apply mutation paths pass it
+ * explicitly to record the undo target.
  */
 export type LocalSwitchStateInput = Pick<
   LocalSwitchState,
   "activeProfileUid" | "_switchInProgress"
->;
+> & { previousProfileUid?: string | null };
 
 /**
  * Tracked staging dir entry — registered by {@link StagingDirTracker.allocate}
@@ -125,6 +140,7 @@ export interface FileOnlyAssetSpaceEntry {
 
 const EMPTY_STATE: LocalSwitchState = {
   activeProfileUid: null,
+  previousProfileUid: null,
   _switchInProgress: false,
 };
 
@@ -161,6 +177,17 @@ export class PluginLocalDataStore {
     return this.cache.activeProfileUid;
   }
 
+  /**
+   * Returns the cached undo target — the profile active immediately before the
+   * most recent successful apply (RFC 0002 §3.10), or `null` when no prior
+   * switch has happened. Requires `init()` first. Drives «Undo last profile
+   * apply» availability + execution.
+   */
+  getPreviousProfileUid(): string | null {
+    this.assertInitialized();
+    return this.cache.previousProfileUid;
+  }
+
   /** Returns the cached switch-in-progress flag. Requires `init()` first. */
   isSwitchInProgress(): boolean {
     this.assertInitialized();
@@ -187,6 +214,12 @@ export class PluginLocalDataStore {
     all[KEY_ACTIVE_PROFILE_UID] =
       state.activeProfileUid === null ? null : state.activeProfileUid;
     all[KEY_SWITCH_IN_PROGRESS] = state._switchInProgress;
+    // Optional undo-target slot (RFC 0002 §3.10): write only when the caller
+    // provides it, so existing call sites that omit it keep the persisted value
+    // via the read-modify-write above (backward compatible).
+    if (state.previousProfileUid !== undefined) {
+      all[KEY_PREVIOUS_PROFILE_UID] = state.previousProfileUid;
+    }
     await this.persist(all);
     this.cache = this.deriveStateFromRaw(all);
     this.initialized = true;
@@ -404,6 +437,7 @@ export class PluginLocalDataStore {
       typeof v === "string" ? v : null;
     return {
       activeProfileUid: asStr(all[KEY_ACTIVE_PROFILE_UID]),
+      previousProfileUid: asStr(all[KEY_PREVIOUS_PROFILE_UID]),
       _switchInProgress: all[KEY_SWITCH_IN_PROGRESS] === true,
     };
   }

--- a/packages/obsidian-plugin/src/infrastructure/adapters/ProfileApplyManager.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/ProfileApplyManager.ts
@@ -415,6 +415,21 @@ export class ApplyAbortedByUser extends Error {
   }
 }
 
+/**
+ * Thrown by {@link ProfileApplyManager.undoLastApply} when there is no recorded
+ * previous profile to revert to (RFC 0002 §3.10) — no apply has switched
+ * profile yet on this device. The command-palette handler maps it to a friendly
+ * «nothing to undo» Notice; the command itself is hidden via `checkCallback`
+ * until {@link ProfileApplyManager.getUndoTargetProfileUid} is non-null, so this
+ * is only a defensive guard against a race.
+ */
+export class NoPreviousProfileError extends Error {
+  constructor(message = "No previous profile to undo to") {
+    super(message);
+    this.name = "NoPreviousProfileError";
+  }
+}
+
 export class ProfileApplyManager {
   private readonly app: App;
   private readonly lockMgr: PluginLockManager;
@@ -1046,6 +1061,62 @@ export class ProfileApplyManager {
   }
 
   /**
+   * Compute the undo-target slot to persist after a successful apply
+   * (RFC 0002 §3.10). The pre-apply active profile becomes the new undo target
+   * ONLY when this apply genuinely switched profile (`priorActiveUid` is set and
+   * differs from the target) — a re-apply of the same profile, or the very first
+   * apply (no prior active), leaves the previous undo target untouched. Returns
+   * `undefined` to mean "leave the persisted value as-is" (the store's
+   * read-modify-write preserves it).
+   */
+  private computeUndoTarget(
+    priorActiveUid: string | null,
+    targetProfileUid: string,
+    currentPrevious: string | null | undefined,
+  ): string | null | undefined {
+    if (priorActiveUid !== null && priorActiveUid !== targetProfileUid) {
+      return priorActiveUid;
+    }
+    return currentPrevious;
+  }
+
+  /**
+   * The undo target — the profile active immediately before the most recent
+   * successful apply (RFC 0002 §3.10), or `null` when none is recorded / the
+   * local data store is not wired. Synchronous (reads the in-memory cache) so
+   * the command palette can gate «Undo last profile apply» visibility on it.
+   */
+  getUndoTargetProfileUid(): string | null {
+    return this.localDataStore?.getPreviousProfileUid() ?? null;
+  }
+
+  /**
+   * «Undo last profile apply» (RFC 0002 §3.10, resolves P15). Re-applies the
+   * profile that was active immediately before the most recent apply so a wrong
+   * profile choice is one click to revert.
+   *
+   * Implemented as a normal {@link applyProfile} of the previous profile — a
+   * mount-state strict replace. This is **zero-data-loss by construction**: it
+   * goes through the SAME confirm gate + uncommitted-changes guard + (on the
+   * REST path) mount-before-unmount ordering as any apply, so it never destroys
+   * un-pushed work. It is NOT a filesystem rollback — it re-materialises the
+   * prior effective set and unmounts the rest.
+   *
+   * After the undo completes, the profile being undone FROM becomes the new undo
+   * target (the apply success-save records it), so a second invocation toggles
+   * back — a single-level undo/redo.
+   *
+   * @throws NoPreviousProfileError when no previous profile is recorded.
+   */
+  async undoLastApply(): Promise<void> {
+    const previous = this.getUndoTargetProfileUid();
+    if (previous === null) {
+      throw new NoPreviousProfileError();
+    }
+    await this.applyProfile(previous);
+  }
+
+  /**
    * Post-confirm desktop apply mutation — extracted from {@link applyProfile}
    * so {@link withApplyDeadline} can race the whole critical section against a
    * deadline (Issue #3532). Acquire lock → Phase 1 pull → Phase 2
@@ -1283,10 +1354,19 @@ export class ProfileApplyManager {
       });
 
       // ---- Persist new state + trigger RDF re-index ----
-      // Record the applied profile as the last-applied cache.
+      // Record the applied profile as the last-applied cache, and the profile
+      // active BEFORE this apply as the undo target (RFC 0002 §3.10) — only
+      // when this apply genuinely switched profile (old ≠ new); otherwise keep
+      // the prior undo target untouched.
       const persistState = deps.localDataStore.snapshot();
+      const priorActiveUid = persistState.activeProfileUid;
       await deps.localDataStore.save({
         ...persistState,
+        previousProfileUid: this.computeUndoTarget(
+          priorActiveUid,
+          targetProfileUid,
+          persistState.previousProfileUid,
+        ),
         activeProfileUid: targetProfileUid,
         _switchInProgress: false,
       });
@@ -1684,10 +1764,18 @@ export class ProfileApplyManager {
         });
       }
 
-      // Persist the applied profile as last-applied cache + clear in-progress.
+      // Persist the applied profile as last-applied cache + clear in-progress,
+      // and record the pre-apply profile as the undo target (RFC 0002 §3.10)
+      // when this apply genuinely switched profile (old ≠ new).
       const persistState = localDataStore.snapshot();
+      const priorActiveUid = persistState.activeProfileUid;
       await localDataStore.save({
         ...persistState,
+        previousProfileUid: this.computeUndoTarget(
+          priorActiveUid,
+          targetProfileUid,
+          persistState.previousProfileUid,
+        ),
         activeProfileUid: targetProfileUid,
         _switchInProgress: false,
       });

--- a/packages/obsidian-plugin/src/infrastructure/adapters/ProfileApplyManager.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/ProfileApplyManager.ts
@@ -1019,6 +1019,14 @@ export class ProfileApplyManager {
             targetProfileUid,
             this.noChangeNotice(targetProfileLabel, currentAsUids.size),
           );
+          // LOW #1 — record the undo target even on the no-op path so a switch
+          // between two distinct profiles with an identical effective set still
+          // offers «Undo» (the reindex above only persisted activeProfileUid).
+          await this.recordNoOpUndoTarget(
+            deps.localDataStore,
+            prevActiveProfileUid,
+            targetProfileUid,
+          );
           await this.appendJournal({
             phase: "apply-completed",
             targetUid: targetProfileUid,
@@ -1081,6 +1089,43 @@ export class ProfileApplyManager {
   }
 
   /**
+   * Record the undo target for the no-op (empty-diff) apply branches
+   * (RFC 0002 §3.10 — code-review LOW #1). The MUTATING apply success-saves
+   * record the undo target inline, but the no-op reindex path persists only
+   * `activeProfileUid` (via the settings store), so a switch between two
+   * DISTINCT profiles that happen to share an identical effective AssetSpace set
+   * (→ empty mount diff → no-op) would otherwise leave «Undo» unavailable even
+   * though the active profile IDENTITY changed. This persists
+   * `previousProfileUid = prevActiveProfileUid` when this apply genuinely changed
+   * identity (old ≠ new, old non-null); otherwise leaves the undo target intact.
+   *
+   * Best-effort — must run AFTER the reindex set `activeProfileUid = target` so
+   * the spread preserves it; a failure here only loses the undo offer (never
+   * corrupts state), so it is swallowed.
+   */
+  private async recordNoOpUndoTarget(
+    localDataStore: PluginLocalDataStore,
+    prevActiveProfileUid: string | null,
+    targetProfileUid: string,
+  ): Promise<void> {
+    if (
+      prevActiveProfileUid === null ||
+      prevActiveProfileUid === targetProfileUid
+    ) {
+      return;
+    }
+    try {
+      const snap = localDataStore.snapshot();
+      await localDataStore.save({
+        ...snap,
+        previousProfileUid: prevActiveProfileUid,
+      });
+    } catch {
+      // Undo-offer bookkeeping is additive — never surface as an apply error.
+    }
+  }
+
+  /**
    * The undo target — the profile active immediately before the most recent
    * successful apply (RFC 0002 §3.10), or `null` when none is recorded / the
    * local data store is not wired. Synchronous (reads the in-memory cache) so
@@ -1112,6 +1157,16 @@ export class ProfileApplyManager {
     const previous = this.getUndoTargetProfileUid();
     if (previous === null) {
       throw new NoPreviousProfileError();
+    }
+    // LOW #2 — if the recorded previous profile was deleted from the vault,
+    // applyProfile would resolve an empty effective set and throw a confusing
+    // `TsFloorViolationError`. Pre-resolve so the user gets a clear "the
+    // previous profile no longer exists" message instead.
+    const resolved = await this.resolver.resolve(previous);
+    if (resolved === null) {
+      throw new NoPreviousProfileError(
+        "the profile you'd revert to no longer exists in the vault",
+      );
     }
     await this.applyProfile(previous);
   }
@@ -1614,6 +1669,14 @@ export class ProfileApplyManager {
       await this.reindexMountState(
         targetProfileUid,
         this.noChangeNotice(targetProfileLabel, currentAsUids.size),
+      );
+      // LOW #1 — record the undo target on the no-op path too (desktop parity);
+      // see recordNoOpUndoTarget. A distinct-profile switch with an identical
+      // effective set must still offer «Undo».
+      await this.recordNoOpUndoTarget(
+        localDataStore,
+        prevActiveProfileUid,
+        targetProfileUid,
       );
       return;
     }

--- a/packages/obsidian-plugin/src/infrastructure/adapters/ProfileCommands.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/ProfileCommands.ts
@@ -260,7 +260,9 @@ export class ProfileCommands {
       await this.switchMgr.undoLastApply();
     } catch (e) {
       if (e instanceof NoPreviousProfileError) {
-        this.notify("Nothing to undo — no previous profile recorded.");
+        // Surface the specific reason (e.g. the previous profile was deleted),
+        // not a generic "no previous profile recorded".
+        this.notify(`Nothing to undo — ${e.message}.`);
         return;
       }
       if (e instanceof ApplyAbortedByUser) {

--- a/packages/obsidian-plugin/src/infrastructure/adapters/ProfileCommands.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/ProfileCommands.ts
@@ -29,9 +29,12 @@
  * happens в B.11 plugin entry-point integration.
  */
 
+import { isAuthError } from "exocortex";
+
 import type { ProfileApplyManager } from "./ProfileApplyManager";
 import {
   ApplyAbortedByUser,
+  NoPreviousProfileError,
   TsFloorViolationError,
   UncommittedChangesAbortError,
 } from "./ProfileApplyManager";
@@ -127,6 +130,12 @@ export interface ProfileCommandsDeps {
    * state» (RFC 0a0791c1 Phase 5 T2 — single slot).
    */
   getActiveProfileUid: () => string | null;
+  /**
+   * Returns the undo target — the profile active immediately before the most
+   * recent apply (RFC 0002 §3.10), or null. Used by «Undo last profile apply»
+   * for the pre-flight availability check + the "Reverting to <label>…" notice.
+   */
+  getPreviousProfileUid: () => string | null;
   /** Show a user-facing Notice. */
   notify: (message: string) => void;
 }
@@ -139,6 +148,7 @@ export class ProfileCommands {
   private readonly fuzzyPick: ProfileCommandsDeps["fuzzyPick"];
   private readonly getActiveFilePath: () => string | null;
   private readonly getActiveProfileUid: () => string | null;
+  private readonly getPreviousProfileUid: () => string | null;
   private readonly notify: (message: string) => void;
 
   constructor(deps: ProfileCommandsDeps) {
@@ -149,6 +159,7 @@ export class ProfileCommands {
     this.fuzzyPick = deps.fuzzyPick;
     this.getActiveFilePath = deps.getActiveFilePath;
     this.getActiveProfileUid = deps.getActiveProfileUid;
+    this.getPreviousProfileUid = deps.getPreviousProfileUid;
     this.notify = deps.notify;
   }
 
@@ -215,6 +226,60 @@ export class ProfileCommands {
         return;
       }
       this.notify(`Apply profile failed: ${this.safeMessage(e)}`);
+    }
+  }
+
+  /**
+   * Command — `Exocortex: Undo last profile apply` (RFC 0002 §3.10, resolves
+   * P15). Reverts to the profile active immediately before the most recent
+   * apply, so a wrong profile choice is one click to undo without re-finding it
+   * in the picker.
+   *
+   * Delegates to {@link ProfileApplyManager.undoLastApply}, which re-applies the
+   * previous profile through the SAME confirm gate + uncommitted-changes guard +
+   * mount-before-unmount path as any apply (zero data loss — it never destroys
+   * un-pushed work). When nothing is recorded yet, surfaces a friendly notice
+   * (the command is also hidden by `checkCallback` until an undo target exists,
+   * so this is a defensive fallback).
+   *
+   * Error mapping mirrors {@link invokeApplyProfile} — cancel / TS-floor /
+   * uncommitted aborts get distinct notices.
+   */
+  async invokeUndoLastApply(): Promise<void> {
+    const previous = this.getPreviousProfileUid();
+    if (previous === null) {
+      this.notify(
+        "Nothing to undo — no previous profile recorded yet. Apply a different profile first; this then reverts to the one you had.",
+      );
+      return;
+    }
+
+    const label = await this.resolveLabel(previous, this.profileLister);
+    this.notify(`Reverting to ${label}…`);
+    try {
+      await this.switchMgr.undoLastApply();
+    } catch (e) {
+      if (e instanceof NoPreviousProfileError) {
+        this.notify("Nothing to undo — no previous profile recorded.");
+        return;
+      }
+      if (e instanceof ApplyAbortedByUser) {
+        this.notify("Undo cancelled.");
+        return;
+      }
+      if (e instanceof TsFloorViolationError) {
+        this.notify(`Undo refused — ${e.message}`);
+        return;
+      }
+      if (e instanceof UncommittedChangesAbortError) {
+        const total = e.affectedFiles.reduce((s, a) => s + a.files.length, 0);
+        this.notify(
+          `Undo aborted — ${total} uncommitted file(s) in ${e.affectedFiles.length} AssetSpace(s) reverting would remove. ` +
+            `Commit (or stash) the vault first, then undo again. See docs/profile.md.`,
+        );
+        return;
+      }
+      this.notify(`Undo failed: ${this.safeMessage(e)}`);
     }
   }
 
@@ -288,8 +353,30 @@ export class ProfileCommands {
       }
       this.notify(`Pushed \`${folderName}\` → ${sha.slice(0, 7)}`);
     } catch (e) {
-      this.notify(`Push failed: ${this.safeMessage(e)}`);
+      this.notify(this.mapPushError(e, folderName));
     }
+  }
+
+  /**
+   * RFC 0002 §3.10 (resolves P15c) — explain a PAT push that 403/401s even
+   * though «Test connection» passed. «Test connection» only proves the token can
+   * READ (list repos / metadata); a push writes repository Contents, so a token
+   * without **Contents: Read and write** — or an expired one — passes the test
+   * but 403s on push. Surface that gap + the recovery step instead of the opaque
+   * raw HTTP error. Non-auth failures (network, 422 non-fast-forward, …) keep the
+   * generic message.
+   */
+  private mapPushError(e: unknown, folderName: string): string {
+    if (isAuthError(e)) {
+      return (
+        `Push failed — GitHub rejected the token (403/401) for \`${folderName}\`. ` +
+        `«Test connection» only checks READ access; pushing needs a fine-grained token with ` +
+        `Contents: Read and write on this repo, and it must not be expired. ` +
+        `Open Settings → GitHub PAT, create/re-scope the token (Contents: Read and write), ` +
+        `save it, then push again. (${this.safeMessage(e)})`
+      );
+    }
+    return `Push failed: ${this.safeMessage(e)}`;
   }
 
   // === Helpers ===

--- a/packages/obsidian-plugin/src/presentation/modals/BootstrapResultModal.ts
+++ b/packages/obsidian-plugin/src/presentation/modals/BootstrapResultModal.ts
@@ -1,48 +1,58 @@
 import { App, Modal } from "obsidian";
-import type { BootstrapResultInfo } from "../../infrastructure/adapters/BootstrapAssetSpaceCommands";
+import type {
+  BootstrapResultInfo,
+  BootstrapFailureCause,
+  BootstrapOperation,
+} from "../../infrastructure/adapters/BootstrapAssetSpaceCommands";
 
 /**
  * Action callbacks for the durable bootstrap-result panel. The panel owns no
- * business logic — its single forward action fires the injected callback, which
- * the plugin wires to the Add-AssetSpace flow pre-filled with the starter
- * registry (RFC 0002 §3.3 next-step nudge → §3.1 step 2).
+ * business logic — its forward actions fire the injected callbacks, which the
+ * plugin wires to the Add-AssetSpace flow (success nudge) and to re-running the
+ * failed operation (failure recovery).
  */
 export interface BootstrapResultModalActions {
   /**
-   * Next-step nudge — open «Add AssetSpace by URL» pre-filled with the public
-   * starter-registry URL so the user can pull the starter content right away.
-   * The user still reviews + confirms in that modal.
+   * Next-step nudge (success outcomes, §3.3) — open «Add AssetSpace by URL»
+   * pre-filled with the public starter-registry URL so the user can pull the
+   * starter content right away. The user still reviews + confirms in that modal.
    */
   onAddStarterContent: () => void;
+  /**
+   * Failure recovery (§3.10) — re-run the operation that failed (bootstrap OR
+   * add-AssetSpace), so a wrong URL / dropped network / mis-scoped token is one
+   * click to retry after the user fixes it. Optional — when absent the failure
+   * panel shows the cause + recovery text without a retry button.
+   */
+  onRetry?: (operation: BootstrapOperation) => void;
 }
 
 /**
  * BootstrapResultModal — the **durable, in-context** bootstrap result panel
- * (RFC 0002 §3.3, resolves P5).
+ * (RFC 0002 §3.3 + §3.10).
  *
  * The bootstrap flow already fires an unconditional toast (`notifier.info` →
  * `new Notice`) plus an always-on activity-log entry, so feedback is NOT
- * missing. The residual UX gap (P5, rev-2-corrected) is that the toast is
- * **transient (~4-5 s)** and easy to miss mid-action, and the activity log is a
- * surface a first-run user won't think to open. This panel adds **durability**:
- * a persistent result the user can read after the toast fades, stating what
- * happened **and what to do next** — so the action dead-ends nowhere.
+ * missing. The residual UX gap is that the toast is **transient (~4-5 s)** and
+ * easy to miss mid-action, and the activity log is a surface a first-run user
+ * won't think to open. This panel adds **durability**: a persistent result the
+ * user can read after the toast fades, stating what happened **and what to do
+ * next** — so the action dead-ends nowhere.
  *
- * It fires on the three terminal bootstrap outcomes that have a meaningful
- * "what next" (driven by {@link BootstrapResultInfo}):
- *   - `bootstrapped` — a cold bootstrap materialised the engine floor.
+ * Fires on the terminal bootstrap outcomes (driven by {@link BootstrapResultInfo}):
+ *   - `bootstrapped` — a cold bootstrap materialised the engine floor (§3.3).
  *   - `fetched` — the EC2 clone-needs-fetch path restored tracked AssetSpaces.
  *   - `already-bootstrapped` — the guard fired on an already-set-up vault.
- *
- * It deliberately does NOT fire on hard failures / cancels — those are surfaced
- * by the toast, and a "next step" nudge would be wrong there (error-recovery is
- * P15, a separate scope).
+ *   - `failed` — a Bootstrap / Add operation failed (§3.10, resolves P15): the
+ *     panel surfaces the **classified cause** (bad URL / network / PAT) + a
+ *     **recovery step**, with a one-click "Try again" of the failed operation,
+ *     instead of a toast that fades before the user can act on it.
  *
  * ## Accessibility (P16, §3.11)
  * - Native `<button>`s (keyboard-navigable, Enter/Space activation) with explicit
  *   `aria-label`s.
- * - Managed focus: the forward action (the most likely next move) is focused on
- *   open, guarded for jsdom / headless contexts.
+ * - Managed focus: the most likely next move (the forward action, else Done) is
+ *   focused on open, guarded for jsdom / headless contexts.
  * - No icon/emoji-only signalling — every cue is plain text.
  */
 export class BootstrapResultModal extends Modal {
@@ -63,6 +73,8 @@ export class BootstrapResultModal extends Modal {
   override onOpen(): void {
     const { contentEl } = this;
     contentEl.addClass("bootstrap-result");
+    const isFailure = this.result.kind === "failed";
+    if (isFailure) contentEl.addClass("bootstrap-result-failed");
 
     const copy = resultCopy(this.result);
 
@@ -77,7 +89,7 @@ export class BootstrapResultModal extends Modal {
       text: copy.summary,
     });
 
-    // The "what to do next" nudge + a one-click forward action.
+    // The "what to do next" / recovery-step nudge.
     contentEl.createEl("p", {
       cls: "bootstrap-result-next",
       text: copy.nextHint,
@@ -87,31 +99,59 @@ export class BootstrapResultModal extends Modal {
       cls: "modal-button-container bootstrap-result-actions",
     });
 
-    const nextBtn = actions.createEl("button", {
-      cls: "mod-cta bootstrap-result-next-action",
-      text: "Add the starter content",
-    });
-    nextBtn.setAttribute(
-      "aria-label",
-      "Add the starter content (opens a dialog pre-filled with the recommended starter registry)",
-    );
-    nextBtn.addEventListener("click", () => {
-      // Close the panel first, then hand off — the Add-AssetSpace modal stacks
-      // cleanly on its own rather than under a now-stale result panel.
-      this.close();
-      this.actions.onAddStarterContent();
-    });
-    this.firstFocusable = nextBtn;
+    if (this.result.kind === "failed") {
+      // Failure recovery (§3.10) — one-click retry of the failed operation.
+      if (this.actions.onRetry !== undefined) {
+        const operation = this.result.operation;
+        const onRetry = this.actions.onRetry;
+        const retryBtn = actions.createEl("button", {
+          cls: "mod-cta bootstrap-result-retry-action",
+          text: "Try again",
+        });
+        retryBtn.setAttribute(
+          "aria-label",
+          operation === "bootstrap"
+            ? "Try setting up the engine again"
+            : "Try adding the knowledge pack again",
+        );
+        retryBtn.addEventListener("click", () => {
+          // Close first, then re-run — the operation's own modal stacks cleanly
+          // rather than under a now-stale result panel.
+          this.close();
+          onRetry(operation);
+        });
+        this.firstFocusable = retryBtn;
+      }
+    } else {
+      // Success (§3.3) — the next-step nudge + one-click forward action.
+      const nextBtn = actions.createEl("button", {
+        cls: "mod-cta bootstrap-result-next-action",
+        text: "Add the starter content",
+      });
+      nextBtn.setAttribute(
+        "aria-label",
+        "Add the starter content (opens a dialog pre-filled with the recommended starter registry)",
+      );
+      nextBtn.addEventListener("click", () => {
+        this.close();
+        this.actions.onAddStarterContent();
+      });
+      this.firstFocusable = nextBtn;
+    }
 
     const doneBtn = actions.createEl("button", {
       cls: "bootstrap-result-done",
-      text: "Done",
+      text: isFailure ? "Dismiss" : "Done",
     });
-    doneBtn.setAttribute("aria-label", "Close the setup result");
+    doneBtn.setAttribute(
+      "aria-label",
+      isFailure ? "Dismiss the setup error" : "Close the setup result",
+    );
     doneBtn.addEventListener("click", () => this.close());
 
-    // Managed focus (P16) — land on the forward action. Guarded: jsdom /
-    // headless contexts may lack focus support.
+    // Managed focus (P16) — land on the forward action, or Done when there is
+    // no forward action (e.g. a failure panel with no retry wired).
+    if (this.firstFocusable === null) this.firstFocusable = doneBtn;
     try {
       this.firstFocusable?.focus();
     } catch {
@@ -165,6 +205,61 @@ export function resultCopy(result: BootstrapResultInfo): ResultCopy {
         nextHint:
           "Next: add the starter content, or use «Add AssetSpace by URL» to " +
           "pull another AssetSpace.",
+      };
+    case "failed":
+      return failureCopy(result.operation, result.cause, result.detail);
+  }
+}
+
+/**
+ * Durable failure copy (RFC 0002 §3.10, resolves P15b) — title + cause summary +
+ * recovery step, per classified {@link BootstrapFailureCause}. Pure so the
+ * per-cause recovery wording is unit-testable.
+ */
+function failureCopy(
+  operation: BootstrapOperation,
+  cause: BootstrapFailureCause,
+  detail: string,
+): ResultCopy {
+  const what =
+    operation === "bootstrap" ? "Set up the engine" : "Add a knowledge pack";
+  const title = `${what} didn't finish`;
+  switch (cause) {
+    case "bad-url":
+      return {
+        title,
+        summary: `The repository URL was rejected: ${detail}`,
+        nextHint:
+          "Next: check the URL — it should look like " +
+          "https://github.com/<owner>/exoas-<name> — then try again.",
+      };
+    case "network":
+      return {
+        title,
+        summary: `Couldn't reach GitHub — ${detail}`,
+        nextHint:
+          "Next: check your internet connection (and any VPN / proxy / firewall), " +
+          "then try again.",
+      };
+    case "auth":
+      return {
+        title,
+        summary:
+          "GitHub rejected the request — the token is missing, expired, or lacks " +
+          `access to this repository. (${detail})`,
+        nextHint:
+          "Next: open Settings → GitHub PAT, create a fine-grained token with " +
+          "Contents: Read-only (or Read and write, to also push) scoped to this " +
+          "repo, save it, then try again. If the repository is public, double-check " +
+          "the URL instead.",
+      };
+    case "unknown":
+      return {
+        title,
+        summary: `The operation failed — ${detail}`,
+        nextHint:
+          "Next: open «Open logs» from the command palette for the full error, " +
+          "then try again.",
       };
   }
 }

--- a/packages/obsidian-plugin/tests/unit/PluginLocalDataStore.test.ts
+++ b/packages/obsidian-plugin/tests/unit/PluginLocalDataStore.test.ts
@@ -305,3 +305,81 @@ describe("PluginLocalDataStore — first-run onboarding flag (RFC 0002 §3.1)", 
     expect(await store.getOnboardingCompleted()).toBe(true);
   });
 });
+
+describe("PluginLocalDataStore — previousProfileUid (undo target, §3.10)", () => {
+  it("init() with absent file → null undo target", async () => {
+    const { app } = makeFakeApp();
+    const store = new PluginLocalDataStore({ app });
+    await store.init();
+    expect(store.getPreviousProfileUid()).toBeNull();
+  });
+
+  it("reads previousProfileUid from data.local.json", async () => {
+    const { app } = makeFakeApp({
+      [PATH]: JSON.stringify({
+        activeProfileUid: "p-active",
+        previousProfileUid: "p-prev",
+      }),
+    });
+    const store = new PluginLocalDataStore({ app });
+    await store.init();
+    expect(store.getActiveProfileUid()).toBe("p-active");
+    expect(store.getPreviousProfileUid()).toBe("p-prev");
+  });
+
+  it("save() persists previousProfileUid when provided", async () => {
+    const { app, files } = makeFakeApp();
+    const store = new PluginLocalDataStore({ app });
+    await store.init();
+    await store.save({
+      activeProfileUid: "p-active",
+      previousProfileUid: "p-prev",
+      _switchInProgress: false,
+    });
+    expect(store.getPreviousProfileUid()).toBe("p-prev");
+    const parsed = JSON.parse(files.get(PATH) ?? "{}");
+    expect(parsed.previousProfileUid).toBe("p-prev");
+  });
+
+  it("save() WITHOUT previousProfileUid preserves the persisted value (RMW)", async () => {
+    const { app, files } = makeFakeApp({
+      [PATH]: JSON.stringify({
+        activeProfileUid: "p-old",
+        previousProfileUid: "p-prev",
+        pat: "ghp_keep",
+      }),
+    });
+    const store = new PluginLocalDataStore({ app });
+    await store.init();
+    // Legacy-shaped save (active + in-progress only) must NOT clobber the undo
+    // target — backward compatibility for every prior call site.
+    await store.save({ activeProfileUid: "p-new", _switchInProgress: false });
+    expect(store.getActiveProfileUid()).toBe("p-new");
+    expect(store.getPreviousProfileUid()).toBe("p-prev");
+    const parsed = JSON.parse(files.get(PATH) ?? "{}");
+    expect(parsed.previousProfileUid).toBe("p-prev");
+    expect(parsed.pat).toBe("ghp_keep");
+  });
+
+  it("save() can clear the undo target with explicit null", async () => {
+    const { app } = makeFakeApp({
+      [PATH]: JSON.stringify({ previousProfileUid: "p-prev" }),
+    });
+    const store = new PluginLocalDataStore({ app });
+    await store.init();
+    await store.save({
+      activeProfileUid: "p-x",
+      previousProfileUid: null,
+      _switchInProgress: false,
+    });
+    expect(store.getPreviousProfileUid()).toBeNull();
+  });
+
+  it("getPreviousProfileUid throws before init()", () => {
+    const { app } = makeFakeApp();
+    const store = new PluginLocalDataStore({ app });
+    expect(() => store.getPreviousProfileUid()).toThrow(
+      /init\(\) must be awaited/,
+    );
+  });
+});

--- a/packages/obsidian-plugin/tests/unit/ProfileApplyManager.undo.test.ts
+++ b/packages/obsidian-plugin/tests/unit/ProfileApplyManager.undo.test.ts
@@ -1,0 +1,306 @@
+/**
+ * ProfileApplyManager — «Undo last profile apply» (RFC 0002 §3.10, resolves
+ * P15a).
+ *
+ * Exercises the REAL {@link PluginLocalDataStore} (in-memory vault.adapter) so
+ * the `previousProfileUid` undo-target slot is persisted + read exactly as in
+ * production, and a `FakeRestMount` that MUTATES the in-memory mount-state
+ * (fsFolders) so sequential applies compute realistic mount diffs. This mirrors
+ * the production REST apply path end-to-end:
+ *
+ *   - apply A from empty → records active=A, previous=null (no prior switch)
+ *   - apply B from A      → records active=B, previous=A
+ *   - undoLastApply()     → re-applies A → active=A, previous=B (toggle)
+ *   - undoLastApply() with no recorded previous → NoPreviousProfileError
+ *   - re-apply same profile → previous untouched
+ *
+ * Revert-verify: the toggle test fails if the success-save stops recording the
+ * pre-apply profile as the undo target (see "revert-verify" annotation).
+ */
+import type { App, TFile } from "obsidian";
+import type { ApplyPlan, IConfirmGate } from "exocortex";
+
+import {
+  ProfileApplyManager,
+  NoPreviousProfileError,
+  type IProfileResolver,
+  type IRdfIndexer,
+  type ProfileResolution,
+} from "../../src/infrastructure/adapters/ProfileApplyManager";
+import { PluginLockManager } from "../../src/infrastructure/adapters/PluginLockManager";
+import { PluginLocalDataStore } from "../../src/infrastructure/adapters/PluginLocalDataStore";
+import { PluginSettingsStoreAdapter } from "../../src/infrastructure/adapters/PluginSettingsStoreAdapter";
+import { TS_FLOOR_AS_UID_EXO } from "../../src/infrastructure/adapters/ProfileOnloadWiring";
+
+// ─── Fakes ────────────────────────────────────────────────────────────────
+
+interface FakeFile {
+  path: string;
+  basename: string;
+  frontmatter: Record<string, unknown>;
+}
+
+function makeFakeApp(
+  files: FakeFile[],
+  fsFolders: Map<string, { files: string[]; folders: string[] }>,
+): App {
+  const fsFiles = new Map<string, string>();
+  const tfiles: TFile[] = files.map(
+    (f) => ({ path: f.path, basename: f.basename }) as unknown as TFile,
+  );
+  const frontmatterByPath = new Map<string, Record<string, unknown>>();
+  for (const f of files) frontmatterByPath.set(f.path, f.frontmatter);
+
+  return {
+    vault: {
+      configDir: ".obsidian",
+      getMarkdownFiles: () => tfiles,
+      adapter: {
+        exists: async (p: string) => fsFiles.has(p) || fsFolders.has(p),
+        read: async (p: string) => {
+          const v = fsFiles.get(p);
+          if (v === undefined) throw new Error(`ENOENT: ${p}`);
+          return v;
+        },
+        write: async (p: string, d: string) => {
+          fsFiles.set(p, d);
+        },
+        // Lock release (PluginLockManager.deleteLock) + any folder teardown go
+        // through `remove`; without it the lock file persists and a second
+        // sequential apply in the same test would fail to acquire.
+        remove: async (p: string) => {
+          fsFiles.delete(p);
+          fsFolders.delete(p);
+        },
+        list: async (dir: string) =>
+          fsFolders.get(dir) ?? { files: [], folders: [] },
+      },
+    },
+    metadataCache: {
+      getFileCache: (file: TFile) => {
+        const fm = frontmatterByPath.get(file.path);
+        return fm ? { frontmatter: fm } : null;
+      },
+    },
+  } as unknown as App;
+}
+
+class FakeResolver implements IProfileResolver {
+  constructor(private readonly profiles: Map<string, ProfileResolution>) {}
+  async resolve(uid: string): Promise<ProfileResolution | null> {
+    return this.profiles.get(uid) ?? null;
+  }
+  async discoverSharedOntologies(): Promise<string[]> {
+    return [];
+  }
+}
+
+class FakeIndexer implements IRdfIndexer {
+  refreshCalls = 0;
+  async refresh(): Promise<void> {
+    this.refreshCalls++;
+  }
+}
+
+class FakeConfirmGate implements IConfirmGate {
+  approve = true;
+  plans: ApplyPlan[] = [];
+  async confirmApply(plan: ApplyPlan): Promise<boolean> {
+    this.plans.push(plan);
+    return this.approve;
+  }
+}
+
+/** REST mount that MUTATES the shared fsFolders so mount-state diffs are real. */
+class FakeRestMount {
+  mounted: string[] = [];
+  unmounted: string[] = [];
+  constructor(
+    private readonly fsFolders: Map<
+      string,
+      { files: string[]; folders: string[] }
+    >,
+  ) {}
+  async mount(_gitUrl: string, submodulePath: string, _ref: string) {
+    this.mounted.push(submodulePath);
+    this.fsFolders.set(submodulePath, {
+      files: [`${submodulePath}/f.md`],
+      folders: [],
+    });
+    return { sha: "abc1234", fileCount: 1 };
+  }
+  async unmount(submodulePath: string): Promise<void> {
+    this.unmounted.push(submodulePath);
+    this.fsFolders.delete(submodulePath);
+  }
+}
+
+// ─── AssetSpace descriptors ─────────────────────────────────────────────────
+
+const EXO = {
+  uid: TS_FLOOR_AS_UID_EXO,
+  folder: "assetspaces/kitelev/exoas-exo",
+  ns: "exo",
+};
+const EMS = {
+  uid: "ems-uid",
+  folder: "assetspaces/kitelev/exoas-ems",
+  ns: "ems",
+};
+const KPC = {
+  uid: "kpc-uid",
+  folder: "assetspaces/kitelev/exoas-kpc",
+  ns: "kpc",
+};
+const ALL_AS = [EXO, EMS, KPC];
+
+async function setup() {
+  const files: FakeFile[] = [
+    {
+      path: "profiles/A.md",
+      basename: "A",
+      frontmatter: {
+        exo__Asset_uid: "A",
+        exo__Asset_label: "Profile A",
+        exo__Instance_class: ["[[exo__Profile]]"],
+      },
+    },
+    {
+      path: "profiles/B.md",
+      basename: "B",
+      frontmatter: {
+        exo__Asset_uid: "B",
+        exo__Asset_label: "Profile B",
+        exo__Instance_class: ["[[exo__Profile]]"],
+      },
+    },
+    ...ALL_AS.map((as) => ({
+      path: `${as.folder}/${as.uid}.md`,
+      basename: as.uid,
+      frontmatter: {
+        exo__Asset_uid: as.uid,
+        exo__Asset_label: as.ns,
+        exo__Instance_class: ["[[exo__AssetSpace]]"],
+        exo__AssetSpace_source: `https://github.com/${as.folder.replace("assetspaces/", "")}`,
+        exo__AssetSpace_namespace: as.ns,
+      },
+    })),
+  ];
+
+  // Initial mount-state: only the floor (exo) is materialised.
+  const fsFolders = new Map<string, { files: string[]; folders: string[] }>();
+  fsFolders.set(EXO.folder, { files: [`${EXO.folder}/x.md`], folders: [] });
+
+  const app = makeFakeApp(files, fsFolders);
+
+  const resolver = new FakeResolver(
+    new Map<string, ProfileResolution>([
+      ["A", { uid: "A", includes: [EXO.uid, EMS.uid], label: "Profile A" }],
+      ["B", { uid: "B", includes: [EXO.uid, KPC.uid], label: "Profile B" }],
+    ]),
+  );
+
+  const localDataStore = new PluginLocalDataStore({
+    app,
+    path: ".obsidian/plugins/exocortex/data.local.json",
+  });
+  await localDataStore.init();
+  const settingsStore = new PluginSettingsStoreAdapter(localDataStore);
+  const indexer = new FakeIndexer();
+  const confirmGate = new FakeConfirmGate();
+  const restMount = new FakeRestMount(fsFolders);
+  const lockMgr = new PluginLockManager({ app });
+
+  const mgr = new ProfileApplyManager({
+    app,
+    lockMgr,
+    resolver,
+    rdfIndexer: indexer,
+    settingsStore,
+    confirmGate,
+    /* eslint-disable @typescript-eslint/no-explicit-any */
+    localDataStore: localDataStore as any,
+    restMount: restMount as any,
+    /* eslint-enable @typescript-eslint/no-explicit-any */
+    notify: () => undefined,
+  });
+
+  return { mgr, localDataStore, restMount, confirmGate, indexer };
+}
+
+// ─── Tests ──────────────────────────────────────────────────────────────────
+
+describe("ProfileApplyManager — undo target recording", () => {
+  it("first apply (from empty) records no undo target", async () => {
+    const { mgr, localDataStore } = await setup();
+    await mgr.applyProfile("A");
+    expect(localDataStore.getActiveProfileUid()).toBe("A");
+    expect(localDataStore.getPreviousProfileUid()).toBeNull();
+    expect(mgr.getUndoTargetProfileUid()).toBeNull();
+  });
+
+  it("second apply records the previously-active profile as the undo target", async () => {
+    const { mgr, localDataStore } = await setup();
+    await mgr.applyProfile("A");
+    await mgr.applyProfile("B");
+    expect(localDataStore.getActiveProfileUid()).toBe("B");
+    expect(localDataStore.getPreviousProfileUid()).toBe("A");
+    expect(mgr.getUndoTargetProfileUid()).toBe("A");
+  });
+
+  it("re-applying the SAME profile leaves the undo target untouched", async () => {
+    const { mgr, localDataStore } = await setup();
+    await mgr.applyProfile("A");
+    await mgr.applyProfile("B"); // previous = A
+    await mgr.applyProfile("B"); // no-op-ish re-apply; previous must stay A
+    expect(localDataStore.getActiveProfileUid()).toBe("B");
+    expect(localDataStore.getPreviousProfileUid()).toBe("A");
+  });
+});
+
+describe("ProfileApplyManager.undoLastApply", () => {
+  it("re-applies the previous profile and toggles the undo target", async () => {
+    const { mgr, localDataStore, restMount } = await setup();
+    await mgr.applyProfile("A"); // mount ems
+    await mgr.applyProfile("B"); // unmount ems, mount kpc; previous=A
+    restMount.mounted.length = 0;
+    restMount.unmounted.length = 0;
+
+    await mgr.undoLastApply(); // back to A
+
+    // Re-applied A → ems mounted, kpc unmounted (mount-state strict replace).
+    expect(restMount.mounted).toContain(EMS.folder);
+    expect(restMount.unmounted).toContain(KPC.folder);
+    expect(localDataStore.getActiveProfileUid()).toBe("A");
+    // revert-verify: the toggle (previous becomes the profile we undid FROM)
+    // only holds because the apply success-save records the pre-apply profile
+    // as the undo target. If that recording is removed, previous stays "A" and
+    // this assertion fails.
+    expect(localDataStore.getPreviousProfileUid()).toBe("B");
+  });
+
+  it("a second undo toggles back (single-level undo/redo)", async () => {
+    const { mgr, localDataStore } = await setup();
+    await mgr.applyProfile("A");
+    await mgr.applyProfile("B"); // previous=A
+    await mgr.undoLastApply(); // active=A, previous=B
+    await mgr.undoLastApply(); // active=B, previous=A
+    expect(localDataStore.getActiveProfileUid()).toBe("B");
+    expect(localDataStore.getPreviousProfileUid()).toBe("A");
+  });
+
+  it("throws NoPreviousProfileError when nothing has been switched yet", async () => {
+    const { mgr } = await setup();
+    await expect(mgr.undoLastApply()).rejects.toBeInstanceOf(
+      NoPreviousProfileError,
+    );
+  });
+
+  it("getUndoTargetProfileUid returns null before any switch, the prior profile after", async () => {
+    const { mgr } = await setup();
+    expect(mgr.getUndoTargetProfileUid()).toBeNull();
+    await mgr.applyProfile("A");
+    await mgr.applyProfile("B");
+    expect(mgr.getUndoTargetProfileUid()).toBe("A");
+  });
+});

--- a/packages/obsidian-plugin/tests/unit/ProfileApplyManager.undo.test.ts
+++ b/packages/obsidian-plugin/tests/unit/ProfileApplyManager.undo.test.ts
@@ -197,6 +197,8 @@ async function setup() {
     new Map<string, ProfileResolution>([
       ["A", { uid: "A", includes: [EXO.uid, EMS.uid], label: "Profile A" }],
       ["B", { uid: "B", includes: [EXO.uid, KPC.uid], label: "Profile B" }],
+      // Profile C — DISTINCT identity, IDENTICAL effective set to A (LOW #1).
+      ["C", { uid: "C", includes: [EXO.uid, EMS.uid], label: "Profile C" }],
     ]),
   );
 
@@ -291,6 +293,39 @@ describe("ProfileApplyManager.undoLastApply", () => {
 
   it("throws NoPreviousProfileError when nothing has been switched yet", async () => {
     const { mgr } = await setup();
+    await expect(mgr.undoLastApply()).rejects.toBeInstanceOf(
+      NoPreviousProfileError,
+    );
+  });
+
+  // LOW #1 (code-review) — a switch between two DISTINCT profiles that share an
+  // identical effective set takes the no-op reindex path; the undo target must
+  // still be recorded so «Undo» is offered.
+  it("records the undo target on the no-op path (distinct profiles, identical effective set)", async () => {
+    const { mgr, localDataStore, restMount } = await setup();
+    await mgr.applyProfile("A"); // mounts ems → mount-state {exo, ems}
+    restMount.mounted.length = 0;
+    restMount.unmounted.length = 0;
+    // C declares the SAME effective set as A → empty mount diff → no-op branch.
+    await mgr.applyProfile("C");
+    expect(restMount.mounted).toEqual([]);
+    expect(restMount.unmounted).toEqual([]);
+    expect(localDataStore.getActiveProfileUid()).toBe("C");
+    // The identity changed A→C even though nothing was (un)mounted — undo offered.
+    expect(localDataStore.getPreviousProfileUid()).toBe("A");
+    expect(mgr.getUndoTargetProfileUid()).toBe("A");
+  });
+
+  // LOW #2 (code-review) — undo to a profile that was since deleted from the
+  // vault throws NoPreviousProfileError (clear message) rather than a confusing
+  // TsFloorViolationError from an empty effective set.
+  it("throws NoPreviousProfileError (not TS-floor) when the previous profile was deleted", async () => {
+    const { mgr, localDataStore } = await setup();
+    await mgr.applyProfile("A");
+    await mgr.applyProfile("B"); // previous = A
+    // Simulate A being deleted: point the undo target at an unresolvable UID.
+    const snap = localDataStore.snapshot();
+    await localDataStore.save({ ...snap, previousProfileUid: "ghost-deleted" });
     await expect(mgr.undoLastApply()).rejects.toBeInstanceOf(
       NoPreviousProfileError,
     );

--- a/packages/obsidian-plugin/tests/unit/ProfileCommands.test.ts
+++ b/packages/obsidian-plugin/tests/unit/ProfileCommands.test.ts
@@ -8,6 +8,7 @@ import {
 import {
   type ProfileApplyManager,
   ApplyAbortedByUser,
+  NoPreviousProfileError,
   TsFloorViolationError,
   UncommittedChangesAbortError,
 } from "../../src/infrastructure/adapters/ProfileApplyManager";
@@ -382,6 +383,22 @@ describe("ProfileCommands.invokeUndoLastApply", () => {
     h.switchMgr.undoThrows = new Error("boom");
     await h.cmd.invokeUndoLastApply();
     expect(h.notices.some((n) => /Undo failed: boom/.test(n))).toBe(true);
+  });
+
+  it("deleted previous profile (NoPreviousProfileError) → surfaces the specific reason", async () => {
+    const h = makeHarness({
+      profiles: [{ uid: "prof-prev", label: "Personal" }],
+      previousProfileUid: "prof-prev",
+    });
+    // LOW #2 — undoLastApply pre-resolves and throws with a deleted-profile
+    // message; the command surfaces it instead of a generic "not recorded".
+    h.switchMgr.undoThrows = new NoPreviousProfileError(
+      "the profile you'd revert to no longer exists in the vault",
+    );
+    await h.cmd.invokeUndoLastApply();
+    expect(
+      h.notices.some((n) => /Nothing to undo — the profile you'd revert to no longer exists/.test(n)),
+    ).toBe(true);
   });
 });
 

--- a/packages/obsidian-plugin/tests/unit/ProfileCommands.test.ts
+++ b/packages/obsidian-plugin/tests/unit/ProfileCommands.test.ts
@@ -16,13 +16,24 @@ import {
 
 class FakeSwitchMgr {
   applyCalls: string[] = [];
+  undoCalls = 0;
   /** Error to throw from the next applyProfile call (then cleared). */
   applyThrows: Error | null = null;
+  /** Error to throw from the next undoLastApply call (then cleared). */
+  undoThrows: Error | null = null;
   async applyProfile(uid: string): Promise<void> {
     this.applyCalls.push(uid);
     if (this.applyThrows) {
       const e = this.applyThrows;
       this.applyThrows = null;
+      throw e;
+    }
+  }
+  async undoLastApply(): Promise<void> {
+    this.undoCalls++;
+    if (this.undoThrows) {
+      const e = this.undoThrows;
+      this.undoThrows = null;
       throw e;
     }
   }
@@ -65,6 +76,7 @@ function makeHarness(opts: {
   asLookups?: Array<[string, string]>;
   listError?: Error;
   activeProfileUid?: string | null;
+  previousProfileUid?: string | null;
 }): Harness {
   const switchMgr = new FakeSwitchMgr();
   const pushMgr = new FakePushMgr();
@@ -91,6 +103,7 @@ function makeHarness(opts: {
     },
     getActiveFilePath: () => opts.activeFilePath ?? null,
     getActiveProfileUid: () => opts.activeProfileUid ?? null,
+    getPreviousProfileUid: () => opts.previousProfileUid ?? null,
     notify: (m) => notices.push(m),
   };
   return {
@@ -201,6 +214,7 @@ describe("ProfileCommands.invokePushCurrentAssetSpace", () => {
       fuzzyPick: async () => null,
       getActiveFilePath: () => "assetspaces/exo/foo.md",
       getActiveProfileUid: () => null,
+      getPreviousProfileUid: () => null,
       notify: (m) => notices.push(m),
     });
 
@@ -225,6 +239,7 @@ describe("ProfileCommands.invokePushCurrentAssetSpace", () => {
       fuzzyPick: async () => null,
       getActiveFilePath: () => "assetspaces/exo/foo.md",
       getActiveProfileUid: () => null,
+      getPreviousProfileUid: () => null,
       notify: (m) => notices.push(m),
     });
 
@@ -232,6 +247,141 @@ describe("ProfileCommands.invokePushCurrentAssetSpace", () => {
     // not an unhandled promise rejection.
     await expect(cmd.invokePushCurrentAssetSpace()).resolves.not.toThrow();
     expect(notices.some((n) => /Push failed.*PAT read failed/.test(n))).toBe(true);
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// invokePushCurrentAssetSpace — PAT push 403 after a green "Test connection"
+// (RFC 0002 §3.10 / P15c)
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe("ProfileCommands.invokePushCurrentAssetSpace — auth-failure (P15c)", () => {
+  it("403 push (post green Test-connection) → explains scope/expiry, not opaque", async () => {
+    const h = makeHarness({
+      profiles: [],
+      activeFilePath: "assetspaces/exo/foo.md",
+      asLookups: [["assetspaces/exo", "as-uid-1"]],
+    });
+    // Transport error shape from GitHubRestClient: a write rejected for a
+    // read-scoped (or expired) token.
+    h.pushMgr.pushThrows = new Error(
+      "GitHub request POST https://api.github.com/repos/u/exoas-x/git/commits → HTTP 403: Resource not accessible by personal access token",
+    );
+
+    await h.cmd.invokePushCurrentAssetSpace();
+
+    const notice = h.notices.find((n) => /Push failed/.test(n)) ?? "";
+    // The explanatory message names the read/write scope gap + recovery path.
+    expect(notice).toMatch(/Contents: Read and write/);
+    expect(notice).toMatch(/Settings . GitHub PAT|GitHub PAT/);
+    expect(notice).toMatch(/Test connection/);
+  });
+
+  it("401 push → same auth explanation", async () => {
+    const h = makeHarness({
+      profiles: [],
+      activeFilePath: "assetspaces/exo/foo.md",
+      asLookups: [["assetspaces/exo", "as-uid-1"]],
+    });
+    h.pushMgr.pushThrows = new Error(
+      "GitHub request POST https://api.github.com/repos/u/exoas-x/git/refs → HTTP 401: Bad credentials",
+    );
+    await h.cmd.invokePushCurrentAssetSpace();
+    expect(h.notices.some((n) => /Contents: Read and write/.test(n))).toBe(true);
+  });
+
+  it("non-auth push failure keeps the generic message (no false scope advice)", async () => {
+    const h = makeHarness({
+      profiles: [],
+      activeFilePath: "assetspaces/exo/foo.md",
+      asLookups: [["assetspaces/exo", "as-uid-1"]],
+    });
+    // 422 non-fast-forward is NOT an auth problem — must not get scope advice.
+    h.pushMgr.pushThrows = new Error(
+      "GitHub request PATCH https://api.github.com/repos/u/exoas-x/git/refs → HTTP 422: Update is not a fast forward",
+    );
+    await h.cmd.invokePushCurrentAssetSpace();
+    const notice = h.notices.find((n) => /Push failed/.test(n)) ?? "";
+    expect(notice).not.toMatch(/Contents: Read and write/);
+    expect(notice).toMatch(/fast forward/);
+  });
+
+  it("403 rate-limit is throttling, not auth — generic message", async () => {
+    const h = makeHarness({
+      profiles: [],
+      activeFilePath: "assetspaces/exo/foo.md",
+      asLookups: [["assetspaces/exo", "as-uid-1"]],
+    });
+    h.pushMgr.pushThrows = new Error(
+      "GitHub request POST https://api.github.com/... → HTTP 403: API rate limit exceeded",
+    );
+    await h.cmd.invokePushCurrentAssetSpace();
+    expect(h.notices.some((n) => /Contents: Read and write/.test(n))).toBe(false);
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// invokeUndoLastApply (RFC 0002 §3.10 / P15a)
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe("ProfileCommands.invokeUndoLastApply", () => {
+  it("no previous profile → friendly notice, no undo call", async () => {
+    const h = makeHarness({ profiles: [], previousProfileUid: null });
+    await h.cmd.invokeUndoLastApply();
+    expect(h.switchMgr.undoCalls).toBe(0);
+    expect(h.notices.some((n) => /Nothing to undo/.test(n))).toBe(true);
+  });
+
+  it("previous profile set → reverts + 'Reverting to <label>…' notice", async () => {
+    const h = makeHarness({
+      profiles: [{ uid: "prof-prev", label: "Personal" }],
+      previousProfileUid: "prof-prev",
+    });
+    await h.cmd.invokeUndoLastApply();
+    expect(h.switchMgr.undoCalls).toBe(1);
+    expect(h.notices.some((n) => /Reverting to Personal/.test(n))).toBe(true);
+  });
+
+  it("undo cancelled (ApplyAbortedByUser) → 'Undo cancelled.'", async () => {
+    const h = makeHarness({
+      profiles: [{ uid: "prof-prev", label: "Personal" }],
+      previousProfileUid: "prof-prev",
+    });
+    h.switchMgr.undoThrows = new ApplyAbortedByUser();
+    await h.cmd.invokeUndoLastApply();
+    expect(h.notices.some((n) => /Undo cancelled/.test(n))).toBe(true);
+  });
+
+  it("undo TS-floor refusal → distinct notice", async () => {
+    const h = makeHarness({
+      profiles: [{ uid: "prof-prev", label: "Personal" }],
+      previousProfileUid: "prof-prev",
+    });
+    h.switchMgr.undoThrows = new TsFloorViolationError("floor brick");
+    await h.cmd.invokeUndoLastApply();
+    expect(h.notices.some((n) => /Undo refused/.test(n))).toBe(true);
+  });
+
+  it("undo uncommitted abort → actionable notice", async () => {
+    const h = makeHarness({
+      profiles: [{ uid: "prof-prev", label: "Personal" }],
+      previousProfileUid: "prof-prev",
+    });
+    h.switchMgr.undoThrows = new UncommittedChangesAbortError("dirty", [
+      { asUid: "x", submodulePath: "assetspaces/x", files: ["a.md", "b.md"] },
+    ]);
+    await h.cmd.invokeUndoLastApply();
+    expect(h.notices.some((n) => /Undo aborted.*uncommitted/.test(n))).toBe(true);
+  });
+
+  it("generic undo failure → 'Undo failed: …'", async () => {
+    const h = makeHarness({
+      profiles: [{ uid: "prof-prev", label: "Personal" }],
+      previousProfileUid: "prof-prev",
+    });
+    h.switchMgr.undoThrows = new Error("boom");
+    await h.cmd.invokeUndoLastApply();
+    expect(h.notices.some((n) => /Undo failed: boom/.test(n))).toBe(true);
   });
 });
 
@@ -417,6 +567,7 @@ function makeScopedHarness(
     },
     getActiveFilePath: () => null,
     getActiveProfileUid: () => null,
+      getPreviousProfileUid: () => null,
     notify: (m) => notices.push(m),
   });
   return { switchMgr, notices, pickCalls, cmd };

--- a/packages/obsidian-plugin/tests/unit/infrastructure/adapters/BootstrapAssetSpaceCommands.test.ts
+++ b/packages/obsidian-plugin/tests/unit/infrastructure/adapters/BootstrapAssetSpaceCommands.test.ts
@@ -1,5 +1,6 @@
 import {
   BootstrapAssetSpaceCommands,
+  classifyBootstrapFailure,
   type BootstrapAssetSpaceCommandsDeps,
   type BootstrapResultInfo,
   type IAssetSpacePuller,
@@ -349,24 +350,32 @@ describe("BootstrapAssetSpaceCommands — durable result panel (RFC 0002 §3.3 /
     expect(h.results).toEqual([{ kind: "fetched", fetched: 2, total: 2 }]);
   });
 
-  it("hard failure / cancel / invalid URL → NO durable result (toast only)", async () => {
-    // Bootstrap pull failure.
+  it("hard failure / invalid URL → durable `failed` panel (RFC 0002 §3.10); cancel → no result", async () => {
+    // Bootstrap pull failure → durable failed panel (was toast-only before §3.10).
     const fail = makeHarness({ isGitVault: true });
     fail.puller.pullAssetSpace.mockRejectedValueOnce(new Error("network down"));
     await fail.cmds.invokeBootstrap();
-    expect(fail.results).toEqual([]);
+    expect(fail.results).toEqual([
+      expect.objectContaining({ kind: "failed", operation: "bootstrap" }),
+    ]);
 
-    // User cancelled the URL prompt.
+    // User cancelled the URL prompt — a cancel is NOT a failure → no panel.
     const cancel = makeHarness({ bootstrapUrls: null });
     await cancel.cmds.invokeBootstrap();
     expect(cancel.results).toEqual([]);
 
-    // Invalid URL.
+    // Invalid URL → durable failed panel (bad-url).
     const invalid = makeHarness({
       bootstrapUrls: { exoUrl: "http://evil.example/x" },
     });
     await invalid.cmds.invokeBootstrap();
-    expect(invalid.results).toEqual([]);
+    expect(invalid.results).toEqual([
+      expect.objectContaining({
+        kind: "failed",
+        operation: "bootstrap",
+        cause: "bad-url",
+      }),
+    ]);
   });
 
   it("showResult absent → command still completes (best-effort, optional dep)", async () => {
@@ -809,5 +818,109 @@ describe("BootstrapAssetSpaceCommands — mobile restMount strategy (#3535)", ()
     const state = await h.cmds.detectVaultState();
     expect(state).toBe("bootstrapped");
     expect(h.restMount.readGitmodulesEntries).toHaveBeenCalled();
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Durable FAILURE panel (RFC 0002 §3.10 / P15b)
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe("classifyBootstrapFailure", () => {
+  it.each([
+    ["HTTP 401 → auth", "GitHub request POST … → HTTP 401: Bad credentials", "auth"],
+    ["HTTP 403 (no rate-limit) → auth", "… → HTTP 403: Resource not accessible by personal access token", "auth"],
+    ["HTTP 404 (private + under-scoped) → auth", "… → HTTP 404: Not Found", "auth"],
+    ["HTTP 403 rate-limit → NOT auth → unknown", "… → HTTP 403: API rate limit exceeded", "unknown"],
+    ["invalid URL → bad-url", "Invalid GitHub repo URL: foo (extra path segments)", "bad-url"],
+    ["could not derive folder → bad-url", "could not derive folder name", "bad-url"],
+    ["ENOTFOUND → network", "request to https://github.com failed, reason: getaddrinfo ENOTFOUND", "network"],
+    ["timeout → network", "GitHub request GET … timed out after 120000ms", "network"],
+    ["other → unknown", "something unexpected happened", "unknown"],
+  ])("%s", (_label, message, expected) => {
+    expect(classifyBootstrapFailure(new Error(message))).toBe(expected);
+  });
+});
+
+describe("BootstrapAssetSpaceCommands — durable failure panel", () => {
+  function failures(results: BootstrapResultInfo[]) {
+    return results.filter((r) => r.kind === "failed");
+  }
+
+  it("bootstrap invalid URL → durable failed panel (bad-url) + no pull", async () => {
+    const h = makeHarness({
+      isGitVault: true,
+      bootstrapUrls: { exoUrl: "not-a-valid-url" },
+    });
+    await h.cmds.invokeBootstrap();
+    expect(h.puller.pullAssetSpace).not.toHaveBeenCalled();
+    expect(failures(h.results)).toEqual([
+      expect.objectContaining({
+        kind: "failed",
+        operation: "bootstrap",
+        cause: "bad-url",
+      }),
+    ]);
+  });
+
+  it("bootstrap pull 403 → durable failed panel (auth)", async () => {
+    const h = makeHarness({ isGitVault: true });
+    h.puller.pullAssetSpace.mockRejectedValueOnce(
+      new Error("GitHub request GET … → HTTP 403: not accessible by token"),
+    );
+    await h.cmds.invokeBootstrap();
+    expect(failures(h.results)).toEqual([
+      expect.objectContaining({
+        kind: "failed",
+        operation: "bootstrap",
+        cause: "auth",
+      }),
+    ]);
+    // The toast still fires — durable panel is additive.
+    expect(h.notices.some((n) => /Bootstrap failed/.test(n))).toBe(true);
+  });
+
+  it("bootstrap pull network error → durable failed panel (network)", async () => {
+    const h = makeHarness({ isGitVault: true });
+    h.puller.pullAssetSpace.mockRejectedValueOnce(
+      new Error("request failed: getaddrinfo ENOTFOUND github.com"),
+    );
+    await h.cmds.invokeBootstrap();
+    expect(failures(h.results)).toEqual([
+      expect.objectContaining({ kind: "failed", cause: "network" }),
+    ]);
+  });
+
+  it("add invalid URL → durable failed panel (bad-url, operation=add)", async () => {
+    const h = makeHarness({ addUrl: { url: "nope" } });
+    await h.cmds.invokeAddAssetSpace();
+    expect(failures(h.results)).toEqual([
+      expect.objectContaining({
+        kind: "failed",
+        operation: "add",
+        cause: "bad-url",
+      }),
+    ]);
+  });
+
+  it("add pull 404 → durable failed panel (auth, operation=add)", async () => {
+    const h = makeHarness({ isGitVault: true });
+    h.puller.pullAssetSpace.mockRejectedValueOnce(
+      new Error("GitHub request GET … → HTTP 404: Not Found"),
+    );
+    await h.cmds.invokeAddAssetSpace();
+    expect(failures(h.results)).toEqual([
+      expect.objectContaining({
+        kind: "failed",
+        operation: "add",
+        cause: "auth",
+      }),
+    ]);
+  });
+
+  it("successful bootstrap emits NO failed panel (no false positive)", async () => {
+    const h = makeHarness({ isGitVault: true });
+    await h.cmds.invokeBootstrap();
+    expect(failures(h.results)).toEqual([]);
+    expect(h.results.some((r) => r.kind === "bootstrapped")).toBe(true);
   });
 });

--- a/packages/obsidian-plugin/tests/unit/presentation/modals/BootstrapModals.test.ts
+++ b/packages/obsidian-plugin/tests/unit/presentation/modals/BootstrapModals.test.ts
@@ -314,6 +314,66 @@ describe("BootstrapResultModal", () => {
       /Close the setup result/i,
     );
   });
+
+  // RFC 0002 §3.10 / P15b — the durable FAILURE panel: cause + recovery step +
+  // one-click retry of the failed operation. Revert-verify: dropping the `failed`
+  // branch in onOpen (or its retry button) makes the retry assertions FAIL.
+  const FAILED_AUTH: BootstrapResultInfo = {
+    kind: "failed",
+    operation: "add",
+    cause: "auth",
+    detail: "HTTP 403: not accessible by token",
+  };
+
+  it("failed (auth) — surfaces the cause + a PAT recovery step", () => {
+    new BootstrapResultModal(fakeApp, FAILED_AUTH, {
+      onAddStarterContent: () => undefined,
+    }).open();
+    const text = document.body.textContent ?? "";
+    expect(text).toMatch(/didn't finish/i);
+    expect(text).toMatch(/rejected the request/i);
+    expect(text).toMatch(/GitHub PAT/);
+    // No success nudge on a failure panel.
+    expect(findButton("Add the starter content")).toBeUndefined();
+  });
+
+  it("failed — «Try again» fires onRetry with the failing operation + closes", () => {
+    const retried: string[] = [];
+    new BootstrapResultModal(fakeApp, FAILED_AUTH, {
+      onAddStarterContent: () => undefined,
+      onRetry: (op) => retried.push(op),
+    }).open();
+    findButton("Try again")!.click();
+    expect(retried).toEqual(["add"]);
+    expect(document.querySelector(".bootstrap-result-title")).toBeNull();
+  });
+
+  it("failed (bad-url, bootstrap) — retry passes operation=bootstrap", () => {
+    const retried: string[] = [];
+    new BootstrapResultModal(
+      fakeApp,
+      {
+        kind: "failed",
+        operation: "bootstrap",
+        cause: "bad-url",
+        detail: "Invalid GitHub repo URL: x",
+      },
+      { onAddStarterContent: () => undefined, onRetry: (op) => retried.push(op) },
+    ).open();
+    const text = document.body.textContent ?? "";
+    expect(text).toMatch(/check the URL/i);
+    findButton("Try again")!.click();
+    expect(retried).toEqual(["bootstrap"]);
+  });
+
+  it("failed without onRetry wired — still renders (cause + Dismiss), no crash", () => {
+    new BootstrapResultModal(fakeApp, FAILED_AUTH, {
+      onAddStarterContent: () => undefined,
+    }).open();
+    expect(findButton("Try again")).toBeUndefined();
+    // The Done button is labelled «Dismiss» on a failure panel.
+    expect(findButton("Dismiss")).toBeDefined();
+  });
 });
 
 // resultCopy is the pure per-outcome wording — unit-testable without DOM.
@@ -323,6 +383,7 @@ describe("resultCopy", () => {
       { kind: "bootstrapped", folderName: "assetspaces/x", sha: "deadbee" },
       { kind: "fetched", fetched: 1, total: 4 },
       { kind: "already-bootstrapped" },
+      { kind: "failed", operation: "add", cause: "network", detail: "ENOTFOUND" },
     ];
     for (const k of kinds) {
       const copy = resultCopy(k);
@@ -331,6 +392,34 @@ describe("resultCopy", () => {
       // Every outcome dead-ends nowhere — there is always a "Next:" hint.
       expect(copy.nextHint).toMatch(/Next:/);
     }
+  });
+
+  it("failed copy carries a per-cause recovery step (§3.10)", () => {
+    const badUrl = resultCopy({
+      kind: "failed",
+      operation: "add",
+      cause: "bad-url",
+      detail: "Invalid GitHub repo URL: x",
+    });
+    expect(badUrl.nextHint).toMatch(/check the URL/i);
+
+    const network = resultCopy({
+      kind: "failed",
+      operation: "bootstrap",
+      cause: "network",
+      detail: "ENOTFOUND",
+    });
+    expect(network.summary).toMatch(/reach GitHub/i);
+    expect(network.nextHint).toMatch(/connection/i);
+
+    const auth = resultCopy({
+      kind: "failed",
+      operation: "add",
+      cause: "auth",
+      detail: "HTTP 403",
+    });
+    expect(auth.nextHint).toMatch(/GitHub PAT/);
+    expect(auth.nextHint).toMatch(/Contents: Read/);
   });
 
   it("bootstrapped copy embeds the folder + sha", () => {


### PR DESCRIPTION
## RFC 0002 §3.10 — Error-recovery & undo (resolves **P15**)

WBS node \`ef3bd9a2\` (UX onboarding improvements). Phase 2 of the onboarding RFC — gives the failure paths a new user actually hits a recovery, and a wrong profile choice a one-click undo.

### 1. Undo last profile apply (P15a)
- Persist the **pre-apply** profile as a device-local undo target (\`previousProfileUid\` in \`data.local.json\`, RMW-preserved, never Sync-replicated).
- New **«Exocortex: Undo last profile apply»** command — re-applies the previous profile. `checkCallback` hides it until an undo target exists (no dead command on a fresh vault); gated identically to **Apply profile** (Desktop↔Mobile parity — `undoLastApply` routes through the same `applyProfile` → REST path).
- **Zero data loss by construction**: it is a normal apply (same confirm gate + uncommitted-changes guard + mount-before-unmount), not a filesystem rollback. The undo target toggles, giving single-level undo/redo.

### 2. Bootstrap / Add failure UX (P15b)
- On a Bootstrap/Add failure, classify the cause (**bad URL / network / PAT / unknown**) and surface it **+ a recovery step** through the durable result panel (§3.3 `BootstrapResultModal`) with a one-click **«Try again»**, instead of a toast that fades. A *cancel* is not a failure → no panel.
- New `failed` variant on `BootstrapResultInfo` + pure `classifyBootstrapFailure` (unit-tabled). HTTP-status detection mirrors the core `isAuthError` contract (401, or 403 without rate-limit markers; private-repo 404 → auth recovery copy).

### 3. PAT push 403 after a green «Test connection» (P15c)
- «Test connection» only proves the token can **read**; a push writes Contents. A read-scoped/expired token passes the test but 403s on push.
- `invokePushCurrentAssetSpace` now detects the auth error (`isAuthError`) and explains the **Contents: Read and write** scope gap / expiry + recovery, instead of an opaque HTTP error. Non-auth failures (network, 422 non-fast-forward) keep the generic message.

### Tests (TDD, production-shape)
- \`ProfileApplyManager.undo.test.ts\` (new) — end-to-end against the **real** `PluginLocalDataStore` + a mount-state-mutating REST fake: records the undo target, re-applies + toggles, `NoPreviousProfileError`, re-apply-same leaves it untouched. **Revert-verified** (disabling the recording fails 5/7).
- `PluginLocalDataStore` (previousProfileUid persistence + RMW preserve + clear), `ProfileCommands` (undo notices + PAT-403 message + non-auth/rate-limit negatives), `BootstrapAssetSpaceCommands` (classifier table + per-cause durable panel + no-false-positive), `BootstrapResultModal` (failure copy + retry button + a11y).

### Verification (local)
- typecheck ✓ · lint ✓ (0 errors) · build ✓ + **mobile-loadable** ✓ + console-channel ✓ · archgate 21/21 (incl. **MOBILE-004** desktop-parity)
- Full plugin unit suite green (the only failures were an uninitialized `exoas-exo` submodule, unrelated — verified passing once initialized).
- a11y: native buttons + explicit `aria-label`s + managed focus on the failure panel (P16).

⛔ Not verified via Docker e2e (per overnight constraints). The undo path reuses the already-shipped `applyProfile` mount machinery; the durable panel + classifier are pure/unit-covered.

Closes #ef3bd9a2 (WBS node) — RFC \`docs/rfc/0002-ux-onboarding-improvements.md\` §3.10.