### PR TITLE
fix(#3842): re-scan displayName specs on metadataCache 'resolved'

### DIFF
--- a/packages/obsidian-plugin/src/ExocortexPlugin.ts
+++ b/packages/obsidian-plugin/src/ExocortexPlugin.ts
@@ -1240,6 +1240,24 @@ export default class ExocortexPlugin extends Plugin {
           // "resolved" event fires post-dispose.
           this.exoLayoutRepository?.rebuildNow();
 
+          // Issue #3842 — re-scan vault `exo__DisplayNameSpec` rules on the
+          // authoritative "metadata fully parsed" signal. The onload
+          // `printNameRuleService.initialize()` scan runs BEFORE metadataCache
+          // has resolved on a large vault, so late-parsed (or mid-session
+          // ExoSync-pulled) spec assets are missed — `getFileCache` returns
+          // null for their still-unparsed frontmatter → 0 rules → hardcoded
+          // suffix classes silently render without the vault-configured
+          // displayName. The `metadataCache.on("changed")` subscription
+          // (wired at construction) only fires on per-file edits, so specs
+          // synced without a subsequent edit stayed invisible until a manual
+          // refresh. `refresh()` re-runs `scanVault()` against the now-warm
+          // cache. Kept outside the `postResolveReindexDone` one-shot guard
+          // (like `rebuildNow()` above): "resolved" is rare and `scanVault`
+          // is cheap + idempotent (a bounded `getFileCache` sweep), so
+          // re-emissions after large vault-level reindexes correctly refresh
+          // the rules too.
+          this.printNameRuleService.refresh();
+
           if (postResolveReindexDone) return;
           postResolveReindexDone = true;
 

--- a/packages/obsidian-plugin/tests/unit/ExocortexPlugin.test.ts
+++ b/packages/obsidian-plugin/tests/unit/ExocortexPlugin.test.ts
@@ -1892,6 +1892,34 @@ describe("ExocortexPlugin", () => {
       expect(preconditionEvaluatorSpy).toHaveBeenCalled();
     });
 
+    // Issue #3842 — the onload `printNameRuleService.initialize()` scan runs
+    // BEFORE metadataCache resolves on a large vault, so late-parsed (or
+    // mid-session ExoSync-pulled) `exo__DisplayNameSpec` assets are missed →
+    // 0 rules → hardcoded suffix classes render without the vault-configured
+    // displayName until a manual refresh. The fix re-scans specs on the
+    // authoritative "metadata fully parsed" `resolved` signal. This test pins
+    // that the resolved handler calls `printNameRuleService.refresh()`.
+    it("re-scans display-name specs (printNameRuleService.refresh) on 'resolved' (#3842)", async () => {
+      await plugin.onload();
+      await flushPromises();
+
+      // Spy AFTER onload — printNameRuleService is constructed inside onload.
+      // Record the baseline so the assertion isolates the resolved-triggered
+      // refresh from any onload-time scan / "changed"-event refresh.
+      const refreshRuleSpy = jest.spyOn(
+        plugin.printNameRuleService,
+        "refresh",
+      );
+      expect(refreshRuleSpy).not.toHaveBeenCalled();
+
+      resolvedHandler!();
+      await flushPromises();
+
+      // Post-fix: firing "resolved" re-scans the vault display-name specs.
+      // Pre-fix (refresh not wired into the resolved handler): 0 calls → RED.
+      expect(refreshRuleSpy).toHaveBeenCalledTimes(1);
+    });
+
     it("re-index is one-shot: subsequent 'resolved' events do not trigger another refresh", async () => {
       await plugin.onload();
       await flushPromises();


### PR DESCRIPTION
## Problem (#3842)

The onload `printNameRuleService.initialize()` scan runs **before** metadataCache resolves on a large vault, so late-parsed (or mid-session ExoSync-pulled) `exo__DisplayNameSpec` assets are missed — `getFileCache` returns `null` for their still-unparsed frontmatter → **0 rules** → hardcoded suffix classes (ems__TaskPrototype / ems__MeetingPrototype) render **without** the vault-configured displayName suffix until a manual refresh.

The `metadataCache.on("changed")` subscription (wired at construction) only fires on **per-file edits**, so specs synced without a subsequent edit stayed invisible.

**Observed live** during the displayName-labeling v1 UI-smoke: `specFiles=3` on disk but `rules=0` after onload; a manual `refresh()` produced `rules=6` and the suffix rendered.

## Fix

Call `printNameRuleService.refresh()` inside the **existing** `metadataCache.on("resolved")` handler — Obsidian's authoritative *"initial vault parse complete"* signal, already used for the SPARQL reindex + layout rebuild. Placed **outside** the `postResolveReindexDone` one-shot guard (like the sibling `exoLayoutRepository?.rebuildNow()`): "resolved" is rare and `scanVault` is a cheap, idempotent, bounded `getFileCache` sweep, so re-emissions after large vault-level reindexes correctly refresh the rules too.

## Test (revert-verified)

New unit test in the resolved-handler describe block spies on `printNameRuleService.refresh` (constructed during onload) and asserts firing the resolved handler calls it exactly once.

- **Revert-verified**: reverting the `refresh()` call → test RED (0 calls); restored → GREEN (1 call).
- Full `ExocortexPlugin.test.ts` suite **99/99** green; `check:types` clean.

Req: covered by Active req b4ee3caa (homoiconic displayName v1) — this restores its already-required render behavior on cold-start (bug-fix, not a new requirement).

Closes #3842