### PR TITLE
fix(core+plugin): $today executor + form-prefill use local timezone, not UTC (@req:26d79c70) (#3809)

### DIFF
--- a/packages/core/src/services/GroundingExecutor.ts
+++ b/packages/core/src/services/GroundingExecutor.ts
@@ -1230,18 +1230,23 @@ export class GroundingExecutor {
    * Feature ec15f83e / req 57b03ab3 — the target DATE for a newly-created
    * instance: the reserved `plannedDate` userInput (the plugin modal's date
    * field / the CLI `--date` parameter) when a valid `YYYY-MM-DD`; otherwise
-   * today (same source as the `$today` token — `clock.now()` UTC date slice).
+   * today's LOCAL calendar day (req 26d79c70 / #3809 — same source and basis as
+   * the `$today` SubstitutionToken and `$date`, which use local `Date` getters).
    * Drives BOTH the date-denoting label (`$today` in the labelTemplate) AND the
-   * planned timestamps, so the two never disagree. `isoNow` lets callers reuse
-   * an already-computed `clock.now().toISOString()` (substituteVariables) to
-   * avoid a second clock read; both code paths resolve `plannedDate` identically.
+   * planned timestamps, so the two never disagree — and, since the prototype
+   * time-of-day at {@link applyPrototypeTimePropagation} is already a local
+   * `"YYYY-MM-DDTHH:MM:SS"`, the DATE and TIME are now both local (the former
+   * UTC date slice made them disagree just after local midnight in a UTC+N
+   * timezone). `nowDate` lets callers reuse an already-computed `clock.now()`
+   * Date (substituteVariables) to avoid a second clock read; both code paths
+   * resolve `plannedDate` identically.
    */
-  private resolveInstanceDate(userInput?: UserInput, isoNow?: string): string {
+  private resolveInstanceDate(userInput?: UserInput, nowDate?: Date): string {
     const explicit = GroundingExecutor.firstScalar(
       userInput?.["plannedDate"] as string | string[] | undefined,
     );
     if (explicit && /^\d{4}-\d{2}-\d{2}$/.test(explicit)) return explicit;
-    return (isoNow ?? this.clock.now().toISOString()).slice(0, 10);
+    return DateFormatter.toDateString(nowDate ?? this.clock.now());
   }
 
   /**
@@ -2027,10 +2032,14 @@ export class GroundingExecutor {
     const nowLocal = DateFormatter.toLocalTimestamp(date);
     // Feature ec15f83e / req 57b03ab3 — `$today` denotes the instance's nominal
     // DAY, which is the chosen target date (reserved `plannedDate` userInput),
-    // defaulting to today. `$now`/`$nowLocal`/`$nowCompact` stay the real clock
-    // time (createdAt etc. unaffected). When no plannedDate is supplied this is
-    // identical to the prior `now.slice(0, 10)` behaviour (zero regression).
-    const today = this.resolveInstanceDate(userInput, now);
+    // defaulting to today's LOCAL calendar day (req 26d79c70 / #3809 — reuse the
+    // already-read `date` so the LOCAL getters slice the same instant as the
+    // rest of this method). `$now`/`$nowLocal`/`$nowCompact` stay the real clock
+    // time (createdAt etc. unaffected).
+    const today = this.resolveInstanceDate(userInput, date);
+    // `$todayStart` = today's local day at midnight, timezone-naive
+    // (YYYY-MM-DDT00:00:00) — matches DateFormatter.getTodayStartTimestamp; now
+    // that `today` is the LOCAL day it is local-day-consistent (req 26d79c70).
     const todayStart = `${today}T00:00:00`;
     // RFC ce27e55d $nowCompact: filename-safe minute-precision form derived
     // from nowLocal slices. nowLocal = "YYYY-MM-DDTHH:mm:ss" → indices 0..10

--- a/packages/core/tests/helpers/installFakeOffsetDate.ts
+++ b/packages/core/tests/helpers/installFakeOffsetDate.ts
@@ -1,0 +1,85 @@
+/**
+ * Install a global `Date` subclass simulating a FIXED whole-hour UTC offset (no
+ * DST) at a FIXED instant — the CI-robust technique for timezone-sensitive
+ * revert-verify tests ([[jest-timezone-sensitive-tests]]).
+ *
+ * Why not `process.env.TZ`: it cannot be re-tzset at runtime under jest (V8
+ * caches the worker timezone on first `Date` use), so a runtime `TZ` assignment
+ * is a silent no-op. And a local-vs-UTC date fix has NO observable effect in a
+ * UTC runner (local === UTC there), so a test that only sets `TZ` passes both
+ * with AND without the fix in CI — a false-positive.
+ *
+ * This subclass instead makes the LOCAL getters
+ * (`getFullYear/getMonth/getDate/getHours/getMinutes/getSeconds/getDay`) report
+ * the chosen offset's wall-clock, while the UTC getters (`getUTC*`,
+ * `toISOString`, `getTime`) stay true — independent of the runner's real
+ * timezone. Local constructor components `(y, mo, d, …)` are interpreted in the
+ * simulated zone. `new Date()` (no args) returns the fixed instant.
+ *
+ * Usage (revert-verify at the local/UTC midnight boundary):
+ * ```ts
+ * const restore = installFakeOffsetDate(5, "2026-07-02T19:27:00Z"); // UTC+5, 00:27 local
+ * try {
+ *   expect(new Date().getHours()).toBe(0);    // guard: simulated tz active
+ *   expect(new Date().getUTCDate()).toBe(2);  // still previous day in UTC
+ *   // ...exercise the code under test; local day = 03, UTC day = 02
+ * } finally {
+ *   restore();
+ * }
+ * ```
+ *
+ * @param offsetHours whole-hour offset east of UTC (Asia/Almaty = +5)
+ * @param fixedIso    the UTC ISO instant that `new Date()` (no args) returns
+ * @returns a restore function that reinstates the real global `Date`
+ */
+export function installFakeOffsetDate(
+  offsetHours: number,
+  fixedIso: string,
+): () => void {
+  const RealDate = Date;
+  const OFFSET_MS = offsetHours * 60 * 60 * 1000;
+  const FIXED_EPOCH = RealDate.parse(fixedIso);
+  class FakeOffsetDate extends RealDate {
+    constructor(...args: unknown[]) {
+      if (args.length === 0) {
+        super(FIXED_EPOCH); // "now" = the fixed boundary instant
+      } else if (args.length === 1) {
+        super(args[0] as number | string | Date);
+      } else {
+        // (y, mo, d, …) are LOCAL (simulated-zone) components → shift to UTC.
+        const [y, mo, d = 1, h = 0, mi = 0, s = 0, ms = 0] = args as number[];
+        super(RealDate.UTC(y, mo, d, h, mi, s, ms) - OFFSET_MS);
+      }
+    }
+    // Local getters = UTC getters of (epoch + offset); UTC getters inherited.
+    private shifted(): Date {
+      return new RealDate(this.getTime() + OFFSET_MS);
+    }
+    override getFullYear(): number {
+      return this.shifted().getUTCFullYear();
+    }
+    override getMonth(): number {
+      return this.shifted().getUTCMonth();
+    }
+    override getDate(): number {
+      return this.shifted().getUTCDate();
+    }
+    override getHours(): number {
+      return this.shifted().getUTCHours();
+    }
+    override getMinutes(): number {
+      return this.shifted().getUTCMinutes();
+    }
+    override getSeconds(): number {
+      return this.shifted().getUTCSeconds();
+    }
+    override getDay(): number {
+      return this.shifted().getUTCDay();
+    }
+  }
+  (globalThis as { Date: DateConstructor }).Date =
+    FakeOffsetDate as unknown as DateConstructor;
+  return () => {
+    (globalThis as { Date: DateConstructor }).Date = RealDate;
+  };
+}

--- a/packages/core/tests/unit/services/CommandResolver.todayLocalTz.test.ts
+++ b/packages/core/tests/unit/services/CommandResolver.todayLocalTz.test.ts
@@ -38,6 +38,7 @@ import {
   installDefaultResolvers,
   type ResolverContext,
 } from "../../../src/services/SubstitutionResolverRegistry";
+import { installFakeOffsetDate } from "../../helpers/installFakeOffsetDate";
 
 const CREATE_INSTANCE_TYPE_UID = "4367e2d6-6c92-450a-becb-abce1fb07682";
 const PROP_PLANNED_UID = "7f773e3e-54d0-426b-98c5-5b75d01695cb"; // ems__Effort_plannedStartTimestamp
@@ -61,51 +62,10 @@ async function addLabelled(
   ]);
 }
 
-/**
- * Installs a `Date` subclass simulating a fixed UTC+5 offset at 00:27 local
- * (2026-07-02T19:27:00Z). Local getters = UTC getters of (epoch + offset); UTC
- * getters are inherited. Returns a restore function.
- */
-function installFakeAlmatyDate(): () => void {
-  const RealDate = Date;
-  const OFFSET_MS = 5 * 60 * 60 * 1000; // UTC+5 (Asia/Almaty, no DST)
-  const FIXED_EPOCH = RealDate.parse("2026-07-02T19:27:00Z"); // 00:27 Almaty
-  class FakeAlmatyDate extends RealDate {
-    constructor(...args: unknown[]) {
-      if (args.length === 0) {
-        super(FIXED_EPOCH); // "now" = the fixed boundary instant
-      } else if (args.length === 1) {
-        super(args[0] as number | string | Date);
-      } else {
-        const [y, mo, d = 1, h = 0, mi = 0, s = 0, ms = 0] = args as number[];
-        super(RealDate.UTC(y, mo, d, h, mi, s, ms) - OFFSET_MS);
-      }
-    }
-    private shifted(): Date {
-      return new RealDate(this.getTime() + OFFSET_MS);
-    }
-    override getFullYear(): number {
-      return this.shifted().getUTCFullYear();
-    }
-    override getMonth(): number {
-      return this.shifted().getUTCMonth();
-    }
-    override getDate(): number {
-      return this.shifted().getUTCDate();
-    }
-    override getHours(): number {
-      return this.shifted().getUTCHours();
-    }
-    override getDay(): number {
-      return this.shifted().getUTCDay();
-    }
-  }
-  (globalThis as { Date: DateConstructor }).Date =
-    FakeAlmatyDate as unknown as DateConstructor;
-  return () => {
-    (globalThis as { Date: DateConstructor }).Date = RealDate;
-  };
-}
+// Fixed UTC+5 (Asia/Almaty, no DST) at 2026-07-02T19:27:00Z = 00:27 local
+// (local day 03, UTC day 02) — see the shared installFakeOffsetDate helper.
+const installFakeAlmatyDate = () =>
+  installFakeOffsetDate(5, "2026-07-02T19:27:00Z");
 
 describe("$today resolvers return the LOCAL calendar day (req 5c47471a / #3807)", () => {
   // Parse-time path — production-shape via CommandResolver.loadCommand.

--- a/packages/core/tests/unit/services/CommandResolver.waitingCheckLoader.test.ts
+++ b/packages/core/tests/unit/services/CommandResolver.waitingCheckLoader.test.ts
@@ -26,6 +26,7 @@ import { Triple } from "../../../src/domain/models/rdf/Triple";
 import { IRI } from "../../../src/domain/models/rdf/IRI";
 import { Literal } from "../../../src/domain/models/rdf/Literal";
 import { Namespace } from "../../../src/domain/models/rdf/Namespace";
+import { installFakeOffsetDate } from "../../helpers/installFakeOffsetDate";
 
 const CREATE_INSTANCE_TYPE_UID = "4367e2d6-6c92-450a-becb-abce1fb07682";
 
@@ -202,43 +203,7 @@ describe("CommandResolver — ems__WaitingCheckTask loader stage (req 915b20b2)"
   // runner's real timezone. Pre-fix resolves to "2026-07-03" (= local TODAY) →
   // RED; post-fix (local getFullYear/getMonth/getDate + 1) → "2026-07-04" GREEN.
   it("resolves $tomorrow to the next LOCAL calendar day just after local midnight (UTC still previous day) @req:bca93bfb-b663-4309-a19e-996de8e526da", async () => {
-    const RealDate = Date;
-    const OFFSET_MS = 5 * 60 * 60 * 1000; // UTC+5 (Asia/Almaty, no DST)
-    const FIXED_EPOCH = RealDate.parse("2026-07-02T19:27:00Z"); // 00:27 Almaty
-    class FakeAlmatyDate extends RealDate {
-      constructor(...args: unknown[]) {
-        if (args.length === 0) {
-          super(FIXED_EPOCH); // "now" = the fixed boundary instant
-        } else if (args.length === 1) {
-          super(args[0] as number | string | Date);
-        } else {
-          // (y, m, d, …) are LOCAL Almaty components → shift to the UTC epoch.
-          const [y, mo, d = 1, h = 0, mi = 0, s = 0, ms = 0] = args as number[];
-          super(RealDate.UTC(y, mo, d, h, mi, s, ms) - OFFSET_MS);
-        }
-      }
-      // Local getters = UTC getters of (epoch + offset); UTC getters inherited.
-      private shifted(): Date {
-        return new RealDate(this.getTime() + OFFSET_MS);
-      }
-      override getFullYear(): number {
-        return this.shifted().getUTCFullYear();
-      }
-      override getMonth(): number {
-        return this.shifted().getUTCMonth();
-      }
-      override getDate(): number {
-        return this.shifted().getUTCDate();
-      }
-      override getHours(): number {
-        return this.shifted().getUTCHours();
-      }
-      override getDay(): number {
-        return this.shifted().getUTCDay();
-      }
-    }
-    (globalThis as { Date: DateConstructor }).Date =
-      FakeAlmatyDate as unknown as DateConstructor;
+    const restore = installFakeOffsetDate(5, "2026-07-02T19:27:00Z");
     try {
       // Guard: prove the simulated tz is active (else the assertion below would
       // be vacuous in a UTC-tz runner and silently pass both ways — fail loud).
@@ -308,7 +273,7 @@ describe("CommandResolver — ems__WaitingCheckTask loader stage (req 915b20b2)"
       // (= local TODAY at this instant) — the bug FIX-2 corrects.
       expect(value).toBe("2026-07-04");
     } finally {
-      (globalThis as { Date: DateConstructor }).Date = RealDate;
+      restore();
     }
   });
 });

--- a/packages/core/tests/unit/services/GroundingExecutor.test.ts
+++ b/packages/core/tests/unit/services/GroundingExecutor.test.ts
@@ -637,7 +637,10 @@ describe("GroundingExecutor", () => {
       const result = await executor.execute(grounding, TARGET_IRI, FILE_PATH);
 
       expect(result.success).toBe(true);
-      const today = new Date().toISOString().slice(0, 10);
+      // req 26d79c70 / #3809 — `$today` is the LOCAL calendar day (matches the
+      // executor's DateFormatter.toDateString basis), not the UTC slice.
+      const now = new Date();
+      const today = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}-${String(now.getDate()).padStart(2, "0")}`;
       expect(mockService.execute).toHaveBeenCalledWith(TARGET_IRI, {
         plannedStartDate: today,
       });

--- a/packages/core/tests/unit/services/GroundingExecutor.todayLocalTz.test.ts
+++ b/packages/core/tests/unit/services/GroundingExecutor.todayLocalTz.test.ts
@@ -1,0 +1,84 @@
+/**
+ * `$today` executor local-timezone revert-verify (req 26d79c70 / #3809,
+ * follow-up to #3808 which fixed the two SubstitutionToken resolution paths).
+ *
+ * `GroundingExecutor.resolveInstanceDate` feeds the executor's `$today` /
+ * `$todayStart` in `substituteVariables` (labelTemplate / serviceCallPayload /
+ * property_set) AND the created instance's nominal date + prototype-time planned
+ * timestamps. It formerly sliced `clock.now().toISOString()` (UTC), mis-firing
+ * to yesterday's LOCAL day just after local midnight in a UTC+N timezone — while
+ * the `$today` SubstitutionToken resolvers (#3808) and `$date` were already
+ * local, so `$today` was split-basis across surfaces at the boundary. The fix
+ * slices the LOCAL calendar day (`DateFormatter.toDateString`).
+ *
+ * Revert-verify ([[integration-test-revert-verify]]): reverting
+ * `resolveInstanceDate` to `(isoNow ?? clock.now().toISOString()).slice(0, 10)`
+ * makes `$today` resolve to "2026-07-02" (the UTC day) → RED; the local form →
+ * GREEN ("2026-07-03").
+ *
+ * CI-robustness ([[jest-timezone-sensitive-tests]]): `process.env.TZ` cannot be
+ * re-tzset at runtime under jest (V8 caches the worker timezone), and the fix
+ * has NO observable effect in a UTC runner — so a `Date` subclass (shared
+ * `installFakeOffsetDate` helper) simulates a fixed UTC+5 (Asia/Almaty, no DST)
+ * offset at 2026-07-02T19:27:00Z = 2026-07-03T00:27 local (local day 03, UTC day
+ * 02), independent of the runner's real timezone. A guard proves the simulated
+ * tz is active so the assertion can never silently pass both ways in a UTC-tz
+ * CI runner.
+ *
+ * @req:26d79c70-8e39-454c-b07e-a8d9d0ea2b66
+ */
+import {
+  GroundingExecutor,
+  ServiceRegistry,
+} from "../../../src/services/GroundingExecutor";
+import { installFakeOffsetDate } from "../../helpers/installFakeOffsetDate";
+
+function createMockReader() {
+  return {
+    readFile: jest.fn().mockResolvedValue("---\nfoo: bar\n---\nBody"),
+    fileExists: jest.fn().mockResolvedValue(true),
+    getMarkdownFiles: jest.fn().mockResolvedValue([]),
+  };
+}
+
+function createMockWriter() {
+  return {
+    createFile: jest.fn().mockResolvedValue(""),
+    updateFile: jest.fn().mockResolvedValue(undefined),
+    writeFile: jest.fn().mockResolvedValue(undefined),
+    deleteFile: jest.fn().mockResolvedValue(undefined),
+    renameFile: jest.fn().mockResolvedValue(undefined),
+  };
+}
+
+describe("GroundingExecutor $today = LOCAL calendar day (req 26d79c70 / #3809)", () => {
+  const TARGET_IRI = "https://exocortex.my/assets/test-asset-123";
+
+  it("substituteVariables interpolates $today as today's LOCAL day just after local midnight (UTC still previous day) @req:26d79c70-8e39-454c-b07e-a8d9d0ea2b66", () => {
+    const restore = installFakeOffsetDate(5, "2026-07-02T19:27:00Z");
+    try {
+      // Guard: prove the simulated tz is active (else the assertion below would
+      // be vacuous in a UTC-tz runner and silently pass both ways — fail loud).
+      expect(new Date().getHours()).toBe(0); // 00:27 local (Almaty)
+      expect(new Date().getUTCDate()).toBe(2); // still July 2 in UTC
+
+      const executor = new GroundingExecutor(
+        createMockReader(),
+        createMockWriter(),
+        new ServiceRegistry(),
+      );
+
+      // `$today` in a label-template / property value. Local today = 2026-07-03;
+      // the former UTC form returned "2026-07-02" (yesterday's local date).
+      const label = executor.substituteVariables("due $today", TARGET_IRI);
+      expect(label).toBe("due 2026-07-03");
+
+      // `$todayStart` = today's LOCAL day at midnight (timezone-naive) — now
+      // local-day-consistent since it derives from the same `$today`.
+      const planned = executor.substituteVariables("$todayStart", TARGET_IRI);
+      expect(planned).toBe("2026-07-03T00:00:00");
+    } finally {
+      restore();
+    }
+  });
+});

--- a/packages/obsidian-plugin/src/presentation/components/dynamic-form/DynamicForm.tsx
+++ b/packages/obsidian-plugin/src/presentation/components/dynamic-form/DynamicForm.tsx
@@ -34,15 +34,24 @@ function normalizeEnumOption(opt: string | EnumOption): EnumOption {
  * date as `YYYY-MM-DD` so a `type="date"` input pre-fills with today (feature
  * ec15f83e / req 57b03ab3 — the create-task-instance modal's planned-date field).
  *
- * Uses the UTC date slice (`toISOString().slice(0, 10)`) on purpose: it mirrors
- * the engine's own `$today` basis (`GroundingExecutor.resolveInstanceDate` /
- * label-template `$today` both slice `clock.now().toISOString()`), so the
+ * Uses LOCAL `Date` getters (`getFullYear()/getMonth()/getDate()`, req 26d79c70
+ * / #3809), matching the engine's now-local `$today` basis
+ * (`GroundingExecutor.resolveInstanceDate` slices the local calendar day, and
+ * the `$today` SubstitutionToken resolvers are local since #3808), so the
  * pre-filled modal date, the derived label, and the planned timestamps all
- * agree by default. Any non-`$today` value (including a literal `YYYY-MM-DD`)
+ * agree by default even just after local midnight in a UTC+N timezone (the
+ * former `toISOString().slice(0, 10)` UTC slice prefilled yesterday's local day
+ * at that boundary). Any non-`$today` value (including a literal `YYYY-MM-DD`)
  * passes through verbatim.
  */
 function resolveDefaultValue(raw: string | undefined): string {
-  if (raw === "$today") return new Date().toISOString().slice(0, 10);
+  if (raw === "$today") {
+    const now = new Date();
+    const year = now.getFullYear();
+    const month = String(now.getMonth() + 1).padStart(2, "0");
+    const day = String(now.getDate()).padStart(2, "0");
+    return `${year}-${month}-${day}`;
+  }
   return raw ?? "";
 }
 

--- a/packages/obsidian-plugin/tests/unit/presentation/components/DynamicForm.test.tsx
+++ b/packages/obsidian-plugin/tests/unit/presentation/components/DynamicForm.test.tsx
@@ -3,6 +3,10 @@ import "@testing-library/jest-dom";
 import { render, screen, fireEvent } from "@testing-library/react";
 import { DynamicForm, DynamicFormProps } from "../../../../src/presentation/components/dynamic-form/DynamicForm";
 import type { InputSchemaField } from "../../../../src/presentation/builders/button-groups/DynamicCommandButtonGroupBuilder";
+// Shared tz-simulation helper (canonical copy lives in core tests). Cross-package
+// import keeps the FakeOffsetDate technique deduplicated across the $today revert-
+// verify suites ([[jest-timezone-sensitive-tests]]).
+import { installFakeOffsetDate } from "../../../../../core/tests/helpers/installFakeOffsetDate";
 
 function renderForm(
   schema: InputSchemaField[],
@@ -65,8 +69,10 @@ describe("DynamicForm", () => {
 
   // Feature ec15f83e / req 57b03ab3 — the create-task-instance modal pre-fills
   // its planned-date field with today via the `$today` token in defaultValue.
-  // UTC date slice mirrors the engine's $today basis (GroundingExecutor /
-  // labelTemplate) so the modal date, label, and planned timestamps agree.
+  // The LOCAL date slice (req 26d79c70 / #3809) mirrors the engine's now-local
+  // $today basis (GroundingExecutor.resolveInstanceDate + label-template $today)
+  // so the modal date, label, and planned timestamps agree — see the dedicated
+  // boundary revert-verify describe below for the local-vs-UTC lock.
   describe("$today defaultValue token (req 57b03ab3)", () => {
     beforeEach(() => {
       jest.useFakeTimers();
@@ -102,23 +108,40 @@ describe("DynamicForm", () => {
       expect(screen.getByTestId("field-note")).toHaveValue("$todayish");
     });
 
-    // Locks the load-bearing UTC decision: at an instant where the Almaty
-    // (UTC+5) local date (2026-06-29) differs from the UTC date (2026-06-28),
-    // the resolved value must follow the engine's UTC slice — NOT the local
-    // date — so the modal date, label `$today`, and planned timestamps agree.
-    // `toISOString()` is timezone-independent, so this never flakes on the impl;
-    // it only fails if someone reimplements with local date components.
-    it("@req:57b03ab3 uses the engine's UTC date, not the local-timezone date, across midnight", () => {
-      const prevTz = process.env.TZ;
-      process.env.TZ = "Asia/Almaty";
+  });
+
+  // req 26d79c70 / #3809 — the `$today` prefill must resolve to today's LOCAL
+  // calendar day, matching the now-local engine `$today` (GroundingExecutor +
+  // SubstitutionToken resolvers from #3808). The former `toISOString().slice`
+  // (UTC) prefilled yesterday's local day just after local midnight in a UTC+N
+  // timezone.
+  //
+  // CI-robust ([[jest-timezone-sensitive-tests]]): `process.env.TZ` cannot be
+  // re-tzset at runtime under jest (V8 caches the worker timezone), and the fix
+  // has NO observable effect in a UTC runner — so a `Date` subclass
+  // (installFakeOffsetDate) simulates a fixed UTC+5 (Asia/Almaty, no DST) offset
+  // at 2026-07-02T19:27:00Z = 00:27 local (local day 03, UTC day 02),
+  // independent of the runner's real timezone. Kept in a separate describe with
+  // NO jest fake timers (the subclass IS the clock) to avoid the
+  // fake-timers × Date-subclass interaction. Revert-verify: reverting
+  // resolveDefaultValue to `toISOString().slice(0,10)` resolves "2026-07-02"
+  // (UTC) → RED; the local form → GREEN ("2026-07-03").
+  describe("$today prefill = LOCAL calendar day (req 26d79c70 / #3809)", () => {
+    it("@req:26d79c70-8e39-454c-b07e-a8d9d0ea2b66 prefills today's LOCAL day just after local midnight (UTC still previous day)", () => {
+      const restore = installFakeOffsetDate(5, "2026-07-02T19:27:00Z");
       try {
-        jest.setSystemTime(new Date("2026-06-28T23:30:00Z")); // 04:30 next day in Almaty
+        // Guard: prove the simulated tz is active (else the assertion below
+        // would be vacuous in a UTC-tz runner and silently pass both ways).
+        expect(new Date().getHours()).toBe(0); // 00:27 local (Almaty)
+        expect(new Date().getUTCDate()).toBe(2); // still July 2 in UTC
+
         renderForm([
           { name: "plannedDate", type: "date", defaultValue: "$today" },
         ]);
-        expect(screen.getByTestId("field-plannedDate")).toHaveValue("2026-06-28");
+        // Local today = 2026-07-03; the former UTC form prefilled "2026-07-02".
+        expect(screen.getByTestId("field-plannedDate")).toHaveValue("2026-07-03");
       } finally {
-        process.env.TZ = prevTz;
+        restore();
       }
     });
   });


### PR DESCRIPTION
## Summary

Aligns the **two declared** `$today` surfaces (Closes #3809) that still computed `$today` as UTC, after #3808 fixed the two SubstitutionToken resolution paths (parse-time + registry). This PR does the executor + form:

1. **`GroundingExecutor.resolveInstanceDate`** (`packages/core/src/services/GroundingExecutor.ts`) — feeds the executor's `$today` / `$todayStart` in `substituteVariables` (labelTemplate / serviceCallPayload / property_set) AND the created instance's nominal date + prototype-time planned timestamps. Was `(isoNow ?? clock.now().toISOString()).slice(0,10)` (UTC) → now `DateFormatter.toDateString(nowDate ?? clock.now())` (LOCAL). The call site passes the already-read `Date` object (was the ISO string) so it slices the same instant locally.
2. **`DynamicForm.resolveDefaultValue`** (`packages/obsidian-plugin/.../DynamicForm.tsx`) — the create-instance modal's `type="date"` `$today` prefill. Was `new Date().toISOString().slice(0,10)` (UTC) → now local `getFullYear()/getMonth()/getDate()`.

`$todayStart` (LOW) derives from the now-local `$today` (`${today}T00:00:00`), so it becomes local-day-consistent automatically (matches `DateFormatter.getTodayStartTimestamp` naive local-midnight shape). The executor's planned time-of-day was already local — now the DATE matches, resolving the second internal inconsistency the issue noted.

Docstrings (executor `resolveInstanceDate`, form `resolveDefaultValue` + the `DynamicForm.test.tsx` rationale comment) updated from the stale "UTC on purpose" wording to the local basis.

## Test / dedup

- Extracted the `FakeAlmatyDate` tz-simulation (duplicated across #3806/#3808 suites) into a shared **`packages/core/tests/helpers/installFakeOffsetDate.ts`** helper. The two existing suites (`CommandResolver.waitingCheckLoader`, `CommandResolver.todayLocalTz`) + the new executor suite reuse it; the plugin form suite imports it cross-package.
- New revert-verify suites for both surfaces (`GroundingExecutor.todayLocalTz.test.ts` + a `#3809` describe in `DynamicForm.test.tsx`), CI-robust via the `Date`-subclass technique (`process.env.TZ` can't be re-tzset under jest — [[jest-timezone-sensitive-tests]]).
- Removed the now-inverted UTC-locking boundary test in `DynamicForm.test.tsx`; updated the one UTC-exact assert in `GroundingExecutor.test.ts` (#2999) to local.

## Verification

- **Revert-verify** ([[integration-test-revert-verify]]): reverting either surface to `toISOString().slice(0,10)` → boundary asserts "2026-07-02" (UTC) → **RED**; local form → **GREEN** ("2026-07-03"). Confirmed for both.
- **Double-gate empirical** on built dist: real compiled `GroundingExecutor.substituteVariables` → `$today` label + `$todayStart` = today's LOCAL day; CLI bundle-grep confirms `DateFormatter.toDateString`.
- Broad affected core suites: 28 suites / 493 tests green (GroundingExecutor / CommandResolver / create-instance / proto-time / SubstitutionResolver). Plugin `DynamicForm.test.tsx`: 48 green. `check:types` 0 errors. All 3 CI guard scripts (shard / anti-pattern ratchet / coverage-monotonic) pass.


## Known remaining (out of scope → follow-up)

Code review of this PR surfaced a **5th** `$today` UTC surface — `PreconditionEvaluator` precondition-SPARQL substitution (`$today` UTC while its sibling `$yesterday`/`$thisWeekStart` are Almaty-local → boundary mis-fire), plus LOW `$todayStart` shape-split / `DatePropertyField` dead-code. Tracked in **#3811** (req-first). This PR completes the 4 declared surfaces (parse-time + registry + executor + form); the 5th is deferred.

req-first SDD: `@req:26d79c70-8e39-454c-b07e-a8d9d0ea2b66` (proposed on `exoas-exo-reqs` main; flips active after merge). Follow-up to #3807/#3808 (req 5c47471a); sibling #3806 (req bca93bfb); feature `ems__WaitingCheckTask` (req 915b20b2).

Closes #3809

