### PR TITLE
fix: drop dead `|| null` in parseDateModifier (js/trivial-conditional #3696)

### DIFF
--- a/packages/core/src/services/SubstitutionResolverRegistry.ts
+++ b/packages/core/src/services/SubstitutionResolverRegistry.ts
@@ -311,7 +311,10 @@ function parseDateModifier(parameter?: string): {
 } {
   if (!parameter) return { offset: null, format: null };
   const colon = parameter.indexOf(":");
-  if (colon < 0) return { offset: parameter || null, format: null };
+  // `parameter` is guaranteed non-empty here (the `!parameter` guard above
+  // returns early), so `parameter || null` was a no-op `|| null` — dropped
+  // to clear the js/trivial-conditional alert (#3696) without behaviour change.
+  if (colon < 0) return { offset: parameter, format: null };
   const offsetPart = parameter.slice(0, colon);
   const format = parameter.slice(colon + 1);
   return { offset: offsetPart || null, format: format || null };


### PR DESCRIPTION
## What

Removes the dead `|| null` in `SubstitutionResolverRegistry.parseDateModifier` — the only open code-scanning alert in the repo.

```ts
if (!parameter) return { offset: null, format: null };   // ← guards truthiness
const colon = parameter.indexOf(":");
if (colon < 0) return { offset: parameter || null, format: null };  // `parameter` is always truthy here → `|| null` is dead
```

CodeQL `js/trivial-conditional`: *"This use of variable 'parameter' always evaluates to true."* Correct — the `!parameter` early-return guarantees `parameter` is a non-empty string at the `colon < 0` branch, so `parameter || null` always yields `parameter`.

## Stale-path note (verify-before-assert)

The issue body points at `packages/exocortex/src/services/SubstitutionResolverRegistry.ts:314` and alert **#310**. That path no longer exists — package `exocortex` was renamed to `core` (M5a). Alert #310 auto-closed as `fixed` (path-rename artifact); the **live** finding is alert **#311** at `packages/core/src/services/SubstitutionResolverRegistry.ts:314`, the single open code-scanning alert (last main analysis still flags 1 result). The finding is genuine and current.

## Why no behavioural test / req-first SDD note

This is a pure dead-code removal — `parameter || null` ≡ `parameter` given the guard — so a revert-verify would be **vacuous** (behaviour identical with or without `|| null`), and authoring a new requirement asset for it would be ceremony-spam. The SDD spec-lock here is *"no behaviour change"*, enforced by the **58 existing `SubstitutionResolverRegistry` tests** (all `parseDateModifier` offset/format/leniency cases — `+7d:YYYY-MM-DD`, `:HH:mm`, `+7d`, empty-format, unknown-unit) staying green.

## Verification

- `SubstitutionResolverRegistry.test.ts`: **58/58 passed** (regression lock).
- `tsc --noEmit`: 0 errors.
- `eslint --max-warnings=0` on changed file: clean.

Closes #3696

https://claude.ai/code/session_01Fv7J6erevq46YpDL1yLh13