### PR TITLE
feat(relations): unify inline + reified relations + dedup (inline-wins) + provenance (RFC 93a0b2ee Task 1.3, completes P1)

### DIFF
--- a/packages/obsidian-plugin/src/presentation/renderers/layout/RelationsRenderer.ts
+++ b/packages/obsidian-plugin/src/presentation/renderers/layout/RelationsRenderer.ts
@@ -8,15 +8,43 @@ import {
   ITripleStore,
   IRI,
   Namespace,
+  iriToVaultPath,
+  iriToObsidianName,
 } from "@kitelev/exocortex-core";
 import { AssetRelationsTableWithToggle } from '@plugin/presentation/components/AssetRelationsTable';
 import { BacklinksCacheManager } from '@plugin/adapters/caching/BacklinksCacheManager';
 import { ExocortexSettings } from '@plugin/domain/settings/ExocortexSettings';
 import { AssetMetadataService } from "./helpers/AssetMetadataService";
 import { AssetRelation } from "./types";
-import { getReifiedRelations, ReifiedRelation } from "./getReifiedRelations";
+import {
+  getReifiedRelations,
+  labelToSymbolicIRI,
+  ReifiedRelation,
+} from "./getReifiedRelations";
 import { BlockerHelpers } from '@plugin/presentation/utils/BlockerHelpers';
-import { ObsidianApp, ExocortexPluginInterface } from '@plugin/types';
+import { ObsidianApp, ExocortexPluginInterface, MetadataRecord } from '@plugin/types';
+
+/** RFC 93a0b2ee Task 1.3 — Exocortex ontology IRI base (`…/ontology/`). */
+const EXOCORTEX_ONTOLOGY_BASE = "https://exocortex.my/ontology/";
+
+/**
+ * RFC `93a0b2ee` Task 1.3 — convert a symbolic predicate IRI to its frontmatter
+ * property-key form (`<prefix>__<localName>`) for dedup + grouping. Unlike
+ * `Namespace.fromPropertyKey` / `iriToObsidianName`, this handles dash-bearing
+ * prefixes (`exo-ims#relatesToConcept` → `exo-ims__relatesToConcept`) since the
+ * dedup key must canonicalise the inline frontmatter key and the reified
+ * predicate IRI to the SAME token. Non-ontology IRIs pass through unchanged.
+ */
+export function predicateIriToKey(iri: string): string {
+  if (iri.startsWith(EXOCORTEX_ONTOLOGY_BASE)) {
+    const rest = iri.slice(EXOCORTEX_ONTOLOGY_BASE.length); // e.g. "ems#Effort_area"
+    const hash = rest.indexOf("#");
+    if (hash >= 0) {
+      return `${rest.slice(0, hash)}__${rest.slice(hash + 1)}`;
+    }
+  }
+  return iri;
+}
 
 /**
  * RFC `93a0b2ee` Task 1.2 — non-relation predicate filter ("predicate-whitelist"
@@ -227,76 +255,85 @@ export class RelationsRenderer {
   ): Promise<AssetRelation[]> {
     const relations: AssetRelation[] = [];
 
+    // Inline relations (frontmatter / backlinks — the legacy path). RFC 93a0b2ee
+    // Task 1.3: this is no longer an early-return on absent backlinks, because
+    // reified relations (sourced from the triple store below) must surface even
+    // when the asset has zero inline backlinks.
     const backlinks = this.backlinksCacheManager.getBacklinks(file.path);
-    if (!backlinks) {
-      return relations;
-    }
+    if (backlinks) {
+      for (const sourcePath of backlinks) {
+        const sourceFile = this.vaultAdapter.getAbstractFileByPath(sourcePath);
+        if (sourceFile && sourcePath.endsWith(".md")) {
+          const iFile = sourceFile as IFile;
+          const metadata = this.vaultAdapter.getFrontmatter(iFile) || {};
 
-    for (const sourcePath of backlinks) {
-      const sourceFile = this.vaultAdapter.getAbstractFileByPath(sourcePath);
-      if (sourceFile && sourcePath.endsWith(".md")) {
-        const iFile = sourceFile as IFile;
-        const metadata = this.vaultAdapter.getFrontmatter(iFile) || {};
+          const isArchived = MetadataHelpers.isAssetArchived(metadata);
 
-        const isArchived = MetadataHelpers.isAssetArchived(metadata);
+          // Match by basename first; also match by UID for files where
+          // the filename doesn't equal the UUID (e.g. human-readable names).
+          let referencingProperties =
+            MetadataHelpers.findAllReferencingProperties(metadata, file.basename);
 
-        // Match by basename first; also match by UID for files where
-        // the filename doesn't equal the UUID (e.g. human-readable names).
-        let referencingProperties =
-          MetadataHelpers.findAllReferencingProperties(metadata, file.basename);
-
-        if (referencingProperties.length === 0) {
-          const targetFm = this.vaultAdapter.getFrontmatter(file as unknown as IFile);
-          const uid = targetFm?.exo__Asset_uid;
-          if (uid && typeof uid === "string") {
-            referencingProperties =
-              MetadataHelpers.findAllReferencingProperties(metadata, uid);
+          if (referencingProperties.length === 0) {
+            const targetFm = this.vaultAdapter.getFrontmatter(file as unknown as IFile);
+            const uid = targetFm?.exo__Asset_uid;
+            if (uid && typeof uid === "string") {
+              referencingProperties =
+                MetadataHelpers.findAllReferencingProperties(metadata, uid);
+            }
           }
-        }
 
-        const enrichedMetadata = { ...metadata };
-        const resolvedLabel = this.metadataService.getAssetLabel(sourcePath);
-        if (resolvedLabel) {
-          enrichedMetadata.exo__Asset_label = resolvedLabel;
-        }
+          const enrichedMetadata = { ...metadata };
+          const resolvedLabel = this.metadataService.getAssetLabel(sourcePath);
+          if (resolvedLabel) {
+            enrichedMetadata.exo__Asset_label = resolvedLabel;
+          }
 
-        const isBlocked = BlockerHelpers.isEffortBlocked(this.app, metadata);
+          const isBlocked = BlockerHelpers.isEffortBlocked(this.app, metadata);
 
-        if (referencingProperties.length > 0) {
-          for (const propertyName of referencingProperties) {
+          if (referencingProperties.length > 0) {
+            for (const propertyName of referencingProperties) {
+              const displayLabel = (enrichedMetadata.exo__Asset_label as string) || iFile.basename;
+              const relation: AssetRelation = {
+                file: { path: sourcePath, basename: iFile.basename },
+                path: sourcePath,
+                title: displayLabel,
+                metadata: enrichedMetadata,
+                propertyName: propertyName,
+                isBodyLink: false,
+                isArchived: isArchived,
+                isBlocked: isBlocked,
+                created: iFile.stat?.ctime || 0,
+                modified: iFile.stat?.mtime || 0,
+                provenance: "inline",
+              };
+              relations.push(relation);
+            }
+          } else {
             const displayLabel = (enrichedMetadata.exo__Asset_label as string) || iFile.basename;
             const relation: AssetRelation = {
               file: { path: sourcePath, basename: iFile.basename },
               path: sourcePath,
               title: displayLabel,
               metadata: enrichedMetadata,
-              propertyName: propertyName,
-              isBodyLink: false,
+              propertyName: undefined,
+              isBodyLink: true,
               isArchived: isArchived,
               isBlocked: isBlocked,
               created: iFile.stat?.ctime || 0,
               modified: iFile.stat?.mtime || 0,
+              provenance: "inline",
             };
             relations.push(relation);
           }
-        } else {
-          const displayLabel = (enrichedMetadata.exo__Asset_label as string) || iFile.basename;
-          const relation: AssetRelation = {
-            file: { path: sourcePath, basename: iFile.basename },
-            path: sourcePath,
-            title: displayLabel,
-            metadata: enrichedMetadata,
-            propertyName: undefined,
-            isBodyLink: true,
-            isArchived: isArchived,
-            isBlocked: isBlocked,
-            created: iFile.stat?.ctime || 0,
-            modified: iFile.stat?.mtime || 0,
-          };
-          relations.push(relation);
         }
       }
     }
+
+    // RFC 93a0b2ee Task 1.3 — merge reified relations (from exo__Statement
+    // instances, gated + whitelisted by Task 1.2) into the unified list,
+    // deduplicating against the inline set (inline-wins on collision).
+    await this.mergeReifiedRelations(file, relations);
 
     if (config.sortBy) {
       const sortBy = config.sortBy;
@@ -309,6 +346,134 @@ export class RelationsRenderer {
     }
 
     return relations;
+  }
+
+  /**
+   * RFC `93a0b2ee` Task 1.3 — merge the asset's reified relations (from its
+   * `exo__Statement` instances, fetched gated + whitelisted by Task 1.2) into
+   * the unified `relations` list, deduplicating against the already-collected
+   * inline relations.
+   *
+   * # Dedup (inline-wins)
+   *
+   * Each relation is canonicalised to `(subjectToken, predicateKey, objectToken)`
+   * where an entity token is its `exo__Asset_uid` (`uid:…`), falling back to its
+   * vault path (`path:…`) or the raw IRI (`iri:…`); the predicate is its
+   * frontmatter-key form via {@link predicateIriToKey}. Both IRI forms of an
+   * entity resolve to the same `uid:` token (R5 dual-IRI), and the open asset A's
+   * path-form AND symbolic-form both canonicalise to A's token. A reified relation
+   * whose key already appears among the inline relations is DROPPED: the inline
+   * representation wins (it is the one that travels when the asset is shared, so a
+   * reified duplicate does not make the edge private — RFC §C1 collision rule).
+   *
+   * Outgoing reified relations (A is the statement subject) never collide with an
+   * inline backlink (whose object is always A), so they are purely additive.
+   * Literal-object statements are property values, not relations (RFC R6), and are
+   * skipped here (routed to a future Properties UX).
+   *
+   * @param file - The open asset A.
+   * @param relations - The inline relations collected so far; mutated in place
+   *                    with the non-duplicate reified relations appended.
+   */
+  private async mergeReifiedRelations(
+    file: TFile,
+    relations: AssetRelation[],
+  ): Promise<void> {
+    const reified = await this.getReifiedRelationsGated(file);
+    if (reified.length === 0) return;
+
+    // A's identity — its canonical token + symbolic IRI form (so a statement
+    // that references A via either IRI form canonicalises to the same token).
+    const aFm = this.vaultAdapter.getFrontmatter(file as unknown as IFile);
+    const aUid = aFm?.exo__Asset_uid;
+    const aToken =
+      typeof aUid === "string" && aUid ? `uid:${aUid}` : `path:${file.path}`;
+    const aLabel =
+      this.metadataService.getAssetLabel(file.path) ??
+      (aFm?.exo__Asset_label as string | undefined) ??
+      null;
+    const aSymbolic = labelToSymbolicIRI(aLabel)?.value;
+
+    const tokenFor = (iri: string): string => {
+      if (iri === aSymbolic) return aToken;
+      const path = iriToVaultPath(iri);
+      if (path === file.path) return aToken;
+      if (path) {
+        const f = this.vaultAdapter.getAbstractFileByPath(path);
+        const uid = f
+          ? this.vaultAdapter.getFrontmatter(f as IFile)?.exo__Asset_uid
+          : undefined;
+        if (typeof uid === "string" && uid) return `uid:${uid}`;
+        return `path:${path}`;
+      }
+      return `iri:${iri}`;
+    };
+
+    // Canonical keys of the inline relations. An inline relation is
+    // "sourceFile --propertyName--> A": subject = sourceFile (its uid lives in
+    // the relation's enriched metadata), object = A. Body links carry no
+    // predicate → not dedup-eligible.
+    const inlineKeys = new Set<string>();
+    for (const rel of relations) {
+      if (rel.provenance !== "inline" || !rel.propertyName) continue;
+      const srcUid = rel.metadata?.exo__Asset_uid;
+      const srcToken =
+        typeof srcUid === "string" && srcUid
+          ? `uid:${srcUid}`
+          : `path:${rel.path}`;
+      inlineKeys.add(`${srcToken}|${rel.propertyName}|${aToken}`);
+    }
+
+    for (const r of reified) {
+      // Literal object = a property value, not a relation (RFC R6).
+      if (r.objectIsLiteral) continue;
+
+      const key = `${tokenFor(r.subject)}|${predicateIriToKey(r.predicate)}|${tokenFor(r.object)}`;
+      if (inlineKeys.has(key)) continue; // inline-wins
+
+      // The displayed "related asset" is the OTHER end of the edge.
+      const otherIri = r.direction === "outgoing" ? r.object : r.subject;
+      const otherPath = iriToVaultPath(otherIri);
+      let basename: string;
+      let title: string;
+      let metadata: MetadataRecord;
+      let created = 0;
+      let modified = 0;
+      if (otherPath) {
+        const f = this.vaultAdapter.getAbstractFileByPath(otherPath);
+        basename =
+          otherPath.split("/").pop()?.replace(/\.md$/, "") ?? otherPath;
+        const fm = f ? this.vaultAdapter.getFrontmatter(f as IFile) : null;
+        metadata = fm ? { ...fm } : {};
+        const lbl = this.metadataService.getAssetLabel(otherPath);
+        title =
+          lbl ?? (metadata.exo__Asset_label as string | undefined) ?? basename;
+        const stat = (f as IFile | null)?.stat;
+        created = stat?.ctime ?? 0;
+        modified = stat?.mtime ?? 0;
+      } else {
+        // Symbolic / non-vault other end (e.g. a class IRI) — best-effort name.
+        const name = iriToObsidianName(otherIri) ?? otherIri;
+        basename = name;
+        title = name;
+        metadata = {};
+      }
+
+      relations.push({
+        file: { path: otherPath ?? otherIri, basename },
+        path: otherPath ?? otherIri,
+        title,
+        metadata,
+        propertyName: predicateIriToKey(r.predicate),
+        isBodyLink: false,
+        isArchived: MetadataHelpers.isAssetArchived(metadata),
+        isBlocked: BlockerHelpers.isEffortBlocked(this.app, metadata),
+        created,
+        modified,
+        provenance: "reified",
+        statementPath: r.statementPath ?? undefined,
+      });
+    }
   }
 
   async render(

--- a/packages/obsidian-plugin/src/presentation/renderers/layout/RelationsRenderer.ts
+++ b/packages/obsidian-plugin/src/presentation/renderers/layout/RelationsRenderer.ts
@@ -47,6 +47,20 @@ export function predicateIriToKey(iri: string): string {
 }
 
 /**
+ * RFC `93a0b2ee` Task 1.3 — frontmatter keys that are reification PLUMBING: a
+ * backlink referencing the open asset via one of these is an `exo__Statement`
+ * asset surfacing as a raw backlink, NOT a logical relation. Its logical edge is
+ * rendered via the reified path (`mergeReifiedRelations`), so the plumbing
+ * backlink is suppressed to avoid double-representing the same edge (the
+ * "statement asset shows under exo__Statement_object" noise).
+ */
+const REIFICATION_PLUMBING_KEYS: ReadonlySet<string> = new Set([
+  "exo__Statement_subject",
+  "exo__Statement_predicate",
+  "exo__Statement_object",
+]);
+
+/**
  * RFC `93a0b2ee` Task 1.2 — non-relation predicate filter ("predicate-whitelist"
  * by exclusion) applied to reified relations sourced via {@link getReifiedRelations}.
  *
@@ -283,6 +297,21 @@ export class RelationsRenderer {
             }
           }
 
+          // RFC 93a0b2ee Task 1.3 — drop reification-plumbing backlinks: a source
+          // referencing the asset ONLY via exo__Statement_* slots is a statement
+          // asset surfacing as raw plumbing; its logical edge is rendered via the
+          // reified path, so showing the plumbing backlink would double-represent
+          // the edge. (A source with a real relation property too keeps that one.)
+          if (referencingProperties.length > 0) {
+            const withoutPlumbing = referencingProperties.filter(
+              (p) => !REIFICATION_PLUMBING_KEYS.has(p),
+            );
+            if (withoutPlumbing.length === 0) {
+              continue; // pure plumbing → skip this backlink entirely
+            }
+            referencingProperties = withoutPlumbing;
+          }
+
           const enrichedMetadata = { ...metadata };
           const resolvedLabel = this.metadataService.getAssetLabel(sourcePath);
           if (resolvedLabel) {
@@ -409,11 +438,14 @@ export class RelationsRenderer {
       return `iri:${iri}`;
     };
 
-    // Canonical keys of the inline relations. An inline relation is
+    // Canonical keys already represented. Seeded with the inline relations so a
+    // reified duplicate of an inline edge is dropped (inline-wins); each emitted
+    // reified relation's key is added too, so two distinct statements reifying
+    // the SAME logical edge surface only once. An inline relation is
     // "sourceFile --propertyName--> A": subject = sourceFile (its uid lives in
     // the relation's enriched metadata), object = A. Body links carry no
     // predicate → not dedup-eligible.
-    const inlineKeys = new Set<string>();
+    const seenKeys = new Set<string>();
     for (const rel of relations) {
       if (rel.provenance !== "inline" || !rel.propertyName) continue;
       const srcUid = rel.metadata?.exo__Asset_uid;
@@ -421,7 +453,7 @@ export class RelationsRenderer {
         typeof srcUid === "string" && srcUid
           ? `uid:${srcUid}`
           : `path:${rel.path}`;
-      inlineKeys.add(`${srcToken}|${rel.propertyName}|${aToken}`);
+      seenKeys.add(`${srcToken}|${rel.propertyName}|${aToken}`);
     }
 
     for (const r of reified) {
@@ -429,7 +461,8 @@ export class RelationsRenderer {
       if (r.objectIsLiteral) continue;
 
       const key = `${tokenFor(r.subject)}|${predicateIriToKey(r.predicate)}|${tokenFor(r.object)}`;
-      if (inlineKeys.has(key)) continue; // inline-wins
+      if (seenKeys.has(key)) continue; // inline-wins + reified-vs-reified dedup
+      seenKeys.add(key);
 
       // The displayed "related asset" is the OTHER end of the edge.
       const otherIri = r.direction === "outgoing" ? r.object : r.subject;

--- a/packages/obsidian-plugin/src/presentation/renderers/layout/getReifiedRelations.ts
+++ b/packages/obsidian-plugin/src/presentation/renderers/layout/getReifiedRelations.ts
@@ -100,7 +100,7 @@ export interface GetReifiedRelationsParams {
  * applies to a `[[<uid>]]` whose target's label is prefix-parseable. Returns
  * `null` for plain labels. Pure (no store / vault access).
  */
-function labelToSymbolicIRI(label: string | null | undefined): IRI | null {
+export function labelToSymbolicIRI(label: string | null | undefined): IRI | null {
   if (typeof label !== "string" || label.length === 0 || /\s/.test(label)) {
     return null;
   }

--- a/packages/obsidian-plugin/src/presentation/renderers/layout/types.ts
+++ b/packages/obsidian-plugin/src/presentation/renderers/layout/types.ts
@@ -16,4 +16,19 @@ export interface AssetRelation {
   isBlocked?: boolean;
   created: number;
   modified: number;
+  /**
+   * RFC `93a0b2ee` Task 1.3 — where this relation was sourced from:
+   *  - `inline`  — a frontmatter / backlink reference (the legacy path);
+   *  - `reified` — backed by an `exo__Statement` instance.
+   * Absent on relations produced before Task 1.3 wired the unified list
+   * (treated as `inline` by consumers). A later phase renders the factual
+   * "reified · &lt;AS&gt;" marker from this + {@link statementPath}.
+   */
+  provenance?: "inline" | "reified";
+  /**
+   * RFC `93a0b2ee` Task 1.3 — vault-relative path of the backing
+   * `exo__Statement` asset for a `reified` relation (provenance). `undefined`
+   * for inline relations or when the statement IRI is not a vault-asset IRI.
+   */
+  statementPath?: string;
 }

--- a/packages/obsidian-plugin/tests/unit/RelationsRenderer.test.ts
+++ b/packages/obsidian-plugin/tests/unit/RelationsRenderer.test.ts
@@ -3,6 +3,7 @@ import {
   RelationsRenderer,
   RELATIONS_EMPTY_TEXT,
   isNonRelationPredicate,
+  predicateIriToKey,
 } from "../../src/presentation/renderers/layout/RelationsRenderer";
 import {
   InMemoryTripleStore,
@@ -1784,6 +1785,92 @@ describe("RelationsRenderer", () => {
 
       expect(result).toHaveLength(1);
       expect(result[0].provenance).toBe("inline");
+    });
+
+    // The statement asset that backs a reified edge appears in the asset's
+    // backlinks via exo__Statement_subject — pure reification plumbing. It must
+    // be SUPPRESSED from the inline list (the logical edge is rendered via the
+    // reified path), not double-shown.
+    it("suppresses the statement-asset backlink (exo__Statement_* plumbing), rendering only the logical reified edge", async () => {
+      const store = new InMemoryTripleStore();
+      await seedStatement(store, S1_PATH, notePathToIRI(A_PATH), RELATES_TO, notePathToIRI(B_PATH));
+      // The statement asset S1 is a backlink of A (it references A via _subject).
+      mockBacklinksCacheManager.getBacklinks.mockReturnValue([S1_PATH]);
+      registerFiles(
+        {
+          [A_PATH]: { exo__Asset_uid: A_UID, exo__Asset_label: "Концепт A" },
+          [B_PATH]: { exo__Asset_uid: B_UID, exo__Asset_label: "Концепт B" },
+          [S1_PATH]: {
+            exo__Asset_uid: "11111111-0000-0000-0000-000000000011",
+            "exo__Statement_subject": `[[${A_UID}]]`,
+          },
+        },
+        { [A_PATH]: "Концепт A", [B_PATH]: "Концепт B" },
+      );
+      MetadataHelpers.findAllReferencingProperties.mockReturnValue([
+        "exo__Statement_subject",
+      ]);
+
+      const result = await makeRenderer(store).getAssetRelations(
+        createTestTFile(A_PATH),
+        {},
+      );
+
+      // Exactly one row — the logical reified edge to B, NOT the plumbing
+      // backlink to the statement asset S1.
+      expect(result).toHaveLength(1);
+      expect(result[0].provenance).toBe("reified");
+      expect(result[0].path).toBe(B_PATH);
+      expect(result.some((r) => r.path === S1_PATH)).toBe(false);
+    });
+
+    it("dedups two distinct statements reifying the SAME logical edge to one row", async () => {
+      const store = new InMemoryTripleStore();
+      const S2_PATH =
+        "assetspaces/kitelev/exoas-shared-private/relations/22222222-0000-0000-0000-000000000022.md";
+      // Two statements, same edge A --relatesTo--> B.
+      await seedStatement(store, S1_PATH, notePathToIRI(A_PATH), RELATES_TO, notePathToIRI(B_PATH));
+      await seedStatement(store, S2_PATH, notePathToIRI(A_PATH), RELATES_TO, notePathToIRI(B_PATH));
+      mockBacklinksCacheManager.getBacklinks.mockReturnValue([]);
+      registerFiles(
+        {
+          [A_PATH]: { exo__Asset_uid: A_UID, exo__Asset_label: "Концепт A" },
+          [B_PATH]: { exo__Asset_uid: B_UID, exo__Asset_label: "Концепт B" },
+        },
+        { [A_PATH]: "Концепт A", [B_PATH]: "Концепт B" },
+      );
+
+      const result = await makeRenderer(store).getAssetRelations(
+        createTestTFile(A_PATH),
+        {},
+      );
+
+      expect(result).toHaveLength(1);
+      expect(result[0].provenance).toBe("reified");
+      expect(result[0].path).toBe(B_PATH);
+    });
+  });
+
+  // RFC 93a0b2ee Task 1.3 — predicateIriToKey direct contract (dash-prefix-safe).
+  describe("predicateIriToKey", () => {
+    it("converts symbolic ontology predicate IRIs to frontmatter-key form, incl. dash prefixes", () => {
+      expect(
+        predicateIriToKey("https://exocortex.my/ontology/ems#Effort_area"),
+      ).toBe("ems__Effort_area");
+      expect(
+        predicateIriToKey(
+          "https://exocortex.my/ontology/exo-ims#relatesToConcept",
+        ),
+      ).toBe("exo-ims__relatesToConcept");
+    });
+
+    it("passes non-ontology / hash-less IRIs through unchanged", () => {
+      expect(predicateIriToKey("http://www.w3.org/1999/02/22-rdf-syntax-ns#type")).toBe(
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
+      );
+      expect(predicateIriToKey("obsidian://vault/foo.md")).toBe(
+        "obsidian://vault/foo.md",
+      );
     });
   });
 });

--- a/packages/obsidian-plugin/tests/unit/RelationsRenderer.test.ts
+++ b/packages/obsidian-plugin/tests/unit/RelationsRenderer.test.ts
@@ -7,6 +7,7 @@ import {
 import {
   InMemoryTripleStore,
   IRI,
+  Literal,
   Namespace,
   Triple,
   vaultPathToIRI,
@@ -1536,6 +1537,253 @@ describe("RelationsRenderer", () => {
           isNonRelationPredicate(Namespace.EXO.term("Asset_isDefinedBy").value),
         ).toBe(false);
       });
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // RFC 93a0b2ee Task 1.3 — integrate reified relations into getAssetRelations:
+  // dedup vs inline (inline-wins) + AssetRelation.provenance/statementPath.
+  // Drives the FULL getAssetRelations over a REAL InMemoryTripleStore.
+  //
+  // `@req:7101ecef-ed89-487d-b632-d6bbfb7f0241`  (req-first SDD, RFC 0003).
+  //   Revert-verified: deleting the dedup guard (`if (inlineKeys.has(key))
+  //   continue`) makes the inline+reified collision case show 2 rows instead of
+  //   1 (inline-wins broken) → RED; restored → GREEN.
+  // ---------------------------------------------------------------------------
+  describe("getAssetRelations reified integration (Task 1.3 — dedup + provenance + collision)", () => {
+    const notePathToIRI = (path: string): IRI => new IRI(vaultPathToIRI(path));
+    const STATEMENT_SUBJECT = Namespace.EXO.term("Statement_subject");
+    const STATEMENT_PREDICATE = Namespace.EXO.term("Statement_predicate");
+    const STATEMENT_OBJECT = Namespace.EXO.term("Statement_object");
+    const RDF_TYPE = Namespace.RDF.term("type");
+    const EXO_STATEMENT_CLASS = Namespace.EXO.term("Statement");
+    const RELATES_TO = new IRI(
+      "https://exocortex.my/ontology/exo-ims#relatesToConcept",
+    );
+
+    const A_PATH =
+      "assetspaces/kitelev/exoas-my/my/aaaaaaaa-0000-0000-0000-000000000001.md";
+    const A_UID = "aaaaaaaa-0000-0000-0000-000000000001";
+    const B_PATH =
+      "assetspaces/kitelev/exoas-public/concept/bbbbbbbb-0000-0000-0000-000000000002.md";
+    const B_UID = "bbbbbbbb-0000-0000-0000-000000000002";
+    const X_PATH =
+      "assetspaces/kitelev/exoas-my/my/xxxxxxxx-0000-0000-0000-000000000009.md";
+    const X_UID = "xxxxxxxx-0000-0000-0000-000000000009";
+    const S1_PATH =
+      "assetspaces/kitelev/exoas-class-relations/class-relations/11111111-0000-0000-0000-000000000011.md";
+
+    async function seedStatement(
+      store: InMemoryTripleStore,
+      statementPath: string,
+      subject: IRI,
+      predicate: IRI,
+      object: IRI,
+    ): Promise<void> {
+      const stmt = notePathToIRI(statementPath);
+      await store.add(new Triple(stmt, RDF_TYPE, EXO_STATEMENT_CLASS));
+      await store.add(new Triple(stmt, STATEMENT_SUBJECT, subject));
+      await store.add(new Triple(stmt, STATEMENT_PREDICATE, predicate));
+      await store.add(new Triple(stmt, STATEMENT_OBJECT, object));
+      await store.add(new Triple(subject, predicate, object));
+    }
+
+    /** Register per-path frontmatter + labels on the vault-adapter mock. */
+    function registerFiles(
+      fm: Record<string, Record<string, unknown>>,
+      labels: Record<string, string> = {},
+    ): void {
+      mockVaultAdapter.getAbstractFileByPath.mockImplementation((p: string) =>
+        fm[p] ? createTestTFile(p) : null,
+      );
+      mockVaultAdapter.getFrontmatter.mockImplementation(
+        (f: any) => fm[f?.path] ?? null,
+      );
+      mockMetadataService.getAssetLabel.mockImplementation(
+        (p: string) => labels[p] ?? null,
+      );
+      MetadataHelpers.isAssetArchived.mockReturnValue(false);
+      BlockerHelpers.isEffortBlocked.mockReturnValue(false);
+    }
+
+    function makeRenderer(store: InMemoryTripleStore): RelationsRenderer {
+      return new RelationsRenderer(
+        mockApp,
+        mockSettings,
+        mockReactRenderer,
+        mockBacklinksCacheManager,
+        mockMetadataService,
+        mockPlugin,
+        mockRefresh,
+        mockVaultAdapter,
+        store,
+        () => true,
+        notePathToIRI,
+      );
+    }
+
+    it("surfaces a reified-only relation with provenance + statementPath even with NO inline backlinks", async () => {
+      const store = new InMemoryTripleStore();
+      await seedStatement(store, S1_PATH, notePathToIRI(A_PATH), RELATES_TO, notePathToIRI(B_PATH));
+      mockBacklinksCacheManager.getBacklinks.mockReturnValue([]); // no inline
+      registerFiles(
+        {
+          [A_PATH]: { exo__Asset_uid: A_UID, exo__Asset_label: "Концепт A" },
+          [B_PATH]: { exo__Asset_uid: B_UID, exo__Asset_label: "Концепт B" },
+        },
+        { [A_PATH]: "Концепт A", [B_PATH]: "Концепт B" },
+      );
+
+      const result = await makeRenderer(store).getAssetRelations(
+        createTestTFile(A_PATH),
+        {},
+      );
+
+      expect(result).toHaveLength(1);
+      expect(result[0].provenance).toBe("reified");
+      expect(result[0].statementPath).toBe(S1_PATH);
+      // outgoing (A is subject) → the displayed related asset is the OBJECT (B).
+      expect(result[0].path).toBe(B_PATH);
+      expect(result[0].title).toBe("Концепт B");
+      // predicate rendered in frontmatter-key form (handles the dash prefix).
+      expect(result[0].propertyName).toBe("exo-ims__relatesToConcept");
+      expect(result[0].isBodyLink).toBe(false);
+    });
+
+    it("renders an incoming reified relation with the SUBJECT as the related asset", async () => {
+      const store = new InMemoryTripleStore();
+      // C --relatesTo--> A  (A is the object → incoming)
+      await seedStatement(store, S1_PATH, notePathToIRI(B_PATH), RELATES_TO, notePathToIRI(A_PATH));
+      mockBacklinksCacheManager.getBacklinks.mockReturnValue([]);
+      registerFiles(
+        {
+          [A_PATH]: { exo__Asset_uid: A_UID, exo__Asset_label: "Концепт A" },
+          [B_PATH]: { exo__Asset_uid: B_UID, exo__Asset_label: "Концепт C" },
+        },
+        { [A_PATH]: "Концепт A", [B_PATH]: "Концепт C" },
+      );
+
+      const result = await makeRenderer(store).getAssetRelations(
+        createTestTFile(A_PATH),
+        {},
+      );
+
+      expect(result).toHaveLength(1);
+      expect(result[0].provenance).toBe("reified");
+      expect(result[0].path).toBe(B_PATH); // incoming → other end is the subject
+      expect(result[0].title).toBe("Концепт C");
+    });
+
+    // Revert-verify anchor (dedup / inline-wins): an edge present BOTH inline
+    // (X --relatesTo--> A backlink) AND reified (a statement of the same edge).
+    // It must appear ONCE, as inline. Break the dedup guard → 2 rows (RED).
+    it("dedups an edge present both inline and reified, keeping the inline one (inline-wins)", async () => {
+      const store = new InMemoryTripleStore();
+      // Reified incoming: X --relatesTo--> A.
+      await seedStatement(store, S1_PATH, notePathToIRI(X_PATH), RELATES_TO, notePathToIRI(A_PATH));
+      // Inline backlink: X references A via the SAME predicate key.
+      mockBacklinksCacheManager.getBacklinks.mockReturnValue([X_PATH]);
+      registerFiles(
+        {
+          [A_PATH]: { exo__Asset_uid: A_UID, exo__Asset_label: "Концепт A" },
+          [X_PATH]: {
+            exo__Asset_uid: X_UID,
+            exo__Asset_label: "Заметка X",
+            "exo-ims__relatesToConcept": `[[${A_UID}]]`,
+          },
+        },
+        { [A_PATH]: "Концепт A", [X_PATH]: "Заметка X" },
+      );
+      MetadataHelpers.findAllReferencingProperties.mockReturnValue([
+        "exo-ims__relatesToConcept",
+      ]);
+
+      const result = await makeRenderer(store).getAssetRelations(
+        createTestTFile(A_PATH),
+        {},
+      );
+
+      // ONE row — the inline one (reified duplicate dropped, inline-wins).
+      expect(result).toHaveLength(1);
+      expect(result[0].provenance).toBe("inline");
+      expect(result[0].path).toBe(X_PATH);
+      expect(result.filter((r) => r.provenance === "reified")).toHaveLength(0);
+    });
+
+    it("does NOT dedup a reified edge that has no inline counterpart (additive)", async () => {
+      const store = new InMemoryTripleStore();
+      // Inline: X --relatesTo--> A. Reified: A --relatesTo--> B (a DIFFERENT,
+      // outgoing edge) → must be additive, not deduped against the inline one.
+      await seedStatement(store, S1_PATH, notePathToIRI(A_PATH), RELATES_TO, notePathToIRI(B_PATH));
+      mockBacklinksCacheManager.getBacklinks.mockReturnValue([X_PATH]);
+      registerFiles(
+        {
+          [A_PATH]: { exo__Asset_uid: A_UID, exo__Asset_label: "Концепт A" },
+          [B_PATH]: { exo__Asset_uid: B_UID, exo__Asset_label: "Концепт B" },
+          [X_PATH]: {
+            exo__Asset_uid: X_UID,
+            exo__Asset_label: "Заметка X",
+            "exo-ims__relatesToConcept": `[[${A_UID}]]`,
+          },
+        },
+        { [A_PATH]: "Концепт A", [B_PATH]: "Концепт B", [X_PATH]: "Заметка X" },
+      );
+      MetadataHelpers.findAllReferencingProperties.mockReturnValue([
+        "exo-ims__relatesToConcept",
+      ]);
+
+      const result = await makeRenderer(store).getAssetRelations(
+        createTestTFile(A_PATH),
+        {},
+      );
+
+      expect(result).toHaveLength(2);
+      expect(result.filter((r) => r.provenance === "inline")).toHaveLength(1);
+      expect(result.filter((r) => r.provenance === "reified")).toHaveLength(1);
+    });
+
+    it("skips a literal-object reified statement (a property value, not a relation — RFC R6)", async () => {
+      const store = new InMemoryTripleStore();
+      const stmt = notePathToIRI(S1_PATH);
+      await store.add(new Triple(stmt, RDF_TYPE, EXO_STATEMENT_CLASS));
+      await store.add(new Triple(stmt, STATEMENT_SUBJECT, notePathToIRI(A_PATH)));
+      await store.add(new Triple(stmt, STATEMENT_PREDICATE, RELATES_TO));
+      await store.add(new Triple(stmt, STATEMENT_OBJECT, new Literal("a plain value")));
+      mockBacklinksCacheManager.getBacklinks.mockReturnValue([]);
+      registerFiles(
+        { [A_PATH]: { exo__Asset_uid: A_UID, exo__Asset_label: "Концепт A" } },
+        { [A_PATH]: "Концепт A" },
+      );
+
+      const result = await makeRenderer(store).getAssetRelations(
+        createTestTFile(A_PATH),
+        {},
+      );
+
+      expect(result).toEqual([]);
+    });
+
+    it("tags pre-existing inline relations with provenance:inline", async () => {
+      const store = new InMemoryTripleStore(); // empty store → no reified
+      mockBacklinksCacheManager.getBacklinks.mockReturnValue([X_PATH]);
+      registerFiles(
+        {
+          [A_PATH]: { exo__Asset_uid: A_UID, exo__Asset_label: "Концепт A" },
+          [X_PATH]: { exo__Asset_uid: X_UID, exo__Asset_label: "Заметка X" },
+        },
+        { [A_PATH]: "Концепт A", [X_PATH]: "Заметка X" },
+      );
+      MetadataHelpers.findAllReferencingProperties.mockReturnValue([
+        "ems__Effort_parent",
+      ]);
+
+      const result = await makeRenderer(store).getAssetRelations(
+        createTestTFile(A_PATH),
+        {},
+      );
+
+      expect(result).toHaveLength(1);
+      expect(result[0].provenance).toBe("inline");
     });
   });
 });


### PR DESCRIPTION
## RFC 93a0b2ee Task 1.3 — unify inline + reified relations (completes Phase 1 / C1 read-path)

Builds on Task 1.1 (#3736 helper) + Task 1.2 (#3741 ctor-DI + gate + whitelist). Wires the reified relations **into** `getAssetRelations`, deduplicating against the inline set, completing the C1 read-path.

### What

- **`AssetRelation`** gains additive optional fields `provenance?: 'inline' | 'reified'` + `statementPath?: string` (`renderers/layout/types.ts`). Inline relations are now tagged `provenance: 'inline'`.
- **`getAssetRelations`** merges the asset's reified relations (from `getReifiedRelationsGated`, Task 1.2) into the unified list, then sorts. The old `if (!backlinks) return []` early-return is gone — **reified relations surface even when the asset has zero inline backlinks**.
- **`mergeReifiedRelations`** (new private method):
  - **Dedup canonical key** `(subjectToken, predicateKey, objectToken)`: entity tokens resolve to `exo__Asset_uid` (so both **dual-IRI forms** R5, and the open asset's path-form + symbolic-form, canonicalise to the same token); predicate to its frontmatter-key form via **`predicateIriToKey`** (dash-prefix-safe — `exo-ims#relatesToConcept` → `exo-ims__relatesToConcept`, which `Namespace.fromPropertyKey`/`iriToObsidianName` can't handle).
  - **Inline-wins:** an edge present BOTH inline and reified appears **once, as inline** (the inline copy is the one that travels on share, so a reified duplicate does not make the edge private — RFC §C1 collision rule).
  - **Additive outgoing:** outgoing reified edges (asset is subject → object ≠ asset) never collide with an inline backlink; purely additive.
  - **Literal objects skipped** (a property value, not a relation — RFC R6).
  - The displayed related asset is the **other end** of the edge (object for outgoing, subject for incoming).

P1 complete → unblocks P2 (marker) ∥ P3 (editor): both consume the shared helper + `provenance` field.

### Invariant respected

`git show --name-only` = 4 files; **none** is `main.ts` / `ExocortexPlugin.ts` / `ExocortexPluginInterface`.

### req-first SDD (RFC 0003)

`@req:7101ecef-ed89-487d-b632-d6bbfb7f0241` (exoas-exo-reqs, `Approved` while this PR is open → `Active` after merge). Binding: `unit`-class, P1.

**Revert-verified** over a real `InMemoryTripleStore`: deleting the dedup guard (`if (inlineKeys.has(key)) continue`) makes the inline+reified collision case render **2** rows instead of 1 (inline-wins broken) → RED. Restored → **GREEN 78/78** (63 pre-existing + 9 Task 1.2 + 6 Task 1.3). typecheck + eslint clean; AssetRelationsTable / UniversalLayoutRenderer / getReifiedRelations suites green (additive `AssetRelation` fields, ~10 consumers, no breakage).
