### PR TITLE
feat(exosync): in-plugin «Deduplicate uids» command — Desktop↔Mobile parity (#3676)

### DIFF
--- a/packages/cli/src/commands/exosync-quarantine.ts
+++ b/packages/cli/src/commands/exosync-quarantine.ts
@@ -377,14 +377,18 @@ export async function runDedupUids(
       snap: Map<string, string>;
     }> = [];
     for (const [uid, paths] of dups) {
-      const files: Array<{ path: string; content: string }> = [];
+      const groupFiles: Array<{ path: string; content: string }> = [];
       const snap = new Map<string, string>();
       for (const p of paths) {
         const c = await fsp.readFile(p, "utf-8");
-        files.push({ path: p, content: c });
+        groupFiles.push({ path: p, content: c });
         snap.set(p, c);
       }
-      plans.push({ uid, decisions: planDedupGroup(uid, files, randomUUID), snap });
+      plans.push({
+        uid,
+        decisions: planDedupGroup(uid, groupFiles, randomUUID),
+        snap,
+      });
     }
 
     let plannedDeletes = 0;

--- a/packages/cli/src/commands/exosync-quarantine.ts
+++ b/packages/cli/src/commands/exosync-quarantine.ts
@@ -36,6 +36,10 @@ import {
   OUTBOX_STORE_FILENAME,
   QuarantineResolver,
   extractAssetUid,
+  rewriteAssetUid,
+  findDuplicateUidGroups,
+  planDuplicateUidFix,
+  type DedupUidFile,
   type ResolveChoice,
   type SyncRepoSpec,
 } from "@kitelev/exocortex-core";
@@ -237,31 +241,6 @@ export async function runQuarantineResolve(
 }
 
 /**
- * Rewrite the `exo__Asset_uid` scalar to a fresh value, scoped to the `---`
- * frontmatter block exactly like {@link extractAssetUid} reads it (same block
- * isolation + same lenient value shape `[^\s"']+`). Scoping the WRITE to the
- * same region as the READ avoids re-stamping a `exo__Asset_uid:` token that
- * happens to appear in the body (code-reviewer MEDIUM-1). Returns the content
- * unchanged when there is no frontmatter uid line.
- */
-function rewriteUid(content: string, fresh: string): string {
-  const fm = /^(---\r?\n)([\s\S]*?)(\r?\n---(?=\r?\n|$))/.exec(content);
-  if (fm === null) return content;
-  const rewrittenBlock = fm[2].replace(
-    /^(exo__Asset_uid:[ \t]*["']?)[^\s"']+(["']?[ \t]*)$/m,
-    `$1${fresh}$2`,
-  );
-  if (rewrittenBlock === fm[2]) return content;
-  return (
-    content.slice(0, fm.index) +
-    fm[1] +
-    rewrittenBlock +
-    fm[3] +
-    content.slice(fm.index + fm[0].length)
-  );
-}
-
-/**
  * Content-preserving normalization for the IDENTICAL-copy test. Two files equal
  * after this carry the SAME content — only line-ending STYLE (CRLF vs LF) and
  * trailing blank lines / a final newline differ, which no markdown/RDF reader
@@ -353,33 +332,31 @@ export async function runDedupUids(
   const { specs, warnings } = collectVaultSpecs(vaultPath);
   for (const w of warnings) out(`warn: ${w}`);
 
-  // Group absolute file paths by the uid declared in their frontmatter, scoped
-  // to the materialized sync units (the same set sync diffs).
-  const byUid = new Map<string, string[]>();
+  // Enumerate absolute paths + content across the materialized sync units (the
+  // same set sync diffs), then defer the uid grouping to the shared
+  // platform-free helper (#3676 — the in-plugin command composes the SAME
+  // `findDuplicateUidGroups` / `planDuplicateUidFix` over `vault.adapter`).
+  const files: DedupUidFile[] = [];
   for (const spec of specs) {
     const root = path.join(vaultPath, spec.localPath);
     if (!existsSync(root)) continue;
     const port = nodeLocalFilesPort(root);
     for (const rel of await port.list()) {
       if (!rel.endsWith(".md")) continue;
-      let content: string;
       try {
-        content = await port.read(rel);
+        files.push({ path: path.join(root, rel), content: await port.read(rel) });
       } catch {
         continue;
       }
-      const uid = extractAssetUid(content);
-      if (uid === undefined) continue;
-      const abs = path.join(root, rel);
-      const list = byUid.get(uid) ?? [];
-      list.push(abs);
-      byUid.set(uid, list);
     }
   }
 
-  const dups = [...byUid.entries()]
-    .filter(([, paths]) => paths.length > 1)
-    .sort(([a], [b]) => a.localeCompare(b));
+  // Duplicate-uid groups, sorted by uid (paths keep enumeration order for the
+  // report). Shaped as `[uid, paths]` so the report / `--auto` flow below is
+  // unchanged.
+  const dups: Array<[string, string[]]> = findDuplicateUidGroups(files).map(
+    (g) => [g.uid, [...g.paths]],
+  );
 
   if (dups.length === 0) {
     out("No duplicate uids on disk. ✅");
@@ -489,7 +466,7 @@ export async function runDedupUids(
           skipped++;
           continue;
         }
-        const rewritten = rewriteUid(current, d.toUid);
+        const rewritten = rewriteAssetUid(current, d.toUid);
         if (rewritten !== current) {
           await fsp.writeFile(d.path, rewritten, "utf-8");
           out(`  re-uuid ${rel(d.path)} → uid=${d.toUid} (content differs from kept copy)`);
@@ -523,21 +500,15 @@ export async function runDedupUids(
     return 1; // a non-fix report is a "needs attention" signal (exit 1)
   }
 
+  // Keep the FIRST occurrence's uid per group, re-uuid the rest (the shared
+  // `planDuplicateUidFix` plans deterministically by path so a re-run is
+  // idempotent — the first stays first). The in-plugin command applies the
+  // identical plan over `vault.adapter` (#3676 — same fix on both platforms).
   let fixed = 0;
-  for (const [, paths] of dups) {
-    // Keep the FIRST occurrence's uid; re-uuid the rest (deterministic order
-    // by path so a re-run is idempotent — the first stays first).
-    const ordered = [...paths].sort((a, b) => a.localeCompare(b));
-    for (const file of ordered.slice(1)) {
-      const content = await fsp.readFile(file, "utf-8");
-      const fresh = randomUUID();
-      const rewritten = rewriteUid(content, fresh);
-      if (rewritten !== content) {
-        await fsp.writeFile(file, rewritten, "utf-8");
-        out(`  fixed ${path.relative(vaultPath, file)} → uid=${fresh}`);
-        fixed++;
-      }
-    }
+  for (const r of planDuplicateUidFix(files, randomUUID)) {
+    await fsp.writeFile(r.path, r.content, "utf-8");
+    out(`  fixed ${rel(r.path)} → uid=${r.toUid}`);
+    fixed++;
   }
   out(`Reassigned ${fixed} uid(s). Run \`exosync sync\` to propagate.`);
   return 0;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -607,6 +607,17 @@ export {
   type DetectChangesParams,
 } from "./services/sync/ChangeDetector";
 export { gitBlobSha } from "./services/sync/gitBlobSha";
+// dedup-uids (#3477) shared platform-free core (#3676) — report + fix semantics
+// composed by BOTH the CLI `runDedupUids` (Node enumeration) and the in-plugin
+// «Deduplicate uids» command (vault.adapter enumeration). Desktop↔Mobile parity.
+export {
+  rewriteAssetUid,
+  findDuplicateUidGroups,
+  planDuplicateUidFix,
+  type DedupUidFile,
+  type DedupUidGroup,
+  type DedupUidRewrite,
+} from "./services/sync/dedupUids";
 export {
   getBlobBytes,
   getBlobText,

--- a/packages/core/src/services/sync/dedupUids.ts
+++ b/packages/core/src/services/sync/dedupUids.ts
@@ -1,0 +1,125 @@
+/**
+ * dedupUids — the platform-free core of `exosync dedup-uids` (#3477) shared by
+ * BOTH surfaces (Desktop↔Mobile Command Parity, #3676):
+ *
+ *  - the CLI `runDedupUids` (`exosync-quarantine.ts`) injects a Node-backed file
+ *    enumeration; and
+ *  - the in-plugin «Exocortex: Deduplicate uids» command injects a
+ *    `vault.adapter`-backed enumeration (mobile-safe, no Node `fs`).
+ *
+ * Both compose the SAME report + fix semantics here, so a phone user who hits a
+ * dissonance message ("run dedup-uids") can act on it. The functions are pure
+ * (no fs/path/io) — each surface owns its own enumeration + persistence.
+ *
+ * Semantics (mirrors the CLI `--fix` path, NOT the `--auto` zero-loss resolver):
+ *  - **report-first** — group files by their frontmatter `exo__Asset_uid` and
+ *    surface every uid shared by >1 file (with their paths);
+ *  - **confirm-gated fix** — keep the lexicographically-first path's uid and
+ *    reassign a FRESH uuid to every other file in the group via a frontmatter
+ *    rewrite ONLY (the file is NEVER renamed). Deterministic ordering makes a
+ *    re-run idempotent (the first stays first).
+ */
+
+import { extractAssetUid } from "./ChangeDetector";
+
+/** A file's path + content, as the dedup pass sees it. */
+export interface DedupUidFile {
+  readonly path: string;
+  readonly content: string;
+}
+
+/** One uid shared by >1 file, with the paths declaring it. */
+export interface DedupUidGroup {
+  readonly uid: string;
+  readonly paths: readonly string[];
+}
+
+/** One concrete fix to persist: rewrite `path`'s uid `fromUid` → `toUid`. */
+export interface DedupUidRewrite {
+  readonly path: string;
+  readonly fromUid: string;
+  readonly toUid: string;
+  /** The full file content with the frontmatter uid scalar rewritten. */
+  readonly content: string;
+}
+
+/**
+ * Rewrite the `exo__Asset_uid` scalar to a fresh value, scoped to the `---`
+ * frontmatter block exactly like {@link extractAssetUid} reads it (same block
+ * isolation + same lenient value shape `[^\s"']+`). Scoping the WRITE to the
+ * same region as the READ avoids re-stamping a `exo__Asset_uid:` token that
+ * happens to appear in the body. Returns the content unchanged when there is no
+ * frontmatter uid line. (Moved verbatim from the CLI `rewriteUid` so both
+ * surfaces rewrite identically — #3676.)
+ */
+export function rewriteAssetUid(content: string, fresh: string): string {
+  const fm = /^(---\r?\n)([\s\S]*?)(\r?\n---(?=\r?\n|$))/.exec(content);
+  if (fm === null) return content;
+  const rewrittenBlock = fm[2].replace(
+    /^(exo__Asset_uid:[ \t]*["']?)[^\s"']+(["']?[ \t]*)$/m,
+    `$1${fresh}$2`,
+  );
+  if (rewrittenBlock === fm[2]) return content;
+  return (
+    content.slice(0, fm.index) +
+    fm[1] +
+    rewrittenBlock +
+    fm[3] +
+    content.slice(fm.index + fm[0].length)
+  );
+}
+
+/**
+ * Report-first: group `files` by their frontmatter `exo__Asset_uid` and return
+ * only the groups a uid is shared by >1 file (the #3477 anomaly). Groups are
+ * sorted by uid for a stable report; the paths within a group keep INPUT order
+ * (the caller's enumeration order — CLI report output is unchanged). Files
+ * without a uid are ignored.
+ */
+export function findDuplicateUidGroups(
+  files: ReadonlyArray<DedupUidFile>,
+): DedupUidGroup[] {
+  const byUid = new Map<string, string[]>();
+  for (const f of files) {
+    const uid = extractAssetUid(f.content);
+    if (uid === undefined) continue;
+    const list = byUid.get(uid) ?? [];
+    list.push(f.path);
+    byUid.set(uid, list);
+  }
+  return [...byUid.entries()]
+    .filter(([, paths]) => paths.length > 1)
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([uid, paths]) => ({ uid, paths }));
+}
+
+/**
+ * Confirm-gated fix plan: for every duplicate-uid group, keep the
+ * lexicographically-first path's uid and reassign a fresh uuid (from
+ * `freshUid`) to every OTHER file — a frontmatter rewrite only, never a rename.
+ * Pure: returns the concrete rewrites (path + new content); the caller
+ * persists them. A file whose content carries no rewritable uid line is skipped
+ * (defensive — every grouped file does have one). `freshUid` is injected so a
+ * test can make it deterministic.
+ */
+export function planDuplicateUidFix(
+  files: ReadonlyArray<DedupUidFile>,
+  freshUid: () => string,
+): DedupUidRewrite[] {
+  const contentByPath = new Map(files.map((f) => [f.path, f.content]));
+  const rewrites: DedupUidRewrite[] = [];
+  for (const group of findDuplicateUidGroups(files)) {
+    // Deterministic order — keep the first path, re-uuid the rest (a re-run is
+    // idempotent because the first stays first).
+    const ordered = [...group.paths].sort((a, b) => a.localeCompare(b));
+    for (const path of ordered.slice(1)) {
+      const content = contentByPath.get(path);
+      if (content === undefined) continue;
+      const toUid = freshUid();
+      const rewritten = rewriteAssetUid(content, toUid);
+      if (rewritten === content) continue; // no frontmatter uid line — skip
+      rewrites.push({ path, fromUid: group.uid, toUid, content: rewritten });
+    }
+  }
+  return rewrites;
+}

--- a/packages/core/tests/unit/services/sync/dedupUids.test.ts
+++ b/packages/core/tests/unit/services/sync/dedupUids.test.ts
@@ -1,0 +1,114 @@
+/**
+ * dedupUids — the platform-free core shared by the CLI `runDedupUids` and the
+ * in-plugin «Deduplicate uids» command (#3676). Covers the report grouping, the
+ * keep-first / reassign-rest fix plan (frontmatter rewrite only — never rename),
+ * determinism / idempotency, and the rewrite scoping.
+ */
+
+import {
+  findDuplicateUidGroups,
+  planDuplicateUidFix,
+  rewriteAssetUid,
+  type DedupUidFile,
+} from "../../../../src/services/sync/dedupUids";
+
+const fm = (uid: string, body = "body"): string =>
+  `---\nexo__Asset_uid: ${uid}\n---\n\n${body}\n`;
+
+describe("findDuplicateUidGroups", () => {
+  it("returns only uids shared by >1 file, sorted by uid, paths in input order", () => {
+    const files: DedupUidFile[] = [
+      { path: "z.md", content: fm("dup-b") },
+      { path: "a.md", content: fm("dup-a") },
+      { path: "b.md", content: fm("dup-a") },
+      { path: "c.md", content: fm("unique") },
+      { path: "y.md", content: fm("dup-b") },
+    ];
+    expect(findDuplicateUidGroups(files)).toEqual([
+      { uid: "dup-a", paths: ["a.md", "b.md"] },
+      { uid: "dup-b", paths: ["z.md", "y.md"] }, // input order, not sorted
+    ]);
+  });
+
+  it("ignores files with no frontmatter uid", () => {
+    const files: DedupUidFile[] = [
+      { path: "a.md", content: "no frontmatter here" },
+      { path: "b.md", content: fm("solo") },
+    ];
+    expect(findDuplicateUidGroups(files)).toEqual([]);
+  });
+
+  it("returns an empty array when every uid is unique", () => {
+    expect(
+      findDuplicateUidGroups([
+        { path: "a.md", content: fm("u1") },
+        { path: "b.md", content: fm("u2") },
+      ]),
+    ).toEqual([]);
+  });
+});
+
+describe("planDuplicateUidFix", () => {
+  it("keeps the lexicographically-first path's uid and re-uuids the rest (never renames)", () => {
+    let n = 0;
+    const freshUid = (): string => `fresh-${++n}`;
+    const files: DedupUidFile[] = [
+      { path: "b.md", content: fm("shared") },
+      { path: "a.md", content: fm("shared") },
+      { path: "c.md", content: fm("shared") },
+    ];
+    const rewrites = planDuplicateUidFix(files, freshUid);
+    // a.md (first sorted) is NOT rewritten; b.md + c.md get fresh uids.
+    expect(rewrites.map((r) => r.path)).toEqual(["b.md", "c.md"]);
+    expect(rewrites.every((r) => r.fromUid === "shared")).toBe(true);
+    expect(rewrites.map((r) => r.toUid)).toEqual(["fresh-1", "fresh-2"]);
+    // The rewrite is a frontmatter change only — the path (file name) is intact.
+    expect(rewrites[0].content).toContain("exo__Asset_uid: fresh-1");
+    expect(rewrites[0].content).not.toContain("exo__Asset_uid: shared");
+  });
+
+  it("is idempotent — a re-run over the fixed files plans nothing", () => {
+    let n = 0;
+    const freshUid = (): string => `fresh-${++n}`;
+    const files: DedupUidFile[] = [
+      { path: "a.md", content: fm("shared") },
+      { path: "b.md", content: fm("shared") },
+    ];
+    const first = planDuplicateUidFix(files, freshUid);
+    expect(first).toHaveLength(1);
+    // Apply the plan, then re-plan — no duplicates remain.
+    const fixed: DedupUidFile[] = files.map((f) => {
+      const r = first.find((x) => x.path === f.path);
+      return r ? { path: f.path, content: r.content } : f;
+    });
+    expect(planDuplicateUidFix(fixed, freshUid)).toEqual([]);
+  });
+
+  it("plans nothing when there are no duplicates", () => {
+    expect(
+      planDuplicateUidFix(
+        [
+          { path: "a.md", content: fm("u1") },
+          { path: "b.md", content: fm("u2") },
+        ],
+        () => "fresh",
+      ),
+    ).toEqual([]);
+  });
+});
+
+describe("rewriteAssetUid", () => {
+  it("rewrites the frontmatter uid scalar only, leaving the body untouched", () => {
+    const content = "---\nexo__Asset_uid: old\nexo__Asset_label: x\n---\n\nexo__Asset_uid: in-body\n";
+    const out = rewriteAssetUid(content, "new");
+    expect(out).toContain("exo__Asset_uid: new");
+    expect(out).toContain("exo__Asset_label: x");
+    // a `exo__Asset_uid:` token in the BODY is not re-stamped.
+    expect(out).toContain("exo__Asset_uid: in-body");
+  });
+
+  it("returns the content unchanged when there is no frontmatter uid line", () => {
+    const content = "---\nexo__Asset_label: x\n---\n\nbody\n";
+    expect(rewriteAssetUid(content, "new")).toBe(content);
+  });
+});

--- a/packages/obsidian-plugin/src/ExocortexPlugin.ts
+++ b/packages/obsidian-plugin/src/ExocortexPlugin.ts
@@ -3274,7 +3274,13 @@ export default class ExocortexPlugin extends Plugin {
       },
       writeFile: async (filePath, content) => {
         const file = this.app.vault.getAbstractFileByPath(filePath);
-        if (file instanceof TFile) await this.app.vault.modify(file, content);
+        if (!(file instanceof TFile)) {
+          // The file vanished between the scan and the write (TOCTOU) — reject
+          // so invokeDedup's catch logs it and the "Reassigned N" count stays
+          // truthful (never silently overstates).
+          throw new Error(`no longer a vault file (moved/deleted?): ${filePath}`);
+        }
+        await this.app.vault.modify(file, content);
       },
       freshUid: () => crypto.randomUUID(),
       confirm: (groups) =>

--- a/packages/obsidian-plugin/src/ExocortexPlugin.ts
+++ b/packages/obsidian-plugin/src/ExocortexPlugin.ts
@@ -207,6 +207,10 @@ import { registerExoSyncCommands } from "./infrastructure/adapters/registerExoSy
 import { QuarantineResolverCommands } from "./infrastructure/adapters/QuarantineResolverCommands";
 import { QuarantineResolverModal } from "./infrastructure/adapters/QuarantineResolverModal";
 import { registerQuarantineResolverCommand } from "./infrastructure/adapters/registerQuarantineResolverCommand";
+import { DedupUidsCommands } from "./infrastructure/adapters/DedupUidsCommands";
+import { registerDedupUidsCommand } from "./infrastructure/adapters/registerDedupUidsCommand";
+import { DedupUidsModal } from "./presentation/modals/DedupUidsModal";
+import type { DedupUidFile } from "@kitelev/exocortex-core";
 import {
   PluginVaultCheckReader,
   listOntologyCandidates,
@@ -3247,6 +3251,49 @@ export default class ExocortexPlugin extends Plugin {
     // see the resolver's busy flag (HIGH-2).
     resolverHolder.commands = quarantineResolverCommands;
 
+    // «Exocortex: Deduplicate uids» (#3676) — Desktop↔Mobile parity for
+    // `exosync dedup-uids`. The sync/resolver dissonance messages (#3675) point
+    // a phone user at "run dedup-uids"; this command surfaces that fix in-plugin,
+    // driving the SAME platform-free core (findDuplicateUidGroups /
+    // planDuplicateUidFix) over `vault.adapter` (no Node fs/git, iOS-capable). A
+    // fix WRITES → D11-excluded against an in-flight sync / profile apply.
+    const dedupUidsCommands = new DedupUidsCommands({
+      listFiles: async () => {
+        const files: DedupUidFile[] = [];
+        for (const file of this.app.vault.getMarkdownFiles()) {
+          try {
+            files.push({
+              path: file.path,
+              content: await this.app.vault.read(file),
+            });
+          } catch {
+            // Skip an unreadable file — the rest of the scan still proceeds.
+          }
+        }
+        return files;
+      },
+      writeFile: async (filePath, content) => {
+        const file = this.app.vault.getAbstractFileByPath(filePath);
+        if (file instanceof TFile) await this.app.vault.modify(file, content);
+      },
+      freshUid: () => crypto.randomUUID(),
+      confirm: (groups) =>
+        new Promise<boolean>((resolve) => {
+          new DedupUidsModal(this.app, groups, resolve).open();
+        }),
+      notify: (message) => this.notifier.info(message),
+      isSyncBusy: () => syncCommands.isBusy(),
+      isSwitchInProgress: () => localDataStore.isSwitchInProgress(),
+      log: (message) => {
+        this.logger.warn(message);
+        this.activityLog.record({
+          category: "exosync",
+          level: "warn",
+          message,
+        });
+      },
+    });
+
     const switchMgr = new ProfileApplyManager({
       app: this.app,
       lockMgr,
@@ -3531,6 +3578,9 @@ export default class ExocortexPlugin extends Plugin {
     registerExoSyncCommands(this, syncCommands);
     // «Exocortex: Resolve sync conflicts» (finding a0a3d1d6).
     registerQuarantineResolverCommand(this, quarantineResolverCommands);
+    // «Exocortex: Deduplicate uids» (#3676) — registered on BOTH platforms
+    // (Desktop↔Mobile Command Parity; the fix runs over vault.adapter).
+    registerDedupUidsCommand(this, dedupUidsCommands);
 
     // RFC f402002b M1.5 — «Validate vault» + «Scaffold validation settings»,
     // registered on BOTH desktop AND mobile (Desktop↔Mobile Command Parity).

--- a/packages/obsidian-plugin/src/infrastructure/adapters/DedupUidsCommands.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/DedupUidsCommands.ts
@@ -1,0 +1,135 @@
+/**
+ * DedupUidsCommands — «Exocortex: Deduplicate uids» palette logic (#3676).
+ *
+ * Desktop↔Mobile Command Parity by construction: `dedup-uids` used to live ONLY
+ * in the CLI (`exosync-quarantine.ts` `runDedupUids`), yet the dissonance
+ * messages (#3675: SyncCommands toast + QuarantineResolverCommands empty-state)
+ * point a phone user at it. This command surfaces the SAME fix in-plugin,
+ * driving the platform-free core {@link findDuplicateUidGroups} /
+ * {@link planDuplicateUidFix} over `vault.adapter` (no Node `fs` — iOS-capable).
+ *
+ * Pure logic — file enumeration (`listFiles`), persistence (`writeFile`), the
+ * confirm modal (`confirm`), the uuid source (`freshUid`) and the Notice
+ * (`notify`) are all injected, so the orchestration (D11 guards, report-first,
+ * confirm-gate, error redaction) is unit-testable without a renderer.
+ *
+ * Semantics mirror the CLI `--fix` path: **report-first** (list dup-uids +
+ * paths) → **confirm-gated** fix that reassigns a fresh uuid to every duplicate
+ * but the first (frontmatter rewrite ONLY — the file is NEVER renamed).
+ *
+ * D11 exclusion (a fix WRITES): refuse to run during a sync or a profile apply,
+ * and refuse re-entry while a fix is in flight.
+ */
+
+import {
+  findDuplicateUidGroups,
+  planDuplicateUidFix,
+  type DedupUidFile,
+  type DedupUidGroup,
+} from "@kitelev/exocortex-core";
+
+export interface DedupUidsCommandsDeps {
+  /**
+   * Enumerate the vault's markdown files as `{path, content}` — mobile-safe via
+   * `app.vault.getMarkdownFiles()` + `app.vault.read()` (no Node `fs`).
+   */
+  listFiles: () => Promise<DedupUidFile[]>;
+  /** Persist a rewritten file by path (`app.vault.modify`). */
+  writeFile: (path: string, content: string) => Promise<void>;
+  /** Fresh uuid generator (injected — deterministic in tests; `crypto.randomUUID` in prod). */
+  freshUid: () => string;
+  /**
+   * Report-first + confirm gate. Receives the duplicate-uid groups (uid +
+   * paths) to render; resolves `true` to apply the fix, `false` to cancel.
+   */
+  confirm: (groups: DedupUidGroup[]) => Promise<boolean>;
+  /** User-facing Notice (route through ObsidianNotificationService). */
+  notify: (message: string) => void;
+  /** D11 — a sync/pull/push in flight (SyncCommands.isBusy). */
+  isSyncBusy?: () => boolean;
+  /** D11 — a profile apply in flight (PluginLocalDataStore). */
+  isSwitchInProgress?: () => boolean;
+  /** Diagnostic sink (warnings / activity-log). Default console. */
+  log?: (message: string) => void;
+}
+
+export class DedupUidsCommands {
+  private readonly deps: DedupUidsCommandsDeps;
+  private running = false;
+
+  constructor(deps: DedupUidsCommandsDeps) {
+    this.deps = deps;
+  }
+
+  /** Sync→apply→dedup exclusion input. */
+  isBusy(): boolean {
+    return this.running;
+  }
+
+  /** «Exocortex: Deduplicate uids» palette entry point. */
+  async invokeDedup(): Promise<void> {
+    if (this.running) {
+      this.deps.notify("Deduplicate is already running");
+      return;
+    }
+    if (this.deps.isSyncBusy?.() === true) {
+      this.deps.notify(
+        "A sync is in progress — deduplicate after it finishes (D11)",
+      );
+      return;
+    }
+    if (this.deps.isSwitchInProgress?.() === true) {
+      this.deps.notify(
+        "A profile apply is in progress — deduplicate after it finishes (D11)",
+      );
+      return;
+    }
+
+    this.running = true;
+    try {
+      const files = await this.deps.listFiles();
+      const groups = findDuplicateUidGroups(files);
+      if (groups.length === 0) {
+        this.deps.notify("No duplicate uids on disk ✅");
+        return;
+      }
+
+      const proceed = await this.deps.confirm(groups);
+      if (!proceed) {
+        this.deps.notify("Deduplicate cancelled — no changes");
+        return;
+      }
+
+      // Apply the SAME plan the CLI `--fix` runs — keep the first path per
+      // group, reassign a fresh uuid to the rest (frontmatter rewrite only).
+      const rewrites = planDuplicateUidFix(files, this.deps.freshUid);
+      let fixed = 0;
+      for (const r of rewrites) {
+        try {
+          await this.deps.writeFile(r.path, r.content);
+          fixed++;
+        } catch (err) {
+          this.logWarn(
+            `[ExoSync] dedup write ${r.path} failed: ${this.errMsg(err)}`,
+          );
+        }
+      }
+      this.deps.notify(
+        `Reassigned ${fixed} duplicate uid(s) to fresh values. Run Sync to propagate.`,
+      );
+    } catch (err) {
+      this.deps.notify(`Deduplicate failed: ${this.errMsg(err)}`);
+      this.logWarn(`[ExoSync] dedup-uids threw: ${this.errMsg(err)}`);
+    } finally {
+      this.running = false;
+    }
+  }
+
+  private errMsg(err: unknown): string {
+    return err instanceof Error ? err.message : String(err);
+  }
+
+  private logWarn(message: string): void {
+    (this.deps.log ?? ((m: string): void => console.warn(m)))(message);
+  }
+}

--- a/packages/obsidian-plugin/src/infrastructure/adapters/DedupUidsCommands.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/DedupUidsCommands.ts
@@ -18,7 +18,13 @@
  * but the first (frontmatter rewrite ONLY — the file is NEVER renamed).
  *
  * D11 exclusion (a fix WRITES): refuse to run during a sync or a profile apply,
- * and refuse re-entry while a fix is in flight.
+ * and refuse re-entry while a fix is in flight. The exclusion is INTENTIONALLY
+ * one-directional — unlike the quarantine resolver (which writes the
+ * device-local watermark, hence the symmetric HIGH-2 guard), dedup rewrites
+ * ONLY markdown frontmatter and never touches the watermark, so it need only
+ * refuse to START during a sync/apply; a sync that begins while a dedup is in
+ * flight sees the ordinary "file edited mid-sync" state that change-detection
+ * already tolerates on the next pass.
  */
 
 import {
@@ -59,11 +65,6 @@ export class DedupUidsCommands {
 
   constructor(deps: DedupUidsCommandsDeps) {
     this.deps = deps;
-  }
-
-  /** Sync→apply→dedup exclusion input. */
-  isBusy(): boolean {
-    return this.running;
   }
 
   /** «Exocortex: Deduplicate uids» palette entry point. */

--- a/packages/obsidian-plugin/src/infrastructure/adapters/registerDedupUidsCommand.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/registerDedupUidsCommand.ts
@@ -1,0 +1,37 @@
+/**
+ * Palette registration for «Exocortex: Deduplicate uids» (#3676 — Desktop↔Mobile
+ * Command Parity for `exosync dedup-uids`). Extracted so the id/name contract is
+ * unit-testable (Obsidian persists hotkeys by command id — the id MUST stay
+ * byte-exact across releases).
+ *
+ * Registered UNCONDITIONALLY on both platforms — the whole point of #3676 is
+ * that a phone user, pointed at "run exosync dedup-uids" by the sync/resolver
+ * dissonance messages, can act on it. No `Platform.isMobile` gating (the fix is
+ * driven over `vault.adapter`, not Node `fs`).
+ *
+ * Obsidian renders the label as «Exocortex: Deduplicate uids».
+ */
+
+import type { DedupUidsCommands } from "./DedupUidsCommands";
+
+/** Structural slice of `Plugin.addCommand` (no `obsidian` runtime import). */
+export interface DedupUidsCommandRegistrar {
+  addCommand(command: {
+    id: string;
+    name: string;
+    callback: () => void;
+  }): unknown;
+}
+
+export function registerDedupUidsCommand(
+  plugin: DedupUidsCommandRegistrar,
+  dedupCommands: DedupUidsCommands,
+): void {
+  plugin.addCommand({
+    id: "exosync-dedup-uids",
+    name: "Deduplicate uids",
+    callback: () => {
+      void dedupCommands.invokeDedup();
+    },
+  });
+}

--- a/packages/obsidian-plugin/src/presentation/modals/DedupUidsModal.ts
+++ b/packages/obsidian-plugin/src/presentation/modals/DedupUidsModal.ts
@@ -42,14 +42,21 @@ export class DedupUidsModal extends Modal {
       text: `Found ${this.groups.length} duplicate uid(s) across ${fileCount} file(s). Reassign a fresh uuid to every duplicate but the first (the files are never renamed)? Run Sync afterwards to propagate.`,
     });
 
-    // The report — each shared uid + the paths declaring it.
+    // The report — each shared uid + the paths declaring it. Paths are shown in
+    // the lexicographic order the fix uses (so "the first" is unambiguous): the
+    // first KEEPS the uid, the rest are re-uuid'd.
     const list = contentEl.createEl("ul");
     for (const group of this.groups) {
       const item = list.createEl("li", {
         text: `${group.uid} — ${group.paths.length} files:`,
       });
       const paths = item.createEl("ul");
-      for (const path of group.paths) paths.createEl("li", { text: path });
+      const ordered = [...group.paths].sort((a, b) => a.localeCompare(b));
+      ordered.forEach((path, i) => {
+        paths.createEl("li", {
+          text: i === 0 ? `${path} (keeps this uid)` : `${path} → fresh uid`,
+        });
+      });
     }
 
     const actions = contentEl.createEl("div", {

--- a/packages/obsidian-plugin/src/presentation/modals/DedupUidsModal.ts
+++ b/packages/obsidian-plugin/src/presentation/modals/DedupUidsModal.ts
@@ -1,0 +1,85 @@
+import { App, Modal } from "obsidian";
+import type { DedupUidGroup } from "@kitelev/exocortex-core";
+
+/**
+ * DedupUidsModal — the report-first + confirm gate for «Exocortex: Deduplicate
+ * uids» (#3676). Renders every duplicate `exo__Asset_uid` and the paths that
+ * declare it (the "report"), then a Cancel / Deduplicate gate. Resolves `true`
+ * only on the explicit Deduplicate button; Esc / Cancel / any close path
+ * resolves `false`. The promise resolves exactly once.
+ *
+ * A plain Obsidian Modal (no renderer dependency) so the command logic stays
+ * testable with an injected `confirm` callback; this class is the presentation
+ * the wiring injects.
+ */
+export class DedupUidsModal extends Modal {
+  private resolved = false;
+  private readonly groups: readonly DedupUidGroup[];
+  private readonly resolveFn: (approved: boolean) => void;
+
+  constructor(
+    app: App,
+    groups: readonly DedupUidGroup[],
+    resolve: (approved: boolean) => void,
+  ) {
+    super(app);
+    this.groups = groups;
+    this.resolveFn = resolve;
+  }
+
+  private settle(value: boolean): void {
+    if (this.resolved) return;
+    this.resolved = true;
+    this.resolveFn(value);
+  }
+
+  override onOpen(): void {
+    const { contentEl } = this;
+    contentEl.createEl("h2", { text: "Deduplicate uids" });
+
+    const fileCount = this.groups.reduce((n, g) => n + g.paths.length, 0);
+    contentEl.createEl("p", {
+      text: `Found ${this.groups.length} duplicate uid(s) across ${fileCount} file(s). Reassign a fresh uuid to every duplicate but the first (the files are never renamed)? Run Sync afterwards to propagate.`,
+    });
+
+    // The report — each shared uid + the paths declaring it.
+    const list = contentEl.createEl("ul");
+    for (const group of this.groups) {
+      const item = list.createEl("li", {
+        text: `${group.uid} — ${group.paths.length} files:`,
+      });
+      const paths = item.createEl("ul");
+      for (const path of group.paths) paths.createEl("li", { text: path });
+    }
+
+    const actions = contentEl.createEl("div", {
+      cls: "modal-button-container",
+    });
+    const cancelBtn = actions.createEl("button", { text: "Cancel" });
+    cancelBtn.setAttribute("aria-label", "Cancel");
+    cancelBtn.addEventListener("click", () => {
+      this.settle(false);
+      this.close();
+    });
+    const confirmBtn = actions.createEl("button", {
+      cls: "mod-cta",
+      text: "Deduplicate",
+    });
+    confirmBtn.setAttribute("aria-label", "Deduplicate");
+    confirmBtn.addEventListener("click", () => {
+      this.settle(true);
+      this.close();
+    });
+
+    try {
+      confirmBtn.focus();
+    } catch {
+      /* focus is best-effort */
+    }
+  }
+
+  override onClose(): void {
+    this.settle(false);
+    this.contentEl.empty();
+  }
+}

--- a/packages/obsidian-plugin/tests/unit/sync/DedupUidsCommands.test.ts
+++ b/packages/obsidian-plugin/tests/unit/sync/DedupUidsCommands.test.ts
@@ -1,0 +1,178 @@
+/**
+ * DedupUidsCommands unit tests (#3676) — the in-plugin «Deduplicate uids»
+ * command, Desktop↔Mobile parity for `exosync dedup-uids`. Drives the REAL
+ * command + the REAL platform-free core (findDuplicateUidGroups /
+ * planDuplicateUidFix) over a production-shape `vault.adapter`-style fake
+ * (an in-memory file map whose write MODIFIES by path — never creates / renames,
+ * mirroring app.vault.modify). Pure logic — no Obsidian renderer.
+ *
+ * Covers: report-first → confirm-gated fix (reassign all-but-first, never
+ * rename, first keeps uid, idempotent re-run), cancel = no-op, empty-state,
+ * and the D11 sync/apply/own-reentry guards.
+ */
+
+import {
+  DedupUidsCommands,
+  type DedupUidsCommandsDeps,
+} from "../../../src/infrastructure/adapters/DedupUidsCommands";
+import type { DedupUidFile, DedupUidGroup } from "@kitelev/exocortex-core";
+
+const fm = (uid: string, body = "body"): string =>
+  `---\nexo__Asset_uid: ${uid}\n---\n\n${body}\n`;
+
+/**
+ * Production-shape vault fake: a path→content map. `listFiles` snapshots it as
+ * {path, content}[] (like app.vault.getMarkdownFiles()+read); `writeFile`
+ * MODIFIES an existing path in place (like app.vault.modify) — it never adds a
+ * new key, so a rename would surface as a failed assertion on the key set.
+ */
+class FakeVault {
+  constructor(private readonly files: Map<string, string>) {}
+  listFiles = async (): Promise<DedupUidFile[]> =>
+    [...this.files.entries()].map(([path, content]) => ({ path, content }));
+  writeFile = async (path: string, content: string): Promise<void> => {
+    if (!this.files.has(path)) {
+      throw new Error(`writeFile to a non-existent path (rename?): ${path}`);
+    }
+    this.files.set(path, content);
+  };
+  snapshot(): Map<string, string> {
+    return new Map(this.files);
+  }
+}
+
+function makeDeps(
+  vault: FakeVault,
+  overrides: Partial<DedupUidsCommandsDeps> = {},
+): {
+  deps: DedupUidsCommandsDeps;
+  notices: string[];
+  confirmGroups: DedupUidGroup[][];
+} {
+  const notices: string[] = [];
+  const confirmGroups: DedupUidGroup[][] = [];
+  let n = 0;
+  const deps: DedupUidsCommandsDeps = {
+    listFiles: vault.listFiles,
+    writeFile: vault.writeFile,
+    freshUid: () => `fresh-uid-${++n}`,
+    confirm: async (groups) => {
+      confirmGroups.push(groups);
+      return true; // default: proceed
+    },
+    notify: (m) => notices.push(m),
+    log: () => undefined,
+    ...overrides,
+  };
+  return { deps, notices, confirmGroups };
+}
+
+describe("DedupUidsCommands", () => {
+  it("the «Deduplicate uids» command reports duplicate uids and, on confirm, reassigns a fresh uuid to every duplicate but the first over vault.adapter — never renaming a file @req:e8a51306-158c-4713-a4c3-979c582bf8c7", async () => {
+    const vault = new FakeVault(
+      new Map([
+        ["a.md", fm("dupe-uid")], // first (sorted) — keeps its uid
+        ["b.md", fm("dupe-uid")], // duplicate — gets a fresh uid
+        ["c.md", fm("solo")], // unique — untouched
+      ]),
+    );
+    const { deps, notices, confirmGroups } = makeDeps(vault);
+    const keysBefore = [...vault.snapshot().keys()];
+
+    await new DedupUidsCommands(deps).invokeDedup();
+
+    // Report-first: the confirm gate was shown the duplicate group (uid + paths).
+    expect(confirmGroups).toEqual([
+      [{ uid: "dupe-uid", paths: ["a.md", "b.md"] }],
+    ]);
+
+    const after = vault.snapshot();
+    // a.md (first sorted) KEEPS the original uid; b.md gets a fresh one.
+    expect(after.get("a.md")).toMatch(/^exo__Asset_uid: dupe-uid$/m);
+    expect(after.get("b.md")).not.toMatch(/^exo__Asset_uid: dupe-uid$/m);
+    expect(after.get("b.md")).toMatch(/^exo__Asset_uid: fresh-uid-1$/m);
+    // The unique file is untouched.
+    expect(after.get("c.md")).toBe(fm("solo"));
+    // No file was renamed — the path set is identical (FakeVault.writeFile
+    // throws on a new key, so this also guards rename by construction).
+    expect([...after.keys()]).toEqual(keysBefore);
+    expect(notices).toContain(
+      "Reassigned 1 duplicate uid(s) to fresh values. Run Sync to propagate.",
+    );
+
+    // Idempotent: a second run finds no duplicates.
+    const second = makeDeps(vault);
+    await new DedupUidsCommands(second.deps).invokeDedup();
+    expect(second.confirmGroups).toEqual([]); // never reached the confirm gate
+    expect(second.notices).toContain("No duplicate uids on disk ✅");
+  });
+
+  it("cancel at the confirm gate writes nothing", async () => {
+    const vault = new FakeVault(
+      new Map([
+        ["a.md", fm("dup")],
+        ["b.md", fm("dup")],
+      ]),
+    );
+    const before = vault.snapshot();
+    const { deps, notices } = makeDeps(vault, { confirm: async () => false });
+    await new DedupUidsCommands(deps).invokeDedup();
+    expect(vault.snapshot()).toEqual(before); // untouched
+    expect(notices).toContain("Deduplicate cancelled — no changes");
+  });
+
+  it("reports the empty-state without opening the confirm gate", async () => {
+    const vault = new FakeVault(new Map([["a.md", fm("u1")], ["b.md", fm("u2")]]));
+    const { deps, notices, confirmGroups } = makeDeps(vault);
+    await new DedupUidsCommands(deps).invokeDedup();
+    expect(confirmGroups).toEqual([]);
+    expect(notices).toContain("No duplicate uids on disk ✅");
+  });
+
+  it("refuses while a sync is in flight (D11) — no scan, no write", async () => {
+    const vault = new FakeVault(new Map([["a.md", fm("dup")], ["b.md", fm("dup")]]));
+    let listed = 0;
+    const { deps, notices } = makeDeps(vault, {
+      isSyncBusy: () => true,
+      listFiles: async () => {
+        listed++;
+        return vault.listFiles();
+      },
+    });
+    await new DedupUidsCommands(deps).invokeDedup();
+    expect(listed).toBe(0);
+    expect(notices).toContain(
+      "A sync is in progress — deduplicate after it finishes (D11)",
+    );
+  });
+
+  it("refuses while a profile apply is in flight (D11)", async () => {
+    const vault = new FakeVault(new Map([["a.md", fm("dup")], ["b.md", fm("dup")]]));
+    const { deps, notices } = makeDeps(vault, {
+      isSwitchInProgress: () => true,
+    });
+    await new DedupUidsCommands(deps).invokeDedup();
+    expect(notices).toContain(
+      "A profile apply is in progress — deduplicate after it finishes (D11)",
+    );
+  });
+
+  it("refuses re-entry while a dedup is already running", async () => {
+    const vault = new FakeVault(new Map([["a.md", fm("dup")], ["b.md", fm("dup")]]));
+    // Hold the confirm gate open so the first invocation parks with running=true.
+    let release!: () => void;
+    const held = new Promise<boolean>((r) => {
+      release = () => r(false); // cancel so the held run writes nothing
+    });
+    const { deps, notices } = makeDeps(vault, { confirm: () => held });
+    const cmd = new DedupUidsCommands(deps);
+
+    const first = cmd.invokeDedup(); // parks at the held confirm gate
+    await Promise.resolve(); // let the first run reach the confirm await
+    await cmd.invokeDedup(); // re-entry while the first is mid-confirm
+    expect(notices).toContain("Deduplicate is already running");
+
+    release();
+    await first;
+  });
+});

--- a/packages/obsidian-plugin/tests/unit/sync/registerDedupUidsCommand.test.ts
+++ b/packages/obsidian-plugin/tests/unit/sync/registerDedupUidsCommand.test.ts
@@ -1,0 +1,35 @@
+/**
+ * registerDedupUidsCommand contract test (#3676) — the command id MUST stay
+ * byte-exact (Obsidian persists hotkeys by id), it is registered on both
+ * platforms (no Platform gate), and the callback MUST drive `invokeDedup`.
+ */
+
+import { registerDedupUidsCommand } from "../../../src/infrastructure/adapters/registerDedupUidsCommand";
+import type { DedupUidsCommands } from "../../../src/infrastructure/adapters/DedupUidsCommands";
+
+describe("registerDedupUidsCommand", () => {
+  it("registers «Deduplicate uids» with the stable id and wires invokeDedup", () => {
+    const registered: Array<{ id: string; name: string; callback: () => void }> =
+      [];
+    const plugin = {
+      addCommand: (cmd: { id: string; name: string; callback: () => void }) => {
+        registered.push(cmd);
+        return cmd;
+      },
+    };
+    let invoked = 0;
+    const commands = {
+      invokeDedup: async () => {
+        invoked++;
+      },
+    } as unknown as DedupUidsCommands;
+
+    registerDedupUidsCommand(plugin, commands);
+
+    expect(registered).toHaveLength(1);
+    expect(registered[0].id).toBe("exosync-dedup-uids");
+    expect(registered[0].name).toBe("Deduplicate uids");
+    registered[0].callback();
+    expect(invoked).toBe(1);
+  });
+});


### PR DESCRIPTION
## What

Adds the in-plugin **«Exocortex: Deduplicate uids»** command for **Desktop↔Mobile Command Parity** (#3676). `dedup-uids` lived only in the CLI (`runDedupUids`), yet the #3675 sync/resolver dissonance messages (`SyncCommands` toast + `QuarantineResolverCommands` empty-state) point a phone user at "run `exosync dedup-uids`" — a command they cannot run on mobile.

## How

- **Shared platform-free core** — extracted `findDuplicateUidGroups` / `planDuplicateUidFix` / `rewriteAssetUid` into `@kitelev/exocortex-core` (`dedupUids.ts`). The plugin command and the refactored CLI `runDedupUids` compose the **same** helper, so both surfaces dedup identically.
- **CLI refactored, no behaviour change** — `runDedupUids` now enumerates `{path, content}` and defers grouping/fix to the shared helper; `rewriteUid` moved to core (`rewriteAssetUid`). 15/15 back-compat suite green.
- **In-plugin command** — `DedupUidsCommands` (injected-deps, unit-testable) + `registerDedupUidsCommand` (stable id `exosync-dedup-uids`) + `DedupUidsModal` (the report-first confirm gate). Registered **unconditionally on both platforms** (⛔ no `Platform.isMobile` gate), driven over `vault.adapter` (`app.vault.getMarkdownFiles`/`read`/`modify` — no Node `fs`, iOS-capable).
- **Semantics** mirror the CLI `--fix` path: report-first (list dup-uids + paths) → confirm-gated fix that reassigns a fresh uuid to every duplicate **but the first** (frontmatter rewrite only — **never renames** the file; first keeps its uid; idempotent re-run). A fix WRITES → **D11**-excluded against an in-flight sync / profile apply.

## Spec-Driven Development

- **Requirement (P2):** `e8a51306-158c-4713-a4c3-979c582bf8c7` in `kitelev/exoas-exo-reqs` (proposed → flips to Active after merge).
- **Revert-verified:** `@req:e8a51306-158c-4713-a4c3-979c582bf8c7` — breaking `planDuplicateUidFix` in `DedupUidsCommands.invokeDedup` to plan nothing makes the bound test **RED** (`b.md` keeps the duplicate uid); restoring → **GREEN**.

## Tests

- `packages/core/tests/unit/services/sync/dedupUids.test.ts` — 8 tests (grouping / keep-first-reassign-rest / idempotency / rewrite scoping).
- `packages/obsidian-plugin/tests/unit/sync/DedupUidsCommands.test.ts` — production-shape `vault.adapter` fake (write modifies by path, throws on rename); report-first, confirm-gated fix, cancel no-op, empty-state, D11 guards. **Carries the `@req` binding.**
- `packages/obsidian-plugin/tests/unit/sync/registerDedupUidsCommand.test.ts` — id/name contract.
- CLI `exosync-quarantine.test.ts` — 15/15 (no regression). Plugin `findRelatedTests` 124/124 incl. `ExocortexPlugin` onload.

Closes #3676
