### PR TITLE
feat(layout): precondition ASK gating for exo-layout action buttons (#3654 Part 1)

### DIFF
--- a/packages/obsidian-plugin/src/application/api/SPARQLApi.ts
+++ b/packages/obsidian-plugin/src/application/api/SPARQLApi.ts
@@ -231,6 +231,32 @@ export class SPARQLApi {
   }
 
   /**
+   * Executes a SPARQL **ASK** query and returns its boolean result.
+   *
+   * `query()` cannot serve an ASK: its contract is `SolutionMapping[]`, so it
+   * runs the ASK and discards the boolean. This method exposes the boolean the
+   * executor already computes — used to gate `exo-layout` action buttons by
+   * their `exo__Precondition_sparql` ASK (#3654 Part 1): `true` ⇒ button shown,
+   * `false` ⇒ hidden.
+   *
+   * @param sparql - A SPARQL ASK query string.
+   * @returns Promise resolving to the ASK boolean.
+   * @throws {ValidationError} If the query is not a valid ASK query.
+   * @throws {ServiceError} If the query service is not initialized or execution fails.
+   *
+   * @example
+   * ```typescript
+   * const holds = await api.ask(`
+   *   PREFIX ems: <https://exocortex.my/ontology/ems#>
+   *   ASK { <obsidian://vault/tasks/t1.md> ems:Effort_status ?s }
+   * `);
+   * ```
+   */
+  async ask(sparql: string): Promise<boolean> {
+    return this.queryService.ask(sparql);
+  }
+
+  /**
    * Returns the underlying in-memory triple store.
    *
    * Provides direct access to the RDF triple store for advanced operations

--- a/packages/obsidian-plugin/src/application/layout/LayoutService.ts
+++ b/packages/obsidian-plugin/src/application/layout/LayoutService.ts
@@ -517,7 +517,14 @@ export class LayoutService {
       rows.push({
         id: assetId,
         path: assetPath,
-        metadata: solution.toJSON(),
+        // Carry the store's ACTUAL subject IRI (the `?asset` binding value) so
+        // the action-button precondition gate (#3654) substitutes the right
+        // `$target`. Recomputing it from `path` downstream via
+        // `encodeURIComponent` over-encodes slashes (`/` → `%2F`) and never
+        // matches the store subject (`encodeURI`), silently hiding every
+        // button. `uri` overrides any `uri` key that `solution.toJSON()` might
+        // carry from a bound variable named `uri`.
+        metadata: { ...solution.toJSON(), uri: assetUri },
         values,
       });
     }

--- a/packages/obsidian-plugin/src/application/processors/LayoutCodeBlockProcessor.ts
+++ b/packages/obsidian-plugin/src/application/processors/LayoutCodeBlockProcessor.ts
@@ -406,6 +406,20 @@ export class LayoutCodeBlockProcessor {
           );
         },
         getAssetLabel: (path: string) => this.wikilinkResolver.getAssetLabel(path),
+        // Gate action buttons by their `exo__Precondition_sparql` ASK (#3654
+        // Part 1): true ⇒ shown, false ⇒ hidden. Previously unwired → every
+        // button defaulted visible. The ASK boolean is surfaced via the new
+        // `SPARQLApi.ask` (the executor already computed it; `query()` discarded
+        // it). `$target` resolves to the row's REAL store subject IRI (threaded
+        // through `LayoutService` metadata), so the ASK matches the live asset.
+        onCheckPrecondition: (sparql: string, assetUri: string) =>
+          this.checkPrecondition(sparql, assetUri),
+        // NOTE: `onExecuteCommand` is intentionally NOT wired — the raw-SPARQL-
+        // UPDATE execution engine is #3654 Part 2 (deferred; the issue's own
+        // recommendation is to route layout actions through structural exocmd
+        // commands rather than build a parallel UPDATE engine). Until then a
+        // click on a precondition-passing button surfaces the #3628
+        // "no executor available" notice via onError below.
         // Surface action-button failures to the user instead of failing silently
         // (#3628). Routed through the central notifier (eslint forbids `new
         // Notice` elsewhere).
@@ -414,6 +428,35 @@ export class LayoutCodeBlockProcessor {
         },
       })
     );
+  }
+
+  /**
+   * Evaluates an `exo-layout` action button's `exo__Precondition_sparql` ASK to
+   * decide whether the button is shown (#3654 Part 1).
+   *
+   * Substitutes `$target` → `<assetUri>` (the same text-substitution convention
+   * as the structural `PreconditionEvaluator.substituteVariables`) and runs the
+   * ASK via {@link SPARQLApi.ask}. `assetUri` is the store's real subject IRI
+   * (threaded through `LayoutService.transformToTableRows` → row metadata), so
+   * the ASK evaluates against the asset that actually exists in the graph.
+   *
+   * Only `$target` is substituted; date macros (`$now`, `$today`, …) are not
+   * supported on this niche layout-action surface — a precondition using one
+   * would fail to parse, which the caller (`ActionsRenderer`) catches and treats
+   * as "hide the button" (conservative, never a false-positive show).
+   */
+  private async checkPrecondition(
+    sparql: string,
+    assetUri: string
+  ): Promise<boolean> {
+    const api = this.plugin.getSPARQLApi();
+    if (!api) {
+      throw new Error(
+        "SPARQL API is not available for layout-action preconditions"
+      );
+    }
+    const substituted = sparql.replace(/\$target/g, `<${assetUri}>`);
+    return api.ask(substituted);
   }
 
   /**

--- a/packages/obsidian-plugin/src/application/services/SPARQLQueryService.ts
+++ b/packages/obsidian-plugin/src/application/services/SPARQLQueryService.ts
@@ -165,6 +165,87 @@ export class SPARQLQueryService {
   }
 
   /**
+   * Executes a SPARQL **ASK** query and returns its boolean result.
+   *
+   * Unlike {@link query} — whose contract is `SolutionMapping[]`, so for an ASK
+   * it runs `executor.executeAsk(algebra)` and **discards** the boolean,
+   * returning `[]` — this method surfaces the boolean the executor already
+   * computes (`QueryExecutor.executeAsk → Promise<boolean>`). It exists to gate
+   * `exo-layout` action buttons by their `exo__Precondition_sparql` ASK (#3654
+   * Part 1): `true` ⇒ the button is shown, `false` ⇒ hidden.
+   *
+   * @param queryString - A SPARQL ASK query.
+   * @returns the ASK boolean.
+   * @throws {ValidationError} if the query is not a valid ASK query (or fails to parse).
+   * @throws {ServiceError} if the service is not initialized or execution fails.
+   */
+  async ask(queryString: string): Promise<boolean> {
+    if (!this.isInitialized) {
+      await this.initialize();
+    }
+
+    if (!this.executor) {
+      throw new ServiceError(
+        "query executor not initialized",
+        {
+          service: "SPARQLQueryService",
+          operation: "ask",
+        }
+      );
+    }
+
+    try {
+      const ast: SPARQLQuery = this.parser.parse(queryString);
+
+      let algebra: AlgebraOperation = this.translator.translate(ast);
+      algebra = this.optimizer.optimize(algebra);
+
+      if (!this.executor.isAskQuery(algebra)) {
+        throw new ValidationError(
+          "ask() requires an ASK query",
+          { query: queryString }
+        );
+      }
+
+      return await this.executor.executeAsk(algebra);
+    } catch (error) {
+      // Pre-built domain errors (a non-ASK ValidationError above, or a
+      // ServiceError) pass through unchanged; mirror query()'s normalisation
+      // for everything else.
+      if (error instanceof ServiceError || error instanceof ValidationError) {
+        this.errorHandler.handle(error);
+        throw error;
+      }
+
+      const errorMessage = error instanceof Error ? error.message : String(error);
+
+      if (errorMessage.includes("parse") || errorMessage.includes("syntax")) {
+        const validationError = new ValidationError(
+          "invalid sparql query",
+          {
+            query: queryString,
+            originalError: errorMessage,
+          }
+        );
+        this.errorHandler.handle(validationError);
+        throw validationError;
+      }
+
+      const serviceError = new ServiceError(
+        "sparql ask execution failed",
+        {
+          service: "SPARQLQueryService",
+          operation: "ask",
+          query: queryString,
+          originalError: errorMessage,
+        }
+      );
+      this.errorHandler.handle(serviceError);
+      throw serviceError;
+    }
+  }
+
+  /**
    * Returns true once the underlying triple store is fully populated and
    * ready to execute SPARQL queries.
    *

--- a/packages/obsidian-plugin/tests/unit/application/layout/LayoutServiceRowUri.test.ts
+++ b/packages/obsidian-plugin/tests/unit/application/layout/LayoutServiceRowUri.test.ts
@@ -1,0 +1,60 @@
+/**
+ * LayoutService.transformToTableRows — threads the store's real `?asset`
+ * subject IRI into row metadata so the action-button precondition gate (#3654)
+ * substitutes the correct `$target`.
+ *
+ * Without this, the downstream `TableLayoutRenderer` recomputes the asset IRI
+ * from `row.path` via `encodeURIComponent` (over-encoding slashes → `%2F`),
+ * which never matches the store subject (`encodeURI`) → every precondition ASK
+ * evaluates false → every button silently hidden (mis-gating). This guards the
+ * fix at its source.
+ *
+ * Binds req c5542956-dded-4892-b35c-011a03227562.
+ */
+import type { App } from "obsidian";
+import { SolutionMapping, IRI } from "@kitelev/exocortex-core";
+import type { IVaultAdapter } from "@kitelev/exocortex-core";
+import { LayoutService } from "../../../../src/application/layout/LayoutService";
+
+const REQ = "@req:c5542956-dded-4892-b35c-011a03227562";
+
+interface RowShape {
+  path: string;
+  metadata: Record<string, unknown>;
+}
+interface RowBuilder {
+  transformToTableRows(
+    solutions: SolutionMapping[],
+    columns: unknown[],
+    variables: string[],
+  ): RowShape[];
+}
+
+// `transformToTableRows` is a pure transformation (no app/adapter access), so a
+// minimal stub App/adapter is sufficient — the service is never initialised.
+const stubApp = {
+  vault: { getMarkdownFiles: () => [] },
+  metadataCache: {},
+} as unknown as App;
+const stubAdapter = {} as unknown as IVaultAdapter;
+
+describe(`LayoutService row metadata.uri carries the real store IRI [${REQ}]`, () => {
+  it(`sets row.metadata.uri to the store's actual ?asset subject IRI (slashes preserved, not %2F) [${REQ}]`, () => {
+    const service = new LayoutService(stubApp, stubAdapter);
+
+    const assetIri = "obsidian://vault/assetspaces/ems/task-alpha.md";
+    const solution = new SolutionMapping();
+    solution.set("asset", new IRI(assetIri));
+
+    const rows = (
+      service as unknown as RowBuilder
+    ).transformToTableRows([solution], [], []);
+
+    expect(rows).toHaveLength(1);
+    // The precondition gate substitutes `$target` with this exact value, so it
+    // MUST be the store subject form (encodeURI — slashes preserved), never the
+    // over-encoded `encodeURIComponent` recompute.
+    expect(rows[0].metadata.uri).toBe(assetIri);
+    expect(String(rows[0].metadata.uri)).not.toContain("%2F");
+  });
+});

--- a/packages/obsidian-plugin/tests/unit/application/processors/LayoutActionPreconditionGating.integration.test.ts
+++ b/packages/obsidian-plugin/tests/unit/application/processors/LayoutActionPreconditionGating.integration.test.ts
@@ -1,0 +1,148 @@
+/**
+ * exo-layout action button precondition ASK gating — INTEGRATION (#3654 Part 1).
+ *
+ * Real engine end-to-end: a realistic in-memory Obsidian `App` (vault +
+ * metadataCache holding actual markdown frontmatter) is driven through the REAL
+ * `SPARQLApi` (REAL `NoteToRDFConverter` → `InMemoryTripleStore` → ExoQL
+ * parser/translator/optimizer/executor) and the REAL
+ * `LayoutCodeBlockProcessor.checkPrecondition` gate. Only the Obsidian platform
+ * boundary (vault/metadataCache) is faked — the correct seam per
+ * test-fixture-realism; nothing in the engine is mocked. The asset's `$target`
+ * IRI is the store's ACTUAL `?asset` subject value, not a synthetic shape.
+ *
+ * Binds req c5542956-dded-4892-b35c-011a03227562.
+ */
+import { TFile } from "obsidian";
+import type { App } from "obsidian";
+import { SPARQLApi } from "../../../../src/application/api/SPARQLApi";
+import { LayoutCodeBlockProcessor } from "../../../../src/application/processors/LayoutCodeBlockProcessor";
+import type ExocortexPlugin from "../../../../src/ExocortexPlugin";
+
+const EXO = "https://exocortex.my/ontology/exo#";
+const REQ = "@req:c5542956-dded-4892-b35c-011a03227562";
+
+interface SeedFile {
+  path: string;
+  frontmatter: Record<string, unknown>;
+}
+
+function buildApp(seed: SeedFile[]): App {
+  const files: TFile[] = [];
+  const fmByPath = new Map<string, Record<string, unknown>>();
+  const contentByPath = new Map<string, string>();
+  const renderYaml = (fm: Record<string, unknown>): string =>
+    "---\n" +
+    Object.entries(fm)
+      .map(([k, v]) => `${k}: ${JSON.stringify(v)}`)
+      .join("\n") +
+    "\n---\n";
+  for (const f of seed) {
+    const tfile = new TFile(f.path);
+    files.push(tfile);
+    fmByPath.set(f.path, f.frontmatter);
+    contentByPath.set(f.path, renderYaml(f.frontmatter));
+  }
+  const vault = {
+    getMarkdownFiles: () => files.filter((f) => f.extension === "md"),
+    getAbstractFileByPath: (p: string) =>
+      files.find((f) => f.path === p) ?? null,
+    read: async (f: TFile) => contentByPath.get(f.path) ?? "",
+    on: () => ({}) as unknown,
+    off: () => {},
+    offref: () => {},
+  };
+  const metadataCache = {
+    getFileCache: (f: TFile) => {
+      const fm = fmByPath.get(f.path);
+      return fm ? { frontmatter: fm } : null;
+    },
+    getFirstLinkpathDest: (linkpath: string) => {
+      const base = linkpath.replace(/\.md$/, "");
+      return files.find((f) => f.basename === base) ?? null;
+    },
+    resolvedLinks: {},
+  };
+  return { vault, metadataCache } as unknown as App;
+}
+
+// A real asset whose vault path contains SLASHES — this is what makes the
+// dual-IRI form matter (encodeURI keeps `/`; encodeURIComponent → `%2F`).
+const TASK_ALPHA: SeedFile = {
+  path: "assetspaces/ems/task-alpha.md",
+  frontmatter: {
+    exo__Asset_uid: "task-alpha-uid",
+    exo__Asset_label: "Alpha Task",
+    exo__Instance_class: ["[[ems__Task]]"],
+  },
+};
+
+interface PreconditionGate {
+  checkPrecondition(sparql: string, assetUri: string): Promise<boolean>;
+}
+
+describe(`LayoutCodeBlockProcessor — action button precondition ASK gating [${REQ}]`, () => {
+  let api: SPARQLApi;
+  let processor: LayoutCodeBlockProcessor;
+  let assetIri: string;
+
+  beforeEach(async () => {
+    const app = buildApp([TASK_ALPHA]);
+    const apiPlugin = {
+      app,
+      settings: { excludedFolders: [] },
+    } as unknown as ExocortexPlugin;
+    api = new SPARQLApi(apiPlugin);
+
+    // The store's REAL subject IRI for the asset — exactly the `?asset` value
+    // LayoutService threads into the row's metadata (production-shape).
+    const res = await api.query(
+      `PREFIX exo: <${EXO}> SELECT ?s WHERE { ?s exo:Asset_label "Alpha Task" }`,
+    );
+    assetIri = String((res.bindings[0].get("s") as { value: unknown }).value);
+
+    const procPlugin = {
+      app,
+      getSPARQLApi: () => api,
+      notifier: { error: () => {} },
+    } as unknown as ExocortexPlugin;
+    processor = new LayoutCodeBlockProcessor(procPlugin);
+  });
+
+  afterEach(async () => {
+    processor.cleanup();
+    await api.dispose();
+  });
+
+  const check = (sparql: string, iri: string): Promise<boolean> =>
+    (processor as unknown as PreconditionGate).checkPrecondition(sparql, iri);
+
+  it(`shows a button whose precondition ASK holds for the asset [${REQ}]`, async () => {
+    // Every parsed asset carries exo:Asset_label → the ASK holds → button shown.
+    const ask = `PREFIX exo: <${EXO}> ASK { $target exo:Asset_label ?l }`;
+    await expect(check(ask, assetIri)).resolves.toBe(true);
+  });
+
+  it(`hides a button whose precondition ASK does not hold for the asset [${REQ}]`, async () => {
+    // No asset carries this predicate → the ASK is false → button hidden.
+    const ask = `PREFIX exo: <${EXO}> ASK { $target exo:DefinitelyNotAPredicate ?l }`;
+    await expect(check(ask, assetIri)).resolves.toBe(false);
+  });
+
+  it(`substitutes $target with the store's real subject IRI — the over-encoded form mis-gates [${REQ}]`, async () => {
+    const ask = `PREFIX exo: <${EXO}> ASK { $target exo:Asset_label ?l }`;
+
+    // The REAL store IRI (encodeURI: slashes preserved) matches the subject.
+    expect(assetIri).toBe("obsidian://vault/assetspaces/ems/task-alpha.md");
+    await expect(check(ask, assetIri)).resolves.toBe(true);
+
+    // The over-encoded form (encodeURIComponent → `%2F`) is a DIFFERENT,
+    // non-existent subject → the SAME true precondition silently evaluates
+    // false. This is the mis-gating the LayoutService metadata threading
+    // prevents by passing the store's real `?asset` IRI downstream.
+    const overEncoded = `obsidian://vault/${encodeURIComponent(
+      "assetspaces/ems/task-alpha.md",
+    )}`;
+    expect(overEncoded).toContain("%2F");
+    await expect(check(ask, overEncoded)).resolves.toBe(false);
+  });
+});


### PR DESCRIPTION
## What

Wires **precondition ASK gating** for `exo-layout` table action buttons (#3654 **Part 1**): a button whose `exo__Precondition_sparql` ASK evaluates **false** is hidden, **true** is shown. Previously `onCheckPrecondition` was unwired → every button defaulted visible.

## Why it was broken

1. `SPARQLQueryService.query()` runs an ASK but its contract is `SolutionMapping[]`, so it calls `executor.executeAsk(algebra)` and **discards the boolean** (`return []`). There was no way to get the ASK result.
2. `LayoutCodeBlockProcessor.renderTableLayout` created `TableLayoutRenderer` **without** `onCheckPrecondition`.

## Changes

- **`SPARQLQueryService.ask(query): Promise<boolean>`** — surfaces the boolean the executor already computes (`QueryExecutor.executeAsk`). Non-ASK input throws `ValidationError`.
- **`SPARQLApi.ask()`** — passthrough.
- **`LayoutCodeBlockProcessor.checkPrecondition`** — substitutes `$target` → `<assetIRI>` (the same text convention as the structural `PreconditionEvaluator.substituteVariables`) and runs via `SPARQLApi.ask`; wired as `onCheckPrecondition` in `renderTableLayout`.
- **`LayoutService.transformToTableRows`** threads the store's **real `?asset` subject IRI** into `row.metadata.uri`. `TableLayoutRenderer` previously recomputed the IRI from `row.path` via `encodeURIComponent`, which over-encodes slashes (`/` → `%2F`) and **never matches the store subject** (`encodeURI`) — so every precondition ASK against a real (slashed-path) asset would evaluate false and **silently hide every button** (mis-gating). Threading the store's own returned IRI is dual-IRI-correct by construction.

`onExecuteCommand` stays **intentionally unwired** — the raw-SPARQL-UPDATE execution engine is **Part 2 (#3777, deferred)**. Per #3654's own recommendation + the design spike, the right path is to route layout actions through structural exocmd commands (`CommandExecutionFlow`), not build a parallel raw-UPDATE engine. A precondition-passing click still surfaces the #3628 "no executor available" Notice (honest, not a silent no-op).

## Tests (production-shape, real engine)

`LayoutActionPreconditionGating.integration.test.ts` drives the REAL engine (NoteToRDFConverter → InMemoryTripleStore → ExoQL executor) through `LayoutCodeBlockProcessor.checkPrecondition`:
- ASK holds → button shown; ASK does not hold → hidden.
- dual-IRI: the real store IRI matches; the over-encoded `encodeURIComponent` form mis-gates (false).

`LayoutServiceRowUri.test.ts` guards the `metadata.uri` threading (real IRI, no `%2F`).

The existing `ActionsRenderer` tests already cover hide-on-false / show-on-true given the boolean.

**Revert-verified** ([[integration-test-revert-verify]]): neutralising `SPARQLQueryService.ask`'s body to always-`true` reds the two false-precondition assertions; restored → green.

## Requirement (SDD)

Req: `c5542956-dded-4892-b35c-011a03227562` (req__Requirement, P2, Integration binding) — `exoas-exo-reqs`, status flips → Active **after** this PR merges (binding-in-main first).

Closes #3654 (Part 1). Part 2 → #3777.
