### PR TITLE
feat(display-name): resolver considers ALL exo__Instance_class values (class-membership) (#3864)

### DIFF
--- a/packages/obsidian-plugin/src/domain/display-name/DisplayNameResolver.ts
+++ b/packages/obsidian-plugin/src/domain/display-name/DisplayNameResolver.ts
@@ -19,10 +19,13 @@ export class DisplayNameResolver {
   resolve(context: DisplayNameContext): string | null {
     const { metadata, basename, createdDate } = context;
 
-    const assetClass = this.extractAssetClass(metadata);
-    // Pass the instance metadata so a conditional spec (matchPath/matchValue) can be
-    // evaluated per-render — the specialized displayName tracks the instance's state.
-    const template = this.getTemplateForClass(assetClass, metadata);
+    // Consider EVERY class the note carries (class-MEMBERSHIP), not only the first — so a
+    // class-level exo__DisplayNameSpec (e.g. ems__Meeting → 👥) applies whenever its class
+    // is present, regardless of order (req 83be3f2f, #3864). Pass the instance metadata so a
+    // conditional spec (matchPath/matchValue) is evaluated per-render — the specialized
+    // displayName tracks the instance's state.
+    const assetClasses = this.extractAssetClasses(metadata);
+    const template = this.getTemplateForClasses(assetClasses, metadata);
     const engine = new DisplayNameTemplateEngine(template);
 
     return engine.render(
@@ -33,41 +36,73 @@ export class DisplayNameResolver {
     );
   }
 
-  getTemplateForClass(
-    assetClass: string | null,
+  /**
+   * Select the winning template across ALL of a note's classes (class-membership,
+   * req 83be3f2f). For each class the ruleService yields its best `{template, priority}`
+   * (direct rules + ancestor-inheritance walk + the per-render conditional matcher of
+   * req ed4201d1); the highest-priority PARTICIPATING result across every class wins — so a
+   * class-level spec participates whenever its class is present among the note's classes,
+   * regardless of which one is listed first. Ties keep the earliest (first-listed) class,
+   * so a single-class note is byte-identical to the pre-membership `[0]` path. Falls back to
+   * the first class's TS classTemplate seed, then the default template — exactly as before.
+   * The single-winning-template model still picks ONE template (no prefix composition —
+   * out of scope, see req 83be3f2f).
+   */
+  getTemplateForClasses(
+    assetClasses: string[],
     metadata?: Record<string, unknown>,
   ): string {
-    if (assetClass && this.ruleService) {
-      const dynamicRule = this.ruleService.getTemplateForClass(assetClass, metadata);
-      if (dynamicRule) {
-        return dynamicRule.template;
+    if (this.ruleService && assetClasses.length > 0) {
+      let best: { template: string; priority: number } | null = null;
+      for (const assetClass of assetClasses) {
+        const rule = this.ruleService.getTemplateForClass(assetClass, metadata);
+        // Strictly-greater keeps the earliest class on a priority tie (deterministic,
+        // and byte-identical to the single-class path).
+        if (rule && (best === null || rule.priority > best.priority)) {
+          best = rule;
+        }
       }
+      if (best) return best.template;
     }
 
-    if (assetClass && this.settings.classTemplates[assetClass]) {
-      return this.settings.classTemplates[assetClass];
+    const firstClass = assetClasses[0];
+    if (firstClass && this.settings.classTemplates[firstClass]) {
+      return this.settings.classTemplates[firstClass];
     }
 
     return this.settings.defaultTemplate;
   }
 
-  private extractAssetClass(metadata: Record<string, unknown>): string | null {
+  /**
+   * Single-class variant retained for callers that have already resolved one class (and
+   * direct tests). Delegates to the all-classes path — byte-identical for one class.
+   */
+  getTemplateForClass(
+    assetClass: string | null,
+    metadata?: Record<string, unknown>,
+  ): string {
+    return this.getTemplateForClasses(assetClass ? [assetClass] : [], metadata);
+  }
+
+  private extractAssetClasses(metadata: Record<string, unknown>): string[] {
     const instanceClass = metadata.exo__Instance_class;
 
     if (!instanceClass) {
-      return null;
+      return [];
     }
 
-    if (Array.isArray(instanceClass)) {
-      if (instanceClass.length === 0) return null;
-      return this.cleanClassValue(instanceClass[0]);
-    }
+    const rawValues = Array.isArray(instanceClass) ? instanceClass : [instanceClass];
 
-    if (typeof instanceClass === "string") {
-      return this.cleanClassValue(instanceClass);
+    const classes: string[] = [];
+    const seen = new Set<string>();
+    for (const value of rawValues) {
+      const cleaned = this.cleanClassValue(value);
+      if (cleaned && !seen.has(cleaned)) {
+        seen.add(cleaned);
+        classes.push(cleaned);
+      }
     }
-
-    return null;
+    return classes;
   }
 
   private cleanClassValue(value: unknown): string | null {

--- a/packages/obsidian-plugin/tests/unit/domain/display-name/DisplayNameResolver.multiClass.test.ts
+++ b/packages/obsidian-plugin/tests/unit/domain/display-name/DisplayNameResolver.multiClass.test.ts
@@ -1,0 +1,263 @@
+import { PrintNameRuleService } from "@plugin/domain/display-name/PrintNameRuleService";
+import { DisplayNameResolver } from "@plugin/domain/display-name/DisplayNameResolver";
+import { TFile } from "obsidian";
+import type { App, CachedMetadata } from "obsidian";
+
+// Production-shape mock vault: real files + metadataCache, so the REAL
+// PrintNameRuleService.scanVault → compileDisplayNameSpecs pipeline runs (no
+// hand-injected rules), and DisplayNameResolver.resolve drives selection end-to-end.
+function createMockApp(files: Array<{ path: string; frontmatter: Record<string, unknown> }>): App {
+  const fileCache = new Map<string, CachedMetadata>();
+  const mockFiles: TFile[] = [];
+
+  for (const f of files) {
+    const tfile = new TFile(f.path);
+    tfile.basename = f.path.replace(".md", "");
+    tfile.extension = "md";
+    mockFiles.push(tfile);
+    fileCache.set(f.path, { frontmatter: f.frontmatter } as CachedMetadata);
+  }
+
+  return {
+    vault: {
+      getMarkdownFiles: jest.fn().mockReturnValue(mockFiles),
+    },
+    metadataCache: {
+      getFileCache: jest.fn().mockImplementation((file: TFile) => fileCache.get(file.path) ?? null),
+      getFirstLinkpathDest: jest.fn().mockImplementation((path: string) => {
+        const cleanPath = path.endsWith(".md") ? path : path + ".md";
+        return mockFiles.find((f) => f.path === cleanPath) ?? null;
+      }),
+    },
+  } as unknown as App;
+}
+
+describe("DisplayNameResolver — multi-class membership [req 83be3f2f]", () => {
+  // Real class/enum/property UIDs (fixture mirrors the shipped 🔄 / 👥 / ✅👥 specs).
+  const TASK_UID = "1b20a8f0-d745-4e93-91db-4531b3df120e";
+  const STATUS_PROP_UID = "44c6e9e3-955f-4afc-9ca5-b4bd70667051"; // ems__Effort_status
+  const DOING_UID = "027e78f4-6e16-4b36-b8fb-5510507d5745"; // ems__EffortStatusDoing
+  const DONE_UID = "7b9b3116-7c3c-438c-9618-94fe301320a6"; // ems__EffortStatusDone
+  const BACKLOG_UID = "753a44d5-846c-4b82-9196-4fd9a4d48777"; // ems__EffortStatusBacklog
+  const LABEL_PROP_UID = "12a6151b-801f-4be2-bd6e-a787eedd56ae"; // exo__Asset_label
+
+  /**
+   * Production-shape vault carrying three real-shaped specs, compiled by the real
+   * scanVault pipeline:
+   *   - ems__Meeting → "👥 " (UNCONDITIONAL, priority 10)
+   *   - ems__Meeting + status=Done → "✅👥 " (CONDITIONAL, priority 60 — the composed spec)
+   *   - ems__Task + status=Doing → "🔄 " (CONDITIONAL, priority 50 — the existing 🔄-Doing)
+   * Plus the ems__Effort_status property def (so a conditional matchPath UID-form resolves
+   * its frontmatter key via the second hop).
+   */
+  function meetingClassSpecVault(): App {
+    return createMockApp([
+      // ems__Effort_status property def — second hop for matchPath resolution.
+      {
+        path: `${STATUS_PROP_UID}.md`,
+        frontmatter: {
+          exo__Asset_uid: STATUS_PROP_UID,
+          exo__Instance_class: ["[[9a1cf31c-9d41-4ef3-9023-584a8d087d16|exo__ObjectProperty]]"],
+          exo__Asset_label: "ems__Effort_status",
+        },
+      },
+
+      // --- ems__Meeting → "👥 " (unconditional, priority 10) ---
+      {
+        path: "spec-meeting-people.md",
+        frontmatter: {
+          exo__Asset_uid: "spec-meeting-people",
+          exo__Instance_class: ["[[07eab746-0874-4676-9d98-dbaad1bc6fb8|exo__DisplayNameSpec]]"],
+          exo__DisplayNameSpec_appliesToClass: "[[ems__Meeting]]",
+          exo__DisplayNameSpec_priority: 10,
+        },
+      },
+      {
+        path: "mp-literal.md",
+        frontmatter: {
+          exo__Asset_uid: "mp-literal",
+          exo__Instance_class: ["[[4d5437c9-788e-4a6d-9be0-4af3a84554f4|exo__PrintedLiteral]]"],
+          exo__DisplayNamePart_of: "[[spec-meeting-people]]",
+          exo__DisplayNamePart_order: 0,
+          exo__PrintedLiteral_literal: "👥 ",
+        },
+      },
+      {
+        path: "mp-prop.md",
+        frontmatter: {
+          exo__Asset_uid: "mp-prop",
+          exo__Instance_class: ["[[7d58de40-d941-4a66-88e2-13afc4fdc41d|exo__PrintedProperty]]"],
+          exo__DisplayNamePart_of: "[[spec-meeting-people]]",
+          exo__DisplayNamePart_order: 1,
+          exo__PrintedProperty_property: `[[${LABEL_PROP_UID}|exo__Asset_label]]`,
+        },
+      },
+
+      // --- ems__Meeting + status=Done → "✅👥 " (conditional composed, priority 60) ---
+      {
+        path: "spec-meeting-done.md",
+        frontmatter: {
+          exo__Asset_uid: "spec-meeting-done",
+          exo__Instance_class: ["[[07eab746-0874-4676-9d98-dbaad1bc6fb8|exo__DisplayNameSpec]]"],
+          exo__DisplayNameSpec_appliesToClass: "[[ems__Meeting]]",
+          exo__DisplayNameSpec_priority: 60,
+          exo__DisplayNameSpec_matchPath: `[[${STATUS_PROP_UID}]]`,
+          exo__DisplayNameSpec_matchValue: `[[${DONE_UID}]]`,
+        },
+      },
+      {
+        path: "md-literal.md",
+        frontmatter: {
+          exo__Asset_uid: "md-literal",
+          exo__Instance_class: ["[[4d5437c9-788e-4a6d-9be0-4af3a84554f4|exo__PrintedLiteral]]"],
+          exo__DisplayNamePart_of: "[[spec-meeting-done]]",
+          exo__DisplayNamePart_order: 0,
+          exo__PrintedLiteral_literal: "✅👥 ",
+        },
+      },
+      {
+        path: "md-prop.md",
+        frontmatter: {
+          exo__Asset_uid: "md-prop",
+          exo__Instance_class: ["[[7d58de40-d941-4a66-88e2-13afc4fdc41d|exo__PrintedProperty]]"],
+          exo__DisplayNamePart_of: "[[spec-meeting-done]]",
+          exo__DisplayNamePart_order: 1,
+          exo__PrintedProperty_property: `[[${LABEL_PROP_UID}|exo__Asset_label]]`,
+        },
+      },
+
+      // --- ems__Task + status=Doing → "🔄 " (conditional, priority 50) ---
+      {
+        path: "spec-task-doing.md",
+        frontmatter: {
+          exo__Asset_uid: "spec-task-doing",
+          exo__Instance_class: ["[[07eab746-0874-4676-9d98-dbaad1bc6fb8|exo__DisplayNameSpec]]"],
+          exo__DisplayNameSpec_appliesToClass: `[[${TASK_UID}|ems__Task]]`,
+          exo__DisplayNameSpec_priority: 50,
+          exo__DisplayNameSpec_matchPath: `[[${STATUS_PROP_UID}]]`,
+          exo__DisplayNameSpec_matchValue: `[[${DOING_UID}]]`,
+        },
+      },
+      {
+        path: "td-literal.md",
+        frontmatter: {
+          exo__Asset_uid: "td-literal",
+          exo__Instance_class: ["[[4d5437c9-788e-4a6d-9be0-4af3a84554f4|exo__PrintedLiteral]]"],
+          exo__DisplayNamePart_of: "[[spec-task-doing]]",
+          exo__DisplayNamePart_order: 0,
+          exo__PrintedLiteral_literal: "🔄 ",
+        },
+      },
+      {
+        path: "td-prop.md",
+        frontmatter: {
+          exo__Asset_uid: "td-prop",
+          exo__Instance_class: ["[[7d58de40-d941-4a66-88e2-13afc4fdc41d|exo__PrintedProperty]]"],
+          exo__DisplayNamePart_of: "[[spec-task-doing]]",
+          exo__DisplayNamePart_order: 1,
+          exo__PrintedProperty_property: `[[${LABEL_PROP_UID}|exo__Asset_label]]`,
+        },
+      },
+    ]);
+  }
+
+  // A note whose exo__Instance_class carries BOTH classes, in the given order.
+  function multiClassMeeting(
+    classes: string[],
+    statusUid: string,
+    label = "Weekly sync",
+  ): Record<string, unknown> {
+    return {
+      exo__Instance_class: classes,
+      exo__Asset_label: label,
+      ems__Effort_status: `[[${statusUid}]]`,
+    };
+  }
+
+  function buildResolver(app: App): DisplayNameResolver {
+    const service = new PrintNameRuleService(app);
+    service.initialize(); // real scanVault → compileDisplayNameSpecs
+    // EMPTY classTemplates — proves the VAULT specs (not TS hardcodes) drive the prefixes.
+    return new DisplayNameResolver(
+      { defaultTemplate: "{{exo__Asset_label}}", classTemplates: {} },
+      service,
+    );
+  }
+
+  it("@req:83be3f2f-5b8a-49bb-a142-61918977b268 a Task-first multi-class meeting gets the ems__Meeting 👥 prefix (the reported bug — class-membership, not first-class-only) [revert-verify anchor]", () => {
+    const resolver = buildResolver(meetingClassSpecVault());
+
+    // exo__Instance_class = [ ems__Task, ems__Meeting ] — Meeting is NOT first, status NOT Doing.
+    // Class-membership: the ems__Meeting 👥 spec applies because the class is PRESENT.
+    // Revert-verify RED anchor: reverting the resolver to instance_class[0]-only makes only
+    // ems__Task be consulted → the 🔄-Doing conditional is skipped (Backlog) → fallback label →
+    // "Weekly sync" (👥 dropped) → this assertion RED. Restore → GREEN.
+    const taskFirst = resolver.resolve({
+      metadata: multiClassMeeting(["[[ems__Task]]", "[[ems__Meeting]]"], BACKLOG_UID),
+      basename: "meeting-note",
+    });
+    expect(taskFirst).toBe("👥 Weekly sync");
+  });
+
+  it("is order-independent: a Meeting-first note gets the same 👥 prefix (byte-identical to today, guards symmetry)", () => {
+    const resolver = buildResolver(meetingClassSpecVault());
+    const meetingFirst = resolver.resolve({
+      metadata: multiClassMeeting(["[[ems__Meeting]]", "[[ems__Task]]"], BACKLOG_UID),
+      basename: "meeting-note",
+    });
+    expect(meetingFirst).toBe("👥 Weekly sync");
+  });
+
+  it("the highest-priority participating spec across ALL classes wins — a Done Task-first meeting gets the composed ✅👥", () => {
+    const resolver = buildResolver(meetingClassSpecVault());
+    // Done: the composed ems__Meeting+Done ✅👥 spec (priority 60) beats the unconditional
+    // ems__Meeting 👥 (priority 10); the ems__Task 🔄-Doing conditional is skipped (not Doing).
+    const done = resolver.resolve({
+      metadata: multiClassMeeting(["[[ems__Task]]", "[[ems__Meeting]]"], DONE_UID),
+      basename: "meeting-note",
+    });
+    expect(done).toBe("✅👥 Weekly sync");
+  });
+
+  it("two distinct-prefix specs simultaneously applicable → exactly ONE wins (composition out of scope)", () => {
+    const resolver = buildResolver(meetingClassSpecVault());
+    // Doing: BOTH the ems__Task 🔄-Doing spec (priority 50) AND the ems__Meeting 👥 spec
+    // (priority 10) participate. The single-winning-template model picks ONE — the highest
+    // priority (🔄). It does NOT compose into "🔄👥" (prefix composition is a further design,
+    // explicitly out of scope for req 83be3f2f).
+    const doing = resolver.resolve({
+      metadata: multiClassMeeting(["[[ems__Task]]", "[[ems__Meeting]]"], DOING_UID),
+      basename: "meeting-note",
+    });
+    expect(doing).toBe("🔄 Weekly sync");
+    // Non-vacuity: exactly one prefix, not both, not the other.
+    expect(doing).not.toContain("👥");
+  });
+
+  it("no-regression: a single-class ems__Meeting note is byte-identical (still 👥), both before and after the membership change", () => {
+    const resolver = buildResolver(meetingClassSpecVault());
+    const single = resolver.resolve({
+      metadata: multiClassMeeting(["[[ems__Meeting]]"], BACKLOG_UID),
+      basename: "meeting-note",
+    });
+    expect(single).toBe("👥 Weekly sync");
+  });
+
+  it("no-regression + negative control: a single-class ems__Task note (Backlog) shows the bare label — the membership fix does NOT leak 👥 onto a non-Meeting note", () => {
+    const resolver = buildResolver(meetingClassSpecVault());
+    const taskOnly = resolver.resolve({
+      metadata: multiClassMeeting(["[[ems__Task]]"], BACKLOG_UID, "Fix the parser"),
+      basename: "task-note",
+    });
+    expect(taskOnly).toBe("Fix the parser");
+  });
+
+  it("no-regression: a single-class ems__Task note (Doing) still gets its own 🔄 (single-class path unaffected)", () => {
+    const resolver = buildResolver(meetingClassSpecVault());
+    const doingTask = resolver.resolve({
+      metadata: multiClassMeeting(["[[ems__Task]]"], DOING_UID, "Fix the parser"),
+      basename: "task-note",
+    });
+    expect(doingTask).toBe("🔄 Fix the parser");
+  });
+});


### PR DESCRIPTION
## Summary

`DisplayNameResolver.extractAssetClass` used `exo__Instance_class[0]` only, so a **Task-first** multi-class meeting (`[[ems__Task]], [[ems__Meeting]]`) never consulted the `ems__Meeting` 👥 spec and dropped the class prefix. This teaches the resolver a **class-MEMBERSHIP** test: `resolve()` now considers **every** class the note carries and picks the **highest-priority PARTICIPATING** `exo__DisplayNameSpec` across all of them.

- `extractAssetClass` → **`extractAssetClasses`** (full cleaned, de-duped, order-preserving list).
- New **`getTemplateForClasses(classes, metadata)`**: for each class, `PrintNameRuleService.getTemplateForClass(class, metadata)` yields its best `{template, priority}` (per-class **ancestor-inheritance walk** + the **per-render conditional matcher** of req `ed4201d1` preserved); the **max-priority** result wins. Ties keep the earliest class → **byte-identical for single-class notes** (the `[0]` and all-classes paths coincide). Falls back to the first class's TS `classTemplate` seed, then the default template — exactly as before.
- Public `getTemplateForClass(assetClass)` **retained** (delegates to the all-classes path) — backward compatible for direct callers/tests.
- The composed `ems__Meeting+Done → ✅👥` spec now applies to Task-first meetings for free.

`resolve()` is the **single funnel** for all 10 render surfaces (BodyLinkPatch, GraphViewPatch, WikilinkLabelViewPlugin, InlineTitlePatch, PropertiesLinkPatch, TabTitlePatch, DailyTasksRenderer, RelationsRenderer, LayoutCodeBlockProcessor, settings preview) — every surface passes full `metadata` to `resolve()`, so the fix lands on native links **and** in the plugin's tables at once.

Fourth in the homoiconic-displayName line — the three render-surface wirings already shipped (`a577316f`/v16.178.0, `3f65eb4a`/v16.179.0, `71cc75f3`/v16.180.0). This fixes the class-**selection** engine.

### In scope / out of scope
- ✅ Highest-priority **participating** spec across all classes wins — a **single** winning template.
- ⛔ **Prefix COMPOSITION** (a Doing meeting getting BOTH 🔄 AND 👥 → "🔄👥") is a further engine design — explicitly **out of scope** (req `83be3f2f`); the single-winning-template model still picks ONE. A follow-up if wanted.
- ⛔ `#3865` (computed 🚩 blocked matcher) — separate.

## Revert-verified

Production-shape component test (`@req:83be3f2f-5b8a-49bb-a142-61918977b268`) drives the **real** `PrintNameRuleService.scanVault → getTemplateForClass(metadata) → DisplayNameResolver.resolve` over an in-memory vault (`ems__Meeting → 👥`, conditional composed `ems__Meeting+Done → ✅👥`, conditional `ems__Task 🔄-Doing`) with a Task-first multi-class note — **no hand-injected class**.

- **Axis 1 (membership):** revert `resolve()` to `instance_class[0]`-only → the Task-first meeting (Backlog) loses "👥 " and (Done) loses "✅👥 " → assertion **RED** (2 fail / 5 pass); restore → **GREEN** (7/7). Ran RED first.
- **Axis 2 (no-regression):** single-class `ems__Meeting` (👥) and single-class `ems__Task` (bare label; Doing → 🔄) assertions stay **GREEN both ways** — the membership change does not leak a prefix onto a non-Meeting note.
- Order-independence + "two distinct-prefix specs → exactly ONE prefix (composition out of scope, `.not.toContain("👥")`)" also asserted.

Local: `check:types` 0 errors · eslint (src) clean · `check-test-antipatterns` ratchet 55/55 no-recurrence · **256 tests / 9 resolver-consuming suites GREEN** (all display-name domain + integration + DailyTasks/Relations/LayoutCodeBlock render-surface homoiconicDisplayName + ExocortexPlugin).

Req: 83be3f2f-5b8a-49bb-a142-61918977b268
Closes #3864
