### PR TITLE
feat(relations): getReifiedRelations read-path helper (reified relations from exo__Statement instances) — RFC 93a0b2ee Task 1.1

### DIFF
--- a/packages/obsidian-plugin/src/presentation/renderers/layout/getReifiedRelations.ts
+++ b/packages/obsidian-plugin/src/presentation/renderers/layout/getReifiedRelations.ts
@@ -1,0 +1,234 @@
+import {
+  ITripleStore,
+  IRI,
+  Literal,
+  Namespace,
+  iriToVaultPath,
+} from "@kitelev/exocortex-core";
+
+/**
+ * RFC `93a0b2ee` Phase 1 / Task 1.1 — read-path helper that sources reified
+ * relations of an asset from its `exo__Statement` *instances* in the triple
+ * store, NOT from the materialized D5 logical edge.
+ *
+ * Why instances and not the materialized edge: the EKA D5 materialize-at-index
+ * (`NoteToRDFConverter.convertLegacyNote`) emits a logical edge
+ * `<subject> <predicate> <object>` for a reified `exo__Statement`. That edge is
+ * **byte-identical** to an inline frontmatter edge and is **deduplicated** by
+ * `InMemoryTripleStore.add` — so it is provenance-free: from the edge alone you
+ * cannot tell "inline vs reified" nor recover which statement asset backs it
+ * (RFC §C1, review-unanimous). The raw `exo__Statement_subject/_predicate/
+ * _object` triples DO carry that provenance (the statement asset's IRI is their
+ * subject), so this helper queries them.
+ *
+ * This module is intentionally isolated (callers = 0 at Task 1.1; integration
+ * into `RelationsRenderer.getAssetRelations` is Task 1.3, the triple-store
+ * ctor-DI + `isReady` cold-start gate are Task 1.2). It performs no inline /
+ * reified dedup (Task 1.3) and adds no marker (Task 2).
+ */
+
+/** `exo#Statement_subject` — the reified statement's subject slot. */
+const STATEMENT_SUBJECT: IRI = Namespace.EXO.term("Statement_subject");
+/** `exo#Statement_predicate` — the reified statement's predicate slot. */
+const STATEMENT_PREDICATE: IRI = Namespace.EXO.term("Statement_predicate");
+/** `exo#Statement_object` — the reified statement's object slot. */
+const STATEMENT_OBJECT: IRI = Namespace.EXO.term("Statement_object");
+
+/**
+ * One reified relation surfaced for an asset A, derived from a single
+ * `exo__Statement` instance. Carries provenance (the statement asset's path +
+ * its AssetSpace) so a later phase can render the factual
+ * "reified · &lt;AS&gt;" marker (RFC C2).
+ */
+export interface ReifiedRelation {
+  /** IRI of the backing `exo__Statement` asset (its subject IRI in the store). */
+  statementIri: string;
+  /** Resolved `exo__Statement_subject` IRI of the logical edge. */
+  subject: string;
+  /** Resolved `exo__Statement_predicate` IRI of the logical edge. */
+  predicate: string;
+  /** Resolved `exo__Statement_object` — IRI string, or literal lexical value. */
+  object: string;
+  /** True when the object resolved to a Literal (RFC R6 — Task 1.3 routes those). */
+  objectIsLiteral: boolean;
+  /** Relative to asset A: `outgoing` (A is subject) or `incoming` (A is object). */
+  direction: "outgoing" | "incoming";
+  /**
+   * Provenance — the vault-relative path of the backing statement asset,
+   * derived from `statementIri`. `null` when the statement IRI is not a vault
+   * asset IRI (`obsidian://vault/...`).
+   */
+  statementPath: string | null;
+  /**
+   * The AssetSpace the statement asset lives in (e.g. `exoas-class-relations`),
+   * parsed from `statementPath`. `null` when not derivable.
+   */
+  assetSpace: string | null;
+}
+
+/** The asset A whose reified relations to fetch — only the fields this helper reads. */
+export interface ReifiedRelationsAsset {
+  /** Vault-relative path of A (e.g. `assetspaces/.../<uid>.md`). */
+  path: string;
+  /**
+   * A's `exo__Asset_label`. Used ONLY to compute the symbolic IRI candidate
+   * form for the dual-IRI union (R5) when the label is a `prefix__LocalName`
+   * class reference. Plain human-text labels contribute no symbolic form.
+   */
+  label?: string | null;
+}
+
+export interface GetReifiedRelationsParams {
+  /** The asset A. */
+  file: ReifiedRelationsAsset;
+  /** The triple store to query (Task 1.2 wires the live store via ctor-DI). */
+  store: ITripleStore;
+  /**
+   * The indexer's `notePathToIRI` — reused so this helper computes A's path-form
+   * IRI with the SAME `subjectIriPrefix` (mount prefix) the converter used when
+   * it emitted the statement triples. Injected (not hardcoded) so a
+   * prefix-labeled / mounted A resolves instead of silently matching nothing
+   * (R5, `sparql-iri-form-pre-verify`).
+   */
+  notePathToIRI: (path: string) => IRI;
+}
+
+/**
+ * Compute A's symbolic class IRI candidate (the `…/ns#LocalName` form) when its
+ * label is a `prefix__LocalName` reference — mirrors
+ * `NoteToRDFConverter.expandClassValue`, the exact resolution the converter
+ * applies to a `[[<uid>]]` whose target's label is prefix-parseable. Returns
+ * `null` for plain labels. Pure (no store / vault access).
+ */
+function labelToSymbolicIRI(label: string | null | undefined): IRI | null {
+  if (typeof label !== "string" || label.length === 0 || /\s/.test(label)) {
+    return null;
+  }
+  const parsed = Namespace.fromPropertyKey(label);
+  if (!parsed) return null;
+  // Reject local names whose IRI form would be invalid (parens/space) — same
+  // guard as expandClassValue (Issue #3121).
+  if (/[\s()]/.test(parsed.localName)) return null;
+  try {
+    return parsed.namespace.term(parsed.localName);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * The union of all IRI forms under which A may appear as a statement's
+ * subject/object (R5 dual-IRI):
+ *  1. path-form `obsidian://vault/<prefix><path>` via the injected `notePathToIRI`;
+ *  2. symbolic-form `…/ns#LocalName` when A's label is a class reference.
+ * Querying only one form would silently miss statements stored under the other.
+ */
+function assetIriForms(
+  file: ReifiedRelationsAsset,
+  notePathToIRI: (path: string) => IRI,
+): IRI[] {
+  const forms: IRI[] = [notePathToIRI(file.path)];
+  const symbolic = labelToSymbolicIRI(file.label);
+  if (symbolic && !forms.some((f) => f.value === symbolic.value)) {
+    forms.push(symbolic);
+  }
+  return forms;
+}
+
+/** First `IRI` object of `<subject> <predicate> ?o`, or `null`. */
+async function firstObjectIri(
+  store: ITripleStore,
+  subject: IRI,
+  predicate: IRI,
+): Promise<IRI | null> {
+  const triples = await store.match(subject, predicate, undefined);
+  for (const t of triples) {
+    if (t.object instanceof IRI) return t.object;
+  }
+  return null;
+}
+
+/** First `IRI`-or-`Literal` object of `<subject> <predicate> ?o`, or `null`. */
+async function firstIriOrLiteral(
+  store: ITripleStore,
+  subject: IRI,
+  predicate: IRI,
+): Promise<IRI | Literal | null> {
+  const triples = await store.match(subject, predicate, undefined);
+  for (const t of triples) {
+    if (t.object instanceof IRI || t.object instanceof Literal) return t.object;
+  }
+  return null;
+}
+
+/** Parse the `exoas-<name>` AssetSpace segment from a vault path, or `null`. */
+function extractAssetSpace(path: string): string | null {
+  const m = path.match(/(?:^|\/)(exoas-[a-z0-9-]+)(?:\/|$)/i);
+  return m ? m[1] : null;
+}
+
+/**
+ * Fetch the reified relations of asset A from its `exo__Statement` instances.
+ *
+ * Outgoing (A is the statement's `_subject`) is found via
+ * `match(⊥, exo:Statement_subject, A-form)`; incoming (A is `_object`) via
+ * `match(⊥, exo:Statement_object, A-form)` — the same bidirectional match shape
+ * `DescribeExecutor` uses. A is matched against ALL of its candidate IRI forms
+ * (R5). Each matched statement is read back for its three slots + provenance.
+ *
+ * Statements are keyed by their IRI, so a statement matched via multiple
+ * candidate forms (or that resolves both directions for a self-relation)
+ * appears once — `outgoing` wins for a degenerate self-edge. NO inline/reified
+ * dedup is done here (Task 1.3).
+ *
+ * @returns the reified relations; `[]` for an empty store or an asset with none.
+ */
+export async function getReifiedRelations(
+  params: GetReifiedRelationsParams,
+): Promise<ReifiedRelation[]> {
+  const { file, store, notePathToIRI } = params;
+  const forms = assetIriForms(file, notePathToIRI);
+
+  // statementIri.value → direction. Outgoing is collected first so it wins over
+  // incoming for a self-relation (A is both subject and object of one statement).
+  const direction = new Map<string, "outgoing" | "incoming">();
+
+  for (const form of forms) {
+    const outgoing = await store.match(undefined, STATEMENT_SUBJECT, form);
+    for (const t of outgoing) {
+      if (t.subject instanceof IRI) direction.set(t.subject.value, "outgoing");
+    }
+  }
+  for (const form of forms) {
+    const incoming = await store.match(undefined, STATEMENT_OBJECT, form);
+    for (const t of incoming) {
+      if (t.subject instanceof IRI && !direction.has(t.subject.value)) {
+        direction.set(t.subject.value, "incoming");
+      }
+    }
+  }
+
+  const relations: ReifiedRelation[] = [];
+  for (const [statementIriValue, dir] of direction) {
+    const statementIri = new IRI(statementIriValue);
+    const subject = await firstObjectIri(store, statementIri, STATEMENT_SUBJECT);
+    const predicate = await firstObjectIri(store, statementIri, STATEMENT_PREDICATE);
+    const object = await firstIriOrLiteral(store, statementIri, STATEMENT_OBJECT);
+    // A well-formed logical edge needs all three slots; skip a malformed /
+    // partial statement rather than surface a half-edge.
+    if (!subject || !predicate || !object) continue;
+
+    const statementPath = iriToVaultPath(statementIriValue);
+    relations.push({
+      statementIri: statementIriValue,
+      subject: subject.value,
+      predicate: predicate.value,
+      object: object.value,
+      objectIsLiteral: object instanceof Literal,
+      direction: dir,
+      statementPath,
+      assetSpace: statementPath ? extractAssetSpace(statementPath) : null,
+    });
+  }
+  return relations;
+}

--- a/packages/obsidian-plugin/tests/unit/getReifiedRelations.test.ts
+++ b/packages/obsidian-plugin/tests/unit/getReifiedRelations.test.ts
@@ -1,0 +1,228 @@
+import {
+  InMemoryTripleStore,
+  IRI,
+  Literal,
+  Namespace,
+  Triple,
+  vaultPathToIRI,
+} from "@kitelev/exocortex-core";
+import {
+  getReifiedRelations,
+  ReifiedRelation,
+} from "../../src/presentation/renderers/layout/getReifiedRelations";
+
+/**
+ * RFC `93a0b2ee` Task 1.1 — production-shape unit test for `getReifiedRelations`
+ * over a REAL `InMemoryTripleStore` (not a stub). Statements are seeded exactly
+ * the way `NoteToRDFConverter` emits them: the raw
+ * `exo__Statement_subject/_predicate/_object` triples (provenance) PLUS the
+ * materialized D5 logical edge — so we also prove the helper sources from the
+ * statement instances, not the bare edge.
+ *
+ * `@req:8d134593-3896-42d5-9436-7e994ad8fa7b`  (req-first SDD, RFC 0003).
+ *   Revert-verified: forcing `assetIriForms` to return `[]` (no candidate IRI
+ *   forms) makes the helper find zero statements → every "expect ≥1 relation"
+ *   case below goes RED; restored → GREEN.
+ */
+
+// Mirrors NoteToRDFConverter.notePathToIRI with an empty subjectIriPrefix
+// (the legacy / default mount) — the exact path-form IRI the converter emits.
+const notePathToIRI = (path: string): IRI => new IRI(vaultPathToIRI(path));
+
+const STATEMENT_SUBJECT = Namespace.EXO.term("Statement_subject");
+const STATEMENT_PREDICATE = Namespace.EXO.term("Statement_predicate");
+const STATEMENT_OBJECT = Namespace.EXO.term("Statement_object");
+const RDF_TYPE = Namespace.RDF.term("type");
+const EXO_INSTANCE_CLASS = Namespace.EXO.term("Instance_class");
+const EXO_STATEMENT_CLASS = Namespace.EXO.term("Statement");
+
+/** A relatesTo-style predicate (opaque to the helper — any IRI works). */
+const RELATES_TO = new IRI("https://exocortex.my/ontology/exo-ims#relatesToConcept");
+const PART_OF = new IRI("https://exocortex.my/ontology/ems#Effort_area");
+
+/**
+ * Seed one reified `exo__Statement` the way the indexer emits it:
+ *  - rdf:type / exo:Instance_class → exo:Statement
+ *  - the three raw slot triples (provenance lives on the statement subject)
+ *  - the materialized D5 logical edge `<subject> <predicate> <object>`
+ */
+async function seedStatement(
+  store: InMemoryTripleStore,
+  statementPath: string,
+  subject: IRI,
+  predicate: IRI,
+  object: IRI | Literal,
+): Promise<void> {
+  const stmt = notePathToIRI(statementPath);
+  await store.add(new Triple(stmt, RDF_TYPE, EXO_STATEMENT_CLASS));
+  await store.add(new Triple(stmt, EXO_INSTANCE_CLASS, EXO_STATEMENT_CLASS));
+  await store.add(new Triple(stmt, STATEMENT_SUBJECT, subject));
+  await store.add(new Triple(stmt, STATEMENT_PREDICATE, predicate));
+  await store.add(new Triple(stmt, STATEMENT_OBJECT, object));
+  // Materialized D5 edge (provenance-free, deduped) — present in the real store.
+  await store.add(new Triple(subject, predicate, object));
+}
+
+// Paths chosen so the AssetSpace segment is parseable for the provenance assert.
+const A_PATH = "assetspaces/kitelev/exoas-my/my/aaaaaaaa-0000-0000-0000-000000000001.md";
+const B_PATH = "assetspaces/kitelev/exoas-public/concept/bbbbbbbb-0000-0000-0000-000000000002.md";
+const C_PATH = "assetspaces/kitelev/exoas-public/concept/cccccccc-0000-0000-0000-000000000003.md";
+const S1_PATH = "assetspaces/kitelev/exoas-class-relations/class-relations/11111111-0000-0000-0000-000000000011.md";
+const S2_PATH = "assetspaces/kitelev/exoas-shared-private/relations/22222222-0000-0000-0000-000000000022.md";
+
+describe("getReifiedRelations (Task 1.1 — read-path from exo__Statement instances)", () => {
+  it("returns an outgoing reified relation (A is the statement subject) with provenance", async () => {
+    const store = new InMemoryTripleStore();
+    await seedStatement(store, S1_PATH, notePathToIRI(A_PATH), RELATES_TO, notePathToIRI(B_PATH));
+
+    const relations = await getReifiedRelations({
+      file: { path: A_PATH, label: "Концепт A" },
+      store,
+      notePathToIRI,
+    });
+
+    expect(relations).toHaveLength(1);
+    const r = relations[0];
+    expect(r.direction).toBe("outgoing");
+    expect(r.subject).toBe(notePathToIRI(A_PATH).value);
+    expect(r.predicate).toBe(RELATES_TO.value);
+    expect(r.object).toBe(notePathToIRI(B_PATH).value);
+    expect(r.objectIsLiteral).toBe(false);
+    // Provenance: backed by the statement asset, NOT the bare materialized edge.
+    expect(r.statementIri).toBe(notePathToIRI(S1_PATH).value);
+    expect(r.statementPath).toBe(S1_PATH);
+    expect(r.assetSpace).toBe("exoas-class-relations");
+  });
+
+  it("returns an incoming reified relation (A is the statement object)", async () => {
+    const store = new InMemoryTripleStore();
+    await seedStatement(store, S2_PATH, notePathToIRI(C_PATH), RELATES_TO, notePathToIRI(A_PATH));
+
+    const relations = await getReifiedRelations({
+      file: { path: A_PATH, label: "Концепт A" },
+      store,
+      notePathToIRI,
+    });
+
+    expect(relations).toHaveLength(1);
+    const r = relations[0];
+    expect(r.direction).toBe("incoming");
+    expect(r.subject).toBe(notePathToIRI(C_PATH).value);
+    expect(r.object).toBe(notePathToIRI(A_PATH).value);
+    expect(r.assetSpace).toBe("exoas-shared-private");
+  });
+
+  it("returns both outgoing and incoming relations for the same asset", async () => {
+    const store = new InMemoryTripleStore();
+    await seedStatement(store, S1_PATH, notePathToIRI(A_PATH), RELATES_TO, notePathToIRI(B_PATH));
+    await seedStatement(store, S2_PATH, notePathToIRI(C_PATH), PART_OF, notePathToIRI(A_PATH));
+
+    const relations = await getReifiedRelations({
+      file: { path: A_PATH, label: "Концепт A" },
+      store,
+      notePathToIRI,
+    });
+
+    expect(relations).toHaveLength(2);
+    const byDir = (d: ReifiedRelation["direction"]) => relations.filter((r) => r.direction === d);
+    expect(byDir("outgoing")).toHaveLength(1);
+    expect(byDir("incoming")).toHaveLength(1);
+    expect(byDir("outgoing")[0].object).toBe(notePathToIRI(B_PATH).value);
+    expect(byDir("incoming")[0].subject).toBe(notePathToIRI(C_PATH).value);
+  });
+
+  // R5 dual-IRI union: A's label is a prefix-parseable class reference, so the
+  // converter resolved A's `[[<uid>]]` in the statement to the SYMBOLIC IRI
+  // (concept#Foo), NOT A's path-form. The helper must still find it by querying
+  // the symbolic candidate form — otherwise prefix-labeled subjects silently
+  // yield 0 (sparql-iri-form-pre-verify). This is the revert-verify anchor for
+  // the dual-IRI behavior specifically.
+  it("resolves a prefix-labeled subject via the symbolic IRI candidate form (dual-IRI union, not silently 0)", async () => {
+    const store = new InMemoryTripleStore();
+    const symbolicA = Namespace.forPrefix("concept")!.term("Foo"); // concept#Foo
+    await seedStatement(store, S1_PATH, symbolicA, RELATES_TO, notePathToIRI(B_PATH));
+
+    const relations = await getReifiedRelations({
+      file: { path: A_PATH, label: "concept__Foo" },
+      store,
+      notePathToIRI,
+    });
+
+    expect(relations).toHaveLength(1);
+    expect(relations[0].direction).toBe("outgoing");
+    expect(relations[0].subject).toBe(symbolicA.value);
+    expect(relations[0].object).toBe(notePathToIRI(B_PATH).value);
+  });
+
+  it("flags a literal object (object=Literal → routed to properties in Task 1.3, RFC R6)", async () => {
+    const store = new InMemoryTripleStore();
+    await seedStatement(store, S1_PATH, notePathToIRI(A_PATH), RELATES_TO, new Literal("a plain value"));
+
+    const relations = await getReifiedRelations({
+      file: { path: A_PATH, label: "Концепт A" },
+      store,
+      notePathToIRI,
+    });
+
+    expect(relations).toHaveLength(1);
+    expect(relations[0].objectIsLiteral).toBe(true);
+    expect(relations[0].object).toBe("a plain value");
+  });
+
+  it("does not double-count: the bare materialized edge is not surfaced as a relation", async () => {
+    const store = new InMemoryTripleStore();
+    // Two statements + their materialized edges. Helper must return exactly 2
+    // (one per statement) — never extra rows from the bare edges.
+    await seedStatement(store, S1_PATH, notePathToIRI(A_PATH), RELATES_TO, notePathToIRI(B_PATH));
+    await seedStatement(store, S2_PATH, notePathToIRI(A_PATH), PART_OF, notePathToIRI(C_PATH));
+
+    const relations = await getReifiedRelations({
+      file: { path: A_PATH, label: "Концепт A" },
+      store,
+      notePathToIRI,
+    });
+
+    expect(relations).toHaveLength(2);
+    expect(relations.every((r) => r.direction === "outgoing")).toBe(true);
+    expect(relations.every((r) => r.statementPath !== null)).toBe(true);
+  });
+
+  it("returns [] for an asset with no reified statements", async () => {
+    const store = new InMemoryTripleStore();
+    // An unrelated statement about other assets must not leak into A's result.
+    await seedStatement(store, S2_PATH, notePathToIRI(C_PATH), RELATES_TO, notePathToIRI(B_PATH));
+
+    const relations = await getReifiedRelations({
+      file: { path: A_PATH, label: "Концепт A" },
+      store,
+      notePathToIRI,
+    });
+
+    expect(relations).toEqual([]);
+  });
+
+  it("returns [] for an empty store", async () => {
+    const store = new InMemoryTripleStore();
+    const relations = await getReifiedRelations({
+      file: { path: A_PATH, label: "Концепт A" },
+      store,
+      notePathToIRI,
+    });
+    expect(relations).toEqual([]);
+  });
+
+  it("skips a malformed statement missing a slot (partial → no half-edge)", async () => {
+    const store = new InMemoryTripleStore();
+    const stmt = notePathToIRI(S1_PATH);
+    // Only _subject present (no predicate / object) — must not surface a relation.
+    await store.add(new Triple(stmt, STATEMENT_SUBJECT, notePathToIRI(A_PATH)));
+
+    const relations = await getReifiedRelations({
+      file: { path: A_PATH, label: "Концепт A" },
+      store,
+      notePathToIRI,
+    });
+
+    expect(relations).toEqual([]);
+  });
+});


### PR DESCRIPTION
## What

Adds `getReifiedRelations` — an isolated read-path helper (Task 1.1 of RFC `93a0b2ee` §C1, Phase 1) that surfaces an asset's **reified** relations from its `exo__Statement` instances in the triple store.

For an asset A it queries the store for statements where A is the `_subject` (**outgoing**) or `_object` (**incoming**), reading each statement's `_subject` / `_predicate` / `_object` slots plus the backing statement asset's **provenance** (vault path + AssetSpace).

## Why source from instances, not the materialized edge

EKA D5 materialize-at-index emits a logical edge `<s><p><o>` for a reified statement. That edge is **byte-identical** to an inline frontmatter edge and is **deduplicated** by `InMemoryTripleStore.add` → it is provenance-free (you can't tell inline-vs-reified, nor recover the backing statement). The raw `exo__Statement_*` triples carry the provenance, so the helper reads those (RFC §C1, review-unanimous).

## Dual-IRI union (R5)

A can appear under multiple IRI forms: the path-form (via the indexer's `notePathToIRI`, same `subjectIriPrefix`) and the symbolic `…/ns#LocalName` form when A's label is a `prefix__LocalName` class reference. The helper matches A against the **union** of both, so a prefix-labeled subject isn't silently missed (`sparql-iri-form-pre-verify`).

## Scope (Task 1.1 only)

Isolated function, **callers = 0**. Out of scope (separate tasks): triple-store ctor-DI + `isReady` cold-start gate (Task 1.2); inline↔reified dedup + `AssetRelation.provenance` (Task 1.3); marker (Task 2); editor (Phase 3). No inline/reified dedup here.

## req-first SDD (RFC 0003)

- Requirement `8d134593-3896-42d5-9436-7e994ad8fa7b` (P1, **unit** binding) — pushed to `exoas-exo-reqs` main as **Approved**; will flip to **Active** after this merges.
- Bound test: `@req:8d134593-…` in `getReifiedRelations.test.ts`.
- **Revert-verified** over a real `InMemoryTripleStore` (not a stub): forcing `assetIriForms` to return `[]` → **RED** (6/9, all positive cases); restored → **GREEN** (9/9).

## Verification

- `getReifiedRelations.test.ts` — 9/9 green (real `InMemoryTripleStore`, statements seeded as the converter emits them incl. the materialized edge).
- `npm run check:types` clean · `eslint --max-warnings=0` clean on the helper.
- `requirements audit` — 0 active violations, 0 dangling tags; Active-flip simulated → binding detected (0 violations).
