### PR TITLE
fix(core+plugin): PreconditionEvaluator $today + $todayStart canon = LOCAL day, not UTC (@req:ecb90c06) (#3811)

### DIFF
--- a/packages/core/src/services/CommandResolver.ts
+++ b/packages/core/src/services/CommandResolver.ts
@@ -9,6 +9,7 @@ import { GroundingType } from "../domain/constants/GroundingType";
 import { resolveGroundingTypeFromIRI } from "../domain/constants/GroundingTypeUIDs";
 import { utf8ToBase64 } from "../utilities/base64";
 import { iriToObsidianName } from "../utilities/iriToObsidianName";
+import { DateFormatter } from "../utilities/DateFormatter";
 import {
   COMMAND_VARIANT_VALUES,
   LABEL_CLASS_VALUES,
@@ -2480,7 +2481,14 @@ export class CommandResolver {
         return `${t.getFullYear()}-${pad(t.getMonth() + 1)}-${pad(t.getDate())}`;
       }
       case "todayStart":
-        return new Date(new Date().setHours(0, 0, 0, 0)).toISOString();
+        // #3811 — today's LOCAL day at midnight, timezone-naive
+        // `YYYY-MM-DDT00:00:00` (via `DateFormatter.getTodayStartTimestamp`),
+        // matching the executor `$todayStart` (`${today}T00:00:00`), the
+        // registry resolver, and the effort/timestamp frontmatter convention.
+        // The former `new Date(...setHours(0,0,0,0)).toISOString()` emitted a
+        // UTC Z-instant (`...T00:00:00.000Z`) — same instant, different string
+        // shape that disagreed with the executor form.
+        return DateFormatter.getTodayStartTimestamp();
       case "nowTimestamp":
         return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}:${pad(d.getSeconds())}`;
       case "nowDate":

--- a/packages/core/src/services/GroundingExecutor.ts
+++ b/packages/core/src/services/GroundingExecutor.ts
@@ -2004,7 +2004,10 @@ export class GroundingExecutor {
    * - $todayStart → today at local midnight (YYYY-MM-DDT00:00:00, no TZ) —
    *   matches `DateFormatter.getTodayStartTimestamp()`. A declarative
    *   `property_set` with `$todayStart` is byte-identical to the legacy
-   *   `planOnToday` service_call output (removed in Issue #3136).
+   *   `planOnToday` service_call output (removed in Issue #3136). #3811 aligned
+   *   the SubstitutionToken `$todayStart` (registry + CommandResolver parse-time)
+   *   to this same timezone-naive shape — the former Z-instant form
+   *   (`...T00:00:00.000Z`) is gone, so all three `$todayStart` paths agree.
    * - $targetFolder → parent folder (vault-relative) of the $target file.
    *   Resolves to empty string when target is at the vault root. Available
    *   only when callers pass `targetFilePath`; fail-fast otherwise.

--- a/packages/core/src/services/PreconditionEvaluator.ts
+++ b/packages/core/src/services/PreconditionEvaluator.ts
@@ -7,6 +7,7 @@ import { ExoQLAlgebraTranslator } from "../infrastructure/sparql/algebra/Algebra
 import { ExoQLQueryExecutor } from "../infrastructure/sparql/executors/QueryExecutor";
 import type { AskOperation } from "../infrastructure/sparql/algebra/AlgebraOperation";
 import { evaluateWithExoEval } from "../exoql/evaluateWithExoEval";
+import { DateFormatter } from "../utilities/DateFormatter";
 import type { IClock } from "./IClock";
 import { liveClock } from "./IClock";
 
@@ -246,70 +247,83 @@ export class PreconditionEvaluator {
   }
 
   /**
-   * Asia/Almaty UTC offset in milliseconds (UTC+5, no DST).
-   */
-  private static readonly ALMATY_OFFSET_MS = 5 * 60 * 60 * 1000;
-
-  /**
    * Substitute custom variables in SPARQL query string.
    * This is TEXT replacement, NOT SPARQL variable binding.
    *
    * Variables:
    * - $target → <targetIRI> (wrapped in angle brackets)
-   * - $now → "2026-03-31T10:00:00.000Z"^^xsd:dateTime
-   * - $today → "2026-03-31"^^xsd:date
-   * - $yesterday → "2026-03-30"^^xsd:date (Asia/Almaty)
-   * - $thisWeekStart → "2026-03-30"^^xsd:date (Monday, Asia/Almaty)
-   * - $lastWeekStart → "2026-03-23"^^xsd:date (prev Monday, Asia/Almaty)
-   * - $thisMonthStart → "2026-03-01"^^xsd:date (Asia/Almaty)
-   * - $lastMonthStart → "2026-02-01"^^xsd:date (Asia/Almaty)
-   * - $thisYearStart → "2026-01-01"^^xsd:date (Asia/Almaty)
+   * - $now → "2026-03-31T10:00:00.000Z"^^xsd:dateTime (UTC instant)
+   * - $today → "2026-03-31"^^xsd:date (LOCAL calendar day)
+   * - $yesterday → "2026-03-30"^^xsd:date (LOCAL)
+   * - $thisWeekStart → "2026-03-30"^^xsd:date (Monday, LOCAL)
+   * - $lastWeekStart → "2026-03-23"^^xsd:date (prev Monday, LOCAL)
+   * - $thisMonthStart → "2026-03-01"^^xsd:date (LOCAL)
+   * - $lastMonthStart → "2026-02-01"^^xsd:date (LOCAL)
+   * - $thisYearStart → "2026-01-01"^^xsd:date (LOCAL)
+   *
+   * All calendar-date tokens derive from ONE shared LOCAL wall-clock day
+   * (`DateFormatter.toDateString` / local `Date` getters + plain local
+   * `new Date(y, mo, d - N)` arithmetic), consistent with the rest of the
+   * `$today` family (#3806/#3808/#3809). `$now` stays a UTC `xsd:dateTime`
+   * instant — an instant is timezone-absolute.
+   *
+   * Formerly `$today` was sliced from `clock.now().toISOString()` (UTC) while
+   * its sibling tokens derived from a hardcoded `ALMATY_OFFSET_MS` local shift,
+   * so between local midnight and 05:00 Asia/Almaty `$today` equalled
+   * `$yesterday` (internally absurd) and any visibility precondition comparing
+   * an asset date against `$today` mis-fired at the boundary (#3811). Now every
+   * token shares one local basis — no hardcoded timezone, portable, and
+   * internally consistent.
    */
   substituteVariables(query: string, targetIRI: string): string {
-    const utcNow = this.clock.now();
-    const now = utcNow.toISOString();
-    const today = now.slice(0, 10);
+    const now = this.clock.now();
+    const nowIso = now.toISOString();
 
-    // Compute Almaty-local date components
-    const almatyNow = new Date(utcNow.getTime() + PreconditionEvaluator.ALMATY_OFFSET_MS);
-    const almatyYear = almatyNow.getUTCFullYear();
-    const almatyMonth = almatyNow.getUTCMonth(); // 0-based
-    const almatyDate = almatyNow.getUTCDate();
-    const almatyDay = almatyNow.getUTCDay(); // 0=Sun
+    // ONE local wall-clock day basis (system timezone) for every calendar-date
+    // token — no hardcoded offset. `DateFormatter.toDateString` and the
+    // `new Date(y, mo, d - N)` arithmetic below all read/write local components.
+    const year = now.getFullYear();
+    const month = now.getMonth(); // 0-based
+    const date = now.getDate();
+    const day = now.getDay(); // 0=Sun
+
+    // $today
+    const todayStr = DateFormatter.toDateString(now);
 
     // $yesterday
-    const yesterday = new Date(Date.UTC(almatyYear, almatyMonth, almatyDate - 1));
-    const yesterdayStr = yesterday.toISOString().slice(0, 10);
+    const yesterdayStr = DateFormatter.toDateString(new Date(year, month, date - 1));
 
     // $thisWeekStart (Monday of current week)
-    const daysFromMonday = (almatyDay + 6) % 7; // Mon=0, Tue=1, ..., Sun=6
-    const thisWeekStart = new Date(Date.UTC(almatyYear, almatyMonth, almatyDate - daysFromMonday));
-    const thisWeekStartStr = thisWeekStart.toISOString().slice(0, 10);
+    const daysFromMonday = (day + 6) % 7; // Mon=0, Tue=1, ..., Sun=6
+    const thisWeekStartStr = DateFormatter.toDateString(
+      new Date(year, month, date - daysFromMonday),
+    );
 
     // $lastWeekStart (Monday of previous week)
-    const lastWeekStart = new Date(thisWeekStart.getTime() - 7 * 24 * 60 * 60 * 1000);
-    const lastWeekStartStr = lastWeekStart.toISOString().slice(0, 10);
+    const lastWeekStartStr = DateFormatter.toDateString(
+      new Date(year, month, date - daysFromMonday - 7),
+    );
 
     // $thisMonthStart
-    const thisMonthStartStr = `${almatyYear}-${String(almatyMonth + 1).padStart(2, "0")}-01`;
+    const thisMonthStartStr = `${year}-${String(month + 1).padStart(2, "0")}-01`;
 
     // $lastMonthStart
-    const lastMonthIdx = almatyMonth === 0 ? 11 : almatyMonth - 1;
-    const lastMonthYear = almatyMonth === 0 ? almatyYear - 1 : almatyYear;
+    const lastMonthIdx = month === 0 ? 11 : month - 1;
+    const lastMonthYear = month === 0 ? year - 1 : year;
     const lastMonthStartStr = `${lastMonthYear}-${String(lastMonthIdx + 1).padStart(2, "0")}-01`;
 
     // $thisYearStart
-    const thisYearStartStr = `${almatyYear}-01-01`;
+    const thisYearStartStr = `${year}-01-01`;
 
     return query
       .replace(/\$target/g, `<${targetIRI}>`)
-      .replace(/\$now/g, `"${now}"^^xsd:dateTime`)
+      .replace(/\$now/g, `"${nowIso}"^^xsd:dateTime`)
       .replace(/\$yesterday/g, `"${yesterdayStr}"^^xsd:date`)
       .replace(/\$thisWeekStart/g, `"${thisWeekStartStr}"^^xsd:date`)
       .replace(/\$lastWeekStart/g, `"${lastWeekStartStr}"^^xsd:date`)
       .replace(/\$thisMonthStart/g, `"${thisMonthStartStr}"^^xsd:date`)
       .replace(/\$lastMonthStart/g, `"${lastMonthStartStr}"^^xsd:date`)
       .replace(/\$thisYearStart/g, `"${thisYearStartStr}"^^xsd:date`)
-      .replace(/\$today/g, `"${today}"^^xsd:date`);
+      .replace(/\$today/g, `"${todayStr}"^^xsd:date`);
   }
 }

--- a/packages/core/src/services/SubstitutionResolverRegistry.ts
+++ b/packages/core/src/services/SubstitutionResolverRegistry.ts
@@ -16,6 +16,8 @@
  * RFC 727572d2-194b-4a4d-8a5a-585a1d3bac8e.
  */
 
+import { DateFormatter } from "../utilities/DateFormatter";
+
 /**
  * Runtime context made available to resolver functions. Optional fields permit
  * use in test/CLI harnesses where some context (target frontmatter, grounding
@@ -356,9 +358,15 @@ export function installDefaultResolvers(): void {
     const d = new Date();
     return `${d.getFullYear()}-${pad2(d.getMonth() + 1)}-${pad2(d.getDate())}`;
   });
-  registerResolver("todayStart", () =>
-    new Date(new Date().setHours(0, 0, 0, 0)).toISOString(),
-  );
+  // #3811 — `todayStart` returns today's LOCAL day at midnight in the
+  // timezone-naive `YYYY-MM-DDT00:00:00` shape (via
+  // `DateFormatter.getTodayStartTimestamp`), matching the executor's
+  // `$todayStart` (`${today}T00:00:00`) and the effort/timestamp frontmatter
+  // convention. The former `new Date(...setHours(0,0,0,0)).toISOString()` form
+  // emitted a UTC Z-instant (`...T00:00:00.000Z`) — same instant, but a
+  // different string shape that disagreed with the executor form under
+  // lexicographic comparison. Now both `$todayStart` paths share one shape.
+  registerResolver("todayStart", () => DateFormatter.getTodayStartTimestamp());
 
   // -- Date format + offset tokens (Веха 5 — Templater `tp.date.*` parity) --
   // modifier-AWARE: the inline `$token<offset><:format>` suffix is consumed and

--- a/packages/core/tests/helpers/installFakeOffsetDate.ts
+++ b/packages/core/tests/helpers/installFakeOffsetDate.ts
@@ -28,6 +28,15 @@
  * }
  * ```
  *
+ * Limitation (#3811 review): only the LOCAL date/time GETTERS are shifted — the
+ * SETTERS (`setHours`/`setDate`/…), `getTimezoneOffset()`, and `Date`-arithmetic
+ * helpers that mix them (e.g. `DateFormatter.addDays`, `d.setHours(0,0,0,0)`)
+ * are NOT offset-aware and would read the runner's real zone under the fake. So
+ * construct dates via the multi-arg LOCAL constructor (`new Date(y, mo, d - N)`,
+ * interpreted in the simulated zone) and format with local getters
+ * (`DateFormatter.toDateString`) — avoid setter-based mutation inside the fake.
+ * If a suite needs `getTimezoneOffset()`-driven arithmetic, override it too.
+ *
  * @param offsetHours whole-hour offset east of UTC (Asia/Almaty = +5)
  * @param fixedIso    the UTC ISO instant that `new Date()` (no args) returns
  * @returns a restore function that reinstates the real global `Date`

--- a/packages/core/tests/integration/asset-creation/proto-time-propagation.test.ts
+++ b/packages/core/tests/integration/asset-creation/proto-time-propagation.test.ts
@@ -171,8 +171,10 @@ const GROUNDING: GroundingDefinition = {
   ],
 };
 
-// Frozen clock → deterministic "today" = 2026-06-28 (UTC date slice, matching
-// the $today token source). 08:00Z is mid-day Almaty, so no UTC date-edge.
+// Frozen clock → deterministic "today" = 2026-06-28. 12:00Z = 17:00 Asia/Almaty
+// (UTC+5), maximally clear of BOTH the local and the UTC midnight edges — max
+// tz-headroom so the now-local `$today` (DateFormatter.toDateString, #3809) and
+// the UTC date agree here regardless of the port runner's timezone (#3811).
 const FROZEN_TODAY = "2026-06-28";
 
 // ---------------------------------------------------------------------------
@@ -203,7 +205,7 @@ describe(`Integration: create_instance prototype-time propagation (ec15f83e) ${R
     await fs.createFile(PROTO_BAD_TIME_PATH, PROTO_BAD_TIME);
     const serviceRegistry = new ServiceRegistry();
     groundingExecutor = new GroundingExecutor(fs, fs, serviceRegistry, undefined, {
-      clock: frozenClock(`${FROZEN_TODAY}T08:00:00Z`),
+      clock: frozenClock(`${FROZEN_TODAY}T12:00:00Z`),
     });
   });
 

--- a/packages/core/tests/unit/services/CommandResolver.substitutionToken.test.ts
+++ b/packages/core/tests/unit/services/CommandResolver.substitutionToken.test.ts
@@ -164,6 +164,7 @@ const PROP_UID = "11111111-1111-4111-8111-111111111111";
 const TOKEN_TODAY_UID         = "22222222-2222-4222-8222-222222222222";
 const TOKEN_TARGET_FOLDER_UID = "33333333-3333-4333-8333-333333333333";
 const TOKEN_UNKNOWN_UID       = "44444444-4444-4444-8444-444444444444";
+const TOKEN_TODAY_START_UID   = "66666666-6666-4666-8666-666666666666";
 
 const PD_UID  = "55555555-5555-4555-8555-555555555555";
 
@@ -210,6 +211,40 @@ describe("CommandResolver — RFC v2 Phase 3a SubstitutionToken dispatch", () =>
     const value = cmd!.grounding.propertyDefault![0].value;
     // Clock-flake safe assertion — regex, not literal.
     expect(value).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    expect(logger.warnings).toHaveLength(0);
+  });
+
+  // #3811 — `$todayStart` canon: parse-time resolution emits the timezone-naive
+  // `YYYY-MM-DDT00:00:00` shape (via DateFormatter.getTodayStartTimestamp),
+  // matching the executor `$todayStart` (`${today}T00:00:00`) and the
+  // effort/timestamp frontmatter convention. Revert-verify: the former
+  // `new Date(...setHours(0,0,0,0)).toISOString()` emitted a UTC Z-instant
+  // (`...T00:00:00.000Z`) → fails this naive-local shape → RED.
+  it("resolves a `todayStart` SubstitutionToken at parse time to naive-local YYYY-MM-DDT00:00:00 (no Z, no millis) @req:ecb90c06-92af-41bd-bb81-1d4510e53fa3", async () => {
+    await addSubstitutionToken(store, {
+      uid: TOKEN_TODAY_START_UID,
+      label: "$todayStart",
+      resolverId: "todayStart",
+    });
+    await addPropertyDefault(store, {
+      uid: PD_UID,
+      propertyRefUid: PROP_UID,
+      valueRefUid: TOKEN_TODAY_START_UID,
+    });
+    await addGrounding(store, {
+      uid: GROUNDING_UID,
+      label: "Grounding with $todayStart PD",
+      propertyDefaultRefs: [PD_UID],
+    });
+    await addCommand(store, COMMAND_UID, GROUNDING_UID);
+
+    const cmd = await resolver.loadCommand(COMMAND_UID);
+
+    const value = cmd!.grounding.propertyDefault![0].value;
+    // Naive-local midnight — NOT the former UTC Z-instant `...T00:00:00.000Z`.
+    expect(value).toMatch(/^\d{4}-\d{2}-\d{2}T00:00:00$/);
+    expect(value).not.toContain("Z");
+    expect(value).not.toContain(".000");
     expect(logger.warnings).toHaveLength(0);
   });
 

--- a/packages/core/tests/unit/services/PreconditionEvaluator.todayLocalTz.test.ts
+++ b/packages/core/tests/unit/services/PreconditionEvaluator.todayLocalTz.test.ts
@@ -1,0 +1,114 @@
+/**
+ * `PreconditionEvaluator` `$today` local-timezone revert-verify (req ecb90c06 /
+ * #3811) — the 5th and final declared `$today` surface.
+ *
+ * `PreconditionEvaluator.substituteVariables` interpolates `$today` (and its
+ * sibling calendar-date tokens `$yesterday`/`$thisWeekStart`/…) into a
+ * visibility/availability precondition-SPARQL ASK. It formerly sliced
+ * `clock.now().toISOString()` (UTC) for `$today` while the sibling tokens
+ * derived from a hardcoded `ALMATY_OFFSET_MS` local shift — so between local
+ * midnight and 05:00 Asia/Almaty `$today` EQUALLED `$yesterday` (internally
+ * absurd) and any precondition comparing an asset date against `$today`
+ * mis-fired at the boundary. The fix derives every calendar-date token from ONE
+ * shared local `Date` basis (`DateFormatter.toDateString` / local getters),
+ * removing the hardcode.
+ *
+ * Revert-verify ([[integration-test-revert-verify]]): reverting `$today` to
+ * `clock.now().toISOString().slice(0, 10)` (and the siblings back on
+ * `ALMATY_OFFSET_MS`) makes `$today` resolve to "2026-07-02" (the UTC day, ==
+ * `$yesterday`) → RED; the shared-local form → GREEN ("2026-07-03").
+ *
+ * CI-robustness ([[jest-timezone-sensitive-tests]]): `process.env.TZ` cannot be
+ * re-tzset under jest (V8 caches the worker timezone), and the fix has NO
+ * observable effect in a UTC runner — so a `Date` subclass (shared
+ * `installFakeOffsetDate` helper) simulates a fixed UTC+5 (Asia/Almaty, no DST)
+ * offset at 2026-07-02T19:27:00Z = 2026-07-03T00:27 local (local day 03, UTC day
+ * 02), independent of the runner's real timezone. A guard proves the simulated
+ * tz is active so the assertion can never silently pass both ways.
+ *
+ * @req:ecb90c06-92af-41bd-bb81-1d4510e53fa3
+ */
+import { PreconditionEvaluator } from "../../../src/services/PreconditionEvaluator";
+import { InMemoryTripleStore } from "../../../src/infrastructure/rdf/InMemoryTripleStore";
+import { Triple } from "../../../src/domain/models/rdf/Triple";
+import { IRI } from "../../../src/domain/models/rdf/IRI";
+import { Literal } from "../../../src/domain/models/rdf/Literal";
+import { installFakeOffsetDate } from "../../helpers/installFakeOffsetDate";
+
+describe("PreconditionEvaluator $today = LOCAL calendar day (req ecb90c06 / #3811)", () => {
+  const ASSET_IRI = "https://exocortex.my/ontology/ems/test-asset-123";
+
+  it("substituteVariables interpolates $today as today's LOCAL day just after local midnight (UTC still previous day) and $today !== $yesterday @req:ecb90c06-92af-41bd-bb81-1d4510e53fa3", () => {
+    const restore = installFakeOffsetDate(5, "2026-07-02T19:27:00Z");
+    try {
+      // Guard: prove the simulated tz is active (else the assertions below would
+      // be vacuous in a UTC-tz runner and silently pass both ways — fail loud).
+      expect(new Date().getHours()).toBe(0); // 00:27 local (Almaty)
+      expect(new Date().getUTCDate()).toBe(2); // still July 2 in UTC
+
+      const evaluator = new PreconditionEvaluator(new InMemoryTripleStore());
+
+      // Local today = 2026-07-03; the former UTC form returned "2026-07-02".
+      const today = evaluator.substituteVariables("$today", ASSET_IRI);
+      expect(today).toBe(`"2026-07-03"^^xsd:date`);
+
+      // Sibling token — local yesterday = 2026-07-02.
+      const yesterday = evaluator.substituteVariables("$yesterday", ASSET_IRI);
+      expect(yesterday).toBe(`"2026-07-02"^^xsd:date`);
+
+      // The bug's absurdity: at the boundary the former UTC `$today` equalled
+      // `$yesterday`. The shared-local basis keeps them one local day apart.
+      expect(today).not.toBe(yesterday);
+    } finally {
+      restore();
+    }
+  });
+
+  it("evaluate (production-shape): a real precondition ASK comparing an asset xsd:date against $today matches TODAY's LOCAL day, NOT the UTC day, at the boundary @req:ecb90c06-92af-41bd-bb81-1d4510e53fa3", async () => {
+    const restore = installFakeOffsetDate(5, "2026-07-02T19:27:00Z");
+    try {
+      expect(new Date().getHours()).toBe(0); // 00:27 local — guard
+      expect(new Date().getUTCDate()).toBe(2); // still July 2 in UTC
+
+      // Precondition ASK: is the asset's planned date == $today? Runs the REAL
+      // substitute → parse → ASK evaluate pipeline through PreconditionEvaluator.
+      const precondition = {
+        id: "pre-planned-today",
+        label: "planned for today (local)",
+        sparqlAsk: `
+          PREFIX ems: <https://exocortex.my/ontology/ems#>
+          PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+          ASK {
+            <${ASSET_IRI}> ems:plannedDate ?d .
+            FILTER(?d = $today)
+          }
+        `,
+      };
+      const PLANNED = new IRI("https://exocortex.my/ontology/ems#plannedDate");
+      const XSD_DATE = new IRI("http://www.w3.org/2001/XMLSchema#date");
+
+      // Asset planned for TODAY's LOCAL day (2026-07-03) → the precondition
+      // matches. With the former UTC `$today` (= "2026-07-02") it would NOT.
+      const todayStore = new InMemoryTripleStore();
+      await todayStore.add(
+        new Triple(new IRI(ASSET_IRI), PLANNED, new Literal("2026-07-03", XSD_DATE)),
+      );
+      expect(
+        await new PreconditionEvaluator(todayStore).evaluate(precondition, ASSET_IRI),
+      ).toBe(true);
+
+      // Control (non-vacuity): asset planned for the UTC day (2026-07-02, which
+      // the bug's `$today` produced). The local `$today` (= "2026-07-03") must
+      // NOT match it — proving the ASK really discriminates on the date value.
+      const utcDayStore = new InMemoryTripleStore();
+      await utcDayStore.add(
+        new Triple(new IRI(ASSET_IRI), PLANNED, new Literal("2026-07-02", XSD_DATE)),
+      );
+      expect(
+        await new PreconditionEvaluator(utcDayStore).evaluate(precondition, ASSET_IRI),
+      ).toBe(false);
+    } finally {
+      restore();
+    }
+  });
+});

--- a/packages/core/tests/unit/services/SubstitutionResolverRegistry.test.ts
+++ b/packages/core/tests/unit/services/SubstitutionResolverRegistry.test.ts
@@ -53,6 +53,22 @@ describe("SubstitutionResolverRegistry — RFC 727572d2 Phase A2 vocabulary", ()
     );
   });
 
+  // #3811 — `$todayStart` canon: the registry resolver emits the timezone-naive
+  // `YYYY-MM-DDT00:00:00` shape (via DateFormatter.getTodayStartTimestamp),
+  // matching the executor `$todayStart` (`${today}T00:00:00`), the parse-time
+  // resolver, and the effort/timestamp frontmatter convention. Revert-verify:
+  // the former `new Date(...setHours(0,0,0,0)).toISOString()` emitted a UTC
+  // Z-instant (`...T00:00:00.000Z`) → fails this naive-local shape → RED.
+  describe("todayStart canon (#3811 — naive-local midnight, no Z)", () => {
+    it("resolves to YYYY-MM-DDT00:00:00 (no Z, no millis) @req:ecb90c06-92af-41bd-bb81-1d4510e53fa3", () => {
+      const fn = getResolver("todayStart")!;
+      const value = fn({} as ResolverContext) as string;
+      expect(value).toMatch(/^\d{4}-\d{2}-\d{2}T00:00:00$/);
+      expect(value).not.toContain("Z");
+      expect(value).not.toContain(".000");
+    });
+  });
+
   describe("targetClassSelf (T1 Create Instance — host IS the class)", () => {
     it("returns a quoted wikilink to the host file's own UID (basename)", () => {
       const fn = getResolver("targetClassSelf")!;

--- a/packages/obsidian-plugin/src/presentation/components/property-fields/DatePropertyField.ts
+++ b/packages/obsidian-plugin/src/presentation/components/property-fields/DatePropertyField.ts
@@ -1,4 +1,5 @@
 import { Setting } from "obsidian";
+import { DateFormatter } from "@kitelev/exocortex-core";
 import type { DatePropertyFieldProps, ValidationResult } from "./types";
 
 /**
@@ -100,7 +101,11 @@ export class DatePropertyField {
     try {
       const date = new Date(value);
       if (!isNaN(date.getTime())) {
-        return date.toISOString().split("T")[0];
+        // #3811 — derive the LOCAL calendar day (via DateFormatter.toDateString)
+        // so a near-midnight datetime value doesn't slide the date-input prefill
+        // to the previous UTC day in a UTC+N timezone. The former
+        // `toISOString().split("T")[0]` produced the UTC day.
+        return DateFormatter.toDateString(date);
       }
     } catch {
       // Fall through
@@ -191,13 +196,6 @@ export class DatePropertyField {
     if (this.inputEl) {
       this.inputEl.focus();
     }
-  }
-
-  /**
-   * Get today's date in ISO format.
-   */
-  static today(): string {
-    return new Date().toISOString().split("T")[0];
   }
 
   /**

--- a/packages/obsidian-plugin/tests/unit/property-fields/DatePropertyField.test.ts
+++ b/packages/obsidian-plugin/tests/unit/property-fields/DatePropertyField.test.ts
@@ -227,13 +227,6 @@ describe("DatePropertyField", () => {
     });
   });
 
-  describe("static methods", () => {
-    it("should return today's date", () => {
-      const today = DatePropertyField.today();
-      expect(today).toMatch(/^\d{4}-\d{2}-\d{2}$/);
-    });
-  });
-
   describe("destroy", () => {
     it("should remove the setting element", () => {
       const field = new DatePropertyField(containerEl, {


### PR DESCRIPTION
Closes #3811. Follow-up to #3809 (PR #3810) / #3807 (#3808) / #3806 — the **5th and final** `$today` surface. `@req:ecb90c06-92af-41bd-bb81-1d4510e53fa3` (req-first SDD).

## What
1. **[MED] `PreconditionEvaluator.substituteVariables`** — `$today` was `clock.now().toISOString().slice(0,10)` (UTC) while its sibling calendar tokens (`$yesterday`/`$thisWeekStart`/`$lastWeekStart`/`$thisMonthStart`/`$lastMonthStart`/`$thisYearStart`) derived from a hardcoded `ALMATY_OFFSET_MS` local shift. Between local midnight and 05:00 Almaty `$today` **equalled** `$yesterday` → visibility/availability preconditions mis-fired at the boundary. The whole method now derives every calendar-date token from **one local `Date` basis** (`DateFormatter.toDateString` + local getters + `new Date(y,mo,d-N)` arithmetic); the `ALMATY_OFFSET_MS` hardcode is gone. `$now` stays a UTC `xsd:dateTime` instant (an instant is timezone-absolute).
2. **[LOW] `$todayStart` shape-split canon** — the registry + `CommandResolver` parse-time resolvers emitted a UTC Z-instant (`...T00:00:00.000Z`); the executor emitted naive-local (`...T00:00:00`). All three now use `DateFormatter.getTodayStartTimestamp()` (naive-local), matching the effort/timestamp frontmatter convention.
3. **[LOW] `DatePropertyField`** — dead `static today()` removed (no callers); the parse-fallback (`:103`) routes through local `DateFormatter.toDateString` instead of `toISOString().split("T")[0]` (UTC).
4. **[LOW-opt] test hardening** — `proto-time-propagation` frozen instant `08:00Z`→`12:00Z` (max tz-headroom).

**Sweep:** `grep -rn 'toISOString().slice(0, 10)\|toISOString().split("T")' packages/*/src` → only comments remain (legit `$now`/SPARQL Z-instants untouched).

## Verify (req-first SDD)
- **Revert-verify RED/GREEN** via the shared `installFakeOffsetDate` helper (UTC+5 @ `2026-07-02T19:27Z` = 00:27 local, local day 03 / UTC day 02; CI-robust per [[jest-timezone-sensitive-tests]], guarded fail-loud):
  - `PreconditionEvaluator.todayLocalTz.test.ts` — boundary string test (`$today`="2026-07-03", `$today !== $yesterday`) + **production-shape `evaluate()`** ASK (`FILTER(?d = $today)` against a typed `xsd:date` asset triple; MATCH local-today / NON-MATCH UTC-day control). Both go RED with `$today` reverted to the UTC slice.
  - `$todayStart` naive-local shape locks in `SubstitutionResolverRegistry.test.ts` + `CommandResolver.substitutionToken.test.ts` (RED on the Z-instant form).
- **Double gate (built dist):** compiled `packages/core/dist` `PreconditionEvaluator` with a frozen clock @ the boundary yields `$today="2026-07-03"` (LOCAL), `$yesterday="2026-07-02"`, `$thisWeekStart="2026-06-29"`.
- typecheck clean; 3 CI lint-job guards (test-antipatterns ratchet 55/55, shard-assignments, coverage-monotonic) + eslint `--max-warnings=0` clean.

Desktop↔Mobile parity preserved (no `Platform` gating; plain local `Date` arithmetic). Requirement `ecb90c06` pushed to `exoas-exo-reqs` main (status Proposed → Active after merge).
