### PR TITLE
fix(cli): merge multi-value exo__Instance_class from --property into --class array (#3852)

### DIFF
--- a/packages/core/src/services/GenericAssetCreationService.ts
+++ b/packages/core/src/services/GenericAssetCreationService.ts
@@ -294,7 +294,14 @@ export class GenericAssetCreationService {
         ? extraInstanceClasses
         : [extraInstanceClasses];
       for (const extra of extras) {
-        if (extra === null || extra === undefined) {
+        // Skip null/undefined and empty/whitespace-only values — the latter
+        // would otherwise emit a malformed `"[[]]"` class entry (mirrors the
+        // `createdBy` trim guard above).
+        if (
+          extra === null ||
+          extra === undefined ||
+          String(extra).trim() === ""
+        ) {
           continue;
         }
         const formatted = this.formatWikilink(String(extra));

--- a/packages/core/src/services/GenericAssetCreationService.ts
+++ b/packages/core/src/services/GenericAssetCreationService.ts
@@ -278,6 +278,32 @@ export class GenericAssetCreationService {
         : config.className;
     frontmatter["exo__Instance_class"] = [this.formatWikilink(classRef)];
 
+    // Merge any additional `exo__Instance_class` values supplied via
+    // propertyValues (e.g. `cli create --class A --property
+    // "exo__Instance_class=[[B]]"`, or a repeated `--property` flag) into the
+    // array, so a multi-class asset can be created in one command (issue
+    // #3852). `--class` sets the primary class; extras accumulate in order,
+    // de-duplicated. Formatting goes through `formatWikilink` so bare-UUID,
+    // `[[..]]` and `"[[..]]"` inputs all normalise to the same quoted form as
+    // the primary. The propertyValues loop below still skips
+    // `exo__Instance_class`, so these are not re-emitted there.
+    const extraInstanceClasses = config.propertyValues?.["exo__Instance_class"];
+    if (extraInstanceClasses !== undefined && extraInstanceClasses !== null) {
+      const instanceClasses = frontmatter["exo__Instance_class"] as string[];
+      const extras = Array.isArray(extraInstanceClasses)
+        ? extraInstanceClasses
+        : [extraInstanceClasses];
+      for (const extra of extras) {
+        if (extra === null || extra === undefined) {
+          continue;
+        }
+        const formatted = this.formatWikilink(String(extra));
+        if (!instanceClasses.includes(formatted)) {
+          instanceClasses.push(formatted);
+        }
+      }
+    }
+
     // Creator — emitted only when explicitly supplied (no implicit default).
     if (config.createdBy && config.createdBy.trim() !== "") {
       frontmatter["exo__Asset_createdBy"] = this.formatWikilink(

--- a/packages/core/tests/unit/services/GenericAssetCreationService.test.ts
+++ b/packages/core/tests/unit/services/GenericAssetCreationService.test.ts
@@ -452,6 +452,21 @@ describe("GenericAssetCreationService", () => {
         expect(primaryOccurrences).toBe(1);
       });
 
+      it("should ignore empty/whitespace-only exo__Instance_class values (no malformed [[]] entry)", async () => {
+        const config = {
+          className: "ztlk__Note",
+          classRefForm: "uuid" as const,
+          classUid: "65b58c34-7451-4b89-bea3-483f7c65fe73",
+          label: "Empty extra class",
+          propertyValues: { exo__Instance_class: ["", "   "] },
+        };
+        await service.createAsset(config);
+        const content = mockVault.create.mock.calls[0][1];
+        expect(content).not.toContain("[[]]");
+        // primary class from --class is still present, no bogus extras
+        expect(content).toContain("[[65b58c34-7451-4b89-bea3-483f7c65fe73]]");
+      });
+
       it("should skip system property aliases in propertyValues", async () => {
         const config = {
           className: "ems__Task",

--- a/packages/core/tests/unit/services/GenericAssetCreationService.test.ts
+++ b/packages/core/tests/unit/services/GenericAssetCreationService.test.ts
@@ -406,14 +406,50 @@ describe("GenericAssetCreationService", () => {
         expect(content).not.toContain("2020-01-01T00:00:00");
       });
 
-      it("should skip system property exo__Instance_class in propertyValues", async () => {
+      // exo__Instance_class is the ONE system property that is MERGED, not
+      // skipped: `--class` sets the primary class and additional values from
+      // propertyValues accumulate into the array so a multi-class asset can be
+      // created in one command (issue #3852).
+      it("should merge additional exo__Instance_class from propertyValues into the class array (issue #3852)", async () => {
         const config = {
-          className: "ems__Task",
-          propertyValues: { exo__Instance_class: ["[[custom_class]]"] },
+          className: "ztlk__Note",
+          classRefForm: "uuid" as const,
+          classUid: "65b58c34-7451-4b89-bea3-483f7c65fe73",
+          label: "Multi-class asset",
+          propertyValues: {
+            exo__Instance_class: "[[45c96de0-b70a-44b1-b35b-c023f8857a12]]",
+          },
         };
         await service.createAsset(config);
         const content = mockVault.create.mock.calls[0][1];
-        expect(content).not.toContain("custom_class");
+        // primary class (from --class) is present
+        expect(content).toContain("[[65b58c34-7451-4b89-bea3-483f7c65fe73]]");
+        // second class (from --property) is MERGED, not dropped
+        expect(content).toContain("[[45c96de0-b70a-44b1-b35b-c023f8857a12]]");
+      });
+
+      it("should merge repeated exo__Instance_class values and de-duplicate against --class", async () => {
+        const config = {
+          className: "ztlk__Note",
+          classRefForm: "uuid" as const,
+          classUid: "aaaaaaaa-0000-0000-0000-000000000000",
+          label: "Repeated multi-class",
+          propertyValues: {
+            // one genuinely new class + one that duplicates the --class primary
+            exo__Instance_class: [
+              "[[bbbbbbbb-1111-1111-1111-111111111111]]",
+              "[[aaaaaaaa-0000-0000-0000-000000000000]]",
+            ],
+          },
+        };
+        await service.createAsset(config);
+        const content = mockVault.create.mock.calls[0][1];
+        expect(content).toContain("[[bbbbbbbb-1111-1111-1111-111111111111]]");
+        // primary class is not duplicated (dedup): appears exactly once
+        const primaryOccurrences = content.split(
+          "[[aaaaaaaa-0000-0000-0000-000000000000]]",
+        ).length - 1;
+        expect(primaryOccurrences).toBe(1);
       });
 
       it("should skip system property aliases in propertyValues", async () => {


### PR DESCRIPTION
## Problem

`exocortex-cli create` silently dropped a second `exo__Instance_class` passed via `--property` when `--class` already set the primary class. It was impossible to create a multi-class asset in one command.

Root cause: `GenericAssetCreationService.buildAsset` sets `exo__Instance_class` to a single-element array from `--class`, and the subsequent `propertyValues` loop explicitly **skips** `exo__Instance_class` — so any value passed via `--property "exo__Instance_class=..."` was ignored with no warning.

Reproduction (before): `create --class A --property "exo__Instance_class=[[B]]" --dry-run` → the preview emitted only class A.

## Fix

`buildAsset` now merges additional `exo__Instance_class` values from `propertyValues` (scalar or a repeated `--property` flag) into the class array — de-duplicated, and formatted through `formatWikilink` so bare-UUID / `[[..]]` / `"[[..]]"` inputs all normalise to the same quoted form as the primary. `--class` still sets the primary class; the loop still skips `exo__Instance_class` so values are not re-emitted there.

~15 LOC in one core function; `exocortex-cli` inherits the fix (no CLI-side change needed — the values already flow through `propertyValues`).

## Verification

- **Revert-verified** unit tests: 2 new tests (merge + repeated/dedup) **FAIL without the merge**, **PASS with it**; the other 97 tests in the suite are unaffected. The pre-existing "skip exo__Instance_class" test was repurposed to assert the new merge contract (it codified the old limitation).
- **Typecheck**: core `tsc --noEmit` → 0 errors.
- **End-to-end** real built CLI dry-run (the exact #3852 scenario) now emits both classes:

```
exo__Instance_class:
  - "[[65b58c34-7451-4b89-bea3-483f7c65fe73]]"
  - "[[45c96de0-b70a-44b1-b35b-c023f8857a12]]"
```

Closes #3852

https://claude.ai/code/session_017j92wpGSFfbfuvXYCKecMK
