### PR TITLE
fix(core): quote YAML scalars on create_instance frontmatter writes (#3748)

### DIFF
--- a/packages/core/src/utilities/FrontmatterService.ts
+++ b/packages/core/src/utilities/FrontmatterService.ts
@@ -9,6 +9,7 @@
  */
 
 import { loadDefaultSpec, orderProperties } from "../services/OrderSpecResolver";
+import { serializeYamlScalar } from "./yamlScalar";
 
 /**
  * Result of frontmatter parsing operation
@@ -362,8 +363,10 @@ export class FrontmatterService {
    */
   createFrontmatter(content: string, properties: Record<string, unknown>): string {
     const ordered = orderProperties(properties, loadDefaultSpec());
+    // Issue #3748: quote scalars on new-asset writes so a label / alias
+    // containing `: ` (or another YAML indicator) stays valid YAML.
     const frontmatterLines = Object.entries(ordered).map(
-      ([key, value]) => this.serializeValue(key, value),
+      ([key, value]) => this.serializeValue(key, value, true),
     );
 
     const frontmatterBlock = `---\n${frontmatterLines.join("\n")}\n---`;
@@ -411,18 +414,33 @@ export class FrontmatterService {
    * @private
    */
   /**
-   * Serialize a property key-value pair to YAML string.
+   * Serialize a property key-value pair to a YAML frontmatter line.
    * Arrays are serialized as multi-line YAML lists.
+   *
+   * `quoteScalars` (Issue #3748) wraps string scalars / array items that would
+   * otherwise emit invalid YAML (e.g. `exo__Asset_label` containing `: `) in a
+   * double-quoted scalar. It is enabled ONLY on the `createFrontmatter` path
+   * (new-asset writes from `create_instance`). The `updateProperty` path leaves
+   * it OFF: that path receives already-formatted values — pre-quoted wikilinks
+   * and deliberate YAML flow-array strings like `["[[ems__Task]]"]` (multi-class
+   * convert) — that must be emitted verbatim, not re-quoted into a string.
    */
-  private serializeValue(property: string, value: unknown): string {
+  private serializeValue(
+    property: string,
+    value: unknown,
+    quoteScalars = false,
+  ): string {
     if (Array.isArray(value)) {
       if (value.length === 0) {
         return `${property}:`;
       }
-      const items = value.map((v) => `  - ${v}`).join("\n");
+      const items = value
+        .map((v) => `  - ${quoteScalars ? serializeYamlScalar(v) : String(v)}`)
+        .join("\n");
       return `${property}:\n${items}`;
     }
-    return `${property}: ${String(value)}`;
+    const scalar = quoteScalars ? serializeYamlScalar(value) : String(value);
+    return `${property}: ${scalar}`;
   }
 
   private escapeRegex(str: string): string {

--- a/packages/core/src/utilities/yamlScalar.ts
+++ b/packages/core/src/utilities/yamlScalar.ts
@@ -1,0 +1,78 @@
+/**
+ * YAML scalar serialization helpers — quote-when-needed.
+ *
+ * Issue #3748: `create_instance` / `apply create-task` wrote string scalars
+ * (notably `exo__Asset_label` and `aliases` items) verbatim into frontmatter.
+ * A label containing `: ` (colon-space) — e.g. `"ZZ probe: colon-space"` —
+ * produced invalid YAML (`mapping values are not allowed here` /
+ * `bad indentation of a mapping entry`). The created file then parsed to `{}`
+ * (silently un-parseable frontmatter) → invisible to findFileByUID / SHACL /
+ * metadataCache. Root cause of #3701 + ~16 broken WBS nodes.
+ *
+ * Strategy: emit string scalars verbatim UNLESS YAML would mis-parse them, in
+ * which case wrap in a double-quoted scalar with proper escaping. Deliberately
+ * conservative ("quote only when needed") so labels without special characters
+ * keep their existing bare form — avoids mass snapshot churn and over-quoting.
+ */
+
+const YAML_LEADING_INDICATORS = /^[-!&*?|>%@`"'#,[\]{}]/;
+
+/**
+ * Does this string require double-quoting to round-trip as a YAML plain scalar?
+ *
+ * Returns false for values that are ALREADY a complete double-quoted scalar
+ * (start and end with `"`) — production wikilink values arrive pre-wrapped as
+ * `"[[uid]]"` and must pass through verbatim.
+ */
+export function needsYamlQuoting(value: string): boolean {
+  // Empty → must be `""` (a bare empty value is an implicit null in YAML).
+  if (value === "") return true;
+
+  // Already a complete double-quoted scalar (e.g. `"[[StatusDone]]"`) — leave as-is.
+  if (value.length >= 2 && value.startsWith('"') && value.endsWith('"')) {
+    return false;
+  }
+
+  // Leading or trailing whitespace is stripped by a plain scalar.
+  if (value !== value.trim()) return true;
+
+  // `: ` or trailing `:` → YAML reads this as a nested mapping (the #3748 bug).
+  if (/:(\s|$)/.test(value)) return true;
+
+  // ` #` → YAML comment indicator mid-value.
+  if (/\s#/.test(value)) return true;
+
+  // Leading indicator characters that start anchors/aliases/tags/flow/quotes/etc.
+  if (YAML_LEADING_INDICATORS.test(value)) return true;
+
+  // Control characters that break a single-line plain scalar.
+  if (/[\n\r\t]/.test(value)) return true;
+
+  return false;
+}
+
+/** Wrap a string in a YAML double-quoted scalar with proper escaping. */
+export function quoteYamlString(value: string): string {
+  const escaped = value
+    .replace(/\\/g, "\\\\")
+    .replace(/"/g, '\\"')
+    .replace(/\n/g, "\\n")
+    .replace(/\r/g, "\\r")
+    .replace(/\t/g, "\\t");
+  return `"${escaped}"`;
+}
+
+/**
+ * Serialize a single scalar value for a YAML frontmatter line.
+ *
+ * - Non-strings (boolean, number) are emitted via `String()` unquoted so
+ *   `archived: true` / `priority: 1` keep YAML-native types.
+ * - Strings are emitted verbatim unless {@link needsYamlQuoting}, in which case
+ *   they are double-quoted via {@link quoteYamlString}.
+ */
+export function serializeYamlScalar(value: unknown): string {
+  if (typeof value !== "string") {
+    return String(value);
+  }
+  return needsYamlQuoting(value) ? quoteYamlString(value) : value;
+}

--- a/packages/core/tests/utilities/FrontmatterService.yamlQuoting.test.ts
+++ b/packages/core/tests/utilities/FrontmatterService.yamlQuoting.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Issue #3748 — `create_instance` / `apply create-task` must emit VALID YAML
+ * frontmatter even when a string scalar (notably `exo__Asset_label` and
+ * `aliases` items) contains `: ` (colon-space) or other YAML indicators.
+ *
+ * Production chokepoint: `GroundingExecutor.executeCreateInstance` builds the
+ * `properties` object (including `exo__Asset_label = userInput.label` verbatim
+ * and `aliases = [label]`) then calls `FrontmatterService.createFrontmatter`
+ * (GroundingExecutor.ts:1092). These tests exercise that exact serializer and
+ * parse the result with a REAL YAML parser (js-yaml), asserting both that it
+ * loads and that the value round-trips to the original literal.
+ *
+ * Revert-verify: with the quote fix reverted (serializeValue emitting
+ * `${property}: ${String(value)}` verbatim) the colon-label / aliases cases
+ * FAIL (js-yaml throws "bad indentation of a mapping entry"). With the fix they
+ * PASS. Empirically verified FAILS pre-fix / PASSES post-fix.
+ */
+import * as yaml from "js-yaml";
+import { FrontmatterService } from "../../src/utilities/FrontmatterService";
+
+function parseFrontmatter(created: string): Record<string, unknown> {
+  const match = created.match(/^---\n([\s\S]*?)\n---/);
+  if (!match) throw new Error(`No frontmatter block in: ${created}`);
+  return yaml.load(match[1]) as Record<string, unknown>;
+}
+
+describe("FrontmatterService — YAML-safe scalar quoting (#3748)", () => {
+  const service = new FrontmatterService();
+
+  it("colon-space label produces valid YAML and round-trips (scalar + aliases)", () => {
+    const label = "ZZ probe: colon-space inside label";
+    const created = service.createFrontmatter("", {
+      exo__Asset_label: label,
+      aliases: [label],
+    });
+
+    // Must not throw — this is the regression: verbatim emission throws here.
+    const parsed = parseFrontmatter(created);
+
+    expect(parsed.exo__Asset_label).toBe(label);
+    expect(parsed.aliases).toEqual([label]);
+  });
+
+  it("plain label without special chars is NOT gratuitously quoted (no regression)", () => {
+    const created = service.createFrontmatter("", {
+      exo__Asset_label: "Plain Task Label",
+      status: "draft",
+    });
+
+    expect(created).toContain("exo__Asset_label: Plain Task Label");
+    expect(created).toContain("status: draft");
+    // No quotes added around bare values.
+    expect(created).not.toContain('"Plain Task Label"');
+  });
+
+  it("pre-quoted wikilink values pass through verbatim (not double-quoted)", () => {
+    const created = service.createFrontmatter("", {
+      exo__Instance_class: '"[[1b20a8f0]]"',
+      aliases: ['"[[SomeLabel]]"'],
+    });
+
+    expect(created).toContain('exo__Instance_class: "[[1b20a8f0]]"');
+    expect(created).toContain('  - "[[SomeLabel]]"');
+    expect(created).not.toContain('\\"[[');
+
+    const parsed = parseFrontmatter(created);
+    expect(parsed.exo__Instance_class).toBe("[[1b20a8f0]]");
+    expect(parsed.aliases).toEqual(["[[SomeLabel]]"]);
+  });
+
+  it("edge cases: leading indicator, surrounding spaces, embedded quote, empty", () => {
+    const cases: Record<string, string> = {
+      leadingBang: "!important reminder",
+      leadingAt: "@mention thing",
+      leadingHash: "#hashtag note",
+      surroundingSpaces: "  padded label  ",
+      embeddedQuoteWithColon: 'He said: "go"',
+      empty: "",
+    };
+
+    const created = service.createFrontmatter("", { ...cases });
+    const parsed = parseFrontmatter(created);
+
+    for (const [key, value] of Object.entries(cases)) {
+      expect(parsed[key]).toBe(value);
+    }
+  });
+
+  it("booleans and numbers stay unquoted (YAML-native types preserved)", () => {
+    const created = service.createFrontmatter("", {
+      archived: true,
+      draft: false,
+      priority: 1,
+      effort: 42,
+    });
+
+    expect(created).toContain("archived: true");
+    expect(created).toContain("draft: false");
+    expect(created).toContain("priority: 1");
+    expect(created).toContain("effort: 42");
+
+    const parsed = parseFrontmatter(created);
+    expect(parsed.archived).toBe(true);
+    expect(parsed.priority).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary

`create_instance` / `apply create-task` wrote `exo__Asset_label` (and `aliases` items) **verbatim** into frontmatter. A label containing `: ` (colon-space) — e.g. `"ZZ probe: colon-space inside label"` — produced **invalid YAML** (`mapping values are not allowed here` / `bad indentation of a mapping entry`). The created file then parsed to `{}` — silently un-parseable frontmatter → invisible to `findFileByUID` / SHACL / `metadataCache`. Root cause of #3701 and ~16 broken WBS nodes in `exoas-exodev/exodev`.

Closes #3748.

## Real chokepoint (empirically established)

`create_instance` serializes frontmatter via **`FrontmatterService.createFrontmatter`** → `serializeValue` (`GroundingExecutor.executeCreateInstance:1092`: `this.frontmatterService.createFrontmatter("", properties)`, where `properties.exo__Asset_label` = raw label and `properties.aliases = [label]`). Its scalar branch emitted `${property}: ${String(value)}` and array items `  - ${v}` verbatim — no quoting.

Empirical repro on the chokepoint:
```
exo__Asset_label: ZZ probe: colon-space inside label   ← invalid YAML
aliases:
  - ZZ probe: colon-space inside label                 ← invalid YAML
# js-yaml → YAMLException: bad indentation of a mapping entry
```

## Fix

- New shared helper `packages/core/src/utilities/yamlScalar.ts` — `serializeYamlScalar` (quote-when-needed): wraps a string scalar in a double-quoted YAML scalar **only when** it would otherwise mis-parse (contains `: `/trailing `:`, leading YAML indicator `!&*?|>%@\`"'#,[]{}-`, leading/trailing whitespace, ` #`, control chars, or empty). Already-quoted values (`"[[uid]]"`) and booleans/numbers pass through unchanged. Internal `"`/`\`/newlines escaped.
- `FrontmatterService.serializeValue` gets a `quoteScalars` flag, enabled **only on the `createFrontmatter` (new-asset) path**. The `updateProperty` path stays verbatim on purpose — it receives already-formatted values (pre-quoted wikilinks + deliberate YAML flow-array strings like `["[[ems__Task]]"]` for multi-class convert) that must not be re-quoted into a string.

### MetadataHelpers — descoped (follow-up)
`MetadataHelpers.buildFileContent` has the same latent verbatim emission, but quoting it changes output for **all 9 callers** that rely on Obsidian's lenient bare-wikilink parsing (e.g. `link: [[MyFile]]` → would become `"[[MyFile]]"`; empty → `""`) — a broad behavioral change beyond #3748 (which is the `create_instance` path). Left verbatim; tracked as a follow-up.

## Testing — revert-verify (empirically verified FAILS pre-fix / PASSES post-fix)

New `packages/core/tests/utilities/FrontmatterService.yamlQuoting.test.ts` drives the real `createFrontmatter` chokepoint with the production property shape and parses the result with **js-yaml**:
- colon-space label → valid YAML, round-trips to literal `ZZ probe: colon-space inside label` (scalar + aliases item)
- plain label → **not** gratuitously quoted (no snapshot regression)
- pre-quoted wikilinks pass through verbatim (not double-quoted)
- edge cases: leading `!`/`@`/`#`, surrounding spaces, embedded `"`, empty string
- booleans/numbers stay unquoted (YAML-native types)

**Revert-verify:** with the `quoteScalars` flag flipped to `false` (fix disabled, type-preserving), the colon-label + edge-case tests **FAIL** (`YAMLException: bad indentation of a mapping entry` / `unknown tag !<!important>`); restored → **PASS**.

End-to-end against the **built core dist**: `createFrontmatter` with `{exo__Asset_label:"ZZ probe: colon-space...", aliases:[...], exo__Instance_class:'"[[..]]"'}` → valid YAML, round-trips, wikilinks verbatim.

Full affected-suite run (FrontmatterService / MetadataHelpers / GroundingExecutor / DynamicFrontmatterGenerator / GroundingFrontmatterParser): **578/578 green** — both `create_instance` (now quoted) and convert/`updateProperty` flow-array (verbatim preserved) paths pass. Typecheck clean.
