### PR TITLE
docs: README core-meta only + Getting-Started ontology-agnostic (paradigm refactor)

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Compared to existing tools:
 | File-based (git-friendly) |    ✅     |   —    |  —   |         —          |   ✅    |
 | UI from ontology          |    ✅     |   ✅   |  ~   |         ~          |   ✅    |
 | Offline-first             |    ✅     |   ~    |  —   |         —          |   ✅    |
-| For knowledge workers     |    ✅     |   ✅   |  ✅  |         ~          |   ��    |
+| For knowledge workers     |    ✅     |   ✅   |  ✅  |         ~          |    —    |
 | Action layer (commands)   |    ✅     |   ~    |  ✅  |         —          |    —    |
 
 ---
@@ -42,12 +42,13 @@ Compared to existing tools:
 
 - **Semantic knowledge graph** — every piece of knowledge is an Asset with UUID, class, properties, and relationships stored as RDF triples
 - **SPARQL queries** — ask complex questions across your entire knowledge base
-- **Modular ontologies** — IMS (concepts, notes, people), EMS (tasks, projects, meetings), ZTLK (zettelkasten)
+- **Modular ontologies (AssetSpaces)** — the engine itself is domain-agnostic; every domain vocabulary ships as a separate, versioned, independently-shareable package you mount on demand. See [Exo-as-SDK topology](./docs/explanation/assetspace-sdk-topology.md).
 - **Everything as Knowledge** — commands, workflows, property schemas, layouts, and even plugin settings (`exo__Setting` assets — see [docs/explanation/settings-homoiconization.md](./docs/explanation/settings-homoiconization.md)) defined as vault assets, not hardcoded
-- **Ontology plugins** — extend the system with installable ontology packages (e.g. [GTD + Jedi Techniques](https://github.com/kitelev/gtd-jedi))
+- **Installable ontology packages** — extend the graph by mounting an AssetSpace from any public or private GitHub repo (`assetspace-add` in the CLI, **Add a knowledge pack** in the plugin) — no engine change required
 - **Profile** (production-ready) — vault-declared homoiconic profiles that drive on-disk AssetSpace materialization via a single **Apply profile** operation (mount-state strict replace). One vault, multiple contexts, selective sync. See [docs/explanation/profile.md](./docs/explanation/profile.md).
 - **ExoSync** — GitHub-backed vault sync via the **Exocortex: Sync** command: pull → merge → push over the GitHub REST API, with structured 3-way merge and quarantine for unresolvable conflicts (a SHACL merge-gate ships in core but is not yet wired into the plugin). Works on mobile (no git binary required). See [docs/how-to/exosync.md](./docs/how-to/exosync.md).
 - **UI/CLI Parity** — every capability is reachable from the Obsidian plugin and the CLI; neither client holds exclusive features. The complement of homoiconicity: it keeps the _invocation_ layer open just as homoiconicity keeps the _data_ layer open. See [VISION.md](./VISION.md#uicli-parity-invariant).
+- **Desktop / Mobile parity** — every plugin command works on both desktop and mobile; none is gated desktop-only (a desktop-only dependency such as the git binary is bridged through a cross-platform path — `vault.adapter` / GitHub REST). The third member of the no-lock-in triad. See [VISION.md](./VISION.md#the-no-lock-in-triad).
 - **Local-first** — all data stays on your device, no cloud required
 
 ---
@@ -84,14 +85,12 @@ The CLI exposes five core verbs — `find`, `apply`, `query`, `index`, `validate
 ```bash
 # Run via npx (or npm install -g @kitelev/exocortex-cli)
 
-# Query your knowledge graph
+# Query your knowledge graph — core `exo:` vocabulary, works on any vault
 npx @kitelev/exocortex-cli query "
 PREFIX exo: <https://exocortex.my/ontology/exo#>
-PREFIX ems: <https://exocortex.my/ontology/ems#>
-SELECT ?task ?label WHERE {
-  ?task exo:Instance_class ems:Task .
-  ?task exo:Asset_label ?label
-}" --vault ~/vault
+SELECT ?asset ?label WHERE {
+  ?asset exo:Asset_label ?label
+} LIMIT 20" --vault ~/vault
 
 # Apply a vault-defined command (exocmd__Command) to an asset —
 # e.g. a status-transition command that completes a task.
@@ -138,14 +137,16 @@ Every piece of knowledge is a Markdown file with YAML frontmatter:
 ---
 exo__Asset_uid: 965fd5c2-808e-4c7e-8242-e2e5d85bd996
 exo__Instance_class:
-  - "[[ims__Concept]]"
+  - "[[3f9a1c20-0000-4000-8000-000000000001|Concept]]" # any class your ontology defines
 exo__Asset_label: "Exocortex"
 exo__Asset_relates:
-  - "[[PKM]]"
-  - "[[Semantic Web]]"
+  - "[[7b2e4d80-0000-4000-8000-000000000002|PKM]]"
+  - "[[a1c8f600-0000-4000-8000-000000000003|Semantic Web]]"
 ---
 Knowledge content in Markdown...
 ```
+
+> Wikilinks resolve by UID; the readable alias after `|` is just for humans. Class membership (`exo__Instance_class`) points at whichever ontology class your mounted AssetSpaces define — the engine has no built-in domain classes of its own.
 
 Assets are connected through typed relationships. Individual assets are information; connected assets become knowledge.
 
@@ -154,37 +155,25 @@ Assets are connected through typed relationships. Individual assets are informat
 Ask complex questions about your knowledge:
 
 ```sparql
-# Find all tasks related to a specific concept
+# Find every asset related to one with a given label — pure core `exo:` vocabulary
 PREFIX exo: <https://exocortex.my/ontology/exo#>
-PREFIX ems: <https://exocortex.my/ontology/ems#>
-SELECT ?task ?label WHERE {
-  ?task exo:Instance_class ems:Task .
-  ?task exo:Asset_label ?label .
-  ?task exo:Asset_relates ?concept .
-  ?concept exo:Asset_label "Machine Learning" .
+SELECT ?asset ?label WHERE {
+  ?asset exo:Asset_label ?label .
+  ?asset exo:Asset_relates ?other .
+  ?other exo:Asset_label "Machine Learning" .
 }
-```
-
-### Effort Lifecycle
-
-Complete workflow from idea to completion with automatic timestamp tracking:
-
-```
-Draft → Backlog → Analysis → ToDo → Doing → Done
-                     ↓
-                  Trashed
 ```
 
 ### Workflow Customization
 
-Define custom status lifecycles for your tasks and projects — all using regular vault assets:
+Status lifecycles are not built into the engine — you define them for **any** class as regular vault assets, and the UI buttons follow:
 
 ```bash
 exocortex-cli workflow list --vault ~/vault
 exocortex-cli workflow validate <uid> --vault ~/vault
 ```
 
-See **[Workflow Customization Guide](./docs/how-to/WORKFLOW_CUSTOMIZATION.md)** for details.
+See the **[Workflow Customization Guide](./docs/how-to/WORKFLOW_CUSTOMIZATION.md)** for the mechanism. Concrete domain lifecycles (e.g. the EMS effort flow `Draft → Backlog → Analysis → ToDo → Doing → Done`) live in their own AssetSpace, not in core — see that AssetSpace's README.
 
 ### Ontology-Driven Forms
 
@@ -196,7 +185,7 @@ Embed Layout definitions directly in your notes:
 
 ````markdown
 ```exo-layout
-[[emslayout__UpcomingTasksLayout]]
+[[8c4d2e10-0000-4000-8000-000000000004|MyLayout]]
 ```
 ````
 
@@ -206,7 +195,7 @@ Features: wikilink syntax, loading state, error handling, auto-refresh, interact
 
 Install community ontology packages (AssetSpaces) to extend your knowledge graph:
 
-- **CLI:** `npx @kitelev/exocortex-cli assetspace-add --vault ~/vault --url https://github.com/kitelev/exoas-pmbok-ontology` adds a single AssetSpace from a public GitHub URL; `bootstrap` sets up a fresh vault with the SDK floor.
+- **CLI:** `npx @kitelev/exocortex-cli assetspace-add --vault ~/vault --url https://github.com/kitelev/exoas-pmbok` adds a single AssetSpace from a public GitHub URL; `bootstrap` sets up a fresh vault with the SDK floor.
 - **Plugin:** the **Add a knowledge pack** and **Set up the engine** palette commands do the same from Obsidian. (A first-run **Setup (getting started)** wizard chains them with the recommended URLs pre-filled — see the [Getting Started Guide](./docs/tutorials/Getting-Started.md).)
 
 ### Profile — Vault-Declared Context
@@ -243,7 +232,7 @@ Statically registered plugin commands (all prefixed `Exocortex:` in the palette)
 | **Remove knowledge pack (advanced)**  | Unmount an AssetSpace from the vault                                                                                                                                |
 | **Reset profile cache (advanced)**    | Clear the profile-switch tarball cache                                                                                                                              |
 
-In addition, vault-defined `exocmd__Command` assets are registered **dynamically** as palette commands (the homoiconic command layer) — their set depends on the commands declared in your vault, with visibility gated by their preconditions. Asset-creation commands (e.g. **Create Task Instance**, **Create Project**) live in this dynamic layer rather than as a static "Create asset" command.
+In addition, vault-defined `exocmd__Command` assets are registered **dynamically** as palette commands (the homoiconic command layer) — their set depends on the commands declared in your mounted AssetSpaces, with visibility gated by their preconditions. Asset-creation and status-transition commands come from this dynamic layer rather than being hardcoded in the engine; which ones you see depends on which AssetSpaces you mount.
 
 ---
 

--- a/docs/tutorials/Getting-Started.md
+++ b/docs/tutorials/Getting-Started.md
@@ -30,16 +30,15 @@ If any component is below the minimum, update it before continuing.
 1. [Requirements](#requirements)
 2. [What is Exocortex?](#what-is-exocortex)
 3. [Installation](#installation)
-4. [Your First Area](#your-first-area)
-5. [Your First Project](#your-first-project)
-6. [Your First Task](#your-first-task)
-7. [Daily Planning](#daily-planning)
-8. [Understanding the Layout](#understanding-the-layout)
-9. [Plugin Settings](#plugin-settings)
-10. [Troubleshooting](#troubleshooting)
-11. [Known Limitations](#known-limitations)
-12. [Feedback](#feedback)
-13. [Next Steps](#next-steps)
+4. [Your first assets — the EMS example domain](#your-first-assets--the-ems-example-domain)
+   - [Your First Area](#your-first-area) · [Your First Project](#your-first-project) · [Your First Task](#your-first-task)
+5. [Daily Planning](#daily-planning)
+6. [Understanding the Layout](#understanding-the-layout)
+7. [Plugin Settings](#plugin-settings)
+8. [Troubleshooting](#troubleshooting)
+9. [Known Limitations](#known-limitations)
+10. [Feedback](#feedback)
+11. [Getting Help](#getting-help)
 
 ---
 
@@ -48,6 +47,8 @@ If any component is below the minimum, update it before continuing.
 Exocortex is an Obsidian plugin that lets you **define custom entity types, their properties, and UI — all as data, not code**. Think of it as Notion databases, but with an ontology layer and fully offline.
 
 You describe your entities (tasks, projects, areas, or any custom type) in YAML frontmatter, and the plugin automatically generates layouts, action buttons, and workflows based on those definitions. No server, no vendor lock-in — your data lives as Markdown files in your git repository.
+
+> **About this guide.** The setup flow — install → bootstrap → registry → profiles → apply → sync — is **ontology-agnostic**: it is the engine, and it knows nothing about any particular domain. The hands-on walkthrough later (Areas → Projects → Tasks) uses the **EMS AssetSpace** (Effort Management) as one concrete example domain. EMS is not part of the engine — it is a mountable package. For the EMS domain model itself (its classes, status lifecycle, and properties) see the **[EMS AssetSpace README](https://github.com/kitelev/exoas-public)**; the same mechanism drives any ontology you mount.
 
 > **Important — Reading Mode is required**: every Exocortex layout (action buttons, Asset Relations, Area tree, Daily Tasks) renders **only in Obsidian's Reading Mode**. In Live Preview or Source Mode the layout is intentionally hidden — you will see only the raw frontmatter. Toggle with **Ctrl/Cmd + E** or the reading-glass icon in the top-right. This is a deliberate design choice (read vs. edit separation), not a bug.
 
@@ -188,7 +189,13 @@ The **first** sync over a freshly-mounted AssetSpace just bootstraps its baselin
 
 ---
 
-## Your First Area
+## Your first assets — the EMS example domain
+
+> **From here on, the walkthrough uses the EMS AssetSpace as a concrete example.** EMS (Effort Management) ships the classes you see below — Area, Project, Task — plus a status lifecycle. It is one mountable domain among many, not part of the engine. The steps demonstrate the **mechanism** (define an asset in frontmatter → the layout, buttons, and workflows follow); to apply it to a different domain, mount that domain's AssetSpace and use its classes instead. The full EMS reference (every class, the status lifecycle, all properties) lives in the **[EMS AssetSpace README](https://github.com/kitelev/exoas-public)** — it is intentionally not duplicated here.
+>
+> **Tip:** the **recommended** path below is the in-layout **buttons** (Create Project, Create Task). They write the correct, canonical (UID-form) frontmatter for you, so you never have to type wikilinks by hand. The manual-frontmatter examples are shown for reference; when you type a class label like `[[ems__Area]]`, the plugin resolves and canonicalizes it on save.
+
+### Your First Area
 
 Areas represent broad domains of work (e.g., "Development", "Marketing", "Personal Projects").
 
@@ -223,7 +230,7 @@ The Exocortex layout renders with these sections (header labels match the on-scr
 
 ---
 
-## Your First Project
+### Your First Project
 
 Projects represent specific initiatives within an area.
 
@@ -270,12 +277,7 @@ REST API for the mobile app.
 
 ### Available Status Values
 
-- `ems__EffortStatusDraft` - Initial idea, not yet committed
-- `ems__EffortStatusBacklog` - Committed, awaiting analysis
-- `ems__EffortStatusAnalysis` - Being analyzed/planned
-- `ems__EffortStatusToDo` - Ready to start
-- `ems__EffortStatusDoing` - In progress
-- `ems__EffortStatusDone` - Completed
+EMS ships a status lifecycle — `Draft → Backlog → Analysis → ToDo → Doing → Done` (plus `Trashed`). The individual status values (`ems__EffortStatusBacklog`, `ems__EffortStatusToDo`, …) and their exact meaning are part of the **EMS domain model**, documented in the **[EMS AssetSpace README](https://github.com/kitelev/exoas-public)** — kept there (not duplicated here) so the two never drift.
 
 ### What You'll See
 
@@ -284,7 +286,7 @@ REST API for the mobile app.
 
 ---
 
-## Your First Task
+### Your First Task
 
 Tasks represent specific work items within a project.
 

--- a/docs/tutorials/Getting-Started.md
+++ b/docs/tutorials/Getting-Started.md
@@ -193,7 +193,7 @@ The **first** sync over a freshly-mounted AssetSpace just bootstraps its baselin
 
 > **From here on, the walkthrough uses the EMS AssetSpace as a concrete example.** EMS (Effort Management) ships the classes you see below — Area, Project, Task — plus a status lifecycle. It is one mountable domain among many, not part of the engine. The steps demonstrate the **mechanism** (define an asset in frontmatter → the layout, buttons, and workflows follow); to apply it to a different domain, mount that domain's AssetSpace and use its classes instead. The full EMS reference (every class, the status lifecycle, all properties) lives in the **[EMS AssetSpace README](https://github.com/kitelev/exoas-public)** — it is intentionally not duplicated here.
 >
-> **Tip:** the **recommended** path below is the in-layout **buttons** (Create Project, Create Task). They write the correct, canonical (UID-form) frontmatter for you, so you never have to type wikilinks by hand. The manual-frontmatter examples are shown for reference; when you type a class label like `[[ems__Area]]`, the plugin resolves and canonicalizes it on save.
+> **Tip:** the **recommended** path below is the in-layout **buttons** (Create Project, Create Task). They write the correct, canonical (UID-form) frontmatter for you, so you never have to type wikilinks by hand. The manual-frontmatter examples are shown for reference; when you type a class label like `[[ems__Area]]`, the plugin resolves it so the link works — only the **buttons** write the canonical UID-form frontmatter to disk for you.
 
 ### Your First Area
 


### PR DESCRIPTION
## What

Documentation **paradigm** refactor per user directive (2026-06-20): the main repo's docs should describe **only core meta-features** of Exocortex (the engine) — module/domain features (EMS effort lifecycle, etc.) belong in their own AssetSpace READMEs.

This PR is **PR1** (main-repo cleanup). A follow-up adds the EMS AssetSpace README (`exoas-public`).

### README.md → core-meta only
- Drop module-feature leakage: the `Modular ontologies — IMS/EMS/ZTLK` enumeration, the `### Effort Lifecycle` section (EMS), EMS-specific `Create Task Instance / Create Project` command names, and `ems:Task` SPARQL examples → replaced with the domain-agnostic mechanism (AssetSpaces) + pointers.
- **Fix two broken links** (verify-before-assert against GitHub): `kitelev/gtd-jedi` does not exist (removed); `exoas-pmbok-ontology` → `exoas-pmbok` (the real repo).
- `[[ims__Concept]]` example (stale — `ims__`→`concept__` re-prefix) → synthetic `[[uuid|alias]]`, ontology-neutral.
- Add **Desktop / Mobile parity** bullet (third member of the no-lock-in triad; VISION already documents the invariant, README did not).
- Repair a garbled UTF-8 byte in the comparison table (pre-existing on main).

### docs/tutorials/Getting-Started.md → ontology-agnostic
- Reframe so the setup flow (install → bootstrap → registry → profiles → apply → sync) is presented as **ontology-agnostic**, and the Areas → Projects → Tasks walkthrough is clearly the **EMS example domain** (one mountable package, not the engine), with a pointer to the EMS AssetSpace README.
- Condense the EMS status-value enumeration → pointer (don't duplicate module reference content → no drift).
- Fix the dead `Next Steps` TOC anchor (→ `Getting Help`).
- **Note:** label-form wikilinks (`[[ems__Area]]`) are kept in the tutorial because they are what a user **types** and they resolve to the mounted class; converting them to synthetic UIDs would break copy-paste. The recommended button-creation path writes canonical UID-form frontmatter automatically (now stated explicitly).

## Scope
Docs only. No code touched. No engine behaviour change.

## Verification
- All referenced files + VISION anchors resolve; no broken internal links.
- `prettier --check` clean (files were clean on origin/main; additions hand-formatted to match).
