### PR TITLE
feat(dynamic-form): resolve $today defaultValue to today's date in create-task modal (req 57b03ab3)

### DIFF
--- a/packages/obsidian-plugin/src/presentation/components/dynamic-form/DynamicForm.tsx
+++ b/packages/obsidian-plugin/src/presentation/components/dynamic-form/DynamicForm.tsx
@@ -29,6 +29,23 @@ function normalizeEnumOption(opt: string | EnumOption): EnumOption {
   return typeof opt === "string" ? { value: opt, label: opt } : opt;
 }
 
+/**
+ * Resolve a field's `defaultValue`, expanding the `$today` token to today's
+ * date as `YYYY-MM-DD` so a `type="date"` input pre-fills with today (feature
+ * ec15f83e / req 57b03ab3 — the create-task-instance modal's planned-date field).
+ *
+ * Uses the UTC date slice (`toISOString().slice(0, 10)`) on purpose: it mirrors
+ * the engine's own `$today` basis (`GroundingExecutor.resolveInstanceDate` /
+ * label-template `$today` both slice `clock.now().toISOString()`), so the
+ * pre-filled modal date, the derived label, and the planned timestamps all
+ * agree by default. Any non-`$today` value (including a literal `YYYY-MM-DD`)
+ * passes through verbatim.
+ */
+function resolveDefaultValue(raw: string | undefined): string {
+  if (raw === "$today") return new Date().toISOString().slice(0, 10);
+  return raw ?? "";
+}
+
 export const DynamicForm: React.FC<DynamicFormProps> = ({
   schema,
   onSubmit,
@@ -39,7 +56,7 @@ export const DynamicForm: React.FC<DynamicFormProps> = ({
   const initialValues = useMemo(() => {
     const values: Record<string, string> = {};
     for (const field of schema) {
-      values[field.name] = field.defaultValue ?? "";
+      values[field.name] = resolveDefaultValue(field.defaultValue);
     }
     return values;
   }, [schema]);

--- a/packages/obsidian-plugin/tests/unit/presentation/components/DynamicForm.test.tsx
+++ b/packages/obsidian-plugin/tests/unit/presentation/components/DynamicForm.test.tsx
@@ -101,6 +101,26 @@ describe("DynamicForm", () => {
       expect(screen.getByTestId("field-plannedDate")).toHaveValue("2026-01-15");
       expect(screen.getByTestId("field-note")).toHaveValue("$todayish");
     });
+
+    // Locks the load-bearing UTC decision: at an instant where the Almaty
+    // (UTC+5) local date (2026-06-29) differs from the UTC date (2026-06-28),
+    // the resolved value must follow the engine's UTC slice — NOT the local
+    // date — so the modal date, label `$today`, and planned timestamps agree.
+    // `toISOString()` is timezone-independent, so this never flakes on the impl;
+    // it only fails if someone reimplements with local date components.
+    it("@req:57b03ab3 uses the engine's UTC date, not the local-timezone date, across midnight", () => {
+      const prevTz = process.env.TZ;
+      process.env.TZ = "Asia/Almaty";
+      try {
+        jest.setSystemTime(new Date("2026-06-28T23:30:00Z")); // 04:30 next day in Almaty
+        renderForm([
+          { name: "plannedDate", type: "date", defaultValue: "$today" },
+        ]);
+        expect(screen.getByTestId("field-plannedDate")).toHaveValue("2026-06-28");
+      } finally {
+        process.env.TZ = prevTz;
+      }
+    });
   });
 
   // T3 «Create Instance» — number/boolean field types for required-property

--- a/packages/obsidian-plugin/tests/unit/presentation/components/DynamicForm.test.tsx
+++ b/packages/obsidian-plugin/tests/unit/presentation/components/DynamicForm.test.tsx
@@ -63,6 +63,46 @@ describe("DynamicForm", () => {
     });
   });
 
+  // Feature ec15f83e / req 57b03ab3 — the create-task-instance modal pre-fills
+  // its planned-date field with today via the `$today` token in defaultValue.
+  // UTC date slice mirrors the engine's $today basis (GroundingExecutor /
+  // labelTemplate) so the modal date, label, and planned timestamps agree.
+  describe("$today defaultValue token (req 57b03ab3)", () => {
+    beforeEach(() => {
+      jest.useFakeTimers();
+      jest.setSystemTime(new Date("2026-06-28T10:00:00Z"));
+    });
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
+    it("@req:57b03ab3 resolves a date field's '$today' defaultValue to today's date", () => {
+      renderForm([{ name: "plannedDate", type: "date", defaultValue: "$today" }]);
+      expect(screen.getByTestId("field-plannedDate")).toHaveValue("2026-06-28");
+    });
+
+    it("@req:57b03ab3 submits the resolved today date as the field value", () => {
+      const { onSubmit } = renderForm([
+        { name: "label", type: "text", defaultValue: "x" },
+        { name: "plannedDate", type: "date", defaultValue: "$today" },
+      ]);
+      fireEvent.click(screen.getByText("OK"));
+      expect(onSubmit).toHaveBeenCalledWith({
+        label: "x",
+        plannedDate: "2026-06-28",
+      });
+    });
+
+    it("@req:57b03ab3 leaves a literal date and non-'$today' text defaultValue untouched", () => {
+      renderForm([
+        { name: "plannedDate", type: "date", defaultValue: "2026-01-15" },
+        { name: "note", type: "text", defaultValue: "$todayish" },
+      ]);
+      expect(screen.getByTestId("field-plannedDate")).toHaveValue("2026-01-15");
+      expect(screen.getByTestId("field-note")).toHaveValue("$todayish");
+    });
+  });
+
   // T3 «Create Instance» — number/boolean field types for required-property
   // datatype ranges (xsd:integer/decimal/… → number, xsd:boolean → boolean).
   describe("number field (T3)", () => {


### PR DESCRIPTION
## What
The create-task-instance modal's planned-date field carries `defaultValue: "$today"`. `DynamicForm` copied `defaultValue` verbatim, so a `type="date"` input pre-filled with the literal `"$today"` (invalid → blank) instead of today's date.

`resolveDefaultValue()` now expands the `$today` token to today's date as `YYYY-MM-DD` via the **UTC date slice** (`new Date().toISOString().slice(0, 10)`) — the **same basis** the engine uses for `$today` (`GroundingExecutor.resolveInstanceDate` + label-template `$today`), so the pre-filled modal date, the derived label, and the planned timestamps **agree by default**. Any non-`$today` value (including a literal `YYYY-MM-DD`) passes through verbatim.

## Why
Completes the **user-facing modal surface** of feature ec15f83e (auto-propagate prototype time → instance planned timestamps). The executor side shipped in PR #3782 (CLI `--input '{"plannedDate":...}'` already works); this is the missing piece so the Obsidian modal shows a date field defaulting to today. The vault grounding's `inputSchema` will add the `plannedDate` field after this lands.

## Scope
Presentation-only (`DynamicForm.tsx`). No parser / executor / TBox path touched.

## Tests (revert-verified)
3 new tests `@req:57b03ab3` (jest fake-timers for determinism):
- resolves a date field's `$today` defaultValue → today's date
- submits the resolved today date as the field value
- leaves a literal date / non-`$today` text defaultValue untouched (control)

**Revert-verified:** reverting `resolveDefaultValue` to verbatim → the 2 token tests go RED (`plannedDate "$today"` not `"2026-06-28"`); restored → 47/47 GREEN.

Req: 57b03ab3-9666-4c5a-8f38-cf650e4f48d2

https://claude.ai/code/session_01M8xZAX8JZznff2yAL7nzCk