### PR TITLE
docs(onboarding): actualize palette command names + lead with first-run wizard + PAT scopes

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,11 +65,11 @@ Best for: Visual knowledge management, daily planning, interactive exploration.
 **Install Exocortex via BRAT:**
 
 1. Install [BRAT](https://github.com/TfTHacker/obsidian42-brat) plugin from Obsidian Community Plugins
-2. Open BRAT settings → **Add Beta Plugin**
-3. Enter repository: `kitelev/exocortex`
-4. Click **Add Plugin** and enable Exocortex in Community plugins
+2. Open the command palette (**Cmd/Ctrl + P**) and run **"BRAT: Plugins: Add a beta plugin for testing"** — in current BRAT (2.0.8+) adding a plugin is a command-palette action, **not** a settings-tab button.
+3. Enter repository `kitelev/exocortex`, then **select a release from the "Select a version…" dropdown** (required — the dialog ignores **Add Plugin** until a version is picked).
+4. Click **Add Plugin** and confirm Exocortex is enabled in Community plugins.
 
-BRAT will automatically keep the plugin updated with new releases.
+BRAT will automatically keep the plugin updated with new releases. For the full walkthrough (Restricted Mode, Windows `obsidian://` fallback, version-dropdown gotcha) see the **[Getting Started Guide](./docs/tutorials/Getting-Started.md#installation)**.
 
 > **Next:** Follow the **[Getting Started Guide](./docs/tutorials/Getting-Started.md)** to bootstrap your vault and create your first Area, Project, and Task.
 >
@@ -207,7 +207,7 @@ Features: wikilink syntax, loading state, error handling, auto-refresh, interact
 Install community ontology packages (AssetSpaces) to extend your knowledge graph:
 
 - **CLI:** `npx @kitelev/exocortex-cli assetspace-add --vault ~/vault --url https://github.com/kitelev/exoas-pmbok-ontology` adds a single AssetSpace from a public GitHub URL; `bootstrap` sets up a fresh vault with the SDK floor.
-- **Plugin:** the **Add assetspace by URL** and **Bootstrap vault** palette commands do the same from Obsidian.
+- **Plugin:** the **Add a knowledge pack** and **Set up the engine** palette commands do the same from Obsidian. (A first-run **Setup (getting started)** wizard chains them with the recommended URLs pre-filled — see the [Getting Started Guide](./docs/tutorials/Getting-Started.md).)
 
 ### Profile — Vault-Declared Context
 
@@ -227,19 +227,22 @@ Statically registered plugin commands (all prefixed `Exocortex:` in the palette)
 
 | Command                               | Description                                                                                                                                                         |
 | ------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Setup (getting started)**           | Open the guided first-run setup wizard (token → engine → registry → profiles → apply); re-openable any time                                                         |
 | **Create asset**                      | Create a new asset via an ontology-driven form                                                                                                                      |
-| **edit properties**                   | Edit the active asset's frontmatter properties                                                                                                                      |
+| **Edit properties**                   | Edit the active asset's frontmatter properties                                                                                                                      |
 | **Reload layout**                     | Re-render the layout on the active asset                                                                                                                            |
 | **Toggle layout visibility**          | Show or hide layouts in Reading Mode                                                                                                                                |
 | **Toggle archived assets visibility** | Show or hide archived assets in layout tables                                                                                                                       |
-| **open sparql query builder**         | Open the interactive SPARQL query builder                                                                                                                           |
 | **Apply profile**                     | Apply a vault-declared profile — mount-state strict replace of the AssetSpace set (available when filesystem materialization is wired: desktop git, or mobile REST) |
+| **Undo last profile apply**           | Revert the most recent profile apply, restoring the previous mount state                                                                                            |
 | **Sync**                              | ExoSync: pull → merge → push the materialized AssetSpace set over the GitHub REST API                                                                               |
-| **Bootstrap vault**                   | Fetch tracked AssetSpaces into a vault (desktop)                                                                                                                    |
-| **Add assetspace by URL**             | Add an AssetSpace from a public GitHub repository (desktop)                                                                                                         |
-| **Push current assetspace**           | Push the AssetSpace containing the active file to its remote                                                                                                        |
-| **Show current state**                | Report the last-applied profile                                                                                                                                     |
-| **Clear switch cache (wipe-all)**     | Clear the profile-switch tarball cache                                                                                                                              |
+| **Check sync status**                 | Report sync divergence for the materialized AssetSpaces without writing (read-only parity check)                                                                    |
+| **Set up the engine**                 | Bootstrap a vault with the foundational exo AssetSpace floor                                                                                                        |
+| **Add a knowledge pack**              | Add an AssetSpace from a public GitHub repository                                                                                                                   |
+| **Push current knowledge pack**       | Push the AssetSpace containing the active file to its remote                                                                                                        |
+| **Show active profile**               | Report the last-applied profile                                                                                                                                     |
+| **Remove knowledge pack (advanced)**  | Unmount an AssetSpace from the vault                                                                                                                                |
+| **Reset profile cache (advanced)**    | Clear the profile-switch tarball cache                                                                                                                              |
 
 In addition, vault-defined `exocmd__Command` assets are registered **dynamically** as palette commands (the homoiconic command layer) — their set depends on the commands declared in your vault, with visibility gated by their preconditions.
 

--- a/README.md
+++ b/README.md
@@ -228,7 +228,6 @@ Statically registered plugin commands (all prefixed `Exocortex:` in the palette)
 | Command                               | Description                                                                                                                                                         |
 | ------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | **Setup (getting started)**           | Open the guided first-run setup wizard (token → engine → registry → profiles → apply); re-openable any time                                                         |
-| **Create asset**                      | Create a new asset via an ontology-driven form                                                                                                                      |
 | **Edit properties**                   | Edit the active asset's frontmatter properties                                                                                                                      |
 | **Reload layout**                     | Re-render the layout on the active asset                                                                                                                            |
 | **Toggle layout visibility**          | Show or hide layouts in Reading Mode                                                                                                                                |
@@ -244,7 +243,7 @@ Statically registered plugin commands (all prefixed `Exocortex:` in the palette)
 | **Remove knowledge pack (advanced)**  | Unmount an AssetSpace from the vault                                                                                                                                |
 | **Reset profile cache (advanced)**    | Clear the profile-switch tarball cache                                                                                                                              |
 
-In addition, vault-defined `exocmd__Command` assets are registered **dynamically** as palette commands (the homoiconic command layer) — their set depends on the commands declared in your vault, with visibility gated by their preconditions.
+In addition, vault-defined `exocmd__Command` assets are registered **dynamically** as palette commands (the homoiconic command layer) — their set depends on the commands declared in your vault, with visibility gated by their preconditions. Asset-creation commands (e.g. **Create Task Instance**, **Create Project**) live in this dynamic layer rather than as a static "Create asset" command.
 
 ---
 

--- a/docs/tutorials/Getting-Started.md
+++ b/docs/tutorials/Getting-Started.md
@@ -89,6 +89,20 @@ You describe your entities (tasks, projects, areas, or any custom type) in YAML 
 
 BRAT will automatically keep the plugin updated with new releases.
 
+### Recommended: the first-run setup wizard
+
+The fastest way through setup is the built-in wizard. **When you enable Exocortex on a fresh vault** (empty, or only the stock `Welcome.md`), a **"Welcome to Exocortex"** panel opens automatically with a **5-step checklist** that walks you through the whole canonical path — with the recommended repository URLs pre-filled:
+
+1. **Add your GitHub token** (optional) — only needed for **private** AssetSpaces; skip it for a fully-public vault. Includes a **Create token on GitHub** link and a **Test connection** button (see [Plugin Settings → GitHub PAT](#plugin-settings)).
+2. **Set up the engine** — bootstraps the `exo` SDK floor.
+3. **Add the AssetSpace registry** — `kitelev/exoas-registry` (pre-filled).
+4. **Add the profiles AssetSpace** — `kitelev/exoas-profiles` (pre-filled).
+5. **Apply a profile** — pick one; it mounts that profile's AssetSpaces.
+
+Each step opens its own dialog **on top of** the panel, so the panel stays open underneath and you can come back to the next step. **Re-open the wizard any time** via **Cmd/Ctrl + P → "Exocortex: Setup (getting started)"** — handy if your vault already had notes (the wizard auto-shows only on a genuinely fresh vault, but the command always works).
+
+> **Prefer to do it by hand?** The numbered **Step 2 / Step 2b** sections below are the same flow done manually and explained in depth. If the wizard is open, just follow it; the sections below are the reference for what each step does (and the git-commit note in Step 2b still applies to a git-backed vault before the first Apply).
+
 ### Step 2: Bootstrap your vault (the engine floor)
 
 The plugin needs ontology files in your vault to enable layouts, action buttons, and commands. Rather than downloading anything by hand, the plugin pulls them straight from public GitHub repositories using its built-in **Set up the engine** command.
@@ -162,9 +176,15 @@ exo__Asset_label: Test Area
 - If the `exocmd/` folder is present and the plugin loads cleanly, fully **quit and reopen Obsidian** (cold restart) to force re-indexing
 - Try Cmd/Ctrl+P → "Reload layout"
 
-### Keeping AssetSpaces up to date: "Exocortex: Sync"
+### Your first sync: "Exocortex: Sync"
 
-Bootstrapped AssetSpaces are GitHub-backed. To pull (and push) updates later, run **Cmd/Ctrl + P → "Exocortex: Sync"**. The command syncs every materialized AssetSpace with its GitHub repository and requires a GitHub **Personal Access Token** configured in **Settings → Exocortex**. See [ExoSync](../how-to/exosync.md) for details.
+Bootstrapped AssetSpaces are GitHub-backed. To pull (and push) updates, run **Cmd/Ctrl + P → "Exocortex: Sync"**. This is the last step of the canonical setup path.
+
+1. **Configure a GitHub PAT first** — Sync needs the fine-grained token from the section above (it pushes/pulls AssetSpace commits). Without one, the command shows a "configure PAT" notice instead of running. The engine reads the currently-stored PAT on every invocation, so a freshly-saved token works without a reload.
+2. **Run "Exocortex: Sync".** One run syncs **every** materialized AssetSpace with its GitHub repository — pull → merge → push, children-before-parents, best-effort (one failing repo never blocks the rest).
+3. **Read the summary notice** — it reports `pushed / pulled / merged / quarantined` counts; per-repo details go to the developer console (`[ExoSync] …`).
+
+The **first** sync over a freshly-mounted AssetSpace just bootstraps its baseline (nothing is overwritten unless the local tree already diverged from the remote). For the full model — 3-way merge, conflict quarantine, FileSpaces, CLI usage, and troubleshooting (`full-conflict`, `auth-required`, rate limits) — see [ExoSync](../how-to/exosync.md).
 
 ---
 
@@ -412,8 +432,18 @@ Open **Settings → Exocortex** to configure the plugin. Three things worth know
 
 The starter onboarding (Step 2b) pulls only **public** repositories, so no token is involved. To add **your own** or a **private** AssetSpace:
 
-1. Configure your **GitHub PAT** in _Settings → Exocortex_ (see the bullet above), scoped to the repositories you own (fine-grained PAT with a per-repository allowlist is recommended).
+1. **Create a fine-grained GitHub PAT.** This is the single fiddliest setup step, so the plugin scaffolds it: both the first-run wizard's step 1 and _Settings → Exocortex → GitHub PAT_ show a **Create token on GitHub** link that deep-links straight to GitHub's **fine-grained** token page — [github.com/settings/personal-access-tokens/new](https://github.com/settings/personal-access-tokens/new). Use the **fine-grained** page (not the classic `/settings/tokens/new` one), scope the token to your `exoas-*` repositories with a per-repository allowlist, and grant exactly these permissions:
+
+   | Permission   | Access         | Why                                                                                        |
+   | ------------ | -------------- | ------------------------------------------------------------------------------------------ |
+   | **Contents** | Read and write | Push AssetSpace commits to your `exoas-*` repos (and pull private ones)                    |
+   | **Metadata** | Read-only      | Mandatory baseline (GitHub auto-selects it); also lets **Test connection** list your repos |
+
+   Paste the token into the PAT field and click **Save PAT**, then **Test connection** to verify it reaches GitHub before you rely on it. (The token is stored device-local in `data.local.json`, never synced — see the bullet above.)
+
 2. Declare the AssetSpace in a profile (an `exo__Profile` asset that lists it under `exo__Profile_includes`) and run **"Exocortex: Apply profile"**. Apply uses your PAT to materialize private AssetSpaces.
+
+> **Under-scoped fine-grained PAT?** GitHub returns **404** (not 403) for a private repo the token's allowlist doesn't cover — so a "repo does not exist" error during Apply/Sync usually means the token is missing that repo, not that the repo is gone. Check the token's repository allowlist first.
 
 > The **"Add a knowledge pack"** command is for a single **public** repository (no token), and it does **not** pull that repo's dependencies automatically. For private content, or for a complete dependency-resolved set, prefer the profile path (**Apply profile**) over **Add a knowledge pack**.
 


### PR DESCRIPTION
## What

Docs-only completeness pass over the **canonical new-tester onboarding path** (install → first-run wizard → PAT → Apply profile → first ExoSync). Walked the path as a doc-reader against **fresh origin/main** source and filled the gaps found. **No code touched** (one code-gap flagged, not edited).

## Gaps fixed

**README.md**
- Stale palette **command names** (RFC 0002 §3.2 grooming, source: `commandPaletteContract.ts`): `Bootstrap vault`→**Set up the engine**, `Add assetspace by URL`→**Add a knowledge pack**, `Push current assetspace`→**Push current knowledge pack**, `Show current state`→**Show active profile**, `Clear switch cache (wipe-all)`→**Reset profile cache (advanced)**, `edit properties`→**Edit properties**.
- Dropped **`open sparql query builder`** row — the modal is **absent on origin/main** (`SPARQLQueryBuilderModal.tsx` no longer exists).
- Added verified commands: **Setup (getting started)**, **Undo last profile apply**, **Check sync status**, **Remove knowledge pack (advanced)**.
- Fixed stale BRAT instruction (`Open BRAT settings → Add Beta Plugin`) — BRAT 2.x has **no button**, it's a command-palette action (consistent with the Getting Started guide).

**docs/tutorials/Getting-Started.md**
- Added **"Recommended: the first-run setup wizard"** section — the auto-shown *Welcome to Exocortex* 5-step panel is now the documented primary path (was only a parenthetical). Source: `FirstRunOnboardingModal.ts` + `firstRunOnboarding.ts`.
- Documented the **exact fine-grained PAT** setup (the single hardest step): deep-link `github.com/settings/personal-access-tokens/new` + scope table (**Contents: Read and write**, **Metadata: Read-only**) + **Save PAT** / **Test connection** + 404-not-403 under-scoped caveat. Source: `patSetupHelper.ts` + `exosync.md`.
- Expanded **"Your first sync"** into a followable walkthrough (PAT-gate, children-before-parents, summary notice, first-sync baseline).

## Verification
- Every claim verified against origin/main source (verify-before-assert) — no "looks stale" guesses.
- Internal links + anchors checked; renamed heading has no inbound links.
- Prettier-clean (files were clean on origin/main; only the new PAT table re-aligned).

## Code-gap flagged (not in this PR)
- README still has a `### SPARQL Queries` feature section + CLI examples (valid — **CLI SPARQL still exists**). The branch `refactor/remove-user-facing-sparql` (`al-sparql-rm`) removes the *plugin* SPARQL surface but **does not touch README/docs** — README SPARQL reconciliation should be folded into that work once it merges. (The now-removed palette command was already dropped here.)

🤖 docs-only; ⛔ no plugin/wizard code touched.