### PR TITLE
feat(preconditions): composite homoiconic preconditions — recursive all/any/not eval (RFC df602adc Phase 4)

### DIFF
--- a/packages/core/src/domain/models/CommandDefinition.ts
+++ b/packages/core/src/domain/models/CommandDefinition.ts
@@ -58,12 +58,35 @@ export interface CommandDefinition {
  * Domain model for a precondition (RFC-009 Section 4.2.2).
  *
  * Determines WHEN a command button should be visible.
- * Uses SPARQL ASK query evaluated against the target asset.
  *
- * Variables in SPARQL:
+ * A precondition is one of:
+ *   - **atomic** — an evaluation leaf carrying exactly one of `sparqlAsk`,
+ *     `query`, or `hostFunction`;
+ *   - **composite** — a boolean combinator over child preconditions:
+ *     `composite` (AND/OR over `children`) or `not` (a single negated child);
+ *   - **broken** — an explicit fail-closed sentinel for a child precondition
+ *     that could not be resolved (unmounted / cyclic / malformed). Only ever
+ *     appears as a *child* node inside a composite tree.
+ *
+ * onto-RFC df602adc (Composable homoiconic preconditions) — способ A (boolean
+ * composition). The tree is authored entirely in RDF (`exocmd__AllPrecondition`
+ * / `AnyPrecondition` / `NotPrecondition` combinator assets); the engine (this
+ * interface + {@link PreconditionEvaluator}) is a pure recursive interpreter.
+ *
+ * Fail-open/fail-closed boundary (RFC Vision Lock 6):
+ *   - a command with NO precondition → always available (top-level fail-OPEN);
+ *   - a top-level precondition that cannot be resolved → `null` → same fail-open;
+ *   - a broken/empty/cyclic *child* → `false` (fail-CLOSED, command hidden).
+ *
+ * Variables in SPARQL (atomic leaves):
  * - `$target` replaced with IRI of the current asset
  * - `$now` replaced with current timestamp (ISO 8601)
  * - `$user` replaced with IRI of the current user
+ *
+ * The interface uses OPTIONAL fields (not a discriminated union) so adding the
+ * combinator/broken fields is backward-compatible — existing atomic
+ * constructors (`WorkflowCommandAdapter.buildPrecondition`, the loader's atomic
+ * branch) stay valid without touching them.
  */
 export interface PreconditionDefinition {
   /** Asset UID of the precondition */
@@ -80,6 +103,38 @@ export interface PreconditionDefinition {
    * pipeline (allowlist + flag + executor). Mutually exclusive with `sparqlAsk`.
    */
   readonly query?: string;
+  /**
+   * onto-RFC df602adc — AND/OR combinator over child preconditions.
+   * `op: 'all'` (`exocmd__AllPrecondition`) → available iff EVERY child is true;
+   * `op: 'any'` (`exocmd__AnyPrecondition`) → available iff at least one child
+   * is true. An empty `children` list evaluates to `false` (fail-closed).
+   * Disjoint with {@link not} and the atomic fields — a well-formed node carries
+   * exactly one combinator (enforced at authoring time by the Phase-3 sh:xone
+   * integrity guard; the loader picks all > any > not deterministically).
+   */
+  readonly composite?: {
+    readonly op: "all" | "any";
+    readonly children: readonly PreconditionDefinition[];
+  };
+  /**
+   * onto-RFC df602adc — NOT combinator (`exocmd__NotPrecondition`). Available
+   * iff the single nested child is NOT satisfied. Disjoint with
+   * {@link composite} and the atomic fields.
+   */
+  readonly not?: PreconditionDefinition;
+  /**
+   * onto-RFC df602adc (Impl-HIGH — explicit false-sentinel). Marks a child
+   * precondition that could NOT be loaded — an unresolvable wikilink, a cycle
+   * caught by the loader's visited-set, an over-depth reference, or a malformed
+   * atomic (no `sparqlAsk`/`query`/`hostFunction`). {@link PreconditionEvaluator}
+   * evaluates it to `false` (fail-CLOSED → command hidden).
+   *
+   * ⛔ This is a DISTINCT contract from the loader returning `null`. `null` is
+   * the fail-OPEN top-level boundary (no usable precondition → command shown);
+   * `broken` is the fail-CLOSED child boundary (a sub-precondition is broken →
+   * command hidden). Never conflate the two.
+   */
+  readonly broken?: true;
 }
 
 /**

--- a/packages/core/src/domain/models/CommandDefinition.ts
+++ b/packages/core/src/domain/models/CommandDefinition.ts
@@ -123,16 +123,24 @@ export interface PreconditionDefinition {
    */
   readonly not?: PreconditionDefinition;
   /**
-   * onto-RFC df602adc (Impl-HIGH — explicit false-sentinel). Marks a child
+   * onto-RFC df602adc (Impl-HIGH — explicit fail-closed sentinel). Marks a child
    * precondition that could NOT be loaded — an unresolvable wikilink, a cycle
    * caught by the loader's visited-set, an over-depth reference, or a malformed
-   * atomic (no `sparqlAsk`/`query`/`hostFunction`). {@link PreconditionEvaluator}
-   * evaluates it to `false` (fail-CLOSED → command hidden).
+   * atomic (no `sparqlAsk`/`query`/`hostFunction`).
+   *
+   * {@link PreconditionEvaluator} treats it as a THREE-VALUED (Kleene) `unknown`:
+   * it PROPAGATES through the boolean combinators — `not(broken) = broken`,
+   * `all` becomes `unknown` unless a child is definitively `false`, `any` becomes
+   * `unknown` unless a child is definitively `true` — and is collapsed to
+   * fail-CLOSED (`false` → command hidden) only at the top level. This is what
+   * keeps the fail-closed guarantee alive under negation/nesting: a naive
+   * `broken → false` would leak (`not[broken]` → `!false = true` → shown) in
+   * exactly the unmounted-assetspace scenario this sentinel targets.
    *
    * ⛔ This is a DISTINCT contract from the loader returning `null`. `null` is
    * the fail-OPEN top-level boundary (no usable precondition → command shown);
    * `broken` is the fail-CLOSED child boundary (a sub-precondition is broken →
-   * command hidden). Never conflate the two.
+   * command hidden, and stays hidden through negation). Never conflate the two.
    */
   readonly broken?: true;
 }

--- a/packages/core/src/services/CommandResolver.ts
+++ b/packages/core/src/services/CommandResolver.ts
@@ -1300,6 +1300,21 @@ export class CommandResolver {
     );
   }
 
+  /**
+   * Top-level precondition loader (onto-RFC df602adc — способ A).
+   *
+   * Resolves the precondition referenced from `predicate` on `subject`
+   * (`Command_precondition` / `CommandBinding_precondition`) into a — possibly
+   * composite — {@link PreconditionDefinition} tree via
+   * {@link loadPreconditionSubject}.
+   *
+   * Fail-OPEN boundary (unchanged from the pre-composite behaviour): returns
+   * `null` when there is no ref, the ref does not resolve, OR the resolved
+   * top-level precondition is a malformed atomic (no `sparqlAsk`/`query`/
+   * `hostFunction` and no combinator). `null` → `PreconditionEvaluator.evaluate`
+   * treats it as "no precondition" → command SHOWN. A *broken child* deep inside
+   * the tree is fail-CLOSED instead — see {@link loadChildPrecondition}.
+   */
   private async loadLinkedPreconditionFromProperty(
     subject: IRI,
     predicate: IRI,
@@ -1311,62 +1326,142 @@ export class CommandResolver {
     );
     if (refTriples.length === 0) return null;
 
-    const ref = refTriples[0].object;
-    let preconditionSubject: IRI | null = null;
-
-    if (ref instanceof IRI) {
-      preconditionSubject = ref;
-    } else if (ref instanceof Literal) {
-      // Wikilink reference: resolve by UID
-      const uid = this.normalizeWikilink(ref.value);
-      preconditionSubject = await this.findSubjectByUID(uid);
-    }
-
+    const preconditionSubject = await this.resolvePreconditionRef(
+      refTriples[0].object,
+    );
     if (!preconditionSubject) return null;
 
-    const uid = await this.getLiteralValue(
+    // Top-level: a malformed/atomic-without-source precondition yields `null`
+    // (fail-open, backward compatible). Composite/not/valid-atomic yields a
+    // definition; any broken descendants are embedded (fail-closed) inside it.
+    return this.loadPreconditionSubject(
       preconditionSubject,
+      new Set<string>(),
+      0,
+    );
+  }
+
+  /**
+   * Resolve a precondition object reference (IRI or Literal wikilink) to the
+   * referenced precondition asset's IRI subject. Returns `null` when the
+   * reference cannot be resolved (UID not indexed). Mirrors
+   * {@link resolveGroundingRef} for the precondition domain.
+   */
+  private async resolvePreconditionRef(
+    ref: IRI | Literal | unknown,
+  ): Promise<IRI | null> {
+    if (ref instanceof IRI) return ref;
+    if (ref instanceof Literal) {
+      const uid = this.normalizeWikilink(ref.value);
+      return await this.findSubjectByUID(uid);
+    }
+    return null;
+  }
+
+  /**
+   * Recursively load a precondition subject into a (possibly composite) tree.
+   *
+   * Kind is decided by PROPERTY PRESENCE (onto-RFC df602adc — dual-IRI-safe, no
+   * class-IRI walk): `AllPrecondition_preconditions` → `all`;
+   * `AnyPrecondition_preconditions` → `any`; `NotPrecondition_precondition` →
+   * `not`; otherwise atomic. Precedence all > any > not is deterministic (the
+   * Phase-3 sh:xone integrity guard ensures ≤1 combinator per instance, but the
+   * loader must never be ambiguous even for malformed authoring).
+   *
+   * Returns `null` ONLY for a malformed atomic (no combinator property AND no
+   * `sparqlAsk`/`query`/`hostFunction`, or no `Asset_uid`). The caller decides
+   * what `null` means: the top-level entry treats it as fail-OPEN (no
+   * precondition), while {@link loadChildPrecondition} converts it to a broken
+   * node (fail-CLOSED). Cycles (visited-set) and over-depth are returned as
+   * explicit `broken` nodes (fail-CLOSED) regardless of caller.
+   *
+   * @param visited UIDs of ancestor combinator nodes on the current path
+   *   (copy-on-recurse; read-only for the callee) — cycle guard.
+   * @param depth   recursion depth — capped by {@link MAX_TRANSITIVE_DEPTH}.
+   */
+  private async loadPreconditionSubject(
+    subject: IRI,
+    visited: ReadonlySet<string>,
+    depth: number,
+  ): Promise<PreconditionDefinition | null> {
+    const uid = await this.getLiteralValue(
+      subject,
       Namespace.EXO.term("Asset_uid"),
     );
     const label =
       (await this.getLiteralValue(
-        preconditionSubject,
+        subject,
         Namespace.EXO.term("Asset_label"),
       )) ?? "";
+
+    // Cycle / over-depth guards (fail-closed). Only combinator subjects recurse,
+    // but checking here keeps both boundaries in one place. At the top level
+    // (depth 0, empty visited) neither fires.
+    if (uid && visited.has(uid)) return this.brokenPreconditionNode(uid, label);
+    if (depth >= MAX_TRANSITIVE_DEPTH)
+      return this.brokenPreconditionNode(uid ?? "", label);
+
+    const allRefs = await this.tripleStore.match(
+      subject,
+      Namespace.EXOCMD.term("AllPrecondition_preconditions"),
+      undefined,
+    );
+    const anyRefs = await this.tripleStore.match(
+      subject,
+      Namespace.EXOCMD.term("AnyPrecondition_preconditions"),
+      undefined,
+    );
+    const notRefs = await this.tripleStore.match(
+      subject,
+      Namespace.EXOCMD.term("NotPrecondition_precondition"),
+      undefined,
+    );
+
+    if (allRefs.length > 0 || anyRefs.length > 0 || notRefs.length > 0) {
+      const nextVisited = new Set<string>(visited);
+      if (uid) nextVisited.add(uid);
+
+      if (allRefs.length > 0 || anyRefs.length > 0) {
+        const op: "all" | "any" = allRefs.length > 0 ? "all" : "any";
+        const listRefs = allRefs.length > 0 ? allRefs : anyRefs;
+        const children: PreconditionDefinition[] = [];
+        for (const triple of listRefs) {
+          children.push(
+            await this.loadChildPrecondition(
+              triple.object,
+              nextVisited,
+              depth + 1,
+            ),
+          );
+        }
+        return { id: uid ?? "", label, composite: { op, children } };
+      }
+
+      // NotPrecondition — exactly one child (Phase-3 Single cardinality; take
+      // the first defensively if authoring somehow yields more).
+      const child = await this.loadChildPrecondition(
+        notRefs[0].object,
+        nextVisited,
+        depth + 1,
+      );
+      return { id: uid ?? "", label, not: child };
+    }
+
+    // Atomic leaf.
     const sparqlAsk = await this.getLiteralValue(
-      preconditionSubject,
+      subject,
       Namespace.EXOCMD.term("Precondition_sparqlAsk"),
     );
     const hostFunction = await this.getLiteralValue(
-      preconditionSubject,
+      subject,
       Namespace.EXOCMD.term("Precondition_hostFunction"),
     );
-
-    // Precondition_query — wikilink reference to an exoql__Query asset.
-    // Resolved to its UID so PreconditionEvaluator can fetch the body
-    // through the existing asset-loader. RFC c78cc5c8 Phase 1a (T4).
-    const queryRefTriples = await this.tripleStore.match(
-      preconditionSubject,
-      Namespace.EXOCMD.term("Precondition_query"),
-      undefined,
-    );
-    let query: string | undefined = undefined;
-    if (queryRefTriples.length > 0) {
-      const queryRef = queryRefTriples[0].object;
-      if (queryRef instanceof IRI) {
-        const queryUid = await this.getLiteralValue(
-          queryRef,
-          Namespace.EXO.term("Asset_uid"),
-        );
-        if (queryUid) query = queryUid;
-      } else if (queryRef instanceof Literal) {
-        query = this.normalizeWikilink(queryRef.value);
-      }
-    }
+    const query = await this.loadPreconditionQueryRef(subject);
 
     if (!uid) return null;
 
-    // A precondition must have at least one evaluation source.
+    // A concrete atomic precondition must carry at least one evaluation source.
+    // Malformed atomic → null (top-level: fail-open; child: converted to broken).
     if (!sparqlAsk && !hostFunction && !query) return null;
 
     return {
@@ -1376,6 +1471,81 @@ export class CommandResolver {
       ...(hostFunction && { hostFunction }),
       ...(query && { query }),
     };
+  }
+
+  /**
+   * Load a CHILD precondition reference into a node. Unlike the top-level
+   * boundary, a child that cannot be loaded is fail-CLOSED: an unresolvable
+   * ref, a cyclic/over-depth subject, or a malformed atomic all become an
+   * explicit `broken` node (evaluated to `false` → command hidden). A child is
+   * therefore NEVER dropped from a composite's `children` list.
+   */
+  private async loadChildPrecondition(
+    ref: IRI | Literal | unknown,
+    visited: ReadonlySet<string>,
+    depth: number,
+  ): Promise<PreconditionDefinition> {
+    const childSubject = await this.resolvePreconditionRef(ref);
+    if (!childSubject) {
+      // Unresolvable wikilink (UID not indexed / precondition unmounted).
+      const hint =
+        ref instanceof Literal ? this.normalizeWikilink(ref.value) : "";
+      return this.brokenPreconditionNode(hint, "");
+    }
+
+    const def = await this.loadPreconditionSubject(
+      childSubject,
+      visited,
+      depth,
+    );
+    if (def) return def;
+
+    // Malformed atomic child (loadPreconditionSubject returned null) → broken.
+    const uid = await this.getLiteralValue(
+      childSubject,
+      Namespace.EXO.term("Asset_uid"),
+    );
+    return this.brokenPreconditionNode(uid ?? "", "");
+  }
+
+  /**
+   * Resolve `Precondition_query` (wikilink → `exoql__Query` asset UID) so
+   * PreconditionEvaluator can fetch the body through the asset-loader.
+   * RFC c78cc5c8 Phase 1a (T4). Returns `undefined` when no query ref exists.
+   */
+  private async loadPreconditionQueryRef(
+    subject: IRI,
+  ): Promise<string | undefined> {
+    const queryRefTriples = await this.tripleStore.match(
+      subject,
+      Namespace.EXOCMD.term("Precondition_query"),
+      undefined,
+    );
+    if (queryRefTriples.length === 0) return undefined;
+
+    const queryRef = queryRefTriples[0].object;
+    if (queryRef instanceof IRI) {
+      const queryUid = await this.getLiteralValue(
+        queryRef,
+        Namespace.EXO.term("Asset_uid"),
+      );
+      return queryUid ?? undefined;
+    }
+    if (queryRef instanceof Literal) {
+      return this.normalizeWikilink(queryRef.value);
+    }
+    return undefined;
+  }
+
+  /**
+   * Build a fail-closed `broken` sentinel node (onto-RFC df602adc Impl-HIGH).
+   * Distinct from the top-level `null` fail-open boundary.
+   */
+  private brokenPreconditionNode(
+    id: string,
+    label: string,
+  ): PreconditionDefinition {
+    return { id, label, broken: true };
   }
 
   /**

--- a/packages/core/src/services/PreconditionEvaluator.ts
+++ b/packages/core/src/services/PreconditionEvaluator.ts
@@ -27,6 +27,16 @@ export interface EvalContext {
 export type HostFunction = (context: EvalContext) => boolean;
 
 /**
+ * Three-valued (Kleene) evaluation state for the composite-precondition tree
+ * (onto-RFC df602adc). `"unknown"` models a broken/cyclic/malformed sub-
+ * precondition — an undeterminable branch that PROPAGATES through the boolean
+ * combinators and is collapsed to fail-closed (`false`) only at the top level.
+ * This is what makes the fail-closed guarantee survive negation (`not[broken]`
+ * stays hidden) instead of leaking (`!false = true`).
+ */
+type TriState = "yes" | "no" | "unknown";
+
+/**
  * Evaluates preconditions for dynamic commands (RFC-009 §5.4).
  *
  * Supports two evaluation strategies:
@@ -101,20 +111,38 @@ export class PreconditionEvaluator {
     // returns → zero cross-render staleness (the store cannot change mid-tree),
     // and fully independent from the day-aware `askCache` compile cache (#3819).
     const memo = new Map<string, Promise<boolean>>();
-    return this.evaluateNode(precondition, targetIRI, context, memo);
+    // Three-valued (Kleene) evaluation, collapsed to fail-CLOSED at the top: an
+    // undeterminable tree (`unknown` — a broken/cyclic/malformed sub-precondition)
+    // hides the command. Only "yes" makes it available.
+    const state = await this.evaluateNode(
+      precondition,
+      targetIRI,
+      context,
+      memo,
+    );
+    return state === "yes";
   }
 
   /**
-   * Recursive precondition evaluator (onto-RFC df602adc — способ A). Handles the
-   * boolean-combinator tree BEFORE the terminal atomic dispatch:
-   *   - `broken` sentinel → `false` (fail-CLOSED — an unresolvable/cyclic/
-   *     malformed child hides the command);
-   *   - `composite {op:'all'}` → every child true; empty list → `false`;
-   *   - `composite {op:'any'}` → some child true; empty list → `false`;
-   *   - `not` → negation of the single child;
-   *   - otherwise the existing atomic dispatch (sparqlAsk / query / hostFunction)
-   *     and the terminal `return true` (an atomic with no eval source is
-   *     fail-OPEN — unchanged from the pre-composite behaviour).
+   * Recursive precondition evaluator (onto-RFC df602adc — способ A), using
+   * THREE-VALUED (Kleene) logic so the fail-closed guarantee survives negation
+   * and nesting. Returns a {@link TriState}:
+   *   - `"unknown"` for a broken/cyclic/malformed sub-precondition (an
+   *     undeterminable branch). It PROPAGATES through the combinators rather than
+   *     collapsing to `"no"`, and is turned into fail-CLOSED (`false`) only at the
+   *     top level by {@link evaluate}. Collapsing broken→`"no"` here would leak
+   *     under `not` — `not[broken]` would become `!false = true` → command shown
+   *     in exactly the unmounted-assetspace scenario the broken sentinel targets.
+   *   - `not(unknown) = unknown`; `not(yes) = no`; `not(no) = yes`.
+   *   - `all`: any `"no"` → `"no"` (a failed child kills AND regardless); else any
+   *     `"unknown"` → `"unknown"`; else `"yes"`. Empty list → `"unknown"`
+   *     (malformed → fail-closed, and survives negation).
+   *   - `any`: any `"yes"` → `"yes"` (a satisfied child wins OR regardless — so
+   *     `any[broken, true]` stays SHOWN, no usability regression); else any
+   *     `"unknown"` → `"unknown"`; else `"no"`. Empty list → `"unknown"`.
+   *   - otherwise the atomic dispatch (sparqlAsk / query / hostFunction) maps
+   *     `boolean → "yes"/"no"`, and the terminal `"yes"` keeps a source-less
+   *     atomic fail-OPEN (unchanged from the pre-composite behaviour).
    *
    * Children are evaluated concurrently (`Promise.all`) and share the render
    * memo, so a reused atomic leaf runs its ASK once even across parallel
@@ -125,41 +153,51 @@ export class PreconditionEvaluator {
     targetIRI: string,
     context: EvalContext | undefined,
     memo: Map<string, Promise<boolean>>,
-  ): Promise<boolean> {
-    // Broken child sentinel — fail-closed (command hidden).
-    if (precondition.broken) return false;
+  ): Promise<TriState> {
+    // Broken child sentinel — undeterminable (propagates; fail-closed at top).
+    if (precondition.broken) return "unknown";
 
-    // AND / OR combinator.
+    // AND / OR combinator (Kleene).
     if (precondition.composite) {
       const { op, children } = precondition.composite;
-      // Empty combinator → fail-closed (an `all`/`any` with no children can't be
-      // "satisfied" in a meaningful way; matches the RFC's fail-closed default).
-      if (children.length === 0) return false;
+      // Empty combinator → undeterminable → fail-closed (and survives `not`).
+      if (children.length === 0) return "unknown";
       const results = await Promise.all(
         children.map((child) =>
           this.evaluateNode(child, targetIRI, context, memo),
         ),
       );
-      return op === "all" ? results.every(Boolean) : results.some(Boolean);
+      if (op === "all") {
+        if (results.includes("no")) return "no";
+        if (results.includes("unknown")) return "unknown";
+        return "yes";
+      }
+      // any
+      if (results.includes("yes")) return "yes";
+      if (results.includes("unknown")) return "unknown";
+      return "no";
     }
 
-    // NOT combinator.
+    // NOT combinator (Kleene: unknown negates to unknown).
     if (precondition.not) {
-      return !(await this.evaluateNode(
+      const child = await this.evaluateNode(
         precondition.not,
         targetIRI,
         context,
         memo,
-      ));
+      );
+      return child === "unknown" ? "unknown" : child === "yes" ? "no" : "yes";
     }
 
     // SPARQL ASK evaluation (inline body — legacy path), memoized per render.
     if (precondition.sparqlAsk) {
-      return this.evaluateSparqlAskMemoized(
+      return (await this.evaluateSparqlAskMemoized(
         precondition.sparqlAsk,
         targetIRI,
         memo,
-      );
+      ))
+        ? "yes"
+        : "no";
     }
 
     // exoql__Query reference (RFC c78cc5c8 Phase 1a) — resolve body
@@ -167,7 +205,9 @@ export class PreconditionEvaluator {
     // (allowlist + flag + executor). Fail closed if resolver is absent
     // or the query asset cannot be loaded.
     if (precondition.query) {
-      return this.evaluateQueryRef(precondition.query, targetIRI);
+      return (await this.evaluateQueryRef(precondition.query, targetIRI))
+        ? "yes"
+        : "no";
     }
 
     // Host function evaluation
@@ -176,10 +216,13 @@ export class PreconditionEvaluator {
         precondition.hostFunction,
         targetIRI,
         context,
-      );
+      )
+        ? "yes"
+        : "no";
     }
 
-    return true;
+    // Source-less atomic → fail-open (unchanged from pre-composite behaviour).
+    return "yes";
   }
 
   /**

--- a/packages/core/src/services/PreconditionEvaluator.ts
+++ b/packages/core/src/services/PreconditionEvaluator.ts
@@ -89,12 +89,77 @@ export class PreconditionEvaluator {
     targetIRI: string,
     context?: EvalContext,
   ): Promise<boolean> {
-    // No precondition = always available
+    // No precondition = always available (top-level fail-open boundary).
     if (!precondition) return true;
 
-    // SPARQL ASK evaluation (inline body — legacy path)
+    // Render-scoped result memo (onto-RFC df602adc — SPARQL-M). Keyed by
+    // `sparqlAsk` (targetIRI is invariant per memo), lives ONLY for THIS command's
+    // availability check — so a leaf reused across sub-branches of the composite
+    // tree (the reuse the composite feature introduces — e.g. a factored-out
+    // "не-прототип" ASK referenced by both an `all` and a `not` branch) executes
+    // the SPARQL ASK once, not once per occurrence. Discarded when evaluate()
+    // returns → zero cross-render staleness (the store cannot change mid-tree),
+    // and fully independent from the day-aware `askCache` compile cache (#3819).
+    const memo = new Map<string, Promise<boolean>>();
+    return this.evaluateNode(precondition, targetIRI, context, memo);
+  }
+
+  /**
+   * Recursive precondition evaluator (onto-RFC df602adc — способ A). Handles the
+   * boolean-combinator tree BEFORE the terminal atomic dispatch:
+   *   - `broken` sentinel → `false` (fail-CLOSED — an unresolvable/cyclic/
+   *     malformed child hides the command);
+   *   - `composite {op:'all'}` → every child true; empty list → `false`;
+   *   - `composite {op:'any'}` → some child true; empty list → `false`;
+   *   - `not` → negation of the single child;
+   *   - otherwise the existing atomic dispatch (sparqlAsk / query / hostFunction)
+   *     and the terminal `return true` (an atomic with no eval source is
+   *     fail-OPEN — unchanged from the pre-composite behaviour).
+   *
+   * Children are evaluated concurrently (`Promise.all`) and share the render
+   * memo, so a reused atomic leaf runs its ASK once even across parallel
+   * branches.
+   */
+  private async evaluateNode(
+    precondition: PreconditionDefinition,
+    targetIRI: string,
+    context: EvalContext | undefined,
+    memo: Map<string, Promise<boolean>>,
+  ): Promise<boolean> {
+    // Broken child sentinel — fail-closed (command hidden).
+    if (precondition.broken) return false;
+
+    // AND / OR combinator.
+    if (precondition.composite) {
+      const { op, children } = precondition.composite;
+      // Empty combinator → fail-closed (an `all`/`any` with no children can't be
+      // "satisfied" in a meaningful way; matches the RFC's fail-closed default).
+      if (children.length === 0) return false;
+      const results = await Promise.all(
+        children.map((child) =>
+          this.evaluateNode(child, targetIRI, context, memo),
+        ),
+      );
+      return op === "all" ? results.every(Boolean) : results.some(Boolean);
+    }
+
+    // NOT combinator.
+    if (precondition.not) {
+      return !(await this.evaluateNode(
+        precondition.not,
+        targetIRI,
+        context,
+        memo,
+      ));
+    }
+
+    // SPARQL ASK evaluation (inline body — legacy path), memoized per render.
     if (precondition.sparqlAsk) {
-      return this.evaluateSparqlAsk(precondition.sparqlAsk, targetIRI);
+      return this.evaluateSparqlAskMemoized(
+        precondition.sparqlAsk,
+        targetIRI,
+        memo,
+      );
     }
 
     // exoql__Query reference (RFC c78cc5c8 Phase 1a) — resolve body
@@ -115,6 +180,32 @@ export class PreconditionEvaluator {
     }
 
     return true;
+  }
+
+  /**
+   * Render-scoped memoized wrapper over {@link evaluateSparqlAsk}. Caches the
+   * in-flight PROMISE (not the resolved boolean) keyed by `sparqlAsk` (targetIRI
+   * is constant across one memo — see below), so concurrent siblings in one
+   * composite tree that reference the same atomic leaf await ONE execution.
+   * Cross-tree/cross-render calls each get a fresh memo (see {@link evaluate}) →
+   * no staleness.
+   */
+  private evaluateSparqlAskMemoized(
+    sparqlAsk: string,
+    targetIRI: string,
+    memo: Map<string, Promise<boolean>>,
+  ): Promise<boolean> {
+    // Keyed by `sparqlAsk` ALONE — collision-free with no separator, because
+    // `targetIRI` is INVARIANT across a single render memo: one memo is created
+    // per top-level `evaluate()` call and `targetIRI` is threaded unchanged
+    // through the whole `evaluateNode` recursion, so every leaf in this tree is
+    // evaluated against the same target. Distinct commands / targets each get a
+    // fresh memo (see {@link evaluate}).
+    const cached = memo.get(sparqlAsk);
+    if (cached !== undefined) return cached;
+    const pending = this.evaluateSparqlAsk(sparqlAsk, targetIRI);
+    memo.set(sparqlAsk, pending);
+    return pending;
   }
 
   private async evaluateQueryRef(

--- a/packages/core/tests/unit/services/CommandResolver.compositePrecondition.test.ts
+++ b/packages/core/tests/unit/services/CommandResolver.compositePrecondition.test.ts
@@ -1,0 +1,420 @@
+/**
+ * Phase 4 (onto-RFC df602adc — Composable homoiconic preconditions, способ A):
+ * PRODUCTION-SHAPE coverage for the composite-precondition ENGINE — the full
+ * `CommandResolver.loadCommand` recursive LOADER *and* the
+ * `PreconditionEvaluator.evaluate` recursive EVALUATOR, driven from a real
+ * `InMemoryTripleStore` (seed markdown-shaped triples → loadCommand → evaluate),
+ * NOT a hand-injected `PreconditionDefinition` tree.
+ *
+ * Why production-shape (test-fixture-realism): a hand-injected composite tree
+ * would exercise only the evaluator and MASK the 4.2 loader — the property-
+ * presence combinator detection (`AllPrecondition_preconditions` /
+ * `AnyPrecondition_preconditions` / `NotPrecondition_precondition`), the
+ * ALL-refs iteration (not `[0]`), the recursive wikilink resolution, the
+ * extended guard (composites don't have sparqlAsk/query/hostFunction and would
+ * be silently dropped by the old `return null` guard), the visited-set cycle
+ * guard, and the broken-child sentinel. These tests load the tree FROM the store
+ * so a loader regression is caught.
+ *
+ * Revert-verify ([[integration-test-revert-verify]]) — run out-of-band and
+ * documented in the PR:
+ *   - remove `if (precondition.broken) return false` in evaluateNode → the
+ *     broken-child + cycle cases go RED (broken falls through to `return true`);
+ *   - remove the loader combinator detection (revert to atomic-only) → every
+ *     composite case that expects a specific boolean goes RED (composites load
+ *     as null → evaluate → true);
+ *   - top-level `return null` fail-open boundary → broken node → the
+ *     top-level-unresolvable case goes RED (true → false);
+ *   - drop the render memo → the reuse "executed once" assertion goes RED (2).
+ *
+ * @req:4370db77-3df2-48d3-bf20-f439d49fc12e
+ */
+import { CommandResolver } from "../../../src/services/CommandResolver";
+import { PreconditionEvaluator } from "../../../src/services/PreconditionEvaluator";
+import { InMemoryTripleStore } from "../../../src/infrastructure/rdf/InMemoryTripleStore";
+import { Triple } from "../../../src/domain/models/rdf/Triple";
+import { IRI } from "../../../src/domain/models/rdf/IRI";
+import { Literal } from "../../../src/domain/models/rdf/Literal";
+import { Namespace } from "../../../src/domain/models/rdf/Namespace";
+import type { PreconditionDefinition } from "../../../src/domain/models/CommandDefinition";
+
+// create_instance grounding type UID (same as CommandResolver.waitingCheckLoader
+// production-shape test — a minimal valid grounding so loadCommand returns).
+const CREATE_INSTANCE_TYPE_UID = "4367e2d6-6c92-450a-becb-abce1fb07682";
+
+const COMMAND_UID = "0c0mmand-0000-0000-0000-000000000001";
+const GROUNDING_UID = "09r0und-0000-0000-0000-000000000001";
+const TARGET_UID = "07a89e70-0000-0000-0000-000000000001";
+const TARGET_IRI = `obsidian://vault/${TARGET_UID}.md`;
+
+function iri(uid: string): IRI {
+  return new IRI(`obsidian://vault/${uid}.md`);
+}
+
+/** An ASK that is TRUE iff the target carries `ems:<predLocal>`. */
+function askFor(predLocal: string): string {
+  return `PREFIX ems: <https://exocortex.my/ontology/ems#>
+    ASK { $target ems:${predLocal} ?x }`;
+}
+
+async function addLabelled(
+  store: InMemoryTripleStore,
+  uid: string,
+  label: string,
+): Promise<void> {
+  await store.addAll([
+    new Triple(iri(uid), Namespace.EXO.term("Asset_uid"), new Literal(uid)),
+    new Triple(iri(uid), Namespace.EXO.term("Asset_label"), new Literal(label)),
+  ]);
+}
+
+/** Atomic precondition asset carrying a `Precondition_sparqlAsk`. */
+async function addAtomic(
+  store: InMemoryTripleStore,
+  uid: string,
+  sparqlAsk: string,
+): Promise<void> {
+  await addLabelled(store, uid, `atomic:${uid}`);
+  await store.add(
+    new Triple(
+      iri(uid),
+      Namespace.EXOCMD.term("Precondition_sparqlAsk"),
+      new Literal(sparqlAsk),
+    ),
+  );
+}
+
+/** All/Any combinator asset — children as `"[[<uid>]]"` wikilink literals. */
+async function addComposite(
+  store: InMemoryTripleStore,
+  uid: string,
+  op: "all" | "any",
+  childUids: string[],
+): Promise<void> {
+  await addLabelled(store, uid, `${op}:${uid}`);
+  const predicate =
+    op === "all"
+      ? Namespace.EXOCMD.term("AllPrecondition_preconditions")
+      : Namespace.EXOCMD.term("AnyPrecondition_preconditions");
+  for (const c of childUids) {
+    await store.add(new Triple(iri(uid), predicate, new Literal(`[[${c}]]`)));
+  }
+}
+
+/** Not combinator asset — single `NotPrecondition_precondition` child. */
+async function addNot(
+  store: InMemoryTripleStore,
+  uid: string,
+  childRef: string,
+): Promise<void> {
+  await addLabelled(store, uid, `not:${uid}`);
+  await store.add(
+    new Triple(
+      iri(uid),
+      Namespace.EXOCMD.term("NotPrecondition_precondition"),
+      new Literal(`[[${childRef}]]`),
+    ),
+  );
+}
+
+/**
+ * Command referencing `precondRef` via `Command_precondition`
+ * (wikilink-literal form) + a minimal create_instance grounding so
+ * `loadCommand` returns non-null. `precondRef === null` → no precondition.
+ */
+async function addCommand(
+  store: InMemoryTripleStore,
+  precondRef: string | null,
+): Promise<void> {
+  await addLabelled(store, COMMAND_UID, "Test command");
+  await store.add(
+    new Triple(
+      iri(COMMAND_UID),
+      Namespace.RDF.term("type"),
+      Namespace.EXOCMD.term("Command"),
+    ),
+  );
+  if (precondRef !== null) {
+    await store.add(
+      new Triple(
+        iri(COMMAND_UID),
+        Namespace.EXOCMD.term("Command_precondition"),
+        new Literal(`[[${precondRef}]]`),
+      ),
+    );
+  }
+  await store.add(
+    new Triple(
+      iri(COMMAND_UID),
+      Namespace.EXOCMD.term("Command_grounding"),
+      iri(GROUNDING_UID),
+    ),
+  );
+  await store.addAll([
+    new Triple(
+      iri(GROUNDING_UID),
+      Namespace.EXO.term("Asset_uid"),
+      new Literal(GROUNDING_UID),
+    ),
+    new Triple(
+      iri(GROUNDING_UID),
+      Namespace.EXO.term("Asset_label"),
+      new Literal("g"),
+    ),
+    new Triple(
+      iri(GROUNDING_UID),
+      Namespace.EXOCMD.term("Grounding_type"),
+      new Literal(`[[${CREATE_INSTANCE_TYPE_UID}]]`),
+    ),
+    new Triple(
+      iri(GROUNDING_UID),
+      Namespace.EXOCMD.term("Grounding_targetClass"),
+      new Literal("ems__Task"),
+    ),
+  ]);
+}
+
+describe("CommandResolver + PreconditionEvaluator — composite preconditions (onto-RFC df602adc, Phase 4)", () => {
+  let store: InMemoryTripleStore;
+  let resolver: CommandResolver;
+  let evaluator: PreconditionEvaluator;
+
+  beforeEach(async () => {
+    store = new InMemoryTripleStore();
+    resolver = new CommandResolver(store);
+    evaluator = new PreconditionEvaluator(store);
+    // Target markers so `askFor("Effort_status")` is TRUE and
+    // `askFor("Effort_startTimestamp")` is FALSE (marker absent).
+    await store.addAll([
+      new Triple(
+        iri(TARGET_UID),
+        Namespace.EXO.term("Asset_uid"),
+        new Literal(TARGET_UID),
+      ),
+      new Triple(
+        iri(TARGET_UID),
+        Namespace.EMS.term("Effort_status"),
+        new Literal("Doing"),
+      ),
+      new Triple(
+        iri(TARGET_UID),
+        Namespace.EMS.term("Effort_area"),
+        new Literal("A"),
+      ),
+      new Triple(
+        iri(TARGET_UID),
+        Namespace.EMS.term("Effort_parent"),
+        new Literal("P"),
+      ),
+    ]);
+  });
+
+  /** loadCommand → evaluate against TARGET_IRI (the full production path). */
+  async function loadAndEvaluate(): Promise<boolean> {
+    const cmd = await resolver.loadCommand(COMMAND_UID);
+    expect(cmd).not.toBeNull();
+    return evaluator.evaluate(cmd!.precondition, TARGET_IRI);
+  }
+
+  async function loadPrecondition(): Promise<
+    PreconditionDefinition | undefined
+  > {
+    const cmd = await resolver.loadCommand(COMMAND_UID);
+    expect(cmd).not.toBeNull();
+    return cmd!.precondition;
+  }
+
+  // ---- AND (all) ----
+  it("all: every child true → available (true)", async () => {
+    await addAtomic(store, "t1", askFor("Effort_status")); // true
+    await addAtomic(store, "t2", askFor("Effort_area")); // true
+    await addComposite(store, "cAll", "all", ["t1", "t2"]);
+    await addCommand(store, "cAll");
+
+    const def = await loadPrecondition();
+    expect(def?.composite?.op).toBe("all");
+    expect(def?.composite?.children).toHaveLength(2);
+    expect(await loadAndEvaluate()).toBe(true);
+  });
+
+  it("all: one child false → hidden (false)", async () => {
+    await addAtomic(store, "t1", askFor("Effort_status")); // true
+    await addAtomic(store, "f1", askFor("Effort_startTimestamp")); // false
+    await addComposite(store, "cAll", "all", ["t1", "f1"]);
+    await addCommand(store, "cAll");
+
+    expect(await loadAndEvaluate()).toBe(false);
+  });
+
+  // ---- OR (any) ----
+  it("any: one child true (rest false) → available (true)", async () => {
+    await addAtomic(store, "f1", askFor("Effort_startTimestamp")); // false
+    await addAtomic(store, "t1", askFor("Effort_status")); // true
+    await addComposite(store, "cAny", "any", ["f1", "t1"]);
+    await addCommand(store, "cAny");
+
+    const def = await loadPrecondition();
+    expect(def?.composite?.op).toBe("any");
+    expect(await loadAndEvaluate()).toBe(true);
+  });
+
+  it("any: all children false → hidden (false)", async () => {
+    await addAtomic(store, "f1", askFor("Effort_startTimestamp")); // false
+    await addAtomic(store, "f2", askFor("Effort_endTimestamp")); // false
+    await addComposite(store, "cAny", "any", ["f1", "f2"]);
+    await addCommand(store, "cAny");
+
+    expect(await loadAndEvaluate()).toBe(false);
+  });
+
+  // ---- NOT ----
+  it("not(false child) → available (true)", async () => {
+    await addAtomic(store, "f1", askFor("Effort_startTimestamp")); // false
+    await addNot(store, "cNot", "f1");
+    await addCommand(store, "cNot");
+
+    const def = await loadPrecondition();
+    expect(def?.not).toBeDefined();
+    expect(await loadAndEvaluate()).toBe(true);
+  });
+
+  it("not(true child) → hidden (false)", async () => {
+    await addAtomic(store, "t1", askFor("Effort_status")); // true
+    await addNot(store, "cNot", "t1");
+    await addCommand(store, "cNot");
+
+    expect(await loadAndEvaluate()).toBe(false);
+  });
+
+  // ---- Nesting ----
+  it("nested: all[ any[false, true], not[false] ] → true", async () => {
+    await addAtomic(store, "f1", askFor("Effort_startTimestamp")); // false
+    await addAtomic(store, "t1", askFor("Effort_status")); // true
+    await addAtomic(store, "f2", askFor("Effort_endTimestamp")); // false
+    await addComposite(store, "inner-any", "any", ["f1", "t1"]); // → true
+    await addNot(store, "inner-not", "f2"); // → true
+    await addComposite(store, "root", "all", ["inner-any", "inner-not"]);
+    await addCommand(store, "root");
+
+    const def = await loadPrecondition();
+    expect(def?.composite?.op).toBe("all");
+    // Structural: the loader built a nested tree, not a flat atomic.
+    expect(def?.composite?.children[0].composite?.op).toBe("any");
+    expect(def?.composite?.children[1].not).toBeDefined();
+    expect(await loadAndEvaluate()).toBe(true);
+  });
+
+  it("nested: all[ any[false, true], not[true] ] → false", async () => {
+    await addAtomic(store, "f1", askFor("Effort_startTimestamp")); // false
+    await addAtomic(store, "t1", askFor("Effort_status")); // true
+    await addComposite(store, "inner-any", "any", ["f1", "t1"]); // → true
+    await addNot(store, "inner-not", "t1"); // not(true) → false
+    await addComposite(store, "root", "all", ["inner-any", "inner-not"]);
+    await addCommand(store, "root");
+
+    expect(await loadAndEvaluate()).toBe(false); // all(true, false) → false
+  });
+
+  // ---- Reuse (CQ3) + render-memo (SPARQL-M) ----
+  it("reuse: a leaf referenced in two sub-branches evaluates its ASK ONCE (render memo) and stays correct", async () => {
+    // shared "true" leaf reused by both the `all` root AND the nested `not`.
+    const sharedAsk = askFor("Effort_status"); // true
+    await addAtomic(store, "shared", sharedAsk);
+    await addAtomic(store, "t2", askFor("Effort_area")); // true
+    await addNot(store, "not-shared", "shared"); // not(true) → false
+    // all[ shared(true), t2(true), not[shared](false) ] → false, but `shared`
+    // appears TWICE (direct child + inside the not).
+    await addComposite(store, "root", "all", ["shared", "t2", "not-shared"]);
+    await addCommand(store, "root");
+
+    const spy = jest.spyOn(
+      evaluator as unknown as {
+        evaluateSparqlAsk: (a: string, b: string) => Promise<boolean>;
+      },
+      "evaluateSparqlAsk",
+    );
+
+    // all(true, true, not(true)=false) → false
+    expect(await loadAndEvaluate()).toBe(false);
+
+    // The shared leaf's ASK ran exactly once despite two occurrences (memo).
+    const sharedCalls = spy.mock.calls.filter((c) => c[0] === sharedAsk);
+    expect(sharedCalls).toHaveLength(1);
+    spy.mockRestore();
+  });
+
+  // ---- Cycle → false (fail-closed, no hang) ----
+  it("cycle A→all[B], B→all[A] → hidden (false), loader terminates with a broken node", async () => {
+    await addComposite(store, "A", "all", ["B"]);
+    await addComposite(store, "B", "all", ["A"]);
+    await addCommand(store, "A");
+
+    const def = await loadPrecondition();
+    // The recursion terminated (no hang) with a broken sentinel deep inside.
+    const bBranch = def?.composite?.children[0]; // B
+    const aAgain = bBranch?.composite?.children[0]; // A revisited → broken
+    expect(aAgain?.broken).toBe(true);
+    expect(await loadAndEvaluate()).toBe(false);
+  });
+
+  // ---- Broken child → false (Impl-HIGH regress-lock) ----
+  it("broken child (unresolvable wikilink) → hidden (false); loader marks it broken @req:4370db77-3df2-48d3-bf20-f439d49fc12e", async () => {
+    await addAtomic(store, "t1", askFor("Effort_status")); // true
+    // "ghost" is NOT added to the store → unresolvable wikilink → broken node.
+    await addComposite(store, "cAll", "all", ["t1", "ghost-uid-not-in-store"]);
+    await addCommand(store, "cAll");
+
+    const def = await loadPrecondition();
+    expect(def?.composite?.children).toHaveLength(2); // child NOT dropped
+    expect(def?.composite?.children[1].broken).toBe(true); // marked broken
+    // all(true, broken) → false (fail-closed).
+    expect(await loadAndEvaluate()).toBe(false);
+  });
+
+  it("malformed atomic child (no sparqlAsk/query/hostFunction) → broken → all hidden (false)", async () => {
+    await addAtomic(store, "t1", askFor("Effort_status")); // true
+    await addLabelled(store, "malformed", "no eval source"); // atomic w/o source
+    await addComposite(store, "cAll", "all", ["t1", "malformed"]);
+    await addCommand(store, "cAll");
+
+    const def = await loadPrecondition();
+    expect(def?.composite?.children[1].broken).toBe(true);
+    expect(await loadAndEvaluate()).toBe(false);
+  });
+
+  // ---- Fail-open boundary (top-level) ----
+  it("no precondition at all → available (true, fail-open)", async () => {
+    await addCommand(store, null);
+    const def = await loadPrecondition();
+    expect(def).toBeUndefined();
+    expect(await loadAndEvaluate()).toBe(true);
+  });
+
+  it("top-level precondition ref UNRESOLVABLE → null → available (true, fail-open — NOT fail-closed like a child)", async () => {
+    await addCommand(store, "ghost-top-level-not-in-store");
+    const def = await loadPrecondition();
+    // Top-level unresolvable is fail-OPEN (null → command shown), unlike a
+    // broken CHILD which is fail-closed.
+    expect(def).toBeUndefined();
+    expect(await loadAndEvaluate()).toBe(true);
+  });
+
+  it("top-level malformed atomic (no eval source) → null → available (true, backward-compat fail-open)", async () => {
+    await addLabelled(store, "malformed-top", "no eval source");
+    await addCommand(store, "malformed-top");
+    const def = await loadPrecondition();
+    expect(def).toBeUndefined();
+    expect(await loadAndEvaluate()).toBe(true);
+  });
+
+  // ---- Atomic still works through the recursive loader (backward-compat) ----
+  it("plain atomic precondition still loads + evaluates (true when ASK matches)", async () => {
+    await addAtomic(store, "t1", askFor("Effort_status")); // true
+    await addCommand(store, "t1");
+    const def = await loadPrecondition();
+    expect(def?.sparqlAsk).toContain("Effort_status");
+    expect(def?.composite).toBeUndefined();
+    expect(def?.not).toBeUndefined();
+    expect(await loadAndEvaluate()).toBe(true);
+  });
+});

--- a/packages/core/tests/unit/services/CommandResolver.compositePrecondition.test.ts
+++ b/packages/core/tests/unit/services/CommandResolver.compositePrecondition.test.ts
@@ -382,6 +382,61 @@ describe("CommandResolver + PreconditionEvaluator — composite preconditions (o
     expect(await loadAndEvaluate()).toBe(false);
   });
 
+  // ---- Fail-closed SURVIVES negation & nesting (three-valued Kleene, HIGH fix) ----
+  // Guards against the value-propagation leak: a naive broken→false would make
+  // not[broken] evaluate to !(false)=true (command SHOWN in the unmounted-
+  // assetspace scenario the sentinel targets). `unknown` must propagate through
+  // `not`/`all`/`any` and collapse to false only at the top.
+  it("not[broken] (unresolvable child) → hidden (false) — fail-closed survives negation @req:4370db77-3df2-48d3-bf20-f439d49fc12e", async () => {
+    // "ghost" NOT in store → broken; not(broken) must stay hidden, NOT !false=true.
+    await addNot(store, "cNot", "ghost-uid-not-in-store");
+    await addCommand(store, "cNot");
+
+    const def = await loadPrecondition();
+    expect(def?.not?.broken).toBe(true); // loader marked the child broken
+    expect(await loadAndEvaluate()).toBe(false); // three-valued: not(unknown)→unknown→false
+  });
+
+  it("not[cycle] → hidden (false) — cyclic child is unknown, negation stays hidden", async () => {
+    // cNot = not[cyc]; cyc = all[cyc] (self-cycle) → visited-set → broken deep inside.
+    await addNot(store, "cNot", "cyc");
+    await addComposite(store, "cyc", "all", ["cyc"]);
+    await addCommand(store, "cNot");
+
+    expect(await loadAndEvaluate()).toBe(false);
+  });
+
+  it("nested not[all[broken, true]] → hidden (false) — a narrow immediate-not patch would NOT catch this", async () => {
+    await addAtomic(store, "t1", askFor("Effort_status")); // true
+    await addComposite(store, "inner", "all", ["ghost-uid", "t1"]); // all[unknown, yes] → unknown
+    await addNot(store, "cNot", "inner");
+    await addCommand(store, "cNot");
+
+    // all(broken, true) = unknown (a naive broken→false gives all(false,true)=false
+    // → not(false)=true → SHOWN, the leak). Three-valued: not(unknown)→unknown→false.
+    expect(await loadAndEvaluate()).toBe(false);
+  });
+
+  it("any[broken, true] → shown (true) — a satisfied branch wins OR (no over-hide/usability regression)", async () => {
+    await addAtomic(store, "t1", askFor("Effort_status")); // true
+    await addComposite(store, "cAny", "any", ["ghost-uid", "t1"]);
+    await addCommand(store, "cAny");
+
+    // OR short-circuits to true on the genuinely-true branch, regardless of the
+    // broken one — proves the fix does NOT poison-propagate (over-hide).
+    expect(await loadAndEvaluate()).toBe(true);
+  });
+
+  it("any[broken, false] → hidden (false) — no true branch, unknown propagates", async () => {
+    await addAtomic(store, "f1", askFor("Effort_startTimestamp")); // false
+    await addComposite(store, "cAny", "any", ["ghost-uid", "f1"]);
+    await addCommand(store, "cAny");
+
+    // any(unknown, no) → unknown → false (hidden): the broken branch might have
+    // been the one to satisfy OR, so we cannot claim availability.
+    expect(await loadAndEvaluate()).toBe(false);
+  });
+
   // ---- Fail-open boundary (top-level) ----
   it("no precondition at all → available (true, fail-open)", async () => {
     await addCommand(store, null);


### PR DESCRIPTION
## What

onto-RFC `df602adc` **Phase 4 (code, feature-sdd)** — composite homoiconic preconditions. Command availability can now be authored as a boolean-combinator tree (AND / OR / NOT) over reusable atomic preconditions. The RDF classes + 3 predicates + 37-instance migration + integrity guards already shipped in Phases 1–3; this PR is the **engine** (способ A — recursive boolean composition).

## Layers (one cohesive PR)

- **Model** (`CommandDefinition.ts`) — `PreconditionDefinition` gains optional `composite {op:'all'|'any', children}`, `not`, and an explicit `broken: true` fail-closed sentinel (Impl-HIGH — a **distinct contract** from the loader's top-level `null` fail-open boundary). Optional fields, not a discriminated union → backward-compatible; `WorkflowCommandAdapter.buildPrecondition` (atomic constructor) untouched.
- **Loader** (`CommandResolver.loadLinkedPreconditionFromProperty` → recursive `loadPreconditionSubject`) — combinator kind by **property presence** (`AllPrecondition_preconditions` / `AnyPrecondition_preconditions` / `NotPrecondition_precondition`; dual-IRI-safe, no class-IRI walk), iterates **ALL** list refs (not `[0]`), resolves child wikilinks, **visited-set cycle guard** + `MAX_TRANSITIVE_DEPTH` cap → `broken` node. The atomic `return null` guard is widened so composites are **not silently dropped**. Top-level unresolvable / malformed-atomic → `null` (fail-**open**, backward-compat); a broken **child** → fail-**closed**.
- **Evaluator** (`PreconditionEvaluator.evaluateNode`) — handles `broken → false`, `all → every`, `any → some`, `not → negate` **before** the terminal atomic dispatch; empty composite → `false`. **Render-scoped result memo** keyed by `sparqlAsk` (targetIRI is invariant within one memo) so a leaf reused across sub-branches runs its ASK **once** — independent of and coexisting with the day-aware `askCache` compile cache (#3819).
- Sync palette (`evaluateHostFunctionSync`) unchanged; public `evaluate` / `loadCommand` signatures unchanged. No Node-only deps introduced (mobile-safe; Desktop↔Mobile parity is Phase 5).

## Tests — production-shape + revert-verify

New suite `CommandResolver.compositePrecondition.test.ts` (16 tests) seeds a real `InMemoryTripleStore` (markdown-shaped triples) and drives the **full** `loadCommand → evaluate` path — **NOT** a hand-injected tree, so the 4.2 loader is exercised (test-fixture-realism). Covers all / any / not, nesting, **reuse (CQ3)**, cycle→false, **broken-child→false (regress-lock)**, and the **fail-open top-level boundary**.

**Revert-verify** ([[integration-test-revert-verify]]) — each RED→GREEN confirmed out-of-band (2026-07-04, `feat/composite-preconditions`):

| Revert | RED | Restored |
|---|---|---|
| remove `if (precondition.broken) return false` (evaluator) | 3/16 (broken-child, cycle, malformed) | GREEN |
| remove the evaluator composite branch | 7/16 (all/any/nested/reuse/cycle/broken/malformed) | GREEN |
| loader first-child-only (`[0]`) instead of all refs | 7/16 | GREEN |
| top-level fail-open `return null` → broken node | 1/16 (top-level unresolvable) | GREEN |
| drop the render memo | 1/16 (reuse "ASK ran once" → 2) | GREEN |

16/16 GREEN with the fix. Local gates: `check:types` 0 errors; 302 precondition/resolver tests pass; `check-test-antipatterns` + shard + coverage-monotonic guards OK; prettier clean.

## Requirement (feature-sdd)

`@req:4370db77-3df2-48d3-bf20-f439d49fc12e` (exoas-exo-reqs, **proposed** on remote main — flipped **active** after this merges, per req-first-sdd-ci-binding ordering). Bound by the `broken child …` test.

## Scope

IN: `packages/core` model / loader / evaluator + production-shape tests. OUT: Phase 5 release, Phase 6 baseline-refactor. The exocortex `packages/exoas-exo-reqs` submodule pointer is intentionally **not** bumped (the req binding resolves via the reqs-repo remote, per req-first-sdd-ci-binding).

Closes RFC df602adc Phase 4.
