### PR TITLE
test(req): bind 3 ExoSync P0 reqs via @req tags (RFC 0003 P2 inc3)

### DIFF
--- a/packages/exocortex/tests/unit/services/sync/ChangeDetector.test.ts
+++ b/packages/exocortex/tests/unit/services/sync/ChangeDetector.test.ts
@@ -146,7 +146,7 @@ describe("detectChanges — uid-keyed diff (D18)", () => {
     }
   });
 
-  it("rename: same uid at a new path → modified with basePath, NOT delete+add", async () => {
+  it("@req:8a97d6ed-9ffc-4802-8df5-09d1b371cb09 rename: same uid at a new path → modified with basePath, NOT delete+add", async () => {
     const content = mdAsset("u1");
     const wm = await watermarkFor({ "old/a.md": content });
     const result = await detectChanges({

--- a/packages/exocortex/tests/unit/services/sync/MergeShaclGate.test.ts
+++ b/packages/exocortex/tests/unit/services/sync/MergeShaclGate.test.ts
@@ -49,7 +49,7 @@ function gateWith(opts: {
 }
 
 describe("MergeShaclGate — intrinsic constraints always gate", () => {
-  it("minCount violation on the merged asset fails the gate", async () => {
+  it("@req:b0fd3343-03c5-409a-bede-5c47eae5593c minCount violation on the merged asset fails the gate", async () => {
     const gate = gateWith({
       candidate: [t(SUBJ, TYPE, iri(TASK_CLASS))],
       shapes: [

--- a/packages/exocortex/tests/unit/services/sync/QuarantineResolver.test.ts
+++ b/packages/exocortex/tests/unit/services/sync/QuarantineResolver.test.ts
@@ -188,7 +188,7 @@ describe("QuarantineResolver.resolve — keep-local", () => {
 });
 
 describe("QuarantineResolver.resolve — keep-remote (zero-loss)", () => {
-  it("writes remote to disk, preserves the discarded local in a .txt backup, and unpins", async () => {
+  it("@req:e85487a7-695e-4dea-b076-dc5f42ce2d50 writes remote to disk, preserves the discarded local in a .txt backup, and unpins", async () => {
     const { repo, spec, disk, watermarks, resolver, local, remote } =
       await makeConflict();
     const remoteHeadBefore = repo.headSha();


### PR DESCRIPTION
## Summary

RFC 0003 P2 (requirements-management) **increment 3** — binds 3 ExoSync P0 data-loss-prevention behaviors to their existing unit tests via `@req:<uid>` tags. **Test-only** change (three `it()` title strings); **no production code touched**.

Reverse-documented (A14) into `req__Requirement` assets in `exoas-exo-reqs` (vault). Each binding is **revert-verified** (break the exact prod line → test RED → restore → GREEN, against origin/main `53519a89`):

| `@req` uid | behavior | prod break → RED |
| --- | --- | --- |
| `8a97d6ed` | ChangeDetector tracks a moved asset by stable uid — one modify+basePath, never a data-losing delete+add | disable uid Pass-1 lookup → rename degrades to delete+add (`modified` empty) |
| `b0fd3343` | MergeShaclGate blocks a merged asset that violates an intrinsic constraint (never ships an invalid auto-merge) | skip intrinsic `violations.push(v)` (class branch intact) → gate returns `ok:true` for a minCount violation |
| `e85487a7` | QuarantineResolver keep-remote preserves the discarded local in a `.txt` backup (zero data loss) | skip the zero-loss `localFiles.write(backup, local)` → discarded local is `undefined` on disk |

Also (vault-only, not in this PR): the deferred integration floor of `40b1be4d` (ExoSync 3-way merge) was revert-verified via the `#3590` SyncEngine mount-base path → now fully revert-verified.

## Checker

`requirements audit` (P1): **17 requirements / 17 bound / 100% coverage / 17 tags / 0 hard findings** (no dangling, no duplicates, no binding-class-floor violations). SHACL = 0 on vault-exodev (94734 triples, conforms).

## Scope / safety

- ⛔ No production code changed (only test it() titles). Despite touching `services/sync/` test files, the ExoSync engine src is untouched.
- Each binding is a revert-verified happy-path mutation (single revertible prod line) — not an idempotent/no-op precondition test.
- Node: `17e868ff` (P2 hub), checklist now 16 P0 reqs (11 fully revert-verified).

RFC 0003 P2 increment 3 (al-reqmgmt-p2-inc3).