### PR TITLE
feat(templating): editor «Insert template token» command (homoiconic templating MVP)

### DIFF
--- a/packages/exocortex/src/index.ts
+++ b/packages/exocortex/src/index.ts
@@ -133,6 +133,20 @@ export { EffortStatusWorkflow } from "./services/EffortStatusWorkflow";
 export { WorkflowEngine } from "./services/WorkflowEngine";
 export type { WorkflowValidationResult } from "./services/WorkflowEngine";
 export { WorkflowResolver } from "./services/WorkflowResolver";
+// Homoiconic substitution-token registry (RFC 727572d2). Public so consumers
+// (Obsidian plugin templating, CLI) can resolve/register token vocabulary —
+// e.g. the editor "Insert template token" command reuses `getResolver`.
+export {
+  installDefaultResolvers,
+  getResolver,
+  registerResolver,
+  clearResolvers,
+  getRegisteredResolverIds,
+} from "./services/SubstitutionResolverRegistry";
+export type {
+  ResolverContext,
+  ResolverFn,
+} from "./services/SubstitutionResolverRegistry";
 export { InstantiationRuleResolver } from "./services/InstantiationRuleResolver";
 export type { InstantiationRule, PropertySetRule } from "./services/InstantiationRuleResolver";
 export { VisibilityGenerator } from "./services/VisibilityGenerator";

--- a/packages/obsidian-plugin/src/ExocortexPlugin.ts
+++ b/packages/obsidian-plugin/src/ExocortexPlugin.ts
@@ -3880,13 +3880,16 @@ export default class ExocortexPlugin extends Plugin {
    * emits no extra Notice.
    */
   private async invokeInsertTemplateToken(editor: Editor): Promise<void> {
-    const choice = await pickTemplateToken(
-      this.app,
-      TEMPLATE_TOKEN_CHOICES,
-      "Insert template token",
-    );
-    if (choice === null) return; // dismissed without a selection — no-op
+    // Single try covers both the picker await (Modal.open could throw) and the
+    // resolve+insert — so no failure escapes as an unhandled rejection (the
+    // command body calls this via bare `void`).
     try {
+      const choice = await pickTemplateToken(
+        this.app,
+        TEMPLATE_TOKEN_CHOICES,
+        "Insert template token",
+      );
+      if (choice === null) return; // dismissed without a selection — no-op
       insertTemplateToken(editor, choice);
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);

--- a/packages/obsidian-plugin/src/ExocortexPlugin.ts
+++ b/packages/obsidian-plugin/src/ExocortexPlugin.ts
@@ -1,5 +1,6 @@
 import "reflect-metadata";
 import {
+  type Editor,
   MarkdownPostProcessorContext,
   MarkdownView,
   MetadataCache,
@@ -20,6 +21,11 @@ import {
 } from "./adapters/logging/activityFanIn";
 import { ActivityLogModal } from "./presentation/modals/ActivityLogModal";
 import { LogFileModal } from "./presentation/modals/LogFileModal";
+import {
+  TEMPLATE_TOKEN_CHOICES,
+  insertTemplateToken,
+} from "./infrastructure/adapters/TemplateTokenInserter";
+import { pickTemplateToken } from "./infrastructure/adapters/TemplateTokenFuzzyModal";
 import { CommandManager } from "./application/services/CommandManager";
 import { IndexingCompleteNotifier } from "./application/services/IndexingCompleteNotifier";
 import {
@@ -3254,6 +3260,23 @@ export default class ExocortexPlugin extends Plugin {
       },
     });
 
+    // Homoiconic templating MVP (project 17f58ebe / vision 09a3fbec) —
+    // «Insert template token»: editor-only command → fuzzy picker
+    // (Random UUID / Current Timestamp / Current Date) → insert at cursor.
+    // `editorCallback` makes Obsidian auto-hide the command outside an active
+    // Markdown editor (interview Q4). Pure editor op — no Node/git/fs deps — so
+    // it is registered UNCONDITIONALLY (Desktop↔Mobile Command Parity; the
+    // editorCallback signature is identical on both surfaces). Token values come
+    // from the shared SubstitutionResolverRegistry (interview Q6 — reuse, not a
+    // duplicate vocabulary).
+    this.addCommand({
+      id: "insert-template-token",
+      name: "Insert template token",
+      editorCallback: (editor: Editor) => {
+        void this.invokeInsertTemplateToken(editor);
+      },
+    });
+
     // RFC 0a0791c1 Phase 5 T2 — «Apply profile» (the single consolidated
     // profile command; the former soft «Switch focus profile» was removed and
     // the mount-state «Switch knowledge profile» was renamed here). Needs the
@@ -3844,6 +3867,30 @@ export default class ExocortexPlugin extends Plugin {
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       this.notifier.error(`Clear switch cache failed: ${msg}`);
+    }
+  }
+
+  /**
+   * «Insert template token» (homoiconic templating MVP, project 17f58ebe).
+   * Opens the fuzzy picker; on a choice, resolves the token via the shared
+   * SubstitutionResolverRegistry and inserts it at the cursor (replacing any
+   * selection). A dismissed picker (Escape) is a silent no-op. A resolver error
+   * (e.g. unregistered id — a programming error) is surfaced, not swallowed —
+   * the inserted text is otherwise its own success feedback, so the happy path
+   * emits no extra Notice.
+   */
+  private async invokeInsertTemplateToken(editor: Editor): Promise<void> {
+    const choice = await pickTemplateToken(
+      this.app,
+      TEMPLATE_TOKEN_CHOICES,
+      "Insert template token",
+    );
+    if (choice === null) return; // dismissed without a selection — no-op
+    try {
+      insertTemplateToken(editor, choice);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      this.notifier.error(`Insert template token failed: ${msg}`);
     }
   }
 

--- a/packages/obsidian-plugin/src/infrastructure/adapters/TemplateTokenFuzzyModal.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/TemplateTokenFuzzyModal.ts
@@ -1,0 +1,111 @@
+import { App, FuzzySuggestModal, type FuzzyMatch } from "obsidian";
+
+import type { TemplateTokenChoice } from "./TemplateTokenInserter";
+
+/**
+ * TemplateTokenFuzzyModal — fuzzy picker for the editor "Insert template token"
+ * command (homoiconic templating MVP). Interview Q5: reuse the `Apply profile`
+ * FuzzySuggestModal UX (fuzzy search + native keyboard nav + a11y) rather than a
+ * bespoke menu.
+ *
+ * Lifecycle contract (⚠ order matters — same as ProfileFuzzyModal, Issue #3561):
+ *   - `onChooseItem` only RECORDS the chosen value (does NOT resolve).
+ *   - `onClose` performs the single resolution, deferred to a microtask.
+ *   - The Promise resolves exactly once; a `settled` flag suppresses Obsidian's
+ *     double `onClose`.
+ *
+ * Why resolution is deferred (the picker-no-op bug): Obsidian's real
+ * `SuggestModal.selectSuggestion` calls `close()` (→ `onClose`) BEFORE
+ * `onChooseItem`, both synchronously in one selection. A synchronous resolve in
+ * `onClose` would see no choice recorded yet and resolve `null` — making every
+ * picker selection a silent no-op. The microtask runs after the synchronous
+ * `selectSuggestion` stack, by which point `onChooseItem` has recorded the
+ * choice; a cancel (Escape) records nothing and resolves `null`. Order-independent.
+ */
+export class TemplateTokenFuzzyModal extends FuzzySuggestModal<TemplateTokenChoice> {
+  private chosen: TemplateTokenChoice | null = null;
+  private settled = false;
+  private readonly resolveChoice: (value: TemplateTokenChoice | null) => void;
+
+  constructor(
+    app: App,
+    private readonly options: readonly TemplateTokenChoice[],
+    title: string,
+    resolve: (value: TemplateTokenChoice | null) => void,
+  ) {
+    super(app);
+    this.resolveChoice = resolve;
+    this.setPlaceholder(title);
+  }
+
+  getItems(): TemplateTokenChoice[] {
+    return [...this.options];
+  }
+
+  /**
+   * Fuzzy-searchable text — label first (so a user can type "uuid" / "date"),
+   * then the description so the description is searchable too, not just
+   * decorative.
+   */
+  getItemText(item: TemplateTokenChoice): string {
+    return `${item.label} — ${item.description}`;
+  }
+
+  /**
+   * Structured suggestion row: a title line (label) and a muted description
+   * line. Both carry visible text, so assistive tech announces the full row
+   * naturally — no redundant `aria-label` (which would override, not augment,
+   * the text). The fuzzy picker itself is natively keyboard-navigable, which is
+   * the a11y win (interview Q5). Overriding `renderSuggestion` replaces
+   * Obsidian's default fuzzy-highlight rendering, acceptable for this small
+   * curated list; `getItemText` still drives the fuzzy match.
+   */
+  override renderSuggestion(
+    match: FuzzyMatch<TemplateTokenChoice>,
+    el: HTMLElement,
+  ): void {
+    const item = match.item;
+    el.addClass("exocortex-token-suggestion");
+    el.createDiv({
+      cls: "exocortex-token-suggestion__title",
+      text: item.label,
+    });
+    el.createDiv({
+      cls: "exocortex-token-suggestion__desc",
+      text: item.description,
+    });
+  }
+
+  onChooseItem(item: TemplateTokenChoice): void {
+    // Record only — Obsidian fires this AFTER onClose (see class docstring), so
+    // the single resolution happens in onClose's deferred microtask.
+    this.chosen = item;
+  }
+
+  override onClose(): void {
+    // Schedule the single resolution BEFORE super.onClose() so a throw from
+    // Obsidian's DOM teardown cannot leave the awaiter pending forever. The
+    // microtask still runs after the whole synchronous selectSuggestion stack
+    // (close → onChooseItem), so `chosen` is populated for a real selection and
+    // stays null for a cancel.
+    if (!this.settled) {
+      this.settled = true;
+      queueMicrotask(() => this.resolveChoice(this.chosen));
+    }
+    super.onClose();
+  }
+}
+
+/**
+ * Open the token picker and resolve with the chosen token, or `null` when the
+ * user dismisses it without selecting. Mirrors `ProfileCommands.fuzzyPick`.
+ */
+export function pickTemplateToken(
+  app: App,
+  options: readonly TemplateTokenChoice[],
+  title: string,
+): Promise<TemplateTokenChoice | null> {
+  return new Promise((resolve) => {
+    new TemplateTokenFuzzyModal(app, options, title, resolve).open();
+  });
+}

--- a/packages/obsidian-plugin/src/infrastructure/adapters/TemplateTokenInserter.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/TemplateTokenInserter.ts
@@ -1,0 +1,106 @@
+import type { Editor } from "obsidian";
+import { getResolver, installDefaultResolvers } from "exocortex";
+
+/**
+ * TemplateTokenInserter — pure logic behind the editor "Insert template token"
+ * command (homoiconic templating MVP, project 17f58ebe / vision 09a3fbec).
+ *
+ * The MVP inserts a single substitution-token value at the cursor. Token values
+ * are produced by the SAME `SubstitutionResolverRegistry` that drives the
+ * RFC 727572d2 RDF-driven asset-creation pipeline — so a "Random UUID" inserted
+ * by hand and a `$randomUUIDv4` resolved during `create_instance` come from one
+ * source of truth (interview Q6: reuse the existing resolvers, no duplication).
+ *
+ * The menu set + formats are the interview-confirmed MVP decisions (2026-06-20):
+ *   - Random UUID     → `randomUUIDv4`  (bare v4 lowercase, crypto.randomUUID())  [Q1/Q2]
+ *   - Current Timestamp → `nowTimestamp` (local ISO YYYY-MM-DDTHH:MM:SS, no TZ)    [Q1/Q3]
+ *   - Current Date    → `nowDate`       (LOCAL date YYYY-MM-DD)                     [Q1]
+ *
+ * Why `nowDate` (local) and not the registry's `today` (UTC `toISOString`):
+ * Andrey is UTC+5 and works in the early morning, when a UTC date is still
+ * "yesterday". A local date matches both the user's expectation and the local
+ * (no-TZ) timestamp decision (Q3) — same `YYYY-MM-DD` shape Andrey asked for.
+ */
+
+/** A single menu choice in the "Insert template token" picker. */
+export interface TemplateTokenChoice {
+  /** Stable id (command/test reference; not user-facing). */
+  readonly id: string;
+  /** Human-facing menu label. */
+  readonly label: string;
+  /** Resolver id in the SubstitutionResolverRegistry. */
+  readonly resolverId: string;
+  /** Short human description (searchable in the fuzzy picker; a11y line). */
+  readonly description: string;
+}
+
+/**
+ * MVP menu set (interview-confirmed Q1). Frozen so callers cannot mutate the
+ * shared list. Extending the set later (vehy 2-5) is additive.
+ */
+export const TEMPLATE_TOKEN_CHOICES: readonly TemplateTokenChoice[] = Object.freeze([
+  {
+    id: "random-uuid",
+    label: "Random UUID",
+    resolverId: "randomUUIDv4",
+    description: "A random UUID v4 (lowercase, crypto.randomUUID())",
+  },
+  {
+    id: "current-timestamp",
+    label: "Current Timestamp",
+    resolverId: "nowTimestamp",
+    description: "Local date-time, no timezone (YYYY-MM-DDTHH:MM:SS)",
+  },
+  {
+    id: "current-date",
+    label: "Current Date",
+    resolverId: "nowDate",
+    description: "Today's local date (YYYY-MM-DD)",
+  },
+]);
+
+// Ensure the default resolver vocabulary is installed even if no other module
+// (e.g. GroundingExecutor) imported it first. Idempotent — last registration
+// wins, so this never clobbers a deterministic resolver a test injected AFTER
+// import (tests that need determinism call clearResolvers + registerResolver in
+// beforeEach).
+installDefaultResolvers();
+
+/**
+ * Resolve a token's value via the shared registry. These MVP tokens
+ * (`randomUUIDv4` / `nowTimestamp` / `nowDate`) need no context, so an empty
+ * ResolverContext is passed. Throws (fail-loud) when the resolver id is
+ * unregistered or yields a non-string — the menu only offers known scalar
+ * tokens, so either is a programming error worth surfacing, not a silent
+ * no-op insert.
+ */
+export function resolveTokenValue(resolverId: string): string {
+  const resolver = getResolver(resolverId);
+  if (resolver === undefined) {
+    throw new Error(
+      `Insert template token: no resolver registered for "${resolverId}".`,
+    );
+  }
+  const value = resolver({});
+  if (typeof value !== "string") {
+    throw new Error(
+      `Insert template token: resolver "${resolverId}" did not produce a scalar string value.`,
+    );
+  }
+  return value;
+}
+
+/**
+ * Resolve the chosen token and insert it at the cursor (replacing any selection)
+ * via the Obsidian Editor API. Returns the inserted value so the caller can
+ * surface it (e.g. a confirmation Notice) and so tests can assert exact
+ * passthrough deterministically without registering a fixed resolver.
+ */
+export function insertTemplateToken(
+  editor: Editor,
+  choice: TemplateTokenChoice,
+): string {
+  const value = resolveTokenValue(choice.resolverId);
+  editor.replaceSelection(value);
+  return value;
+}

--- a/packages/obsidian-plugin/styles.css
+++ b/packages/obsidian-plugin/styles.css
@@ -2511,6 +2511,25 @@
   font-style: italic;
 }
 
+/* «Insert template token» picker rows (homoiconic templating MVP) — mirrors
+   the profile-suggestion layout: a title line and a muted description line. */
+.exocortex-token-suggestion__title {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+
+.exocortex-token-suggestion__desc {
+  font-size: 0.8em;
+  color: var(--text-muted);
+  margin-top: 2px;
+  /* Single-line truncate — ellipsis needs nowrap to take effect. */
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
 /* Required indicator */
 .required-indicator {
   color: var(--text-error);

--- a/packages/obsidian-plugin/tests/unit/TemplateTokenFuzzyModal.test.ts
+++ b/packages/obsidian-plugin/tests/unit/TemplateTokenFuzzyModal.test.ts
@@ -1,0 +1,139 @@
+import {
+  TemplateTokenFuzzyModal,
+  pickTemplateToken,
+} from "../../src/infrastructure/adapters/TemplateTokenFuzzyModal";
+import { TEMPLATE_TOKEN_CHOICES } from "../../src/infrastructure/adapters/TemplateTokenInserter";
+import type { TemplateTokenChoice } from "../../src/infrastructure/adapters/TemplateTokenInserter";
+import type { FuzzyMatch } from "obsidian";
+
+const fakeApp = {} as any;
+
+const tokens: TemplateTokenChoice[] = [...TEMPLATE_TOKEN_CHOICES];
+
+/**
+ * Drive the modal exactly as Obsidian's real `SuggestModal.selectSuggestion`
+ * does (verified against `obsidian.asar`): `close()` (→ `onClose()`) fires
+ * BEFORE `onChooseItem()`, both synchronously in one selection. This is the
+ * production-shape ordering — NOT the vacuous "onChooseItem first" assumption.
+ * See ProfileFuzzyModal Issue #3561.
+ */
+function realObsidianSelect(
+  modal: TemplateTokenFuzzyModal,
+  item: TemplateTokenChoice,
+): void {
+  modal.onClose(); // Obsidian calls close() first
+  modal.onChooseItem(item); // then onChooseSuggestion → onChooseItem
+}
+
+describe("TemplateTokenFuzzyModal", () => {
+  it("getItems returns the constructor-supplied options", () => {
+    const modal = new TemplateTokenFuzzyModal(fakeApp, tokens, "Pick", () => {});
+    expect(modal.getItems()).toEqual(tokens);
+  });
+
+  it("getItemText renders label first then description (both searchable)", () => {
+    const modal = new TemplateTokenFuzzyModal(fakeApp, tokens, "Pick", () => {});
+    expect(modal.getItemText(tokens[0])).toBe(
+      "Random UUID — A random UUID v4 (lowercase, crypto.randomUUID())",
+    );
+  });
+
+  it("setPlaceholder is invoked on construction with the provided title", () => {
+    const modal = new TemplateTokenFuzzyModal(
+      fakeApp,
+      tokens,
+      "Insert template token",
+      () => {},
+    );
+    expect(modal.inputEl.placeholder).toBe("Insert template token");
+  });
+
+  // ── renderSuggestion structured a11y DOM ──────────────────────────────────
+  function fuzzy(item: TemplateTokenChoice): FuzzyMatch<TemplateTokenChoice> {
+    return { item, match: { score: 0, matches: [] } };
+  }
+
+  it("renderSuggestion renders a title (label) line and a description line", () => {
+    const modal = new TemplateTokenFuzzyModal(fakeApp, tokens, "Pick", () => {});
+    const el = document.createElement("div");
+    modal.renderSuggestion(fuzzy(tokens[1]), el);
+
+    expect(el.classList.contains("exocortex-token-suggestion")).toBe(true);
+    expect(
+      el.querySelector(".exocortex-token-suggestion__title")?.textContent,
+    ).toBe("Current Timestamp");
+    expect(
+      el.querySelector(".exocortex-token-suggestion__desc")?.textContent,
+    ).toBe("Local date-time, no timezone (YYYY-MM-DDTHH:MM:SS)");
+  });
+
+  // ── Regression: picker selection NO-OP (Issue #3561 pattern) ──────────────
+  // Obsidian closes the modal BEFORE invoking onChooseItem, so a synchronous
+  // null-resolve in onClose would win and the choice would be lost (insert
+  // silently never runs). Production-shape revert-verify gate: with the deferred
+  // microtask resolution it resolves the chosen token; reverting to a synchronous
+  // null-resolve in onClose makes it resolve null and FAIL.
+  it("resolves with the chosen token when Obsidian closes BEFORE onChooseItem", async () => {
+    const result = await new Promise<TemplateTokenChoice | null>((resolve) => {
+      const modal = new TemplateTokenFuzzyModal(fakeApp, tokens, "Pick", resolve);
+      realObsidianSelect(modal, tokens[2]);
+    });
+    expect(result).toEqual(tokens[2]);
+  });
+
+  it("resolves null when dismissed without a choice (Escape)", async () => {
+    const result = await new Promise<TemplateTokenChoice | null>((resolve) => {
+      const modal = new TemplateTokenFuzzyModal(fakeApp, tokens, "Pick", resolve);
+      modal.onClose(); // Escape closes without ever calling onChooseItem
+    });
+    expect(result).toBeNull();
+  });
+
+  it("resolves exactly once for the close-then-choose sequence", async () => {
+    const resolve = jest.fn();
+    const modal = new TemplateTokenFuzzyModal(fakeApp, tokens, "Pick", resolve);
+    realObsidianSelect(modal, tokens[0]);
+    await Promise.resolve(); // flush the deferred (microtask) resolution
+    expect(resolve).toHaveBeenCalledTimes(1);
+    expect(resolve).toHaveBeenCalledWith(tokens[0]);
+  });
+
+  it("double onClose is idempotent — resolves at most once with null", async () => {
+    const resolve = jest.fn();
+    const modal = new TemplateTokenFuzzyModal(fakeApp, tokens, "Pick", resolve);
+    modal.onClose();
+    modal.onClose();
+    await Promise.resolve();
+    expect(resolve).toHaveBeenCalledTimes(1);
+    expect(resolve).toHaveBeenCalledWith(null);
+  });
+
+  describe("pickTemplateToken wrapper", () => {
+    it("opens the modal and resolves with the chosen token", async () => {
+      // Spy on FuzzySuggestModal.prototype.open (mock no-ops) to drive a
+      // selection synchronously once the modal is constructed+opened.
+      const openSpy = jest
+        .spyOn(TemplateTokenFuzzyModal.prototype, "open")
+        .mockImplementation(function (this: TemplateTokenFuzzyModal) {
+          realObsidianSelect(this, tokens[1]);
+        });
+
+      const chosen = await pickTemplateToken(fakeApp, tokens, "Insert template token");
+      expect(chosen).toEqual(tokens[1]);
+      expect(openSpy).toHaveBeenCalledTimes(1);
+      openSpy.mockRestore();
+    });
+
+    it("resolves null when the picker is opened and dismissed", async () => {
+      const openSpy = jest
+        .spyOn(TemplateTokenFuzzyModal.prototype, "open")
+        .mockImplementation(function (this: TemplateTokenFuzzyModal) {
+          this.onClose(); // Escape
+        });
+
+      const chosen = await pickTemplateToken(fakeApp, tokens, "Insert template token");
+      expect(chosen).toBeNull();
+      openSpy.mockRestore();
+    });
+  });
+});

--- a/packages/obsidian-plugin/tests/unit/TemplateTokenInserter.test.ts
+++ b/packages/obsidian-plugin/tests/unit/TemplateTokenInserter.test.ts
@@ -1,0 +1,122 @@
+import type { Editor } from "obsidian";
+import {
+  clearResolvers,
+  installDefaultResolvers,
+  registerResolver,
+} from "exocortex";
+import {
+  TEMPLATE_TOKEN_CHOICES,
+  type TemplateTokenChoice,
+  insertTemplateToken,
+  resolveTokenValue,
+} from "../../src/infrastructure/adapters/TemplateTokenInserter";
+
+const UUID_V4 =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+const LOCAL_ISO_NO_TZ = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}$/;
+const LOCAL_DATE = /^\d{4}-\d{2}-\d{2}$/;
+
+/** Minimal Editor double — only `replaceSelection` is exercised by the inserter. */
+function fakeEditor(): Editor & { replaceSelection: jest.Mock } {
+  return { replaceSelection: jest.fn() } as unknown as Editor & {
+    replaceSelection: jest.Mock;
+  };
+}
+
+describe("TemplateTokenInserter", () => {
+  beforeEach(() => {
+    // Reset to the real default vocabulary before each test — mirrors how the
+    // registry is populated in production (GroundingExecutor / inserter import).
+    clearResolvers();
+    installDefaultResolvers();
+  });
+
+  describe("TEMPLATE_TOKEN_CHOICES (interview Q1 menu set)", () => {
+    it("offers exactly the 3 MVP tokens with the confirmed resolver ids", () => {
+      expect(TEMPLATE_TOKEN_CHOICES).toHaveLength(3);
+      expect(TEMPLATE_TOKEN_CHOICES.map((c) => c.resolverId)).toEqual([
+        "randomUUIDv4",
+        "nowTimestamp",
+        "nowDate",
+      ]);
+      expect(TEMPLATE_TOKEN_CHOICES.map((c) => c.label)).toEqual([
+        "Random UUID",
+        "Current Timestamp",
+        "Current Date",
+      ]);
+    });
+
+    it("is frozen (callers cannot mutate the shared list)", () => {
+      expect(Object.isFrozen(TEMPLATE_TOKEN_CHOICES)).toBe(true);
+    });
+  });
+
+  describe("resolveTokenValue (reuses the shared registry — Q6)", () => {
+    it("Random UUID → bare lowercase v4 UUID (Q2)", () => {
+      expect(resolveTokenValue("randomUUIDv4")).toMatch(UUID_V4);
+    });
+
+    it("Current Timestamp → local ISO, no timezone (Q3)", () => {
+      expect(resolveTokenValue("nowTimestamp")).toMatch(LOCAL_ISO_NO_TZ);
+    });
+
+    it("Current Date → local YYYY-MM-DD (Q1)", () => {
+      expect(resolveTokenValue("nowDate")).toMatch(LOCAL_DATE);
+    });
+
+    it("throws (fail-loud) for an unregistered resolver id", () => {
+      expect(() => resolveTokenValue("does-not-exist")).toThrow(
+        /no resolver registered/i,
+      );
+    });
+
+    it("throws when a resolver yields a non-scalar (array) value", () => {
+      registerResolver("listy", () => ["a", "b"]);
+      expect(() => resolveTokenValue("listy")).toThrow(/scalar string/i);
+    });
+  });
+
+  describe("insertTemplateToken", () => {
+    it("inserts the resolved value at the cursor via editor.replaceSelection", () => {
+      // Deterministic resolver so the asserted insert value is exact
+      // (revert-verify discipline: change the resolver → the asserted value
+      // changes; the inserter must pass exactly what the registry produced).
+      registerResolver("fixed", () => "FIXED-TOKEN-VALUE");
+      const choice: TemplateTokenChoice = {
+        id: "fixed",
+        label: "Fixed",
+        resolverId: "fixed",
+        description: "fixed for test",
+      };
+      const editor = fakeEditor();
+
+      const returned = insertTemplateToken(editor, choice);
+
+      expect(editor.replaceSelection).toHaveBeenCalledTimes(1);
+      expect(editor.replaceSelection).toHaveBeenCalledWith("FIXED-TOKEN-VALUE");
+      expect(returned).toBe("FIXED-TOKEN-VALUE");
+    });
+
+    it("passes the EXACT resolved value through to the editor for a real token", () => {
+      // No fixed stub — the real randomUUIDv4 resolver produces a fresh value;
+      // the inserter must insert that same value (returned === inserted).
+      const editor = fakeEditor();
+      const inserted = insertTemplateToken(editor, TEMPLATE_TOKEN_CHOICES[0]);
+
+      expect(inserted).toMatch(UUID_V4);
+      expect(editor.replaceSelection).toHaveBeenCalledWith(inserted);
+    });
+
+    it("does not insert when the resolver is missing (throws before write)", () => {
+      const editor = fakeEditor();
+      const badChoice: TemplateTokenChoice = {
+        id: "x",
+        label: "X",
+        resolverId: "missing",
+        description: "",
+      };
+      expect(() => insertTemplateToken(editor, badChoice)).toThrow();
+      expect(editor.replaceSelection).not.toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Homoiconic templating **MVP** (project [[17f58ebe]] / vision [[09a3fbec]], Exocortex Alpha Launch). Adds an **editor-only** Command Palette command **«Insert template token»** → fuzzy picker (**Random UUID** / **Current Timestamp** / **Current Date**) → inserts the value at the cursor.

First step toward replacing the non-homoiconic Obsidian Core **Template** + Community **Templater** plugins. Milestones 2-5 (markdown blocks → `exotemplate__Template` body-copy → variables → full Templater replacement) are planned in the WBS only — **not** implemented here.

## Interview-confirmed decisions (Андрей, 2026-06-20)

| # | Decision |
|---|---|
| Q1 | Menu: **3 items** — Random UUID, Current Timestamp, **Current Date** |
| Q2 | UUID: bare **v4 lowercase** (`crypto.randomUUID()`) |
| Q3 | Timestamp: **local ISO, no TZ** (`YYYY-MM-DDTHH:MM:SS`) |
| Q4 | Editor-gating: idiomatic **`editorCallback`** (Obsidian auto editor-only) |
| Q5 | UX: **`FuzzySuggestModal`** (reuse `Apply profile` pattern + #3561 lifecycle) |
| Q6 | **Reuse** the shared `SubstitutionResolverRegistry` — no duplicate vocabulary |

## Design

- **Reuse, not duplication (Q6):** token values come from the existing `randomUUIDv4` / `nowTimestamp` / `nowDate` resolvers (RFC 727572d2) — now exported from the `exocortex` package index. A hand-inserted «Random UUID» and a `$randomUUIDv4` resolved during `create_instance` share one source of truth.
- **Current Date uses `nowDate` (LOCAL), not the registry's `today` (UTC `toISOString`):** for a UTC+5 early riser the UTC date is still *yesterday* in the morning. Local date matches user expectation and the local-no-TZ timestamp decision (Q3) — same `YYYY-MM-DD` shape.
- **#3561 picker lifecycle:** `TemplateTokenFuzzyModal` records the choice in `onChooseItem` and resolves in an `onClose` microtask (Obsidian fires `close()` before `onChooseItem`), so a real selection is never a silent no-op.
- **Desktop↔Mobile Command Parity:** registered **unconditionally** (no `Platform` gate) — pure editor op, no Node/git/fs deps. `assert-mobile-loadable` passes; MOBILE-004 archgate rule clean.

## Files

- `packages/exocortex/src/index.ts` — export the substitution-resolver registry API (public homoiconic vocabulary).
- `packages/obsidian-plugin/src/infrastructure/adapters/TemplateTokenInserter.ts` — pure logic: menu set + `resolveTokenValue` + `insertTemplateToken`.
- `packages/obsidian-plugin/src/infrastructure/adapters/TemplateTokenFuzzyModal.ts` — generic fuzzy picker (#3561 pattern) + `pickTemplateToken`.
- `packages/obsidian-plugin/src/ExocortexPlugin.ts` — command registration (`editorCallback`) + `invokeInsertTemplateToken`.

## Tests (production-shape, 20 new)

- **TemplateTokenInserter** — resolver output shapes (v4 UUID / local-ISO / local-date), **exact-value insert passthrough** (`replaceSelection` receives exactly what the registry produced), fail-loud on missing/non-scalar resolver (no write).
- **TemplateTokenFuzzyModal** — `getItems`/`getItemText`/`renderSuggestion`, and the **#3561 close-before-choose revert-verify lifecycle** (resolves chosen on real selection; null on cancel; resolves once; idempotent double-close).

## Verification (local)

- `npm run build` ✅ (tsc typecheck + esbuild + mobile-loadable + console-channel)
- `npm run lint` ✅ (0 errors)
- `archgate check --ci` ✅ (21 passed, 0 failed — MOBILE-004 parity clean)
- new suites 20/20 ✅; `ExocortexPlugin.test` + `desktopOnlyCommandGate` + `commandPaletteContract` green

## Out of scope (WBS only)

⛔ Milestones 2-5 (markdown blocks, `exotemplate__Template` body-copy composite-step, variables via `exocmd__SubstitutionToken`, full Templater replacement) — planned as nested WBS tasks, not implemented here.