### PR TITLE
feat(docs): Living-Docs review queue + surface 2 active reqs (M4, RFC 0004)

### DIFF
--- a/docs-site/lib/render.mjs
+++ b/docs-site/lib/render.mjs
@@ -67,6 +67,48 @@ export function coverageBadge(covered, n) {
     : `<span class="badge badge-warn" title="no verification binding yet">○ uncovered</span>`;
 }
 
+/**
+ * Render the "Awaiting review" queue — the requirements that need human approval
+ * (status `Proposed`, plus the legacy `Draft` alias). This is the morning-approve
+ * surface of the SDD feature-lifecycle (RFC 0003): a focused, deep-linkable list
+ * separated from the full reference table so a reviewer sees exactly what awaits
+ * their sign-off and can open each to read its Gherkin and approve. Already-
+ * `Active`/`Approved`/`Deprecated` requirements are intentionally excluded.
+ * Renders a positive "nothing awaiting" note when the queue is empty.
+ *
+ * @param {Array<{uid:string,label:string,status:string|null,priority:string|null,covered:boolean,verifiedBy?:string[]}>} reqs
+ */
+export function awaitingReviewSection(reqs) {
+  const awaiting = (reqs ?? []).filter(
+    (r) => r.status === "Proposed" || r.status === "Draft",
+  );
+  if (awaiting.length === 0) {
+    return `
+<section id="awaiting-review" class="review-queue reviewed">
+  <h2>Awaiting review <span class="badge badge-ok">✓ none</span></h2>
+  <p class="note">The review queue is empty — no requirement is in the <em>Proposed</em> state awaiting approval.</p>
+</section>`;
+  }
+  const items = awaiting
+    .map(
+      (r) => `<li>
+  <a href="requirements/${safeSegment(r.uid)}.html">${escapeHtml(r.label)}</a>
+  ${[priorityBadge(r.priority), coverageBadge(r.covered, (r.verifiedBy ?? []).length)]
+    .filter(Boolean)
+    .join(" ")}
+</li>`,
+    )
+    .join("\n");
+  return `
+<section id="awaiting-review" class="review-queue">
+  <h2>Awaiting review <span class="chip">${awaiting.length}</span></h2>
+  <p class="note">Requirements drafted and <strong>awaiting approval</strong> (status <em>Proposed</em>). Open one to read its <code>Given / When / Then</code> statement, then approve. Sorted by priority.</p>
+  <ul class="review-list">
+${items}
+  </ul>
+</section>`;
+}
+
 /** A full HTML page shell (Jekyll-free static output). */
 export function layout({ title, content, relRoot = "" }) {
   return `<!doctype html>
@@ -85,6 +127,7 @@ export function layout({ title, content, relRoot = "" }) {
 <header class="site-header">
   <a class="brand" href="${relRoot}index.html">Exocortex · Living Documentation</a>
   <nav>
+    <a href="${relRoot}index.html#awaiting-review">Review queue</a>
     <a href="${relRoot}index.html#requirements">Requirements</a>
     <a href="${relRoot}index.html#adrs">Architecture</a>
     <a href="${relRoot}ontology.html">Ontology</a>
@@ -231,6 +274,8 @@ export function indexPage({ reqs, adrs, stats, ontology, generatedNote }) {
   <p class="chips">${statusChips}</p>
 </section>
 
+${awaitingReviewSection(reqs)}
+
 <section id="requirements">
   <h2>Functional requirements</h2>
   <p class="note">Each requirement carries a Gherkin <code>Given/When/Then</code> statement. <em>Coverage</em> reflects the <code>verifiedBy</code> binding declared on the requirement (from-graph). All lifecycle statuses are shown, explicitly labelled.</p>
@@ -303,4 +348,10 @@ table.grid th{font-size:.8rem;text-transform:uppercase;letter-spacing:.04em;colo
 .note{color:var(--muted);font-size:.9rem}
 .kv ul{margin:.2rem 0 0;padding-left:1.1rem}
 .kv li{margin:.2rem 0}
+.review-queue{border-left:4px solid var(--warn-fg);background:#fffdf5;border-radius:0 10px 10px 0;padding:.2rem 1.1rem 1rem;margin:1.4rem 0}
+.review-queue.reviewed{border-left-color:var(--ok-fg);background:#f6fef9}
+.review-queue h2{border-bottom:none;margin:1rem 0 .3rem;font-size:1.2rem}
+.review-list{list-style:none;margin:.4rem 0 0;padding:0}
+.review-list li{padding:.45rem 0;border-bottom:1px solid var(--line)}
+.review-list li:last-child{border-bottom:none}
 `;

--- a/docs-site/test/render.test.mjs
+++ b/docs-site/test/render.test.mjs
@@ -5,6 +5,7 @@ import {
   mdToHtml,
   statusBadge,
   coverageBadge,
+  awaitingReviewSection,
   requirementPage,
   adrPage,
   indexPage,
@@ -156,4 +157,64 @@ test("every page carries a noindex robots meta (publicly reachable, not search-i
   for (const html of [index, req, adr]) {
     assert.match(html, /<meta name="robots" content="noindex, nofollow, noarchive">/);
   }
+});
+
+test("awaitingReviewSection lists Proposed/Draft as deep-links and excludes Active/Approved", () => {
+  const reqs = [
+    { uid: "p1", label: "needs review one", status: "Proposed", priority: "P0", covered: true, verifiedBy: ["t"] },
+    { uid: "d2", label: "legacy draft two", status: "Draft", priority: null, covered: false, verifiedBy: [] },
+    { uid: "a3", label: "already active", status: "Active", priority: "P1", covered: true, verifiedBy: ["t"] },
+    { uid: "ap4", label: "already approved", status: "Approved", priority: "P2", covered: true, verifiedBy: ["t"] },
+  ];
+  const html = awaitingReviewSection(reqs);
+  assert.match(html, /id="awaiting-review"/);
+  assert.match(html, /Awaiting review/);
+  // count chip = the two awaiting (Proposed + Draft), not the active/approved ones
+  assert.match(html, /<span class="chip">2<\/span>/);
+  // both awaiting requirements are deep-linked
+  assert.match(html, /requirements\/p1\.html/);
+  assert.match(html, /requirements\/d2\.html/);
+  assert.match(html, /needs review one/);
+  // Active / Approved requirements are excluded from the queue
+  assert.doesNotMatch(html, /requirements\/a3\.html/);
+  assert.doesNotMatch(html, /requirements\/ap4\.html/);
+  assert.doesNotMatch(html, /already active/);
+});
+
+test("awaitingReviewSection shows a positive note when nothing awaits approval", () => {
+  const html = awaitingReviewSection([
+    { uid: "a3", label: "active", status: "Active", priority: "P1", covered: true, verifiedBy: ["t"] },
+  ]);
+  assert.match(html, /reviewed/); // the `review-queue reviewed` empty-state class
+  assert.match(html, /review queue is empty/);
+  assert.doesNotMatch(html, /review-list/); // no queue list rendered
+});
+
+test("awaitingReviewSection escapes a label with HTML metacharacters", () => {
+  const html = awaitingReviewSection([
+    { uid: "p1", label: "req: a < b && c", status: "Proposed", priority: null, covered: false, verifiedBy: [] },
+  ]);
+  assert.match(html, /a &lt; b &amp;&amp; c/);
+  assert.doesNotMatch(html, /a < b && c/);
+});
+
+test("indexPage embeds the awaiting-review queue ahead of the full requirements table", () => {
+  const reqs = [
+    { uid: "p1", label: "proposed req", status: "Proposed", priority: "P0", verifiedBy: ["t"], covered: true },
+    { uid: "a2", label: "active req", status: "Active", priority: "P1", verifiedBy: ["t"], covered: true },
+  ];
+  const adrs = [{ id: "ARCH-001", title: "Filenames", domain: "data", rules: false }];
+  const stats = {
+    total: 2,
+    covered: 2,
+    coverage: 1,
+    byStatus: { Proposed: 1, Active: 1 },
+    byPriority: { P0: 1, P1: 1 },
+  };
+  const html = indexPage({ reqs, adrs, stats, ontology: { classes: [], properties: [] } });
+  assert.match(html, /id="awaiting-review"/);
+  // header nav exposes the review queue
+  assert.match(html, /index\.html#awaiting-review/);
+  // the review queue appears before the full functional-requirements table
+  assert.ok(html.indexOf('id="awaiting-review"') < html.indexOf('id="requirements"'));
 });

--- a/docs-site/test/requirements.test.mjs
+++ b/docs-site/test/requirements.test.mjs
@@ -67,13 +67,19 @@ test("toRequirementRecord marks uncovered when verifiedBy is empty", () => {
 // Integration: read the real exoas-exo-reqs submodule fixtures.
 const hasSubmodule = existsSync(REQS_DIR);
 test(
-  "loadRequirements reads the exoas-exo-reqs submodule (30 requirements; the $exo-reqs anchor is excluded)",
+  "loadRequirements reads the exoas-exo-reqs submodule (anchor + non-requirement assets excluded)",
   { skip: hasSubmodule ? false : "submodule not checked out" },
   async () => {
     const reqs = await loadRequirements(REQS_DIR);
-    // 31 .md files = 30 req__Requirement instances + 1 assetspace anchor
-    // ($exo-reqs, which carries no req__Requirement_status and is correctly excluded).
-    assert.equal(reqs.length, 30, "expected 30 functional requirements (anchor excluded)");
+    // The submodule grows over time (new requirements added on each bump), so
+    // assert a lower bound rather than an exact count — an exact count is a
+    // maintenance trap that reds the docs-site test on every reqs pointer bump.
+    // Non-requirement assets (the $exo-reqs assetspace anchor and ui-acceptance
+    // evidence-attestations) carry no req__Requirement_status and are excluded.
+    assert.ok(
+      reqs.length >= 30,
+      `expected ≥30 functional requirements (anchor excluded), got ${reqs.length}`,
+    );
     assert.ok(
       reqs.every((r) => r.status !== null),
       "every requirement must carry a parseable status",
@@ -94,11 +100,13 @@ test(
   async () => {
     const reqs = await loadRequirements(REQS_DIR);
     const stats = requirementStats(reqs);
-    assert.equal(stats.total, 30);
+    assert.equal(stats.total, reqs.length);
+    assert.ok(stats.total >= 30, `expected ≥30 requirements, got ${stats.total}`);
     assert.ok(stats.coverage >= 0 && stats.coverage <= 1);
+    // byStatus must partition the full set (sum === total) regardless of count.
     assert.equal(
       Object.values(stats.byStatus).reduce((a, b) => a + b, 0),
-      30,
+      stats.total,
     );
   },
 );


### PR DESCRIPTION
## M4 — Living-Docs review surface for morning approve (RFC 0004)

Makes the published Living-Documentation site (`kitelev.github.io/exocortex`) a good **morning-approve review surface** for the SDD requirements lifecycle, and surfaces the night's newly-active requirements. Docs-only, low-risk.

### What changed

**1. `docs-site/lib/render.mjs` — "Awaiting review" queue**
- New `awaitingReviewSection(reqs)`: a focused, deep-linkable list of requirements in the **Proposed** (+ legacy **Draft**) state — the approval queue — placed in `indexPage` right after the hero and **before** the full requirements table. Each item deep-links to its detail page (Gherkin) with priority + coverage badges.
- `Active` / `Approved` / `Deprecated` requirements are **excluded** from the queue (they remain in the full reference table below). Empty-state renders a positive "review queue is empty" note.
- "Review queue" nav link in the shared header; `.review-queue` callout CSS.

**2. `packages/exoas-exo-reqs` pointer bump `181eaf68 → 389229a`**
- Surfaces the night's 2 newly-active requirements on the published site:
  - `a2d3abd4` — Create Subclass co-location + UID-canon (DEFECT-D1, ui-acceptance)
  - `547ef066` — `component` binding-class recognized below the P0 floor
- The active-requirement CI gate is **decoupled** from this pointer (`requirements-trace` clones the reqs repo fresh, so it already validates these on every main run). This bump is a **presentation-only** surface, not a gate change.

**3. Tests**
- New render tests: escaping, Proposed/Draft filter, exclusion of Active/Approved, empty-state, nav placement, queue-before-table ordering.
- Relaxed the two integration count assertions from exact-`30` to `>= 30` — an exact count was a maintenance trap that red the docs-site test on every reqs bump. Structural tripwires retained (parser-broke→0, every req has status/uid/label, priority sort, `byStatus` partition sums to total).

### Verification
- `docs-site` suite: **38/38 green** (incl. real-submodule integration tests).
- Build at the bumped pointer: 32 requirements (30 Proposed + 2 Active), queue lists the 30 Proposed, both Active reqs surfaced in the full table + detail pages.
- code-reviewer agent: **APPROVE**, 0 CRITICAL/HIGH/MEDIUM (2 LOW; the empty-state copy LOW was addressed).

### Scope
Bounded per the M4 brief — surface existing artifacts better, no new generator features. The PR triggers the `living-docs` workflow (build+test on PR; Pages deploy on merge-to-main).
