### PR TITLE
feat(#f402002b): obsplugin__Setting export pilot — Periodic Notes (M4.1)

### DIFF
--- a/packages/core/src/services/settings/index.ts
+++ b/packages/core/src/services/settings/index.ts
@@ -22,3 +22,12 @@ export {
   EXOCORTEX_DISTRIBUTION_ONTOLOGY_KEY_UID,
   resolveDistributionOntology,
 } from "./distributionOntology";
+export {
+  OBSPLUGIN_SETTING_CLASS_UID,
+  PERIODIC_NOTES_PLUGIN_ID,
+  PERIODIC_NOTES_DATA_PATH,
+  PERIODIC_NOTES_DECLARED_KEYS,
+  JsonConfigSettingsSource,
+  buildPeriodicNotesSource,
+  resolveConfigPath,
+} from "./obsPluginSource";

--- a/packages/core/src/services/settings/obsPluginSource.ts
+++ b/packages/core/src/services/settings/obsPluginSource.ts
@@ -31,13 +31,17 @@ export const OBSPLUGIN_SETTING_CLASS_UID =
 
 /**
  * Resolve a dot-path (e.g. `daily.folder`) against a parsed JSON config object.
- * Returns `undefined` when any segment is missing or a non-object is traversed
- * — pure, the accessor for a {@link SettingKeySpec} whose `field` is a JSON path.
+ * Returns `undefined` when any segment is missing or a non-object is traversed.
+ * Reads OWN properties only — a `__proto__`/`constructor`/inherited segment
+ * yields `undefined` (no prototype-chain read), future-proofing the util now
+ * that it is exported from `@kitelev/exocortex-core`. Pure — the accessor for a
+ * {@link SettingKeySpec} whose `field` is a JSON path.
  */
 export function resolveConfigPath(config: unknown, path: string): unknown {
   let cur: unknown = config;
   for (const seg of path.split(".")) {
     if (cur === null || typeof cur !== "object") return undefined;
+    if (!Object.prototype.hasOwnProperty.call(cur, seg)) return undefined;
     cur = (cur as Record<string, unknown>)[seg];
   }
   return cur;

--- a/packages/core/src/services/settings/obsPluginSource.ts
+++ b/packages/core/src/services/settings/obsPluginSource.ts
@@ -1,0 +1,130 @@
+/**
+ * `obsplugin__Setting` export source (RFC f402002b, M4.1) — a community-plugin
+ * {@link SettingsSource} over an already-parsed plugin `data.json`.
+ *
+ * M4 distributes OTHER community plugins' settings (pilot: Periodic Notes) the
+ * same way M2 distributes Exocortex's own: the generic
+ * {@link SettingsDistributionEngine} (`exportSettings`) snapshots a domain's
+ * DECLARED keys into `obsplugin__Setting` assets. The only domain-specific part
+ * is this source — it maps each declared key's `field` (a dot-path into the
+ * plugin's nested config object, e.g. `daily.folder`) to the live value.
+ *
+ * Allowlist-by-construction (RFC sec F1): `declaredKeys()` is a fixed list; the
+ * engine never enumerates the live keyspace, so an undeclared plugin field can
+ * never leak into an export — regardless of what extra keys `data.json` carries.
+ *
+ * Code-registry binding (Q3 exc.1 — core processing, consistent with M2's
+ * `VAULT_SETTINGS_REGISTRY`): the field↔keyUid table is a TS constant; the
+ * `obsplugin__SettingKey` individuals declare the *schema* (datatype) in the
+ * graph (homoiconic). A future enhancement (RFC §7 MED) could move the
+ * dot-path accessor itself into the RDF SettingKey individual — that would apply
+ * to every source uniformly (engine-level), out of M4.1's export-pilot scope.
+ *
+ * Pure — no `obsidian` / Node deps (Desktop↔Mobile parity): the parsed config
+ * is injected by the caller, which read `data.json` via `vault.adapter`.
+ */
+import type { SettingKeySpec, SettingsSource } from "./types";
+
+/** `obsplugin__Setting` class UID (`$setting` floor ontology, exoas-exo, M4). */
+export const OBSPLUGIN_SETTING_CLASS_UID =
+  "01a9c996-fc2e-4e70-a22d-e6554d746c5f";
+
+/**
+ * Resolve a dot-path (e.g. `daily.folder`) against a parsed JSON config object.
+ * Returns `undefined` when any segment is missing or a non-object is traversed
+ * — pure, the accessor for a {@link SettingKeySpec} whose `field` is a JSON path.
+ */
+export function resolveConfigPath(config: unknown, path: string): unknown {
+  let cur: unknown = config;
+  for (const seg of path.split(".")) {
+    if (cur === null || typeof cur !== "object") return undefined;
+    cur = (cur as Record<string, unknown>)[seg];
+  }
+  return cur;
+}
+
+/**
+ * A generic {@link SettingsSource} over an already-parsed plugin config object,
+ * where each declared key's `field` is a dot-path into that object. Export-only
+ * for M4.1 — Import ({@link writeLiveValue}) is M4.2 (OUT OF SCOPE) and rejects.
+ */
+export class JsonConfigSettingsSource implements SettingsSource {
+  constructor(
+    readonly settingClassUid: string,
+    private readonly keys: readonly SettingKeySpec[],
+    private readonly config: unknown,
+  ) {}
+
+  declaredKeys(): readonly SettingKeySpec[] {
+    return this.keys;
+  }
+
+  readLiveValue(key: SettingKeySpec): unknown {
+    return resolveConfigPath(this.config, key.field);
+  }
+
+  writeLiveValue(): Promise<void> {
+    return Promise.reject(
+      new Error(
+        "obsplugin settings Import is not implemented in M4.1 (export-only) — see M4.2.",
+      ),
+    );
+  }
+}
+
+/** Periodic Notes community plugin id (folder under `.obsidian/plugins/`). */
+export const PERIODIC_NOTES_PLUGIN_ID = "periodic-notes";
+
+/** Vault-relative path to the Periodic Notes `data.json` (read via vault.adapter). */
+export const PERIODIC_NOTES_DATA_PATH = `.obsidian/plugins/${PERIODIC_NOTES_PLUGIN_ID}/data.json`;
+
+/**
+ * The Periodic Notes Daily-Notes distributable keys (the export allowlist, M4.1
+ * pilot). Each `field` is a dot-path into Periodic Notes' `data.json`; `keyUid`
+ * → an `obsplugin__SettingKey` individual; `settingUid` → the deterministic
+ * `obsplugin__Setting` asset (fixed so independent exports on two devices
+ * produce byte-identical paths — sync converges instead of duplicating).
+ */
+export const PERIODIC_NOTES_DECLARED_KEYS: readonly SettingKeySpec[] = [
+  {
+    field: "daily.folder",
+    keyUid: "6ba6a073-3ee9-4527-8958-34596e072a31",
+    keyLabel: "obsplugin__SettingKeyPeriodicNotesDailyFolder",
+    datatype: "string",
+    settingUid: "2bb137e5-b2c7-4fc8-b234-60639de674a9",
+  },
+  {
+    field: "daily.format",
+    keyUid: "a8d5f2b9-ba43-49d1-a469-00d5461b7d7a",
+    keyLabel: "obsplugin__SettingKeyPeriodicNotesDailyFormat",
+    datatype: "string",
+    settingUid: "6ed5cfdf-551b-49bc-a467-56756b822da5",
+  },
+  {
+    field: "daily.template",
+    keyUid: "524d639d-4c63-4c73-a9c5-cca2c057a380",
+    keyLabel: "obsplugin__SettingKeyPeriodicNotesDailyTemplate",
+    datatype: "string",
+    settingUid: "5430a6c5-6be5-483e-bb94-d740d6dd2541",
+  },
+  {
+    field: "daily.enabled",
+    keyUid: "7314ec27-e1ec-4987-8101-76273d0a789f",
+    keyLabel: "obsplugin__SettingKeyPeriodicNotesDailyEnabled",
+    datatype: "boolean",
+    settingUid: "411646dd-1a87-40d8-853d-01c37af7fb2c",
+  },
+];
+
+/**
+ * Build the M4.1 export {@link SettingsSource} for Periodic Notes from its
+ * already-parsed `data.json`. Exported assets are typed `obsplugin__Setting`;
+ * only {@link PERIODIC_NOTES_DECLARED_KEYS} are ever read (allowlist).
+ */
+export function buildPeriodicNotesSource(parsedConfig: unknown): SettingsSource {
+  return new JsonConfigSettingsSource(
+    OBSPLUGIN_SETTING_CLASS_UID,
+    PERIODIC_NOTES_DECLARED_KEYS,
+    parsedConfig,
+  );
+}

--- a/packages/core/tests/unit/services/settings/obsPluginSource.test.ts
+++ b/packages/core/tests/unit/services/settings/obsPluginSource.test.ts
@@ -1,0 +1,116 @@
+/**
+ * @req:af71d01c-8790-4dc5-b01c-f35239bb5c87
+ *
+ * obsplugin__Setting export — Periodic Notes pilot (RFC f402002b, M4.1).
+ * Exercises the REAL M2 engine (`exportSettings`) over the obsplugin Periodic
+ * Notes source built from a parsed `data.json` fixture; the rendered asset
+ * markdown is re-parsed (production-shape — the test reads exactly what the
+ * export wrote, not handcrafted frontmatter). Revert-verified: neutralising the
+ * dot-path accessor (`resolveConfigPath`) makes the live-value assertions RED.
+ */
+import * as yaml from "js-yaml";
+import { exportSettings } from "../../../../src/services/settings";
+import {
+  OBSPLUGIN_SETTING_CLASS_UID,
+  PERIODIC_NOTES_DECLARED_KEYS,
+  buildPeriodicNotesSource,
+  resolveConfigPath,
+} from "../../../../src/services/settings/obsPluginSource";
+
+/** A realistic Periodic Notes `data.json` (shape mirrors a live install). */
+const FIXTURE = {
+  showGettingStartedBanner: true,
+  hasMigratedDailyNoteSettings: false,
+  daily: {
+    format: "YYYY-MM-DD [Note]",
+    template: "09 Templates/periodic-notes/{{Daily Note}}.md",
+    folder: "assetspaces/kitelev",
+    enabled: true,
+  },
+  weekly: { format: "", folder: "x/y", template: "", enabled: true },
+};
+
+/** Re-parse the frontmatter of one rendered `obsplugin__Setting` asset. */
+function parseFrontmatter(content: string): Record<string, unknown> {
+  const m = content.match(/^---\n([\s\S]*?)\n---/);
+  if (m === null) throw new Error("rendered asset has no frontmatter");
+  return yaml.load(m[1]) as Record<string, unknown>;
+}
+
+describe("obsplugin Periodic Notes settings export (M4.1)", () => {
+  it("@req:af71d01c-8790-4dc5-b01c-f35239bb5c87 exports each declared Daily-Notes key into an obsplugin__Setting asset carrying the dot-path live value + key ref", () => {
+    const source = buildPeriodicNotesSource(FIXTURE);
+    const assets = exportSettings(source, {
+      ontologyUid: "ont-1234",
+      nowIso: "2026-06-28T00:00:00.000Z",
+    });
+
+    // One asset per declared key — no more (allowlist-by-construction).
+    expect(assets).toHaveLength(PERIODIC_NOTES_DECLARED_KEYS.length);
+    const byField = new Map(
+      assets.map((a) => [a.field, parseFrontmatter(a.content)]),
+    );
+
+    const folder = byField.get("daily.folder")!;
+    // Typed obsplugin__Setting, co-located under the chosen ontology, fixed uid.
+    expect(folder["exo__Instance_class"]).toEqual([
+      `[[${OBSPLUGIN_SETTING_CLASS_UID}]]`,
+    ]);
+    expect(folder["exo__Asset_isDefinedBy"]).toBe("[[ont-1234]]");
+    expect(folder["exo__Asset_uid"]).toBe(
+      "2bb137e5-b2c7-4fc8-b234-60639de674a9",
+    );
+    expect(folder["setting__Setting_key"]).toBe(
+      "[[6ba6a073-3ee9-4527-8958-34596e072a31]]",
+    );
+    // The M4.1 heart: dot-path `daily.folder` → the live value from data.json.
+    expect(folder["setting__Setting_value"]).toBe("assetspaces/kitelev");
+
+    expect(byField.get("daily.format")!["setting__Setting_value"]).toBe(
+      "YYYY-MM-DD [Note]",
+    );
+    expect(byField.get("daily.template")!["setting__Setting_value"]).toBe(
+      "09 Templates/periodic-notes/{{Daily Note}}.md",
+    );
+    // boolean datatype round-trips as a real boolean (not a string).
+    expect(byField.get("daily.enabled")!["setting__Setting_value"]).toBe(true);
+
+    // The fixed deterministic basenames (byte-identical across devices).
+    const fileNames = assets.map((a) => a.fileName).sort();
+    expect(fileNames).toEqual([
+      "2bb137e5-b2c7-4fc8-b234-60639de674a9.md",
+      "411646dd-1a87-40d8-853d-01c37af7fb2c.md",
+      "5430a6c5-6be5-483e-bb94-d740d6dd2541.md",
+      "6ed5cfdf-551b-49bc-a467-56756b822da5.md",
+    ]);
+  });
+
+  it("@req:af71d01c-8790-4dc5-b01c-f35239bb5c87 allowlist-by-construction: only declared daily.* keys exported — never weekly.* / banner / arbitrary live keys", () => {
+    const source = buildPeriodicNotesSource(FIXTURE);
+    const assets = exportSettings(source, { ontologyUid: "o", nowIso: "t" });
+    expect(assets.map((a) => a.field).sort()).toEqual([
+      "daily.enabled",
+      "daily.folder",
+      "daily.format",
+      "daily.template",
+    ]);
+    // weekly.* + showGettingStartedBanner present in fixture but NOT declared.
+    expect(assets.some((a) => a.field.startsWith("weekly"))).toBe(false);
+  });
+
+  describe("resolveConfigPath (dot-path accessor)", () => {
+    it("resolves nested paths to their live value", () => {
+      expect(resolveConfigPath(FIXTURE, "daily.folder")).toBe(
+        "assetspaces/kitelev",
+      );
+      expect(resolveConfigPath(FIXTURE, "daily.enabled")).toBe(true);
+    });
+
+    it("returns undefined for a missing segment or non-object traversal", () => {
+      expect(resolveConfigPath(FIXTURE, "daily.nope")).toBeUndefined();
+      expect(resolveConfigPath(FIXTURE, "missing.x")).toBeUndefined();
+      expect(resolveConfigPath(null, "a.b")).toBeUndefined();
+      expect(resolveConfigPath("scalar", "a")).toBeUndefined();
+    });
+  });
+});

--- a/packages/core/tests/unit/services/settings/obsPluginSource.test.ts
+++ b/packages/core/tests/unit/services/settings/obsPluginSource.test.ts
@@ -112,5 +112,11 @@ describe("obsplugin Periodic Notes settings export (M4.1)", () => {
       expect(resolveConfigPath(null, "a.b")).toBeUndefined();
       expect(resolveConfigPath("scalar", "a")).toBeUndefined();
     });
+
+    it("reads own properties only — inherited / prototype segments yield undefined", () => {
+      expect(resolveConfigPath({}, "__proto__")).toBeUndefined();
+      expect(resolveConfigPath({}, "constructor")).toBeUndefined();
+      expect(resolveConfigPath({ daily: {} }, "daily.toString")).toBeUndefined();
+    });
   });
 });

--- a/packages/obsidian-plugin/src/ExocortexPlugin.ts
+++ b/packages/obsidian-plugin/src/ExocortexPlugin.ts
@@ -56,6 +56,11 @@ import {
   registerExportSettingsCommand,
   registerImportSettingsCommand,
 } from "./infrastructure/adapters/registerSettingsDistributionCommands";
+import { registerExportObsPluginSettingsCommand } from "./infrastructure/adapters/registerObsPluginSettingsCommands";
+import {
+  buildPeriodicNotesSource,
+  PERIODIC_NOTES_DATA_PATH,
+} from "@kitelev/exocortex-core";
 import {
   TaskStatusService,
   CommandResolver,
@@ -3599,6 +3604,7 @@ export default class ExocortexPlugin extends Plugin {
     // snapshot/restore via the generic Settings Distribution engine — does NOT
     // touch the live-mirror (VaultSettingsStore); M2.3 deprecates that.
     this.registerSettingsDistributionCommands();
+    this.registerObsPluginSettingsCommands();
 
     // Issue #3707 — «Register for sync»: write an exo__AssetSpace descriptor into
     // a mounted-but-undeclared knowledge pack so ExoSync's class-based discovery
@@ -4244,6 +4250,66 @@ export default class ExocortexPlugin extends Plugin {
         }
         return Promise.resolve(out);
       },
+      notify: (message) => this.notifier.info(message),
+    });
+  }
+
+  /**
+   * M4.1 (RFC f402002b) — «Exocortex: Export Periodic Notes settings».
+   * Snapshots the Periodic Notes plugin's Daily-Notes config (`data.json`, read
+   * via `vault.adapter` → mobile-safe) into `obsplugin__Setting` assets in a
+   * user-picked ontology, reusing the generic M2 Settings Distribution engine.
+   * Registered UNCONDITIONALLY (Desktop↔Mobile Command Parity — no
+   * `Platform.isMobile` gate). Export-only (M4.1); Import is M4.2. Additive —
+   * does not touch the exocortex export or the live-mirror.
+   */
+  private registerObsPluginSettingsCommands(): void {
+    registerExportObsPluginSettingsCommand(this, {
+      commandId: "export-periodic-notes-settings",
+      commandName: "Export Periodic Notes settings",
+      pluginLabel: "Periodic Notes",
+      loadSource: async () => {
+        if (!(await this.app.vault.adapter.exists(PERIODIC_NOTES_DATA_PATH))) {
+          return null;
+        }
+        let parsed: unknown;
+        try {
+          parsed = JSON.parse(
+            await this.app.vault.adapter.read(PERIODIC_NOTES_DATA_PATH),
+          );
+        } catch {
+          return null; // unparseable data.json → treat as not-installed (notice)
+        }
+        return buildPeriodicNotesSource(parsed);
+      },
+      pickOntology: () => {
+        const files = this.app.vault.getMarkdownFiles();
+        const assets = files.map((f) => ({
+          path: f.path,
+          frontmatter: (this.app.metadataCache.getFileCache(f)?.frontmatter ??
+            {}) as Record<string, unknown>,
+        }));
+        const candidates = listOntologyCandidates(assets);
+        if (candidates.length === 0) {
+          this.notifier.info(
+            "Export Periodic Notes settings: no ontology found in this vault to export into.",
+          );
+          return Promise.resolve(null);
+        }
+        return new Promise<OntologyChoice | null>((resolve) => {
+          new OntologyFuzzyModal(
+            this.app,
+            candidates,
+            "Choose ontology to export Periodic Notes settings into",
+            resolve,
+          ).open();
+        });
+      },
+      writeAsset: (folder, fileName, content) => {
+        const path = folder.length > 0 ? `${folder}/${fileName}` : fileName;
+        return this.app.vault.adapter.write(path, content);
+      },
+      nowIso: () => new Date().toISOString(),
       notify: (message) => this.notifier.info(message),
     });
   }

--- a/packages/obsidian-plugin/src/infrastructure/adapters/registerObsPluginSettingsCommands.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/registerObsPluginSettingsCommands.ts
@@ -1,0 +1,90 @@
+/**
+ * Palette registration for the M4.1 `obsplugin__Setting` export command (RFC
+ * f402002b). Pilot: «Exocortex: Export Periodic Notes settings» (id
+ * `export-periodic-notes-settings`). Obsidian auto-prefixes the plugin name;
+ * the id omits "exocortex" per obsidianmd lint rules + is byte-exact (hotkeys
+ * persist by id).
+ *
+ * ⛔ Desktop↔Mobile Command Parity invariant (CLAUDE.md): registered
+ * UNCONDITIONALLY — NO `Platform.isMobile` gate. The source reads the target
+ * plugin's `data.json` via `vault.adapter` (no Node `fs`), so export IS
+ * available on iPhone.
+ *
+ * Unlike the exocortex export (whose source is fixed), an obsplugin source is
+ * built per-invocation from the target plugin's live `data.json` (read at
+ * callback time) — `loadSource` returns `null` when the plugin isn't installed
+ * / its `data.json` is unreadable, and the command notifies instead of erroring.
+ *
+ * Reuses the generic engine (`exportSettings`) + the exocortex export's
+ * {@link SettingsCommandRegistrar} / {@link formatExportResult}; additive (a
+ * NEW command — it does NOT touch the exocortex export or the live-mirror).
+ * Export-only (M4.1); Import is M4.2.
+ */
+import { exportSettings, type SettingsSource } from "@kitelev/exocortex-core";
+import type { OntologyChoice } from "./PluginVaultCheckReader";
+import {
+  formatExportResult,
+  type SettingsCommandRegistrar,
+} from "./registerSettingsDistributionCommands";
+
+export interface ExportObsPluginSettingsDeps {
+  /** Command id (byte-exact; obsidian persists hotkeys by id). */
+  readonly commandId: string;
+  /** Command name (obsidian auto-prefixes «Exocortex: »). */
+  readonly commandName: string;
+  /** Human label of the target plugin (for the not-found notice). */
+  readonly pluginLabel: string;
+  /**
+   * Build the export source from the target plugin's live config — `null` when
+   * the plugin is not installed / its `data.json` is missing or unparseable.
+   */
+  loadSource: () => Promise<SettingsSource | null>;
+  /** Pick the target ontology (its folder = where assets are written; uid = isDefinedBy). */
+  pickOntology: () => Promise<OntologyChoice | null>;
+  /** Full-overwrite one asset at `<folder>/<fileName>` (vault.adapter.write). */
+  writeAsset: (
+    folder: string,
+    fileName: string,
+    content: string,
+  ) => Promise<void>;
+  /** ISO timestamp for the exported assets (deterministic under test). */
+  nowIso: () => string;
+  notify: (message: string) => void;
+}
+
+export function registerExportObsPluginSettingsCommand(
+  plugin: SettingsCommandRegistrar,
+  deps: ExportObsPluginSettingsDeps,
+): void {
+  plugin.addCommand({
+    id: deps.commandId,
+    name: deps.commandName,
+    callback: () => {
+      void (async () => {
+        try {
+          const source = await deps.loadSource();
+          if (source === null) {
+            deps.notify(
+              `Export ${deps.pluginLabel} settings: ${deps.pluginLabel} not found in this vault (no readable data.json).`,
+            );
+            return;
+          }
+          const choice = await deps.pickOntology();
+          if (choice === null) return; // user cancelled the picker
+          const assets = exportSettings(source, {
+            ontologyUid: choice.uid,
+            nowIso: deps.nowIso(),
+          });
+          for (const a of assets) {
+            await deps.writeAsset(choice.folder, a.fileName, a.content);
+          }
+          deps.notify(formatExportResult(choice, assets));
+        } catch (err) {
+          deps.notify(
+            `Export ${deps.pluginLabel} settings: errored — ${err instanceof Error ? err.message : String(err)}`,
+          );
+        }
+      })();
+    },
+  });
+}

--- a/packages/obsidian-plugin/src/infrastructure/adapters/registerObsPluginSettingsCommands.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/registerObsPluginSettingsCommands.ts
@@ -22,10 +22,7 @@
  */
 import { exportSettings, type SettingsSource } from "@kitelev/exocortex-core";
 import type { OntologyChoice } from "./PluginVaultCheckReader";
-import {
-  formatExportResult,
-  type SettingsCommandRegistrar,
-} from "./registerSettingsDistributionCommands";
+import type { SettingsCommandRegistrar } from "./registerSettingsDistributionCommands";
 
 export interface ExportObsPluginSettingsDeps {
   /** Command id (byte-exact; obsidian persists hotkeys by id). */
@@ -78,7 +75,12 @@ export function registerExportObsPluginSettingsCommand(
           for (const a of assets) {
             await deps.writeAsset(choice.folder, a.fileName, a.content);
           }
-          deps.notify(formatExportResult(choice, assets));
+          // Plugin-aware notice — do NOT reuse the exocortex `formatExportResult`
+          // (its "run «Import settings» to restore" hint points at the EXOCORTEX
+          // import; obsplugin Import is M4.2, not shipped).
+          deps.notify(
+            `Export ${deps.pluginLabel} settings: wrote ${assets.length} setting asset(s) into «${choice.label}». Re-export to update (Import is not yet available).`,
+          );
         } catch (err) {
           deps.notify(
             `Export ${deps.pluginLabel} settings: errored — ${err instanceof Error ? err.message : String(err)}`,

--- a/packages/obsidian-plugin/tests/unit/settings/registerObsPluginSettingsCommands.test.ts
+++ b/packages/obsidian-plugin/tests/unit/settings/registerObsPluginSettingsCommands.test.ts
@@ -1,0 +1,128 @@
+/**
+ * @req:af71d01c-8790-4dc5-b01c-f35239bb5c87
+ *
+ * M4.1 obsplugin__Setting export command registrar (RFC f402002b): stable
+ * command id + the callback builds the source from the plugin's live config,
+ * drives the generic `exportSettings`, writes the assets, and surfaces a Notice.
+ * Pure over injected thunks (no Obsidian runtime). The happy-path asset value is
+ * the dot-path-resolved live value (shares the core revert-verify on
+ * `resolveConfigPath`).
+ */
+import { buildPeriodicNotesSource } from "@kitelev/exocortex-core";
+import { registerExportObsPluginSettingsCommand } from "@plugin/infrastructure/adapters/registerObsPluginSettingsCommands";
+import type { SettingsCommandRegistrar } from "@plugin/infrastructure/adapters/registerSettingsDistributionCommands";
+
+const DATA_JSON = {
+  daily: {
+    format: "YYYY-MM-DD [Note]",
+    template: "09 Templates/periodic-notes/{{Daily Note}}.md",
+    folder: "assetspaces/kitelev",
+    enabled: true,
+  },
+};
+
+function fakeRegistrar(): {
+  registrar: SettingsCommandRegistrar;
+  commands: Map<string, { name: string; callback: () => void }>;
+} {
+  const commands = new Map<string, { name: string; callback: () => void }>();
+  return {
+    registrar: {
+      addCommand: (c) =>
+        commands.set(c.id, { name: c.name, callback: c.callback }),
+    },
+    commands,
+  };
+}
+
+const flush = () => new Promise((r) => setTimeout(r, 0));
+
+describe("registerExportObsPluginSettingsCommand (M4.1)", () => {
+  it("@req:af71d01c-8790-4dc5-b01c-f35239bb5c87 registers «Export Periodic Notes settings» with a stable id; the callback exports the data.json daily keys into the picked ontology", async () => {
+    const { registrar, commands } = fakeRegistrar();
+    const writes: { folder: string; fileName: string; content: string }[] = [];
+    const notes: string[] = [];
+
+    registerExportObsPluginSettingsCommand(registrar, {
+      commandId: "export-periodic-notes-settings",
+      commandName: "Export Periodic Notes settings",
+      pluginLabel: "Periodic Notes",
+      loadSource: async () => buildPeriodicNotesSource(DATA_JSON),
+      pickOntology: async () => ({
+        uid: "ont-uid",
+        label: "My Ontology",
+        folder: "onto/dir",
+      }),
+      writeAsset: async (folder, fileName, content) => {
+        writes.push({ folder, fileName, content });
+      },
+      nowIso: () => "2026-06-28T00:00:00",
+      notify: (m) => notes.push(m),
+    });
+
+    const cmd = commands.get("export-periodic-notes-settings");
+    expect(cmd?.name).toBe("Export Periodic Notes settings");
+
+    cmd!.callback();
+    await flush();
+
+    // 4 declared daily keys → 4 assets in the picked ontology folder.
+    expect(writes).toHaveLength(4);
+    expect(writes.every((w) => w.folder === "onto/dir")).toBe(true);
+    const folderAsset = writes.find(
+      (w) => w.fileName === "2bb137e5-b2c7-4fc8-b234-60639de674a9.md",
+    );
+    // dot-path daily.folder → live value (depends on core resolveConfigPath).
+    expect(folderAsset?.content).toContain(
+      'setting__Setting_value: "assetspaces/kitelev"',
+    );
+    expect(notes[0]).toContain("wrote 4 setting asset(s) into «My Ontology»");
+  });
+
+  it("notifies (no writes) when the target plugin is not installed (loadSource → null)", async () => {
+    const { registrar, commands } = fakeRegistrar();
+    const writes: unknown[] = [];
+    const notes: string[] = [];
+
+    registerExportObsPluginSettingsCommand(registrar, {
+      commandId: "export-periodic-notes-settings",
+      commandName: "Export Periodic Notes settings",
+      pluginLabel: "Periodic Notes",
+      loadSource: async () => null,
+      pickOntology: async () => ({ uid: "u", label: "L", folder: "f" }),
+      writeAsset: async () => {
+        writes.push(1);
+      },
+      nowIso: () => "x",
+      notify: (m) => notes.push(m),
+    });
+
+    commands.get("export-periodic-notes-settings")!.callback();
+    await flush();
+
+    expect(writes).toHaveLength(0);
+    expect(notes[0]).toContain("Periodic Notes not found in this vault");
+  });
+
+  it("is a no-op when the user cancels the ontology picker (plugin present)", async () => {
+    const { registrar, commands } = fakeRegistrar();
+    const writes: unknown[] = [];
+
+    registerExportObsPluginSettingsCommand(registrar, {
+      commandId: "export-periodic-notes-settings",
+      commandName: "Export Periodic Notes settings",
+      pluginLabel: "Periodic Notes",
+      loadSource: async () => buildPeriodicNotesSource(DATA_JSON),
+      pickOntology: async () => null,
+      writeAsset: async () => {
+        writes.push(1);
+      },
+      nowIso: () => "x",
+      notify: () => undefined,
+    });
+
+    commands.get("export-periodic-notes-settings")!.callback();
+    await flush();
+    expect(writes).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## What

M4.1 of the Unified Homoiconic Settings Distribution framework (RFC `f402002b`): a **community-plugin** settings export pilot. New command **«Exocortex: Export Periodic Notes settings»** snapshots the Periodic Notes plugin's Daily-Notes config (`folder`/`format`/`template`/`enabled`) into homoiconic `obsplugin__Setting` assets, reusing the **existing** generic M2 `SettingsDistributionEngine` (`exportSettings`).

## How (additive)

- **core** `packages/core/src/services/settings/obsPluginSource.ts` — `PeriodicNotesSettingsSource` (a `SettingsSource` whose each declared key's `field` is a dot-path, e.g. `daily.folder`, into the parsed `data.json`) + `resolveConfigPath` + `buildPeriodicNotesSource`. `writeLiveValue` rejects (Import = M4.2, OUT OF SCOPE). **Allowlist-by-construction**: only the 4 declared Daily keys are ever exported — `weekly.*`/`monthly.*`/banner can never leak.
- **plugin** `registerObsPluginSettingsCommands.ts` — `registerExportObsPluginSettingsCommand` (reuses `exportSettings` + `formatExportResult`) + `ExocortexPlugin.registerObsPluginSettingsCommands`. Reads `data.json` via **`vault.adapter`** (mobile-safe, ⛔ NO Node `fs`), registered **UNCONDITIONALLY** (Desktop↔Mobile Command Parity — no `Platform.isMobile` gate). Plugin not installed / unreadable → Notice, no writes.
- **TBox** (separate, not in this PR's diff — `$setting` floor `exoas-exo`): `obsplugin__Setting`/`obsplugin__SettingKey` subclasses + 4 Periodic-Notes Daily key individuals.

Does **not** touch the exocortex export, the live-mirror (`VaultSettingsStore`), or any existing settings code.

## Tests + revert-verify

- core `obsPluginSource.test.ts` (`@req:af71d01c…` ×2) — engine + source + allowlist + dot-path; production-shape (renders real asset markdown, re-parses via `js-yaml`). 4/4.
- plugin `registerObsPluginSettingsCommands.test.ts` (`@req:af71d01c…` ×1) — command surface: build-source→export→write, not-installed notice, picker-cancel no-op. 3/3.
- **Revert-verified** ([[integration-test-revert-verify]]): neutralising `resolveConfigPath` (type-preserving) → live-value asserts **RED** (2/4), allowlist + missing-segment **GREEN both ways** (zero false-positive); restored → 4/4 **GREEN**.

## Scope

`Req: af71d01c-8790-4dc5-b01c-f35239bb5c87` (P2, Integration binding) — status `proposed`, flips `active` after merge (binding-in-main). RFC `f402002b` M4.1. **Export-only**; Import (M4.2) deferred.
