### PR TITLE
fix(ui): onboarding step-done marker + friendlier table empty-copy + drop dead Switch-cache section

### DIFF
--- a/packages/obsidian-plugin/src/presentation/modals/FirstRunOnboardingModal.ts
+++ b/packages/obsidian-plugin/src/presentation/modals/FirstRunOnboardingModal.ts
@@ -288,9 +288,16 @@ export class FirstRunOnboardingModal extends Modal {
     // eslint-disable-next-line obsidianmd/ui/sentence-case -- "Step 1:" a11y prefix (matches the step-numbered aria-labels above) + "GitHub" proper noun
     saveBtn.setAttribute("aria-label", "Step 1: Save your GitHub token");
     saveBtn.addEventListener("click", () => {
-      void this.actions.onSavePat(input.value).catch(() => {
-        /* save failure is surfaced by the wiring (notifier); never throw here */
-      });
+      void this.actions
+        .onSavePat(input.value)
+        // Tick step 1 off only once the token actually persists (saving "" is
+        // the valid skip path and still resolves). A save failure is surfaced
+        // by the wiring's notifier and leaves the step un-ticked so the tester
+        // knows to retry.
+        .then(() => this.markStepDone(item, header))
+        .catch(() => {
+          /* save failure is surfaced by the wiring (notifier); never throw here */
+        });
     });
 
     // Test connection (RFC 0002) — verify the token reaches GitHub BEFORE the
@@ -374,7 +381,38 @@ export class FirstRunOnboardingModal extends Modal {
     // Screen-reader label spells out the step number so the action is
     // unambiguous out of visual context (P16).
     button.setAttribute("aria-label", `${step.marker}: ${step.actionLabel}`);
-    button.addEventListener("click", () => step.action());
+    button.addEventListener("click", () => {
+      step.action();
+      // Tick the step off so a tester walking the checklist can see what they
+      // have already done — especially after the sub-dialog stacks on top and
+      // they return to this panel.
+      this.markStepDone(item, header);
+    });
+  }
+
+  /**
+   * Mark a step as completed once its primary action has been invoked, so a
+   * tester can track their progress through the checklist (RFC 0002 §3.1
+   * polish). Adds an `is-done` modifier to the step `<li>` and a plain-text
+   * "✓ Done" marker into the step header.
+   *
+   * Idempotent — re-actioning a step (the sub-dialogs stack on top, so a step
+   * button can be clicked again) keeps a single marker.
+   *
+   * Accessibility (P16): the marker carries the word "Done" — never a glyph
+   * alone — and lives in a `role="status"` / `aria-live="polite"` region so
+   * assistive tech announces the completion as it happens.
+   */
+  private markStepDone(item: HTMLElement, header: HTMLElement): void {
+    if (item.classList.contains("is-done")) return;
+    item.classList.add("is-done");
+    const done = header.createEl("span", {
+      cls: "exocortex-onboarding-step-done",
+      // eslint-disable-next-line obsidianmd/ui/sentence-case -- decorative "✓" completion glyph precedes the status word "Done"; the word (never the glyph alone) carries the meaning per P16
+      text: "✓ Done",
+    });
+    done.setAttribute("role", "status");
+    done.setAttribute("aria-live", "polite");
   }
 
   override onClose(): void {

--- a/packages/obsidian-plugin/src/presentation/renderers/TableLayoutRenderer.tsx
+++ b/packages/obsidian-plugin/src/presentation/renderers/TableLayoutRenderer.tsx
@@ -423,7 +423,7 @@ export const TableLayoutRenderer: React.FC<TableLayoutRendererProps> = ({
           <tbody>
             <tr>
               <td colSpan={totalColumns} className="exo-layout-empty-message">
-                No data available
+                No items to display yet
               </td>
             </tr>
           </tbody>

--- a/packages/obsidian-plugin/src/presentation/settings/ExocortexSettingTab.ts
+++ b/packages/obsidian-plugin/src/presentation/settings/ExocortexSettingTab.ts
@@ -12,7 +12,6 @@ import {
 import { GitHubRestClient } from "@plugin/infrastructure/adapters/GitHubRestClient";
 import { LocalSecretsStore } from "@plugin/infrastructure/adapters/LocalSecretsStore";
 import { OperationsLogReader } from "@plugin/infrastructure/adapters/OperationsLogReader";
-import { SwitchCacheLayer } from "@plugin/infrastructure/adapters/SwitchCacheLayer";
 import { resolvePastedSecret } from "@plugin/presentation/settings/patClipboard";
 import { renderPatSetupHelper } from "@plugin/presentation/settings/patSetupHelper";
 import {
@@ -78,8 +77,8 @@ export class ExocortexSettingTab extends PluginSettingTab {
         "you first install the plugin.",
     );
 
-    // Profiles overview, GitHub PAT, ExoSync, Active profile, Switch cache,
-    // and the Operations log. Moved to the top of the tab (RFC 0002 §3.6).
+    // Profiles overview, GitHub PAT, ExoSync, Active profile, and the
+    // Operations log. Moved to the top of the tab (RFC 0002 §3.6).
     this.renderProfileSections(containerEl);
   }
 
@@ -641,16 +640,16 @@ export class ExocortexSettingTab extends PluginSettingTab {
   }
 
   /**
-   * Issue #3320 — render the 4 Profile sections (PAT, Active profile,
-   * Switch cache, Operations log) per RFC 0a0791c1 §B.8.
+   * Issue #3320 — render the Profile sections (PAT, Active profile,
+   * Operations log) per RFC 0a0791c1 §B.8. The non-functional «Switch cache»
+   * section (always-zero stats + a Clear-cache button that only toasted a
+   * «Phase C+D, not implemented in v3» notice) was removed as dead UI — it
+   * leaked an internal phase name and offered no working control to a tester.
    *
    * Architectural notes:
    *
-   *   - LocalSecretsStore / OperationsLogReader / SwitchCacheLayer are
-   *     constructed locally here. They are cheap, stateless wrappers over
-   *     the vault adapter (or, in SwitchCacheLayer's case, intentionally
-   *     empty in v3 — its docstring explicitly says «Settings UI wires
-   *     getCacheStats() and shows zeros — acceptable»).
+   *   - LocalSecretsStore / OperationsLogReader are constructed locally here.
+   *     They are cheap, stateless wrappers over the vault adapter.
    *
    *   - ProfileApplyManager is NOT constructed here — it would race
    *     the manager from registerProfileCommands on the persisted
@@ -678,7 +677,6 @@ export class ExocortexSettingTab extends PluginSettingTab {
     const app = this.plugin.app;
     const notifier = this.plugin.notifier;
     const secretsStore = new LocalSecretsStore({ app });
-    const switchCache = new SwitchCacheLayer();
     const operationsLog = new OperationsLogReader({ app });
 
     // ─────── Section 0 — Profile overview (Phase 5 apply-model) ───────
@@ -960,30 +958,7 @@ export class ExocortexSettingTab extends PluginSettingTab {
           "confirmation prompt guards it because it mutates the filesystem.",
       );
 
-    // ─────── Section 3 — Switch cache ───────
-    new Setting(containerEl).setName("Switch cache").setHeading();
-
-    // In v3 the SwitchCacheLayer is constructed here freshly per display()
-    // и therefore reports zeros — by design, per its docstring. Phase C+D
-    // would hoist a singleton to retain populated stats.
-    const stats = switchCache.getCacheStats();
-    const sizeMb = (stats.totalSize / (1024 * 1024)).toFixed(2);
-    new Setting(containerEl)
-      .setName("Cache stats")
-      .setDesc(
-        `${stats.count} cached AssetSpaces · ${sizeMb} MB · ` +
-          `oldest: ${stats.oldestEntry ?? "(empty)"}`,
-      )
-      .addButton((button) =>
-        button.setButtonText("Clear cache").onClick(() => {
-          notifier.info(
-            "Clear cache: Phase C+D feature, not implemented in v3. " +
-              "The cache is currently empty by construction.",
-          );
-        }),
-      );
-
-    // ─────── Section 4 — Operations log ───────
+    // ─────── Section 3 — Operations log ───────
     new Setting(containerEl).setName("Operations log").setHeading();
 
     const opsDesc = containerEl.createDiv({ cls: "setting-item-description" });

--- a/packages/obsidian-plugin/tests/unit/ExocortexSettingTab.focusProfile.test.ts
+++ b/packages/obsidian-plugin/tests/unit/ExocortexSettingTab.focusProfile.test.ts
@@ -98,14 +98,6 @@ jest.mock("@plugin/infrastructure/adapters/OperationsLogReader", () => {
   return { OperationsLogReader: MockOperationsLogReader };
 });
 
-jest.mock("@plugin/infrastructure/adapters/SwitchCacheLayer", () => ({
-  SwitchCacheLayer: class {
-    getCacheStats(): { count: number; totalSize: number; oldestEntry: string | null } {
-      return { count: 0, totalSize: 0, oldestEntry: null };
-    }
-  },
-}));
-
 describe("ExocortexSettingTab — Issue #3320 Profile sections", () => {
   let settingTab: ExocortexSettingTab;
   let mockApp: any;
@@ -242,15 +234,15 @@ describe("ExocortexSettingTab — Issue #3320 Profile sections", () => {
     settingTab.containerEl = mockContainerEl;
   });
 
-  it("renders all 4 Profile section headings in expected order", () => {
+  it("renders the Profile section headings in expected order", () => {
     settingTab.display();
     const headings = settingCalls.filter((c) => c.heading).map((c) => c.name);
     // The Display-Name section also contributes headings. We just assert
-    // что 4 expected headings appear в the correct relative order.
+    // что the expected headings appear в the correct relative order. The dead
+    // «Switch cache» section was removed, so it is no longer in the sequence.
     const expected = [
       "Profile: GitHub PAT",
       "Active profile",
-      "Switch cache",
       "Operations log",
     ];
     const filtered = headings.filter((h) =>
@@ -330,10 +322,15 @@ describe("ExocortexSettingTab — Issue #3320 Profile sections", () => {
     expect(appendCalls).toContain("Last applied: uid-deleted");
   });
 
-  it("renders the Switch cache stats row with Clear button", () => {
+  it("does NOT render the dead «Switch cache» section (removed as non-functional UI)", () => {
     settingTab.display();
+    // The section showed always-zero stats and a Clear-cache button that only
+    // toasted a «Phase C+D, not implemented in v3» notice — dead UI leaking an
+    // internal phase name. It must no longer render to a tester.
+    const cacheHeading = settingCalls.find((c) => c.name === "Switch cache");
     const cacheRow = settingCalls.find((c) => c.name === "Cache stats");
-    expect(cacheRow).toBeDefined();
+    expect(cacheHeading).toBeUndefined();
+    expect(cacheRow).toBeUndefined();
   });
 
   it("renders the Operations log <pre> element", () => {

--- a/packages/obsidian-plugin/tests/unit/ExocortexSettingTab.informationArchitecture.test.ts
+++ b/packages/obsidian-plugin/tests/unit/ExocortexSettingTab.informationArchitecture.test.ts
@@ -252,17 +252,6 @@ jest.mock("@plugin/infrastructure/adapters/OperationsLogReader", () => {
   }
   return { OperationsLogReader: MockOperationsLogReader };
 });
-jest.mock("@plugin/infrastructure/adapters/SwitchCacheLayer", () => ({
-  SwitchCacheLayer: class {
-    getCacheStats(): {
-      count: number;
-      totalSize: number;
-      oldestEntry: string | null;
-    } {
-      return { count: 0, totalSize: 0, oldestEntry: null };
-    }
-  },
-}));
 
 const INTERNAL_ID_PATTERNS: { label: string; re: RegExp }[] = [
   { label: "Vision Lock", re: /Vision Lock/ },

--- a/packages/obsidian-plugin/tests/unit/ExocortexSettingTab.test.ts
+++ b/packages/obsidian-plugin/tests/unit/ExocortexSettingTab.test.ts
@@ -212,8 +212,10 @@ describe("ExocortexSettingTab", () => {
       expect(mockContainerEl.empty).toHaveBeenCalled();
       // RFC 0002 §3.6 — count = 45 (pre-§3.6) + 3 section headings
       // («Onboarding & sync» / «Display» / «Advanced») = 48, minus the
-      // removed "Auto-execute SPARQL code blocks" toggle = 47.
-      expect(MockSetting).toHaveBeenCalledTimes(47);
+      // removed "Auto-execute SPARQL code blocks" toggle = 47, minus the
+      // removed dead «Switch cache» section (its heading + the «Cache stats»
+      // row = 2 Settings) = 45.
+      expect(MockSetting).toHaveBeenCalledTimes(45);
     });
 
     it("renders the settings-homoiconization toggle", () => {

--- a/packages/obsidian-plugin/tests/unit/presentation/modals/FirstRunOnboardingModal.test.ts
+++ b/packages/obsidian-plugin/tests/unit/presentation/modals/FirstRunOnboardingModal.test.ts
@@ -479,3 +479,110 @@ describe("FirstRunOnboardingModal — Test connection (RFC 0002)", () => {
     expect(patStatus()!.classList.contains("is-invalid")).toBe(true);
   });
 });
+
+describe("FirstRunOnboardingModal — step-completion indicator (RFC 0002 §3.1 polish)", () => {
+  function doneMarkers(): HTMLElement[] {
+    return Array.from(
+      document.querySelectorAll(".exocortex-onboarding-step-done"),
+    );
+  }
+
+  it("ticks a materialise step off with a ✓ Done marker once its action runs", () => {
+    const { actions } = makeActions();
+    new FirstRunOnboardingModal(fakeApp, actions).open();
+
+    const btn = findButton("Set up the engine")!;
+    const li = btn.closest("li.exocortex-onboarding-step") as HTMLElement;
+    // Not done before the action runs.
+    expect(li.classList.contains("is-done")).toBe(false);
+    expect(li.querySelector(".exocortex-onboarding-step-done")).toBeNull();
+
+    btn.click();
+
+    expect(li.classList.contains("is-done")).toBe(true);
+    const marker = li.querySelector(".exocortex-onboarding-step-done")!;
+    expect(marker.textContent).toContain("Done");
+  });
+
+  it("the ✓ Done marker is an aria-live status with the word Done (P16, never glyph-only)", () => {
+    const { actions } = makeActions();
+    new FirstRunOnboardingModal(fakeApp, actions).open();
+
+    findButton("Apply a profile")!.click();
+
+    const marker = doneMarkers()[0];
+    expect(marker).toBeDefined();
+    expect(marker.getAttribute("role")).toBe("status");
+    expect(marker.getAttribute("aria-live")).toBe("polite");
+    // The word "Done" carries the meaning — the ✓ glyph is decorative.
+    expect(marker.textContent).toMatch(/done/i);
+  });
+
+  it("ticks off only the actioned step — sibling steps stay un-done (independent tracking)", () => {
+    const { actions } = makeActions();
+    new FirstRunOnboardingModal(fakeApp, actions).open();
+
+    findButton("Set up the engine")!.click();
+
+    // Exactly one marker across the whole checklist.
+    expect(doneMarkers()).toHaveLength(1);
+    const engineLi = findButton("Set up the engine")!.closest("li")!;
+    const registryLi = findButton("Add the AssetSpace registry")!.closest("li")!;
+    expect(engineLi.classList.contains("is-done")).toBe(true);
+    expect(registryLi.classList.contains("is-done")).toBe(false);
+  });
+
+  it("re-actioning a step keeps a single ✓ Done marker (idempotent — sub-dialogs let a step be re-clicked)", () => {
+    const { actions } = makeActions();
+    new FirstRunOnboardingModal(fakeApp, actions).open();
+
+    const btn = findButton("Add the AssetSpace registry")!;
+    btn.click();
+    btn.click();
+    btn.click();
+
+    const li = btn.closest("li.exocortex-onboarding-step") as HTMLElement;
+    expect(li.querySelectorAll(".exocortex-onboarding-step-done")).toHaveLength(1);
+  });
+
+  it("ticks step 1 off once the token save resolves (incl. the empty skip path)", async () => {
+    const { actions } = makeActions();
+    new FirstRunOnboardingModal(fakeApp, actions).open();
+
+    const saveBtn = findButton("Save token")!;
+    const patLi = saveBtn.closest(
+      "li.exocortex-onboarding-step-pat",
+    ) as HTMLElement;
+    expect(patLi.classList.contains("is-done")).toBe(false);
+
+    saveBtn.click();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(patLi.classList.contains("is-done")).toBe(true);
+    expect(
+      patLi.querySelector(".exocortex-onboarding-step-done")?.textContent,
+    ).toContain("Done");
+  });
+
+  it("does NOT tick step 1 off when the token save fails (tester should retry)", async () => {
+    const { actions } = makeActions({
+      onSavePat: async () => {
+        throw new Error("disk full");
+      },
+    });
+    new FirstRunOnboardingModal(fakeApp, actions).open();
+
+    const saveBtn = findButton("Save token")!;
+    const patLi = saveBtn.closest(
+      "li.exocortex-onboarding-step-pat",
+    ) as HTMLElement;
+
+    saveBtn.click();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(patLi.classList.contains("is-done")).toBe(false);
+    expect(patLi.querySelector(".exocortex-onboarding-step-done")).toBeNull();
+  });
+});

--- a/packages/obsidian-plugin/tests/unit/presentation/renderers/TableLayoutRenderer.test.tsx
+++ b/packages/obsidian-plugin/tests/unit/presentation/renderers/TableLayoutRenderer.test.tsx
@@ -143,7 +143,7 @@ describe("TableLayoutRenderer", () => {
         />
       );
 
-      expect(screen.getByText("No data available")).toBeInTheDocument();
+      expect(screen.getByText("No items to display yet")).toBeInTheDocument();
     });
 
     it("still renders column headers in empty state", () => {


### PR DESCRIPTION
Three disjoint fresh-tester UI/UX polish items from the alpha audit (vault node `f4863294`, `al-alpha-polish-audit`). All verified against fresh `origin/main`. No P1 blockers — pure cosmetic / dead-UI cleanup.

## G1 — Onboarding step-completion indicator
`FirstRunOnboardingModal` — the 5-step setup checklist stayed visually static; after running a step it looked identical, so a tester (especially after the sub-dialogs stack on top) lost track of progress. Now each step is ticked off with an a11y **`✓ Done`** marker once its action runs:
- `role="status"` + `aria-live="polite"`; the word **"Done"** carries the meaning (never the glyph alone) per P16.
- Step 1 (token) ticks only on a **successful** save (the empty skip-path still resolves; a save failure leaves it un-ticked so the tester retries). Steps 2–5 tick on action.
- Idempotent — re-clicking a step (sub-dialogs let a step be re-actioned) keeps a single marker; tracking is per-step independent.

## G2 — Table empty-state copy tone
`TableLayoutRenderer` empty-state `No data available` → **`No items to display yet`** — warmer, consistent with the Relations (`No related assets yet`) and Calendar (`No events to display…`) empty-states.

## G3 — Drop dead "Switch cache" settings section
`ExocortexSettingTab` — the **Switch cache** section was dead UI: "Cache stats" always showed zeros (the `SwitchCacheLayer` is rebuilt per `display()` by construction) and the "Clear cache" button only toasted *"Phase C+D feature, not implemented in v3."* — leaking an internal phase name and offering no working control. Removed the section + its now-unused import/declaration; updated docstrings.
> The separate `ExocortexPlugin` "clear switch cache" command is out of scope (untouched).

## Tests
- G1: new step-completion suite — 6 cases (marker appears on action; a11y status/aria-live + word "Done"; independent per-step; idempotent; step-1-on-save-success; step-1-NOT-on-save-failure).
- G2: empty-copy assertion updated.
- G3: stats-row test flipped to assert the section is **gone**; "all settings" count 47→45; expected-headings sequence drops "Switch cache"; dead `SwitchCacheLayer` mock removed.
- typecheck clean; eslint `--max-warnings=0` clean; 6 affected suites green (101 tests); archgate 22/22.

🤖 Generated with [Claude Code](https://claude.com/claude-code)