### PR TITLE
feat(exocmd): "Clean Properties" button visible only when the asset has empty properties

### DIFF
--- a/packages/cli/src/commands/apply.ts
+++ b/packages/cli/src/commands/apply.ts
@@ -43,6 +43,7 @@ import { ExitCodes } from "../utils/ExitCodes.js";
 import { FileSystemVaultAdapter } from "../adapters/FileSystemVaultAdapter.js";
 import { NodeFsAdapter } from "../adapters/NodeFsAdapter.js";
 import { createIsInWrongFolderHostFunction } from "../precondition/createIsInWrongFolderHostFunction.js";
+import { createHasEmptyPropertiesHostFunction } from "../precondition/createHasEmptyPropertiesHostFunction.js";
 import { populateCliServiceRegistry } from "../services/CliServiceRegistryPopulator.js";
 import { FsQueryBodyResolver } from "../services/FsQueryBodyResolver.js";
 import { registerOrderSpecFromVault } from "../services/registerOrderSpec.js";
@@ -230,6 +231,13 @@ async function executeOnTarget(
   evaluator.registerHostFunction(
     "isInWrongFolder",
     createIsInWrongFolderHostFunction(vaultAdapter, folderRepairService),
+  );
+  // `hasObsoleteProperties` gates the homoiconic "Clean Properties" command
+  // (asset 0da175e1) on the presence of empty frontmatter properties — same
+  // fail-open fix as isInWrongFolder, mirrored on the CLI surface.
+  evaluator.registerHostFunction(
+    "hasObsoleteProperties",
+    createHasEmptyPropertiesHostFunction(vaultAdapter),
   );
 
   // EvalContext populated with the fields the registered host functions

--- a/packages/cli/src/precondition/createHasEmptyPropertiesHostFunction.ts
+++ b/packages/cli/src/precondition/createHasEmptyPropertiesHostFunction.ts
@@ -1,0 +1,45 @@
+import {
+  hasEmptyProperties,
+  type HostFunction,
+  type IFile,
+  type IVaultAdapter,
+} from "@kitelev/exocortex-core";
+
+/**
+ * CLI counterpart of the plugin's
+ * `obsidian-plugin/src/infrastructure/precondition/createHasEmptyPropertiesHostFunction.ts`.
+ *
+ * Returns `true` only when the asset referenced by `ctx.filePath` has at least
+ * one EMPTY frontmatter property — a value that is `null`/`undefined`, an empty
+ * string (after trim), an empty array, or an empty object — exactly the
+ * properties `PropertyCleanupService.cleanEmptyProperties` removes. Used by the
+ * homoiconic "Clean Properties" exocmd command (vault asset
+ * `0da175e1-79e3-46b8-975b-adadeb40887a`) to keep
+ * `npx exocortex-cli apply clean-properties <path>` from running on assets that
+ * have nothing to clean.
+ *
+ * Fail-closed on missing context, missing file, or unreadable frontmatter —
+ * mirrors the plugin factory's contract so visible/invocable gating is
+ * symmetric between surfaces.
+ */
+export function createHasEmptyPropertiesHostFunction(
+  vaultAdapter: IVaultAdapter,
+): HostFunction {
+  return (ctx) => {
+    const filePath =
+      typeof ctx.filePath === "string" && ctx.filePath.length > 0
+        ? ctx.filePath
+        : null;
+    if (filePath === null) return false;
+
+    const node = vaultAdapter.getAbstractFileByPath(filePath);
+    if (node === null || !("basename" in node)) return false;
+    const file = node as IFile;
+
+    const metadata =
+      (vaultAdapter.getFrontmatter(file) as Record<string, unknown> | null) ??
+      {};
+
+    return hasEmptyProperties(metadata);
+  };
+}

--- a/packages/cli/src/precondition/createHasEmptyPropertiesHostFunction.ts
+++ b/packages/cli/src/precondition/createHasEmptyPropertiesHostFunction.ts
@@ -32,6 +32,12 @@ export function createHasEmptyPropertiesHostFunction(
         : null;
     if (filePath === null) return false;
 
+    // Templater templates (09 Templates/) carry exo__Asset_isDefinedBy by
+    // pattern inheritance but are NOT assets and must never be cleaned — never
+    // surface this destructive command on them (mirror the plugin factory +
+    // co-location-enforce hook exclusion, RFC 0b7a2fad CR-1).
+    if (filePath.split("/").includes("09 Templates")) return false;
+
     const node = vaultAdapter.getAbstractFileByPath(filePath);
     if (node === null || !("basename" in node)) return false;
     const file = node as IFile;

--- a/packages/cli/tests/integration/apply-clean-properties-precondition.integration.test.ts
+++ b/packages/cli/tests/integration/apply-clean-properties-precondition.integration.test.ts
@@ -1,0 +1,183 @@
+/**
+ * req:f05caada-fbaa-43fb-9808-e5330c685df4 — the homoiconic "Clean Properties"
+ * exocmd command (asset 0da175e1) is available ONLY on assets that have at
+ * least one EMPTY frontmatter property. Its precondition declares host function
+ * `hasObsoleteProperties`, which was UNREGISTERED in code → on the async
+ * inline-button path `PreconditionEvaluator.evaluateHostFunction` fell open
+ * (`return true`) and the button showed on every asset. The CLI surface gates
+ * `apply` on the same precondition, so it exhibits the parallel fail-open.
+ *
+ * Fix: register `hasObsoleteProperties` on the CLI/plugin PreconditionEvaluator
+ * via a factory that reads the target's frontmatter and returns the pure
+ * `hasEmptyProperties(metadata)` helper (mirrors `isInWrongFolder` / Issue #3302).
+ *
+ * Production-shape (test-fixture-realism): these tests run the REAL `apply`
+ * pipeline against a temp vault (no `--dry-run`; the mutated file is read back —
+ * dry-run-preview-not-real-output.md):
+ *   apply → NoteToRDFConverter.convertVault → CommandResolver.loadCommand →
+ *   PreconditionEvaluator.evaluate (real `hasObsoleteProperties` host function) →
+ *   GroundingExecutor → cleanProperties service (PropertyCleanupService).
+ *
+ * Revert-verify (integration-test-revert-verify): with the registration reverted
+ * (delete the `evaluator.registerHostFunction("hasObsoleteProperties", …)` line in
+ * `apply.ts`), the "CLEAN asset is blocked" test goes RED — the unregistered host
+ * function falls open, the precondition passes, and `apply` proceeds instead of
+ * printing "Precondition not satisfied". With the fix it is GREEN. The
+ * "EMPTY asset proceeds" test passes both ways (it was always fail-open on a
+ * clean-and-EMPTY asset), so it guards the working direction, not the regression.
+ */
+import {
+  jest,
+  describe,
+  it,
+  expect,
+  beforeEach,
+  afterEach,
+} from "@jest/globals";
+import * as fs from "fs";
+import * as path from "path";
+import * as os from "os";
+
+const { applyCommand } = await import("../../src/commands/apply.js");
+
+// GroundingType catalog UID (packages/core/src/domain/constants/GroundingTypeUIDs.ts)
+const GT_SERVICE_CALL = "9bf9fc99-ac37-4e51-b9f5-bd920099947c";
+
+// Fixture command / precondition / grounding (local UIDs).
+const CMD = "f05caada-0000-0000-0000-000000000001";
+const PRECOND = "f05caada-0000-0000-0000-000000000002";
+const GROUNDING = "f05caada-0000-0000-0000-000000000003";
+
+const fm = (lines: string[]): string => ["---", ...lines, "---", ""].join("\n");
+
+const CMD_MD = fm([
+  `exo__Asset_uid: ${CMD}`,
+  `exo__Asset_label: "Clean Properties (fixture)"`,
+  `exo__Asset_isDefinedBy: "[[!kitelev]]"`,
+  `exo__Instance_class: ["[[exocmd__Command]]"]`,
+  `exocmd__Command_cliName: clean-props-fixture`,
+  `exocmd__Command_precondition: "[[${PRECOND}|precondition]]"`,
+  `exocmd__Command_grounding: "[[${GROUNDING}|g]]"`,
+]);
+// Mirrors the real precondition asset 79a7fb4b — a host-function gate on
+// "has empty properties" (legacy name `hasObsoleteProperties`).
+const PRECOND_MD = fm([
+  `exo__Asset_uid: ${PRECOND}`,
+  `exo__Asset_label: "Has empty properties (fixture)"`,
+  `exo__Asset_isDefinedBy: "[[!kitelev]]"`,
+  `exo__Instance_class: ["[[exocmd__Precondition]]"]`,
+  `exocmd__Precondition_hostFunction: "hasObsoleteProperties"`,
+]);
+// Mirrors the real grounding de7914fb — service_call → cleanProperties.
+const GROUNDING_MD = fm([
+  `exo__Asset_uid: ${GROUNDING}`,
+  `exo__Asset_label: "Clean properties via service (fixture)"`,
+  `exo__Instance_class: ["[[exocmd__Grounding]]"]`,
+  `exocmd__Grounding_type: "[[${GT_SERVICE_CALL}]]"`,
+  `exocmd__Grounding_serviceId: "cleanProperties"`,
+]);
+
+function buildVault(): string {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "exo-cleanprops-"));
+  const write = (uid: string, md: string) =>
+    fs.writeFileSync(path.join(root, `${uid}.md`), md, "utf-8");
+  write(CMD, CMD_MD);
+  write(PRECOND, PRECOND_MD);
+  write(GROUNDING, GROUNDING_MD);
+  return root;
+}
+
+describe("req:f05caada — CLI apply clean-properties is gated by empty-property presence", () => {
+  let root: string;
+  let processExitSpy: jest.SpiedFunction<typeof process.exit>;
+  let consoleLogSpy: jest.SpiedFunction<typeof console.log>;
+  let consoleErrorSpy: jest.SpiedFunction<typeof console.error>;
+
+  beforeEach(() => {
+    processExitSpy = jest
+      .spyOn(process, "exit")
+      .mockImplementation(((code?: number) => {
+        throw new Error(`__process_exit_${code ?? 0}__`);
+      }) as never);
+    consoleLogSpy = jest.spyOn(console, "log").mockImplementation(() => {});
+    consoleErrorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+    root = buildVault();
+  });
+
+  afterEach(() => {
+    processExitSpy.mockRestore();
+    consoleLogSpy.mockRestore();
+    consoleErrorSpy.mockRestore();
+    if (root) fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  async function runApply(targetPath: string): Promise<void> {
+    const cmd = applyCommand();
+    try {
+      await cmd.parseAsync([
+        "node",
+        "apply",
+        "clean-props-fixture",
+        targetPath,
+        "--vault",
+        root,
+        "--yes",
+      ]);
+    } catch (err) {
+      if (!/^__process_exit_/.test(String((err as Error)?.message))) throw err;
+    }
+  }
+
+  function writeTarget(uid: string, extraLines: string[]): string {
+    const rel = `${uid}.md`;
+    fs.writeFileSync(
+      path.join(root, rel),
+      fm([
+        `exo__Asset_uid: ${uid}`,
+        `exo__Asset_label: "Target ${uid}"`,
+        ...extraLines,
+      ]),
+      "utf-8",
+    );
+    return rel;
+  }
+
+  function read(rel: string): string {
+    return fs.readFileSync(path.join(root, rel), "utf-8");
+  }
+
+  function preconditionBlocked(): boolean {
+    return consoleErrorSpy.mock.calls.some((c) =>
+      /Precondition not satisfied/.test(String(c[0])),
+    );
+  }
+
+  it("@req:f05caada-fbaa-43fb-9808-e5330c685df4 EMPTY-property asset → precondition passes and the empty property is removed (real mutation)", async () => {
+    // `empty_marker:` parses to null → an empty frontmatter value.
+    const rel = writeTarget("f05caada-0000-0000-0000-0000000000a1", [
+      "empty_marker:",
+    ]);
+
+    await runApply(rel);
+
+    expect(preconditionBlocked()).toBe(false);
+    const written = read(rel);
+    // cleanProperties removed the empty property; the real ones survive.
+    expect(written).not.toContain("empty_marker");
+    expect(written).toContain("exo__Asset_uid:");
+    expect(written).toContain("exo__Asset_label:");
+  });
+
+  it("@req:f05caada-fbaa-43fb-9808-e5330c685df4 CLEAN asset (no empty property) → precondition NOT satisfied, no mutation", async () => {
+    // Every frontmatter value is non-empty.
+    const rel = writeTarget("f05caada-0000-0000-0000-0000000000a2", [
+      "some_prop: a real value",
+    ]);
+    const before = read(rel);
+
+    await runApply(rel);
+
+    expect(preconditionBlocked()).toBe(true);
+    expect(read(rel)).toBe(before); // untouched
+  });
+});

--- a/packages/cli/tests/unit/precondition/createHasEmptyPropertiesHostFunction.test.ts
+++ b/packages/cli/tests/unit/precondition/createHasEmptyPropertiesHostFunction.test.ts
@@ -50,6 +50,18 @@ describe("createHasEmptyPropertiesHostFunction (CLI parity)", () => {
     expect(fn(baseCtx({ filePath: undefined }))).toBe(false);
   });
 
+  it("returns false for a Templater template (09 Templates/) even with an empty property", () => {
+    const fn = createHasEmptyPropertiesHostFunction(
+      buildAdapter({
+        node: buildFile("09 Templates/task-template.md"),
+        frontmatter: { exo__Asset_label: "ok", empty: null } as unknown as IFrontmatter,
+      }),
+    );
+    expect(
+      fn(baseCtx({ filePath: "09 Templates/task-template.md" })),
+    ).toBe(false);
+  });
+
   it("returns false when file not found in vault", () => {
     const fn = createHasEmptyPropertiesHostFunction(
       buildAdapter({ node: null }),

--- a/packages/cli/tests/unit/precondition/createHasEmptyPropertiesHostFunction.test.ts
+++ b/packages/cli/tests/unit/precondition/createHasEmptyPropertiesHostFunction.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect, jest } from "@jest/globals";
+import {
+  type EvalContext,
+  type IFile,
+  type IFolder,
+  type IFrontmatter,
+  type IVaultAdapter,
+} from "@kitelev/exocortex-core";
+import { createHasEmptyPropertiesHostFunction } from "../../../src/precondition/createHasEmptyPropertiesHostFunction.js";
+
+describe("createHasEmptyPropertiesHostFunction (CLI parity)", () => {
+  const buildFile = (path: string): IFile =>
+    ({
+      path,
+      basename: path.split("/").pop()?.replace(/\.md$/, "") ?? "",
+      name: path.split("/").pop() ?? "",
+      parent: { path: "x", name: "x" } as IFolder,
+    }) as IFile;
+
+  const buildAdapter = (opts: {
+    node?: IFile | IFolder | null;
+    frontmatter?: IFrontmatter | null;
+  }): IVaultAdapter =>
+    ({
+      getAbstractFileByPath: jest
+        .fn()
+        .mockReturnValue(opts.node === undefined ? null : opts.node),
+      getFrontmatter: jest
+        .fn()
+        .mockReturnValue(
+          opts.frontmatter === undefined ? null : opts.frontmatter,
+        ),
+    }) as unknown as IVaultAdapter;
+
+  const baseCtx = (overrides: Partial<EvalContext> = {}): EvalContext => ({
+    targetIRI: "obsidian://vault/x/asset.md",
+    fileBasename: "asset",
+    currentFolder: "x",
+    filePath: "x/asset.md",
+    ...overrides,
+  });
+
+  it("returns false when filePath missing from context", () => {
+    const fn = createHasEmptyPropertiesHostFunction(
+      buildAdapter({
+        node: buildFile("x/asset.md"),
+        frontmatter: { a: "" } as unknown as IFrontmatter,
+      }),
+    );
+    expect(fn(baseCtx({ filePath: undefined }))).toBe(false);
+  });
+
+  it("returns false when file not found in vault", () => {
+    const fn = createHasEmptyPropertiesHostFunction(
+      buildAdapter({ node: null }),
+    );
+    expect(fn(baseCtx())).toBe(false);
+  });
+
+  it("returns false when the node is a folder (no basename)", () => {
+    const fn = createHasEmptyPropertiesHostFunction(
+      buildAdapter({ node: { path: "x", name: "x" } as IFolder }),
+    );
+    expect(fn(baseCtx())).toBe(false);
+  });
+
+  it("returns false when frontmatter is null", () => {
+    const fn = createHasEmptyPropertiesHostFunction(
+      buildAdapter({ node: buildFile("x/asset.md"), frontmatter: null }),
+    );
+    expect(fn(baseCtx())).toBe(false);
+  });
+
+  it("returns false when every frontmatter value is non-empty", () => {
+    const fn = createHasEmptyPropertiesHostFunction(
+      buildAdapter({
+        node: buildFile("x/asset.md"),
+        frontmatter: {
+          exo__Asset_label: "Some label",
+          tags: ["a"],
+        } as unknown as IFrontmatter,
+      }),
+    );
+    expect(fn(baseCtx())).toBe(false);
+  });
+
+  it.each([
+    ["null value", { exo__Asset_label: "ok", empty: null }],
+    ["empty string", { exo__Asset_label: "ok", empty: "" }],
+    ["empty array", { exo__Asset_label: "ok", empty: [] }],
+    ["empty object", { exo__Asset_label: "ok", empty: {} }],
+  ])(
+    "returns true when the asset has an empty property — %s",
+    (_label, frontmatter) => {
+      const fn = createHasEmptyPropertiesHostFunction(
+        buildAdapter({
+          node: buildFile("x/asset.md"),
+          frontmatter: frontmatter as unknown as IFrontmatter,
+        }),
+      );
+      expect(fn(baseCtx())).toBe(true);
+    },
+  );
+});

--- a/packages/obsidian-plugin/src/ExocortexPlugin.ts
+++ b/packages/obsidian-plugin/src/ExocortexPlugin.ts
@@ -585,12 +585,16 @@ export default class ExocortexPlugin extends Plugin {
 
       // Register `hasObsoleteProperties` host function used by the homoiconic
       // `Clean Properties` exocmd command (vault asset
-      // `0da175e1-79e3-46b8-975b-adadeb40887a`). Without this registration
-      // `evaluateHostFunction` fails open (`return true`) and the inline
-      // button + Cmd+P entry would show on every asset regardless of whether
-      // it has empty properties to clean. The behaviour it computes is "has
-      // empty frontmatter values" (the legacy host-function name is kept so
-      // the fix needs no re-sync of the exoas-exocmd assetspace).
+      // `0da175e1-79e3-46b8-975b-adadeb40887a`). Without this registration the
+      // async inline-button path (`evaluateHostFunction`) fails OPEN
+      // (`return true`) so the button showed on every asset regardless of
+      // whether it had empty properties to clean; the sync Cmd+P path
+      // (`evaluateHostFunctionSync`) fails CLOSED for an unregistered name, so
+      // the palette entry was hidden everywhere. This registration makes both
+      // surfaces gate on the actual presence of empty properties. The
+      // behaviour it computes is "has empty frontmatter values" (the legacy
+      // host-function name is kept so the fix needs no re-sync of the
+      // exoas-exocmd assetspace).
       this.preconditionEvaluator.registerHostFunction(
         "hasObsoleteProperties",
         createHasEmptyPropertiesHostFunction(this.app),

--- a/packages/obsidian-plugin/src/ExocortexPlugin.ts
+++ b/packages/obsidian-plugin/src/ExocortexPlugin.ts
@@ -90,6 +90,7 @@ import {
 import { ObsidianVaultAdapter } from "./adapters/ObsidianVaultAdapter";
 import { ObsidianQueryBodyResolver } from "./infrastructure/ObsidianQueryBodyResolver";
 import { createIsInWrongFolderHostFunction } from "./infrastructure/precondition/createIsInWrongFolderHostFunction";
+import { createHasEmptyPropertiesHostFunction } from "./infrastructure/precondition/createHasEmptyPropertiesHostFunction";
 import { TaskTrackingService } from "./application/services/TaskTrackingService";
 import { AliasSyncService } from "./application/services/AliasSyncService";
 import { WikilinkAliasService } from "./application/services/WikilinkAliasService";
@@ -580,6 +581,19 @@ export default class ExocortexPlugin extends Plugin {
           this.app,
           new FolderRepairService(this.vaultAdapter),
         ),
+      );
+
+      // Register `hasObsoleteProperties` host function used by the homoiconic
+      // `Clean Properties` exocmd command (vault asset
+      // `0da175e1-79e3-46b8-975b-adadeb40887a`). Without this registration
+      // `evaluateHostFunction` fails open (`return true`) and the inline
+      // button + Cmd+P entry would show on every asset regardless of whether
+      // it has empty properties to clean. The behaviour it computes is "has
+      // empty frontmatter values" (the legacy host-function name is kept so
+      // the fix needs no re-sync of the exoas-exocmd assetspace).
+      this.preconditionEvaluator.registerHostFunction(
+        "hasObsoleteProperties",
+        createHasEmptyPropertiesHostFunction(this.app),
       );
 
       // RFC c7da0bca Phase 3a — construct lazy loader. Parallel-mode: runs

--- a/packages/obsidian-plugin/src/infrastructure/precondition/createHasEmptyPropertiesHostFunction.ts
+++ b/packages/obsidian-plugin/src/infrastructure/precondition/createHasEmptyPropertiesHostFunction.ts
@@ -34,6 +34,13 @@ export function createHasEmptyPropertiesHostFunction(app: App): HostFunction {
         : null;
     if (filePath === null) return false;
 
+    // Templater templates (09 Templates/) carry exo__Asset_isDefinedBy by
+    // pattern inheritance but are NOT assets and must never be cleaned — never
+    // surface this destructive command on them (mirror
+    // createIsInWrongFolderHostFunction + co-location-enforce hook exclusion,
+    // RFC 0b7a2fad CR-1).
+    if (filePath.split("/").includes("09 Templates")) return false;
+
     const file = app.vault.getAbstractFileByPath(filePath);
     if (!(file instanceof TFile)) return false;
 

--- a/packages/obsidian-plugin/src/infrastructure/precondition/createHasEmptyPropertiesHostFunction.ts
+++ b/packages/obsidian-plugin/src/infrastructure/precondition/createHasEmptyPropertiesHostFunction.ts
@@ -1,0 +1,47 @@
+import { TFile, type App } from "obsidian";
+import { hasEmptyProperties, type HostFunction } from "@kitelev/exocortex-core";
+
+/**
+ * Factory for the `hasObsoleteProperties` precondition host function used by
+ * the homoiconic exocmd "Clean Properties" command (vault asset
+ * `0da175e1-79e3-46b8-975b-adadeb40887a`). Returns `true` only when the
+ * target asset's frontmatter contains at least one EMPTY property — a value
+ * that is `null`/`undefined`, an empty string (after trim), an empty array,
+ * or an empty object — exactly the properties the `cleanProperties` service
+ * (`PropertyCleanupService.cleanEmptyProperties`) removes.
+ *
+ * Hides the inline button + the Cmd+P palette entry on assets that have no
+ * empty properties to clean. Without this registration
+ * `PreconditionEvaluator.evaluateHostFunction` fails open (`return true`) on
+ * the async inline-button path and the button would show on EVERY asset —
+ * the exact bug this closes. Mirrors the `isInWrongFolder` / "Repair Folder"
+ * wiring (`createIsInWrongFolderHostFunction`, Issue #3302).
+ *
+ * The host-function NAME is the legacy `hasObsoleteProperties` baked into the
+ * precondition asset (`79a7fb4b`); keeping that name means the fix reaches the
+ * user on a plain plugin update with no re-sync of the `exoas-exocmd`
+ * assetspace. The behaviour it computes is "has empty frontmatter values",
+ * delegated to the pure core `hasEmptyProperties` helper.
+ *
+ * Falls back to `false` (hide) whenever the file or its frontmatter cannot be
+ * resolved — fail-closed for consistency with the other exocmd host gates.
+ */
+export function createHasEmptyPropertiesHostFunction(app: App): HostFunction {
+  return (ctx) => {
+    const filePath =
+      typeof ctx.filePath === "string" && ctx.filePath.length > 0
+        ? ctx.filePath
+        : null;
+    if (filePath === null) return false;
+
+    const file = app.vault.getAbstractFileByPath(filePath);
+    if (!(file instanceof TFile)) return false;
+
+    const metadata =
+      (app.metadataCache.getFileCache(file)?.frontmatter as
+        | Record<string, unknown>
+        | undefined) ?? {};
+
+    return hasEmptyProperties(metadata);
+  };
+}

--- a/packages/obsidian-plugin/tests/unit/infrastructure/precondition/createHasEmptyPropertiesHostFunction.test.ts
+++ b/packages/obsidian-plugin/tests/unit/infrastructure/precondition/createHasEmptyPropertiesHostFunction.test.ts
@@ -42,6 +42,18 @@ describe("createHasEmptyPropertiesHostFunction", () => {
     expect(fn(baseCtx())).toBe(false);
   });
 
+  it("returns false for a Templater template (09 Templates/) even with an empty property", () => {
+    const fn = createHasEmptyPropertiesHostFunction(
+      buildApp({
+        file: new TFile("09 Templates/task-template.md"),
+        metadata: { exo__Asset_label: "ok", empty: null },
+      }),
+    );
+    expect(fn(baseCtx({ filePath: "09 Templates/task-template.md" }))).toBe(
+      false,
+    );
+  });
+
   it("returns false when the abstract file is a folder (not a TFile)", () => {
     const fn = createHasEmptyPropertiesHostFunction(
       buildApp({ file: new TFolder("x") }),

--- a/packages/obsidian-plugin/tests/unit/infrastructure/precondition/createHasEmptyPropertiesHostFunction.test.ts
+++ b/packages/obsidian-plugin/tests/unit/infrastructure/precondition/createHasEmptyPropertiesHostFunction.test.ts
@@ -1,0 +1,95 @@
+import { App, TFile, TFolder } from "obsidian";
+import { type EvalContext } from "@kitelev/exocortex-core";
+import { createHasEmptyPropertiesHostFunction } from "../../../../src/infrastructure/precondition/createHasEmptyPropertiesHostFunction";
+
+describe("createHasEmptyPropertiesHostFunction", () => {
+  const buildApp = (opts: {
+    file?: TFile | TFolder | null;
+    metadata?: Record<string, unknown> | null;
+  }): App =>
+    ({
+      vault: {
+        getAbstractFileByPath: jest
+          .fn()
+          .mockReturnValue(opts.file === undefined ? null : opts.file),
+      },
+      metadataCache: {
+        getFileCache: jest.fn().mockReturnValue(
+          opts.metadata === null
+            ? null
+            : { frontmatter: opts.metadata ?? {} },
+        ),
+      },
+    }) as unknown as App;
+
+  const baseCtx = (overrides: Partial<EvalContext> = {}): EvalContext => ({
+    targetIRI: "obsidian://vault/x/asset.md",
+    fileBasename: "asset",
+    currentFolder: "x",
+    filePath: "x/asset.md",
+    ...overrides,
+  });
+
+  it("returns false when filePath missing from context", () => {
+    const fn = createHasEmptyPropertiesHostFunction(
+      buildApp({ file: new TFile("x/asset.md"), metadata: { a: "" } }),
+    );
+    expect(fn(baseCtx({ filePath: undefined }))).toBe(false);
+  });
+
+  it("returns false when file not found in vault", () => {
+    const fn = createHasEmptyPropertiesHostFunction(buildApp({ file: null }));
+    expect(fn(baseCtx())).toBe(false);
+  });
+
+  it("returns false when the abstract file is a folder (not a TFile)", () => {
+    const fn = createHasEmptyPropertiesHostFunction(
+      buildApp({ file: new TFolder("x") }),
+    );
+    expect(fn(baseCtx())).toBe(false);
+  });
+
+  it("returns false when frontmatter cache is absent", () => {
+    const fn = createHasEmptyPropertiesHostFunction(
+      buildApp({ file: new TFile("x/asset.md"), metadata: null }),
+    );
+    expect(fn(baseCtx())).toBe(false);
+  });
+
+  it("returns false when the asset has no frontmatter at all (empty object)", () => {
+    const fn = createHasEmptyPropertiesHostFunction(
+      buildApp({ file: new TFile("x/asset.md"), metadata: {} }),
+    );
+    expect(fn(baseCtx())).toBe(false);
+  });
+
+  it("returns false when every frontmatter value is non-empty", () => {
+    const fn = createHasEmptyPropertiesHostFunction(
+      buildApp({
+        file: new TFile("x/asset.md"),
+        metadata: {
+          exo__Asset_label: "Some label",
+          exo__Asset_uid: "1234",
+          tags: ["a", "b"],
+        },
+      }),
+    );
+    expect(fn(baseCtx())).toBe(false);
+  });
+
+  it.each([
+    ["null value (`key:`)", { exo__Asset_label: "ok", empty: null }],
+    ["empty string", { exo__Asset_label: "ok", empty: "" }],
+    ["whitespace-only string", { exo__Asset_label: "ok", empty: "   " }],
+    ["empty array", { exo__Asset_label: "ok", empty: [] }],
+    ["empty object", { exo__Asset_label: "ok", empty: {} }],
+  ])(
+    "returns true when the asset has an empty property — %s",
+    (_label, metadata) => {
+      const fn = createHasEmptyPropertiesHostFunction(
+        buildApp({ file: new TFile("x/asset.md"), metadata }),
+      );
+      expect(fn(baseCtx())).toBe(true);
+    },
+  );
+});


### PR DESCRIPTION
## What

Gate the homoiconic **"Clean Properties"** exocmd command (vault asset `0da175e1`) so its inline button / Cmd+P entry / CLI `apply clean-properties` are shown **only when the target asset has ≥1 empty frontmatter property** (a value that is `null`, empty string, empty array, or empty object — exactly what the `cleanProperties` service removes). Previously the button showed on **every** asset.

## Why (root cause)

The command's precondition asset (`79a7fb4b`) declares host function `exocmd__Precondition_hostFunction: hasObsoleteProperties`, but that name was **never registered in code**. `PreconditionEvaluator.evaluateHostFunction` then falls **open** (`return true`) on the async inline-button path → button always visible. (On the sync palette path it fell closed, so the palette entry was hidden — an inconsistency this also fixes.)

## Fix

Register `hasObsoleteProperties` on the plugin **and** CLI `PreconditionEvaluator` via a small factory that reads the target's frontmatter and returns the existing pure core helper `hasEmptyProperties(metadata)`. Directly mirrors the `isInWrongFolder` / "Repair Folder" wiring (Issue #3302).

- The legacy host-function **name** `hasObsoleteProperties` is kept (not renamed to `hasEmptyProperties`) so the fix reaches users on a plain plugin update with **no re-sync** of the `exoas-exocmd` assetspace. Behaviour computed = "has empty frontmatter values".

## Files

- `packages/obsidian-plugin/src/infrastructure/precondition/createHasEmptyPropertiesHostFunction.ts` (new factory)
- `packages/cli/src/precondition/createHasEmptyPropertiesHostFunction.ts` (new factory, CLI parity)
- `ExocortexPlugin.ts` + `apply.ts` — register the host function
- 3 tests (plugin factory unit, CLI factory unit, CLI integration)

## Tests / revert-verify

- Plugin factory unit **11/11**, CLI factory unit **9/9**, CLI integration **2/2**.
- Core `PreconditionEvaluator` + visibility `helpers` regression **358/358**; sibling `isInWrongFolder` suites green.
- **Revert-verify** (`@req:f05caada-fbaa-43fb-9808-e5330c685df4`): removing the `apply.ts` registration → the CLEAN-asset integration test goes **RED** (precondition falls open, apply proceeds); restoring → **2/2 GREEN**.

Req: f05caada-fbaa-43fb-9808-e5330c685df4

https://claude.ai/code/session_01PMcjpHdkjyV9EWMWrgLb3K
