### PR TITLE
feat(plugin): «Use default» button fills engine URL in Bootstrap modal

### DIFF
--- a/packages/obsidian-plugin/src/presentation/modals/BootstrapVaultModal.ts
+++ b/packages/obsidian-plugin/src/presentation/modals/BootstrapVaultModal.ts
@@ -9,11 +9,16 @@ export interface BootstrapVaultUrls {
  * example AND linked from the inline explainer (RFC 0002 §3.3 — "a link to the
  * floor repo"). Single source so the placeholder and the link never drift.
  *
- * EC7 note: this is a LINK + a greyed-out placeholder example, NOT a pre-fill.
- * The field starts empty (the `kitelev/exoas-*` repos materialise a specific
- * ontology and are not auto-filled as a generic default — see EC7 below); the
- * link only lets a user *view / fork* the public floor before they decide what
- * to enter.
+ * EC7 note: this is a LINK + a greyed-out placeholder example, NOT an
+ * *auto*-pre-fill. The field starts empty (the `kitelev/exoas-*` repos
+ * materialise a specific ontology and are not auto-filled as a generic default
+ * — see EC7 below); the link only lets a user *view / fork* the public floor
+ * before they decide what to enter.
+ *
+ * This same URL is ALSO the value the explicit «Use default» button writes into
+ * the field on click (directive 2026-06-20). That is an opt-in user action, so
+ * it does not violate EC7's no-*auto*-prefill rule — the field still starts
+ * empty; the user chooses to populate it.
  */
 export const PUBLIC_EXO_FLOOR_URL = "https://github.com/kitelev/exoas-exo";
 

--- a/packages/obsidian-plugin/src/presentation/modals/BootstrapVaultModal.ts
+++ b/packages/obsidian-plugin/src/presentation/modals/BootstrapVaultModal.ts
@@ -168,13 +168,43 @@ export class BootstrapVaultModal extends Modal {
     const fieldId = "bootstrap-vault-exo-url";
     const labelEl = wrap.createEl("label", { text: label });
     labelEl.setAttribute("for", fieldId);
-    const input = wrap.createEl("input", {
+    // The input and its inline «Use default» button share a row so the
+    // affordance sits next to the field (the label stays on its own line above).
+    const inputRow = wrap.createEl("div", {
+      cls: "bootstrap-vault-input-row",
+    });
+    const input = inputRow.createEl("input", {
       type: "text",
       placeholder,
       cls: "bootstrap-vault-input bootstrap-modal-input",
       // Screen-reader label mirrors the visible <label> so the field is named
       // even out of visual context (P16 a11y); id pairs with the label's for.
       attr: { id: fieldId, "aria-label": label },
+    });
+    // «Use default» — one-click fill of the public engine floor URL (directive
+    // Андрей 2026-06-20). EC7 is preserved: the field still STARTS empty (no
+    // auto-pre-fill); this is an explicit, opt-in user action that populates it.
+    // Reuses PUBLIC_EXO_FLOOR_URL (single source — no hardcoded dup). Pure DOM,
+    // so it works identically on desktop and mobile (no Platform gating).
+    const useDefaultBtn = inputRow.createEl("button", {
+      cls: "bootstrap-vault-use-default",
+      text: "Use default",
+      // type=button so it never acts as an implicit form-submit affordance;
+      // aria-label names the action out of visual context (P16 a11y).
+      attr: {
+        type: "button",
+        "aria-label": "Use the default public engine floor URL",
+      },
+    });
+    useDefaultBtn.addEventListener("click", () => {
+      input.value = PUBLIC_EXO_FLOOR_URL;
+      // A valid URL is now present — clear any stale validation error.
+      this.clearError();
+      try {
+        input.focus();
+      } catch {
+        /* focus is best-effort */
+      }
     });
     return input;
   }
@@ -194,6 +224,12 @@ export class BootstrapVaultModal extends Modal {
     if (this.errorEl === null) return;
     this.errorEl.textContent = message;
     this.errorEl.classList.add("is-visible");
+  }
+
+  private clearError(): void {
+    if (this.errorEl === null) return;
+    this.errorEl.textContent = "";
+    this.errorEl.classList.remove("is-visible");
   }
 
   override onClose(): void {

--- a/packages/obsidian-plugin/styles.css
+++ b/packages/obsidian-plugin/styles.css
@@ -6184,6 +6184,24 @@
   font-weight: var(--font-semibold, 600);
 }
 
+/* Directive 2026-06-20 — the «Use default» button sits inline next to the
+   engine-URL input: the input flex-grows, the button hugs its content. */
+.bootstrap-vault-input-row {
+  display: flex;
+  gap: 0.5em;
+  align-items: center;
+}
+
+.bootstrap-vault-input-row .bootstrap-vault-input {
+  flex: 1;
+  min-width: 0;
+}
+
+.bootstrap-vault-use-default {
+  flex: 0 0 auto;
+  white-space: nowrap;
+}
+
 .bootstrap-vault-note,
 .add-assetspace-note,
 .add-assetspace-preview {

--- a/packages/obsidian-plugin/tests/unit/presentation/modals/BootstrapModals.test.ts
+++ b/packages/obsidian-plugin/tests/unit/presentation/modals/BootstrapModals.test.ts
@@ -228,6 +228,57 @@ describe("BootstrapVaultModal", () => {
     findButton("Cancel")!.click();
     expect(result).toBeNull();
   });
+
+  // Directive (Андрей 2026-06-20): a «Use default» button next to the URL field
+  // one-click-fills the public engine floor URL. This is an EXPLICIT opt-in
+  // action — it does NOT change EC7 (the field still STARTS empty); it only
+  // populates on click. Revert-verify: removing the button / its handler makes
+  // these assertions FAIL.
+  it("«Use default» button fills the field with the public engine floor URL", () => {
+    new BootstrapVaultModal(fakeApp, () => undefined).open();
+    const input = document.querySelector("input") as HTMLInputElement;
+    // EC7 holds — the field starts empty (no auto-pre-fill).
+    expect(input.value).toBe("");
+    const useDefault = findButton("Use default");
+    expect(useDefault).toBeDefined();
+    useDefault!.click();
+    // Reuses the existing PUBLIC_EXO_FLOOR_URL constant (no hardcoded dup).
+    expect(input.value).toBe(PUBLIC_EXO_FLOOR_URL);
+    expect(input.value).toBe("https://github.com/kitelev/exoas-exo");
+  });
+
+  it("«Use default» → field then passes validation and Bootstrap resolves { exoUrl }", () => {
+    let result: { exoUrl: string } | null | undefined;
+    new BootstrapVaultModal(fakeApp, (r) => {
+      result = r;
+    }).open();
+    findButton("Use default")!.click();
+    findButton("Bootstrap")!.click();
+    expect(result).toEqual({ exoUrl: PUBLIC_EXO_FLOOR_URL });
+  });
+
+  it("a11y — «Use default» is a real <button type=button> with an aria-label (P16)", () => {
+    new BootstrapVaultModal(fakeApp, () => undefined).open();
+    const useDefault = findButton("Use default")!;
+    expect(useDefault.tagName).toBe("BUTTON");
+    // type=button so it never acts as an implicit form-submit affordance.
+    expect(useDefault.getAttribute("type")).toBe("button");
+    expect(useDefault.getAttribute("aria-label")).toBeTruthy();
+  });
+
+  it("«Use default» clears a prior validation error", () => {
+    new BootstrapVaultModal(fakeApp, () => undefined).open();
+    // Provoke the empty-field error first.
+    findButton("Bootstrap")!.click();
+    const errorEl = document.querySelector(
+      ".bootstrap-vault-error",
+    ) as HTMLElement;
+    expect(errorEl.textContent).toMatch(/required/i);
+    expect(errorEl.classList.contains("is-visible")).toBe(true);
+    // Filling a valid default URL clears the stale error.
+    findButton("Use default")!.click();
+    expect(errorEl.classList.contains("is-visible")).toBe(false);
+  });
 });
 
 // RFC 0002 §3.3 / P5 — the durable, in-context bootstrap result panel. Adds a


### PR DESCRIPTION
## What

Adds a **«Use default»** button next to the engine repository URL field in the **«Set up the engine»** (`BootstrapVaultModal`) onboarding modal. Clicking it one-click-fills the public engine floor URL `https://github.com/kitelev/exoas-exo`.

Directive (Андрей 2026-06-20): «В модальном окне Set up engine рядом с полем для ввода URL добавить кнопку "Use default", которая вставит в поле https://github.com/kitelev/exoas-exo».

## How

- New inline `bootstrap-vault-input-row` (flex) holds the input + button so the affordance sits next to the field.
- Click handler sets `input.value = PUBLIC_EXO_FLOOR_URL` — **reuses the existing constant** (no hardcoded dup), and clears any stale validation error.
- **EC7 preserved**: the field still STARTS empty (no auto-pre-fill). «Use default» is an explicit, opt-in user action — consistent with EC7's reasoning (the prior decision was only against *auto*-prefill).
- a11y (P16): real `<button type=button>` with an aria-label; keyboard-accessible. The existing 'no emoji-only button labels' a11y test covers it.
- **Desktop↔Mobile parity**: pure DOM, no `Platform` gating / Node / git.

## Tests (TDD)

4 new unit tests in `BootstrapModals.test.ts` (red→green verified):
- button exists + click fills `PUBLIC_EXO_FLOOR_URL` (= `https://github.com/kitelev/exoas-exo`)
- «Use default» → Bootstrap resolves `{ exoUrl }`
- a11y: real `<button type=button>` with aria-label
- «Use default» clears a prior validation error

Full modal + a11y suite **50/50 green**; typecheck + lint clean; archgate 21/21 (incl. MOBILE-004 desktop-parity).

Closes directive 2026-06-20.