### PR TITLE
fix(core): workflow_transition resolves any effort class data-driven — no crash on non-Task/Project/Meeting

### DIFF
--- a/packages/core/src/domain/constants/WorkflowClassUids.ts
+++ b/packages/core/src/domain/constants/WorkflowClassUids.ts
@@ -1,0 +1,25 @@
+import { AssetClass } from "./AssetClass";
+
+/**
+ * RFC 36347daf Phase 2 — UID → AssetClass label map for the built-in status
+ * workflows. These are the classes that ship with a default workflow
+ * (Task + Project + Meeting) so a `workflow_transition` grounding can resolve
+ * them even when their `exo__Instance_class` is stored in UID-canon strip-form
+ * (`"[[<uid>]]"`, no alias) — the canonical vault representation post-#3165.
+ *
+ * NOT an exhaustive class registry: any *other* effort-bearing class gets a
+ * workflow purely from vault data — a per-asset `ems__Effort_workflow` override
+ * or a per-class `ems__Workflow` ABox (Homoiconicity Invariant). Classes with
+ * no applicable workflow resolve to `null` (graceful no-op) rather than
+ * crashing. See {@link WorkflowResolver.resolveForAssetOrNull}.
+ *
+ * Drift guards (defense in depth):
+ *   1. `GroundingExecutor.status_uid_integrity.test.ts` — UUID-shape + uniqueness.
+ *   2. Vault `validate-wikilinks` hook blocks writes to renamed class TBox files.
+ */
+export const CLASS_UID_TO_LABEL: Readonly<Record<string, string>> =
+  Object.freeze({
+    "1b20a8f0-d745-4e93-91db-4531b3df120e": AssetClass.TASK,
+    "7db5eeff-718a-49b0-8d2b-39b084a356e3": AssetClass.PROJECT,
+    "1b0a5e34-dd7f-4ead-b43a-6c7c5a5ecaca": AssetClass.MEETING,
+  });

--- a/packages/core/src/services/CommandExecutionFlow.ts
+++ b/packages/core/src/services/CommandExecutionFlow.ts
@@ -170,6 +170,17 @@ export class CommandExecutionFlow {
       this.logger.info(
         `[CommandExecutionFlow] Executed "${command.name}" on ${displayPath}`,
       );
+    } else if (result.notApplicable) {
+      // Benign "not applicable" outcome (e.g. a generic status-transition button
+      // rendered on a class with no status workflow). Surface as an
+      // informational notice — NOT a "Command failed" error — so the user sees a
+      // clear, non-alarming message instead of a crash. See ExecutionResult.
+      this.notificationService.info(
+        result.error ?? "This command is not available for this asset.",
+      );
+      this.logger.info(
+        `[CommandExecutionFlow] Not applicable "${command.name}": ${result.error}`,
+      );
     } else {
       this.notificationService.error(
         `Command failed: ${result.error ?? "unknown error"}`,

--- a/packages/core/src/services/GroundingExecutor.ts
+++ b/packages/core/src/services/GroundingExecutor.ts
@@ -282,20 +282,20 @@ const MAX_COMPOSITE_DEPTH = 20;
  * without store hydration), the workflow_transition dispatch fails loud
  * with a clear error message.
  *
- * `resolveForAssetOrNull` is data-driven: it accepts the raw class reference
- * (UID-canon `"[[<uid>]]"`, alias `"[[<uid>|label]]"`, or bare label) from the
- * target's `exo__Instance_class` and returns the applicable workflow, or
- * `null` when the class has none (a per-asset `ems__Effort_workflow` override,
- * a per-class `ems__Workflow` ABox, and the built-in Task/Project/Meeting
- * defaults are all consulted). A `null` return is NOT an error — the
- * dispatcher treats it as "no status workflow for this class" and degrades
- * gracefully (no crash on non-Effort / lifecycle-only classes such as
- * `ems__Action`).
+ * `resolveForAssetOrNull` is data-driven: it accepts the raw class references
+ * (each UID-canon `"<uid>"`, alias `"<uid>|label"`, or bare label) from the
+ * target's possibly multi-valued `exo__Instance_class` and returns the
+ * applicable workflow, or `null` when no class has one (a per-asset
+ * `ems__Effort_workflow` override, a per-class `ems__Workflow` ABox, and the
+ * built-in Task/Project/Meeting defaults are all consulted). A `null` return is
+ * NOT an error — the dispatcher treats it as "no status workflow for this class"
+ * and degrades gracefully (no crash on non-Effort / lifecycle-only classes such
+ * as `ems__Action`).
  */
 export type WorkflowResolverPort = {
   resolveForAssetOrNull(
     subjectIRI: IRI,
-    classRef: string,
+    classRefs: readonly string[],
   ): Promise<WorkflowDefinition | null>;
 };
 
@@ -2344,12 +2344,12 @@ export class GroundingExecutor {
     const content = await this.fileReader.readFile(filePath);
     const fm = this.frontmatterService.parseObject(content) ?? {};
 
-    // 2. Resolve the asset's class reference (any class — UID-canon, alias, or
-    //    label form). Only a missing `exo__Instance_class` is a hard stop here;
-    //    the class need NOT be one of the built-in workflow classes — that is
-    //    decided data-drivenly by the resolver below.
-    const classRef = this.resolveClassRefFromFrontmatter(fm);
-    if (!classRef) {
+    // 2. Resolve the asset's class references (any class — UID-canon, alias, or
+    //    label form; `exo__Instance_class` may be multi-valued). Only a missing
+    //    `exo__Instance_class` is a hard stop here; the classes need NOT be
+    //    built-in workflow classes — that is decided data-drivenly below.
+    const classRefs = this.resolveClassRefsFromFrontmatter(fm);
+    if (classRefs.length === 0) {
       return {
         success: false,
         notApplicable: true,
@@ -2376,7 +2376,7 @@ export class GroundingExecutor {
     }
     const workflow = await this.workflowResolver.resolveForAssetOrNull(
       subjectIRI,
-      classRef,
+      classRefs,
     );
     if (!workflow) {
       return {
@@ -2486,22 +2486,24 @@ export class GroundingExecutor {
   }
 
   /**
-   * RFC 36347daf Phase 2 (generalised) — extract the FIRST `exo__Instance_class`
-   * reference from frontmatter as a raw class ref string for the data-driven
+   * RFC 36347daf Phase 2 (generalised) — extract ALL `exo__Instance_class`
+   * references from frontmatter as raw class ref strings for the data-driven
    * {@link WorkflowResolverPort.resolveForAssetOrNull}. Handles string and array
-   * shapes and wikilink-form values; returns the inner ref WITHOUT the `[[ ]]`
+   * shapes and wikilink-form values; returns each inner ref WITHOUT the `[[ ]]`
    * wrapping (`"<uid>"`, `"<uid>|label"`, or `"label"`) — the resolver
-   * normalises and maps it. Unlike the previous implementation this is NOT
-   * limited to a hardcoded set of classes: ANY class ref is returned so the
-   * resolver can apply per-asset / per-class / built-in workflow rules. Returns
-   * null ONLY when `exo__Instance_class` is absent or carries no usable value.
+   * normalises and maps them. Unlike the previous implementation this is NOT
+   * limited to a hardcoded set of classes, and it returns EVERY ref (not just
+   * the first) so a multi-valued `exo__Instance_class` still resolves when a
+   * workflow-bearing class is not listed first. Empty array when
+   * `exo__Instance_class` is absent or carries no usable value.
    */
-  private resolveClassRefFromFrontmatter(
+  private resolveClassRefsFromFrontmatter(
     fm: Record<string, unknown>,
-  ): string | null {
+  ): string[] {
     const raw = fm["exo__Instance_class"];
-    if (raw === undefined || raw === null) return null;
+    if (raw === undefined || raw === null) return [];
     const values = Array.isArray(raw) ? raw : [raw];
+    const refs: string[] = [];
     for (const v of values) {
       if (typeof v !== "string") continue;
       // Strip wikilink wrapping `"[[...|label]]"` or `"[[label]]"`.
@@ -2509,9 +2511,9 @@ export class GroundingExecutor {
         .replace(/^\s*"?\[\[/, "")
         .replace(/\]\]"?\s*$/, "")
         .trim();
-      if (inside.length > 0) return inside;
+      if (inside.length > 0) refs.push(inside);
     }
-    return null;
+    return refs;
   }
 
   /**

--- a/packages/core/src/services/GroundingExecutor.ts
+++ b/packages/core/src/services/GroundingExecutor.ts
@@ -12,7 +12,6 @@ import type {
 } from "../domain/models/CommandDefinition";
 import { GroundingType } from "../domain/constants/GroundingType";
 import { resolveTemplateBody } from "./TemplateBodyResolver";
-import { AssetClass } from "../domain/constants/AssetClass";
 import { base64ToUtf8 } from "../utilities/base64";
 import { EffortStatus } from "../domain/constants/EffortStatus";
 import { IRI } from "../domain/models/rdf/IRI";
@@ -71,24 +70,12 @@ const STATUS_ENUM_BY_UID: Readonly<Record<string, EffortStatus>> = Object.freeze
   ) as Record<string, EffortStatus>,
 );
 
-/**
- * RFC 36347daf Phase 2 — UID → AssetClass label map for workflow_transition
- * class resolution when target asset's exo__Instance_class is stored in
- * UID-form (post-RFC #3165 UUID-canon). Limited to classes that have default
- * workflows today (Task + Project + Meeting).
- *
- * Drift guards (defense in depth):
- *   1. `StatusUidByEnumIntegrity.test.ts` — UUID-shape + uniqueness check.
- *   2. Vault `validate-wikilinks` hook blocks writes to renamed class TBox files.
- *
- * Adding more workflow target classes requires adding an entry here AND
- * creating the corresponding vault Workflow ABox per the Phase 2 RFC.
- */
-export const CLASS_UID_TO_LABEL: Readonly<Record<string, string>> = Object.freeze({
-  "1b20a8f0-d745-4e93-91db-4531b3df120e": AssetClass.TASK,
-  "7db5eeff-718a-49b0-8d2b-39b084a356e3": AssetClass.PROJECT,
-  "1b0a5e34-dd7f-4ead-b43a-6c7c5a5ecaca": AssetClass.MEETING,
-});
+// RFC 36347daf Phase 2 — UID → AssetClass label map for the built-in status
+// workflows (Task/Project/Meeting). Extracted to a shared constant so the
+// data-driven WorkflowResolver can reuse it without importing GroundingExecutor
+// (avoids an import cycle). Re-exported here for backward compatibility with
+// `GroundingExecutor.status_uid_integrity.test.ts`.
+export { CLASS_UID_TO_LABEL } from "../domain/constants/WorkflowClassUids";
 import {
   installDefaultResolvers,
   getResolver,
@@ -112,6 +99,17 @@ export interface ExecutionResult {
   readonly success: boolean;
   readonly error?: string;
   readonly openPath?: string;
+  /**
+   * Marks an unsuccessful result as a benign "not applicable" outcome rather
+   * than a hard failure. Set by `workflow_transition` when the target asset's
+   * class has no applicable status workflow (e.g. `ems__Action`, which has its
+   * own one-shot lifecycle, or a class for which no `ems__Workflow` ABox /
+   * `ems__Effort_workflow` override exists). The presentation layer surfaces
+   * this as an informational notice — NOT a "Command failed" error — so a
+   * generic status-transition button rendered on such a class degrades
+   * gracefully instead of crashing. See `CommandExecutionFlow`.
+   */
+  readonly notApplicable?: boolean;
 }
 
 /**
@@ -283,12 +281,22 @@ const MAX_COMPOSITE_DEPTH = 20;
  * asset's class at execution time. Optional — when absent (tests, CLI
  * without store hydration), the workflow_transition dispatch fails loud
  * with a clear error message.
+ *
+ * `resolveForAssetOrNull` is data-driven: it accepts the raw class reference
+ * (UID-canon `"[[<uid>]]"`, alias `"[[<uid>|label]]"`, or bare label) from the
+ * target's `exo__Instance_class` and returns the applicable workflow, or
+ * `null` when the class has none (a per-asset `ems__Effort_workflow` override,
+ * a per-class `ems__Workflow` ABox, and the built-in Task/Project/Meeting
+ * defaults are all consulted). A `null` return is NOT an error — the
+ * dispatcher treats it as "no status workflow for this class" and degrades
+ * gracefully (no crash on non-Effort / lifecycle-only classes such as
+ * `ems__Action`).
  */
 export type WorkflowResolverPort = {
-  resolveForAsset(
+  resolveForAssetOrNull(
     subjectIRI: IRI,
-    assetClass: AssetClass,
-  ): Promise<WorkflowDefinition>;
+    classRef: string,
+  ): Promise<WorkflowDefinition | null>;
 };
 
 /**
@@ -2336,27 +2344,27 @@ export class GroundingExecutor {
     const content = await this.fileReader.readFile(filePath);
     const fm = this.frontmatterService.parseObject(content) ?? {};
 
-    // 2. Resolve asset class (first ems__* match in exo__Instance_class).
-    const assetClass = this.resolveAssetClassFromFrontmatter(fm);
-    if (!assetClass) {
+    // 2. Resolve the asset's class reference (any class — UID-canon, alias, or
+    //    label form). Only a missing `exo__Instance_class` is a hard stop here;
+    //    the class need NOT be one of the built-in workflow classes — that is
+    //    decided data-drivenly by the resolver below.
+    const classRef = this.resolveClassRefFromFrontmatter(fm);
+    if (!classRef) {
       return {
         success: false,
+        notApplicable: true,
         error:
-          "workflow_transition: target asset has no recognised ems__* class in exo__Instance_class (cannot resolve workflow).",
+          "workflow_transition: target asset has no exo__Instance_class — status transitions are not available for it.",
       };
     }
 
-    // 3. Resolve current status from ems__Effort_status.
-    const currentStatus = this.resolveStatusFromFrontmatter(fm);
-    if (!currentStatus) {
-      return {
-        success: false,
-        error:
-          "workflow_transition: target asset has no parseable ems__Effort_status value (need wikilink to an ems__EffortStatus* asset).",
-      };
-    }
-
-    // 4. Resolve workflow for this asset.
+    // 3. Resolve the workflow for this asset's class. Data-driven: a per-asset
+    //    `ems__Effort_workflow` override, a per-class `ems__Workflow` ABox, or a
+    //    built-in Task/Project/Meeting default — in that order. A `null` return
+    //    means the class has NO applicable status workflow (e.g. `ems__Action`'s
+    //    own one-shot lifecycle, or any class without a declared workflow). That
+    //    is a benign no-op, NOT a crash — generic status buttons that happen to
+    //    render on such a class degrade gracefully instead of failing loud.
     let subjectIRI: IRI;
     try {
       subjectIRI = new IRI(targetIRI);
@@ -2366,10 +2374,28 @@ export class GroundingExecutor {
         error: `workflow_transition: invalid targetIRI "${targetIRI}" — ${error instanceof Error ? error.message : String(error)}`,
       };
     }
-    const workflow = await this.workflowResolver.resolveForAsset(
+    const workflow = await this.workflowResolver.resolveForAssetOrNull(
       subjectIRI,
-      assetClass,
+      classRef,
     );
+    if (!workflow) {
+      return {
+        success: false,
+        notApplicable: true,
+        error:
+          "workflow_transition: this asset's class has no status workflow — status transitions are not available for it.",
+      };
+    }
+
+    // 4. Resolve current status from ems__Effort_status.
+    const currentStatus = this.resolveStatusFromFrontmatter(fm);
+    if (!currentStatus) {
+      return {
+        success: false,
+        error:
+          "workflow_transition: target asset has no parseable ems__Effort_status value (need wikilink to an ems__EffortStatus* asset).",
+      };
+    }
 
     // 5. Find matching transition.
     const direction: "forward" | "rollback" = grounding.direction ?? "forward";
@@ -2380,7 +2406,7 @@ export class GroundingExecutor {
     if (!transition) {
       return {
         success: false,
-        error: `workflow_transition: no ${direction} transition from "${currentStatus}" defined in workflow "${workflow.name}" (target class: ${assetClass}).`,
+        error: `workflow_transition: no ${direction} transition from "${currentStatus}" defined in workflow "${workflow.name}" (target class: ${workflow.targetClass}).`,
       };
     }
 
@@ -2460,41 +2486,30 @@ export class GroundingExecutor {
   }
 
   /**
-   * RFC 36347daf Phase 2 — extract the first recognised `ems__*` class from
-   * frontmatter `exo__Instance_class`. Handles both string and array shapes,
-   * and wikilink-form values (`"[[<UID>|ems__Task]]"`,
-   * `"[[<UID>]]"`, `"[[ems__Task]]"`). Returns null when nothing matches.
-   *
-   * UID-form refs are resolved via the existing classLabelToUid injection
-   * when available; otherwise we fall back to the inline mapping for the
-   * Task/Project pair (the only classes that have default workflows today).
+   * RFC 36347daf Phase 2 (generalised) — extract the FIRST `exo__Instance_class`
+   * reference from frontmatter as a raw class ref string for the data-driven
+   * {@link WorkflowResolverPort.resolveForAssetOrNull}. Handles string and array
+   * shapes and wikilink-form values; returns the inner ref WITHOUT the `[[ ]]`
+   * wrapping (`"<uid>"`, `"<uid>|label"`, or `"label"`) — the resolver
+   * normalises and maps it. Unlike the previous implementation this is NOT
+   * limited to a hardcoded set of classes: ANY class ref is returned so the
+   * resolver can apply per-asset / per-class / built-in workflow rules. Returns
+   * null ONLY when `exo__Instance_class` is absent or carries no usable value.
    */
-  private resolveAssetClassFromFrontmatter(
+  private resolveClassRefFromFrontmatter(
     fm: Record<string, unknown>,
-  ): AssetClass | null {
+  ): string | null {
     const raw = fm["exo__Instance_class"];
     if (raw === undefined || raw === null) return null;
     const values = Array.isArray(raw) ? raw : [raw];
-    const knownClasses = new Set<string>(Object.values(AssetClass));
     for (const v of values) {
       if (typeof v !== "string") continue;
       // Strip wikilink wrapping `"[[...|label]]"` or `"[[label]]"`.
-      const inside = v.replace(/^\s*"?\[\[/, "").replace(/\]\]"?\s*$/, "");
-      const aliasPart = inside.includes("|") ? inside.split("|")[1] : inside;
-      const bare = aliasPart.trim();
-      if (knownClasses.has(bare)) {
-        return bare as AssetClass;
-      }
-      // UID-form: map UID → AssetClass label.
-      const uuidMatch = inside.match(
-        /^([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})/i,
-      );
-      if (uuidMatch) {
-        const uidToLabel = CLASS_UID_TO_LABEL[uuidMatch[1].toLowerCase()];
-        if (uidToLabel && knownClasses.has(uidToLabel)) {
-          return uidToLabel as AssetClass;
-        }
-      }
+      const inside = v
+        .replace(/^\s*"?\[\[/, "")
+        .replace(/\]\]"?\s*$/, "")
+        .trim();
+      if (inside.length > 0) return inside;
     }
     return null;
   }

--- a/packages/core/src/services/WorkflowResolver.ts
+++ b/packages/core/src/services/WorkflowResolver.ts
@@ -79,10 +79,10 @@ export class WorkflowResolver {
   /**
    * RFC 36347daf (generalised, fix wf-transition crash) — data-driven workflow
    * resolution for the `workflow_transition` grounding. Accepts the RAW class
-   * reference from the target's `exo__Instance_class` (UID-canon `"<uid>"`,
-   * alias `"<uid>|label"`, or bare `"label"`) — NOT constrained to a hardcoded
-   * class set — and returns the applicable workflow, or `null` when the class
-   * has NONE.
+   * references from the target's `exo__Instance_class` (each UID-canon `"<uid>"`,
+   * alias `"<uid>|label"`, or bare `"label"`; `exo__Instance_class` may be
+   * multi-valued) — NOT constrained to a hardcoded class set — and returns the
+   * applicable workflow, or `null` when no class has one.
    *
    * Resolution priority (all vault-data-driven except the built-in defaults):
    *   1. Per-asset override — `ems__Effort_workflow` on the asset itself
@@ -102,7 +102,7 @@ export class WorkflowResolver {
    */
   async resolveForAssetOrNull(
     subjectIRI: IRI,
-    classRef: string,
+    classRefs: readonly string[],
   ): Promise<WorkflowDefinition | null> {
     // 1. Per-asset workflow override — class-independent.
     const workflowTriples = await this.tripleStore.match(
@@ -118,10 +118,14 @@ export class WorkflowResolver {
       }
     }
 
-    // 2. Built-in class default (Task / Project / Meeting only).
-    const builtIn = this.classRefToBuiltInClass(classRef);
-    if (builtIn !== null) {
-      return this.resolveForClass(builtIn);
+    // 2. Built-in class default (Task / Project / Meeting only) — try EACH class
+    //    ref so a multi-valued `exo__Instance_class` still resolves when a
+    //    built-in class is not listed first.
+    for (const classRef of classRefs) {
+      const builtIn = this.classRefToBuiltInClass(classRef);
+      if (builtIn !== null) {
+        return this.resolveForClass(builtIn);
+      }
     }
 
     // 3. No applicable workflow — benign, NOT an error.

--- a/packages/core/src/services/WorkflowResolver.ts
+++ b/packages/core/src/services/WorkflowResolver.ts
@@ -15,6 +15,7 @@ import {
   PROJECT_DEFAULT_WORKFLOW,
   TASK_DEFAULT_WORKFLOW,
 } from "../domain/defaults/DefaultWorkflows";
+import { CLASS_UID_TO_LABEL } from "../domain/constants/WorkflowClassUids";
 
 /**
  * Resolves WorkflowDefinitions from vault assets stored in an ITripleStore.
@@ -73,6 +74,87 @@ export class WorkflowResolver {
 
     // Fall back to class default
     return this.resolveForClass(assetClass);
+  }
+
+  /**
+   * RFC 36347daf (generalised, fix wf-transition crash) — data-driven workflow
+   * resolution for the `workflow_transition` grounding. Accepts the RAW class
+   * reference from the target's `exo__Instance_class` (UID-canon `"<uid>"`,
+   * alias `"<uid>|label"`, or bare `"label"`) — NOT constrained to a hardcoded
+   * class set — and returns the applicable workflow, or `null` when the class
+   * has NONE.
+   *
+   * Resolution priority (all vault-data-driven except the built-in defaults):
+   *   1. Per-asset override — `ems__Effort_workflow` on the asset itself
+   *      (works for ANY class, e.g. a one-off `ems__Bug` with its own workflow).
+   *   2. Built-in default — Task / Project / Meeting resolve their
+   *      class-default workflow (a vault `ems__Workflow` ABox with matching
+   *      `Workflow_targetClass` if present, else the hardcoded fallback).
+   *   3. `null` — the class is neither overridden nor a built-in workflow class
+   *      (e.g. `ems__Action`'s own one-shot lifecycle, `exo__Asset`, or any
+   *      class for which no workflow has been declared). The caller treats this
+   *      as "no status workflow" and degrades gracefully — no crash.
+   *
+   * To make a NEW class status-managed without code changes: add an
+   * `ems__Effort_workflow` to its assets (step 1) — Homoiconicity Invariant.
+   * (Per-class `ems__Workflow` ABox support for arbitrary non-built-in classes
+   * is a follow-up; today only the built-in three resolve a class default.)
+   */
+  async resolveForAssetOrNull(
+    subjectIRI: IRI,
+    classRef: string,
+  ): Promise<WorkflowDefinition | null> {
+    // 1. Per-asset workflow override — class-independent.
+    const workflowTriples = await this.tripleStore.match(
+      subjectIRI,
+      Namespace.EMS.term("Effort_workflow"),
+      undefined,
+    );
+    if (workflowTriples.length > 0) {
+      const workflowRef = workflowTriples[0].object;
+      if (workflowRef instanceof IRI) {
+        const specific = await this.loadWorkflowBySubject(workflowRef);
+        if (specific) return specific;
+      }
+    }
+
+    // 2. Built-in class default (Task / Project / Meeting only).
+    const builtIn = this.classRefToBuiltInClass(classRef);
+    if (builtIn !== null) {
+      return this.resolveForClass(builtIn);
+    }
+
+    // 3. No applicable workflow — benign, NOT an error.
+    return null;
+  }
+
+  /**
+   * Map a raw `exo__Instance_class` reference to a built-in workflow
+   * {@link AssetClass} (Task / Project / Meeting), or `null` when it is not one
+   * of them. Tolerates UID-canon (`"<uid>"`), alias (`"<uid>|ems__Task"`), and
+   * bare-label (`"ems__Task"`) forms. Case-insensitive on the UID.
+   */
+  private classRefToBuiltInClass(classRef: string): AssetClass | null {
+    const norm = this.normalizeWikilink(classRef);
+    const bare = norm.includes("|")
+      ? (norm.split("|").pop() ?? "").trim()
+      : norm.trim();
+
+    const BUILT_IN = new Set<string>([
+      AssetClass.TASK,
+      AssetClass.PROJECT,
+      AssetClass.MEETING,
+    ]);
+    if (BUILT_IN.has(bare)) return bare as AssetClass;
+
+    const uuidMatch = norm.match(
+      /([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})/i,
+    );
+    if (uuidMatch) {
+      const label = CLASS_UID_TO_LABEL[uuidMatch[1].toLowerCase()];
+      if (label && BUILT_IN.has(label)) return label as AssetClass;
+    }
+    return null;
   }
 
   /**

--- a/packages/core/tests/unit/services/GroundingExecutor.workflow_transition.test.ts
+++ b/packages/core/tests/unit/services/GroundingExecutor.workflow_transition.test.ts
@@ -116,7 +116,9 @@ describe("GroundingExecutor.workflow_transition (RFC 36347daf Phase 2)", () => {
       },
     ];
     const workflowResolver: WorkflowResolverPort = {
-      resolveForAsset: jest.fn().mockResolvedValue(makeTaskWorkflow(transitions)),
+      resolveForAssetOrNull: jest
+        .fn()
+        .mockResolvedValue(makeTaskWorkflow(transitions)),
     };
 
     const loadedActions: string[] = [];
@@ -173,7 +175,9 @@ describe("GroundingExecutor.workflow_transition (RFC 36347daf Phase 2)", () => {
       },
     ];
     const workflowResolver: WorkflowResolverPort = {
-      resolveForAsset: jest.fn().mockResolvedValue(makeTaskWorkflow(transitions)),
+      resolveForAssetOrNull: jest
+        .fn()
+        .mockResolvedValue(makeTaskWorkflow(transitions)),
     };
     const groundingLoader: GroundingLoaderPort = async (uid) => ({
       id: uid,
@@ -214,7 +218,9 @@ describe("GroundingExecutor.workflow_transition (RFC 36347daf Phase 2)", () => {
       },
     ];
     const workflowResolver: WorkflowResolverPort = {
-      resolveForAsset: jest.fn().mockResolvedValue(makeTaskWorkflow(transitions)),
+      resolveForAssetOrNull: jest
+        .fn()
+        .mockResolvedValue(makeTaskWorkflow(transitions)),
     };
 
     const { executor, writer } = makeExecutor({
@@ -242,7 +248,9 @@ describe("GroundingExecutor.workflow_transition (RFC 36347daf Phase 2)", () => {
       },
     ];
     const workflowResolver: WorkflowResolverPort = {
-      resolveForAsset: jest.fn().mockResolvedValue(makeTaskWorkflow(transitions)),
+      resolveForAssetOrNull: jest
+        .fn()
+        .mockResolvedValue(makeTaskWorkflow(transitions)),
     };
 
     const { executor, writer } = makeExecutor({
@@ -279,9 +287,20 @@ describe("GroundingExecutor.workflow_transition (RFC 36347daf Phase 2)", () => {
     expect(result.error).toMatch(/WorkflowResolver injection/i);
   });
 
-  it("fails loud when target asset has no recognised ems__* class", async () => {
+  // ───── Crash fix: non-built-in effort classes degrade gracefully ─────
+  // @req:7489624f-c17f-47dd-8108-3571a5809f61 — a generic status-transition
+  // button rendered on an effort-status-bearing asset whose class is NOT one of
+  // Task/Project/Meeting (UID-canon `"[[<uid>]]"`, no alias) must NOT crash with
+  // "no recognised ems__* class". When the class has no applicable workflow the
+  // dispatch is a graceful no-op (notApplicable), and when the class DOES have a
+  // workflow (per-asset override / per-class ABox) the transition works.
+
+  it("@req:7489624f graceful no-op (notApplicable) when class has no applicable workflow — no crash", async () => {
+    // resolveForAssetOrNull returns null → the class (e.g. ems__Action, ems__Idea,
+    // exo__Asset) has no status workflow. Must NOT surface the old fail-loud
+    // "no recognised ems__* class" error.
     const workflowResolver: WorkflowResolverPort = {
-      resolveForAsset: jest.fn(),
+      resolveForAssetOrNull: jest.fn().mockResolvedValue(null),
     };
     const { executor } = makeExecutor({
       content: `---\nexo__Instance_class:\n  - "[[some-random-uid]]"\nems__Effort_status: "[[${DOING_UID}]]"\n---\n`,
@@ -289,19 +308,63 @@ describe("GroundingExecutor.workflow_transition (RFC 36347daf Phase 2)", () => {
     });
 
     const result = await executor.execute(
-      makeGrounding("forward"),
+      makeGrounding("rollback"),
       TARGET_IRI,
       FILE_PATH,
     );
 
     expect(result.success).toBe(false);
-    expect(result.error).toMatch(/no recognised ems__\* class/i);
-    expect(workflowResolver.resolveForAsset).not.toHaveBeenCalled();
+    expect(result.notApplicable).toBe(true);
+    expect(result.error).not.toMatch(/no recognised ems__\* class/i);
+    expect(result.error).toMatch(/no status workflow/i);
+    // The resolver IS consulted (data-driven), not short-circuited.
+    expect(workflowResolver.resolveForAssetOrNull).toHaveBeenCalledTimes(1);
+  });
+
+  it("@req:7489624f data-driven transition works for a NON-built-in class with a workflow", async () => {
+    // A class outside Task/Project/Meeting (UID-canon form) whose asset has a
+    // declared workflow (e.g. via ems__Effort_workflow) resolves and transitions
+    // Doing→Backlog — proving the dispatch is no longer gated by a hardcoded
+    // 3-class map.
+    const transitions: WorkflowTransitionDefinition[] = [
+      {
+        from: EffortStatus.DOING,
+        to: EffortStatus.BACKLOG,
+        label: "← Backlog",
+        isRollback: true,
+      },
+    ];
+    const workflowResolver: WorkflowResolverPort = {
+      resolveForAssetOrNull: jest
+        .fn()
+        .mockResolvedValue(makeTaskWorkflow(transitions)),
+    };
+    const { executor, writer } = makeExecutor({
+      content: `---\nexo__Instance_class:\n  - "[[d4f1c0a2-0000-4000-a000-00000000bbbb]]"\nems__Effort_status: "[[${DOING_UID}]]"\n---\n`,
+      workflowResolver,
+    });
+
+    const result = await executor.execute(
+      makeGrounding("rollback"),
+      TARGET_IRI,
+      FILE_PATH,
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.notApplicable).toBeFalsy();
+    // Status mutated to Backlog (UID-canon wikilink) on disk.
+    expect(writer.updateFile).toHaveBeenCalled();
+    const written = (writer.updateFile as jest.Mock).mock.calls[0][1] as string;
+    expect(written).toContain(BACKLOG_UID);
   });
 
   it("fails loud when current status cannot be parsed", async () => {
+    // Workflow resolves (built-in Task) but the asset has no parseable status —
+    // this remains a hard, informative error (distinct from notApplicable).
     const workflowResolver: WorkflowResolverPort = {
-      resolveForAsset: jest.fn(),
+      resolveForAssetOrNull: jest
+        .fn()
+        .mockResolvedValue(makeTaskWorkflow([])),
     };
     const { executor } = makeExecutor({
       content: `---\nexo__Instance_class:\n  - "[[${TASK_UID}]]"\n# no status\n---\n`,
@@ -315,6 +378,7 @@ describe("GroundingExecutor.workflow_transition (RFC 36347daf Phase 2)", () => {
     );
 
     expect(result.success).toBe(false);
+    expect(result.notApplicable).toBeFalsy();
     expect(result.error).toMatch(/no parseable ems__Effort_status/i);
   });
 
@@ -328,7 +392,9 @@ describe("GroundingExecutor.workflow_transition (RFC 36347daf Phase 2)", () => {
       },
     ];
     const workflowResolver: WorkflowResolverPort = {
-      resolveForAsset: jest.fn().mockResolvedValue(makeTaskWorkflow(transitions)),
+      resolveForAssetOrNull: jest
+        .fn()
+        .mockResolvedValue(makeTaskWorkflow(transitions)),
     };
     const { executor } = makeExecutor({
       content: `---\nexo__Instance_class:\n  - "[[${TASK_UID}]]"\nems__Effort_status: "[[${DONE_UID}]]"\n---\n`,
@@ -356,7 +422,9 @@ describe("GroundingExecutor.workflow_transition (RFC 36347daf Phase 2)", () => {
       },
     ];
     const workflowResolver: WorkflowResolverPort = {
-      resolveForAsset: jest.fn().mockResolvedValue(makeTaskWorkflow(transitions)),
+      resolveForAssetOrNull: jest
+        .fn()
+        .mockResolvedValue(makeTaskWorkflow(transitions)),
     };
     const { executor } = makeExecutor({
       content: `---\nexo__Instance_class:\n  - "[[${TASK_UID}]]"\nems__Effort_status: "[[${DOING_UID}]]"\n---\n`,
@@ -385,7 +453,9 @@ describe("GroundingExecutor.workflow_transition (RFC 36347daf Phase 2)", () => {
       },
     ];
     const workflowResolver: WorkflowResolverPort = {
-      resolveForAsset: jest.fn().mockResolvedValue(makeTaskWorkflow(transitions)),
+      resolveForAssetOrNull: jest
+        .fn()
+        .mockResolvedValue(makeTaskWorkflow(transitions)),
     };
     const groundingLoader: GroundingLoaderPort = async () => null;
 
@@ -416,7 +486,9 @@ describe("GroundingExecutor.workflow_transition (RFC 36347daf Phase 2)", () => {
       },
     ];
     const workflowResolver: WorkflowResolverPort = {
-      resolveForAsset: jest.fn().mockResolvedValue(makeTaskWorkflow(transitions)),
+      resolveForAssetOrNull: jest
+        .fn()
+        .mockResolvedValue(makeTaskWorkflow(transitions)),
     };
     const groundingLoader: GroundingLoaderPort = async () => ({
       id: "pa-bad",

--- a/packages/core/tests/unit/services/WorkflowResolver.resolveForAssetOrNull.test.ts
+++ b/packages/core/tests/unit/services/WorkflowResolver.resolveForAssetOrNull.test.ts
@@ -1,0 +1,124 @@
+/**
+ * Data-driven workflow resolution for the `workflow_transition` grounding —
+ * fix for the "Rollback to Backlog crashes on non-Task/Project/Meeting effort
+ * classes" bug. Production-shape: a real {@link WorkflowResolver} over an
+ * {@link InMemoryTripleStore}, exercising the FULL `resolveForAssetOrNull`
+ * path (no mocks).
+ *
+ * @req:7489624f-c17f-47dd-8108-3571a5809f61
+ */
+import { InMemoryTripleStore } from "../../../src/infrastructure/rdf/InMemoryTripleStore";
+import { WorkflowResolver } from "../../../src/services/WorkflowResolver";
+import { Triple } from "../../../src/domain/models/rdf/Triple";
+import { IRI } from "../../../src/domain/models/rdf/IRI";
+import { Literal } from "../../../src/domain/models/rdf/Literal";
+import { Namespace } from "../../../src/domain/models/rdf/Namespace";
+import { AssetClass } from "../../../src/domain/constants/AssetClass";
+import { EffortStatus } from "../../../src/domain/constants/EffortStatus";
+
+const TASK_UID = "1b20a8f0-d745-4e93-91db-4531b3df120e";
+const BUG_UID = "d4f1c0a2-0000-4000-a000-00000000bbbb";
+const ACTION_UID = "a11c0000-0000-4000-a000-00000000aaaa";
+
+async function seedWorkflow(
+  store: InMemoryTripleStore,
+  wfUid: string,
+  targetClassLabel: string,
+): Promise<IRI> {
+  const wf = new IRI(`obsidian://vault/${wfUid}.md`);
+  const trans = new IRI(`obsidian://vault/${wfUid}-t1.md`);
+  await store.addAll([
+    new Triple(wf, Namespace.RDF.term("type"), Namespace.EMS.term("Workflow")),
+    new Triple(wf, Namespace.EXO.term("Asset_uid"), new Literal(wfUid)),
+    new Triple(wf, Namespace.EXO.term("Asset_label"), new Literal("Bug Workflow")),
+    new Triple(
+      wf,
+      Namespace.EMS.term("Workflow_targetClass"),
+      Namespace.EMS.term(targetClassLabel.replace("ems__", "")),
+    ),
+    new Triple(wf, Namespace.EMS.term("Workflow_isDefault"), new Literal("true")),
+    // one transition so loadWorkflowBySubject yields a non-null definition
+    new Triple(
+      trans,
+      Namespace.RDF.term("type"),
+      Namespace.EMS.term("WorkflowTransition"),
+    ),
+    new Triple(trans, Namespace.EMS.term("WorkflowTransition_workflow"), wf),
+    new Triple(
+      trans,
+      Namespace.EMS.term("WorkflowTransition_from"),
+      new Literal(EffortStatus.DOING),
+    ),
+    new Triple(
+      trans,
+      Namespace.EMS.term("WorkflowTransition_to"),
+      new Literal(EffortStatus.BACKLOG),
+    ),
+    new Triple(
+      trans,
+      Namespace.EMS.term("WorkflowTransition_isRollback"),
+      new Literal("true"),
+    ),
+  ]);
+  return wf;
+}
+
+describe("WorkflowResolver.resolveForAssetOrNull (data-driven, crash fix)", () => {
+  let store: InMemoryTripleStore;
+  let resolver: WorkflowResolver;
+  const asset = new IRI("obsidian://vault/some-asset.md");
+
+  beforeEach(() => {
+    store = new InMemoryTripleStore();
+    resolver = new WorkflowResolver(store);
+  });
+
+  it("returns the per-asset ems__Effort_workflow override for a NON-built-in class", async () => {
+    // A Bug asset (UID-canon class ref, NOT Task/Project/Meeting) with its own
+    // declared workflow resolves it — Homoiconicity: new class managed by vault
+    // data, no code change.
+    const wf = await seedWorkflow(store, "bug-wf-uid", "ems__Bug");
+    await store.add(
+      new Triple(asset, Namespace.EMS.term("Effort_workflow"), wf),
+    );
+
+    const result = await resolver.resolveForAssetOrNull(asset, `[[${BUG_UID}]]`);
+
+    expect(result).not.toBeNull();
+    expect(result?.transitions.some((t) => t.isRollback)).toBe(true);
+  });
+
+  it("returns null for a non-built-in class with NO workflow (e.g. ems__Action — own lifecycle)", async () => {
+    const result = await resolver.resolveForAssetOrNull(
+      asset,
+      `[[${ACTION_UID}|ems__Action]]`,
+    );
+    expect(result).toBeNull();
+  });
+
+  it("returns null for a bare unknown class ref with no workflow", async () => {
+    const result = await resolver.resolveForAssetOrNull(asset, "some-random-uid");
+    expect(result).toBeNull();
+  });
+
+  it("resolves the built-in Task default for a UID-canon Task class ref", async () => {
+    const result = await resolver.resolveForAssetOrNull(asset, `[[${TASK_UID}]]`);
+    expect(result).not.toBeNull();
+    expect(result?.targetClass).toBe(AssetClass.TASK);
+  });
+
+  it("resolves the built-in default for an alias-form Task class ref", async () => {
+    const result = await resolver.resolveForAssetOrNull(
+      asset,
+      `${TASK_UID}|ems__Task`,
+    );
+    expect(result).not.toBeNull();
+    expect(result?.targetClass).toBe(AssetClass.TASK);
+  });
+
+  it("resolves the built-in default for a bare-label Project class ref", async () => {
+    const result = await resolver.resolveForAssetOrNull(asset, "ems__Project");
+    expect(result).not.toBeNull();
+    expect(result?.targetClass).toBe(AssetClass.PROJECT);
+  });
+});

--- a/packages/core/tests/unit/services/WorkflowResolver.resolveForAssetOrNull.test.ts
+++ b/packages/core/tests/unit/services/WorkflowResolver.resolveForAssetOrNull.test.ts
@@ -82,7 +82,7 @@ describe("WorkflowResolver.resolveForAssetOrNull (data-driven, crash fix)", () =
       new Triple(asset, Namespace.EMS.term("Effort_workflow"), wf),
     );
 
-    const result = await resolver.resolveForAssetOrNull(asset, `[[${BUG_UID}]]`);
+    const result = await resolver.resolveForAssetOrNull(asset, [`[[${BUG_UID}]]`]);
 
     expect(result).not.toBeNull();
     expect(result?.transitions.some((t) => t.isRollback)).toBe(true);
@@ -91,18 +91,18 @@ describe("WorkflowResolver.resolveForAssetOrNull (data-driven, crash fix)", () =
   it("returns null for a non-built-in class with NO workflow (e.g. ems__Action — own lifecycle)", async () => {
     const result = await resolver.resolveForAssetOrNull(
       asset,
-      `[[${ACTION_UID}|ems__Action]]`,
+      [`[[${ACTION_UID}|ems__Action]]`],
     );
     expect(result).toBeNull();
   });
 
   it("returns null for a bare unknown class ref with no workflow", async () => {
-    const result = await resolver.resolveForAssetOrNull(asset, "some-random-uid");
+    const result = await resolver.resolveForAssetOrNull(asset, ["some-random-uid"]);
     expect(result).toBeNull();
   });
 
   it("resolves the built-in Task default for a UID-canon Task class ref", async () => {
-    const result = await resolver.resolveForAssetOrNull(asset, `[[${TASK_UID}]]`);
+    const result = await resolver.resolveForAssetOrNull(asset, [`[[${TASK_UID}]]`]);
     expect(result).not.toBeNull();
     expect(result?.targetClass).toBe(AssetClass.TASK);
   });
@@ -110,15 +110,27 @@ describe("WorkflowResolver.resolveForAssetOrNull (data-driven, crash fix)", () =
   it("resolves the built-in default for an alias-form Task class ref", async () => {
     const result = await resolver.resolveForAssetOrNull(
       asset,
-      `${TASK_UID}|ems__Task`,
+      [`${TASK_UID}|ems__Task`],
     );
     expect(result).not.toBeNull();
     expect(result?.targetClass).toBe(AssetClass.TASK);
   });
 
   it("resolves the built-in default for a bare-label Project class ref", async () => {
-    const result = await resolver.resolveForAssetOrNull(asset, "ems__Project");
+    const result = await resolver.resolveForAssetOrNull(asset, ["ems__Project"]);
     expect(result).not.toBeNull();
     expect(result?.targetClass).toBe(AssetClass.PROJECT);
+  });
+
+  it("resolves from a multi-valued exo__Instance_class where the built-in class is NOT first", async () => {
+    // A multi-class asset (e.g. a non-built-in class listed before ems__Task) with
+    // no per-asset override must still resolve the Task workflow — the resolver
+    // scans EVERY ref, not just the first.
+    const result = await resolver.resolveForAssetOrNull(asset, [
+      `[[${BUG_UID}]]`,
+      `[[${TASK_UID}]]`,
+    ]);
+    expect(result).not.toBeNull();
+    expect(result?.targetClass).toBe(AssetClass.TASK);
   });
 });


### PR DESCRIPTION
## Problem (reported by Andrey, 2026-06-29)

Clicking **"Rollback to Backlog"** on an in-Doing effort asset crashed:

```
Command failed: workflow_transition: target asset has no recognised ems__* class
in exo__Instance_class (cannot resolve workflow)
```

Generic status-transition buttons (Rollback / Start / Done) render on **any** asset
carrying `ems__Effort_status`, but `GroundingExecutor.executeWorkflowTransition`
resolved the target class through a **hardcoded 3-UID map** (`CLASS_UID_TO_LABEL` =
Task / Project / Meeting). Every other effort class — `ems__Action`, `ems__Bug`,
`ems__Idea`, `ems__OfflineMeeting`, `exo__Asset`, … — is stored in UID-canon
strip-form `"[[<uid>]]"` and is **not** in that map → `resolveAssetClassFromFrontmatter`
returned `null` → fail-loud "no recognised ems__* class".

## Fix — data-driven resolution + graceful degradation

- **`WorkflowResolver.resolveForAssetOrNull(subjectIRI, classRef)`** (new) resolves a
  workflow for **any** class ref, vault-data-driven (Homoiconicity Invariant):
  1. per-asset `ems__Effort_workflow` override (works for **any** class), then
  2. built-in Task/Project/Meeting class default (a vault `ems__Workflow` ABox with
     matching `Workflow_targetClass` overrides the hardcoded fallback when present),
  3. else `null` — the class has **no applicable status workflow**.
- **`executeWorkflowTransition`** now extracts the raw class ref (any class) and treats
  a `null` workflow as a **graceful no-op** (`ExecutionResult.notApplicable`), surfaced
  by `CommandExecutionFlow` as an **info** notice — not a "Command failed" error.
- `ems__Action` (own Create/Execute/Trash one-shot lifecycle) resolves to `null` → not
  given an Effort workflow.
- `CLASS_UID_TO_LABEL` extracted to `domain/constants/WorkflowClassUids.ts` (shared,
  re-exported from `GroundingExecutor` for back-compat) so the resolver reuses it
  without an import cycle.

**Result:** no status-transition button crashes on any effort class. Classes with a
workflow transition correctly (incl. non-built-in classes via `ems__Effort_workflow`);
classes without one degrade gracefully.

## req-first SDD

`@req:7489624f-c17f-47dd-8108-3571a5809f61` (proposed → active after merge).

**Revert-verified (unit):** reverting `executeWorkflowTransition` to the pre-fix
hardcoded 3-class gate makes the two `@req:7489624f` cases in
`GroundingExecutor.workflow_transition.test.ts` go **RED** (graceful case expected
`notApplicable`; non-built-in transition expected `success`); restored → **GREEN**.
Plus production-shape `WorkflowResolver.resolveForAssetOrNull.test.ts` (real
`InMemoryTripleStore`).

## Scope notes / follow-ups (out of scope here, Path B)

- The buttons still **render** on no-workflow classes (then no-op gracefully); hiding
  them via precondition gating is a follow-up.
- Per-class `ems__Workflow` ABox resolution for arbitrary non-built-in classes, and
  default workflows for Bug/Idea/OfflineMeeting if they should be status-managed.

## Verification

- core suite (changed dirs) green; root `check:types` 0; 3 lint guards OK;
  esbuild + mobile-loadable + console-channel OK.
