### PR TITLE
feat(docs): add exoas-exo-reqs public submodule (Living-Docs MVP-1, RFC 0004)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "packages/exoas-exocmd"]
 	path = packages/exoas-exocmd
 	url = https://github.com/kitelev/exoas-exocmd
+[submodule "packages/exoas-exo-reqs"]
+	path = packages/exoas-exo-reqs
+	url = https://github.com/kitelev/exoas-exo-reqs

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "workspaces": [
     "packages/*",
     "!packages/exoas-exo",
-    "!packages/exoas-exocmd"
+    "!packages/exoas-exocmd",
+    "!packages/exoas-exo-reqs"
   ],
   "engines": {
     "node": ">=18.0.0"


### PR DESCRIPTION
**Living Documentation MVP-1 — submodule wiring** (RFC 0004 §3.3, §6).

Adds `kitelev/exoas-exo-reqs` (functional requirements ABox) as a **PUBLIC HTTPS** submodule at `packages/exoas-exo-reqs`, pinned. Excluded from npm workspaces (no `package.json` — a data submodule, identical pattern to the existing `exoas-exo` / `exoas-exocmd` submodules).

### Why
The **only NEW** submodule wiring the Living-Documentation site needs (RFC 0004 §3.3). The docs generator (MVP-2) will render requirements from this single checkout.

### Privacy invariant (RFC 0004 §3.1 / §5)
HTTPS is the PAT-less-friendly transport for **public** repos — a credential-free `git submodule update` fetches it fine. The **credential-free fetch IS the privacy gate**: a *private* submodule would fail that fetch → build fails → fail-closed by absence. `ci.yml` already checks out `submodules: recursive` in 6 jobs, so this PR's CI green **directly proves** the new public submodule fetches cleanly repo-wide and the only-public-submodule invariant holds.

### Changes
- `.gitmodules`: `packages/exoas-exo-reqs` → `https://github.com/kitelev/exoas-exo-reqs`
- `package.json`: `!packages/exoas-exo-reqs` workspace exclude (data submodule, no `package.json`)
- pinned gitlink (mode 160000)

WBS: Living-Docs MVP-1 `a4a152dc`.
