### PR TITLE
chore: mark exocortex-services + exocortex-test-utils as private (#3818)

### DIFF
--- a/packages/services/package.json
+++ b/packages/services/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@kitelev/exocortex-services",
   "version": "0.1.0",
+  "private": true,
   "description": "Shared grounding-service factories for Exocortex plugin and CLI (RFC 94e520da Phase 1, T1.2)",
   "main": "dist/index.js",
   "module": "dist/index.js",

--- a/packages/test-utils/package.json
+++ b/packages/test-utils/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@kitelev/exocortex-test-utils",
   "version": "1.0.0",
+  "private": true,
   "description": "Shared test utilities and mock factories for Exocortex packages",
   "main": "./src/index.ts",
   "types": "./src/index.ts",


### PR DESCRIPTION
Closes part of #3818.

## What
Set `"private": true` on `@kitelev/exocortex-services` and `@kitelev/exocortex-test-utils`.

## Why
Both are workspace-internal libs (consumed in-repo via `file:../` / `*`) and were never published to npm (`npm view` → E404), yet declared no `private` flag (default = public) and no `files` allowlist. Marking them private reflects reality and guards against an accidental `npm publish` shipping an internal lib. Matches the already-private `@kitelev/exocortex-obsidian-plugin`.

## Safety
**Zero effect on the release flow.** Both publish steps are cli-scoped:
- `auto-release.yml` → `cd packages/cli && npm publish`
- `npm-publish-cli.yml` → `working-directory: packages/cli`

Neither iterates workspaces, so services/test-utils were never being published — `private:true` only prevents a *future* accidental publish. Workspace resolution (`file:../`) is unaffected by the private flag.

## Scope
Partial fix for #3818. `@kitelev/exocortex-core` left public — it's the plausible future-public engine lib and deserves a separate decision (issue #3818 keeps that open).

Follows the doc-consistency audit (#3812/#3814/#3815/#3816).

https://claude.ai/code/session_0124GcUVvdaFPC4x5LVcvPWn