### PR TITLE
fix(sync): ExoSync keep-local batch head-staleness — all N stragglers converge in ONE sync

### DIFF
--- a/packages/core/src/services/sync/SyncEngine.ts
+++ b/packages/core/src/services/sync/SyncEngine.ts
@@ -1631,8 +1631,14 @@ export class SyncEngine {
       return { pushed: 0, reconflicted: 0 };
     }
 
-    let pushed = 0;
+    // ── Phase 1: classify every queued resolution against the ONE head-tree
+    // snapshot captured above (no head mutation yet). TOCTOU-skips drop here;
+    // the rest are collected into a single batch. ───────────────────────────
     let reconflicted = 0;
+    const pushable: Array<{
+      entry: (typeof pending)[number];
+      stalePaths: string[];
+    }> = [];
     for (const entry of pending) {
       const currentRemoteSha =
         remoteShaByPath.get(entry.path) ?? OUTBOX_REMOTE_ABSENT;
@@ -1679,51 +1685,94 @@ export class SyncEngine {
         );
         continue;
       }
-      // Push the chosen content (same-path: remote unchanged at our guard-read;
-      // cross-path: the SAME commit deletes the stale sibling copies). The
-      // `expectedHeadSha` CAS closes the window between THIS guard-read and
-      // restCreateCommit's own ref-read: if the head moved in between, the push
-      // aborts (no overwrite) and we leave the entry to retry next sync — which
-      // re-checks the per-path TOCTOU and re-conflicts if needed. force:false
-      // additionally guards restCreateCommit's own GET→PATCH window (→ 422).
-      try {
-        await restCreateCommit(this.transport, {
-          owner: spec.owner,
-          repo: spec.repo,
-          branch: spec.branch,
-          files: new Map([[entry.path, entry.chosenContent]]),
-          ...(stalePaths.length > 0 ? { deletions: stalePaths } : {}),
-          message:
-            stalePaths.length > 0
-              ? `chore(exosync): resolve cross-path conflict for ${entry.path} (consolidate ${stalePaths.length} stale remote path(s))`
-              : `chore(exosync): push resolved conflict for ${entry.path}`,
-          expectedHeadSha: head,
-          ...(this.deps.baseURL !== undefined ? { baseURL: this.deps.baseURL } : {}),
-          ...(this.deps.redact !== undefined ? { redact: this.deps.redact } : {}),
-        });
-      } catch (err) {
-        warnings.push(
-          `outbox: push deferred for ${entry.path}, will retry next sync: ${redact(errMsg(err))}`,
-        );
-        continue; // leave the entry; never overwrite on a failed/raced/moved push
+      pushable.push({ entry, stalePaths });
+    }
+
+    if (pushable.length === 0) {
+      return { pushed: 0, reconflicted };
+    }
+
+    // ── Phase 2: ONE atomic commit for ALL pushable resolutions (batch
+    // head-staleness fix). Pre-fix this loop pushed each resolution in its OWN
+    // restCreateCommit: the FIRST push moved heads/{branch}, so the 2nd…Nth
+    // pushes (each carrying the head captured ONCE above as `expectedHeadSha`)
+    // failed the CAS guard with "head moved", were deferred and re-quarantined
+    // in the SAME sync — only ONE straggler converged per sync, the rest
+    // re-surfaced (Andrey's 7-straggler keep-local that never stuck). Committing
+    // every chosen content + the union of stale-sibling deletions in a SINGLE
+    // tree update moves the head exactly once, so all queued keep-local
+    // resolutions land in one sync. restCreateCommit already builds a recursive
+    // multi-file tree with `sha:null` deletions (#3476), so one commit expresses
+    // N writes + M deletes. Atomic = all-or-nothing: a genuine concurrent
+    // EXTERNAL writer (head moved between our head fetch and our one commit)
+    // aborts the WHOLE batch via `expectedHeadSha` → every entry stays queued
+    // (zero-loss, never a partial/forced overwrite), and the next sync re-checks
+    // each per-path TOCTOU and re-conflicts only those whose remote truly moved.
+    const batchFiles = new Map<string, string>();
+    for (const { entry } of pushable) {
+      batchFiles.set(entry.path, entry.chosenContent);
+    }
+    // Union of stale-sibling deletions, MINUS any path another resolution writes
+    // in this same batch — never delete a path we are committing (the write
+    // wins; restCreateCommit also rejects a path that is both written and
+    // deleted). Each entry's watermark snap below uses only its EFFECTIVELY
+    // deleted siblings (same filter), keeping the unpin/base-drop consistent.
+    const batchDeletions = new Set<string>();
+    for (const { stalePaths } of pushable) {
+      for (const p of stalePaths) {
+        if (!batchFiles.has(p)) batchDeletions.add(p);
       }
+    }
+    const deletions = [...batchDeletions];
+    try {
+      await restCreateCommit(this.transport, {
+        owner: spec.owner,
+        repo: spec.repo,
+        branch: spec.branch,
+        files: batchFiles,
+        ...(deletions.length > 0 ? { deletions } : {}),
+        message:
+          deletions.length > 0
+            ? `chore(exosync): resolve ${pushable.length} keep-local conflict(s) (consolidate ${deletions.length} stale remote path(s))`
+            : `chore(exosync): push ${pushable.length} resolved conflict(s)`,
+        expectedHeadSha: head,
+        ...(this.deps.baseURL !== undefined ? { baseURL: this.deps.baseURL } : {}),
+        ...(this.deps.redact !== undefined ? { redact: this.deps.redact } : {}),
+      });
+    } catch (err) {
+      // The whole batch is deferred — a concurrent external writer moved the
+      // head (CAS abort) or the commit raced (422). Leave EVERY entry queued;
+      // never a partial/forced overwrite. The next sync re-checks each per-path
+      // TOCTOU and re-conflicts only those whose remote genuinely moved.
+      warnings.push(
+        `outbox: batch push deferred for ${pushable.length} resolution(s), will retry next sync: ${redact(errMsg(err))}`,
+      );
+      return { pushed: 0, reconflicted };
+    }
+
+    // The single commit landed — finalise every resolution (watermark snap +
+    // unpin, markResolved, drain outbox). Per-entry warnings preserve the
+    // existing consolidation/pushed log lines.
+    let pushed = 0;
+    for (const { entry, stalePaths } of pushable) {
+      const deletedSiblings = stalePaths.filter((p) => !batchFiles.has(p));
       await this.snapOutboxWatermark(
         spec,
         entry.path,
         entry.chosenContent,
-        stalePaths,
+        deletedSiblings,
       );
       await this.deps.quarantine?.markResolved?.(entry.repoKey, entry.path);
       // Stale sibling copies were deleted on the remote — clear their cross-
       // device unresolved-count too (best-effort; most have no cache entry).
-      for (const sp of stalePaths) {
+      for (const sp of deletedSiblings) {
         await this.deps.quarantine?.markResolved?.(entry.repoKey, sp);
       }
       await outbox.remove(entry.repoKey, entry.path);
       pushed++;
-      if (stalePaths.length > 0) {
+      if (deletedSiblings.length > 0) {
         warnings.push(
-          `consolidated cross-path conflict for ${entry.path} — removed ${stalePaths.length} stale remote copy/copies (recoverable in git history)`,
+          `consolidated cross-path conflict for ${entry.path} — removed ${deletedSiblings.length} stale remote copy/copies (recoverable in git history)`,
         );
       }
     }

--- a/packages/core/tests/unit/services/sync/SyncEngine.outbox.test.ts
+++ b/packages/core/tests/unit/services/sync/SyncEngine.outbox.test.ts
@@ -380,3 +380,177 @@ describe("ExoSync cross-path conflict consolidation (#3729)", () => {
     expect(await s.resolver.listOpenConflicts([s.spec])).toHaveLength(0);
   });
 });
+
+// ── Batch head-staleness: N>1 keep-local stragglers converge in ONE sync ─────
+// The exact production sequel to #3729: after the cross-path consolidation fix
+// shipped (v16.149.3), Andrey's `exoas-tbank` keep-local of SEVEN cross-path
+// stragglers in one sync healed only ONE — the flush pushed each queued
+// resolution in its OWN restCreateCommit against a head SHA captured ONCE before
+// the loop, so the FIRST push moved heads/main and the 2nd..Nth pushes failed
+// the expectedHeadSha CAS ("head heads/main moved since the commit"), were
+// deferred and RE-quarantined in the SAME sync ("pushed 1 resolved conflict(s)"
+// → group RE-DETECTED). The fix commits every pushable resolution + the union
+// of stale deletions in ONE atomic tree commit (one head move), so all queued
+// keep-local resolutions land in one sync.
+const M_SHARED = "shared/anchor.md";
+const M_SHARED_BODY = mdAsset("anchor", "anchor, unchanged");
+// Three distinct same-uid cross-path stragglers (flat local ↔ co-located remote),
+// each with its OWN uid/body so blob SHAs are distinct (no cross-contamination of
+// the content-addressed stale-sibling match).
+const STRAGGLERS = [
+  {
+    uid: "s1",
+    flat: "tbank-efforts/s1.md",
+    colocated: "og/s1.md",
+    local: mdAsset("s1", "LOCAL edit s1, flat isDefinedBy"),
+    remote: mdAsset("s1", "REMOTE edit s1, co-located isDefinedBy"),
+  },
+  {
+    uid: "s2",
+    flat: "tbank-efforts/s2.md",
+    colocated: "toos/s2.md",
+    local: mdAsset("s2", "LOCAL edit s2, flat isDefinedBy"),
+    remote: mdAsset("s2", "REMOTE edit s2, co-located isDefinedBy"),
+  },
+  {
+    uid: "s3",
+    flat: "tbank-pns/2026-06-17 Note.md",
+    colocated: "tbank-pn/2026-06-17 Note.md",
+    local: mdAsset("s3", "LOCAL edit s3, flat isDefinedBy"),
+    remote: mdAsset("s3", "REMOTE edit s3, co-located isDefinedBy"),
+  },
+] as const;
+
+function setupMultiXPath() {
+  const gh = new FakeGitHubRepo({ [M_SHARED]: M_SHARED_BODY });
+  const cache = new LocalConflictCacheStore({ io: memIO() });
+  const outbox = new LocalOutboxStore({ io: memIO() });
+  const watermarks = new FakeWatermarkStore();
+  const disk = new FakeLocalFiles({ [M_SHARED]: M_SHARED_BODY });
+  const engine = new SyncEngine({
+    transport: gh.transport(),
+    watermarkStore: watermarks,
+    materializationCheck: alwaysMaterialized(),
+    localFilesFor: () => disk,
+    sha1: sha1Hex,
+    quarantine: cache,
+    outbox,
+    mergeLayer: forceQuarantine,
+  });
+  const resolver = new QuarantineResolver({
+    transport: gh.transport(),
+    watermarkStore: watermarks,
+    localFilesFor: () => disk,
+    sha1: sha1Hex,
+    conflictCache: cache,
+    outbox,
+  });
+  return { gh, cache, outbox, watermarks, disk, engine, resolver, spec: gh.spec() };
+}
+
+/**
+ * Bootstrap converged, then introduce N same-uid cross-path divergences (the
+ * remote co-location migration), quarantine them, and keep-local each — leaving
+ * N queued resolutions in the outbox awaiting a single flush.
+ */
+async function quarantineAndResolveAll(
+  s: ReturnType<typeof setupMultiXPath>,
+): Promise<void> {
+  await s.engine.sync(s.spec); // bootstrap (disk == remote == {M_SHARED})
+  // Local keeps each asset at its FLAT path; the remote migration put each SAME
+  // uid at its CO-LOCATED path with divergent frontmatter (no common base).
+  for (const g of STRAGGLERS) s.disk.files.set(g.flat, g.local);
+  s.gh.commitDirect(
+    "main",
+    {
+      [M_SHARED]: M_SHARED_BODY,
+      ...Object.fromEntries(STRAGGLERS.map((g) => [g.colocated, g.remote])),
+    },
+    "remote bulk co-location migration",
+  );
+  const r = await s.engine.sync(s.spec);
+  expect(r.quarantinedCount).toBeGreaterThanOrEqual(STRAGGLERS.length);
+
+  // Keep-local each conflict → one outbox entry per straggler.
+  const open = await s.resolver.listOpenConflicts([s.spec]);
+  expect(open.length).toBe(STRAGGLERS.length);
+  for (const c of open) {
+    await s.resolver.resolve(s.spec, c.path, { take: "local" });
+  }
+  expect(await s.outbox.listForRepo(s.spec.repoKey)).toHaveLength(
+    STRAGGLERS.length,
+  );
+}
+
+describe("ExoSync batch head-staleness — multiple keep-local stragglers converge in ONE sync", () => {
+  it("@req:e1c6bf01-0580-474b-b66b-9c81180978c6 keep-local of N>1 cross-path stragglers ALL converge in ONE sync — atomic batch commit moves the head once (was 1-per-sync 'head moved' defer + re-quarantine)", async () => {
+    const s = setupMultiXPath();
+    await quarantineAndResolveAll(s);
+
+    // ── ONE flush sync resolves EVERY queued straggler ──────────────────────
+    const flush = await s.engine.sync(s.spec);
+    // ⛤ REVERT-VERIFY BINDING: pre-fix the per-push flush moves the head on the
+    // first push, so the 2nd..Nth fail the CAS and are deferred — outboxPushedCount
+    // would be 1 (received), not STRAGGLERS.length (3). The atomic batch makes it 3.
+    expect(flush.outboxPushedCount).toBe(STRAGGLERS.length);
+    expect(flush.outboxReconflictedCount ?? 0).toBe(0);
+
+    // Outbox fully drained — NOTHING deferred within the batch.
+    expect(await s.outbox.listForRepo(s.spec.repoKey)).toHaveLength(0);
+
+    // Every asset converged to its single (flat) path; every stale co-located
+    // sibling is gone (deleted, recoverable in git history); the anchor is
+    // untouched.
+    const head = s.gh.headFiles();
+    for (const g of STRAGGLERS) {
+      expect(head.get(g.flat)).toBe(g.local); // converged to the flat path
+      expect(head.has(g.colocated)).toBe(false); // stale sibling consolidated away
+    }
+    expect(head.get(M_SHARED)).toBe(M_SHARED_BODY);
+
+    // No conflict re-surfaces for ANY straggler on a subsequent sync — keep-local
+    // stuck for all of them in ONE sync.
+    expect(await s.resolver.listOpenConflicts([s.spec])).toHaveLength(0);
+    const after = await s.engine.sync(s.spec);
+    expect(after.quarantinedCount).toBe(0);
+    expect(after.status).toBe("synced");
+  });
+
+  it("⛤ zero-loss: a genuine concurrent EXTERNAL writer moving the head aborts the WHOLE batch (expectedHeadSha CAS) — every entry stays queued, nothing overwritten", async () => {
+    const s = setupMultiXPath();
+    await quarantineAndResolveAll(s);
+
+    // The flush's guard-read (getHeadSha) sees the unchanged head and proceeds;
+    // inject a concurrent EXTERNAL push in the window before the batch commit's
+    // OWN ref-read (arm-call #1 = flush getHeadSha, #2 = restCreateCommit GET-ref)
+    // by moving an UNRELATED remote path — the CAS must abort the entire batch.
+    let getRefCalls = 0;
+    s.gh.onGetRef = (): void => {
+      getRefCalls++;
+      if (getRefCalls === 2) {
+        s.gh.onGetRef = undefined;
+        s.gh.commitDirect(
+          "main",
+          { [M_SHARED]: mdAsset("anchor", "external writer moved the anchor") },
+          "external writer in the race window",
+        );
+      }
+    };
+
+    const flush = await s.engine.sync(s.spec);
+    s.gh.onGetRef = undefined;
+
+    // ⛤ The whole batch aborts — NOTHING pushed, every straggler stays queued.
+    expect(flush.outboxPushedCount ?? 0).toBe(0);
+    expect(await s.outbox.listForRepo(s.spec.repoKey)).toHaveLength(
+      STRAGGLERS.length,
+    );
+    // The external change is preserved (never overwritten); the stale siblings
+    // are all still present (no partial consolidation).
+    const head = s.gh.headFiles();
+    expect(head.get(M_SHARED)).toBe(mdAsset("anchor", "external writer moved the anchor"));
+    for (const g of STRAGGLERS) {
+      expect(head.get(g.colocated)).toBe(g.remote); // untouched
+    }
+  });
+});


### PR DESCRIPTION
## Real blocker (Andrey's work vault, profile `$$kitelev-tbank`, v16.149.3)

After the cross-path consolidation fix shipped (#3730), keep-local of **7 cross-path stragglers in one sync healed only ONE**. The log showed exactly:

```
consolidated cross-path conflict for tbank-efforts/2e06294e…md — removed 1 stale remote copy   ← worked for 1 of 7
outbox: push deferred for tbank-efforts/48a1b9f0…md … head heads/main moved since the commit   ← the other 6
… (head moved) ×5
pushed 1 resolved conflict(s)
conflict group 48a1b9f0/809875cb/… RE-DETECTED → RE-quarantined
```

## Root cause (confirmed in code + reproduced)

`SyncEngine.flushOutbox` captured the remote head SHA **once before the loop** and passed that **stale** value as `expectedHeadSha` to **every per-entry** `restCreateCommit`. The first push moved `heads/<branch>`, so the 2nd…Nth pushes failed `restCreateCommit`'s CAS guard (`head … moved since the caller's check`), were deferred and re-quarantined **in the same sync** — only **one straggler converged per sync**, the rest re-surfaced. The #3729 cross-path consolidation itself works; this is the 1-per-sync head-staleness in the deferred-push flush.

## Fix — atomic batch (one head move for all N)

Restructured `flushOutbox` from per-entry push to **classify-then-batch**:
- **Phase 1** classifies every queued resolution against the ONE head-tree snapshot (TOCTOU-skips drop unchanged; the rest are collected).
- **Phase 2** commits all chosen contents + the **union of stale-sibling deletions** (minus any path another resolution writes — never delete a path we're committing) in a **single** `restCreateCommit` with `expectedHeadSha=head`. `restCreateCommit` already builds a recursive multi-file tree with `sha:null` deletions (#3476), so one commit expresses N writes + M deletes → the head moves exactly once → all queued keep-local resolutions land in one sync.

**Zero-loss preserved:** atomic = all-or-nothing. A genuine concurrent **external** writer (head moved between our head fetch and our one commit) aborts the **whole** batch via `expectedHeadSha` → every entry stays queued, nothing overwritten, next sync re-checks each per-path TOCTOU. Deleted siblings survive in git history + the device-local conflict cache.

## Revert-verify (binding, integration)

`@req:e1c6bf01-0580-474b-b66b-9c81180978c6` — production-shape `FakeGitHubRepo` (real git blob SHAs, force:false 422, ref that ACTUALLY advances on PATCH) with the GENUINE `SyncEngine` + `QuarantineResolver` + real device-local outbox/cache/watermark. Three same-uid cross-path stragglers, keep-local each, one flush:

- **RED** (revert `flushOutbox` to origin/main `b649a44b`): `expect(outboxPushedCount).toBe(3)` → **received `1`** — only the first straggler converged; 2 deferred "head moved" + 2 stale siblings survive.
- **GREEN** (fix): `3` — all stragglers converge in one sync; outbox drained; no re-conflict on the next sync.

`SyncEngine.outbox.test.ts` 11/11; full `tests/unit/services/sync` 29 suites / 403 tests; typecheck clean; eslint `--max-warnings=0` clean.

## Out of scope
Keep-remote symmetry (#3731) — separate session, same file; not touched here.

Follow-up to #3729. req `e1c6bf01` (Active, integration, revert-verified).
