### PR TITLE
fix(cli): literal @req:2678df55 binding for the static requirements-audit

### DIFF
--- a/packages/cli/tests/integration/run-query-namedquery.integration.test.ts
+++ b/packages/cli/tests/integration/run-query-namedquery.integration.test.ts
@@ -169,6 +169,11 @@ function buildVault(listSparql: string = LIST_SPARQL_EXCLUDE_GADGET): string {
   return root;
 }
 
+// @req:2678df55-ef74-4b45-a168-90db5e958882 — LITERAL binding for the static
+// `requirements audit` scanner. The it() titles below build the tag via a
+// `@req:${REQ}` template literal, which the audit's static `@req:<uuid>` regex
+// cannot resolve — so without this literal line the now-Active req reads as
+// unbound and reds `requirements-trace` on every PR (cross-session blast radius).
 describe("req 2678df55 — run-query + homoiconic classes read-axis", () => {
   let root: string | undefined;
   let processExitSpy: jest.SpiedFunction<typeof process.exit>;


### PR DESCRIPTION
## Problem (whole-repo blast radius)

req `2678df55` (run-query + homoiconic classes, shipped in #3857) was flipped **Active**, but its `@req` binding in `run-query-namedquery.integration.test.ts` is built via a `it(\`@req:${REQ}\`)` **template literal**. The `requirements audit` static scanner matches `@req:<literal-uuid>` and cannot resolve `${REQ}` — so the now-Active req reads as **unbound**, reddening the always-on **active-requirement gate** in `requirements-trace` on **every open PR** (not just its own).

Main's last `requirements-trace` was green because it ran while 2678df55 was still *Approved* (the Active flip landed after the #3857 merge). The pre-flip guard passed because it checks UID *presence*, not `@req:<literal>` *form*.

## Fix

Add the literal `@req:2678df55-ef74-4b45-a168-90db5e958882` tag as a comment (the audit counts a `@req` tag anywhere in test content). Test-only, behaviour unchanged.

## Verification (authoritative — reqs cloned + real audit)

```
requirements audit --reqs <cloned exoas-*-reqs> --tests <this branch> --gate soft
→ Active requirements: 103 | invariant violations: 0   (was 1)
```

The 3 remaining floor-violations are pre-existing soft warnings (`continue-on-error`, non-blocking) — unrelated to this change.

Follow-up lesson (feature-sdd): the `@req` tag must be a **literal** `@req:<uuid>`, never a `${var}` template — and the pre-flip guard should check the literal form, not just UID presence.

https://claude.ai/code/session_01LzX9NekNcwGuBjWUw2mCGr