### PR TITLE
refactor(cli): rename resolve-buttons → resolve-inline-buttons (+ back-compat alias)

### DIFF
--- a/packages/cli/src/commands/resolve-buttons.ts
+++ b/packages/cli/src/commands/resolve-buttons.ts
@@ -25,7 +25,7 @@ import { createIsInWrongFolderHostFunction } from "../precondition/createIsInWro
 import { createHasEmptyPropertiesHostFunction } from "../precondition/createHasEmptyPropertiesHostFunction.js";
 
 /**
- * Issue #3833 — `resolve-buttons <target>` prints the command button-set the
+ * Issue #3833 — `resolve-inline-buttons <target>` prints the command button-set the
  * plugin resolves for an asset's page BEFORE the (downstream, out-of-scope)
  * RFC-024 class-panel filter: **Layer A** (binding-match via the class
  * hierarchy, `CommandResolver.resolveForAssetMulti`) **∩ Layer B**
@@ -377,11 +377,13 @@ function printHuman(result: ResolveButtonsResult, showHidden: boolean): void {
 }
 
 /**
- * `exocortex resolve-buttons <target> [--vault <v>] [--json] [--show-hidden]`
+ * `exocortex resolve-inline-buttons <target> [--vault <v>] [--json] [--show-hidden]`
  * — Issue #3833. The authoritative inline-button-visibility oracle.
+ * (Aliased `resolve-buttons` for back-compat.)
  */
 export function resolveButtonsCommand(): Command {
-  return new Command("resolve-buttons")
+  return new Command("resolve-inline-buttons")
+    .alias("resolve-buttons")
     .description(
       "Print the actual command button-set for an asset — binding-match ∩ " +
         "precondition-eval (Issue #3833). The authoritative button-visibility " +
@@ -396,7 +398,7 @@ export function resolveButtonsCommand(): Command {
     )
     .action(async (targetArg: string, options: ResolveButtonsOptions) => {
       // LOW#4 (#3833) — honour --json on the error path too, so a failing
-      // resolve-buttons emits a structured JSON error (ErrorHandler json mode)
+      // resolve-inline-buttons emits a structured JSON error (ErrorHandler json mode)
       // instead of human text. Mirrors the resolve/validate-* convention.
       ErrorHandler.setFormat((options.json ? "json" : "text") as OutputFormat);
       try {

--- a/packages/cli/tests/integration/resolve-buttons.integration.test.ts
+++ b/packages/cli/tests/integration/resolve-buttons.integration.test.ts
@@ -369,3 +369,16 @@ describe("@req:960a7ba7-3470-42ba-afdc-f6766c3c3126 resolve-buttons — binding-
     expect(errs.join("\n")).not.toMatch(/❌ Error:/);
   });
 });
+
+// Homoiconization audit 2026-07-11 (Andrey interview): the verb was renamed
+// `resolve-buttons` → `resolve-inline-buttons` (the name now reflects the
+// inline-button scope; the command palette is a separate path). `resolve-buttons`
+// is kept as a back-compat alias so existing scripts + the homoiconic-rule oracle
+// references (`resolve-buttons <target> --json`) keep resolving.
+describe("resolve-inline-buttons rename + back-compat alias", () => {
+  it("has primary name resolve-inline-buttons and a resolve-buttons alias", () => {
+    const cmd = resolveButtonsCommand();
+    expect(cmd.name()).toBe("resolve-inline-buttons");
+    expect(cmd.aliases()).toContain("resolve-buttons");
+  });
+});


### PR DESCRIPTION
## What

Renames the CLI verb `resolve-buttons` → **`resolve-inline-buttons`**, keeping `resolve-buttons` as a **back-compat alias** (commander `.alias()`, mirrors the `classes`/`describe-class` convention).

## Why

From the homoiconization audit of exocortex-cli commands (Andrey interview 2026-07-11). The verb resolves the **inline-button** set (Layer A binding-match ∩ Layer B precondition-eval) — the command **palette** is a deliberately separate path (`findPaletteEnabledCommands`). `resolve-buttons` under-described the scope; `resolve-inline-buttons` is precise. Behaviour is unchanged → **refactor** (feature-sdd Step 0 exempt, no requirement).

## Back-compat

The alias keeps every existing `resolve-buttons` invocation working — including the homoiconic-rule oracle references (`resolve-buttons <target> --json`) and the prose comments in the `packages/core/tests/integration/dynamic-commands/*` suites (left untouched — still accurate via the alias).

## Verification

- New assertion in `resolve-buttons.integration.test.ts`: `resolveButtonsCommand().name() === "resolve-inline-buttons"` and `.aliases()` contains `"resolve-buttons"`.
- Full `@req:960a7ba7` oracle suite still green (7/7 locally) — proving the alias keeps the old-name invocations resolving.
- Behaviour-preserving rename; no revert-verify (refactor, not a behavior change).

https://claude.ai/code/session_01LzX9NekNcwGuBjWUw2mCGr