### PR TITLE
docs(taxonomy): drop stale NL→SPARQL doc rows (feature already removed)

### DIFF
--- a/docs/TAXONOMY.md
+++ b/docs/TAXONOMY.md
@@ -67,7 +67,6 @@ already-bucketed or non-prose.
 | `docs/exosync.md`                                                      | `docs/how-to/exosync.md`                             | how-to       | ExoSync **usage** (`Exocortex: Sync`, structured merge, conflict quarantine)                                                                                                           |
 | `docs/ROLLBACK_EXOQL_EVAL.md`                                          | `docs/how-to/ROLLBACK_EXOQL_EVAL.md`                 | how-to       | operational rollback **procedure** (runbook); task-oriented                                                                                                                            |
 | `docs/PROPERTY_SCHEMA.md`                                              | `docs/reference/PROPERTY_SCHEMA.md`                  | reference    | frontmatter property vocabulary (pure reference)                                                                                                                                       |
-| `docs/NL-TO-SPARQL.md`                                                 | `docs/reference/NL-TO-SPARQL.md`                     | reference    | canonical NL → query translation reference                                                                                                                                             |
 | `docs/SHACL_LITE_MAPPING.md`                                           | `docs/reference/SHACL_LITE_MAPPING.md`               | reference    | self-labeled "Status: Reference"; vocabulary mapping                                                                                                                                   |
 | `docs/Performance-Guide.md`                                            | `docs/reference/Performance-Guide.md`                | reference    | **straddle**: "optimization tips **and performance characteristics**" — the system-characteristics content (index permutations, complexity) dominates over the tuning tips → reference |
 | `docs/api/Core-API.md`                                                 | `docs/reference/Core-API.md`                         | reference    | programmatic core API reference (`api/` subdir flattened — single file)                                                                                                                |
@@ -110,18 +109,18 @@ already-bucketed or non-prose.
 
 ## Package-local docs — logically `reference/`, physically stay (npm-shipped)
 
-| Path                                                                                  | Mode                                                                            |
-| ------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
-| `packages/cli/docs/CLI_API_REFERENCE.md`                                              | reference                                                                       |
-| `packages/cli/docs/ONTOLOGY_REFERENCE.md`                                             | reference                                                                       |
-| `packages/cli/docs/SPARQL_GUIDE.md`, `SPARQL_COOKBOOK.md`                             | reference                                                                       |
-| `packages/cli/VERSIONING.md`                                                          | reference                                                                       |
-| `packages/cli/docs/RCA_DYNCOMMAND_SHOW_VS_EXEC.md`, `SUNSET_LEGACY_COMMAND_START.md`  | contributing (process)                                                          |
-| `packages/obsidian-plugin/docs/EXO_LAYOUT.md`                                         | reference                                                                       |
-| `packages/obsidian-plugin/docs/release-checklist-mobile.md`                           | how-to                                                                          |
-| `packages/obsidian-plugin/docs/FLAKY_DASHBOARD.md`                                    | contributing                                                                    |
-| `packages/obsidian-plugin/docs/TESTING.md`, `packages/exocortex/docs/NL-TO-SPARQL.md` | stubs → canonical (root `TESTING.md` / `docs/reference/NL-TO-SPARQL.md`)        |
-| `packages/obsidian-plugin/docs/phase3/**`                                             | frozen archive (referenced by `docker-entrypoint-e2e.sh` comment — do not move) |
+| Path                                                                                 | Mode                                                                            |
+| ------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------- |
+| `packages/cli/docs/CLI_API_REFERENCE.md`                                             | reference                                                                       |
+| `packages/cli/docs/ONTOLOGY_REFERENCE.md`                                            | reference                                                                       |
+| `packages/cli/docs/SPARQL_GUIDE.md`, `SPARQL_COOKBOOK.md`                            | reference                                                                       |
+| `packages/cli/VERSIONING.md`                                                         | reference                                                                       |
+| `packages/cli/docs/RCA_DYNCOMMAND_SHOW_VS_EXEC.md`, `SUNSET_LEGACY_COMMAND_START.md` | contributing (process)                                                          |
+| `packages/obsidian-plugin/docs/EXO_LAYOUT.md`                                        | reference                                                                       |
+| `packages/obsidian-plugin/docs/release-checklist-mobile.md`                          | how-to                                                                          |
+| `packages/obsidian-plugin/docs/FLAKY_DASHBOARD.md`                                   | contributing                                                                    |
+| `packages/obsidian-plugin/docs/TESTING.md`                                           | stub → canonical (root `TESTING.md`)                                            |
+| `packages/obsidian-plugin/docs/phase3/**`                                            | frozen archive (referenced by `docker-entrypoint-e2e.sh` comment — do not move) |
 
 ---
 


### PR DESCRIPTION
## What

Removes the two stale **natural-language → SPARQL** documentation rows from `docs/TAXONOMY.md`.

## Why

Per directive: NL-query (natural-language → SPARQL) is not used and is being removed from docs (the long-term reasoning/inference **vision stays in `VISION.md`**).

Characterization (fresh `origin/main`, multi-pattern grep) confirmed the **feature is already fully removed from the codebase**:
- `findClassByTerm` (term→class NL routing) — **0 hits**.
- `SPARQLTemplateLibrary` — gone; only a provenance comment remains in `SparqlPrefixes.ts`.
- `OpenQueryBuilderCommand` + `SPARQLQueryBuilderModal` — removed earlier (EKA Phase A C1 / RFC 78c2b7d0 §5; breadcrumb in `CommandManager.ts:21`).
- No NL command/flag in the CLI, no NL→SPARQL translator.

No actual `NL-TO-SPARQL.md` doc file exists anywhere, yet `docs/TAXONOMY.md` still listed two mapping rows pointing at a **non-existent** `docs/reference/NL-TO-SPARQL.md` (dangling references in a "source of truth for the physical layout" doc).

## Scope

- ✅ Removed the pure `docs/NL-TO-SPARQL.md` row + trimmed the NL part out of the bundled `TESTING.md` stub row (TESTING.md mapping preserved).
- ⛔ `VISION.md` untouched (directive — reasoning/inference vision stays).
- ⛔ `docs/rfc/0001` (historical reorg decision record) left intact — preserving the historical record.
- ⛤ Shared SPARQL infra (exoql / SPARQLParser / AlgebraTranslator / QueryExecutor / LayoutQueryBuilder / `SPARQL_PREFIXES` / `isAskQuery`) untouched — that is base SPARQL, not the NL-query feature.

Docs-only change. Table re-padding in the diff is `prettier --write` canonical output (file was prettier-clean on main).
