### PR TITLE
test(framework): mutation testing core+cli nightly (Stryker) — P4

### DIFF
--- a/.github/workflows/mutation-nightly.yml
+++ b/.github/workflows/mutation-nightly.yml
@@ -1,0 +1,113 @@
+name: Mutation Testing (nightly)
+
+# Stryker mutation testing over packages/core + packages/cli. Mutation testing
+# PROVES the test suite actually catches bugs (a surviving mutant = a test gap
+# the manual per-fix revert-verify cannot find systemically).
+#
+# Test-quality improvement-plan 2026-06-22 (P4). NIGHTLY CRON ONLY — NOT a
+# required PR check (decision Q2: a full Stryker run is far too slow for the
+# critical PR path; plugin/e2e are excluded entirely as too slow under mutation).
+# The score gate (scripts/check-mutation-score.mjs vs scripts/mutation-budget.json)
+# fails this job when a package's mutation score drops below its honest
+# break-budget, and the job-summary surfaces the score + killed/survived counts.
+#
+# Speed: Stryker `incremental` caches per-mutant results; the incremental file is
+# persisted across runs via actions/cache, so the first run is the slow full
+# baseline and subsequent runs only re-mutate changed files.
+
+on:
+  schedule:
+    # 03:30 UTC nightly (08:30 Asia/Almaty) — offset from the other nightlies
+    # (eka-obsidian-leg 02:00, eka-gui 02:30, e2e-desktop 06:00).
+    - cron: "30 3 * * *"
+  workflow_dispatch:
+    inputs:
+      package:
+        description: "Which package(s) to mutate"
+        type: choice
+        options: [both, core, cli]
+        default: both
+
+permissions:
+  contents: read
+
+concurrency:
+  group: mutation-nightly-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  mutation:
+    runs-on: ubuntu-latest
+    # Generous — the first full run is the slow baseline (~1.5-2.5h for full
+    # core+cli on these runners); incremental runs after that are minutes.
+    timeout-minutes: 330
+    strategy:
+      fail-fast: false
+      matrix:
+        package: [core, cli]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          # core integration suites read fixtures from the exoas-exocmd data
+          # submodule; without it the dry-run would fail.
+          submodules: recursive
+
+      - name: Skip non-selected package (manual dispatch)
+        id: gate
+        run: |
+          sel="${{ github.event.inputs.package || 'both' }}"
+          if [ "$sel" = "both" ] || [ "$sel" = "${{ matrix.package }}" ]; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "run=false" >> "$GITHUB_OUTPUT"
+            echo "Skipping ${{ matrix.package }} (dispatch selected: $sel)"
+          fi
+
+      - name: Setup Node & install deps
+        if: steps.gate.outputs.run == 'true'
+        uses: ./.github/actions/setup-node-pnpm
+
+      - name: Restore Stryker incremental cache
+        if: steps.gate.outputs.run == 'true'
+        uses: actions/cache@v4
+        with:
+          path: reports/mutation/incremental-${{ matrix.package }}.json
+          key: stryker-incremental-${{ matrix.package }}-${{ github.run_id }}
+          restore-keys: |
+            stryker-incremental-${{ matrix.package }}-
+
+      - name: Run Stryker (${{ matrix.package }})
+        if: steps.gate.outputs.run == 'true'
+        env:
+          # CLI is ESM — jest needs the VM-modules flag (mirrors test:mutation:cli).
+          NODE_OPTIONS: --experimental-vm-modules
+        run: npm run test:mutation:${{ matrix.package }}
+
+      - name: Mutation-score summary header
+        if: steps.gate.outputs.run == 'true' && always()
+        run: |
+          {
+            echo "## Mutation score — \`${{ matrix.package }}\`"
+            echo ""
+            echo "| package | score | budget | verdict | killed | timeout | survived | no-cov |"
+            echo "|---|---|---|---|---|---|---|---|"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Mutation-score gate (${{ matrix.package }})
+        if: steps.gate.outputs.run == 'true' && always()
+        # The gate appends its score row to the job-summary BEFORE exiting, so the
+        # observability table is present even when the run is below budget (RED).
+        run: |
+          node scripts/check-mutation-score.mjs \
+            --report reports/mutation/mutation-${{ matrix.package }}.json \
+            --package ${{ matrix.package }}
+
+      - name: Upload mutation HTML report
+        if: steps.gate.outputs.run == 'true' && always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: mutation-report-${{ matrix.package }}
+          path: reports/mutation/mutation-${{ matrix.package }}.html
+          if-no-files-found: ignore
+          retention-days: 14

--- a/TESTING.md
+++ b/TESTING.md
@@ -714,6 +714,57 @@ over-mock file, so the shift is self-sustaining without relying on reviewer
 memory: a new plugin service-wrapper test must drive a real collaborator or it
 fails the `lint` gate.
 
+### Mutation Testing (nightly)
+
+[Stryker](https://stryker-mutator.io/) mutation testing **proves the suite
+actually catches bugs**. It modifies source ("mutants" — flip `>` to `>=`,
+delete a statement, swap `&&`/`||`, …) and checks whether a test fails ("kills"
+the mutant). A **surviving** mutant is a test gap: the code was broken and _no
+test noticed_. This is the automated form of the manual per-fix revert-verify —
+it finds harness theater **systemically**, across the whole suite, not just on
+the files you happen to touch.
+
+```
+mutation score = (killed + timeout) / (killed + timeout + survived + no-coverage)
+```
+
+**Scope: `packages/core` + `packages/cli` only** (the deterministic engine + the
+fast CLI). The plugin and e2e layers are excluded — they are far too slow under
+mutation. It runs as a **nightly cron**
+([`.github/workflows/mutation-nightly.yml`](.github/workflows/mutation-nightly.yml)),
+**NOT a required PR check** — a full Stryker run is too slow for the critical PR
+path. core is CommonJS jest ([`stryker.config.mjs`](stryker.config.mjs)); cli is
+ESM jest, so it needs `--experimental-vm-modules`
+([`stryker.cli.config.mjs`](stryker.cli.config.mjs)).
+
+Run on-demand locally (slow — scope down with Stryker's `--mutate` while iterating):
+
+```bash
+npm run test:mutation:core            # packages/core
+npm run test:mutation:cli             # packages/cli (sets NODE_OPTIONS for you)
+npx stryker run stryker.config.mjs --mutate 'packages/core/src/utilities/**/*.ts'  # narrow scope
+```
+
+**Break-budget gate.** [`scripts/check-mutation-score.mjs`](scripts/check-mutation-score.mjs)
+reads the Stryker JSON report and fails (exit 1) when a package's score drops
+below its budget in [`scripts/mutation-budget.json`](scripts/mutation-budget.json).
+The budgets are **conservative honest floors** — initial scores can be low, and
+the first nightly run on `main` establishes the real baseline. **Ratchet each
+number UP** toward the observed score as the suite hardens; lowering one is a
+conscious withdrawal that, under everything-req-first (RFC 0003), needs a
+`req__Requirement` justification. The gate also writes the score + killed/survived
+counts to the job-summary for observability. An escaped mutant that drops the
+score below budget turns the nightly **red** — see the revert-verify binding in
+[`packages/obsidian-plugin/tests/unit/build/check-mutation-score.test.ts`](packages/obsidian-plugin/tests/unit/build/check-mutation-score.test.ts)
+(`@req:7af848cd`, runs in required CI: it drives the real gate against fixture
+reports — below-budget → red, at/above → green).
+
+**Speed.** `coverageAnalysis: perTest` + `enableFindRelatedTests` run only the
+covering tests per mutant; Stryker `incremental` (persisted across runs via
+actions/cache) means the first nightly is the slow full baseline and subsequent
+runs only re-mutate changed files. The full first run over core+cli is long
+(~1.5–2.5h on the runners) — acceptable nightly, never on the PR path.
+
 ### Async Testing
 
 #### Testing Promises

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,8 @@
         "@playwright/experimental-ct-react": "^1.56.1",
         "@playwright/test": "^1.56.1",
         "@preact/compat": "^18.3.1",
+        "@stryker-mutator/core": "^9.6.1",
+        "@stryker-mutator/jest-runner": "^9.6.1",
         "@testing-library/dom": "^10.4.1",
         "@testing-library/react": "^16.3.0",
         "@testing-library/user-event": "^14.6.1",
@@ -93,13 +95,13 @@
       "license": "ISC"
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
-      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/helper-validator-identifier": "^7.29.7",
         "js-tokens": "^4.0.0",
         "picocolors": "^1.1.1"
       },
@@ -149,14 +151,14 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.29.1",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
-      "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+      "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.29.0",
-        "@babel/types": "^7.29.0",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "@jridgewell/gen-mapping": "^0.3.12",
         "@jridgewell/trace-mapping": "^0.3.28",
         "jsesc": "^3.0.2"
@@ -166,13 +168,13 @@
       }
     },
     "node_modules/@babel/helper-annotate-as-pure": {
-      "version": "7.27.3",
-      "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.27.3.tgz",
-      "integrity": "sha512-fXSwMQqitTGeHLBC08Eq5yXz2m37E4pJX1qAU1+2cNedz/ifv/bVXft90VeSav5nFO61EcNgwr0aJxbyPaWBPg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.29.7.tgz",
+      "integrity": "sha512-OoK6239jHPuSQOoS0kfTVKn0b/rVTk0seKq4Gd2UMLtmOVLjDC0ki3e+c90Trqv2gMfvJFqkiljrr568+qddiw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.27.3"
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -196,18 +198,18 @@
       }
     },
     "node_modules/@babel/helper-create-class-features-plugin": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.28.6.tgz",
-      "integrity": "sha512-dTOdvsjnG3xNT9Y0AUg1wAl38y+4Rl4sf9caSQZOXdNqVn+H+HbbJ4IyyHaIqNR6SW9oJpA/RuRjsjCw2IdIow==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.29.7.tgz",
+      "integrity": "sha512-IY3ZD9Tmooqr3TUhc3DUWxiuo8xx1DWLhd5M7hQ+ZWJamqM2BbalrBJb2MisSLoYorOj75U03qULCxQTY9r3hg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-annotate-as-pure": "^7.27.3",
-        "@babel/helper-member-expression-to-functions": "^7.28.5",
-        "@babel/helper-optimise-call-expression": "^7.27.1",
-        "@babel/helper-replace-supers": "^7.28.6",
-        "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1",
-        "@babel/traverse": "^7.28.6",
+        "@babel/helper-annotate-as-pure": "^7.29.7",
+        "@babel/helper-member-expression-to-functions": "^7.29.7",
+        "@babel/helper-optimise-call-expression": "^7.29.7",
+        "@babel/helper-replace-supers": "^7.29.7",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
         "semver": "^6.3.1"
       },
       "engines": {
@@ -253,9 +255,9 @@
       }
     },
     "node_modules/@babel/helper-globals": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
-      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -263,14 +265,14 @@
       }
     },
     "node_modules/@babel/helper-member-expression-to-functions": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.28.5.tgz",
-      "integrity": "sha512-cwM7SBRZcPCLgl8a7cY0soT1SptSzAlMH39vwiRpOQkJlh53r5hdHwLSCZpQdVLT39sZt+CRpNwYG4Y2v77atg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.29.7.tgz",
+      "integrity": "sha512-j+7JYmk1JYDtACIGj0QJqqWZjoUpMoEikQGADMaHgCMCSDqd2+P32rfcibUNrGOMWrlzK1WJBdxrB3JJQZwWtg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/traverse": "^7.28.5",
-        "@babel/types": "^7.28.5"
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -309,22 +311,22 @@
       }
     },
     "node_modules/@babel/helper-optimise-call-expression": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.27.1.tgz",
-      "integrity": "sha512-URMGH08NzYFhubNSGJrpUEphGKQwMQYBySzat5cAByY1/YgIRkULnIy3tAMeszlL/so2HbeilYloUmSpd7GdVw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.29.7.tgz",
+      "integrity": "sha512-+kmGVjcT9RGYzoDwdwEqEvGgKe3BYq+O1iGzjFubaNgZHwYHP6lsF2Yghf4kEuv9BV7tYDZ913aBW9am6YKong==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.27.1"
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-plugin-utils": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.28.6.tgz",
-      "integrity": "sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.29.7.tgz",
+      "integrity": "sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -350,15 +352,15 @@
       }
     },
     "node_modules/@babel/helper-replace-supers": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.28.6.tgz",
-      "integrity": "sha512-mq8e+laIk94/yFec3DxSjCRD2Z0TAjhVbEJY3UQrlwVo15Lmt7C2wAUbK4bjnTs4APkwsYLTahXRraQXhb1WCg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.29.7.tgz",
+      "integrity": "sha512-atfGXWSeCiF4DnKZIfmJfQRkSw9b9gNNXR1kqKjbhG4pGYCOnkp8OcTB8E3NXjBu8NpheSnOeNKz8KT7UNFTmQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-member-expression-to-functions": "^7.28.5",
-        "@babel/helper-optimise-call-expression": "^7.27.1",
-        "@babel/traverse": "^7.28.6"
+        "@babel/helper-member-expression-to-functions": "^7.29.7",
+        "@babel/helper-optimise-call-expression": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -368,23 +370,23 @@
       }
     },
     "node_modules/@babel/helper-skip-transparent-expression-wrappers": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.27.1.tgz",
-      "integrity": "sha512-Tub4ZKEXqbPjXgWLl2+3JpQAYBJ8+ikpQ2Ocj/q/r0LwE3UhENh7EUabyHjz2kCEsrRY83ew2DQdHluuiDQFzg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.29.7.tgz",
+      "integrity": "sha512-brcMGQaVzIeUb+6/bs1Av0f8YuNNjKY2JyvfRCsFuFsdKccEQ5Ges2y74D74NZ1Rz8lKJ9ksJkfqwQFJ/iNEyQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/traverse": "^7.27.1",
-        "@babel/types": "^7.27.1"
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -392,9 +394,9 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -441,13 +443,13 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.0.tgz",
-      "integrity": "sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.29.0"
+        "@babel/types": "^7.29.7"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -540,6 +542,24 @@
         "@babel/core": "^7.0.0"
       }
     },
+    "node_modules/@babel/plugin-proposal-decorators": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-decorators/-/plugin-proposal-decorators-7.29.7.tgz",
+      "integrity": "sha512-EtU0Hi3GvrTqD56xKmZvV/uCXK2ZbwVNPNLAquVItcAZpUhkXwWlo3Fmj0c2LxgSf2I8IDULeAepwNP1OefLXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-create-class-features-plugin": "^7.29.7",
+        "@babel/helper-plugin-utils": "^7.29.7",
+        "@babel/plugin-syntax-decorators": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
     "node_modules/@babel/plugin-proposal-private-property-in-object": {
       "version": "7.21.0-placeholder-for-preset-env.2",
       "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.0-placeholder-for-preset-env.2.tgz",
@@ -600,6 +620,22 @@
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.14.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-decorators": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-decorators/-/plugin-syntax-decorators-7.29.7.tgz",
+      "integrity": "sha512-9MTTLbF39X6sqM92JPEsoI7++26hjZvzkxKZy64aMhWLH2mPkJ/Q3AV4QLmls3R14FpSpkOwQQfUh962JGQxxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -793,13 +829,13 @@
       }
     },
     "node_modules/@babel/plugin-syntax-typescript": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.28.6.tgz",
-      "integrity": "sha512-+nDNmQye7nlnuuHDboPbGm00Vqg3oO8niRRL27/4LYHUsHYh0zJ1xWOz0uRwNFmM1Avzk8wZbc6rdiYhomzv/A==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.29.7.tgz",
+      "integrity": "sha512-ngr+82Sh0xMz25TPCZi+nC2iTzjfCdWS2ONXTp/PtSCHCgaCNBpdMqgvJ2ccdLlClVZ7sisIgB914j/JFe+RZA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.28.6"
+        "@babel/helper-plugin-utils": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1646,6 +1682,26 @@
         "@babel/core": "^7.0.0-0"
       }
     },
+    "node_modules/@babel/plugin-transform-typescript": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.29.7.tgz",
+      "integrity": "sha512-jK52h8LaLc7JarhQV2ofeFMts4H7vnOXnqZNA6fYglBTZewRBE51KWt3BUltW1P+KoPsYkHoJeXePuz4zo2LMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^7.29.7",
+        "@babel/helper-create-class-features-plugin": "^7.29.7",
+        "@babel/helper-plugin-utils": "^7.29.7",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.29.7",
+        "@babel/plugin-syntax-typescript": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
     "node_modules/@babel/plugin-transform-unicode-escapes": {
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-escapes/-/plugin-transform-unicode-escapes-7.27.1.tgz",
@@ -1813,6 +1869,26 @@
         "@babel/core": "^7.0.0-0 || ^8.0.0-0 <8.0.0"
       }
     },
+    "node_modules/@babel/preset-typescript": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.28.5.tgz",
+      "integrity": "sha512-+bQy5WOI2V6LJZpPVxY+yp66XdZ2yifu0Mc1aP5CQKgjn4QM5IN2i5fAZ4xKop47pr8rpVhiAeu+nDQa12C8+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1",
+        "@babel/helper-validator-option": "^7.27.1",
+        "@babel/plugin-syntax-jsx": "^7.27.1",
+        "@babel/plugin-transform-modules-commonjs": "^7.27.1",
+        "@babel/plugin-transform-typescript": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
     "node_modules/@babel/runtime": {
       "version": "7.28.4",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.4.tgz",
@@ -1824,33 +1900,33 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
-      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.28.6",
-        "@babel/parser": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
-      "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
+      "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.29.0",
-        "@babel/generator": "^7.29.0",
-        "@babel/helper-globals": "^7.28.0",
-        "@babel/parser": "^7.29.0",
-        "@babel/template": "^7.28.6",
-        "@babel/types": "^7.29.0",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "debug": "^4.3.1"
       },
       "engines": {
@@ -1858,14 +1934,14 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
-      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.28.5"
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -2805,6 +2881,350 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@inquirer/ansi": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-2.0.7.tgz",
+      "integrity": "sha512-3eTuUO1vH2cZm2ZKHeQxnOqlTi9EfZDGgIe3BL3I4u+rJHocr9Fz86M4fjYABPvFnQG/gGK551HqDiIcETwU6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      }
+    },
+    "node_modules/@inquirer/checkbox": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-5.2.1.tgz",
+      "integrity": "sha512-b6xmA/VlTe0ZgDQHDui+Nav470u7u49nRd8/iuhOcQPO9Ch7lGuogydhi2VOmNlZ+zXcM8IcPuNSwQcdJaF/kw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^2.0.7",
+        "@inquirer/core": "^11.2.1",
+        "@inquirer/figures": "^2.0.7",
+        "@inquirer/type": "^4.0.7"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/confirm": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-6.1.1.tgz",
+      "integrity": "sha512-eb8DBZcz/2qHWQda4rk2JiQk5h9QV/cVHi1yjt0f69WFZMRFn0sJTye3EAP8icut8UDMjQPsaH5KbcOogefrFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^11.2.1",
+        "@inquirer/type": "^4.0.7"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/core": {
+      "version": "11.2.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-11.2.1.tgz",
+      "integrity": "sha512-Qd6GJT1yVyrZZCfN8W2qKF5ApmqryXRhRKCuip8h01x2w/esJQ2XIYc6f9abMIHgKQdBfFTSOdbHRLAhuM09UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^2.0.7",
+        "@inquirer/figures": "^2.0.7",
+        "@inquirer/type": "^4.0.7",
+        "cli-width": "^4.1.0",
+        "fast-wrap-ansi": "^0.2.0",
+        "mute-stream": "^3.0.0",
+        "signal-exit": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/editor": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-5.2.2.tgz",
+      "integrity": "sha512-ZRVd/oD+sYsUd5zVm0NflqEzlqfYCyHNsqkHl2oWXEUHs12tCbcSFi+wVFEvD8+LGRaMUsVrE7qeo6lSG/S1Vg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^11.2.1",
+        "@inquirer/external-editor": "^3.0.3",
+        "@inquirer/type": "^4.0.7"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/expand": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-5.1.1.tgz",
+      "integrity": "sha512-YmQpenjbFSHAK3sOd44puHh3V1KXXr+JiNpUztoSQ4drLh2rTVzTap/YtlAVu/5xavifIlBfNEzJ/neZJ1a/1g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^11.2.1",
+        "@inquirer/type": "^4.0.7"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/external-editor": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@inquirer/external-editor/-/external-editor-3.0.3.tgz",
+      "integrity": "sha512-6thf5I8q7lZwzGLAxPaaGEREEkZ3nyePPDQ1oyobblxmEE8mqTLguScP7pDjUTAibiyb4hfXl+qjUEJ+di/aNA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chardet": "^2.1.1",
+        "iconv-lite": "^0.7.2"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/figures": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-2.0.7.tgz",
+      "integrity": "sha512-aJ8TBPOGB6f/2qziPfElISTCEd5XOYTFckA2SGjhNmiKzfK/u4ot3v0DUzGVdUnKjN10EqnnEPck36BkyfLnJw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      }
+    },
+    "node_modules/@inquirer/input": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-5.1.2.tgz",
+      "integrity": "sha512-9K/DDBSQpOyZSkt6sOVP9Vo0TR7atX2kuILsUu0x3wVcVbe97lJwIJKMLdMw25tDYuXl/qp6erT0Xs1rfmcfZg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^11.2.1",
+        "@inquirer/type": "^4.0.7"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/number": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/number/-/number-4.1.1.tgz",
+      "integrity": "sha512-XF4IXAbPnGPgw0wsbC/i2tPcyfdZgDpUlhsqU0SfT4IRIGWha6Xm9VRgN5yYxJq+jnyXlfXI/nQ3ulfk0iEICA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^11.2.1",
+        "@inquirer/type": "^4.0.7"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/password": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-5.1.1.tgz",
+      "integrity": "sha512-3XBfF7DAsp5qeDsvN5Rd1HmbNokVvEQoUM0QLrRcybC9nX96w3Pbmu7qUsb3IT3J3jBvs2+mTXaKHOUsgHMLzg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^2.0.7",
+        "@inquirer/core": "^11.2.1",
+        "@inquirer/type": "^4.0.7"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/prompts": {
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-8.5.2.tgz",
+      "integrity": "sha512-IYR/3C/paEVVQYQvdDlFZVjRCJVYHHON0XXMH91KO9GSxs0TdKYWlUdvfQl2EfAHDxUaN3IBffkE/BDTh5nJ6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/checkbox": "^5.2.1",
+        "@inquirer/confirm": "^6.1.1",
+        "@inquirer/editor": "^5.2.2",
+        "@inquirer/expand": "^5.1.1",
+        "@inquirer/input": "^5.1.2",
+        "@inquirer/number": "^4.1.1",
+        "@inquirer/password": "^5.1.1",
+        "@inquirer/rawlist": "^5.3.1",
+        "@inquirer/search": "^4.2.1",
+        "@inquirer/select": "^5.2.1"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/rawlist": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-5.3.1.tgz",
+      "integrity": "sha512-QqdTqQddL3qPX/PPrjobpsO25NZ4dWXgTLenrR445L2ptLEYE6Z+PD5c5CNDJNx4ugRgELAIpSIJxZaO2jJ2Og==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^11.2.1",
+        "@inquirer/type": "^4.0.7"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/search": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/search/-/search-4.2.1.tgz",
+      "integrity": "sha512-xJj8QWKRSrfKoBIITLZK61dD3zwo0Rz11fgDImku30/Oe81zMdIdGgrLY2h6RkJ+KZ/GhNYIRMKnH/62qBTA5g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^11.2.1",
+        "@inquirer/figures": "^2.0.7",
+        "@inquirer/type": "^4.0.7"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/select": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-5.2.1.tgz",
+      "integrity": "sha512-FlDndEUww8m7BfukO2nJa25vhD+H5jxxCv4oGioKqzyWz3nPHhhw4LKdYRSlXuAx7DsdWia7iyaBPKKS95Evfw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^2.0.7",
+        "@inquirer/core": "^11.2.1",
+        "@inquirer/figures": "^2.0.7",
+        "@inquirer/type": "^4.0.7"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/type": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-4.0.7.tgz",
+      "integrity": "sha512-t28inv14nMQ1PhKpsJPY+kEs/c00qzeCOS2gTNRyTjG5d6qsVA2fItxW4hkvGZ5lvanGLdtCzVIx5dwdRpN1+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
       }
     },
     "node_modules/@isaacs/cliui": {
@@ -3975,12 +4395,32 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@sec-ant/readable-stream": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@sec-ant/readable-stream/-/readable-stream-0.4.1.tgz",
+      "integrity": "sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@sinclair/typebox": {
       "version": "0.34.41",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.41.tgz",
       "integrity": "sha512-6gS8pZzSXdyRHTIqoqSVknxolr1kzfy4/CeDnrzsVz8TTIWUbOBr6gnzOmTYJ3eXQNh4IYHIGi5aIL7sOZ2G/g==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@sindresorhus/merge-streams": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-4.0.0.tgz",
+      "integrity": "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/@sinonjs/commons": {
       "version": "3.0.1",
@@ -4001,6 +4441,165 @@
       "dependencies": {
         "@sinonjs/commons": "^3.0.1"
       }
+    },
+    "node_modules/@stryker-mutator/api": {
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/@stryker-mutator/api/-/api-9.6.1.tgz",
+      "integrity": "sha512-g8VNoFWQWbx0pdal3Vt8jVCZW+v3sc3gi94iI0GVtVgUGTqphAjJF6EAruPTx0lqvtonsaAxn5TD36hcG1d6Wg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "mutation-testing-metrics": "3.7.3",
+        "mutation-testing-report-schema": "3.7.3",
+        "tslib": "~2.8.0",
+        "typed-inject": "~5.0.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@stryker-mutator/core": {
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/@stryker-mutator/core/-/core-9.6.1.tgz",
+      "integrity": "sha512-WMgnvf+Wyh/yiruhNZwc8w8DlzmmjXhPjSn5MR8RhAXzlnWji8TQrUYgBUkHk9bEgSaIlB3KZHm37iiU5Q2cLQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@inquirer/prompts": "^8.0.0",
+        "@stryker-mutator/api": "9.6.1",
+        "@stryker-mutator/instrumenter": "9.6.1",
+        "@stryker-mutator/util": "9.6.1",
+        "ajv": "~8.18.0",
+        "chalk": "~5.6.0",
+        "commander": "~14.0.0",
+        "diff-match-patch": "1.0.5",
+        "emoji-regex": "~10.6.0",
+        "execa": "~9.6.0",
+        "json-rpc-2.0": "^1.7.0",
+        "lodash.groupby": "~4.6.0",
+        "minimatch": "~10.2.4",
+        "mutation-server-protocol": "~0.4.0",
+        "mutation-testing-elements": "3.7.3",
+        "mutation-testing-metrics": "3.7.3",
+        "mutation-testing-report-schema": "3.7.3",
+        "npm-run-path": "~6.0.0",
+        "progress": "~2.0.3",
+        "rxjs": "~7.8.1",
+        "semver": "^7.6.3",
+        "source-map": "~0.7.4",
+        "tree-kill": "~1.2.2",
+        "tslib": "2.8.1",
+        "typed-inject": "~5.0.0",
+        "typed-rest-client": "~2.3.0"
+      },
+      "bin": {
+        "stryker": "bin/stryker.js"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@stryker-mutator/core/node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@stryker-mutator/core/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@stryker-mutator/instrumenter": {
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/@stryker-mutator/instrumenter/-/instrumenter-9.6.1.tgz",
+      "integrity": "sha512-5K8wH4Pthly25c2uKKik4Dfcoeou7sbJdFS6u3QIYHlulgFVDJwtEMWTZGkZfs7IiUEXIDNa0keRACq5jn5AvA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@babel/core": "~7.29.0",
+        "@babel/generator": "~7.29.0",
+        "@babel/parser": "~7.29.0",
+        "@babel/plugin-proposal-decorators": "~7.29.0",
+        "@babel/plugin-transform-explicit-resource-management": "^7.28.0",
+        "@babel/preset-typescript": "~7.28.0",
+        "@stryker-mutator/api": "9.6.1",
+        "@stryker-mutator/util": "9.6.1",
+        "angular-html-parser": "~10.4.0",
+        "semver": "~7.7.0",
+        "tslib": "2.8.1",
+        "weapon-regex": "~1.3.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@stryker-mutator/instrumenter/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@stryker-mutator/jest-runner": {
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/@stryker-mutator/jest-runner/-/jest-runner-9.6.1.tgz",
+      "integrity": "sha512-nIrIndfWwdweYkIcxJmyBTpl84nrXs9AE6A8vzEwwzUGvDb9kVvwBPfpEajtdAkjwPceH0pPuVrPkotvqcgYqQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@stryker-mutator/api": "9.6.1",
+        "@stryker-mutator/util": "9.6.1",
+        "semver": "~7.7.0",
+        "tslib": "~2.8.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@stryker-mutator/core": "9.6.1"
+      }
+    },
+    "node_modules/@stryker-mutator/jest-runner/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@stryker-mutator/util": {
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/@stryker-mutator/util/-/util-9.6.1.tgz",
+      "integrity": "sha512-Lk/ALVctJjFv1vvwR+CFoKzDCWvsBlq7flDUnmnpuwTrGbm156EdZD1Jjq4o8KdOap0ezUZqQNE9OAI1m2+pUQ==",
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/@tanstack/query-core": {
       "version": "5.90.12",
@@ -5131,6 +5730,16 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/angular-html-parser": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/angular-html-parser/-/angular-html-parser-10.4.0.tgz",
+      "integrity": "sha512-++nLNyZwRfHqFh7akH5Gw/JYizoFlMRz0KRigfwfsLqV8ZqlcVRb1LkPEWdYvEKDnbktknM2J4BXaYUGrQZPww==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/ansi-escapes": {
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
@@ -5792,6 +6401,13 @@
         "node": ">=10"
       }
     },
+    "node_modules/chardet": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-2.2.0.tgz",
+      "integrity": "sha512-rddelWYNPRrXq6PtNEN2S3f6t9ILzvqaN5pVgi4kqt9jHQaXIial9PznB5iSPVlQSLNaaH22ItWz3EJtQ10+OA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/ci-info": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.3.1.tgz",
@@ -5874,6 +6490,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-width": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
+      "integrity": "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/cliui": {
@@ -6268,6 +6894,17 @@
         "node": ">=6"
       }
     },
+    "node_modules/des.js": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.1.0.tgz",
+      "integrity": "sha512-r17GxjhUCjSRy8aiJpr8/UadFIzMzJGexI3Nmz4ADi9LYSFx4gTBp80+NaX/YsXWWLhpZ7v/v/ubEc/bCNfKwg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
+      }
+    },
     "node_modules/detect-newline": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
@@ -6287,6 +6924,13 @@
       "engines": {
         "node": ">=0.3.1"
       }
+    },
+    "node_modules/diff-match-patch": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/diff-match-patch/-/diff-match-patch-1.0.5.tgz",
+      "integrity": "sha512-IayShXAgj/QMXgB0IWmKx+rOPuGMhqm5w6jvFxmVenXKIzRqTAAsbBPT3kWQeGANj3jGgvcvv4yK6SxqYmikgw==",
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/doctrine": {
       "version": "2.1.0",
@@ -7516,6 +8160,46 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/execa": {
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-9.6.1.tgz",
+      "integrity": "sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sindresorhus/merge-streams": "^4.0.0",
+        "cross-spawn": "^7.0.6",
+        "figures": "^6.1.0",
+        "get-stream": "^9.0.0",
+        "human-signals": "^8.0.1",
+        "is-plain-obj": "^4.1.0",
+        "is-stream": "^4.0.1",
+        "npm-run-path": "^6.0.0",
+        "pretty-ms": "^9.2.0",
+        "signal-exit": "^4.1.0",
+        "strip-final-newline": "^4.0.0",
+        "yoctocolors": "^2.1.1"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.5.0"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/execa/node_modules/is-stream": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
+      "integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/exit-x": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/exit-x/-/exit-x-0.2.2.tgz",
@@ -7605,6 +8289,23 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-string-truncated-width": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/fast-string-truncated-width/-/fast-string-truncated-width-3.0.3.tgz",
+      "integrity": "sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-string-width": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/fast-string-width/-/fast-string-width-3.0.2.tgz",
+      "integrity": "sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-string-truncated-width": "^3.0.2"
+      }
+    },
     "node_modules/fast-uri": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
@@ -7622,6 +8323,16 @@
       ],
       "license": "BSD-3-Clause"
     },
+    "node_modules/fast-wrap-ansi": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/fast-wrap-ansi/-/fast-wrap-ansi-0.2.2.tgz",
+      "integrity": "sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-string-width": "^3.0.2"
+      }
+    },
     "node_modules/fb-watchman": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.2.tgz",
@@ -7630,6 +8341,22 @@
       "license": "Apache-2.0",
       "dependencies": {
         "bser": "2.1.1"
+      }
+    },
+    "node_modules/figures": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-6.1.0.tgz",
+      "integrity": "sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-unicode-supported": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/file-entry-cache": {
@@ -7910,6 +8637,36 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/get-stream": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-9.0.1.tgz",
+      "integrity": "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sec-ant/readable-stream": "^0.4.1",
+        "is-stream": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/get-stream/node_modules/is-stream": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
+      "integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/get-symbol-description": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.1.0.tgz",
@@ -8177,6 +8934,16 @@
         "node": ">= 14"
       }
     },
+    "node_modules/human-signals": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-8.0.1.tgz",
+      "integrity": "sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
     "node_modules/husky": {
       "version": "9.1.7",
       "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
@@ -8191,6 +8958,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/typicode"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/ignore": {
@@ -8594,6 +9378,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-plain-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-potential-custom-element-name": {
@@ -10599,6 +11396,13 @@
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
+    "node_modules/js-md4": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/js-md4/-/js-md4-0.3.2.tgz",
+      "integrity": "sha512-/GDnfQYsltsjRswQhN9fhv3EMw2sCpUdrdxyWDOUK7eyD++r3gRhzgiQgc/x4MAv2i1iuQ4lxO5mvqM3vj4bwA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -10682,6 +11486,13 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-rpc-2.0": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/json-rpc-2.0/-/json-rpc-2.0-1.7.1.tgz",
+      "integrity": "sha512-JqZjhjAanbpkXIzFE7u8mE/iFblawwlXtONaCvRqI+pyABVz7B4M1EUNpyVW+dZjqgQ2L5HFmZCmOCgUKm00hg==",
       "dev": true,
       "license": "MIT"
     },
@@ -10911,6 +11722,13 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
       "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.groupby": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.groupby/-/lodash.groupby-4.6.0.tgz",
+      "integrity": "sha512-5dcWxm23+VAoz+awKmBaiBvzox8+RqMgFhi7UvX9DHZr2HdxHXM/Wrf8cfKpsW37RNrvtPn6hSwNqurSILbmJw==",
       "dev": true,
       "license": "MIT"
     },
@@ -11145,6 +11963,52 @@
         "node": ">=4"
       }
     },
+    "node_modules/minimalistic-assert": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minimatch/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/minimatch/node_modules/brace-expansion": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
     "node_modules/minimist": {
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
@@ -11186,6 +12050,53 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/mutation-server-protocol": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/mutation-server-protocol/-/mutation-server-protocol-0.4.1.tgz",
+      "integrity": "sha512-SBGK0j8hLDne7bktgThKI8kGvGTx3rY3LAeQTmOKZ5bVnL/7TorLMvcVF7dIPJCu5RNUWhkkuF53kurygYVt3g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "zod": "^4.1.12"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/mutation-testing-elements": {
+      "version": "3.7.3",
+      "resolved": "https://registry.npmjs.org/mutation-testing-elements/-/mutation-testing-elements-3.7.3.tgz",
+      "integrity": "sha512-SMeIPxngJpfjfNYctFpYQQtlBlZaVO0aoB3FKdwrI8Ee/2bkyUuCZzAOCLv1U9fnmfA37dPFq0Owduoxs2XgGQ==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/mutation-testing-metrics": {
+      "version": "3.7.3",
+      "resolved": "https://registry.npmjs.org/mutation-testing-metrics/-/mutation-testing-metrics-3.7.3.tgz",
+      "integrity": "sha512-B8QrP0ZomErzTPNlhrzKWPNBln+3afwBZPHv0Q7N8wZZTYxMptzb/Gdm3ExXVmioVYrtZAtsDs7W/T/b2AixOQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "mutation-testing-report-schema": "3.7.3"
+      }
+    },
+    "node_modules/mutation-testing-report-schema": {
+      "version": "3.7.3",
+      "resolved": "https://registry.npmjs.org/mutation-testing-report-schema/-/mutation-testing-report-schema-3.7.3.tgz",
+      "integrity": "sha512-BHm3MYq+ckO+t5CtlG8zpqxc75rdJCkxVlE+fGuGJM3F7tNCQ/OW2N+TQVHN3BHsYa84+BFc6g3AwDYkUsw2MA==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/mute-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-3.0.0.tgz",
+      "integrity": "sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
     },
     "node_modules/nano-spawn": {
       "version": "2.0.0",
@@ -11277,6 +12188,36 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npm-run-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-6.0.0.tgz",
+      "integrity": "sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^4.0.0",
+        "unicorn-magic": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/npm-run-path/node_modules/path-key": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/nwsapi": {
@@ -11628,6 +12569,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/parse-ms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-4.0.0.tgz",
+      "integrity": "sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/parse5": {
       "version": "7.3.0",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
@@ -11894,6 +12848,32 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/pretty-ms": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-9.3.0.tgz",
+      "integrity": "sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parse-ms": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/progress": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/prop-types": {
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
@@ -11952,6 +12932,22 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/qs": {
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
+      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/querystringify": {
       "version": "2.2.0",
@@ -12314,6 +13310,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/rxjs": {
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
+      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
     "node_modules/safe-array-concat": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.3.tgz",
@@ -12632,6 +13638,16 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
+      "integrity": "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/source-map-js": {
@@ -13020,6 +14036,19 @@
         "node": ">=10"
       }
     },
+    "node_modules/strip-final-newline": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-4.0.0.tgz",
+      "integrity": "sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/strip-indent": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
@@ -13310,6 +14339,16 @@
         "node": ">=18"
       }
     },
+    "node_modules/tree-kill": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
+      "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "tree-kill": "cli.js"
+      }
+    },
     "node_modules/ts-api-utils": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.1.0.tgz",
@@ -13514,6 +14553,16 @@
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
       "license": "0BSD"
     },
+    "node_modules/tunnel": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
+      "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6.11 <=0.7.0 || >=0.7.3"
+      }
+    },
     "node_modules/tunnel-agent": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
@@ -13641,6 +14690,33 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/typed-inject": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/typed-inject/-/typed-inject-5.0.0.tgz",
+      "integrity": "sha512-0Ql2ORqBORLMdAW89TQKZsb1PQkFGImFfVmncXWe7a+AA3+7dh7Se9exxZowH4kbnlvKEFkMxUYdHUpjYWFJaA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/typed-rest-client": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-2.3.1.tgz",
+      "integrity": "sha512-k4kX5Up6qA68D0Cby2AK+6+vM5k3qTxe+/3FqhnHRExjY5cfbOnzjQZbP/LXleF8hVoDvDqxlgk9KK83HoBZlQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "des.js": "^1.1.0",
+        "js-md4": "^0.3.2",
+        "qs": "6.15.1",
+        "tunnel": "0.0.6",
+        "underscore": "^1.13.8"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      }
+    },
     "node_modules/typescript": {
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
@@ -13712,6 +14788,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/underscore": {
+      "version": "1.13.8",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.8.tgz",
+      "integrity": "sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/undici-types": {
       "version": "5.26.5",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
@@ -13761,6 +14844,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/unicorn-magic": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.3.0.tgz",
+      "integrity": "sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/universalify": {
@@ -14513,6 +15609,13 @@
         "makeerror": "1.0.12"
       }
     },
+    "node_modules/weapon-regex": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/weapon-regex/-/weapon-regex-1.3.6.tgz",
+      "integrity": "sha512-wsf1m1jmMrso5nhwVFJJHSubEBf3+pereGd7+nBKtYJ18KoB/PWJOHS3WRkwS04VrOU0iJr2bZU+l1QaTJ+9nA==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
     "node_modules/webidl-conversions": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
@@ -14954,6 +16057,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/zustand": {

--- a/package.json
+++ b/package.json
@@ -36,6 +36,8 @@
     "test:all": "npm test && npm run test:e2e:docker",
     "test:perf": "jest --config packages/obsidian-plugin/jest.config.js --testPathPatterns='performance.*\\.test\\.ts$'",
     "test:perf:component": "cd packages/obsidian-plugin && npx playwright test -c playwright-ct.config.ts RenderingPerformance && cd ../..",
+    "test:mutation:core": "stryker run stryker.config.mjs",
+    "test:mutation:cli": "NODE_OPTIONS=--experimental-vm-modules stryker run stryker.cli.config.mjs",
     "docs:validate": "node scripts/validate-docs-properties.js"
   },
   "keywords": [
@@ -55,6 +57,8 @@
     "@playwright/experimental-ct-react": "^1.56.1",
     "@playwright/test": "^1.56.1",
     "@preact/compat": "^18.3.1",
+    "@stryker-mutator/core": "^9.6.1",
+    "@stryker-mutator/jest-runner": "^9.6.1",
     "@testing-library/dom": "^10.4.1",
     "@testing-library/react": "^16.3.0",
     "@testing-library/user-event": "^14.6.1",

--- a/packages/obsidian-plugin/tests/unit/build/check-mutation-score.test.ts
+++ b/packages/obsidian-plugin/tests/unit/build/check-mutation-score.test.ts
@@ -125,4 +125,27 @@ describe("check-mutation-score.mjs — mutation-score break-budget gate (P4, @re
     expect(r.status).toBe(1);
     expect(r.stderr).toContain("zero score-relevant mutants");
   });
+
+  it("fails closed (exit 1) when the report is a non-object (JSON null)", () => {
+    // JSON.parse("null") → null; must route through the zero-mutants
+    // fail-closed path, never crash with a raw stack trace, never pass.
+    const p = path.join(workDir, "null.json");
+    writeFileSync(p, "null");
+    const r = runGate(p, 50);
+    expect(r.status).toBe(1);
+    expect(r.stderr).toContain("zero score-relevant mutants");
+  });
+
+  it("fails closed (exit 1) when the budget is not a number (no silent score < NaN)", () => {
+    // A typo'd budget must fail CLOSED — `score < NaN` is always false, which
+    // would otherwise pass a real below-budget run silently.
+    const report = writeReport("any.json", { Killed: 1, Survived: 9 });
+    const r = spawnSync("node", [scriptPath, "--report", report], {
+      cwd: repoRoot,
+      encoding: "utf8",
+      env: { ...process.env, MUTATION_BUDGET: "not-a-number" },
+    });
+    expect(r.status).toBe(1);
+    expect(r.stderr).toContain("is not a number");
+  });
 });

--- a/packages/obsidian-plugin/tests/unit/build/check-mutation-score.test.ts
+++ b/packages/obsidian-plugin/tests/unit/build/check-mutation-score.test.ts
@@ -1,0 +1,128 @@
+import { mkdtempSync, writeFileSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import * as path from "path";
+import { spawnSync } from "child_process";
+
+/**
+ * Mutation-score break-budget gate — revert-verify binding.
+ *
+ * Test-quality improvement-plan 2026-06-22, recommendation P4 (mutation testing
+ * core+cli nightly). The NIGHTLY workflow (.github/workflows/mutation-nightly.yml)
+ * runs Stryker over packages/{core,cli}/src and feeds the JSON report to
+ * `scripts/check-mutation-score.mjs`, which FAILS (exit 1) when the total
+ * mutation score drops below the package's break-budget
+ * (scripts/mutation-budget.json). A surviving mutant ABOVE budget means a test
+ * gap — source was mutated and NO test failed.
+ *
+ * A full Stryker run is far too slow for the required PR path (decision Q2:
+ * nightly only), so THIS required-CI test drives the REAL gate script against
+ * fixture Stryker reports — the same integration shape as the over-mock ratchet
+ * binding (check-test-antipatterns-overmock.test.ts). It pins the
+ * RED-when-below / GREEN-when-at-or-above revert-verify contract that the
+ * end-to-end escaped-mutant nightly proof rides on:
+ *   • a report whose score is BELOW the budget (escaped mutants survived) → exit 1 (RED)
+ *   • a report whose score is AT/ABOVE the budget                          → exit 0 (GREEN)
+ *   • a missing report  → exit 1 (fail-closed — no verdict is never "green")
+ *   • a report with zero score-relevant mutants → exit 1 (nothing was tested)
+ *
+ * @req:7af848cd-b8a5-4842-b0fb-b01184a94b95
+ */
+describe("check-mutation-score.mjs — mutation-score break-budget gate (P4, @req:7af848cd)", () => {
+  const repoRoot = path.resolve(__dirname, "../../../../..");
+  const scriptPath = path.join(repoRoot, "scripts/check-mutation-score.mjs");
+
+  let workDir: string;
+
+  /** Build a Stryker JSON report (schema v1) with the given status tally. */
+  const writeReport = (
+    file: string,
+    tally: {
+      Killed?: number;
+      Timeout?: number;
+      Survived?: number;
+      NoCoverage?: number;
+    },
+  ): string => {
+    const mutants: { id: string; status: string }[] = [];
+    let id = 0;
+    for (const [status, n] of Object.entries(tally)) {
+      for (let i = 0; i < (n ?? 0); i++) {
+        mutants.push({ id: String(id++), status });
+      }
+    }
+    const report = {
+      schemaVersion: "1.0",
+      thresholds: { high: 80, low: 60 },
+      files: {
+        "src/example.ts": { language: "typescript", source: "", mutants },
+      },
+    };
+    const p = path.join(workDir, file);
+    writeFileSync(p, JSON.stringify(report));
+    return p;
+  };
+
+  const runGate = (reportPath: string, budget: number) =>
+    spawnSync("node", [scriptPath, "--report", reportPath], {
+      cwd: repoRoot,
+      encoding: "utf8",
+      env: { ...process.env, MUTATION_BUDGET: String(budget) },
+    });
+
+  beforeEach(() => {
+    workDir = mkdtempSync(path.join(tmpdir(), "mutation-score-gate-"));
+  });
+
+  afterEach(() => {
+    rmSync(workDir, { recursive: true, force: true });
+  });
+
+  it("FAILS (exit 1) when survived mutants drop the score BELOW budget (escaped-mutant RED)", () => {
+    // 4 killed + 6 survived = 40% total score; budget 50 → RED. The 6 survived
+    // mutants are exactly what a deliberately weak test leaves uncaught.
+    const report = writeReport("below.json", { Killed: 4, Survived: 6 });
+    const r = runGate(report, 50);
+    expect(r.status).toBe(1);
+    expect(r.stderr).toContain("40.00% < break-budget 50%");
+    expect(r.stderr).toContain("survived=6");
+  });
+
+  it("PASSES (exit 0) when the mutants are killed and score is AT/ABOVE budget (GREEN)", () => {
+    // 9 killed + 1 survived = 90% total; budget 50 → GREEN. Removing the weak
+    // test (killing the escaped mutants) restores a green gate.
+    const report = writeReport("above.json", { Killed: 9, Survived: 1 });
+    const r = runGate(report, 50);
+    expect(r.status).toBe(0);
+    expect(r.stdout).toContain("90.00% >= break-budget 50%");
+  });
+
+  it("counts Timeout as detected and NoCoverage against the score", () => {
+    // (killed 5 + timeout 1) / (5 + 1 + survived 2 + no-cov 2) = 60% → GREEN at 50.
+    const report = writeReport("mixed.json", {
+      Killed: 5,
+      Timeout: 1,
+      Survived: 2,
+      NoCoverage: 2,
+    });
+    const r = runGate(report, 50);
+    expect(r.status).toBe(0);
+    expect(r.stdout).toContain("60.00%");
+    // ...and RED at a higher budget.
+    const r2 = runGate(report, 70);
+    expect(r2.status).toBe(1);
+    expect(r2.stderr).toContain("no-coverage=2");
+  });
+
+  it("fails closed (exit 1) when the report is missing — no verdict is never green", () => {
+    const r = runGate(path.join(workDir, "does-not-exist.json"), 50);
+    expect(r.status).toBe(1);
+    expect(r.stderr).toContain("cannot read Stryker report");
+  });
+
+  it("fails closed (exit 1) when the report has zero score-relevant mutants", () => {
+    const report = writeReport("empty.json", {});
+    const r = runGate(report, 50);
+    expect(r.status).toBe(1);
+    expect(r.stderr).toContain("zero score-relevant mutants");
+  });
+});

--- a/scripts/check-mutation-score.mjs
+++ b/scripts/check-mutation-score.mjs
@@ -71,7 +71,11 @@ export function tallyMutants(report) {
     noCoverage: 0,
     other: 0,
   };
-  const files = report.files ?? {};
+  // A report that parses as JSON `null`, a string, or an array has no mutants —
+  // route it through the zero-mutants fail-closed path (never crash with a raw
+  // stack trace, never silently pass).
+  const files =
+    report && typeof report === "object" ? (report.files ?? {}) : {};
   for (const fileReport of Object.values(files)) {
     for (const mutant of fileReport.mutants ?? []) {
       switch (mutant.status) {
@@ -111,15 +115,23 @@ export function mutationScore(counts) {
   return ((counts.killed + counts.timeout) / counts.total) * 100;
 }
 
+/** Reject a non-finite budget so a typo fails CLOSED, never `score < NaN` (false → green). */
+function asFiniteBudget(raw, source) {
+  const value = Number(raw);
+  if (!Number.isFinite(value)) {
+    throw new Error(
+      `budget from ${source} is not a number: ${JSON.stringify(raw)}`,
+    );
+  }
+  return { value, source };
+}
+
 function resolveBudget(args) {
   if (process.env.MUTATION_BUDGET !== undefined) {
-    return {
-      value: Number(process.env.MUTATION_BUDGET),
-      source: "env MUTATION_BUDGET",
-    };
+    return asFiniteBudget(process.env.MUTATION_BUDGET, "env MUTATION_BUDGET");
   }
   if (args.budget !== undefined && args.budget !== true) {
-    return { value: Number(args.budget), source: "--budget" };
+    return asFiniteBudget(args.budget, "--budget");
   }
   const pkg = process.env.MUTATION_PACKAGE ?? args.package;
   if (!pkg || pkg === true) {
@@ -137,7 +149,7 @@ function resolveBudget(args) {
       `budget key "${pkg}" not found in ${budgetFile} (keys: ${Object.keys(budgets).join(", ")})`,
     );
   }
-  return { value: Number(budgets[pkg]), source: `${budgetFile}#${pkg}` };
+  return asFiniteBudget(budgets[pkg], `${budgetFile}#${pkg}`);
 }
 
 function main() {

--- a/scripts/check-mutation-score.mjs
+++ b/scripts/check-mutation-score.mjs
@@ -1,0 +1,230 @@
+#!/usr/bin/env node
+//
+// check-mutation-score.mjs — mutation-score break-budget gate.
+//
+// Source: test-quality improvement-plan 2026-06-22, recommendation P4 (mutation
+// testing core+cli nightly). Stryker mutation testing PROVES the test suite
+// actually catches bugs — it mutates source and checks whether a test fails
+// ("kills" the mutant). A surviving mutant is a test-harness gap the manual
+// per-fix revert-verify discipline cannot find systemically. This gate reads a
+// Stryker JSON report and FAILS (exit 1) when the total mutation score falls
+// BELOW the package's committed break-budget (scripts/mutation-budget.json).
+//
+// It runs in the NIGHTLY cron workflow (.github/workflows/mutation-nightly.yml),
+// NOT in the required PR checks — a full Stryker run over packages/core +
+// packages/cli is far too slow for the critical PR path (decision Q2: nightly
+// only). The budget is intentionally a conservative honest floor (initial
+// scores can be low); ratchet it UP in mutation-budget.json as the suite hardens.
+//
+// Total mutation score (the honest one — no-coverage counts against you):
+//     (Killed + Timeout) / (Killed + Timeout + Survived + NoCoverage) * 100
+// CompileError / RuntimeError / Ignored mutants are excluded from the
+// denominator (they were never a valid test of the suite).
+//
+// Usage:
+//   node scripts/check-mutation-score.mjs --report <path> --package <core|cli>
+//   node scripts/check-mutation-score.mjs --report <path> --budget 50
+//   node scripts/check-mutation-score.mjs --report <path> --package core --summary "$GITHUB_STEP_SUMMARY"
+//
+// Testability (the @req binding test drives the gate against fixture reports):
+//   MUTATION_REPORT       — path to the Stryker JSON report (overrides --report)
+//   MUTATION_BUDGET       — numeric break-budget (overrides --budget and the file)
+//   MUTATION_BUDGET_FILE  — path to the budget JSON (default: <root>/scripts/mutation-budget.json)
+//   MUTATION_PACKAGE      — budget key to read from the budget file (overrides --package)
+
+import { readFileSync, appendFileSync } from "fs";
+import { dirname, resolve } from "path";
+import { fileURLToPath } from "url";
+
+const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(SCRIPT_DIR, "..");
+
+/** Minimal CLI-arg parser: `--flag value` and `--flag` (boolean). */
+function parseArgs(argv) {
+  const out = {};
+  for (let i = 0; i < argv.length; i++) {
+    if (!argv[i].startsWith("--")) continue;
+    const key = argv[i].slice(2);
+    const next = argv[i + 1];
+    if (next === undefined || next.startsWith("--")) {
+      out[key] = true;
+    } else {
+      out[key] = next;
+      i++;
+    }
+  }
+  return out;
+}
+
+/**
+ * Tally the four score-relevant mutant statuses across every file in a Stryker
+ * JSON report (mutation-testing schema v1).
+ *
+ * @param {{files: Record<string, {mutants: {status: string}[]}>}} report
+ * @returns {{killed:number, timeout:number, survived:number, noCoverage:number, other:number, total:number}}
+ */
+export function tallyMutants(report) {
+  const counts = {
+    killed: 0,
+    timeout: 0,
+    survived: 0,
+    noCoverage: 0,
+    other: 0,
+  };
+  const files = report.files ?? {};
+  for (const fileReport of Object.values(files)) {
+    for (const mutant of fileReport.mutants ?? []) {
+      switch (mutant.status) {
+        case "Killed":
+          counts.killed++;
+          break;
+        case "Timeout":
+          counts.timeout++;
+          break;
+        case "Survived":
+          counts.survived++;
+          break;
+        case "NoCoverage":
+          counts.noCoverage++;
+          break;
+        default:
+          // CompileError / RuntimeError / Ignored — excluded from the score.
+          counts.other++;
+      }
+    }
+  }
+  counts.total =
+    counts.killed + counts.timeout + counts.survived + counts.noCoverage;
+  return counts;
+}
+
+/**
+ * Total mutation score (0..100). Detected = Killed + Timeout; the denominator
+ * counts uncaught mutants (Survived) and untested code (NoCoverage). Returns
+ * null when there are zero score-relevant mutants (nothing to judge).
+ *
+ * @param {ReturnType<typeof tallyMutants>} counts
+ * @returns {number|null}
+ */
+export function mutationScore(counts) {
+  if (counts.total === 0) return null;
+  return ((counts.killed + counts.timeout) / counts.total) * 100;
+}
+
+function resolveBudget(args) {
+  if (process.env.MUTATION_BUDGET !== undefined) {
+    return {
+      value: Number(process.env.MUTATION_BUDGET),
+      source: "env MUTATION_BUDGET",
+    };
+  }
+  if (args.budget !== undefined && args.budget !== true) {
+    return { value: Number(args.budget), source: "--budget" };
+  }
+  const pkg = process.env.MUTATION_PACKAGE ?? args.package;
+  if (!pkg || pkg === true) {
+    throw new Error(
+      "no budget given — pass --budget <n>, --package <key>, or set MUTATION_BUDGET",
+    );
+  }
+  const budgetFile =
+    process.env.MUTATION_BUDGET_FILE ??
+    resolve(SCRIPT_DIR, "mutation-budget.json");
+  const parsed = JSON.parse(readFileSync(budgetFile, "utf8"));
+  const budgets = parsed.budgets ?? parsed;
+  if (budgets[pkg] === undefined) {
+    throw new Error(
+      `budget key "${pkg}" not found in ${budgetFile} (keys: ${Object.keys(budgets).join(", ")})`,
+    );
+  }
+  return { value: Number(budgets[pkg]), source: `${budgetFile}#${pkg}` };
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const reportPath = process.env.MUTATION_REPORT ?? args.report;
+  if (!reportPath || reportPath === true) {
+    console.error(
+      "❌ mutation-score gate: no report path — pass --report <path> or set MUTATION_REPORT",
+    );
+    process.exit(1);
+  }
+
+  let report;
+  try {
+    report = JSON.parse(readFileSync(reportPath, "utf8"));
+  } catch (e) {
+    // Fail-closed: a missing/unparseable report means the nightly run did not
+    // produce a verdict — treat that as RED, never silently green.
+    console.error(
+      `❌ mutation-score gate: cannot read Stryker report ${reportPath}: ${e.message}`,
+    );
+    process.exit(1);
+  }
+
+  let budget;
+  try {
+    budget = resolveBudget(args);
+  } catch (e) {
+    console.error(`❌ mutation-score gate: ${e.message}`);
+    process.exit(1);
+  }
+
+  const counts = tallyMutants(report);
+  const score = mutationScore(counts);
+  const label =
+    process.env.MUTATION_PACKAGE ??
+    (args.package && args.package !== true ? args.package : "report");
+
+  if (score === null) {
+    console.error(
+      `❌ mutation-score gate [${label}]: report has zero score-relevant mutants — nothing was tested (failing closed).`,
+    );
+    process.exit(1);
+  }
+
+  const scoreStr = score.toFixed(2);
+  const detail =
+    `killed=${counts.killed} timeout=${counts.timeout} ` +
+    `survived=${counts.survived} no-coverage=${counts.noCoverage}` +
+    (counts.other ? ` (excluded: ${counts.other})` : "");
+
+  // Optional GitHub job-summary observability (markdown).
+  const summaryPath =
+    args.summary && args.summary !== true
+      ? args.summary
+      : process.env.GITHUB_STEP_SUMMARY;
+  if (summaryPath) {
+    const verdict = score >= budget.value ? "✅ PASS" : "❌ BELOW BUDGET";
+    try {
+      appendFileSync(
+        summaryPath,
+        `| \`${label}\` | **${scoreStr}%** | ${budget.value}% | ${verdict} | ` +
+          `${counts.killed} | ${counts.timeout} | ${counts.survived} | ${counts.noCoverage} |\n`,
+      );
+    } catch {
+      /* summary is best-effort observability — never fail the gate over it */
+    }
+  }
+
+  if (score < budget.value) {
+    console.error(
+      `❌ mutation-score gate [${label}]: ${scoreStr}% < break-budget ${budget.value}% (${budget.source})`,
+    );
+    console.error(`   ${detail}`);
+    console.error(
+      "\n   A surviving mutant above budget means a test gap: source was mutated and\n" +
+        "   NO test failed. Kill the surviving mutants (strengthen the tests) — see the\n" +
+        "   Stryker HTML report. To lower the budget instead, edit scripts/mutation-budget.json\n" +
+        "   (a conscious withdrawal under RFC 0003 everything-req-first).",
+    );
+    process.exit(1);
+  }
+
+  console.log(
+    `✅ mutation-score gate [${label}]: ${scoreStr}% >= break-budget ${budget.value}% (${budget.source})`,
+  );
+  console.log(`   ${detail}`);
+}
+
+main();

--- a/scripts/mutation-budget.json
+++ b/scripts/mutation-budget.json
@@ -1,0 +1,7 @@
+{
+  "_comment": "Mutation-score break-budgets per package (test-quality plan P4, RFC 0003 everything-req-first). The NIGHTLY mutation workflow (.github/workflows/mutation-nightly.yml) runs Stryker over packages/{core,cli}/src and fails when the total mutation score (killed+timeout over killed+timeout+survived+no-coverage) falls BELOW the budget here. These are INTENTIONALLY conservative honest floors — initial mutation scores can be low, and the first nightly run on main establishes the real baseline. RATCHET each number UP (toward the observed score minus a small margin) as the suite hardens; LOWERING a number is a conscious withdrawal that, under everything-req-first, requires a req__Requirement justification. NOT a PR-gating check (decision Q2: nightly only — a full Stryker run is too slow for the critical PR path).",
+  "budgets": {
+    "core": 40,
+    "cli": 40
+  }
+}

--- a/stryker.cli.config.mjs
+++ b/stryker.cli.config.mjs
@@ -1,0 +1,99 @@
+/**
+ * @type {import('@stryker-mutator/api').PartialStrykerOptions}
+ *
+ * Stryker mutation-testing config — packages/cli (ESM jest).
+ *
+ * Companion to stryker.config.mjs (core). The CLI package is ESM
+ * (`"type": "module"`), so its jest runs under `useESM` ts-jest +
+ * `--experimental-vm-modules` (set in NODE_OPTIONS by the npm script and the
+ * nightly workflow). This config mirrors packages/cli/jest.config.js exactly so
+ * the Stryker dry-run reproduces the real CLI test environment (incl. the
+ * reflect-metadata setup tsyringe DI requires and the `@kitelev/exocortex-*`
+ * source moduleNameMappers).
+ *
+ * Test-quality improvement-plan 2026-06-22 (P4). Nightly cron only — NOT a
+ * required PR check (decision Q2). Gate: scripts/check-mutation-score.mjs
+ * against scripts/mutation-budget.json (`cli`).
+ *
+ * @see https://stryker-mutator.io/docs/stryker-js/configuration/
+ */
+export default {
+  packageManager: "npm",
+  reporters: ["html", "clear-text", "progress", "json"],
+  testRunner: "jest",
+
+  jest: {
+    projectType: "custom",
+    config: {
+      preset: "ts-jest",
+      testEnvironment: "node",
+      rootDir: "packages/cli",
+      testMatch: ["<rootDir>/tests/**/*.test.ts"],
+      setupFilesAfterEnv: ["<rootDir>/tests/setup.ts"],
+      moduleNameMapper: {
+        "^@kitelev/exocortex-core$": "<rootDir>/../core/src/index.ts",
+        "^@kitelev/exocortex-services$": "<rootDir>/../services/src/index.ts",
+        "^(\\.{1,2}/.*)\\.js$": "$1",
+      },
+      transform: {
+        "^.+\\.tsx?$": [
+          "ts-jest",
+          {
+            useESM: true,
+            // Mutated source may not type-check; skip the check (Stryker measures
+            // behaviour, not types).
+            isolatedModules: true,
+            tsconfig: {
+              module: "ESNext",
+              moduleResolution: "node",
+              esModuleInterop: true,
+            },
+          },
+        ],
+      },
+      transformIgnorePatterns: ["node_modules/(?!(uuid)/)"],
+      extensionsToTreatAsEsm: [".ts"],
+      forceExit: true,
+      testTimeout: 60000,
+    },
+    enableFindRelatedTests: true,
+  },
+
+  checkers: [],
+  coverageAnalysis: "perTest",
+  timeoutMS: 60000,
+  timeoutFactor: 2.5,
+  concurrency: process.env.CI ? 3 : 4,
+  inPlace: true,
+
+  incremental: true,
+  incrementalFile: "reports/mutation/incremental-cli.json",
+
+  mutate: [
+    "packages/cli/src/**/*.ts",
+    "!packages/cli/src/**/*.d.ts",
+    "!packages/cli/src/**/index.ts",
+    "!packages/cli/src/**/*.test.ts",
+    // daily-review.ts is excluded from cli coverage (logic tested via
+    // DailyReviewService) — exclude from mutation for the same reason.
+    "!packages/cli/src/commands/daily-review.ts",
+  ],
+
+  ignorePatterns: [
+    "node_modules",
+    "dist",
+    "reports",
+    "**/*.test.ts",
+    "**/*.spec.ts",
+    "**/tests/**",
+    "*.d.ts",
+    ".stryker-tmp",
+  ],
+
+  thresholds: { high: 80, low: 60, break: null },
+
+  jsonReporter: { fileName: "reports/mutation/mutation-cli.json" },
+  htmlReporter: { fileName: "reports/mutation/mutation-cli.html" },
+  tempDirName: ".stryker-tmp",
+  logLevel: process.env.CI ? "info" : "debug",
+};

--- a/stryker.config.mjs
+++ b/stryker.config.mjs
@@ -1,0 +1,105 @@
+/**
+ * @type {import('@stryker-mutator/api').PartialStrykerOptions}
+ *
+ * Stryker mutation-testing config — packages/core (deterministic engine, CommonJS jest).
+ *
+ * Mutation testing modifies source ("mutants") and checks whether a test fails
+ * ("kills" the mutant). A surviving mutant is a test gap the manual per-fix
+ * revert-verify discipline cannot find systemically — it proves WHERE the suite
+ * is theater. Mutation score = (killed + timeout) / (killed + timeout +
+ * survived + no-coverage).
+ *
+ * Test-quality improvement-plan 2026-06-22 (P4). This runs in the NIGHTLY cron
+ * workflow only (.github/workflows/mutation-nightly.yml) — a full Stryker run is
+ * far too slow for the required PR path (decision Q2: core+cli, nightly, NOT
+ * PR-gating). `scripts/check-mutation-score.mjs` reads the JSON report and
+ * fails when the score drops below the honest break-budget in
+ * scripts/mutation-budget.json (`core`).
+ *
+ * The score-gate is the script (not Stryker's own `break`) so the workflow can
+ * always emit the job-summary observability even on a below-budget run.
+ *
+ * Speed: `enableFindRelatedTests` + `coverageAnalysis: perTest` run only the
+ * covering tests per mutant; `incremental` reuses prior results across nightly
+ * runs (the workflow persists the incremental file via actions/cache), so only
+ * changed files are re-mutated after the first (slow) baseline run.
+ *
+ * @see https://stryker-mutator.io/docs/stryker-js/configuration/
+ */
+export default {
+  packageManager: "npm",
+  reporters: ["html", "clear-text", "progress", "json"],
+  testRunner: "jest",
+
+  jest: {
+    projectType: "custom",
+    config: {
+      preset: "ts-jest",
+      testEnvironment: "node",
+      rootDir: "packages/core",
+      roots: ["<rootDir>/tests"],
+      testMatch: ["**/?(*.)+(spec|test).ts"],
+      // Performance micro-benchmarks assert wall-clock time — flaky under
+      // mutation instrumentation + irrelevant to mutation score. Excluded.
+      testPathIgnorePatterns: ["/node_modules/", "/tests/performance/"],
+      setupFiles: ["reflect-metadata"],
+      transformIgnorePatterns: ["node_modules/(?!(uuid)/)"],
+      transform: {
+        // isolatedModules: mutated source may not type-check; skip the check so
+        // the mutant is run, not rejected by tsc (Stryker measures behaviour).
+        "^.+\\.ts$": ["ts-jest", { isolatedModules: true }],
+        "^.+\\.(js|mjs)$": "babel-jest",
+      },
+      forceExit: true,
+      testTimeout: 60000,
+    },
+    enableFindRelatedTests: true,
+  },
+
+  // Type-checking mutants is disabled (isolatedModules above) — a typescript
+  // checker would reject mutants on pre-existing test-file type quirks.
+  checkers: [],
+
+  coverageAnalysis: "perTest",
+  timeoutMS: 60000,
+  timeoutFactor: 2.5,
+  // GH ubuntu-latest = 4 cores; leave one for the orchestrator process.
+  concurrency: process.env.CI ? 3 : 4,
+
+  // In-place mode avoids the sandbox-copy cost + monorepo path-resolution issues
+  // (Stryker backs up originals and restores them after the run).
+  inPlace: true,
+
+  // Incremental: reuse prior mutant results; only re-mutate changed files. The
+  // nightly workflow persists this file via actions/cache so the first run is
+  // the slow full baseline and subsequent runs are fast.
+  incremental: true,
+  incrementalFile: "reports/mutation/incremental-core.json",
+
+  mutate: [
+    "packages/core/src/**/*.ts",
+    "!packages/core/src/**/*.d.ts",
+    "!packages/core/src/**/index.ts",
+    "!packages/core/src/**/*.test.ts",
+  ],
+
+  ignorePatterns: [
+    "node_modules",
+    "dist",
+    "reports",
+    "**/*.test.ts",
+    "**/*.spec.ts",
+    "**/tests/**",
+    "*.d.ts",
+    ".stryker-tmp",
+  ],
+
+  // Stryker never self-fails — scripts/check-mutation-score.mjs is the gate, so
+  // the workflow always reaches the job-summary step. high/low colour the report.
+  thresholds: { high: 80, low: 60, break: null },
+
+  jsonReporter: { fileName: "reports/mutation/mutation-core.json" },
+  htmlReporter: { fileName: "reports/mutation/mutation-core.html" },
+  tempDirName: ".stryker-tmp",
+  logLevel: process.env.CI ? "info" : "debug",
+};


### PR DESCRIPTION
## What

Mutation testing for `packages/core` + `packages/cli` via **Stryker**, run as a **nightly cron** (NOT a required PR check). Test-quality improvement-plan **P4** (Exocortex Alpha Launch, everything-req-first SDD-loop).

Mutation testing **proves the suite actually catches bugs**: it modifies source ("mutants") and checks whether a test fails ("kills" the mutant). A surviving mutant is a test gap the line-coverage gate is blind to — the automated form of the manual per-fix revert-verify, applied systemically.

## Why nightly + core/cli only (Andrew's audit-locked decisions)

- **core + cli** — deterministic engine + fast CLI. plugin/e2e excluded (far too slow under mutation).
- **nightly cron, NOT PR-gating** — a full Stryker run (~1.5–2.5h first baseline) is too slow for the critical PR path. Stryker `incremental` (persisted via actions/cache) makes subsequent runs fast.

## Changes

| File | Role |
|---|---|
| `stryker.config.mjs` | core mutation config (CommonJS jest, perTest + find-related + incremental, inPlace) |
| `stryker.cli.config.mjs` | cli mutation config (ESM jest — `--experimental-vm-modules`, mirrors cli jest.config) |
| `scripts/check-mutation-score.mjs` | break-budget gate — reads Stryker JSON, score = `(killed+timeout)/(killed+timeout+survived+no-coverage)`, fails below budget (fail-closed on missing/empty), appends score to `$GITHUB_STEP_SUMMARY` |
| `scripts/mutation-budget.json` | conservative honest floors (core/cli=40), ratchet UP as the suite hardens |
| `.github/workflows/mutation-nightly.yml` | cron 03:30 UTC, matrix core+cli, submodules recursive, incremental cache, gate + HTML-report artifact |
| `check-mutation-score.test.ts` | **`@req:7af848cd`** integration binding (required CI) — drives the real gate vs fixture reports |
| `TESTING.md` | Mutation Testing (nightly) section |

## Verification

**Gate-script binding (required CI):** `check-mutation-score.test.ts` 5/5 — below-budget→RED (exit 1), at/above→GREEN (exit 0), missing/zero-mutant→fail-closed.

**End-to-end revert-verify (real Stryker, on-demand local):** `DateFormatter.ts` scored **91.43%** (96 killed / 7 survived) → gate@88 = **GREEN**. Skipping its 5 mutation-killing `describe` blocks (escaped mutants 7→23 survived) dropped it to **76.19%** → gate@88 = **RED (exit 1)**; restoring → GREEN. Full pipeline (Stryker → JSON → gate → red/green) proven on real core source. CLI ESM harness proven on `QueryPrefixInjector.ts` (76.24%, 101 mutants).

## SDD requirement

`req(testsys)` **kitelev/exoas-exo-reqs@20609fd** — status `approved` (self, direction-owner). Flips to `active` after this PR merges (so the `@req` binding is on main and the active-requirement gate is satisfied).

## Scope note (honest)

The configs declare full `packages/{core,cli}/src` as the mutation scope; the **first nightly run on `main` establishes the real baseline** (which I can't run fully locally — multi-hour). Budgets start at a conservative floor (40) and ratchet up once the real score is known. The nightly workflow itself does NOT run on this PR (it's cron/dispatch only) — required CI validates the gate script + binding test + configs (typecheck/lint).
