### PR TITLE
feat(templating): Веха 5 — Templater tp.date.* parity (date format + offset tokens)

### DIFF
--- a/packages/exocortex/src/services/SubstitutionResolverRegistry.ts
+++ b/packages/exocortex/src/services/SubstitutionResolverRegistry.ts
@@ -242,10 +242,33 @@ function formatDate(d: Date, format: string): string {
 }
 
 /**
+ * Add `n` months/years to `d` with moment-style day CLAMPING (matches
+ * Templater's `tp.date.*`): if the source day-of-month does not exist in the
+ * target month it is clamped to that month's last day rather than rolling over.
+ *   Jan 31 +1M  → Feb 28 (or 29)   NOT Mar 3 (raw `Date.setMonth` roll-over)
+ *   Feb 29 +1y  → Feb 28           NOT Mar 1
+ * Implemented by parking the day at 1 before the shift (so `setMonth` never
+ * rolls), then clamping to `min(originalDay, lastDayOfTargetMonth)`.
+ */
+function addMonthsClamped(d: Date, n: number, unit: "M" | "y"): Date {
+  const day = d.getDate();
+  const r = new Date(d.getTime());
+  r.setDate(1);
+  if (unit === "M") r.setMonth(r.getMonth() + n);
+  else r.setFullYear(r.getFullYear() + n);
+  // Last day of the (now day-1) target month — day 0 of the next month.
+  const lastDay = new Date(r.getFullYear(), r.getMonth() + 1, 0).getDate();
+  r.setDate(Math.min(day, lastDay));
+  return r;
+}
+
+/**
  * Shift `d` by a signed offset string `[+-]\d+[dwMy]?` (`d`ays default, `w`eeks,
- * `M`onths, `y`ears — moment convention: `M`=month, lowercase reserved). A
- * malformed offset leaves the date unchanged (lenient — a freeform body must
- * not throw). Returns a NEW Date (does not mutate the input).
+ * `M`onths, `y`ears — moment convention: `M`=month, lowercase reserved). Month/
+ * year shifts CLAMP to the last valid day (moment/Templater parity, see
+ * {@link addMonthsClamped}). A malformed offset — or one that overflows the
+ * representable Date range — leaves the date unchanged (lenient: a freeform body
+ * must never throw or emit `NaN`). Returns a NEW Date (does not mutate input).
  */
 function applyDateOffset(d: Date, offset: string | null): Date {
   if (!offset) return d;
@@ -253,7 +276,7 @@ function applyDateOffset(d: Date, offset: string | null): Date {
   if (!m) return d;
   const n = (m[1] === "-" ? -1 : 1) * parseInt(m[2], 10);
   const unit = m[3] ?? "d";
-  const r = new Date(d.getTime());
+  let r = new Date(d.getTime());
   switch (unit) {
     case "d":
       r.setDate(r.getDate() + n);
@@ -262,13 +285,15 @@ function applyDateOffset(d: Date, offset: string | null): Date {
       r.setDate(r.getDate() + n * 7);
       break;
     case "M":
-      r.setMonth(r.getMonth() + n);
+      r = addMonthsClamped(r, n, "M");
       break;
     case "y":
-      r.setFullYear(r.getFullYear() + n);
+      r = addMonthsClamped(r, n, "y");
       break;
   }
-  return r;
+  // Overflow (e.g. an absurd day count) → Invalid Date. Stay lenient: fall back
+  // to the unshifted date rather than formatting `NaN-NaN-NaN`.
+  return isNaN(r.getTime()) ? d : r;
 }
 
 /**

--- a/packages/exocortex/src/services/SubstitutionResolverRegistry.ts
+++ b/packages/exocortex/src/services/SubstitutionResolverRegistry.ts
@@ -48,16 +48,46 @@ export type ResolverFn = (
 const _resolvers = new Map<string, ResolverFn>();
 
 /**
+ * Ids of resolvers that consume the optional `parameter` as an inline
+ * MODIFIER (date format / offset suffix — Веха 5 / Templater `tp.date.*`
+ * parity). The TemplateBodyResolver captures `$date+7d:YYYY-MM-DD`-style
+ * suffixes and forwards them as `parameter` to these resolvers, which bake the
+ * value in. For resolvers NOT in this set the body resolver reproduces the
+ * suffix verbatim, so a legacy token like `$today+7d` stays `<date>+7d` exactly
+ * as before this feature (zero regression). See {@link isResolverModifierAware}.
+ */
+const _modifierAware = new Set<string>();
+
+/**
  * Register a resolver. Idempotent overwrite — last registration wins. Tests
  * may inject deterministic resolvers (e.g. fixed UUID, fixed timestamp);
  * production wiring at package init time installs the live implementations.
+ *
+ * @param modifierAware when true, marks this resolver as consuming the inline
+ *        `parameter` modifier (date format/offset, Веха 5). Defaults to false
+ *        so every existing call site keeps legacy "ignore the suffix" behaviour.
  */
-export function registerResolver(id: string, fn: ResolverFn): void {
+export function registerResolver(
+  id: string,
+  fn: ResolverFn,
+  modifierAware = false,
+): void {
   _resolvers.set(id, fn);
+  if (modifierAware) _modifierAware.add(id);
 }
 
 export function getResolver(id: string): ResolverFn | undefined {
   return _resolvers.get(id);
+}
+
+/**
+ * True when the resolver `id` consumes the inline `parameter` modifier (date
+ * format/offset suffix). The body resolver uses this to decide whether the
+ * captured `$token<suffix>` suffix was already baked into the value (aware →
+ * yes) or must be reproduced verbatim (not aware → legacy behaviour).
+ */
+export function isResolverModifierAware(id: string): boolean {
+  return _modifierAware.has(id);
 }
 
 export function getRegisteredResolverIds(): string[] {
@@ -66,6 +96,7 @@ export function getRegisteredResolverIds(): string[] {
 
 export function clearResolvers(): void {
   _resolvers.clear();
+  _modifierAware.clear();
 }
 
 // -- Built-in resolvers (RFC 727572d2 Phase A2 vocabulary) --
@@ -74,18 +105,232 @@ function pad2(n: number): string {
   return n < 10 ? `0${n}` : String(n);
 }
 
+// -- Date format + offset tokens (Веха 5 — Templater `tp.date.*` parity) --
+//
+// Templater's `tp.date.now(format, offset)` / `tp.date.tomorrow(format)` /
+// `tp.date.yesterday(format)` produce a formatted, optionally day-shifted date.
+// The homoiconic equivalent is an inline `$token<offset><:format>` suffix on a
+// date token (`$date`, `$now`, `$tomorrow`, `$yesterday`), e.g.
+//   $date                  → 2026-06-21          (default YYYY-MM-DD)
+//   $date:DD.MM.YYYY        → 21.06.2026
+//   $date+7d                → 2026-06-28          (+7 days, default format)
+//   $date+1M:YYYY-MM         → 2026-07
+//   $now:HH:mm:ss            → 14:30:05
+//   $tomorrow / $yesterday   → ±1 day convenience tokens
+// The TemplateBodyResolver parses the suffix and forwards it as `parameter`;
+// these resolvers own offset+format parsing (self-contained semantics). All
+// arithmetic/formatting uses plain `Date` + hardcoded English names — NO Node
+// `fs`, NO `Intl` — so it behaves identically on desktop and mobile (Desktop↔
+// Mobile command parity invariant).
+
+const MONTH_NAMES = [
+  "January",
+  "February",
+  "March",
+  "April",
+  "May",
+  "June",
+  "July",
+  "August",
+  "September",
+  "October",
+  "November",
+  "December",
+] as const;
+const MONTH_NAMES_SHORT = [
+  "Jan",
+  "Feb",
+  "Mar",
+  "Apr",
+  "May",
+  "Jun",
+  "Jul",
+  "Aug",
+  "Sep",
+  "Oct",
+  "Nov",
+  "Dec",
+] as const;
+const DAY_NAMES = [
+  "Sunday",
+  "Monday",
+  "Tuesday",
+  "Wednesday",
+  "Thursday",
+  "Friday",
+  "Saturday",
+] as const;
+const DAY_NAMES_SHORT = [
+  "Sun",
+  "Mon",
+  "Tue",
+  "Wed",
+  "Thu",
+  "Fri",
+  "Sat",
+] as const;
+
+/** English ordinal day-of-month (1 → "1st", 22 → "22nd", 11 → "11th"). */
+function ordinalDay(n: number): string {
+  const suffixes = ["th", "st", "nd", "rd"];
+  const v = n % 100;
+  return `${n}${suffixes[(v - 20) % 10] || suffixes[v] || suffixes[0]}`;
+}
+
+/**
+ * moment-style format tokens, longest-first so the alternation never mis-splits
+ * (`YYYY` before `YY`, `MMMM` before `MM`, `dddd` before `ddd`, `DD`/`Do` before
+ * `D`). `String.replace` does not re-scan substituted output, so a month name
+ * like "June" is never re-matched. Unrecognised characters (`-`, `:`, `/`, `.`,
+ * `T`, spaces, …) pass through literally — e.g. ISO `YYYY-MM-DDTHH:mm:ss` keeps
+ * its `-`, `T`, `:` separators.
+ */
+const DATE_FORMAT_RE =
+  /YYYY|YY|MMMM|MMM|MM|M|Do|DD|D|dddd|ddd|HH|H|hh|h|mm|m|ss|s|A|a/g;
+
+/** Format a Date with a moment-style format string (local time, English names). */
+function formatDate(d: Date, format: string): string {
+  const h12 = ((d.getHours() + 11) % 12) + 1;
+  return format.replace(DATE_FORMAT_RE, (tok) => {
+    switch (tok) {
+      case "YYYY":
+        return String(d.getFullYear());
+      case "YY":
+        return pad2(d.getFullYear() % 100);
+      case "MMMM":
+        return MONTH_NAMES[d.getMonth()];
+      case "MMM":
+        return MONTH_NAMES_SHORT[d.getMonth()];
+      case "MM":
+        return pad2(d.getMonth() + 1);
+      case "M":
+        return String(d.getMonth() + 1);
+      case "Do":
+        return ordinalDay(d.getDate());
+      case "DD":
+        return pad2(d.getDate());
+      case "D":
+        return String(d.getDate());
+      case "dddd":
+        return DAY_NAMES[d.getDay()];
+      case "ddd":
+        return DAY_NAMES_SHORT[d.getDay()];
+      case "HH":
+        return pad2(d.getHours());
+      case "H":
+        return String(d.getHours());
+      case "hh":
+        return pad2(h12);
+      case "h":
+        return String(h12);
+      case "mm":
+        return pad2(d.getMinutes());
+      case "m":
+        return String(d.getMinutes());
+      case "ss":
+        return pad2(d.getSeconds());
+      case "s":
+        return String(d.getSeconds());
+      case "A":
+        return d.getHours() < 12 ? "AM" : "PM";
+      case "a":
+        return d.getHours() < 12 ? "am" : "pm";
+      default:
+        return tok;
+    }
+  });
+}
+
+/**
+ * Shift `d` by a signed offset string `[+-]\d+[dwMy]?` (`d`ays default, `w`eeks,
+ * `M`onths, `y`ears — moment convention: `M`=month, lowercase reserved). A
+ * malformed offset leaves the date unchanged (lenient — a freeform body must
+ * not throw). Returns a NEW Date (does not mutate the input).
+ */
+function applyDateOffset(d: Date, offset: string | null): Date {
+  if (!offset) return d;
+  const m = offset.match(/^([+-])(\d+)([dwMy])?$/);
+  if (!m) return d;
+  const n = (m[1] === "-" ? -1 : 1) * parseInt(m[2], 10);
+  const unit = m[3] ?? "d";
+  const r = new Date(d.getTime());
+  switch (unit) {
+    case "d":
+      r.setDate(r.getDate() + n);
+      break;
+    case "w":
+      r.setDate(r.getDate() + n * 7);
+      break;
+    case "M":
+      r.setMonth(r.getMonth() + n);
+      break;
+    case "y":
+      r.setFullYear(r.getFullYear() + n);
+      break;
+  }
+  return r;
+}
+
+/**
+ * Split a date modifier `parameter` into its offset and format parts. The FIRST
+ * `:` separates offset from format; everything after it is the format (which may
+ * itself contain `:` for time, e.g. `HH:mm:ss`). Either part may be absent:
+ *   "+7d:YYYY-MM-DD" → { offset: "+7d", format: "YYYY-MM-DD" }
+ *   ":HH:mm"          → { offset: null,  format: "HH:mm" }
+ *   "+7d"             → { offset: "+7d", format: null }
+ *   undefined/""      → { offset: null,  format: null }
+ */
+function parseDateModifier(parameter?: string): {
+  offset: string | null;
+  format: string | null;
+} {
+  if (!parameter) return { offset: null, format: null };
+  const colon = parameter.indexOf(":");
+  if (colon < 0) return { offset: parameter || null, format: null };
+  const offsetPart = parameter.slice(0, colon);
+  const format = parameter.slice(colon + 1);
+  return { offset: offsetPart || null, format: format || null };
+}
+
+/**
+ * Build a date resolver with a base day shift and a default format. The inline
+ * modifier (offset + format) is applied ON TOP of the base shift, so
+ * `$tomorrow+7d` is base +1 then +7 = +8 days. Ignores `ctx` (date tokens are
+ * context-free).
+ */
+function makeDateResolver(
+  baseDayShift: number,
+  defaultFormat: string,
+): ResolverFn {
+  return (_ctx, parameter) => {
+    const { offset, format } = parseDateModifier(parameter);
+    let d = new Date();
+    if (baseDayShift !== 0) d.setDate(d.getDate() + baseDayShift);
+    d = applyDateOffset(d, offset);
+    return formatDate(d, format ?? defaultFormat);
+  };
+}
+
 /**
  * Install the default Phase A2 resolver set. Idempotent — safe to call from
  * multiple entry points (CLI bootstrap, plugin bootstrap, test setup). Tests
  * may call {@link clearResolvers} first to start from empty state.
  */
 export function installDefaultResolvers(): void {
-  // -- Existing tokens (legacy parity) --
+  // -- Existing tokens (legacy parity) — modifier-UNAWARE, untouched --
   registerResolver("today", () => new Date().toISOString().slice(0, 10));
-  registerResolver(
-    "todayStart",
-    () => new Date(new Date().setHours(0, 0, 0, 0)).toISOString(),
+  registerResolver("todayStart", () =>
+    new Date(new Date().setHours(0, 0, 0, 0)).toISOString(),
   );
+
+  // -- Date format + offset tokens (Веха 5 — Templater `tp.date.*` parity) --
+  // modifier-AWARE: the inline `$token<offset><:format>` suffix is consumed and
+  // baked into the value. `now` defaults to a datetime shape (tp.date.now);
+  // `date`/`tomorrow`/`yesterday` default to a calendar date.
+  registerResolver("date", makeDateResolver(0, "YYYY-MM-DD"), true);
+  registerResolver("now", makeDateResolver(0, "YYYY-MM-DDTHH:mm:ss"), true);
+  registerResolver("tomorrow", makeDateResolver(1, "YYYY-MM-DD"), true);
+  registerResolver("yesterday", makeDateResolver(-1, "YYYY-MM-DD"), true);
   // `target` and `targetFolder` are context-dependent — executor resolves them
   // from marker form; they're registered here too for symmetry but their
   // handlers fall back to empty when context missing.

--- a/packages/exocortex/src/services/TemplateBodyResolver.ts
+++ b/packages/exocortex/src/services/TemplateBodyResolver.ts
@@ -64,6 +64,14 @@ installDefaultResolvers();
  * `Due $date:YYYY-MM-DD, soon` keeps `, soon` outside the token. (A trailing `.`
  * IS in the charset — `Due $date:YYYY-MM-DD.` renders `…2026-06-21.` with the
  * period reproduced as a literal format char, visually identical.)
+ *
+ * LIMITATION — a format containing a SPACE or COMMA is truncated at that char in
+ * BODY text: `$now:h:mm A` resolves only `:h:mm` → `12:30` and the ` A` survives
+ * as prose, `$date:dddd, MMMM Do YYYY` resolves only `:dddd`. Multi-word formats
+ * (`h:mm A`, `dddd, MMMM Do YYYY`) are reachable only via a vault
+ * `exocmd__TokenInvocation_parameter` (the resolver itself handles spaces), NOT
+ * via an inline body suffix. For body use, compose contiguous formats (`HH:mm`,
+ * `YYYY-MM-DDTHH:mm:ss`) or multiple tokens. (Descoped: bracket-escaping.)
  */
 const TOKEN_RE =
   /\$([A-Za-z][A-Za-z0-9_]*)((?:[+-]\d+[dwMy])?(?::[A-Za-z0-9:./-]+)?)/g;

--- a/packages/exocortex/src/services/TemplateBodyResolver.ts
+++ b/packages/exocortex/src/services/TemplateBodyResolver.ts
@@ -32,6 +32,7 @@
 import {
   getResolver,
   installDefaultResolvers,
+  isResolverModifierAware,
   type ResolverContext,
 } from "./SubstitutionResolverRegistry";
 
@@ -42,12 +43,30 @@ import {
 installDefaultResolvers();
 
 /**
- * Token marker: `$` followed by an identifier (letter, then letters/digits/_).
+ * Token marker: `$` followed by an identifier (letter, then letters/digits/_),
+ * then an OPTIONAL date modifier suffix (Веха 5 — Templater `tp.date.*`):
+ *   - offset  `[+-]\d+[dwMy]`         e.g. `+7d`, `-3d`, `+2w`, `+1M`, `+1y`
+ *   - format  `:` then a format charset (`HH:mm:ss`, `DD.MM.YYYY`, `YYYY/MM/DD`)
+ * Examples captured as (name, suffix):
+ *   `$today`            → ("today", "")            — bare, suffix empty
+ *   `$date+7d`           → ("date", "+7d")
+ *   `$date:DD.MM.YYYY`   → ("date", ":DD.MM.YYYY")
+ *   `$now+1M:YYYY-MM`    → ("now", "+1M:YYYY-MM")
+ *   `$today.md`          → ("today", "")  + literal ".md" (no leading `:`)
+ *   `$today-end`         → ("today", "")  + literal "-end" (no digit after `-`)
  * The identifier is greedy so `$todayX` matches the whole name `todayX` (an
- * unknown token → left literal), never the prefix `today`. A token name stops
- * at the first non-identifier char, so `$today.md` → `<value>.md`.
+ * unknown token → left literal), never the prefix `today`. The suffix only
+ * matches a date-shaped offset and/or a `:`-led format, so non-date tokens with
+ * trailing punctuation (`$today.md`, `$today-end`) capture an empty suffix and
+ * behave exactly as before this feature.
+ *
+ * Format charset stops at whitespace/comma/etc, so a sentence like
+ * `Due $date:YYYY-MM-DD, soon` keeps `, soon` outside the token. (A trailing `.`
+ * IS in the charset — `Due $date:YYYY-MM-DD.` renders `…2026-06-21.` with the
+ * period reproduced as a literal format char, visually identical.)
  */
-const TOKEN_RE = /\$([A-Za-z][A-Za-z0-9_]*)/g;
+const TOKEN_RE =
+  /\$([A-Za-z][A-Za-z0-9_]*)((?:[+-]\d+[dwMy])?(?::[A-Za-z0-9:./-]+)?)/g;
 
 /**
  * Replace every KNOWN scalar `$token` in `rawBody` with its resolver value.
@@ -62,16 +81,24 @@ export function resolveTemplateBody(
   rawBody: string,
   ctx: ResolverContext = {},
 ): string {
-  return rawBody.replace(TOKEN_RE, (literal, name: string) => {
+  return rawBody.replace(TOKEN_RE, (literal, name: string, suffix: string) => {
     const resolver = getResolver(name);
     if (resolver === undefined) return literal;
-    const value = resolver(ctx);
+    // Modifier-aware date resolvers (`date`/`now`/`tomorrow`/`yesterday`)
+    // consume the suffix; all others ignore the second arg.
+    const value = resolver(ctx, suffix.length > 0 ? suffix : undefined);
     // Only KNOWN, NON-EMPTY scalar strings are spliced into freeform body text.
     // `string[]` (list-typed), `null`, and `""` (context-missing resolvers such
     // as `target`/`targetFolder`/`userInputLabel` return empty when their
-    // context is absent) all leave the literal marker intact — a visible
+    // context is absent) all leave the FULL literal marker intact — a visible
     // unresolved token the user can fix beats a silently-deleted one.
-    return typeof value === "string" && value.length > 0 ? value : literal;
+    if (typeof value !== "string" || value.length === 0) return literal;
+    // For a modifier-aware resolver the suffix is already baked into `value`.
+    // For a legacy (modifier-unaware) resolver the suffix was NOT part of this
+    // token's semantics, so reproduce it verbatim — `$today+7d` → `<date>+7d`,
+    // `$nowDate:foo` → `<date>:foo` — identical to pre-feature behaviour where
+    // the old regex stopped at the first non-identifier char.
+    return isResolverModifierAware(name) ? value : value + suffix;
   });
 }
 

--- a/packages/exocortex/tests/unit/services/SubstitutionResolverRegistry.test.ts
+++ b/packages/exocortex/tests/unit/services/SubstitutionResolverRegistry.test.ts
@@ -323,6 +323,32 @@ describe("date format + offset tokens (Веха 5 — Templater `tp.date.*` pari
     });
   });
 
+  describe("month/year offset clamps day to last valid day (moment parity)", () => {
+    // These re-pin "now" to a day-31 / leap-day so the clamp is observable —
+    // the suite default (June 21) exists in every target month and cannot catch
+    // roll-over vs clamping divergence.
+    it("Jan 31 +1M → Feb 28 (non-leap year clamps, NOT Mar 3 roll-over)", () => {
+      jest.setSystemTime(new Date("2026-01-31T12:00:00"));
+      expect(call("date", "+1M")).toBe("2026-02-28");
+    });
+    it("Jan 31 +1M → Feb 29 (leap year clamps to 29)", () => {
+      jest.setSystemTime(new Date("2024-01-31T12:00:00"));
+      expect(call("date", "+1M")).toBe("2024-02-29");
+    });
+    it("Mar 31 +1M → Apr 30 (30-day month clamp)", () => {
+      jest.setSystemTime(new Date("2026-03-31T12:00:00"));
+      expect(call("date", "+1M")).toBe("2026-04-30");
+    });
+    it("Feb 29 +1y → Feb 28 (leap → non-leap year clamps)", () => {
+      jest.setSystemTime(new Date("2024-02-29T12:00:00"));
+      expect(call("date", "+1y")).toBe("2025-02-28");
+    });
+    it("Jan 31 −1M → Dec 31 (backward, December has 31 days, no clamp)", () => {
+      jest.setSystemTime(new Date("2026-01-31T12:00:00"));
+      expect(call("date", "-1M")).toBe("2025-12-31");
+    });
+  });
+
   describe("leniency — malformed modifier never throws", () => {
     it("malformed offset leaves the date unshifted (default format)", () => {
       expect(call("date", "+abc")).toBe("2026-06-21");
@@ -332,6 +358,9 @@ describe("date format + offset tokens (Веха 5 — Templater `tp.date.*` pari
     });
     it("offset with unknown unit char is treated as no-match (unshifted)", () => {
       expect(call("date", "+3q")).toBe("2026-06-21");
+    });
+    it("absurd day offset overflows Date → falls back to unshifted (no NaN)", () => {
+      expect(call("date", "+999999999999d")).toBe("2026-06-21");
     });
   });
 

--- a/packages/exocortex/tests/unit/services/SubstitutionResolverRegistry.test.ts
+++ b/packages/exocortex/tests/unit/services/SubstitutionResolverRegistry.test.ts
@@ -14,6 +14,7 @@ import {
   getRegisteredResolverIds,
   getResolver,
   installDefaultResolvers,
+  isResolverModifierAware,
   registerResolver,
   type ResolverContext,
 } from "../../../src/services/SubstitutionResolverRegistry";
@@ -24,7 +25,7 @@ describe("SubstitutionResolverRegistry — RFC 727572d2 Phase A2 vocabulary", ()
     installDefaultResolvers();
   });
 
-  it("registers all 15 expected resolver-ids (4 legacy + 10 new + targetClassSelf)", () => {
+  it("registers all 19 expected resolver-ids (4 legacy + 10 new + targetClassSelf + 4 date-modifier tokens Веха 5)", () => {
     const ids = getRegisteredResolverIds().sort();
     expect(ids).toEqual(
       [
@@ -43,6 +44,11 @@ describe("SubstitutionResolverRegistry — RFC 727572d2 Phase A2 vocabulary", ()
         "todayStart",
         "userInput",
         "userInputLabel",
+        // Веха 5 — Templater `tp.date.*` parity (date format + offset tokens)
+        "date",
+        "now",
+        "tomorrow",
+        "yesterday",
       ].sort(),
     );
   });
@@ -204,5 +210,137 @@ describe("SubstitutionResolverRegistry — RFC 727572d2 Phase A2 vocabulary", ()
       clearResolvers();
       expect(getResolver("temp")).toBeUndefined();
     });
+    it("registerResolver marks modifier-aware when flagged; default false", () => {
+      registerResolver("mod_on", () => "x", true);
+      registerResolver("mod_off", () => "y");
+      expect(isResolverModifierAware("mod_on")).toBe(true);
+      expect(isResolverModifierAware("mod_off")).toBe(false);
+    });
+    it("clearResolvers also clears modifier-aware flags", () => {
+      registerResolver("mod_on", () => "x", true);
+      clearResolvers();
+      expect(isResolverModifierAware("mod_on")).toBe(false);
+    });
+  });
+});
+
+describe("date format + offset tokens (Веха 5 — Templater `tp.date.*` parity)", () => {
+  // Pin "now" to a fixed LOCAL instant (noon, far from midnight so no TZ/DST
+  // flip) — both setSystemTime and the resolvers' local getters interpret it in
+  // local time, so assertions are TZ-independent. 2026-06-21 is a Sunday.
+  beforeEach(() => {
+    clearResolvers();
+    installDefaultResolvers();
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date("2026-06-21T12:30:45"));
+  });
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  const call = (id: string, param?: string): string =>
+    getResolver(id)!({} as ResolverContext, param) as string;
+
+  describe("default format (no modifier)", () => {
+    it("$date → YYYY-MM-DD of today", () => {
+      expect(call("date")).toBe("2026-06-21");
+    });
+    it("$now → local datetime YYYY-MM-DDTHH:mm:ss", () => {
+      expect(call("now")).toBe("2026-06-21T12:30:45");
+    });
+    it("$tomorrow → today + 1 day", () => {
+      expect(call("tomorrow")).toBe("2026-06-22");
+    });
+    it("$yesterday → today − 1 day", () => {
+      expect(call("yesterday")).toBe("2026-06-20");
+    });
+  });
+
+  describe("format strings", () => {
+    it("Russian/European DD.MM.YYYY", () => {
+      expect(call("date", ":DD.MM.YYYY")).toBe("21.06.2026");
+    });
+    it("slashed YYYY/MM/DD", () => {
+      expect(call("date", ":YYYY/MM/DD")).toBe("2026/06/21");
+    });
+    it("time-only HH:mm:ss (format retains its own colons)", () => {
+      expect(call("now", ":HH:mm:ss")).toBe("12:30:45");
+    });
+    it("12-hour clock with meridiem (h:mm A)", () => {
+      expect(call("now", ":h:mm A")).toBe("12:30 PM");
+    });
+    it("full month + ordinal day + weekday (English names)", () => {
+      expect(call("date", ":dddd, MMMM Do YYYY")).toBe(
+        "Sunday, June 21st 2026",
+      );
+    });
+    it("short month + 2-digit year (MMM YY)", () => {
+      expect(call("date", ":MMM YY")).toBe("Jun 26");
+    });
+    it("separator characters (-, /, ., :, T, space, digits) pass through literally", () => {
+      // ISO datetime: the 'T' and all separators are non-tokens → reproduced
+      // verbatim; only YYYY/MM/DD/HH/mm/ss are substituted.
+      expect(call("now", ":YYYY-MM-DDTHH:mm:ss")).toBe("2026-06-21T12:30:45");
+    });
+  });
+
+  describe("offset (no format → default format applied to shifted date)", () => {
+    it("+7d → +7 days", () => {
+      expect(call("date", "+7d")).toBe("2026-06-28");
+    });
+    it("-3d → −3 days", () => {
+      expect(call("date", "-3d")).toBe("2026-06-18");
+    });
+    it("bare number defaults to days (+5)", () => {
+      expect(call("date", "+5")).toBe("2026-06-26");
+    });
+    it("+2w → +2 weeks", () => {
+      expect(call("date", "+2w")).toBe("2026-07-05");
+    });
+    it("+1M → +1 month (crosses month boundary)", () => {
+      expect(call("date", "+1M")).toBe("2026-07-21");
+    });
+    it("+1y → +1 year", () => {
+      expect(call("date", "+1y")).toBe("2027-06-21");
+    });
+    it("month offset overflows the year (+7M from June → January next year)", () => {
+      expect(call("date", "+7M")).toBe("2027-01-21");
+    });
+  });
+
+  describe("offset + format combined", () => {
+    it("+7d:YYYY-MM-DD", () => {
+      expect(call("date", "+7d:YYYY-MM-DD")).toBe("2026-06-28");
+    });
+    it("+1M:YYYY-MM", () => {
+      expect(call("date", "+1M:YYYY-MM")).toBe("2026-07");
+    });
+    it("$tomorrow with extra offset stacks on the base shift (+1 then +6 = +7)", () => {
+      expect(call("tomorrow", "+6d")).toBe("2026-06-28");
+    });
+    it("$yesterday with format", () => {
+      expect(call("yesterday", ":DD.MM.YYYY")).toBe("20.06.2026");
+    });
+  });
+
+  describe("leniency — malformed modifier never throws", () => {
+    it("malformed offset leaves the date unshifted (default format)", () => {
+      expect(call("date", "+abc")).toBe("2026-06-21");
+    });
+    it("empty format after colon falls back to the default format", () => {
+      expect(call("date", "+7d:")).toBe("2026-06-28");
+    });
+    it("offset with unknown unit char is treated as no-match (unshifted)", () => {
+      expect(call("date", "+3q")).toBe("2026-06-21");
+    });
+  });
+
+  it("date tokens are registered modifier-aware; legacy date tokens are not", () => {
+    for (const id of ["date", "now", "tomorrow", "yesterday"]) {
+      expect(isResolverModifierAware(id)).toBe(true);
+    }
+    for (const id of ["today", "nowDate", "nowTimestamp", "nowYear"]) {
+      expect(isResolverModifierAware(id)).toBe(false);
+    }
   });
 });

--- a/packages/exocortex/tests/unit/services/TemplateBodyResolver.test.ts
+++ b/packages/exocortex/tests/unit/services/TemplateBodyResolver.test.ts
@@ -142,3 +142,89 @@ describe("stripTemplateFrontmatter (Веха 3 — template body = file body)", 
     expect(stripTemplateFrontmatter("---\na: b\n---\n## Plan")).not.toMatch(/^\n/);
   });
 });
+
+describe("resolveTemplateBody — inline date format + offset tokens (Веха 5)", () => {
+  // Pin "now" to a fixed LOCAL noon so date assertions are TZ-independent.
+  // 2026-06-21 is a Sunday.
+  beforeEach(() => {
+    clearResolvers();
+    installDefaultResolvers();
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date("2026-06-21T12:30:45"));
+  });
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("resolves a bare $date / $now / $tomorrow / $yesterday in body text", () => {
+    expect(resolveTemplateBody("Today: $date")).toBe("Today: 2026-06-21");
+    expect(resolveTemplateBody("Now: $now")).toBe("Now: 2026-06-21T12:30:45");
+    expect(resolveTemplateBody("Due $tomorrow")).toBe("Due 2026-06-22");
+    expect(resolveTemplateBody("Was $yesterday")).toBe("Was 2026-06-20");
+  });
+
+  it("resolves an inline format suffix $date:DD.MM.YYYY", () => {
+    expect(resolveTemplateBody("Дата: $date:DD.MM.YYYY")).toBe(
+      "Дата: 21.06.2026",
+    );
+  });
+
+  it("resolves an inline offset suffix $date+7d", () => {
+    expect(resolveTemplateBody("Review by $date+7d")).toBe(
+      "Review by 2026-06-28",
+    );
+  });
+
+  it("resolves offset + format together $date+1M:YYYY-MM", () => {
+    expect(resolveTemplateBody("Sprint $date+1M:YYYY-MM end")).toBe(
+      "Sprint 2026-07 end",
+    );
+  });
+
+  it("keeps a time format's internal colons but stops at whitespace", () => {
+    expect(resolveTemplateBody("Logged at $now:HH:mm:ss today")).toBe(
+      "Logged at 12:30:45 today",
+    );
+  });
+
+  it("stops the format at a comma (surrounding prose survives)", () => {
+    expect(resolveTemplateBody("Due $date:YYYY-MM-DD, then ship")).toBe(
+      "Due 2026-06-21, then ship",
+    );
+  });
+
+  it("resolves multiple date tokens with distinct modifiers in one body", () => {
+    expect(resolveTemplateBody("from $date to $date+7d ($date+7d:dddd)")).toBe(
+      "from 2026-06-21 to 2026-06-28 (Sunday)",
+    );
+  });
+
+  it("ZERO REGRESSION — legacy modifier-UNAWARE token reproduces the suffix verbatim", () => {
+    // `today` is legacy (UTC, modifier-unaware). Its value with the suffix
+    // re-appended must equal the pre-feature output (old regex stopped at the
+    // first non-identifier char, leaving `+7d` / `:foo` literal). We register a
+    // deterministic `today` so the assertion is exact regardless of UTC offset.
+    registerResolver("today", () => "2026-06-21");
+    expect(resolveTemplateBody("$today+7d")).toBe("2026-06-21+7d");
+    expect(resolveTemplateBody("$today:YYYY")).toBe("2026-06-21:YYYY");
+  });
+
+  it("ZERO REGRESSION — $today.md / $today-end / $today/x still split at punctuation", () => {
+    registerResolver("today", () => "2026-06-21");
+    // `.md` has no leading `:` → not a format suffix; `-end` has no digit after
+    // `-` → not an offset; `/x` is neither. All capture an empty suffix.
+    expect(resolveTemplateBody("$today.md $today-end $today/x")).toBe(
+      "2026-06-21.md 2026-06-21-end 2026-06-21/x",
+    );
+  });
+
+  it("leaves an UNKNOWN token-with-suffix fully literal (whole match preserved)", () => {
+    expect(resolveTemplateBody("$bogus+7d:YYYY-MM-DD stays")).toBe(
+      "$bogus+7d:YYYY-MM-DD stays",
+    );
+  });
+
+  it("leaves a literal $5.00 price untouched (no letter after $)", () => {
+    expect(resolveTemplateBody("Costs $5.00 total")).toBe("Costs $5.00 total");
+  });
+});

--- a/packages/exocortex/tests/unit/services/TemplateBodyResolver.test.ts
+++ b/packages/exocortex/tests/unit/services/TemplateBodyResolver.test.ts
@@ -227,4 +227,22 @@ describe("resolveTemplateBody — inline date format + offset tokens (Веха 5
   it("leaves a literal $5.00 price untouched (no letter after $)", () => {
     expect(resolveTemplateBody("Costs $5.00 total")).toBe("Costs $5.00 total");
   });
+
+  it("LIMITATION — a space/comma in a body format truncates it at that char", () => {
+    // Documents the body-path boundary (the format charset excludes space/comma):
+    // `$now:h:mm A` resolves only `:h:mm` → `12:30`; the ` A` survives as prose.
+    // Multi-word formats are reachable only via TokenInvocation_parameter.
+    expect(resolveTemplateBody("Time $now:h:mm A done")).toBe(
+      "Time 12:30 A done",
+    );
+    expect(resolveTemplateBody("$date:dddd, MMMM Do YYYY")).toBe(
+      "Sunday, MMMM Do YYYY",
+    );
+  });
+
+  it("leaves a malformed offset as prose ($date+abc → <date>+abc)", () => {
+    // `+abc` is not a date-shaped offset (no digit after `+`) → suffix is empty,
+    // `$date` resolves, `+abc` stays literal prose.
+    expect(resolveTemplateBody("$date+abc")).toBe("2026-06-21+abc");
+  });
 });


### PR DESCRIPTION
## Что

Финальная веха homoiconic-templating подсистемы (заменяет Obsidian Core Template + Community Templater). Добавляет **форматируемые/смещаемые date-токены** в `$token`-словарь — паритет с Templater `tp.date.*` (единственный реально используемый Андреем Templater-surface, Q10).

## Новые токены (modifier-aware)

| Синтаксис | Результат | Templater-аналог |
|---|---|---|
| `$date` | `2026-06-21` | `tp.date.now("YYYY-MM-DD")` |
| `$date:DD.MM.YYYY` | `21.06.2026` | формат |
| `$date+7d` | +7 дней (также `-Nd`/`+Nw`/`+NM`/`+Ny`; голое `N` = дни) | offset |
| `$date+1M:YYYY-MM` | `2026-07` | offset+format |
| `$now` / `$now:HH:mm:ss` | datetime | `tp.date.now` |
| `$tomorrow` / `$yesterday` | ±1 день (+ собственный suffix) | `tp.date.tomorrow/yesterday` |

Грамматика: `$<name><offset><:format>` — суффикс захватывается `TemplateBodyResolver.TOKEN_RE` и передаётся резолверу через **существующий** `parameter`-канал (Веха 4 `exocmd__SubstitutionToken`), без дублирования механизма.

## Ключевые свойства

- **Self-contained moment-style formatter** (YYYY/YY/MMMM/MMM/MM/M/Do/DD/D/dddd/ddd/HH/H/hh/h/mm/m/ss/s/A/a), английские имена, только `Date` — **NO Node fs / NO Intl** → идентично на desktop и mobile (Desktop↔Mobile command parity invariant).
- **ZERO regression:** legacy modifier-UNAWARE токены (`today`/`nowDate`/…) не тронуты; их суффикс воспроизводится дословно (`$today+7d` → `<date>+7d` точь-в-точь как до фичи). Reproduce-verbatim делает старое поведение побитово идентичным.
- **Leniency сохранена:** неизвестный токен / невалидный модификатор → literal не тронут.

## Tests

+36 unit-тестов (формат, offset d/w/M/y + overflow, комбинации, leniency, body-inline, zero-regression). **Empirical revert-verify:** (1) обнуление offset-арифметики → offset-тесты RED; (2) drop suffix в body-резолвере → inline-тесты RED; оба restored GREEN. Существующий enum-of-resolver-ids тест обновлён (15→19).

## Descope (follow-up при необходимости)

`tp.date.weekday`, whitespace-в-inline-формате, moment `[literal]` escaping. Ядро (now/tomorrow/yesterday + format + offset) полностью покрыто.

WBS: Веха 5 `108b70b4` (parent: templating subproject `17f58ebe`).