### PR TITLE
feat(profile-apply): granular install progress for large AssetSpace mounts

### DIFF
--- a/packages/cli/src/services/BootstrapAssetSpaceService.ts
+++ b/packages/cli/src/services/BootstrapAssetSpaceService.ts
@@ -286,7 +286,11 @@ export class BootstrapAssetSpaceService {
       async removeDir(p: string): Promise<void> {
         rmSync(p, { recursive: true, force: true });
       },
-      async materialize(targetDir: string, files: MountFile[]): Promise<number> {
+      async materialize(
+        targetDir: string,
+        files: MountFile[],
+        onFileWritten?: (processed: number) => void,
+      ): Promise<number> {
         const stagingDir = await mkdtemp(join(tmpdir(), `exo-bootstrap-${basename(targetDir)}-`));
         let fileCount = 0;
         try {
@@ -305,6 +309,10 @@ export class BootstrapAssetSpaceService {
             mkdirSync(dirname(target), { recursive: true });
             writeFileSync(target, file.content);
             fileCount++;
+            // Per-file progress tick (al-mount-observability) — the core
+            // throttles it; the CLI bootstrap path omits onProgress so this is a
+            // no-op closure here (zero cost).
+            onFileWritten?.(fileCount);
           }
 
           // Atomic move к target.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -586,6 +586,9 @@ export {
   type MountResult,
   type MountAssetSpaceParams,
   type MountProgressPhase,
+  type MountFileProgress,
+  MATERIALIZE_PROGRESS_INTERVAL,
+  MATERIALIZE_PROGRESS_MIN_FILES,
   type GitmodulesAppendResult,
 } from "./services/assetspace/AssetSpaceMount";
 

--- a/packages/core/src/services/assetspace/AssetSpaceMount.ts
+++ b/packages/core/src/services/assetspace/AssetSpaceMount.ts
@@ -61,8 +61,19 @@ export interface FileSystemPort {
    * a non-empty target). Each `relPath` is already core-validated against
    * zip-slip; the adapter MAY keep its own defense-in-depth resolve check.
    * Returns the number of files written.
+   *
+   * `onFileWritten(processed)` — optional per-file progress tick
+   * (al-mount-observability). Invoked by the adapter after each file is written
+   * with the 1-based count so the core can re-emit throttled within-AS install
+   * progress for a large AssetSpace. Best-effort: the core wraps it so a
+   * throwing observer can never break the mount; adapters MAY call it
+   * unconditionally (cheap when absent → no-op closure not passed).
    */
-  materialize(targetPath: string, files: MountFile[]): Promise<number>;
+  materialize(
+    targetPath: string,
+    files: MountFile[],
+    onFileWritten?: (processed: number) => void,
+  ): Promise<number>;
   /** Recursively remove a mount tree. The platform owns any safety guards. */
   removeDir(path: string): Promise<void>;
 }
@@ -185,6 +196,33 @@ function buildMountFiles(entries: TarballEntry[], wrapper: string): MountFile[] 
  */
 export type MountProgressPhase = "fetch" | "extract" | "materialize";
 
+/**
+ * Within-AS materialize file-write progress (al-mount-observability) — the
+ * count of files written so far and the AssetSpace's total file volume. Carried
+ * by the `materialize` sub-phase of {@link MountAssetSpaceParams.onProgress} so a
+ * slow install advances visibly (`N of M files`) instead of going silent.
+ */
+export interface MountFileProgress {
+  processed: number;
+  total: number;
+}
+
+/**
+ * Files between within-AS materialize progress ticks (al-mount-observability).
+ * Mirrors {@link NoteToRDFConverter.INDEX_PROGRESS_INTERVAL} (200) — keeps a
+ * ~5 000-file mount to ~25 activity-log lines.
+ */
+export const MATERIALIZE_PROGRESS_INTERVAL = 200;
+
+/**
+ * Minimum file count for a mount to emit granular materialize progress
+ * (al-mount-observability). A small AssetSpace materialises fast enough that the
+ * per-AS "Mounting … (i of N)" marker suffices; only large AssetSpaces went
+ * silent for ~100s during the file-write phase, so only those (strictly greater
+ * than this threshold) emit per-file ticks.
+ */
+export const MATERIALIZE_PROGRESS_MIN_FILES = 500;
+
 /** Parameters for {@link mountAssetSpaceFiles}. */
 export interface MountAssetSpaceParams {
   http: HttpClient;
@@ -199,8 +237,13 @@ export interface MountAssetSpaceParams {
    * BEFORE each phase (`fetch` → `extract` → `materialize`) so a long mount
    * shows live progress. Best-effort: a throwing observer is swallowed so it
    * can never break a mount. Omitted by the CLI bootstrap path (zero cost).
+   *
+   * The `materialize` phase additionally re-emits with a {@link MountFileProgress}
+   * payload every {@link MATERIALIZE_PROGRESS_INTERVAL} files for a large
+   * AssetSpace (> {@link MATERIALIZE_PROGRESS_MIN_FILES}) — al-mount-observability.
+   * The `progress` arg is `undefined` for the baseline phase markers.
    */
-  onProgress?: (phase: MountProgressPhase) => void;
+  onProgress?: (phase: MountProgressPhase, progress?: MountFileProgress) => void;
 }
 
 /**
@@ -218,10 +261,10 @@ export async function mountAssetSpaceFiles(params: MountAssetSpaceParams): Promi
   const { http, fs, owner, repo, ref, targetPath } = params;
   // Best-effort sub-phase progress (#al-activitylog-progress) — a throwing
   // observer must never break the mount.
-  const emit = (phase: MountProgressPhase): void => {
+  const emit = (phase: MountProgressPhase, progress?: MountFileProgress): void => {
     if (params.onProgress === undefined) return;
     try {
-      params.onProgress(phase);
+      params.onProgress(phase, progress);
     } catch {
       /* swallow — progress is best-effort, never blocks the mount */
     }
@@ -238,7 +281,29 @@ export async function mountAssetSpaceFiles(params: MountAssetSpaceParams): Promi
   const sha = extractShaFromWrapper(wrapper);
   const files = buildMountFiles(entries, wrapper);
   emit("materialize");
-  const fileCount = await fs.materialize(targetPath, files);
+  // Granular within-AS install progress (al-mount-observability). The file-write
+  // phase is the longest for a large AssetSpace and was previously silent (one
+  // "materialize" marker then ~100s of nothing on iPhone). Mirror the indexing
+  // observability (NoteToRDFConverter `Indexing vault: N of M` every 200): when
+  // the file volume exceeds the threshold, hand the platform's materialize a
+  // per-file tick and re-emit it throttled every N files, skipping the final
+  // tick (the post-mount "Mounted" marker covers completion). Below the
+  // threshold a small AS stays quiet — the per-AS "Mounting … (i of N)" marker
+  // is signal enough.
+  const total = files.length;
+  const trackProgress =
+    params.onProgress !== undefined && total > MATERIALIZE_PROGRESS_MIN_FILES;
+  const fileCount = await fs.materialize(
+    targetPath,
+    files,
+    trackProgress
+      ? (processed) => {
+          if (processed % MATERIALIZE_PROGRESS_INTERVAL === 0 && processed < total) {
+            emit("materialize", { processed, total });
+          }
+        }
+      : undefined,
+  );
   return { sha, fileCount };
 }
 

--- a/packages/core/tests/unit/services/assetspace/AssetSpaceMount.materializeProgress.test.ts
+++ b/packages/core/tests/unit/services/assetspace/AssetSpaceMount.materializeProgress.test.ts
@@ -1,0 +1,124 @@
+/**
+ * Unit tests for granular within-AS materialize progress (al-mount-observability).
+ *
+ * A large AssetSpace mount used to emit a single `materialize` sub-phase marker
+ * and then go silent for ~100s on iPhone while {@link FileSystemPort.materialize}
+ * wrote thousands of files in one batched call. The mount core now hands the
+ * platform a per-file tick and re-emits it throttled — `(processed, total)` every
+ * {@link MATERIALIZE_PROGRESS_INTERVAL} files — but ONLY for an AssetSpace with
+ * more than {@link MATERIALIZE_PROGRESS_MIN_FILES} files (a small AS stays quiet).
+ * This mirrors the indexing observability (`Indexing vault: N of M assets`).
+ */
+
+import { gzipSync } from "node:zlib";
+import { createTar } from "nanotar";
+import {
+  mountAssetSpaceFiles,
+  MATERIALIZE_PROGRESS_INTERVAL,
+  MATERIALIZE_PROGRESS_MIN_FILES,
+  type FileSystemPort,
+  type AssetSpaceHttpClient,
+  type MountProgressPhase,
+  type MountFileProgress,
+} from "../../../../src/index";
+
+const enc = (s: string): Uint8Array => new TextEncoder().encode(s);
+
+/** Gzipped GitHub-shape tarball with `count` flat `.md` files under the wrapper. */
+function makeTarballWithNFiles(wrapper: string, count: number): Uint8Array {
+  const files = Array.from({ length: count }, (_, i) => ({
+    name: `${wrapper}/f${i}.md`,
+    data: enc("x"),
+  }));
+  return gzipSync(Buffer.from(createTar(files)));
+}
+
+function fakeHttp(blob: Uint8Array): AssetSpaceHttpClient {
+  return { async fetchTarball() { return blob; } };
+}
+
+/**
+ * Fake FileSystemPort honouring the production contract: its `materialize`
+ * invokes `onFileWritten(processed)` after EACH file (exactly as the REST + CLI
+ * adapters do). The core owns the throttle, so this fake ticks every file.
+ */
+function tickingFs(): FileSystemPort {
+  return {
+    async exists() { return false; },
+    async read() { throw new Error("not used"); },
+    async write() { /* not used */ },
+    async removeDir() { /* not used */ },
+    async materialize(_targetPath, files, onFileWritten): Promise<number> {
+      let n = 0;
+      for (const _f of files) {
+        n++;
+        onFileWritten?.(n);
+      }
+      return n;
+    },
+  };
+}
+
+interface ProgressCapture {
+  phase: MountProgressPhase;
+  progress?: MountFileProgress;
+}
+
+async function mountAndCapture(fileCount: number): Promise<ProgressCapture[]> {
+  const events: ProgressCapture[] = [];
+  await mountAssetSpaceFiles({
+    http: fakeHttp(makeTarballWithNFiles(`kitelev-exoas-x-abc1234`, fileCount)),
+    fs: tickingFs(),
+    owner: "kitelev",
+    repo: "exoas-x",
+    ref: "main",
+    targetPath: "assetspaces/x",
+    onProgress: (phase, progress) => events.push({ phase, progress }),
+  });
+  return events;
+}
+
+describe("mountAssetSpaceFiles materialize progress", () => {
+  it("emits N-of-M file ticks every 200 files only for an AssetSpace with >500 files @req:eba100d5-503f-43e0-bd31-994dd6303c37", async () => {
+    const total = 1000;
+    const events = await mountAndCapture(total);
+
+    // Baseline phase markers (no progress payload) always fire in order.
+    const bareMaterialize = events.filter(
+      (e) => e.phase === "materialize" && e.progress === undefined,
+    );
+    expect(events.map((e) => e.phase).slice(0, 3)).toEqual(["fetch", "extract", "materialize"]);
+    expect(bareMaterialize).toHaveLength(1);
+
+    // Throttled file ticks: every INTERVAL files, skipping the final tick.
+    const ticks = events
+      .filter((e) => e.phase === "materialize" && e.progress !== undefined)
+      .map((e) => e.progress as MountFileProgress);
+    // 1000 files, interval 200 → ticks at 200,400,600,800 (NOT 1000).
+    expect(ticks.map((p) => p.processed)).toEqual([200, 400, 600, 800]);
+    // Each tick carries the AS volume as `total`.
+    expect(ticks.every((p) => p.total === total)).toBe(true);
+    // No tick at the final file (completion is covered by the post-mount marker).
+    expect(ticks.some((p) => p.processed === total)).toBe(false);
+    // Cadence sanity — interval is the mirror of indexing's 200.
+    expect(MATERIALIZE_PROGRESS_INTERVAL).toBe(200);
+  });
+
+  it("emits NO granular file tick for an AssetSpace at or below the 500-file threshold @req:eba100d5-503f-43e0-bd31-994dd6303c37", async () => {
+    // Exactly the threshold (500) — guard is strictly greater-than, so silent.
+    const events = await mountAndCapture(MATERIALIZE_PROGRESS_MIN_FILES);
+    const ticks = events.filter((e) => e.phase === "materialize" && e.progress !== undefined);
+    expect(ticks).toHaveLength(0);
+    // The baseline sub-phase markers still fire so the AS isn't fully silent.
+    expect(events.map((e) => e.phase)).toEqual(["fetch", "extract", "materialize"]);
+  });
+
+  it("starts emitting ticks once the volume exceeds the threshold (501 files)", async () => {
+    const events = await mountAndCapture(MATERIALIZE_PROGRESS_MIN_FILES + 1); // 501
+    const ticks = events
+      .filter((e) => e.phase === "materialize" && e.progress !== undefined)
+      .map((e) => (e.progress as MountFileProgress).processed);
+    // 501 files → ticks at 200,400 (600 > 501 never reached).
+    expect(ticks).toEqual([200, 400]);
+  });
+});

--- a/packages/obsidian-plugin/src/adapters/logging/activityFanIn.ts
+++ b/packages/obsidian-plugin/src/adapters/logging/activityFanIn.ts
@@ -116,6 +116,23 @@ export function progressToActivity(
     event.label && event.label !== asPrefix
       ? `${event.label} ${asPrefix}`
       : asPrefix;
+  // Within-AS install progress (al-mount-observability) — a throttled
+  // `materialize` tick carries the file count + the AS volume, rendered as
+  // `Installing my 08dd15ed: 400 of 5000 files (8%)` (interview-validated:
+  // files + percent), mirroring `Indexing vault: N of M assets`. The baseline
+  // per-AS / sub-phase markers (no file counts) keep the `(index of total)`
+  // AssetSpace-batch form.
+  if (event.fileTotal !== undefined && event.fileProcessed !== undefined) {
+    const pct =
+      event.fileTotal > 0
+        ? Math.round((event.fileProcessed / event.fileTotal) * 100)
+        : 0;
+    return {
+      category: "progress",
+      level: "info",
+      message: `${verb} ${labelPart}: ${event.fileProcessed} of ${event.fileTotal} files (${pct}%)`,
+    };
+  }
   return {
     category: "progress",
     level: "info",

--- a/packages/obsidian-plugin/src/infrastructure/adapters/ProfileApplyManager.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/ProfileApplyManager.ts
@@ -201,6 +201,16 @@ export type ApplyProgressEvent =
       index: number;
       /** Total count in the current op batch. */
       total: number;
+      /**
+       * Within-AS install progress (al-mount-observability) — files written so
+       * far during the `materialize` step. Present only on throttled materialize
+       * ticks for a large AssetSpace (> MATERIALIZE_PROGRESS_MIN_FILES); absent
+       * on the baseline per-AS / sub-phase markers. Distinct from
+       * {@link index}/{@link total} (which count AssetSpaces, not files).
+       */
+      fileProcessed?: number;
+      /** Within-AS install progress — the AssetSpace's total file volume. */
+      fileTotal?: number;
     }
   // Apply-tail RDF reindex (#al-activitylog-progress) — emitted BEFORE the
   // `rdfIndexer.refresh()` that follows mount/unmount, so the previously-silent
@@ -1805,7 +1815,7 @@ export class ProfileApplyManager {
             target.gitUrl,
             target.submodulePath,
             target.ref,
-            (step) =>
+            (step, progress) =>
               this.emitProgress({
                 op: "mount",
                 step,
@@ -1813,6 +1823,10 @@ export class ProfileApplyManager {
                 label: target.label,
                 index: i + 1,
                 total: toMaterialize.length,
+                // Within-AS install progress (al-mount-observability) — carried
+                // only on throttled `materialize` ticks for a large AssetSpace.
+                fileProcessed: progress?.processed,
+                fileTotal: progress?.total,
               }),
           );
         } catch (mountErr) {

--- a/packages/obsidian-plugin/src/infrastructure/adapters/RestAssetSpaceMount.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/RestAssetSpaceMount.ts
@@ -17,6 +17,7 @@ import {
   type MountFile,
   type MountResult,
   type MountProgressPhase,
+  type MountFileProgress,
 } from "@kitelev/exocortex-core";
 
 /**
@@ -113,10 +114,12 @@ export class RestAssetSpaceMount {
     /**
      * Optional sub-phase progress sink (#al-activitylog-progress) — forwarded
      * into {@link mountAssetSpaceFiles} so a long mount surfaces fetch → extract
-     * → materialize, finer than the caller's single "Mounting X" marker. Omitted
-     * by bootstrap/fetch-tracked callers (zero cost).
+     * → materialize, finer than the caller's single "Mounting X" marker. The
+     * `materialize` phase additionally carries a {@link MountFileProgress} payload
+     * every N files for a large AssetSpace (al-mount-observability). Omitted by
+     * bootstrap/fetch-tracked callers (zero cost).
      */
-    onProgress?: (phase: MountProgressPhase) => void,
+    onProgress?: (phase: MountProgressPhase, progress?: MountFileProgress) => void,
   ): Promise<RestMountResult> {
     const safePath = validateVaultPathArg(submodulePath);
     // Allowlist + owner/repo extraction (throws on traversal / non-github).
@@ -235,7 +238,11 @@ export class RestAssetSpaceMount {
       read: (p) => adapter.read(p),
       write: (p, c) => adapter.write(p, c),
       removeDir: (p) => adapter.rmdir(p, true),
-      async materialize(targetPath: string, files: MountFile[]): Promise<number> {
+      async materialize(
+        targetPath: string,
+        files: MountFile[],
+        onFileWritten?: (processed: number) => void,
+      ): Promise<number> {
         const ensureDir = async (dir: string): Promise<void> => {
           if (dir.length === 0) return;
           if (!(await adapter.exists(dir))) await adapter.mkdir(dir);
@@ -266,6 +273,9 @@ export class RestAssetSpaceMount {
           if (parent.length > 0) await ensureDirChain(parent);
           await adapter.writeBinary(target, toArrayBuffer(file.content));
           count++;
+          // Per-file install progress tick (al-mount-observability) — the core
+          // throttles this to every N files for a large AssetSpace.
+          onFileWritten?.(count);
         }
         return count;
       },

--- a/packages/obsidian-plugin/tests/unit/adapters/logging/activityFanIn.test.ts
+++ b/packages/obsidian-plugin/tests/unit/adapters/logging/activityFanIn.test.ts
@@ -180,6 +180,41 @@ describe("progressToActivity (live materialize progress feed)", () => {
     ).toBe("Installing ems 1b20a8f0 (2 of 5)");
   });
 
+  // ── al-mount-observability: granular within-AS install file progress ──
+
+  it("formats a within-AS materialize file tick as 'Installing <label> <uid8>: N of M files (X%)' @req:eba100d5-503f-43e0-bd31-994dd6303c37", () => {
+    expect(
+      progressToActivity(
+        evt({
+          op: "mount",
+          step: "materialize",
+          label: "my",
+          as: "08dd15ed-0000-0000-0000-000000000000",
+          fileProcessed: 400,
+          fileTotal: 5000,
+        }),
+      ),
+    ).toEqual({
+      category: "progress",
+      level: "info",
+      message: "Installing my 08dd15ed: 400 of 5000 files (8%)",
+    });
+  });
+
+  it("rounds the install percent (200 of 1000 → 20%) @req:eba100d5-503f-43e0-bd31-994dd6303c37", () => {
+    expect(
+      progressToActivity(
+        evt({ op: "mount", step: "materialize", fileProcessed: 200, fileTotal: 1000 }),
+      ).message,
+    ).toBe("Installing ems 1b20a8f0: 200 of 1000 files (20%)");
+  });
+
+  it("a materialize event WITHOUT file counts keeps the per-AS '(N of M)' form (no regression)", () => {
+    expect(
+      progressToActivity(evt({ op: "mount", step: "materialize", index: 3, total: 7 })).message,
+    ).toBe("Installing ems 1b20a8f0 (3 of 7)");
+  });
+
   it("reindex marker → 'Reindexing vault after apply' (category 'progress', info)", () => {
     expect(progressToActivity({ op: "reindex" })).toEqual({
       category: "progress",


### PR DESCRIPTION
## Problem

Applying a profile that materializes a large AssetSpace on iPhone went **silent
for ~100s** during the file-write phase. The apply log showed a single
`Installing my 08dd15ed (1 of 7)` line and then nothing until `Mounted` — the
user couldn't tell whether materialization was progressing or hung. The per-AS
`(1 of 7)` counts AssetSpaces, not files within an AssetSpace; `mountAssetSpaceFiles`
wrote every file in one batched `FileSystemPort.materialize` call with no
per-file feedback.

Empirical (Andrey, iPhone bootstrap `$$kitelev-my`): `my` Installing 13:30:00 →
Mounted 13:31:40 = ~100s; `shared-private` ~117s.

## Fix — mirror the indexing observability

Vault indexing already shows `Indexing vault: N of M assets` every 200 files and
works well. This mirrors it for the mount's file-write (Installing) phase:

- **`core/AssetSpaceMount`**: `FileSystemPort.materialize` gains an optional
  `onFileWritten(processed)` tick. `mountAssetSpaceFiles`, when the file volume
  is **> 500** (`MATERIALIZE_PROGRESS_MIN_FILES`), re-emits the tick throttled
  **every 200** files (`MATERIALIZE_PROGRESS_INTERVAL`, == indexing's interval),
  carrying the AS file volume, skipping the final tick (the post-mount marker
  covers completion). A small AS (≤500) stays quiet — the per-AS marker is enough.
- **`RestAssetSpaceMount` (iPhone) + `BootstrapAssetSpaceService` (CLI)**:
  `materialize` calls the tick per written file.
- **`ProfileApplyManager`**: forwards `fileProcessed`/`fileTotal` on `materialize`
  ticks (distinct from per-AS `index`/`total`).
- **`activityFanIn.progressToActivity`**: formats `Installing <label> <uid8>: N of M files (X%)`.

Interview-validated content (Andrey 2026-06-22): files + percent; Installing
phase only; every 200, only AS > 500 files.

### Log: before → after (large AS)
```
before:  Installing my 08dd15ed (1 of 7)           ← then ~100s of silence
after:   Installing my 08dd15ed: 200 of 5000 files (4%)
         Installing my 08dd15ed: 400 of 5000 files (8%)
         ...
         Mounted my 08dd15ed (101230ms)
```

## Tests
- `AssetSpaceMount.materializeProgress.test.ts` (core, 3) — throttle/threshold/volume; **revert-verified RED→GREEN** (disabling the `>500` gate fails 2/3).
- `activityFanIn.test.ts` (+3) — `N of M files (X%)` format, percent rounding, no-regression of the bare `(N of M)` form.
- Regression green: AssetSpaceMount 20/20, RestAssetSpaceMount 17/17, ProfileApplyManager 128/128, CLI bootstrap 88/88.
- All impl points additive (optional params/fields) — bootstrap/CLI paths without `onProgress` are zero-cost.

Requirement: `req:eba100d5-503f-43e0-bd31-994dd6303c37` (exoas-exo-reqs). WBS `567d6dcb` (Alpha Launch M3).
