### PR TITLE
feat(req): migrate 5 P0-critical exo requirements + @req bindings (RFC 0003 P2)

### DIFF
--- a/.archgate/adrs/ARCH-002-property-naming.md
+++ b/.archgate/adrs/ARCH-002-property-naming.md
@@ -18,15 +18,16 @@ Properties follow the format: `namespace__Class_property`
 
 ### Approved Namespaces
 
-| Namespace | Domain |
-|-----------|--------|
-| `exo__` | Core Exocortex |
-| `ems__` | Effort Management System |
-| `ims__` | Information Management System |
-| `ztlk__` | Zettelkasten |
-| `ptms__` | Personality Type Management System |
-| `lit__` | Literature |
-| `inbox__` | Inbox |
+| Namespace | Domain                             |
+| --------- | ---------------------------------- |
+| `exo__`   | Core Exocortex                     |
+| `ems__`   | Effort Management System           |
+| `ims__`   | Information Management System      |
+| `ztlk__`  | Zettelkasten                       |
+| `ptms__`  | Personality Type Management System |
+| `lit__`   | Literature                         |
+| `inbox__` | Inbox                              |
+| `req__`   | Requirements management (RFC 0003) |
 
 ## Do's and Don'ts
 

--- a/.archgate/adrs/ARCH-002-property-naming.rules.ts
+++ b/.archgate/adrs/ARCH-002-property-naming.rules.ts
@@ -3,7 +3,7 @@ export default {
   rules: {
     "property-naming-convention": {
       description:
-        "Frontmatter property constants must use approved namespace prefixes (exo__, ems__, ims__, ztlk__, ptms__, lit__, inbox__)",
+        "Frontmatter property constants must use approved namespace prefixes (exo__, ems__, ims__, ztlk__, ptms__, lit__, inbox__, req__)",
       severity: "warning",
       async check(ctx) {
         // Check domain constants files for property definitions
@@ -23,6 +23,11 @@ export default {
           "ptms__",
           "lit__",
           "inbox__",
+          // RFC 0003 (requirements management, A13): the `req` namespace is the
+          // canonical home for functional requirement constants. Added proactively
+          // so `req__*` domain constants (e.g. a future homoiconic req renderer)
+          // never trip this warning. No `req__` domain constants exist yet.
+          "req__",
         ];
 
         for (const file of allFiles) {
@@ -43,7 +48,7 @@ export default {
                 message: `Property uses non-standard namespace prefix: ${hit.content.trim()}`,
                 file: hit.file,
                 line: hit.line,
-                fix: `Use approved namespaces: exo__, ems__, ims__, ztlk__, ptms__, lit__, inbox__`,
+                fix: `Use approved namespaces: exo__, ems__, ims__, ztlk__, ptms__, lit__, inbox__, req__`,
               });
             }
           }

--- a/packages/cli/tests/integration/commands/apply-profile.integration.test.ts
+++ b/packages/cli/tests/integration/commands/apply-profile.integration.test.ts
@@ -203,7 +203,7 @@ describe("CLI — apply-profile real mount-state switch (Issue #3416)", () => {
     await makeFixtureVault(vaultRoot, testlibMaterialised);
   }
 
-  it("[revert-verify] tear-down: switching to a narrower profile removes the AS folder + strips .gitmodules", async () => {
+  it("@req:919c4aeb-23cf-4aef-a954-0244db31c0bb [revert-verify] tear-down: switching to a narrower profile removes the AS folder + strips .gitmodules", async () => {
     await setup(/* testlibMaterialised */ true);
     const testlibMount = path.join(vaultRoot, MOUNT_TESTLIB);
     expect(existsSync(testlibMount)).toBe(true); // precondition
@@ -260,7 +260,7 @@ describe("CLI — apply-profile real mount-state switch (Issue #3416)", () => {
     expect(existsSync(testlibMount)).toBe(true);
   });
 
-  it("materialise: switching to a wider profile pulls the AS via (faked) tarball + adds .gitmodules", async () => {
+  it("@req:7dea2191-12ca-447a-b1f1-23dbc99272d1 materialise: switching to a wider profile pulls the AS via (faked) tarball + adds .gitmodules", async () => {
     await setup(/* testlibMaterialised */ false);
     const testlibMount = path.join(vaultRoot, MOUNT_TESTLIB);
     expect(existsSync(testlibMount)).toBe(false); // precondition
@@ -559,7 +559,7 @@ describe("CLI — central-registry profile resolution (Issue #3511)", () => {
     await fs.writeFile(path.join(vaultRoot, ".gitmodules"), gm, "utf-8");
   }
 
-  it("resolves the profile WITHOUT degraded/refuse and materialises the transitive dependsOn closure", async () => {
+  it("@req:a23e8e34-b4f2-49d9-8b1b-0c3acc3a65e7 resolves the profile WITHOUT degraded/refuse and materialises the transitive dependsOn closure", async () => {
     await makeRegistryVault();
 
     // Fake mount: stub the only network op so no GitHub tarball is fetched.

--- a/packages/exocortex/tests/unit/services/RequiredPropertyResolver.test.ts
+++ b/packages/exocortex/tests/unit/services/RequiredPropertyResolver.test.ts
@@ -98,7 +98,7 @@ beforeEach(() => {
 });
 
 describe("createTripleStoreRequiredPropertyResolver", () => {
-  it("resolves a class's required (minCount>0) properties, skipping non-required", async () => {
+  it("@req:ace6df4f-b2c7-4dcb-afb6-bda8b20e7da0 resolves a class's required (minCount>0) properties, skipping non-required", async () => {
     const store = await seed([
       {
         key: "exo__Setting_key",

--- a/packages/exocortex/tests/unit/services/sync/StructuredMerger.test.ts
+++ b/packages/exocortex/tests/unit/services/sync/StructuredMerger.test.ts
@@ -82,7 +82,7 @@ describe("StructuredMerger — file-level outcomes", () => {
 });
 
 describe("StructuredMerger — frontmatter per-key 3-way (D1)", () => {
-  it("non-overlapping scalar edits on different keys merge", () => {
+  it("@req:40b1be4d-0aae-4c1b-8047-998e7f3ebf8b non-overlapping scalar edits on different keys merge", () => {
     const base = asset({ label: "L0", extra: { ems__Effort_status: '"[[s0]]"' } });
     const local = asset({ label: "L1", extra: { ems__Effort_status: '"[[s0]]"' } });
     const remote = asset({ label: "L0", extra: { ems__Effort_status: '"[[s1]]"' } });


### PR DESCRIPTION
## RFC 0003 — Requirements management, **P2** (migrate exo Alpha-critical functional requirements)

Implements the next increment of the spec-driven requirements base. **P0** (`exoas-req` TBox + `exoas-exo-reqs` ABox + 4 seeds, #3648) and **P1** (`requirements audit` checker + soft `requirements-trace` CI gate, #3650) are already shipped — this PR **populates** the P0-critical set and wires its `@req` traceability bindings.

`Req: 17e868ff-1158-4d41-89da-d50c00ee8446` (P2 vault node)

### What this PR contains (repo side)
- **`@req:<uid>` tags** added to the `it()` titles of the existing real tests that exercise 5 newly-migrated P0 functional requirements (the requirement assets live in `kitelev/exoas-exo-reqs`, pushed separately):
  | uid | behavior | bound test | class |
  |---|---|---|---|
  | `919c4aeb` | apply narrower profile → unmount AS outside effective set | `apply-profile.integration` tear-down | integration |
  | `7dea2191` | apply wider profile → materialize newly-included AS | `apply-profile.integration` materialise | integration |
  | `a23e8e34` | apply leaf profile → materialize transitive dependsOn closure (#3511) | `apply-profile.integration` registry closure | integration |
  | `40b1be4d` | ExoSync 3-way merge combines non-overlapping edits | `StructuredMerger` non-overlap merge | unit (+SyncEngine #3590 integration cited) |
  | `ace6df4f` | create-instance surfaces SHACL-required properties as form fields (T3 #3656) | `RequiredPropertyResolver` minCount | unit (+eka-gui gui-bdd cited) |
- **ARCH-002**: `req__` added to the property-naming allowlist (RFC 0003 A13, proactive — no `req__` domain constants exist yet; future-proofs a homoiconic req renderer).

### Revert-verify evidence (RFC 0003 §3.6, D1 — binding validity)
Each binding's primary test was proven to **fail when the production behavior is reverted**, GREEN restored (origin/main `035804ab`):
- `919c4aeb` — no-op'd `CliApplyProfileService.execute` tear-down loop → tear-down test RED.
- `7dea2191` — no-op'd `execute` materialize loop → materialise test RED.
- `a23e8e34` — un-expanded `transitiveDependsOnClosure` in `CliProfileResolver` → closure test RED.
- `40b1be4d` — disabled the local-only branch in `StructuredMerger.mergeFrontmatter` → non-overlap merge test RED.
- `ace6df4f` — inverted the `minCount > 0` filter in `RequiredPropertyResolver` → required-props test RED.

### Checker
`exocortex requirements audit --reqs exoas-exo-reqs --tests .` → **9 requirements / 9 bound / 100% coverage / 0 hard findings** (no dangling tags, no P0 binding-class floor violations). The soft `requirements-trace` CI job will surface the same report.

### No production code changed
Only test `it()` titles + the `.archgate` ARCH-002 rule/doc. SHACL = 0 on vault-exodev (incl. `exoas-exo-reqs` + `exoas-req`).