### PR TITLE
fix(archive): folder-repair must not relocate to filesystem root + harden co-location edge-cases

### DIFF
--- a/packages/cli/tests/unit/services/repairFolder.test.ts
+++ b/packages/cli/tests/unit/services/repairFolder.test.ts
@@ -143,6 +143,108 @@ describe("repairFolder (CLI)", () => {
     await expect(service.execute("02 Misplaced/does-not-exist")).rejects.toThrow();
   });
 
+  // ---------------------------------------------------------------------------
+  // Data-integrity edge cases (al-archive-hardening) — exercised against the
+  // REAL FileSystemVaultAdapter + FolderRepairService chain (no mocks), so the
+  // assertions reflect what actually happens to bytes on disk.
+  // ---------------------------------------------------------------------------
+
+  it("collision: when a file already occupies the target path, it throws and the SOURCE is preserved (no data loss)", async () => {
+    writeRaw(
+      vaultRoot,
+      `01 Areas/${AREA_REFERENT}.md`,
+      `---\nexo__Asset_uid: ${AREA_REFERENT}\nexo__Asset_label: Areas\n---\nBody\n`,
+    );
+    // The asset to be relocated lives in the wrong folder.
+    const sourceBody =
+      `---\nexo__Asset_uid: collide-uid\nexo__Asset_label: Source\nexo__Asset_isDefinedBy: "[[${AREA_REFERENT}]]"\n---\nSOURCE BODY\n`;
+    writeRaw(vaultRoot, "02 Misplaced/collide-uid.md", sourceBody);
+    // A DIFFERENT file already occupies the destination path.
+    const occupantBody =
+      `---\nexo__Asset_uid: occupant\nexo__Asset_label: Occupant\n---\nOCCUPANT BODY\n`;
+    writeRaw(vaultRoot, "01 Areas/collide-uid.md", occupantBody);
+
+    await expect(service.execute("02 Misplaced/collide-uid")).rejects.toThrow(
+      /already exists/i,
+    );
+
+    // Source untouched (not moved, not deleted, content intact).
+    const sourcePath = path.join(vaultRoot, "02 Misplaced/collide-uid.md");
+    expect(fs.existsSync(sourcePath)).toBe(true);
+    expect(fs.readFileSync(sourcePath, "utf-8")).toBe(sourceBody);
+    // Occupant untouched (not overwritten).
+    expect(
+      fs.readFileSync(path.join(vaultRoot, "01 Areas/collide-uid.md"), "utf-8"),
+    ).toBe(occupantBody);
+  });
+
+  it("alias-form isDefinedBy [[uuid|$label]] resolves via the TARGET uid and relocates", async () => {
+    writeRaw(
+      vaultRoot,
+      `01 Areas/${AREA_REFERENT}.md`,
+      `---\nexo__Asset_uid: ${AREA_REFERENT}\nexo__Asset_label: Areas\n---\nBody\n`,
+    );
+    writeRaw(
+      vaultRoot,
+      "02 Misplaced/aliased-uid.md",
+      `---\nexo__Asset_uid: aliased-uid\nexo__Asset_label: Aliased\nexo__Asset_isDefinedBy: "[[${AREA_REFERENT}|$areas]]"\n---\nBody\n`,
+    );
+
+    await service.execute("02 Misplaced/aliased-uid");
+
+    expect(fs.existsSync(path.join(vaultRoot, "01 Areas/aliased-uid.md"))).toBe(true);
+    expect(fs.existsSync(path.join(vaultRoot, "02 Misplaced/aliased-uid.md"))).toBe(false);
+  });
+
+  it("relocates to the VAULT ROOT (not the filesystem root) for a root-level isDefinedBy referent", async () => {
+    // Regression guard for the `/asset.md` misplace: a root-level ontology
+    // yields expectedFolder "". `repairFolder` must produce `asset.md` (vault
+    // root), NOT `/asset.md`. The latter is absolute → FileSystemVaultAdapter
+    // would `fs.move` the file to the OS filesystem root, escaping the vault.
+    const ROOT_ONTO = "11111111-2222-3333-4444-555555555555";
+    writeRaw(
+      vaultRoot,
+      `${ROOT_ONTO}.md`,
+      `---\nexo__Asset_uid: ${ROOT_ONTO}\nexo__Asset_label: RootOnto\n---\nBody\n`,
+    );
+    writeRaw(
+      vaultRoot,
+      "02 Misplaced/root-anchored.md",
+      `---\nexo__Asset_uid: root-anchored\nexo__Asset_label: RootAnchored\nexo__Asset_isDefinedBy: "[[${ROOT_ONTO}]]"\n---\nBody\n`,
+    );
+
+    await service.execute("02 Misplaced/root-anchored");
+
+    // Landed at the vault root, content intact.
+    const landed = path.join(vaultRoot, "root-anchored.md");
+    expect(fs.existsSync(landed)).toBe(true);
+    expect(fs.existsSync(path.join(vaultRoot, "02 Misplaced/root-anchored.md"))).toBe(false);
+    // Did NOT escape to the absolute path `/root-anchored.md`.
+    expect(fs.existsSync("/root-anchored.md")).toBe(false);
+    expect(readFrontmatter(landed).exo__Asset_uid).toBe("root-anchored");
+  });
+
+  it("fail-open: a `!`-anchor isDefinedBy that does not resolve does NOT relocate the asset", async () => {
+    // Bang-anchored assets (e.g. command-system assets `[[!kitelev]]`) are
+    // intentional anchors. With no `!kitelev.md` on disk the referent is
+    // unresolvable → no expected folder → throw → the asset stays put. This
+    // documents the *effective* fail-open (via non-resolution) of the repair
+    // path — there is no explicit bang-prefix guard here, unlike
+    // resolveCoLocationFolder; see al-archive-hardening PR notes.
+    const bangBody =
+      `---\nexo__Asset_uid: bang-anchored\nexo__Asset_label: Anchored\nexo__Asset_isDefinedBy: "[[!kitelev]]"\n---\nBody\n`;
+    writeRaw(vaultRoot, "02 Misplaced/bang-anchored.md", bangBody);
+
+    await expect(service.execute("02 Misplaced/bang-anchored")).rejects.toThrow(
+      /expected folder|isDefinedBy/i,
+    );
+
+    // Asset NOT relocated — stays exactly where it was, content intact.
+    const stayed = path.join(vaultRoot, "02 Misplaced/bang-anchored.md");
+    expect(fs.existsSync(stayed)).toBe(true);
+    expect(fs.readFileSync(stayed, "utf-8")).toBe(bangBody);
+  });
+
   it("registry integration: populateCliServiceRegistry with deps registers real repairFolder (no throw-stub)", async () => {
     writeRaw(
       vaultRoot,

--- a/packages/exocortex/src/services/FolderRepairService.ts
+++ b/packages/exocortex/src/services/FolderRepairService.ts
@@ -60,8 +60,14 @@ export class FolderRepairService {
    * Move asset to its expected folder based on exo__Asset_isDefinedBy
    */
   async repairFolder(file: IFile, expectedFolder: string): Promise<void> {
-    // Construct new path
-    const newPath = `${expectedFolder}/${file.name}`;
+    // Construct new path. For a root-level target (expectedFolder === "") the
+    // file lands at the vault root as `<name>`, NOT `/<name>`: a leading-slash
+    // path is an *absolute* filesystem path. `FileSystemVaultAdapter.resolvePath`
+    // returns absolute paths verbatim, so `/<name>` would `fs.move` the asset to
+    // the OS filesystem root — out of the vault entirely (lost). This mirrors the
+    // CLI `FolderRepairExecutor`/`BatchExecutor`, which already build
+    // `expectedFolder ? \`${expectedFolder}/${fileName}\` : fileName`.
+    const newPath = expectedFolder ? `${expectedFolder}/${file.name}` : file.name;
 
     // Check if target path already exists
     const existingFile = this.vault.getAbstractFileByPath(newPath);

--- a/packages/exocortex/tests/unit/services/FolderRepairService.test.ts
+++ b/packages/exocortex/tests/unit/services/FolderRepairService.test.ts
@@ -273,14 +273,18 @@ describe("FolderRepairService", () => {
       await expect(service.repairFolder(file, "new-folder")).rejects.toBe("string error");
     });
 
-    it("should not create folder when expectedFolder is empty string (root)", async () => {
+    it("should move to vault root (no leading slash) when expectedFolder is empty string", async () => {
+      // Regression guard: a root-level target must produce the relative path
+      // `asset.md`, NOT `/asset.md`. A leading slash is an *absolute* path that
+      // FileSystemVaultAdapter.resolvePath returns verbatim, so `fs.move` would
+      // relocate the asset to the OS filesystem root — out of the vault (lost).
       const file = createMockFile();
       mockVault.getAbstractFileByPath.mockReturnValue(null);
 
       await service.repairFolder(file, "");
 
       expect(mockVault.createFolder).not.toHaveBeenCalled();
-      expect(mockVault.rename).toHaveBeenCalledWith(file, "/asset.md");
+      expect(mockVault.rename).toHaveBeenCalledWith(file, "asset.md");
     });
   });
 

--- a/packages/obsidian-plugin/tests/unit/FolderRepairService.test.ts
+++ b/packages/obsidian-plugin/tests/unit/FolderRepairService.test.ts
@@ -213,7 +213,10 @@ describe("FolderRepairService", () => {
       );
     });
 
-    test("should handle empty folder path (root)", async () => {
+    test("should move to vault root without a leading slash (root folder path)", async () => {
+      // Regression guard: empty expectedFolder → `file.md`, NOT `/file.md`.
+      // A leading slash is an absolute path; FileSystemVaultAdapter.resolvePath
+      // returns it verbatim, so the asset would be moved out of the vault.
       const file = {
         path: "old/path/file.md",
         name: "file.md",
@@ -224,7 +227,7 @@ describe("FolderRepairService", () => {
       await service.repairFolder(file, "");
 
       expect(mockVaultAdapter.createFolder).not.toHaveBeenCalled();
-      expect(mockVaultAdapter.rename).toHaveBeenCalledWith(file, "/file.md");
+      expect(mockVaultAdapter.rename).toHaveBeenCalledWith(file, "file.md");
     });
   });
 


### PR DESCRIPTION
## Summary

Test-hardening for the **ontological-archive / co-location-repair** path (data-relocating; a bug = lost/misplaced assets). Found + fixed one real data-loss bug, added 4 production-shape edge-case tests.

### 🐞 Fix — relocate-to-filesystem-root (data loss)

`FolderRepairService.repairFolder` built `` `${expectedFolder}/${file.name}` `` for a root-level co-location target (`expectedFolder === ""`), producing `/asset.md`. A leading slash is an **absolute** path — `FileSystemVaultAdapter.resolvePath` returns absolute paths verbatim (`if (path.isAbsolute(p)) return p`), so `fs.move` would relocate the asset to the **OS filesystem root** `/asset.md`, escaping the vault entirely (asset lost).

This is reachable via the homoiconic **«Archive Ontologically» composite** (`createRepairFolderService` → `FolderRepairService.repairFolder`) when an archive ontology lives at the vault root: `getExpectedFolder` returns `""`, and for an asset in a subfolder `createRepairFolderService` does *not* early-return (`currentFolder !== ""`), so it calls `repairFolder(file, "")`.

**Fix:** produce `file.name` for the root case — matching the CLI `FolderRepairExecutor` / `BatchExecutor`, which already build `` expectedFolder ? `${expectedFolder}/${fileName}` : fileName ``.

Empirically **verified to FAIL pre-fix and PASS post-fix** (revert-verify, per `integration-test-revert-verify`) on all 3 layers (CLI integration + exocortex unit + plugin unit). Confirmed no filesystem-root pollution on the failing pre-fix run (EACCES on non-root).

### 🧪 Hardening — production-shape (real `FileSystemVaultAdapter`, no mocks)

Added to `packages/cli/tests/unit/services/repairFolder.test.ts`:
- **collision**: target path already occupied → throws, **SOURCE preserved** (content intact, not lost), occupant not overwritten
- **alias-form** `[[uuid|$label]]` `isDefinedBy` → resolves via the target uid (alias stripped) + relocates
- **relocate to vault root** (not filesystem root) for a root-level referent — FIX proof at real-fs level
- **fail-open**: unresolvable `[[!kitelev]]` anchor → throws, asset **NOT relocated** (stays put, content intact)

### 📋 Notes / deferred

- The repair path (`getExpectedFolder` / `findReferencedFile`) has **no explicit `!`-prefix guard**, unlike `resolveCoLocationFolder` (which short-circuits bang anchors). Today bang-anchored assets fail-open only *by non-resolution* (no `!kitelev.md` on disk). If a literal `!`-named file ever existed, repair could relocate an intentionally-anchored asset. Low likelihood; documented as a deferred consistency finding rather than a behavior change in this PR.
- Excluded the regenerated `packages/cli/dist/index.js` (build artifact; `prepublishOnly`/auto-release rebuild it — the src fix ships via that rebuild).

## Test plan
- `repairFolder.test.ts` 12/12 ✓ · `FolderRepairExecutor` ✓ · `BatchExecutor.repair-folder` ✓ · `apply-ontological-archive.integration` ✓ (43 CLI repair/archive total)
- exocortex `FolderRepairService` 23/23 ✓ · plugin `FolderRepairService` 16/16 ✓ · `grounding-service-factories` 52/52 ✓
- `check:types` ✓ · `build` (+ mobile-loadable + console-channel) ✓ · archgate 22/22 ✓