### PR TITLE
fix(plugin): Create Subclass co-locates + UID-names new exo__Class (DEFECT-D1)

### DIFF
--- a/packages/exocortex/src/services/ClassCreationService.ts
+++ b/packages/exocortex/src/services/ClassCreationService.ts
@@ -3,12 +3,15 @@ import { v4 as uuidv4 } from "uuid";
 import { DateFormatter } from "../utilities/DateFormatter";
 import { MetadataHelpers } from "../utilities/MetadataHelpers";
 import type { IVaultAdapter, IFile } from "../interfaces/IVaultAdapter";
+import { FolderRepairService } from "./FolderRepairService";
 import { DI_TOKENS } from "../interfaces/tokens";
 
 @injectable()
 export class ClassCreationService {
   constructor(
     @inject(DI_TOKENS.IVaultAdapter) private vault: IVaultAdapter,
+    @inject(DI_TOKENS.FolderRepairService)
+    private folderRepair: FolderRepairService,
   ) {}
 
   async createSubclass(
@@ -17,8 +20,6 @@ export class ClassCreationService {
     parentMetadata: Record<string, unknown>,
   ): Promise<IFile> {
     const uid = uuidv4();
-    const fileName = this.generateFileName(label);
-    const fullFileName = fileName.endsWith(".md") ? fileName : `${fileName}.md`;
 
     const frontmatter = this.generateClassFrontmatter(
       parentFile.basename,
@@ -29,12 +30,35 @@ export class ClassCreationService {
 
     const fileContent = MetadataHelpers.buildFileContent(frontmatter);
 
-    const folderPath = "classes";
-    const filePath = `${folderPath}/${fullFileName}`;
+    // UUID-CANON TBOX (CLAUDE.md): TBox classes MUST be UID-named, never
+    // label-named — so the symbolic-IRI subject scheme resolves and SHACL can
+    // verify class membership. Mirrors Create Instance, which UID-names too.
+    const fullFileName = `${uid}.md`;
 
-    const folder = this.vault.getAbstractFileByPath(folderPath);
-    if (!folder) {
-      await this.vault.createFolder(folderPath);
+    // CO-LOCATION INVARIANT (CLAUDE.md, RFC 0b7a2fad): place the new class in
+    // the folder of its `exo__Asset_isDefinedBy` ontology, using the same
+    // resolver as Create Instance (`$isDefinedByFolder`) / `apply
+    // repair-folder` (FolderRepairService → IVaultAdapter.getFirstLinkpathDest).
+    // The new class inherits the parent's isDefinedBy, so resolution targets
+    // the parent's ontology folder. Falls back to the parent class's own
+    // folder when the ontology ref can't be resolved (empty / `!`-anchor /
+    // unresolvable isDefinedBy) — a degraded-but-co-located location matching
+    // GroundingExecutor's host-folder fallback; the parent class is itself
+    // co-located, so the subclass stays in-ontology either way.
+    const resolvedFolder = this.folderRepair.getExpectedFolderSync(
+      parentFile,
+      frontmatter,
+    );
+    const folderPath =
+      resolvedFolder ?? ClassCreationService.parentFolderOf(parentFile.path);
+
+    const filePath = folderPath ? `${folderPath}/${fullFileName}` : fullFileName;
+
+    if (folderPath) {
+      const folder = this.vault.getAbstractFileByPath(folderPath);
+      if (!folder) {
+        await this.vault.createFolder(folderPath);
+      }
     }
 
     const createdFile = await this.vault.create(filePath, fileContent);
@@ -42,18 +66,12 @@ export class ClassCreationService {
     return createdFile;
   }
 
-  private generateFileName(label: string): string {
-    let result = label.toLowerCase().replace(/[^a-z0-9]+/g, "-");
-    // Remove leading dashes using a loop to avoid ReDoS
-    // The pattern /^-+|-+$/g with alternation can cause backtracking
-    while (result.startsWith("-")) {
-      result = result.slice(1);
-    }
-    // Remove trailing dashes
-    while (result.endsWith("-")) {
-      result = result.slice(0, -1);
-    }
-    return result;
+  /** Vault-relative parent folder of a file path ("" when at the vault root). */
+  private static parentFolderOf(filePath: string | undefined): string {
+    if (!filePath) return "";
+    const normalized = filePath.replace(/^\/+/, "");
+    const slashIdx = normalized.lastIndexOf("/");
+    return slashIdx >= 0 ? normalized.slice(0, slashIdx) : "";
   }
 
   private generateClassFrontmatter(

--- a/packages/exocortex/tests/unit/services/ClassCreationService.test.ts
+++ b/packages/exocortex/tests/unit/services/ClassCreationService.test.ts
@@ -1,119 +1,244 @@
 import "reflect-metadata";
-import { describe, it, expect, beforeEach, jest } from "@jest/globals";
+import { describe, it, expect, jest } from "@jest/globals";
 import { ClassCreationService } from "../../../src/services/ClassCreationService";
-import type { IVaultAdapter, IFile } from "../../../src/interfaces/IVaultAdapter";
+import { FolderRepairService } from "../../../src/services/FolderRepairService";
+import type {
+  IVaultAdapter,
+  IFile,
+  IFolder,
+} from "../../../src/interfaces/IVaultAdapter";
+
+/**
+ * Production-shape fake IVaultAdapter that mirrors the real Obsidian /
+ * vault-adapter contract used by the co-location resolver
+ * (FolderRepairService → getFirstLinkpathDest), per test-fixture-realism:
+ *
+ *  - `getFirstLinkpathDest(linkpath, source)` resolves a UID/basename linkpath
+ *    to its ontology file ONLY when registered, returning `null` for unknown
+ *    linkpaths — exactly as real Obsidian does (it does NOT invent a file).
+ *  - the resolved ontology file exposes a `.parent.path` folder, which is what
+ *    co-location reads back.
+ *
+ * This lets the revert-verify tests exercise the real placement logic rather
+ * than a stub-returning-any.
+ */
+function makeVault(ontologyFolders: Record<string, string>) {
+  const created: { path: string; content: string }[] = [];
+  const createdFolders: string[] = [];
+  const existingFolders = new Set<string>();
+
+  const vault = {
+    create: jest.fn(async (path: string, content: string): Promise<IFile> => {
+      created.push({ path, content });
+      const slash = path.lastIndexOf("/");
+      const folderPath = slash >= 0 ? path.slice(0, slash) : "";
+      const name = slash >= 0 ? path.slice(slash + 1) : path;
+      return {
+        path,
+        basename: name.replace(/\.md$/, ""),
+        name,
+        parent: { path: folderPath },
+      } as unknown as IFile;
+    }),
+    createFolder: jest.fn(async (path: string): Promise<void> => {
+      createdFolders.push(path);
+      existingFolders.add(path);
+    }),
+    getAbstractFileByPath: jest.fn((path: string) =>
+      existingFolders.has(path)
+        ? ({ path, name: path, children: [] } as unknown as IFolder)
+        : null,
+    ),
+    // Real Obsidian semantics: resolve a linkpath to its file, null when the
+    // linkpath is unknown.
+    getFirstLinkpathDest: jest.fn(
+      (linkpath: string, _source: string): IFile | null => {
+        const folder = ontologyFolders[linkpath];
+        if (folder === undefined) return null;
+        const name = `${linkpath}.md`;
+        return {
+          path: folder ? `${folder}/${name}` : name,
+          basename: linkpath,
+          name,
+          parent: { path: folder },
+        } as unknown as IFile;
+      },
+    ),
+  } as unknown as IVaultAdapter;
+
+  return { vault, created, createdFolders };
+}
+
+function makeService(ontologyFolders: Record<string, string> = {}) {
+  const { vault, created, createdFolders } = makeVault(ontologyFolders);
+  const folderRepair = new FolderRepairService(vault);
+  const service = new ClassCreationService(vault, folderRepair);
+  return { service, vault, created, createdFolders };
+}
+
+const UID_RE =
+  /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/;
 
 describe("ClassCreationService", () => {
-  let service: ClassCreationService;
-  let mockVault: jest.Mocked<IVaultAdapter>;
+  describe("createSubclass — co-location + UID-canon (DEFECT-D1)", () => {
+    const ONT_UID = "ca97bb2f-0000-4000-8000-000000000001";
+    const ONT_FOLDER = "assetspaces/kitelev/exoas-exo/exo";
 
-  beforeEach(() => {
-    mockVault = {
-      create: jest.fn<(path: string, content: string) => Promise<IFile>>(),
-      createFolder: jest.fn<(path: string) => Promise<void>>(),
-      getAbstractFileByPath: jest.fn(),
-    } as unknown as jest.Mocked<IVaultAdapter>;
+    it("co-locates the new class in its isDefinedBy ontology folder (NOT vault-root classes/)", async () => {
+      const { service, created } = makeService({ [ONT_UID]: ONT_FOLDER });
+      const parentFile = {
+        basename: "ae56ca4c-0000-4000-8000-000000000002",
+        path: `${ONT_FOLDER}/ae56ca4c-0000-4000-8000-000000000002.md`,
+      } as IFile;
 
-    mockVault.create.mockResolvedValue({ path: "classes/my-class.md", basename: "my-class" } as IFile);
+      await service.createSubclass(parentFile, "NightUxccTestSubclass", {
+        exo__Asset_isDefinedBy: `"[[${ONT_UID}]]"`,
+      });
 
-    service = new (ClassCreationService as any)(mockVault);
+      const filePath = created[0].path;
+      expect(filePath.startsWith(`${ONT_FOLDER}/`)).toBe(true);
+      // Revert-verify anchor: with the bug (hardcoded "classes/" + label name)
+      // this file would be "classes/nightuxcctestsubclass.md".
+      expect(filePath).not.toContain("classes/");
+      expect(filePath.toLowerCase()).not.toContain("nightuxcctestsubclass");
+    });
+
+    it("UID-names the new class file (NOT label-named lowercase)", async () => {
+      const { service, created } = makeService({ [ONT_UID]: ONT_FOLDER });
+      const parentFile = {
+        basename: "Parent",
+        path: `${ONT_FOLDER}/Parent.md`,
+      } as IFile;
+
+      await service.createSubclass(parentFile, "My Test Class!", {
+        exo__Asset_isDefinedBy: `"[[${ONT_UID}]]"`,
+      });
+
+      const filePath = created[0].path;
+      // <uuid>.md — matches the file's own exo__Asset_uid, not the label.
+      expect(filePath).toMatch(
+        new RegExp(`^${ONT_FOLDER}/${UID_RE.source}\\.md$`),
+      );
+      const content = created[0].content;
+      const uidInFile = content.match(/exo__Asset_uid:\s*(\S+)/)?.[1];
+      expect(filePath).toBe(`${ONT_FOLDER}/${uidInFile}.md`);
+    });
+
+    it("creates the resolved ontology folder when it does not yet exist", async () => {
+      const { service, createdFolders } = makeService({
+        [ONT_UID]: ONT_FOLDER,
+      });
+      const parentFile = {
+        basename: "Parent",
+        path: `${ONT_FOLDER}/Parent.md`,
+      } as IFile;
+
+      await service.createSubclass(parentFile, "Child", {
+        exo__Asset_isDefinedBy: `"[[${ONT_UID}]]"`,
+      });
+
+      expect(createdFolders).toContain(ONT_FOLDER);
+    });
+
+    it("falls back to the parent class folder when isDefinedBy is unresolvable (still UID-named, never vault-root classes/)", async () => {
+      // No ontologies registered → getFirstLinkpathDest returns null →
+      // FolderRepairService.getExpectedFolderSync returns null → fall back to
+      // the parent class's own (co-located) folder, mirroring GroundingExecutor.
+      const { service, created } = makeService({});
+      const parentFile = {
+        basename: "Parent",
+        path: "assetspaces/kitelev/exoas-public/ems/Parent.md",
+      } as IFile;
+
+      await service.createSubclass(parentFile, "Child", {
+        exo__Asset_isDefinedBy: '"[[Ontology/EXO]]"',
+      });
+
+      const filePath = created[0].path;
+      expect(filePath).toMatch(
+        new RegExp(
+          `^assetspaces/kitelev/exoas-public/ems/${UID_RE.source}\\.md$`,
+        ),
+      );
+      expect(filePath).not.toContain("classes/");
+    });
+
+    it("places the class at the vault root when its ontology lives at the root", async () => {
+      const { service, created } = makeService({ "root-onto": "" });
+      const parentFile = { basename: "Parent", path: "Parent.md" } as IFile;
+
+      await service.createSubclass(parentFile, "Child", {
+        exo__Asset_isDefinedBy: '"[[root-onto]]"',
+      });
+
+      const filePath = created[0].path;
+      expect(filePath).toMatch(new RegExp(`^${UID_RE.source}\\.md$`));
+      expect(filePath).not.toContain("/");
+    });
   });
 
-  describe("createSubclass", () => {
-    it("should create file in classes folder", async () => {
-      const parentFile = { basename: "exo__Class", path: "classes/exo__Class.md" } as IFile;
+  describe("createSubclass — frontmatter (unchanged by D1 fix)", () => {
+    const ONT_UID = "ca97bb2f-0000-4000-8000-000000000001";
+    const ONT_FOLDER = "assetspaces/kitelev/exoas-exo/exo";
 
-      await service.createSubclass(parentFile, "My New Class", {});
+    function frontmatterFixture() {
+      const { service, created } = makeService({ [ONT_UID]: ONT_FOLDER });
+      const parentFile = {
+        basename: "ParentClass",
+        path: `${ONT_FOLDER}/ParentClass.md`,
+      } as IFile;
+      return { service, created, parentFile };
+    }
 
-      expect(mockVault.create).toHaveBeenCalledWith(
-        expect.stringContaining("classes/"),
-        expect.any(String),
-      );
-    });
-
-    it("should create classes folder if not exists", async () => {
-      mockVault.getAbstractFileByPath.mockReturnValue(null);
-      const parentFile = { basename: "exo__Class" } as IFile;
-
-      await service.createSubclass(parentFile, "Test", {});
-
-      expect(mockVault.createFolder).toHaveBeenCalledWith("classes");
-    });
-
-    it("should not create folder if already exists", async () => {
-      mockVault.getAbstractFileByPath.mockReturnValue({ path: "classes", name: "classes" });
-      const parentFile = { basename: "exo__Class" } as IFile;
-
-      await service.createSubclass(parentFile, "Test", {});
-
-      expect(mockVault.createFolder).not.toHaveBeenCalled();
-    });
-
-    it("should generate frontmatter with exo__Instance_class", async () => {
-      const parentFile = { basename: "exo__Class" } as IFile;
-
-      await service.createSubclass(parentFile, "My Class", {});
-
-      const content = mockVault.create.mock.calls[0][1];
+    it("declares exo__Instance_class as exo__Class", async () => {
+      const { service, created, parentFile } = frontmatterFixture();
+      await service.createSubclass(parentFile, "My Class", {
+        exo__Asset_isDefinedBy: `"[[${ONT_UID}]]"`,
+      });
+      const content = created[0].content;
       expect(content).toContain("exo__Instance_class");
       expect(content).toContain("exo__Class");
     });
 
-    it("should include parent class as superClass", async () => {
-      const parentFile = { basename: "ParentClass" } as IFile;
-
-      await service.createSubclass(parentFile, "Child", {});
-
-      const content = mockVault.create.mock.calls[0][1];
+    it("includes the parent class as exo__Class_superClass", async () => {
+      const { service, created, parentFile } = frontmatterFixture();
+      await service.createSubclass(parentFile, "Child", {
+        exo__Asset_isDefinedBy: `"[[${ONT_UID}]]"`,
+      });
+      const content = created[0].content;
       expect(content).toContain("exo__Class_superClass");
       expect(content).toContain("[[ParentClass]]");
     });
 
-    it("should use isDefinedBy from parent metadata", async () => {
-      const parentFile = { basename: "Parent" } as IFile;
-      const metadata = { exo__Asset_isDefinedBy: '"[[MyOntology]]"' };
-
-      await service.createSubclass(parentFile, "Child", metadata);
-
-      const content = mockVault.create.mock.calls[0][1];
-      expect(content).toContain("[[MyOntology]]");
+    it("propagates isDefinedBy from the parent metadata", async () => {
+      const { service, created, parentFile } = frontmatterFixture();
+      await service.createSubclass(parentFile, "Child", {
+        exo__Asset_isDefinedBy: `"[[${ONT_UID}]]"`,
+      });
+      const content = created[0].content;
+      expect(content).toContain(`[[${ONT_UID}]]`);
     });
 
-    it("should use default isDefinedBy when parent has none", async () => {
-      const parentFile = { basename: "Parent" } as IFile;
-
+    it("uses a default isDefinedBy when the parent has none", async () => {
+      const { service, created } = makeService({});
+      const parentFile = {
+        basename: "Parent",
+        path: "classes/Parent.md",
+      } as IFile;
       await service.createSubclass(parentFile, "Child", {});
-
-      const content = mockVault.create.mock.calls[0][1];
+      const content = created[0].content;
       expect(content).toContain("exo__Asset_isDefinedBy");
     });
 
-    it("should generate clean filenames from labels", async () => {
-      const parentFile = { basename: "Parent" } as IFile;
-
-      await service.createSubclass(parentFile, "My Test Class!", {});
-
-      const filePath = mockVault.create.mock.calls[0][0];
-      expect(filePath).toMatch(/classes\/[a-z0-9-]+\.md$/);
-    });
-
-    it("should add .md extension if not present", async () => {
-      const parentFile = { basename: "Parent" } as IFile;
-
-      await service.createSubclass(parentFile, "Test", {});
-
-      const filePath = mockVault.create.mock.calls[0][0];
-      expect(filePath).toMatch(/\.md$/);
-    });
-
-    it("should include aliases in frontmatter", async () => {
-      const parentFile = { basename: "Parent" } as IFile;
-
-      await service.createSubclass(parentFile, "My Label", {});
-
-      const content = mockVault.create.mock.calls[0][1];
+    it("includes the label in aliases and as the asset label", async () => {
+      const { service, created, parentFile } = frontmatterFixture();
+      await service.createSubclass(parentFile, "My Label", {
+        exo__Asset_isDefinedBy: `"[[${ONT_UID}]]"`,
+      });
+      const content = created[0].content;
       expect(content).toContain("aliases");
       expect(content).toContain("My Label");
+      expect(content).toMatch(UID_RE); // exo__Asset_uid present
     });
   });
 });

--- a/packages/obsidian-plugin/src/infrastructure/services/ServiceRegistryPopulator.ts
+++ b/packages/obsidian-plugin/src/infrastructure/services/ServiceRegistryPopulator.ts
@@ -223,7 +223,10 @@ export function populateServiceRegistry(
     const renameToUidService = new RenameToUidService(vaultAdapter);
     const folderRepairService = new FolderRepairService(vaultAdapter);
     const conceptCreationService = new ConceptCreationService(vaultAdapter);
-    const classCreationService = new ClassCreationService(vaultAdapter);
+    const classCreationService = new ClassCreationService(
+      vaultAdapter,
+      folderRepairService,
+    );
     // Obsidian-aware resolver for shared @kitelev/exocortex-services factories
     // (RFC 94e520da Phase 1, T1.3). Produces byte-identical IFile resolution
     // to the legacy `resolveIFile` helper below — see ObsidianTargetResolver.

--- a/packages/obsidian-plugin/tests/unit/ClassCreationService.test.ts
+++ b/packages/obsidian-plugin/tests/unit/ClassCreationService.test.ts
@@ -1,213 +1,210 @@
-import { ClassCreationService } from "exocortex";
-import { IVaultAdapter, IFile } from "exocortex";
+import {
+  ClassCreationService,
+  FolderRepairService,
+  IVaultAdapter,
+  IFile,
+  IFolder,
+} from "exocortex";
+
+/**
+ * Production-shape fake IVaultAdapter mirroring the real Obsidian contract the
+ * co-location resolver (FolderRepairService → getFirstLinkpathDest) depends on
+ * — `getFirstLinkpathDest` resolves a registered ontology linkpath to a file
+ * with a `.parent.path`, and returns `null` for unknown linkpaths (as real
+ * Obsidian does). Per test-fixture-realism: not a stub-returning-any.
+ */
+function makeVault(ontologyFolders: Record<string, string>) {
+  const created: { path: string; content: string }[] = [];
+  const createdFolders: string[] = [];
+  const existingFolders = new Set<string>();
+
+  const vault = {
+    create: jest.fn(async (path: string, content: string): Promise<IFile> => {
+      created.push({ path, content });
+      const slash = path.lastIndexOf("/");
+      const folderPath = slash >= 0 ? path.slice(0, slash) : "";
+      const name = slash >= 0 ? path.slice(slash + 1) : path;
+      return {
+        path,
+        basename: name.replace(/\.md$/, ""),
+        extension: "md",
+        name,
+        parent: { path: folderPath },
+      } as unknown as IFile;
+    }),
+    createFolder: jest.fn(async (path: string): Promise<void> => {
+      createdFolders.push(path);
+      existingFolders.add(path);
+    }),
+    getAbstractFileByPath: jest.fn((path: string) =>
+      existingFolders.has(path)
+        ? ({ path, name: path, children: [] } as unknown as IFolder)
+        : null,
+    ),
+    getFirstLinkpathDest: jest.fn(
+      (linkpath: string, _source: string): IFile | null => {
+        const folder = ontologyFolders[linkpath];
+        if (folder === undefined) return null;
+        const name = `${linkpath}.md`;
+        return {
+          path: folder ? `${folder}/${name}` : name,
+          basename: linkpath,
+          extension: "md",
+          name,
+          parent: { path: folder },
+        } as unknown as IFile;
+      },
+    ),
+    modify: jest.fn(),
+    read: jest.fn(),
+    delete: jest.fn(),
+    rename: jest.fn(),
+    exists: jest.fn(),
+    getFiles: jest.fn(),
+  } as unknown as IVaultAdapter;
+
+  return { vault, created, createdFolders };
+}
+
+function makeService(ontologyFolders: Record<string, string> = {}) {
+  const { vault, created, createdFolders } = makeVault(ontologyFolders);
+  const folderRepair = new FolderRepairService(vault);
+  const service = new ClassCreationService(vault, folderRepair);
+  return { service, vault, created, createdFolders };
+}
+
+const UID_RE =
+  /[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/;
+
+const ONT_UID = "ca97bb2f-0000-4000-8000-000000000001";
+const ONT_FOLDER = "assetspaces/kitelev/exoas-exo/exo";
 
 describe("ClassCreationService", () => {
-  let service: ClassCreationService;
-  let mockVault: jest.Mocked<IVaultAdapter>;
-  let mockParentFile: IFile;
+  describe("createSubclass — co-location + UID-canon (DEFECT-D1)", () => {
+    it("co-locates in the isDefinedBy ontology folder and UID-names the file", async () => {
+      const { service, created } = makeService({ [ONT_UID]: ONT_FOLDER });
+      const parentFile = {
+        basename: "ParentClass",
+        path: `${ONT_FOLDER}/ParentClass.md`,
+        extension: "md",
+        name: "ParentClass.md",
+        parent: { path: ONT_FOLDER },
+      } as IFile;
 
-  beforeEach(() => {
-    mockVault = {
-      getAbstractFileByPath: jest.fn(),
-      createFolder: jest.fn(),
-      create: jest.fn(),
-      modify: jest.fn(),
-      read: jest.fn(),
-      delete: jest.fn(),
-      rename: jest.fn(),
-      exists: jest.fn(),
-      getFiles: jest.fn(),
-    } as any;
+      const result = await service.createSubclass(parentFile, "Test Subclass", {
+        exo__Asset_isDefinedBy: `"[[${ONT_UID}]]"`,
+      });
 
-    mockParentFile = {
-      path: "classes/ParentClass.md",
-      basename: "ParentClass",
-      extension: "md",
-      name: "ParentClass.md",
-      parent: null,
-    } as IFile;
+      const filePath = created[0].path;
+      // co-located in the ontology folder, NOT vault-root classes/
+      expect(filePath).toMatch(
+        new RegExp(`^${ONT_FOLDER}/${UID_RE.source}\\.md$`),
+      );
+      expect(filePath).not.toContain("classes/");
+      // not label-named
+      expect(filePath.toLowerCase()).not.toContain("test-subclass");
+      expect(result.path).toBe(filePath);
+    });
 
-    service = new ClassCreationService(mockVault);
+    it("falls back to the parent class folder when isDefinedBy is unresolvable (UID-named, never vault-root classes/)", async () => {
+      const { service, created } = makeService({}); // nothing resolves
+      const parentFile = {
+        basename: "ParentClass",
+        path: "classes/ParentClass.md",
+        extension: "md",
+        name: "ParentClass.md",
+        parent: null,
+      } as IFile;
+
+      await service.createSubclass(parentFile, "Subclass", {
+        exo__Asset_isDefinedBy: '"[[Ontology/EXO]]"',
+      });
+
+      const filePath = created[0].path;
+      // parent lives in "classes/" → fallback keeps it there, but UID-named now
+      expect(filePath).toMatch(new RegExp(`^classes/${UID_RE.source}\\.md$`));
+      expect(filePath.toLowerCase()).not.toContain("subclass.md");
+    });
+
+    it("creates the resolved ontology folder when it does not exist", async () => {
+      const { service, createdFolders } = makeService({
+        [ONT_UID]: ONT_FOLDER,
+      });
+      const parentFile = {
+        basename: "ParentClass",
+        path: `${ONT_FOLDER}/ParentClass.md`,
+        parent: { path: ONT_FOLDER },
+      } as IFile;
+
+      await service.createSubclass(parentFile, "Subclass", {
+        exo__Asset_isDefinedBy: `"[[${ONT_UID}]]"`,
+      });
+
+      expect(createdFolders).toContain(ONT_FOLDER);
+    });
   });
 
-  describe("createSubclass", () => {
-    it("should create subclass with correct frontmatter", async () => {
-      const parentMetadata = {
-        exo__Asset_isDefinedBy: '"[[Ontology/EXO]]"',
-      };
-
-      mockVault.getAbstractFileByPath.mockReturnValue(null);
-      mockVault.create.mockResolvedValue({
-        path: "classes/test-subclass.md",
-        basename: "test-subclass",
+  describe("createSubclass — frontmatter", () => {
+    function fixture(ontologyFolders: Record<string, string> = {}) {
+      const ctx = makeService(ontologyFolders);
+      const parentFile = {
+        basename: "ParentClass",
+        path: "classes/ParentClass.md",
         extension: "md",
-        name: "test-subclass.md",
+        name: "ParentClass.md",
         parent: null,
-      } as IFile);
+      } as IFile;
+      return { ...ctx, parentFile };
+    }
 
-      const result = await service.createSubclass(
-        mockParentFile,
-        "Test Subclass",
-        parentMetadata,
-      );
-
-      expect(mockVault.createFolder).toHaveBeenCalledWith("classes");
-      expect(mockVault.create).toHaveBeenCalled();
-
-      const createArgs = mockVault.create.mock.calls[0];
-      const filePath = createArgs[0];
-      const content = createArgs[1];
-
-      expect(filePath).toBe("classes/test-subclass.md");
+    it("writes correct frontmatter", async () => {
+      const { service, created, parentFile } = fixture();
+      await service.createSubclass(parentFile, "Test Subclass", {
+        exo__Asset_isDefinedBy: '"[[Ontology/EXO]]"',
+      });
+      const content = created[0].content;
       expect(content).toContain("exo__Asset_label: Test Subclass");
       expect(content).toContain('exo__Instance_class:\n  - "[[exo__Class]]"');
       expect(content).toContain('exo__Class_superClass: "[[ParentClass]]"');
       expect(content).toContain('exo__Asset_isDefinedBy: "[[Ontology/EXO]]"');
       expect(content).toContain("aliases:\n  - Test Subclass");
-      expect(result.path).toBe("classes/test-subclass.md");
     });
 
-    it("should not create folder if it already exists", async () => {
-      const parentMetadata = {};
-
-      mockVault.getAbstractFileByPath.mockReturnValue({ type: "folder" } as any);
-      mockVault.create.mockResolvedValue({
-        path: "classes/subclass.md",
-        basename: "subclass",
-        extension: "md",
-        name: "subclass.md",
-        parent: null,
-      } as IFile);
-
-      await service.createSubclass(mockParentFile, "Subclass", parentMetadata);
-
-      expect(mockVault.createFolder).not.toHaveBeenCalled();
-    });
-
-    it("should generate correct filename from label", async () => {
-      const parentMetadata = {};
-
-      mockVault.getAbstractFileByPath.mockReturnValue({ type: "folder" } as any);
-      mockVault.create.mockResolvedValue({
-        path: "classes/complex-subclass-name.md",
-        basename: "complex-subclass-name",
-        extension: "md",
-        name: "complex-subclass-name.md",
-        parent: null,
-      } as IFile);
-
-      await service.createSubclass(
-        mockParentFile,
-        "Complex Subclass Name!",
-        parentMetadata,
-      );
-
-      const createArgs = mockVault.create.mock.calls[0];
-      const filePath = createArgs[0];
-
-      expect(filePath).toBe("classes/complex-subclass-name.md");
-    });
-
-    it("should inherit isDefinedBy from parent", async () => {
-      const parentMetadata = {
+    it("inherits isDefinedBy from parent", async () => {
+      const { service, created, parentFile } = fixture();
+      await service.createSubclass(parentFile, "Child", {
         exo__Asset_isDefinedBy: '"[[Custom/Ontology]]"',
-      };
-
-      mockVault.getAbstractFileByPath.mockReturnValue({ type: "folder" } as any);
-      mockVault.create.mockResolvedValue({
-        path: "classes/child.md",
-        basename: "child",
-        extension: "md",
-        name: "child.md",
-        parent: null,
-      } as IFile);
-
-      await service.createSubclass(mockParentFile, "Child", parentMetadata);
-
-      const createArgs = mockVault.create.mock.calls[0];
-      const content = createArgs[1];
-
-      expect(content).toContain('exo__Asset_isDefinedBy: "[[Custom/Ontology]]"');
+      });
+      expect(created[0].content).toContain(
+        'exo__Asset_isDefinedBy: "[[Custom/Ontology]]"',
+      );
     });
 
-    it("should use default isDefinedBy if not in parent", async () => {
-      const parentMetadata = {};
-
-      mockVault.getAbstractFileByPath.mockReturnValue({ type: "folder" } as any);
-      mockVault.create.mockResolvedValue({
-        path: "classes/child.md",
-        basename: "child",
-        extension: "md",
-        name: "child.md",
-        parent: null,
-      } as IFile);
-
-      await service.createSubclass(mockParentFile, "Child", parentMetadata);
-
-      const createArgs = mockVault.create.mock.calls[0];
-      const content = createArgs[1];
-
-      expect(content).toContain('exo__Asset_isDefinedBy: "[[Ontology/EXO]]"');
+    it("uses default isDefinedBy when parent has none", async () => {
+      const { service, created, parentFile } = fixture();
+      await service.createSubclass(parentFile, "Child", {});
+      expect(created[0].content).toContain(
+        'exo__Asset_isDefinedBy: "[[Ontology/EXO]]"',
+      );
     });
 
-    it("should add .md extension if not present", async () => {
-      const parentMetadata = {};
-
-      mockVault.getAbstractFileByPath.mockReturnValue({ type: "folder" } as any);
-      mockVault.create.mockResolvedValue({
-        path: "classes/test.md",
-        basename: "test",
-        extension: "md",
-        name: "test.md",
-        parent: null,
-      } as IFile);
-
-      await service.createSubclass(mockParentFile, "Test", parentMetadata);
-
-      const createArgs = mockVault.create.mock.calls[0];
-      const filePath = createArgs[0];
-
-      expect(filePath).toBe("classes/test.md");
+    it("includes createdAt timestamp", async () => {
+      const { service, created, parentFile } = fixture();
+      await service.createSubclass(parentFile, "Child", {});
+      expect(created[0].content).toMatch(
+        /exo__Asset_createdAt: \d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/,
+      );
     });
 
-    it("should include createdAt timestamp", async () => {
-      const parentMetadata = {};
-
-      mockVault.getAbstractFileByPath.mockReturnValue({ type: "folder" } as any);
-      mockVault.create.mockResolvedValue({
-        path: "classes/child.md",
-        basename: "child",
-        extension: "md",
-        name: "child.md",
-        parent: null,
-      } as IFile);
-
-      await service.createSubclass(mockParentFile, "Child", parentMetadata);
-
-      const createArgs = mockVault.create.mock.calls[0];
-      const content = createArgs[1];
-
-      expect(content).toMatch(/exo__Asset_createdAt: \d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/);
-    });
-
-    it("should generate valid UUID for uid", async () => {
-      const parentMetadata = {};
-
-      mockVault.getAbstractFileByPath.mockReturnValue({ type: "folder" } as any);
-      mockVault.create.mockResolvedValue({
-        path: "classes/child.md",
-        basename: "child",
-        extension: "md",
-        name: "child.md",
-        parent: null,
-      } as IFile);
-
-      await service.createSubclass(mockParentFile, "Child", parentMetadata);
-
-      const createArgs = mockVault.create.mock.calls[0];
-      const content = createArgs[1];
-
-      expect(content).toMatch(/exo__Asset_uid: [0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/);
+    it("generates a valid UUID for uid (matching the filename)", async () => {
+      const { service, created, parentFile } = fixture();
+      await service.createSubclass(parentFile, "Child", {});
+      const content = created[0].content;
+      expect(content).toMatch(
+        new RegExp(`exo__Asset_uid: ${UID_RE.source}`),
+      );
+      const uidInFile = content.match(/exo__Asset_uid:\s*(\S+)/)?.[1];
+      expect(created[0].path).toContain(`${uidInFile}.md`);
     });
   });
 });

--- a/packages/obsidian-plugin/tests/unit/infrastructure/services/ServiceRegistryPopulator.test.ts
+++ b/packages/obsidian-plugin/tests/unit/infrastructure/services/ServiceRegistryPopulator.test.ts
@@ -58,6 +58,9 @@ function createMockDeps(withVaultAdapter = false): ServiceRegistryDeps {
   if (withVaultAdapter) {
     deps.vaultAdapter = {
       getAbstractFileByPath: jest.fn().mockReturnValue(mockIFile),
+      // Co-location resolver (FolderRepairService) probes this; null → the
+      // ontology ref doesn't resolve → callers fall back to the host folder.
+      getFirstLinkpathDest: jest.fn().mockReturnValue(null),
       getFrontmatter: jest.fn().mockReturnValue({
         exo__Asset_uid: "test-uid-123",
         exo__Asset_label: "Test Asset",
@@ -845,14 +848,20 @@ describe("ServiceRegistryPopulator (with vaultAdapter)", () => {
   });
 
   describe("createSubclass", () => {
-    it("should create child class with exo__Class_superClass pointing to parent", async () => {
+    it("should create a UID-named child class with exo__Class_superClass pointing to parent", async () => {
       const service = registry.get("createSubclass")!;
       await service.execute("test-uid-123", { label: "ChildClass" });
 
-      expect(deps.vaultAdapter!.create).toHaveBeenCalledWith(
-        expect.stringContaining("classes/childclass.md"),
-        expect.stringContaining("exo__Class_superClass: \"[[test-uid-123]]\""),
+      const [path, content] = (
+        deps.vaultAdapter!.create as jest.Mock
+      ).mock.calls[0] as [string, string];
+      expect(content).toContain('exo__Class_superClass: "[[test-uid-123]]"');
+      // UID-canon (DEFECT-D1): UID-named, NOT vault-root label-named
+      // "classes/childclass.md".
+      expect(path).toMatch(
+        /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\.md$/,
       );
+      expect(path.toLowerCase()).not.toContain("childclass");
     });
 
     it("should write exo__Instance_class as exo__Class", async () => {


### PR DESCRIPTION
## DEFECT-D1 — Create Class/Subclass violated co-location + UID-canon

The Obsidian-plugin **Create Class / Create Subclass** command created the new `exo__Class` in **vault-root `classes/<label>.md`** (label-named, lowercase), violating two project invariants in CLAUDE.md:

1. **CO-LOCATION INVARIANT** — a new asset must land in the folder of its `exo__Asset_isDefinedBy` ontology (same resolver as Create Instance / `apply repair-folder`).
2. **UUID-CANON TBOX** — TBox classes MUST be UID-named (`<uid>.md`), not label-named.

The reference path **Create Instance** already co-locates + UID-names (disk-verified in a live-Obsidian computer-control test, al-night-uxcc, v16.144.0); **Create Subclass** diverged — its frontmatter was already correct, only the **placement (folder) + filename** were wrong.

## Root cause
`ClassCreationService.createSubclass` hardcoded `folderPath = "classes"` and named the file from `label.toLowerCase()`, never consulting the co-location resolver that Create Instance uses (`GroundingExecutor.resolveIsDefinedByFolder` → `getFirstLinkpathDest`).

## Fix
`packages/exocortex/src/services/ClassCreationService.ts`:
- Injects the canonical core resolver **`FolderRepairService`** (already DI-registered; `getExpectedFolderSync` → `IVaultAdapter.getFirstLinkpathDest`) instead of hardcoding `"classes"`.
- Resolves the co-location folder from the new class's inherited `isDefinedBy`; **falls back to the parent class's own folder** when the ontology ref can't be resolved — mirroring `GroundingExecutor`'s host-folder fallback (the parent class is itself co-located, so the subclass stays in-ontology). Handles root-level ontologies (`""` → vault root, no leading-slash escape).
- **UID-names** the file (`<uid>.md`); removed the now-dead label-filename generator.
- `ServiceRegistryPopulator.ts` passes the already-constructed `folderRepairService` into `new ClassCreationService(...)`.

## Verification
- **Production-shape revert-verify** (Executable Specification): fakes mirror real Obsidian `getFirstLinkpathDest` semantics (resolves registered ontologies, returns `null` for unknown — not stub-returning-any). Body-only revert of the fix → **5 co-location/UID tests FAIL**; with the fix → **10/10 PASS** (frontmatter tests placement-independent, unaffected).
- core ClassCreationService 10/10, plugin ClassCreationService 8/8, ServiceRegistryPopulator 81/81, FolderRepairService 23/23 (unchanged resolver).
- typecheck clean; `npm run lint` exit 0; production plugin bundle builds (mobile-loadable); archgate 23/23 (incl. MOBILE-004 desktop↔mobile parity).
- **code-reviewer** agent (adversarial): APPROVE — 0 CRITICAL / 0 HIGH / 0 MEDIUM (3 LOW: a pre-existing `"/"`-root edge in the shared `FolderRepairService`, not introduced here).

Closes the Create Class/Subclass half of the homoiconic create-path co-location/UID-canon parity (Create Instance already conformant).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
