### PR TITLE
fix(ui): apply-confirm modal title — drop stray Cyrillic «к» (Apply profile:)

### DIFF
--- a/packages/obsidian-plugin/src/infrastructure/adapters/ModalConfirmGate.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/ModalConfirmGate.ts
@@ -62,7 +62,7 @@ class ApplyConfirmModal extends Modal {
     // — keeps the adapter testable without a custom Modal mock.
     contentEl.createEl("h2", {
       cls: "apply-confirm-title",
-      text: `Apply к profile: ${this.plan.targetProfileLabel}`,
+      text: `Apply profile: ${this.plan.targetProfileLabel}`,
     });
 
     // a11y (RFC 0002 §3.11 / P16): id this consequence line so the destructive

--- a/packages/obsidian-plugin/tests/unit/ModalConfirmGate.test.ts
+++ b/packages/obsidian-plugin/tests/unit/ModalConfirmGate.test.ts
@@ -141,6 +141,9 @@ describe("ModalConfirmGate", () => {
     const title = document.querySelector(".apply-confirm-title");
     expect(title).not.toBeNull();
     expect(title?.textContent).toContain("Work");
+    // Title prefix must be the clean English «Apply profile:» — guards against
+    // the stray Cyrillic «к» regression (live UX smoke 2026-06-21).
+    expect(title?.textContent).toContain("Apply profile:");
 
     findButton("Cancel")?.click();
     await promise;


### PR DESCRIPTION
## What

Fix the **apply-profile confirm modal** title: it rendered **«Apply к profile: <name>»** — a stray **Cyrillic «к»** (keyboard-layout slip) in `ModalConfirmGate.ts:65`. Now renders the clean **«Apply profile: <name>»**.

## Why

Found during a **live UX/UI smoke** of the full plugin (child `al-ux-onboarding`, 2026-06-21, computer-control in real Obsidian on a fresh temp-vault). The defect is user-visible in the **core apply-profile confirm dialog** — a destructive-action gate every tester hits. Minor (LOW) but unprofessional for alpha.

## Change

- `ModalConfirmGate.ts`: `Apply к profile:` → `Apply profile:` (1 char).
- `ModalConfirmGate.test.ts`: strengthened the existing title test to assert the `Apply profile:` prefix.

## Verification

- **Revert-verified** (integration-test-revert-verify discipline): the new assertion **FAILS** with the Cyrillic «к», **PASSES** without it.
- `ModalConfirmGate.test.ts` — 13/13 green locally.

## Scope

Pure copy fix + test strengthening. No behavior change. Part of the al-ux-onboarding full-plugin test pass (other findings reported separately to the orchestrator for triage).
