### PR TITLE
test(profile): harden ProfileApplyManager data-integrity edge-cases

### DIFF
--- a/packages/obsidian-plugin/tests/unit/ProfileApplyManager.apply.test.ts
+++ b/packages/obsidian-plugin/tests/unit/ProfileApplyManager.apply.test.ts
@@ -1330,6 +1330,133 @@ describe("ProfileApplyManager.applyProfile", () => {
       expect((commits[0].args[0] as string)).toContain("apply");
     });
   });
+
+  // F6 — the cache-verify gate is the zero-loss safety net of the desktop git
+  // path: an AssetSpace is cached BEFORE it is torn down, so a destroy can only
+  // run for content we have already backed up. The cache layer verifies its own
+  // archive before returning (F6 in RFC 22b50a17), so a `cache()` rejection
+  // means "could not back this up" and the destroy MUST NOT proceed.
+  //
+  // These pin the invariant the `FakeCacheLayer.failCache` switch was built for
+  // but no test exercised: a caching failure aborts the WHOLE destroy phase the
+  // moment it happens, leaving the vault's to-destroy AssetSpaces on disk
+  // (nothing deinit'd / no working tree removed). Paired revert-verify proves
+  // the gate is load-bearing — with caching healthy the same scenario tears the
+  // AssetSpaces down.
+  describe("F6 — cache-verify gate (cannot destroy what cannot be cached)", () => {
+    it("aborts the destroy phase the instant caching a to-destroy AssetSpace fails — zero destroys, vault intact", async () => {
+      const { mgr, gitOps, cacheLayer } = setup({
+        targetUid: "target",
+        sourceUid: null,
+        // Target = floor only → ems + kpc are torn down (pure-destroy, no pull).
+        targetIncludes: [
+          TS_FLOOR_AS_UID_EXO,
+          TS_FLOOR_AS_UID_EXOCMD,
+          TS_FLOOR_AS_UID_SHARED_IDENTITIES,
+        ],
+        materialized: [
+          "ems-uid",
+          "kpc-uid",
+          TS_FLOOR_AS_UID_EXO,
+          TS_FLOOR_AS_UID_EXOCMD,
+          TS_FLOOR_AS_UID_SHARED_IDENTITIES,
+        ],
+      });
+      cacheLayer.failCache = true;
+
+      await expect(mgr.applyProfile("target")).rejects.toThrow(
+        /cache failure/i,
+      );
+
+      // CORE INVARIANT: a cache failure aborts BEFORE any teardown. Not a single
+      // AssetSpace may be deinit'd or have its working tree removed — the vault's
+      // to-destroy AssetSpaces are still fully on disk (zero data loss).
+      expect(
+        gitOps.calls.filter((c) => c.op === "submoduleDeinit").length,
+      ).toBe(0);
+      expect(
+        gitOps.calls.filter((c) => c.op === "removeWorkingTree").length,
+      ).toBe(0);
+      expect(
+        gitOps.calls.filter((c) => c.op === "removeGitModulesDir").length,
+      ).toBe(0);
+      // No commit either — the mutation never reached the commit step.
+      expect(gitOps.calls.filter((c) => c.op === "commit").length).toBe(0);
+    });
+
+    it("REVERT-VERIFY: with caching healthy the same profile DOES tear the AssetSpaces down (gate is load-bearing)", async () => {
+      const { mgr, gitOps, cacheLayer } = setup({
+        targetUid: "target",
+        sourceUid: null,
+        targetIncludes: [
+          TS_FLOOR_AS_UID_EXO,
+          TS_FLOOR_AS_UID_EXOCMD,
+          TS_FLOOR_AS_UID_SHARED_IDENTITIES,
+        ],
+        materialized: [
+          "ems-uid",
+          "kpc-uid",
+          TS_FLOOR_AS_UID_EXO,
+          TS_FLOOR_AS_UID_EXOCMD,
+          TS_FLOOR_AS_UID_SHARED_IDENTITIES,
+        ],
+      });
+      cacheLayer.failCache = false; // healthy cache → destroy proceeds.
+
+      await mgr.applyProfile("target");
+
+      // Both non-floor AssetSpaces cached then torn down (the gate let them through).
+      expect(cacheLayer.cachedCalls.length).toBe(2);
+      expect(
+        gitOps.calls.filter((c) => c.op === "submoduleDeinit").length,
+      ).toBe(2);
+      expect(
+        gitOps.calls.filter((c) => c.op === "removeWorkingTree").length,
+      ).toBe(2);
+    });
+  });
+
+  // Concurrent-switch guard on the DESTRUCTIVE apply-mutation path. The lock
+  // contention suite in ProfileApplyManager.test.ts only covers the pure
+  // (non-destructive) reindex path; this pins that a second apply, started
+  // while a foreign session still holds the persistent switch-lock, refuses to
+  // mutate the filesystem (no AssetSpace is torn down while another switch is
+  // in flight — the data-loss race the lock exists to prevent).
+  describe("Concurrent apply — lock guard (desktop git path)", () => {
+    it("refuses a second apply while the lock is held — no AssetSpace torn down", async () => {
+      const { mgr, gitOps, app, localDataStore } = setup({
+        targetUid: "target",
+        sourceUid: null,
+        targetIncludes: [
+          TS_FLOOR_AS_UID_EXO,
+          TS_FLOOR_AS_UID_EXOCMD,
+          TS_FLOOR_AS_UID_SHARED_IDENTITIES,
+        ],
+        materialized: [
+          "ems-uid",
+          TS_FLOOR_AS_UID_EXO,
+          TS_FLOOR_AS_UID_EXOCMD,
+          TS_FLOOR_AS_UID_SHARED_IDENTITIES,
+        ],
+      });
+      // A foreign session (distinct pid) holds a FRESH (non-stale) lock.
+      const foreignLock = new PluginLockManager({ app, pid: "foreign-pid" });
+      expect(await foreignLock.acquireLock("foreign-apply")).toBe(true);
+
+      await expect(mgr.applyProfile("target")).rejects.toThrow(/lock held/i);
+
+      // The mutation never started: ems was NOT torn down (zero destroys), so a
+      // concurrent apply cannot race a half-applied filesystem.
+      expect(
+        gitOps.calls.filter((c) => c.op === "submoduleDeinit").length,
+      ).toBe(0);
+      expect(
+        gitOps.calls.filter((c) => c.op === "removeWorkingTree").length,
+      ).toBe(0);
+      // The active profile is untouched (the failed apply never persisted).
+      expect(localDataStore.getActiveProfileUid()).toBe(null);
+    });
+  });
 });
 
 /**

--- a/packages/obsidian-plugin/tests/unit/ProfileApplyManager.restAtomicity.test.ts
+++ b/packages/obsidian-plugin/tests/unit/ProfileApplyManager.restAtomicity.test.ts
@@ -576,4 +576,79 @@ describe("ProfileApplyManager REST apply atomicity (#3548)", () => {
       expect(restMount.unmounted).toEqual([folderOf("kpc-uid")]);
     });
   });
+
+  // Concurrent-switch guard on the production REST mutation path. A second apply
+  // started while a foreign session still holds the persistent switch-lock must
+  // refuse to touch the filesystem — the lock is the only thing preventing two
+  // applies from mutating the same AssetSpace folders simultaneously (the
+  // race that corrupts mount-state / loses data). The reindex-only lock
+  // contention is covered in ProfileApplyManager.test.ts; this pins the
+  // destructive mount/unmount path.
+  describe("concurrent apply — lock guard (REST production path)", () => {
+    it("refuses a second apply while the lock is held — no mount/unmount, pre-apply state intact", async () => {
+      const { mgr, restMount, localDataStore, fsFolders, app } = setup({
+        targetIncludes: [...ALL_FLOOR_UIDS, "ems-uid"],
+        materialized: [...ALL_FLOOR_UIDS, "kpc-uid"],
+      });
+      // A foreign session (distinct pid) holds a FRESH (non-stale) lock.
+      const foreignLock = new PluginLockManager({ app, pid: "foreign-pid" });
+      expect(await foreignLock.acquireLock("foreign-apply")).toBe(true);
+
+      await expect(mgr.applyProfileViaRest("target")).rejects.toThrow(
+        /lock held/i,
+      );
+
+      // Zero filesystem mutation: nothing mounted, nothing unmounted.
+      expect(restMount.mounted).toEqual([]);
+      expect(restMount.unmounted).toEqual([]);
+      // The pre-apply mount-state is fully intact — kpc still on disk, ems not.
+      expect(fsFolders.has(folderOf("kpc-uid"))).toBe(true);
+      expect(fsFolders.has(folderOf("ems-uid"))).toBe(false);
+      // Active profile unchanged + in-progress flag never raised.
+      expect(localDataStore.getActiveProfileUid()).toBe("source");
+      expect(localDataStore.isSwitchInProgress()).toBe(false);
+    });
+  });
+
+  // A best-effort rollback must never MASK the original failure. When a mount
+  // fails AND the rollback unmount of that freshly-pulled partial folder itself
+  // throws, the apply must still reject with the ROOT cause (the mount error),
+  // not the secondary rollback error — so the user is told why the apply failed,
+  // and the to-destroy set (real user data) is still never touched (the failure
+  // happened in the mount phase, before any unmount of the old set).
+  describe("rollback unmount failure never masks the original mount error", () => {
+    it("propagates the mount error (not the rollback-unmount error) and leaves the to-destroy set intact", async () => {
+      const { mgr, restMount, localDataStore, fsFolders } = setup({
+        targetIncludes: [...ALL_FLOOR_UIDS, "ems-uid"],
+        materialized: [...ALL_FLOOR_UIDS, "kpc-uid"],
+      });
+      // The only to-materialize mount fails, AND its rollback unmount also throws.
+      restMount.failMountOn.add(folderOf("ems-uid"));
+      restMount.failUnmountOn.add(folderOf("ems-uid"));
+
+      // The rejection surfaces the ROOT cause — the mount error — not the
+      // secondary rollback-unmount error (rollbackRestMounts journals each
+      // unmount failure but never rethrows it). Capture the error ONCE — a
+      // second apply would run against the partial folder left on disk and
+      // diverge — and assert on its message directly.
+      let caught: unknown;
+      try {
+        await mgr.applyProfileViaRest("target");
+      } catch (e) {
+        caught = e;
+      }
+      expect(caught).toBeInstanceOf(Error);
+      const message = (caught as Error).message;
+      expect(message).toMatch(/mount failed/);
+      expect(message).not.toMatch(/unmount failed/);
+
+      // The to-destroy AssetSpace (the only real user data here) was never
+      // reached — the failure happened in the mount phase, before any unmount.
+      expect(restMount.unmounted).not.toContain(folderOf("kpc-uid"));
+      expect(fsFolders.has(folderOf("kpc-uid"))).toBe(true);
+      // State is left clean despite the double failure.
+      expect(localDataStore.getActiveProfileUid()).toBe("source");
+      expect(localDataStore.isSwitchInProgress()).toBe(false);
+    });
+  });
 });


### PR DESCRIPTION
## What

Coverage-hardening for the **profile-apply** data-mutating paths (`ProfileApplyManager`). Profile apply materialises/destroys AssetSpace folders on disk, so a data-loss bug here = lost personal assets — alpha-critical. Same pattern as the StructuredMerger zero-loss hardening (#3665).

**Source unchanged** — tests only (3 previously-unexercised invariants).

## Gaps pinned

1. **F6 cache-verify gate (desktop git path)** — `cacheLayer.cache()` failure on a to-destroy AssetSpace aborts the WHOLE destroy phase the instant it happens: **zero** `submoduleDeinit`/`removeWorkingTree`, vault intact (you cannot destroy what you could not back up). The `FakeCacheLayer.failCache` switch existed in the harness but **no test ever flipped it** — the gate was dead-covered. Paired **revert-verify** sibling proves it is load-bearing (healthy cache → the same profile DOES tear the AssetSpaces down). Empirically revert-verified against source: swallowing the cache throw → test goes RED.

2. **Concurrent-apply lock guard on BOTH destructive mutation paths** (`runApplyMutation` desktop + `runRestApplyMutation` REST production path) — a second apply started while a foreign session holds the persistent switch-lock refuses to touch the filesystem (no destroy / no mount/unmount; pre-apply mount-state intact). The existing lock-contention suite only covered the **non-destructive reindex** path.

3. **`rollbackRestMounts` never masks the original error** — when a mount fails AND its rollback unmount also throws, the apply still rejects with the **root** mount error (not the secondary unmount error), and the to-destroy set (real user data) is never reached.

## Verification

- 183/183 profile/switch unit tests green (`ProfileApplyManager*`, `ProfileSwitch`, `SwitchCacheLayer`, `ProfileWiring`, …).
- `npm run check:types` clean (exit 0, 0 TS errors).
- Archgate 22/22 pass.
- F6 gate revert-verified against source (RED when gate disabled, GREEN when restored).

## Scope

Strictly `ProfileApplyManager` + switch/recovery/cache **tests**. No production change, no ExoSync/req/docs/plugin-UI touched.