### PR TITLE
fix(deps): bump js-yaml to ^4.2.0 (GHSA-h67p-54hq-rp68 DoS, alert #102)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11411,9 +11411,19 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -16108,7 +16118,7 @@
         "commander": "^14.0.2",
         "fs-extra": "^11.0.0",
         "glob": "^10.3.0",
-        "js-yaml": "^4.1.1",
+        "js-yaml": "^4.2.0",
         "minimatch": "^10.2.4",
         "nanotar": "0.3.0",
         "ora": "^9.0.0"
@@ -16215,7 +16225,7 @@
         "eslint": "^9.38.0",
         "fast-check": "^3.23.2",
         "jest": "^30.0.0",
-        "js-yaml": "^4.1.1",
+        "js-yaml": "^4.2.0",
         "ts-jest": "^29.4.6",
         "typescript": "^5.9.3"
       }
@@ -16288,7 +16298,7 @@
         "jest": "^30.0.5",
         "jest-environment-jsdom": "^30.2.0",
         "jest-environment-obsidian": "^0.0.1",
-        "js-yaml": "^4.1.0"
+        "js-yaml": "^4.2.0"
       }
     },
     "packages/obsidian-plugin/node_modules/@codemirror/state": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -51,7 +51,7 @@
     "commander": "^14.0.2",
     "fs-extra": "^11.0.0",
     "glob": "^10.3.0",
-    "js-yaml": "^4.1.1",
+    "js-yaml": "^4.2.0",
     "minimatch": "^10.2.4",
     "nanotar": "0.3.0",
     "ora": "^9.0.0"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -54,7 +54,7 @@
     "eslint": "^9.38.0",
     "fast-check": "^3.23.2",
     "jest": "^30.0.0",
-    "js-yaml": "^4.1.1",
+    "js-yaml": "^4.2.0",
     "ts-jest": "^29.4.6",
     "typescript": "^5.9.3"
   }

--- a/packages/obsidian-plugin/package.json
+++ b/packages/obsidian-plugin/package.json
@@ -44,6 +44,6 @@
     "jest": "^30.0.5",
     "jest-environment-jsdom": "^30.2.0",
     "jest-environment-obsidian": "^0.0.1",
-    "js-yaml": "^4.1.0"
+    "js-yaml": "^4.2.0"
   }
 }


### PR DESCRIPTION
## What

Bumps `js-yaml` floor `^4.1.x` → `^4.2.0` in all 3 declaring packages; lockfile resolves **js-yaml@4.3.0**.

## Why

**Dependabot alert #102** — `GHSA-h67p-54hq-rp68`: quadratic-complexity DoS in merge-key handling via repeated YAML aliases (CVSS 5.3 moderate, CWE-407). Affected range `<= 4.1.1`, patched in `4.2.0`.

- **Runtime exposure** = the **CLI frontmatter parser** (`packages/cli` — `js-yaml` is a direct `dependencies` entry). Vault `.md` files are attacker-influenceable input, so the DoS is real for the runtime path.
- `packages/core` + `packages/obsidian-plugin` declare `js-yaml` as `devDependencies` (test-only); bumped for hygiene + lockfile consistency.

## Verification

- `npm install` regenerated root `package-lock.json` → `js-yaml@4.3.0` (vulnerable 4.x gone from runtime tree).
- `npm run check:types` → **0 errors** (bump is within the same major, API-compatible).
- Diff is **package.json + lockfile only** — no source changes.

## Out of scope — alert #107 (intentionally not addressed here)

Alert #107 (`scope: development`, `packages/core/package-lock.json`) is the **transitive** `js-yaml@3.14.2` pulled via `babel-jest → babel-plugin-istanbul → @istanbuljs/load-nyc-config`. `fixAvailable: false` — no upstream version of the istanbul chain accepts a patched js-yaml. It is:

- **dev-scope only** (coverage instrumentation, never shipped),
- **not attacker-reachable** (load-nyc-config parses self-controlled coverage config, not vault data),
- and forcing a `js-yaml@^4.2.0` `overrides` would **break** `load-nyc-config@1.1.0` (js-yaml 4.x removed `safeLoad`) for zero real-world security benefit.

Left as-is deliberately.

Closes #102 (after merge, Dependabot auto-resolves the runtime alert).