### PR TITLE
fix(test): align UniversalLayout UI empty-state assertion with «+ Add relation» affordance (#3787 follow-up)

### DIFF
--- a/packages/obsidian-plugin/tests/ui/UniversalLayoutRenderer.ui.test.ts
+++ b/packages/obsidian-plugin/tests/ui/UniversalLayoutRenderer.ui.test.ts
@@ -478,7 +478,18 @@ describe("UniversalLayoutRenderer UI Integration", () => {
         ".exocortex-relations-empty",
       );
       expect(emptyState).toBeTruthy();
-      expect(emptyState?.textContent).toBe("No related assets yet");
+      // PDD 4d7decb9 — the empty-state now also hosts a «+ Add relation»
+      // affordance: UniversalLayoutRenderer threads the asset's currentFile into
+      // RelationsRenderer.render, so the muted text is the leading content but no
+      // longer the WHOLE textContent. Assert the muted copy is present AND the
+      // affordance is rendered (the real layout-integration path proves it ships
+      // with currentFile, opening the relations editor).
+      expect(emptyState?.textContent).toContain("No related assets yet");
+      const addRelationAffordance = emptyState?.querySelector(
+        ".exocortex-relations-empty-add",
+      );
+      expect(addRelationAffordance).toBeTruthy();
+      expect(addRelationAffordance?.textContent).toBe("+ Add relation");
 
       // No relations table is rendered when there are no relations.
       expect(


### PR DESCRIPTION
## What

Test-only follow-up to #3787. Aligns the `UniversalLayoutRenderer` UI integration test's empty-state assertion with the «+ Add relation» affordance shipped in #3787.

## Why

#3787 added a `currentFile`-gated «+ Add relation» affordance to the read-view Relations **empty-state**. `UniversalLayoutRenderer` threads the asset's `currentFile` into `RelationsRenderer.render`, so in the real layout-integration path the empty-state `textContent` is now `"No related assets yet+ Add relation"`, not the bare muted text.

The **non-required** `test-ui` job (`jest.ui.config.js`) asserted exact `textContent` equality. Because `test-ui` is **not** one of the 14 required checks, it passed #3787's merge gate but **failed on the push-to-main CI run** → the CI workflow concluded `failure` → **Auto Release was gated to `skipped`** (no release published after the merge). See `~/dotfiles/.claude/rules/auto-release-gated-on-ci-workflow-conclusion.md`.

## How

- `expect(emptyState?.textContent).toBe("No related assets yet")` → `.toContain("No related assets yet")` **plus** assert the `.exocortex-relations-empty-add` affordance renders with text `"+ Add relation"`. This both fixes the break and **strengthens** coverage (proves the affordance ships in the real `UniversalLayout` integration path, with `currentFile` threaded).

## Verification

- The break itself is the revert-verify: the old assertion was **RED** on `main` (push-run failure), the new assertion is **GREEN**.
- `jest --config jest.ui.config.js` → **53/53 pass** (was 1 failed).
- Test-only; no production code change. Aligns with the already-shipped & Active req `57fc5804-2c67-4fb6-ba3d-5bac562da7c1`.

Req: 57fc5804-2c67-4fb6-ba3d-5bac562da7c1
