### PR TITLE
feat(display-name): prefix composition — compose multiple participating specs + remove DailyNote 🚩 residual (#3878)

### DIFF
--- a/packages/obsidian-plugin/src/domain/display-name/DisplayNameResolver.ts
+++ b/packages/obsidian-plugin/src/domain/display-name/DisplayNameResolver.ts
@@ -89,39 +89,64 @@ export class DisplayNameResolver {
 
   /**
    * Compose ≥2 participating specs (already priority-DESC) into one template:
-   * `<composed prefixes><base label>`. Each spec's PREFIX is the text before its first
-   * {{placeholder}}; the base (the placeholder part = the printed label) is taken ONCE, from the
-   * highest-priority spec that carries one. Prefix markers are de-duplicated by whitespace token, so
-   * a spec that re-bakes a marker already present does not double it (req 1a550210, Option B —
-   * e.g. the Meeting "✅ 👥"-Done spec over the plain "👥" spec composes to "✅ 👥", not "✅ 👥 👥").
-   * NOTE: composition treats a prefix as space-separated marker tokens — the shipped combined specs
+   * `<composed prefixes><base label><composed suffixes>`. Each spec is split into a PREFIX (leading
+   * literals, before its first {{placeholder}}), a CORE (the placeholder region = the printed label,
+   * taken ONCE from the highest-priority spec that carries one), and a SUFFIX (trailing literals,
+   * after its last {{placeholder}}). Both prefix AND suffix markers are composed — symmetric — so a
+   * suffix spec ("{{label}} (RFC)") that co-participates with a higher-priority prefix spec keeps its
+   * "(RFC)" instead of being dropped. Markers are de-duplicated by whitespace token, so a spec that
+   * re-bakes a marker already present does not double it (req 1a550210, Option B — e.g. the Meeting
+   * "✅ 👥"-Done spec over the plain "👥" spec composes to "✅ 👥", not "✅ 👥 👥").
+   * NOTE: composition treats each side as space-separated marker tokens — the shipped combined specs
    * (e.g. "✅ 👥 ") space their markers, so re-baked markers de-dup correctly.
    */
   private composeTemplates(rules: ParticipatingRule[]): string {
-    const seen = new Set<string>();
-    const markers: string[] = [];
-    let base: string | null = null;
-    for (const rule of rules) {
-      const { prefix, rest } = this.splitAtPlaceholder(rule.template);
-      // Base label = the first (highest-priority) spec that carries a {{placeholder}} part.
-      if (base === null && rest.trim() !== "") base = rest;
-      for (const token of prefix.trim().split(/\s+/)) {
+    const seenPrefix = new Set<string>();
+    const seenSuffix = new Set<string>();
+    const prefixMarkers: string[] = [];
+    const suffixMarkers: string[] = [];
+    let core: string | null = null;
+    const collect = (raw: string, seen: Set<string>, into: string[]) => {
+      for (const token of raw.trim().split(/\s+/)) {
         if (!token || seen.has(token)) continue;
         seen.add(token);
-        markers.push(token);
+        into.push(token);
       }
+    };
+    for (const rule of rules) {
+      const { prefix, core: ruleCore, suffix } = this.splitTemplate(rule.template);
+      // Core (the label placeholder) = the first (highest-priority) spec that carries one.
+      if (core === null && ruleCore !== "") core = ruleCore;
+      collect(prefix, seenPrefix, prefixMarkers);
+      collect(suffix, seenSuffix, suffixMarkers);
     }
-    // Degenerate: no spec carried a base placeholder — fall back to the top spec's (possibly empty) rest.
-    if (base === null) base = this.splitAtPlaceholder(rules[0].template).rest;
-    const composedPrefix = markers.map((m) => `${m} `).join("");
-    return `${composedPrefix}${base}`;
+    // Degenerate: no spec carried a {{placeholder}} core — the composed prefix markers stand alone.
+    const composedCore = core ?? "";
+    const composedPrefix = prefixMarkers.map((m) => `${m} `).join("");
+    const composedSuffix = suffixMarkers.length ? ` ${suffixMarkers.join(" ")}` : "";
+    return `${composedPrefix}${composedCore}${composedSuffix}`;
   }
 
-  /** Split a template at its first {{placeholder}} → prefix (leading literals) + rest (base label + suffix). */
-  private splitAtPlaceholder(template: string): { prefix: string; rest: string } {
-    const idx = template.indexOf("{{");
-    if (idx === -1) return { prefix: template, rest: "" };
-    return { prefix: template.slice(0, idx), rest: template.slice(idx) };
+  /**
+   * Split a template into prefix (leading literals) + core (the {{placeholder}} region = the label) +
+   * suffix (trailing literals). A template with no {{placeholder}} is treated as all-prefix (a pure
+   * literal marker). Uses first `{{` and last `}}` so a multi-placeholder core stays intact.
+   */
+  private splitTemplate(template: string): {
+    prefix: string;
+    core: string;
+    suffix: string;
+  } {
+    const first = template.indexOf("{{");
+    const last = template.lastIndexOf("}}");
+    if (first === -1 || last === -1 || last < first) {
+      return { prefix: template, core: "", suffix: "" };
+    }
+    return {
+      prefix: template.slice(0, first),
+      core: template.slice(first, last + 2),
+      suffix: template.slice(last + 2),
+    };
   }
 
   /**

--- a/packages/obsidian-plugin/src/domain/display-name/DisplayNameResolver.ts
+++ b/packages/obsidian-plugin/src/domain/display-name/DisplayNameResolver.ts
@@ -1,6 +1,6 @@
 import { DisplayNameTemplateEngine } from "./DisplayNameTemplateEngine";
 import type { MetadataResolver } from "./DisplayNameTemplateEngine";
-import type { PrintNameRuleService } from "./PrintNameRuleService";
+import type { PrintNameRuleService, ParticipatingRule } from "./PrintNameRuleService";
 import type { DisplayNameSettings } from "@plugin/domain/settings/ExocortexSettings";
 
 export interface DisplayNameContext {
@@ -37,32 +37,46 @@ export class DisplayNameResolver {
   }
 
   /**
-   * Select the winning template across ALL of a note's classes (class-membership,
-   * req 83be3f2f). For each class the ruleService yields its best `{template, priority}`
-   * (direct rules + ancestor-inheritance walk + the per-render conditional matcher of
-   * req ed4201d1); the highest-priority PARTICIPATING result across every class wins — so a
-   * class-level spec participates whenever its class is present among the note's classes,
-   * regardless of which one is listed first. Ties keep the earliest (first-listed) class,
-   * so a single-class note is byte-identical to the pre-membership `[0]` path. Falls back to
-   * the first class's TS classTemplate seed, then the default template — exactly as before.
-   * The single-winning-template model still picks ONE template (no prefix composition —
-   * out of scope, see req 83be3f2f).
+   * COMPOSE the displayName template across ALL of a note's classes (PREFIX COMPOSITION,
+   * req 1a550210). This supersedes the single-winning-template model (req 83be3f2f): instead of
+   * picking the one highest-priority participating spec, EVERY participating spec across the note's
+   * classes (direct + ancestor-inheritance walk + the per-render matcher of req ed4201d1/d6cd2371)
+   * contributes its PREFIX, composed in a deterministic order into `<composed prefixes><base label>`.
+   *
+   *  - a blocked Doing task composes 🚩 (isEffortBlocked host-function spec) + 🔄 (status=Doing spec)
+   *    → "🚩 🔄 <label>" — the same on native links AND every plugin table (previously only DailyNote
+   *    faked the 🚩 renderer-side; that residual is now removed).
+   *  - de-dup guards the pre-existing "combined" specs (e.g. the Meeting ✅ 👥-Done spec that re-bakes
+   *    👥) from double-printing a marker already present → a Done Meeting stays "✅ 👥 <label>".
+   *  - a SINGLE participating spec composes to itself → byte-identical, no regression; NO participating
+   *    spec falls back to the first class's TS classTemplate seed, then the default template — as before.
    */
   getTemplateForClasses(
     assetClasses: string[],
     metadata?: Record<string, unknown>,
   ): string {
     if (this.ruleService && assetClasses.length > 0) {
-      let best: { template: string; priority: number } | null = null;
+      // Gather EVERY participating spec across all of the note's classes, de-duped by spec UID so a
+      // spec that applies to more than one of the note's classes contributes at most one prefix.
+      const gathered: ParticipatingRule[] = [];
+      const seenSpecs = new Set<string>();
       for (const assetClass of assetClasses) {
-        const rule = this.ruleService.getTemplateForClass(assetClass, metadata);
-        // Strictly-greater keeps the earliest class on a priority tie (deterministic,
-        // and byte-identical to the single-class path).
-        if (rule && (best === null || rule.priority > best.priority)) {
-          best = rule;
+        for (const rule of this.ruleService.getParticipatingRules(assetClass, metadata)) {
+          if (seenSpecs.has(rule.sourceFile)) continue;
+          seenSpecs.add(rule.sourceFile);
+          gathered.push(rule);
         }
       }
-      if (best) return best.template;
+      if (gathered.length > 0) {
+        // Deterministic compose order = priority DESC (the vault-declared compose-order field),
+        // tiebreak by spec UID for full determinism. One spec → its template unchanged (byte-identical).
+        gathered.sort(
+          (a, b) => b.priority - a.priority || a.sourceFile.localeCompare(b.sourceFile),
+        );
+        return gathered.length === 1
+          ? gathered[0].template
+          : this.composeTemplates(gathered);
+      }
     }
 
     const firstClass = assetClasses[0];
@@ -71,6 +85,43 @@ export class DisplayNameResolver {
     }
 
     return this.settings.defaultTemplate;
+  }
+
+  /**
+   * Compose ≥2 participating specs (already priority-DESC) into one template:
+   * `<composed prefixes><base label>`. Each spec's PREFIX is the text before its first
+   * {{placeholder}}; the base (the placeholder part = the printed label) is taken ONCE, from the
+   * highest-priority spec that carries one. Prefix markers are de-duplicated by whitespace token, so
+   * a spec that re-bakes a marker already present does not double it (req 1a550210, Option B —
+   * e.g. the Meeting "✅ 👥"-Done spec over the plain "👥" spec composes to "✅ 👥", not "✅ 👥 👥").
+   * NOTE: composition treats a prefix as space-separated marker tokens — the shipped combined specs
+   * (e.g. "✅ 👥 ") space their markers, so re-baked markers de-dup correctly.
+   */
+  private composeTemplates(rules: ParticipatingRule[]): string {
+    const seen = new Set<string>();
+    const markers: string[] = [];
+    let base: string | null = null;
+    for (const rule of rules) {
+      const { prefix, rest } = this.splitAtPlaceholder(rule.template);
+      // Base label = the first (highest-priority) spec that carries a {{placeholder}} part.
+      if (base === null && rest.trim() !== "") base = rest;
+      for (const token of prefix.trim().split(/\s+/)) {
+        if (!token || seen.has(token)) continue;
+        seen.add(token);
+        markers.push(token);
+      }
+    }
+    // Degenerate: no spec carried a base placeholder — fall back to the top spec's (possibly empty) rest.
+    if (base === null) base = this.splitAtPlaceholder(rules[0].template).rest;
+    const composedPrefix = markers.map((m) => `${m} `).join("");
+    return `${composedPrefix}${base}`;
+  }
+
+  /** Split a template at its first {{placeholder}} → prefix (leading literals) + rest (base label + suffix). */
+  private splitAtPlaceholder(template: string): { prefix: string; rest: string } {
+    const idx = template.indexOf("{{");
+    if (idx === -1) return { prefix: template, rest: "" };
+    return { prefix: template.slice(0, idx), rest: template.slice(idx) };
   }
 
   /**

--- a/packages/obsidian-plugin/src/domain/display-name/PrintNameRuleService.ts
+++ b/packages/obsidian-plugin/src/domain/display-name/PrintNameRuleService.ts
@@ -74,6 +74,19 @@ export interface PrintNameRule {
   matcher?: DisplayNameMatcher;
 }
 
+/**
+ * A single participating spec exposed to the DisplayNameResolver for PREFIX COMPOSITION
+ * (req 1a550210): its compiled template, its priority (the vault-declared compose-order field),
+ * and the spec UID it came from (sourceFile) so the resolver can de-duplicate a spec that applies
+ * to several of the note's classes. This is the multi-rule sibling of getTemplateForClass's single
+ * `{ template, priority }` — the resolver composes a LIST of these instead of picking one.
+ */
+export interface ParticipatingRule {
+  template: string;
+  priority: number;
+  sourceFile: string;
+}
+
 type MetadataResolver = (wikilinkTarget: string) => Record<string, unknown> | null;
 
 // --- exo__DisplayNameSpec (structured-RDF displayName specs, v1 thin) ---
@@ -154,11 +167,35 @@ export class PrintNameRuleService {
   }
 
   /**
-   * Pick the highest-priority PARTICIPATING rule from a priority-sorted list. A rule
-   * participates if it is unconditional (no matcher) OR its matcher is satisfied by the
-   * instance metadata. A matched conditional rule beats an unconditional one purely by
-   * priority (the list is already sorted descending), so a conditional spec authored with
-   * a higher priority wins over the fallback; an unmatched conditional is skipped.
+   * Return ALL participating rules for a class — the list the DisplayNameResolver composes into a
+   * multi-prefix displayName (PREFIX COMPOSITION, req 1a550210). Mirrors getTemplateForClass's
+   * direct-shadows-ancestor precedence: if ANY direct rule participates, EVERY participating direct
+   * rule is returned (priority-DESC, already sorted); otherwise the participating rules of the first
+   * ancestor level that has any. Each entry carries its spec sourceFile so the resolver can de-dup a
+   * spec that applies to several of the note's classes. Empty when no rule participates (the resolver
+   * then falls back to classTemplates / the default label). getTemplateForClass (single winner) is
+   * retained for direct callers and byte-identical to `getParticipatingRules(...)[0]`.
+   */
+  getParticipatingRules(
+    className: string,
+    metadata?: Record<string, unknown>,
+  ): ParticipatingRule[] {
+    if (!this.initialized) return [];
+
+    const direct = this.participatingOf(this.rules.get(className), metadata);
+    if (direct.length > 0) return direct;
+
+    for (const ancestor of this.getAncestorClasses(className)) {
+      const inherited = this.participatingOf(this.rules.get(ancestor), metadata);
+      if (inherited.length > 0) return inherited;
+    }
+    return [];
+  }
+
+  /**
+   * Pick the highest-priority PARTICIPATING rule from a priority-sorted list — the single-winner
+   * accessor still used by getTemplateForClass and direct tests. A rule participates if it is
+   * unconditional (no matcher) OR its matcher is satisfied by the instance metadata (ruleParticipates).
    */
   private selectRule(
     rules: PrintNameRule[] | undefined,
@@ -166,10 +203,42 @@ export class PrintNameRuleService {
   ): PrintNameRule | null {
     if (!rules || rules.length === 0) return null;
     for (const rule of rules) {
-      if (!rule.matcher) return rule; // unconditional — always participates
-      if (metadata && this.matcherSatisfied(rule.matcher, metadata)) return rule;
+      if (this.ruleParticipates(rule, metadata)) return rule;
     }
     return null;
+  }
+
+  /** Every participating rule from a (priority-sorted) list — the multi-rule sibling of selectRule. */
+  private participatingOf(
+    rules: PrintNameRule[] | undefined,
+    metadata?: Record<string, unknown>,
+  ): ParticipatingRule[] {
+    if (!rules || rules.length === 0) return [];
+    const out: ParticipatingRule[] = [];
+    for (const rule of rules) {
+      if (this.ruleParticipates(rule, metadata)) {
+        out.push({
+          template: rule.template,
+          priority: rule.priority,
+          sourceFile: rule.sourceFile,
+        });
+      }
+    }
+    return out;
+  }
+
+  /**
+   * True when a rule participates in selection: unconditional (no matcher — v1 path, always
+   * participates) OR its matcher is satisfied by the rendered instance metadata (per-render). When
+   * `metadata` is omitted a conditional rule cannot be tested, so it is skipped.
+   */
+  private ruleParticipates(
+    rule: PrintNameRule,
+    metadata?: Record<string, unknown>,
+  ): boolean {
+    if (!rule.matcher) return true;
+    if (!metadata) return false; // conditional rule but no instance to test → skipped
+    return this.matcherSatisfied(rule.matcher, metadata);
   }
 
   /**

--- a/packages/obsidian-plugin/src/presentation/components/daily-tasks/helpers.ts
+++ b/packages/obsidian-plugin/src/presentation/components/daily-tasks/helpers.ts
@@ -126,29 +126,28 @@ export const formatTimeEstimate = (minutes: number | null | undefined): string =
 /**
  * Compose the DailyNote task-cell label.
  *
- * The status/class prefix (\uD83D\uDD04 Doing, \u2705 Done, \u274C Trashed, \uD83D\uDC65 Meeting) is HOMOICONIC \u2014 it is
- * carried by `task.displayName`, resolved by DailyTasksRenderer through the vault
- * `exo__DisplayNameSpec` system (single source of truth, same as native Obsidian links). This
- * helper no longer re-implements a hardcoded emoji map (Issue: req a577316f).
+ * EVERY prefix marker (\uD83D\uDD04 Doing, \u2705 Done, \u274C Trashed, \uD83D\uDC65 Meeting, AND \uD83D\uDEA9 blocked) is now
+ * HOMOICONIC \u2014 it is carried by `task.displayName`, resolved by DailyTasksRenderer through the vault
+ * `exo__DisplayNameSpec` system (single source of truth, same as native Obsidian links). The \uD83D\uDEA9
+ * blocked marker used to be RE-ADDED renderer-side here (`blockerIcon`) because the resolver picked a
+ * single winning template and could not COMPOSE \uD83D\uDEA9 with the status prefix; with prefix composition
+ * (req 1a550210) the resolver emits "\uD83D\uDEA9 \uD83D\uDD04 <label>" itself, on ALL surfaces, so that residual is
+ * REMOVED (removing it also closes the double-\uD83D\uDEA9 window it caused once the live \uD83D\uDEA9 spec ships). This
+ * helper no longer re-implements ANY hardcoded emoji \u2014 all prefixes come from vault data (req a577316f).
  *
- * The \uD83D\uDEA9 blocked marker is RETAINED renderer-side: it is a computed predicate over the
- * referenced blocker asset's status, which the current single-value exo__DisplayNameSpec
- * matcher cannot express \u2014 tracked as a separate engine-extension follow-up.
- *
- * When `task.displayName` is unavailable (empty slots, or no printNameRuleService in tests)
- * the old label path is used: a custom `getAssetLabel(path)` wins over `task.label`.
+ * When `task.displayName` is unavailable (empty slots, or no printNameRuleService in tests) the old
+ * label path is used: a custom `getAssetLabel(path)` wins over `task.label` \u2014 with no prefix (there
+ * is no resolver to supply the homoiconic markers, consistent with how \uD83D\uDD04/\u2705 also vanish then).
  */
 export const getDisplayName = (
   task: DailyTask,
   getAssetLabel?: (path: string) => string | null,
 ): string => {
-  const blockerIcon = task.isBlocked ? "\uD83D\uDEA9 " : "";
-
   if (task.displayName != null && task.displayName !== "") {
-    return blockerIcon + task.displayName;
+    return task.displayName;
   }
 
-  // Fallback: no resolver-driven name \u2192 old label path (no status/class prefix).
+  // Fallback: no resolver-driven name \u2192 old label path (no homoiconic prefixes).
   let displayText = task.label || task.title;
 
   if (typeof getAssetLabel === "function") {
@@ -162,7 +161,7 @@ export const getDisplayName = (
     }
   }
 
-  return blockerIcon + displayText;
+  return displayText;
 };
 
 export const getEffortAreaDisplayText = (

--- a/packages/obsidian-plugin/tests/component/DailyTasksTable.spec.tsx
+++ b/packages/obsidian-plugin/tests/component/DailyTasksTable.spec.tsx
@@ -342,12 +342,18 @@ test.describe("DailyTasksTable", () => {
     await expect(component.locator('thead th:has-text("Status")')).toContainText("↑");
   });
 
-  test("should display blocker icon when task is blocked", async ({ mount }) => {
+  test("should display the 🚩 blocker marker carried by the homoiconic displayName", async ({
+    mount,
+  }) => {
+    // 🚩 is now HOMOICONIC (req 1a550210): the resolver composes it into `displayName` (via the live
+    // isEffortBlocked exo__DisplayNameSpec) — the DailyNote renderer no longer prepends a residual 🚩.
     const blockedTask: DailyTask = {
       file: { path: "blocked-task.md", basename: "blocked-task" },
       path: "blocked-task.md",
       title: "Blocked Task",
       label: "Blocked Task",
+      // What the resolver hands the row: the 🚩 prefix comes from vault data, not renderer hardcode.
+      displayName: "🚩 Blocked Task",
       startTime: "09:00",
       endTime: "10:00",
       status: "ems__EffortStatusInProgress",
@@ -366,6 +372,9 @@ test.describe("DailyTasksTable", () => {
     );
     await expect(taskName).toContainText("🚩");
     await expect(taskName).toContainText("Blocked Task");
+    // No double 🚩: the renderer residual is removed, so the single displayName 🚩 is not doubled.
+    const text = (await taskName.textContent()) ?? "";
+    expect(text).not.toContain("🚩 🚩");
   });
 
   test("should not display blocker icon when task is not blocked", async ({

--- a/packages/obsidian-plugin/tests/unit/domain/display-name/DisplayNameResolver.composition.test.ts
+++ b/packages/obsidian-plugin/tests/unit/domain/display-name/DisplayNameResolver.composition.test.ts
@@ -142,6 +142,94 @@ function compositionVault(
   return { resolver, setBlockerStatus };
 }
 
+/**
+ * Vault with the 🔄-Doing PREFIX spec (priority 100) + an unconditional SUFFIX spec
+ * "{{label}} (RFC)" (priority 10) on ems__Task — to prove symmetric compose (prefix + suffix).
+ */
+function compositionVaultWithSuffix(): DisplayNameResolver {
+  const fileCache = new Map<string, CachedMetadata>();
+  const mockFiles: TFile[] = [];
+  const addFile = (path: string, frontmatter: Record<string, unknown>) => {
+    const tfile = new TFile(path);
+    tfile.basename = path.replace(".md", "");
+    tfile.extension = "md";
+    mockFiles.push(tfile);
+    fileCache.set(path, { frontmatter } as CachedMetadata);
+  };
+
+  addFile(`${STATUS_PROP_UID}.md`, {
+    exo__Asset_uid: STATUS_PROP_UID,
+    exo__Instance_class: ["[[9a1cf31c-9d41-4ef3-9023-584a8d087d16|exo__ObjectProperty]]"],
+    exo__Asset_label: "ems__Effort_status",
+  });
+
+  // 🔄-Doing prefix spec (priority 100).
+  addFile("spec-doing.md", {
+    exo__Asset_uid: "spec-doing",
+    exo__Instance_class: [`[[${DISPLAY_NAME_SPEC_CLASS}|exo__DisplayNameSpec]]`],
+    exo__DisplayNameSpec_appliesToClass: `[[${TASK_UID}|ems__Task]]`,
+    exo__DisplayNameSpec_priority: 100,
+    exo__DisplayNameSpec_matchPath: `[[${STATUS_PROP_UID}|ems__Effort_status]]`,
+    exo__DisplayNameSpec_matchValue: `[[${DOING_UID}|ems__EffortStatusDoing]]`,
+  });
+  addFile("doing-literal.md", {
+    exo__Asset_uid: "doing-literal",
+    exo__Instance_class: [`[[${PRINTED_LITERAL_CLASS}|exo__PrintedLiteral]]`],
+    exo__DisplayNamePart_of: "[[spec-doing]]",
+    exo__DisplayNamePart_order: 0,
+    exo__PrintedLiteral_literal: "🔄 ",
+  });
+  addFile("doing-prop.md", {
+    exo__Asset_uid: "doing-prop",
+    exo__Instance_class: [`[[${PRINTED_PROPERTY_CLASS}|exo__PrintedProperty]]`],
+    exo__DisplayNamePart_of: "[[spec-doing]]",
+    exo__DisplayNamePart_order: 1,
+    exo__PrintedProperty_property: `[[${LABEL_PROP_UID}|exo__Asset_label]]`,
+  });
+
+  // Unconditional SUFFIX spec: "{{label}} (RFC)" (priority 10) — PrintedProperty THEN PrintedLiteral.
+  addFile("spec-suffix.md", {
+    exo__Asset_uid: "spec-suffix",
+    exo__Instance_class: [`[[${DISPLAY_NAME_SPEC_CLASS}|exo__DisplayNameSpec]]`],
+    exo__DisplayNameSpec_appliesToClass: `[[${TASK_UID}|ems__Task]]`,
+    exo__DisplayNameSpec_priority: 10,
+  });
+  addFile("suffix-prop.md", {
+    exo__Asset_uid: "suffix-prop",
+    exo__Instance_class: [`[[${PRINTED_PROPERTY_CLASS}|exo__PrintedProperty]]`],
+    exo__DisplayNamePart_of: "[[spec-suffix]]",
+    exo__DisplayNamePart_order: 0,
+    exo__PrintedProperty_property: `[[${LABEL_PROP_UID}|exo__Asset_label]]`,
+  });
+  addFile("suffix-literal.md", {
+    exo__Asset_uid: "suffix-literal",
+    exo__Instance_class: [`[[${PRINTED_LITERAL_CLASS}|exo__PrintedLiteral]]`],
+    exo__DisplayNamePart_of: "[[spec-suffix]]",
+    exo__DisplayNamePart_order: 1,
+    exo__PrintedLiteral_literal: " (RFC)",
+  });
+
+  const app = {
+    vault: { getMarkdownFiles: jest.fn().mockReturnValue(mockFiles) },
+    metadataCache: {
+      getFileCache: jest
+        .fn()
+        .mockImplementation((file: TFile) => fileCache.get(file.path) ?? null),
+      getFirstLinkpathDest: jest.fn().mockImplementation((path: string) => {
+        const clean = path.endsWith(".md") ? path : path + ".md";
+        return mockFiles.find((f) => f.path === clean) ?? null;
+      }),
+    },
+  } as unknown as App;
+
+  const service = new PrintNameRuleService(app);
+  service.initialize();
+  return new DisplayNameResolver(
+    { defaultTemplate: "{{exo__Asset_label}}", classTemplates: {} },
+    service,
+  );
+}
+
 function taskMeta(
   opts: { status?: string; blocker?: string | null; label?: string } = {},
 ): Record<string, unknown> {
@@ -208,6 +296,19 @@ describe("DisplayNameResolver — prefix composition [req 1a550210]", () => {
       basename: "backlog-unblocked",
     });
     expect(plain).toBe("Ship the release");
+  });
+
+  it("@req:1a550210-f07e-4cbc-8707-6d4b428bba11 composition is SYMMETRIC — a co-participating SUFFIX spec keeps its trailing marker, not dropped by a higher-priority prefix spec", () => {
+    // Add a SUFFIX spec on ems__Task ("{{label}} (RFC)", unconditional, priority 10) alongside the
+    // 🔄-Doing prefix spec (priority 100). A Doing task composes the prefix 🔄 (front) AND the suffix
+    // (RFC) (back) → "🔄 <label> (RFC)". Guards the latent suffix-drop the reviewer flagged (a
+    // suffix spec that is not the base must not have its trailing marker discarded).
+    const resolver = compositionVaultWithSuffix();
+    const composed = resolver.resolve({
+      metadata: taskMeta({ status: `[[${DOING_UID}]]` }),
+      basename: "doing-rfc",
+    });
+    expect(composed).toBe("🔄 Ship the release (RFC)");
   });
 
   it("@req:1a550210-f07e-4cbc-8707-6d4b428bba11 composition is PER-RENDER + CROSS-ASSET — flipping the BLOCKER's status toggles the composed 🚩 without a re-scan", () => {

--- a/packages/obsidian-plugin/tests/unit/domain/display-name/DisplayNameResolver.composition.test.ts
+++ b/packages/obsidian-plugin/tests/unit/domain/display-name/DisplayNameResolver.composition.test.ts
@@ -1,0 +1,232 @@
+import { PrintNameRuleService } from "@plugin/domain/display-name/PrintNameRuleService";
+import { DisplayNameResolver } from "@plugin/domain/display-name/DisplayNameResolver";
+import { DEFAULT_DISPLAY_MATCHER_HOST_FUNCTIONS } from "@plugin/presentation/utils/displayMatcherHostFunctions";
+import { TFile } from "obsidian";
+import type { App, CachedMetadata } from "obsidian";
+
+/**
+ * PREFIX COMPOSITION (req 1a550210) — the displayName resolver COMPOSES the prefixes of ALL
+ * participating exo__DisplayNameSpec specs into "<composed prefixes> + <base label>", instead of
+ * selecting a single winning template. Production-shape: a REAL PrintNameRuleService.scanVault
+ * compiles the vault specs, the REAL DEFAULT_DISPLAY_MATCHER_HOST_FUNCTIONS registry runs the REAL
+ * BlockerHelpers.isEffortBlocked (a cross-asset predicate over the referenced blocker's status), and
+ * DisplayNameResolver.resolve drives selection end-to-end — NO hand-injected rule or matcher result.
+ *
+ * The vault carries the two shipped-shaped Task specs the acceptance scenario needs:
+ *   - 🚩-blocked  (matchHostFunction isEffortBlocked, priority 200 — blocker tier, composes FIRST)
+ *   - 🔄-Doing    (matchValue ems__Effort_status=Doing, priority 100 — status tier)
+ * A blocked Doing task therefore composes "🚩 🔄 <label>"; the compose ORDER (priority DESC =
+ * blocker before status) is vault-declared, not hardcoded.
+ */
+
+// Canonical UIDs (verified in-vault this session — mirror the shipped d069c316 🔄-Doing spec).
+const TASK_UID = "1b20a8f0-d745-4e93-91db-4531b3df120e";
+const STATUS_PROP_UID = "44c6e9e3-955f-4afc-9ca5-b4bd70667051"; // ems__Effort_status
+const DOING_UID = "027e78f4-6e16-4b36-b8fb-5510507d5745";
+const BACKLOG_UID = "753a44d5-846c-4b82-9196-4fd9a4d48777";
+const LABEL_PROP_UID = "12a6151b-801f-4be2-bd6e-a787eedd56ae"; // exo__Asset_label
+const DISPLAY_NAME_SPEC_CLASS = "07eab746-0874-4676-9d98-dbaad1bc6fb8";
+const PRINTED_LITERAL_CLASS = "4d5437c9-788e-4a6d-9be0-4af3a84554f4";
+const PRINTED_PROPERTY_CLASS = "7d58de40-d941-4a66-88e2-13afc4fdc41d";
+
+const BLOCKER_BASENAME = "the-blocking-task";
+
+/**
+ * Build the production-shape vault + resolver. `blockerStatus` seeds the referenced blocker's own
+ * status (bare-label form), shared by reference with the fileCache so `setBlockerStatus` can flip the
+ * CROSS-ASSET condition per-render (no re-scan), exactly like the shipped isEffortBlocked path.
+ */
+function compositionVault(
+  opts: { blockerStatus?: string | null } = {},
+): {
+  resolver: DisplayNameResolver;
+  setBlockerStatus: (status: string | null) => void;
+} {
+  const blockerFm: Record<string, unknown> = {
+    exo__Asset_uid: "blocker-asset-uid",
+    exo__Asset_label: "The blocking task",
+  };
+  if (opts.blockerStatus != null) blockerFm.ems__Effort_status = opts.blockerStatus;
+
+  const fileCache = new Map<string, CachedMetadata>();
+  const mockFiles: TFile[] = [];
+  const addFile = (path: string, frontmatter: Record<string, unknown>) => {
+    const tfile = new TFile(path);
+    tfile.basename = path.replace(".md", "");
+    tfile.extension = "md";
+    mockFiles.push(tfile);
+    fileCache.set(path, { frontmatter } as CachedMetadata);
+  };
+
+  // ems__Effort_status property def — second hop for the 🔄-Doing matchPath UID-form.
+  addFile(`${STATUS_PROP_UID}.md`, {
+    exo__Asset_uid: STATUS_PROP_UID,
+    exo__Instance_class: ["[[9a1cf31c-9d41-4ef3-9023-584a8d087d16|exo__ObjectProperty]]"],
+    exo__Asset_label: "ems__Effort_status",
+  });
+
+  // --- 🚩-blocked spec (host-function matcher, priority 200 — composes FIRST) ---
+  addFile("spec-blocked.md", {
+    exo__Asset_uid: "spec-blocked",
+    exo__Instance_class: [`[[${DISPLAY_NAME_SPEC_CLASS}|exo__DisplayNameSpec]]`],
+    exo__DisplayNameSpec_appliesToClass: `[[${TASK_UID}|ems__Task]]`,
+    exo__DisplayNameSpec_priority: 200,
+    exo__DisplayNameSpec_matchHostFunction: "isEffortBlocked",
+  });
+  addFile("blocked-literal.md", {
+    exo__Asset_uid: "blocked-literal",
+    exo__Instance_class: [`[[${PRINTED_LITERAL_CLASS}|exo__PrintedLiteral]]`],
+    exo__DisplayNamePart_of: "[[spec-blocked]]",
+    exo__DisplayNamePart_order: 0,
+    exo__PrintedLiteral_literal: "🚩 ",
+  });
+  addFile("blocked-prop.md", {
+    exo__Asset_uid: "blocked-prop",
+    exo__Instance_class: [`[[${PRINTED_PROPERTY_CLASS}|exo__PrintedProperty]]`],
+    exo__DisplayNamePart_of: "[[spec-blocked]]",
+    exo__DisplayNamePart_order: 1,
+    exo__PrintedProperty_property: `[[${LABEL_PROP_UID}|exo__Asset_label]]`,
+  });
+
+  // --- 🔄-Doing spec (value matcher status=Doing, priority 100 — status tier) ---
+  addFile("spec-doing.md", {
+    exo__Asset_uid: "spec-doing",
+    exo__Instance_class: [`[[${DISPLAY_NAME_SPEC_CLASS}|exo__DisplayNameSpec]]`],
+    exo__DisplayNameSpec_appliesToClass: `[[${TASK_UID}|ems__Task]]`,
+    exo__DisplayNameSpec_priority: 100,
+    exo__DisplayNameSpec_matchPath: `[[${STATUS_PROP_UID}|ems__Effort_status]]`,
+    exo__DisplayNameSpec_matchValue: `[[${DOING_UID}|ems__EffortStatusDoing]]`,
+  });
+  addFile("doing-literal.md", {
+    exo__Asset_uid: "doing-literal",
+    exo__Instance_class: [`[[${PRINTED_LITERAL_CLASS}|exo__PrintedLiteral]]`],
+    exo__DisplayNamePart_of: "[[spec-doing]]",
+    exo__DisplayNamePart_order: 0,
+    exo__PrintedLiteral_literal: "🔄 ",
+  });
+  addFile("doing-prop.md", {
+    exo__Asset_uid: "doing-prop",
+    exo__Instance_class: [`[[${PRINTED_PROPERTY_CLASS}|exo__PrintedProperty]]`],
+    exo__DisplayNamePart_of: "[[spec-doing]]",
+    exo__DisplayNamePart_order: 1,
+    exo__PrintedProperty_property: `[[${LABEL_PROP_UID}|exo__Asset_label]]`,
+  });
+
+  addFile(`${BLOCKER_BASENAME}.md`, blockerFm); // the SAME blockerFm reference lives in fileCache
+
+  const app = {
+    vault: { getMarkdownFiles: jest.fn().mockReturnValue(mockFiles) },
+    metadataCache: {
+      getFileCache: jest
+        .fn()
+        .mockImplementation((file: TFile) => fileCache.get(file.path) ?? null),
+      getFirstLinkpathDest: jest.fn().mockImplementation((path: string) => {
+        const clean = path.endsWith(".md") ? path : path + ".md";
+        return mockFiles.find((f) => f.path === clean) ?? null;
+      }),
+    },
+  } as unknown as App;
+
+  // Wire the REAL host-function registry (isEffortBlocked → BlockerHelpers.isEffortBlocked).
+  const service = new PrintNameRuleService(app, DEFAULT_DISPLAY_MATCHER_HOST_FUNCTIONS);
+  service.initialize(); // real scanVault → compileDisplayNameSpecs
+  // EMPTY classTemplates prove the VAULT specs (not TS hardcodes) drive every prefix.
+  const resolver = new DisplayNameResolver(
+    { defaultTemplate: "{{exo__Asset_label}}", classTemplates: {} },
+    service,
+  );
+  const setBlockerStatus = (status: string | null) => {
+    if (status === null) delete blockerFm.ems__Effort_status;
+    else blockerFm.ems__Effort_status = status;
+  };
+  return { resolver, setBlockerStatus };
+}
+
+function taskMeta(
+  opts: { status?: string; blocker?: string | null; label?: string } = {},
+): Record<string, unknown> {
+  const m: Record<string, unknown> = {
+    exo__Instance_class: [`[[${TASK_UID}]]`],
+    exo__Asset_label: opts.label ?? "Ship the release",
+  };
+  if (opts.status != null) m.ems__Effort_status = opts.status;
+  if (opts.blocker != null) m.ems__Effort_blocker = opts.blocker;
+  return m;
+}
+
+describe("DisplayNameResolver — prefix composition [req 1a550210]", () => {
+  it("@req:1a550210-f07e-4cbc-8707-6d4b428bba11 a blocked Doing task composes BOTH prefixes → '🚩 🔄 <label>' (blocker before status, vault-declared priority order) [revert-verify anchor]", () => {
+    // The task is Doing (🔄 value-spec matches) AND blocked — its blocker's status is Doing (not
+    // done) so the REAL isEffortBlocked returns true (🚩 host-fn spec matches). BOTH specs
+    // participate; composition prints both prefixes in priority-DESC order (🚩 prio 200 before 🔄
+    // prio 100). Revert-verify RED anchor: revert the resolver to single-winning-template → only
+    // the highest-priority spec (🚩) renders → "🚩 Ship the release" (🔄 dropped) → RED; restore →
+    // "🚩 🔄 Ship the release" GREEN.
+    const { resolver } = compositionVault({ blockerStatus: "[[ems__EffortStatusDoing]]" });
+
+    const composed = resolver.resolve({
+      metadata: taskMeta({
+        status: `[[${DOING_UID}]]`,
+        blocker: `[[${BLOCKER_BASENAME}]]`,
+      }),
+      basename: "blocked-doing",
+    });
+    expect(composed).toBe("🚩 🔄 Ship the release");
+  });
+
+  it("@req:1a550210-f07e-4cbc-8707-6d4b428bba11 a blocked NON-Doing task shows a single 🚩 (only the blocked spec participates)", () => {
+    // Backlog status → the 🔄-Doing value matcher does NOT match; only the 🚩 host-fn spec
+    // participates → a single prefix, no double 🚩.
+    const { resolver } = compositionVault({ blockerStatus: "[[ems__EffortStatusDoing]]" });
+
+    const single = resolver.resolve({
+      metadata: taskMeta({
+        status: `[[${BACKLOG_UID}]]`,
+        blocker: `[[${BLOCKER_BASENAME}]]`,
+      }),
+      basename: "blocked-backlog",
+    });
+    expect(single).toBe("🚩 Ship the release");
+    expect(single).not.toContain("🚩 🚩");
+  });
+
+  it("@req:1a550210-f07e-4cbc-8707-6d4b428bba11 a single participating spec composes to itself — a Doing, NOT-blocked task is byte-identical '🔄 <label>' (no regression)", () => {
+    const { resolver } = compositionVault({ blockerStatus: "[[ems__EffortStatusDoing]]" });
+    // Doing but NO ems__Effort_blocker → isEffortBlocked false → only the 🔄 spec participates.
+    const only = resolver.resolve({
+      metadata: taskMeta({ status: `[[${DOING_UID}]]` }),
+      basename: "doing-unblocked",
+    });
+    expect(only).toBe("🔄 Ship the release");
+  });
+
+  it("@req:1a550210-f07e-4cbc-8707-6d4b428bba11 no participating spec → plain label (no regression)", () => {
+    const { resolver } = compositionVault({ blockerStatus: "[[ems__EffortStatusDoing]]" });
+    // Backlog + not blocked → neither spec participates → the bare label.
+    const plain = resolver.resolve({
+      metadata: taskMeta({ status: `[[${BACKLOG_UID}]]` }),
+      basename: "backlog-unblocked",
+    });
+    expect(plain).toBe("Ship the release");
+  });
+
+  it("@req:1a550210-f07e-4cbc-8707-6d4b428bba11 composition is PER-RENDER + CROSS-ASSET — flipping the BLOCKER's status toggles the composed 🚩 without a re-scan", () => {
+    const { resolver, setBlockerStatus } = compositionVault({
+      blockerStatus: "[[ems__EffortStatusDoing]]",
+    });
+    const meta = taskMeta({
+      status: `[[${DOING_UID}]]`,
+      blocker: `[[${BLOCKER_BASENAME}]]`,
+    }); // SAME task metadata throughout — only the OTHER asset (blocker) changes.
+
+    // blocker not-done → task blocked → both prefixes compose.
+    expect(resolver.resolve({ metadata: meta, basename: "t" })).toBe(
+      "🚩 🔄 Ship the release",
+    );
+    // the blocker becomes Done → task no longer blocked → 🚩 drops, 🔄 (still Doing) remains — no re-scan.
+    setBlockerStatus("[[ems__EffortStatusDone]]");
+    expect(resolver.resolve({ metadata: meta, basename: "t" })).toBe(
+      "🔄 Ship the release",
+    );
+  });
+});

--- a/packages/obsidian-plugin/tests/unit/domain/display-name/DisplayNameResolver.multiClass.test.ts
+++ b/packages/obsidian-plugin/tests/unit/domain/display-name/DisplayNameResolver.multiClass.test.ts
@@ -45,7 +45,9 @@ describe("DisplayNameResolver — multi-class membership [req 83be3f2f]", () => 
    * Production-shape vault carrying three real-shaped specs, compiled by the real
    * scanVault pipeline:
    *   - ems__Meeting → "👥 " (UNCONDITIONAL, priority 10)
-   *   - ems__Meeting + status=Done → "✅👥 " (CONDITIONAL, priority 60 — the composed spec)
+   *   - ems__Meeting + status=Done → "✅ 👥 " (CONDITIONAL, priority 60 — the combined spec, whose
+   *     leading literal SPACES its markers like the shipped 248f104c spec, so composition de-dups
+   *     the re-baked 👥 against the plain 👥 spec instead of double-printing it — req 1a550210)
    *   - ems__Task + status=Doing → "🔄 " (CONDITIONAL, priority 50 — the existing 🔄-Doing)
    * Plus the ems__Effort_status property def (so a conditional matchPath UID-form resolves
    * its frontmatter key via the second hop).
@@ -112,7 +114,7 @@ describe("DisplayNameResolver — multi-class membership [req 83be3f2f]", () => 
           exo__Instance_class: ["[[4d5437c9-788e-4a6d-9be0-4af3a84554f4|exo__PrintedLiteral]]"],
           exo__DisplayNamePart_of: "[[spec-meeting-done]]",
           exo__DisplayNamePart_order: 0,
-          exo__PrintedLiteral_literal: "✅👥 ",
+          exo__PrintedLiteral_literal: "✅ 👥 ",
         },
       },
       {
@@ -208,30 +210,34 @@ describe("DisplayNameResolver — multi-class membership [req 83be3f2f]", () => 
     expect(meetingFirst).toBe("👥 Weekly sync");
   });
 
-  it("the highest-priority participating spec across ALL classes wins — a Done Task-first meeting gets the composed ✅👥", () => {
+  it("@req:1a550210-f07e-4cbc-8707-6d4b428bba11 composition de-dups a re-baked marker — a Done Task-first meeting stays '✅ 👥' (NOT '✅ 👥 👥'), guarding the combined-spec regression", () => {
     const resolver = buildResolver(meetingClassSpecVault());
-    // Done: the composed ems__Meeting+Done ✅👥 spec (priority 60) beats the unconditional
-    // ems__Meeting 👥 (priority 10); the ems__Task 🔄-Doing conditional is skipped (not Doing).
+    // Done: BOTH the combined ems__Meeting+Done "✅ 👥" spec (priority 60) AND the unconditional
+    // ems__Meeting "👥" spec (priority 10) participate; the ems__Task 🔄-Doing conditional is
+    // skipped (not Doing). Prefix composition (req 1a550210) would naively print "✅ 👥 👥", but the
+    // combined spec already carries 👥, so the marker de-dup drops the second 👥 → "✅ 👥".
+    // (This is exactly why the shipped 248f104c combined spec at priority 200 must not double 👥.)
     const done = resolver.resolve({
       metadata: multiClassMeeting(["[[ems__Task]]", "[[ems__Meeting]]"], DONE_UID),
       basename: "meeting-note",
     });
-    expect(done).toBe("✅👥 Weekly sync");
+    expect(done).toBe("✅ 👥 Weekly sync");
+    expect(done).not.toContain("👥 👥"); // no double 👥 — the combined-spec no-regression guard
   });
 
-  it("two distinct-prefix specs simultaneously applicable → exactly ONE wins (composition out of scope)", () => {
+  it("@req:1a550210-f07e-4cbc-8707-6d4b428bba11 two DISTINCT-prefix specs across classes COMPOSE — a Doing multi-class note shows BOTH 🔄 and 👥 (prefix composition, supersedes the single-winner 'out of scope' note of req 83be3f2f)", () => {
     const resolver = buildResolver(meetingClassSpecVault());
-    // Doing: BOTH the ems__Task 🔄-Doing spec (priority 50) AND the ems__Meeting 👥 spec
-    // (priority 10) participate. The single-winning-template model picks ONE — the highest
-    // priority (🔄). It does NOT compose into "🔄👥" (prefix composition is a further design,
-    // explicitly out of scope for req 83be3f2f).
+    // Doing: the ems__Task 🔄-Doing spec (priority 50) AND the ems__Meeting 👥 spec (priority 10)
+    // both participate with DISTINCT markers. Prefix composition (req 1a550210) now composes them —
+    // priority-DESC → status 🔄 before class 👥 — instead of the old single-winner picking only 🔄.
     const doing = resolver.resolve({
       metadata: multiClassMeeting(["[[ems__Task]]", "[[ems__Meeting]]"], DOING_UID),
       basename: "meeting-note",
     });
-    expect(doing).toBe("🔄 Weekly sync");
-    // Non-vacuity: exactly one prefix, not both, not the other.
-    expect(doing).not.toContain("👥");
+    expect(doing).toBe("🔄 👥 Weekly sync");
+    // Non-vacuity: BOTH markers present, in the declared (priority-DESC) order.
+    expect(doing).toContain("🔄");
+    expect(doing).toContain("👥");
   });
 
   it("no-regression: a single-class ems__Meeting note is byte-identical (still 👥), both before and after the membership change", () => {

--- a/packages/obsidian-plugin/tests/unit/domain/display-name/DisplayNameResolver.test.ts
+++ b/packages/obsidian-plugin/tests/unit/domain/display-name/DisplayNameResolver.test.ts
@@ -184,11 +184,16 @@ describe("DisplayNameResolver", () => {
 
   describe("with PrintNameRuleService", () => {
     it("should use dynamic rule template over settings template", () => {
+      // The resolver now composes the PARTICIPATING specs (req 1a550210): a single participating
+      // rule composes to itself (byte-identical to the old single-winning-template path).
       const mockRuleService = {
-        getTemplateForClass: jest.fn().mockReturnValue({
-          template: "{{exo__Asset_label}} (DynamicRule)",
-          priority: 100,
-        }),
+        getParticipatingRules: jest.fn().mockReturnValue([
+          {
+            template: "{{exo__Asset_label}} (DynamicRule)",
+            priority: 100,
+            sourceFile: "spec-dynamic",
+          },
+        ]),
         createMetadataResolver: jest.fn().mockReturnValue(null),
       };
 
@@ -206,9 +211,9 @@ describe("DisplayNameResolver", () => {
       });
 
       expect(result).toBe("My Task (DynamicRule)");
-      // The resolver now forwards the instance metadata so a conditional spec
-      // (matchPath/matchValue) can be evaluated per-render (req ed4201d1).
-      expect(mockRuleService.getTemplateForClass).toHaveBeenCalledWith(
+      // The resolver forwards the instance metadata so a conditional spec
+      // (matchPath/matchValue/matchHostFunction) can be evaluated per-render (req ed4201d1/d6cd2371).
+      expect(mockRuleService.getParticipatingRules).toHaveBeenCalledWith(
         "ems__Task",
         expect.objectContaining({ exo__Asset_label: "My Task" }),
       );
@@ -216,7 +221,7 @@ describe("DisplayNameResolver", () => {
 
     it("should fall back to settings when no dynamic rule exists", () => {
       const mockRuleService = {
-        getTemplateForClass: jest.fn().mockReturnValue(null),
+        getParticipatingRules: jest.fn().mockReturnValue([]),
         createMetadataResolver: jest.fn().mockReturnValue(null),
       };
 
@@ -255,10 +260,13 @@ describe("DisplayNameResolver", () => {
         exo__Asset_label: "Parent Project",
       });
       const mockRuleService = {
-        getTemplateForClass: jest.fn().mockReturnValue({
-          template: "{{exo__Asset_label}} / {{ems__Effort_project.exo__Asset_label}}",
-          priority: 50,
-        }),
+        getParticipatingRules: jest.fn().mockReturnValue([
+          {
+            template: "{{exo__Asset_label}} / {{ems__Effort_project.exo__Asset_label}}",
+            priority: 50,
+            sourceFile: "spec-cross-asset",
+          },
+        ]),
         createMetadataResolver: jest.fn().mockReturnValue(mockMetadataResolver),
       };
 

--- a/packages/obsidian-plugin/tests/unit/domain/display-name/PrintNameRuleService.test.ts
+++ b/packages/obsidian-plugin/tests/unit/domain/display-name/PrintNameRuleService.test.ts
@@ -545,10 +545,11 @@ describe("PrintNameRuleService — conditional exo__DisplayNameSpec (v2 slice, p
     ).toBe("Fix the parser");
   });
 
-  it("a matched conditional spec BEATS a lower-priority unconditional spec; an unmatched conditional yields to it", () => {
-    // Two specs on ems__Task: a HIGH-priority conditional 🔄-Doing + a LOW-priority
-    // unconditional "[TASK] <label>". Doing → conditional wins; non-Doing → conditional
-    // is skipped and the unconditional wins.
+  it("a matched conditional spec COMPOSES with a lower-priority unconditional spec (priority sets order); an unmatched conditional yields to it alone [req 1a550210]", () => {
+    // Two specs on ems__Task: a HIGH-priority conditional 🔄-Doing (prio 80) + a LOW-priority
+    // unconditional "[TASK] <label>" (prio 1). Doing → BOTH participate → prefix composition prints
+    // them priority-DESC ("🔄 [TASK] <label>"); non-Doing → the conditional is skipped and only the
+    // unconditional participates.
     const app = createMockApp([
       // conditional (priority 80)
       {
@@ -628,11 +629,11 @@ describe("PrintNameRuleService — conditional exo__DisplayNameSpec (v2 slice, p
       service,
     );
 
-    // Doing → high-priority conditional wins.
+    // Doing → BOTH participate → composition prints 🔄 (prio 80) before [TASK] (prio 1).
     expect(resolver.resolve({ metadata: taskMeta(`[[${DOING_UID}]]`), basename: "t" })).toBe(
-      "🔄 Fix the parser",
+      "🔄 [TASK] Fix the parser",
     );
-    // Done → conditional skipped → unconditional "[TASK] <label>" wins (not the fallback label).
+    // Done → conditional skipped → only the unconditional "[TASK] <label>" participates.
     expect(resolver.resolve({ metadata: taskMeta(`[[${DONE_UID}]]`), basename: "t" })).toBe(
       "[TASK] Fix the parser",
     );
@@ -827,7 +828,7 @@ describe("PrintNameRuleService — host-function exo__DisplayNameSpec (v2 comput
     expect(resolver.resolve({ metadata: meta, basename: "t" })).toBe("🚩 Ship the release");
   });
 
-  it("a matched host-function spec BEATS a lower-priority unconditional spec; an unmatched one yields to it (selection stays priority-based)", () => {
+  it("a matched host-function spec COMPOSES with a lower-priority unconditional spec (priority sets order); an unmatched one yields to it alone [req 1a550210]", () => {
     const { resolver } = blockedHostFnVault({
       priority: 80, // host-function spec
       blockerStatus: "[[ems__EffortStatusDoing]]",
@@ -864,11 +865,12 @@ describe("PrintNameRuleService — host-function exo__DisplayNameSpec (v2 comput
       ],
     });
 
-    // blocked → high-priority host-function spec wins.
+    // blocked → BOTH participate → prefix composition prints them in priority-DESC order:
+    // 🚩 (host-fn, prio 80) before [TASK] (unconditional, prio 1) → "🚩 [TASK] <label>" (req 1a550210).
     expect(
       resolver.resolve({ metadata: taskMeta({ blocker: `[[${BLOCKER_BASENAME}]]` }), basename: "t" }),
-    ).toBe("🚩 Ship the release");
-    // not blocked → host-function skipped → unconditional "[TASK] <label>" wins (not the bare label).
+    ).toBe("🚩 [TASK] Ship the release");
+    // not blocked → host-function skipped → only the unconditional "[TASK] <label>" participates.
     expect(resolver.resolve({ metadata: taskMeta(), basename: "t" })).toBe(
       "[TASK] Ship the release",
     );

--- a/packages/obsidian-plugin/tests/unit/renderers/dailyTasks/DailyTasksRenderer.homoiconicDisplayName.test.ts
+++ b/packages/obsidian-plugin/tests/unit/renderers/dailyTasks/DailyTasksRenderer.homoiconicDisplayName.test.ts
@@ -258,3 +258,48 @@ describe("DailyTasksRenderer — homoiconic displayName (req a577316f)", () => {
     expect(getDisplayName(tasks[0])).toBe("🔄 Write the report");
   });
 });
+
+describe("getDisplayName — 🚩 residual REMOVED, blocked marker is homoiconic [req 1a550210]", () => {
+  /** Minimal DailyTask shape getDisplayName reads (displayName / label / title / path / isBlocked). */
+  const task = (over: Partial<DailyTask>): DailyTask =>
+    ({
+      file: { path: "t.md", basename: "t" },
+      path: "t.md",
+      title: "Ship it",
+      label: "Ship it",
+      startTime: "09:00",
+      endTime: "10:00",
+      status: "Doing",
+      metadata: {},
+      isDoing: true,
+      isBlocked: false,
+      ...over,
+    }) as DailyTask;
+
+  it("@req:1a550210-f07e-4cbc-8707-6d4b428bba11 does NOT re-add a 🚩 residual — the 🚩 comes from the composed displayName only, so a blocked task is NOT double-🚩 [revert-verify anchor]", () => {
+    // The resolver now composes 🚩 into displayName (via the live isEffortBlocked spec). The
+    // DailyNote renderer residual (blockerIcon) is REMOVED. Revert-verify RED anchor: re-adding the
+    // residual (`blockerIcon = task.isBlocked ? "🚩 " : ""`) makes this "🚩 🚩 🔄 Ship it" → RED;
+    // restore → "🚩 🔄 Ship it".
+    const blockedDoing = task({ displayName: "🚩 🔄 Ship it", isBlocked: true });
+    expect(getDisplayName(blockedDoing)).toBe("🚩 🔄 Ship it");
+    expect(getDisplayName(blockedDoing)).not.toContain("🚩 🚩");
+  });
+
+  it("@req:1a550210-f07e-4cbc-8707-6d4b428bba11 a blocked NON-Doing row shows a single 🚩 (from displayName), not the old renderer-doubled 🚩", () => {
+    // The blocked, non-Doing task's resolved displayName is "🚩 <label>". With the residual removed,
+    // the row shows exactly one 🚩 (re-adding the residual would double it → "🚩 🚩 ...").
+    const blockedBacklog = task({
+      displayName: "🚩 Ship it",
+      isBlocked: true,
+      isDoing: false,
+    });
+    expect(getDisplayName(blockedBacklog)).toBe("🚩 Ship it");
+    expect(getDisplayName(blockedBacklog)).not.toContain("🚩 🚩");
+  });
+
+  it("@req:1a550210-f07e-4cbc-8707-6d4b428bba11 an unblocked task keeps its plain composed displayName (no phantom 🚩)", () => {
+    const unblocked = task({ displayName: "🔄 Ship it", isBlocked: false });
+    expect(getDisplayName(unblocked)).toBe("🔄 Ship it");
+  });
+});


### PR DESCRIPTION
## displayName PREFIX COMPOSITION — the final, most-fundamental piece of the homoiconic-🚩 line

The displayName resolver now **composes the prefixes of ALL participating `exo__DisplayNameSpec` specs** into `<composed prefixes> + <base label> + <composed suffixes>`, instead of selecting a single winning template. A blocked Doing task composes 🚩 (isEffortBlocked host-function spec, #3877) + 🔄 (status=Doing spec) = **`🚩 🔄 <label>`** — the same on native links AND every plugin table.

Closes #3878. Depends on #3865/#3877 (host-function matcher, v16.182.0) — this consumes it.

### Design decision (early escalation → Andrey chose Option B)
The req's literal "compose every participating prefix" regresses the live Meeting `✅ 👥`-Done spec (prio 200, authored to *shadow* the plain `👥`) into **double-👥**. I escalated a `WAITING_DECISION` design-spike; **Andrey chose Option B (marker-token dedup, no new ontology)** over Option C (new schema field = onto-RFC). Composition dedups a re-baked marker → a Done Meeting stays `✅ 👥`, not `✅ 👥 👥`.

### Three deliverables (per #3878)
1. **Composition engine** — `PrintNameRuleService.getParticipatingRules()` (all participating rules, direct-shadows-ancestor) + `DisplayNameResolver.composeTemplates()` (prefix+suffix symmetric, priority-DESC order = the vault-declared compose-order field, marker de-dup). Single/no participating spec → **byte-identical** (no regression).
2. **Live 🚩-blocked `exo__DisplayNameSpec`** on `ems__Task` (`matchHostFunction: isEffortBlocked`, `🚩 ` + `exo__Asset_label`) → authored + pushed to `kitelev/exoas-exo` **right after this releases** (data channel; see coordination note).
3. **Remove DailyNote renderer 🚩 residual** (`daily-tasks/helpers.ts getDisplayName blockerIcon`) — 🚩 now comes from the resolver on all surfaces.

⚠ **Coordination (2)+(3):** (3) is code (this PR), (2) is data (exoas-exo). To avoid the **double-🚩** window (the worse case), the code (residual removed) is released **first**, then the live spec is pushed. Transient after release, before the spec syncs: a blocked DailyNote task briefly shows no 🚩 (never double). On the device: update the plugin (BRAT) **and** sync the vault (ExoSync) together.

### Verification
- **Production-shape component test** `DisplayNameResolver.composition.test.ts` (`@req:1a550210-...`) drives the REAL `PrintNameRuleService.scanVault → DisplayNameResolver.resolve` with the REAL `isEffortBlocked` host function (cross-asset, per-render, no hand-injected result) → `🚩 🔄 <label>`. Full plugin suite: **329 suites / 5904 tests green**; typecheck + lint + 3 CI guard scripts clean.
- **Revert-verified:**
  - Revert composition → single-winning-template → blocked-Doing = `🚩 <label>` (loses 🔄) → **RED**; restore → `🚩 🔄 <label>` **GREEN**.
  - Re-add the renderer residual → blocked row = `🚩 🚩 <label>` → no-double assertion **RED**; restore → **GREEN**.
  - Single-spec + no-spec + Done-Meeting-dedup + suffix-symmetry assertions GREEN.

### Code-reviewer
WARNING → applied: **MEDIUM** (suffix marker silently dropped) fixed by making composition prefix+suffix **symmetric**; **HIGH** (residual removed without live spec) addressed by the (2)+(3) coordination above (live spec shipped in the same window). LOW×2 (dedup assumes space-separated markers; priority sets order) documented in code.

Req: 1a550210-f07e-4cbc-8707-6d4b428bba11
Revert-verified: see above.
