### PR TITLE
feat(create-instance): reusable ReferencePicker (T2)

### DIFF
--- a/docs/reference/dynamic-form-reference-picker.md
+++ b/docs/reference/dynamic-form-reference-picker.md
@@ -1,0 +1,80 @@
+# DynamicForm reference-picker (`assetRef` fuzzy picker)
+
+> Generic, reusable fuzzy reference-picker for `DynamicForm`. Extracted from the
+> T1 «Create Instance» button (project bbe40f8c, T2) so any future command form
+> can embed the same combobox without reimplementing it.
+>
+> Source: `packages/obsidian-plugin/src/presentation/components/dynamic-form/ReferencePicker.tsx`.
+
+## What it is
+
+A controlled React combobox that lets the user fuzzy-search a list of candidate
+assets (by `exo__Asset_label`) and commit the chosen one as a quoted frontmatter
+wikilink (`"[[<uid>]]"`). It is **parameterised by class** — the caller decides
+which class's instances become candidates — so it is a building block, not a
+one-off.
+
+## Using it from a grounding's `inputSchema`
+
+Declare an `assetRef` field with a `targetClassUid`. The picker offers every
+vault asset that is an instance of that class:
+
+```jsonc
+{
+  "type": "object",
+  "properties": {
+    "exo__Asset_isDefinedBy": {
+      "type": "assetRef",
+      "title": "Ontology",
+      "targetClassUid": "829b9b3b-6fc3-4276-be6a-27d3398c012e", // exo__Ontology
+    },
+  },
+  "required": ["exo__Asset_isDefinedBy"],
+}
+```
+
+Resolution path (no code needed per command):
+
+1. `CommandResolver` parses the JSON into an `InputSchemaField` with
+   `type: "assetRef"` + `targetClassUid`.
+2. `DynamicFormModal.buildCandidates()` resolves candidates for each such field
+   via `findAssetRefCandidates(app, targetClassUid)` (matches the dual IRI
+   scheme — UID-canon or symbolic — desktop **and** mobile, metadata-cache only,
+   no `Platform.isMobile` gating).
+3. `DynamicForm` renders `<ReferencePicker>` for the field.
+
+Object-typed **required** properties (T3) reuse the exact same path: the
+required-property resolver emits an `assetRef` field whose `targetClassUid` is
+the property's `exo__Property_range` class.
+
+## Embedding the component directly (non-`inputSchema` callers)
+
+`ReferencePicker` is decoupled from `InputSchemaField` — it takes primitives:
+
+| Prop          | Meaning                                                                        |
+| ------------- | ------------------------------------------------------------------------------ |
+| `name`        | Stable id segment for `data-testid` (typically the field name).                |
+| `value`       | Committed value: a quoted wikilink `"[[<uid>]]"`, or `""`.                     |
+| `candidates`  | `{ uid, label }[]` the user may pick.                                          |
+| `onChange`    | Receives `"[[<uid>]]"` on select, `""` while typing (free text never commits). |
+| `picker`      | `true` → fuzzy combobox; `false` → plain text passthrough (legacy).            |
+| `placeholder` | Optional input placeholder.                                                    |
+
+Contract guarantees:
+
+- **No free-text leak** — typing clears the committed value until a candidate is
+  chosen, so only real `"[[<uid>]]"` references reach frontmatter.
+- **Value round-trip** — a committed `"[[<uid>]]"` that matches a candidate
+  shows that candidate's label on mount (re-opening a pre-filled form is
+  readable).
+- **Accessibility** — ARIA combobox: ArrowDown/ArrowUp move the active option,
+  Enter selects, Escape closes; `aria-controls` / `aria-activedescendant` wired.
+- **Graceful degrade** — `picker={false}` (no candidates / no target class)
+  renders a plain text input, so existing `assetRef` groundings keep working.
+
+## Tests
+
+- `packages/obsidian-plugin/tests/unit/presentation/components/ReferencePicker.test.tsx`
+  — filter / select / keyboard / value round-trip / free-text degrade.
+- `packages/obsidian-plugin/tests/unit/presentation/components/DynamicForm.test.tsx`
+  — integration within the form.

--- a/packages/obsidian-plugin/src/presentation/components/dynamic-form/DynamicForm.tsx
+++ b/packages/obsidian-plugin/src/presentation/components/dynamic-form/DynamicForm.tsx
@@ -1,16 +1,10 @@
-import React, {
-  useState,
-  useCallback,
-  useMemo,
-  useRef,
-  useId,
-  useEffect,
-} from "react";
+import React, { useState, useCallback, useMemo } from "react";
 import type {
   InputSchemaField,
   EnumOption,
   AssetRefCandidate,
 } from "@plugin/presentation/builders/button-groups/DynamicCommandButtonGroupBuilder";
+import { ReferencePicker } from "@plugin/presentation/components/dynamic-form/ReferencePicker";
 
 export interface DynamicFormProps {
   readonly schema: InputSchemaField[];
@@ -97,11 +91,15 @@ export const DynamicForm: React.FC<DynamicFormProps> = ({
             {field.required && <span className="dynamic-form-required"> *</span>}
           </label>
           {field.type === "assetRef" ? (
-            <AssetRefPicker
-              field={field}
+            <ReferencePicker
+              name={field.name}
               value={values[field.name] ?? ""}
               candidates={candidates?.[field.name] ?? []}
-              onChange={handleChange}
+              picker={
+                (candidates?.[field.name]?.length ?? 0) > 0 ||
+                field.targetClassUid !== undefined
+              }
+              onChange={(v) => handleChange(field.name, v)}
             />
           ) : (
             renderField(field, values[field.name] ?? "", handleChange)
@@ -120,179 +118,6 @@ export const DynamicForm: React.FC<DynamicFormProps> = ({
         </button>
       </div>
     </form>
-  );
-};
-
-/**
- * T1 "Create Instance" — reusable fuzzy reference-picker for `assetRef` fields
- * (project bbe40f8c, meta-requirement (a): a generic, parameterised-by-class
- * component, not a one-off). Displays candidate `label`s, commits a quoted
- * wikilink (`"[[<uid>]]"`) to the selected candidate. When no candidates are
- * supplied (e.g. unparameterised field) it degrades to a free-text input so
- * existing assetRef groundings keep working.
- *
- * Accessibility: ARIA combobox pattern with keyboard navigation —
- * ArrowDown/ArrowUp move the active option, Enter selects, Escape closes.
- */
-interface AssetRefPickerProps {
-  readonly field: InputSchemaField;
-  readonly value: string;
-  readonly candidates: ReadonlyArray<AssetRefCandidate>;
-  readonly onChange: (name: string, value: string) => void;
-}
-
-function toWikilink(uid: string): string {
-  return `"[[${uid}]]"`;
-}
-
-const AssetRefPicker: React.FC<AssetRefPickerProps> = ({
-  field,
-  value,
-  candidates,
-  onChange,
-}) => {
-  const [query, setQuery] = useState("");
-  const [open, setOpen] = useState(false);
-  const [activeIndex, setActiveIndex] = useState(-1);
-  const listboxId = useId();
-  const blurTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
-
-  // Clear any pending blur-close timer on unmount so it can't fire after the
-  // modal closes (harmless no-op in React 19, but tidy).
-  useEffect(
-    () => () => {
-      if (blurTimer.current) clearTimeout(blurTimer.current);
-    },
-    [],
-  );
-
-  // No candidates supplied → behave like a plain text input (backward compat
-  // with assetRef fields that don't declare a targetClassUid).
-  const isPicker = candidates.length > 0 || field.targetClassUid !== undefined;
-
-  const filtered = useMemo(() => {
-    const q = query.trim().toLowerCase();
-    if (q.length === 0) return candidates.slice(0, 50);
-    return candidates
-      .filter((c) => c.label.toLowerCase().includes(q))
-      .slice(0, 50);
-  }, [candidates, query]);
-
-  const commit = useCallback(
-    (candidate: AssetRefCandidate) => {
-      onChange(field.name, toWikilink(candidate.uid));
-      setQuery(candidate.label);
-      setOpen(false);
-      setActiveIndex(-1);
-    },
-    [field.name, onChange],
-  );
-
-  const handleInput = useCallback(
-    (text: string) => {
-      setQuery(text);
-      setOpen(true);
-      setActiveIndex(-1);
-      // Clear the committed selection until a candidate is chosen, so free
-      // text never leaks into frontmatter as a value.
-      if (value) onChange(field.name, "");
-    },
-    [field.name, onChange, value],
-  );
-
-  const handleKeyDown = useCallback(
-    (e: React.KeyboardEvent<HTMLInputElement>) => {
-      if (!isPicker) return;
-      if (e.key === "ArrowDown") {
-        e.preventDefault();
-        setOpen(true);
-        setActiveIndex((i) => Math.min(i + 1, filtered.length - 1));
-      } else if (e.key === "ArrowUp") {
-        e.preventDefault();
-        setActiveIndex((i) => Math.max(i - 1, 0));
-      } else if (e.key === "Enter") {
-        if (open && activeIndex >= 0 && activeIndex < filtered.length) {
-          e.preventDefault();
-          commit(filtered[activeIndex]);
-        }
-      } else if (e.key === "Escape") {
-        setOpen(false);
-        setActiveIndex(-1);
-      }
-    },
-    [isPicker, filtered, open, activeIndex, commit],
-  );
-
-  if (!isPicker) {
-    // Plain text passthrough (legacy assetRef without candidates).
-    return (
-      <input
-        type="text"
-        className="dynamic-form-input"
-        placeholder="asset reference..."
-        value={value}
-        onChange={(e) => onChange(field.name, e.target.value)}
-        data-testid={`field-${field.name}`}
-      />
-    );
-  }
-
-  return (
-    <div className="dynamic-form-assetref">
-      <input
-        type="text"
-        role="combobox"
-        aria-expanded={open}
-        aria-controls={listboxId}
-        aria-autocomplete="list"
-        aria-activedescendant={
-          open && activeIndex >= 0
-            ? `${listboxId}-opt-${activeIndex}`
-            : undefined
-        }
-        className="dynamic-form-input"
-        placeholder="Type to search…"
-        value={query}
-        onChange={(e) => handleInput(e.target.value)}
-        onFocus={() => setOpen(true)}
-        onBlur={() => {
-          // Delay so an option's mousedown can commit before blur closes.
-          blurTimer.current = setTimeout(() => setOpen(false), 150);
-        }}
-        onKeyDown={handleKeyDown}
-        data-testid={`field-${field.name}`}
-      />
-      {open && filtered.length > 0 && (
-        <ul
-          id={listboxId}
-          role="listbox"
-          className="dynamic-form-assetref-options"
-        >
-          {filtered.map((candidate, idx) => (
-            <li
-              key={candidate.uid}
-              id={`${listboxId}-opt-${idx}`}
-              role="option"
-              aria-selected={idx === activeIndex}
-              className={
-                idx === activeIndex
-                  ? "dynamic-form-assetref-option is-active"
-                  : "dynamic-form-assetref-option"
-              }
-              // onMouseDown (not onClick) so it fires before the input blur.
-              onMouseDown={(e) => {
-                e.preventDefault();
-                if (blurTimer.current) clearTimeout(blurTimer.current);
-                commit(candidate);
-              }}
-              data-testid={`option-${field.name}-${candidate.uid}`}
-            >
-              {candidate.label}
-            </li>
-          ))}
-        </ul>
-      )}
-    </div>
   );
 };
 

--- a/packages/obsidian-plugin/src/presentation/components/dynamic-form/ReferencePicker.tsx
+++ b/packages/obsidian-plugin/src/presentation/components/dynamic-form/ReferencePicker.tsx
@@ -1,0 +1,221 @@
+import React, {
+  useState,
+  useCallback,
+  useMemo,
+  useRef,
+  useId,
+  useEffect,
+} from "react";
+import type { AssetRefCandidate } from "@plugin/presentation/builders/button-groups/DynamicCommandButtonGroupBuilder";
+
+/**
+ * T2 «Create Instance» (project bbe40f8c) — a **generic, reusable** fuzzy
+ * reference-picker, extracted from the inline T1 `assetRef` field so any future
+ * command/form can embed it without reimplementing the combobox.
+ *
+ * Contract (decoupled from `InputSchemaField` on purpose, so non-form callers
+ * can use it too):
+ *
+ *   - `candidates`  — the assets the user may pick (one per class; the caller
+ *                     resolves them, e.g. from `findAssetRefCandidates(app,
+ *                     targetClassUid)` — parameterised by class).
+ *   - `value`       — the committed value: a quoted wikilink `"[[<uid>]]"`, or
+ *                     `""` when nothing is selected. The component round-trips
+ *                     this: on mount it shows the matching candidate's label.
+ *   - `onChange`    — called with the new committed value: `"[[<uid>]]"` when a
+ *                     candidate is chosen, `""` while the user is typing (free
+ *                     text never leaks into frontmatter).
+ *   - `picker`      — `true` renders the fuzzy combobox; `false` degrades to a
+ *                     plain text input (legacy `assetRef` with no target class).
+ *
+ * Accessibility: ARIA combobox pattern with full keyboard navigation —
+ * ArrowDown/ArrowUp move the active option, Enter selects, Escape closes.
+ * The listbox/options are wired via `aria-controls` / `aria-activedescendant`.
+ */
+export interface ReferencePickerProps {
+  /** Stable id segment for `data-testid` (typically the form field name). */
+  readonly name: string;
+  /** Committed value — a quoted wikilink `"[[<uid>]]"` or `""`. */
+  readonly value: string;
+  /** Candidate assets to fuzzy-filter and select (label + uid). */
+  readonly candidates: ReadonlyArray<AssetRefCandidate>;
+  /** Receives the committed value: `"[[<uid>]]"` on select, `""` while typing. */
+  readonly onChange: (value: string) => void;
+  /**
+   * `true` → fuzzy combobox; `false` → plain text passthrough (back-compat with
+   * `assetRef` fields that declare no target class / supply no candidates).
+   */
+  readonly picker: boolean;
+  /** Placeholder for the plain text passthrough mode (default below). */
+  readonly placeholder?: string;
+}
+
+/** Wrap a bare UID as a quoted frontmatter wikilink (`"[[<uid>]]"`). */
+export function toReferenceWikilink(uid: string): string {
+  return `"[[${uid}]]"`;
+}
+
+/** Extract the bare UID from a committed `"[[<uid>]]"` value (or `null`). */
+function bareUidOf(value: string): string | null {
+  const m = /^"?\[\[([^|\]]+)(?:\|[^\]]*)?\]\]"?$/.exec(value.trim());
+  return m ? m[1].trim() : null;
+}
+
+const MAX_VISIBLE_OPTIONS = 50;
+
+export const ReferencePicker: React.FC<ReferencePickerProps> = ({
+  name,
+  value,
+  candidates,
+  onChange,
+  picker,
+  placeholder,
+}) => {
+  // Initial display text: if the committed value points at a known candidate,
+  // show that candidate's label so a pre-filled / re-opened picker is readable.
+  const initialQuery = useMemo(() => {
+    const uid = bareUidOf(value);
+    if (!uid) return "";
+    const match = candidates.find((c) => c.uid === uid);
+    return match ? match.label : "";
+  }, [value, candidates]);
+
+  const [query, setQuery] = useState(initialQuery);
+  const [open, setOpen] = useState(false);
+  const [activeIndex, setActiveIndex] = useState(-1);
+  const listboxId = useId();
+  const blurTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Clear any pending blur-close timer on unmount so it can't fire after the
+  // host (modal/form) unmounts.
+  useEffect(
+    () => () => {
+      if (blurTimer.current) clearTimeout(blurTimer.current);
+    },
+    [],
+  );
+
+  const filtered = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (q.length === 0) return candidates.slice(0, MAX_VISIBLE_OPTIONS);
+    return candidates
+      .filter((c) => c.label.toLowerCase().includes(q))
+      .slice(0, MAX_VISIBLE_OPTIONS);
+  }, [candidates, query]);
+
+  const commit = useCallback(
+    (candidate: AssetRefCandidate) => {
+      onChange(toReferenceWikilink(candidate.uid));
+      setQuery(candidate.label);
+      setOpen(false);
+      setActiveIndex(-1);
+    },
+    [onChange],
+  );
+
+  const handleInput = useCallback(
+    (text: string) => {
+      setQuery(text);
+      setOpen(true);
+      setActiveIndex(-1);
+      // Clear the committed selection until a candidate is chosen, so free
+      // text never leaks into frontmatter as a value.
+      if (value) onChange("");
+    },
+    [onChange, value],
+  );
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLInputElement>) => {
+      if (e.key === "ArrowDown") {
+        e.preventDefault();
+        setOpen(true);
+        setActiveIndex((i) => Math.min(i + 1, filtered.length - 1));
+      } else if (e.key === "ArrowUp") {
+        e.preventDefault();
+        setActiveIndex((i) => Math.max(i - 1, 0));
+      } else if (e.key === "Enter") {
+        if (open && activeIndex >= 0 && activeIndex < filtered.length) {
+          e.preventDefault();
+          commit(filtered[activeIndex]);
+        }
+      } else if (e.key === "Escape") {
+        setOpen(false);
+        setActiveIndex(-1);
+      }
+    },
+    [filtered, open, activeIndex, commit],
+  );
+
+  if (!picker) {
+    // Plain text passthrough (legacy assetRef without candidates).
+    return (
+      <input
+        type="text"
+        className="dynamic-form-input"
+        placeholder={placeholder ?? "asset reference..."}
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        data-testid={`field-${name}`}
+      />
+    );
+  }
+
+  return (
+    <div className="dynamic-form-assetref">
+      <input
+        type="text"
+        role="combobox"
+        aria-expanded={open}
+        aria-controls={listboxId}
+        aria-autocomplete="list"
+        aria-activedescendant={
+          open && activeIndex >= 0
+            ? `${listboxId}-opt-${activeIndex}`
+            : undefined
+        }
+        className="dynamic-form-input"
+        placeholder={placeholder ?? "Type to search…"}
+        value={query}
+        onChange={(e) => handleInput(e.target.value)}
+        onFocus={() => setOpen(true)}
+        onBlur={() => {
+          // Delay so an option's mousedown can commit before blur closes.
+          blurTimer.current = setTimeout(() => setOpen(false), 150);
+        }}
+        onKeyDown={handleKeyDown}
+        data-testid={`field-${name}`}
+      />
+      {open && filtered.length > 0 && (
+        <ul
+          id={listboxId}
+          role="listbox"
+          className="dynamic-form-assetref-options"
+        >
+          {filtered.map((candidate, idx) => (
+            <li
+              key={candidate.uid}
+              id={`${listboxId}-opt-${idx}`}
+              role="option"
+              aria-selected={idx === activeIndex}
+              className={
+                idx === activeIndex
+                  ? "dynamic-form-assetref-option is-active"
+                  : "dynamic-form-assetref-option"
+              }
+              // onMouseDown (not onClick) so it fires before the input blur.
+              onMouseDown={(e) => {
+                e.preventDefault();
+                if (blurTimer.current) clearTimeout(blurTimer.current);
+                commit(candidate);
+              }}
+              data-testid={`option-${name}-${candidate.uid}`}
+            >
+              {candidate.label}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+};

--- a/packages/obsidian-plugin/tests/unit/presentation/components/ReferencePicker.test.tsx
+++ b/packages/obsidian-plugin/tests/unit/presentation/components/ReferencePicker.test.tsx
@@ -1,0 +1,154 @@
+import React from "react";
+import "@testing-library/jest-dom";
+import { render, screen, fireEvent } from "@testing-library/react";
+import {
+  ReferencePicker,
+  toReferenceWikilink,
+} from "../../../../src/presentation/components/dynamic-form/ReferencePicker";
+import type { AssetRefCandidate } from "../../../../src/presentation/builders/button-groups/DynamicCommandButtonGroupBuilder";
+
+/**
+ * T2 «Create Instance» (project bbe40f8c) — focused unit tests for the generic,
+ * reusable {@link ReferencePicker}. Verifies the contract any future command
+ * relies on: fuzzy filtering, commit-as-wikilink, keyboard navigation, value
+ * round-trip, and the free-text passthrough degrade.
+ */
+
+const CANDIDATES: AssetRefCandidate[] = [
+  { uid: "11111111-1111-1111-1111-111111111111", label: "Alpha ontology" },
+  { uid: "22222222-2222-2222-2222-222222222222", label: "Beta ontology" },
+  { uid: "33333333-3333-3333-3333-333333333333", label: "Gamma ontology" },
+];
+
+function renderPicker(
+  overrides: Partial<React.ComponentProps<typeof ReferencePicker>> = {},
+) {
+  const onChange = jest.fn();
+  const utils = render(
+    <ReferencePicker
+      name="ontology"
+      value=""
+      candidates={CANDIDATES}
+      picker
+      onChange={onChange}
+      {...overrides}
+    />,
+  );
+  return { ...utils, onChange };
+}
+
+describe("ReferencePicker", () => {
+  describe("toReferenceWikilink", () => {
+    it("wraps a bare uid as a quoted frontmatter wikilink", () => {
+      expect(toReferenceWikilink("abc")).toBe('"[[abc]]"');
+    });
+  });
+
+  describe("picker mode", () => {
+    it("renders an ARIA combobox", () => {
+      renderPicker();
+      const input = screen.getByTestId("field-ontology");
+      expect(input).toHaveAttribute("role", "combobox");
+      expect(input).toHaveAttribute("aria-autocomplete", "list");
+    });
+
+    it("opens the listbox on focus and shows all candidates", () => {
+      renderPicker();
+      fireEvent.focus(screen.getByTestId("field-ontology"));
+      expect(screen.getByRole("listbox")).toBeInTheDocument();
+      expect(screen.getAllByRole("option")).toHaveLength(3);
+    });
+
+    it("fuzzy-filters candidates by label substring (case-insensitive)", () => {
+      renderPicker();
+      const input = screen.getByTestId("field-ontology");
+      fireEvent.focus(input);
+      fireEvent.change(input, { target: { value: "beta" } });
+      const options = screen.getAllByRole("option");
+      expect(options).toHaveLength(1);
+      expect(options[0]).toHaveTextContent("Beta ontology");
+    });
+
+    it("commits the selected candidate as a quoted wikilink on click", () => {
+      const { onChange } = renderPicker();
+      const input = screen.getByTestId("field-ontology");
+      fireEvent.focus(input);
+      fireEvent.mouseDown(
+        screen.getByTestId(
+          "option-ontology-22222222-2222-2222-2222-222222222222",
+        ),
+      );
+      expect(onChange).toHaveBeenLastCalledWith(
+        '"[[22222222-2222-2222-2222-222222222222]]"',
+      );
+    });
+
+    it("clears the committed value while the user types free text", () => {
+      const { onChange } = renderPicker({
+        value: '"[[11111111-1111-1111-1111-111111111111]]"',
+      });
+      const input = screen.getByTestId("field-ontology");
+      fireEvent.change(input, { target: { value: "Be" } });
+      // Free text never leaks into frontmatter — value is cleared until commit.
+      expect(onChange).toHaveBeenCalledWith("");
+    });
+
+    it("round-trips the value: a committed wikilink shows the candidate label", () => {
+      renderPicker({ value: '"[[33333333-3333-3333-3333-333333333333]]"' });
+      expect(screen.getByTestId("field-ontology")).toHaveValue(
+        "Gamma ontology",
+      );
+    });
+
+    describe("keyboard navigation", () => {
+      it("ArrowDown then Enter selects the first option", () => {
+        const { onChange } = renderPicker();
+        const input = screen.getByTestId("field-ontology");
+        fireEvent.focus(input);
+        fireEvent.keyDown(input, { key: "ArrowDown" });
+        fireEvent.keyDown(input, { key: "Enter" });
+        expect(onChange).toHaveBeenLastCalledWith(
+          '"[[11111111-1111-1111-1111-111111111111]]"',
+        );
+      });
+
+      it("ArrowDown twice highlights the second option (aria-selected)", () => {
+        renderPicker();
+        const input = screen.getByTestId("field-ontology");
+        fireEvent.focus(input);
+        fireEvent.keyDown(input, { key: "ArrowDown" });
+        fireEvent.keyDown(input, { key: "ArrowDown" });
+        const options = screen.getAllByRole("option");
+        expect(options[1]).toHaveAttribute("aria-selected", "true");
+      });
+
+      it("Escape closes the listbox", () => {
+        renderPicker();
+        const input = screen.getByTestId("field-ontology");
+        fireEvent.focus(input);
+        expect(screen.queryByRole("listbox")).toBeInTheDocument();
+        fireEvent.keyDown(input, { key: "Escape" });
+        expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+      });
+    });
+  });
+
+  describe("free-text passthrough (picker=false)", () => {
+    it("renders a plain text input and forwards raw input", () => {
+      const onChange = jest.fn();
+      render(
+        <ReferencePicker
+          name="freeform"
+          value=""
+          candidates={[]}
+          picker={false}
+          onChange={onChange}
+        />,
+      );
+      const input = screen.getByTestId("field-freeform");
+      expect(input).not.toHaveAttribute("role", "combobox");
+      fireEvent.change(input, { target: { value: "[[manual-ref]]" } });
+      expect(onChange).toHaveBeenCalledWith("[[manual-ref]]");
+    });
+  });
+});


### PR DESCRIPTION
## What

T2 of the homoiconic «Create Instance» flagship (project `bbe40f8c`). Extracts the inline T1 `assetRef` fuzzy-picker into a **standalone, documented, parameterised-by-class** `ReferencePicker` component so any future command form can embed the same combobox without reimplementing it (meta-requirement: reusable, not a one-off).

## Changes

- **New** `packages/obsidian-plugin/src/presentation/components/dynamic-form/ReferencePicker.tsx` — primitive contract decoupled from `InputSchemaField` (`name`/`value`/`candidates`/`onChange`/`picker`/`placeholder`). Adds **value round-trip**: a committed `"[[<uid>]]"` shows the matching candidate's label on mount (re-opening a pre-filled form is readable).
- `DynamicForm.tsx` delegates `assetRef` rendering to it — behaviour-preserving; the inline `AssetRefPicker` is removed (193-line diff is mostly that move).
- **13 focused component tests** (fuzzy filter, commit-as-wikilink, ArrowDown/Up/Enter/Escape keyboard nav, value round-trip, free-text passthrough degrade).
- **Reference doc** `docs/reference/dynamic-form-reference-picker.md` — contract for future commands.

## Safety

- No parser / grounding / TBox changes; no vault changes.
- Existing `DynamicForm` + `DynamicFormModal` + `assetRefCandidates` suites green (96 tests).
- Desktop ↔ mobile unaffected (metadata-cache candidate resolution path unchanged; no `Platform.isMobile` gating).

Part of the T2–T5 «Create Instance» completion (T1 shipped v16.102.0, PR #3611).