### PR TITLE
feat(display-name): exo__DisplayNameSpec gains a computed / host-function matcher (#3865)

### DIFF
--- a/packages/obsidian-plugin/src/ExocortexPlugin.ts
+++ b/packages/obsidian-plugin/src/ExocortexPlugin.ts
@@ -134,6 +134,7 @@ import { ReadingModeEnforcer } from "./presentation/reading-mode/ReadingModeEnfo
 import { BodyLinkPatch } from "./presentation/body/BodyLinkPatch";
 import { GraphViewPatch } from "./presentation/graph-view/GraphViewPatch";
 import { PrintNameRuleService } from "./domain/display-name/PrintNameRuleService";
+import { DEFAULT_DISPLAY_MATCHER_HOST_FUNCTIONS } from "./presentation/utils/displayMatcherHostFunctions";
 import { ObsidianFileSystemAdapter } from "./adapters/ObsidianFileSystemAdapter";
 import { populateServiceRegistry } from "./infrastructure/services/ServiceRegistryPopulator";
 import { ObsidianFileOpener } from "./infrastructure/services/ObsidianFileOpener";
@@ -521,7 +522,10 @@ export default class ExocortexPlugin extends Plugin {
       await this.fileLogChannel.ensureFileExists();
       this.configureLogChannels();
 
-      this.printNameRuleService = new PrintNameRuleService(this.app);
+      this.printNameRuleService = new PrintNameRuleService(
+        this.app,
+        DEFAULT_DISPLAY_MATCHER_HOST_FUNCTIONS,
+      );
       this.printNameRuleService.initialize();
 
       this.registerEvent(

--- a/packages/obsidian-plugin/src/domain/display-name/PrintNameRuleService.ts
+++ b/packages/obsidian-plugin/src/domain/display-name/PrintNameRuleService.ts
@@ -2,7 +2,7 @@ import { TFile } from "obsidian";
 import type { App } from "obsidian";
 
 /**
- * A per-render condition compiled from an exo__DisplayNameSpec's
+ * A per-render VALUE-EQUALITY condition compiled from an exo__DisplayNameSpec's
  * exo__DisplayNameSpec_matchPath (→ frontmatter key) + exo__DisplayNameSpec_matchValue
  * (→ cleaned enum identity/-ies). A rule carrying a matcher is CONDITIONAL: it only
  * participates in class selection when the rendered instance's frontmatter value at
@@ -10,7 +10,8 @@ import type { App } from "obsidian";
  * into the compiled template because it depends on the concrete instance). v2
  * conditional-slice (RFC 92b91345, req ed4201d1).
  */
-export interface DisplayNameMatcher {
+export interface ValueEqualityMatcher {
+  kind: "value";
   /** Frontmatter key of the instance property the condition inspects (e.g. "ems__Effort_status"). */
   matchKey: string;
   /**
@@ -24,12 +25,52 @@ export interface DisplayNameMatcher {
   matchValues: string[];
 }
 
+/**
+ * A per-render COMPUTED / host-function condition compiled from an
+ * exo__DisplayNameSpec's exo__DisplayNameSpec_matchHostFunction (→ the NAME of a
+ * registered display-matcher host function). A rule carrying this matcher participates
+ * only when the named host function returns true for the rendered instance — evaluated
+ * per-render from (app, instance metadata), so it can resolve OTHER assets (a CROSS-ASSET
+ * predicate) that a value-equality matcher on the instance's own frontmatter cannot
+ * express. The first registered function is `isEffortBlocked`. v2 computed-slice
+ * (RFC 92b91345, req d6cd2371).
+ */
+export interface HostFunctionMatcher {
+  kind: "hostFunction";
+  /** Name of a registered display-matcher host function, e.g. "isEffortBlocked". */
+  hostFunction: string;
+}
+
+/**
+ * A spec's per-render matcher. A spec MAY carry EITHER a value-equality matcher OR a
+ * host-function matcher (v2 single-matcher slice — conjunctions/disjunctions are a
+ * future exo__DisplayNameMatcher). When a spec declares both, value-equality takes
+ * precedence (see compileDisplayNameSpecs).
+ */
+export type DisplayNameMatcher = ValueEqualityMatcher | HostFunctionMatcher;
+
+/**
+ * A registered display-matcher host function: a per-render, possibly CROSS-ASSET
+ * predicate over (app, rendered-instance metadata). Seeded with isEffortBlocked. Kept
+ * as an injected registry (composition-root seeding) so the engine stays free of any
+ * concrete predicate — the plugin wires the real functions (see ExocortexPlugin).
+ */
+export type DisplayMatcherHostFunction = (
+  app: App,
+  metadata: Record<string, unknown>,
+) => boolean;
+export type DisplayMatcherHostFunctionRegistry = Record<string, DisplayMatcherHostFunction>;
+
 export interface PrintNameRule {
   className: string;
   template: string;
   priority: number;
   sourceFile: string;
-  /** Present iff the spec declared exo__DisplayNameSpec_matchPath + _matchValue (conditional). */
+  /**
+   * Present iff the spec declared a matcher — exo__DisplayNameSpec_matchPath + _matchValue
+   * (value-equality) OR exo__DisplayNameSpec_matchHostFunction (host-function). Absent =
+   * unconditional (v1 path).
+   */
   matcher?: DisplayNameMatcher;
 }
 
@@ -51,9 +92,11 @@ interface RawDisplayNameSpec {
   uid: string;
   classKeys: string[]; // UID + label of appliesToClass (both indexed — #2110)
   priority: number;
-  // Conditional specialization (v2 slice — RFC 92b91345, req ed4201d1). Both present or both absent.
+  // Value-equality specialization (v2 slice — RFC 92b91345, req ed4201d1). Both present or both absent.
   matchKey?: string; // frontmatter key resolved from exo__DisplayNameSpec_matchPath
   matchValues?: string[]; // accepted identities (UID + label) from exo__DisplayNameSpec_matchValue
+  // Host-function specialization (v2 slice — RFC 92b91345, req d6cd2371).
+  hostFunction?: string; // registered host-function name from exo__DisplayNameSpec_matchHostFunction
 }
 
 interface RawDisplayNamePart {
@@ -68,7 +111,16 @@ export class PrintNameRuleService {
   private classHierarchy: Map<string, string[]> = new Map();
   private initialized = false;
 
-  constructor(private readonly app: App) {}
+  /**
+   * @param hostFunctions Registry of display-matcher host functions (name → predicate),
+   *   consulted by a host-function matcher (req d6cd2371). Defaults to empty — a spec that
+   *   names an unregistered function never participates (fail-closed). The plugin seeds it
+   *   with isEffortBlocked (see ExocortexPlugin); v1/value-equality specs are unaffected.
+   */
+  constructor(
+    private readonly app: App,
+    private readonly hostFunctions: DisplayMatcherHostFunctionRegistry = {},
+  ) {}
 
   initialize(): void {
     this.scanVault();
@@ -121,16 +173,26 @@ export class PrintNameRuleService {
   }
 
   /**
-   * True when the instance's frontmatter value at `matcher.matchKey` equals `matchValue`
-   * under dual-IRI equality: both sides are reduced to their identity set (UID + label
-   * forms via extractClassKeys) and the sets must intersect. This makes the condition
-   * robust whether the status is stored as `[[<uid>]]`, `[[<uid>|label]]`, or the bare
-   * label — see sparql-iri-form-pre-verify.
+   * True when the rendered instance satisfies the rule's matcher, dispatched by kind:
+   *  - "hostFunction": look the named function up in the injected registry and call it
+   *    with (app, metadata) — a per-render, possibly cross-asset predicate (req d6cd2371).
+   *    An UNREGISTERED name never participates (fail-closed): a conditional prefix must
+   *    not appear when its predicate can't be evaluated.
+   *  - "value": the instance's frontmatter value at `matcher.matchKey` equals `matchValue`
+   *    under dual-IRI equality — both sides reduced to their identity set (UID + label
+   *    forms via extractClassKeys) and the sets must intersect, so it is robust whether the
+   *    status is stored as `[[<uid>]]`, `[[<uid>|label]]`, or the bare label (req ed4201d1;
+   *    see sparql-iri-form-pre-verify).
    */
   private matcherSatisfied(
     matcher: DisplayNameMatcher,
     metadata: Record<string, unknown>,
   ): boolean {
+    if (matcher.kind === "hostFunction") {
+      const fn = this.hostFunctions[matcher.hostFunction];
+      if (!fn) return false;
+      return fn(this.app, metadata);
+    }
     const instanceForms = this.extractClassKeys(metadata[matcher.matchKey]);
     if (instanceForms.length === 0) return false;
     return instanceForms.some((form) => matcher.matchValues.includes(form));
@@ -160,6 +222,28 @@ export class PrintNameRuleService {
       if (typeof label === "string" && label.trim()) forms.add(label.trim());
     }
     return [...forms];
+  }
+
+  /**
+   * Resolve exo__DisplayNameSpec_matchHostFunction to the registered host-function NAME
+   * it references. Unlike matchPath/matchValue (which are wikilinks to property/enum
+   * assets), this is a plain STRING datatype value — the name of a registered
+   * display-matcher host function (e.g. "isEffortBlocked"). Takes the first element if an
+   * array; strips surrounding wikilink brackets / quotes / whitespace defensively.
+   */
+  private resolveHostFunctionName(value: unknown): string | null {
+    let raw = value;
+    if (Array.isArray(raw)) {
+      if (raw.length === 0) return null;
+      raw = raw[0];
+    }
+    if (typeof raw !== "string") return null;
+
+    const cleaned = raw
+      .replace(/^\[\[|\]\]$/g, "")
+      .replace(/^"|"$/g, "")
+      .trim();
+    return cleaned || null;
   }
 
   createMetadataResolver(): MetadataResolver {
@@ -254,20 +338,26 @@ export class PrintNameRuleService {
           ? Number(rawPriority)
           : 0;
 
-    // Conditional specialization (v2 slice): resolve matchPath → the frontmatter key it
+    // Value-equality specialization (v2 slice): resolve matchPath → the frontmatter key it
     // inspects (single-hop, same wikilink resolution as a PrintedProperty ref) and
     // matchValue → the accepted identity set (all forms of the ONE accepted value). A
-    // matcher is set only when BOTH are present; otherwise the spec stays unconditional
-    // (v1 path).
+    // value-equality matcher is set only when BOTH are present.
     const matchKey = this.resolvePropertyKey(fm.exo__DisplayNameSpec_matchPath);
     const matchValues = this.resolveMatchValues(fm.exo__DisplayNameSpec_matchValue);
-    const hasMatcher = matchKey !== null && matchValues.length > 0;
+    const hasValueMatcher = matchKey !== null && matchValues.length > 0;
+
+    // Host-function specialization (v2 slice, req d6cd2371): resolve matchHostFunction →
+    // the registered host-function NAME (a plain string, not a wikilink). Carried on the
+    // raw spec; the union matcher is built in compileDisplayNameSpecs. Absent both → the
+    // spec stays unconditional (v1 path).
+    const hostFunction = this.resolveHostFunctionName(fm.exo__DisplayNameSpec_matchHostFunction);
 
     rawSpecs.set(uid, {
       uid,
       classKeys,
       priority: Number.isFinite(priority) ? priority : 0,
-      ...(hasMatcher ? { matchKey: matchKey ?? undefined, matchValues } : {}),
+      ...(hasValueMatcher ? { matchKey: matchKey ?? undefined, matchValues } : {}),
+      ...(hostFunction ? { hostFunction } : {}),
     });
   }
 
@@ -327,10 +417,16 @@ export class PrintNameRuleService {
 
       const priority = DISPLAY_NAME_SPEC_BASE_PRIORITY + spec.priority;
 
-      const matcher: DisplayNameMatcher | undefined =
-        spec.matchKey && spec.matchValues && spec.matchValues.length > 0
-          ? { matchKey: spec.matchKey, matchValues: spec.matchValues }
-          : undefined;
+      // Build the union matcher. A spec MAY carry EITHER a value-equality matcher OR a
+      // host-function matcher (v2 single-matcher slice). If a spec somehow declares both,
+      // value-equality takes precedence (deterministic; conjunctions are a future
+      // exo__DisplayNameMatcher).
+      let matcher: DisplayNameMatcher | undefined;
+      if (spec.matchKey && spec.matchValues && spec.matchValues.length > 0) {
+        matcher = { kind: "value", matchKey: spec.matchKey, matchValues: spec.matchValues };
+      } else if (spec.hostFunction) {
+        matcher = { kind: "hostFunction", hostFunction: spec.hostFunction };
+      }
 
       for (const classKey of spec.classKeys) {
         if (!classKey) continue;

--- a/packages/obsidian-plugin/src/presentation/utils/displayMatcherHostFunctions.ts
+++ b/packages/obsidian-plugin/src/presentation/utils/displayMatcherHostFunctions.ts
@@ -1,0 +1,19 @@
+import type { DisplayMatcherHostFunctionRegistry } from "@plugin/domain/display-name/PrintNameRuleService";
+import { BlockerHelpers } from "./BlockerHelpers";
+
+/**
+ * The built-in registry of display-matcher host functions (req d6cd2371), keyed by the
+ * name an `exo__DisplayNameSpec_matchHostFunction` references. Each is a per-render,
+ * possibly CROSS-ASSET predicate over (app, rendered-instance metadata) — the concrete
+ * predicates that the storage-agnostic `PrintNameRuleService` engine consults through its
+ * injected registry. Seeded from the composition root (see ExocortexPlugin), mirroring the
+ * precondition-host-function pattern (`registerDefaultHostFunctions`).
+ *
+ * Seeded with `isEffortBlocked` — reuses the DailyNote renderer's `BlockerHelpers`
+ * (reads `ems__Effort_blocker`, resolves that asset, checks ITS status), so a spec can
+ * declare the 🚩-blocked condition as homoiconic vault data instead of renderer hardcode.
+ * Extend by adding an entry here; the engine looks names up at match time.
+ */
+export const DEFAULT_DISPLAY_MATCHER_HOST_FUNCTIONS: DisplayMatcherHostFunctionRegistry = {
+  isEffortBlocked: (app, metadata) => BlockerHelpers.isEffortBlocked(app, metadata),
+};

--- a/packages/obsidian-plugin/tests/unit/domain/display-name/PrintNameRuleService.test.ts
+++ b/packages/obsidian-plugin/tests/unit/domain/display-name/PrintNameRuleService.test.ts
@@ -1,5 +1,6 @@
 import { PrintNameRuleService } from "@plugin/domain/display-name/PrintNameRuleService";
 import { DisplayNameResolver } from "@plugin/domain/display-name/DisplayNameResolver";
+import { DEFAULT_DISPLAY_MATCHER_HOST_FUNCTIONS } from "@plugin/presentation/utils/displayMatcherHostFunctions";
 import { TFile } from "obsidian";
 import type { App, CachedMetadata } from "obsidian";
 
@@ -672,5 +673,251 @@ describe("PrintNameRuleService — conditional exo__DisplayNameSpec (v2 slice, p
       exo__Instance_class: ["[[ems__Project]]"],
     });
     expect(withMeta!.template).toBe("PROJECT");
+  });
+});
+
+describe("PrintNameRuleService — host-function exo__DisplayNameSpec (v2 computed matcher, cross-asset) [req d6cd2371]", () => {
+  const TASK_UID = "1b20a8f0-d745-4e93-91db-4531b3df120e";
+  const LABEL_PROP_UID = "12a6151b-801f-4be2-bd6e-a787eedd56ae"; // exo__Asset_label
+  const SPEC_UID = "spec-blocked-hostfn-uid";
+  const BLOCKER_BASENAME = "the-blocking-task";
+
+  // Production-shape vault: a 🚩-blocked exo__DisplayNameSpec for ems__Task whose matcher is a
+  // HOST FUNCTION (matchHostFunction=isEffortBlocked) + its two ordered parts + a BLOCKER asset
+  // the task's ems__Effort_blocker resolves to. The service is wired with the REAL registry
+  // (DEFAULT_DISPLAY_MATCHER_HOST_FUNCTIONS) so the REAL BlockerHelpers.isEffortBlocked runs —
+  // NO hand-injected matcher result. `setBlockerStatus` mutates the SAME blocker cache so a
+  // per-render test can flip the CROSS-ASSET condition without a re-scan.
+  function blockedHostFnVault(
+    opts: {
+      priority?: number;
+      blockerStatus?: string | null; // bare-label form, e.g. "[[ems__EffortStatusDoing]]"
+      hostFunctionName?: string; // override to exercise the fail-closed path
+      extraFiles?: Array<{ path: string; frontmatter: Record<string, unknown> }>;
+    } = {},
+  ): {
+    service: PrintNameRuleService;
+    resolver: DisplayNameResolver;
+    setBlockerStatus: (status: string | null) => void;
+  } {
+    // The blocker's frontmatter is a live object shared with the fileCache so status flips
+    // are visible to isEffortBlocked on the next render (mirrors metadataCache re-reads).
+    const blockerFm: Record<string, unknown> = {
+      exo__Asset_uid: "blocker-asset-uid",
+      exo__Asset_label: "The blocking task",
+    };
+    if (opts.blockerStatus != null) blockerFm.ems__Effort_status = opts.blockerStatus;
+
+    const fileCache = new Map<string, CachedMetadata>();
+    const mockFiles: TFile[] = [];
+    const addFile = (path: string, frontmatter: Record<string, unknown>) => {
+      const tfile = new TFile(path);
+      tfile.basename = path.replace(".md", "");
+      tfile.extension = "md";
+      mockFiles.push(tfile);
+      fileCache.set(path, { frontmatter } as CachedMetadata);
+    };
+
+    addFile(`${SPEC_UID}.md`, {
+      exo__Asset_uid: SPEC_UID,
+      exo__Instance_class: ["[[07eab746-0874-4676-9d98-dbaad1bc6fb8|exo__DisplayNameSpec]]"],
+      exo__DisplayNameSpec_appliesToClass: `[[${TASK_UID}|ems__Task]]`,
+      exo__DisplayNameSpec_priority: opts.priority ?? 100,
+      // The computed matcher: a plain string naming the registered host function.
+      exo__DisplayNameSpec_matchHostFunction: opts.hostFunctionName ?? "isEffortBlocked",
+    });
+    addFile("blocked-literal.md", {
+      exo__Asset_uid: "blocked-literal",
+      exo__Instance_class: ["[[4d5437c9-788e-4a6d-9be0-4af3a84554f4|exo__PrintedLiteral]]"],
+      exo__DisplayNamePart_of: `[[${SPEC_UID}]]`,
+      exo__DisplayNamePart_order: 0,
+      exo__PrintedLiteral_literal: "🚩 ",
+    });
+    addFile("blocked-prop.md", {
+      exo__Asset_uid: "blocked-prop",
+      exo__Instance_class: ["[[7d58de40-d941-4a66-88e2-13afc4fdc41d|exo__PrintedProperty]]"],
+      exo__DisplayNamePart_of: `[[${SPEC_UID}]]`,
+      exo__DisplayNamePart_order: 1,
+      exo__PrintedProperty_property: `[[${LABEL_PROP_UID}|exo__Asset_label]]`,
+    });
+    addFile(`${BLOCKER_BASENAME}.md`, blockerFm); // fileCache holds the SAME blockerFm reference
+
+    for (const ef of opts.extraFiles ?? []) addFile(ef.path, ef.frontmatter);
+
+    const app = {
+      vault: { getMarkdownFiles: jest.fn().mockReturnValue(mockFiles) },
+      metadataCache: {
+        getFileCache: jest
+          .fn()
+          .mockImplementation((file: TFile) => fileCache.get(file.path) ?? null),
+        getFirstLinkpathDest: jest.fn().mockImplementation((path: string) => {
+          const cleanPath = path.endsWith(".md") ? path : path + ".md";
+          return mockFiles.find((f) => f.path === cleanPath) ?? null;
+        }),
+      },
+    } as unknown as App;
+
+    // Wire the REAL registry (isEffortBlocked → BlockerHelpers.isEffortBlocked).
+    const service = new PrintNameRuleService(app, DEFAULT_DISPLAY_MATCHER_HOST_FUNCTIONS);
+    service.initialize();
+    const resolver = new DisplayNameResolver(
+      { defaultTemplate: "{{exo__Asset_label}}", classTemplates: {} },
+      service,
+    );
+    const setBlockerStatus = (status: string | null) => {
+      if (status === null) delete blockerFm.ems__Effort_status;
+      else blockerFm.ems__Effort_status = status;
+    };
+    return { service, resolver, setBlockerStatus };
+  }
+
+  function taskMeta(
+    opts: { blocker?: string | null; label?: string } = {},
+  ): Record<string, unknown> {
+    const m: Record<string, unknown> = {
+      exo__Instance_class: [`[[${TASK_UID}]]`],
+      exo__Asset_label: opts.label ?? "Ship the release",
+    };
+    if (opts.blocker != null) m.ems__Effort_blocker = opts.blocker;
+    return m;
+  }
+
+  it("@req:d6cd2371-bdf2-460e-840e-841480273869 a 🚩-blocked host-function spec applies ONLY to a blocked task; a non-blocked task falls through to the label (revert-verify anchor)", () => {
+    // The blocker asset's status is Doing (not done) → real isEffortBlocked returns true for a
+    // task referencing it. EMPTY classTemplates prove the VAULT host-function spec drives the 🚩,
+    // not a TS hardcode. Revert-verify RED anchor: neutralize the host-function matcher gate
+    // (treat host-function rules as never-participating) → the blocked task loses "🚩 " → RED.
+    const { resolver } = blockedHostFnVault({ blockerStatus: "[[ems__EffortStatusDoing]]" });
+
+    const blocked = resolver.resolve({
+      metadata: taskMeta({ blocker: `[[${BLOCKER_BASENAME}]]` }),
+      basename: "t1",
+    });
+    expect(blocked).toBe("🚩 Ship the release");
+
+    // No blocker → isEffortBlocked false → the spec does NOT participate.
+    const notBlocked = resolver.resolve({ metadata: taskMeta(), basename: "t2" });
+    expect(notBlocked).toBe("Ship the release");
+  });
+
+  it("the condition is CROSS-ASSET — a task whose blocker is DONE is not blocked → no 🚩 (reads the BLOCKER's status, not the task's own frontmatter)", () => {
+    const { resolver } = blockedHostFnVault({ blockerStatus: "[[ems__EffortStatusDone]]" });
+    // The task DOES carry ems__Effort_blocker, but the referenced blocker is Done → not blocked.
+    expect(
+      resolver.resolve({
+        metadata: taskMeta({ blocker: `[[${BLOCKER_BASENAME}]]` }),
+        basename: "t",
+      }),
+    ).toBe("Ship the release");
+  });
+
+  it("evaluates the condition PER-RENDER — the SAME loaded spec flips 🚩 on/off as the referenced BLOCKER's status changes (cross-asset, no re-scan)", () => {
+    const { resolver, setBlockerStatus } = blockedHostFnVault({
+      blockerStatus: "[[ems__EffortStatusDoing]]",
+    });
+    const meta = taskMeta({ blocker: `[[${BLOCKER_BASENAME}]]` }); // SAME task metadata throughout
+
+    // blocker not-done → blocked → 🚩
+    expect(resolver.resolve({ metadata: meta, basename: "t" })).toBe("🚩 Ship the release");
+    // the OTHER asset (the blocker) becomes Done → task no longer blocked → 🚩 disappears (no refresh()).
+    setBlockerStatus("[[ems__EffortStatusDone]]");
+    expect(resolver.resolve({ metadata: meta, basename: "t" })).toBe("Ship the release");
+    // blocker reverts to not-done → 🚩 returns.
+    setBlockerStatus("[[ems__EffortStatusDoing]]");
+    expect(resolver.resolve({ metadata: meta, basename: "t" })).toBe("🚩 Ship the release");
+  });
+
+  it("a matched host-function spec BEATS a lower-priority unconditional spec; an unmatched one yields to it (selection stays priority-based)", () => {
+    const { resolver } = blockedHostFnVault({
+      priority: 80, // host-function spec
+      blockerStatus: "[[ems__EffortStatusDoing]]",
+      extraFiles: [
+        {
+          path: "uncond-spec.md",
+          frontmatter: {
+            exo__Asset_uid: "uncond-spec",
+            exo__Instance_class: ["[[07eab746-0874-4676-9d98-dbaad1bc6fb8|exo__DisplayNameSpec]]"],
+            exo__DisplayNameSpec_appliesToClass: `[[${TASK_UID}|ems__Task]]`,
+            exo__DisplayNameSpec_priority: 1,
+          },
+        },
+        {
+          path: "ul.md",
+          frontmatter: {
+            exo__Asset_uid: "ul",
+            exo__Instance_class: ["[[4d5437c9-788e-4a6d-9be0-4af3a84554f4|exo__PrintedLiteral]]"],
+            exo__DisplayNamePart_of: "[[uncond-spec]]",
+            exo__DisplayNamePart_order: 0,
+            exo__PrintedLiteral_literal: "[TASK] ",
+          },
+        },
+        {
+          path: "up.md",
+          frontmatter: {
+            exo__Asset_uid: "up",
+            exo__Instance_class: ["[[7d58de40-d941-4a66-88e2-13afc4fdc41d|exo__PrintedProperty]]"],
+            exo__DisplayNamePart_of: "[[uncond-spec]]",
+            exo__DisplayNamePart_order: 1,
+            exo__PrintedProperty_property: `[[${LABEL_PROP_UID}|exo__Asset_label]]`,
+          },
+        },
+      ],
+    });
+
+    // blocked → high-priority host-function spec wins.
+    expect(
+      resolver.resolve({ metadata: taskMeta({ blocker: `[[${BLOCKER_BASENAME}]]` }), basename: "t" }),
+    ).toBe("🚩 Ship the release");
+    // not blocked → host-function skipped → unconditional "[TASK] <label>" wins (not the bare label).
+    expect(resolver.resolve({ metadata: taskMeta(), basename: "t" })).toBe(
+      "[TASK] Ship the release",
+    );
+  });
+
+  it("a spec naming an UNREGISTERED host function never participates (fail-closed) → falls through to the label", () => {
+    const { resolver } = blockedHostFnVault({
+      blockerStatus: "[[ems__EffortStatusDoing]]",
+      hostFunctionName: "noSuchDisplayMatcher",
+    });
+    // Even a genuinely blocked task gets no 🚩 — the unknown function can't be evaluated.
+    expect(
+      resolver.resolve({ metadata: taskMeta({ blocker: `[[${BLOCKER_BASENAME}]]` }), basename: "t" }),
+    ).toBe("Ship the release");
+  });
+
+  it("no-regression: a no-matcher spec is byte-identical even with the host-function registry wired (v1 path, no metadata)", () => {
+    // A pure-v1 spec (no matchPath/matchValue/matchHostFunction) still always participates when
+    // the service is constructed WITH the real host-function registry.
+    const app = createMockApp([
+      {
+        path: "v1-spec.md",
+        frontmatter: {
+          exo__Asset_uid: "v1-spec",
+          exo__Instance_class: ["[[exo__DisplayNameSpec]]"],
+          exo__DisplayNameSpec_appliesToClass: "[[C|ems__Project]]",
+          exo__DisplayNameSpec_priority: 5,
+        },
+      },
+      {
+        path: "v1-part.md",
+        frontmatter: {
+          exo__Asset_uid: "v1-part",
+          exo__Instance_class: ["[[exo__PrintedLiteral]]"],
+          exo__DisplayNamePart_of: "[[v1-spec]]",
+          exo__DisplayNamePart_order: 1,
+          exo__PrintedLiteral_literal: "PROJECT",
+        },
+      },
+    ]);
+    const service = new PrintNameRuleService(app, DEFAULT_DISPLAY_MATCHER_HOST_FUNCTIONS);
+    service.initialize();
+    // v1 call shape (no metadata) still returns the unconditional rule.
+    expect(service.getTemplateForClass("ems__Project")!.template).toBe("PROJECT");
+    // and with metadata it is unchanged (matcher-less → always participates).
+    expect(
+      service.getTemplateForClass("ems__Project", {
+        exo__Instance_class: ["[[ems__Project]]"],
+      })!.template,
+    ).toBe("PROJECT");
   });
 });


### PR DESCRIPTION
## What

Adds a **computed / host-function matcher** kind to `exo__DisplayNameSpec`. Until now a spec's matcher was value-equality only (`exo__DisplayNameSpec_matchPath` + `_matchValue`, req ed4201d1) — it can only inspect the instance's OWN frontmatter. This adds a new `exo__DisplayNameSpec_matchHostFunction` property naming a **registered display-matcher host function** evaluated PER-RENDER from `(app, instance metadata)`, so a spec can match on a **cross-asset** condition (resolving OTHER assets). The first registered function is `isEffortBlocked` (reuses `BlockerHelpers.isEffortBlocked` — reads `ems__Effort_blocker`, resolves that asset, checks ITS status), making the 🚩 blocked marker expressible as a homoiconic `exo__DisplayNameSpec`.

`Req: d6cd2371-bdf2-460e-840e-841480273869`

## How

- `DisplayNameMatcher` → discriminated union `ValueEqualityMatcher | HostFunctionMatcher`.
- The host-function registry is **injected** into `PrintNameRuleService` (default `{}`), seeded from the composition root (`ExocortexPlugin`) with `DEFAULT_DISPLAY_MATCHER_HOST_FUNCTIONS = { isEffortBlocked }` — the domain engine stays free of the concrete predicate (dependency inversion, mirrors the precondition-host-function pattern). An **unregistered** name never participates (fail-closed — a conditional prefix must not appear when its predicate can't be evaluated).
- Selection stays **priority-based** (`selectRule`). No-matcher specs are **v1 byte-identical**. v2 single-matcher slice: a spec carries EITHER value-equality OR host-function (value-equality wins if both declared); conjunctions are a future `exo__DisplayNameMatcher`.
- New TBox property `exo__DisplayNameSpec_matchHostFunction` (DatatypeProperty, domain `exo__DisplayNameSpec`, range xsd:string, 0..1) shipped to `exoas-exo` — SHACL-clean (`conforms: true`, 0 violations).

## Scope boundary (intentional, orchestrator-approved)

Delivers the **capability + a revert-verified binding test + the TBox property**. It does **NOT** ship a LIVE 🚩-blocked instance-spec to production and does **NOT** remove the DailyNote renderer 🚩 residual (`daily-tasks/helpers.ts getDisplayName`). Reason: the renderer residual stays until **prefix composition** — a blocked *Doing* task must show BOTH 🚩 AND 🔄, and the single-winning-template model shows ONE. Shipping a live `ems__Task` 🚩 spec now would double-🚩 blocked non-Doing tasks in the DailyNote table (collision with the residual). The live 🚩 instance-spec + residual removal + native-link 🚩+🔄 composition are bundled into the **deferred #3864-line composition follow-up** (filed as a follow-up issue).

## Test / revert-verify

New `[req d6cd2371]` suite (7 tests) drives the **real** `PrintNameRuleService.scanVault → getTemplateForClass(metadata) → DisplayNameResolver.resolve` over an in-memory vault carrying a 🚩-blocked host-function spec + a blocker asset the task's `ems__Effort_blocker` resolves to — the **real** `isEffortBlocked` runs (no hand-injected matcher result). Covers: binding, cross-asset done-check, per-render flip (blocker status changes → 🚩 toggles, no re-scan), priority interaction, fail-closed unregistered name, v1 no-regression.

**Revert-verified:**
- Neutralize the host-function eval to **never-participate** → the blocked task loses 🚩 → **3 tests RED**; restore → GREEN.
- Neutralize to **always-participate** → non-blocked/done tasks gain a spurious 🚩 → **4-5 tests RED** (incl. the fail-closed guard proving independence); restore → **21/21 GREEN**.
- The no-matcher spec assertion stays GREEN both ways (guards the v1 path).

## Verification

- `npm run check:types` = 0 errors; `npm run lint` + 3 CI guard scripts (shard-assign, check-test-antipatterns 55/55, coverage-monotonic) = exit 0.
- Full display-name + daily-tasks suites: **225/225**. New suite: **21/21**.
- code-reviewer: **APPROVE**, 0 CRITICAL/HIGH/MEDIUM (2 informational LOWs — no fixes needed; independently re-ran the revert-verify).

Closes #3865
