### PR TITLE
feat(templating): body_template grounding step (Веха 3) — body-copy into created asset

### DIFF
--- a/packages/cli/src/commands/apply.ts
+++ b/packages/cli/src/commands/apply.ts
@@ -19,6 +19,7 @@ import {
   TaskStatusService,
   WorkflowResolver,
   NamedQueryRunner,
+  stripTemplateFrontmatter,
   createVaultFrontmatterClassLabelResolver,
   createVaultFrontmatterRefToFolderResolver,
   registerDefaultHostFunctions,
@@ -307,6 +308,14 @@ async function executeOnTarget(
       uidGenerator: uidGen,
       workflowResolver,
       groundingLoader: (uid) => resolver.loadGroundingByUid(uid),
+      // Subproject 17f58ebe Веха 3 — load an exotemplate__Template asset's body
+      // by UID for `body_template` groundings that use `templateRef` (UI/CLI
+      // parity, Issue #3417). Mirrors the plugin's templateLoader.
+      templateLoader: async (uid) => {
+        const path = await nodeFsAdapter.findFileByUID(uid);
+        if (!path) return null;
+        return stripTemplateFrontmatter(await nodeFsAdapter.readFile(path));
+      },
       namedQueryRunner,
       // T1 "Create Instance" (project bbe40f8c) — co-locate new instances in
       // their chosen ontology's folder via `$isDefinedByFolder` (UI/CLI parity,

--- a/packages/exocortex/src/domain/constants/GroundingType.ts
+++ b/packages/exocortex/src/domain/constants/GroundingType.ts
@@ -64,4 +64,19 @@ export enum GroundingType {
    * RFC 36347daf Phase 2 — homoiconic workflow definitions.
    */
   WORKFLOW_TRANSITION = "workflow_transition",
+  /**
+   * Copy a body template's resolved markdown into the body of the target
+   * (typically a just-created asset inside a composite). Reads the template
+   * markdown from `bodyTemplate` (inline literal) OR `templateRef` (UID of an
+   * `exotemplate__Template` asset, loaded via the injected TemplateLoaderPort),
+   * resolves `$token` markers via the shared SubstitutionResolverRegistry, and
+   * replaces the target file's body (frontmatter preserved).
+   *
+   * Homoiconic templating subproject 17f58ebe, Веха 3 — the body-copy primitive
+   * (`create_instance` writes an empty body). Composable as one step of a
+   * `composite` grounding; when it follows a `create_instance` step it writes
+   * into the newly created asset (the composite threads the created file's path
+   * to subsequent `body_template` steps).
+   */
+  BODY_TEMPLATE = "body_template",
 }

--- a/packages/exocortex/src/domain/constants/GroundingTypeUIDs.ts
+++ b/packages/exocortex/src/domain/constants/GroundingTypeUIDs.ts
@@ -35,6 +35,8 @@ export const GROUNDING_TYPE_UIDS: Readonly<Record<GroundingType, string>> = {
   [GroundingType.SPARQL_UPDATE]:       "79c3e709-8d1d-4694-bcc6-b9ff07d59b86",
   // RFC 36347daf Phase 2 — workflow_transition catalog instance
   [GroundingType.WORKFLOW_TRANSITION]: "5c1a2552-d576-496d-8823-563573dd1e2f",
+  // Subproject 17f58ebe Веха 3 — body_template catalog instance (exoas-exocmd)
+  [GroundingType.BODY_TEMPLATE]:       "6093bfcb-cf9b-4565-86c3-ff74d8bc11c0",
 } as const;
 
 /**
@@ -75,6 +77,7 @@ export const GROUNDING_TYPE_IRI_TO_ENUM: Readonly<Record<string, GroundingType>>
   [`${EXOCMD_NAMESPACE}GroundingTypePropertyShift`]:     GroundingType.PROPERTY_SHIFT,
   [`${EXOCMD_NAMESPACE}GroundingTypeSparqlUpdate`]:      GroundingType.SPARQL_UPDATE,
   [`${EXOCMD_NAMESPACE}GroundingTypeWorkflowTransition`]: GroundingType.WORKFLOW_TRANSITION,
+  [`${EXOCMD_NAMESPACE}GroundingTypeBodyTemplate`]:      GroundingType.BODY_TEMPLATE,
 });
 
 const UUID_PATTERN = /([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})/i;

--- a/packages/exocortex/src/domain/models/CommandDefinition.ts
+++ b/packages/exocortex/src/domain/models/CommandDefinition.ts
@@ -236,6 +236,26 @@ export interface GroundingDefinition {
    * Authored as the `exocmd__Grounding_direction` RDF triple (xsd:string).
    */
   readonly direction?: "forward" | "rollback";
+  /**
+   * Subproject 17f58ebe Веха 3 — `body_template` grounding. Inline markdown
+   * literal used as the body template. `$token` markers resolve via the shared
+   * SubstitutionResolverRegistry at execute time. Disjoint with
+   * {@link templateRef} (templateRef takes priority when both are present).
+   *
+   * Authored as the `exocmd__Grounding_bodyTemplate` RDF triple (xsd:string).
+   */
+  readonly bodyTemplate?: string;
+  /**
+   * Subproject 17f58ebe Веха 3 — `body_template` grounding. Bare UID of an
+   * `exotemplate__Template` asset whose markdown BODY is loaded (via the
+   * injected TemplateLoaderPort) and used as the body template. Preferred over
+   * the inline {@link bodyTemplate} when both are set; when no loader is wired
+   * (CLI/test) the step falls back to {@link bodyTemplate} or fails loud.
+   *
+   * Authored as the `exocmd__Grounding_templateRef` RDF triple (UID wikilink,
+   * normalized to a bare UID by the parser).
+   */
+  readonly templateRef?: string;
 }
 
 /**

--- a/packages/exocortex/src/domain/models/GroundingFrontmatterParser.ts
+++ b/packages/exocortex/src/domain/models/GroundingFrontmatterParser.ts
@@ -105,6 +105,15 @@ export function parseGroundingDefinitionFromFrontmatter(
     ? normalizeGroundingRef(rawTargetValueRef)
     : undefined;
 
+  // Subproject 17f58ebe Веха 3 — body_template grounding fields. templateRef is
+  // a wikilink to an exotemplate__Template asset → normalized to its bare UID.
+  const rawTemplateRef = fm["exocmd__Grounding_templateRef"] as
+    | string
+    | undefined;
+  const templateRef = rawTemplateRef
+    ? normalizeGroundingRef(rawTemplateRef)
+    : undefined;
+
   return {
     id: uid,
     label: (fm["exo__Asset_label"] as string) ?? "",
@@ -133,6 +142,8 @@ export function parseGroundingDefinitionFromFrontmatter(
     linkBackProperty: fm["exocmd__Grounding_linkBackProperty"] as
       | string
       | undefined,
+    bodyTemplate: fm["exocmd__Grounding_bodyTemplate"] as string | undefined,
+    templateRef,
     steps,
   };
 }

--- a/packages/exocortex/src/index.ts
+++ b/packages/exocortex/src/index.ts
@@ -150,7 +150,7 @@ export type {
 // Homoiconic templating (vehy 2-4) — resolve `$token` markers inside a markdown
 // body via the shared registry. Consumed by the editor "Insert template"
 // command and the `body_template` grounding step.
-export { resolveTemplateBody } from "./services/TemplateBodyResolver";
+export { resolveTemplateBody, stripTemplateFrontmatter } from "./services/TemplateBodyResolver";
 export { InstantiationRuleResolver } from "./services/InstantiationRuleResolver";
 export type { InstantiationRule, PropertySetRule } from "./services/InstantiationRuleResolver";
 export { VisibilityGenerator } from "./services/VisibilityGenerator";

--- a/packages/exocortex/src/services/CommandResolver.ts
+++ b/packages/exocortex/src/services/CommandResolver.ts
@@ -1773,6 +1773,18 @@ export class CommandResolver {
       }
     }
 
+    // Subproject 17f58ebe Веха 3 — body_template grounding fields. bodyTemplate
+    // is the inline markdown literal; templateRef points at an
+    // exotemplate__Template asset (UID-canon → its obsidian name is the UID).
+    const bodyTemplate = await this.getLiteralValue(
+      subject,
+      Namespace.EXOCMD.term("Grounding_bodyTemplate"),
+    );
+    const templateRef = await this.getObsidianName(
+      subject,
+      Namespace.EXOCMD.term("Grounding_templateRef"),
+    );
+
     const grounding: GroundingDefinition = {
       id: uid,
       label,
@@ -1798,6 +1810,8 @@ export class CommandResolver {
       prefillLabelWithDate: prefillLabelWithDate || undefined,
       labelTemplate: labelTemplate ?? undefined,
       direction,
+      bodyTemplate: bodyTemplate ?? undefined,
+      templateRef: templateRef ?? undefined,
     };
 
     if (inputSchema) {

--- a/packages/exocortex/src/services/GroundingExecutor.ts
+++ b/packages/exocortex/src/services/GroundingExecutor.ts
@@ -11,6 +11,7 @@ import type {
   PropertyDefaultResolved,
 } from "../domain/models/CommandDefinition";
 import { GroundingType } from "../domain/constants/GroundingType";
+import { resolveTemplateBody } from "./TemplateBodyResolver";
 import { AssetClass } from "../domain/constants/AssetClass";
 import { base64ToUtf8 } from "../utilities/base64";
 import { EffortStatus } from "../domain/constants/EffortStatus";
@@ -297,6 +298,16 @@ export type GroundingLoaderPort = (
   uid: string,
 ) => Promise<GroundingDefinition | null>;
 
+/**
+ * Subproject 17f58ebe Веха 3 — load an `exotemplate__Template` asset's markdown
+ * BODY by UID, for `body_template` groundings that reference a template via
+ * `templateRef`. Returns the body (frontmatter stripped) or `null` when the
+ * template UID is unresolvable. When absent (CLI/test without a vault index),
+ * `body_template` falls back to the inline `bodyTemplate` literal or fails loud.
+ * Plugin wires `(uid) => read template file → extractTemplateBody`.
+ */
+export type TemplateLoaderPort = (uid: string) => Promise<string | null>;
+
 @injectable()
 export class GroundingExecutor {
   private readonly frontmatterService: FrontmatterService;
@@ -307,6 +318,7 @@ export class GroundingExecutor {
   private readonly refToFolder?: RefToFolderResolver;
   private readonly workflowResolver?: WorkflowResolverPort;
   private readonly groundingLoader?: GroundingLoaderPort;
+  private readonly templateLoader?: TemplateLoaderPort;
   private readonly namedQueryRunner?: NamedQueryRunnerPort;
   private readonly clock: IClock;
   private readonly uidGen: IUidGenerator;
@@ -327,6 +339,9 @@ export class GroundingExecutor {
       // dispatch returns a clear error rather than silently no-op'ing.
       workflowResolver?: WorkflowResolverPort;
       groundingLoader?: GroundingLoaderPort;
+      // Subproject 17f58ebe Веха 3 — load exotemplate__Template body by UID for
+      // `body_template` groundings that reference a template via `templateRef`.
+      templateLoader?: TemplateLoaderPort;
       // RFC 78c2b7d0 C4 — read-side value-source for property_set
       // `targetValueQuery`. When absent, such groundings fail loud.
       namedQueryRunner?: NamedQueryRunnerPort;
@@ -344,6 +359,7 @@ export class GroundingExecutor {
     this.refToFolder = options?.refToFolder;
     this.workflowResolver = options?.workflowResolver;
     this.groundingLoader = options?.groundingLoader;
+    this.templateLoader = options?.templateLoader;
     this.namedQueryRunner = options?.namedQueryRunner;
     this.clock = options?.clock ?? liveClock();
     this.uidGen = options?.uidGenerator ?? liveUidGenerator();
@@ -434,6 +450,14 @@ export class GroundingExecutor {
 
         case GroundingType.WORKFLOW_TRANSITION:
           return await this.executeWorkflowTransition(
+            grounding,
+            targetIRI,
+            targetFilePath,
+            userInput,
+          );
+
+        case GroundingType.BODY_TEMPLATE:
+          return await this.executeBodyTemplate(
             grounding,
             targetIRI,
             targetFilePath,
@@ -645,13 +669,24 @@ export class GroundingExecutor {
 
     const completedSteps: number[] = [];
 
+    // Subproject 17f58ebe Веха 3 — track the most-recently-created asset's path
+    // so a later `body_template` step writes into THAT file (the created
+    // instance), not the composite click-target. Only `body_template` consumes
+    // this thread; every other step type keeps operating on `filePath`, so this
+    // is a zero-regression addition for existing composites.
+    let lastCreatedPath: string | undefined;
+
     try {
       for (let i = 0; i < steps.length; i++) {
         const step = steps[i];
+        const stepPath =
+          step.type === GroundingType.BODY_TEMPLATE && lastCreatedPath
+            ? lastCreatedPath
+            : filePath;
         const result = await this.executeStep(
           step,
           targetIRI,
-          filePath,
+          stepPath,
           userInput,
           depth + 1,
         );
@@ -663,6 +698,9 @@ export class GroundingExecutor {
             error: `Composite step ${i} failed: ${result.error}`,
           };
         }
+        // create_instance returns the new file's path — thread it to a later
+        // body_template step.
+        if (result.openPath) lastCreatedPath = result.openPath;
         completedSteps.push(i);
       }
 
@@ -810,6 +848,90 @@ export class GroundingExecutor {
     );
     await this.fileWriter.updateFile(filePath, updated);
     return { success: true };
+  }
+
+  /**
+   * Subproject 17f58ebe Веха 3 — `body_template` grounding. Resolve a body
+   * template (inline `bodyTemplate` literal OR `templateRef` →
+   * `exotemplate__Template` body via the injected loader) and write it as the
+   * BODY of the target file, preserving its frontmatter. `$token` markers are
+   * resolved via the shared SubstitutionResolverRegistry (Веха 4). Inside a
+   * `composite`, the target is the most-recently created asset (the composite
+   * threads its path here) — so create_instance + body_template gives a created
+   * asset with a templated body.
+   */
+  private async executeBodyTemplate(
+    grounding: GroundingDefinition,
+    targetIRI: string,
+    targetFilePath: string,
+    userInput?: UserInput,
+  ): Promise<ExecutionResult> {
+    // 1. Source the raw template markdown. templateRef (homoiconic, points at an
+    //    exotemplate__Template asset) wins; inline bodyTemplate is the fallback
+    //    / test path. Neither → fail loud (a no-op body write is a config error).
+    let rawBody: string | null = null;
+    if (grounding.templateRef) {
+      if (!this.templateLoader) {
+        // A templateRef was authored but no loader is wired — degrade to the
+        // inline literal if present, else fail loud rather than silently no-op.
+        if (grounding.bodyTemplate === undefined) {
+          return {
+            success: false,
+            error: `body_template: templateRef "${grounding.templateRef}" set but no TemplateLoaderPort is wired (and no inline bodyTemplate fallback).`,
+          };
+        }
+        rawBody = grounding.bodyTemplate;
+      } else {
+        rawBody = await this.templateLoader(grounding.templateRef);
+        if (rawBody === null) {
+          return {
+            success: false,
+            error: `body_template: templateRef "${grounding.templateRef}" did not resolve to a template body (asset missing or empty).`,
+          };
+        }
+      }
+    } else if (grounding.bodyTemplate !== undefined) {
+      rawBody = grounding.bodyTemplate;
+    } else {
+      return {
+        success: false,
+        error: "body_template requires bodyTemplate or templateRef",
+      };
+    }
+
+    // 2. Resolve $token markers via the shared registry (Веха 4). Context is
+    //    lenient — unknown / empty / non-scalar tokens stay literal.
+    const resolved = resolveTemplateBody(rawBody, {
+      userInput,
+      targetIRI,
+      targetFilePath,
+    });
+
+    // 3. Write the resolved markdown as the target file's body, preserving any
+    //    frontmatter the create_instance step (or the existing file) wrote.
+    let content: string;
+    try {
+      content = await this.fileReader.readFile(targetFilePath);
+    } catch (error) {
+      return {
+        success: false,
+        error: `body_template: failed to read target file "${targetFilePath}": ${error instanceof Error ? error.message : String(error)}`,
+      };
+    }
+    const newContent = GroundingExecutor.replaceBody(content, resolved);
+    await this.fileWriter.updateFile(targetFilePath, newContent);
+    return { success: true };
+  }
+
+  /**
+   * Replace a markdown file's body (everything after the leading frontmatter
+   * block) with `body`, preserving the frontmatter. When the file has no
+   * frontmatter, the whole content becomes `body`. `\r?\n` tolerates CRLF.
+   */
+  private static replaceBody(content: string, body: string): string {
+    const fmMatch = content.match(/^---\r?\n[\s\S]*?\r?\n---/);
+    if (!fmMatch) return body;
+    return `${fmMatch[0]}\n${body}`;
   }
 
   private async executeCreateInstance(

--- a/packages/exocortex/src/services/GroundingExecutor.ts
+++ b/packages/exocortex/src/services/GroundingExecutor.ts
@@ -927,6 +927,12 @@ export class GroundingExecutor {
    * Replace a markdown file's body (everything after the leading frontmatter
    * block) with `body`, preserving the frontmatter. When the file has no
    * frontmatter, the whole content becomes `body`. `\r?\n` tolerates CRLF.
+   *
+   * NOTE: an EMPTY frontmatter (`---\n---`) has no line between the fences, so
+   * the regex treats it as "no frontmatter" and `body` replaces the whole file.
+   * This never triggers on the composite create_instance path (it always writes
+   * non-empty frontmatter: uid/label/instance_class/createdAt); it only affects
+   * a standalone body_template on an empty-FM file — an acceptable corner.
    */
   private static replaceBody(content: string, body: string): string {
     const fmMatch = content.match(/^---\r?\n[\s\S]*?\r?\n---/);

--- a/packages/exocortex/src/services/TemplateBodyResolver.ts
+++ b/packages/exocortex/src/services/TemplateBodyResolver.ts
@@ -74,3 +74,22 @@ export function resolveTemplateBody(
     return typeof value === "string" && value.length > 0 ? value : literal;
   });
 }
+
+/**
+ * Strip the leading YAML frontmatter block, returning the markdown body. When
+ * no frontmatter is present the whole content is the body. A single newline
+ * separating the closing `---` from the body is consumed so the body does not
+ * start with a blank line. `\r?\n` tolerates CRLF (Windows vaults).
+ *
+ * Single source for "an exotemplate__Template asset's body is its file body"
+ * — reused by the plugin editor inserter, the plugin TemplateLoaderPort, and
+ * the CLI TemplateLoaderPort (one strip, no per-consumer regex drift).
+ *
+ * NOTE — distinct from `utilities/sparqlBlock.stripFrontmatter`, which keeps a
+ * leading newline (`\nbody`). This one consumes the separating newline so the
+ * inserted/copied block does not start blank, and is CRLF-tolerant.
+ */
+export function stripTemplateFrontmatter(content: string): string {
+  const match = content.match(/^---\r?\n[\s\S]*?\r?\n---\r?\n?/);
+  return match ? content.slice(match[0].length) : content;
+}

--- a/packages/exocortex/tests/domain/models/GroundingFrontmatterParser.test.ts
+++ b/packages/exocortex/tests/domain/models/GroundingFrontmatterParser.test.ts
@@ -280,4 +280,43 @@ describe("parseGroundingDefinitionFromFrontmatter", () => {
       expect(def.targetValueRef).toBe("abc-123");
     });
   });
+
+  describe("body_template fields (Веха 3, subproject 17f58ebe)", () => {
+    it("maps inline exocmd__Grounding_bodyTemplate to bodyTemplate", () => {
+      const def = parseGroundingDefinitionFromFrontmatter(
+        "uid",
+        {
+          exocmd__Grounding_type: typeLink(GroundingType.BODY_TEMPLATE),
+          exocmd__Grounding_bodyTemplate: "## Plan\n- $today",
+        },
+        failingResolveStep,
+      );
+      expect(def.type).toBe(GroundingType.BODY_TEMPLATE);
+      expect(def.bodyTemplate).toBe("## Plan\n- $today");
+      expect(def.templateRef).toBeUndefined();
+    });
+
+    it("normalizes exocmd__Grounding_templateRef wikilink to a bare UID", () => {
+      const def = parseGroundingDefinitionFromFrontmatter(
+        "uid",
+        {
+          exocmd__Grounding_type: typeLink(GroundingType.BODY_TEMPLATE),
+          exocmd__Grounding_templateRef:
+            '"[[8bdf4506-80bf-4999-8fda-1ea0808b4ee5|exotemplate__Template]]"',
+        },
+        failingResolveStep,
+      );
+      expect(def.templateRef).toBe("8bdf4506-80bf-4999-8fda-1ea0808b4ee5");
+    });
+
+    it("leaves both fields undefined when neither key is present", () => {
+      const def = parseGroundingDefinitionFromFrontmatter(
+        "uid",
+        { exocmd__Grounding_type: typeLink(GroundingType.PROPERTY_SET) },
+        failingResolveStep,
+      );
+      expect(def.bodyTemplate).toBeUndefined();
+      expect(def.templateRef).toBeUndefined();
+    });
+  });
 });

--- a/packages/exocortex/tests/integration/dynamic-commands/grounding-type-vault-fixture-parity.test.ts
+++ b/packages/exocortex/tests/integration/dynamic-commands/grounding-type-vault-fixture-parity.test.ts
@@ -6,8 +6,8 @@
  * `exocmd__GroundingType` class (UID `708604a5-a682-4ff6-9391-c2e80ab78ca5`).
  * Asserts:
  *
- * 1. Exactly 10 instances (matches `GroundingType` TS enum cardinality)
- * 2. The 10 vault UIDs are exactly the values in `GROUNDING_TYPE_UIDS`
+ * 1. Exactly 11 instances (matches `GroundingType` TS enum cardinality)
+ * 2. The 11 vault UIDs are exactly the values in `GROUNDING_TYPE_UIDS`
  * 3. Each vault asset's `exo__Asset_label` matches the expected naming
  *    convention X (e.g., `exocmd__GroundingTypePropertySet` for
  *    `GroundingType.PROPERTY_SET`)
@@ -43,6 +43,8 @@ const ENUM_TO_EXPECTED_LABEL: Record<GroundingType, string> = {
   [GroundingType.SPARQL_UPDATE]:       "exocmd__GroundingTypeSparqlUpdate",
   // RFC 36347daf Phase 2 — workflow_transition catalog instance.
   [GroundingType.WORKFLOW_TRANSITION]: "exocmd__GroundingTypeWorkflowTransition",
+  // Subproject 17f58ebe Веха 3 — body_template catalog instance.
+  [GroundingType.BODY_TEMPLATE]:       "exocmd__GroundingTypeBodyTemplate",
 };
 
 interface VaultAsset {
@@ -132,8 +134,8 @@ describe("RFC 9d20c91f Phase 2 — vault-fixture parity (exoas-exocmd submodule)
     instances = scanGroundingTypeInstances();
   });
 
-  it("contains exactly 10 GroundingType instances", () => {
-    expect(instances).toHaveLength(10);
+  it("contains exactly 11 GroundingType instances", () => {
+    expect(instances).toHaveLength(11);
   });
 
   it("instance UIDs match TS GROUNDING_TYPE_UIDS exactly", () => {

--- a/packages/exocortex/tests/unit/domain/constants/CommandConstants.test.ts
+++ b/packages/exocortex/tests/unit/domain/constants/CommandConstants.test.ts
@@ -17,12 +17,13 @@ describe("GroundingType", () => {
     expect(GroundingType.CREATE_INSTANCE).toBe("create_instance");
   });
 
-  it("should have exactly 10 values", () => {
+  it("should have exactly 11 values", () => {
     // SPARQL_UPDATE, PROPERTY_DELETE, PROPERTY_SET, COMPOSITE, SERVICE_CALL,
     // CREATE_INSTANCE, PROPERTY_APPEND (#3132), PROPERTY_INCREMENT (#3134),
-    // PROPERTY_SHIFT (#3134), WORKFLOW_TRANSITION (RFC 36347daf Phase 2).
+    // PROPERTY_SHIFT (#3134), WORKFLOW_TRANSITION (RFC 36347daf Phase 2),
+    // BODY_TEMPLATE (subproject 17f58ebe Веха 3).
     const values = Object.values(GroundingType);
-    expect(values).toHaveLength(10);
+    expect(values).toHaveLength(11);
   });
 });
 

--- a/packages/exocortex/tests/unit/domain/constants/GroundingTypeParity.test.ts
+++ b/packages/exocortex/tests/unit/domain/constants/GroundingTypeParity.test.ts
@@ -44,9 +44,9 @@ describe("RFC 9d20c91f Phase 2 — TS enum ↔ vault asset parity", () => {
       }
     });
 
-    it("10 unique UIDs (no collisions)", () => {
+    it("11 unique UIDs (no collisions)", () => {
       const uids = Object.values(GROUNDING_TYPE_UIDS);
-      expect(new Set(uids).size).toBe(10);
+      expect(new Set(uids).size).toBe(11);
     });
   });
 
@@ -60,13 +60,13 @@ describe("RFC 9d20c91f Phase 2 — TS enum ↔ vault asset parity", () => {
       }
     });
 
-    it("has the same 10 entries as GROUNDING_TYPE_UIDS", () => {
-      expect(Object.keys(GROUNDING_TYPE_UID_TO_ENUM)).toHaveLength(10);
+    it("has the same 11 entries as GROUNDING_TYPE_UIDS", () => {
+      expect(Object.keys(GROUNDING_TYPE_UID_TO_ENUM)).toHaveLength(11);
     });
   });
 
   describe("GROUNDING_TYPE_IRI_TO_ENUM (symbolic class IRI map)", () => {
-    it("covers all 10 enum values", () => {
+    it("covers all 11 enum values", () => {
       const enumValuesFromIRI = new Set(Object.values(GROUNDING_TYPE_IRI_TO_ENUM));
       const allEnumValues = new Set(Object.values(GroundingType));
       expect(enumValuesFromIRI).toEqual(allEnumValues);

--- a/packages/exocortex/tests/unit/services/GroundingExecutor.body_template.test.ts
+++ b/packages/exocortex/tests/unit/services/GroundingExecutor.body_template.test.ts
@@ -1,0 +1,270 @@
+/**
+ * Unit tests — GroundingExecutor `body_template` step (homoiconic templating
+ * Веха 3, subproject 17f58ebe).
+ *
+ * The `body_template` step copies a body template's resolved markdown into the
+ * BODY of the target file (frontmatter preserved). Source = inline
+ * `bodyTemplate` literal OR `templateRef` (an exotemplate__Template asset loaded
+ * via the injected TemplateLoaderPort). `$token` markers resolve via the shared
+ * SubstitutionResolverRegistry (Веха 4). Inside a composite it writes into the
+ * most-recently created asset (the composite threads create_instance's openPath).
+ *
+ * Uses an in-memory fs (mirrors the real read-after-write contract) so the
+ * composite create_instance → body_template thread can be asserted end-to-end.
+ */
+
+import {
+  GroundingExecutor,
+  ServiceRegistry,
+  type TemplateLoaderPort,
+} from "../../../src/services/GroundingExecutor";
+import {
+  clearResolvers,
+  installDefaultResolvers,
+  registerResolver,
+} from "../../../src/services/SubstitutionResolverRegistry";
+import { GroundingType } from "../../../src/domain/constants/GroundingType";
+import { GroundingDefinition } from "../../../src/domain/models/CommandDefinition";
+
+/** In-memory fs that honours read-after-write (unlike the bare jest mocks). */
+function makeFs(seed: Record<string, string> = {}) {
+  const files = new Map<string, string>(Object.entries(seed));
+  const reader = {
+    readFile: jest.fn(async (path: string) => {
+      if (!files.has(path)) throw new Error(`ENOENT: ${path}`);
+      return files.get(path) as string;
+    }),
+    fileExists: jest.fn(async (path: string) => files.has(path)),
+    getMarkdownFiles: jest.fn().mockResolvedValue([]),
+  };
+  const writer = {
+    createFile: jest.fn(async (path: string, content: string) => {
+      files.set(path, content);
+      return "";
+    }),
+    updateFile: jest.fn(async (path: string, content: string) => {
+      files.set(path, content);
+    }),
+    writeFile: jest.fn(async (path: string, content: string) => {
+      files.set(path, content);
+    }),
+    deleteFile: jest.fn(async (path: string) => {
+      files.delete(path);
+    }),
+    renameFile: jest.fn().mockResolvedValue(undefined),
+  };
+  return { files, reader, writer };
+}
+
+function gnd(overrides: Record<string, unknown>): GroundingDefinition {
+  return {
+    id: "gnd-bt",
+    label: "Body template",
+    ...overrides,
+  } as unknown as GroundingDefinition;
+}
+
+const TARGET_IRI = "https://exocortex.my/assets/area-123";
+
+describe("GroundingExecutor — body_template (Веха 3)", () => {
+  beforeEach(() => {
+    clearResolvers();
+    installDefaultResolvers();
+  });
+
+  describe("standalone — inline bodyTemplate", () => {
+    it("replaces the target file's body, preserving frontmatter", async () => {
+      const { files, reader, writer } = makeFs({
+        "/vault/note.md": "---\nexo__Asset_uid: x\n---\nOLD BODY",
+      });
+      const exec = new GroundingExecutor(reader, writer, new ServiceRegistry());
+      const res = await exec.execute(
+        gnd({ type: GroundingType.BODY_TEMPLATE, bodyTemplate: "## Plan\n- step" }),
+        TARGET_IRI,
+        "/vault/note.md",
+      );
+      expect(res.success).toBe(true);
+      expect(files.get("/vault/note.md")).toBe(
+        "---\nexo__Asset_uid: x\n---\n## Plan\n- step",
+      );
+    });
+
+    it("resolves $token markers in the body", async () => {
+      registerResolver("nowDate", () => "2026-06-20");
+      const { files, reader, writer } = makeFs({
+        "/vault/n.md": "---\na: b\n---\n",
+      });
+      const exec = new GroundingExecutor(reader, writer, new ServiceRegistry());
+      await exec.execute(
+        gnd({
+          type: GroundingType.BODY_TEMPLATE,
+          bodyTemplate: "## Log\n- opened $nowDate",
+        }),
+        TARGET_IRI,
+        "/vault/n.md",
+      );
+      expect(files.get("/vault/n.md")).toBe(
+        "---\na: b\n---\n## Log\n- opened 2026-06-20",
+      );
+    });
+
+    it("writes the whole body when the target has no frontmatter", async () => {
+      const { files, reader, writer } = makeFs({ "/vault/raw.md": "anything" });
+      const exec = new GroundingExecutor(reader, writer, new ServiceRegistry());
+      await exec.execute(
+        gnd({ type: GroundingType.BODY_TEMPLATE, bodyTemplate: "# Fresh" }),
+        TARGET_IRI,
+        "/vault/raw.md",
+      );
+      expect(files.get("/vault/raw.md")).toBe("# Fresh");
+    });
+  });
+
+  describe("templateRef + TemplateLoaderPort", () => {
+    it("loads the referenced template body and writes it", async () => {
+      const loader: TemplateLoaderPort = jest.fn(async (uid) =>
+        uid === "tpl-1" ? "## From template\n- $nowDate" : null,
+      );
+      registerResolver("nowDate", () => "2026-06-20");
+      const { files, reader, writer } = makeFs({
+        "/vault/n.md": "---\na: b\n---\n",
+      });
+      const exec = new GroundingExecutor(reader, writer, new ServiceRegistry(), undefined, {
+        templateLoader: loader,
+      });
+      const res = await exec.execute(
+        gnd({ type: GroundingType.BODY_TEMPLATE, templateRef: "tpl-1" }),
+        TARGET_IRI,
+        "/vault/n.md",
+      );
+      expect(res.success).toBe(true);
+      expect(loader).toHaveBeenCalledWith("tpl-1");
+      expect(files.get("/vault/n.md")).toBe(
+        "---\na: b\n---\n## From template\n- 2026-06-20",
+      );
+    });
+
+    it("prefers templateRef over inline bodyTemplate when a loader is wired", async () => {
+      const loader: TemplateLoaderPort = jest.fn(async () => "FROM REF");
+      const { files, reader, writer } = makeFs({ "/vault/n.md": "---\na: b\n---\n" });
+      const exec = new GroundingExecutor(reader, writer, new ServiceRegistry(), undefined, {
+        templateLoader: loader,
+      });
+      await exec.execute(
+        gnd({
+          type: GroundingType.BODY_TEMPLATE,
+          templateRef: "tpl-1",
+          bodyTemplate: "INLINE",
+        }),
+        TARGET_IRI,
+        "/vault/n.md",
+      );
+      expect(files.get("/vault/n.md")).toBe("---\na: b\n---\nFROM REF");
+    });
+
+    it("falls back to inline bodyTemplate when templateRef is set but NO loader is wired", async () => {
+      const { files, reader, writer } = makeFs({ "/vault/n.md": "---\na: b\n---\n" });
+      const exec = new GroundingExecutor(reader, writer, new ServiceRegistry());
+      const res = await exec.execute(
+        gnd({
+          type: GroundingType.BODY_TEMPLATE,
+          templateRef: "tpl-1",
+          bodyTemplate: "INLINE FALLBACK",
+        }),
+        TARGET_IRI,
+        "/vault/n.md",
+      );
+      expect(res.success).toBe(true);
+      expect(files.get("/vault/n.md")).toBe("---\na: b\n---\nINLINE FALLBACK");
+    });
+
+    it("fails loud when templateRef set, no loader, and no inline fallback", async () => {
+      const { reader, writer } = makeFs({ "/vault/n.md": "---\na: b\n---\n" });
+      const exec = new GroundingExecutor(reader, writer, new ServiceRegistry());
+      const res = await exec.execute(
+        gnd({ type: GroundingType.BODY_TEMPLATE, templateRef: "tpl-1" }),
+        TARGET_IRI,
+        "/vault/n.md",
+      );
+      expect(res.success).toBe(false);
+      expect(res.error).toMatch(/templateRef.*no TemplateLoaderPort/);
+    });
+
+    it("fails loud when the loader returns null (template unresolvable)", async () => {
+      const loader: TemplateLoaderPort = jest.fn(async () => null);
+      const { reader, writer } = makeFs({ "/vault/n.md": "---\na: b\n---\n" });
+      const exec = new GroundingExecutor(reader, writer, new ServiceRegistry(), undefined, {
+        templateLoader: loader,
+      });
+      const res = await exec.execute(
+        gnd({ type: GroundingType.BODY_TEMPLATE, templateRef: "missing" }),
+        TARGET_IRI,
+        "/vault/n.md",
+      );
+      expect(res.success).toBe(false);
+      expect(res.error).toMatch(/did not resolve to a template body/);
+    });
+  });
+
+  describe("config errors", () => {
+    it("fails loud when neither bodyTemplate nor templateRef is set", async () => {
+      const { reader, writer } = makeFs({ "/vault/n.md": "---\na: b\n---\n" });
+      const exec = new GroundingExecutor(reader, writer, new ServiceRegistry());
+      const res = await exec.execute(
+        gnd({ type: GroundingType.BODY_TEMPLATE }),
+        TARGET_IRI,
+        "/vault/n.md",
+      );
+      expect(res.success).toBe(false);
+      expect(res.error).toMatch(/requires bodyTemplate or templateRef/);
+    });
+  });
+
+  describe("composite — create_instance THEN body_template threads the created path", () => {
+    it("writes the template body into the NEWLY created asset, not the click target", async () => {
+      registerResolver("nowDate", () => "2026-06-20");
+      const { files, reader, writer } = makeFs({
+        "/vault/areas/area-123.md":
+          "---\nexo__Asset_uid: area-123\nexo__Asset_label: My Area\n---\nArea body",
+      });
+      const exec = new GroundingExecutor(reader, writer, new ServiceRegistry());
+
+      const composite = gnd({
+        type: GroundingType.COMPOSITE,
+        steps: [
+          gnd({
+            id: "step-create",
+            type: GroundingType.CREATE_INSTANCE,
+            targetClass: "ems__Project",
+            targetFolder: "/vault/projects",
+          }),
+          gnd({
+            id: "step-body",
+            type: GroundingType.BODY_TEMPLATE,
+            bodyTemplate: "## Plan\n- created $nowDate",
+          }),
+        ],
+      });
+
+      const res = await exec.execute(
+        composite,
+        "https://exocortex.my/assets/area-123",
+        "/vault/areas/area-123.md",
+      );
+      expect(res.success).toBe(true);
+
+      // The click-target (area) body is UNCHANGED — body_template wrote elsewhere.
+      expect(files.get("/vault/areas/area-123.md")).toContain("Area body");
+
+      // A NEW project file was created under /vault/projects with the template body.
+      const created = [...files.entries()].find(
+        ([p]) => p.startsWith("/vault/projects/") && p !== "/vault/areas/area-123.md",
+      );
+      expect(created).toBeDefined();
+      const [, createdContent] = created as [string, string];
+      expect(createdContent).toContain("## Plan\n- created 2026-06-20");
+      // Frontmatter from create_instance is preserved above the templated body.
+      expect(createdContent).toMatch(/^---\n[\s\S]*?\n---\n## Plan/);
+    });
+  });
+});

--- a/packages/exocortex/tests/unit/services/TemplateBodyResolver.test.ts
+++ b/packages/exocortex/tests/unit/services/TemplateBodyResolver.test.ts
@@ -22,7 +22,10 @@ import {
   installDefaultResolvers,
   registerResolver,
 } from "../../../src/services/SubstitutionResolverRegistry";
-import { resolveTemplateBody } from "../../../src/services/TemplateBodyResolver";
+import {
+  resolveTemplateBody,
+  stripTemplateFrontmatter,
+} from "../../../src/services/TemplateBodyResolver";
 
 describe("resolveTemplateBody — registry-driven $token substitution (vehy 2-4)", () => {
   beforeEach(() => {
@@ -110,5 +113,32 @@ describe("resolveTemplateBody — registry-driven $token substitution (vehy 2-4)
   it("resolves the live built-in vocabulary (module-load install) after beforeEach", () => {
     // beforeEach reinstalled defaults; `nowYear` is a built-in 4-digit resolver.
     expect(resolveTemplateBody("Year $nowYear")).toMatch(/^Year \d{4}$/);
+  });
+});
+
+describe("stripTemplateFrontmatter (Веха 3 — template body = file body)", () => {
+  it("returns the body after the frontmatter, consuming the separating newline", () => {
+    expect(
+      stripTemplateFrontmatter("---\nexo__Asset_uid: x\n---\n## Plan\n- step"),
+    ).toBe("## Plan\n- step");
+  });
+
+  it("returns the whole content when there is no frontmatter", () => {
+    expect(stripTemplateFrontmatter("## Just a body")).toBe("## Just a body");
+  });
+
+  it("returns an empty body after frontmatter", () => {
+    expect(stripTemplateFrontmatter("---\na: b\n---\n")).toBe("");
+  });
+
+  it("tolerates CRLF frontmatter (Windows vault)", () => {
+    expect(
+      stripTemplateFrontmatter("---\r\na: b\r\n---\r\n## Plan\r\n- x"),
+    ).toBe("## Plan\r\n- x");
+  });
+
+  it("differs from sparqlBlock.stripFrontmatter — no leading newline kept", () => {
+    // sparqlBlock.stripFrontmatter would return "\n## Plan"; this one consumes it.
+    expect(stripTemplateFrontmatter("---\na: b\n---\n## Plan")).not.toMatch(/^\n/);
   });
 });

--- a/packages/obsidian-plugin/src/ExocortexPlugin.ts
+++ b/packages/obsidian-plugin/src/ExocortexPlugin.ts
@@ -28,6 +28,7 @@ import {
 import { pickTemplateToken } from "./infrastructure/adapters/TemplateTokenFuzzyModal";
 import {
   collectTemplateChoices,
+  extractTemplateBody,
   insertTemplate,
   resolveTemplateForInsert,
   type TemplateChoice,
@@ -614,6 +615,23 @@ export default class ExocortexPlugin extends Plugin {
           workflowResolver: this.workflowResolver,
           groundingLoader: (uid) =>
             this.commandResolver.loadGroundingByUid(uid),
+          // Subproject 17f58ebe Веха 3 — load an exotemplate__Template asset's
+          // body by UID for `body_template` groundings that use `templateRef`.
+          // UID-canon → filename basename === uid; fall back to a frontmatter
+          // exo__Asset_uid scan for label-named template files.
+          templateLoader: async (uid) => {
+            const files = this.app.vault.getMarkdownFiles();
+            const file =
+              files.find((f) => f.basename === uid) ??
+              files.find(
+                (f) =>
+                  this.app.metadataCache.getFileCache(f)?.frontmatter?.[
+                    "exo__Asset_uid"
+                  ] === uid,
+              );
+            if (!file) return null;
+            return extractTemplateBody(await this.app.vault.cachedRead(file));
+          },
           namedQueryRunner,
           // T1 "Create Instance" (project bbe40f8c) — co-locate new instances in
           // their chosen ontology's folder via the `$isDefinedByFolder` token.

--- a/packages/obsidian-plugin/src/infrastructure/adapters/TemplateInserter.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/TemplateInserter.ts
@@ -107,9 +107,10 @@ export function collectTemplateChoices(
 
 /**
  * Strip the leading YAML frontmatter block, returning the markdown body.
- * Delegates to the core `stripFrontmatter` so the editor inserter, the plugin
- * TemplateLoaderPort, and the CLI TemplateLoaderPort share one strip impl
- * (Веха 3 — no per-consumer regex drift).
+ * Delegates to the core `stripTemplateFrontmatter` (CRLF-aware, consumes the
+ * separating newline — distinct from `sparqlBlock.stripFrontmatter`) so the
+ * editor inserter, the plugin TemplateLoaderPort, and the CLI TemplateLoaderPort
+ * share one strip impl (Веха 3 — no per-consumer regex drift).
  */
 export function extractTemplateBody(content: string): string {
   return stripTemplateFrontmatter(content);

--- a/packages/obsidian-plugin/src/infrastructure/adapters/TemplateInserter.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/TemplateInserter.ts
@@ -1,5 +1,5 @@
 import type { Editor, TFile } from "obsidian";
-import { resolveTemplateBody } from "exocortex";
+import { resolveTemplateBody, stripTemplateFrontmatter } from "exocortex";
 
 /**
  * TemplateInserter — logic behind the editor "Insert template" command
@@ -106,17 +106,13 @@ export function collectTemplateChoices(
 }
 
 /**
- * Strip the leading YAML frontmatter block, returning the markdown body. When
- * no frontmatter is present the whole content is the body. A single newline
- * separating the closing `---` from the body is consumed so the inserted block
- * does not start with a blank line.
+ * Strip the leading YAML frontmatter block, returning the markdown body.
+ * Delegates to the core `stripFrontmatter` so the editor inserter, the plugin
+ * TemplateLoaderPort, and the CLI TemplateLoaderPort share one strip impl
+ * (Веха 3 — no per-consumer regex drift).
  */
 export function extractTemplateBody(content: string): string {
-  // `\r?\n` so a CRLF-stored template file (Windows vault) strips correctly
-  // rather than leaking its frontmatter block into the inserted body — matching
-  // the repo's newer frontmatter strippers (validate-schema, CliProfileResolver).
-  const match = content.match(/^---\r?\n[\s\S]*?\r?\n---\r?\n?/);
-  return match ? content.slice(match[0].length) : content;
+  return stripTemplateFrontmatter(content);
 }
 
 /**


### PR DESCRIPTION
## What

Homoiconic templating subproject `17f58ebe`, **Веха 3** — the body-copy primitive (`create_instance` writes an empty body). Builds on the merged Веха 2+4 (#3637).

A new `body_template` grounding type copies a body template into the target file's body (frontmatter preserved):
- **source:** inline `bodyTemplate` literal OR `templateRef` → an `exotemplate__Template` asset loaded via the injected `TemplateLoaderPort`.
- **$token resolution** via the shared `SubstitutionResolverRegistry` (Веха 4 — reuse, interview Q6).
- **composable** as a `composite` step: after `create_instance` it writes into the **newly created** asset (the composite threads the created file's path to `body_template` steps — zero regression for existing composites). This is the Q7 design: body-copy = a separate composite step, not a create_instance argument. Q9: the capability is implemented + tested; Andrey wires the concrete «Create Project» composite himself.

## Files
**Core:** `GroundingType.BODY_TEMPLATE` + 3 bijection maps (parity-guarded) · `executeBodyTemplate` + composite openPath threading · `stripTemplateFrontmatter` (single strip impl, distinct from `sparqlBlock.stripFrontmatter` which keeps a leading newline) · `TemplateLoaderPort` · `GroundingDefinition.bodyTemplate`/`templateRef` + both parsers (CommandResolver triple-store + GroundingFrontmatterParser).
**Wiring (UI/CLI parity #3417):** plugin + CLI inject a `templateLoader` (load exotemplate__Template body by UID).
**TBox (exoas-exocmd submodule, pointer bumped):** `exocmd__GroundingTypeBodyTemplate` enum + `Grounding_bodyTemplate`/`_templateRef` properties.

## Tests
body_template ×10 (incl. **composite create_instance→body_template thread** end-to-end via in-memory fs) · GroundingTypeParity 11/11 · vault-fixture-parity 11/11 (reads the bumped submodule) · parser fields · `stripTemplateFrontmatter` ×5. Regression: CommandResolver 148, GroundingExecutor 159. Full build + mobile-loadable + archgate (MOBILE-004=0) green.

## Out of scope
Веха 5 (Templater replacement) — narrow, `tp.date.*` already covered by resolvers; WBS-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)