### PR TITLE
feat(core): homoiconic vault-validation engine — check-runner + uid-uniqueness + co-location (M1.4)

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -796,3 +796,8 @@ export {
   isFormatOnlyDrift,
   type SemanticComparison,
 } from "./services/sync/assetSemanticCompare";
+
+// Homoiconic vault-validation engine (RFC f402002b, M1.4): the check-runner,
+// registry, 4 checks (uid-uniqueness / co-location / SHACL / DAG), and the
+// warm one-pass reader contract consumed by the `Validate vault` command (M1.5).
+export * from "./services/validation";

--- a/packages/core/src/services/validation/CheckRegistry.ts
+++ b/packages/core/src/services/validation/CheckRegistry.ts
@@ -1,0 +1,62 @@
+import type { CheckRegistryEntry } from "./types";
+import {
+  CHECK_ID_SHACL,
+  CHECK_ID_CO_LOCATION,
+  CHECK_ID_UID_UNIQUENESS,
+  CHECK_ID_DAG_ONTOLOGY_IMPORTS,
+} from "./checkIds";
+import { uidUniquenessCheck } from "./checks/uidUniquenessCheck";
+import { coLocationCheck } from "./checks/coLocationCheck";
+import { shaclCheck } from "./checks/shaclCheck";
+import { dagOntologyImportsCheck } from "./checks/dagOntologyImportsCheck";
+
+/**
+ * The check-id → runner registry. Keying is by the validation-check
+ * `setting__SettingKey` UID (data, RFC f402002b M1.3); the runner functions are
+ * code (Homoiconicity Q3 exc.1). A {@link VaultCheckRunner} given an enabled
+ * check-id with no registry entry reports it **fail-loud**.
+ */
+export class CheckRegistry {
+  private readonly entries = new Map<string, CheckRegistryEntry>();
+
+  register(entry: CheckRegistryEntry): this {
+    this.entries.set(entry.id, entry);
+    return this;
+  }
+
+  get(checkId: string): CheckRegistryEntry | undefined {
+    return this.entries.get(checkId);
+  }
+
+  has(checkId: string): boolean {
+    return this.entries.has(checkId);
+  }
+
+  ids(): string[] {
+    return [...this.entries.keys()];
+  }
+}
+
+/**
+ * The M1 MVP registry — the 4 checks (SHACL / co-location / uid-uniqueness /
+ * DAG ontology-imports) bound to the 4 `setting__SettingKey` check-ids.
+ */
+export function createDefaultCheckRegistry(): CheckRegistry {
+  return new CheckRegistry()
+    .register({
+      id: CHECK_ID_UID_UNIQUENESS,
+      label: "uid-uniqueness",
+      run: uidUniquenessCheck,
+    })
+    .register({
+      id: CHECK_ID_CO_LOCATION,
+      label: "co-location",
+      run: coLocationCheck,
+    })
+    .register({ id: CHECK_ID_SHACL, label: "shacl", run: shaclCheck })
+    .register({
+      id: CHECK_ID_DAG_ONTOLOGY_IMPORTS,
+      label: "dag-ontology-imports",
+      run: dagOntologyImportsCheck,
+    });
+}

--- a/packages/core/src/services/validation/VaultCheckRunner.ts
+++ b/packages/core/src/services/validation/VaultCheckRunner.ts
@@ -1,0 +1,70 @@
+import type {
+  CheckResult,
+  IVaultCheckReader,
+  VaultCheckReport,
+} from "./types";
+import { CheckRegistry } from "./CheckRegistry";
+
+/**
+ * The vault-validation engine (RFC f402002b, M1.4).
+ *
+ * Builds the warm {@link CheckContext} ONCE per run (one `reader.read()` call —
+ * the warm-cache / one-pass contract: checks never re-read files), then runs
+ * each ENABLED check (enabled-set = data, passed in by the `Validate vault`
+ * command from check-Setting instances) against that single context.
+ *
+ * **Fail-loud (RFC):** an enabled check-id with no registry entry, OR a runner
+ * that throws (e.g. SHACL/DAG with no platform machinery wired), is reported as
+ * an `error` result — NEVER a silent skip (anti-precedent: Repair-Folder
+ * fail-open). `ok` is true only when every enabled check `pass`ed.
+ */
+export class VaultCheckRunner {
+  constructor(private readonly registry: CheckRegistry = new CheckRegistry()) {}
+
+  async run(
+    reader: IVaultCheckReader,
+    enabledCheckIds: readonly string[],
+  ): Promise<VaultCheckReport> {
+    const ctx = await reader.read(); // ← ONE pass; warm source built once
+    const results: CheckResult[] = [];
+
+    for (const checkId of enabledCheckIds) {
+      const entry = this.registry.get(checkId);
+      if (!entry) {
+        results.push({
+          checkId,
+          label: checkId,
+          status: "error",
+          findings: [],
+          errorMessage: `fail-loud: enabled check-id "${checkId}" has no registered runner`,
+        });
+        continue;
+      }
+      try {
+        const findings = await entry.run(ctx);
+        results.push({
+          checkId,
+          label: entry.label,
+          status: findings.length > 0 ? "fail" : "pass",
+          findings,
+        });
+      } catch (err) {
+        results.push({
+          checkId,
+          label: entry.label,
+          status: "error",
+          findings: [],
+          errorMessage: `fail-loud: check "${entry.label}" threw — ${
+            err instanceof Error ? err.message : String(err)
+          }`,
+        });
+      }
+    }
+
+    return {
+      totalAssets: ctx.assets.length,
+      results,
+      ok: results.every((r) => r.status === "pass"),
+    };
+  }
+}

--- a/packages/core/src/services/validation/checkIds.ts
+++ b/packages/core/src/services/validation/checkIds.ts
@@ -1,0 +1,42 @@
+/**
+ * Stable check-ids — the UIDs of the validation-check `setting__SettingKey`
+ * individuals (RFC f402002b, M1.3, in `exoas-exo/setting/`). These are the keys
+ * the {@link CheckRegistry} maps to runners; a check-Setting instance whose key
+ * UID is none of these (no registered runner) is reported **fail-loud** by the
+ * runner, never silently skipped.
+ *
+ * The split is the Homoiconicity Invariant in action: the ENABLED-SET is data
+ * (check-Setting instances reference these keys); the RUNNER mapping is code.
+ */
+
+/** `setting__ValidationCheckShacl` — SHACL-lite vault-wide check. */
+export const CHECK_ID_SHACL = "f83ffedd-1f05-4ab5-839d-58873c69c4ba";
+
+/** `setting__ValidationCheckCoLocation` — asset folder == isDefinedBy ontology folder. */
+export const CHECK_ID_CO_LOCATION = "61f95c82-f6fc-4b20-b06d-19f3dc1b1f12";
+
+/** `setting__ValidationCheckUidUniqueness` — no two assets share an exo__Asset_uid. */
+export const CHECK_ID_UID_UNIQUENESS = "ac10db25-231c-4677-8cac-647d3cf15c64";
+
+/** `setting__ValidationCheckDagOntologyImports` — cross-ontology link covered by imports closure. */
+export const CHECK_ID_DAG_ONTOLOGY_IMPORTS = "a57f4a6b-a462-4c8d-b958-0dbee4674727";
+
+/** All known validation-check ids (the M1 MVP set of 4). */
+export const KNOWN_CHECK_IDS: ReadonlySet<string> = new Set([
+  CHECK_ID_SHACL,
+  CHECK_ID_CO_LOCATION,
+  CHECK_ID_UID_UNIQUENESS,
+  CHECK_ID_DAG_ONTOLOGY_IMPORTS,
+]);
+
+/**
+ * Filename-named classes (UUID-canon whitelist, CLAUDE.md) whose instances are
+ * NOT UID-named (`pn__DailyNote` → `YYYY-MM-DD.md`, `period__Week` →
+ * `YYYY-Www.md`, required by obsidian-calendar-plugin). Their assets still carry
+ * a unique `exo__Asset_uid`, but they are exempt from the uid-uniqueness check
+ * so a (defensive) collision in the calendar corpus never false-flags.
+ */
+export const UID_UNIQUENESS_WHITELIST_CLASS_UIDS: ReadonlySet<string> = new Set([
+  "b04e7a3e-6b49-4984-9f8d-b74e9f36818b", // pn__DailyNote
+  "2b754a16-cccf-49ee-af69-a18c6d1e3b63", // period__Week
+]);

--- a/packages/core/src/services/validation/checks/coLocationCheck.ts
+++ b/packages/core/src/services/validation/checks/coLocationCheck.ts
@@ -1,0 +1,73 @@
+import type { CheckContext, CheckFinding } from "../types";
+import { readUid, readIsDefinedByRef } from "../frontmatterRefs";
+
+/** UUID v4-ish — distinguishes a uid reference from a label reference. */
+const UID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+function dirOf(p: string): string {
+  const i = p.lastIndexOf("/");
+  return i < 0 ? "" : p.slice(0, i);
+}
+
+function baseNameNoExt(p: string): string {
+  const seg = p.slice(p.lastIndexOf("/") + 1);
+  return seg.endsWith(".md") ? seg.slice(0, -3) : seg;
+}
+
+/** Templates hold placeholder syntax, carry isDefinedBy by inheritance, must never move (CR-1). */
+function isTemplatesPath(p: string): boolean {
+  return p.split("/").some((seg) => seg.toLowerCase() === "templates");
+}
+
+/**
+ * co-location check (RFC f402002b, M1.4): every asset with
+ * `exo__Asset_isDefinedBy` must physically live in the same folder as the
+ * ontology file that reference resolves to (FLAT, exact-match — CR-1).
+ *
+ * Reader-based + DI-free: resolution uses one-pass indexes built from the warm
+ * asset array (uid → path, basename → path), the same uid-then-basename order
+ * the CLI `findReferencedFile` resolver uses, so the mobile validate path and
+ * the CLI `audit co-location` agree.
+ *
+ * Fail-open (skipped, never a violation): empty isDefinedBy, `!`-prefixed
+ * (intentionally unresolvable) ref, or a ref that resolves to no asset in this
+ * vault (cross-vault / missing ontology file).
+ */
+export function coLocationCheck(ctx: CheckContext): CheckFinding[] {
+  const byUid = new Map<string, string>();
+  const byBasename = new Map<string, string>();
+  for (const a of ctx.assets) {
+    const uid = readUid(a.frontmatter);
+    if (uid && !byUid.has(uid)) byUid.set(uid, a.path);
+    const base = baseNameNoExt(a.path);
+    if (!byBasename.has(base)) byBasename.set(base, a.path);
+  }
+
+  const resolve = (ref: string): string | undefined =>
+    UID_RE.test(ref)
+      ? (byUid.get(ref) ?? byBasename.get(ref))
+      : (byBasename.get(ref) ?? byUid.get(ref));
+
+  const findings: CheckFinding[] = [];
+  for (const a of ctx.assets) {
+    if (a.path.split("/").includes("node_modules")) continue;
+    if (isTemplatesPath(a.path)) continue;
+
+    const ref = readIsDefinedByRef(a.frontmatter);
+    if (!ref) continue; // empty isDefinedBy — fail-open
+    if (ref.startsWith("!")) continue; // bang-prefix — intentionally unresolvable
+
+    const ontologyPath = resolve(ref);
+    if (!ontologyPath) continue; // unresolvable in this vault — fail-open
+
+    const expected = dirOf(ontologyPath);
+    const actual = dirOf(a.path);
+    if (expected !== actual) {
+      findings.push({
+        path: a.path,
+        message: `co-location: isDefinedBy=${ref} expects folder "${expected}/" but asset is in "${actual}/"`,
+      });
+    }
+  }
+  return findings;
+}

--- a/packages/core/src/services/validation/checks/dagOntologyImportsCheck.ts
+++ b/packages/core/src/services/validation/checks/dagOntologyImportsCheck.ts
@@ -1,0 +1,29 @@
+import type { CheckContext, CheckFinding } from "../types";
+
+/**
+ * Ontology-imports DAG check (RFC f402002b, M1.4) — a cross-ontology link is a
+ * violation unless the source ontology declares an `exo__Ontology_imports`
+ * closure covering the target (the invariant of the existing CLI
+ * `audit ontology-imports`, req 6999f49b).
+ *
+ * The ontology-graph derivation (asset → ontology, declared-imports edges,
+ * cross-ontology link classification) is shared with — and validated against —
+ * the CLI scanner (`ontologyImportsGraph` transitive-closure primitives). To
+ * keep that single source of truth and avoid a drifting re-implementation, the
+ * reader injects a pre-bound `runDag` thunk (plugin: over the warm asset graph;
+ * CLI: the existing scanner). This check just surfaces its findings.
+ *
+ * **Fail-loud:** if the context provides no `runDag`, the check throws — the
+ * runner surfaces it as an `error` result, never a silent skip.
+ */
+export async function dagOntologyImportsCheck(
+  ctx: CheckContext,
+): Promise<CheckFinding[]> {
+  if (!ctx.runDag) {
+    throw new Error(
+      "DAG ontology-imports check is enabled but this context provides no graph " +
+        "derivation (runDag). Wire a reader that supplies it, or disable the check.",
+    );
+  }
+  return [...(await ctx.runDag())];
+}

--- a/packages/core/src/services/validation/checks/shaclCheck.ts
+++ b/packages/core/src/services/validation/checks/shaclCheck.ts
@@ -1,0 +1,27 @@
+import type { CheckContext, CheckFinding } from "../types";
+
+/**
+ * SHACL-lite vault-wide check (RFC f402002b, M1.4).
+ *
+ * The triple-store machinery is platform-specific and heavy, so the reader
+ * injects a pre-bound `runShacl` thunk (plugin: `ShaclLiteValidator.validate`
+ * over the warm `getTripleStore()`; CLI: `runShapesValidation`). This check
+ * just maps the violations to findings.
+ *
+ * **Fail-loud:** if the context provides no `runShacl` (the reader cannot supply
+ * a triple-store), the check throws — the runner surfaces it as an `error`
+ * result, never a silent skip (anti-precedent: Repair-Folder fail-open).
+ */
+export async function shaclCheck(ctx: CheckContext): Promise<CheckFinding[]> {
+  if (!ctx.runShacl) {
+    throw new Error(
+      "SHACL check is enabled but this context provides no triple-store (runShacl). " +
+        "Wire a warm getTripleStore()/runShapesValidation reader, or disable the check.",
+    );
+  }
+  const violations = await ctx.runShacl();
+  return violations.map((v) => ({
+    path: v.focusNode ?? v.path,
+    message: `SHACL: ${v.message}${v.path ? ` (path ${v.path})` : ""}`,
+  }));
+}

--- a/packages/core/src/services/validation/checks/uidUniquenessCheck.ts
+++ b/packages/core/src/services/validation/checks/uidUniquenessCheck.ts
@@ -1,0 +1,47 @@
+import type { CheckContext, CheckFinding } from "../types";
+import { readUid, readInstanceClassRefs } from "../frontmatterRefs";
+import { UID_UNIQUENESS_WHITELIST_CLASS_UIDS } from "../checkIds";
+
+/**
+ * uid-uniqueness check (RFC f402002b, M1.4): no two assets share an
+ * `exo__Asset_uid`. A uid on ≥2 paths breaks the UID-canon contract (the
+ * resolver, ExoSync uid-keyed diff #3477, and SHACL class resolution all assume
+ * a uid maps to exactly one file).
+ *
+ * Filename-named classes (`pn__DailyNote` / `period__Week`, whitelist) are
+ * exempt — their identity is the filename, not the uid (see
+ * {@link UID_UNIQUENESS_WHITELIST_CLASS_UIDS}).
+ *
+ * Pure over the warm one-pass asset array; never re-reads files.
+ */
+export function uidUniquenessCheck(ctx: CheckContext): CheckFinding[] {
+  const byUid = new Map<string, string[]>();
+
+  for (const asset of ctx.assets) {
+    const uid = readUid(asset.frontmatter);
+    if (!uid) continue; // assets without a uid match by path (D18); not our concern
+
+    // Exempt whitelist filename-classes: their uid is not their identity.
+    const classes = readInstanceClassRefs(asset.frontmatter);
+    if (classes.some((c) => UID_UNIQUENESS_WHITELIST_CLASS_UIDS.has(c))) continue;
+
+    const paths = byUid.get(uid);
+    if (paths) paths.push(asset.path);
+    else byUid.set(uid, [asset.path]);
+  }
+
+  const findings: CheckFinding[] = [];
+  for (const [uid, paths] of byUid) {
+    if (paths.length < 2) continue;
+    const sorted = [...paths].sort();
+    for (const p of sorted) {
+      findings.push({
+        path: p,
+        message: `duplicate exo__Asset_uid "${uid}" — also at ${sorted
+          .filter((o) => o !== p)
+          .join(", ")}`,
+      });
+    }
+  }
+  return findings;
+}

--- a/packages/core/src/services/validation/frontmatterRefs.ts
+++ b/packages/core/src/services/validation/frontmatterRefs.ts
@@ -1,0 +1,36 @@
+import { extractAssetReference } from "../../utilities/extractAssetReference";
+
+/**
+ * Small frontmatter accessors shared by the asset-array checks. They read the
+ * already-parsed warm frontmatter (never re-parse files) and normalise the two
+ * shapes a value can take (scalar vs YAML list of `[[ref]]` wikilinks).
+ */
+
+/** `exo__Asset_uid` as a trimmed string, or null. */
+export function readUid(fm: Readonly<Record<string, unknown>>): string | null {
+  const v = fm["exo__Asset_uid"];
+  if (typeof v !== "string") return null;
+  const t = v.trim();
+  return t.length > 0 ? t : null;
+}
+
+/** `exo__Asset_isDefinedBy` resolved to its bare reference (uid or label), or null. */
+export function readIsDefinedByRef(
+  fm: Readonly<Record<string, unknown>>,
+): string | null {
+  return extractAssetReference(fm["exo__Asset_isDefinedBy"]);
+}
+
+/** All `exo__Instance_class` references (bare uid/label), normalising scalar | list shape. */
+export function readInstanceClassRefs(
+  fm: Readonly<Record<string, unknown>>,
+): string[] {
+  const raw = fm["exo__Instance_class"];
+  const values: unknown[] = Array.isArray(raw) ? raw : raw == null ? [] : [raw];
+  const refs: string[] = [];
+  for (const v of values) {
+    const ref = extractAssetReference(v);
+    if (ref) refs.push(ref);
+  }
+  return refs;
+}

--- a/packages/core/src/services/validation/index.ts
+++ b/packages/core/src/services/validation/index.ts
@@ -1,0 +1,21 @@
+/**
+ * Homoiconic vault-validation engine (RFC f402002b, M1.4) — public barrel.
+ *
+ * The `Validate vault` command (M1.5, plugin + CLI + mobile) builds a concrete
+ * {@link IVaultCheckReader} (warm metadataCache/getTripleStore on the plugin; a
+ * single fs-walk on the CLI), reads the enabled-set from validation-check
+ * `setting__Setting` instances, and runs {@link VaultCheckRunner}.
+ */
+export * from "./types";
+export * from "./checkIds";
+export { CheckRegistry, createDefaultCheckRegistry } from "./CheckRegistry";
+export { VaultCheckRunner } from "./VaultCheckRunner";
+export { uidUniquenessCheck } from "./checks/uidUniquenessCheck";
+export { coLocationCheck } from "./checks/coLocationCheck";
+export { shaclCheck } from "./checks/shaclCheck";
+export { dagOntologyImportsCheck } from "./checks/dagOntologyImportsCheck";
+export {
+  readUid,
+  readIsDefinedByRef,
+  readInstanceClassRefs,
+} from "./frontmatterRefs";

--- a/packages/core/src/services/validation/types.ts
+++ b/packages/core/src/services/validation/types.ts
@@ -1,0 +1,97 @@
+/**
+ * Homoiconic vault-validation engine (RFC f402002b, M1.4).
+ *
+ * The engine is the **code** half of the Homoiconicity Invariant (Q3 exc.1 —
+ * algorithm in TS); WHICH checks are enabled is **data** (validation-check
+ * `setting__Setting` instances, read by the `Validate vault` command, M1.5).
+ *
+ * Desktop↔Mobile parity: every check operates on a `CheckContext` that is built
+ * ONCE per run from a warm source — the plugin reader builds it from
+ * `metadataCache.getFileCache` (+ `getTripleStore()`), NEVER by re-reading +
+ * re-parsing each file (the "iPhone reindex 10 minutes" anti-pattern); the CLI
+ * reader builds it from a single fs-walk. Both satisfy {@link IVaultCheckReader}.
+ */
+
+/** One vault asset, as the warm reader surfaces it: path + already-parsed frontmatter. */
+export interface VaultAssetRecord {
+  /** Vault-relative path (e.g. `assetspaces/kitelev/exoas-exo/exo/abc.md`). */
+  readonly path: string;
+  /** Parsed YAML frontmatter (warm — from metadataCache / fs-walk; never re-read per check). */
+  readonly frontmatter: Readonly<Record<string, unknown>>;
+}
+
+/** A SHACL violation, structurally minimal so the engine does not depend on the validator package. */
+export interface ShaclViolationLike {
+  readonly focusNode?: string;
+  readonly path?: string;
+  readonly message: string;
+}
+
+/**
+ * Everything a check needs, built ONCE per run from a warm source.
+ *
+ * `assets` powers the asset-array checks (uid-uniqueness, co-location) directly
+ * in core (mobile-portable, no platform deps). `runShacl` / `runDag` are
+ * pre-bound runners injected by the reader for the two checks whose machinery is
+ * platform-specific and heavy — SHACL needs a triple-store (plugin wraps
+ * `ShaclLiteValidator.validate` over the warm `getTripleStore()`; CLI wraps
+ * `runShapesValidation`), DAG needs the ontology-imports graph derivation
+ * (validated against the existing CLI `audit ontology-imports`). Kept as thunks
+ * so the core engine carries neither; absent when the reader cannot provide one
+ * → the runner reports that check **fail-loud** (never silently skipped).
+ */
+export interface CheckContext {
+  readonly assets: readonly VaultAssetRecord[];
+  readonly runShacl?: () => Promise<readonly ShaclViolationLike[]>;
+  readonly runDag?: () => Promise<readonly CheckFinding[]>;
+}
+
+/** One problem a check found. */
+export interface CheckFinding {
+  /** Vault-relative path the finding is about (omitted for vault-wide findings). */
+  readonly path?: string;
+  /** Human-readable description. */
+  readonly message: string;
+}
+
+export type CheckStatus = "pass" | "fail" | "error";
+
+/** Per-check outcome in a {@link VaultCheckReport}. */
+export interface CheckResult {
+  /** The check-id (a validation-check `setting__SettingKey` UID). */
+  readonly checkId: string;
+  /** Human label for the check (from the registry). */
+  readonly label: string;
+  readonly status: CheckStatus;
+  readonly findings: readonly CheckFinding[];
+  /** Present when `status === "error"` (fail-loud), e.g. unregistered check-id or runner threw. */
+  readonly errorMessage?: string;
+}
+
+/** Full report of one `Validate vault` run. */
+export interface VaultCheckReport {
+  readonly totalAssets: number;
+  readonly results: readonly CheckResult[];
+  /** True iff every enabled check `pass`ed (no `fail`, no `error`). */
+  readonly ok: boolean;
+}
+
+/** A check function: pure over the warm context (may be async — SHACL is). */
+export type CheckFn = (
+  ctx: CheckContext,
+) => readonly CheckFinding[] | Promise<readonly CheckFinding[]>;
+
+/** A registered check: stable id (check-key UID) + label + runner. */
+export interface CheckRegistryEntry {
+  readonly id: string;
+  readonly label: string;
+  readonly run: CheckFn;
+}
+
+/**
+ * The warm reader that builds a {@link CheckContext} ONCE. Plugin and CLI each
+ * provide a concrete implementation (M1.5); the engine depends only on this.
+ */
+export interface IVaultCheckReader {
+  read(): Promise<CheckContext>;
+}

--- a/packages/core/tests/services/validation/VaultCheckRunner.test.ts
+++ b/packages/core/tests/services/validation/VaultCheckRunner.test.ts
@@ -1,0 +1,219 @@
+import {
+  VaultCheckRunner,
+  createDefaultCheckRegistry,
+  CheckRegistry,
+  uidUniquenessCheck,
+  coLocationCheck,
+  shaclCheck,
+  CHECK_ID_UID_UNIQUENESS,
+  CHECK_ID_CO_LOCATION,
+  CHECK_ID_SHACL,
+  CHECK_ID_DAG_ONTOLOGY_IMPORTS,
+  type CheckContext,
+  type IVaultCheckReader,
+  type VaultAssetRecord,
+} from "../../../src/services/validation";
+
+/** Production-shape asset record: path + already-parsed frontmatter (warm). */
+function asset(
+  path: string,
+  fm: Record<string, unknown>,
+): VaultAssetRecord {
+  return { path, frontmatter: fm };
+}
+
+/** A reader that hands the engine a fixed context and counts read() calls (one-pass contract). */
+class FakeReader implements IVaultCheckReader {
+  reads = 0;
+  constructor(private readonly ctx: CheckContext) {}
+  async read(): Promise<CheckContext> {
+    this.reads++;
+    return this.ctx;
+  }
+}
+
+const PN_DAILY_NOTE = "b04e7a3e-6b49-4984-9f8d-b74e9f36818b";
+
+describe("uid-uniqueness check (RFC f402002b M1.4)", () => {
+  it("@req:4b45aaca-0857-4e16-922d-40ecd7b237ac flags a duplicate exo__Asset_uid across two paths and leaves unique uids clean", () => {
+    const assets = [
+      asset("a/x.md", { exo__Asset_uid: "11111111-1111-1111-1111-111111111111" }),
+      asset("b/y.md", { exo__Asset_uid: "11111111-1111-1111-1111-111111111111" }),
+      asset("c/z.md", { exo__Asset_uid: "22222222-2222-2222-2222-222222222222" }),
+    ];
+    const findings = uidUniquenessCheck({ assets });
+    // Both members of the duplicate group are reported; the unique one is not.
+    expect(findings.map((f) => f.path).sort()).toEqual(["a/x.md", "b/y.md"]);
+    expect(findings.every((f) => f.message.includes("11111111"))).toBe(true);
+  });
+
+  it("@req:4b45aaca-0857-4e16-922d-40ecd7b237ac exempts whitelisted filename-classes (pn__DailyNote) from the uid-uniqueness check", () => {
+    // Two daily notes that (defensively) share a uid must NOT be flagged — their
+    // identity is the filename, not the uid. revert-verify: dropping the
+    // `classes.some(c => WHITELIST.has(c))` guard in uidUniquenessCheck makes
+    // this go RED (the pair would be reported as a duplicate).
+    const assets = [
+      asset("daily/2026-06-27.md", {
+        exo__Asset_uid: "33333333-3333-3333-3333-333333333333",
+        exo__Instance_class: [`[[${PN_DAILY_NOTE}]]`],
+      }),
+      asset("daily/2026-06-28.md", {
+        exo__Asset_uid: "33333333-3333-3333-3333-333333333333",
+        exo__Instance_class: [`[[${PN_DAILY_NOTE}]]`],
+      }),
+    ];
+    expect(uidUniquenessCheck({ assets })).toEqual([]);
+  });
+
+  it("@req:4b45aaca-0857-4e16-922d-40ecd7b237ac ignores assets without a uid (path identity, D18)", () => {
+    const assets = [asset("a.md", {}), asset("b.md", { exo__Asset_uid: "" })];
+    expect(uidUniquenessCheck({ assets })).toEqual([]);
+  });
+});
+
+describe("VaultCheckRunner engine (RFC f402002b M1.4)", () => {
+  it("@req:2214573f-4278-4bcd-bf19-8c459a5abd05 runs exactly the enabled checks and passes when none find anything", async () => {
+    const reader = new FakeReader({
+      assets: [
+        asset("a/x.md", { exo__Asset_uid: "aaaaaaaa-0000-0000-0000-000000000000" }),
+      ],
+    });
+    const report = await new VaultCheckRunner(createDefaultCheckRegistry()).run(
+      reader,
+      [CHECK_ID_UID_UNIQUENESS],
+    );
+    expect(report.results).toHaveLength(1);
+    expect(report.results[0].status).toBe("pass");
+    expect(report.ok).toBe(true);
+    expect(report.totalAssets).toBe(1);
+  });
+
+  it("@req:2214573f-4278-4bcd-bf19-8c459a5abd05 reads the warm context ONCE even with multiple enabled checks (one-pass / warm-cache contract)", async () => {
+    const reader = new FakeReader({ assets: [] });
+    await new VaultCheckRunner(createDefaultCheckRegistry()).run(reader, [
+      CHECK_ID_UID_UNIQUENESS,
+      CHECK_ID_CO_LOCATION,
+    ]);
+    // The engine MUST build the context once and share it — never per-check or
+    // per-file re-read (the "iPhone reindex 10 minutes" anti-pattern).
+    expect(reader.reads).toBe(1);
+  });
+
+  it("@req:2214573f-4278-4bcd-bf19-8c459a5abd05 fails LOUD (error result) on an enabled check-id with no registered runner — never a silent skip", async () => {
+    const reader = new FakeReader({ assets: [] });
+    const report = await new VaultCheckRunner(createDefaultCheckRegistry()).run(
+      reader,
+      ["00000000-dead-beef-0000-000000000000"],
+    );
+    expect(report.results[0].status).toBe("error");
+    expect(report.results[0].errorMessage).toMatch(/fail-loud.*no registered runner/);
+    expect(report.ok).toBe(false);
+  });
+
+  it("@req:2214573f-4278-4bcd-bf19-8c459a5abd05 fails LOUD when an enabled check throws (SHACL with no triple-store wired) instead of skipping it", async () => {
+    const reader = new FakeReader({ assets: [] }); // no runShacl provided
+    const report = await new VaultCheckRunner(createDefaultCheckRegistry()).run(
+      reader,
+      [CHECK_ID_SHACL],
+    );
+    expect(report.results[0].status).toBe("error");
+    expect(report.results[0].errorMessage).toMatch(/fail-loud.*runShacl/);
+    expect(report.ok).toBe(false);
+  });
+
+  it("@req:2214573f-4278-4bcd-bf19-8c459a5abd05 marks ok=false when any enabled check fails", async () => {
+    const reader = new FakeReader({
+      assets: [
+        asset("a/x.md", { exo__Asset_uid: "dup-0000-0000-0000-000000000000" }),
+        asset("b/y.md", { exo__Asset_uid: "dup-0000-0000-0000-000000000000" }),
+      ],
+    });
+    const report = await new VaultCheckRunner(createDefaultCheckRegistry()).run(
+      reader,
+      [CHECK_ID_UID_UNIQUENESS],
+    );
+    expect(report.results[0].status).toBe("fail");
+    expect(report.ok).toBe(false);
+  });
+
+  it("@req:2214573f-4278-4bcd-bf19-8c459a5abd05 an empty registry fails loud for every enabled check (no silent pass)", async () => {
+    const reader = new FakeReader({ assets: [] });
+    const report = await new VaultCheckRunner(new CheckRegistry()).run(reader, [
+      CHECK_ID_UID_UNIQUENESS,
+    ]);
+    expect(report.results[0].status).toBe("error");
+  });
+});
+
+describe("co-location check (RFC f402002b M1.4)", () => {
+  const ONTO = "ca97bb2f-99bd-4ceb-b51e-c386b9231ae3";
+  function ctxWith(assetPath: string): CheckContext {
+    return {
+      assets: [
+        asset(`onto/${ONTO}.md`, {
+          exo__Asset_uid: ONTO,
+          exo__Asset_isDefinedBy: `[[${ONTO}]]`,
+        }),
+        asset(assetPath, {
+          exo__Asset_uid: "cccccccc-0000-0000-0000-000000000000",
+          exo__Asset_isDefinedBy: `[[${ONTO}]]`,
+        }),
+      ],
+    };
+  }
+
+  it("@req:2214573f-4278-4bcd-bf19-8c459a5abd05 flags an asset whose folder differs from its isDefinedBy ontology folder", () => {
+    const findings = coLocationCheck(ctxWith("wrong/c.md"));
+    expect(findings).toHaveLength(1);
+    expect(findings[0].path).toBe("wrong/c.md");
+  });
+
+  it("@req:2214573f-4278-4bcd-bf19-8c459a5abd05 passes when the asset is co-located with its ontology", () => {
+    expect(coLocationCheck(ctxWith(`onto/c.md`))).toEqual([]);
+  });
+
+  it("@req:2214573f-4278-4bcd-bf19-8c459a5abd05 fail-opens (skips, never violates) on empty / bang-prefix / unresolvable isDefinedBy", () => {
+    const ctx: CheckContext = {
+      assets: [
+        asset("a/empty.md", { exo__Asset_uid: "e1" }),
+        asset("a/bang.md", {
+          exo__Asset_uid: "e2",
+          exo__Asset_isDefinedBy: "[[!kitelev]]",
+        }),
+        asset("a/missing.md", {
+          exo__Asset_uid: "e3",
+          exo__Asset_isDefinedBy: "[[ffffffff-0000-0000-0000-000000000000]]",
+        }),
+      ],
+    };
+    expect(coLocationCheck(ctx)).toEqual([]);
+  });
+});
+
+describe("SHACL/DAG thunk delegation (RFC f402002b M1.4)", () => {
+  it("@req:2214573f-4278-4bcd-bf19-8c459a5abd05 SHACL check maps reader-provided violations to findings", async () => {
+    const ctx: CheckContext = {
+      assets: [],
+      runShacl: async () => [
+        { focusNode: "obsidian://vault/x.md", message: "minCount 1 violated" },
+      ],
+    };
+    const findings = await shaclCheck(ctx);
+    expect(findings).toHaveLength(1);
+    expect(findings[0].path).toBe("obsidian://vault/x.md");
+    expect(findings[0].message).toMatch(/SHACL: minCount/);
+  });
+
+  it("@req:2214573f-4278-4bcd-bf19-8c459a5abd05 DAG check delegates to the reader-provided runDag and surfaces its findings via the runner", async () => {
+    const reader = new FakeReader({
+      assets: [],
+      runDag: async () => [{ path: "a.md", message: "cross-ontology link not in imports closure" }],
+    });
+    const report = await new VaultCheckRunner(createDefaultCheckRegistry()).run(
+      reader,
+      [CHECK_ID_DAG_ONTOLOGY_IMPORTS],
+    );
+    expect(report.results[0].status).toBe("fail");
+    expect(report.results[0].findings[0].message).toMatch(/cross-ontology/);
+  });
+});


### PR DESCRIPTION
## M1.4 — Homoiconic vault-validation engine (RFC f402002b)

Milestone **M1** (validation-first re-slice) of the Unified Settings Distribution project. This PR ships the **portable core engine** that the `Validate vault` command (M1.5) wires; the TBox it consumes (`$setting` ontology, `setting__Setting`/`setting__SettingKey`, the 4 validation-check `setting__SettingKey` individuals) already landed in `exoas-exo` (M1.1–M1.3, SHACL=0 both vaults).

### What's added (`packages/core/src/services/validation/`)
- **`VaultCheckRunner`** — builds the warm `CheckContext` **once** per run (one `reader.read()` — the warm-cache / one-pass contract: checks never re-read files, avoiding the "iPhone reindex 10 minutes" anti-pattern), runs each enabled check, returns a structured report.
- **Fail-loud** — an enabled check-id with no registered runner, or a runner that throws (SHACL/DAG with no platform machinery wired), is reported as an `error` result (never a silent skip — anti-precedent: Repair-Folder fail-open).
- **`CheckRegistry`** — maps the 4 validation-check `setting__SettingKey` UIDs → runners (enabled-set is **data**, runners are **code** — Homoiconicity Q3 exc.1).
- **Checks:** `uidUniquenessCheck` + `coLocationCheck` are pure over the warm asset array (mobile-portable, no platform deps). `shaclCheck` / `dagOntologyImportsCheck` delegate to reader-injected `runShacl`/`runDag` thunks so the core engine carries neither the triple-store nor the ontology-graph machinery (wired by the concrete plugin/CLI readers in M1.5, where they're verified against the warm `getTripleStore()` and the existing `audit ontology-imports`).

### Scope note (cascade-cap)
The heavy CLI scanners (`audit-co-location`, `audit-ontology-imports`, 1480 LOC) stay as the CI source-of-truth. M1.4 adds **additive** reader-based core checks reusing core primitives (`extractAssetReference`/`extractAssetUid`); unifying the CLI audits onto the core checks is an M2 follow-up (avoids a 1480-LOC extraction + cascade in M1).

### Requirements (req-first SDD)
- `@req:4b45aaca-…` — uid-uniqueness flags a shared `exo__Asset_uid`, exempts filename-classes (pn__DailyNote / period__Week).
- `@req:2214573f-…` — check-runner reads the warm context once + fails loud on unregistered/unwired checks.

Both **revert-verified**: neutralising the whitelist guard → whitelist test RED (1/14); silent-skipping unregistered → fail-loud tests RED (2/14); restored → 14/14 GREEN. Reqs are `proposed` in `exoas-exo-reqs` (`f5b4313`) — flipped to `active` after merge.

### Tests
14/14 in `packages/core/tests/services/validation/VaultCheckRunner.test.ts` (auto-gated by `test-coverage-exocortex` full jest config).
