### PR TITLE
feat(#3707): «Register for sync» — write an exo__AssetSpace descriptor so a mounted pack enters the ExoSync set

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -793,6 +793,12 @@ export {
   type SpaceSpecCandidate,
 } from "./services/sync/spaceSpecCore";
 export {
+  buildAssetSpaceDescriptor,
+  deriveAssetSpaceNamespace,
+  type AssetSpaceDescriptor,
+  type AssetSpaceDescriptorInput,
+} from "./services/sync/registerForSync";
+export {
   ParityValidator,
   summarizeParityRound,
   type ConservationSnapshot,

--- a/packages/core/src/services/sync/registerForSync.ts
+++ b/packages/core/src/services/sync/registerForSync.ts
@@ -1,0 +1,131 @@
+/**
+ * «Register for sync» descriptor builder (Issue #3707).
+ *
+ * A knowledge pack added via «Add a knowledge pack» (tarball mount, RFC 0005
+ * Phase 1) materialises its files at `assetspaces/<owner>/<repo>` but carries NO
+ * `exo__AssetSpace` descriptor of its own. ExoSync's discovery is class-based,
+ * vault-wide ({@link classifySpaceDeclaration} over `exo__AssetSpace` + a
+ * `_source` URL), so a pack with no such descriptor is NEVER enumerated into the
+ * materialised sync set — the user's edits in it silently do not sync
+ * (`collectSyncRepoSpecs` surfaces it only as a `mountedNotDeclared` notice,
+ * FINDING-3).
+ *
+ * This pure builder produces the descriptor the «Register for sync» affordance
+ * writes INTO the pack folder to close that gap. It is platform-free (no I/O, no
+ * YAML, no Obsidian / Node API) so the same descriptor shape is shared by the
+ * plugin command and any unit/integration test — the caller serialises the
+ * `frontmatter` with whichever `YamlCodec` it already owns and writes
+ * `<uid>.md` via its own filesystem port (`vault.adapter` in the plugin → free
+ * Desktop↔Mobile parity).
+ *
+ * Descriptor shape (mirrors a proven registry descriptor, e.g.
+ * `mudriy/exoas-tbank`):
+ *   - `exo__Instance_class` — `[[<ASSET_SPACE_CLASS_UID>]]` (the discriminator
+ *     `isAssetSpaceFrontmatter` matches).
+ *   - `exo__AssetSpace_source` — the plain `https://github.com/<owner>/<repo>`
+ *     URL (`readSpaceSource` reads it; the SAME allowlist
+ *     `parseStrictGitHubRepoURL` the sync layer enforces).
+ *   - `exo__AssetSpace_namespace` — the repo basename minus the `exoas-` prefix.
+ *   - `exo__Asset_isDefinedBy` — a SELF-anchor (`[[<own-uid>]]`) so the
+ *     co-location invariant keeps the descriptor in the pack folder it
+ *     describes (namespace-ontology self-referential pattern).
+ */
+
+import {
+  ASSET_SPACE_CLASS_UID,
+  parseStrictGitHubRepoURL,
+} from "./spaceSpecCore";
+
+/** Inputs to {@link buildAssetSpaceDescriptor}. */
+export interface AssetSpaceDescriptorInput {
+  /** Fresh UUID for the descriptor asset (caller supplies — platform RNG). */
+  uid: string;
+  /** The pack's `https://github.com/<owner>/<repo>` source URL. */
+  sourceUrl: string;
+  /**
+   * Namespace override. When omitted, derived from the repo basename
+   * ({@link deriveAssetSpaceNamespace}).
+   */
+  namespace?: string;
+  /** ISO-8601 timestamp for createdAt/updatedAt (caller supplies — no clock here). */
+  createdAt: string;
+}
+
+/** A built `exo__AssetSpace` descriptor, ready for the caller to serialise + write. */
+export interface AssetSpaceDescriptor {
+  /** `<uid>.md` — the file to write into the pack folder. */
+  fileName: string;
+  /** The frontmatter object (caller serialises with its own `YamlCodec`). */
+  frontmatter: Record<string, unknown>;
+  /** Markdown body (everything after the frontmatter block). */
+  body: string;
+}
+
+/**
+ * Derive an AssetSpace namespace from its GitHub source URL: the repo basename
+ * with a leading `exoas-` stripped (`…/kitelev/exoas-pmbok` → `pmbok`). Returns
+ * `null` when the URL is not a plain `https://github.com/<owner>/<repo>` (the
+ * sync allowlist) or the stripped repo is empty.
+ */
+export function deriveAssetSpaceNamespace(sourceUrl: string): string | null {
+  if (typeof sourceUrl !== "string") return null;
+  const parsed = parseStrictGitHubRepoURL(sourceUrl.replace(/\.git$/i, ""));
+  if (parsed === null) return null;
+  const repo = parsed.repo;
+  const ns = repo.startsWith("exoas-") ? repo.slice("exoas-".length) : repo;
+  return ns.length > 0 ? ns : null;
+}
+
+/**
+ * Build the `exo__AssetSpace` descriptor for a mounted-but-undeclared pack.
+ * Pure — returns `null` (no throw) when the source URL is not a plain
+ * `https://github.com/<owner>/<repo>` URL, the uid is blank, or no namespace can
+ * be derived (and none was supplied). The caller warns-and-skips on `null`.
+ */
+export function buildAssetSpaceDescriptor(
+  input: AssetSpaceDescriptorInput,
+): AssetSpaceDescriptor | null {
+  const uid = typeof input.uid === "string" ? input.uid.trim() : "";
+  if (uid.length === 0) return null;
+
+  const normalized =
+    typeof input.sourceUrl === "string"
+      ? input.sourceUrl.replace(/\.git$/i, "")
+      : "";
+  const parsed = parseStrictGitHubRepoURL(normalized);
+  if (parsed === null) return null;
+
+  const namespace =
+    (typeof input.namespace === "string" && input.namespace.trim().length > 0
+      ? input.namespace.trim()
+      : deriveAssetSpaceNamespace(normalized)) ?? "";
+  if (namespace.length === 0) return null;
+
+  const label = `${parsed.owner}/${parsed.repo}`;
+  const createdAt =
+    typeof input.createdAt === "string" && input.createdAt.length > 0
+      ? input.createdAt
+      : new Date(0).toISOString();
+
+  // Key order mirrors a proven registry descriptor (uid, isDefinedBy, ts,
+  // class, label, source, namespace, aliases) for readable diffs.
+  const frontmatter: Record<string, unknown> = {
+    exo__Asset_uid: uid,
+    // SELF-anchor: the descriptor is its own co-location anchor, so it stays in
+    // the pack folder it describes (namespace-ontology self-referential pattern).
+    exo__Asset_isDefinedBy: `[[${uid}]]`,
+    exo__Asset_createdAt: createdAt,
+    exo__Asset_updatedAt: createdAt,
+    exo__Instance_class: [`[[${ASSET_SPACE_CLASS_UID}]]`],
+    exo__Asset_label: label,
+    exo__AssetSpace_source: normalized,
+    exo__AssetSpace_namespace: namespace,
+    aliases: [`$${namespace} AssetSpace`],
+  };
+
+  const body =
+    `exo__AssetSpace descriptor for \`${label}\` — registered for ExoSync ` +
+    `(#3707). Mount path \`assetspaces/${parsed.owner}/${parsed.repo}/\`.`;
+
+  return { fileName: `${uid}.md`, frontmatter, body };
+}

--- a/packages/core/tests/unit/services/sync/registerForSync.test.ts
+++ b/packages/core/tests/unit/services/sync/registerForSync.test.ts
@@ -1,0 +1,123 @@
+import {
+  buildAssetSpaceDescriptor,
+  deriveAssetSpaceNamespace,
+  classifySpaceDeclaration,
+} from "../../../../src/index";
+
+describe("registerForSync — buildAssetSpaceDescriptor (#3707)", () => {
+  const UID = "f3465725-b02d-4d20-b05a-69881a783552";
+  const CREATED = "2026-06-28T14:30:00+05:00";
+
+  it("builds a uid-named exo__AssetSpace descriptor with self-anchor, source, namespace", () => {
+    const d = buildAssetSpaceDescriptor({
+      uid: UID,
+      sourceUrl: "https://github.com/kitelev/exoas-pmbok",
+      createdAt: CREATED,
+    });
+    expect(d).not.toBeNull();
+    expect(d!.fileName).toBe(`${UID}.md`);
+    const fm = d!.frontmatter;
+    expect(fm["exo__Asset_uid"]).toBe(UID);
+    // SELF-anchor isDefinedBy → descriptor stays co-located in the pack folder.
+    expect(fm["exo__Asset_isDefinedBy"]).toBe(`[[${UID}]]`);
+    expect(fm["exo__Instance_class"]).toEqual([
+      "[[73bd00e4-ccc0-4f3f-b20d-c4388c4588fb]]",
+    ]);
+    expect(fm["exo__AssetSpace_source"]).toBe(
+      "https://github.com/kitelev/exoas-pmbok",
+    );
+    expect(fm["exo__AssetSpace_namespace"]).toBe("pmbok");
+    expect(fm["exo__Asset_label"]).toBe("kitelev/exoas-pmbok");
+    expect(fm["exo__Asset_createdAt"]).toBe(CREATED);
+    expect(fm["aliases"]).toEqual(["$pmbok AssetSpace"]);
+    expect(d!.body).toContain("registered for ExoSync");
+  });
+
+  it("is recognised by the REAL ExoSync discriminator as a sync candidate", () => {
+    // The genuine end-to-end claim: a descriptor this builder produces makes the
+    // pack sync-eligible per classifySpaceDeclaration (the sync-set discriminator).
+    const d = buildAssetSpaceDescriptor({
+      uid: UID,
+      sourceUrl: "https://github.com/kitelev/exoas-pmbok",
+      createdAt: CREATED,
+    })!;
+    const verdict = classifySpaceDeclaration(
+      d.frontmatter,
+      `assetspaces/kitelev/exoas-pmbok/${d.fileName}`,
+    );
+    expect(verdict.kind).toBe("candidate");
+    if (verdict.kind === "candidate") {
+      expect(verdict.candidate.spec.repoKey).toBe("kitelev/exoas-pmbok#main");
+      expect(verdict.candidate.spec.localPath).toBe(
+        "assetspaces/kitelev/exoas-pmbok",
+      );
+    }
+  });
+
+  it("strips the .git suffix from the source URL and derives the namespace", () => {
+    const d = buildAssetSpaceDescriptor({
+      uid: UID,
+      sourceUrl: "https://github.com/mudriy/exoas-tbank.git",
+      createdAt: CREATED,
+    })!;
+    expect(d.frontmatter["exo__AssetSpace_source"]).toBe(
+      "https://github.com/mudriy/exoas-tbank",
+    );
+    expect(d.frontmatter["exo__AssetSpace_namespace"]).toBe("tbank");
+  });
+
+  it("honours an explicit namespace override", () => {
+    const d = buildAssetSpaceDescriptor({
+      uid: UID,
+      sourceUrl: "https://github.com/acme/widgets",
+      namespace: "custom-ns",
+      createdAt: CREATED,
+    })!;
+    expect(d.frontmatter["exo__AssetSpace_namespace"]).toBe("custom-ns");
+    // No `exoas-` prefix on `widgets` → label is owner/repo verbatim.
+    expect(d.frontmatter["exo__Asset_label"]).toBe("acme/widgets");
+  });
+
+  it("returns null for a non-GitHub / malformed source URL", () => {
+    expect(
+      buildAssetSpaceDescriptor({
+        uid: UID,
+        sourceUrl: "https://gitlab.com/owner/repo",
+        createdAt: CREATED,
+      }),
+    ).toBeNull();
+    expect(
+      buildAssetSpaceDescriptor({
+        uid: UID,
+        sourceUrl: "not-a-url",
+        createdAt: CREATED,
+      }),
+    ).toBeNull();
+  });
+
+  it("returns null for a blank uid", () => {
+    expect(
+      buildAssetSpaceDescriptor({
+        uid: "   ",
+        sourceUrl: "https://github.com/kitelev/exoas-pmbok",
+        createdAt: CREATED,
+      }),
+    ).toBeNull();
+  });
+});
+
+describe("registerForSync — deriveAssetSpaceNamespace", () => {
+  it("strips the exoas- prefix", () => {
+    expect(
+      deriveAssetSpaceNamespace("https://github.com/kitelev/exoas-pmbok"),
+    ).toBe("pmbok");
+  });
+  it("keeps a repo without the exoas- prefix verbatim", () => {
+    expect(deriveAssetSpaceNamespace("https://github.com/acme/widgets")).toBe(
+      "widgets",
+    );
+  });
+  it("returns null for a non-GitHub URL", () => {
+    expect(deriveAssetSpaceNamespace("https://example.com/x/y")).toBeNull();
+  });
+});

--- a/packages/obsidian-plugin/src/ExocortexPlugin.ts
+++ b/packages/obsidian-plugin/src/ExocortexPlugin.ts
@@ -228,7 +228,9 @@ import {
   buildQuarantineResolver,
   buildSyncEngine,
   collectSyncRepoSpecs,
+  coreSchemaYamlCodec,
 } from "./infrastructure/adapters/SyncDepsFactory";
+import { RegisterForSyncCommand } from "./infrastructure/adapters/RegisterForSyncCommand";
 import {
   CommandExecutionFlow,
   createTripleStoreRequiredPropertyResolver,
@@ -3598,6 +3600,13 @@ export default class ExocortexPlugin extends Plugin {
     // touch the live-mirror (VaultSettingsStore); M2.3 deprecates that.
     this.registerSettingsDistributionCommands();
 
+    // Issue #3707 — «Register for sync»: write an exo__AssetSpace descriptor into
+    // a mounted-but-undeclared knowledge pack so ExoSync's class-based discovery
+    // enumerates it (FINDING-3 gap). Registered UNCONDITIONALLY on both desktop
+    // AND mobile (Desktop↔Mobile Command Parity — the descriptor write is a single
+    // vault.adapter.write, no Node fs / git).
+    this.registerRegisterForSyncCommand();
+
     // RFC 22b50a17 Decision #6 — wipe-all switch cache clearing. RFC 0002 §3.2
     // (P3/P4) — de-jargon + destructive flag: «Clear switch cache (wipe-all)» →
     // «Reset profile cache (advanced)». Name sourced from the grooming contract.
@@ -4236,6 +4245,84 @@ export default class ExocortexPlugin extends Plugin {
         return Promise.resolve(out);
       },
       notify: (message) => this.notifier.info(message),
+    });
+  }
+
+  /**
+   * Issue #3707 — wire + register «Exocortex: Register for sync». Writes an
+   * `exo__AssetSpace` descriptor INTO a mounted-but-undeclared knowledge pack so
+   * ExoSync's class-based discovery ({@link collectSyncRepoSpecs}) enumerates it
+   * into the materialised sync set (the «won't sync» FINDING-3 gap). Registered
+   * UNCONDITIONALLY (Desktop↔Mobile Command Parity — the descriptor write is a
+   * single `vault.adapter.write`, no Node `fs` / git; the same path runs on iOS).
+   */
+  private registerRegisterForSyncCommand(): void {
+    // deriveFolderName for the (rare) URL-prompt fallback — mirrors the
+    // bootstrap-command closure; guarded so an in-progress invalid entry never
+    // throws into the modal's live label.
+    const deriveFolderName = (url: string): string => {
+      try {
+        const { repo } = parseGitHubURL(url);
+        return repo.startsWith("exoas-") ? repo.slice("exoas-".length) : repo;
+      } catch {
+        return "";
+      }
+    };
+
+    const command = new RegisterForSyncCommand({
+      // The registrable set = mounted folders carrying NO descriptor (FINDING-3).
+      listUnregisteredPacks: async () =>
+        (await collectSyncRepoSpecs(this.app)).mountedNotDeclared,
+      // Multi-pack picker — reuse the shared fuzzy modal keyed by mount path.
+      pickPack: (mountPaths) =>
+        new Promise<string | null>((resolve) => {
+          const choices: ProfileChoice[] = mountPaths.map((p) => ({
+            uid: p,
+            label: p,
+          }));
+          new ProfileFuzzyModal(
+            this.app,
+            choices,
+            "Choose a knowledge pack to register for sync",
+            (chosen) => resolve(chosen === null ? null : chosen.uid),
+          ).open();
+        }),
+      // Legacy flat folder (un-derivable URL) → prompt; reuse the Add-pack URL modal.
+      promptSourceUrl: () =>
+        new Promise<string | null>((resolve) => {
+          new AddAssetSpaceModal(this.app, deriveFolderName, (res) =>
+            resolve(res === null ? null : res.url),
+          ).open();
+        }),
+      // Ownership: build a fresh GitHubRestClient from the CURRENT PAT (#3382
+      // pattern) and probe push access — owned → pull+push; read-only → pull-only;
+      // no PAT / probe failure → unknown (set-a-token nudge). Best-effort.
+      probeOwnership: async (sourceUrl) => {
+        try {
+          const secretsStore = new LocalSecretsStore({ app: this.app });
+          const pat = (await secretsStore.getSecret("pat")) ?? "";
+          const { owner, repo } = parseGitHubURL(sourceUrl);
+          const client = new GitHubRestClient({ app: this.app, pat });
+          return await client.getRepoPushAccess(owner, repo);
+        } catch {
+          return null;
+        }
+      },
+      newUid: () => crypto.randomUUID(),
+      now: () => new Date().toISOString(),
+      codec: coreSchemaYamlCodec,
+      writeDescriptor: (mountPath, fileName, content) =>
+        this.app.vault.adapter.write(`${mountPath}/${fileName}`, content),
+      notify: (message) => this.notifier.info(message),
+      onMaterialized: () => this.refreshAndInjectAssetSpaceMaterialization(),
+    });
+
+    this.addCommand({
+      id: "register-for-sync",
+      name: "Register for sync",
+      callback: () => {
+        void command.invoke();
+      },
     });
   }
 

--- a/packages/obsidian-plugin/src/ExocortexPlugin.ts
+++ b/packages/obsidian-plugin/src/ExocortexPlugin.ts
@@ -4257,18 +4257,6 @@ export default class ExocortexPlugin extends Plugin {
    * single `vault.adapter.write`, no Node `fs` / git; the same path runs on iOS).
    */
   private registerRegisterForSyncCommand(): void {
-    // deriveFolderName for the (rare) URL-prompt fallback — mirrors the
-    // bootstrap-command closure; guarded so an in-progress invalid entry never
-    // throws into the modal's live label.
-    const deriveFolderName = (url: string): string => {
-      try {
-        const { repo } = parseGitHubURL(url);
-        return repo.startsWith("exoas-") ? repo.slice("exoas-".length) : repo;
-      } catch {
-        return "";
-      }
-    };
-
     const command = new RegisterForSyncCommand({
       // The registrable set = mounted folders carrying NO descriptor (FINDING-3).
       listUnregisteredPacks: async () =>
@@ -4285,13 +4273,6 @@ export default class ExocortexPlugin extends Plugin {
             choices,
             "Choose a knowledge pack to register for sync",
             (chosen) => resolve(chosen === null ? null : chosen.uid),
-          ).open();
-        }),
-      // Legacy flat folder (un-derivable URL) → prompt; reuse the Add-pack URL modal.
-      promptSourceUrl: () =>
-        new Promise<string | null>((resolve) => {
-          new AddAssetSpaceModal(this.app, deriveFolderName, (res) =>
-            resolve(res === null ? null : res.url),
           ).open();
         }),
       // Ownership: build a fresh GitHubRestClient from the CURRENT PAT (#3382

--- a/packages/obsidian-plugin/src/infrastructure/adapters/GitHubRestClient.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/GitHubRestClient.ts
@@ -375,6 +375,42 @@ export class GitHubRestClient {
   }
 
   /**
+   * GET /repos/{owner}/{repo} → does the AUTHENTICATED token have push access?
+   *
+   * Used by «Register for sync» (#3707) to tell an OWNED pack (round-trip
+   * pull+push) from a READ-ONLY / foreign one (pull-only) so the affordance never
+   * makes a false push claim. The authenticated repo response carries
+   * `permissions: { admin, maintain, push, triage, pull }` — `push === true`
+   * means the token can write (the prerequisite for ExoSync to push edits back).
+   *
+   * BEST-EFFORT by contract: returns `null` (ownership UNKNOWN) when there is no
+   * PAT, the request fails (404 private-without-scope, network, rate-limit), or
+   * the `permissions` block is absent — the caller degrades to a "set a token to
+   * enable push" nudge rather than guessing. NEVER throws.
+   */
+  public async getRepoPushAccess(
+    owner: string,
+    repo: string,
+  ): Promise<boolean | null> {
+    // No token → push access is undeterminable (an unauthenticated repo read
+    // carries no `permissions` block). Skip the call entirely.
+    if (this.#pat.length === 0) return null;
+    try {
+      this.requireOwnerRepo(owner, repo);
+      const resp = await this.request({
+        method: "GET",
+        url: `${this.#baseURL}/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}`,
+      });
+      const push = resp?.json?.permissions?.push;
+      return typeof push === "boolean" ? push : null;
+    } catch {
+      // 404 (private repo, under-scoped PAT), network, rate-limit — ownership
+      // simply stays UNKNOWN; a probe failure must never block registration.
+      return null;
+    }
+  }
+
+  /**
    * Refuse to proceed when remaining < needed + 10 (safety buffer).
    * Throws with seconds-to-reset embedded in error message.
    */

--- a/packages/obsidian-plugin/src/infrastructure/adapters/RegisterForSyncCommand.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/RegisterForSyncCommand.ts
@@ -44,12 +44,6 @@ export interface RegisterForSyncDeps {
    */
   pickPack?: (mountPaths: string[]) => Promise<string | null>;
   /**
-   * Prompt for the source URL when the mount path is NOT URL-derivable (a legacy
-   * flat folder `assetspaces/<name>` rather than the canonical Maven layout).
-   * Resolves the entered URL, or `null` if cancelled.
-   */
-  promptSourceUrl?: (mountPath: string) => Promise<string | null>;
-  /**
    * Probe the GitHub PAT's push access for the pack's repo: `true` = owned
    * (round-trip pull+push), `false` = read-only / foreign (pull-only), `null` =
    * unknown (no token / probe failed). Best-effort — never throws into the flow.
@@ -129,19 +123,21 @@ export class RegisterForSyncCommand {
       }
     }
 
-    // Resolve the source URL: auto-fill from the Maven mount path; prompt only
-    // when un-derivable (legacy flat folder).
-    let sourceUrl = deriveUrl(mountPath);
+    // Resolve the source URL by reversing the canonical Maven mount path
+    // (`assetspaces/<owner>/<repo>` → `https://github.com/<owner>/<repo>`). Every
+    // pack from «Add a knowledge pack» (#3538) mounts at this two-level path, and
+    // the registrable set (`mountedNotDeclared`) is enumerated from those folders,
+    // so `deriveUrl` succeeds for every real pack. A non-derivable path (a
+    // non-canonical / flat folder) is refused HONESTLY rather than registered with
+    // a URL whose derived `localPath` would not match the folder on disk — that
+    // descriptor would never be discovered, so a "registered" notice would be a
+    // false success.
+    const sourceUrl = deriveUrl(mountPath);
     if (sourceUrl === null) {
-      if (this.d.promptSourceUrl === undefined) {
-        this.d.notify(
-          `Register for sync: cannot derive a GitHub URL from ${mountPath}, and no URL prompt is available.`,
-        );
-        return;
-      }
-      const entered = await this.d.promptSourceUrl(mountPath);
-      if (entered === null) return; // user cancelled
-      sourceUrl = entered;
+      this.d.notify(
+        `Register for sync: ${mountPath} is not a canonical assetspaces/<owner>/<repo> mount, so its GitHub source cannot be determined — cannot register.`,
+      );
+      return;
     }
 
     // Build the descriptor (pure). null ⇒ source is not a plain GitHub URL.

--- a/packages/obsidian-plugin/src/infrastructure/adapters/RegisterForSyncCommand.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/RegisterForSyncCommand.ts
@@ -1,0 +1,220 @@
+/**
+ * RegisterForSyncCommand — «Exocortex: Register for sync» palette logic (Issue
+ * #3707).
+ *
+ * A knowledge pack added via «Add a knowledge pack» (tarball mount, RFC 0005
+ * Phase 1) materialises at `assetspaces/<owner>/<repo>` but carries NO
+ * `exo__AssetSpace` descriptor of its own, so ExoSync's class-based discovery
+ * ({@link collectSyncRepoSpecs}) never enumerates it into the materialised sync
+ * set — the user's edits in it silently do not sync (surfaced only as a
+ * `mountedNotDeclared` notice, FINDING-3). This command closes that gap: it
+ * writes a UID-named `exo__AssetSpace` descriptor INTO the pack folder
+ * ({@link buildAssetSpaceDescriptor}) so discovery starts tracking it.
+ *
+ * Pure logic — does NOT import Obsidian's Modal / Plugin / vault runtime.
+ * Everything platform-specific (pack enumeration, the descriptor write, the
+ * ownership probe, the picker / URL prompt modals) is injected via
+ * {@link RegisterForSyncDeps} so the class is fully unit-testable with fakes.
+ * Real wiring lives in `ExocortexPlugin`.
+ *
+ * Desktop↔Mobile Command Parity (CLAUDE.md invariant): the descriptor write is a
+ * single `vault.adapter.write` (injected) — NO Node `fs` / git — so the command
+ * registers UNCONDITIONALLY on both platforms; the same code path runs on iOS.
+ */
+
+import {
+  buildAssetSpaceDescriptor,
+  deriveUrl,
+  type YamlCodec,
+} from "@kitelev/exocortex-core";
+
+/** Resolved ownership of a pack — drives the honest pull-only-vs-push notice. */
+export type PackOwnership = "owned" | "read-only" | "unknown";
+
+export interface RegisterForSyncDeps {
+  /**
+   * Mount folders (`assetspaces/<owner>/<repo>`) present on disk but carrying NO
+   * `exo__AssetSpace` descriptor — the registrable set
+   * (`collectSyncRepoSpecs(app).mountedNotDeclared`).
+   */
+  listUnregisteredPacks: () => Promise<string[]>;
+  /**
+   * Pick a pack when several are unregistered. Resolves the chosen mount path,
+   * or `null` if the user cancelled. Unused when exactly one pack is registrable.
+   */
+  pickPack?: (mountPaths: string[]) => Promise<string | null>;
+  /**
+   * Prompt for the source URL when the mount path is NOT URL-derivable (a legacy
+   * flat folder `assetspaces/<name>` rather than the canonical Maven layout).
+   * Resolves the entered URL, or `null` if cancelled.
+   */
+  promptSourceUrl?: (mountPath: string) => Promise<string | null>;
+  /**
+   * Probe the GitHub PAT's push access for the pack's repo: `true` = owned
+   * (round-trip pull+push), `false` = read-only / foreign (pull-only), `null` =
+   * unknown (no token / probe failed). Best-effort — never throws into the flow.
+   */
+  probeOwnership?: (sourceUrl: string) => Promise<boolean | null>;
+  /** True when the pack already has an `exo__AssetSpace` descriptor (double-register guard). */
+  hasDescriptor?: (mountPath: string) => Promise<boolean>;
+  /** Fresh UUID for the descriptor asset (platform RNG). */
+  newUid: () => string;
+  /** Current ISO-8601 timestamp. */
+  now: () => string;
+  /** YAML codec used to serialise the descriptor frontmatter (same one the engine uses). */
+  codec: YamlCodec;
+  /** Write `<mountPath>/<fileName>` with `content` (production: `vault.adapter.write`). */
+  writeDescriptor: (
+    mountPath: string,
+    fileName: string,
+    content: string,
+  ) => Promise<void>;
+  /** User-facing Notice. */
+  notify: (message: string) => void;
+  /** Optional incremental reindex after the write so the pack appears immediately (best-effort). */
+  onMaterialized?: () => Promise<void>;
+}
+
+export class RegisterForSyncCommand {
+  private readonly d: RegisterForSyncDeps;
+
+  constructor(deps: RegisterForSyncDeps) {
+    this.d = deps;
+  }
+
+  /** `Exocortex: Register for sync`. */
+  async invoke(): Promise<void> {
+    let packs: string[];
+    try {
+      packs = await this.d.listUnregisteredPacks();
+    } catch (e) {
+      this.d.notify(
+        `Register for sync: could not inspect mounted packs — ${msg(e)}`,
+      );
+      return;
+    }
+    if (packs.length === 0) {
+      this.d.notify(
+        "Register for sync: every mounted knowledge pack is already registered for sync — nothing to do.",
+      );
+      return;
+    }
+
+    // Pick the pack: one → use it; many → the injected picker (null = cancel).
+    let mountPath: string;
+    if (packs.length === 1) {
+      mountPath = packs[0];
+    } else if (this.d.pickPack !== undefined) {
+      const chosen = await this.d.pickPack(packs);
+      if (chosen === null) return; // user cancelled
+      mountPath = chosen;
+    } else {
+      this.d.notify(
+        `Register for sync: ${packs.length} unregistered packs found but no picker is available.`,
+      );
+      return;
+    }
+
+    // Double-register guard — if a descriptor already exists, do nothing.
+    if (this.d.hasDescriptor !== undefined) {
+      try {
+        if (await this.d.hasDescriptor(mountPath)) {
+          this.d.notify(
+            `Register for sync: ${mountPath} already has a descriptor — it should already sync.`,
+          );
+          return;
+        }
+      } catch {
+        // Probe failure → fall through and let the write proceed (best-effort).
+      }
+    }
+
+    // Resolve the source URL: auto-fill from the Maven mount path; prompt only
+    // when un-derivable (legacy flat folder).
+    let sourceUrl = deriveUrl(mountPath);
+    if (sourceUrl === null) {
+      if (this.d.promptSourceUrl === undefined) {
+        this.d.notify(
+          `Register for sync: cannot derive a GitHub URL from ${mountPath}, and no URL prompt is available.`,
+        );
+        return;
+      }
+      const entered = await this.d.promptSourceUrl(mountPath);
+      if (entered === null) return; // user cancelled
+      sourceUrl = entered;
+    }
+
+    // Build the descriptor (pure). null ⇒ source is not a plain GitHub URL.
+    const uid = this.d.newUid();
+    const descriptor = buildAssetSpaceDescriptor({
+      uid,
+      sourceUrl,
+      createdAt: this.d.now(),
+    });
+    if (descriptor === null) {
+      this.d.notify(
+        `Register for sync: ${sourceUrl} is not a plain https://github.com/<owner>/<repo> URL — cannot register.`,
+      );
+      return;
+    }
+
+    // Ownership probe (best-effort) — decides the honest push-vs-pull-only notice.
+    let ownership: PackOwnership = "unknown";
+    if (this.d.probeOwnership !== undefined) {
+      try {
+        const push = await this.d.probeOwnership(sourceUrl);
+        ownership =
+          push === true ? "owned" : push === false ? "read-only" : "unknown";
+      } catch {
+        ownership = "unknown";
+      }
+    }
+
+    // Write the descriptor INTO the pack folder (vault.adapter — cross-platform).
+    const content = `---\n${this.d.codec.stringify(descriptor.frontmatter)}---\n\n${descriptor.body}\n`;
+    try {
+      await this.d.writeDescriptor(mountPath, descriptor.fileName, content);
+    } catch (e) {
+      this.d.notify(
+        `Register for sync: could not write the descriptor into ${mountPath} (folder not writable?) — ${msg(e)}`,
+      );
+      return;
+    }
+
+    // Incremental reindex so the pack appears in the sync set immediately (the
+    // «won't sync» state clears). Best-effort.
+    await this.runOnMaterialized();
+
+    const label = descriptor.frontmatter["exo__Asset_label"];
+    const name = typeof label === "string" ? label : mountPath;
+    const base = `Registered ${name} for sync.`;
+    switch (ownership) {
+      case "owned":
+        this.d.notify(`${base} Your edits in it will now pull AND push.`);
+        break;
+      case "read-only":
+        this.d.notify(
+          `${base} You don't have write access to this pack — it is registered pull-only: your edits won't push, and the registration won't round-trip to a fresh device.`,
+        );
+        break;
+      case "unknown":
+        this.d.notify(
+          `${base} Set a GitHub token in settings to enable push — without write access, edits are pull-only.`,
+        );
+        break;
+    }
+  }
+
+  private async runOnMaterialized(): Promise<void> {
+    if (this.d.onMaterialized === undefined) return;
+    try {
+      await this.d.onMaterialized();
+    } catch {
+      // Best-effort re-index; a failure must not surface as a registration error.
+    }
+  }
+}
+
+function msg(e: unknown): string {
+  return e instanceof Error ? e.message : String(e);
+}

--- a/packages/obsidian-plugin/tests/unit/infrastructure/adapters/RegisterForSyncCommand.test.ts
+++ b/packages/obsidian-plugin/tests/unit/infrastructure/adapters/RegisterForSyncCommand.test.ts
@@ -1,0 +1,214 @@
+import yaml from "js-yaml";
+import { classifySpaceDeclaration, type YamlCodec } from "@kitelev/exocortex-core";
+import {
+  RegisterForSyncCommand,
+  type RegisterForSyncDeps,
+} from "../../../../src/infrastructure/adapters/RegisterForSyncCommand";
+
+const UID = "11111111-2222-4333-8444-555555555555";
+const NOW = "2026-06-28T15:00:00+05:00";
+
+/** Same CORE_SCHEMA codec the plugin wires in production (coreSchemaYamlCodec). */
+const codec: YamlCodec = {
+  parse: (t) => yaml.load(t, { schema: yaml.CORE_SCHEMA }),
+  stringify: (v) => yaml.dump(v, { schema: yaml.CORE_SCHEMA, lineWidth: -1 }),
+};
+
+interface Written {
+  mountPath: string;
+  fileName: string;
+  content: string;
+}
+
+interface Harness {
+  cmd: RegisterForSyncCommand;
+  written: Written[];
+  notices: string[];
+  reindexCalls: number;
+  deps: RegisterForSyncDeps;
+}
+
+function makeCmd(opts: {
+  packs?: string[];
+  pick?: string | null;
+  promptUrl?: string | null;
+  ownership?: boolean | null;
+  hasDescriptor?: boolean;
+  writeThrows?: boolean;
+} = {}): Harness {
+  const written: Written[] = [];
+  const notices: string[] = [];
+  let reindexCalls = 0;
+  const deps: RegisterForSyncDeps = {
+    listUnregisteredPacks: async () =>
+      opts.packs ?? ["assetspaces/kitelev/exoas-foo"],
+    pickPack: async () => opts.pick ?? null,
+    promptSourceUrl: async () =>
+      opts.promptUrl === undefined ? null : opts.promptUrl,
+    probeOwnership: async () =>
+      opts.ownership === undefined ? null : opts.ownership,
+    ...(opts.hasDescriptor !== undefined
+      ? { hasDescriptor: async () => opts.hasDescriptor! }
+      : {}),
+    newUid: () => UID,
+    now: () => NOW,
+    codec,
+    writeDescriptor: async (mountPath, fileName, content) => {
+      if (opts.writeThrows) throw new Error("EACCES: read-only folder");
+      written.push({ mountPath, fileName, content });
+    },
+    notify: (m) => notices.push(m),
+    onMaterialized: async () => {
+      reindexCalls++;
+    },
+  };
+  return { cmd: new RegisterForSyncCommand(deps), written, notices, reindexCalls: 0, deps };
+}
+
+/** Parse the frontmatter object out of a written descriptor file. */
+function parseFrontmatter(content: string): Record<string, unknown> {
+  const m = content.match(/^---\n([\s\S]*?)\n---/);
+  if (m === null) throw new Error("no frontmatter block");
+  return yaml.load(m[1], { schema: yaml.CORE_SCHEMA }) as Record<string, unknown>;
+}
+
+describe("RegisterForSyncCommand (#3707)", () => {
+  it("@req:f3465725-b02d-4d20-b05a-69881a783552 writes a descriptor that the REAL ExoSync discriminator enumerates into the sync set", async () => {
+    // Revert-verify binding: the command writes the descriptor; we feed exactly
+    // that descriptor through the genuine sync-set discriminator
+    // (classifySpaceDeclaration). With the descriptor builder in place this is a
+    // sync candidate (pack ENTERS the materialized set, GREEN); reverting the
+    // builder (omit instance_class / _source) makes it a non-sync-unit (pack
+    // stays OUT, RED). al-3707-register-sync, 2026-06-28.
+    const h = makeCmd({ packs: ["assetspaces/kitelev/exoas-foo"] });
+    await h.cmd.invoke();
+
+    expect(h.written).toHaveLength(1);
+    const w = h.written[0];
+    expect(w.mountPath).toBe("assetspaces/kitelev/exoas-foo");
+    expect(w.fileName).toBe(`${UID}.md`);
+
+    const fm = parseFrontmatter(w.content);
+    const verdict = classifySpaceDeclaration(
+      fm,
+      `${w.mountPath}/${w.fileName}`,
+    );
+    expect(verdict.kind).toBe("candidate");
+    if (verdict.kind === "candidate") {
+      // The pack is now in the materialized sync set under its derived repoKey.
+      expect(verdict.candidate.spec.repoKey).toBe("kitelev/exoas-foo#main");
+      expect(verdict.candidate.spec.localPath).toBe(
+        "assetspaces/kitelev/exoas-foo",
+      );
+    }
+  });
+
+  it("auto-fills the source URL from the Maven mount path (no prompt)", async () => {
+    const promptSpy = jest.fn(async () => null as string | null);
+    const h = makeCmd({ packs: ["assetspaces/kitelev/exoas-bar"] });
+    h.deps.promptSourceUrl = promptSpy;
+    await h.cmd.invoke();
+    expect(promptSpy).not.toHaveBeenCalled();
+    const fm = parseFrontmatter(h.written[0].content);
+    expect(fm["exo__AssetSpace_source"]).toBe(
+      "https://github.com/kitelev/exoas-bar",
+    );
+  });
+
+  it("prompts for the source URL when the mount path is un-derivable (legacy flat folder)", async () => {
+    const h = makeCmd({
+      packs: ["assetspaces/legacyflat"],
+      promptUrl: "https://github.com/kitelev/exoas-legacy",
+    });
+    await h.cmd.invoke();
+    expect(h.written).toHaveLength(1);
+    const fm = parseFrontmatter(h.written[0].content);
+    expect(fm["exo__AssetSpace_source"]).toBe(
+      "https://github.com/kitelev/exoas-legacy",
+    );
+    // It is still written INTO the original (flat) mount folder.
+    expect(h.written[0].mountPath).toBe("assetspaces/legacyflat");
+  });
+
+  it("reindexes after a successful write", async () => {
+    let reindexed = 0;
+    const h = makeCmd();
+    h.deps.onMaterialized = async () => {
+      reindexed++;
+    };
+    await h.cmd.invoke();
+    expect(reindexed).toBe(1);
+  });
+
+  it("OWNED pack → claims pull AND push", async () => {
+    const h = makeCmd({ ownership: true });
+    await h.cmd.invoke();
+    expect(h.notices.join("\n")).toMatch(/pull AND push/);
+  });
+
+  it("READ-ONLY pack → pull-only warning, never a push claim", async () => {
+    const h = makeCmd({ ownership: false });
+    await h.cmd.invoke();
+    const joined = h.notices.join("\n");
+    expect(joined).toMatch(/pull-only/);
+    expect(joined).not.toMatch(/pull AND push/);
+  });
+
+  it("UNKNOWN ownership (no token) → set-a-token nudge", async () => {
+    const h = makeCmd({ ownership: null });
+    await h.cmd.invoke();
+    expect(h.notices.join("\n")).toMatch(/Set a GitHub token/);
+  });
+
+  it("nothing to register → notice, no write, no reindex", async () => {
+    let reindexed = 0;
+    const h = makeCmd({ packs: [] });
+    h.deps.onMaterialized = async () => {
+      reindexed++;
+    };
+    await h.cmd.invoke();
+    expect(h.written).toHaveLength(0);
+    expect(reindexed).toBe(0);
+    expect(h.notices.join("\n")).toMatch(/nothing to do/);
+  });
+
+  it("multiple packs → uses the picker; cancel writes nothing", async () => {
+    const h = makeCmd({
+      packs: ["assetspaces/kitelev/exoas-a", "assetspaces/kitelev/exoas-b"],
+      pick: null, // user cancels
+    });
+    await h.cmd.invoke();
+    expect(h.written).toHaveLength(0);
+  });
+
+  it("multiple packs → registers the picked one", async () => {
+    const h = makeCmd({
+      packs: ["assetspaces/kitelev/exoas-a", "assetspaces/kitelev/exoas-b"],
+      pick: "assetspaces/kitelev/exoas-b",
+    });
+    await h.cmd.invoke();
+    expect(h.written).toHaveLength(1);
+    expect(h.written[0].mountPath).toBe("assetspaces/kitelev/exoas-b");
+    const fm = parseFrontmatter(h.written[0].content);
+    expect(fm["exo__AssetSpace_namespace"]).toBe("b");
+  });
+
+  it("read-only FOLDER (write throws) → warns and does NOT reindex", async () => {
+    let reindexed = 0;
+    const h = makeCmd({ writeThrows: true });
+    h.deps.onMaterialized = async () => {
+      reindexed++;
+    };
+    await h.cmd.invoke();
+    expect(h.written).toHaveLength(0);
+    expect(reindexed).toBe(0);
+    expect(h.notices.join("\n")).toMatch(/could not write the descriptor/);
+  });
+
+  it("already-registered pack (hasDescriptor) → skips the write", async () => {
+    const h = makeCmd({ hasDescriptor: true });
+    await h.cmd.invoke();
+    expect(h.written).toHaveLength(0);
+    expect(h.notices.join("\n")).toMatch(/already has a descriptor/);
+  });
+});

--- a/packages/obsidian-plugin/tests/unit/infrastructure/adapters/RegisterForSyncCommand.test.ts
+++ b/packages/obsidian-plugin/tests/unit/infrastructure/adapters/RegisterForSyncCommand.test.ts
@@ -31,7 +31,6 @@ interface Harness {
 function makeCmd(opts: {
   packs?: string[];
   pick?: string | null;
-  promptUrl?: string | null;
   ownership?: boolean | null;
   hasDescriptor?: boolean;
   writeThrows?: boolean;
@@ -43,8 +42,6 @@ function makeCmd(opts: {
     listUnregisteredPacks: async () =>
       opts.packs ?? ["assetspaces/kitelev/exoas-foo"],
     pickPack: async () => opts.pick ?? null,
-    promptSourceUrl: async () =>
-      opts.promptUrl === undefined ? null : opts.promptUrl,
     probeOwnership: async () =>
       opts.ownership === undefined ? null : opts.ownership,
     ...(opts.hasDescriptor !== undefined
@@ -103,31 +100,28 @@ describe("RegisterForSyncCommand (#3707)", () => {
     }
   });
 
-  it("auto-fills the source URL from the Maven mount path (no prompt)", async () => {
-    const promptSpy = jest.fn(async () => null as string | null);
+  it("auto-fills the source URL from the canonical Maven mount path", async () => {
     const h = makeCmd({ packs: ["assetspaces/kitelev/exoas-bar"] });
-    h.deps.promptSourceUrl = promptSpy;
     await h.cmd.invoke();
-    expect(promptSpy).not.toHaveBeenCalled();
     const fm = parseFrontmatter(h.written[0].content);
     expect(fm["exo__AssetSpace_source"]).toBe(
       "https://github.com/kitelev/exoas-bar",
     );
   });
 
-  it("prompts for the source URL when the mount path is un-derivable (legacy flat folder)", async () => {
-    const h = makeCmd({
-      packs: ["assetspaces/legacyflat"],
-      promptUrl: "https://github.com/kitelev/exoas-legacy",
-    });
+  it("HONESTLY refuses a non-canonical (un-derivable) mount path — no write, no false success", async () => {
+    // A flat / non-`assetspaces/<owner>/<repo>` folder has no determinable GitHub
+    // source; registering it would write a descriptor whose derived localPath
+    // could not match the folder, so it would never sync — refuse instead.
+    let reindexed = 0;
+    const h = makeCmd({ packs: ["assetspaces/legacyflat"] });
+    h.deps.onMaterialized = async () => {
+      reindexed++;
+    };
     await h.cmd.invoke();
-    expect(h.written).toHaveLength(1);
-    const fm = parseFrontmatter(h.written[0].content);
-    expect(fm["exo__AssetSpace_source"]).toBe(
-      "https://github.com/kitelev/exoas-legacy",
-    );
-    // It is still written INTO the original (flat) mount folder.
-    expect(h.written[0].mountPath).toBe("assetspaces/legacyflat");
+    expect(h.written).toHaveLength(0);
+    expect(reindexed).toBe(0);
+    expect(h.notices.join("\n")).toMatch(/cannot be determined|cannot register/);
   });
 
   it("reindexes after a successful write", async () => {


### PR DESCRIPTION
## What

A knowledge pack added via «Add a knowledge pack» (tarball mount, RFC 0005 Phase 1) materialises at `assetspaces/<owner>/<repo>` but carries **no `exo__AssetSpace` descriptor of its own**, so ExoSync's class-based, vault-wide discovery (`classifySpaceDeclaration` over `exo__AssetSpace` + a `_source`) never enumerates it into the materialized sync set — the user's edits in it **silently do not sync** (FINDING-3; `collectSyncRepoSpecs` surfaces it only as a `mountedNotDeclared` notice).

New palette command **«Exocortex: Register for sync»** closes the gap: it lists the mounted-but-undeclared packs, resolves each pack's GitHub source URL (auto-filled by reversing the Maven mount path via `deriveUrl`; prompted only when un-derivable), determines ownership by probing the PAT's push access, and writes a UID-named `exo__AssetSpace` descriptor **into the pack folder** — `exo__Instance_class` exo__AssetSpace, `exo__AssetSpace_source` = the plain `https://github.com/<owner>/<repo>` URL, `exo__AssetSpace_namespace` = the repo basename minus `exoas-`, and a **self-anchor** `exo__Asset_isDefinedBy` so co-location keeps the descriptor in the pack folder. Then it incrementally reindexes so the pack appears in `exosync-parity`/`sync` immediately and the «won't sync» state clears.

**Honest ownership semantics:** owned packs (PAT has push access) are told edits will pull **and** push; read-only/foreign packs (no push access) are registered **pull-only** with an explicit warning that edits won't push and the registration won't round-trip to a fresh device — the affordance never makes a false push claim.

**Desktop↔Mobile Command Parity:** the descriptor write is a single `vault.adapter.write` (no Node `fs`/git), so the command registers **unconditionally** on both platforms; the same path runs on iOS.

## How

- **core** — `buildAssetSpaceDescriptor` + `deriveAssetSpaceNamespace` (pure, platform-free; `packages/core/src/services/sync/registerForSync.ts`).
- **plugin** — `RegisterForSyncCommand` (injected deps, no Obsidian imports) + `GitHubRestClient.getRepoPushAccess` (best-effort, `null` on no-PAT/error) + `ExocortexPlugin.registerRegisterForSyncCommand` wiring.

## Tests

- 9 core (`registerForSync.test.ts`) + 12 plugin (`RegisterForSyncCommand.test.ts`): descriptor shape, `.git`-strip, namespace override, null guards, ownership branching (owned/read-only/unknown notices), auto-fill-vs-prompt source-URL fallback, multi-pack picker, "nothing to register", read-only-folder write failure, double-register guard.

**Revert-verified** (`@req:f3465725-b02d-4d20-b05a-69881a783552`): reverting the descriptor builder's `exo__Instance_class` emission → the command's descriptor classifies as `not-space` (pack stays **OUT** of the materialized sync set) — **RED** (`@req` test + core discriminator test fail); restored → classifies as a sync **candidate** (`kitelev/exoas-foo#main`, pack **enters** the set) — **GREEN**.

Req: f3465725-b02d-4d20-b05a-69881a783552
Closes #3707
