### PR TITLE
test(reqs): bind 5 NON-sync P0 req__Requirement assets via @req tags (RFC 0003 P2/P5)

### DIFF
--- a/packages/cli/tests/integration/apply-class-resolver.integration.test.ts
+++ b/packages/cli/tests/integration/apply-class-resolver.integration.test.ts
@@ -152,7 +152,7 @@ describe("Issue #3258: CLI `apply` emits UID-form exo__Instance_class", () => {
     }
   }
 
-  it("emits exo__Instance_class as UID-form wikilink when class TBox is present", async () => {
+  it("@req:56d736ac-21e2-4536-81a4-f270f9cda34e emits exo__Instance_class as UID-form wikilink when class TBox is present", async () => {
     vault = buildVault({ withClassTBox: true });
 
     await runApply(vault.root);

--- a/packages/cli/tests/integration/apply-targetvaluequery.integration.test.ts
+++ b/packages/cli/tests/integration/apply-targetvaluequery.integration.test.ts
@@ -164,7 +164,7 @@ describe("RFC 78c2b7d0 C4 — CLI apply property_set targetValueQuery", () => {
     }
   }
 
-  it("re-anchors isDefinedBy to the NamedQuery-computed archive ontology (real mutation)", async () => {
+  it("@req:bbaa37e1-de71-426e-9399-97dba43967e4 re-anchors isDefinedBy to the NamedQuery-computed archive ontology (real mutation)", async () => {
     const vault = buildVault();
     root = vault.root;
 

--- a/packages/cli/tests/integration/commands/audit-co-location.integration.test.ts
+++ b/packages/cli/tests/integration/commands/audit-co-location.integration.test.ts
@@ -56,7 +56,7 @@ describe("audit co-location — revert→fail / restore→pass (integration)", (
     rmSync(vault, { recursive: true, force: true });
   });
 
-  it("PASS when co-located, FAIL when moved away, PASS again when restored", async () => {
+  it("@req:dd9d1be5-16d4-49be-bbde-1e4fdd53c8ee PASS when co-located, FAIL when moved away, PASS again when restored", async () => {
     // --- State 1: co-located → audit PASS (0 violations) ---
     const coLocated = writeAsset(ontoDir, ASSET_UID, `"[[${ONTO_UID}]]"`);
     let r = await scanVaultForCoLocation(vault);

--- a/packages/cli/tests/integration/create-cardinality.integration.test.ts
+++ b/packages/cli/tests/integration/create-cardinality.integration.test.ts
@@ -199,7 +199,7 @@ describe("Issue #3179: create cardinality emission via core service (integration
     );
   });
 
-  it("AC#1: ems__Effort_relatesTo (Multiple cardinality) → array form", async () => {
+  it("@req:699d121c-d410-4a26-b68c-14470ded6d39 AC#1: ems__Effort_relatesTo (Multiple cardinality) → array form", async () => {
     const { frontmatter, content } = await run(
       { ems__Effort_relatesTo: `[[${STATUS_BACKLOG_UID}]]` },
       "TEST-3179-multi",

--- a/packages/cli/tests/integration/rename-to-uid-update-inbound-links.integration.test.ts
+++ b/packages/cli/tests/integration/rename-to-uid-update-inbound-links.integration.test.ts
@@ -63,7 +63,7 @@ describe("Issue #3113: rename-to-uid updates inbound wikilinks", () => {
     return full;
   }
 
-  it("collapses all wikilink shapes to bare [[uid]]; skips code/embeds/already-UID-form", async () => {
+  it("@req:8dc90308-e3e8-4f46-918a-c7757dd4b675 collapses all wikilink shapes to bare [[uid]]; skips code/embeds/already-UID-form", async () => {
     const inbox = "01 Inbox/Choco.md";
     write(inbox, targetFile({ uid: ASSET_UID, label: "Choco" }));
 


### PR DESCRIPTION
## What

Binds **5 new `req__Requirement` assets** (RFC 0003 P2/P5 ramp, `exoas-exo-reqs` increment 4) to existing exo **NON-sync** integration tests by adding a `@req:<uid>` token to each test's `it()` title. **Test-title-only change — no production code change.**

| `@req` uid | test file | behavior | class |
| --- | --- | --- | --- |
| `56d736ac` | `apply-class-resolver.integration.test.ts` | cli apply emits UID-form `exo__Instance_class` (UI parity) when class TBox present (#3258) | integration |
| `699d121c` | `create-cardinality.integration.test.ts` | create emits scalar vs YAML-array per declared SHACL cardinality (#3179) | integration |
| `8dc90308` | `rename-to-uid-update-inbound-links.integration.test.ts` | rename-to-uid collapses inbound wikilinks to bare `[[uid]]` (#3113) | integration |
| `dd9d1be5` | `audit-co-location.integration.test.ts` | audit co-location flags asset folder ≠ isDefinedBy ontology folder (CR-1) | integration |
| `bbaa37e1` | `apply-targetvaluequery.integration.test.ts` | property_set `targetValueQuery` computes value from a NamedQuery (RFC 78c2b7d0 C4) | integration |

All 5 are **P0**, **`integration`-class** (P0 binding-class floor satisfied — **no deferred floor**), each **empirically revert-verified** (break the production line → cited test RED on an assertion → restore → GREEN). Revert evidence is recorded in each req asset body + the P2 WBS node (`exoas-exodev` `17e868ff` increment 4).

## Revert-verify (each break→RED→restore→GREEN, origin/main `1a6915d5`)

- `56d736ac` — null-resolver replaces `createVaultFrontmatterClassLabelResolver` in `apply.ts` → instance emits label-form `[[ems__Task]]` → RED.
- `699d121c` — `GenericAssetCreationService.shouldEmitAsArray` forced `return false` → Multiple→scalar → RED.
- `8dc90308` — `replaceWikilinks` returns `_match` (counter kept) → inbound `[[Choco]]` uncollapsed → RED.
- `dd9d1be5` — `scanVaultForCoLocation` mismatch push disabled → moved asset not flagged → RED.
- `bbaa37e1` — `resolveTargetValueQuery` iri→`""` → isDefinedBy not re-anchored → RED.

## Checker

`exocortex-cli requirements audit` → **22 requirements / 22 bound / 100% coverage / 22 tags / 0 hard findings**. SHACL = 0 on vault-exodev. archgate REQ-001 (well-formed `@req` tags) PASS.

## Scope

- ⛔ NON-sync only (sync was the area of a parallel session).
- req assets + pointers shipped on the vault side (`exoas-exo-reqs` `75ec868`, node `ab8ab8f`, vault-exodev `99bb71c`); this PR ships only the `@req` test-title tags.