### PR TITLE
perf(sync): mtime-manifest local-hash skip (ExoSync Phase 1)

### DIFF
--- a/packages/cli/src/commands/exosync-sync.ts
+++ b/packages/cli/src/commands/exosync-sync.ts
@@ -39,9 +39,11 @@ import { promisify } from "node:util";
 import * as path from "node:path";
 import yaml from "js-yaml";
 import {
+  FileLocalManifestStore,
   FileMountBaseStore,
   FileWatermarkStore,
   GatedStructuredMerger,
+  LOCAL_MANIFEST_STORE_FILENAME,
   MOUNT_BASE_STORE_FILENAME,
   StructuredMerger,
   SyncedQuarantineStore,
@@ -222,6 +224,15 @@ export function nodeLocalFilesPort(root: string): LocalFilesPort {
         bytes.byteOffset + bytes.byteLength,
       ) as ArrayBuffer;
       await writeAtomic(abs(rel), (tmp) => fsp.writeFile(tmp, Buffer.from(buf)));
+    },
+    // mtime-manifest (perf): cheap metadata, no content read. `null` on ENOENT.
+    async stat(rel): Promise<{ mtimeMs: number; size: number } | null> {
+      try {
+        const s = await fsp.stat(abs(rel));
+        return { mtimeMs: s.mtimeMs, size: s.size };
+      } catch {
+        return null;
+      }
     },
   };
 }
@@ -427,6 +438,16 @@ export async function runExosyncSync(
     "exocortex",
     WATERMARK_STORE_FILENAME,
   );
+  // mtime-manifest (perf) — sits next to the watermark in the same device-local
+  // (`.local.`, Sync-excluded) store dir. Same single-file IO contract as the
+  // watermark, so `nodeWatermarkFileIO` is reused verbatim.
+  const manifestPath = path.join(
+    vaultPath,
+    configDir,
+    "plugins",
+    "exocortex",
+    LOCAL_MANIFEST_STORE_FILENAME,
+  );
   let quarantine: QuarantinePort | undefined;
   const quarantineUrl = opts.quarantineRepo?.trim() ?? "";
   if (quarantineUrl.length > 0) {
@@ -446,6 +467,11 @@ export async function runExosyncSync(
   const engine = new SyncEngine({
     transport,
     watermarkStore: new FileWatermarkStore(nodeWatermarkFileIO(watermarkPath)),
+    // mtime-manifest local-hash skip (perf) — same IO/store family as the
+    // watermark; skips reading+re-hashing unchanged asset files each sync.
+    localManifestStore: new FileLocalManifestStore(
+      nodeWatermarkFileIO(manifestPath),
+    ),
     mountBaseStore: nodeMountBaseStore(vaultPath, configDir),
     localBaseShaProvider: nodeLocalBaseShaProvider(vaultPath),
     materializationCheck: nodeMaterializationCheck(vaultPath),

--- a/packages/exocortex/src/index.ts
+++ b/packages/exocortex/src/index.ts
@@ -617,6 +617,7 @@ export {
 } from "./services/sync/githubRepoReader";
 export {
   DEFAULT_MAX_PUSH_RETRIES,
+  DEFAULT_LOCAL_MANIFEST_REHASH_MS,
   SyncEngine,
   isNonFastForwardError,
   orderChildrenFirst,
@@ -666,6 +667,9 @@ export {
   type AssetChange,
   type ChangeDetectionResult,
   type LocalFilesPort,
+  type LocalManifestEntry,
+  type LocalManifestRecord,
+  type LocalManifestStorePort,
   type MaterializationCheck,
   type MaterializationCheckPort,
   type MergeConflictInput,
@@ -684,6 +688,12 @@ export {
   type WatermarkRecord,
   type WatermarkStorePort,
 } from "./services/sync/syncTypes";
+// ExoSync Phase 1 (perf) — device-local mtime-manifest store: skips reading +
+// re-hashing files whose (mtime,size) are unchanged since the last sync.
+export {
+  FileLocalManifestStore,
+  LOCAL_MANIFEST_STORE_FILENAME,
+} from "./services/sync/FileLocalManifestStore";
 // ExoSync A2 — StructuredMerger (3-way frontmatter per-key + D20 set-union
 // tombstones + D21 structured body merge) over the generic diff3 helper.
 export { diff3, type Diff3Result } from "./services/sync/diff3";

--- a/packages/exocortex/src/services/sync/ChangeDetector.ts
+++ b/packages/exocortex/src/services/sync/ChangeDetector.ts
@@ -44,9 +44,21 @@ export interface DetectChangesParams {
   /**
    * Allowlist-scoped disk snapshot: repo-relative path → content. Phase C
    * file-mode passes raw bytes — uid identity never applies to bytes
-   * (opaque blobs match by path), text identity is unchanged.
+   * (opaque blobs match by path), text identity is unchanged. With the
+   * mtime-manifest optimisation active this holds ONLY the files actually
+   * read this sync (new / mtime-or-size-changed); unchanged files arrive via
+   * {@link cachedEntries} instead — the two maps are DISJOINT and together
+   * cover every present syncable path.
    */
   localFiles: ReadonlyMap<string, SyncContent>;
+  /**
+   * Precomputed `{ blobSha, uid }` for files the caller already knows are
+   * unchanged since the last sync (mtime-manifest cache hit, perf). Folded
+   * into the disk snapshot WITHOUT re-reading or re-hashing. Keys MUST be
+   * disjoint from {@link localFiles}. Absent/empty ⇒ every file is hashed
+   * from `localFiles` (status quo, zero regression).
+   */
+  cachedEntries?: ReadonlyMap<string, { blobSha: string; uid?: string }>;
   watermark: WatermarkRecord | null;
   /**
    * Actual root tree SHA of the `watermark.lastSyncedSha` commit on the
@@ -67,7 +79,8 @@ interface DiskEntry {
 export async function detectChanges(
   params: DetectChangesParams,
 ): Promise<ChangeDetectionResult> {
-  const { localFiles, watermark, actualBaseTreeSha, sha1 } = params;
+  const { localFiles, cachedEntries, watermark, actualBaseTreeSha, sha1 } =
+    params;
 
   if (watermark === null) {
     return { kind: "full-conflict", reason: "first-sync" };
@@ -98,6 +111,14 @@ export async function detectChanges(
       // Bytes are opaque (file-mode, D18): no uid identity — path matches.
       uid: typeof content === "string" ? extractAssetUid(content) : undefined,
     });
+  }
+  // mtime-manifest cache hits (perf): unchanged files whose blobSha+uid the
+  // caller already resolved — no read, no hash. Disjoint from `localFiles`.
+  if (cachedEntries !== undefined) {
+    for (const [path, entry] of cachedEntries) {
+      diskBlobShas.set(path, entry.blobSha);
+      disk.push({ path, blobSha: entry.blobSha, uid: entry.uid });
+    }
   }
 
   const added: AssetChange[] = [];

--- a/packages/exocortex/src/services/sync/FileLocalManifestStore.ts
+++ b/packages/exocortex/src/services/sync/FileLocalManifestStore.ts
@@ -1,0 +1,87 @@
+/**
+ * ExoSync durable per-device LOCAL MANIFEST store (perf, ExoSync Phase 1).
+ *
+ * Sibling of {@link FileWatermarkStore}: one JSON file holds every repo's
+ * {@link LocalManifestRecord}, keyed by `repoKey`. The file carries the
+ * `.local.` infix (`exosync-localmanifest.local.json`) so Obsidian Sync
+ * excludes it AND `isSyncablePath` refuses it symmetrically — the manifest is
+ * a DEVICE-LOCAL cache (file mtimes are device-specific) and must never be
+ * committed.
+ *
+ * Purpose: the mtime-manifest skips reading + re-hashing files whose
+ * `(mtimeMs, size)` are unchanged since the last sync, reusing the stored
+ * `blobSha`/`uid`. On a 14-AS / ~6304-file iPhone vault that turns a no-op
+ * sync's dominant cost (read + SHA-1 of every file) into a cheap stat sweep.
+ *
+ * Corruption tolerance (matches the watermark store, R10): a missing or
+ * unparseable file yields `get() === null` for every repo — the engine then
+ * reads + hashes every file (status quo), NEVER a wrong skip. The store never
+ * throws on read. Writes are serialised through a promise chain (lossless RMW
+ * across repos) and MUST be atomic at the IO layer (temp + rename) so a crash
+ * mid-write cannot leave a torn cache.
+ *
+ * Reuses {@link WatermarkFileIO} — the same trivial single-file IO contract
+ * (read / atomic-write) both platforms already implement for the watermark.
+ */
+
+import type { LocalManifestRecord, LocalManifestStorePort } from "./syncTypes";
+import type { WatermarkFileIO } from "./FileWatermarkStore";
+
+/** Recommended store filename — `.local.` infix is Sync-excluded. */
+export const LOCAL_MANIFEST_STORE_FILENAME = "exosync-localmanifest.local.json";
+
+interface StoreShape {
+  version: 1;
+  repos: Record<string, LocalManifestRecord>;
+}
+
+function isLocalManifestRecord(v: unknown): v is LocalManifestRecord {
+  if (v === null || typeof v !== "object") return false;
+  const r = v as Record<string, unknown>;
+  return (
+    r.version === 1 &&
+    typeof r.lastFullRehashMs === "number" &&
+    r.files !== null &&
+    typeof r.files === "object"
+  );
+}
+
+export class FileLocalManifestStore implements LocalManifestStorePort {
+  private writeChain: Promise<void> = Promise.resolve();
+
+  constructor(private readonly io: WatermarkFileIO) {}
+
+  async get(repoKey: string): Promise<LocalManifestRecord | null> {
+    const repos = await this.readRepos();
+    const record = repos[repoKey];
+    return isLocalManifestRecord(record) ? record : null;
+  }
+
+  async set(repoKey: string, record: LocalManifestRecord): Promise<void> {
+    const task = this.writeChain.then(async () => {
+      const repos = await this.readRepos();
+      repos[repoKey] = record;
+      const store: StoreShape = { version: 1, repos };
+      await this.io.writeAtomic(JSON.stringify(store));
+    });
+    // Keep the chain alive even when a write fails — the NEXT set must still
+    // run; the failure propagates to THIS caller only.
+    this.writeChain = task.catch(() => undefined);
+    return task;
+  }
+
+  /** Tolerant read: absent/corrupt file → empty store (R10, never throws). */
+  private async readRepos(): Promise<Record<string, LocalManifestRecord>> {
+    try {
+      const raw = await this.io.read();
+      if (raw === null) return {};
+      const parsed = JSON.parse(raw) as unknown;
+      if (parsed === null || typeof parsed !== "object") return {};
+      const repos = (parsed as { repos?: unknown }).repos;
+      if (repos === null || typeof repos !== "object") return {};
+      return { ...(repos as Record<string, LocalManifestRecord>) };
+    } catch {
+      return {};
+    }
+  }
+}

--- a/packages/exocortex/src/services/sync/SyncEngine.ts
+++ b/packages/exocortex/src/services/sync/SyncEngine.ts
@@ -86,6 +86,9 @@ import {
   type AssetChange,
   type ChangeDetectionResult,
   type LocalFilesPort,
+  type LocalManifestEntry,
+  type LocalManifestRecord,
+  type LocalManifestStorePort,
   type MaterializationCheckPort,
   type MergeLayerPort,
   type MountBaseStorePort,
@@ -104,6 +107,17 @@ import {
 /** D16: retries after the first non-fast-forward failure. */
 export const DEFAULT_MAX_PUSH_RETRIES = 3;
 
+/**
+ * Zero-loss safety valve for the mtime-manifest (perf, ExoSync Phase 1).
+ * When `now - lastFullRehashMs >= this`, the engine ignores the `(mtime,size)`
+ * cache and re-hashes EVERY file — catching the (extraordinarily rare) content
+ * edit that preserved both mtime and byte-size, which the cache would
+ * otherwise skip. Time-based (not per-sync-count) so the staleness window is
+ * bounded by wall-clock regardless of sync frequency, and frequent no-op syncs
+ * stay cheap. Default 12h; override via {@link SyncEngineDeps.localManifestFullRehashMs}.
+ */
+export const DEFAULT_LOCAL_MANIFEST_REHASH_MS = 12 * 60 * 60 * 1000;
+
 export interface SyncEngineDeps {
   transport: RestCommitTransport;
   watermarkStore: WatermarkStorePort;
@@ -121,6 +135,26 @@ export interface SyncEngineDeps {
    * (M1 zero-loss intact). See {@link MountBaseStorePort}.
    */
   mountBaseStore?: MountBaseStorePort;
+  /**
+   * Per-device local mtime-manifest store (perf, ExoSync Phase 1). When wired
+   * AND the per-repo {@link LocalFilesPort} provides `stat`, the engine skips
+   * reading + re-hashing ASSET-mode files whose `(mtimeMs, size)` are
+   * unchanged since the last sync, reusing the cached `blobSha`/`uid`. Absent
+   * (or no `stat`) ⇒ the engine reads + hashes every file each sync (status
+   * quo, zero regression). Disabled for file-mode (Phase C binary) repos. The
+   * cache never changes a sync OUTCOME — only which files are read/hashed; a
+   * stale entry causes a re-hash (cache miss), never a wrong skip (M1
+   * zero-loss), and a periodic full re-hash backstops the mtime-preserving
+   * edit. See {@link LocalManifestStorePort}.
+   */
+  localManifestStore?: LocalManifestStorePort;
+  /**
+   * Override for the mtime-manifest periodic full-rehash interval (ms). See
+   * {@link DEFAULT_LOCAL_MANIFEST_REHASH_MS}. Lower = smaller staleness window
+   * for the mtime-preserving edit, more frequent full re-hashes; tests inject
+   * `0` (rehash every sync) or `Infinity` (never).
+   */
+  localManifestFullRehashMs?: number;
   /**
    * #3590 full fix — base BACKFILL source for repos MOUNTED BEFORE the mount
    * layer began recording the base (or by any path that never recorded one):
@@ -634,6 +668,13 @@ export class SyncEngine {
           return rawWriteBinary(path, bytes);
         });
     }
+    // mtime-manifest stat sweep (perf) — metadata-only, timed into the
+    // `localList` bucket (same directory-walk phase). The before/after signal
+    // is the collapse of `localRead`/`hash` + their counts, not stat time.
+    const rawStat = raw.stat?.bind(raw);
+    if (rawStat !== undefined) {
+      wrapped.stat = (path) => timed("localList", () => rawStat(path));
+    }
     return wrapped;
   }
 
@@ -872,29 +913,12 @@ export class SyncEngine {
       }
 
       const maxBytes = this.deps.maxFileBytes ?? DEFAULT_MAX_FILE_BYTES;
-      const disk = new Map<string, SyncContent>();
-      // Paths excluded by the size cap on the LOCAL side. The exclusion
-      // must hold across every representation (disk snapshot, diff base,
-      // remote diff, watermark) — a path visible on one side only would
-      // read as a phantom add/delete (reviewer HIGH: cap-boundary
-      // crossing).
-      const sizeExcluded = new Set<string>();
-      for (const path of (await localFiles.list()).filter(mode.syncable)) {
-        if (mode.fileMode) {
-          const bytes = await readBinaryStrict(localFiles, path);
-          if (bytes.byteLength > maxBytes) {
-            sizeExcluded.add(path);
-            warnings.push(
-              `skipped oversized file ${path} (${bytes.byteLength} bytes > ${maxBytes} cap) — excluded from sync symmetrically (Phase C size cap)`,
-            );
-            continue;
-          }
-          disk.set(path, bytes);
-        } else {
-          disk.set(path, await localFiles.read(path));
-        }
-      }
 
+      // The watermark is loaded BEFORE the local snapshot so the mtime-manifest
+      // cache (perf) can be gated on its presence: the cache only applies to a
+      // steady-state sync — first-sync logic (bootstrapWatermark / file-mode
+      // first-sync) needs the FULL disk snapshot, so a null watermark forces a
+      // read+hash of every file (status quo). (Reordered from after the loop.)
       let watermark = await this.deps.watermarkStore.get(spec.repoKey);
       // Kind-flip guard (reviewer MEDIUM — makes the documented downgrade
       // marker operational): a file-mode watermark read by an asset-mode
@@ -921,6 +945,102 @@ export class SyncEngine {
         );
         watermark = null;
       }
+
+      // ── Local snapshot (mtime-manifest optimisation, perf — ExoSync Ph1) ──
+      // When the port exposes `stat`, a manifest store is wired, the watermark
+      // exists and this is an ASSET-mode repo, files whose `(mtimeMs, size)`
+      // match the manifest are NOT read or re-hashed — their cached blobSha/uid
+      // is reused. This collapses a no-op sync's dominant cost (read + SHA-1 of
+      // every file) into a cheap stat sweep. Any other case reads + hashes every
+      // file exactly as before (status quo, zero regression). file-mode (Phase C
+      // binary) is intentionally excluded — the dominant cost is the asset md
+      // corpus, and binary keeps its size-cap-on-read path unchanged.
+      // `.bind` so the method is called with its own port as `this` (no
+      // unbound-method) — the instrumented `stat` is an arrow closure, so the
+      // bind is a no-op functionally but keeps the linter sound.
+      const statFn =
+        this.deps.localManifestStore !== undefined
+          ? localFiles.stat?.bind(localFiles)
+          : undefined;
+      const canUseCache =
+        statFn !== undefined && watermark !== null && !mode.fileMode;
+      const manifest =
+        canUseCache && this.deps.localManifestStore !== undefined
+          ? await this.deps.localManifestStore.get(spec.repoKey)
+          : null;
+      const rehashIntervalMs =
+        this.deps.localManifestFullRehashMs ?? DEFAULT_LOCAL_MANIFEST_REHASH_MS;
+      // Zero-loss safety valve: bypass the cache (re-hash everything) on the
+      // first sync with no manifest and every `rehashIntervalMs`, catching the
+      // (extraordinarily rare) edit that preserved both mtime and size.
+      const fullRehash =
+        canUseCache &&
+        (manifest === null ||
+          this.now() - manifest.lastFullRehashMs >= rehashIntervalMs);
+
+      const disk = new Map<string, SyncContent>();
+      // Paths excluded by the size cap on the LOCAL side. The exclusion
+      // must hold across every representation (disk snapshot, diff base,
+      // remote diff, watermark) — a path visible on one side only would
+      // read as a phantom add/delete (reviewer HIGH: cap-boundary
+      // crossing).
+      const sizeExcluded = new Set<string>();
+      // mtime-manifest cache hits (perf): blobSha+uid reused without read/hash,
+      // DISJOINT from `disk`. Fed to detectChanges as `cachedEntries`.
+      const reused = new Map<string, { blobSha: string; uid?: string }>();
+      // blobSha at sync-start for cache-hit (NOT-read) files — applyRemoteChanges
+      // needs it for the TOCTOU check (their content is absent from `disk`).
+      const cachedBlobShas = new Map<string, string>();
+      // (mtimeMs,size) for every present cache-participating path — to rebuild
+      // the manifest after detection.
+      const statByPath = new Map<string, { mtimeMs: number; size: number }>();
+      // Persist the manifest only when it actually changed (a file was
+      // read/added/removed) or a full re-hash advanced its timestamp — a pure
+      // no-op sync (every file a cache hit) writes nothing.
+      let manifestDirty = false;
+      for (const path of (await localFiles.list()).filter(mode.syncable)) {
+        if (mode.fileMode) {
+          const bytes = await readBinaryStrict(localFiles, path);
+          if (bytes.byteLength > maxBytes) {
+            sizeExcluded.add(path);
+            warnings.push(
+              `skipped oversized file ${path} (${bytes.byteLength} bytes > ${maxBytes} cap) — excluded from sync symmetrically (Phase C size cap)`,
+            );
+            continue;
+          }
+          disk.set(path, bytes);
+          continue;
+        }
+        if (!canUseCache || statFn === undefined) {
+          // status quo — read + hash every asset file.
+          disk.set(path, await localFiles.read(path));
+          continue;
+        }
+        const st = await statFn(path);
+        const cached =
+          !fullRehash && st !== null ? manifest?.files[path] : undefined;
+        if (
+          st !== null &&
+          cached !== undefined &&
+          cached.mtimeMs === st.mtimeMs &&
+          cached.size === st.size
+        ) {
+          // Cache hit — unchanged since last sync: reuse blobSha+uid, NO read,
+          // NO hash. The (mtime,size) match is the unchanged-content signal.
+          reused.set(path, {
+            blobSha: cached.blobSha,
+            ...(cached.uid !== undefined ? { uid: cached.uid } : {}),
+          });
+          cachedBlobShas.set(path, cached.blobSha);
+          statByPath.set(path, st);
+          continue;
+        }
+        // Cache miss (new / mtime-or-size changed / full re-hash) — read + hash.
+        manifestDirty = true;
+        disk.set(path, await localFiles.read(path));
+        if (st !== null) statByPath.set(path, st);
+      }
+
       let syntheticFirstSyncBase = false;
       if (watermark === null) {
         if (!mode.fileMode) {
@@ -980,6 +1100,9 @@ export class SyncEngine {
       this.emitProgress(onProgress, spec.repoKey, "detecting");
       const detection = await detectChanges({
         localFiles: disk,
+        // Cache hits fold into the diff WITHOUT re-hashing (perf). Empty/absent
+        // when the cache is off → every file is hashed from `disk` (status quo).
+        ...(canUseCache ? { cachedEntries: reused } : {}),
         watermark,
         actualBaseTreeSha: await this.resolveBaseTreeSha(spec, watermark),
         sha1: this.sha1,
@@ -990,6 +1113,57 @@ export class SyncEngine {
         });
       }
       warnings.push(...detection.warnings);
+
+      // Rebuild + persist the mtime-manifest (perf). Done right after detection
+      // so it covers the no-op fast path too. `detection.diskBlobShas` now holds
+      // the blobSha for BOTH freshly-read and reused files; reused files carry
+      // their stat forward. A pulled file's stale entry (recorded pre-pull) only
+      // causes a re-hash next sync (cache miss) — never a wrong skip. Persisted
+      // only when dirty (a file changed, or the full-rehash timestamp advanced).
+      if (canUseCache && this.deps.localManifestStore !== undefined) {
+        const files: Record<string, LocalManifestEntry> = {};
+        for (const [path, content] of disk) {
+          const st = statByPath.get(path);
+          const blobSha = detection.diskBlobShas.get(path);
+          if (st === undefined || blobSha === undefined) continue;
+          const uid =
+            typeof content === "string" ? extractAssetUid(content) : undefined;
+          files[path] = {
+            mtimeMs: st.mtimeMs,
+            size: st.size,
+            blobSha,
+            ...(uid !== undefined ? { uid } : {}),
+          };
+        }
+        for (const [path, entry] of reused) {
+          const st = statByPath.get(path);
+          if (st === undefined) continue;
+          files[path] = {
+            mtimeMs: st.mtimeMs,
+            size: st.size,
+            blobSha: entry.blobSha,
+            ...(entry.uid !== undefined ? { uid: entry.uid } : {}),
+          };
+        }
+        // A path present last time but gone now (deleted) ⇒ the manifest shrank.
+        if (
+          manifest !== null &&
+          Object.keys(manifest.files).some((p) => !(p in files))
+        ) {
+          manifestDirty = true;
+        }
+        if (manifestDirty || fullRehash || manifest === null) {
+          const record: LocalManifestRecord = {
+            version: 1,
+            files,
+            lastFullRehashMs:
+              fullRehash || manifest === null
+                ? this.now()
+                : manifest.lastFullRehashMs,
+          };
+          await this.deps.localManifestStore.set(spec.repoKey, record);
+        }
+      }
 
       const pinned = this.pinLocalChanges(
         detection,
@@ -1187,6 +1361,9 @@ export class SyncEngine {
         ),
         applyDeletes.filter((d) => !withheldPaths.has(d.path)),
         warnings,
+        // mtime-manifest: cache-hit (NOT-read) files have no `disk` snapshot —
+        // their sync-start blobSha drives the TOCTOU check instead.
+        cachedBlobShas,
       );
 
       // Quarantined paths keep their OLD watermark entry (same mechanism as
@@ -2145,6 +2322,12 @@ export class SyncEngine {
     applyWrites: RemoteChange[],
     applyDeletes: RemoteChange[],
     warnings: string[],
+    // mtime-manifest (perf): sync-start blobSha for cache-hit files that were
+    // NOT read (so absent from `disk`). For those the TOCTOU check compares a
+    // fresh hash against this blobSha instead of comparing content snapshots —
+    // a cache hit must NOT read as "vanished from snapshot" and wrongly defer
+    // the pull (M1 zero-loss: never overwrites a concurrently-edited file).
+    cachedBlobShas: ReadonlyMap<string, string> = new Map(),
   ): Promise<{ pulledCount: number; pinnedPaths: Set<string> }> {
     let pulledCount = 0;
     const pinnedPaths = new Set<string>();
@@ -2173,6 +2356,16 @@ export class SyncEngine {
         await writeBinaryStrict(localFiles, path, content);
       }
     };
+    // TOCTOU verdict for a cache-hit path (no content snapshot): the file is
+    // safe to overwrite/delete iff its CURRENT content still hashes to the
+    // sync-start blobSha. A mismatch (concurrent edit, or the rare
+    // mtime-preserving edit) defers — never a silent overwrite.
+    const cacheHitUnchanged = async (path: string): Promise<boolean> => {
+      const current = await tryRead(path, false); // manifest cache = asset text
+      if (current === undefined) return true; // already gone — write recreates / delete no-ops
+      const currentSha = await gitBlobSha(current, this.sha1);
+      return currentSha === cachedBlobShas.get(path);
+    };
     for (const w of applyWrites) {
       if (w.content === undefined) continue; // change entries always carry content
       if (!isSafeRepoRelativePath(w.path)) {
@@ -2181,6 +2374,19 @@ export class SyncEngine {
         continue;
       }
       const snapshot = disk.get(w.path);
+      if (snapshot === undefined && cachedBlobShas.has(w.path)) {
+        // Cache-hit local file (unchanged per manifest, not read this sync).
+        if (!(await cacheHitUnchanged(w.path))) {
+          warnings.push(
+            `pull-apply skipped: ${w.path} changed on disk mid-sync (TOCTOU) — remote change re-derives next sync`,
+          );
+          pinnedPaths.add(w.path);
+          continue;
+        }
+        await writeContent(w.path, w.content);
+        pulledCount++;
+        continue;
+      }
       const current = await tryRead(
         w.path,
         typeof (snapshot ?? w.content) !== "string",
@@ -2202,6 +2408,19 @@ export class SyncEngine {
         continue;
       }
       const snapshot = disk.get(d.path);
+      if (snapshot === undefined && cachedBlobShas.has(d.path)) {
+        // Cache-hit local file being remote-deleted (not read this sync).
+        if (!(await cacheHitUnchanged(d.path))) {
+          warnings.push(
+            `pull-delete skipped: ${d.path} changed on disk mid-sync (TOCTOU) — delete-vs-modify re-derives next sync`,
+          );
+          pinnedPaths.add(d.path);
+          continue;
+        }
+        await localFiles.delete(d.path);
+        pulledCount++;
+        continue;
+      }
       if (snapshot !== undefined) {
         const current = await tryRead(d.path, typeof snapshot !== "string");
         if (current !== undefined && !contentEquals(current, snapshot)) {

--- a/packages/exocortex/src/services/sync/syncTypes.ts
+++ b/packages/exocortex/src/services/sync/syncTypes.ts
@@ -139,6 +139,63 @@ export interface MountBaseStorePort {
 }
 
 /**
+ * One file's entry in the per-device local mtime-manifest (perf, ExoSync
+ * Phase 1). A content-addressing CACHE keyed by `(mtimeMs, size)`: when a
+ * file's current stat matches a stored entry, its `blobSha` (and parsed
+ * `uid`) are reused WITHOUT reading or re-hashing the file. The keying fact:
+ * any real edit through Obsidian/the OS bumps `mtimeMs` (and usually `size`),
+ * so an unchanged `(mtimeMs, size)` reliably means unchanged content. The one
+ * theoretical hole — a content edit that preserves BOTH mtime and byte-size —
+ * is backstopped by the periodic full re-hash (see
+ * {@link LocalManifestRecord.lastFullRehashMs}) and, when the remote also
+ * moved, by the remote tree-SHA diff. NEVER a content authority.
+ */
+export interface LocalManifestEntry {
+  /** File modification time (ms) captured when the blobSha was computed. */
+  mtimeMs: number;
+  /** File byte size captured when the blobSha was computed. */
+  size: number;
+  /** Git blob SHA of the content at that `(mtimeMs, size)`. */
+  blobSha: string;
+  /** `exo__Asset_uid` parsed from the content then, if present (asset mode). */
+  uid?: string;
+}
+
+/**
+ * Per-device, per-repo local file manifest (perf cache). Lives in the SAME
+ * NON-synced device-local store family as the watermark (`.local.`-infix,
+ * Sync-excluded) — file mtimes are device-specific. Tolerant: a
+ * missing/corrupt record means "no cache" → the engine reads+hashes every
+ * file (status quo), never a wrong skip.
+ */
+export interface LocalManifestRecord {
+  version: 1;
+  /** Cache entries keyed by repo-relative forward-slash path. */
+  files: Record<string, LocalManifestEntry>;
+  /**
+   * Wall-clock (ms) of the last FULL re-hash (cache bypass). Zero-loss
+   * safety valve: when `now - lastFullRehashMs >= fullRehashIntervalMs` the
+   * engine ignores the cache and re-hashes every file, catching the
+   * (extraordinarily rare) edit that preserved both mtime and size. Bounds
+   * the staleness window to the interval regardless of sync frequency.
+   */
+  lastFullRehashMs: number;
+}
+
+/**
+ * Per-device local manifest persistence port (perf). Absent ⇒ the
+ * mtime-manifest optimisation is disabled and the engine reads+hashes every
+ * file each sync (status quo, zero regression). Tolerant on read (corrupt ⇒
+ * `null` ⇒ full re-hash), atomic on write (temp+rename) like the watermark
+ * store — a torn manifest is harmless (re-hash) but must never be a wrong
+ * skip.
+ */
+export interface LocalManifestStorePort {
+  get(repoKey: string): Promise<LocalManifestRecord | null>;
+  set(repoKey: string, record: LocalManifestRecord): Promise<void>;
+}
+
+/**
  * Local working-tree access for ONE repo, repo-relative forward-slash paths.
  * String content only — binary attachments are out of A1 scope (Phase C,
  * D4/VL#3); the engine additionally applies {@link isSyncablePath} so adapters
@@ -166,6 +223,18 @@ export interface LocalFilesPort {
   readBinary?(path: string): Promise<Uint8Array>;
   /** Byte-exact atomic write (same atomicity contract as {@link write}). */
   writeBinary?(path: string, bytes: Uint8Array): Promise<void>;
+  /**
+   * Cheap file metadata (modification time + byte size) WITHOUT reading the
+   * content — the mtime-manifest optimisation (perf, ExoSync Phase 1). Returns
+   * `null` when the path does not exist. OPTIONAL: a port without it disables
+   * the optimisation (the engine falls back to reading+hashing every file —
+   * status quo, zero regression). CLI: `node:fs` `stat().mtimeMs`/`size`;
+   * plugin: `DataAdapter.stat().mtime`/`size`. Used ONLY to decide whether a
+   * file is unchanged since the last sync — NEVER as a content authority (the
+   * blobSha cache is keyed by `(mtime, size)`, and a periodic full re-hash +
+   * the remote tree-SHA still backstop a mtime-preserving edit; M1 zero-loss).
+   */
+  stat?(path: string): Promise<{ mtimeMs: number; size: number } | null>;
 }
 
 /** Result of the full-materialization gate check (D19). */

--- a/packages/exocortex/tests/unit/services/sync/FileLocalManifestStore.test.ts
+++ b/packages/exocortex/tests/unit/services/sync/FileLocalManifestStore.test.ts
@@ -1,0 +1,95 @@
+/**
+ * ExoSync Phase 1 (perf) — durable per-device local mtime-manifest store.
+ *
+ * Sibling contract to {@link FileWatermarkStore}: per-repoKey records in one
+ * JSON file, tolerant on read (corrupt/missing ⇒ `null` ⇒ the engine re-hashes
+ * every file — NEVER a wrong skip), atomic on write, lossless RMW across repos.
+ */
+
+import {
+  FileLocalManifestStore,
+  LOCAL_MANIFEST_STORE_FILENAME,
+  isSyncablePath,
+  type LocalManifestRecord,
+  type WatermarkFileIO,
+} from "../../../../src";
+
+class FakeIO implements WatermarkFileIO {
+  content: string | null = null;
+  writes = 0;
+  failNextWrite = false;
+  async read(): Promise<string | null> {
+    return this.content;
+  }
+  async writeAtomic(content: string): Promise<void> {
+    if (this.failNextWrite) {
+      this.failNextWrite = false;
+      throw new Error("disk full");
+    }
+    this.writes++;
+    this.content = content;
+  }
+}
+
+const record = (sha: string): LocalManifestRecord => ({
+  version: 1,
+  lastFullRehashMs: 1700,
+  files: {
+    "a.md": { mtimeMs: 1000, size: 42, blobSha: `blob-${sha}`, uid: "u1" },
+    "b.md": { mtimeMs: 1001, size: 7, blobSha: `blob2-${sha}` },
+  },
+});
+
+describe("FileLocalManifestStore", () => {
+  it("round-trips records per repoKey through one JSON file", async () => {
+    const io = new FakeIO();
+    const store = new FileLocalManifestStore(io);
+
+    await store.set("o/r1#main", record("s1"));
+    await store.set("o/r2#main", record("s2"));
+
+    expect(await store.get("o/r1#main")).toEqual(record("s1"));
+    expect(await store.get("o/r2#main")).toEqual(record("s2"));
+    expect(await store.get("o/unknown#main")).toBeNull();
+    expect(JSON.parse(io.content ?? "")).toMatchObject({ version: 1 });
+  });
+
+  it("missing file → null for every repo (full re-hash path)", async () => {
+    const store = new FileLocalManifestStore(new FakeIO());
+    expect(await store.get("o/r#main")).toBeNull();
+  });
+
+  it("corrupt JSON → null, never throws (R10 — re-hash, not wrong skip)", async () => {
+    const io = new FakeIO();
+    io.content = "{ not json !!!";
+    const store = new FileLocalManifestStore(io);
+    expect(await store.get("o/r#main")).toBeNull();
+
+    // Wrong shape (missing lastFullRehashMs / files) → rejected → null.
+    io.content = JSON.stringify({ version: 1, repos: { "o/r#main": "junk" } });
+    expect(await store.get("o/r#main")).toBeNull();
+    io.content = JSON.stringify({
+      version: 1,
+      repos: { "o/r#main": { version: 1, files: {} } }, // no lastFullRehashMs
+    });
+    expect(await store.get("o/r#main")).toBeNull();
+  });
+
+  it("a failed write propagates to the caller but keeps the chain alive", async () => {
+    const io = new FakeIO();
+    const store = new FileLocalManifestStore(io);
+    io.failNextWrite = true;
+    await expect(store.set("o/r#main", record("s1"))).rejects.toThrow(
+      "disk full",
+    );
+    // Next write must still run (chain not poisoned).
+    await store.set("o/r#main", record("s2"));
+    expect(await store.get("o/r#main")).toEqual(record("s2"));
+  });
+
+  it("the store filename carries the Sync-excluded `.local.` infix", () => {
+    expect(LOCAL_MANIFEST_STORE_FILENAME).toContain(".local.");
+    // Symmetric guard: the engine's allowlist must REFUSE to sync it.
+    expect(isSyncablePath(LOCAL_MANIFEST_STORE_FILENAME)).toBe(false);
+  });
+});

--- a/packages/exocortex/tests/unit/services/sync/SyncEngine.mtime-manifest.test.ts
+++ b/packages/exocortex/tests/unit/services/sync/SyncEngine.mtime-manifest.test.ts
@@ -1,0 +1,410 @@
+/**
+ * ExoSync Phase 1 (perf) — mtime-manifest local-hash skip.
+ *
+ * The dominant cost of an iPhone sync on a 14-AS / ~6304-file vault is the
+ * UNCONDITIONAL local read + SHA-1 of EVERY file each sync (no mtime cache —
+ * `exosync-perf-plan-2026-06-20.md` §2). This optimisation persists a per-file
+ * `{mtimeMs, size, blobSha, uid}` manifest between syncs and SKIPS reading +
+ * re-hashing files whose `(mtimeMs, size)` are unchanged, reusing the cached
+ * blobSha — turning a no-op sync into a cheap stat sweep.
+ *
+ * ⛤ The zero-loss invariant is SACRED: the cache must NEVER cause a change to
+ * be missed. These tests prove (a) the perf win (reads/hashes collapse to the
+ * changed-file count), (b) OUTCOME parity (manifest on/off produce identical
+ * detection — the cache changes only WHICH files are read, never the result),
+ * (c) the TOCTOU guard for cache-hit pulled files, and (d) the safety net:
+ * the rare mtime+size-preserving edit is missed by the cache (revert) but
+ * caught by the periodic full re-hash (restore) — `integration-test-revert-verify`.
+ *
+ * Production-shape (`test-fixture-realism`): the SAME `FakeGitHubRepo` every
+ * other SyncEngine test uses, a stat-tracking local port that mirrors a real
+ * filesystem (writes bump mtime; stat reports the live byte size) and an
+ * in-memory manifest store mirroring `FileLocalManifestStore`'s contract.
+ */
+
+import {
+  SyncEngine,
+  type LocalFilesPort,
+  type LocalManifestRecord,
+  type LocalManifestStorePort,
+  type SyncEngineDeps,
+} from "../../../../src";
+import {
+  FakeGitHubRepo,
+  FakeWatermarkStore,
+  alwaysMaterialized,
+  mdAsset,
+  sha1Hex,
+} from "./fakeGitHub";
+
+/**
+ * Local port with real-filesystem semantics: a write bumps the file's mtime;
+ * `stat` reports the live `(mtimeMs, size)`. The cache keys off exactly this.
+ */
+class StatLocalFiles implements LocalFilesPort {
+  readonly files = new Map<string, string>();
+  private readonly mtimes = new Map<string, number>();
+  private clock = 1000;
+
+  constructor(initial: Record<string, string> = {}) {
+    for (const [p, c] of Object.entries(initial)) {
+      this.files.set(p, c);
+      this.mtimes.set(p, ++this.clock);
+    }
+  }
+
+  async list(): Promise<string[]> {
+    return [...this.files.keys()];
+  }
+  async read(path: string): Promise<string> {
+    const c = this.files.get(path);
+    if (c === undefined) throw new Error(`ENOENT: ${path}`);
+    return c;
+  }
+  async write(path: string, content: string): Promise<void> {
+    this.files.set(path, content);
+    this.mtimes.set(path, ++this.clock); // every write bumps mtime (real FS)
+  }
+  async delete(path: string): Promise<void> {
+    this.files.delete(path);
+    this.mtimes.delete(path);
+  }
+  async stat(
+    path: string,
+  ): Promise<{ mtimeMs: number; size: number } | null> {
+    const c = this.files.get(path);
+    if (c === undefined) return null;
+    return { mtimeMs: this.mtimes.get(path)!, size: Buffer.byteLength(c) };
+  }
+
+  // ── test mutators ──────────────────────────────────────────────────────
+  /** A normal user edit through Obsidian: content + mtime change. */
+  userEdit(path: string, content: string): void {
+    this.files.set(path, content);
+    this.mtimes.set(path, ++this.clock);
+  }
+  /** A new local file appears. */
+  addLocal(path: string, content: string): void {
+    this.files.set(path, content);
+    this.mtimes.set(path, ++this.clock);
+  }
+  /** A local file is removed (outside the sync). */
+  removeLocal(path: string): void {
+    this.files.delete(path);
+    this.mtimes.delete(path);
+  }
+  /**
+   * The pathological zero-loss edge: content changes but mtime AND size are
+   * BOTH preserved (a tool that restores mtime, identical byte length). Real
+   * editors never do this — but the safety net must catch it anyway.
+   */
+  edgeEditPreservingStat(path: string, content: string): void {
+    const before = this.files.get(path);
+    if (before === undefined) throw new Error(`ENOENT: ${path}`);
+    if (Buffer.byteLength(before) !== Buffer.byteLength(content)) {
+      throw new Error("test bug: edge edit must preserve byte size");
+    }
+    this.files.set(path, content); // mtime deliberately NOT bumped
+  }
+}
+
+/** In-memory manifest store mirroring FileLocalManifestStore's contract. */
+class MemManifestStore implements LocalManifestStorePort {
+  readonly records = new Map<string, LocalManifestRecord>();
+  setCount = 0;
+  async get(repoKey: string): Promise<LocalManifestRecord | null> {
+    return this.records.get(repoKey) ?? null;
+  }
+  async set(repoKey: string, record: LocalManifestRecord): Promise<void> {
+    this.setCount++;
+    this.records.set(repoKey, JSON.parse(JSON.stringify(record)));
+  }
+}
+
+/** A manifest store that returns garbage — corruption tolerance (R10). */
+class CorruptManifestStore implements LocalManifestStorePort {
+  async get(): Promise<LocalManifestRecord | null> {
+    // simulate a torn/garbage record the store-layer parse would reject → null
+    return null;
+  }
+  async set(): Promise<void> {
+    /* writes ignored */
+  }
+}
+
+function makeEngine(
+  gh: FakeGitHubRepo,
+  local: LocalFilesPort,
+  overrides: Partial<SyncEngineDeps> = {},
+): SyncEngine {
+  return new SyncEngine({
+    transport: gh.transport(),
+    watermarkStore: new FakeWatermarkStore(),
+    materializationCheck: alwaysMaterialized(),
+    localFilesFor: () => local,
+    sha1: sha1Hex,
+    now: () => 1_000_000, // fixed clock; default 12h rehash → no auto-rehash
+    ...overrides,
+  });
+}
+
+const A = "assets/a.md";
+const B = "assets/b.md";
+const C = "assets/c.md";
+
+/**
+ * Drive the engine to a WARM cache: a clean-mount first sync seeds the
+ * watermark, a second sync (manifest still empty ⇒ full re-hash) writes the
+ * manifest. The THIRD+ sync is the steady state under test. Returns the result
+ * of the last (steady-state, no-op) sync.
+ */
+async function warmUp(
+  engine: SyncEngine,
+  gh: FakeGitHubRepo,
+): Promise<void> {
+  await engine.syncAll([gh.spec()], "sync"); // sync 1 — seed watermark
+  await engine.syncAll([gh.spec()], "sync"); // sync 2 — seed manifest (full rehash)
+}
+
+describe("SyncEngine — mtime-manifest local-hash skip (perf, zero-loss)", () => {
+  it("warm no-op sync reads + hashes ZERO files (the perf win)", async () => {
+    const files = { [A]: mdAsset("u1"), [B]: mdAsset("u2"), [C]: mdAsset("u3") };
+    const gh = new FakeGitHubRepo(files);
+    const local = new StatLocalFiles(files);
+    const manifest = new MemManifestStore();
+    const engine = makeEngine(gh, local, { localManifestStore: manifest });
+
+    await warmUp(engine, gh);
+    const [r] = await engine.syncAll([gh.spec()], "sync"); // steady-state no-op
+
+    expect(r.status).toBe("synced");
+    expect(r.pushedCount).toBe(0);
+    expect(r.pulledCount).toBe(0);
+    // The headline before/after signal: a no-op steady-state sync touches no
+    // file content at all — only stats.
+    expect(r.timings!.counts.filesRead).toBe(0);
+    expect(r.timings!.counts.filesHashed).toBe(0);
+  });
+
+  it("re-hashes ONLY the changed file; unchanged files stay cache hits", async () => {
+    const files = { [A]: mdAsset("u1"), [B]: mdAsset("u2"), [C]: mdAsset("u3") };
+    const gh = new FakeGitHubRepo(files);
+    const local = new StatLocalFiles(files);
+    const manifest = new MemManifestStore();
+    const engine = makeEngine(gh, local, { localManifestStore: manifest });
+
+    await warmUp(engine, gh);
+    local.userEdit(B, mdAsset("u2", "edited locally")); // mtime + size change
+
+    const [r] = await engine.syncAll([gh.spec()], "sync");
+
+    expect(r.status).toBe("synced");
+    expect(r.pushedCount).toBe(1); // only B pushed
+    // The headline cache win: ONLY B is read — A and C are reused from the
+    // manifest (no read ⇒ no detection hash for them).
+    expect(r.timings!.counts.filesRead).toBe(1);
+    // B is hashed in detection AND once more by the pre-existing phantom-push
+    // guard (#3475, head-tree dedup of the pushed blob) — bounded by the push
+    // count, not the working-tree size. A/C contribute zero hashes.
+    expect(r.timings!.counts.filesHashed).toBe(2);
+    // The edit reached the remote.
+    expect(gh.headFiles().get(B)).toBe(mdAsset("u2", "edited locally"));
+  });
+
+  it("same-size edit that bumps mtime IS detected (mtime alone catches it)", async () => {
+    // Real editors bump mtime even when the byte length is unchanged.
+    const files = { [A]: mdAsset("u1", "aaaa") };
+    const gh = new FakeGitHubRepo(files);
+    const local = new StatLocalFiles(files);
+    const manifest = new MemManifestStore();
+    const engine = makeEngine(gh, local, { localManifestStore: manifest });
+
+    await warmUp(engine, gh);
+    // Same byte length ("bbbb" === "aaaa".length), mtime bumped by userEdit.
+    local.userEdit(A, mdAsset("u1", "bbbb"));
+
+    const [r] = await engine.syncAll([gh.spec()], "sync");
+
+    expect(r.status).toBe("synced");
+    expect(r.pushedCount).toBe(1);
+    expect(gh.headFiles().get(A)).toBe(mdAsset("u1", "bbbb"));
+  });
+
+  it("detects a local add and a local delete with the cache warm", async () => {
+    const files = { [A]: mdAsset("u1"), [B]: mdAsset("u2") };
+    const gh = new FakeGitHubRepo(files);
+    const local = new StatLocalFiles(files);
+    const manifest = new MemManifestStore();
+    const engine = makeEngine(gh, local, { localManifestStore: manifest });
+
+    await warmUp(engine, gh);
+    local.addLocal(C, mdAsset("u3")); // new file
+    local.removeLocal(B); // deleted file
+
+    const [r] = await engine.syncAll([gh.spec()], "sync");
+
+    expect(r.status).toBe("synced");
+    expect(r.pushedCount).toBe(1); // C added
+    expect(r.pushedDeletes).toEqual([B]); // B deletion propagated
+    const head = gh.headFiles();
+    expect(head.has(C)).toBe(true);
+    expect(head.has(B)).toBe(false);
+  });
+
+  it("pulls a remote change onto a cache-hit (unread) file — TOCTOU guard", async () => {
+    // The regression guard: a pulled file that was NOT read this sync (cache
+    // hit) must NOT read as 'vanished from snapshot' and wrongly TOCTOU-skip.
+    const files = { [A]: mdAsset("u1"), [B]: mdAsset("u2") };
+    const gh = new FakeGitHubRepo(files);
+    const local = new StatLocalFiles(files);
+    const manifest = new MemManifestStore();
+    const engine = makeEngine(gh, local, { localManifestStore: manifest });
+
+    await warmUp(engine, gh);
+    // Device B edits A on the remote; locally A is unchanged (cache hit).
+    gh.commitDirect(gh.branch, { [A]: mdAsset("u1", "remote edit") }, "device B");
+
+    const [r] = await engine.syncAll([gh.spec()], "sync");
+
+    expect(r.status).toBe("synced");
+    expect(r.pulledCount).toBe(1); // A pulled — NOT skipped
+    expect(local.files.get(A)).toBe(mdAsset("u1", "remote edit"));
+  });
+
+  it("OUTCOME parity: manifest ON vs OFF produce identical detection", async () => {
+    const files = { [A]: mdAsset("u1"), [B]: mdAsset("u2"), [C]: mdAsset("u3") };
+    const scenario = (local: StatLocalFiles, gh: FakeGitHubRepo): void => {
+      local.userEdit(A, mdAsset("u1", "local edit")); // local modify → push
+      local.addLocal("assets/d.md", mdAsset("u4")); // local add → push
+      gh.commitDirect(gh.branch, { [C]: mdAsset("u3", "remote") }, "device B"); // remote → pull
+    };
+
+    // OFF — no manifest store wired (status quo: reads + hashes everything).
+    const ghOff = new FakeGitHubRepo(files);
+    const localOff = new StatLocalFiles(files);
+    const engOff = makeEngine(ghOff, localOff);
+    await engOff.syncAll([ghOff.spec()], "sync"); // seed watermark
+    scenario(localOff, ghOff);
+    const [off] = await engOff.syncAll([ghOff.spec()], "sync");
+
+    // ON — manifest store wired + warm cache.
+    const ghOn = new FakeGitHubRepo(files);
+    const localOn = new StatLocalFiles(files);
+    const engOn = makeEngine(ghOn, localOn, {
+      localManifestStore: new MemManifestStore(),
+    });
+    await warmUp(engOn, ghOn);
+    scenario(localOn, ghOn);
+    const [on] = await engOn.syncAll([ghOn.spec()], "sync");
+
+    // Identical OUTCOME — the cache changes only WHICH files are read.
+    expect(on.status).toBe(off.status);
+    expect(on.pushedCount).toBe(off.pushedCount);
+    expect(on.pulledCount).toBe(off.pulledCount);
+    expect((on.pushedDeletes ?? []).sort()).toEqual(
+      (off.pushedDeletes ?? []).sort(),
+    );
+    // Identical final disk + remote state.
+    expect([...localOn.files.entries()].sort()).toEqual(
+      [...localOff.files.entries()].sort(),
+    );
+    expect([...ghOn.headFiles().entries()].sort()).toEqual(
+      [...ghOff.headFiles().entries()].sort(),
+    );
+  });
+
+  // ── ZERO-LOSS safety net (integration-test-revert-verify discipline) ─────
+  // REVERT: with the safety valve OFF (rehash interval = Infinity), the cache
+  // misses the pathological mtime+size-preserving edit.
+  // RESTORE: with the valve ON (interval = 0 → re-hash every sync), the edit
+  // is caught. Proves the periodic full re-hash is what makes the edge safe.
+
+  it("REVERT: a mtime+size-preserving edit is MISSED while full-rehash is disabled", async () => {
+    const files = { [A]: mdAsset("u1", "aaaa") };
+    const gh = new FakeGitHubRepo(files);
+    const local = new StatLocalFiles(files);
+    const engine = makeEngine(gh, local, {
+      localManifestStore: new MemManifestStore(),
+      localManifestFullRehashMs: Number.POSITIVE_INFINITY, // never re-hash
+    });
+
+    await warmUp(engine, gh);
+    // Same byte length, mtime NOT bumped — the pathological edge.
+    local.edgeEditPreservingStat(A, mdAsset("u1", "bbbb"));
+
+    const [r] = await engine.syncAll([gh.spec()], "sync");
+
+    // Demonstrates the edge: the cache wrongly treats A as unchanged → the
+    // edit is NOT pushed. (This is WHY the safety valve below exists.)
+    expect(r.pushedCount).toBe(0);
+    expect(gh.headFiles().get(A)).toBe(mdAsset("u1", "aaaa")); // stale on remote
+  });
+
+  it("RESTORE: the periodic full re-hash CATCHES the mtime+size-preserving edit", async () => {
+    const files = { [A]: mdAsset("u1", "aaaa") };
+    const gh = new FakeGitHubRepo(files);
+    const local = new StatLocalFiles(files);
+    const engine = makeEngine(gh, local, {
+      localManifestStore: new MemManifestStore(),
+      localManifestFullRehashMs: 0, // re-hash every sync (safety valve forced)
+    });
+
+    await warmUp(engine, gh);
+    local.edgeEditPreservingStat(A, mdAsset("u1", "bbbb"));
+
+    const [r] = await engine.syncAll([gh.spec()], "sync");
+
+    // The full re-hash reads + hashes A regardless of stat → the edit IS
+    // detected and pushed. Zero-loss restored.
+    expect(r.pushedCount).toBe(1);
+    expect(gh.headFiles().get(A)).toBe(mdAsset("u1", "bbbb"));
+  });
+
+  it("falls back to read+hash-all when no manifest store is wired (opt-in)", async () => {
+    const files = { [A]: mdAsset("u1"), [B]: mdAsset("u2") };
+    const gh = new FakeGitHubRepo(files);
+    const local = new StatLocalFiles(files);
+    const engine = makeEngine(gh, local); // no localManifestStore
+
+    await engine.syncAll([gh.spec()], "sync"); // seed watermark
+    const [r] = await engine.syncAll([gh.spec()], "sync"); // would be a no-op
+
+    expect(r.status).toBe("synced");
+    // Status quo: every file read + hashed even on a no-op (no cache).
+    expect(r.timings!.counts.filesRead).toBe(2);
+    expect(r.timings!.counts.filesHashed).toBe(2);
+  });
+
+  it("tolerates a corrupt/empty manifest store (full re-hash, no crash)", async () => {
+    const files = { [A]: mdAsset("u1") };
+    const gh = new FakeGitHubRepo(files);
+    const local = new StatLocalFiles(files);
+    const engine = makeEngine(gh, local, {
+      localManifestStore: new CorruptManifestStore(),
+    });
+
+    await engine.syncAll([gh.spec()], "sync");
+    local.userEdit(A, mdAsset("u1", "edit"));
+    const [r] = await engine.syncAll([gh.spec()], "sync");
+
+    // get() always null → full re-hash every sync → still correct.
+    expect(r.status).toBe("synced");
+    expect(r.pushedCount).toBe(1);
+    expect(gh.headFiles().get(A)).toBe(mdAsset("u1", "edit"));
+  });
+
+  it("a pure no-op steady-state sync does NOT re-write the manifest", async () => {
+    const files = { [A]: mdAsset("u1"), [B]: mdAsset("u2") };
+    const gh = new FakeGitHubRepo(files);
+    const local = new StatLocalFiles(files);
+    const manifest = new MemManifestStore();
+    const engine = makeEngine(gh, local, { localManifestStore: manifest });
+
+    await warmUp(engine, gh); // sync 2 wrote the manifest once
+    const before = manifest.setCount;
+    await engine.syncAll([gh.spec()], "sync"); // pure no-op
+    await engine.syncAll([gh.spec()], "sync"); // pure no-op
+
+    expect(manifest.setCount).toBe(before); // no churn on cache-hit no-ops
+  });
+});

--- a/packages/obsidian-plugin/src/infrastructure/adapters/SyncDepsFactory.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/SyncDepsFactory.ts
@@ -1,9 +1,11 @@
 import type { App, DataAdapter } from "obsidian";
 import yaml from "js-yaml";
 import {
+  FileLocalManifestStore,
   FileMountBaseStore,
   FileWatermarkStore,
   GatedStructuredMerger,
+  LOCAL_MANIFEST_STORE_FILENAME,
   MOUNT_BASE_STORE_FILENAME,
   QuarantineResolver,
   SYNC_BRANCH,
@@ -202,7 +204,7 @@ export function vaultLocalFilesPort(
   rootPath: string,
 ): LocalFilesPort {
   const abs = (rel: string): string => `${rootPath}/${rel}`;
-  return {
+  const port: LocalFilesPort = {
     async list(): Promise<string[]> {
       const out: string[] = [];
       const walk = async (dir: string): Promise<void> => {
@@ -257,6 +259,29 @@ export function vaultLocalFilesPort(
       await adapter.rename(tmp, target);
     },
   };
+  // mtime-manifest (perf): expose `stat` ONLY when the underlying adapter
+  // supports it. Real Obsidian `DataAdapter.stat` is cheap metadata (no content
+  // read) and works on desktop AND mobile; an adapter without it (an older
+  // host, a partial test double) simply disables the optimisation — the engine
+  // falls back to reading+hashing every file (status quo, zero regression),
+  // never a crash.
+  const rawStat = (
+    adapter as {
+      stat?: (
+        path: string,
+      ) => Promise<{ type?: string; mtime: number; size: number } | null>;
+    }
+  ).stat;
+  if (typeof rawStat === "function") {
+    port.stat = async (
+      path: string,
+    ): Promise<{ mtimeMs: number; size: number } | null> => {
+      const s = await rawStat.call(adapter, abs(path));
+      if (s === null || s === undefined || s.type !== "file") return null;
+      return { mtimeMs: s.mtime, size: s.size };
+    };
+  }
+  return port;
 }
 
 /** Single-file `WatermarkFileIO` over `vault.adapter` (D8 store). */
@@ -406,6 +431,10 @@ export async function buildSyncEngine(
   // `RestAssetSpaceMount` under the SAME path convention (same vault.adapter,
   // same `.local.`-infix file).
   const mountBasePath = `${configDir}/plugins/exocortex/${MOUNT_BASE_STORE_FILENAME}`;
+  // mtime-manifest (perf) — device-local, `.local.`-infix, same store family as
+  // the watermark; skips reading+re-hashing unchanged asset files each sync
+  // (the dominant iPhone cost on a 14-AS / ~6304-file vault).
+  const manifestPath = `${configDir}/plugins/exocortex/${LOCAL_MANIFEST_STORE_FILENAME}`;
 
   let quarantine: QuarantinePort | undefined;
   const quarantineUrl = opts.quarantineRepoUrl?.trim() ?? "";
@@ -454,6 +483,11 @@ export async function buildSyncEngine(
     transport,
     watermarkStore: new FileWatermarkStore(
       vaultWatermarkFileIO(adapter, watermarkPath),
+    ),
+    // mtime-manifest local-hash skip (perf) — same vault.adapter IO/store
+    // family as the watermark. The port's `stat` (added above) gates it.
+    localManifestStore: new FileLocalManifestStore(
+      vaultWatermarkFileIO(adapter, manifestPath),
     ),
     mountBaseStore: new FileMountBaseStore(
       vaultWatermarkFileIO(adapter, mountBasePath),

--- a/packages/obsidian-plugin/tests/unit/sync/syncTestHelpers.ts
+++ b/packages/obsidian-plugin/tests/unit/sync/syncTestHelpers.ts
@@ -43,10 +43,18 @@ interface FakeRequestUrlParam {
 export class InMemoryAdapter {
   readonly files = new Map<string, string | Uint8Array>();
   readonly dirs = new Set<string>([""]);
+  // mtime tracking — mirrors a real FS: every write bumps the file's mtime, so
+  // the mtime-manifest (perf) detects changes exactly as on a real device.
+  private readonly mtimes = new Map<string, number>();
+  private clock = 1_000;
 
   private parent(p: string): string {
     const i = p.lastIndexOf("/");
     return i < 0 ? "" : p.slice(0, i);
+  }
+
+  private touch(p: string): void {
+    this.mtimes.set(p, ++this.clock);
   }
 
   async exists(path: string): Promise<boolean> {
@@ -67,6 +75,7 @@ export class InMemoryAdapter {
       throw new Error(`ENOENT: parent folder of ${path} does not exist`);
     }
     this.files.set(path, content);
+    this.touch(path);
   }
 
   /** Real `DataAdapter.readBinary` shape — ArrayBuffer, byte-exact. */
@@ -89,12 +98,14 @@ export class InMemoryAdapter {
       throw new Error(`ENOENT: parent folder of ${path} does not exist`);
     }
     this.files.set(path, new Uint8Array(data));
+    this.touch(path);
   }
 
   async remove(path: string): Promise<void> {
     if (!this.files.delete(path)) {
       throw new Error(`ENOENT: ${path}`);
     }
+    this.mtimes.delete(path);
   }
 
   async rename(from: string, to: string): Promise<void> {
@@ -109,6 +120,28 @@ export class InMemoryAdapter {
     }
     this.files.delete(from);
     this.files.set(to, content);
+    this.mtimes.delete(from);
+    this.touch(to);
+  }
+
+  /** Real `DataAdapter.stat` shape — cheap metadata (mtime/size, no read). */
+  async stat(
+    path: string,
+  ): Promise<{
+    type: "file" | "folder";
+    ctime: number;
+    mtime: number;
+    size: number;
+  } | null> {
+    if (this.dirs.has(path)) {
+      return { type: "folder", ctime: 0, mtime: 0, size: 0 };
+    }
+    const content = this.files.get(path);
+    if (content === undefined) return null;
+    const size =
+      typeof content === "string" ? Buffer.byteLength(content) : content.byteLength;
+    const mtime = this.mtimes.get(path) ?? ++this.clock;
+    return { type: "file", ctime: mtime, mtime, size };
   }
 
   async mkdir(path: string): Promise<void> {
@@ -156,6 +189,7 @@ export class InMemoryAdapter {
     const i = path.lastIndexOf("/");
     if (i > 0) this.mkdirAll(path.slice(0, i));
     this.files.set(path, content);
+    this.touch(path); // a re-seed simulates a local edit → mtime bumps
   }
 }
 


### PR DESCRIPTION
## What

Persists a per-device **mtime-manifest** between ExoSync runs so unchanged files are **not read or re-hashed** each sync.

ExoSync's dominant iPhone cost (>2 min on a 14-AS / ~6304-file vault) is the **unconditional local read + SHA-1 of every file** each sync — there was no mtime cache, so unchanged files re-hash every time (verified against `origin/main`; root cause in `exosync-perf-plan-2026-06-20.md` §2, Phase 0 timings shipped v16.125.2).

## How

- New device-local store `exosync-localmanifest.local.json` (Sync-excluded, same `.local.`-infix family as the watermark) holding `{ mtimeMs, size, blobSha, uid }` per file (`FileLocalManifestStore`).
- On an **asset-mode** sync with a watermark, files whose `(mtimeMs, size)` match the manifest reuse the cached blobSha/uid — **no `read`, no `gitBlobSha`**. A no-op steady-state sync collapses to a cheap `stat` sweep.
- New optional `LocalFilesPort.stat` + `SyncEngineDeps.localManifestStore` ports; wired identically for **CLI** (`node:fs`) and **plugin** (`vault.adapter`, desktop + mobile) — no engine fork.

## Zero-loss (M1 SACRED)

The cache changes only **which files are read**, never the sync **outcome**. A stale entry causes a re-hash (cache miss), **never a wrong skip**. Three backstops for the rare content edit that preserves *both* mtime and byte-size:
1. `(mtime, size)` key — real editors bump mtime;
2. time-based **periodic full re-hash** (default 12h, `localManifestFullRehashMs`) re-hashes everything;
3. the existing remote tree-SHA diff.

Cache-hit (unread) **pulled** files get a blobSha-based **TOCTOU guard** so a clean pull is never wrongly deferred.

**Opt-in & zero-regression:** disabled unless the port exposes `stat` **and** a manifest store is wired ⇒ falls back to read+hash-all. file-mode (Phase C binary) keeps its read path untouched.

## Tests (TDD)

- `SyncEngine.mtime-manifest.test.ts` (11): perf win (no-op reads/hashes **0** files), re-hash only the changed file, **outcome parity** (manifest on/off identical detection + final disk/remote state), TOCTOU on cache-hit pulls, add/delete detection, opt-in fallback, corruption tolerance, no-churn on no-ops, and the **revert→fail / restore→pass** zero-loss pair (the mtime+size-preserving edit is *missed* with the safety valve off, *caught* with it on).
- `FileLocalManifestStore.test.ts` (5): round-trip, corruption tolerance, chain-alive-after-failed-write, `.local.` Sync-exclusion.
- `ExoSyncRequestUrlParity.integration.test.ts` now exercises the manifest end-to-end via a stat-capable `InMemoryAdapter`.

Local: full exocortex suite 311 suites / 8045 tests, CLI exosync 32, plugin sync 99 + integration 108, typecheck clean, eslint `--max-warnings=0` clean, build + mobile-loadable green.

## Validation (measure-first, for @kitelev on iPhone)

Before/after via the Phase 0 per-sync breakdown: `localRead` + `hash` durations and `filesRead`/`filesHashed` counts should collapse from ~6304 to the changed-file count on a steady-state sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)