### PR TITLE
feat(settings-m2.3): live-mirror read-only transitional deprecation (RFC f402002b §6 R2)

### DIFF
--- a/packages/obsidian-plugin/src/ExocortexPlugin.ts
+++ b/packages/obsidian-plugin/src/ExocortexPlugin.ts
@@ -2047,13 +2047,14 @@ export default class ExocortexPlugin extends Plugin {
 
   async saveSettings(): Promise<void> {
     await this.saveData(this.settings);
-    // onto-RFC 981b6070 (D2) — write-through to vault assets for
-    // homoiconizable fields. Every UI surface funnels through this
-    // method (SettingTab × 32 controls, palette commands,
-    // DailyTasksRenderer), so intercepting here covers them all without
-    // touching call sites. Diff-based + debounced inside the store;
-    // remote applies go through `saveData` directly, so this cannot
-    // loop.
+    // RFC f402002b M2.3 — the live-mirror UI→asset auto-write is DEPRECATED in
+    // favour of the explicit «Exocortex: Export settings» command. The store is
+    // constructed read-only (outboundWriteEnabled defaults false), so this call
+    // is now a no-op that logs a one-time deprecation notice (the asset→UI
+    // watcher stays read-only; the RDF asset is canonical, data.json a derived
+    // cache). The call is kept here (rather than removed) so the deprecation
+    // notice fires from the single saveSettings() funnel; the whole store is
+    // scheduled for removal ≥1 release after the deprecation window.
     this.vaultSettingsStore?.pushChangedFields();
   }
 
@@ -2087,6 +2088,15 @@ export default class ExocortexPlugin extends Plugin {
       return;
     }
 
+    // RFC f402002b M2.3 — read-only transitional: the store keeps the asset→UI
+    // inbound watcher + load-overlay + one-shot migrate, but the continuous
+    // UI→asset auto-write is deprecated (outboundWriteEnabled defaults false).
+    // Canonical authority = the RDF asset; data.json = derived cache. Persist UI
+    // changes to assets via «Exocortex: Export settings».
+    this.logger.info(
+      "[D2] vault-settings live-mirror is read-only (RFC f402002b M2.3 deprecation) — " +
+        "asset→UI inbound only; use «Export settings» to persist UI changes to assets",
+    );
     const store = new VaultSettingsStore({
       app: this.app,
       logger: this.logger,

--- a/packages/obsidian-plugin/src/infrastructure/adapters/VaultSettingsStore.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/VaultSettingsStore.ts
@@ -28,6 +28,13 @@ import {
  * only via «Exocortex: Export settings». The whole store is scheduled for removal
  * ≥1 release after this deprecation window (RFC §6 R2).
  *
+ * Read-only consequence (accepted, §6 R2 — un-Exported UI changes are not
+ * durable): a UI toggle not persisted via «Export settings» reverts to the
+ * canonical asset value whenever the asset is re-read — via a
+ * `metadataCache.changed` re-fire, a profile-switch unmount→remount, OR a plugin
+ * reload (the `applyScan` load-overlay). The `deferredPushFields` resurface
+ * protection is inert here (reachable only from the now-disabled outbound path).
+ *
  * Architecture: data.json stays a write-through mirror (instant boot
  * baseline + fallback for non-homoiconized keys); the vault asset is the
  * source of truth once it exists. Discovery is class-based and
@@ -260,11 +267,13 @@ export class VaultSettingsStore {
           }
         } else {
           // Read-only transitional (M2.3): no outbound write. The user's
-          // pre-scan UI value is kept (not overlaid), but the canonical asset
-          // value is what the inbound watcher dedups against — so lastApplied
-          // tracks the ASSET, not the un-persisted UI value (a later real
-          // asset change still applies; an un-Exported UI change is not durable
-          // — RFC §6 R2, canonical = RDF).
+          // pre-scan UI value is kept (not overlaid). lastApplied has no live
+          // reader in read-only mode (pushChangedFields, its only consumer,
+          // no-ops) — set to the canonical asset value purely for consistency
+          // if outbound is ever re-enabled. The inbound watcher
+          // (onMetadataChanged) dedups against the LIVE settings value, not
+          // lastApplied, so a later real asset change still applies
+          // (canonical = RDF); an un-Exported UI change is not durable (§6 R2).
           this.lastApplied.set(field, effectiveCanonical);
         }
         continue;
@@ -368,8 +377,9 @@ export class VaultSettingsStore {
   pushChangedFields(): void {
     if (!this.outboundWriteEnabled) {
       // Read-only transitional (M2.3): never write assets from UI changes.
-      // lastApplied is left untouched (it tracks the canonical asset value via
-      // applyScan / the inbound watcher) so inbound dedup stays consistent.
+      // lastApplied is left untouched. It has no live reader in read-only mode
+      // (this method, its only consumer, returns here); the inbound watcher
+      // (onMetadataChanged) dedups against live settings, not lastApplied.
       if (!this.outboundDeprecationWarned) {
         this.outboundDeprecationWarned = true;
         this.logger.warn(

--- a/packages/obsidian-plugin/src/infrastructure/adapters/VaultSettingsStore.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/VaultSettingsStore.ts
@@ -17,6 +17,17 @@ import {
  * VaultSettingsStore — reads/writes `exo__Setting` vault assets
  * (onto-RFC 981b6070 Phase 5 / ExoSync Phase D, task D2).
  *
+ * DEPRECATED — RFC f402002b M2.3 — the bidirectional **live-mirror** is being
+ * replaced by the explicit Settings-Distribution Export/Import engine (M2.1).
+ * As of M2.3 the store is a **READ-ONLY transitional watcher**: the continuous
+ * UI→asset auto-write ({@link pushChangedFields}, gated by
+ * {@link VaultSettingsStoreOptions.outboundWriteEnabled}, default false) is
+ * disabled and logs a one-time deprecation notice; the asset→UI inbound watcher
+ * + load-overlay + one-shot migrate remain. **Canonical authority = the RDF
+ * asset; data.json = derived runtime cache.** UI changes are persisted to assets
+ * only via «Exocortex: Export settings». The whole store is scheduled for removal
+ * ≥1 release after this deprecation window (RFC §6 R2).
+ *
  * Architecture: data.json stays a write-through mirror (instant boot
  * baseline + fallback for non-homoiconized keys); the vault asset is the
  * source of truth once it exists. Discovery is class-based and
@@ -77,6 +88,18 @@ export interface VaultSettingsStoreOptions {
   writeDebounceMs?: number;
   /** Folder where migrateMissing materialises assets. */
   settingsFolder?: string;
+  /**
+   * Continuous UI→asset auto-write (the "live-mirror" outbound half).
+   * DEPRECATED — RFC f402002b M2.3 — the live-mirror is being replaced by the
+   * explicit Export/Import engine. Default **false**: the store is a
+   * READ-ONLY transitional watcher (asset→UI inbound + load-overlay +
+   * one-shot migrate still work; UI changes are persisted to assets only via
+   * «Exocortex: Export settings»). Canonical authority = the RDF asset;
+   * data.json = derived runtime cache. The whole store is scheduled for
+   * removal ≥1 release after this deprecation window. Pass `true` only to
+   * exercise the legacy outbound path (tests / the deprecation window).
+   */
+  outboundWriteEnabled?: boolean;
 }
 
 interface ScanEntry {
@@ -110,6 +133,10 @@ export class VaultSettingsStore {
   ) => Promise<void>;
   private readonly writeDebounceMs: number;
   private readonly settingsFolder: string;
+  /** DEPRECATED — RFC f402002b M2.3 — see {@link VaultSettingsStoreOptions.outboundWriteEnabled}. */
+  private readonly outboundWriteEnabled: boolean;
+  /** One-shot guard so the deprecation notice is logged at most once. */
+  private outboundDeprecationWarned = false;
 
   /** field → vault path of the winning asset. */
   private readonly knownFiles = new Map<string, string>();
@@ -146,6 +173,8 @@ export class VaultSettingsStore {
     this.applyRemote = options.applyRemote;
     this.writeDebounceMs = options.writeDebounceMs ?? 1000;
     this.settingsFolder = options.settingsFolder ?? DEFAULT_SETTINGS_FOLDER;
+    // RFC f402002b M2.3 — default read-only (no continuous UI→asset auto-write).
+    this.outboundWriteEnabled = options.outboundWriteEnabled ?? false;
   }
 
   // ────────────────────────────────────────────────────────────────
@@ -223,10 +252,20 @@ export class VaultSettingsStore {
       const isDirty = currentCanonical !== baselineCanonical;
 
       if (isDirty) {
-        // User acted before the scan landed — their change wins; push it.
-        this.lastApplied.set(field, currentCanonical);
-        if (effectiveCanonical !== currentCanonical) {
-          this.queueWrite(field, settings[field]);
+        if (this.outboundWriteEnabled) {
+          // User acted before the scan landed — their change wins; push it.
+          this.lastApplied.set(field, currentCanonical);
+          if (effectiveCanonical !== currentCanonical) {
+            this.queueWrite(field, settings[field]);
+          }
+        } else {
+          // Read-only transitional (M2.3): no outbound write. The user's
+          // pre-scan UI value is kept (not overlaid), but the canonical asset
+          // value is what the inbound watcher dedups against — so lastApplied
+          // tracks the ASSET, not the un-persisted UI value (a later real
+          // asset change still applies; an un-Exported UI change is not durable
+          // — RFC §6 R2, canonical = RDF).
+          this.lastApplied.set(field, effectiveCanonical);
         }
         continue;
       }
@@ -318,8 +357,31 @@ export class VaultSettingsStore {
    * Called from the `saveSettings()` funnel: diffs registry fields
    * against the last applied/pushed value and queues vault writes for
    * the changed ones. Cheap no-op when nothing relevant changed.
+   *
+   * DEPRECATED — RFC f402002b M2.3 — the continuous UI→asset auto-write (the
+   * "live-mirror" outbound half) is deprecated in favour of the explicit
+   * «Exocortex: Export settings» command. When {@link outboundWriteEnabled}
+   * is false (the default), this is a no-op that logs a one-time deprecation
+   * notice — the watcher stays READ-ONLY (asset→UI still works) and the RDF
+   * asset is the canonical authority. Scheduled for removal ≥1 release on.
    */
   pushChangedFields(): void {
+    if (!this.outboundWriteEnabled) {
+      // Read-only transitional (M2.3): never write assets from UI changes.
+      // lastApplied is left untouched (it tracks the canonical asset value via
+      // applyScan / the inbound watcher) so inbound dedup stays consistent.
+      if (!this.outboundDeprecationWarned) {
+        this.outboundDeprecationWarned = true;
+        this.logger.warn(
+          "[VaultSettingsStore] live-mirror UI→asset auto-write is deprecated " +
+            "(RFC f402002b M2.3, read-only transitional). Use «Exocortex: Export " +
+            "settings» to persist settings to assets; the asset→UI watcher remains " +
+            "read-only and the RDF asset is canonical. This store is scheduled for " +
+            "removal ≥1 release after the deprecation window.",
+        );
+      }
+      return;
+    }
     if (!this.scanned) return; // pre-scan changes handled as dirty fields
     const settings = this.getSettings();
     for (const d of VAULT_SETTINGS_REGISTRY) {

--- a/packages/obsidian-plugin/tests/unit/infrastructure/adapters/VaultSettingsStore.test.ts
+++ b/packages/obsidian-plugin/tests/unit/infrastructure/adapters/VaultSettingsStore.test.ts
@@ -160,6 +160,10 @@ function makeStore(
   overrides: {
     baseline?: Record<string, unknown>;
     applyRemote?: jest.Mock;
+    // RFC f402002b M2.3 — opt into the legacy/deprecated outbound UI→asset
+    // auto-write (default false = read-only transitional watcher).
+    outboundWriteEnabled?: boolean;
+    logger?: { warn: jest.Mock } & Record<string, jest.Mock>;
   } = {},
 ) {
   const applyRemote =
@@ -167,15 +171,17 @@ function makeStore(
     jest.fn(async (field: string, value: unknown) => {
       settings[field] = value;
     });
+  const logger = overrides.logger ?? noopLogger;
   const store = new VaultSettingsStore({
     app: fake.asApp(),
-    logger: noopLogger,
+    logger: logger as never,
     getSettings: () => settings,
     baseline: overrides.baseline ?? snapshot(settings),
     applyRemote,
     writeDebounceMs: 0,
+    outboundWriteEnabled: overrides.outboundWriteEnabled ?? false,
   });
-  return { store, applyRemote };
+  return { store, applyRemote, logger };
 }
 
 function snapshot(settings: Record<string, unknown>): Record<string, unknown> {
@@ -246,7 +252,10 @@ describe("VaultSettingsStore", () => {
       const settings = freshSettings();
       const baseline = snapshot(settings); // baseline: false
       settings.showArchivedAssets = true; // user toggled pre-scan
-      const { store, applyRemote } = makeStore(fake, settings, { baseline });
+      const { store, applyRemote } = makeStore(fake, settings, {
+        baseline,
+        outboundWriteEnabled: true, // M2.3: this test asserts the deprecated dirty-field push
+      });
 
       await store.applyScan(store.scanAll());
       await store.flushWrites();
@@ -484,7 +493,11 @@ describe("VaultSettingsStore", () => {
     async function setupMigrated() {
       const fake = new FakeApp();
       const settings = freshSettings();
-      const { store, applyRemote } = makeStore(fake, settings);
+      // M2.3: these blocks exercise the (now-deprecated) outbound UI→asset
+      // auto-write path → opt in explicitly.
+      const { store, applyRemote } = makeStore(fake, settings, {
+        outboundWriteEnabled: true,
+      });
       store.scanAll();
       await store.migrateMissing();
       return { fake, settings, store, applyRemote };
@@ -518,7 +531,9 @@ describe("VaultSettingsStore", () => {
     it("never creates a missing asset on push (F2 — no duplicate factory)", async () => {
       const fake = new FakeApp();
       const settings = freshSettings();
-      const { store } = makeStore(fake, settings);
+      const { store } = makeStore(fake, settings, {
+        outboundWriteEnabled: true, // M2.3: exercises the deprecated push path
+      });
       store.scanAll(); // no assets at all, no migration
 
       settings.showArchivedAssets = true;
@@ -543,11 +558,103 @@ describe("VaultSettingsStore", () => {
     });
   });
 
+  // @req:5c08b7ad-0e82-4dfa-b258-316a2d21c143
+  describe("read-only transitional deprecation (M2.3, RFC f402002b §6 R2)", () => {
+    async function setupReadOnly(logger?: { warn: jest.Mock } & Record<string, jest.Mock>) {
+      const fake = new FakeApp();
+      const settings = freshSettings();
+      // Default makeStore = read-only (outboundWriteEnabled defaults false).
+      const { store, applyRemote } = makeStore(fake, settings, { logger });
+      store.scanAll();
+      await store.migrateMissing();
+      return { fake, settings, store, applyRemote };
+    }
+
+    function tfileOf(path: string): TFile {
+      return { path } as unknown as TFile;
+    }
+
+    it("pushChangedFields is a no-op (no UI→asset write) when read-only", async () => {
+      const { fake, settings, store } = await setupReadOnly();
+      const d = descriptorByField("enableShaclValidation")!;
+      const path = `${DEFAULT_SETTINGS_FOLDER}/${d.settingUid}.md`;
+      const before = fake.files.get(path)!.frontmatter!.exo__Setting_value;
+      const processCallsBefore = fake.processCalls.length;
+
+      settings.enableShaclValidation = true; // user toggles in UI
+      store.pushChangedFields();
+      await store.flushWrites();
+
+      // The asset is NOT rewritten — the UI change is not auto-mirrored.
+      expect(fake.files.get(path)!.frontmatter!.exo__Setting_value).toBe(before);
+      expect(fake.processCalls.length).toBe(processCallsBefore);
+    });
+
+    it("logs the deprecation notice at most once across many UI saves", async () => {
+      const logger = {
+        debug: jest.fn(),
+        info: jest.fn(),
+        warn: jest.fn(),
+        error: jest.fn(),
+      };
+      const { settings, store } = await setupReadOnly(logger);
+      logger.warn.mockClear(); // ignore any scan/migrate warnings
+
+      settings.enableShaclValidation = true;
+      store.pushChangedFields();
+      settings.showArchivedAssets = true;
+      store.pushChangedFields();
+      store.pushChangedFields();
+
+      const deprecationWarns = logger.warn.mock.calls.filter((c) =>
+        String(c[0]).includes("deprecated"),
+      );
+      expect(deprecationWarns).toHaveLength(1);
+    });
+
+    it("KEEPS the asset→UI inbound watcher (read-only): a synced asset change still applies", async () => {
+      const { fake, settings, store, applyRemote } = await setupReadOnly();
+      const d = descriptorByField("showArchivedAssets")!;
+      const path = `${DEFAULT_SETTINGS_FOLDER}/${d.settingUid}.md`;
+      fake.files.get(path)!.frontmatter!.exo__Setting_value = true; // arrives via sync
+
+      await store.onMetadataChanged(tfileOf(path));
+
+      expect(applyRemote).toHaveBeenCalledWith("showArchivedAssets", true);
+      expect(settings.showArchivedAssets).toBe(true);
+    });
+
+    it("a pre-scan dirty field is NOT auto-pushed to the asset (read-only) — the user must Export", async () => {
+      const fake = new FakeApp();
+      const path = fake.seedSettingAsset("showArchivedAssets", false);
+      const settings = freshSettings();
+      const baseline = snapshot(settings); // baseline: false
+      settings.showArchivedAssets = true; // user toggled pre-scan
+      const { store, applyRemote } = makeStore(fake, settings, { baseline }); // read-only
+
+      await store.applyScan(store.scanAll());
+      await store.flushWrites();
+
+      // No overlay (UI keeps the user's value during the session) and — the
+      // M2.3 invariant — NO outbound write: the asset is untouched. (canonical
+      // = RDF: the un-Exported UI value is not durable; a later asset change
+      // applies via the inbound watcher, covered above.)
+      expect(applyRemote).not.toHaveBeenCalled();
+      expect(settings.showArchivedAssets).toBe(true);
+      expect(fake.files.get(path)!.frontmatter!.exo__Setting_value).toBe(false);
+      expect(fake.processCalls.filter((p) => p === path)).toHaveLength(0);
+    });
+  });
+
   describe("watcher (remote changes + echo suppression)", () => {
     async function setupMigrated() {
       const fake = new FakeApp();
       const settings = freshSettings();
-      const { store, applyRemote } = makeStore(fake, settings);
+      // M2.3: these blocks exercise the (now-deprecated) outbound UI→asset
+      // auto-write path → opt in explicitly.
+      const { store, applyRemote } = makeStore(fake, settings, {
+        outboundWriteEnabled: true,
+      });
       store.scanAll();
       await store.migrateMissing();
       return { fake, settings, store, applyRemote };


### PR DESCRIPTION
## M2.3 — Live-mirror replacement (dual-read/deprecation) [god-file, LAST]

Project `c5d50dc3` Milestone M2 (`87d1b257`), node `2291e3e7`. RFC `f402002b` §6 R2.

Replaces the bidirectional homoiconic-settings live-mirror with the explicit Export/Import engine (M2.1) — **transitional read-only watcher** this release, store removal ≥1 release on.

### What changes
- **`VaultSettingsStore` → READ-ONLY transitional watcher.** New `outboundWriteEnabled` option (default **false**): the continuous UI→asset auto-write (`pushChangedFields`, the live-mirror outbound half) no-ops + logs a **one-time deprecation notice** pointing to «Exocortex: Export settings». The `applyScan` dirty-field (F12) branch no longer auto-writes when read-only.
- **Kept (read-only):** the asset→UI inbound watcher (`onMetadataChanged`), the load-overlay (`applyScan`), the one-shot `migrateMissing` bootstrap. **Canonical authority = the RDF asset; data.json = derived runtime cache.**
- **god-file:** `ExocortexPlugin.ts` constructs the store read-only + logs the deprecation; `saveSettings` keeps the now-no-op `pushChangedFields` call as the single deprecation-notice funnel. **cascade-cap: 1 consumer, ~4 callsites** (well under ≤15).
- Feature is gated overall by `settingsHomoiconizationEnabled` (default OFF) — only opted-in users are affected.

### Accepted behavior (RFC §6 R2, gated OFF + Export escape hatch)
An un-Exported UI toggle reverts to the canonical asset value when the asset is re-read (changed-event re-fire / profile-switch / plugin reload). Documented in the class JSDoc.

### Tests
`VaultSettingsStore.test.ts` → new "read-only transitional deprecation (M2.3)" block (4 tests: no-op outbound + warn-once + inbound-still-applies + dirty-field-not-pushed). Existing 34 write-path tests opt into `outboundWriteEnabled: true` (legacy path preserved for the deprecation window). 38/38 green; typecheck + eslint clean.

**Revert-verified:** `@req:5c08b7ad` — inverting the `pushChangedFields` read-only guard → 2/4 read-only tests RED; forcing the `applyScan` branch outbound → test 4 RED; restored → 38/38 GREEN.

### Review (VaultSettings* elevated-risk — CLAUDE.md auto-merge discipline)
- **code-reviewer round-1:** APPROVE, 0 CRITICAL/HIGH (1 MEDIUM by-design canonical-wins, 2 LOW comment-accuracy → fixed).
- **advisor round-2:** APPROVE, 0 CRITICAL/HIGH — probed an ungated `deferredPushFields` outbound leak → **provably unreachable** (closed-loop, empty seed in read-only); `migrateMissing` is the only remaining (bounded one-shot) write; comment fixes confirmed accurate.

Req: 5c08b7ad-0e82-4dfa-b258-316a2d21c143 (Active on merge, `kitelev/exoas-exo-reqs`)