### PR TITLE
test(reqs): RFC 0003 P2 increment 6 — bind 3 revert-verified exo functional requirements

### DIFF
--- a/packages/cli/tests/integration/issue-2997-loader-2pc.integration.test.ts
+++ b/packages/cli/tests/integration/issue-2997-loader-2pc.integration.test.ts
@@ -98,7 +98,7 @@ describe("Issue #2997 Phase 2 — Loader two-phase commit (all-or-nothing)", () 
   });
 
   it(
-    "loads the full mixed fixture vault: only valid files contribute triples, all 11 bad files reported as skipped",
+    "loads the full mixed fixture vault: only valid files contribute triples, all 11 bad files reported as skipped @req:fe50da38-4798-46e6-bb0a-b4b88596c340",
     async () => {
       const fixtureRoot = resolve(__dirname, "../fixtures/issue-2997");
       const adapter = new FileSystemVaultAdapter(fixtureRoot);

--- a/packages/cli/tests/integration/rfc-01a83de8-cq-gate.integration.test.ts
+++ b/packages/cli/tests/integration/rfc-01a83de8-cq-gate.integration.test.ts
@@ -305,7 +305,7 @@ describe("RFC 01a83de8 §5 CQ gate — STRICT-mode profile-imports closure (Issu
   });
 
   describe("label-form `_imports` (mandate violated — EV7)", () => {
-    it("STRICT mode THROWS instead of silently collapsing the closure", async () => {
+    it("STRICT mode THROWS instead of silently collapsing the closure @req:70e12858-9e9e-4e2d-84fe-e582bfa02513", async () => {
       process.env.EXOCORTEX_SPARQL_STRICT = "1";
       await expect(runQuery(fixture("label"), CQ2)).rejects.toThrow(
         /Literal in subject position/,

--- a/packages/cli/tests/integration/validate-schema-labelless-class.integration.test.ts
+++ b/packages/cli/tests/integration/validate-schema-labelless-class.integration.test.ts
@@ -182,7 +182,7 @@ afterAll(() => {
 });
 
 describe("Issue #3242 integration: label-less class chain", () => {
-  it("does not emit sh:class violation against exo__Asset on exo__Asset_relates path", () => {
+  it("does not emit sh:class violation against exo__Asset on exo__Asset_relates path @req:7a337cbd-75ab-436c-986b-d061ace9f4da", () => {
     const falsePositives = violations.filter(
       (v) =>
         v.propertyPath ===


### PR DESCRIPTION
## RFC 0003 (requirements-management) — P2 increment 6

Owner-orchestrator session for the requirements-management direction (`al-reqmgmt-orch`, Andrey present, chose **continue P2-ramp**). Reverse-documents (RFC 0003 §3.8 A14) 3 Alpha-critical `exo`-module **functional** behaviors as `req__Requirement` assets (in `exoas-exo-reqs`, already pushed) and binds each to an existing integration test via a `@req:<uid>` token in the test `it()` title. **Tag-only change — no production behavior change.**

### The 3 requirements (each integration-class, fully revert-verified)
| @req uid | behavior | binding test | revert (break → RED) |
| --- | --- | --- | --- |
| `fe50da38` | vault loader is all-or-nothing — a malformed asset → 0 triples + reported skipped (#2997) | `issue-2997-loader-2pc` | gate `NoteToRDFConverter.convertVaultWithValidation` violation-skip → 10/11 RED |
| `7a337cbd` | `validate schema` emits NO false sh:class for a label-less-class-typed value (#3242) | `validate-schema-labelless-class` | gate `ShaclLiteValidator` sh:class subclass-closure → 2/2 RED |
| `70e12858` | SPARQL STRICT throws on label-form profile `_imports` (recall-loss guard, EV7 #3427) | `rfc-01a83de8-cq-gate` | gate `BGPExecutor` strict literal-guard → STRICT-throw test RED |

### Verification
- **Revert-verified** each: break production → cited test RED → restore → GREEN (evidence in each asset body + commit `Revert-verified:` tokens).
- Checker `requirements audit`: **30 requirements / 30 bound / 100% coverage / 0 hard findings**.
- SHACL = 0 on vault-exodev (96132 triples conform).
- archgate REQ-001 (well-formed-req-tags) PASS.

### Notes
- A `cli-plugin-triple-parity` candidate was **dropped** — CLI↔plugin output parity is an *architectural invariant* (RFC §3.9 → ADR/archgate, not a `req__Requirement`).
- `requirements-trace` CI job stays **soft** (non-blocking) — P3 (hard-gate) is gated to Alpha GA by design.

Closes-part-of: req-mgmt P2 (RFC 0003) — vault project `89728805`.