### PR TITLE
feat(layout): pn__DailyNote section visibility toggles — Actions/Tasks/Projects (@req:a38ac95b)

### DIFF
--- a/packages/core/src/domain/constants/AssetClass.ts
+++ b/packages/core/src/domain/constants/AssetClass.ts
@@ -2,6 +2,15 @@ export enum AssetClass {
   AREA = "ems__Area",
   TASK = "ems__Task",
   PROJECT = "ems__Project",
+  /**
+   * Action — a subclass of `ems__Effort` (RL#3, RFC pn__DailyNote toggles).
+   * Used by the daily-efforts-by-class partition to carve `ems__Action`
+   * instances of the day into their own «Actions» block, distinct from the
+   * inclusive «Tasks» catch-all. The TBox `ems__Action` asset already declares
+   * `exo__Class_superClass = ems__Effort`, so day-scoped Effort queries already
+   * include actions; this enum entry names the class for the partition split.
+   */
+  ACTION = "ems__Action",
   MEETING = "ems__Meeting",
   INITIATIVE = "ems__Initiative",
   TASK_PROTOTYPE = "ems__TaskPrototype",

--- a/packages/core/src/domain/layout/LayoutBlock.ts
+++ b/packages/core/src/domain/layout/LayoutBlock.ts
@@ -292,7 +292,7 @@ export function createLayoutBlockFromFrontmatter(
   }
 
   warn(
-    `LayoutBlock ${base.uid}: unknown block class at ${options.sourcePath} — expected exo__PropertiesBlock or exo__BacklinksTableBlock`,
+    `LayoutBlock ${base.uid}: unknown block class at ${options.sourcePath} — expected exo__PropertiesBlock, exo__BacklinksTableBlock, or exo__DailyEffortsByClassBlock`,
   );
   return null;
 }

--- a/packages/core/src/domain/layout/LayoutBlock.ts
+++ b/packages/core/src/domain/layout/LayoutBlock.ts
@@ -20,6 +20,20 @@ export interface LayoutBlockBase {
   readonly uid: string;
   readonly title: string;
   readonly collapsed: boolean;
+  /**
+   * Per-block visibility (RL#4a, RFC pn__DailyNote toggles). Holds the EXPLICIT
+   * `exo__LayoutBlock_visible` value (`true`/`false`/coerced from
+   * `"true"`/`"false"`), or `undefined` when the asset omits the flag.
+   *
+   * - Generic blocks (properties / backlinks): `ExoLayoutRenderer` renders the
+   *   block unless `visible === false` — so `undefined` (legacy, flag absent)
+   *   keeps rendering (back-compat).
+   * - Daily-efforts blocks: this value is the *Layout default* layer of the
+   *   visibility precedence (override > Layout default > built-in VL#3); when
+   *   `undefined`, the built-in VL#3 default applies (see
+   *   `resolveDailyEffortVisibility`).
+   */
+  readonly visible?: boolean;
   readonly sourcePath: string;
 }
 
@@ -38,12 +52,51 @@ export interface BacklinksTableBlock extends LayoutBlockBase {
   readonly showArchived: boolean;
 }
 
-export type LayoutBlock = PropertiesBlock | BacklinksTableBlock;
+/**
+ * Which class-partition of the day's efforts a `daily-efforts-by-class` block
+ * shows (RL#4b / VL#4, RFC pn__DailyNote toggles):
+ *   - `actions`  — `ems__Action` instances of the day.
+ *   - `tasks`    — the day's efforts EXCEPT Action and Project (so meetings /
+ *                  `ems__Meeting` and any other Effort subclass stay here —
+ *                  RL#1 inclusive carve-out).
+ *   - `projects` — `ems__Project` instances of the day.
+ */
+export type DailyEffortsPartition = "actions" | "tasks" | "projects";
+
+export interface DailyEffortsByClassBlock extends LayoutBlockBase {
+  readonly kind: "daily-efforts-by-class";
+  readonly partition: DailyEffortsPartition;
+}
+
+export type LayoutBlock =
+  | PropertiesBlock
+  | BacklinksTableBlock
+  | DailyEffortsByClassBlock;
 
 export const PROPERTIES_BLOCK_CLASS_IRI = "exo__PropertiesBlock";
 export const PROPERTIES_BLOCK_CLASS_UID = "fd039b3c-ed2b-41c2-a42e-bbfcdd074bfe";
 export const BACKLINKS_TABLE_BLOCK_CLASS_IRI = "exo__BacklinksTableBlock";
 export const BACKLINKS_TABLE_BLOCK_CLASS_UID = "2e868956-d81e-43fd-9817-1addde9cb311";
+export const DAILY_EFFORTS_BY_CLASS_BLOCK_CLASS_IRI =
+  "exo__DailyEffortsByClassBlock";
+export const DAILY_EFFORTS_BY_CLASS_BLOCK_CLASS_UID =
+  "22528ed6-6ec9-48d0-8e60-e370c0b242a9";
+
+const DAILY_EFFORTS_PARTITIONS: readonly DailyEffortsPartition[] = [
+  "actions",
+  "tasks",
+  "projects",
+];
+
+function parseDailyEffortsPartition(
+  value: unknown,
+): DailyEffortsPartition | null {
+  if (typeof value !== "string") return null;
+  const lowered = value.trim().toLowerCase();
+  return (DAILY_EFFORTS_PARTITIONS as readonly string[]).includes(lowered)
+    ? (lowered as DailyEffortsPartition)
+    : null;
+}
 
 function toStringArray(value: unknown): string[] {
   if (value == null) return [];
@@ -69,6 +122,22 @@ function parseBoolean(value: unknown, fallback: boolean): boolean {
     if (lowered === "false") return false;
   }
   return fallback;
+}
+
+/**
+ * Coerce a frontmatter visibility flag to an explicit boolean, or `undefined`
+ * when the flag is absent / not coercible. Kept local (not imported from
+ * `blockVisibility`) to avoid a runtime import cycle between the two modules.
+ * Mirrors `coerceVisibilityOverride` semantics.
+ */
+function coerceVisible(value: unknown): boolean | undefined {
+  if (typeof value === "boolean") return value;
+  if (typeof value === "string") {
+    const lowered = value.trim().toLowerCase();
+    if (lowered === "true") return true;
+    if (lowered === "false") return false;
+  }
+  return undefined;
 }
 
 function parseInteger(value: unknown): number | null {
@@ -129,10 +198,15 @@ function extractBase(
         ? labelRaw.trim()
         : basenameFromPath(options.sourcePath);
   const collapsed = parseBoolean(frontmatter["exo__LayoutBlock_collapsed"], false);
+  // Explicit flag, or undefined when absent. The renderer treats undefined as
+  // visible for generic blocks (back-compat) and as «fall to built-in VL#3»
+  // for daily-efforts blocks (RL#4a).
+  const visible = coerceVisible(frontmatter["exo__LayoutBlock_visible"]);
   return {
     uid,
     title,
     collapsed,
+    visible,
     sourcePath: options.sourcePath,
   };
 }
@@ -152,6 +226,25 @@ export function createLayoutBlockFromFrontmatter(
 
   if (classOf(frontmatter, PROPERTIES_BLOCK_CLASS_IRI, PROPERTIES_BLOCK_CLASS_UID)) {
     return { ...base, kind: "properties" };
+  }
+
+  if (
+    classOf(
+      frontmatter,
+      DAILY_EFFORTS_BY_CLASS_BLOCK_CLASS_IRI,
+      DAILY_EFFORTS_BY_CLASS_BLOCK_CLASS_UID,
+    )
+  ) {
+    const partition = parseDailyEffortsPartition(
+      frontmatter["exo__DailyEffortsByClassBlock_partition"],
+    );
+    if (partition === null) {
+      warn(
+        `DailyEffortsByClassBlock ${base.uid}: exo__DailyEffortsByClassBlock_partition must be one of actions|tasks|projects (${options.sourcePath})`,
+      );
+      return null;
+    }
+    return { ...base, kind: "daily-efforts-by-class", partition };
   }
 
   if (classOf(frontmatter, BACKLINKS_TABLE_BLOCK_CLASS_IRI, BACKLINKS_TABLE_BLOCK_CLASS_UID)) {
@@ -210,7 +303,12 @@ export function isLayoutBlockFrontmatter(
   if (!frontmatter) return false;
   return (
     classOf(frontmatter, PROPERTIES_BLOCK_CLASS_IRI, PROPERTIES_BLOCK_CLASS_UID) ||
-    classOf(frontmatter, BACKLINKS_TABLE_BLOCK_CLASS_IRI, BACKLINKS_TABLE_BLOCK_CLASS_UID)
+    classOf(frontmatter, BACKLINKS_TABLE_BLOCK_CLASS_IRI, BACKLINKS_TABLE_BLOCK_CLASS_UID) ||
+    classOf(
+      frontmatter,
+      DAILY_EFFORTS_BY_CLASS_BLOCK_CLASS_IRI,
+      DAILY_EFFORTS_BY_CLASS_BLOCK_CLASS_UID,
+    )
   );
 }
 
@@ -222,4 +320,10 @@ export function isBacklinksTableBlock(
   value: LayoutBlock,
 ): value is BacklinksTableBlock {
   return value.kind === "backlinks-table";
+}
+
+export function isDailyEffortsByClassBlock(
+  value: LayoutBlock,
+): value is DailyEffortsByClassBlock {
+  return value.kind === "daily-efforts-by-class";
 }

--- a/packages/core/src/domain/layout/blockVisibility.ts
+++ b/packages/core/src/domain/layout/blockVisibility.ts
@@ -1,0 +1,109 @@
+/**
+ * blockVisibility — pure resolution of a LayoutBlock's effective visibility.
+ *
+ * Precedence (VL#2 / VL#3, RFC pn__DailyNote toggles):
+ *
+ *   per-note frontmatter override  >  exo__Layout per-block default  >  built-in
+ *
+ * The built-in default for the three daily-efforts partitions is
+ * {@link BUILTIN_DAILY_EFFORTS_VISIBILITY}: Actions shown, Tasks shown,
+ * Projects HIDDEN (VL#3 — a deliberate, accepted partial regression).
+ *
+ * Coercion of the override value is explicit and total: a real boolean or the
+ * strings `"true"`/`"false"` (case-insensitive, trimmed) decide the result;
+ * anything else (absent / null / `""` / unrelated string / a partial key set
+ * that omits this partition) is treated as «not set» and falls through to the
+ * next precedence layer. This makes a partial frontmatter override (e.g. only
+ * `pn__DailyNote_showProjects: true`) leave the other partitions on their
+ * Layout/built-in defaults rather than collapsing them to a single value.
+ *
+ * @module domain/layout
+ * @since RFC pn__DailyNote toggles (req a38ac95b)
+ */
+
+import type { DailyEffortsPartition } from "./LayoutBlock";
+
+/**
+ * Out-of-the-box visibility for the three daily-efforts partitions (VL#3).
+ * Used as the lowest precedence layer when neither a frontmatter override nor
+ * an `exo__Layout` per-block default is present.
+ */
+export const BUILTIN_DAILY_EFFORTS_VISIBILITY: Readonly<
+  Record<DailyEffortsPartition, boolean>
+> = Object.freeze({
+  actions: true,
+  tasks: true,
+  projects: false,
+});
+
+/**
+ * Per-note frontmatter override keys for the three daily-efforts partitions
+ * (VL#2). Present on the `pn__DailyNote` instance; absent keys fall through to
+ * the Layout / built-in default.
+ */
+export const DAILY_EFFORTS_OVERRIDE_KEYS: Readonly<
+  Record<DailyEffortsPartition, string>
+> = Object.freeze({
+  actions: "pn__DailyNote_showActions",
+  tasks: "pn__DailyNote_showTasks",
+  projects: "pn__DailyNote_showProjects",
+});
+
+/**
+ * Coerce a raw override value to a definite boolean, or `undefined` when it is
+ * «not set» / not coercible. Accepts native booleans and the case-insensitive,
+ * trimmed strings `"true"`/`"false"`. Everything else (absent / null / empty /
+ * arbitrary string / number / object) → `undefined`.
+ */
+export function coerceVisibilityOverride(value: unknown): boolean | undefined {
+  if (typeof value === "boolean") return value;
+  if (typeof value === "string") {
+    const lowered = value.trim().toLowerCase();
+    if (lowered === "true") return true;
+    if (lowered === "false") return false;
+  }
+  return undefined;
+}
+
+/**
+ * Resolve effective visibility from the three precedence layers.
+ *
+ * @param override      raw per-note frontmatter value (coerced internally).
+ * @param layoutDefault the `exo__Layout` per-block default, or `undefined` when
+ *                      there is no Layout asset / no per-block flag.
+ * @param builtin       the built-in fallback (VL#3 for daily-efforts).
+ */
+export function resolveBlockVisibility(
+  override: unknown,
+  layoutDefault: boolean | undefined,
+  builtin: boolean,
+): boolean {
+  const coerced = coerceVisibilityOverride(override);
+  if (coerced !== undefined) return coerced;
+  if (layoutDefault !== undefined) return layoutDefault;
+  return builtin;
+}
+
+/**
+ * Convenience wrapper for a daily-efforts partition: reads the matching
+ * frontmatter override key off the note, then applies the full precedence
+ * (override > Layout default > built-in VL#3). A `null`/`undefined`
+ * frontmatter, or a frontmatter that omits this partition's key, falls through
+ * to `layoutDefault` then to the built-in.
+ */
+export function resolveDailyEffortVisibility(
+  partition: DailyEffortsPartition,
+  noteFrontmatter: Record<string, unknown> | null | undefined,
+  layoutDefault: boolean | undefined,
+): boolean {
+  const key = DAILY_EFFORTS_OVERRIDE_KEYS[partition];
+  const override =
+    noteFrontmatter && typeof noteFrontmatter === "object"
+      ? noteFrontmatter[key]
+      : undefined;
+  return resolveBlockVisibility(
+    override,
+    layoutDefault,
+    BUILTIN_DAILY_EFFORTS_VISIBILITY[partition],
+  );
+}

--- a/packages/core/src/domain/layout/dailyEffortsPartition.ts
+++ b/packages/core/src/domain/layout/dailyEffortsPartition.ts
@@ -1,0 +1,108 @@
+/**
+ * dailyEffortsPartition — pure single-scan split of a day's efforts into the
+ * three class partitions used by the daily-note Layout (RL#1 / RL#4b / VL#4,
+ * RFC pn__DailyNote toggles):
+ *
+ *   - `projects` — `ems__Project` instances of the day.
+ *   - `actions`  — `ems__Action` instances of the day (Action is a subclass of
+ *                  `ems__Effort`, RL#3 — already declared in TBox).
+ *   - `tasks`    — every other effort of the day (RL#1 inclusive carve-out):
+ *                  `ems__Task`, `ems__Meeting`, `ems__Initiative`, … — anything
+ *                  that is neither Action nor Project. Meetings deliberately
+ *                  stay here so the default view does not lose them.
+ *
+ * Each effort is placed in exactly one bucket; the scan is O(n) over the
+ * efforts (one pass, no per-class re-scan) per the review perf note.
+ *
+ * Class matching is dual-form aware (per `sparql-iri-form-pre-verify`): a class
+ * ref is treated as Action/Project if it contains the symbolic IRI
+ * (`ems__Action` / `ems__Project`, e.g. `[[ems__Project]]`,
+ * `[[uid|ems__Project]]`) OR normalises to the class UID (UID-canon
+ * `[[<uid>]]`). This keeps the carve-out correct whether instances carry
+ * symbolic, aliased, or UID-only `exo__Instance_class` references.
+ *
+ * @module domain/layout
+ * @since RFC pn__DailyNote toggles (req a38ac95b)
+ */
+
+import { AssetClass } from "../constants/AssetClass";
+import { WikiLinkHelpers } from "../../utilities/WikiLinkHelpers";
+
+/** TBox UID of `ems__Action` (UID-canon `exo__Instance_class` form). */
+export const EMS_ACTION_CLASS_UID = "6a99d2ca-d402-4734-a10b-33f5f1a1aa42";
+/** TBox UID of `ems__Project` (UID-canon `exo__Instance_class` form). */
+export const EMS_PROJECT_CLASS_UID = "7db5eeff-718a-49b0-8d2b-39b084a356e3";
+
+export interface DailyEffortsPartitioned<T> {
+  readonly actions: readonly T[];
+  readonly tasks: readonly T[];
+  readonly projects: readonly T[];
+}
+
+function toClassArray(value: unknown): string[] {
+  if (value == null) return [];
+  if (Array.isArray(value)) {
+    return value.filter((v): v is string => typeof v === "string");
+  }
+  if (typeof value === "string") return [value];
+  return [];
+}
+
+/**
+ * Whether any class ref in the list denotes `symbolicIRI`/`uid`. Matches the
+ * symbolic IRI by substring (catching `[[ems__Project]]` and
+ * `[[uid|ems__Project]]`, same semantics as the legacy DailyTasksRenderer
+ * project skip) OR the normalised UID exactly (catching UID-canon `[[uid]]`).
+ */
+function classListMatches(
+  classes: readonly string[],
+  symbolicIRI: string,
+  uid: string,
+): boolean {
+  for (const raw of classes) {
+    if (typeof raw !== "string") continue;
+    if (raw.includes(symbolicIRI)) return true;
+    if (WikiLinkHelpers.normalize(raw) === uid) return true;
+  }
+  return false;
+}
+
+/**
+ * Partition a list of day-scoped efforts into actions / tasks / projects.
+ *
+ * @param efforts   the day's efforts (already filtered by `isEffortInDay`).
+ * @param classesOf extracts a list of raw `exo__Instance_class` refs for an
+ *                  effort (defaults to reading `exo__Instance_class` off a
+ *                  `{ metadata }` shape).
+ */
+export function partitionDailyEffortsByClass<
+  T extends { metadata?: Record<string, unknown> },
+>(
+  efforts: readonly T[],
+  classesOf: (e: T) => readonly string[] = defaultClassesOf,
+): DailyEffortsPartitioned<T> {
+  const actions: T[] = [];
+  const tasks: T[] = [];
+  const projects: T[] = [];
+
+  for (const effort of efforts) {
+    const classes = classesOf(effort);
+    // Project takes precedence, then Action; everything else is a Task (RL#1
+    // inclusive carve-out — meetings and other Effort subclasses land here).
+    if (classListMatches(classes, AssetClass.PROJECT, EMS_PROJECT_CLASS_UID)) {
+      projects.push(effort);
+    } else if (
+      classListMatches(classes, AssetClass.ACTION, EMS_ACTION_CLASS_UID)
+    ) {
+      actions.push(effort);
+    } else {
+      tasks.push(effort);
+    }
+  }
+
+  return { actions, tasks, projects };
+}
+
+function defaultClassesOf(e: { metadata?: Record<string, unknown> }): string[] {
+  return toClassArray(e.metadata?.["exo__Instance_class"]);
+}

--- a/packages/core/src/domain/layout/index.ts
+++ b/packages/core/src/domain/layout/index.ts
@@ -1,6 +1,21 @@
 export { normalizeRef } from "./normalizeRef";
 
 export {
+  BUILTIN_DAILY_EFFORTS_VISIBILITY,
+  DAILY_EFFORTS_OVERRIDE_KEYS,
+  coerceVisibilityOverride,
+  resolveBlockVisibility,
+  resolveDailyEffortVisibility,
+} from "./blockVisibility";
+
+export {
+  EMS_ACTION_CLASS_UID,
+  EMS_PROJECT_CLASS_UID,
+  partitionDailyEffortsByClass,
+  type DailyEffortsPartitioned,
+} from "./dailyEffortsPartition";
+
+export {
   LAYOUT_CLASS_IRI,
   LAYOUT_CLASS_UID,
   createLayoutFromFrontmatter,
@@ -13,14 +28,19 @@ export {
 export {
   BACKLINKS_TABLE_BLOCK_CLASS_IRI,
   BACKLINKS_TABLE_BLOCK_CLASS_UID,
+  DAILY_EFFORTS_BY_CLASS_BLOCK_CLASS_IRI,
+  DAILY_EFFORTS_BY_CLASS_BLOCK_CLASS_UID,
   PROPERTIES_BLOCK_CLASS_IRI,
   PROPERTIES_BLOCK_CLASS_UID,
   createLayoutBlockFromFrontmatter,
   isBacklinksTableBlock,
+  isDailyEffortsByClassBlock,
   isLayoutBlockFrontmatter,
   isPropertiesBlock,
   type BacklinksTableBlock,
   type CreateLayoutBlockOptions,
+  type DailyEffortsByClassBlock,
+  type DailyEffortsPartition,
   type LayoutBlock,
   type LayoutBlockBase,
   type PropertiesBlock,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -505,17 +505,36 @@ export {
 export {
   BACKLINKS_TABLE_BLOCK_CLASS_IRI,
   BACKLINKS_TABLE_BLOCK_CLASS_UID,
+  DAILY_EFFORTS_BY_CLASS_BLOCK_CLASS_IRI,
+  DAILY_EFFORTS_BY_CLASS_BLOCK_CLASS_UID,
   PROPERTIES_BLOCK_CLASS_IRI,
   PROPERTIES_BLOCK_CLASS_UID,
   createLayoutBlockFromFrontmatter,
   isBacklinksTableBlock,
+  isDailyEffortsByClassBlock,
   isLayoutBlockFrontmatter,
   isPropertiesBlock,
   type BacklinksTableBlock,
   type CreateLayoutBlockOptions,
+  type DailyEffortsByClassBlock,
+  type DailyEffortsPartition,
   type LayoutBlock,
   type LayoutBlockBase,
   type PropertiesBlock,
+} from "./domain/layout";
+
+// pn__DailyNote section toggles (RFC pn__DailyNote toggles — req a38ac95b):
+// per-block visibility merge + day-efforts class partition.
+export {
+  BUILTIN_DAILY_EFFORTS_VISIBILITY,
+  DAILY_EFFORTS_OVERRIDE_KEYS,
+  coerceVisibilityOverride,
+  resolveBlockVisibility,
+  resolveDailyEffortVisibility,
+  EMS_ACTION_CLASS_UID,
+  EMS_PROJECT_CLASS_UID,
+  partitionDailyEffortsByClass,
+  type DailyEffortsPartitioned,
 } from "./domain/layout";
 
 export {

--- a/packages/core/tests/domain/constants/AssetClass.test.ts
+++ b/packages/core/tests/domain/constants/AssetClass.test.ts
@@ -13,6 +13,10 @@ describe("AssetClass", () => {
     expect(AssetClass.PROJECT).toBe("ems__Project");
   });
 
+  it("should have ACTION constant (subclass of ems__Effort, RL#3)", () => {
+    expect(AssetClass.ACTION).toBe("ems__Action");
+  });
+
   it("should have MEETING constant", () => {
     expect(AssetClass.MEETING).toBe("ems__Meeting");
   });
@@ -93,8 +97,8 @@ describe("AssetClass", () => {
     expect(AssetClass.COMMAND_BINDING).toBe("exocmd__CommandBinding");
   });
 
-  it("should have exactly 24 constants", () => {
+  it("should have exactly 25 constants", () => {
     const values = Object.values(AssetClass);
-    expect(values).toHaveLength(24);
+    expect(values).toHaveLength(25);
   });
 });

--- a/packages/core/tests/domain/layout/LayoutBlock.test.ts
+++ b/packages/core/tests/domain/layout/LayoutBlock.test.ts
@@ -1,0 +1,130 @@
+/**
+ * LayoutBlock parser — the new `visible` flag (RL#4a) and the
+ * `daily-efforts-by-class` block kind (RL#4b). Covers the model-extension half
+ * of req a38ac95b.
+ *
+ * @req:a38ac95b-b347-42e4-8522-f481ab422337
+ *
+ * revert-verify:
+ *  - removing the `daily-efforts-by-class` branch in
+ *    `createLayoutBlockFromFrontmatter` → "parses daily-efforts-by-class block"
+ *    goes RED (returns null), other kinds stay GREEN.
+ *  - changing `coerceVisible` to always return `true` → the
+ *    "visible: false parsed" test goes RED.
+ */
+
+import {
+  DAILY_EFFORTS_BY_CLASS_BLOCK_CLASS_IRI,
+  DAILY_EFFORTS_BY_CLASS_BLOCK_CLASS_UID,
+  PROPERTIES_BLOCK_CLASS_IRI,
+  createLayoutBlockFromFrontmatter,
+  isDailyEffortsByClassBlock,
+  isLayoutBlockFrontmatter,
+} from "../../../src/domain/layout/LayoutBlock";
+
+const SRC = { sourcePath: "block.md" };
+
+describe("LayoutBlock — visible flag (RL#4a, req a38ac95b)", () => {
+  test("omitted exo__LayoutBlock_visible → undefined (back-compat visible)", () => {
+    const block = createLayoutBlockFromFrontmatter(
+      {
+        exo__Asset_uid: "u1",
+        exo__Instance_class: [`[[${PROPERTIES_BLOCK_CLASS_IRI}]]`],
+      },
+      SRC,
+    );
+    expect(block).not.toBeNull();
+    expect(block?.visible).toBeUndefined();
+  });
+
+  test("@req:a38ac95b-b347-42e4-8522-f481ab422337 exo__LayoutBlock_visible: false → visible=false", () => {
+    const block = createLayoutBlockFromFrontmatter(
+      {
+        exo__Asset_uid: "u1",
+        exo__Instance_class: [`[[${PROPERTIES_BLOCK_CLASS_IRI}]]`],
+        exo__LayoutBlock_visible: false,
+      },
+      SRC,
+    );
+    expect(block?.visible).toBe(false);
+  });
+
+  test("exo__LayoutBlock_visible: \"false\" (string) → visible=false", () => {
+    const block = createLayoutBlockFromFrontmatter(
+      {
+        exo__Asset_uid: "u1",
+        exo__Instance_class: [`[[${PROPERTIES_BLOCK_CLASS_IRI}]]`],
+        exo__LayoutBlock_visible: "false",
+      },
+      SRC,
+    );
+    expect(block?.visible).toBe(false);
+  });
+});
+
+describe("LayoutBlock — daily-efforts-by-class kind (RL#4b, req a38ac95b)", () => {
+  test("isLayoutBlockFrontmatter recognises the new block class (IRI + UID)", () => {
+    expect(
+      isLayoutBlockFrontmatter({
+        exo__Instance_class: [`[[${DAILY_EFFORTS_BY_CLASS_BLOCK_CLASS_IRI}]]`],
+      }),
+    ).toBe(true);
+    expect(
+      isLayoutBlockFrontmatter({
+        exo__Instance_class: [`[[${DAILY_EFFORTS_BY_CLASS_BLOCK_CLASS_UID}]]`],
+      }),
+    ).toBe(true);
+  });
+
+  test("@req:a38ac95b-b347-42e4-8522-f481ab422337 parses a daily-efforts-by-class block with a valid partition", () => {
+    const block = createLayoutBlockFromFrontmatter(
+      {
+        exo__Asset_uid: "daily-actions",
+        exo__Asset_label: "Действия",
+        exo__Instance_class: [`[[${DAILY_EFFORTS_BY_CLASS_BLOCK_CLASS_UID}]]`],
+        exo__DailyEffortsByClassBlock_partition: "actions",
+        exo__LayoutBlock_visible: false,
+      },
+      SRC,
+    );
+    expect(block).not.toBeNull();
+    expect(block?.kind).toBe("daily-efforts-by-class");
+    expect(block && isDailyEffortsByClassBlock(block)).toBe(true);
+    if (block && isDailyEffortsByClassBlock(block)) {
+      expect(block.partition).toBe("actions");
+      expect(block.title).toBe("Действия");
+      expect(block.visible).toBe(false);
+    }
+  });
+
+  test.each(["actions", "tasks", "projects", "PROJECTS", "  Tasks "])(
+    "accepts and normalises partition %p",
+    (raw) => {
+      const block = createLayoutBlockFromFrontmatter(
+        {
+          exo__Asset_uid: "b",
+          exo__Instance_class: [
+            `[[${DAILY_EFFORTS_BY_CLASS_BLOCK_CLASS_IRI}]]`,
+          ],
+          exo__DailyEffortsByClassBlock_partition: raw,
+        },
+        SRC,
+      );
+      expect(block?.kind).toBe("daily-efforts-by-class");
+    },
+  );
+
+  test("rejects (returns null) an invalid / missing partition", () => {
+    const warnings: string[] = [];
+    const block = createLayoutBlockFromFrontmatter(
+      {
+        exo__Asset_uid: "b",
+        exo__Instance_class: [`[[${DAILY_EFFORTS_BY_CLASS_BLOCK_CLASS_IRI}]]`],
+        exo__DailyEffortsByClassBlock_partition: "bogus",
+      },
+      { ...SRC, warn: (m) => warnings.push(m) },
+    );
+    expect(block).toBeNull();
+    expect(warnings.some((w) => w.includes("partition"))).toBe(true);
+  });
+});

--- a/packages/core/tests/domain/layout/blockVisibility.test.ts
+++ b/packages/core/tests/domain/layout/blockVisibility.test.ts
@@ -1,0 +1,114 @@
+/**
+ * blockVisibility — coercion + visibility precedence (override > Layout default
+ * > built-in VL#3). Covers req a38ac95b assertions (d) precedence, (e)
+ * coercion, (f) VL#3 no-config default.
+ *
+ * @req:a38ac95b-b347-42e4-8522-f481ab422337
+ *
+ * revert-verify: removing the `coerceVisibilityOverride !== undefined` short-
+ * circuit in `resolveBlockVisibility` (so override never wins) turns the
+ * precedence tests RED while the built-in/VL#3 tests stay GREEN; restoring →
+ * all GREEN.
+ */
+
+import {
+  BUILTIN_DAILY_EFFORTS_VISIBILITY,
+  DAILY_EFFORTS_OVERRIDE_KEYS,
+  coerceVisibilityOverride,
+  resolveBlockVisibility,
+  resolveDailyEffortVisibility,
+} from "../../../src/domain/layout/blockVisibility";
+
+describe("coerceVisibilityOverride (req a38ac95b — coercion)", () => {
+  test.each([
+    [true, true],
+    [false, false],
+    ["true", true],
+    ["false", false],
+    ["TRUE", true],
+    ["  False  ", false],
+  ])("coerces %p → %p", (input, expected) => {
+    expect(coerceVisibilityOverride(input)).toBe(expected);
+  });
+
+  test.each([
+    [undefined],
+    [null],
+    [""],
+    ["yes"],
+    ["1"],
+    [1],
+    [0],
+    [{}],
+    [[]],
+  ])("treats %p as not-set (undefined)", (input) => {
+    expect(coerceVisibilityOverride(input)).toBeUndefined();
+  });
+});
+
+describe("resolveBlockVisibility (req a38ac95b — precedence)", () => {
+  test("@req:a38ac95b-b347-42e4-8522-f481ab422337 frontmatter override wins over Layout default and built-in", () => {
+    // override=false beats layoutDefault=true beats builtin=true
+    expect(resolveBlockVisibility(false, true, true)).toBe(false);
+    // override="true" beats layoutDefault=false beats builtin=false
+    expect(resolveBlockVisibility("true", false, false)).toBe(true);
+  });
+
+  test("Layout default wins when override is not set", () => {
+    expect(resolveBlockVisibility(undefined, false, true)).toBe(false);
+    expect(resolveBlockVisibility(null, true, false)).toBe(true);
+    // a non-coercible string override falls through to the layout default
+    expect(resolveBlockVisibility("maybe", false, true)).toBe(false);
+  });
+
+  test("built-in wins when neither override nor Layout default is set", () => {
+    expect(resolveBlockVisibility(undefined, undefined, true)).toBe(true);
+    expect(resolveBlockVisibility(undefined, undefined, false)).toBe(false);
+  });
+});
+
+describe("BUILTIN_DAILY_EFFORTS_VISIBILITY (req a38ac95b — VL#3 default)", () => {
+  test("Actions shown, Tasks shown, Projects hidden out of the box", () => {
+    expect(BUILTIN_DAILY_EFFORTS_VISIBILITY.actions).toBe(true);
+    expect(BUILTIN_DAILY_EFFORTS_VISIBILITY.tasks).toBe(true);
+    expect(BUILTIN_DAILY_EFFORTS_VISIBILITY.projects).toBe(false);
+  });
+});
+
+describe("resolveDailyEffortVisibility (req a38ac95b — daily merge)", () => {
+  test("@req:a38ac95b-b347-42e4-8522-f481ab422337 no config anywhere → VL#3 default (Actions+Tasks shown, Projects hidden)", () => {
+    // null frontmatter, undefined layout default → built-in VL#3
+    expect(resolveDailyEffortVisibility("actions", null, undefined)).toBe(true);
+    expect(resolveDailyEffortVisibility("tasks", null, undefined)).toBe(true);
+    expect(resolveDailyEffortVisibility("projects", null, undefined)).toBe(false);
+  });
+
+  test("Layout default overrides VL#3 when frontmatter is silent", () => {
+    // Layout asset declares Projects visible=true → shown despite VL#3 false
+    expect(resolveDailyEffortVisibility("projects", {}, true)).toBe(true);
+    // Layout asset declares Tasks visible=false → hidden despite VL#3 true
+    expect(resolveDailyEffortVisibility("tasks", {}, false)).toBe(false);
+  });
+
+  test("frontmatter override beats Layout default and VL#3", () => {
+    const fm = {
+      [DAILY_EFFORTS_OVERRIDE_KEYS.projects]: true, // show projects
+      [DAILY_EFFORTS_OVERRIDE_KEYS.tasks]: "false", // hide tasks (string)
+    };
+    expect(resolveDailyEffortVisibility("projects", fm, false)).toBe(true);
+    expect(resolveDailyEffortVisibility("tasks", fm, true)).toBe(false);
+  });
+
+  test("partial key set — unset partitions fall through, not collapse", () => {
+    // Only Projects overridden; Actions/Tasks keep their layout/built-in default
+    const fm = { [DAILY_EFFORTS_OVERRIDE_KEYS.projects]: true };
+    expect(resolveDailyEffortVisibility("projects", fm, undefined)).toBe(true);
+    expect(resolveDailyEffortVisibility("actions", fm, undefined)).toBe(true); // VL#3
+    expect(resolveDailyEffortVisibility("tasks", fm, undefined)).toBe(true); // VL#3
+  });
+
+  test("null override value falls through to layout default / built-in", () => {
+    const fm = { [DAILY_EFFORTS_OVERRIDE_KEYS.actions]: null };
+    expect(resolveDailyEffortVisibility("actions", fm, false)).toBe(false);
+  });
+});

--- a/packages/core/tests/domain/layout/dailyEffortsPartition.test.ts
+++ b/packages/core/tests/domain/layout/dailyEffortsPartition.test.ts
@@ -1,0 +1,111 @@
+/**
+ * dailyEffortsPartition — single-scan split of day efforts into
+ * Actions / Tasks / Projects. Covers req a38ac95b assertions (b) partition by
+ * class and (c) RL#1 meeting-regression (the day's meeting stays in Tasks).
+ *
+ * @req:a38ac95b-b347-42e4-8522-f481ab422337
+ *
+ * revert-verify: changing the Tasks bucket to also exclude meetings (e.g. an
+ * extra `classListMatches(..., "ems__Meeting", ...)` branch routing meetings
+ * away from `tasks`) turns the RL#1 meeting test RED; the carve-out as written
+ * keeps meetings in Tasks → GREEN.
+ */
+
+import {
+  EMS_ACTION_CLASS_UID,
+  EMS_PROJECT_CLASS_UID,
+  partitionDailyEffortsByClass,
+} from "../../../src/domain/layout/dailyEffortsPartition";
+
+interface Effort {
+  readonly path: string;
+  readonly metadata: Record<string, unknown>;
+}
+
+function effort(path: string, classes: string[]): Effort {
+  return { path, metadata: { exo__Instance_class: classes } };
+}
+
+describe("partitionDailyEffortsByClass (req a38ac95b)", () => {
+  test("partitions symbolic-form classes into actions / tasks / projects", () => {
+    const efforts = [
+      effort("a.md", ["[[ems__Action]]"]),
+      effort("t.md", ["[[ems__Task]]"]),
+      effort("p.md", ["[[ems__Project]]"]),
+    ];
+    const { actions, tasks, projects } = partitionDailyEffortsByClass(efforts);
+    expect(actions.map((e) => e.path)).toEqual(["a.md"]);
+    expect(tasks.map((e) => e.path)).toEqual(["t.md"]);
+    expect(projects.map((e) => e.path)).toEqual(["p.md"]);
+  });
+
+  test("@req:a38ac95b-b347-42e4-8522-f481ab422337 RL#1 — a day's meeting STAYS in Tasks (inclusive carve-out)", () => {
+    const efforts = [
+      effort("m.md", ["[[ems__Meeting]]"]),
+      effort("i.md", ["[[ems__Initiative]]"]),
+      effort("a.md", ["[[ems__Action]]"]),
+    ];
+    const { actions, tasks, projects } = partitionDailyEffortsByClass(efforts);
+    expect(tasks.map((e) => e.path).sort()).toEqual(["i.md", "m.md"]);
+    expect(actions.map((e) => e.path)).toEqual(["a.md"]);
+    expect(projects).toHaveLength(0);
+  });
+
+  test("matches UID-canon class form ([[<uid>]]) for Action and Project", () => {
+    const efforts = [
+      effort("a.md", [`[[${EMS_ACTION_CLASS_UID}]]`]),
+      effort("p.md", [`[[${EMS_PROJECT_CLASS_UID}]]`]),
+      effort("t.md", ["[[6f000000-0000-0000-0000-000000000000]]"]), // unknown uid → tasks
+    ];
+    const { actions, tasks, projects } = partitionDailyEffortsByClass(efforts);
+    expect(actions.map((e) => e.path)).toEqual(["a.md"]);
+    expect(projects.map((e) => e.path)).toEqual(["p.md"]);
+    expect(tasks.map((e) => e.path)).toEqual(["t.md"]);
+  });
+
+  test("matches aliased class form ([[<uid>|ems__Action]])", () => {
+    const efforts = [
+      effort("a.md", [`[[${EMS_ACTION_CLASS_UID}|ems__Action]]`]),
+      effort("p.md", ["[[7db5eeff-718a-49b0-8d2b-39b084a356e3|ems__Project]]"]),
+    ];
+    const { actions, projects } = partitionDailyEffortsByClass(efforts);
+    expect(actions.map((e) => e.path)).toEqual(["a.md"]);
+    expect(projects.map((e) => e.path)).toEqual(["p.md"]);
+  });
+
+  test("Project takes precedence when an effort carries both Action and Project", () => {
+    const efforts = [effort("x.md", ["[[ems__Action]]", "[[ems__Project]]"])];
+    const { actions, projects } = partitionDailyEffortsByClass(efforts);
+    expect(projects.map((e) => e.path)).toEqual(["x.md"]);
+    expect(actions).toHaveLength(0);
+  });
+
+  test("efforts with no class array → Tasks; each effort placed exactly once", () => {
+    const efforts = [
+      { path: "n.md", metadata: {} },
+      effort("a.md", ["[[ems__Action]]"]),
+    ];
+    const { actions, tasks, projects } = partitionDailyEffortsByClass(efforts);
+    expect(tasks.map((e) => e.path)).toEqual(["n.md"]);
+    expect(actions.map((e) => e.path)).toEqual(["a.md"]);
+    // every input lands in exactly one bucket (no dup, no drop)
+    expect(actions.length + tasks.length + projects.length).toBe(efforts.length);
+  });
+
+  test("supports a custom class extractor", () => {
+    const items = [
+      { path: "a.md", kind: "ems__Action" },
+      { path: "t.md", kind: "ems__Task" },
+    ];
+    const { actions, tasks } = partitionDailyEffortsByClass(
+      items as unknown as Array<{ metadata?: Record<string, unknown> }>,
+      (e) => [(e as unknown as { kind: string }).kind],
+    );
+    expect(actions.map((e) => (e as unknown as { path: string }).path)).toEqual([
+      "a.md",
+    ]);
+    expect(tasks.map((e) => (e as unknown as { path: string }).path)).toEqual([
+      "t.md",
+    ]);
+  });
+});

--- a/packages/obsidian-plugin/src/presentation/components/LayoutBlocks.tsx
+++ b/packages/obsidian-plugin/src/presentation/components/LayoutBlocks.tsx
@@ -144,3 +144,49 @@ function resolveCell(row: AssetRelation, column: string): string {
   const value = row.metadata[column];
   return formatPropertyValue(value);
 }
+
+/**
+ * DailyEffortsBlockView — renders one class-partition of the day's efforts
+ * (Actions / Tasks / Projects) as a clickable list (RL#4b / VL#4, RFC
+ * pn__DailyNote toggles). The partition + visibility are decided upstream in
+ * `ExoLayoutRenderer`; this view just renders the supplied items.
+ *
+ * Security: `title` and each item title are auto-escaped by JSX.
+ */
+export interface DailyEffortsBlockViewProps {
+  readonly title: string;
+  readonly items: ReadonlyArray<{ readonly path: string; readonly title: string }>;
+  readonly onItemClick?: (path: string) => void;
+}
+
+export const DailyEffortsBlockView: React.FC<DailyEffortsBlockViewProps> = ({
+  title,
+  items,
+  onItemClick,
+}) => {
+  return (
+    <div className="exocortex-layout-block exocortex-layout-block-daily-efforts">
+      <h3 className="exocortex-layout-block-title">{title}</h3>
+      {items.length === 0 ? (
+        <div className="exocortex-layout-block-empty">No efforts</div>
+      ) : (
+        <ul className="exocortex-layout-block-daily-efforts-list">
+          {items.map((item) => (
+            <li key={item.path} data-asset-path={item.path}>
+              <a
+                className="exocortex-daily-effort-link"
+                href={item.path}
+                onClick={(e) => {
+                  e.preventDefault();
+                  onItemClick?.(item.path);
+                }}
+              >
+                {item.title}
+              </a>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+};

--- a/packages/obsidian-plugin/src/presentation/renderers/ExoLayoutRenderer.tsx
+++ b/packages/obsidian-plugin/src/presentation/renderers/ExoLayoutRenderer.tsx
@@ -24,7 +24,12 @@
 
 import React from "react";
 import type { TFile } from "obsidian";
-import type { Layout, LayoutBlock } from "@kitelev/exocortex-core";
+import type {
+  DailyEffortsPartition,
+  DailyEffortsPartitioned,
+  Layout,
+  LayoutBlock,
+} from "@kitelev/exocortex-core";
 import type { ReactRenderer } from "@plugin/presentation/utils/ReactRenderer";
 import type { ExoLayoutSnapshot } from "@plugin/infrastructure/repositories";
 import type { AssetRelation } from "./layout/types";
@@ -32,16 +37,44 @@ import type { ILogger } from "@plugin/adapters/logging/ILogger";
 import type { ObsidianApp } from "@plugin/types";
 import {
   BacklinksTableBlockView,
+  DailyEffortsBlockView,
   PropertiesBlockView,
 } from "@plugin/presentation/components/LayoutBlocks";
 import { AssetMetadataService } from "@plugin/presentation/renderers/layout/helpers/AssetMetadataService";
-import { WikiLinkHelpers } from "@kitelev/exocortex-core";
+import {
+  WikiLinkHelpers,
+  partitionDailyEffortsByClass,
+  resolveDailyEffortVisibility,
+} from "@kitelev/exocortex-core";
+
+/**
+ * A day-scoped effort surfaced to a `daily-efforts-by-class` block. The
+ * provider (wired in `UniversalLayoutRenderer`) scans the vault for efforts
+ * whose timestamps fall in the note's day (`isEffortInDay`) and returns this
+ * minimal shape; the renderer partitions it by class once per render.
+ */
+export interface DailyEffortItem {
+  readonly path: string;
+  readonly title: string;
+  readonly metadata: Record<string, unknown>;
+}
 
 export interface ExoLayoutRendererDeps {
   readonly app: ObsidianApp;
   readonly reactRenderer: ReactRenderer;
   readonly logger: ILogger;
   readonly snapshotProvider: () => ExoLayoutSnapshot;
+  /**
+   * RFC pn__DailyNote toggles (req a38ac95b) — supplies the day's efforts for
+   * `daily-efforts-by-class` blocks. Returns `null` when `file` is not a daily
+   * note (or no day can be derived); returns the (possibly empty) effort list
+   * otherwise. Optional: when absent, daily-efforts blocks render empty. The
+   * read-path is Obsidian-core only (vault.adapter), no Platform gate
+   * (desktop↔mobile parity).
+   */
+  readonly dailyEffortsProvider?: (
+    file: TFile,
+  ) => readonly DailyEffortItem[] | null;
 }
 
 export interface ExoLayoutRenderResult {
@@ -66,6 +99,15 @@ export class ExoLayoutRenderer {
       String(layout.coexistsWithDefault),
     );
 
+    // Resolve note frontmatter (for daily-efforts visibility overrides) and
+    // the day's efforts partition ONCE per render. The partition is a single
+    // O(n) scan reused across all three daily-efforts blocks (perf — review
+    // note); it is computed lazily only when the layout actually carries a
+    // daily-efforts block.
+    const noteFrontmatter = (this.deps.app.metadataCache.getFileCache(file)
+      ?.frontmatter ?? null) as Record<string, unknown> | null;
+    const partition = this.computeDailyPartition(file, layout, snapshot);
+
     let blockCount = 0;
     for (const rawRef of layout.blocks) {
       const block = resolveBlock(rawRef, snapshot);
@@ -75,11 +117,52 @@ export class ExoLayoutRenderer {
         );
         continue;
       }
-      await this.renderBlock(container, file, block, relations);
+      // RL#4a — a block resolved as not-visible is skipped entirely (no DOM,
+      // no React render). Visibility is generic (`block.visible !== false`)
+      // for properties/backlinks blocks; for daily-efforts blocks it merges
+      // the per-note override > Layout default > built-in VL#3.
+      if (!this.isBlockVisible(block, noteFrontmatter)) {
+        continue;
+      }
+      await this.renderBlock(container, file, block, relations, partition);
       blockCount += 1;
     }
 
     return { rendered: blockCount > 0, blockCount };
+  }
+
+  /**
+   * Compute the day-efforts partition once when the layout has at least one
+   * daily-efforts block and a provider is wired. Returns `null` otherwise
+   * (non-daily layouts pay zero cost).
+   */
+  private computeDailyPartition(
+    file: TFile,
+    layout: Layout,
+    snapshot: ExoLayoutSnapshot,
+  ): DailyEffortsPartitioned<DailyEffortItem> | null {
+    if (this.deps.dailyEffortsProvider === undefined) return null;
+    const hasDailyBlock = layout.blocks.some((rawRef) => {
+      const block = resolveBlock(rawRef, snapshot);
+      return block !== null && block.kind === "daily-efforts-by-class";
+    });
+    if (!hasDailyBlock) return null;
+    const efforts = this.deps.dailyEffortsProvider(file) ?? [];
+    return partitionDailyEffortsByClass(efforts);
+  }
+
+  private isBlockVisible(
+    block: LayoutBlock,
+    noteFrontmatter: Record<string, unknown> | null,
+  ): boolean {
+    if (block.kind === "daily-efforts-by-class") {
+      return resolveDailyEffortVisibility(
+        block.partition,
+        noteFrontmatter,
+        block.visible,
+      );
+    }
+    return block.visible !== false;
   }
 
   private async renderBlock(
@@ -87,6 +170,7 @@ export class ExoLayoutRenderer {
     file: TFile,
     block: LayoutBlock,
     relations: readonly AssetRelation[],
+    partition: DailyEffortsPartitioned<DailyEffortItem> | null,
   ): Promise<void> {
     const blockContainer = container.createDiv({
       cls: "exocortex-exo-layout-block",
@@ -104,11 +188,34 @@ export class ExoLayoutRenderer {
       this.renderBacklinksBlock(blockContainer, relations, block);
       return;
     }
+    if (block.kind === "daily-efforts-by-class") {
+      this.renderDailyEffortsBlock(blockContainer, block.partition, block.title, partition);
+      return;
+    }
     // Defensive branch — parser/type guard should have prevented unknown
     // kinds from ever reaching this point; we still skip quietly.
     const unreachable: never = block;
     this.deps.logger.warn(
       `ExoLayoutRenderer: unknown block kind on asset ${(unreachable as LayoutBlock).uid}`,
+    );
+  }
+
+  private renderDailyEffortsBlock(
+    container: HTMLElement,
+    partitionKey: DailyEffortsPartition,
+    title: string,
+    partition: DailyEffortsPartitioned<DailyEffortItem> | null,
+  ): void {
+    const items = partition ? partition[partitionKey] : [];
+    this.deps.reactRenderer.render(
+      container,
+      React.createElement(DailyEffortsBlockView, {
+        title,
+        items: items.map((e) => ({ path: e.path, title: e.title })),
+        onItemClick: (path: string) => {
+          void this.deps.app.workspace.openLinkText(path, "", false);
+        },
+      }),
     );
   }
 

--- a/packages/obsidian-plugin/src/presentation/renderers/UniversalLayoutRenderer.ts
+++ b/packages/obsidian-plugin/src/presentation/renderers/UniversalLayoutRenderer.ts
@@ -10,9 +10,10 @@ import { IVaultAdapter, MetadataExtractor, INotificationService } from "@kitelev
 import { FolderRepairService } from "@kitelev/exocortex-core";
 import { CommandResolver, PreconditionEvaluator, GroundingExecutor } from "@kitelev/exocortex-core";
 import type { LayoutSelector, ITripleStore, LazyAssetGraphLoader } from "@kitelev/exocortex-core";
-import { IRI, vaultPathToIRI } from "@kitelev/exocortex-core";
+import { IRI, vaultPathToIRI, WikiLinkHelpers } from "@kitelev/exocortex-core";
 import type { ExoLayoutRepository } from "@plugin/infrastructure/repositories";
 import { ExoLayoutRenderer } from "./ExoLayoutRenderer";
+import { collectDayEfforts } from "./helpers/DailyEffortsCollector";
 import { BacklinksCacheManager } from '@plugin/adapters/caching/BacklinksCacheManager';
 import { EventListenerManager } from '@plugin/adapters/events/EventListenerManager';
 import { ButtonGroupsBuilder } from '@plugin/presentation/builders/ButtonGroupsBuilder';
@@ -194,6 +195,11 @@ export class UniversalLayoutRenderer {
           blocksByUid: new Map(),
           blocksByLabel: new Map(),
         },
+      // RFC pn__DailyNote toggles (req a38ac95b) — supplies the day's efforts
+      // for `daily-efforts-by-class` blocks. Obsidian-core read-path only
+      // (vault.adapter), no Platform gate → desktop↔mobile parity.
+      dailyEffortsProvider: (file) =>
+        collectDayEfforts(file, this.vaultAdapter, this.metadataExtractor),
     });
   }
 
@@ -361,6 +367,22 @@ export class UniversalLayoutRenderer {
       const renderHeader = (c: HTMLElement, id: string, t: string) =>
         this.sectionStateManager.renderHeader(c, id, t, this.eventListenerManager);
 
+      // RFC exo__Layout Phase 2 — resolve the Layout once (reused below for
+      // both the daily-tasks suppression decision and block rendering).
+      // RFC pn__DailyNote toggles (req a38ac95b) — when the active layout
+      // carries daily-efforts-by-class blocks, the day's efforts are rendered
+      // through the block pipeline (Actions / Tasks / Projects), so the legacy
+      // catch-all DailyTasksRenderer is suppressed to avoid a duplicate
+      // "Tasks" section. Daily navigation (rendered above) is preserved.
+      // Back-compat: when no daily-efforts layout is active (the common case —
+      // no exo__Layout asset targets pn__DailyNote), the legacy renderer runs
+      // exactly as before → zero regression.
+      const layout = this.resolveLayoutForFile(currentFile);
+      const layoutActive =
+        layout !== null && this.settings.enableExoLayoutRenderer;
+      const dailyEffortsLayoutActive =
+        layoutActive && layout !== null && this.layoutHasDailyEffortsBlock(layout);
+
       // RFC c7da0bca Phase 3b-main — ensure the active file + its class
       // chain + prototype chain are in the triple store before button
       // resolution. The loader is idempotent + cycle-safe; per-render
@@ -397,17 +419,16 @@ export class UniversalLayoutRenderer {
         this.renderCommandsSkeleton(el);
       }
 
-      await this.dailyTasksRenderer.render(el, currentFile, renderHeader, this.sectionStateManager.isCollapsed("daily-tasks"));
+      if (!dailyEffortsLayoutActive) {
+        await this.dailyTasksRenderer.render(el, currentFile, renderHeader, this.sectionStateManager.isCollapsed("daily-tasks"));
+      }
 
       const relations = await this.relationsRenderer.getAssetRelations(currentFile, config);
 
-      // RFC exo__Layout Phase 2 — resolve Layout for current asset's classes.
-      // When a layout is found AND the feature flag is on, render its blocks.
-      // If the layout's `coexistsWithDefault` is false, skip the default
-      // AreaTree + Relations sections (full replace mode). Properties block
-      // and action buttons are always preserved per RFC §62.
-      const layout = this.resolveLayoutForFile(currentFile);
-      const layoutActive = layout !== null && this.settings.enableExoLayoutRenderer;
+      // RFC exo__Layout Phase 2 — render the resolved Layout's blocks (when the
+      // feature flag is on). If the layout's `coexistsWithDefault` is false,
+      // skip the default AreaTree + Relations sections (full replace mode).
+      // Properties block and action buttons are always preserved per RFC §62.
       if (layoutActive && layout !== null) {
         await this.exoLayoutRenderer.render(el, currentFile, layout, relations);
         if (!layout.coexistsWithDefault) {
@@ -453,6 +474,31 @@ export class UniversalLayoutRenderer {
         : [];
     if (classes.length === 0) return null;
     return this.layoutSelector.resolve(classes);
+  }
+
+  /**
+   * RFC pn__DailyNote toggles (req a38ac95b) — whether the resolved layout
+   * carries at least one `daily-efforts-by-class` block. Drives suppression of
+   * the legacy DailyTasksRenderer (its catch-all "Tasks" would otherwise
+   * duplicate the daily-efforts blocks). Resolves block refs against the
+   * ExoLayout snapshot; returns false when the repository is absent (back-compat).
+   */
+  private layoutHasDailyEffortsBlock(
+    layout: import("@kitelev/exocortex-core").Layout,
+  ): boolean {
+    const snapshot = this.exoLayoutRepository?.getSnapshot();
+    if (snapshot === undefined) return false;
+    for (const rawRef of layout.blocks) {
+      const normalized = WikiLinkHelpers.normalize(rawRef);
+      if (!normalized) continue;
+      const block =
+        snapshot.blocksByUid.get(normalized) ??
+        snapshot.blocksByLabel.get(normalized);
+      if (block !== undefined && block.kind === "daily-efforts-by-class") {
+        return true;
+      }
+    }
+    return false;
   }
 
   public async refresh(_el?: HTMLElement): Promise<void> {

--- a/packages/obsidian-plugin/src/presentation/renderers/helpers/DailyEffortsCollector.ts
+++ b/packages/obsidian-plugin/src/presentation/renderers/helpers/DailyEffortsCollector.ts
@@ -1,0 +1,41 @@
+import type { TFile } from "obsidian";
+import type { IVaultAdapter, MetadataExtractor } from "@kitelev/exocortex-core";
+import type { DailyEffortItem } from "../ExoLayoutRenderer";
+import { DailyNoteHelpers } from "./DailyNoteHelpers";
+
+/**
+ * collectDayEfforts — gathers the efforts of a daily note's day for the
+ * `daily-efforts-by-class` Layout blocks (RFC pn__DailyNote toggles, req
+ * a38ac95b).
+ *
+ * Returns `null` when `file` is not a daily note (or no day can be derived) —
+ * the renderer then renders the daily-efforts blocks empty. Otherwise returns
+ * every effort whose timestamps fall in the day (`isEffortInDay`), in vault
+ * order, as the minimal `{ path, title, metadata }` shape the partition needs.
+ *
+ * Read-path is Obsidian-core only via `vaultAdapter` (no Node `fs`, no
+ * `Platform` gate) — identical on desktop and mobile (Desktop↔Mobile parity).
+ */
+export function collectDayEfforts(
+  file: TFile,
+  vaultAdapter: IVaultAdapter,
+  metadataExtractor: MetadataExtractor,
+): DailyEffortItem[] | null {
+  const info = DailyNoteHelpers.extractDailyNoteInfo(file, metadataExtractor);
+  if (!info.isDailyNote || !info.day) {
+    return null;
+  }
+  const day = info.day;
+  const efforts: DailyEffortItem[] = [];
+  for (const candidate of vaultAdapter.getAllFiles()) {
+    const metadata = metadataExtractor.extractMetadata(candidate);
+    if (!DailyNoteHelpers.isEffortInDay(metadata, day)) continue;
+    const label =
+      typeof metadata.exo__Asset_label === "string" &&
+      metadata.exo__Asset_label.trim().length > 0
+        ? (metadata.exo__Asset_label as string)
+        : candidate.basename;
+    efforts.push({ path: candidate.path, title: label, metadata });
+  }
+  return efforts;
+}

--- a/packages/obsidian-plugin/tests/unit/presentation/renderers/ExoLayoutRenderer.dailyEfforts.test.ts
+++ b/packages/obsidian-plugin/tests/unit/presentation/renderers/ExoLayoutRenderer.dailyEfforts.test.ts
@@ -1,0 +1,324 @@
+/**
+ * ExoLayoutRenderer — per-block visibility (RL#4a) + daily-efforts-by-class
+ * block rendering (RL#4b) with the visibility precedence
+ * (frontmatter override > Layout default > built-in VL#3).
+ *
+ * Covers req a38ac95b assertions:
+ *   (a) a block with visible=false is NOT rendered, a sibling visible one is.
+ *   (b) daily-efforts-by-class partitions the day's efforts by class.
+ *   (c) RL#1 — a day's meeting renders in the Tasks block at the default.
+ *   (d)(e) precedence + coercion at the renderer level (frontmatter override).
+ *   (f) VL#3 no-config default: Actions+Tasks shown, Projects hidden.
+ *
+ * @req:a38ac95b-b347-42e4-8522-f481ab422337
+ *
+ * revert-verify:
+ *  - removing the `if (!this.isBlockVisible(...)) continue;` gate in render()
+ *    → the visibility / VL#3 / precedence tests go RED (hidden blocks render);
+ *    restoring → GREEN.
+ *  - removing the `daily-efforts-by-class` case in renderBlock() → the
+ *    partition / RL#1 tests go RED.
+ */
+
+import type { Layout, LayoutBlock } from "@kitelev/exocortex-core";
+import { ExoLayoutRenderer } from "../../../../src/presentation/renderers/ExoLayoutRenderer";
+import type {
+  DailyEffortItem,
+} from "../../../../src/presentation/renderers/ExoLayoutRenderer";
+import type { ExoLayoutSnapshot } from "../../../../src/infrastructure/repositories";
+
+function enhance(el: HTMLElement): HTMLElement {
+  (el as unknown as { setAttr: (k: string, v: string) => void }).setAttr = (
+    k,
+    v,
+  ) => el.setAttribute(k, v);
+  (el as unknown as { createDiv: (options?: unknown) => HTMLElement }).createDiv =
+    (options?: { cls?: string | string[]; attr?: Record<string, string> }) => {
+      const child = document.createElement("div");
+      if (options?.cls) {
+        child.className = Array.isArray(options.cls)
+          ? options.cls.join(" ")
+          : options.cls;
+      }
+      if (options?.attr) {
+        for (const [k, v] of Object.entries(options.attr)) {
+          child.setAttribute(k, v);
+        }
+      }
+      el.appendChild(child);
+      return enhance(child);
+    };
+  return el;
+}
+
+function makeEl(): HTMLElement {
+  return enhance(document.createElement("div"));
+}
+
+function makeLayout(blocks: string[]): Layout {
+  return {
+    uid: "daily-layout",
+    label: "Daily",
+    targetClass: "pn__DailyNote",
+    blocks,
+    priority: 0,
+    coexistsWithDefault: true,
+    sourcePath: "layout.md",
+  };
+}
+
+function propertiesBlock(uid: string, visible?: boolean): LayoutBlock {
+  return {
+    kind: "properties",
+    uid,
+    title: `Props ${uid}`,
+    collapsed: false,
+    visible,
+    sourcePath: `${uid}.md`,
+  } as LayoutBlock;
+}
+
+function dailyBlock(
+  uid: string,
+  partition: "actions" | "tasks" | "projects",
+  visible?: boolean,
+): LayoutBlock {
+  return {
+    kind: "daily-efforts-by-class",
+    uid,
+    title: partition,
+    collapsed: false,
+    visible,
+    sourcePath: `${uid}.md`,
+    partition,
+  } as LayoutBlock;
+}
+
+function makeSnapshot(blocks: LayoutBlock[]): ExoLayoutSnapshot {
+  const byUid = new Map<string, LayoutBlock>();
+  const byLabel = new Map<string, LayoutBlock>();
+  for (const b of blocks) {
+    byUid.set(b.uid, b);
+    byLabel.set(b.uid, b);
+  }
+  return {
+    layouts: [],
+    blocks: [...blocks],
+    blocksByUid: byUid,
+    blocksByLabel: byLabel,
+  };
+}
+
+function effort(path: string, classes: string[]): DailyEffortItem {
+  return {
+    path,
+    title: path.replace(/\.md$/, ""),
+    metadata: { exo__Instance_class: classes },
+  };
+}
+
+function makeRenderer(
+  snapshot: ExoLayoutSnapshot,
+  opts: {
+    noteFrontmatter?: Record<string, unknown>;
+    dayEfforts?: DailyEffortItem[] | null;
+  } = {},
+) {
+  const renderCalls: Array<{ element: unknown }> = [];
+  const reactRenderer = {
+    render: jest.fn((_container: HTMLElement, element: unknown) => {
+      renderCalls.push({ element });
+    }),
+    cleanup: jest.fn(),
+  };
+  const logger = { warn: jest.fn(), info: jest.fn(), debug: jest.fn(), error: jest.fn() };
+  const app = {
+    metadataCache: {
+      getFileCache: jest.fn(() => ({
+        frontmatter: opts.noteFrontmatter ?? {},
+      })),
+    },
+    workspace: { openLinkText: jest.fn() },
+  };
+  const renderer = new ExoLayoutRenderer({
+    app: app as never,
+    reactRenderer: reactRenderer as never,
+    logger: logger as never,
+    snapshotProvider: () => snapshot,
+    dailyEffortsProvider:
+      opts.dayEfforts === undefined ? undefined : () => opts.dayEfforts ?? null,
+  });
+  return { renderer, reactRenderer, renderCalls };
+}
+
+/** Pull the props of the i-th React element passed to reactRenderer.render. */
+function propsAt(reactRenderer: { render: jest.Mock }, i: number): any {
+  return (reactRenderer.render as jest.Mock).mock.calls[i][1].props;
+}
+
+describe("ExoLayoutRenderer — per-block visibility (req a38ac95b a)", () => {
+  test("@req:a38ac95b-b347-42e4-8522-f481ab422337 a block with visible=false is NOT rendered; a sibling visible one is", async () => {
+    const hidden = propertiesBlock("hidden", false);
+    const shown = propertiesBlock("shown", true);
+    const snap = makeSnapshot([hidden, shown]);
+    const { renderer, reactRenderer } = makeRenderer(snap);
+    const el = makeEl();
+
+    const result = await renderer.render(
+      el,
+      { path: "n.md" } as never,
+      makeLayout(["hidden", "shown"]),
+      [],
+    );
+
+    expect(result.blockCount).toBe(1);
+    expect(reactRenderer.render).toHaveBeenCalledTimes(1);
+    // only the visible block produced a DOM container
+    const containers = el.querySelectorAll(".exocortex-exo-layout-block");
+    expect(containers).toHaveLength(1);
+    expect(containers[0].getAttribute("data-block-uid")).toBe("shown");
+  });
+
+  test("visible undefined (legacy, flag absent) → block still renders", async () => {
+    const legacy = propertiesBlock("legacy"); // visible undefined
+    const snap = makeSnapshot([legacy]);
+    const { renderer, reactRenderer } = makeRenderer(snap);
+    const el = makeEl();
+    const result = await renderer.render(
+      el,
+      { path: "n.md" } as never,
+      makeLayout(["legacy"]),
+      [],
+    );
+    expect(result.blockCount).toBe(1);
+    expect(reactRenderer.render).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("ExoLayoutRenderer — daily-efforts partition (req a38ac95b b, c)", () => {
+  const dayEfforts = [
+    effort("act.md", ["[[ems__Action]]"]),
+    effort("task.md", ["[[ems__Task]]"]),
+    effort("meet.md", ["[[ems__Meeting]]"]),
+    effort("proj.md", ["[[ems__Project]]"]),
+  ];
+
+  test("@req:a38ac95b-b347-42e4-8522-f481ab422337 partitions efforts into Actions / Tasks / Projects blocks", async () => {
+    // all three blocks forced visible to verify the partition itself
+    const blocks = [
+      dailyBlock("a", "actions", true),
+      dailyBlock("t", "tasks", true),
+      dailyBlock("p", "projects", true),
+    ];
+    const snap = makeSnapshot(blocks);
+    const { renderer, reactRenderer } = makeRenderer(snap, { dayEfforts });
+    const el = makeEl();
+
+    await renderer.render(
+      el,
+      { path: "n.md" } as never,
+      makeLayout(["a", "t", "p"]),
+      [],
+    );
+
+    expect(reactRenderer.render).toHaveBeenCalledTimes(3);
+    const actions = propsAt(reactRenderer, 0);
+    const tasks = propsAt(reactRenderer, 1);
+    const projects = propsAt(reactRenderer, 2);
+    expect(actions.items.map((i: { path: string }) => i.path)).toEqual([
+      "act.md",
+    ]);
+    // RL#1 — meeting + task land in Tasks (inclusive carve-out)
+    expect(tasks.items.map((i: { path: string }) => i.path).sort()).toEqual([
+      "meet.md",
+      "task.md",
+    ]);
+    expect(projects.items.map((i: { path: string }) => i.path)).toEqual([
+      "proj.md",
+    ]);
+  });
+
+  test("RL#1 — at the default (Tasks shown) a day meeting renders in Tasks", async () => {
+    // Tasks block with no explicit visible → VL#3 default = shown
+    const blocks = [dailyBlock("t", "tasks")];
+    const snap = makeSnapshot(blocks);
+    const { renderer, reactRenderer } = makeRenderer(snap, {
+      dayEfforts: [effort("meet.md", ["[[ems__Meeting]]"])],
+    });
+    const el = makeEl();
+    await renderer.render(el, { path: "n.md" } as never, makeLayout(["t"]), []);
+    expect(reactRenderer.render).toHaveBeenCalledTimes(1);
+    expect(propsAt(reactRenderer, 0).items.map((i: { path: string }) => i.path)).toEqual([
+      "meet.md",
+    ]);
+  });
+});
+
+describe("ExoLayoutRenderer — VL#3 default + precedence (req a38ac95b d, e, f)", () => {
+  const dayEfforts = [
+    effort("act.md", ["[[ems__Action]]"]),
+    effort("task.md", ["[[ems__Task]]"]),
+    effort("proj.md", ["[[ems__Project]]"]),
+  ];
+
+  test("@req:a38ac95b-b347-42e4-8522-f481ab422337 VL#3 no-config default: Actions + Tasks shown, Projects hidden", async () => {
+    // no explicit visible on any block, no frontmatter override
+    const blocks = [
+      dailyBlock("a", "actions"),
+      dailyBlock("t", "tasks"),
+      dailyBlock("p", "projects"),
+    ];
+    const snap = makeSnapshot(blocks);
+    const { renderer, reactRenderer } = makeRenderer(snap, { dayEfforts });
+    const el = makeEl();
+    const result = await renderer.render(
+      el,
+      { path: "n.md" } as never,
+      makeLayout(["a", "t", "p"]),
+      [],
+    );
+    // Projects skipped → 2 blocks rendered
+    expect(result.blockCount).toBe(2);
+    const kinds = Array.from(
+      el.querySelectorAll(".exocortex-exo-layout-block"),
+    ).map((c) => c.getAttribute("data-block-uid"));
+    expect(kinds).toEqual(["a", "t"]);
+  });
+
+  test("frontmatter override pn__DailyNote_showProjects:true reveals Projects (override > VL#3)", async () => {
+    const blocks = [dailyBlock("p", "projects")]; // VL#3 default hidden
+    const snap = makeSnapshot(blocks);
+    const { renderer, reactRenderer } = makeRenderer(snap, {
+      dayEfforts,
+      noteFrontmatter: { pn__DailyNote_showProjects: true },
+    });
+    const el = makeEl();
+    const result = await renderer.render(
+      el,
+      { path: "n.md" } as never,
+      makeLayout(["p"]),
+      [],
+    );
+    expect(result.blockCount).toBe(1);
+    expect(propsAt(reactRenderer, 0).items.map((i: { path: string }) => i.path)).toEqual([
+      "proj.md",
+    ]);
+  });
+
+  test("frontmatter override pn__DailyNote_showActions:\"false\" hides Actions (coercion)", async () => {
+    const blocks = [dailyBlock("a", "actions")]; // VL#3 default shown
+    const snap = makeSnapshot(blocks);
+    const { renderer } = makeRenderer(snap, {
+      dayEfforts,
+      noteFrontmatter: { pn__DailyNote_showActions: "false" },
+    });
+    const el = makeEl();
+    const result = await renderer.render(
+      el,
+      { path: "n.md" } as never,
+      makeLayout(["a"]),
+      [],
+    );
+    expect(result.blockCount).toBe(0);
+  });
+});

--- a/packages/obsidian-plugin/tests/unit/presentation/renderers/UniversalLayoutRenderer.dailyEffortsSuppression.test.ts
+++ b/packages/obsidian-plugin/tests/unit/presentation/renderers/UniversalLayoutRenderer.dailyEffortsSuppression.test.ts
@@ -1,0 +1,200 @@
+/**
+ * UniversalLayoutRenderer — suppress the legacy DailyTasksRenderer when an
+ * active layout carries daily-efforts-by-class blocks (RL#4c), while preserving
+ * the daily navigation. Back-compat: no daily-efforts layout → legacy renders
+ * unchanged.
+ *
+ * Covers req a38ac95b assertion (h) daily navigation preserved after reroute +
+ * the no-duplicate-Tasks orchestration.
+ *
+ * @req:a38ac95b-b347-42e4-8522-f481ab422337
+ *
+ * revert-verify: removing the `if (!dailyEffortsLayoutActive)` guard around the
+ * legacy `dailyTasksRenderer.render(...)` call → the "suppressed" test goes RED
+ * (legacy render fires alongside the block pipeline = duplicate Tasks);
+ * restoring → GREEN.
+ */
+
+import "reflect-metadata";
+import { container } from "tsyringe";
+import {
+  DI_TOKENS,
+  registerCoreServices,
+  resetContainer,
+  LayoutSelector,
+  type Layout,
+  type LayoutBlock,
+} from "@kitelev/exocortex-core";
+import { UniversalLayoutRenderer } from "../../../../src/presentation/renderers/UniversalLayoutRenderer";
+import type { ExocortexSettings } from "../../../../src/domain/settings/ExocortexSettings";
+
+function enhance(el: HTMLElement): HTMLElement {
+  const anyEl = el as unknown as Record<string, unknown>;
+  anyEl.createDiv = (options?: { cls?: string | string[] }) => {
+    const child = document.createElement("div");
+    if (options?.cls) {
+      child.className = Array.isArray(options.cls)
+        ? options.cls.join(" ")
+        : options.cls;
+    }
+    el.appendChild(child);
+    return enhance(child);
+  };
+  anyEl.createEl = (tag: string) => {
+    const child = document.createElement(tag);
+    el.appendChild(child);
+    return enhance(child);
+  };
+  anyEl.addClass = (c: string) => el.classList.add(c);
+  anyEl.empty = () => {
+    el.innerHTML = "";
+  };
+  return el;
+}
+
+function dailyLayout(blocks: string[]): Layout {
+  return {
+    uid: "daily-layout",
+    label: "Daily",
+    targetClass: "pn__DailyNote",
+    blocks,
+    priority: 0,
+    coexistsWithDefault: true,
+    sourcePath: "layout.md",
+  };
+}
+
+function dailyBlock(uid: string): LayoutBlock {
+  return {
+    kind: "daily-efforts-by-class",
+    uid,
+    title: "Tasks",
+    collapsed: false,
+    sourcePath: `${uid}.md`,
+    partition: "tasks",
+  } as LayoutBlock;
+}
+
+function backlinksBlock(uid: string): LayoutBlock {
+  return {
+    kind: "backlinks-table",
+    uid,
+    title: "Children",
+    collapsed: false,
+    sourcePath: `${uid}.md`,
+    rowClass: "ems__Task",
+    referencingProperty: "ems__Effort_parent",
+    columns: [],
+    sortBy: null,
+    sortOrder: "asc",
+    limit: null,
+    showArchived: false,
+  } as LayoutBlock;
+}
+
+function snapshotWith(blocks: LayoutBlock[]) {
+  const byUid = new Map<string, LayoutBlock>();
+  const byLabel = new Map<string, LayoutBlock>();
+  for (const b of blocks) {
+    byUid.set(b.uid, b);
+    byLabel.set(b.uid, b);
+  }
+  return { layouts: [], blocks, blocksByUid: byUid, blocksByLabel: byLabel };
+}
+
+describe("UniversalLayoutRenderer — daily-efforts suppression (req a38ac95b h)", () => {
+  let mockApp: any;
+  let mockSettings: ExocortexSettings;
+  let mockPlugin: any;
+  let mockVaultAdapter: any;
+
+  beforeEach(() => {
+    resetContainer();
+    mockApp = {
+      vault: { getMarkdownFiles: jest.fn().mockReturnValue([]) },
+      metadataCache: {
+        getFileCache: jest.fn().mockReturnValue({
+          frontmatter: { exo__Instance_class: ["[[pn__DailyNote]]"] },
+        }),
+        getFirstLinkpathDest: jest.fn(),
+      },
+      workspace: {
+        getActiveFile: jest.fn().mockReturnValue({ path: "2026-06-28.md", basename: "2026-06-28" }),
+        openLinkText: jest.fn(),
+      },
+    };
+    mockSettings = { enableExoLayoutRenderer: true } as ExocortexSettings;
+    mockPlugin = { saveSettings: jest.fn() };
+    mockVaultAdapter = {
+      getAllFiles: jest.fn().mockReturnValue([]),
+      getFrontmatter: jest.fn().mockReturnValue({}),
+    };
+    const mockLogger = { info: jest.fn(), error: jest.fn(), warn: jest.fn(), debug: jest.fn() };
+    container.register(DI_TOKENS.IVaultAdapter, { useValue: mockVaultAdapter });
+    container.register(DI_TOKENS.ILogger, { useValue: mockLogger });
+    registerCoreServices();
+  });
+
+  afterEach(() => resetContainer());
+
+  function buildRenderer(layout: Layout, snapshotBlocks: LayoutBlock[]) {
+    const layoutSelector = new LayoutSelector({ all: [layout] });
+    const exoLayoutRepository = {
+      getSnapshot: () => snapshotWith(snapshotBlocks),
+    } as never;
+    const renderer = new UniversalLayoutRenderer(
+      mockApp,
+      mockSettings,
+      mockPlugin,
+      mockVaultAdapter,
+      { layoutSelector, exoLayoutRepository },
+    );
+    // Isolate the orchestration: spy on the section renderers/builders so the
+    // render() flow is deterministic and we observe only the call decisions.
+    const navSpy = jest.fn();
+    const tasksSpy = jest.fn().mockResolvedValue(undefined);
+    (renderer as any).dailyNavRenderer = { render: navSpy };
+    (renderer as any).dailyTasksRenderer = { render: tasksSpy };
+    (renderer as any).buttonGroupsBuilder = { build: jest.fn().mockResolvedValue([]) };
+    (renderer as any).relationsRenderer = {
+      getAssetRelations: jest.fn().mockResolvedValue([]),
+      render: jest.fn().mockResolvedValue(undefined),
+    };
+    (renderer as any).areaTreeRenderer = { render: jest.fn().mockResolvedValue(undefined) };
+    (renderer as any).exoLayoutRenderer = {
+      render: jest.fn().mockResolvedValue({ rendered: true, blockCount: 1 }),
+    };
+    return { renderer, navSpy, tasksSpy };
+  }
+
+  test("@req:a38ac95b-b347-42e4-8522-f481ab422337 daily-efforts layout active → legacy DailyTasksRenderer suppressed, nav preserved", async () => {
+    const { renderer, navSpy, tasksSpy } = buildRenderer(
+      dailyLayout(["t"]),
+      [dailyBlock("t")],
+    );
+    const el = enhance(document.createElement("div"));
+    await renderer.render("", el, {} as never);
+
+    expect(navSpy).toHaveBeenCalledTimes(1); // navigation preserved
+    expect(tasksSpy).not.toHaveBeenCalled(); // legacy Tasks suppressed
+    expect((renderer as any).exoLayoutRenderer.render).toHaveBeenCalledTimes(1);
+  });
+
+  test("layout without daily-efforts block → legacy DailyTasksRenderer still runs (back-compat)", async () => {
+    const { renderer, navSpy, tasksSpy } = buildRenderer(
+      dailyLayout(["b"]),
+      [backlinksBlock("b")],
+    );
+    const el = enhance(document.createElement("div"));
+    await renderer.render("", el, {} as never);
+
+    expect(navSpy).toHaveBeenCalledTimes(1);
+    expect(tasksSpy).toHaveBeenCalledTimes(1); // not suppressed
+  });
+
+  test("layoutHasDailyEffortsBlock decision (unit)", () => {
+    const { renderer } = buildRenderer(dailyLayout(["t"]), [dailyBlock("t")]);
+    expect((renderer as any).layoutHasDailyEffortsBlock(dailyLayout(["t"]))).toBe(true);
+    expect((renderer as any).layoutHasDailyEffortsBlock(dailyLayout(["b"]))).toBe(false);
+  });
+});


### PR DESCRIPTION
## What

Extends the homoiconic `exo__Layout` block model with **per-section visibility toggles for the `pn__DailyNote` Layout** (Actions / Tasks / Projects), per RFC v3 `f5f178ae` and the unified requirement **`@req:a38ac95b-b347-42e4-8522-f481ab422337`** (req-first SDD, RFC 0003).

This is **Phase 1-3** of the project (`b2bce264`): the code capability + onto enum + full unit/component coverage + revert-verify. The live-activating vault asset + GUI smoke are a **separate serialized gate (Phase 4-5)** — see "Scoping" below.

## Changes

**Core (`packages/core`)**
- `LayoutBlockBase.visible?: boolean` — optional, holds the explicit `exo__LayoutBlock_visible` value (undefined when absent). Generic blocks render unless `visible === false` (RL#4a, back-compat).
- New `daily-efforts-by-class` block kind (class `exo__DailyEffortsByClassBlock`, uid `22528ed6-…`) carrying a `partition: "actions" | "tasks" | "projects"`.
- `blockVisibility.ts` — pure visibility merge: **frontmatter override > exo__Layout default > built-in VL#3** (Actions+Tasks shown, Projects hidden), with explicit coercion (`true`/`false`/`"true"`/`"false"`/absent/null/partial set).
- `dailyEffortsPartition.ts` — single-scan O(n) partition; **RL#1 inclusive carve-out** (meetings & other Effort subclasses stay in Tasks). Dual-IRI-aware matching (symbolic `ems__Action`/`ems__Project` OR UID-canon).
- `AssetClass.ACTION = "ems__Action"`.

**Plugin (`packages/obsidian-plugin`)**
- `ExoLayoutRenderer` honors per-block visibility (skips not-visible blocks entirely — no DOM) and renders `daily-efforts-by-class` blocks via an injected day-efforts provider + once-per-render partition + per-partition visibility merge.
- `DailyEffortsBlockView` React component.
- `collectDayEfforts` helper (Obsidian-core read-path via `vault.adapter`, no `Platform` gate → desktop↔mobile parity).
- `UniversalLayoutRenderer` suppresses the legacy `DailyTasksRenderer` when a daily-efforts layout is active (no duplicate "Tasks"); **daily navigation preserved**. Back-compat: no daily-efforts layout selected → legacy renders exactly as before.

## Verify-before-assert finding

RFC Phase-0 claimed *"ems__Action is NOT a subclass of ems__Effort"*. **Stale** — the TBox `ems__Action` (`6a99d2ca`) **already** declares `exo__Class_superClass → ems__Effort` (`086f71fa`) in the canonical vaults, structurally identical to the clean `ems__Task`/`ems__Project` classes. So RL#3's onto half is already done; this PR only adds the `AssetClass.ACTION` code enum. No `ems__Action` label hardcodes in src → no NL-routing ripple (multi-parser-predicate-migration).

## Scoping (additive + dormant; live activation = Phase 4-5)

The change is **additive and dormant**: no `exo__Layout` asset targets `pn__DailyNote` yet, so `layoutHasDailyEffortsBlock` is false on real daily notes → the legacy renderer runs unchanged → **zero regression**. Creating the live-activating `exo__Layout` + `LayoutBlock` vault assets (which would change the user's real daily note) is deferred to **Phase 4-5** (create on a temp-vault → GUI smoke desktop + iPhone → roll out), per `ui-smoke-transitive-proof` + `migration-pre-verify-use-case`. The ready-to-apply asset spec for Phase 4-5 is in the project hub / RFC.

## Tests + revert-verify (RED→GREEN)

75 tests across core + plugin. Each behavioral assertion revert-verified (production line broken → bound test RED, restored → GREEN):

| Assertion | Test | revert-verify |
|---|---|---|
| (a) visible=false not rendered | `ExoLayoutRenderer.dailyEfforts` | gate broken → 3 RED |
| (b) partition by class | `ExoLayoutRenderer.dailyEfforts` + `dailyEffortsPartition` | empty slice → RED |
| (c) RL#1 meeting in Tasks | `dailyEffortsPartition` + renderer | meeting-drop break → RED |
| (d)(e) precedence + coercion | `blockVisibility` + renderer | override short-circuit neutralized → 3 RED |
| (f) VL#3 no-config default | `blockVisibility` + renderer | (covered by a) |
| (g) ems__Action subclass | TBox pre-existing (clean) + `AssetClass.ACTION` | n/a (pre-existing) |
| (h) nav preserved + suppression | `UniversalLayoutRenderer.dailyEffortsSuppression` | suppression gate broken → RED |
| (i) no Platform gate | structural (vault.adapter only) | — |

Local gates: `check:types` clean · `eslint --max-warnings=0` clean · 3 lint-job guard scripts pass (anti-pattern ratchet 55/55).

## Requirement

`@req:a38ac95b-b347-42e4-8522-f481ab422337` (Component + Unit, `proposed`). Bindings land in main with this PR; the req flips **Active** in `exoas-exo-reqs` after merge. The req is already on the `exoas-exo-reqs` remote (proposed) → `@req` tags resolve (not dangling) for `requirements-trace`.

Closes Phase 1-3 of project `b2bce264`. RFC `f5f178ae`.
