### PR TITLE
feat(display-name): render displayName from vault exo__DisplayNameSpec (v1 thin) [req b4ee3caa]

### DIFF
--- a/packages/obsidian-plugin/src/domain/display-name/PrintNameRuleService.ts
+++ b/packages/obsidian-plugin/src/domain/display-name/PrintNameRuleService.ts
@@ -10,6 +10,31 @@ export interface PrintNameRule {
 
 type MetadataResolver = (wikilinkTarget: string) => Record<string, unknown> | null;
 
+// --- exo__DisplayNameSpec (structured-RDF displayName specs, v1 thin) ---
+// TBox: PMBOK project 47d57acf, onto-RFC 92b91345, req b4ee3caa. Match a spec/part
+// asset's exo__Instance_class by BOTH its label and its UID (assets key either form).
+const DISPLAY_NAME_SPEC_CLASS = "exo__DisplayNameSpec";
+const DISPLAY_NAME_SPEC_CLASS_UID = "07eab746-0874-4676-9d98-dbaad1bc6fb8";
+const PRINTED_PROPERTY_CLASS = "exo__PrintedProperty";
+const PRINTED_PROPERTY_CLASS_UID = "7d58de40-d941-4a66-88e2-13afc4fdc41d";
+const PRINTED_LITERAL_CLASS = "exo__PrintedLiteral";
+const PRINTED_LITERAL_CLASS_UID = "4d5437c9-788e-4a6d-9be0-4af3a84554f4";
+// Compiled specs win over legacy exoob__PrintNameRule rules (which max out well below this).
+const DISPLAY_NAME_SPEC_BASE_PRIORITY = 1000;
+
+interface RawDisplayNameSpec {
+  uid: string;
+  classKeys: string[]; // UID + label of appliesToClass (both indexed — #2110)
+  priority: number;
+}
+
+interface RawDisplayNamePart {
+  specUid: string;
+  order: number;
+  propertyKey?: string; // frontmatter key for exo__PrintedProperty
+  literal?: string; // static text for exo__PrintedLiteral
+}
+
 export class PrintNameRuleService {
   private rules: Map<string, PrintNameRule[]> = new Map();
   private classHierarchy: Map<string, string[]> = new Map();
@@ -72,6 +97,9 @@ export class PrintNameRuleService {
     this.rules.clear();
     this.classHierarchy.clear();
 
+    const rawSpecs = new Map<string, RawDisplayNameSpec>();
+    const rawParts: RawDisplayNamePart[] = [];
+
     const files = this.app.vault.getMarkdownFiles();
 
     for (const file of files) {
@@ -83,6 +111,18 @@ export class PrintNameRuleService {
 
       if (instanceClass === "exoob__PrintNameRule") {
         this.processRuleAsset(fm, file.path);
+      } else if (
+        instanceClass === DISPLAY_NAME_SPEC_CLASS ||
+        instanceClass === DISPLAY_NAME_SPEC_CLASS_UID
+      ) {
+        this.collectDisplayNameSpec(fm, rawSpecs);
+      } else if (
+        instanceClass === PRINTED_PROPERTY_CLASS ||
+        instanceClass === PRINTED_PROPERTY_CLASS_UID ||
+        instanceClass === PRINTED_LITERAL_CLASS ||
+        instanceClass === PRINTED_LITERAL_CLASS_UID
+      ) {
+        this.collectDisplayNamePart(fm, rawParts);
       }
 
       const superClass = this.cleanClassValue(fm.exo__Class_superClass);
@@ -97,6 +137,138 @@ export class PrintNameRuleService {
         }
       }
     }
+
+    this.compileDisplayNameSpecs(rawSpecs, rawParts);
+  }
+
+  /** Collect a raw exo__DisplayNameSpec instance (appliesToClass + priority). */
+  private collectDisplayNameSpec(
+    fm: Record<string, unknown>,
+    rawSpecs: Map<string, RawDisplayNameSpec>,
+  ): void {
+    const uid = typeof fm.exo__Asset_uid === "string" ? fm.exo__Asset_uid.trim() : "";
+    if (!uid) return;
+
+    const classKeys = this.extractClassKeys(fm.exo__DisplayNameSpec_appliesToClass);
+    if (classKeys.length === 0) return;
+
+    const rawPriority = fm.exo__DisplayNameSpec_priority;
+    const priority =
+      typeof rawPriority === "number"
+        ? rawPriority
+        : typeof rawPriority === "string" && rawPriority.trim() !== ""
+          ? Number(rawPriority)
+          : 0;
+
+    rawSpecs.set(uid, {
+      uid,
+      classKeys,
+      priority: Number.isFinite(priority) ? priority : 0,
+    });
+  }
+
+  /** Collect a raw exo__PrintedProperty / exo__PrintedLiteral part (of + order + payload). */
+  private collectDisplayNamePart(
+    fm: Record<string, unknown>,
+    rawParts: RawDisplayNamePart[],
+  ): void {
+    const specUid = this.cleanClassValue(fm.exo__DisplayNamePart_of);
+    if (!specUid) return;
+
+    const rawOrder = fm.exo__DisplayNamePart_order;
+    const order =
+      typeof rawOrder === "number"
+        ? rawOrder
+        : typeof rawOrder === "string" && rawOrder.trim() !== ""
+          ? Number(rawOrder)
+          : NaN;
+    if (!Number.isFinite(order)) return;
+
+    // exo__PrintedProperty → resolve the referenced property's local key (label after "|").
+    const propertyKey = this.cleanClassValue(fm.exo__PrintedProperty_property);
+    const rawLiteral = fm.exo__PrintedLiteral_literal;
+    const literal = typeof rawLiteral === "string" ? rawLiteral : undefined;
+
+    if (propertyKey) {
+      rawParts.push({ specUid, order, propertyKey });
+    } else if (literal !== undefined) {
+      rawParts.push({ specUid, order, literal });
+    }
+  }
+
+  /**
+   * Compile collected specs + parts into template strings and register them as
+   * high-priority PrintNameRules (so they win over legacy exoob rules and the
+   * TS classTemplates). Each spec is indexed under BOTH its class UID and label.
+   */
+  private compileDisplayNameSpecs(
+    rawSpecs: Map<string, RawDisplayNameSpec>,
+    rawParts: RawDisplayNamePart[],
+  ): void {
+    const partsBySpec = new Map<string, RawDisplayNamePart[]>();
+    for (const part of rawParts) {
+      const arr = partsBySpec.get(part.specUid);
+      if (arr) arr.push(part);
+      else partsBySpec.set(part.specUid, [part]);
+    }
+
+    for (const spec of rawSpecs.values()) {
+      const parts = (partsBySpec.get(spec.uid) ?? []).slice().sort((a, b) => a.order - b.order);
+      if (parts.length === 0) continue;
+
+      const template = parts
+        .map((p) => (p.propertyKey ? `{{${p.propertyKey}}}` : (p.literal ?? "")))
+        .join("");
+      if (!template.trim()) continue;
+
+      const priority = DISPLAY_NAME_SPEC_BASE_PRIORITY + spec.priority;
+
+      for (const classKey of spec.classKeys) {
+        if (!classKey) continue;
+        const rule: PrintNameRule = {
+          className: classKey,
+          template,
+          priority,
+          sourceFile: spec.uid,
+        };
+        const existing = this.rules.get(classKey);
+        if (existing) {
+          existing.push(rule);
+          existing.sort((a, b) => b.priority - a.priority);
+        } else {
+          this.rules.set(classKey, [rule]);
+        }
+      }
+    }
+  }
+
+  /**
+   * Extract the class match-keys from an appliesToClass wikilink. Returns BOTH the
+   * link target (UID) and the alias/label when a "|" is present, so an asset whose
+   * exo__Instance_class keys by UID (`[[<uid>]]`) OR by label (`[[<uid>|label]]`)
+   * both match the same spec (#2110 dual-keying).
+   */
+  private extractClassKeys(value: unknown): string[] {
+    let raw = value;
+    if (Array.isArray(raw)) {
+      if (raw.length === 0) return [];
+      raw = raw[0];
+    }
+    if (typeof raw !== "string") return [];
+
+    const cleaned = raw
+      .replace(/^\[\[|\]\]$/g, "")
+      .replace(/^"|"$/g, "")
+      .trim();
+    if (!cleaned) return [];
+
+    if (cleaned.includes("|")) {
+      const [target, label] = cleaned.split("|");
+      return [target.trim().replace(/\.md$/, ""), label.trim()].filter(
+        (k): k is string => Boolean(k),
+      );
+    }
+    return [cleaned.replace(/\.md$/, "")];
   }
 
   private processRuleAsset(fm: Record<string, unknown>, path: string): void {
@@ -164,7 +336,8 @@ export class PrintNameRuleService {
       .trim();
 
     if (cleaned.includes("|")) {
-      cleaned = cleaned.split("|").pop()!.trim();
+      const last = cleaned.split("|").pop();
+      cleaned = (last ?? cleaned).trim();
     }
 
     return cleaned || null;

--- a/packages/obsidian-plugin/src/domain/display-name/PrintNameRuleService.ts
+++ b/packages/obsidian-plugin/src/domain/display-name/PrintNameRuleService.ts
@@ -184,8 +184,8 @@ export class PrintNameRuleService {
           : NaN;
     if (!Number.isFinite(order)) return;
 
-    // exo__PrintedProperty → resolve the referenced property's local key (label after "|").
-    const propertyKey = this.cleanClassValue(fm.exo__PrintedProperty_property);
+    // exo__PrintedProperty → resolve the referenced property's frontmatter key (all wikilink forms).
+    const propertyKey = this.resolvePropertyKey(fm.exo__PrintedProperty_property);
     const rawLiteral = fm.exo__PrintedLiteral_literal;
     const literal = typeof rawLiteral === "string" ? rawLiteral : undefined;
 
@@ -240,6 +240,52 @@ export class PrintNameRuleService {
         }
       }
     }
+  }
+
+  /**
+   * Resolve an exo__PrintedProperty_property reference to the frontmatter KEY it prints.
+   * Handles every wikilink form so a spec authored either way works:
+   *  - `[[uid|label]]` → the alias is the key (fast path, no hop);
+   *  - `[[exo__Asset_label]]` → the bare target is already the key;
+   *  - `[[<uid>]]` (UID-canon strip-alias) → second hop: read the referenced property
+   *    asset's exo__Asset_label (which equals its frontmatter key).
+   */
+  private resolvePropertyKey(value: unknown): string | null {
+    let raw = value;
+    if (Array.isArray(raw)) {
+      if (raw.length === 0) return null;
+      raw = raw[0];
+    }
+    if (typeof raw !== "string") return null;
+
+    const cleaned = raw
+      .replace(/^\[\[|\]\]$/g, "")
+      .replace(/^"|"$/g, "")
+      .trim();
+    if (!cleaned) return null;
+
+    if (cleaned.includes("|")) {
+      const label = cleaned.split("|").pop()?.trim();
+      return label || null;
+    }
+
+    const target = cleaned.replace(/\.md$/, "").trim();
+    if (!target) return null;
+
+    // Second hop: resolve the bare target to a property asset and use its label.
+    const file =
+      this.app.metadataCache.getFirstLinkpathDest(target, "") ??
+      this.app.metadataCache.getFirstLinkpathDest(
+        target.endsWith(".md") ? target : `${target}.md`,
+        "",
+      );
+    if (file instanceof TFile) {
+      const label = this.app.metadataCache.getFileCache(file)?.frontmatter?.exo__Asset_label;
+      if (typeof label === "string" && label.trim()) return label.trim();
+    }
+
+    // Fallback: the bare value is itself the frontmatter key.
+    return target;
   }
 
   /**

--- a/packages/obsidian-plugin/src/domain/settings/ExocortexSettings.ts
+++ b/packages/obsidian-plugin/src/domain/settings/ExocortexSettings.ts
@@ -19,17 +19,22 @@ export const DEFAULT_DISPLAY_NAME_SETTINGS: DisplayNameSettings = {
   defaultTemplate: "{{exo__Asset_label}}",
 
   classTemplates: {
+    // Suffix classes: the homoiconic source is the vault exo__DisplayNameSpec
+    // (PMBOK project 47d57acf, req b4ee3caa) read by PrintNameRuleService; these TS
+    // entries are the cold-start SEED that prevents a raw→suffixed flicker before the
+    // vault specs index. Keyed by BOTH the class UID (real instances reference
+    // exo__Instance_class as `[[<class-uid>]]`) AND the label form. Adding the real
+    // class UIDs (df7e579d / 7ab483c7) fixes a pre-existing gap where UID-keyed
+    // prototype instances rendered with no suffix (only label/instance-UID keys matched).
     ems__TaskPrototype: "{{exo__Asset_label}} (TaskPrototype)",
-    // UID-based identifier for ems__TaskPrototype (Issue #2110)
-    "75302770-279e-4a59-ba85-09df29725713":
-      "{{exo__Asset_label}} (TaskPrototype)",
-    ems__Task: "{{exo__Asset_label}}",
-    ems__Project: "{{exo__Asset_label}}",
-    ems__Area: "{{exo__Asset_label}}",
+    "df7e579d-02d4-4f3a-971f-3d1d785b689b": "{{exo__Asset_label}} (TaskPrototype)",
     ems__MeetingPrototype: "{{exo__Asset_label}} (MeetingPrototype)",
-    ems__Meeting: "{{exo__Asset_label}}",
+    "7ab483c7-aafc-4ac8-8aca-0de52db34a93": "{{exo__Asset_label}} (MeetingPrototype)",
     // DailyNote uses the basename (date) as its display name since it typically doesn't have a label
     pn__DailyNote: "{{_basename}}",
+    // Pure-label classes (Task/Project/Area/Meeting) removed — they equalled defaultTemplate
+    // ("{{exo__Asset_label}}") so they now fall through to it unchanged (byte-identical).
+    // The buggy instance-UID key 75302770 (Issue #2110) is dropped — no asset references it.
   },
 };
 

--- a/packages/obsidian-plugin/tests/unit/domain/display-name/DisplayNameResolver.test.ts
+++ b/packages/obsidian-plugin/tests/unit/domain/display-name/DisplayNameResolver.test.ts
@@ -282,12 +282,22 @@ describe("DisplayNameResolver", () => {
       expect(DEFAULT_DISPLAY_NAME_SETTINGS.defaultTemplate).toBe("{{exo__Asset_label}}");
     });
 
-    it("should have class templates for common classes", () => {
-      expect(DEFAULT_DISPLAY_NAME_SETTINGS.classTemplates["ems__Task"]).toBeDefined();
+    it("has explicit templates only for suffix classes (label + real class UID) + DailyNote; pure-label classes use the default", () => {
+      // Suffix classes — cold-start seed keyed by BOTH label AND real class UID (req b4ee3caa, #2110).
       expect(DEFAULT_DISPLAY_NAME_SETTINGS.classTemplates["ems__TaskPrototype"]).toBeDefined();
-      expect(DEFAULT_DISPLAY_NAME_SETTINGS.classTemplates["ems__Project"]).toBeDefined();
-      expect(DEFAULT_DISPLAY_NAME_SETTINGS.classTemplates["ems__Area"]).toBeDefined();
+      expect(
+        DEFAULT_DISPLAY_NAME_SETTINGS.classTemplates["df7e579d-02d4-4f3a-971f-3d1d785b689b"],
+      ).toBeDefined();
+      expect(DEFAULT_DISPLAY_NAME_SETTINGS.classTemplates["ems__MeetingPrototype"]).toBeDefined();
+      expect(
+        DEFAULT_DISPLAY_NAME_SETTINGS.classTemplates["7ab483c7-aafc-4ac8-8aca-0de52db34a93"],
+      ).toBeDefined();
       expect(DEFAULT_DISPLAY_NAME_SETTINGS.classTemplates["pn__DailyNote"]).toBeDefined();
+      // Pure-label classes equalled the default template → removed (they fall through unchanged).
+      expect(DEFAULT_DISPLAY_NAME_SETTINGS.classTemplates["ems__Task"]).toBeUndefined();
+      expect(DEFAULT_DISPLAY_NAME_SETTINGS.classTemplates["ems__Project"]).toBeUndefined();
+      expect(DEFAULT_DISPLAY_NAME_SETTINGS.classTemplates["ems__Area"]).toBeUndefined();
+      expect(DEFAULT_DISPLAY_NAME_SETTINGS.classTemplates["ems__Meeting"]).toBeUndefined();
     });
 
     it("should work correctly with resolver", () => {
@@ -312,6 +322,28 @@ describe("DisplayNameResolver", () => {
         basename: "morning-routine",
       });
       expect(prototypeResult).toBe("Morning routine (TaskPrototype)");
+
+      // FIX (req b4ee3caa): a TaskPrototype instance keyed by the REAL class UID
+      // (how real instances reference exo__Instance_class) now gets the suffix via
+      // the cold-start seed — previously it fell through to the label-only default.
+      const uidKeyedPrototype = resolver.resolve({
+        metadata: {
+          exo__Asset_label: "Measure HRV",
+          exo__Instance_class: ["[[df7e579d-02d4-4f3a-971f-3d1d785b689b]]"],
+        },
+        basename: "measure-hrv",
+      });
+      expect(uidKeyedPrototype).toBe("Measure HRV (TaskPrototype)");
+
+      // Pure-label class (Project) — byte-identical after its redundant classTemplate removal.
+      const projectResult = resolver.resolve({
+        metadata: {
+          exo__Asset_label: "Q3 Roadmap",
+          exo__Instance_class: ["[[ems__Project]]"],
+        },
+        basename: "q3-roadmap",
+      });
+      expect(projectResult).toBe("Q3 Roadmap");
     });
 
     it("should use default template (label only) for unknown asset types", () => {

--- a/packages/obsidian-plugin/tests/unit/domain/display-name/PrintNameRuleService.test.ts
+++ b/packages/obsidian-plugin/tests/unit/domain/display-name/PrintNameRuleService.test.ts
@@ -1,4 +1,5 @@
 import { PrintNameRuleService } from "@plugin/domain/display-name/PrintNameRuleService";
+import { DisplayNameResolver } from "@plugin/domain/display-name/DisplayNameResolver";
 import { TFile } from "obsidian";
 import type { App, CachedMetadata } from "obsidian";
 
@@ -329,5 +330,132 @@ describe("PrintNameRuleService", () => {
       const resolver = service.createMetadataResolver();
       expect(resolver("[[nonexistent]]")).toBeNull();
     });
+  });
+});
+
+describe("PrintNameRuleService — exo__DisplayNameSpec (v1 thin, single-hop) [req b4ee3caa]", () => {
+  const TASK_PROTO_UID = "df7e579d-02d4-4f3a-971f-3d1d785b689b";
+  const SPEC_UID = "spec-taskproto-uid";
+
+  // Production-shape vault: one exo__DisplayNameSpec + a PrintedProperty part + a PrintedLiteral part.
+  function taskPrototypeSpecVault(): App {
+    return createMockApp([
+      {
+        path: `${SPEC_UID}.md`,
+        frontmatter: {
+          exo__Asset_uid: SPEC_UID,
+          exo__Instance_class: ["[[07eab746-0874-4676-9d98-dbaad1bc6fb8|exo__DisplayNameSpec]]"],
+          exo__DisplayNameSpec_appliesToClass: `[[${TASK_PROTO_UID}|ems__TaskPrototype]]`,
+          exo__DisplayNameSpec_priority: 10,
+        },
+      },
+      {
+        path: "part-prop.md",
+        frontmatter: {
+          exo__Asset_uid: "part-prop",
+          exo__Instance_class: ["[[7d58de40-d941-4a66-88e2-13afc4fdc41d|exo__PrintedProperty]]"],
+          exo__DisplayNamePart_of: `[[${SPEC_UID}]]`,
+          exo__DisplayNamePart_order: 1,
+          exo__PrintedProperty_property: "[[12a6151b-801f-4be2-bd6e-a787eedd56ae|exo__Asset_label]]",
+        },
+      },
+      {
+        path: "part-literal.md",
+        frontmatter: {
+          exo__Asset_uid: "part-literal",
+          exo__Instance_class: ["[[4d5437c9-788e-4a6d-9be0-4af3a84554f4|exo__PrintedLiteral]]"],
+          exo__DisplayNamePart_of: `[[${SPEC_UID}]]`,
+          exo__DisplayNamePart_order: 2,
+          exo__PrintedLiteral_literal: " (TaskPrototype)",
+        },
+      },
+    ]);
+  }
+
+  it("@req:b4ee3caa-8dda-4596-89b2-59111b14602f compiles a vault DisplayNameSpec into a template and renders the composed displayName (revert-verify anchor)", () => {
+    const app = taskPrototypeSpecVault();
+    const service = new PrintNameRuleService(app);
+    service.initialize();
+
+    // Ordered parts compile to a single-hop template string.
+    const byUid = service.getTemplateForClass(TASK_PROTO_UID);
+    expect(byUid).not.toBeNull();
+    expect(byUid!.template).toBe("{{exo__Asset_label}} (TaskPrototype)");
+
+    // #2110 dual-keying: the SAME spec is reachable by the class LABEL too.
+    const byLabel = service.getTemplateForClass("ems__TaskPrototype");
+    expect(byLabel).not.toBeNull();
+    expect(byLabel!.template).toBe("{{exo__Asset_label}} (TaskPrototype)");
+
+    // End-to-end render with EMPTY classTemplates — proves the VAULT spec (not a TS
+    // hardcode) drives the suffix. Revert-verify RED anchor: reverting scanVault's
+    // spec-reading makes getTemplateForClass return null → resolver falls to
+    // defaultTemplate → displayName becomes the raw label "Morning Routine".
+    const resolver = new DisplayNameResolver(
+      { defaultTemplate: "{{exo__Asset_label}}", classTemplates: {} },
+      service,
+    );
+    const displayName = resolver.resolve({
+      metadata: {
+        exo__Instance_class: [`[[${TASK_PROTO_UID}]]`],
+        exo__Asset_label: "Morning Routine",
+      },
+      basename: TASK_PROTO_UID,
+    });
+    expect(displayName).toBe("Morning Routine (TaskPrototype)");
+  });
+
+  it("selects the higher-priority spec when two specs apply to the same class", () => {
+    const app = createMockApp([
+      {
+        path: "specA.md",
+        frontmatter: {
+          exo__Asset_uid: "specA",
+          exo__Instance_class: ["[[exo__DisplayNameSpec]]"],
+          exo__DisplayNameSpec_appliesToClass: "[[C|ems__Task]]",
+          exo__DisplayNameSpec_priority: 1,
+        },
+      },
+      {
+        path: "pA.md",
+        frontmatter: {
+          exo__Asset_uid: "pA",
+          exo__Instance_class: ["[[exo__PrintedLiteral]]"],
+          exo__DisplayNamePart_of: "[[specA]]",
+          exo__DisplayNamePart_order: 1,
+          exo__PrintedLiteral_literal: "LOW",
+        },
+      },
+      {
+        path: "specB.md",
+        frontmatter: {
+          exo__Asset_uid: "specB",
+          exo__Instance_class: ["[[exo__DisplayNameSpec]]"],
+          exo__DisplayNameSpec_appliesToClass: "[[C|ems__Task]]",
+          exo__DisplayNameSpec_priority: 99,
+        },
+      },
+      {
+        path: "pB.md",
+        frontmatter: {
+          exo__Asset_uid: "pB",
+          exo__Instance_class: ["[[exo__PrintedLiteral]]"],
+          exo__DisplayNamePart_of: "[[specB]]",
+          exo__DisplayNamePart_order: 1,
+          exo__PrintedLiteral_literal: "HIGH",
+        },
+      },
+    ]);
+    const service = new PrintNameRuleService(app);
+    service.initialize();
+    const result = service.getTemplateForClass("ems__Task");
+    expect(result).not.toBeNull();
+    expect(result!.template).toBe("HIGH");
+  });
+
+  it("returns null (→ resolver fallback) for a class with no spec", () => {
+    const service = new PrintNameRuleService(createMockApp([]));
+    service.initialize();
+    expect(service.getTemplateForClass("ems__Whatever")).toBeNull();
   });
 });

--- a/packages/obsidian-plugin/tests/unit/domain/display-name/PrintNameRuleService.test.ts
+++ b/packages/obsidian-plugin/tests/unit/domain/display-name/PrintNameRuleService.test.ts
@@ -458,4 +458,44 @@ describe("PrintNameRuleService — exo__DisplayNameSpec (v1 thin, single-hop) [r
     service.initialize();
     expect(service.getTemplateForClass("ems__Whatever")).toBeNull();
   });
+
+  it("resolves a PrintedProperty authored with the UID-canon strip-alias form [[<uid>]] via a second hop", () => {
+    const PROP_UID = "12a6151b-801f-4be2-bd6e-a787eedd56ae";
+    const app = createMockApp([
+      // the exo__Property def asset — second hop reads its exo__Asset_label
+      {
+        path: `${PROP_UID}.md`,
+        frontmatter: {
+          exo__Asset_uid: PROP_UID,
+          exo__Instance_class: ["[[ae56ca4c-b610-42a4-a25d-058c23673296|exo__DatatypeProperty]]"],
+          exo__Asset_label: "exo__Asset_label",
+        },
+      },
+      {
+        path: "spec.md",
+        frontmatter: {
+          exo__Asset_uid: "spec",
+          exo__Instance_class: ["[[exo__DisplayNameSpec]]"],
+          exo__DisplayNameSpec_appliesToClass: "[[C|ems__Task]]",
+          exo__DisplayNameSpec_priority: 1,
+        },
+      },
+      {
+        path: "part.md",
+        frontmatter: {
+          exo__Asset_uid: "part",
+          exo__Instance_class: ["[[exo__PrintedProperty]]"],
+          exo__DisplayNamePart_of: "[[spec]]",
+          exo__DisplayNamePart_order: 1,
+          // strip-alias UID-canon form — no "|label"
+          exo__PrintedProperty_property: `[[${PROP_UID}]]`,
+        },
+      },
+    ]);
+    const service = new PrintNameRuleService(app);
+    service.initialize();
+    const result = service.getTemplateForClass("ems__Task");
+    expect(result).not.toBeNull();
+    expect(result!.template).toBe("{{exo__Asset_label}}");
+  });
 });


### PR DESCRIPTION
## Summary

Phase 2 of PMBOK project `47d57acf` (**Гомоиконичный displayName-лейблинг v1**), onto-RFC `92b91345`, requirement `b4ee3caa` (approved).

`PrintNameRuleService.scanVault` now also reads vault-declared **`exo__DisplayNameSpec`** + its `exo__DisplayNamePart` children (TBox shipped in Phase 1, `kitelev/exoas-exo`), compiles the ordered parts into a template string, and registers them as high-priority rules — so displayName rendering is driven by queryable vault RDF instead of the hardcoded `classTemplates`. **Single-hop v1** (reuses the existing `DisplayNameTemplateEngine`); recursion / multi-hop / conditional matcher are v2.

**Minimal blast radius (R4-safe):** zero changes to the 8 UI surfaces — the service is already threaded through all of them and `DisplayNameResolver.getTemplateForClass` consults it first.

## Changes
- `PrintNameRuleService.ts` — read `exo__DisplayNameSpec` + parts → compile → high-priority rules indexed by **both class UID and label** (fixes #2110 dual-keying). (+ eslint fix of a pre-existing non-null assertion in the touched `cleanClassValue`.)
- `ExocortexSettings.ts` `classTemplates` — removed redundant pure-label entries (`ems__Task/Project/Area/Meeting` equalled the default → **byte-identical**) + the buggy instance-UID key `75302770`; added the **real class UIDs** `df7e579d` / `7ab483c7` as cold-start seeds. This fixes a pre-existing gap where UID-keyed prototype instances (how real instances reference `exo__Instance_class`) rendered **without** the suffix.

## Revert-verify (`@req:b4ee3caa`)
Reverting `scanVault`'s spec-reading (`void rawSpecs/rawParts`) → the compiled-template + composed-render tests go **RED** (`getTemplateForClass` returns null → resolver falls to `defaultTemplate`); restoring → **GREEN**. Local: PrintNameRuleService 17/17, display-name 106/106, typecheck 0, eslint 0.

## Notes
- Vault default specs (TaskPrototype/MeetingPrototype) ship separately in `kitelev/exoas-exo` (bootstrap/pull), not bundled.
- 8-surface UI-smoke + the `(TaskPrototype)` suffix-on-real-instances fix will be verified at release (Phase 6).
- Follow-up issue to be filed for the legacy #2110 `75302770` data-keying cleanup.

Req: b4ee3caa-8dda-4596-89b2-59111b14602f