### PR TITLE
fix(cli): classes/describe-class NaN counts — read Literal.value not toString (#3859)

### DIFF
--- a/packages/cli/src/commands/classes.ts
+++ b/packages/cli/src/commands/classes.ts
@@ -156,6 +156,18 @@ function requireSelectRows(
   return result.rows;
 }
 
+/**
+ * Extract a numeric count from a COUNT-aggregate binding (#3859). The bound term
+ * is a typed `Literal` whose `.toString()` serialises as `"3093"^^<xsd:integer>`
+ * (parseInt-hostile — the leading quote yields NaN); `.value` is the lexical
+ * form `3093`. Falls back to 0 for a missing / non-numeric term.
+ */
+export function parseCount(term: unknown): number {
+  const v = (term as { value?: unknown } | null | undefined)?.value;
+  const n = typeof v === "string" ? parseInt(v, 10) : NaN;
+  return Number.isNaN(n) ? 0 : n;
+}
+
 async function listAllClasses(
   runner: NamedQueryRunner,
   options: ClassesCommandOptions,
@@ -169,7 +181,7 @@ async function listAllClasses(
     const countValue = row.get("count");
     return {
       name: classIri ? extractLocalName(classIri.toString()) : "unknown",
-      count: countValue ? parseInt(countValue.toString(), 10) : 0,
+      count: parseCount(countValue),
     };
   });
 
@@ -220,9 +232,7 @@ async function showClassDetails(
     INTROSPECT_CLASS_COUNT_QUERY_UID,
   );
   const instanceCount =
-    countRows.length > 0
-      ? parseInt(countRows[0].get("count")?.toString() || "0", 10)
-      : 0;
+    countRows.length > 0 ? parseCount(countRows[0].get("count")) : 0;
 
   const propsResult = await runner.run(
     INTROSPECT_CLASS_PROPERTIES_QUERY_UID,
@@ -238,7 +248,7 @@ async function showClassDetails(
     const usageValue = row.get("usageCount");
     return {
       name: propIri ? extractLocalName(propIri.toString()) : "unknown",
-      usageCount: usageValue ? parseInt(usageValue.toString(), 10) : 0,
+      usageCount: parseCount(usageValue),
     };
   });
 

--- a/packages/cli/tests/unit/commands/classes.test.ts
+++ b/packages/cli/tests/unit/commands/classes.test.ts
@@ -71,7 +71,7 @@ jest.unstable_mockModule("../../../src/services/NamedQueryCliRunner.js", () => (
 }));
 
 // Import the classes command after mocking
-const { classesCommand } = await import("../../../src/commands/classes.js");
+const { classesCommand, parseCount } = await import("../../../src/commands/classes.js");
 
 describe("classesCommand", () => {
   let consoleLogSpy: jest.SpiedFunction<typeof console.log>;
@@ -185,5 +185,29 @@ describe("classesCommand", () => {
 
       expect(consoleLogSpy).toHaveBeenCalled();
     });
+  });
+});
+
+// #3859 — classes/describe-class rendered NaN instance counts because the
+// COUNT-aggregate binding is a typed Literal whose `.toString()` serialises as
+// `"3093"^^<xsd:integer>` (parseInt-hostile). parseCount reads `.value` (the
+// lexical form) instead. Revert-verify: swap `.value`→`.toString()` in
+// parseCount and this suite goes RED (3093 → NaN).
+describe("parseCount (#3859 typed-literal COUNT)", () => {
+  // Mimics a core Literal: `.value` = lexical form; `.toString()` = the
+  // parseInt-hostile serialisation the real term produces.
+  const typedIntLiteral = {
+    value: "3093",
+    toString: () => '"3093"^^<http://www.w3.org/2001/XMLSchema#integer>',
+  };
+
+  it("extracts the lexical numeric value (3093, not NaN) from a typed integer Literal", () => {
+    expect(parseCount(typedIntLiteral)).toBe(3093);
+  });
+
+  it("falls back to 0 for a missing / non-numeric term", () => {
+    expect(parseCount(undefined)).toBe(0);
+    expect(parseCount(null)).toBe(0);
+    expect(parseCount({ value: "not-a-number" })).toBe(0);
   });
 });


### PR DESCRIPTION
## Bug (Closes #3859)

`exocortex classes` and `describe-class <class>` render **`NaN`** for every instance/usage count.

## Root cause

The COUNT-aggregate binding is a typed `Literal` whose `.toString()` serialises as `"3093"^^<http://www.w3.org/2001/XMLSchema#integer>` — the leading quote makes `parseInt(term.toString(), 10)` return `NaN`. The `Literal.value` accessor is the lexical form `3093`.

## Fix

New `parseCount(term)` helper reads `.value` (matching the `find.ts`/`apply.ts` term-value pattern) and guards missing/non-numeric → 0. Applied at all **3** sites: list-classes count, describe-class instance-count, property usage-count.

## Verification

- New `parseCount (#3859 typed-literal COUNT)` unit suite (a stub mimicking a core Literal: `.value` lexical + `.toString()` the parseInt-hostile form).
- **Revert-verified locally:** swapping `.value`→`.toString()` reds the suite (`Expected 3093, Received 0`); restoring → GREEN (11 passed).
- Bug-fix (feature-sdd Step 0 exempt); behaviour-restoring, no new requirement.

https://claude.ai/code/session_01LzX9NekNcwGuBjWUw2mCGr