### PR TITLE
feat(plugin): Validate vault + Scaffold validation settings — desktop+mobile parity (M1.5)

### DIFF
--- a/packages/cli/src/commands/validate-vault.ts
+++ b/packages/cli/src/commands/validate-vault.ts
@@ -5,36 +5,11 @@ import {
   VaultCheckRunner,
   createDefaultCheckRegistry,
   KNOWN_CHECK_IDS,
-  extractAssetReference,
+  readEnabledCheckIds,
   type CheckContext,
   type IVaultCheckReader,
   type VaultAssetRecord,
 } from "@kitelev/exocortex-core";
-
-/**
- * Read the enabled validation-check set — the DATA half of the Homoiconicity
- * Invariant: WHICH checks run is configured by validation-check `setting__Setting`
- * instances (created by `scaffold validation-settings`), not by code. A
- * check-Setting carries `setting__Setting_key` (→ a check-key UID = the check-id)
- * and `setting__Setting_value` (boolean). Returns the truthy ones; only KNOWN
- * check-ids count, so unrelated setting__Setting instances never leak in.
- *
- * (Kept inline in the CLI for now: it re-uses KNOWN_CHECK_IDS +
- * extractAssetReference, both already in core's barrel, so it needs no new core
- * export. The shared home for plugin reuse is the M1.5-plugin follow-up.)
- */
-function readEnabledCheckIds(
-  assets: readonly VaultAssetRecord[],
-): string[] {
-  const enabled = new Set<string>();
-  for (const a of assets) {
-    const keyRef = extractAssetReference(a.frontmatter["setting__Setting_key"]);
-    if (!keyRef || !KNOWN_CHECK_IDS.has(keyRef)) continue;
-    const value = a.frontmatter["setting__Setting_value"];
-    if (value === true || value === "true") enabled.add(keyRef);
-  }
-  return [...enabled];
-}
 import { CachingNodeFsAdapter } from "../adapters/CachingNodeFsAdapter.js";
 import { ErrorHandler, type OutputFormat } from "../utils/ErrorHandler.js";
 import { VaultNotFoundError } from "../utils/errors/index.js";

--- a/packages/cli/tests/unit/commands/validate-schema.test.ts
+++ b/packages/cli/tests/unit/commands/validate-schema.test.ts
@@ -32,6 +32,7 @@ jest.unstable_mockModule("@kitelev/exocortex-core", () => ({
   createDefaultCheckRegistry: jest.fn(),
   KNOWN_CHECK_IDS: new Set<string>(),
   extractAssetReference: jest.fn(),
+  readEnabledCheckIds: jest.fn(() => []),
 }));
 
 // Mock fs-extra (CacheManager dependency)

--- a/packages/cli/tests/unit/commands/validate.test.ts
+++ b/packages/cli/tests/unit/commands/validate.test.ts
@@ -39,6 +39,7 @@ jest.unstable_mockModule("@kitelev/exocortex-core", () => ({
   createDefaultCheckRegistry: jest.fn(),
   KNOWN_CHECK_IDS: new Set<string>(),
   extractAssetReference: jest.fn(),
+  readEnabledCheckIds: jest.fn(() => []),
 }));
 
 // Mock fs-extra (CacheManager dependency)

--- a/packages/core/src/services/validation/index.ts
+++ b/packages/core/src/services/validation/index.ts
@@ -10,6 +10,7 @@ export * from "./types";
 export * from "./checkIds";
 export { CheckRegistry, createDefaultCheckRegistry } from "./CheckRegistry";
 export { VaultCheckRunner } from "./VaultCheckRunner";
+export { readEnabledCheckIds } from "./readEnabledCheckIds";
 export { uidUniquenessCheck } from "./checks/uidUniquenessCheck";
 export { coLocationCheck } from "./checks/coLocationCheck";
 export { shaclCheck } from "./checks/shaclCheck";

--- a/packages/core/src/services/validation/readEnabledCheckIds.ts
+++ b/packages/core/src/services/validation/readEnabledCheckIds.ts
@@ -1,0 +1,31 @@
+import { KNOWN_CHECK_IDS } from "./checkIds";
+import { extractAssetReference } from "../../utilities/extractAssetReference";
+import type { VaultAssetRecord } from "./types";
+
+/**
+ * Read the enabled validation-check set — the DATA half of the Homoiconicity
+ * Invariant (RFC f402002b): WHICH checks `Validate vault` runs is configured by
+ * validation-check `setting__Setting` instances (created by `scaffold
+ * validation-settings`), NOT by code.
+ *
+ * A check-Setting carries `setting__Setting_key` (a wikilink → a check-key UID
+ * that is also the check-id) and `setting__Setting_value` (boolean). This
+ * returns the check-ids whose value is truthy. Only KNOWN check-ids count, so
+ * unrelated `setting__Setting` instances never leak in.
+ *
+ * Shared by both readers (CLI fs-walk + plugin warm metadataCache) so the
+ * enabled-set semantics — an integrity-relevant decision — have a single home
+ * (M1.5; the CLI command and the plugin `Validate vault` command both call it).
+ */
+export function readEnabledCheckIds(
+  assets: readonly VaultAssetRecord[],
+): string[] {
+  const enabled = new Set<string>();
+  for (const a of assets) {
+    const keyRef = extractAssetReference(a.frontmatter["setting__Setting_key"]);
+    if (!keyRef || !KNOWN_CHECK_IDS.has(keyRef)) continue;
+    const value = a.frontmatter["setting__Setting_value"];
+    if (value === true || value === "true") enabled.add(keyRef);
+  }
+  return [...enabled];
+}

--- a/packages/core/tests/services/validation/readEnabledCheckIds.test.ts
+++ b/packages/core/tests/services/validation/readEnabledCheckIds.test.ts
@@ -1,0 +1,49 @@
+import {
+  readEnabledCheckIds,
+  CHECK_ID_UID_UNIQUENESS,
+  CHECK_ID_SHACL,
+  type VaultAssetRecord,
+} from "../../../src/index";
+
+function asset(fm: Record<string, unknown>): VaultAssetRecord {
+  return { path: "x.md", frontmatter: fm };
+}
+
+describe("readEnabledCheckIds (RFC f402002b — shared enabled-set reader)", () => {
+  it("returns the check-ids whose setting__Setting_value is truthy (true or \"true\")", () => {
+    const enabled = readEnabledCheckIds([
+      asset({ setting__Setting_key: `[[${CHECK_ID_UID_UNIQUENESS}]]`, setting__Setting_value: true }),
+      asset({ setting__Setting_key: `[[${CHECK_ID_SHACL}]]`, setting__Setting_value: "true" }),
+    ]);
+    expect(enabled.sort()).toEqual([CHECK_ID_UID_UNIQUENESS, CHECK_ID_SHACL].sort());
+  });
+
+  it("excludes settings whose value is falsy", () => {
+    const enabled = readEnabledCheckIds([
+      asset({ setting__Setting_key: `[[${CHECK_ID_UID_UNIQUENESS}]]`, setting__Setting_value: false }),
+      asset({ setting__Setting_key: `[[${CHECK_ID_SHACL}]]`, setting__Setting_value: "no" }),
+    ]);
+    expect(enabled).toEqual([]);
+  });
+
+  it("ignores unknown check-ids and assets with no setting__Setting_key (no leakage)", () => {
+    const enabled = readEnabledCheckIds([
+      asset({ setting__Setting_key: "[[not-a-check-id]]", setting__Setting_value: true }),
+      asset({ exo__Asset_label: "unrelated asset" }),
+      asset({ setting__Setting_key: `[[${CHECK_ID_UID_UNIQUENESS}]]`, setting__Setting_value: true }),
+    ]);
+    expect(enabled).toEqual([CHECK_ID_UID_UNIQUENESS]);
+  });
+
+  it("de-duplicates a check-id enabled by more than one setting", () => {
+    const enabled = readEnabledCheckIds([
+      asset({ setting__Setting_key: `[[${CHECK_ID_UID_UNIQUENESS}]]`, setting__Setting_value: true }),
+      asset({ setting__Setting_key: `[[${CHECK_ID_UID_UNIQUENESS}]]`, setting__Setting_value: true }),
+    ]);
+    expect(enabled).toEqual([CHECK_ID_UID_UNIQUENESS]);
+  });
+
+  it("returns an empty set for an empty vault", () => {
+    expect(readEnabledCheckIds([])).toEqual([]);
+  });
+});

--- a/packages/obsidian-plugin/src/ExocortexPlugin.ts
+++ b/packages/obsidian-plugin/src/ExocortexPlugin.ts
@@ -88,6 +88,11 @@ import {
   isLayoutFrontmatter,
 } from "./domain/layout";
 import { isCommandBindingFrontmatter } from "@kitelev/exocortex-core";
+import {
+  VaultCheckRunner,
+  createDefaultCheckRegistry,
+  readEnabledCheckIds,
+} from "@kitelev/exocortex-core";
 import { LayoutCodeBlockProcessor } from "./application/processors/LayoutCodeBlockProcessor";
 import { SPARQLApi } from "./application/api/SPARQLApi";
 import { ExocortexAPI } from "./application/api/ExocortexAPI";
@@ -191,6 +196,18 @@ import { registerExoSyncCommands } from "./infrastructure/adapters/registerExoSy
 import { QuarantineResolverCommands } from "./infrastructure/adapters/QuarantineResolverCommands";
 import { QuarantineResolverModal } from "./infrastructure/adapters/QuarantineResolverModal";
 import { registerQuarantineResolverCommand } from "./infrastructure/adapters/registerQuarantineResolverCommand";
+import {
+  PluginVaultCheckReader,
+  listOntologyCandidates,
+  type WarmVaultSource,
+  type OntologyChoice,
+} from "./infrastructure/adapters/PluginVaultCheckReader";
+import { ValidationScaffolder } from "./infrastructure/adapters/ValidationScaffolder";
+import { OntologyFuzzyModal } from "./infrastructure/adapters/OntologyFuzzyModal";
+import {
+  registerValidateVaultCommand,
+  registerScaffoldValidationCommand,
+} from "./infrastructure/adapters/registerValidationCommands";
 import { buildParityCheck } from "./infrastructure/adapters/ExoSyncParityFactory";
 import {
   buildQuarantineResolver,
@@ -3490,6 +3507,10 @@ export default class ExocortexPlugin extends Plugin {
     // «Exocortex: Resolve sync conflicts» (finding a0a3d1d6).
     registerQuarantineResolverCommand(this, quarantineResolverCommands);
 
+    // RFC f402002b M1.5 — «Validate vault» + «Scaffold validation settings»,
+    // registered on BOTH desktop AND mobile (Desktop↔Mobile Command Parity).
+    this.registerVaultValidationCommands();
+
     // RFC 22b50a17 Decision #6 — wipe-all switch cache clearing. RFC 0002 §3.2
     // (P3/P4) — de-jargon + destructive flag: «Clear switch cache (wipe-all)» →
     // «Reset profile cache (advanced)». Name sourced from the grooming contract.
@@ -3944,6 +3965,87 @@ export default class ExocortexPlugin extends Plugin {
    * (post git-elim), so this registers on both desktop + mobile (Desktop↔Mobile
    * Command Parity).
    */
+  /**
+   * RFC f402002b M1.5 — register the homoiconic vault-validation commands on
+   * BOTH desktop AND mobile (⛔ Desktop↔Mobile Command Parity — no
+   * `Platform.isMobile` gate). The reader is mobile-portable (warm
+   * `metadataCache`, no per-file re-read) and SHACL runs over the already-built
+   * warm triple store (the plugin's advantage over the CLI); the scaffold writes
+   * through `vault.adapter` (no Node `fs`). The enabled-set is DATA
+   * (`readEnabledCheckIds` over validation-check `setting__Setting` instances),
+   * not code (Homoiconicity Invariant).
+   */
+  private registerVaultValidationCommands(): void {
+    const buildWarmSource = (): WarmVaultSource => {
+      const files = this.app.vault.getMarkdownFiles();
+      const byPath = new Map(files.map((f) => [f.path, f] as const));
+      return {
+        listMarkdownPaths: () => files.map((f) => f.path),
+        frontmatterOf: (path) => {
+          const file = byPath.get(path);
+          if (!file) return undefined;
+          return (
+            (this.app.metadataCache.getFileCache(file)?.frontmatter as
+              | Record<string, unknown>
+              | undefined) ?? undefined
+          );
+        },
+      };
+    };
+
+    registerValidateVaultCommand(this, {
+      runValidation: async () => {
+        // SHACL/DAG runners deferred to M2 (parity with the CLI) → portable
+        // checks run on mobile; enabling SHACL/DAG is reported fail-loud.
+        const reader = new PluginVaultCheckReader(buildWarmSource());
+        const ctx = await reader.read();
+        const enabled = readEnabledCheckIds(ctx.assets);
+        return new VaultCheckRunner(createDefaultCheckRegistry()).runWithContext(
+          ctx,
+          enabled,
+        );
+      },
+      notify: (message) => this.notifier.info(message),
+    });
+
+    const scaffolder = new ValidationScaffolder(
+      {
+        exists: (path) => this.app.vault.adapter.exists(path),
+        write: (path, content) => this.app.vault.adapter.write(path, content),
+      },
+      () => crypto.randomUUID(),
+      () => new Date().toISOString(),
+    );
+
+    registerScaffoldValidationCommand(this, {
+      pickOntology: () => {
+        const files = this.app.vault.getMarkdownFiles();
+        const assets = files.map((f) => ({
+          path: f.path,
+          frontmatter: (this.app.metadataCache.getFileCache(f)?.frontmatter ??
+            {}) as Record<string, unknown>,
+        }));
+        const candidates = listOntologyCandidates(assets);
+        if (candidates.length === 0) {
+          this.notifier.info(
+            "Scaffold validation settings: no ontology found in this vault to scaffold into.",
+          );
+          return Promise.resolve(null);
+        }
+        return new Promise<OntologyChoice | null>((resolve) => {
+          new OntologyFuzzyModal(
+            this.app,
+            candidates,
+            "Choose ontology to scaffold validation settings into",
+            resolve,
+          ).open();
+        });
+      },
+      scaffold: (choice) => scaffolder.scaffold(choice.uid, choice.folder),
+      notify: (message) => this.notifier.info(message),
+    });
+  }
+
   private registerUnmountCommand(
     restMount: RestAssetSpaceMount,
     switchMgr: ProfileApplyManager,

--- a/packages/obsidian-plugin/src/infrastructure/adapters/OntologyFuzzyModal.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/OntologyFuzzyModal.ts
@@ -1,0 +1,56 @@
+import { App, FuzzySuggestModal } from "obsidian";
+
+import type { OntologyChoice } from "./PluginVaultCheckReader";
+
+/**
+ * OntologyFuzzyModal — `FuzzySuggestModal` for `Scaffold validation settings`'s
+ * ontology choice (RFC f402002b, M1.5). Resolves the caller's Promise with the
+ * chosen ontology, or `null` when the user dismisses without selecting.
+ *
+ * Uses the deferred-microtask resolution contract proven necessary by the
+ * picker-no-op bug (Issue #3561, see {@link ProfileFuzzyModal}): Obsidian's real
+ * `SuggestModal.selectSuggestion` fires `close()` (→ `onClose`) BEFORE
+ * `onChooseItem`, both synchronously. So `onChooseItem` only RECORDS the choice;
+ * `onClose` schedules the single resolution on a microtask (queued before
+ * `super.onClose()` so a teardown throw cannot strand the awaiter). The
+ * microtask runs after the synchronous selection stack, so a real selection
+ * resolves with the item and a cancel resolves with `null` — order-independent.
+ */
+export class OntologyFuzzyModal extends FuzzySuggestModal<OntologyChoice> {
+  private chosen: OntologyChoice | null = null;
+  private settled = false;
+  private readonly resolveChoice: (value: OntologyChoice | null) => void;
+
+  constructor(
+    app: App,
+    private readonly options: OntologyChoice[],
+    title: string,
+    resolve: (value: OntologyChoice | null) => void,
+  ) {
+    super(app);
+    this.resolveChoice = resolve;
+    this.setPlaceholder(title);
+  }
+
+  getItems(): OntologyChoice[] {
+    return this.options;
+  }
+
+  /** Human label, never the UID (P10). Folder shown so duplicate labels disambiguate. */
+  getItemText(item: OntologyChoice): string {
+    return item.folder.length > 0 ? `${item.label} — ${item.folder}` : item.label;
+  }
+
+  onChooseItem(item: OntologyChoice): void {
+    // Record only — resolution happens in onClose's deferred microtask.
+    this.chosen = item;
+  }
+
+  override onClose(): void {
+    if (!this.settled) {
+      this.settled = true;
+      queueMicrotask(() => this.resolveChoice(this.chosen));
+    }
+    super.onClose();
+  }
+}

--- a/packages/obsidian-plugin/src/infrastructure/adapters/PluginVaultCheckReader.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/PluginVaultCheckReader.ts
@@ -1,0 +1,112 @@
+/**
+ * Plugin-side vault-validation wiring (RFC f402002b, M1.5 — Desktop↔Mobile
+ * parity). The plugin reads the warm `metadataCache` (NEVER re-reading +
+ * re-parsing each file — the "iPhone reindex 10 minutes" anti-pattern). Both
+ * desktop AND mobile use exactly this path; there is no `Platform.isMobile`
+ * gate.
+ *
+ * SHACL/DAG runner thunks are deferred to M2 (the same unification the CLI
+ * defers — `CliFsCheckReader` provides neither), so the portable checks
+ * (uid-uniqueness, co-location) run on mobile from the warm asset array, and
+ * enabling SHACL/DAG is reported FAIL-LOUD (never a silent skip). The optional
+ * `shaclRunner` constructor seam is where M2 wires the warm-store SHACL runner.
+ *
+ * The units here are pure over structural slices (no `obsidian` runtime import)
+ * so they are unit-testable; `ExocortexPlugin` injects the concrete Obsidian
+ * `vault`/`metadataCache` slices at onload.
+ */
+import {
+  readUid,
+  readIsDefinedByRef,
+  type CheckContext,
+  type IVaultCheckReader,
+  type ShaclViolationLike,
+  type VaultAssetRecord,
+} from "@kitelev/exocortex-core";
+
+/**
+ * Structural slice of the Obsidian vault + metadataCache the reader needs.
+ * `listMarkdownPaths` ← `vault.getMarkdownFiles().map(f => f.path)`;
+ * `frontmatterOf` ← `metadataCache.getFileCache(file)?.frontmatter` (warm).
+ */
+export interface WarmVaultSource {
+  listMarkdownPaths(): readonly string[];
+  frontmatterOf(path: string): Readonly<Record<string, unknown>> | undefined;
+}
+
+/**
+ * Plugin warm-cache check-reader (RFC f402002b, M1.5). One `read()` builds the
+ * asset array from the warm metadataCache; the portable checks (uid-uniqueness,
+ * co-location) run from it with no platform machinery — that IS the
+ * "validate on iPhone" value.
+ *
+ * SHACL + DAG runner thunks are deferred to M2 (the same unification the CLI
+ * defers — `CliFsCheckReader` provides neither), so enabling either is reported
+ * FAIL-LOUD, never a silent skip. The optional `shaclRunner` constructor arg is
+ * the seam where M2 wires the warm-store SHACL runner (the warm triple store
+ * holds DOMAIN triples, so that wiring needs the same domain→algebra conversion
+ * the CLI's `runShapesValidation` performs — promoted to a shared home in M2).
+ */
+export class PluginVaultCheckReader implements IVaultCheckReader {
+  constructor(
+    private readonly source: WarmVaultSource,
+    private readonly shaclRunner?: () => Promise<readonly ShaclViolationLike[]>,
+  ) {}
+
+  async read(): Promise<CheckContext> {
+    const assets: VaultAssetRecord[] = [];
+    for (const path of this.source.listMarkdownPaths()) {
+      const frontmatter = this.source.frontmatterOf(path);
+      if (frontmatter === undefined) continue; // no cache entry yet → skip (warm-only)
+      assets.push({ path, frontmatter });
+    }
+    return { assets, runShacl: this.shaclRunner };
+  }
+}
+
+/** A scaffold target: an ontology (co-location anchor) + the folder its assets live in. */
+export interface OntologyChoice {
+  readonly uid: string;
+  readonly label: string;
+  readonly folder: string;
+}
+
+/**
+ * List candidate ontologies for `Scaffold validation settings`: assets that
+ * anchor a co-location group — i.e. are the `exo__Asset_isDefinedBy` target of
+ * at least one asset present in the vault. Each resolves to its own
+ * `{uid, label, folder}` so the scaffold writes the 4 check-Settings co-located
+ * in that ontology's folder (the co-location invariant). Pure over the warm
+ * asset array.
+ */
+export function listOntologyCandidates(
+  assets: readonly VaultAssetRecord[],
+): OntologyChoice[] {
+  const byUid = new Map<string, { label: string; folder: string }>();
+  for (const a of assets) {
+    const uid = readUid(a.frontmatter);
+    if (uid === null) continue;
+    const label =
+      typeof a.frontmatter["exo__Asset_label"] === "string"
+        ? (a.frontmatter["exo__Asset_label"] as string)
+        : uid;
+    const slash = a.path.lastIndexOf("/");
+    const folder = slash >= 0 ? a.path.slice(0, slash) : "";
+    byUid.set(uid, { label, folder });
+  }
+
+  const anchorUids = new Set<string>();
+  for (const a of assets) {
+    const ref = readIsDefinedByRef(a.frontmatter);
+    if (ref !== null) anchorUids.add(ref);
+  }
+
+  const out: OntologyChoice[] = [];
+  for (const uid of anchorUids) {
+    const meta = byUid.get(uid);
+    if (meta === undefined) continue; // unresolvable / cross-vault anchor → not a local scaffold target
+    out.push({ uid, label: meta.label, folder: meta.folder });
+  }
+  out.sort((a, b) => a.label.localeCompare(b.label));
+  return out;
+}

--- a/packages/obsidian-plugin/src/infrastructure/adapters/ValidationScaffolder.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/ValidationScaffolder.ts
@@ -1,0 +1,108 @@
+/**
+ * Plugin-side `Scaffold validation settings` writer (RFC f402002b, M1.5 —
+ * Desktop↔Mobile parity). Writes the 4 validation-check `setting__Setting`
+ * instances co-located in a chosen ontology's folder, giving `Validate vault`
+ * an enabled-set to read. Mirrors the CLI `scaffold validation-settings`
+ * defaults + asset template byte-for-byte, but writes through a structural
+ * `ScaffoldFileWriter` (Obsidian `vault.adapter.write` on both desktop AND
+ * mobile — no Node `fs`, no platform gate).
+ *
+ * Pure over its injected deps (writer / uid-source / clock) so the defaults +
+ * template are unit-testable without Obsidian.
+ */
+import {
+  CHECK_ID_SHACL,
+  CHECK_ID_CO_LOCATION,
+  CHECK_ID_UID_UNIQUENESS,
+  CHECK_ID_DAG_ONTOLOGY_IMPORTS,
+} from "@kitelev/exocortex-core";
+
+/** setting__Setting class UID (exoas-exo/setting/, RFC f402002b M1.1). */
+const SETTING_CLASS_UID = "35cf35fb-935f-4d35-a150-939f29109aec";
+
+/**
+ * The M1 scaffold default: uid-uniqueness ON, the rest OFF. uid-uniqueness is
+ * the cheapest, always-safe, fully-portable integrity check (runs on mobile);
+ * SHACL/co-location/DAG are opt-in.
+ */
+export const SCAFFOLD_DEFAULTS: ReadonlyArray<{
+  checkId: string;
+  label: string;
+  value: boolean;
+}> = [
+  { checkId: CHECK_ID_UID_UNIQUENESS, label: "uid-uniqueness", value: true },
+  { checkId: CHECK_ID_CO_LOCATION, label: "co-location", value: false },
+  { checkId: CHECK_ID_SHACL, label: "shacl", value: false },
+  { checkId: CHECK_ID_DAG_ONTOLOGY_IMPORTS, label: "dag-ontology-imports", value: false },
+];
+
+function settingAsset(
+  uid: string,
+  ontologyUid: string,
+  checkId: string,
+  label: string,
+  value: boolean,
+  nowIso: string,
+): string {
+  return `---
+exo__Asset_uid: ${uid}
+exo__Asset_isDefinedBy: "[[${ontologyUid}]]"
+exo__Asset_createdAt: ${nowIso}
+exo__Instance_class:
+  - "[[${SETTING_CLASS_UID}]]"
+exo__Asset_label: "Validation check: ${label} (${value ? "enabled" : "disabled"})"
+setting__Setting_key: "[[${checkId}]]"
+setting__Setting_value: ${value}
+---
+
+# Validation check: ${label}
+
+Homoiconic validation-check setting (RFC f402002b, M1.5). \`Exocortex: Validate vault\` reads this instance's \`setting__Setting_value\` to decide whether to run the **${label}** check (key \`[[${checkId}]]\`). Scaffolded default — edit \`setting__Setting_value\` to toggle.
+`;
+}
+
+/** Structural file-writer slice (Obsidian `vault.adapter.write`; mobile-portable). */
+export interface ScaffoldFileWriter {
+  exists(path: string): Promise<boolean>;
+  write(path: string, content: string): Promise<void>;
+}
+
+export interface ScaffoldedSetting {
+  readonly path: string;
+  readonly checkId: string;
+  readonly value: boolean;
+}
+
+/**
+ * Writes the 4 validation-check `setting__Setting` instances co-located in the
+ * chosen ontology's folder. `newUid` is injected (Obsidian wires
+ * `crypto.randomUUID` — SEC-001: never `Math.random`); `nowIso` is injected so
+ * the template is deterministic under test.
+ */
+export class ValidationScaffolder {
+  constructor(
+    private readonly writer: ScaffoldFileWriter,
+    private readonly newUid: () => string,
+    private readonly nowIso: () => string,
+  ) {}
+
+  async scaffold(
+    ontologyUid: string,
+    ontologyFolder: string,
+  ): Promise<ScaffoldedSetting[]> {
+    const out: ScaffoldedSetting[] = [];
+    for (const d of SCAFFOLD_DEFAULTS) {
+      const uid = this.newUid();
+      const path = ontologyFolder.length > 0 ? `${ontologyFolder}/${uid}.md` : `${uid}.md`;
+      // Defensive: never clobber an existing asset (a fresh UID collision is
+      // astronomically unlikely, but writing is a mutation — skip if present).
+      if (await this.writer.exists(path)) continue;
+      await this.writer.write(
+        path,
+        settingAsset(uid, ontologyUid, d.checkId, d.label, d.value, this.nowIso()),
+      );
+      out.push({ path, checkId: d.checkId, value: d.value });
+    }
+    return out;
+  }
+}

--- a/packages/obsidian-plugin/src/infrastructure/adapters/registerValidationCommands.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/registerValidationCommands.ts
@@ -1,0 +1,115 @@
+/**
+ * Palette registration for the M1.5 vault-validation commands (RFC f402002b):
+ *   - «Exocortex: Validate vault»             (id `validate-vault`)
+ *   - «Exocortex: Scaffold validation settings» (id `scaffold-validation-settings`)
+ *
+ * ⛔ Desktop↔Mobile Command Parity invariant (CLAUDE.md): BOTH commands register
+ * UNCONDITIONALLY — there is NO `Platform.isMobile` gate. The plugin reader is
+ * mobile-portable (warm metadataCache) and the scaffold writes via
+ * `vault.adapter` (no Node `fs`), so «Validate vault» on iPhone IS the core M1
+ * value. Command ids are byte-exact (Obsidian persists hotkeys by id).
+ *
+ * The registrars take high-level thunks (no `obsidian` runtime import) so they
+ * are unit-testable; `ExocortexPlugin` injects the warm reader / scaffolder /
+ * picker / Notice slices at onload.
+ */
+import type {
+  ScaffoldedSetting,
+} from "./ValidationScaffolder";
+import type { OntologyChoice } from "./PluginVaultCheckReader";
+import type { VaultCheckReport } from "@kitelev/exocortex-core";
+
+/** Structural slice of `Plugin.addCommand` (no `obsidian` runtime import). */
+export interface ValidationCommandRegistrar {
+  addCommand(command: { id: string; name: string; callback: () => void }): unknown;
+}
+
+export interface ValidateVaultDeps {
+  /** Build the warm context + run the enabled-set; the report is what we render. */
+  runValidation: () => Promise<VaultCheckReport>;
+  /** Surface the result to the user (Obsidian `new Notice`). */
+  notify: (message: string) => void;
+}
+
+export interface ScaffoldValidationDeps {
+  /** Open the ontology picker; resolves the chosen ontology or null on cancel. */
+  pickOntology: () => Promise<OntologyChoice | null>;
+  /** Write the 4 check-Settings co-located in the chosen ontology's folder. */
+  scaffold: (choice: OntologyChoice) => Promise<ScaffoldedSetting[]>;
+  notify: (message: string) => void;
+}
+
+/** Human-readable summary of a vault-check run for a Notice. */
+export function formatVaultCheckReport(report: VaultCheckReport): string {
+  if (report.results.length === 0) {
+    return "Validate vault: no checks enabled. Run «Scaffold validation settings» (or enable some) first.";
+  }
+  const lines = report.results.map((r) => {
+    if (r.status === "pass") return `✅ ${r.label}`;
+    if (r.status === "error")
+      return `🟥 ${r.label}: ${r.errorMessage ?? "errored"}`;
+    return `❌ ${r.label}: ${r.findings.length} violation(s)`;
+  });
+  const head = report.ok
+    ? `Validate vault: all ${report.results.length} check(s) passed (${report.totalAssets} assets)`
+    : `Validate vault: FAILED (${report.totalAssets} assets)`;
+  return [head, ...lines].join("\n");
+}
+
+/** Human-readable summary of a scaffold run for a Notice. */
+export function formatScaffoldResult(
+  choice: OntologyChoice,
+  created: ScaffoldedSetting[],
+): string {
+  if (created.length === 0) {
+    return `Scaffold validation settings: nothing written for «${choice.label}» (settings already exist).`;
+  }
+  const enabled = created.filter((c) => c.value).length;
+  return `Scaffold validation settings: wrote ${created.length} check-setting(s) in «${choice.label}» (${enabled} enabled by default). Run «Validate vault» to use them.`;
+}
+
+export function registerValidateVaultCommand(
+  plugin: ValidationCommandRegistrar,
+  deps: ValidateVaultDeps,
+): void {
+  plugin.addCommand({
+    id: "validate-vault",
+    name: "Validate vault",
+    callback: () => {
+      void (async () => {
+        try {
+          const report = await deps.runValidation();
+          deps.notify(formatVaultCheckReport(report));
+        } catch (err) {
+          deps.notify(
+            `Validate vault: errored — ${err instanceof Error ? err.message : String(err)}`,
+          );
+        }
+      })();
+    },
+  });
+}
+
+export function registerScaffoldValidationCommand(
+  plugin: ValidationCommandRegistrar,
+  deps: ScaffoldValidationDeps,
+): void {
+  plugin.addCommand({
+    id: "scaffold-validation-settings",
+    name: "Scaffold validation settings",
+    callback: () => {
+      void (async () => {
+        try {
+          const choice = await deps.pickOntology();
+          if (choice === null) return; // user cancelled the picker
+          const created = await deps.scaffold(choice);
+          deps.notify(formatScaffoldResult(choice, created));
+        } catch (err) {
+          deps.notify(
+            `Scaffold validation settings: errored — ${err instanceof Error ? err.message : String(err)}`,
+          );
+        }
+      })();
+    },
+  });
+}

--- a/packages/obsidian-plugin/tests/unit/validation/OntologyFuzzyModal.test.ts
+++ b/packages/obsidian-plugin/tests/unit/validation/OntologyFuzzyModal.test.ts
@@ -1,0 +1,52 @@
+/**
+ * OntologyFuzzyModal tests (RFC f402002b, M1.5). Verifies the deferred-microtask
+ * resolution contract (picker-no-op bug #3561): on a real selection Obsidian
+ * fires onClose() BEFORE onChooseItem(), so onChooseItem must only RECORD and
+ * onClose must defer the single resolution. A selection resolves the item; a
+ * dismissal (onClose with no choice) resolves null.
+ */
+import { App } from "obsidian";
+import { OntologyFuzzyModal } from "../../../src/infrastructure/adapters/OntologyFuzzyModal";
+import type { OntologyChoice } from "../../../src/infrastructure/adapters/PluginVaultCheckReader";
+
+const flush = (): Promise<void> => new Promise((r) => setTimeout(r, 0));
+
+const OPTS: OntologyChoice[] = [
+  { uid: "a", label: "$exo", folder: "assetspaces/exo/exo" },
+  { uid: "b", label: "$ems", folder: "assetspaces/ems/ems" },
+];
+
+describe("OntologyFuzzyModal", () => {
+  it("resolves with the chosen ontology — real Obsidian order: onClose() then onChooseItem()", async () => {
+    let resolved: OntologyChoice | null | undefined;
+    const modal = new OntologyFuzzyModal(
+      new App(),
+      OPTS,
+      "Choose ontology",
+      (v) => {
+        resolved = v;
+      },
+    );
+    // Mirror SuggestModal.selectSuggestion: close() (→ onClose) BEFORE onChooseItem.
+    modal.onClose();
+    modal.onChooseItem(OPTS[1]);
+    await flush();
+    expect(resolved).toEqual(OPTS[1]);
+  });
+
+  it("resolves null when dismissed without a choice", async () => {
+    let resolved: OntologyChoice | null | undefined;
+    const modal = new OntologyFuzzyModal(new App(), OPTS, "Choose ontology", (v) => {
+      resolved = v;
+    });
+    modal.onClose();
+    await flush();
+    expect(resolved).toBeNull();
+  });
+
+  it("getItemText shows the human label (never the UID) + folder for disambiguation", () => {
+    const modal = new OntologyFuzzyModal(new App(), OPTS, "t", () => {});
+    expect(modal.getItemText(OPTS[0])).toBe("$exo — assetspaces/exo/exo");
+    expect(modal.getItemText(OPTS[0])).not.toContain("uid");
+  });
+});

--- a/packages/obsidian-plugin/tests/unit/validation/PluginVaultCheckReader.test.ts
+++ b/packages/obsidian-plugin/tests/unit/validation/PluginVaultCheckReader.test.ts
@@ -1,0 +1,90 @@
+/**
+ * PluginVaultCheckReader + listOntologyCandidates tests (RFC f402002b, M1.5
+ * plugin half). The reader builds the warm asset array from the metadataCache
+ * source (skipping paths with no cache entry) and omits the SHACL/DAG runner
+ * thunks (M2-deferred → enabling them is fail-loud, not a silent skip).
+ */
+import {
+  PluginVaultCheckReader,
+  listOntologyCandidates,
+  type WarmVaultSource,
+} from "../../../src/infrastructure/adapters/PluginVaultCheckReader";
+import type { VaultAssetRecord } from "@kitelev/exocortex-core";
+
+function source(
+  fm: Record<string, Record<string, unknown> | undefined>,
+): WarmVaultSource {
+  return {
+    listMarkdownPaths: () => Object.keys(fm),
+    frontmatterOf: (p) => fm[p],
+  };
+}
+
+describe("PluginVaultCheckReader", () => {
+  it("builds the warm asset array from the metadataCache source, skipping no-cache paths, and omits SHACL/DAG runners — @req:807a8a6d-95d4-49a3-90b0-5e2b8d330d32", async () => {
+    const reader = new PluginVaultCheckReader(
+      source({
+        "a/x.md": { exo__Asset_uid: "x" },
+        "a/y.md": undefined, // no cache entry yet → skipped (warm-only)
+        "a/z.md": { exo__Asset_uid: "z" },
+      }),
+    );
+    const ctx = await reader.read();
+
+    expect(ctx.assets.map((a) => a.path)).toEqual(["a/x.md", "a/z.md"]);
+    // SHACL/DAG deferred to M2 → no thunks → the runner reports them fail-loud
+    expect(ctx.runShacl).toBeUndefined();
+    expect(ctx.runDag).toBeUndefined();
+  });
+
+  it("passes through an injected SHACL runner seam when provided (M2 wiring point)", async () => {
+    const runShacl = jest.fn().mockResolvedValue([]);
+    const reader = new PluginVaultCheckReader(source({}), runShacl);
+    const ctx = await reader.read();
+    expect(ctx.runShacl).toBe(runShacl);
+  });
+});
+
+describe("listOntologyCandidates", () => {
+  const assets: VaultAssetRecord[] = [
+    // the ontology anchor (self-referential isDefinedBy)
+    {
+      path: "assetspaces/exo/exo/onto.md",
+      frontmatter: {
+        exo__Asset_uid: "onto-1",
+        exo__Asset_label: "$exo",
+        exo__Asset_isDefinedBy: "[[onto-1]]",
+      },
+    },
+    // an instance pointing at the anchor
+    {
+      path: "assetspaces/exo/exo/inst.md",
+      frontmatter: {
+        exo__Asset_uid: "inst-1",
+        exo__Asset_label: "Some class",
+        exo__Asset_isDefinedBy: "[[onto-1]]",
+      },
+    },
+    // an instance pointing at an UNRESOLVABLE (cross-vault) anchor → not a candidate
+    {
+      path: "assetspaces/x/y/orphan.md",
+      frontmatter: {
+        exo__Asset_uid: "orphan-1",
+        exo__Asset_label: "Orphan",
+        exo__Asset_isDefinedBy: "[[missing-anchor]]",
+      },
+    },
+  ];
+
+  it("lists ontologies that anchor a co-location group (resolvable isDefinedBy targets) with label + folder — @req:0b7ce59c-0486-45b7-94a4-66f266484b1f", () => {
+    const candidates = listOntologyCandidates(assets);
+    expect(candidates).toEqual([
+      { uid: "onto-1", label: "$exo", folder: "assetspaces/exo/exo" },
+    ]);
+  });
+
+  it("returns no candidates when nothing resolves (e.g. all anchors cross-vault)", () => {
+    const candidates = listOntologyCandidates([assets[2]]);
+    expect(candidates).toEqual([]);
+  });
+});

--- a/packages/obsidian-plugin/tests/unit/validation/ValidationScaffolder.test.ts
+++ b/packages/obsidian-plugin/tests/unit/validation/ValidationScaffolder.test.ts
@@ -1,0 +1,81 @@
+/**
+ * ValidationScaffolder tests (RFC f402002b, M1.5 plugin half). The scaffold
+ * writes exactly the 4 validation-check setting__Setting instances, co-located
+ * in the chosen ontology's folder, with the M1 default (uid-uniqueness ON, rest
+ * OFF). The `trueCount === 1` assertion IS the revert-verify: flipping a second
+ * default to true breaks it.
+ */
+import {
+  ValidationScaffolder,
+  SCAFFOLD_DEFAULTS,
+  type ScaffoldFileWriter,
+} from "../../../src/infrastructure/adapters/ValidationScaffolder";
+import { CHECK_ID_UID_UNIQUENESS } from "@kitelev/exocortex-core";
+
+function fakeWriter(): { writer: ScaffoldFileWriter; written: Map<string, string> } {
+  const written = new Map<string, string>();
+  return {
+    written,
+    writer: {
+      exists: (path) => Promise.resolve(written.has(path)),
+      write: (path, content) => {
+        written.set(path, content);
+        return Promise.resolve();
+      },
+    },
+  };
+}
+
+describe("ValidationScaffolder", () => {
+  const ONTOLOGY_UID = "abcd1234-0000-0000-0000-000000000000";
+  const FOLDER = "assetspaces/kitelev/exoas-exo/exo";
+
+  it("writes the 4 check-settings co-located in the chosen folder, exactly one true (uid-uniqueness), isDefinedBy=ontology — @req:0b7ce59c-0486-45b7-94a4-66f266484b1f", async () => {
+    const { writer, written } = fakeWriter();
+    let n = 0;
+    const scaffolder = new ValidationScaffolder(
+      writer,
+      () => `uid-${n++}`,
+      () => "2026-06-27T16:20:00+05:00",
+    );
+
+    const created = await scaffolder.scaffold(ONTOLOGY_UID, FOLDER);
+
+    expect(created).toHaveLength(4);
+    // co-located: every file under the chosen folder
+    for (const c of created) expect(c.path.startsWith(`${FOLDER}/`)).toBe(true);
+
+    // exactly one default is enabled, and it is uid-uniqueness (revert-verify anchor)
+    const trueCount = created.filter((c) => c.value).length;
+    expect(trueCount).toBe(1);
+    const enabled = created.find((c) => c.value);
+    expect(enabled?.checkId).toBe(CHECK_ID_UID_UNIQUENESS);
+
+    // every written asset carries the chosen ontology as isDefinedBy + the setting class
+    for (const content of written.values()) {
+      expect(content).toContain(`exo__Asset_isDefinedBy: "[[${ONTOLOGY_UID}]]"`);
+      expect(content).toContain(`"[[35cf35fb-935f-4d35-a150-939f29109aec]]"`);
+      expect(content).toMatch(/setting__Setting_key: "\[\[[a-f0-9-]+\]\]"/);
+    }
+  });
+
+  it("the M1 default is uid-uniqueness only (guards the safe default)", () => {
+    const enabled = SCAFFOLD_DEFAULTS.filter((d) => d.value);
+    expect(enabled).toHaveLength(1);
+    expect(enabled[0].checkId).toBe(CHECK_ID_UID_UNIQUENESS);
+  });
+
+  it("never clobbers an existing asset (skips when the path already exists)", async () => {
+    const { writer, written } = fakeWriter();
+    written.set(`${FOLDER}/uid-0.md`, "PRE-EXISTING");
+    const scaffolder = new ValidationScaffolder(
+      writer,
+      () => "uid-0", // collide on the first write only
+      () => "2026-06-27T16:20:00+05:00",
+    );
+    const created = await scaffolder.scaffold(ONTOLOGY_UID, FOLDER);
+    // the colliding write is skipped → fewer than 4, and the pre-existing file is untouched
+    expect(written.get(`${FOLDER}/uid-0.md`)).toBe("PRE-EXISTING");
+    expect(created.every((c) => c.path !== `${FOLDER}/uid-0.md`)).toBe(true);
+  });
+});

--- a/packages/obsidian-plugin/tests/unit/validation/registerValidationCommands.test.ts
+++ b/packages/obsidian-plugin/tests/unit/validation/registerValidationCommands.test.ts
@@ -1,0 +1,147 @@
+/**
+ * registerValidationCommands contract tests (RFC f402002b, M1.5 plugin half).
+ * Command ids MUST stay byte-exact (Obsidian persists hotkeys by id) and the
+ * callbacks MUST drive the injected thunks. Both commands register
+ * UNCONDITIONALLY — there is no Platform.isMobile gate (Desktop↔Mobile parity).
+ */
+import {
+  registerValidateVaultCommand,
+  registerScaffoldValidationCommand,
+  formatVaultCheckReport,
+  formatScaffoldResult,
+} from "../../../src/infrastructure/adapters/registerValidationCommands";
+import type { OntologyChoice } from "../../../src/infrastructure/adapters/PluginVaultCheckReader";
+import type { VaultCheckReport } from "@kitelev/exocortex-core";
+
+const flush = (): Promise<void> => new Promise((r) => setTimeout(r, 0));
+
+interface Registered {
+  id: string;
+  name: string;
+  callback: () => void;
+}
+function fakeRegistrar(): { plugin: { addCommand: (c: Registered) => void }; registered: Registered[] } {
+  const registered: Registered[] = [];
+  return {
+    plugin: { addCommand: (c: Registered) => registered.push(c) },
+    registered,
+  };
+}
+
+const PASS_REPORT: VaultCheckReport = {
+  totalAssets: 3,
+  ok: true,
+  results: [{ checkId: "k", label: "uid-uniqueness", status: "pass", findings: [] }],
+};
+
+describe("registerValidateVaultCommand", () => {
+  it("registers «Validate vault» with the stable id and renders the report — @req:807a8a6d-95d4-49a3-90b0-5e2b8d330d32", async () => {
+    const { plugin, registered } = fakeRegistrar();
+    const runValidation = jest.fn().mockResolvedValue(PASS_REPORT);
+    const notify = jest.fn();
+
+    registerValidateVaultCommand(plugin, { runValidation, notify });
+
+    expect(registered).toHaveLength(1);
+    expect(registered[0].id).toBe("validate-vault");
+    expect(registered[0].name).toBe("Validate vault");
+
+    registered[0].callback();
+    await flush();
+    expect(runValidation).toHaveBeenCalledTimes(1);
+    expect(notify).toHaveBeenCalledTimes(1);
+    expect(notify.mock.calls[0][0]).toContain("uid-uniqueness");
+  });
+
+  it("notifies fail-loud when runValidation throws (never swallows) — @req:807a8a6d-95d4-49a3-90b0-5e2b8d330d32", async () => {
+    const { plugin, registered } = fakeRegistrar();
+    const notify = jest.fn();
+    registerValidateVaultCommand(plugin, {
+      runValidation: jest.fn().mockRejectedValue(new Error("store not ready")),
+      notify,
+    });
+    registered[0].callback();
+    await flush();
+    expect(notify.mock.calls[0][0]).toContain("store not ready");
+  });
+});
+
+describe("registerScaffoldValidationCommand", () => {
+  const ONTOLOGY: OntologyChoice = { uid: "onto-uid", label: "$exo", folder: "assetspaces/exo/exo" };
+
+  it("registers «Scaffold validation settings» with the stable id and scaffolds the picked ontology — @req:0b7ce59c-0486-45b7-94a4-66f266484b1f", async () => {
+    const { plugin, registered } = fakeRegistrar();
+    const pickOntology = jest.fn().mockResolvedValue(ONTOLOGY);
+    const scaffold = jest
+      .fn()
+      .mockResolvedValue([{ path: "p/u.md", checkId: "k", value: true }]);
+    const notify = jest.fn();
+
+    registerScaffoldValidationCommand(plugin, { pickOntology, scaffold, notify });
+
+    expect(registered).toHaveLength(1);
+    expect(registered[0].id).toBe("scaffold-validation-settings");
+    expect(registered[0].name).toBe("Scaffold validation settings");
+
+    registered[0].callback();
+    await flush();
+    expect(pickOntology).toHaveBeenCalledTimes(1);
+    expect(scaffold).toHaveBeenCalledWith(ONTOLOGY);
+    expect(notify).toHaveBeenCalledTimes(1);
+  });
+
+  it("writes NOTHING when the picker is cancelled (null) — @req:0b7ce59c-0486-45b7-94a4-66f266484b1f", async () => {
+    const { plugin, registered } = fakeRegistrar();
+    const scaffold = jest.fn();
+    const notify = jest.fn();
+    registerScaffoldValidationCommand(plugin, {
+      pickOntology: jest.fn().mockResolvedValue(null),
+      scaffold,
+      notify,
+    });
+    registered[0].callback();
+    await flush();
+    expect(scaffold).not.toHaveBeenCalled();
+    expect(notify).not.toHaveBeenCalled();
+  });
+});
+
+describe("format helpers", () => {
+  it("summarises a passing report", () => {
+    expect(formatVaultCheckReport(PASS_REPORT)).toContain("all 1 check(s) passed");
+  });
+  it("flags an enabled-but-empty run", () => {
+    expect(
+      formatVaultCheckReport({ totalAssets: 0, ok: true, results: [] }),
+    ).toContain("no checks enabled");
+  });
+  it("reports a fail-loud error result", () => {
+    const msg = formatVaultCheckReport({
+      totalAssets: 1,
+      ok: false,
+      results: [
+        {
+          checkId: "k",
+          label: "dag-ontology-imports",
+          status: "error",
+          findings: [],
+          errorMessage: "no runner",
+        },
+      ],
+    });
+    expect(msg).toContain("FAILED");
+    expect(msg).toContain("dag-ontology-imports");
+    expect(msg).toContain("no runner");
+  });
+  it("summarises a scaffold result", () => {
+    const msg = formatScaffoldResult(
+      { uid: "u", label: "$exo", folder: "f" },
+      [
+        { path: "a", checkId: "k1", value: true },
+        { path: "b", checkId: "k2", value: false },
+      ],
+    );
+    expect(msg).toContain("wrote 2");
+    expect(msg).toContain("1 enabled");
+  });
+});


### PR DESCRIPTION
## M1.5 plugin half — the core M1 value: **validate on iPhone**

RFC `f402002b` Milestone M1.5, second half. The CLI half (PR #3739) shipped the
`validate vault` + `scaffold validation-settings` commands; this adds the
**Obsidian plugin** equivalents so vault-integrity validation is a first-class,
cross-platform action — not desktop-only / CLI-only.

### What

- **`Exocortex: Validate vault`** (id `validate-vault`) — builds a
  `PluginVaultCheckReader` over the **warm `metadataCache`** (no per-file
  re-read → no "iPhone reindex 10 minutes"), reads the enabled-set, runs
  `VaultCheckRunner`, reports per-check pass/fail/error.
- **`Exocortex: Scaffold validation settings`** (id `scaffold-validation-settings`)
  — opens an ontology picker (`OntologyFuzzyModal`, with the #3561
  deferred-resolution contract), writes the 4 check-Settings (uid-uniqueness=true,
  rest false) co-located in the chosen ontology's folder via `vault.adapter`.
- ⛔ **Desktop↔Mobile Command Parity** — both commands register
  **unconditionally** (no `Platform.isMobile` gate; archgate `MOBILE-004`
  enforces). The portable checks (uid-uniqueness, co-location) run on mobile with
  zero platform machinery — that IS the M1 value.
- **`readEnabledCheckIds` promoted to core** — single home for the
  integrity-relevant enabled-set logic, shared by the CLI + plugin (the "shared
  home" the CLI's inline comment promised). CLI `validate-vault.ts` now imports
  it; both CLI ESM mocks updated.

### Scope decision — runShacl deferred to M2 (parity with the CLI)

The plan named "runShacl from the warm `getTripleStore()`". On wiring it I
verified the warm store holds **DOMAIN** triples, so SHACL needs the same
domain→algebra conversion (`domainToAlgebraTriples`) the CLI's
`runShapesValidation` performs — which lives CLI-internal. SHACL is **OFF by
default**, the CLI **also defers** it (`CliFsCheckReader` provides neither
runner), and the req/comment already designate SHACL as the **M2 unification**.
So I defer runShacl + runDag (fail-loud if enabled, never a silent skip),
keeping exact CLI↔plugin parity; the reader exposes an optional `shaclRunner`
ctor seam as the M2 wiring point. Result: `validate on iPhone` is delivered by
the portable checks today, SHACL unification is M2.

### Tests (revert-verifiable binding floor)

- 18 plugin unit/component: registrar stable id/name + callback wiring +
  fail-loud-on-throw; scaffolder 4-settings / `trueCount===1` (revert anchor) /
  co-location / isDefinedBy / no-clobber; warm-reader build + SHACL/DAG omit +
  M2 seam; modal selection-vs-cancel (real Obsidian order).
- 5 core `readEnabledCheckIds` (truthy/falsy/unknown-key/dedup/empty).

Bumps `packages/exoas-exo-reqs` (A's M1.5 CLI req flips → Active + 2 **proposed**
plugin reqs `807a8a6d` validate-on-mobile / `0b7ce59c` scaffold-modal — flip to
Active after merge).

Verified locally (fresh clone): typecheck clean, eslint `--max-warnings=0` clean,
plugin validation suite 18/18, core 5/5, CLI regression (validate +
validate-schema + integration) 88/88, `ExocortexPlugin` related 117/117.
