### PR TITLE
feat(rfc0005-p1): git-free vault carries no .gitmodules — readers re-derive URLs via deriveUrl

### DIFF
--- a/packages/obsidian-plugin/src/ExocortexPlugin.ts
+++ b/packages/obsidian-plugin/src/ExocortexPlugin.ts
@@ -3863,7 +3863,7 @@ export default class ExocortexPlugin extends Plugin {
     // Mobile path: desktop deps unavailable (`applyDeps === null`) but the
     // cross-platform `RestAssetSpaceMount` is wired. `RestAssetSpaceMount`
     // structurally satisfies `IRestBootstrapMount` (mount() → {sha},
-    // readGitmodulesEntries()).
+    // listMountedAssetSpaces()).
     const restStrategy =
       applyDeps === null && restMount !== null ? restMount : undefined;
 
@@ -3978,7 +3978,9 @@ export default class ExocortexPlugin extends Plugin {
   /**
    * Wire + register the «Exocortex: Unmount assetspace» palette command
    * (#e6b8827c) — the inverse of «Add assetspace by URL». Lists the currently
-   * mounted AssetSpaces (the `.gitmodules` registry, cross-referenced with the
+   * mounted AssetSpaces (RFC 0005 Phase 1 — filesystem enumeration of the
+   * materialised `assetspaces/<owner>/<repo>` folders via
+   * {@link RestAssetSpaceMount.listMountedAssetSpaces}, cross-referenced with the
    * AssetSpace descriptor scan for uid/namespace → TS-floor identity), fuzzy-
    * picks one, and tears it down via the git-free cross-platform
    * {@link RestAssetSpaceMount.unmount}.
@@ -4077,14 +4079,16 @@ export default class ExocortexPlugin extends Plugin {
   ): void {
     const unmountCommand = new UnmountAssetSpaceCommand({
       listMounted: async (): Promise<UnmountableAssetSpace[]> => {
-        // `.gitmodules` is the canonical "what's mounted" registry (the same
-        // source apply-profile reads). The descriptor scan (a full-vault
+        // RFC 0005 Phase 1 — the "what's mounted" registry is the FILESYSTEM:
+        // listMountedAssetSpaces enumerates the materialised
+        // `assetspaces/<owner>/<repo>` folders and re-derives each URL via
+        // `deriveUrl` (no `.gitmodules`). The descriptor scan (a full-vault
         // markdown walk, run once per command open — not per keystroke) supplies
         // uid + namespace so the TS-floor identity can be computed.
         // buildUnmountableList does the join + dual floor guard (descriptor-based
         // AND path-based, so a floor mounted flat / with an un-derivable
         // descriptor is still recognised).
-        const entries = await restMount.readGitmodulesEntries();
+        const entries = await restMount.listMountedAssetSpaces();
         const infos: AssetSpaceInfo[] = switchMgr.listAllAssetSpaceInfos();
         return buildUnmountableList(entries, infos);
       },

--- a/packages/obsidian-plugin/src/infrastructure/adapters/BootstrapAssetSpaceCommands.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/BootstrapAssetSpaceCommands.ts
@@ -74,31 +74,38 @@ export interface IGitSubmoduleOps {
 }
 
 /**
- * Cross-platform (incl. iOS) materialise + `.gitmodules` strategy — the
- * mobile-capable counterpart of {@link IAssetSpacePuller} + {@link IGitSubmoduleOps}
- * (#3535). A single combined op (pull tarball → materialise into the vault
- * folder → write `.gitmodules`) over `vault.adapter`, with NO Node `fs` /
- * staging dir / file-only registry split. Satisfied structurally by
- * `RestAssetSpaceMount` (RFC 01a83de8) — the same adapter that `apply-profile`
- * already mounts through on mobile.
+ * Cross-platform (incl. iOS) materialise strategy — the mobile-capable
+ * counterpart of {@link IAssetSpacePuller} + {@link IGitSubmoduleOps} (#3535).
+ * A single combined op (pull tarball → materialise into the vault folder) over
+ * `vault.adapter`, with NO Node `fs` / staging dir / file-only registry split.
+ * Satisfied structurally by `RestAssetSpaceMount` (RFC 01a83de8) — the same
+ * adapter `apply-profile` already mounts through on mobile.
  *
- * When injected, it fully replaces the desktop `getPuller` + `gitOps` path:
- * `.gitmodules` becomes the single source of truth that `apply-profile`
- * (`listAllAssetSpaceInfos`) reads, written regardless of `.git` presence (a
- * fresh mobile vault has no `.git`).
+ * When injected, it fully replaces the desktop `getPuller` + `gitOps` path.
+ * RFC 0005 Phase 1 — the mount writes **no** `.gitmodules`; the mounted set is
+ * tracked by folder presence (`assetspaces/<owner>/<repo>`), and
+ * {@link listMountedAssetSpaces} re-derives URLs from those paths. apply-profile
+ * (`listAllAssetSpaceInfos`) already reads filesystem presence + descriptors,
+ * not `.gitmodules`.
  */
 export interface IRestBootstrapMount {
   /**
-   * Pull `gitUrl`'s tarball, materialise it into `submodulePath`, and write the
-   * `.gitmodules` entry — all via `vault.adapter`. Returns the tarball SHA.
+   * Pull `gitUrl`'s tarball and materialise it into `submodulePath` via
+   * `vault.adapter`. Returns the tarball SHA. RFC 0005 Phase 1 — writes **no**
+   * `.gitmodules`: the folder presence at `assetspaces/<owner>/<repo>` is the
+   * mount-state record.
    */
   mount(
     gitUrl: string,
     submodulePath: string,
     ref: string,
   ): Promise<{ sha: string }>;
-  /** Read the current `.gitmodules` (path, url) entries via `vault.adapter`. */
-  readGitmodulesEntries(): Promise<
+  /**
+   * List the mounted AssetSpaces by enumerating the `assetspaces/<owner>/<repo>`
+   * folders on disk + re-deriving each URL (RFC 0005 Phase 1 — replaces reading
+   * the `.gitmodules` URL-registry). `{submodulePath, url}` per folder.
+   */
+  listMountedAssetSpaces(): Promise<
     Array<{ submodulePath: string; url: string }>
   >;
 }
@@ -264,10 +271,13 @@ export class BootstrapAssetSpaceCommands {
   }
 
   /**
-   * Classify the current vault for the bootstrap command:
-   *   - `empty` — no `.gitmodules` entries AND no materialised `assetspaces/*`.
-   *   - `clone-needs-fetch` — `.gitmodules` has entries but no folder is
-   *     materialised (EC2: cloned without `--recurse-submodules`).
+   * Classify the current vault for the bootstrap command (tracked entries come
+   * from {@link listTrackedEntries} — RFC 0005 Phase 1: folder enumeration on a
+   * git-free vault, the committed `.gitmodules` on a desktop git vault):
+   *   - `empty` — no tracked AssetSpace folders AND none materialised.
+   *   - `clone-needs-fetch` — tracked folders exist but none is materialised
+   *     (present-but-empty `assetspaces/<owner>/<repo>` dirs, or — on a git vault
+   *     — committed `.gitmodules` entries cloned without `--recurse-submodules`).
    *   - `bootstrapped` — at least one `assetspaces/<ns>/` folder has content.
    */
   async detectVaultState(): Promise<VaultBootstrapState> {
@@ -432,10 +442,13 @@ export class BootstrapAssetSpaceCommands {
   // ─────────────────────────── internal ───────────────────────────
 
   /**
-   * EC2 — re-materialise every `.gitmodules`-tracked AssetSpace whose folder is
-   * currently empty (vault was cloned without `--recurse-submodules`). A git
-   * clone always has a `.git` dir, so this path stays in git mode (the
-   * `.gitmodules` entries already exist; `appendGitmodulesEntry` is a no-op).
+   * EC2 — re-materialise every tracked AssetSpace whose folder is currently
+   * empty. The tracked set comes from {@link listTrackedEntries}: on a git-free
+   * vault (RFC 0005 Phase 1) these are the present-but-empty
+   * `assetspaces/<owner>/<repo>` folders with their URL re-derived via
+   * `deriveUrl`; on a desktop git vault they are the committed `.gitmodules`
+   * entries (cloned without `--recurse-submodules`). Re-materialising writes the
+   * content back into the same folder.
    */
   private async fetchTrackedAssetSpaces(): Promise<void> {
     let entries: Array<{ submodulePath: string; url: string }>;
@@ -489,12 +502,12 @@ export class BootstrapAssetSpaceCommands {
     submodulePath: string,
     isGit: boolean,
   ): Promise<MaterializeResult> {
-    // Mobile (#3535 / RFC 01a83de8): one cross-platform op — pull the tarball,
-    // materialise it into the vault folder, and write the `.gitmodules` entry,
-    // all via `vault.adapter` (no Node fs, no staging dir, no file-only
-    // registry split). `.gitmodules` is the single source of truth that
-    // apply-profile (`listAllAssetSpaceInfos`) reads, so it is written
-    // regardless of the `isGit` flag (a fresh mobile vault has no `.git`).
+    // Cross-platform (#3535 / RFC 01a83de8): one op — pull the tarball and
+    // materialise it into the vault folder via `vault.adapter` (no Node fs, no
+    // staging dir, no file-only registry split). RFC 0005 Phase 1 — writes NO
+    // `.gitmodules`; the materialised folder presence at
+    // `assetspaces/<owner>/<repo>` is the mount-state record that
+    // `listMountedAssetSpaces` + apply-profile read.
     if (this.d.restMount !== undefined) {
       const { sha } = await this.d.restMount.mount(
         url,
@@ -636,15 +649,19 @@ export class BootstrapAssetSpaceCommands {
   }
 
   /**
-   * Read the `.gitmodules` (path, url) entries via whichever strategy is wired —
-   * the mobile {@link IRestBootstrapMount} (vault.adapter) or the desktop
-   * {@link IGitSubmoduleOps} (Node fs). Throws if neither is wired.
+   * List the tracked AssetSpaces (path, url) via whichever strategy is wired —
+   * the cross-platform {@link IRestBootstrapMount} (RFC 0005 Phase 1: filesystem
+   * folder enumeration + `deriveUrl`, no `.gitmodules`) or the desktop
+   * {@link IGitSubmoduleOps} (reads the committed `.gitmodules` of a git vault,
+   * Node fs). Throws if neither is wired.
    */
   private async listTrackedEntries(): Promise<
     Array<{ submodulePath: string; url: string }>
   > {
     if (this.d.restMount !== undefined) {
-      return this.d.restMount.readGitmodulesEntries();
+      // RFC 0005 Phase 1 — git-free vaults track AssetSpaces by folder presence,
+      // not `.gitmodules`: enumerate the mounted folders + derived URLs.
+      return this.d.restMount.listMountedAssetSpaces();
     }
     if (this.d.gitOps !== undefined) {
       return this.d.gitOps.readGitmodulesEntries();

--- a/packages/obsidian-plugin/src/infrastructure/adapters/BootstrapAssetSpaceCommands.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/BootstrapAssetSpaceCommands.ts
@@ -334,9 +334,9 @@ export class BootstrapAssetSpaceCommands {
     }
 
     const isGit = await this.d.isGitVault();
-    // On mobile (restMount) the REST mount always writes `.gitmodules` via
-    // vault.adapter regardless of `.git` presence (apply-profile reads it), so
-    // the desktop "file-only mode" notice would be misleading — suppress it.
+    // On the REST path the cross-platform mount tracks AssetSpaces by folder
+    // presence (RFC 0005 Phase 1 — no `.gitmodules` at all, on any platform), so
+    // the desktop-only "file-only mode" notice would be misleading — suppress it.
     if (!isGit && this.d.restMount === undefined) {
       this.d.notify(
         "Vault is not a git repository — bootstrapping in file-only mode (no .gitmodules; AssetSpaces tracked device-locally).",
@@ -416,8 +416,9 @@ export class BootstrapAssetSpaceCommands {
     }
 
     const isGit = await this.d.isGitVault();
-    // See invokeBootstrap: the mobile REST path writes `.gitmodules` regardless,
-    // so the desktop "file-only mode" notice does not apply.
+    // See invokeBootstrap: the REST path tracks AssetSpaces by folder presence
+    // (RFC 0005 Phase 1 — no `.gitmodules`), so the desktop "file-only mode"
+    // notice does not apply.
     if (!isGit && this.d.restMount === undefined) {
       this.d.notify(
         "Vault is not a git repository — adding in file-only mode (no .gitmodules; tracked device-locally).",
@@ -455,7 +456,7 @@ export class BootstrapAssetSpaceCommands {
     try {
       entries = await this.listTrackedEntries();
     } catch (e) {
-      this.d.notify(`Bootstrap: could not read .gitmodules — ${this.msg(e)}`);
+      this.d.notify(`Bootstrap: could not list tracked AssetSpaces — ${this.msg(e)}`);
       return;
     }
 

--- a/packages/obsidian-plugin/src/infrastructure/adapters/RestAssetSpaceMount.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/RestAssetSpaceMount.ts
@@ -218,6 +218,18 @@ export class RestAssetSpaceMount {
    * RFC 0005 §10.1; legacy flat mounts are deprecated, #3538). A missing
    * `assetspaces/` dir yields `[]`.
    *
+   * ⚠ **Known limitation (deprecated layout).** The enum assumes the canonical
+   * Maven shape `assetspaces/<owner>/<repo>/...`. A pre-#3538 **flat** mount
+   * (`assetspaces/<repo>/...`) whose content sits in a namespace subdir would
+   * have its `assetspaces/<repo>/<namespace>` read as a fake `<owner>/<repo>`
+   * pair — there is no cheap filesystem signal to tell a flat repo from an
+   * owner. This only affects the «Unmount» picker on a vault still carrying a
+   * deprecated flat mount (apply-profile + ExoSync are descriptor/presence
+   * sourced and never call this; `fetchTrackedAssetSpaces` only clones in
+   * clone-needs-fetch, where a flat-with-content mount is already `bootstrapped`
+   * and so never re-fetched). On canonical (EKA) vaults every AssetSpace is
+   * two-level, so this does not arise; migrate any flat mount per #3538.
+   *
    * Used by the cross-platform Bootstrap / Add-AssetSpace flow
    * ({@link BootstrapAssetSpaceCommands}) to classify the vault state (empty vs
    * clone-needs-fetch vs bootstrapped) and by «Unmount assetspace» to list what

--- a/packages/obsidian-plugin/src/infrastructure/adapters/RestAssetSpaceMount.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/RestAssetSpaceMount.ts
@@ -3,13 +3,12 @@ import { GitHubRestClient } from "./GitHubRestClient";
 import { parseGitHubURL } from "./AssetSpaceManager";
 import {
   validateVaultPathArg,
-  parseGitmodulesEntries,
   type GitmodulesEntry,
 } from "./GitSubmoduleOps";
 import {
   mountAssetSpaceFiles,
-  appendGitmodulesEntry,
   stripGitmodulesEntry,
+  deriveUrl,
   SYNC_BRANCH,
   type FileSystemPort,
   type AssetSpaceHttpClient,
@@ -27,10 +26,22 @@ import {
  * ## Thin adapter over the shared mount core (Issue #3423)
  *
  * The mount/unmount pipeline (fetch tarball → discover `<owner>-<repo>-<sha>/`
- * wrapper → extract SHA → zip-slip validate → materialise files → `.gitmodules`
- * mutation) lives ONCE in `exocortex`'s {@link mountAssetSpaceFiles} +
- * `.gitmodules` text transforms. This adapter supplies the two Obsidian-coupled
- * ports:
+ * wrapper → extract SHA → zip-slip validate → materialise files) lives ONCE in
+ * `exocortex`'s {@link mountAssetSpaceFiles}. This adapter supplies the two
+ * Obsidian-coupled ports:
+ *
+ * ## RFC 0005 Phase 1 — no `.gitmodules` on a git-free vault
+ *
+ * A git-free vault (iPhone, and post-#3567 every canonical desktop vault) no
+ * longer carries a `.gitmodules` sidecar at all: {@link mount} stops writing it,
+ * and {@link listMountedAssetSpaces} reconstructs the mounted set by enumerating
+ * the canonical `assetspaces/<owner>/<repo>` folders and re-deriving each URL
+ * with {@link deriveUrl} (the pure inverse of `derivePath` under the
+ * github-https invariant). {@link unmount} still strips a *pre-existing* legacy
+ * `.gitmodules` stanza (hygiene for vaults bootstrapped on an older version) —
+ * it is a no-op when the file is absent. The desktop git-submodule path
+ * (`GitSubmoduleOps`) keeps its committed `.gitmodules` (git vaults, out of
+ * scope — RFC 0005 Phase 2, N/A).
  *
  *   - **{@link FileSystemPort}** over `vault.adapter` — `materialize()` writes
  *     files **additively** (overwrite collisions, leave files absent from the
@@ -71,6 +82,8 @@ export interface RestAssetSpaceMountOptions {
 export type RestMountResult = MountResult;
 
 const GITMODULES = ".gitmodules";
+/** Vault-relative root all AssetSpaces mount under (`assetspaces/<owner>/<repo>`). */
+const ASSETSPACES_DIR = "assetspaces";
 
 export class RestAssetSpaceMount {
   private readonly app: App;
@@ -94,9 +107,14 @@ export class RestAssetSpaceMount {
   }
 
   /**
-   * Mount an AssetSpace: fetch its GitHub tarball, materialise the content
-   * directly into `<submodulePath>/...` inside the vault, and register the
-   * `.gitmodules` entry.
+   * Mount an AssetSpace: fetch its GitHub tarball and materialise the content
+   * directly into `<submodulePath>/...` inside the vault.
+   *
+   * RFC 0005 Phase 1 — writes **no** `.gitmodules`: a git-free vault carries no
+   * such sidecar. The folder presence at `assetspaces/<owner>/<repo>` IS the
+   * mount-state record, and {@link listMountedAssetSpaces} re-derives the URL
+   * from that path via {@link deriveUrl}; rediscovery no longer needs a stored
+   * URL registry.
    *
    * The mount is **additive** at the file level — colliding paths are
    * overwritten, but files present locally yet absent from the tarball are
@@ -151,22 +169,19 @@ export class RestAssetSpaceMount {
       }
     }
 
-    // Record the AssetSpace in `.gitmodules` (path + source URL). This is NOT a
-    // git submodule registration — a git-free REST mount creates no gitlink
-    // (`.git/config` / index stay untouched; mount-state visibility is
-    // folder-presence, see class doc). The stanza is an INTENTIONAL, load-bearing
-    // URL registry — NOT vestigial (D6 triage, node 794a95ae) — consumed by the
-    // git-free rediscovery flows that have no other source for the remote URLs:
-    //   - Bootstrap «clone-needs-fetch» — after a vault is cloned/synced without
-    //     `--recurse-submodules` the `assetspaces/*` folders are empty but the
-    //     URLs survive here, so {@link BootstrapAssetSpaceCommands}'s
-    //     `fetchTrackedAssetSpaces()` re-materialises each AssetSpace from its
-    //     recorded URL.
-    //   - «Unmount assetspace» — {@link readGitmodulesEntries} is the canonical
-    //     "what's mounted" registry the command lists.
-    // The live apply path keys mount-state on folder presence, but neither it nor
-    // ExoSync (descriptor-sourced URLs) read this — so do not "clean up" the write.
-    await this.appendGitmodulesEntry(safePath, gitUrl);
+    // RFC 0005 Phase 1 — NO `.gitmodules` write. The git-free rediscovery flows
+    // that used to read the recorded URL now reconstruct it from the folder path
+    // via {@link deriveUrl} (the github-https invariant holds across the whole
+    // ecosystem — RFC 0005 §3.2):
+    //   - Bootstrap «clone-needs-fetch» — a present-but-empty
+    //     `assetspaces/<owner>/<repo>` folder is filesystem-detectable, and its
+    //     URL is `deriveUrl(folderPath)`; fully-absent AssetSpaces are
+    //     re-materialised by apply-profile (descriptor-driven).
+    //   - «Unmount assetspace» — {@link listMountedAssetSpaces} enumerates the
+    //     mounted folders (+ derived URL) — the "what's mounted" registry.
+    //   - apply-profile already keys mount-state on folder presence and sources
+    //     URLs from the AssetSpace descriptors, never from `.gitmodules`.
+    // ExoSync is descriptor-sourced and ignores `.gitmodules` entirely.
     return result;
   }
 
@@ -190,21 +205,48 @@ export class RestAssetSpaceMount {
   }
 
   /**
-   * Read the current `.gitmodules` (path, url) entries via `vault.adapter` —
-   * the mobile-capable counterpart of
-   * {@link GitSubmoduleOps.readGitmodulesEntries} (#3535). Reuses the shared
-   * pure-text {@link parseGitmodulesEntries} parser (no Node `fs`). A missing
-   * `.gitmodules` yields `[]`.
+   * List the currently-mounted AssetSpaces by enumerating the canonical
+   * `assetspaces/<owner>/<repo>` folders on disk and reconstructing each URL
+   * with {@link deriveUrl} (RFC 0005 Phase 1 — replaces reading the
+   * `.gitmodules` URL-registry, which a git-free vault no longer writes). A
+   * folder that is present on disk IS a mounted (or clone-needs-fetch, present-
+   * but-empty) AssetSpace; its URL is `https://github.com/<owner>/<repo>`.
    *
-   * Used by the mobile Bootstrap / Add-AssetSpace flow
+   * Only canonical two-level Maven paths are returned: a non-conforming folder
+   * (one level, or an out-of-charset / traversal segment) yields
+   * `deriveUrl → null` and is **skipped** (it cannot be a github AssetSpace —
+   * RFC 0005 §10.1; legacy flat mounts are deprecated, #3538). A missing
+   * `assetspaces/` dir yields `[]`.
+   *
+   * Used by the cross-platform Bootstrap / Add-AssetSpace flow
    * ({@link BootstrapAssetSpaceCommands}) to classify the vault state (empty vs
-   * clone-needs-fetch vs bootstrapped) without the desktop-only
-   * `GitSubmoduleOps`.
+   * clone-needs-fetch vs bootstrapped) and by «Unmount assetspace» to list what
+   * is mounted — all without the desktop-only `GitSubmoduleOps` and without any
+   * `.gitmodules` sidecar.
    */
-  public async readGitmodulesEntries(): Promise<GitmodulesEntry[]> {
-    if (!(await this.adapter.exists(GITMODULES))) return [];
-    const raw = await this.adapter.read(GITMODULES);
-    return parseGitmodulesEntries(raw);
+  public async listMountedAssetSpaces(): Promise<GitmodulesEntry[]> {
+    const out: GitmodulesEntry[] = [];
+    if (!(await this.adapter.exists(ASSETSPACES_DIR))) return out;
+    let owners: { files: string[]; folders: string[] };
+    try {
+      owners = await this.adapter.list(ASSETSPACES_DIR);
+    } catch {
+      return out;
+    }
+    for (const ownerDir of owners.folders) {
+      let repos: { files: string[]; folders: string[] };
+      try {
+        repos = await this.adapter.list(ownerDir);
+      } catch {
+        continue; // unreadable owner dir — skip, keep enumerating
+      }
+      for (const repoDir of repos.folders) {
+        const url = deriveUrl(repoDir);
+        if (url === null) continue; // non-conforming → not a github AssetSpace
+        out.push({ submodulePath: repoDir, url });
+      }
+    }
+    return out;
   }
 
   // ───────────────────────────── ports ─────────────────────────────
@@ -282,28 +324,14 @@ export class RestAssetSpaceMount {
     };
   }
 
-  // ───────────────────────────── .gitmodules I/O ─────────────────────────────
-
-  /**
-   * Idempotent `.gitmodules` stanza insertion over `vault.adapter` using the
-   * shared {@link appendGitmodulesEntry} text transform.
-   */
-  private async appendGitmodulesEntry(
-    submodulePath: string,
-    url: string,
-  ): Promise<void> {
-    let existing = "";
-    if (await this.adapter.exists(GITMODULES)) {
-      existing = await this.adapter.read(GITMODULES);
-    }
-    const { content, added } = appendGitmodulesEntry(existing, submodulePath, url);
-    if (added) await this.adapter.write(GITMODULES, content);
-  }
+  // ───────────────────────────── .gitmodules cleanup (legacy) ─────────────────
 
   /**
    * Strip a `.gitmodules` stanza over `vault.adapter`, reusing the shared
    * {@link stripGitmodulesEntry} text transform. No-op when `.gitmodules` is
-   * absent or has no matching stanza.
+   * absent or has no matching stanza. RFC 0005 Phase 1 stops *writing*
+   * `.gitmodules`, but {@link unmount} still strips a *pre-existing* legacy
+   * stanza (vaults bootstrapped on an older plugin version) — pure hygiene.
    */
   private async removeGitmodulesEntry(submodulePath: string): Promise<void> {
     if (!(await this.adapter.exists(GITMODULES))) return;

--- a/packages/obsidian-plugin/tests/unit/infrastructure/adapters/BootstrapAssetSpaceCommands.test.ts
+++ b/packages/obsidian-plugin/tests/unit/infrastructure/adapters/BootstrapAssetSpaceCommands.test.ts
@@ -749,25 +749,27 @@ interface MobileHarness {
 }
 
 function makeMobileHarness(opts: {
-  gitmodulesEntries?: Array<{ submodulePath: string; url: string }>;
+  mountedEntries?: Array<{ submodulePath: string; url: string }>;
   materializedFolders?: Record<string, string[]>;
   bootstrapUrls?: { exoUrl: string } | null;
   addUrl?: { url: string } | null;
   confirm?: boolean;
 } = {}): MobileHarness {
   const notices: string[] = [];
-  const gitmodulesEntries = opts.gitmodulesEntries ?? [];
+  const mountedEntries = opts.mountedEntries ?? [];
   const materialized = opts.materializedFolders ?? {};
 
-  // Mobile materialise strategy — one combined op returning the sha (mirrors
-  // RestAssetSpaceMount.mount), plus the vault.adapter-backed .gitmodules read.
+  // Cross-platform materialise strategy — one combined op returning the sha
+  // (mirrors RestAssetSpaceMount.mount), plus the RFC 0005 Phase 1 filesystem-
+  // derived mounted-set read (no .gitmodules). The fake returns canned entries
+  // to drive the consumer's state machine.
   const restMount = {
     mount: jest.fn(
       async (_gitUrl: string, _submodulePath: string, _ref: string) => ({
         sha: "deadbee",
       }),
     ),
-    readGitmodulesEntries: jest.fn(async () => [...gitmodulesEntries]),
+    listMountedAssetSpaces: jest.fn(async () => [...mountedEntries]),
   } as jest.Mocked<IRestBootstrapMount>;
 
   const folderHasContent = Object.keys(materialized).length > 0;
@@ -823,12 +825,13 @@ function makeMobileHarness(opts: {
 }
 
 describe("BootstrapAssetSpaceCommands — mobile restMount strategy (#3535)", () => {
-  it("empty vault → bootstrap materialises exo only via restMount.mount (Maven path), writes .gitmodules, no Node-fs deps", async () => {
+  it("empty vault → bootstrap materialises exo only via restMount.mount (Maven path), no .gitmodules, no Node-fs deps", async () => {
     const h = makeMobileHarness();
     await h.cmds.invokeBootstrap();
 
-    // detectVaultState read .gitmodules via the mobile vault.adapter path.
-    expect(h.restMount.readGitmodulesEntries).toHaveBeenCalled();
+    // detectVaultState classified via the filesystem-derived mounted set
+    // (RFC 0005 Phase 1 — no .gitmodules).
+    expect(h.restMount.listMountedAssetSpaces).toHaveBeenCalled();
     // Exo-only clean bootstrap (2026-06-20): a single combined cross-platform op
     // for exo, at the Maven path. exocmd is added later (Add AssetSpace / profile).
     expect(h.restMount.mount).toHaveBeenCalledTimes(1);
@@ -844,8 +847,9 @@ describe("BootstrapAssetSpaceCommands — mobile restMount strategy (#3535)", ()
       "main",
     );
     expect(h.notices.some((n) => /Bootstrap complete/.test(n))).toBe(true);
-    // The misleading desktop "file-only mode" notice MUST NOT fire on mobile,
-    // even though there is no `.git` — restMount writes .gitmodules regardless.
+    // The misleading desktop "file-only mode" notice MUST NOT fire on the REST
+    // path, even though there is no `.git` — the REST mount is the unified
+    // cross-platform path (mount-state = folder presence, no .gitmodules).
     expect(h.notices.some((n) => /file-only mode/.test(n))).toBe(false);
   });
 
@@ -890,9 +894,9 @@ describe("BootstrapAssetSpaceCommands — mobile restMount strategy (#3535)", ()
     expect(h.notices.some((n) => /already has AssetSpaces/.test(n))).toBe(true);
   });
 
-  it("EC2 clone-needs-fetch → re-materialises each tracked entry via restMount.mount", async () => {
+  it("EC2 clone-needs-fetch → re-materialises each tracked (filesystem-derived) entry via restMount.mount", async () => {
     const h = makeMobileHarness({
-      gitmodulesEntries: [
+      mountedEntries: [
         { submodulePath: "assetspaces/kitelev/exoas-exo", url: EXO_URL },
         { submodulePath: "assetspaces/kitelev/exoas-exocmd", url: EXOCMD_URL },
       ],
@@ -919,7 +923,7 @@ describe("BootstrapAssetSpaceCommands — mobile restMount strategy (#3535)", ()
     // Mobile parity with the desktop EC2 resilience: a single failing mount must
     // not abort the rest of the clone-needs-fetch recovery (per-entry try/catch).
     const h = makeMobileHarness({
-      gitmodulesEntries: [
+      mountedEntries: [
         { submodulePath: "assetspaces/kitelev/exoas-exo", url: EXO_URL },
         { submodulePath: "assetspaces/kitelev/exoas-exocmd", url: EXOCMD_URL },
       ],
@@ -947,16 +951,16 @@ describe("BootstrapAssetSpaceCommands — mobile restMount strategy (#3535)", ()
     expect(h.notices.some((n) => /Fetched 1\/2/.test(n))).toBe(true);
   });
 
-  it("detectVaultState classifies via restMount.readGitmodulesEntries (no gitOps)", async () => {
+  it("detectVaultState classifies via restMount.listMountedAssetSpaces (filesystem, no gitOps)", async () => {
     const h = makeMobileHarness({
-      gitmodulesEntries: [
+      mountedEntries: [
         { submodulePath: "assetspaces/kitelev/exoas-exo", url: EXO_URL },
       ],
       materializedFolders: { "kitelev/exoas-exo": ["a.md"] },
     });
     const state = await h.cmds.detectVaultState();
     expect(state).toBe("bootstrapped");
-    expect(h.restMount.readGitmodulesEntries).toHaveBeenCalled();
+    expect(h.restMount.listMountedAssetSpaces).toHaveBeenCalled();
   });
 });
 

--- a/packages/obsidian-plugin/tests/unit/infrastructure/adapters/RestAssetSpaceMount.test.ts
+++ b/packages/obsidian-plugin/tests/unit/infrastructure/adapters/RestAssetSpaceMount.test.ts
@@ -13,18 +13,21 @@
  * NON-recursive, `rmdir(path, true)` removes the subtree, `read` throws on a
  * missing file, `writeBinary` does NOT auto-create parents.
  *
- * Coverage:
+ * Coverage (RFC 0005 Phase 1 — git-free vault carries no `.gitmodules`):
  *   1. Happy path — files materialise under mount folder, content round-trips,
- *      nested dirs created, `.gitmodules` entry appended, sha returned.
- *   2. Idempotent `.gitmodules` — re-mount of same path does not duplicate.
- *   3. `.gitmodules` append preserves existing stanzas + separators.
- *   4. unmount — removes folder subtree AND strips `.gitmodules` stanza.
+ *      nested dirs created, NO `.gitmodules` written, sha returned.
+ *   2. Re-mount writes no `.gitmodules` on either pass.
+ *   3. Mount does not touch a pre-existing legacy `.gitmodules`.
+ *   4. unmount — removes folder subtree AND strips a pre-existing legacy
+ *      `.gitmodules` stanza (hygiene).
  *   5. unmount idempotent — missing folder / absent stanza = no-op.
  *   6. Empty tarball → throws.
  *   7. Zip-slip (absolute path) → throws, no escape write.
  *   8. Rate-limit gate fires before any fetch.
  *   9. Invalid repo URL → throws before any REST call.
  *  10. Invalid submodule path (traversal) → throws.
+ *  11. listMountedAssetSpaces — enumerates `assetspaces/<owner>/<repo>` folders +
+ *      `deriveUrl`, ignoring any `.gitmodules`.
  */
 
 import type { App } from "obsidian";
@@ -68,7 +71,17 @@ class InMemoryAdapter {
   readonly orphanWrites: string[] = [];
 
   async exists(p: string): Promise<boolean> {
-    return this.files.has(p) || this.textFiles.has(p) || this.dirs.has(p);
+    if (this.files.has(p) || this.textFiles.has(p) || this.dirs.has(p)) {
+      return true;
+    }
+    // A directory exists if any known path is under it (real-FS / Obsidian
+    // DataAdapter semantics) — mount() only mkdir's the leaf path, so an
+    // ancestor like `assetspaces` must still report existing.
+    const prefix = p.replace(/\/+$/, "") + "/";
+    for (const k of this.files.keys()) if (k.startsWith(prefix)) return true;
+    for (const k of this.textFiles.keys()) if (k.startsWith(prefix)) return true;
+    for (const d of this.dirs) if (d.startsWith(prefix)) return true;
+    return false;
   }
 
   async read(p: string): Promise<string> {
@@ -110,6 +123,28 @@ class InMemoryAdapter {
     for (const k of [...this.dirs]) {
       if (k.startsWith(prefix)) this.dirs.delete(k);
     }
+  }
+
+  /** Obsidian DataAdapter.list — immediate children as full vault paths. */
+  async list(dir: string): Promise<{ files: string[]; folders: string[] }> {
+    const prefix = dir === "" ? "" : dir.replace(/\/+$/, "") + "/";
+    const files = new Set<string>();
+    const folders = new Set<string>();
+    const consider = (full: string, isDir: boolean): void => {
+      if (!full.startsWith(prefix)) return;
+      const rest = full.slice(prefix.length);
+      if (rest.length === 0) return;
+      const slash = rest.indexOf("/");
+      if (slash === -1) {
+        (isDir ? folders : files).add(prefix + rest);
+      } else {
+        folders.add(prefix + rest.slice(0, slash));
+      }
+    };
+    for (const k of this.files.keys()) consider(k, false);
+    for (const k of this.textFiles.keys()) consider(k, false);
+    for (const d of this.dirs) consider(d, true);
+    return { files: [...files], folders: [...folders] };
   }
 }
 
@@ -158,7 +193,7 @@ function makeMount(
 // ─── Tests ──────────────────────────────────────────────────────────────────
 
 describe("RestAssetSpaceMount.mount", () => {
-  it("materialises tarball files under the mount folder + appends .gitmodules", async () => {
+  it("materialises tarball files under the mount folder and writes NO .gitmodules (RFC 0005 Phase 1)", async () => {
     const adapter = new InMemoryAdapter();
     const tarball = await makeTarball("kitelev-exoas-ems-abc1234", [
       { name: "README.md", data: new TextEncoder().encode("# EMS\n") },
@@ -183,11 +218,9 @@ describe("RestAssetSpaceMount.mount", () => {
     expect(adapter.dirs.has(`${PATH_OK}/ontology`)).toBe(true);
     expect(adapter.orphanWrites).toEqual([]);
 
-    // .gitmodules entry registered as plain text.
-    const gm = adapter.textFiles.get(".gitmodules") ?? "";
-    expect(gm).toContain(`[submodule "${PATH_OK}"]`);
-    expect(gm).toContain(`url = ${URL_OK}`);
-    expect(gm).toContain(`path = ${PATH_OK}`);
+    // RFC 0005 Phase 1 — NO .gitmodules sidecar on a git-free vault. (Re-instating
+    // the appendGitmodulesEntry write in mount() makes this RED — revert-verified.)
+    expect(adapter.textFiles.has(".gitmodules")).toBe(false);
 
     // Rate-limit gate consulted before fetch.
     expect(client.ensureRateLimit).toHaveBeenCalledWith(1);
@@ -259,7 +292,7 @@ describe("RestAssetSpaceMount.mount", () => {
     expect(adapter.textFiles.has(".gitmodules")).toBe(false);
   });
 
-  it("is idempotent on .gitmodules — re-mount does not duplicate the stanza", async () => {
+  it("re-mount does not write a .gitmodules sidecar on either pass (RFC 0005 Phase 1)", async () => {
     const adapter = new InMemoryAdapter();
     const tarball = await makeTarball("kitelev-exoas-ems-abc1234", [
       { name: "README.md", data: new TextEncoder().encode("x") },
@@ -269,17 +302,14 @@ describe("RestAssetSpaceMount.mount", () => {
     await mount.mount(URL_OK, PATH_OK);
     await mount.mount(URL_OK, PATH_OK);
 
-    const gm = adapter.textFiles.get(".gitmodules") ?? "";
-    const occurrences = gm.split(`[submodule "${PATH_OK}"]`).length - 1;
-    expect(occurrences).toBe(1);
+    expect(adapter.textFiles.has(".gitmodules")).toBe(false);
   });
 
-  it("preserves an existing .gitmodules stanza when appending a new one", async () => {
+  it("does NOT touch a pre-existing legacy .gitmodules on mount (writer fully removed)", async () => {
     const adapter = new InMemoryAdapter();
-    await adapter.write(
-      ".gitmodules",
-      '[submodule "assetspaces/other/repo"]\n\tpath = assetspaces/other/repo\n\turl = https://github.com/o/repo\n',
-    );
+    const legacy =
+      '[submodule "assetspaces/other/repo"]\n\tpath = assetspaces/other/repo\n\turl = https://github.com/o/repo\n';
+    await adapter.write(".gitmodules", legacy);
     const tarball = await makeTarball("kitelev-exoas-ems-abc1234", [
       { name: "README.md", data: new TextEncoder().encode("x") },
     ]);
@@ -287,9 +317,9 @@ describe("RestAssetSpaceMount.mount", () => {
 
     await mount.mount(URL_OK, PATH_OK);
 
-    const gm = adapter.textFiles.get(".gitmodules") ?? "";
-    expect(gm).toContain('[submodule "assetspaces/other/repo"]');
-    expect(gm).toContain(`[submodule "${PATH_OK}"]`);
+    // The mount neither adds its own stanza nor rewrites the legacy file — it
+    // simply does not write .gitmodules at all.
+    expect(adapter.textFiles.get(".gitmodules")).toBe(legacy);
   });
 
   it("rejects an empty tarball", async () => {
@@ -355,7 +385,7 @@ describe("RestAssetSpaceMount.mount", () => {
 });
 
 describe("RestAssetSpaceMount.unmount", () => {
-  it("removes the mount folder subtree AND strips the .gitmodules stanza", async () => {
+  it("removes the mount folder subtree AND strips a pre-existing legacy .gitmodules stanza (hygiene)", async () => {
     const adapter = new InMemoryAdapter();
     const tarball = await makeTarball("kitelev-exoas-ems-abc1234", [
       { name: "README.md", data: new TextEncoder().encode("x") },
@@ -363,6 +393,13 @@ describe("RestAssetSpaceMount.unmount", () => {
     ]);
     const mount = makeMount(adapter, makeFakeClient(tarball));
     await mount.mount(URL_OK, PATH_OK);
+    // RFC 0005 Phase 1 — mount no longer writes .gitmodules; seed a LEGACY one
+    // (as a vault bootstrapped on an older plugin would have) to prove unmount
+    // still strips it for hygiene.
+    await adapter.write(
+      ".gitmodules",
+      `[submodule "${PATH_OK}"]\n\tpath = ${PATH_OK}\n\turl = ${URL_OK}\n`,
+    );
 
     await mount.unmount(PATH_OK);
 
@@ -373,7 +410,7 @@ describe("RestAssetSpaceMount.unmount", () => {
     expect(adapter.dirs.has(PATH_OK)).toBe(false);
     expect(adapter.dirs.has(`${PATH_OK}/ontology`)).toBe(false);
 
-    // .gitmodules stanza stripped.
+    // Legacy .gitmodules stanza stripped.
     const gm = adapter.textFiles.get(".gitmodules") ?? "";
     expect(gm).not.toContain(`[submodule "${PATH_OK}"]`);
   });
@@ -393,26 +430,24 @@ describe("RestAssetSpaceMount.unmount", () => {
   });
 });
 
-describe("RestAssetSpaceMount.readGitmodulesEntries (#3535 — mobile vault state)", () => {
-  it("returns [] when .gitmodules is absent", async () => {
+describe("RestAssetSpaceMount.listMountedAssetSpaces (RFC 0005 Phase 1 — filesystem-derived, no .gitmodules)", () => {
+  it("returns [] when the assetspaces/ dir is absent", async () => {
     const adapter = new InMemoryAdapter();
     const mount = makeMount(adapter, makeFakeClient(new ArrayBuffer(0)));
-    await expect(mount.readGitmodulesEntries()).resolves.toEqual([]);
+    await expect(mount.listMountedAssetSpaces()).resolves.toEqual([]);
   });
 
-  it("parses (path, url) entries from a vault.adapter .gitmodules", async () => {
+  it("enumerates assetspaces/<owner>/<repo> folders + deriveUrl, ignoring any .gitmodules", async () => {
     const adapter = new InMemoryAdapter();
-    await adapter.write(
-      ".gitmodules",
-      `[submodule "assetspaces/kitelev/exoas-exo"]\n` +
-        `\tpath = assetspaces/kitelev/exoas-exo\n` +
-        `\turl = https://github.com/kitelev/exoas-exo\n` +
-        `[submodule "assetspaces/kitelev/exoas-exocmd"]\n` +
-        `\tpath = assetspaces/kitelev/exoas-exocmd\n` +
-        `\turl = https://github.com/kitelev/exoas-exocmd\n`,
-    );
+    // A stale .gitmodules must NOT be the source — the folders are.
+    await adapter.write(".gitmodules", "[submodule \"stale/x\"]\n\tpath = stale/x\n\turl = https://github.com/stale/x\n");
+    await adapter.mkdir("assetspaces");
+    await adapter.mkdir("assetspaces/kitelev");
+    await adapter.mkdir("assetspaces/kitelev/exoas-exo");
+    await adapter.mkdir("assetspaces/kitelev/exoas-exocmd");
     const mount = makeMount(adapter, makeFakeClient(new ArrayBuffer(0)));
-    await expect(mount.readGitmodulesEntries()).resolves.toEqual([
+    const entries = await mount.listMountedAssetSpaces();
+    expect(entries.sort((a, b) => a.submodulePath.localeCompare(b.submodulePath))).toEqual([
       {
         submodulePath: "assetspaces/kitelev/exoas-exo",
         url: "https://github.com/kitelev/exoas-exo",
@@ -424,7 +459,7 @@ describe("RestAssetSpaceMount.readGitmodulesEntries (#3535 — mobile vault stat
     ]);
   });
 
-  it("round-trips an entry written by mount() (mount → read)", async () => {
+  it("lists the folder a mount() materialised (mount → list), with no .gitmodules involved", async () => {
     const adapter = new InMemoryAdapter();
     const tarball = await makeTarball("kitelev-exoas-ems-abc1234", [
       { name: "README.md", data: new TextEncoder().encode("# EMS\n") },
@@ -432,7 +467,8 @@ describe("RestAssetSpaceMount.readGitmodulesEntries (#3535 — mobile vault stat
     const mount = makeMount(adapter, makeFakeClient(tarball));
     await mount.mount(URL_OK, PATH_OK, "main");
 
-    await expect(mount.readGitmodulesEntries()).resolves.toEqual([
+    expect(adapter.textFiles.has(".gitmodules")).toBe(false);
+    await expect(mount.listMountedAssetSpaces()).resolves.toEqual([
       { submodulePath: PATH_OK, url: URL_OK },
     ]);
   });

--- a/packages/obsidian-plugin/tests/unit/integration/BootstrapAssetSpaceMobile.integration.test.ts
+++ b/packages/obsidian-plugin/tests/unit/integration/BootstrapAssetSpaceMobile.integration.test.ts
@@ -364,4 +364,33 @@ describe("Mobile bootstrap integration — real RestAssetSpaceMount + vault.adap
       { submodulePath: "assetspaces/kitelev/exoas-exo", url: EXO_URL },
     ]);
   });
+
+  it("KNOWN LIMITATION (deprecated #3538 flat layout) — a flat mount whose content sits in a namespace subdir is mis-enumerated as owner/repo", async () => {
+    const adapter = new InMemoryAdapter();
+    const notices: string[] = [];
+    const { restMount } = makeCmds(adapter, notices, {});
+
+    // A pre-#3538 FLAT mount: the repo is one level under assetspaces/ and its
+    // content lives in a namespace subdir → assetspaces/<repo>/<ns>/file.md.
+    await adapter.writeBinary(
+      "assetspaces/ems/ems/Task.md",
+      new TextEncoder().encode("x").buffer,
+    );
+    await adapter.mkdir("assetspaces/ems/ems");
+    await adapter.mkdir("assetspaces/ems");
+    await adapter.mkdir("assetspaces");
+
+    // Documented limitation (RFC 0005 §10.1 / listMountedAssetSpaces docstring):
+    // the enum cannot tell a flat repo from an owner, so it reads
+    // assetspaces/ems/ems as a fake owner=ems/repo=ems pair. This is harmless on
+    // canonical (EKA) vaults — every AssetSpace is two-level — and the only
+    // consumer affected is the «Unmount» picker (apply-profile + ExoSync are
+    // descriptor/presence-sourced; clone-needs-fetch never re-fetches a
+    // flat-with-content mount). Pinned here so the behavior is explicit, not
+    // silently truncated; migrate any flat mount per #3538.
+    const entries = await restMount.listMountedAssetSpaces();
+    expect(entries).toEqual([
+      { submodulePath: "assetspaces/ems/ems", url: "https://github.com/ems/ems" },
+    ]);
+  });
 });

--- a/packages/obsidian-plugin/tests/unit/integration/BootstrapAssetSpaceMobile.integration.test.ts
+++ b/packages/obsidian-plugin/tests/unit/integration/BootstrapAssetSpaceMobile.integration.test.ts
@@ -17,9 +17,12 @@
  *
  * Proves the end-to-end mobile contract a fresh iPhone vault relies on:
  *   empty vault → bootstrap → exo materialised via vault.adapter (exo-only clean
- *   bootstrap, 2026-06-20) + `.gitmodules` written; then add-assetspace → a
- *   second entry — all readable back via `RestAssetSpaceMount.readGitmodulesEntries`,
- *   which is exactly what apply-profile (`listAllAssetSpaceInfos`) consumes next.
+ *   bootstrap, 2026-06-20) and — RFC 0005 Phase 1 — NO `.gitmodules` written;
+ *   then add-assetspace → a second folder. The mounted set is read back by
+ *   enumerating the materialised `assetspaces/<owner>/<repo>` folders +
+ *   re-deriving each URL via `RestAssetSpaceMount.listMountedAssetSpaces`, which
+ *   is exactly what apply-profile (`listAllAssetSpaceInfos`, already filesystem-
+ *   based) consumes next.
  *
  * Revert-verify (mobile): remove the `restMount` branch from
  * `BootstrapAssetSpaceCommands.materialize` / `listTrackedEntries` and these
@@ -219,7 +222,7 @@ function makeCmds(
 // ─── Tests ──────────────────────────────────────────────────────────────────
 
 describe("Mobile bootstrap integration — real RestAssetSpaceMount + vault.adapter (#3535)", () => {
-  it("empty vault → bootstrap materialises exo only via vault.adapter + writes .gitmodules", async () => {
+  it("empty vault → bootstrap materialises exo only via vault.adapter; the mounted set is read back from the filesystem (RFC 0005 Phase 1, no .gitmodules) @req:b02a3994-91a2-4b87-8872-fbac860e5630", async () => {
     const adapter = new InMemoryAdapter();
     const notices: string[] = [];
     const { cmds, restMount } = makeCmds(adapter, notices, {});
@@ -237,9 +240,17 @@ describe("Mobile bootstrap integration — real RestAssetSpaceMount + vault.adap
     ).toBe(false);
     expect(adapter.orphanWrites).toEqual([]);
 
-    // .gitmodules written via vault.adapter (text file), readable back — just the
-    // single exo entry.
-    const entries = await restMount.readGitmodulesEntries();
+    // RFC 0005 Phase 1 — WRITER STOPPED: a git-free vault carries NO .gitmodules
+    // sidecar. (Re-instating the appendGitmodulesEntry write in
+    // RestAssetSpaceMount.mount makes this RED — revert-verified.)
+    expect(adapter.textFiles.has(".gitmodules")).toBe(false);
+    expect(await adapter.exists(".gitmodules")).toBe(false);
+
+    // READER from the FILESYSTEM: the mounted set + URLs are reconstructed by
+    // enumerating assetspaces/<owner>/<repo> and deriveUrl(path) — NOT from a
+    // .gitmodules registry (which does not exist). (Reverting
+    // listMountedAssetSpaces to read .gitmodules returns [] here — revert-verified.)
+    const entries = await restMount.listMountedAssetSpaces();
     expect(entries).toEqual([
       { submodulePath: "assetspaces/kitelev/exoas-exo", url: EXO_URL },
     ]);
@@ -248,7 +259,7 @@ describe("Mobile bootstrap integration — real RestAssetSpaceMount + vault.adap
     expect(notices.some((n) => /file-only mode/.test(n))).toBe(false);
   });
 
-  it("after exo-only bootstrap, add-assetspace appends a second .gitmodules entry at the canonical Maven path + materialises it (#3538) @req:59afd046-eb41-4fd5-a03a-062a53d0acc5", async () => {
+  it("after exo-only bootstrap, add-assetspace materialises a second AssetSpace at the canonical Maven path; both appear in the filesystem-derived mounted set (#3538) @req:59afd046-eb41-4fd5-a03a-062a53d0acc5", async () => {
     const adapter = new InMemoryAdapter();
     const notices: string[] = [];
     const { cmds, restMount } = makeCmds(adapter, notices, {});
@@ -265,9 +276,11 @@ describe("Mobile bootstrap integration — real RestAssetSpaceMount + vault.adap
       ),
     ).toBe(true);
 
-    // Bootstrap wrote exo only; add-assetspace appends pmbok as the 2nd entry.
-    const entries = await restMount.readGitmodulesEntries();
-    expect(entries.map((e) => e.submodulePath)).toEqual([
+    // RFC 0005 Phase 1 — still no .gitmodules; the mounted set is enumerated
+    // from the two materialised folders (exo from bootstrap + pmbok from add).
+    expect(adapter.textFiles.has(".gitmodules")).toBe(false);
+    const entries = await restMount.listMountedAssetSpaces();
+    expect(entries.map((e) => e.submodulePath).sort()).toEqual([
       "assetspaces/kitelev/exoas-exo",
       "assetspaces/kitelev/exoas-pmbok-ontology",
     ]);
@@ -280,13 +293,75 @@ describe("Mobile bootstrap integration — real RestAssetSpaceMount + vault.adap
     const { cmds, restMount } = makeCmds(adapter, notices, {});
 
     await cmds.invokeBootstrap();
-    const before = await restMount.readGitmodulesEntries();
+    const before = await restMount.listMountedAssetSpaces();
     notices.length = 0;
 
     await cmds.invokeBootstrap();
-    const after = await restMount.readGitmodulesEntries();
+    const after = await restMount.listMountedAssetSpaces();
 
     expect(after).toEqual(before);
     expect(notices.some((n) => /already has AssetSpaces/.test(n))).toBe(true);
+  });
+
+  it("clone-needs-fetch — present-but-empty assetspaces/<owner>/<repo> folder (no .gitmodules) is detected + re-fetched from the filesystem-derived URL @req:b02a3994-91a2-4b87-8872-fbac860e5630", async () => {
+    const adapter = new InMemoryAdapter();
+    const notices: string[] = [];
+    const { cmds, restMount } = makeCmds(adapter, notices, {});
+
+    // Simulate a vault synced WITHOUT content: the canonical Maven folder exists
+    // but is empty, and there is NO .gitmodules registry (git-free, RFC 0005
+    // Phase 1). The state must be derived from the filesystem alone.
+    await adapter.mkdir("assetspaces");
+    await adapter.mkdir("assetspaces/kitelev");
+    await adapter.mkdir("assetspaces/kitelev/exoas-exo");
+    expect(adapter.textFiles.has(".gitmodules")).toBe(false);
+
+    // Detection: the empty folder is enumerated (tracked) but has no .md content
+    // → clone-needs-fetch (NOT "empty", NOT "bootstrapped"). Reverting
+    // listTrackedEntries to read .gitmodules would yield [] → "empty" here.
+    expect(await cmds.detectVaultState()).toBe("clone-needs-fetch");
+
+    // Bootstrap on this state re-materialises each tracked folder from its
+    // deriveUrl(folderPath) URL (confirm=true wired in makeCmds), filling the
+    // empty folder with content — without any stored .gitmodules URL.
+    await cmds.invokeBootstrap();
+
+    expect(adapter.files.has("assetspaces/kitelev/exoas-exo/exoas-exo.md")).toBe(
+      true,
+    );
+    expect(adapter.textFiles.has(".gitmodules")).toBe(false);
+    const entries = await restMount.listMountedAssetSpaces();
+    expect(entries).toEqual([
+      { submodulePath: "assetspaces/kitelev/exoas-exo", url: EXO_URL },
+    ]);
+    expect(notices.some((n) => /Fetched 1\/1/.test(n))).toBe(true);
+  });
+
+  it("enumerates exactly the canonical 2-level owner/repo — does not descend into a repo's namespace subdirs, and skips a stray one-level folder @req:b02a3994-91a2-4b87-8872-fbac860e5630", async () => {
+    const adapter = new InMemoryAdapter();
+    const notices: string[] = [];
+    const { restMount } = makeCmds(adapter, notices, {});
+
+    // A canonical mount whose content sits a level deeper (owner/repo/<ns>/file)
+    // — the real EKA layout — plus a stray one-level folder directly under
+    // assetspaces/ (a legacy flat remnant).
+    await adapter.writeBinary(
+      "assetspaces/kitelev/exoas-exo/exo/Class.md",
+      new TextEncoder().encode("x").buffer,
+    );
+    await adapter.mkdir("assetspaces/kitelev/exoas-exo/exo");
+    await adapter.mkdir("assetspaces/kitelev/exoas-exo");
+    await adapter.mkdir("assetspaces/kitelev");
+    await adapter.mkdir("assetspaces");
+    await adapter.mkdir("assetspaces/legacyflat"); // one level → no owner/repo pair
+
+    const entries = await restMount.listMountedAssetSpaces();
+    // Exactly the canonical assetspaces/<owner>/<repo>: the enum stops at two
+    // levels (it does NOT surface the inner `exo/` namespace as a fake
+    // owner/repo), and the one-level `legacyflat` (no second-level child)
+    // contributes nothing.
+    expect(entries).toEqual([
+      { submodulePath: "assetspaces/kitelev/exoas-exo", url: EXO_URL },
+    ]);
   });
 });


### PR DESCRIPTION
## RFC 0005 Phase 1 — a git-free vault carries no `.gitmodules`

Implements **RFC 0005 Phase 1** (`docs/rfc/0005-eliminate-gitmodules-url-registry.md`, §6). Andrey approved **Option A — full removal** (`@req:b02a3994-91a2-4b87-8872-fbac860e5630`, Active in `kitelev/exoas-exo-reqs`).

A git-free vault (iPhone + post-#3567 every canonical desktop vault) no longer carries a `.gitmodules` sidecar at all. The device-side readers reconstruct each AssetSpace's GitHub URL from its folder path via `deriveUrl(path)` (the Phase 0 primitive, `@req:1e56367b`, already on main).

### Changes
- **Writer removed:** `RestAssetSpaceMount.mount` stops calling `appendGitmodulesEntry` — the single REST-mount writer (covers bootstrap, add-assetspace, apply-profile materialise). The private method + its core import are gone.
- **Readers re-derive from the filesystem:** `RestAssetSpaceMount.readGitmodulesEntries` → **`listMountedAssetSpaces`** — enumerates `assetspaces/<owner>/<repo>` (two-level Maven) folders via `vault.adapter.list` and reconstructs each URL with `deriveUrl(path)`, skipping non-conforming folders (`deriveUrl → null`). Consumed by «Unmount assetspace» listing (`ExocortexPlugin`) and Bootstrap clone-needs-fetch detect/re-fetch (`BootstrapAssetSpaceCommands.listTrackedEntries`, REST branch). Interface `IRestBootstrapMount` renamed accordingly.
- **No change to apply-profile switch-back:** `ProfileApplyManager.applyProfileViaRest` already computes mount-state from filesystem presence (`derivePhysicallyMaterializedAsUids`) and sources URLs from AssetSpace descriptors (`info.git`) — never `.gitmodules`.
- **Untouched:** the desktop git-submodule path (`GitSubmoduleOps`) keeps its committed `.gitmodules` (git vaults — RFC 0005 Phase 2 N/A). `unmount` still strips a *pre-existing* legacy `.gitmodules` (hygiene).

### Verification
- **Revert-verified** (`@req:b02a3994`): re-instating the `.gitmodules` write → "no .gitmodules" tests RED (7); neutralising `listMountedAssetSpaces` → filesystem-derive + clone-needs-fetch tests RED (6); both restored → GREEN.
- typecheck 0 errors; changed suites 78/78; regression suites (BootstrapAssetSpace desktop, BootstrapPatRefresh, ProfileApplyManager restApply/restAtomicity/apply, core AssetSpaceMount, deriveUrl) all green; eslint `--max-warnings=0` clean.
- **code-reviewer agent: APPROVE** (0 CRITICAL/HIGH). 1 MEDIUM (legacy flat-mount-with-content mis-enumeration — bounded to the Unmount picker on a deprecated layout) documented in the `listMountedAssetSpaces` docstring + pinned by an explicit test; 3 LOW (stale comments / source-agnostic error string / branch-sync) addressed.

### RFC §10.3 (path-list source) — resolved
Filesystem enum (present folders, incl. present-but-empty) + apply-profile (already filesystem+descriptor) fully replace the `.gitmodules` path-list. The "`.gitmodules` entries arrive without folders" state is a git-clone artifact that does not arise on a git-free vault (ExoSync ignores `.gitmodules`).

Req: b02a3994-91a2-4b87-8872-fbac860e5630
