### PR TITLE
docs: bump Getting-Started minimum plugin version to v16.111.0 (EKA flow)

### DIFF
--- a/docs/tutorials/Getting-Started.md
+++ b/docs/tutorials/Getting-Started.md
@@ -6,14 +6,14 @@
 
 ## Requirements
 
-Exocortex has been verified to work with the following minimum versions. Older versions are known to miss critical fixes for grounding, createAsset, and IRI resolution.
+Exocortex has been verified to work with the following minimum versions. Older versions miss the EKA setup commands this guide walks you through (and earlier fixes for grounding, createAsset, and IRI resolution).
 
-| Component            | Minimum version | Recommended    | Why                                                                                                                               |
-| -------------------- | --------------- | -------------- | --------------------------------------------------------------------------------------------------------------------------------- |
-| **Obsidian**         | 1.5.0           | 1.7.0 or newer | Plugin uses APIs available since 1.5.                                                                                             |
-| **Exocortex plugin** | v15.90.9        | Latest release | Fixes for createAsset, IRI resolution, targetValue.                                                                               |
-| **git** (CLI)        | Optional        | Latest         | Only needed for git-backed vaults — used to register pulled AssetSpaces as git submodules. Non-git vaults work in file-only mode. |
-| **BRAT**             | Latest          | Latest         | Delivers plugin updates automatically.                                                                                            |
+| Component            | Minimum version | Recommended    | Why                                                                                                                                                                                                                                                                                      |
+| -------------------- | --------------- | -------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Obsidian**         | 1.5.0           | 1.7.0 or newer | Plugin uses APIs available since 1.5.                                                                                                                                                                                                                                                    |
+| **Exocortex plugin** | v16.111.0       | Latest release | This guide's setup flow uses the EKA command names it ships («Set up the engine», «Add a knowledge pack», «Apply profile») and the Bootstrap → registry → profiles → Create Instance path. Older builds expose differently-named or missing commands, so the steps below will not match. |
+| **git** (CLI)        | Optional        | Latest         | Only needed for git-backed vaults — used to register pulled AssetSpaces as git submodules. Non-git vaults work in file-only mode.                                                                                                                                                        |
+| **BRAT**             | Latest          | Latest         | Delivers plugin updates automatically.                                                                                                                                                                                                                                                   |
 
 ### How to check your versions
 


### PR DESCRIPTION
**G4** from the alpha UI/UX audit (vault node `f4863294`).

The Getting-Started Requirements table listed **v15.90.9** as the minimum Exocortex plugin version — but that predates the entire EKA setup flow the guide walks through. A fresh tester installing the stated minimum would not find a single command from the guide.

Verified against `origin/main`: the guide instructs testers to run the groomed command names **«Exocortex: Set up the engine»** and **«Add a knowledge pack»**, which were introduced in **v16.111.0** (commit `b5b08bdf`). Earlier builds expose differently-named or missing commands.

- Min version `v15.90.9` → **`v16.111.0`**, recommended stays `Latest release`.
- Updated the "Why" cell + the section intro to reflect the EKA Bootstrap → registry → profiles → Create Instance path rather than the stale grounding/createAsset/IRI rationale.

Docs-only; no code change. (`prettier --write` re-aligned the markdown table columns since the "Why" cell widened.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)