### PR TITLE
feat(sync): surface mounted-but-undeclared packs in ExoSync (FINDING-3 B1)

### DIFF
--- a/packages/obsidian-plugin/src/infrastructure/adapters/SyncCommands.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/SyncCommands.ts
@@ -289,6 +289,21 @@ export class SyncCommands {
 
     const collection = await this.deps.collectSpecs();
     for (const w of collection.warnings) log(`[ExoSync] ${w}`);
+    // FINDING-3 (al-ux-findings) — surface mounted-but-undeclared packs so the
+    // user is not silently surprised that edits in an ad-hoc «Add a knowledge
+    // pack» repo (added by URL outside the registry, hence no AssetSpace
+    // descriptor) never push. One notice per run; also logged for the record.
+    if (collection.mountedNotDeclared.length > 0) {
+      const n = collection.mountedNotDeclared.length;
+      log(
+        `[ExoSync] ${n} mounted pack(s) not synced (no AssetSpace descriptor): ` +
+          collection.mountedNotDeclared.join(", "),
+      );
+      this.deps.notify(
+        `${n} mounted pack(s) won't sync — they have no AssetSpace descriptor ` +
+          "(added by URL outside the registry). Their edits stay local.",
+      );
+    }
     if (collection.specs.length === 0) {
       this.deps.notify(
         "Nothing to sync — no materialized AssetSpaces with a GitHub source found",

--- a/packages/obsidian-plugin/src/infrastructure/adapters/SyncDepsFactory.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/SyncDepsFactory.ts
@@ -82,6 +82,15 @@ export interface SyncSpecCollection {
   asUidByRepoKey: Map<string, string>;
   /** Skipped AssetSpaces (unparseable / non-GitHub source). */
   warnings: string[];
+  /**
+   * FINDING-3 (al-ux-findings) — mount folders (`assetspaces/<owner>/<repo>`)
+   * that exist on disk but match NO AssetSpace descriptor in the sync unit.
+   * These are typically ad-hoc packs added via «Add a knowledge pack» by a URL
+   * outside the registry: they mount (files pulled) but carry no `exo__AssetSpace`
+   * descriptor, so ExoSync never pushes edits made in them. Surfaced as a notice
+   * so the user is not silently surprised that their edits don't sync.
+   */
+  mountedNotDeclared: string[];
 }
 
 /**
@@ -129,11 +138,48 @@ export async function collectSyncRepoSpecs(
     acc.commit(verdict.candidate);
   }
 
+  // FINDING-3 — detect mounted-but-undeclared packs: enumerate physical mount
+  // folders and subtract the declared+materialized set. A folder present on
+  // disk with no descriptor is an ad-hoc add (pulled by URL, never registered)
+  // → it won't sync. Best-effort: any adapter error yields an empty list so a
+  // listing failure never blocks the sync.
+  const declaredPaths = new Set(acc.specs.map((s) => s.localPath));
+  const mountFolders = await enumerateMountFolders(app);
+  const mountedNotDeclared = mountFolders.filter((p) => !declaredPaths.has(p));
+
   return {
     specs: acc.specs,
     asUidByRepoKey: acc.asUidByRepoKey,
     warnings: acc.warnings,
+    mountedNotDeclared,
   };
+}
+
+/**
+ * Enumerate physical AssetSpace mount folders — `assetspaces/<owner>/<repo>`,
+ * the canonical two-level layout `derivePath` produces. Pure filesystem walk
+ * over `vault.adapter` (desktop + mobile). Best-effort: a missing `assetspaces`
+ * dir or any list error yields `[]` (a detection helper must never throw into
+ * the sync path).
+ */
+async function enumerateMountFolders(app: App): Promise<string[]> {
+  const root = "assetspaces";
+  const out: string[] = [];
+  try {
+    if (!(await app.vault.adapter.exists(root))) return out;
+    const owners = (await app.vault.adapter.list(root)).folders;
+    for (const owner of owners) {
+      try {
+        const repos = (await app.vault.adapter.list(owner)).folders;
+        out.push(...repos);
+      } catch {
+        // one owner dir unreadable → skip it, keep the rest
+      }
+    }
+  } catch {
+    // assetspaces missing / unreadable → no mounts to report
+  }
+  return out;
 }
 
 /** Default `Sha1Fn` over WebCrypto (renderer-safe on desktop AND iOS). */

--- a/packages/obsidian-plugin/tests/unit/sync/QuarantineResolverCommands.test.ts
+++ b/packages/obsidian-plugin/tests/unit/sync/QuarantineResolverCommands.test.ts
@@ -109,6 +109,7 @@ function makeHarness(opts: HarnessOpts = {}) {
     specs: opts.specs ?? [spec("a/b")],
     asUidByRepoKey: new Map(),
     warnings: [],
+    mountedNotDeclared: [],
   };
   const commands = new QuarantineResolverCommands({
     collectSpecs: async () => collection,

--- a/packages/obsidian-plugin/tests/unit/sync/SyncCommands.test.ts
+++ b/packages/obsidian-plugin/tests/unit/sync/SyncCommands.test.ts
@@ -84,6 +84,8 @@ interface HarnessOptions {
    * `onProgress` callback (3rd syncAll arg) during a run, to assert routing.
    */
   progressEvents?: SyncProgressEvent[];
+  /** FINDING-3 — mounted-but-undeclared pack folders surfaced by the run. */
+  mountedNotDeclared?: string[];
 }
 
 function makeHarness(opts: HarnessOptions = {}) {
@@ -110,6 +112,7 @@ function makeHarness(opts: HarnessOptions = {}) {
     specs: opts.specs ?? [spec("o/r")],
     asUidByRepoKey: new Map(),
     warnings: [],
+    mountedNotDeclared: opts.mountedNotDeclared ?? [],
   };
   const built: BuiltSyncEngine = {
     engine: { syncAll } as unknown as SyncEngine,
@@ -192,6 +195,44 @@ describe("SyncCommands", () => {
 
     expect(notices.some((n) => n.includes("Nothing to sync"))).toBe(true);
     expect(syncAll).not.toHaveBeenCalled();
+  });
+
+  // FINDING-3 (al-ux-findings) — surface mounted-but-undeclared packs.
+  it("warns about mounted packs that have no AssetSpace descriptor (FINDING-3)", async () => {
+    const { commands, notices } = makeHarness({
+      mountedNotDeclared: ["assetspaces/kitelev/exoas-temp"],
+    });
+
+    await commands.invokeSync();
+
+    const warn = notices.find((n) => n.includes("won't sync"));
+    expect(warn).toBeDefined();
+    expect(warn).toContain("1 mounted pack(s)");
+    expect(warn).toContain("no AssetSpace descriptor");
+  });
+
+  it("surfaces the mounted-not-declared warning even when nothing is syncable (FINDING-3)", async () => {
+    const { commands, notices } = makeHarness({
+      specs: [],
+      mountedNotDeclared: [
+        "assetspaces/kitelev/exoas-temp",
+        "assetspaces/kitelev/exoas-other",
+      ],
+    });
+
+    await commands.invokeSync();
+
+    expect(notices.some((n) => n.includes("2 mounted pack(s)"))).toBe(true);
+    // The nothing-to-sync notice still fires too.
+    expect(notices.some((n) => n.includes("Nothing to sync"))).toBe(true);
+  });
+
+  it("does NOT warn when every mounted pack is declared (FINDING-3)", async () => {
+    const { commands, notices } = makeHarness({ mountedNotDeclared: [] });
+
+    await commands.invokeSync();
+
+    expect(notices.some((n) => n.includes("won't sync"))).toBe(false);
   });
 
   it("aggregates counts across repos in the success notice", async () => {
@@ -499,6 +540,7 @@ describe("SyncCommands — #3489 explicit success signal (info console + Notice)
         specs: [spec("o/r")],
         asUidByRepoKey: new Map(),
         warnings: [],
+        mountedNotDeclared: [],
       }),
       buildEngine: async () => ({
         engine: { syncAll: async (specs: SyncRepoSpec[]) => specs.map((s) => result(s.repoKey, "synced")) } as unknown as import("exocortex").SyncEngine,
@@ -722,6 +764,7 @@ describe("SyncCommands — #3495 quarantine-sink degraded-mode warn", () => {
         specs: [spec("o/r")],
         asUidByRepoKey: new Map(),
         warnings: [],
+        mountedNotDeclared: [],
       }),
       buildEngine: async () => ({
         engine: {
@@ -983,6 +1026,7 @@ describe("SyncCommands — #3499 opt-in per-step Notice toggle", () => {
         specs: [spec("o/r")],
         asUidByRepoKey: new Map(),
         warnings: [],
+        mountedNotDeclared: [],
       }),
       buildEngine: async () => ({
         engine: {

--- a/packages/obsidian-plugin/tests/unit/sync/SyncDepsFactory.test.ts
+++ b/packages/obsidian-plugin/tests/unit/sync/SyncDepsFactory.test.ts
@@ -50,6 +50,29 @@ describe("collectSyncRepoSpecs", () => {
     expect(result.specs).toEqual([spec()]);
     expect(result.asUidByRepoKey.get(`o/r#${SYNC_BRANCH}`)).toBe("uid-1");
     expect(result.warnings).toEqual([]);
+    // A declared+mounted folder is NOT flagged as undeclared.
+    expect(result.mountedNotDeclared).toEqual([]);
+  });
+
+  // FINDING-3 (al-ux-findings) — a mount folder on disk with no AssetSpace
+  // descriptor (ad-hoc «Add a knowledge pack» by URL) is reported as
+  // mounted-but-undeclared so ExoSync can warn the user it won't sync.
+  it("flags a mounted folder that has no AssetSpace descriptor (FINDING-3)", async () => {
+    const adapter = new InMemoryAdapter();
+    adapter.mkdirAll("assetspaces/o/r"); // declared (descriptor as1.md below)
+    adapter.mkdirAll("assetspaces/o/adhoc"); // mounted, NO descriptor
+    const app = makeApp({
+      adapter,
+      mdFiles: [{ path: "as1.md" }],
+      frontmatters: new Map([
+        ["as1.md", assetSpaceFm("uid-1", "https://github.com/o/r")],
+      ]),
+    });
+
+    const result = await collectSyncRepoSpecs(app as unknown as App);
+
+    expect(result.specs).toEqual([spec()]);
+    expect(result.mountedNotDeclared).toEqual(["assetspaces/o/adhoc"]);
   });
 
   it("excludes AssetSpaces whose mount folder is absent (VL#4)", async () => {

--- a/packages/obsidian-plugin/tests/unit/sync/registerExoSyncCommands.test.ts
+++ b/packages/obsidian-plugin/tests/unit/sync/registerExoSyncCommands.test.ts
@@ -31,6 +31,7 @@ function makeCommands(): SyncCommands {
       specs: [],
       asUidByRepoKey: new Map(),
       warnings: [],
+      mountedNotDeclared: [],
     }),
     buildEngine: async () => {
       throw new Error("unreachable in registration tests");


### PR DESCRIPTION
## What (FINDING-3 B1)

UX-triage from the `al-ux-onboarding` live-Obsidian run (Andrey-validated): an ad-hoc **"Add a knowledge pack"** by a URL *outside the registry* mounts the repo (files pulled) but writes **no `exo__AssetSpace` descriptor**. ExoSync's sync unit (`collectSyncRepoSpecs`) only includes descriptor-bearing AssetSpaces, so such a pack is **mounted but never pushed** — edits in it silently stay local (observed: "Sync done: 5/5" while 6 were mounted).

This **surfaces the gap** (FINDING-3 decision **B**, the "surface" half):
- `collectSyncRepoSpecs` now enumerates physical mount folders (`assetspaces/<owner>/<repo>`) and returns `mountedNotDeclared` = folders with no matching descriptor.
- The Sync command emits **one notice per run**: "N mounted pack(s) won't sync — they have no AssetSpace descriptor (added by URL outside the registry). Their edits stay local."

**Detection-only, best-effort** — `enumerateMountFolders` never throws into the sync path (any adapter error → empty list); **no ExoSync engine change** (`services/sync/` untouched). The folder walk is in the plugin-side collector + command adapter only.

## Out of scope (follow-up)
- **B2 — "register for sync" affordance** (auto-create a descriptor for an ad-hoc repo): deferred to its own design/issue — descriptor placement + namespace for an arbitrary private repo (co-location invariant, EKA registry model) needs a deliberate decision. Issue to follow.

## Tests
- `SyncDepsFactory.test.ts` — collector flags a mounted folder with no descriptor (+ declared+mounted folder is NOT flagged).
- `SyncCommands.test.ts` — notice fires (1 pack; 2 packs even with 0 syncable specs; no notice when all declared).
- **Revert-verified**: the 3 positive tests FAIL with the detection/notice neutralised, PASS with the fix. typecheck + eslint clean; all 9 sync suites green (129 tests).

al-ux-findings UX triage. No Docker.
