### PR TITLE
docs(cli): document scaffold + requirements verbs; sync --help description

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -54,6 +54,7 @@ The following v15 verbs were **removed**: `batch`, `batch-repair`, `command`, `d
 | [`resolve`](#resolve)                     | Resolve a UUID (full or partial) to a file path                                    |
 | [`workflow`](#workflow)                   | List / show / validate workflow definitions                                        |
 | [`recover`](#recover)                     | Detect and recover orphaned claude-child tmux sessions                             |
+| [`scaffold`](#scaffold)                   | Scaffold homoiconic configuration assets (validation-check settings)               |
 | [`audit`](#audit)                         | Regression-pattern audits (`co-location`, `ontology-imports`)                      |
 | [`apply-profile`](#apply-profile)         | Apply an `exo__Profile` (mount-state filesystem mutation)                          |
 | [`bootstrap`](#bootstrap)                 | Bootstrap a vault with the SDK floor AssetSpace                                    |
@@ -62,6 +63,7 @@ The following v15 verbs were **removed**: `batch`, `batch-repair`, `command`, `d
 | [`exosync`](#exosync)                     | Sync / pull / push the materialized AssetSpace set over the GitHub REST API        |
 | [`exosync-parity`](#exosync-parity)       | Read-only ExoSync divergence report (M1/M2 parity check)                           |
 | [`resolve-deps`](#resolve-deps)           | Resolve an AssetSpace's transitive `dependsOn` closure from the registry (CI gate) |
+| [`requirements`](#requirements)           | Requirements↔test traceability checker (RFC 0003)                                  |
 
 ---
 
@@ -385,6 +387,22 @@ npx @kitelev/exocortex-cli recover --apply --vault ~/vault-2025
 | `--dry-run`      | —                                    | List orphans without applying changes (default behavior) |
 | `--apply`        | off                                  | Apply recovery: set Failed + kill the tmux session       |
 
+### scaffold
+
+Scaffold homoiconic configuration assets. Currently exposes one subcommand, `validation-settings`, which materializes the four validation-check `setting__Setting` instances (`uid-uniqueness=true`, the rest `false`) co-located in the chosen ontology's folder, so `validate vault` has an enabled-set to read (RFC f402002b).
+
+```bash
+npx @kitelev/exocortex-cli scaffold validation-settings \
+  --vault ~/vault-2025 \
+  --ontology <ontology-uid>
+```
+
+| Option             | Default      | Description                                                           |
+| ------------------ | ------------ | --------------------------------------------------------------------- |
+| `--vault <path>`   | **required** | Vault root directory                                                  |
+| `--ontology <uid>` | **required** | UID of the ontology whose folder the check settings are co-located in |
+| `--output <type>`  | `text`       | Response format: `text` \| `json`                                     |
+
 ---
 
 ## Vault Management Commands
@@ -547,6 +565,24 @@ npx @kitelev/exocortex-cli resolve-deps \
 | `--self <id>`       | **required** | Identity of the calling repo: an `owner/repo` slug (matches GitHub's `github.repository`), a full git URL, or a bare namespace |
 | `--format <type>`   | `urls`       | Output format: `urls` (one clone URL per line) or `json` (full diagnostics)                                                    |
 | `--strict`          | off          | Exit non-zero (`2`) when `self` is not registered, instead of validating standalone                                            |
+
+### requirements
+
+Requirements-management tooling (RFC 0003). The `requirements audit` subcommand checks requirement↔test traceability — orphan requirements, dangling `@req:<uid>` tags, duplicate bindings, the binding-class floor, coverage, and P0 ramp-readiness. Used by the `requirements-trace` CI job.
+
+```bash
+npx @kitelev/exocortex-cli requirements audit \
+  --reqs ./exoas-exo-reqs \
+  --tests .
+```
+
+| Option            | Default      | Description                                                                            |
+| ----------------- | ------------ | -------------------------------------------------------------------------------------- |
+| `--reqs <path>`   | **required** | Directory tree containing `req__Requirement` assets (a vault or a reqs assetspace)     |
+| `--tests <path>`  | `.`          | Test-corpus root scanned for `@req:<uid>` tags                                         |
+| `--output <type>` | `text`       | Response format: `text` \| `json`                                                      |
+| `--strict`        | off          | Also exit `1` on orphan requirements                                                   |
+| `--gate <mode>`   | `soft`       | Gate mode: `soft` (warn only) \| `hard` (also block when the P0 checklist isn't ready) |
 
 ---
 

--- a/packages/cli/src/program.ts
+++ b/packages/cli/src/program.ts
@@ -38,7 +38,9 @@ export function createProgram(version?: string): Command {
 
   program
     .name("exocortex")
-    .description("CLI tool for Exocortex knowledge management system")
+    .description(
+      "CLI tool for Exocortex knowledge management system - SPARQL queries, task management, and more",
+    )
     .version(version ?? __CLI_VERSION__);
 
   // Five core verbs (RFC 8e83442b)


### PR DESCRIPTION
## What

The CLI ships **21 commands**, but the README Command Overview documented only **18** — and `--help` printed a truncated short description. This PR closes both gaps (verification requested by user).

### 1. README: document 2 undocumented verbs
Added table rows + dedicated sections for verbs that exist in the CLI but were absent from the README (and therefore from the npmjs page, which renders the same README):

- **`scaffold`** — Scaffold homoiconic configuration assets (`scaffold validation-settings`, RFC f402002b / M1.5).
- **`requirements`** — Requirements↔test traceability checker (`requirements audit`, RFC 0003; used by the `requirements-trace` CI job).

### 2. `--help` short description synced with package.json / npm
`program.ts` `.description()` was `"CLI tool for Exocortex knowledge management system"` while package.json / npmjs use `"... - SPARQL queries, task management, and more"`. Extended the `--help` string to match.

## Why
Verification of description consistency across README ⇄ `--help` ⇄ npmjs surfaced these two mismatches. README on npmjs is byte-identical to git, so the README fix also fixes the npmjs page (published on next Auto Release).

## Verification
- Descriptions/options mirror the actual source (`scaffold-validation.ts`, `requirements.ts`, `requirements-audit.ts`) and `--help` output of published `16.170.2`.
- README was prettier-clean on origin/main → only additions reformatted (no whole-table churn).
- Local pre-commit green: lint-staged `jest --findRelatedTests program.ts` 4/4 PASS, prettier clean, `archgate check --staged` pass (0 errors). No test asserts the old `.description()` string.

Docs + one help-string only — no behavior change.

https://claude.ai/code/session_0124GcUVvdaFPC4x5LVcvPWn