### PR TITLE
feat(settings-m2.2): distribution-ontology meta-setting reader (RFC f402002b)

### DIFF
--- a/packages/core/src/services/settings/distributionOntology.ts
+++ b/packages/core/src/services/settings/distributionOntology.ts
@@ -1,0 +1,58 @@
+/**
+ * Distribution-ontology meta-setting reader (RFC f402002b, M2.2 — §5).
+ *
+ * WHERE a domain distributes its settings (the target AssetSpace) is itself
+ * user-configurable semantics → per the Homoiconicity Invariant it lives in the
+ * graph as a `setting__Setting` meta-instance on the floor-anchored `$setting`
+ * ontology, NOT as a TS-hardcoded ontology UID. This module is the **code half**
+ * (Q3 exc.1): a pure reader over warm floor setting-assets.
+ *
+ * It is DISTINCT from the non-homoiconic master switch
+ * `settingsHomoiconizationEnabled` (which is on/off): this records a *target*.
+ *
+ * No I/O, no platform deps (Desktop↔Mobile parity) — the caller supplies the
+ * warm setting-assets it read from `metadataCache` / fs.
+ */
+import { coerceSettingValue, extractKeyRef, readSettingValueRaw } from "./settingAsset";
+import type { ImportableSettingAsset } from "./types";
+
+/**
+ * UID of the `setting__SettingKeyExocortexDistributionOntology` floor meta key
+ * (datatype `string`, on the `$setting` floor `34872f64-…`). The
+ * `setting__Setting` meta-instance carrying this key holds the opaque AssetSpace
+ * UID the Exocortex domain distributes into.
+ */
+export const EXOCORTEX_DISTRIBUTION_ONTOLOGY_KEY_UID =
+  "ea44f996-64e5-46ce-8953-b13d21ee750d";
+
+/**
+ * Resolve the recorded distribution-ontology target (an opaque AssetSpace UID)
+ * from the floor `setting__Setting` meta-instance whose `setting__Setting_key`
+ * matches `keyUid` (by UID).
+ *
+ * Returns the recorded UID (trimmed), or `null` when no meta-setting is present
+ * or its value is blank — default-on-absence is the **location-convention**
+ * (the caller picks the target), NEVER a code-hardcoded ontology UID.
+ *
+ * Dual-read: canonical `setting__Setting_key` / `setting__Setting_value` first,
+ * then the legacy `exo__Setting_*` fallback (so a legacy-authored meta-setting
+ * still resolves). The value is coerced as a `string` (the meta key's declared
+ * datatype). The first non-blank match (in `assets` order) wins.
+ */
+export function resolveDistributionOntology(
+  assets: readonly ImportableSettingAsset[],
+  keyUid: string,
+): string | null {
+  for (const asset of assets) {
+    if (extractKeyRef(asset.frontmatter) !== keyUid) continue;
+    const value = coerceSettingValue(
+      "string",
+      readSettingValueRaw(asset.frontmatter),
+    );
+    if (typeof value === "string") {
+      const trimmed = value.trim();
+      if (trimmed.length > 0) return trimmed;
+    }
+  }
+  return null;
+}

--- a/packages/core/src/services/settings/index.ts
+++ b/packages/core/src/services/settings/index.ts
@@ -18,3 +18,7 @@ export {
   renderSettingAssetMarkdown,
 } from "./settingAsset";
 export { exportSettings, importSettings } from "./SettingsDistributionEngine";
+export {
+  EXOCORTEX_DISTRIBUTION_ONTOLOGY_KEY_UID,
+  resolveDistributionOntology,
+} from "./distributionOntology";

--- a/packages/core/tests/unit/services/settings/resolveDistributionOntology.test.ts
+++ b/packages/core/tests/unit/services/settings/resolveDistributionOntology.test.ts
@@ -1,0 +1,85 @@
+/**
+ * @req:de812abe-4982-4813-abf4-c8c26d341de0
+ *
+ * Distribution-ontology meta-setting reader (RFC f402002b, M2.2 — §5):
+ * resolve the recorded AssetSpace UID from a floor `setting__Setting`
+ * meta-instance, null on absence / blank / key-mismatch, dual-read of the
+ * canonical and legacy setting predicates. Fixtures are warm-metadataCache-shape
+ * frontmatter objects (the same shape the plugin / CLI readers surface).
+ */
+import {
+  EXOCORTEX_DISTRIBUTION_ONTOLOGY_KEY_UID,
+  resolveDistributionOntology,
+  type ImportableSettingAsset,
+} from "../../../../src/services/settings";
+
+const KEY_UID = EXOCORTEX_DISTRIBUTION_ONTOLOGY_KEY_UID;
+const TARGET_AS_UID = "8dca2799-3c3c-4ea0-aa0a-c039c779417c";
+
+/** A floor meta-setting asset (canonical predicates), value = target AssetSpace UID. */
+function metaAsset(value: unknown, path = "exoas-exo/setting/meta.md"): ImportableSettingAsset {
+  return {
+    path,
+    frontmatter: {
+      "exo__Instance_class": "[[88b938af-... ]]",
+      "setting__Setting_key": `[[${KEY_UID}]]`,
+      "setting__Setting_value": value,
+    },
+  };
+}
+
+/** An unrelated setting asset (a different key). */
+function otherAsset(): ImportableSettingAsset {
+  return {
+    path: "exoas-exo/setting/other.md",
+    frontmatter: {
+      "setting__Setting_key": "[[cccccccc-0000-0000-0000-000000000099]]",
+      "setting__Setting_value": "not-the-target",
+    },
+  };
+}
+
+describe("resolveDistributionOntology", () => {
+  it("returns the recorded AssetSpace UID from the matching floor meta-setting", () => {
+    const assets = [otherAsset(), metaAsset(TARGET_AS_UID)];
+    expect(resolveDistributionOntology(assets, KEY_UID)).toBe(TARGET_AS_UID);
+  });
+
+  it("returns null when no meta-setting for the key is present (caller picks)", () => {
+    const assets = [otherAsset()];
+    expect(resolveDistributionOntology(assets, KEY_UID)).toBeNull();
+    expect(resolveDistributionOntology([], KEY_UID)).toBeNull();
+  });
+
+  it("returns null when the meta-setting's value is blank / whitespace-only", () => {
+    expect(resolveDistributionOntology([metaAsset("")], KEY_UID)).toBeNull();
+    expect(resolveDistributionOntology([metaAsset("   ")], KEY_UID)).toBeNull();
+  });
+
+  it("does not match an asset carrying a different setting key", () => {
+    // otherAsset has a different key — must NOT be returned even though it has a value.
+    expect(resolveDistributionOntology([otherAsset()], KEY_UID)).toBeNull();
+  });
+
+  it("trims surrounding whitespace from the recorded UID", () => {
+    expect(resolveDistributionOntology([metaAsset(`  ${TARGET_AS_UID}  `)], KEY_UID)).toBe(
+      TARGET_AS_UID,
+    );
+  });
+
+  it("dual-reads a legacy-authored meta-setting (exo__Setting_key / exo__Setting_value)", () => {
+    const legacy: ImportableSettingAsset = {
+      path: "exoas-exo/setting/legacy.md",
+      frontmatter: {
+        "exo__Setting_key": `[[${KEY_UID}]]`,
+        "exo__Setting_value": TARGET_AS_UID,
+      },
+    };
+    expect(resolveDistributionOntology([legacy], KEY_UID)).toBe(TARGET_AS_UID);
+  });
+
+  it("returns the first non-blank match in array order", () => {
+    const assets = [metaAsset("", "a.md"), metaAsset(TARGET_AS_UID, "b.md")];
+    expect(resolveDistributionOntology(assets, KEY_UID)).toBe(TARGET_AS_UID);
+  });
+});


### PR DESCRIPTION
## M2.2 — Meta-setting (floor-anchored individual + reader)

Project `c5d50dc3` Milestone M2 (`87d1b257`), node `f560df09`. RFC `f402002b` §5.

**WHERE a domain distributes its settings is user-configurable semantics → it lives in the graph, not as a TS-hardcoded ontology UID** (Homoiconicity Invariant, Q3 exc.1).

### What ships
- **TBox** (cross-repo, not in this PR's diff): `setting__SettingKeyExocortexDistributionOntology` (`ea44f996`, datatype `string`) on the `$setting` floor — pushed to `kitelev/exoas-exo` (`fb5a109`) + the 3 mounted vaults (vault-my/vault-tbank/vault-exodev). Value = opaque AssetSpace UID (not a raw repo-URL — floor public anchor is world-readable, RFC sec F8).
- **Core reader** (this PR): pure `resolveDistributionOntology(assets, keyUid)` (`packages/core/src/services/settings/distributionOntology.ts`) + `EXOCORTEX_DISTRIBUTION_ONTOLOGY_KEY_UID` constant, exported from the settings barrel. Returns the recorded AssetSpace UID, or `null` on absence/blank (default-on-absence = location-convention → caller picks; **never** a hardcoded UID). Dual-read canonical `setting__Setting_*` + legacy `exo__Setting_*`.
- Distinct from the non-homoiconic master switch `settingsHomoiconizationEnabled` (on/off, not a target).

### Scope note (god-file serialization)
The Export "remember chosen ontology" / Import "default target" **behavioral wiring** consumes this reader and lands in **M2.3** — it touches `ExocortexPlugin.ts` (the god-file), which M2.3 reworks anyway. M2.2 stays god-file-avoiding per the serialization discipline. The submodule pointer for `exoas-exo` is intentionally **not** bumped here — the reader test uses fixtures (not CI-blocking) and runtime reads the mounted vault.

### Tests
`resolveDistributionOntology.test.ts` (7 cases) — resolve / null-on-absence / null-on-blank / key-mismatch / trim / dual-read / first-non-blank.

**Revert-verified:** `@req:de812abe` — inverting the key-match guard → 6/7 RED; restored → 7/7 GREEN. Full settings suite 13/13 (no M2.1 regression).

Req: de812abe-4982-4813-abf4-c8c26d341de0 (Active on merge, `kitelev/exoas-exo-reqs`)