### PR TITLE
feat(layout): render task-link labels via homoiconic displayName in relation/query tables (#3863)

### DIFF
--- a/packages/obsidian-plugin/src/presentation/components/AssetRelationsTable.tsx
+++ b/packages/obsidian-plugin/src/presentation/components/AssetRelationsTable.tsx
@@ -102,11 +102,68 @@ export interface AssetRelation {
    */
   provenance?: "inline" | "reified";
   /**
+   * req `3f65eb4a` — the related asset's HOMOICONIC display name, resolved by
+   * `RelationsRenderer.getAssetRelations` through the vault `exo__DisplayNameSpec`
+   * system (the SAME stack as native links + the DailyNote tasks table). Carries the
+   * status/class prefix (🔄 while Doing, …). Preferred by {@link getRelationDisplayLabel};
+   * `undefined` → the plain `exo__Asset_label` / {@link title} fallback (no regression).
+   */
+  displayName?: string;
+  /**
    * RFC `93a0b2ee` Task 2 (C2) — the AssetSpace (`exoas-<name>`) the backing
    * statement asset lives in, for the factual "reified · <AS>" marker text.
    * `undefined` → a `reified` relation shows a bare "reified".
    */
   assetSpace?: string;
+}
+
+/**
+ * req `3f65eb4a` — the PLAIN row label (a custom `exo__Asset_label` wins over the
+ * `title`), without the 🚩 blocker or the homoiconic `displayName` prefix. Shared by the
+ * display + sort helpers below.
+ */
+function relationPlainLabel(relation: AssetRelation): string {
+  const label = relation.metadata?.exo__Asset_label;
+  if (label && typeof label === "string" && label.trim() !== "") {
+    return label;
+  }
+  return relation.title;
+}
+
+/**
+ * req `3f65eb4a` — compose the relation-table row's task-link cell label (for DISPLAY).
+ *
+ * The status/class prefix (🔄 Doing, ✅ Done, 👥 Meeting, …) is HOMOICONIC — carried by
+ * `relation.displayName`, resolved by `RelationsRenderer` through the vault
+ * `exo__DisplayNameSpec` system (single source of truth, the SAME as native links + the
+ * DailyNote tasks table; sibling of req a577316f). When `displayName` is absent (no
+ * `printNameRuleService` in a unit-test mock, or no matching spec) the OLD label path is
+ * used — a custom `exo__Asset_label` wins over `relation.title` (byte-identical to
+ * pre-3f65eb4a, no regression).
+ *
+ * The 🚩 blocked marker is RETAINED renderer-side: it is a computed predicate over the
+ * referenced blocker's status, which the single-value `exo__DisplayNameSpec` matcher
+ * cannot express (tracked separately as #3865).
+ */
+export function getRelationDisplayLabel(relation: AssetRelation): string {
+  const blockerIcon = relation.isBlocked ? "🚩 " : "";
+  if (relation.displayName != null && relation.displayName !== "") {
+    return blockerIcon + relation.displayName;
+  }
+  return blockerIcon + relationPlainLabel(relation);
+}
+
+/**
+ * req `3f65eb4a` — the SORT key for the relation title column: the PLAIN label (keeping
+ * the pre-existing 🚩 blocker prefix), deliberately WITHOUT the homoiconic `displayName`
+ * prefix — so rows collate by their text label, NOT by an emoji codepoint (🔄/👥). This is
+ * byte-identical to the pre-3f65eb4a title sort (no reorder regression); only the DISPLAYED
+ * cell ({@link getRelationDisplayLabel}) carries the resolver prefix. Mirrors the exo__Layout
+ * table, which likewise sorts on the unprefixed `row.title` (ExoLayoutRenderer.cellValue).
+ */
+export function getRelationSortLabel(relation: AssetRelation): string {
+  const blockerIcon = relation.isBlocked ? "🚩 " : "";
+  return blockerIcon + relationPlainLabel(relation);
 }
 
 /**
@@ -259,14 +316,10 @@ const SingleTable: React.FC<SingleTableProps> = ({
     return getInstanceClasses(metadata)[0];
   };
 
-  const getDisplayLabel = (relation: AssetRelation): string => {
-    const blockerIcon = relation.isBlocked ? "🚩 " : "";
-    const label = relation.metadata?.exo__Asset_label;
-    if (label && typeof label === "string" && label.trim() !== "") {
-      return blockerIcon + label;
-    }
-    return blockerIcon + relation.title;
-  };
+  // req `3f65eb4a` — the row task-link label now prefers the homoiconic
+  // `relation.displayName` (vault exo__DisplayNameSpec status/class prefix) via the
+  // shared, testable helper; null-safe fallback to the plain label (no regression).
+  const getDisplayLabel = getRelationDisplayLabel;
 
   const isWikiLink = (value: unknown): boolean => {
     return typeof value === "string" && /\[\[.*?\]\]/.test(value);
@@ -368,8 +421,11 @@ const SingleTable: React.FC<SingleTableProps> = ({
       let bVal: string | number;
 
       if (sortState.column === "title") {
-        aVal = getDisplayLabel(a).toLowerCase();
-        bVal = getDisplayLabel(b).toLowerCase();
+        // req `3f65eb4a` — sort on the UNPREFIXED label (getRelationSortLabel), so the
+        // homoiconic display prefix (🔄/👥) doesn't collate rows by emoji codepoint. Display
+        // still uses getDisplayLabel (with the prefix). Byte-identical to the pre-3f65eb4a sort.
+        aVal = getRelationSortLabel(a).toLowerCase();
+        bVal = getRelationSortLabel(b).toLowerCase();
       } else if (sortState.column === "exo__Instance_class") {
         const aClass = getInstanceClass(a.metadata);
         const bClass = getInstanceClass(b.metadata);

--- a/packages/obsidian-plugin/src/presentation/components/LayoutBlocks.tsx
+++ b/packages/obsidian-plugin/src/presentation/components/LayoutBlocks.tsx
@@ -136,6 +136,14 @@ export const BacklinksTableBlockView: React.FC<BacklinksTableBlockViewProps> = (
 
 function resolveCell(row: AssetRelation, column: string): string {
   if (column === "exo__Asset_label") {
+    // req `3f65eb4a` — the exo__Layout children/query table's label column now shows the
+    // HOMOICONIC display name (vault exo__DisplayNameSpec status/class prefix, e.g. 🔄 while
+    // Doing), resolved by RelationsRenderer onto `row.displayName` — the SAME single source
+    // as the Relations block + native links. Null-safe: no resolver / no matching spec →
+    // `displayName` is undefined → plain `row.title` fallback (byte-identical, no regression).
+    if (row.displayName != null && row.displayName !== "") {
+      return row.displayName;
+    }
     return row.title || "";
   }
   if (column === "_basename") {

--- a/packages/obsidian-plugin/src/presentation/renderers/layout/RelationsRenderer.ts
+++ b/packages/obsidian-plugin/src/presentation/renderers/layout/RelationsRenderer.ts
@@ -22,6 +22,8 @@ import {
   ReifiedRelation,
 } from "./getReifiedRelations";
 import { BlockerHelpers } from '@plugin/presentation/utils/BlockerHelpers';
+import { DisplayNameResolver } from '@plugin/domain/display-name/DisplayNameResolver';
+import { DEFAULT_DISPLAY_NAME_SETTINGS } from '@plugin/domain/settings/ExocortexSettings';
 import { ObsidianApp, ExocortexPluginInterface, MetadataRecord } from '@plugin/types';
 
 /** RFC 93a0b2ee Task 1.3 — Exocortex ontology IRI base (`…/ontology/`). */
@@ -277,6 +279,56 @@ export class RelationsRenderer {
     return legacy;
   }
 
+  /**
+   * req `3f65eb4a` — build a {@link DisplayNameResolver} the SAME way the native-link
+   * patches (BodyLinkPatch, InlineTitlePatch, …) and the DailyNote tasks table
+   * (DailyTasksRenderer, req a577316f) do, so a relation-table task-link label is
+   * produced by the homoiconic `exo__DisplayNameSpec` system — the status/class prefix
+   * (🔄/✅/❌/👥) comes from vault data, not a hardcoded map. Degrades to a label-only
+   * resolver when `printNameRuleService` / `displayNameSettings` are unavailable (e.g. a
+   * unit-test mock) → the tables keep the plain-label fallback (no regression).
+   */
+  private createDisplayNameResolver(): DisplayNameResolver {
+    const ruleService = this.plugin.printNameRuleService ?? null;
+    const settings =
+      this.plugin.settings?.displayNameSettings ?? DEFAULT_DISPLAY_NAME_SETTINGS;
+    const metadataResolver = ruleService?.createMetadataResolver() ?? null;
+    return new DisplayNameResolver(settings, ruleService, metadataResolver);
+  }
+
+  /**
+   * req `3f65eb4a` — attach the homoiconic `displayName` to each relation, resolved
+   * through the vault `exo__DisplayNameSpec` system (one resolver per call, carrying the
+   * compiled vault specs). Mutates each `AssetRelation` in place: `displayName` is the
+   * resolver output, or `undefined` when the resolver is unavailable / yields nothing —
+   * in which case the tables fall back to the plain `exo__Asset_label` / title.
+   *
+   * The related asset's own `exo__Asset_label` is defaulted to the relation title (which
+   * already resolves label→basename), so a labelless asset keeps its basename fallback
+   * INSIDE the resolved prefix (mirrors DailyTasksRenderer). The resolver reads the
+   * related asset's `exo__Instance_class` + status from `rel.metadata` to select and
+   * evaluate its (possibly conditional) spec.
+   */
+  private applyHomoiconicDisplayNames(relations: AssetRelation[]): void {
+    const resolver = this.createDisplayNameResolver();
+    for (const rel of relations) {
+      // Guard the label to a non-empty STRING (a non-string exo__Asset_label falls through
+      // to the title) — byte-identical to the plain-label fallback in getRelationDisplayLabel.
+      const rawLabel = rel.metadata?.exo__Asset_label;
+      const label =
+        (typeof rawLabel === "string" && rawLabel.trim() !== ""
+          ? rawLabel
+          : undefined) ??
+        rel.title ??
+        rel.file.basename;
+      rel.displayName =
+        resolver.resolve({
+          metadata: { ...rel.metadata, exo__Asset_label: label },
+          basename: rel.file.basename,
+        }) ?? undefined;
+    }
+  }
+
   async getAssetRelations(
     file: TFile,
     config: UniversalLayoutConfig,
@@ -377,6 +429,18 @@ export class RelationsRenderer {
     // instances, gated + whitelisted by Task 1.2) into the unified list,
     // deduplicating against the inline set (inline-wins on collision).
     await this.mergeReifiedRelations(file, relations);
+
+    // req `3f65eb4a` — resolve each related asset's HOMOICONIC display name through
+    // the vault `exo__DisplayNameSpec` system (the SAME stack as native links + the
+    // DailyNote tasks table). Attaches `displayName` so the relation/children/query
+    // table cell carries the status/class prefix (🔄 while Doing, …) from vault data,
+    // consistently with those surfaces — replacing the plain `exo__Asset_label` text.
+    // Single injection point: this list is the ONE source that feeds the Relations
+    // block (AssetRelationsTable) AND the exo__Layout backlinks/children/query tables
+    // (ExoLayoutRenderer → BacklinksTableBlockView). Null-safe: no printNameRuleService
+    // or no matching spec → `displayName` stays undefined and the tables fall back to
+    // the plain label (byte-identical to pre-3f65eb4a, no regression).
+    this.applyHomoiconicDisplayNames(relations);
 
     if (config.sortBy) {
       const sortBy = config.sortBy;

--- a/packages/obsidian-plugin/src/presentation/renderers/layout/types.ts
+++ b/packages/obsidian-plugin/src/presentation/renderers/layout/types.ts
@@ -26,6 +26,18 @@ export interface AssetRelation {
    */
   provenance?: "inline" | "reified";
   /**
+   * req `3f65eb4a` — the related asset's HOMOICONIC display name, resolved by
+   * {@link RelationsRenderer.getAssetRelations} through the vault
+   * `exo__DisplayNameSpec` system (the SAME `DisplayNameResolver` stack as native
+   * Obsidian links + the DailyNote tasks table, sibling of req a577316f). Carries
+   * the status/class prefix (`🔄 ` while Doing, …) from vault data, so the layout
+   * relation/children/query table cell shows it consistently with those surfaces.
+   * `undefined` when the resolver is unavailable (no `printNameRuleService`, e.g. a
+   * unit-test mock) or yields nothing → the table falls back to the plain
+   * `exo__Asset_label` / {@link title} (byte-identical to pre-3f65eb4a, no regression).
+   */
+  displayName?: string;
+  /**
    * RFC `93a0b2ee` Task 1.3 — vault-relative path of the backing
    * `exo__Statement` asset for a `reified` relation (provenance). `undefined`
    * for inline relations or when the statement IRI is not a vault-asset IRI.

--- a/packages/obsidian-plugin/tests/unit/renderers/layout/RelationsRenderer.homoiconicDisplayName.test.ts
+++ b/packages/obsidian-plugin/tests/unit/renderers/layout/RelationsRenderer.homoiconicDisplayName.test.ts
@@ -1,0 +1,296 @@
+import { TFile } from "obsidian";
+import type { App, CachedMetadata } from "obsidian";
+import { RelationsRenderer } from "@plugin/presentation/renderers/layout/RelationsRenderer";
+import {
+  getRelationDisplayLabel,
+  getRelationSortLabel,
+} from "@plugin/presentation/components/AssetRelationsTable";
+import { PrintNameRuleService } from "@plugin/domain/display-name/PrintNameRuleService";
+import { DEFAULT_DISPLAY_NAME_SETTINGS } from "@plugin/domain/settings/ExocortexSettings";
+import { AssetMetadataService } from "@plugin/presentation/renderers/layout/helpers/AssetMetadataService";
+import type { AssetRelation } from "@plugin/presentation/renderers/layout/types";
+import type { ExocortexSettings } from "@plugin/domain/settings/ExocortexSettings";
+import type { ReactRenderer } from "@plugin/presentation/utils/ReactRenderer";
+import type { BacklinksCacheManager } from "@plugin/adapters/caching/BacklinksCacheManager";
+import type { IVaultAdapter, IFile } from "@kitelev/exocortex-core";
+
+jest.mock("obsidian", () => {
+  class MockTFile {
+    path = "";
+    name = "";
+    basename = "";
+    extension = "";
+    parent: unknown = null;
+    vault: unknown = null;
+    stat: unknown = null;
+    constructor(path?: string) {
+      if (path) {
+        this.path = path;
+        this.basename = path.replace(/\.md$/, "");
+        this.name = this.basename + ".md";
+        this.extension = "md";
+      }
+    }
+  }
+  return {
+    ...jest.requireActual("obsidian"),
+    Keymap: { isModEvent: jest.fn() },
+    TFile: MockTFile,
+  };
+});
+
+// Real relation plumbing: findAllReferencingProperties + isAssetArchived are pure and
+// orthogonal to the displayName resolution under test — deterministic-stub them (the
+// task IS a backlink of the open asset via ems__Effort_area). The DisplayNameResolver +
+// PrintNameRuleService.scanVault path is REAL (no stubbed resolver — test-fixture-realism).
+jest.mock("@kitelev/exocortex-core", () => ({
+  ...jest.requireActual("@kitelev/exocortex-core"),
+  MetadataHelpers: {
+    isAssetArchived: jest.fn().mockReturnValue(false),
+    findAllReferencingProperties: jest.fn().mockReturnValue(["ems__Effort_area"]),
+    getPropertyValue: jest.fn(),
+  },
+}));
+
+jest.mock("@plugin/presentation/utils/BlockerHelpers", () => ({
+  BlockerHelpers: { isEffortBlocked: jest.fn().mockReturnValue(false) },
+}));
+
+// Canonical UIDs (verified in-vault; identical to the a577316f DailyNote binding test).
+const TASK_UID = "1b20a8f0-d745-4e93-91db-4531b3df120e";
+const DOING_UID = "027e78f4-6e16-4b36-b8fb-5510507d5745";
+const BACKLOG_UID = "753a44d5-846c-4b82-9196-4fd9a4d48777";
+const SPEC_UID = "d069c316-fcd3-4c25-8f24-3109382b72cf";
+
+const AREA_PATH = "area.md";
+const TASK_PATH = "doing-task.md";
+const TASK_LABEL = "Write the report";
+
+/**
+ * In-memory vault app exposing the SAME surface PrintNameRuleService.scanVault reads
+ * (getMarkdownFiles + getFileCache + getFirstLinkpathDest). Carries the REAL 🔄-Doing
+ * exo__DisplayNameSpec (d069c316) + its two parts — production-shape, no hand-injected
+ * template, no stubbed resolver (test-fixture-realism).
+ */
+function createSpecVaultApp(
+  files: Array<{ path: string; frontmatter: Record<string, unknown> }>,
+): App {
+  const fileCache = new Map<string, CachedMetadata>();
+  const mockFiles: TFile[] = [];
+  for (const f of files) {
+    const tfile = new TFile(f.path);
+    mockFiles.push(tfile);
+    fileCache.set(f.path, { frontmatter: f.frontmatter } as CachedMetadata);
+  }
+  return {
+    vault: { getMarkdownFiles: jest.fn().mockReturnValue(mockFiles) },
+    metadataCache: {
+      getFileCache: jest
+        .fn()
+        .mockImplementation((file: TFile) => fileCache.get(file.path) ?? null),
+      getFirstLinkpathDest: jest.fn().mockImplementation((path: string) => {
+        const clean = path.endsWith(".md") ? path : path + ".md";
+        return mockFiles.find((f) => f.path === clean) ?? null;
+      }),
+    },
+    workspace: {
+      getLeaf: jest.fn().mockReturnValue({ openLinkText: jest.fn() }),
+      openLinkText: jest.fn(),
+    },
+  } as unknown as App;
+}
+
+/** The real 🔄-Doing spec (d069c316) + PrintedLiteral "🔄 " + PrintedProperty exo__Asset_label. */
+function doingSpecFiles(
+  taskFrontmatter: Record<string, unknown>,
+): Array<{ path: string; frontmatter: Record<string, unknown> }> {
+  return [
+    {
+      path: `${SPEC_UID}.md`,
+      frontmatter: {
+        exo__Asset_uid: SPEC_UID,
+        exo__Instance_class: [
+          "[[07eab746-0874-4676-9d98-dbaad1bc6fb8|exo__DisplayNameSpec]]",
+        ],
+        exo__DisplayNameSpec_appliesToClass: `[[${TASK_UID}|ems__Task]]`,
+        exo__DisplayNameSpec_priority: 100,
+        exo__DisplayNameSpec_matchPath:
+          "[[44c6e9e3-955f-4afc-9ca5-b4bd70667051|ems__Effort_status]]",
+        exo__DisplayNameSpec_matchValue: `[[${DOING_UID}|ems__EffortStatusDoing]]`,
+        exo__Asset_label: "displayName spec — ems__Task 🔄 while Doing",
+      },
+    },
+    {
+      path: "spec-literal.md",
+      frontmatter: {
+        exo__Asset_uid: "spec-literal",
+        exo__Instance_class: [
+          "[[4d5437c9-788e-4a6d-9be0-4af3a84554f4|exo__PrintedLiteral]]",
+        ],
+        exo__DisplayNamePart_of: `[[${SPEC_UID}]]`,
+        exo__DisplayNamePart_order: 0,
+        exo__PrintedLiteral_literal: "🔄 ",
+      },
+    },
+    {
+      path: "spec-property.md",
+      frontmatter: {
+        exo__Asset_uid: "spec-property",
+        exo__Instance_class: [
+          "[[7d58de40-d941-4a66-88e2-13afc4fdc41d|exo__PrintedProperty]]",
+        ],
+        exo__DisplayNamePart_of: `[[${SPEC_UID}]]`,
+        exo__DisplayNamePart_order: 1,
+        exo__PrintedProperty_property:
+          "[[12a6151b-801f-4be2-bd6e-a787eedd56ae|exo__Asset_label]]",
+      },
+    },
+    // The Doing task itself — carried in the vault so the real AssetMetadataService resolves
+    // its label; its frontmatter (instance class + status) is what the resolver reads.
+    { path: TASK_PATH, frontmatter: taskFrontmatter },
+  ];
+}
+
+/**
+ * Drive the REAL RelationsRenderer.getAssetRelations over an in-memory vault carrying the
+ * real spec, with a REAL PrintNameRuleService compiled from that vault (or absent). Returns
+ * the AssetRelation[] the renderer produced — the exact objects the layout relation/query
+ * tables render. `statusValue` is stored on the linked task's ems__Effort_status.
+ */
+async function getRelationsForTaskWithStatus(
+  statusValue: string,
+  opts: { withResolver?: boolean } = {},
+): Promise<AssetRelation[]> {
+  const withResolver = opts.withResolver ?? true;
+
+  const taskFrontmatter = {
+    exo__Instance_class: [`[[${TASK_UID}]]`], // UID-canon — the form that broke the naive strip
+    ems__Effort_status: statusValue,
+    ems__Effort_area: `[[${AREA_PATH.replace(".md", "")}]]`,
+    exo__Asset_label: TASK_LABEL,
+  };
+
+  const app = createSpecVaultApp(doingSpecFiles(taskFrontmatter));
+
+  let printNameRuleService: PrintNameRuleService | undefined;
+  if (withResolver) {
+    printNameRuleService = new PrintNameRuleService(app);
+    printNameRuleService.initialize(); // real scanVault — compiles the vault spec
+  }
+
+  const settings = {
+    showArchivedAssets: false,
+    showEffortVotes: false,
+    displayNameSettings: DEFAULT_DISPLAY_NAME_SETTINGS,
+  } as unknown as ExocortexSettings;
+
+  const plugin = {
+    settings: { displayNameSettings: DEFAULT_DISPLAY_NAME_SETTINGS },
+    printNameRuleService, // undefined in the null-resolver scenario
+    saveSettings: jest.fn(),
+  } as unknown as import("@plugin/types").ExocortexPluginInterface;
+
+  const reactRenderer = {
+    render: jest.fn(),
+    unmount: jest.fn(),
+  } as unknown as jest.Mocked<ReactRenderer>;
+
+  const backlinksCacheManager = {
+    getBacklinks: jest.fn().mockReturnValue(new Set([TASK_PATH])),
+  } as unknown as jest.Mocked<BacklinksCacheManager>;
+
+  // Real metadata service over the spec vault (resolves the task's label from the app).
+  const metadataService = new AssetMetadataService(app as never);
+
+  const taskFile = new TFile(TASK_PATH);
+  (taskFile as unknown as { stat: unknown }).stat = {
+    ctime: 1,
+    mtime: 2,
+    size: 0,
+  };
+  const areaFile = new TFile(AREA_PATH);
+
+  const vaultAdapter = {
+    getAbstractFileByPath: jest
+      .fn()
+      .mockImplementation((p: string) => (p === TASK_PATH ? taskFile : null)),
+    getFrontmatter: jest.fn().mockImplementation((f: IFile) => {
+      if (f.path === TASK_PATH) return taskFrontmatter;
+      if (f.path === AREA_PATH) {
+        return { exo__Asset_uid: "area-uid", exo__Asset_label: "My Area" };
+      }
+      return null;
+    }),
+  } as unknown as jest.Mocked<IVaultAdapter>;
+
+  const renderer = new RelationsRenderer(
+    app as never,
+    settings,
+    reactRenderer,
+    backlinksCacheManager,
+    metadataService,
+    plugin,
+    jest.fn(),
+    vaultAdapter,
+    // reified-relation deps omitted → getReifiedRelationsGated is a no-op (back-compat)
+  );
+
+  return renderer.getAssetRelations(areaFile as unknown as TFile, {});
+}
+
+describe("RelationsRenderer — homoiconic displayName in the layout relation/query tables (req 3f65eb4a)", () => {
+  // jest.config has resetMocks: true → re-establish the plumbing-stub return values each test.
+  beforeEach(() => {
+    const { MetadataHelpers } = require("@kitelev/exocortex-core");
+    MetadataHelpers.isAssetArchived.mockReturnValue(false);
+    MetadataHelpers.findAllReferencingProperties.mockReturnValue([
+      "ems__Effort_area",
+    ]);
+    const { BlockerHelpers } = require("@plugin/presentation/utils/BlockerHelpers");
+    BlockerHelpers.isEffortBlocked.mockReturnValue(false);
+  });
+
+  it("@req:3f65eb4a-c0df-41da-917e-3112de19b531 renders 🔄 for a UID-canon Doing task link via the vault exo__DisplayNameSpec (DisplayNameResolver + PrintNameRuleService), NOT a plain exo__Asset_label", async () => {
+    // Doing status stored UID-canon "[[<doing-uid>]]".
+    const relations = await getRelationsForTaskWithStatus(`[[${DOING_UID}]]`);
+    expect(relations).toHaveLength(1);
+
+    // The homoiconic name carries the vault-declared 🔄 prefix, resolved through the real stack.
+    expect(relations[0].displayName).toBe("🔄 Write the report");
+
+    // The final relation-table cell (what AssetRelationsTable / the exo__Layout query table
+    // renders) shows "🔄 <label>".
+    expect(getRelationDisplayLabel(relations[0])).toBe("🔄 Write the report");
+  });
+
+  it("@req:3f65eb4a-c0df-41da-917e-3112de19b531 shows the bare label when the linked task is NOT Doing (the conditional spec does not participate)", async () => {
+    const relations = await getRelationsForTaskWithStatus(`[[${BACKLOG_UID}]]`);
+    expect(relations).toHaveLength(1);
+    expect(relations[0].displayName).toBe("Write the report");
+    expect(getRelationDisplayLabel(relations[0])).toBe("Write the report");
+  });
+
+  it("@req:3f65eb4a-c0df-41da-917e-3112de19b531 resolves 🔄 for the [[<uid>|label]] status form too (dual-IRI)", async () => {
+    const relations = await getRelationsForTaskWithStatus(
+      `[[${DOING_UID}|ems__EffortStatusDoing]]`,
+    );
+    expect(getRelationDisplayLabel(relations[0])).toBe("🔄 Write the report");
+  });
+
+  it("@req:3f65eb4a-c0df-41da-917e-3112de19b531 sorts a Doing task by its UNPREFIXED label (the display 🔄 prefix must not collate rows by emoji)", async () => {
+    const relations = await getRelationsForTaskWithStatus(`[[${DOING_UID}]]`);
+    // Display carries the 🔄 prefix …
+    expect(getRelationDisplayLabel(relations[0])).toBe("🔄 Write the report");
+    // … but the SORT key is the plain label (no emoji-codepoint collation regression).
+    expect(getRelationSortLabel(relations[0])).toBe("Write the report");
+  });
+
+  it("@req:3f65eb4a-c0df-41da-917e-3112de19b531 falls back to the plain label when printNameRuleService is absent (no-regression guard)", async () => {
+    // No resolver on the plugin → the cell is byte-identical to the pre-3f65eb4a plain label.
+    const relations = await getRelationsForTaskWithStatus(`[[${DOING_UID}]]`, {
+      withResolver: false,
+    });
+    expect(relations).toHaveLength(1);
+    expect(getRelationDisplayLabel(relations[0])).toBe("Write the report");
+  });
+});


### PR DESCRIPTION
## What & why

Route the layout **relation / children / query table** task-link cell labels through the homoiconic `DisplayNameResolver` (over vault `exo__DisplayNameSpec` assets), so a Doing task's `🔄 ` prefix appears there consistently with native Obsidian links and the DailyNote tasks table — replacing the plain `exo__Asset_label` cell text. Sibling of req `a577316f` / PR #3862 (which did the DailyNote table). **Pure wiring** — the 12 `exo__DisplayNameSpec` vault assets already exist.

## Approach (single injection, mirrors the PR #3862 pattern)

`RelationsRenderer.getAssetRelations` computes `AssetRelation.displayName` **once** — via a `createDisplayNameResolver()` helper identical to `DailyTasksRenderer` (reads the already-exposed `plugin.printNameRuleService`). That one list feeds **both** consumers:

- `AssetRelationsTable` (Relations block) — `getRelationDisplayLabel` prefers `displayName`.
- `ExoLayoutRenderer` → `BacklinksTableBlockView` (exo__Layout backlinks/children/query table) — `resolveCell` prefers `row.displayName`.

`UniversalLayoutRenderer` is covered transitively (delegates to `RelationsRenderer`) — **zero constructor churn** on that hot file. Sort key uses the **unprefixed** label (`getRelationSortLabel`) so the 🔄 display prefix never collates rows by emoji codepoint.

**Null-safe / no-regression:** no `printNameRuleService` (unit-test mock) or no matching spec → `displayName` is `undefined` → both tables fall back to the plain `exo__Asset_label` / `title`, byte-identical to today. Non-task links (Area/Project/Concept) resolve through their own class spec or the default `{{exo__Asset_label}}` template = unchanged. The 🚩 blocked marker stays renderer-side (#3865).

## Revert-verified

Production-shape component test `RelationsRenderer.homoiconicDisplayName.test.ts` (`@req:3f65eb4a-c0df-41da-917e-3112de19b531`) drives the REAL `RelationsRenderer.getAssetRelations` over an in-memory vault carrying the real 🔄-Doing `exo__DisplayNameSpec` + parts → real `PrintNameRuleService.scanVault` → real `DisplayNameResolver` (no stubbed resolver, no hand-injected label — test-fixture-realism).

**Revert-verified:** removing the layout-renderer wiring (`displayName` no longer set → cell falls back to plain `exo__Asset_label`) makes the UID-canon Doing assertion **RED** (`🔄 Write the report` → `Write the report`); restoring makes it **GREEN** (ran RED first). The null-resolver fallback case correctly stays GREEN both ways (no-regression guard).

## Scope note

Covers `RelationsRenderer` + `UniversalLayoutRenderer` (relation/children/query tables via the shared `AssetRelation` row-label path). The separate `TableLayoutRenderer` configured-`exocortex`-code-block cell path (labels flow through the shared `wikilinkResolver.getAssetLabel` property-value resolver — a broader/distinct surface, not on this revert-verify axis, same shape the DailyNote sibling left untouched) is tracked as a follow-up: **#3870**.

## Verification

- `npm run check:types` clean; `npm run lint` clean; 3 CI `lint`-job guard scripts pass (antipattern ratchet 55/55).
- New suite 5/5 green; 103 existing tests across affected suites green; the release-gating `test-ui` `UniversalLayoutRenderer.ui.test.ts` (52) green.
- code-reviewer agent: 0 CRITICAL/HIGH; 2 MEDIUM applied (sort decoupling + this scope note/#3870), 1 LOW applied (guard the `exo__Asset_label` string cast).

Req: 3f65eb4a-c0df-41da-917e-3112de19b531

Closes #3863
