### PR TITLE
fix(layout): exo-layout cell-renderer cluster (#3628 #3629 #3630)

### DIFF
--- a/packages/obsidian-plugin/src/application/layout/LayoutService.ts
+++ b/packages/obsidian-plugin/src/application/layout/LayoutService.ts
@@ -570,23 +570,83 @@ export class LayoutService {
       }
 
       case "datetime": {
-        // Try to parse as date
+        // Date-only ISO values ("2026-06-20") must parse as LOCAL midnight, not
+        // UTC midnight, otherwise the day shifts one earlier west of UTC (#3630).
+        const dateOnly = stringValue.match(/^(\d{4})-(\d{2})-(\d{2})$/);
+        if (dateOnly) {
+          const local = new Date(
+            Number(dateOnly[1]),
+            Number(dateOnly[2]) - 1,
+            Number(dateOnly[3]),
+          );
+          return isNaN(local.getTime()) ? stringValue : local;
+        }
         const date = new Date(stringValue);
         return isNaN(date.getTime()) ? stringValue : date;
       }
 
-      case "link": {
-        // Keep as string for link rendering
+      case "link":
+      case "tags":
+      case "badge": {
+        // A bare IRI object (an unwrapped wikilink, e.g. a status/class binding)
+        // must become a resolvable [[basename]] wikilink so the renderer can
+        // resolve a human label via getAssetLabel — instead of showing the raw
+        // IRI/UUID (#3629).
+        if (term instanceof IRI) {
+          const basename = this.iriToBasename(stringValue);
+          if (basename) {
+            return `[[${basename}]]`;
+          }
+        }
         return stringValue;
       }
 
-      case "tags":
-      case "badge":
       case "image":
       case "text":
       default:
         return stringValue;
     }
+  }
+
+  /**
+   * Reduce an RDF IRI to a vault-resolvable basename so cell renderers can look
+   * up a human label via getAssetLabel:
+   *  - filename IRI `obsidian://vault/<path>/<uid>.md` → `<uid>`
+   *  - symbolic IRI `https://exocortex.my/ontology/<ns>#<Local>` → `<Local>`
+   *
+   * Returns null when no sensible basename can be extracted.
+   */
+  private iriToBasename(iri: string): string | null {
+    if (!iri) {
+      return null;
+    }
+
+    // Symbolic ontology IRI (http/https with a '#fragment') → localname.
+    if (/^https?:\/\//i.test(iri)) {
+      const hashIdx = iri.lastIndexOf("#");
+      if (hashIdx !== -1) {
+        const local = iri.slice(hashIdx + 1).trim();
+        if (local) {
+          return local;
+        }
+      }
+    }
+
+    // Path-style IRI (obsidian://, file://, http(s)://…/x.md) → last segment.
+    if (/^[a-z][a-z0-9+.-]*:\/\//i.test(iri)) {
+      let last = iri.split("/").pop() || "";
+      try {
+        last = decodeURIComponent(last);
+      } catch {
+        // keep raw segment on malformed percent-encoding
+      }
+      last = last.replace(/\.md$/i, "").trim();
+      if (last) {
+        return last;
+      }
+    }
+
+    return null;
   }
 
   /**

--- a/packages/obsidian-plugin/src/application/processors/LayoutCodeBlockProcessor.ts
+++ b/packages/obsidian-plugin/src/application/processors/LayoutCodeBlockProcessor.ts
@@ -406,6 +406,12 @@ export class LayoutCodeBlockProcessor {
           );
         },
         getAssetLabel: (path: string) => this.wikilinkResolver.getAssetLabel(path),
+        // Surface action-button failures to the user instead of failing silently
+        // (#3628). Routed through the central notifier (eslint forbids `new
+        // Notice` elsewhere).
+        onError: (message: string) => {
+          this.plugin.notifier?.error(message);
+        },
       })
     );
   }

--- a/packages/obsidian-plugin/src/presentation/renderers/TableLayoutRenderer.tsx
+++ b/packages/obsidian-plugin/src/presentation/renderers/TableLayoutRenderer.tsx
@@ -89,6 +89,12 @@ export interface TableLayoutRendererProps {
    * resolved label instead of the raw target path.
    */
   getAssetLabel?: (path: string) => string | null;
+
+  /**
+   * Callback to surface a user-facing error from an action button (e.g. a Notice
+   * toast) instead of failing silently (#3628).
+   */
+  onError?: (message: string) => void;
 }
 
 /**
@@ -180,6 +186,7 @@ export const TableLayoutRenderer: React.FC<TableLayoutRendererProps> = ({
   onCheckPrecondition,
   onExecuteCommand,
   getAssetLabel,
+  onError,
 }) => {
   const options = { ...defaultOptions, ...propOptions };
   const columns = layout.columns || [];
@@ -354,6 +361,7 @@ export const TableLayoutRenderer: React.FC<TableLayoutRendererProps> = ({
           assetPath={row.path}
           onCheckPrecondition={onCheckPrecondition}
           onExecuteCommand={onExecuteCommand}
+          onError={onError}
         />
       </td>
     );

--- a/packages/obsidian-plugin/src/presentation/renderers/cell-renderers/ActionsRenderer.tsx
+++ b/packages/obsidian-plugin/src/presentation/renderers/cell-renderers/ActionsRenderer.tsx
@@ -111,6 +111,16 @@ export interface ActionsRendererProps {
   disabled?: boolean;
 
   /**
+   * Callback to surface a user-facing error message (e.g. a Notice toast).
+   *
+   * Without this, action-button failures — a missing executor, a command with
+   * no grounding, or an execution that throws — are swallowed to the console
+   * and the button silently no-ops (#3628). When provided, those conditions are
+   * reported to the user instead of failing silently.
+   */
+  onError?: (message: string) => void;
+
+  /**
    * Custom class name
    */
   className?: string;
@@ -134,6 +144,7 @@ export const ActionsRenderer: React.FC<ActionsRendererProps> = ({
   assetPath,
   onCheckPrecondition,
   onExecuteCommand,
+  onError,
   disabled = false,
   className,
 }) => {
@@ -203,8 +214,19 @@ export const ActionsRenderer: React.FC<ActionsRendererProps> = ({
       event.preventDefault();
       event.stopPropagation();
 
-      if (!cmd.groundingSparql || !onExecuteCommand) {
-        console.warn(`No grounding SPARQL for command: ${cmd.label}`);
+      // Surface why a click had no effect instead of silently bailing (#3628):
+      // a command with no grounding, or no executor wired by the host, used to
+      // log to the console and no-op — indistinguishable from a broken button.
+      if (!cmd.groundingSparql) {
+        const message = `No action is configured for "${cmd.label}".`;
+        console.warn(message);
+        onError?.(message);
+        return;
+      }
+      if (!onExecuteCommand) {
+        const message = `Cannot run "${cmd.label}": no command executor is available for layout actions.`;
+        console.warn(message);
+        onError?.(message);
         return;
       }
 
@@ -233,7 +255,9 @@ export const ActionsRenderer: React.FC<ActionsRendererProps> = ({
           }
         }
       } catch (error) {
+        const detail = error instanceof Error ? error.message : String(error);
         console.error(`Command execution failed for ${cmd.label}:`, error);
+        onError?.(`Failed to run "${cmd.label}": ${detail}`);
       } finally {
         setCommandStates((prev) => ({
           ...prev,
@@ -241,7 +265,7 @@ export const ActionsRenderer: React.FC<ActionsRendererProps> = ({
         }));
       }
     },
-    [assetUri, commands, onCheckPrecondition, onExecuteCommand],
+    [assetUri, commands, onCheckPrecondition, onExecuteCommand, onError],
   );
 
   // Render a single button

--- a/packages/obsidian-plugin/src/presentation/renderers/cell-renderers/BadgeRenderer.tsx
+++ b/packages/obsidian-plugin/src/presentation/renderers/cell-renderers/BadgeRenderer.tsx
@@ -5,13 +5,32 @@ import React from "react";
 import type { CellRendererProps } from "./types";
 
 /**
- * Extract label from wikilink or return value as-is.
+ * Extract a display label from a wikilink (or return the value as-is).
+ *
+ * Mirrors LinkRenderer: an explicit alias wins; otherwise, when getAssetLabel
+ * is provided, the alias-less target is resolved to its exo:Asset_label so a
+ * badge bound to a wikilink/IRI property shows the human label instead of the
+ * raw UUID/IRI (#3629).
  */
-function extractLabel(value: string): string {
+function extractLabel(
+  value: string,
+  getAssetLabel?: (path: string) => string | null,
+): string {
   // Match [[target]] or [[target|alias]]
   const match = value.match(/^\[\[([^\]|]+)(?:\|([^\]]+))?\]\]$/);
   if (match) {
-    return match[2]?.trim() || match[1].trim();
+    const target = match[1].trim();
+    const alias = match[2]?.trim();
+    if (alias) {
+      return alias;
+    }
+    if (getAssetLabel) {
+      const resolved = getAssetLabel(target);
+      if (resolved) {
+        return resolved;
+      }
+    }
+    return target;
   }
   return value;
 }
@@ -48,13 +67,14 @@ function getBadgeColorClass(value: string): string {
 export const BadgeRenderer: React.FC<CellRendererProps> = ({
   value,
   onLinkClick,
+  getAssetLabel,
 }) => {
   if (value == null || value === "") {
     return <span className="exo-cell-badge exo-cell-badge-empty">-</span>;
   }
 
   const stringValue = String(value);
-  const label = extractLabel(stringValue);
+  const label = extractLabel(stringValue, getAssetLabel);
   const colorClass = getBadgeColorClass(label);
 
   // Check if this is a wikilink - if so, make it clickable

--- a/packages/obsidian-plugin/src/presentation/renderers/cell-renderers/DateTimeRenderer.tsx
+++ b/packages/obsidian-plugin/src/presentation/renderers/cell-renderers/DateTimeRenderer.tsx
@@ -44,6 +44,19 @@ function parseDate(value: unknown): Date | null {
 
   // String (ISO format or other parseable format)
   if (typeof value === "string") {
+    // Date-only ISO values ("2026-06-20") parse as UTC midnight via `new Date`,
+    // which renders one day earlier for users west of UTC (#3630). Construct a
+    // LOCAL-midnight Date instead so the calendar day is stable in every TZ.
+    const dateOnly = value.match(/^(\d{4})-(\d{2})-(\d{2})$/);
+    if (dateOnly) {
+      const local = new Date(
+        Number(dateOnly[1]),
+        Number(dateOnly[2]) - 1,
+        Number(dateOnly[3]),
+      );
+      return isNaN(local.getTime()) ? null : local;
+    }
+
     // Try ISO format first
     let date = new Date(value);
     if (!isNaN(date.getTime())) return date;

--- a/packages/obsidian-plugin/src/presentation/renderers/cell-renderers/TagsRenderer.tsx
+++ b/packages/obsidian-plugin/src/presentation/renderers/cell-renderers/TagsRenderer.tsx
@@ -29,15 +29,26 @@ function parseTags(value: unknown): string[] {
 }
 
 /**
- * Extract label from wikilink or return value as-is.
+ * Extract a target + display label from a wikilink (or return the value as-is).
+ *
+ * Mirrors LinkRenderer: an explicit alias wins; otherwise, when getAssetLabel
+ * is provided, the alias-less target is resolved to its exo:Asset_label so a
+ * tag bound to a wikilink/IRI property shows the human label instead of the raw
+ * UUID/IRI (#3629).
  */
-function extractLabel(value: string): { target: string; label: string } {
+function extractLabel(
+  value: string,
+  getAssetLabel?: (path: string) => string | null,
+): { target: string; label: string } {
   const match = value.match(/^\[\[([^\]|]+)(?:\|([^\]]+))?\]\]$/);
   if (match) {
-    return {
-      target: match[1].trim(),
-      label: match[2]?.trim() || match[1].trim(),
-    };
+    const target = match[1].trim();
+    const alias = match[2]?.trim();
+    let label: string | undefined = alias;
+    if (!label && getAssetLabel) {
+      label = getAssetLabel(target) || undefined;
+    }
+    return { target, label: label || target };
   }
   return { target: value, label: value };
 }
@@ -73,6 +84,7 @@ function getTagColorClass(value: string): string {
 export const TagsRenderer: React.FC<CellRendererProps> = ({
   value,
   onLinkClick,
+  getAssetLabel,
 }) => {
   const tags = parseTags(value);
 
@@ -83,7 +95,7 @@ export const TagsRenderer: React.FC<CellRendererProps> = ({
   return (
     <span className="exo-cell-tags">
       {tags.map((tag, index) => {
-        const { target, label } = extractLabel(tag);
+        const { target, label } = extractLabel(tag, getAssetLabel);
         const colorClass = getTagColorClass(label);
         const isWikiLink = /^\[\[.+\]\]$/.test(tag);
 

--- a/packages/obsidian-plugin/tests/unit/application/layout/LayoutService.test.ts
+++ b/packages/obsidian-plugin/tests/unit/application/layout/LayoutService.test.ts
@@ -378,6 +378,114 @@ describe("LayoutService", () => {
       expect(result.success).toBe(true);
       expect(result.rows![0].values["col-001"]).toBeInstanceOf(Date);
     });
+
+    it("parses a date-only datetime value as local midnight (#3630 / F12)", async () => {
+      const layoutWithDate: TableLayout = {
+        ...defaultLayout,
+        columns: [
+          { uid: "col-001", label: "Due", property: "[[due]]", renderer: "datetime" },
+        ],
+      };
+      mockParserParseFromFile.mockResolvedValue({
+        success: true,
+        layout: layoutWithDate,
+      });
+
+      const mapping = new SolutionMapping();
+      mapping.set("asset", new IRI("obsidian://vault/test.md"));
+      mapping.set("col0", new Literal("2026-06-20"));
+      mockSparqlQuery.mockResolvedValue([mapping]);
+
+      const result = await service.renderLayout(layoutFile);
+      const value = result.rows![0].values["col-001"];
+
+      expect(value).toBeInstanceOf(Date);
+      // Local midnight of the 20th — NOT UTC midnight (which shifts a day west
+      // of UTC). Discriminates the bug on any non-UTC machine.
+      expect((value as Date).getTime()).toBe(new Date(2026, 5, 20).getTime());
+    });
+
+    it("converts a bare IRI to a resolvable wikilink for badge columns (#3629 / F10)", async () => {
+      const layoutWithBadge: TableLayout = {
+        ...defaultLayout,
+        columns: [
+          { uid: "col-001", label: "Status", property: "[[ems__Effort_status]]", renderer: "badge" },
+        ],
+      };
+      mockParserParseFromFile.mockResolvedValue({
+        success: true,
+        layout: layoutWithBadge,
+      });
+
+      const mapping = new SolutionMapping();
+      mapping.set("asset", new IRI("obsidian://vault/test.md"));
+      mapping.set(
+        "col0",
+        new IRI("obsidian://vault/assetspaces/ems/1b20a8f0-d745-4e93-91db-4531b3df120e.md"),
+      );
+      mockSparqlQuery.mockResolvedValue([mapping]);
+
+      const result = await service.renderLayout(layoutFile);
+
+      // A bare IRI must become a resolvable [[basename]] wikilink so the renderer
+      // can resolve it to a human label via getAssetLabel — instead of showing
+      // the raw IRI/UUID.
+      expect(result.rows![0].values["col-001"]).toBe(
+        "[[1b20a8f0-d745-4e93-91db-4531b3df120e]]",
+      );
+    });
+
+    it("converts a bare IRI to a resolvable wikilink for tags columns (#3629 / F10)", async () => {
+      const layoutWithTags: TableLayout = {
+        ...defaultLayout,
+        columns: [
+          { uid: "col-001", label: "Class", property: "[[exo__Instance_class]]", renderer: "tags" },
+        ],
+      };
+      mockParserParseFromFile.mockResolvedValue({
+        success: true,
+        layout: layoutWithTags,
+      });
+
+      const mapping = new SolutionMapping();
+      mapping.set("asset", new IRI("obsidian://vault/test.md"));
+      mapping.set(
+        "col0",
+        new IRI("obsidian://vault/assetspaces/ems/7db5eeff-718a-49b0-8d2b-39b084a356e3.md"),
+      );
+      mockSparqlQuery.mockResolvedValue([mapping]);
+
+      const result = await service.renderLayout(layoutFile);
+
+      expect(result.rows![0].values["col-001"]).toBe(
+        "[[7db5eeff-718a-49b0-8d2b-39b084a356e3]]",
+      );
+    });
+
+    it("extracts the localname from a symbolic IRI for badge columns (#3629 / F10)", async () => {
+      const layoutWithBadge: TableLayout = {
+        ...defaultLayout,
+        columns: [
+          { uid: "col-001", label: "Status", property: "[[ems__Effort_status]]", renderer: "badge" },
+        ],
+      };
+      mockParserParseFromFile.mockResolvedValue({
+        success: true,
+        layout: layoutWithBadge,
+      });
+
+      const mapping = new SolutionMapping();
+      mapping.set("asset", new IRI("obsidian://vault/test.md"));
+      mapping.set(
+        "col0",
+        new IRI("https://exocortex.my/ontology/ems#EffortStatusDoing"),
+      );
+      mockSparqlQuery.mockResolvedValue([mapping]);
+
+      const result = await service.renderLayout(layoutFile);
+
+      expect(result.rows![0].values["col-001"]).toBe("[[EffortStatusDoing]]");
+    });
   });
 
   describe("renderLayoutFromWikiLink", () => {

--- a/packages/obsidian-plugin/tests/unit/presentation/renderers/cell-renderers/ActionsRenderer.test.tsx
+++ b/packages/obsidian-plugin/tests/unit/presentation/renderers/cell-renderers/ActionsRenderer.test.tsx
@@ -262,6 +262,99 @@ describe("ActionsRenderer", () => {
     });
   });
 
+  describe("Error surfacing (#3628)", () => {
+    it("surfaces an error (not a silent no-op) when no executor is wired", () => {
+      const onError = jest.fn();
+      const actions = createMockActions(); // has groundingSparql, but no onExecuteCommand
+
+      render(
+        <ActionsRenderer actions={actions} {...defaultProps} onError={onError} />,
+      );
+
+      fireEvent.click(screen.getByRole("button"));
+
+      expect(onError).toHaveBeenCalledTimes(1);
+      expect(onError.mock.calls[0][0]).toContain("Start");
+    });
+
+    it("surfaces an error when the command has no action configured", () => {
+      const onError = jest.fn();
+      const onExecuteCommand = jest.fn();
+      const actions = createMockActions({
+        commands: [
+          {
+            uid: "cmd-1",
+            label: "Start",
+            icon: "play-circle",
+            groundingSparql: undefined,
+          },
+        ],
+      });
+
+      render(
+        <ActionsRenderer
+          actions={actions}
+          {...defaultProps}
+          onExecuteCommand={onExecuteCommand}
+          onError={onError}
+        />,
+      );
+
+      fireEvent.click(screen.getByRole("button"));
+
+      expect(onError).toHaveBeenCalledTimes(1);
+      expect(onExecuteCommand).not.toHaveBeenCalled();
+    });
+
+    it("surfaces execution errors instead of swallowing them", async () => {
+      const onError = jest.fn();
+      const onExecuteCommand = jest
+        .fn<() => Promise<void>>()
+        .mockRejectedValue(new Error("boom"));
+      const actions = createMockActions(); // has groundingSparql
+
+      render(
+        <ActionsRenderer
+          actions={actions}
+          {...defaultProps}
+          onExecuteCommand={onExecuteCommand}
+          onError={onError}
+        />,
+      );
+
+      fireEvent.click(screen.getByRole("button"));
+
+      await waitFor(() => {
+        expect(onError).toHaveBeenCalledTimes(1);
+      });
+      expect(onError.mock.calls[0][0]).toContain("boom");
+    });
+
+    it("does not surface an error on a successful execution", async () => {
+      const onError = jest.fn();
+      const onExecuteCommand = jest
+        .fn<() => Promise<void>>()
+        .mockResolvedValue(undefined);
+      const actions = createMockActions();
+
+      render(
+        <ActionsRenderer
+          actions={actions}
+          {...defaultProps}
+          onExecuteCommand={onExecuteCommand}
+          onError={onError}
+        />,
+      );
+
+      fireEvent.click(screen.getByRole("button"));
+
+      await waitFor(() => {
+        expect(onExecuteCommand).toHaveBeenCalled();
+      });
+      expect(onError).not.toHaveBeenCalled();
+    });
+  });
+
   describe("Disabled State", () => {
     it("should disable buttons when disabled prop is true", () => {
       const actions = createMockActions();

--- a/packages/obsidian-plugin/tests/unit/presentation/renderers/cell-renderers/BadgeRenderer.test.tsx
+++ b/packages/obsidian-plugin/tests/unit/presentation/renderers/cell-renderers/BadgeRenderer.test.tsx
@@ -136,6 +136,64 @@ describe("BadgeRenderer", () => {
     });
   });
 
+  describe("getAssetLabel resolution (#3629 / F10)", () => {
+    const getAssetLabel = (path: string): string | null =>
+      path === "1b20a8f0" ? "Doing" : null;
+
+    it("resolves an alias-less wikilink target to its label", () => {
+      render(
+        <BadgeRenderer
+          value="[[1b20a8f0]]"
+          column={createColumn()}
+          getAssetLabel={getAssetLabel}
+        />,
+      );
+
+      expect(screen.getByText("Doing")).toBeInTheDocument();
+      expect(screen.queryByText("1b20a8f0")).not.toBeInTheDocument();
+    });
+
+    it("falls back to the target when getAssetLabel returns null", () => {
+      render(
+        <BadgeRenderer
+          value="[[unknown-uid]]"
+          column={createColumn()}
+          getAssetLabel={getAssetLabel}
+        />,
+      );
+
+      expect(screen.getByText("unknown-uid")).toBeInTheDocument();
+    });
+
+    it("prefers an explicit alias over getAssetLabel", () => {
+      render(
+        <BadgeRenderer
+          value="[[1b20a8f0|Explicit]]"
+          column={createColumn()}
+          getAssetLabel={getAssetLabel}
+        />,
+      );
+
+      expect(screen.getByText("Explicit")).toBeInTheDocument();
+    });
+
+    it("resolves the label on a clickable wikilink badge", () => {
+      const onLinkClick = jest.fn();
+      render(
+        <BadgeRenderer
+          value="[[1b20a8f0]]"
+          column={createColumn()}
+          getAssetLabel={getAssetLabel}
+          onLinkClick={onLinkClick}
+        />,
+      );
+
+      const badge = screen.getByText("Doing");
+      expect(badge.tagName).toBe("A");
+      expect(badge).toHaveAttribute("data-href", "1b20a8f0");
+    });
+  });
+
   describe("Empty State", () => {
     it("renders dash for null value", () => {
       render(

--- a/packages/obsidian-plugin/tests/unit/presentation/renderers/cell-renderers/DateTimeRenderer.test.tsx
+++ b/packages/obsidian-plugin/tests/unit/presentation/renderers/cell-renderers/DateTimeRenderer.test.tsx
@@ -123,6 +123,58 @@ describe("DateTimeRenderer", () => {
   });
 });
 
+describe("Date-only TZ-safety (#3630 / F12)", () => {
+  const createColumn = (): LayoutColumn => ({
+    uid: "col-1",
+    label: "Created",
+    property: "created",
+  });
+
+  // A date-only ISO value ("2026-06-20") must parse as LOCAL midnight, not UTC
+  // midnight. `new Date("2026-06-20")` parses as UTC midnight, which renders one
+  // day earlier west of UTC. The renderer exposes the parsed instant via the
+  // `title` (toISOString), so we assert the parsed instant equals LOCAL midnight
+  // of the same calendar day — a TZ-independent invariant that discriminates the
+  // bug on any machine whose UTC offset is non-zero (the bug is invisible on UTC,
+  // which is inherent: UTC midnight === local midnight there).
+  it("DateRenderer parses a date-only value as local midnight", () => {
+    render(<DateRenderer value="2026-06-20" column={createColumn()} />);
+
+    const el = document.querySelector(".exo-cell-date") as HTMLElement;
+    expect(el).toBeTruthy();
+    const expectedLocalMidnight = new Date(2026, 5, 20).toISOString();
+    expect(el.getAttribute("title")).toBe(expectedLocalMidnight);
+  });
+
+  it("DateTimeRenderer parses a date-only value as local midnight", () => {
+    render(<DateTimeRenderer value="2026-06-20" column={createColumn()} />);
+
+    const el = document.querySelector(".exo-cell-datetime") as HTMLElement;
+    expect(el).toBeTruthy();
+    const expectedLocalMidnight = new Date(2026, 5, 20).toISOString();
+    expect(el.getAttribute("title")).toBe(expectedLocalMidnight);
+  });
+
+  it("full ISO timestamps without TZ designator stay local (no regression)", () => {
+    render(
+      <DateTimeRenderer value="2026-06-20T10:30:00" column={createColumn()} />,
+    );
+
+    const el = document.querySelector(".exo-cell-datetime") as HTMLElement;
+    const expectedLocal = new Date(2026, 5, 20, 10, 30, 0).toISOString();
+    expect(el.getAttribute("title")).toBe(expectedLocal);
+  });
+
+  it("ISO timestamps with Z designator stay UTC (no regression)", () => {
+    render(
+      <DateTimeRenderer value="2026-06-20T10:30:00Z" column={createColumn()} />,
+    );
+
+    const el = document.querySelector(".exo-cell-datetime") as HTMLElement;
+    expect(el.getAttribute("title")).toBe("2026-06-20T10:30:00.000Z");
+  });
+});
+
 describe("DateRenderer", () => {
   const createColumn = (): LayoutColumn => ({
     uid: "col-1",

--- a/packages/obsidian-plugin/tests/unit/presentation/renderers/cell-renderers/TagsRenderer.test.tsx
+++ b/packages/obsidian-plugin/tests/unit/presentation/renderers/cell-renderers/TagsRenderer.test.tsx
@@ -17,6 +17,63 @@ describe("TagsRenderer", () => {
     property: "tags",
   });
 
+  describe("getAssetLabel resolution (#3629 / F10)", () => {
+    const getAssetLabel = (path: string): string | null =>
+      path === "7db5eeff" ? "Project" : null;
+
+    it("resolves an alias-less wikilink tag to its label", () => {
+      render(
+        <TagsRenderer
+          value="[[7db5eeff]]"
+          column={createColumn()}
+          getAssetLabel={getAssetLabel}
+        />,
+      );
+
+      expect(screen.getByText("Project")).toBeInTheDocument();
+      expect(screen.queryByText("7db5eeff")).not.toBeInTheDocument();
+    });
+
+    it("falls back to the target when getAssetLabel returns null", () => {
+      render(
+        <TagsRenderer
+          value="[[unknown-uid]]"
+          column={createColumn()}
+          getAssetLabel={getAssetLabel}
+        />,
+      );
+
+      expect(screen.getByText("unknown-uid")).toBeInTheDocument();
+    });
+
+    it("prefers an explicit alias over getAssetLabel", () => {
+      render(
+        <TagsRenderer
+          value="[[7db5eeff|Explicit]]"
+          column={createColumn()}
+          getAssetLabel={getAssetLabel}
+        />,
+      );
+
+      expect(screen.getByText("Explicit")).toBeInTheDocument();
+    });
+
+    it("resolves labels for each tag in a multi-tag value", () => {
+      const resolver = (path: string): string | null =>
+        ({ "7db5eeff": "Project", "1b20a8f0": "Task" })[path] ?? null;
+      render(
+        <TagsRenderer
+          value="[[7db5eeff]], [[1b20a8f0]]"
+          column={createColumn()}
+          getAssetLabel={resolver}
+        />,
+      );
+
+      expect(screen.getByText("Project")).toBeInTheDocument();
+      expect(screen.getByText("Task")).toBeInTheDocument();
+    });
+  });
+
   describe("Array Input", () => {
     it("renders array of tags", () => {
       render(


### PR DESCRIPTION
## exo-layout cell-renderer cluster (#3628 + #3629 + #3630)

Three related defects in the `exo-layout` table cell renderers (advanced/niche authoring surface, flagged pre-alpha). Verified against `origin/main` per finding; all changes TDD'd with **revert-verify** (fail pre-fix / pass post-fix).

### #3630 (F12) — date-only off-by-one west of UTC
`new Date("2026-06-20")` parses as **UTC** midnight; an `Intl` formatter in a negative-UTC TZ then renders the **19th**. Fixed at **both** parse sites — `DateTimeRenderer.parseDate` (string branch) and `LayoutService.convertRdfToCellValue` (`datetime` case) — by detecting `^\d{4}-\d{2}-\d{2}$` and constructing **local** midnight. Tested via a TZ-independent `toISOString`/`getTime` invariant (discriminates on any non-UTC machine; the bug is inherently invisible on UTC). Zero-impact east of UTC (no regression for Almaty UTC+5).

### #3629 (F10) — badge/tags showed raw IRI/UUID instead of label
Two-part, mirroring the #3141 class:
- **Renderer asymmetry:** `BadgeRenderer` + `TagsRenderer` now accept + use `getAssetLabel` to resolve alias-less `[[uid]]` wikilinks (mirroring `LinkRenderer`). Explicit alias still wins; null-resolve falls back to the target.
- **Pipeline emits bare IRI:** `LayoutService.convertRdfToCellValue` now converts a bare `IRI` binding to a resolvable `[[basename]]` wikilink for `link`/`badge`/`tags` columns (filename IRI `obsidian://vault/.../<uid>.md` → `[[<uid>]]`; symbolic IRI `…#<Local>` → `[[<Local>]]`), so the renderer can resolve a human label instead of showing the raw IRI.

### #3628 (F9) — action buttons failed silently
`ActionsRenderer` now surfaces a **user-facing error** (`onError` → `notifier.error`) when a command has no grounding, no executor is wired, or execution throws — **no more silent no-op** (the primary pain). Routed through the central notifier (eslint forbids `new Notice` elsewhere).

**Deferred (genuinely out of scope), tracked in #3654:** precondition ASK gating and raw-`groundingSparql` UPDATE execution. Verify-before-assert: exo-layout actions carry **raw SPARQL** (`exo__Precondition_sparql` ASK + `exo__Grounding_sparql` UPDATE), not structural exocmd commands — there is **no SPARQL-UPDATE engine** in the plugin, and `SPARQLQueryService.query()` executes an ASK but **discards the boolean** (`return []`), so precondition gating needs a new `ask()` exposure outside the renderer/processor scope. This PR fixes the silent-fail symptom; #3654 tracks wiring execution + gating.

### Tests
- `DateTimeRenderer.test.tsx` — date-only local-midnight invariant (+ no-regression for full ISO / `Z`).
- `LayoutService.test.ts` — date-only datetime, IRI→wikilink (badge/tags/symbolic).
- `BadgeRenderer.test.tsx` / `TagsRenderer.test.tsx` — `getAssetLabel` resolution (+ alias precedence, null fallback, multi-tag).
- `ActionsRenderer.test.tsx` — error surfacing (no executor / no grounding / throw / success-no-error).

All 182 affected tests green; `check:types` + `lint` clean; archgate 22/22.

Closes #3630, #3629. Closes #3628 (silent-fail fixed; execution+gating → #3654).
