### PR TITLE
test(framework): improvement-plan cluster 1 — burndown + over-mock & coverage-monotonic ratchets + lift docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -169,6 +169,14 @@ jobs:
       - name: Guard test anti-patterns
         run: bash scripts/check-test-antipatterns.sh
 
+      # Test-quality audit 2026-06-22 (recommendation P5.1): coverage-monotonic
+      # ratchet. jest coverageThreshold.global metrics may only GROW; this fails
+      # the lint job if any threshold drifts BELOW the high-water mark recorded
+      # in scripts/coverage-thresholds-baseline.json. Lowering a baseline number
+      # is the explicit, req-justified withdrawal (RFC 0003 everything-req-first).
+      - name: Guard coverage-threshold monotonicity
+        run: node scripts/check-coverage-monotonic.mjs
+
   docs-link-check:
     runs-on: ubuntu-latest
     timeout-minutes: 3

--- a/TESTING.md
+++ b/TESTING.md
@@ -654,6 +654,66 @@ const metadata = createMockMetadata({
 const metadata = createMockMetadata({ exo__Asset_label: null });
 ```
 
+#### Lift over-mock service-wrappers to integration
+
+> Test-quality audit 2026-06-22, P3.1 (Testing-Trophy opportunistic-lift policy).
+
+When you **touch** a plugin service-wrapper test that wholesale-mocks a central
+collaborator (`@kitelev/exocortex-core` / `-services`, `VaultRDFIndexer`, a
+`/services/` / `/adapters/` / `/infrastructure/` module) and asserts **only
+delegation** (`expect(mockX.foo).toHaveBeenCalled()`) with **no output-value
+assertion**, lift it to a `*.integration.test.ts` that drives the **real**
+collaborator. A pass-through test proves "the call was forwarded" but never
+exercises the behaviour the user depends on — and it breaks on any valid
+internal refactor while a real bug (wrong query, wrong mapping) slips through.
+
+**The correct seam is the Obsidian platform boundary only** (vault /
+metadataCache). Everything inside `@kitelev/exocortex-*` stays REAL (jest maps
+the workspace packages to source). Fake a realistic in-memory `App` whose
+`getMarkdownFiles()` / `getFileCache().frontmatter` / `read()` mirror the real
+Obsidian read contract, then assert on the real solution mappings.
+
+**Exemplar:** `packages/obsidian-plugin/tests/unit/services/SPARQLQueryService.integration.test.ts`.
+The old over-mock unit (`SPARQLQueryService.test.ts`) fully mocked
+`VaultRDFIndexer` and asserted only `initialize/refresh/dispose
+toHaveBeenCalled` — the service's primary method (`query()` actually parsing +
+executing SPARQL) was never exercised. It was deleted and replaced by an
+integration suite where the whole engine stack is real (`ObsidianVaultAdapter` →
+`NoteToRDFConverter` → `InMemoryTripleStore` → `ExoQLParser`/executor) and only
+the Obsidian boundary is faked.
+
+```typescript
+// ❌ over-mock pass-through (delegation only — verifies nothing real)
+jest.mock("@kitelev/exocortex-core", () => ({ VaultRDFIndexer: jest.fn() }));
+it("refreshes the index", async () => {
+  await service.query("SELECT ...");
+  expect(mockIndexer.refresh).toHaveBeenCalled(); // only that a call happened
+});
+
+// ✅ integration lift (real engine, fake only the Obsidian boundary)
+it("returns the assets matching the SPARQL query", async () => {
+  const { app } = buildApp([
+    {
+      path: "a.md",
+      frontmatter: {
+        /* real fm */
+      },
+    },
+  ]);
+  const service = new SPARQLQueryService(app); // real VaultRDFIndexer underneath
+  const rows = await service.query("SELECT ?s WHERE { ?s a exo:Asset }");
+  expect(rows).toEqual([{ s: "https://exocortex.my/...a" }]); // real solution mapping
+});
+```
+
+**Policy:** lift **by touch**, not as a big-bang sweep (cascade-cap — each lift is
+independent and revert-verifiable). The
+[`scripts/check-test-antipatterns.sh`](scripts/check-test-antipatterns.sh)
+over-mock ratchet (baseline 0) bans **introducing** a NEW pure pass-through
+over-mock file, so the shift is self-sustaining without relying on reviewer
+memory: a new plugin service-wrapper test must drive a real collaborator or it
+fails the `lint` gate.
+
 ### Async Testing
 
 #### Testing Promises

--- a/packages/core/tests/unit/services/SessionEventService.branch.test.ts
+++ b/packages/core/tests/unit/services/SessionEventService.branch.test.ts
@@ -114,14 +114,28 @@ describe("SessionEventService - branch coverage", () => {
       expect(filePath).toMatch(/^[0-9a-f-]+\.md$/);
     });
 
-    it("should cache folder path after first call", async () => {
+    it("creates each event under the resolved default folder across consecutive calls", async () => {
       mockVault.getDefaultNewFileParent.mockReturnValue({ path: "cached-folder", name: "cached-folder" });
 
       await service.createSessionStartEvent("Area1");
       await service.createSessionEndEvent("Area1");
 
-      // getDefaultNewFileParent should only be called once due to caching
-      expect(mockVault.getDefaultNewFileParent).toHaveBeenCalledTimes(1);
+      // BEHAVIOUR, not memoization (test-quality audit 2026-06-22, P1.1):
+      // the old assertion pinned `getDefaultNewFileParent` CALL COUNT (== 1),
+      // which couples the test to an internal cache optimization — it breaks on
+      // a valid refactor (removing the cache) even though the observable
+      // behaviour is unchanged, and it never verifies the folder is actually
+      // applied. Assert the OUTCOME instead: both consecutive events land under
+      // the resolved default folder. This survives the cache being removed and
+      // still catches a real regression (the 2nd event no longer placed in the
+      // resolved folder).
+      expect(mockVault.create).toHaveBeenCalledTimes(2);
+      expect(mockVault.create.mock.calls[0][0]).toMatch(
+        /^cached-folder\/[0-9a-f-]+\.md$/,
+      );
+      expect(mockVault.create.mock.calls[1][0]).toMatch(
+        /^cached-folder\/[0-9a-f-]+\.md$/,
+      );
     });
 
     it("should handle empty folder path (no folder creation needed)", async () => {

--- a/packages/obsidian-plugin/tests/unit/ProfileApplyManager.test.ts
+++ b/packages/obsidian-plugin/tests/unit/ProfileApplyManager.test.ts
@@ -357,7 +357,12 @@ describe("ProfileApplyManager.reindexMountState — happy path (apply reindex)",
     expect(lines).toHaveLength(2);
     expect(lines[0].phase).toBe("starting");
     expect(lines[1].phase).toBe("completed");
-    expect(lines[1].elapsedMs).toBeGreaterThanOrEqual(0);
+    // Non-vacuous (test-quality audit 2026-06-22, P1.3): the old ">= 0"
+    // duration assert is always true and verifies nothing about the value.
+    // Assert the completed entry actually CARRIES a numeric elapsedMs — this
+    // fails if the field is dropped/undefined (a real regression), without the
+    // vacuous always-true value claim.
+    expect(typeof lines[1].elapsedMs).toBe("number");
   });
 
   it("notifies user with profile label + elapsed ms", async () => {

--- a/packages/obsidian-plugin/tests/unit/build/check-coverage-monotonic.test.ts
+++ b/packages/obsidian-plugin/tests/unit/build/check-coverage-monotonic.test.ts
@@ -1,0 +1,103 @@
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import * as path from "path";
+import { spawnSync } from "child_process";
+
+/**
+ * Coverage-monotonic ratchet guard — revert-verify binding.
+ *
+ * Test-quality audit 2026-06-22, recommendation P5.1. `scripts/check-coverage-monotonic.mjs`
+ * enforces that every jest `coverageThreshold.global` metric stays AT or ABOVE
+ * the high-water mark in `scripts/coverage-thresholds-baseline.json`. Thresholds
+ * may rise freely; a value drifting BELOW baseline (the documented plugin
+ * branches 64->63 "marginal failure" smell) fails the guard. Lowering a baseline
+ * number is the explicit, req-justified withdrawal (RFC 0003).
+ *
+ * This test drives the REAL guard script against fixture jest configs + a
+ * fixture baseline (via `COVERAGE_ROOT` + `COVERAGE_BASELINE`) and asserts the
+ * revert-verify contract:
+ *   • a fixture threshold BELOW baseline → exit 1 (coverage regression)
+ *   • the threshold restored to baseline → exit 0
+ *   • a threshold ABOVE baseline (growth) → exit 0.
+ *
+ * @req:289f87f4-23c8-4106-8069-0823c45167fe
+ */
+describe("check-coverage-monotonic.mjs — coverage-threshold monotonicity (P5.1, @req:289f87f4)", () => {
+  const repoRoot = path.resolve(__dirname, "../../../../..");
+  const scriptPath = path.join(repoRoot, "scripts/check-coverage-monotonic.mjs");
+
+  let fixtureRoot: string;
+  let configPath: string;
+  let baselinePath: string;
+
+  const writeConfig = (branches: number) => {
+    writeFileSync(
+      configPath,
+      [
+        "module.exports = {",
+        "  coverageThreshold: {",
+        `    global: { branches: ${branches}, functions: 70, lines: 65, statements: 65 },`,
+        "  },",
+        "};",
+        "",
+      ].join("\n"),
+    );
+  };
+
+  const runGuard = () =>
+    spawnSync("node", [scriptPath], {
+      cwd: repoRoot,
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        COVERAGE_ROOT: fixtureRoot,
+        COVERAGE_BASELINE: baselinePath,
+      },
+    });
+
+  beforeEach(() => {
+    fixtureRoot = mkdtempSync(path.join(tmpdir(), "coverage-monotonic-"));
+    mkdirSync(path.join(fixtureRoot, "packages/foo"), { recursive: true });
+    configPath = path.join(fixtureRoot, "packages/foo/jest.config.js");
+    baselinePath = path.join(fixtureRoot, "baseline.json");
+    // High-water mark: branches must be >= 63.
+    writeFileSync(
+      baselinePath,
+      JSON.stringify({
+        thresholds: {
+          "packages/foo/jest.config.js": {
+            branches: 63,
+            functions: 70,
+            lines: 65,
+            statements: 65,
+          },
+        },
+      }),
+    );
+  });
+
+  afterEach(() => {
+    rmSync(fixtureRoot, { recursive: true, force: true });
+  });
+
+  it("FAILS (exit 1) when a threshold drifts BELOW baseline", () => {
+    writeConfig(60); // branches 60 < baseline 63
+    const r = runGuard();
+    expect(r.status).toBe(1);
+    expect(r.stderr).toContain("below baseline");
+    expect(r.stderr).toContain("branches: 60 < baseline 63");
+  });
+
+  it("PASSES (exit 0) when the threshold is restored to baseline (revert-verify GREEN)", () => {
+    writeConfig(63); // == baseline
+    const r = runGuard();
+    expect(r.status).toBe(0);
+    expect(r.stdout).toContain("coverage-monotonic guard OK");
+  });
+
+  it("PASSES (exit 0) when a threshold GROWS above baseline (ratchet up allowed)", () => {
+    writeConfig(70); // > baseline 63
+    const r = runGuard();
+    expect(r.status).toBe(0);
+  });
+});

--- a/packages/obsidian-plugin/tests/unit/build/check-test-antipatterns-overmock.test.ts
+++ b/packages/obsidian-plugin/tests/unit/build/check-test-antipatterns-overmock.test.ts
@@ -1,0 +1,122 @@
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import * as path from "path";
+import { spawnSync } from "child_process";
+
+/**
+ * Over-mock pass-through ratchet guard — revert-verify binding.
+ *
+ * Test-quality audit 2026-06-22, recommendation P2. `scripts/check-test-antipatterns.sh`
+ * was extended with a 4th ratchet: it FAILS when a NEW test file wholesale-mocks
+ * a central internal collaborator (`@kitelev/exocortex-core`/`-services`, or a
+ * relative mock of `/services/`, `/adapters/`, `/infrastructure/`,
+ * `VaultRDFIndexer`) AND asserts ONLY delegation (`toHaveBeenCalled*`) with NO
+ * output-value assertion anywhere in the file. That is the pure pass-through
+ * service-wrapper shape (the deleted-and-lifted `SPARQLQueryService.test.ts`),
+ * which verifies a call was forwarded but never exercises real behaviour — the
+ * Testing-Trophy shift (P3) wants such tests written as `*.integration.test.ts`
+ * driving the real collaborator instead. Baseline is 0 (no pure pass-through
+ * over-mock file exists today), so the guard bans introducing one.
+ *
+ * This test drives the REAL guard script against a fixture corpus (via the
+ * `ANTIPATTERN_SCAN_DIR` + `BASELINE_*` env overrides) and asserts the
+ * RED-without / GREEN-with revert-verify contract:
+ *   • a fixture over-mock pass-through file present  → exit 1 (count 1 > baseline 0)
+ *   • the over-mock file removed                     → exit 0
+ *   • a file that mocks the same collaborator but ALSO asserts output is NOT
+ *     flagged (the output-assertion exclusion has teeth).
+ *
+ * @req:427530e2-6365-48ae-9bfc-513180333ecd
+ */
+describe("check-test-antipatterns.sh — over-mock pass-through ratchet (P2, @req:427530e2)", () => {
+  const repoRoot = path.resolve(__dirname, "../../../../..");
+  const scriptPath = path.join(repoRoot, "scripts/check-test-antipatterns.sh");
+
+  // High baselines for the unrelated ratchets so ONLY the over-mock check can
+  // drive the verdict against the fixture; over-mock baseline pinned at 0.
+  const isolatingEnv = {
+    BASELINE_METHOD_EXISTS: "999",
+    BASELINE_VACUOUS_LENGTH: "999",
+    BASELINE_NONCANON_SERVICE_DIR: "999",
+    BASELINE_OVERMOCK: "0",
+  };
+
+  let scanDir: string;
+
+  const runGuard = (extraEnv: Record<string, string>) =>
+    spawnSync("bash", [scriptPath], {
+      cwd: repoRoot,
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        ...isolatingEnv,
+        ANTIPATTERN_SCAN_DIR: scanDir,
+        ANTIPATTERN_NONCANON_DIR: path.join(scanDir, "__no_such_dir__"),
+        ...extraEnv,
+      },
+    });
+
+  const writeCleanFile = () => {
+    // Mocks the same central collaborator wholesale, but asserts OUTPUT — so it
+    // is NOT a pure pass-through and must NOT be flagged.
+    writeFileSync(
+      path.join(scanDir, "pkg/tests/clean.test.ts"),
+      [
+        'jest.mock("@kitelev/exocortex-core", () => ({ Foo: jest.fn() }));',
+        'it("does real work", () => {',
+        "  expect(result).toEqual({ a: 1 });",
+        "  expect(mock.bar).toHaveBeenCalled();",
+        "});",
+        "",
+      ].join("\n"),
+    );
+  };
+
+  const writeOverMockFile = () => {
+    writeFileSync(
+      path.join(scanDir, "pkg/tests/overmock.test.ts"),
+      [
+        'jest.mock("@kitelev/exocortex-core", () => ({ Indexer: jest.fn() }));',
+        'it("delegates initialize", () => {',
+        "  service.initialize();",
+        "  expect(mockIndexer.initialize).toHaveBeenCalled();",
+        "  expect(mockIndexer.refresh).toHaveBeenCalledTimes(1);",
+        "});",
+        "",
+      ].join("\n"),
+    );
+  };
+
+  beforeEach(() => {
+    scanDir = mkdtempSync(path.join(tmpdir(), "antipattern-overmock-"));
+    mkdirSync(path.join(scanDir, "pkg/tests"), { recursive: true });
+    writeCleanFile();
+  });
+
+  afterEach(() => {
+    rmSync(scanDir, { recursive: true, force: true });
+  });
+
+  it("FAILS (exit 1) when a NEW over-mock pass-through file is present", () => {
+    writeOverMockFile();
+    const r = runGuard({});
+    expect(r.status).toBe(1);
+    expect(r.stdout).toContain("over-mock pass-through service-wrappers increased");
+    expect(r.stdout).toContain("overmock.test.ts");
+  });
+
+  it("PASSES (exit 0) once the over-mock file is removed (revert-verify GREEN)", () => {
+    // Only the clean file remains (mocks core + asserts output) → not flagged.
+    const r = runGuard({});
+    expect(r.status).toBe(0);
+    expect(r.stdout).toContain("over-mock=0/0");
+  });
+
+  it("does NOT flag a wholesale-mock file that also asserts output", () => {
+    // The clean fixture mocks @kitelev/exocortex-core AND has toHaveBeenCalled,
+    // but it also asserts an output value (toEqual) — so it is real behaviour
+    // verification, not pure pass-through. Guard must stay green.
+    const r = runGuard({});
+    expect(r.status).toBe(0);
+  });
+});

--- a/scripts/check-coverage-monotonic.mjs
+++ b/scripts/check-coverage-monotonic.mjs
@@ -1,0 +1,144 @@
+#!/usr/bin/env node
+//
+// check-coverage-monotonic.mjs — ratchet guard: jest coverage thresholds may
+// only GROW, never silently drop.
+//
+// Source: test-quality audit 2026-06-22, recommendation P5.1. The audit (§
+// coverage) flagged that the obsidian-plugin branch threshold had drifted DOWN
+// (64 -> 63) and statements down (76 -> 75.5) "due to marginal failure" — a
+// soft smell: a threshold lowered to make a red build pass is a coverage
+// regression hidden as a config tweak.
+//
+// Mechanism: scripts/coverage-thresholds-baseline.json records the high-water
+// mark for every jest.config.js coverageThreshold.global metric. This guard
+// reads each config's CURRENT thresholds and FAILS (exit 1) if any metric is
+// BELOW its baseline. Thresholds may rise freely (ratchet the baseline number
+// UP — allowed). LOWERING is only possible by editing the baseline number down
+// — a conscious, reviewed act that, under everything-req-first (RFC 0003), must
+// carry a req__Requirement justification. So a coverage threshold can never
+// silently drift down: the config must stay >= baseline, and moving the
+// baseline down is the explicit withdrawal.
+//
+// Wired into the required `lint` CI job (alongside check-test-antipatterns.sh).
+//
+// Usage:
+//   node scripts/check-coverage-monotonic.mjs            # CI gate
+//
+// Testability (the @req binding test drives the guard against a fixture):
+//   COVERAGE_BASELINE  — path to the baseline JSON (default: <root>/scripts/coverage-thresholds-baseline.json)
+//   COVERAGE_ROOT      — root that config paths in the baseline resolve against (default: repo root)
+
+import { readFileSync } from "fs";
+import { dirname, resolve } from "path";
+import { fileURLToPath } from "url";
+
+const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(SCRIPT_DIR, "..");
+
+const baselinePath =
+  process.env.COVERAGE_BASELINE ??
+  resolve(SCRIPT_DIR, "coverage-thresholds-baseline.json");
+const configRoot = process.env.COVERAGE_ROOT ?? REPO_ROOT;
+
+/**
+ * Extract the coverageThreshold.global metric numbers from a jest config's
+ * source text. Regex-based (the config is a JS module that may import other
+ * modules, so importing it is unsafe — mirrors the esbuild-config text-assert
+ * precedent). The `global` block contains only `metric: number` pairs and no
+ * nested braces, so a non-greedy `{...}` capture is robust.
+ *
+ * @param {string} text jest.config.js source
+ * @returns {Record<string, number>} e.g. { branches: 95, functions: 95, ... }
+ */
+function extractThresholds(text) {
+  const ctIdx = text.indexOf("coverageThreshold");
+  if (ctIdx === -1) return {};
+  const fromCt = text.slice(ctIdx);
+  const globalMatch = fromCt.match(/global\s*:\s*\{([^}]*)\}/);
+  if (!globalMatch) return {};
+  const body = globalMatch[1];
+  /** @type {Record<string, number>} */
+  const out = {};
+  const pairRe = /(\w+)\s*:\s*([\d.]+)/g;
+  let m;
+  while ((m = pairRe.exec(body)) !== null) {
+    out[m[1]] = Number(m[2]);
+  }
+  return out;
+}
+
+function loadBaseline(path) {
+  const parsed = JSON.parse(readFileSync(path, "utf8"));
+  // Support both the wrapped shape ({_comment, thresholds:{...}}) and a bare map.
+  return parsed.thresholds ?? parsed;
+}
+
+function main() {
+  let baseline;
+  try {
+    baseline = loadBaseline(baselinePath);
+  } catch (e) {
+    console.error(
+      `❌ coverage-monotonic guard: could not read baseline ${baselinePath}: ${e.message}`,
+    );
+    process.exit(1);
+  }
+
+  const violations = [];
+  const summary = [];
+
+  for (const [configRel, baseMetrics] of Object.entries(baseline)) {
+    const configAbs = resolve(configRoot, configRel);
+    let current;
+    try {
+      current = extractThresholds(readFileSync(configAbs, "utf8"));
+    } catch (e) {
+      violations.push(
+        `${configRel}: cannot read config (${e.message}) — a tracked jest config must exist`,
+      );
+      continue;
+    }
+    for (const [metric, baseVal] of Object.entries(baseMetrics)) {
+      const cur = current[metric];
+      if (cur === undefined) {
+        violations.push(
+          `${configRel} ${metric}: threshold REMOVED (baseline ${baseVal}) — a tracked coverage threshold may not be deleted`,
+        );
+        continue;
+      }
+      if (cur < baseVal) {
+        violations.push(
+          `${configRel} ${metric}: ${cur} < baseline ${baseVal} — coverage threshold lowered`,
+        );
+      } else {
+        summary.push(`${configRel} ${metric}=${cur} (>=${baseVal})`);
+      }
+    }
+  }
+
+  if (violations.length > 0) {
+    console.error(
+      `❌ coverage-monotonic guard: ${violations.length} threshold(s) below baseline (coverage regression):`,
+    );
+    for (const v of violations) console.error(`   ${v}`);
+    console.error(
+      "\n   Coverage thresholds may only GROW. To raise a threshold, ratchet the",
+    );
+    console.error(
+      "   number UP in scripts/coverage-thresholds-baseline.json (allowed).",
+    );
+    console.error(
+      "   LOWERING a baseline number is a coverage regression that requires an",
+    );
+    console.error(
+      "   explicit req__Requirement justification (RFC 0003 everything-req-first).",
+    );
+    process.exit(1);
+  }
+
+  console.log(
+    `✅ coverage-monotonic guard OK — ${summary.length} threshold(s) at or above baseline (no downward drift).`,
+  );
+}
+
+main();

--- a/scripts/check-test-antipatterns.sh
+++ b/scripts/check-test-antipatterns.sh
@@ -30,6 +30,25 @@
 #      ratchet only prevents the legacy dir from GROWING. A new test added there
 #      fails the guard with a pointer to the canon dir.
 #
+#   4. over-mock pass-through service-wrappers — a test file that wholesale-mocks
+#      a CENTRAL internal collaborator (`@kitelev/exocortex-core`/`-services`, or
+#      a relative mock of `/services/`, `/adapters/`, `/infrastructure/`,
+#      `VaultRDFIndexer`) AND asserts ONLY delegation (`toHaveBeenCalled*`) with
+#      ZERO output-value assertions in the whole file. Such a test verifies the
+#      service forwarded a call but NEVER exercises the real behaviour — exactly
+#      the shape the audit's Testing-Trophy shift targets (P2 + P3). The
+#      canonical example (`SPARQLQueryService.test.ts`) was DELETED and lifted to
+#      `SPARQLQueryService.integration.test.ts` (real engine stack, faking only
+#      the Obsidian boundary), so the current baseline is 0 — there are no pure
+#      pass-through over-mock files today. This ratchet bans INTRODUCING a new
+#      one: a new plugin service-wrapper test must drive a real collaborator
+#      (lift to `*.integration.test.ts`) instead of mocking it and asserting
+#      delegation. See TESTING.md §"Lift over-mock service-wrappers to integration".
+#      Like the method-exists guard the detection is heuristic (FP-tolerant): the
+#      file-level "no output-value assertion anywhere" filter is narrow (almost
+#      every real test asserts an output), and a justified exception bumps the
+#      baseline UP with a PR comment (the same escape hatch as the other ratchets).
+#
 # Mechanism: count current occurrences across all test files and FAIL if the
 # count exceeds the committed baseline. This bans NEW occurrences (recidivism)
 # while grandfathering the existing debt. As the debt is cleaned, ratchet the
@@ -39,6 +58,13 @@
 # Usage:
 #   bash scripts/check-test-antipatterns.sh                 # CI gate
 #   bash scripts/check-test-antipatterns.sh --update-baseline  # print current counts
+#
+# Testability (the @req binding test drives the guard against a fixture tree):
+#   ANTIPATTERN_SCAN_DIR    — test-corpus root to scan (default: packages)
+#   ANTIPATTERN_NONCANON_DIR— legacy non-canon service dir (default: packages/core/tests/services)
+#   BASELINE_METHOD_EXISTS / BASELINE_VACUOUS_LENGTH /
+#   BASELINE_NONCANON_SERVICE_DIR / BASELINE_OVERMOCK — override the committed
+#   baselines (used by the guard's own revert-verify test, never in CI).
 
 set -u
 
@@ -46,41 +72,80 @@ ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$ROOT"
 
 # --- Baselines (grandfathered existing occurrences). Ratchet DOWN as cleaned. ---
-BASELINE_METHOD_EXISTS=55
-BASELINE_VACUOUS_LENGTH=22
+# Env-overridable so the guard's own @req binding test can force a RED/GREEN
+# verdict against a fixture corpus without touching the real tree (the defaults
+# are the committed baselines used in CI).
+BASELINE_METHOD_EXISTS="${BASELINE_METHOD_EXISTS:-55}"
+BASELINE_VACUOUS_LENGTH="${BASELINE_VACUOUS_LENGTH:-21}"
 # Legacy non-canon core service-test dir. Canon for NEW tests is
 # packages/core/tests/unit/services/. This grandfathers the existing files and
 # bans growth (see header item 3). Ratchet DOWN if legacy files are removed.
-BASELINE_NONCANON_SERVICE_DIR=24
+BASELINE_NONCANON_SERVICE_DIR="${BASELINE_NONCANON_SERVICE_DIR:-24}"
+# Over-mock pass-through service-wrappers (header item 4). Baseline 0 — the
+# canonical over-mock was lifted to an integration suite, so no pure pass-through
+# over-mock file exists today. Bans introducing one.
+BASELINE_OVERMOCK="${BASELINE_OVERMOCK:-0}"
+
+# Scan root (default: the whole monorepo packages tree). Overridable for the
+# guard's revert-verify test (points at a fixture corpus).
+SCAN_DIR="${ANTIPATTERN_SCAN_DIR:-packages}"
 
 # --- Patterns (must match the grep used to compute the baselines above). ---
 ME_PATTERN="\.toBe\((\"|')function(\"|')\)"
 VL_PATTERN="toBeGreaterThanOrEqual\(0\)"
 
+# over-mock detection patterns (header item 4):
+#  - OM_MOCK: a wholesale jest.mock() of a CENTRAL internal collaborator. Matches
+#    the core/services workspace packages and relative mocks into the
+#    service/adapter/infrastructure layers (the central-collaborator surface),
+#    NOT platform mocks like jest.mock("obsidian").
+#  - OM_OUTPUT_ASSERT: any output-VALUE assertion. A file carrying one is NOT a
+#    pure pass-through (it exercises real behaviour) → excluded.
+OM_MOCK="jest\.mock\((\"|')[^\"']*(@kitelev/exocortex-(core|services)|/services/|/adapters/|/infrastructure/|VaultRDFIndexer)"
+OM_OUTPUT_ASSERT="\.(toEqual|toStrictEqual|toMatchObject|toMatchSnapshot|toContain|toContainEqual|toHaveLength|toHaveProperty|toMatch|toThrow|toThrowError|toBeTruthy|toBeFalsy|toBeDefined|toBeNull|toBeNaN|toBeInstanceOf|toBeGreaterThan|toBeGreaterThanOrEqual|toBeLessThan|toBeLessThanOrEqual|toBeCloseTo)\(|\.toBe\(|resolves|rejects"
+
 # Canon-dir guideline: count .test.ts files in the legacy non-canon dir.
-NONCANON_SERVICE_DIR="packages/core/tests/services"
+NONCANON_SERVICE_DIR="${ANTIPATTERN_NONCANON_DIR:-packages/core/tests/services}"
 
 count() {
   # Line count of matches across all test files. grep exits 1 on no match;
   # the trailing `| wc -l` makes the pipeline's exit status wc's (0), and we
   # avoid `set -e`/pipefail so a zero count never aborts the script.
-  grep -rnE "$1" packages --include='*.test.ts' --include='*.test.tsx' 2>/dev/null | wc -l | tr -d ' '
+  grep -rnE "$1" "$SCAN_DIR" --include='*.test.ts' --include='*.test.tsx' 2>/dev/null | wc -l | tr -d ' '
 }
 
 list_files() {
-  grep -rlE "$1" packages --include='*.test.ts' --include='*.test.tsx' 2>/dev/null | sed 's/^/     /'
+  grep -rlE "$1" "$SCAN_DIR" --include='*.test.ts' --include='*.test.tsx' 2>/dev/null | sed 's/^/     /'
+}
+
+# Count test files that are over-mock pass-through service-wrappers: wholesale
+# mock a central collaborator AND assert delegation (toHaveBeenCalled) AND have
+# NO output-value assertion anywhere in the file. Emits one path per match on
+# stdout; callers `| wc -l` to count or read the list directly.
+overmock_files() {
+  grep -rlE "$OM_MOCK" "$SCAN_DIR" --include='*.test.ts' --include='*.test.tsx' 2>/dev/null |
+    while IFS= read -r f; do
+      [ -z "$f" ] && continue
+      # Must assert delegation …
+      grep -qE 'toHaveBeenCalled' "$f" || continue
+      # … and carry NO output-value assertion (pure pass-through).
+      grep -qE "$OM_OUTPUT_ASSERT" "$f" && continue
+      echo "$f"
+    done
 }
 
 ME_COUNT="$(count "$ME_PATTERN")"
 VL_COUNT="$(count "$VL_PATTERN")"
 # Top-level .test.ts files in the legacy non-canon service dir (flat dir).
 NONCANON_COUNT="$(find "$NONCANON_SERVICE_DIR" -maxdepth 1 -name '*.test.ts' 2>/dev/null | wc -l | tr -d ' ')"
+OVERMOCK_COUNT="$(overmock_files | sed '/^$/d' | wc -l | tr -d ' ')"
 
 if [ "${1:-}" = "--update-baseline" ]; then
   echo "Current counts (paste into this script's BASELINE_* values):"
   echo "  BASELINE_METHOD_EXISTS=$ME_COUNT"
   echo "  BASELINE_VACUOUS_LENGTH=$VL_COUNT"
   echo "  BASELINE_NONCANON_SERVICE_DIR=$NONCANON_COUNT"
+  echo "  BASELINE_OVERMOCK=$OVERMOCK_COUNT"
   exit 0
 fi
 
@@ -113,8 +178,22 @@ if [ "$NONCANON_COUNT" -gt "$BASELINE_NONCANON_SERVICE_DIR" ]; then
   fail=1
 fi
 
+if [ "$OVERMOCK_COUNT" -gt "$BASELINE_OVERMOCK" ]; then
+  echo "❌ over-mock pass-through service-wrappers increased: $OVERMOCK_COUNT > baseline $BASELINE_OVERMOCK"
+  echo "   A new test file wholesale-mocks a central collaborator"
+  echo "   (@kitelev/exocortex-core/-services, or /services//adapters//infrastructure/,"
+  echo "   VaultRDFIndexer) and asserts ONLY delegation (toHaveBeenCalled*) with no"
+  echo "   output-value assertion — it verifies a call was forwarded but never"
+  echo "   exercises real behaviour. Lift it to a *.integration.test.ts that drives"
+  echo "   the real collaborator and faking only the Obsidian boundary (see"
+  echo "   TESTING.md §\"Lift over-mock service-wrappers to integration\")."
+  echo "   Files with this pattern:"
+  overmock_files | sed 's/^/     /'
+  fail=1
+fi
+
 if [ "$fail" -eq 0 ]; then
-  echo "✅ test anti-pattern guard OK — method-exists=$ME_COUNT/$BASELINE_METHOD_EXISTS, vacuous-length=$VL_COUNT/$BASELINE_VACUOUS_LENGTH, non-canon-service-dir=$NONCANON_COUNT/$BASELINE_NONCANON_SERVICE_DIR (no recurrence)"
+  echo "✅ test anti-pattern guard OK — method-exists=$ME_COUNT/$BASELINE_METHOD_EXISTS, vacuous-length=$VL_COUNT/$BASELINE_VACUOUS_LENGTH, non-canon-service-dir=$NONCANON_COUNT/$BASELINE_NONCANON_SERVICE_DIR, over-mock=$OVERMOCK_COUNT/$BASELINE_OVERMOCK (no recurrence)"
 fi
 
 # Non-fatal nudge: when counts drop, the baseline should be ratcheted down so the
@@ -127,6 +206,9 @@ if [ "$VL_COUNT" -lt "$BASELINE_VACUOUS_LENGTH" ]; then
 fi
 if [ "$NONCANON_COUNT" -lt "$BASELINE_NONCANON_SERVICE_DIR" ]; then
   echo "ℹ️  non-canon service-dir dropped to $NONCANON_COUNT (baseline $BASELINE_NONCANON_SERVICE_DIR) — ratchet BASELINE_NONCANON_SERVICE_DIR down via --update-baseline."
+fi
+if [ "$OVERMOCK_COUNT" -lt "$BASELINE_OVERMOCK" ]; then
+  echo "ℹ️  over-mock dropped to $OVERMOCK_COUNT (baseline $BASELINE_OVERMOCK) — ratchet BASELINE_OVERMOCK down via --update-baseline."
 fi
 
 exit $fail

--- a/scripts/coverage-thresholds-baseline.json
+++ b/scripts/coverage-thresholds-baseline.json
@@ -1,0 +1,23 @@
+{
+  "_comment": "Coverage-threshold high-water mark (test-quality audit 2026-06-22, P5.1). The monotonic guard (scripts/check-coverage-monotonic.mjs) FAILS if any jest.config.js coverageThreshold.global metric drops BELOW the value recorded here. Thresholds may only grow: when coverage rises, ratchet a number here UP (allowed silently). LOWERING a number here is the explicit, reviewed act that a coverage regression requires — it must carry a req__Requirement justification (RFC 0003 everything-req-first). The guard mechanizes 'no silent threshold drift' (e.g. the documented plugin branches 64->63 marginal drift); the baseline edit is the conscious withdrawal.",
+  "thresholds": {
+    "packages/core/jest.config.js": {
+      "branches": 95,
+      "functions": 95,
+      "lines": 95,
+      "statements": 95
+    },
+    "packages/obsidian-plugin/jest.config.js": {
+      "statements": 75.5,
+      "branches": 63,
+      "functions": 69,
+      "lines": 76
+    },
+    "packages/cli/jest.config.js": {
+      "statements": 65,
+      "branches": 60,
+      "functions": 70,
+      "lines": 65
+    }
+  }
+}


### PR DESCRIPTION
## Test-framework improvement-plan — cluster 1 (P1 + P2 + P3.1 + P5.1)

Implements the first (S-effort) cluster of the test-quality improvement plan (`testframework-improvement-plan-2026-06-22.md`). Audit-locked decision: "всё это" + everything-req-first SDD-loop.

### P1 — Impl-coupling burndown (exempt refactor)
- **P1.1** `SessionEventService.branch.test.ts`: replaced the impl-coupling assertion `getDefaultNewFileParent toHaveBeenCalledTimes(1)` (which pins an internal memoization detail — breaks on a valid cache-removal refactor, never checks placement) with a **behaviour** assert: both consecutive events land under the resolved default folder. **Revert-verified**: RED when the folder is no longer applied; the old call-count test never caught that.
- **P1.2** `.toBe("function")` method-exists trimming is **by-touch** — the two touched files carry none, so the method-exists baseline (55) is unchanged (no mass sweep).
- **P1.3** `ProfileApplyManager.test.ts`: vacuous `toBeGreaterThanOrEqual(0)` → non-vacuous `typeof elapsedMs).toBe("number")`. Vacuous-length ratchet baseline `22 → 21`.

### P2 — Over-mock ratchet-guard (req `427530e2`, approved → active on merge)
Extends `scripts/check-test-antipatterns.sh` with a 4th ratchet: a NEW test file that wholesale-mocks a central collaborator (`@kitelev/exocortex-core`/`-services`, `/services/`, `/adapters/`, `/infrastructure/`, `VaultRDFIndexer`) AND asserts only delegation (`toHaveBeenCalled*`) with no output-value assertion → fails the required `lint` job. **Baseline 0** (no pure pass-through over-mock file exists today — the canonical `SPARQLQueryService.test.ts` was lifted to an integration suite). Makes the Testing-Trophy opportunistic-lift policy self-sustaining (not reviewer-memory). Env-overridable scan dir + baselines for the revert-verify test.

### P3.1 — Trophy lift-policy docs (exempt)
`TESTING.md` §Patterns "Lift over-mock service-wrappers to integration" — when you touch a plugin service-wrapper test that mocks a central collaborator and asserts only delegation, lift it to `*.integration.test.ts` driving the real engine (exemplar `SPARQLQueryService.integration.test.ts`); correct seam = the Obsidian boundary only.

### P5.1 — Coverage-monotonic guard (req `289f87f4`, approved → active on merge)
`scripts/check-coverage-monotonic.mjs` + `scripts/coverage-thresholds-baseline.json`: jest `coverageThreshold.global` metrics may only **grow**; a drift below the committed high-water mark (the documented plugin `64→63` smell) fails the required `lint` job. Lowering a baseline number is the explicit, req-justified withdrawal.

### Verification
- `check:types` clean; `lint` blocking steps (anti-pattern guard, coverage-monotonic guard, shard-assignments) all green locally.
- Both ratchet guards have **`@req`-tagged integration revert-verify tests** under `packages/obsidian-plugin/tests/unit/build/` (RED-without / GREEN-with codified as live tests).
- Affected suites: SessionEventService.branch (10/10), ProfileApplyManager family + build/ dir (137/137).

### Out of scope (orchestrator)
P4 (mutation core+cli nightly), P6.1 (P0-gate flip, M3-closure-gated), P6.2 (dual-dir backlog), P3.2/P5.2 (ongoing by-touch lifts).

WBS: `ems__Task 07cfa5cd` under M3 (`1ec7677e`). Reqs in `kitelev/exoas-exo-reqs`.
