### PR TITLE
fix(cli): wikilink validation finds nested UID-canon assets like resolve (#3701)

### DIFF
--- a/packages/cli/src/adapters/NodeFsAdapter.ts
+++ b/packages/cli/src/adapters/NodeFsAdapter.ts
@@ -117,6 +117,59 @@ export class NodeFsAdapter implements IFileSystemAdapter {
     return files.length > 0 ? files[0] : null;
   }
 
+  /**
+   * Find a vault file by UID via its FILENAME (recursive), mirroring the
+   * authoritative UID->path discovery used by `exocortex resolve`
+   * (resolve.ts `findFilesWithUuid`). Matches any `<uid>.md`, `<uid> ...md`,
+   * or `<uid>-...md` at any depth, skipping hidden directories and
+   * `node_modules`.
+   *
+   * Unlike {@link findFileByUID} (which scans frontmatter and so cannot read an
+   * asset whose YAML is malformed/unparseable), this method never reads file
+   * contents — it locates UID-named assets purely by name, exactly like
+   * `resolve`. This keeps wikilink validation consistent with `resolve` for
+   * nested UID-canon assets (issue #3701).
+   *
+   * @returns vault-relative path of the first match, or null.
+   */
+  async findFileByUidFilename(uid: string): Promise<string | null> {
+    const uidLower = uid.toLowerCase();
+
+    const walk = async (dir: string): Promise<string | null> => {
+      let entries;
+      try {
+        entries = await fs.readdir(dir, { withFileTypes: true });
+      } catch {
+        return null;
+      }
+
+      for (const entry of entries) {
+        const fullPath = path.join(dir, entry.name);
+
+        if (entry.isDirectory()) {
+          if (entry.name.startsWith(".") || entry.name === "node_modules") {
+            continue;
+          }
+          const found = await walk(fullPath);
+          if (found) return found;
+        } else if (entry.isFile() && entry.name.endsWith(".md")) {
+          const nameLower = entry.name.toLowerCase();
+          if (
+            nameLower.startsWith(uidLower + ".md") ||
+            nameLower.startsWith(uidLower + " ") ||
+            nameLower.startsWith(uidLower + "-")
+          ) {
+            return path.relative(this.rootPath, fullPath);
+          }
+        }
+      }
+
+      return null;
+    };
+
+    return walk(this.rootPath);
+  }
+
   private resolvePath(filePath: string): string {
     if (path.isAbsolute(filePath)) {
       return filePath;

--- a/packages/cli/src/services/WikilinkValidator.ts
+++ b/packages/cli/src/services/WikilinkValidator.ts
@@ -94,15 +94,23 @@ export class WikilinkValidator {
       return;
     }
 
-    const exists = await this.fsAdapter.fileExists(`${uuid}.md`);
+    // Primary: filename-based recursive lookup — the SAME authoritative UID->path
+    // discovery used by `exocortex resolve` (findFilesWithUuid). This finds nested
+    // UID-canon assets at any depth AND is robust to malformed YAML frontmatter,
+    // which the frontmatter scan below cannot read. Without this, `create`
+    // rejected a nested UID-wikilink that `resolve` happily found (issue #3701).
+    const foundByFilename = await this.fsAdapter.findFileByUidFilename(uuid);
+    if (foundByFilename) {
+      return;
+    }
 
-    if (!exists) {
-      // Also try finding by UID in metadata
-      const foundByUid = await this.fsAdapter.findFileByUID(uuid);
-
-      if (!foundByUid) {
-        throw new WikilinkNotFoundError(uuid, label);
-      }
+    // Fallback: frontmatter `exo__Asset_uid` scan — covers assets that are NOT
+    // UID-named (e.g. pn__DailyNote `YYYY-MM-DD.md`, period__Week `YYYY-Www.md`)
+    // but are referenced by their UID. Keeps validation from regressing for the
+    // calendar-plugin whitelist files.
+    const foundByUid = await this.fsAdapter.findFileByUID(uuid);
+    if (!foundByUid) {
+      throw new WikilinkNotFoundError(uuid, label);
     }
   }
 

--- a/packages/cli/tests/unit/services/WikilinkValidator.nestedUid.test.ts
+++ b/packages/cli/tests/unit/services/WikilinkValidator.nestedUid.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect, beforeAll, afterAll } from "@jest/globals";
+import fs from "fs-extra";
+import os from "os";
+import path from "path";
+import { NodeFsAdapter } from "../../../src/adapters/NodeFsAdapter.js";
+import {
+  WikilinkValidator,
+  WikilinkNotFoundError,
+} from "../../../src/services/WikilinkValidator.js";
+
+/**
+ * Production-shape regression test for issue #3701.
+ *
+ * Uses a REAL on-disk multi-folder vault and the REAL NodeFsAdapter (no mocks of
+ * glob / js-yaml / fs) so the malformed-YAML failure mode is reproduced exactly:
+ * `create --property "<prop>=[[<nested-uuid>]]"` rejected a nested UID-canon asset
+ * that `exocortex resolve` happily found, because the validator's only fallback
+ * (frontmatter `exo__Asset_uid` scan) could not parse the asset's malformed YAML.
+ *
+ * The fix routes wikilink validation through the SAME authoritative FILENAME-based
+ * discovery that `resolve` uses (NodeFsAdapter.findFileByUidFilename), which never
+ * reads file contents.
+ *
+ * Revert-verify (mandatory, integration-test-revert-verify rule): with the fix
+ * reverted, the AC#1 test FAILS (nested UID with malformed YAML is rejected). With
+ * the fix restored it PASSES. AC#2 (nonexistent UID rejected) is GREEN both ways —
+ * proof the validator is not blindly accepting everything.
+ */
+describe("WikilinkValidator — nested UID discovery (issue #3701)", () => {
+  let vaultRoot: string;
+  let validator: WikilinkValidator;
+
+  // A nested UID-canon asset whose YAML frontmatter is MALFORMED (an unquoted
+  // label containing a colon) — exactly the real vault-exodev failure shape.
+  const NESTED_UID = "3b40f843-c2b2-44b4-9b8c-b68405548189";
+  const NESTED_REL = path.join(
+    "assetspaces",
+    "kitelev",
+    "exoas-exodev",
+    "exodev",
+    `${NESTED_UID}.md`,
+  );
+  const MALFORMED_FRONTMATTER = `---
+exo__Asset_uid: ${NESTED_UID}
+exo__Instance_class:
+  - "[[7db5eeff-718a-49b0-8d2b-39b084a356e3]]"
+exo__Asset_label: W1 — Facet-1 create-hybrid: agent-workflow on apply create_instance (Task)
+exo__Asset_createdAt: 2026-06-21T19:11:13
+---
+
+Body.
+`;
+
+  // A second nested asset with WELL-FORMED YAML (control: filename lookup must
+  // also work for clean files).
+  const NESTED_CLEAN_UID = "a1b2c3d4-e5f6-4789-9abc-def012345678";
+  const NESTED_CLEAN_REL = path.join(
+    "assetspaces",
+    "kitelev",
+    "exoas-exodev",
+    "exodev",
+    `${NESTED_CLEAN_UID}.md`,
+  );
+
+  // A root-level UID-canon asset (AC#3: no regression for non-nested).
+  const ROOT_UID = "11112222-3333-4444-5555-666677778888";
+  const ROOT_REL = `${ROOT_UID}.md`;
+
+  // A NON-UID-named asset referenced by its UID — must still resolve via the
+  // frontmatter fallback (calendar-plugin whitelist files, e.g. pn__DailyNote).
+  const DAILY_UID = "99998888-7777-6666-5555-444433332222";
+  const DAILY_REL = path.join("daily", "2025-01-01.md");
+
+  const NONEXISTENT_UID = "deadbeef-0000-0000-0000-000000000000";
+
+  beforeAll(async () => {
+    vaultRoot = await fs.mkdtemp(path.join(os.tmpdir(), "wlv-3701-"));
+
+    await fs.outputFile(path.join(vaultRoot, NESTED_REL), MALFORMED_FRONTMATTER);
+    await fs.outputFile(
+      path.join(vaultRoot, NESTED_CLEAN_REL),
+      `---\nexo__Asset_uid: ${NESTED_CLEAN_UID}\nexo__Asset_label: Clean nested\n---\n\nBody.\n`,
+    );
+    await fs.outputFile(
+      path.join(vaultRoot, ROOT_REL),
+      `---\nexo__Asset_uid: ${ROOT_UID}\nexo__Asset_label: Root asset\n---\n\nBody.\n`,
+    );
+    await fs.outputFile(
+      path.join(vaultRoot, DAILY_REL),
+      `---\nexo__Asset_uid: ${DAILY_UID}\nexo__Asset_label: 2025-01-01\n---\n\nBody.\n`,
+    );
+
+    const adapter = new NodeFsAdapter(vaultRoot);
+    validator = new WikilinkValidator(adapter);
+  });
+
+  afterAll(async () => {
+    if (vaultRoot) {
+      await fs.remove(vaultRoot);
+    }
+  });
+
+  // AC#1 — the regression: nested UID-canon asset with MALFORMED YAML must pass
+  // validation (consistent with `resolve`). This is the revert-verify anchor:
+  // RED with the fix reverted, GREEN with it restored.
+  it("AC#1: passes for a nested UID-canon asset even with malformed YAML frontmatter", async () => {
+    await expect(
+      validator.validatePropertyValues({
+        "ems__Effort_parent": `[[${NESTED_UID}]]`,
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("AC#1b: passes for a nested UID-canon asset with well-formed YAML", async () => {
+    await expect(
+      validator.validatePropertyValues({
+        "ems__Effort_parent": `[[${NESTED_CLEAN_UID}|Clean nested]]`,
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  // AC#2 — must STILL reject a genuinely nonexistent UID (proof the validator is
+  // not blindly accepting everything). GREEN both pre- and post-fix.
+  it("AC#2: still rejects a nonexistent UID wikilink", async () => {
+    await expect(
+      validator.validatePropertyValues({
+        "ems__Effort_parent": `[[${NONEXISTENT_UID}|Missing]]`,
+      }),
+    ).rejects.toBeInstanceOf(WikilinkNotFoundError);
+  });
+
+  // AC#3 — no regression for root-level (non-nested) UID wikilinks.
+  it("AC#3: passes for a root-level UID-canon asset", async () => {
+    await expect(
+      validator.validatePropertyValues({
+        "ems__Effort_parent": `[[${ROOT_UID}]]`,
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  // Frontmatter fallback — a NON-UID-named asset referenced by its UID must still
+  // resolve (filename lookup misses, frontmatter scan finds it).
+  it("resolves a non-UID-named asset by its frontmatter exo__Asset_uid (fallback)", async () => {
+    await expect(
+      validator.validatePropertyValues({
+        "ems__Effort_day": `[[${DAILY_UID}|2025-01-01]]`,
+      }),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/packages/cli/tests/unit/services/WikilinkValidator.test.ts
+++ b/packages/cli/tests/unit/services/WikilinkValidator.test.ts
@@ -15,6 +15,8 @@ const mockFsAdapter = {
   directoryExists: jest.fn(),
   findFilesByMetadata: jest.fn(),
   findFileByUID: jest.fn<(uid: string) => Promise<string | null>>(),
+  findFileByUidFilename:
+    jest.fn<(uid: string) => Promise<string | null>>(),
 };
 
 jest.unstable_mockModule("../../../src/adapters/NodeFsAdapter.js", () => ({
@@ -35,7 +37,9 @@ describe("WikilinkValidator", () => {
 
   describe("validatePropertyValues()", () => {
     it("should pass for existing UUID wikilinks", async () => {
-      mockFsAdapter.fileExists.mockResolvedValue(true);
+      mockFsAdapter.findFileByUidFilename.mockResolvedValue(
+        "some/path/a3f9c2d1-1234-4567-8901-abcdef123456.md",
+      );
 
       await expect(
         validator.validatePropertyValues({
@@ -44,13 +48,13 @@ describe("WikilinkValidator", () => {
         }),
       ).resolves.toBeUndefined();
 
-      expect(mockFsAdapter.fileExists).toHaveBeenCalledWith(
-        "a3f9c2d1-1234-4567-8901-abcdef123456.md",
+      expect(mockFsAdapter.findFileByUidFilename).toHaveBeenCalledWith(
+        "a3f9c2d1-1234-4567-8901-abcdef123456",
       );
     });
 
     it("should throw WikilinkNotFoundError for missing UUID", async () => {
-      mockFsAdapter.fileExists.mockResolvedValue(false);
+      mockFsAdapter.findFileByUidFilename.mockResolvedValue(null);
       mockFsAdapter.findFileByUID.mockResolvedValue(null);
 
       await expect(
@@ -64,7 +68,7 @@ describe("WikilinkValidator", () => {
     });
 
     it("should throw WikilinkNotFoundError instance", async () => {
-      mockFsAdapter.fileExists.mockResolvedValue(false);
+      mockFsAdapter.findFileByUidFilename.mockResolvedValue(null);
       mockFsAdapter.findFileByUID.mockResolvedValue(null);
 
       await expect(
@@ -75,7 +79,7 @@ describe("WikilinkValidator", () => {
     });
 
     it("should validate multiple wikilinks in one value", async () => {
-      mockFsAdapter.fileExists.mockResolvedValue(true);
+      mockFsAdapter.findFileByUidFilename.mockResolvedValue("some/path.md");
 
       await expect(
         validator.validatePropertyValues({
@@ -84,13 +88,13 @@ describe("WikilinkValidator", () => {
         }),
       ).resolves.toBeUndefined();
 
-      expect(mockFsAdapter.fileExists).toHaveBeenCalledTimes(2);
+      expect(mockFsAdapter.findFileByUidFilename).toHaveBeenCalledTimes(2);
     });
 
     it("should fail on first missing wikilink", async () => {
-      mockFsAdapter.fileExists
-        .mockResolvedValueOnce(true) // First exists
-        .mockResolvedValueOnce(false); // Second does not
+      mockFsAdapter.findFileByUidFilename
+        .mockResolvedValueOnce("some/path.md") // First exists
+        .mockResolvedValueOnce(null); // Second does not
       mockFsAdapter.findFileByUID.mockResolvedValue(null);
 
       await expect(
@@ -109,7 +113,7 @@ describe("WikilinkValidator", () => {
         }),
       ).resolves.toBeUndefined();
 
-      expect(mockFsAdapter.fileExists).not.toHaveBeenCalled();
+      expect(mockFsAdapter.findFileByUidFilename).not.toHaveBeenCalled();
     });
 
     it("should skip non-UUID wikilinks like class names", async () => {
@@ -119,11 +123,11 @@ describe("WikilinkValidator", () => {
         }),
       ).resolves.toBeUndefined();
 
-      expect(mockFsAdapter.fileExists).not.toHaveBeenCalled();
+      expect(mockFsAdapter.findFileByUidFilename).not.toHaveBeenCalled();
     });
 
     it("should validate across multiple properties", async () => {
-      mockFsAdapter.fileExists.mockResolvedValue(true);
+      mockFsAdapter.findFileByUidFilename.mockResolvedValue("some/path.md");
 
       await expect(
         validator.validatePropertyValues({
@@ -132,7 +136,7 @@ describe("WikilinkValidator", () => {
         }),
       ).resolves.toBeUndefined();
 
-      expect(mockFsAdapter.fileExists).toHaveBeenCalledTimes(2);
+      expect(mockFsAdapter.findFileByUidFilename).toHaveBeenCalledTimes(2);
     });
 
     it("should handle properties without wikilinks", async () => {
@@ -143,19 +147,27 @@ describe("WikilinkValidator", () => {
         }),
       ).resolves.toBeUndefined();
 
-      expect(mockFsAdapter.fileExists).not.toHaveBeenCalled();
+      expect(mockFsAdapter.findFileByUidFilename).not.toHaveBeenCalled();
     });
 
-    it("should find file by UID fallback when filename does not match", async () => {
-      mockFsAdapter.fileExists.mockResolvedValue(false);
+    it("should find file by UID frontmatter fallback when filename does not match", async () => {
+      // Filename lookup misses (e.g. asset is not UID-named) but the
+      // frontmatter exo__Asset_uid scan finds it — must NOT throw.
+      mockFsAdapter.findFileByUidFilename.mockResolvedValue(null);
       mockFsAdapter.findFileByUID.mockResolvedValue("some/path/to/file.md");
 
-      // Should NOT throw because findFileByUID found it
       await expect(
         validator.validatePropertyValues({
           "prop": "[[aaaaaaaa-1111-2222-3333-444444444444|Found by UID]]",
         }),
       ).resolves.toBeUndefined();
+
+      expect(mockFsAdapter.findFileByUidFilename).toHaveBeenCalledWith(
+        "aaaaaaaa-1111-2222-3333-444444444444",
+      );
+      expect(mockFsAdapter.findFileByUID).toHaveBeenCalledWith(
+        "aaaaaaaa-1111-2222-3333-444444444444",
+      );
     });
   });
 


### PR DESCRIPTION
## Summary

`exocortex create --property "<prop>=[[<uuid>]]"` rejected a UID-wikilink as
**"file not found in vault"** for a nested asset that `exocortex resolve <uuid>`
found without issue — the two commands used different discovery paths.

Closes #3701.

## Real root cause (empirically established, **not** the candidate)

The issue candidate suspected glob/submodule traversal. **Empirically falsified** —
glob traverses the nested submodule fine and lists the file. The actual cause:

- `resolve` → `findFilesWithUuid` matches by **filename** (recursive walk, never
  reads file contents).
- `WikilinkValidator` → `fileExists("<uuid>.md")` (root only) → fallback
  `findFileByUID` → `findFilesByMetadata({exo__Asset_uid})` which **parses each
  file's YAML frontmatter**.

The real vault-exodev asset `3b40f843-…` has **malformed YAML** frontmatter — an
unquoted `exo__Asset_label` containing a colon:
`W1 — Фасет-1 create-гибрид: agent-workflow на apply create_instance`. js-yaml
throws `bad indentation of a mapping entry`; `extractFrontmatter` catches it and
returns `{}` → no `exo__Asset_uid` → `findFileByUID` returns `null` → validator
throws. `resolve` (filename-based) is immune to malformed YAML, hence the divergence.

Verified end-to-end with the published CLI (v16.141.1):
`resolve` returns the URI; `create --property` rejects the same UID.

## Fix

Route wikilink validation through the **same authoritative filename-based UID→path
discovery `resolve` uses**: new `NodeFsAdapter.findFileByUidFilename` (recursive,
mirrors `resolve.ts` `findFilesWithUuid`). It never reads file contents, so it finds
nested UID-canon assets at any depth even with malformed YAML. The frontmatter
`findFileByUID` scan is kept as a **fallback** so non-UID-named assets referenced by
UID (e.g. `pn__DailyNote` `YYYY-MM-DD.md`, `period__Week` `YYYY-Www.md`) still resolve.

Scope is minimal: a new `NodeFsAdapter` method + the validator's primary check.
`findFileByUID` semantics are untouched (its other callers — `apply`,
`folderRepairHelpers`, `ontologyImportsResolve`, `CachingNodeFsAdapter` parity —
are unaffected). The `IFileSystemAdapter` interface is untouched (the validator
takes a concrete `NodeFsAdapter`); `CachingNodeFsAdapter` inherits the new method.

## Acceptance criteria

1. ✅ `create --property "<prop>=[[<nested-uuid>]]"` for an existing nested asset
   passes validation, consistent with `resolve`.
2. ✅ `create --property "<prop>=[[<nonexistent-uuid>]]"` is still rejected.
3. ✅ Root-level UID-wikilinks still validate (no regression).
4. ✅ `--skip-wikilink-validation` workaround untouched.

## Testing — revert-verify (mandatory)

New production-shape test `WikilinkValidator.nestedUid.test.ts` uses a **real
on-disk multi-folder vault** + the **real `NodeFsAdapter`** (no glob/js-yaml mocks),
with a nested UID-named asset whose YAML is malformed exactly like the real bug.

**Empirically verified FAILS pre-fix / PASSES post-fix:**
- Fix reverted → **AC#1 RED** (nested malformed-YAML asset rejected), 4 passed.
- Fix restored → **all GREEN** (5/5 in the new suite; 69/69 across
  WikilinkValidator + NodeFsAdapter + createAsset + CachingNodeFsAdapter).
- AC#2 (nonexistent rejected) is **GREEN both ways** — proof the validator is not
  blindly accepting everything.

`npm run check:types` clean for `packages/cli` (the only pre-existing TS errors are
`nanotar` in obsidian-plugin, an unrelated local-deps artifact resolved by CI
`npm ci`).
