### PR TITLE
fix(core): date-aware PreconditionEvaluator askCache key — $today no longer freezes across local midnight (#3819)

### DIFF
--- a/packages/core/src/services/PreconditionEvaluator.ts
+++ b/packages/core/src/services/PreconditionEvaluator.ts
@@ -173,6 +173,45 @@ export class PreconditionEvaluator {
 
   private static readonly SENTINEL_IRI = "urn:exocortex:cache-sentinel:target";
 
+  /**
+   * Calendar/temporal tokens whose substituted value (see
+   * {@link substituteVariables}) changes with the local calendar day. When a
+   * `sparqlAsk` contains any of these, the compiled-ASK cache entry must NOT
+   * survive across local midnight — so {@link askCacheKey} folds the local day
+   * into the cache key for such queries.
+   *
+   * `$today`/`$yesterday`/`$this*Start`/`$last*Start` are exactly the date
+   * tokens rewritten by `substituteVariables`. `$now` is included deliberately:
+   * folding it into a *day*-granular key is more honest than freezing its
+   * instant forever (the prior behaviour of a raw-text key). Residual sub-day
+   * staleness — the `$now` value stays frozen to the first-compile instant
+   * *within* one local day — is intended: precondition availability granularity
+   * is the day, not the minute. (`$target` is excluded — it is re-instantiated
+   * per evaluation from the SENTINEL and never baked into a date value.)
+   */
+  private static readonly TEMPORAL_TOKEN =
+    /\$(?:now|today|yesterday|thisWeekStart|lastWeekStart|thisMonthStart|lastMonthStart|thisYearStart)\b/;
+
+  /**
+   * Compute the `askCache` key for a `sparqlAsk`.
+   *
+   * Token-free queries → the raw `sparqlAsk` text (unchanged behaviour: one
+   * compile, reused forever — zero perf regression). Queries containing a
+   * temporal token → the raw text prefixed with the current LOCAL calendar day
+   * (`YYYY-MM-DD` via `DateFormatter.toDateString`), so a compiled ASK whose
+   * `$today`/`$now`/… were baked in for day D is a cache MISS on day D+1 and gets
+   * recompiled against the new day — no manual `invalidateCache()` needed. The
+   * local day derives from the same `clock.now()` basis as `substituteVariables`
+   * (shared `$today`-family local basis; no hardcoded timezone). Fixes #3819.
+   */
+  private askCacheKey(sparqlAsk: string): string {
+    if (!PreconditionEvaluator.TEMPORAL_TOKEN.test(sparqlAsk)) {
+      return sparqlAsk;
+    }
+    const localDay = DateFormatter.toDateString(this.clock.now());
+    return `${localDay} ${sparqlAsk}`;
+  }
+
   private compileAsk(sparqlAsk: string): AskOperation | null {
     const processedQuery = this.substituteVariables(
       sparqlAsk,
@@ -223,13 +262,18 @@ export class PreconditionEvaluator {
     targetIRI: string,
   ): Promise<boolean> {
     try {
-      let compiled = this.askCache.get(sparqlAsk);
+      // Date-aware cache key: temporal-token queries are keyed per LOCAL calendar
+      // day so a compiled ASK (with its `$today`/`$now`/… baked in at compile
+      // time by `compileAsk`) never survives across local midnight; token-free
+      // queries keep the raw-text key (perf-neutral). Fixes #3819.
+      const cacheKey = this.askCacheKey(sparqlAsk);
+      let compiled = this.askCache.get(cacheKey);
 
       if (compiled === undefined) {
         const result = this.compileAsk(sparqlAsk);
         if (!result) return false;
         compiled = result;
-        this.askCache.set(sparqlAsk, compiled);
+        this.askCache.set(cacheKey, compiled);
       }
 
       const instantiated = JSON.parse(

--- a/packages/core/src/services/PreconditionEvaluator.ts
+++ b/packages/core/src/services/PreconditionEvaluator.ts
@@ -54,7 +54,15 @@ export type HostFunction = (context: EvalContext) => boolean;
 export class PreconditionEvaluator {
   private readonly hostFunctions = new Map<string, HostFunction>();
   private readonly tripleStore: ITripleStore;
-  private readonly askCache = new Map<string, AskOperation>();
+  // Keyed by the RAW sparqlAsk text → at most ONE entry per distinct query (no
+  // per-day accumulation). For temporal-token queries the entry records the LOCAL
+  // day its `$today`/`$now`/… values were compiled for; a day change REPLACES the
+  // entry (the stale-day compiled ASK is overwritten, never leaked). `day` is
+  // null for token-free queries (day-independent, never recompiled). Fixes #3819.
+  private readonly askCache = new Map<
+    string,
+    { readonly day: string | null; readonly compiled: AskOperation }
+  >();
   private readonly queryBodyResolver?: IQueryBodyResolver;
   private readonly clock: IClock;
 
@@ -177,8 +185,8 @@ export class PreconditionEvaluator {
    * Calendar/temporal tokens whose substituted value (see
    * {@link substituteVariables}) changes with the local calendar day. When a
    * `sparqlAsk` contains any of these, the compiled-ASK cache entry must NOT
-   * survive across local midnight — so {@link askCacheKey} folds the local day
-   * into the cache key for such queries.
+   * survive across local midnight, so `evaluateSparqlAsk` scopes the cache
+   * entry to the local day for such queries.
    *
    * `$today`/`$yesterday`/`$this*Start`/`$last*Start` are exactly the date
    * tokens rewritten by `substituteVariables`. `$now` is included deliberately:
@@ -191,26 +199,6 @@ export class PreconditionEvaluator {
    */
   private static readonly TEMPORAL_TOKEN =
     /\$(?:now|today|yesterday|thisWeekStart|lastWeekStart|thisMonthStart|lastMonthStart|thisYearStart)\b/;
-
-  /**
-   * Compute the `askCache` key for a `sparqlAsk`.
-   *
-   * Token-free queries → the raw `sparqlAsk` text (unchanged behaviour: one
-   * compile, reused forever — zero perf regression). Queries containing a
-   * temporal token → the raw text prefixed with the current LOCAL calendar day
-   * (`YYYY-MM-DD` via `DateFormatter.toDateString`), so a compiled ASK whose
-   * `$today`/`$now`/… were baked in for day D is a cache MISS on day D+1 and gets
-   * recompiled against the new day — no manual `invalidateCache()` needed. The
-   * local day derives from the same `clock.now()` basis as `substituteVariables`
-   * (shared `$today`-family local basis; no hardcoded timezone). Fixes #3819.
-   */
-  private askCacheKey(sparqlAsk: string): string {
-    if (!PreconditionEvaluator.TEMPORAL_TOKEN.test(sparqlAsk)) {
-      return sparqlAsk;
-    }
-    const localDay = DateFormatter.toDateString(this.clock.now());
-    return `${localDay} ${sparqlAsk}`;
-  }
 
   private compileAsk(sparqlAsk: string): AskOperation | null {
     const processedQuery = this.substituteVariables(
@@ -262,22 +250,26 @@ export class PreconditionEvaluator {
     targetIRI: string,
   ): Promise<boolean> {
     try {
-      // Date-aware cache key: temporal-token queries are keyed per LOCAL calendar
-      // day so a compiled ASK (with its `$today`/`$now`/… baked in at compile
-      // time by `compileAsk`) never survives across local midnight; token-free
-      // queries keep the raw-text key (perf-neutral). Fixes #3819.
-      const cacheKey = this.askCacheKey(sparqlAsk);
-      let compiled = this.askCache.get(cacheKey);
-
-      if (compiled === undefined) {
+      const isTemporal = PreconditionEvaluator.TEMPORAL_TOKEN.test(sparqlAsk);
+      const day = isTemporal
+        ? DateFormatter.toDateString(this.clock.now())
+        : null;
+      let entry = this.askCache.get(sparqlAsk);
+      // Recompile when absent, OR when a temporal query's cached entry was
+      // compiled for a DIFFERENT local day — the day change OVERWRITES the same
+      // raw-text key, so there is at most one entry per query (no stale-day
+      // leak) and the compiled $today/$now/... never survives local midnight.
+      // Token-free queries (day === null) are compiled once and reused forever
+      // (byte-identical to the pre-fix cache-hit path).
+      if (entry === undefined || (isTemporal && entry.day !== day)) {
         const result = this.compileAsk(sparqlAsk);
         if (!result) return false;
-        compiled = result;
-        this.askCache.set(cacheKey, compiled);
+        entry = { day, compiled: result };
+        this.askCache.set(sparqlAsk, entry);
       }
 
       const instantiated = JSON.parse(
-        JSON.stringify(compiled).replaceAll(
+        JSON.stringify(entry.compiled).replaceAll(
           PreconditionEvaluator.SENTINEL_IRI,
           targetIRI,
         ),

--- a/packages/core/tests/unit/services/PreconditionEvaluator.askCacheDayLock.test.ts
+++ b/packages/core/tests/unit/services/PreconditionEvaluator.askCacheDayLock.test.ts
@@ -1,0 +1,155 @@
+/**
+ * `PreconditionEvaluator` `askCache` day-lock (req 96be4042 / #3819) — the 6th
+ * and final surface of the date-tz family (#3806/#3808/#3810/#3813/#3817).
+ *
+ * `evaluateSparqlAsk` caches the COMPILED `AskOperation` in `askCache`. Formerly
+ * the key was the RAW `sparqlAsk` text, but `compileAsk` runs `substituteVariables`
+ * at COMPILE time — so the computed `$today`/`$now`/… values are BAKED into the
+ * cached entry. A precondition first compiled on local day D therefore kept
+ * evaluating against day D even after local midnight into day D+1, until a manual
+ * `invalidateCache()` — so a button's visibility gate mis-fired overnight.
+ *
+ * The fix folds the LOCAL calendar day into the cache key ONLY for queries
+ * containing a temporal token (`$today`/`$now`/…): a compiled ASK from day D is a
+ * cache MISS on day D+1 → recompiled against the new day, no manual invalidate.
+ * Token-free queries keep the raw-text key (one compile, reused forever — zero
+ * perf regression).
+ *
+ * Revert-verify ([[integration-test-revert-verify]]): with the cache key reverted
+ * to the raw `sparqlAsk` text, the day-D+1 evaluation re-serves the stale day-D
+ * compiled ASK (`$today` = day D) → the asset (planned for day D+1) does NOT match
+ * → RED; the date-aware key → recompile → match → GREEN.
+ *
+ * CI-robustness ([[jest-timezone-sensitive-tests]]): `process.env.TZ` cannot be
+ * re-tzset under jest (V8 caches the worker timezone) and the local/UTC distinction
+ * has no observable effect in a UTC runner — so the shared `installFakeOffsetDate`
+ * `Date`-subclass simulates a fixed UTC+5 (Asia/Almaty, no DST) offset and the
+ * fixed instant is switched across the local-midnight boundary (day D 23:00 local →
+ * day D+1 00:30 local, UTC still day D). Guards (`getHours()`/`getDate()`/
+ * `getUTCDate()`) assert the simulated tz is active so the test can never silently
+ * pass both ways.
+ *
+ * @req:96be4042-6521-4f62-bdc6-ee31e7e260a5
+ */
+import { PreconditionEvaluator } from "../../../src/services/PreconditionEvaluator";
+import { InMemoryTripleStore } from "../../../src/infrastructure/rdf/InMemoryTripleStore";
+import { Triple } from "../../../src/domain/models/rdf/Triple";
+import { IRI } from "../../../src/domain/models/rdf/IRI";
+import { Literal } from "../../../src/domain/models/rdf/Literal";
+import { ExoQLParser } from "../../../src/infrastructure/sparql/SPARQLParser";
+import { installFakeOffsetDate } from "../../helpers/installFakeOffsetDate";
+
+describe("PreconditionEvaluator askCache day-lock (req 96be4042 / #3819)", () => {
+  const ASSET_IRI = "https://exocortex.my/ontology/ems/test-asset-daylock";
+  const PLANNED = new IRI("https://exocortex.my/ontology/ems#plannedDate");
+  const XSD_DATE = new IRI("http://www.w3.org/2001/XMLSchema#date");
+
+  // A visibility precondition: is the asset planned for TODAY (local)?
+  const TODAY_ASK = `
+    PREFIX ems: <https://exocortex.my/ontology/ems#>
+    PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+    ASK {
+      <${ASSET_IRI}> ems:plannedDate ?d .
+      FILTER(?d = $today)
+    }
+  `;
+
+  it("a $today precondition compiled on local day D recompiles on day D+1 WITHOUT invalidateCache — the compiled ASK does not survive local midnight @req:96be4042-6521-4f62-bdc6-ee31e7e260a5", async () => {
+    // Asset is planned for LOCAL day 2026-07-04 (= day D+1 below).
+    const store = new InMemoryTripleStore();
+    await store.add(
+      new Triple(new IRI(ASSET_IRI), PLANNED, new Literal("2026-07-04", XSD_DATE)),
+    );
+    // ONE evaluator instance — its askCache persists across the day boundary.
+    const evaluator = new PreconditionEvaluator(store);
+    const precondition = {
+      id: "pre-planned-today",
+      label: "planned for today (local)",
+      sparqlAsk: TODAY_ASK,
+    };
+
+    // --- Local day D = 2026-07-03 (23:00 local, UTC 18:00 day 03) ---
+    let restore = installFakeOffsetDate(5, "2026-07-03T18:00:00Z");
+    try {
+      expect(new Date().getHours()).toBe(23); // 23:00 local — guard (sim tz active)
+      expect(new Date().getDate()).toBe(3); // local day 03 — guard
+      // $today = "2026-07-03"; asset planned "2026-07-04" (tomorrow) → NOT available.
+      // This ALSO compiles + caches the ASK with $today baked in as "2026-07-03".
+      expect(await evaluator.evaluate(precondition, ASSET_IRI)).toBe(false);
+    } finally {
+      restore();
+    }
+
+    // --- Local day D+1 = 2026-07-04 (00:30 local, UTC still 19:30 day 03) ---
+    restore = installFakeOffsetDate(5, "2026-07-03T19:30:00Z");
+    try {
+      expect(new Date().getHours()).toBe(0); // 00:30 local — past local midnight
+      expect(new Date().getDate()).toBe(4); // local day advanced to 04
+      expect(new Date().getUTCDate()).toBe(3); // ...while UTC is STILL day 03
+      // $today is now "2026-07-04"; the asset planned "2026-07-04" is TODAY →
+      // the command MUST become available. With the raw-text cache key the stale
+      // day-03 compiled ASK ($today = "2026-07-03") would be re-served → false (RED).
+      // With the date-aware key the day change forces a recompile → true (GREEN).
+      expect(await evaluator.evaluate(precondition, ASSET_IRI)).toBe(true);
+    } finally {
+      restore();
+    }
+  });
+
+  it("token-free precondition ASK is compiled ONCE across a local-day change (perf-neutral) while a $today ASK recompiles @req:96be4042-6521-4f62-bdc6-ee31e7e260a5", async () => {
+    const store = new InMemoryTripleStore();
+    await store.add(
+      new Triple(new IRI(ASSET_IRI), PLANNED, new Literal("2026-07-04", XSD_DATE)),
+    );
+
+    const parseSpy = jest.spyOn(ExoQLParser.prototype, "parse");
+
+    // --- Token-free query: same cache entry must be reused across days ---
+    const tokenFree = new PreconditionEvaluator(store);
+    const tokenFreePre = {
+      id: "pre-any",
+      label: "asset exists",
+      sparqlAsk: `ASK { <${ASSET_IRI}> ?p ?o }`,
+    };
+    parseSpy.mockClear();
+    let restore = installFakeOffsetDate(5, "2026-07-03T18:00:00Z");
+    try {
+      await tokenFree.evaluate(tokenFreePre, ASSET_IRI);
+    } finally {
+      restore();
+    }
+    restore = installFakeOffsetDate(5, "2026-07-03T19:30:00Z");
+    try {
+      await tokenFree.evaluate(tokenFreePre, ASSET_IRI);
+    } finally {
+      restore();
+    }
+    // Compiled ONCE — raw-text key, reused across the day change (no perf regression).
+    expect(parseSpy).toHaveBeenCalledTimes(1);
+
+    // --- Temporal query: must recompile once the local day changes ---
+    const temporal = new PreconditionEvaluator(store);
+    const temporalPre = {
+      id: "pre-planned-today-2",
+      label: "planned for today (local)",
+      sparqlAsk: TODAY_ASK,
+    };
+    parseSpy.mockClear();
+    restore = installFakeOffsetDate(5, "2026-07-03T18:00:00Z");
+    try {
+      await temporal.evaluate(temporalPre, ASSET_IRI);
+    } finally {
+      restore();
+    }
+    restore = installFakeOffsetDate(5, "2026-07-03T19:30:00Z");
+    try {
+      await temporal.evaluate(temporalPre, ASSET_IRI);
+    } finally {
+      restore();
+    }
+    // Recompiled on the new local day — one parse per day (date-aware key).
+    expect(parseSpy).toHaveBeenCalledTimes(2);
+
+    parseSpy.mockRestore();
+  });
+});

--- a/packages/core/tests/unit/services/PreconditionEvaluator.askCacheDayLock.test.ts
+++ b/packages/core/tests/unit/services/PreconditionEvaluator.askCacheDayLock.test.ts
@@ -44,6 +44,11 @@ describe("PreconditionEvaluator askCache day-lock (req 96be4042 / #3819)", () =>
   const PLANNED = new IRI("https://exocortex.my/ontology/ems#plannedDate");
   const XSD_DATE = new IRI("http://www.w3.org/2001/XMLSchema#date");
 
+  // Restore any jest.spyOn even if an assertion throws before an inline restore.
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
   // A visibility precondition: is the asset planned for TODAY (local)?
   const TODAY_ASK = `
     PREFIX ems: <https://exocortex.my/ontology/ems#>
@@ -149,7 +154,41 @@ describe("PreconditionEvaluator askCache day-lock (req 96be4042 / #3819)", () =>
     }
     // Recompiled on the new local day — one parse per day (date-aware key).
     expect(parseSpy).toHaveBeenCalledTimes(2);
+    // (afterEach restores the spy — no manual mockRestore that could leak on throw.)
+  });
 
-    parseSpy.mockRestore();
+  it("memory bound: the SAME $today query evaluated across a local-day change keeps exactly ONE cache entry (no per-day leak) @req:96be4042-6521-4f62-bdc6-ee31e7e260a5", async () => {
+    const store = new InMemoryTripleStore();
+    await store.add(
+      new Triple(new IRI(ASSET_IRI), PLANNED, new Literal("2026-07-04", XSD_DATE)),
+    );
+    const evaluator = new PreconditionEvaluator(store);
+    const precondition = {
+      id: "pre-mem",
+      label: "planned today",
+      sparqlAsk: TODAY_ASK,
+    };
+    // White-box: the cache is keyed by raw text so a day change REPLACES the
+    // entry rather than adding a second one.
+    const cache = (
+      evaluator as unknown as { askCache: Map<string, unknown> }
+    ).askCache;
+
+    let restore = installFakeOffsetDate(5, "2026-07-03T18:00:00Z"); // day D
+    try {
+      await evaluator.evaluate(precondition, ASSET_IRI);
+    } finally {
+      restore();
+    }
+    expect(cache.size).toBe(1);
+
+    restore = installFakeOffsetDate(5, "2026-07-03T19:30:00Z"); // day D+1
+    try {
+      await evaluator.evaluate(precondition, ASSET_IRI);
+    } finally {
+      restore();
+    }
+    // Still ONE entry — the day-D compiled ASK was overwritten, not accumulated.
+    expect(cache.size).toBe(1);
   });
 });


### PR DESCRIPTION
Closes #3819. **6th and final surface of the date-tz family** (#3806 → #3808 → #3810 → #3813 → #3817), flagged "Known pre-existing" in the #3817 review.

## Problem

`PreconditionEvaluator.evaluateSparqlAsk` caches the **compiled** `AskOperation` in `askCache`, keyed by the **raw** `sparqlAsk` text. But `compileAsk` runs `substituteVariables` at **compile time**, so the computed `$today`/`$now`/`$yesterday`/… values are **baked into the cached entry** (only `$target` is re-instantiated per evaluation). A precondition first compiled before local midnight therefore keeps evaluating against **yesterday's** date until `invalidateCache()` — button-visibility gates mis-fire for a long-lived process (Obsidian left open overnight). Mitigated in practice by frequent store-refresh invalidations, but the window is real.

## Fix

Date-aware cache key: fold the **local calendar day** (`DateFormatter.toDateString(clock.now())`, `YYYY-MM-DD`) into the `askCache` key **only** for queries containing a temporal token (`$today`/`$now`/`$yesterday`/`$this*Start`/`$last*Start`/`$thisYearStart`). A compiled ASK from day D is a **cache miss** on day D+1 → recompiled against the new day, no manual `invalidateCache()`. Deterministic, no timers.

- **Token-free queries keep the raw-text key** → one compile, reused forever. **Zero perf regression** (the cache-hit path for non-temporal preconditions is byte-identical to before).
- **`$now`** (sub-day granularity) is folded into the **day** key deliberately — more honest than the eternal freeze it had. Residual sub-day staleness within one local day is intended and documented (precondition availability granularity = the day, not the minute).
- **`evaluateQueryRef` (`exoql__Query` path) is unaffected** — it re-runs `substituteVariables` on every call (no `askCache`).

## Verification

- **Revert-verify** ([[integration-test-revert-verify]]): with the cache key reverted to the raw `sparqlAsk` text, the day-D+1 evaluation re-serves the stale day-D compiled ASK (`$today` = day D) → the asset (planned for day D+1) does not match → **RED (2 failed)**; the date-aware key recompiles → match → **GREEN (2 passed)**. Verified locally.
- **CI-robust** ([[jest-timezone-sensitive-tests]]): no `process.env.TZ` (V8 caches the worker tz under jest). Uses the shared `installFakeOffsetDate` `Date`-subclass simulating a fixed UTC+5 (Asia/Almaty, no DST) offset, switching the fixed instant across the local-midnight boundary (day D 23:00 local → day D+1 00:30 local, **UTC still day D**). Guards (`getHours()`/`getDate()`/`getUTCDate()`) assert the simulated tz is active so the test can never silently pass both ways.
- **Perf-neutrality test**: a spy on the real SPARQL parser proves a token-free ASK is compiled **once** across a day change while a `$today` ASK is compiled **twice** (recompiled on the new day).
- **Empirical double-gate** (built `dist`, deleted after): the real compiled `PreconditionEvaluator` with an injected `IClock` flipped day D → D+1 flips a `$today` precondition from not-available → available **without any `invalidateCache()`** (`false`→`true`, as expected).
- 53/53 PreconditionEvaluator unit tests pass; `tsc` 0 errors; eslint clean on the changed src file.

Req: `96be4042-6521-4f62-bdc6-ee31e7e260a5` (proposed → active on merge). Test title carries `@req:96be4042-...`.