### PR TITLE
fix(core): harden frontmatter scalar quoting — wire MetadataHelpers + tighten passthrough/coercion/control-chars (#3750)

### DIFF
--- a/packages/core/src/utilities/FrontmatterService.ts
+++ b/packages/core/src/utilities/FrontmatterService.ts
@@ -9,7 +9,7 @@
  */
 
 import { loadDefaultSpec, orderProperties } from "../services/OrderSpecResolver";
-import { serializeYamlScalar } from "./yamlScalar";
+import { serializeYamlScalar, STRING_SCALAR_PROPERTIES } from "./yamlScalar";
 
 /**
  * Result of frontmatter parsing operation
@@ -430,16 +430,25 @@ export class FrontmatterService {
     value: unknown,
     quoteScalars = false,
   ): string {
+    // #3750 MEDIUM-3: also quote scalar-looking strings (123 / true / date)
+    // for string-semantic properties (label / aliases) so they round-trip as
+    // strings; other properties keep native number/date type.
+    const quoteAmbiguous = quoteScalars && STRING_SCALAR_PROPERTIES.has(property);
     if (Array.isArray(value)) {
       if (value.length === 0) {
         return `${property}:`;
       }
       const items = value
-        .map((v) => `  - ${quoteScalars ? serializeYamlScalar(v) : String(v)}`)
+        .map(
+          (v) =>
+            `  - ${quoteScalars ? serializeYamlScalar(v, quoteAmbiguous) : String(v)}`,
+        )
         .join("\n");
       return `${property}:\n${items}`;
     }
-    const scalar = quoteScalars ? serializeYamlScalar(value) : String(value);
+    const scalar = quoteScalars
+      ? serializeYamlScalar(value, quoteAmbiguous)
+      : String(value);
     return `${property}: ${scalar}`;
   }
 

--- a/packages/core/src/utilities/MetadataHelpers.ts
+++ b/packages/core/src/utilities/MetadataHelpers.ts
@@ -1,4 +1,8 @@
 import { loadDefaultSpec, orderProperties } from "../services/OrderSpecResolver";
+import {
+  serializeYamlScalar,
+  STRING_SCALAR_PROPERTIES,
+} from "./yamlScalar";
 
 export class MetadataHelpers {
   static findAllReferencingProperties(
@@ -146,11 +150,19 @@ export class MetadataHelpers {
     const ordered = orderProperties(frontmatter, loadDefaultSpec());
     const frontmatterLines = Object.entries(ordered)
       .map(([key, value]) => {
+        // #3750 MEDIUM-1: route through serializeYamlScalar so scalars with
+        // YAML-breaking chars (colon-space, leading indicators, control chars)
+        // are quoted — mirrors the #3748 fix on the create_instance serializer
+        // (FrontmatterService.serializeValue). Scalar-looking coercion (#3750
+        // MEDIUM-3) is gated to string-semantic properties (label/aliases).
+        const quoteAmbiguous = STRING_SCALAR_PROPERTIES.has(key);
         if (Array.isArray(value)) {
-          const arrayItems = value.map((item) => `  - ${String(item)}`).join("\n");
+          const arrayItems = value
+            .map((item) => `  - ${serializeYamlScalar(item, quoteAmbiguous)}`)
+            .join("\n");
           return `${key}:\n${arrayItems}`;
         }
-        return `${key}: ${String(value)}`;
+        return `${key}: ${serializeYamlScalar(value, quoteAmbiguous)}`;
       })
       .join("\n");
 

--- a/packages/core/src/utilities/yamlScalar.ts
+++ b/packages/core/src/utilities/yamlScalar.ts
@@ -9,27 +9,126 @@
  * (silently un-parseable frontmatter) → invisible to findFileByUID / SHACL /
  * metadataCache. Root cause of #3701 + ~16 broken WBS nodes.
  *
- * Strategy: emit string scalars verbatim UNLESS YAML would mis-parse them, in
- * which case wrap in a double-quoted scalar with proper escaping. Deliberately
- * conservative ("quote only when needed") so labels without special characters
- * keep their existing bare form — avoids mass snapshot churn and over-quoting.
+ * Issue #3750 (follow-up hardening, from an adversarial review of #3749):
+ *  - MEDIUM-2: the `"`-wrapped passthrough accepted ANY value starting+ending
+ *    with `"`, so `"a" and "b"` (not a complete scalar) emitted bare → invalid
+ *    YAML. Tightened to pass through only a *complete* double-quoted scalar
+ *    (no unescaped interior `"`).
+ *  - MEDIUM-3: scalar-looking strings (`123`, `12_000`, `true`, `null`, `~`,
+ *    `1.5`, `.inf`, `.nan`, date-only `2026-01-15`) emitted bare are coerced to
+ *    number/bool/null/Date by a real YAML parser (Obsidian metadataCache) —
+ *    wrong type for a semantically-string label/alias. They are now quoted so
+ *    they round-trip as strings. NB: datetime timestamps (`YYYY-MM-DDThh:mm:ss`,
+ *    the system's `createdAt`/`updatedAt`/effort-timestamp format) are
+ *    deliberately NOT quoted — they are semantic dates and stay bare.
+ *  - LOW-4: control chars beyond `\n\r\t` (`\x07`, `\b`, `\f`, `\v`, NUL, DEL)
+ *    are detected and escaped (`\xNN`) so they never reach a parser bare.
+ *
+ * Strategy: emit string scalars verbatim UNLESS YAML would mis-parse or
+ * mis-type them, in which case wrap in a double-quoted scalar with proper
+ * escaping. Deliberately conservative ("quote only when needed") so labels
+ * without special characters keep their existing bare form — avoids mass
+ * snapshot churn and over-quoting.
  */
 
 const YAML_LEADING_INDICATORS = /^[-!&*?|>%@`"'#,[\]{}]/;
 
+// Control characters (C0 range + DEL) that break a single-line plain scalar.
+// Covers `\t` `\n` `\r` plus `\x07` `\b` `\f` `\v` NUL etc. (#3750 LOW-4).
+// eslint-disable-next-line no-control-regex
+const YAML_CONTROL_CHARS = /[\u0000-\u001f\u007f]/;
+
+// Scalar tokens a real YAML parser (js-yaml DEFAULT_SCHEMA, used by Obsidian
+// metadataCache) coerces away from string. Replicated from js-yaml's resolvers
+// (lib/type/{bool,null,int,float,timestamp}.js). (#3750 MEDIUM-3.)
+const YAML_BOOL = /^(?:true|True|TRUE|false|False|FALSE)$/;
+const YAML_NULL = /^(?:null|Null|NULL|~)$/;
+const YAML_INT = /^[-+]?(?:0b[01_]+|0o[0-7_]+|0x[0-9a-fA-F_]+|[0-9][0-9_]*)$/;
+const YAML_FLOAT =
+  /^(?:[-+]?[0-9][0-9_]*(?:\.[0-9_]*)?(?:[eE][-+]?[0-9]+)?|\.[0-9_]+(?:[eE][-+]?[0-9]+)?|[-+]?\.(?:inf|Inf|INF)|\.(?:nan|NaN|NAN))$/;
+// Date-only timestamp (`2026-01-15`). Datetime values (with a `T`/time part)
+// are intentionally excluded — they are the system's semantic-date format.
+const YAML_DATE = /^[0-9]{4}-[0-9]{2}-[0-9]{2}$/;
+
+/**
+ * Frontmatter properties whose values are semantically STRINGS (labels), so a
+ * scalar-looking value (`123`, `true`, `2026-01-15`) must be quoted to avoid
+ * type-coercion (#3750 MEDIUM-3). This is deliberately narrow: timestamp
+ * properties (`exo__Asset_createdAt`, `ems__Effort_plannedStartTimestamp`, …)
+ * and numeric properties are NOT here — they SHOULD keep their native
+ * number/date type under a real YAML parser.
+ */
+export const STRING_SCALAR_PROPERTIES = new Set<string>([
+  "exo__Asset_label",
+  "aliases",
+]);
+
+/**
+ * Is the value a COMPLETE, single double-quoted YAML scalar (`"…"`)?
+ *
+ * True for production-formed values like `"[[uid]]"` (wikilinks arrive
+ * pre-wrapped) and `"My Workflow"` (DefaultWorkflows pre-wraps labels) — these
+ * pass through verbatim. False for `"a" and "b"` (two quoted runs — has an
+ * unescaped interior `"`) and `"\"` (the closing quote is escaped), which must
+ * be re-quoted instead of emitted as invalid YAML. (#3750 MEDIUM-2.)
+ */
+function isCompleteDoubleQuotedScalar(value: string): boolean {
+  if (value.length < 2 || !value.startsWith('"') || !value.endsWith('"')) {
+    return false;
+  }
+  const inner = value.slice(1, -1);
+  for (let i = 0; i < inner.length; i++) {
+    if (inner[i] === "\\") {
+      // A trailing backslash would escape the closing `"` → not complete.
+      if (i + 1 >= inner.length) return false;
+      i++; // skip the escaped char
+      continue;
+    }
+    if (inner[i] === '"') return false; // unescaped interior quote
+  }
+  return true;
+}
+
+/**
+ * Does a real YAML parser coerce this bare plain scalar to a non-string type?
+ * (#3750 MEDIUM-3 — quote these so a semantically-string label/alias survives
+ * as a string.) Datetime timestamps are excluded by {@link YAML_DATE} so the
+ * system's `createdAt`/effort-timestamp values keep their native date type.
+ */
+function looksLikeNonStringScalar(value: string): boolean {
+  return (
+    YAML_BOOL.test(value) ||
+    YAML_NULL.test(value) ||
+    YAML_INT.test(value) ||
+    YAML_FLOAT.test(value) ||
+    YAML_DATE.test(value)
+  );
+}
+
 /**
  * Does this string require double-quoting to round-trip as a YAML plain scalar?
  *
- * Returns false for values that are ALREADY a complete double-quoted scalar
- * (start and end with `"`) — production wikilink values arrive pre-wrapped as
- * `"[[uid]]"` and must pass through verbatim.
+ * Returns false for values that are ALREADY a complete double-quoted scalar —
+ * production wikilink values arrive pre-wrapped as `"[[uid]]"` and some callers
+ * pre-wrap plain labels as `"name"`; both must pass through verbatim.
+ *
+ * @param quoteAmbiguousScalars — when true (string-semantic properties like
+ *   `exo__Asset_label` / `aliases`), also quote scalar-looking strings so they
+ *   survive as strings (#3750 MEDIUM-3). Default false — number/bool/date-shaped
+ *   values of OTHER properties keep their native YAML type.
  */
-export function needsYamlQuoting(value: string): boolean {
+export function needsYamlQuoting(
+  value: string,
+  quoteAmbiguousScalars = false,
+): boolean {
   // Empty → must be `""` (a bare empty value is an implicit null in YAML).
   if (value === "") return true;
 
-  // Already a complete double-quoted scalar (e.g. `"[[StatusDone]]"`) — leave as-is.
-  if (value.length >= 2 && value.startsWith('"') && value.endsWith('"')) {
+  // Already a COMPLETE double-quoted scalar (e.g. `"[[StatusDone]]"`) — leave
+  // as-is. Tightened in #3750 MEDIUM-2: an incomplete/invalid quoted run like
+  // `"a" and "b"` is NOT passed through (it would emit invalid YAML); it falls
+  // through to quoteYamlString and round-trips as the literal string.
+  if (isCompleteDoubleQuotedScalar(value)) {
     return false;
   }
 
@@ -45,21 +144,41 @@ export function needsYamlQuoting(value: string): boolean {
   // Leading indicator characters that start anchors/aliases/tags/flow/quotes/etc.
   if (YAML_LEADING_INDICATORS.test(value)) return true;
 
-  // Control characters that break a single-line plain scalar.
-  if (/[\n\r\t]/.test(value)) return true;
+  // Control characters that break a single-line plain scalar (#3750 LOW-4).
+  if (YAML_CONTROL_CHARS.test(value)) return true;
+
+  // Scalar-looking strings coerced to non-string types by a real YAML parser
+  // (#3750 MEDIUM-3) — quote so a semantically-string value round-trips. Gated
+  // to string-semantic properties so timestamp/numeric properties keep their
+  // native type (see {@link STRING_SCALAR_PROPERTIES}).
+  if (quoteAmbiguousScalars && looksLikeNonStringScalar(value)) return true;
 
   return false;
 }
 
-/** Wrap a string in a YAML double-quoted scalar with proper escaping. */
+/**
+ * Wrap a string in a YAML double-quoted scalar with proper escaping.
+ *
+ * Escapes `\` `"` `\n` `\r` `\t` and any other control character (`\xNN`) so
+ * the quoted form is itself valid and js-yaml can load it (#3750 LOW-4).
+ */
 export function quoteYamlString(value: string): string {
-  const escaped = value
-    .replace(/\\/g, "\\\\")
-    .replace(/"/g, '\\"')
-    .replace(/\n/g, "\\n")
-    .replace(/\r/g, "\\r")
-    .replace(/\t/g, "\\t");
-  return `"${escaped}"`;
+  let out = "";
+  for (let i = 0; i < value.length; i++) {
+    const ch = value[i];
+    const code = value.charCodeAt(i);
+    if (ch === "\\") out += "\\\\";
+    else if (ch === '"') out += '\\"';
+    else if (ch === "\n") out += "\\n";
+    else if (ch === "\r") out += "\\r";
+    else if (ch === "\t") out += "\\t";
+    else if (code < 0x20 || code === 0x7f) {
+      out += "\\x" + code.toString(16).toUpperCase().padStart(2, "0");
+    } else {
+      out += ch;
+    }
+  }
+  return `"${out}"`;
 }
 
 /**
@@ -70,9 +189,14 @@ export function quoteYamlString(value: string): string {
  * - Strings are emitted verbatim unless {@link needsYamlQuoting}, in which case
  *   they are double-quoted via {@link quoteYamlString}.
  */
-export function serializeYamlScalar(value: unknown): string {
+export function serializeYamlScalar(
+  value: unknown,
+  quoteAmbiguousScalars = false,
+): string {
   if (typeof value !== "string") {
     return String(value);
   }
-  return needsYamlQuoting(value) ? quoteYamlString(value) : value;
+  return needsYamlQuoting(value, quoteAmbiguousScalars)
+    ? quoteYamlString(value)
+    : value;
 }

--- a/packages/core/tests/utilities/MetadataHelpers.test.ts
+++ b/packages/core/tests/utilities/MetadataHelpers.test.ts
@@ -641,14 +641,17 @@ describe("MetadataHelpers", () => {
       expect(result).toBe("---\ntags:\n\n---\n\n");
     });
 
-    it("should preserve value formatting", () => {
+    it("should emit YAML-safe values (bare wikilink quoted; non-label date stays bare)", () => {
       const frontmatter = {
         link: "[[MyFile]]",
         date: "2025-10-24",
       };
       const result = MetadataHelpers.buildFileContent(frontmatter);
 
-      expect(result).toBe("---\nlink: [[MyFile]]\ndate: 2025-10-24\n---\n\n");
+      // #3750: a bare `[[MyFile]]` parses as a nested flow array in real YAML,
+      // so it is quoted (universal). `date` is NOT a string-semantic property,
+      // so the date-only value stays bare (MEDIUM-3 is gated to label/aliases).
+      expect(result).toBe('---\nlink: "[[MyFile]]"\ndate: 2025-10-24\n---\n\n');
     });
 
     it("should handle multiline body", () => {
@@ -691,7 +694,9 @@ describe("MetadataHelpers", () => {
       };
       const result = MetadataHelpers.buildFileContent(frontmatter);
 
-      expect(result).toBe("---\nexo__Asset_label: \n---\n\n");
+      // #3750: a bare empty value parses as null in YAML; quote so it stays an
+      // empty string.
+      expect(result).toBe('---\nexo__Asset_label: ""\n---\n\n');
     });
   });
 

--- a/packages/core/tests/utilities/MetadataHelpers.yamlQuoting.test.ts
+++ b/packages/core/tests/utilities/MetadataHelpers.yamlQuoting.test.ts
@@ -1,0 +1,105 @@
+/**
+ * Issue #3750 MEDIUM-1 — `MetadataHelpers.buildFileContent` is the SECOND
+ * new-asset serializer (used by Concept / Area / Class / Session / Supervision
+ * creation + DefaultWorkflows). It emitted scalars + array items verbatim
+ * (`${String(value)}`) — the same latent #3748 bug fixed for the
+ * `create_instance` path (`FrontmatterService.createFrontmatter`).
+ *
+ * This mirrors `FrontmatterService.yamlQuoting.test.ts`: it exercises the real
+ * `buildFileContent` serializer and parses the produced frontmatter with a REAL
+ * YAML parser (js-yaml), asserting both that it LOADS and that the value
+ * round-trips.
+ *
+ * Revert-verify (empirically confirmed FAILS pre-fix / PASSES post-fix): with
+ * the `serializeYamlScalar` wiring reverted to `${String(value)}`, the
+ * colon-space scalar + array-item cases throw "bad indentation of a mapping
+ * entry" in js-yaml.
+ */
+import * as yaml from "js-yaml";
+import { MetadataHelpers } from "../../src/utilities/MetadataHelpers";
+
+function parseFrontmatter(content: string): Record<string, unknown> {
+  const match = content.match(/^---\n([\s\S]*?)\n---/);
+  if (!match) throw new Error(`No frontmatter block in: ${content}`);
+  return yaml.load(match[1]) as Record<string, unknown>;
+}
+
+describe("MetadataHelpers.buildFileContent — YAML-safe scalar quoting (#3750)", () => {
+  it("colon-space label produces valid YAML and round-trips (scalar + aliases array)", () => {
+    const label = "ZZ probe: colon-space inside label";
+    const content = MetadataHelpers.buildFileContent({
+      exo__Asset_label: label,
+      aliases: [label],
+    });
+
+    // Pre-fix: verbatim emission of a colon-space scalar throws here.
+    const parsed = parseFrontmatter(content);
+
+    expect(parsed.exo__Asset_label).toBe(label);
+    expect(parsed.aliases).toEqual([label]);
+  });
+
+  it("plain label without special chars is NOT gratuitously quoted (no regression)", () => {
+    const content = MetadataHelpers.buildFileContent({
+      exo__Asset_label: "Plain Concept Label",
+      ims__Concept_definition: "a normal definition",
+    });
+
+    expect(content).toContain("exo__Asset_label: Plain Concept Label");
+    expect(content).toContain("ims__Concept_definition: a normal definition");
+    expect(content).not.toContain('"Plain Concept Label"');
+  });
+
+  it("pre-quoted wikilink values pass through verbatim (not double-quoted)", () => {
+    const content = MetadataHelpers.buildFileContent({
+      exo__Instance_class: ['"[[concept__Concept]]"'],
+      ims__Concept_broader: '"[[Parent Concept]]"',
+    });
+
+    expect(content).toContain('  - "[[concept__Concept]]"');
+    expect(content).toContain('ims__Concept_broader: "[[Parent Concept]]"');
+    expect(content).not.toContain('\\"[[');
+
+    const parsed = parseFrontmatter(content);
+    expect(parsed.exo__Instance_class).toEqual(["[[concept__Concept]]"]);
+    expect(parsed.ims__Concept_broader).toBe("[[Parent Concept]]");
+  });
+
+  it("scalar-looking LABEL/aliases round-trip as strings, not number/bool/date", () => {
+    const content = MetadataHelpers.buildFileContent({
+      exo__Asset_label: "2026-01-15",
+      aliases: ["123", "true"],
+    });
+    const parsed = parseFrontmatter(content);
+
+    expect(parsed.exo__Asset_label).toBe("2026-01-15");
+    expect(typeof parsed.exo__Asset_label).toBe("string");
+    expect(parsed.aliases).toEqual(["123", "true"]);
+  });
+
+  it("scalar-looking NON-label property keeps its native type (timestamp/numeric props not over-quoted)", () => {
+    // #3750 MEDIUM-3 is gated to label/aliases: a date-only value on a
+    // timestamp property must stay bare (coerces to a Date), not become a
+    // quoted string.
+    const content = MetadataHelpers.buildFileContent({
+      exo__Asset_label: "Plain",
+      ems__Effort_plannedStartTimestamp: "2026-05-23",
+    });
+
+    expect(content).toContain(
+      "ems__Effort_plannedStartTimestamp: 2026-05-23",
+    );
+    expect(content).not.toContain('"2026-05-23"');
+  });
+
+  it("array item with colon-space stays valid YAML and round-trips", () => {
+    const item = "alias: with colon";
+    const content = MetadataHelpers.buildFileContent({
+      exo__Asset_label: "Plain",
+      aliases: [item, "plain alias"],
+    });
+    const parsed = parseFrontmatter(content);
+
+    expect(parsed.aliases).toEqual([item, "plain alias"]);
+  });
+});

--- a/packages/core/tests/utilities/yamlScalar.test.ts
+++ b/packages/core/tests/utilities/yamlScalar.test.ts
@@ -1,0 +1,154 @@
+/**
+ * Issue #3750 — hardening `serializeYamlScalar` (follow-up to #3748).
+ *
+ * Every assertion parses the emitted scalar with a REAL YAML parser (js-yaml,
+ * the same family Obsidian metadataCache uses) in a `key: value` mapping
+ * context — the exact shape the frontmatter serializers emit.
+ *
+ * Revert-verify (empirically confirmed FAILS pre-fix / PASSES post-fix):
+ *  - MEDIUM-2: revert the `isCompleteDoubleQuotedScalar` tightening (passthrough
+ *    ANY `"…"`), and the `"a" and "b"` case throws in js-yaml.
+ *  - MEDIUM-3: remove the `looksLikeNonStringScalar` check, and `123`/`true`/
+ *    `2026-01-15` round-trip to number/boolean/Date (not string).
+ *  - LOW-4: revert the control-char escaping, and `\x07` throws
+ *    ("non-printable characters") in js-yaml.
+ */
+import * as yaml from "js-yaml";
+import { serializeYamlScalar } from "../../src/utilities/yamlScalar";
+
+/** Emit a scalar, parse it back in a real `key: value` mapping. */
+function roundTrip(value: unknown, quoteAmbiguous = false): unknown {
+  const line = `v: ${serializeYamlScalar(value, quoteAmbiguous)}`;
+  const parsed = yaml.load(line) as Record<string, unknown>;
+  return parsed.v;
+}
+
+describe("serializeYamlScalar (#3750)", () => {
+  describe("MEDIUM-2 — `\"`-wrapped passthrough tightening", () => {
+    it("re-quotes `\"a\" and \"b\"` (not a complete scalar) so it round-trips as the literal string", () => {
+      const input = '"a" and "b"';
+      // Pre-fix this emitted bare → js-yaml throws. Post-fix it is quoted.
+      expect(() => roundTrip(input)).not.toThrow();
+      expect(roundTrip(input)).toBe(input);
+    });
+
+    it("re-quotes `\"` (closing quote escaped → incomplete scalar)", () => {
+      const input = '"\\"';
+      expect(() => roundTrip(input)).not.toThrow();
+      expect(roundTrip(input)).toBe(input);
+    });
+
+    it("passes a complete pre-quoted wikilink through verbatim (no regression)", () => {
+      const input = '"[[1b20a8f0-uid]]"';
+      // Production wikilinks arrive pre-wrapped; must NOT be double-quoted.
+      expect(serializeYamlScalar(input)).toBe(input);
+      expect(roundTrip(input)).toBe("[[1b20a8f0-uid]]");
+    });
+
+    it("passes a complete pre-quoted plain label through (DefaultWorkflows `\"${name}\"` — no regression)", () => {
+      // DefaultWorkflows.ts pre-wraps labels as `"My Workflow"`. A complete
+      // double-quoted scalar passes through (the prompt Part-2 spec). NB: this
+      // also means a user-literal `"test"` round-trips to `test`, not `"test"`
+      // — the two are byte-identical and the production passthrough wins.
+      expect(serializeYamlScalar('"My Workflow"')).toBe('"My Workflow"');
+      expect(roundTrip('"My Workflow"')).toBe("My Workflow");
+    });
+  });
+
+  describe("MEDIUM-3 — scalar-looking strings quoted to round-trip as strings", () => {
+    const coercibleStrings = [
+      "123",
+      "12_000",
+      "0x1A",
+      "0o17",
+      "-17",
+      "true",
+      "True",
+      "TRUE",
+      "false",
+      "FALSE",
+      "null",
+      "Null",
+      "~",
+      "1.5",
+      ".inf",
+      "-.inf",
+      ".nan",
+      "2e3",
+      "2026-01-15",
+    ];
+
+    it.each(coercibleStrings)(
+      "for a string-semantic property quotes %p so a real YAML parser keeps it a string",
+      (s) => {
+        const result = roundTrip(s, true); // quoteAmbiguousScalars (label/aliases)
+        expect(typeof result).toBe("string");
+        expect(result).toBe(s);
+      },
+    );
+
+    // Subset that is quoted ONLY by MEDIUM-3 (not by a universal leading
+    // indicator like `-`). `-17` / `-.inf` start with `-` and are always quoted.
+    const coercibleNonIndicator = coercibleStrings.filter(
+      (s) => !/^[-+]/.test(s),
+    );
+
+    it.each(coercibleNonIndicator)(
+      "for a non-string-semantic property leaves %p bare (timestamp/numeric props keep native type)",
+      (s) => {
+        // Default (quoteAmbiguousScalars=false) — e.g. plannedStartTimestamp.
+        expect(serializeYamlScalar(s)).toBe(s);
+      },
+    );
+
+    it("does NOT quote datetime timestamps even for a string-semantic property", () => {
+      const datetime = "2025-10-24T14:30:45";
+      // Datetime is excluded from MEDIUM-3 (semantic-date format).
+      expect(serializeYamlScalar(datetime, true)).toBe(datetime);
+      expect(roundTrip(datetime, true)).toBeInstanceOf(Date);
+    });
+  });
+
+  describe("LOW-4 — control characters escaped, never emitted bare", () => {
+    const controlStrings = [
+      "bell\x07here",
+      "back\x08space",
+      "form\x0cfeed",
+      "vert\x0btab",
+      "nul\x00byte",
+      "del\x7fchar",
+    ];
+
+    it.each(controlStrings)(
+      "escapes control chars in %j so js-yaml loads and round-trips it",
+      (s) => {
+        expect(() => roundTrip(s)).not.toThrow();
+        expect(roundTrip(s)).toBe(s);
+      },
+    );
+  });
+
+  describe("no gratuitous quoting / native types preserved", () => {
+    it.each(["Plain Task Label", "draft", "concept name", "a/b/c path"])(
+      "leaves plain string %p bare",
+      (s) => {
+        expect(serializeYamlScalar(s)).toBe(s);
+        expect(roundTrip(s)).toBe(s);
+      },
+    );
+
+    it("emits boolean / number values unquoted (YAML-native)", () => {
+      expect(serializeYamlScalar(true)).toBe("true");
+      expect(serializeYamlScalar(42)).toBe("42");
+      expect(roundTrip(true)).toBe(true);
+      expect(roundTrip(42)).toBe(42);
+    });
+
+    it("still quotes the #3748 colon-space and leading-indicator cases", () => {
+      expect(roundTrip("ZZ probe: colon-space")).toBe("ZZ probe: colon-space");
+      expect(roundTrip("!important")).toBe("!important");
+      expect(roundTrip("#hashtag")).toBe("#hashtag");
+      expect(roundTrip("")).toBe("");
+    });
+  });
+});

--- a/packages/obsidian-plugin/tests/unit/ConceptCreationService.test.ts
+++ b/packages/obsidian-plugin/tests/unit/ConceptCreationService.test.ts
@@ -238,7 +238,9 @@ describe("ConceptCreationService", () => {
 
       const [, content] = mockVault.create.mock.calls[0];
 
-      expect(content).toMatch(/ims__Concept_definition:\s*$/m);
+      // #3750 MEDIUM-1/empty: a bare empty value parses as null in YAML; the
+      // serializer now emits an explicit empty string.
+      expect(content).toContain('ims__Concept_definition: ""');
     });
 
     it("should handle definition with special characters", async () => {
@@ -255,8 +257,10 @@ describe("ConceptCreationService", () => {
 
       const [, content] = mockVault.create.mock.calls[0];
 
+      // #3750 MEDIUM-1: a `: ` (colon-space) definition emitted bare is invalid
+      // YAML (the #3748 bug, on the buildFileContent serializer) — now quoted.
       expect(content).toContain(
-        "ims__Concept_definition: Definition with: quotes, commas, & symbols!",
+        'ims__Concept_definition: "Definition with: quotes, commas, & symbols!"',
       );
     });
 


### PR DESCRIPTION
## Summary

Follow-up to #3748. An adversarial review of PR #3749 found the **second new-asset serializer** (`MetadataHelpers.buildFileContent`) still had the #3748 verbatim-emission bug, plus three hardening gaps in the `serializeYamlScalar` helper. This wires the second serializer through the shared helper and hardens all four findings. Closes #3750.

## Changes

**MEDIUM-1 — `MetadataHelpers.buildFileContent` routed through `serializeYamlScalar`**
The serializer used by Concept / Area / Class / Session / Supervision creation + DefaultWorkflows emitted scalars + array items as `${String(value)}` verbatim. A colon-space label/definition produced invalid YAML → `{}` (silently un-parseable), exactly the #3748 failure. Now both scalar and array-item emission go through the existing helper (reused, not duplicated).

**MEDIUM-2 — tightened the `"`-wrapped passthrough**
`needsYamlQuoting` passed through ANY value starting+ending with `"`. `"a" and "b"` (two quoted runs — not a single scalar) emitted bare → js-yaml throws. Now only a **complete** double-quoted scalar (no unescaped interior `"`, no escaped closing quote) passes through; malformed runs fall through to `quoteYamlString` and round-trip as the literal string. Production pre-quoted values (wikilinks `"[[uid]]"`, DefaultWorkflows `"name"`) still pass through.

**MEDIUM-3 — quote scalar-looking strings (property-aware)**
`123` / `12_000` / `true` / `null` / `~` / `1.5` / `.inf` / `.nan` / date-only `2026-01-15` are coerced to number/bool/null/Date by a real YAML parser (Obsidian metadataCache). These are now quoted **only for string-semantic properties** (`exo__Asset_label`, `aliases` — see `STRING_SCALAR_PROPERTIES`). 

> **Deviation from a blanket value-only fix (verify-before-assert):** applying coercion-quoting to *every* property would wrongly quote semantic **timestamp** properties (`exo__Asset_createdAt`, `ems__Effort_plannedStartTimestamp` with a date-only value) and numeric properties, changing their metadataCache type from Date/number to string. Gating to label/aliases (the properties the issue names as "semantically-string") satisfies AC#2 for label values while leaving timestamp/numeric properties their native type. Datetime timestamps (`YYYY-MM-DDThh:mm:ss`) are excluded from the coercion set entirely as a second safety layer.

**LOW-4 — control chars beyond `\n\r\t`**
`\x07` / `\b` / `\f` / `\v` / NUL / DEL are now detected in `needsYamlQuoting` and escaped (`\xNN`) in `quoteYamlString`, so they never reach a parser bare (which throws "non-printable characters").

> **Note on AC#2 `"test"` → `"test"`:** a user-literal `"test"` is byte-identical to a defensively pre-quoted plain label (`DefaultWorkflows` emits `exo__Asset_label: "${name}"`, and the whole create stack — incl. #3748's `GroundingExecutor` — relies on pre-quoted-wikilink passthrough). A pure value-only function cannot distinguish them. Per the spec ("passthrough only a valid complete double-quoted scalar"), a complete pre-quoted scalar passes through, so `"test"` round-trips to `test`. Honouring the literal-quote intent would regress every pre-quoted production value. The other AC#2 cases (`"a" and "b"`, scalar-looking labels) are fully met.

## Acceptance criteria

1. ✅ Concept/Area/Class via `buildFileContent` with a colon-space label → valid YAML, literal round-trip (`MetadataHelpers.yamlQuoting.test.ts`; `ConceptCreationService.test.ts` colon-space definition).
2. ✅ `serializeYamlScalar` round-trips `"a" and "b"` and scalar-looking label values (`123`/`true`/`2026-01-15`) to the exact string under js-yaml. (`"test"` → `test` by necessity — see note above.)
3. ✅ No gratuitous quoting for plain labels / pre-quoted wikilinks; timestamp & numeric properties keep native type (new `MetadataHelpers.yamlQuoting` non-label test; GroundingExecutor & GenericAssetCreationService suites pass unchanged).
4. ✅ Control-char labels quoted + `\xNN`-escaped.

## Testing — revert-verify (empirically confirmed FAILS pre-fix / PASSES post-fix)

All assertions parse with real js-yaml. Per-part temporary type-preserving break → RED → restore → GREEN:

| Part | Break applied | Tests RED pre-fix |
|---|---|---|
| MEDIUM-1 | `serializeYamlScalar` → `String()` in `buildFileContent` | 3 (`MetadataHelpers.yamlQuoting`) |
| MEDIUM-2 | passthrough any `"…"` | 2 (`yamlScalar` MEDIUM-2) |
| MEDIUM-3 | drop `looksLikeNonStringScalar` check | 17 (`yamlScalar` MEDIUM-3) |
| LOW-4 | revert control-char detection to `/[\n\r\t]/` | 6 (`yamlScalar` LOW-4) |

Full `@kitelev/exocortex-core` suite: **331 suites / 8311 tests green** (after `git submodule update --init`). Plugin `ConceptCreationService` 20/20, CLI buildFileContent suites 34/34. typecheck 0 errors.
