### PR TITLE
fix(core): emit exo__Asset_updatedAt = createdAt at asset creation (task 1af85afd create-side)

### DIFF
--- a/packages/core/src/services/GenericAssetCreationService.ts
+++ b/packages/core/src/services/GenericAssetCreationService.ts
@@ -265,9 +265,15 @@ export class GenericAssetCreationService {
     // Set required system properties
     frontmatter["exo__Asset_uid"] = uid;
 
-    frontmatter["exo__Asset_createdAt"] = config.timezone
+    const createdAt = config.timezone
       ? this.generateTimestampInTimezone(config.timezone)
       : DateFormatter.toLocalTimestamp(this.clock.now());
+    frontmatter["exo__Asset_createdAt"] = createdAt;
+    // exo__Asset_updatedAt: every created asset satisfies the "updatedAt is an
+    // enforced last-modified invariant" from birth (task 1af85afd) — set equal
+    // to createdAt at creation. Subsequent mutations bump it separately (via
+    // explicit grounding steps / the plugin modify-listener).
+    frontmatter["exo__Asset_updatedAt"] = createdAt;
 
     // exo__Instance_class: opt-in UID-canon strip form (`[[<uuid>]]`) when the
     // caller resolves a class UUID and requests it; otherwise the historical
@@ -345,6 +351,7 @@ export class GenericAssetCreationService {
         if (
           propertyName === "exo__Asset_uid" ||
           propertyName === "exo__Asset_createdAt" ||
+          propertyName === "exo__Asset_updatedAt" ||
           propertyName === "exo__Asset_createdBy" ||
           propertyName === "exo__Instance_class" ||
           propertyName === "exo__Asset_label" ||

--- a/packages/core/tests/unit/services/GenericAssetCreationService.test.ts
+++ b/packages/core/tests/unit/services/GenericAssetCreationService.test.ts
@@ -120,6 +120,24 @@ describe("GenericAssetCreationService", () => {
       expect(content).toMatch(/exo__Asset_createdAt: \d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/);
     });
 
+    it("should include updatedAt equal to createdAt at creation (task 1af85afd)", async () => {
+      const config = {
+        className: "ems__Task",
+      };
+
+      await service.createAsset(config);
+
+      const content = mockVault.create.mock.calls[0][1];
+
+      // Every created asset carries exo__Asset_updatedAt from birth (enforced
+      // last-modified invariant) — set equal to createdAt at creation.
+      expect(content).toContain("exo__Asset_updatedAt:");
+      const createdAt = content.match(/exo__Asset_createdAt: (\S+)/)?.[1];
+      const updatedAt = content.match(/exo__Asset_updatedAt: (\S+)/)?.[1];
+      expect(updatedAt).toBeDefined();
+      expect(updatedAt).toBe(createdAt);
+    });
+
     it("should include UID in frontmatter", async () => {
       const config = {
         className: "ems__Task",


### PR DESCRIPTION
## Problem

`exocortex-cli create` (and every path through `GenericAssetCreationService.buildAsset` — CLI `create`/`apply`, plugin create-instance) produced assets **without `exo__Asset_updatedAt`**. That breaks the "updatedAt is an enforced last-modified invariant" goal (task `1af85afd`): a freshly created asset had no updatedAt from birth, and — because the field was absent — an in-place `Edit` of its body could not proceed (the `validate-updatedat` hook requires an updatedAt bump, while `dogfood-cli-mutation` blocks adding a missing property). In practice this forced full delete+recreate cycles to amend a CLI-created note.

## Fix (create-side, engine)

`buildAsset` now sets `exo__Asset_updatedAt` equal to `exo__Asset_createdAt` at creation, for **all** creation paths, so the invariant holds from birth. A single `createdAt` value is computed once and used for both fields (they are byte-identical). `exo__Asset_updatedAt` is added to the `propertyValues` skip-list (system-managed, like `createdAt`).

This is the **creation** half of task `1af85afd`. The **mutation** half (bumping updatedAt on `apply` commands via explicit `property_set(updatedAt=$nowLocal)` grounding steps + a plugin modify-listener for native Obsidian edits) is the separate, locked-design Phase 1/2 and is out of scope here.

## Verification

- **Revert-verified** unit test: `should include updatedAt equal to createdAt at creation` FAILS without the emit (`void createdAt`), PASSES with it; the other 100 tests in the suite are unaffected.
- **No regression**: all frontmatter-asserting suites pass with the added field — core `GenericAssetCreationService` (101), core `asset-creation-flow` (20), CLI create/apply incl. `create-cardinality`/`create-multivalue`/`createAsset` (ESM run, 23+), plugin `ServiceRegistryPopulator` (81) + `asset-creation-flow`/`ProfileWiring` (29). They use presence assertions, so an extra field is safe.
- **Typecheck**: core `tsc --noEmit` → 0 errors.
- **End-to-end** real built CLI dry-run:

```
exo__Asset_createdAt: 2026-07-11T17:16:03
exo__Asset_updatedAt: 2026-07-11T17:16:03
```

Ref: task `1af85afd` (vault-exodev). Follows the same delivery discipline as #3852 (revert-verify + code-review + CI).

https://claude.ai/code/session_017j92wpGSFfbfuvXYCKecMK
