### PR TITLE
fix(sync): deliver edit-before-pull — mtime-manifest cache-hit must not skip a file divergent from the watermark base (#3751)

### DIFF
--- a/packages/core/src/services/sync/SyncEngine.ts
+++ b/packages/core/src/services/sync/SyncEngine.ts
@@ -1032,6 +1032,24 @@ export class SyncEngine {
       // read/added/removed) or a full re-hash advanced its timestamp — a pure
       // no-op sync (every file a cache hit) writes nothing.
       let manifestDirty = false;
+      // #3751 — base blobSha per path. A manifest cache hit may SKIP reading a
+      // file ONLY when its cached blobSha matches the watermark base for that
+      // path (the file is genuinely IN SYNC). The mtime-manifest is rebuilt
+      // every cycle INCLUDING `pull`, so a local edit made before a `pull`
+      // records the EDITED (mtime,size,blobSha) into the manifest while the
+      // watermark (the push base) is NOT advanced — the edit was never pushed.
+      // Without this gate the next `push` sees a `(mtime,size)` cache hit,
+      // reuses the cached blobSha WITHOUT reading the file, detection correctly
+      // flags it modified-vs-base, but its content is absent from `disk`, so the
+      // push-set builder (`pinLocalChanges`) silently drops it → "synced" with
+      // an undelivered edit (zero-loss violation). Gating the skip on
+      // `cached.blobSha === base` restores the documented invariant: a stale /
+      // divergent entry causes a re-hash (cache miss → read → pushable), NEVER a
+      // wrong skip. canUseCache ⇒ watermark !== null.
+      const baseBlobByPath = new Map<string, string>();
+      if (canUseCache && watermark !== null) {
+        for (const f of watermark.files) baseBlobByPath.set(f.path, f.blobSha);
+      }
       for (const path of (await localFiles.list()).filter(mode.syncable)) {
         if (mode.fileMode) {
           const bytes = await readBinaryStrict(localFiles, path);
@@ -1057,10 +1075,18 @@ export class SyncEngine {
           st !== null &&
           cached !== undefined &&
           cached.mtimeMs === st.mtimeMs &&
-          cached.size === st.size
+          cached.size === st.size &&
+          // #3751 — only skip the read when the cached blob is ALREADY the
+          // sync base for this path (genuinely delivered). A `(mtime,size)`
+          // match whose blobSha diverges from the watermark base is a pending
+          // un-pushed delta (e.g. an edit made before a `pull`, whose manifest
+          // entry advanced but whose watermark did not) — it MUST be read so it
+          // lands in `disk` and the push-set carries it. Divergent ⇒ cache miss.
+          cached.blobSha === baseBlobByPath.get(path)
         ) {
-          // Cache hit — unchanged since last sync: reuse blobSha+uid, NO read,
-          // NO hash. The (mtime,size) match is the unchanged-content signal.
+          // Cache hit — unchanged AND already in sync with the base: reuse
+          // blobSha+uid, NO read, NO hash. The (mtime,size) match is the
+          // unchanged-content signal; the base match is the delivered signal.
           reused.set(path, {
             blobSha: cached.blobSha,
             ...(cached.uid !== undefined ? { uid: cached.uid } : {}),

--- a/packages/core/tests/unit/services/sync/SyncEngine.mtime-manifest.test.ts
+++ b/packages/core/tests/unit/services/sync/SyncEngine.mtime-manifest.test.ts
@@ -408,3 +408,102 @@ describe("SyncEngine — mtime-manifest local-hash skip (perf, zero-loss)", () =
     expect(manifest.setCount).toBe(before); // no churn on cache-hit no-ops
   });
 });
+
+/**
+ * #3751 — ZERO-LOSS: an edit made BEFORE a `pull` must still be delivered by
+ * the next `push`. The mtime-manifest is rebuilt + persisted EVERY cycle
+ * (including `pull`), so a `pull` after a local edit records the edited
+ * `(mtime,size,blobSha)` into the manifest WITHOUT pushing the edit and WITHOUT
+ * advancing the watermark (the push base). The subsequent `push` then sees a
+ * `(mtime,size)` cache HIT, reuses the cached blobSha WITHOUT reading the file,
+ * detection correctly flags it modified-vs-base, but the push-set builder
+ * (`pinLocalChanges`) reads content from the `disk` snapshot — which a cache-hit
+ * file is absent from — so the change was SILENTLY DROPPED and `push` reported
+ * "synced, pushed 0" with the edit undelivered (the workaround was `touch` to
+ * bump mtime). The fix gates the cache-hit skip on `cached.blobSha === base`:
+ * a file divergent from the watermark base is a cache MISS → read → pushable,
+ * restoring the documented invariant "a stale entry causes a re-hash, NEVER a
+ * wrong skip".
+ *
+ * Revert-verify (integration-test-revert-verify): removing the
+ * `cached.blobSha === baseBlobByPath.get(path)` clause from the cache-hit gate
+ * in `SyncEngine.ts` makes the first test below RED (push delivers nothing,
+ * remote stays stale); restoring it → GREEN.
+ */
+describe("SyncEngine — #3751 edit-before-pull is delivered by push (zero-loss)", () => {
+  it("@req:702e8bda-1e13-42b0-9858-3d5697f71b6a push delivers a local edit made BEFORE a pull (manifest cache-hit must not skip a file divergent from the watermark base)", async () => {
+    const files = { [A]: mdAsset("u1") };
+    const gh = new FakeGitHubRepo(files);
+    const local = new StatLocalFiles(files);
+    const manifest = new MemManifestStore();
+    const engine = makeEngine(gh, local, { localManifestStore: manifest });
+
+    // Warm the cache to steady state (watermark + manifest seeded).
+    await warmUp(engine, gh);
+
+    // Edit A locally (content + mtime + size all change). The remote is NOT
+    // touched — this is a purely local pending delta.
+    const edited = mdAsset("u1", "edited locally before the pull");
+    local.userEdit(A, edited);
+
+    // `pull` first (remote unchanged → pulls nothing). The pull cycle rebuilds
+    // the mtime-manifest from the post-edit disk snapshot, but does NOT push the
+    // edit and does NOT advance the watermark.
+    const [pull] = await engine.syncAll([gh.spec()], "pull");
+    expect(pull.status).toBe("synced");
+    expect(pull.pushedCount).toBe(0);
+    expect(pull.pulledCount).toBe(0);
+
+    // `push` next. The edit MUST be delivered (AC#1/#2): the manifest is a perf
+    // cache only — correctness of delivery must not depend on it.
+    const [push] = await engine.syncAll([gh.spec()], "push");
+    expect(push.status).toBe("synced");
+    expect(push.pushedCount).toBe(1);
+
+    // Zero-loss: the edited blob reached the remote.
+    expect(gh.headFiles().get(A)).toBe(edited);
+  });
+
+  it("@req:702e8bda-1e13-42b0-9858-3d5697f71b6a the same edit-before-pull holds under a combined Sync after the pull, and converges to a clean parity (no residual local delta)", async () => {
+    const files = { [A]: mdAsset("u1"), [B]: mdAsset("u2") };
+    const gh = new FakeGitHubRepo(files);
+    const local = new StatLocalFiles(files);
+    const manifest = new MemManifestStore();
+    const engine = makeEngine(gh, local, { localManifestStore: manifest });
+    await warmUp(engine, gh);
+
+    const edited = mdAsset("u1", "edited before pull, delivered by Sync");
+    local.userEdit(A, edited);
+
+    await engine.syncAll([gh.spec()], "pull"); // manifest advances, edit unpushed
+    const [sync] = await engine.syncAll([gh.spec()], "sync"); // must deliver it
+
+    expect(sync.status).toBe("synced");
+    expect(sync.pushedCount).toBe(1);
+    expect(gh.headFiles().get(A)).toBe(edited);
+
+    // Convergence: a follow-up no-op sees no residual local delta (push and the
+    // base now agree — AC#3) and skips the read again (perf restored once the
+    // file is genuinely in sync).
+    const [noop] = await engine.syncAll([gh.spec()], "sync");
+    expect(noop.pushedCount).toBe(0);
+    expect(noop.timings!.counts.filesRead).toBe(0);
+  });
+
+  it("the cache-hit fast path is preserved for genuinely in-sync files (no perf regression)", async () => {
+    // The fix must not turn every steady-state sync into a full re-hash: a file
+    // whose cached blob equals the base is still a cache hit on a no-op.
+    const files = { [A]: mdAsset("u1"), [B]: mdAsset("u2"), [C]: mdAsset("u3") };
+    const gh = new FakeGitHubRepo(files);
+    const local = new StatLocalFiles(files);
+    const manifest = new MemManifestStore();
+    const engine = makeEngine(gh, local, { localManifestStore: manifest });
+    await warmUp(engine, gh);
+
+    const [r] = await engine.syncAll([gh.spec()], "sync");
+    expect(r.status).toBe("synced");
+    expect(r.pushedCount).toBe(0);
+    expect(r.timings!.counts.filesRead).toBe(0); // pure no-op: nothing read
+    expect(r.timings!.counts.filesHashed).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #3751 — `exosync push` after `pull` silently skips a pending-local-edit (mtime-manifest fast-path) while reporting `synced`.

## Root cause (empirically confirmed on origin/main)

The mtime-manifest fast-path skips reading+re-hashing ASSET-mode files whose `(mtimeMs, size)` are unchanged, reusing the cached `blobSha`. The manifest is rebuilt + persisted in **every** cycle **including `pull`**. So an edit made **before** a `pull`:

1. `pull` reads the edited file (mtime changed → cache miss), records the **edited** `(mtime, size, blobSha)` into the manifest, but does **not** push it and does **not** advance the watermark (the push base).
2. The next `push` sees a `(mtime, size)` **cache hit** → reuses the cached blobSha **without reading the file** → the content is absent from the `disk` snapshot.
3. Detection (`detectChanges`) **correctly** flags the file as `modified` vs the watermark base (the cached blobSha ≠ base). But the push-set builder (`pinLocalChanges`) reads content from `disk.get(path)` — which a cache-hit file is absent from — so the change is **silently dropped** → `synced — pushed 0`, edit undelivered until a `touch` or the 12h full-rehash.

`ParityValidator` hashes independently of the manifest → correctly reported `pending-local-edit`. That **asymmetry (parity dirty, push clean)** was the smoking gun.

Verified with a temporary instrumented repro against the real `SyncEngine`: `detection.modified` carried the edited blobSha, but `disk` was empty during `push` → push set dropped it.

## Fix

Gate the cache-hit skip on `cached.blobSha === <watermark base blobSha for the path>`:

```ts
cached.mtimeMs === st.mtimeMs &&
cached.size === st.size &&
cached.blobSha === baseBlobByPath.get(path)   // #3751
```

A file whose cached blob diverges from the watermark base is a **pending un-pushed delta** → treated as a **cache MISS** (read), so it lands in `disk` and the push set carries it. This restores the documented invariant: *a stale/divergent manifest entry causes a re-hash (cache miss), **never** a wrong skip* (M1 zero-loss). Correctness of delivery no longer depends on the perf cache (AC#1/#2/#3). The perf win is preserved for genuinely in-sync files (cached blob == base → still a cache hit on a no-op).

`baseBlobByPath` is built once from `watermark.files`; `canUseCache ⇒ watermark !== null`.

## Test (revert-verified, mandatory)

Production-shape integration test over the real `SyncEngine` + a fake remote (`SyncEngine.mtime-manifest.test.ts`), driving the exact issue scenario: warm cache → edit before `pull` → `pull` → `push`, asserting the remote received the edited blob (blobSha match).

**Empirically revert-verified:** removing the `cached.blobSha === baseBlobByPath.get(path)` clause (type-preserving) makes the two behavioural tests **FAIL** (push delivers nothing, remote stays stale); restoring → **PASS**. The third test (cache-hit fast path preserved for in-sync files) stays GREEN both ways — it guards a perf regression, not the bug, so it is intentionally not revert-bound.

## Verification

- `tsc` (core build): clean.
- `eslint --max-warnings=0` on the changed source: clean.
- Full core suite (CI-equivalent): all green (the 3 `dynamic-commands` suites need the `exoas-exocmd` submodule, green with `submodules: recursive` as CI runs).
- `@kitelev/exocortex-services` suite: 52/52.

## req-first SDD

`@req:702e8bda-1e13-42b0-9858-3d5697f71b6a` — `req(exo): ExoSync push delivers any pending local delta — the mtime-manifest is a perf cache only`. P0, `integration` binding-class. Status `approved`; flips to `active` after merge.

Closes #3751
