### PR TITLE
feat(create-instance): SHACL-driven required-property form fields (T3)

### DIFF
--- a/packages/exocortex/src/index.ts
+++ b/packages/exocortex/src/index.ts
@@ -121,6 +121,12 @@ export {
   type CommandPromptAdapter,
   type IFileOpener,
 } from "./services/CommandExecutionFlow";
+export {
+  createTripleStoreRequiredPropertyResolver,
+  type RequiredPropertyResolver,
+  type RequiredPropertyField,
+  type RequiredPropertyFieldType,
+} from "./services/RequiredPropertyResolver";
 export { TaskStatusService } from "./services/TaskStatusService";
 export { AreaCreationService } from "./services/AreaCreationService";
 export {

--- a/packages/exocortex/src/services/CommandExecutionFlow.ts
+++ b/packages/exocortex/src/services/CommandExecutionFlow.ts
@@ -6,6 +6,7 @@ import type { ILogger } from "../interfaces/ILogger";
 import type { ITripleStore } from "../interfaces/ITripleStore";
 import type { GroundingDefinition } from "../domain/models/CommandDefinition";
 import { GroundingType } from "../domain/constants/GroundingType";
+import type { RequiredPropertyResolver } from "./RequiredPropertyResolver";
 import { IRI } from "../domain/models/rdf/IRI";
 import { Literal } from "../domain/models/rdf/Literal";
 import { Namespace } from "../domain/models/rdf/Namespace";
@@ -95,6 +96,10 @@ export class CommandExecutionFlow {
     private readonly prompts: CommandPromptAdapter,
     private readonly tripleStore?: ITripleStore,
     private readonly fileOpener?: IFileOpener,
+    // T3 «Create Instance» (project bbe40f8c) — resolves a host class's SHACL
+    // required (`minCount > 0`) properties so the create-instance form prompts
+    // for them. Optional: absent → no augmentation (back-compat).
+    private readonly requiredPropertyResolver?: RequiredPropertyResolver,
   ) {}
 
   async run(
@@ -111,10 +116,15 @@ export class CommandExecutionFlow {
     let userInput: UserInput | undefined = ctx.injectedUserInput;
     const inputSchema = CommandExecutionFlow.extractInputSchema(rc);
     if (inputSchema !== null && inputSchema.length > 0) {
-      const effectiveSchema = await this.applyLabelDatePrefill(
+      let effectiveSchema = await this.applyLabelDatePrefill(
         inputSchema,
         command.grounding,
         ctx.targetIRI,
+      );
+      effectiveSchema = await this.applyRequiredPropertyFields(
+        effectiveSchema,
+        command.grounding,
+        ctx,
       );
       const collected = await this.prompts.promptInputSchema(effectiveSchema);
       if (collected === null) return;
@@ -237,6 +247,106 @@ export class CommandExecutionFlow {
       if (typeof existing === "string" && existing.length > 0) return field;
       return { ...f, defaultValue: prefill };
     });
+  }
+
+  /**
+   * T3 «Create Instance» (project bbe40f8c) — append the host class's SHACL
+   * required (`exo__Property_minCount > 0`) properties as form fields, so the
+   * create-instance form prompts for them and the new asset is SHACL-valid.
+   *
+   * Active ONLY for the host-as-class «Create Instance» flagship — a
+   * `create_instance` grounding with **no** `targetClass` (verified the only
+   * such grounding; every other create command bakes a `targetClass`). The new
+   * instance's class IS the host class (`$targetClassSelf`), so its required
+   * properties come from the host class def. No-op (schema unchanged) when:
+   *   - the grounding isn't that flagship,
+   *   - no resolver is wired (CLI/test harness without a vault store),
+   *   - no `filePath` (global palette surface with no active file),
+   *   - the resolver throws, or the class has no required properties (common).
+   *
+   * Fields already covered — by the static schema (e.g. `label`,
+   * `exo__Asset_isDefinedBy`) or by the Universal Default Template
+   * ({@link ALWAYS_COVERED}: uid/createdAt/updatedAt/label/createdBy/
+   * instance_class/isDefinedBy) — are skipped, so the form never double-asks.
+   */
+  async applyRequiredPropertyFields(
+    schema: ReadonlyArray<unknown>,
+    grounding: GroundingDefinition,
+    ctx: CommandExecutionContext,
+  ): Promise<ReadonlyArray<unknown>> {
+    if (grounding.type !== GroundingType.CREATE_INSTANCE) return schema;
+    if (grounding.targetClass) return schema;
+    if (!this.requiredPropertyResolver) return schema;
+    if (!ctx.filePath) return schema;
+
+    const hostClassUid = CommandExecutionFlow.basenameUid(ctx.filePath);
+    if (!hostClassUid) return schema;
+
+    let required;
+    try {
+      required = await this.requiredPropertyResolver(hostClassUid);
+    } catch (error) {
+      this.logger.info(
+        `[CommandExecutionFlow] required-property resolution failed for "${hostClassUid}": ${error instanceof Error ? error.message : String(error)}`,
+      );
+      return schema;
+    }
+    if (required.length === 0) return schema;
+
+    const covered = new Set<string>(CommandExecutionFlow.ALWAYS_COVERED);
+    for (const field of schema) {
+      if (
+        field &&
+        typeof field === "object" &&
+        typeof (field as Record<string, unknown>).name === "string"
+      ) {
+        covered.add((field as Record<string, unknown>).name as string);
+      }
+    }
+
+    const additions = required
+      .filter((f) => !covered.has(f.propertyKey))
+      .map((f) => {
+        const field: Record<string, unknown> = {
+          name: f.propertyKey,
+          type: f.fieldType,
+          label: f.label,
+          required: true,
+        };
+        if (f.targetClassUid) field.targetClassUid = f.targetClassUid;
+        // A boolean is always "filled" — default to false so it submits valid.
+        if (f.fieldType === "boolean") field.defaultValue = "false";
+        return field;
+      });
+
+    if (additions.length === 0) return schema;
+    return [...schema, ...additions];
+  }
+
+  /** Frontmatter keys always supplied by the Universal Default Template. */
+  private static readonly ALWAYS_COVERED: ReadonlyArray<string> = [
+    "exo__Asset_uid",
+    "exo__Asset_createdAt",
+    "exo__Asset_updatedAt",
+    "exo__Asset_label",
+    "exo__Asset_createdBy",
+    "exo__Instance_class",
+    "exo__Asset_isDefinedBy",
+  ];
+
+  /** Vault-relative file path → its basename UID (UID-canon), or null. */
+  private static basenameUid(filePath: string): string | null {
+    const base = filePath
+      .replace(/^\/+/, "")
+      .split("/")
+      .pop()
+      ?.replace(/\.md$/i, "");
+    if (!base) return null;
+    return /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(
+      base,
+    )
+      ? base.toLowerCase()
+      : null;
   }
 
   /**

--- a/packages/exocortex/src/services/RequiredPropertyResolver.ts
+++ b/packages/exocortex/src/services/RequiredPropertyResolver.ts
@@ -1,0 +1,230 @@
+import type { ITripleStore } from "../interfaces/ITripleStore";
+import { IRI } from "../domain/models/rdf/IRI";
+import { Literal } from "../domain/models/rdf/Literal";
+import { Namespace } from "../domain/models/rdf/Namespace";
+
+/**
+ * T3 «Create Instance» (project bbe40f8c) — SHACL-shape-driven resolution of a
+ * class's **required** properties, so the create-instance form can prompt for
+ * them and produce a SHACL-valid instance.
+ *
+ * "Required" follows the SHACL-lite engine exactly (see {@link ShaclLiteValidator}):
+ * a property is required iff it declares `exo__Property_minCount > 0` and its
+ * `exo__Property_domain` is the class — or an ancestor of it via transitive
+ * `exo__Class_superClass` (subclass closure). These are precisely the properties
+ * whose absence yields a `sh:minCount` violation.
+ *
+ * Resolution runs entirely over the {@link ITripleStore} (available on desktop,
+ * mobile, and CLI), keyed by **bare UID** so it is robust to the dual file-IRI
+ * forms NoteToRDFConverter can emit (full-path `obsidian://vault/dir/<uid>.md`
+ * vs synthesized `obsidian://vault/<uid>.md`). No canonical-IRI machinery.
+ */
+
+const XSD_NS = "http://www.w3.org/2001/XMLSchema#";
+
+export type RequiredPropertyFieldType =
+  | "text"
+  | "date"
+  | "number"
+  | "boolean"
+  | "assetRef";
+
+export interface RequiredPropertyField {
+  /** Frontmatter key written to the new instance, e.g. `exo__Setting_value`. */
+  readonly propertyKey: string;
+  /** Human label for the form field (defaults to the property key). */
+  readonly label: string;
+  /** Field renderer the form should use, derived from the property range. */
+  readonly fieldType: RequiredPropertyFieldType;
+  /**
+   * For object ranges (`fieldType === "assetRef"`) — the UID of the range class
+   * whose instances populate the reusable reference-picker. Absent for datatype
+   * ranges or when the range class UID is unresolvable.
+   */
+  readonly targetClassUid?: string;
+}
+
+/**
+ * Resolve the SHACL-required properties of `hostClassUid`. Returns `[]` when the
+ * class has no required (`minCount > 0`) properties — the common case, so the
+ * create-instance form is unchanged for classes that don't need them.
+ */
+export type RequiredPropertyResolver = (
+  hostClassUid: string,
+) => Promise<RequiredPropertyField[]>;
+
+/** `obsidian://vault/[<dirs>/]<uuid>.md` → captures the bare UUID. */
+const FILE_IRI_UID_RE =
+  /\/([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\.md$/i;
+const BARE_UID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/** Extract a lowercase bare UID from a file IRI or a bare-UID string, or null. */
+function uidFrom(value: string): string | null {
+  const m = FILE_IRI_UID_RE.exec(value);
+  if (m) return m[1].toLowerCase();
+  if (BARE_UID_RE.test(value.trim())) return value.trim().toLowerCase();
+  return null;
+}
+
+/** Map an `exo__Property_range` value to a form field type (+ picker class). */
+function fieldTypeFromRange(
+  rangeValues: ReadonlyArray<{ iri: boolean; value: string }>,
+): {
+  fieldType: RequiredPropertyFieldType;
+  targetClassUid?: string;
+} {
+  for (const r of rangeValues) {
+    const value = r.value;
+    if (value.startsWith(XSD_NS)) {
+      const local = value.slice(XSD_NS.length).toLowerCase();
+      if (local === "date" || local === "datetime")
+        return { fieldType: "date" };
+      if (local === "boolean") return { fieldType: "boolean" };
+      if (
+        [
+          "integer",
+          "int",
+          "long",
+          "short",
+          "decimal",
+          "float",
+          "double",
+          "nonnegativeinteger",
+          "positiveinteger",
+        ].includes(local)
+      ) {
+        return { fieldType: "number" };
+      }
+      return { fieldType: "text" };
+    }
+    // Non-xsd IRI range → an object (class) property → reference-picker.
+    if (r.iri) {
+      const uid = uidFrom(value);
+      return uid
+        ? { fieldType: "assetRef", targetClassUid: uid }
+        : { fieldType: "assetRef" };
+    }
+  }
+  return { fieldType: "text" };
+}
+
+/**
+ * Build a {@link RequiredPropertyResolver} backed by an {@link ITripleStore}.
+ * Used by the plugin's create-instance form (desktop + mobile) — both share the
+ * same in-memory store, so this is a single implementation, not per-surface
+ * (avoids the parser-drift class of bug).
+ */
+export function createTripleStoreRequiredPropertyResolver(
+  store: ITripleStore,
+): RequiredPropertyResolver {
+  const EXO = Namespace.EXO;
+  const RDFS = Namespace.RDFS;
+
+  return async (hostClassUid: string): Promise<RequiredPropertyField[]> => {
+    const host = uidFrom(hostClassUid) ?? hostClassUid.trim().toLowerCase();
+    if (!host) return [];
+
+    // 1. host + transitive ancestors via exo:Class_superClass (cycle-safe).
+    const superEdges = await store.match(
+      undefined,
+      EXO.term("Class_superClass"),
+      undefined,
+    );
+    const childToParents = new Map<string, Set<string>>();
+    for (const t of superEdges) {
+      const child = t.subject instanceof IRI ? uidFrom(t.subject.value) : null;
+      const parent = t.object instanceof IRI ? uidFrom(t.object.value) : null;
+      if (!child || !parent) continue;
+      let set = childToParents.get(child);
+      if (!set) {
+        set = new Set<string>();
+        childToParents.set(child, set);
+      }
+      set.add(parent);
+    }
+    const classUids = new Set<string>([host]);
+    const queue: string[] = [host];
+    while (queue.length > 0) {
+      const cur = queue.shift();
+      if (cur === undefined) break;
+      for (const parent of childToParents.get(cur) ?? []) {
+        if (!classUids.has(parent)) {
+          classUids.add(parent);
+          queue.push(parent);
+        }
+      }
+    }
+
+    // 2. required (minCount > 0) properties whose domain ∈ {host + ancestors}.
+    const minCountTriples = await store.match(
+      undefined,
+      EXO.term("Property_minCount"),
+      undefined,
+    );
+    const fields: RequiredPropertyField[] = [];
+    const seen = new Set<string>();
+
+    for (const t of minCountTriples) {
+      const mc =
+        t.object instanceof Literal ? parseInt(t.object.value, 10) : NaN;
+      if (!(mc > 0)) continue;
+      const prop = t.subject;
+      if (!(prop instanceof IRI)) continue;
+
+      const domainTriples = await store.match(
+        prop,
+        EXO.term("Property_domain"),
+        undefined,
+      );
+      const domainUids = domainTriples
+        .map((d) => (d.object instanceof IRI ? uidFrom(d.object.value) : null))
+        .filter((u): u is string => u !== null);
+      if (!domainUids.some((u) => classUids.has(u))) continue;
+
+      // The property's label IS its frontmatter key (e.g. "exo__Setting_value").
+      let propertyKey: string | null = null;
+      for (const pred of [EXO.term("Asset_label"), RDFS.term("label")]) {
+        const labelTriples = await store.match(prop, pred, undefined);
+        for (const lt of labelTriples) {
+          if (
+            lt.object instanceof Literal &&
+            lt.object.value.trim().length > 0
+          ) {
+            propertyKey = lt.object.value.trim();
+            break;
+          }
+        }
+        if (propertyKey) break;
+      }
+      if (!propertyKey || seen.has(propertyKey)) continue;
+      seen.add(propertyKey);
+
+      const rangeTriples = await store.match(
+        prop,
+        EXO.term("Property_range"),
+        undefined,
+      );
+      const rangeValues = rangeTriples
+        .map((rt) =>
+          rt.object instanceof IRI
+            ? { iri: true, value: rt.object.value }
+            : rt.object instanceof Literal
+              ? { iri: false, value: rt.object.value }
+              : null,
+        )
+        .filter((v): v is { iri: boolean; value: string } => v !== null);
+
+      const { fieldType, targetClassUid } = fieldTypeFromRange(rangeValues);
+      fields.push({
+        propertyKey,
+        label: propertyKey,
+        fieldType,
+        targetClassUid,
+      });
+    }
+
+    fields.sort((a, b) => a.propertyKey.localeCompare(b.propertyKey));
+    return fields;
+  };
+}

--- a/packages/exocortex/tests/services/CommandExecutionFlow.test.ts
+++ b/packages/exocortex/tests/services/CommandExecutionFlow.test.ts
@@ -56,6 +56,16 @@ function makeFlow(overrides?: {
   promptResult?: UserInput | null;
   tripleStore?: InMemoryTripleStore;
   fileOpener?: IFileOpener;
+  requiredPropertyResolver?: (
+    hostClassUid: string,
+  ) => Promise<
+    Array<{
+      propertyKey: string;
+      label: string;
+      fieldType: "text" | "date" | "number" | "boolean" | "assetRef";
+      targetClassUid?: string;
+    }>
+  >;
 }) {
   const groundingExecutor = {
     execute: jest
@@ -95,6 +105,7 @@ function makeFlow(overrides?: {
     prompts,
     tripleStore,
     fileOpener,
+    overrides?.requiredPropertyResolver,
   );
 
   return {
@@ -697,6 +708,170 @@ describe("CommandExecutionFlow", () => {
       );
       // Success path side-effects should still have fired (no error toast).
       expect(notificationService.error).not.toHaveBeenCalled();
+    });
+  });
+
+  // T3 «Create Instance» (project bbe40f8c) — SHACL required-property field
+  // augmentation. Active ONLY for the host-as-class flagship (create_instance
+  // with no targetClass).
+  describe("required-property field augmentation (T3)", () => {
+    const HOST_UID = "88b938af-1a55-451c-b3cc-2f03e5115fcf";
+    const HOST_PATH = `assetspaces/x/${HOST_UID}.md`;
+
+    // The host-as-class flagship grounding: create_instance, NO targetClass,
+    // with the static label + ontology inputSchema.
+    function flagshipRC() {
+      return makeRC(
+        {},
+        {
+          type: GroundingType.CREATE_INSTANCE,
+          targetClass: undefined,
+          inputSchema: [
+            { name: "label", type: "text" },
+            { name: "exo__Asset_isDefinedBy", type: "assetRef" },
+          ],
+        },
+      );
+    }
+
+    async function schemaPassedToPrompt(
+      overrides: Parameters<typeof makeFlow>[0],
+      ctxOverrides?: { filePath?: string | null; rc?: ReturnType<typeof makeRC> },
+    ) {
+      const { flow, prompts } = makeFlow({
+        promptResult: { label: "x" },
+        ...overrides,
+      });
+      const rc = ctxOverrides?.rc ?? flagshipRC();
+      await flow.run(rc, {
+        targetIRI: `obsidian://vault/${HOST_PATH}`,
+        filePath:
+          ctxOverrides && "filePath" in ctxOverrides
+            ? ctxOverrides.filePath ?? null
+            : HOST_PATH,
+      });
+      const calls = prompts.promptInputSchema.mock.calls;
+      return calls.length > 0
+        ? (calls[0][0] as Array<Record<string, unknown>>)
+        : null;
+    }
+
+    it("appends the host class's required properties to the form schema", async () => {
+      const schema = await schemaPassedToPrompt({
+        requiredPropertyResolver: async () => [
+          { propertyKey: "exo__Setting_value", label: "exo__Setting_value", fieldType: "text" },
+          {
+            propertyKey: "exo__Setting_key",
+            label: "exo__Setting_key",
+            fieldType: "assetRef",
+            targetClassUid: "a37d39ec-413d-4d9c-8cf2-da9b6025b00c",
+          },
+        ],
+      });
+      const names = schema!.map((f) => f.name);
+      expect(names).toEqual([
+        "label",
+        "exo__Asset_isDefinedBy",
+        "exo__Setting_value",
+        "exo__Setting_key",
+      ]);
+      const keyField = schema!.find((f) => f.name === "exo__Setting_key")!;
+      expect(keyField).toMatchObject({
+        type: "assetRef",
+        required: true,
+        targetClassUid: "a37d39ec-413d-4d9c-8cf2-da9b6025b00c",
+      });
+    });
+
+    it("gives boolean fields a defaultValue of 'false' (always submit-valid)", async () => {
+      const schema = await schemaPassedToPrompt({
+        requiredPropertyResolver: async () => [
+          { propertyKey: "ex__C_flag", label: "ex__C_flag", fieldType: "boolean" },
+        ],
+      });
+      const flagField = schema!.find((f) => f.name === "ex__C_flag")!;
+      expect(flagField).toMatchObject({
+        type: "boolean",
+        required: true,
+        defaultValue: "false",
+      });
+    });
+
+    it("skips properties already covered by the Universal Default Template", async () => {
+      const schema = await schemaPassedToPrompt({
+        requiredPropertyResolver: async () => [
+          { propertyKey: "exo__Instance_class", label: "x", fieldType: "text" },
+          { propertyKey: "exo__Asset_label", label: "x", fieldType: "text" },
+          { propertyKey: "exo__Setting_value", label: "x", fieldType: "text" },
+        ],
+      });
+      const names = schema!.map((f) => f.name);
+      expect(names).not.toContain("exo__Instance_class");
+      expect(names).not.toContain("exo__Asset_label");
+      expect(names).toContain("exo__Setting_value");
+    });
+
+    it("skips properties already present as a static schema field", async () => {
+      const schema = await schemaPassedToPrompt({
+        requiredPropertyResolver: async () => [
+          { propertyKey: "exo__Asset_isDefinedBy", label: "x", fieldType: "assetRef" },
+          { propertyKey: "exo__Setting_value", label: "x", fieldType: "text" },
+        ],
+      });
+      // exo__Asset_isDefinedBy already in the static schema → not duplicated.
+      const occurrences = schema!.filter(
+        (f) => f.name === "exo__Asset_isDefinedBy",
+      ).length;
+      expect(occurrences).toBe(1);
+    });
+
+    it("is a no-op when the grounding bakes a targetClass (not the flagship)", async () => {
+      const rc = makeRC(
+        {},
+        {
+          type: GroundingType.CREATE_INSTANCE,
+          targetClass: "[[ems__Task]]",
+          inputSchema: [{ name: "label", type: "text" }],
+        },
+      );
+      const resolver = jest.fn(async () => [
+        { propertyKey: "exo__Setting_value", label: "x", fieldType: "text" as const },
+      ]);
+      const schema = await schemaPassedToPrompt(
+        { requiredPropertyResolver: resolver },
+        { rc },
+      );
+      expect(resolver).not.toHaveBeenCalled();
+      expect(schema!.map((f) => f.name)).toEqual(["label"]);
+    });
+
+    it("is a no-op when no resolver is wired", async () => {
+      const schema = await schemaPassedToPrompt({});
+      expect(schema!.map((f) => f.name)).toEqual([
+        "label",
+        "exo__Asset_isDefinedBy",
+      ]);
+    });
+
+    it("is a no-op when there is no filePath (global palette surface)", async () => {
+      const resolver = jest.fn(async () => [
+        { propertyKey: "exo__Setting_value", label: "x", fieldType: "text" as const },
+      ]);
+      const schema = await schemaPassedToPrompt(
+        { requiredPropertyResolver: resolver },
+        { filePath: null },
+      );
+      expect(resolver).not.toHaveBeenCalled();
+      expect(schema!.map((f) => f.name)).toEqual([
+        "label",
+        "exo__Asset_isDefinedBy",
+      ]);
+    });
+
+    it("resolves the host class UID from the file basename", async () => {
+      const resolver = jest.fn(async () => []);
+      await schemaPassedToPrompt({ requiredPropertyResolver: resolver });
+      expect(resolver).toHaveBeenCalledWith(HOST_UID);
     });
   });
 });

--- a/packages/exocortex/tests/unit/services/RequiredPropertyResolver.test.ts
+++ b/packages/exocortex/tests/unit/services/RequiredPropertyResolver.test.ts
@@ -1,0 +1,235 @@
+import { createTripleStoreRequiredPropertyResolver } from "../../../src/services/RequiredPropertyResolver";
+import { InMemoryTripleStore } from "../../../src/infrastructure/rdf/InMemoryTripleStore";
+import { IRI } from "../../../src/domain/models/rdf/IRI";
+import { Literal } from "../../../src/domain/models/rdf/Literal";
+import { Namespace } from "../../../src/domain/models/rdf/Namespace";
+import { Triple } from "../../../src/domain/models/rdf/Triple";
+
+/**
+ * T3 «Create Instance» (project bbe40f8c) — unit tests for the SHACL-shape-driven
+ * required-property resolver. Models the real `exo__Setting` scenario (a class
+ * that actually declares `exo__Property_minCount` required props) plus datatype
+ * range mapping and subclass closure.
+ */
+
+const EXO = Namespace.EXO;
+
+// Real-data-shaped UIDs.
+const SETTING = "88b938af-1a55-451c-b3cc-2f03e5115fcf";
+const SETTINGKEY = "a37d39ec-413d-4d9c-8cf2-da9b6025b00c";
+const OTHER_CLASS = "11111111-2222-3333-4444-555555555555";
+const SETTING_SUBCLASS = "99999999-8888-7777-6666-555555555555";
+const XSD = "http://www.w3.org/2001/XMLSchema#";
+
+function fileIRI(uid: string): string {
+  return `obsidian://vault/assetspaces/x/${uid}.md`;
+}
+
+let propCounter = 0;
+function propUid(): string {
+  propCounter++;
+  const n = propCounter.toString(16).padStart(12, "0");
+  return `00000000-0000-0000-0000-${n}`;
+}
+
+interface PropDef {
+  key: string;
+  domainUid: string;
+  minCount?: number;
+  rangeIRI?: string; // IRI object (class file IRI or xsd IRI)
+  rangeLiteral?: string; // literal object (xsd datatype as literal)
+}
+
+async function seed(
+  props: PropDef[],
+  superEdges: Array<[string, string]> = [],
+): Promise<InMemoryTripleStore> {
+  const store = new InMemoryTripleStore();
+  const triples: Triple[] = [];
+  for (const p of props) {
+    const subj = new IRI(fileIRI(propUid()));
+    triples.push(new Triple(subj, EXO.term("Asset_label"), new Literal(p.key)));
+    triples.push(
+      new Triple(
+        subj,
+        EXO.term("Property_domain"),
+        new IRI(fileIRI(p.domainUid)),
+      ),
+    );
+    if (p.minCount !== undefined) {
+      triples.push(
+        new Triple(
+          subj,
+          EXO.term("Property_minCount"),
+          new Literal(String(p.minCount)),
+        ),
+      );
+    }
+    if (p.rangeIRI) {
+      triples.push(
+        new Triple(subj, EXO.term("Property_range"), new IRI(p.rangeIRI)),
+      );
+    }
+    if (p.rangeLiteral) {
+      triples.push(
+        new Triple(
+          subj,
+          EXO.term("Property_range"),
+          new Literal(p.rangeLiteral),
+        ),
+      );
+    }
+  }
+  for (const [child, parent] of superEdges) {
+    triples.push(
+      new Triple(
+        new IRI(fileIRI(child)),
+        EXO.term("Class_superClass"),
+        new IRI(fileIRI(parent)),
+      ),
+    );
+  }
+  await store.addAll(triples);
+  return store;
+}
+
+beforeEach(() => {
+  propCounter = 0;
+});
+
+describe("createTripleStoreRequiredPropertyResolver", () => {
+  it("resolves a class's required (minCount>0) properties, skipping non-required", async () => {
+    const store = await seed([
+      {
+        key: "exo__Setting_key",
+        domainUid: SETTING,
+        minCount: 1,
+        rangeIRI: fileIRI(SETTINGKEY),
+      },
+      { key: "exo__Setting_value", domainUid: SETTING, minCount: 1 },
+      // optional (no minCount) — must NOT appear
+      { key: "exo__Setting_note", domainUid: SETTING },
+    ]);
+    const resolve = createTripleStoreRequiredPropertyResolver(store);
+    const fields = await resolve(SETTING);
+    const keys = fields.map((f) => f.propertyKey);
+    expect(keys).toContain("exo__Setting_key");
+    expect(keys).toContain("exo__Setting_value");
+    expect(keys).not.toContain("exo__Setting_note");
+  });
+
+  it("maps an object (class) range to an assetRef field with the range class UID", async () => {
+    const store = await seed([
+      {
+        key: "exo__Setting_key",
+        domainUid: SETTING,
+        minCount: 1,
+        rangeIRI: fileIRI(SETTINGKEY),
+      },
+    ]);
+    const fields =
+      await createTripleStoreRequiredPropertyResolver(store)(SETTING);
+    expect(fields[0]).toMatchObject({
+      propertyKey: "exo__Setting_key",
+      fieldType: "assetRef",
+      targetClassUid: SETTINGKEY,
+    });
+  });
+
+  it("maps datatype ranges to date / number / boolean / text", async () => {
+    const store = await seed([
+      {
+        key: "ex__C_when",
+        domainUid: SETTING,
+        minCount: 1,
+        rangeIRI: `${XSD}date`,
+      },
+      {
+        key: "ex__C_count",
+        domainUid: SETTING,
+        minCount: 1,
+        rangeIRI: `${XSD}integer`,
+      },
+      {
+        key: "ex__C_flag",
+        domainUid: SETTING,
+        minCount: 1,
+        rangeLiteral: `${XSD}boolean`,
+      },
+      {
+        key: "ex__C_text",
+        domainUid: SETTING,
+        minCount: 1,
+        rangeIRI: `${XSD}string`,
+      },
+      { key: "ex__C_norange", domainUid: SETTING, minCount: 1 },
+    ]);
+    const fields =
+      await createTripleStoreRequiredPropertyResolver(store)(SETTING);
+    const byKey = Object.fromEntries(
+      fields.map((f) => [f.propertyKey, f.fieldType]),
+    );
+    expect(byKey["ex__C_when"]).toBe("date");
+    expect(byKey["ex__C_count"]).toBe("number");
+    expect(byKey["ex__C_flag"]).toBe("boolean");
+    expect(byKey["ex__C_text"]).toBe("text");
+    expect(byKey["ex__C_norange"]).toBe("text");
+  });
+
+  it("does NOT return required properties of a different class", async () => {
+    const store = await seed([
+      { key: "exo__Setting_value", domainUid: SETTING, minCount: 1 },
+      { key: "other__Thing_name", domainUid: OTHER_CLASS, minCount: 1 },
+    ]);
+    const fields =
+      await createTripleStoreRequiredPropertyResolver(store)(SETTING);
+    expect(fields.map((f) => f.propertyKey)).toEqual(["exo__Setting_value"]);
+  });
+
+  it("includes inherited required properties via transitive subclass closure", async () => {
+    const store = await seed(
+      [
+        { key: "exo__Setting_value", domainUid: SETTING, minCount: 1 },
+        { key: "sub__X_extra", domainUid: SETTING_SUBCLASS, minCount: 1 },
+      ],
+      [[SETTING_SUBCLASS, SETTING]],
+    );
+    const fields =
+      await createTripleStoreRequiredPropertyResolver(store)(SETTING_SUBCLASS);
+    const keys = fields.map((f) => f.propertyKey).sort();
+    expect(keys).toEqual(["exo__Setting_value", "sub__X_extra"]);
+  });
+
+  it("returns [] for a class with no required properties (no-op for the common case)", async () => {
+    const store = await seed([
+      { key: "exo__Setting_note", domainUid: SETTING },
+    ]);
+    const fields =
+      await createTripleStoreRequiredPropertyResolver(store)(SETTING);
+    expect(fields).toEqual([]);
+  });
+
+  it("matches the host even when its domain arrived as a synthesized bare-uid file IRI", async () => {
+    // NoteToRDFConverter can emit a domain wikilink as obsidian://vault/<uid>.md
+    // (no dir) for cross-vault deps. Both forms must match by bare UID.
+    const store = new InMemoryTripleStore();
+    const subj = new IRI(`obsidian://vault/assetspaces/x/${propUid()}.md`);
+    await store.addAll([
+      new Triple(
+        subj,
+        EXO.term("Asset_label"),
+        new Literal("exo__Setting_value"),
+      ),
+      new Triple(subj, EXO.term("Property_minCount"), new Literal("1")),
+      // synthesized bare-uid file IRI for the domain
+      new Triple(
+        subj,
+        EXO.term("Property_domain"),
+        new IRI(`obsidian://vault/${SETTING}.md`),
+      ),
+    ]);
+    const fields =
+      await createTripleStoreRequiredPropertyResolver(store)(SETTING);
+    expect(fields.map((f) => f.propertyKey)).toEqual(["exo__Setting_value"]);
+  });
+});

--- a/packages/obsidian-plugin/src/ExocortexPlugin.ts
+++ b/packages/obsidian-plugin/src/ExocortexPlugin.ts
@@ -198,6 +198,7 @@ import {
 } from "./infrastructure/adapters/SyncDepsFactory";
 import {
   CommandExecutionFlow,
+  createTripleStoreRequiredPropertyResolver,
   DI_TOKENS,
   type IVaultSettings,
 } from "exocortex";
@@ -1020,6 +1021,11 @@ export default class ExocortexPlugin extends Plugin {
             new ObsidianCommandPromptAdapter(this.app),
             tripleStore,
             new ObsidianFileOpener(this.app),
+            // T3 «Create Instance» — required-property form augmentation for the
+            // palette surface too (Cmd+P on a class-def page).
+            tripleStore
+              ? createTripleStoreRequiredPropertyResolver(tripleStore)
+              : undefined,
           );
           await new ExocmdCommandPaletteRegistrar(
             this,

--- a/packages/obsidian-plugin/src/presentation/builders/ButtonGroupsBuilder.ts
+++ b/packages/obsidian-plugin/src/presentation/builders/ButtonGroupsBuilder.ts
@@ -13,6 +13,7 @@ import {
   INotificationService,
   CommandExecutionFlow,
   ITripleStore,
+  createTripleStoreRequiredPropertyResolver,
 } from "exocortex";
 import {
   ButtonBuilderContext,
@@ -120,6 +121,12 @@ export class ButtonGroupsBuilder {
         new ObsidianCommandPromptAdapter(app),
         tripleStore,
         new ObsidianFileOpener(app),
+        // T3 «Create Instance» — augment the create-instance form with the host
+        // class's SHACL required properties (over the same in-memory store; works
+        // on desktop and mobile, no Platform.isMobile gating).
+        tripleStore
+          ? createTripleStoreRequiredPropertyResolver(tripleStore)
+          : undefined,
       );
       this.builders.push(
         new DynamicCommandButtonGroupBuilder({

--- a/packages/obsidian-plugin/src/presentation/builders/button-groups/DynamicCommandButtonGroupBuilder.ts
+++ b/packages/obsidian-plugin/src/presentation/builders/button-groups/DynamicCommandButtonGroupBuilder.ts
@@ -72,7 +72,17 @@ export interface EnumOption {
  */
 export interface InputSchemaField {
   readonly name: string;
-  readonly type: "text" | "date" | "enum" | "multiline" | "assetRef";
+  // T3 «Create Instance» (project bbe40f8c) — `number` / `boolean` added so the
+  // required-property resolver can map xsd:integer/decimal/… → number and
+  // xsd:boolean → boolean from a property's range.
+  readonly type:
+    | "text"
+    | "date"
+    | "number"
+    | "boolean"
+    | "enum"
+    | "multiline"
+    | "assetRef";
   readonly label?: string;
   readonly required?: boolean;
   readonly defaultValue?: string;

--- a/packages/obsidian-plugin/src/presentation/components/dynamic-form/DynamicForm.tsx
+++ b/packages/obsidian-plugin/src/presentation/components/dynamic-form/DynamicForm.tsx
@@ -138,6 +138,31 @@ function renderField(
         />
       );
 
+    case "number":
+      return (
+        <input
+          type="number"
+          className="dynamic-form-input"
+          value={value}
+          onChange={(e) => onChange(field.name, e.target.value)}
+          data-testid={`field-${field.name}`}
+        />
+      );
+
+    case "boolean":
+      // Committed as the string "true"/"false" so it serialises to a YAML
+      // boolean in frontmatter. A checkbox is always "filled" (default false),
+      // so a required boolean never blocks submit.
+      return (
+        <input
+          type="checkbox"
+          className="dynamic-form-checkbox"
+          checked={value === "true"}
+          onChange={(e) => onChange(field.name, e.target.checked ? "true" : "false")}
+          data-testid={`field-${field.name}`}
+        />
+      );
+
     case "enum":
       return (
         <select

--- a/packages/obsidian-plugin/tests/unit/presentation/builders/InputSchemaField.test.ts
+++ b/packages/obsidian-plugin/tests/unit/presentation/builders/InputSchemaField.test.ts
@@ -15,6 +15,17 @@ describe("InputSchemaField type definitions", () => {
       expect(field.type).toBe("date");
     });
 
+    // T3 «Create Instance» — number/boolean for required-property datatype ranges.
+    it("should accept number type", () => {
+      const field: InputSchemaField = { name: "count", type: "number" };
+      expect(field.type).toBe("number");
+    });
+
+    it("should accept boolean type", () => {
+      const field: InputSchemaField = { name: "flag", type: "boolean" };
+      expect(field.type).toBe("boolean");
+    });
+
     it("should accept enum type", () => {
       const field: InputSchemaField = { name: "status", type: "enum" };
       expect(field.type).toBe("enum");

--- a/packages/obsidian-plugin/tests/unit/presentation/components/DynamicForm.test.tsx
+++ b/packages/obsidian-plugin/tests/unit/presentation/components/DynamicForm.test.tsx
@@ -63,6 +63,55 @@ describe("DynamicForm", () => {
     });
   });
 
+  // T3 «Create Instance» — number/boolean field types for required-property
+  // datatype ranges (xsd:integer/decimal/… → number, xsd:boolean → boolean).
+  describe("number field (T3)", () => {
+    it("should render a number input", () => {
+      renderForm([{ name: "count", type: "number", label: "Count" }]);
+      const input = screen.getByTestId("field-count");
+      expect(input.tagName).toBe("INPUT");
+      expect(input).toHaveAttribute("type", "number");
+    });
+
+    it("should forward typed numeric value", () => {
+      const { onSubmit } = renderForm([{ name: "count", type: "number" }]);
+      fireEvent.change(screen.getByTestId("field-count"), {
+        target: { value: "42" },
+      });
+      fireEvent.click(screen.getByText("OK"));
+      expect(onSubmit).toHaveBeenCalledWith({ count: "42" });
+    });
+  });
+
+  describe("boolean field (T3)", () => {
+    it("should render a checkbox", () => {
+      renderForm([{ name: "flag", type: "boolean", label: "Flag" }]);
+      const input = screen.getByTestId("field-flag");
+      expect(input.tagName).toBe("INPUT");
+      expect(input).toHaveAttribute("type", "checkbox");
+    });
+
+    it("commits 'true'/'false' string on toggle", () => {
+      const { onSubmit } = renderForm([
+        { name: "flag", type: "boolean", defaultValue: "false" },
+      ]);
+      const cb = screen.getByTestId("field-flag");
+      expect(cb).not.toBeChecked();
+      fireEvent.click(cb);
+      expect(cb).toBeChecked();
+      fireEvent.click(screen.getByText("OK"));
+      expect(onSubmit).toHaveBeenCalledWith({ flag: "true" });
+    });
+
+    it("a required boolean defaulting to 'false' submits without blocking", () => {
+      const { onSubmit } = renderForm([
+        { name: "flag", type: "boolean", required: true, defaultValue: "false" },
+      ]);
+      fireEvent.click(screen.getByText("OK"));
+      expect(onSubmit).toHaveBeenCalledWith({ flag: "false" });
+    });
+  });
+
   describe("enum field", () => {
     it("should render a select dropdown with string options", () => {
       renderForm([{


### PR DESCRIPTION
## What

T3 of the homoiconic «Create Instance» flagship (project `bbe40f8c`). The create-instance form now prompts for the host class's **SHACL-required** properties (`exo__Property_minCount > 0`), so creating an instance of a class that declares them (e.g. `exo__Setting` → required key + value) yields a SHACL-valid asset instead of a transient `sh:minCount` violation.

## Design (verify-before-assert)

- **"Required" = SHACL minCount**, matching `ShaclLiteValidator` exactly. Empirically only a handful of vault classes declare `minCount > 0` today (exo__Setting/SettingKey/AssetSpace), so for the vast majority of classes (ems__Task, …) the resolver returns `[]` → **the form is unchanged** (zero regression). The feature is general & future-proof: declare `minCount` in TBox → the form auto-prompts.
- **Activation signal:** the host-as-class flagship = a `create_instance` grounding with **no** `targetClass` — verified the *only* such grounding (every other create command bakes a `targetClass`). So augmentation is automatic yet precisely scoped; every other create command is untouched.
- **Parity:** resolver runs over the shared in-memory triple store → desktop **and** mobile (no `Platform.isMobile` gating; mobile-loadable build assert green). CLI uses `--input` (the shared `create_instance` write path) — unaffected.

## Changes

**Core**
- `RequiredPropertyResolver.ts` — `createTripleStoreRequiredPropertyResolver(store)`: required props of a class via `minCount`, matched by **bare UID** (robust to dual file-IRI forms) with transitive `exo__Class_superClass` subclass closure. Range → field type (object class → `assetRef` + `targetClassUid`; `xsd:date`→date, `xsd:integer/decimal/…`→number, `xsd:boolean`→boolean, else→text).
- `CommandExecutionFlow.applyRequiredPropertyFields` — appends those fields to the form; dedups against the static schema + Universal Default Template keys; no-op when not the flagship / no resolver / no filePath / class has no required props. Injectable (back-compat).

**Plugin**
- `number` / `boolean` field types in `InputSchemaField` + `DynamicForm` (number input; checkbox committing `"true"`/`"false"`, required boolean defaults to `false`).
- Resolver wired into the inline-button flow + palette flow.

## Tests (TDD, production-shape)

- `RequiredPropertyResolver` unit — class matrix (required/optional, object + 4 datatype range mappings, cross-class isolation, subclass closure, synthesized bare-uid domain).
- `CommandExecutionFlow` augmentation unit — append, dedup (covered + static), boolean default, all no-op gates. **Revert-verified**: the assertion tests FAIL when the append is neutered.
- `DynamicForm` number/boolean rendering + `InputSchemaField` type.

## Safety

- **No new RDF predicate** (reads existing minCount/domain/range/superClass) → light multi-parser footprint; `CommandResolver` passes field types through unchanged; `DynamicFormModal` branches on `assetRef` only.
- Build: mobile-loadable + console-channel asserts green; typecheck + lint clean.

Part of the T2–T5 «Create Instance» completion (T1 v16.102.0 #3611, T2 #3653).