### PR TITLE
fix(cli): vault adapters never re-nest the vault root (#3761)

### DIFF
--- a/packages/cli/src/adapters/FileSystemVaultAdapter.ts
+++ b/packages/cli/src/adapters/FileSystemVaultAdapter.ts
@@ -313,6 +313,21 @@ export class FileSystemVaultAdapter implements IVaultAdapter {
     if (path.isAbsolute(filePath)) {
       return filePath;
     }
+    // #3761 — a co-location folder resolver that "relativized" an ABSOLUTE
+    // vault path by stripping its leading slash (`replace(/^\/+/, "")`) yields
+    // a fake-relative `<vault-root-without-leading-slash>/assetspaces/...`
+    // string. It is not `path.isAbsolute`, so the guard above misses it and
+    // `path.join(rootPath, …)` nests the entire vault-root path UNDER the vault
+    // root, `mkdir -p`-ing a phantom duplicate tree. Detect that the
+    // "relative" arg is the vault's own absolute path with a stripped leading
+    // slash and resolve it to the correct in-vault location instead.
+    const reAbsolute = path.sep + filePath;
+    if (
+      reAbsolute === this.rootPath ||
+      reAbsolute.startsWith(this.rootPath + path.sep)
+    ) {
+      return reAbsolute;
+    }
     return path.join(this.rootPath, filePath);
   }
 

--- a/packages/cli/src/adapters/FileSystemVaultAdapter.ts
+++ b/packages/cli/src/adapters/FileSystemVaultAdapter.ts
@@ -320,12 +320,12 @@ export class FileSystemVaultAdapter implements IVaultAdapter {
     // `path.join(rootPath, …)` nests the entire vault-root path UNDER the vault
     // root, `mkdir -p`-ing a phantom duplicate tree. Detect that the
     // "relative" arg is the vault's own absolute path with a stripped leading
-    // slash and resolve it to the correct in-vault location instead.
+    // slash and resolve it to the correct in-vault location instead. Normalize
+    // any trailing separator on the root so the guard holds regardless of how
+    // the caller constructed `rootPath`.
+    const root = this.rootPath.replace(/[/\\]+$/, "");
     const reAbsolute = path.sep + filePath;
-    if (
-      reAbsolute === this.rootPath ||
-      reAbsolute.startsWith(this.rootPath + path.sep)
-    ) {
+    if (reAbsolute === root || reAbsolute.startsWith(root + path.sep)) {
       return reAbsolute;
     }
     return path.join(this.rootPath, filePath);

--- a/packages/cli/src/adapters/NodeFsAdapter.ts
+++ b/packages/cli/src/adapters/NodeFsAdapter.ts
@@ -181,12 +181,12 @@ export class NodeFsAdapter implements IFileSystemAdapter {
     // `path.join(rootPath, …)` nests the entire vault-root path UNDER the vault
     // root, `mkdir -p`-ing a phantom duplicate tree. Detect that the
     // "relative" arg is the vault's own absolute path with a stripped leading
-    // slash and resolve it to the correct in-vault location instead.
+    // slash and resolve it to the correct in-vault location instead. Normalize
+    // any trailing separator on the root so the guard holds regardless of how
+    // the caller constructed `rootPath`.
+    const root = this.rootPath.replace(/[/\\]+$/, "");
     const reAbsolute = path.sep + filePath;
-    if (
-      reAbsolute === this.rootPath ||
-      reAbsolute.startsWith(this.rootPath + path.sep)
-    ) {
+    if (reAbsolute === root || reAbsolute.startsWith(root + path.sep)) {
       return reAbsolute;
     }
     return path.join(this.rootPath, filePath);

--- a/packages/cli/src/adapters/NodeFsAdapter.ts
+++ b/packages/cli/src/adapters/NodeFsAdapter.ts
@@ -174,6 +174,21 @@ export class NodeFsAdapter implements IFileSystemAdapter {
     if (path.isAbsolute(filePath)) {
       return filePath;
     }
+    // #3761 — a co-location folder resolver that "relativized" an ABSOLUTE
+    // vault path by stripping its leading slash (`replace(/^\/+/, "")`) yields
+    // a fake-relative `<vault-root-without-leading-slash>/assetspaces/...`
+    // string. It is not `path.isAbsolute`, so the guard above misses it and
+    // `path.join(rootPath, …)` nests the entire vault-root path UNDER the vault
+    // root, `mkdir -p`-ing a phantom duplicate tree. Detect that the
+    // "relative" arg is the vault's own absolute path with a stripped leading
+    // slash and resolve it to the correct in-vault location instead.
+    const reAbsolute = path.sep + filePath;
+    if (
+      reAbsolute === this.rootPath ||
+      reAbsolute.startsWith(this.rootPath + path.sep)
+    ) {
+      return reAbsolute;
+    }
     return path.join(this.rootPath, filePath);
   }
 

--- a/packages/cli/tests/integration/colocate-renest-3761.integration.test.ts
+++ b/packages/cli/tests/integration/colocate-renest-3761.integration.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, beforeEach, afterEach } from "@jest/globals";
+import fs from "fs-extra";
+import os from "os";
+import path from "path";
+import { NodeFsAdapter } from "../../src/adapters/NodeFsAdapter.js";
+import { FileSystemVaultAdapter } from "../../src/adapters/FileSystemVaultAdapter.js";
+
+/**
+ * Issue #3761 — co-located create path-doubling.
+ *
+ * A co-location folder resolver (`GroundingExecutor.parentFolderOf` /
+ * `VaultFrontmatterRefToFolderResolver.parentFolderOf`) "relativizes" an
+ * ABSOLUTE folder path by stripping its leading slash, yielding a fake-relative
+ * `<vault-root-without-leading-slash>/assetspaces/...` string. That string is
+ * NOT `path.isAbsolute`, so a vault adapter's `isAbsolute` early-return guard
+ * misses it and `path.join(rootPath, fakeRelative)` nests the whole vault-root
+ * path UNDER the vault root, `mkdir -p`-ing a phantom duplicate directory tree.
+ *
+ * Production-shape: drives the REAL adapters against a REAL temp filesystem
+ * (no mocks) so the assertions observe the actual on-disk tree — the doubled
+ * directory is a filesystem phenomenon, not a string-arg detail.
+ *
+ * Revert-verify (integration-test-revert-verify): with the re-nest guard
+ * removed from `resolvePath`, the "leading-slash-stripped absolute" scenarios
+ * recreate the phantom `<root>/<root-1st-segment>/...` tree (RED). With the
+ * guard, the write lands in the correct co-located folder and no phantom tree
+ * exists (GREEN). The relative / true-absolute regression scenarios pass both
+ * ways.
+ */
+describe("#3761 — co-located create must not re-nest the vault root", () => {
+  let root: string;
+  const REL_FOLDER = "assetspaces/kitelev/exoas-tbank/tbank-efforts";
+  const UID = "aaaa1111-2222-4333-8444-555566667777";
+
+  beforeEach(async () => {
+    root = await fs.mkdtemp(path.join(os.tmpdir(), "exo-3761-"));
+    await fs.ensureDir(path.join(root, REL_FOLDER));
+  });
+
+  afterEach(async () => {
+    await fs.remove(root);
+  });
+
+  /** The directory the bug `mkdir -p`'d under the vault root, if it exists. */
+  const phantomRootSegment = (): string => {
+    // root e.g. "/var/folders/xx/exo-3761-yyy"; stripped → "var/..." → the
+    // phantom tree begins at "<root>/var".
+    const firstSegment = root.replace(/^\/+/, "").split("/")[0];
+    return path.join(root, firstSegment);
+  };
+
+  const content = "---\nexo__Asset_uid: " + UID + "\n---\n";
+  const correctTarget = (): string =>
+    path.join(root, REL_FOLDER, `${UID}.md`);
+
+  describe("NodeFsAdapter.createFile (the `apply create-instance` fileWriter)", () => {
+    it("leading-slash-stripped absolute folder → writes to correct co-located folder, no phantom tree", async () => {
+      const adapter = new NodeFsAdapter(root);
+      // exactly what parentFolderOf produces from an absolute ontology folder
+      const fakeRelative =
+        root.replace(/^\/+/, "") + `/${REL_FOLDER}/${UID}.md`;
+
+      await adapter.createFile(fakeRelative, content);
+
+      expect(await fs.pathExists(correctTarget())).toBe(true);
+      expect(await fs.pathExists(phantomRootSegment())).toBe(false);
+    });
+
+    it("ordinary vault-relative folder still works (regression guard)", async () => {
+      const adapter = new NodeFsAdapter(root);
+      await adapter.createFile(`${REL_FOLDER}/${UID}.md`, content);
+      expect(await fs.pathExists(correctTarget())).toBe(true);
+      expect(await fs.pathExists(phantomRootSegment())).toBe(false);
+    });
+
+    it("true-absolute folder inside the vault still works (regression guard)", async () => {
+      const adapter = new NodeFsAdapter(root);
+      await adapter.createFile(
+        path.join(root, REL_FOLDER, `${UID}.md`),
+        content,
+      );
+      expect(await fs.pathExists(correctTarget())).toBe(true);
+      expect(await fs.pathExists(phantomRootSegment())).toBe(false);
+    });
+  });
+
+  describe("FileSystemVaultAdapter (the `cli create` write path)", () => {
+    it("leading-slash-stripped absolute folder → createFolder + create land correctly, no phantom tree", async () => {
+      const adapter = new FileSystemVaultAdapter(root);
+      const fakeFolder = root.replace(/^\/+/, "") + `/${REL_FOLDER}`;
+
+      // mirrors GenericAssetCreationService.createAsset: createFolder then create
+      await adapter.createFolder(fakeFolder);
+      await adapter.create(`${fakeFolder}/${UID}.md`, content);
+
+      expect(await fs.pathExists(correctTarget())).toBe(true);
+      expect(await fs.pathExists(phantomRootSegment())).toBe(false);
+    });
+
+    it("ordinary vault-relative folder still works (regression guard)", async () => {
+      const adapter = new FileSystemVaultAdapter(root);
+      await adapter.createFolder(REL_FOLDER);
+      await adapter.create(`${REL_FOLDER}/${UID}.md`, content);
+      expect(await fs.pathExists(correctTarget())).toBe(true);
+      expect(await fs.pathExists(phantomRootSegment())).toBe(false);
+    });
+  });
+});

--- a/packages/cli/tests/integration/colocate-renest-3761.integration.test.ts
+++ b/packages/cli/tests/integration/colocate-renest-3761.integration.test.ts
@@ -82,6 +82,15 @@ describe("#3761 — co-located create must not re-nest the vault root", () => {
       expect(await fs.pathExists(correctTarget())).toBe(true);
       expect(await fs.pathExists(phantomRootSegment())).toBe(false);
     });
+
+    it("guard holds when the adapter root has a trailing separator (robustness)", async () => {
+      const adapter = new NodeFsAdapter(root + path.sep);
+      const fakeRelative =
+        root.replace(/^\/+/, "") + `/${REL_FOLDER}/${UID}.md`;
+      await adapter.createFile(fakeRelative, content);
+      expect(await fs.pathExists(correctTarget())).toBe(true);
+      expect(await fs.pathExists(phantomRootSegment())).toBe(false);
+    });
   });
 
   describe("FileSystemVaultAdapter (the `cli create` write path)", () => {


### PR DESCRIPTION
## Summary

Fixes #3761 — a co-located create could `mkdir -p` an empty **phantom duplicate directory tree** under the vault root (e.g. `<vault>/Users/kitelev/vaults/<vault>/assetspaces/...`).

## Root cause (confirmed empirically, verify-before-assert)

A co-location folder resolver (`GroundingExecutor.parentFolderOf` / `VaultFrontmatterRefToFolderResolver.parentFolderOf`, core) "relativizes" an **absolute** folder path by stripping its leading slash (`replace(/^\/+/, "")`). That yields a fake-relative `<vault-root-without-leading-slash>/assetspaces/...` string. It is **not** `path.isAbsolute`, so the CLI write adapters' `isAbsolute` early-return guard in `resolvePath` misses it, and `path.join(rootPath, fakeRelative)` nests the entire vault-root path **under** the vault root → the empty doubled tree. (The doubled-tree shape observed in the issue — `path.join(root, "Users/<root>/...")` — is exactly this signature.)

Reproduced the RED on a real temp filesystem: feeding `NodeFsAdapter.createFile` the production-shape `<root-without-slash>/...` path produced `/<root>/<root>/...`.

## Fix

Harden the single write chokepoint `resolvePath` in **both** CLI adapters:
- `NodeFsAdapter` — the `apply create-instance` fileWriter
- `FileSystemVaultAdapter` — the `cli create` write path

If a "relative" arg is actually the vault's own absolute path with a stripped leading slash, resolve it to the correct in-vault location instead of `path.join`-nesting it under the root. This implements #3761's optional acceptance criterion ("a guard that detects and refuses to mkdir a target folder that re-nests the vault root path") at the point all co-located CLI writes pass through, and is robust to any upstream that produces such a path. The shared-core `parentFolderOf` slash-strip is the upstream contributor; the plugin (Obsidian) provider surface is a separate follow-up (out of this CLI-scoped fix; plugin god-file untouched).

## Tests (production-shape, real-fs, revert-verified)

`packages/cli/tests/integration/colocate-renest-3761.integration.test.ts` drives the **real** adapters against a **real** temp vault (no fs mocks — the doubled tree is a filesystem phenomenon):

- **Revert-verify** (`@req:9994c7d7-39dc-4e0e-ab4f-972da9ef49ad`): with the guard removed → the two leading-slash-stripped scenarios fail (phantom tree recreated, **RED 2/5**); with the guard → **GREEN 5/5**, asset lands in the correct co-located folder and no phantom tree exists.
- Regression guards (ordinary vault-relative folder, true-absolute folder inside the vault) pass **both** ways.

140/140 affected CLI suites pass (adapters, create, apply, co-location); `check:types` clean.

## Requirement

Req `9994c7d7-39dc-4e0e-ab4f-972da9ef49ad` (`exoas-exo-reqs`, P1, BindingClass=Integration): https://github.com/kitelev/exoas-exo-reqs/blob/main/exo-reqs/9994c7d7-39dc-4e0e-ab4f-972da9ef49ad.md

Req: 9994c7d7-39dc-4e0e-ab4f-972da9ef49ad

Closes #3761