### PR TITLE
feat(sync): device-local conflict cache — offline-resolution foundation (PR-2)

### DIFF
--- a/packages/cli/src/commands/exosync-sync.ts
+++ b/packages/cli/src/commands/exosync-sync.ts
@@ -39,11 +39,14 @@ import { promisify } from "node:util";
 import * as path from "node:path";
 import yaml from "js-yaml";
 import {
+  CONFLICT_CACHE_STORE_FILENAME,
+  CompositeQuarantineStore,
   FileLocalManifestStore,
   FileMountBaseStore,
   FileWatermarkStore,
   GatedStructuredMerger,
   LOCAL_MANIFEST_STORE_FILENAME,
+  LocalConflictCacheStore,
   MOUNT_BASE_STORE_FILENAME,
   StructuredMerger,
   SyncedQuarantineStore,
@@ -448,11 +451,27 @@ export async function runExosyncSync(
     "exocortex",
     LOCAL_MANIFEST_STORE_FILENAME,
   );
-  let quarantine: QuarantinePort | undefined;
+  // Device-local conflict cache (offline-resolution foundation) — ALWAYS wired,
+  // same `.local.` (Sync-excluded) store family as the watermark; reuses
+  // `nodeWatermarkFileIO` verbatim. Captures the 3 versions of every conflict on
+  // disk so the resolver works offline (PR-3) and conflicts are never dropped.
+  const conflictCachePath = path.join(
+    vaultPath,
+    configDir,
+    "plugins",
+    "exocortex",
+    CONFLICT_CACHE_STORE_FILENAME,
+  );
+  const conflictCache = new LocalConflictCacheStore({
+    io: nodeWatermarkFileIO(conflictCachePath),
+  });
+
+  let quarantine: QuarantinePort = conflictCache;
   const quarantineUrl = opts.quarantineRepo?.trim() ?? "";
-  if (quarantineUrl.length > 0) {
+  const syncedQuarantineConfigured = quarantineUrl.length > 0;
+  if (syncedQuarantineConfigured) {
     const { owner, repo } = parseGitHubRepoUrl(quarantineUrl);
-    quarantine = new SyncedQuarantineStore({
+    const synced = new SyncedQuarantineStore({
       // The engine wraps ITS transport internally; the quarantine store is
       // the highest-volume caller, so it needs its own backoff wrap.
       transport: withRateLimitBackoff(transport),
@@ -462,6 +481,8 @@ export async function runExosyncSync(
       branch: SYNC_BRANCH,
       redact: (m) => pushService.redact(m),
     });
+    // Tee: device-local cache FIRST (durability-critical), synced repo second.
+    quarantine = new CompositeQuarantineStore([conflictCache, synced]);
   }
 
   const engine = new SyncEngine({
@@ -484,12 +505,12 @@ export async function runExosyncSync(
     // GatedStructuredMerger without a SHACL gate still quarantines
     // unresolvable merges (D17) — parity with the plugin's Phase B wiring.
     mergeLayer: new GatedStructuredMerger(new StructuredMerger(coreSchemaYaml)),
-    ...(quarantine !== undefined ? { quarantine } : {}),
+    quarantine,
     ...(opts.apiBase !== undefined ? { baseURL: opts.apiBase } : {}),
   });
 
   out(
-    `ExoSync ${direction}: ${specs.length} repo(s), vault ${vaultPath}${quarantine !== undefined ? " (quarantine configured)" : ""}`,
+    `ExoSync ${direction}: ${specs.length} repo(s), vault ${vaultPath}${syncedQuarantineConfigured ? " (synced quarantine configured)" : ""}`,
   );
   // Children before parents (deeper mount paths first) — D12 ordering.
   const ordered = orderChildrenFirst(specs);

--- a/packages/exocortex/src/index.ts
+++ b/packages/exocortex/src/index.ts
@@ -748,6 +748,17 @@ export {
   type QuarantineEntryRecord,
   type SyncedQuarantineStoreDeps,
 } from "./services/sync/SyncedQuarantineStore";
+// Device-local conflict cache (offline-resolution foundation): a QuarantinePort
+// that persists the 3 versions of every conflict to a `.local.` (Sync-excluded)
+// file so the resolver can work offline. CompositeQuarantineStore tees it with
+// the optional synced repo while both coexist.
+export {
+  LocalConflictCacheStore,
+  CONFLICT_CACHE_STORE_FILENAME,
+  type ConflictCacheRecord,
+  type LocalConflictCacheStoreDeps,
+} from "./services/sync/LocalConflictCacheStore";
+export { CompositeQuarantineStore } from "./services/sync/CompositeQuarantineStore";
 // ExoSync E1 — platform-free space-declaration classification core shared by
 // the plugin's collectSyncRepoSpecs and the CLI's exosync-parity collector
 // (one parser, no drift), plus the M1/M2 parity validation harness

--- a/packages/exocortex/src/services/sync/CompositeQuarantineStore.ts
+++ b/packages/exocortex/src/services/sync/CompositeQuarantineStore.ts
@@ -1,0 +1,66 @@
+/**
+ * ExoSync composite quarantine sink — fan-out one {@link QuarantinePort} call
+ * to several members.
+ *
+ * Bridges the device-local conflict cache (offline-resolution foundation) and
+ * the OPTIONAL synced quarantine repo while both coexist: when the user has a
+ * quarantine repo configured, the engine writes to BOTH — the device-local
+ * cache (so the resolver works offline) AND the synced repo (so the
+ * cross-device unresolved-count keeps working). When no repo is configured the
+ * factory wires the cache directly and this composite is not used.
+ *
+ * Zero-loss ordering: EVERY member is attempted even when an earlier one throws
+ * (a network failure of the synced repo must NOT skip the local cache write, on
+ * which offline durability now depends). The FIRST error is re-thrown after all
+ * members ran — so the device-local cache (placed first) is always written, yet
+ * a synced-store failure still surfaces to the engine, which degrades it to a
+ * warning / withholds a destructive file-mode apply (conservative, no loss).
+ */
+
+import type { QuarantineEntry, QuarantinePort } from "./syncTypes";
+
+export class CompositeQuarantineStore implements QuarantinePort {
+  private readonly members: readonly QuarantinePort[];
+
+  /** Members are attempted in order; place the durability-critical one first. */
+  constructor(members: readonly QuarantinePort[]) {
+    this.members = members;
+  }
+
+  async quarantine(entry: QuarantineEntry): Promise<void> {
+    await this.quarantineAll([entry]);
+  }
+
+  async quarantineAll(entries: QuarantineEntry[]): Promise<void> {
+    if (entries.length === 0) return;
+    let firstErr: unknown;
+    for (const member of this.members) {
+      try {
+        if (member.quarantineAll !== undefined) {
+          await member.quarantineAll(entries);
+        } else {
+          for (const entry of entries) await member.quarantine(entry);
+        }
+      } catch (err) {
+        if (firstErr === undefined) firstErr = err;
+      }
+    }
+    if (firstErr !== undefined) {
+      throw firstErr instanceof Error ? firstErr : new Error(String(firstErr));
+    }
+  }
+
+  async markResolved(repoKey: string, path: string): Promise<void> {
+    let firstErr: unknown;
+    for (const member of this.members) {
+      try {
+        await member.markResolved?.(repoKey, path);
+      } catch (err) {
+        if (firstErr === undefined) firstErr = err;
+      }
+    }
+    if (firstErr !== undefined) {
+      throw firstErr instanceof Error ? firstErr : new Error(String(firstErr));
+    }
+  }
+}

--- a/packages/exocortex/src/services/sync/LocalConflictCacheStore.ts
+++ b/packages/exocortex/src/services/sync/LocalConflictCacheStore.ts
@@ -1,0 +1,212 @@
+/**
+ * ExoSync device-local conflict cache (offline-resolution foundation).
+ *
+ * A {@link QuarantinePort} that persists the THREE versions of every
+ * quarantined conflict — base / local / remote content (plus the losing-local
+ * binary payload of a file-mode remote-wins resolution) — to a SINGLE
+ * device-local JSON file. The `.local.` infix Sync-excludes it (the exact
+ * convention the watermark store uses: Obsidian Sync skips it AND both
+ * `isSyncablePath` / `isFileSpaceSyncablePath` refuse it), so the cache NEVER
+ * leaves the device.
+ *
+ * Why it exists: today the engine HAS all three versions in memory at
+ * quarantine time ({@link QuarantineEntry}) but, with no quarantine sink wired,
+ * drops them — so the resolver must fetch the remote version over the network
+ * to show or resolve a conflict (it cannot work offline). Capturing the three
+ * versions here, on disk, is what lets the resolver list / diff / resolve a
+ * conflict with ZERO network (PR-3): the remote version is already local.
+ *
+ * ⛤ Deliberately NOT redacted (unlike {@link SyncedQuarantineStore}). The
+ * synced store redacts secrets because it COMMITS conflict copies to a remote
+ * git repo — a leak vector. This cache is the OPPOSITE: it never syncs (the
+ * `.local.` exclusion is the leak guard), and it MUST hold the EXACT bytes —
+ * a redacted cache would make the offline resolver diff and PUSH corrupted
+ * content (a redaction is not reversible). Leak mitigation here is "the file
+ * never leaves the device", not "the content is scrubbed".
+ *
+ * Same store family as {@link FileWatermarkStore}: single file, atomic IO
+ * through the injected {@link WatermarkFileIO}, tolerant read (a missing or
+ * corrupt file reads as an empty cache — never throws), serialized writes
+ * (a lossless read-modify-write chain so concurrent `quarantine` /
+ * `markResolved` calls cannot clobber each other).
+ */
+
+import { bytesToBase64 } from "../../utilities/base64";
+import type { WatermarkFileIO } from "./FileWatermarkStore";
+import type { QuarantineEntry, QuarantinePort } from "./syncTypes";
+
+/** Recommended store filename — `.local.` infix is Sync-excluded. */
+export const CONFLICT_CACHE_STORE_FILENAME = "exosync-conflicts.local.json";
+
+/** Persisted shape of one cached conflict (the 3 versions at quarantine time). */
+export interface ConflictCacheRecord {
+  version: 1;
+  repoKey: string;
+  /** Repo-relative forward-slash path. */
+  path: string;
+  uid?: string;
+  reason: string;
+  /** ISO timestamp of the FIRST time this (repoKey,path) was quarantined. */
+  quarantinedAt: string;
+  /** 3-way base content; absent ⇒ did not exist at the base (or unavailable). */
+  baseContent?: string;
+  /** Local content captured at quarantine time; absent ⇒ deleted locally. */
+  localContent?: string;
+  /** Remote (head-tree) content captured at quarantine time; absent ⇒ deleted remotely. */
+  remoteContent?: string;
+  /**
+   * Base64 of the losing-LOCAL binary bytes of a file-mode remote-wins
+   * resolution (D18) — the only durable copy of those bytes once the synced
+   * quarantine repo is gone. Asset-mode entries never carry this.
+   */
+  localContentBytesBase64?: string;
+}
+
+interface StoreShape {
+  version: 1;
+  /** Keyed by `repoKey\0path`. */
+  entries: Record<string, ConflictCacheRecord>;
+}
+
+/** Stable cache key for one conflict — repoKey + path (NUL-separated). */
+function cacheKey(repoKey: string, path: string): string {
+  return `${repoKey}\0${path}`;
+}
+
+function isRecord(v: unknown): v is ConflictCacheRecord {
+  if (v === null || typeof v !== "object") return false;
+  const r = v as Record<string, unknown>;
+  return (
+    typeof r.repoKey === "string" &&
+    typeof r.path === "string" &&
+    typeof r.reason === "string" &&
+    typeof r.quarantinedAt === "string"
+  );
+}
+
+export interface LocalConflictCacheStoreDeps {
+  io: WatermarkFileIO;
+  /** Injected clock (ISO string) — deterministic tests. */
+  now?: () => string;
+}
+
+export class LocalConflictCacheStore implements QuarantinePort {
+  private readonly io: WatermarkFileIO;
+  private readonly now: () => string;
+  private writeChain: Promise<void> = Promise.resolve();
+
+  constructor(deps: LocalConflictCacheStoreDeps) {
+    this.io = deps.io;
+    this.now = deps.now ?? ((): string => new Date().toISOString());
+  }
+
+  async quarantine(entry: QuarantineEntry): Promise<void> {
+    await this.quarantineAll([entry]);
+  }
+
+  /**
+   * Cache MANY entries in one read-modify-write. A re-quarantine of an entry
+   * that is already cached PRESERVES its original `quarantinedAt` (the conflict
+   * has been open since then) while refreshing the captured content — the
+   * disk/remote may have moved since the first capture, and the cache must
+   * mirror the version the engine just observed.
+   */
+  async quarantineAll(entries: QuarantineEntry[]): Promise<void> {
+    if (entries.length === 0) return;
+    await this.mutate((store) => {
+      for (const entry of entries) {
+        const key = cacheKey(entry.repoKey, entry.path);
+        const prior = store.entries[key];
+        const quarantinedAt =
+          prior !== undefined && isRecord(prior)
+            ? prior.quarantinedAt
+            : this.now();
+        store.entries[key] = {
+          version: 1,
+          repoKey: entry.repoKey,
+          path: entry.path,
+          ...(entry.uid !== undefined ? { uid: entry.uid } : {}),
+          reason: entry.reason,
+          quarantinedAt,
+          ...(entry.baseContent !== undefined
+            ? { baseContent: entry.baseContent }
+            : {}),
+          ...(entry.localContent !== undefined
+            ? { localContent: entry.localContent }
+            : {}),
+          ...(entry.remoteContent !== undefined
+            ? { remoteContent: entry.remoteContent }
+            : {}),
+          ...(entry.localContentBytes !== undefined
+            ? {
+                localContentBytesBase64: bytesToBase64(entry.localContentBytes),
+              }
+            : {}),
+        };
+      }
+    });
+  }
+
+  /**
+   * Drop a cached entry — called by the engine when a pinned path clears
+   * convergently (auto-resolve) and by the resolver after it resolves a
+   * conflict. A no-op when the entry is absent (port contract).
+   */
+  async markResolved(repoKey: string, path: string): Promise<void> {
+    const key = cacheKey(repoKey, path);
+    await this.mutate((store) => {
+      delete store.entries[key];
+    });
+  }
+
+  /** Every cached conflict (across all repos). Tolerant — never throws. */
+  async list(): Promise<ConflictCacheRecord[]> {
+    const store = await this.read();
+    return Object.values(store.entries).filter(isRecord);
+  }
+
+  /** One cached conflict, or null when not cached. Tolerant — never throws. */
+  async get(
+    repoKey: string,
+    path: string,
+  ): Promise<ConflictCacheRecord | null> {
+    const store = await this.read();
+    const record = store.entries[cacheKey(repoKey, path)];
+    return record !== undefined && isRecord(record) ? record : null;
+  }
+
+  /** Serialized read-modify-write (lossless RMW, atomic IO). */
+  private async mutate(fn: (store: StoreShape) => void): Promise<void> {
+    const task = this.writeChain.then(async () => {
+      const store = await this.read();
+      fn(store);
+      await this.io.writeAtomic(JSON.stringify(store, null, 2));
+    });
+    // Keep the chain alive even when a write fails — the NEXT mutate must still
+    // run; the failure propagates to THIS caller only.
+    this.writeChain = task.catch(() => undefined);
+    return task;
+  }
+
+  /** Tolerant read: absent/corrupt file → empty store (never throws). */
+  private async read(): Promise<StoreShape> {
+    try {
+      const raw = await this.io.read();
+      if (raw === null) return { version: 1, entries: {} };
+      const parsed = JSON.parse(raw) as unknown;
+      if (parsed === null || typeof parsed !== "object") {
+        return { version: 1, entries: {} };
+      }
+      const entries = (parsed as { entries?: unknown }).entries;
+      if (entries === null || typeof entries !== "object") {
+        return { version: 1, entries: {} };
+      }
+      return {
+        version: 1,
+        entries: { ...(entries as Record<string, ConflictCacheRecord>) },
+      };
+    } catch {
+      return { version: 1, entries: {} };
+    }
+  }
+}

--- a/packages/exocortex/tests/unit/services/sync/CompositeQuarantineStore.test.ts
+++ b/packages/exocortex/tests/unit/services/sync/CompositeQuarantineStore.test.ts
@@ -1,0 +1,102 @@
+/**
+ * ExoSync composite quarantine sink — fan-out to several QuarantinePort members
+ * with zero-loss ordering (every member runs even when an earlier one throws;
+ * the first error is re-thrown after all ran).
+ */
+
+import { describe, expect, it } from "@jest/globals";
+import {
+  CompositeQuarantineStore,
+  type QuarantineEntry,
+  type QuarantinePort,
+} from "../../../../src";
+
+const ENTRY: QuarantineEntry = {
+  repoKey: "o/r#main",
+  path: "a.md",
+  reason: "x",
+  localContent: "L",
+  remoteContent: "R",
+};
+
+/** Spy QuarantinePort recording calls, optionally throwing. */
+function spy(
+  opts: { hasAll?: boolean; throwOn?: "quarantine" | "markResolved" } = {},
+): {
+  port: QuarantinePort;
+  quarantined: QuarantineEntry[];
+  resolved: string[];
+} {
+  const quarantined: QuarantineEntry[] = [];
+  const resolved: string[] = [];
+  const port: QuarantinePort = {
+    async quarantine(entry) {
+      if (opts.throwOn === "quarantine") throw new Error("quarantine boom");
+      quarantined.push(entry);
+    },
+    async markResolved(repoKey, path) {
+      if (opts.throwOn === "markResolved") throw new Error("markResolved boom");
+      resolved.push(`${repoKey}\0${path}`);
+    },
+  };
+  if (opts.hasAll === true) {
+    port.quarantineAll = async (entries): Promise<void> => {
+      if (opts.throwOn === "quarantine") throw new Error("quarantineAll boom");
+      quarantined.push(...entries);
+    };
+  }
+  return { port, quarantined, resolved };
+}
+
+describe("CompositeQuarantineStore", () => {
+  it("fans out quarantine to every member (prefers quarantineAll, falls back to per-entry)", async () => {
+    const a = spy({ hasAll: true });
+    const b = spy({ hasAll: false }); // no quarantineAll → per-entry fallback
+    const composite = new CompositeQuarantineStore([a.port, b.port]);
+
+    await composite.quarantineAll([ENTRY, { ...ENTRY, path: "b.md" }]);
+
+    expect(a.quarantined.map((e) => e.path)).toEqual(["a.md", "b.md"]);
+    expect(b.quarantined.map((e) => e.path)).toEqual(["a.md", "b.md"]);
+  });
+
+  it("fans out markResolved to every member", async () => {
+    const a = spy();
+    const b = spy();
+    const composite = new CompositeQuarantineStore([a.port, b.port]);
+
+    await composite.markResolved("o/r#main", "a.md");
+
+    expect(a.resolved).toEqual(["o/r#main\0a.md"]);
+    expect(b.resolved).toEqual(["o/r#main\0a.md"]);
+  });
+
+  it("zero-loss ordering: a later member's failure does NOT skip the durable first member", async () => {
+    const cache = spy({ hasAll: true }); // durability-critical, listed first
+    const synced = spy({ hasAll: true, throwOn: "quarantine" }); // network fails
+    const composite = new CompositeQuarantineStore([cache.port, synced.port]);
+
+    // The composite re-throws (engine degrades conservatively) BUT the cache
+    // write must have happened first — the data is durable.
+    await expect(composite.quarantineAll([ENTRY])).rejects.toThrow(/boom/);
+    expect(cache.quarantined).toHaveLength(1);
+  });
+
+  it("markResolved still runs every member even if one throws, then re-throws", async () => {
+    const a = spy({ throwOn: "markResolved" });
+    const b = spy();
+    const composite = new CompositeQuarantineStore([a.port, b.port]);
+
+    await expect(composite.markResolved("o/r#main", "a.md")).rejects.toThrow(
+      /boom/,
+    );
+    expect(b.resolved).toEqual(["o/r#main\0a.md"]); // member b still ran
+  });
+
+  it("quarantineAll([]) is a no-op", async () => {
+    const a = spy({ hasAll: true });
+    const composite = new CompositeQuarantineStore([a.port]);
+    await composite.quarantineAll([]);
+    expect(a.quarantined).toHaveLength(0);
+  });
+});

--- a/packages/exocortex/tests/unit/services/sync/LocalConflictCacheStore.test.ts
+++ b/packages/exocortex/tests/unit/services/sync/LocalConflictCacheStore.test.ts
@@ -1,0 +1,278 @@
+/**
+ * ExoSync device-local conflict cache (offline-resolution foundation).
+ *
+ * Two layers, production-shape (test-fixture-realism):
+ *  1. Store mechanics over an in-memory single-file IO that mirrors the real
+ *     WatermarkFileIO contract (read → string|null, atomic write).
+ *  2. End-to-end: the REAL {@link SyncEngine} drives a genuine asset-mode
+ *     conflict and the cache (wired as the engine's quarantine sink) captures
+ *     all three versions on disk — the foundation the offline resolver reads.
+ */
+
+import { describe, expect, it } from "@jest/globals";
+import yaml from "js-yaml";
+import {
+  GatedStructuredMerger,
+  LocalConflictCacheStore,
+  CONFLICT_CACHE_STORE_FILENAME,
+  StructuredMerger,
+  SyncEngine,
+  type MergeLayerPort,
+  type QuarantineEntry,
+  type WatermarkFileIO,
+  type YamlCodec,
+} from "../../../../src";
+import {
+  FakeGitHubRepo,
+  FakeLocalFiles,
+  FakeWatermarkStore,
+  alwaysMaterialized,
+  mdAsset,
+  sha1Hex,
+} from "./fakeGitHub";
+
+/** In-memory WatermarkFileIO — same single-file contract the real adapters honour. */
+function memIO(): WatermarkFileIO & { content: string | null } {
+  const state: { content: string | null } = { content: null };
+  return {
+    get content(): string | null {
+      return state.content;
+    },
+    set content(v: string | null) {
+      state.content = v;
+    },
+    async read(): Promise<string | null> {
+      return state.content;
+    },
+    async writeAtomic(content: string): Promise<void> {
+      state.content = content;
+    },
+  };
+}
+
+const ENTRY: QuarantineEntry = {
+  repoKey: "o/r#main",
+  path: "assets/a.md",
+  uid: "u1",
+  reason: "frontmatter key changed differently on both sides",
+  baseContent: "base text",
+  localContent: "LOCAL text",
+  remoteContent: "REMOTE text",
+};
+
+const yamlCodec: YamlCodec = {
+  parse: (text) => yaml.load(text, { schema: yaml.CORE_SCHEMA }),
+  stringify: (value) =>
+    yaml.dump(value, { schema: yaml.CORE_SCHEMA, lineWidth: -1 }),
+};
+
+describe("LocalConflictCacheStore — store mechanics", () => {
+  it("caches all three versions of one conflict and lists/gets it back", async () => {
+    const io = memIO();
+    const store = new LocalConflictCacheStore({
+      io,
+      now: () => "2026-06-21T00:00:00Z",
+    });
+
+    await store.quarantine(ENTRY);
+
+    const listed = await store.list();
+    expect(listed).toHaveLength(1);
+    expect(listed[0]).toMatchObject({
+      repoKey: "o/r#main",
+      path: "assets/a.md",
+      uid: "u1",
+      baseContent: "base text",
+      localContent: "LOCAL text",
+      remoteContent: "REMOTE text",
+      quarantinedAt: "2026-06-21T00:00:00Z",
+    });
+    const got = await store.get("o/r#main", "assets/a.md");
+    expect(got?.localContent).toBe("LOCAL text");
+  });
+
+  it("stores the EXACT content unredacted — a cache that scrubbed secrets would push corruption", async () => {
+    const io = memIO();
+    const store = new LocalConflictCacheStore({ io });
+    const withSecret: QuarantineEntry = {
+      ...ENTRY,
+      localContent: "token: ghp_" + "x".repeat(36),
+    };
+
+    await store.quarantine(withSecret);
+
+    const got = await store.get(ENTRY.repoKey, ENTRY.path);
+    // The `.local.` exclusion is the leak guard; the bytes must survive verbatim.
+    expect(got?.localContent).toBe("token: ghp_" + "x".repeat(36));
+  });
+
+  it("round-trips a losing-local binary payload as base64 (file-mode, D18)", async () => {
+    const io = memIO();
+    const store = new LocalConflictCacheStore({ io });
+    const bytes = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x00, 0xff, 0x10]);
+
+    await store.quarantine({
+      repoKey: "o/r#main",
+      path: "img.png",
+      reason: "file-mode remote-wins; losing local preserved",
+      localContentBytes: bytes,
+    });
+
+    const got = await store.get("o/r#main", "img.png");
+    expect(got?.localContentBytesBase64).toBe(
+      Buffer.from(bytes).toString("base64"),
+    );
+  });
+
+  it("batches many entries in one quarantineAll", async () => {
+    const io = memIO();
+    const store = new LocalConflictCacheStore({ io });
+    await store.quarantineAll([
+      { ...ENTRY, path: "a.md" },
+      { ...ENTRY, path: "b.md" },
+    ]);
+    const paths = (await store.list()).map((r) => r.path).sort();
+    expect(paths).toEqual(["a.md", "b.md"]);
+  });
+
+  it("preserves quarantinedAt on re-quarantine but refreshes the captured content", async () => {
+    let n = 0;
+    const io = memIO();
+    const store = new LocalConflictCacheStore({
+      io,
+      now: () => `2026-06-21T00:00:0${n++}`,
+    });
+
+    await store.quarantine(ENTRY);
+    await store.quarantine({ ...ENTRY, remoteContent: "REMOTE moved again" });
+
+    const got = await store.get(ENTRY.repoKey, ENTRY.path);
+    expect(got?.quarantinedAt).toBe("2026-06-21T00:00:00"); // original, not refreshed
+    expect(got?.remoteContent).toBe("REMOTE moved again"); // content refreshed
+  });
+
+  it("markResolved drops the entry (no-op when absent)", async () => {
+    const io = memIO();
+    const store = new LocalConflictCacheStore({ io });
+    await store.quarantine(ENTRY);
+    expect(await store.list()).toHaveLength(1);
+
+    await store.markResolved(ENTRY.repoKey, ENTRY.path);
+    expect(await store.list()).toHaveLength(0);
+    // idempotent
+    await expect(
+      store.markResolved(ENTRY.repoKey, ENTRY.path),
+    ).resolves.toBeUndefined();
+  });
+
+  it("tolerant read: a corrupt/absent file reads as an empty cache, never throws", async () => {
+    const io = memIO();
+    io.content = "}{ not json";
+    const store = new LocalConflictCacheStore({ io });
+    expect(await store.list()).toEqual([]);
+    expect(await store.get("o/r#main", "a.md")).toBeNull();
+  });
+
+  it("serializes concurrent writes without clobbering (lossless RMW)", async () => {
+    const io = memIO();
+    const store = new LocalConflictCacheStore({ io });
+    await Promise.all([
+      store.quarantine({ ...ENTRY, path: "a.md" }),
+      store.quarantine({ ...ENTRY, path: "b.md" }),
+      store.quarantine({ ...ENTRY, path: "c.md" }),
+    ]);
+    expect((await store.list()).map((r) => r.path).sort()).toEqual([
+      "a.md",
+      "b.md",
+      "c.md",
+    ]);
+  });
+
+  it("uses the Sync-excluded `.local.` filename convention", () => {
+    expect(CONFLICT_CACHE_STORE_FILENAME).toContain(".local.");
+    expect(CONFLICT_CACHE_STORE_FILENAME).toBe("exosync-conflicts.local.json");
+  });
+});
+
+describe("LocalConflictCacheStore — real SyncEngine quarantine flush (foundation)", () => {
+  const FILE = "assets/a.md";
+
+  function makeEngineWithCache(
+    gh: FakeGitHubRepo,
+    local: FakeLocalFiles,
+    cache: LocalConflictCacheStore,
+    mergeLayer?: MergeLayerPort,
+  ): { engine: SyncEngine; watermarks: FakeWatermarkStore } {
+    const watermarks = new FakeWatermarkStore();
+    const engine = new SyncEngine({
+      transport: gh.transport(),
+      watermarkStore: watermarks,
+      materializationCheck: alwaysMaterialized(),
+      localFilesFor: () => local,
+      sha1: sha1Hex,
+      quarantine: cache,
+      mergeLayer:
+        mergeLayer ??
+        new GatedStructuredMerger(new StructuredMerger(yamlCodec)),
+    });
+    return { engine, watermarks };
+  }
+
+  it("captures base/local/remote in the cache when the engine quarantines a genuine 3-way", async () => {
+    const gh = new FakeGitHubRepo({ [FILE]: mdAsset("u1", "base body") });
+    const local = new FakeLocalFiles({ [FILE]: mdAsset("u1", "base body") });
+    const cache = new LocalConflictCacheStore({ io: memIO() });
+    // Force a quarantine deterministically (mirrors an unmergeable conflict).
+    const { engine } = makeEngineWithCache(gh, local, cache, {
+      resolve: async () => ({
+        action: "quarantine",
+        reason: "unmergeable (test)",
+      }),
+    });
+    await engine.sync(gh.spec()); // bootstrap watermark
+
+    gh.commitDirect(
+      "main",
+      { [FILE]: mdAsset("u1", "REMOTE edit") },
+      "device B",
+    );
+    local.files.set(FILE, mdAsset("u1", "LOCAL edit"));
+    const result = await engine.sync(gh.spec());
+
+    expect(result.quarantinedCount).toBe(1);
+    const cached = await cache.get(gh.spec().repoKey, FILE);
+    expect(cached).not.toBeNull();
+    expect(cached?.localContent).toContain("LOCAL edit");
+    expect(cached?.remoteContent).toContain("REMOTE edit");
+    expect(cached?.baseContent).toContain("base body");
+  });
+
+  it("evicts the cached entry when a previously-pinned conflict converges (engine markResolved)", async () => {
+    const gh = new FakeGitHubRepo({ [FILE]: mdAsset("u1", "base body") });
+    const local = new FakeLocalFiles({ [FILE]: mdAsset("u1", "base body") });
+    const cache = new LocalConflictCacheStore({ io: memIO() });
+    const { engine } = makeEngineWithCache(gh, local, cache, {
+      resolve: async () => ({
+        action: "quarantine",
+        reason: "unmergeable (test)",
+      }),
+    });
+    await engine.sync(gh.spec()); // bootstrap
+
+    // Conflict → cached + pinned.
+    gh.commitDirect(
+      "main",
+      { [FILE]: mdAsset("u1", "REMOTE edit") },
+      "device B",
+    );
+    local.files.set(FILE, mdAsset("u1", "LOCAL edit"));
+    await engine.sync(gh.spec());
+    expect(await cache.get(gh.spec().repoKey, FILE)).not.toBeNull();
+
+    // User converges local to the remote version → next sync clears the pin and
+    // the engine calls markResolved, which drops the cache entry.
+    local.files.set(FILE, mdAsset("u1", "REMOTE edit"));
+    await engine.sync(gh.spec());
+    expect(await cache.get(gh.spec().repoKey, FILE)).toBeNull();
+  });
+});

--- a/packages/obsidian-plugin/src/infrastructure/adapters/SyncDepsFactory.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/SyncDepsFactory.ts
@@ -1,11 +1,14 @@
 import type { App, DataAdapter } from "obsidian";
 import yaml from "js-yaml";
 import {
+  CONFLICT_CACHE_STORE_FILENAME,
+  CompositeQuarantineStore,
   FileLocalManifestStore,
   FileMountBaseStore,
   FileWatermarkStore,
   GatedStructuredMerger,
   LOCAL_MANIFEST_STORE_FILENAME,
+  LocalConflictCacheStore,
   MOUNT_BASE_STORE_FILENAME,
   QuarantineResolver,
   SYNC_BRANCH,
@@ -63,9 +66,11 @@ import type { PluginLocalDataStore } from "./PluginLocalDataStore";
  *    contract). The optional SHACL merge-gate is NOT wired in Phase B —
  *    plugin-side ShapeRegistry/ClassHierarchy/triplesFor composition is a
  *    follow-up; unresolvable merges still quarantine (D17).
- *  - quarantine — `SyncedQuarantineStore` against the user-configured
- *    quarantine repo (settings), absent ⇒ engine degrades safely (watermark
- *    pins re-derive conflicts, no data loss).
+ *  - quarantine — the device-local `LocalConflictCacheStore` (offline-resolution
+ *    foundation) is ALWAYS wired: it persists the 3 versions of every conflict
+ *    to a `.local.` (Sync-excluded) file so the resolver can work offline. A
+ *    user-configured `SyncedQuarantineStore` (settings) is TEE'd alongside it
+ *    via `CompositeQuarantineStore` for the cross-device count.
  */
 
 /** Per-repo sync branch — re-exported from the core (ExoSync E1: the
@@ -400,10 +405,10 @@ export interface BuiltSyncEngine {
   /** PAT resolved at build time; null ⇒ caller surfaces the R8 prompt. */
   pat: string | null;
   /**
-   * #3495 — whether the engine was built with a durable quarantine sink.
-   * `false` ⇒ conflicts are pinned and re-derive every sync but BOTH versions
-   * are never saved (silent degraded mode). The caller surfaces a one-shot
-   * warn when a conflict actually occurs without a sink.
+   * #3495 — whether the engine was built with a durable quarantine sink. Now
+   * ALWAYS `true`: the device-local conflict cache is wired unconditionally and
+   * is itself durable (survives restart), so conflicts are never silently
+   * dropped. Retained so the caller's one-shot "no sink" warning stays inert.
    */
   quarantineConfigured: boolean;
 }
@@ -436,12 +441,22 @@ export async function buildSyncEngine(
   // (the dominant iPhone cost on a 14-AS / ~6304-file vault).
   const manifestPath = `${configDir}/plugins/exocortex/${LOCAL_MANIFEST_STORE_FILENAME}`;
 
-  let quarantine: QuarantinePort | undefined;
+  // Device-local conflict cache (offline-resolution foundation) — ALWAYS wired,
+  // same `.local.` (Sync-excluded) store family as the watermark. It captures
+  // the 3 versions of every conflict on disk so the resolver can work offline
+  // (PR-3). It is also a durable sink in its own right (survives restart), so
+  // conflicts are NEVER silently dropped — the #3495 degraded-mode is gone.
+  const conflictCachePath = `${configDir}/plugins/exocortex/${CONFLICT_CACHE_STORE_FILENAME}`;
+  const conflictCache = new LocalConflictCacheStore({
+    io: vaultWatermarkFileIO(adapter, conflictCachePath),
+  });
+
+  let quarantine: QuarantinePort = conflictCache;
   const quarantineUrl = opts.quarantineRepoUrl?.trim() ?? "";
   if (quarantineUrl.length > 0) {
     GitHubRestClient.validateRepoURL(quarantineUrl);
     const { owner, repo } = parseGitHubURL(quarantineUrl);
-    quarantine = new SyncedQuarantineStore({
+    const synced = new SyncedQuarantineStore({
       // The engine wraps ITS transport internally; the quarantine store
       // needs its own backoff wrap (it is the highest-volume caller).
       transport: withRateLimitBackoff(transport),
@@ -451,6 +466,10 @@ export async function buildSyncEngine(
       branch: SYNC_BRANCH,
       redact: (m) => GitHubRestClient.redactTokens(m),
     });
+    // Tee: device-local cache FIRST (durability-critical), synced repo second
+    // (cross-device count). The cache write always runs even if the synced push
+    // fails — see CompositeQuarantineStore.
+    quarantine = new CompositeQuarantineStore([conflictCache, synced]);
   }
 
   // #3590 FULL fix — base BACKFILL source for AssetSpaces mounted BEFORE the
@@ -510,10 +529,12 @@ export async function buildSyncEngine(
     mergeLayer: new GatedStructuredMerger(
       new StructuredMerger(coreSchemaYamlCodec),
     ),
-    ...(quarantine !== undefined ? { quarantine } : {}),
+    quarantine,
   });
 
-  return { engine, pat, quarantineConfigured: quarantine !== undefined };
+  // A durable quarantine sink is now ALWAYS present (the device-local conflict
+  // cache) — conflicts are always saved, so the #3495 "no sink" warning is moot.
+  return { engine, pat, quarantineConfigured: true };
 }
 
 export interface BuildQuarantineResolverOptions {

--- a/packages/obsidian-plugin/tests/unit/sync/ExoSyncRequestUrlParity.integration.test.ts
+++ b/packages/obsidian-plugin/tests/unit/sync/ExoSyncRequestUrlParity.integration.test.ts
@@ -222,6 +222,37 @@ describe("ExoSync over requestUrl (desktop parity, AC#3)", () => {
     expect(h.repo.headFiles().get("a.md")).toContain("remote-version");
   });
 
+  it("captures the 3 versions in the device-local conflict cache even with NO quarantine repo (offline foundation)", async () => {
+    const h = await makeHarness({
+      initialFiles: { "a.md": asset("u1", "one") },
+      // NB: no withQuarantineRepo — the device-local cache must be wired anyway.
+    });
+    await h.sync(); // bootstrap
+
+    h.adapter.seedFile(`${MOUNT}/a.md`, asset("u1", "local-version"));
+    h.repo.commitDirect(
+      "main",
+      { "a.md": asset("u1", "remote-version") },
+      "device B",
+    );
+    const results = await h.sync();
+    expect(results[0].quarantinedCount).toBe(1);
+
+    // The factory wired LocalConflictCacheStore unconditionally → the 3 versions
+    // are on disk in the `.local.` (Sync-excluded) cache, ready for an offline
+    // resolve. (Revert-verify: drop the cache wiring in buildSyncEngine and this
+    // file never gets written → FAIL.)
+    const cachePath = `.obsidian/plugins/exocortex/exosync-conflicts.local.json`;
+    expect(await h.adapter.exists(cachePath)).toBe(true);
+    const store = JSON.parse(await h.adapter.read(cachePath)) as {
+      entries: Record<string, { localContent?: string; remoteContent?: string }>;
+    };
+    const records = Object.values(store.entries);
+    expect(records).toHaveLength(1);
+    expect(records[0].localContent).toContain("local-version");
+    expect(records[0].remoteContent).toContain("remote-version");
+  });
+
   it("persists both versions to the synced quarantine repo (D17)", async () => {
     const h = await makeHarness({
       initialFiles: { "a.md": asset("u1", "one") },


### PR DESCRIPTION
## What

PR-2 of the ExoSync **offline-resolution** program (PR-2 cache → PR-3 offline resolve+outbox+auto-flush+TOCTOU → PR-4 remove SyncedQuarantineStore). Andrey wants IntelliJ-style **offline** conflict resolution; this is the foundation.

Wire an **always-on** `LocalConflictCacheStore` (a `QuarantinePort`) that persists the **3 versions** (base/local/remote + losing-local binary payload) of every quarantined conflict to a **device-local** `exosync-conflicts.local.json` (the `.local.` infix is Sync-excluded, same family as the watermark store).

### Why
Today the engine **has** all three versions in memory at quarantine time (`QuarantineEntry`) but **drops** them when no synced quarantine repo is configured (off by default). Capturing them on disk is what lets the resolver work **offline** (PR-3): the remote version is already local → `list`/`diff`/`resolve` no longer need a network fetch.

## Changes
- **`LocalConflictCacheStore`** — single-file store (`WatermarkFileIO` family), tolerant read, serialized RMW, `markResolved` eviction. ⛤ **Deliberately NOT redacted** (unlike `SyncedQuarantineStore`): the `.local.` exclusion is the leak guard, and the cache must hold the **exact** bytes — a redacted cache would make the offline resolver push corrupted content.
- **`CompositeQuarantineStore`** — tees the cache with the optional synced repo while both coexist (zero-loss ordering: the cache write always runs even if the synced push fails). Collapses in PR-4.
- Wired **unconditionally** in `SyncDepsFactory.buildSyncEngine` + CLI `exosync-sync`. `quarantineConfigured` is now always `true` (a durable sink is always present → #3495 degraded-mode warning is moot). **Zero `SyncEngine` edits** — pure factory-level wiring.

## Tests (production-shape, revert-verified)
- Store mechanics (3-version capture, binary base64 round-trip, re-quarantine preserves `quarantinedAt`, tolerant read, serialized writes).
- **Real `SyncEngine` quarantine flush** captures base/local/remote in the cache + evicts on convergent `markResolved`.
- Composite fan-out + zero-loss ordering (durable member runs even when a later member throws).
- **Plugin factory revert-verify**: the 3 versions land in the cache even with **NO** quarantine repo — empirically RED→GREEN (dropping the wiring fails the test).

Local: typecheck clean, eslint `--max-warnings=0` clean, core sync suite 395/395, plugin parity 8/8, CLI exosync 32/32.