### PR TITLE
feat(relations): read-view «Edit relations» affordance → property-editor (RFC 93a0b2ee §C3 / PDD dccff87b)

### DIFF
--- a/packages/obsidian-plugin/src/presentation/components/AssetRelationsTable.tsx
+++ b/packages/obsidian-plugin/src/presentation/components/AssetRelationsTable.tsx
@@ -169,6 +169,16 @@ export interface AssetRelationsTableProps {
    * form is stripped upstream.
    */
   resolveAccent?: (classRef: string) => string | null;
+  /**
+   * PDD puzzle `dccff87b` (RFC `93a0b2ee` §C3 read-view follow-up) — opens the
+   * relations editor for the asset whose read-view Relations block this is.
+   * When provided, a single BLOCK-LEVEL «Edit relations» affordance
+   * (`.exocortex-edit-relations`) is rendered so the relations editor (the
+   * Relations section of the property-editor, Tasks 3.1–3.3) is discoverable
+   * directly from the read view — not only via the command palette. ADDITIVE:
+   * legacy callers that pass no callback render no affordance (zero regression).
+   */
+  onEditRelations?: () => void;
 }
 
 interface SortState {
@@ -697,11 +707,35 @@ export const AssetRelationsTable: React.FC<AssetRelationsTableProps> = ({
   onAssetClick,
   getAssetLabel,
   resolveAccent,
+  onEditRelations,
 }) => {
   // State to track collapsed groups (all expanded by default)
   const [collapsedGroups, setCollapsedGroups] = useState<Set<string>>(
     new Set()
   );
+
+  // PDD `dccff87b` — block-level «Edit relations» affordance. Rendered once at
+  // the top of the read-view Relations block when a callback is wired (i.e. the
+  // renderer threaded the viewed asset's currentFile). Activating it opens the
+  // asset's property-editor (Relations section) — the read-view → editor entry
+  // point. Absent callback → no affordance (additive; back-compat).
+  const editRelationsButton = onEditRelations ? (
+    <button
+      type="button"
+      className="exocortex-edit-relations"
+      aria-label="Edit relations"
+      title="Edit relations"
+      onClick={onEditRelations}
+      style={{
+        marginBottom: "8px",
+        padding: "4px 8px",
+        cursor: "pointer",
+        fontSize: "12px",
+      }}
+    >
+      ✎ Edit relations
+    </button>
+  ) : null;
 
   // RFC `93a0b2ee` Task 2 (C2) — show the persistent reified-marker legend iff
   // at least one rendered relation is reified (mobile-safe explanation channel).
@@ -753,6 +787,7 @@ export const AssetRelationsTable: React.FC<AssetRelationsTableProps> = ({
   if (groupByProperty) {
     return (
       <div className="exocortex-relations-grouped">
+        {editRelationsButton}
         {Object.entries(groupedRelations).map(([groupName, items]) => {
           const groupProps = groupSpecificProperties[groupName] || [];
           const mergedProperties = [...showProperties, ...groupProps];
@@ -799,6 +834,7 @@ export const AssetRelationsTable: React.FC<AssetRelationsTableProps> = ({
 
   return (
     <div className="exocortex-relations">
+      {editRelationsButton}
       <SingleTable
         items={groupedRelations.ungrouped}
         sortBy={sortBy}

--- a/packages/obsidian-plugin/src/presentation/renderers/UniversalLayoutRenderer.ts
+++ b/packages/obsidian-plugin/src/presentation/renderers/UniversalLayoutRenderer.ts
@@ -426,7 +426,7 @@ export class UniversalLayoutRenderer {
       }
 
       await this.areaTreeRenderer.render(el, currentFile, relations, renderHeader, this.sectionStateManager.isCollapsed("area-tree"));
-      await this.relationsRenderer.render(el, relations, config, renderHeader, this.sectionStateManager.isCollapsed("relations"));
+      await this.relationsRenderer.render(el, relations, config, renderHeader, this.sectionStateManager.isCollapsed("relations"), currentFile);
 
       this.currentFilePath = currentFile.path;
       this.currentConfig = config;

--- a/packages/obsidian-plugin/src/presentation/renderers/helpers/IncrementalUpdateHandler.ts
+++ b/packages/obsidian-plugin/src/presentation/renderers/helpers/IncrementalUpdateHandler.ts
@@ -219,7 +219,7 @@ export class IncrementalUpdateHandler {
         break;
       case LayoutSection.RELATIONS:
         await this.deps.relationsRenderer.render(
-          parent, relations, config, renderHeader, ssm.isCollapsed("relations"));
+          parent, relations, config, renderHeader, ssm.isCollapsed("relations"), file);
         break;
     }
   }

--- a/packages/obsidian-plugin/src/presentation/renderers/layout/RelationsRenderer.ts
+++ b/packages/obsidian-plugin/src/presentation/renderers/layout/RelationsRenderer.ts
@@ -510,12 +510,34 @@ export class RelationsRenderer {
     }
   }
 
+  /**
+   * PDD `dccff87b` — open the relations editor for the read-view «Edit relations»
+   * affordance. Reuses the already-registered `exocortex:edit-properties`
+   * command (the SAME flow as Cmd+P and the ribbon — single source of truth)
+   * via Obsidian-core `app.commands.executeCommandById`; the command operates on
+   * the active file, which IS the asset whose Relations block this is. Parity-
+   * safe: Obsidian-core API only, no Node fs, no platform gate → identical on
+   * desktop AND mobile (Desktop↔Mobile Command Parity invariant).
+   */
+  private openRelationsEditor(): void {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const commands = (this.app as any).commands;
+    if (typeof commands?.executeCommandById === "function") {
+      commands.executeCommandById("exocortex:edit-properties");
+    }
+  }
+
   async render(
     el: HTMLElement,
     relations: AssetRelation[],
     config: UniversalLayoutConfig,
     renderHeader?: (container: HTMLElement, sectionId: string, title: string) => void,
     isCollapsed?: boolean,
+    // PDD `dccff87b` — the asset whose read-view Relations block this is. When
+    // provided, a block-level «Edit relations» affordance is wired (opens this
+    // asset's property-editor). Optional → legacy callers render no affordance
+    // (additive, zero read-view regression).
+    currentFile?: TFile,
   ): Promise<void> {
     const container = el.createDiv({ cls: "exocortex-assets-relations" });
 
@@ -586,6 +608,12 @@ export class RelationsRenderer {
         getAssetLabel: (path: string) => this.metadataService.getAssetLabel(path),
         resolveAccent: (classRef: string) =>
           this.plugin.themeResolver?.resolveAccent(classRef) ?? null,
+        // PDD `dccff87b` — block-level «Edit relations» affordance, wired only
+        // when the renderer knows the asset (currentFile). Opens this asset's
+        // property-editor via the registered edit-properties command.
+        onEditRelations: currentFile
+          ? () => this.openRelationsEditor()
+          : undefined,
       }),
     );
   }

--- a/packages/obsidian-plugin/tests/unit/RelationsRenderer.test.ts
+++ b/packages/obsidian-plugin/tests/unit/RelationsRenderer.test.ts
@@ -815,6 +815,51 @@ describe("RelationsRenderer", () => {
       );
     });
 
+    // PDD `dccff87b` (RFC 93a0b2ee §C3 read-view follow-up) — block-level
+    // «Edit relations» affordance wiring. @req:cbb982a3-17dc-42ec-8a01-9857d81a881f
+    describe("«Edit relations» affordance wiring (PDD dccff87b)", () => {
+      const propsPassedToTable = () =>
+        (React.createElement as jest.Mock).mock.calls
+          .map((c) => c[1])
+          .find(
+            (p) => p && typeof p === "object" && "groupByProperty" in p,
+          );
+
+      it("passes an onEditRelations that invokes the edit-properties command when currentFile is provided", async () => {
+        const executeCommandById = jest.fn();
+        mockApp.commands = { executeCommandById };
+        const relations = [createMockAssetRelation()];
+
+        await renderer.render(
+          mockElement,
+          relations,
+          {},
+          undefined,
+          false,
+          mockFile,
+        );
+
+        const props = propsPassedToTable();
+        expect(props).toBeDefined();
+        expect(typeof props.onEditRelations).toBe("function");
+
+        props.onEditRelations();
+        expect(executeCommandById).toHaveBeenCalledWith(
+          "exocortex:edit-properties",
+        );
+      });
+
+      it("passes NO onEditRelations when currentFile is absent (additive — back-compat)", async () => {
+        const relations = [createMockAssetRelation()];
+
+        await renderer.render(mockElement, relations, {});
+
+        const props = propsPassedToTable();
+        expect(props).toBeDefined();
+        expect(props.onEditRelations).toBeUndefined();
+      });
+    });
+
     it("should pass correct sort configuration to component", async () => {
       const relations = [createMockAssetRelation()];
 

--- a/packages/obsidian-plugin/tests/unit/RelationsRenderer.test.ts
+++ b/packages/obsidian-plugin/tests/unit/RelationsRenderer.test.ts
@@ -841,8 +841,10 @@ describe("RelationsRenderer", () => {
 
         const props = propsPassedToTable();
         expect(props).toBeDefined();
-        expect(typeof props.onEditRelations).toBe("function");
+        expect(props.onEditRelations).toBeDefined();
 
+        // Behaviour, not method-exists: invoking the wired callback drives the
+        // registered edit-properties command (the read-view → editor open path).
         props.onEditRelations();
         expect(executeCommandById).toHaveBeenCalledWith(
           "exocortex:edit-properties",

--- a/packages/obsidian-plugin/tests/unit/presentation/components/AssetRelationsTable.edit-affordance.test.tsx
+++ b/packages/obsidian-plugin/tests/unit/presentation/components/AssetRelationsTable.edit-affordance.test.tsx
@@ -1,0 +1,85 @@
+/**
+ * AssetRelationsTable — PDD puzzle `dccff87b` (RFC `93a0b2ee` §C3 read-view
+ * follow-up).
+ *
+ * Locks in the read-view → editor entry point: when an `onEditRelations`
+ * callback is wired (i.e. the renderer threaded the viewed asset's
+ * `currentFile`), the read-view Relations block renders a SINGLE block-level
+ * «Edit relations» affordance (`.exocortex-edit-relations`) that invokes the
+ * callback on activation. With no callback the affordance is absent (additive —
+ * zero read-view regression). The callback opens the asset's property-editor
+ * (the Relations section, Tasks 3.1–3.3) so relation editing is discoverable
+ * directly from the read view, not only via the command palette.
+ *
+ * @req:cbb982a3-17dc-42ec-8a01-9857d81a881f
+ */
+
+import React from "react";
+import "@testing-library/jest-dom";
+import { render, fireEvent } from "@testing-library/react";
+import {
+  AssetRelationsTable,
+  AssetRelation,
+} from "../../../../src/presentation/components/AssetRelationsTable";
+
+const baseRelation = (
+  overrides: Partial<AssetRelation> = {},
+): AssetRelation => ({
+  path: "p.md",
+  title: "P",
+  propertyName: undefined,
+  isBodyLink: true,
+  created: 0,
+  modified: 0,
+  metadata: {},
+  ...overrides,
+});
+
+describe("AssetRelationsTable — read-view «Edit relations» affordance (PDD dccff87b)", () => {
+  it("renders a single `.exocortex-edit-relations` button and invokes onEditRelations on click", () => {
+    const onEditRelations = jest.fn();
+    const { container } = render(
+      <AssetRelationsTable
+        relations={[baseRelation()]}
+        onEditRelations={onEditRelations}
+      />,
+    );
+
+    const buttons = container.querySelectorAll<HTMLButtonElement>(
+      ".exocortex-edit-relations",
+    );
+    expect(buttons).toHaveLength(1);
+    expect(buttons[0].textContent).toContain("Edit relations");
+
+    fireEvent.click(buttons[0]);
+    expect(onEditRelations).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders NO affordance when onEditRelations is absent (additive — back-compat)", () => {
+    const { container } = render(
+      <AssetRelationsTable relations={[baseRelation()]} />,
+    );
+
+    expect(
+      container.querySelectorAll(".exocortex-edit-relations"),
+    ).toHaveLength(0);
+  });
+
+  it("renders a single affordance in grouped mode too", () => {
+    const onEditRelations = jest.fn();
+    const { container } = render(
+      <AssetRelationsTable
+        relations={[
+          baseRelation({ propertyName: "ems__Effort_parent", isBodyLink: false }),
+          baseRelation({ propertyName: "ems__Effort_area", isBodyLink: false }),
+        ]}
+        groupByProperty
+        onEditRelations={onEditRelations}
+      />,
+    );
+
+    expect(
+      container.querySelectorAll(".exocortex-edit-relations"),
+    ).toHaveLength(1);
+  });
+});

--- a/packages/obsidian-plugin/tests/unit/presentation/components/AssetRelationsTable.edit-affordance.test.tsx
+++ b/packages/obsidian-plugin/tests/unit/presentation/components/AssetRelationsTable.edit-affordance.test.tsx
@@ -19,6 +19,7 @@ import "@testing-library/jest-dom";
 import { render, fireEvent } from "@testing-library/react";
 import {
   AssetRelationsTable,
+  AssetRelationsTableWithToggle,
   AssetRelation,
 } from "../../../../src/presentation/components/AssetRelationsTable";
 
@@ -63,6 +64,31 @@ describe("AssetRelationsTable — read-view «Edit relations» affordance (PDD d
     expect(
       container.querySelectorAll(".exocortex-edit-relations"),
     ).toHaveLength(0);
+  });
+
+  it("AssetRelationsTableWithToggle forwards onEditRelations to the inner table (rest-spread regression lock)", () => {
+    // The production renderer renders the WithToggle wrapper, not AssetRelationsTable
+    // directly — so lock that the wrapper forwards onEditRelations (it does so via
+    // its `...props` rest-spread; this guards the "wiring breaks while tests pass"
+    // hazard if the wrapper ever destructures the prop out).
+    const onEditRelations = jest.fn();
+    const { container } = render(
+      <AssetRelationsTableWithToggle
+        relations={[baseRelation()]}
+        onEditRelations={onEditRelations}
+        showEffortVotes={false}
+        onToggleEffortVotes={jest.fn()}
+        showArchived={false}
+        onToggleArchived={jest.fn()}
+      />,
+    );
+
+    const buttons = container.querySelectorAll<HTMLButtonElement>(
+      ".exocortex-edit-relations",
+    );
+    expect(buttons).toHaveLength(1);
+    fireEvent.click(buttons[0]);
+    expect(onEditRelations).toHaveBeenCalledTimes(1);
   });
 
   it("renders a single affordance in grouped mode too", () => {


### PR DESCRIPTION
## What

Adds a block-level **«Edit relations»** affordance to the **read-view** Asset Relations block, so the relations editor is discoverable directly from the read view — not only via `Cmd+P → «Edit properties»`.

RFC `93a0b2ee` §C3 read-view follow-up. PDD puzzle `dccff87b`.

## Why

The relations editor (the **Relations section** of `PropertyEditorModal` — list inline+reified, create/delete, reify/de-reify toggle, Tasks 3.1–3.3) was reachable **only** via the command palette. The read-view `AssetRelationsTable` had **no** edit entry point at all.

> **Premise correction (verify-before-assert):** the originating puzzle node said «T3.1 added a discoverability ⋯-affordance in the read-view AssetRelationsTable». In fact T3.1 (#3764) built the Relations section *inside* the modal; the read-view table had no affordance. This PR fills exactly that read-view → editor gap.

## How

- **`AssetRelationsTable.tsx`** — new `onEditRelations?: () => void` prop; the `.exocortex-edit-relations` button rendered once at the top of the read-view block (grouped + ungrouped branches) when the callback is wired.
- **`RelationsRenderer.ts`** — `render(...)` gains optional `currentFile`; when present it wires `onEditRelations` → `app.commands.executeCommandById('exocortex:edit-properties')` (the **same** flow as the palette and ribbon — single source of truth; the command operates on the active file, which is this block's asset).
- **`UniversalLayoutRenderer.ts` + `IncrementalUpdateHandler.ts`** — thread the existing `currentFile`/`file` into `render(...)`.

**Design (orchestrator-confirmed): block-level, not per-row.** A per-row `✎` was rejected as architecturally ambiguous — a backlink row's relation is owned by a *different* asset.

**Desktop↔Mobile Command Parity invariant** — Obsidian-core API only (no Node fs, no `Platform.isMobile` gate) → identical on desktop and mobile.

**Additive / zero regression** — legacy callers that thread no `currentFile` render no affordance.

## Tests (req-first SDD, revert-verified)

`req @req:cbb982a3-17dc-42ec-8a01-9857d81a881f` (exoas-exo-reqs, proposed→active on merge).

- `AssetRelationsTable.edit-affordance.test.tsx` — single `.exocortex-edit-relations` button iff `onEditRelations` provided; click invokes it; absent → no button.
- `RelationsRenderer.test.ts` — `render(..., currentFile)` passes an `onEditRelations` invoking `executeCommandById('exocortex:edit-properties')`; passes none when `currentFile` absent.

**Revert-verify:** type-preserving break of both impl points → the 3 positive tests RED (back-compat tests stayed GREEN) → restore → 87 pass. `findRelatedTests`: 13 suites / 302 pass. typecheck + eslint clean.
