### PR TITLE
feat(req): @req bindings for 5 P2 increment-2 exo P0 requirements (RFC 0003 P2)

### DIFF
--- a/packages/cli/tests/integration/apply-ontological-archive.integration.test.ts
+++ b/packages/cli/tests/integration/apply-ontological-archive.integration.test.ts
@@ -260,7 +260,7 @@ describe("RFC 78c2b7d0 C5 — Archive Ontologically (homoiconic composite)", () 
     }
   }
 
-  it("relocates the asset into the archive ontology folder and re-anchors isDefinedBy (real mutation)", async () => {
+  it("relocates the asset into the archive ontology folder and re-anchors isDefinedBy (real mutation) @req:8efc003c-f0b3-4572-b702-710d66b8b184", async () => {
     const vault = buildVault();
     root = vault.root;
 

--- a/packages/cli/tests/integration/apply-workflow-transition.integration.test.ts
+++ b/packages/cli/tests/integration/apply-workflow-transition.integration.test.ts
@@ -392,7 +392,7 @@ describe("RFC 36347daf Phase 3: CLI apply workflow_transition", () => {
     }
   }
 
-  it("forward Backlog → Doing — status mutated, postAction marker written", async () => {
+  it("forward Backlog → Doing — status mutated, postAction marker written @req:14b1c592-9879-4523-bc6e-5cebd81d4ac4", async () => {
     vault = buildVault();
 
     await runApply(vault.root, COMMAND_UID, `${TASK_UID}.md`);

--- a/packages/cli/tests/integration/create-co-location.integration.test.ts
+++ b/packages/cli/tests/integration/create-co-location.integration.test.ts
@@ -131,7 +131,7 @@ describe("Issue #3520: `cli create` co-locates by exo__Asset_isDefinedBy", () =>
     return JSON.parse(json);
   }
 
-  it("resolvable isDefinedBy → asset placed in the ontology folder (not inbox)", async () => {
+  it("resolvable isDefinedBy → asset placed in the ontology folder (not inbox) @req:ec877f5e-d466-41fb-a3ae-9b8239cd7345", async () => {
     const result = await runCreate([
       "--property",
       `exo__Asset_isDefinedBy=[[${ONTOLOGY_UID}]]`,

--- a/packages/obsidian-plugin/tests/unit/integration/BootstrapAssetSpace.integration.test.ts
+++ b/packages/obsidian-plugin/tests/unit/integration/BootstrapAssetSpace.integration.test.ts
@@ -116,7 +116,7 @@ describe("Bootstrap integration — real GitSubmoduleOps + tmpdir vault (git mod
     if (vaultRoot) await fs.rm(vaultRoot, { recursive: true, force: true });
   });
 
-  it("empty vault → bootstrap → 1 .gitmodules entry + assetspaces/exo populated (exo-only)", async () => {
+  it("empty vault → bootstrap → 1 .gitmodules entry + assetspaces/exo populated (exo-only) @req:c50395c8-7eda-424d-b828-a25ad4a59756", async () => {
     vaultRoot = await makeTmpVault();
     const gitOps = new GitSubmoduleOps({ vaultRootPath: vaultRoot });
     const probes = makeVaultProbes(vaultRoot);

--- a/packages/obsidian-plugin/tests/unit/integration/BootstrapAssetSpaceMobile.integration.test.ts
+++ b/packages/obsidian-plugin/tests/unit/integration/BootstrapAssetSpaceMobile.integration.test.ts
@@ -248,7 +248,7 @@ describe("Mobile bootstrap integration — real RestAssetSpaceMount + vault.adap
     expect(notices.some((n) => /file-only mode/.test(n))).toBe(false);
   });
 
-  it("after exo-only bootstrap, add-assetspace appends a second .gitmodules entry at the canonical Maven path + materialises it (#3538)", async () => {
+  it("after exo-only bootstrap, add-assetspace appends a second .gitmodules entry at the canonical Maven path + materialises it (#3538) @req:59afd046-eb41-4fd5-a03a-062a53d0acc5", async () => {
     const adapter = new InMemoryAdapter();
     const notices: string[] = [];
     const { cmds, restMount } = makeCmds(adapter, notices, {});


### PR DESCRIPTION
## Summary

RFC 0003 **P2 increment 2** (req-mgmt, node \`17e868ff\`). Binds **5 reverse-documented exo P0 functional requirements** to their existing **integration** tests via \`@req:<uid>\` tokens in the \`it()\` titles (RFC 0003 §3.6). **Test-only change — no production src touched.** The \`req__Requirement\` assets live in the \`exoas-exo-reqs\` ABox repo (pushed separately, \`94a2ebd\`).

All 5 are **pure-\`integration\` bindings**, each **revert-verified without Docker** (break the prod line the test asserts → test RED → restore → GREEN), so they arm P3 directly with no deferred floor follow-up.

| uid | behavior | test (binding) | revert-verify |
| --- | --- | --- | --- |
| \`ec877f5e\` | cli create co-locates a new asset into its isDefinedBy ontology folder | \`create-co-location.integration.test.ts\` | revert \`create.ts\` co-location branch → RED |
| \`8efc003c\` | «Archive Ontologically» relocates asset + re-anchors isDefinedBy | \`apply-ontological-archive.integration.test.ts\` | revert \`FolderRepairService\` move → RED |
| \`c50395c8\` | bootstrap empty git vault → exo Maven path + 1 \`.gitmodules\` | \`BootstrapAssetSpace.integration.test.ts\` | revert \`appendGitmodulesEntry\` → RED |
| \`59afd046\` | mobile Add AssetSpace Maven path + 2nd \`.gitmodules\` (#3538) | \`BootstrapAssetSpaceMobile.integration.test.ts\` | revert Maven \`derivePath\` → flat → RED |
| \`14b1c592\` | apply workflow_transition advances \`ems__Effort_status\` + postActions | \`apply-workflow-transition.integration.test.ts\` | revert status \`targetProperty\` → RED |

Areas: co-location/repair-folder (create + relocate), bootstrap/assetspace-add (desktop git + mobile REST — Desktop↔Mobile parity), command execution / workflow status-transition.

### Revert-verified evidence (D1, machine-checkable)
- \`Revert-verified: @req:ec877f5e-d466-41fb-a3ae-9b8239cd7345 reverting create.ts (co-location branch) → create-co-location.integration.test.ts "resolvable isDefinedBy → ontology folder" RED\`
- \`Revert-verified: @req:8efc003c-f0b3-4572-b702-710d66b8b184 reverting FolderRepairService.repairFolder (vault.rename) → apply-ontological-archive.integration.test.ts "relocates the asset into the archive ontology folder" RED\`
- \`Revert-verified: @req:c50395c8-7eda-424d-b828-a25ad4a59756 reverting BootstrapAssetSpaceCommands.materialize (appendGitmodulesEntry) → BootstrapAssetSpace.integration.test.ts "empty vault → bootstrap → 1 .gitmodules entry" RED\`
- \`Revert-verified: @req:59afd046-eb41-4fd5-a03a-062a53d0acc5 reverting BootstrapAssetSpaceCommands.invokeAddAssetSpace (Maven derivePath → flat) → BootstrapAssetSpaceMobile.integration.test.ts "add-assetspace appends a second .gitmodules entry at the canonical Maven path (#3538)" RED\`
- \`Revert-verified: @req:14b1c592-9879-4523-bc6e-5cebd81d4ac4 reverting GroundingExecutor workflow_transition (targetProperty ems__Effort_status) → apply-workflow-transition.integration.test.ts "forward Backlog → Doing — status mutated" RED\`

(All revert-verified against origin/main \`91e90630\`.)

## Checker

\`requirements audit\`: **14 requirements / 14 bound / 100% coverage / 14 tags / 0 hard findings** (no dangling, no duplicates, no floor violations). archgate REQ-001 (well-formed-req-tags) PASS.

## Notes
- A 6th candidate (archive idempotent **precondition gating**) was **dropped** — empirically NOT revert-verifiable (the idempotent test stays GREEN even with the precondition gate forced-open, because the grounding self-no-ops on an already-archived asset → false-positive coverage). Caught by the revert-verify discipline.
- Out of scope (P3): \`ci.yml\` / \`requirements-audit.ts\` checker / branch-protection (untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)