### PR TITLE
feat(sync): IntelliJ-style 3-pane conflict resolver (Local | Merge | Remote)

### DIFF
--- a/packages/obsidian-plugin/src/infrastructure/adapters/QuarantineResolverModal.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/QuarantineResolverModal.ts
@@ -5,24 +5,31 @@ import type {
   ResolveChoice,
 } from "exocortex";
 import type { ResolverModalContext } from "./QuarantineResolverCommands";
+import { buildPaneModel, type DiffRow } from "./conflictDiff";
 
 /**
  * QuarantineResolverModal — the «Resolve sync conflicts» UI (finding a0a3d1d6,
- * design interview 2026-06-20).
+ * design interviews 2026-06-20 + 2026-06-21).
  *
- * List → per-file resolve (interview Q): the modal shows the open conflicts;
- * picking one renders the two competing versions SIDE-BY-SIDE (local | remote,
- * responsive: stacked on a narrow modal via CSS) with three actions — Keep
- * local / Keep remote / Merge (an editable field seeded with the local version).
- * Applying a choice removes the conflict from the list and returns to it; when
- * the list empties the modal closes.
+ * List → per-file resolve. Picking a conflict renders an IntelliJ-style 3-pane
+ * view — **Local (yours) | Merge (result, editable) | Remote (theirs)** — with
+ * line-level diff colouring (green = added, red = removed, amber = conflict),
+ * per-hunk accept actions, and Prev/Next conflict navigation. The centre Merge
+ * pane is seeded with a diff3 auto-merge (non-conflicting changes pre-applied,
+ * conflicts default to the local side); the user edits it freely. Applying a
+ * choice removes the conflict from the list and returns to it; an empty list
+ * closes the modal.
  *
- * Thin by design: ALL logic lives in {@link ResolverModalContext} (the testable
- * `QuarantineResolverCommands`). This file is render + a11y only.
+ * Thin by design: ALL resolve logic lives in {@link ResolverModalContext} (the
+ * testable `QuarantineResolverCommands`) and the diff maths in the pure
+ * {@link buildPaneModel}. This file is render + a11y only; it NEVER touches the
+ * zero-loss resolve path — the user's choice still flows out as a `ResolveChoice`.
  *
- * a11y (RFC 0002 §3.11 / P16): every action button carries an explicit
- * `aria-label` (never a glyph alone); the resolve actions reference a
- * `aria-describedby` consequence line; focus is managed on view transitions.
+ * a11y (RFC 0002 §3.11 / P16): every action button (incl. per-hunk + nav)
+ * carries an explicit `aria-label`; the resolve actions reference an
+ * `aria-describedby` consequence line; diff lines convey meaning by a prefix
+ * marker + screen-reader text, not colour alone (WCAG 1.4.1); focus is managed
+ * on view transitions.
  */
 export class QuarantineResolverModal extends Modal {
   private readonly ctx: ResolverModalContext;
@@ -117,24 +124,104 @@ export class QuarantineResolverModal extends Modal {
       return;
     }
 
-    const cols = contentEl.createEl("div", { cls: "exosync-resolver-cols" });
-    this.versionColumn(cols, "Local (yours)", detail.local);
-    this.versionColumn(cols, "Remote (theirs)", detail.remote);
+    const model = buildPaneModel(detail);
+    // Per-hunk choices: index → side. Default "local" (matches the auto-merge
+    // seed); flipping a hunk to "remote" rebuilds the merge text.
+    const choices: ("local" | "remote")[] = model.hunks.map(() => "local");
+    // Nav anchors — the first DOM element of each conflict hunk per pane.
+    const navAnchors: { local: HTMLElement; remote: HTMLElement }[] = [];
 
-    // Merge field — seeded with local (or remote when local is absent).
-    const mergeWrap = contentEl.createEl("div", { cls: "exosync-resolver-merge" });
-    mergeWrap.createEl("label", {
-      cls: "exosync-resolver-merge-label",
-      text: "Merge manually (edit, then resolve with merged):",
-      attr: { for: "exosync-resolver-merge-area" },
+    // ── Navigation bar (conflict counter + Prev/Next) ──────────────────────
+    // The arrow glyphs are decorative (aria-hidden); the text + aria-label carry
+    // the meaning. Keeping the glyph in a separate span keeps the button text in
+    // sentence case (the first letter stays the capital).
+    const navBar = contentEl.createEl("div", {
+      cls: "exosync-resolver-navbar",
     });
-    const area = mergeWrap.createEl("textarea", {
-      cls: "exosync-resolver-merge-area",
+    const prevBtn = navBar.createEl("button", {
+      cls: "exosync-resolver-nav-btn",
     });
+    prevBtn.createEl("span", { text: "◀ ", attr: { "aria-hidden": "true" } });
+    prevBtn.createEl("span", { text: "Prev conflict" });
+    prevBtn.setAttribute("aria-label", "Scroll to the previous conflict hunk");
+    const nextBtn = navBar.createEl("button", {
+      cls: "exosync-resolver-nav-btn",
+    });
+    nextBtn.createEl("span", { text: "Next conflict" });
+    nextBtn.createEl("span", { text: " ▶", attr: { "aria-hidden": "true" } });
+    nextBtn.setAttribute("aria-label", "Scroll to the next conflict hunk");
+    navBar.createEl("span", {
+      cls: "exosync-resolver-nav-count",
+      text:
+        `${model.hunkCount} conflict hunk${model.hunkCount === 1 ? "" : "s"}` +
+        ` · ${model.autoMergedCount} auto-merged`,
+    });
+    // Disabled state is set AFTER the panes render — it keys on the number of
+    // navigable (line-level) hunks, which is 0 for a whole-side add/delete
+    // conflict (hunkCount === 1 there, but its rows are added/removed, not
+    // conflict, so no nav anchor is registered). See the post-renderPane block.
+
+    // ── 3-pane grid: Local | Merge (editable) | Remote ─────────────────────
+    const grid = contentEl.createEl("div", { cls: "exosync-resolver-3pane" });
+
+    // The merge textarea is created first so the pane accept-buttons can target
+    // it; it is appended into the centre pane below.
+    const area = document.createElement("textarea");
+    area.className = "exosync-resolver-merge-area";
     area.setAttribute("id", "exosync-resolver-merge-area");
     area.setAttribute("aria-label", `Merged content for ${conflict.path}`);
-    area.value = detail.local ?? detail.remote ?? "";
+    area.value = model.autoMerge;
 
+    const applyHunkChoice = (
+      hunkIndex: number,
+      side: "local" | "remote",
+    ): void => {
+      choices[hunkIndex] = side;
+      area.value = model.rebuildMerge(choices);
+      this.tryFocus(area);
+    };
+
+    this.renderPane(
+      grid,
+      "local",
+      "Local (yours)",
+      conflict.path,
+      model.localRows,
+      navAnchors,
+      applyHunkChoice,
+    );
+    this.renderMergePane(grid, area);
+    this.renderPane(
+      grid,
+      "remote",
+      "Remote (theirs)",
+      conflict.path,
+      model.remoteRows,
+      navAnchors,
+      applyHunkChoice,
+    );
+
+    // Wire navigation now that anchors exist. Nav is only meaningful when there
+    // are line-level conflict hunks to scroll between.
+    const navigable = navAnchors.length;
+    prevBtn.toggleAttribute("disabled", navigable === 0);
+    nextBtn.toggleAttribute("disabled", navigable === 0);
+    let activeHunk = -1;
+    const gotoHunk = (delta: number): void => {
+      if (navAnchors.length === 0) return;
+      activeHunk = (activeHunk + delta + navAnchors.length) % navAnchors.length;
+      for (let i = 0; i < navAnchors.length; i++) {
+        const on = i === activeHunk;
+        navAnchors[i].local.toggleClass("is-active-conflict", on);
+        navAnchors[i].remote.toggleClass("is-active-conflict", on);
+      }
+      this.scrollIntoView(navAnchors[activeHunk].local);
+      this.scrollIntoView(navAnchors[activeHunk].remote);
+    };
+    prevBtn.addEventListener("click", () => gotoHunk(-1));
+    nextBtn.addEventListener("click", () => gotoHunk(+1));
+
+    // ── Action bar (the three ResolveChoice + back) ────────────────────────
     const actions = contentEl.createEl("div", {
       cls: "modal-button-container exosync-resolver-detail-actions",
     });
@@ -153,6 +240,19 @@ export class QuarantineResolverModal extends Modal {
       void this.applyChoice(conflict, { take: "local" });
     });
 
+    const keepMerged = actions.createEl("button", {
+      cls: "mod-cta",
+      text: "Resolve with merge",
+    });
+    keepMerged.setAttribute(
+      "aria-label",
+      `Resolve ${conflict.path} with the merged content`,
+    );
+    keepMerged.setAttribute("aria-describedby", consequenceId);
+    keepMerged.addEventListener("click", () => {
+      void this.applyChoice(conflict, { take: "merged", content: area.value });
+    });
+
     const keepRemote = actions.createEl("button", { text: "Keep remote" });
     keepRemote.setAttribute(
       "aria-label",
@@ -163,31 +263,114 @@ export class QuarantineResolverModal extends Modal {
       void this.applyChoice(conflict, { take: "remote" });
     });
 
-    const keepMerged = actions.createEl("button", { text: "Resolve with merged" });
-    keepMerged.setAttribute(
-      "aria-label",
-      `Resolve ${conflict.path} with your hand-merged content`,
-    );
-    keepMerged.setAttribute("aria-describedby", consequenceId);
-    keepMerged.addEventListener("click", () => {
-      void this.applyChoice(conflict, { take: "merged", content: area.value });
-    });
-
     this.backButton(actions);
     this.tryFocus(keepLocal.hasAttribute("disabled") ? keepRemote : keepLocal);
   }
 
-  private versionColumn(
-    parent: HTMLElement,
+  /**
+   * Render one read-only side pane (Local or Remote) from its diff rows.
+   * Consecutive conflict rows form a hunk: the first row is the nav anchor and
+   * the run is followed by a per-hunk accept button.
+   */
+  private renderPane(
+    grid: HTMLElement,
+    side: "local" | "remote",
     heading: string,
-    content: string | undefined,
+    path: string,
+    rows: DiffRow[],
+    navAnchors: { local: HTMLElement; remote: HTMLElement }[],
+    applyHunkChoice: (hunkIndex: number, side: "local" | "remote") => void,
   ): void {
-    const col = parent.createEl("div", { cls: "exosync-resolver-col" });
-    col.createEl("h3", { cls: "exosync-resolver-col-title", text: heading });
-    col.createEl("pre", {
-      cls: "exosync-resolver-col-body",
-      text: content ?? "(deleted on this side)",
+    const pane = grid.createEl("div", {
+      cls: `exosync-resolver-pane exosync-resolver-pane--${side}`,
     });
+    pane.setAttribute("role", "group");
+    pane.setAttribute("aria-label", `${heading} version of ${path}`);
+    pane.createEl("h3", { cls: "exosync-resolver-pane-title", text: heading });
+    const body = pane.createEl("div", { cls: "exosync-resolver-pane-body" });
+
+    let hunkIndex = 0;
+    let i = 0;
+    while (i < rows.length) {
+      const row = rows[i];
+      if (row.cls === "conflict" && row.conflictStart) {
+        // Group the whole conflict run.
+        const hunk = body.createEl("div", { cls: "exosync-diff-hunk" });
+        const thisHunkIndex = hunkIndex;
+        let firstAnchor: HTMLElement | null = null;
+        do {
+          const lineEl = this.renderLine(hunk, rows[i]);
+          if (firstAnchor === null) firstAnchor = lineEl;
+          i++;
+        } while (
+          i < rows.length &&
+          rows[i].cls === "conflict" &&
+          !rows[i].conflictStart
+        );
+
+        // Per-hunk accept button.
+        const acceptBtn = hunk.createEl("button", {
+          cls: "exosync-resolver-hunk-btn",
+          text: side === "local" ? "◀ use local" : "use remote ▶",
+        });
+        acceptBtn.setAttribute(
+          "aria-label",
+          `Use the ${side} version of conflict hunk ${thisHunkIndex + 1} in the merge`,
+        );
+        acceptBtn.addEventListener("click", () =>
+          applyHunkChoice(thisHunkIndex, side),
+        );
+
+        // Register / reuse the nav anchor slot for this hunk (both panes write
+        // into the SAME slot index, in document order).
+        const anchorEl = firstAnchor ?? hunk;
+        if (!navAnchors[thisHunkIndex]) {
+          navAnchors[thisHunkIndex] = {
+            local: anchorEl,
+            remote: anchorEl,
+          };
+        }
+        navAnchors[thisHunkIndex][side] = anchorEl;
+        hunkIndex++;
+      } else {
+        this.renderLine(body, row);
+        i++;
+      }
+    }
+  }
+
+  /** Render one diff line: marker + SR text + content (meaning ≠ colour only). */
+  private renderLine(parent: HTMLElement, row: DiffRow): HTMLElement {
+    const line = parent.createEl("div", {
+      cls: `exosync-diff-line exosync-diff-${row.cls}`,
+    });
+    const marker = MARKERS[row.cls];
+    line.createEl("span", {
+      cls: "exosync-diff-marker",
+      text: marker.glyph,
+      attr: { "aria-hidden": "true" },
+    });
+    if (marker.sr) {
+      line.createEl("span", {
+        cls: "exosync-visually-hidden",
+        text: `${marker.sr}: `,
+      });
+    }
+    line.createEl("span", { cls: "exosync-diff-text", text: row.text });
+    return line;
+  }
+
+  private renderMergePane(grid: HTMLElement, area: HTMLTextAreaElement): void {
+    const pane = grid.createEl("div", {
+      cls: "exosync-resolver-pane exosync-resolver-pane--merge",
+    });
+    pane.setAttribute("role", "group");
+    pane.setAttribute("aria-label", "Merged result (editable)");
+    pane.createEl("h3", {
+      cls: "exosync-resolver-pane-title",
+      text: "Merge (result) ✎",
+    });
+    pane.appendChild(area);
   }
 
   private backButton(parent: HTMLElement): void {
@@ -223,4 +406,19 @@ export class QuarantineResolverModal extends Modal {
       /* focus is best-effort (jsdom / headless) */
     }
   }
+
+  private scrollIntoView(el: HTMLElement): void {
+    try {
+      el.scrollIntoView?.({ block: "nearest" });
+    } catch {
+      /* scrollIntoView is best-effort (jsdom / headless) */
+    }
+  }
 }
+
+const MARKERS: Record<DiffRow["cls"], { glyph: string; sr: string }> = {
+  context: { glyph: " ", sr: "" },
+  added: { glyph: "+", sr: "added" },
+  removed: { glyph: "-", sr: "removed" },
+  conflict: { glyph: "‼", sr: "conflict" }, // ‼
+};

--- a/packages/obsidian-plugin/src/infrastructure/adapters/conflictDiff.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/conflictDiff.ts
@@ -1,0 +1,451 @@
+/**
+ * conflictDiff — pure presentation helper for the IntelliJ-style 3-pane
+ * ExoSync conflict resolver (design 2026-06-21, finding a0a3d1d6).
+ *
+ * This is a VISUALISATION concern (homoiconicity Q3 — rendering core), NOT a
+ * merge engine: it never decides a resolution, it only describes how Local and
+ * Remote differ from their common `base` so the modal can colour the lines and
+ * seed the editable merge pane. The user's choice still flows out through the
+ * unchanged `ResolveChoice` → `resolver.resolve` path; zero-loss semantics live
+ * in the engine, untouched here.
+ *
+ * Why an in-house 3-way walk instead of `diff3` from the core: `diff3` returns
+ * at the FIRST conflict region (`{ ok:false, conflict }`), which is enough for
+ * the engine's "auto-merge or quarantine" decision but NOT for a UI that must
+ * (a) navigate EVERY conflict hunk and (b) colour each line. So this module
+ * walks all regions, reusing the engine's exact LCS pairing (`lcsMatch`, copied
+ * verbatim — it is module-private in diff3.ts) so the alignment matches.
+ */
+
+import type { ConflictDetail } from "exocortex";
+
+export type DiffClass = "context" | "added" | "removed" | "conflict";
+
+export interface DiffRow {
+  text: string;
+  cls: DiffClass;
+  /** First row of a conflict hunk — the anchor the Prev/Next nav scrolls to. */
+  conflictStart?: boolean;
+}
+
+/** One conflict hunk's two competing versions (per-hunk accept + nav). */
+export interface ConflictHunk {
+  localLines: string[];
+  remoteLines: string[];
+}
+
+export interface PaneModel {
+  localRows: DiffRow[];
+  remoteRows: DiffRow[];
+  /** Merge-pane seed: non-conflicting changes auto-merged, conflicts → local. */
+  autoMerge: string;
+  /** Number of genuine conflict hunks (both sides changed differently). */
+  hunkCount: number;
+  /** Number of change regions auto-merged without conflict (UX counter). */
+  autoMergedCount: number;
+  hasConflict: boolean;
+  /** Conflict hunks in document order (for per-hunk accept + navigation). */
+  hunks: ConflictHunk[];
+  /**
+   * Rebuild the merge text from per-hunk choices. `choices[i]` selects the i-th
+   * conflict hunk's side; defaults to "local" (the {@link autoMerge} seed) for
+   * any index not supplied. Non-conflicting regions are always auto-merged.
+   */
+  rebuildMerge: (choices: ReadonlyArray<"local" | "remote">) => string;
+}
+
+/**
+ * Monotonic LCS pairing: index in `a` → index in `b`. Copied verbatim from
+ * `packages/exocortex/src/services/sync/diff3.ts` (`lcsMatch` is module-private
+ * there) so the UI alignment matches the engine's 3-way merge exactly.
+ */
+function lcsMatch(
+  a: readonly string[],
+  b: readonly string[],
+): Map<number, number> {
+  const n = a.length;
+  const m = b.length;
+  const dp: Int32Array[] = Array.from(
+    { length: n + 1 },
+    () => new Int32Array(m + 1),
+  );
+  for (let i = n - 1; i >= 0; i--) {
+    for (let j = m - 1; j >= 0; j--) {
+      dp[i][j] =
+        a[i] === b[j]
+          ? dp[i + 1][j + 1] + 1
+          : Math.max(dp[i + 1][j], dp[i][j + 1]);
+    }
+  }
+  const match = new Map<number, number>();
+  let i = 0;
+  let j = 0;
+  while (i < n && j < m) {
+    if (a[i] === b[j]) {
+      match.set(i, j);
+      i++;
+      j++;
+    } else if (dp[i + 1][j] >= dp[i][j + 1]) {
+      i++;
+    } else {
+      j++;
+    }
+  }
+  return match;
+}
+
+function sliceEq(a: readonly string[], b: readonly string[]): boolean {
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) {
+    if (a[i] !== b[i]) return false;
+  }
+  return true;
+}
+
+/**
+ * 2-way line alignment of `side` against a reference (`base` in 3-way, the
+ * other side when there is no base): matched lines → context, side-only lines →
+ * added (green), reference-only lines → removed (red, the reference text shown
+ * so the user sees what this side dropped).
+ */
+function alignAgainstBase(
+  side: readonly string[],
+  base: readonly string[],
+): DiffRow[] {
+  const match = lcsMatch(side, base);
+  const rows: DiffRow[] = [];
+  let si = 0;
+  let bi = 0;
+  while (si < side.length || bi < base.length) {
+    if (si < side.length && match.has(si)) {
+      const bj = match.get(si) as number;
+      while (bi < bj) {
+        rows.push({ text: base[bi], cls: "removed" });
+        bi++;
+      }
+      rows.push({ text: side[si], cls: "context" });
+      si++;
+      bi++;
+    } else if (si < side.length) {
+      rows.push({ text: side[si], cls: "added" });
+      si++;
+    } else {
+      rows.push({ text: base[bi], cls: "removed" });
+      bi++;
+    }
+  }
+  return rows;
+}
+
+type SegmentKind = "stable" | "local" | "remote" | "convergent" | "conflict";
+
+interface Segment {
+  kind: SegmentKind;
+  localRows: DiffRow[];
+  remoteRows: DiffRow[];
+  /** Lines this segment contributes to the default auto-merge (conflict→local). */
+  mergeLines: string[];
+  /** Conflict alternatives (present only when kind === "conflict"). */
+  conflictLocal?: string[];
+  conflictRemote?: string[];
+}
+
+function splitLines(s: string | undefined): string[] {
+  if (s === undefined || s === "") return s === "" ? [""] : [];
+  return s.split("\n");
+}
+
+/** Map an aligned side's non-context rows to conflict class (whole hunk). */
+function markConflict(lines: string[]): DiffRow[] {
+  if (lines.length === 0) {
+    return [
+      { text: "(empty on this side)", cls: "conflict", conflictStart: true },
+    ];
+  }
+  return lines.map((text, i) => ({
+    text,
+    cls: "conflict" as const,
+    ...(i === 0 ? { conflictStart: true } : {}),
+  }));
+}
+
+/** Region kinds for a changed (non-stable) base-gap. */
+function changedSegment(
+  baseChunk: string[],
+  localChunk: string[],
+  remoteChunk: string[],
+): Segment {
+  const localChanged = !sliceEq(localChunk, baseChunk);
+  const remoteChanged = !sliceEq(remoteChunk, baseChunk);
+
+  if (localChanged && remoteChanged && !sliceEq(localChunk, remoteChunk)) {
+    // Genuine conflict — both sides diverged differently.
+    return {
+      kind: "conflict",
+      localRows: markConflict(localChunk),
+      remoteRows: markConflict(remoteChunk),
+      mergeLines: localChunk,
+      conflictLocal: localChunk,
+      conflictRemote: remoteChunk,
+    };
+  }
+  if (localChanged && remoteChanged) {
+    // Convergent — both made the same change.
+    return {
+      kind: "convergent",
+      localRows: alignAgainstBase(localChunk, baseChunk),
+      remoteRows: alignAgainstBase(remoteChunk, baseChunk),
+      mergeLines: localChunk,
+    };
+  }
+  if (localChanged) {
+    // Only local changed — auto-merge takes local; remote pane is unchanged.
+    return {
+      kind: "local",
+      localRows: alignAgainstBase(localChunk, baseChunk),
+      remoteRows: remoteChunk.map((text) => ({
+        text,
+        cls: "context" as const,
+      })),
+      mergeLines: localChunk,
+    };
+  }
+  // Only remote changed — auto-merge takes remote; local pane is unchanged.
+  return {
+    kind: "remote",
+    localRows: localChunk.map((text) => ({ text, cls: "context" as const })),
+    remoteRows: alignAgainstBase(remoteChunk, baseChunk),
+    mergeLines: remoteChunk,
+  };
+}
+
+function stableSegment(lines: string[]): Segment {
+  const rows = lines.map((text) => ({ text, cls: "context" as const }));
+  return {
+    kind: "stable",
+    localRows: rows,
+    remoteRows: rows,
+    mergeLines: lines,
+  };
+}
+
+/**
+ * Full 3-way region walk (mirrors diff3's anchor loop but COLLECTS every region
+ * instead of returning at the first conflict).
+ */
+function collectRegions3(
+  base: string[],
+  local: string[],
+  remote: string[],
+): Segment[] {
+  const ml = lcsMatch(base, local);
+  const mr = lcsMatch(base, remote);
+  const segments: Segment[] = [];
+  let bi = 0;
+  let li = 0;
+  let ri = 0;
+
+  for (;;) {
+    let anchor = bi;
+    while (anchor < base.length && !(ml.has(anchor) && mr.has(anchor))) {
+      anchor++;
+    }
+    const lEnd =
+      anchor < base.length ? (ml.get(anchor) as number) : local.length;
+    const rEnd =
+      anchor < base.length ? (mr.get(anchor) as number) : remote.length;
+
+    const baseChunk = base.slice(bi, anchor);
+    const localChunk = local.slice(li, lEnd);
+    const remoteChunk = remote.slice(ri, rEnd);
+
+    const localChanged = !sliceEq(localChunk, baseChunk);
+    const remoteChanged = !sliceEq(remoteChunk, baseChunk);
+    if (!localChanged && !remoteChanged) {
+      if (baseChunk.length > 0) segments.push(stableSegment(baseChunk));
+    } else {
+      segments.push(changedSegment(baseChunk, localChunk, remoteChunk));
+    }
+
+    if (anchor >= base.length) break;
+    segments.push(stableSegment([base[anchor]])); // stable anchor line
+    bi = anchor + 1;
+    li = lEnd + 1;
+    ri = rEnd + 1;
+  }
+
+  return segments;
+}
+
+/**
+ * 2-way fallback when there is no common base (GC'd or absent): align Local
+ * against Remote and vice-versa; any non-context run is treated as a conflict
+ * hunk (we cannot tell who is "right" without a base).
+ */
+function collectRegions2(local: string[], remote: string[]): Segment[] {
+  // Build a single conflict segment per differing run by aligning local↔remote.
+  const match = lcsMatch(local, remote);
+  const segments: Segment[] = [];
+  let li = 0;
+  let ri = 0;
+  let pendLocal: string[] = [];
+  let pendRemote: string[] = [];
+
+  const flush = (): void => {
+    if (pendLocal.length === 0 && pendRemote.length === 0) return;
+    segments.push({
+      kind: "conflict",
+      localRows: markConflict(pendLocal),
+      remoteRows: markConflict(pendRemote),
+      mergeLines: pendLocal.length > 0 ? pendLocal : pendRemote,
+      conflictLocal: pendLocal,
+      conflictRemote: pendRemote,
+    });
+    pendLocal = [];
+    pendRemote = [];
+  };
+
+  while (li < local.length || ri < remote.length) {
+    if (li < local.length && match.has(li)) {
+      const rj = match.get(li) as number;
+      while (ri < rj) {
+        pendRemote.push(remote[ri]);
+        ri++;
+      }
+      flush();
+      segments.push(stableSegment([local[li]]));
+      li++;
+      ri++;
+    } else if (li < local.length) {
+      pendLocal.push(local[li]);
+      li++;
+    } else {
+      pendRemote.push(remote[ri]);
+      ri++;
+    }
+  }
+  flush();
+  return segments;
+}
+
+/** Whole-side add/delete (one side absent) → one conflict hunk. */
+function addDeleteModel(detail: ConflictDetail): PaneModel {
+  const localAbsent = detail.local === undefined;
+  const localLines = splitLines(detail.local);
+  const remoteLines = splitLines(detail.remote);
+
+  const placeholder: DiffRow = {
+    text: "(deleted on this side)",
+    cls: "removed",
+    conflictStart: true,
+  };
+  const localRows = localAbsent
+    ? [placeholder]
+    : localLines.map((text, i) => ({
+        text,
+        cls: "added" as const,
+        ...(i === 0 ? { conflictStart: true } : {}),
+      }));
+  const remoteRows = localAbsent
+    ? remoteLines.map((text, i) => ({
+        text,
+        cls: "added" as const,
+        ...(i === 0 ? { conflictStart: true } : {}),
+      }))
+    : [placeholder];
+
+  // Default keeps the SURVIVING side (the one with content) — rarely does the
+  // user want the empty result. autoMerge stays === rebuildMerge([]).
+  const defaultSide: "local" | "remote" = localAbsent ? "remote" : "local";
+  const rebuildMerge = (choices: ReadonlyArray<"local" | "remote">): string =>
+    (choices[0] ?? defaultSide) === "remote"
+      ? (detail.remote ?? "")
+      : (detail.local ?? "");
+  const hunk: ConflictHunk = { localLines, remoteLines };
+  return {
+    localRows,
+    remoteRows,
+    autoMerge: rebuildMerge([]),
+    hunkCount: 1,
+    autoMergedCount: 0,
+    hasConflict: true,
+    hunks: [hunk],
+    rebuildMerge,
+  };
+}
+
+function buildFromSegments(segments: Segment[]): PaneModel {
+  const localRows: DiffRow[] = [];
+  const remoteRows: DiffRow[] = [];
+  const hunks: ConflictHunk[] = [];
+  let autoMergedCount = 0;
+
+  for (const seg of segments) {
+    localRows.push(...seg.localRows);
+    remoteRows.push(...seg.remoteRows);
+    if (seg.kind === "conflict") {
+      hunks.push({
+        localLines: seg.conflictLocal ?? [],
+        remoteLines: seg.conflictRemote ?? [],
+      });
+    } else if (
+      seg.kind === "local" ||
+      seg.kind === "remote" ||
+      seg.kind === "convergent"
+    ) {
+      autoMergedCount++;
+    }
+  }
+
+  const rebuildMerge = (choices: ReadonlyArray<"local" | "remote">): string => {
+    const out: string[] = [];
+    let ci = 0;
+    for (const seg of segments) {
+      if (seg.kind === "conflict") {
+        const choice = choices[ci] ?? "local";
+        out.push(
+          ...(choice === "remote"
+            ? (seg.conflictRemote ?? [])
+            : (seg.conflictLocal ?? [])),
+        );
+        ci++;
+      } else {
+        out.push(...seg.mergeLines);
+      }
+    }
+    return out.join("\n");
+  };
+
+  return {
+    localRows,
+    remoteRows,
+    autoMerge: rebuildMerge([]),
+    hunkCount: hunks.length,
+    autoMergedCount,
+    hasConflict: hunks.length > 0,
+    hunks,
+    rebuildMerge,
+  };
+}
+
+/**
+ * Build the 3-pane diff model for one conflict. Picks the strategy from the
+ * available versions: whole-side add/delete → one conflict hunk; common base
+ * present → true 3-way; base GC'd → 2-way Local↔Remote fallback.
+ */
+export function buildPaneModel(detail: ConflictDetail): PaneModel {
+  // Whole-side add/delete (one side entirely absent).
+  if (detail.local === undefined || detail.remote === undefined) {
+    return addDeleteModel(detail);
+  }
+
+  const local = splitLines(detail.local);
+  const remote = splitLines(detail.remote);
+
+  if (detail.base !== undefined) {
+    const base = splitLines(detail.base);
+    return buildFromSegments(collectRegions3(base, local, remote));
+  }
+  // No base — 2-way fallback.
+  return buildFromSegments(collectRegions2(local, remote));
+}

--- a/packages/obsidian-plugin/styles.css
+++ b/packages/obsidian-plugin/styles.css
@@ -6057,39 +6057,121 @@
   font-family: var(--font-monospace);
   white-space: normal;
 }
-/* Side-by-side local | remote; stacks vertically when the modal is narrow. */
-.exosync-resolver-cols {
+/* ── IntelliJ-style 3-pane diff: Local | Merge (editable) | Remote ───────── */
+/* Conflict navigation bar (Prev/Next + counter). */
+.exosync-resolver-navbar {
   display: flex;
+  align-items: center;
+  gap: 8px;
+  margin: 8px 0 4px;
   flex-wrap: wrap;
+}
+.exosync-resolver-nav-count {
+  color: var(--text-muted);
+  font-size: var(--font-ui-small);
+}
+/* 3 equal columns horizontally; stacks vertically when the modal is narrow. */
+.exosync-resolver-3pane {
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
   gap: 12px;
   margin: 8px 0;
 }
-.exosync-resolver-col {
-  flex: 1 1 280px;
+.exosync-resolver-pane {
   min-width: 0;
+  display: flex;
+  flex-direction: column;
 }
-.exosync-resolver-col-title {
+.exosync-resolver-pane-title {
   margin: 0 0 4px;
   font-size: var(--font-ui-small);
 }
-.exosync-resolver-col-body {
-  max-height: 240px;
+.exosync-resolver-pane-body {
+  max-height: 320px;
   overflow: auto;
-  white-space: pre-wrap;
-  word-break: break-word;
   background: var(--background-secondary);
   border: 1px solid var(--background-modifier-border);
   border-radius: 4px;
-  padding: 6px 8px;
+  padding: 4px 0;
+  font-family: var(--font-monospace);
   font-size: var(--font-ui-smaller);
 }
-.exosync-resolver-merge {
-  margin: 8px 0;
+/* One diff line: marker gutter + text, coloured by semantic class. */
+.exosync-diff-line {
+  display: flex;
+  white-space: pre-wrap;
+  word-break: break-word;
+  padding: 0 8px;
+  border-left: 3px solid transparent;
+}
+.exosync-diff-marker {
+  flex: 0 0 1.2em;
+  text-align: center;
+  opacity: 0.7;
+  user-select: none;
+}
+.exosync-diff-text {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+/* added = green, removed = red, conflict = warning — all via theme vars so the
+ * light/dark adaptation is automatic; rgba fallbacks for older themes. */
+.exosync-diff-added {
+  background: var(--background-modifier-success, rgba(var(--color-green-rgb), 0.15));
+  border-left-color: var(--color-green, #4caf50);
+}
+.exosync-diff-removed {
+  background: var(--background-modifier-error, rgba(var(--color-red-rgb), 0.15));
+  border-left-color: var(--color-red, #e05252);
+  color: var(--text-muted);
+}
+.exosync-diff-conflict {
+  /* Hard rgba first; the var() form overrides it when --color-orange-rgb
+   * resolves, and is simply ignored (keeping the hard tint) on themes that
+   * omit the var — so the conflict tint never disappears entirely. */
+  background: rgba(217, 147, 13, 0.15);
+  background: rgba(var(--color-orange-rgb), 0.15);
+  border-left-color: var(--text-warning, var(--color-orange, #d9930d));
+}
+/* Active conflict hunk (Prev/Next navigation highlight). */
+.exosync-diff-line.is-active-conflict {
+  outline: 2px solid var(--interactive-accent);
+  outline-offset: -2px;
+}
+.exosync-diff-hunk {
+  display: contents;
+}
+.exosync-resolver-hunk-btn {
+  margin: 2px 8px 4px;
+  font-size: var(--font-ui-smaller);
+  padding: 1px 6px;
+}
+.exosync-resolver-pane--merge .exosync-resolver-merge-area {
+  flex: 1 1 auto;
 }
 .exosync-resolver-merge-area {
   width: 100%;
-  min-height: 120px;
+  min-height: 240px;
   font-family: var(--font-monospace);
+  font-size: var(--font-ui-smaller);
+}
+/* Screen-reader-only diff semantics (meaning is never colour-only — WCAG 1.4.1). */
+.exosync-visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+/* Narrow modal / mobile: stack the three panes vertically (Local → Merge → Remote). */
+@media (max-width: 720px) {
+  .exosync-resolver-3pane {
+    grid-template-columns: 1fr;
+  }
 }
 .exosync-resolver-error {
   color: var(--text-error);

--- a/packages/obsidian-plugin/tests/unit/sync/QuarantineResolverModal.test.ts
+++ b/packages/obsidian-plugin/tests/unit/sync/QuarantineResolverModal.test.ts
@@ -1,0 +1,335 @@
+import { App } from "obsidian";
+import type {
+  ConflictDetail,
+  ResolvableConflict,
+  ResolveChoice,
+} from "exocortex";
+import { QuarantineResolverModal } from "../../../src/infrastructure/adapters/QuarantineResolverModal";
+import type { ResolverModalContext } from "../../../src/infrastructure/adapters/QuarantineResolverCommands";
+
+const flush = (): Promise<void> => new Promise((r) => setTimeout(r, 0));
+
+function makeConflict(p: Partial<ResolvableConflict> = {}): ResolvableConflict {
+  return {
+    repoKey: "repo",
+    path: "note.md",
+    uid: "uid-1",
+    hasLocal: true,
+    hasRemote: true,
+    ...p,
+  };
+}
+
+interface Harness {
+  modal: QuarantineResolverModal;
+  ctx: ResolverModalContext;
+  resolveOne: jest.Mock;
+  loadConflict: jest.Mock;
+  onClose: jest.Mock;
+  notify: jest.Mock;
+  body: HTMLElement;
+}
+
+function buildHarness(
+  detail: ConflictDetail,
+  conflicts: ResolvableConflict[] = [makeConflict()],
+): Harness {
+  const resolveOne = jest.fn().mockResolvedValue({
+    repoKey: detail.repoKey,
+    path: detail.path,
+    resolvedTo: "local",
+  });
+  const loadConflict = jest.fn().mockResolvedValue(detail);
+  const onClose = jest.fn();
+  const notify = jest.fn();
+  const ctx: ResolverModalContext = {
+    resolver: {} as never,
+    specByRepoKey: new Map(),
+    conflicts,
+    loadConflict,
+    resolveOne,
+    notify,
+    onClose,
+  };
+  const modal = new QuarantineResolverModal(new App(), ctx);
+  return {
+    modal,
+    ctx,
+    resolveOne,
+    loadConflict,
+    onClose,
+    notify,
+    body: modal.contentEl,
+  };
+}
+
+/** Open the modal and drill into the first conflict's detail view. */
+async function openDetail(h: Harness): Promise<void> {
+  h.modal.onOpen();
+  const row = h.body.querySelector<HTMLButtonElement>(".exosync-resolver-row");
+  expect(row).not.toBeNull();
+  row!.click();
+  await flush();
+}
+
+describe("QuarantineResolverModal — 3-pane detail view", () => {
+  const conflictDetail: ConflictDetail = {
+    repoKey: "repo",
+    path: "note.md",
+    uid: "uid-1",
+    hasLocal: true,
+    hasRemote: true,
+    base: "x",
+    local: "L",
+    remote: "R",
+  };
+
+  it("renders three panes (Local | Merge | Remote) in a grid", async () => {
+    const h = buildHarness(conflictDetail);
+    await openDetail(h);
+
+    expect(h.body.querySelector(".exosync-resolver-3pane")).not.toBeNull();
+    const panes = h.body.querySelectorAll(".exosync-resolver-pane");
+    expect(panes).toHaveLength(3);
+    expect(
+      h.body.querySelector(".exosync-resolver-pane--local"),
+    ).not.toBeNull();
+    expect(
+      h.body.querySelector(".exosync-resolver-pane--merge"),
+    ).not.toBeNull();
+    expect(
+      h.body.querySelector(".exosync-resolver-pane--remote"),
+    ).not.toBeNull();
+  });
+
+  it("colours diverging lines as conflict on both side panes", async () => {
+    const h = buildHarness(conflictDetail);
+    await openDetail(h);
+
+    const local = h.body.querySelector(".exosync-resolver-pane--local")!;
+    const remote = h.body.querySelector(".exosync-resolver-pane--remote")!;
+    expect(
+      local.querySelector(".exosync-diff-conflict")?.textContent,
+    ).toContain("L");
+    expect(
+      remote.querySelector(".exosync-diff-conflict")?.textContent,
+    ).toContain("R");
+  });
+
+  it("seeds the centre merge textarea with the auto-merge (conflict → local)", async () => {
+    const h = buildHarness(conflictDetail);
+    await openDetail(h);
+
+    const area = h.body.querySelector<HTMLTextAreaElement>(
+      ".exosync-resolver-merge-area",
+    );
+    expect(area).not.toBeNull();
+    expect(area!.value).toBe("L");
+  });
+
+  it("per-hunk 'use remote' rebuilds the merge text from the remote side", async () => {
+    const h = buildHarness(conflictDetail);
+    await openDetail(h);
+
+    const remotePane = h.body.querySelector(".exosync-resolver-pane--remote")!;
+    const useRemote = remotePane.querySelector<HTMLButtonElement>(
+      ".exosync-resolver-hunk-btn",
+    );
+    expect(useRemote?.textContent).toContain("use remote");
+    useRemote!.click();
+
+    const area = h.body.querySelector<HTMLTextAreaElement>(
+      ".exosync-resolver-merge-area",
+    )!;
+    expect(area.value).toBe("R");
+  });
+
+  it("Keep local resolves with {take:'local'}", async () => {
+    const h = buildHarness(conflictDetail);
+    await openDetail(h);
+
+    const btn = [...h.body.querySelectorAll<HTMLButtonElement>("button")].find(
+      (b) => b.textContent === "Keep local",
+    )!;
+    btn.click();
+    await flush();
+    expect(h.resolveOne).toHaveBeenCalledWith(
+      expect.objectContaining({ path: "note.md" }),
+      { take: "local" } as ResolveChoice,
+    );
+  });
+
+  it("Keep remote resolves with {take:'remote'}", async () => {
+    const h = buildHarness(conflictDetail);
+    await openDetail(h);
+
+    const btn = [...h.body.querySelectorAll<HTMLButtonElement>("button")].find(
+      (b) => b.textContent === "Keep remote",
+    )!;
+    btn.click();
+    await flush();
+    expect(h.resolveOne).toHaveBeenCalledWith(
+      expect.objectContaining({ path: "note.md" }),
+      { take: "remote" } as ResolveChoice,
+    );
+  });
+
+  it("Resolve with merge sends the current textarea content", async () => {
+    const h = buildHarness(conflictDetail);
+    await openDetail(h);
+
+    // Flip the hunk to remote first, then resolve-with-merge.
+    h.body
+      .querySelector<HTMLButtonElement>(
+        ".exosync-resolver-pane--remote .exosync-resolver-hunk-btn",
+      )!
+      .click();
+
+    const btn = [...h.body.querySelectorAll<HTMLButtonElement>("button")].find(
+      (b) => b.textContent === "Resolve with merge",
+    )!;
+    btn.click();
+    await flush();
+    expect(h.resolveOne).toHaveBeenCalledWith(
+      expect.objectContaining({ path: "note.md" }),
+      { take: "merged", content: "R" } as ResolveChoice,
+    );
+  });
+
+  it("shows a navigation bar with the conflict-hunk counter", async () => {
+    const h = buildHarness(conflictDetail);
+    await openDetail(h);
+
+    const nav = h.body.querySelector(".exosync-resolver-navbar");
+    expect(nav).not.toBeNull();
+    expect(
+      h.body.querySelector(".exosync-resolver-nav-count")?.textContent,
+    ).toContain("1 conflict hunk");
+    const navBtns = nav!.querySelectorAll<HTMLButtonElement>(
+      ".exosync-resolver-nav-btn",
+    );
+    expect(navBtns).toHaveLength(2);
+    // Prev/Next are enabled when there is at least one conflict.
+    expect(navBtns[0].hasAttribute("disabled")).toBe(false);
+  });
+
+  it("a non-conflicting addition shows a green line and disables nav", async () => {
+    const detail: ConflictDetail = {
+      repoKey: "repo",
+      path: "note.md",
+      uid: "uid-1",
+      hasLocal: true,
+      hasRemote: true,
+      base: "a",
+      local: "a\nb",
+      remote: "a",
+    };
+    const h = buildHarness(detail);
+    await openDetail(h);
+
+    const local = h.body.querySelector(".exosync-resolver-pane--local")!;
+    expect(local.querySelector(".exosync-diff-added")?.textContent).toContain(
+      "b",
+    );
+    expect(
+      h.body.querySelector(".exosync-resolver-nav-count")?.textContent,
+    ).toContain("0 conflict hunks");
+    const prev = h.body.querySelector<HTMLButtonElement>(
+      ".exosync-resolver-nav-btn",
+    );
+    expect(prev!.hasAttribute("disabled")).toBe(true);
+  });
+
+  it("preserves a11y: panes are groups, buttons are labelled, diff meaning is not colour-only", async () => {
+    const h = buildHarness(conflictDetail);
+    await openDetail(h);
+
+    for (const pane of h.body.querySelectorAll(".exosync-resolver-pane")) {
+      expect(pane.getAttribute("role")).toBe("group");
+      expect(pane.getAttribute("aria-label")).toBeTruthy();
+    }
+    for (const btn of h.body.querySelectorAll<HTMLButtonElement>("button")) {
+      expect(btn.getAttribute("aria-label")).toBeTruthy();
+    }
+    // Screen-reader text conveys "conflict" without relying on colour.
+    const srText = [...h.body.querySelectorAll(".exosync-visually-hidden")].map(
+      (n) => n.textContent,
+    );
+    expect(srText.join(" ")).toContain("conflict");
+  });
+
+  it("a load failure surfaces an error and a back button (no crash)", async () => {
+    const h = buildHarness(conflictDetail);
+    h.loadConflict.mockRejectedValueOnce(new Error("offline"));
+    await openDetail(h);
+
+    expect(
+      h.body.querySelector(".exosync-resolver-error")?.textContent,
+    ).toContain("offline");
+    expect(h.body.querySelector(".exosync-resolver-3pane")).toBeNull();
+  });
+
+  it("Next conflict marks the active hunk on both panes across multiple hunks", async () => {
+    const twoHunks: ConflictDetail = {
+      repoKey: "repo",
+      path: "note.md",
+      uid: "uid-1",
+      hasLocal: true,
+      hasRemote: true,
+      base: "a\nb\nc\nd\ne",
+      local: "a\nL1\nc\nL2\ne",
+      remote: "a\nR1\nc\nR2\ne",
+    };
+    const h = buildHarness(twoHunks, [makeConflict()]);
+    await openDetail(h);
+
+    const next = [
+      ...h.body.querySelectorAll<HTMLButtonElement>(
+        ".exosync-resolver-nav-btn",
+      ),
+    ].find((b) => b.getAttribute("aria-label")?.includes("next"))!;
+
+    // First Next → hunk 0 active on local + remote pane.
+    next.click();
+    const active1 = h.body.querySelectorAll(".is-active-conflict");
+    expect(active1).toHaveLength(2); // one per pane
+    expect([...active1].some((n) => n.textContent?.includes("L1"))).toBe(true);
+    expect([...active1].some((n) => n.textContent?.includes("R1"))).toBe(true);
+
+    // Second Next → hunk 1 active (and hunk 0 no longer active).
+    next.click();
+    const active2 = h.body.querySelectorAll(".is-active-conflict");
+    expect(active2).toHaveLength(2);
+    expect([...active2].some((n) => n.textContent?.includes("L2"))).toBe(true);
+    expect([...active2].some((n) => n.textContent?.includes("L1"))).toBe(false);
+  });
+
+  it("whole-side add/delete disables nav (no line-level hunk to scroll)", async () => {
+    const addDelete: ConflictDetail = {
+      repoKey: "repo",
+      path: "note.md",
+      uid: "uid-1",
+      hasLocal: false,
+      hasRemote: true,
+      base: "x",
+      local: undefined,
+      remote: "r1\nr2",
+    };
+    const h = buildHarness(addDelete, [makeConflict({ hasLocal: false })]);
+    await openDetail(h);
+
+    // The bottom action bar still resolves it; the nav arrows are inert → disabled.
+    const navBtns = h.body.querySelectorAll<HTMLButtonElement>(
+      ".exosync-resolver-nav-btn",
+    );
+    expect(navBtns).toHaveLength(2);
+    expect(navBtns[0].hasAttribute("disabled")).toBe(true);
+    expect(navBtns[1].hasAttribute("disabled")).toBe(true);
+    // No per-hunk accept button is rendered for a whole-side add/delete.
+    expect(h.body.querySelector(".exosync-resolver-hunk-btn")).toBeNull();
+    // Local pane shows the deletion placeholder; remote pane is all-green.
+    expect(
+      h.body.querySelector(".exosync-resolver-pane--local")?.textContent,
+    ).toContain("(deleted on this side)");
+  });
+});

--- a/packages/obsidian-plugin/tests/unit/sync/conflictDiff.test.ts
+++ b/packages/obsidian-plugin/tests/unit/sync/conflictDiff.test.ts
@@ -1,0 +1,152 @@
+import type { ConflictDetail } from "exocortex";
+import {
+  buildPaneModel,
+  type DiffRow,
+} from "../../../src/infrastructure/adapters/conflictDiff";
+
+/** Helper: a conflict detail with sane defaults. */
+function detail(p: Partial<ConflictDetail>): ConflictDetail {
+  return {
+    repoKey: "repo",
+    path: "a.md",
+    hasLocal: p.local !== undefined,
+    hasRemote: p.remote !== undefined,
+    ...p,
+  };
+}
+
+const texts = (rows: DiffRow[], cls: string): string[] =>
+  rows.filter((r) => r.cls === cls).map((r) => r.text);
+
+describe("conflictDiff.buildPaneModel", () => {
+  it("3-way: local-only addition is green on the local pane, auto-merges", () => {
+    const m = buildPaneModel(
+      detail({ base: "a\nb", local: "a\nb\nc", remote: "a\nb" }),
+    );
+    expect(m.hasConflict).toBe(false);
+    expect(m.hunkCount).toBe(0);
+    expect(m.autoMergedCount).toBe(1);
+    expect(texts(m.localRows, "added")).toEqual(["c"]);
+    expect(m.autoMerge).toBe("a\nb\nc");
+    // rebuildMerge with no choices === the auto-merge seed.
+    expect(m.rebuildMerge([])).toBe(m.autoMerge);
+  });
+
+  it("3-way: local-only removal shows the dropped base line as red", () => {
+    const m = buildPaneModel(
+      detail({ base: "a\nb\nc", local: "a\nc", remote: "a\nb\nc" }),
+    );
+    expect(m.hasConflict).toBe(false);
+    expect(texts(m.localRows, "removed")).toEqual(["b"]);
+    expect(m.autoMerge).toBe("a\nc");
+  });
+
+  it("3-way: divergent edits are a conflict hunk (both panes, navigable)", () => {
+    const m = buildPaneModel(detail({ base: "x", local: "L", remote: "R" }));
+    expect(m.hasConflict).toBe(true);
+    expect(m.hunkCount).toBe(1);
+    expect(m.hunks).toEqual([{ localLines: ["L"], remoteLines: ["R"] }]);
+    expect(texts(m.localRows, "conflict")).toEqual(["L"]);
+    expect(texts(m.remoteRows, "conflict")).toEqual(["R"]);
+    // First conflict row is the nav anchor on both panes.
+    expect(m.localRows.find((r) => r.conflictStart)?.text).toBe("L");
+    expect(m.remoteRows.find((r) => r.conflictStart)?.text).toBe("R");
+    // Default seed = local; per-hunk flip to remote rebuilds the merge.
+    expect(m.autoMerge).toBe("L");
+    expect(m.rebuildMerge(["remote"])).toBe("R");
+    expect(m.rebuildMerge(["local"])).toBe("L");
+  });
+
+  it("add/delete: a side deleted locally → placeholder + whole remote green", () => {
+    const m = buildPaneModel(
+      detail({ base: "a", local: undefined, remote: "r1\nr2" }),
+    );
+    expect(m.hasConflict).toBe(true);
+    expect(m.hunkCount).toBe(1);
+    expect(m.localRows).toEqual([
+      { text: "(deleted on this side)", cls: "removed", conflictStart: true },
+    ]);
+    expect(texts(m.remoteRows, "added")).toEqual(["r1", "r2"]);
+    // Default keeps the surviving (remote) side; seed === rebuild([]).
+    expect(m.autoMerge).toBe("r1\nr2");
+    expect(m.rebuildMerge([])).toBe(m.autoMerge);
+    // Flipping to "local" accepts the deletion (empty result).
+    expect(m.rebuildMerge(["local"])).toBe("");
+  });
+
+  it("no base (GC'd): falls back to a 2-way Local↔Remote conflict", () => {
+    const m = buildPaneModel(
+      detail({ base: undefined, local: "a\nb", remote: "a\nc" }),
+    );
+    expect(m.hasConflict).toBe(true);
+    expect(m.hunkCount).toBe(1);
+    expect(m.hunks).toEqual([{ localLines: ["b"], remoteLines: ["c"] }]);
+    expect(m.autoMerge).toBe("a\nb");
+    expect(m.rebuildMerge(["remote"])).toBe("a\nc");
+  });
+
+  it("auto-merge seed: non-conflicting edits on both sides merge cleanly", () => {
+    const m = buildPaneModel(
+      detail({
+        base: "a\nb\nc\nd",
+        local: "a\nX\nc\nd", // changed b→X
+        remote: "a\nb\nc\nY", // changed d→Y
+      }),
+    );
+    expect(m.hasConflict).toBe(false);
+    expect(m.hunkCount).toBe(0);
+    expect(m.autoMergedCount).toBe(2);
+    expect(m.autoMerge).toBe("a\nX\nc\nY");
+  });
+
+  it("3-way: identical content yields all-context, no conflict, no change", () => {
+    const m = buildPaneModel(
+      detail({ base: "a\nb", local: "a\nb", remote: "a\nb" }),
+    );
+    expect(m.hasConflict).toBe(false);
+    expect(m.hunkCount).toBe(0);
+    expect(m.autoMergedCount).toBe(0);
+    expect(m.localRows.every((r) => r.cls === "context")).toBe(true);
+    expect(m.autoMerge).toBe("a\nb");
+  });
+
+  it("multiple conflict hunks are all collected for navigation", () => {
+    const m = buildPaneModel(
+      detail({
+        base: "a\nb\nc\nd\ne",
+        local: "a\nL1\nc\nL2\ne",
+        remote: "a\nR1\nc\nR2\ne",
+      }),
+    );
+    expect(m.hunkCount).toBe(2);
+    expect(m.hunks).toEqual([
+      { localLines: ["L1"], remoteLines: ["R1"] },
+      { localLines: ["L2"], remoteLines: ["R2"] },
+    ]);
+    // Two nav anchors per pane.
+    expect(m.localRows.filter((r) => r.conflictStart)).toHaveLength(2);
+    // Per-hunk: take remote for hunk 0, keep local for hunk 1.
+    expect(m.rebuildMerge(["remote", "local"])).toBe("a\nR1\nc\nL2\ne");
+  });
+
+  it("3-way: a convergent edit (both sides identical) is auto-merged, not a conflict", () => {
+    const m = buildPaneModel(
+      detail({ base: "a\nb\nc", local: "a\nX\nc", remote: "a\nX\nc" }),
+    );
+    expect(m.hasConflict).toBe(false);
+    expect(m.hunkCount).toBe(0);
+    expect(m.autoMergedCount).toBe(1);
+    expect(m.autoMerge).toBe("a\nX\nc");
+  });
+
+  it("defensive: both sides absent yields an empty, crash-free model", () => {
+    // Unreachable in production (the resolver filters out local===remote===absent),
+    // but buildPaneModel is exported — guard against a future direct caller.
+    const m = buildPaneModel(detail({ local: undefined, remote: undefined }));
+    expect(m.autoMerge).toBe("");
+    expect(m.localRows).toEqual([
+      { text: "(deleted on this side)", cls: "removed", conflictStart: true },
+    ]);
+    expect(m.remoteRows).toEqual([]);
+  });
+});


### PR DESCRIPTION
## What

Rewrites the ExoSync **«Resolve sync conflicts»** modal from a 2-pane (local | remote) view into an **IntelliJ-style 3-pane horizontal layout** — **Local (yours) | Merge (result, editable) | Remote (theirs)** — with line-level diff colouring (green=added, red=removed, amber=conflict), per-hunk accept actions, conflict navigation, and a responsive/a11y layout.

**Presentation-only.** The resolve path (`ResolveChoice` → `resolver.resolve`), the outbox/commit flow, and the zero-loss engine semantics are **untouched**. The modal's only outward effect is still `ctx.resolveOne(conflict, choice)` with `choice ∈ {take:"local"} | {take:"remote"} | {take:"merged", content}`.

## How

- **New pure helper `conflictDiff.ts`** — a full 3-way region walk (`collectRegions3`) + 2-way fallback (`collectRegions2`) when `base` is GC'd + whole-side add/delete handling. Reuses the engine's exact `lcsMatch` LCS pairing (copied verbatim — it is module-private in `diff3.ts`). `buildPaneModel()` returns local/remote diff rows, a **diff3-style auto-merge seed** (non-conflicting changes pre-applied à la IntelliJ; conflicts default to the local side), the conflict hunks, and a `rebuildMerge(choices)` closure for per-hunk accept. (`diff3` itself returns at the *first* conflict — insufficient for navigating every hunk + colouring every line.)
- **`QuarantineResolverModal.ts`** `renderDetail` → 3-pane CSS grid + nav bar (Prev/Next conflict + counter) + per-hunk `◀ use local` / `use remote ▶` buttons that splice a side into the editable merge textarea. List view, `applyChoice`, and a11y preserved. `ResolverModalContext` interface **unchanged** (0 caller-cascade) — it just consumes `detail.base` (already in the type).
- **`styles.css`** — `.exosync-resolver-3pane` grid + `.exosync-diff-*` classes via Obsidian theme-vars (light/dark auto, rgba fallbacks) + `@media (max-width: 720px)` stacks the panes vertically (**Desktop↔Mobile parity**).
- **a11y (RFC 0002 §3.11 / WCAG 1.4.1)** — aria-labels on all buttons incl. per-hunk + nav; panes `role=group`; diff meaning conveyed by prefix marker (`+`/`-`/`‼`) + screen-reader text, **not colour alone**.

## Tests

- **10 unit** (`conflictDiff.test.ts`): added / removed / divergent conflict / add-delete / no-base fallback / auto-merge seed / convergent / multi-hunk nav / both-undefined defensive — **revert-verified** (conflict detection break → 2 tests fail).
- **13 jsdom component** (`QuarantineResolverModal.test.ts`): 3 panes render, conflict colouring, merge seed, per-hunk rebuild, the 3 ResolveChoice actions, nav counter + active-hunk highlight, add/delete nav-disabled, a11y, load-failure.
- Full `tests/unit/sync` dir: **125/125 green**. typecheck clean. production build + `assert-mobile-loadable` ✅. archgate 22/22.

## Review

Two adversarial `code-reviewer` passes — **APPROVE, 0 CRITICAL / 0 HIGH** (round-1 fuzz-tested the diff maths 5000 cases + cross-checked auto-merge byte-for-byte vs the engine's `diff3`; round-2 verified the 2 MEDIUM + 3 LOW fixes incl. a revert-verify on the nav test).

Closes WBS `fee209b1` (vault-exodev M3).