### PR TITLE
docs: packages/exocortex → packages/core in CLAUDE.md Monorepo Structure tree (M5a)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,7 @@
 
 ```
 packages/
-├── exocortex/          # exocortex — core: domain models, RDF, SPARQL, services
+├── core/               # @kitelev/exocortex-core — domain models, RDF, SPARQL, services
 ├── obsidian-plugin/    # @kitelev/exocortex-obsidian-plugin — UI, renderers, commands (consumer)
 ├── cli/                # @kitelev/exocortex-cli — CLI tooling (consumer)
 ├── services/           # @kitelev/exocortex-services — shared grounding-service factories


### PR DESCRIPTION
## What
The in-repo `CLAUDE.md` **Monorepo Structure** tree still listed the pre-M5a `exocortex/` package dir, while the rest of the file (Notable subsystems, Auto-merge discipline, etc.) already references `packages/core/`. The core package dir was renamed `packages/exocortex` → `packages/core` (M5a; package `@kitelev/exocortex-core`).

## Change
- Tree entry `├── exocortex/  # exocortex — core: …` → `├── core/  # @kitelev/exocortex-core — …` (name style now matches the sibling entries).

## Verification
- All consumers reference `@kitelev/exocortex-core`; `packages/core/` is the actual dir on `main`.
- prettier clean (baseline clean → only the 1 line), `archgate check --staged` pass (0 errors).

Docs-only. Companion: the coordination-hub `exocortex-development/CLAUDE.md` (a dotfiles symlink) had the same stale ref fixed separately. Part of the monorepo doc-consistency audit (follows #3812/#3814/#3815).

https://claude.ai/code/session_0124GcUVvdaFPC4x5LVcvPWn