### PR TITLE
fix(core): word-boundary-anchor PreconditionEvaluator token substitution + DatePropertyField tz test (#3811 LOW-hardening)

### DIFF
--- a/packages/core/src/services/PreconditionEvaluator.ts
+++ b/packages/core/src/services/PreconditionEvaluator.ts
@@ -261,14 +261,17 @@ export class PreconditionEvaluator {
    * - $lastMonthStart → "2026-02-01"^^xsd:date (LOCAL)
    * - $thisYearStart → "2026-01-01"^^xsd:date (LOCAL)
    *
-   * The list above is the COMPLETE set of supported tokens. Each is matched with
-   * a trailing `\b` word boundary, so an unrecognized `$token` that merely shares
-   * a prefix with a supported one (e.g. `$todayStart` — an executor /
-   * SubstitutionToken form, NOT a precondition token) is left LITERAL rather than
-   * partially rewritten into malformed SPARQL (`"…"^^xsd:dateStart`). The SPARQL
-   * parser then rejects the unknown `$todayStart` loudly — better than a silent
-   * mangle (#3811 review). `$target` is exempt (an IRI substitution delimited by
-   * property-path chars, not a calendar token).
+   * The list above is the COMPLETE set of supported tokens. EVERY token (including
+   * `$target`) is matched with a trailing `\b` word boundary, so an unrecognized
+   * `$token` that merely shares a prefix with a supported one is left LITERAL
+   * rather than partially rewritten into malformed SPARQL. Examples of real
+   * prefix-colliding tokens (all executor / SubstitutionToken forms, NOT
+   * precondition tokens): `$todayStart` (else → `"…"^^xsd:dateStart`),
+   * `$nowCompact`/`$nowLocal`, and `$targetFolder`/`$targetStart`/`$targetClassSelf`
+   * (else `$target` → `<IRI>Folder`). Left literal, the unknown token fails to
+   * compile and the precondition FAILS CLOSED (evaluateSparqlAsk's bare catch →
+   * `false` → command hidden) — a predictable, safe outcome, unlike a
+   * silently-mangled query that could return the wrong ASK boolean (#3811 review).
    *
    * All calendar-date tokens derive from ONE shared LOCAL wall-clock day
    * (`DateFormatter.toDateString` / local `Date` getters + plain local
@@ -324,19 +327,24 @@ export class PreconditionEvaluator {
     // $thisYearStart
     const thisYearStartStr = `${year}-01-01`;
 
-    // Each token regex is anchored with a trailing `\b` word boundary so an
+    // EVERY token regex is anchored with a trailing `\b` word boundary so an
     // unrecognized `$token` that merely SHARES A PREFIX with a supported one is
     // left literal rather than partially rewritten into malformed SPARQL. Without
     // `\b`, a `sparqlAsk` containing `$todayStart` (an executor/SubstitutionToken
     // form, not a precondition token) would have its `$today` prefix replaced →
-    // `"YYYY-MM-DD"^^xsd:dateStart` (mangled). With `\b` it stays `$todayStart`
-    // (an unknown token the SPARQL parser rejects loudly) — better than silently
-    // wrong (#3811 review). `$now\b`/`$yesterday\b`/… likewise won't clobber
-    // `$nowCompact`/`$nowLocal` etc. `$target` keeps no `\b` — it is an IRI
-    // substitution routinely followed by SPARQL property-path chars (`/`, `.`,
-    // `)`) which already delimit it, and a trailing `\b` there is redundant.
+    // `"YYYY-MM-DD"^^xsd:dateStart` (mangled). With `\b` it stays `$todayStart` —
+    // an unknown token the SPARQL compiler can't parse, so the precondition FAILS
+    // CLOSED (evaluateSparqlAsk's bare catch → `false` → command hidden): a
+    // predictable, safe outcome, unlike a silently-mangled query that could return
+    // the WRONG ASK boolean (#3811 review). `$now\b`/`$yesterday\b`/… likewise won't clobber
+    // `$nowCompact`/`$nowLocal`. `$target\b` is anchored for the SAME reason:
+    // real grounding-only tokens share its prefix (`$targetFolder`, `$targetStart`,
+    // `$targetClassSelf` — GroundingExecutor tokens, NOT precondition tokens), so
+    // an unanchored `$target` would mangle e.g. `$targetFolder` → `<IRI>Folder`.
+    // `\b` still matches every valid precondition `$target` (always delimited by
+    // whitespace or property-path chars `/` `.` `)` `,` `<` `]` — all non-word).
     return query
-      .replace(/\$target/g, `<${targetIRI}>`)
+      .replace(/\$target\b/g, `<${targetIRI}>`)
       .replace(/\$now\b/g, `"${nowIso}"^^xsd:dateTime`)
       .replace(/\$yesterday\b/g, `"${yesterdayStr}"^^xsd:date`)
       .replace(/\$thisWeekStart\b/g, `"${thisWeekStartStr}"^^xsd:date`)

--- a/packages/core/src/services/PreconditionEvaluator.ts
+++ b/packages/core/src/services/PreconditionEvaluator.ts
@@ -261,6 +261,15 @@ export class PreconditionEvaluator {
    * - $lastMonthStart → "2026-02-01"^^xsd:date (LOCAL)
    * - $thisYearStart → "2026-01-01"^^xsd:date (LOCAL)
    *
+   * The list above is the COMPLETE set of supported tokens. Each is matched with
+   * a trailing `\b` word boundary, so an unrecognized `$token` that merely shares
+   * a prefix with a supported one (e.g. `$todayStart` — an executor /
+   * SubstitutionToken form, NOT a precondition token) is left LITERAL rather than
+   * partially rewritten into malformed SPARQL (`"…"^^xsd:dateStart`). The SPARQL
+   * parser then rejects the unknown `$todayStart` loudly — better than a silent
+   * mangle (#3811 review). `$target` is exempt (an IRI substitution delimited by
+   * property-path chars, not a calendar token).
+   *
    * All calendar-date tokens derive from ONE shared LOCAL wall-clock day
    * (`DateFormatter.toDateString` / local `Date` getters + plain local
    * `new Date(y, mo, d - N)` arithmetic), consistent with the rest of the
@@ -315,15 +324,26 @@ export class PreconditionEvaluator {
     // $thisYearStart
     const thisYearStartStr = `${year}-01-01`;
 
+    // Each token regex is anchored with a trailing `\b` word boundary so an
+    // unrecognized `$token` that merely SHARES A PREFIX with a supported one is
+    // left literal rather than partially rewritten into malformed SPARQL. Without
+    // `\b`, a `sparqlAsk` containing `$todayStart` (an executor/SubstitutionToken
+    // form, not a precondition token) would have its `$today` prefix replaced →
+    // `"YYYY-MM-DD"^^xsd:dateStart` (mangled). With `\b` it stays `$todayStart`
+    // (an unknown token the SPARQL parser rejects loudly) — better than silently
+    // wrong (#3811 review). `$now\b`/`$yesterday\b`/… likewise won't clobber
+    // `$nowCompact`/`$nowLocal` etc. `$target` keeps no `\b` — it is an IRI
+    // substitution routinely followed by SPARQL property-path chars (`/`, `.`,
+    // `)`) which already delimit it, and a trailing `\b` there is redundant.
     return query
       .replace(/\$target/g, `<${targetIRI}>`)
-      .replace(/\$now/g, `"${nowIso}"^^xsd:dateTime`)
-      .replace(/\$yesterday/g, `"${yesterdayStr}"^^xsd:date`)
-      .replace(/\$thisWeekStart/g, `"${thisWeekStartStr}"^^xsd:date`)
-      .replace(/\$lastWeekStart/g, `"${lastWeekStartStr}"^^xsd:date`)
-      .replace(/\$thisMonthStart/g, `"${thisMonthStartStr}"^^xsd:date`)
-      .replace(/\$lastMonthStart/g, `"${lastMonthStartStr}"^^xsd:date`)
-      .replace(/\$thisYearStart/g, `"${thisYearStartStr}"^^xsd:date`)
-      .replace(/\$today/g, `"${todayStr}"^^xsd:date`);
+      .replace(/\$now\b/g, `"${nowIso}"^^xsd:dateTime`)
+      .replace(/\$yesterday\b/g, `"${yesterdayStr}"^^xsd:date`)
+      .replace(/\$thisWeekStart\b/g, `"${thisWeekStartStr}"^^xsd:date`)
+      .replace(/\$lastWeekStart\b/g, `"${lastWeekStartStr}"^^xsd:date`)
+      .replace(/\$thisMonthStart\b/g, `"${thisMonthStartStr}"^^xsd:date`)
+      .replace(/\$lastMonthStart\b/g, `"${lastMonthStartStr}"^^xsd:date`)
+      .replace(/\$thisYearStart\b/g, `"${thisYearStartStr}"^^xsd:date`)
+      .replace(/\$today\b/g, `"${todayStr}"^^xsd:date`);
   }
 }

--- a/packages/core/tests/unit/services/PreconditionEvaluator.tokenWordBoundary.test.ts
+++ b/packages/core/tests/unit/services/PreconditionEvaluator.tokenWordBoundary.test.ts
@@ -1,0 +1,69 @@
+/**
+ * `PreconditionEvaluator.substituteVariables` word-boundary token substitution
+ * (req 9bff6eb9 / #3811 review LOW #1).
+ *
+ * The method text-substitutes calendar-date tokens (`$today`, `$now`,
+ * `$yesterday`, …) into a precondition-SPARQL ASK. The token regexes were
+ * formerly unanchored (`.replace(/\$today/g, …)`), so a `sparqlAsk` containing
+ * `$todayStart` (an executor / SubstitutionToken form, NOT a documented
+ * precondition token) had its `$today` prefix replaced → `"YYYY-MM-DD"^^xsd:date`
+ * + a stray `Start` = `"…"^^xsd:dateStart` (a malformed, silently-wrong literal).
+ *
+ * The fix anchors every calendar-date token regex with a trailing `\b` word
+ * boundary (matching the `GroundingExecutor` `/\$todayStart\b/` convention), so
+ * an unknown token whose name merely shares a prefix with a supported one is left
+ * LITERAL — the SPARQL parser then rejects it loudly (fail-loud) rather than
+ * substituting a mangled datatype.
+ *
+ * Revert-verify ([[integration-test-revert-verify]]): removing the `\b` from
+ * `/\$today\b/g` makes `substituteVariables("$todayStart")` return a mangled
+ * `"…"^^xsd:dateStart` (≠ `"$todayStart"`) → RED; restored with `\b` → GREEN. The
+ * assertion compares against the literal unchanged token, so it is
+ * date-independent (no fake clock needed).
+ *
+ * @req:9bff6eb9-c8c2-4931-a93d-331334fc6e15
+ */
+import { PreconditionEvaluator } from "../../../src/services/PreconditionEvaluator";
+import { InMemoryTripleStore } from "../../../src/infrastructure/rdf/InMemoryTripleStore";
+
+describe("PreconditionEvaluator token substitution is word-boundary-anchored (req 9bff6eb9 / #3811 LOW #1)", () => {
+  const ASSET_IRI = "https://exocortex.my/ontology/ems/test-asset-123";
+  const evaluator = new PreconditionEvaluator(new InMemoryTripleStore());
+
+  it("leaves an unknown $token that shares a prefix with a supported one LITERAL (no partial rewrite) @req:9bff6eb9-c8c2-4931-a93d-331334fc6e15", () => {
+    // `$todayStart` shares the `$today` prefix. Without the `\b` boundary the
+    // `$today` regex clobbers the prefix → `"YYYY-MM-DD"^^xsd:dateStart` (mangled).
+    // With `\b` the whole token is left verbatim (an unknown token the SPARQL
+    // parser rejects loudly).
+    const todayStart = evaluator.substituteVariables("$todayStart", ASSET_IRI);
+    expect(todayStart).toBe("$todayStart");
+    // Guard the exact mangle the revert produces (`"…"^^xsd:dateStart`) — defeats
+    // a false-GREEN where the token vanished/substituted for some other reason.
+    expect(todayStart).not.toContain("^^xsd:date");
+
+    // Same class of collision for the `$now` prefix (`$nowCompact` / `$nowLocal`
+    // are executor tokens, not precondition tokens) — the sweep covers every
+    // calendar-date regex, not just `$today`.
+    expect(evaluator.substituteVariables("$nowCompact", ASSET_IRI)).toBe("$nowCompact");
+    expect(evaluator.substituteVariables("$nowLocal", ASSET_IRI)).toBe("$nowLocal");
+  });
+
+  it("still substitutes every VALID token (word boundary is not a regression) @req:9bff6eb9-c8c2-4931-a93d-331334fc6e15", () => {
+    // A standalone valid token, and one embedded in a real ASK, both substitute.
+    const today = evaluator.substituteVariables("$today", ASSET_IRI);
+    expect(today).toMatch(/^"\d{4}-\d{2}-\d{2}"\^\^xsd:date$/);
+    expect(today).not.toContain("$today");
+
+    const now = evaluator.substituteVariables("$now", ASSET_IRI);
+    expect(now).toMatch(/\^\^xsd:dateTime$/);
+
+    const ask = evaluator.substituteVariables(
+      "ASK { $target ems:plannedDate ?d . FILTER(?d = $today && ?d >= $thisWeekStart) }",
+      ASSET_IRI,
+    );
+    expect(ask).toContain(`<${ASSET_IRI}>`); // $target → IRI
+    expect(ask).not.toContain("$today");
+    expect(ask).not.toContain("$thisWeekStart");
+    expect(ask).toContain("^^xsd:date"); // both date tokens materialised
+  });
+});

--- a/packages/core/tests/unit/services/PreconditionEvaluator.tokenWordBoundary.test.ts
+++ b/packages/core/tests/unit/services/PreconditionEvaluator.tokenWordBoundary.test.ts
@@ -46,6 +46,15 @@ describe("PreconditionEvaluator token substitution is word-boundary-anchored (re
     // calendar-date regex, not just `$today`.
     expect(evaluator.substituteVariables("$nowCompact", ASSET_IRI)).toBe("$nowCompact");
     expect(evaluator.substituteVariables("$nowLocal", ASSET_IRI)).toBe("$nowLocal");
+
+    // And the `$target` prefix: real grounding-only tokens `$targetFolder` /
+    // `$targetStart` / `$targetClassSelf` must NOT be clobbered to `<IRI>Folder`
+    // etc. by the `$target` → IRI substitution (they are not precondition tokens).
+    expect(evaluator.substituteVariables("$targetFolder", ASSET_IRI)).toBe("$targetFolder");
+    expect(evaluator.substituteVariables("$targetStart", ASSET_IRI)).toBe("$targetStart");
+    expect(evaluator.substituteVariables("$targetClassSelf", ASSET_IRI)).toBe(
+      "$targetClassSelf",
+    );
   });
 
   it("still substitutes every VALID token (word boundary is not a regression) @req:9bff6eb9-c8c2-4931-a93d-331334fc6e15", () => {

--- a/packages/obsidian-plugin/tests/unit/property-fields/DatePropertyField.test.ts
+++ b/packages/obsidian-plugin/tests/unit/property-fields/DatePropertyField.test.ts
@@ -1,5 +1,10 @@
 import { PropertyFieldType } from "@kitelev/exocortex-core";
 import { DatePropertyField } from "../../../src/presentation/components/property-fields/DatePropertyField";
+// Cross-package import of the shared CI-robust Date-subclass helper (precedent:
+// DynamicForm.test.tsx after #3810). Locks the DatePropertyField parse-fallback
+// branch (#3810 / #3811 LOW #2): a non-YYYY-MM-DD(T) datetime value routed
+// through `new Date()` → `DateFormatter.toDateString` must yield the LOCAL day.
+import { installFakeOffsetDate } from "../../../../core/tests/helpers/installFakeOffsetDate";
 
 // Helper to extend HTMLElement with Obsidian's methods
 function extendElement(el: HTMLElement): HTMLElement {
@@ -224,6 +229,46 @@ describe("DatePropertyField", () => {
       field.setValue("2024-12-31");
       const input = containerEl.querySelector("input") as HTMLInputElement | null;
       expect(input!.value).toBe("2024-12-31");
+    });
+  });
+
+  describe("parse-fallback branch — LOCAL calendar day at the UTC boundary (#3810 / #3811 LOW #2)", () => {
+    // A datetime `value` that is neither plain `YYYY-MM-DD` nor `YYYY-MM-DDT…`
+    // reaches the `new Date(value)` fallback (DatePropertyField.parseToDateInputValue
+    // :100-108), which #3810 routed through `DateFormatter.toDateString` (local)
+    // instead of the former `toISOString().split("T")[0]` (UTC). At an instant
+    // just after LOCAL midnight in a UTC+N timezone the two disagree by a day.
+    // CI-robust via the shared `installFakeOffsetDate` Date-subclass — a UTC
+    // runner sees local === UTC, so a plain test would pass both ways.
+    it("routes a near-UTC-midnight datetime value to TODAY's LOCAL day, not the UTC previous day", () => {
+      // 2026-07-02T19:27:00Z = 2026-07-03T00:27 local (Almaty, UTC+5): local day 03, UTC day 02.
+      const restore = installFakeOffsetDate(5, "2026-07-02T19:27:00Z");
+      try {
+        // Guard: prove the simulated tz is active (else the assertion is vacuous
+        // in a UTC-tz runner and silently passes both ways — fail loud).
+        expect(new Date().getHours()).toBe(0); // 00:27 local
+        expect(new Date().getUTCDate()).toBe(2); // still July 2 in UTC
+
+        // A space-separated UTC datetime — not YYYY-MM-DD, not YYYY-MM-DDT… — so
+        // it falls through to the `new Date()` + toDateString branch.
+        new DatePropertyField(containerEl, {
+          property: {
+            uri: "exo:dueDate",
+            name: "exo__Asset_dueDate",
+            label: "Due Date",
+            fieldType: PropertyFieldType.Date,
+          },
+          value: "2026-07-02 19:27:00Z",
+          onChange: jest.fn(),
+        });
+
+        const input = containerEl.querySelector("input") as HTMLInputElement | null;
+        // LOCAL day = 2026-07-03. The former UTC `.split("T")[0]` produced "2026-07-02".
+        expect(input!.value).toBe("2026-07-03");
+        expect(input!.value).not.toBe("2026-07-02");
+      } finally {
+        restore();
+      }
     });
   });
 


### PR DESCRIPTION
## Summary

LOW-hardening follow-up to the **date-tz family** (#3806 → #3808 → #3810 → #3811/#3813, v16.170.5). Closes the 3 optional-LOW findings preserved in the [#3811 review comment](https://github.com/kitelev/exocortex/issues/3811#issuecomment) (PDD-lossless). **Not** `Closes` — #3811 is already closed; this is a hardening PR that finishes the trace.

## The 3 LOW findings

### 1. [behavioral] `PreconditionEvaluator` token substitution lacked a word boundary — **fixed**
`PreconditionEvaluator.substituteVariables` text-substitutes calendar-date tokens (`$today`, `$now`, `$yesterday`, …) into a precondition-SPARQL ASK. The token regexes were unanchored (`.replace(/\$today/g, …)`), so a `sparqlAsk` containing **`$todayStart`** (an executor / SubstitutionToken form, **not** a documented precondition token) had its `$today` prefix replaced → `"YYYY-MM-DD"^^xsd:dateStart` — a **mangled, silently-wrong** literal.

**Fix:** anchor each of the 8 calendar-date token regexes with a trailing `\b` word boundary (matching the `GroundingExecutor` `/\$todayStart\b/` convention). An unknown token that merely shares a prefix (`$todayStart`, `$nowCompact`, `$nowLocal`) is now left **literal** → the SPARQL parser rejects it **loudly** (fail-loud) instead of substituting a malformed datatype. `$target` stays exempt (an IRI substitution routinely followed by property-path chars `/` `.` `)` that already delimit it). **Every valid token substitutes byte-identically** — the change only affects prefix-colliding unknown tokens. The supported-token set + this behaviour are documented in the method JSDoc.

- Requirement: `9bff6eb9-c8c2-4931-a93d-331334fc6e15` (proposed → active on merge), `req__RequirementBindingClassUnit`, P3.
- Revert-verify ([[integration-test-revert-verify]]): removing `\b` makes `substituteVariables("$todayStart")` return a mangled `"…"^^xsd:dateStart` → **RED**; restored → **GREEN** (`PreconditionEvaluator.tokenWordBoundary.test.ts`, `@req:9bff6eb9-…`). Date-independent assertion (no fake clock needed).

### 2. [test-only] `DatePropertyField` parse-fallback branch — **test added**
The `:100-108` `new Date(value)` → `DateFormatter.toDateString` (local) branch that #3810 introduced had no dedicated test. Added one (appended to the existing `DatePropertyField.test.ts`) via the **shared `installFakeOffsetDate` helper** (cross-package import from `packages/core/tests/helpers`, precedent: `DynamicForm.test.tsx` after #3810): a near-UTC-midnight datetime value routed through the fallback resolves to **today's LOCAL day**, not the UTC previous day. Revert-verified RED (reverting `:108` to the pre-#3810 `toISOString().split("T")[0]` UTC form) / GREEN. CI-robust — a UTC runner sees local === UTC, so a plain test would pass both ways ([[jest-timezone-sensitive-tests]]).

### 3. [doc-only] `installFakeOffsetDate` setter/`getTimezoneOffset()` limitation — **already done**
Verified against fresh origin/main: `installFakeOffsetDate.ts:31-38` already documents this limitation (shipped in **#3813** `63f4d09`). **No change needed** (overtaken-by-events — verify-before-assert).

## Verification (local, before push)

- ✅ `check:types` clean
- ✅ affected suites: core `PreconditionEvaluator` (3 suites, 51 tests) + integration `dynamic-commands` (7 suites, 66 tests, submodule checked out) + plugin `DatePropertyField` (10 tests)
- ✅ 3 CI-guard scripts: `validate-shard-assignments`, `check-test-antipatterns` (ratchet 55/55, no new anti-patterns — behaviour assertions), `check-coverage-monotonic`
- ✅ `eslint` clean on changed src; `npm run lint` exit 0
- ✅ Both fixes revert-verified RED→GREEN

## Scope

Confined to `PreconditionEvaluator.substituteVariables` (source) + 2 test files. No production change to `DatePropertyField.ts` or the helper.

---

## Review LOWs folded in (post-verdict, same PR)

- **LOW #1 — `$target` also needs `\b`.** Independently caught the same collision: real grounding-only tokens `$targetFolder` / `$targetStart` / `$targetClassSelf` share the `$target` prefix, so an unanchored `$target` mangled e.g. `$targetFolder` → `<IRI>Folder`. Anchored `/\$target\b/g` (strictly better — every valid precondition `$target` is delimited by whitespace or property-path chars, all non-word, so `\b` matches identically; 51 precond + 66 integration tests confirm no regression). Added `$targetClassSelf`/`$targetFolder`/`$targetStart` boundary-test cases (revert-verified RED). Corrected the "redundant" comment.
- **LOW #2 — fail-closed wording.** An unknown literal token does **not** "get rejected loudly": `evaluateSparqlAsk`'s bare `catch { return false }` fails **closed silently** (precondition = false → command hidden). Corrected the JSDoc + inline comment to say so — a predictable/safe outcome vs a mangled query returning the wrong ASK boolean.

## Known pre-existing (out of scope — reviewer note, follow-up candidate)

`PreconditionEvaluator.askCache` caches the **compiled** ASK operation keyed by the raw `sparqlAsk` string, with `$today`/`$now` already substituted (frozen). A cached compiled ASK survives past local midnight until `invalidateCache()` is called, so a `$today`-comparing precondition can evaluate against a stale calendar day between midnight and the next cache invalidation. This is **pre-existing** (not introduced or touched by this PR) and out of scope here — a follow-up candidate.
