### PR TITLE
feat(link-label): auto re-resolve labels on profile apply (Веха 2)

### DIFF
--- a/packages/obsidian-plugin/src/ExocortexPlugin.ts
+++ b/packages/obsidian-plugin/src/ExocortexPlugin.ts
@@ -2919,6 +2919,13 @@ export default class ExocortexPlugin extends Plugin {
     // `ems__Project` / `ems__MeetingPrototype` until a full plugin reload.
     // This mirrors the cold-start (`metadataCache.on("resolved")`) and
     // hot-reindex (`scheduleHotReindex`) paths, which already do this.
+    //
+    // Link-label Веха 2 (WBS f01836c1) — the hook ALSO re-resolves
+    // wikilink labels in the open editor views (`updateOptions()`), so a
+    // bare `[[uid]]` whose target lived in a previously-unmounted
+    // AssetSpace stops showing the raw `uid` automatically on apply — the
+    // same editor-view rebuild the manual «Refresh link labels» command
+    // (`LinkLabelRefreshService`) performs, now fired without a command.
     const rdfIndexer = new PluginRdfIndexerAdapter(
       this.sparql.getRdfIndexer(),
       createProfileApplyRefreshHook({
@@ -2930,6 +2937,7 @@ export default class ExocortexPlugin extends Plugin {
         invalidatePreconditionCache: () =>
           this.preconditionEvaluator.invalidateCache(),
         rerenderLayouts: () => this.autoRenderLayout(),
+        refreshEditorLabels: () => this.app.workspace.updateOptions(),
       }),
     );
 

--- a/packages/obsidian-plugin/src/ExocortexPlugin.ts
+++ b/packages/obsidian-plugin/src/ExocortexPlugin.ts
@@ -2938,6 +2938,9 @@ export default class ExocortexPlugin extends Plugin {
           this.preconditionEvaluator.invalidateCache(),
         rerenderLayouts: () => this.autoRenderLayout(),
         refreshEditorLabels: () => this.app.workspace.updateOptions(),
+        logger: {
+          warn: (message, ...args) => this.logger.warn(message, ...args),
+        },
       }),
     );
 

--- a/packages/obsidian-plugin/src/infrastructure/adapters/profileApplyRefreshHook.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/profileApplyRefreshHook.ts
@@ -76,6 +76,12 @@ export interface ProfileApplyRefreshDeps {
    * (Веха 2 auto re-resolve, WBS `f01836c1`).
    */
   refreshEditorLabels: () => void;
+  /**
+   * Optional logger for graceful per-step failure visibility. Mirrors
+   * `LinkLabelRefreshService` so an `refreshEditorLabels` failure on the
+   * auto path leaves the same breadcrumb the manual command would.
+   */
+  logger?: { warn?(message: string, ...args: unknown[]): void };
 }
 
 export function createProfileApplyRefreshHook(
@@ -107,9 +113,15 @@ export function createProfileApplyRefreshHook(
     // recreated decorations resolve against the up-to-date metadataCache.
     try {
       deps.refreshEditorLabels();
-    } catch {
+    } catch (err) {
       // Graceful by contract — unresolvable links simply stay as their raw
-      // `uid` (the WikilinkLabelViewPlugin already degrades that way).
+      // `uid` (the WikilinkLabelViewPlugin already degrades that way). Log
+      // a breadcrumb so a regression here is not invisible, mirroring the
+      // manual command's `LinkLabelRefreshService.rebuildEditorViews` path.
+      deps.logger?.warn?.(
+        "[ProfileApplyRefresh] refreshEditorLabels failed (continuing)",
+        err,
+      );
     }
   };
 }

--- a/packages/obsidian-plugin/src/infrastructure/adapters/profileApplyRefreshHook.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/profileApplyRefreshHook.ts
@@ -28,14 +28,32 @@
  *  3. **Re-render active layouts.** Even with clean caches the layout DOM
  *     is not refreshed by the store rebuild; `rerenderLayouts` makes the
  *     freshly-resolvable buttons appear without an Obsidian restart.
+ *  4. **Re-resolve wikilink labels in open editor views.** A bare
+ *     `[[uid]]` whose target lived in a previously-unmounted AssetSpace
+ *     renders as the raw `uid`; the open CodeMirror editor views hold a
+ *     stale `DecorationSet` and are NOT subscribed to `metadataCache`
+ *     events, so the label keeps showing `uid` until an Obsidian restart.
+ *     `refreshEditorLabels` reconfigures the open editor views
+ *     (`app.workspace.updateOptions()`), recreating the
+ *     `WikilinkLabelViewPlugin` instances → fresh `buildDecorations`
+ *     against the now-fresh `metadataCache`. This is the Веха 2 auto-hook
+ *     for the link-label MVP (`LinkLabelRefreshService`, WBS `f01836c1`):
+ *     what the manual «Exocortex: Refresh link labels» command does, now
+ *     fired automatically on every profile apply. The index is already
+ *     fresh here (the `rdfIndexer.refresh()` that triggered this hook ran
+ *     `convertVault()`), so — unlike the manual command — no extra
+ *     `ensureIndexFresh` / `rerenderLayouts` is needed; only the open
+ *     editor views still need the reconfigure.
  *
  * The cold-start + hot-reindex paths already perform (2)+(3); the
- * apply path previously did only (1), which is the D1 root cause.
+ * apply path previously did only (1), which is the D1 root cause. Step (4)
+ * closes the link-label gap so already-open notes re-resolve labels too.
  *
  * Returned as an `async () => Promise<void>` so it can be wired directly
  * as the `PluginRdfIndexerAdapter` `onAfterRefresh` hook. The materialize
  * re-injection is awaited (it is async + store-touching); the cache
- * invalidations + re-render are synchronous fire-after.
+ * invalidations + re-render + editor-label refresh are synchronous
+ * fire-after.
  */
 export interface ProfileApplyRefreshDeps {
   /** Re-inject `exo:AssetSpace_materialized` triples (async, store-touching). */
@@ -48,6 +66,16 @@ export interface ProfileApplyRefreshDeps {
   invalidatePreconditionCache: () => void;
   /** Re-render active layouts so refreshed button visibility shows. */
   rerenderLayouts: () => void;
+  /**
+   * Re-resolve wikilink display labels in open editor views — reconfigure
+   * the open Markdown views (`app.workspace.updateOptions()`) so the
+   * `WikilinkLabelViewPlugin` instances are recreated and re-run
+   * `buildDecorations` against the now-fresh `metadataCache`. Maps to the
+   * same editor-view rebuild the manual «Refresh link labels» command uses
+   * (`LinkLabelRefreshService.rebuildEditorViews`). Synchronous + isolated
+   * (Веха 2 auto re-resolve, WBS `f01836c1`).
+   */
+  refreshEditorLabels: () => void;
 }
 
 export function createProfileApplyRefreshHook(
@@ -69,5 +97,19 @@ export function createProfileApplyRefreshHook(
 
     // (3) Re-render so the now-resolvable buttons appear without a reload.
     deps.rerenderLayouts();
+
+    // (4) Re-resolve wikilink labels in the open editor views (Веха 2).
+    // Last + isolated: reconfiguring the editor views is best-effort UI
+    // polish, and its failure must not reject the post-refresh chain whose
+    // earlier duties (materialization re-injection, cache invalidation,
+    // layout render) have already succeeded. The index is already fresh
+    // (the refresh that triggered this hook ran convertVault), so the
+    // recreated decorations resolve against the up-to-date metadataCache.
+    try {
+      deps.refreshEditorLabels();
+    } catch {
+      // Graceful by contract — unresolvable links simply stay as their raw
+      // `uid` (the WikilinkLabelViewPlugin already degrades that way).
+    }
   };
 }

--- a/packages/obsidian-plugin/tests/unit/profileApplyRefreshHook.test.ts
+++ b/packages/obsidian-plugin/tests/unit/profileApplyRefreshHook.test.ts
@@ -65,18 +65,21 @@ describe("createProfileApplyRefreshHook", () => {
 
   it("stays graceful when refreshEditorLabels throws (best-effort UI polish)", async () => {
     const deps = makeDeps();
+    const warn = jest.fn();
     deps.refreshEditorLabels.mockImplementation(() => {
       throw new Error("updateOptions blew up");
     });
 
     // Must resolve, not reject — the earlier duties already succeeded.
     await expect(
-      createProfileApplyRefreshHook(deps)(),
+      createProfileApplyRefreshHook({ ...deps, logger: { warn } })(),
     ).resolves.toBeUndefined();
     // The earlier, more-important duties still ran.
     expect(deps.refreshAndInject).toHaveBeenCalledTimes(1);
     expect(deps.invalidateCommandResolverCache).toHaveBeenCalledTimes(1);
     expect(deps.rerenderLayouts).toHaveBeenCalledTimes(1);
+    // And the failure leaves a breadcrumb (not silently swallowed).
+    expect(warn).toHaveBeenCalledTimes(1);
   });
 
   it("re-injects BEFORE invalidating + re-rendering + label-refresh (store must be rebuilt first)", async () => {

--- a/packages/obsidian-plugin/tests/unit/profileApplyRefreshHook.test.ts
+++ b/packages/obsidian-plugin/tests/unit/profileApplyRefreshHook.test.ts
@@ -14,6 +14,11 @@ import { createProfileApplyRefreshHook } from "../../src/infrastructure/adapters
  * `invalidatePreconditionCache` / `clearLazyLoader` / `rerenderLayouts`
  * lines from `createProfileApplyRefreshHook` and the
  * "invalidates caches + re-renders" tests below FAIL; restore → PASS.
+ *
+ * Link-label Веха 2 (WBS f01836c1): the hook ALSO re-resolves wikilink
+ * labels in open editor views (`refreshEditorLabels`). Revert-verify:
+ * delete the `deps.refreshEditorLabels()` call from the hook and the
+ * "re-resolves wikilink labels" + order tests FAIL; restore → PASS.
  */
 describe("createProfileApplyRefreshHook", () => {
   function makeDeps() {
@@ -23,6 +28,7 @@ describe("createProfileApplyRefreshHook", () => {
       invalidateCommandResolverCache: jest.fn(),
       invalidatePreconditionCache: jest.fn(),
       rerenderLayouts: jest.fn(),
+      refreshEditorLabels: jest.fn(),
     };
   }
 
@@ -51,7 +57,29 @@ describe("createProfileApplyRefreshHook", () => {
     expect(deps.rerenderLayouts).toHaveBeenCalledTimes(1);
   });
 
-  it("re-injects BEFORE invalidating + re-rendering (store must be rebuilt first)", async () => {
+  it("re-resolves wikilink labels in open editor views after a mount-state rebuild (Веха 2)", async () => {
+    const deps = makeDeps();
+    await createProfileApplyRefreshHook(deps)();
+    expect(deps.refreshEditorLabels).toHaveBeenCalledTimes(1);
+  });
+
+  it("stays graceful when refreshEditorLabels throws (best-effort UI polish)", async () => {
+    const deps = makeDeps();
+    deps.refreshEditorLabels.mockImplementation(() => {
+      throw new Error("updateOptions blew up");
+    });
+
+    // Must resolve, not reject — the earlier duties already succeeded.
+    await expect(
+      createProfileApplyRefreshHook(deps)(),
+    ).resolves.toBeUndefined();
+    // The earlier, more-important duties still ran.
+    expect(deps.refreshAndInject).toHaveBeenCalledTimes(1);
+    expect(deps.invalidateCommandResolverCache).toHaveBeenCalledTimes(1);
+    expect(deps.rerenderLayouts).toHaveBeenCalledTimes(1);
+  });
+
+  it("re-injects BEFORE invalidating + re-rendering + label-refresh (store must be rebuilt first)", async () => {
     const order: string[] = [];
     const deps = {
       refreshAndInject: jest.fn(async () => {
@@ -65,6 +93,7 @@ describe("createProfileApplyRefreshHook", () => {
         order.push("invalidatePreconditionCache"),
       ),
       rerenderLayouts: jest.fn(() => order.push("rerenderLayouts")),
+      refreshEditorLabels: jest.fn(() => order.push("refreshEditorLabels")),
     };
 
     await createProfileApplyRefreshHook(deps)();
@@ -75,7 +104,23 @@ describe("createProfileApplyRefreshHook", () => {
       "invalidateCommandResolverCache",
       "invalidatePreconditionCache",
       "rerenderLayouts",
+      "refreshEditorLabels",
     ]);
+  });
+
+  it("re-resolves editor labels only AFTER the index-fresh re-inject (fresh metadataCache)", async () => {
+    const order: string[] = [];
+    const deps = makeDeps();
+    deps.refreshAndInject.mockImplementation(async () =>
+      order.push("refreshAndInject"),
+    );
+    deps.refreshEditorLabels.mockImplementation(() =>
+      order.push("refreshEditorLabels"),
+    );
+
+    await createProfileApplyRefreshHook(deps)();
+
+    expect(order).toEqual(["refreshAndInject", "refreshEditorLabels"]);
   });
 
   it("re-renders only AFTER caches are invalidated (fresh resolution)", async () => {


### PR DESCRIPTION
## Что

Веха 2 link-label (WBS \`f01836c1\`): авто re-resolve лейблов ссылок на profile-apply. После mount-state replace лейблы `[[uid]]`-ссылок в открытых редакторах пересчитываются **автоматически** — без ручной команды «Exocortex: Refresh link labels» (Веха 1 / MVP, #3622).

## Как

Добавлен **4-й шаг** `refreshEditorLabels` в `createProfileApplyRefreshHook` (`profileApplyRefreshHook.ts`):

1. re-inject materialization triples (H1)
2. invalidate command/precondition caches + lazy-loader marks (D1)
3. re-render active layouts (D1)
4. **re-resolve wikilink labels in open editor views (Веха 2)** ← новое

Шаг реконфигурирует открытые Markdown-редакторы (`app.workspace.updateOptions()`) → пересоздаёт `WikilinkLabelViewPlugin` → свежий `buildDecorations` против актуального `metadataCache`. Тот же editor-view rebuild, что использует MVP-команда (`LinkLabelRefreshService.rebuildEditorViews`).

Индекс **уже свежий** на момент хука (`rdfIndexer.refresh()`, запустивший хук, прогнал `convertVault()`) → НЕ дублируем `ensureIndexFresh` / `rerenderLayouts`, добавляем ровно недостающий editor-view reconfigure. Шаг изолирован/graceful: его падение не ломает post-refresh chain (более важные duties уже отработали).

Wired в `ExocortexPlugin.registerProfileCommands`: `refreshEditorLabels: () => this.app.workspace.updateOptions()`. Без `Platform`-gate (pure in-memory re-resolve, no Node/fs/git) — соблюдён Desktop↔Mobile Command Parity invariant.

## Тесты

- 9/9 unit (`profileApplyRefreshHook.test.ts`): вызов `refreshEditorLabels`, порядок (после re-inject), graceful при throw.
- **Revert-verify**: удаление `deps.refreshEditorLabels()` → 3 теста FAIL; restore → PASS.
- Связанные suites (LinkLabelRefreshService, registerRefreshLinkLabelsCommand, refresh-link-labels integration) — green (23/23).
- tsc clean, eslint `--max-warnings=0` clean, archgate 22/22 pass.

## Scope

Strictly `profileApplyRefreshHook` + его wiring в `ExocortexPlugin.ts` + тест. Никаких docs/SPARQLApi/grounding изменений.