### PR TITLE
feat(cli)!: bootstrap installs only the SDK floor — remove --exocmd flag (req e0e5ad0f)

### DIFF
--- a/docs/explanation/assetspace-sdk-topology.md
+++ b/docs/explanation/assetspace-sdk-topology.md
@@ -1,7 +1,7 @@
 # Exo-as-SDK: AssetSpaces, the `exoas-*` repos, and Profiles
 
-> **Audience:** contributors and technical users trying to understand *why the vault is
-> split across many git repositories* and *what gets mounted when*.
+> **Audience:** contributors and technical users trying to understand _why the vault is
+> split across many git repositories_ and _what gets mounted when_.
 > **Position:** conceptual orientation. For the runtime mechanics of mounting see
 > [ARCHITECTURE.md → Profiles & AssetSpace Mounting](../../ARCHITECTURE.md#profiles--assetspace-mounting);
 > for the full Profile model see [profile.md](profile.md); for syncing see
@@ -13,18 +13,18 @@ Exocortex deliberately separates **the engine** from **the data it operates on**
 
 - **`exo` is the SDK / platform** — the RDF parser, SPARQL engine, layout renderer, command
   machinery. It ships as code (the plugin + the `@kitelev/exocortex-cli`) and as a small core
-  of class/property/command *definitions*. It knows nothing about *your* domain.
+  of class/property/command _definitions_. It knows nothing about _your_ domain.
 - **The vault is the data** — your notes, projects, people, ontologies. The product is the
-  vault *plus* the SDK, and [every client must be able to drive the full system](../../VISION.md)
+  vault _plus_ the SDK, and [every client must be able to drive the full system](../../VISION.md)
   (the no-lock-in north star, enforced by the UI/CLI Parity Invariant).
 
 Borrowing from the JVM ecosystem, the rest of this doc uses one analogy throughout:
 
-| Exocortex concept | SDK-ecosystem analogy |
-| --- | --- |
-| `exo` (engine + core defs) | the platform / runtime |
-| an **AssetSpace** | a **library (a jar)** — a versioned, shareable package of assets |
-| a **Profile** | a **BOM / manifest** — the named set of libraries you want loaded |
+| Exocortex concept          | SDK-ecosystem analogy                                             |
+| -------------------------- | ----------------------------------------------------------------- |
+| `exo` (engine + core defs) | the platform / runtime                                            |
+| an **AssetSpace**          | a **library (a jar)** — a versioned, shareable package of assets  |
+| a **Profile**              | a **BOM / manifest** — the named set of libraries you want loaded |
 
 The three questions below are just the three nouns in that table.
 
@@ -42,8 +42,8 @@ An AssetSpace is the **unit of packaging, sharing, and mounting**:
   an asset lives in the folder of the ontology its `exo__Asset_isDefinedBy` points at.
 - **Sharing** — because it is a normal git repo, an AssetSpace can be public, private, or
   shared with a specific set of collaborators, independently of every other AssetSpace.
-- **Mounting** — an AssetSpace is either *materialized* (present on disk, indexed into the
-  triple store) or *unmounted* (absent). Only mounted, UID-bearing markdown participates in
+- **Mounting** — an AssetSpace is either _materialized_ (present on disk, indexed into the
+  triple store) or _unmounted_ (absent). Only mounted, UID-bearing markdown participates in
   the graph. Two examples that always-or-often ship as AssetSpaces: `exoas-exo` (the core
   `exo` ontology) and `exoas-exocmd` (UI command definitions) — both also vendored as npm
   data submodules under `packages/`.
@@ -54,9 +54,9 @@ An AssetSpace is the **unit of packaging, sharing, and mounting**:
 ## 2. Why are there so many `exoas-*` repos?
 
 Because the **axis of separation is sharing-audience, not topic**. The question each
-AssetSpace answers is *"who is this allowed to be shared with?"* — and that has many distinct
-answers, so there are many repos. A single big vault repo could not give *personal*,
-*work*, and *shared-with-one-collaborator* data different visibility and different remotes.
+AssetSpace answers is _"who is this allowed to be shared with?"_ — and that has many distinct
+answers, so there are many repos. A single big vault repo could not give _personal_,
+_work_, and _shared-with-one-collaborator_ data different visibility and different remotes.
 
 The naming convention encodes the audience directly:
 
@@ -64,13 +64,13 @@ The naming convention encodes the audience directly:
   Private by default unless the domain is meant to be public.
 - **`exoas-shared-<audience>`** — data deliberately shared with a named audience (a team, a
   specific collaborator).
-- **Public floor spaces** — `exoas-exo`, `exoas-exocmd`, and the W3C-vocabulary space are
-  public because the SDK and its vocabulary are not secret.
+- **Public spaces** — `exoas-exo` (the SDK floor), `exoas-exocmd`, and the W3C-vocabulary
+  space are public because the SDK and its vocabulary are not secret.
 
 This split buys four things that a monorepo-vault cannot:
 
 1. **Privacy boundaries are physical.** A private AssetSpace that is not in your active
-   Profile is *not on disk* — it cannot leak into search, SPARQL, or a screenshot.
+   Profile is _not on disk_ — it cannot leak into search, SPARQL, or a screenshot.
 2. **Per-audience remotes & permissions.** Each repo has its own GitHub visibility and
    collaborators; sharing one space with someone never exposes another.
 3. **Independent versioning.** A library you depend on can be updated (pointer-bumped) without
@@ -93,7 +93,7 @@ BOM in the analogy. It is a regular markdown asset with two declarative properti
   import a "base" profile rather than re-listing its spaces).
 
 There is **one** operation over a profile — **`Cmd+P → Exocortex: Apply profile`** — and it
-performs a **mount-state strict replace**: the profile's *effective set* is materialized on
+performs a **mount-state strict replace**: the profile's _effective set_ is materialized on
 disk and everything else is unmounted. The effective set is:
 
 ```
@@ -107,7 +107,7 @@ shared-identity spaces are optional add-ons). Applying a profile that omits `exo
 recovery on load) and works on mobile through a REST/tarball transport when no git binary is
 present.
 
-The result: switching from a *work* context to a *personal* one is a single command that
+The result: switching from a _work_ context to a _personal_ one is a single command that
 physically swaps which repositories exist on disk — privacy, focus, and index size all follow
 from the mount state.
 

--- a/packages/cli/src/commands/bootstrap.ts
+++ b/packages/cli/src/commands/bootstrap.ts
@@ -10,7 +10,6 @@ import { InvalidArgumentsError } from "../utils/errors/index.js";
 interface BootstrapOptions {
   vault: string;
   exo?: string;
-  exocmd?: string;
   ref?: string;
   json?: boolean;
   token?: string;
@@ -25,10 +24,13 @@ interface BootstrapOptions {
  * REST tarball pull. Writes `.gitmodules` entries so future `git submodule
  * update` calls work cleanly.
  *
- * RFC 01a83de8 §3.4 / alt-G rejection (issue #3426): `exocmd` is an OPTIONAL
- * UI-command library, NOT part of the SDK floor. Only `--exo` is required; a
- * bare-bones SDK/headless vault (no exocmd) is a first-class configuration.
- * `--exocmd` is opt-in here, or add it later via `exocortex assetspace add`.
+ * RFC 01a83de8 §3.4 / alt-G rejection (issue #3426) + req e0e5ad0f (Andrey
+ * interview 2026-06-27): `exocmd` is an OPTIONAL UI-command library, NOT part of
+ * the SDK floor — and NOT a bootstrap concern. Bootstrap installs only the SDK
+ * platform (`exo`, the TS-floor). exocmd is an ordinary AssetSpace, added via
+ * `exocortex assetspace add` (or by applying a profile), never bundled into the
+ * platform-install step. The previous `--exocmd` opt-in flag was removed to keep
+ * bootstrap strictly about the SDK floor.
  *
  * Refuses к overwrite vaults that already have TS-floor materialized — this
  * is intentional safety. Existing vaults use `exocortex assetspace add`.
@@ -40,16 +42,12 @@ interface BootstrapOptions {
 export function bootstrapCommand(): Command {
   return new Command("bootstrap")
     .description(
-      "Bootstrap a vault with the SDK floor AssetSpace (exo). Pulls tarballs from public GitHub repos, extracts к assetspaces/, writes .gitmodules. Only --exo is required; --exocmd (the optional UI-command library) is opt-in. Example URLs: https://github.com/kitelev/exoas-exo, https://github.com/kitelev/exoas-exocmd.",
+      "Bootstrap a vault with the SDK floor AssetSpace (exo). Pulls a tarball from a public GitHub repo, extracts к assetspaces/, writes .gitmodules. Only --exo is required — bootstrap installs only the SDK platform. exocmd (the optional UI-command library) and any other AssetSpace are added afterwards via `exocortex assetspace add`. Example URL: https://github.com/kitelev/exoas-exo.",
     )
     .requiredOption("--vault <path>", "Path к target vault")
     .requiredOption(
       "--exo <url>",
       "Public GitHub URL для exo TBox AssetSpace (e.g. https://github.com/kitelev/exoas-exo)",
-    )
-    .option(
-      "--exocmd <url>",
-      "Optional: Public GitHub URL для exocmd UI-command AssetSpace (e.g. https://github.com/kitelev/exoas-exocmd). Opt-in — omit for a bare SDK/headless vault; add later via `assetspace add`.",
     )
     .option("--ref <branch>", "Branch ref к pull from", "main")
     .option(
@@ -111,21 +109,9 @@ export function bootstrapCommand(): Command {
           fileCount: exoResult.fileCount,
         });
 
-        // Pull exocmd → Maven mount path — OPTIONAL (RFC 01a83de8 alt-G
-        // rejection, issue #3426). Omit `--exocmd` for a bare SDK/headless vault.
-        if (options.exocmd) {
-          const exocmdRel = derivePath(options.exocmd) ?? "assetspaces/exocmd";
-          const exocmdTarget = join(vaultPath, exocmdRel);
-          process.stderr.write(`[bootstrap] Pulling ${options.exocmd}@${ref} → ${exocmdRel}/...\n`);
-          const exocmdResult = await svc.pullAssetSpace(options.exocmd, ref, exocmdTarget);
-          svc.ensureGitmodulesEntry(vaultPath, exocmdRel, options.exocmd);
-          results.push({
-            folder: exocmdRel,
-            url: options.exocmd,
-            sha: exocmdResult.sha,
-            fileCount: exocmdResult.fileCount,
-          });
-        }
+        // exocmd and all other AssetSpaces are NOT bootstrap concerns (req
+        // e0e5ad0f, Andrey interview 2026-06-27): bootstrap installs only the
+        // SDK floor (exo). Add exocmd later via `exocortex assetspace add`.
 
         if (options.json) {
           process.stdout.write(JSON.stringify({ vault: vaultPath, materialized: results }, null, 2) + "\n");
@@ -138,12 +124,8 @@ export function bootstrapCommand(): Command {
           process.stdout.write(`\nNext steps:\n`);
           process.stdout.write(`  1. cd ${vaultPath} && git init (if not initialized)\n`);
           process.stdout.write(`  2. git add . && git commit -m "feat: bootstrap vault"\n`);
-          if (!options.exocmd) {
-            process.stdout.write(`  3. (optional) Add the exocmd UI-command library: \`exocortex assetspace add --vault ${vaultPath} --url https://github.com/kitelev/exoas-exocmd\`\n`);
-            process.stdout.write(`  4. Add additional AssetSpaces via \`exocortex assetspace add --vault ${vaultPath} --url <github-url>\`\n`);
-          } else {
-            process.stdout.write(`  3. Add additional AssetSpaces via \`exocortex assetspace add --vault ${vaultPath} --url <github-url>\`\n`);
-          }
+          process.stdout.write(`  3. (optional) Add the exocmd UI-command library: \`exocortex assetspace add --vault ${vaultPath} --url https://github.com/kitelev/exoas-exocmd\`\n`);
+          process.stdout.write(`  4. Add additional AssetSpaces via \`exocortex assetspace add --vault ${vaultPath} --url <github-url>\`\n`);
         }
         process.exit(0);
       } catch (e) {

--- a/packages/cli/tests/unit/commands/bootstrap.command.test.ts
+++ b/packages/cli/tests/unit/commands/bootstrap.command.test.ts
@@ -3,14 +3,18 @@ import { describe, it, expect } from "@jest/globals";
 import { bootstrapCommand } from "../../../src/commands/bootstrap.js";
 
 /**
- * Issue #3426 (Gap 1) — `bootstrap --exocmd` must be OPTIONAL.
+ * req e0e5ad0f (Andrey interview 2026-06-27) — `bootstrap` installs ONLY the SDK
+ * floor (exo). `exocmd` is an ordinary optional AssetSpace, added via
+ * `exocortex assetspace add` — NOT a bootstrap option.
  *
- * RFC 01a83de8 alt-G rejection: `exo` is the SDK; `exocmd` is the optional
- * UI-command library. A bare SDK/headless vault (only `--exo`) is first-class.
+ * History: issue #3426 (RFC 01a83de8 alt-G rejection) first made `--exocmd`
+ * OPTIONAL (was a `.requiredOption`); req e0e5ad0f then removed the flag
+ * entirely to keep bootstrap strictly about the SDK platform.
+ *
  * These tests assert the Commander option configuration directly — deterministic,
  * no network / no `process.exit`.
  */
-describe("bootstrap command — exocmd optionality (issue #3426)", () => {
+describe("bootstrap command — SDK-floor-only (req e0e5ad0f)", () => {
   it("--exo is a required (mandatory) option", () => {
     const cmd = bootstrapCommand();
     const exo = cmd.options.find((o) => o.long === "--exo");
@@ -25,18 +29,11 @@ describe("bootstrap command — exocmd optionality (issue #3426)", () => {
     expect(vault!.mandatory).toBe(true);
   });
 
-  it("--exocmd is OPTIONAL (NOT mandatory) — the core of Gap 1", () => {
+  it("registers NO --exocmd option — bootstrap installs only the SDK floor @req:e0e5ad0f-56ce-4bc8-9e1b-7a0e20a735d7", () => {
     const cmd = bootstrapCommand();
     const exocmd = cmd.options.find((o) => o.long === "--exocmd");
-    expect(exocmd).toBeDefined();
-    // Pre-#3426 this was a `.requiredOption(...)` (mandatory === true).
-    expect(exocmd!.mandatory).toBeFalsy();
-  });
-
-  it("still offers --exocmd as an opt-in flag (so post-bootstrap users can add it inline)", () => {
-    const cmd = bootstrapCommand();
-    const exocmd = cmd.options.find((o) => o.long === "--exocmd");
-    expect(exocmd).toBeDefined();
-    expect(exocmd!.flags).toContain("--exocmd");
+    // exocmd is an optional AssetSpace added via `assetspace add`, not a
+    // bootstrap option. Re-adding `.option("--exocmd", ...)` makes this RED.
+    expect(exocmd).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary

Bootstrap should install **only the SDK platform** (`exo`, the TS-floor). `exocmd` is an ordinary optional AssetSpace (a "jar"), added via `exocortex assetspace add` (or by applying a profile) — never bundled into the platform-install step.

This PR:
1. **Removes the `--exocmd` opt-in flag** from `exocortex bootstrap` (the option, its materialization block, JSDoc, and post-bootstrap-hint branching). Bootstrap now installs only `--exo`.
2. **Fixes `docs/explanation/assetspace-sdk-topology.md:67`** — it mislabeled `exocmd`+w3c as **"Public floor spaces"**, contradicting line 103 of the same file (TS-floor = `{exo}`) and the code (`SDK_FLOOR`/`PLUGIN_UI_FLOOR` = `[{exo}]`). Renamed to "Public spaces", `exo` tagged "(the SDK floor)".

**Decision:** Andrey interview 2026-06-27 (Q2 "Remove --exocmd entirely"; Q1 topology wording = minimal drop-floor-word).

## Requirement (req-first SDD)

`Req: e0e5ad0f-56ce-4bc8-9e1b-7a0e20a735d7` — *"bootstrap installs only the SDK floor — no --exocmd option"* (P2, unit binding), status **Approved** in `exoas-exo-reqs`.

## Revert-verify

`@req:e0e5ad0f-56ce-4bc8-9e1b-7a0e20a735d7` — re-adding the `--exocmd` `.option(...)` makes `packages/cli/tests/unit/commands/bootstrap.command.test.ts` *"registers NO --exocmd option"* go **RED** (option found); removed → **GREEN** (worktree origin/main `5032e8da`).

## Verification

- `npm run check:types` → 0 errors
- `bootstrap.command.test.ts` → 3 passed (incl. the @req binding)
- No other code references `bootstrap --exocmd` / `options.exocmd` (grep clean)
- The `--exocmd` flag was never documented in `docs/` (no doc references to remove)

## Notes

- `topology.md` diff includes prettier normalizing **pre-existing** markdown drift (`*emphasis*` → `_emphasis_`, table alignment) — renders identically; the only semantic change is the line-67 "Public spaces" bullet. (lint-staged `prettier --write` on a dirty md file; cf. prettier-write-bundles-dirty-files.)
- Plugin `BootstrapVaultModal` already collects only `exo` (exocmd field removed, decision 2026-06-20) — this PR brings the **CLI** to parity.
