### PR TITLE
fix(core): silent updatedAt=createdAt top-up for create_instance groundings (task 1af85afd)

### DIFF
--- a/packages/core/src/services/GroundingExecutor.ts
+++ b/packages/core/src/services/GroundingExecutor.ts
@@ -1501,6 +1501,18 @@ export class GroundingExecutor {
       missing.push("exo__Asset_createdAt");
     }
 
+    // exo__Asset_updatedAt: enforced last-modified invariant from birth (task
+    // 1af85afd). Created assets carry updatedAt = createdAt. This is a SILENT
+    // safety-net (NOT pushed to `missing`): the homoiconic Universal Default
+    // Template PropertyDefault is the primary mechanism, but its absence is not
+    // an "unhealthy vault" signal the way a missing uid/createdAt/label/class
+    // is — the derived updatedAt = createdAt is always recoverable here. Keeping
+    // it out of `missing` avoids a spurious unhealthy-state warning on every
+    // create_instance until the template PD lands.
+    if (properties.exo__Asset_updatedAt === undefined) {
+      properties.exo__Asset_updatedAt = properties.exo__Asset_createdAt;
+    }
+
     // RFC ce27e55d: also treat an empty / whitespace-only `exo__Asset_label`
     // written by an upstream PropertyDefault as "missing". Discovered during
     // UI smoke 2026-05-29 — Universal Default Template's PD #3

--- a/packages/core/tests/unit/services/GroundingExecutor.test.ts
+++ b/packages/core/tests/unit/services/GroundingExecutor.test.ts
@@ -1617,6 +1617,26 @@ describe("GroundingExecutor", () => {
       expect(content).toMatch(/exo__Asset_createdAt: \d{4}-\d{2}-\d{2}T/);
     });
 
+    it("should include exo__Asset_updatedAt equal to createdAt at create_instance (task 1af85afd)", async () => {
+      const grounding = makeGrounding({
+        type: GroundingType.CREATE_INSTANCE,
+        targetClass: "ems__Task",
+        targetFolder: "01 Inbox",
+      });
+
+      const result = await executor.execute(grounding, TARGET_IRI, FILE_PATH);
+
+      expect(result.success).toBe(true);
+      const [, content] = writer.createFile.mock.calls[0];
+      // create_instance assets carry updatedAt = createdAt from birth (safety-net
+      // top-up mirroring the createdAt top-up).
+      expect(content).toContain("exo__Asset_updatedAt:");
+      const createdAt = content.match(/exo__Asset_createdAt: (\S+)/)?.[1];
+      const updatedAt = content.match(/exo__Asset_updatedAt: (\S+)/)?.[1];
+      expect(updatedAt).toBeDefined();
+      expect(updatedAt).toBe(createdAt);
+    });
+
     it("should emit exo__Asset_createdAt as a local timestamp (no Z / TZ suffix) — Issue #3188", async () => {
       const grounding = makeGrounding({
         type: GroundingType.CREATE_INSTANCE,


### PR DESCRIPTION
## Problem

#3854 made `GenericAssetCreationService.buildAsset` emit `exo__Asset_updatedAt = createdAt`, covering CLI `create` and `service_call` groundings. But the **flagship `create_instance` grounding path** (the plugin "Create Instance" buttons + CLI `apply` create_instance) does NOT go through `buildAsset` — it is handled internally by `GroundingExecutor.executeCreateInstance`. So create_instance assets still lacked `exo__Asset_updatedAt` (empirically confirmed: the Universal Default Template declares 0 `exo__Asset_updatedAt` PropertyDefaults, only createdAt).

## Fix (engine safety-net, mirrors createdAt)

`GroundingExecutor.applyMissingScalarPrimitives` now fills `exo__Asset_updatedAt = properties.exo__Asset_createdAt` when a create_instance grounding does not otherwise set it — the exact mirror of the existing createdAt top-up two lines above.

**Deliberately SILENT** — unlike the essential primitives (uid/createdAt/label/Instance_class), `exo__Asset_updatedAt` is **not** pushed to the `missing` list. Its absence from the template is recoverable (updatedAt := createdAt) and must not raise the "Universal Default Template did not cover essential scalar primitives — vault may be unhealthy" warning on every create_instance until the homoiconic template PropertyDefault lands.

This is the engine half of the "оба, как createdAt" approach: the homoiconic Universal Default Template `PropertyDefault(exo__Asset_updatedAt = $nowTimestamp)` is the primary mechanism (separate exocmd change), this top-up is the safety-net for template-less create_instance flows — exactly how createdAt is covered by BOTH today.

## Verification

- **Revert-verified** unit test: `should include exo__Asset_updatedAt equal to createdAt at create_instance` FAILS without the top-up (`void`), PASSES with it; the other 237 GroundingExecutor tests are unaffected.
- Two pre-existing tests that asserted the exact "essential primitives not covered" set / `missing` length stayed green precisely because the top-up is silent (not in `missing`).
- **No regression**: GroundingExecutor (238), create_instance integration incl. prototype-precondition + grounding-type parity (submodule-init'd, 38), CLI apply-determinism/create-instance ESM (48) — all green.
- **Typecheck**: core `tsc --noEmit` → 0 errors.

Ref: task `1af85afd` (create-side). Complements #3854. Follows the same discipline (revert-verify + code-review + advisor, per elevated-risk GroundingExecutor).

https://claude.ai/code/session_017j92wpGSFfbfuvXYCKecMK
