### PR TITLE
test(e2e): cover flagship «Create Instance» on exo__Class page (eka-gui)

### DIFF
--- a/packages/obsidian-plugin/tests/e2e/eka-gui/create-instance-buttons.spec.ts
+++ b/packages/obsidian-plugin/tests/e2e/eka-gui/create-instance-buttons.spec.ts
@@ -43,7 +43,10 @@ const EMS_TASK_CLASSDEF_REL = path.posix.join(
  * a copy of the host class's own ontology. `$exo` lives in the cloned exoas-exo.
  */
 const PICK_ONTOLOGY_UID = "ca97bb2f-99bd-4ceb-b51e-c386b9231ae3"; // $exo
-const PICK_ONTOLOGY_QUERY = "$exo"; // fuzzy query that surfaces the $exo option
+// Fuzzy query for the picker. `label.includes(query)` is a substring match, so
+// this surfaces `$exo` AND any `$exo…`-prefixed sibling (e.g. `$exocmd`); the
+// test then clicks the exact `$exo` option BY UID, so selection is deterministic.
+const PICK_ONTOLOGY_QUERY = "$exo";
 const PICK_ONTOLOGY_DIR = "assetspaces/kitelev/exoas-exo/exo";
 
 /**
@@ -279,20 +282,25 @@ test.describe("EKA GUI — create-instance buttons (fresh real-content vault)", 
       PICK_ONTOLOGY_UID, // picked ontology — set as exo__Asset_isDefinedBy
       PICK_ONTOLOGY_QUERY,
       "E2E Instance on Class",
+      PICK_ONTOLOGY_DIR, // expected co-location folder (folded into retry-accept)
     );
     log(`created flagship instance: ${rel}`);
 
+    // Pin each UID to its OWN property (not a bare whole-frontmatter substring),
+    // so a hypothetical value-swap of the two refs can't pass vacuously.
     // exo__Instance_class = the host class (the class-def page IS the class).
     expect(
       fm,
-      "instance must carry the host class in exo__Instance_class ($targetClassSelf)",
-    ).toContain(UID.emsTaskClass);
+      "exo__Instance_class must be the host class ($targetClassSelf)",
+    ).toMatch(
+      new RegExp(`exo__Instance_class:[\\s\\S]{0,60}?${UID.emsTaskClass}`),
+    );
     // exo__Asset_isDefinedBy = the PICKED ontology ($exo), proving the picker
     // drove it (≠ the host class's own $ems).
     expect(
       fm,
-      "instance must carry the picked ontology in exo__Asset_isDefinedBy",
-    ).toContain(PICK_ONTOLOGY_UID);
+      "exo__Asset_isDefinedBy must be the picked ontology ($exo)",
+    ).toMatch(new RegExp(`exo__Asset_isDefinedBy:[^\\n]*${PICK_ONTOLOGY_UID}`));
     // Co-located in the PICKED ontology's folder ($isDefinedByFolder) — exoas-exo,
     // NOT the host class's ems folder.
     expect(

--- a/packages/obsidian-plugin/tests/e2e/eka-gui/create-instance-buttons.spec.ts
+++ b/packages/obsidian-plugin/tests/e2e/eka-gui/create-instance-buttons.spec.ts
@@ -7,6 +7,8 @@ import {
   SEED_AREA_UID,
   SEED_MEETING_PROTO_UID,
   SEED_PROJECT_UID,
+  UID,
+  createInstanceOnClass,
   createOnTarget,
   findByUid,
   launchObsidianWithPlugin,
@@ -22,6 +24,28 @@ import {
 /** ems__Area class UID — the seed area's `exo__Instance_class`. */
 const EMS_AREA_CLASS_UID = "82c74542-1b14-4217-b852-d84730484b25";
 
+/** exo__Class **metaclass** UID — what the flagship "Create Instance" binding targets. */
+const EXO_CLASS_METACLASS_UID = "8619c4fc-64f1-4869-b17e-e34186cacca9";
+/**
+ * A real published class-definition page to drive the flagship "Create Instance"
+ * on: the `ems__Task` class def (an `exo__Class` instance), shipped in the cloned
+ * `exoas-public` repo. Co-located in the ems ontology folder.
+ */
+const EMS_TASK_CLASSDEF_REL = path.posix.join(
+  "assetspaces/kitelev/exoas-public/ems",
+  `${UID.emsTaskClass}.md`,
+);
+/**
+ * The ontology the picker SELECTS — deliberately `$exo`, DIFFERENT from the
+ * ems__Task class-def's own isDefinedBy (`$ems`). Picking a different ontology
+ * proves the form's reusable reference-picker drives BOTH the new instance's
+ * `exo__Asset_isDefinedBy` AND its co-location folder ($isDefinedByFolder) — not
+ * a copy of the host class's own ontology. `$exo` lives in the cloned exoas-exo.
+ */
+const PICK_ONTOLOGY_UID = "ca97bb2f-99bd-4ceb-b51e-c386b9231ae3"; // $exo
+const PICK_ONTOLOGY_QUERY = "$exo"; // fuzzy query that surfaces the $exo option
+const PICK_ONTOLOGY_DIR = "assetspaces/kitelev/exoas-exo/exo";
+
 /**
  * ============================================================================
  *  EKA GUI BDD — create-instance buttons on a fresh, real-content vault
@@ -36,6 +60,9 @@ const EMS_AREA_CLASS_UID = "82c74542-1b14-4217-b852-d84730484b25";
  *   - Create child Area (#3555)          → ems:Area_parent   = the area  ⚠ REGRESSION
  *   - Create Task on an ems__Project     → ems:Effort_parent = the project
  *   - Create Meeting on a MeetingProto   → exo:Asset_prototype = the source
+ *   - Create Instance on an exo__Class   → exo:Instance_class = host class +
+ *                                          isDefinedBy/folder = PICKED ontology
+ *                                          (flagship bbe40f8c, two-field form)
  *   - cleanup-idempotent                 → created instances removed, ontologies intact
  *
  * Design (see eka-gui-helpers.ts header): one suite over ONE fresh vault per run
@@ -218,9 +245,72 @@ test.describe("EKA GUI — create-instance buttons (fresh real-content vault)", 
     ).toContain(SEED_MEETING_PROTO_UID);
   });
 
+  // ── Flagship: homoiconic «Create Instance» on a CLASS-def page (project ──────
+  // bbe40f8c, T5 — closes the deferred live-visual of node 8e892543). ──────────
+  //
+  // The other scenarios drive the ems-specific create buttons on INSTANCES with a
+  // single-field (label) form. THIS drives the generic "Create Instance" command
+  // — bound to the `exo__Class` METACLASS, so it renders on every class-def page
+  // — on a real published class def (ems__Task), through the TWO-field form:
+  // `Label` + the reusable Ontology fuzzy reference-picker (T2). It proves the
+  // full flagship path end-to-end against the live published command/binding/
+  // grounding: button render → form → picker selection → on-disk UUID instance
+  // whose exo__Instance_class is the host class (via the $targetClassSelf
+  // PropertyDefault) and whose exo__Asset_isDefinedBy + folder follow the PICKED
+  // ontology ($exo ≠ the host's own $ems → proves the picker drives both).
+  test("scenario 9 — Create Instance on an exo__Class page (flagship bbe40f8c)", async () => {
+    // Store-completeness gate for THIS target: the binding targets the exo__Class
+    // metaclass (not ems__Area), so gate on "Create Instance" resolving on the
+    // class-def page itself (same #3587 rationale as the beforeAll area gate).
+    await waitForCreateCommandsResolvable(
+      window,
+      EMS_TASK_CLASSDEF_REL,
+      EXO_CLASS_METACLASS_UID,
+      ["Create Instance"],
+      120_000,
+      ["exo__Class", "exo__Asset"],
+    );
+
+    const { rel, fm } = await createInstanceOnClass(
+      window,
+      vaultPath,
+      EMS_TASK_CLASSDEF_REL,
+      UID.emsTaskClass, // host class — set as exo__Instance_class ($targetClassSelf)
+      PICK_ONTOLOGY_UID, // picked ontology — set as exo__Asset_isDefinedBy
+      PICK_ONTOLOGY_QUERY,
+      "E2E Instance on Class",
+    );
+    log(`created flagship instance: ${rel}`);
+
+    // exo__Instance_class = the host class (the class-def page IS the class).
+    expect(
+      fm,
+      "instance must carry the host class in exo__Instance_class ($targetClassSelf)",
+    ).toContain(UID.emsTaskClass);
+    // exo__Asset_isDefinedBy = the PICKED ontology ($exo), proving the picker
+    // drove it (≠ the host class's own $ems).
+    expect(
+      fm,
+      "instance must carry the picked ontology in exo__Asset_isDefinedBy",
+    ).toContain(PICK_ONTOLOGY_UID);
+    // Co-located in the PICKED ontology's folder ($isDefinedByFolder) — exoas-exo,
+    // NOT the host class's ems folder.
+    expect(
+      rel.startsWith(PICK_ONTOLOGY_DIR + "/"),
+      `instance must be co-located in the picked ontology folder (got ${rel})`,
+    ).toBe(true);
+    // UID-canon: the instance file is UUID-named.
+    expect(
+      path.basename(rel),
+      `instance file must be UUID-named (got ${path.basename(rel)})`,
+    ).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\.md$/,
+    );
+  });
+
   test("scenario 8 — cleanup removes created instances, leaves ontologies + seed intact", async () => {
     const isCreated = (fm: string): boolean =>
-      /exo__Asset_label:\s*"?E2E (Task on Area|Project on Area|Child Area|Task on Project|Meeting on Proto)/.test(
+      /exo__Asset_label:\s*"?E2E (Task on Area|Project on Area|Child Area|Task on Project|Meeting on Proto|Instance on Class)/.test(
         fm,
       );
 

--- a/packages/obsidian-plugin/tests/e2e/eka-gui/eka-gui-helpers.ts
+++ b/packages/obsidian-plugin/tests/e2e/eka-gui/eka-gui-helpers.ts
@@ -433,16 +433,20 @@ export async function waitForStoreSettled(
  */
 export async function waitForCreateCommandsResolvable(
   window: Page,
-  areaRel: string,
-  areaClassUid: string,
+  targetRel: string,
+  targetClassUid: string,
   requiredLabels: string[],
   timeoutMs = 120_000,
+  // Extra class identifiers (label / ancestor) merged with `targetClassUid` when
+  // probing resolution. Default mirrors a seed ems__Area page; the flagship
+  // class-def gate passes `["exo__Class", "exo__Asset"]` instead.
+  classAliases: string[] = ["ems__Area", "exo__Asset"],
 ): Promise<void> {
   await pollUntil(
-    `create commands resolvable on seed area (${requiredLabels.join(", ")})`,
+    `create commands resolvable on ${targetRel} (${requiredLabels.join(", ")})`,
     async () => {
       const names = await window.evaluate(
-        async ({ rel, cls }) => {
+        async ({ rel, cls, aliases }) => {
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           const plugin = (window as any).app?.plugins?.plugins?.exocortex;
           if (!plugin?.commandResolver?.resolveForAssetMulti) return [];
@@ -462,7 +466,7 @@ export async function waitForCreateCommandsResolvable(
           try {
             const resolved = await plugin.commandResolver.resolveForAssetMulti(
               iri,
-              [cls, "ems__Area", "exo__Asset"],
+              [cls, ...aliases],
             );
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
             return resolved.map((rc: any) => rc?.command?.name).filter(Boolean);
@@ -470,7 +474,7 @@ export async function waitForCreateCommandsResolvable(
             return [];
           }
         },
-        { rel: areaRel, cls: areaClassUid },
+        { rel: targetRel, cls: targetClassUid, aliases: classAliases },
       );
       return requiredLabels.every((l) => names.includes(l));
     },
@@ -706,5 +710,158 @@ export async function createOnTarget(
   }
   throw new Error(
     `"${buttonText}" did not produce ${backlinkRe} after ${attempts} attempts.\nLast: ${lastErr}`,
+  );
+}
+
+/**
+ * Drive the flagship homoiconic «Create Instance» command (project bbe40f8c) on
+ * a CLASS-definition page — an `exo__Class` instance such as the `ems__Task`
+ * class def. Opens the class-def page → clicks the inline "Create Instance"
+ * button (bound to the `exo__Class` metaclass) → fills the two-field
+ * DynamicFormModal — a `Label` text input plus the generic, reusable
+ * **Ontology fuzzy reference-picker** (`exo__Asset_isDefinedBy`, an `assetRef`
+ * over `exo__Ontology`, T2) — → submits → returns the created instance file +
+ * its frontmatter.
+ *
+ * Differs from {@link createOnTarget}: that drives a single-field (label) form on
+ * an INSTANCE; this drives the two-field form on a CLASS and additionally selects
+ * an ontology via the combobox. The grounding (`ef896bf8`, `create_instance`,
+ * `$isDefinedByFolder`) sets the new instance's `exo__Instance_class` to the HOST
+ * class's own UID (the `$targetClassSelf` PropertyDefault) and its
+ * `exo__Asset_isDefinedBy` to the PICKED ontology → co-located in that ontology's
+ * folder (co-location invariant).
+ *
+ * Retries the whole open→click→fill cycle until a valid instance lands — the
+ * binding+grounding resolution settles asynchronously (the same store-load race
+ * {@link createOnTarget} guards). A failed attempt's instance is deleted
+ * (label-scoped) so the snapshot diff stays clean for the next attempt.
+ *
+ * The picker is a real React component ({@link ReferencePicker}, drivable under
+ * CDP — unlike the un-drivable FuzzySuggestModal): its input is
+ * `[data-testid="field-exo__Asset_isDefinedBy"]` and each option is
+ * `[data-testid="option-exo__Asset_isDefinedBy-<uid>"]`, committing on mousedown.
+ */
+export async function createInstanceOnClass(
+  window: Page,
+  vaultPath: string,
+  classDefRel: string,
+  hostClassUid: string,
+  ontologyUid: string,
+  ontologyQuery: string,
+  labelBase: string,
+  attempts = 6,
+): Promise<{ rel: string; fm: string }> {
+  const pickerSel = '.dynamic-form [data-testid="field-exo__Asset_isDefinedBy"]';
+  const optionSel = `[data-testid="option-exo__Asset_isDefinedBy-${ontologyUid}"]`;
+  let lastErr = "";
+  for (let i = 1; i <= attempts; i++) {
+    const attemptLabel = `${labelBase} ${i}`;
+    try {
+      await openAssetAndRender(window, classDefRel);
+      const before = new Set(listMarkdown(vaultPath));
+
+      // Inline button bound to the exo__Class metaclass — only one command binds
+      // there ("Create Instance"), so the text match is unambiguous.
+      const btn = window
+        .locator(".exocortex-action-button", { hasText: "Create Instance" })
+        .first();
+      await expect(
+        btn,
+        '"Create Instance" button must render on the class-def page',
+      ).toBeVisible({ timeout: 20_000 });
+      await btn.click();
+
+      // Field 1 — Label (plain text input).
+      const labelField = window
+        .locator(
+          '.dynamic-form [data-testid="field-label"], .dynamic-form input.dynamic-form-input',
+        )
+        .first();
+      await expect(
+        labelField,
+        "create-instance form label input must appear",
+      ).toBeVisible({ timeout: 15_000 });
+      await labelField.fill(attemptLabel);
+
+      // Field 2 — Ontology fuzzy reference-picker: focus → type to filter → pick
+      // the committed option (commits "[[uid]]" into the form value on mousedown).
+      const picker = window.locator(pickerSel);
+      await expect(
+        picker,
+        "ontology reference-picker input must appear",
+      ).toBeVisible({ timeout: 15_000 });
+      await picker.fill(ontologyQuery);
+      const option = window.locator(optionSel);
+      await expect(
+        option,
+        `ontology option ${ontologyUid} must appear in the picker`,
+      ).toBeVisible({ timeout: 10_000 });
+      await option.click();
+
+      // Submit the form (modal CTA).
+      await window
+        .locator(".dynamic-form .modal-button-container button.mod-cta")
+        .first()
+        .click();
+      await window
+        .locator(".dynamic-form")
+        .waitFor({ state: "hidden", timeout: 10_000 })
+        .catch(() => undefined);
+
+      // The grounding writes the instance to disk async — poll for the new file.
+      let created: string[] = [];
+      await pollUntil(
+        `new instance created via "Create Instance"`,
+        () => {
+          created = listMarkdown(vaultPath).filter((p) => !before.has(p));
+          return created.length > 0;
+        },
+        30_000,
+      );
+      for (const rel of created) {
+        const head = readVaultFile(vaultPath, rel)
+          .split("\n")
+          .slice(0, 30)
+          .join(" | ");
+        log(`created via "Create Instance": ${rel} :: ${head}`);
+      }
+
+      // Accept the instance carrying BOTH the host class (via $targetClassSelf)
+      // AND the picked ontology (isDefinedBy). Anything else = grounding not yet
+      // fully resolved → clean up + retry.
+      for (const rel of created) {
+        const fm = readVaultFile(vaultPath, rel);
+        if (fm.includes(hostClassUid) && fm.includes(ontologyUid)) {
+          return { rel, fm };
+        }
+      }
+      lastErr =
+        `instance missing host class ${hostClassUid} or ontology ${ontologyUid} in: ` +
+        created
+          .map((r) => `${r}: ${readVaultFile(vaultPath, r).replace(/\n/g, " | ")}`)
+          .join(" ;; ");
+      for (const rel of created) {
+        try {
+          if (readVaultFile(vaultPath, rel).includes(attemptLabel)) {
+            fs.rmSync(path.join(vaultPath, rel));
+          }
+        } catch {
+          /* ignore */
+        }
+      }
+    } catch (e) {
+      // Transient: button not yet rendered / form raced / picker option not yet
+      // populated. Re-open on the next attempt re-resolves against the
+      // now-more-indexed store. Clear any half-open modal first.
+      lastErr = String((e as Error)?.message ?? e);
+      await clearModals(window).catch(() => undefined);
+    }
+    log(
+      `createInstanceOnClass attempt ${i}/${attempts} not resolved (${lastErr.slice(0, 160)}) — retrying`,
+    );
+    await new Promise((r) => setTimeout(r, 3000));
+  }
+  throw new Error(
+    `"Create Instance" did not produce a valid instance (host ${hostClassUid} + ontology ${ontologyUid}) after ${attempts} attempts.\nLast: ${lastErr}`,
   );
 }

--- a/packages/obsidian-plugin/tests/e2e/eka-gui/eka-gui-helpers.ts
+++ b/packages/obsidian-plugin/tests/e2e/eka-gui/eka-gui-helpers.ts
@@ -749,6 +749,7 @@ export async function createInstanceOnClass(
   ontologyUid: string,
   ontologyQuery: string,
   labelBase: string,
+  expectedFolder: string,
   attempts = 6,
 ): Promise<{ rel: string; fm: string }> {
   const pickerSel = '.dynamic-form [data-testid="field-exo__Asset_isDefinedBy"]';
@@ -827,16 +828,23 @@ export async function createInstanceOnClass(
       }
 
       // Accept the instance carrying BOTH the host class (via $targetClassSelf)
-      // AND the picked ontology (isDefinedBy). Anything else = grounding not yet
-      // fully resolved → clean up + retry.
+      // AND the picked ontology (isDefinedBy) AND co-located in that ontology's
+      // folder ($isDefinedByFolder). Folder is part of the predicate so a folder-
+      // resolution miss — `resolveIsDefinedByFolder` silently falls back to the
+      // host folder when refToFolder returns null — is RETRIED (re-open re-
+      // resolves against the more-indexed store), not surfaced as a hard fail.
       for (const rel of created) {
         const fm = readVaultFile(vaultPath, rel);
-        if (fm.includes(hostClassUid) && fm.includes(ontologyUid)) {
+        if (
+          fm.includes(hostClassUid) &&
+          fm.includes(ontologyUid) &&
+          rel.startsWith(expectedFolder + "/")
+        ) {
           return { rel, fm };
         }
       }
       lastErr =
-        `instance missing host class ${hostClassUid} or ontology ${ontologyUid} in: ` +
+        `instance missing host class ${hostClassUid} / ontology ${ontologyUid} / folder ${expectedFolder} in: ` +
         created
           .map((r) => `${r}: ${readVaultFile(vaultPath, r).replace(/\n/g, " | ")}`)
           .join(" ;; ");


### PR DESCRIPTION
## What

Adds an **eka-gui** release-gate e2e scenario (scenario 9) driving the homoiconic **«Create Instance»** command end-to-end on a real published class-def page — closing the **deferred live-visual** of the Create-Instance flagship (project `bbe40f8c`, T5 / vault node `8e892543`) with a **CI-runnable e2e on native amd64**, instead of a local Docker / computer-control smoke (⛔ NO-Docker panic rule).

## Why this is the missing layer

The flagship «Create Instance» path is already covered at unit / integration / component layers and proven via CLI smoke (v16.102.0). The one gap T5 left open was a **live-Obsidian visual** of the *augmented two-field form* (a new code path vs T1's static form). This scenario fills exactly that gap as a repeatable CI e2e.

The existing eka-gui scenarios drive *ems-specific* create buttons on **instances** through a single-field (label) form. This new scenario drives the **generic** «Create Instance» command — bound to the `exo__Class` **metaclass**, so it renders on every class-def page — on the `ems__Task` class def, through the **two-field** `DynamicFormModal`:

- `Label` (text)
- the reusable **Ontology fuzzy reference-picker** (`exo__Asset_isDefinedBy`, an `assetRef` over `exo__Ontology`, T2)

It asserts a valid **UUID-named** instance lands on disk with:
- `exo__Instance_class` = the **host class** (via the `$targetClassSelf` PropertyDefault),
- `exo__Asset_isDefinedBy` = the **PICKED ontology** (`$exo`, deliberately ≠ the host's own `$ems` — proving the picker drives the value, not a copy of the host),
- **co-located** in the picked ontology's folder (`$isDefinedByFolder`).

## Verify-before-assert (published content)

Confirmed against the live published `exoas-exocmd` the suite clones:
- Command `d638a1fd` «Create Instance» → grounding `ef896bf8` (`create_instance`, `$isDefinedByFolder`, two-field inputSchema)
- Binding `a24e196d` `targetClass = 8619c4fc` (exo__Class metaclass), `position: inline`
- PropertyDefault `059605d1` (`exo__Instance_class = $targetClassSelf`)
- `ems__Task` class def (`1b20a8f0`, an `exo__Class` instance) + `$exo`/`$ems` (`exo__Ontology` instances) present in cloned `exoas-exo`/`exoas-public`.

## Changes (scope: STRICTLY `tests/e2e/eka-gui/`)

- `eka-gui-helpers.ts`:
  - new `createInstanceOnClass` helper — drives the `ReferencePicker` combobox (type-to-filter → commit option) on top of the existing open→click retry + store-completeness discipline.
  - `waitForCreateCommandsResolvable` gains an optional `classAliases` param (backward compatible) so the flagship gate can target the `exo__Class` metaclass.
- `create-instance-buttons.spec.ts`:
  - scenario 9 (flagship), plus the cleanup scenario's idempotent regex extended to remove its created instance.

## Verification
- `tsc --noEmit` on the two files → **0 errors** (the `tests/**` dir is outside the gated `check:types` config + Playwright esbuild, so checked locally).
- This PR triggers the **EKA GUI-BDD E2E** workflow (`pull_request` paths filter matches `tests/e2e/eka-gui/**`) → runs in Docker on native amd64. **Non-required** check (network/QEMU flake never gates PRs).