### PR TITLE
feat(logs): disambiguate «Open logs» ↔ «Open activity log» + reciprocal cross-nav

### DIFF
--- a/docs/tutorials/Getting-Started.md
+++ b/docs/tutorials/Getting-Started.md
@@ -457,7 +457,7 @@ These are the most common problems encountered by first-time users. Start here b
 **Fix**:
 
 1. Open Settings → Community plugins and confirm Exocortex is **toggled on** (not just installed).
-2. Run **Cmd/Ctrl+P → "Exocortex: Open logs"** to view `exocortex-logs.txt` and its real location. The file lives in the **plugin's data folder** (`<vault>/.obsidian/plugins/exocortex/exocortex-logs.txt`), _not_ the vault root — the command shows the exact path and content so you never have to hunt for it. Search for lines starting with `[ERROR]` or `Failed` to see why initialization failed. (By default only warnings and errors are written to the file; for a live stream of everything the plugin is doing, run **"Exocortex: Open activity log"**.)
+2. Run **Cmd/Ctrl+P → "Exocortex: Open log file (saved)"** to view `exocortex-logs.txt` and its real location. The file lives in the **plugin's data folder** (`<vault>/.obsidian/plugins/exocortex/exocortex-logs.txt`), _not_ the vault root — the command shows the exact path and content so you never have to hunt for it. Search for lines starting with `[ERROR]` or `Failed` to see why initialization failed. (By default only warnings and errors are written to the file; for a live stream of everything the plugin is doing, run **"Exocortex: Open activity log (live)"**.)
 3. Open Obsidian's developer console: **Ctrl/Cmd + Shift + I → Console**. Exocortex logs initialization there as well.
 4. If the log mentions schema or RDF errors, a bootstrapped AssetSpace file may be corrupted — re-run **Cmd/Ctrl+P → "Exocortex: Set up the engine"** (or **"Exocortex: Add a knowledge pack"** for a single space) to re-download the AssetSpace.
 5. As a last resort, disable the plugin, restart Obsidian, re-enable it.
@@ -495,7 +495,7 @@ These are the most common problems encountered by first-time users. Start here b
 
 ### General diagnostic: `exocortex-logs.txt`
 
-Whenever something feels wrong, the **first place to look** is `exocortex-logs.txt`. The quickest way to it is **Cmd/Ctrl+P → "Exocortex: Open logs"** — that opens the file's content _and_ shows its exact path. The file is written to the **plugin's data folder**, not the vault root:
+Whenever something feels wrong, the **first place to look** is `exocortex-logs.txt`. The quickest way to it is **Cmd/Ctrl+P → "Exocortex: Open log file (saved)"** — that opens the file's content _and_ shows its exact path. The file is written to the **plugin's data folder**, not the vault root:
 
 ```
 <vault>/.obsidian/plugins/exocortex/exocortex-logs.txt
@@ -508,7 +508,7 @@ Whenever something feels wrong, the **first place to look** is `exocortex-logs.t
 - IRI resolution results
 - Failed grounding calls
 
-By default only **warnings and errors** are written to the file. To capture everything, enable the **Info** row under **Settings → Exocortex → Log channels**. For a live, no-setup stream of plugin activity, run **"Exocortex: Open activity log"** instead.
+By default only **warnings and errors** are written to the file. To capture everything, enable the **Info** row under **Settings → Exocortex → Log channels**. For a live, no-setup stream of plugin activity, run **"Exocortex: Open activity log (live)"** instead.
 
 Quick grep to find failures (run from the folder above, or pass the full path):
 
@@ -596,7 +596,7 @@ For the full diagnostic walkthrough see [Troubleshooting](#troubleshooting) abov
 | ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | Layout doesn't appear     | Switch to Reading Mode (Ctrl/Cmd + E)                                                                                                                                    |
 | No action buttons visible | Verify the AssetSpaces are bootstrapped (`exocmd/` folder exists in vault); if the folder is present, fully quit and reopen Obsidian (cold restart) to force re-indexing |
-| Action buttons don't work | Run **Exocortex: Open logs** (file lives in the plugin data folder, not vault root); check console (Ctrl/Cmd + Shift + I)                                                |
+| Action buttons don't work | Run **Exocortex: Open log file (saved)** (file lives in the plugin data folder, not vault root); check console (Ctrl/Cmd + Shift + I)                                    |
 | Wiki-links grey           | Reload app without saving (Cmd/Ctrl + P); re-run **Exocortex: Set up the engine** if folders missing                                                                     |
 | Daily tasks not showing   | Check task has `ems__Effort_plannedStartTimestamp` matching daily note's `pn__DailyNote_day`                                                                             |
 | Literal `$input` written  | Update the plugin via BRAT — current versions substitute `$input`/`$value` in `property_set` groundings                                                                  |

--- a/packages/obsidian-plugin/src/ExocortexPlugin.ts
+++ b/packages/obsidian-plugin/src/ExocortexPlugin.ts
@@ -2874,6 +2874,30 @@ export default class ExocortexPlugin extends Plugin {
     return uids;
   }
 
+  /**
+   * Open the live in-memory «Open activity log» modal (#3540), wired with a
+   * cross-nav hook to the persisted log-file modal. The two log views are easy
+   * to confuse in the command palette, so each opens the other in one click —
+   * the hook re-enters via {@link openLogFileModal}, which in turn wires the
+   * reciprocal hook, so the bridge stays bidirectional at every hop.
+   */
+  private openActivityLogModal(): void {
+    new ActivityLogModal(this.app, this.activityLog, () =>
+      this.openLogFileModal(),
+    ).open();
+  }
+
+  /**
+   * Open the persisted «Open log file» modal (RFC 0002 §3.8 / #3588), wired with
+   * a cross-nav hook back to the live activity-log modal. Reciprocal of
+   * {@link openActivityLogModal}.
+   */
+  private openLogFileModal(): void {
+    new LogFileModal(this.app, this.fileLogChannel, () =>
+      this.openActivityLogModal(),
+    ).open();
+  }
+
   private async registerProfileCommands(): Promise<void> {
     const lockMgr = new PluginLockManager({ app: this.app });
     const resolver = new VaultProfileResolver(this.app);
@@ -3228,29 +3252,37 @@ export default class ExocortexPlugin extends Plugin {
       },
     });
 
-    // #3540 — «Open activity log»: real-time modal over the in-memory activity
-    // stream (ExoSync / profile apply / mount-unmount / bootstrap). Pure UI +
-    // in-memory buffer (no Node/fs/git) → registered UNCONDITIONALLY so it works
-    // identically on desktop and mobile (Desktop↔Mobile Command Parity).
+    // #3540 — «Open activity log (live)»: real-time modal over the in-memory
+    // activity stream (ExoSync / profile apply / mount-unmount / bootstrap).
+    // Pure UI + in-memory buffer (no Node/fs/git) → registered UNCONDITIONALLY
+    // so it works identically on desktop and mobile (Desktop↔Mobile Command
+    // Parity). The «(live)» qualifier disambiguates it from «Open log file
+    // (saved)» below — the in-memory stream is ephemeral (cleared on reload),
+    // the file persists across reloads (the dedup is naming + cross-nav, not a
+    // merge — the two are functionally distinct: live stream vs saved file).
     this.addCommand({
       id: "open-activity-log",
-      name: "Open activity log",
+      name: "Open activity log (live)",
       callback: () => {
-        new ActivityLogModal(this.app, this.activityLog).open();
+        this.openActivityLogModal();
       },
     });
 
-    // RFC 0002 §3.8 P12 (#3588) — «Open logs»: surfaces the persisted
-    // `exocortex-logs.txt` and its REAL location (the plugin data folder, not
-    // the vault root — reconciling the long-standing docs mismatch). Reads via
-    // the DataAdapter + renders a pure-DOM modal → registered UNCONDITIONALLY
-    // so it works identically on desktop and mobile (Desktop↔Mobile Command
-    // Parity). Distinct from «Open activity log» (live in-memory stream).
+    // RFC 0002 §3.8 P12 (#3588) — «Open log file (saved)»: surfaces the
+    // persisted `exocortex-logs.txt` and its REAL location (the plugin data
+    // folder, not the vault root — reconciling the long-standing docs mismatch).
+    // Reads via the DataAdapter + renders a pure-DOM modal → registered
+    // UNCONDITIONALLY so it works identically on desktop and mobile
+    // (Desktop↔Mobile Command Parity). The «(saved)» qualifier disambiguates it
+    // from «Open activity log (live)» — this is the persistent file (survives
+    // reload/crash, the cold-start / post-mortem use-case), the live stream is
+    // in-memory only. The command id stays `open-logs` so existing hotkeys keep
+    // working.
     this.addCommand({
       id: "open-logs",
-      name: "Open logs",
+      name: "Open log file (saved)",
       callback: () => {
-        new LogFileModal(this.app, this.fileLogChannel).open();
+        this.openLogFileModal();
       },
     });
 

--- a/packages/obsidian-plugin/src/adapters/logging/FileLogChannel.ts
+++ b/packages/obsidian-plugin/src/adapters/logging/FileLogChannel.ts
@@ -131,15 +131,16 @@ export class FileLogChannel {
   /**
    * The (vault-relative) path of the active log file, e.g.
    * `.obsidian/plugins/exocortex/exocortex-logs.txt`. Surfaced by the
-   * «Exocortex: Open logs» command so users know exactly where the sink
-   * lives — it is the plugin data folder, NOT the vault root (P12).
+   * «Exocortex: Open log file (saved)» command so users know exactly where the
+   * sink lives — it is the plugin data folder, NOT the vault root (P12).
    */
   getLogFilePath(): string {
     return this.logFilePath;
   }
 
   /**
-   * Read the current log file content for display (the «Open logs» command).
+   * Read the current log file content for display (the «Open log file (saved)»
+   * command).
    *
    * Returns "" when the file does not exist yet: info-level logging is off
    * by default (only warn/error route to the file channel), so on a healthy

--- a/packages/obsidian-plugin/src/application/services/commandPaletteContract.ts
+++ b/packages/obsidian-plugin/src/application/services/commandPaletteContract.ts
@@ -15,9 +15,11 @@
  * display `name` ONLY; the keys of {@link GROOMED_COMMAND_NAMES} are the stable
  * ids and must stay byte-exact.
  *
- * Scope: only the commands §3.2 grooms. Untouched commands (`reload-layout`,
- * `sync`/`pull`/`push`, `apply-profile`, `open-activity-log`, `open-logs`, …)
- * are deliberately absent — their names are already plain and benign.
+ * Scope: only the commands §3.2 grooms. Other commands (`reload-layout`,
+ * `sync`/`pull`/`push`, `apply-profile`, …) are deliberately absent — their
+ * names are already plain and benign. `open-activity-log` / `open-logs` are
+ * likewise out of §3.2 scope; their «(live)» / «(saved)» disambiguation is owned
+ * by the separate logs-dedup change, not this grooming contract.
  */
 
 /** The user-facing text marker that flags a destructive / power-user command. */

--- a/packages/obsidian-plugin/src/presentation/modals/ActivityLogModal.ts
+++ b/packages/obsidian-plugin/src/presentation/modals/ActivityLogModal.ts
@@ -53,13 +53,23 @@ export function shouldAutoScroll(metrics: {
  */
 export class ActivityLogModal extends Modal {
   private readonly svc: ActivityLogService;
+  private readonly onOpenLogFile?: () => void;
   private listEl: HTMLElement | null = null;
   private unsub: (() => void) | null = null;
   private unsubClear: (() => void) | null = null;
 
-  constructor(app: App, svc: ActivityLogService) {
+  /**
+   * @param onOpenLogFile Optional cross-navigation hook — when provided, the
+   *   footer gains an «Open log file» button that switches to the persisted
+   *   `LogFileModal`. This is the reciprocal of `LogFileModal`'s «Open activity
+   *   log» button: the two log views (live in-memory ↔ saved file) are easy to
+   *   confuse in the command palette, so each modal offers a one-click bridge to
+   *   the other instead of forcing the user back to the palette to guess again.
+   */
+  constructor(app: App, svc: ActivityLogService, onOpenLogFile?: () => void) {
     super(app);
     this.svc = svc;
+    this.onOpenLogFile = onOpenLogFile;
   }
 
   override onOpen(): void {
@@ -91,6 +101,17 @@ export class ActivityLogModal extends Modal {
       // clear() fires the onClear subscription below → re-renders empty.
       this.svc.clear();
     });
+    if (this.onOpenLogFile) {
+      // Cross-nav to the persisted log file (saved). Close this modal first so
+      // the two log views never stack on top of each other.
+      const openFileBtn = footer.createEl("button", {
+        text: "Open log file",
+      });
+      openFileBtn.addEventListener("click", () => {
+        this.close();
+        this.onOpenLogFile?.();
+      });
+    }
     const doneBtn = footer.createEl("button", { text: "Done" });
     doneBtn.addEventListener("click", () => {
       this.close();

--- a/packages/obsidian-plugin/src/presentation/modals/BootstrapResultModal.ts
+++ b/packages/obsidian-plugin/src/presentation/modals/BootstrapResultModal.ts
@@ -258,8 +258,8 @@ function failureCopy(
         title,
         summary: `The operation failed — ${detail}`,
         nextHint:
-          "Next: open «Open logs» from the command palette for the full error, " +
-          "then try again.",
+          "Next: open «Open log file (saved)» from the command palette for the " +
+          "full error, then try again.",
       };
   }
 }

--- a/packages/obsidian-plugin/src/presentation/modals/LogFileModal.ts
+++ b/packages/obsidian-plugin/src/presentation/modals/LogFileModal.ts
@@ -20,26 +20,41 @@ export interface LogFileSource {
 export const EMPTY_LOG_HINT =
   "No file logs yet. By default only warnings and errors are written to this " +
   "file (enable Info under Settings → Exocortex → Log channels for verbose " +
-  "logging). For the live activity stream, run «Exocortex: Open activity log».";
+  "logging). For the live activity stream, use the «Open activity log» button " +
+  "below.";
 
 /**
  * LogFileModal — surfaces the persisted `exocortex-logs.txt` (GitHub #3588 P12).
  *
- * The «Exocortex: Open logs» command opens this. It reconciles the long-standing
- * docs mismatch (the file was documented as living in the vault root, but the
- * sink is the plugin data folder, `FileLogChannel`): the modal shows the REAL
- * path at the top and the file content below, so the user never has to hunt for
- * it. Reads via the DataAdapter and renders pure DOM (no Node/fs/git) → works
- * identically on desktop and mobile (Desktop↔Mobile Command Parity).
+ * The «Exocortex: Open log file (saved)» command opens this. It reconciles the
+ * long-standing docs mismatch (the file was documented as living in the vault
+ * root, but the sink is the plugin data folder, `FileLogChannel`): the modal
+ * shows the REAL path at the top and the file content below, so the user never
+ * has to hunt for it. Reads via the DataAdapter and renders pure DOM (no
+ * Node/fs/git) → works identically on desktop and mobile (Desktop↔Mobile
+ * Command Parity).
  */
 export class LogFileModal extends Modal {
   private readonly source: LogFileSource;
+  private readonly onOpenActivityLog?: () => void;
   private bodyEl: HTMLElement | null = null;
   private loadedText = "";
 
-  constructor(app: App, source: LogFileSource) {
+  /**
+   * @param onOpenActivityLog Optional cross-navigation hook — when provided, the
+   *   footer gains an «Open activity log» button that switches to the live
+   *   in-memory `ActivityLogModal`. Reciprocal of `ActivityLogModal`'s «Open log
+   *   file» button: each log view offers a one-click bridge to the other so the
+   *   user who opened the wrong one does not have to return to the palette.
+   */
+  constructor(
+    app: App,
+    source: LogFileSource,
+    onOpenActivityLog?: () => void,
+  ) {
     super(app);
     this.source = source;
+    this.onOpenActivityLog = onOpenActivityLog;
   }
 
   override onOpen(): void {
@@ -70,6 +85,17 @@ export class LogFileModal extends Modal {
     copyBtn.addEventListener("click", () => {
       void this.copyToClipboard();
     });
+    if (this.onOpenActivityLog) {
+      // Cross-nav to the live activity stream. Close this modal first so the two
+      // log views never stack on top of each other.
+      const openActivityBtn = footer.createEl("button", {
+        text: "Open activity log",
+      });
+      openActivityBtn.addEventListener("click", () => {
+        this.close();
+        this.onOpenActivityLog?.();
+      });
+    }
     const doneBtn = footer.createEl("button", { text: "Done" });
     doneBtn.addEventListener("click", () => {
       this.close();

--- a/packages/obsidian-plugin/tests/unit/ExocortexPlugin.test.ts
+++ b/packages/obsidian-plugin/tests/unit/ExocortexPlugin.test.ts
@@ -313,6 +313,35 @@ describe("ExocortexPlugin", () => {
     });
   });
 
+  // Dedup «Open logs» ↔ «Open activity log» (interview decision (b), 2026-06-20).
+  // The two commands are functionally distinct (live in-memory stream vs saved
+  // file) but were easy to confuse in the palette; disambiguate their display
+  // names with «(live)» / «(saved)» qualifiers. The command ids stay stable
+  // (`open-activity-log` / `open-logs`) so existing hotkeys keep working.
+  describe("Dedup logs — disambiguated command names (live / saved)", () => {
+    const nameById = (spy: jest.SpyInstance): Map<string, string> =>
+      new Map(
+        spy.mock.calls.map((c) => {
+          const cmd = c[0] as { id?: string; name?: string };
+          return [cmd.id ?? "", cmd.name ?? ""];
+        }),
+      );
+
+    it("registers «Open activity log (live)» under the stable `open-activity-log` id", async () => {
+      const addCommandSpy = jest.spyOn(plugin, "addCommand");
+      await plugin.onload();
+      const names = nameById(addCommandSpy);
+      expect(names.get("open-activity-log")).toBe("Open activity log (live)");
+    });
+
+    it("registers «Open log file (saved)» under the stable `open-logs` id", async () => {
+      const addCommandSpy = jest.spyOn(plugin, "addCommand");
+      await plugin.onload();
+      const names = nameById(addCommandSpy);
+      expect(names.get("open-logs")).toBe("Open log file (saved)");
+    });
+  });
+
   // Issue #3554 — profile apply → next Obsidian load hangs at "Loading plugins…".
   // After an `Apply profile` sets `data.local.json.activeProfileUid`, the next
   // load deadlocked: `registerProfileCommands` (awaited by `onload`) awaited the

--- a/packages/obsidian-plugin/tests/unit/ExocortexPlugin.test.ts
+++ b/packages/obsidian-plugin/tests/unit/ExocortexPlugin.test.ts
@@ -340,6 +340,46 @@ describe("ExocortexPlugin", () => {
       const names = nameById(addCommandSpy);
       expect(names.get("open-logs")).toBe("Open log file (saved)");
     });
+
+    // Guards the production cross-nav wiring: both commands must route through the
+    // helper that opens the modal WITH the reciprocal cross-nav hook. A regression
+    // that inlines `new ActivityLogModal(this.app, this.activityLog)` in the
+    // callback (dropping the hook) compiles fine — the param is optional — but
+    // would no longer call the helper, so this test fails.
+    const callbackById = (spy: jest.SpyInstance, id: string): (() => void) | undefined =>
+      spy.mock.calls
+        .map((c) => c[0] as { id?: string; callback?: () => void })
+        .find((cmd) => cmd.id === id)?.callback;
+
+    it("`open-activity-log` callback routes through the cross-nav-wired helper", async () => {
+      const addCommandSpy = jest.spyOn(plugin, "addCommand");
+      const helperSpy = jest
+        .spyOn(
+          plugin as unknown as { openActivityLogModal: () => void },
+          "openActivityLogModal",
+        )
+        .mockImplementation(() => {});
+      await plugin.onload();
+      const callback = callbackById(addCommandSpy, "open-activity-log");
+      expect(callback).toBeDefined();
+      callback!();
+      expect(helperSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it("`open-logs` callback routes through the cross-nav-wired helper", async () => {
+      const addCommandSpy = jest.spyOn(plugin, "addCommand");
+      const helperSpy = jest
+        .spyOn(
+          plugin as unknown as { openLogFileModal: () => void },
+          "openLogFileModal",
+        )
+        .mockImplementation(() => {});
+      await plugin.onload();
+      const callback = callbackById(addCommandSpy, "open-logs");
+      expect(callback).toBeDefined();
+      callback!();
+      expect(helperSpy).toHaveBeenCalledTimes(1);
+    });
   });
 
   // Issue #3554 — profile apply → next Obsidian load hangs at "Loading plugins…".

--- a/packages/obsidian-plugin/tests/unit/presentation/modals/ActivityLogModal.test.ts
+++ b/packages/obsidian-plugin/tests/unit/presentation/modals/ActivityLogModal.test.ts
@@ -235,3 +235,36 @@ describe("ActivityLogModal — render & controls", () => {
     expect(rows[0].textContent).toBe("07:30:15 [bootstrap] cold start");
   });
 });
+
+// «Open logs» ↔ «Open activity log» dedup (interview decision (b), 2026-06-20):
+// keep both commands, add a reciprocal one-click bridge so a user who opened the
+// wrong log view can switch without returning to the command palette. This is
+// the activity→file half (the file→activity half lives in LogFileModal).
+describe("ActivityLogModal — cross-nav to log file", () => {
+  it("renders an «Open log file» footer button when the cross-nav hook is provided", () => {
+    const svc = new ActivityLogService({ now: () => 0 });
+    new ActivityLogModal(fakeApp, svc, () => {}).open();
+    expect(findButton("Open log file")).toBeDefined();
+    // The existing controls remain present (additive change).
+    expect(findButton("Copy")).toBeDefined();
+    expect(findButton("Clear")).toBeDefined();
+    expect(findButton("Done")).toBeDefined();
+  });
+
+  it("omits the «Open log file» button when no cross-nav hook is given (backward compatible)", () => {
+    const svc = new ActivityLogService({ now: () => 0 });
+    new ActivityLogModal(fakeApp, svc).open();
+    expect(findButton("Open log file")).toBeUndefined();
+  });
+
+  it("«Open log file» invokes the hook and closes this modal (views never stack)", () => {
+    const svc = new ActivityLogService({ now: () => 0 });
+    const onOpenLogFile = jest.fn();
+    new ActivityLogModal(fakeApp, svc, onOpenLogFile).open();
+    expect(document.querySelector(".exocortex-activity-log-list")).not.toBeNull();
+    findButton("Open log file")!.click();
+    expect(onOpenLogFile).toHaveBeenCalledTimes(1);
+    // close() runs before the sibling opens → this modal's list is detached.
+    expect(document.querySelector(".exocortex-activity-log-list")).toBeNull();
+  });
+});

--- a/packages/obsidian-plugin/tests/unit/presentation/modals/LogFileModal.test.ts
+++ b/packages/obsidian-plugin/tests/unit/presentation/modals/LogFileModal.test.ts
@@ -151,3 +151,42 @@ describe("LogFileModal", () => {
     expect(document.body.querySelector(".exocortex-log-file-path")).toBeNull();
   });
 });
+
+// «Open logs» ↔ «Open activity log» dedup (interview decision (b), 2026-06-20):
+// the file→activity half of the reciprocal cross-nav bridge. The empty-state
+// hint already pointed users at the live stream; this promotes that to a
+// one-click footer button (and the activity→file half lives in ActivityLogModal).
+describe("LogFileModal — cross-nav to activity log", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  const findButton = (label: string): HTMLButtonElement | undefined =>
+    Array.from(document.body.querySelectorAll("button")).find(
+      (b) => b.textContent === label,
+    ) as HTMLButtonElement | undefined;
+
+  it("renders an «Open activity log» footer button when the cross-nav hook is provided", () => {
+    const modal = new LogFileModal(fakeApp, makeSource(""), () => {});
+    modal.open(); // button is created synchronously in onOpen, before load()
+    expect(findButton("Open activity log")).toBeDefined();
+    expect(findButton("Copy")).toBeDefined();
+    expect(findButton("Done")).toBeDefined();
+  });
+
+  it("omits the «Open activity log» button when no cross-nav hook is given (backward compatible)", () => {
+    const modal = new LogFileModal(fakeApp, makeSource(""));
+    modal.open();
+    expect(findButton("Open activity log")).toBeUndefined();
+  });
+
+  it("«Open activity log» invokes the hook and closes this modal (views never stack)", () => {
+    const onOpenActivityLog = jest.fn();
+    const modal = new LogFileModal(fakeApp, makeSource(""), onOpenActivityLog);
+    modal.open();
+    expect(document.body.querySelector(".exocortex-log-file-path")).not.toBeNull();
+    findButton("Open activity log")!.click();
+    expect(onOpenActivityLog).toHaveBeenCalledTimes(1);
+    expect(document.body.querySelector(".exocortex-log-file-path")).toBeNull();
+  });
+});


### PR DESCRIPTION
## What & why

Two log commands were easy to confuse in the command palette — a user reported «I keep opening the wrong one». A research spike confirmed they are **functionally distinct** (NOT a code-redundancy):

| | `Open activity log` (#3540) | `Open logs` (RFC 0002 §3.8 / #3588) |
|---|---|---|
| Backing | in-memory ring buffer (`ActivityLogService`) | persisted file `exocortex-logs.txt` (`FileLogChannel`) |
| Persistence | ephemeral — cleared on reload | durable — survives reload, ~2 MB rotation |
| Updates | real-time live-append | static snapshot at open |
| Use-case | watch operations live | post-mortem / cold-start / find the file |

The overlap is **UX/discoverability**, not implementation. So this is a **naming + cross-nav dedup**, not a merge — both commands stay (and both stay registered unconditionally → Desktop↔Mobile parity), so the cold-start/post-mortem direct-to-file use-case is preserved (after a reload/crash the in-memory buffer is empty, so a direct command to the persisted file matters).

Decision captured via an interactive interview with the user (2026-06-20), variant **(b) keep both + clarify naming + cross-nav**.

## Changes

- **Rename display names** → `Open activity log (live)` / `Open log file (saved)`. Command **ids stay** `open-activity-log` / `open-logs` so existing hotkeys keep working.
- **Reciprocal one-click cross-nav**: each modal footer gains a button to the other view (closes the current modal first so the two never stack). This promotes the pre-existing `EMPTY_LOG_HINT` pointer (file→activity) to a real button and adds the activity→file direction.
- **No export-to-file** — `Copy` already covers ad-hoc capture (user decision).
- Updated the «next step» hint in `BootstrapResultModal` + `FileLogChannel`/`LogFileModal` docstrings to the new command name.

## Tests

- `ActivityLogModal` / `LogFileModal`: cross-nav button present-with-hook, absent-without-hook (backward compatible), invokes hook + closes the modal.
- `ExocortexPlugin`: registers the disambiguated names under the stable ids.
- **Revert-verified**: the new tests fail on origin/main source and pass with the fix.
- Full affected suites green: `ActivityLogModal` (16), `LogFileModal` (12), `ExocortexPlugin` (97), `FileLogChannel` (21), `BootstrapModals` (41). typecheck 0, lint clean, archgate 21/21 (incl. MOBILE-004 Desktop↔Mobile parity).

🤖 Generated with [Claude Code](https://claude.com/claude-code)