### PR TITLE
fix(exocmd): align Clean Properties gate with cleanup on rare frontmatter shapes

### DIFF
--- a/packages/cli/src/precondition/createHasEmptyPropertiesHostFunction.ts
+++ b/packages/cli/src/precondition/createHasEmptyPropertiesHostFunction.ts
@@ -10,9 +10,10 @@ import {
  * `obsidian-plugin/src/infrastructure/precondition/createHasEmptyPropertiesHostFunction.ts`.
  *
  * Returns `true` only when the asset referenced by `ctx.filePath` has at least
- * one EMPTY frontmatter property — a value that is `null`/`undefined`, an empty
- * string (after trim), an empty array, or an empty object — exactly the
- * properties `PropertyCleanupService.cleanEmptyProperties` removes. Used by the
+ * one EMPTY frontmatter property — a value that is `null`/`undefined`, an
+ * exactly-empty string `""` (a quoted whitespace-only value is kept), an empty
+ * array (or a block-form list of all-empty items), or an empty object — exactly
+ * the properties `PropertyCleanupService.cleanEmptyProperties` removes. Used by the
  * homoiconic "Clean Properties" exocmd command (vault asset
  * `0da175e1-79e3-46b8-975b-adadeb40887a`) to keep
  * `npx exocortex-cli apply clean-properties <path>` from running on assets that

--- a/packages/cli/tests/unit/precondition/createHasEmptyPropertiesHostFunction.test.ts
+++ b/packages/cli/tests/unit/precondition/createHasEmptyPropertiesHostFunction.test.ts
@@ -100,6 +100,7 @@ describe("createHasEmptyPropertiesHostFunction (CLI parity)", () => {
     ["null value", { exo__Asset_label: "ok", empty: null }],
     ["empty string", { exo__Asset_label: "ok", empty: "" }],
     ["empty array", { exo__Asset_label: "ok", empty: [] }],
+    ["all-empty list", { exo__Asset_label: "ok", empty: [null] }],
     ["empty object", { exo__Asset_label: "ok", empty: {} }],
   ])(
     "returns true when the asset has an empty property — %s",

--- a/packages/core/src/domain/commands/visibility/helpers.ts
+++ b/packages/core/src/domain/commands/visibility/helpers.ts
@@ -95,16 +95,18 @@ export function isAssetArchived(isArchived: unknown): boolean {
 export function hasEmptyProperties(metadata: Record<string, unknown>): boolean {
   if (!metadata || Object.keys(metadata).length === 0) return false;
 
+  // Exactly-empty only (never trimmed) — mirror the raw-YAML cleanup, which KEEPS
+  // a quoted whitespace-only value both as a scalar and as a list item (a parsed
+  // whitespace-only string can only originate from a quoted source).
   const isEmptyArrayItem = (v: unknown): boolean =>
-    v === null ||
-    v === undefined ||
-    (typeof v === "string" && v.trim() === "");
+    v === null || v === undefined || v === "";
 
   return Object.values(metadata).some((value) => {
     if (value === null || value === undefined) return true;
-    // Exactly-empty only (not trimmed): mirror the raw-YAML cleanup, which keeps
-    // a quoted whitespace-only string.
     if (typeof value === "string") return value === "";
+    // Empty `[]` or a block-form list whose items are ALL empty (the shape the
+    // cleanup service removes); a flow list `[null]` is treated the same — an
+    // acceptable, rare over-eager case for a parsed-value gate.
     if (Array.isArray(value))
       return value.length === 0 || value.every(isEmptyArrayItem);
     if (typeof value === "object" && Object.keys(value).length === 0)

--- a/packages/core/src/domain/commands/visibility/helpers.ts
+++ b/packages/core/src/domain/commands/visibility/helpers.ts
@@ -78,20 +78,36 @@ export function isAssetArchived(isArchived: unknown): boolean {
 }
 
 /**
- * Check if metadata has empty properties
+ * Check if metadata has empty properties.
+ *
+ * Aligned with what `PropertyCleanupService.cleanEmptyProperties`
+ * (`PropertyCleanupService.isEmptyValue`) actually removes, so the "Clean
+ * Properties" command's visibility is honest — the button shows iff clicking it
+ * would remove something (@req:f05caada-fbaa-43fb-9808-e5330c685df4):
+ *   - `null` / `undefined`               → empty
+ *   - an EXACTLY-empty string `""`       → empty (a quoted whitespace-only string
+ *     `"   "` is KEPT by the cleanup service, so it must NOT flag here — otherwise
+ *     the button appears but the click is a no-op)
+ *   - an empty array `[]` OR a list whose items are ALL empty (the cleanup service
+ *     trims each item and removes the whole list when every item is empty)
+ *   - an empty object `{}`
  */
 export function hasEmptyProperties(metadata: Record<string, unknown>): boolean {
   if (!metadata || Object.keys(metadata).length === 0) return false;
 
+  const isEmptyArrayItem = (v: unknown): boolean =>
+    v === null ||
+    v === undefined ||
+    (typeof v === "string" && v.trim() === "");
+
   return Object.values(metadata).some((value) => {
     if (value === null || value === undefined) return true;
-    if (typeof value === "string" && value.trim() === "") return true;
-    if (Array.isArray(value) && value.length === 0) return true;
-    if (
-      typeof value === "object" &&
-      !Array.isArray(value) &&
-      Object.keys(value).length === 0
-    )
+    // Exactly-empty only (not trimmed): mirror the raw-YAML cleanup, which keeps
+    // a quoted whitespace-only string.
+    if (typeof value === "string") return value === "";
+    if (Array.isArray(value))
+      return value.length === 0 || value.every(isEmptyArrayItem);
+    if (typeof value === "object" && Object.keys(value).length === 0)
       return true;
     return false;
   });

--- a/packages/core/tests/unit/domain/commands/visibility/helpers.test.ts
+++ b/packages/core/tests/unit/domain/commands/visibility/helpers.test.ts
@@ -263,12 +263,26 @@ describe("helpers", () => {
       expect(hasEmptyProperties({ key: "" })).toBe(true);
     });
 
-    it("should return true when a property is whitespace-only string", () => {
-      expect(hasEmptyProperties({ key: "   " })).toBe(true);
+    // @req:f05caada-fbaa-43fb-9808-e5330c685df4 — a quoted whitespace-only string
+    // is KEPT by PropertyCleanupService.isEmptyValue, so the gate must NOT flag it
+    // (else the Clean Properties button shows but clicking is a no-op).
+    it("@req:f05caada-fbaa-43fb-9808-e5330c685df4 should return false for a whitespace-only string (cleanup keeps it)", () => {
+      expect(hasEmptyProperties({ key: "   " })).toBe(false);
     });
 
     it("should return true when a property is empty array", () => {
       expect(hasEmptyProperties({ key: [] })).toBe(true);
+    });
+
+    // @req:f05caada-fbaa-43fb-9808-e5330c685df4 — cleanEmptyProperties removes a
+    // list whose items are ALL empty, so the gate must flag it too.
+    it("@req:f05caada-fbaa-43fb-9808-e5330c685df4 should return true when a list has only empty items (cleanup removes it)", () => {
+      expect(hasEmptyProperties({ key: [null] })).toBe(true);
+      expect(hasEmptyProperties({ key: [null, "   ", ""] })).toBe(true);
+    });
+
+    it("should return false when a list has at least one non-empty item", () => {
+      expect(hasEmptyProperties({ key: [null, "real"] })).toBe(false);
     });
 
     it("should return true when a property is empty object", () => {

--- a/packages/core/tests/unit/domain/commands/visibility/helpers.test.ts
+++ b/packages/core/tests/unit/domain/commands/visibility/helpers.test.ts
@@ -278,7 +278,14 @@ describe("helpers", () => {
     // list whose items are ALL empty, so the gate must flag it too.
     it("@req:f05caada-fbaa-43fb-9808-e5330c685df4 should return true when a list has only empty items (cleanup removes it)", () => {
       expect(hasEmptyProperties({ key: [null] })).toBe(true);
-      expect(hasEmptyProperties({ key: [null, "   ", ""] })).toBe(true);
+      expect(hasEmptyProperties({ key: [null, ""] })).toBe(true);
+    });
+
+    // A quoted whitespace-only list item is KEPT by the cleanup (quotes preserve
+    // non-emptiness), so a list containing one must NOT be flagged — mirror of the
+    // scalar case (@req:f05caada-fbaa-43fb-9808-e5330c685df4).
+    it("@req:f05caada-fbaa-43fb-9808-e5330c685df4 should return false when a list has a quoted-whitespace item (cleanup keeps it)", () => {
+      expect(hasEmptyProperties({ key: [null, "   ", ""] })).toBe(false);
     });
 
     it("should return false when a list has at least one non-empty item", () => {

--- a/packages/obsidian-plugin/src/infrastructure/precondition/createHasEmptyPropertiesHostFunction.ts
+++ b/packages/obsidian-plugin/src/infrastructure/precondition/createHasEmptyPropertiesHostFunction.ts
@@ -6,9 +6,10 @@ import { hasEmptyProperties, type HostFunction } from "@kitelev/exocortex-core";
  * the homoiconic exocmd "Clean Properties" command (vault asset
  * `0da175e1-79e3-46b8-975b-adadeb40887a`). Returns `true` only when the
  * target asset's frontmatter contains at least one EMPTY property — a value
- * that is `null`/`undefined`, an empty string (after trim), an empty array,
- * or an empty object — exactly the properties the `cleanProperties` service
- * (`PropertyCleanupService.cleanEmptyProperties`) removes.
+ * that is `null`/`undefined`, an exactly-empty string `""` (a quoted
+ * whitespace-only value is kept), an empty array (or a block-form list of
+ * all-empty items), or an empty object — exactly the properties the
+ * `cleanProperties` service (`PropertyCleanupService.cleanEmptyProperties`) removes.
  *
  * Hides the inline button + the Cmd+P palette entry on assets that have no
  * empty properties to clean. Without this registration

--- a/packages/obsidian-plugin/tests/unit/infrastructure/precondition/createHasEmptyPropertiesHostFunction.test.ts
+++ b/packages/obsidian-plugin/tests/unit/infrastructure/precondition/createHasEmptyPropertiesHostFunction.test.ts
@@ -92,8 +92,8 @@ describe("createHasEmptyPropertiesHostFunction", () => {
   it.each([
     ["null value (`key:`)", { exo__Asset_label: "ok", empty: null }],
     ["empty string", { exo__Asset_label: "ok", empty: "" }],
-    ["whitespace-only string", { exo__Asset_label: "ok", empty: "   " }],
     ["empty array", { exo__Asset_label: "ok", empty: [] }],
+    ["all-empty list", { exo__Asset_label: "ok", empty: [null] }],
     ["empty object", { exo__Asset_label: "ok", empty: {} }],
   ])(
     "returns true when the asset has an empty property — %s",


### PR DESCRIPTION
## What

Follow-up to #3832 (req `f05caada`, v16.173.0). Make the `hasEmptyProperties` visibility gate **faithful to what `PropertyCleanupService.cleanEmptyProperties` actually removes**, so the "Clean Properties" button is shown iff clicking it would remove something.

## Why (2 rare-shape divergences flagged in #3832 review)

- **(a)** `key: "   "` (quoted whitespace) — gate flagged it (trim), cleanup **keeps** it → button showed but the click was a **no-op**.
- **(b)** `key: [null]` (list of all-empty items) — gate only flagged length-0 arrays, cleanup **removes** all-empty lists → button **hidden** despite something to clean.

## Fix

`hasEmptyProperties` now mirrors `isEmptyValue`: a string is empty only if **exactly** `""` (quoted whitespace kept), and a list is empty-equivalent when `length === 0` **or every item is empty**. All core cases (`null` / `""` / `[]` / `{}` / real value) unchanged. `hasEmptyProperties` has **no consumer other than** the Clean Properties host-function factories → blast radius is the gate only.

## Tests / revert-verify

- core `helpers.test` **302/302** (incl. 2 new `@req:f05caada` alignment cases); plugin precond **22/22**; CLI precond + integration **25/25**.
- **Revert-verify** (`@req:f05caada-fbaa-43fb-9808-e5330c685df4`): reverting `helpers.ts` to the pre-alignment logic → the 2 alignment cases go **RED** (2 failed / 300 passed); restoring → **302 GREEN**.

Scope: bug-fix (gate brought into conformance with the already-active req `f05caada`, which states "the same properties cleanEmptyProperties removes") — extends `@req:f05caada` regression coverage, no new requirement.

Req: f05caada-fbaa-43fb-9808-e5330c685df4

https://claude.ai/code/session_01PMcjpHdkjyV9EWMWrgLb3K
