### PR TITLE
fix(sync): ExoSync keep-local consolidates cross-path (co-located rename) conflicts (#3729)

### DIFF
--- a/packages/core/src/services/sync/SyncEngine.ts
+++ b/packages/core/src/services/sync/SyncEngine.ts
@@ -1636,10 +1636,40 @@ export class SyncEngine {
     for (const entry of pending) {
       const currentRemoteSha =
         remoteShaByPath.get(entry.path) ?? OUTBOX_REMOTE_ABSENT;
-      if (currentRemoteSha !== entry.baseRemoteSha) {
-        // ⛤ TOCTOU: the remote moved since the offline resolution. Never
-        // overwrite — drop the queued push; the still-pinned path re-derives the
-        // conflict in this sync's detect (the user's choice is on disk).
+
+      // ── Cross-path consolidation (#3729) ────────────────────────────────
+      // A resolved conflict whose asset's remote copy lives at a DIFFERENT
+      // path than the conflict path (a co-located rename of the SAME asset:
+      // local `tbank-efforts/X.md` ↔ remote `og/X.md`). The conflict path is
+      // ABSENT on the remote, yet some SIBLING remote path still holds EXACTLY
+      // the blob the resolution was based on (`baseRemoteSha`) — that sibling
+      // IS the stale remote copy. Without this, the per-path TOCTOU below reads
+      // the conflict path (absent) ≠ baseRemoteSha and drops the push FOREVER,
+      // while the sibling re-introduces the conflict on every sync ("keep local
+      // never sticks"). Resolution: push the chosen content to the conflict
+      // path AND delete the stale sibling(s) in the SAME commit, converging the
+      // asset to ONE remote path. Zero-loss: the deleted blob survives in git
+      // history (forward commit, never a rewrite) and in the device-local
+      // conflict cache. A genuine TOCTOU (remote truly moved — the based-on
+      // blob is gone from the tree entirely) yields NO sibling match and still
+      // drops below. The match is CONTENT-ADDRESSED (a sibling qualifies iff it
+      // STILL holds exactly the based-on blob), so deleting it discards exactly
+      // the remote version the user already saw and superseded — never an
+      // independent edit. (Assets carry a unique `exo__Asset_uid`, so a
+      // byte-identical-but-distinct asset cannot collide on the blob-SHA.)
+      const stalePaths =
+        currentRemoteSha === OUTBOX_REMOTE_ABSENT &&
+        entry.baseRemoteSha !== OUTBOX_REMOTE_ABSENT
+          ? [...remoteShaByPath]
+              .filter(([p, sha]) => p !== entry.path && sha === entry.baseRemoteSha)
+              .map(([p]) => p)
+          : [];
+
+      if (currentRemoteSha !== entry.baseRemoteSha && stalePaths.length === 0) {
+        // ⛤ TOCTOU: the remote moved since the offline resolution AND no sibling
+        // path still holds the based-on blob. Never overwrite — drop the queued
+        // push; the still-pinned path re-derives the conflict in this sync's
+        // detect (the user's choice is on disk).
         await outbox.remove(entry.repoKey, entry.path);
         reconflicted++;
         warnings.push(
@@ -1649,7 +1679,8 @@ export class SyncEngine {
         );
         continue;
       }
-      // Remote unchanged at our guard-read → push the chosen content. The
+      // Push the chosen content (same-path: remote unchanged at our guard-read;
+      // cross-path: the SAME commit deletes the stale sibling copies). The
       // `expectedHeadSha` CAS closes the window between THIS guard-read and
       // restCreateCommit's own ref-read: if the head moved in between, the push
       // aborts (no overwrite) and we leave the entry to retry next sync — which
@@ -1661,7 +1692,11 @@ export class SyncEngine {
           repo: spec.repo,
           branch: spec.branch,
           files: new Map([[entry.path, entry.chosenContent]]),
-          message: `chore(exosync): push resolved conflict for ${entry.path}`,
+          ...(stalePaths.length > 0 ? { deletions: stalePaths } : {}),
+          message:
+            stalePaths.length > 0
+              ? `chore(exosync): resolve cross-path conflict for ${entry.path} (consolidate ${stalePaths.length} stale remote path(s))`
+              : `chore(exosync): push resolved conflict for ${entry.path}`,
           expectedHeadSha: head,
           ...(this.deps.baseURL !== undefined ? { baseURL: this.deps.baseURL } : {}),
           ...(this.deps.redact !== undefined ? { redact: this.deps.redact } : {}),
@@ -1672,10 +1707,25 @@ export class SyncEngine {
         );
         continue; // leave the entry; never overwrite on a failed/raced/moved push
       }
-      await this.snapOutboxWatermark(spec, entry.path, entry.chosenContent);
+      await this.snapOutboxWatermark(
+        spec,
+        entry.path,
+        entry.chosenContent,
+        stalePaths,
+      );
       await this.deps.quarantine?.markResolved?.(entry.repoKey, entry.path);
+      // Stale sibling copies were deleted on the remote — clear their cross-
+      // device unresolved-count too (best-effort; most have no cache entry).
+      for (const sp of stalePaths) {
+        await this.deps.quarantine?.markResolved?.(entry.repoKey, sp);
+      }
       await outbox.remove(entry.repoKey, entry.path);
       pushed++;
+      if (stalePaths.length > 0) {
+        warnings.push(
+          `consolidated cross-path conflict for ${entry.path} — removed ${stalePaths.length} stale remote copy/copies (recoverable in git history)`,
+        );
+      }
     }
     if (pushed > 0) {
       warnings.push(`pushed ${pushed} resolved conflict(s)`);
@@ -1727,18 +1777,27 @@ export class SyncEngine {
     spec: SyncRepoSpec,
     path: string,
     chosen: string,
+    stalePaths: readonly string[] = [],
   ): Promise<void> {
     const record = await this.deps.watermarkStore.get(spec.repoKey);
     if (record === null) return;
-    const pinnedPaths = (record.pinnedPaths ?? []).filter((p) => p !== path);
+    // Unpin the resolved path AND any stale sibling paths consolidated away
+    // (#3729) — their remote copies were deleted in the resolution commit, so
+    // they must not keep re-deriving the conflict.
+    const removeFromPins = new Set<string>([path, ...stalePaths]);
+    const pinnedPaths = (record.pinnedPaths ?? []).filter(
+      (p) => !removeFromPins.has(p),
+    );
     const blobSha = await gitBlobSha(chosen, this.sha1);
     const uid = extractAssetUid(chosen);
     const entry = { path, blobSha, ...(uid !== undefined ? { uid } : {}) };
-    const idx = record.files.findIndex((f) => f.path === path);
+    // Drop base entries for the consolidated-away stale paths before snapping
+    // the surviving path — their remote blobs no longer exist.
+    const staleSet = new Set(stalePaths);
+    const base = record.files.filter((f) => !staleSet.has(f.path));
+    const idx = base.findIndex((f) => f.path === path);
     const files =
-      idx >= 0
-        ? record.files.map((f, i) => (i === idx ? entry : f))
-        : [...record.files, entry];
+      idx >= 0 ? base.map((f, i) => (i === idx ? entry : f)) : [...base, entry];
     await this.deps.watermarkStore.set(spec.repoKey, {
       ...record,
       files,

--- a/packages/core/tests/unit/services/sync/SyncEngine.outbox.test.ts
+++ b/packages/core/tests/unit/services/sync/SyncEngine.outbox.test.ts
@@ -232,3 +232,151 @@ describe("ExoSync deferred-push outbox — resolve queues, sync flushes (PR-3b)"
     expect(await s.resolver.listOpenConflicts([s.spec])).toHaveLength(0);
   });
 });
+
+// ── Cross-path conflict consolidation (#3729) ───────────────────────────────
+// The exact production bug: a co-location reorg moved an asset on the REMOTE
+// (flat `tbank-efforts/x.md` → co-located `og/x.md`) while the local vault kept
+// the flat path, and the asset's frontmatter diverged on both sides (no common
+// base). ExoSync correctly quarantines, but pre-fix "keep local" NEVER stuck:
+// the flush read the conflict (flat) path — ABSENT on the remote — against the
+// based-on remote blob and dropped the push forever as a phantom TOCTOU, while
+// the co-located sibling re-introduced the conflict every sync. The fix: the
+// flush detects that the based-on blob still lives at a SIBLING remote path and
+// CONSOLIDATES (push chosen → conflict path + delete the stale sibling in one
+// zero-loss commit) instead of dropping.
+const SHARED = "shared/keep.md";
+const SHARED_BODY = mdAsset("keep", "shared, unchanged on both sides");
+const FLAT = "tbank-efforts/x.md"; // local (old flat) path
+const COLOCATED = "og/x.md"; // remote (new co-located) path — SAME uid
+const FLAT_LOCAL = mdAsset("u1", "LOCAL edit, flat isDefinedBy");
+const COLOCATED_REMOTE = mdAsset("u1", "REMOTE edit, co-located isDefinedBy");
+
+function setupXPath() {
+  const gh = new FakeGitHubRepo({ [SHARED]: SHARED_BODY });
+  const cache = new LocalConflictCacheStore({ io: memIO() });
+  const outbox = new LocalOutboxStore({ io: memIO() });
+  const watermarks = new FakeWatermarkStore();
+  const disk = new FakeLocalFiles({ [SHARED]: SHARED_BODY });
+  const engine = new SyncEngine({
+    transport: gh.transport(),
+    watermarkStore: watermarks,
+    materializationCheck: alwaysMaterialized(),
+    localFilesFor: () => disk,
+    sha1: sha1Hex,
+    quarantine: cache,
+    outbox,
+    mergeLayer: forceQuarantine,
+  });
+  const resolver = new QuarantineResolver({
+    transport: gh.transport(),
+    watermarkStore: watermarks,
+    localFilesFor: () => disk,
+    sha1: sha1Hex,
+    conflictCache: cache,
+    outbox,
+  });
+  return { gh, cache, outbox, watermarks, disk, engine, resolver, spec: gh.spec() };
+}
+
+/** Bootstrap converged, then introduce a cross-path same-uid divergence. */
+async function crossPathConflict(
+  s: ReturnType<typeof setupXPath>,
+): Promise<string> {
+  await s.engine.sync(s.spec); // bootstrap (disk == remote == {SHARED})
+  // Local keeps the asset at the FLAT path; the remote co-location migration
+  // put the SAME uid at the CO-LOCATED path with different frontmatter.
+  s.disk.files.set(FLAT, FLAT_LOCAL);
+  s.gh.commitDirect(
+    "main",
+    { [SHARED]: SHARED_BODY, [COLOCATED]: COLOCATED_REMOTE },
+    "remote co-location migration",
+  );
+  const r = await s.engine.sync(s.spec);
+  expect(r.quarantinedCount).toBeGreaterThanOrEqual(1);
+  const open = await s.resolver.listOpenConflicts([s.spec]);
+  expect(open.length).toBeGreaterThanOrEqual(1);
+  return open[0].path; // the conflict (flat) path the user resolves
+}
+
+describe("ExoSync cross-path conflict consolidation (#3729)", () => {
+  it("@req:5bcfe5d0-a64c-4c87-85a4-7fb8e3140c78 keep-local of a co-located rename consolidates: pushes local to the flat path AND deletes the stale co-located remote copy, converging (was a phantom TOCTOU drop)", async () => {
+    const s = setupXPath();
+    const conflictPath = await crossPathConflict(s);
+
+    await s.resolver.resolve(s.spec, conflictPath, { take: "local" });
+    // Deferred (outbox), still pinned, NOT yet pushed.
+    expect(await s.outbox.listForRepo(s.spec.repoKey)).toHaveLength(1);
+
+    const flush = await s.engine.sync(s.spec);
+    expect(flush.outboxPushedCount).toBe(1);
+    expect(flush.outboxReconflictedCount ?? 0).toBe(0);
+
+    // Remote converged to ONE path (the flat conflict path) with the local
+    // content; the stale co-located sibling is GONE (deleted, recoverable in
+    // git history); SHARED untouched.
+    const head = s.gh.headFiles();
+    expect(head.get(conflictPath)).toBe(FLAT_LOCAL);
+    expect(head.has(COLOCATED)).toBe(false);
+    expect(head.get(SHARED)).toBe(SHARED_BODY);
+
+    // Outbox drained, conflict cleared, no re-conflict on a subsequent sync.
+    expect(await s.outbox.listForRepo(s.spec.repoKey)).toHaveLength(0);
+    expect(await s.resolver.listOpenConflicts([s.spec])).toHaveLength(0);
+    const after = await s.engine.sync(s.spec);
+    expect(after.quarantinedCount).toBe(0);
+    expect(after.status).toBe("synced");
+  });
+
+  it("⛤ zero-loss: a genuine cross-path TOCTOU (the stale sibling itself moved) does NOT delete anything — drops and re-conflicts", async () => {
+    const s = setupXPath();
+    const conflictPath = await crossPathConflict(s);
+    await s.resolver.resolve(s.spec, conflictPath, { take: "local" });
+
+    // The co-located sibling is edited again on the remote AFTER the offline
+    // resolution → the based-on blob is no longer anywhere in the tree → no
+    // sibling match → never delete, drop instead.
+    s.gh.commitDirect(
+      "main",
+      { [SHARED]: SHARED_BODY, [COLOCATED]: mdAsset("u1", "remote moved AGAIN") },
+      "device C",
+    );
+
+    const flush = await s.engine.sync(s.spec);
+    expect(flush.outboxPushedCount ?? 0).toBe(0);
+    expect(flush.outboxReconflictedCount).toBe(1);
+    // The remote sibling is preserved (never overwritten/deleted).
+    expect(s.gh.headFiles().get(COLOCATED)).toBe(mdAsset("u1", "remote moved AGAIN"));
+  });
+
+  it("consolidates ALL stale siblings when the based-on blob is duplicated across ≥2 remote paths (one commit deletes every copy)", async () => {
+    const s = setupXPath();
+    const conflictPath = await crossPathConflict(s);
+    await s.resolver.resolve(s.spec, conflictPath, { take: "local" });
+
+    // Before the flush, a SECOND remote sibling appears holding the SAME
+    // based-on blob (a uid duplicated to a third co-located path). The
+    // match is CONTENT-ADDRESSED (blob-SHA), so BOTH siblings must be
+    // consolidated away in the single resolution commit.
+    const COLOCATED_2 = "archive/x.md";
+    s.gh.commitDirect(
+      "main",
+      {
+        [SHARED]: SHARED_BODY,
+        [COLOCATED]: COLOCATED_REMOTE,
+        [COLOCATED_2]: COLOCATED_REMOTE, // same content → same blob-SHA
+      },
+      "uid duplicated to a second co-located path",
+    );
+
+    const flush = await s.engine.sync(s.spec);
+    expect(flush.outboxPushedCount).toBe(1);
+    expect(flush.outboxReconflictedCount ?? 0).toBe(0);
+
+    const head = s.gh.headFiles();
+    expect(head.get(conflictPath)).toBe(FLAT_LOCAL); // converged to the flat path
+    expect(head.has(COLOCATED)).toBe(false); // both stale copies gone
+    expect(head.has(COLOCATED_2)).toBe(false);
+    expect(head.get(SHARED)).toBe(SHARED_BODY); // unrelated file untouched
+    expect(await s.resolver.listOpenConflicts([s.spec])).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
Closes #3729.

## Problem
When the same asset (same `exo__Asset_uid`) exists locally at one path and on the remote at a **different** path — a co-located rename, e.g. local `tbank-efforts/X.md` ↔ remote `og/X.md` — with divergent frontmatter and no common sync base, ExoSync correctly quarantines, but **"keep local" never sticks**: every sync re-reports the conflict.

`SyncEngine.flushOutbox` keyed its TOCTOU check on `remoteShaByPath.get(entry.path)` where `entry.path` is the **conflict (local) path** — ABSENT on the remote (which holds the asset at the sibling co-located path). So `currentRemoteSha = ABSENT ≠ entry.baseRemoteSha` → the deferred push was **dropped as a phantom TOCTOU on every sync**, while the stale co-located sibling re-introduced the conflict each detect. The push never landed.

Confirmed on a real work vault (profile `$$kitelev-tbank`): `exoas-tbank` had 14 pins = 7 assets each pinned at BOTH a flat path and a co-located path; empty outbox (every resolve TOCTOU-dropped); `reason: "exo__Asset_isDefinedBy changed differently on both sides"`.

## Fix
`flushOutbox`: when the conflict path is absent on the remote but a **sibling** remote path still holds **exactly** `entry.baseRemoteSha` (the based-on blob), that sibling IS the stale remote copy → push the chosen content to the conflict path **AND delete the stale sibling(s) in the same `restCreateCommit`** (`deletions` + `expectedHeadSha` CAS), converging the asset to one remote path. A genuine TOCTOU (the based-on blob gone from the tree entirely) yields no sibling match and still drops — never deletes. `snapOutboxWatermark` also unpins + drops base entries for the consolidated stale paths.

**Zero-loss:** the deleted sibling survives in git history (forward commit, never a rewrite) + the device-local conflict cache.

## Verification
- **Revert-verified** (RED→GREEN): reverting the fix makes the consolidation + multi-sibling tests fail (`outboxPushedCount` undefined — flush dropped it); the same-path/genuine-TOCTOU tests stay green.
- New tests in `SyncEngine.outbox.test.ts` (`ExoSync cross-path conflict consolidation (#3729)`): single-sibling consolidation (`@req:5bcfe5d0-...`), genuine-TOCTOU drop (zero-loss), multi-sibling consolidation.
- Full sync suite **400/400**; outbox suite **9/9**; typecheck clean; archgate 23/23; eslint clean.
- code-reviewer agent: **APPROVE**, 0 CRITICAL/HIGH (zero-loss + CAS + restCreateCommit contract verified).
- Reverse-documented as `req__Requirement` `@req:5bcfe5d0-a64c-4c87-85a4-7fb8e3140c78` in `exoas-exo-reqs` (status Active, revert-verified).

Same-path flush behavior is byte-identical (existing 6 outbox tests unchanged).
