### PR TITLE
feat(display-name): per-render conditional exo__DisplayNameSpec matcher (matchPath/matchValue)

### DIFF
--- a/packages/obsidian-plugin/src/domain/display-name/DisplayNameResolver.ts
+++ b/packages/obsidian-plugin/src/domain/display-name/DisplayNameResolver.ts
@@ -20,7 +20,9 @@ export class DisplayNameResolver {
     const { metadata, basename, createdDate } = context;
 
     const assetClass = this.extractAssetClass(metadata);
-    const template = this.getTemplateForClass(assetClass);
+    // Pass the instance metadata so a conditional spec (matchPath/matchValue) can be
+    // evaluated per-render — the specialized displayName tracks the instance's state.
+    const template = this.getTemplateForClass(assetClass, metadata);
     const engine = new DisplayNameTemplateEngine(template);
 
     return engine.render(
@@ -31,9 +33,12 @@ export class DisplayNameResolver {
     );
   }
 
-  getTemplateForClass(assetClass: string | null): string {
+  getTemplateForClass(
+    assetClass: string | null,
+    metadata?: Record<string, unknown>,
+  ): string {
     if (assetClass && this.ruleService) {
-      const dynamicRule = this.ruleService.getTemplateForClass(assetClass);
+      const dynamicRule = this.ruleService.getTemplateForClass(assetClass, metadata);
       if (dynamicRule) {
         return dynamicRule.template;
       }
@@ -74,7 +79,8 @@ export class DisplayNameResolver {
       .trim();
 
     if (cleaned.includes("|")) {
-      cleaned = cleaned.split("|").pop()!.trim();
+      const last = cleaned.split("|").pop();
+      cleaned = (last ?? cleaned).trim();
     }
 
     return cleaned || null;

--- a/packages/obsidian-plugin/src/domain/display-name/PrintNameRuleService.ts
+++ b/packages/obsidian-plugin/src/domain/display-name/PrintNameRuleService.ts
@@ -14,9 +14,12 @@ export interface DisplayNameMatcher {
   /** Frontmatter key of the instance property the condition inspects (e.g. "ems__Effort_status"). */
   matchKey: string;
   /**
-   * Accepted identities of the expected value — BOTH the UID and the label form
-   * (dual-IRI equality). A conditional rule matches when the instance value's
-   * cleaned identity set intersects this set.
+   * All identity forms of the ONE accepted value — its UID, its label, and any raw
+   * wikilink form(s) — collected at compile time (dual-IRI equality). NOT a set of
+   * distinct accepted values (v2 single-value slice; conjunctions/disjunctions are a
+   * future exo__DisplayNameMatcher). A conditional rule matches when the instance value's
+   * cleaned identity set intersects this set — so it matches whether the instance stores
+   * the value as `[[<uid>]]`, `[[<uid>|label]]`, or the bare `[[<label>]]`.
    */
   matchValues: string[];
 }
@@ -133,6 +136,32 @@ export class PrintNameRuleService {
     return instanceForms.some((form) => matcher.matchValues.includes(form));
   }
 
+  /**
+   * Resolve exo__DisplayNameSpec_matchValue into ALL identity forms of the single
+   * accepted value — the raw wikilink form(s) PLUS, via one compile-time second hop, the
+   * referenced asset's UID and label. This closes the dual-IRI gap fully: a matchValue
+   * authored UID-canon `[[<uid>]]` still matches an instance whose value is stored as the
+   * bare label `[[<label>]]` (and vice versa), because both the UID and the label end up
+   * in the accepted set. The hop runs once per spec at scanVault — no per-render cost.
+   */
+  private resolveMatchValues(value: unknown): string[] {
+    const raw = this.extractClassKeys(value);
+    if (raw.length === 0) return [];
+    const forms = new Set<string>(raw);
+    for (const id of raw) {
+      const file =
+        this.app.metadataCache.getFirstLinkpathDest(id, "") ??
+        this.app.metadataCache.getFirstLinkpathDest(id.endsWith(".md") ? id : `${id}.md`, "");
+      if (!(file instanceof TFile)) continue;
+      const fm = this.app.metadataCache.getFileCache(file)?.frontmatter;
+      const uid = fm?.exo__Asset_uid;
+      const label = fm?.exo__Asset_label;
+      if (typeof uid === "string" && uid.trim()) forms.add(uid.trim());
+      if (typeof label === "string" && label.trim()) forms.add(label.trim());
+    }
+    return [...forms];
+  }
+
   createMetadataResolver(): MetadataResolver {
     return (wikilinkTarget: string): Record<string, unknown> | null => {
       const cleaned = wikilinkTarget
@@ -227,10 +256,11 @@ export class PrintNameRuleService {
 
     // Conditional specialization (v2 slice): resolve matchPath → the frontmatter key it
     // inspects (single-hop, same wikilink resolution as a PrintedProperty ref) and
-    // matchValue → the accepted identity set (UID + label). A matcher is set only when
-    // BOTH are present; otherwise the spec stays unconditional (v1 path).
+    // matchValue → the accepted identity set (all forms of the ONE accepted value). A
+    // matcher is set only when BOTH are present; otherwise the spec stays unconditional
+    // (v1 path).
     const matchKey = this.resolvePropertyKey(fm.exo__DisplayNameSpec_matchPath);
-    const matchValues = this.extractClassKeys(fm.exo__DisplayNameSpec_matchValue);
+    const matchValues = this.resolveMatchValues(fm.exo__DisplayNameSpec_matchValue);
     const hasMatcher = matchKey !== null && matchValues.length > 0;
 
     rawSpecs.set(uid, {

--- a/packages/obsidian-plugin/src/domain/display-name/PrintNameRuleService.ts
+++ b/packages/obsidian-plugin/src/domain/display-name/PrintNameRuleService.ts
@@ -1,11 +1,33 @@
 import { TFile } from "obsidian";
 import type { App } from "obsidian";
 
+/**
+ * A per-render condition compiled from an exo__DisplayNameSpec's
+ * exo__DisplayNameSpec_matchPath (→ frontmatter key) + exo__DisplayNameSpec_matchValue
+ * (→ cleaned enum identity/-ies). A rule carrying a matcher is CONDITIONAL: it only
+ * participates in class selection when the rendered instance's frontmatter value at
+ * `matchKey` equals `matchValue` (evaluated per-render — the condition cannot be baked
+ * into the compiled template because it depends on the concrete instance). v2
+ * conditional-slice (RFC 92b91345, req ed4201d1).
+ */
+export interface DisplayNameMatcher {
+  /** Frontmatter key of the instance property the condition inspects (e.g. "ems__Effort_status"). */
+  matchKey: string;
+  /**
+   * Accepted identities of the expected value — BOTH the UID and the label form
+   * (dual-IRI equality). A conditional rule matches when the instance value's
+   * cleaned identity set intersects this set.
+   */
+  matchValues: string[];
+}
+
 export interface PrintNameRule {
   className: string;
   template: string;
   priority: number;
   sourceFile: string;
+  /** Present iff the spec declared exo__DisplayNameSpec_matchPath + _matchValue (conditional). */
+  matcher?: DisplayNameMatcher;
 }
 
 type MetadataResolver = (wikilinkTarget: string) => Record<string, unknown> | null;
@@ -26,6 +48,9 @@ interface RawDisplayNameSpec {
   uid: string;
   classKeys: string[]; // UID + label of appliesToClass (both indexed — #2110)
   priority: number;
+  // Conditional specialization (v2 slice — RFC 92b91345, req ed4201d1). Both present or both absent.
+  matchKey?: string; // frontmatter key resolved from exo__DisplayNameSpec_matchPath
+  matchValues?: string[]; // accepted identities (UID + label) from exo__DisplayNameSpec_matchValue
 }
 
 interface RawDisplayNamePart {
@@ -47,23 +72,65 @@ export class PrintNameRuleService {
     this.initialized = true;
   }
 
-  getTemplateForClass(className: string): { template: string; priority: number } | null {
+  /**
+   * Select the winning template for a class. Rules are priority-sorted; a CONDITIONAL
+   * rule (one carrying a `matcher`) only participates when the rendered instance's
+   * `metadata` satisfies the matcher — evaluated per-render, so a specialized displayName
+   * appears/disappears as the instance's value changes without a re-scan. Unconditional
+   * rules always participate (v1 path byte-identical). When `metadata` is omitted,
+   * conditional rules are skipped (no instance to test).
+   */
+  getTemplateForClass(
+    className: string,
+    metadata?: Record<string, unknown>,
+  ): { template: string; priority: number } | null {
     if (!this.initialized) return null;
 
-    const directRules = this.rules.get(className);
-    if (directRules && directRules.length > 0) {
-      return { template: directRules[0].template, priority: directRules[0].priority };
-    }
+    const direct = this.selectRule(this.rules.get(className), metadata);
+    if (direct) return { template: direct.template, priority: direct.priority };
 
     const ancestors = this.getAncestorClasses(className);
     for (const ancestor of ancestors) {
-      const ancestorRules = this.rules.get(ancestor);
-      if (ancestorRules && ancestorRules.length > 0) {
-        return { template: ancestorRules[0].template, priority: ancestorRules[0].priority };
-      }
+      const inherited = this.selectRule(this.rules.get(ancestor), metadata);
+      if (inherited) return { template: inherited.template, priority: inherited.priority };
     }
 
     return null;
+  }
+
+  /**
+   * Pick the highest-priority PARTICIPATING rule from a priority-sorted list. A rule
+   * participates if it is unconditional (no matcher) OR its matcher is satisfied by the
+   * instance metadata. A matched conditional rule beats an unconditional one purely by
+   * priority (the list is already sorted descending), so a conditional spec authored with
+   * a higher priority wins over the fallback; an unmatched conditional is skipped.
+   */
+  private selectRule(
+    rules: PrintNameRule[] | undefined,
+    metadata?: Record<string, unknown>,
+  ): PrintNameRule | null {
+    if (!rules || rules.length === 0) return null;
+    for (const rule of rules) {
+      if (!rule.matcher) return rule; // unconditional — always participates
+      if (metadata && this.matcherSatisfied(rule.matcher, metadata)) return rule;
+    }
+    return null;
+  }
+
+  /**
+   * True when the instance's frontmatter value at `matcher.matchKey` equals `matchValue`
+   * under dual-IRI equality: both sides are reduced to their identity set (UID + label
+   * forms via extractClassKeys) and the sets must intersect. This makes the condition
+   * robust whether the status is stored as `[[<uid>]]`, `[[<uid>|label]]`, or the bare
+   * label — see sparql-iri-form-pre-verify.
+   */
+  private matcherSatisfied(
+    matcher: DisplayNameMatcher,
+    metadata: Record<string, unknown>,
+  ): boolean {
+    const instanceForms = this.extractClassKeys(metadata[matcher.matchKey]);
+    if (instanceForms.length === 0) return false;
+    return instanceForms.some((form) => matcher.matchValues.includes(form));
   }
 
   createMetadataResolver(): MetadataResolver {
@@ -158,10 +225,19 @@ export class PrintNameRuleService {
           ? Number(rawPriority)
           : 0;
 
+    // Conditional specialization (v2 slice): resolve matchPath → the frontmatter key it
+    // inspects (single-hop, same wikilink resolution as a PrintedProperty ref) and
+    // matchValue → the accepted identity set (UID + label). A matcher is set only when
+    // BOTH are present; otherwise the spec stays unconditional (v1 path).
+    const matchKey = this.resolvePropertyKey(fm.exo__DisplayNameSpec_matchPath);
+    const matchValues = this.extractClassKeys(fm.exo__DisplayNameSpec_matchValue);
+    const hasMatcher = matchKey !== null && matchValues.length > 0;
+
     rawSpecs.set(uid, {
       uid,
       classKeys,
       priority: Number.isFinite(priority) ? priority : 0,
+      ...(hasMatcher ? { matchKey: matchKey ?? undefined, matchValues } : {}),
     });
   }
 
@@ -221,6 +297,11 @@ export class PrintNameRuleService {
 
       const priority = DISPLAY_NAME_SPEC_BASE_PRIORITY + spec.priority;
 
+      const matcher: DisplayNameMatcher | undefined =
+        spec.matchKey && spec.matchValues && spec.matchValues.length > 0
+          ? { matchKey: spec.matchKey, matchValues: spec.matchValues }
+          : undefined;
+
       for (const classKey of spec.classKeys) {
         if (!classKey) continue;
         const rule: PrintNameRule = {
@@ -228,6 +309,7 @@ export class PrintNameRuleService {
           template,
           priority,
           sourceFile: spec.uid,
+          ...(matcher ? { matcher } : {}),
         };
         const existing = this.rules.get(classKey);
         if (existing) {

--- a/packages/obsidian-plugin/tests/unit/domain/display-name/DisplayNameResolver.test.ts
+++ b/packages/obsidian-plugin/tests/unit/domain/display-name/DisplayNameResolver.test.ts
@@ -206,7 +206,12 @@ describe("DisplayNameResolver", () => {
       });
 
       expect(result).toBe("My Task (DynamicRule)");
-      expect(mockRuleService.getTemplateForClass).toHaveBeenCalledWith("ems__Task");
+      // The resolver now forwards the instance metadata so a conditional spec
+      // (matchPath/matchValue) can be evaluated per-render (req ed4201d1).
+      expect(mockRuleService.getTemplateForClass).toHaveBeenCalledWith(
+        "ems__Task",
+        expect.objectContaining({ exo__Asset_label: "My Task" }),
+      );
     });
 
     it("should fall back to settings when no dynamic rule exists", () => {

--- a/packages/obsidian-plugin/tests/unit/domain/display-name/PrintNameRuleService.test.ts
+++ b/packages/obsidian-plugin/tests/unit/domain/display-name/PrintNameRuleService.test.ts
@@ -469,6 +469,81 @@ describe("PrintNameRuleService — conditional exo__DisplayNameSpec (v2 slice, p
     ).toBe("Fix the parser");
   });
 
+  it("dual-IRI equality closes the bare-label gap — a UID-form matchValue matches a BARE-label-form status via the compile-time second hop", () => {
+    // The shipped spec authors matchValue UID-canon [[<doing-uid>]]; a legacy instance may
+    // store its status as the bare label [[ems__EffortStatusDoing]] (no UID). With the
+    // enum asset present, resolveMatchValues expands matchValue to {uid, label} at compile
+    // time, so the bare-label instance still matches. Fixture includes the EffortStatusDoing
+    // enum asset so the second hop can read its uid + label.
+    const app = createMockApp([
+      {
+        path: `${DOING_UID}.md`,
+        frontmatter: {
+          exo__Asset_uid: DOING_UID,
+          exo__Instance_class: ["[[ems__EffortStatus]]"],
+          exo__Asset_label: "ems__EffortStatusDoing",
+        },
+      },
+      {
+        path: `${STATUS_PROP_UID}.md`,
+        frontmatter: {
+          exo__Asset_uid: STATUS_PROP_UID,
+          exo__Instance_class: ["[[9a1cf31c-9d41-4ef3-9023-584a8d087d16|exo__ObjectProperty]]"],
+          exo__Asset_label: "ems__Effort_status",
+        },
+      },
+      {
+        path: `${SPEC_UID}.md`,
+        frontmatter: {
+          exo__Asset_uid: SPEC_UID,
+          exo__Instance_class: ["[[07eab746-0874-4676-9d98-dbaad1bc6fb8|exo__DisplayNameSpec]]"],
+          exo__DisplayNameSpec_appliesToClass: `[[${TASK_UID}|ems__Task]]`,
+          exo__DisplayNameSpec_priority: 50,
+          exo__DisplayNameSpec_matchPath: `[[${STATUS_PROP_UID}]]`,
+          exo__DisplayNameSpec_matchValue: `[[${DOING_UID}]]`, // UID-canon
+        },
+      },
+      {
+        path: "cond-literal.md",
+        frontmatter: {
+          exo__Asset_uid: "cond-literal",
+          exo__Instance_class: ["[[4d5437c9-788e-4a6d-9be0-4af3a84554f4|exo__PrintedLiteral]]"],
+          exo__DisplayNamePart_of: `[[${SPEC_UID}]]`,
+          exo__DisplayNamePart_order: 0,
+          exo__PrintedLiteral_literal: "🔄 ",
+        },
+      },
+      {
+        path: "cond-prop.md",
+        frontmatter: {
+          exo__Asset_uid: "cond-prop",
+          exo__Instance_class: ["[[7d58de40-d941-4a66-88e2-13afc4fdc41d|exo__PrintedProperty]]"],
+          exo__DisplayNamePart_of: `[[${SPEC_UID}]]`,
+          exo__DisplayNamePart_order: 1,
+          exo__PrintedProperty_property: `[[${LABEL_PROP_UID}|exo__Asset_label]]`,
+        },
+      },
+    ]);
+    const service = new PrintNameRuleService(app);
+    service.initialize();
+    const resolver = new DisplayNameResolver(
+      { defaultTemplate: "{{exo__Asset_label}}", classTemplates: {} },
+      service,
+    );
+    // bare label-form status (target IS the label, no UID) still resolves the 🔄.
+    expect(
+      resolver.resolve({ metadata: taskMeta("[[ems__EffortStatusDoing]]"), basename: "t" }),
+    ).toBe("🔄 Fix the parser");
+    // UID-form still works.
+    expect(resolver.resolve({ metadata: taskMeta(`[[${DOING_UID}]]`), basename: "t" })).toBe(
+      "🔄 Fix the parser",
+    );
+    // a different bare label must NOT match (negative control).
+    expect(
+      resolver.resolve({ metadata: taskMeta("[[ems__EffortStatusDone]]"), basename: "t" }),
+    ).toBe("Fix the parser");
+  });
+
   it("a matched conditional spec BEATS a lower-priority unconditional spec; an unmatched conditional yields to it", () => {
     // Two specs on ems__Task: a HIGH-priority conditional 🔄-Doing + a LOW-priority
     // unconditional "[TASK] <label>". Doing → conditional wins; non-Doing → conditional

--- a/packages/obsidian-plugin/tests/unit/domain/display-name/PrintNameRuleService.test.ts
+++ b/packages/obsidian-plugin/tests/unit/domain/display-name/PrintNameRuleService.test.ts
@@ -330,3 +330,272 @@ describe("PrintNameRuleService — exo__DisplayNameSpec (v1 thin, single-hop) [r
     expect(service.getTemplateForClass("ems__Task")).toBeNull();
   });
 });
+
+describe("PrintNameRuleService — conditional exo__DisplayNameSpec (v2 slice, per-render matcher) [req ed4201d1]", () => {
+  // Real class/enum/property UIDs (the fixture mirrors the shipped 🔄-Doing spec).
+  const TASK_UID = "1b20a8f0-d745-4e93-91db-4531b3df120e";
+  const STATUS_PROP_UID = "44c6e9e3-955f-4afc-9ca5-b4bd70667051"; // ems__Effort_status
+  const DOING_UID = "027e78f4-6e16-4b36-b8fb-5510507d5745"; // ems__EffortStatusDoing
+  const DONE_UID = "7b9b3116-7c3c-438c-9618-94fe301320a6"; // ems__EffortStatusDone
+  const LABEL_PROP_UID = "12a6151b-801f-4be2-bd6e-a787eedd56ae"; // exo__Asset_label
+  const SPEC_UID = "spec-doing-cond-uid";
+
+  // Production-shape vault: a CONDITIONAL 🔄-Doing spec (matchPath=ems__Effort_status,
+  // matchValue=EffortStatusDoing) + its two ordered parts + the ems__Effort_status
+  // property def (so matchPath's UID-form resolves the frontmatter key via a second hop).
+  // NO hand-injected rule — the real scanVault→compile pipeline builds the matcher.
+  function conditionalDoingSpecVault(priority = 50): App {
+    return createMockApp([
+      {
+        path: `${STATUS_PROP_UID}.md`,
+        frontmatter: {
+          exo__Asset_uid: STATUS_PROP_UID,
+          exo__Instance_class: ["[[9a1cf31c-9d41-4ef3-9023-584a8d087d16|exo__ObjectProperty]]"],
+          exo__Asset_label: "ems__Effort_status",
+        },
+      },
+      {
+        path: `${SPEC_UID}.md`,
+        frontmatter: {
+          exo__Asset_uid: SPEC_UID,
+          exo__Instance_class: ["[[07eab746-0874-4676-9d98-dbaad1bc6fb8|exo__DisplayNameSpec]]"],
+          exo__DisplayNameSpec_appliesToClass: `[[${TASK_UID}|ems__Task]]`,
+          exo__DisplayNameSpec_priority: priority,
+          // UID-canon strip-alias form → second-hop resolves the property KEY "ems__Effort_status".
+          exo__DisplayNameSpec_matchPath: `[[${STATUS_PROP_UID}]]`,
+          exo__DisplayNameSpec_matchValue: `[[${DOING_UID}]]`,
+        },
+      },
+      {
+        path: "cond-literal.md",
+        frontmatter: {
+          exo__Asset_uid: "cond-literal",
+          exo__Instance_class: ["[[4d5437c9-788e-4a6d-9be0-4af3a84554f4|exo__PrintedLiteral]]"],
+          exo__DisplayNamePart_of: `[[${SPEC_UID}]]`,
+          exo__DisplayNamePart_order: 0,
+          exo__PrintedLiteral_literal: "🔄 ",
+        },
+      },
+      {
+        path: "cond-prop.md",
+        frontmatter: {
+          exo__Asset_uid: "cond-prop",
+          exo__Instance_class: ["[[7d58de40-d941-4a66-88e2-13afc4fdc41d|exo__PrintedProperty]]"],
+          exo__DisplayNamePart_of: `[[${SPEC_UID}]]`,
+          exo__DisplayNamePart_order: 1,
+          exo__PrintedProperty_property: `[[${LABEL_PROP_UID}|exo__Asset_label]]`,
+        },
+      },
+    ]);
+  }
+
+  function taskMeta(statusValue: string, label = "Fix the parser"): Record<string, unknown> {
+    return {
+      exo__Instance_class: [`[[${TASK_UID}]]`],
+      exo__Asset_label: label,
+      ems__Effort_status: statusValue,
+    };
+  }
+
+  it("@req:ed4201d1-f9da-4142-b12a-5769d4c67f38 the conditional 🔄-Doing spec applies ONLY to a Doing task; a non-Doing task falls through to the label (revert-verify anchor)", () => {
+    const app = conditionalDoingSpecVault();
+    const service = new PrintNameRuleService(app);
+    service.initialize();
+
+    // EMPTY classTemplates — proves the VAULT conditional spec drives the 🔄, not a TS hardcode.
+    // Revert-verify RED anchor: neutralize the per-render matcher gate (treat conditional
+    // rules as always-participating) → the DONE task ALSO gets "🔄 " → this assertion RED.
+    const resolver = new DisplayNameResolver(
+      { defaultTemplate: "{{exo__Asset_label}}", classTemplates: {} },
+      service,
+    );
+
+    const doing = resolver.resolve({ metadata: taskMeta(`[[${DOING_UID}]]`), basename: "t1" });
+    expect(doing).toBe("🔄 Fix the parser");
+
+    const done = resolver.resolve({ metadata: taskMeta(`[[${DONE_UID}]]`), basename: "t2" });
+    expect(done).toBe("Fix the parser");
+  });
+
+  it("evaluates the condition PER-RENDER — the same loaded spec flips 🔄 on/off as the instance status changes (no re-scan)", () => {
+    const app = conditionalDoingSpecVault();
+    const service = new PrintNameRuleService(app);
+    service.initialize(); // scanVault runs ONCE
+
+    const resolver = new DisplayNameResolver(
+      { defaultTemplate: "{{exo__Asset_label}}", classTemplates: {} },
+      service,
+    );
+
+    // Same task, three consecutive renders with a changing status — no service.refresh() between them.
+    expect(resolver.resolve({ metadata: taskMeta(`[[${DOING_UID}]]`), basename: "t" })).toBe(
+      "🔄 Fix the parser",
+    );
+    expect(resolver.resolve({ metadata: taskMeta(`[[${DONE_UID}]]`), basename: "t" })).toBe(
+      "Fix the parser",
+    );
+    expect(resolver.resolve({ metadata: taskMeta(`[[${DOING_UID}]]`), basename: "t" })).toBe(
+      "🔄 Fix the parser",
+    );
+  });
+
+  it("dual-IRI equality — matches the Doing status in UID form AND in the [[uid|label]] alias form", () => {
+    const app = conditionalDoingSpecVault();
+    const service = new PrintNameRuleService(app);
+    service.initialize();
+    const resolver = new DisplayNameResolver(
+      { defaultTemplate: "{{exo__Asset_label}}", classTemplates: {} },
+      service,
+    );
+
+    // UID form
+    expect(resolver.resolve({ metadata: taskMeta(`[[${DOING_UID}]]`), basename: "t" })).toBe(
+      "🔄 Fix the parser",
+    );
+    // alias form [[uid|label]] — cleaned-identity equality, not raw-string.
+    // Revert-verify RED anchor #2: break the dual-IRI cleaning → this assertion RED.
+    expect(
+      resolver.resolve({
+        metadata: taskMeta(`[[${DOING_UID}|ems__EffortStatusDoing]]`),
+        basename: "t",
+      }),
+    ).toBe("🔄 Fix the parser");
+    // a genuinely different status must NOT match (negative control — non-vacuity).
+    expect(
+      resolver.resolve({
+        metadata: taskMeta(`[[${DONE_UID}|ems__EffortStatusDone]]`),
+        basename: "t",
+      }),
+    ).toBe("Fix the parser");
+  });
+
+  it("a matched conditional spec BEATS a lower-priority unconditional spec; an unmatched conditional yields to it", () => {
+    // Two specs on ems__Task: a HIGH-priority conditional 🔄-Doing + a LOW-priority
+    // unconditional "[TASK] <label>". Doing → conditional wins; non-Doing → conditional
+    // is skipped and the unconditional wins.
+    const app = createMockApp([
+      // conditional (priority 80)
+      {
+        path: `${STATUS_PROP_UID}.md`,
+        frontmatter: {
+          exo__Asset_uid: STATUS_PROP_UID,
+          exo__Instance_class: ["[[9a1cf31c-9d41-4ef3-9023-584a8d087d16|exo__ObjectProperty]]"],
+          exo__Asset_label: "ems__Effort_status",
+        },
+      },
+      {
+        path: "cond-spec.md",
+        frontmatter: {
+          exo__Asset_uid: "cond-spec",
+          exo__Instance_class: ["[[07eab746-0874-4676-9d98-dbaad1bc6fb8|exo__DisplayNameSpec]]"],
+          exo__DisplayNameSpec_appliesToClass: `[[${TASK_UID}|ems__Task]]`,
+          exo__DisplayNameSpec_priority: 80,
+          exo__DisplayNameSpec_matchPath: `[[${STATUS_PROP_UID}]]`,
+          exo__DisplayNameSpec_matchValue: `[[${DOING_UID}]]`,
+        },
+      },
+      {
+        path: "cl.md",
+        frontmatter: {
+          exo__Asset_uid: "cl",
+          exo__Instance_class: ["[[4d5437c9-788e-4a6d-9be0-4af3a84554f4|exo__PrintedLiteral]]"],
+          exo__DisplayNamePart_of: "[[cond-spec]]",
+          exo__DisplayNamePart_order: 0,
+          exo__PrintedLiteral_literal: "🔄 ",
+        },
+      },
+      {
+        path: "cp.md",
+        frontmatter: {
+          exo__Asset_uid: "cp",
+          exo__Instance_class: ["[[7d58de40-d941-4a66-88e2-13afc4fdc41d|exo__PrintedProperty]]"],
+          exo__DisplayNamePart_of: "[[cond-spec]]",
+          exo__DisplayNamePart_order: 1,
+          exo__PrintedProperty_property: `[[${LABEL_PROP_UID}|exo__Asset_label]]`,
+        },
+      },
+      // unconditional (priority 1)
+      {
+        path: "uncond-spec.md",
+        frontmatter: {
+          exo__Asset_uid: "uncond-spec",
+          exo__Instance_class: ["[[07eab746-0874-4676-9d98-dbaad1bc6fb8|exo__DisplayNameSpec]]"],
+          exo__DisplayNameSpec_appliesToClass: `[[${TASK_UID}|ems__Task]]`,
+          exo__DisplayNameSpec_priority: 1,
+        },
+      },
+      {
+        path: "ul.md",
+        frontmatter: {
+          exo__Asset_uid: "ul",
+          exo__Instance_class: ["[[4d5437c9-788e-4a6d-9be0-4af3a84554f4|exo__PrintedLiteral]]"],
+          exo__DisplayNamePart_of: "[[uncond-spec]]",
+          exo__DisplayNamePart_order: 0,
+          exo__PrintedLiteral_literal: "[TASK] ",
+        },
+      },
+      {
+        path: "up.md",
+        frontmatter: {
+          exo__Asset_uid: "up",
+          exo__Instance_class: ["[[7d58de40-d941-4a66-88e2-13afc4fdc41d|exo__PrintedProperty]]"],
+          exo__DisplayNamePart_of: "[[uncond-spec]]",
+          exo__DisplayNamePart_order: 1,
+          exo__PrintedProperty_property: `[[${LABEL_PROP_UID}|exo__Asset_label]]`,
+        },
+      },
+    ]);
+    const service = new PrintNameRuleService(app);
+    service.initialize();
+    const resolver = new DisplayNameResolver(
+      { defaultTemplate: "{{exo__Asset_label}}", classTemplates: {} },
+      service,
+    );
+
+    // Doing → high-priority conditional wins.
+    expect(resolver.resolve({ metadata: taskMeta(`[[${DOING_UID}]]`), basename: "t" })).toBe(
+      "🔄 Fix the parser",
+    );
+    // Done → conditional skipped → unconditional "[TASK] <label>" wins (not the fallback label).
+    expect(resolver.resolve({ metadata: taskMeta(`[[${DONE_UID}]]`), basename: "t" })).toBe(
+      "[TASK] Fix the parser",
+    );
+  });
+
+  it("no-regression: an unconditional spec compiles WITHOUT a matcher (v1 path byte-identical, works with no metadata)", () => {
+    // A pure-v1 spec (no matchPath/matchValue) resolves exactly as before — including via
+    // getTemplateForClass called with NO metadata (the v1 signature).
+    const app = createMockApp([
+      {
+        path: "v1-spec.md",
+        frontmatter: {
+          exo__Asset_uid: "v1-spec",
+          exo__Instance_class: ["[[exo__DisplayNameSpec]]"],
+          exo__DisplayNameSpec_appliesToClass: "[[C|ems__Project]]",
+          exo__DisplayNameSpec_priority: 5,
+        },
+      },
+      {
+        path: "v1-part.md",
+        frontmatter: {
+          exo__Asset_uid: "v1-part",
+          exo__Instance_class: ["[[exo__PrintedLiteral]]"],
+          exo__DisplayNamePart_of: "[[v1-spec]]",
+          exo__DisplayNamePart_order: 1,
+          exo__PrintedLiteral_literal: "PROJECT",
+        },
+      },
+    ]);
+    const service = new PrintNameRuleService(app);
+    service.initialize();
+    // v1 call shape (no metadata) still returns the unconditional rule.
+    const byUid = service.getTemplateForClass("ems__Project");
+    expect(byUid).not.toBeNull();
+    expect(byUid!.template).toBe("PROJECT");
+    // and with metadata it is unchanged (matcher-less → always participates).
+    const withMeta = service.getTemplateForClass("ems__Project", {
+      exo__Instance_class: ["[[ems__Project]]"],
+    });
+    expect(withMeta!.template).toBe("PROJECT");
+  });
+});


### PR DESCRIPTION
## What

Adds **per-render conditional specialization** to the homoiconic `exo__DisplayNameSpec` engine (v2 conditional-slice of onto-RFC `92b91345`, PMBOK `fec2f499`).

A spec may now carry a condition, declared as vault data:
- `exo__DisplayNameSpec_matchPath` — a single-hop wikilink to the instance property the condition inspects (e.g. `ems__Effort_status`).
- `exo__DisplayNameSpec_matchValue` — the expected enum asset (e.g. `EffortStatusDoing`).

A **conditional** rule (one carrying a matcher) participates in class selection **only when** the rendered instance's frontmatter value at `matchPath` equals `matchValue`. The condition is evaluated **per-render** — `PrintNameRuleService.getTemplateForClass(className, metadata)` now receives the instance metadata and filters conditional rules against it. So a specialized displayName (e.g. a `🔄` prefix on an `ems__Task` while it is `Doing`) **appears and disappears automatically** as the instance's status changes, with no re-scan.

Demo (real-demand, Andrey): `🔄` prefix on Doing tasks — delivered as a vault `exo__DisplayNameSpec` in `exoas-exo`, zero engine-template-per-state.

## Architectural shift

`compileDisplayNameSpecs` compiles a spec → template **once** at `scanVault`, so the condition cannot be baked into the template (it depends on the concrete instance). The rule now carries an optional `matcher` `{matchKey, matchValues}` (resolved at compile time from `matchPath`/`matchValue`); selection evaluates it against the instance metadata at render time.

- **Dual-IRI equality:** both sides are reduced to their identity set (UID + label forms via `extractClassKeys`) and must intersect — robust whether the status is stored `[[<uid>]]`, `[[<uid>|label]]`, or bare label ([[sparql-iri-form-pre-verify]]).
- **No regression:** a spec **without** a matcher takes the v1 unconditional path byte-identical; `getTemplateForClass` with no metadata skips conditional rules. Pure-label classes (Task/Project/Area/Meeting) + suffix classes (TaskPrototype/MeetingPrototype) render exactly as before.

## Verification

**Revert-verified** (production-shape — real `scanVault → getTemplateForClass(metadata) → DisplayNameResolver.resolve`, no hand-injected rule):

`@req:ed4201d1-f9da-4142-b12a-5769d4c67f38` — neutralizing the per-render matcher gate in `PrintNameRuleService.selectRule` (every rule always participates) reds the Doing/Done anchor (the **Done** task wrongly gains `🔄`); restored → GREEN (`Doing = "🔄 <label>"`, non-Doing `= "<label>"`). A second axis breaks the dual-IRI cleaning → the label-form status assertion reds.

Also covered: per-render dynamics (same loaded spec flips `🔄` on/off across renders), matched-conditional-beats-unconditional-by-priority, unmatched-conditional-yields, dual-IRI UID+alias forms, no-matcher v1 path.

- 103/103 display-name tests GREEN; broader regression suites (ExocortexPlugin, wikilink-resolution) GREEN.
- `check:types` clean; eslint(src, `--max-warnings=0`) clean; 3 CI guard scripts (shard-assignments / test-antipatterns 55/55 / coverage-monotonic) clean.

## TBox / vault (delivered via `exoas-exo`, out-of-tree)

- `exo__DisplayNameSpec_matchPath` + `_matchValue` property defs pushed to `kitelev/exoas-exo` main (SHACL 0). `validate-properties.sh` whitelist extended.
- The 🔄-Doing conditional spec asset is authored + pushed separately (T3).

Requirement `ed4201d1` (exoas-exo-reqs, `approved`; → `active` on merge).

Req: ed4201d1-f9da-4142-b12a-5769d4c67f38
