### PR TITLE
feat(docs): publish Living-Docs to GitHub Pages, noindex'd (MVP-4, RFC 0004)

### DIFF
--- a/.github/workflows/living-docs.yml
+++ b/.github/workflows/living-docs.yml
@@ -1,19 +1,22 @@
-# Living Documentation (RFC 0004) — PAT-less build.
+# Living Documentation (RFC 0004) — PAT-less build + GitHub Pages deploy.
 #
-# Privacy is guaranteed BY CONSTRUCTION: this workflow injects NO PAT / no
-# broad-scope secret into git or the generator. `actions/checkout` runs with only
-# the default repo-scoped GITHUB_TOKEN, which cannot read other private repos — so
-# `git submodule update` can pull ONLY public submodules. A private submodule would
-# fail the credential-free fetch and break the build (fail-closed by absence, §5).
+# Privacy is guaranteed BY CONSTRUCTION: the BUILD job injects NO PAT / no
+# broad-scope secret. `actions/checkout` runs with only the default repo-scoped
+# GITHUB_TOKEN, which cannot read other private repos — so `git submodule update`
+# can pull ONLY public submodules. A private submodule would fail the
+# credential-free fetch and break the build (fail-closed by absence, §5).
 #
-# Scope (MVP-3): BUILD + TEST the generator and publish the built `_site` as a
-# downloadable CI ARTIFACT — there is still NO GitHub Pages deploy here. Enabling
-# Pages and the first publish are outward-facing + irreversible and require
-# explicit human confirmation (MVP-4, RFC 0004 §5).
+# The PAT-less air-gap is enforced as a REQUIRED gate by the archgate rule SEC-002
+# (.archgate/adrs/SEC-002-living-docs-air-gap.rules.ts) and proved by the docs-site
+# test `test/workflow-air-gap.test.mjs`.
 #
-# The PAT-less air-gap is additionally enforced as a REQUIRED gate by the archgate
-# rule SEC-002 (.archgate/adrs/SEC-002-living-docs-air-gap.rules.ts) and proved by
-# the docs-site test `test/workflow-air-gap.test.mjs`.
+# Scope (MVP-4): the site IS published to GitHub Pages, but ONLY on push-to-main
+# or a manual dispatch — never on a pull_request (PRs build + test only). The
+# deploy uses the repo-scoped GITHUB_TOKEN (`pages: write` / `id-token: write`)
+# to publish to THIS repo's own Pages — that is NOT a credential to any other
+# private repo, so the air-gap (no private-repo fetch) is preserved. Every page
+# carries `<meta name="robots" content="noindex, nofollow, noarchive">`: the site
+# is reachable by link but deliberately kept out of search-engine indexes.
 name: Living Docs
 
 on:
@@ -34,18 +37,24 @@ on:
       - "packages/exoas-exo"
       - ".github/workflows/living-docs.yml"
 
-# Read-only: this job never needs write access (no Pages deploy — MVP-3).
+# Default (build job): read-only, PAT-less. The deploy job narrowly elevates to
+# the repo-scoped Pages permissions — see its own `permissions:` block.
 permissions:
   contents: read
 
 concurrency:
-  group: living-docs-${{ github.ref }}
-  cancel-in-progress: true
+  # Serialize Pages deploys; do NOT cancel an in-flight deploy.
+  group: living-docs-pages
+  cancel-in-progress: false
 
 jobs:
   build:
-    name: build (PAT-less, no publish)
+    name: build (PAT-less)
     runs-on: ubuntu-latest
+    # Explicitly read-only: the build that produces the docs has no credential
+    # granting access to any private repo (the entire air-gap, RFC 0004 §5).
+    permissions:
+      contents: read
     steps:
       # No `token:` and no `ssh-key:` override → only the default repo-scoped
       # GITHUB_TOKEN is available. Public submodules fetch fine; a private one
@@ -68,7 +77,7 @@ jobs:
         working-directory: docs-site
         run: npm test
 
-      - name: Build the site (local only — no publish)
+      - name: Build the site
         run: node docs-site/build.mjs --out _site
 
       - name: Verify the site built
@@ -79,12 +88,28 @@ jobs:
           test -d _site/adrs
           echo "Living-Docs site built: $(find _site -type f | wc -l) files."
 
-      # Publish the built site as a downloadable CI artifact (NO deploy — the
-      # site is inspectable here, but is not served to the public until MVP-4
-      # enables GitHub Pages on explicit human confirmation).
-      - name: Upload _site as a CI artifact (no publish)
-        uses: actions/upload-artifact@v4
+      # Package _site as the GitHub Pages artifact (also downloadable for review).
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
         with:
-          name: living-docs-site
           path: _site
-          retention-days: 14
+
+  deploy:
+    name: deploy to GitHub Pages
+    needs: build
+    # ⛔ Deploy ONLY on push-to-main or a manual dispatch — never on a PR. PRs
+    # build + test only; they never publish.
+    if: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
+    runs-on: ubuntu-latest
+    # Repo-scoped Pages permissions — publish to THIS repo's Pages only. NOT a
+    # credential to any other (private) repo, so the air-gap is preserved.
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages (repo-scoped GITHUB_TOKEN, no PAT)
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/docs-site/lib/render.mjs
+++ b/docs-site/lib/render.mjs
@@ -70,6 +70,10 @@ export function layout({ title, content, relRoot = "" }) {
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
+<!-- Publicly reachable by link, but kept out of search engines: noindex (do not
+     index), nofollow (do not follow links for indexing), noarchive (no cached
+     copy). The content is public, but discoverability is deliberately not. -->
+<meta name="robots" content="noindex, nofollow, noarchive">
 <title>${escapeHtml(title)} · Exocortex Living Docs</title>
 <link rel="stylesheet" href="${relRoot}assets/style.css">
 </head>

--- a/docs-site/test/render.test.mjs
+++ b/docs-site/test/render.test.mjs
@@ -134,3 +134,26 @@ test("indexPage renders summary tables + links", () => {
   assert.match(html, /100%/); // coverage stat
   assert.match(html, /req one/);
 });
+
+test("every page carries a noindex robots meta (publicly reachable, not search-indexed)", () => {
+  const stats = { total: 0, covered: 0, coverage: 1, byStatus: {}, byPriority: {} };
+  const index = indexPage({ reqs: [], adrs: [], stats, ontology: { classes: [], properties: [] } });
+  const req = requirementPage({
+    uid: "u1",
+    label: "r",
+    status: "Draft",
+    priority: null,
+    bindingClasses: [],
+    covers: [],
+    verifiedBy: [],
+    implementedBy: [],
+    area: null,
+    author: null,
+    covered: false,
+    body: "x",
+  });
+  const adr = adrPage({ id: "ARCH-001", title: "T", domain: "data", rules: false, body: "x" });
+  for (const html of [index, req, adr]) {
+    assert.match(html, /<meta name="robots" content="noindex, nofollow, noarchive">/);
+  }
+});

--- a/docs-site/test/workflow-air-gap.test.mjs
+++ b/docs-site/test/workflow-air-gap.test.mjs
@@ -53,25 +53,31 @@ test(
 );
 
 test(
-  "living-docs.yml has no Pages deploy step (MVP-3 is build-only, no publish)",
+  "living-docs.yml deploy is gated to push/dispatch — a pull_request never publishes (MVP-4)",
   { skip: hasWorkflow ? false : "workflow not present" },
   () => {
     const yaml = readFileSync(WORKFLOW, "utf-8");
-    assert.doesNotMatch(
+    // The deploy job must be conditioned off pull_request events: PRs build +
+    // test only, they never publish.
+    assert.match(
       yaml,
-      /actions\/deploy-pages|deploy-pages@|actions\/upload-pages-artifact/,
-      "MVP-3 must not deploy to GitHub Pages — that is MVP-4 (explicit human confirm).",
+      /if:\s*\$\{\{\s*github\.event_name\s*==\s*'push'\s*\|\|\s*github\.event_name\s*==\s*'workflow_dispatch'\s*\}\}/,
+      "the deploy job must run only on push-to-main or workflow_dispatch, never on a PR",
     );
   },
 );
 
 test(
-  "living-docs.yml grants only read permissions (no write/pages — no deploy)",
+  "the build is read-only PAT-less; deploy uses repo-scoped deploy-pages (no cross-repo PAT) (MVP-4)",
   { skip: hasWorkflow ? false : "workflow not present" },
   () => {
     const yaml = readFileSync(WORKFLOW, "utf-8");
+    // The default + build permissions are read-only — the air-gap build cannot write.
     assert.match(yaml, /permissions:\s*\n\s*contents:\s*read/);
-    assert.doesNotMatch(yaml, /pages:\s*write/);
-    assert.doesNotMatch(yaml, /id-token:\s*write/);
+    // `pages: write` must NOT be the top-level default; it is granted only inside
+    // the deploy job (repo-scoped, for THIS repo's Pages — not a cross-repo PAT).
+    assert.doesNotMatch(yaml, /^permissions:\s*\n\s*pages:\s*write/m);
+    // Deploy uses the standard GitHub Pages action (repo-scoped GITHUB_TOKEN).
+    assert.match(yaml, /actions\/deploy-pages@/);
   },
 );


### PR DESCRIPTION
**Living Documentation MVP-4** (RFC 0004 §6) — the first outward-facing publish. **Andrey explicitly confirmed** (2026-06-21) after visually reviewing the built site + requesting search engines be kept out.

### Changes
1. **noindex** — every generated page now carries `<meta name="robots" content="noindex, nofollow, noarchive">`. The site is **reachable by link but kept OUT of search-engine indexes** (no indexing, no following, no cached copies). Canonical mechanism — stronger than `robots.txt Disallow` (which only blocks crawling; a Disallow'd URL can still be indexed). +1 test (all pages carry it).
2. **Deploy** — `living-docs.yml` gains a `deploy` job (`actions/deploy-pages@v4`) that runs **ONLY on push-to-main or `workflow_dispatch` — never on a PR** (PRs build + test only). 

### Air-gap preserved (RFC §5)
The **build** job stays **read-only + PAT-less** (`contents: read`, default `GITHUB_TOKEN`, no `token:`/`ssh-key:` override, only public submodules). The **deploy** job uses the repo-scoped `GITHUB_TOKEN` (`pages: write` / `id-token: write`) to publish to **THIS repo's own Pages** — that is **NOT** a credential to any other private repo, so the "no private-repo fetch" air-gap holds. The **SEC-002 archgate gate stays green** (no `secrets.*`, no token override added). The air-gap tests are updated: the MVP-3 "no deploy" invariant becomes the MVP-4 "deploy gated off PRs" + "build read-only, deploy via repo-scoped deploy-pages".

### Verification
- 34 `node:test` pass; `archgate check --ci` → 23 passed / 0 failed (SEC-002 intact); every one of 51 HTML pages carries the noindex meta.
- Andrey visually reviewed the rendered site (landing + requirements + ADRs) — content is public Exocortex product documentation, zero-leak.

**After merge:** GitHub Pages is enabled (source = GitHub Actions) and the push-to-main triggers build + deploy → the site goes live (noindex'd).

WBS: Living-Docs MVP-4 `90db0c98`.
