### PR TITLE
docs(troubleshooting): alpha-tester operational guide + concepts glossary

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -22,6 +22,7 @@ docs kept at root) is in **[TAXONOMY.md](TAXONOMY.md)**.
 
 - [../README.md](../README.md) — product overview & feature front door
 - [Getting-Started.md](tutorials/Getting-Started.md) — install, first vault, core concepts
+- [explanation/Concepts.md](explanation/Concepts.md) — tester's glossary (AssetSpace, Profile, mount-state, PAT, ExoSync, …)
 - [../VISION.md](../VISION.md) — product vision + cross-cutting invariants (UI/CLI parity, Desktop↔Mobile parity)
 - [../CONTRIBUTING.md](../CONTRIBUTING.md) — contributor setup, PR workflow, coding standards
 
@@ -31,7 +32,7 @@ docs kept at root) is in **[TAXONOMY.md](TAXONOMY.md)**.
 - [Plugin-Development-Guide.md](how-to/Plugin-Development-Guide.md) — building/extending the plugin
 - [WORKFLOW_CUSTOMIZATION.md](how-to/WORKFLOW_CUSTOMIZATION.md) — customizing status workflows
 - [ONTOLOGY_EXTENSION.md](how-to/ONTOLOGY_EXTENSION.md) — adding classes/properties
-- [Troubleshooting.md](how-to/Troubleshooting.md) — **user** troubleshooting (common issues & fixes)
+- [Troubleshooting.md](how-to/Troubleshooting.md) — **user** troubleshooting: setup/auth/sync (PAT, ExoSync, Apply profile, bootstrap, mobile) + layout/usage fixes
 - [profile.md](explanation/profile.md) — Profile pitch + Apply-profile (mount-state) usage
 - [exosync.md](how-to/exosync.md) — ExoSync usage (`Exocortex: Sync`, structured merge, conflict quarantine)
 - [templating.md](how-to/templating.md) — homoiconic templating: insert tokens, insert template blocks, `body_template` grounding
@@ -50,6 +51,7 @@ docs kept at root) is in **[TAXONOMY.md](TAXONOMY.md)**.
 ## Explanation & Architecture
 
 - [../ARCHITECTURE.md](../ARCHITECTURE.md) — layering, monorepo, clean architecture
+- [Concepts.md](explanation/Concepts.md) — **tester's glossary**: AssetSpace, Profile, mount-state, TS-floor, homoiconicity, co-location, UID-canon, PAT, ExoSync, FileSpace, BRAT (one-liners + deep-doc links)
 - [assetspace-sdk-topology.md](explanation/assetspace-sdk-topology.md) — exo-as-SDK: what an AssetSpace is, why there are many `exoas-*` repos, what a Profile is
 - [CROSS_RUNTIME_PARITY.md](explanation/CROSS_RUNTIME_PARITY.md) — validator instance of the UI/CLI Parity Invariant
 - [settings-homoiconization.md](explanation/settings-homoiconization.md) — plugin settings as `exo__Setting` vault assets

--- a/docs/explanation/Concepts.md
+++ b/docs/explanation/Concepts.md
@@ -107,7 +107,8 @@ Synchronizes your mounted AssetSpaces directly against their GitHub repos over
 the REST API — no Obsidian Sync subscription and no `git` binary, so the same
 path works on desktop and iOS. One **`Exocortex: Sync`** runs pull → merge → push
 per repo; conflicts it cannot safely merge go to **quarantine** and re-derive
-every sync until you make the two sides converge.
+every sync until you resolve them (run **`Exocortex: Resolve sync conflicts`**,
+or converge the two sides by hand).
 → [exosync.md](../how-to/exosync.md)
 
 ### FileSpace — _an attachments space_

--- a/docs/explanation/Concepts.md
+++ b/docs/explanation/Concepts.md
@@ -1,0 +1,135 @@
+# Concepts — a tester's glossary
+
+> **Audience:** alpha testers and new users.
+> **What this is:** a fast, plain-language tour of the handful of Exocortex
+> concepts you meet during setup and troubleshooting. Each entry links to the
+> deep doc if you want the full story.
+
+For the hands-on install path see [Getting Started](../tutorials/Getting-Started.md);
+for the architectural narrative behind the vault split see
+[assetspace-sdk-topology.md](assetspace-sdk-topology.md).
+
+---
+
+## The one-line mental model
+
+**Exo is an SDK; your vault is the data.** The engine — the Obsidian plugin plus
+the `@kitelev/exocortex-cli` — ships as code and a small core of class/property
+definitions. Everything _about your domain_ (notes, projects, ontologies, and
+even the action buttons and settings) lives in your vault **as data**. The
+product is the vault _plus_ the engine, and every client can drive the whole
+system. See [VISION.md](../../VISION.md).
+
+---
+
+## Glossary
+
+### AssetSpace — _a library (a jar)_
+
+A git-backed repository of vault assets, mounted under
+`assetspaces/<owner>/<repo>/`. It is the unit of **packaging, sharing, and
+mounting**: one ontology and its instances, one team's shared data, or your
+private notes — each a separate repo with its own GitHub visibility. An
+AssetSpace is either **materialized** (present on disk, indexed into the graph)
+or **unmounted** (absent — invisible to search and SPARQL). The axis of
+separation is _sharing-audience_, not topic — that is why there are many
+`exoas-*` repos.
+→ [assetspace-sdk-topology.md § What is an AssetSpace](assetspace-sdk-topology.md#1-what-is-an-assetspace)
+
+### Profile — _a BOM / manifest_
+
+A vault-declared, named set of AssetSpaces to mount: an `exo__Profile` asset with
+`exo__Profile_includes` (the AssetSpaces it activates) and optional
+`exo__Profile_imports` (a parent profile to compose). There is **one** operation
+over it — **`Exocortex: Apply profile`** — and it performs a **mount-state strict
+replace**: materialize the profile's effective set, unmount everything else.
+Switching a _work_ context to a _personal_ one is a single command that
+physically swaps which repositories exist on disk, so privacy, focus, and index
+size all follow from the mount state.
+→ [profile.md](profile.md) · [assetspace-sdk-topology.md § What is a Profile](assetspace-sdk-topology.md#3-what-is-a-profile)
+
+### Mount-state
+
+"Materialized" means the AssetSpace folder exists on disk — and the on-disk
+directory is the **source of truth** for what's active, **not** `.gitmodules`
+membership (the `.gitmodules` entry is kept as a per-vault URL registry even
+while an AssetSpace is unmounted, so re-applying a profile can re-pull it).
+Apply reconciles the on-disk set to the target profile's effective set.
+→ [profile.md](profile.md)
+
+### TS-floor — _the always-mounted minimum_
+
+The core AssetSpace the engine cannot run without — currently `{exo}` (the
+class/property definitions). It is **never unmounted**, and applying a profile
+that omits it is **refused** (not silently repaired), because stripping the floor
+would self-brick the plugin. `exocmd` (the UI-command library that draws the
+action buttons) and shared-identity spaces are **optional** add-ons, not floor
+members — a read-only / SPARQL-only vault works without them.
+→ [profile.md](profile.md)
+
+### Homoiconicity — _behaviour is data, not code_
+
+Borrowing from LISP: the things you should be able to change **without editing
+source code** — which buttons appear, layout structure, which classes/properties
+exist, query logic for analytics — are all described by **vault assets (RDF)**,
+not hardcoded. Hardcode is reserved for the engine, platform integration, and
+graph-integrity guards. This is why action buttons come from the `exocmd`
+AssetSpace and why plugin settings show up as `exo__Setting` notes in your vault.
+→ [VISION.md](../../VISION.md) · [settings-homoiconization.md](settings-homoiconization.md) · [CLAUDE.md → Homoiconicity Invariant](../../CLAUDE.md)
+
+### Co-location
+
+Every asset physically lives in the folder of the ontology its
+`exo__Asset_isDefinedBy` points at. Keeping an asset next to the ontology that
+defines it is an invariant (enforced when notes are written), so an AssetSpace
+stays a self-contained, movable package.
+
+### UID-canon — _why files are named by UUID_
+
+Most assets are filenamed by their `exo__Asset_uid` (a UUID), with the
+human-readable name in `exo__Asset_label`. UUID filenames give every asset a
+stable identity that survives renames and bridges the two IRI schemes the engine
+uses — so links never break when you rename a note. (A short whitelist — the
+daily / weekly calendar notes — keeps date-based filenames so calendar plugins
+still recognise them.)
+→ [CLAUDE.md → UUID-canon TBox](../../CLAUDE.md)
+
+### PAT — _GitHub Personal Access Token_
+
+A fine-grained GitHub token the plugin uses to **pull private** AssetSpaces and
+**push** your changes. It is stored device-local in `data.local.json` (never
+synced, never committed). The fully-public starter onboarding needs none.
+→ [Getting Started → Plugin Settings](../tutorials/Getting-Started.md#plugin-settings) · [Troubleshooting → GitHub auth](../how-to/Troubleshooting.md#github-auth--personal-access-token-pat)
+
+### ExoSync — _GitHub-backed vault sync_
+
+Synchronizes your mounted AssetSpaces directly against their GitHub repos over
+the REST API — no Obsidian Sync subscription and no `git` binary, so the same
+path works on desktop and iOS. One **`Exocortex: Sync`** runs pull → merge → push
+per repo; conflicts it cannot safely merge go to **quarantine** and re-derive
+every sync until you make the two sides converge.
+→ [exosync.md](../how-to/exosync.md)
+
+### FileSpace — _an attachments space_
+
+Like an AssetSpace, but for opaque binary blobs (`exo__FileSpace`): its contents
+are never parsed into the graph. Conflicts are deterministic remote-wins, so
+file-mode sync requires a quarantine repo to preserve the losing local copy.
+→ [exosync.md § FileSpaces (attachments)](../how-to/exosync.md#filespaces-attachments)
+
+### BRAT
+
+The community plugin that installs and auto-updates Exocortex straight from its
+GitHub releases (Exocortex is not in the Obsidian community-plugin store yet).
+Adding and updating the plugin run through BRAT's **command-palette** actions.
+→ [Getting Started → Install via BRAT](../tutorials/Getting-Started.md#step-1-install-via-brat)
+
+---
+
+## Where to go next
+
+- [Getting Started](../tutorials/Getting-Started.md) — install + first vault, hands-on.
+- [assetspace-sdk-topology.md](assetspace-sdk-topology.md) — the full "exo is an SDK" narrative.
+- [profile.md](profile.md) — the complete Profile model (apply semantics, atomicity, recovery).
+- [exosync.md](../how-to/exosync.md) — syncing mounted AssetSpaces with their GitHub remotes.
+- [Troubleshooting → Setup, auth & sync](../how-to/Troubleshooting.md#setup-auth--sync) — when something operational goes wrong.

--- a/docs/how-to/Troubleshooting.md
+++ b/docs/how-to/Troubleshooting.md
@@ -1,7 +1,232 @@
 # User Troubleshooting Guide
 
 **Common issues and solutions for Exocortex users.**
-For **development / CI** issues, see [DEV-TROUBLESHOOTING.md](../../DEV-TROUBLESHOOTING.md).
+
+This page has two halves:
+
+- **[Setup, auth & sync](#setup-auth--sync)** — the _operational_ issues you hit
+  while getting a vault running: GitHub auth/PAT, ExoSync conflicts, applying a
+  profile, bootstrapping, and mobile. **Start here if you're an early tester.**
+- **Layout & usage** (the sections below the divider) — display/behaviour issues
+  once a vault is up: layouts, buttons, wiki-links, daily tasks, graph view.
+
+> **First-run hiccups during install** (no buttons yet, grey class links, plugin
+> not loading, BRAT URL doing nothing) are walked through in the
+> [Getting Started → Troubleshooting](../tutorials/Getting-Started.md#troubleshooting)
+> section — that's the place for setup-time problems.
+>
+> For new vocabulary (AssetSpace, Profile, mount-state, TS-floor, PAT, …) see the
+> [Concepts glossary](../explanation/Concepts.md).
+>
+> For **development / CI** issues, see [DEV-TROUBLESHOOTING.md](../../DEV-TROUBLESHOOTING.md).
+
+---
+
+## Setup, auth & sync
+
+These are the issues early testers hit most. They are grouped by the command
+that surfaces them: **GitHub auth**, **Sync**, **Apply profile**, **Bootstrap**,
+and **Mobile**.
+
+### GitHub auth — Personal Access Token (PAT)
+
+**Problem**: Adding or syncing a **private** AssetSpace fails with _"repository
+does not exist"_, **404**, or **401**.
+
+**Cause**: A **fine-grained** PAT whose repository allowlist doesn't cover the
+repo gets a **404** from GitHub (it hides the existence of repos you can't see) —
+so a "does not exist" error usually means the token is _missing that repo_, not
+that the repo is gone. A genuine **401/403** means the token is expired, revoked,
+or under-scoped. Public onboarding (`$$core`, the registry, the profiles space)
+needs **no** PAT at all.
+
+**Solutions**:
+
+1. **Settings → Exocortex → GitHub PAT.** Use a **fine-grained** token from
+   [github.com/settings/personal-access-tokens/new](https://github.com/settings/personal-access-tokens/new)
+   (not the classic `/settings/tokens/new` page). Scope it to your `exoas-*`
+   repos with a **per-repository allowlist** and grant exactly:
+
+   | Permission   | Access         | Why                                            |
+   | ------------ | -------------- | ---------------------------------------------- |
+   | **Contents** | Read and write | Pull private AssetSpaces and push your commits |
+   | **Metadata** | Read-only      | Mandatory baseline (GitHub auto-selects it)    |
+
+2. Click **Save PAT**, then **Test connection** to confirm it reaches GitHub
+   before you rely on it.
+3. **If a private repo "does not exist"** during Apply/Sync, check the token's
+   repository allowlist first — that is the most common cause.
+
+The token is stored device-local in
+`.obsidian/plugins/exocortex/data.local.json` (key `pat`); the `.local.` infix
+keeps it out of Obsidian Sync replication, and it is never committed.
+
+---
+
+### "I saved a PAT but the plugin still acts unauthenticated"
+
+**Problem**: You entered a valid PAT, but a Bootstrap / Add-pack / Apply of a
+private repo still fails as if no token were set.
+
+**Cause & fix**:
+
+- **Bootstrap, Add a knowledge pack, and Sync read the _currently-stored_ PAT at
+  command time** — a freshly-saved token works **without a reload** (fixed in
+  [#3382](https://github.com/kitelev/exocortex/issues/3382)). Just re-run the
+  command.
+- **One path captures the PAT at plugin onload: the mobile profile-mount path.**
+  If, on mobile, an **Apply profile** of a private profile still pulls
+  unauthenticated after you saved the PAT, **reload Obsidian** (Cmd/Ctrl + P →
+  "Reload app without saving") so the new PAT is picked up, then re-apply.
+
+---
+
+### Sync (`Exocortex: Sync`)
+
+**Problem**: `Exocortex: Sync` reports an error status, or conflicts pile up.
+
+**Reading the result**: One run syncs every mounted AssetSpace (pull → merge →
+push, best-effort). The summary notice shows `pushed / pulled / merged /
+quarantined`; per-repo detail goes to the developer console
+(`[ExoSync] …`, Ctrl/Cmd + Shift + I). Common statuses:
+
+1. **`auth-required` (HTTP 401 / 403)** — the PAT is expired, revoked, or
+   under-scoped. (A _fine-grained_ PAT missing a private repo surfaces as a
+   generic **404**, not `auth-required` — see [GitHub auth](#github-auth--personal-access-token-pat) above.)
+2. **`full-conflict`** — the first sync over a tree that already diverged from
+   the remote, or a watermark whose base commit no longer matches the remote
+   (e.g. after a backup restore). **Nothing is touched.** Align the local tree
+   with the remote (or delete the watermark file
+   `exosync-watermarks.local.json` in the plugin folder) and re-sync.
+3. **Conflicts → quarantine** — a real conflict is preserved, not guessed; it
+   **re-derives on every sync until you resolve it**. There is **no dedicated
+   resolver UI yet** — resolve by making the two sides **converge** (edit the
+   local file and/or the remote so they agree); once they match, the pin clears
+   and the entry auto-tombstones as `resolved`. Optionally set a
+   **Quarantine repo URL** (Settings → Exocortex → ExoSync) to keep conflict
+   copies cross-device. **FileSpaces refuse to sync without a quarantine repo**,
+   because their remote-wins policy would otherwise destroy the only local copy.
+4. **First sync is safe** — on a freshly-mounted AssetSpace the first sync just
+   bootstraps the baseline; nothing is overwritten unless the local tree already
+   diverged from the remote.
+5. **Local deletes/renames are not pushed** — the write primitive cannot express
+   deletions, so they appear as `deferredDeletes` warnings and re-surface every
+   sync. Remote deletes _are_ applied locally.
+
+For the full sync model (3-way merge, FileSpaces, CLI usage), see
+[ExoSync](exosync.md).
+
+---
+
+### Apply profile (`Exocortex: Apply profile`)
+
+> A **profile** is a vault-declared set of AssetSpaces to mount, and **Apply
+> profile** is a **mount-state strict replace**: it materializes the profile's
+> AssetSpaces and **unmounts everything else**. See the
+> [Concepts glossary → Profile](../explanation/Concepts.md) and
+> [profile.md](../explanation/profile.md).
+
+**"My assets disappeared after I applied a profile"**
+
+- They are **not lost** — Apply _unmounted_ the AssetSpaces that the new profile
+  doesn't include (their folders are removed from disk but re-pullable from
+  GitHub / restored from cache). **Re-apply a profile that includes them** (one
+  whose `exo__Profile_includes` lists their AssetSpace) to bring them back.
+
+**"Apply aborted — N uncommitted file(s) …" (`UncommittedChangesAbortError`)**
+
+- On a **git-backed** vault, Apply refuses to unmount an AssetSpace with
+  uncommitted changes — it never destroys un-pushed work. A fresh setup pulls
+  AssetSpaces in as **untracked** files, which git counts as "uncommitted", so
+  the very first Apply aborts. **Fix — commit the vault once first:**
+
+  ```bash
+  # Add a .gitignore so your PAT (data.local.json) is never committed:
+  printf '.obsidian/\n.exocortex/\n' >> .gitignore
+  git add -A && git commit -m "vault setup"
+  ```
+
+  Then re-run **Apply profile**. (Apply never auto-commits — committing is a
+  deliberate, user-owned git action.)
+
+**"Apply refused — profile omits the floor" (`TsFloorViolationError`)**
+
+- Every profile must include the **TS-floor** — `exo`, the core class/property
+  definitions the engine needs. Apply **refuses** a profile that would strip the
+  floor rather than silently re-adding it, because stripping it would self-brick
+  the plugin (no class defs, no commands). Add `exo` back to the profile, or pick
+  a profile that includes it.
+
+**Apply failed or was interrupted**
+
+- Nothing is silently corrupted (2-phase commit + journal + on-load recovery).
+  In order:
+  1. **Reload Obsidian** ("Reload app without saving"). The recovery worker
+     restores any AssetSpace that was destroyed-but-not-yet-materialized.
+  2. **Re-run "Apply profile"** to the same target — Apply is a strict reconcile,
+     so re-running converges the vault regardless of the partial state.
+  3. **Desktop only** — if `git status` shows uncommitted
+     `.gitmodules` / `assetspaces/` changes afterwards, re-running Apply
+     recommits cleanly (or commit manually once the mount-state is correct).
+
+**Obsidian hangs at "Loading plugins…" right after an Apply**
+
+- **Fixed in the #3554 build** — update via BRAT (Cmd/Ctrl + P → "BRAT: Check
+  for updates to all beta plugins"). On an older build, the one-time manual
+  recovery is to quit Obsidian, set `"activeProfileUid": null` in
+  `.obsidian/plugins/exocortex/data.local.json` (this does **not** undo the
+  apply — the reduced mount stays as applied), and relaunch.
+
+---
+
+### Bootstrap & knowledge packs
+
+**"I bootstrapped but there are no action buttons"**
+
+- A clean bootstrap is **exo-only** (the floor). Action buttons (Create Task,
+  Set Status, Plan on Today, …) come from the **`exocmd`** AssetSpace — add it
+  via **Cmd/Ctrl + P → "Exocortex: Add a knowledge pack"**, or pull it
+  transitively by **applying a profile**. (The small filter/toggle buttons at the
+  top of widgets are built into the plugin and don't need `exocmd`.)
+
+**Bootstrapping a vault that already has notes**
+
+- The first-run wizard auto-shows only on a _genuinely fresh_ vault, but the
+  commands always work from the palette. Run **"Exocortex: Set up the engine"**
+  manually; re-open the wizard any time with **"Exocortex: Setup (getting
+  started)"**.
+
+**"Add a knowledge pack" didn't pull dependencies**
+
+- It pulls **one public repo** and does **not** follow `dependsOn`. For a
+  dependency-resolved set, add the **registry** and **profiles** AssetSpaces
+  first, then **Apply profile** (it resolves the closure over the descriptors
+  already in your vault). This is the standard bootstrap order — see
+  [Getting Started → Step 2b](../tutorials/Getting-Started.md#step-2b-add-the-registry--profiles-then-apply-a-profile-recommended).
+
+**First-run indexing placeholder**
+
+- Right after a bootstrap the buttons area shows _"indexing… buttons will appear
+  shortly"_ for a few seconds while 150+ ontology files index; the real buttons
+  replace it automatically. If links still look stale after that, switch tabs or
+  run **Reload layout** once.
+
+---
+
+### Mobile (iPhone / iPad)
+
+**Everything runs over REST — no `git` binary needed.** Sync, Apply profile,
+Bootstrap and Add-knowledge-pack all work on mobile (Desktop↔Mobile command
+parity); sync and apply use a REST/tarball transport instead of `git`.
+
+- **PAT saved after onload needs a reload on mobile** — the mobile
+  profile-mount path captures the PAT at plugin load, so after saving a PAT
+  **reload Obsidian** before applying a private profile (see
+  ["I saved a PAT…"](#i-saved-a-pat-but-the-plugin-still-acts-unauthenticated)).
+- **Keep mounts lean for fast reindexing** — a phone reindexes everything it
+  mounts, so a large mount can take noticeably longer than on desktop. Apply a
+  **lean profile** (only the AssetSpaces you actually need) to keep indexing
+  fast. This is one of the core reasons Profiles exist.
 
 ---
 

--- a/docs/how-to/Troubleshooting.md
+++ b/docs/how-to/Troubleshooting.md
@@ -70,14 +70,17 @@ private repo still fails as if no token were set.
 
 **Cause & fix**:
 
-- **Bootstrap, Add a knowledge pack, and Sync read the _currently-stored_ PAT at
-  command time** — a freshly-saved token works **without a reload** (fixed in
-  [#3382](https://github.com/kitelev/exocortex/issues/3382)). Just re-run the
-  command.
-- **One path captures the PAT at plugin onload: the mobile profile-mount path.**
-  If, on mobile, an **Apply profile** of a private profile still pulls
-  unauthenticated after you saved the PAT, **reload Obsidian** (Cmd/Ctrl + P →
-  "Reload app without saving") so the new PAT is picked up, then re-apply.
+- **Current builds read the _currently-stored_ PAT at command time on every
+  path** — Bootstrap, Add a knowledge pack, Sync, **and Apply profile (both
+  desktop and mobile)** rebuild their GitHub client from the PAT you just saved,
+  so a freshly-entered token works **without a reload**
+  ([#3382](https://github.com/kitelev/exocortex/issues/3382) for Bootstrap/Add,
+  [#3557](https://github.com/kitelev/exocortex/issues/3557) for the apply
+  materialize path). **Just re-run the command.**
+- **If it still fails unauthenticated, you're probably on an older build** where
+  apply used an onload-captured client. **Reload Obsidian** (Cmd/Ctrl + P →
+  "Reload app without saving") so the PAT is picked up, then re-apply — and
+  update via BRAT so the per-command PAT rebuild applies.
 
 ---
 
@@ -99,9 +102,13 @@ quarantined`; per-repo detail goes to the developer console
    with the remote (or delete the watermark file
    `exosync-watermarks.local.json` in the plugin folder) and re-sync.
 3. **Conflicts → quarantine** — a real conflict is preserved, not guessed; it
-   **re-derives on every sync until you resolve it**. There is **no dedicated
-   resolver UI yet** — resolve by making the two sides **converge** (edit the
-   local file and/or the remote so they agree); once they match, the pin clears
+   **re-derives on every sync until you resolve it**. Resolve it with
+   **Cmd/Ctrl + P → "Exocortex: Resolve sync conflicts"**, which lists each
+   conflict and shows the two versions side-by-side (local | remote) with
+   **Keep local / Keep remote / Merge** (an editable field seeded with the local
+   version); choosing writes the kept version to disk **and** the remote.
+   Alternatively, resolve by making the two sides **converge** by hand (edit the
+   local file and/or the remote so they agree) — once they match, the pin clears
    and the entry auto-tombstones as `resolved`. Optionally set a
    **Quarantine repo URL** (Settings → Exocortex → ExoSync) to keep conflict
    copies cross-device. **FileSpaces refuse to sync without a quarantine repo**,
@@ -219,9 +226,11 @@ For the full sync model (3-way merge, FileSpaces, CLI usage), see
 Bootstrap and Add-knowledge-pack all work on mobile (Desktop↔Mobile command
 parity); sync and apply use a REST/tarball transport instead of `git`.
 
-- **PAT saved after onload needs a reload on mobile** — the mobile
-  profile-mount path captures the PAT at plugin load, so after saving a PAT
-  **reload Obsidian** before applying a private profile (see
+- **A PAT saved after the plugin loaded is honoured without a reload** — the
+  mobile apply path rebuilds its GitHub client from the currently-stored PAT on
+  each apply (#3382 pattern), just like desktop. If a private apply still fails
+  unauthenticated, you're likely on an older build — reload Obsidian and update
+  via BRAT (see
   ["I saved a PAT…"](#i-saved-a-pat-but-the-plugin-still-acts-unauthenticated)).
 - **Keep mounts lean for fast reindexing** — a phone reindexes everything it
   mounts, so a large mount can take noticeably longer than on desktop. Apply a


### PR DESCRIPTION
## Summary

Fills the **docs gap for alpha testers** hitting *operational* issues. The existing `docs/how-to/Troubleshooting.md` was layout-era (Layout/Buttons/Wiki-Links/SPARQL) and did not cover the setup/auth/sync issues a fresh tester actually hits; there was no single tester-facing concepts glossary.

Every troubleshooting **fix is verified against `origin/main` code/docs** (`exosync.md`, `profile.md`, `ApplyDepsFactory.ts`) — no invented fixes.

## Changes (docs-only)

**`docs/how-to/Troubleshooting.md`** — new top "Setup, auth & sync" section:
- **GitHub auth / PAT** — 404 (under-scoped fine-grained allowlist) vs 401/403 (expired/revoked); where to enter it (Settings → Exocortex → GitHub PAT), Contents+Metadata scopes; the *PAT-after-onload* nuance: Bootstrap/Add/Sync read PAT at call time (no reload, #3382), but the **mobile profile-mount path captures it at onload** → reload needed.
- **Sync (ExoSync)** — `auth-required`, `full-conflict`, conflict→quarantine (**no resolver UI yet** — resolve by convergent edit; FileSpaces require a quarantine repo), first-sync safety, `deferredDeletes`.
- **Apply profile** — "assets disappeared" = unmounted not lost (re-apply); `UncommittedChangesAbortError` + .gitignore/commit fix; `TsFloorViolationError`; interrupted-apply recovery; pre-#3554 "Loading plugins…" hang.
- **Bootstrap / knowledge packs** — exo-only floor ⇒ no buttons until `exocmd`; registry-before-apply order; non-empty-vault wizard.
- **Mobile** — REST parity (sync/apply/bootstrap all work), PAT-onload reload, lean-profile reindex.

**`docs/explanation/Concepts.md`** (new) — tester glossary: AssetSpace (jar), Profile (BOM), mount-state, TS-floor, homoiconicity, co-location, UID-canon, PAT, ExoSync, FileSpace, BRAT — one-liners + deep-doc links. Fills the homoiconicity/UID-canon gap that `assetspace-sdk-topology.md` doesn't cover as a single tester overview.

**`docs/README.md`** — index both new entries.

## Verification
- `node scripts/validate-docs-properties.js` → 0 missing (exit 0).
- Manual relative-link + GitHub-anchor check on all 3 files → all resolve.
- Prettier-clean (edited files were clean on origin/main → no bundling; README diff = 3 lines).
- ⛔ No code touched. No Docker.