### PR TITLE
test(reqs): bind 3 new P0 exo reqs — namespace-agnostic sh:class, ontology-imports audit, SPARQL OPTIONAL (RFC 0003 P2 increment 7)

### DIFF
--- a/packages/cli/tests/integration/commands/audit-ontology-imports.integration.test.ts
+++ b/packages/cli/tests/integration/commands/audit-ontology-imports.integration.test.ts
@@ -101,7 +101,7 @@ describe("audit ontology-imports — revert→fail / restore→pass (integration
     rmSync(vault, { recursive: true, force: true });
   });
 
-  it("FAIL without the import declaration, PASS with it, FAIL again without", async () => {
+  it("FAIL without the import declaration, PASS with it, FAIL again without @req:6999f49b-6e87-4cbb-b7e9-648ee38e68da", async () => {
     // --- State 1: no declared import A→B → the a→b link is a violation ---
     writeOntology(join(vault, "alpha"), ONTO_A, "$alpha", []);
     let r = await scanVaultForOntologyImports(vault);

--- a/packages/cli/tests/integration/validate-schema-person-subclass.integration.test.ts
+++ b/packages/cli/tests/integration/validate-schema-person-subclass.integration.test.ts
@@ -201,7 +201,7 @@ const agentClassViolations = (focusUid: string) => {
 };
 
 describe("Issue #3512 — person__Person resolves as subclass of ems__Agent", () => {
-  it("does NOT emit a sh:class violation for a person__Person-typed responsible (KEY: fails pre-fix)", () => {
+  it("does NOT emit a sh:class violation for a person__Person-typed responsible (KEY: fails pre-fix) @req:740244c1-a29a-4c31-8d4d-c74b141fb80e", () => {
     expect(agentClassViolations(AREA_PERSON_UID)).toEqual([]);
   });
 

--- a/packages/core/tests/integration/sparql/issue-2208-optional-left-join.test.ts
+++ b/packages/core/tests/integration/sparql/issue-2208-optional-left-join.test.ts
@@ -80,7 +80,7 @@ describe("Issue #2208: OPTIONAL should use LEFT JOIN semantics", () => {
   });
 
   describe("regression test - reproduces the exact bug scenario", () => {
-    it("should return all tasks, with project bound only when exists", async () => {
+    it("should return all tasks, with project bound only when exists @req:8f422d73-d74d-443c-a39e-7d546a210056", async () => {
       // Task 1: has a project
       await store.add(new Triple(
         new IRI(`${EX}task1`),


### PR DESCRIPTION
## What

RFC 0003 P2 **increment 7** (al-reqmgmt-p2-cont) — reverse-documented (A14) **3 new Alpha-critical exo P0 functional requirements** into \`exoas-exo-reqs\`, each bound via \`@req:<uid>\` inside an existing **integration** test and **revert-verified**. Expands the P0 ramp set 27→30 (Andrey directive: continue the ramp). Also bumps the \`exoas-exo-reqs\` submodule pointer (67de4c1→07a824f), which additionally clears stale-pointer drift by pulling in the already-on-main keep-remote convergence req (\`5c7e8d2a\`, #3733).

| req uid | behavior | binding (integration) | revert-verified |
| --- | --- | --- | --- |
| \`740244c1\` | validate schema --shapes-mode resolves a person__Person-typed value as an ems__Agent subclass — no false sh:class (namespace-agnostic class resolution, #3512) | \`validate-schema-person-subclass.integration.test.ts\` | ✅ |
| \`6999f49b\` | audit ontology-imports flags an undeclared cross-ontology link as a violation | \`audit-ontology-imports.integration.test.ts\` | ✅ |
| \`8f422d73\` | SPARQL OPTIONAL uses LEFT JOIN semantics — every left solution preserved, optional vars unbound when no match (#2208) | \`issue-2208-optional-left-join.test.ts\` | ✅ |

## Revert-verify evidence (D1, each break→RED→restore→GREEN, origin/main \`79bee33b\`)

- \`Revert-verified: @req:740244c1 reverting labelToOntologyIRI namespace-agnostic fallback (validate-schema.ts, if(false&&…)) → validate-schema-person-subclass person__Person case RED\` (ims__Person curated-map case stays GREEN — precise revert).
- \`Revert-verified: @req:6999f49b reverting scanVaultForOntologyImports per-link coverage (valid=true) → audit-ontology-imports "FAIL without the import declaration" RED\` (declared-import State-2 stays GREEN).
- \`Revert-verified: @req:8f422d73 reverting OptionalExecutor unmatched-left preservation (if(!matched&&false)) → issue-2208 "all tasks, project bound only when exists" RED\`.

All prod reverts restored; \`git diff\` shows only test-title \`@req\` tags + the submodule pointer (no production source change).

## Checks

- \`requirements audit\` (CI-replica, \`--gate hard\`, both reqs assetspaces cloned fresh): **47 reqs / 46 bound / P0 30/30 / rampReady=true / clean=true / 0 dangling / 0 floor / 0 active-violations**.
- SHACL \`validate schema --shapes-mode --vault vault-exodev\`: **0 violations** (97699 triples, conforms).
- archgate: 23/23 pass (the 3 REQ-001 "malformed" warnings are pre-existing truncated example tags in build-check tests, not these bindings — my 3 tags are full UUIDs).

## Federation (D2/D5)

All 3 are **functional** behaviors (validation gates, ontology-dependency audit, SPARQL query semantics). No architectural/NFR invariant restated as a req.

🤖 Generated with [Claude Code](https://claude.ai/code)