### PR TITLE
feat(layout): homoiconic displayName in configured exocortex code-block query tables (#3870)

### DIFF
--- a/packages/obsidian-plugin/src/application/processors/LayoutCodeBlockProcessor.ts
+++ b/packages/obsidian-plugin/src/application/processors/LayoutCodeBlockProcessor.ts
@@ -18,7 +18,7 @@
 
 import React from "react";
 import type { MarkdownPostProcessorContext, EventRef } from "obsidian";
-import { MarkdownRenderChild } from "obsidian";
+import { MarkdownRenderChild, TFile } from "obsidian";
 import type ExocortexPlugin from "@plugin/ExocortexPlugin";
 import { LayoutService } from "../layout";
 import type { LayoutRenderResult } from "../layout";
@@ -26,6 +26,8 @@ import { ReactRenderer } from "@plugin/presentation/utils/ReactRenderer";
 import { LoggerFactory } from "@plugin/adapters/logging/LoggerFactory";
 import { TableLayoutRenderer } from "@plugin/presentation/renderers/TableLayoutRenderer";
 import { WikilinkLabelResolver } from "@plugin/presentation/utils/WikilinkLabelResolver";
+import { DisplayNameResolver } from "@plugin/domain/display-name/DisplayNameResolver";
+import { DEFAULT_DISPLAY_NAME_SETTINGS } from "@plugin/domain/settings/ExocortexSettings";
 import type { TableLayout } from "@plugin/domain/layout";
 import { isTableLayout } from "@plugin/domain/layout";
 
@@ -405,7 +407,19 @@ export class LayoutCodeBlockProcessor {
             newValue as import("@plugin/presentation/renderers/cell-renderers").CellValue
           );
         },
-        getAssetLabel: (path: string) => this.wikilinkResolver.getAssetLabel(path),
+        // req `71cc75f3` — route every cell wikilink label through the homoiconic
+        // displayName system (the SAME `exo__DisplayNameSpec` stack as native links, the
+        // DailyNote table a577316f and the relation/query tables 3f65eb4a) BEFORE the plain
+        // resolver, so a status/class-conditional prefix (🔄 for a Doing ems__Task, …) that
+        // the user declared as vault data appears in configured `exocortex` code-block tables
+        // too — consistently with those other surfaces. Null-safe: no resolver / no file /
+        // labelless path → the plain `getAssetLabel`. For a class whose displayName template
+        // equals the plain label (the common case) the output is byte-identical to today; a
+        // class WITH its own template (prototype suffix, pn__DailyNote basename) intentionally
+        // adopts the SAME template already shown on native links / the other tables.
+        getAssetLabel: (path: string) =>
+          this.resolveHomoiconicDisplayName(path) ??
+          this.wikilinkResolver.getAssetLabel(path),
         // Gate action buttons by their `exo__Precondition_sparql` ASK (#3654
         // Part 1): true ⇒ shown, false ⇒ hidden. Previously unwired → every
         // button defaulted visible. The ASK boolean is surfaced via the new
@@ -428,6 +442,67 @@ export class LayoutCodeBlockProcessor {
         },
       })
     );
+  }
+
+  /**
+   * req `71cc75f3` — resolve a cell wikilink's display label through the homoiconic
+   * `exo__DisplayNameSpec` system, the SAME `DisplayNameResolver` + `PrintNameRuleService`
+   * stack native links, the DailyNote tasks table (a577316f) and the layout relation/query
+   * tables (3f65eb4a) use. Reads the linked asset's real frontmatter (instance class + status)
+   * so a conditional spec (matchPath/matchValue, req ed4201d1) is evaluated per-render.
+   *
+   * Returns `null` — so the caller falls through to the plain `wikilinkResolver.getAssetLabel`
+   * — when there is NO resolver (`printNameRuleService` absent, e.g. a unit-test mock), the
+   * path resolves to no file, the file has no frontmatter, OR the asset is labelless (kept null
+   * so no basename substitution leaks into the general property-value cell path). A class with
+   * no applicable spec renders the default `{{exo__Asset_label}}` template = the plain label
+   * (byte-identical); a class WITH a `classTemplates` entry (prototype suffix, pn__DailyNote
+   * basename) renders that template — the SAME one native links and the other tables already
+   * apply — so this surface stays consistent with them.
+   */
+  private resolveHomoiconicDisplayName(path: string): string | null {
+    const ruleService = this.plugin.printNameRuleService;
+    if (!ruleService) {
+      return null;
+    }
+
+    const file = this.resolveLinkedFile(path);
+    if (!file) {
+      return null;
+    }
+
+    const metadata =
+      this.plugin.app.metadataCache.getFileCache(file)?.frontmatter;
+    if (!metadata) {
+      return null;
+    }
+
+    // Labelless asset → the plain resolver returns null today; preserve that (do NOT
+    // substitute a basename) by falling through to the plain getAssetLabel.
+    if (this.wikilinkResolver.getAssetLabel(path) === null) {
+      return null;
+    }
+
+    const settings =
+      this.plugin.settings?.displayNameSettings ?? DEFAULT_DISPLAY_NAME_SETTINGS;
+    const metadataResolver = ruleService.createMetadataResolver();
+    const resolver = new DisplayNameResolver(settings, ruleService, metadataResolver);
+
+    const resolved = resolver.resolve({ metadata, basename: file.basename });
+    return typeof resolved === "string" && resolved.trim() !== "" ? resolved : null;
+  }
+
+  /**
+   * Resolve a wikilink path to its `TFile` the SAME way `WikilinkLabelResolver.getAssetLabel`
+   * does (linkpath dest + a `.md` retry), so the homoiconic resolver reads the exact same
+   * target file as the plain fallback.
+   */
+  private resolveLinkedFile(path: string): TFile | null {
+    let file = this.plugin.app.metadataCache.getFirstLinkpathDest(path, "");
+    if (!file && !path.endsWith(".md")) {
+      file = this.plugin.app.metadataCache.getFirstLinkpathDest(path + ".md", "");
+    }
+    return file instanceof TFile ? file : null;
   }
 
   /**

--- a/packages/obsidian-plugin/tests/unit/application/processors/LayoutCodeBlockProcessor.homoiconicDisplayName.test.ts
+++ b/packages/obsidian-plugin/tests/unit/application/processors/LayoutCodeBlockProcessor.homoiconicDisplayName.test.ts
@@ -1,0 +1,294 @@
+import { TFile } from "obsidian";
+import type { App, CachedMetadata } from "obsidian";
+import type React from "react";
+import { LayoutCodeBlockProcessor } from "@plugin/application/processors/LayoutCodeBlockProcessor";
+import { PrintNameRuleService } from "@plugin/domain/display-name/PrintNameRuleService";
+import { DEFAULT_DISPLAY_NAME_SETTINGS } from "@plugin/domain/settings/ExocortexSettings";
+import type ExocortexPlugin from "@plugin/ExocortexPlugin";
+import type { ReactRenderer } from "@plugin/presentation/utils/ReactRenderer";
+import type { TableLayout } from "@plugin/domain/layout";
+
+jest.mock("obsidian", () => {
+  class MockTFile {
+    path = "";
+    name = "";
+    basename = "";
+    extension = "";
+    parent: unknown = null;
+    vault: unknown = null;
+    stat: unknown = null;
+    constructor(path?: string) {
+      if (path) {
+        this.path = path;
+        this.basename = path.replace(/\.md$/, "");
+        this.name = this.basename + ".md";
+        this.extension = "md";
+      }
+    }
+  }
+  class MockMarkdownRenderChild {
+    constructor(public containerEl: unknown) {}
+    onload(): void {}
+    onunload(): void {}
+  }
+  return {
+    ...jest.requireActual("obsidian"),
+    TFile: MockTFile,
+    MarkdownRenderChild: MockMarkdownRenderChild,
+  };
+});
+
+// Canonical UIDs (verified in-vault; identical to the a577316f DailyNote + 3f65eb4a relation binding tests).
+const TASK_UID = "1b20a8f0-d745-4e93-91db-4531b3df120e";
+const DOING_UID = "027e78f4-6e16-4b36-b8fb-5510507d5745";
+const BACKLOG_UID = "753a44d5-846c-4b82-9196-4fd9a4d48777";
+const SPEC_UID = "d069c316-fcd3-4c25-8f24-3109382b72cf";
+
+const TASK_PATH = "doing-task.md";
+const TASK_LABEL = "Write the report";
+const PROJECT_PATH = "some-project.md";
+const PROJECT_LABEL = "Ship the plugin";
+const LABELLESS_PATH = "labelless-note.md";
+
+/**
+ * In-memory vault app exposing the SAME surface PrintNameRuleService.scanVault reads
+ * (getMarkdownFiles + getFileCache + getFirstLinkpathDest) AND the surface the cell
+ * label resolver reads (getFileCache + getFirstLinkpathDest). Carries the REAL 🔄-Doing
+ * exo__DisplayNameSpec (d069c316) + its two parts — production-shape, no hand-injected
+ * template, no stubbed resolver (test-fixture-realism).
+ */
+function createSpecVaultApp(
+  files: Array<{ path: string; frontmatter: Record<string, unknown> }>,
+): App {
+  const fileCache = new Map<string, CachedMetadata>();
+  const mockFiles: TFile[] = [];
+  for (const f of files) {
+    const tfile = new TFile(f.path);
+    mockFiles.push(tfile);
+    fileCache.set(f.path, { frontmatter: f.frontmatter } as CachedMetadata);
+  }
+  return {
+    vault: { getMarkdownFiles: jest.fn().mockReturnValue(mockFiles) },
+    metadataCache: {
+      on: jest.fn().mockReturnValue({ id: "test-event-ref" }),
+      offref: jest.fn(),
+      getFileCache: jest
+        .fn()
+        .mockImplementation((file: TFile) => fileCache.get(file.path) ?? null),
+      getFirstLinkpathDest: jest.fn().mockImplementation((path: string) => {
+        const clean = path.endsWith(".md") ? path : path + ".md";
+        return mockFiles.find((f) => f.path === clean) ?? null;
+      }),
+    },
+    workspace: {
+      openLinkText: jest.fn(),
+    },
+  } as unknown as App;
+}
+
+/** The real 🔄-Doing spec (d069c316) + PrintedLiteral "🔄 " + PrintedProperty exo__Asset_label. */
+function specParts(): Array<{ path: string; frontmatter: Record<string, unknown> }> {
+  return [
+    {
+      path: `${SPEC_UID}.md`,
+      frontmatter: {
+        exo__Asset_uid: SPEC_UID,
+        exo__Instance_class: [
+          "[[07eab746-0874-4676-9d98-dbaad1bc6fb8|exo__DisplayNameSpec]]",
+        ],
+        exo__DisplayNameSpec_appliesToClass: `[[${TASK_UID}|ems__Task]]`,
+        exo__DisplayNameSpec_priority: 100,
+        exo__DisplayNameSpec_matchPath:
+          "[[44c6e9e3-955f-4afc-9ca5-b4bd70667051|ems__Effort_status]]",
+        exo__DisplayNameSpec_matchValue: `[[${DOING_UID}|ems__EffortStatusDoing]]`,
+        exo__Asset_label: "displayName spec — ems__Task 🔄 while Doing",
+      },
+    },
+    {
+      path: "spec-literal.md",
+      frontmatter: {
+        exo__Asset_uid: "spec-literal",
+        exo__Instance_class: [
+          "[[4d5437c9-788e-4a6d-9be0-4af3a84554f4|exo__PrintedLiteral]]",
+        ],
+        exo__DisplayNamePart_of: `[[${SPEC_UID}]]`,
+        exo__DisplayNamePart_order: 0,
+        exo__PrintedLiteral_literal: "🔄 ",
+      },
+    },
+    {
+      path: "spec-property.md",
+      frontmatter: {
+        exo__Asset_uid: "spec-property",
+        exo__Instance_class: [
+          "[[7d58de40-d941-4a66-88e2-13afc4fdc41d|exo__PrintedProperty]]",
+        ],
+        exo__DisplayNamePart_of: `[[${SPEC_UID}]]`,
+        exo__DisplayNamePart_order: 1,
+        exo__PrintedProperty_property:
+          "[[12a6151b-801f-4be2-bd6e-a787eedd56ae|exo__Asset_label]]",
+      },
+    },
+  ];
+}
+
+/** A code-block cell links to a Task with `statusValue`; the vault also carries a non-Task
+ * asset (Project, no applicable spec) and a labelless note, to guard the no-regression path. */
+function vaultFiles(
+  statusValue: string,
+): Array<{ path: string; frontmatter: Record<string, unknown> }> {
+  return [
+    ...specParts(),
+    {
+      path: TASK_PATH,
+      frontmatter: {
+        exo__Instance_class: [`[[${TASK_UID}]]`], // UID-canon — the form that broke a naive strip
+        ems__Effort_status: statusValue,
+        exo__Asset_label: TASK_LABEL,
+      },
+    },
+    {
+      path: PROJECT_PATH,
+      frontmatter: {
+        exo__Instance_class: ["[[7db5eeff-718a-49b0-8d2b-39b084a356e3|ems__Project]]"],
+        ems__Effort_status: `[[${DOING_UID}]]`, // Doing, but NO spec applies to ems__Project
+        exo__Asset_label: PROJECT_LABEL,
+      },
+    },
+    {
+      path: LABELLESS_PATH,
+      frontmatter: {
+        exo__Instance_class: [`[[${TASK_UID}]]`],
+        ems__Effort_status: `[[${DOING_UID}]]`,
+        // no exo__Asset_label
+      },
+    },
+  ];
+}
+
+/**
+ * Build a production-shape LayoutCodeBlockProcessor over an in-memory vault carrying the real
+ * spec, with a REAL PrintNameRuleService compiled from that vault (or absent), then capture the
+ * exact `getAssetLabel` cell resolver the processor passes to TableLayoutRenderer and return it.
+ * This is the real code-block-table cell-label path — no hand-injected label, no stubbed resolver.
+ */
+function captureCellLabelResolver(
+  statusValue: string,
+  opts: { withResolver?: boolean } = {},
+): {
+  getCellLabel: (path: string) => string | null;
+  cleanup: () => void;
+} {
+  const withResolver = opts.withResolver ?? true;
+  const app = createSpecVaultApp(vaultFiles(statusValue));
+
+  let printNameRuleService: PrintNameRuleService | undefined;
+  if (withResolver) {
+    printNameRuleService = new PrintNameRuleService(app);
+    printNameRuleService.initialize(); // real scanVault — compiles the vault spec
+  }
+
+  const plugin = {
+    app,
+    settings: { displayNameSettings: DEFAULT_DISPLAY_NAME_SETTINGS },
+    printNameRuleService, // undefined in the null-resolver scenario
+    notifier: { error: jest.fn() },
+  } as unknown as ExocortexPlugin;
+
+  const processor = new LayoutCodeBlockProcessor(plugin);
+
+  // Capture the getAssetLabel callback the processor passes to TableLayoutRenderer.
+  let captured: ((path: string) => string | null) | undefined;
+  jest
+    .spyOn(
+      (processor as unknown as { reactRenderer: ReactRenderer }).reactRenderer,
+      "render",
+    )
+    .mockImplementation((_container: HTMLElement, component: React.ReactElement) => {
+      captured = (
+        component as unknown as {
+          props: { getAssetLabel: (path: string) => string | null };
+        }
+      ).props.getAssetLabel;
+    });
+
+  const layout = { columns: [] } as unknown as TableLayout;
+  (
+    processor as unknown as {
+      renderTableLayout: (l: TableLayout, r: unknown[], c: HTMLElement) => void;
+    }
+  ).renderTableLayout(layout, [], document.createElement("div"));
+
+  if (!captured) {
+    throw new Error("getAssetLabel cell resolver was not captured");
+  }
+
+  return {
+    getCellLabel: captured,
+    cleanup: () => processor.cleanup(),
+  };
+}
+
+describe("LayoutCodeBlockProcessor — homoiconic displayName in configured exocortex code-block query tables (req 71cc75f3)", () => {
+  it("@req:71cc75f3-fc88-4193-b6ab-2a4d2c323a0b renders 🔄 for a UID-canon Doing task-link cell via the vault exo__DisplayNameSpec (DisplayNameResolver + PrintNameRuleService), NOT a plain exo__Asset_label", () => {
+    const { getCellLabel, cleanup } = captureCellLabelResolver(`[[${DOING_UID}]]`);
+    try {
+      // The homoiconic name carries the vault-declared 🔄 prefix, resolved through the real stack.
+      expect(getCellLabel(TASK_PATH)).toBe("🔄 Write the report");
+    } finally {
+      cleanup();
+    }
+  });
+
+  it("@req:71cc75f3-fc88-4193-b6ab-2a4d2c323a0b resolves 🔄 for the [[<uid>|label]] status form too (dual-IRI)", () => {
+    const { getCellLabel, cleanup } = captureCellLabelResolver(
+      `[[${DOING_UID}|ems__EffortStatusDoing]]`,
+    );
+    try {
+      expect(getCellLabel(TASK_PATH)).toBe("🔄 Write the report");
+    } finally {
+      cleanup();
+    }
+  });
+
+  it("@req:71cc75f3-fc88-4193-b6ab-2a4d2c323a0b shows the bare label when the linked task is NOT Doing (the conditional spec does not participate)", () => {
+    const { getCellLabel, cleanup } = captureCellLabelResolver(`[[${BACKLOG_UID}]]`);
+    try {
+      expect(getCellLabel(TASK_PATH)).toBe("Write the report");
+    } finally {
+      cleanup();
+    }
+  });
+
+  it("@req:71cc75f3-fc88-4193-b6ab-2a4d2c323a0b leaves a non-matching-class cell (Project, no applicable spec) byte-identical to the plain label", () => {
+    const { getCellLabel, cleanup } = captureCellLabelResolver(`[[${DOING_UID}]]`);
+    try {
+      // A general property-value wikilink cell that is NOT a Doing ems__Task → unchanged.
+      expect(getCellLabel(PROJECT_PATH)).toBe(PROJECT_LABEL);
+    } finally {
+      cleanup();
+    }
+  });
+
+  it("@req:71cc75f3-fc88-4193-b6ab-2a4d2c323a0b falls through to the plain resolver (null) for a labelless asset — no basename substitution regression", () => {
+    const { getCellLabel, cleanup } = captureCellLabelResolver(`[[${DOING_UID}]]`);
+    try {
+      // getAssetLabel returns null today for a labelless asset; the wrapper must keep that.
+      expect(getCellLabel(LABELLESS_PATH)).toBeNull();
+    } finally {
+      cleanup();
+    }
+  });
+
+  it("@req:71cc75f3-fc88-4193-b6ab-2a4d2c323a0b falls back to the plain label when printNameRuleService is absent (no-regression guard)", () => {
+    // No resolver on the plugin → the cell is byte-identical to the pre-71cc75f3 plain label.
+    const { getCellLabel, cleanup } = captureCellLabelResolver(`[[${DOING_UID}]]`, {
+      withResolver: false,
+    });
+    try {
+      expect(getCellLabel(TASK_PATH)).toBe("Write the report");
+    } finally {
+      cleanup();
+    }
+  });
+});


### PR DESCRIPTION
## What

Third and final surface of the homoiconic-displayName line (after `a577316f`/#3862 DailyNote table, `3f65eb4a`/#3871 relation/query tables). Routes the per-cell `getAssetLabel` label resolver in configured `exocortex` **code-block** `TableLayout` tables (`LayoutCodeBlockProcessor.renderTableLayout`, the `getAssetLabel` prop passed to `TableLayoutRenderer`) through the vault `exo__DisplayNameSpec` `DisplayNameResolver` + `PrintNameRuleService` stack — the SAME homoiconic system as native links and the two sibling tables.

Consequence: a Doing `ems__Task` link in a user-authored `exocortex` code-block query table now shows **`🔄 <label>`** (driven by the per-render conditional matcher spec `d069c316`, req `ed4201d1`), consistently with every other Exocortex surface. After this, ALL task-link render surfaces are homoiconic. Closes #3870.

## How

`getAssetLabel: (path) => this.resolveHomoiconicDisplayName(path) ?? this.wikilinkResolver.getAssetLabel(path)`.

`resolveHomoiconicDisplayName` builds a `DisplayNameResolver` from `plugin.printNameRuleService` + `plugin.settings.displayNameSettings` (identical construction to the siblings), fetches the linked file's real frontmatter via `metadataCache.getFileCache`, and resolves. **Null-safe fallback** to the plain `getAssetLabel` when there is no resolver / no file / no frontmatter / the asset is labelless — so the general property-value wikilink cell path is unchanged for non-task / non-matching cells (a class with no applicable spec renders the default `{{exo__Asset_label}}` = the plain label).

No vault authoring, no engine change — pure wiring (the 12 `exo__DisplayNameSpec` already exist). This is a **presentation/rendering** change (not parser/TBox/schema).

## Verify

- `Req: 71cc75f3-fc88-4193-b6ab-2a4d2c323a0b`
- Production-shape binding test `@req:71cc75f3-fc88-4193-b6ab-2a4d2c323a0b` (`LayoutCodeBlockProcessor.homoiconicDisplayName.test.ts`) — real `PrintNameRuleService.scanVault` over an in-memory vault carrying the real 🔄-Doing spec `d069c316` + its two parts, captures the ACTUAL `getAssetLabel` callback the processor passes to `TableLayoutRenderer`, no stubbed resolver, no hand-injected label.
- **Revert-verified:** reverting the `getAssetLabel` wrapper → the UID-canon Doing task-link cell loses the resolver-driven `🔄 ` → **2 assertions RED** (Doing + dual-IRI `[[uid|label]]`), the **4 no-regression assertions GREEN** (non-Doing, non-matching `ems__Project`, labelless→null, null-resolver); restore → **6/6 GREEN**.
- `npm run check:types` clean · `npm run lint` clean · 3 CI guard scripts pass (`check-test-antipatterns` 55/55 — behavior asserts, not method-exists) · 195 affected suites (`processors` + `renderers/{dailyTasks,layout}` + `domain/display-name`) green.
- `code-reviewer` agent: **APPROVE** (0 CRITICAL / 0 HIGH; 1 MEDIUM comment-accuracy applied, 2 LOW cosmetic accepted).

Out of scope (tracked): #3864 (first-instance-class multi-class), #3865 (computed 🚩 blocked marker).
