### PR TITLE
feat(cli): create --property accumulates repeated keys into YAML array (#3759)

### DIFF
--- a/packages/cli/src/commands/create.ts
+++ b/packages/cli/src/commands/create.ts
@@ -51,21 +51,28 @@ interface CreateCommandOptions {
 /**
  * Parse --property flags into a key-value map.
  *
- * Each --property flag has the format "key=value".
- * Multiple values for the same key are concatenated with commas.
+ * Each --property flag has the format "key=value". A key supplied ONCE maps to
+ * a scalar string (back-compat). The SAME key supplied more than once
+ * accumulates its values into an array (issue #3759) — the standard multi-value
+ * CLI pattern — which the downstream serializer emits as a YAML array. A single
+ * `--property 'key=["a","b"]'` flow-array is NOT parsed as an array; it stays a
+ * literal value (use the repeatable flag for multi-value).
  *
  * @example
  * parseProperties(["ztlk__Note_developedFrom=[[uuid|Label]]", "custom_prop=value"])
  * // => { "ztlk__Note_developedFrom": "[[uuid|Label]]", "custom_prop": "value" }
+ * @example
+ * parseProperties(["exo__Asset_relates=[[A]]", "exo__Asset_relates=[[B]]"])
+ * // => { "exo__Asset_relates": ["[[A]]", "[[B]]"] }
  */
 function parseProperties(
   propertyArgs: string[] | undefined,
-): Record<string, string> {
+): Record<string, string | string[]> {
   if (!propertyArgs || propertyArgs.length === 0) {
     return {};
   }
 
-  const properties: Record<string, string> = {};
+  const properties: Record<string, string | string[]> = {};
 
   for (const prop of propertyArgs) {
     const eqIndex = prop.indexOf("=");
@@ -84,7 +91,17 @@ function parseProperties(
       );
     }
 
-    properties[key] = value;
+    const existing = properties[key];
+    if (existing === undefined) {
+      // First occurrence → scalar (back-compat with every single-value create).
+      properties[key] = value;
+    } else if (Array.isArray(existing)) {
+      // Third+ occurrence → append to the accumulating array.
+      existing.push(value);
+    } else {
+      // Second occurrence → promote the scalar to a two-element array.
+      properties[key] = [existing, value];
+    }
   }
 
   return properties;
@@ -195,7 +212,7 @@ export function createCommand(): Command {
     .requiredOption("--label <text>", "Human-readable label for the asset")
     .option("--vault <path>", "Path to Obsidian vault", process.cwd())
     .option("--aliases <names...>", "Additional aliases for the asset")
-    .option("--property <key=value...>", "Property key-value pairs (repeatable)", collect, [])
+    .option("--property <key=value...>", "Property key-value pairs (repeatable; the SAME key passed more than once accumulates into a YAML array)", collect, [])
     .option("--body <text>", "Markdown body content (use '-' to read from stdin)")
     .option("--body-file <path>", "Read body content from file")
     .option("--dry-run", "Preview frontmatter without writing file")
@@ -248,7 +265,12 @@ export function createCommand(): Command {
         // `apply repair-folder` / `audit co-location`. Fail-open to the inbox
         // default when isDefinedBy is missing / `!`-prefixed / unresolvable.
         let folderPath = DEFAULT_INBOX_FOLDER;
-        const isDefinedBy = propertyValues?.["exo__Asset_isDefinedBy"];
+        const isDefinedByRaw = propertyValues?.["exo__Asset_isDefinedBy"];
+        // isDefinedBy is cardinality-1; if a user degenerate-passes it more than
+        // once (→ array), co-locate by the first reference.
+        const isDefinedBy = Array.isArray(isDefinedByRaw)
+          ? isDefinedByRaw[0]
+          : isDefinedByRaw;
         if (isDefinedBy) {
           const coLocatedFolder = await resolveCoLocationFolder(
             fsAdapter,

--- a/packages/cli/src/services/WikilinkValidator.ts
+++ b/packages/cli/src/services/WikilinkValidator.ts
@@ -39,10 +39,15 @@ export class WikilinkValidator {
    * @throws WikilinkNotFoundError if any wikilink references a non-existent file
    */
   async validatePropertyValues(
-    properties: Record<string, string>,
+    properties: Record<string, string | string[]>,
   ): Promise<void> {
     for (const [, value] of Object.entries(properties)) {
-      await this.validateValue(value);
+      // A multi-value property (repeated --property, issue #3759) is an array;
+      // validate every element's wikilinks.
+      const values = Array.isArray(value) ? value : [value];
+      for (const v of values) {
+        await this.validateValue(v);
+      }
     }
   }
 

--- a/packages/cli/tests/integration/create-multivalue.integration.test.ts
+++ b/packages/cli/tests/integration/create-multivalue.integration.test.ts
@@ -1,0 +1,169 @@
+/**
+ * Issue #3759 — `exocortex-cli create --property` multi-value support.
+ *
+ * Repeating the SAME `--property key=value` flag MUST accumulate the values
+ * into a YAML array on the produced frontmatter (not last-wins, which silently
+ * dropped all but the final value). A single occurrence MUST stay a scalar
+ * string (back-compat).
+ *
+ * This drives the REAL `createCommand()` end-to-end against a temp vault —
+ * commander `collect` → `parseProperties` → core `GenericAssetCreationService`
+ * → on-disk frontmatter — i.e. the exact production path, not a hand-built
+ * propertyValues map. `--skip-wikilink-validation` keeps the fixture minimal;
+ * the `--class` is a pass-through UUID (no class file needed).
+ *
+ * Revert-verify (RFC 0003): restoring the last-wins `parseProperties` reduce
+ * (`properties[key] = value`) turns the multi-value assertion RED; the fix
+ * (accumulate repeated keys → array) turns it GREEN.
+ */
+import { jest, describe, it, expect, beforeEach, afterEach } from "@jest/globals";
+import * as fs from "fs";
+import * as path from "path";
+import * as os from "os";
+
+const { createCommand } = await import("../../src/commands/create.js");
+
+const RELATE_A = "11111111-1111-4111-8111-111111111111";
+const RELATE_B = "22222222-2222-4222-8222-222222222222";
+const RELATE_C = "33333333-3333-4333-8333-333333333333";
+const CLASS_UID = "65b58c34-7451-4b89-bea3-483f7c65fe73"; // pass-through (ztlk:Note)
+
+describe("Issue #3759: cli create --property multi-value (integration)", () => {
+  let vault: string;
+  let exitSpy: any;
+  let stdoutSpy: any;
+  let stderrSpy: any;
+  let consoleErrSpy: any;
+  let stdoutChunks: string[];
+  let errChunks: string[];
+
+  beforeEach(() => {
+    vault = fs.mkdtempSync(path.join(os.tmpdir(), "cli-3759-"));
+    fs.mkdirSync(path.join(vault, "01 Inbox"), { recursive: true });
+    stdoutChunks = [];
+    errChunks = [];
+    consoleErrSpy = jest
+      .spyOn(console, "error")
+      .mockImplementation(((...a: any[]) => {
+        errChunks.push(a.map(String).join(" "));
+      }) as any);
+    exitSpy = jest.spyOn(process, "exit").mockImplementation(((code?: number) => {
+      throw new Error(`__process_exit_${code ?? 0}__`);
+    }) as any);
+    stdoutSpy = jest
+      .spyOn(process.stdout, "write")
+      .mockImplementation(((chunk: any) => {
+        stdoutChunks.push(String(chunk));
+        return true;
+      }) as any);
+    stderrSpy = jest
+      .spyOn(process.stderr, "write")
+      .mockImplementation((() => true) as any);
+  });
+
+  afterEach(() => {
+    exitSpy.mockRestore();
+    stdoutSpy.mockRestore();
+    stderrSpy.mockRestore();
+    consoleErrSpy.mockRestore();
+    fs.rmSync(vault, { recursive: true, force: true });
+  });
+
+  /**
+   * Run the real `create` command with the given `--property` args, then return
+   * the written file's content + parsed JSON output ({uuid, path}). Swallows the
+   * spied `process.exit(0)` throw.
+   */
+  const run = async (propertyArgs: string[], label: string) => {
+    const argv = [
+      "node",
+      "exocortex",
+      "--vault",
+      vault,
+      "--class",
+      CLASS_UID,
+      "--label",
+      label,
+      "--skip-wikilink-validation",
+      ...propertyArgs,
+    ];
+    // NB: the action calls `process.exit(0)` INSIDE its own try/catch, so the
+    // spied exit(0) throw is caught by the action → ErrorHandler → exit(1).
+    // Either way the success JSON has already been written to stdout and the
+    // file to disk before the first exit. We swallow any spied exit and parse
+    // the stdout JSON (empty stdout ⇒ a genuine failure ⇒ JSON.parse throws).
+    try {
+      await createCommand().parseAsync(argv);
+    } catch (e: any) {
+      if (!/^__process_exit_\d+__$/.test(String(e?.message)))
+        throw new Error(
+          `create threw: ${e?.message} | console.error=${errChunks.join(" || ")}`,
+        );
+    }
+    const stdout = stdoutChunks.join("").trim();
+    if (!stdout)
+      throw new Error(
+        `create produced no stdout (failed) | console.error=${errChunks.join(" || ")}`,
+      );
+    const out = JSON.parse(stdout);
+    const content = fs.readFileSync(path.join(vault, out.path), "utf-8");
+    return { content, out };
+  };
+
+  it("@req:cd2c3f18-b798-4084-899d-38e2f438a2cc multi-value: repeated --property → YAML array", async () => {
+    const { content } = await run(
+      [
+        "--property",
+        `exo__Asset_relates=[[${RELATE_A}]]`,
+        "--property",
+        `exo__Asset_relates=[[${RELATE_B}]]`,
+        "--property",
+        `exo__Asset_relates=[[${RELATE_C}]]`,
+      ],
+      "TEST-3759-multi",
+    );
+
+    // YAML array form: `exo__Asset_relates:` followed by `  - "[[...]]"` lines.
+    expect(content).toMatch(
+      /exo__Asset_relates:\s*\n\s*-\s+"\[\[11111111/,
+    );
+    expect(content).toMatch(/\n\s*-\s+"\[\[22222222/);
+    expect(content).toMatch(/\n\s*-\s+"\[\[33333333/);
+
+    // All three values are present (no last-wins drop).
+    expect(content).toContain(RELATE_A);
+    expect(content).toContain(RELATE_B);
+    expect(content).toContain(RELATE_C);
+
+    // NOT a scalar (the last-wins bug emitted `exo__Asset_relates: "[[C]]"`).
+    expect(content).not.toMatch(/exo__Asset_relates:\s*"\[\[/);
+  });
+
+  it("@req:cd2c3f18-b798-4084-899d-38e2f438a2cc back-compat: single --property → scalar string", async () => {
+    const { content } = await run(
+      ["--property", `exo__Asset_relates=[[${RELATE_A}]]`],
+      "TEST-3759-single",
+    );
+
+    // Scalar form: `exo__Asset_relates: "[[...]]"` on one line, NOT an array.
+    expect(content).toMatch(
+      new RegExp(`exo__Asset_relates:\\s*"\\[\\[${RELATE_A}\\]\\]"`),
+    );
+    expect(content).not.toMatch(/exo__Asset_relates:\s*\n\s*-\s+"\[\[/);
+  });
+
+  it("@req:cd2c3f18-b798-4084-899d-38e2f438a2cc works for any key (exo__Instance_class-like repeated key)", async () => {
+    // A non-system custom key repeated → array, proving key-independence.
+    const { content } = await run(
+      [
+        "--property",
+        `custom__Asset_tag=[[${RELATE_A}]]`,
+        "--property",
+        `custom__Asset_tag=[[${RELATE_B}]]`,
+      ],
+      "TEST-3759-anykey",
+    );
+    expect(content).toMatch(/custom__Asset_tag:\s*\n\s*-\s+"\[\[11111111/);
+    expect(content).toMatch(/\n\s*-\s+"\[\[22222222/);
+  });
+});

--- a/packages/core/src/services/GenericAssetCreationService.ts
+++ b/packages/core/src/services/GenericAssetCreationService.ts
@@ -335,7 +335,9 @@ export class GenericAssetCreationService {
             // key=...` flag, issue #3759): emit a flat YAML array, quoting each
             // wikilink element exactly as a scalar would be. The repeated flag
             // is the explicit array signal — independent of the property's
-            // declared cardinality.
+            // declared cardinality. (Scoped to the shape-registry path — the CLI
+            // create path — so the no-registry plugin/apply path keeps its
+            // existing array-as-inferred-value behavior, covered by tests.)
             frontmatter[propertyName] = value.map((element) =>
               this.quoteWikilinkValue(String(element)),
             );

--- a/packages/core/src/services/GenericAssetCreationService.ts
+++ b/packages/core/src/services/GenericAssetCreationService.ts
@@ -330,11 +330,22 @@ export class GenericAssetCreationService {
         // scalar by default, array only for Multiple-cardinality properties.
         // Otherwise the PropertyFieldType formatter applies (plugin/apply).
         if (config.shapeRegistry !== undefined) {
-          frontmatter[propertyName] = this.formatPropertyValueWithCardinality(
-            propertyName,
-            String(value),
-            config.shapeRegistry,
-          );
+          if (Array.isArray(value)) {
+            // Explicit multi-value (e.g. a repeated `cli create --property
+            // key=...` flag, issue #3759): emit a flat YAML array, quoting each
+            // wikilink element exactly as a scalar would be. The repeated flag
+            // is the explicit array signal — independent of the property's
+            // declared cardinality.
+            frontmatter[propertyName] = value.map((element) =>
+              this.quoteWikilinkValue(String(element)),
+            );
+          } else {
+            frontmatter[propertyName] = this.formatPropertyValueWithCardinality(
+              propertyName,
+              String(value),
+              config.shapeRegistry,
+            );
+          }
         } else {
           const fieldType = propertyTypeMap.get(propertyName);
           frontmatter[propertyName] = this.formatValue(value, fieldType);
@@ -607,19 +618,27 @@ export class GenericAssetCreationService {
     value: string,
     shapeRegistry?: ShapeRegistry,
   ): string | string[] {
+    const formatted = this.quoteWikilinkValue(value);
+
+    // A wikilink whose property has Multiple cardinality emits an array-of-1
+    // (issue #3179). Non-wikilink values are returned unchanged.
+    if (formatted.includes("[[") && this.shouldEmitAsArray(key, shapeRegistry)) {
+      return [formatted];
+    }
+
+    return formatted;
+  }
+
+  /**
+   * Quote a wikilink value (`[[...]]`) for YAML emission, leaving non-wikilink
+   * values and already-quoted values untouched. Shared by the scalar
+   * cardinality formatter and the explicit multi-value array path (#3759).
+   */
+  private quoteWikilinkValue(value: string): string {
     if (!value.includes("[[")) {
       return value;
     }
-
-    // Quote the wikilink if not already quoted
-    const quoted =
-      value.startsWith('"') && value.endsWith('"') ? value : `"${value}"`;
-
-    if (this.shouldEmitAsArray(key, shapeRegistry)) {
-      return [quoted];
-    }
-
-    return quoted;
+    return value.startsWith('"') && value.endsWith('"') ? value : `"${value}"`;
   }
 
   /**


### PR DESCRIPTION
## Problem (#3759)

`exocortex-cli create --property key=value` did not support multi-value:
- **Repeatable `--property` with the same key → last-wins** (all but the final value silently dropped).

This blocked one-step creation of any asset with a multi-value property (`exo__Asset_relates` >1, `exo__Instance_class` >1, …), forcing a manual `Edit` follow-up and undermining "vault assets only through the CLI".

## Fix

Repeating the same `--property key=value` flag now **accumulates** into a YAML array; a single occurrence stays a **scalar** (back-compat). Works for any key, independent of declared SHACL cardinality — the repeated flag is the explicit multi-value signal.

- `parseProperties` (CLI): first key → scalar, second → promote to 2-element array, third+ → append.
- `GenericAssetCreationService` (core): array property values emit a flat YAML array, each wikilink element quoted via a shared `quoteWikilinkValue` helper. The #3179 single-value cardinality-aware emission (Multiple → array-of-1) is preserved unchanged.
- `WikilinkValidator.validatePropertyValues` + co-location `isDefinedBy`: array-aware.
- **Out of scope:** a flow-array literal in a single `--property 'key=["a","b"]'` is NOT parsed as an array (value/array ambiguity not in the AC); it stays literal. Repeatable `--property` is the supported multi-value path (documented in the flag help).

## Acceptance criteria (#3759) — all met

- `create --property relates=A --property relates=B` → `exo__Asset_relates:` YAML array `[A, B]` ✅
- single `--property relates=A` → scalar `"A"` (back-compat) ✅
- works for any key ✅

## Tests / revert-verify (RFC 0003)

`packages/cli/tests/integration/create-multivalue.integration.test.ts` drives the **real `createCommand()` end-to-end** (commander collect → parseProperties → core GenericAssetCreationService → on-disk frontmatter).

**Revert-verified:** FAILS pre-fix (2/3, last-wins → scalar of last value) / PASSES post-fix (3/3). Full CLI suite 1755 green; core GenericAssetCreation 98 green; `check:types` 0; lint clean.

Req: cd2c3f18-b798-4084-899d-38e2f438a2cc
Closes #3759