### PR TITLE
fix(onboarding): sync panel step-done marker when advancing via result-modal CTA (#3705)

### DIFF
--- a/packages/obsidian-plugin/src/ExocortexPlugin.ts
+++ b/packages/obsidian-plugin/src/ExocortexPlugin.ts
@@ -163,7 +163,10 @@ import { BootstrapVaultModal } from "./presentation/modals/BootstrapVaultModal";
 import { BootstrapResultModal } from "./presentation/modals/BootstrapResultModal";
 import { AddAssetSpaceModal } from "./presentation/modals/AddAssetSpaceModal";
 import { SimpleConfirmModal } from "./presentation/modals/SimpleConfirmModal";
-import { FirstRunOnboardingModal } from "./presentation/modals/FirstRunOnboardingModal";
+import {
+  FirstRunOnboardingModal,
+  ONBOARDING_STEP_KEYS,
+} from "./presentation/modals/FirstRunOnboardingModal";
 import { testPatConnection } from "./presentation/settings/patConnectionTest";
 import {
   registerOnboardingCommands,
@@ -375,6 +378,10 @@ export default class ExocortexPlugin extends Plugin {
   // forbids `new Notice()` outside ObsidianNotificationService).
   notifier!: ObsidianNotificationService;
   private shaclStatusBar: HTMLElement | null = null;
+  // #3705 — the currently-open first-run onboarding panel (or null). Lets the
+  // bootstrap-result modal's next-step CTA mark the matching panel step done
+  // across the modal boundary; cleared when the panel closes.
+  private activeOnboardingPanel: FirstRunOnboardingModal | null = null;
   // Issue #2780: tracked so the post-resolve reindex can await it before
   // calling refresh(), avoiding a concurrent clear()/convertVault() race.
   private eagerInitPromise: Promise<void> | null = null;
@@ -3599,7 +3606,7 @@ export default class ExocortexPlugin extends Plugin {
     const secretsStore = new LocalSecretsStore({ app: this.app });
 
     const openPanel = (): void => {
-      new FirstRunOnboardingModal(this.app, {
+      const panel = new FirstRunOnboardingModal(this.app, {
         // Step 1 (optional, token-first): persist the PAT device-local BEFORE
         // the materialise steps run (cd9444bd). Empty value clears it (skip
         // path). A failure is surfaced as a notice but never blocks onboarding.
@@ -3661,6 +3668,12 @@ export default class ExocortexPlugin extends Plugin {
           void profileCommands.invokeApplyProfile();
         },
         onClosePanel: () => {
+          // #3705 — the panel is gone; stop routing result-modal step ticks to
+          // it (markStepDoneByKey already no-ops post-close, but drop the ref so
+          // a stale instance is not retained).
+          if (this.activeOnboardingPanel === panel) {
+            this.activeOnboardingPanel = null;
+          }
           void localDataStore.setOnboardingCompleted(true).catch((err) => {
             this.logger.warn(
               "[ExocortexPlugin] persisting onboarding-completed flag failed: " +
@@ -3668,7 +3681,11 @@ export default class ExocortexPlugin extends Plugin {
             );
           });
         },
-      }).open();
+      });
+      // #3705 — track the open panel so a stacked bootstrap-result modal's
+      // next-step CTA can mark the matching panel step done.
+      this.activeOnboardingPanel = panel;
+      panel.open();
     };
 
     // Guided Setup command — unconditional (parity); the re-entry point the
@@ -3912,6 +3929,14 @@ export default class ExocortexPlugin extends Plugin {
         new BootstrapResultModal(this.app, result, {
           onAddRegistry: () =>
             void bootstrapCommands.invokeAddAssetSpace(REGISTRY_ASSETSPACE_URL),
+          // #3705 — this CTA performs the onboarding panel's Step 3 (Add the
+          // AssetSpace registry); tick that step done if the panel is still open
+          // underneath, so the checklist matches what the user actually did.
+          // No-op when there is no onboarding panel (standalone Bootstrap run).
+          onStepCompleted: () =>
+            this.activeOnboardingPanel?.markStepDoneByKey(
+              ONBOARDING_STEP_KEYS.addRegistry,
+            ),
           // RFC 0002 §3.10 — one-click retry of the failed operation: re-open
           // the same Bootstrap / Add flow (its modal collects the URL again) so
           // the user can fix the URL / token / connection and retry in place.

--- a/packages/obsidian-plugin/src/presentation/modals/BootstrapResultModal.ts
+++ b/packages/obsidian-plugin/src/presentation/modals/BootstrapResultModal.ts
@@ -20,6 +20,21 @@ export interface BootstrapResultModalActions {
    */
   onAddRegistry: () => void;
   /**
+   * Cross-modal onboarding sync (#3705) — fired right after the success-path
+   * next-step CTA («Add the AssetSpace registry») is taken, so a first-run
+   * onboarding panel still open underneath can mark its matching step (Step 3)
+   * done, keeping the checklist in sync with what was actually performed (not
+   * only with the panel's own step buttons).
+   *
+   * Optional + decoupled: this result modal also opens standalone from the
+   * Bootstrap command (no onboarding panel underneath), where the hook is simply
+   * absent. The modal stays ignorant of onboarding step identifiers — the wiring
+   * binds this to the right step. No argument: the success path has exactly one
+   * step-advancing CTA, so the wiring already knows which step it is. The bound
+   * handler is idempotent and a no-op when the panel is already closed.
+   */
+  onStepCompleted?: () => void;
+  /**
    * Failure recovery (§3.10) — re-run the operation that failed (bootstrap OR
    * add-AssetSpace), so a wrong URL / dropped network / mis-scoped token is one
    * click to retry after the user fixes it. Optional — when absent the failure
@@ -138,6 +153,9 @@ export class BootstrapResultModal extends Modal {
       nextBtn.addEventListener("click", () => {
         this.close();
         this.actions.onAddRegistry();
+        // #3705 — tick the onboarding panel's matching step (Step 3) done if a
+        // panel is still open underneath; decoupled no-op otherwise.
+        this.actions.onStepCompleted?.();
       });
       this.firstFocusable = nextBtn;
     }

--- a/packages/obsidian-plugin/src/presentation/modals/FirstRunOnboardingModal.ts
+++ b/packages/obsidian-plugin/src/presentation/modals/FirstRunOnboardingModal.ts
@@ -58,7 +58,28 @@ export interface FirstRunOnboardingActions {
   onClosePanel?: () => void;
 }
 
+/**
+ * Stable identifiers for the onboarding steps (#3705). They let a coordinating
+ * surface — specifically a result-modal next-step CTA stacked on top of this
+ * panel — mark the matching panel step done across the modal boundary
+ * (`markStepDoneByKey`), without reaching into the panel's DOM internals. The
+ * keys are the cross-modal contract; the wiring (ExocortexPlugin) maps a
+ * result-modal CTA to the step it advances.
+ */
+export const ONBOARDING_STEP_KEYS = {
+  pat: "pat",
+  setupEngine: "setup-engine",
+  addRegistry: "add-registry",
+  addProfiles: "add-profiles",
+  applyProfile: "apply-profile",
+} as const;
+
+export type OnboardingStepKey =
+  (typeof ONBOARDING_STEP_KEYS)[keyof typeof ONBOARDING_STEP_KEYS];
+
 interface StepSpec {
+  /** Stable cross-modal identifier for `markStepDoneByKey` (#3705). */
+  key: OnboardingStepKey;
   /** Plain-text step marker (NOT a glyph) so it is screen-reader reliable (P16). */
   marker: string;
   title: string;
@@ -110,6 +131,15 @@ export class FirstRunOnboardingModal extends Modal {
   private readonly actions: FirstRunOnboardingActions;
   private closed = false;
   private firstFocusable: HTMLElement | null = null;
+  /**
+   * Step `<li>` + header, keyed by {@link OnboardingStepKey}, so an external
+   * caller can mark a step done by key (#3705). Populated as each step renders;
+   * left intact on close — `markStepDoneByKey` guards on the `closed` flag.
+   */
+  private readonly stepElements = new Map<
+    string,
+    { item: HTMLElement; header: HTMLElement }
+  >();
 
   constructor(app: App, actions: FirstRunOnboardingActions) {
     super(app);
@@ -146,6 +176,7 @@ export class FirstRunOnboardingModal extends Modal {
 
     const steps: StepSpec[] = [
       {
+        key: ONBOARDING_STEP_KEYS.setupEngine,
         marker: "Step 2",
         title: "Set up the engine",
         description:
@@ -157,6 +188,7 @@ export class FirstRunOnboardingModal extends Modal {
         action: this.actions.onSetupEngine,
       },
       {
+        key: ONBOARDING_STEP_KEYS.addRegistry,
         marker: "Step 3",
         title: "Add the AssetSpace registry",
         description:
@@ -167,6 +199,7 @@ export class FirstRunOnboardingModal extends Modal {
         action: this.actions.onAddRegistry,
       },
       {
+        key: ONBOARDING_STEP_KEYS.addProfiles,
         marker: "Step 4",
         title: "Add the profiles AssetSpace",
         description:
@@ -177,6 +210,7 @@ export class FirstRunOnboardingModal extends Modal {
         action: this.actions.onAddProfiles,
       },
       {
+        key: ONBOARDING_STEP_KEYS.applyProfile,
         marker: "Step 5",
         title: "Apply a profile",
         description:
@@ -227,6 +261,8 @@ export class FirstRunOnboardingModal extends Modal {
     const header = item.createEl("div", {
       cls: "exocortex-onboarding-step-header",
     });
+    // Register for cross-modal `markStepDoneByKey` (#3705).
+    this.stepElements.set(ONBOARDING_STEP_KEYS.pat, { item, header });
     header.createEl("span", {
       cls: "exocortex-onboarding-step-marker",
       text: "Step 1 — ",
@@ -360,6 +396,8 @@ export class FirstRunOnboardingModal extends Modal {
     const header = item.createEl("div", {
       cls: "exocortex-onboarding-step-header",
     });
+    // Register for cross-modal `markStepDoneByKey` (#3705).
+    this.stepElements.set(step.key, { item, header });
     header.createEl("span", {
       cls: "exocortex-onboarding-step-marker",
       text: `${step.marker} — `,
@@ -413,6 +451,24 @@ export class FirstRunOnboardingModal extends Modal {
     });
     done.setAttribute("role", "status");
     done.setAttribute("aria-live", "polite");
+  }
+
+  /**
+   * Mark the step identified by {@link stepKey} done from OUTSIDE the panel
+   * (#3705) — used when a result modal stacked on top advances onboarding past a
+   * panel step via its own next-step CTA (e.g. the "Engine ready" panel's "Add
+   * the AssetSpace registry" button performs Step 3), so the checklist stays in
+   * sync with what the user actually did, not only with the panel's own buttons.
+   *
+   * A safe no-op when the panel is already closed (the coordinating surface need
+   * not track the panel's lifecycle) or the key is unknown. Idempotent — it
+   * delegates to {@link markStepDone}, which keeps a single marker per step.
+   */
+  markStepDoneByKey(stepKey: string): void {
+    if (this.closed) return;
+    const entry = this.stepElements.get(stepKey);
+    if (entry === undefined) return;
+    this.markStepDone(entry.item, entry.header);
   }
 
   override onClose(): void {

--- a/packages/obsidian-plugin/tests/unit/presentation/modals/OnboardingResultStepSync.test.ts
+++ b/packages/obsidian-plugin/tests/unit/presentation/modals/OnboardingResultStepSync.test.ts
@@ -1,0 +1,239 @@
+/**
+ * Cross-modal step-sync between the first-run onboarding panel and the durable
+ * bootstrap-result modal (#3705).
+ *
+ * The panel (`FirstRunOnboardingModal`) and the result modal
+ * (`BootstrapResultModal`) are separate modal instances; the result modal's
+ * success-path next-step CTA («Add the AssetSpace registry») performs the
+ * panel's Step 3, but historically only the panel's OWN step button ticked the
+ * step done, so advancing via the result-modal CTA left the checklist desynced.
+ * The fix threads an optional `onStepCompleted` hook from the result modal that
+ * the wiring binds to `panel.markStepDoneByKey(addRegistry)`.
+ *
+ * These tests drive the REAL modal classes (the production button handlers)
+ * over a jsdom DOM, mirroring the `ExocortexPlugin` wiring, so they exercise the
+ * actual cross-modal coordination — not a stub.
+ *
+ * Revert-verify: dropping the result modal's `this.actions.onStepCompleted?.()`
+ * call (BootstrapResultModal) makes the "marks the matching panel step done"
+ * assertion FAIL (Step 3 stays un-ticked); restoring it PASSES.
+ */
+import { describe, it, expect, beforeEach, jest } from "@jest/globals";
+
+jest.mock("obsidian", () => {
+  interface CreateOpts {
+    cls?: string;
+    text?: string;
+    type?: string;
+    placeholder?: string;
+    href?: string;
+    attr?: Record<string, string>;
+  }
+  function augment(el: HTMLElement): void {
+    (
+      el as unknown as { createEl: (tag: string, o?: CreateOpts) => HTMLElement }
+    ).createEl = function (tag: string, o?: CreateOpts): HTMLElement {
+      const child = document.createElement(tag);
+      if (o?.cls) child.className = o.cls;
+      if (o?.text) child.textContent = o.text;
+      if (o?.type) child.setAttribute("type", o.type);
+      if (o?.placeholder) child.setAttribute("placeholder", o.placeholder);
+      if (o?.href) child.setAttribute("href", o.href);
+      if (o?.attr) {
+        for (const [name, value] of Object.entries(o.attr)) {
+          child.setAttribute(name, value);
+        }
+      }
+      this.appendChild(child);
+      augment(child);
+      return child;
+    }.bind(el);
+    (el as unknown as { addClass: (c: string) => void }).addClass = function (
+      c: string,
+    ): void {
+      this.classList.add(c);
+    }.bind(el);
+    (el as unknown as { empty: () => void }).empty = function (): void {
+      while (this.firstChild) this.removeChild(this.firstChild);
+    }.bind(el);
+  }
+  class MockModal {
+    app: unknown;
+    contentEl: HTMLElement;
+    constructor(app: unknown) {
+      this.app = app;
+      this.contentEl = document.createElement("div");
+      augment(this.contentEl);
+    }
+    open(): void {
+      document.body.appendChild(this.contentEl);
+      this.onOpen();
+    }
+    close(): void {
+      this.onClose();
+      if (this.contentEl.parentNode) {
+        this.contentEl.parentNode.removeChild(this.contentEl);
+      }
+    }
+    onOpen(): void {}
+    onClose(): void {}
+  }
+  return { Modal: MockModal, App: class {} };
+});
+
+import type { App } from "obsidian";
+import {
+  FirstRunOnboardingModal,
+  ONBOARDING_STEP_KEYS,
+  type FirstRunOnboardingActions,
+} from "../../../../src/presentation/modals/FirstRunOnboardingModal";
+import {
+  BootstrapResultModal,
+  type BootstrapResultModalActions,
+} from "../../../../src/presentation/modals/BootstrapResultModal";
+import type { BootstrapResultInfo } from "../../../../src/infrastructure/adapters/BootstrapAssetSpaceCommands";
+
+const fakeApp = {} as unknown as App;
+
+const BOOTSTRAPPED: BootstrapResultInfo = {
+  kind: "bootstrapped",
+  folderName: "assetspaces/kitelev/exoas-exo",
+  sha: "abc1234",
+};
+
+function noopActions(): FirstRunOnboardingActions {
+  return {
+    onSavePat: async () => undefined,
+    onSetupEngine: () => undefined,
+    onAddRegistry: () => undefined,
+    onAddProfiles: () => undefined,
+    onApplyProfile: () => undefined,
+  };
+}
+
+/** The panel's own Step 3 `<li>` (queried within the panel's contentEl). */
+function panelStep3Li(panel: FirstRunOnboardingModal): HTMLElement {
+  const btn = Array.from(
+    panel.contentEl.querySelectorAll<HTMLButtonElement>(
+      "button.exocortex-onboarding-step-action",
+    ),
+  ).find((b) => b.textContent === "Add the AssetSpace registry")!;
+  return btn.closest("li.exocortex-onboarding-step") as HTMLElement;
+}
+
+/** Open a result modal whose `onStepCompleted` mirrors the plugin wiring. */
+function openResultModal(
+  panel: FirstRunOnboardingModal | null,
+  over: Partial<BootstrapResultModalActions> = {},
+): BootstrapResultModal {
+  const actions: BootstrapResultModalActions = {
+    onAddRegistry: () => undefined,
+    // Mirror ExocortexPlugin's wiring: the result-modal CTA performs Step 3, so
+    // tick that panel step done (no-op when the panel is gone — markStepDoneByKey
+    // guards on its closed flag).
+    onStepCompleted: () =>
+      panel?.markStepDoneByKey(ONBOARDING_STEP_KEYS.addRegistry),
+    ...over,
+  };
+  const modal = new BootstrapResultModal(fakeApp, BOOTSTRAPPED, actions);
+  modal.open();
+  return modal;
+}
+
+/** The result modal's success-path next-step CTA button. */
+function resultCtaButton(modal: BootstrapResultModal): HTMLButtonElement {
+  return modal.contentEl.querySelector<HTMLButtonElement>(
+    "button.bootstrap-result-next-action",
+  )!;
+}
+
+beforeEach(() => {
+  document.body.innerHTML = "";
+});
+
+describe("Onboarding ↔ bootstrap-result step sync (#3705)", () => {
+  it("@req:e4d8a948-0928-4519-b7e0-ffb1e4440248 the result-modal next-step CTA marks the onboarding panel's matching step done", () => {
+    const panel = new FirstRunOnboardingModal(fakeApp, noopActions());
+    panel.open();
+
+    // Step 3 starts un-ticked (the user has NOT clicked the panel's own button).
+    const step3 = panelStep3Li(panel);
+    expect(step3.classList.contains("is-done")).toBe(false);
+    expect(step3.querySelector(".exocortex-onboarding-step-done")).toBeNull();
+
+    // Advance via the result-modal CTA instead (the desync repro).
+    const result = openResultModal(panel);
+    resultCtaButton(result).click();
+
+    // The panel's Step 3 is now ticked, in sync with what was actually done.
+    expect(step3.classList.contains("is-done")).toBe(true);
+    const marker = step3.querySelector(".exocortex-onboarding-step-done")!;
+    expect(marker.textContent).toContain("Done");
+  });
+
+  it("@req:e4d8a948-0928-4519-b7e0-ffb1e4440248 only the matching step ticks — sibling panel steps stay un-done", () => {
+    const panel = new FirstRunOnboardingModal(fakeApp, noopActions());
+    panel.open();
+
+    const result = openResultModal(panel);
+    resultCtaButton(result).click();
+
+    // Exactly one done-marker across the panel — Step 3 only (the result-modal
+    // CTA must not tick steps 1/2/4/5).
+    const markers = panel.contentEl.querySelectorAll(
+      ".exocortex-onboarding-step-done",
+    );
+    expect(markers).toHaveLength(1);
+    expect(panelStep3Li(panel).classList.contains("is-done")).toBe(true);
+  });
+
+  it("@req:e4d8a948-0928-4519-b7e0-ffb1e4440248 is idempotent — repeated result-modal CTAs keep a single ✓ Done marker on the step", () => {
+    const panel = new FirstRunOnboardingModal(fakeApp, noopActions());
+    panel.open();
+
+    // Fire the result-modal CTA three times (the sub-dialogs let a user re-run it).
+    for (let i = 0; i < 3; i++) {
+      const result = openResultModal(panel);
+      resultCtaButton(result).click();
+    }
+
+    const step3 = panelStep3Li(panel);
+    expect(
+      step3.querySelectorAll(".exocortex-onboarding-step-done"),
+    ).toHaveLength(1);
+  });
+
+  it("@req:e4d8a948-0928-4519-b7e0-ffb1e4440248 is a safe no-op when the panel is already closed (no throw, no marker)", () => {
+    const panel = new FirstRunOnboardingModal(fakeApp, noopActions());
+    panel.open();
+    const step3 = panelStep3Li(panel);
+    panel.close();
+
+    // The result modal fires its CTA after the panel closed (panel is gone).
+    const result = openResultModal(panel);
+    expect(() => resultCtaButton(result).click()).not.toThrow();
+
+    // The (detached) Step 3 element was never ticked.
+    expect(step3.classList.contains("is-done")).toBe(false);
+    expect(step3.querySelector(".exocortex-onboarding-step-done")).toBeNull();
+  });
+
+  it("the result modal fires onStepCompleted exactly once per success CTA click (the cross-modal contract)", () => {
+    let calls = 0;
+    const result = openResultModal(null, {
+      onStepCompleted: () => {
+        calls++;
+      },
+    });
+    resultCtaButton(result).click();
+    expect(calls).toBe(1);
+  });
+
+  it("the result modal works standalone — no onStepCompleted wired (no throw)", () => {
+    const modal = new BootstrapResultModal(fakeApp, BOOTSTRAPPED, {
+      onAddRegistry: () => undefined,
+    });
+    modal.open();
+    expect(() => resultCtaButton(modal).click()).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary

Fixes the onboarding **step-done marker desync** (#3705, LOW cosmetic). The first-run onboarding panel (`FirstRunOnboardingModal`) marked a step **"✓ Done"** only when its *own* step button was clicked. If the user advanced instead via the durable bootstrap-result modal's success CTA — **"Add the AssetSpace registry"** in the "Engine ready" panel, which performs the panel's **Step 3** — the panel's Step 3 stayed un-ticked, so the checklist desynced from what was actually done. The action itself always worked (purely cosmetic).

## Approach (minimally-invasive, 3 source files)

The panel and the result modal are **separate modal instances** wired in `ExocortexPlugin`. Cross-modal coordination:

- **`FirstRunOnboardingModal`** — exports stable `ONBOARDING_STEP_KEYS`, keeps a `stepKey → {item, header}` map, and exposes a public **`markStepDoneByKey(stepKey)`**: idempotent (delegates to the existing `markStepDone`, single marker per step) and a **safe no-op when the panel is already closed** (guards on the `closed` flag) or the key is unknown.
- **`BootstrapResultModal`** — adds an optional, **decoupled** `onStepCompleted` hook to `BootstrapResultModalActions`, fired right after the success-path next-step CTA. The modal stays ignorant of onboarding step identifiers and remains usable **standalone** (opened from the Bootstrap command, no panel underneath → hook absent).
- **`ExocortexPlugin`** — tracks the open panel via `activeOnboardingPanel` (set on open, cleared on close) and binds the result modal's `onStepCompleted` to `panel.markStepDoneByKey(addRegistry)`.

No callers cascaded (3 source files touched; well under cascade-cap).

## req-first SDD

`@req:e4d8a948-0928-4519-b7e0-ffb1e4440248` — *advancing onboarding via a result-modal next-step CTA marks the matching panel step done (idempotent; no-op if the panel is closed)*. Unit-bound (`req__RequirementBindingClassUnit`), P3, status **proposed**; published to `exoas-exo-reqs` main (`903e54b`). SHACL `validate schema --shapes-mode` against vault-exodev: **conforms: true, 0 violations**.

## Testing — revert-verified

New production-shape unit test `OnboardingResultStepSync.test.ts` drives the **real** `FirstRunOnboardingModal` + `BootstrapResultModal` classes (their production button handlers) over jsdom, mirroring the plugin wiring — 6 cases (cross-modal mark, only-matching-step, idempotency, panel-closed no-op, `onStepCompleted` once-per-click contract, standalone no-throw).

**Empirically verified FAILS pre-fix / PASSES post-fix:** removing the result modal's `this.actions.onStepCompleted?.()` call (type-preserving) → **RED** (4/6 fail — Step 3 stays un-ticked when advanced via the result-modal CTA); restored → **GREEN** (6/6, plus the full 9-suite / 141-test modal corpus; 203 `--findRelatedTests` for the 3 src files). `npm run check:types` clean; eslint `--max-warnings=0` clean on the 3 src files.

Not Docker-e2e tested (LOW cosmetic + unit cross-modal callback coverage is sufficient per the spec).

Closes #3705
