### PR TITLE
fix(exocmd): a display alias in exo__Instance_class no longer suppresses command buttons (req-first)

### DIFF
--- a/packages/obsidian-plugin/src/application/commands/CommandRegistry.ts
+++ b/packages/obsidian-plugin/src/application/commands/CommandRegistry.ts
@@ -22,6 +22,12 @@ export class CommandRegistry {
     return this.globalCommands;
   }
 
+  // NOTE: currently unused (no live caller). If revived, `assetClass` MUST be a
+  // wikilink-alias-stripped class string (the TARGET before any `|`) — pass the
+  // output of `DynamicCommandButtonGroupBuilder.extractAssetClasses`, never a raw
+  // `exo__Instance_class` frontmatter value — otherwise an aliased instance class
+  // (`[[uid|Display]]`) would silently resolve no class-targeted bindings (the
+  // alias-suppresses-buttons bug this fix repaired at the builder surface).
   async getCommandsForAsset(
     subjectIRI: string,
     assetClass: string,

--- a/packages/obsidian-plugin/src/presentation/builders/button-groups/DynamicCommandButtonGroupBuilder.ts
+++ b/packages/obsidian-plugin/src/presentation/builders/button-groups/DynamicCommandButtonGroupBuilder.ts
@@ -524,8 +524,20 @@ export class DynamicCommandButtonGroupBuilder implements IButtonGroupBuilder {
       // target (`ems__Meeting`) matches a binding's `targetClass` directly.
       // Both converge to the same resolved set as the alias-free form, so an
       // alias on a Meeting/Task instance class no longer suppresses its buttons
-      // (Issue: aliased `[[uid|ems__Meeting]]` previously yielded 0 buttons
-      // because `uid|ems__Meeting` is neither a UUID nor a symbolic class name).
+      // (Issue: aliased `[[uid|Some Title]]` previously yielded 0 buttons
+      // because `uid|Some Title` is neither a UUID nor a symbolic class name —
+      // the buggy extractor skipped #3141 expansion and the resolver could not
+      // match it. NB: an alias that happens to EQUAL the class name
+      // (`[[uid|ems__Meeting]]`) or a symbolic-form alias coincidentally still
+      // resolved pre-fix via `CommandResolver.matchesReference`'s #2740 alias
+      // cross-match + pipe-stripping `normalizeWikilink`; the genuinely-broken
+      // case is an ARBITRARY display alias. This strip makes resolution
+      // alias-independent for ALL forms.)
+      //
+      // NOTE: this differs deliberately from `WikiLinkHelpers.normalize`, which
+      // for `[[UUID|alias]]` returns the ALIAS (#2764, used by prototype-
+      // detection / live-preview relabeling). Here the TARGET is authoritative
+      // for resolution and the true `exo__Asset_label` is resolved via #3141.
       const pipe = cleaned.indexOf("|");
       if (pipe !== -1) cleaned = cleaned.slice(0, pipe).trim();
       if (cleaned && !classes.includes(cleaned)) classes.push(cleaned);

--- a/packages/obsidian-plugin/src/presentation/builders/button-groups/DynamicCommandButtonGroupBuilder.ts
+++ b/packages/obsidian-plugin/src/presentation/builders/button-groups/DynamicCommandButtonGroupBuilder.ts
@@ -515,7 +515,19 @@ export class DynamicCommandButtonGroupBuilder implements IButtonGroupBuilder {
 
     const collect = (value: unknown): void => {
       if (typeof value !== "string") return;
-      const cleaned = value.replace(/["'[\]]/g, "").trim();
+      let cleaned = value.replace(/["'[\]]/g, "").trim();
+      // A wikilink display alias (`[[<target>|<alias>]]`) is DISPLAY-ONLY — it
+      // governs how the link is rendered, never how `exo__Instance_class` is
+      // resolved for exocmd command/binding matching. Keep only the target
+      // (everything before the first `|`): a bare UUID then satisfies
+      // `isUuidRef` and gets symbolic-label expansion (#3141), and a symbolic
+      // target (`ems__Meeting`) matches a binding's `targetClass` directly.
+      // Both converge to the same resolved set as the alias-free form, so an
+      // alias on a Meeting/Task instance class no longer suppresses its buttons
+      // (Issue: aliased `[[uid|ems__Meeting]]` previously yielded 0 buttons
+      // because `uid|ems__Meeting` is neither a UUID nor a symbolic class name).
+      const pipe = cleaned.indexOf("|");
+      if (pipe !== -1) cleaned = cleaned.slice(0, pipe).trim();
       if (cleaned && !classes.includes(cleaned)) classes.push(cleaned);
     };
 

--- a/packages/obsidian-plugin/tests/unit/integration/alias-instance-class-exocmd-resolution.test.ts
+++ b/packages/obsidian-plugin/tests/unit/integration/alias-instance-class-exocmd-resolution.test.ts
@@ -1,0 +1,310 @@
+/**
+ * Integration test — a wikilink DISPLAY ALIAS in `exo__Instance_class` must NOT
+ * affect exocmd command/binding resolution.
+ *
+ * Bug (Andrey, on `ems__Meeting` assets): an `exo__Instance_class` written as
+ * `"[[<uid>|ems__Meeting]]"` (a display alias) rendered ZERO command buttons,
+ * while the alias-free `"[[<uid>]]"` rendered them. The alias is purely a
+ * DISPLAY concern (how the wikilink is shown) and must never participate in
+ * command resolution — the resolved command set has to be identical to the
+ * alias-free form.
+ *
+ * Realism (test-fixture-realism): this wires the REAL resolution pipeline —
+ * `InMemoryTripleStore` + `CommandResolver` (class-hierarchy expansion + UID→
+ * label resolution + binding match) + `PreconditionEvaluator` + the REAL
+ * `DynamicCommandButtonGroupBuilder.extractAssetClasses`. The only stub is
+ * `CommandExecutionFlow`, which is invoked on a button CLICK and never during
+ * resolution. Declared binding-class: Integration (RFC 0003 §3.6) — it exercises
+ * real production beyond a mocked unit. Co-located under `tests/unit/integration/`
+ * (the precedent for plugin integration suites, e.g. `sparql-critical-paths`)
+ * because the obsidian-plugin jest `testMatch` only runs `tests/unit/**`.
+ *
+ * Empirical nuance (verify-before-assert): the resolver's own
+ * `matchesReference` carries a legacy `UUID|alias` cross-match (Issue #2740) and
+ * `normalizeWikilink` already strips a pipe to its TARGET. So a UID-form alias
+ * that happens to EQUAL the symbolic class name (`[[uid|ems__Meeting]]`) and any
+ * SYMBOLIC-form alias (`[[ems__Meeting|Display]]`) are coincidentally resolved
+ * even WITHOUT the extractor fix. The genuinely-broken case — and the
+ * revert-verify discriminator — is a UID-form ref with an ARBITRARY display
+ * alias (a real meeting title, not the class name): `[[uid|Завтрак с командой]]`.
+ * There `normalizeWikilink` yields the bare UID (≠ "ems__Meeting"), the alias is
+ * not the class name (no #2740 cross-match), and the buggy extractor skips the
+ * #3141 UUID→label expansion (`isUuidRef("uid|alias")` is false) — so 0 buttons.
+ *
+ * Revert-verify: removing the alias-strip in `extractAssetClasses.collect`
+ * makes the ARBITRARY-alias case render 0 buttons while the alias-free form
+ * renders 1 — the "ARBITRARY display alias" `toEqual` assertion goes RED.
+ * Restoring the strip converges all forms → GREEN. Empirically verified
+ * (FAILS pre-fix on the arbitrary-alias case / PASSES post-fix). The
+ * class-name-alias and symbolic-form cases are regression coverage: the fix
+ * must keep them working (they pass both ways).
+ *
+ * @req:9e84c833-2057-4343-9006-b2d05ec69159
+ */
+
+import {
+  InMemoryTripleStore,
+  CommandResolver,
+  PreconditionEvaluator,
+  CommandExecutionFlow,
+  Triple,
+  IRI,
+  Literal,
+  Namespace,
+} from "@kitelev/exocortex-core";
+import { DynamicCommandButtonGroupBuilder } from "../../../src/presentation/builders/button-groups/DynamicCommandButtonGroupBuilder";
+import type { ButtonBuilderContext } from "../../../src/presentation/builders/button-groups/ButtonBuilderTypes";
+
+// Real Meeting class UID (matches the production class `ems__Meeting`).
+const MEETING_UID = "1b0a5e34-dd7f-4ead-b43a-6c7c5a5ecaca";
+const CMD_UID = "aa11bb22-cc33-4d44-9e55-6f7788990011";
+const GND_UID = "bb22cc33-dd44-4e55-9f66-778899001122";
+const BIND_UID = "cc33dd44-ee55-4f66-8a77-889900112233";
+
+// property_set grounding-type wikilink (mirror of GroundingTypeUIDs catalog).
+const PROPERTY_SET_GND_TYPE = "[[cf3bb923-f1f1-40be-b728-782844402426]]";
+
+/**
+ * Seed the REAL store with: a `ems__Meeting` class definition (so the resolver
+ * can resolve `MEETING_UID → "ems__Meeting"`), a property_set Command + its
+ * Grounding, and a class-targeted CommandBinding (`targetClass: "ems__Meeting"`).
+ * No precondition → the command renders unconditionally.
+ */
+async function seedMeetingClassAndBinding(
+  store: InMemoryTripleStore,
+): Promise<void> {
+  // Class definition — UID-named subject; label is the symbolic class name.
+  const classSubject = new IRI(`obsidian://vault/${MEETING_UID}.md`);
+  await store.addAll([
+    new Triple(
+      classSubject,
+      Namespace.RDF.term("type"),
+      Namespace.EXO.term("Class"),
+    ),
+    new Triple(
+      classSubject,
+      Namespace.EXO.term("Asset_uid"),
+      new Literal(MEETING_UID),
+    ),
+    new Triple(
+      classSubject,
+      Namespace.EXO.term("Asset_label"),
+      new Literal("ems__Meeting"),
+    ),
+  ]);
+
+  // Grounding (property_set).
+  const gndSubject = new IRI(`obsidian://vault/${GND_UID}.md`);
+  await store.addAll([
+    new Triple(
+      gndSubject,
+      Namespace.RDF.term("type"),
+      Namespace.EXOCMD.term("Grounding"),
+    ),
+    new Triple(
+      gndSubject,
+      Namespace.EXO.term("Asset_uid"),
+      new Literal(GND_UID),
+    ),
+    new Triple(
+      gndSubject,
+      Namespace.EXO.term("Asset_label"),
+      new Literal("Gnd: Mark meeting done"),
+    ),
+    new Triple(
+      gndSubject,
+      Namespace.EXOCMD.term("Grounding_type"),
+      new Literal(PROPERTY_SET_GND_TYPE),
+    ),
+    new Triple(
+      gndSubject,
+      Namespace.EXOCMD.term("Grounding_targetProperty"),
+      new Literal("ems__Effort_status"),
+    ),
+    new Triple(
+      gndSubject,
+      Namespace.EXOCMD.term("Grounding_targetValueLiteral"),
+      new Literal("done"),
+    ),
+  ]);
+
+  // Command.
+  const cmdSubject = new IRI(`obsidian://vault/${CMD_UID}.md`);
+  await store.addAll([
+    new Triple(
+      cmdSubject,
+      Namespace.RDF.term("type"),
+      Namespace.EXOCMD.term("Command"),
+    ),
+    new Triple(
+      cmdSubject,
+      Namespace.EXO.term("Asset_uid"),
+      new Literal(CMD_UID),
+    ),
+    new Triple(
+      cmdSubject,
+      Namespace.EXO.term("Asset_label"),
+      new Literal("Mark meeting done"),
+    ),
+    new Triple(
+      cmdSubject,
+      Namespace.EXOCMD.term("Command_grounding"),
+      gndSubject,
+    ),
+    new Triple(
+      cmdSubject,
+      Namespace.EXOCMD.term("Command_category"),
+      new Literal("status"),
+    ),
+  ]);
+
+  // Binding — class-targeted at `ems__Meeting`.
+  const bindSubject = new IRI(`obsidian://vault/${BIND_UID}.md`);
+  await store.addAll([
+    new Triple(
+      bindSubject,
+      Namespace.RDF.term("type"),
+      Namespace.EXOCMD.term("CommandBinding"),
+    ),
+    new Triple(
+      bindSubject,
+      Namespace.EXO.term("Asset_uid"),
+      new Literal(BIND_UID),
+    ),
+    new Triple(
+      bindSubject,
+      Namespace.EXO.term("Asset_label"),
+      new Literal("Bind: Mark meeting done"),
+    ),
+    new Triple(
+      bindSubject,
+      Namespace.EXOCMD.term("CommandBinding_command"),
+      cmdSubject,
+    ),
+    new Triple(
+      bindSubject,
+      Namespace.EXOCMD.term("CommandBinding_targetClass"),
+      new Literal("ems__Meeting"),
+    ),
+  ]);
+}
+
+function createMeetingContext(
+  instanceClassValue: string,
+): ButtonBuilderContext {
+  return {
+    app: {} as ButtonBuilderContext["app"],
+    settings: {} as ButtonBuilderContext["settings"],
+    plugin: {} as ButtonBuilderContext["plugin"],
+    file: {
+      path: "meetings/standup-2026-06-26.md",
+      basename: "standup-2026-06-26",
+      parent: { path: "meetings" },
+    } as ButtonBuilderContext["file"],
+    metadata: {
+      exo__Asset_uid: "obsidian://vault/meetings/standup-2026-06-26.md",
+      exo__Instance_class: instanceClassValue,
+    },
+    instanceClass: instanceClassValue,
+    visibilityContext: {
+      instanceClass: instanceClassValue,
+      currentStatus: null,
+      metadata: {},
+      isArchived: false,
+      currentFolder: "meetings",
+      expectedFolder: "meetings",
+      classIsPrototype: false,
+    },
+    logger: {
+      info: jest.fn(),
+      error: jest.fn(),
+      warn: jest.fn(),
+      debug: jest.fn(),
+    } as unknown as ButtonBuilderContext["logger"],
+    refresh: jest.fn().mockResolvedValue(undefined),
+  };
+}
+
+describe("alias in exo__Instance_class does not affect exocmd resolution (#alias-exocmd)", () => {
+  let builder: DynamicCommandButtonGroupBuilder;
+
+  beforeEach(async () => {
+    const store = new InMemoryTripleStore();
+    await seedMeetingClassAndBinding(store);
+
+    const commandResolver = new CommandResolver(store);
+    const preconditionEvaluator = new PreconditionEvaluator(store);
+
+    // Stub flow — never invoked during resolution (only on a button click).
+    const commandExecutionFlow = {
+      run: jest.fn(),
+    } as unknown as CommandExecutionFlow;
+
+    builder = new DynamicCommandButtonGroupBuilder({
+      commandResolver,
+      preconditionEvaluator,
+      commandExecutionFlow,
+    });
+  });
+
+  async function buttonLabelsFor(instanceClassValue: string): Promise<string[]> {
+    const buttons = await builder.build(createMeetingContext(instanceClassValue));
+    return buttons.map((b) => b.label).sort();
+  }
+
+  it("renders the same buttons for an alias-free UID-form instance class as the alias-free baseline (sanity)", async () => {
+    const aliasFree = await buttonLabelsFor(`[[${MEETING_UID}]]`);
+    expect(aliasFree).toContain("Mark meeting done");
+  });
+
+  it("UID-form alias [[uid|ems__Meeting]] resolves the IDENTICAL command set as the alias-free [[uid]] — the user's exact report", async () => {
+    const aliasFree = await buttonLabelsFor(`[[${MEETING_UID}]]`);
+    const aliased = await buttonLabelsFor(`[[${MEETING_UID}|ems__Meeting]]`);
+
+    expect(aliasFree.length).toBeGreaterThan(0);
+    expect(aliased).toEqual(aliasFree);
+  });
+
+  it("an ARBITRARY (non-class) display alias still renders the Meeting buttons — the alias is display-only", async () => {
+    const aliasFree = await buttonLabelsFor(`[[${MEETING_UID}]]`);
+    const arbitraryAlias = await buttonLabelsFor(
+      `[[${MEETING_UID}|Завтрак с командой]]`,
+    );
+
+    expect(aliasFree.length).toBeGreaterThan(0);
+    expect(arbitraryAlias).toEqual(aliasFree);
+  });
+
+  it("symbolic-form alias [[ems__Meeting|Display]] resolves the IDENTICAL set as the alias-free [[ems__Meeting]]", async () => {
+    const aliasFree = await buttonLabelsFor("[[ems__Meeting]]");
+    const aliased = await buttonLabelsFor("[[ems__Meeting|Weekly Sync]]");
+
+    expect(aliasFree.length).toBeGreaterThan(0);
+    expect(aliased).toEqual(aliasFree);
+  });
+
+  it("array-form instance class with aliased entry resolves the same as the alias-free array", async () => {
+    const aliasFree = await builder.build(
+      createMeetingContextArray([`[[${MEETING_UID}]]`]),
+    );
+    const aliased = await builder.build(
+      createMeetingContextArray([`[[${MEETING_UID}|ems__Meeting]]`]),
+    );
+
+    const aliasFreeLabels = aliasFree.map((b) => b.label).sort();
+    const aliasedLabels = aliased.map((b) => b.label).sort();
+    expect(aliasFreeLabels.length).toBeGreaterThan(0);
+    expect(aliasedLabels).toEqual(aliasFreeLabels);
+  });
+});
+
+function createMeetingContextArray(
+  instanceClassValue: string[],
+): ButtonBuilderContext {
+  const ctx = createMeetingContext(instanceClassValue[0]);
+  return {
+    ...ctx,
+    metadata: { ...ctx.metadata, exo__Instance_class: instanceClassValue },
+    instanceClass: instanceClassValue,
+  };
+}

--- a/packages/obsidian-plugin/tests/unit/presentation/editor-extensions/WikilinkLabelViewPlugin.test.ts
+++ b/packages/obsidian-plugin/tests/unit/presentation/editor-extensions/WikilinkLabelViewPlugin.test.ts
@@ -417,4 +417,84 @@ describe("WikilinkLabelViewPlugin", () => {
       expect(label).toBeNull();
     });
   });
+
+  /**
+   * Wikilink display-label precedence (RFC 0003 SDD requirement): the visible
+   * label of a wikilink resolves by precedence
+   *   explicit alias  >  target `exo__Asset_label`  >  filename (uid).
+   *
+   * This is the plugin-OWNED half of the precedence (Obsidian renders the raw
+   * target only when this plugin declines to relabel). The chain is exercised
+   * over the two plugin-owned APIs:
+   *   • `parseWikilinksFromText` — an ALIASED link is excluded (`hasAlias`), so
+   *     the ViewPlugin never overrides it → Obsidian shows the explicit alias
+   *     (alias wins over label).
+   *   • `resolveLabel` — returns `exo__Asset_label` when present (label wins over
+   *     filename), and `null` when missing/empty → the ViewPlugin emits no
+   *     decoration → Obsidian shows the bare target (filename/uid last resort).
+   *
+   * Already-satisfied (no production change): this binds an existing,
+   * plugin-owned precedence to RFC 0003. Revert-verify (where meaningful):
+   * `resolveLabel` guards a blank label (`label && … && label.trim() !== ""`)
+   * and returns `null` so the filename shows; dropping that blank-guard (so a
+   * blank `exo__Asset_label` is returned verbatim) regresses the
+   * label→filename fallback → the "empty/blank label falls back" case goes RED.
+   *
+   * @req:6636f1a7-a7a2-4c8a-9c74-6c9d0d79ffc7
+   */
+  describe("display-label precedence: alias > exo__Asset_label > filename", () => {
+    const cacheWith = (files: Record<string, { exo__Asset_label?: string }>) => ({
+      getFirstLinkpathDest: jest.fn().mockImplementation((path: string) => {
+        const fullPath = path.endsWith(".md") ? path : `${path}.md`;
+        if (files[path] || files[fullPath]) {
+          const f = new TFile();
+          (f as unknown as { path: string }).path = fullPath;
+          return f;
+        }
+        return null;
+      }),
+      getFileCache: jest.fn().mockImplementation((file: TFile) => {
+        const pathWithoutExt = file.path.replace(".md", "");
+        const md = files[file.path] || files[pathWithoutExt];
+        return md ? { frontmatter: md } : null;
+      }),
+    });
+
+    it("explicit alias wins — an aliased link is left untouched so its alias shows (alias > label)", () => {
+      // The target HAS an exo__Asset_label, but the link carries an explicit
+      // alias, so the plugin does not relabel it — Obsidian shows the alias.
+      const matches = WikilinkLabelViewPlugin.parseWikilinksFromText(
+        "Met [[5c8f1e22-aaaa-4bbb-8ccc-1d2e3f405162|Завтрак с Машей]] today",
+        0,
+      );
+      expect(matches).toHaveLength(0);
+    });
+
+    it("no alias → target exo__Asset_label wins over filename (label > filename)", () => {
+      const cache = cacheWith({
+        "5c8f1e22-aaaa-4bbb-8ccc-1d2e3f405162": {
+          exo__Asset_label: "Weekly Sync",
+        },
+      });
+      const label = WikilinkLabelViewPlugin.resolveLabel(
+        cache as any,
+        "5c8f1e22-aaaa-4bbb-8ccc-1d2e3f405162",
+      );
+      expect(label).toBe("Weekly Sync");
+    });
+
+    it("no alias + empty/missing label → null so the bare filename (uid) shows (filename last resort)", () => {
+      const emptyLabel = WikilinkLabelViewPlugin.resolveLabel(
+        cacheWith({ "5c8f1e22-aaaa-4bbb-8ccc-1d2e3f405162": { exo__Asset_label: "" } }) as any,
+        "5c8f1e22-aaaa-4bbb-8ccc-1d2e3f405162",
+      );
+      expect(emptyLabel).toBeNull();
+
+      const noLabel = WikilinkLabelViewPlugin.resolveLabel(
+        cacheWith({ "5c8f1e22-aaaa-4bbb-8ccc-1d2e3f405162": {} }) as any,
+        "5c8f1e22-aaaa-4bbb-8ccc-1d2e3f405162",
+      );
+      expect(noLabel).toBeNull();
+    });
+  });
 });


### PR DESCRIPTION
## Problem

On `ems__Meeting` assets, an `exo__Instance_class` written with a wikilink
**display alias** (`"[[<uid>|<alias>]]"`) suppressed the exocmd command buttons
that the alias-free form renders. An alias added purely for readability silently
removed the user's command buttons.

## Root cause

`DynamicCommandButtonGroupBuilder.extractAssetClasses` (the `collect` closure)
stripped only quotes + brackets, **not** the `|alias` tail. So
`[[<uid>|<alias>]]` became the class string `<uid>|<alias>`, which
`CommandResolver` could not resolve:

- `normalizeWikilink` takes the part **before** the pipe (the bare `<uid>`,
  which is not the symbolic `targetClass`), and
- the buggy extractor **skipped** the #3141 UUID→label expansion because
  `isUuidRef("<uid>|<alias>")` is `false`.

→ the class-targeted binding matched nothing → **0 buttons**.

### Empirical nuance (verify-before-assert)

The resolver's `matchesReference` carries a legacy `UUID|alias` cross-match
(Issue #2740) and a symbolic-form ref already normalizes the pipe to its target,
so a UID-form alias that **equals** the class name (`[[uid|ems__Meeting]]`) and
any symbolic-form alias (`[[ems__Meeting|Display]]`) were resolved even
**without** the fix. The genuinely-broken (and revert-verified) case is a
UID-form ref with an **arbitrary** display alias (a real meeting title, not the
class name), e.g. `[[uid|Завтрак с командой]]`.

## Fix

Strip the display alias to its target in `collect` (everything before the first
`|`). A bare UUID then drives the #3141 symbolic-label expansion and a symbolic
target matches a `targetClass` directly — so resolution is **alias-independent**
end-to-end. The alias is purely a display concern; the wikilink **target** is
authoritative for exocmd command/binding resolution.

**Single fix-point** (multi-surface audit): only the inline-button builder
extracts `exo__Instance_class` for binding-resolution. The Cmd+P palette
(`ExocmdCommandPaletteRegistrar`) registers commands globally and gates them by
host-function preconditions (no class-binding extraction); the CLI `apply` path
executes a named command with no class-applicability gate. Both are unaffected.

## req-first (RFC 0003 SDD)

- **req `9e84c833`** (P0 / Integration, in `exoas-exo-reqs`): an aliased
  `exo__Instance_class` resolves the **identical** exocmd command set as the
  alias-free form, and the buttons render.
  - Integration test wiring the **real** pipeline (`InMemoryTripleStore` +
    `CommandResolver` class-hierarchy/UID→label expansion + binding match +
    `PreconditionEvaluator` + the **real** `DynamicCommandButtonGroupBuilder`;
    only `CommandExecutionFlow`, used on a button click, is stubbed).
  - **Revert-verified RED→GREEN**: removing the alias-strip makes the
    arbitrary-alias UID-form render 0 buttons (≠ the alias-free 1) → the
    "ARBITRARY display alias" assertion goes RED; restoring it → GREEN.
    Class-name-alias / symbolic-form / array cases are regression coverage
    (pass both ways).
- **req `6636f1a7`** (P2 / Unit, already-satisfied, 0 production code): wikilink
  display-label precedence **alias > `exo__Asset_label` > filename** — binds the
  existing plugin-owned precedence to the SDD ledger via a focused test
  exercising the full chain.

## Verification

- `check:types` clean; `npm run lint` clean; affected suites green
  (integration 5/5, WikilinkLabelViewPlugin 34/34, builder regression suite,
  `findRelatedTests` 238/238).
- `requirements audit`: ramp-ready **yes**, P0 **31/31** bound, 0
  active-invariant / floor / dangling, coverage 100%.
- SHACL `validate schema --shapes-mode` over vault-exodev: **0 violations**.

Reqs flip Proposed→Approved (this PR) → **Active** after merge (binding lands in
main), per the SDD lifecycle.
