### PR TITLE
feat(req): GUI-in-CI ui-acceptance runner — dedup eka-gui-e2e into the ui-acceptance auto-verification tier

### DIFF
--- a/.github/workflows/eka-gui-e2e.yml
+++ b/.github/workflows/eka-gui-e2e.yml
@@ -118,11 +118,17 @@ jobs:
             -v "$PWD/eka-gui-results:/app/packages/obsidian-plugin/test-results-eka-gui" \
             exocortex-eka-gui-e2e:ci
 
-      - name: Upload artifacts on failure
-        if: failure()
+      # Upload on EVERY run (not just failure): a PASSING acceptance run produces
+      # the auto-evidence for its `@req`-bound ui-acceptance scenarios — the
+      # req-evidence.json manifest + per-scenario DOM screenshots (al-gui-ci-runner
+      # dedup). The eka-gui run IS the automated ui-acceptance evidence, so the
+      # artifact must be retained on success, not only on failure (failure also
+      # carries the trace/video for debugging via `if: always()`).
+      - name: Upload EKA GUI req-evidence + artifacts
+        if: always()
         uses: actions/upload-artifact@v6
         with:
-          name: eka-gui-e2e-results
+          name: eka-gui-req-evidence
           path: eka-gui-results
           retention-days: 14
           if-no-files-found: ignore

--- a/packages/cli/src/commands/requirements-audit.ts
+++ b/packages/cli/src/commands/requirements-audit.ts
@@ -79,6 +79,30 @@ const BINDING_CLASS_MAP: Record<string, string> = {
 const UI_ACCEPTANCE = "ui-acceptance";
 
 /**
+ * GUI-in-CI runner spec path (al-gui-ci-runner — dedup of `eka-gui-e2e`).
+ *
+ * A `@req:<uid>` tag whose test file lives under `tests/e2e/eka-gui/` is an
+ * **automated GUI verification**: it binds the requirement to a scenario of the
+ * `eka-gui-e2e` suite, which drives the REAL plugin UI against a fresh vault on
+ * native-amd64 CI and asserts real on-disk frontmatter. For the `ui-acceptance`
+ * tier this is the *automated* sub-mode: the eka-gui run auto-produces the
+ * evidence (screenshot / DOM snapshot / per-`@req` manifest), deduplicating the
+ * hand-written committed evidence-attestation. A `@req` tag in any OTHER test
+ * (a jsdom unit/component test, a CLI integration test) is NOT a GUI-in-CI run
+ * and so does NOT auto-evidence a `ui-acceptance` requirement.
+ *
+ * Scoped deliberately to `eka-gui` (public repos, always-runs) — NOT its sibling
+ * `eka-obsidian-leg` (private repos, PAT-gated, self-skips), which is not a
+ * reliable always-on auto-evidence source.
+ */
+const GUI_RUNNER_SPEC_RE = /(^|[\\/])tests[\\/]e2e[\\/]eka-gui[\\/]/;
+
+/** True iff a scanned test-file path is a GUI-in-CI runner (`eka-gui`) spec. */
+export function isGuiRunnerSpec(file: string): boolean {
+  return GUI_RUNNER_SPEC_RE.test(file);
+}
+
+/**
  * A binding class that exercises production beyond a pure unit test. `ui-acceptance`
  * is included: a manual live-UI acceptance check exercises real production more
  * than a unit test, so it satisfies the P0 binding-class floor.
@@ -233,6 +257,18 @@ export interface TraceabilityReport {
   uiAcceptanceTotal: number;
   /** `ui-acceptance` requirements with ≥1 resolving committed evidence link. */
   uiAcceptanceEvidenced: number;
+  /**
+   * `ui-acceptance` requirements verified by the AUTOMATED sub-mode — a `@req`
+   * binding in a GUI-in-CI runner (`eka-gui`) spec (al-gui-ci-runner dedup).
+   * The eka-gui run auto-produces the evidence; no committed attestation needed.
+   */
+  uiAcceptanceAutomated: number;
+  /**
+   * `ui-acceptance` requirements verified by the MANUAL sub-mode — a resolving
+   * committed evidence-attestation (computer-control), WITHOUT a GUI-runner
+   * `@req` binding. The genuinely-not-automatable tier (RFC 0003 §3.6).
+   */
+  uiAcceptanceManual: number;
   /**
    * `ui-acceptance` requirements with NO resolving evidence — evidence-coverage
    * gap (reported for visibility; HARD only for the `active` subset, via
@@ -473,6 +509,14 @@ export function auditTraceability(
     else occByUid.set(key, [t]);
   }
 
+  // True iff the requirement is bound by a `@req` tag living in a GUI-in-CI
+  // runner (`eka-gui`) spec — the AUTOMATED ui-acceptance sub-mode
+  // (al-gui-ci-runner dedup). The eka-gui run is the auto-evidence.
+  const hasGuiRunnerBinding = (r: RequirementRecord): boolean =>
+    (occByUid.get(r.uid.toLowerCase()) ?? []).some((o) =>
+      isGuiRunnerSpec(o.file),
+    );
+
   const orphans: OrphanFinding[] = [];
   let bound = 0;
   let manuallyVerified = 0;
@@ -550,29 +594,33 @@ export function auditTraceability(
     if (r.status?.toLowerCase() !== "active") continue;
     activeTotal++;
     const isBound = occByUid.has(r.uid.toLowerCase());
-    // A jest `@req` binding satisfies the active req regardless of binding class
-    // (matches the existing "jest tag takes precedence" count semantics).
-    if (isBound) continue;
     if (isManuallyVerified(r)) {
-      // ui-acceptance tier: the verification binding IS the recorded
-      // computer-control evidence (RFC 0003 §3.6). For an `active` ui-acceptance
-      // requirement, require that evidence to be committed + linked + resolving —
-      // otherwise the tier is a self-asserting "trust the prose" (the gap
-      // al-night-uiaccept closes). A declared-but-missing evidence path is ALSO
-      // a danglingEvidence finding; here it additionally blocks the always-on
-      // active gate. Proposed/Draft ui-acceptance reqs are NOT gated on evidence
-      // (migration-friendly) — only the in-force `active` subset.
-      if (!hasResolvingEvidence(r)) {
-        activeViolations.push({
-          uid: r.uid,
-          label: r.label,
-          path: r.path,
-          reason:
-            "active ui-acceptance requirement has no resolving committed evidence (req__Requirement_evidence) — commit + link the evidence artifact, or move it to Deprecated",
-        });
-      }
+      // ui-acceptance tier — TWO satisfaction sub-modes (al-gui-ci-runner dedup,
+      // RFC 0003 §3.6). The verification of a `ui-acceptance` (live-UI) req is a
+      // REAL UI run, not "any @req tag":
+      //   • AUTOMATED — a `@req` binding in a GUI-in-CI runner (`eka-gui`) spec.
+      //     The eka-gui run (real plugin UI, native-amd64 CI) auto-produces the
+      //     evidence; no committed attestation needed (the dedup — ONE engine).
+      //   • MANUAL — a resolving committed evidence-attestation (computer-control)
+      //     for the genuinely-not-automatable case.
+      // A `@req` tag in a NON-GUI test (jsdom unit/component, CLI integration) is
+      // NOT a live-UI verification, so it does NOT auto-evidence a ui-acceptance
+      // req — closing the `if (isBound)` hole where a unit-test tag faked an
+      // acceptance. Proposed/Draft ui-acceptance reqs are NOT gated (migration-
+      // friendly) — only the in-force `active` subset.
+      if (hasGuiRunnerBinding(r) || hasResolvingEvidence(r)) continue;
+      activeViolations.push({
+        uid: r.uid,
+        label: r.label,
+        path: r.path,
+        reason:
+          "active ui-acceptance requirement is not verified — bind it to an eka-gui GUI-in-CI scenario (@req in tests/e2e/eka-gui/, automated evidence) OR commit + link a req__Requirement_evidence attestation (manual), OR move it to Deprecated. A @req tag in a non-GUI test does not auto-evidence a live-UI acceptance.",
+      });
       continue;
     }
+    // Non-ui-acceptance reqs: any `@req` jest binding satisfies (unchanged —
+    // "jest tag takes precedence" count semantics).
+    if (isBound) continue;
     activeViolations.push({
       uid: r.uid,
       label: r.label,
@@ -589,6 +637,13 @@ export function auditTraceability(
   const danglingEvidence: DanglingEvidenceFinding[] = [];
   let uiAcceptanceTotal = 0;
   let uiAcceptanceEvidenced = 0;
+  // al-gui-ci-runner dedup: split the ui-acceptance tier into the AUTOMATED
+  // sub-mode (verified by a GUI-in-CI runner `@req` binding — the eka-gui run is
+  // the auto-evidence) vs the MANUAL sub-mode (committed attestation only, no
+  // GUI-runner binding). A req with BOTH counts as automated (the stronger,
+  // reproducible verification).
+  let uiAcceptanceAutomated = 0;
+  let uiAcceptanceManual = 0;
   for (const r of requirements) {
     if (r.evidenceMissing.length > 0) {
       danglingEvidence.push({
@@ -601,6 +656,8 @@ export function auditTraceability(
     if (isManuallyVerified(r)) {
       uiAcceptanceTotal++;
       if (hasResolvingEvidence(r)) uiAcceptanceEvidenced++;
+      if (hasGuiRunnerBinding(r)) uiAcceptanceAutomated++;
+      else if (hasResolvingEvidence(r)) uiAcceptanceManual++;
     }
   }
   const uiAcceptanceMissingEvidence = uiAcceptanceTotal - uiAcceptanceEvidenced;
@@ -639,6 +696,8 @@ export function auditTraceability(
     danglingEvidence,
     uiAcceptanceTotal,
     uiAcceptanceEvidenced,
+    uiAcceptanceAutomated,
+    uiAcceptanceManual,
     uiAcceptanceMissingEvidence,
     unknownPriority,
     clean,
@@ -672,7 +731,8 @@ function renderText(report: TraceabilityReport, gate: GateMode = "soft"): void {
   );
   console.log(
     `ui-acceptance: ${report.uiAcceptanceTotal} | ` +
-      `with committed evidence: ${report.uiAcceptanceEvidenced} | ` +
+      `automated (eka-gui runner): ${report.uiAcceptanceAutomated} | ` +
+      `manual (committed evidence): ${report.uiAcceptanceManual} | ` +
       `missing evidence: ${report.uiAcceptanceMissingEvidence}`,
   );
 

--- a/packages/cli/src/commands/requirements-audit.ts
+++ b/packages/cli/src/commands/requirements-audit.ts
@@ -606,8 +606,11 @@ export function auditTraceability(
       // A `@req` tag in a NON-GUI test (jsdom unit/component, CLI integration) is
       // NOT a live-UI verification, so it does NOT auto-evidence a ui-acceptance
       // req — closing the `if (isBound)` hole where a unit-test tag faked an
-      // acceptance. Proposed/Draft ui-acceptance reqs are NOT gated (migration-
-      // friendly) — only the in-force `active` subset.
+      // acceptance. This binds the WHOLE req: a combination-classed req (e.g.
+      // [ui-acceptance, integration]) is governed by these two sub-modes, NOT by
+      // its other class's plain `@req` tag — a non-GUI tag alone never satisfies a
+      // req that carries `ui-acceptance` (the live-UI tier wins). Proposed/Draft
+      // ui-acceptance reqs are NOT gated (migration-friendly) — only `active`.
       if (hasGuiRunnerBinding(r) || hasResolvingEvidence(r)) continue;
       activeViolations.push({
         uid: r.uid,

--- a/packages/cli/tests/unit/commands/requirements-audit.test.ts
+++ b/packages/cli/tests/unit/commands/requirements-audit.test.ts
@@ -36,6 +36,19 @@ function tag(uid: string, file = "a.test.ts", line = 1): TagOccurrence {
   return { uid, file, line };
 }
 
+/**
+ * A `@req` tag living in a GUI-in-CI runner (`eka-gui`) spec — the AUTOMATED
+ * ui-acceptance sub-mode (al-gui-ci-runner dedup). Path mirrors the real
+ * `packages/obsidian-plugin/tests/e2e/eka-gui/*.spec.ts` runner location.
+ */
+function guiTag(
+  uid: string,
+  file = "packages/obsidian-plugin/tests/e2e/eka-gui/create-instance-buttons.spec.ts",
+  line = 1,
+): TagOccurrence {
+  return { uid, file, line };
+}
+
 describe("requirements — Commander wiring", () => {
   it("registers 'audit' under the 'requirements' parent command", () => {
     const parent = requirementsCommand();
@@ -519,13 +532,69 @@ describe("auditTraceability — active-requirement invariant (SDD feature-lifecy
     expect(r.clean).toBe(false);
   });
 
-  it("an active ui-acceptance requirement bound by a jest @req tag is satisfied without evidence (tag precedence)", () => {
+  it("@req:58326e2f-2b89-49f2-af1d-78829fd78b57 an active ui-acceptance requirement bound by a GUI-in-CI runner (eka-gui) @req tag is satisfied WITHOUT committed evidence (AUTOMATED sub-mode)", () => {
+    // al-gui-ci-runner dedup: a `@req` binding in an eka-gui runner spec IS the
+    // auto-evidence (the eka-gui run drives real plugin UI on native-amd64 CI),
+    // so the active ui-acceptance req is satisfied without a hand-written
+    // committed attestation. ONE engine — no parallel ui-acceptance runner.
     const reqs = [
       req({ uid: UID_A, status: "Active", bindingClasses: ["ui-acceptance"] }),
     ];
-    const r = auditTraceability(reqs, [tag(UID_A)]); // jest-bound → satisfied
+    const r = auditTraceability(reqs, [guiTag(UID_A)]); // eka-gui-bound → automated
     expect(r.activeViolations).toHaveLength(0);
+    expect(r.uiAcceptanceAutomated).toBe(1);
+    expect(r.uiAcceptanceManual).toBe(0);
     expect(r.clean).toBe(true);
+  });
+
+  it("an active ui-acceptance requirement bound ONLY by a NON-GUI @req tag, no committed evidence, is an invariant violation (revert-verify: a jsdom/CLI tag cannot auto-evidence a live-UI acceptance)", () => {
+    // Closes the `if (isBound) continue;` hole: before al-gui-ci-runner, ANY
+    // @req tag (even in a unit/jsdom test) satisfied an active ui-acceptance req.
+    // A non-GUI tag is not a live-UI run → it does NOT auto-evidence the tier.
+    // REVERT-VERIFY: restoring the broad `if (isBound) continue;` for the
+    // ui-acceptance branch makes this expectation FAIL (the unit-test tag would
+    // spuriously satisfy the req); the al-gui-ci-runner logic makes it PASS.
+    const reqs = [
+      req({ uid: UID_A, status: "Active", bindingClasses: ["ui-acceptance"] }),
+    ];
+    const r = auditTraceability(reqs, [tag(UID_A)]); // non-GUI unit-test tag only
+    expect(r.activeViolations.map((a) => a.uid)).toEqual([UID_A]);
+    expect(r.activeViolations[0].reason).toMatch(/eka-gui|live-UI/i);
+    expect(r.uiAcceptanceAutomated).toBe(0);
+    expect(r.clean).toBe(false);
+  });
+
+  it("an active ui-acceptance requirement satisfied by committed evidence (no GUI-runner tag) counts as MANUAL sub-mode", () => {
+    const reqs = [
+      req({
+        uid: UID_A,
+        status: "Active",
+        bindingClasses: ["ui-acceptance"],
+        evidence: ["evidence/a.md"],
+        evidenceMissing: [],
+      }),
+    ];
+    const r = auditTraceability(reqs, []); // no tag — manual committed evidence
+    expect(r.activeViolations).toHaveLength(0);
+    expect(r.uiAcceptanceAutomated).toBe(0);
+    expect(r.uiAcceptanceManual).toBe(1);
+    expect(r.clean).toBe(true);
+  });
+
+  it("a ui-acceptance req with BOTH a GUI-runner tag AND committed evidence counts as automated (reproducible verification wins)", () => {
+    const reqs = [
+      req({
+        uid: UID_A,
+        status: "Active",
+        bindingClasses: ["ui-acceptance"],
+        evidence: ["evidence/a.md"],
+        evidenceMissing: [],
+      }),
+    ];
+    const r = auditTraceability(reqs, [guiTag(UID_A)]);
+    expect(r.activeViolations).toHaveLength(0);
+    expect(r.uiAcceptanceAutomated).toBe(1);
+    expect(r.uiAcceptanceManual).toBe(0);
   });
 
   it("a PROPOSED requirement with no binding is NOT an active violation (only an orphan warning)", () => {

--- a/packages/obsidian-plugin/playwright-eka-gui.config.ts
+++ b/packages/obsidian-plugin/playwright-eka-gui.config.ts
@@ -27,11 +27,18 @@ export default defineConfig({
   expect: {
     timeout: 60_000,
   },
-  reporter: [["list"]],
+  // `list` for the human log + the req-evidence reporter (al-gui-ci-runner): it
+  // writes test-results-eka-gui/req-evidence.json mapping each `@req:<uid>`
+  // scenario → result — the machine-readable AUTOMATED ui-acceptance evidence
+  // (uploaded as the eka-gui-req-evidence CI artifact, retained on success too).
+  reporter: [["list"], ["./tests/e2e/eka-gui/req-evidence-reporter.ts"]],
   outputDir: "test-results-eka-gui",
   use: {
     trace: "retain-on-failure",
-    screenshot: "only-on-failure",
+    // `on` (not only-on-failure): capture a per-scenario DOM screenshot on EVERY
+    // run so a PASSING acceptance leaves a durable visual evidence trail (the
+    // auto-produced ui-acceptance evidence), alongside the req-evidence manifest.
+    screenshot: "on",
     video: "retain-on-failure",
     launchOptions: {
       args: [

--- a/packages/obsidian-plugin/tests/e2e/eka-gui/create-instance-buttons.spec.ts
+++ b/packages/obsidian-plugin/tests/e2e/eka-gui/create-instance-buttons.spec.ts
@@ -261,7 +261,14 @@ test.describe("EKA GUI — create-instance buttons (fresh real-content vault)", 
   // whose exo__Instance_class is the host class (via the $targetClassSelf
   // PropertyDefault) and whose exo__Asset_isDefinedBy + folder follow the PICKED
   // ontology ($exo ≠ the host's own $ems → proves the picker drives both).
-  test("scenario 9 — Create Instance on an exo__Class page (flagship bbe40f8c)", async () => {
+  // `@req:` GUI-in-CI runner binding (al-gui-ci-runner dedup): this scenario IS
+  // the gui-bdd floor binding that req ace6df4f ("creating an instance surfaces
+  // the class's SHACL-required properties as form fields") already names in its
+  // prose verifiedBy — making that claim a TRACED binding the `requirements
+  // audit` checker picks up (`--tests .` scans this spec). A `@req` tag in an
+  // eka-gui spec = the AUTOMATED verification sub-mode; the eka-gui run on
+  // native-amd64 CI auto-produces the evidence (req-evidence.json + screenshot).
+  test("scenario 9 — Create Instance on an exo__Class page (flagship bbe40f8c) @req:ace6df4f-b2c7-4dcb-afb6-bda8b20e7da0", async () => {
     // Store-completeness gate for THIS target: the binding targets the exo__Class
     // metaclass (not ems__Area), so gate on "Create Instance" resolving on the
     // class-def page itself (same #3587 rationale as the beforeAll area gate).

--- a/packages/obsidian-plugin/tests/e2e/eka-gui/req-evidence-reporter.ts
+++ b/packages/obsidian-plugin/tests/e2e/eka-gui/req-evidence-reporter.ts
@@ -1,0 +1,125 @@
+import type {
+  FullConfig,
+  Reporter,
+  TestCase,
+  TestResult,
+} from "@playwright/test/reporter";
+import * as fs from "fs";
+import * as path from "path";
+
+/**
+ * EKA GUI-in-CI **req-evidence** reporter (al-gui-ci-runner — dedup of
+ * `eka-gui-e2e` into the ui-acceptance auto-runner).
+ *
+ * The dedup model (design-doc gui-ci-runner-design-2026-06-22): a `req__Requirement`
+ * is bound to an eka-gui scenario by a `@req:<uid>` token in the test title. When
+ * the suite runs on native-amd64 CI it auto-produces the evidence for those reqs:
+ * this reporter writes a machine-readable manifest mapping each `@req:<uid>` →
+ * {scenario, status, spec, duration}, AND the Playwright `screenshot` artifact
+ * (DOM snapshot) is captured per scenario. The manifest + screenshots are uploaded
+ * as the `eka-gui-req-evidence` CI artifact (retained on success too), so a passing
+ * acceptance run leaves a durable, auto-attributed evidence trail — no hand-written
+ * committed attestation needed (that path stays for genuinely-manual ui-acceptance).
+ *
+ * The `requirements audit` checker recognises the `@req` binding itself (a tag in a
+ * `tests/e2e/eka-gui/` spec = the AUTOMATED ui-acceptance sub-mode); this reporter
+ * produces the corroborating artifact. It NEVER throws / fails the run — evidence
+ * production must not gate the suite.
+ */
+
+const REQ_UID_RE =
+  /@req:([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})/g;
+
+interface ReqEvidenceEntry {
+  /** The requirement uid the scenario verifies (lower-cased). */
+  reqUid: string;
+  /** The full scenario title (carries the `@req:` token + human description). */
+  scenario: string;
+  /** Pass/fail/skipped of the GUI acceptance run. */
+  status: TestResult["status"];
+  durationMs: number;
+  /** Spec file (repo-relative) the scenario lives in. */
+  spec: string;
+}
+
+interface ReqEvidenceManifest {
+  generatedAt: string;
+  runner: "eka-gui-e2e";
+  totalReqScenarios: number;
+  passed: number;
+  failed: number;
+  /** Distinct requirement uids auto-verified by this run. */
+  reqUids: string[];
+  entries: ReqEvidenceEntry[];
+}
+
+/** Extract every `@req:<uid>` token from a scenario title (lower-cased). */
+export function extractReqUids(title: string): string[] {
+  const uids: string[] = [];
+  REQ_UID_RE.lastIndex = 0;
+  let m: RegExpExecArray | null;
+  while ((m = REQ_UID_RE.exec(title)) !== null) uids.push(m[1].toLowerCase());
+  return uids;
+}
+
+function resolveOutputPath(rootDir: string): string {
+  const envOverride = process.env.EKA_GUI_REQ_EVIDENCE_OUTPUT;
+  if (envOverride) return envOverride;
+  // `outputDir: "test-results-eka-gui"` (playwright-eka-gui.config.ts) is the
+  // Docker volume mount (-v $PWD/eka-gui-results:/app/.../test-results-eka-gui),
+  // so writing here ensures the manifest is picked up as a CI artifact.
+  return path.join(rootDir, "test-results-eka-gui", "req-evidence.json");
+}
+
+export default class ReqEvidenceReporter implements Reporter {
+  private rootDir: string = process.cwd();
+  private entries: ReqEvidenceEntry[] = [];
+
+  onBegin(config: FullConfig): void {
+    this.rootDir = config.rootDir || process.cwd();
+  }
+
+  onTestEnd(test: TestCase, result: TestResult): void {
+    try {
+      const uids = extractReqUids(test.title);
+      for (const reqUid of uids) {
+        this.entries.push({
+          reqUid,
+          scenario: test.title,
+          status: result.status,
+          durationMs: result.duration,
+          spec: path.relative(this.rootDir, test.location.file),
+        });
+      }
+    } catch {
+      // never let evidence collection break the suite
+    }
+  }
+
+  onEnd(): void {
+    try {
+      const manifest: ReqEvidenceManifest = {
+        generatedAt: new Date().toISOString(),
+        runner: "eka-gui-e2e",
+        totalReqScenarios: this.entries.length,
+        passed: this.entries.filter((e) => e.status === "passed").length,
+        failed: this.entries.filter((e) => e.status === "failed").length,
+        reqUids: [...new Set(this.entries.map((e) => e.reqUid))].sort(),
+        entries: this.entries,
+      };
+      const outPath = resolveOutputPath(this.rootDir);
+      fs.mkdirSync(path.dirname(outPath), { recursive: true });
+      fs.writeFileSync(outPath, JSON.stringify(manifest, null, 2), "utf-8");
+      console.log(
+        `[req-evidence-reporter] ${manifest.totalReqScenarios} @req scenario(s) for ` +
+          `${manifest.reqUids.length} requirement(s) → ${path.relative(this.rootDir, outPath)}`,
+      );
+    } catch (err) {
+      console.warn("[req-evidence-reporter] manifest write failed:", err);
+    }
+  }
+
+  printsToStdio(): boolean {
+    return false;
+  }
+}

--- a/packages/obsidian-plugin/tests/e2e/eka-gui/req-evidence-reporter.ts
+++ b/packages/obsidian-plugin/tests/e2e/eka-gui/req-evidence-reporter.ts
@@ -120,6 +120,7 @@ export default class ReqEvidenceReporter implements Reporter {
   }
 
   printsToStdio(): boolean {
-    return false;
+    // onEnd prints a one-line summary to stdout — report that honestly.
+    return true;
   }
 }

--- a/packages/obsidian-plugin/tests/unit/eka-gui-req-evidence-reporter.test.ts
+++ b/packages/obsidian-plugin/tests/unit/eka-gui-req-evidence-reporter.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from "@jest/globals";
+import { extractReqUids } from "../e2e/eka-gui/req-evidence-reporter";
+
+// al-gui-ci-runner — the eka-gui req-evidence reporter binds an eka-gui scenario
+// to a requirement by a `@req:<uid>` token in the test title (the AUTOMATED
+// ui-acceptance sub-mode). This pins the title→uid extraction the manifest +
+// the `requirements audit` checker both rely on.
+//
+// NB: the test inputs build the tag prefix from parts (`TAG`) so this file does
+// NOT contain a literal contiguous `@req:<uuid>` — otherwise `requirements audit`
+// (`--tests .`) would scan THIS file and treat the fixture uids as dangling tags.
+const TAG = "@" + "req:";
+
+describe("eka-gui req-evidence reporter — extractReqUids", () => {
+  it("extracts a @req:<uid> token from a scenario title (lower-cased)", () => {
+    expect(
+      extractReqUids(
+        `scenario 9 — Create Instance (flagship) ${TAG}ACE6DF4F-B2C7-4DCB-AFB6-BDA8B20E7DA0`,
+      ),
+    ).toEqual(["ace6df4f-b2c7-4dcb-afb6-bda8b20e7da0"]);
+  });
+
+  it("extracts multiple @req tags from one title", () => {
+    expect(
+      extractReqUids(
+        `${TAG}11111111-1111-4111-8111-111111111111 and ${TAG}22222222-2222-4222-8222-222222222222`,
+      ),
+    ).toEqual([
+      "11111111-1111-4111-8111-111111111111",
+      "22222222-2222-4222-8222-222222222222",
+    ]);
+  });
+
+  it("returns [] for a title with no @req tag", () => {
+    expect(extractReqUids("scenario 2 — Create Task on ems__Area")).toEqual([]);
+  });
+
+  it("ignores a malformed (non-UUID) @req token", () => {
+    expect(extractReqUids(`${TAG}not-a-uuid`)).toEqual([]);
+  });
+});


### PR DESCRIPTION
## GUI-в-CI ui-acceptance runner — дедуплицируя `eka-gui-e2e`

Расширяет существующий `eka-gui-e2e` (НЕ строит параллельный runner), чтобы он служил авто-runner'ом для тира **ui-acceptance**. Per директива Андрея «полный GUI-в-CI runner, но с дедуплицированием eka-gui-e2e».

### Binding-class развязка — **решение (b): ui-acceptance остаётся тиром + automated sub-mode**
- **automated** (новый): `@req:<uid>` тег в eka-gui runner-спеке (`tests/e2e/eka-gui/`) → CI-прогон auto-produces evidence → satisfies the active-gate без committed attestation.
- **manual** (как было): committed `req__Requirement_evidence` attestation — для genuinely-not-automatable.
- ⛔ НЕ миграция в gui-bdd (вариант a отклонён — директива «для ui-acceptance **тира**»). Surfaced prominently; директива-aligned (не 50/50) → решено без эскалации.

**Дедуп: ОДИН движок** — `eka-gui-e2e` обслуживает и gui-bdd, и automated ui-acceptance.

### Что меняется
- **`requirements-audit.ts`** (gate-affecting): `isGuiRunnerSpec` + `hasGuiRunnerBinding`; ui-acceptance active-gate satisfied ⇔ **(GUI-runner @req binding [automated]) OR (resolving committed evidence [manual])**. Тег в **non-GUI** тесте (jsdom unit/CLI integration) больше НЕ auto-evidence'ит live-UI acceptance (закрывает дыру broad `if (isBound) continue;`). Новые поля `uiAcceptanceAutomated`/`uiAcceptanceManual`.
- **eka-gui auto-evidence:** `req-evidence-reporter.ts` (manifest `req-evidence.json` мапит `@req:<uid>` → результат), `playwright-eka-gui.config.ts` (`screenshot: on`), `eka-gui-e2e.yml` (upload `if: always()` как `eka-gui-req-evidence`, retain на success).
- **Runner-binding demo:** `@req:ace6df4f` на eka-gui сценарии 9 — реализует prose-claimed gui-bdd floor binding (теперь traced). Duplicate-binding WARNING accepted (non-blocking, корректно).
- **Новый req `58326e2f`** (exoas-exo-reqs, Approved→Active после merge), `unit`-bound.

### Revert-verify (Executable Specification)
Production-shape unit-тесты `auditTraceability` (real `RequirementRecord`/`TagOccurrence`; `.file` различает eka-gui runner-спеку от non-GUI теста). **FAIL pre / PASS post:** active ui-acceptance bound ТОЛЬКО non-GUI тегом без evidence → НОВЫЙ код raise violation (PASS теста) / body-revert broad `isBound` → no violation (FAIL). Empirically verified.

### Verify
- ✅ Root typecheck `tsc --noEmit --skipLibCheck` clean.
- ✅ `requirements-audit.test.ts` 71/71; reporter test 4/4.
- ✅ Local audit против real corpus (exoas-exo-reqs + exoas-ems-reqs): `dangling 0, activeViolations 0, floorViolations 0, danglingEvidence 0, clean: true, rampReady`. Req 58326e2f bound; единственный active ui-acceptance (`a2d3abd4`) остаётся satisfied (manual) → 0 regression.
- ⛤ eka-gui-e2e verified via **CI** (native amd64), ⛔ НЕ локальный Docker (panic-rule).

Refs: design-doc `gui-ci-runner-design-2026-06-22`, RFC 0003 §3.6, WBS M3 `1ec7677e`.
