### PR TITLE
feat(create_instance): auto-stamp planned timestamps from a time-bearing prototype + target-date selection (ec15f83e)

### DIFF
--- a/packages/core/src/services/GroundingExecutor.ts
+++ b/packages/core/src/services/GroundingExecutor.ts
@@ -1073,6 +1073,12 @@ export class GroundingExecutor {
         // `label`): it never becomes a frontmatter key; instead it is written
         // as the created asset's markdown body below.
         if (key === "body") continue;
+        // Feature ec15f83e / req 57b03ab3 — `plannedDate` is a reserved engine
+        // input (the plugin modal's date field / the CLI `--date` parameter):
+        // it never becomes a frontmatter key; it selects the instance's target
+        // DATE for `$today`/label resolution + the prototype-time planned-
+        // timestamp stamp (see applyPrototypeTimePropagation). Defaults to today.
+        if (key === "plannedDate") continue;
         if (value === null || value === undefined) continue;
         properties[key] = value;
       }
@@ -1113,6 +1119,12 @@ export class GroundingExecutor {
         properties[grounding.linkBackProperty] = `"[[${backLinkTarget}]]"`;
       }
     }
+
+    // Feature ec15f83e / req 57b03ab3 — when the $target prototype declares a
+    // time-of-day on itself (ems__EffortPrototype_startTime/_endTime), stamp
+    // the instance's planned timestamps for the chosen date (default today).
+    // No-op for prototypes / create flows without a time-of-day.
+    this.applyPrototypeTimePropagation(properties, targetFm, userInput);
 
     // Determine uid for filename — read from properties (PropertyDefault wrote
     // it via $randomUUIDv4 token; top-up guaranteed it's set otherwise).
@@ -1160,6 +1172,90 @@ export class GroundingExecutor {
     // — actually opening the file is wired by the platform adapter through
     // CommandExecutionFlow's optional IFileOpener dependency.
     return { success: true, openPath: filePath };
+  }
+
+  /**
+   * Feature ec15f83e / req 57b03ab3 — the target DATE for a newly-created
+   * instance: the reserved `plannedDate` userInput (the plugin modal's date
+   * field / the CLI `--date` parameter) when a valid `YYYY-MM-DD`; otherwise
+   * today (same source as the `$today` token — `clock.now()` UTC date slice).
+   * Drives BOTH the date-denoting label (`$today` in the labelTemplate) AND the
+   * planned timestamps, so the two never disagree. `isoNow` lets callers reuse
+   * an already-computed `clock.now().toISOString()` (substituteVariables) to
+   * avoid a second clock read; both code paths resolve `plannedDate` identically.
+   */
+  private resolveInstanceDate(userInput?: UserInput, isoNow?: string): string {
+    const explicit = GroundingExecutor.firstScalar(
+      userInput?.["plannedDate"] as string | string[] | undefined,
+    );
+    if (explicit && /^\d{4}-\d{2}-\d{2}$/.test(explicit)) return explicit;
+    return (isoNow ?? this.clock.now().toISOString()).slice(0, 10);
+  }
+
+  /**
+   * Feature ec15f83e / req 57b03ab3 — when the $target prototype declares a
+   * time-of-day on itself (`ems__EffortPrototype_startTime`, optionally
+   * `_endTime`, in `"HH:MM"` form), stamp the new instance's
+   * `ems__Effort_plannedStartTimestamp` (and `_plannedEndTimestamp`) =
+   * {@link resolveInstanceDate} + that time, as a FULL timezone-naive local
+   * dateTime `"YYYY-MM-DDTHH:MM:SS"` (Asia/Almaty convention — matches the
+   * existing `ems__Effort_plannedStartTimestamp` frontmatter shape).
+   *
+   * No-op when the prototype declares no `startTime` → zero regression for
+   * prototypes / create flows without a time-of-day. Never overwrites a planned
+   * timestamp that an explicit `userInput` already wrote into `properties` (the
+   * prototype time is a default, not an override).
+   */
+  private applyPrototypeTimePropagation(
+    properties: Record<string, unknown>,
+    targetFm: Record<string, string | string[]> | null,
+    userInput?: UserInput,
+  ): void {
+    if (!targetFm) return;
+    const startTime = GroundingExecutor.firstScalar(
+      targetFm["ems__EffortPrototype_startTime"],
+    );
+    if (!startTime) return; // prototype declares no time-of-day → no-op
+    const instanceDate = this.resolveInstanceDate(userInput);
+    if (properties["ems__Effort_plannedStartTimestamp"] === undefined) {
+      properties["ems__Effort_plannedStartTimestamp"] =
+        GroundingExecutor.combineDateAndTime(instanceDate, startTime);
+    }
+    const endTime = GroundingExecutor.firstScalar(
+      targetFm["ems__EffortPrototype_endTime"],
+    );
+    if (endTime && properties["ems__Effort_plannedEndTimestamp"] === undefined) {
+      properties["ems__Effort_plannedEndTimestamp"] =
+        GroundingExecutor.combineDateAndTime(instanceDate, endTime);
+    }
+  }
+
+  /**
+   * First scalar of a frontmatter value (`string | string[]`), trimmed with any
+   * surrounding YAML quotes stripped. Returns null for empty / non-string.
+   */
+  private static firstScalar(
+    value: string | string[] | undefined,
+  ): string | null {
+    if (value === undefined || value === null) return null;
+    const raw = Array.isArray(value) ? value[0] : value;
+    if (typeof raw !== "string") return null;
+    const trimmed = raw
+      .trim()
+      .replace(/^["'](.*)["']$/, "$1")
+      .trim();
+    return trimmed.length > 0 ? trimmed : null;
+  }
+
+  /**
+   * Combine a `YYYY-MM-DD` date with a `"HH:MM"` (or `"HH:MM:SS"`) time-of-day
+   * into a full timezone-naive local dateTime `"YYYY-MM-DDTHH:MM:SS"`. A bare
+   * `HH:MM` gets `:00` seconds appended; an already-`HH:MM:SS` value passes
+   * through. NEVER emits a trailing timezone offset.
+   */
+  private static combineDateAndTime(date: string, timeOfDay: string): string {
+    const time = /^\d{2}:\d{2}$/.test(timeOfDay) ? `${timeOfDay}:00` : timeOfDay;
+    return `${date}T${time}`;
   }
 
   /**
@@ -1828,7 +1924,12 @@ export class GroundingExecutor {
     const date = this.clock.now();
     const now = date.toISOString();
     const nowLocal = DateFormatter.toLocalTimestamp(date);
-    const today = now.slice(0, 10);
+    // Feature ec15f83e / req 57b03ab3 — `$today` denotes the instance's nominal
+    // DAY, which is the chosen target date (reserved `plannedDate` userInput),
+    // defaulting to today. `$now`/`$nowLocal`/`$nowCompact` stay the real clock
+    // time (createdAt etc. unaffected). When no plannedDate is supplied this is
+    // identical to the prior `now.slice(0, 10)` behaviour (zero regression).
+    const today = this.resolveInstanceDate(userInput, now);
     const todayStart = `${today}T00:00:00`;
     // RFC ce27e55d $nowCompact: filename-safe minute-precision form derived
     // from nowLocal slices. nowLocal = "YYYY-MM-DDTHH:mm:ss" → indices 0..10

--- a/packages/core/src/services/GroundingExecutor.ts
+++ b/packages/core/src/services/GroundingExecutor.ts
@@ -1205,6 +1205,12 @@ export class GroundingExecutor {
    * prototypes / create flows without a time-of-day. Never overwrites a planned
    * timestamp that an explicit `userInput` already wrote into `properties` (the
    * prototype time is a default, not an override).
+   *
+   * Reads from `targetFm`, which is only populated when `needsTargetRead` is
+   * true (InheritanceRule / `__SUBSTITUTE` PropertyDefault / `$target.`
+   * labelTemplate). For the real prototype-instance flow this always holds —
+   * the `exo__Asset_prototype` backlink InheritanceRule forces the read — so a
+   * time-bearing prototype is always seen; a null `targetFm` is a safe no-op.
    */
   private applyPrototypeTimePropagation(
     properties: Record<string, unknown>,
@@ -1218,15 +1224,30 @@ export class GroundingExecutor {
     if (!startTime) return; // prototype declares no time-of-day → no-op
     const instanceDate = this.resolveInstanceDate(userInput);
     if (properties["ems__Effort_plannedStartTimestamp"] === undefined) {
-      properties["ems__Effort_plannedStartTimestamp"] =
-        GroundingExecutor.combineDateAndTime(instanceDate, startTime);
+      const startTs = GroundingExecutor.combineDateAndTime(
+        instanceDate,
+        startTime,
+      );
+      if (startTs !== null) {
+        properties["ems__Effort_plannedStartTimestamp"] = startTs;
+      } else {
+        LoggingService.warn(
+          `[GroundingExecutor] prototype ems__EffortPrototype_startTime "${startTime}" is not a valid HH:MM[:SS] time-of-day — skipping plannedStartTimestamp stamp.`,
+        );
+      }
     }
     const endTime = GroundingExecutor.firstScalar(
       targetFm["ems__EffortPrototype_endTime"],
     );
     if (endTime && properties["ems__Effort_plannedEndTimestamp"] === undefined) {
-      properties["ems__Effort_plannedEndTimestamp"] =
-        GroundingExecutor.combineDateAndTime(instanceDate, endTime);
+      const endTs = GroundingExecutor.combineDateAndTime(instanceDate, endTime);
+      if (endTs !== null) {
+        properties["ems__Effort_plannedEndTimestamp"] = endTs;
+      } else {
+        LoggingService.warn(
+          `[GroundingExecutor] prototype ems__EffortPrototype_endTime "${endTime}" is not a valid HH:MM[:SS] time-of-day — skipping plannedEndTimestamp stamp.`,
+        );
+      }
     }
   }
 
@@ -1252,8 +1273,18 @@ export class GroundingExecutor {
    * into a full timezone-naive local dateTime `"YYYY-MM-DDTHH:MM:SS"`. A bare
    * `HH:MM` gets `:00` seconds appended; an already-`HH:MM:SS` value passes
    * through. NEVER emits a trailing timezone offset.
+   *
+   * Returns null when `timeOfDay` is not a valid `HH:MM[:SS]` (HH 00-23, MM/SS
+   * 00-59) — the caller then skips stamping rather than splicing a garbage
+   * value into the typed `ems__Effort_planned*Timestamp` (which downstream
+   * calendar/sort consumers could not parse). Defensive against a malformed
+   * user-authored `ems__EffortPrototype_startTime`.
    */
-  private static combineDateAndTime(date: string, timeOfDay: string): string {
+  private static combineDateAndTime(
+    date: string,
+    timeOfDay: string,
+  ): string | null {
+    if (!/^([01]\d|2[0-3]):[0-5]\d(:[0-5]\d)?$/.test(timeOfDay)) return null;
     const time = /^\d{2}:\d{2}$/.test(timeOfDay) ? `${timeOfDay}:00` : timeOfDay;
     return `${date}T${time}`;
   }

--- a/packages/core/tests/integration/asset-creation/proto-time-propagation.test.ts
+++ b/packages/core/tests/integration/asset-creation/proto-time-propagation.test.ts
@@ -138,6 +138,19 @@ const PROTO_WITHOUT_TIME = [
   "",
 ].join("\n");
 
+/** Prototype with a MALFORMED start time → must be skipped, never spliced. */
+const PROTO_BAD_TIME = [
+  "---",
+  'exo__Asset_uid: "proto-bad-uid"',
+  'exo__Asset_label: "Broken routine"',
+  "exo__Instance_class:",
+  '  - "[[df7e579d-02d4-4f3a-971f-3d1d785b689b]]"',
+  'ems__EffortPrototype_startTime: "25:99"',
+  "---",
+  "",
+].join("\n");
+const PROTO_BAD_TIME_PATH = "/vault/broken-proto.md";
+
 // create-task-instance-shaped grounding: InheritanceRule writes the prototype
 // backlink (so needsTargetRead → targetFm is the prototype frontmatter), and a
 // labelTemplate uses $today so we can assert the label denotes the chosen date.
@@ -187,6 +200,7 @@ describe(`Integration: create_instance prototype-time propagation (ec15f83e) ${R
     await fs.createFile(PROTO_PATH, PROTO_WITH_TIMES);
     await fs.createFile(PROTO_NO_END_PATH, PROTO_ONLY_START);
     await fs.createFile(PROTO_NO_TIME_PATH, PROTO_WITHOUT_TIME);
+    await fs.createFile(PROTO_BAD_TIME_PATH, PROTO_BAD_TIME);
     const serviceRegistry = new ServiceRegistry();
     groundingExecutor = new GroundingExecutor(fs, fs, serviceRegistry, undefined, {
       clock: frozenClock(`${FROZEN_TODAY}T08:00:00Z`),
@@ -195,7 +209,12 @@ describe(`Integration: create_instance prototype-time propagation (ec15f83e) ${R
 
   /** The created instance file = the only path that is not a prototype fixture. */
   function createdContent(): string {
-    const protos = new Set([PROTO_PATH, PROTO_NO_END_PATH, PROTO_NO_TIME_PATH]);
+    const protos = new Set([
+      PROTO_PATH,
+      PROTO_NO_END_PATH,
+      PROTO_NO_TIME_PATH,
+      PROTO_BAD_TIME_PATH,
+    ]);
     const path = fs.getAllPaths().find((p) => !protos.has(p));
     if (!path) throw new Error("No created file");
     return fs.getContent(path)!;
@@ -309,5 +328,21 @@ describe(`Integration: create_instance prototype-time propagation (ec15f83e) ${R
     // No timezone offset.
     expect(value).not.toContain("+05:00");
     expect(value).not.toContain("Z");
+  });
+
+  // Hardening (code-reviewer LOW): a malformed prototype time must be skipped,
+  // never spliced into the typed planned*Timestamp as a garbage value.
+  it(`${REQ} malformed prototype startTime is skipped, not written as a garbage timestamp`, async () => {
+    const result = await groundingExecutor.execute(
+      GROUNDING,
+      "https://exocortex.my/assets/broken-proto",
+      PROTO_BAD_TIME_PATH,
+      undefined,
+    );
+    expect(result.success).toBe(true);
+
+    const content = createdContent();
+    expect(content).not.toContain("ems__Effort_plannedStartTimestamp");
+    expect(content).not.toContain("25:99");
   });
 });

--- a/packages/core/tests/integration/asset-creation/proto-time-propagation.test.ts
+++ b/packages/core/tests/integration/asset-creation/proto-time-propagation.test.ts
@@ -1,0 +1,313 @@
+/**
+ * Integration test: create_instance grounding → prototype-time propagation.
+ *
+ * Feature ec15f83e / req 57b03ab3 — when the $target prototype declares a
+ * time-of-day on itself (`ems__EffortPrototype_startTime`, optionally
+ * `_endTime`, in "HH:MM" form), creating an instance from it:
+ *   (A) lets the user choose the target DATE (reserved `plannedDate` userInput =
+ *       the plugin modal's date field / the CLI `--date` param), defaulting to
+ *       today; the chosen date drives the date-denoting label (`$today`) too.
+ *   (B) auto-stamps `ems__Effort_plannedStartTimestamp` (and `_plannedEnd...`
+ *       when endTime present) = chosenDate + that time, a FULL timezone-naive
+ *       local dateTime "YYYY-MM-DDTHH:MM:SS".
+ * When the prototype declares no time-of-day → unchanged (no planned timestamps,
+ * no date prompt) — zero regression.
+ *
+ * Exercises the real `create_instance` pipeline through GroundingExecutor with
+ * an in-memory file system (executor logic NOT mocked) + a frozen clock for a
+ * deterministic "today". Mirrors `create-instance-body.test.ts`.
+ *
+ * Revert-verify ([[integration-test-revert-verify]]): with the propagation
+ * neutralised (applyPrototypeTimePropagation call removed / startTime read
+ * skipped), the default-date / explicit-date / only-start / full-timestamp
+ * assertions FAIL; restored → PASS. The "prototype declares no time" scenario
+ * stays GREEN both ways (intended no-op signal, not a false positive).
+ */
+
+import "reflect-metadata";
+import {
+  GroundingExecutor,
+  ServiceRegistry,
+} from "../../../src/services/GroundingExecutor";
+import { GroundingType } from "../../../src/domain/constants/GroundingType";
+import { GroundingDefinition } from "../../../src/domain/models/CommandDefinition";
+import { frozenClock } from "../../../src/services/IClock";
+import {
+  IFileSystemReader,
+  IFileSystemWriter,
+} from "../../../src/interfaces/IFileSystemAdapter";
+
+const REQ = "@req:57b03ab3-9666-4c5a-8f38-cf650e4f48d2";
+
+// ---------------------------------------------------------------------------
+// In-memory file system (shared between GroundingExecutor reads + writes)
+// ---------------------------------------------------------------------------
+
+class InMemoryFileSystem implements IFileSystemReader, IFileSystemWriter {
+  private files = new Map<string, string>();
+
+  async readFile(path: string): Promise<string> {
+    const content = this.files.get(path);
+    if (content === undefined) throw new Error(`File not found: ${path}`);
+    return content;
+  }
+
+  async fileExists(path: string): Promise<boolean> {
+    return this.files.has(path);
+  }
+
+  async getMarkdownFiles(): Promise<string[]> {
+    return Array.from(this.files.keys()).filter((p) => p.endsWith(".md"));
+  }
+
+  async createFile(path: string, content: string): Promise<string> {
+    this.files.set(path, content);
+    return path;
+  }
+
+  async updateFile(path: string, content: string): Promise<void> {
+    this.files.set(path, content);
+  }
+
+  async writeFile(path: string, content: string): Promise<void> {
+    this.files.set(path, content);
+  }
+
+  async deleteFile(path: string): Promise<void> {
+    this.files.delete(path);
+  }
+
+  async renameFile(oldPath: string, newPath: string): Promise<void> {
+    const content = this.files.get(oldPath);
+    if (content !== undefined) {
+      this.files.set(newPath, content);
+      this.files.delete(oldPath);
+    }
+  }
+
+  getContent(path: string): string | undefined {
+    return this.files.get(path);
+  }
+
+  getAllPaths(): string[] {
+    return Array.from(this.files.keys());
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const PROTO_PATH = "/vault/breakfast-proto.md";
+const PROTO_NO_END_PATH = "/vault/dinner-proto.md";
+const PROTO_NO_TIME_PATH = "/vault/plain-proto.md";
+
+/** Prototype carrying BOTH start + end time-of-day (Breakfast 09:45–10:15). */
+const PROTO_WITH_TIMES = [
+  "---",
+  'exo__Asset_uid: "proto-breakfast-uid"',
+  'exo__Asset_label: "Breakfast"',
+  "exo__Instance_class:",
+  '  - "[[df7e579d-02d4-4f3a-971f-3d1d785b689b]]"',
+  'ems__EffortPrototype_startTime: "09:45"',
+  'ems__EffortPrototype_endTime: "10:15"',
+  "---",
+  "",
+].join("\n");
+
+/** Prototype with ONLY a start time (Dinner 20:00, no end). */
+const PROTO_ONLY_START = [
+  "---",
+  'exo__Asset_uid: "proto-dinner-uid"',
+  'exo__Asset_label: "Dinner"',
+  "exo__Instance_class:",
+  '  - "[[df7e579d-02d4-4f3a-971f-3d1d785b689b]]"',
+  'ems__EffortPrototype_startTime: "20:00"',
+  "---",
+  "",
+].join("\n");
+
+/** Prototype declaring NO time-of-day (control — no-op expected). */
+const PROTO_WITHOUT_TIME = [
+  "---",
+  'exo__Asset_uid: "proto-plain-uid"',
+  'exo__Asset_label: "Plain routine"',
+  "exo__Instance_class:",
+  '  - "[[df7e579d-02d4-4f3a-971f-3d1d785b689b]]"',
+  "---",
+  "",
+].join("\n");
+
+// create-task-instance-shaped grounding: InheritanceRule writes the prototype
+// backlink (so needsTargetRead → targetFm is the prototype frontmatter), and a
+// labelTemplate uses $today so we can assert the label denotes the chosen date.
+const GROUNDING: GroundingDefinition = {
+  id: "gnd-create-task-instance-ec15f83e",
+  label: "Create Task Instance",
+  type: GroundingType.CREATE_INSTANCE,
+  targetClass: "ems__Task",
+  targetFolder: "01 Inbox",
+  labelTemplate: "$target.exo__Asset_label $today",
+  inheritanceRule: [
+    {
+      sourcePropertyName: "exo__Asset_uid",
+      targetPropertyName: "exo__Asset_prototype",
+      targetClassExclusion: [],
+      priority: 50,
+    },
+  ],
+};
+
+// Frozen clock → deterministic "today" = 2026-06-28 (UTC date slice, matching
+// the $today token source). 08:00Z is mid-day Almaty, so no UTC date-edge.
+const FROZEN_TODAY = "2026-06-28";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function splitFrontmatterAndBody(content: string): { fm: string; body: string } {
+  const match = content.match(/^---\r?\n[\s\S]*?\r?\n---/);
+  if (!match) return { fm: "", body: content };
+  const fm = match[0];
+  const body = content.slice(fm.length).replace(/^\r?\n/, "");
+  return { fm, body };
+}
+
+// ---------------------------------------------------------------------------
+// Test Suite
+// ---------------------------------------------------------------------------
+
+describe(`Integration: create_instance prototype-time propagation (ec15f83e) ${REQ}`, () => {
+  let fs: InMemoryFileSystem;
+  let groundingExecutor: GroundingExecutor;
+
+  beforeEach(async () => {
+    fs = new InMemoryFileSystem();
+    await fs.createFile(PROTO_PATH, PROTO_WITH_TIMES);
+    await fs.createFile(PROTO_NO_END_PATH, PROTO_ONLY_START);
+    await fs.createFile(PROTO_NO_TIME_PATH, PROTO_WITHOUT_TIME);
+    const serviceRegistry = new ServiceRegistry();
+    groundingExecutor = new GroundingExecutor(fs, fs, serviceRegistry, undefined, {
+      clock: frozenClock(`${FROZEN_TODAY}T08:00:00Z`),
+    });
+  });
+
+  /** The created instance file = the only path that is not a prototype fixture. */
+  function createdContent(): string {
+    const protos = new Set([PROTO_PATH, PROTO_NO_END_PATH, PROTO_NO_TIME_PATH]);
+    const path = fs.getAllPaths().find((p) => !protos.has(p));
+    if (!path) throw new Error("No created file");
+    return fs.getContent(path)!;
+  }
+
+  // Scenario: default target date is today.
+  it(`${REQ} default target date is today → plannedStart/End = today + prototype time`, async () => {
+    const result = await groundingExecutor.execute(
+      GROUNDING,
+      "https://exocortex.my/assets/breakfast-proto",
+      PROTO_PATH,
+      undefined, // no userInput → no explicit date → today
+    );
+    expect(result.success).toBe(true);
+
+    const { fm } = splitFrontmatterAndBody(createdContent());
+    expect(fm).toMatch(
+      /ems__Effort_plannedStartTimestamp:\s*"?2026-06-28T09:45:00"?/,
+    );
+    expect(fm).toMatch(
+      /ems__Effort_plannedEndTimestamp:\s*"?2026-06-28T10:15:00"?/,
+    );
+  });
+
+  // Scenario: explicit target date is honoured (modal date field / CLI param).
+  it(`${REQ} explicit plannedDate is honoured for timestamps AND the label`, async () => {
+    const result = await groundingExecutor.execute(
+      GROUNDING,
+      "https://exocortex.my/assets/breakfast-proto",
+      PROTO_PATH,
+      { plannedDate: "2026-07-01" },
+    );
+    expect(result.success).toBe(true);
+
+    const content = createdContent();
+    const { fm } = splitFrontmatterAndBody(content);
+
+    expect(fm).toMatch(
+      /ems__Effort_plannedStartTimestamp:\s*"?2026-07-01T09:45:00"?/,
+    );
+    expect(fm).toMatch(
+      /ems__Effort_plannedEndTimestamp:\s*"?2026-07-01T10:15:00"?/,
+    );
+    // The label denotes the CHOSEN date, not today ($today → plannedDate).
+    expect(fm).toMatch(/exo__Asset_label:\s*"?Breakfast 2026-07-01"?/);
+    // The label's date is the chosen one — never today's date.
+    expect(fm).not.toMatch(
+      new RegExp(`exo__Asset_label:.*${FROZEN_TODAY}`),
+    );
+    // …but createdAt remains the REAL clock time (today), proving the split:
+    // createdAt = now, label + planned timestamps = the chosen date.
+    expect(fm).toMatch(
+      new RegExp(`exo__Asset_createdAt:\\s*${FROZEN_TODAY}T`),
+    );
+    // `plannedDate` never leaks as a frontmatter key (reserved engine input).
+    expect(fm).not.toMatch(/^plannedDate:/m);
+    expect(content).not.toContain("\nplannedDate:");
+  });
+
+  // Scenario: prototype declares only a start time → only plannedStart.
+  it(`${REQ} prototype with only startTime → instance gets only plannedStart`, async () => {
+    await groundingExecutor.execute(
+      GROUNDING,
+      "https://exocortex.my/assets/dinner-proto",
+      PROTO_NO_END_PATH,
+      { plannedDate: "2026-07-02" },
+    );
+    const { fm } = splitFrontmatterAndBody(createdContent());
+
+    expect(fm).toMatch(
+      /ems__Effort_plannedStartTimestamp:\s*"?2026-07-02T20:00:00"?/,
+    );
+    expect(fm).not.toContain("ems__Effort_plannedEndTimestamp");
+  });
+
+  // Scenario: prototype declares NO time-of-day → unchanged (no-op, no regression).
+  // GREEN both ways under revert-verify — guards against over-eager stamping.
+  it(`${REQ} prototype without time-of-day → no planned timestamps written`, async () => {
+    const result = await groundingExecutor.execute(
+      GROUNDING,
+      "https://exocortex.my/assets/plain-proto",
+      PROTO_NO_TIME_PATH,
+      undefined,
+    );
+    expect(result.success).toBe(true);
+
+    const content = createdContent();
+    expect(content).not.toContain("ems__Effort_plannedStartTimestamp");
+    expect(content).not.toContain("ems__Effort_plannedEndTimestamp");
+  });
+
+  // Scenario: the planned value is a FULL date+time, timezone-naive.
+  it(`${REQ} planned timestamp is a full timezone-naive dateTime, never bare HH:MM`, async () => {
+    await groundingExecutor.execute(
+      GROUNDING,
+      "https://exocortex.my/assets/breakfast-proto",
+      PROTO_PATH,
+      { plannedDate: "2026-07-01" },
+    );
+    const { fm } = splitFrontmatterAndBody(createdContent());
+
+    const startMatch = fm.match(
+      /ems__Effort_plannedStartTimestamp:\s*"?([^"\n]+)"?/,
+    );
+    expect(startMatch).not.toBeNull();
+    const value = startMatch![1].trim().replace(/"$/, "");
+    // Full "YYYY-MM-DDTHH:MM:SS".
+    expect(value).toBe("2026-07-01T09:45:00");
+    // Never the bare prototype "HH:MM".
+    expect(value).not.toBe("09:45");
+    // No timezone offset.
+    expect(value).not.toContain("+05:00");
+    expect(value).not.toContain("Z");
+  });
+});


### PR DESCRIPTION
## What

Realises vault backlog idea **ec15f83e** (12 votes) and approved requirement **`57b03ab3-9666-4c5a-8f38-cf650e4f48d2`** (SDD).

When `create_instance` materialises an instance from a prototype that declares its time-of-day **on the prototype itself** (`ems__EffortPrototype_startTime`, optionally `_endTime`, `"HH:MM"`), the executor now:

1. **Target-date selection** — the caller chooses the instance's DATE via the reserved `plannedDate` userInput, defaulting to today. The chosen date drives BOTH the date-denoting label (`$today`) AND the planned timestamps, so they never disagree.
   - **CLI**: `apply create-task-instance <proto> --input '{"plannedDate":"2026-07-01"}'` (flows today via the generic `--input` channel — no CLI change).
   - **Plugin modal date field**: a homoiconic grounding `inputSchema` change (the `date` input type + `DynamicFormModal` infra already exist) — tracked **separately** as a UX fork (keep the fast one-click vs always-prompt), not in this exocortex PR.
2. **Planned-timestamp stamp** — writes `ems__Effort_plannedStartTimestamp` (and `_plannedEndTimestamp` when `endTime` present) = `chosenDate + that time` as a FULL timezone-naive local dateTime `"YYYY-MM-DDTHH:MM:SS"` (Asia/Almaty convention, matching existing frontmatter).

**Zero regression**: no-op when the prototype declares no time-of-day. `createdAt` stays the real clock time; only `$today`/label/planned-timestamps follow the chosen date. When no `plannedDate` is supplied, `$today` is byte-identical to the prior `now.slice(0,10)`.

## Why

The user declares the time ONCE on the prototype (e.g. Breakfast `09:45`–`10:15`) and a single create — for today or any future day — produces a correctly-planned instance, instead of hand-setting `ems__Effort_plannedStartTimestamp` per instance and instead of only ever creating for "today". The instance then surfaces on the right day's daily-note Tasks table.

## Verification (binding class: Integration)

`packages/core/tests/integration/asset-creation/proto-time-propagation.test.ts` — 5 scenarios, real `GroundingExecutor` + real `FrontmatterService` + in-memory FS + frozen clock (executor logic NOT mocked). Test titles carry `@req:57b03ab3-9666-4c5a-8f38-cf650e4f48d2`.

**Revert-verified** ([[integration-test-revert-verify]], type-preserving breaks):
- Neutralise the stamping (mismatched lookup key) → the 4 timestamp scenarios go **RED**.
- Neutralise the `$today`→chosenDate resolution → the explicit-date **label** scenario goes **RED**.
- The "prototype declares no time-of-day" no-op scenario stays **GREEN both ways** (intended no-op signal).
- Restored → **5/5 GREEN**.

Auto-gated by the `test-coverage-exocortex` CI job (full `packages/core/jest.config.js`).

## Scope note

Parser-path file (`GroundingExecutor.ts`) → auto-merge discipline (code-reviewer + advisor + manual squash, no `--auto`). The plugin modal date-field surface is a separate homoiconic grounding-asset change (different repo) pending a UX decision.

Req: 57b03ab3-9666-4c5a-8f38-cf650e4f48d2

https://claude.ai/code/session_01M8xZAX8JZznff2yAL7nzCk
