### PR TITLE
fix(precondition): host function throw → fail-closed + command-visibility edge-case guards

### DIFF
--- a/packages/exocortex/src/services/PreconditionEvaluator.ts
+++ b/packages/exocortex/src/services/PreconditionEvaluator.ts
@@ -40,6 +40,12 @@ export type HostFunction = (context: EvalContext) => boolean;
  * Default behavior:
  * - No precondition → true (permissive: command always available)
  * - SPARQL engine error → false (fail closed for safety)
+ * - Registered host function throws → false (fail closed for safety)
+ * - Unregistered host function → true on the async {@link evaluate} path
+ *   (fail open, permissive for inline buttons); `null` on
+ *   {@link evaluateHostFunctionSync} (caller decides — the palette registrar
+ *   treats `null` as fail closed to surface misconfiguration). This
+ *   asymmetry is intentional and regression-guarded by unit tests.
  *
  * Issue #2429
  */
@@ -195,7 +201,20 @@ export class PreconditionEvaluator {
       ? { ...context, targetIRI }
       : { targetIRI };
 
-    return fn(evalContext);
+    try {
+      return fn(evalContext);
+    } catch {
+      // A registered host function that throws is treated as fail-closed
+      // (command hidden), consistent with the SPARQL-engine-error policy.
+      // This matters most for `evaluateHostFunctionSync`, which runs inside
+      // Obsidian's synchronous `addCommand({ checkCallback })` on every
+      // Command Palette open — an uncaught throw there surfaces as a
+      // palette-breaking exception. The async inline-button path also relied
+      // on its own caller-side catch; centralising here makes both surfaces
+      // uniformly graceful. Note this only governs the registered-but-errored
+      // case; the unregistered fail-open/closed asymmetry above is unchanged.
+      return false;
+    }
   }
 
   private async evaluateSparqlAsk(

--- a/packages/exocortex/tests/unit/services/PreconditionEvaluator.test.ts
+++ b/packages/exocortex/tests/unit/services/PreconditionEvaluator.test.ts
@@ -621,4 +621,164 @@ describe("PreconditionEvaluator", () => {
       expect(resolver.resolveSparql).not.toHaveBeenCalled();
     });
   });
+
+  // --- Command-visibility edge-case hardening ---------------------------
+  // Buttons / palette entries are gated by these paths; a regression here
+  // means a tester sees the wrong commands or a command silently breaks
+  // (UX-critical). The fail-open/closed asymmetry caused real visibility
+  // bugs (#3296 / #3298 Repair Folder). These suites lock the contract.
+
+  describe("host function that throws (robustness — graceful fail-closed)", () => {
+    it("async evaluate: resolves to false when a registered host function throws (does not reject)", async () => {
+      evaluator.registerHostFunction("boom", () => {
+        throw new Error("host fn blew up");
+      });
+      const precondition = {
+        id: "pre-boom",
+        label: "Throwing host fn",
+        hostFunction: "boom",
+      };
+      // A registered-but-throwing host fn must fail closed (command hidden),
+      // not propagate. The inline-button path has its own caller-side catch,
+      // but the palette checkCallback (sync) had none — an uncaught throw
+      // there surfaces as a palette-breaking exception in Obsidian.
+      await expect(
+        evaluator.evaluate(precondition, ASSET_IRI),
+      ).resolves.toBe(false);
+    });
+
+    it("sync evaluateHostFunctionSync: returns false when a registered host function throws (does not throw)", () => {
+      evaluator.registerHostFunction("boom", () => {
+        throw new Error("host fn blew up");
+      });
+      // checkCallback (Cmd+P) runs this synchronously on every palette open —
+      // a thrown error here would break the command palette. Registered-but-
+      // errored must read as fail-closed (false), distinct from the
+      // unregistered signal (null).
+      expect(() =>
+        evaluator.evaluateHostFunctionSync("boom", ASSET_IRI),
+      ).not.toThrow();
+      expect(evaluator.evaluateHostFunctionSync("boom", ASSET_IRI)).toBe(false);
+    });
+
+    it("a throwing host function does not poison sibling registered functions", () => {
+      evaluator.registerHostFunction("boom", () => {
+        throw new Error("nope");
+      });
+      evaluator.registerHostFunction("ok", () => true);
+      expect(evaluator.evaluateHostFunctionSync("boom", ASSET_IRI)).toBe(false);
+      expect(evaluator.evaluateHostFunctionSync("ok", ASSET_IRI)).toBe(true);
+    });
+  });
+
+  describe("fail-open vs fail-closed asymmetry for unregistered host functions (regression guard)", () => {
+    // PreconditionEvaluator deliberately treats an UNREGISTERED host function
+    // differently on its two surfaces (documented at PreconditionEvaluator.ts
+    // ~138-159). The async evaluate() path is fail-OPEN (inline buttons stay
+    // visible — permissive), evaluateHostFunctionSync() is fail-CLOSED
+    // (returns null so the palette registrar hides the command and surfaces
+    // misconfiguration loudly). This pairing locks the contract: if someone
+    // "unifies" the two paths, this test breaks loudly and forces a
+    // deliberate decision instead of a silent regression (cf. #3296 / #3298).
+    const UNREGISTERED = "neverRegisteredFn";
+
+    it("async evaluate is FAIL-OPEN (inline buttons): unregistered host fn → true", async () => {
+      const result = await evaluator.evaluate(
+        { id: "p", label: "Unregistered", hostFunction: UNREGISTERED },
+        ASSET_IRI,
+      );
+      expect(result).toBe(true);
+    });
+
+    it("sync evaluateHostFunctionSync is FAIL-CLOSED (Cmd+P): unregistered host fn → null", () => {
+      const result = evaluator.evaluateHostFunctionSync(UNREGISTERED, ASSET_IRI);
+      expect(result).toBeNull();
+    });
+
+    it("the two surfaces disagree on the same unregistered name (asymmetry is intentional)", async () => {
+      const asyncResult = await evaluator.evaluate(
+        { id: "p", label: "U", hostFunction: UNREGISTERED },
+        ASSET_IRI,
+      );
+      const syncResult = evaluator.evaluateHostFunctionSync(
+        UNREGISTERED,
+        ASSET_IRI,
+      );
+      expect(asyncResult).toBe(true); // fail open
+      expect(syncResult).toBeNull(); // fail closed (caller decides)
+      // Coercion-agnostic proof they diverge: true !== null.
+      expect(asyncResult === (syncResult as unknown)).toBe(false);
+    });
+  });
+
+  describe("precondition field priority contract (sparqlAsk > query > hostFunction)", () => {
+    // evaluate() consults at most ONE strategy, in source order. These tests
+    // pin the order so a refactor can't silently reshuffle it — gating the
+    // wrong field would mis-show/mis-hide commands.
+    it("sparqlAsk wins over hostFunction when both present (host fn never consulted)", async () => {
+      let hostFnCalled = false;
+      evaluator.registerHostFunction("shouldNotRun", () => {
+        hostFnCalled = true;
+        return true; // would force visible if it were consulted
+      });
+      // Empty store → ASK does not match → false. host fn would have returned
+      // true, so result === false proves sparqlAsk took priority.
+      const result = await evaluator.evaluate(
+        {
+          id: "p",
+          label: "ask+host",
+          sparqlAsk: `PREFIX ems: <https://exocortex.my/ontology/ems#>
+            ASK { <${ASSET_IRI}> ems:Effort_startTimestamp ?ts }`,
+          hostFunction: "shouldNotRun",
+        },
+        ASSET_IRI,
+      );
+      expect(result).toBe(false);
+      expect(hostFnCalled).toBe(false);
+    });
+
+    it("query wins over hostFunction when both present and no sparqlAsk", async () => {
+      let hostFnCalled = false;
+      const resolver = {
+        resolveSparql: jest.fn().mockResolvedValue("ASK { }"), // trivially true
+      };
+      const ev = new PreconditionEvaluator(store, resolver);
+      ev.registerHostFunction("shouldNotRun", () => {
+        hostFnCalled = true;
+        return false; // would force hidden if it were consulted
+      });
+      const result = await ev.evaluate(
+        {
+          id: "p",
+          label: "query+host",
+          query: "q-uid",
+          hostFunction: "shouldNotRun",
+        },
+        ASSET_IRI,
+      );
+      expect(result).toBe(true); // query (ASK {}) → true
+      expect(hostFnCalled).toBe(false);
+      expect(resolver.resolveSparql).toHaveBeenCalledWith("q-uid");
+    });
+  });
+
+  describe("empty / edge-shaped precondition fields", () => {
+    it("returns true when hostFunction is an empty string (falsy → no-precondition path)", async () => {
+      const result = await evaluator.evaluate(
+        { id: "p", label: "Empty host", hostFunction: "" },
+        ASSET_IRI,
+      );
+      expect(result).toBe(true);
+    });
+
+    it("returns true when precondition has id/label but no strategy field at all", async () => {
+      // Defensive: a malformed precondition asset (no sparqlAsk/query/host)
+      // should not hide the command — falls through to the permissive default.
+      const result = await evaluator.evaluate(
+        { id: "p", label: "No strategy" },
+        ASSET_IRI,
+      );
+      expect(result).toBe(true);
+    });
+  });
 });


### PR DESCRIPTION
## What

Hardens `PreconditionEvaluator` — the gate for exocmd command **visibility / executability**. A regression here means a tester sees the wrong buttons or a command silently breaks (UX-critical, Alpha-blocker class). Robustness fix + 10 new production-shape tests.

## Fix: registered host function that throws → fail-closed

`evaluateHostFunction` called `fn(evalContext)` with **no try/catch**. A registered-but-throwing host function:
- **Inline-button path** (`DynamicCommandButtonGroupBuilder`) — caught by its own caller-side try/catch → button hidden (graceful).
- **Cmd+P path** (`ExocmdCommandPaletteRegistrar`) — runs `evaluateHostFunctionSync` inside Obsidian's **synchronous** `addCommand({ checkCallback })` with **no caller-side catch** → uncaught throw → **palette-breaking exception** on every palette open.

Fix: wrap the host-fn call in `try/catch` → `return false` (fail closed), consistent with the documented SPARQL-engine-error policy. Both surfaces are now uniformly graceful.

⛤ **Scope-safe:** this only governs the *registered-but-errored* case. The unregistered **fail-open** (async `evaluate` → `true`) / **fail-closed** (`evaluateHostFunctionSync` → `null`) asymmetry is **unchanged** — that gating semantics is deliberate (#3296/#3298) and now regression-guarded.

### Empirically verified (revert-verify discipline)
The 3 throw tests **FAIL pre-fix** (throw propagates → promise rejects / sync throws) and **PASS post-fix** (resolve/return `false`). Confirmed by running the suite against the unmodified source first.

## Tests (+10, all CI-gated under `test-coverage-exocortex` full jest run)
- **Throwing host fn** (3): async `evaluate` resolves false; sync `evaluateHostFunctionSync` returns false without throwing; sibling-fn isolation.
- **Fail-open vs fail-closed asymmetry** (3): regression-guard locking the intentional contract — async fail-open (`true`), sync fail-closed (`null`), and that the two surfaces diverge on the same unregistered name. Breaks loudly if someone "unifies" the paths.
- **Precondition field-priority contract** (2): `sparqlAsk` > `query` > `hostFunction` — proven via "would-be-different-result" host fn that must NOT be consulted.
- **Empty / strategy-less precondition** (2): empty `hostFunction` string and a precondition with no strategy field both fall through to the permissive default.

## Verification
- `PreconditionEvaluator.test.ts` + `preconditionHostFunctions.test.ts`: **69 pass** (was 59).
- Consumers green: `ExocmdCommandPaletteRegistrar` + `DynamicCommandButtonGroupBuilder` (86), `tests/unit/services` dir (1889), `DynamicCommandPipeline`/integration smoke (59).
- `npm run check:types` clean · `eslint --max-warnings=0` clean on changed src.

## Refs
#3296 #3298 (Repair Folder visibility — same fail-open/closed class). Issue #2429.