### PR TITLE
perf(exosync): Phase 0 per-phase sync timing instrumentation (measure-first)

### DIFF
--- a/packages/cli/src/commands/exosync-sync.ts
+++ b/packages/cli/src/commands/exosync-sync.ts
@@ -48,7 +48,11 @@ import {
   SyncEngine,
   SYNC_BRANCH,
   WATERMARK_STORE_FILENAME,
+  aggregateTimings,
+  formatRepoTimings,
+  formatTimingsLine,
   orderChildrenFirst,
+  totalMs,
   withRateLimitBackoff,
   type LocalFilesPort,
   type MaterializationCheckPort,
@@ -363,6 +367,10 @@ function printRepoResult(
   if ((r.deferredDeletes?.length ?? 0) > 0) {
     out(`  deferred deletes: ${r.deferredDeletes.join(", ")}`);
   }
+  // ExoSync Phase 0 (measure-first) — per-AS phase breakdown for desktop runs.
+  if (r.timings !== undefined && totalMs(r.timings) > 0) {
+    out(`  ${formatRepoTimings(r.repoKey, r.timings)}`);
+  }
 }
 
 /** A repo result is a FAILURE (non-zero exit) when it left unresolved
@@ -477,6 +485,10 @@ export async function runExosyncSync(
     out(
       `Summary: ${results.length} repo(s) — pulled ${totals.pulled}, pushed ${totals.pushed}, merged ${totals.merged}, quarantined ${totals.quarantined}`,
     );
+    // ExoSync Phase 0 (measure-first) — run-total per-phase breakdown so the
+    // dominant phase is visible (which optimisation Phase 1 picks).
+    const aggTimings = aggregateTimings(results);
+    if (totalMs(aggTimings) > 0) out(formatTimingsLine(aggTimings));
   }
 
   return results.some((r) => isFailureStatus(r.status)) ? 1 : 0;

--- a/packages/exocortex/src/index.ts
+++ b/packages/exocortex/src/index.ts
@@ -619,6 +619,26 @@ export {
   type SyncProgressFn,
   type SyncProgressPhase,
 } from "./services/sync/SyncEngine";
+// ExoSync Phase 0 (measure-first) — per-phase wall-clock instrumentation.
+// Engine attributes every REST round-trip / SHA-1 digest / file read into a
+// phase bucket; consumers aggregate + format the breakdown for the device.
+export {
+  SyncPhaseTimer,
+  SYNC_PHASES,
+  classifyRestPhase,
+  emptyTimings,
+  addTimings,
+  aggregateTimings,
+  totalMs,
+  dominantPhase,
+  fmtMs,
+  formatTimingsLine,
+  formatRepoTimings,
+  type SyncPhase,
+  type SyncPhaseCounts,
+  type SyncPhaseTimings,
+  type NowFn,
+} from "./services/sync/SyncPhaseTimer";
 // ExoSync quarantine resolver (finding a0a3d1d6) — the user-facing reconcile
 // the engine announced but never built. Device-local-first (watermark pins +
 // disk + AssetSpace head), one-action convergent resolution, zero-loss.

--- a/packages/exocortex/src/services/sync/SyncEngine.ts
+++ b/packages/exocortex/src/services/sync/SyncEngine.ts
@@ -56,8 +56,14 @@
 import {
   restCreateCommit,
   type CommitFileContent,
+  type RestCommitRequest,
   type RestCommitTransport,
 } from "../../infrastructure/github/restCommit";
+import {
+  SyncPhaseTimer,
+  classifyRestPhase,
+  type NowFn,
+} from "./SyncPhaseTimer";
 import {
   getBlobBytes,
   getBlobText,
@@ -134,6 +140,11 @@ export interface SyncEngineDeps {
    */
   localBaseShaProvider?: (spec: SyncRepoSpec) => Promise<string | null>;
   sha1: Sha1Fn;
+  /**
+   * Clock for the Phase 0 per-phase timing instrumentation (measure-first).
+   * Defaults to `Date.now`. Injected in tests for deterministic durations.
+   */
+  now?: NowFn;
   baseURL?: string;
   /** Cap on 422 re-pull→retry cycles (D16). Default {@link DEFAULT_MAX_PUSH_RETRIES}. */
   maxPushRetries?: number;
@@ -518,14 +529,112 @@ function quarantinedPathsOf(merge: MergeResolution): string[] {
 
 export class SyncEngine {
   private readonly deps: SyncEngineDeps;
-  /** Backoff-wrapped transport (R6) — ALL remote calls go through it. */
+  /**
+   * Backoff-wrapped transport (R6) — ALL remote calls go through it. Phase 0:
+   * additionally wrapped with timing instrumentation so every REST round-trip
+   * is attributed to a phase bucket (observation-only, never branches).
+   */
   private readonly transport: RestCommitTransport;
+  /**
+   * Phase 0: timing-wrapped `sha1`. ALL hashing goes through `gitBlobSha(_,
+   * this.sha1)` so the `hash` bucket captures the hypothesised hot path.
+   */
+  private readonly sha1: Sha1Fn;
+  /** Phase 0 clock (default `Date.now`; injected in tests). */
+  private readonly now: NowFn;
+  /**
+   * Phase 0: the timer of the AS currently being synced. Set by `syncLocked`
+   * and read by the transport/sha1/localFiles chokepoint wrappers. Safe as a
+   * single field because syncs are serialised by the D11 `opInProgress`
+   * guard; `null` outside a sync (the wrappers skip timing then).
+   */
+  private activeTimer: SyncPhaseTimer | null = null;
   /** D11 — one sync/apply operation at a time. */
   private opInProgress = false;
 
   constructor(deps: SyncEngineDeps) {
     this.deps = deps;
-    this.transport = withRateLimitBackoff(deps.transport, deps.backoff);
+    this.now = deps.now ?? ((): number => Date.now());
+    this.transport = this.instrumentTransport(
+      withRateLimitBackoff(deps.transport, deps.backoff),
+    );
+    this.sha1 = this.instrumentSha1(deps.sha1);
+  }
+
+  /**
+   * Phase 0 — wrap the transport so every REST round-trip is timed into its
+   * phase bucket (by URL/method) and counted. Transparent pass-through: same
+   * args, same return, same throw; timing accrues in `finally`. No-op when no
+   * sync is in flight (`activeTimer === null`).
+   */
+  private instrumentTransport(raw: RestCommitTransport): RestCommitTransport {
+    return async (req: RestCommitRequest) => {
+      const timer = this.activeTimer;
+      if (timer === null) return raw(req);
+      timer.bumpRest();
+      return timer.time(classifyRestPhase(req), () => raw(req));
+    };
+  }
+
+  /**
+   * Phase 0 — wrap `sha1` so every digest accrues to the `hash` bucket and the
+   * hashed-file count. `gitBlobSha` calls this exactly once per file, so the
+   * bucket ≈ wall-clock spent hashing all files.
+   */
+  private instrumentSha1(raw: Sha1Fn): Sha1Fn {
+    return (data) => {
+      const timer = this.activeTimer;
+      if (timer === null) return raw(data);
+      timer.bumpHashed();
+      return timer.time("hash", () => raw(data));
+    };
+  }
+
+  /**
+   * Phase 0 — wrap a per-repo `LocalFilesPort` so the directory walk, file
+   * reads and pull-applied writes are timed. Transparent: every method
+   * delegates; only the timed ones are decorated. Optional byte-port methods
+   * are forwarded only when the underlying port provides them.
+   */
+  private instrumentLocalFiles(raw: LocalFilesPort): LocalFilesPort {
+    const timed = <T>(
+      phase: Parameters<SyncPhaseTimer["time"]>[0],
+      op: () => Promise<T>,
+    ): Promise<T> => {
+      const timer = this.activeTimer;
+      return timer === null ? op() : timer.time(phase, op);
+    };
+    const wrapped: LocalFilesPort = {
+      list: () => timed("localList", () => raw.list()),
+      read: (path) => {
+        this.activeTimer?.bumpRead();
+        return timed("localRead", () => raw.read(path));
+      },
+      write: (path, content) =>
+        timed("localWrite", () => {
+          this.activeTimer?.bumpWritten();
+          return raw.write(path, content);
+        }),
+      delete: (path) => raw.delete(path),
+    };
+    // Bind the optional byte-port methods to `raw` so the wrapper closures call
+    // a plain bound function — no non-null assertion, no unbound-method.
+    const rawReadBinary = raw.readBinary?.bind(raw);
+    if (rawReadBinary !== undefined) {
+      wrapped.readBinary = (path) => {
+        this.activeTimer?.bumpRead();
+        return timed("localRead", () => rawReadBinary(path));
+      };
+    }
+    const rawWriteBinary = raw.writeBinary?.bind(raw);
+    if (rawWriteBinary !== undefined) {
+      wrapped.writeBinary = (path, bytes) =>
+        timed("localWrite", () => {
+          this.activeTimer?.bumpWritten();
+          return rawWriteBinary(path, bytes);
+        });
+    }
+    return wrapped;
   }
 
   /**
@@ -612,7 +721,7 @@ export class SyncEngine {
     for (const entry of headTree) {
       const content = disk.get(entry.path);
       if (content === undefined) continue;
-      if ((await gitBlobSha(content, this.deps.sha1)) === entry.blobSha) {
+      if ((await gitBlobSha(content, this.sha1)) === entry.blobSha) {
         files.push({ path: entry.path, blobSha: entry.blobSha });
       }
     }
@@ -689,6 +798,12 @@ export class SyncEngine {
     direction: SyncDirection = "sync",
     onProgress?: SyncProgressFn,
   ): Promise<RepoSyncResult> {
+    // Phase 0 — fresh per-AS timer. Set as the engine's `activeTimer` so the
+    // transport/sha1/localFiles chokepoint wrappers attribute their durations
+    // to this repo, and restored in `finally` (nested safe via save/restore).
+    const timer = new SyncPhaseTimer(this.now);
+    const prevTimer = this.activeTimer;
+    this.activeTimer = timer;
     const warnings: string[] = [];
     const deferredDeletes: string[] = [];
     // Deletions detected this cycle whose push loop is still IN FLIGHT —
@@ -708,6 +823,9 @@ export class SyncEngine {
       quarantinedCount: 0,
       warnings,
       deferredDeletes,
+      // Phase 0 — snapshot at the return point captures the full breakdown
+      // for whatever phases ran (early skips snapshot ~zero, harmless).
+      timings: timer.snapshot(),
       ...extra,
     });
 
@@ -723,7 +841,11 @@ export class SyncEngine {
       }
 
       const mode = this.modeOps(spec);
-      const localFiles = this.deps.localFilesFor(spec);
+      // Phase 0 — instrument the per-repo port so local list/read/write
+      // durations attribute to this AS's timer (the hypothesised hot path).
+      const localFiles = this.instrumentLocalFiles(
+        this.deps.localFilesFor(spec),
+      );
       if (
         mode.fileMode &&
         (localFiles.readBinary === undefined ||
@@ -860,7 +982,7 @@ export class SyncEngine {
         localFiles: disk,
         watermark,
         actualBaseTreeSha: await this.resolveBaseTreeSha(spec, watermark),
-        sha1: this.deps.sha1,
+        sha1: this.sha1,
       });
       if (detection.kind === "full-conflict") {
         return result("full-conflict", {
@@ -1159,6 +1281,10 @@ export class SyncEngine {
       }
       warnings.push(`sync failed: ${redact(errMsg(err))}`);
       return result("error", { detail: redact(errMsg(err)) });
+    } finally {
+      // Phase 0 — restore the previous timer (null outside a sync) so the
+      // chokepoint wrappers never accumulate into a stale repo's breakdown.
+      this.activeTimer = prevTimer;
     }
   }
 
@@ -1675,7 +1801,7 @@ export class SyncEngine {
           const headBlobSha = headTreeByPath.get(path);
           if (
             headBlobSha !== undefined &&
-            headBlobSha === (await gitBlobSha(content, this.deps.sha1))
+            headBlobSha === (await gitBlobSha(content, this.sha1))
           ) {
             pushFiles.delete(path);
             alreadyInHead.push(path);
@@ -1902,7 +2028,7 @@ export class SyncEngine {
           content: decision.content,
           // Precomputed so the watermark rebuild reuses it instead of
           // re-fetching the merged blob (A2 deferred LOW).
-          blobSha: await gitBlobSha(decision.content, this.deps.sha1),
+          blobSha: await gitBlobSha(decision.content, this.sha1),
           ...(uid !== undefined ? { uid } : {}),
         });
       }
@@ -2458,7 +2584,7 @@ export class SyncEngine {
       const content = disk.get(entry.path);
       if (
         content === undefined ||
-        (await gitBlobSha(content, this.deps.sha1)) !== entry.blobSha
+        (await gitBlobSha(content, this.sha1)) !== entry.blobSha
       ) {
         // Divergent (same-path content difference) or absent on disk: NOT part
         // of the R⊆L synthetic base. Absent-on-disk → a remote-only ADD the
@@ -2915,7 +3041,7 @@ export class SyncEngine {
       // Reuse the blob SHA computed during change detection (A1 perf
       // finding: no-op syncs double-hashed the whole working tree).
       const sha =
-        diskBlobShas?.get(path) ?? (await gitBlobSha(content, this.deps.sha1));
+        diskBlobShas?.get(path) ?? (await gitBlobSha(content, this.sha1));
       uidByBlobSha.set(
         sha,
         typeof content === "string" ? extractAssetUid(content) : undefined,

--- a/packages/exocortex/src/services/sync/SyncPhaseTimer.ts
+++ b/packages/exocortex/src/services/sync/SyncPhaseTimer.ts
@@ -1,0 +1,261 @@
+/**
+ * ExoSync Phase 0 — per-phase wall-clock instrumentation (measure-first).
+ *
+ * Andrey's directive: before choosing an optimisation (mtime-manifest vs
+ * Compare API vs parallelising the detect phase), MEASURE which phase actually
+ * dominates a real iPhone sync (>2 min on a 14-AS / ~6304-file vault). The
+ * hypothesis (`exosync-perf-plan-2026-06-20.md` §2) is that the unconditional
+ * local read + SHA-1 of EVERY file each sync dominates — this instrumentation
+ * confirms or refutes it with numbers.
+ *
+ * Mechanism — port chokepoints. The {@link SyncEngine} drives the WHOLE remote
+ * side through ONE injected `transport` and the WHOLE hashing side through ONE
+ * injected `sha1`; local file IO goes through ONE `LocalFilesPort` per repo.
+ * Wrapping those three chokepoints attributes every REST round-trip, every
+ * SHA-1 digest and every file read/write to a per-AS timer WITHOUT threading a
+ * timer through the dozen call sites. Because `syncLocked` runs strictly
+ * sequentially (D11 `opInProgress` guard + sequential `for…await` at every
+ * read / hash / blob site — verified: no `Promise.all` on the hot path), the
+ * accumulated per-bucket durations approximate wall-clock per phase, and their
+ * sum approximates the repo's wall-clock (minus the negligible pure-CPU diff).
+ *
+ * Observation-only: a timer can never change the sync outcome — the wrappers
+ * are transparent pass-throughs and accumulate in `finally`, mirroring the
+ * #3498 onProgress discipline. Decision (AC): instrumentation is PERMANENT and
+ * always-on (the per-op overhead is two clock reads — negligible), so Andrey
+ * just syncs and reads the breakdown; no debug toggle to flip.
+ */
+
+import type { RestCommitRequest } from "../../infrastructure/github/restCommit";
+
+/**
+ * Wall-clock buckets one sync's time is attributed to. Local phases (the
+ * hypothesised hot path) are separated from remote REST phases so the
+ * dominant cost is unambiguous.
+ */
+export type SyncPhase =
+  | "localList" // adapter.list() — recursive mount-folder directory walk
+  | "localRead" // adapter.read()/readBinary() — read ALL syncable file content
+  | "localWrite" // adapter.write()/writeBinary() — pull-applied writes to disk
+  | "hash" // gitBlobSha → sha1 digest of every file (hypothesised hot path)
+  | "restHead" // GET git/refs/heads — getHeadSha (≥1 round-trip per AS, no-op too)
+  | "restCommit" // GET git/commits/{sha} — getCommitInfo (base / race / D22)
+  | "restTree" // GET git/trees/{sha}?recursive=1 — full recursive tree fetch+parse
+  | "restBlob" // GET git/blobs/{sha} — per-changed-blob content fetch
+  | "restPush"; // POST/PATCH — createCommit chain (blobs/trees/commits/refs)
+
+/** Stable phase order for deterministic snapshots and formatting. */
+export const SYNC_PHASES: readonly SyncPhase[] = [
+  "localList",
+  "localRead",
+  "localWrite",
+  "hash",
+  "restHead",
+  "restCommit",
+  "restTree",
+  "restBlob",
+  "restPush",
+];
+
+/** Operation counts that contextualise the durations. */
+export interface SyncPhaseCounts {
+  /** Files read from disk (adapter.read/readBinary) this sync. */
+  filesRead: number;
+  /** SHA-1 digests computed (gitBlobSha) this sync. */
+  filesHashed: number;
+  /** Files written to disk (pull-applied changes) this sync. */
+  filesWritten: number;
+  /** Total REST round-trips (transport calls) this sync. */
+  restCalls: number;
+}
+
+/** Immutable timing snapshot for one AS, attached to its `RepoSyncResult`. */
+export interface SyncPhaseTimings {
+  /** Wall-clock milliseconds accumulated per phase. */
+  durations: Record<SyncPhase, number>;
+  counts: SyncPhaseCounts;
+}
+
+/** Clock injected for deterministic tests; defaults to `Date.now` in prod. */
+export type NowFn = () => number;
+
+function zeroDurations(): Record<SyncPhase, number> {
+  const d = {} as Record<SyncPhase, number>;
+  for (const p of SYNC_PHASES) d[p] = 0;
+  return d;
+}
+
+function zeroCounts(): SyncPhaseCounts {
+  return { filesRead: 0, filesHashed: 0, filesWritten: 0, restCalls: 0 };
+}
+
+/**
+ * Map a single transport request to its phase bucket by URL/method. POST/PATCH
+ * is always the createCommit chain (push). GET buckets by the Git Data API
+ * path segment (refs/commits/trees/blobs).
+ */
+export function classifyRestPhase(req: RestCommitRequest): SyncPhase {
+  if (req.method !== "GET") return "restPush";
+  const u = req.url;
+  if (u.includes("/git/blobs/")) return "restBlob";
+  if (u.includes("/git/trees/")) return "restTree";
+  if (u.includes("/git/commits/")) return "restCommit";
+  if (u.includes("/git/refs/")) return "restHead";
+  // Unknown GET — bucket conservatively as a commit-class round-trip rather
+  // than silently dropping it (the round-trip still happened).
+  return "restCommit";
+}
+
+/**
+ * Per-AS accumulator. Created fresh for each repo in `syncLocked` and read by
+ * the chokepoint wrappers via the engine's `activeTimer` field (safe: syncs
+ * are serialised by the D11 guard).
+ */
+export class SyncPhaseTimer {
+  private readonly durations = zeroDurations();
+  private readonly counts = zeroCounts();
+
+  constructor(private readonly now: NowFn) {}
+
+  /**
+   * Time an async op into `phase` — transparent pass-through: returns the op's
+   * value, rethrows its error, and accumulates the elapsed time in `finally`
+   * so a throwing op is still measured and never swallowed.
+   */
+  async time<T>(phase: SyncPhase, op: () => Promise<T>): Promise<T> {
+    const start = this.now();
+    try {
+      return await op();
+    } finally {
+      this.durations[phase] += this.now() - start;
+    }
+  }
+
+  bumpRead(): void {
+    this.counts.filesRead++;
+  }
+
+  bumpHashed(): void {
+    this.counts.filesHashed++;
+  }
+
+  bumpWritten(): void {
+    this.counts.filesWritten++;
+  }
+
+  bumpRest(): void {
+    this.counts.restCalls++;
+  }
+
+  /** Immutable copy of the accumulated state at the moment of call. */
+  snapshot(): SyncPhaseTimings {
+    return {
+      durations: { ...this.durations },
+      counts: { ...this.counts },
+    };
+  }
+}
+
+/** An all-zero timing, for aggregation seeds and tests. */
+export function emptyTimings(): SyncPhaseTimings {
+  return { durations: zeroDurations(), counts: zeroCounts() };
+}
+
+/** Sum of all phase durations (≈ wall-clock for one AS / the whole run). */
+export function totalMs(t: SyncPhaseTimings): number {
+  let sum = 0;
+  for (const p of SYNC_PHASES) sum += t.durations[p];
+  return sum;
+}
+
+/** Sum two timings (used to aggregate per-AS results into a run total). */
+export function addTimings(
+  a: SyncPhaseTimings,
+  b: SyncPhaseTimings,
+): SyncPhaseTimings {
+  const durations = zeroDurations();
+  for (const p of SYNC_PHASES) durations[p] = a.durations[p] + b.durations[p];
+  return {
+    durations,
+    counts: {
+      filesRead: a.counts.filesRead + b.counts.filesRead,
+      filesHashed: a.counts.filesHashed + b.counts.filesHashed,
+      filesWritten: a.counts.filesWritten + b.counts.filesWritten,
+      restCalls: a.counts.restCalls + b.counts.restCalls,
+    },
+  };
+}
+
+/**
+ * Aggregate every result's timing into one run total. Results without timings
+ * (e.g. a `busy` early-return that never created a timer) contribute nothing.
+ */
+export function aggregateTimings(
+  results: ReadonlyArray<{ timings?: SyncPhaseTimings }>,
+): SyncPhaseTimings {
+  let acc = emptyTimings();
+  for (const r of results) {
+    if (r.timings !== undefined) acc = addTimings(acc, r.timings);
+  }
+  return acc;
+}
+
+/** The single largest phase, with its share of the total (null when idle). */
+export function dominantPhase(
+  t: SyncPhaseTimings,
+): { phase: SyncPhase; ms: number; pct: number } | null {
+  const total = totalMs(t);
+  if (total <= 0) return null;
+  let phase: SyncPhase = SYNC_PHASES[0];
+  let ms = -1;
+  for (const p of SYNC_PHASES) {
+    if (t.durations[p] > ms) {
+      ms = t.durations[p];
+      phase = p;
+    }
+  }
+  return { phase, ms, pct: (ms / total) * 100 };
+}
+
+/** Human-readable duration: `1.2s` ≥1000ms, else `742ms`. */
+export function fmtMs(ms: number): string {
+  return ms >= 1000 ? `${(ms / 1000).toFixed(1)}s` : `${Math.round(ms)}ms`;
+}
+
+/**
+ * Concise one-line aggregate for the summary toast (iPhone-readable): total +
+ * the non-zero phases sorted descending with each phase's share. Empty string
+ * when nothing was timed (clean no-op with zero IO — never happens in
+ * practice since every AS reads + hashes).
+ */
+export function formatTimingsLine(t: SyncPhaseTimings): string {
+  const total = totalMs(t);
+  if (total <= 0) return "";
+  const parts = SYNC_PHASES.filter((p) => t.durations[p] > 0)
+    .sort((a, b) => t.durations[b] - t.durations[a])
+    .map(
+      (p) =>
+        `${p} ${fmtMs(t.durations[p])} ${Math.round(
+          (t.durations[p] / total) * 100,
+        )}%`,
+    );
+  return `⏱ ExoSync ${fmtMs(total)} — ${parts.join(" · ")} (${
+    t.counts.filesHashed
+  } hashed, ${t.counts.filesRead} read, ${t.counts.restCalls} REST)`;
+}
+
+/**
+ * Detailed per-AS line for the durable / activity-log channel. Includes ALL
+ * phases (zeros too) so the breakdown is comparable across repos.
+ */
+export function formatRepoTimings(
+  repoKey: string,
+  t: SyncPhaseTimings,
+): string {
+  const parts = SYNC_PHASES.map((p) => `${p}=${fmtMs(t.durations[p])}`);
+  return `[ExoSync timings] ${repoKey}: total ${fmtMs(
+    totalMs(t),
+  )} — ${parts.join(" ")} | hashed ${t.counts.filesHashed} read ${
+    t.counts.filesRead
+  } written ${t.counts.filesWritten} REST ${t.counts.restCalls}`;
+}

--- a/packages/exocortex/src/services/sync/syncTypes.ts
+++ b/packages/exocortex/src/services/sync/syncTypes.ts
@@ -9,6 +9,8 @@
  * (iOS-portable, same as the write primitive it reuses).
  */
 
+import type { SyncPhaseTimings } from "./SyncPhaseTimer";
+
 /**
  * Which `exo__Space` subtype a sync unit declares (Phase C, onto-RFC
  * 18808c73). `"asset"` (default) — UID-bearing markdown assets, text-only
@@ -323,6 +325,15 @@ export interface RepoSyncResult {
    * this round (always absent for full `sync` runs).
    */
   deferredPaths?: string[];
+  /**
+   * Phase 0 (measure-first) — per-phase wall-clock breakdown of this repo's
+   * sync: local list/read/write, SHA-1 hashing, and each remote REST class
+   * (head/commit/tree/blob/push), plus operation counts. Observation-only,
+   * always populated by the engine. Consumers aggregate it into a readable
+   * per-sync summary so the dominant phase is visible on the device (iPhone).
+   * See {@link SyncPhaseTimings}.
+   */
+  timings?: SyncPhaseTimings;
   detail?: string;
 }
 

--- a/packages/exocortex/tests/unit/services/sync/SyncEngine.timings.test.ts
+++ b/packages/exocortex/tests/unit/services/sync/SyncEngine.timings.test.ts
@@ -1,0 +1,259 @@
+/**
+ * ExoSync Phase 0 — SyncEngine per-phase timing instrumentation (measure-first).
+ *
+ * Proves the engine's THREE chokepoint wrappers (transport / sha1 / localFiles)
+ * attribute a REAL sync's wall-clock to the right phase buckets and counts.
+ * Production-shape (test-fixture-realism): the SAME `FakeGitHubRepo` /
+ * `FakeLocalFiles` used by every other SyncEngine test, with a deterministic
+ * injected clock and thin clock-advancing port wrappers that mirror the cost
+ * of each operation on a real device. The clock advances ONLY inside the
+ * underlying op, so the engine's `start = now()` / `finally end = now()`
+ * bracket measures exactly that op's simulated cost.
+ *
+ * This is the harness Andrey reads on iPhone: it confirms which phase dominates
+ * a sync, so Phase 1 picks the optimisation by measurement, not by guess.
+ */
+
+import {
+  SyncEngine,
+  dominantPhase,
+  type LocalFilesPort,
+  type RestCommitRequest,
+  type RestCommitTransport,
+  type Sha1Fn,
+  type SyncEngineDeps,
+} from "../../../../src";
+import {
+  FakeGitHubRepo,
+  FakeLocalFiles,
+  FakeWatermarkStore,
+  alwaysMaterialized,
+  mdAsset,
+  sha1Hex,
+} from "./fakeGitHub";
+
+/** A clock the test advances by injecting per-op costs into the port wrappers. */
+function fakeClock(): { now: () => number; advance: (ms: number) => void } {
+  let t = 0;
+  return { now: () => t, advance: (ms) => (t += ms) };
+}
+
+/** Cost (ms) charged to each op so a sync's wall-clock is deterministic. */
+interface Costs {
+  read: number;
+  hash: number;
+  restHead: number;
+  restCommit: number;
+  restTree: number;
+  restBlob: number;
+  restPush: number;
+}
+
+const DEFAULT_COSTS: Costs = {
+  read: 5,
+  hash: 50, // the hypothesised hot path — heaviest per-op by design
+  restHead: 200,
+  restCommit: 200,
+  restTree: 300,
+  restBlob: 150,
+  restPush: 400,
+};
+
+/** sha1 wrapper that advances the clock by the hashing cost on every digest. */
+function advancingSha1(advance: (ms: number) => void, cost: number): Sha1Fn {
+  return async (data) => {
+    advance(cost);
+    return sha1Hex(data);
+  };
+}
+
+/** LocalFilesPort wrapper that charges `read` per read (list/delete are free). */
+function advancingLocalFiles(
+  inner: LocalFilesPort,
+  advance: (ms: number) => void,
+  cost: number,
+): LocalFilesPort {
+  return {
+    list: () => inner.list(),
+    read: async (p) => {
+      advance(cost);
+      return inner.read(p);
+    },
+    write: (p, c) => inner.write(p, c),
+    delete: (p) => inner.delete(p),
+    readBinary: inner.readBinary
+      ? async (p) => {
+          advance(cost);
+          return inner.readBinary!(p);
+        }
+      : undefined,
+    writeBinary: inner.writeBinary
+      ? (p, b) => inner.writeBinary!(p, b)
+      : undefined,
+  };
+}
+
+/** Transport wrapper that charges the per-URL REST cost on every round-trip. */
+function advancingTransport(
+  inner: RestCommitTransport,
+  advance: (ms: number) => void,
+  costs: Costs,
+): RestCommitTransport {
+  return async (req: RestCommitRequest) => {
+    advance(restCost(req, costs));
+    return inner(req);
+  };
+}
+
+function restCost(req: RestCommitRequest, c: Costs): number {
+  if (req.method !== "GET") return c.restPush;
+  if (req.url.includes("/git/blobs/")) return c.restBlob;
+  if (req.url.includes("/git/trees/")) return c.restTree;
+  if (req.url.includes("/git/commits/")) return c.restCommit;
+  if (req.url.includes("/git/refs/")) return c.restHead;
+  return c.restCommit;
+}
+
+function makeEngine(
+  gh: FakeGitHubRepo,
+  local: FakeLocalFiles,
+  clock: { now: () => number; advance: (ms: number) => void },
+  costs: Costs = DEFAULT_COSTS,
+  overrides: Partial<SyncEngineDeps> = {},
+): SyncEngine {
+  return new SyncEngine({
+    transport: advancingTransport(gh.transport(), clock.advance, costs),
+    watermarkStore: new FakeWatermarkStore(),
+    materializationCheck: alwaysMaterialized(),
+    localFilesFor: () => advancingLocalFiles(local, clock.advance, costs.read),
+    sha1: advancingSha1(clock.advance, costs.hash),
+    now: clock.now,
+    ...overrides,
+  });
+}
+
+const A = "assets/a.md";
+const B = "assets/b.md";
+const C = "assets/c.md";
+
+describe("SyncEngine — Phase 0 per-phase timing instrumentation", () => {
+  it("attributes a no-op sync's time to local read + hash, with deterministic counts", async () => {
+    const files = {
+      [A]: mdAsset("u1"),
+      [B]: mdAsset("u2"),
+      [C]: mdAsset("u3"),
+    };
+    const gh = new FakeGitHubRepo(files);
+    const local = new FakeLocalFiles(files);
+    const clock = fakeClock();
+    const engine = makeEngine(gh, local, clock);
+
+    await engine.sync(gh.spec()); // bootstrap (its own timer, ignored)
+    const result = await engine.sync(gh.spec()); // clean no-op
+
+    expect(result.status).toBe("synced");
+    const t = result.timings;
+    expect(t).toBeDefined();
+    // Every syncable file is read once and hashed once on the detect pass.
+    expect(t!.counts.filesRead).toBe(3);
+    expect(t!.counts.filesHashed).toBe(3);
+    expect(t!.durations.localRead).toBe(3 * DEFAULT_COSTS.read); // 15ms
+    expect(t!.durations.hash).toBe(3 * DEFAULT_COSTS.hash); // 150ms
+    // No-op fast path: base-commit + head ref round-trips, no tree/blob fetch.
+    expect(t!.counts.restCalls).toBeGreaterThanOrEqual(2);
+    expect(t!.durations.restCommit).toBeGreaterThan(0); // resolveBaseTreeSha
+    expect(t!.durations.restHead).toBeGreaterThan(0); // getHeadSha
+    expect(t!.durations.restTree).toBe(0); // root-Merkle short-circuit
+    expect(t!.durations.restBlob).toBe(0);
+  });
+
+  it("identifies the dominant phase — hash when hashing is the heaviest per-op", async () => {
+    // Many files, hashing dwarfs everything (the plan's §2 hypothesis shape).
+    const files: Record<string, string> = {};
+    for (let i = 0; i < 40; i++) files[`assets/f${i}.md`] = mdAsset(`u${i}`);
+    const gh = new FakeGitHubRepo(files);
+    const local = new FakeLocalFiles(files);
+    const clock = fakeClock();
+    const engine = makeEngine(gh, local, clock);
+
+    await engine.sync(gh.spec());
+    const result = await engine.sync(gh.spec());
+
+    const t = result.timings!;
+    const dom = dominantPhase(t);
+    expect(dom).not.toBeNull();
+    expect(dom!.phase).toBe("hash"); // 40×50ms hashing ≫ 40×5ms reads + 2 REST
+    // … and the inverse: make remote tree fetch the heaviest → tree dominates.
+  });
+
+  it("identifies the dominant phase — restTree when the tree fetch is heaviest", async () => {
+    const files: Record<string, string> = {};
+    for (let i = 0; i < 3; i++) files[`assets/f${i}.md`] = mdAsset(`u${i}`);
+    const gh = new FakeGitHubRepo(files);
+    const local = new FakeLocalFiles(files);
+    const clock = fakeClock();
+    // Cheap local, very expensive tree fetch.
+    const engine = makeEngine(gh, local, clock, {
+      ...DEFAULT_COSTS,
+      read: 1,
+      hash: 1,
+      restTree: 9000,
+    });
+
+    await engine.sync(gh.spec());
+    // Remote moves → head-tree fetch fires this sync.
+    gh.commitDirect("main", { [`assets/f0.md`]: mdAsset("u0", "edited") }, "B");
+    const result = await engine.sync(gh.spec());
+
+    expect(result.status).toBe("synced");
+    const t = result.timings!;
+    expect(t.durations.restTree).toBeGreaterThan(0);
+    expect(t.durations.restBlob).toBeGreaterThan(0); // the changed blob fetched
+    expect(dominantPhase(t)!.phase).toBe("restTree");
+  });
+
+  it("counts pull-applied writes in the localWrite bucket", async () => {
+    const files = { [A]: mdAsset("u1", "v1") };
+    const gh = new FakeGitHubRepo(files);
+    const local = new FakeLocalFiles(files);
+    const clock = fakeClock();
+    const engine = makeEngine(gh, local, clock);
+
+    await engine.sync(gh.spec());
+    gh.commitDirect("main", { [A]: mdAsset("u1", "remote v2") }, "device B");
+    const result = await engine.sync(gh.spec());
+
+    expect(result.status).toBe("synced");
+    expect(result.pulledCount).toBe(1);
+    expect(result.timings!.counts.filesWritten).toBe(1);
+  });
+
+  it("aggregates per-AS timings across a multi-repo syncAll run", async () => {
+    const filesA = { [A]: mdAsset("u1") };
+    const ghA = new FakeGitHubRepo(filesA);
+    const localA = new FakeLocalFiles(filesA);
+    const clock = fakeClock();
+    const engine = makeEngine(ghA, localA, clock);
+
+    const results = await engine.syncAll([ghA.spec()]);
+    // Every result carries its own breakdown (observation-only, always set).
+    expect(results[0].timings).toBeDefined();
+    expect(results[0].timings!.counts.filesHashed).toBeGreaterThan(0);
+  });
+
+  it("instrumentation is observation-only — does not change the sync outcome", async () => {
+    const files = { [A]: mdAsset("u1", "original") };
+    const gh = new FakeGitHubRepo(files);
+    const local = new FakeLocalFiles(files);
+    const clock = fakeClock();
+    const engine = makeEngine(gh, local, clock);
+
+    await engine.sync(gh.spec());
+    gh.commitDirect("main", { [A]: mdAsset("u1", "remote edit") }, "device B");
+    const result = await engine.sync(gh.spec());
+
+    // Same convergence as the un-instrumented engine (cf. progress test).
+    expect(result.status).toBe("synced");
+    expect(local.files.get(A)).toBe(mdAsset("u1", "remote edit"));
+  });
+});

--- a/packages/exocortex/tests/unit/services/sync/SyncPhaseTimer.test.ts
+++ b/packages/exocortex/tests/unit/services/sync/SyncPhaseTimer.test.ts
@@ -1,0 +1,269 @@
+/**
+ * ExoSync Phase 0 — SyncPhaseTimer unit tests (measure-first instrumentation).
+ *
+ * Pure tests of the timing primitive + aggregation/formatting helpers with a
+ * deterministic injected clock. The engine-integration test
+ * (SyncEngine.timings.test.ts) proves the chokepoint wiring attributes a REAL
+ * sync's time to the right buckets.
+ */
+
+import {
+  SyncPhaseTimer,
+  SYNC_PHASES,
+  classifyRestPhase,
+  emptyTimings,
+  addTimings,
+  aggregateTimings,
+  totalMs,
+  dominantPhase,
+  fmtMs,
+  formatTimingsLine,
+  formatRepoTimings,
+  type SyncPhaseTimings,
+} from "../../../../src";
+import type { RestCommitRequest } from "../../../../src";
+
+/** Controllable clock: `now()` returns the current value, `set`/`advance` move it. */
+function fakeClock(): {
+  now: () => number;
+  advance: (ms: number) => void;
+  set: (ms: number) => void;
+} {
+  let t = 0;
+  return {
+    now: () => t,
+    advance: (ms) => {
+      t += ms;
+    },
+    set: (ms) => {
+      t = ms;
+    },
+  };
+}
+
+const get = (
+  method: RestCommitRequest["method"],
+  url: string,
+): RestCommitRequest => ({
+  method,
+  url,
+});
+
+describe("classifyRestPhase", () => {
+  const base = "https://api.github.com/repos/o/r";
+  it("buckets GET refs/heads as restHead", () => {
+    expect(classifyRestPhase(get("GET", `${base}/git/refs/heads/main`))).toBe(
+      "restHead",
+    );
+  });
+  it("buckets GET commits as restCommit", () => {
+    expect(classifyRestPhase(get("GET", `${base}/git/commits/abc`))).toBe(
+      "restCommit",
+    );
+  });
+  it("buckets GET trees as restTree", () => {
+    expect(
+      classifyRestPhase(get("GET", `${base}/git/trees/abc?recursive=1`)),
+    ).toBe("restTree");
+  });
+  it("buckets GET blobs as restBlob", () => {
+    expect(classifyRestPhase(get("GET", `${base}/git/blobs/abc`))).toBe(
+      "restBlob",
+    );
+  });
+  it("buckets POST/PATCH (createCommit chain) as restPush", () => {
+    expect(classifyRestPhase(get("POST", `${base}/git/blobs`))).toBe(
+      "restPush",
+    );
+    expect(classifyRestPhase(get("POST", `${base}/git/trees`))).toBe(
+      "restPush",
+    );
+    expect(classifyRestPhase(get("POST", `${base}/git/commits`))).toBe(
+      "restPush",
+    );
+    expect(classifyRestPhase(get("PATCH", `${base}/git/refs/heads/main`))).toBe(
+      "restPush",
+    );
+  });
+  it("buckets an unknown GET conservatively as restCommit (never drops it)", () => {
+    expect(classifyRestPhase(get("GET", `${base}/git/unknown/x`))).toBe(
+      "restCommit",
+    );
+  });
+});
+
+describe("SyncPhaseTimer.time", () => {
+  it("accumulates the elapsed clock delta into the phase bucket", async () => {
+    const clock = fakeClock();
+    const timer = new SyncPhaseTimer(clock.now);
+    await timer.time("hash", async () => {
+      clock.advance(7);
+    });
+    await timer.time("hash", async () => {
+      clock.advance(3);
+    });
+    await timer.time("localRead", async () => {
+      clock.advance(5);
+    });
+    const snap = timer.snapshot();
+    expect(snap.durations.hash).toBe(10);
+    expect(snap.durations.localRead).toBe(5);
+    expect(snap.durations.restTree).toBe(0);
+  });
+
+  it("returns the op's value (transparent pass-through)", async () => {
+    const timer = new SyncPhaseTimer(fakeClock().now);
+    const v = await timer.time("restTree", async () => 42);
+    expect(v).toBe(42);
+  });
+
+  it("still measures AND rethrows when the op throws", async () => {
+    const clock = fakeClock();
+    const timer = new SyncPhaseTimer(clock.now);
+    await expect(
+      timer.time("restBlob", async () => {
+        clock.advance(9);
+        throw new Error("boom");
+      }),
+    ).rejects.toThrow("boom");
+    // Timed in `finally` even on the throwing path.
+    expect(timer.snapshot().durations.restBlob).toBe(9);
+  });
+});
+
+describe("SyncPhaseTimer counts + snapshot immutability", () => {
+  it("counts reads/hashes/writes/REST independently", () => {
+    const timer = new SyncPhaseTimer(fakeClock().now);
+    timer.bumpRead();
+    timer.bumpRead();
+    timer.bumpHashed();
+    timer.bumpWritten();
+    timer.bumpRest();
+    timer.bumpRest();
+    timer.bumpRest();
+    const c = timer.snapshot().counts;
+    expect(c).toEqual({
+      filesRead: 2,
+      filesHashed: 1,
+      filesWritten: 1,
+      restCalls: 3,
+    });
+  });
+
+  it("snapshot is a copy — later mutations do not leak into it", () => {
+    const clock = fakeClock();
+    const timer = new SyncPhaseTimer(clock.now);
+    timer.bumpRead();
+    const snap = timer.snapshot();
+    timer.bumpRead();
+    expect(snap.counts.filesRead).toBe(1); // frozen at snapshot time
+  });
+
+  it("seeds every phase at zero", () => {
+    const snap = new SyncPhaseTimer(fakeClock().now).snapshot();
+    for (const p of SYNC_PHASES) expect(snap.durations[p]).toBe(0);
+    expect(totalMs(snap)).toBe(0);
+  });
+});
+
+describe("aggregation helpers", () => {
+  function timings(
+    durations: Partial<Record<(typeof SYNC_PHASES)[number], number>>,
+    counts?: Partial<SyncPhaseTimings["counts"]>,
+  ): SyncPhaseTimings {
+    const t = emptyTimings();
+    for (const [k, v] of Object.entries(durations)) {
+      t.durations[k as (typeof SYNC_PHASES)[number]] = v as number;
+    }
+    Object.assign(t.counts, counts ?? {});
+    return t;
+  }
+
+  it("totalMs sums all phases", () => {
+    expect(totalMs(timings({ hash: 10, localRead: 5, restTree: 3 }))).toBe(18);
+  });
+
+  it("addTimings sums durations + counts pairwise", () => {
+    const a = timings({ hash: 10 }, { filesHashed: 3, restCalls: 2 });
+    const b = timings(
+      { hash: 4, restTree: 6 },
+      { filesHashed: 1, filesRead: 9 },
+    );
+    const sum = addTimings(a, b);
+    expect(sum.durations.hash).toBe(14);
+    expect(sum.durations.restTree).toBe(6);
+    expect(sum.counts).toEqual({
+      filesRead: 9,
+      filesHashed: 4,
+      filesWritten: 0,
+      restCalls: 2,
+    });
+  });
+
+  it("aggregateTimings sums every result's timings and ignores missing ones", () => {
+    const agg = aggregateTimings([
+      { timings: timings({ hash: 10 }, { filesHashed: 2 }) },
+      { timings: timings({ hash: 5, restBlob: 3 }, { filesHashed: 1 }) },
+      {}, // a `busy` result with no timer — contributes nothing
+    ]);
+    expect(agg.durations.hash).toBe(15);
+    expect(agg.durations.restBlob).toBe(3);
+    expect(agg.counts.filesHashed).toBe(3);
+  });
+
+  it("dominantPhase picks the single largest bucket with its share", () => {
+    const dom = dominantPhase(
+      timings({ hash: 80, localRead: 15, restTree: 5 }),
+    );
+    expect(dom).not.toBeNull();
+    expect(dom!.phase).toBe("hash");
+    expect(dom!.ms).toBe(80);
+    expect(Math.round(dom!.pct)).toBe(80); // 80/100
+  });
+
+  it("dominantPhase is null for an idle timing", () => {
+    expect(dominantPhase(emptyTimings())).toBeNull();
+  });
+});
+
+describe("formatting", () => {
+  it("fmtMs renders sub-second as ms and ≥1s as seconds", () => {
+    expect(fmtMs(742)).toBe("742ms");
+    expect(fmtMs(1500)).toBe("1.5s");
+    expect(fmtMs(124800)).toBe("124.8s");
+  });
+
+  it("formatTimingsLine leads with total, sorts phases desc with shares + counts", () => {
+    const t = emptyTimings();
+    t.durations.hash = 78200;
+    t.durations.localRead = 31100;
+    t.durations.restTree = 8400;
+    t.counts.filesHashed = 6304;
+    t.counts.filesRead = 6304;
+    t.counts.restCalls = 31;
+    const line = formatTimingsLine(t);
+    expect(line).toContain("⏱ ExoSync 117.7s");
+    // hash is the dominant phase → appears first.
+    expect(line.indexOf("hash")).toBeLessThan(line.indexOf("localRead"));
+    expect(line).toContain("hash 78.2s 66%");
+    expect(line).toContain("6304 hashed");
+    expect(line).toContain("31 REST");
+    // zero phases are omitted from the concise line.
+    expect(line).not.toContain("restBlob");
+  });
+
+  it("formatTimingsLine is empty when nothing was timed", () => {
+    expect(formatTimingsLine(emptyTimings())).toBe("");
+  });
+
+  it("formatRepoTimings includes ALL phases (zeros too) + counts", () => {
+    const t = emptyTimings();
+    t.durations.hash = 5000;
+    t.counts.filesHashed = 100;
+    const line = formatRepoTimings("o/r#main", t);
+    expect(line).toContain("o/r#main");
+    expect(line).toContain("hash=5.0s");
+    expect(line).toContain("restBlob=0ms"); // zeros kept for cross-repo comparison
+    expect(line).toContain("hashed 100");
+  });
+});

--- a/packages/obsidian-plugin/src/infrastructure/adapters/SyncCommands.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/SyncCommands.ts
@@ -26,7 +26,13 @@ import type {
   SyncProgressEvent,
   SyncRepoSpec,
 } from "exocortex";
-import { orderChildrenFirst } from "exocortex";
+import {
+  aggregateTimings,
+  formatRepoTimings,
+  formatTimingsLine,
+  orderChildrenFirst,
+  totalMs,
+} from "exocortex";
 
 import { GitHubRestClient } from "./GitHubRestClient";
 import type { SyncSpecCollection, BuiltSyncEngine } from "./SyncDepsFactory";
@@ -419,6 +425,16 @@ export class SyncCommands {
       this.maybeStepNotice(stepLine);
       // #3498 — durable verbose file trace (no-op unless verboseSyncLogging on).
       this.deps.logVerbose?.(stepLine);
+      // ExoSync Phase 0 (measure-first) — per-AS phase breakdown. Goes to the
+      // ALWAYS-ON activity log (logInfo, #3540 — persistent + iPhone-readable
+      // in-app) and the durable file trace, never a toast (would be the same
+      // 14-repo firehose). This is the per-phase + per-AS data Andrey reads to
+      // decide which optimisation Phase 1 picks.
+      if (r.timings !== undefined && totalMs(r.timings) > 0) {
+        const timingLine = formatRepoTimings(r.repoKey, r.timings);
+        logInfo(timingLine);
+        this.deps.logVerbose?.(timingLine);
+      }
       pushed += r.pushedCount;
       deleted += r.pushedDeletes?.length ?? 0;
       pulled += r.pulledCount;
@@ -443,6 +459,20 @@ export class SyncCommands {
     }
 
     const summary = { quarantined, deferred, authRequired };
+
+    // ExoSync Phase 0 (measure-first) — aggregate the per-AS breakdowns into a
+    // run total and surface the dominant phase. The concise line rides the
+    // single summary toast (as a 2nd line — preserves the "no double summary"
+    // toast invariant #3499) so Andrey reads which phase dominated immediately
+    // on iPhone; the same line also goes to the always-on activity log.
+    const aggTimings = aggregateTimings(results);
+    const timingLine =
+      totalMs(aggTimings) > 0 ? formatTimingsLine(aggTimings) : "";
+    if (timingLine !== "") {
+      logInfo(timingLine);
+      this.deps.logVerbose?.(timingLine);
+    }
+    const timingSuffix = timingLine !== "" ? `\n${timingLine}` : "";
 
     if (authRequired) {
       // R8 — explicit, never treated as success.
@@ -472,14 +502,14 @@ export class SyncCommands {
         : "");
     if (problems.length === 0) {
       this.deps.notify(
-        `${label} done: ${synced}/${results.length} repo(s) — ${counts}`,
+        `${label} done: ${synced}/${results.length} repo(s) — ${counts}${timingSuffix}`,
       );
       logInfo(
         `[ExoSync] ${label} OK: ${synced}/${results.length} repo(s) — ${counts}`,
       );
     } else {
       this.deps.notify(
-        `${label} finished with issues (${problems.join("; ")}) — ${counts}. See console for details.`,
+        `${label} finished with issues (${problems.join("; ")}) — ${counts}. See console for details.${timingSuffix}`,
       );
     }
     return summary;

--- a/packages/obsidian-plugin/tests/unit/sync/SyncCommands.test.ts
+++ b/packages/obsidian-plugin/tests/unit/sync/SyncCommands.test.ts
@@ -17,9 +17,23 @@ import type { ParityCheck } from "../../../src/infrastructure/adapters/ExoSyncPa
 import type {
   RepoSyncResult,
   SyncEngine,
+  SyncPhaseTimings,
   SyncProgressEvent,
   SyncRepoSpec,
 } from "exocortex";
+import { emptyTimings } from "exocortex";
+
+/** Phase 0 — a production-shape timing fixture for the summary-surface tests. */
+const timingsOf = (hashMs: number, readMs: number): SyncPhaseTimings => {
+  const t = emptyTimings();
+  t.durations.hash = hashMs;
+  t.durations.localRead = readMs;
+  t.durations.restCommit = 200;
+  t.counts.filesHashed = 3;
+  t.counts.filesRead = 3;
+  t.counts.restCalls = 2;
+  return t;
+};
 
 const spec = (key: string): SyncRepoSpec => {
   const [owner, repo] = key.split("/");
@@ -1013,5 +1027,78 @@ describe("SyncCommands — #3498 in-flight progress + verbose file log", () => {
     // #3499 toasts cover start + per-repo summary lines; the in-flight phase
     // firehose (3/repo) stays off the toast channel (#3498 info discipline).
     expect(notices.some((n) => n.includes("merge layer firing"))).toBe(false);
+  });
+
+  // ExoSync Phase 0 (measure-first) — per-phase timing surfaces.
+  describe("Phase 0 timing breakdown surface", () => {
+    it("appends the aggregate ⏱ breakdown to the summary toast (dominant phase visible)", async () => {
+      const { commands, notices } = makeHarness({
+        results: [
+          result("o/r#main", "synced", { timings: timingsOf(150, 15) }),
+        ],
+      });
+
+      await commands.invokeSync();
+
+      const summary = notices.find((n) => n.includes("Sync done:"));
+      expect(summary).toBeDefined();
+      // The timing line rides the SAME summary toast as a 2nd line — preserves
+      // the "no double summary" invariant (#3499).
+      expect(summary).toContain("⏱ ExoSync");
+      // hash (150ms) dominates the read (15ms) → it leads the breakdown.
+      expect(summary).toContain("hash");
+      expect(summary!.indexOf("hash")).toBeLessThan(
+        summary!.indexOf("localRead"),
+      );
+    });
+
+    it("emits a per-AS breakdown to the always-on activity-log channel (logInfo)", async () => {
+      const { commands, infoLogs } = makeHarness({
+        results: [
+          result("o/r#main", "synced", { timings: timingsOf(150, 15) }),
+          result("o/s#main", "synced", { timings: timingsOf(90, 9) }),
+        ],
+        specs: [spec("o/r"), spec("o/s")],
+      });
+
+      await commands.invokeSync();
+
+      // Per-AS detail lands on logInfo (→ #3540 persistent activity log,
+      // iPhone-readable in-app), one line per repo, never a toast firehose.
+      const perRepo = infoLogs.filter((l) =>
+        l.includes("[ExoSync timings]"),
+      );
+      expect(perRepo.length).toBe(2);
+      expect(perRepo.some((l) => l.includes("o/r#main"))).toBe(true);
+      expect(perRepo.some((l) => l.includes("o/s#main"))).toBe(true);
+    });
+
+    it("aggregates the per-AS breakdowns into one run total on the toast", async () => {
+      const { commands, notices } = makeHarness({
+        results: [
+          result("o/r#main", "synced", { timings: timingsOf(100, 10) }),
+          result("o/s#main", "synced", { timings: timingsOf(100, 10) }),
+        ],
+        specs: [spec("o/r"), spec("o/s")],
+      });
+
+      await commands.invokeSync();
+
+      const summary = notices.find((n) => n.includes("Sync done:"));
+      // 6 files hashed total across the 2 repos (3 each).
+      expect(summary).toContain("6 hashed");
+    });
+
+    it("omits the timing line entirely when no AS reported any time", async () => {
+      const { commands, notices } = makeHarness({
+        results: [result("o/r#main", "synced")], // no timings (e.g. busy/skip)
+      });
+
+      await commands.invokeSync();
+
+      const summary = notices.find((n) => n.includes("Sync done:"));
+      expect(summary).toBeDefined();
+      expect(summary).not.toContain("⏱");
+    });
   });
 });


### PR DESCRIPTION
## What

Phase 0 of the ExoSync iPhone-perf plan (measure-first, Andrey's directive): instrument **per-phase, per-AS wall-clock timings** in the `SyncEngine` so a real iPhone sync (>2 min on 14 AS / ~6304 files) reports **which phase dominates**. No optimisation here — observation only. The measured distribution decides the Phase 1 lever (mtime-manifest vs GitHub Compare API vs parallelising the detect phase).

WBS: `75dbbe1b` (Alpha Launch → ExoSync iPhone sync perf → Phase 0). Plan: `exosync-perf-plan-2026-06-20.md`.

## How (engine, universal — port chokepoints)

- **New `SyncPhaseTimer`**: per-AS accumulator + `classifyRestPhase(url)` + aggregate/format helpers. Buckets: `localList` / `localRead` / `localWrite`, `hash`, and each REST class (`restHead` / `restCommit` / `restTree` / `restBlob` / `restPush`) + op counts (filesRead / filesHashed / filesWritten / restCalls).
- **`SyncEngine` wraps its THREE injected ports** (transport, sha1, localFiles) so every REST round-trip / SHA-1 digest / file read+write attributes to the AS's timer — **no threading** through the dozen call sites. The hot path is strictly sequential (D11 guard + `for…await` at every read/hash/blob site — verified no `Promise.all`), so accumulated per-bucket time ≈ wall-clock per phase. **Observation-only** (timing in `finally`; never branches; injected `now()` clock defaults to `Date.now`).
- **`RepoSyncResult.timings`** (additive) carries the breakdown.

## Surfaces (existing channels)

- **Plugin**: concise aggregate `⏱` line rides the *single* summary toast (2nd line — preserves the #3499 no-double-summary invariant); full **per-AS** detail → the always-on activity log (#3540, iPhone-readable in-app, persistent) + verbose file trace.
- **CLI**: per-AS + run-total breakdown for desktop measurement.

## Verify-before-assert

Confirmed the hot path in code BEFORE instrumenting: `ChangeDetector` hashes **every** file (`for…gitBlobSha`) and `syncLocked` reads **every** file each sync — both O(all files), unconditionally. The instrumentation measures whether this local read+hash actually dominates (plan §2 hypothesis) or whether REST does.

## Decision (AC)

Instrumentation is **PERMANENT / always-on** — overhead is two clock reads per op (negligible); Andrey just syncs and reads the breakdown, no debug toggle to flip.

## Tests

- `SyncPhaseTimer.test.ts` (timer + classify + aggregate + format, deterministic clock).
- `SyncEngine.timings.test.ts` (production-shape: same `FakeGitHubRepo`/`FakeLocalFiles` as every other sync test + clock-advancing port wrappers; proves the chokepoints attribute a REAL sync to the right buckets + counts, and that `dominantPhase` correctly identifies hash vs restTree).
- Plugin `SyncCommands` surface tests (aggregate on toast + per-AS on activity log + omitted when idle).
- **revert-verify**: disabling the sha1 chokepoint fails the hash-bucket assertions (test is not vacuous).
- No regression: 345 sync + 99 plugin + 17 CLI existing tests green; mobile-loadable + console-channel assertions pass (`Date.now`, no Node deps — Desktop↔Mobile parity).

## Scope

Strictly the ExoSync sync-engine + its existing plugin/CLI surfaces. No docs, no onboarding, no unrelated plugin code.