### PR TITLE
feat(precondition): prototype-class assets hide instance-lifecycle commands (req 5579ffa1)

### DIFF
--- a/packages/core/tests/integration/dynamic-commands/PrototypePreconditionForgetGuard.test.ts
+++ b/packages/core/tests/integration/dynamic-commands/PrototypePreconditionForgetGuard.test.ts
@@ -1,0 +1,197 @@
+/**
+ * Forget-leak guard (req @req:5579ffa1-a829-4fcf-b93d-4fb664b02d62).
+ *
+ * Walks the REAL `packages/exoas-exocmd` submodule, classifies every
+ * `exocmd__Command` by the targetClass of its `exocmd__CommandBinding`s, and
+ * asserts that EVERY instance-lifecycle command (bindings target
+ * ems__Task/Project/Area/Meeting/Session — NOT exo__Asset, NOT a prototype
+ * class, NOT a class metaclass) carries a command-level
+ * `exocmd__Command_precondition` whose precondition asset's
+ * `exocmd__Precondition_sparqlAsk` contains the canonical not-a-prototype clause
+ * (`FILTER NOT EXISTS { … exo:Instance_class … STRENDS(…, "Prototype") … }`).
+ *
+ * If a future lifecycle command (or a binding retargeted onto a lifecycle class)
+ * ships without the clause, this fails — the silent-leak the precondition-primary
+ * design is otherwise vulnerable to (design node f853eadd, §forget-leak guard).
+ *
+ * Conversely, asserts universal-maintenance commands (targetClass exo__Asset) do
+ * NOT carry the clause (they must keep working on prototype-template assets).
+ *
+ * @req:5579ffa1-a829-4fcf-b93d-4fb664b02d62
+ */
+import * as fs from "fs";
+import * as path from "path";
+
+const SUBMODULE_EXOCMD = path.resolve(__dirname, "../../../../exoas-exocmd/exocmd");
+
+const COMMAND_BINDING_CLASS_UID = "3677039a-a5a8-4402-9a07-f8f18fe384ad";
+const STANDALONE_PRECONDITION_UID = "847c37e0-9812-4dc7-9a92-923dac7cda56";
+
+// Lifecycle target classes (label form) — bindings on these make a command an
+// instance-lifecycle command that MUST carry the not-a-prototype clause.
+const LIFECYCLE_TARGET_CLASSES = new Set([
+  "ems__Task",
+  "ems__Project",
+  "ems__Area",
+  "ems__Effort",
+  "ems__Meeting",
+  "ems__Session",
+]);
+const UNIVERSAL_TARGET_CLASSES = new Set(["exo__Asset"]);
+
+// STRENDS not-a-prototype clause (suffix check on the symbolic instance_class IRI).
+const NOT_A_PROTOTYPE_CLAUSE_RE =
+  /FILTER\s+NOT\s+EXISTS\s*\{[^}]*Instance_class[^}]*STRENDS\s*\(\s*STR\s*\(\s*\?\w+\s*\)\s*,\s*["']Prototype["']\s*\)[^}]*\}/i;
+
+interface Asset {
+  uid: string;
+  label: string;
+  file: string;
+  fm: Record<string, string | string[]>;
+  raw: string;
+}
+
+function parseFrontmatter(content: string): Record<string, string | string[]> {
+  const m = content.match(/^---\n([\s\S]*?)\n---/);
+  if (!m) return {};
+  const fm: Record<string, string | string[]> = {};
+  let key: string | null = null;
+  let list: string[] | null = null;
+  for (const line of m[1].split("\n")) {
+    const li = line.match(/^\s*-\s*(.+)$/);
+    if (li && list) {
+      list.push(li[1].trim().replace(/^"|"$/g, ""));
+      continue;
+    }
+    const kv = line.match(/^([a-zA-Z_][\w]*?):\s*(.*)$/);
+    if (kv) {
+      key = kv[1];
+      const v = kv[2].trim();
+      if (v === "") {
+        list = [];
+        fm[key] = list;
+      } else {
+        fm[key] = v.replace(/^"|"$/g, "");
+        list = null;
+      }
+    }
+  }
+  return fm;
+}
+
+function wikilinkUid(v: string | undefined): string | null {
+  if (!v) return null;
+  const m = v.match(/\[\[([0-9a-f-]{36})/i);
+  return m ? m[1].toLowerCase() : null;
+}
+
+function loadAssets(): Asset[] {
+  if (!fs.existsSync(SUBMODULE_EXOCMD)) {
+    throw new Error(
+      `exoas-exocmd submodule not found at ${SUBMODULE_EXOCMD}. Run \`git submodule update --init packages/exoas-exocmd\``,
+    );
+  }
+  const out: Asset[] = [];
+  const walk = (dir: string): void => {
+    for (const e of fs.readdirSync(dir, { withFileTypes: true })) {
+      if (e.name.startsWith(".")) continue;
+      const full = path.join(dir, e.name);
+      if (e.isDirectory()) {
+        walk(full);
+        continue;
+      }
+      if (!e.isFile() || !e.name.endsWith(".md")) continue;
+      const raw = fs.readFileSync(full, "utf8");
+      const fm = parseFrontmatter(raw);
+      out.push({
+        uid: (fm["exo__Asset_uid"] as string) ?? "",
+        label: (fm["exo__Asset_label"] as string) ?? "",
+        file: full,
+        fm,
+        raw,
+      });
+    }
+  };
+  walk(SUBMODULE_EXOCMD);
+  return out;
+}
+
+function instanceClassUids(fm: Record<string, string | string[]>): string[] {
+  const ic = fm["exo__Instance_class"];
+  const refs = Array.isArray(ic) ? ic : typeof ic === "string" ? [ic] : [];
+  return refs.map(wikilinkUid).filter((u): u is string => u !== null);
+}
+
+describe("prototype precondition — forget-leak guard (exoas-exocmd submodule) (@req:5579ffa1-a829-4fcf-b93d-4fb664b02d62)", () => {
+  const assets = loadAssets();
+  const byUid = new Map(assets.map((a) => [a.uid, a]));
+
+  // command uid -> set of binding targetClass labels
+  const commandTargets = new Map<string, Set<string>>();
+  for (const a of assets) {
+    if (!instanceClassUids(a.fm).includes(COMMAND_BINDING_CLASS_UID)) continue;
+    const tc = a.fm["exocmd__CommandBinding_targetClass"];
+    const cmdUid = wikilinkUid(a.fm["exocmd__CommandBinding_command"] as string | undefined);
+    if (typeof tc !== "string" || !cmdUid) continue;
+    if (!commandTargets.has(cmdUid)) commandTargets.set(cmdUid, new Set());
+    commandTargets.get(cmdUid)!.add(tc);
+  }
+
+  /** Resolve a command's command-level precondition sparqlAsk (or null). */
+  function commandPreconditionAsk(cmdUid: string): string | null {
+    const cmd = byUid.get(cmdUid);
+    if (!cmd) return null;
+    const preUid = wikilinkUid(cmd.fm["exocmd__Command_precondition"] as string | undefined);
+    if (!preUid) return null;
+    const pre = byUid.get(preUid);
+    if (!pre) return null;
+    // sparqlAsk is a multi-line YAML scalar — read from the raw file.
+    const m = pre.raw.match(/exocmd__Precondition_sparqlAsk:\s*[>|][-]?\n((?:  .*\n?)+)/);
+    return m ? m[1] : (typeof pre.fm["exocmd__Precondition_sparqlAsk"] === "string" ? (pre.fm["exocmd__Precondition_sparqlAsk"] as string) : null);
+  }
+
+  const lifecycleCommands = [...commandTargets.entries()].filter(
+    ([, tcs]) =>
+      [...tcs].some((t) => LIFECYCLE_TARGET_CLASSES.has(t)) &&
+      ![...tcs].some((t) => UNIVERSAL_TARGET_CLASSES.has(t)),
+  );
+
+  it("finds the instance-lifecycle command set (non-trivial)", () => {
+    expect(lifecycleCommands.length).toBeGreaterThanOrEqual(20);
+  });
+
+  it.each(
+    // present a readable [uid, label] tuple per lifecycle command
+    [...commandTargets.keys()]
+      .filter((u) =>
+        commandTargets.get(u)!.size > 0 &&
+        [...commandTargets.get(u)!].some((t) => LIFECYCLE_TARGET_CLASSES.has(t)) &&
+        ![...commandTargets.get(u)!].some((t) => UNIVERSAL_TARGET_CLASSES.has(t)),
+      )
+      .map((u) => [u, byUid.get(u)?.label ?? "?"] as [string, string]),
+  )(
+    "lifecycle command %s (%s) carries the not-a-prototype clause",
+    (cmdUid) => {
+      const ask = commandPreconditionAsk(cmdUid);
+      expect(ask).toBeTruthy();
+      expect(ask!).toMatch(NOT_A_PROTOTYPE_CLAUSE_RE);
+    },
+  );
+
+  it("the standalone 'Target is not a prototype' precondition exists and carries the clause", () => {
+    const pre = byUid.get(STANDALONE_PRECONDITION_UID);
+    expect(pre).toBeTruthy();
+    expect(pre!.raw).toMatch(NOT_A_PROTOTYPE_CLAUSE_RE);
+  });
+
+  it("universal-maintenance commands (targetClass exo__Asset) do NOT carry the clause", () => {
+    const universal = [...commandTargets.entries()].filter(
+      ([, tcs]) => [...tcs].every((t) => UNIVERSAL_TARGET_CLASSES.has(t)),
+    );
+    expect(universal.length).toBeGreaterThanOrEqual(1);
+    for (const [cmdUid] of universal) {
+      const ask = commandPreconditionAsk(cmdUid);
+      if (ask) expect(ask).not.toMatch(NOT_A_PROTOTYPE_CLAUSE_RE);
+    }
+  });
+});

--- a/packages/core/tests/integration/dynamic-commands/PrototypePreconditionRevertVerify.test.ts
+++ b/packages/core/tests/integration/dynamic-commands/PrototypePreconditionRevertVerify.test.ts
@@ -1,0 +1,214 @@
+/**
+ * Revert-verify (req @req:5579ffa1-a829-4fcf-b93d-4fb664b02d62) — a prototype-class
+ * asset hides instance-lifecycle commands via the homoiconic "not-a-prototype"
+ * precondition, while concrete instances keep them. Design node f853eadd.
+ *
+ * ⚠ REAL STORE SHAPE (dual-IRI). The fixtures mirror the production triple store:
+ *   - an asset's `exo:Instance_class` object is the SYMBOLIC class IRI
+ *     (`https://exocortex.my/ontology/ems#TaskPrototype`);
+ *   - `exo:Class_superClass` triples live under the class FILE IRI
+ *     (`obsidian://vault/<uid>.md`), NOT on the symbolic IRI.
+ * These two representations are unconnected in SPARQL (the resolver bridges them
+ * in code). The earlier transitive form
+ * `$target exo:Instance_class/exo:Class_superClass* exo:Prototype` false-passed a
+ * synthetic store that (wrongly) put superClass on the symbolic IRI; on the real
+ * shape it never fires. The shipped precondition uses a STRENDS suffix check on
+ * the symbolic instance_class IRI instead. A guard test below asserts the
+ * transitive form would NOT hide on this real shape (documenting the gotcha).
+ *
+ * Both layers run against the REAL `exoas-exocmd` submodule precondition strings.
+ *
+ * @req:5579ffa1-a829-4fcf-b93d-4fb664b02d62
+ */
+import * as fs from "fs";
+import * as path from "path";
+import { CommandResolver } from "../../../src/services/CommandResolver";
+import { PreconditionEvaluator } from "../../../src/services/PreconditionEvaluator";
+import { InMemoryTripleStore } from "../../../src/infrastructure/rdf/InMemoryTripleStore";
+import { Triple } from "../../../src/domain/models/rdf/Triple";
+import { IRI } from "../../../src/domain/models/rdf/IRI";
+import { Literal } from "../../../src/domain/models/rdf/Literal";
+import { Namespace } from "../../../src/domain/models/rdf/Namespace";
+
+const EXO = "https://exocortex.my/ontology/exo#";
+const EMS = "https://exocortex.my/ontology/ems#";
+
+const SUBMODULE_EXOCMD = path.resolve(__dirname, "../../../../exoas-exocmd/exocmd");
+
+const START_EFFORT_PRECONDITION_UID = "575404fc"; // augmented status gate
+const STANDALONE_PRECONDITION_UID = "847c37e0"; // "Target is not a prototype"
+
+// The shipped STRENDS not-a-prototype clause (suffix check on the symbolic IRI).
+const NOT_A_PROTOTYPE_CLAUSE_RE =
+  /FILTER\s+NOT\s+EXISTS\s*\{[^}]*Instance_class[^}]*STRENDS\s*\(\s*STR\s*\(\s*\?\w+\s*\)\s*,\s*["']Prototype["']\s*\)[^}]*\}\s*/i;
+
+const PROTO_ASSET = "obsidian://vault/my-task-template.md";
+const CONCRETE_ASSET = "obsidian://vault/buy-milk.md";
+const TASK_PROTOTYPE_FILE = "obsidian://vault/ems-taskprototype-class.md";
+
+function readSparqlAsk(uidPrefix: string): string {
+  const file = fs
+    .readdirSync(SUBMODULE_EXOCMD)
+    .find((f) => f.startsWith(uidPrefix) && f.endsWith(".md"));
+  if (!file) throw new Error(`precondition ${uidPrefix} not found in ${SUBMODULE_EXOCMD}`);
+  const txt = fs.readFileSync(path.join(SUBMODULE_EXOCMD, file), "utf8");
+  const m = txt.match(/exocmd__Precondition_sparqlAsk:\s*[>|][-]?\n((?:  .*\n?)+)/);
+  if (!m) throw new Error(`no sparqlAsk block in ${file}`);
+  return m[1].replace(/^ {2}/gm, "").trim();
+}
+
+/**
+ * Production-shape store. ABox instance_class → SYMBOLIC class IRI. The
+ * TaskPrototype CLASS file (file IRI) carries Asset_label/uid + a file-IRI
+ * `Class_superClass` → symbolic `ems#Task` so the resolver's code-side
+ * subclass-closure expands `ems__TaskPrototype` → `ems__Task` (matching the
+ * lifecycle binding) — exactly as in production.
+ */
+function buildRealStore(): InMemoryTripleStore {
+  const store = new InMemoryTripleStore();
+  const I = (s: string) => new IRI(s);
+  const instanceClass = I(`${EXO}Instance_class`);
+  const superClass = I(`${EXO}Class_superClass`);
+  const status = I(`${EMS}Effort_status`);
+
+  // TaskPrototype class FILE (the resolver seeds the hierarchy walk from here,
+  // resolved via label→uid→file). superClass object is the SYMBOLIC ems#Task.
+  store.add(new Triple(I(TASK_PROTOTYPE_FILE), Namespace.EXO.term("Asset_uid"), new Literal("tp-uid")));
+  store.add(new Triple(I(TASK_PROTOTYPE_FILE), Namespace.EXO.term("Asset_label"), new Literal("ems__TaskPrototype")));
+  store.add(new Triple(I(TASK_PROTOTYPE_FILE), superClass, I(`${EMS}Task`)));
+
+  // Prototype-TEMPLATE asset — instance_class is the SYMBOLIC prototype IRI.
+  // Status set so a status gate would otherwise pass; the not-a-prototype clause
+  // must still veto.
+  store.add(new Triple(I(PROTO_ASSET), instanceClass, I(`${EMS}TaskPrototype`)));
+  store.add(new Triple(I(PROTO_ASSET), status, I(`${EMS}EffortStatusBacklog`)));
+
+  // Concrete task — instance_class is the SYMBOLIC concrete class IRI.
+  store.add(new Triple(I(CONCRETE_ASSET), instanceClass, I(`${EMS}Task`)));
+  store.add(new Triple(I(CONCRETE_ASSET), status, I(`${EMS}EffortStatusBacklog`)));
+  return store;
+}
+
+describe("prototype precondition — revert-verify on REAL store shape (@req:5579ffa1-a829-4fcf-b93d-4fb664b02d62)", () => {
+  describe("A. PreconditionEvaluator on real augmented submodule strings", () => {
+    it("the shipped preconditions carry the STRENDS not-a-prototype clause (suffix form)", () => {
+      expect(readSparqlAsk(START_EFFORT_PRECONDITION_UID)).toMatch(NOT_A_PROTOTYPE_CLAUSE_RE);
+      expect(readSparqlAsk(STANDALONE_PRECONDITION_UID)).toMatch(NOT_A_PROTOTYPE_CLAUSE_RE);
+    });
+
+    it("GREEN: augmented Start-Effort precondition HIDES on a status-bearing prototype-template", async () => {
+      const ev = new PreconditionEvaluator(buildRealStore());
+      const ask = readSparqlAsk(START_EFFORT_PRECONDITION_UID);
+      expect(await ev.evaluate({ id: "x", label: "x", sparqlAsk: ask }, PROTO_ASSET)).toBe(false);
+    });
+
+    it("GREEN: augmented Start-Effort precondition SHOWS on a concrete Backlog task (status gate preserved)", async () => {
+      const ev = new PreconditionEvaluator(buildRealStore());
+      const ask = readSparqlAsk(START_EFFORT_PRECONDITION_UID);
+      expect(await ev.evaluate({ id: "x", label: "x", sparqlAsk: ask }, CONCRETE_ASSET)).toBe(true);
+    });
+
+    it("RED on revert: stripping the not-a-prototype clause makes the prototype show Start (leak)", async () => {
+      const ev = new PreconditionEvaluator(buildRealStore());
+      const augmented = readSparqlAsk(START_EFFORT_PRECONDITION_UID);
+      const reverted = augmented.replace(NOT_A_PROTOTYPE_CLAUSE_RE, "");
+      expect(reverted).not.toMatch(NOT_A_PROTOTYPE_CLAUSE_RE);
+      // prototype-template has status Backlog → without the prototype gate the
+      // status gate alone passes → Start LEAKS onto the template (the regression).
+      expect(await ev.evaluate({ id: "x", label: "x", sparqlAsk: reverted }, PROTO_ASSET)).toBe(true);
+    });
+
+    it("GOTCHA guard: the OLD transitive form would NOT hide on the real dual-IRI shape", async () => {
+      // Documents why STRENDS replaced the transitive walk: on the real store,
+      // superClass lives on the file IRI, so the symbolic instance_class never
+      // reaches exo:Prototype → the transitive clause fails to hide.
+      const ev = new PreconditionEvaluator(buildRealStore());
+      const transitive = `PREFIX exo: <${EXO}> ASK { FILTER NOT EXISTS { $target exo:Instance_class/exo:Class_superClass* exo:Prototype } }`;
+      expect(await ev.evaluate({ id: "x", label: "x", sparqlAsk: transitive }, PROTO_ASSET)).toBe(true); // (would-be) leak
+    });
+  });
+
+  describe("B. full CommandResolver + precondition-filter pipeline (real dual-IRI shape)", () => {
+    const CMD_UID = "e941b3bb-d375-40d2-b271-e1d71deb014c"; // Start Effort
+    const BIND_UID = "11111111-1111-1111-1111-111111111111";
+    const PRE_UID = "575404fc-9085-4f4a-a3e4-bfebb49c42a4";
+
+    async function resolveVisible(
+      store: InMemoryTripleStore,
+      subjectIRI: string,
+      classes: string[],
+    ): Promise<string[]> {
+      const resolver = new CommandResolver(store);
+      const evaluator = new PreconditionEvaluator(store);
+      const resolved = await resolver.resolveForAssetMulti(subjectIRI, classes);
+      const checks = await Promise.all(
+        resolved.map(async (rc) => ({
+          name: rc.command.name,
+          available: await evaluator.evaluate(rc.command.precondition, subjectIRI, { targetIRI: subjectIRI }),
+        })),
+      );
+      return checks.filter((c) => c.available).map((c) => c.name);
+    }
+
+    async function mountStartEffort(store: InMemoryTripleStore, preconditionAsk: string): Promise<void> {
+      const cmd = new IRI(`obsidian://vault/${CMD_UID}.md`);
+      const bind = new IRI(`obsidian://vault/${BIND_UID}.md`);
+      const pre = new IRI(`obsidian://vault/${PRE_UID}.md`);
+      const gnd = new IRI("obsidian://vault/gnd.md");
+      await store.addAll([
+        new Triple(cmd, Namespace.RDF.term("type"), Namespace.EXOCMD.term("Command")),
+        new Triple(cmd, Namespace.EXO.term("Asset_uid"), new Literal(CMD_UID)),
+        new Triple(cmd, Namespace.EXO.term("Asset_label"), new Literal("Start Effort")),
+        new Triple(cmd, Namespace.EXOCMD.term("Command_grounding"), gnd),
+        new Triple(cmd, Namespace.EXOCMD.term("Command_precondition"), pre),
+        // Grounding — production-shape so loadLinkedGrounding succeeds.
+        new Triple(gnd, Namespace.RDF.term("type"), Namespace.EXOCMD.term("Grounding")),
+        new Triple(gnd, Namespace.EXO.term("Asset_uid"), new Literal("gnd")),
+        new Triple(gnd, Namespace.EXO.term("Asset_label"), new Literal("Start effort")),
+        new Triple(gnd, Namespace.EXOCMD.term("Grounding_type"), new Literal("[[4367e2d6-6c92-450a-becb-abce1fb07682]]")),
+        new Triple(gnd, Namespace.EXOCMD.term("Grounding_targetClass"), new Literal("1b20a8f0-d745-4e93-91db-4531b3df120e|ems__Task")),
+        // Precondition asset carrying the (real, augmented) sparqlAsk.
+        new Triple(pre, Namespace.RDF.term("type"), Namespace.EXOCMD.term("Precondition")),
+        new Triple(pre, Namespace.EXO.term("Asset_uid"), new Literal(PRE_UID)),
+        new Triple(pre, Namespace.EXOCMD.term("Precondition_sparqlAsk"), new Literal(preconditionAsk)),
+        // Binding targetClass=ems__Task.
+        new Triple(bind, Namespace.RDF.term("type"), Namespace.EXOCMD.term("CommandBinding")),
+        new Triple(bind, Namespace.EXO.term("Asset_uid"), new Literal(BIND_UID)),
+        new Triple(bind, Namespace.EXOCMD.term("CommandBinding_command"), cmd),
+        new Triple(bind, Namespace.EXOCMD.term("CommandBinding_targetClass"), new Literal("ems__Task")),
+        new Triple(bind, Namespace.EXOCMD.term("CommandBinding_position"), new Literal("inline")),
+        new Triple(bind, Namespace.EXOCMD.term("CommandBinding_order"), new Literal("100")),
+      ]);
+    }
+
+    it("sanity: resolver expands ems__TaskPrototype → ems__Task via file-IRI superClass (binding matches)", async () => {
+      // No precondition on the command → proves the binding actually resolves
+      // for the prototype class (so the GREEN 'not shown' below is meaningful,
+      // not a false-positive from non-resolution).
+      const store = buildRealStore();
+      const resolver = new CommandResolver(store);
+      await mountStartEffort(store, "PREFIX e: <x:> ASK { }"); // always-true precondition
+      const names = (await resolver.resolveForAssetMulti(PROTO_ASSET, ["ems__TaskPrototype", "exo__Asset"])).map((r) => r.command.name);
+      expect(names).toContain("Start Effort");
+    });
+
+    it("GREEN: TaskPrototype-template does NOT show Start Effort; concrete Task does", async () => {
+      const ask = readSparqlAsk(START_EFFORT_PRECONDITION_UID);
+
+      const protoStore = buildRealStore();
+      await mountStartEffort(protoStore, ask);
+      expect(await resolveVisible(protoStore, PROTO_ASSET, ["ems__TaskPrototype", "exo__Asset"])).not.toContain("Start Effort");
+
+      const concreteStore = buildRealStore();
+      await mountStartEffort(concreteStore, ask);
+      expect(await resolveVisible(concreteStore, CONCRETE_ASSET, ["ems__Task", "exo__Asset"])).toContain("Start Effort");
+    });
+
+    it("RED on revert: with the not-a-prototype clause stripped, the TaskPrototype-template shows Start Effort (leak)", async () => {
+      const reverted = readSparqlAsk(START_EFFORT_PRECONDITION_UID).replace(NOT_A_PROTOTYPE_CLAUSE_RE, "");
+      const store = buildRealStore();
+      await mountStartEffort(store, reverted);
+      expect(await resolveVisible(store, PROTO_ASSET, ["ems__TaskPrototype", "exo__Asset"])).toContain("Start Effort");
+    });
+  });
+});


### PR DESCRIPTION
## What

A **prototype-class asset** (an instance of `ems__TaskPrototype` / any
`exo__Prototype` descendant — i.e. a task/project/… *template*) no longer shows
instance-lifecycle commands (Start, Mark Done, Set Criticality, status
transitions, child-creation, convert, vote). It keeps **universal-maintenance**
(Clean Properties, Repair Folder, …) and its own **create-instance** command.

Realises the vision-interview verdict (design node `f853eadd`) the homoiconic
way: command availability is user-configurable semantics → expressed as an
**RDF precondition**, not hardcoded engine logic. **No engine code changed** —
`PreconditionEvaluator` + `DynamicCommandButtonGroupBuilder` already filter the
visible command set per asset.

## How (vault — `exoas-exocmd` submodule, pointer bumped to `6d70c37`)

- New standalone `exocmd__Precondition` **"Target is not a prototype"** (`847c37e0`),
  wired command-level on the 6 lifecycle commands that had no prior precondition.
- The same not-a-prototype clause conjoined into the **17 existing** lifecycle
  status/criticality/convert preconditions (ANDed with their status gates) so the
  18 status-bearing lifecycle commands are covered too. Universal-maintenance
  (targetClass `exo__Asset`) + create-instance are untouched.

## Clause: STRENDS suffix, not transitive `Class_superClass*` (verify-before-assert)

The designed `$target exo:Instance_class/exo:Class_superClass* exo:Prototype` is
**broken on the real store**: an asset's `exo:Instance_class` resolves to the
SYMBOLIC class IRI (`ems#TaskPrototype`) but `exo:Class_superClass` triples live
under the class FILE IRI — unconnected in SPARQL (the resolver bridges them in
code). Empirically (CLI SELECT) the path never reaches `exo:Prototype`. The
shipped clause is a queryable suffix check on the symbolic IRI:
`FILTER NOT EXISTS { $target exo:Instance_class ?c . FILTER(STRENDS(STR(?c), "Prototype")) }`.
It catches every conventionally-named prototype class (incl. ones an enum-list
missed) + future ones. No material false-positive: the 5 vault classes named
`…Prototype` that aren't IS-A `exo__Prototype` are none IS-A a lifecycle class →
no lifecycle commands to wrongly hide.

The inline `sparqlAsk` form (not `Precondition_query`) is used so the gate works
on BOTH the plugin visibility surface AND the CLI `apply` path (the CLI builds
its `PreconditionEvaluator` without an `IQueryBodyResolver`, so the query form
would fail-closed there).

## Tests (this repo)

- `PrototypePreconditionRevertVerify.test.ts` — production-shape **REAL dual-IRI**
  store + the real submodule precondition strings, through PreconditionEvaluator
  AND the full CommandResolver pipeline. RED→GREEN: stripping the clause leaks
  Start onto a TaskPrototype-template. Includes a gotcha-guard proving the
  transitive form would NOT hide on the real shape.
- `PrototypePreconditionForgetGuard.test.ts` — walks `exoas-exocmd`, asserts
  EVERY instance-lifecycle command carries the clause (silent leak → CI fail) and
  universal-maintenance commands do NOT.

Bound to requirement `@req:5579ffa1-a829-4fcf-b93d-4fb664b02d62`.
