### PR TITLE
chore: mark exocortex-core as private (closes #3818)

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@kitelev/exocortex-core",
   "version": "0.1.0",
+  "private": true,
   "description": "Core business logic for Exocortex knowledge management system",
   "main": "dist/index.js",
   "module": "dist/index.js",


### PR DESCRIPTION
Closes #3818.

## What
Set `"private": true` on `@kitelev/exocortex-core`, completing #3818 (services/test-utils were done in #3821).

## Evidence core is internal-only (verified)
- **Bundled into cli** via esbuild — cli declares core as a **devDependency** (`file:../core`); the published cli has **no** external core dep (`npm view @kitelev/exocortex-cli dependencies` → chalk/commander/… only).
- **Bundled into the obsidian-plugin** (workspace `*`, distributed via BRAT — not npm).
- **Never published** to npm (`npm view @kitelev/exocortex-core` → E404).
- **No publish intent**: no `publishConfig`, no `files` allowlist, no `prepublishOnly`; no core publish workflow (`auto-release.yml` + `npm-publish-cli.yml` are both cli-scoped).

## Safety
Zero effect on cli/plugin (both bundle core) or on the release flow (cli-scoped). Workspace resolution (`file:../core` / `*`) is unaffected by the private flag. **Reversible** — if core is ever promoted to a public engine lib, flip back + add README/`files`/release wiring.

Final piece of the doc-consistency + package-hygiene audit (#3812/#3814/#3815/#3816/#3821).

https://claude.ai/code/session_0124GcUVvdaFPC4x5LVcvPWn