### PR TITLE
docs(core): use @kitelev/exocortex-core package name in README

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,4 +1,4 @@
-# exocortex
+# @kitelev/exocortex-core
 
 Core engine of the Exocortex knowledge management system: RDF triple store, SPARQL/ExoQL query engine, SHACL-lite validation, vault-declared (homoiconic) commands, GitHub-backed sync, and AssetSpace/profile machinery — all in platform-agnostic TypeScript with **zero Obsidian dependency**.
 
@@ -6,7 +6,7 @@ Platform specifics (Obsidian API, Node `fs`, network transports) are injected th
 
 ## Installation
 
-This is a workspace package of the [exocortex monorepo](../../README.md). It is consumed in-repo by the other packages (`"exocortex": "*"` / `file:../core`), not installed standalone:
+This is a workspace package of the [exocortex monorepo](../../README.md). It is consumed in-repo by the other packages (`"@kitelev/exocortex-core": "*"` / `file:../core`), not installed standalone:
 
 ```bash
 # From the monorepo root


### PR DESCRIPTION
## What
`packages/core/README.md` still referenced the pre-M5a package name `exocortex` in two spots. The package was renamed `exocortex` → `@kitelev/exocortex-core` (M5a rename: `packages/exocortex` → `packages/core`), and every consumer now depends on `@kitelev/exocortex-core` (grep confirms no package declares a bare `exocortex` dependency).

## Changes
- H1 title: `# exocortex` → `# @kitelev/exocortex-core`
- Dependency example: `"exocortex": "*"` → `"@kitelev/exocortex-core": "*"`

## Verification
- Consumers (cli, obsidian-plugin, services) all reference `@kitelev/exocortex-core`; `git grep '"exocortex":' packages/*/package.json` returns nothing.
- Rest of the core README (subsystems table, consumer table, Development) already current.
- prettier clean (baseline clean → only the 2 spots), `archgate check --staged` pass (0 errors).

Docs-only; core is a workspace-internal package (not npm-published). Part of the CLI/monorepo doc-consistency audit (follow-up to #3812/#3814).

https://claude.ai/code/session_0124GcUVvdaFPC4x5LVcvPWn