### PR TITLE
feat(graph-viz): add person__Person node style (M3.5-A)

### DIFF
--- a/packages/exocortex/src/domain/models/GraphTypes.ts
+++ b/packages/exocortex/src/domain/models/GraphTypes.ts
@@ -351,6 +351,12 @@ export const BUILT_IN_NODE_STYLES: Record<string, Partial<NodeStyle>> = {
     color: "#f59e0b",
     shape: "diamond",
   },
+  // Person — canonical class. `ims__Person` retained for backward-compat with
+  // not-yet-migrated graph nodes (deprecated; data migration is M3.5-B post-alpha).
+  "person__Person": {
+    color: "#06b6d4",
+    shape: "circle",
+  },
   "ims__Person": {
     color: "#06b6d4",
     shape: "circle",

--- a/packages/exocortex/tests/unit/domain/models/GraphTypes.test.ts
+++ b/packages/exocortex/tests/unit/domain/models/GraphTypes.test.ts
@@ -96,6 +96,18 @@ describe("GraphTypes", () => {
       expect(BUILT_IN_NODE_STYLES[RDF_TYPE_PREDICATES.OWL_CLASS]).toBeDefined();
       expect(BUILT_IN_NODE_STYLES[RDF_TYPE_PREDICATES.OWL_CLASS].shape).toBe("diamond");
     });
+
+    it("should have style for person__Person (canonical person class)", () => {
+      expect(BUILT_IN_NODE_STYLES["person__Person"]).toBeDefined();
+      expect(BUILT_IN_NODE_STYLES["person__Person"].color).toBe("#06b6d4");
+      expect(BUILT_IN_NODE_STYLES["person__Person"].shape).toBe("circle");
+    });
+
+    it("should retain style for ims__Person (deprecated, backward-compat for un-migrated nodes)", () => {
+      expect(BUILT_IN_NODE_STYLES["ims__Person"]).toBeDefined();
+      expect(BUILT_IN_NODE_STYLES["ims__Person"].color).toBe("#06b6d4");
+      expect(BUILT_IN_NODE_STYLES["ims__Person"].shape).toBe("circle");
+    });
   });
 
   describe("BUILT_IN_EDGE_STYLES", () => {


### PR DESCRIPTION
## Что

Добавляет канонический ключ `person__Person` в `BUILT_IN_NODE_STYLES` (cyan circle, `#06b6d4`), зеркалящий стиль deprecated `ims__Person`. `ims__Person` **сохранён** для backward-compat с ещё-не-мигрированными узлами графа.

## Зачем

Code-first часть re-prefix `ims__Person` → `person__Person` (веха M3.5-A, Alpha Launch). После удаления NL-feature (параллельная сессия) `GraphTypes.ts` — **единственная** оставшаяся code-side ссылка на `ims__Person` (graph-viz косметика). Data-миграция ~137 инстансов — отдельно, M3.5-B post-alpha.

## Изменения

- `packages/exocortex/src/domain/models/GraphTypes.ts` — +1 запись `person__Person` (additive, `ims__Person` не тронут)
- `packages/exocortex/tests/unit/domain/models/GraphTypes.test.ts` — +2 кейса (canonical + backward-compat)

## Verification (TDD, revert-verify)

- `person__Person` тест **FAILS pre-impl** (undefined), **PASSES post-impl** — exercises the change
- `ims__Person` backward-compat тест PASSES (style retained)
- GraphTypes suite: 38/38 ✓ · TypeRegistry: 60/60 ✓
- typecheck: ✓ · lint (source, `--max-warnings=0`): ✓ · archgate: 21/21 ✓

Additive only (18 insertions, 0 deletions); zero behavioural regression — узлы `person__Person` теперь получают cyan-circle стиль вместо default.

Refs M3.5-A (vault node `23d96411`).