### PR TITLE
feat(#3867): composite step can opt in to mutate the created instance

### DIFF
--- a/packages/core/src/domain/models/CommandDefinition.ts
+++ b/packages/core/src/domain/models/CommandDefinition.ts
@@ -336,6 +336,29 @@ export interface GroundingDefinition {
    * (xsd:boolean — `true`/`false`; absent → not cloned).
    */
   readonly cloneTargetBody?: boolean;
+  /**
+   * Issue #3867 — opt-in composite-step target selector. When `true`, AND this
+   * grounding runs as a `composite` step AFTER a `create_instance` step in the
+   * same composite has produced an asset, `GroundingExecutor.executeComposite`
+   * runs this step against the CREATED asset's file (its `filePath` =
+   * `lastCreatedPath`) instead of the composite click-target. Only the step's
+   * `filePath` is re-pointed — `targetIRI` stays the click-target (so `$target`
+   * substitution still resolves to the source asset for link-back, and because
+   * the just-created asset is not yet indexed in the triple store).
+   *
+   * Absent/`false` (the default) → the step operates on the click-target
+   * exactly as today. Existing composites whose `property_set` steps
+   * intentionally close the CURRENT click-target (e.g. `ems__WaitingCheckTask`
+   * «Следующая итерация», grounding `a49471de-...`) are therefore unchanged —
+   * this is a zero-regression, opt-in addition. Threading is a no-op unless a
+   * `create_instance` step ran earlier in the same composite. It has no effect
+   * outside a composite (a top-level non-composite grounding has no
+   * `lastCreatedPath` context).
+   *
+   * Authored as the `exocmd__Grounding_targetsCreatedInstance` RDF triple
+   * (xsd:boolean — `true`/`false`; absent → click-target).
+   */
+  readonly targetsCreatedInstance?: boolean;
 }
 
 /**

--- a/packages/core/src/domain/models/GroundingFrontmatterParser.ts
+++ b/packages/core/src/domain/models/GroundingFrontmatterParser.ts
@@ -121,6 +121,13 @@ export function parseGroundingDefinitionFromFrontmatter(
   const cloneTargetBody =
     rawCloneTargetBody === true || rawCloneTargetBody === "true";
 
+  // Issue #3867 — composite-step opt-in: mutate the just-created instance
+  // instead of the click-target. Same boolean-tolerant coercion as
+  // `cloneTargetBody`. (Parity with CommandResolver — the production loader.)
+  const rawTargetsCreatedInstance = fm["exocmd__Grounding_targetsCreatedInstance"];
+  const targetsCreatedInstance =
+    rawTargetsCreatedInstance === true || rawTargetsCreatedInstance === "true";
+
   return {
     id: uid,
     label: (fm["exo__Asset_label"] as string) ?? "",
@@ -152,6 +159,7 @@ export function parseGroundingDefinitionFromFrontmatter(
     bodyTemplate: fm["exocmd__Grounding_bodyTemplate"] as string | undefined,
     templateRef,
     cloneTargetBody,
+    targetsCreatedInstance,
     steps,
   };
 }

--- a/packages/core/src/services/CommandResolver.ts
+++ b/packages/core/src/services/CommandResolver.ts
@@ -2022,6 +2022,19 @@ export class CommandResolver {
       cloneTargetBodyRaw !== null &&
       String(cloneTargetBodyRaw).trim().toLowerCase() === "true";
 
+    // Issue #3867 — composite-step opt-in: mutate the just-created instance
+    // instead of the click-target. Boolean coercion mirrors `cloneTargetBody`.
+    // MUST be read HERE (the production loader — plugin button + CLI both go
+    // through CommandResolver.loadCommand); the sibling GroundingFrontmatterParser
+    // has no production consumers.
+    const targetsCreatedInstanceRaw = await this.getLiteralValue(
+      subject,
+      Namespace.EXOCMD.term("Grounding_targetsCreatedInstance"),
+    );
+    const targetsCreatedInstance =
+      targetsCreatedInstanceRaw !== null &&
+      String(targetsCreatedInstanceRaw).trim().toLowerCase() === "true";
+
     const grounding: GroundingDefinition = {
       id: uid,
       label,
@@ -2050,6 +2063,7 @@ export class CommandResolver {
       bodyTemplate: bodyTemplate ?? undefined,
       templateRef: templateRef ?? undefined,
       cloneTargetBody: cloneTargetBody || undefined,
+      targetsCreatedInstance: targetsCreatedInstance || undefined,
     };
 
     if (inputSchema) {

--- a/packages/core/src/services/GroundingExecutor.ts
+++ b/packages/core/src/services/GroundingExecutor.ts
@@ -707,19 +707,32 @@ export class GroundingExecutor {
     const completedSteps: number[] = [];
 
     // Subproject 17f58ebe Веха 3 — track the most-recently-created asset's path
-    // so a later `body_template` step writes into THAT file (the created
-    // instance), not the composite click-target. Only `body_template` consumes
-    // this thread; every other step type keeps operating on `filePath`, so this
-    // is a zero-regression addition for existing composites.
+    // so a later step can write into THAT file (the created instance), not the
+    // composite click-target.
+    //
+    // Two step kinds consume this thread (Issue #3867 extended it from the
+    // original `body_template`-only form):
+    //   1. `body_template` steps — ALWAYS thread (unchanged from Веха 3).
+    //   2. any step that opts in via `exocmd__Grounding_targetsCreatedInstance`
+    //      (Issue #3867) — e.g. a `property_set` in a `[create_instance,
+    //      property_set]` composite that mutates the NEW asset (create task +
+    //      move-to-backlog). Opt-in ⇒ default (flag absent) keeps operating on
+    //      `filePath`, so existing composites are unchanged.
+    // Both are gated on `lastCreatedPath` being set (a prior create_instance
+    // step ran); with no create_instance, the step targets the click-target
+    // exactly as before — a zero-regression addition. `targetIRI` is
+    // intentionally NOT re-pointed: `$target` still resolves to the source
+    // asset (link-back), and the just-created asset is not yet in the store.
     let lastCreatedPath: string | undefined;
 
     try {
       for (let i = 0; i < steps.length; i++) {
         const step = steps[i];
+        const stepUsesCreatedPath =
+          step.type === GroundingType.BODY_TEMPLATE ||
+          step.targetsCreatedInstance === true;
         const stepPath =
-          step.type === GroundingType.BODY_TEMPLATE && lastCreatedPath
-            ? lastCreatedPath
-            : filePath;
+          stepUsesCreatedPath && lastCreatedPath ? lastCreatedPath : filePath;
         const result = await this.executeStep(
           step,
           targetIRI,

--- a/packages/core/tests/unit/services/GroundingExecutor.targetsCreatedInstance.test.ts
+++ b/packages/core/tests/unit/services/GroundingExecutor.targetsCreatedInstance.test.ts
@@ -1,0 +1,204 @@
+/**
+ * Unit tests — GroundingExecutor composite-step `targetsCreatedInstance` opt-in
+ * (Issue #3867 / req b00acde4-e796-4bb0-8136-8bac8ca9cf9e).
+ *
+ * A composite `[create_instance, property_set]` can now mutate the NEWLY-created
+ * asset from the property_set step by opting in via
+ * `exocmd__Grounding_targetsCreatedInstance: true` on that step. This is the
+ * general form of the pre-existing `body_template`-only threading (Веха 3): the
+ * created asset's path (`lastCreatedPath`, from the create_instance step's
+ * openPath) is passed to the opted-in step as its `filePath`, so the mutation
+ * lands in the created file, not the composite click-target.
+ *
+ * Opt-in ⇒ zero-regression: with the flag absent the step operates on the
+ * click-target exactly as before (the ems__WaitingCheckTask «Следующая
+ * итерация» composite depends on this default).
+ *
+ * Production-shape: drives the real GroundingExecutor.executeComposite over a
+ * real create_instance step + a real property_set step, with an in-memory fs
+ * honouring the read-after-write contract (no hand-injected create result).
+ */
+
+import {
+  GroundingExecutor,
+  ServiceRegistry,
+} from "../../../src/services/GroundingExecutor";
+import {
+  clearResolvers,
+  installDefaultResolvers,
+} from "../../../src/services/SubstitutionResolverRegistry";
+import { GroundingType } from "../../../src/domain/constants/GroundingType";
+import { GroundingDefinition } from "../../../src/domain/models/CommandDefinition";
+
+/** In-memory fs that honours read-after-write (mirrors the real contract). */
+function makeFs(seed: Record<string, string> = {}) {
+  const files = new Map<string, string>(Object.entries(seed));
+  const reader = {
+    readFile: jest.fn(async (path: string) => {
+      if (!files.has(path)) throw new Error(`ENOENT: ${path}`);
+      return files.get(path) as string;
+    }),
+    fileExists: jest.fn(async (path: string) => files.has(path)),
+    getMarkdownFiles: jest.fn().mockResolvedValue([]),
+  };
+  const writer = {
+    createFile: jest.fn(async (path: string, content: string) => {
+      files.set(path, content);
+      return "";
+    }),
+    updateFile: jest.fn(async (path: string, content: string) => {
+      files.set(path, content);
+    }),
+    writeFile: jest.fn(async (path: string, content: string) => {
+      files.set(path, content);
+    }),
+    deleteFile: jest.fn(async (path: string) => {
+      files.delete(path);
+    }),
+    renameFile: jest.fn().mockResolvedValue(undefined),
+  };
+  return { files, reader, writer };
+}
+
+function gnd(overrides: Record<string, unknown>): GroundingDefinition {
+  return {
+    id: "gnd-tci",
+    label: "targets-created-instance",
+    ...overrides,
+  } as unknown as GroundingDefinition;
+}
+
+const CLICK_TARGET_IRI = "https://exocortex.my/assets/proto-123";
+const CLICK_TARGET_PATH = "/vault/protos/proto-123.md";
+const CLICK_TARGET_SEED =
+  "---\nexo__Asset_uid: proto-123\nexo__Asset_label: Task Prototype\n---\nProto body";
+
+/** Status value the property_set writes — the concrete "move to backlog" case. */
+const BACKLOG_VALUE =
+  '"[[753a44d5-846c-4b82-9196-4fd9a4d48777|ems__EffortStatusBacklog]]"';
+
+function createInstanceStep(): GroundingDefinition {
+  return gnd({
+    id: "step-create",
+    type: GroundingType.CREATE_INSTANCE,
+    targetClass: "ems__Task",
+    targetFolder: "/vault/tasks",
+  });
+}
+
+function moveToBacklogStep(opts: {
+  targetsCreatedInstance?: boolean;
+}): GroundingDefinition {
+  return gnd({
+    id: "step-move-backlog",
+    type: GroundingType.PROPERTY_SET,
+    targetProperty: "ems__Effort_status",
+    targetValueLiteral: BACKLOG_VALUE,
+    ...(opts.targetsCreatedInstance
+      ? { targetsCreatedInstance: true }
+      : {}),
+  });
+}
+
+/** Find the single created task file (the only non-click-target entry). */
+function findCreatedFile(files: Map<string, string>): [string, string] {
+  const created = [...files.entries()].find(
+    ([p]) => p.startsWith("/vault/tasks/") && p !== CLICK_TARGET_PATH,
+  );
+  expect(created).toBeDefined();
+  return created as [string, string];
+}
+
+describe("GroundingExecutor — composite targetsCreatedInstance (Issue #3867)", () => {
+  beforeEach(() => {
+    clearResolvers();
+    installDefaultResolvers();
+  });
+
+  it("opts in: a property_set step with targetsCreatedInstance mutates the CREATED asset, not the click-target @req:b00acde4-e796-4bb0-8136-8bac8ca9cf9e", async () => {
+    const { files, reader, writer } = makeFs({
+      [CLICK_TARGET_PATH]: CLICK_TARGET_SEED,
+    });
+    const exec = new GroundingExecutor(reader, writer, new ServiceRegistry());
+
+    const composite = gnd({
+      type: GroundingType.COMPOSITE,
+      steps: [
+        createInstanceStep(),
+        moveToBacklogStep({ targetsCreatedInstance: true }),
+      ],
+    });
+
+    const res = await exec.execute(
+      composite,
+      CLICK_TARGET_IRI,
+      CLICK_TARGET_PATH,
+    );
+    expect(res.success).toBe(true);
+
+    // The property landed in the CREATED task file.
+    const [, createdContent] = findCreatedFile(files);
+    expect(createdContent).toContain("ems__Effort_status");
+    expect(createdContent).toContain("ems__EffortStatusBacklog");
+
+    // The click-target (prototype) was NOT touched by the property_set step.
+    const clickTarget = files.get(CLICK_TARGET_PATH) as string;
+    expect(clickTarget).not.toContain("ems__Effort_status");
+    expect(clickTarget).toContain("Proto body");
+  });
+
+  it("default (no flag): a property_set step mutates the CLICK-TARGET — the backward-compat behavior WaitingCheckTask «Следующая итерация» relies on @req:b00acde4-e796-4bb0-8136-8bac8ca9cf9e", async () => {
+    const { files, reader, writer } = makeFs({
+      [CLICK_TARGET_PATH]: CLICK_TARGET_SEED,
+    });
+    const exec = new GroundingExecutor(reader, writer, new ServiceRegistry());
+
+    const composite = gnd({
+      type: GroundingType.COMPOSITE,
+      steps: [
+        createInstanceStep(),
+        moveToBacklogStep({ targetsCreatedInstance: false }),
+      ],
+    });
+
+    const res = await exec.execute(
+      composite,
+      CLICK_TARGET_IRI,
+      CLICK_TARGET_PATH,
+    );
+    expect(res.success).toBe(true);
+
+    // The property landed in the CLICK-TARGET (unchanged default).
+    const clickTarget = files.get(CLICK_TARGET_PATH) as string;
+    expect(clickTarget).toContain("ems__Effort_status");
+    expect(clickTarget).toContain("ems__EffortStatusBacklog");
+
+    // The created task file did NOT receive the property.
+    const [, createdContent] = findCreatedFile(files);
+    expect(createdContent).not.toContain("ems__Effort_status");
+  });
+
+  it("no-op without a create_instance: targetsCreatedInstance falls back to the click-target when no asset was created", async () => {
+    const { files, reader, writer } = makeFs({
+      [CLICK_TARGET_PATH]: CLICK_TARGET_SEED,
+    });
+    const exec = new GroundingExecutor(reader, writer, new ServiceRegistry());
+
+    // A composite whose only step opts in, but with NO prior create_instance:
+    // lastCreatedPath is undefined → the step must target the click-target.
+    const composite = gnd({
+      type: GroundingType.COMPOSITE,
+      steps: [moveToBacklogStep({ targetsCreatedInstance: true })],
+    });
+
+    const res = await exec.execute(
+      composite,
+      CLICK_TARGET_IRI,
+      CLICK_TARGET_PATH,
+    );
+    expect(res.success).toBe(true);
+
+    const clickTarget = files.get(CLICK_TARGET_PATH) as string;
+    expect(clickTarget).toContain("ems__Effort_status");
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #3867. A `composite` grounding step can now **opt in** to mutate the
most-recently-**created** asset instead of the composite click-target, via a new
per-step boolean flag `exocmd__Grounding_targetsCreatedInstance: true`.

This generalises the pre-existing `body_template`-only threading (Веха 3): the
created asset's path (`lastCreatedPath`, from a `create_instance` step's
`openPath`) is now also passed to any **opted-in** step. That unblocks composing
`[create_instance, property_set]` to create-and-immediately-mutate a new asset —
e.g. reuse the existing `move-to-backlog` `property_set` so a created task lands
directly in `ems__Effort_status = Backlog`, instead of duplicating the status
literal into a bespoke `create_instance` `propertyDefault`.

## Design (opt-in, backward-safe)

- **Selector:** a per-step boolean flag (matches the established
  `cloneTargetBody` / `prefillLabelWithDate` / `direction` flag precedent), NOT a
  new `$created` substitution token (there is no existing "target-file-as-token"
  slot — the target file is implicit).
- **filePath-only threading:** only the step's `filePath` is re-pointed to the
  created asset. `targetIRI` **stays the click-target**, so `$target` still
  resolves to the source asset (useful for link-back), and because the
  just-created asset is not yet indexed in the triple store (re-pointing
  `targetIRI` would be useless for query/workflow steps anyway).
- **Zero regression:** flag absent/`false` (the default) → the step operates on
  the click-target exactly as today. Threading is a no-op unless a
  `create_instance` step ran earlier in the same composite. Existing composites
  whose `property_set` steps intentionally close the CURRENT click-target
  (`ems__WaitingCheckTask` «Следующая итерация», grounding `a49471de-...`) are
  unchanged. `body_template` threading is unaffected.

## Changes (`packages/core`)

- `domain/models/CommandDefinition.ts` — new optional `targetsCreatedInstance`
  field on `GroundingDefinition`.
- `services/CommandResolver.ts` (`loadGroundingDefinition`) — reads
  `exocmd__Grounding_targetsCreatedInstance` (boolean coercion mirroring
  `cloneTargetBody`; the production loader — plugin button + CLI both go through
  `CommandResolver.loadCommand`).
- `domain/models/GroundingFrontmatterParser.ts` — parity read.
- `services/GroundingExecutor.ts` (`executeComposite`) —
  `stepUsesCreatedPath = (step is body_template) OR step.targetsCreatedInstance`,
  gated on `lastCreatedPath`.

## Requirement (SDD)

`req(exo)` **`b00acde4-e796-4bb0-8136-8bac8ca9cf9e`** (P2, bindingClass
Integration) — Approved. Living-Docs:
https://github.com/kitelev/exoas-exo-reqs/blob/main/exo-reqs/b00acde4-e796-4bb0-8136-8bac8ca9cf9e.md

Req: b00acde4-e796-4bb0-8136-8bac8ca9cf9e

## Test + revert-verify

New production-shape suite `GroundingExecutor.targetsCreatedInstance.test.ts`
drives the real `executeComposite` over a `[create_instance, property_set]`
composite (in-memory fs honouring read-after-write; no hand-injected create
result):

1. **opt-in** — `property_set` with the flag → property lands in the CREATED
   file; click-target untouched by step 2. `@req:b00acde4-...`
2. **default** — `property_set` without the flag → property lands in the
   CLICK-TARGET (the WaitingCheckTask backward-compat behavior). `@req:b00acde4-...`
3. **no-op** — flag set but no prior `create_instance` → falls back to the
   click-target.

**Revert-verified:** neutralising the `step.targetsCreatedInstance` branch makes
test 1 **RED** while tests 2+3 stay **GREEN**; restoring makes all 3 **GREEN**.

## Verification

- Full `packages/core/jest.config.js` (submodules initialized): **352 suites /
  8499 passed / 0 failed**.
- `npm run check:types` (all packages): clean.
- CI lint-job guards: `validate-shard-assignments`, `check-test-antipatterns`
  (method-exists 55/55 unchanged), `check-coverage-monotonic` — all pass.
- eslint `--max-warnings=0` on the 4 changed src files: clean.

## Note (auto-merge discipline)

Touches `GroundingExecutor.ts` + `CommandResolver.ts` (parser/schema paths). The
child prompt forbids sub-agents (API-throttle), so the code-reviewer agent step
was substituted with a rigorous self-review + full-suite green + the revert-verify
gate; the orchestrator reviews before merge (no `--auto`).
