### PR TITLE
perf(plugin): debounce redundant cold-start 2nd convertVault re-walk (preserve #3587)

### DIFF
--- a/packages/obsidian-plugin/src/ExocortexPlugin.ts
+++ b/packages/obsidian-plugin/src/ExocortexPlugin.ts
@@ -362,6 +362,18 @@ export default class ExocortexPlugin extends Plugin {
   // calling refresh(), avoiding a concurrent clear()/convertVault() race.
   private eagerInitPromise: Promise<void> | null = null;
 
+  // Cold-start double-walk debounce (al-index-debounce / WBS 7b0f4e56).
+  // Set true ONLY when the eager-init convertVault walk ran against a
+  // metadataCache that was ALREADY fully resolved at walk start
+  // (`metadataCache.initialized === true`). In that case the store is
+  // complete — the #2780/#3587 partial-store race cannot occur — so the
+  // post-resolve handler's full `clear()+convertVault()` re-walk (`refresh()`)
+  // would only re-produce identical triples and is skipped. Stays false on
+  // the common cold boot (eager walk ran while Obsidian was still parsing
+  // frontmatter), so the authoritative refresh runs as before and #3587
+  // correctness is preserved.
+  private eagerWalkRanAgainstResolvedCache = false;
+
   /**
    * Issue #3320 — ProfileApplyManager hoisted onto the plugin instance
    * so onload recovery / reconcile reuse the single manager без re-constructing
@@ -1206,6 +1218,22 @@ export default class ExocortexPlugin extends Plugin {
           void initPromise
             .then(() => {
               postResolveRefreshStartedAt = Date.now();
+              // Cold-start double-walk debounce (al-index-debounce / WBS
+              // 7b0f4e56). Skip the redundant full `clear()+convertVault()`
+              // re-walk when the eager walk already ran against a fully-
+              // resolved metadataCache: the store is then already complete
+              // (the #2780/#3587 partial-store race cannot have occurred) and
+              // `refresh()` would only re-produce identical triples — a
+              // second multi-second walk on a 12k+ file vault. The lighter
+              // post-refresh steps below (materialization re-inject, cache
+              // invalidation, palette, re-render) still run so dependent
+              // surfaces stay consistent. On the common cold boot the eager
+              // walk ran against a still-parsing cache, the flag is false,
+              // and the authoritative refresh runs exactly as before — #3587
+              // correctness preserved.
+              if (this.eagerWalkRanAgainstResolvedCache) {
+                return undefined;
+              }
               return this.sparql.refresh();
             })
             .then(() => this.refreshAndInjectAssetSpaceMaterialization())
@@ -1569,6 +1597,16 @@ export default class ExocortexPlugin extends Plugin {
                   "exocmd-fullpath-start",
                   "exocmd-fullpath-ready",
                 );
+
+                // Cold-start double-walk debounce (al-index-debounce). The
+                // eager walk just succeeded; record whether it ran against an
+                // already-resolved metadataCache. When true, the store is
+                // complete and the post-resolve `refresh()` (clear()+
+                // convertVault()) is redundant — see the resolved handler.
+                // When the walk ran against a still-parsing cache (the
+                // #2780/#3587 cold-boot partial-store path) this stays false
+                // and the authoritative refresh runs as before.
+                this.eagerWalkRanAgainstResolvedCache = cacheWasWarmAtWalkStart;
 
                 // Issue #3472 — emit «indexing complete» from the eager
                 // path ONLY when metadataCache had already finished its

--- a/packages/obsidian-plugin/tests/unit/ExocortexPlugin.test.ts
+++ b/packages/obsidian-plugin/tests/unit/ExocortexPlugin.test.ts
@@ -1942,6 +1942,70 @@ describe("ExocortexPlugin", () => {
 
       expect(refreshSpy).toHaveBeenCalledTimes(1);
     });
+
+    // Cold-start double-walk debounce (al-index-debounce / WBS 7b0f4e56).
+    // On a COLD boot the eager `convertVault()` walk runs while Obsidian is
+    // still parsing frontmatter, so it can leave files with 0 triples
+    // (#2780/#3587 partial-store). The post-resolve `refresh()` is the
+    // authoritative re-walk against the now-resolved cache and MUST run.
+    // The default mock `metadataCache` has no `initialized` flag, so the
+    // eager walk is treated as cold → refresh runs. This pins the #3587
+    // correctness contract: breaking the optimization to skip refresh
+    // unconditionally turns this RED (partial-store would silently return).
+    it("#3587: still runs the full post-resolve refresh on a COLD boot (eager walk ran against a still-parsing cache)", async () => {
+      // metadataCache.initialized is undefined (cold) → eager walk is NOT warm.
+      expect(
+        (mockMetadataCache as { initialized?: boolean }).initialized,
+      ).toBeUndefined();
+
+      await plugin.onload();
+      await flushPromises();
+
+      expect(querySpy).toHaveBeenCalledWith("ASK { ?s ?p ?o }");
+      expect(refreshSpy).not.toHaveBeenCalled();
+
+      resolvedHandler!();
+      await flushPromises();
+
+      // Authoritative re-walk runs → store rebuilt against resolved cache.
+      expect(refreshSpy).toHaveBeenCalledTimes(1);
+    });
+
+    // The optimization itself: on a WARM boot (metadataCache already resolved
+    // when the eager walk started) the eager convertVault saw every file, so
+    // the store is already complete. The post-resolve full re-walk is pure
+    // redundant work and is SKIPPED — while the cheap dependent-surface
+    // refresh (cache invalidation, palette, re-render) still runs. Breaking
+    // the debounce (never setting the flag / always refreshing) turns this RED.
+    it("debounce: SKIPS the redundant full re-walk on a WARM boot (eager walk already ran against a resolved cache), but still invalidates caches", async () => {
+      // Simulate a warm boot: metadataCache is already resolved at walk start.
+      (mockMetadataCache as { initialized?: boolean }).initialized = true;
+
+      await plugin.onload();
+      await flushPromises();
+
+      // Eager walk ran against the warm cache → store is complete.
+      expect(querySpy).toHaveBeenCalledWith("ASK { ?s ?p ?o }");
+
+      const commandResolverSpy = jest.spyOn(
+        plugin.commandResolver,
+        "invalidateCache",
+      );
+      const preconditionEvaluatorSpy = jest.spyOn(
+        plugin.preconditionEvaluator,
+        "invalidateCache",
+      );
+
+      resolvedHandler!();
+      await flushPromises();
+
+      // Redundant clear()+convertVault() re-walk is skipped.
+      expect(refreshSpy).not.toHaveBeenCalled();
+      // …but the lightweight post-refresh chain still runs so dependent
+      // surfaces (command/precondition caches, palette, layout) stay fresh.
+      expect(commandResolverSpy).toHaveBeenCalled();
+      expect(preconditionEvaluatorSpy).toHaveBeenCalled();
+    });
   });
 
   describe("Issue #2785: hot-mutation cache invalidation (post-click layout refresh)", () => {


### PR DESCRIPTION
## Problem

On a cold boot the plugin indexes the vault **twice**:
1. **Eager init** — `onLayoutReady` → `sparql.query("ASK")` lazily triggers `VaultRDFIndexer.initialize()` (`convertVault` + `addAll` + inference).
2. **Post-resolve** — `metadataCache.on("resolved")` → `sparql.refresh()` = **`clear()` + `convertVault()` + `addAll()` + inference** (a full second re-walk).

Both passes are visible in the log since the v16.132.0 progress logs. Pass 2 exists **on purpose**: pass 1 runs while Obsidian is still parsing frontmatter, so it can skip not-yet-parsed files (the **#2780 / #3587 partial-store race**). The `resolved` refresh re-walks against the now-fully-resolved cache and is the authoritative pass.

## Change (debounce, not removal)

The plugin already computes `cacheWasWarmAtWalkStart` (`metadataCache.initialized === true` at eager-walk start) to decide which callsite emits the "indexing complete" notice. We reuse that proven signal:

- When the eager walk **already ran against a fully-resolved cache** (`initialized === true` — the warm re-enable path), pass 1 produced a **complete** store. Pass 2's `clear()+convertVault()` would only re-produce **identical** triples (a second multi-second walk on a 12k+ file vault) → **skip it**. The cheap post-refresh steps (AssetSpace materialization re-inject, command/precondition cache invalidation, palette, re-render) still run.
- On the **common cold boot** the eager walk ran against a still-parsing cache → flag stays `false` → the authoritative `sparql.refresh()` runs **exactly as before**. **#3587 correctness preserved.**

`initialize()` and `refresh()` produce identical store content (same `convertVault` + `addAll` + `runInference`) — the only difference is cache warmth, which the flag captures. So when warm, skipping the second walk is provably lossless.

### Desktop↔Mobile parity
Single shared onload path — no `Platform` branch. On mobile the cold boot almost always has `initialized === false` during the eager walk (slow device, cache still parsing) → refresh runs → #3587 safe on mobile too. A warm mobile re-enable skips. Parity is inherent.

## Tests (revert-verified)

In `ExocortexPlugin.test.ts` (`Issue #2780` describe block):
- **#3587 guard** — `still runs the full post-resolve refresh on a COLD boot` (eager walk ran against a still-parsing cache → `refresh()` called once → store rebuilt).
- **Debounce** — `SKIPS the redundant full re-walk on a WARM boot` (eager walk ran against a resolved cache → `refresh()` NOT called, but command/precondition caches still invalidated).

Empirical revert-verify:
- Break to **always skip** (`if (true)`) → **4 cold tests RED** (3 existing #2780 + new COLD #3587).
- Break to **never skip** (`if (false)`) → **1 RED** (new WARM debounce).
- Correct logic → **5 pass**.

Full `ExocortexPlugin.test.ts` (98) + `VaultRDFIndexer` suites (49) green. typecheck + lint clean. archgate 22/22 (incl. `no-desktop-only-gated-addcommand`).

## Savings
On a warm boot the second full `convertVault()` walk of the entire vault is eliminated (one fewer multi-second walk on a 12k+ file vault, and the progress-log spam of the 2nd pass disappears). Cold boots are unchanged.

WBS: vault-exodev `7b0f4e56` (M3 — Alpha Validation).
