### PR TITLE
feat(relations): triple-store ctor-DI + cold-start gate + predicate-whitelist for reified read-path (RFC 93a0b2ee Task 1.2)

### DIFF
--- a/packages/core/src/services/LazyAssetGraphLoader.ts
+++ b/packages/core/src/services/LazyAssetGraphLoader.ts
@@ -186,6 +186,22 @@ export class LazyAssetGraphLoader {
   }
 
   /**
+   * Compute an asset's path-form IRI with the SAME `subjectIriPrefix` the
+   * loader's converter uses (RFC `93a0b2ee` Task 1.2). Delegates to
+   * `INoteConverter.notePathToIRI` so a consumer that needs to match assets
+   * against the store (e.g. the Relations read-path sourcing reified
+   * `exo__Statement` relations) keys by the EXACT IRI form the indexer emitted
+   * — not a hand-rolled `obsidian://vault/<path>` guess that would silently
+   * miss mounted / prefix-labeled subjects (`sparql-iri-form-pre-verify`).
+   *
+   * @param path - The asset's vault-relative path (e.g. `assetspaces/…/<uid>.md`).
+   * @returns The path-form IRI (`<subjectIriPrefix><path>` → `obsidian://vault/…`).
+   */
+  notePathToIRI(path: string): IRI {
+    return this.converter.notePathToIRI(path);
+  }
+
+  /**
    * Mark a single IRI as no-longer-loaded so the next ensure-call for
    * this asset re-walks frontmatter + chains afresh.
    *

--- a/packages/core/tests/unit/services/LazyAssetGraphLoader.test.ts
+++ b/packages/core/tests/unit/services/LazyAssetGraphLoader.test.ts
@@ -120,6 +120,24 @@ describe("LazyAssetGraphLoader", () => {
     });
   });
 
+  // RFC 93a0b2ee Task 1.2 — public delegation so a consumer (the Relations
+  // read-path) can key an asset by the SAME IRI form the converter emits.
+  describe("notePathToIRI", () => {
+    it("delegates to the converter's notePathToIRI (matches the load-mark form)", () => {
+      const path = "assetspaces/kitelev/exoas-my/my/some-uid.md";
+      expect(loader.notePathToIRI(path).value).toBe(pathToIRI(path).value);
+    });
+
+    it("is consistent with the IRI form ensureFileLoaded keys its load-mark by", async () => {
+      const file = makeFile("task.md");
+      converter.registerFile(file, []);
+      await loader.ensureFileLoaded(file);
+      // The loaded-set is keyed by converter.notePathToIRI — so the public
+      // accessor must return the IRI that isLoaded() recognises.
+      expect(loader.isLoaded(loader.notePathToIRI("task.md"))).toBe(true);
+    });
+  });
+
   describe("class chain walk", () => {
     it("loads the asset's declared classes via exo:Instance_class", async () => {
       const taskFile = makeFile("my-task.md");

--- a/packages/obsidian-plugin/src/presentation/renderers/UniversalLayoutRenderer.ts
+++ b/packages/obsidian-plugin/src/presentation/renderers/UniversalLayoutRenderer.ts
@@ -204,9 +204,19 @@ export class UniversalLayoutRenderer {
       this.app, this.reactRenderer, this.metadataExtractor,
       this.vaultAdapter, this.metadataService, this.logger);
 
+    // RFC 93a0b2ee Task 1.2 — wire the reified-relation read-path deps without
+    // touching ExocortexPlugin.ts (ctor-DI, not ExocortexPluginInterface → zero
+    // overlap with parallel sessions). `notePathToIRI` comes from the lazy
+    // loader's converter (same empty subjectIriPrefix the main indexer used to
+    // emit the statements), so reified subjects key by the matching IRI form.
+    const loader = this.lazyAssetGraphLoader;
+    const notePathToIRI = loader
+      ? (path: string) => loader.notePathToIRI(path)
+      : undefined;
     this.relationsRenderer = new RelationsRenderer(
       this.app, this.settings, this.reactRenderer, this.backlinksCacheManager,
-      this.metadataService, this.plugin, () => this.refresh(), this.vaultAdapter);
+      this.metadataService, this.plugin, () => this.refresh(), this.vaultAdapter,
+      this.tripleStore, this.isStoreReady, notePathToIRI);
 
     this.buttonGroupsBuilder = new ButtonGroupsBuilder({
       app: this.app,

--- a/packages/obsidian-plugin/src/presentation/renderers/layout/RelationsRenderer.ts
+++ b/packages/obsidian-plugin/src/presentation/renderers/layout/RelationsRenderer.ts
@@ -26,28 +26,54 @@ import { ObsidianApp, ExocortexPluginInterface } from '@plugin/types';
  * triple. The Relations block only wants genuine relation predicates (user-defined
  * object properties such as `ems#Effort_area`, `exo-ims#relatesToConcept`); a
  * statement whose `_predicate` is a SYSTEM / metadata / plumbing predicate
- * (`rdf:type`, the `exo:Asset_*` frontmatter system properties, `exo:Instance_class`,
- * `exo:Class_superClass`, or the `exo:Statement_*` reification slots themselves) is
- * noise, not a relation, and must be dropped. RDFS / OWL schema predicates (inferred
- * noise) are likewise excluded.
+ * (`rdf:type`, the literal `exo:Asset_*` frontmatter metadata, the TBox-structural
+ * `exo:Instance_*` / `exo:Class_*`, or the `exo:Statement_*` reification slots
+ * themselves) is noise, not a relation, and must be dropped. RDFS / OWL schema
+ * predicates (inferred noise) are likewise excluded.
  *
- * Implemented as a denylist-by-pattern rather than an allowlist because relation
- * predicates are open-ended (user-defined): we cannot enumerate every legitimate
- * relation predicate a priori, so we exclude the closed set of known non-relation
- * predicates and let everything else through. Mirrors RFC §C1 "whitelist
- * relation-предикатов (отсечь rdf:type / exo:Asset_<x> / inferred-шум)".
+ * The exclusion is deliberately a CLOSED, narrow set — NOT a coarse `exo#Asset_`
+ * prefix. The `exo:Asset_*` family contains genuine OBJECT relations the inline
+ * relation path already surfaces — `exo:Asset_relates` (canonical relates),
+ * `exo:Asset_prototype`, `exo:Asset_createdBy`, `exo:Asset_isDefinedBy`,
+ * `exo:Asset_source` — which MUST stay visible (else Task 1.3 would render a
+ * reified `Asset_relates` invisible while an inline one shows: an inline/reified
+ * asymmetry). Only the LITERAL Asset metadata properties (label / uid / timestamps /
+ * isArchived / description) are dropped. So RFC §C1's "отсечь … exo:Asset_<x>" is
+ * read as its system-metadata subset, mirrored against the inline path's behaviour.
+ *
+ * Implemented as a denylist (not an allowlist) because relation predicates are
+ * open-ended (user-defined): we exclude the closed set of known non-relation
+ * predicates and let everything else through.
  */
 const RDF_TYPE_IRI: string = Namespace.RDF.term("type").value;
 const EXO_BASE: string = Namespace.EXO.iri.value;
 const RDFS_BASE: string = Namespace.RDFS.iri.value;
 const OWL_BASE: string = Namespace.OWL.iri.value;
-/** `exo#` local-name prefixes that mark a system / metadata / plumbing predicate. */
+/**
+ * `exo#` local-name prefixes that are purely TBox-structural / reification-plumbing
+ * — never user-data relations (`Instance_class`, `Class_superClass`, the three
+ * `Statement_` slots). Safe to drop wholesale by prefix.
+ */
 const EXO_NON_RELATION_LOCALNAME_PREFIXES = [
-  "Asset_",
   "Instance_",
   "Class_",
   "Statement_",
 ];
+/**
+ * The LITERAL `exo#Asset_*` metadata properties (string / datetime / boolean
+ * values) — dropped explicitly. The OBJECT `exo:Asset_*` relations
+ * (`Asset_relates`, `Asset_prototype`, `Asset_createdBy`, `Asset_isDefinedBy`,
+ * `Asset_source`) are intentionally ABSENT here so they pass as relations,
+ * matching what the inline path surfaces.
+ */
+const EXO_NON_RELATION_ASSET_LOCALNAMES: ReadonlySet<string> = new Set([
+  "Asset_label",
+  "Asset_uid",
+  "Asset_createdAt",
+  "Asset_updatedAt",
+  "Asset_isArchived",
+  "Asset_description",
+]);
 
 /**
  * True when `predicateIri` is a SYSTEM / metadata / plumbing predicate that must
@@ -60,6 +86,7 @@ export function isNonRelationPredicate(predicateIri: string): boolean {
   }
   if (predicateIri.startsWith(EXO_BASE)) {
     const localName = predicateIri.slice(EXO_BASE.length);
+    if (EXO_NON_RELATION_ASSET_LOCALNAMES.has(localName)) return true;
     return EXO_NON_RELATION_LOCALNAME_PREFIXES.some((p) =>
       localName.startsWith(p),
     );

--- a/packages/obsidian-plugin/src/presentation/renderers/layout/RelationsRenderer.ts
+++ b/packages/obsidian-plugin/src/presentation/renderers/layout/RelationsRenderer.ts
@@ -1,14 +1,71 @@
 import { TFile, Keymap } from "obsidian";
 import React from "react";
 import { ReactRenderer } from '@plugin/presentation/utils/ReactRenderer';
-import { MetadataHelpers, IVaultAdapter, IFile } from "@kitelev/exocortex-core";
+import {
+  MetadataHelpers,
+  IVaultAdapter,
+  IFile,
+  ITripleStore,
+  IRI,
+  Namespace,
+} from "@kitelev/exocortex-core";
 import { AssetRelationsTableWithToggle } from '@plugin/presentation/components/AssetRelationsTable';
 import { BacklinksCacheManager } from '@plugin/adapters/caching/BacklinksCacheManager';
 import { ExocortexSettings } from '@plugin/domain/settings/ExocortexSettings';
 import { AssetMetadataService } from "./helpers/AssetMetadataService";
 import { AssetRelation } from "./types";
+import { getReifiedRelations, ReifiedRelation } from "./getReifiedRelations";
 import { BlockerHelpers } from '@plugin/presentation/utils/BlockerHelpers';
 import { ObsidianApp, ExocortexPluginInterface } from '@plugin/types';
+
+/**
+ * RFC `93a0b2ee` Task 1.2 — non-relation predicate filter ("predicate-whitelist"
+ * by exclusion) applied to reified relations sourced via {@link getReifiedRelations}.
+ *
+ * A reified `exo__Statement` reifies an arbitrary `<subject> <predicate> <object>`
+ * triple. The Relations block only wants genuine relation predicates (user-defined
+ * object properties such as `ems#Effort_area`, `exo-ims#relatesToConcept`); a
+ * statement whose `_predicate` is a SYSTEM / metadata / plumbing predicate
+ * (`rdf:type`, the `exo:Asset_*` frontmatter system properties, `exo:Instance_class`,
+ * `exo:Class_superClass`, or the `exo:Statement_*` reification slots themselves) is
+ * noise, not a relation, and must be dropped. RDFS / OWL schema predicates (inferred
+ * noise) are likewise excluded.
+ *
+ * Implemented as a denylist-by-pattern rather than an allowlist because relation
+ * predicates are open-ended (user-defined): we cannot enumerate every legitimate
+ * relation predicate a priori, so we exclude the closed set of known non-relation
+ * predicates and let everything else through. Mirrors RFC §C1 "whitelist
+ * relation-предикатов (отсечь rdf:type / exo:Asset_<x> / inferred-шум)".
+ */
+const RDF_TYPE_IRI: string = Namespace.RDF.term("type").value;
+const EXO_BASE: string = Namespace.EXO.iri.value;
+const RDFS_BASE: string = Namespace.RDFS.iri.value;
+const OWL_BASE: string = Namespace.OWL.iri.value;
+/** `exo#` local-name prefixes that mark a system / metadata / plumbing predicate. */
+const EXO_NON_RELATION_LOCALNAME_PREFIXES = [
+  "Asset_",
+  "Instance_",
+  "Class_",
+  "Statement_",
+];
+
+/**
+ * True when `predicateIri` is a SYSTEM / metadata / plumbing predicate that must
+ * NOT be surfaced as a relation in the Relations block (RFC `93a0b2ee` Task 1.2).
+ */
+export function isNonRelationPredicate(predicateIri: string): boolean {
+  if (predicateIri === RDF_TYPE_IRI) return true;
+  if (predicateIri.startsWith(RDFS_BASE) || predicateIri.startsWith(OWL_BASE)) {
+    return true;
+  }
+  if (predicateIri.startsWith(EXO_BASE)) {
+    const localName = predicateIri.slice(EXO_BASE.length);
+    return EXO_NON_RELATION_LOCALNAME_PREFIXES.some((p) =>
+      localName.startsWith(p),
+    );
+  }
+  return false;
+}
 
 export interface UniversalLayoutConfig {
   sortBy?: string;
@@ -53,7 +110,75 @@ export class RelationsRenderer {
     private plugin: ExocortexPluginInterface,
     private refresh: () => Promise<void>,
     private vaultAdapter: IVaultAdapter,
+    // RFC `93a0b2ee` Task 1.2 — reified-relation read-path dependencies, all
+    // OPTIONAL so existing callers (and back-compat) behave exactly as before
+    // when absent (reified sourcing is simply skipped). Wired in production at
+    // `UniversalLayoutRenderer.initializeRenderers()` from the live triple store,
+    // the `SPARQLApi.isReady` probe, and the lazy loader's `notePathToIRI`.
+    /** Live triple store the reified `exo__Statement` instances are queried from. */
+    private store?: ITripleStore,
+    /**
+     * Cold-start readiness probe (`() => sparql.isReady()`). The reified query is
+     * GATED on this so a partially-indexed store never yields an UNDER-count of
+     * reified relations (RFC R4 / pattern #3587): while it returns false the
+     * reified fetch yields `[]`, and the post-refresh `autoRenderLayout()`
+     * re-render (self-heal) surfaces them once indexing settles. Omit → assume
+     * ready (back-compat: no gate).
+     */
+    private isStoreReady?: () => boolean,
+    /**
+     * The indexer's `notePathToIRI` (same `subjectIriPrefix`) — reused so the
+     * reified query keys an asset by the EXACT IRI form the converter emitted
+     * (R5 dual-IRI). Injected (not hand-rolled) so a mounted / prefix-labeled
+     * subject resolves instead of silently matching nothing.
+     */
+    private notePathToIRI?: (path: string) => IRI,
   ) {}
+
+  /**
+   * Fetch the asset's reified relations from its `exo__Statement` instances —
+   * GATED on store readiness and FILTERED to genuine relation predicates
+   * (RFC `93a0b2ee` §C1, Task 1.2). This is the cold-start-safe, whitelisted
+   * wrapper over the pure {@link getReifiedRelations} helper (Task 1.1). The
+   * integration of these into the unified relation list (dedup vs inline +
+   * provenance tagging) is Task 1.3 — this method has no caller in
+   * `getAssetRelations` yet.
+   *
+   * Returns `[]` (a no-op, never a partial set) when:
+   *  - the triple store or `notePathToIRI` dependency is absent (back-compat);
+   *  - the store is not ready (`isStoreReady?.() === false`) — the cold-start
+   *    gate that prevents an UNDER-count; the next post-refresh re-render fills
+   *    them in (self-heal).
+   *
+   * Otherwise it queries the helper and drops any reified relation whose
+   * `_predicate` is a non-relation system/plumbing predicate
+   * ({@link isNonRelationPredicate}).
+   *
+   * @param file - The asset whose reified relations to fetch.
+   * @returns the filtered reified relations; `[]` when gated off or none exist.
+   */
+  async getReifiedRelationsGated(file: TFile): Promise<ReifiedRelation[]> {
+    const store = this.store;
+    const notePathToIRI = this.notePathToIRI;
+    if (!store || !notePathToIRI) return [];
+    // Cold-start gate: never source reified relations from a not-yet-ready store
+    // (would under-count). `isStoreReady` absent → assume ready (back-compat).
+    if (this.isStoreReady && !this.isStoreReady()) return [];
+
+    const label =
+      this.metadataService.getAssetLabel(file.path) ??
+      (this.vaultAdapter.getFrontmatter(file as unknown as IFile)
+        ?.exo__Asset_label as string | undefined) ??
+      null;
+
+    const reified = await getReifiedRelations({
+      file: { path: file.path, label },
+      store,
+      notePathToIRI,
+    });
+    // Predicate-whitelist: keep only genuine relation predicates.
+    return reified.filter((r) => !isNonRelationPredicate(r.predicate));
+  }
 
   /**
    * Compose the `groupSpecificProperties` map consumed by

--- a/packages/obsidian-plugin/tests/unit/RelationsRenderer.test.ts
+++ b/packages/obsidian-plugin/tests/unit/RelationsRenderer.test.ts
@@ -2,7 +2,15 @@ import React from "react";
 import {
   RelationsRenderer,
   RELATIONS_EMPTY_TEXT,
+  isNonRelationPredicate,
 } from "../../src/presentation/renderers/layout/RelationsRenderer";
+import {
+  InMemoryTripleStore,
+  IRI,
+  Namespace,
+  Triple,
+  vaultPathToIRI,
+} from "@kitelev/exocortex-core";
 import { Keymap, TFile } from "obsidian";
 import {
   createMockApp,
@@ -1272,6 +1280,247 @@ describe("RelationsRenderer", () => {
         showProperties: ["custom_prop1", "custom_prop2"],
         showEffortVotes: true,
         groupByProperty: true,
+      });
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // RFC 93a0b2ee Task 1.2 — reified-relation read-path: triple-store ctor-DI +
+  // cold-start isReady gate + predicate-whitelist. Production-shape: exercises
+  // `getReifiedRelationsGated` over a REAL InMemoryTripleStore (not a stub),
+  // seeding statements exactly as NoteToRDFConverter emits them.
+  //
+  // `@req:1cbd6248-2e68-43d8-8f06-f35faf25fe9a`  (req-first SDD, RFC 0003).
+  //   Revert-verified: (a) deleting the cold-start gate (`if (this.isStoreReady
+  //   && !this.isStoreReady()) return []`) makes the "not-ready → []" case RED;
+  //   (b) deleting the predicate-whitelist filter makes the "filters non-relation
+  //   predicate" case RED. Restored → GREEN.
+  // ---------------------------------------------------------------------------
+  describe("getReifiedRelationsGated (Task 1.2 — cold-start gate + predicate-whitelist)", () => {
+    // Mirrors NoteToRDFConverter.notePathToIRI with an empty subjectIriPrefix —
+    // the exact path-form the indexer emits and the wiring injects in prod.
+    const notePathToIRI = (path: string): IRI => new IRI(vaultPathToIRI(path));
+
+    const STATEMENT_SUBJECT = Namespace.EXO.term("Statement_subject");
+    const STATEMENT_PREDICATE = Namespace.EXO.term("Statement_predicate");
+    const STATEMENT_OBJECT = Namespace.EXO.term("Statement_object");
+    const RDF_TYPE = Namespace.RDF.term("type");
+    const EXO_STATEMENT_CLASS = Namespace.EXO.term("Statement");
+    /** A genuine user-defined relation predicate. */
+    const RELATES_TO = new IRI(
+      "https://exocortex.my/ontology/exo-ims#relatesToConcept",
+    );
+
+    const A_PATH =
+      "assetspaces/kitelev/exoas-my/my/aaaaaaaa-0000-0000-0000-000000000001.md";
+    const B_PATH =
+      "assetspaces/kitelev/exoas-public/concept/bbbbbbbb-0000-0000-0000-000000000002.md";
+    const S1_PATH =
+      "assetspaces/kitelev/exoas-class-relations/class-relations/11111111-0000-0000-0000-000000000011.md";
+
+    /** Seed one reified statement (raw slot triples + materialized D5 edge). */
+    async function seedStatement(
+      store: InMemoryTripleStore,
+      statementPath: string,
+      subject: IRI,
+      predicate: IRI,
+      object: IRI,
+    ): Promise<void> {
+      const stmt = notePathToIRI(statementPath);
+      await store.add(new Triple(stmt, RDF_TYPE, EXO_STATEMENT_CLASS));
+      await store.add(new Triple(stmt, STATEMENT_SUBJECT, subject));
+      await store.add(new Triple(stmt, STATEMENT_PREDICATE, predicate));
+      await store.add(new Triple(stmt, STATEMENT_OBJECT, object));
+      await store.add(new Triple(subject, predicate, object));
+    }
+
+    // NB: `noteFn` is intentionally NOT defaulted — passing `undefined`
+    // explicitly must stay undefined (a default param would resurrect
+    // `notePathToIRI` on an explicit-undefined call, defeating the
+    // dependency-absent test).
+    function makeRenderer(
+      store: InMemoryTripleStore | undefined,
+      isStoreReady: (() => boolean) | undefined,
+      noteFn: ((path: string) => IRI) | undefined,
+    ): RelationsRenderer {
+      // Label resolution feeds the dual-IRI symbolic candidate; for these
+      // path-keyed statements a plain label is fine (no symbolic form).
+      mockMetadataService.getAssetLabel.mockReturnValue("Концепт A");
+      mockVaultAdapter.getFrontmatter.mockReturnValue(null);
+      return new RelationsRenderer(
+        mockApp,
+        mockSettings,
+        mockReactRenderer,
+        mockBacklinksCacheManager,
+        mockMetadataService,
+        mockPlugin,
+        mockRefresh,
+        mockVaultAdapter,
+        store,
+        isStoreReady,
+        noteFn,
+      );
+    }
+
+    it("surfaces an outgoing reified relation when the store is ready", async () => {
+      const store = new InMemoryTripleStore();
+      await seedStatement(
+        store,
+        S1_PATH,
+        notePathToIRI(A_PATH),
+        RELATES_TO,
+        notePathToIRI(B_PATH),
+      );
+      const renderer = makeRenderer(store, () => true, notePathToIRI);
+
+      const result = await renderer.getReifiedRelationsGated(
+        createTestTFile(A_PATH),
+      );
+
+      expect(result).toHaveLength(1);
+      expect(result[0].direction).toBe("outgoing");
+      expect(result[0].predicate).toBe(RELATES_TO.value);
+      expect(result[0].object).toBe(notePathToIRI(B_PATH).value);
+      expect(result[0].statementPath).toBe(S1_PATH);
+    });
+
+    // Revert-verify anchor (gate): break the `isStoreReady() === false` gate and
+    // this goes RED — a not-ready store would leak a partial / under-counted set.
+    it("returns [] (no under-count) when the store is NOT ready (cold-start gate)", async () => {
+      const store = new InMemoryTripleStore();
+      await seedStatement(
+        store,
+        S1_PATH,
+        notePathToIRI(A_PATH),
+        RELATES_TO,
+        notePathToIRI(B_PATH),
+      );
+      const renderer = makeRenderer(store, () => false, notePathToIRI);
+
+      const result = await renderer.getReifiedRelationsGated(
+        createTestTFile(A_PATH),
+      );
+
+      expect(result).toEqual([]);
+    });
+
+    it("assumes ready (back-compat) when no isStoreReady probe is wired", async () => {
+      const store = new InMemoryTripleStore();
+      await seedStatement(
+        store,
+        S1_PATH,
+        notePathToIRI(A_PATH),
+        RELATES_TO,
+        notePathToIRI(B_PATH),
+      );
+      const renderer = makeRenderer(store, undefined, notePathToIRI);
+
+      const result = await renderer.getReifiedRelationsGated(
+        createTestTFile(A_PATH),
+      );
+
+      expect(result).toHaveLength(1);
+    });
+
+    // Revert-verify anchor (whitelist): break the predicate-whitelist filter and
+    // this goes RED — the rdf:type-reified statement would leak as a "relation".
+    it("filters out a reified statement whose predicate is a non-relation predicate (rdf:type)", async () => {
+      const store = new InMemoryTripleStore();
+      // A genuine relation + a noise statement reifying rdf:type — only the
+      // genuine relation must survive the whitelist.
+      await seedStatement(
+        store,
+        S1_PATH,
+        notePathToIRI(A_PATH),
+        RELATES_TO,
+        notePathToIRI(B_PATH),
+      );
+      await seedStatement(
+        store,
+        "assetspaces/kitelev/exoas-class-relations/class-relations/22222222-0000-0000-0000-000000000022.md",
+        notePathToIRI(A_PATH),
+        RDF_TYPE,
+        EXO_STATEMENT_CLASS,
+      );
+      const renderer = makeRenderer(store, () => true, notePathToIRI);
+
+      const result = await renderer.getReifiedRelationsGated(
+        createTestTFile(A_PATH),
+      );
+
+      expect(result).toHaveLength(1);
+      expect(result[0].predicate).toBe(RELATES_TO.value);
+    });
+
+    it("filters out a reified statement whose predicate is an exo system property (exo:Asset_label)", async () => {
+      const store = new InMemoryTripleStore();
+      await seedStatement(
+        store,
+        S1_PATH,
+        notePathToIRI(A_PATH),
+        Namespace.EXO.term("Asset_label"),
+        notePathToIRI(B_PATH),
+      );
+      const renderer = makeRenderer(store, () => true, notePathToIRI);
+
+      const result = await renderer.getReifiedRelationsGated(
+        createTestTFile(A_PATH),
+      );
+
+      expect(result).toEqual([]);
+    });
+
+    it("returns [] when the triple store dependency is absent (back-compat)", async () => {
+      const renderer = makeRenderer(undefined, () => true, notePathToIRI);
+
+      const result = await renderer.getReifiedRelationsGated(
+        createTestTFile(A_PATH),
+      );
+
+      expect(result).toEqual([]);
+    });
+
+    it("returns [] when the notePathToIRI dependency is absent (back-compat)", async () => {
+      const store = new InMemoryTripleStore();
+      await seedStatement(
+        store,
+        S1_PATH,
+        notePathToIRI(A_PATH),
+        RELATES_TO,
+        notePathToIRI(B_PATH),
+      );
+      const renderer = makeRenderer(store, () => true, undefined);
+
+      const result = await renderer.getReifiedRelationsGated(
+        createTestTFile(A_PATH),
+      );
+
+      expect(result).toEqual([]);
+    });
+
+    describe("isNonRelationPredicate", () => {
+      it("flags rdf:type, exo system + plumbing predicates; passes genuine relations", () => {
+        expect(isNonRelationPredicate(RDF_TYPE.value)).toBe(true);
+        expect(
+          isNonRelationPredicate(Namespace.EXO.term("Asset_label").value),
+        ).toBe(true);
+        expect(
+          isNonRelationPredicate(Namespace.EXO.term("Instance_class").value),
+        ).toBe(true);
+        expect(
+          isNonRelationPredicate(Namespace.EXO.term("Class_superClass").value),
+        ).toBe(true);
+        expect(
+          isNonRelationPredicate(Namespace.EXO.term("Statement_subject").value),
+        ).toBe(true);
+        expect(
+          isNonRelationPredicate(Namespace.RDFS.term("label").value),
+        ).toBe(true);
+        // Genuine user-defined relation predicates pass.
+        expect(isNonRelationPredicate(RELATES_TO.value)).toBe(false);
+        expect(
+          isNonRelationPredicate(Namespace.EMS.term("Effort_area").value),
+        ).toBe(false);
       });
     });
   });

--- a/packages/obsidian-plugin/tests/unit/RelationsRenderer.test.ts
+++ b/packages/obsidian-plugin/tests/unit/RelationsRenderer.test.ts
@@ -1521,6 +1521,20 @@ describe("RelationsRenderer", () => {
         expect(
           isNonRelationPredicate(Namespace.EMS.term("Effort_area").value),
         ).toBe(false);
+        // Genuine OBJECT exo:Asset_* relations MUST pass (the inline path
+        // surfaces them — dropping them would be an inline/reified asymmetry).
+        expect(
+          isNonRelationPredicate(Namespace.EXO.term("Asset_relates").value),
+        ).toBe(false);
+        expect(
+          isNonRelationPredicate(Namespace.EXO.term("Asset_prototype").value),
+        ).toBe(false);
+        expect(
+          isNonRelationPredicate(Namespace.EXO.term("Asset_createdBy").value),
+        ).toBe(false);
+        expect(
+          isNonRelationPredicate(Namespace.EXO.term("Asset_isDefinedBy").value),
+        ).toBe(false);
       });
     });
   });


### PR DESCRIPTION
## RFC 93a0b2ee Task 1.2 — triple-store ctor-DI + cold-start gate + predicate-whitelist (Phase 1 / C1 read-path)

Builds on Task 1.1 (#3736, `getReifiedRelations` helper). Wires the reified-relation read-path **infrastructure** into `RelationsRenderer` without touching `ExocortexPlugin.ts` / `main.ts` / `ExocortexPluginInterface` (design invariant — zero overlap with parallel sessions).

### What

- **`RelationsRenderer`** gains 3 NEW **optional** ctor params (back-compat — absent ⇒ reified sourcing skipped, behaves exactly as today): the live `ITripleStore`, an `isStoreReady` probe, and `notePathToIRI`.
- **`getReifiedRelationsGated(file)`** wraps the Task 1.1 helper:
  - **Cold-start gate** — gated on `isStoreReady()`; a partially-indexed store never yields an UNDER-count of reified relations (R4 / pattern #3587). Returns `[]` (never a partial set) while not ready; the post-refresh `autoRenderLayout()` re-render self-heals. `isStoreReady` absent ⇒ assume ready.
  - **Predicate-whitelist** (`isNonRelationPredicate`, denylist-by-pattern) — drops `rdf:type`, the `exo:Asset_*`/`Instance_`/`Class_`/`Statement_` system + plumbing predicates, and RDFS/OWL inferred noise; lets all user-defined relation predicates through.
- **`LazyAssetGraphLoader.notePathToIRI`** — new public delegate so the renderer keys an asset by the **same IRI form** the indexer emitted (same empty `subjectIriPrefix`; verified both the main indexer + lazy converters construct without a prefix override → identical forms). This is the wiring source at `UniversalLayoutRenderer.initializeRenderers()`.

Integration of these reified relations into `getAssetRelations` (dedup vs inline + `provenance` field) is **Task 1.3** — `getReifiedRelationsGated` has no caller in `getAssetRelations` yet (mirrors Task 1.1 shipping the helper at callers=0).

### Invariant respected

`git show --name-only` = 5 files, **none** is `main.ts` / `ExocortexPlugin.ts` / `ExocortexPluginInterface`. ctor-DI only.

### req-first SDD (RFC 0003)

`@req:1cbd6248-2e68-43d8-8f06-f35faf25fe9a` (exoas-exo-reqs, `Approved` while this PR is open → `Active` after merge). Binding: `unit`-class, P1.

**Revert-verified** over a real `InMemoryTripleStore` (not a stub): (a) deleting the cold-start gate → "not-ready → []" RED; (b) deleting the predicate-whitelist `.filter` → the two "filters non-relation predicate" cases RED. Restored → **GREEN 72/72** (incl. the pre-existing 63 RelationsRenderer cases). LazyAssetGraphLoader 31/31, UniversalLayoutRenderer 18/18, typecheck clean.

> Docker e2e on store-completeness (RFC P1 AC) is realized once Task 1.3 wires the full chain; per the no-local-Docker + multichild-panic constraints it is verified in CI, and the cold-start gate is revert-verified at unit level here.
