### PR TITLE
feat(daily-tasks): homoiconic displayName in pn__DailyNote tasks table (req a577316f)

### DIFF
--- a/packages/obsidian-plugin/src/presentation/components/daily-tasks/helpers.ts
+++ b/packages/obsidian-plugin/src/presentation/components/daily-tasks/helpers.ts
@@ -123,24 +123,32 @@ export const formatTimeEstimate = (minutes: number | null | undefined): string =
   return `${hours}h ${mins}m`;
 };
 
+/**
+ * Compose the DailyNote task-cell label.
+ *
+ * The status/class prefix (\uD83D\uDD04 Doing, \u2705 Done, \u274C Trashed, \uD83D\uDC65 Meeting) is HOMOICONIC \u2014 it is
+ * carried by `task.displayName`, resolved by DailyTasksRenderer through the vault
+ * `exo__DisplayNameSpec` system (single source of truth, same as native Obsidian links). This
+ * helper no longer re-implements a hardcoded emoji map (Issue: req a577316f).
+ *
+ * The \uD83D\uDEA9 blocked marker is RETAINED renderer-side: it is a computed predicate over the
+ * referenced blocker asset's status, which the current single-value exo__DisplayNameSpec
+ * matcher cannot express \u2014 tracked as a separate engine-extension follow-up.
+ *
+ * When `task.displayName` is unavailable (empty slots, or no printNameRuleService in tests)
+ * the old label path is used: a custom `getAssetLabel(path)` wins over `task.label`.
+ */
 export const getDisplayName = (
   task: DailyTask,
   getAssetLabel?: (path: string) => string | null,
 ): string => {
   const blockerIcon = task.isBlocked ? "\uD83D\uDEA9 " : "";
-  const icon =
-    task.isDone && task.isMeeting
-      ? "\u2705 \uD83D\uDC65 "
-      : task.isDone
-        ? "\u2705 "
-        : task.isTrashed
-          ? "\u274C "
-          : task.isDoing
-            ? "\uD83D\uDD04 "
-            : task.isMeeting
-              ? "\uD83D\uDC65 "
-              : "";
 
+  if (task.displayName != null && task.displayName !== "") {
+    return blockerIcon + task.displayName;
+  }
+
+  // Fallback: no resolver-driven name \u2192 old label path (no status/class prefix).
   let displayText = task.label || task.title;
 
   if (typeof getAssetLabel === "function") {
@@ -154,7 +162,7 @@ export const getDisplayName = (
     }
   }
 
-  return blockerIcon + icon + displayText;
+  return blockerIcon + displayText;
 };
 
 export const getEffortAreaDisplayText = (
@@ -266,10 +274,7 @@ export const createEmptySlot = (
       ems__Effort_startTimestamp: startTimestamp,
       ems__Effort_endTimestamp: endTimestamp,
     },
-    isDone: false,
-    isTrashed: false,
     isDoing: false,
-    isMeeting: false,
     isBlocked: false,
     isEmptySlot: true,
   };

--- a/packages/obsidian-plugin/src/presentation/components/daily-tasks/types.ts
+++ b/packages/obsidian-plugin/src/presentation/components/daily-tasks/types.ts
@@ -14,10 +14,27 @@ export interface DailyTask {
   endTimestamp: string | number | null;
   status: string;
   metadata: Record<string, unknown>;
-  isDone: boolean;
-  isTrashed: boolean;
+  /**
+   * Homoiconic display name resolved through the vault `exo__DisplayNameSpec` system
+   * (DisplayNameResolver + PrintNameRuleService), computed by DailyTasksRenderer. Carries
+   * the status/class prefix (🔄/✅/❌/👥) declared in vault data — single source of truth,
+   * same as native Obsidian links. Undefined when no resolver is available (fallback to label).
+   */
+  displayName?: string;
+  /**
+   * Dual-IRI-robust "Doing" flag (derived via getStatusLabel, NOT a naive strict-equality
+   * against a label-form enum). Used for the NON-display sort that lifts Doing tasks to the top.
+   */
   isDoing: boolean;
-  isMeeting: boolean;
+  /**
+   * @deprecated Display-only status/class flags — the status/class prefix is now homoiconic
+   * (see `displayName`), so these no longer drive rendering. Retained optional for the
+   * DailyTask shape's backward-compat (many test fixtures still set them); not computed by
+   * the renderer nor read by getDisplayName.
+   */
+  isDone?: boolean;
+  isTrashed?: boolean;
+  isMeeting?: boolean;
   isBlocked: boolean;
   isEmptySlot?: boolean;
 }

--- a/packages/obsidian-plugin/src/presentation/renderers/DailyTasksRenderer.ts
+++ b/packages/obsidian-plugin/src/presentation/renderers/DailyTasksRenderer.ts
@@ -8,13 +8,15 @@ import {
   DailyTasksTableWithToggle,
   isDateOnlyTimestamp,
 } from '@plugin/presentation/components/DailyTasksTable';
-import { AssetClass, EffortStatus, IVaultAdapter, IFile } from "@kitelev/exocortex-core";
+import { AssetClass, IVaultAdapter, IFile } from "@kitelev/exocortex-core";
 import { MetadataExtractor } from "@kitelev/exocortex-core";
 import { EffortSortingHelpers } from "@kitelev/exocortex-core";
 import { AssetMetadataService } from "./layout/helpers/AssetMetadataService";
 import { DailyNoteHelpers } from "./helpers/DailyNoteHelpers";
 import { BlockerHelpers } from '@plugin/presentation/utils/BlockerHelpers';
 import { getStatusLabel } from '@plugin/domain/property-editor/PropertySchemas';
+import { DisplayNameResolver } from '@plugin/domain/display-name/DisplayNameResolver';
+import { DEFAULT_DISPLAY_NAME_SETTINGS } from '@plugin/domain/settings/ExocortexSettings';
 import { ObsidianApp, ExocortexPluginInterface } from '@plugin/types';
 
 export class DailyTasksRenderer {
@@ -160,11 +162,29 @@ export class DailyTasksRenderer {
     this.logger.info(`Rendered ${tasks.length} tasks for DailyNote: ${day}`);
   }
 
+  /**
+   * Build a DisplayNameResolver the SAME way the native-link patches do (BodyLinkPatch,
+   * InlineTitlePatch, …), so a task's DailyNote-table label is produced by the homoiconic
+   * exo__DisplayNameSpec system — the status/class prefix (🔄/✅/❌/👥) comes from vault
+   * data, not a hardcoded emoji map. Degrades to a label-only resolver when the plugin's
+   * printNameRuleService / displayNameSettings are unavailable (e.g. unit-test mocks).
+   */
+  private createDisplayNameResolver(): DisplayNameResolver {
+    const ruleService = this.plugin.printNameRuleService ?? null;
+    const settings =
+      this.plugin.settings?.displayNameSettings ?? DEFAULT_DISPLAY_NAME_SETTINGS;
+    const metadataResolver = ruleService?.createMetadataResolver() ?? null;
+    return new DisplayNameResolver(settings, ruleService, metadataResolver);
+  }
+
   private async getDailyTasks(day: string): Promise<DailyTask[]> {
     try {
       const tasks: DailyTask[] = [];
 
       const allFiles = this.vaultAdapter.getAllFiles();
+
+      // One resolver per render — carries the compiled vault exo__DisplayNameSpec rules.
+      const displayNameResolver = this.createDisplayNameResolver();
 
       for (const file of allFiles) {
         const metadata = this.metadataExtractor.extractMetadata(file);
@@ -219,12 +239,13 @@ export class DailyTasksRenderer {
         const endTime =
           formatTime(endTimestamp as string | number | null | undefined) || formatTime(plannedEndTimestamp as string | number | null | undefined);
 
-        const isDone = effortStatusStr === EffortStatus.DONE;
-        const isTrashed = effortStatusStr === EffortStatus.TRASHED;
-        const isDoing = effortStatusStr === EffortStatus.DOING;
-        const isMeeting = instanceClassArray.some((c: string) =>
-          String(c).includes(AssetClass.MEETING),
-        );
+        // Dual-IRI-robust status label (normalizes [[uid]] / [[uid|label]] / label+UUID forms).
+        // isDoing feeds the NON-display sort that lifts Doing tasks to the top — derived from
+        // this normalized label, NEVER a naive strict-equality against the label-form enum (the
+        // bug that silently dropped 🔄 for UID-canon statuses). The status/class emoji prefixes
+        // are no longer derived here — they come from the homoiconic resolver (displayName below).
+        const statusLabel = getStatusLabel(effortStatusStr);
+        const isDoing = statusLabel === "Doing";
 
         const label = (metadata.exo__Asset_label as string) || file.basename;
 
@@ -236,6 +257,16 @@ export class DailyTasksRenderer {
         const enrichedMetadata = prototypeClasses
           ? { ...metadata, _prototypeClasses: prototypeClasses }
           : metadata;
+
+        // Homoiconic display name: resolve the task through the vault exo__DisplayNameSpec
+        // system (same stack as native links). Default exo__Asset_label to the basename so a
+        // labelless task keeps the old basename fallback inside the resolved prefix. Falls back
+        // to `label` when the resolver produces nothing (e.g. no printNameRuleService in tests).
+        const displayName =
+          displayNameResolver.resolve({
+            metadata: { ...enrichedMetadata, exo__Asset_label: label },
+            basename: file.basename,
+          }) ?? undefined;
 
         tasks.push({
           file: {
@@ -249,12 +280,10 @@ export class DailyTasksRenderer {
           endTime,
           startTimestamp: (startTimestamp || plannedStartTimestamp || null) as string | number | null,
           endTimestamp: (endTimestamp || plannedEndTimestamp || null) as string | number | null,
-          status: getStatusLabel(effortStatusStr),
+          status: statusLabel,
           metadata: enrichedMetadata,
-          isDone,
-          isTrashed,
+          displayName,
           isDoing,
-          isMeeting,
           isBlocked,
         });
       }

--- a/packages/obsidian-plugin/src/types/index.ts
+++ b/packages/obsidian-plugin/src/types/index.ts
@@ -6,6 +6,8 @@ import type { App, Plugin, TFile } from "obsidian";
 import type { IVaultAdapter } from "@kitelev/exocortex-core";
 import type ExocortexPlugin from '@plugin/ExocortexPlugin';
 import type { ThemeResolver } from '@plugin/application/services/ThemeResolver';
+import type { PrintNameRuleService } from '@plugin/domain/display-name/PrintNameRuleService';
+import type { DisplayNameSettings } from '@plugin/domain/settings/ExocortexSettings';
 
 /**
  * Metadata extracted from Obsidian frontmatter
@@ -64,9 +66,16 @@ export interface ExocortexPluginInterface extends Plugin {
     showEffortArea?: boolean;
     showEffortVotes?: boolean;
     excludedFolders?: string[];
+    /** Per-class display name templates (homoiconic exo__DisplayNameSpec cold-start seed). */
+    displayNameSettings?: DisplayNameSettings;
   };
   vaultAdapter: IVaultAdapter;
   themeResolver?: ThemeResolver;
+  /**
+   * Homoiconic displayName rule service (compiled from vault exo__DisplayNameSpec assets).
+   * Optional so renderers degrade gracefully when it hasn't been initialized (tests).
+   */
+  printNameRuleService?: PrintNameRuleService;
   saveSettings(): Promise<void>;
   refreshLayout?(): void;
 }

--- a/packages/obsidian-plugin/tests/component/DailyTasksTable.spec.tsx
+++ b/packages/obsidian-plugin/tests/component/DailyTasksTable.spec.tsx
@@ -30,6 +30,8 @@ test.describe("DailyTasksTable", () => {
       path: "task2.md",
       title: "Task 2",
       label: "Second Task",
+      // Homoiconic resolved name (DailyTasksRenderer resolves this via the vault ✅-Done spec).
+      displayName: "✅ Second Task",
       startTime: "10:30",
       endTime: "11:30",
       startTimestamp: null,
@@ -47,6 +49,8 @@ test.describe("DailyTasksTable", () => {
       path: "meeting1.md",
       title: "Meeting 1",
       label: "Team Sync",
+      // Homoiconic resolved name (vault 👥 Meeting spec).
+      displayName: "👥 Team Sync",
       startTime: "14:00",
       endTime: "15:00",
       startTimestamp: null,
@@ -64,6 +68,8 @@ test.describe("DailyTasksTable", () => {
       path: "task3.md",
       title: "Task 3",
       label: "Trashed Task",
+      // Homoiconic resolved name (vault ❌ Trashed spec).
+      displayName: "❌ Trashed Task",
       startTime: "",
       endTime: "",
       startTimestamp: null,
@@ -81,6 +87,8 @@ test.describe("DailyTasksTable", () => {
       path: "meeting2.md",
       title: "Meeting 2",
       label: "Completed Meeting",
+      // Homoiconic resolved name (vault ✅👥 Meeting-Done spec).
+      displayName: "✅ 👥 Completed Meeting",
       startTime: "16:00",
       endTime: "17:00",
       startTimestamp: null,
@@ -872,6 +880,8 @@ test.describe("DailyTasksTable", () => {
       path: "doing-task.md",
       title: "Doing Task",
       label: "Doing Task",
+      // Homoiconic resolved name (vault 🔄 Doing spec, d069c316).
+      displayName: "🔄 Doing Task",
       startTime: "09:00",
       endTime: "10:00",
       startTimestamp: null,
@@ -1648,11 +1658,27 @@ test.describe("Large Data Volume Rendering (100 records)", () => {
       const startTime = `${hour.toString().padStart(2, "0")}:${minute.toString().padStart(2, "0")}`;
       const endTime = `${hour.toString().padStart(2, "0")}:${(minute + 14).toString().padStart(2, "0")}`;
 
+      // Homoiconic resolved name — mirrors what DailyTasksRenderer computes via the vault
+      // exo__DisplayNameSpec system (status/class prefix from vault data, not a hardcoded map).
+      const prefix =
+        isDone && isMeeting
+          ? "✅ 👥 "
+          : isDone
+            ? "✅ "
+            : isTrashed
+              ? "❌ "
+              : isDoing
+                ? "🔄 "
+                : isMeeting
+                  ? "👥 "
+                  : "";
+
       tasks.push({
         file: { path: `task${i}.md`, basename: `task${i}` },
         path: `task${i}.md`,
         title: `Task ${i}`,
         label: `Task ${i} - ${status}`,
+        displayName: `${prefix}Task ${i} - ${status}`,
         startTime,
         endTime,
         startTimestamp: new Date(`2025-01-15T${startTime}:00`).getTime(),

--- a/packages/obsidian-plugin/tests/unit/renderers/dailyTasks/DailyTasksRenderer.homoiconicDisplayName.test.ts
+++ b/packages/obsidian-plugin/tests/unit/renderers/dailyTasks/DailyTasksRenderer.homoiconicDisplayName.test.ts
@@ -1,0 +1,260 @@
+import { TFile } from "obsidian";
+import type { App, CachedMetadata } from "obsidian";
+import { DailyTasksRenderer } from "@plugin/presentation/renderers/DailyTasksRenderer";
+import { PrintNameRuleService } from "@plugin/domain/display-name/PrintNameRuleService";
+import { DEFAULT_DISPLAY_NAME_SETTINGS } from "@plugin/domain/settings/ExocortexSettings";
+import { getDisplayName } from "@plugin/presentation/components/daily-tasks/helpers";
+import { AssetMetadataService } from "@plugin/presentation/renderers/layout/helpers/AssetMetadataService";
+import type { ExocortexSettings } from "@plugin/domain/settings/ExocortexSettings";
+import type { ILogger } from "@plugin/infrastructure/logging/ILogger";
+import type { MetadataExtractor, IVaultAdapter } from "@kitelev/exocortex-core";
+import type { ReactRenderer } from "@plugin/presentation/utils/ReactRenderer";
+import type { DailyTask } from "@plugin/presentation/components/daily-tasks/types";
+
+jest.mock("obsidian", () => ({
+  ...jest.requireActual("obsidian"),
+  Keymap: { isModEvent: jest.fn() },
+}));
+
+// Canonical UIDs (verified in-vault this session).
+const TASK_UID = "1b20a8f0-d745-4e93-91db-4531b3df120e";
+const DOING_UID = "027e78f4-6e16-4b36-b8fb-5510507d5745";
+const SPEC_UID = "d069c316-fcd3-4c25-8f24-3109382b72cf";
+const DAY = "2026-07-11";
+
+/**
+ * In-memory vault mock exposing the SAME surface PrintNameRuleService.scanVault reads
+ * (getMarkdownFiles + getFileCache + getFirstLinkpathDest). Carries the REAL 🔄-Doing
+ * exo__DisplayNameSpec (d069c316) + its two parts — production-shape, no hand-injected
+ * template, no stubbed resolver (test-fixture-realism).
+ */
+function createSpecVaultApp(
+  files: Array<{ path: string; frontmatter: Record<string, unknown> }>,
+): App {
+  const fileCache = new Map<string, CachedMetadata>();
+  const mockFiles: TFile[] = [];
+  for (const f of files) {
+    const tfile = new TFile(f.path);
+    tfile.basename = f.path.replace(".md", "");
+    tfile.extension = "md";
+    mockFiles.push(tfile);
+    fileCache.set(f.path, { frontmatter: f.frontmatter } as CachedMetadata);
+  }
+  return {
+    vault: { getMarkdownFiles: jest.fn().mockReturnValue(mockFiles) },
+    metadataCache: {
+      getFileCache: jest
+        .fn()
+        .mockImplementation((file: TFile) => fileCache.get(file.path) ?? null),
+      getFirstLinkpathDest: jest.fn().mockImplementation((path: string) => {
+        const clean = path.endsWith(".md") ? path : path + ".md";
+        return mockFiles.find((f) => f.path === clean) ?? null;
+      }),
+    },
+    workspace: {
+      getLeaf: jest.fn().mockReturnValue({ openLinkText: jest.fn() }),
+      openLinkText: jest.fn(),
+    },
+  } as unknown as App;
+}
+
+/** The real 🔄-Doing spec (d069c316) + PrintedLiteral "🔄 " + PrintedProperty exo__Asset_label. */
+function doingSpecFiles(): Array<{
+  path: string;
+  frontmatter: Record<string, unknown>;
+}> {
+  return [
+    {
+      path: `${SPEC_UID}.md`,
+      frontmatter: {
+        exo__Asset_uid: SPEC_UID,
+        exo__Instance_class: [
+          "[[07eab746-0874-4676-9d98-dbaad1bc6fb8|exo__DisplayNameSpec]]",
+        ],
+        exo__DisplayNameSpec_appliesToClass: `[[${TASK_UID}|ems__Task]]`,
+        exo__DisplayNameSpec_priority: 100,
+        exo__DisplayNameSpec_matchPath:
+          "[[44c6e9e3-955f-4afc-9ca5-b4bd70667051|ems__Effort_status]]",
+        exo__DisplayNameSpec_matchValue: `[[${DOING_UID}|ems__EffortStatusDoing]]`,
+        exo__Asset_label: "displayName spec — ems__Task 🔄 while Doing",
+      },
+    },
+    {
+      path: "spec-literal.md",
+      frontmatter: {
+        exo__Asset_uid: "spec-literal",
+        exo__Instance_class: [
+          "[[4d5437c9-788e-4a6d-9be0-4af3a84554f4|exo__PrintedLiteral]]",
+        ],
+        exo__DisplayNamePart_of: `[[${SPEC_UID}]]`,
+        exo__DisplayNamePart_order: 0,
+        exo__PrintedLiteral_literal: "🔄 ",
+      },
+    },
+    {
+      path: "spec-property.md",
+      frontmatter: {
+        exo__Asset_uid: "spec-property",
+        exo__Instance_class: [
+          "[[7d58de40-d941-4a66-88e2-13afc4fdc41d|exo__PrintedProperty]]",
+        ],
+        exo__DisplayNamePart_of: `[[${SPEC_UID}]]`,
+        exo__DisplayNamePart_order: 1,
+        exo__PrintedProperty_property:
+          "[[12a6151b-801f-4be2-bd6e-a787eedd56ae|exo__Asset_label]]",
+      },
+    },
+  ];
+}
+
+/**
+ * Drive the REAL DailyTasksRenderer with a REAL PrintNameRuleService (compiled from the vault
+ * spec) wired onto the plugin. Returns the DailyTask[] the renderer handed to React — the exact
+ * objects getDisplayName renders. `statusValue` is stored on the task's ems__Effort_status.
+ */
+async function renderTaskWithStatus(statusValue: string): Promise<DailyTask[]> {
+  const app = createSpecVaultApp(doingSpecFiles());
+  const printNameRuleService = new PrintNameRuleService(app);
+  printNameRuleService.initialize(); // real scanVault — compiles the vault spec
+
+  const settings = {
+    showEffortArea: false,
+    showEffortVotes: false,
+    showTimeEstimate: false,
+    // Same DisplayNameSettings the native-link patches read.
+    displayNameSettings: DEFAULT_DISPLAY_NAME_SETTINGS,
+  } as unknown as ExocortexSettings;
+
+  const plugin = {
+    settings: { displayNameSettings: DEFAULT_DISPLAY_NAME_SETTINGS },
+    printNameRuleService,
+    saveSettings: jest.fn(),
+  } as unknown as import("@plugin/types").ExocortexPluginInterface;
+
+  const logger: jest.Mocked<ILogger> = {
+    info: jest.fn(),
+    debug: jest.fn(),
+    error: jest.fn(),
+    warn: jest.fn(),
+  } as unknown as jest.Mocked<ILogger>;
+
+  const dailyNoteFile = {
+    path: `${DAY}.md`,
+    parent: { path: "DailyNotes" },
+    basename: DAY,
+  } as TFile;
+  const dailyNoteMetadata = {
+    exo__Instance_class: "[[pn__DailyNote]]",
+    pn__DailyNote_day: `[[${DAY}]]`,
+  };
+
+  const taskFile = { path: "doing-task.md", basename: "doing-task" } as TFile;
+  const taskMetadata = {
+    // UID-canon instance class + UID-canon status — the exact form that broke the naive strip.
+    exo__Instance_class: [`[[${TASK_UID}]]`],
+    ems__Effort_day: `[[${DAY}]]`,
+    ems__Effort_startTimestamp: `${DAY}T09:00:00`,
+    ems__Effort_status: statusValue,
+    exo__Asset_label: "Write the report",
+  };
+
+  const metadataExtractor = {
+    extractMetadata: jest
+      .fn()
+      .mockReturnValueOnce(dailyNoteMetadata)
+      .mockReturnValueOnce(taskMetadata),
+    extractInstanceClass: jest.fn().mockReturnValueOnce("[[pn__DailyNote]]"),
+    extractStatus: jest.fn(),
+    extractIsArchived: jest.fn(),
+  } as unknown as jest.Mocked<MetadataExtractor>;
+
+  const reactRenderer = {
+    render: jest.fn(),
+    unmount: jest.fn(),
+  } as unknown as jest.Mocked<ReactRenderer>;
+
+  const vaultAdapter = {
+    getAllFiles: jest.fn().mockReturnValue([taskFile]),
+    getFirstLinkpathDest: jest.fn(),
+  } as unknown as jest.Mocked<IVaultAdapter>;
+
+  const metadataService = new AssetMetadataService(app);
+
+  const renderer = new DailyTasksRenderer(
+    app as never,
+    settings,
+    plugin,
+    logger,
+    metadataExtractor,
+    reactRenderer,
+    jest.fn(),
+    metadataService,
+    vaultAdapter,
+  );
+
+  const el: HTMLElement = document.createElement("div");
+  (el as unknown as { createDiv: (o?: unknown) => HTMLElement }).createDiv = (
+    opts?: unknown,
+  ) => {
+    const div = document.createElement("div") as unknown as {
+      className?: string;
+      createEl: (t: string, o?: { cls?: string; text?: string }) => HTMLElement;
+      createDiv: (o?: unknown) => HTMLElement;
+    };
+    const cls = (opts as { cls?: string } | undefined)?.cls;
+    if (cls) (div as unknown as HTMLElement).className = cls;
+    el.appendChild(div as unknown as HTMLElement);
+    div.createEl = (tag: string, o?: { cls?: string; text?: string }) => {
+      const e = document.createElement(tag);
+      if (o?.cls) e.className = o.cls;
+      if (o?.text) e.textContent = o.text;
+      (div as unknown as HTMLElement).appendChild(e);
+      return e;
+    };
+    div.createDiv = (el as unknown as { createDiv: (o?: unknown) => HTMLElement })
+      .createDiv;
+    return div as unknown as HTMLElement;
+  };
+
+  await renderer.render(el, dailyNoteFile);
+
+  expect(reactRenderer.render).toHaveBeenCalled();
+  return (
+    reactRenderer.render.mock.calls[0][1] as {
+      props: { tasks: DailyTask[] };
+    }
+  ).props.tasks;
+}
+
+describe("DailyTasksRenderer — homoiconic displayName (req a577316f)", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("@req:a577316f-f2ff-469b-a6d3-ff946eccc68f renders 🔄 for a UID-canon Doing task via the vault exo__DisplayNameSpec (DisplayNameResolver + PrintNameRuleService), NOT a hardcoded emoji map", async () => {
+    // Doing status stored UID-canon "[[<doing-uid>]]" — the reported symptom.
+    const tasks = await renderTaskWithStatus(`[[${DOING_UID}]]`);
+    expect(tasks).toHaveLength(1);
+
+    // The homoiconic name carries the vault-declared 🔄 prefix, resolved through the real stack.
+    expect(tasks[0].displayName).toBe("🔄 Write the report");
+
+    // The final DailyNote-table cell (what the row renders) shows "🔄 <label>".
+    expect(getDisplayName(tasks[0])).toBe("🔄 Write the report");
+  });
+
+  it("@req:a577316f-f2ff-469b-a6d3-ff946eccc68f shows the bare label when the same task is NOT Doing (the conditional spec does not participate)", async () => {
+    // Backlog status (UID-canon) — the 🔄-Doing conditional matcher must not match.
+    const tasks = await renderTaskWithStatus(
+      "[[753a44d5-846c-4b82-9196-4fd9a4d48777]]",
+    );
+    expect(tasks).toHaveLength(1);
+    expect(tasks[0].displayName).toBe("Write the report");
+    expect(getDisplayName(tasks[0])).toBe("Write the report");
+  });
+
+  it("@req:a577316f-f2ff-469b-a6d3-ff946eccc68f resolves 🔄 for the [[<uid>|label]] status form too (dual-IRI)", async () => {
+    const tasks = await renderTaskWithStatus(
+      `[[${DOING_UID}|ems__EffortStatusDoing]]`,
+    );
+    expect(getDisplayName(tasks[0])).toBe("🔄 Write the report");
+  });
+});

--- a/packages/obsidian-plugin/tests/unit/renderers/dailyTasks/DailyTasksRenderer.properties.test.ts
+++ b/packages/obsidian-plugin/tests/unit/renderers/dailyTasks/DailyTasksRenderer.properties.test.ts
@@ -13,7 +13,7 @@ describe("DailyTasksRenderer - task properties", () => {
     ctx = setupDailyTasksRendererTest();
   });
 
-  it("should correctly identify meeting tasks", async () => {
+  it("should retain the meeting class and normalize its status", async () => {
     const mockFile = {
       path: "test.md",
       parent: { path: "DailyNotes" },
@@ -52,10 +52,13 @@ describe("DailyTasksRenderer - task properties", () => {
     expect(ctx.mockReactRenderer.render).toHaveBeenCalled();
     const renderCall = ctx.mockReactRenderer.render.mock.calls[0];
     const tasks = renderCall[1].props.tasks;
-    expect(tasks[0].isMeeting).toBe(true);
+    expect(String(tasks[0].metadata.exo__Instance_class)).toContain(
+      "ems__Meeting",
+    );
+    expect(tasks[0].status).toBe("To Do");
   });
 
-  it("should correctly identify done tasks", async () => {
+  it("should normalize done status (dual-IRI)", async () => {
     const mockFile = {
       path: "test.md",
       parent: { path: "DailyNotes" },
@@ -94,12 +97,11 @@ describe("DailyTasksRenderer - task properties", () => {
     expect(ctx.mockReactRenderer.render).toHaveBeenCalled();
     const renderCall = ctx.mockReactRenderer.render.mock.calls[0];
     const tasks = renderCall[1].props.tasks;
-    expect(tasks[0].isDone).toBe(true);
-    expect(tasks[0].isTrashed).toBe(false);
+    expect(tasks[0].status).toBe("Done");
     expect(tasks[0].isDoing).toBe(false);
   });
 
-  it("should correctly identify trashed tasks", async () => {
+  it("should normalize trashed status (dual-IRI)", async () => {
     const mockFile = {
       path: "test.md",
       parent: { path: "DailyNotes" },
@@ -138,8 +140,7 @@ describe("DailyTasksRenderer - task properties", () => {
     expect(ctx.mockReactRenderer.render).toHaveBeenCalled();
     const renderCall = ctx.mockReactRenderer.render.mock.calls[0];
     const tasks = renderCall[1].props.tasks;
-    expect(tasks[0].isTrashed).toBe(true);
-    expect(tasks[0].isDone).toBe(false);
+    expect(tasks[0].status).toBe("Trashed");
     expect(tasks[0].isDoing).toBe(false);
   });
 
@@ -183,8 +184,54 @@ describe("DailyTasksRenderer - task properties", () => {
     const renderCall = ctx.mockReactRenderer.render.mock.calls[0];
     const tasks = renderCall[1].props.tasks;
     expect(tasks[0].isDoing).toBe(true);
-    expect(tasks[0].isDone).toBe(false);
-    expect(tasks[0].isTrashed).toBe(false);
+    expect(tasks[0].status).toBe("Doing");
+  });
+
+  // Regression axis #2 (req a577316f): the retained isDoing sort flag must be
+  // dual-IRI-robust. A UID-canon status "[[<doing-uid>]]" (NOT the label form) must
+  // still be detected as Doing — the naive `=== EffortStatus.DOING` bug returned false here.
+  it("should detect Doing from a UID-canon status (dual-IRI sort flag)", async () => {
+    const mockFile = {
+      path: "test.md",
+      parent: { path: "DailyNotes" },
+      basename: "2025-10-20",
+    } as TFile;
+    const metadata = {
+      exo__Instance_class: "[[pn__DailyNote]]",
+      pn__DailyNote_day: "[[2025-10-20]]",
+    };
+
+    const taskFile = {
+      path: "task.md",
+      basename: "task",
+    } as TFile;
+
+    const taskMetadata = {
+      exo__Instance_class: "[[ems__Task]]",
+      ems__Effort_day: "[[2025-10-20]]",
+      ems__Effort_startTimestamp: "2025-10-20T09:00:00",
+      // UID-canon Doing status — the exact form the naive strict-equality never matched.
+      ems__Effort_status: "[[027e78f4-6e16-4b36-b8fb-5510507d5745]]",
+    };
+
+    ctx.mockMetadataExtractor.extractMetadata
+      .mockReturnValueOnce(metadata)
+      .mockReturnValueOnce(taskMetadata);
+
+    ctx.mockMetadataExtractor.extractInstanceClass.mockReturnValueOnce(
+      "[[pn__DailyNote]]",
+    );
+
+    ctx.mockVaultAdapter.getAllFiles.mockReturnValue([taskFile]);
+
+    const mockEl = createMockElement();
+    await ctx.renderer.render(mockEl, mockFile);
+
+    expect(ctx.mockReactRenderer.render).toHaveBeenCalled();
+    const renderCall = ctx.mockReactRenderer.render.mock.calls[0];
+    const tasks = renderCall[1].props.tasks;
+    expect(tasks[0].isDoing).toBe(true);
+    expect(tasks[0].status).toBe("Doing");
   });
 
   it("should use exo__Asset_label when available", async () => {


### PR DESCRIPTION
## What

The `pn__DailyNote` tasks table now renders a task's name label through the **homoiconic** displayName system (`DisplayNameResolver` + `PrintNameRuleService` over vault `exo__DisplayNameSpec` assets) — the status/class prefix (🔄 Doing, ✅ Done, ❌ Trashed, 👥 Meeting) comes from **vault data**, not a hardcoded TS emoji map. Same source of truth as native Obsidian links.

Closes the reported symptom: **🔄 was silently dropped for Doing tasks in the DailyNote table** — `DailyTasksRenderer`'s `isDoing` used a naive `effortStatusStr === EffortStatus.DOING` (label-form) that never matched a UID-canon status `[[027e78f4-…]]`, while the Status column (via `getStatusLabel`, which normalizes all forms) still showed "Doing".

## How

- `DailyTasksRenderer` builds a `DisplayNameResolver` the **same way the native-link patches do** (`plugin.printNameRuleService` + `displayNameSettings`), computes the task label, and stores it on `DailyTask.displayName`. (No threading through `UniversalLayoutRenderer` — the plugin already owns `printNameRuleService`.)
- `helpers.ts:getDisplayName` **removes the hardcoded status/class emoji map**; the cell = 🚩(if blocked) + resolver output. **🚩 blocked is retained** renderer-side (a computed predicate over the referenced blocker's status — the single-value matcher can't express it; follow-up).
- The retained `isDoing` sort flag is now **dual-IRI-robust** (`getStatusLabel(...) === "Doing"`), never a strict-equality against the label-form enum. `isDone`/`isTrashed`/`isMeeting` are no longer display-drivers (optional on the type).
- `ExocortexPluginInterface` exposes `printNameRuleService` + `displayNameSettings`.

## Behaviour note (verify-before-assert)

The `DisplayNameResolver` reads the **first** `exo__Instance_class` only. Real meetings are inconsistently classed (Meeting-only **and** Task-first). A Task-first meeting therefore renders its status prefix (via the `ems__Task` specs) but **not** the 👥 class prefix — matching native-link behaviour. Fully homoiconifying class-membership prefixes for multi-class notes needs a resolver "honors all instance classes" engine extension → follow-up (same family as the computed 🚩 matcher). The vault `exo__DisplayNameSpec` assets (✅ Done, ❌ Trashed, 👥 Meeting, ✅👥 Meeting-Done) ship separately to `kitelev/exoas-exo`.

## Tests

- **Binding (production-shape, `@req:a577316f-…`):** `DailyTasksRenderer.homoiconicDisplayName.test.ts` drives the **real** `DailyTasksRenderer` → **real** `PrintNameRuleService.scanVault` (in-memory vault carrying the real 🔄-Doing `exo__DisplayNameSpec` d069c316 + its parts) → **real** `DisplayNameResolver` → the DailyTasks label. No hand-injected label, no stubbed resolver.
- Component (`test-component`): `DailyTasksTable.spec.tsx` updated to the new contract (the component renders `task.displayName`).
- Renderer unit: `isDoing` dual-IRI UID-canon detection + status normalization.

Req: a577316f-f2ff-469b-a6d3-ff946eccc68f

Revert-verified: FAILS pre-fix, PASSES post-fix on both axes —
- (1) revert the renderer wiring → a UID-canon Doing task's cell loses the resolver-driven "🔄 " → **RED**; restore → **GREEN**.
- (2) break the dual-IRI `isDoing` normalization → UID-canon Doing not detected (sort flag) → **RED**; restore → **GREEN**.
