### PR TITLE
feat(core): deriveUrl(path) — RFC 0005 Phase 0 (DRY toHttpsGitHubUrl)

### DIFF
--- a/packages/cli/src/services/CliApplyProfileService.ts
+++ b/packages/cli/src/services/CliApplyProfileService.ts
@@ -29,6 +29,7 @@ import yaml from "js-yaml";
 import type { ApplyPlan } from "@kitelev/exocortex-core";
 import {
   derivePath,
+  deriveUrl,
   assertTsFloorReconciled,
   SDK_FLOOR,
   CATALOG_KEEP_NAMESPACES,
@@ -123,14 +124,18 @@ export interface CliApplyProfileServiceOptions {
 /**
  * Convert any GitHub git URL form (HTTPS / SSH scp-like / git://) to the
  * canonical `https://github.com/<owner>/<repo>` form the tarball API needs.
- * Reuses `derivePath` (the single source of truth for owner/repo extraction);
- * falls back to the input unchanged when `derivePath` cannot parse it.
+ *
+ * `derivePath` (url → `assetspaces/<owner>/<repo>`) composed with `deriveUrl`
+ * (path → `https://github.com/<owner>/<repo>`) is the single source of truth for
+ * the url→canonical-url reconstruction (RFC 0005 Phase 0 — the path→url half used
+ * to be duplicated inline here). Falls back to the input unchanged when
+ * `derivePath` cannot parse it (`deriveUrl` of a `derivePath` output never
+ * returns null — the path is already validated).
  */
 export function toHttpsGitHubUrl(git: string): string {
   const folder = derivePath(git);
   if (folder === null) return git;
-  const ownerRepo = folder.slice("assetspaces/".length);
-  return `https://github.com/${ownerRepo}`;
+  return deriveUrl(folder) ?? git;
 }
 
 const SKIP_DIRS = new Set([

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -271,7 +271,11 @@ export {
   IRICanonicalizer,
   type CanonicalizationResult,
 } from "./services/IRICanonicalizer";
-export { derivePath, deriveLegacyFlatPath } from "./services/AssetSpacePathDeriver";
+export {
+  derivePath,
+  deriveUrl,
+  deriveLegacyFlatPath,
+} from "./services/AssetSpacePathDeriver";
 export {
   discoverFileSpaceExclusions,
   frontmatterDeclaresFileSpace,

--- a/packages/core/src/services/AssetSpacePathDeriver.ts
+++ b/packages/core/src/services/AssetSpacePathDeriver.ts
@@ -100,6 +100,72 @@ export function derivePath(source: unknown): string | null {
 }
 
 /**
+ * Inverse of {@link derivePath}: reconstruct an AssetSpace's canonical GitHub
+ * clone URL from its vault-relative mount path.
+ *
+ * `assetspaces/<owner>/<repo>` → `https://github.com/<owner>/<repo>`.
+ *
+ * **LOSSY BY DESIGN.** `derivePath` is many-to-one — it normalises scheme, host,
+ * SSH/scp form, embedded credentials, port and the `.git` suffix all away — so a
+ * true inverse cannot exist in general. This reconstruction holds only under the
+ * invariant that **every AssetSpace URL is `https://github.com/<owner>/<repo>`**,
+ * which is true for the entire current ecosystem (RFC 0005 §3.2: zero non-GitHub
+ * URLs across all vaults) and is already baked into `derivePath`'s Maven design
+ * (its docstring: "GitHub guarantees global uniqueness of `owner/repo`"). A
+ * non-GitHub / non-https AssetSpace would need an explicit URL carrier — none
+ * exist; if one is ever introduced this function still returns a github.com URL
+ * for it, so the invariant must be re-checked before adding such a source.
+ *
+ * Validates BOTH segments with the same {@link SEGMENT_RE} + `.`/`..` traversal
+ * guards as `derivePath`. This is defence-in-depth, not theatre: unlike
+ * `deriveLegacyFlatPath` (whose input is a trusted `derivePath` output),
+ * `deriveUrl`'s input is an untrusted **folder path** (e.g. an on-disk
+ * `assetspaces/<owner>/<repo>` directory name in RFC 0005 Phase 1 re-fetch), so a
+ * malformed or traversal-bearing segment must be rejected rather than spliced
+ * into a URL.
+ *
+ * Tolerates leading/trailing slashes; mirrors `derivePath` by using only the
+ * first two path segments after the `assetspaces/` prefix (deeper segments are
+ * ignored, so the round-trip `deriveUrl(derivePath(url))` is exact).
+ *
+ * @param path A vault-relative mount path of the form
+ *   `assetspaces/<owner>/<repo>`.
+ * @returns `https://github.com/<owner>/<repo>`, or `null` when the path does not
+ *   conform (wrong/absent `assetspaces/` prefix, fewer than two segments, an
+ *   out-of-charset segment, or a `.`/`..` traversal segment) — callers fall back
+ *   to their legacy URL source.
+ */
+export function deriveUrl(path: unknown): string | null {
+  if (typeof path !== "string") return null;
+  let p = path.trim();
+  if (p.length === 0) return null;
+
+  // Tolerate leading/trailing slashes so a folder path with either still parses.
+  p = p.replace(/^\/+/, "").replace(/\/+$/, "");
+
+  const prefix = `${ASSET_SPACES_PREFIX}/`;
+  if (!p.startsWith(prefix)) return null;
+
+  const segments = p
+    .slice(prefix.length)
+    .split("/")
+    .filter((seg) => seg.length > 0);
+  if (segments.length < 2) return null;
+
+  const owner = segments[0];
+  const repo = segments[1];
+  // Same traversal / out-of-charset rejection as `derivePath`: a `.`/`..` or
+  // disallowed-character segment must never be spliced into the reconstructed
+  // URL (the path may be an untrusted on-disk folder name).
+  if (owner === "." || owner === ".." || repo === "." || repo === "..") {
+    return null;
+  }
+  if (!SEGMENT_RE.test(owner) || !SEGMENT_RE.test(repo)) return null;
+
+  return `https://github.com/${owner}/${repo}`;
+}
+
+/**
  * Derive the LEGACY flat mount path `assetspaces/<repo>` (with an `exoas-`
  * prefix stripped) that pre-#3538 `add-assetspace` / `bootstrap` mounted at,
  * before the canonical Maven `derivePath` (`assetspaces/<owner>/<repo>`) was

--- a/packages/core/tests/unit/services/AssetSpacePathDeriver.test.ts
+++ b/packages/core/tests/unit/services/AssetSpacePathDeriver.test.ts
@@ -1,5 +1,6 @@
 import {
   derivePath,
+  deriveUrl,
   deriveLegacyFlatPath,
 } from "../../../src/services/AssetSpacePathDeriver";
 
@@ -112,6 +113,130 @@ describe("derivePath (RFC 01a83de8 v10 UD1)", () => {
       const ssh = derivePath("git@github.com:kitelev/exoas-ems.git");
       expect(https).toBe(ssh);
       expect(https).toBe(EXPECTED);
+    });
+  });
+});
+
+describe("deriveUrl (RFC 0005 Phase 0 — inverse of derivePath)", () => {
+  const ALL_GITHUB_FORMS: Array<[string, string]> = [
+    ["HTTPS bare", "https://github.com/kitelev/exoas-ems"],
+    ["HTTPS with .git", "https://github.com/kitelev/exoas-ems.git"],
+    ["HTTP scheme", "http://github.com/kitelev/exoas-ems"],
+    ["trailing slash", "https://github.com/kitelev/exoas-ems/"],
+    [".git + trailing slash", "https://github.com/kitelev/exoas-ems.git/"],
+    ["SSH scp-like", "git@github.com:kitelev/exoas-ems.git"],
+    ["SSH scp-like no .git", "git@github.com:kitelev/exoas-ems"],
+    ["ssh:// URL", "ssh://git@github.com/kitelev/exoas-ems.git"],
+    ["ssh:// with port", "ssh://git@github.com:22/kitelev/exoas-ems.git"],
+    ["git:// protocol", "git://github.com/kitelev/exoas-ems.git"],
+    ["embedded credentials", "https://user:token@github.com/kitelev/exoas-ems"],
+    ["leading/trailing whitespace", "  https://github.com/kitelev/exoas-ems  "],
+  ];
+
+  // The requirement-bound test (revert-verify keys on this — neutralising the
+  // deriveUrl body, e.g. `return null`, makes the reconstruction + round-trip
+  // assertions go RED; restoring → GREEN).
+  it("@req:1e56367b-ca1d-4c8b-8839-343e82cee2d3 reconstructs the canonical github URL from a mount path, is the exact inverse of derivePath under the github-https invariant, and returns null for non-conforming paths", () => {
+    // 1. Direct reconstruction from a canonical mount path.
+    expect(deriveUrl("assetspaces/kitelev/exoas-exo")).toBe(
+      "https://github.com/kitelev/exoas-exo",
+    );
+    // 2. Exact inverse: deriveUrl(derivePath(url)) === canonical github URL for
+    //    every URL form derivePath normalises.
+    for (const [, url] of ALL_GITHUB_FORMS) {
+      const path = derivePath(url);
+      expect(path).not.toBeNull();
+      expect(deriveUrl(path as string)).toBe(
+        "https://github.com/kitelev/exoas-ems",
+      );
+    }
+    // 3. null for a non-conforming path (caller falls back to its legacy URL
+    //    source — the .gitmodules registry, until RFC 0005 Phase 1 removes it).
+    expect(deriveUrl("not-assetspaces/owner/repo")).toBeNull();
+    expect(deriveUrl("assetspaces/onlyone")).toBeNull();
+  });
+
+  describe("canonical reconstruction (path → https github URL)", () => {
+    it.each([
+      ["kitelev/exoas-exo", "assetspaces/kitelev/exoas-exo", "https://github.com/kitelev/exoas-exo"],
+      ["different owner same repo", "assetspaces/alice/shared", "https://github.com/alice/shared"],
+      ["dotted/.-/_ chars in repo", "assetspaces/kitelev/exoas-kitelev-registry", "https://github.com/kitelev/exoas-kitelev-registry"],
+      ["leading slash tolerated", "/assetspaces/kitelev/exoas-ems", "https://github.com/kitelev/exoas-ems"],
+      ["trailing slash tolerated", "assetspaces/kitelev/exoas-ems/", "https://github.com/kitelev/exoas-ems"],
+      ["extra segments ignored (first two used)", "assetspaces/kitelev/exoas-ems/sub/dir", "https://github.com/kitelev/exoas-ems"],
+      ["surrounding whitespace trimmed", "  assetspaces/kitelev/exoas-ems  ", "https://github.com/kitelev/exoas-ems"],
+    ])("%s → URL", (_label, path, expected) => {
+      expect(deriveUrl(path)).toBe(expected);
+    });
+  });
+
+  describe("exact inverse of derivePath — round-trip for every URL form", () => {
+    it.each(ALL_GITHUB_FORMS)(
+      "%s → derivePath → deriveUrl === canonical github URL",
+      (_label, url) => {
+        const path = derivePath(url);
+        expect(path).not.toBeNull();
+        expect(deriveUrl(path as string)).toBe(
+          "https://github.com/kitelev/exoas-ems",
+        );
+      },
+    );
+  });
+
+  describe("null on non-conforming paths (caller falls back)", () => {
+    it.each([
+      ["empty string", ""],
+      ["whitespace only", "   "],
+      ["non-string", 42 as unknown as string],
+      ["undefined", undefined as unknown as string],
+      ["null", null as unknown as string],
+      ["wrong prefix", "not-assetspaces/owner/repo"],
+      ["no prefix at all", "owner/repo"],
+      ["assetspaces only", "assetspaces"],
+      ["assetspaces/ prefix only", "assetspaces/"],
+      ["owner only (one segment)", "assetspaces/onlyone"],
+      ["bare slashes", "assetspaces///"],
+    ])("%s → null", (_label, input) => {
+      expect(deriveUrl(input)).toBeNull();
+    });
+  });
+
+  describe("traversal / out-of-charset segments rejected (no escape into URL)", () => {
+    it.each([
+      ["owner is ..", "assetspaces/../repo"],
+      ["repo is ..", "assetspaces/owner/.."],
+      ["repo is .", "assetspaces/owner/."],
+      ["owner is .", "assetspaces/./repo"],
+      ["whitespace in repo", "assetspaces/owner/repo with space"],
+      ["url-encoded escape attempt", "assetspaces/owner/%2e%2e"],
+      ["control char in owner", "assetspaces/ow\tner/repo"],
+      ["slash-bearing segment via encoding", "assetspaces/owner/re%2Fpo"],
+    ])("%s → null", (_label, input) => {
+      expect(deriveUrl(input)).toBeNull();
+    });
+
+    it("reconstructed URL never carries a `..` path component", () => {
+      for (const input of [
+        "assetspaces/../repo",
+        "assetspaces/owner/..",
+        "assetspaces/./repo",
+      ]) {
+        const out = deriveUrl(input);
+        if (out !== null) expect(out.split("/")).not.toContain("..");
+      }
+    });
+  });
+
+  describe("idempotent inverse — HTTPS and SSH forms reconstruct identically", () => {
+    it("the same repo via any form round-trips to one canonical URL", () => {
+      const fromHttps = deriveUrl(
+        derivePath("https://github.com/kitelev/exoas-ems.git") as string,
+      );
+      const fromSsh = deriveUrl(
+        derivePath("git@github.com:kitelev/exoas-ems.git") as string,
+      );
+      expect(fromHttps).toBe(fromSsh);
+      expect(fromHttps).toBe("https://github.com/kitelev/exoas-ems");
     });
   });
 });


### PR DESCRIPTION
## RFC 0005 Phase 0 — `deriveUrl(path)`, the pure inverse of `derivePath` (req-first SDD)

Adds the **enabling primitive** for RFC 0005 (eliminate the `.gitmodules` device-side URL-registry): reconstruct an AssetSpace's GitHub clone URL from its on-disk folder path, so the URL no longer has to be stored in a `.gitmodules` sidecar.

**Req:** `1e56367b-ca1d-4c8b-8839-343e82cee2d3` (P2, Unit binding — Approved). Status will flip to **Active** on merge.

### What
- **`deriveUrl(path: unknown): string | null`** in `packages/core/.../AssetSpacePathDeriver.ts` — the inverse of `derivePath`: `assetspaces/<owner>/<repo>` → `https://github.com/<owner>/<repo>`.
  - **Lossy by design** — `derivePath` is many-to-one (drops host/scheme/.git/creds/port). The inverse holds under the **github-https invariant** (every AssetSpace URL is `https://github.com/...`), true for the whole ecosystem (RFC 0005 §3.2) and already baked into `derivePath`'s Maven design.
  - **Validated** — both segments via the same `SEGMENT_RE` + `.`/`..` traversal guards as `derivePath` (its input is an **untrusted folder path**, not a trusted `derivePath` output), returning `null` for non-conforming paths so callers fall back.
- **DRY** — the `path → url` half already existed **duplicated** inside `toHttpsGitHubUrl(git)` (`CliApplyProfileService.ts:129`). Refactored to `deriveUrl(derivePath(git)) ?? git` → `deriveUrl` is the single source of truth. **No behaviour change** (its 7 unit tests stay green — the regression guard).
- Exported from `packages/core` index.

**Ships nothing user-visible** — the primitive RFC 0005 Phase 1 consumes (re-derive a URL from the folder path instead of reading `.gitmodules`).

### Verification
- `typecheck` 0 errors; **core 94/94**, **cli 7/7** green.
- **Revert-verify** (`@req:1e56367b-...`): neutralising the `deriveUrl` body (`return null`, type-preserving) → core reconstruction + round-trip tests **RED** (13 fail) and the DRY-coupled `toHttpsGitHubUrl` tests **RED** (cli 2 fail); restored → **GREEN**.
- archgate 23/23.

### Scope
`packages/core` + `packages/cli` only — **no `packages/obsidian-plugin` change** (Phase 1 territory). Companion RFC v2 doc-PR: #3756.
