### PR TITLE
feat(cli): resolve-buttons — actual command button-set oracle (#3833)

### DIFF
--- a/packages/cli/src/commands/resolve-buttons.ts
+++ b/packages/cli/src/commands/resolve-buttons.ts
@@ -25,10 +25,12 @@ import { createIsInWrongFolderHostFunction } from "../precondition/createIsInWro
 import { createHasEmptyPropertiesHostFunction } from "../precondition/createHasEmptyPropertiesHostFunction.js";
 
 /**
- * Issue #3833 — `resolve-buttons <target>` prints the ACTUAL command button-set
- * the plugin would render on an asset's page: **Layer A** (binding-match via the
- * class hierarchy, `CommandResolver.resolveForAssetMulti`) **∩ Layer B**
- * (precondition-eval, `PreconditionEvaluator.evaluate` per command).
+ * Issue #3833 — `resolve-buttons <target>` prints the command button-set the
+ * plugin resolves for an asset's page BEFORE the (downstream, out-of-scope)
+ * RFC-024 class-panel filter: **Layer A** (binding-match via the class
+ * hierarchy, `CommandResolver.resolveForAssetMulti`) **∩ Layer B**
+ * (precondition-eval, `PreconditionEvaluator.evaluate` per command). For the
+ * common case (no `exo__Layout` panel) this equals the live rendered set.
  *
  * This is the authoritative button-visibility oracle for layout auditing — it
  * mirrors the plugin caller `DynamicCommandButtonGroupBuilder.resolveViaFullPath`

--- a/packages/cli/src/commands/resolve-buttons.ts
+++ b/packages/cli/src/commands/resolve-buttons.ts
@@ -1,0 +1,412 @@
+import { Command } from "commander";
+import { existsSync } from "fs";
+import { resolve, relative, dirname, isAbsolute, sep as pathSep } from "path";
+import {
+  InMemoryTripleStore,
+  NoteToRDFConverter,
+  CommandResolver,
+  PreconditionEvaluator,
+  FolderRepairService,
+  registerDefaultHostFunctions,
+  vaultPathToIRI,
+  IRI,
+  Namespace,
+  liveClock,
+  type EvalContext,
+  type IClock,
+  type IFile,
+  type ResolvedCommand,
+} from "@kitelev/exocortex-core";
+import { ErrorHandler, type OutputFormat } from "../utils/ErrorHandler.js";
+import { VaultNotFoundError } from "../utils/errors/index.js";
+import { ExitCodes } from "../utils/ExitCodes.js";
+import { FileSystemVaultAdapter } from "../adapters/FileSystemVaultAdapter.js";
+import { createIsInWrongFolderHostFunction } from "../precondition/createIsInWrongFolderHostFunction.js";
+import { createHasEmptyPropertiesHostFunction } from "../precondition/createHasEmptyPropertiesHostFunction.js";
+
+/**
+ * Issue #3833 — `resolve-buttons <target>` prints the ACTUAL command button-set
+ * the plugin would render on an asset's page: **Layer A** (binding-match via the
+ * class hierarchy, `CommandResolver.resolveForAssetMulti`) **∩ Layer B**
+ * (precondition-eval, `PreconditionEvaluator.evaluate` per command).
+ *
+ * This is the authoritative button-visibility oracle for layout auditing — it
+ * mirrors the plugin caller `DynamicCommandButtonGroupBuilder.resolveViaFullPath`
+ * exactly (`resolveForAssetMulti` then per-command `evaluate`, keeping the
+ * resolver's `(priority, depth, order)` ordering). ⚠ It is STRICTLY more complete
+ * than `apply <cliName> --dry-run`, which checks ONLY the precondition (Layer B),
+ * never the binding targetClass-match (Layer A) — a bound-but-hidden command and
+ * a never-bound command are indistinguishable under dry-run but distinct here
+ * (`--show-hidden` surfaces the bound-but-hidden ones with reason
+ * `precondition-false`).
+ *
+ * Scope: reflects the inline-button layout surface. The command palette is a
+ * separate path (`findPaletteEnabledCommands`) and the RFC-024 class panel
+ * filter (`exo__Layout` include/exclude) is applied downstream of this in the
+ * plugin — both are deliberately out of scope; the binding ∩ precondition
+ * intersection is what layout curation (e.g. the D2 not-a-prototype gating)
+ * operates on. Zero engine changes — a thin wrapper over public core services.
+ */
+
+export interface ResolveButtonsOptions {
+  vault: string;
+  json?: boolean;
+  showHidden?: boolean;
+}
+
+/** One command in the resolved button-set. */
+export interface ButtonEntry {
+  /** Command asset UID. */
+  readonly id: string;
+  /** Human-readable button label (`exo__Asset_label`). */
+  readonly label: string;
+  /** `exocmd__Command_cliName` slug — `null` for inline-only commands. */
+  readonly cliName: string | null;
+  /** `exocmd__Command_category` — `null` when uncategorised. */
+  readonly category: string | null;
+  /** Only on `hidden` entries: why the command did not render. */
+  readonly reason?: "precondition-false";
+}
+
+/** Structured result of {@link resolveButtons}. Deterministic ordering. */
+export interface ResolveButtonsResult {
+  /** Vault-relative path of the target asset. */
+  readonly target: string;
+  /** Declared `exo__Instance_class` leaves fed to the binding resolver. */
+  readonly classes: string[];
+  /** Direct `exo__Asset_prototype` ref, or `null`. */
+  readonly prototype: string | null;
+  /**
+   * Commands that BIND (targetClass matched via class hierarchy) AND pass their
+   * precondition — the actual button-set, in the plugin's render order.
+   */
+  readonly visible: ButtonEntry[];
+  /**
+   * Commands that BIND but whose precondition evaluated `false`
+   * (`reason: "precondition-false"`) — the layout-curation diagnostic. Empty
+   * unless `--show-hidden`. (Never-bound commands are not enumerated — a
+   * bound-but-hidden command is the layout-relevant case.)
+   */
+  readonly hidden: ButtonEntry[];
+}
+
+const UUID_RE =
+  /([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\.md$/i;
+
+/**
+ * Clean a frontmatter class / prototype ref the same way the plugin's
+ * `DynamicCommandButtonGroupBuilder.extractAssetClasses` does: strip
+ * quote/bracket noise and keep only the wikilink TARGET (everything before the
+ * first `|` display alias). Returns `null` for non-string / empty values.
+ */
+function cleanRef(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  let cleaned = value.replace(/["'[\]]/g, "").trim();
+  const pipe = cleaned.indexOf("|");
+  if (pipe !== -1) cleaned = cleaned.slice(0, pipe).trim();
+  return cleaned.length > 0 ? cleaned : null;
+}
+
+/**
+ * Extract the raw `exo__Instance_class` leaves from frontmatter (UUID-canon
+ * refs in production). These UID leaves drive `resolveForAssetMulti`'s
+ * `exo__Class_superClass` ancestor walk (`getClassAncestors(<uid>)` resolves the
+ * class file by UID → walks superClass).
+ */
+function extractClasses(frontmatter: Record<string, unknown> | null): string[] {
+  if (!frontmatter) return [];
+  const raw = frontmatter["exo__Instance_class"];
+  const out: string[] = [];
+  const collect = (v: unknown): void => {
+    const c = cleanRef(v);
+    if (c && !out.includes(c)) out.push(c);
+  };
+  if (typeof raw === "string") collect(raw);
+  else if (Array.isArray(raw)) for (const item of raw) collect(item);
+  return out;
+}
+
+/**
+ * Convert an ontology IRI (`https://exocortex.my/ontology/<prefix>#<Local>`) to
+ * its symbolic class name (`<prefix>__<Local>`); `null` for non-ontology IRIs
+ * (e.g. `obsidian://vault/...md` file IRIs).
+ */
+function ontologyIriToSymbolic(value: string): string | null {
+  const m = value.match(/\/ontology\/([^#/]+)#(.+)$/);
+  return m ? `${m[1]}__${m[2]}` : null;
+}
+
+/**
+ * Derive the SYMBOLIC class names of the target's `exo__Instance_class` from the
+ * store. `NoteToRDFConverter` resolves a UID-canon `[[<class-uid>]]` ref to the
+ * class's symbolic IRI (`ems#Task`) at the `exo__Instance_class` predicate, so
+ * the store already holds the symbolic form the CommandBindings are authored
+ * against. This is the CLI's equivalent of the plugin's metadata-cache
+ * UID→symbolic expansion (`extractAssetClasses` #3141) — necessary because the
+ * converter substitutes class-shaped `exo__Asset_label` literals to IRIs too,
+ * which breaks the resolver's triple-store `resolveLabelByUID`/`findUidByLabel`
+ * (the plugin sidesteps this via metadataCache; the CLI reads the already-
+ * resolved symbolic instance_class IRIs instead).
+ */
+async function deriveStoreSymbolicClasses(
+  tripleStore: InMemoryTripleStore,
+  subjectIRI: string,
+): Promise<string[]> {
+  const triples = await tripleStore.match(
+    new IRI(subjectIRI),
+    Namespace.EXO.term("Instance_class"),
+    undefined,
+  );
+  const out: string[] = [];
+  for (const t of triples) {
+    const v =
+      typeof (t.object as { value?: unknown }).value === "string"
+        ? (t.object as { value: string }).value
+        : String(t.object);
+    const sym = ontologyIriToSymbolic(v);
+    if (sym && !out.includes(sym)) out.push(sym);
+  }
+  return out;
+}
+
+/**
+ * Build a `commandUid → cliName` map from `exocmd__Command_cliName` triples so
+ * the button-set can carry the CLI slug alongside the human label.
+ */
+async function buildCliNameMap(
+  tripleStore: InMemoryTripleStore,
+): Promise<Map<string, string>> {
+  const cliNameURI = new IRI(
+    "https://exocortex.my/ontology/exocmd#Command_cliName",
+  );
+  const triples = await tripleStore.match(undefined, cliNameURI, undefined);
+  const map = new Map<string, string>();
+  for (const t of triples) {
+    const subj =
+      typeof (t.subject as { value?: unknown }).value === "string"
+        ? (t.subject as { value: string }).value
+        : String(t.subject);
+    const obj =
+      typeof (t.object as { value?: unknown }).value === "string"
+        ? (t.object as { value: string }).value
+        : String(t.object);
+    const m = subj.match(UUID_RE);
+    if (m && obj.length > 0) map.set(m[1], obj);
+  }
+  return map;
+}
+
+/**
+ * Resolve the actual command button-set for a target asset — the core of the
+ * `resolve-buttons` command, exported for production-shape testing (real vault
+ * → NoteToRDFConverter → CommandResolver → PreconditionEvaluator, no mocks).
+ *
+ * @throws {VaultNotFoundError} when `vaultPath` does not exist.
+ * @throws {Error} when the target is missing or resolves outside the vault.
+ */
+export async function resolveButtons(
+  vaultPath: string,
+  targetRelative: string,
+  clock: IClock = liveClock(),
+): Promise<ResolveButtonsResult> {
+  const resolvedVault = resolve(vaultPath);
+  if (!existsSync(resolvedVault)) {
+    throw new VaultNotFoundError(resolvedVault);
+  }
+
+  const targetPath = resolve(resolvedVault, targetRelative);
+  if (!existsSync(targetPath)) {
+    throw new Error(`Target file not found: ${targetRelative}`);
+  }
+  // Issue #3788 parity — canonicalise to a vault-relative path before deriving
+  // the subject IRI. The store is keyed by each note's vault-relative
+  // `vaultPathToIRI(path)`; an absolute / escaping path yields a malformed IRI
+  // no subject matches, so every precondition ASK binds nothing (false).
+  const vaultRelative = relative(resolvedVault, targetPath);
+  if (
+    vaultRelative === ".." ||
+    vaultRelative.startsWith(`..${pathSep}`) ||
+    isAbsolute(vaultRelative)
+  ) {
+    throw new Error(
+      `Target is outside the vault: ${targetRelative} (vault: ${resolvedVault})`,
+    );
+  }
+
+  // Build the triple store from the whole vault (same machinery as `apply`).
+  const vaultAdapter = new FileSystemVaultAdapter(resolvedVault);
+  const converter = new NoteToRDFConverter(vaultAdapter);
+  const triples = await converter.convertVault();
+  const tripleStore = new InMemoryTripleStore();
+  await tripleStore.addAll(triples);
+
+  const subjectIRI = vaultPathToIRI(vaultRelative);
+
+  // Read the target's frontmatter → declared classes + prototype (mirrors the
+  // plugin's extractAssetClasses / extractPrototypeIRI inputs).
+  const targetNode = vaultAdapter.getAbstractFileByPath(vaultRelative);
+  const targetFile =
+    targetNode !== null && "basename" in targetNode
+      ? (targetNode as IFile)
+      : null;
+  const targetFrontmatter = targetFile
+    ? vaultAdapter.getFrontmatter(targetFile)
+    : null;
+  const frontmatterClasses = extractClasses(
+    targetFrontmatter as Record<string, unknown> | null,
+  );
+  // Union the raw UID leaves (drive the superClass ancestor walk) with the
+  // store's resolved SYMBOLIC instance_class (match class-targeted bindings
+  // directly) — see deriveStoreSymbolicClasses. `resolveForAssetMulti` dedups
+  // and is idempotent under this pre-expansion.
+  const storeSymbolicClasses = await deriveStoreSymbolicClasses(
+    tripleStore,
+    subjectIRI,
+  );
+  const assetClasses = [
+    ...new Set([...frontmatterClasses, ...storeSymbolicClasses]),
+  ];
+  const prototypeIRI = cleanRef(
+    (targetFrontmatter as Record<string, unknown> | null)?.[
+      "exo__Asset_prototype"
+    ],
+  );
+  const assetUidRaw = (targetFrontmatter as Record<string, unknown> | null)?.[
+    "exo__Asset_uid"
+  ];
+  const assetUid = typeof assetUidRaw === "string" ? assetUidRaw : undefined;
+
+  // Layer A — binding-match via class hierarchy (nearest-wins, sorted by the
+  // resolver's (priority, depth, order); this ordering IS the button order).
+  const resolver = new CommandResolver(tripleStore);
+  const resolved: ResolvedCommand[] = await resolver.resolveForAssetMulti(
+    subjectIRI,
+    assetClasses,
+    prototypeIRI ?? undefined,
+  );
+
+  // Precondition evaluator wired with the same host functions as `apply` so
+  // vault-declared `exocmd__Precondition_hostFunction` references resolve
+  // (mirrors ExocortexPlugin.ts / apply.ts).
+  const folderRepairService = new FolderRepairService(vaultAdapter);
+  const evaluator = new PreconditionEvaluator(tripleStore, undefined, { clock });
+  registerDefaultHostFunctions(evaluator);
+  evaluator.registerHostFunction(
+    "isInWrongFolder",
+    createIsInWrongFolderHostFunction(vaultAdapter, folderRepairService),
+  );
+  evaluator.registerHostFunction(
+    "hasObsoleteProperties",
+    createHasEmptyPropertiesHostFunction(vaultAdapter),
+  );
+
+  const parent = dirname(vaultRelative);
+  const evalContext: EvalContext = {
+    targetIRI: subjectIRI,
+    filePath: vaultRelative,
+    fileBasename: targetFile?.basename,
+    currentFolder: parent === "." ? "" : parent,
+    assetUid,
+  };
+
+  const cliNames = await buildCliNameMap(tripleStore);
+
+  // Layer B — per-command precondition filter (parallel, matching the plugin).
+  const evaluated = await Promise.all(
+    resolved.map(async (rc) => {
+      let available: boolean;
+      try {
+        available = await evaluator.evaluate(
+          rc.command.precondition,
+          subjectIRI,
+          evalContext,
+        );
+      } catch {
+        available = false; // fail-closed on evaluator error (plugin parity)
+      }
+      return { rc, available };
+    }),
+  );
+
+  const toEntry = (rc: ResolvedCommand): ButtonEntry => ({
+    id: rc.command.id,
+    label: rc.command.name,
+    cliName: cliNames.get(rc.command.id) ?? null,
+    category: rc.command.category ?? null,
+  });
+
+  const visible = evaluated.filter((e) => e.available).map((e) => toEntry(e.rc));
+  const hidden = evaluated
+    .filter((e) => !e.available)
+    .map((e) => ({ ...toEntry(e.rc), reason: "precondition-false" as const }));
+
+  return {
+    target: vaultRelative,
+    classes: assetClasses,
+    prototype: prototypeIRI,
+    visible,
+    hidden,
+  };
+}
+
+function printHuman(result: ResolveButtonsResult, showHidden: boolean): void {
+  const fmt = (e: ButtonEntry): string =>
+    `${e.label}${e.cliName ? `  (${e.cliName})` : ""}`;
+  console.log(
+    `Command buttons on "${result.target}" (${result.visible.length} visible):`,
+  );
+  if (result.visible.length === 0) {
+    console.log("  (none)");
+  } else {
+    for (const e of result.visible) console.log(`  ✓ ${fmt(e)}`);
+  }
+  if (showHidden) {
+    console.log(
+      `\nHidden by precondition (${result.hidden.length}):`,
+    );
+    if (result.hidden.length === 0) {
+      console.log("  (none)");
+    } else {
+      for (const e of result.hidden) {
+        console.log(`  ✗ ${fmt(e)} — precondition not satisfied`);
+      }
+    }
+  }
+}
+
+/**
+ * `exocortex resolve-buttons <target> [--vault <v>] [--json] [--show-hidden]`
+ * — Issue #3833. The authoritative inline-button-visibility oracle.
+ */
+export function resolveButtonsCommand(): Command {
+  return new Command("resolve-buttons")
+    .description(
+      "Print the actual command button-set for an asset — binding-match ∩ " +
+        "precondition-eval (Issue #3833). The authoritative button-visibility " +
+        "oracle; strictly more complete than `apply --dry-run` (precondition-only).",
+    )
+    .argument("<target>", "Vault-relative path to the target asset")
+    .option("--vault <path>", "Path to Obsidian vault", process.cwd())
+    .option("--json", "Emit structured JSON instead of human-readable text")
+    .option(
+      "--show-hidden",
+      "Also list commands that bind but are hidden by their precondition",
+    )
+    .action(async (targetArg: string, options: ResolveButtonsOptions) => {
+      ErrorHandler.setFormat("text" as OutputFormat);
+      try {
+        const result = await resolveButtons(options.vault, targetArg);
+        if (options.json) {
+          const payload = options.showHidden
+            ? result
+            : { ...result, hidden: [] };
+          console.log(JSON.stringify(payload, null, 2));
+        } else {
+          printHuman(result, options.showHidden ?? false);
+        }
+      } catch (error) {
+        ErrorHandler.handle(error as Error);
+        process.exit(ExitCodes.OPERATION_FAILED);
+      }
+    });
+}

--- a/packages/cli/src/program.ts
+++ b/packages/cli/src/program.ts
@@ -3,6 +3,7 @@ import { Command } from "commander";
 import { sparqlQueryCommand } from "./commands/sparql-query.js";
 import { sparqlIndexCommand } from "./commands/sparql-index.js";
 import { resolveCommand } from "./commands/resolve.js";
+import { resolveButtonsCommand } from "./commands/resolve-buttons.js";
 import { validateCommand } from "./commands/validate.js";
 import { classesCommand } from "./commands/classes.js";
 import { createCommand } from "./commands/create.js";
@@ -52,6 +53,10 @@ export function createProgram(version?: string): Command {
 
   // Auxiliary commands retained from v15
   program.addCommand(resolveCommand());
+  // Issue #3833 — authoritative inline-button-visibility oracle
+  // (binding-match ∩ precondition-eval; strictly more complete than
+  // `apply --dry-run`, which is precondition-only).
+  program.addCommand(resolveButtonsCommand());
   program.addCommand(classesCommand());
   program.addCommand(createCommand());
   program.addCommand(workflowCommand());

--- a/packages/cli/tests/integration/resolve-buttons.integration.test.ts
+++ b/packages/cli/tests/integration/resolve-buttons.integration.test.ts
@@ -1,0 +1,267 @@
+/**
+ * Issue #3833 — `resolve-buttons <target>` prints the ACTUAL command button-set
+ * for an asset: **Layer A** (binding-match via the class hierarchy) **∩ Layer B**
+ * (precondition-eval). It is the authoritative inline-button-visibility oracle,
+ * strictly more complete than `apply --dry-run` (precondition-only).
+ *
+ * Production-shape (test-fixture-realism): these tests run the REAL resolution
+ * pipeline against a temp vault of markdown assets — no mocks:
+ *   resolveButtons → NoteToRDFConverter.convertVault → CommandResolver
+ *   .resolveForAssetMulti (Layer A: hierarchy binding-match) →
+ *   PreconditionEvaluator.evaluate per command (Layer B). This mirrors the
+ *   plugin caller `DynamicCommandButtonGroupBuilder.resolveViaFullPath`.
+ *
+ * The fixture reproduces the D2 layout-curation MECHANISM (Issue #3833's AC2):
+ * a class `test__Widget` and a subclass `test__WidgetPrototype ⊑ test__Widget`.
+ * Three commands bind to `test__Widget`:
+ *   - Always      — no precondition → visible on both.
+ *   - NotOnProto   — precondition = STRENDS "not-a-prototype" (the real leaf's
+ *                    suffix form) → visible on the concrete Widget, HIDDEN on
+ *                    the prototype (mirrors "Create Task Instance"/planning
+ *                    commands curated off ems__TaskPrototype).
+ * A fourth command (Unbound) binds to an UNRELATED class → never appears on
+ * either target, proving Layer A (binding scope) actually filters.
+ *
+ * @req:960a7ba7-3470-42ba-afdc-f6766c3c3126  — the requirement UID for the resolve-buttons oracle.
+ *
+ * Revert-verify (integration-test-revert-verify): removing the Layer-B
+ * precondition filter in `resolveButtons` (return every bound command as
+ * visible) makes the "prototype HIDES NotOnProto" assertion go RED (the hidden
+ * command leaks into `visible`). With the filter it is GREEN. Verified locally:
+ *   RED  (filter reverted): prototype `visible` contains "NotOnProto".
+ *   GREEN (filter present):  prototype `visible` = ["Always"] only.
+ */
+import { describe, it, expect, beforeEach, afterEach } from "@jest/globals";
+import * as fs from "fs";
+import * as path from "path";
+import * as os from "os";
+
+const { resolveButtons } = await import("../../src/commands/resolve-buttons.js");
+
+// GroundingType catalog UID (packages/core/src/domain/constants/GroundingTypeUIDs.ts)
+const GT_SERVICE_CALL = "9bf9fc99-ac37-4e51-b9f5-bd920099947c";
+
+// Fixture UIDs (deterministic; local to this test).
+const CLASS_WIDGET = "3833aaaa-0000-0000-0000-000000000001";
+const CLASS_WIDGET_PROTO = "3833aaaa-0000-0000-0000-000000000002";
+const CMD_ALWAYS = "3833bbbb-0000-0000-0000-000000000001";
+const CMD_NOTONPROTO = "3833bbbb-0000-0000-0000-000000000002";
+const CMD_UNBOUND = "3833bbbb-0000-0000-0000-000000000003";
+const BIND_ALWAYS = "3833cccc-0000-0000-0000-000000000001";
+const BIND_NOTONPROTO = "3833cccc-0000-0000-0000-000000000002";
+const BIND_UNBOUND = "3833cccc-0000-0000-0000-000000000003";
+const PRE_NOTPROTO = "3833dddd-0000-0000-0000-000000000001";
+const GND_ALWAYS = "3833eeee-0000-0000-0000-000000000001";
+const GND_NOTONPROTO = "3833eeee-0000-0000-0000-000000000002";
+const GND_UNBOUND = "3833eeee-0000-0000-0000-000000000003";
+const TARGET_CONCRETE = "3833ffff-0000-0000-0000-000000000001";
+const TARGET_PROTO = "3833ffff-0000-0000-0000-000000000002";
+
+const fm = (lines: string[]): string => ["---", ...lines, "---", ""].join("\n");
+
+// The shipped "not-a-prototype" leaf uses a STRENDS suffix check on the SYMBOLIC
+// instance_class IRI (dual-IRI shape — sparql-iri-form-pre-verify). TRUE
+// (available) when the class does NOT end in "Prototype".
+const NOT_A_PROTOTYPE_ASK = [
+  "PREFIX exo: <https://exocortex.my/ontology/exo#>",
+  "ASK { FILTER NOT EXISTS {",
+  '  $target exo:Instance_class ?c . FILTER(STRENDS(STR(?c), "Prototype"))',
+  "} }",
+].join(" ");
+
+function grounding(uid: string, label: string): string {
+  return fm([
+    `exo__Asset_uid: ${uid}`,
+    `exo__Asset_label: "${label}"`,
+    `exo__Instance_class: ["[[exocmd__Grounding]]"]`,
+    `exocmd__Grounding_type: "[[${GT_SERVICE_CALL}]]"`,
+    `exocmd__Grounding_serviceId: "noop"`,
+  ]);
+}
+
+function command(
+  uid: string,
+  label: string,
+  cliName: string,
+  groundingUid: string,
+  preconditionUid?: string,
+): string {
+  const lines = [
+    `exo__Asset_uid: ${uid}`,
+    `exo__Asset_label: "${label}"`,
+    `exo__Asset_isDefinedBy: "[[!kitelev]]"`,
+    `exo__Instance_class: ["[[exocmd__Command]]"]`,
+    `exocmd__Command_cliName: ${cliName}`,
+    `exocmd__Command_category: create`,
+    `exocmd__Command_grounding: "[[${groundingUid}|g]]"`,
+  ];
+  if (preconditionUid) {
+    lines.push(`exocmd__Command_precondition: "[[${preconditionUid}|p]]"`);
+  }
+  return fm(lines);
+}
+
+function binding(
+  uid: string,
+  commandUid: string,
+  targetClass: string,
+  order: number,
+): string {
+  return fm([
+    `exo__Asset_uid: ${uid}`,
+    `exo__Asset_label: "binding ${uid}"`,
+    `exo__Instance_class: ["[[exocmd__CommandBinding]]"]`,
+    `exocmd__CommandBinding_command: "[[${commandUid}]]"`,
+    `exocmd__CommandBinding_targetClass: ${targetClass}`,
+    `exocmd__CommandBinding_position: inline`,
+    `exocmd__CommandBinding_order: ${order}`,
+  ]);
+}
+
+function buildVault(): string {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "exo-resolvebuttons-"));
+  const write = (uid: string, md: string) =>
+    fs.writeFileSync(path.join(root, `${uid}.md`), md, "utf-8");
+
+  // Classes: test__WidgetPrototype ⊑ test__Widget.
+  write(
+    CLASS_WIDGET,
+    fm([
+      `exo__Asset_uid: ${CLASS_WIDGET}`,
+      `exo__Asset_label: test__Widget`,
+      `exo__Instance_class: ["[[exo__Class]]"]`,
+    ]),
+  );
+  write(
+    CLASS_WIDGET_PROTO,
+    fm([
+      `exo__Asset_uid: ${CLASS_WIDGET_PROTO}`,
+      `exo__Asset_label: test__WidgetPrototype`,
+      `exo__Instance_class: ["[[exo__Class]]"]`,
+      // UUID-canon superClass ref (production shape) — the ancestor walk
+      // resolves the parent class file by UID (label→file resolution is broken
+      // by the converter's IRI-substitution of exo__Asset_label).
+      `exo__Class_superClass: "[[${CLASS_WIDGET}]]"`,
+    ]),
+  );
+
+  // Groundings (minimal, so loadCommand succeeds).
+  write(GND_ALWAYS, grounding(GND_ALWAYS, "Always grounding"));
+  write(GND_NOTONPROTO, grounding(GND_NOTONPROTO, "NotOnProto grounding"));
+  write(GND_UNBOUND, grounding(GND_UNBOUND, "Unbound grounding"));
+
+  // Not-a-prototype precondition (STRENDS suffix form).
+  write(
+    PRE_NOTPROTO,
+    fm([
+      `exo__Asset_uid: ${PRE_NOTPROTO}`,
+      `exo__Asset_label: "Target is not a prototype (fixture)"`,
+      `exo__Instance_class: ["[[exocmd__Precondition]]"]`,
+      // Single-quoted YAML so the inner SPARQL `"Prototype"` double-quotes stay
+      // literal (sparql-iri-form-pre-verify): a double-quoted YAML value would
+      // terminate early → empty sparqlAsk → precondition fails open (vacuous).
+      `exocmd__Precondition_sparqlAsk: '${NOT_A_PROTOTYPE_ASK}'`,
+    ]),
+  );
+
+  // Commands.
+  write(CMD_ALWAYS, command(CMD_ALWAYS, "Always", "always", GND_ALWAYS));
+  write(
+    CMD_NOTONPROTO,
+    command(
+      CMD_NOTONPROTO,
+      "NotOnProto",
+      "not-on-proto",
+      GND_NOTONPROTO,
+      PRE_NOTPROTO,
+    ),
+  );
+  write(CMD_UNBOUND, command(CMD_UNBOUND, "Unbound", "unbound", GND_UNBOUND));
+
+  // Bindings: Always + NotOnProto → test__Widget; Unbound → unrelated class.
+  write(BIND_ALWAYS, binding(BIND_ALWAYS, CMD_ALWAYS, "test__Widget", 10));
+  write(
+    BIND_NOTONPROTO,
+    binding(BIND_NOTONPROTO, CMD_NOTONPROTO, "test__Widget", 20),
+  );
+  write(BIND_UNBOUND, binding(BIND_UNBOUND, CMD_UNBOUND, "test__Other", 30));
+
+  // Targets — UUID-canon instance_class refs (production shape).
+  write(
+    TARGET_CONCRETE,
+    fm([
+      `exo__Asset_uid: ${TARGET_CONCRETE}`,
+      `exo__Asset_label: "Concrete widget"`,
+      `exo__Instance_class: ["[[${CLASS_WIDGET}]]"]`,
+    ]),
+  );
+  write(
+    TARGET_PROTO,
+    fm([
+      `exo__Asset_uid: ${TARGET_PROTO}`,
+      `exo__Asset_label: "Widget template"`,
+      `exo__Instance_class: ["[[${CLASS_WIDGET_PROTO}]]"]`,
+    ]),
+  );
+
+  return root;
+}
+
+describe("@req:960a7ba7-3470-42ba-afdc-f6766c3c3126 resolve-buttons — binding-match ∩ precondition-eval oracle", () => {
+  let root: string;
+
+  beforeEach(() => {
+    root = buildVault();
+  });
+
+  afterEach(() => {
+    if (root) fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  it("@req:960a7ba7-3470-42ba-afdc-f6766c3c3126 concrete Widget → both bound commands visible; unbound command excluded (Layer A ∩ Layer B)", async () => {
+    const result = await resolveButtons(root, `${TARGET_CONCRETE}.md`);
+    const labels = result.visible.map((e) => e.label);
+
+    // Layer B: not-a-prototype precondition PASSES on the concrete class.
+    expect(labels).toContain("Always");
+    expect(labels).toContain("NotOnProto");
+    // Layer A: a command bound to an unrelated class never binds here.
+    expect(labels).not.toContain("Unbound");
+    expect(result.hidden).toHaveLength(0);
+
+    // cliName + category surfaced for snapshot-friendly auditing.
+    const always = result.visible.find((e) => e.label === "Always");
+    expect(always?.cliName).toBe("always");
+    expect(always?.category).toBe("create");
+  });
+
+  it("@req:960a7ba7-3470-42ba-afdc-f6766c3c3126 prototype instance → NotOnProto HIDDEN by precondition; Always kept; unbound still excluded (Layer B curation)", async () => {
+    const result = await resolveButtons(root, `${TARGET_PROTO}.md`);
+    const visible = result.visible.map((e) => e.label);
+
+    // Layer A: prototype inherits test__Widget-bound commands via superClass.
+    // Layer B: the not-a-prototype precondition HIDES NotOnProto on the prototype.
+    expect(visible).toContain("Always");
+    expect(visible).not.toContain("NotOnProto");
+    expect(visible).not.toContain("Unbound");
+
+    // The bound-but-hidden command is surfaced with reason (the diagnostic
+    // `apply --dry-run` cannot give — it is precondition-only, never binding).
+    const hiddenLabels = result.hidden.map((e) => e.label);
+    expect(hiddenLabels).toContain("NotOnProto");
+    const notOnProto = result.hidden.find((e) => e.label === "NotOnProto");
+    expect(notOnProto?.reason).toBe("precondition-false");
+  });
+
+  it("@req:960a7ba7-3470-42ba-afdc-f6766c3c3126 output ordering is deterministic (resolver (priority, depth, order)) so a layout is snapshot-testable", async () => {
+    const a = await resolveButtons(root, `${TARGET_CONCRETE}.md`);
+    const b = await resolveButtons(root, `${TARGET_CONCRETE}.md`);
+    expect(a.visible.map((e) => e.id)).toEqual(b.visible.map((e) => e.id));
+    // Always (order 10) sorts before NotOnProto (order 20).
+    expect(a.visible.map((e) => e.label)).toEqual(["Always", "NotOnProto"]);
+  });
+
+  it("@req:960a7ba7-3470-42ba-afdc-f6766c3c3126 throws for a target outside the vault (Issue #3788 canonicalisation parity)", async () => {
+    await expect(resolveButtons(root, "../escape.md")).rejects.toThrow();
+  });
+});

--- a/packages/cli/tests/integration/resolve-buttons.integration.test.ts
+++ b/packages/cli/tests/integration/resolve-buttons.integration.test.ts
@@ -31,12 +31,14 @@
  *   RED  (filter reverted): prototype `visible` contains "NotOnProto".
  *   GREEN (filter present):  prototype `visible` = ["Always"] only.
  */
-import { describe, it, expect, beforeEach, afterEach } from "@jest/globals";
+import { jest, describe, it, expect, beforeEach, afterEach } from "@jest/globals";
 import * as fs from "fs";
 import * as path from "path";
 import * as os from "os";
 
-const { resolveButtons } = await import("../../src/commands/resolve-buttons.js");
+const { resolveButtons, resolveButtonsCommand } = await import(
+  "../../src/commands/resolve-buttons.js"
+);
 
 // GroundingType catalog UID (packages/core/src/domain/constants/GroundingTypeUIDs.ts)
 const GT_SERVICE_CALL = "9bf9fc99-ac37-4e51-b9f5-bd920099947c";
@@ -261,7 +263,51 @@ describe("@req:960a7ba7-3470-42ba-afdc-f6766c3c3126 resolve-buttons — binding-
     expect(a.visible.map((e) => e.label)).toEqual(["Always", "NotOnProto"]);
   });
 
-  it("@req:960a7ba7-3470-42ba-afdc-f6766c3c3126 throws for a target outside the vault (Issue #3788 canonicalisation parity)", async () => {
-    await expect(resolveButtons(root, "../escape.md")).rejects.toThrow();
+  it("@req:960a7ba7-3470-42ba-afdc-f6766c3c3126 throws for an EXISTING target outside the vault (Issue #3788 canonicalisation guard)", async () => {
+    // A file that exists OUTSIDE the vault root — so resolveButtons passes the
+    // not-found guard and actually reaches the #3788 outside-vault branch
+    // (a non-existent `../x.md` would trip the earlier not-found guard instead).
+    const sibling = path.join(path.dirname(root), `rb-escape-${path.basename(root)}.md`);
+    fs.writeFileSync(sibling, "---\nexo__Asset_uid: x\n---\n", "utf-8");
+    try {
+      await expect(
+        resolveButtons(root, path.relative(root, sibling)),
+      ).rejects.toThrow(/outside the vault/);
+    } finally {
+      fs.rmSync(sibling, { force: true });
+    }
+  });
+
+  it("@req:960a7ba7-3470-42ba-afdc-f6766c3c3126 CLI command emits --json with visible + (show-hidden) hidden button-set", async () => {
+    const logs: string[] = [];
+    const logSpy = jest
+      .spyOn(console, "log")
+      .mockImplementation((...args: unknown[]) => {
+        logs.push(args.map(String).join(" "));
+      });
+    try {
+      await resolveButtonsCommand().parseAsync([
+        "node",
+        "resolve-buttons",
+        `${TARGET_PROTO}.md`,
+        "--vault",
+        root,
+        "--json",
+        "--show-hidden",
+      ]);
+      const payload = JSON.parse(logs.join("\n"));
+      expect(payload.target).toBe(`${TARGET_PROTO}.md`);
+      expect(payload.visible.map((e: { label: string }) => e.label)).toEqual([
+        "Always",
+      ]);
+      const hidden = payload.hidden.map((e: { label: string }) => e.label);
+      expect(hidden).toContain("NotOnProto");
+      expect(
+        payload.hidden.find((e: { label: string }) => e.label === "NotOnProto")
+          ?.reason,
+      ).toBe("precondition-false");
+    } finally {
+      logSpy.mockRestore();
+    }
   });
 });


### PR DESCRIPTION
## Summary

Adds `exocortex resolve-buttons <target> [--vault <v>] [--json] [--show-hidden]` (Issue #3833) — the authoritative **inline-button-visibility oracle**. It prints the actual command button-set the plugin would render on an asset's page:

- **Layer A** — binding-match via the class hierarchy (`CommandResolver.resolveForAssetMulti`)
- **Layer B** — precondition-eval per command (`PreconditionEvaluator.evaluate`)
- Visible = Layer A **∩** Layer B, in the resolver's deterministic `(priority, depth, order)` sort.

It mirrors the plugin caller `DynamicCommandButtonGroupBuilder.resolveViaFullPath` exactly. **Thin wrapper over public core services — zero engine changes.**

### Why (vs `apply --dry-run`)

`apply --dry-run` checks **only** the precondition (Layer B), never the binding targetClass-match (Layer A) — so a bound-but-hidden command and a never-bound command are indistinguishable. `resolve-buttons --show-hidden` lists bound-but-hidden commands with reason `precondition-false`. This makes a class layout audit a single deterministic, snapshot-testable command instead of "open the live layout, eyeball it, `apply --dry-run` each command".

### Class-derivation note

Class leaves = **union** of the frontmatter UID refs (drive the `exo__Class_superClass` ancestor walk) **and** the store's already-resolved *symbolic* `exo__Instance_class` IRIs (match class-targeted bindings directly). This is the CLI equivalent of the plugin's metadataCache UID→symbolic expansion — necessary because `NoteToRDFConverter` IRI-substitutes class-shaped `exo__Asset_label` literals, which breaks the resolver's triple-store `resolveLabelByUID`/`findUidByLabel` (the plugin sidesteps this via metadataCache).

## Scope

Reflects the **inline-button layout** surface. The command palette (`findPaletteEnabledCommands`) and the RFC-024 class panel filter (`exo__Layout` include/exclude, applied downstream in the plugin) are deliberately out of scope — the binding ∩ precondition intersection is what layout curation (e.g. the D2 not-a-prototype gating) operates on.

## Verification

**Revert-verified integration test** (`packages/cli/tests/integration/resolve-buttons.integration.test.ts`, `@req:960a7ba7-3470-42ba-afdc-f6766c3c3126`) — production-shape: a temp markdown vault (`test__Widget` + `test__WidgetPrototype ⊑ test__Widget`, commands bound to `test__Widget`, a STRENDS not-a-prototype precondition, two targets) driven through the FULL real pipeline `resolveButtons → NoteToRDFConverter.convertVault → resolveForAssetMulti → PreconditionEvaluator.evaluate` (no mocks).

- **Revert-verify:** reverting the Layer-B precondition filter (`evaluated.filter((e) => e.available)` → `filter(() => true)`) → the "prototype HIDES NotOnProto" assertion goes **RED** (the hidden command leaks into `visible`); restored → **GREEN**. 4/4 GREEN with the fix.

**Empirical (real vault-my) — the oracle reproduces the LIVE layout:**
- real `ems__TaskPrototype` instance → `{Create Task Instance, Clean Properties}`; the 4 planning commands (Plan on Today / for Evening / Shift Day Backward / Forward) correctly **hidden** by the D2 not-a-prototype curation; "Rename to UID" hidden because the prototype is already UID-named (`hasNonUidFilename` false — the exact self-hide the D2 live-smoke documented).
- regular `ems__Task` → planning commands **visible** (opposite of the prototype → curation is precondition-gated, not binding-narrowed).

> Note on the issue's AC2 literal: it listed `{Create Task Instance, Clean Properties, Rename to UID}`, which is the set on a *non-UID-named* prototype. All production prototypes are UUID-canon, so "Rename to UID" self-hides (`hasNonUidFilename` false) — the oracle faithfully reflects the live layout `{Create Task Instance, Clean Properties}`.

## Requirement (RFC 0003 req-first SDD)

`req(exo)` `960a7ba7-3470-42ba-afdc-f6766c3c3126` (proposed → active on merge): https://github.com/kitelev/exoas-exo-reqs/blob/main/exo-reqs/960a7ba7-3470-42ba-afdc-f6766c3c3126.md

Req: 960a7ba7-3470-42ba-afdc-f6766c3c3126

Closes #3833
