### PR TITLE
feat(relations): empty-state «+ Add relation» affordance (read-view, 0 relations)

### DIFF
--- a/packages/obsidian-plugin/src/presentation/renderers/layout/RelationsRenderer.ts
+++ b/packages/obsidian-plugin/src/presentation/renderers/layout/RelationsRenderer.ts
@@ -154,6 +154,20 @@ export interface UniversalLayoutConfig {
 export const RELATIONS_EMPTY_TEXT = "No related assets yet";
 
 /**
+ * PDD `4d7decb9` — user-facing copy for the empty-state «+ Add relation»
+ * affordance.
+ *
+ * Shown inside the Relations empty-state (a zero-relations / first-run asset)
+ * when the renderer knows the asset (`currentFile`). The block-level
+ * «✎ Edit relations» affordance (PDD `dccff87b`) only renders in the ≥1-relation
+ * branch, so on a zero-relations asset the FIRST relation was reachable only via
+ * Cmd+P — a discoverability gap for the exact new-user empty-state. This
+ * affordance closes it, opening the SAME relations editor as the ≥1-branch and
+ * Cmd+P (single source of truth: {@link RelationsRenderer.openRelationsEditor}).
+ */
+export const RELATIONS_EMPTY_ADD_TEXT = "+ Add relation";
+
+/**
  * Legacy hardcoded fallback map for `groupSpecificProperties`.
  *
  * Captures the exact behaviour shipped pre-RFC be70f741 so that existing
@@ -566,10 +580,38 @@ export class RelationsRenderer {
     // skeleton, but settled (no pulse): this is a genuine empty result, not a
     // transient indexing placeholder.
     if (relations.length === 0) {
-      contentContainer.createDiv({
+      const emptyEl = contentContainer.createDiv({
         cls: "exocortex-relations-empty",
         text: RELATIONS_EMPTY_TEXT,
       });
+      // PDD `4d7decb9` — empty-state «+ Add relation» affordance. The ≥1-branch
+      // block-level «Edit relations» button never renders here (no relations to
+      // attach it to), so on a zero-relations asset — exactly the new-user /
+      // first-run empty-state — the only path to the FIRST relation was Cmd+P.
+      // When the renderer knows the asset (currentFile), surface a clickable
+      // «+ Add relation» button INSIDE the empty-state section, right under the
+      // muted "No related assets yet" text (placement decision per AC #3: it
+      // lives in the empty-state block since there is no Relations table to host
+      // a block-level affordance). It opens the SAME relations editor as the
+      // ≥1-branch affordance and Cmd+P via openRelationsEditor() (single source
+      // of truth → exocortex:edit-properties command). currentFile-gated →
+      // legacy callers render no affordance (additive, zero read-view
+      // regression). Parity-safe: Obsidian-core executeCommandById only, no
+      // platform gate (Desktop↔Mobile Command Parity invariant).
+      if (currentFile) {
+        const addRelationBtn = emptyEl.createEl("button", {
+          cls: "exocortex-relations-empty-add",
+          text: RELATIONS_EMPTY_ADD_TEXT,
+          attr: {
+            type: "button",
+            "aria-label": "Add relation",
+            title: "Add relation",
+          },
+        });
+        addRelationBtn.addEventListener("click", () =>
+          this.openRelationsEditor(),
+        );
+      }
       return;
     }
 

--- a/packages/obsidian-plugin/styles.css
+++ b/packages/obsidian-plugin/styles.css
@@ -5996,6 +5996,20 @@
   border-radius: var(--radius-s, 4px);
 }
 
+/* PDD 4d7decb9 — empty-state «+ Add relation» affordance: a clickable button
+   inside the Relations empty-state (zero-relations / first-run) so a new user
+   can add their FIRST relation from read-view without Cmd+P. Sits on its own
+   line under the muted "No related assets yet" text; font-style reset so it
+   reads as an action, not muted prose. */
+.exocortex-relations-empty-add {
+  display: inline-block;
+  margin-top: var(--size-4-2, 8px);
+  padding: var(--size-4-1, 4px) var(--size-4-2, 8px);
+  font-style: normal;
+  font-size: var(--font-smaller, 0.85em);
+  cursor: pointer;
+}
+
 /* T1 "Create Instance" (project bbe40f8c) — fuzzy reference-picker dropdown.
    The picker input reuses .dynamic-form-input; these rules style the
    candidate list and the keyboard-active option so sighted keyboard users

--- a/packages/obsidian-plugin/tests/unit/RelationsRenderer.test.ts
+++ b/packages/obsidian-plugin/tests/unit/RelationsRenderer.test.ts
@@ -2,6 +2,7 @@ import React from "react";
 import {
   RelationsRenderer,
   RELATIONS_EMPTY_TEXT,
+  RELATIONS_EMPTY_ADD_TEXT,
   isNonRelationPredicate,
   predicateIriToKey,
 } from "../../src/presentation/renderers/layout/RelationsRenderer";
@@ -788,6 +789,71 @@ describe("RelationsRenderer", () => {
         expect(renderHeader).toHaveBeenCalled();
         expect(mockElement.querySelector(".exocortex-relations-empty")).toBeNull();
         expect(mockReactRenderer.render).not.toHaveBeenCalled();
+      });
+    });
+
+    // PDD `4d7decb9` — empty-state «+ Add relation» affordance (read-view, 0
+    // relations). The ≥1-branch block-level «Edit relations» affordance never
+    // renders on a zero-relations asset, so the first relation was reachable
+    // only via Cmd+P. This affordance closes that new-user discoverability gap.
+    // @req:57fc5804-2c67-4fb6-ba3d-5bac562da7c1
+    describe("«+ Add relation» empty-state affordance (PDD 4d7decb9)", () => {
+      it("renders a clickable «+ Add relation» affordance in the empty-state that opens the relations editor when currentFile is provided @req:57fc5804-2c67-4fb6-ba3d-5bac562da7c1", async () => {
+        const executeCommandById = jest.fn();
+        mockApp.commands = { executeCommandById };
+
+        await renderer.render(mockElement, [], {}, undefined, false, mockFile);
+
+        // affordance lives INSIDE the empty-state section (AC #3 placement),
+        // under the muted "No related assets yet" text.
+        const addBtn = mockElement.querySelector(
+          ".exocortex-relations-empty .exocortex-relations-empty-add",
+        );
+        expect(addBtn).not.toBeNull();
+        expect(addBtn?.textContent).toBe(RELATIONS_EMPTY_ADD_TEXT);
+
+        // Behaviour, not method-exists: activating it drives the registered
+        // edit-properties command — the same single-source-of-truth editor flow
+        // as the ≥1-branch affordance and Cmd+P.
+        (addBtn as HTMLButtonElement).click();
+        expect(executeCommandById).toHaveBeenCalledWith(
+          "exocortex:edit-properties",
+        );
+      });
+
+      it("renders NO «+ Add relation» affordance in the empty-state when currentFile is absent (additive — back-compat) @req:57fc5804-2c67-4fb6-ba3d-5bac562da7c1", async () => {
+        await renderer.render(mockElement, [], {});
+
+        expect(
+          mockElement.querySelector(".exocortex-relations-empty-add"),
+        ).toBeNull();
+        // the muted empty-state text itself still renders (section discoverable)
+        const emptyState = mockElement.querySelector(
+          ".exocortex-relations-empty",
+        );
+        expect(emptyState).not.toBeNull();
+        expect(emptyState?.textContent).toBe(RELATIONS_EMPTY_TEXT);
+      });
+
+      it("does not add the empty-state affordance on the ≥1-relation path (block-level editor wiring unaffected) @req:57fc5804-2c67-4fb6-ba3d-5bac562da7c1", async () => {
+        const executeCommandById = jest.fn();
+        mockApp.commands = { executeCommandById };
+        const relations = [createMockAssetRelation()];
+
+        await renderer.render(
+          mockElement,
+          relations,
+          {},
+          undefined,
+          false,
+          mockFile,
+        );
+
+        // ≥1 branch renders the React table; no empty-state affordance leaks in.
+        expect(
+          mockElement.querySelector(".exocortex-relations-empty-add"),
+        ).toBeNull();
+        expect(mockReactRenderer.render).toHaveBeenCalled();
       });
     });
 


### PR DESCRIPTION
## What

Adds a **«+ Add relation»** affordance to the read-view Asset Relations **empty-state** (an asset with **zero** relations), opening the current asset's relations editor.

## Why

The block-level «✎ Edit relations» affordance (PR #3774 / req `cbb982a3`) renders **only** in the ≥1-relation branch — it lives on the React relations table. On a **zero-relations** asset the Relations block degrades to the muted F11 empty-state («No related assets yet») and shows **no editor entry point** at all, so the **first** relation was reachable only via the command palette (Cmd+P → «Edit properties»).

A zero-relations asset is exactly the **new-user / first-run empty-state** — and a fresh tester does not know the palette command. This closes that read-view onboarding gap (milestone `ec01fc7d`, PDD puzzle `4d7decb9`).

## How (additive, surgical)

- `RelationsRenderer.render()` empty-state branch: when the optional `currentFile` is provided, append a clickable `.exocortex-relations-empty-add` `<button>` (text `RELATIONS_EMPTY_ADD_TEXT` = «+ Add relation») **inside** the `.exocortex-relations-empty` section, under the muted text.
- Click → `openRelationsEditor()` → `app.commands.executeCommandById('exocortex:edit-properties')` — the **same single source of truth** as the ≥1-branch affordance, the palette, and the ribbon.
- **Placement (AC #3):** inside the empty-state block (there is no Relations table in the empty-state to host a block-level affordance) — documented in a code comment.
- **`currentFile`-gated → additive:** legacy callers that don't thread `currentFile` render no affordance (zero read-view regression). The ≥1-relation path is unaffected.
- **Parity-safe:** Obsidian-core `executeCommandById` only, no platform gate (Desktop↔Mobile Command Parity invariant). Both read-view callers (`UniversalLayoutRenderer`, `IncrementalUpdateHandler`) already thread `currentFile`, so the empty-state receives it in production.
- `styles.css` — `.exocortex-relations-empty-add` rule.

## Spec-Driven Development (RFC 0003)

- **Requirement:** `req:57fc5804-2c67-4fb6-ba3d-5bac562da7c1` (`exoas-exo-reqs`, status proposed → flips Active after this merge lands the `@req` binding in `main`). Orchestrator pre-approved scope.
  Review: https://github.com/kitelev/exoas-exo-reqs/blob/main/exo-reqs/57fc5804-2c67-4fb6-ba3d-5bac562da7c1.md
- **Bound test:** `RelationsRenderer.test.ts` → `«+ Add relation» empty-state affordance (PDD 4d7decb9)`, tagged `@req:57fc5804-2c67-4fb6-ba3d-5bac562da7c1` (3 cases: currentFile→affordance+click drives `exocortex:edit-properties`; no-currentFile→absent (additive); ≥1 path unaffected).
- **Revert-verified:** removing the empty-state affordance block → the currentFile case goes **RED** while the additive + ≥1-path guards stay GREEN (compiles cleanly — type-preserving); restore → **GREEN 87/87**.

## Test plan

- `npm run check:types` → 0 errors
- `eslint --max-warnings=0` on changed src → clean
- CI `lint`-gate guards (antipattern 55/55 baseline, shard-assignments, coverage-monotonic) → pass
- `RelationsRenderer.test.ts` → 87/87

Req: 57fc5804-2c67-4fb6-ba3d-5bac562da7c1
