### PR TITLE
fix(ci): exempt exo__AssetSpace_visibility from docs-property-validation (RFC 0004 negated ref) — UNBLOCK releases

### DIFF
--- a/scripts/validate-docs-properties.js
+++ b/scripts/validate-docs-properties.js
@@ -37,6 +37,7 @@ const KNOWN_EXCEPTIONS = new Set([
   "exo__Property_minCount", // SHACL_LITE_MAPPING.md Phase 3+ planned property (YAGNI Drop #3 in RFC 82a72aca v3)
   "exo__Property_severity", // SHACL_LITE_MAPPING.md sh:severity alignment — docs-only mapping reference (aa6615f0)
   "exo__AssetSpace_materialized", // runtime-derived property; code constructs via Namespace.EXO.term("AssetSpace_materialized") rather than literal string (docs/explanation/profile.md)
+  "exo__AssetSpace_visibility", // RFC 0004 references this ONLY in negated form ("no ... property is introduced") to document the design decision NOT to add it (PAT-less + public-submodule-only is self-sufficient); not in code by design (docs/rfc/0004-living-documentation.md)
 ]);
 
 function extractPropertiesFromDocs() {


### PR DESCRIPTION
## Problem (release-blocker)

The non-required `docs-property-validation` CI job (`node scripts/validate-docs-properties.js`) **fails on every push-to-main**, causing the CI workflow to conclude `failure` → **Auto Release is SKIPPED** (gated on CI success). This blocks releases of already-merged #3678 / #3679 / #3680 (activity-log progress-logs + offline PR-2/3a).

## Root cause (verified)

The script greps `exo__*`-property tokens in `docs/` and checks each exists in code. RFC `docs/rfc/0004-living-documentation.md` (from #3678) references `exo__AssetSpace_visibility` **ONLY in negated form** — it documents the design decision **NOT** to introduce the property:

- L141: "**No** `exo__AssetSpace_visibility` property **is introduced**"
- L397 (Q3): "**No new `exo__AssetSpace_visibility` property** is introduced — PAT-less + public-submodule-only is self-sufficient"

The script has no negation-context awareness → matches the token → flags 'not in code'. The property is absent from code **by design**. The script's own error message recommends `add to KNOWN_EXCEPTIONS if intentional` — this is intentional.

Verified:
- `grep -rn 'AssetSpace_visibility' packages/*/src` = **0** (absent by design)
- before fix: `node scripts/validate-docs-properties.js` → exit 1, 1 missing (`exo__AssetSpace_visibility` @ RFC 0004 L141/L397)
- after fix: → exit 0, 0 missing, PASS

## Fix

One line added to `KNOWN_EXCEPTIONS` Set with an explanatory comment (matches existing pattern, e.g. `exo__AssetSpace_materialized`). No code property added (RFC decided NOT to introduce it). No RFC prose touched.

## Effect

Next push-to-main CI = success (with this fix) → Auto Release publishes a version bundling main HEAD ⊇ #3678/#3679/#3680 + this fix.