### PR TITLE
feat(sync): post-sync targeted disk-read reindex makes pulled assets visible in Layouts without restart

### DIFF
--- a/packages/core/src/services/NoteToRDFConverter.ts
+++ b/packages/core/src/services/NoteToRDFConverter.ts
@@ -188,8 +188,35 @@ export class NoteToRDFConverter {
    * ```
    */
   async convertNote(file: IFile): Promise<Triple[]> {
-    const frontmatter = this.vault.getFrontmatter(file);
+    return this.convertNoteFromFrontmatter(
+      file,
+      this.vault.getFrontmatter(file),
+    );
+  }
 
+  /**
+   * Convert a note to RDF using ALREADY-RESOLVED frontmatter instead of reading
+   * it from the vault adapter (`getFrontmatter`, metadataCache-backed).
+   *
+   * RFC 8f93ff95 — ExoSync writes pulled assets via `vault.adapter.write`,
+   * which does NOT refresh Obsidian's metadataCache, so `getFrontmatter` can be
+   * stale for a just-synced file. The post-sync targeted reindex parses the
+   * frontmatter straight from disk and passes it here, decoupling the per-file
+   * conversion from metadataCache freshness. Wikilink TARGET resolution
+   * (prototype / Exo 0.0.3 anchors) still flows through the adapter —
+   * acceptable for Tier 1: the asset's OWN frontmatter triples (label, class,
+   * `ems__Effort_parent`, …) are what make it visible in a parent's Layout.
+   * Full disk-resolution of wikilinks is Tier 2.
+   *
+   * @param file - The note's path/basename identity (a synthetic `IFile` is
+   *   fine — only `path`/`basename` are read here).
+   * @param frontmatter - The note's frontmatter, already parsed (e.g. from
+   *   disk). `null` ⇒ no triples.
+   */
+  async convertNoteFromFrontmatter(
+    file: IFile,
+    frontmatter: Record<string, unknown> | null,
+  ): Promise<Triple[]> {
     if (!frontmatter) {
       return [];
     }

--- a/packages/core/src/services/sync/SyncEngine.ts
+++ b/packages/core/src/services/sync/SyncEngine.ts
@@ -1437,18 +1437,19 @@ export class SyncEngine {
 
       // Merged contents that differ from the local copy land on disk through
       // the same TOCTOU-guarded apply as remote pulls.
-      const { pulledCount, pinnedPaths } = await this.applyRemoteChanges(
-        localFiles,
-        disk,
-        [...applyWrites, ...merge.mergedWrites].filter(
-          (w) => !withheldPaths.has(w.path),
-        ),
-        applyDeletes.filter((d) => !withheldPaths.has(d.path)),
-        warnings,
-        // mtime-manifest: cache-hit (NOT-read) files have no `disk` snapshot —
-        // their sync-start blobSha drives the TOCTOU check instead.
-        cachedBlobShas,
-      );
+      const { pulledCount, pinnedPaths, pulledPaths } =
+        await this.applyRemoteChanges(
+          localFiles,
+          disk,
+          [...applyWrites, ...merge.mergedWrites].filter(
+            (w) => !withheldPaths.has(w.path),
+          ),
+          applyDeletes.filter((d) => !withheldPaths.has(d.path)),
+          warnings,
+          // mtime-manifest: cache-hit (NOT-read) files have no `disk` snapshot —
+          // their sync-start blobSha drives the TOCTOU check instead.
+          cachedBlobShas,
+        );
 
       // Quarantined paths keep their OLD watermark entry (same mechanism as
       // TOCTOU pins): the conflict re-derives every sync until resolved.
@@ -1522,6 +1523,9 @@ export class SyncEngine {
         ...(merge.mergedPaths.length > 0
           ? { mergedPaths: merge.mergedPaths }
           : {}),
+        // RFC 8f93ff95 — surface the disk-mutated pull paths so the command
+        // layer can targeted-reindex them post-sync (mirrors `mergedPaths`).
+        ...(pulledPaths.length > 0 ? { pulledPaths } : {}),
         ...(quarantinedPathsOf(merge).length > 0
           ? { quarantinedPaths: quarantinedPathsOf(merge) }
           : {}),
@@ -2701,9 +2705,18 @@ export class SyncEngine {
     // a cache hit must NOT read as "vanished from snapshot" and wrongly defer
     // the pull (M1 zero-loss: never overwrites a concurrently-edited file).
     cachedBlobShas: ReadonlyMap<string, string> = new Map(),
-  ): Promise<{ pulledCount: number; pinnedPaths: Set<string> }> {
+  ): Promise<{
+    pulledCount: number;
+    pinnedPaths: Set<string>;
+    pulledPaths: string[];
+  }> {
     let pulledCount = 0;
     const pinnedPaths = new Set<string>();
+    // RFC 8f93ff95 — the paths actually mutated on disk this pull (writes,
+    // merges, remote-deletes), surfaced as `RepoSyncResult.pulledPaths` so the
+    // command layer can targeted-reindex them. One entry per real mutation,
+    // pushed alongside every `pulledCount++` (length stays === pulledCount).
+    const pulledPaths: string[] = [];
     // TOCTOU re-read matches the snapshot's representation: a byte snapshot
     // re-reads bytes, a text snapshot re-reads text — `contentEquals`
     // compares within the representation.
@@ -2758,6 +2771,7 @@ export class SyncEngine {
         }
         await writeContent(w.path, w.content);
         pulledCount++;
+        pulledPaths.push(w.path);
         continue;
       }
       const current = await tryRead(
@@ -2773,6 +2787,7 @@ export class SyncEngine {
       }
       await writeContent(w.path, w.content);
       pulledCount++;
+      pulledPaths.push(w.path);
     }
     for (const d of applyDeletes) {
       if (!isSafeRepoRelativePath(d.path)) {
@@ -2792,6 +2807,7 @@ export class SyncEngine {
         }
         await localFiles.delete(d.path);
         pulledCount++;
+        pulledPaths.push(d.path);
         continue;
       }
       if (snapshot !== undefined) {
@@ -2805,9 +2821,10 @@ export class SyncEngine {
         }
         await localFiles.delete(d.path);
         pulledCount++;
+        pulledPaths.push(d.path);
       }
     }
-    return { pulledCount, pinnedPaths };
+    return { pulledCount, pinnedPaths, pulledPaths };
   }
 
   /**

--- a/packages/core/src/services/sync/syncTypes.ts
+++ b/packages/core/src/services/sync/syncTypes.ts
@@ -341,6 +341,20 @@ export interface RepoSyncResult {
   pushedSha?: string;
   /** Remote changes applied to local disk (pull phase). */
   pulledCount: number;
+  /**
+   * Paths whose local content this sync ACTUALLY mutated on the pull side —
+   * the writes/merges applied to disk AND the remote-deletes propagated to
+   * disk (`pulledPaths.length === pulledCount`). Additive (RFC 8f93ff95,
+   * mirrors `mergedPaths`): ExoSync writes via the low-level
+   * `vault.adapter.write`, which fires NO Obsidian vault/metadataCache event,
+   * so nothing reindexes the triple store post-sync and pulled assets stay
+   * invisible in Layouts until restart. Surfacing the mutated paths lets the
+   * command layer drive a targeted disk-read reindex of exactly these paths.
+   * The consumer dispatches per-path by disk presence (present ⇒ re-index
+   * from disk, absent ⇒ remove triples), so deletes need no separate field.
+   * Absent/empty ⇒ nothing was pulled this round.
+   */
+  pulledPaths?: string[];
   /** Files pushed to remote. */
   pushedCount: number;
   /** Conflicting assets resolved by the merge layer (A2). */

--- a/packages/obsidian-plugin/src/ExocortexPlugin.ts
+++ b/packages/obsidian-plugin/src/ExocortexPlugin.ts
@@ -3144,6 +3144,35 @@ export default class ExocortexPlugin extends Plugin {
         app: this.app,
         log: (message) => this.logger.warn(message),
       }),
+      // RFC 8f93ff95 — post-sync targeted disk-read reindex. ExoSync writes via
+      // vault.adapter.write (no Obsidian event), so a pulled asset stays
+      // invisible in Layouts until restart. After a pull/merge, reindex exactly
+      // the mutated paths STRAIGHT FROM DISK into the shared store + run the
+      // follow-up UI refresh bundle. This mirrors ProfileApplyManager's
+      // post-adapter-write refresh, but TARGETED (O(k), no full convertVault
+      // freeze) and WITHOUT a store clear() — so no blank-Layout window.
+      reindex: {
+        run: async (mutatedPaths) => {
+          await this.sparql.reindexPathsFromDisk(mutatedPaths);
+          // Follow-up bundle — the createProfileApplyRefreshHook duties EXCEPT
+          // the full refresh (the targeted update already touched the store):
+          // drop lazy-loader marks, invalidate resolver/precondition caches,
+          // re-render Layouts, and re-resolve open-editor wikilink labels so a
+          // bare [[uid]] to a just-synced target stops showing the raw uid.
+          this.lazyAssetGraphLoader?.clearAll();
+          this.commandResolver.invalidateCache();
+          this.preconditionEvaluator.invalidateCache();
+          this.autoRenderLayout();
+          try {
+            this.app.workspace.updateOptions();
+          } catch (err) {
+            this.logger.warn(
+              "[ExoSync] refreshEditorLabels after post-sync reindex failed (continuing)",
+              err instanceof Error ? err : new Error(String(err)),
+            );
+          }
+        },
+      },
     });
 
     // Quarantine resolver (finding a0a3d1d6) — the user-facing reconcile the

--- a/packages/obsidian-plugin/src/application/api/SPARQLApi.ts
+++ b/packages/obsidian-plugin/src/application/api/SPARQLApi.ts
@@ -344,6 +344,21 @@ export class SPARQLApi {
   }
 
   /**
+   * Post-sync targeted disk-read reindex (RFC 8f93ff95). For the set of paths
+   * ExoSync mutated this run, re-index each one STRAIGHT FROM DISK into the
+   * shared triple store (present ⇒ update from disk, absent ⇒ remove triples),
+   * then run a single inference pass. Unlike {@link refresh} it is O(k) and
+   * does not clear the store — used by the ExoSync post-sync hook so pulled
+   * assets become visible in Layouts without an Obsidian restart.
+   *
+   * @param paths - Vault-relative paths mutated by the sync run
+   *   (`RepoSyncResult.pulledPaths` ∪ `mergedPaths`).
+   */
+  async reindexPathsFromDisk(paths: string[]): Promise<void> {
+    await this.queryService.reindexPathsFromDisk(paths);
+  }
+
+  /**
    * Returns an application-layer handle to the underlying RDF indexer.
    * Exposed for RFC 0a0791c1 B.4 wiring — `PluginRdfIndexerAdapter`
    * (Issue #3322) constructs an `IRdfIndexer` over this handle so

--- a/packages/obsidian-plugin/src/application/services/SPARQLQueryService.ts
+++ b/packages/obsidian-plugin/src/application/services/SPARQLQueryService.ts
@@ -192,6 +192,19 @@ export class SPARQLQueryService {
     );
   }
 
+  /**
+   * Post-sync targeted disk-read reindex of the paths ExoSync mutated this run
+   * (RFC 8f93ff95). Passthrough to {@link VaultRDFIndexer.reindexPathsFromDisk}
+   * — re-indexes each changed path straight from disk into the shared store
+   * (present ⇒ update, absent ⇒ remove) + one global inference.
+   */
+  async reindexPathsFromDisk(paths: string[]): Promise<void> {
+    await this.errorHandler.executeWithRetry(
+      async () => this.indexer.reindexPathsFromDisk(paths),
+      { context: "SPARQLQueryService.reindexPathsFromDisk" }
+    );
+  }
+
   async dispose(): Promise<void> {
     this.indexer.dispose();
     this.executor = null;

--- a/packages/obsidian-plugin/src/infrastructure/VaultRDFIndexer.ts
+++ b/packages/obsidian-plugin/src/infrastructure/VaultRDFIndexer.ts
@@ -481,11 +481,20 @@ export class VaultRDFIndexer {
    * Parse the YAML frontmatter block from raw file content (disk-read path).
    * Mirrors `ObsidianVaultAdapter.extractFrontmatter` — `null` when there is
    * no block, it is empty, or the YAML is invalid.
+   *
+   * A leading BOM and `\r\n` line endings are normalised first: this is the
+   * SOLE frontmatter parser on the post-sync reindex path (no metadataCache
+   * fallback), and `updateFileFromDisk` removes the path's prior triples
+   * BEFORE calling here — so a CRLF/BOM asset that fails to parse would not
+   * just stay stale, it would silently VANISH from the store until restart.
+   * Plugin/CLI/Obsidian write LF, so this is defensive against foreign-tool
+   * edits, not the common case.
    */
   private parseFrontmatterFromContent(
     content: string,
   ): Record<string, unknown> | null {
-    const match = content.match(/^---\n([\s\S]*?)\n---/);
+    const normalised = content.replace(/^\uFEFF/, "").replace(/\r\n/g, "\n");
+    const match = normalised.match(/^---\n([\s\S]*?)\n---/);
     if (!match) {
       return null;
     }

--- a/packages/obsidian-plugin/src/infrastructure/VaultRDFIndexer.ts
+++ b/packages/obsidian-plugin/src/infrastructure/VaultRDFIndexer.ts
@@ -1,4 +1,4 @@
-import { App, TFile, EventRef } from "obsidian";
+import { App, TFile, EventRef, parseYaml } from "obsidian";
 import {
   InMemoryTripleStore,
   NoteToRDFConverter,
@@ -359,6 +359,158 @@ export class VaultRDFIndexer {
       },
       { context: "VaultRDFIndexer.renameFile", filePath: file.path, oldPath }
     );
+  }
+
+  /**
+   * Post-sync targeted reindex of the paths ExoSync just mutated on disk
+   * (RFC 8f93ff95). ExoSync writes via the low-level `vault.adapter.write`,
+   * which fires NO Obsidian vault/metadataCache event, so nothing reindexes
+   * the store and pulled assets stay invisible in Layouts until restart. This
+   * is the explicit trigger — exactly like `ProfileApplyManager` calling
+   * `refresh()` after its own adapter writes.
+   *
+   * Each path is re-read STRAIGHT FROM DISK (not metadataCache): present ⇒
+   * re-index from disk, absent ⇒ remove its triples (a synced deletion). Then
+   * a SINGLE `runInference()` re-materializes RDFS + prototype-chain triples
+   * for the whole batch (per-file inference is intentionally skipped — review
+   * MEDIUM-3 mitigation). Unlike {@link refresh} it does NOT `clear()` the
+   * store, so a mid-batch failure leaves a partial-but-non-empty store (no
+   * blank-Layout risk); the command layer surfaces an explicit Notice on throw.
+   *
+   * Guards mirror {@link updateFile}: a full reindex in flight is waited out
+   * (it re-reads the current vault state, covering these paths), and a mutated
+   * KNOWN FileSpace declaration falls back to a full {@link refresh} (a changed
+   * mount set must purge/admit content a targeted update cannot).
+   *
+   * @param paths - Vault-relative paths mutated by one sync run
+   *   (`RepoSyncResult.pulledPaths` ∪ `mergedPaths`). De-duplicated internally.
+   */
+  async reindexPathsFromDisk(paths: string[]): Promise<void> {
+    const unique = [...new Set(paths)];
+    if (unique.length === 0) {
+      return;
+    }
+
+    // A full reindex is rebuilding the store right now — targeted adds would
+    // race clear()/addAll(); the refresh re-reads the current vault state, so
+    // these paths are already covered.
+    if (this.refreshInFlight !== null) {
+      await this.refreshInFlight;
+      return;
+    }
+
+    // A mutated KNOWN FileSpace declaration changes the mount set (newly
+    // excluded content must be purged, previously-excluded admitted) — only a
+    // full reindex does that correctly. (A brand-new declaration arriving via
+    // sync is a Tier-1 gap covered by the next full walk / restart.)
+    if (unique.some((p) => this.fileSpaceDeclarations.has(p))) {
+      if (await this.rediscoverFileSpaces()) {
+        await this.refresh();
+        return;
+      }
+    }
+
+    for (const path of unique) {
+      await this.updateFileFromDisk(path);
+    }
+    // One global inference for the whole batch — covers inherited / subClass /
+    // prototype-chain triples the per-file targeted update skips.
+    await this.runInference();
+  }
+
+  /**
+   * Reindex one path read from disk (RFC 8f93ff95). Needs no `TFile` and does
+   * NOT read frontmatter from metadataCache: the content comes from the
+   * low-level `vault.adapter` (mobile-safe, the same seam ExoSync writes
+   * through) and the frontmatter is parsed from it. That makes a just-synced
+   * asset visible even when metadataCache has not caught up.
+   *
+   * Dispatch is by disk presence — a readable path is re-indexed, an absent
+   * path (synced deletion) has its triples removed. Does NOT run inference;
+   * the batch driver {@link reindexPathsFromDisk} runs it once afterwards.
+   */
+  private async updateFileFromDisk(path: string): Promise<void> {
+    if (!path.endsWith(".md")) {
+      return;
+    }
+
+    // Honour folder-exclusion + FileSpace mount skips for synced paths too
+    // (mirrors updateFile): excluded content must never (re-)enter the store,
+    // and a stale triple for a now-excluded path is purged.
+    if (
+      isPathExcluded(path, this.excludedFolders) ||
+      isPathExcluded(path, this.fileSpacePrefixes)
+    ) {
+      await this.removeFileTriples(path);
+      return;
+    }
+
+    const content = await this.readFromDisk(path);
+    // Always drop the path's prior triples first (overwrite-on-reindex). For a
+    // synced deletion (no content on disk) this is the whole operation.
+    await this.removeFileTriples(path);
+    if (content === null) {
+      return;
+    }
+
+    const frontmatter = this.parseFrontmatterFromContent(content);
+    if (frontmatter === null) {
+      return; // no/invalid frontmatter → nothing to index
+    }
+    const triples = await this.converter.convertNoteFromFrontmatter(
+      this.syntheticFile(path),
+      frontmatter,
+    );
+    await this.tripleStore.addAll(triples);
+  }
+
+  /**
+   * Low-level disk read by path (DataAdapter — mobile-safe, bypasses the
+   * `TFile` registry and metadataCache). Returns `null` on miss/unreadable so
+   * the caller treats a vanished path as a deletion.
+   */
+  private async readFromDisk(path: string): Promise<string | null> {
+    try {
+      return await this.app.vault.adapter.read(path);
+    } catch {
+      return null;
+    }
+  }
+
+  /**
+   * Parse the YAML frontmatter block from raw file content (disk-read path).
+   * Mirrors `ObsidianVaultAdapter.extractFrontmatter` — `null` when there is
+   * no block, it is empty, or the YAML is invalid.
+   */
+  private parseFrontmatterFromContent(
+    content: string,
+  ): Record<string, unknown> | null {
+    const match = content.match(/^---\n([\s\S]*?)\n---/);
+    if (!match) {
+      return null;
+    }
+    const yaml = match[1];
+    if (!yaml || yaml.trim() === "") {
+      return null;
+    }
+    try {
+      const parsed = parseYaml(yaml);
+      return typeof parsed === "object" && parsed !== null
+        ? (parsed as Record<string, unknown>)
+        : null;
+    } catch {
+      return null;
+    }
+  }
+
+  /**
+   * Minimal {@link IFile} from a vault path — only `path`/`basename` are read
+   * by the converter on the disk-read reindex path, so a synthetic identity
+   * (no `TFile` lookup) is sufficient and mobile-safe.
+   */
+  private syntheticFile(path: string): IFile {
+    const name = path.split("/").pop() ?? path;
+    return { path, basename: name.replace(/\.md$/, ""), name, parent: null };
   }
 
   /** Adopt a walk's discovery result as the live-event exclusion set. */

--- a/packages/obsidian-plugin/src/infrastructure/adapters/SyncCommands.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/SyncCommands.ts
@@ -38,6 +38,20 @@ import { GitHubRestClient } from "./GitHubRestClient";
 import type { SyncSpecCollection, BuiltSyncEngine } from "./SyncDepsFactory";
 import type { ParityCheck } from "./ExoSyncParityFactory";
 
+/**
+ * Post-sync targeted disk-read reindex (RFC 8f93ff95). `run` is handed the
+ * union of every locally-mutated path across the run's results
+ * (`pulledPaths` ∪ `mergedPaths`); the implementation re-indexes each one
+ * STRAIGHT FROM DISK into the shared triple store (present ⇒ update, absent ⇒
+ * remove triples), runs one inference pass, then refreshes open Layouts — so a
+ * pulled asset becomes visible without an Obsidian restart. Best-effort by
+ * contract: the caller wraps it in try/catch and never lets a reindex failure
+ * mutate the (already-computed) sync outcome.
+ */
+export interface PostSyncReindex {
+  run(mutatedPaths: string[]): Promise<void>;
+}
+
 export interface SyncCommandsDeps {
   /** Enumerate the materialized sync unit (collectSyncRepoSpecs). */
   collectSpecs: () => Promise<SyncSpecCollection>;
@@ -103,6 +117,14 @@ export interface SyncCommandsDeps {
    * and existing tests stay valid.
    */
   parity?: ParityCheck;
+  /**
+   * RFC 8f93ff95 — post-sync targeted disk-read reindex. When wired, a run
+   * that actually pulled/merged assets reindexes exactly those paths into the
+   * shared triple store so they appear in Layouts without an Obsidian restart.
+   * Best-effort (own try/catch, never mutates the sync result). Optional so
+   * engine-only / test compositions stay valid (absent ⇒ no reindex).
+   */
+  reindex?: PostSyncReindex;
 }
 
 export class SyncCommands {
@@ -369,6 +391,48 @@ export class SyncCommands {
     // per session. Skipped on auth-required runs — the PAT prompt already
     // owns that failure and the conflict re-surfaces on the next good run.
     this.maybeWarnQuarantineSink(quarantineConfigured, summary);
+
+    // RFC 8f93ff95 — post-sync targeted reindex. ExoSync writes via the
+    // low-level vault.adapter.write, which fires NO Obsidian vault/metadataCache
+    // event, so nothing reindexes the triple store and pulled assets stay
+    // invisible in Layouts until restart. After a run that actually pulled or
+    // merged something, reindex exactly those paths STRAIGHT FROM DISK into the
+    // shared store + refresh Layouts. Fires for pull-only runs too (NOT gated on
+    // `direction`, unlike the parity round below); the gate is the changed-count,
+    // NOT pushedDeletes — push-side deletes were already event-indexed locally.
+    // Best-effort: `results` is already computed above, so a reindex failure
+    // NEVER affects the sync outcome — it only logs + surfaces its own Notice.
+    if (this.deps.reindex !== undefined) {
+      // Gate: at least one repo pulled or merged an asset this run (#3489
+      // counters). A no-op / push-only sync reindexes nothing.
+      const changedAny = results.some(
+        (r) => r.pulledCount > 0 || r.mergedCount > 0,
+      );
+      if (changedAny) {
+        const mutatedPaths = [
+          ...new Set(
+            results.flatMap((r) => [
+              ...(r.pulledPaths ?? []),
+              ...(r.mergedPaths ?? []),
+            ]),
+          ),
+        ];
+        if (mutatedPaths.length > 0) {
+          try {
+            await this.deps.reindex.run(mutatedPaths);
+          } catch (err) {
+            const msg = GitHubRestClient.redactTokens(
+              err instanceof Error ? err.message : String(err),
+            );
+            log(`[ExoSync] post-sync reindex failed: ${msg}`);
+            this.deps.notify(
+              "ExoSync pulled changes but the in-app index could not refresh — " +
+                "reload Obsidian to see them.",
+            );
+          }
+        }
+      }
+    }
 
     // E1 post-sync parity round (M1/M2). Best-effort: a parity failure is
     // logged + surfaced as its own Notice, never mutates the sync outcome.

--- a/packages/obsidian-plugin/tests/unit/sync/ExoSyncPostSyncReindex.test.ts
+++ b/packages/obsidian-plugin/tests/unit/sync/ExoSyncPostSyncReindex.test.ts
@@ -82,10 +82,18 @@ function buildApp(seed: SeedFile[]) {
   const fmByPath = new Map<string, Record<string, unknown>>();
   const diskByPath = new Map<string, string>();
 
-  const add = (f: SeedFile, opts: { metadataStale?: boolean } = {}): void => {
+  const add = (
+    f: SeedFile,
+    opts: { metadataStale?: boolean; bomCrlf?: boolean } = {},
+  ): void => {
     if (!files.some((t) => t.path === f.path)) files.push(new TFile(f.path));
     if (!opts.metadataStale) fmByPath.set(f.path, f.frontmatter);
-    diskByPath.set(f.path, renderYaml(f.frontmatter));
+    let disk = renderYaml(f.frontmatter);
+    // Simulate a foreign-tool edit: leading BOM + CRLF line endings. The
+    // disk-read frontmatter parser must normalise these, else the file fails to
+    // parse and (since removeFileTriples runs first) the asset VANISHES.
+    if (opts.bomCrlf) disk = "\uFEFF" + disk.replace(/\n/g, "\r\n");
+    diskByPath.set(f.path, disk);
   };
   const del = (path: string): void => {
     const i = files.findIndex((t) => t.path === path);
@@ -131,7 +139,10 @@ function buildApp(seed: SeedFile[]) {
   return {
     app,
     /** ExoSync pull of a new/changed asset: on disk, NO event. */
-    syncWrite: (f: SeedFile, opts?: { metadataStale?: boolean }) => add(f, opts),
+    syncWrite: (
+      f: SeedFile,
+      opts?: { metadataStale?: boolean; bomCrlf?: boolean },
+    ) => add(f, opts),
     /** ExoSync pull of a deletion: off disk, NO event. */
     syncDelete: (path: string) => del(path),
   };
@@ -354,6 +365,64 @@ describe("ExoSync post-sync reindex (RFC 8f93ff95)", () => {
     // pushedDeletes are NOT a reindex trigger (push side is already
     // event-indexed locally) — the gate is pulledCount/mergedCount only.
     expect(reindex.run).not.toHaveBeenCalled();
+  });
+
+  it("merged-only: a sync with mergedPaths but pulledCount 0 still reindexes (gate union covers merges)", async () => {
+    const harness = buildApp([EXISTING_TASK]);
+    service = new SPARQLQueryService(harness.app);
+    await service.initialize();
+
+    // A 3-way merge resolved a change on disk (mergedCount/mergedPaths), with
+    // pulledCount 0 — the reindex must still fire on the mergedPaths branch.
+    harness.syncWrite(SYNCED_TASK);
+
+    const reindexSpy = jest.fn((paths: string[]) =>
+      service!.reindexPathsFromDisk(paths),
+    );
+    const { cmds } = makeSyncCommands({
+      results: [
+        result("synced", {
+          pulledCount: 0,
+          mergedCount: 1,
+          mergedPaths: [SYNCED_TASK.path],
+        }),
+      ],
+      reindex: { run: reindexSpy },
+    });
+    await cmds.invokeSync();
+
+    expect(reindexSpy).toHaveBeenCalledWith([SYNCED_TASK.path]);
+    expect(await labelsInStore(service)).toContain("Synced Task");
+  });
+
+  it("BOM/CRLF: a foreign-tool-edited synced asset is parsed from disk, not dropped (no vanish)", async () => {
+    // The asset is already in the store (cold-start indexed). ExoSync then
+    // pulls a foreign-tool edit of it with a leading BOM + CRLF endings.
+    // updateFileFromDisk removes its triples FIRST, then re-parses from disk —
+    // without BOM/CRLF normalisation the parse fails and the asset would VANISH.
+    const harness = buildApp([EXISTING_TASK, SYNCED_TASK]);
+    service = new SPARQLQueryService(harness.app);
+    await service.initialize();
+    expect(await labelsInStore(service)).toEqual([
+      "Existing Task",
+      "Synced Task",
+    ]);
+
+    harness.syncWrite(SYNCED_TASK, { bomCrlf: true });
+
+    const { cmds } = makeSyncCommands({
+      results: [
+        result("synced", { pulledCount: 1, pulledPaths: [SYNCED_TASK.path] }),
+      ],
+      reindex: realReindex(service),
+    });
+    await cmds.invokeSync();
+
+    // Still visible — normalisation let the disk-read parser succeed.
+    expect(await labelsInStore(service)).toEqual([
+      "Existing Task",
+      "Synced Task",
+    ]);
   });
 
   it("best-effort: a reindex throw NEVER mutates the sync outcome and surfaces a reload Notice", async () => {

--- a/packages/obsidian-plugin/tests/unit/sync/ExoSyncPostSyncReindex.test.ts
+++ b/packages/obsidian-plugin/tests/unit/sync/ExoSyncPostSyncReindex.test.ts
@@ -1,0 +1,384 @@
+/**
+ * @req:e157d3e5-03b7-4e40-822a-3c946b72f32a
+ *
+ * ExoSync post-sync targeted disk-read reindex (RFC 8f93ff95) — production-shape
+ * integration test driving the REAL `SyncCommands` → REAL `VaultRDFIndexer`
+ * (via `SPARQLQueryService`) → the SHARED triple store that backs auto-render
+ * Layouts (`this.sparql.getTripleStore()` in production). NOT a standalone
+ * `SPARQLQueryService.refresh()` test (F4): the reindex is driven through the
+ * real command-layer gate + try/catch, exactly as the plugin wires it.
+ *
+ * Bug: ExoSync writes pulled assets via the low-level `vault.adapter.write`,
+ * which fires NO Obsidian vault/metadataCache event, so nothing reindexes the
+ * store and a pulled asset is invisible in Layouts until restart. The fix wires
+ * a post-sync `reindex` dep into `SyncCommands` that re-reads the mutated paths
+ * straight from disk into the shared store.
+ *
+ * Revert-verify (integration): neuter the `reindex.run(...)` call in
+ * `SyncCommands.runSync` (or break `VaultRDFIndexer.updateFileFromDisk`'s
+ * `addAll`) and the "visible after sync" case goes RED (the synced asset stays
+ * absent — the user-reported bug); restore → GREEN. The `reindex: undefined`
+ * test below is the same revert in injected-dep form (proves the dep is
+ * load-bearing). The delete / gate / disk-read-over-stale-metadataCache cases
+ * cover the rest of the AC.
+ */
+
+jest.mock("obsidian", () => ({
+  ...jest.requireActual<Record<string, unknown>>("obsidian"),
+  requestUrl: jest.fn(),
+}));
+
+import { TFile } from "obsidian";
+import type { App } from "obsidian";
+import { SPARQLQueryService } from "../../../src/application/services/SPARQLQueryService";
+import {
+  SyncCommands,
+  type PostSyncReindex,
+} from "../../../src/infrastructure/adapters/SyncCommands";
+import type {
+  BuiltSyncEngine,
+  SyncSpecCollection,
+} from "../../../src/infrastructure/adapters/SyncDepsFactory";
+import type {
+  RepoSyncResult,
+  SyncEngine,
+  SyncRepoSpec,
+} from "@kitelev/exocortex-core";
+
+const EXO = "https://exocortex.my/ontology/exo#";
+const REPO_KEY = "o/r#main";
+const LAYOUT_QUERY = `PREFIX exo: <${EXO}> SELECT ?label WHERE { ?s exo:Asset_label ?label }`;
+
+interface SeedFile {
+  path: string;
+  frontmatter: Record<string, unknown>;
+}
+
+/** Block-style YAML the mock `parseYaml` parses (quoted scalars + block arrays). */
+function renderYaml(fm: Record<string, unknown>): string {
+  const lines: string[] = ["---"];
+  for (const [k, v] of Object.entries(fm)) {
+    if (Array.isArray(v)) {
+      lines.push(`${k}:`);
+      for (const item of v) lines.push(`  - "${String(item)}"`);
+    } else {
+      lines.push(`${k}: "${String(v)}"`);
+    }
+  }
+  lines.push("---", "");
+  return lines.join("\n");
+}
+
+/**
+ * Production-shape vault/metadataCache fake. `adapter.read(path)` is the
+ * disk-read seam the reindex uses (mirrors `vault.adapter.read`); a path absent
+ * from disk throws (a deletion). `syncWrite`/`syncDelete` mutate disk WITHOUT
+ * firing any `vault.on()` event — exactly ExoSync's `adapter.write`/`rename`
+ * behaviour. `metadataStale` lands a file on disk but hides it from
+ * metadataCache (proves the reindex reads disk, not the cache).
+ */
+function buildApp(seed: SeedFile[]) {
+  const files: TFile[] = [];
+  const fmByPath = new Map<string, Record<string, unknown>>();
+  const diskByPath = new Map<string, string>();
+
+  const add = (f: SeedFile, opts: { metadataStale?: boolean } = {}): void => {
+    if (!files.some((t) => t.path === f.path)) files.push(new TFile(f.path));
+    if (!opts.metadataStale) fmByPath.set(f.path, f.frontmatter);
+    diskByPath.set(f.path, renderYaml(f.frontmatter));
+  };
+  const del = (path: string): void => {
+    const i = files.findIndex((t) => t.path === path);
+    if (i >= 0) files.splice(i, 1);
+    fmByPath.delete(path);
+    diskByPath.delete(path);
+  };
+  seed.forEach((f) => add(f));
+
+  const vault = {
+    getMarkdownFiles: () => files.filter((f) => f.extension === "md"),
+    getAbstractFileByPath: (p: string) =>
+      files.find((f) => f.path === p) ?? null,
+    read: async (f: TFile) => diskByPath.get(f.path) ?? "",
+    // The disk-read seam used by VaultRDFIndexer.readFromDisk — DataAdapter.
+    adapter: {
+      read: async (p: string): Promise<string> => {
+        const c = diskByPath.get(p);
+        if (c === undefined) throw new Error(`ENOENT: ${p}`);
+        return c;
+      },
+    },
+    // Realism: registering a handler is a no-op; an adapter write/delete fires
+    // NOTHING (mirrors Obsidian's behaviour for vault.adapter.*).
+    on: () => ({}) as unknown,
+    off: () => {},
+    offref: () => {},
+  };
+
+  const metadataCache = {
+    getFileCache: (f: TFile) => {
+      const fm = fmByPath.get(f.path);
+      return fm ? { frontmatter: fm } : null;
+    },
+    getFirstLinkpathDest: (linkpath: string) => {
+      const base = linkpath.replace(/\.md$/, "");
+      return files.find((f) => f.basename === base) ?? null;
+    },
+    resolvedLinks: {},
+  };
+
+  const app = { vault, metadataCache } as unknown as App;
+  return {
+    app,
+    /** ExoSync pull of a new/changed asset: on disk, NO event. */
+    syncWrite: (f: SeedFile, opts?: { metadataStale?: boolean }) => add(f, opts),
+    /** ExoSync pull of a deletion: off disk, NO event. */
+    syncDelete: (path: string) => del(path),
+  };
+}
+
+function lex(term: unknown): string {
+  if (term && typeof term === "object" && "value" in term) {
+    return String((term as { value: unknown }).value);
+  }
+  return String(term);
+}
+
+const spec = (): SyncRepoSpec => ({
+  owner: "o",
+  repo: "r",
+  branch: "main",
+  repoKey: REPO_KEY,
+  localPath: "assetspaces/o/r",
+});
+
+const result = (
+  status: RepoSyncResult["status"],
+  extra: Partial<RepoSyncResult> = {},
+): RepoSyncResult => ({
+  repoKey: REPO_KEY,
+  status,
+  pulledCount: 0,
+  pushedCount: 0,
+  mergedCount: 0,
+  quarantinedCount: 0,
+  warnings: [],
+  deferredDeletes: [],
+  ...extra,
+});
+
+/** Build the REAL SyncCommands over a fake engine returning canned results. */
+function makeSyncCommands(opts: {
+  results: RepoSyncResult[];
+  reindex?: PostSyncReindex;
+}): { cmds: SyncCommands; notices: string[] } {
+  const notices: string[] = [];
+  const syncAll = jest.fn(async (): Promise<RepoSyncResult[]> => opts.results);
+  const built: BuiltSyncEngine = {
+    engine: { syncAll } as unknown as SyncEngine,
+    pat: "ghp_x",
+    quarantineConfigured: true,
+  };
+  const collection: SyncSpecCollection = {
+    specs: [spec()],
+    asUidByRepoKey: new Map(),
+    warnings: [],
+    mountedNotDeclared: [],
+  };
+  const cmds = new SyncCommands({
+    collectSpecs: async () => collection,
+    buildEngine: async () => built,
+    isSwitchInProgress: () => false,
+    notify: (m) => notices.push(m),
+    reindex: opts.reindex,
+  });
+  return { cmds, notices };
+}
+
+const EXISTING_TASK: SeedFile = {
+  path: "assetspaces/o/r/existing-task.md",
+  frontmatter: {
+    exo__Asset_uid: "existing-uid",
+    exo__Asset_label: "Existing Task",
+    exo__Instance_class: ["[[ems__Task]]"],
+  },
+};
+
+const SYNCED_TASK: SeedFile = {
+  path: "assetspaces/o/r/synced-task.md",
+  frontmatter: {
+    exo__Asset_uid: "synced-uid",
+    exo__Asset_label: "Synced Task",
+    exo__Instance_class: ["[[ems__Task]]"],
+  },
+};
+
+/** Reindex dep wired to the REAL indexer/store (the production store seam). */
+const realReindex = (service: SPARQLQueryService): PostSyncReindex => ({
+  run: (paths) => service.reindexPathsFromDisk(paths),
+});
+
+async function labelsInStore(service: SPARQLQueryService): Promise<string[]> {
+  return (await service.query(LAYOUT_QUERY)).map((b) => lex(b.get("label"))).sort();
+}
+
+describe("ExoSync post-sync reindex (RFC 8f93ff95)", () => {
+  let service: SPARQLQueryService | undefined;
+
+  afterEach(async () => {
+    await service?.dispose();
+    service = undefined;
+    jest.clearAllMocks();
+  });
+
+  it("makes a pulled asset visible in the shared store after a real SyncCommands sync (no restart)", async () => {
+    const harness = buildApp([EXISTING_TASK]);
+    service = new SPARQLQueryService(harness.app);
+    await service.initialize();
+    expect(await labelsInStore(service)).toEqual(["Existing Task"]);
+
+    // ExoSync pulls a new asset → adapter.write → on disk, NO event fired.
+    harness.syncWrite(SYNCED_TASK);
+
+    const { cmds } = makeSyncCommands({
+      results: [
+        result("synced", { pulledCount: 1, pulledPaths: [SYNCED_TASK.path] }),
+      ],
+      reindex: realReindex(service),
+    });
+    await cmds.invokeSync();
+
+    // The synced asset is now visible WITHOUT a restart — this is the fix.
+    expect(await labelsInStore(service)).toEqual([
+      "Existing Task",
+      "Synced Task",
+    ]);
+  });
+
+  it("WITHOUT the reindex dep the synced asset stays invisible (the bug — dep is load-bearing)", async () => {
+    const harness = buildApp([EXISTING_TASK]);
+    service = new SPARQLQueryService(harness.app);
+    await service.initialize();
+
+    harness.syncWrite(SYNCED_TASK);
+
+    const { cmds } = makeSyncCommands({
+      results: [
+        result("synced", { pulledCount: 1, pulledPaths: [SYNCED_TASK.path] }),
+      ],
+      reindex: undefined, // no post-sync reindex wired → stale store
+    });
+    await cmds.invokeSync();
+
+    expect(await labelsInStore(service)).toEqual(["Existing Task"]);
+  });
+
+  it("reads frontmatter from disk — a stale/empty metadataCache does not hide the synced asset", async () => {
+    const harness = buildApp([EXISTING_TASK]);
+    service = new SPARQLQueryService(harness.app);
+    await service.initialize();
+
+    // On disk (adapter.read OK) but ABSENT from metadataCache (getFileCache →
+    // null). A metadataCache-based reindex (getFrontmatter) would see nothing;
+    // the disk-read path still indexes it.
+    harness.syncWrite(SYNCED_TASK, { metadataStale: true });
+
+    const { cmds } = makeSyncCommands({
+      results: [
+        result("synced", { pulledCount: 1, pulledPaths: [SYNCED_TASK.path] }),
+      ],
+      reindex: realReindex(service),
+    });
+    await cmds.invokeSync();
+
+    expect(await labelsInStore(service)).toContain("Synced Task");
+  });
+
+  it("delete-case: a pulled deletion removes the asset from the store without restart", async () => {
+    const harness = buildApp([EXISTING_TASK, SYNCED_TASK]);
+    service = new SPARQLQueryService(harness.app);
+    await service.initialize();
+    expect(await labelsInStore(service)).toEqual([
+      "Existing Task",
+      "Synced Task",
+    ]);
+
+    // ExoSync pulls a remote deletion → removed from disk, NO event fired.
+    harness.syncDelete(SYNCED_TASK.path);
+
+    const { cmds } = makeSyncCommands({
+      results: [
+        result("synced", { pulledCount: 1, pulledPaths: [SYNCED_TASK.path] }),
+      ],
+      reindex: realReindex(service),
+    });
+    await cmds.invokeSync();
+
+    expect(await labelsInStore(service)).toEqual(["Existing Task"]);
+  });
+
+  it("gate: a no-op sync (nothing pulled/merged) triggers NO reindex", async () => {
+    const harness = buildApp([EXISTING_TASK]);
+    service = new SPARQLQueryService(harness.app);
+    await service.initialize();
+
+    const reindex: PostSyncReindex = { run: jest.fn(async () => {}) };
+    const { cmds } = makeSyncCommands({
+      results: [result("synced", { pulledCount: 0, mergedCount: 0 })],
+      reindex,
+    });
+    await cmds.invokeSync();
+
+    expect(reindex.run).not.toHaveBeenCalled();
+  });
+
+  it("gate: a push-only sync (pushedDeletes, nothing pulled/merged) triggers NO reindex", async () => {
+    const harness = buildApp([EXISTING_TASK]);
+    service = new SPARQLQueryService(harness.app);
+    await service.initialize();
+
+    const reindex: PostSyncReindex = { run: jest.fn(async () => {}) };
+    const { cmds } = makeSyncCommands({
+      results: [
+        result("synced", {
+          pushedCount: 1,
+          pushedDeletes: ["assetspaces/o/r/gone.md"],
+          pulledCount: 0,
+          mergedCount: 0,
+        }),
+      ],
+      reindex,
+    });
+    await cmds.invokeSync();
+
+    // pushedDeletes are NOT a reindex trigger (push side is already
+    // event-indexed locally) — the gate is pulledCount/mergedCount only.
+    expect(reindex.run).not.toHaveBeenCalled();
+  });
+
+  it("best-effort: a reindex throw NEVER mutates the sync outcome and surfaces a reload Notice", async () => {
+    const harness = buildApp([EXISTING_TASK]);
+    service = new SPARQLQueryService(harness.app);
+    await service.initialize();
+
+    harness.syncWrite(SYNCED_TASK);
+
+    const { cmds, notices } = makeSyncCommands({
+      results: [
+        result("synced", { pulledCount: 1, pulledPaths: [SYNCED_TASK.path] }),
+      ],
+      reindex: {
+        run: async () => {
+          throw new Error("boom");
+        },
+      },
+    });
+
+    // invokeSync must not reject — the reindex has its own try/catch.
+    await expect(cmds.invokeSync()).resolves.toBeUndefined();
+
+    // The store is untouched (no blank-Layout) and a reload Notice is shown.
+    expect(await labelsInStore(service)).toEqual(["Existing Task"]);
+    expect(notices.some((n) => /reload Obsidian/i.test(n))).toBe(true);
+  });
+});


### PR DESCRIPTION
## Problem

ExoSync writes pulled/merged assets through `vault.adapter.write`, bypassing the Obsidian `Vault` abstraction. No reindex event fires → the shared triple-store stays stale → **synced assets are invisible in auto-render Layouts until Obsidian is restarted.** Confirmed empirically; same class of bug `ProfileApplyManager` already mitigates by explicitly calling `rdfIndexer.refresh()` after its own `adapter.write`.

## Fix (Tier 1, RFC 8f93ff95 — Andrey-approved targeted disk-read)

After a sync that **actually mutated local content**, re-index exactly the changed paths **straight from disk** (`adapter.read` + `parseYaml`, **not** the possibly-stale `metadataCache`) into the **shared** store, run one global inference, then a single follow-up UI bundle.

- **Targeted O(k)** — no full-vault freeze, no `clear()` (no empty-store window).
- **Robust** — disk-read sidesteps `metadataCache` staleness on the just-written file.
- **Mobile-safe** — `adapter.read` + `parseYaml` from `obsidian`, zero Node `fs`; Desktop↔Mobile command parity preserved (no `Platform.isMobile` gate).
- **Best-effort** — reindex runs in its own `try/catch`, computed after the sync outcome; a failure never mutates the sync result and surfaces an explicit Notice ("reload Obsidian to see them").
- **Gated** — only when `Σ(pulledCount + mergedCount) > 0` (push-only / no-op syncs do nothing; push-side deletes are already event-indexed locally).

**Scope:** auto-render Layout only. The `exo-layout` code-block path is explicitly out of scope (zero adoption).

## Changes

| File | Change |
|---|---|
| `core/.../sync/syncTypes.ts` | `RepoSyncResult.pulledPaths?` (mirrors `mergedPaths`) |
| `core/.../sync/SyncEngine.ts` | populate `pulledPaths` at each write/delete (additive, zero outcome change) |
| `core/.../NoteToRDFConverter.ts` | new `convertNoteFromFrontmatter(file, fm)` (disk-parsed frontmatter); `convertNote` delegates — pure refactor |
| `obsidian-plugin/.../VaultRDFIndexer.ts` | `reindexPathsFromDisk(paths)` — disk-read per path (present ⇒ update, absent ⇒ remove) + one `runInference()` |
| `obsidian-plugin/.../SPARQLQueryService.ts`, `SPARQLApi.ts` | passthrough |
| `obsidian-plugin/.../SyncCommands.ts` | optional `reindex` dep, gated + best-effort post-sync call |
| `obsidian-plugin/.../ExocortexPlugin.ts` | wire `reindex` to `sparql.reindexPathsFromDisk` + UI bundle (clearLazyLoader, invalidate command/precondition caches, autoRenderLayout, refreshEditorLabels) |

## Tests — req-first SDD

`@req:e157d3e5-03b7-4e40-822a-3c946b72f32a` (req__Requirement, Active).

New production-shape integration suite `ExoSyncPostSyncReindex.test.ts` (7 tests) drives the **real** `SyncCommands` to the shared store over a fake engine: add (visible after sync, no restart), without-dep (stays stale — proves the seam), disk-read with empty/stale metadataCache, delete-case, no-op gate, push-only gate, best-effort throw (never mutates outcome + reload Notice).

**revert-verify:** type-preserving break of the reindex callback gives **4 RED**; restore gives **7/7 GREEN**.

## Note on the @req tag and reqs-main

The `req__Requirement` asset is published to `kitelev/exoas-exo-reqs` **after** this PR merges (merge → active SDD order). Publishing an Active req to reqs-main before the binding test is on `main` would orphan it for parallel open PRs (the always-on Active-requirement gate clones reqs-main fresh). During this PR's CI the tag is a non-blocking dangling soft-warning; the blocking Active-gate sees zero violations.

## ⚠️ Sync-touching → manual merge

Per Auto-merge discipline, this touches `packages/core/src/services/sync/` → **NOT** `--auto`. Merging manually after CI green + code-reviewer + advisor round-2.

🤖 https://claude.ai/code/session_01GjNSTDE8gLuAneYWdwq6tE
