### PR TITLE
test(cli): bind active req 9994c7d7 (#3761) to its existing revert-verified test (cross-session unblock)

### DIFF
--- a/packages/cli/tests/integration/colocate-renest-3761.integration.test.ts
+++ b/packages/cli/tests/integration/colocate-renest-3761.integration.test.ts
@@ -54,7 +54,7 @@ describe("#3761 — co-located create must not re-nest the vault root", () => {
     path.join(root, REL_FOLDER, `${UID}.md`);
 
   describe("NodeFsAdapter.createFile (the `apply create-instance` fileWriter)", () => {
-    it("leading-slash-stripped absolute folder → writes to correct co-located folder, no phantom tree", async () => {
+    it("@req:9994c7d7-39dc-4e0e-ab4f-972da9ef49ad leading-slash-stripped absolute folder → writes to correct co-located folder, no phantom tree", async () => {
       const adapter = new NodeFsAdapter(root);
       // exactly what parentFolderOf produces from an absolute ontology folder
       const fakeRelative =
@@ -94,7 +94,7 @@ describe("#3761 — co-located create must not re-nest the vault root", () => {
   });
 
   describe("FileSystemVaultAdapter (the `cli create` write path)", () => {
-    it("leading-slash-stripped absolute folder → createFolder + create land correctly, no phantom tree", async () => {
+    it("@req:9994c7d7-39dc-4e0e-ab4f-972da9ef49ad leading-slash-stripped absolute folder → createFolder + create land correctly, no phantom tree", async () => {
       const adapter = new FileSystemVaultAdapter(root);
       const fakeFolder = root.replace(/^\/+/, "") + `/${REL_FOLDER}`;
 


### PR DESCRIPTION
## Cross-session unblock — binding-only

The #3761 closure (al-cli-3761) flipped req `9994c7d7` ("a CLI vault adapter never re-nests the vault root", PR #3768) to **Active** in `exoas-exo-reqs` without landing its `@req` binding tag in the exocortex tree. Because `requirements-trace` reads the live shared reqs ABox, the active-gate invariant (*an active requirement must have a verification binding*) went **red on `main`**, blocking **all** PRs (CLI #3770 + the inbound T3.3 sibling PR).

## Fix

Tag the **already-merged, revert-verified** test `colocate-renest-3761.integration.test.ts` with `@req:9994c7d7-39dc-4e0e-ab4f-972da9ef49ad`. This test already verifies the exact req behavior (re-nest guard, no phantom duplicate tree) across both write paths (`NodeFsAdapter` + `FileSystemVaultAdapter`) — the req's own `verifiedBy` field already names it, and #3761 revert-verified it RED 2/5 (guard removed) → GREEN 6/6.

**Binding-only — no behavior change.** 6/6 green.

Req: 9994c7d7-39dc-4e0e-ab4f-972da9ef49ad