### PR TITLE
fix(#3773): statement-asset UID from crypto-secure source — never Math.random

### DIFF
--- a/packages/obsidian-plugin/src/presentation/modals/PropertyEditorModal.tsx
+++ b/packages/obsidian-plugin/src/presentation/modals/PropertyEditorModal.tsx
@@ -672,15 +672,25 @@ export class PropertyEditorModal extends Modal {
 }
 
 /** A fresh lowercase UUID for a new statement asset (no `Date`/random in the pure model). */
-function generateStatementUid(): string {
-  const c = (globalThis as { crypto?: { randomUUID?: () => string } }).crypto;
+export function generateStatementUid(): string {
+  const c = (
+    globalThis as {
+      crypto?: {
+        randomUUID?: () => string;
+        getRandomValues?: <T extends ArrayBufferView>(array: T) => T;
+      };
+    }
+  ).crypto;
   if (c?.randomUUID) return c.randomUUID().toLowerCase();
-  // Fallback (non-secure) — only when crypto.randomUUID is unavailable.
-  return "xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx".replace(/[xy]/g, (ch) => {
-    const r = Math.floor(Math.random() * 16);
-    const v = ch === "x" ? r : (r & 0x3) | 0x8;
-    return v.toString(16);
-  });
+  // Fallback — crypto.getRandomValues (crypto-secure; broader availability than
+  // randomUUID, incl. older mobile WebViews). Never Math.random: insecure for
+  // identifiers (CodeQL js/insecure-randomness).
+  const bytes = new Uint8Array(16);
+  c?.getRandomValues?.(bytes);
+  bytes[6] = (bytes[6] & 0x0f) | 0x40; // RFC 4122 version 4
+  bytes[8] = (bytes[8] & 0x3f) | 0x80; // RFC 4122 variant
+  const hex = Array.from(bytes, (b) => b.toString(16).padStart(2, "0")).join("");
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
 }
 
 /**

--- a/packages/obsidian-plugin/tests/unit/generateStatementUid.test.ts
+++ b/packages/obsidian-plugin/tests/unit/generateStatementUid.test.ts
@@ -1,0 +1,54 @@
+import { generateStatementUid } from "../../src/presentation/modals/PropertyEditorModal";
+
+/**
+ * @req:d8ac0a94-d1aa-4cc4-b4af-471898dc15a1
+ *
+ * The statement-asset UID generator must draw randomness from a crypto-secure
+ * source (crypto.randomUUID / crypto.getRandomValues) — NEVER Math.random
+ * (CodeQL js/insecure-randomness, alert 313). Behaviour preserved: a valid
+ * lowercase RFC-4122 v4 UUID.
+ */
+const UUID_V4 =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+
+describe("generateStatementUid", () => {
+  const realCrypto = globalThis.crypto;
+
+  afterEach(() => {
+    Object.defineProperty(globalThis, "crypto", {
+      configurable: true,
+      value: realCrypto,
+    });
+    jest.restoreAllMocks();
+  });
+
+  it("returns a valid lowercase v4 UUID via crypto.randomUUID (primary path)", () => {
+    const id = generateStatementUid();
+    expect(id).toMatch(UUID_V4);
+    expect(id).toBe(id.toLowerCase());
+  });
+
+  it("@req:d8ac0a94-d1aa-4cc4-b4af-471898dc15a1 falls back to crypto.getRandomValues — never Math.random — when randomUUID is unavailable", () => {
+    // Simulate an environment (e.g. an older mobile WebView) where crypto exists
+    // but crypto.randomUUID does not — forcing the fallback path.
+    const getRandomValues = jest.fn((arr: Uint8Array) => {
+      for (let i = 0; i < arr.length; i++) arr[i] = (i * 37 + 11) & 0xff;
+      return arr;
+    });
+    Object.defineProperty(globalThis, "crypto", {
+      configurable: true,
+      value: { getRandomValues },
+    });
+    const mathRandom = jest.spyOn(Math, "random");
+
+    const id = generateStatementUid();
+
+    // crypto-secure source was used …
+    expect(getRandomValues).toHaveBeenCalled();
+    // … and the insecure source was NOT (this assertion is what reverts to RED
+    // on the old Math.random fallback).
+    expect(mathRandom).not.toHaveBeenCalled();
+    // … behaviour preserved: still a valid lowercase v4 UUID.
+    expect(id).toMatch(UUID_V4);
+  });
+});


### PR DESCRIPTION
## P0 / security / CodeQL `js/insecure-randomness` (alert 313)

`PropertyEditorModal.generateStatementUid()` minted a new `exo__Statement`
asset's v4 UUID via a `Math.random()` fallback (used when `crypto.randomUUID`
is unavailable). CodeQL flags `Math.random()` for identifiers as predictable
randomness (alert 313, severity high).

**Fix (surgical, 1 file):** replace the fallback with `crypto.getRandomValues`
— crypto-secure and universally available on **both** desktop (Electron) and
mobile (Obsidian WebView). No `Math.random()` remains in the file. Behaviour
preserved: still a valid lowercase RFC-4122 v4 UUID.

### Verification (req-first SDD)
- Req: `d8ac0a94-d1aa-4cc4-b4af-471898dc15a1` (exoas-exo-reqs, P0, Approved)
- Production-shape test `generateStatementUid.test.ts` (`@req:d8ac0a94-…`):
  fallback path stubs crypto with `getRandomValues` but no `randomUUID`,
  asserts `getRandomValues` called, `Math.random` **not** called, output is a
  valid lowercase v4 UUID.
- **Revert-verified:** reverting the fallback to `Math.random` → test **RED**
  (getRandomValues called 0×); `crypto.getRandomValues` → **GREEN**.
- typecheck clean · eslint clean · test-antipattern ratchet 55/55 (behaviour-asserts) · related suites green.

### DoD (#3773)
- [x] alert source removed (no new alerts: getRandomValues, no unused imports)
- [x] tests pass (revert-verified)
- [x] desktop + mobile safe (getRandomValues universal)

Closes #3773