### PR TITLE
feat(onboarding): 5-step EKA bootstrap wizard (registry+profiles, retire starter-registry)

### DIFF
--- a/docs/tutorials/Getting-Started.md
+++ b/docs/tutorials/Getting-Started.md
@@ -105,18 +105,21 @@ The plugin needs ontology files in your vault to enable layouts, action buttons,
 > - A clean bootstrap is **exo-only** (floor = `{exo}`) — the misleading second «exocmd» field was removed. The `exocmd` UI-command library (which generates the action buttons) is added afterwards: either explicitly via **"Add a knowledge pack"** (Step 2b below) or transitively when you **Apply** a profile.
 > - The URL above is a placeholder — you can point the field at your own fork.
 
-### Step 2b: Add the starter registry, then apply the starter profile (recommended)
+### Step 2b: Add the registry + profiles, then apply a profile (recommended)
 
-The fastest way to get a complete, working Areas → Projects → Tasks + Daily vault — **without** loading anyone's personal notes — is the **3-step onboarding** built on the **starter registry**:
+The fastest way to get a complete, working Areas → Projects → Tasks + Daily vault is the **EKA bootstrap flow** — add the public AssetSpace **registry** and **profiles**, then pick a profile to mount. (The first-run **"Exocortex: Setup (getting started)"** wizard walks you through these same steps with the URLs pre-filled.)
 
-1. **Set up the engine** → `exoas-exo` (Step 2 above; `exocmd` optional, since the profile pulls it).
-2. **Add the registry**: **Cmd/Ctrl + P → "Exocortex: Add a knowledge pack"** → enter
-   `https://github.com/kitelev/exoas-starter-registry`. This is a small public registry — it declares the starter AssetSpaces and a `starter` knowledge profile; it does **not** pull them yet.
-3. **Apply the profile**: **Cmd/Ctrl + P → "Exocortex: Apply profile"** → choose **`starter`**. The plugin materializes exactly the starter set — 7 AssetSpaces: `exo`, `exocmd`, `ems`, `ems-commands`, `period`, `period-commands`, `person` — and nothing else (no `shared-identities`, no personal data).
+1. **Add your token (optional)** → only needed if you'll mount **private** AssetSpaces. **Cmd/Ctrl + P → "Exocortex: Settings"** (or the wizard's first step) to save a GitHub PAT. Skip it for a fully-public vault.
+2. **Set up the engine** → `exoas-exo` (Step 2 above; the engine floor).
+3. **Add the AssetSpace registry**: **Cmd/Ctrl + P → "Exocortex: Add a knowledge pack"** → enter
+   `https://github.com/kitelev/exoas-registry`. This public registry declares every AssetSpace and its `dependsOn` graph — so a later **Apply profile** can resolve any profile's full dependency closure. It does **not** pull those AssetSpaces yet.
+4. **Add the profiles AssetSpace**: **"Exocortex: Add a knowledge pack"** → enter
+   `https://github.com/kitelev/exoas-profiles`. This public AssetSpace declares the knowledge profiles you'll pick from in the next step.
+5. **Apply a profile**: **Cmd/Ctrl + P → "Exocortex: Apply profile"** → choose one. The plugin resolves that profile's `exo__AssetSpace_dependsOn` closure against the registry you added and materializes exactly its effective set. A fully-public choice is **`$$core`** (mounts only `exo`, no token needed); a personal profile (e.g. `$$kitelev-my`) needs the token from step 1 to pull its private AssetSpaces.
 
-> **Why this path**: the `starter` profile mounts only what a fresh vault needs (floor = `{exo}`), so first-run indexing is fast and your vault stays free of unrelated assets. You can still add more AssetSpaces later via **"Add a knowledge pack"** — dependencies are **not** pulled automatically.
+> **Why add the registry first**: a single **Add a knowledge pack** pulls only that one AssetSpace — it does **not** follow `dependsOn` transitively. **Apply profile** resolves the closure only over descriptors already in your vault, so the registry (all descriptors) and profiles must be present before you apply. This is the standard EKA bootstrap order.
 
-> **⚠️ Git-backed vault? Commit before the first Apply.** If your vault is a git repository, Bootstrap + Add-AssetSpace leave the pulled `assetspaces/` as **untracked** files, and **Apply profile** refuses to unmount an AssetSpace with uncommitted changes (it never silently destroys un-pushed work) — you'll see `Apply aborted — N uncommitted file(s) …`. Before step 3, commit the vault once from a terminal at the vault root:
+> **⚠️ Git-backed vault? Commit before the first Apply.** If your vault is a git repository, Bootstrap + Add-AssetSpace leave the pulled `assetspaces/` as **untracked** files, and **Apply profile** refuses to unmount an AssetSpace with uncommitted changes (it never silently destroys un-pushed work) — you'll see `Apply aborted — N uncommitted file(s) …`. Before step 5, commit the vault once from a terminal at the vault root:
 >
 > ```bash
 > # First add a .gitignore so your PAT (data.local.json) is never committed.
@@ -126,7 +129,7 @@ The fastest way to get a complete, working Areas → Projects → Tasks + Daily 
 > git add -A && git commit -m "vault setup"
 > ```
 >
-> Then run **"Exocortex: Apply profile"**. (The starter profile is all-public, so no PAT is needed — but gitignoring `.obsidian/` is still the right habit for when you add a private profile later.) See [Profile → Apply on a git-backed vault](../explanation/profile.md) for details.
+> Then run **"Exocortex: Apply profile"**. (The `$$core` profile is all-public, so no PAT is needed — but gitignoring `.obsidian/` is still the right habit for when you apply a private profile later.) See [Profile → Apply on a git-backed vault](../explanation/profile.md) for details.
 
 ### Step 3: Verify Installation
 

--- a/packages/obsidian-plugin/src/ExocortexPlugin.ts
+++ b/packages/obsidian-plugin/src/ExocortexPlugin.ts
@@ -163,8 +163,8 @@ import {
   registerOnboardingCommands,
   shouldShowFirstRunPanel,
   persistOnboardingPat,
-  STARTER_REGISTRY_URL,
-  STARTER_PROFILE_QUERY,
+  REGISTRY_ASSETSPACE_URL,
+  PROFILES_ASSETSPACE_URL,
 } from "./infrastructure/adapters/firstRunOnboarding";
 import {
   GROOMED_COMMAND_NAMES,
@@ -3510,15 +3510,22 @@ export default class ExocortexPlugin extends Plugin {
           }
           void bootstrapCommands.invokeBootstrap();
         },
-        onAddStarter: () => {
+        onAddRegistry: () => {
           if (bootstrapCommands === null) {
-            unavailable("Add starter content");
+            unavailable("Add the AssetSpace registry");
             return;
           }
-          void bootstrapCommands.invokeAddAssetSpace(STARTER_REGISTRY_URL);
+          void bootstrapCommands.invokeAddAssetSpace(REGISTRY_ASSETSPACE_URL);
         },
-        onApplyStarterProfile: () => {
-          void profileCommands.invokeApplyProfile(STARTER_PROFILE_QUERY);
+        onAddProfiles: () => {
+          if (bootstrapCommands === null) {
+            unavailable("Add the profiles AssetSpace");
+            return;
+          }
+          void bootstrapCommands.invokeAddAssetSpace(PROFILES_ASSETSPACE_URL);
+        },
+        onApplyProfile: () => {
+          void profileCommands.invokeApplyProfile();
         },
         onClosePanel: () => {
           void localDataStore.setOnboardingCompleted(true).catch((err) => {
@@ -3765,12 +3772,13 @@ export default class ExocortexPlugin extends Plugin {
       // ON TOP of the (transient) toast + (always-on) activity-log entry, so the
       // user can read "what happened + what next" after the toast fades. The
       // next-step nudge routes to the same Add-AssetSpace flow the onboarding
-      // panel's step 2 uses, pre-filled with the public starter registry
-      // (`bootstrapCommands` is in scope by the time this closure runs).
+      // panel's step 3 uses, pre-filled with the public EKA registry — the
+      // natural next step after bootstrapping the exo floor (`bootstrapCommands`
+      // is in scope by the time this closure runs).
       showResult: (result) =>
         new BootstrapResultModal(this.app, result, {
           onAddStarterContent: () =>
-            void bootstrapCommands.invokeAddAssetSpace(STARTER_REGISTRY_URL),
+            void bootstrapCommands.invokeAddAssetSpace(REGISTRY_ASSETSPACE_URL),
           // RFC 0002 §3.10 — one-click retry of the failed operation: re-open
           // the same Bootstrap / Add flow (its modal collects the URL again) so
           // the user can fix the URL / token / connection and retry in place.

--- a/packages/obsidian-plugin/src/ExocortexPlugin.ts
+++ b/packages/obsidian-plugin/src/ExocortexPlugin.ts
@@ -3812,8 +3812,8 @@ export default class ExocortexPlugin extends Plugin {
     });
 
     // Returned so `registerProfileCommands` can wire the first-run onboarding
-    // panel's step-1 (Bootstrap) and step-2 (Add starter content, prefilled)
-    // actions to this same handler — RFC 0002 §3.1.
+    // panel's step-2 (Bootstrap exo) and steps 3-4 (Add registry / profiles,
+    // prefilled) actions to this same handler — RFC 0002 §3.1.
     return bootstrapCommands;
   }
 

--- a/packages/obsidian-plugin/src/ExocortexPlugin.ts
+++ b/packages/obsidian-plugin/src/ExocortexPlugin.ts
@@ -3777,7 +3777,7 @@ export default class ExocortexPlugin extends Plugin {
       // is in scope by the time this closure runs).
       showResult: (result) =>
         new BootstrapResultModal(this.app, result, {
-          onAddStarterContent: () =>
+          onAddRegistry: () =>
             void bootstrapCommands.invokeAddAssetSpace(REGISTRY_ASSETSPACE_URL),
           // RFC 0002 §3.10 — one-click retry of the failed operation: re-open
           // the same Bootstrap / Add flow (its modal collects the URL again) so

--- a/packages/obsidian-plugin/src/infrastructure/adapters/BootstrapAssetSpaceCommands.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/BootstrapAssetSpaceCommands.ts
@@ -216,7 +216,7 @@ export interface BootstrapAssetSpaceCommandsDeps {
    * Open the add-AssetSpace modal (single URL field). Resolves the entered
    * URL, or null if the user cancelled. `prefillUrl` (optional) pre-fills the
    * field — used by the first-run onboarding panel to offer the recommended
-   * `exoas-starter-registry` URL (RFC 0002 §3.1 step 2); the user still confirms.
+   * EKA registry / profiles URL (RFC 0002 §3.1 steps 3-4); the user still confirms.
    */
   promptAddAssetSpaceUrl: (
     prefillUrl?: string,
@@ -366,8 +366,8 @@ export class BootstrapAssetSpaceCommands {
    * Command 2 — `Exocortex: Add AssetSpace by URL`.
    *
    * `prefillUrl` (optional) pre-fills the modal field — the first-run
-   * onboarding panel passes the public `exoas-starter-registry` URL here
-   * (RFC 0002 §3.1 step 2). The user still reviews + confirms in the modal;
+   * onboarding panel passes the public EKA registry / profiles URL here
+   * (RFC 0002 §3.1 steps 3-4). The user still reviews + confirms in the modal;
    * the materialisation path below is unchanged.
    */
   async invokeAddAssetSpace(prefillUrl?: string): Promise<void> {

--- a/packages/obsidian-plugin/src/infrastructure/adapters/firstRunOnboarding.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/firstRunOnboarding.ts
@@ -11,21 +11,28 @@
 import type { VaultBootstrapState } from "./BootstrapAssetSpaceCommands";
 
 /**
- * The public, stable starter-content registry pre-filled into step 2 of the
- * onboarding panel. Unlike the Bootstrap floor URL (kept empty per EC7 — the
- * `kitelev/exoas-*` repos are Andrey's own ontology, not a generic floor), this
- * registry IS genuinely recommended for every new tester, so pre-filling it is
- * a deliberate UX affordance and not an EC7 conflict (RFC 0002 §3.1 / §3.3).
+ * The EKA AssetSpace **registry** (`kitelev/exoas-registry`) — the catalog of
+ * `exo__AssetSpace` descriptors + their `dependsOn` DAG (EKA D18). Pre-filled
+ * into the "Add the AssetSpace registry" onboarding step. Adding it lands every
+ * descriptor in the vault so a later "Apply profile" can resolve a chosen
+ * profile's `dependsOn` closure (the descriptors carry the `_source` URLs the
+ * apply step materialises from). Public — pulls anonymously; the PAT (step 1) is
+ * only needed for the *private* leaf AssetSpaces a chosen profile pulls
+ * (RFC 0002 §3.1 / EKA D12 bootstrap: bootstrap exo → add registry → add
+ * profiles → apply profile).
  */
-export const STARTER_REGISTRY_URL =
-  "https://github.com/kitelev/exoas-starter-registry";
+export const REGISTRY_ASSETSPACE_URL =
+  "https://github.com/kitelev/exoas-registry";
 
 /**
- * Initial fuzzy-filter query for step 3's profile picker, so the canonical
- * `starter` profile surfaces first (RFC 0002 §3.1 step 3 / §3.4). The picker
- * still lists all profiles — the query just pre-narrows it.
+ * The EKA **profiles** AssetSpace (`kitelev/exoas-profiles`) — the
+ * `exo__Profile` instances. Pre-filled into the "Add the profiles AssetSpace"
+ * onboarding step. Adding it lands the profile assets in the vault so the final
+ * "Apply profile" step can list + pick one (the picker shows every profile in
+ * the vault). Public — pulls anonymously.
  */
-export const STARTER_PROFILE_QUERY = "starter";
+export const PROFILES_ASSETSPACE_URL =
+  "https://github.com/kitelev/exoas-profiles";
 
 /**
  * The most markdown notes a vault may hold and still count as a genuinely

--- a/packages/obsidian-plugin/src/presentation/modals/AddAssetSpaceModal.ts
+++ b/packages/obsidian-plugin/src/presentation/modals/AddAssetSpaceModal.ts
@@ -21,8 +21,8 @@ export interface AddAssetSpaceInput {
  * exactly once.
  *
  * An optional `initialUrl` pre-fills the field — used by the first-run
- * onboarding panel (RFC 0002 §3.1 step 2) to offer the public, stable
- * `exoas-starter-registry` URL one click away. The user still confirms; a
+ * onboarding panel (RFC 0002 §3.1 steps 3-4) to offer the public, stable
+ * EKA registry / profiles URL one click away. The user still confirms; a
  * pre-fill is a recommended default, not an auto-action.
  */
 export class AddAssetSpaceModal extends Modal {

--- a/packages/obsidian-plugin/src/presentation/modals/BootstrapResultModal.ts
+++ b/packages/obsidian-plugin/src/presentation/modals/BootstrapResultModal.ts
@@ -18,7 +18,7 @@ export interface BootstrapResultModalActions {
    * AssetSpace registry right away (the natural next step after bootstrapping
    * the exo floor). The user still reviews + confirms in that modal.
    */
-  onAddStarterContent: () => void;
+  onAddRegistry: () => void;
   /**
    * Failure recovery (§3.10) — re-run the operation that failed (bootstrap OR
    * add-AssetSpace), so a wrong URL / dropped network / mis-scoped token is one
@@ -137,7 +137,7 @@ export class BootstrapResultModal extends Modal {
       );
       nextBtn.addEventListener("click", () => {
         this.close();
-        this.actions.onAddStarterContent();
+        this.actions.onAddRegistry();
       });
       this.firstFocusable = nextBtn;
     }

--- a/packages/obsidian-plugin/src/presentation/modals/BootstrapResultModal.ts
+++ b/packages/obsidian-plugin/src/presentation/modals/BootstrapResultModal.ts
@@ -14,8 +14,9 @@ import type {
 export interface BootstrapResultModalActions {
   /**
    * Next-step nudge (success outcomes, §3.3) — open «Add AssetSpace by URL»
-   * pre-filled with the public starter-registry URL so the user can pull the
-   * starter content right away. The user still reviews + confirms in that modal.
+   * pre-filled with the public EKA registry URL so the user can pull the
+   * AssetSpace registry right away (the natural next step after bootstrapping
+   * the exo floor). The user still reviews + confirms in that modal.
    */
   onAddStarterContent: () => void;
   /**
@@ -126,11 +127,13 @@ export class BootstrapResultModal extends Modal {
       // Success (§3.3) — the next-step nudge + one-click forward action.
       const nextBtn = actions.createEl("button", {
         cls: "mod-cta bootstrap-result-next-action",
-        text: "Add the starter content",
+        // eslint-disable-next-line obsidianmd/ui/sentence-case -- "AssetSpace" is the product's domain term (same casing as the "Add AssetSpace by URL" command)
+        text: "Add the AssetSpace registry",
       });
       nextBtn.setAttribute(
         "aria-label",
-        "Add the starter content (opens a dialog pre-filled with the recommended starter registry)",
+        // eslint-disable-next-line obsidianmd/ui/sentence-case -- "AssetSpace" + "EKA" are product domain terms (matches the "Add AssetSpace by URL" command)
+        "Add the AssetSpace registry (opens a dialog pre-filled with the recommended EKA registry)",
       );
       nextBtn.addEventListener("click", () => {
         this.close();
@@ -183,8 +186,8 @@ export function resultCopy(result: BootstrapResultInfo): ResultCopy {
           `The engine floor landed — ${result.folderName} @ ${result.sha}. ` +
           "Reload Obsidian if the new assets do not appear yet.",
         nextHint:
-          "Next: add the starter content — a ready-to-use Areas → Projects → " +
-          "Tasks structure.",
+          "Next: add the AssetSpace registry — the catalog of AssetSpaces and " +
+          "profiles you'll pick from to mount a working vault.",
       };
     case "fetched":
       return {
@@ -193,8 +196,8 @@ export function resultCopy(result: BootstrapResultInfo): ResultCopy {
           `Restored ${result.fetched} of ${result.total} tracked AssetSpace(s) ` +
           "from their recorded URLs.",
         nextHint:
-          "Next: add the starter content, or apply a profile to mount what you " +
-          "need.",
+          "Next: add the AssetSpace registry, or apply a profile to mount what " +
+          "you need.",
       };
     case "already-bootstrapped":
       return {
@@ -203,7 +206,7 @@ export function resultCopy(result: BootstrapResultInfo): ResultCopy {
           "This vault already has AssetSpaces materialised — there is nothing " +
           "to bootstrap.",
         nextHint:
-          "Next: add the starter content, or use «Add AssetSpace by URL» to " +
+          "Next: add the AssetSpace registry, or use «Add AssetSpace by URL» to " +
           "pull another AssetSpace.",
       };
     case "failed":

--- a/packages/obsidian-plugin/src/presentation/modals/FirstRunOnboardingModal.ts
+++ b/packages/obsidian-plugin/src/presentation/modals/FirstRunOnboardingModal.ts
@@ -6,10 +6,14 @@ import {
 } from "../settings/patConnectionTest";
 
 /**
- * Action callbacks for the four onboarding steps + a one-time-close hook. The
+ * Action callbacks for the five onboarding steps + a one-time-close hook. The
  * panel is a thin, decoupled UI scaffold (RFC 0002 §3.1) — it owns no business
  * logic; each step just fires the injected action, which the plugin wires to the
- * existing Save-PAT / Bootstrap / Add-AssetSpace / Apply-profile flows.
+ * existing Save-PAT / Bootstrap / Add-AssetSpace / Apply-profile flows. The
+ * materialise steps follow the EKA D12 bootstrap order: bootstrap the exo SDK
+ * floor → add the AssetSpace registry → add the profiles AssetSpace → apply a
+ * chosen profile (which resolves its `dependsOn` closure over the now-present
+ * registry descriptors).
  */
 export interface FirstRunOnboardingActions {
   /**
@@ -38,12 +42,14 @@ export interface FirstRunOnboardingActions {
    * Never rejects — a rejected token / network error resolves `{ ok: false }`.
    */
   onTestPat?: (pat: string) => Promise<PatConnectionResult>;
-  /** Step 2 — open the Bootstrap dialog (fields stay empty per EC7). */
+  /** Step 2 — open the Bootstrap dialog for the exo SDK floor (fields stay empty per EC7). */
   onSetupEngine: () => void;
-  /** Step 3 — open Add-AssetSpace pre-filled with the starter registry URL. */
-  onAddStarter: () => void;
-  /** Step 4 — open the profile picker narrowed to the `starter` profile. */
-  onApplyStarterProfile: () => void;
+  /** Step 3 — open Add-AssetSpace pre-filled with the EKA registry URL. */
+  onAddRegistry: () => void;
+  /** Step 4 — open Add-AssetSpace pre-filled with the EKA profiles URL. */
+  onAddProfiles: () => void;
+  /** Step 5 — open the profile picker (lists every profile; user picks one). */
+  onApplyProfile: () => void;
   /**
    * Fired exactly once when the panel closes (any path: button, Esc, click-out).
    * Used to persist the device-local "onboarding completed" flag so the panel
@@ -66,21 +72,23 @@ interface StepSpec {
  * (RFC 0002 §3.1, resolves P1 first-run-has-zero-orientation + P2
  * sequence-not-discoverable).
  *
- * Renders a 4-step checklist that drives the canonical **starter** path:
+ * Renders a 5-step checklist that drives the EKA D12 bootstrap path:
  *   1. Add your GitHub token (OPTIONAL) → saves the PAT device-local FIRST so
  *      the later steps can clone/pull private `exoas-*` repos (cd9444bd)
- *   2. Set up the engine        → Bootstrap dialog (3.3)
- *   3. Add the starter content  → Add-AssetSpace pre-filled with the registry
- *   4. Apply the starter profile → profile picker on `starter` (3.4)
+ *   2. Set up the engine          → Bootstrap the exo SDK floor (3.3)
+ *   3. Add the AssetSpace registry → Add-AssetSpace pre-filled with exoas-registry
+ *   4. Add the profiles AssetSpace → Add-AssetSpace pre-filled with exoas-profiles
+ *   5. Apply a profile            → profile picker (lists every profile; pick one)
  *
  * ## Why the token step is FIRST (cd9444bd)
  *
  * Bootstrap / Add-AssetSpace / Apply-profile can pull **private** `exoas-*`
  * repos, which need a GitHub PAT to clone/pull. The materialise paths read the
  * token fresh at command-execution time (Issue #3382), so a token saved in
- * step 1 is in place by the time steps 2-4 run. The step is **optional**: a
+ * step 1 is in place by the time steps 2-5 run. The step is **optional**: a
  * public-only tester skips it (leaves it blank, moves to step 2) and the
- * materialise steps pull anonymously — the public flow is never blocked.
+ * materialise steps pull anonymously (the public registry + profiles, and a
+ * fully-public profile such as `$$core`) — the public flow is never blocked.
  *
  * The step sub-dialogs stack ON TOP of this panel (Obsidian modal stacking), so
  * the panel stays open underneath and the user can walk the sequence without
@@ -90,7 +98,7 @@ interface StepSpec {
  *
  * ## Accessibility (P16, §3.11)
  *
- * - Steps are a semantic `<ol>` so assistive tech announces "list, 4 items".
+ * - Steps are a semantic `<ol>` so assistive tech announces "list, 5 items".
  * - Each action is a native `<button>` (keyboard-navigable + Enter/Space
  *   activation for free) with an explicit `aria-label`; the token field is a
  *   native `<input>` with an `aria-label`.
@@ -150,22 +158,34 @@ export class FirstRunOnboardingModal extends Modal {
       },
       {
         marker: "Step 3",
-        title: "Add the starter content",
+        title: "Add the AssetSpace registry",
         description:
-          "Pull the public starter registry — a curated set of AssetSpaces that gives " +
-          "you a ready-to-use Areas → Projects → Tasks structure. The recommended URL is " +
-          "pre-filled for you; just confirm.",
-        actionLabel: "Add the starter content",
-        action: this.actions.onAddStarter,
+          "Pull the public registry — the catalog of every AssetSpace and the " +
+          "knowledge profiles that group them. The recommended URL is pre-filled; " +
+          "just confirm. It's public, so no token is needed for this step.",
+        actionLabel: "Add the AssetSpace registry",
+        action: this.actions.onAddRegistry,
       },
       {
         marker: "Step 4",
-        title: "Apply the starter profile",
+        title: "Add the profiles AssetSpace",
         description:
-          "Materialise the «starter» profile — it mounts the AssetSpaces the starter " +
-          "content needs. The picker opens narrowed to «starter»; select it to finish.",
-        actionLabel: "Apply the starter profile",
-        action: this.actions.onApplyStarterProfile,
+          "Pull the public profiles AssetSpace — the knowledge profiles you'll pick " +
+          "from in the next step. The recommended URL is pre-filled; just confirm. " +
+          "Public, so no token is needed here either.",
+        actionLabel: "Add the profiles AssetSpace",
+        action: this.actions.onAddProfiles,
+      },
+      {
+        marker: "Step 5",
+        title: "Apply a profile",
+        description:
+          "Pick a knowledge profile to materialise — it mounts the AssetSpaces that " +
+          "profile needs (resolving them through the registry you just added). Your " +
+          "own private profile needs the token from step 1; the public «$$core» " +
+          "profile (exo only) works with no token.",
+        actionLabel: "Apply a profile",
+        action: this.actions.onApplyProfile,
       },
     ];
 
@@ -326,7 +346,7 @@ export class FirstRunOnboardingModal extends Modal {
     }
   }
 
-  /** Render a generic single-action step (steps 2-4). */
+  /** Render a generic single-action step (steps 2-5). */
   private renderActionStep(list: HTMLElement, step: StepSpec): void {
     const item = list.createEl("li", { cls: "exocortex-onboarding-step" });
 

--- a/packages/obsidian-plugin/tests/unit/firstRunOnboarding.test.ts
+++ b/packages/obsidian-plugin/tests/unit/firstRunOnboarding.test.ts
@@ -17,8 +17,8 @@ import {
   persistOnboardingPat,
   PAT_SECRET_KEY,
   SETUP_COMMAND_ID,
-  STARTER_REGISTRY_URL,
-  STARTER_PROFILE_QUERY,
+  REGISTRY_ASSETSPACE_URL,
+  PROFILES_ASSETSPACE_URL,
   FRESH_VAULT_MAX_NOTES,
   type OnboardingCommandRegistrar,
   type OnboardingSecretsStore,
@@ -83,15 +83,17 @@ describe("shouldShowFirstRunPanel — first-run detection (RFC 0002 §3.1)", () 
   );
 });
 
-describe("starter-path constants", () => {
-  it("pre-fills the public starter registry (no EC7 conflict)", () => {
-    expect(STARTER_REGISTRY_URL).toBe(
-      "https://github.com/kitelev/exoas-starter-registry",
+describe("EKA bootstrap-path constants (RFC 0002 §3.1 / EKA D12)", () => {
+  it("pre-fills the public EKA AssetSpace registry for step 3", () => {
+    expect(REGISTRY_ASSETSPACE_URL).toBe(
+      "https://github.com/kitelev/exoas-registry",
     );
   });
 
-  it("narrows the profile picker to the canonical starter profile", () => {
-    expect(STARTER_PROFILE_QUERY).toBe("starter");
+  it("pre-fills the public EKA profiles AssetSpace for step 4", () => {
+    expect(PROFILES_ASSETSPACE_URL).toBe(
+      "https://github.com/kitelev/exoas-profiles",
+    );
   });
 });
 

--- a/packages/obsidian-plugin/tests/unit/infrastructure/adapters/BootstrapAssetSpaceCommands.test.ts
+++ b/packages/obsidian-plugin/tests/unit/infrastructure/adapters/BootstrapAssetSpaceCommands.test.ts
@@ -462,11 +462,11 @@ describe("BootstrapAssetSpaceCommands.invokeAddAssetSpace", () => {
     expect(h.notices.some((n) => /invalid URL/i.test(n))).toBe(true);
   });
 
-  // RFC 0002 §3.1 step 2 — the onboarding panel calls
+  // RFC 0002 §3.1 steps 3-4 — the onboarding panel calls
   // invokeAddAssetSpace(prefillUrl) so the modal opens with the recommended
-  // `exoas-starter-registry` URL pre-filled. The prefill must reach the prompt.
-  it("forwards prefillUrl to the prompt (onboarding §3.1 step 2)", async () => {
-    const REGISTRY = "https://github.com/kitelev/exoas-starter-registry";
+  // EKA registry / profiles URL pre-filled. The prefill must reach the prompt.
+  it("forwards prefillUrl to the prompt (onboarding §3.1 steps 3-4)", async () => {
+    const REGISTRY = "https://github.com/kitelev/exoas-registry";
     const h = makeHarness({ isGitVault: true });
     await h.cmds.invokeAddAssetSpace(REGISTRY);
     expect(h.deps.promptAddAssetSpaceUrl).toHaveBeenCalledWith(REGISTRY);

--- a/packages/obsidian-plugin/tests/unit/presentation/modals/AddAssetSpaceModal.a11y.test.ts
+++ b/packages/obsidian-plugin/tests/unit/presentation/modals/AddAssetSpaceModal.a11y.test.ts
@@ -143,11 +143,11 @@ describe("AddAssetSpaceModal — accessibility (P16, §3.11)", () => {
     expect(document.activeElement).toBe(urlInput());
   });
 
-  it("focus lands on the field even when pre-filled (onboarding step 3)", () => {
-    open("https://github.com/kitelev/exoas-starter-registry");
+  it("focus lands on the field even when pre-filled (onboarding steps 3-4)", () => {
+    open("https://github.com/kitelev/exoas-registry");
     expect(document.activeElement).toBe(urlInput());
     expect(urlInput().value).toBe(
-      "https://github.com/kitelev/exoas-starter-registry",
+      "https://github.com/kitelev/exoas-registry",
     );
   });
 

--- a/packages/obsidian-plugin/tests/unit/presentation/modals/BootstrapModals.test.ts
+++ b/packages/obsidian-plugin/tests/unit/presentation/modals/BootstrapModals.test.ts
@@ -284,7 +284,7 @@ describe("BootstrapVaultModal", () => {
 // RFC 0002 §3.3 / P5 — the durable, in-context bootstrap result panel. Adds a
 // persistent surface ON TOP of the (already-firing) toast + activity log, with a
 // next-step nudge. Revert-verify: removing the panel's next-step button (or its
-// `onAddStarterContent` wiring) makes the next-step assertions FAIL.
+// `onAddRegistry` wiring) makes the next-step assertions FAIL.
 describe("BootstrapResultModal", () => {
   const BOOTSTRAPPED: BootstrapResultInfo = {
     kind: "bootstrapped",
@@ -294,7 +294,7 @@ describe("BootstrapResultModal", () => {
 
   it("bootstrapped — durable summary states what landed + a next-step nudge", () => {
     new BootstrapResultModal(fakeApp, BOOTSTRAPPED, {
-      onAddStarterContent: () => undefined,
+      onAddRegistry: () => undefined,
     }).open();
     const text = document.body.textContent ?? "";
     // Durable "what happened" — folder + sha survive the toast fade.
@@ -305,10 +305,10 @@ describe("BootstrapResultModal", () => {
     expect(text).toMatch(/AssetSpace registry/i);
   });
 
-  it("next-step button fires onAddStarterContent and closes the panel", () => {
+  it("next-step button fires onAddRegistry and closes the panel", () => {
     let nextCalls = 0;
     new BootstrapResultModal(fakeApp, BOOTSTRAPPED, {
-      onAddStarterContent: () => {
+      onAddRegistry: () => {
         nextCalls++;
       },
     }).open();
@@ -321,7 +321,7 @@ describe("BootstrapResultModal", () => {
   it("Done button closes without firing the next step", () => {
     let nextCalls = 0;
     new BootstrapResultModal(fakeApp, BOOTSTRAPPED, {
-      onAddStarterContent: () => {
+      onAddRegistry: () => {
         nextCalls++;
       },
     }).open();
@@ -334,7 +334,7 @@ describe("BootstrapResultModal", () => {
     new BootstrapResultModal(
       fakeApp,
       { kind: "already-bootstrapped" },
-      { onAddStarterContent: () => undefined },
+      { onAddRegistry: () => undefined },
     ).open();
     const text = document.body.textContent ?? "";
     expect(text).toMatch(/already/i);
@@ -347,7 +347,7 @@ describe("BootstrapResultModal", () => {
     new BootstrapResultModal(
       fakeApp,
       { kind: "fetched", fetched: 2, total: 3 },
-      { onAddStarterContent: () => undefined },
+      { onAddRegistry: () => undefined },
     ).open();
     const text = document.body.textContent ?? "";
     expect(text).toMatch(/2 of 3/);
@@ -356,7 +356,7 @@ describe("BootstrapResultModal", () => {
 
   it("a11y — both buttons carry explicit aria-labels (P16)", () => {
     new BootstrapResultModal(fakeApp, BOOTSTRAPPED, {
-      onAddStarterContent: () => undefined,
+      onAddRegistry: () => undefined,
     }).open();
     expect(
       findButton("Add the AssetSpace registry")!.getAttribute("aria-label"),
@@ -378,7 +378,7 @@ describe("BootstrapResultModal", () => {
 
   it("failed (auth) — surfaces the cause + a PAT recovery step", () => {
     new BootstrapResultModal(fakeApp, FAILED_AUTH, {
-      onAddStarterContent: () => undefined,
+      onAddRegistry: () => undefined,
     }).open();
     const text = document.body.textContent ?? "";
     expect(text).toMatch(/didn't finish/i);
@@ -391,7 +391,7 @@ describe("BootstrapResultModal", () => {
   it("failed — «Try again» fires onRetry with the failing operation + closes", () => {
     const retried: string[] = [];
     new BootstrapResultModal(fakeApp, FAILED_AUTH, {
-      onAddStarterContent: () => undefined,
+      onAddRegistry: () => undefined,
       onRetry: (op) => retried.push(op),
     }).open();
     findButton("Try again")!.click();
@@ -409,7 +409,7 @@ describe("BootstrapResultModal", () => {
         cause: "bad-url",
         detail: "Invalid GitHub repo URL: x",
       },
-      { onAddStarterContent: () => undefined, onRetry: (op) => retried.push(op) },
+      { onAddRegistry: () => undefined, onRetry: (op) => retried.push(op) },
     ).open();
     const text = document.body.textContent ?? "";
     expect(text).toMatch(/check the URL/i);
@@ -419,7 +419,7 @@ describe("BootstrapResultModal", () => {
 
   it("failed without onRetry wired — still renders (cause + Dismiss), no crash", () => {
     new BootstrapResultModal(fakeApp, FAILED_AUTH, {
-      onAddStarterContent: () => undefined,
+      onAddRegistry: () => undefined,
     }).open();
     expect(findButton("Try again")).toBeUndefined();
     // The Done button is labelled «Dismiss» on a failure panel.

--- a/packages/obsidian-plugin/tests/unit/presentation/modals/BootstrapModals.test.ts
+++ b/packages/obsidian-plugin/tests/unit/presentation/modals/BootstrapModals.test.ts
@@ -300,9 +300,9 @@ describe("BootstrapResultModal", () => {
     // Durable "what happened" — folder + sha survive the toast fade.
     expect(text).toMatch(/assetspaces\/kitelev\/exoas-exo/);
     expect(text).toMatch(/abc1234/);
-    // "What next" nudge points at the starter content.
+    // "What next" nudge points at the EKA registry (the post-bootstrap step).
     expect(text).toMatch(/Next:/);
-    expect(text).toMatch(/starter content/i);
+    expect(text).toMatch(/AssetSpace registry/i);
   });
 
   it("next-step button fires onAddStarterContent and closes the panel", () => {
@@ -312,7 +312,7 @@ describe("BootstrapResultModal", () => {
         nextCalls++;
       },
     }).open();
-    findButton("Add the starter content")!.click();
+    findButton("Add the AssetSpace registry")!.click();
     expect(nextCalls).toBe(1);
     // Panel closed (handed off to the Add-AssetSpace flow) — content torn down.
     expect(document.querySelector(".bootstrap-result-title")).toBeNull();
@@ -340,7 +340,7 @@ describe("BootstrapResultModal", () => {
     expect(text).toMatch(/already/i);
     expect(text).toMatch(/Next:/);
     // The forward action is still offered.
-    expect(findButton("Add the starter content")).toBeDefined();
+    expect(findButton("Add the AssetSpace registry")).toBeDefined();
   });
 
   it("fetched — durable restore summary with the count + next-step nudge", () => {
@@ -359,8 +359,8 @@ describe("BootstrapResultModal", () => {
       onAddStarterContent: () => undefined,
     }).open();
     expect(
-      findButton("Add the starter content")!.getAttribute("aria-label"),
-    ).toMatch(/Add the starter content/i);
+      findButton("Add the AssetSpace registry")!.getAttribute("aria-label"),
+    ).toMatch(/Add the AssetSpace registry/i);
     expect(findButton("Done")!.getAttribute("aria-label")).toMatch(
       /Close the setup result/i,
     );
@@ -385,7 +385,7 @@ describe("BootstrapResultModal", () => {
     expect(text).toMatch(/rejected the request/i);
     expect(text).toMatch(/GitHub PAT/);
     // No success nudge on a failure panel.
-    expect(findButton("Add the starter content")).toBeUndefined();
+    expect(findButton("Add the AssetSpace registry")).toBeUndefined();
   });
 
   it("failed — «Try again» fires onRetry with the failing operation + closes", () => {
@@ -551,8 +551,8 @@ describe("AddAssetSpaceModal", () => {
     expect(result).toEqual({ url: "https://github.com/me/thing" });
   });
 
-  it("initialUrl pre-fills the field + live-previews it (onboarding §3.1 step 2)", () => {
-    const REGISTRY = "https://github.com/kitelev/exoas-starter-registry";
+  it("initialUrl pre-fills the field + live-previews it (onboarding §3.1 steps 3-4)", () => {
+    const REGISTRY = "https://github.com/kitelev/exoas-registry";
     new AddAssetSpaceModal(fakeApp, derive, () => undefined, REGISTRY).open();
     const input = document.querySelector("input") as HTMLInputElement;
     // The recommended registry URL is pre-filled; the user still confirms.
@@ -563,12 +563,12 @@ describe("AddAssetSpaceModal", () => {
     ) as HTMLElement;
     expect(preview.classList.contains("is-placeholder")).toBe(false);
     expect(preview.textContent).toMatch(
-      /Target folder: assetspaces\/kitelev\/exoas-starter-registry/,
+      /Target folder: assetspaces\/kitelev\/exoas-registry/,
     );
   });
 
   it("pre-filled URL → Add resolves it without retyping", () => {
-    const REGISTRY = "https://github.com/kitelev/exoas-starter-registry";
+    const REGISTRY = "https://github.com/kitelev/exoas-registry";
     let result: { url: string } | null | undefined;
     new AddAssetSpaceModal(
       fakeApp,

--- a/packages/obsidian-plugin/tests/unit/presentation/modals/FirstRunOnboardingModal.test.ts
+++ b/packages/obsidian-plugin/tests/unit/presentation/modals/FirstRunOnboardingModal.test.ts
@@ -89,8 +89,9 @@ function makeActions(over: Partial<FirstRunOnboardingActions> = {}): {
     },
     onPastePat: async () => "github_pat_pasted",
     onSetupEngine: () => calls.push("engine"),
-    onAddStarter: () => calls.push("starter"),
-    onApplyStarterProfile: () => calls.push("profile"),
+    onAddRegistry: () => calls.push("registry"),
+    onAddProfiles: () => calls.push("profiles"),
+    onApplyProfile: () => calls.push("profile"),
     onClosePanel: () => calls.push("close"),
     ...over,
   };
@@ -114,7 +115,7 @@ beforeEach(() => {
 });
 
 describe("FirstRunOnboardingModal", () => {
-  it("renders the welcome heading + a 4-step ordered checklist (token-first)", () => {
+  it("renders the welcome heading + a 5-step ordered checklist (token-first)", () => {
     const { actions } = makeActions();
     new FirstRunOnboardingModal(fakeApp, actions).open();
 
@@ -125,10 +126,10 @@ describe("FirstRunOnboardingModal", () => {
     const list = document.querySelector("ol.exocortex-onboarding-steps");
     expect(list).not.toBeNull();
     const items = document.querySelectorAll("li.exocortex-onboarding-step");
-    expect(items).toHaveLength(4);
+    expect(items).toHaveLength(5);
 
     // Each step has a plain-text marker (not a glyph) — P16. Step 1 is the
-    // optional token step (cd9444bd), then the three materialise steps.
+    // optional token step (cd9444bd), then the four EKA materialise steps.
     const markers = Array.from(
       document.querySelectorAll(".exocortex-onboarding-step-marker"),
     ).map((m) => m.textContent);
@@ -137,27 +138,35 @@ describe("FirstRunOnboardingModal", () => {
       "Step 2 — ",
       "Step 3 — ",
       "Step 4 — ",
+      "Step 5 — ",
     ]);
   });
 
-  it("step 1 button fires onSetupEngine (opens Bootstrap)", () => {
+  it("step 2 button fires onSetupEngine (opens Bootstrap)", () => {
     const { actions, calls } = makeActions();
     new FirstRunOnboardingModal(fakeApp, actions).open();
     findButton("Set up the engine")!.click();
     expect(calls).toEqual(["engine"]);
   });
 
-  it("step 2 button fires onAddStarter (Add starter content)", () => {
+  it("step 3 button fires onAddRegistry (Add the AssetSpace registry)", () => {
     const { actions, calls } = makeActions();
     new FirstRunOnboardingModal(fakeApp, actions).open();
-    findButton("Add the starter content")!.click();
-    expect(calls).toEqual(["starter"]);
+    findButton("Add the AssetSpace registry")!.click();
+    expect(calls).toEqual(["registry"]);
   });
 
-  it("step 3 button fires onApplyStarterProfile (Apply starter profile)", () => {
+  it("step 4 button fires onAddProfiles (Add the profiles AssetSpace)", () => {
     const { actions, calls } = makeActions();
     new FirstRunOnboardingModal(fakeApp, actions).open();
-    findButton("Apply the starter profile")!.click();
+    findButton("Add the profiles AssetSpace")!.click();
+    expect(calls).toEqual(["profiles"]);
+  });
+
+  it("step 5 button fires onApplyProfile (Apply a profile)", () => {
+    const { actions, calls } = makeActions();
+    new FirstRunOnboardingModal(fakeApp, actions).open();
+    findButton("Apply a profile")!.click();
     expect(calls).toEqual(["profile"]);
   });
 
@@ -167,12 +176,13 @@ describe("FirstRunOnboardingModal", () => {
     const actionButtons = Array.from(
       document.querySelectorAll("button.exocortex-onboarding-step-action"),
     ) as HTMLButtonElement[];
-    expect(actionButtons).toHaveLength(3);
-    // Steps 2-4 (the token step is step 1 and has its own Save button).
+    expect(actionButtons).toHaveLength(4);
+    // Steps 2-5 (the token step is step 1 and has its own Save button).
     expect(actionButtons.map((b) => b.getAttribute("aria-label"))).toEqual([
       "Step 2: Set up the engine",
-      "Step 3: Add the starter content",
-      "Step 4: Apply the starter profile",
+      "Step 3: Add the AssetSpace registry",
+      "Step 4: Add the profiles AssetSpace",
+      "Step 5: Apply a profile",
     ]);
   });
 
@@ -185,9 +195,9 @@ describe("FirstRunOnboardingModal", () => {
   it("clicking a step does NOT close the panel (sub-dialogs stack on top)", () => {
     const { actions, calls } = makeActions();
     new FirstRunOnboardingModal(fakeApp, actions).open();
-    findButton("Add the starter content")!.click();
+    findButton("Add the AssetSpace registry")!.click();
     // No close persisted yet — the panel stays open underneath the sub-dialog.
-    expect(calls).toEqual(["starter"]);
+    expect(calls).toEqual(["registry"]);
     expect(document.querySelector("ol.exocortex-onboarding-steps")).not.toBeNull();
   });
 


### PR DESCRIPTION
## What

Replaces the 3-step **starter-registry** onboarding (Bootstrap exo → Add `exoas-starter-registry` → Apply `starter`) with the EKA **5-step bootstrap** wizard, and purges `exoas-starter-registry` references. Per Andrey's directive (2026-06-20): **don't create a new `exoas-starter` repo**; instead retire `exoas-starter-registry` and make the wizard the canonical EKA flow.

**New wizard flow** (`FirstRunOnboardingModal`):
1. PAT (optional) — *unchanged, incl. #3636 «Test connection»*
2. Set up the engine → bootstrap `exoas-exo` — *unchanged, incl. #3638 «Use default»*
3. **Add the AssetSpace registry** → `exoas-registry`
4. **Add the profiles AssetSpace** → `exoas-profiles`
5. **Apply a profile** → full picker (no narrowing)

## Why (verified design)

A single *Add AssetSpace by URL* pulls **one** repo and does **not** follow `exo__AssetSpace_dependsOn` transitively (`BootstrapAssetSpaceCommands.invokeAddAssetSpace`); *Apply profile* resolves the `dependsOn` closure **only over descriptors already physically in the vault** (`ProfileApplyManager.listAllAssetSpaceInfos` scans `vault.getMarkdownFiles()`; `toMaterialize` needs each AS's `_source` from a vault-resident descriptor). So a profile's transitive deps can only materialize once the **registry** (all descriptors) and **profiles** are added explicitly. This is the documented EKA D12 bootstrap order; the old self-contained `exoas-starter-registry` worked only because it inlined its 7 descriptors + a `starter` profile.

A public **no-token** tester picks the public `$$core` profile (exo-only); a personal profile (e.g. `$$kitelev-my`) needs the PAT from step 1 to pull its private AssetSpaces (Phase-1 pull aborts cleanly, vault intact, if a private repo is unreachable).

## Changes
- `firstRunOnboarding.ts`: `REGISTRY_ASSETSPACE_URL` + `PROFILES_ASSETSPACE_URL` replace `STARTER_REGISTRY_URL` + `STARTER_PROFILE_QUERY`.
- `FirstRunOnboardingModal`: 5 steps; `onAddStarter`→`onAddRegistry`+`onAddProfiles`, `onApplyStarterProfile`→`onApplyProfile`.
- `ExocortexPlugin` wiring + `BootstrapResultModal` post-bootstrap nudge repointed to `exoas-registry`.
- Comments + tests + `Getting-Started.md` §Step 2b rewritten to the 5-step flow.

## Coordination
Rebased on top of **#3636** (PAT «Test connection») and **#3638** («Use default» engine URL) — **both features preserved** (PAT step + `BootstrapVaultModal` untouched).

## Out of scope / follow-up
- `kitelev/exoas-starter-registry` **repo deletion** — to be done after this merges + verifies (or escalated to Andrey for manual delete).
- `docs/rfc/0002` left as historical design record (heavily prettier-dirty on main → editing bundles a 156-line reformat).

## Test
- 5 affected unit suites updated + green (148 → 197 in the broader modal/onboarding sweep), incl. revert-safe step-button/aria assertions.
- typecheck + eslint (`--max-warnings=0`) clean.