### PR TITLE
refactor(display-name): remove legacy exoob__PrintNameRule reading (Phase 4) [req b4ee3caa]

### DIFF
--- a/packages/cli/src/commands/validate-schema.ts
+++ b/packages/cli/src/commands/validate-schema.ts
@@ -77,7 +77,6 @@ export const NAMESPACE_PREFIX_MAP: ReadonlyMap<string, string> = new Map([
   ["lit__", "https://exocortex.my/ontology/lit#"],
   ["inbox__", "https://exocortex.my/ontology/inbox#"],
   ["place__", "https://exocortex.my/ontology/place#"],
-  ["exoob__", "https://exocortex.my/ontology/exoob#"],
   ["pn__", "https://exocortex.my/ontology/pn#"],
   ["period__", "https://exocortex.my/ontology/period#"],
   ["rdf__", "http://www.w3.org/1999/02/22-rdf-syntax-ns#"],

--- a/packages/obsidian-plugin/src/domain/display-name/PrintNameRuleService.ts
+++ b/packages/obsidian-plugin/src/domain/display-name/PrintNameRuleService.ts
@@ -19,7 +19,7 @@ const PRINTED_PROPERTY_CLASS = "exo__PrintedProperty";
 const PRINTED_PROPERTY_CLASS_UID = "7d58de40-d941-4a66-88e2-13afc4fdc41d";
 const PRINTED_LITERAL_CLASS = "exo__PrintedLiteral";
 const PRINTED_LITERAL_CLASS_UID = "4d5437c9-788e-4a6d-9be0-4af3a84554f4";
-// Compiled specs win over legacy exoob__PrintNameRule rules (which max out well below this).
+// Base priority floor for compiled exo__DisplayNameSpec rules (a spec's own priority adds on top).
 const DISPLAY_NAME_SPEC_BASE_PRIORITY = 1000;
 
 interface RawDisplayNameSpec {
@@ -109,9 +109,7 @@ export class PrintNameRuleService {
 
       const instanceClass = this.cleanClassValue(fm.exo__Instance_class);
 
-      if (instanceClass === "exoob__PrintNameRule") {
-        this.processRuleAsset(fm, file.path);
-      } else if (
+      if (
         instanceClass === DISPLAY_NAME_SPEC_CLASS ||
         instanceClass === DISPLAY_NAME_SPEC_CLASS_UID
       ) {
@@ -198,8 +196,8 @@ export class PrintNameRuleService {
 
   /**
    * Compile collected specs + parts into template strings and register them as
-   * high-priority PrintNameRules (so they win over legacy exoob rules and the
-   * TS classTemplates). Each spec is indexed under BOTH its class UID and label.
+   * high-priority PrintNameRules (so they win over the TS classTemplates cold-start
+   * seeds). Each spec is indexed under BOTH its class UID and label.
    */
   private compileDisplayNameSpecs(
     rawSpecs: Map<string, RawDisplayNameSpec>,
@@ -315,31 +313,6 @@ export class PrintNameRuleService {
       );
     }
     return [cleaned.replace(/\.md$/, "")];
-  }
-
-  private processRuleAsset(fm: Record<string, unknown>, path: string): void {
-    const ruleClass = this.cleanClassValue(fm.exoob__PrintNameRule_class);
-    const template = fm.exoob__PrintNameRule_template;
-    const priority = fm.exoob__Rule_priority;
-
-    if (!ruleClass || typeof template !== "string" || !template.trim()) {
-      return;
-    }
-
-    const rule: PrintNameRule = {
-      className: ruleClass,
-      template: template.trim(),
-      priority: typeof priority === "number" ? priority : 0,
-      sourceFile: path,
-    };
-
-    const existing = this.rules.get(ruleClass);
-    if (existing) {
-      existing.push(rule);
-      existing.sort((a, b) => b.priority - a.priority);
-    } else {
-      this.rules.set(ruleClass, [rule]);
-    }
   }
 
   private getAncestorClasses(className: string): string[] {

--- a/packages/obsidian-plugin/tests/unit/domain/display-name/PrintNameRuleService.test.ts
+++ b/packages/obsidian-plugin/tests/unit/domain/display-name/PrintNameRuleService.test.ts
@@ -30,276 +30,6 @@ function createMockApp(files: Array<{ path: string; frontmatter: Record<string, 
 }
 
 describe("PrintNameRuleService", () => {
-  describe("basic rule resolution", () => {
-    it("should find rule for exact class match", () => {
-      const app = createMockApp([
-        {
-          path: "rule1.md",
-          frontmatter: {
-            exo__Instance_class: ["[[exoob__PrintNameRule]]"],
-            exoob__PrintNameRule_class: "[[ems__TaskPrototype]]",
-            exoob__PrintNameRule_template: "{{exo__Asset_label}} (TP)",
-            exoob__Rule_priority: 100,
-          },
-        },
-      ]);
-
-      const service = new PrintNameRuleService(app);
-      service.initialize();
-
-      const result = service.getTemplateForClass("ems__TaskPrototype");
-      expect(result).not.toBeNull();
-      expect(result!.template).toBe("{{exo__Asset_label}} (TP)");
-      expect(result!.priority).toBe(100);
-    });
-
-    it("should return null when no rule exists for class", () => {
-      const app = createMockApp([]);
-
-      const service = new PrintNameRuleService(app);
-      service.initialize();
-
-      expect(service.getTemplateForClass("ems__Task")).toBeNull();
-    });
-
-    it("should return null when not initialized", () => {
-      const app = createMockApp([]);
-      const service = new PrintNameRuleService(app);
-
-      expect(service.getTemplateForClass("ems__Task")).toBeNull();
-    });
-  });
-
-  describe("priority resolution", () => {
-    it("should use highest priority rule when multiple rules for same class", () => {
-      const app = createMockApp([
-        {
-          path: "rule1.md",
-          frontmatter: {
-            exo__Instance_class: ["[[exoob__PrintNameRule]]"],
-            exoob__PrintNameRule_class: "[[ems__Task]]",
-            exoob__PrintNameRule_template: "{{exo__Asset_label}} (low)",
-            exoob__Rule_priority: 10,
-          },
-        },
-        {
-          path: "rule2.md",
-          frontmatter: {
-            exo__Instance_class: ["[[exoob__PrintNameRule]]"],
-            exoob__PrintNameRule_class: "[[ems__Task]]",
-            exoob__PrintNameRule_template: "{{exo__Asset_label}} (high)",
-            exoob__Rule_priority: 100,
-          },
-        },
-      ]);
-
-      const service = new PrintNameRuleService(app);
-      service.initialize();
-
-      const result = service.getTemplateForClass("ems__Task");
-      expect(result!.template).toBe("{{exo__Asset_label}} (high)");
-      expect(result!.priority).toBe(100);
-    });
-
-    it("should default priority to 0 when not specified", () => {
-      const app = createMockApp([
-        {
-          path: "rule1.md",
-          frontmatter: {
-            exo__Instance_class: ["[[exoob__PrintNameRule]]"],
-            exoob__PrintNameRule_class: "[[ems__Task]]",
-            exoob__PrintNameRule_template: "{{exo__Asset_label}}",
-          },
-        },
-      ]);
-
-      const service = new PrintNameRuleService(app);
-      service.initialize();
-
-      const result = service.getTemplateForClass("ems__Task");
-      expect(result!.priority).toBe(0);
-    });
-  });
-
-  describe("class hierarchy inheritance", () => {
-    it("should inherit rule from parent class", () => {
-      const app = createMockApp([
-        {
-          path: "effort-class.md",
-          frontmatter: {
-            exo__Instance_class: ["[[exo__Class]]"],
-            exo__Asset_label: "ems__Task",
-            exo__Class_superClass: "[[ems__Effort]]",
-          },
-        },
-        {
-          path: "rule1.md",
-          frontmatter: {
-            exo__Instance_class: ["[[exoob__PrintNameRule]]"],
-            exoob__PrintNameRule_class: "[[ems__Effort]]",
-            exoob__PrintNameRule_template: "{{exo__Asset_label}} (Effort)",
-            exoob__Rule_priority: 50,
-          },
-        },
-      ]);
-
-      const service = new PrintNameRuleService(app);
-      service.initialize();
-
-      const result = service.getTemplateForClass("ems__Task");
-      expect(result).not.toBeNull();
-      expect(result!.template).toBe("{{exo__Asset_label}} (Effort)");
-    });
-
-    it("should prefer direct class rule over inherited rule", () => {
-      const app = createMockApp([
-        {
-          path: "task-class.md",
-          frontmatter: {
-            exo__Instance_class: ["[[exo__Class]]"],
-            exo__Asset_label: "ems__Task",
-            exo__Class_superClass: "[[ems__Effort]]",
-          },
-        },
-        {
-          path: "effort-rule.md",
-          frontmatter: {
-            exo__Instance_class: ["[[exoob__PrintNameRule]]"],
-            exoob__PrintNameRule_class: "[[ems__Effort]]",
-            exoob__PrintNameRule_template: "{{exo__Asset_label}} (Effort)",
-            exoob__Rule_priority: 50,
-          },
-        },
-        {
-          path: "task-rule.md",
-          frontmatter: {
-            exo__Instance_class: ["[[exoob__PrintNameRule]]"],
-            exoob__PrintNameRule_class: "[[ems__Task]]",
-            exoob__PrintNameRule_template: "{{exo__Asset_label}} (Task)",
-            exoob__Rule_priority: 10,
-          },
-        },
-      ]);
-
-      const service = new PrintNameRuleService(app);
-      service.initialize();
-
-      const result = service.getTemplateForClass("ems__Task");
-      expect(result!.template).toBe("{{exo__Asset_label}} (Task)");
-    });
-  });
-
-  describe("wikilink class value cleaning", () => {
-    it("should handle class without wikilink brackets", () => {
-      const app = createMockApp([
-        {
-          path: "rule1.md",
-          frontmatter: {
-            exo__Instance_class: ["[[exoob__PrintNameRule]]"],
-            exoob__PrintNameRule_class: "ems__Task",
-            exoob__PrintNameRule_template: "{{exo__Asset_label}}",
-            exoob__Rule_priority: 10,
-          },
-        },
-      ]);
-
-      const service = new PrintNameRuleService(app);
-      service.initialize();
-
-      expect(service.getTemplateForClass("ems__Task")).not.toBeNull();
-    });
-
-    it("should handle class with wikilink brackets", () => {
-      const app = createMockApp([
-        {
-          path: "rule1.md",
-          frontmatter: {
-            exo__Instance_class: ["[[exoob__PrintNameRule]]"],
-            exoob__PrintNameRule_class: "[[ems__Task]]",
-            exoob__PrintNameRule_template: "{{exo__Asset_label}}",
-            exoob__Rule_priority: 10,
-          },
-        },
-      ]);
-
-      const service = new PrintNameRuleService(app);
-      service.initialize();
-
-      expect(service.getTemplateForClass("ems__Task")).not.toBeNull();
-    });
-  });
-
-  describe("invalid rules", () => {
-    it("should skip rules without template", () => {
-      const app = createMockApp([
-        {
-          path: "rule1.md",
-          frontmatter: {
-            exo__Instance_class: ["[[exoob__PrintNameRule]]"],
-            exoob__PrintNameRule_class: "[[ems__Task]]",
-            exoob__Rule_priority: 10,
-          },
-        },
-      ]);
-
-      const service = new PrintNameRuleService(app);
-      service.initialize();
-
-      expect(service.getTemplateForClass("ems__Task")).toBeNull();
-    });
-
-    it("should skip rules without class", () => {
-      const app = createMockApp([
-        {
-          path: "rule1.md",
-          frontmatter: {
-            exo__Instance_class: ["[[exoob__PrintNameRule]]"],
-            exoob__PrintNameRule_template: "{{exo__Asset_label}}",
-            exoob__Rule_priority: 10,
-          },
-        },
-      ]);
-
-      const service = new PrintNameRuleService(app);
-      service.initialize();
-
-      expect(service.getRulesCount()).toBe(0);
-    });
-  });
-
-  describe("refresh", () => {
-    it("should reload rules on refresh", () => {
-      const app = createMockApp([]);
-      const service = new PrintNameRuleService(app);
-      service.initialize();
-
-      expect(service.getRulesCount()).toBe(0);
-
-      const newFiles = [
-        {
-          path: "rule1.md",
-          frontmatter: {
-            exo__Instance_class: ["[[exoob__PrintNameRule]]"],
-            exoob__PrintNameRule_class: "[[ems__Task]]",
-            exoob__PrintNameRule_template: "{{exo__Asset_label}}",
-            exoob__Rule_priority: 10,
-          },
-        },
-      ];
-      const newMockFile = { path: "rule1.md", basename: "rule1", extension: "md" } as TFile;
-      (app.vault.getMarkdownFiles as jest.Mock).mockReturnValue([newMockFile]);
-      (app.metadataCache.getFileCache as jest.Mock).mockImplementation((file: TFile) => {
-        if (file.path === "rule1.md") {
-          return { frontmatter: newFiles[0].frontmatter };
-        }
-        return null;
-      });
-
-      service.refresh();
-
-      expect(service.getRulesCount()).toBe(1);
-    });
-  });
 
   describe("metadataResolver", () => {
     it("should resolve wikilink to metadata", () => {
@@ -497,5 +227,106 @@ describe("PrintNameRuleService — exo__DisplayNameSpec (v1 thin, single-hop) [r
     const result = service.getTemplateForClass("ems__Task");
     expect(result).not.toBeNull();
     expect(result!.template).toBe("{{exo__Asset_label}}");
+  });
+
+  it("applies a spec from a PARENT class to a child-class asset (class-hierarchy inheritance)", () => {
+    const app = createMockApp([
+      {
+        path: "task-class.md",
+        frontmatter: {
+          exo__Asset_uid: "taskcls",
+          exo__Instance_class: ["[[8619c4fc-64f1-4869-b17e-e34186cacca9|exo__Class]]"],
+          exo__Asset_label: "ems__Task",
+          exo__Class_superClass: ["[[E|ems__Effort]]"],
+        },
+      },
+      {
+        path: "spec.md",
+        frontmatter: {
+          exo__Asset_uid: "spec",
+          exo__Instance_class: ["[[exo__DisplayNameSpec]]"],
+          exo__DisplayNameSpec_appliesToClass: "[[E|ems__Effort]]",
+          exo__DisplayNameSpec_priority: 1,
+        },
+      },
+      {
+        path: "part.md",
+        frontmatter: {
+          exo__Asset_uid: "part",
+          exo__Instance_class: ["[[exo__PrintedLiteral]]"],
+          exo__DisplayNamePart_of: "[[spec]]",
+          exo__DisplayNamePart_order: 1,
+          exo__PrintedLiteral_literal: "EFFORT",
+        },
+      },
+    ]);
+    const service = new PrintNameRuleService(app);
+    service.initialize();
+    // direct spec on the parent class...
+    expect(service.getTemplateForClass("ems__Effort")!.template).toBe("EFFORT");
+    // ...inherited by the child class via the hierarchy walk.
+    expect(service.getTemplateForClass("ems__Task")!.template).toBe("EFFORT");
+  });
+
+  it("refresh() reloads specs from the vault", () => {
+    const app = createMockApp([]);
+    const service = new PrintNameRuleService(app);
+    service.initialize();
+    expect(service.getRulesCount()).toBe(0);
+
+    (app.vault.getMarkdownFiles as jest.Mock).mockReturnValue([
+      { path: "spec.md", basename: "spec", extension: "md" } as TFile,
+      { path: "part.md", basename: "part", extension: "md" } as TFile,
+    ]);
+    (app.metadataCache.getFileCache as jest.Mock).mockImplementation((f: TFile) =>
+      f.path === "spec.md"
+        ? {
+            frontmatter: {
+              exo__Asset_uid: "spec",
+              exo__Instance_class: ["[[exo__DisplayNameSpec]]"],
+              exo__DisplayNameSpec_appliesToClass: "[[ems__Task]]",
+            },
+          }
+        : f.path === "part.md"
+          ? {
+              frontmatter: {
+                exo__Asset_uid: "part",
+                exo__Instance_class: ["[[exo__PrintedLiteral]]"],
+                exo__DisplayNamePart_of: "[[spec]]",
+                exo__DisplayNamePart_order: 1,
+                exo__PrintedLiteral_literal: "X",
+              },
+            }
+          : null,
+    );
+
+    service.refresh();
+    expect(service.getRulesCount()).toBe(1);
+  });
+
+  it("skips a spec with no parts and a part carrying neither property nor literal", () => {
+    const app = createMockApp([
+      {
+        path: "empty-spec.md",
+        frontmatter: {
+          exo__Asset_uid: "es",
+          exo__Instance_class: ["[[exo__DisplayNameSpec]]"],
+          exo__DisplayNameSpec_appliesToClass: "[[ems__Task]]",
+        },
+      },
+      {
+        path: "bad-part.md",
+        frontmatter: {
+          exo__Asset_uid: "bp",
+          exo__Instance_class: ["[[exo__PrintedProperty]]"],
+          exo__DisplayNamePart_of: "[[es]]",
+          exo__DisplayNamePart_order: 1,
+        },
+      },
+    ]);
+    const service = new PrintNameRuleService(app);
+    service.initialize();
+    expect(service.getRulesCount()).toBe(0);
+    expect(service.getTemplateForClass("ems__Task")).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary

Phase 4 of PMBOK project `47d57acf` (req `b4ee3caa`). The vault `exo__DisplayNameSpec` mechanism (merged #3837) fully replaces the legacy `exoob__PrintNameRule` string-template, so its reading is now removed.

## Changes
- **`PrintNameRuleService`** — drop the `exoob__PrintNameRule` `scanVault` branch + the `processRuleAsset` method. The service now reads ONLY `exo__DisplayNameSpec` (name kept to avoid an 8-surface rename churn).
- **`validate-schema.ts`** — drop the dead `exoob__` prefix from the curated registry.
- **Test suite rewrite** — remove the ~14 exoob-fixture tests; the `exo__DisplayNameSpec` suite now covers compile/render, dual-keying (#2110), priority-selection, second-hop property-key resolution, **class-hierarchy inheritance**, **refresh**, and **edge/invalid guards**. 98 GREEN, typecheck 0, eslint 0.

## Regression safety
The 1 real exoob instance (`inbox__RFC` → `(RFC)`, `6e325738`) was **migrated beforehand** to a vault `exo__DisplayNameSpec` (`283495b9`, shipped in `exoas-exo`), so RFC assets keep their suffix. Verified: `CQ3` returns `inbox__RFC` + `ems__TaskPrototype` + `ems__MeetingPrototype`. This removal is regression-free.

The exoob-namespace vault assets (`$exoob` anchor + `PrintNameRule`/`PropertyAliasFactory` classes + `PrintNameRule_class` property + the migrated instance) are deleted separately in `exoas-public`.

Req: b4ee3caa-8dda-4596-89b2-59111b14602f