### PR TITLE
feat(core): create_instance cloneTargetBody + subclass workflow inheritance (@req:915b20b2, ems__WaitingCheckTask)

### DIFF
--- a/packages/core/src/domain/models/CommandDefinition.ts
+++ b/packages/core/src/domain/models/CommandDefinition.ts
@@ -256,6 +256,23 @@ export interface GroundingDefinition {
    * normalized to a bare UID by the parser).
    */
   readonly templateRef?: string;
+  /**
+   * `create_instance` grounding — when `true`, the new instance's markdown BODY
+   * is cloned from the click-target's ($target) body (frontmatter is NOT copied
+   * — only the body after the leading frontmatter block). Enables an
+   * "iterate this asset" button (e.g. `ems__WaitingCheckTask` «Следующая
+   * итерация», req 915b20b2) to carry the context notes forward across
+   * iterations without a template asset. Disjoint from `body_template`
+   * (which sources a template) and from the reserved `userInput.body`
+   * (which wins when both a non-empty user body and this flag are present).
+   * Domain-agnostic engine primitive — platform-agnostic (reads the target
+   * file via the injected reader; no Node fs), so it holds identically on
+   * desktop and mobile (Desktop↔Mobile Command Parity invariant).
+   *
+   * Authored as the `exocmd__Grounding_cloneTargetBody` RDF triple
+   * (xsd:boolean — `true`/`false`; absent → not cloned).
+   */
+  readonly cloneTargetBody?: boolean;
 }
 
 /**

--- a/packages/core/src/domain/models/GroundingFrontmatterParser.ts
+++ b/packages/core/src/domain/models/GroundingFrontmatterParser.ts
@@ -114,6 +114,13 @@ export function parseGroundingDefinitionFromFrontmatter(
     ? normalizeGroundingRef(rawTemplateRef)
     : undefined;
 
+  // `create_instance` target-body clone flag (req 915b20b2). Tolerates the
+  // YAML boolean `true` and the string literal `"true"` (vault serialisers may
+  // emit either); anything else → not cloned.
+  const rawCloneTargetBody = fm["exocmd__Grounding_cloneTargetBody"];
+  const cloneTargetBody =
+    rawCloneTargetBody === true || rawCloneTargetBody === "true";
+
   return {
     id: uid,
     label: (fm["exo__Asset_label"] as string) ?? "",
@@ -144,6 +151,7 @@ export function parseGroundingDefinitionFromFrontmatter(
       | undefined,
     bodyTemplate: fm["exocmd__Grounding_bodyTemplate"] as string | undefined,
     templateRef,
+    cloneTargetBody,
     steps,
   };
 }

--- a/packages/core/src/services/CommandResolver.ts
+++ b/packages/core/src/services/CommandResolver.ts
@@ -92,6 +92,11 @@ const SUBSTITUTION_TOKEN_CLASS_IRI =
 const KNOWN_SUBSTITUTION_RESOLVER_IDS: ReadonlySet<string> = new Set([
   // RFC v2 Phase 3a — bootstrap vocabulary
   "today",
+  // req 915b20b2 — `$tomorrow` (today + 1 day, YYYY-MM-DD) soft daily tickler
+  // for ems__WaitingCheckTask. The resolver exists in SubstitutionResolverRegistry
+  // (Веха 5) but was never whitelisted here (no vault token used it) — a
+  // parameterless SubstitutionToken referencing it fell back to wikilink form.
+  "tomorrow",
   "todayStart",
   "targetFolder",
   "target",
@@ -169,6 +174,9 @@ const UNIVERSAL_DEFAULT_TEMPLATE_CTX = "universal-default-template";
  */
 const PARSE_TIME_RESOLVERS: ReadonlySet<string> = new Set([
   "today",
+  // req 915b20b2 — `$tomorrow` is context-free (today + 1 day), baked at parse
+  // time exactly like `$today` (same session-cache semantics).
+  "tomorrow",
   "todayStart",
   "nowTimestamp",
   "nowDate",
@@ -1785,6 +1793,20 @@ export class CommandResolver {
       Namespace.EXOCMD.term("Grounding_templateRef"),
     );
 
+    // req 915b20b2 — create_instance target-body clone flag. Boolean coercion
+    // mirrors `prefillLabelWithDate` (tolerates `true` boolean or `"true"`
+    // literal). MUST be read HERE (the production loader) — the sibling
+    // GroundingFrontmatterParser has no production consumers (CLI BDD/tests
+    // only), so reading it there alone leaves the flag inert in every real
+    // apply (plugin button + CLI both go through CommandResolver.loadCommand).
+    const cloneTargetBodyRaw = await this.getLiteralValue(
+      subject,
+      Namespace.EXOCMD.term("Grounding_cloneTargetBody"),
+    );
+    const cloneTargetBody =
+      cloneTargetBodyRaw !== null &&
+      String(cloneTargetBodyRaw).trim().toLowerCase() === "true";
+
     const grounding: GroundingDefinition = {
       id: uid,
       label,
@@ -1812,6 +1834,7 @@ export class CommandResolver {
       direction,
       bodyTemplate: bodyTemplate ?? undefined,
       templateRef: templateRef ?? undefined,
+      cloneTargetBody: cloneTargetBody || undefined,
     };
 
     if (inputSchema) {
@@ -2394,6 +2417,13 @@ export class CommandResolver {
     switch (resolverId) {
       case "today":
         return d.toISOString().slice(0, 10);
+      case "tomorrow": {
+        // req 915b20b2 — today + 1 day, YYYY-MM-DD (UTC, consistent with the
+        // `today` case above). Matches the `$tomorrow` registry resolver shape.
+        const t = new Date(d);
+        t.setUTCDate(t.getUTCDate() + 1);
+        return t.toISOString().slice(0, 10);
+      }
       case "todayStart":
         return new Date(new Date().setHours(0, 0, 0, 0)).toISOString();
       case "nowTimestamp":

--- a/packages/core/src/services/GroundingExecutor.ts
+++ b/packages/core/src/services/GroundingExecutor.ts
@@ -977,6 +977,20 @@ export class GroundingExecutor {
     return `${fmMatch[0]}\n${body}`;
   }
 
+  /**
+   * req 915b20b2 — extract a markdown file's BODY (everything after the leading
+   * frontmatter block), the inverse of {@link replaceBody}. Strips the single
+   * newline that {@link replaceBody} inserts between the frontmatter fence and
+   * the body, so `extractBody(replaceBody(fm, body)) === body`. When the content
+   * has no leading frontmatter block, the whole content IS the body. Used by
+   * `create_instance` `cloneTargetBody` to carry the $target body forward.
+   */
+  private static extractBody(content: string): string {
+    const fmMatch = content.match(/^---\r?\n[\s\S]*?\r?\n---/);
+    if (!fmMatch) return content;
+    return content.slice(fmMatch[0].length).replace(/^\r?\n/, "");
+  }
+
   private async executeCreateInstance(
     grounding: GroundingDefinition,
     targetIRI: string,
@@ -994,6 +1008,10 @@ export class GroundingExecutor {
     // `grounding.inheritanceRule.length > 0` (RFC 32445c1c); now also needed
     // by Universal Default Template's `$target.property(isDefinedBy)` etc.
     let targetFm: Record<string, string | string[]> | null = null;
+    // req 915b20b2 — target BODY clone: captured from the same single read as
+    // targetFm when `cloneTargetBody` is set (empty string if the target has no
+    // body). `null` = not requested / not read.
+    let targetBody: string | null = null;
     const needsTargetRead =
       (grounding.inheritanceRule && grounding.inheritanceRule.length > 0) ||
       (grounding.propertyDefault &&
@@ -1005,7 +1023,9 @@ export class GroundingExecutor {
       // в frontmatter target'а для substituteVariables. Чисто `$nowCompact`
       // или `$today` не требуют target read, поэтому проверяем dotted-form.
       (grounding.labelTemplate !== undefined &&
-        /\$target\./.test(grounding.labelTemplate));
+        /\$target\./.test(grounding.labelTemplate)) ||
+      // req 915b20b2 — target body clone needs the target file content too.
+      grounding.cloneTargetBody === true;
     if (needsTargetRead && targetIRI && targetFilePath) {
       let targetContent: string;
       try {
@@ -1017,6 +1037,9 @@ export class GroundingExecutor {
         };
       }
       targetFm = this.frontmatterService.parseObject(targetContent) ?? null;
+      if (grounding.cloneTargetBody) {
+        targetBody = GroundingExecutor.extractBody(targetContent);
+      }
     }
 
     // RFC 727572d2 — Resolve grounding's targetClass to canonical UID once
@@ -1167,10 +1190,24 @@ export class GroundingExecutor {
     // uses — to splice the body after the just-built frontmatter. Absent/empty
     // → frontmatter-only content (current behavior; the plugin inline button
     // simply never passes `body`, so zero regression).
+    //
+    // req 915b20b2 — `cloneTargetBody`: when the grounding asks to clone the
+    // click-target's body AND no explicit non-empty `userInput.body` was passed,
+    // splice the captured `targetBody` (empty target body → frontmatter-only, no
+    // spurious content). Precedence: explicit userInput.body > cloned target
+    // body > empty. Frontmatter is never copied — only the markdown body.
     const rawBody = userInput?.body;
-    const finalContent =
+    const bodyToWrite =
       typeof rawBody === "string" && rawBody.length > 0
-        ? GroundingExecutor.replaceBody(content, rawBody)
+        ? rawBody
+        : grounding.cloneTargetBody &&
+            typeof targetBody === "string" &&
+            targetBody.length > 0
+          ? targetBody
+          : null;
+    const finalContent =
+      bodyToWrite !== null
+        ? GroundingExecutor.replaceBody(content, bodyToWrite)
         : content;
 
     await this.fileWriter.createFile(filePath, finalContent);

--- a/packages/core/src/services/GroundingExecutor.ts
+++ b/packages/core/src/services/GroundingExecutor.ts
@@ -984,6 +984,13 @@ export class GroundingExecutor {
    * the body, so `extractBody(replaceBody(fm, body)) === body`. When the content
    * has no leading frontmatter block, the whole content IS the body. Used by
    * `create_instance` `cloneTargetBody` to carry the $target body forward.
+   *
+   * NOTE (symmetric to {@link replaceBody}): an EMPTY frontmatter (`---\n---`)
+   * has no line between the fences, so the regex treats it as "no frontmatter"
+   * and the whole content is returned as the body. This never affects the
+   * cloneTargetBody path in practice: a real $target always carries non-empty
+   * frontmatter (uid/label/instance_class), so its fence is matched and only the
+   * true body is extracted.
    */
   private static extractBody(content: string): string {
     const fmMatch = content.match(/^---\r?\n[\s\S]*?\r?\n---/);

--- a/packages/core/src/services/WorkflowResolver.ts
+++ b/packages/core/src/services/WorkflowResolver.ts
@@ -16,6 +16,7 @@ import {
   TASK_DEFAULT_WORKFLOW,
 } from "../domain/defaults/DefaultWorkflows";
 import { CLASS_UID_TO_LABEL } from "../domain/constants/WorkflowClassUids";
+import { iriToObsidianName } from "../utilities/iriToObsidianName";
 
 /**
  * Resolves WorkflowDefinitions from vault assets stored in an ITripleStore.
@@ -30,6 +31,10 @@ import { CLASS_UID_TO_LABEL } from "../domain/constants/WorkflowClassUids";
 @injectable()
 export class WorkflowResolver {
   private readonly cache = new Map<string, WorkflowDefinition>();
+
+  /** req 915b20b2 — bound on the subclass-workflow ancestry BFS (cycle guard +
+   * pathological-depth backstop). Real class chains are ≤ ~4 deep. */
+  private static readonly MAX_HIERARCHY_DEPTH = 16;
 
   constructor(private readonly tripleStore: ITripleStore) {}
 
@@ -128,6 +133,17 @@ export class WorkflowResolver {
       }
     }
 
+    // 2.5. Subclass inheritance (req 915b20b2) — a class that is a transitive
+    //   subClass (via `exo__Class_superClass`) of a built-in Task/Project/Meeting
+    //   inherits that built-in's workflow. This makes the standard status
+    //   buttons (start-effort / mark-done / move-to-backlog `workflow_transition`
+    //   groundings) work on ANY Task subclass — e.g. `ems__WaitingCheckTask` —
+    //   which previously resolved `null` (only the exact built-in three matched)
+    //   and silently no-op'd. Data-driven walk over the vault class hierarchy;
+    //   degrades to `null` (benign) on any resolution failure.
+    const inherited = await this.findBuiltInWorkflowByAncestry(classRefs);
+    if (inherited) return inherited;
+
     // 3. No applicable workflow — benign, NOT an error.
     return null;
   }
@@ -157,6 +173,144 @@ export class WorkflowResolver {
     if (uuidMatch) {
       const label = CLASS_UID_TO_LABEL[uuidMatch[1].toLowerCase()];
       if (label && BUILT_IN.has(label)) return label as AssetClass;
+    }
+    return null;
+  }
+
+  /**
+   * req 915b20b2 — resolve the built-in workflow inherited by a class that is a
+   * transitive subClass (via `exo__Class_superClass`) of Task/Project/Meeting.
+   *
+   * BFS over the vault class hierarchy from each declared class ref. At each
+   * `exo__Class_superClass` parent, {@link iriToObsidianName} maps the parent
+   * IRI — symbolic (`https://exocortex.my/ontology/ems#Task`) OR class-file
+   * (`obsidian://vault/.../<uid>.md`) — to the `ems__Task` / `<uid>` form
+   * {@link classRefToBuiltInClass} understands. A parent that IS built-in wins
+   * immediately; otherwise the parent is mapped back to its class-file IRI (the
+   * BFS-walkable subject form — symbolic IRIs are not themselves subjects of
+   * `exo__Class_superClass` triples) and enqueued. Cycle-safe (visited Set on
+   * file IRIs), depth-bounded, and consumes only the triple store. Returns
+   * `null` (benign) when no built-in ancestor exists or any lookup fails.
+   */
+  private async findBuiltInWorkflowByAncestry(
+    classRefs: readonly string[],
+  ): Promise<WorkflowDefinition | null> {
+    try {
+      const visited = new Set<string>();
+      let frontier: IRI[] = [];
+      for (const ref of classRefs) {
+        const fileIRI = await this.resolveClassFileIRI(ref);
+        if (fileIRI) frontier.push(fileIRI);
+      }
+      let depth = 0;
+      while (frontier.length > 0 && depth < WorkflowResolver.MAX_HIERARCHY_DEPTH) {
+        const next: IRI[] = [];
+        for (const fileIRI of frontier) {
+          if (visited.has(fileIRI.value)) continue;
+          visited.add(fileIRI.value);
+          const parentTriples = await this.tripleStore.match(
+            fileIRI,
+            Namespace.EXO.term("Class_superClass"),
+            undefined,
+          );
+          for (const triple of parentTriples) {
+            const obj = triple.object;
+            if (!(obj instanceof IRI)) continue;
+            const parentName = iriToObsidianName(obj.value);
+            if (parentName) {
+              const builtIn = this.classRefToBuiltInClass(parentName);
+              if (builtIn !== null) return this.resolveForClass(builtIn);
+            }
+            // Map the parent to its class-file IRI subject to walk further up.
+            const parentFileIRI = obj.value.startsWith("obsidian://vault/")
+              ? obj
+              : parentName
+                ? await this.resolveClassFileIRI(parentName)
+                : null;
+            if (parentFileIRI && !visited.has(parentFileIRI.value)) {
+              next.push(parentFileIRI);
+            }
+          }
+        }
+        frontier = next;
+        depth++;
+      }
+      return null;
+    } catch {
+      // Benign: any resolution failure degrades to "no subclass workflow".
+      return null;
+    }
+  }
+
+  /**
+   * req 915b20b2 — resolve a class ref (`"[[<uid>]]"`, `"<uid>"`,
+   * `"<uid>|<label>"`, or bare `"<label>"`) to the class-file IRI subject under
+   * which its `exo__Class_superClass` triples are stored. `null` when unknown.
+   */
+  private async resolveClassFileIRI(classRef: string): Promise<IRI | null> {
+    const norm = this.normalizeWikilink(classRef);
+    const uuidMatch = norm.match(
+      /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/i,
+    );
+    if (uuidMatch) return this.findSubjectByUID(uuidMatch[0]);
+    const bare = norm.includes("|")
+      ? (norm.split("|").pop() ?? "").trim()
+      : norm.trim();
+    if (!bare) return null;
+    const uid = await this.findUidByLabel(bare);
+    if (!uid) return null;
+    return this.findSubjectByUID(uid);
+  }
+
+  /**
+   * req 915b20b2 — find the subject IRI of the asset whose `exo__Asset_uid`
+   * equals `uid`. Prefers the optional optimized UUID index; falls back to a
+   * literal scan. Mirrors {@link CommandResolver}'s resolver (self-contained
+   * here to keep WorkflowResolver dependency-free).
+   */
+  private async findSubjectByUID(uid: string): Promise<IRI | null> {
+    if (this.tripleStore.findSubjectsByUUID) {
+      const subjects = await this.tripleStore.findSubjectsByUUID(uid);
+      if (subjects.length > 0) return subjects[0] as IRI;
+    }
+    const uidTriples = await this.tripleStore.match(
+      undefined,
+      Namespace.EXO.term("Asset_uid"),
+      undefined,
+    );
+    for (const triple of uidTriples) {
+      if (triple.object instanceof Literal && triple.object.value === uid) {
+        return triple.subject as IRI;
+      }
+    }
+    return null;
+  }
+
+  /**
+   * req 915b20b2 — resolve a class label (`ems__WaitingCheckTask`) to the
+   * `exo__Asset_uid` of the asset that carries it. `null` when unknown.
+   */
+  private async findUidByLabel(label: string): Promise<string | null> {
+    const labelTriples = await this.tripleStore.match(
+      undefined,
+      Namespace.EXO.term("Asset_label"),
+      undefined,
+    );
+    for (const triple of labelTriples) {
+      if (
+        triple.object instanceof Literal &&
+        triple.object.value === label &&
+        triple.subject instanceof IRI
+      ) {
+        const uidTriples = await this.tripleStore.match(
+          triple.subject,
+          Namespace.EXO.term("Asset_uid"),
+          undefined,
+        );
+        if (uidTriples.length > 0 && uidTriples[0].object instanceof Literal) {
+          return uidTriples[0].object.value;
+        }
+      }
     }
     return null;
   }

--- a/packages/core/src/services/WorkflowResolver.ts
+++ b/packages/core/src/services/WorkflowResolver.ts
@@ -17,6 +17,7 @@ import {
 } from "../domain/defaults/DefaultWorkflows";
 import { CLASS_UID_TO_LABEL } from "../domain/constants/WorkflowClassUids";
 import { iriToObsidianName } from "../utilities/iriToObsidianName";
+import { LoggingService } from "./LoggingService";
 
 /**
  * Resolves WorkflowDefinitions from vault assets stored in an ITripleStore.
@@ -35,6 +36,11 @@ export class WorkflowResolver {
   /** req 915b20b2 — bound on the subclass-workflow ancestry BFS (cycle guard +
    * pathological-depth backstop). Real class chains are ≤ ~4 deep. */
   private static readonly MAX_HIERARCHY_DEPTH = 16;
+
+  /** req 915b20b2 — memoise the subclass-workflow ancestry walk (positive AND
+   * negative results) so a repeated `resolveForAssetOrNull` on the same class
+   * set skips the triple-store BFS. Cleared by {@link invalidateCache}. */
+  private readonly ancestryCache = new Map<string, WorkflowDefinition | null>();
 
   constructor(private readonly tripleStore: ITripleStore) {}
 
@@ -195,51 +201,71 @@ export class WorkflowResolver {
   private async findBuiltInWorkflowByAncestry(
     classRefs: readonly string[],
   ): Promise<WorkflowDefinition | null> {
+    const cacheKey = `ancestry:${[...classRefs].sort().join(" ")}`;
+    const cached = this.ancestryCache.get(cacheKey);
+    if (cached !== undefined) return cached; // memoised positive OR negative
+    let result: WorkflowDefinition | null = null;
     try {
-      const visited = new Set<string>();
-      let frontier: IRI[] = [];
-      for (const ref of classRefs) {
-        const fileIRI = await this.resolveClassFileIRI(ref);
-        if (fileIRI) frontier.push(fileIRI);
-      }
-      let depth = 0;
-      while (frontier.length > 0 && depth < WorkflowResolver.MAX_HIERARCHY_DEPTH) {
-        const next: IRI[] = [];
-        for (const fileIRI of frontier) {
-          if (visited.has(fileIRI.value)) continue;
-          visited.add(fileIRI.value);
-          const parentTriples = await this.tripleStore.match(
-            fileIRI,
-            Namespace.EXO.term("Class_superClass"),
-            undefined,
-          );
-          for (const triple of parentTriples) {
-            const obj = triple.object;
-            if (!(obj instanceof IRI)) continue;
-            const parentName = iriToObsidianName(obj.value);
-            if (parentName) {
-              const builtIn = this.classRefToBuiltInClass(parentName);
-              if (builtIn !== null) return this.resolveForClass(builtIn);
-            }
-            // Map the parent to its class-file IRI subject to walk further up.
-            const parentFileIRI = obj.value.startsWith("obsidian://vault/")
-              ? obj
-              : parentName
-                ? await this.resolveClassFileIRI(parentName)
-                : null;
-            if (parentFileIRI && !visited.has(parentFileIRI.value)) {
-              next.push(parentFileIRI);
-            }
+      result = await this.walkAncestryForBuiltIn(classRefs);
+    } catch (error) {
+      // Benign: any resolution failure degrades to "no subclass workflow", but
+      // log it so a genuinely broken hierarchy is not silently swallowed.
+      LoggingService.warn(
+        `[WorkflowResolver] subclass-workflow ancestry walk failed for [${classRefs.join(", ")}] — treating as no workflow: ${error instanceof Error ? error.message : String(error)}`,
+      );
+      result = null;
+    }
+    this.ancestryCache.set(cacheKey, result);
+    return result;
+  }
+
+  /**
+   * req 915b20b2 — the uncached BFS core of {@link findBuiltInWorkflowByAncestry}.
+   * Returns the first built-in ancestor's workflow, or `null` when none.
+   */
+  private async walkAncestryForBuiltIn(
+    classRefs: readonly string[],
+  ): Promise<WorkflowDefinition | null> {
+    const visited = new Set<string>();
+    let frontier: IRI[] = [];
+    for (const ref of classRefs) {
+      const fileIRI = await this.resolveClassFileIRI(ref);
+      if (fileIRI) frontier.push(fileIRI);
+    }
+    let depth = 0;
+    while (frontier.length > 0 && depth < WorkflowResolver.MAX_HIERARCHY_DEPTH) {
+      const next: IRI[] = [];
+      for (const fileIRI of frontier) {
+        if (visited.has(fileIRI.value)) continue;
+        visited.add(fileIRI.value);
+        const parentTriples = await this.tripleStore.match(
+          fileIRI,
+          Namespace.EXO.term("Class_superClass"),
+          undefined,
+        );
+        for (const triple of parentTriples) {
+          const obj = triple.object;
+          if (!(obj instanceof IRI)) continue;
+          const parentName = iriToObsidianName(obj.value);
+          if (parentName) {
+            const builtIn = this.classRefToBuiltInClass(parentName);
+            if (builtIn !== null) return this.resolveForClass(builtIn);
+          }
+          // Map the parent to its class-file IRI subject to walk further up.
+          const parentFileIRI = obj.value.startsWith("obsidian://vault/")
+            ? obj
+            : parentName
+              ? await this.resolveClassFileIRI(parentName)
+              : null;
+          if (parentFileIRI && !visited.has(parentFileIRI.value)) {
+            next.push(parentFileIRI);
           }
         }
-        frontier = next;
-        depth++;
       }
-      return null;
-    } catch {
-      // Benign: any resolution failure degrades to "no subclass workflow".
-      return null;
+      frontier = next;
+      depth++;
     }
+    return null;
   }
 
   /**
@@ -321,6 +347,7 @@ export class WorkflowResolver {
    */
   invalidateCache(): void {
     this.cache.clear();
+    this.ancestryCache.clear();
   }
 
   /**

--- a/packages/core/tests/integration/asset-creation/create-instance-clone-target-body.test.ts
+++ b/packages/core/tests/integration/asset-creation/create-instance-clone-target-body.test.ts
@@ -1,0 +1,201 @@
+/**
+ * Integration test: create_instance `cloneTargetBody` (req 915b20b2 —
+ * ems__WaitingCheckTask «Следующая итерация»).
+ *
+ * When a `create_instance` grounding sets `cloneTargetBody: true`, the new
+ * instance's markdown BODY is cloned from the click-target ($target) body
+ * (frontmatter is NOT copied — only the body). This carries the waiting-check's
+ * context notes forward across iterations without a template asset. Precedence:
+ * explicit non-empty `userInput.body` > cloned target body > empty.
+ *
+ * Exercises the real `create_instance` pipeline through GroundingExecutor with
+ * an in-memory file system (no mock of the executor logic). Mirrors the harness
+ * of `create-instance-body.test.ts`.
+ *
+ * Revert-verify ([[integration-test-revert-verify]]): with the `cloneTargetBody`
+ * handling neutralised, AC#1 ("new body == target body") goes RED; restored →
+ * GREEN. The "empty target body → empty new body" scenario stays GREEN both
+ * ways (intended no-op guard against spurious body writes).
+ *
+ * @req:915b20b2-e0d7-4198-80c0-5561293149f0
+ */
+
+import "reflect-metadata";
+import {
+  GroundingExecutor,
+  ServiceRegistry,
+} from "../../../src/services/GroundingExecutor";
+import { GroundingType } from "../../../src/domain/constants/GroundingType";
+import { GroundingDefinition } from "../../../src/domain/models/CommandDefinition";
+import {
+  IFileSystemReader,
+  IFileSystemWriter,
+} from "../../../src/interfaces/IFileSystemAdapter";
+
+// ---------------------------------------------------------------------------
+// In-memory file system (shared between GroundingExecutor reads + writes)
+// ---------------------------------------------------------------------------
+
+class InMemoryFileSystem implements IFileSystemReader, IFileSystemWriter {
+  private files = new Map<string, string>();
+
+  async readFile(path: string): Promise<string> {
+    const content = this.files.get(path);
+    if (content === undefined) throw new Error(`File not found: ${path}`);
+    return content;
+  }
+  async fileExists(path: string): Promise<boolean> {
+    return this.files.has(path);
+  }
+  async getMarkdownFiles(): Promise<string[]> {
+    return Array.from(this.files.keys()).filter((p) => p.endsWith(".md"));
+  }
+  async createFile(path: string, content: string): Promise<string> {
+    this.files.set(path, content);
+    return path;
+  }
+  async updateFile(path: string, content: string): Promise<void> {
+    this.files.set(path, content);
+  }
+  async writeFile(path: string, content: string): Promise<void> {
+    this.files.set(path, content);
+  }
+  async deleteFile(path: string): Promise<void> {
+    this.files.delete(path);
+  }
+  async renameFile(oldPath: string, newPath: string): Promise<void> {
+    const content = this.files.get(oldPath);
+    if (content !== undefined) {
+      this.files.set(newPath, content);
+      this.files.delete(oldPath);
+    }
+  }
+  getContent(path: string): string | undefined {
+    return this.files.get(path);
+  }
+  getAllPaths(): string[] {
+    return Array.from(this.files.keys());
+  }
+}
+
+function splitFrontmatterAndBody(content: string): { fm: string; body: string } {
+  const match = content.match(/^---\r?\n[\s\S]*?\r?\n---/);
+  if (!match) return { fm: "", body: content };
+  const fm = match[0];
+  const body = content.slice(fm.length).replace(/^\r?\n/, "");
+  return { fm, body };
+}
+
+// The click-target: an existing ems__WaitingCheckTask with a real body + the
+// clonable fields. Mirrors the shape the «Следующая итерация» button operates on.
+const TARGET_PATH = "/vault/current-check.md";
+const TARGET_BODY = [
+  "We are waiting for the consultant's reply on the residence permit.",
+  "",
+  "- asked on 2026-06-30",
+  "- context: [[89a48f55-adc9-4c1a-8a37-e94a4c9d1d66|Сделать ВНЖ]]",
+].join("\n");
+const TARGET_CONTENT = [
+  "---",
+  'exo__Asset_uid: "current-check-uid"',
+  'exo__Asset_label: "Проверить ответ консультанта по ВНЖ"',
+  "exo__Instance_class:",
+  '  - "[[915bc0de-0000-4000-a000-00000000c0de]]"',
+  'ems__Effort_parent: "[[89a48f55-adc9-4c1a-8a37-e94a4c9d1d66]]"',
+  'ems__Effort_status: "[[753a44d5-846c-4b82-9196-4fd9a4d48777]]"',
+  "---",
+  TARGET_BODY,
+].join("\n");
+
+const NEXT_ITERATION: GroundingDefinition = {
+  id: "gnd-next-iteration-clone",
+  label: "Следующая итерация",
+  type: GroundingType.CREATE_INSTANCE,
+  targetClass: "ems__WaitingCheckTask",
+  targetFolder: "01 Inbox",
+  labelTemplate: "$target.exo__Asset_label",
+  cloneTargetBody: true,
+  inheritanceRule: [
+    {
+      sourcePropertyName: "ems__Effort_parent",
+      targetPropertyName: "ems__Effort_parent",
+      targetClassExclusion: [],
+      priority: 50,
+    },
+  ],
+};
+
+describe("Integration: create_instance cloneTargetBody (req 915b20b2)", () => {
+  let fs: InMemoryFileSystem;
+  let executor: GroundingExecutor;
+
+  beforeEach(async () => {
+    fs = new InMemoryFileSystem();
+    await fs.createFile(TARGET_PATH, TARGET_CONTENT);
+    executor = new GroundingExecutor(fs, fs, new ServiceRegistry());
+  });
+
+  function createdContent(): string {
+    const path = fs.getAllPaths().find((p) => p !== TARGET_PATH);
+    if (!path) throw new Error("No created file");
+    return fs.getContent(path)!;
+  }
+
+  // AC#1 — the new iteration's body is the CLONED target body (verbatim).
+  it("clones the target's markdown body into the new instance (no userInput.body)", async () => {
+    const result = await executor.execute(
+      NEXT_ITERATION,
+      "https://exocortex.my/assets/current-check",
+      TARGET_PATH,
+      undefined, // one-click flow — no modal input
+    );
+    expect(result.success).toBe(true);
+
+    const content = createdContent();
+    const { fm, body } = splitFrontmatterAndBody(content);
+
+    // Body cloned verbatim (wikilinks + list intact).
+    expect(body).toBe(TARGET_BODY);
+    // Label cloned via labelTemplate; parent cloned via InheritanceRule.
+    expect(fm).toContain("Проверить ответ консультанта по ВНЖ");
+    expect(fm).toContain("ems__Effort_parent");
+    expect(fm).toContain("89a48f55-adc9-4c1a-8a37-e94a4c9d1d66");
+    // The body is NOT leaked into frontmatter (frontmatter is not copied blob).
+    expect(fm).not.toContain("We are waiting for the consultant");
+    expect(content).not.toContain("\nbody:");
+  });
+
+  // AC#2 — no-op guard: an EMPTY target body → empty new body (GREEN both ways).
+  it("writes an empty body when the target body is empty (no spurious content)", async () => {
+    const EMPTY_BODY_TARGET = "/vault/empty-check.md";
+    await fs.createFile(
+      EMPTY_BODY_TARGET,
+      ["---", 'exo__Asset_uid: "empty-check-uid"', 'exo__Asset_label: "Empty check"', 'exo__Instance_class:', '  - "[[915bc0de-0000-4000-a000-00000000c0de]]"', "---", ""].join("\n"),
+    );
+    const result = await executor.execute(
+      NEXT_ITERATION,
+      "https://exocortex.my/assets/empty-check",
+      EMPTY_BODY_TARGET,
+      undefined,
+    );
+    expect(result.success).toBe(true);
+    const path = fs
+      .getAllPaths()
+      .find((p) => p !== TARGET_PATH && p !== EMPTY_BODY_TARGET);
+    const { body } = splitFrontmatterAndBody(fs.getContent(path!)!);
+    expect(body).toBe("");
+  });
+
+  // AC#3 — precedence: an explicit non-empty userInput.body wins over the clone.
+  it("prefers an explicit non-empty userInput.body over the cloned target body", async () => {
+    await executor.execute(
+      NEXT_ITERATION,
+      "https://exocortex.my/assets/current-check",
+      TARGET_PATH,
+      { body: "explicit override body" },
+    );
+    const { body } = splitFrontmatterAndBody(createdContent());
+    expect(body).toBe("explicit override body");
+    expect(body).not.toContain("We are waiting");
+  });
+});

--- a/packages/core/tests/unit/services/CommandResolver.waitingCheckLoader.test.ts
+++ b/packages/core/tests/unit/services/CommandResolver.waitingCheckLoader.test.ts
@@ -1,0 +1,185 @@
+/**
+ * CommandResolver loader-stage coverage for the ems__WaitingCheckTask feature
+ * (req 915b20b2). Production-shape: the grounding is loaded FROM the triple
+ * store via `CommandResolver.loadCommand` (the real plugin + CLI loader path),
+ * NOT a hand-injected GroundingDefinition — so it catches the two multi-parser
+ * loader gaps a hand-injected fixture masks:
+ *
+ *  1. `exocmd__Grounding_cloneTargetBody` — read by GroundingFrontmatterParser
+ *     (CLI-BDD/tests only) but NOT by the production loader
+ *     `loadGroundingDefinition` → the body clone was inert in every real apply.
+ *  2. `$tomorrow` SubstitutionToken — the `tomorrow` resolver exists in
+ *     SubstitutionResolverRegistry but was absent from CommandResolver's
+ *     KNOWN_SUBSTITUTION_RESOLVER_IDS + PARSE_TIME_RESOLVERS whitelists → a
+ *     parameterless `$tomorrow` PD value fell back to `"[[<uid>]]"` wikilink
+ *     form instead of resolving to a date.
+ *
+ * Revert-verify ([[integration-test-revert-verify]]): reverting the loader read
+ * of `Grounding_cloneTargetBody` makes AC#1 RED; removing `"tomorrow"` from the
+ * whitelists makes AC#2 RED. Restored → GREEN.
+ *
+ * @req:915b20b2-e0d7-4198-80c0-5561293149f0
+ */
+import { CommandResolver } from "../../../src/services/CommandResolver";
+import { InMemoryTripleStore } from "../../../src/infrastructure/rdf/InMemoryTripleStore";
+import { Triple } from "../../../src/domain/models/rdf/Triple";
+import { IRI } from "../../../src/domain/models/rdf/IRI";
+import { Literal } from "../../../src/domain/models/rdf/Literal";
+import { Namespace } from "../../../src/domain/models/rdf/Namespace";
+
+const CREATE_INSTANCE_TYPE_UID = "4367e2d6-6c92-450a-becb-abce1fb07682";
+
+const PROP_PLANNED_UID = "7f773e3e-54d0-426b-98c5-5b75d01695cb"; // ems__Effort_plannedStartTimestamp
+const TOKEN_TOMORROW_UID = "d8d07c5b-3e73-4c9a-aa11-471263d527ae"; // $tomorrow
+const PD_PLANNED_UID = "aac7c7cd-8b70-4562-9290-d870f3e28551";
+const GROUNDING_UID = "af871e36-b8be-45b3-b80b-3a57c1d21c41";
+const COMMAND_UID = "0f8393bc-5ae7-4041-a10f-8651e407345e";
+
+function iri(uid: string): IRI {
+  return new IRI(`obsidian://vault/${uid}.md`);
+}
+
+async function addLabelled(
+  store: InMemoryTripleStore,
+  uid: string,
+  label: string,
+): Promise<void> {
+  await store.addAll([
+    new Triple(iri(uid), Namespace.EXO.term("Asset_uid"), new Literal(uid)),
+    new Triple(iri(uid), Namespace.EXO.term("Asset_label"), new Literal(label)),
+  ]);
+}
+
+async function addCommand(store: InMemoryTripleStore): Promise<void> {
+  await store.addAll([
+    new Triple(iri(COMMAND_UID), Namespace.RDF.term("type"), Namespace.EXOCMD.term("Command")),
+    new Triple(iri(COMMAND_UID), Namespace.EXO.term("Asset_uid"), new Literal(COMMAND_UID)),
+    new Triple(iri(COMMAND_UID), Namespace.EXO.term("Asset_label"), new Literal("Следующая итерация")),
+    new Triple(
+      iri(COMMAND_UID),
+      Namespace.EXOCMD.term("Command_grounding"),
+      iri(GROUNDING_UID),
+    ),
+  ]);
+}
+
+/** create_instance grounding; `cloneTargetBody`/`propertyDefault` are optional. */
+async function addGrounding(
+  store: InMemoryTripleStore,
+  opts: { cloneTargetBody?: boolean; propertyDefaultRefs?: string[] },
+): Promise<void> {
+  const triples: Triple[] = [
+    new Triple(iri(GROUNDING_UID), Namespace.RDF.term("type"), Namespace.EXOCMD.term("Grounding")),
+    new Triple(iri(GROUNDING_UID), Namespace.EXO.term("Asset_uid"), new Literal(GROUNDING_UID)),
+    new Triple(iri(GROUNDING_UID), Namespace.EXO.term("Asset_label"), new Literal("Create next iteration")),
+    new Triple(
+      iri(GROUNDING_UID),
+      Namespace.EXOCMD.term("Grounding_type"),
+      new Literal(`[[${CREATE_INSTANCE_TYPE_UID}]]`),
+    ),
+    new Triple(
+      iri(GROUNDING_UID),
+      Namespace.EXOCMD.term("Grounding_targetClass"),
+      new Literal("ems__WaitingCheckTask"),
+    ),
+    new Triple(
+      iri(GROUNDING_UID),
+      Namespace.EXOCMD.term("Grounding_targetFolder"),
+      new Literal("$targetFolder"),
+    ),
+  ];
+  if (opts.cloneTargetBody !== undefined) {
+    triples.push(
+      new Triple(
+        iri(GROUNDING_UID),
+        Namespace.EXOCMD.term("Grounding_cloneTargetBody"),
+        new Literal(String(opts.cloneTargetBody)),
+      ),
+    );
+  }
+  for (const ref of opts.propertyDefaultRefs ?? []) {
+    triples.push(
+      new Triple(
+        iri(GROUNDING_UID),
+        Namespace.EXOCMD.term("Grounding_propertyDefault"),
+        iri(ref),
+      ),
+    );
+  }
+  await store.addAll(triples);
+}
+
+describe("CommandResolver — ems__WaitingCheckTask loader stage (req 915b20b2)", () => {
+  let store: InMemoryTripleStore;
+  let resolver: CommandResolver;
+
+  beforeEach(() => {
+    store = new InMemoryTripleStore();
+    resolver = new CommandResolver(store);
+  });
+
+  // AC#1 (HIGH#1) — the production loader reads Grounding_cloneTargetBody.
+  it("loads cloneTargetBody=true from the Grounding_cloneTargetBody predicate", async () => {
+    await addGrounding(store, { cloneTargetBody: true });
+    await addCommand(store);
+
+    const cmd = await resolver.loadCommand(COMMAND_UID);
+
+    expect(cmd).not.toBeNull();
+    expect(cmd!.grounding.cloneTargetBody).toBe(true);
+  });
+
+  // AC#1 control — absent predicate → undefined (backward-compat, no clone).
+  it("leaves cloneTargetBody undefined when the predicate is absent", async () => {
+    await addGrounding(store, {});
+    await addCommand(store);
+
+    const cmd = await resolver.loadCommand(COMMAND_UID);
+
+    expect(cmd).not.toBeNull();
+    expect(cmd!.grounding.cloneTargetBody).toBeUndefined();
+  });
+
+  // AC#2 (CODE#3) — a $tomorrow SubstitutionToken PD resolves to a date, not a
+  // wikilink fallback.
+  it("resolves a $tomorrow SubstitutionToken PropertyDefault to tomorrow's YYYY-MM-DD (not a wikilink)", async () => {
+    await addLabelled(store, PROP_PLANNED_UID, "ems__Effort_plannedStartTimestamp");
+    await store.addAll([
+      new Triple(iri(TOKEN_TOMORROW_UID), Namespace.EXO.term("Asset_uid"), new Literal(TOKEN_TOMORROW_UID)),
+      new Triple(iri(TOKEN_TOMORROW_UID), Namespace.EXO.term("Asset_label"), new Literal("$tomorrow")),
+      new Triple(
+        iri(TOKEN_TOMORROW_UID),
+        Namespace.EXO.term("Instance_class"),
+        Namespace.EXOCMD.term("SubstitutionToken"),
+      ),
+      new Triple(
+        iri(TOKEN_TOMORROW_UID),
+        Namespace.EXOCMD.term("SubstitutionToken_resolver"),
+        new Literal("tomorrow"),
+      ),
+    ]);
+    await store.addAll([
+      new Triple(iri(PD_PLANNED_UID), Namespace.RDF.term("type"), Namespace.EXOCMD.term("PropertyDefault")),
+      new Triple(iri(PD_PLANNED_UID), Namespace.EXO.term("Asset_uid"), new Literal(PD_PLANNED_UID)),
+      new Triple(iri(PD_PLANNED_UID), Namespace.EXOCMD.term("PropertyDefault_property"), iri(PROP_PLANNED_UID)),
+      new Triple(iri(PD_PLANNED_UID), Namespace.EXOCMD.term("PropertyDefault_value"), iri(TOKEN_TOMORROW_UID)),
+    ]);
+    await addGrounding(store, { cloneTargetBody: true, propertyDefaultRefs: [PD_PLANNED_UID] });
+    await addCommand(store);
+
+    const cmd = await resolver.loadCommand(COMMAND_UID);
+
+    expect(cmd).not.toBeNull();
+    expect(cmd!.grounding.propertyDefault).toHaveLength(1);
+    const value = cmd!.grounding.propertyDefault![0].value;
+    // Resolved to a bare date (not the `"[[<uid>]]"` wikilink fallback).
+    expect(value).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    expect(String(value)).not.toContain("[[");
+    // ...and it is a FUTURE date (tomorrow), strictly after today — proving it
+    // resolved to today+1, not today. Lexicographic YYYY-MM-DD compare is
+    // clock-flake-safe (no exact-tomorrow race at UTC midnight).
+    const today = new Date().toISOString().slice(0, 10);
+    expect(value).not.toBe(today);
+    expect(String(value) > today).toBe(true);
+  });
+});

--- a/packages/core/tests/unit/services/WorkflowResolver.subclassWorkflow.test.ts
+++ b/packages/core/tests/unit/services/WorkflowResolver.subclassWorkflow.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Subclass workflow inheritance (req 915b20b2 — ems__WaitingCheckTask).
+ *
+ * A class that is a transitive subClass (via `exo__Class_superClass`) of a
+ * built-in Task/Project/Meeting inherits that built-in's workflow, so the
+ * standard status buttons (start-effort / mark-done / move-to-backlog
+ * `workflow_transition` groundings) WORK on any Task subclass — not just the
+ * exact built-in three. Before this, a subclass resolved `null` (silent no-op).
+ *
+ * Production-shape: a real {@link WorkflowResolver} over an
+ * {@link InMemoryTripleStore}, seeded with the REAL store IRI shape — the class
+ * FILE IRI is the subject of `exo__Class_superClass`, whose OBJECT is the
+ * symbolic parent-class IRI (`https://exocortex.my/ontology/ems#Task`), exactly
+ * as `NoteToRDFConverter` emits (dual-IRI). No mocks of the resolver logic.
+ *
+ * Revert-verify ([[integration-test-revert-verify]]): with the ancestry walk
+ * (`findBuiltInWorkflowByAncestry`) neutralised, the "subclass inherits Task
+ * workflow" assertions go RED (resolver returns null); restored → GREEN. The
+ * "non-Task subclass with no built-in ancestor → null" case stays GREEN both
+ * ways (intended no-op guard against over-eager resolution).
+ *
+ * @req:915b20b2-e0d7-4198-80c0-5561293149f0
+ */
+import { InMemoryTripleStore } from "../../../src/infrastructure/rdf/InMemoryTripleStore";
+import { WorkflowResolver } from "../../../src/services/WorkflowResolver";
+import { Triple } from "../../../src/domain/models/rdf/Triple";
+import { IRI } from "../../../src/domain/models/rdf/IRI";
+import { Literal } from "../../../src/domain/models/rdf/Literal";
+import { Namespace } from "../../../src/domain/models/rdf/Namespace";
+import { AssetClass } from "../../../src/domain/constants/AssetClass";
+
+const WCT_UID = "915bc0de-0000-4000-a000-00000000c0de"; // ems__WaitingCheckTask
+const WCT2_UID = "915bc0de-0000-4000-a000-00000000cafe"; // sub-sub-class
+const BASE_UID = "b00e0000-0000-4000-a000-0000000000ba"; // ems__SomeBase (no wf)
+const BUG_UID = "b00e0000-0000-4000-a000-00000000b060"; // ems__Bug (⊑ SomeBase)
+
+/**
+ * Seed a class FILE (subject = `obsidian://vault/<uid>.md`) with its uid, label,
+ * and — when `superClassLocal` is given — an `exo__Class_superClass` triple whose
+ * OBJECT is the SYMBOLIC parent IRI `ems#<superClassLocal>` (production shape).
+ */
+async function seedClass(
+  store: InMemoryTripleStore,
+  uid: string,
+  label: string,
+  superClassLocal?: string,
+): Promise<void> {
+  const file = new IRI(`obsidian://vault/${uid}.md`);
+  const triples = [
+    new Triple(file, Namespace.EXO.term("Asset_uid"), new Literal(uid)),
+    new Triple(file, Namespace.EXO.term("Asset_label"), new Literal(label)),
+  ];
+  if (superClassLocal) {
+    triples.push(
+      new Triple(
+        file,
+        Namespace.EXO.term("Class_superClass"),
+        Namespace.EMS.term(superClassLocal),
+      ),
+    );
+  }
+  await store.addAll(triples);
+}
+
+describe("WorkflowResolver — subclass workflow inheritance (req 915b20b2)", () => {
+  let store: InMemoryTripleStore;
+  let resolver: WorkflowResolver;
+  const asset = new IRI("obsidian://vault/some-wct-instance.md");
+
+  beforeEach(async () => {
+    store = new InMemoryTripleStore();
+    resolver = new WorkflowResolver(store);
+    // ems__WaitingCheckTask ⊑ ems__Task (direct subclass — the primary case).
+    await seedClass(store, WCT_UID, "ems__WaitingCheckTask", "Task");
+  });
+
+  it("resolves the built-in Task workflow for a direct Task subclass (UID-canon ref)", async () => {
+    const result = await resolver.resolveForAssetOrNull(asset, [`[[${WCT_UID}]]`]);
+    expect(result).not.toBeNull();
+    expect(result?.targetClass).toBe(AssetClass.TASK);
+  });
+
+  it("resolves the built-in Task workflow for a bare-label Task subclass ref", async () => {
+    const result = await resolver.resolveForAssetOrNull(asset, [
+      "ems__WaitingCheckTask",
+    ]);
+    expect(result).not.toBeNull();
+    expect(result?.targetClass).toBe(AssetClass.TASK);
+  });
+
+  it("walks a MULTI-hop chain (sub-sub-class ⊑ subclass ⊑ Task) to the built-in workflow", async () => {
+    // WCT2 ⊑ WaitingCheckTask (symbolic parent) ⊑ Task. The walk maps the
+    // symbolic intermediate back to its file IRI (label→uid) to recurse.
+    await seedClass(store, WCT2_UID, "ems__WaitingCheckTask2", "WaitingCheckTask");
+    const result = await resolver.resolveForAssetOrNull(asset, [`[[${WCT2_UID}]]`]);
+    expect(result).not.toBeNull();
+    expect(result?.targetClass).toBe(AssetClass.TASK);
+  });
+
+  it("returns null for a non-Task subclass with NO built-in ancestor (no over-eager resolution)", async () => {
+    // ems__Bug ⊑ ems__SomeBase, neither of which is Task/Project/Meeting and
+    // neither carries a workflow → benign null. (GREEN both ways under revert.)
+    await seedClass(store, BASE_UID, "ems__SomeBase");
+    await seedClass(store, BUG_UID, "ems__Bug", "SomeBase");
+    const result = await resolver.resolveForAssetOrNull(asset, [`[[${BUG_UID}]]`]);
+    expect(result).toBeNull();
+  });
+
+  it("resolves the built-in even when the Task subclass is NOT first in a multi-valued instance_class", async () => {
+    await seedClass(store, BASE_UID, "ems__SomeBase");
+    const result = await resolver.resolveForAssetOrNull(asset, [
+      `[[${BASE_UID}]]`,
+      `[[${WCT_UID}]]`,
+    ]);
+    expect(result).not.toBeNull();
+    expect(result?.targetClass).toBe(AssetClass.TASK);
+  });
+});


### PR DESCRIPTION
## Summary

Two domain-agnostic engine primitives that enable the homoiconic **`ems__WaitingCheckTask`** GTD «Waiting For» feature (design spec `51b249c7`, req `915b20b2`, user interview 2026-06-30). The class, the «Следующая итерация» button, clone rules, tickler default and binding are all vault-declared RDF (shipped separately via ExoSync); only these two generic engine primitives need code.

### 1. `create_instance` `cloneTargetBody`
A `create_instance` grounding with `exocmd__Grounding_cloneTargetBody: true` clones the click-target's markdown **body** into the new instance (frontmatter is never copied — only the body). Precedence: explicit non-empty `userInput.body` > cloned target body > empty. Carries a waiting-check's context notes forward across iterations without a template asset. Platform-agnostic (reads via the injected file reader — no Node `fs`; Desktop↔Mobile parity).

### 2. `WorkflowResolver` subclass inheritance
A class that is a transitive subClass (via `exo__Class_superClass`) of a built-in Task/Project/Meeting now inherits that built-in's workflow. The standard `start-effort`/`mark-done`/`move-to-backlog` `workflow_transition` buttons therefore **work on any Task subclass** (e.g. `ems__WaitingCheckTask`); previously a subclass resolved `null` and the generic status buttons silently no-op'd. Data-driven cycle-safe BFS over the vault class hierarchy (dual-IRI aware: symbolic `ems#Task` + class-file IRI); benign `null` on any lookup failure (no crash).

## Tests / revert-verify
- `create-instance-clone-target-body.test.ts` (integration) — `@req:915b20b2`. Revert-verified: «new body == target body» goes **RED** when the clone is neutralised, GREEN restored; the empty-body no-op guard stays GREEN both ways.
- `WorkflowResolver.subclassWorkflow.test.ts` (unit) — `@req:915b20b2`. Production-shape store (class-file subject + symbolic parent IRI). Revert-verified: 4 subclass-inheritance assertions go **RED** when the ancestry walk is neutralised, GREEN restored; the non-Task-subclass null-guard stays GREEN both ways.
- 301 affected core tests pass; tsc clean; 3 CI lint-guards (antipatterns/shard/coverage-monotonic) pass.

Realises design spec `51b249c7` (6 Vision Locks). The `ems__Effort_prevIteration` property already exists (`3104b383`).