### PR TITLE
docs: remove Diátaxis redirect stubs (RFC 0001 Phase 5, one-release grace elapsed)

### DIFF
--- a/docs/AI-DEVELOPMENT-PATTERNS.md
+++ b/docs/AI-DEVELOPMENT-PATTERNS.md
@@ -1,4 +1,0 @@
-# AI Development Patterns
-
-> **Moved to [`docs/contributing/AI-DEVELOPMENT-PATTERNS.md`](contributing/AI-DEVELOPMENT-PATTERNS.md).**
-> This file was relocated by the Diátaxis documentation reorganization (RFC 0001, Phase 2 — see [`docs/TAXONOMY.md`](TAXONOMY.md)). This redirect stub is kept for one release so external deep-links keep resolving — please update your link to the new path.

--- a/docs/CROSS_RUNTIME_PARITY.md
+++ b/docs/CROSS_RUNTIME_PARITY.md
@@ -1,4 +1,0 @@
-# Cross-Runtime Parity Contract (P1.13)
-
-> **Moved to [`docs/explanation/CROSS_RUNTIME_PARITY.md`](explanation/CROSS_RUNTIME_PARITY.md).**
-> This file was relocated by the Diátaxis documentation reorganization (RFC 0001, Phase 2 — see [`docs/TAXONOMY.md`](TAXONOMY.md)). This redirect stub is kept for one release so external deep-links keep resolving — please update your link to the new path.

--- a/docs/FLAKY_POLICY.md
+++ b/docs/FLAKY_POLICY.md
@@ -1,4 +1,0 @@
-# Flaky Test Policy
-
-> **Moved to [`docs/contributing/FLAKY_POLICY.md`](contributing/FLAKY_POLICY.md).**
-> This file was relocated by the Diátaxis documentation reorganization (RFC 0001, Phase 2 — see [`docs/TAXONOMY.md`](TAXONOMY.md)). This redirect stub is kept for one release so external deep-links keep resolving — please update your link to the new path.

--- a/docs/Getting-Started.md
+++ b/docs/Getting-Started.md
@@ -1,4 +1,0 @@
-# Getting Started with Exocortex
-
-> **Moved to [`docs/tutorials/Getting-Started.md`](tutorials/Getting-Started.md).**
-> This file was relocated by the Diátaxis documentation reorganization (RFC 0001, Phase 2 — see [`docs/TAXONOMY.md`](TAXONOMY.md)). This redirect stub is kept for one release so external deep-links keep resolving — please update your link to the new path.

--- a/docs/ONTOLOGY_EXTENSION.md
+++ b/docs/ONTOLOGY_EXTENSION.md
@@ -1,4 +1,0 @@
-# Ontology Extension Guide
-
-> **Moved to [`docs/how-to/ONTOLOGY_EXTENSION.md`](how-to/ONTOLOGY_EXTENSION.md).**
-> This file was relocated by the Diátaxis documentation reorganization (RFC 0001, Phase 2 — see [`docs/TAXONOMY.md`](TAXONOMY.md)). This redirect stub is kept for one release so external deep-links keep resolving — please update your link to the new path.

--- a/docs/PROPERTY_SCHEMA.md
+++ b/docs/PROPERTY_SCHEMA.md
@@ -1,4 +1,0 @@
-# Exocortex Property Schema Reference
-
-> **Moved to [`docs/reference/PROPERTY_SCHEMA.md`](reference/PROPERTY_SCHEMA.md).**
-> This file was relocated by the Diátaxis documentation reorganization (RFC 0001, Phase 2 — see [`docs/TAXONOMY.md`](TAXONOMY.md)). This redirect stub is kept for one release so external deep-links keep resolving — please update your link to the new path.

--- a/docs/Performance-Guide.md
+++ b/docs/Performance-Guide.md
@@ -1,4 +1,0 @@
-# Performance Guide
-
-> **Moved to [`docs/reference/Performance-Guide.md`](reference/Performance-Guide.md).**
-> This file was relocated by the Diátaxis documentation reorganization (RFC 0001, Phase 2 — see [`docs/TAXONOMY.md`](TAXONOMY.md)). This redirect stub is kept for one release so external deep-links keep resolving — please update your link to the new path.

--- a/docs/Plugin-Development-Guide.md
+++ b/docs/Plugin-Development-Guide.md
@@ -1,4 +1,0 @@
-# Plugin Development Guide
-
-> **Moved to [`docs/how-to/Plugin-Development-Guide.md`](how-to/Plugin-Development-Guide.md).**
-> This file was relocated by the Diátaxis documentation reorganization (RFC 0001, Phase 2 — see [`docs/TAXONOMY.md`](TAXONOMY.md)). This redirect stub is kept for one release so external deep-links keep resolving — please update your link to the new path.

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,7 +14,7 @@ complete `doc → mode` classification (with the move map and the rationale for
 docs kept at root) is in **[TAXONOMY.md](TAXONOMY.md)**.
 
 > Paths are relative to this file (`docs/`). Root-level docs are linked as `../NAME.md`.
-> Old `docs/*` paths keep a one-release redirect stub, so external deep-links still resolve.
+> The old flat `docs/*` redirect stubs were removed (RFC 0001 Phase 5 — the one-release grace elapsed); update any external deep-links to the Diátaxis paths below.
 
 ---
 
@@ -39,9 +39,9 @@ docs kept at root) is in **[TAXONOMY.md](TAXONOMY.md)**.
 ## Reference
 
 - [PROPERTY_SCHEMA.md](reference/PROPERTY_SCHEMA.md) — full frontmatter property vocabulary
-- [api/Core-API.md](reference/Core-API.md) — `exocortex` core programmatic API
+- [Core-API.md](reference/Core-API.md) — `exocortex` core programmatic API
 - [SHACL_LITE_MAPPING.md](reference/SHACL_LITE_MAPPING.md) — SHACL-lite shape mapping
-- [rdf/ExoRDF-Mapping.md](explanation/ExoRDF-Mapping.md) — vault ↔ RDF triple mapping
+- [ExoRDF-Mapping.md](explanation/ExoRDF-Mapping.md) — vault ↔ RDF triple mapping
 - CLI reference — [CLI_API_REFERENCE.md](../packages/cli/docs/CLI_API_REFERENCE.md), [ONTOLOGY_REFERENCE.md](../packages/cli/docs/ONTOLOGY_REFERENCE.md), [SPARQL_GUIDE.md](../packages/cli/docs/SPARQL_GUIDE.md), [SPARQL_COOKBOOK.md](../packages/cli/docs/SPARQL_COOKBOOK.md), [VERSIONING.md](../packages/cli/VERSIONING.md)
 - Plugin reference — [EXO_LAYOUT.md](../packages/obsidian-plugin/docs/EXO_LAYOUT.md) — layout engine
 

--- a/docs/ROLLBACK_EXOQL_EVAL.md
+++ b/docs/ROLLBACK_EXOQL_EVAL.md
@@ -1,4 +1,0 @@
-# Rollback — exoql:eval flag flip (RFC c78cc5c8 Phase 1a, PR3)
-
-> **Moved to [`docs/how-to/ROLLBACK_EXOQL_EVAL.md`](how-to/ROLLBACK_EXOQL_EVAL.md).**
-> This file was relocated by the Diátaxis documentation reorganization (RFC 0001, Phase 2 — see [`docs/TAXONOMY.md`](TAXONOMY.md)). This redirect stub is kept for one release so external deep-links keep resolving — please update your link to the new path.

--- a/docs/SHACL_LITE_MAPPING.md
+++ b/docs/SHACL_LITE_MAPPING.md
@@ -1,4 +1,0 @@
-# SHACL-Lite Vocabulary Mapping
-
-> **Moved to [`docs/reference/SHACL_LITE_MAPPING.md`](reference/SHACL_LITE_MAPPING.md).**
-> This file was relocated by the Diátaxis documentation reorganization (RFC 0001, Phase 2 — see [`docs/TAXONOMY.md`](TAXONOMY.md)). This redirect stub is kept for one release so external deep-links keep resolving — please update your link to the new path.

--- a/docs/TAXONOMY.md
+++ b/docs/TAXONOMY.md
@@ -1,7 +1,7 @@
 # Documentation taxonomy — `doc → Diátaxis mode` mapping
 
 > **Phase-2 deliverable** of [RFC 0001 — Documentation reorganization (Diátaxis)](rfc/0001-documentation-diataxis-reorganization.md).
-> This table classifies **every** prose doc by Diátaxis mode *before* the Phase-2
+> This table classifies **every** prose doc by Diátaxis mode _before_ the Phase-2
 > file moves, so no doc is relocated unclassified. It is the source of truth for the
 > physical layout under `docs/` and for the logical grouping in [`README.md`](README.md)
 > (the single index).
@@ -9,9 +9,9 @@
 [Diátaxis](https://diataxis.fr/) modes: **tutorial** (learning-oriented),
 **how-to** (task-oriented), **reference** (information-oriented),
 **explanation** (understanding-oriented), plus a **contributing** bucket for
-contributor/CI process docs. RFC §3: *the taxonomy + single index + de-duplication
+contributor/CI process docs. RFC §3: _the taxonomy + single index + de-duplication
 matter more than literal paths; cohesion over purity — a straddle doc is placed by
-its dominant intent with an explicit rationale, never silently.*
+its dominant intent with an explicit rationale, never silently._
 
 ---
 
@@ -19,8 +19,8 @@ its dominant intent with an explicit rationale, never silently.*
 
 Phase 2 introduces `docs/{tutorials,how-to,reference,explanation,contributing}/`
 and **physically relocates the `docs/`-tree prose files** into those buckets,
-leaving a redirect stub at every old path (one release) and fixing all cross-links
-+ non-markdown config refs in the same PR.
+leaving a redirect stub at every old path (one-release grace — **removed in Phase 5**
+once the grace elapsed) and fixing all cross-links + non-markdown config refs in the same PR.
 
 Two categories are classified for the index but **NOT physically moved in Phase 2**
 (cohesion-over-purity / bounded blast-radius — explicit, per RFC §3 & §5):
@@ -57,73 +57,74 @@ already-bucketed or non-prose.
 
 ## `docs/`-tree files — physically moved in Phase 2
 
-| Old path | → New path | Mode | Rationale (straddles explicit) |
-| --- | --- | --- | --- |
-| `docs/Getting-Started.md` | `docs/tutorials/Getting-Started.md` | tutorial | learning-oriented first-install walkthrough |
-| `docs/Troubleshooting.md` | `docs/how-to/Troubleshooting.md` | how-to | task-oriented "common issues & fixes" (end-user) |
-| `docs/WORKFLOW_CUSTOMIZATION.md` | `docs/how-to/WORKFLOW_CUSTOMIZATION.md` | how-to | **straddle**: step-by-step (lean tutorial) but the goal is *accomplish a customization task* → how-to (cohesion with the other config how-tos) |
-| `docs/ONTOLOGY_EXTENSION.md` | `docs/how-to/ONTOLOGY_EXTENSION.md` | how-to | **straddle**: step-by-step but goal = *extend the ontology* → how-to |
-| `docs/Plugin-Development-Guide.md` | `docs/how-to/Plugin-Development-Guide.md` | how-to | **straddle**: developer guide; task-oriented "extend Exocortex with custom functionality" |
-| `docs/exosync.md` | `docs/how-to/exosync.md` | how-to | ExoSync **usage** (`Exocortex: Sync`, structured merge, conflict quarantine) |
-| `docs/ROLLBACK_EXOQL_EVAL.md` | `docs/how-to/ROLLBACK_EXOQL_EVAL.md` | how-to | operational rollback **procedure** (runbook); task-oriented |
-| `docs/PROPERTY_SCHEMA.md` | `docs/reference/PROPERTY_SCHEMA.md` | reference | frontmatter property vocabulary (pure reference) |
-| `docs/NL-TO-SPARQL.md` | `docs/reference/NL-TO-SPARQL.md` | reference | canonical NL → query translation reference |
-| `docs/SHACL_LITE_MAPPING.md` | `docs/reference/SHACL_LITE_MAPPING.md` | reference | self-labeled "Status: Reference"; vocabulary mapping |
-| `docs/Performance-Guide.md` | `docs/reference/Performance-Guide.md` | reference | **straddle**: "optimization tips **and performance characteristics**" — the system-characteristics content (index permutations, complexity) dominates over the tuning tips → reference |
-| `docs/api/Core-API.md` | `docs/reference/Core-API.md` | reference | programmatic core API reference (`api/` subdir flattened — single file) |
-| `docs/ci/assetspace-shacl-gate.md` (+ `assetspace-shacl-workflow.yml`) | `docs/reference/ci/assetspace-shacl-gate.md` (+ yml) | reference | **straddle**: documents the per-AssetSpace SHACL CI **gate mechanism** (reference) with a rollout plan; subdir moved as a unit to preserve the sibling `.yml` link |
-| `docs/profile.md` | `docs/explanation/profile.md` | explanation | **straddle**: has Apply-profile usage but the architectural pitch + 2-phase-commit model dominate → explanation (per RFC §3) |
-| `docs/CROSS_RUNTIME_PARITY.md` | `docs/explanation/CROSS_RUNTIME_PARITY.md` | explanation | the UI/CLI parity invariant as a validator instance (concept) |
-| `docs/settings-homoiconization.md` | `docs/explanation/settings-homoiconization.md` | explanation | plugin settings as `exo__Setting` vault assets (concept) |
-| `docs/exosync-parallel-run.md` | `docs/explanation/exosync-parallel-run.md` | explanation | ExoSync internals / M1-M2 parity harness (per RFC §3 "exosync internals") |
-| `docs/rdf/ExoRDF-Mapping.md` | `docs/explanation/ExoRDF-Mapping.md` | explanation | vault ↔ RDF triple-mapping concept (per RFC §3; `rdf/` flattened — single file) |
-| `docs/AI-DEVELOPMENT-PATTERNS.md` | `docs/contributing/AI-DEVELOPMENT-PATTERNS.md` | contributing | patterns for AI-agent contributors |
-| `docs/FLAKY_POLICY.md` | `docs/contributing/FLAKY_POLICY.md` | contributing | **straddle**: a normative CI policy (reference-like) but contributor/CI-ops-facing → contributing (cohesion with the testing/CI contributor docs) |
-| `docs/e2e-desktop.md` | `docs/contributing/e2e-desktop.md` | contributing | documents the `e2e-desktop.yml` CI workflow for contributors |
+| Old path                                                               | → New path                                           | Mode         | Rationale (straddles explicit)                                                                                                                                                         |
+| ---------------------------------------------------------------------- | ---------------------------------------------------- | ------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `docs/Getting-Started.md`                                              | `docs/tutorials/Getting-Started.md`                  | tutorial     | learning-oriented first-install walkthrough                                                                                                                                            |
+| `docs/Troubleshooting.md`                                              | `docs/how-to/Troubleshooting.md`                     | how-to       | task-oriented "common issues & fixes" (end-user)                                                                                                                                       |
+| `docs/WORKFLOW_CUSTOMIZATION.md`                                       | `docs/how-to/WORKFLOW_CUSTOMIZATION.md`              | how-to       | **straddle**: step-by-step (lean tutorial) but the goal is _accomplish a customization task_ → how-to (cohesion with the other config how-tos)                                         |
+| `docs/ONTOLOGY_EXTENSION.md`                                           | `docs/how-to/ONTOLOGY_EXTENSION.md`                  | how-to       | **straddle**: step-by-step but goal = _extend the ontology_ → how-to                                                                                                                   |
+| `docs/Plugin-Development-Guide.md`                                     | `docs/how-to/Plugin-Development-Guide.md`            | how-to       | **straddle**: developer guide; task-oriented "extend Exocortex with custom functionality"                                                                                              |
+| `docs/exosync.md`                                                      | `docs/how-to/exosync.md`                             | how-to       | ExoSync **usage** (`Exocortex: Sync`, structured merge, conflict quarantine)                                                                                                           |
+| `docs/ROLLBACK_EXOQL_EVAL.md`                                          | `docs/how-to/ROLLBACK_EXOQL_EVAL.md`                 | how-to       | operational rollback **procedure** (runbook); task-oriented                                                                                                                            |
+| `docs/PROPERTY_SCHEMA.md`                                              | `docs/reference/PROPERTY_SCHEMA.md`                  | reference    | frontmatter property vocabulary (pure reference)                                                                                                                                       |
+| `docs/NL-TO-SPARQL.md`                                                 | `docs/reference/NL-TO-SPARQL.md`                     | reference    | canonical NL → query translation reference                                                                                                                                             |
+| `docs/SHACL_LITE_MAPPING.md`                                           | `docs/reference/SHACL_LITE_MAPPING.md`               | reference    | self-labeled "Status: Reference"; vocabulary mapping                                                                                                                                   |
+| `docs/Performance-Guide.md`                                            | `docs/reference/Performance-Guide.md`                | reference    | **straddle**: "optimization tips **and performance characteristics**" — the system-characteristics content (index permutations, complexity) dominates over the tuning tips → reference |
+| `docs/api/Core-API.md`                                                 | `docs/reference/Core-API.md`                         | reference    | programmatic core API reference (`api/` subdir flattened — single file)                                                                                                                |
+| `docs/ci/assetspace-shacl-gate.md` (+ `assetspace-shacl-workflow.yml`) | `docs/reference/ci/assetspace-shacl-gate.md` (+ yml) | reference    | **straddle**: documents the per-AssetSpace SHACL CI **gate mechanism** (reference) with a rollout plan; subdir moved as a unit to preserve the sibling `.yml` link                     |
+| `docs/profile.md`                                                      | `docs/explanation/profile.md`                        | explanation  | **straddle**: has Apply-profile usage but the architectural pitch + 2-phase-commit model dominate → explanation (per RFC §3)                                                           |
+| `docs/CROSS_RUNTIME_PARITY.md`                                         | `docs/explanation/CROSS_RUNTIME_PARITY.md`           | explanation  | the UI/CLI parity invariant as a validator instance (concept)                                                                                                                          |
+| `docs/settings-homoiconization.md`                                     | `docs/explanation/settings-homoiconization.md`       | explanation  | plugin settings as `exo__Setting` vault assets (concept)                                                                                                                               |
+| `docs/exosync-parallel-run.md`                                         | `docs/explanation/exosync-parallel-run.md`           | explanation  | ExoSync internals / M1-M2 parity harness (per RFC §3 "exosync internals")                                                                                                              |
+| `docs/rdf/ExoRDF-Mapping.md`                                           | `docs/explanation/ExoRDF-Mapping.md`                 | explanation  | vault ↔ RDF triple-mapping concept (per RFC §3; `rdf/` flattened — single file)                                                                                                        |
+| `docs/AI-DEVELOPMENT-PATTERNS.md`                                      | `docs/contributing/AI-DEVELOPMENT-PATTERNS.md`       | contributing | patterns for AI-agent contributors                                                                                                                                                     |
+| `docs/FLAKY_POLICY.md`                                                 | `docs/contributing/FLAKY_POLICY.md`                  | contributing | **straddle**: a normative CI policy (reference-like) but contributor/CI-ops-facing → contributing (cohesion with the testing/CI contributor docs)                                      |
+| `docs/e2e-desktop.md`                                                  | `docs/contributing/e2e-desktop.md`                   | contributing | documents the `e2e-desktop.yml` CI workflow for contributors                                                                                                                           |
 
 ## `docs/`-tree — stay in place (already bucketed / non-prose)
 
-| Path | Why it stays |
-| --- | --- |
-| `docs/README.md` | **THE single index** (canonical home, RFC §3) |
-| `docs/history/**` | frozen archive bucket (Diátaxis `history/`) |
-| `docs/rfc/**` | RFC home (incl. this taxonomy's parent RFC) |
-| `docs/examples/**` | test fixtures consumed by code/tests (documented index exclusion) |
-| `docs/diagrams/**` | non-prose `.mmd` assets referenced by `ARCHITECTURE.md` |
+| Path                   | Why it stays                                                                                                                               |
+| ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| `docs/README.md`       | **THE single index** (canonical home, RFC §3)                                                                                              |
+| `docs/history/**`      | frozen archive bucket (Diátaxis `history/`)                                                                                                |
+| `docs/rfc/**`          | RFC home (incl. this taxonomy's parent RFC)                                                                                                |
+| `docs/examples/**`     | test fixtures consumed by code/tests (documented index exclusion)                                                                          |
+| `docs/diagrams/**`     | non-prose `.mmd` assets referenced by `ARCHITECTURE.md`                                                                                    |
 | `docs/TEST-PYRAMID.md` | Phase-1 consolidation stub → root `TESTING.md`; kept by path because `packages/{obsidian-plugin,cli}/jest.config.js` comments reference it |
 
 ## Root-level docs — classified for the index, NOT moved in Phase 2
 
-| Doc | Mode (for index grouping) | Why it stays at root |
-| --- | --- | --- |
-| `README.md` | front door | repo-root front door (GitHub convention) |
-| `VISION.md` | explanation | root cluster; referenced widely (`./VISION.md`) |
-| `ARCHITECTURE.md` | explanation | **straddle**: reference-heavy but kept whole (RFC §3); referenced as `exocortex/ARCHITECTURE.md` |
-| `AGENTS.md` | contributing | universal AGENTS standard — root-discovered by AI tools; Phase-3 slim target |
-| `CLAUDE.md` | contributing | Claude Code auto-loads root `CLAUDE.md` |
-| `PATTERNS.md` | contributing | Phase-3 prune target; referenced as `exocortex/PATTERNS.md` |
-| `TESTING.md` | contributing | canonical testing guide; Phase-3 unify target; `exocortex/TESTING.md` |
-| `DEV-TROUBLESHOOTING.md` | contributing | developer/CI troubleshooting; `exocortex/DEV-TROUBLESHOOTING.md` |
-| `TEMPLATES.md` | contributing | post-mortem templates; `exocortex/TEMPLATES.md` |
-| `CONTRIBUTING.md` / `SECURITY.md` / `CODE_OF_CONDUCT.md` | contributing / community | GitHub-auto-detected community-health files (root) |
-| `CHANGELOG.md` | operational (retired) | release notes retired to GitHub Releases; `release.sh` still greps it at root |
+| Doc                                                      | Mode (for index grouping) | Why it stays at root                                                                             |
+| -------------------------------------------------------- | ------------------------- | ------------------------------------------------------------------------------------------------ |
+| `README.md`                                              | front door                | repo-root front door (GitHub convention)                                                         |
+| `VISION.md`                                              | explanation               | root cluster; referenced widely (`./VISION.md`)                                                  |
+| `ARCHITECTURE.md`                                        | explanation               | **straddle**: reference-heavy but kept whole (RFC §3); referenced as `exocortex/ARCHITECTURE.md` |
+| `AGENTS.md`                                              | contributing              | universal AGENTS standard — root-discovered by AI tools; Phase-3 slim target                     |
+| `CLAUDE.md`                                              | contributing              | Claude Code auto-loads root `CLAUDE.md`                                                          |
+| `PATTERNS.md`                                            | contributing              | Phase-3 prune target; referenced as `exocortex/PATTERNS.md`                                      |
+| `TESTING.md`                                             | contributing              | canonical testing guide; Phase-3 unify target; `exocortex/TESTING.md`                            |
+| `DEV-TROUBLESHOOTING.md`                                 | contributing              | developer/CI troubleshooting; `exocortex/DEV-TROUBLESHOOTING.md`                                 |
+| `TEMPLATES.md`                                           | contributing              | post-mortem templates; `exocortex/TEMPLATES.md`                                                  |
+| `CONTRIBUTING.md` / `SECURITY.md` / `CODE_OF_CONDUCT.md` | contributing / community  | GitHub-auto-detected community-health files (root)                                               |
+| `CHANGELOG.md`                                           | operational (retired)     | release notes retired to GitHub Releases; `release.sh` still greps it at root                    |
 
 ## Package-local docs — logically `reference/`, physically stay (npm-shipped)
 
-| Path | Mode |
-| --- | --- |
-| `packages/cli/docs/CLI_API_REFERENCE.md` | reference |
-| `packages/cli/docs/ONTOLOGY_REFERENCE.md` | reference |
-| `packages/cli/docs/SPARQL_GUIDE.md`, `SPARQL_COOKBOOK.md` | reference |
-| `packages/cli/VERSIONING.md` | reference |
-| `packages/cli/docs/RCA_DYNCOMMAND_SHOW_VS_EXEC.md`, `SUNSET_LEGACY_COMMAND_START.md` | contributing (process) |
-| `packages/obsidian-plugin/docs/EXO_LAYOUT.md` | reference |
-| `packages/obsidian-plugin/docs/release-checklist-mobile.md` | how-to |
-| `packages/obsidian-plugin/docs/FLAKY_DASHBOARD.md` | contributing |
-| `packages/obsidian-plugin/docs/TESTING.md`, `packages/exocortex/docs/NL-TO-SPARQL.md` | stubs → canonical (root `TESTING.md` / `docs/reference/NL-TO-SPARQL.md`) |
-| `packages/obsidian-plugin/docs/phase3/**` | frozen archive (referenced by `docker-entrypoint-e2e.sh` comment — do not move) |
+| Path                                                                                  | Mode                                                                            |
+| ------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
+| `packages/cli/docs/CLI_API_REFERENCE.md`                                              | reference                                                                       |
+| `packages/cli/docs/ONTOLOGY_REFERENCE.md`                                             | reference                                                                       |
+| `packages/cli/docs/SPARQL_GUIDE.md`, `SPARQL_COOKBOOK.md`                             | reference                                                                       |
+| `packages/cli/VERSIONING.md`                                                          | reference                                                                       |
+| `packages/cli/docs/RCA_DYNCOMMAND_SHOW_VS_EXEC.md`, `SUNSET_LEGACY_COMMAND_START.md`  | contributing (process)                                                          |
+| `packages/obsidian-plugin/docs/EXO_LAYOUT.md`                                         | reference                                                                       |
+| `packages/obsidian-plugin/docs/release-checklist-mobile.md`                           | how-to                                                                          |
+| `packages/obsidian-plugin/docs/FLAKY_DASHBOARD.md`                                    | contributing                                                                    |
+| `packages/obsidian-plugin/docs/TESTING.md`, `packages/exocortex/docs/NL-TO-SPARQL.md` | stubs → canonical (root `TESTING.md` / `docs/reference/NL-TO-SPARQL.md`)        |
+| `packages/obsidian-plugin/docs/phase3/**`                                             | frozen archive (referenced by `docker-entrypoint-e2e.sh` comment — do not move) |
 
 ---
 
-*Generated for RFC 0001 Phase 2. Redirect stubs at every moved old path link forward
-to the new canonical location for one release; remove after downstream links settle.*
+_Generated for RFC 0001 Phase 2. The redirect stubs at every moved old path (one-release
+grace) were removed in Phase 5 once the grace elapsed; the new canonical Diátaxis paths
+above are now the only locations._

--- a/docs/Troubleshooting.md
+++ b/docs/Troubleshooting.md
@@ -1,4 +1,0 @@
-# User Troubleshooting Guide
-
-> **Moved to [`docs/how-to/Troubleshooting.md`](how-to/Troubleshooting.md).**
-> This file was relocated by the Diátaxis documentation reorganization (RFC 0001, Phase 2 — see [`docs/TAXONOMY.md`](TAXONOMY.md)). This redirect stub is kept for one release so external deep-links keep resolving — please update your link to the new path.

--- a/docs/WORKFLOW_CUSTOMIZATION.md
+++ b/docs/WORKFLOW_CUSTOMIZATION.md
@@ -1,4 +1,0 @@
-# Workflow Customization Guide
-
-> **Moved to [`docs/how-to/WORKFLOW_CUSTOMIZATION.md`](how-to/WORKFLOW_CUSTOMIZATION.md).**
-> This file was relocated by the Diátaxis documentation reorganization (RFC 0001, Phase 2 — see [`docs/TAXONOMY.md`](TAXONOMY.md)). This redirect stub is kept for one release so external deep-links keep resolving — please update your link to the new path.

--- a/docs/api/Core-API.md
+++ b/docs/api/Core-API.md
@@ -1,4 +1,0 @@
-# Core API Reference
-
-> **Moved to [`docs/reference/Core-API.md`](../reference/Core-API.md).**
-> This file was relocated by the Diátaxis documentation reorganization (RFC 0001, Phase 2 — see [`docs/TAXONOMY.md`](../TAXONOMY.md)). This redirect stub is kept for one release so external deep-links keep resolving — please update your link to the new path.

--- a/docs/ci/assetspace-shacl-gate.md
+++ b/docs/ci/assetspace-shacl-gate.md
@@ -1,4 +1,0 @@
-# Per-AssetSpace SHACL CI gate — registry-driven rollout
-
-> **Moved to [`docs/reference/ci/assetspace-shacl-gate.md`](../reference/ci/assetspace-shacl-gate.md).**
-> This file was relocated by the Diátaxis documentation reorganization (RFC 0001, Phase 2 — see [`docs/TAXONOMY.md`](../TAXONOMY.md)). This redirect stub is kept for one release so external deep-links keep resolving — please update your link to the new path.

--- a/docs/e2e-desktop.md
+++ b/docs/e2e-desktop.md
@@ -1,4 +1,0 @@
-# E2E Desktop Smoke Workflow
-
-> **Moved to [`docs/contributing/e2e-desktop.md`](contributing/e2e-desktop.md).**
-> This file was relocated by the Diátaxis documentation reorganization (RFC 0001, Phase 2 — see [`docs/TAXONOMY.md`](TAXONOMY.md)). This redirect stub is kept for one release so external deep-links keep resolving — please update your link to the new path.

--- a/docs/exosync-parallel-run.md
+++ b/docs/exosync-parallel-run.md
@@ -1,4 +1,0 @@
-# ExoSync parallel-run mode — validation harness (M1/M2)
-
-> **Moved to [`docs/explanation/exosync-parallel-run.md`](explanation/exosync-parallel-run.md).**
-> This file was relocated by the Diátaxis documentation reorganization (RFC 0001, Phase 2 — see [`docs/TAXONOMY.md`](TAXONOMY.md)). This redirect stub is kept for one release so external deep-links keep resolving — please update your link to the new path.

--- a/docs/exosync.md
+++ b/docs/exosync.md
@@ -1,4 +1,0 @@
-# ExoSync — GitHub-backed vault sync
-
-> **Moved to [`docs/how-to/exosync.md`](how-to/exosync.md).**
-> This file was relocated by the Diátaxis documentation reorganization (RFC 0001, Phase 2 — see [`docs/TAXONOMY.md`](TAXONOMY.md)). This redirect stub is kept for one release so external deep-links keep resolving — please update your link to the new path.

--- a/docs/profile.md
+++ b/docs/profile.md
@@ -1,4 +1,0 @@
-# Profile — Vault-Declared Context
-
-> **Moved to [`docs/explanation/profile.md`](explanation/profile.md).**
-> This file was relocated by the Diátaxis documentation reorganization (RFC 0001, Phase 2 — see [`docs/TAXONOMY.md`](TAXONOMY.md)). This redirect stub is kept for one release so external deep-links keep resolving — please update your link to the new path.

--- a/docs/rdf/ExoRDF-Mapping.md
+++ b/docs/rdf/ExoRDF-Mapping.md
@@ -1,4 +1,0 @@
-# ExoRDF to RDF/RDFS Mapping Specification
-
-> **Moved to [`docs/explanation/ExoRDF-Mapping.md`](../explanation/ExoRDF-Mapping.md).**
-> This file was relocated by the Diátaxis documentation reorganization (RFC 0001, Phase 2 — see [`docs/TAXONOMY.md`](../TAXONOMY.md)). This redirect stub is kept for one release so external deep-links keep resolving — please update your link to the new path.

--- a/docs/settings-homoiconization.md
+++ b/docs/settings-homoiconization.md
@@ -1,4 +1,0 @@
-# Settings homoiconization (`exo__Setting`)
-
-> **Moved to [`docs/explanation/settings-homoiconization.md`](explanation/settings-homoiconization.md).**
-> This file was relocated by the Diátaxis documentation reorganization (RFC 0001, Phase 2 — see [`docs/TAXONOMY.md`](TAXONOMY.md)). This redirect stub is kept for one release so external deep-links keep resolving — please update your link to the new path.

--- a/packages/obsidian-plugin/src/infrastructure/adapters/ProfileApplyManager.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/ProfileApplyManager.ts
@@ -967,7 +967,7 @@ export class ProfileApplyManager {
           `Apply aborted — ${total} uncommitted file(s) in ${uncommitted.affectedFiles.length} AssetSpace(s) this profile would remove. ` +
             `Commit or stash the vault before applying. On a fresh git-backed vault, Bootstrap / Add-AssetSpace leave the pulled ` +
             `assetspaces/ untracked — run \`git add -A && git commit -m "vault setup"\` first (and gitignore \`.obsidian/\` + ` +
-            `\`.exocortex/\` so your PAT is never committed). See docs/profile.md → "Apply on a git-backed vault (commit first)".`,
+            `\`.exocortex/\` so your PAT is never committed). See docs/explanation/profile.md → "Apply on a git-backed vault (commit first)".`,
           uncommitted.affectedFiles,
         );
       }
@@ -1612,7 +1612,7 @@ export class ProfileApplyManager {
             `Apply aborted — ${total} uncommitted file(s) in ${uncommitted.affectedFiles.length} AssetSpace(s) this profile would remove. ` +
               `Commit or stash the vault before applying. On a fresh git-backed vault, Bootstrap / Add-AssetSpace leave the pulled ` +
               `assetspaces/ untracked — run \`git add -A && git commit -m "vault setup"\` first (and gitignore \`.obsidian/\` + ` +
-              `\`.exocortex/\` so your PAT is never committed). See docs/profile.md → "Apply on a git-backed vault (commit first)".`,
+              `\`.exocortex/\` so your PAT is never committed). See docs/explanation/profile.md → "Apply on a git-backed vault (commit first)".`,
             uncommitted.affectedFiles,
           );
         }
@@ -2601,7 +2601,7 @@ export class ProfileApplyManager {
    * the canonical folder on mobile), so a flat-mounted AssetSpace is NOT
    * recognised as materialized → re-materialized at the canonical path →
    * latent DOUBLE MOUNT of the same AssetSpace UID. This surfaces the affected
-   * AssetSpaces so the user can migrate them manually (see docs/profile.md);
+   * AssetSpaces so the user can migrate them manually (see docs/explanation/profile.md);
    * auto-migration is deferred (risky runtime directory move).
    */
   private async detectLegacyFlatMounts(): Promise<
@@ -2654,7 +2654,7 @@ export class ProfileApplyManager {
     this.notify(
       `⚠ ${legacy.length} AssetSpace(s) mounted at a legacy flat path: ${list}. ` +
         "apply-profile expects the canonical assetspaces/<owner>/<repo> layout — " +
-        "migrate manually to avoid a double mount (see docs/profile.md → " +
+        "migrate manually to avoid a double mount (see docs/explanation/profile.md → " +
         '"Legacy flat-mount migration").',
     );
   }

--- a/packages/obsidian-plugin/src/infrastructure/adapters/ProfileCommands.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/ProfileCommands.ts
@@ -221,7 +221,7 @@ export class ProfileCommands {
           `Apply profile aborted — ${total} uncommitted file(s) in ${e.affectedFiles.length} AssetSpace(s) this profile would remove. ` +
             `Commit (or stash) the vault first, then re-apply. Fresh git-backed vault? The pulled assetspaces/ are untracked — run ` +
             `\`git add -A && git commit -m "vault setup"\` (and gitignore \`.obsidian/\` + \`.exocortex/\` to keep your PAT out of git). ` +
-            `See docs/profile.md.`,
+            `See docs/explanation/profile.md.`,
         );
         return;
       }
@@ -277,7 +277,7 @@ export class ProfileCommands {
         const total = e.affectedFiles.reduce((s, a) => s + a.files.length, 0);
         this.notify(
           `Undo aborted — ${total} uncommitted file(s) in ${e.affectedFiles.length} AssetSpace(s) reverting would remove. ` +
-            `Commit (or stash) the vault first, then undo again. See docs/profile.md.`,
+            `Commit (or stash) the vault first, then undo again. See docs/explanation/profile.md.`,
         );
         return;
       }

--- a/packages/obsidian-plugin/src/presentation/settings/ExocortexSettingTab.ts
+++ b/packages/obsidian-plugin/src/presentation/settings/ExocortexSettingTab.ts
@@ -729,7 +729,7 @@ export class ExocortexSettingTab extends PluginSettingTab {
       text:
         "Adding an ontology to a profile is NOT transitive — listing pmbok " +
         "does not auto-add ems. Add each AssetSpace the profile needs " +
-        "explicitly. See docs/profile.md for the full model, examples, and " +
+        "explicitly. See docs/explanation/profile.md for the full model, examples, and " +
         "composition rules.",
     });
 

--- a/packages/obsidian-plugin/tests/unit/ProfileApplyManager.apply.test.ts
+++ b/packages/obsidian-plugin/tests/unit/ProfileApplyManager.apply.test.ts
@@ -646,7 +646,7 @@ describe("ProfileApplyManager.applyProfile", () => {
       // Names the affected flat path → canonical migration target.
       expect(warn).toContain(FLAT_EXO);
       expect(warn).toContain("assetspaces/kitelev/exoas-exo");
-      expect(warn).toContain("docs/profile.md");
+      expect(warn).toContain("docs/explanation/profile.md");
     });
 
     it("REVERT-VERIFY: no warn when no flat-mount folder exists on disk", async () => {


### PR DESCRIPTION
## Diátaxis Phase 5 — remove redirect stubs (one-release grace elapsed)

Final phase of the Diátaxis docs reorganization (RFC `docs/rfc/0001`, Phases 1-4 shipped #3597/#3598/#3600/#3601). Phase 2 (#3598) left a **4-line redirect stub** at every old flat `docs/*` path, promised "kept for one release". ~35 releases have elapsed → grace overdue. Andrey approved removal.

### What changed
- **Removed 20 verified redirect stubs** (each `> Moved to <new-path> … kept for one release`):
  - **17 top-level** `docs/*.md` — Getting-Started, Troubleshooting, WORKFLOW_CUSTOMIZATION, ONTOLOGY_EXTENSION, Plugin-Development-Guide, exosync, exosync-parallel-run, ROLLBACK_EXOQL_EVAL, PROPERTY_SCHEMA, SHACL_LITE_MAPPING, Performance-Guide, profile, CROSS_RUNTIME_PARITY, settings-homoiconization, AI-DEVELOPMENT-PATTERNS, FLAKY_POLICY, e2e-desktop.
  - **3 subdir** stubs (same Phase-2 grace) — `docs/api/Core-API.md`, `docs/ci/assetspace-shacl-gate.md`, `docs/rdf/ExoRDF-Mapping.md` (subdirs now empty/removed).
- **Kept `docs/TEST-PYRAMID.md`** — intentionally-kept stub (jest.config.js comments reference it by path), **not** a one-release grace stub → out of scope.
- Updated stale **code-string** references `docs/profile.md` → `docs/explanation/profile.md` in user-facing Notice messages (`ProfileApplyManager.ts` ×4, `ProfileCommands.ts` ×2, `ExocortexSettingTab.ts` ×1) + the matching test assertion (`ProfileApplyManager.apply.test.ts:649`).
- Updated `docs/README.md` (removed the "one-release redirect stub" note; dropped two deleted-dir prefixes from index labels) and `docs/TAXONOMY.md` (Phase-5 removal note in the scope paragraph + footer).
  - **Note:** `docs/TAXONOMY.md` shows a large diff because lint-staged `prettier --write` realigned the migration-table columns (auto, pre-commit). The only **logical** edits are the scope-para line + footer.

### Pre-check (verify-before-assert) — links updated BEFORE removal
- Verified **every** stub target holds real content (e.g. PROPERTY_SCHEMA→`reference/` 1452 lines, Getting-Started→`tutorials/` 610 lines).
- All `docs/` markdown links + non-docs refs already point to the new Diátaxis paths (RFC Phase 4). After removal: **0 dangling markdown links in `docs/`** (robust grep) → `docs-link-check` stays green.

### External deep-links
External deep-links to old paths — **accepted** (grace 35 releases elapsed, RFC 0001 Phase 2 one-release intent).

### Local verification (authoritative = CI)
- `npm run check:types` — 0 errors
- `eslint packages/obsidian-plugin/src` — clean
- `ProfileApplyManager.apply.test.ts` — 57/57 pass
- `validate-docs-properties.js` — 0 missing
- robust grep — 0 dangling refs / 0 broken docs links

WBS: tracked as `ems__Task` under the Diátaxis subproject (vault-exodev).
