### PR TITLE
feat(cli): recognize component binding-class below the P0 real-prod floor (SDD-hardening A)

### DIFF
--- a/packages/cli/src/commands/requirements-audit.ts
+++ b/packages/cli/src/commands/requirements-audit.ts
@@ -22,8 +22,9 @@ import { VaultNotFoundError } from "../utils/errors/index.js";
  *  - **duplicate bindings** — one uid claimed by more than one distinct test
  *    occurrence (warning: copy-paste contamination signal);
  *  - **binding-class floor violations** — a `P0` requirement bound *solely* to
- *    a `unit` binding-class, violating RFC 0003 §3.6 (hard finding: P0 must hit
- *    at least one integration/e2e/gui-bdd binding);
+ *    below-floor binding-classes (`unit` and/or `component` — jsdom, not
+ *    real-prod), violating RFC 0003 §3.6 (hard finding: P0 must hit at least one
+ *    integration/e2e/gui-bdd/ui-acceptance binding);
  *  - **coverage** — % of requirements with ≥1 binding.
  *
  * The report is emitted as text (human) or json (CI comment + Pages generator).
@@ -53,9 +54,16 @@ const TEST_GLOB_IGNORE = ["**/node_modules/**", "**/dist/**", "**/.git/**"];
  * Maps a `req__RequirementBindingClass<Token>` capture (the local-name suffix of
  * the enum wikilink) to the canonical binding-class token. Falls back to the
  * lower-cased capture for any future class not enumerated here.
+ *
+ * `component` (`.test.tsx` / jsdom) is a distinct tier from `unit`: it is parsed
+ * to its own token here (the `?? token` fallback already produced `"component"`;
+ * this explicit entry completes + documents the canonical set) and is classified
+ * BELOW the real-prod floor — see REAL_PROD_CLASSES (component is intentionally
+ * absent there, like `unit`).
  */
 const BINDING_CLASS_MAP: Record<string, string> = {
   unit: "unit",
+  component: "component",
   integration: "integration",
   e2e: "e2e",
   guibdd: "gui-bdd",
@@ -74,6 +82,12 @@ const UI_ACCEPTANCE = "ui-acceptance";
  * A binding class that exercises production beyond a pure unit test. `ui-acceptance`
  * is included: a manual live-UI acceptance check exercises real production more
  * than a unit test, so it satisfies the P0 binding-class floor.
+ *
+ * ⛔ `unit` and `component` are intentionally ABSENT — both are below-real-prod
+ * (a `component` test runs a UI component under jsdom, NOT against live Obsidian /
+ * a real desktop UI), so neither satisfies the P0 floor alone. Do NOT add
+ * `component` here: a jsdom binding must not be able to satisfy the real-prod
+ * floor (req__RequirementBindingClassComponent, RFC 0003 §3.6).
  */
 const REAL_PROD_CLASSES = new Set([
   "integration",
@@ -532,7 +546,7 @@ function renderText(report: TraceabilityReport, gate: GateMode = "soft"): void {
 
   if (report.floorViolations.length > 0) {
     console.error(
-      `\nBinding-class floor violations (${report.floorViolations.length}) — P0 bound solely to unit:`,
+      `\nBinding-class floor violations (${report.floorViolations.length}) — P0 bound solely to below-floor classes (unit/component):`,
     );
     for (const f of report.floorViolations) {
       console.error(`  ${f.uid}  [${f.bindingClasses.join(", ")}]  ${f.label}`);

--- a/packages/cli/tests/unit/commands/requirements-audit.test.ts
+++ b/packages/cli/tests/unit/commands/requirements-audit.test.ts
@@ -97,6 +97,17 @@ describe("parseBindingClasses", () => {
       ),
     ).toEqual(["ui-acceptance"]);
   });
+  it("maps the component enum local-name to a distinct `component` token (not collapsed into unit)", () => {
+    // SDD-hardening A: component (.test.tsx / jsdom) is its own tier, parsed to
+    // "component" — NOT "unit". Pins the contract against the real exoas-req enum
+    // asset's local-name (req__RequirementBindingClassComponent, aefdb1a3).
+    expect(
+      parseBindingClasses(
+        "[[aefdb1a3-ae87-4d4e-93fb-fb989a243c0c|req__RequirementBindingClassComponent]]",
+      ),
+    ).toEqual(["component"]);
+  });
+
   it("ignores free-text (non-enum) bindingClass entries", () => {
     expect(
       parseBindingClasses([
@@ -240,6 +251,44 @@ describe("auditTraceability — binding-class floor (P0, hard)", () => {
     const r = auditTraceability(reqs, [tag(UID_B)]);
     expect(r.floorViolations).toHaveLength(0);
     expect(r.clean).toBe(true);
+  });
+
+  // SDD-hardening A (al-night-component): `component` (.test.tsx / jsdom) is a
+  // distinct binding-class classified BELOW the real-prod floor — like `unit`,
+  // a jsdom component test does not exercise live production. This is the
+  // binding for req 547ef066. Revert-verified: temporarily adding "component"
+  // to REAL_PROD_CLASSES makes assertions (2)/(3) FAIL (no floor violation);
+  // restored → PASS (RFC 0003 §3.6).
+  it("@req:547ef066-9155-4ec2-9893-fdc31c4674ea recognizes component as a distinct binding class and treats it as below the P0 real-prod floor", () => {
+    // (1) component is parsed to a distinct token — NOT collapsed into "unit"
+    expect(
+      parseBindingClasses(
+        "[[aefdb1a3-ae87-4d4e-93fb-fb989a243c0c|req__RequirementBindingClassComponent]]",
+      ),
+    ).toEqual(["component"]);
+
+    // (2) a P0 requirement bound SOLELY to component → floor violation
+    const solely = auditTraceability(
+      [req({ uid: UID_D, priority: "P0", bindingClasses: ["component"] })],
+      [tag(UID_D)],
+    );
+    expect(solely.floorViolations.map((f) => f.uid)).toEqual([UID_D]);
+    expect(solely.clean).toBe(false);
+
+    // (3) component + unit (both below-floor) → STILL a floor violation
+    const bothBelow = auditTraceability(
+      [req({ uid: UID_D, priority: "P0", bindingClasses: ["component", "unit"] })],
+      [tag(UID_D)],
+    );
+    expect(bothBelow.floorViolations).toHaveLength(1);
+
+    // (4) component + a real-prod class (integration) → floor satisfied
+    const withRealProd = auditTraceability(
+      [req({ uid: UID_D, priority: "P0", bindingClasses: ["component", "integration"] })],
+      [tag(UID_D)],
+    );
+    expect(withRealProd.floorViolations).toHaveLength(0);
+    expect(withRealProd.clean).toBe(true);
   });
 
   it("does not apply the floor to P1+ requirements", () => {


### PR DESCRIPTION
## SDD-hardening A — `component` binding-class tier

Adds a distinct `component` (`.test.tsx` / jsdom) requirement→test binding-class to the SDD traceability checker, classified **below** the P0 real-prod floor (like `unit` — jsdom is not real-prod-exercising). Previously component tests collapsed into `unit`. RFC 0003 §3.6.

Driven through the `/feature-sdd` loop (req-first → self-approve → impl → revert-verify → CI → active). Night autonomous run (`al-night-component`), self-approve under delegated grant.

### Changes
- `packages/cli/src/commands/requirements-audit.ts`:
  - `BINDING_CLASS_MAP` gains an explicit `component: component` entry (completes + documents the canonical enum set; the generic `?? token` fallback already parsed it — so this is documentation/explicitness).
  - `component` stays **absent** from `REAL_PROD_CLASSES`, now documented as intentional (a jsdom binding must not satisfy the real-prod floor). A P0 requirement bound solely to component/unit trips the binding-class floor.
  - Two human-readable strings updated for accuracy (JSDoc bullet + floor-violation render message).
- `packages/cli/tests/unit/commands/requirements-audit.test.ts`: two unit tests — `parseBindingClasses` → distinct `component` token; and the `@req`-tagged below-floor classification test.

### Companion vault assets (already pushed)
- TBox enum member `req__RequirementBindingClassComponent` (`aefdb1a3-ae87-4d4e-93fb-fb989a243c0c`) in `exoas-req` — the load-bearing deliverable (without it a `bindingClass: component` wikilink dangles / SHACL range violation; un-authorable). SHACL-validated 0 violations.
- Requirement `547ef066-9155-4ec2-9893-fdc31c4674ea` (status **approved**) in `exoas-exo-reqs` — flipped to **active** after merge.

### verify-before-assert finding
The checker already parsed `component` (generic fallback) and already classified it below-floor (whitelist complement). So the load-bearing behavioral guarantee being pinned is the **below-floor classification** + the **TBox enum declaration** — not the redundant map-add. The revert-verify therefore targets the genuine guarantee.

### Verification
- typecheck (root `tsc --noEmit`): 0 errors.
- `packages/cli` unit suite: 411/411 pass (incl. 2 new).
- **Revert-verified**: temporarily adding `"component"` to `REAL_PROD_CLASSES` → `@req:547ef066…` test goes **RED** (no floor violation on solely-component); removed → **GREEN**. Independently re-confirmed by the code-reviewer agent.
- code-reviewer agent: **APPROVE**, 0 CRITICAL/HIGH/MEDIUM/LOW.
- archgate REQ-001 (well-formed `@req` tags): pass.

Req: 547ef066-9155-4ec2-9893-fdc31c4674ea
