### PR TITLE
feat(cli): run-query <uid> + homoiconic classes read-axis (req 2678df55)

### DIFF
--- a/packages/cli/src/commands/classes.ts
+++ b/packages/cli/src/commands/classes.ts
@@ -3,20 +3,35 @@ import { existsSync } from "fs";
 import { resolve } from "path";
 import {
   InMemoryTripleStore,
-  ExoQLParser,
-  ExoQLAlgebraTranslator,
-  AlgebraOptimizer,
-  ExoQLQueryExecutor,
   NoteToRDFConverter,
   Triple,
-  IRI,
+  type NamedQueryRunner,
+  type NamedQueryContext,
+  type SolutionMapping,
+  type ExoQLEvalResult,
 } from "@kitelev/exocortex-core";
 import { FileSystemVaultAdapter } from "../adapters/FileSystemVaultAdapter.js";
-import { TableFormatter } from "../formatters/TableFormatter.js";
 import { ErrorHandler, type OutputFormat } from "../utils/ErrorHandler.js";
+import { ExitCodes } from "../utils/ExitCodes.js";
+import { ErrorCode } from "../responses/index.js";
 import { VaultNotFoundError } from "../utils/errors/index.js";
 import { ResponseBuilder } from "../responses/index.js";
 import { CacheManager } from "../cache/CacheManager.js";
+import { buildNamedQueryRunner } from "../services/NamedQueryCliRunner.js";
+
+/**
+ * Canonical `query__NamedQuery` UIDs backing schema introspection (req
+ * 2678df55 — homoiconic read axis). The SPARQL bodies live in vault assets
+ * (`exoas-public/exoql`); this command resolves them by UID and executes them
+ * read-only through `NamedQueryRunner`, then formats the rows with the in-code
+ * ASCII-table formatter (`extractLocalName` truncation). Editing an asset's
+ * ```sparql body changes what `classes`/`describe-class` prints — no code
+ * change. `run-query <uid>` executes any NamedQuery standalone.
+ */
+const INTROSPECT_CLASSES_QUERY_UID = "b6aa1da9-96b9-4066-99a9-f81cc8b316aa";
+const INTROSPECT_CLASS_COUNT_QUERY_UID = "5ba1031d-2c6e-4528-ab81-fb768d8e061a";
+const INTROSPECT_CLASS_PROPERTIES_QUERY_UID =
+  "efb7bb79-6378-44b0-b1ca-9a27e3eeb684";
 
 export interface ClassesCommandOptions {
   vault: string;
@@ -44,7 +59,8 @@ export function classesCommand(): Command {
     .alias("describe-class")
     .description(
       "List RDF classes in vault, or describe a class (predicates + counts). " +
-      "Alias `describe-class` is provided per #3043 RFC §B (schema introspection).",
+      "Alias `describe-class` is provided per #3043 RFC §B (schema introspection). " +
+      "Introspection SPARQL is read from vault query__NamedQuery assets (req 2678df55).",
     )
     .argument("[class-name]", "Optional class name to show details (e.g., ems__Task)")
     .option("--vault <path>", "Path to Obsidian vault", process.cwd())
@@ -96,12 +112,16 @@ export function classesCommand(): Command {
           console.log(`✅ Loaded ${triples.length} triples in ${loadDuration}ms${cacheStatus}\n`);
         }
 
+        // req 2678df55 — read the introspection SPARQL from vault query__NamedQuery
+        // assets instead of hardcoding it in this command. The formatter stays here.
+        const runner = buildNamedQueryRunner(tripleStore, vaultPath);
+
         if (className) {
           // Show details for specific class
-          await showClassDetails(tripleStore, className, options, outputFormat);
+          await showClassDetails(runner, className, options, outputFormat);
         } else {
           // List all classes
-          await listAllClasses(tripleStore, options, outputFormat);
+          await listAllClasses(runner, options, outputFormat);
         }
       } catch (error) {
         ErrorHandler.handle(error as Error);
@@ -109,35 +129,44 @@ export function classesCommand(): Command {
     });
 }
 
+/**
+ * Narrow a NamedQuery result to its SELECT rows, or fail loud with a clear
+ * message when the introspection query asset is missing / not a SELECT.
+ */
+function requireSelectRows(
+  result: ExoQLEvalResult | null,
+  uid: string,
+): SolutionMapping[] {
+  if (result === null) {
+    ErrorHandler.handleWithMessage(
+      `Introspection query__NamedQuery asset "${uid}" not found in the vault ` +
+        "(no asset with that UID, or it has no ```sparql code-block). The " +
+        "`classes` command reads its SPARQL from vault query assets (req 2678df55).",
+      ExitCodes.FILE_NOT_FOUND,
+      ErrorCode.VALIDATION_FILE_NOT_FOUND,
+    );
+  }
+  if (result.kind !== "select") {
+    ErrorHandler.handleWithMessage(
+      `Introspection query "${uid}" is an ${result.kind} query; expected SELECT.`,
+      ExitCodes.INVALID_ARGUMENTS,
+      ErrorCode.VALIDATION_INVALID_ARGUMENTS,
+    );
+  }
+  return result.rows;
+}
+
 async function listAllClasses(
-  tripleStore: InMemoryTripleStore,
+  runner: NamedQueryRunner,
   options: ClassesCommandOptions,
   outputFormat: OutputFormat
 ): Promise<void> {
-  // SPARQL query to get all classes and their instance counts
-  const query = `
-    PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
-    SELECT ?class (COUNT(?instance) AS ?count)
-    WHERE {
-      ?instance rdf:type ?class .
-    }
-    GROUP BY ?class
-    ORDER BY DESC(?count)
-  `;
+  const result = await runner.run(INTROSPECT_CLASSES_QUERY_UID);
+  const rows = requireSelectRows(result, INTROSPECT_CLASSES_QUERY_UID);
 
-  const parser = new ExoQLParser();
-  const ast = parser.parse(query);
-  const translator = new ExoQLAlgebraTranslator();
-  let algebra = translator.translate(ast);
-  const optimizer = new AlgebraOptimizer();
-  algebra = optimizer.optimize(algebra);
-
-  const executor = new ExoQLQueryExecutor(tripleStore);
-  const results = await executor.executeAll(algebra);
-
-  const classes: { name: string; count: number }[] = results.map((result) => {
-    const classIri = result.get("class");
-    const countValue = result.get("count");
+  const classes: { name: string; count: number }[] = rows.map((row) => {
+    const classIri = row.get("class");
+    const countValue = row.get("count");
     return {
       name: classIri ? extractLocalName(classIri.toString()) : "unknown",
       count: countValue ? parseInt(countValue.toString(), 10) : 0,
@@ -173,59 +202,40 @@ async function listAllClasses(
 }
 
 async function showClassDetails(
-  tripleStore: InMemoryTripleStore,
+  runner: NamedQueryRunner,
   className: string,
   options: ClassesCommandOptions,
   outputFormat: OutputFormat
 ): Promise<void> {
-  // First get instance count for this class
-  const countQuery = `
-    PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
-    SELECT (COUNT(?instance) AS ?count)
-    WHERE {
-      ?instance rdf:type ?class .
-      FILTER(CONTAINS(STR(?class), "${className}"))
-    }
-  `;
+  // $className bound as a literal param, substituted by NamedQueryRunner before
+  // parse (engine-controlled substitution, read-only). Both introspection
+  // queries live in vault query__NamedQuery assets (req 2678df55).
+  const context: NamedQueryContext = {
+    params: { className: { value: className, kind: "literal" } },
+  };
 
-  const parser = new ExoQLParser();
-  let ast = parser.parse(countQuery);
-  let translator = new ExoQLAlgebraTranslator();
-  let algebra = translator.translate(ast);
-  let optimizer = new AlgebraOptimizer();
-  algebra = optimizer.optimize(algebra);
+  const countResult = await runner.run(INTROSPECT_CLASS_COUNT_QUERY_UID, context);
+  const countRows = requireSelectRows(
+    countResult,
+    INTROSPECT_CLASS_COUNT_QUERY_UID,
+  );
+  const instanceCount =
+    countRows.length > 0
+      ? parseInt(countRows[0].get("count")?.toString() || "0", 10)
+      : 0;
 
-  const executor = new ExoQLQueryExecutor(tripleStore);
-  const countResults = await executor.executeAll(algebra);
-  const instanceCount = countResults.length > 0
-    ? parseInt(countResults[0].get("count")?.toString() || "0", 10)
-    : 0;
+  const propsResult = await runner.run(
+    INTROSPECT_CLASS_PROPERTIES_QUERY_UID,
+    context,
+  );
+  const propsRows = requireSelectRows(
+    propsResult,
+    INTROSPECT_CLASS_PROPERTIES_QUERY_UID,
+  );
 
-  // Get properties used by instances of this class
-  const propsQuery = `
-    PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
-    SELECT ?property (COUNT(?value) AS ?usageCount)
-    WHERE {
-      ?instance rdf:type ?class .
-      ?instance ?property ?value .
-      FILTER(CONTAINS(STR(?class), "${className}"))
-      FILTER(?property != rdf:type)
-    }
-    GROUP BY ?property
-    ORDER BY DESC(?usageCount)
-  `;
-
-  ast = parser.parse(propsQuery);
-  translator = new ExoQLAlgebraTranslator();
-  algebra = translator.translate(ast);
-  optimizer = new AlgebraOptimizer();
-  algebra = optimizer.optimize(algebra);
-
-  const propsResults = await executor.executeAll(algebra);
-
-  const properties: PropertyInfo[] = propsResults.map((result) => {
-    const propIri = result.get("property");
-    const usageValue = result.get("usageCount");
+  const properties: PropertyInfo[] = propsRows.map((row) => {
+    const propIri = row.get("property");
+    const usageValue = row.get("usageCount");
     return {
       name: propIri ? extractLocalName(propIri.toString()) : "unknown",
       usageCount: usageValue ? parseInt(usageValue.toString(), 10) : 0,

--- a/packages/cli/src/commands/run-query.ts
+++ b/packages/cli/src/commands/run-query.ts
@@ -1,0 +1,225 @@
+import { Command } from "commander";
+import { existsSync } from "fs";
+import { resolve } from "path";
+import {
+  InMemoryTripleStore,
+  NoteToRDFConverter,
+  Triple,
+  vaultPathToIRI,
+  type NamedQueryContext,
+  type NamedQueryParam,
+  type ExoQLEvalResult,
+} from "@kitelev/exocortex-core";
+import { FileSystemVaultAdapter } from "../adapters/FileSystemVaultAdapter.js";
+import { TableFormatter } from "../formatters/TableFormatter.js";
+import { ErrorHandler, type OutputFormat } from "../utils/ErrorHandler.js";
+import { ExitCodes } from "../utils/ExitCodes.js";
+import { ErrorCode } from "../responses/index.js";
+import { VaultNotFoundError } from "../utils/errors/index.js";
+import { ResponseBuilder } from "../responses/index.js";
+import { CacheManager } from "../cache/CacheManager.js";
+import { buildNamedQueryRunner } from "../services/NamedQueryCliRunner.js";
+
+export interface RunQueryCommandOptions {
+  vault: string;
+  format: "table" | "json";
+  output?: OutputFormat;
+  useCache?: boolean;
+  currentAsset?: string;
+  param: string[];
+  paramIri: string[];
+}
+
+/** Commander collector for repeatable options. */
+function collect(value: string, previous: string[]): string[] {
+  return previous.concat([value]);
+}
+
+/**
+ * Parse `name=value` occurrences into the NamedQuery params map.
+ * `literals` → literal-kind (escaped `"value"`); `iris` → iri-kind, where the
+ * value is a VAULT-RELATIVE path resolved to an `obsidian://vault/...` IRI.
+ */
+function buildParams(
+  literals: string[],
+  iris: string[],
+): Record<string, NamedQueryParam> | undefined {
+  const params: Record<string, NamedQueryParam> = {};
+  const add = (raw: string, kind: "iri" | "literal"): void => {
+    const eq = raw.indexOf("=");
+    if (eq <= 0) {
+      throw new Error(
+        `Invalid --param "${raw}" — expected name=value.`,
+      );
+    }
+    const name = raw.slice(0, eq);
+    const value = raw.slice(eq + 1);
+    params[name] = {
+      value: kind === "iri" ? vaultPathToIRI(value) : value,
+      kind,
+    };
+  };
+  for (const l of literals) add(l, "literal");
+  for (const i of iris) add(i, "iri");
+  return Object.keys(params).length > 0 ? params : undefined;
+}
+
+/**
+ * Creates the `run-query <uid>` command (req 2678df55 — read axis).
+ *
+ * Resolves a `query__NamedQuery` asset by UID and executes its `sparql` body
+ * read-only through `NamedQueryRunner`, printing the result (SELECT → table /
+ * JSON; ASK → boolean; CONSTRUCT → triples). Context-free by default; accepts
+ * `--current-asset` (`$currentAsset`) and repeatable `--param` / `--param-iri`.
+ * This is the standalone read-side surface — NamedQueries were previously
+ * reachable only from inside preconditions / groundings.
+ */
+export function runQueryCommand(): Command {
+  return new Command("run-query")
+    .description(
+      "Execute a query__NamedQuery asset (read-only SELECT / ASK / CONSTRUCT) by UID and print its result.",
+    )
+    .argument("<uid>", "UID of the query__NamedQuery asset to run")
+    .option("--vault <path>", "Path to Obsidian vault", process.cwd())
+    .option("--format <type>", "Output format: table|json", "table")
+    .option("--output <type>", "Response format: text|json (for MCP tools)", "text")
+    .option("--use-cache", "Use persistent cache (faster for repeated queries)")
+    .option(
+      "--current-asset <path>",
+      "Vault-relative path injected as $currentAsset (an IRI) into the query body",
+    )
+    .option(
+      "--param <name=value>",
+      "Literal parameter $<name> substituted as an escaped string. Repeatable.",
+      collect,
+      [],
+    )
+    .option(
+      "--param-iri <name=path>",
+      "IRI parameter $<name>; value is a vault-relative path resolved to an IRI. Repeatable.",
+      collect,
+      [],
+    )
+    .action(async (uid: string, options: RunQueryCommandOptions) => {
+      const outputFormat = (options.output || "text") as OutputFormat;
+      const asJson = outputFormat === "json" || options.format === "json";
+      ErrorHandler.setFormat(outputFormat);
+
+      try {
+        const vaultPath = resolve(options.vault);
+        if (!existsSync(vaultPath)) {
+          throw new VaultNotFoundError(vaultPath);
+        }
+
+        if (!asJson) {
+          console.log(`📦 Loading vault: ${vaultPath}...`);
+        }
+
+        let triples: Triple[];
+        if (options.useCache ?? false) {
+          const cacheResult = await new CacheManager(vaultPath).loadOrBuild();
+          triples = cacheResult.triples;
+        } else {
+          const converter = new NoteToRDFConverter(
+            new FileSystemVaultAdapter(vaultPath),
+          );
+          triples = await converter.convertVault();
+        }
+        const tripleStore = new InMemoryTripleStore();
+        await tripleStore.addAll(triples);
+
+        const runner = buildNamedQueryRunner(tripleStore, vaultPath);
+
+        const context: NamedQueryContext = {};
+        if (options.currentAsset) {
+          (context as { currentAsset?: string }).currentAsset = vaultPathToIRI(
+            options.currentAsset,
+          );
+        }
+        const params = buildParams(options.param, options.paramIri);
+        if (params) {
+          (context as { params?: Record<string, NamedQueryParam> }).params =
+            params;
+        }
+
+        const result = await runner.run(uid, context);
+        if (result === null) {
+          ErrorHandler.handleWithMessage(
+            `No resolvable query__NamedQuery for UID "${uid}" ` +
+              "(asset not found, or it has no ```sparql code-block).",
+            ExitCodes.FILE_NOT_FOUND,
+            ErrorCode.VALIDATION_FILE_NOT_FOUND,
+          );
+        }
+
+        printResult(result, asJson);
+      } catch (error) {
+        ErrorHandler.handle(error as Error);
+      }
+    });
+}
+
+function printResult(result: ExoQLEvalResult, asJson: boolean): void {
+  if (result.kind === "ask") {
+    if (asJson) {
+      console.log(
+        JSON.stringify(
+          ResponseBuilder.success({ kind: "ask", result: result.result }),
+          null,
+          2,
+        ),
+      );
+    } else {
+      console.log(String(result.result));
+    }
+    return;
+  }
+
+  if (result.kind === "construct") {
+    const rows = result.triples.map((t: Triple) => ({
+      subject: t.subject.toString(),
+      predicate: t.predicate.toString(),
+      object: t.object.toString(),
+    }));
+    if (asJson) {
+      console.log(
+        JSON.stringify(
+          ResponseBuilder.success({
+            kind: "construct",
+            triples: rows,
+            count: rows.length,
+          }),
+          null,
+          2,
+        ),
+      );
+    } else {
+      console.log(`📊 CONSTRUCT — ${rows.length} triple(s):\n`);
+      for (const r of rows) {
+        console.log(`${r.subject} ${r.predicate} ${r.object} .`);
+      }
+    }
+    return;
+  }
+
+  // SELECT
+  if (asJson) {
+    const rows = result.rows.map((row) => {
+      const obj: Record<string, string | null> = {};
+      for (const v of row.variables()) {
+        const term = row.get(v);
+        obj[v] = term ? term.toString() : null;
+      }
+      return obj;
+    });
+    console.log(
+      JSON.stringify(
+        ResponseBuilder.success({ kind: "select", rows, count: rows.length }),
+        null,
+        2,
+      ),
+    );
+  } else {
+    console.log(new TableFormatter().format(result.rows));
+  }
+}

--- a/packages/cli/src/program.ts
+++ b/packages/cli/src/program.ts
@@ -6,6 +6,7 @@ import { resolveCommand } from "./commands/resolve.js";
 import { resolveButtonsCommand } from "./commands/resolve-buttons.js";
 import { validateCommand } from "./commands/validate.js";
 import { classesCommand } from "./commands/classes.js";
+import { runQueryCommand } from "./commands/run-query.js";
 import { createCommand } from "./commands/create.js";
 import { workflowCommand } from "./commands/workflow.js";
 import { recoverCommand } from "./commands/recover.js";
@@ -58,6 +59,11 @@ export function createProgram(version?: string): Command {
   // `apply --dry-run`, which is precondition-only).
   program.addCommand(resolveButtonsCommand());
   program.addCommand(classesCommand());
+  // req 2678df55 — read axis: standalone verb to execute a query__NamedQuery
+  // asset by UID (read-only). `classes`/`describe-class` consume the same
+  // mechanism (their introspection SPARQL lives in vault query__NamedQuery
+  // assets).
+  program.addCommand(runQueryCommand());
   program.addCommand(createCommand());
   program.addCommand(workflowCommand());
   // recover — retained: live launchd consumer (com.exocortex.aitask-recover

--- a/packages/cli/src/services/NamedQueryCliRunner.ts
+++ b/packages/cli/src/services/NamedQueryCliRunner.ts
@@ -1,0 +1,23 @@
+import { NamedQueryRunner, type InMemoryTripleStore } from "@kitelev/exocortex-core";
+import { NodeFsAdapter } from "../adapters/NodeFsAdapter.js";
+import { FsQueryBodyResolver } from "./FsQueryBodyResolver.js";
+
+/**
+ * Build a {@link NamedQueryRunner} for CLI use (req 2678df55 — read axis).
+ *
+ * Resolves a `query__NamedQuery` body by UID from the already-hydrated triple
+ * store (`?s exo:Asset_uid "<uid>"`) and reads the file through `NodeFsAdapter`,
+ * exactly as the `apply` path wires it — so `run-query` and the homoiconic
+ * `classes`/`describe-class` share one read-side seam. Execution is read-only
+ * (`evaluateWithExoEval` allowlist rejects UPDATE/SERVICE/FROM/LOAD at parse).
+ */
+export function buildNamedQueryRunner(
+  tripleStore: InMemoryTripleStore,
+  vaultPath: string,
+): NamedQueryRunner {
+  const fsAdapter = new NodeFsAdapter(vaultPath);
+  return new NamedQueryRunner(
+    new FsQueryBodyResolver(tripleStore, fsAdapter),
+    tripleStore,
+  );
+}

--- a/packages/cli/tests/integration/run-query-namedquery.integration.test.ts
+++ b/packages/cli/tests/integration/run-query-namedquery.integration.test.ts
@@ -1,0 +1,388 @@
+/**
+ * req 2678df55 — CLI `run-query <uid>` (read-side NamedQuery verb) + homoiconic
+ * `classes`/`describe-class` (introspection SPARQL read from vault
+ * query__NamedQuery assets, not hardcode).
+ *
+ * Production-shape: a real temp vault (class instances + canonical query assets)
+ * is hydrated through the REAL pipeline —
+ *   FileSystemVaultAdapter → NoteToRDFConverter → InMemoryTripleStore →
+ *   FsQueryBodyResolver → NamedQueryRunner
+ * — and driven through the actual `runQueryCommand()` / `classesCommand()`
+ * commander actions (no stubs). Assertions read captured stdout / the runner's
+ * SELECT rows.
+ *
+ * Revert-verify (documented in the PR body):
+ *  • run-query executes the vault body — a query asset's ```sparql body drives
+ *    the printed result; different bodies → different output.
+ *  • classes reads from vault, NOT hardcode — the canonical class-list asset
+ *    carries a distinctive FILTER that excludes one class; `classes` omits it.
+ *    Reverting `classes` to the old hardcoded (unfiltered) SPARQL makes the
+ *    excluded class reappear → RED. Editing the fixture body flips WHICH class
+ *    is omitted, proving the output is vault-driven.
+ */
+import { jest, describe, it, expect, beforeEach, afterEach } from "@jest/globals";
+import * as fs from "fs";
+import * as path from "path";
+import * as os from "os";
+import {
+  InMemoryTripleStore,
+  NoteToRDFConverter,
+} from "@kitelev/exocortex-core";
+
+const { runQueryCommand } = await import("../../src/commands/run-query.js");
+const { classesCommand } = await import("../../src/commands/classes.js");
+const { buildNamedQueryRunner } = await import(
+  "../../src/services/NamedQueryCliRunner.js"
+);
+const { FileSystemVaultAdapter } = await import(
+  "../../src/adapters/FileSystemVaultAdapter.js"
+);
+
+const REQ = "2678df55-ef74-4b45-a168-90db5e958882";
+
+// Canonical introspection UIDs (must match classes.ts constants).
+const LIST_UID = "b6aa1da9-96b9-4066-99a9-f81cc8b316aa";
+const COUNT_UID = "5ba1031d-2c6e-4528-ab81-fb768d8e061a";
+const PROPS_UID = "efb7bb79-6378-44b0-b1ca-9a27e3eeb684";
+// Test-local NamedQuery assets exercising the other run-query shapes.
+const ASK_UID = "a5000000-0000-4000-8000-0000000000a1";
+const CONSTRUCT_UID = "c5000000-0000-4000-8000-0000000000c1";
+const CURRENT_UID = "ca000000-0000-4000-8000-0000000000a1";
+const WIDGET1_UID = "11111111-0000-4000-8000-000000000001";
+
+const RDF_PREFIX = "PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>";
+
+function instanceMd(uid: string, className: string): string {
+  return [
+    "---",
+    `exo__Asset_uid: ${uid}`,
+    "exo__Instance_class:",
+    `  - "[[${className}]]"`,
+    "---",
+    `# ${uid}`,
+    "",
+  ].join("\n");
+}
+
+/** A query__NamedQuery asset (needs Instance_class to be indexed by convertVault). */
+function queryMd(uid: string, label: string, sparql: string): string {
+  return [
+    "---",
+    `exo__Asset_uid: ${uid}`,
+    `exo__Asset_label: "${label}"`,
+    "exo__Instance_class:",
+    '  - "[[query__NamedQuery]]"',
+    "---",
+    `# ${label}`,
+    "",
+    "```sparql",
+    sparql,
+    "```",
+    "",
+  ].join("\n");
+}
+
+const LIST_SPARQL_EXCLUDE_GADGET = [
+  RDF_PREFIX,
+  "SELECT ?class (COUNT(?instance) AS ?count)",
+  '  WHERE { ?instance rdf:type ?class . FILTER(!CONTAINS(STR(?class), "Gadget")) }',
+  "GROUP BY ?class",
+  "ORDER BY DESC(?count)",
+].join("\n");
+
+const LIST_SPARQL_EXCLUDE_WIDGET = [
+  RDF_PREFIX,
+  "SELECT ?class (COUNT(?instance) AS ?count)",
+  '  WHERE { ?instance rdf:type ?class . FILTER(!CONTAINS(STR(?class), "Widget")) }',
+  "GROUP BY ?class",
+  "ORDER BY DESC(?count)",
+].join("\n");
+
+const COUNT_SPARQL = [
+  RDF_PREFIX,
+  "SELECT (COUNT(?instance) AS ?count)",
+  "  WHERE { ?instance rdf:type ?class . FILTER(CONTAINS(STR(?class), $className)) }",
+].join("\n");
+
+const PROPS_SPARQL = [
+  RDF_PREFIX,
+  "SELECT ?property (COUNT(?value) AS ?usageCount)",
+  "  WHERE { ?instance rdf:type ?class . ?instance ?property ?value .",
+  "          FILTER(CONTAINS(STR(?class), $className)) FILTER(?property != rdf:type) }",
+  "GROUP BY ?property",
+  "ORDER BY DESC(?usageCount)",
+].join("\n");
+
+/** Builds the temp vault. Returns its root; the class-list body is overridable. */
+function buildVault(listSparql: string = LIST_SPARQL_EXCLUDE_GADGET): string {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "exo-runquery-"));
+  const write = (uid: string, md: string) =>
+    fs.writeFileSync(path.join(root, `${uid}.md`), md, "utf-8");
+
+  // Instances: 3 Widget, 1 Gadget, 2 Doohickey.
+  write(WIDGET1_UID, instanceMd(WIDGET1_UID, "test__Widget"));
+  write(
+    "11111111-0000-4000-8000-000000000002",
+    instanceMd("11111111-0000-4000-8000-000000000002", "test__Widget"),
+  );
+  write(
+    "11111111-0000-4000-8000-000000000003",
+    instanceMd("11111111-0000-4000-8000-000000000003", "test__Widget"),
+  );
+  write(
+    "22222222-0000-4000-8000-000000000001",
+    instanceMd("22222222-0000-4000-8000-000000000001", "test__Gadget"),
+  );
+  write(
+    "33333333-0000-4000-8000-000000000001",
+    instanceMd("33333333-0000-4000-8000-000000000001", "test__Doohickey"),
+  );
+  write(
+    "33333333-0000-4000-8000-000000000002",
+    instanceMd("33333333-0000-4000-8000-000000000002", "test__Doohickey"),
+  );
+
+  // Canonical introspection queries (UIDs referenced by classes.ts).
+  write(LIST_UID, queryMd(LIST_UID, "list classes", listSparql));
+  write(COUNT_UID, queryMd(COUNT_UID, "class instance count", COUNT_SPARQL));
+  write(PROPS_UID, queryMd(PROPS_UID, "class properties", PROPS_SPARQL));
+
+  // Extra NamedQuery shapes for run-query coverage.
+  write(ASK_UID, queryMd(ASK_UID, "ask any", "ASK { ?s ?p ?o }"));
+  write(
+    CONSTRUCT_UID,
+    queryMd(
+      CONSTRUCT_UID,
+      "construct types",
+      `${RDF_PREFIX}\nCONSTRUCT { ?s rdf:type ?c } WHERE { ?s rdf:type ?c }`,
+    ),
+  );
+  write(
+    CURRENT_UID,
+    queryMd(
+      CURRENT_UID,
+      "current asset triples",
+      "SELECT ?p ?o WHERE { $currentAsset ?p ?o }",
+    ),
+  );
+
+  return root;
+}
+
+describe("req 2678df55 — run-query + homoiconic classes read-axis", () => {
+  let root: string | undefined;
+  let processExitSpy: jest.SpiedFunction<typeof process.exit>;
+  let consoleLogSpy: jest.SpiedFunction<typeof console.log>;
+  let consoleErrorSpy: jest.SpiedFunction<typeof console.error>;
+
+  beforeEach(() => {
+    processExitSpy = jest
+      .spyOn(process, "exit")
+      .mockImplementation(((code?: number) => {
+        throw new Error(`__process_exit_${code ?? 0}__`);
+      }) as never);
+    consoleLogSpy = jest.spyOn(console, "log").mockImplementation(() => {});
+    consoleErrorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    processExitSpy.mockRestore();
+    consoleLogSpy.mockRestore();
+    consoleErrorSpy.mockRestore();
+    if (root) {
+      fs.rmSync(root, { recursive: true, force: true });
+      root = undefined;
+    }
+  });
+
+  /** Invoke a commander subcommand; return captured stdout+stderr. */
+  async function runCli(
+    cmd: { name(): string; parseAsync(argv: string[]): Promise<unknown> },
+    args: string[],
+  ): Promise<string> {
+    consoleLogSpy.mockClear();
+    consoleErrorSpy.mockClear();
+    try {
+      await cmd.parseAsync(["node", cmd.name(), ...args]);
+    } catch (err) {
+      if (!/^__process_exit_/.test(String((err as Error)?.message))) throw err;
+    }
+    const logs = consoleLogSpy.mock.calls.map((c) => c.map(String).join(" "));
+    const errs = consoleErrorSpy.mock.calls.map((c) => c.map(String).join(" "));
+    return [...logs, ...errs].join("\n");
+  }
+
+  async function buildRunner(vaultRoot: string) {
+    const converter = new NoteToRDFConverter(
+      new FileSystemVaultAdapter(vaultRoot),
+    );
+    const store = new InMemoryTripleStore();
+    await store.addAll(await converter.convertVault());
+    return buildNamedQueryRunner(store, vaultRoot);
+  }
+
+  describe("run-query <uid>", () => {
+    it(`@req:${REQ} executes a query__NamedQuery SELECT body and prints a table`, async () => {
+      root = buildVault();
+      const out = await runCli(runQueryCommand(), [LIST_UID, "--vault", root]);
+      // The vault body (excludes Gadget) drives the printed result.
+      expect(out).toContain("?class");
+      expect(out).toContain("test#Widget");
+      expect(out).toContain("test#Doohickey");
+      expect(out).not.toContain("test#Gadget");
+    });
+
+    it(`@req:${REQ} emits a JSON envelope for --format json`, async () => {
+      root = buildVault();
+      const out = await runCli(runQueryCommand(), [
+        LIST_UID,
+        "--vault",
+        root,
+        "--format",
+        "json",
+      ]);
+      const parsed = JSON.parse(out);
+      expect(parsed.success).toBe(true);
+      expect(parsed.data.kind).toBe("select");
+      const classes = parsed.data.rows.map((r: { class: string }) => r.class);
+      expect(classes.some((c: string) => c.includes("test#Widget"))).toBe(true);
+      expect(classes.some((c: string) => c.includes("test#Gadget"))).toBe(false);
+    });
+
+    it(`@req:${REQ} prints an ASK result as a boolean`, async () => {
+      root = buildVault();
+      const out = await runCli(runQueryCommand(), [ASK_UID, "--vault", root]);
+      expect(out).toContain("true");
+    });
+
+    it(`@req:${REQ} substitutes a literal --param into the query body`, async () => {
+      root = buildVault();
+      const out = await runCli(runQueryCommand(), [
+        COUNT_UID,
+        "--param",
+        "className=Widget",
+        "--vault",
+        root,
+        "--format",
+        "json",
+      ]);
+      const parsed = JSON.parse(out);
+      // 3 Widget instances matched $className="Widget".
+      expect(parsed.data.rows[0].count).toContain('"3"');
+    });
+
+    it(`@req:${REQ} injects --current-asset as $currentAsset`, async () => {
+      root = buildVault();
+      const out = await runCli(runQueryCommand(), [
+        CURRENT_UID,
+        "--current-asset",
+        `${WIDGET1_UID}.md`,
+        "--vault",
+        root,
+        "--format",
+        "json",
+      ]);
+      const parsed = JSON.parse(out);
+      // widget1's own triples (its Instance_class points at test#Widget).
+      const objects = parsed.data.rows.map((r: { o: string }) => r.o).join(" ");
+      expect(objects).toContain("test#Widget");
+    });
+
+    it(`@req:${REQ} renders a CONSTRUCT result`, async () => {
+      root = buildVault();
+      const out = await runCli(runQueryCommand(), [
+        CONSTRUCT_UID,
+        "--vault",
+        root,
+      ]);
+      expect(out).toContain("CONSTRUCT");
+      expect(out).toContain("triple");
+    });
+
+    it(`@req:${REQ} fails closed on an unresolvable UID`, async () => {
+      root = buildVault();
+      const out = await runCli(runQueryCommand(), [
+        "00000000-0000-4000-8000-000000000000",
+        "--vault",
+        root,
+      ]);
+      expect(out).toContain("No resolvable query__NamedQuery");
+      expect(out).toContain("00000000-0000-4000-8000-000000000000");
+      expect(processExitSpy).toHaveBeenCalled();
+    });
+  });
+
+  describe("classes/describe-class read SPARQL from vault", () => {
+    it(`@req:${REQ} classes executes the vault class-list query (revert-verify: FILTER excludes Gadget)`, async () => {
+      root = buildVault(LIST_SPARQL_EXCLUDE_GADGET);
+      const out = await runCli(classesCommand(), ["--vault", root]);
+      // Vault body excludes Gadget → the local names reflect the vault query,
+      // not a hardcoded (unfiltered) list. A revert to hardcode makes Gadget
+      // reappear here (→ RED).
+      expect(out).toContain("Widget");
+      expect(out).toContain("Doohickey");
+      expect(out).not.toContain("Gadget");
+    });
+
+    it(`@req:${REQ} editing the vault SPARQL body changes classes output (body-driven)`, async () => {
+      // Same command, DIFFERENT vault body: now excludes Widget instead.
+      root = buildVault(LIST_SPARQL_EXCLUDE_WIDGET);
+      const out = await runCli(classesCommand(), ["--vault", root]);
+      expect(out).toContain("Gadget");
+      expect(out).toContain("Doohickey");
+      expect(out).not.toContain("Widget");
+    });
+
+    it(`@req:${REQ} describe-class runs the vault count+props queries parametrized by $className`, async () => {
+      root = buildVault();
+      const out = await runCli(classesCommand(), ["Widget", "--vault", root]);
+      expect(out).toContain("Class: Widget");
+      // Widget instances carry these predicates (from the props NamedQuery).
+      expect(out).toContain("Asset_uid");
+      expect(out).toContain("Instance_class");
+    });
+
+    it(`@req:${REQ} classes --format json emits a structured class list`, async () => {
+      root = buildVault();
+      // `--output json` selects JSON *and* suppresses the text loading preamble
+      // (the `📦 Loading…` line is gated on the text output format), so stdout is
+      // pure JSON.
+      const out = await runCli(classesCommand(), [
+        "--vault",
+        root,
+        "--output",
+        "json",
+      ]);
+      const parsed = JSON.parse(out);
+      expect(parsed.success).toBe(true);
+      const names = parsed.data.classes.map((c: { name: string }) => c.name);
+      expect(names).toContain("Widget");
+      expect(names).not.toContain("Gadget");
+    });
+  });
+
+  describe("read-side runner (production-shape)", () => {
+    it(`@req:${REQ} NamedQueryRunner.run executes the vault body over the real store`, async () => {
+      root = buildVault();
+      const runner = await buildRunner(root);
+      const result = await runner.run(LIST_UID);
+      expect(result).not.toBeNull();
+      expect(result!.kind).toBe("select");
+      if (result!.kind !== "select") throw new Error("expected select");
+      const classIris = result!.rows
+        .map((r) => r.get("class")?.toString() ?? "")
+        .join(" ");
+      expect(classIris).toContain("test#Widget");
+      expect(classIris).not.toContain("test#Gadget");
+    });
+
+    it(`@req:${REQ} run() returns null for an unknown UID (fail-closed data path)`, async () => {
+      root = buildVault();
+      const runner = await buildRunner(root);
+      const result = await runner.run(
+        "00000000-0000-4000-8000-000000000000",
+      );
+      expect(result).toBeNull();
+    });
+  });
+});

--- a/packages/cli/tests/unit/commands/classes.test.ts
+++ b/packages/cli/tests/unit/commands/classes.test.ts
@@ -60,6 +60,16 @@ jest.unstable_mockModule("../../../src/cache/CacheManager.js", () => ({
   })),
 }));
 
+// req 2678df55 — classes now reads its introspection SPARQL through the
+// NamedQueryRunner (built by this factory). Mock the seam so the unit test
+// (command structure + vault-not-found) doesn't pull the real
+// FsQueryBodyResolver / NodeFsAdapter core chain.
+jest.unstable_mockModule("../../../src/services/NamedQueryCliRunner.js", () => ({
+  buildNamedQueryRunner: jest.fn(() => ({
+    run: jest.fn().mockResolvedValue({ kind: "select", rows: [] }),
+  })),
+}));
+
 // Import the classes command after mocking
 const { classesCommand } = await import("../../../src/commands/classes.js");
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -113,6 +113,7 @@ export {
   type NamedQueryParam,
   type NamedQueryScalar,
 } from "./services/NamedQueryRunner";
+export type { ExoQLEvalResult } from "./exoql/evaluateWithExoEval";
 export { iriToObsidianName } from "./utilities/iriToObsidianName";
 export { extractSparqlBlock, stripFrontmatter } from "./utilities/sparqlBlock";
 export {

--- a/packages/core/src/infrastructure/sparql/executors/AggregateExecutor.ts
+++ b/packages/core/src/infrastructure/sparql/executors/AggregateExecutor.ts
@@ -1,5 +1,12 @@
 import type { GroupOperation, AggregateExpression, Expression, CustomAggregation, StandardAggregation } from "../algebra/AlgebraOperation";
-import type { SolutionMapping } from "../SolutionMapping";
+// Value import (not `import type`): the class is instantiated below. Previously a
+// lazy `require("../SolutionMapping")` fetched the runtime class — a workaround
+// (Issue #534) that is now vestigial: `SolutionMapping` imports only rdf domain
+// models, so there is no cycle back here. `require` is `undefined` under ESM
+// (the CLI package's jest runs `--experimental-vm-modules`), which broke any
+// aggregate query executed from a CLI test; the top-level import fixes that
+// while staying behavior-preserving in the bundled CJS build.
+import { SolutionMapping } from "../SolutionMapping";
 import { Literal } from "../../../domain/models/rdf/Literal";
 import { IRI } from "../../../domain/models/rdf/IRI";
 import { FilterExecutor } from "./FilterExecutor";
@@ -62,10 +69,12 @@ export class AggregateExecutor {
       // 1. Variables from GROUP BY clause
       // 2. Variables bound to aggregate expressions
       // This fixes Issue #534 Blocker 1: aggregate functions returning extra variables
-      const { SolutionMapping: SM } = require("../SolutionMapping");
-      const result = new SM();
+      const result = new SolutionMapping();
       for (const [key, value] of resultBindings.entries()) {
-        result.set(key, value);
+        // `resultBindings` is `Map<string, unknown>`; the lazy `require`
+        // previously typed the class as `any`, silently accepting these values.
+        // Runtime behaviour is unchanged — cast to the set() param type.
+        result.set(key, value as Parameters<typeof result.set>[1]);
       }
       results.push(result);
     }
@@ -400,8 +409,7 @@ export class AggregateExecutor {
   }
 
   private createEmptyAggregateResult(operation: GroupOperation): SolutionMapping | null {
-    const { SolutionMapping: SM } = require("../SolutionMapping");
-    const result = new SM();
+    const result = new SolutionMapping();
 
     for (const aggregate of operation.aggregates) {
       const agg = aggregate.expression.aggregation;


### PR DESCRIPTION
## Summary

Homoiconize the CLI read-command `classes` via a new standalone read-side verb `run-query <uid>` (req `2678df55`, RFC 78c2b7d0 C4 read axis). First CLI consumer of the read axis: **write → `exocmd__Command`** (`apply`), **read → `query__NamedQuery`** (`NamedQueryRunner`).

### `run-query <uid>` (new)
- Resolves a `query__NamedQuery` asset by UID (via `FsQueryBodyResolver` over the hydrated store), executes its ` ```sparql ` body read-only through `NamedQueryRunner`, prints the result: SELECT → table / `--format json`; ASK → boolean; CONSTRUCT → triples.
- Context-free by default; `--current-asset <path>` (`$currentAsset`), repeatable `--param name=value` (literal) / `--param-iri name=path` (iri).
- Fail-closed with a clear error on an unresolvable UID. Closes the gap that NamedQueries were reachable only from inside preconditions/groundings.

### `classes` / `describe-class` (homoiconized)
- Introspection SPARQL now lives in **canonical `query__NamedQuery` vault assets** (`kitelev/exoas-public` → `exoql/`): `b6aa1da9` (class list + counts), `5ba1031d` (per-class count, `$className`), `efb7bb79` (per-class properties, `$className`).
- `classes` resolves + executes them through the same runner; the ASCII-table formatter (`extractLocalName` truncation) **stays in code**; **output byte-preserved** — including the pre-existing `NaN`-count display (identical on origin/main; `parseInt` on a typed-literal `"3093"^^xsd:integer`). Andrey chose to preserve it and file a separate bug-fix.

### Enabling core fix
`AggregateExecutor` used a vestigial lazy `require("../SolutionMapping")` (no cycle — `SolutionMapping` imports only rdf models) that is `undefined` under the CLI package's ESM jest, breaking any aggregate query run from a CLI test. Converted to the top-level import (behavior-preserving). Core aggregate suites 229/229 + full SPARQL sweep 3098/3098 green.

## Verification (production-shape, `@req:2678df55-...`)
`packages/cli/tests/integration/run-query-namedquery.integration.test.ts` (13 tests) — real temp vault → `FileSystemVaultAdapter → NoteToRDFConverter → InMemoryTripleStore → FsQueryBodyResolver → NamedQueryRunner`, driven through the actual `runQueryCommand()` / `classesCommand()`.

**Revert-verified:**
1. Swapping `classes.ts` for the origin/main hardcoded SPARQL → **3 classes tests RED** (the FILTER-excluded class reappears); restore → GREEN.
2. Flipping the fixture ASK NamedQuery body to always-false → the `run-query` ASK test **RED**; restore → GREEN.

Local gates: `check:types` 0 · full CLI suite (CI=true) 1795 passed / 0 failed · CLI coverage thresholds met (new files: run-query 89%/NamedQueryCliRunner 100%/classes 82%) · lint guards (shard/antipattern/monotonic) pass.

## Vault assets
3 `query__NamedQuery` assets pushed to `kitelev/exoas-public` (`exoql/`, commit `f524cc8`), SHACL 0 violations, co-located by `isDefinedBy=$exoql`.

Req: 2678df55-ef74-4b45-a168-90db5e958882
