### PR TITLE
feat(relations): factual 'reified · <AS>' marker (RFC 93a0b2ee C2 / Phase 2)

### DIFF
--- a/packages/obsidian-plugin/src/presentation/components/AssetRelationsTable.tsx
+++ b/packages/obsidian-plugin/src/presentation/components/AssetRelationsTable.tsx
@@ -90,7 +90,68 @@ export interface AssetRelation {
   isBlocked?: boolean;
 
   metadata: Record<string, unknown>;
+
+  /**
+   * RFC `93a0b2ee` Task 2 (C2) — how this relation was sourced. A `reified`
+   * relation is backed by an `exo__Statement` asset and renders the factual
+   * "reified · <AS>" marker; `inline` (or absent — legacy) renders no marker.
+   * Edge-cases (object=Literal, inline+reified duplicate, dual-IRI subject) are
+   * resolved upstream in `RelationsRenderer.mergeReifiedRelations` (Task 1.3) —
+   * the marker keys strictly off this field, so a relation tagged `inline`
+   * never gets a marker even if it carries {@link assetSpace}.
+   */
+  provenance?: "inline" | "reified";
+  /**
+   * RFC `93a0b2ee` Task 2 (C2) — the AssetSpace (`exoas-<name>`) the backing
+   * statement asset lives in, for the factual "reified · <AS>" marker text.
+   * `undefined` → a `reified` relation shows a bare "reified".
+   */
+  assetSpace?: string;
 }
+
+/**
+ * RFC `93a0b2ee` Task 2 (C2) — the factual relation-type marker text.
+ *
+ * Returns `"reified · <AS>"` (or a bare `"reified"` when the AssetSpace is not
+ * derivable) for a relation backed by an `exo__Statement` asset; `null` for an
+ * inline relation (the default — no marker). The marker is purely FACTUAL: it
+ * states WHERE the backing statement lives, NEVER a privacy promise. Privacy
+ * depends on whether that AssetSpace is shared, which is not a queryable RDF
+ * fact (RFC §C2 decision H; `exo__AssetSpace_visibility` is an out-of-MVP
+ * follow-up). Honest-marker metric: 0 unverifiable statements.
+ */
+export function reifiedMarkerText(relation: AssetRelation): string | null {
+  if (relation.provenance !== "reified") return null;
+  const as = relation.assetSpace?.trim();
+  return as ? `reified · ${as}` : "reified";
+}
+
+/**
+ * RFC `93a0b2ee` Task 2 (C2) — the accessible/title explanation of the marker.
+ * Factual only (no privacy promise). Used for `title` (desktop hover) and
+ * `aria-label`; the persistent on-screen explanation is {@link ReifiedLegend}
+ * (the mobile/tap channel — hover is unavailable there).
+ */
+function reifiedMarkerExplanation(relation: AssetRelation): string {
+  const where = relation.assetSpace?.trim()
+    ? `в AssetSpace ${relation.assetSpace.trim()}`
+    : "в отдельном statement-ассете";
+  return `Связь вынесена ${where} (фактически — где лежит statement). Приватность зависит от того, шарится ли этот AssetSpace.`;
+}
+
+/**
+ * RFC `93a0b2ee` Task 2 (C2) — persistent explanation of the `reified · <AS>`
+ * marker, rendered below the table whenever a reified relation is present.
+ * Persistent (always visible — NOT hover-only) so the marker is explained on
+ * mobile where hover is unavailable. Factual only — no privacy promise.
+ */
+const ReifiedLegend: React.FC = () => (
+  <p className="exocortex-reified-legend" role="note">
+    «reified · &lt;AS&gt;» — связь вынесена в statement-ассет в этом AssetSpace
+    (фактически, где лежит). Приватность зависит от того, шарится ли этот
+    AssetSpace.
+  </p>
+);
 
 export interface AssetRelationsTableProps {
   relations: AssetRelation[];
@@ -459,6 +520,20 @@ const SingleTable: React.FC<SingleTableProps> = ({
           >
             {getDisplayLabel(relation)}
           </a>
+          {(() => {
+            const marker = reifiedMarkerText(relation);
+            if (!marker) return null;
+            const explanation = reifiedMarkerExplanation(relation);
+            return (
+              <span
+                className="exocortex-reified-marker"
+                title={explanation}
+                aria-label={explanation}
+              >
+                {marker}
+              </span>
+            );
+          })()}
         </td>
         <td className="instance-class">
           {renderInstanceClassCell(relation.metadata)}
@@ -628,6 +703,13 @@ export const AssetRelationsTable: React.FC<AssetRelationsTableProps> = ({
     new Set()
   );
 
+  // RFC `93a0b2ee` Task 2 (C2) — show the persistent reified-marker legend iff
+  // at least one rendered relation is reified (mobile-safe explanation channel).
+  const hasReified = useMemo(
+    () => relations.some((r) => r.provenance === "reified"),
+    [relations],
+  );
+
   const groupedRelations = useMemo(() => {
     if (!groupByProperty) {
       return { ungrouped: relations };
@@ -710,6 +792,7 @@ export const AssetRelationsTable: React.FC<AssetRelationsTableProps> = ({
             </div>
           );
         })}
+        {hasReified && <ReifiedLegend />}
       </div>
     );
   }
@@ -725,6 +808,7 @@ export const AssetRelationsTable: React.FC<AssetRelationsTableProps> = ({
         getAssetLabel={getAssetLabel}
         resolveAccent={resolveAccent}
       />
+      {hasReified && <ReifiedLegend />}
     </div>
   );
 };

--- a/packages/obsidian-plugin/src/presentation/renderers/layout/RelationsRenderer.ts
+++ b/packages/obsidian-plugin/src/presentation/renderers/layout/RelationsRenderer.ts
@@ -505,6 +505,7 @@ export class RelationsRenderer {
         modified,
         provenance: "reified",
         statementPath: r.statementPath ?? undefined,
+        assetSpace: r.assetSpace ?? undefined,
       });
     }
   }

--- a/packages/obsidian-plugin/src/presentation/renderers/layout/types.ts
+++ b/packages/obsidian-plugin/src/presentation/renderers/layout/types.ts
@@ -31,4 +31,12 @@ export interface AssetRelation {
    * for inline relations or when the statement IRI is not a vault-asset IRI.
    */
   statementPath?: string;
+  /**
+   * RFC `93a0b2ee` Task 2 (C2) — the AssetSpace segment (`exoas-<name>`) the
+   * backing `exo__Statement` asset lives in, parsed from {@link statementPath}
+   * by the Task 1.1 helper. Drives the factual "reified · &lt;AS&gt;" marker.
+   * `undefined` for inline relations or when the statement path has no
+   * `exoas-*` segment (the marker then shows a bare "reified").
+   */
+  assetSpace?: string;
 }

--- a/packages/obsidian-plugin/styles.css
+++ b/packages/obsidian-plugin/styles.css
@@ -6198,3 +6198,23 @@
 .exosync-resolver-error {
   color: var(--text-error);
 }
+
+/* RFC 93a0b2ee Task 2 (C2) — factual reified-relation marker + persistent legend.
+   Marker states WHERE the backing exo__Statement lives (its AssetSpace); it is
+   NOT a privacy promise. The legend is always visible (not hover-only) so the
+   marker is explained on mobile. */
+.exocortex-reified-marker {
+  margin-left: 0.5em;
+  padding: 0 0.4em;
+  font-size: 0.75em;
+  color: var(--text-muted);
+  background: var(--background-modifier-border);
+  border-radius: 4px;
+  white-space: nowrap;
+  vertical-align: middle;
+}
+.exocortex-reified-legend {
+  margin: 0.5em 0 0;
+  font-size: 0.75em;
+  color: var(--text-muted);
+}

--- a/packages/obsidian-plugin/tests/unit/presentation/components/AssetRelationsTable.reified-marker.test.tsx
+++ b/packages/obsidian-plugin/tests/unit/presentation/components/AssetRelationsTable.reified-marker.test.tsx
@@ -1,0 +1,212 @@
+/**
+ * AssetRelationsTable — RFC `93a0b2ee` Phase 2 / Task 2 (C2)
+ *
+ * Locks in the FACTUAL reified-relation marker: a relation carrying
+ * `provenance: "reified"` renders an inline `.exocortex-reified-marker` reading
+ * `reified · <AS>` (the AssetSpace the backing `exo__Statement` lives in); an
+ * `inline` (or legacy, no-provenance) relation renders none. A persistent
+ * `.exocortex-reified-legend` (mobile-safe, not hover-only) explains the marker
+ * whenever a reified relation is present. The marker is purely factual — it
+ * carries NO privacy claim ("🔒" / "не уедет"); privacy depends on whether the
+ * AssetSpace is shared, which is not a queryable RDF fact (RFC §C2 decision H).
+ *
+ * @req:a4c8a9a0-27aa-48ff-8365-eba1b40c6433
+ */
+
+import React from "react";
+import "@testing-library/jest-dom";
+import { render } from "@testing-library/react";
+import {
+  AssetRelationsTable,
+  AssetRelation,
+  reifiedMarkerText,
+} from "../../../../src/presentation/components/AssetRelationsTable";
+
+const baseRelation = (
+  overrides: Partial<AssetRelation> = {},
+): AssetRelation => ({
+  path: "p.md",
+  title: "P",
+  propertyName: undefined,
+  isBodyLink: true,
+  created: 0,
+  modified: 0,
+  metadata: {},
+  ...overrides,
+});
+
+/** Privacy-claim tokens the honest marker must never contain (RFC §C2 decision H). */
+const PRIVACY_CLAIM_TOKENS = [
+  "🔒",
+  "не уедет",
+  "не уйдёт",
+  "private",
+  "приватно и",
+];
+
+describe("AssetRelationsTable — reified-relation marker (RFC 93a0b2ee C2)", () => {
+  it("renders a `reified · <AS>` marker for a reified relation (the AssetSpace from the backing statement path)", () => {
+    const { container } = render(
+      <AssetRelationsTable
+        relations={[
+          baseRelation({
+            path: "concepts/c.md",
+            title: "Концепт C",
+            provenance: "reified",
+            assetSpace: "exoas-class-relations",
+            statementPath:
+              "assetspaces/kitelev/exoas-class-relations/class-relations/stmt.md",
+          }),
+        ]}
+      />,
+    );
+
+    const markers = container.querySelectorAll<HTMLElement>(
+      ".exocortex-reified-marker",
+    );
+    expect(markers).toHaveLength(1);
+    expect(markers[0].textContent).toBe("reified · exoas-class-relations");
+  });
+
+  it("renders NO marker for an inline relation", () => {
+    const { container } = render(
+      <AssetRelationsTable
+        relations={[
+          baseRelation({
+            path: "concepts/b.md",
+            title: "Концепт B",
+            provenance: "inline",
+          }),
+        ]}
+      />,
+    );
+
+    expect(container.querySelector(".exocortex-reified-marker")).toBeNull();
+    expect(container.querySelector(".exocortex-reified-legend")).toBeNull();
+  });
+
+  it("renders NO marker for a legacy relation with no provenance field", () => {
+    const { container } = render(
+      <AssetRelationsTable
+        relations={[baseRelation({ path: "legacy/a.md", title: "A" })]}
+      />,
+    );
+
+    expect(container.querySelector(".exocortex-reified-marker")).toBeNull();
+  });
+
+  it("keys strictly off provenance — an inline relation gets NO marker even if it carries an assetSpace", () => {
+    const { container } = render(
+      <AssetRelationsTable
+        relations={[
+          baseRelation({
+            path: "concepts/dup.md",
+            title: "Концепт Dup",
+            provenance: "inline",
+            assetSpace: "exoas-class-relations",
+          }),
+        ]}
+      />,
+    );
+
+    expect(container.querySelector(".exocortex-reified-marker")).toBeNull();
+  });
+
+  it("renders a bare `reified` marker when the AssetSpace is not derivable", () => {
+    const { container } = render(
+      <AssetRelationsTable
+        relations={[
+          baseRelation({
+            path: "concepts/e.md",
+            title: "Концепт E",
+            provenance: "reified",
+          }),
+        ]}
+      />,
+    );
+
+    const marker = container.querySelector<HTMLElement>(
+      ".exocortex-reified-marker",
+    );
+    expect(marker).not.toBeNull();
+    expect(marker!.textContent).toBe("reified");
+  });
+
+  it("renders a persistent (not hover-only) explanation legend when a reified relation is present", () => {
+    const { container } = render(
+      <AssetRelationsTable
+        relations={[
+          baseRelation({
+            path: "concepts/c.md",
+            title: "Концепт C",
+            provenance: "reified",
+            assetSpace: "exoas-class-relations",
+          }),
+        ]}
+      />,
+    );
+
+    const legend = container.querySelector<HTMLElement>(
+      ".exocortex-reified-legend",
+    );
+    // Persistent: a plain on-screen element (role=note), NOT a hover-only title.
+    expect(legend).not.toBeNull();
+    expect(legend!.getAttribute("role")).toBe("note");
+    expect(legend!.textContent ?? "").toContain("reified");
+  });
+
+  it("the marker and its persistent legend contain NO privacy claim (honest-marker)", () => {
+    const { container } = render(
+      <AssetRelationsTable
+        relations={[
+          baseRelation({
+            path: "concepts/c.md",
+            title: "Концепт C",
+            provenance: "reified",
+            assetSpace: "exoas-class-relations",
+          }),
+        ]}
+      />,
+    );
+
+    const marker = container.querySelector<HTMLElement>(
+      ".exocortex-reified-marker",
+    );
+    const legend = container.querySelector<HTMLElement>(
+      ".exocortex-reified-legend",
+    );
+    // The marker must actually be present (so this is a real honest-marker check,
+    // not a vacuous pass on an absent element).
+    expect(marker).not.toBeNull();
+    expect(legend).not.toBeNull();
+
+    // Factual surfaces: visible text + the accessible title/aria explanation.
+    const surfaces = [
+      marker!.textContent ?? "",
+      marker!.getAttribute("title") ?? "",
+      marker!.getAttribute("aria-label") ?? "",
+      legend!.textContent ?? "",
+    ]
+      .join(" ")
+      .toLowerCase();
+
+    for (const token of PRIVACY_CLAIM_TOKENS) {
+      expect(surfaces).not.toContain(token.toLowerCase());
+    }
+  });
+
+  it("reifiedMarkerText is a pure factual helper", () => {
+    expect(
+      reifiedMarkerText(
+        baseRelation({ provenance: "reified", assetSpace: "exoas-foo" }),
+      ),
+    ).toBe("reified · exoas-foo");
+    expect(reifiedMarkerText(baseRelation({ provenance: "reified" }))).toBe(
+      "reified",
+    );
+    expect(
+      reifiedMarkerText(baseRelation({ provenance: "inline" })),
+    ).toBeNull();
+    expect(reifiedMarkerText(baseRelation())).toBeNull();
+  });
+});


### PR DESCRIPTION
## Reification Phase 2 (C2) — factual `reified · <AS>` marker in the Relations block

Renders a **factual** visual relation-type marker in the Relations block: a relation
backed by an `exo__Statement` asset (sourced upstream by Phase-1 / Task 1.3 via the
`getReifiedRelations` helper + `AssetRelation.provenance`) shows an inline marker
`reified · <AS>` — where `<AS>` is the AssetSpace the backing statement lives in
(parsed by the P1 helper, carried as `AssetRelation.assetSpace`), or a bare `reified`
when not derivable. Inline relations get **no** marker.

### Honest marker (RFC §C2 decision H)
The marker is purely **factual** — it states WHERE the statement lives, never a privacy
promise (no `🔒`, no «не уедет»). Privacy depends on whether that AssetSpace is shared,
which is not a queryable RDF fact; `exo__AssetSpace_visibility` is an out-of-MVP
follow-up. A **persistent** (not hover-only) legend below the table explains the marker
on mobile.

### Scope / design
- **Marker keys strictly off `provenance`** — edge-cases are resolved upstream in
  `RelationsRenderer.mergeReifiedRelations` (Task 1.3): `object=Literal` → skipped
  (property, not relation); inline+reified duplicate → shown as inline (no marker);
  dual-IRI subject → resolved in the helper. So a relation tagged `inline` never gets
  a marker even if it carries an AssetSpace.
- Renders for both outgoing and incoming reified relations (the read-only object-side
  reify-toggle affordance is Phase 3 — P2 only **displays** the marker).
- Additive only: P1 source (`getReifiedRelations`) untouched; `ExocortexPlugin.ts`
  untouched; no `packages/cli` / `core/.../assetspace` / `infrastructure/adapters`
  changes (disjoint from the parallel reification/assetspace tracks).

### Files
- `renderers/layout/types.ts` — `AssetRelation.assetSpace`
- `renderers/layout/RelationsRenderer.ts` — carry `r.assetSpace` in the reified push
- `components/AssetRelationsTable.tsx` — `reifiedMarkerText` helper + marker render + `ReifiedLegend`
- `styles.css` — muted marker + legend styling
- test: `tests/unit/presentation/components/AssetRelationsTable.reified-marker.test.tsx`

### req-first SDD (RFC 0003)
Req `a4c8a9a0-27aa-48ff-8365-eba1b40c6433` (component-class binding) — proposed →
approved (autonomous, orchestrator mandate) → Active on merge.

**Revert-verified:** `@req:a4c8a9a0-27aa-48ff-8365-eba1b40c6433` — making
`reifiedMarkerText` return `null` makes 4/8 (marker + legend + honest-marker + helper)
cases **RED**; restored → **GREEN 8/8**.

Req: a4c8a9a0-27aa-48ff-8365-eba1b40c6433
