### PR TITLE
docs(templating): document homoiconic templating (вехи 2-4, as-shipped)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -34,6 +34,7 @@ docs kept at root) is in **[TAXONOMY.md](TAXONOMY.md)**.
 - [Troubleshooting.md](how-to/Troubleshooting.md) — **user** troubleshooting (common issues & fixes)
 - [profile.md](explanation/profile.md) — Profile pitch + Apply-profile (mount-state) usage
 - [exosync.md](how-to/exosync.md) — ExoSync usage (`Exocortex: Sync`, structured merge, conflict quarantine)
+- [templating.md](how-to/templating.md) — homoiconic templating: insert tokens, insert template blocks, `body_template` grounding
 - [../packages/obsidian-plugin/docs/release-checklist-mobile.md](../packages/obsidian-plugin/docs/release-checklist-mobile.md) — mobile release checklist
 
 ## Reference
@@ -41,6 +42,7 @@ docs kept at root) is in **[TAXONOMY.md](TAXONOMY.md)**.
 - [PROPERTY_SCHEMA.md](reference/PROPERTY_SCHEMA.md) — full frontmatter property vocabulary
 - [Core-API.md](reference/Core-API.md) — `exocortex` core programmatic API
 - [SHACL_LITE_MAPPING.md](reference/SHACL_LITE_MAPPING.md) — SHACL-lite shape mapping
+- [templating.md](reference/templating.md) — templating commands, `exotemplate__Template` class, `body_template` grounding, substitution tokens
 - [ExoRDF-Mapping.md](explanation/ExoRDF-Mapping.md) — vault ↔ RDF triple mapping
 - CLI reference — [CLI_API_REFERENCE.md](../packages/cli/docs/CLI_API_REFERENCE.md), [ONTOLOGY_REFERENCE.md](../packages/cli/docs/ONTOLOGY_REFERENCE.md), [SPARQL_GUIDE.md](../packages/cli/docs/SPARQL_GUIDE.md), [SPARQL_COOKBOOK.md](../packages/cli/docs/SPARQL_COOKBOOK.md), [VERSIONING.md](../packages/cli/VERSIONING.md)
 - Plugin reference — [EXO_LAYOUT.md](../packages/obsidian-plugin/docs/EXO_LAYOUT.md) — layout engine
@@ -51,6 +53,7 @@ docs kept at root) is in **[TAXONOMY.md](TAXONOMY.md)**.
 - [assetspace-sdk-topology.md](explanation/assetspace-sdk-topology.md) — exo-as-SDK: what an AssetSpace is, why there are many `exoas-*` repos, what a Profile is
 - [CROSS_RUNTIME_PARITY.md](explanation/CROSS_RUNTIME_PARITY.md) — validator instance of the UI/CLI Parity Invariant
 - [settings-homoiconization.md](explanation/settings-homoiconization.md) — plugin settings as `exo__Setting` vault assets
+- [templating.md](explanation/templating.md) — why homoiconic templating (templates as assets, one token vocabulary; replaces Templates/Templater)
 - [exosync-parallel-run.md](explanation/exosync-parallel-run.md) — ExoSync parallel-run mode + M1/M2 parity harness
 - `diagrams/` — Mermaid architecture diagrams (`architecture-overview.mmd`, `asset-creation-flow.mmd`, `command-execution-flow.mmd`, `layout-rendering.mmd`, `property-inheritance.mmd`, `service-dependencies.mmd`, `status-workflow.mmd`, `future-architecture.mmd`)
 

--- a/docs/explanation/templating.md
+++ b/docs/explanation/templating.md
@@ -1,0 +1,92 @@
+# Why homoiconic templating
+
+> Subproject `17f58ebe` (vision `09a3fbec`) · PRs #3637 (v16.116.0), #3641 (v16.121.0)
+> Task guide: [Insert tokens & apply body templates](../how-to/templating.md) ·
+> Reference: [Templating reference](../reference/templating.md)
+
+Templating in Exocortex is **homoiconic**: a template is a vault asset, not a
+file in a hidden plugin folder or a string baked into TypeScript. This page
+explains why, and how it differs from the Obsidian _Templates_ / _Templater_
+plugins it replaces.
+
+## The problem with conventional templating
+
+The Obsidian _Templates_ core plugin and the _Templater_ community plugin store
+templates as plain files in a designated folder and expand a fixed set of
+`{{date}}`-style placeholders. Two things sit outside the knowledge graph:
+
+- **The templates themselves** are just files — not assets. You cannot query
+  them, link to them, classify them, or reason over them the way you do every
+  other thing in the vault.
+- **The placeholder vocabulary** is a parallel, plugin-specific mini-language.
+  A `{{date}}` in a template and a date written by some other automation are
+  produced by different code with different formats.
+
+## The homoiconic answer
+
+Exocortex applies its [Homoiconicity Invariant](../../CLAUDE.md): anything a
+user can configure should be describable as vault assets (an RDF graph), with
+TypeScript reserved for the processing core, platform integration, and
+structural guard rails.
+
+Templating follows that to the letter on two axes:
+
+### Templates are assets
+
+A body template is an instance of the `exotemplate__Template` class. Its
+markdown **body** is the template content — there is no separate "body"
+property, because "an `exotemplate__Template` asset's body is its file body."
+That means a template is a first-class citizen: it has a UID and a label, it
+lives in an AssetSpace (`exoas-public`), it can be linked, queried, and shared
+exactly like any other asset. The "Insert template" command simply enumerates
+the assets of that class — there is no template folder to configure and no
+hardcoded block list.
+
+### Tokens reuse one vocabulary
+
+The vision spoke of "variables", but there is **no** `exotemplate__Variable`
+class. Placeholders are the **existing** `exocmd__SubstitutionToken`
+vocabulary, resolved through the single shared `SubstitutionResolverRegistry`.
+A `$today` typed into a template body and a `$today` resolved while a
+`create_instance` command builds an asset go through the very same resolver —
+one source of truth, identical output. Adding a new token benefits hand-insert,
+template bodies, and RDF-driven creation at once.
+
+## How the three surfaces compose
+
+The same two primitives — "a template body" and "token resolution" — power
+three user-facing surfaces, each a thin layer over shared core code:
+
+| Surface | What it is | Shared core it reuses |
+|---|---|---|
+| `Insert template token` | scalar value at the cursor | the resolver registry |
+| `Insert template` | a template asset's body at the cursor | body strip + token resolution |
+| `body_template` grounding | a template body copied into a created asset | body strip + token resolution |
+
+Because the strip-and-resolve logic lives once in the core package, the plugin
+editor command, the plugin's create-instance pipeline, and the CLI all behave
+identically — no per-consumer drift.
+
+## Desktop ↔ mobile parity
+
+The editor surfaces are pure editor operations — no `git`, Node, or filesystem
+dependency — so they are registered unconditionally and behave the same on
+desktop and iOS, per the [Desktop↔Mobile Command Parity Invariant](../../CLAUDE.md).
+The `body_template` grounding writes through the same vault-adapter path the
+rest of asset creation uses, so it is cross-platform too.
+
+## A note on dates
+
+The "Insert template token" date/timestamp choices resolve to **local** time
+(`nowDate` / `nowTimestamp`), not UTC. The author works in UTC+5 in the early
+morning, when a UTC date is still "yesterday" — a local date matches the user's
+expectation and the no-timezone timestamp shape used elsewhere in the system.
+Template bodies can use either family (`$nowDate` local, `$today` UTC); see the
+[token reference](../reference/templating.md#substitution-tokens).
+
+## Related
+
+- [How-to: insert tokens & apply body templates](../how-to/templating.md)
+- [Templating reference](../reference/templating.md)
+- [assetspace-sdk-topology.md](assetspace-sdk-topology.md) — what an AssetSpace
+  is and why templates live in `exoas-public`

--- a/docs/how-to/templating.md
+++ b/docs/how-to/templating.md
@@ -1,0 +1,154 @@
+# Homoiconic templating — insert tokens & apply body templates
+
+> Subproject `17f58ebe` (vision `09a3fbec`) · PRs #3637 (v16.116.0), #3641 (v16.121.0)
+> See also: [Templating reference](../reference/templating.md) · [Why homoiconic templating](../explanation/templating.md)
+
+Exocortex ships a built-in, homoiconic replacement for the Obsidian _Templates_
+and _Templater_ plugins. Templates are ordinary vault assets (class
+`exotemplate__Template`); placeholder tokens (`$today`, `$randomUUIDv4`, …)
+reuse the same `exocmd__SubstitutionToken` vocabulary that the RDF-driven
+asset-creation pipeline uses — so a value you insert by hand and the same token
+resolved during command execution come from one source of truth.
+
+There are three ways to use it:
+
+1. **Insert a single token** at the cursor (`Insert template token`).
+2. **Insert a whole template block** at the cursor (`Insert template`).
+3. **Apply a body template when an asset is created** (the `body_template`
+   grounding step).
+
+All three are editor/runtime-only — they need no `git`, Node, or filesystem
+access, so they work identically on desktop and iOS (Desktop↔Mobile Command
+Parity).
+
+---
+
+## 1. Insert a single token
+
+Use this to drop a fresh UUID, timestamp, or date wherever your cursor is.
+
+1. Place the cursor in any Markdown note.
+2. Run **`Exocortex: Insert template token`** (`Cmd/Ctrl-P` → search "insert
+   template token"). The command is hidden when no Markdown editor is active.
+3. Pick one of the three choices in the fuzzy picker:
+
+   | Choice | Inserts | Example |
+   |---|---|---|
+   | **Random UUID** | a random UUID v4 (lowercase) | `9f1c2e8a-…` |
+   | **Current Timestamp** | local date-time, no timezone | `2026-06-20T08:14:03` |
+   | **Current Date** | today's **local** date | `2026-06-20` |
+
+   The chosen value replaces any current selection. Press `Escape` to cancel
+   (no-op).
+
+> The date/timestamp choices use your **local** time on purpose — an early
+> morning in UTC+5 should not stamp "yesterday".
+
+## 2. Insert a whole template block
+
+Use this for reusable section skeletons ("## Resources / ## Plan / ## Log").
+The blocks are vault assets, so you edit them like any other note.
+
+### Author a template
+
+Create a note whose **body** is the template content, and tag it with the
+`exotemplate__Template` class:
+
+```yaml
+exo__Instance_class: "[[8bdf4506-80bf-4999-8fda-1ea0808b4ee5]]"
+exo__Asset_label: Project body
+```
+
+```markdown
+## Resources
+
+## Execution plan
+
+## Log
+- $nowTimestamp — created
+```
+
+Anything after the frontmatter is the template body. `$token` markers in the
+body are resolved on insert (see the [token reference](../reference/templating.md#substitution-tokens)).
+
+### Insert it
+
+1. Place the cursor where the block should go.
+2. Run **`Exocortex: Insert template`**.
+3. Fuzzy-pick a template by its label. Its body is inserted at the cursor with
+   tokens resolved.
+
+If the vault has no `exotemplate__Template` assets yet, the command shows a
+guiding notice (`No templates found. Create an exotemplate__Template asset…`)
+instead of an empty picker.
+
+> Unknown or context-less tokens are left **literal** rather than blanked — a
+> visible `$target` you can fix beats a silently deleted one. See the
+> [leniency contract](../reference/templating.md#leniency-contract).
+
+## 3. Apply a body template when an asset is created
+
+Use this to give every asset created by a command a pre-filled body. It is the
+`body_template` grounding step, composed after a `create_instance` step.
+
+A `body_template` grounding sources its markdown from either an inline literal
+or a reference to an `exotemplate__Template` asset (the reference wins when both
+are present), resolves `$token` markers, and writes the result as the target
+file's body (the frontmatter is preserved).
+
+### Reference a template asset (homoiconic — preferred)
+
+```yaml
+exo__Instance_class:
+  - "[[exocmd__Grounding]]"
+exo__Asset_label: "Project body template"
+exocmd__Grounding_type: "[[6093bfcb-cf9b-4565-86c3-ff74d8bc11c0]]"
+exocmd__Grounding_templateRef: "[[8bdf4506-80bf-4999-8fda-1ea0808b4ee5|Project body]]"
+```
+
+### Or inline the markdown
+
+```yaml
+exo__Instance_class:
+  - "[[exocmd__Grounding]]"
+exo__Asset_label: "Inline body template"
+exocmd__Grounding_type: "[[6093bfcb-cf9b-4565-86c3-ff74d8bc11c0]]"
+exocmd__Grounding_bodyTemplate: "## Log\n- $nowTimestamp — created"
+```
+
+### Compose it after `create_instance`
+
+To create an asset _and_ fill its body, list a `create_instance` step and a
+`body_template` step inside a `composite` grounding (`exocmd__Grounding_steps`).
+The composite threads the just-created file's path to the `body_template` step,
+so the template lands in the **new** asset, not the click target:
+
+```yaml
+exo__Instance_class:
+  - "[[exocmd__Grounding]]"
+exo__Asset_label: "Create project with body"
+exocmd__Grounding_type: "[[8f9a57db-3865-4886-92fb-c5ab7f3c3fa3]]"
+exocmd__Grounding_steps:
+  - "[[<create_instance grounding UID>]]"
+  - "[[<body_template grounding UID>]]"
+```
+
+Wire that grounding to an `exocmd__Command` via `exocmd__Command_grounding` as
+for any other dynamic command — see
+[Customizing dynamic commands](ONTOLOGY_EXTENSION.md) for the command/binding
+authoring flow.
+
+> If a `templateRef` is authored but the runtime cannot load the template
+> (e.g. a headless CLI run with no template index), the step falls back to an
+> inline `bodyTemplate` when present, otherwise it fails loudly — a no-op body
+> write is treated as a configuration error.
+
+---
+
+## Related
+
+- [Templating reference](../reference/templating.md) — commands, classes,
+  grounding fields, and the full token table.
+- [Why homoiconic templating](../explanation/templating.md) — design rationale.
+- [ONTOLOGY_EXTENSION.md](ONTOLOGY_EXTENSION.md) — authoring dynamic commands
+  and groundings.

--- a/docs/reference/templating.md
+++ b/docs/reference/templating.md
@@ -123,7 +123,7 @@ with no command context):
 | Token | Resolves to |
 |---|---|
 | `$today` | UTC date `YYYY-MM-DD` (`toISOString`) |
-| `$todayStart` | start of today, ISO timestamp (UTC) |
+| `$todayStart` | start of today at **local** midnight, as a UTC-serialised ISO timestamp |
 | `$nowTimestamp` | **local** date-time `YYYY-MM-DDTHH:MM:SS` (no TZ) |
 | `$nowDate` | **local** date `YYYY-MM-DD` |
 | `$nowYear` | current year, e.g. `2026` |

--- a/docs/reference/templating.md
+++ b/docs/reference/templating.md
@@ -1,0 +1,166 @@
+# Templating reference
+
+> Subproject `17f58ebe` (vision `09a3fbec`) · PRs #3637 (v16.116.0), #3641 (v16.121.0)
+> Task guide: [Insert tokens & apply body templates](../how-to/templating.md) ·
+> Rationale: [Why homoiconic templating](../explanation/templating.md)
+
+Authoritative reference for Exocortex's homoiconic templating: the editor
+commands, the `exotemplate__Template` class, the `body_template` grounding
+step, and the substitution-token vocabulary.
+
+---
+
+## Editor commands
+
+Both commands are editor-only (registered with an `editorCallback`, so Obsidian
+auto-hides them outside an active Markdown editor) and contain no `git`/Node/fs
+dependency, so they are registered unconditionally on desktop and iOS.
+
+| Command name | Command id | Effect |
+|---|---|---|
+| **Insert template token** | `insert-template-token` | Opens a fuzzy picker of three fixed token choices; inserts the resolved scalar value at the cursor. |
+| **Insert template** | `insert-template` | Opens a fuzzy picker over the vault's `exotemplate__Template` assets; inserts the chosen template's body (with `$token` markers resolved) at the cursor. |
+
+### `Insert template token` choices
+
+| Menu label | Resolver | Output format | Notes |
+|---|---|---|---|
+| Random UUID | `randomUUIDv4` | bare v4, lowercase | `crypto.randomUUID()`; throws if no Web Crypto / Node crypto |
+| Current Timestamp | `nowTimestamp` | `YYYY-MM-DDTHH:MM:SS` | **local** time, no timezone suffix |
+| Current Date | `nowDate` | `YYYY-MM-DD` | **local** date |
+
+A dismissed picker (`Escape`) is a silent no-op; the inserted text is its own
+success feedback.
+
+### `Insert template` behaviour
+
+- Enumerates every vault asset whose `exo__Instance_class` names the
+  `exotemplate__Template` class (by UID or by the symbolic label
+  `exotemplate__Template`), sorted case-insensitively by `exo__Asset_label`
+  (falling back to the file basename).
+- An empty result surfaces the notice
+  `No templates found. Create an exotemplate__Template asset (with a body) to insert it here.`
+- On selection: the chosen file is read, its leading frontmatter is stripped,
+  `$token` markers in the body are resolved, and the result replaces the current
+  selection at the cursor.
+
+---
+
+## `exotemplate__Template` class
+
+A body template is an ordinary vault note: the markdown **body** (everything
+after the frontmatter) is the template content. There is **no dedicated body
+property** — homoiconicity means "an `exotemplate__Template` asset's body is its
+file body."
+
+| Attribute | Value |
+|---|---|
+| Class UID | `8bdf4506-80bf-4999-8fda-1ea0808b4ee5` |
+| Symbolic label | `exotemplate__Template` |
+| Metaclass (`exo__Instance_class`) | `exo__Class` (`8619c4fc-…`) |
+| `exo__Class_superClass` | `exo__Asset` (`493c2ae2-…`) |
+| Ontology (`exo__Asset_isDefinedBy`) | `$exotemplate` (`d6947db1-…`), in the `exoas-public` AssetSpace |
+
+Minimal authoring frontmatter:
+
+```yaml
+exo__Instance_class: "[[8bdf4506-80bf-4999-8fda-1ea0808b4ee5]]"
+exo__Asset_label: My template
+```
+
+> There is **no** `exotemplate__Variable` class. The vision's "variables" are
+> the existing `exocmd__SubstitutionToken` vocabulary (see
+> [substitution tokens](#substitution-tokens)) — one source of truth.
+
+---
+
+## `body_template` grounding
+
+A grounding step that copies a resolved body template into the body of its
+target file, preserving the target's frontmatter.
+
+| Attribute | Value |
+|---|---|
+| Grounding type | `body_template` |
+| Catalog asset (`exocmd__Grounding_type`) | `exocmd__GroundingTypeBodyTemplate` (`6093bfcb-cf9b-4565-86c3-ff74d8bc11c0`) |
+
+### Source fields (one required)
+
+| Field | Type | Meaning |
+|---|---|---|
+| `exocmd__Grounding_templateRef` | UID wikilink → `exotemplate__Template` | Load that asset's body as the template. **Preferred** when both are set. |
+| `exocmd__Grounding_bodyTemplate` | inline markdown literal | Used directly as the template. Fallback when `templateRef` cannot be loaded. |
+
+Resolution order: `templateRef` (via the injected template loader) wins; if no
+loader is wired (e.g. a headless CLI/test run) it degrades to the inline
+`bodyTemplate`, and if neither yields a body the step **fails loudly** — a no-op
+body write is a configuration error.
+
+### Target inside a `composite`
+
+When a `body_template` step runs inside a `composite` grounding
+(`exocmd__Grounding_steps`), the composite threads the **most-recently-created
+asset's** path (from a preceding `create_instance` step) to the `body_template`
+step, so the template lands in the new asset rather than the click target. Every
+other step type keeps operating on the original target — a zero-regression
+addition for existing composites.
+
+---
+
+## Substitution tokens
+
+Template bodies (and the `Insert template token` command) draw on the shared
+`SubstitutionResolverRegistry` — the same registry the RDF-driven
+asset-creation pipeline dispatches. A token is written `$name` in a body;
+`$name` is a `$` followed by a letter then letters/digits/underscore (greedy,
+so `$todayX` is the token `todayX`, not `today`).
+
+### Context-free tokens
+
+Resolve anywhere, including the editor `Insert template` command (which runs
+with no command context):
+
+| Token | Resolves to |
+|---|---|
+| `$today` | UTC date `YYYY-MM-DD` (`toISOString`) |
+| `$todayStart` | start of today, ISO timestamp (UTC) |
+| `$nowTimestamp` | **local** date-time `YYYY-MM-DDTHH:MM:SS` (no TZ) |
+| `$nowDate` | **local** date `YYYY-MM-DD` |
+| `$nowYear` | current year, e.g. `2026` |
+| `$nowMonth` | current month, zero-padded, e.g. `06` |
+| `$randomUUIDv4` | a random UUID v4, lowercase |
+
+### Context-dependent tokens
+
+Resolve only when the command supplies context (e.g. inside a `body_template`
+grounding with a target/user-input). With no context they yield an empty string
+and so are left **literal** in editor inserts:
+
+| Token | Resolves to (with context) |
+|---|---|
+| `$target` | `"[[<target IRI>]]"` wikilink |
+| `$targetFolder` | the target file's folder path |
+| `$userInputLabel` | the user-entered label |
+| `$userInput` | a named user-input parameter (`$userInput` family) |
+| `$targetProperty` | a frontmatter property of the target |
+| `$labelAsArray` | the user label wrapped as a single-element list |
+| `$groundingTargetClass` | the grounding's target class wikilink |
+| `$targetClassSelf` | the host file's own UID as a class wikilink |
+
+### Leniency contract
+
+Body-template substitution is deliberately lenient (a markdown body is freeform
+prose). A `$token` is replaced **only** when the token is known **and** resolves
+to a non-empty scalar string. In every other case — unknown token, a list-typed
+or `null` result, **or an empty string** (the context-less case above) — the
+literal `$name` text is left untouched. So `$5.00`, `$totallyUnknown`, and a
+context-missing `$target` all survive unchanged. A visible unresolved token you
+can fix beats a silently deleted one.
+
+---
+
+## Related
+
+- [How-to: insert tokens & apply body templates](../how-to/templating.md)
+- [Explanation: why homoiconic templating](../explanation/templating.md)
+- [PROPERTY_SCHEMA.md](PROPERTY_SCHEMA.md) — full frontmatter property vocabulary


### PR DESCRIPTION
## What

User-facing Diátaxis docs for the homoiconic templating feature (subproject `17f58ebe`, vision `09a3fbec`), which shipped via **PR #3637 (v16.116.0)** + **PR #3641 (v16.121.0)** with **zero user-facing docs** — a systemic gap (Andrey 2026-06-20: «Где почитать про гомоиконный templating?»).

## Docs added (documented **as-shipped**, verify-before-assert against code + TBox)

- **`docs/how-to/templating.md`** — three task flows: `Insert template token` (scalar), `Insert template` (block from `exotemplate__Template` asset), and the `body_template` grounding (`create_instance` + `body_template` composite).
- **`docs/reference/templating.md`** — both editor commands (ids + token formats), the `exotemplate__Template` class (UID/metaclass/superClass/ontology), `body_template` grounding fields (`templateRef` / `bodyTemplate`, priority, composite threading), the full substitution-token table, and the leniency contract.
- **`docs/explanation/templating.md`** — why homoiconic (templates as first-class assets; one `exocmd__SubstitutionToken` vocabulary; Desktop↔Mobile parity; replaces Obsidian Templates/Templater).
- **`docs/README.md`** — index entries under How-to / Reference / Explanation.

## Verify-before-assert note

There is **no** `exotemplate__Variable` class — the vision's «variables» are the existing `exocmd__SubstitutionToken` vocabulary (resolved via the shared `SubstitutionResolverRegistry`). Documented the actual behaviour, not the milestone framing.

## Checks
- `docs:validate` (property names) green locally (0 missing).
- All relative links resolve locally.
- Docs-only change — no source touched.