### PR TITLE
test(forget-guard): traverse precondition composites + bump exoas-exocmd (@req:5579ffa1)

### DIFF
--- a/packages/core/tests/integration/dynamic-commands/PrototypePreconditionForgetGuard.test.ts
+++ b/packages/core/tests/integration/dynamic-commands/PrototypePreconditionForgetGuard.test.ts
@@ -153,9 +153,37 @@ const NOT_PRECONDITION_FIELD = "exocmd__NotPrecondition_precondition";
 const IS_PROTOTYPE_STRENDS_RE =
   /Instance_class[\s\S]*?STRENDS\s*\(\s*STR\s*\(\s*\?\w+\s*\)\s*,\s*["']Prototype["']\s*\)/i;
 
-/** True iff the ask is the positive "target IS a prototype" check (no NOT EXISTS wrapper). */
+/**
+ * True iff the ask is the positive "target IS a prototype" check (STRENDS suffix,
+ * no `NOT EXISTS` wrapper, no `UNION` branch that could admit a non-prototype).
+ * NOTE (deferred hardening): this is a shape heuristic, not identity — a *narrowed*
+ * positive check (`… STRENDS "Prototype" … FILTER(?extra)`) whose child is a strict
+ * subset of prototypes would still classify here, and `¬child` would then NOT
+ * guarantee not-a-prototype. Unreachable in current data (the only composable form
+ * is `NotPrecondition(011eb4d6 pure IsPrototype)`); a fully sound alternative is
+ * UID-identity to the canonical atomics — tracked as a follow-up.
+ */
 function askIsPositivePrototypeCheck(ask: string): boolean {
-  return IS_PROTOTYPE_STRENDS_RE.test(ask) && !/NOT\s+EXISTS/i.test(ask);
+  return (
+    IS_PROTOTYPE_STRENDS_RE.test(ask) &&
+    !/NOT\s+EXISTS/i.test(ask) &&
+    !/\bUNION\b/i.test(ask)
+  );
+}
+
+/**
+ * True iff a flat ask ENFORCES not-a-prototype: it carries the canonical
+ * `FILTER NOT EXISTS { … STRENDS "Prototype" … }` clause AND is not defeated by a
+ * sibling `UNION` branch a prototype could satisfy.
+ */
+function askEnforcesNotPrototypeFlat(ask: string): boolean {
+  return NOT_A_PROTOTYPE_CLAUSE_RE.test(ask) && !/\bUNION\b/i.test(ask);
+}
+
+/** wikilinkUid of a field that may be authored as a scalar OR a single-element list. */
+function firstWikilinkUid(v: string | string[] | undefined): string | null {
+  if (Array.isArray(v)) return v.length > 0 ? wikilinkUid(v[0]) : null;
+  return wikilinkUid(v);
 }
 
 /** Read a precondition's flat sparqlAsk (multi-line block scalar or inline), or null. */
@@ -198,13 +226,11 @@ function enforcesNotPrototype(
   const pre = resolve(uid);
   if (!pre) return false;
   const ask = sparqlAskOf(pre);
-  if (ask && NOT_A_PROTOTYPE_CLAUSE_RE.test(ask)) return true;
+  if (ask && askEnforcesNotPrototypeFlat(ask)) return true;
   const seen2 = new Set(seen).add(uid);
   // NotPrecondition(child): ¬child enforces not-a-prototype iff child is TRUE on
   // all prototypes — i.e. child is the positive "is a prototype" check.
-  const notChildUid = wikilinkUid(
-    pre.fm[NOT_PRECONDITION_FIELD] as string | undefined,
-  );
+  const notChildUid = firstWikilinkUid(pre.fm[NOT_PRECONDITION_FIELD]);
   if (notChildUid) {
     const wrapped = resolve(notChildUid);
     const wAsk = wrapped ? sparqlAskOf(wrapped) : null;
@@ -251,9 +277,7 @@ describe("prototype precondition — forget-leak guard (exoas-exocmd submodule) 
   function commandEnforcesNotPrototype(cmdUid: string): boolean {
     const cmd = byUid.get(cmdUid);
     if (!cmd) return false;
-    const preUid = wikilinkUid(
-      cmd.fm["exocmd__Command_precondition"] as string | undefined,
-    );
+    const preUid = firstWikilinkUid(cmd.fm["exocmd__Command_precondition"]);
     if (!preUid) return false;
     return enforcesNotPrototype(preUid, resolve);
   }
@@ -430,5 +454,27 @@ describe("enforcesNotPrototype — AND/OR composite detection semantics", () => 
       leaf(B, PLAIN), // Not-archived
     ];
     expect(enforcesNotPrototype(ROOT, resolveOf(assets))).toBe(true);
+  });
+
+  // Hardening (LOW#1): a clause defeated by a sibling UNION branch a prototype
+  // could satisfy must NOT read as enforcing.
+  const CLAUSE_UNION =
+    'ASK { { FILTER NOT EXISTS { $target exo:Instance_class ?p . FILTER(STRENDS(STR(?p), "Prototype")) } } UNION { $target exo:Instance_class ?anything } }';
+  const IS_PROTO_UNION =
+    'ASK { { $target exo:Instance_class ?p . FILTER(STRENDS(STR(?p), "Prototype")) } UNION { $target exo:Instance_class ?q } }';
+
+  it("flat clause defeated by a sibling UNION → NOT enforced", () => {
+    expect(enforcesNotPrototype(A, resolveOf([leaf(A, CLAUSE_UNION)]))).toBe(
+      false,
+    );
+  });
+
+  it("NotPrecondition(IsPrototype-with-UNION) → NOT enforced (¬child not guaranteed on prototypes)", () => {
+    const NOT = "aaaaaaaa-0000-4000-8000-0000000000c0";
+    const assets = [
+      notWrap(NOT, A),
+      leaf(A, IS_PROTO_UNION),
+    ];
+    expect(enforcesNotPrototype(NOT, resolveOf(assets))).toBe(false);
   });
 });

--- a/packages/core/tests/integration/dynamic-commands/PrototypePreconditionForgetGuard.test.ts
+++ b/packages/core/tests/integration/dynamic-commands/PrototypePreconditionForgetGuard.test.ts
@@ -6,13 +6,22 @@
  * asserts that EVERY instance-lifecycle command (bindings target
  * ems__Task/Project/Area/Meeting/Session — NOT exo__Asset, NOT a prototype
  * class, NOT a class metaclass) carries a command-level
- * `exocmd__Command_precondition` whose precondition asset's
- * `exocmd__Precondition_sparqlAsk` contains the canonical not-a-prototype clause
+ * `exocmd__Command_precondition` whose precondition tree ENFORCES the canonical
+ * not-a-prototype clause
  * (`FILTER NOT EXISTS { … exo:Instance_class … STRENDS(…, "Prototype") … }`).
  *
+ * The clause may live on the direct precondition's flat `exocmd__Precondition_sparqlAsk`
+ * OR nested inside a `exocmd__AllPrecondition_preconditions` / `exocmd__AnyPrecondition_preconditions`
+ * composite (the preconditions were restructured flat → nested composites on
+ * 2026-07-07, reqs 127763f8 / f6c2b98c). `enforcesNotPrototype` walks the tree
+ * with AND/OR semantics — an AND-conjunct carrying the clause hides the command on
+ * prototypes; an OR needs the clause in EVERY branch. A flat-only read returns null
+ * on a composite → both a false failure AND blindness to a genuine forget-leak.
+ *
  * If a future lifecycle command (or a binding retargeted onto a lifecycle class)
- * ships without the clause, this fails — the silent-leak the precondition-primary
- * design is otherwise vulnerable to (design node f853eadd, §forget-leak guard).
+ * ships without the clause anywhere in its precondition tree, this fails — the
+ * silent-leak the precondition-primary design is otherwise vulnerable to
+ * (design node f853eadd, §forget-leak guard).
  *
  * Conversely, asserts universal-maintenance commands (targetClass exo__Asset) do
  * NOT carry the clause (they must keep working on prototype-template assets).
@@ -122,6 +131,102 @@ function instanceClassUids(fm: Record<string, string | string[]>): string[] {
   return refs.map(wikilinkUid).filter((u): u is string => u !== null);
 }
 
+// ---------------------------------------------------------------------------
+// Composite-aware not-a-prototype enforcement.
+// The preconditions were restructured flat → nested AllPrecondition /
+// AnyPrecondition composites on 2026-07-07 (reqs 127763f8 / f6c2b98c). The
+// canonical clause now lives on a LEAF of the transitive precondition tree, not
+// necessarily on the direct command precondition. A flat `sparqlAsk` read returns
+// null on a composite → a false failure AND blindness to a genuine forget-leak.
+// These pure helpers walk the tree with AND/OR semantics; `resolve` maps a UID to
+// its asset (real `byUid` in the data tests, a synthetic map in the unit tests).
+// ---------------------------------------------------------------------------
+
+const ALL_PRECONDITION_FIELD = "exocmd__AllPrecondition_preconditions";
+const ANY_PRECONDITION_FIELD = "exocmd__AnyPrecondition_preconditions";
+const NOT_PRECONDITION_FIELD = "exocmd__NotPrecondition_precondition";
+
+// Positive "is a prototype" check — the STRENDS suffix on the instance_class IRI
+// WITHOUT the `FILTER NOT EXISTS` wrapper (the extracted atomic `Is prototype`,
+// 011eb4d6, that `NotPrecondition` composites negate). Used to recognise the
+// composable not-a-prototype form `NotPrecondition(IsPrototype)`.
+const IS_PROTOTYPE_STRENDS_RE =
+  /Instance_class[\s\S]*?STRENDS\s*\(\s*STR\s*\(\s*\?\w+\s*\)\s*,\s*["']Prototype["']\s*\)/i;
+
+/** True iff the ask is the positive "target IS a prototype" check (no NOT EXISTS wrapper). */
+function askIsPositivePrototypeCheck(ask: string): boolean {
+  return IS_PROTOTYPE_STRENDS_RE.test(ask) && !/NOT\s+EXISTS/i.test(ask);
+}
+
+/** Read a precondition's flat sparqlAsk (multi-line block scalar or inline), or null. */
+function sparqlAskOf(pre: Asset): string | null {
+  const m = pre.raw.match(
+    /exocmd__Precondition_sparqlAsk:\s*[>|][-]?\n((?:  .*\n?)+)/,
+  );
+  if (m) return m[1];
+  const v = pre.fm["exocmd__Precondition_sparqlAsk"];
+  return typeof v === "string" ? v : null;
+}
+
+/** Child precondition UIDs referenced by a composite field. */
+function compositeChildren(pre: Asset, field: string): string[] {
+  const raw = pre.fm[field];
+  const list = Array.isArray(raw) ? raw : typeof raw === "string" ? [raw] : [];
+  return list
+    .map((v) => wikilinkUid(v))
+    .filter((u): u is string => u !== null);
+}
+
+/**
+ * True iff the precondition rooted at `uid` ENFORCES the not-a-prototype clause,
+ * respecting composite semantics:
+ *   - leaf: its sparqlAsk matches the canonical clause;
+ *   - AllPrecondition (AND): at least ONE child enforces it (an AND-conjunct
+ *     carrying the clause hides the command on prototypes);
+ *   - AnyPrecondition (OR): ALL children enforce it (a single clause-less
+ *     OR-branch would let the command render on a prototype);
+ *   - NotPrecondition (¬child): enforces iff `child` is the positive "is a
+ *     prototype" check (`NotPrecondition(IsPrototype)` is the composable
+ *     not-a-prototype form, 5b49ef19 → 011eb4d6, RFC df602adc Phase 6).
+ */
+function enforcesNotPrototype(
+  uid: string,
+  resolve: (u: string) => Asset | undefined,
+  seen: ReadonlySet<string> = new Set(),
+): boolean {
+  if (seen.has(uid)) return false; // cycle-guard
+  const pre = resolve(uid);
+  if (!pre) return false;
+  const ask = sparqlAskOf(pre);
+  if (ask && NOT_A_PROTOTYPE_CLAUSE_RE.test(ask)) return true;
+  const seen2 = new Set(seen).add(uid);
+  // NotPrecondition(child): ¬child enforces not-a-prototype iff child is TRUE on
+  // all prototypes — i.e. child is the positive "is a prototype" check.
+  const notChildUid = wikilinkUid(
+    pre.fm[NOT_PRECONDITION_FIELD] as string | undefined,
+  );
+  if (notChildUid) {
+    const wrapped = resolve(notChildUid);
+    const wAsk = wrapped ? sparqlAskOf(wrapped) : null;
+    if (wAsk && askIsPositivePrototypeCheck(wAsk)) return true;
+  }
+  const andKids = compositeChildren(pre, ALL_PRECONDITION_FIELD);
+  if (
+    andKids.length > 0 &&
+    andKids.some((k) => enforcesNotPrototype(k, resolve, seen2))
+  ) {
+    return true;
+  }
+  const orKids = compositeChildren(pre, ANY_PRECONDITION_FIELD);
+  if (
+    orKids.length > 0 &&
+    orKids.every((k) => enforcesNotPrototype(k, resolve, seen2))
+  ) {
+    return true;
+  }
+  return false;
+}
+
 describe("prototype precondition — forget-leak guard (exoas-exocmd submodule) (@req:5579ffa1-a829-4fcf-b93d-4fb664b02d62)", () => {
   const assets = loadAssets();
   const byUid = new Map(assets.map((a) => [a.uid, a]));
@@ -137,17 +242,20 @@ describe("prototype precondition — forget-leak guard (exoas-exocmd submodule) 
     commandTargets.get(cmdUid)!.add(tc);
   }
 
-  /** Resolve a command's command-level precondition sparqlAsk (or null). */
-  function commandPreconditionAsk(cmdUid: string): string | null {
+  const resolve = (u: string): Asset | undefined => byUid.get(u);
+
+  /**
+   * True iff the command's precondition tree enforces the not-a-prototype clause
+   * (flat sparqlAsk OR nested in an AllPrecondition/AnyPrecondition composite).
+   */
+  function commandEnforcesNotPrototype(cmdUid: string): boolean {
     const cmd = byUid.get(cmdUid);
-    if (!cmd) return null;
-    const preUid = wikilinkUid(cmd.fm["exocmd__Command_precondition"] as string | undefined);
-    if (!preUid) return null;
-    const pre = byUid.get(preUid);
-    if (!pre) return null;
-    // sparqlAsk is a multi-line YAML scalar — read from the raw file.
-    const m = pre.raw.match(/exocmd__Precondition_sparqlAsk:\s*[>|][-]?\n((?:  .*\n?)+)/);
-    return m ? m[1] : (typeof pre.fm["exocmd__Precondition_sparqlAsk"] === "string" ? (pre.fm["exocmd__Precondition_sparqlAsk"] as string) : null);
+    if (!cmd) return false;
+    const preUid = wikilinkUid(
+      cmd.fm["exocmd__Command_precondition"] as string | undefined,
+    );
+    if (!preUid) return false;
+    return enforcesNotPrototype(preUid, resolve);
   }
 
   const lifecycleCommands = [...commandTargets.entries()].filter(
@@ -170,11 +278,9 @@ describe("prototype precondition — forget-leak guard (exoas-exocmd submodule) 
       )
       .map((u) => [u, byUid.get(u)?.label ?? "?"] as [string, string]),
   )(
-    "lifecycle command %s (%s) carries the not-a-prototype clause",
+    "lifecycle command %s (%s) enforces the not-a-prototype clause (flat or nested in a composite)",
     (cmdUid) => {
-      const ask = commandPreconditionAsk(cmdUid);
-      expect(ask).toBeTruthy();
-      expect(ask!).toMatch(NOT_A_PROTOTYPE_CLAUSE_RE);
+      expect(commandEnforcesNotPrototype(cmdUid)).toBe(true);
     },
   );
 
@@ -184,14 +290,145 @@ describe("prototype precondition — forget-leak guard (exoas-exocmd submodule) 
     expect(pre!.raw).toMatch(NOT_A_PROTOTYPE_CLAUSE_RE);
   });
 
-  it("universal-maintenance commands (targetClass exo__Asset) do NOT carry the clause", () => {
+  it("universal-maintenance commands (targetClass exo__Asset) do NOT enforce the clause", () => {
     const universal = [...commandTargets.entries()].filter(
       ([, tcs]) => [...tcs].every((t) => UNIVERSAL_TARGET_CLASSES.has(t)),
     );
     expect(universal.length).toBeGreaterThanOrEqual(1);
     for (const [cmdUid] of universal) {
-      const ask = commandPreconditionAsk(cmdUid);
-      if (ask) expect(ask).not.toMatch(NOT_A_PROTOTYPE_CLAUSE_RE);
+      expect(commandEnforcesNotPrototype(cmdUid)).toBe(false);
     }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Detection-power unit tests for `enforcesNotPrototype` (synthetic map — no
+// submodule). These are the revert-verify: they prove the composite-aware
+// predicate returns FALSE when the clause is absent (a genuine forget-leak is
+// still caught) and TRUE only when the clause is actually enforced, across
+// leaf / AND / OR shapes. Without them, "traverse composites" could degrade into
+// "clause appears anywhere" and silently lose the OR-branch detection.
+// ---------------------------------------------------------------------------
+describe("enforcesNotPrototype — AND/OR composite detection semantics", () => {
+  const CLAUSE =
+    'PREFIX exo: <https://exocortex.my/ontology/exo#> ASK { FILTER NOT EXISTS { $target exo:Instance_class ?p . FILTER(STRENDS(STR(?p), "Prototype")) } }';
+  const PLAIN =
+    "PREFIX exo: <https://exocortex.my/ontology/exo#> ASK { $target exo:Instance_class ?c . FILTER(?c != <x>) }";
+
+  const leaf = (uid: string, ask: string): Asset => ({
+    uid,
+    label: uid,
+    file: "",
+    fm: { exocmd__Precondition_sparqlAsk: ask },
+    raw: "",
+  });
+  const composite = (uid: string, field: string, kids: string[]): Asset => ({
+    uid,
+    label: uid,
+    file: "",
+    fm: { [field]: kids.map((k) => `[[${k}]]`) },
+    raw: "",
+  });
+  const resolveOf =
+    (assets: Asset[]) =>
+    (u: string): Asset | undefined =>
+      assets.find((a) => a.uid === u);
+
+  const A = "aaaaaaaa-0000-4000-8000-000000000001";
+  const B = "aaaaaaaa-0000-4000-8000-000000000002";
+  const ROOT = "aaaaaaaa-0000-4000-8000-0000000000ff";
+
+  it("leaf WITH clause → enforced", () => {
+    expect(enforcesNotPrototype(A, resolveOf([leaf(A, CLAUSE)]))).toBe(true);
+  });
+
+  it("leaf WITHOUT clause → NOT enforced (leak detected)", () => {
+    expect(enforcesNotPrototype(A, resolveOf([leaf(A, PLAIN)]))).toBe(false);
+  });
+
+  it("AllPrecondition (AND): one clause-bearing conjunct → enforced", () => {
+    const assets = [
+      composite(ROOT, ALL_PRECONDITION_FIELD, [A, B]),
+      leaf(A, PLAIN),
+      leaf(B, CLAUSE),
+    ];
+    expect(enforcesNotPrototype(ROOT, resolveOf(assets))).toBe(true);
+  });
+
+  it("AllPrecondition (AND): NO conjunct has the clause → NOT enforced (forget-leak detected)", () => {
+    const assets = [
+      composite(ROOT, ALL_PRECONDITION_FIELD, [A, B]),
+      leaf(A, PLAIN),
+      leaf(B, PLAIN),
+    ];
+    expect(enforcesNotPrototype(ROOT, resolveOf(assets))).toBe(false);
+  });
+
+  it("AnyPrecondition (OR): only one branch has the clause → NOT enforced (weakening detected)", () => {
+    const assets = [
+      composite(ROOT, ANY_PRECONDITION_FIELD, [A, B]),
+      leaf(A, CLAUSE),
+      leaf(B, PLAIN),
+    ];
+    expect(enforcesNotPrototype(ROOT, resolveOf(assets))).toBe(false);
+  });
+
+  it("AnyPrecondition (OR): every branch has the clause → enforced", () => {
+    const assets = [
+      composite(ROOT, ANY_PRECONDITION_FIELD, [A, B]),
+      leaf(A, CLAUSE),
+      leaf(B, CLAUSE),
+    ];
+    expect(enforcesNotPrototype(ROOT, resolveOf(assets))).toBe(true);
+  });
+
+  it("nested AND-under-OR mirroring the real Convert-to-Project shape → enforced", () => {
+    // OR[ AND[leaf-with-clause, plain], plain ] — enforced iff every OR-branch enforces.
+    const AND = "aaaaaaaa-0000-4000-8000-0000000000a0";
+    const assets = [
+      composite(ROOT, ALL_PRECONDITION_FIELD, [AND]),
+      composite(AND, ALL_PRECONDITION_FIELD, [A, B]),
+      leaf(A, CLAUSE),
+      leaf(B, PLAIN),
+    ];
+    expect(enforcesNotPrototype(ROOT, resolveOf(assets))).toBe(true);
+  });
+
+  it("missing (dangling) child precondition → NOT enforced", () => {
+    const assets = [composite(ROOT, ALL_PRECONDITION_FIELD, [A])]; // A not resolvable
+    expect(enforcesNotPrototype(ROOT, resolveOf(assets))).toBe(false);
+  });
+
+  // NotPrecondition(IsPrototype) — the composable not-a-prototype form (5b49ef19 → 011eb4d6).
+  const IS_PROTO =
+    'ASK { $target <https://exocortex.my/ontology/exo#Instance_class> ?p . FILTER(STRENDS(STR(?p), "Prototype")) }';
+  const notWrap = (uid: string, child: string): Asset => ({
+    uid,
+    label: uid,
+    file: "",
+    fm: { [NOT_PRECONDITION_FIELD]: `[[${child}]]` },
+    raw: "",
+  });
+
+  it("NotPrecondition(IsPrototype positive check) → enforced", () => {
+    const assets = [notWrap(ROOT, A), leaf(A, IS_PROTO)];
+    expect(enforcesNotPrototype(ROOT, resolveOf(assets))).toBe(true);
+  });
+
+  it("NotPrecondition(non-prototype leaf) → NOT enforced (¬X of a non-proto check does not guarantee not-a-prototype)", () => {
+    const assets = [notWrap(ROOT, A), leaf(A, PLAIN)];
+    expect(enforcesNotPrototype(ROOT, resolveOf(assets))).toBe(false);
+  });
+
+  it("AllPrecondition[…, NotPrecondition(IsPrototype), …] mirroring Vote-on-Effort → enforced", () => {
+    const NOT = "aaaaaaaa-0000-4000-8000-0000000000b0";
+    const assets = [
+      composite(ROOT, ALL_PRECONDITION_FIELD, [A, NOT, B]),
+      leaf(A, PLAIN), // Visible-until-terminal
+      notWrap(NOT, "aaaaaaaa-0000-4000-8000-0000000000b1"),
+      leaf("aaaaaaaa-0000-4000-8000-0000000000b1", IS_PROTO),
+      leaf(B, PLAIN), // Not-archived
+    ];
+    expect(enforcesNotPrototype(ROOT, resolveOf(assets))).toBe(true);
   });
 });


### PR DESCRIPTION
## Problem

`PrototypePreconditionForgetGuard.test.ts` (@req:5579ffa1) walks the real `packages/exoas-exocmd` submodule and asserts every instance-lifecycle command carries the canonical **not-a-prototype clause**. It read the clause only from the command's **direct** precondition's flat `exocmd__Precondition_sparqlAsk`.

On **2026-07-07** the exoas-exocmd preconditions were restructured **flat → nested composites** (reqs `127763f8` utility-status-gate, `f6c2b98c`): the clause now lives on a **leaf** of the transitive precondition tree (`AllPrecondition` / `AnyPrecondition` / `NotPrecondition`), not on the direct precondition. The exocortex submodule was still pinned at `532a86a` (pre-restructure), so CI stayed green against stale data — but bumping to current (`2450cb2`) surfaces **6 false failures** (`commandPreconditionAsk` returns `null` on a composite), and — worse — the guard was **blind to a genuine forget-leak** nested in a composite.

## Root cause (verified, not a regression)

Traced both shapes against current data:
- **Convert to Project** `b1b6978e` → `22d4418f` (AllPrecondition) → … → leaf `43a02c67` still carries `FILTER NOT EXISTS { … Instance_class … STRENDS(STR(?x),"Prototype") … }`.
- **Vote on Effort** `169a2c25` → `c57642c4` (AllPrecondition) → `5b49ef19` `NotPrecondition(011eb4d6 "Is prototype")` — the composable not-a-prototype form.

The not-a-prototype guard is **semantically intact** — it just moved into composite leaves. This is a **stale test**, not a code/data regression.

## Fix (test-only + submodule bump)

`enforcesNotPrototype` walks the precondition tree with correct semantics:
- **leaf**: sparqlAsk matches the not-a-prototype clause;
- **AllPrecondition** (AND): ≥1 conjunct enforces (an AND-conjunct hides the command on prototypes);
- **AnyPrecondition** (OR): **ALL** branches enforce (a single clause-less OR-branch would leak);
- **NotPrecondition(IsPrototype)**: the composable form (`5b49ef19` → `011eb4d6`).

The universal-maintenance negative control now asserts `commandEnforcesNotPrototype(...) === false`.

## Verification

- **10 synthetic detection tests** (no submodule) prove the predicate returns **FALSE** when the clause is absent across leaf / AND / OR / Not shapes → the guard is **non-vacuous** and still catches a real forget-leak (revert-verify of detection power).
- **RED→GREEN**: the 6 lifecycle tests were RED with the flat-only resolver on `2450cb2`, GREEN with the composite-aware one.
- **No regression**: all **25** exoas-exocmd-reading core suites (**361 tests**) green on the bumped submodule; `tsc --noEmit` core → 0.
- Bumps pinned `packages/exoas-exocmd` `532a86a` → `2450cb2` (current remote main; includes the precondition restructuring + the `exo__Asset_updatedAt` PropertyDefault `f6936a3f`).

Ref: req `5579ffa1` (forget-guard). Catches the exocortex test up to already-shipped exoas-exocmd data.

https://claude.ai/code/session_017j92wpGSFfbfuvXYCKecMK
