### PR TITLE
refactor(displayName): remove TS cold-start classTemplates seeds (full homoiconic) + extractClassKeys appliesToClass second-hop symmetry (#3838 parts 2+3)

### DIFF
--- a/packages/obsidian-plugin/src/domain/display-name/PrintNameRuleService.ts
+++ b/packages/obsidian-plugin/src/domain/display-name/PrintNameRuleService.ts
@@ -268,14 +268,17 @@ export class PrintNameRuleService {
   }
 
   /**
-   * Resolve exo__DisplayNameSpec_matchValue into ALL identity forms of the single
-   * accepted value — the raw wikilink form(s) PLUS, via one compile-time second hop, the
-   * referenced asset's UID and label. This closes the dual-IRI gap fully: a matchValue
-   * authored UID-canon `[[<uid>]]` still matches an instance whose value is stored as the
-   * bare label `[[<label>]]` (and vice versa), because both the UID and the label end up
-   * in the accepted set. The hop runs once per spec at scanVault — no per-render cost.
+   * Resolve a wikilink-valued field into ALL identity forms of the referenced asset — the
+   * raw wikilink form(s) via extractClassKeys PLUS, via one compile-time second hop, the
+   * referenced asset's exo__Asset_uid AND exo__Asset_label. This closes the dual-IRI gap
+   * fully: a field authored UID-canon `[[<uid>]]` still matches a value stored as the bare
+   * label `[[<label>]]` (and vice versa), because both the UID and the label end up in the
+   * set. Used symmetrically for BOTH exo__DisplayNameSpec_matchValue (an enum value) AND
+   * exo__DisplayNameSpec_appliesToClass (a class) — see resolveMatchValues + the
+   * appliesToClass registration in collectDisplayNameSpec (#3838 part 2). The hop runs once
+   * per spec at scanVault — no per-render cost (the existing docstring promise).
    */
-  private resolveMatchValues(value: unknown): string[] {
+  private resolveIdentityForms(value: unknown): string[] {
     const raw = this.extractClassKeys(value);
     if (raw.length === 0) return [];
     const forms = new Set<string>(raw);
@@ -291,6 +294,14 @@ export class PrintNameRuleService {
       if (typeof label === "string" && label.trim()) forms.add(label.trim());
     }
     return [...forms];
+  }
+
+  /**
+   * Resolve exo__DisplayNameSpec_matchValue into ALL identity forms of the single accepted
+   * value (the shared dual-IRI second hop — see resolveIdentityForms).
+   */
+  private resolveMatchValues(value: unknown): string[] {
+    return this.resolveIdentityForms(value);
   }
 
   /**
@@ -396,7 +407,12 @@ export class PrintNameRuleService {
     const uid = typeof fm.exo__Asset_uid === "string" ? fm.exo__Asset_uid.trim() : "";
     if (!uid) return;
 
-    const classKeys = this.extractClassKeys(fm.exo__DisplayNameSpec_appliesToClass);
+    // appliesToClass second-hop symmetry (#3838 part 2): resolveIdentityForms (not the raw
+    // extractClassKeys) so a spec authored bare-UID `[[<uid>]]` or bare-label `[[<label>]]`
+    // still registers under BOTH the class UID AND its label — closing the same dual-IRI gap
+    // matchValue already closed. Byte-identical for shipped specs (all author `[[uid|label]]`,
+    // which extractClassKeys already expands to both forms — the hop adds nothing for them).
+    const classKeys = this.resolveIdentityForms(fm.exo__DisplayNameSpec_appliesToClass);
     if (classKeys.length === 0) return;
 
     const rawPriority = fm.exo__DisplayNameSpec_priority;

--- a/packages/obsidian-plugin/src/domain/settings/ExocortexSettings.ts
+++ b/packages/obsidian-plugin/src/domain/settings/ExocortexSettings.ts
@@ -12,30 +12,28 @@ export interface DisplayNameSettings {
 /**
  * Default display name configuration
  *
- * The defaultTemplate applies to ALL asset types not explicitly listed in classTemplates.
- * Shows only the label — classes that need a suffix (e.g. TaskPrototype) have explicit entries.
+ * FULL HOMOICONIC (#3838 part 3): classTemplates is EMPTY. Every per-class displayName
+ * (the TaskPrototype/MeetingPrototype suffixes, the status/blocked prefixes, the DailyNote
+ * basename) is now sourced ENTIRELY from vault exo__DisplayNameSpec assets read by
+ * PrintNameRuleService (PMBOK project 47d57acf, req b4ee3caa) — no TS cold-start seed.
+ *
+ * Why the seeds were removable (orchestrator-verified via the live 8-surface Phase-6 smoke
+ * on v16.183.0 + revert-verified tests): vault specs already WIN over any classTemplate
+ * (compileDisplayNameSpecs registers them as HIGH-priority PrintNameRules), so the seeds were
+ * dead-overridden once the vault scanned. Coverage lives in the vault — the unconditional
+ * TaskPrototype spec e20fda38 and the MeetingPrototype spec d7bdca33 render the " (…Prototype)"
+ * suffix; the pn__DailyNote seed was already DEAD (real DailyNotes key exo__Instance_class by
+ * the bare UID [[b04e7a3e]], never the label pn__DailyNote — dn-2110 sweep). The only remaining
+ * difference is a brief cold-start window before the vault scan — identical eventual-consistency
+ * to the status emojis, which are also vault-served and already re-render on store-settle. No
+ * steady-state user-visible change.
+ *
+ * `defaultTemplate` is the base fallback (a plain label), NOT a homoiconic seed — kept.
  */
 export const DEFAULT_DISPLAY_NAME_SETTINGS: DisplayNameSettings = {
   defaultTemplate: "{{exo__Asset_label}}",
 
-  classTemplates: {
-    // Suffix classes: the homoiconic source is the vault exo__DisplayNameSpec
-    // (PMBOK project 47d57acf, req b4ee3caa) read by PrintNameRuleService; these TS
-    // entries are the cold-start SEED that prevents a raw→suffixed flicker before the
-    // vault specs index. Keyed by BOTH the class UID (real instances reference
-    // exo__Instance_class as `[[<class-uid>]]`) AND the label form. Adding the real
-    // class UIDs (df7e579d / 7ab483c7) fixes a pre-existing gap where UID-keyed
-    // prototype instances rendered with no suffix (only label/instance-UID keys matched).
-    ems__TaskPrototype: "{{exo__Asset_label}} (TaskPrototype)",
-    "df7e579d-02d4-4f3a-971f-3d1d785b689b": "{{exo__Asset_label}} (TaskPrototype)",
-    ems__MeetingPrototype: "{{exo__Asset_label}} (MeetingPrototype)",
-    "7ab483c7-aafc-4ac8-8aca-0de52db34a93": "{{exo__Asset_label}} (MeetingPrototype)",
-    // DailyNote uses the basename (date) as its display name since it typically doesn't have a label
-    pn__DailyNote: "{{_basename}}",
-    // Pure-label classes (Task/Project/Area/Meeting) removed — they equalled defaultTemplate
-    // ("{{exo__Asset_label}}") so they now fall through to it unchanged (byte-identical).
-    // The buggy instance-UID key 75302770 (Issue #2110) is dropped — no asset references it.
-  },
+  classTemplates: {},
 };
 
 /**

--- a/packages/obsidian-plugin/tests/unit/domain/display-name/DisplayNameResolver.test.ts
+++ b/packages/obsidian-plugin/tests/unit/domain/display-name/DisplayNameResolver.test.ts
@@ -295,28 +295,36 @@ describe("DisplayNameResolver", () => {
       expect(DEFAULT_DISPLAY_NAME_SETTINGS.defaultTemplate).toBe("{{exo__Asset_label}}");
     });
 
-    it("has explicit templates only for suffix classes (label + real class UID) + DailyNote; pure-label classes use the default", () => {
-      // Suffix classes — cold-start seed keyed by BOTH label AND real class UID (req b4ee3caa, #2110).
-      expect(DEFAULT_DISPLAY_NAME_SETTINGS.classTemplates["ems__TaskPrototype"]).toBeDefined();
+    it("full homoiconic (#3838 part 3): classTemplates is EMPTY — every per-class displayName is vault-sourced", () => {
+      // The TS cold-start seeds were removed: the suffixes/prefixes/basename now come ENTIRELY
+      // from vault exo__DisplayNameSpec assets (see PrintNameRuleService.test.ts revert-verify),
+      // which already win over any classTemplate once the vault scans.
+      expect(DEFAULT_DISPLAY_NAME_SETTINGS.classTemplates).toEqual({});
+      // The removed prototype seeds (label AND real class UID forms) are gone.
+      expect(DEFAULT_DISPLAY_NAME_SETTINGS.classTemplates["ems__TaskPrototype"]).toBeUndefined();
       expect(
         DEFAULT_DISPLAY_NAME_SETTINGS.classTemplates["df7e579d-02d4-4f3a-971f-3d1d785b689b"],
-      ).toBeDefined();
-      expect(DEFAULT_DISPLAY_NAME_SETTINGS.classTemplates["ems__MeetingPrototype"]).toBeDefined();
+      ).toBeUndefined();
+      expect(DEFAULT_DISPLAY_NAME_SETTINGS.classTemplates["ems__MeetingPrototype"]).toBeUndefined();
       expect(
         DEFAULT_DISPLAY_NAME_SETTINGS.classTemplates["7ab483c7-aafc-4ac8-8aca-0de52db34a93"],
-      ).toBeDefined();
-      expect(DEFAULT_DISPLAY_NAME_SETTINGS.classTemplates["pn__DailyNote"]).toBeDefined();
-      // Pure-label classes equalled the default template → removed (they fall through unchanged).
+      ).toBeUndefined();
+      expect(DEFAULT_DISPLAY_NAME_SETTINGS.classTemplates["pn__DailyNote"]).toBeUndefined();
+      // Pure-label classes were already absent (they equalled the default template).
       expect(DEFAULT_DISPLAY_NAME_SETTINGS.classTemplates["ems__Task"]).toBeUndefined();
       expect(DEFAULT_DISPLAY_NAME_SETTINGS.classTemplates["ems__Project"]).toBeUndefined();
       expect(DEFAULT_DISPLAY_NAME_SETTINGS.classTemplates["ems__Area"]).toBeUndefined();
       expect(DEFAULT_DISPLAY_NAME_SETTINGS.classTemplates["ems__Meeting"]).toBeUndefined();
     });
 
-    it("should work correctly with resolver", () => {
+    it("with EMPTY classTemplates (no ruleService) every class falls to the plain label — the suffix now comes from the vault, not a TS seed", () => {
+      // #3838 part 3: with the cold-start seeds removed AND no PrintNameRuleService wired,
+      // a prototype instance resolves to the plain label — the " (TaskPrototype)" suffix is
+      // now provided by the vault exo__DisplayNameSpec (proven in PrintNameRuleService.test.ts),
+      // NOT by DEFAULT_DISPLAY_NAME_SETTINGS. Task/Project are byte-identical (always plain label).
       const resolver = new DisplayNameResolver(DEFAULT_DISPLAY_NAME_SETTINGS);
 
-      // Task
+      // Task — plain label (unchanged).
       const taskResult = resolver.resolve({
         metadata: {
           exo__Asset_label: "Fix bug",
@@ -326,7 +334,7 @@ describe("DisplayNameResolver", () => {
       });
       expect(taskResult).toBe("Fix bug");
 
-      // TaskPrototype
+      // TaskPrototype (label-keyed) — no seed, no ruleService → plain label.
       const prototypeResult = resolver.resolve({
         metadata: {
           exo__Asset_label: "Morning routine",
@@ -334,11 +342,9 @@ describe("DisplayNameResolver", () => {
         },
         basename: "morning-routine",
       });
-      expect(prototypeResult).toBe("Morning routine (TaskPrototype)");
+      expect(prototypeResult).toBe("Morning routine");
 
-      // FIX (req b4ee3caa): a TaskPrototype instance keyed by the REAL class UID
-      // (how real instances reference exo__Instance_class) now gets the suffix via
-      // the cold-start seed — previously it fell through to the label-only default.
+      // TaskPrototype (real-class-UID-keyed) — likewise plain label without the vault spec.
       const uidKeyedPrototype = resolver.resolve({
         metadata: {
           exo__Asset_label: "Measure HRV",
@@ -346,9 +352,9 @@ describe("DisplayNameResolver", () => {
         },
         basename: "measure-hrv",
       });
-      expect(uidKeyedPrototype).toBe("Measure HRV (TaskPrototype)");
+      expect(uidKeyedPrototype).toBe("Measure HRV");
 
-      // Pure-label class (Project) — byte-identical after its redundant classTemplate removal.
+      // Pure-label class (Project) — byte-identical (always plain label).
       const projectResult = resolver.resolve({
         metadata: {
           exo__Asset_label: "Q3 Roadmap",
@@ -400,17 +406,21 @@ describe("DisplayNameResolver", () => {
       expect(noClassResult).toBe("Asset Without Class");
     });
 
-    it("should use basename template for pn__DailyNote class", () => {
+    it("a label-less pn__DailyNote resolves to null (caller falls back to the basename) — the {{_basename}} seed is removed (#3838 part 3)", () => {
       const resolver = new DisplayNameResolver(DEFAULT_DISPLAY_NAME_SETTINGS);
 
-      // DailyNote uses basename (the date) since it typically has no label
+      // The pn__DailyNote → {{_basename}} seed is gone. A label-less DailyNote now falls to the
+      // defaultTemplate ({{exo__Asset_label}}) → empty → resolve() returns null, and the RENDERER
+      // (not the resolver) falls back to the basename — byte-identical for the user. In production
+      // the seed was already DEAD anyway: real DailyNotes key exo__Instance_class by the bare UID
+      // [[b04e7a3e]], not the label pn__DailyNote (dn-2110 sweep), so this key never matched.
       const dailyNoteResult = resolver.resolve({
         metadata: {
           exo__Instance_class: ["[[pn__DailyNote]]"],
         },
         basename: "2025-10-15",
       });
-      expect(dailyNoteResult).toBe("2025-10-15");
+      expect(dailyNoteResult).toBeNull();
     });
   });
 });

--- a/packages/obsidian-plugin/tests/unit/domain/display-name/PrintNameRuleService.test.ts
+++ b/packages/obsidian-plugin/tests/unit/domain/display-name/PrintNameRuleService.test.ts
@@ -923,3 +923,278 @@ describe("PrintNameRuleService — host-function exo__DisplayNameSpec (v2 comput
     ).toBe("PROJECT");
   });
 });
+
+describe("PrintNameRuleService — full-homoiconic seed removal (#3838 part 3)", () => {
+  const TASK_PROTO_UID = "df7e579d-02d4-4f3a-971f-3d1d785b689b";
+  const LABEL_PROP_UID = "12a6151b-801f-4be2-bd6e-a787eedd56ae";
+  const SPEC_UID = "e20fda38-shaped-taskproto-spec";
+
+  // Production-shape vault mirroring the SHIPPED unconditional TaskPrototype spec
+  // (e20fda38 on kitelev/exoas-exo): appliesToClass=ems__TaskPrototype, priority 100,
+  // UNCONDITIONAL → PrintedProperty(label) order 1 + PrintedLiteral(" (TaskPrototype)") order 2.
+  function taskProtoSpecFiles(): Array<{ path: string; frontmatter: Record<string, unknown> }> {
+    return [
+      {
+        path: `${SPEC_UID}.md`,
+        frontmatter: {
+          exo__Asset_uid: SPEC_UID,
+          exo__Instance_class: ["[[07eab746-0874-4676-9d98-dbaad1bc6fb8|exo__DisplayNameSpec]]"],
+          exo__DisplayNameSpec_appliesToClass: `[[${TASK_PROTO_UID}|ems__TaskPrototype]]`,
+          exo__DisplayNameSpec_priority: 100,
+        },
+      },
+      {
+        path: "e20-prop.md",
+        frontmatter: {
+          exo__Asset_uid: "e20-prop",
+          exo__Instance_class: ["[[7d58de40-d941-4a66-88e2-13afc4fdc41d|exo__PrintedProperty]]"],
+          exo__DisplayNamePart_of: `[[${SPEC_UID}]]`,
+          exo__DisplayNamePart_order: 1,
+          exo__PrintedProperty_property: `[[${LABEL_PROP_UID}|exo__Asset_label]]`,
+        },
+      },
+      {
+        path: "e20-literal.md",
+        frontmatter: {
+          exo__Asset_uid: "e20-literal",
+          exo__Instance_class: ["[[4d5437c9-788e-4a6d-9be0-4af3a84554f4|exo__PrintedLiteral]]"],
+          exo__DisplayNamePart_of: `[[${SPEC_UID}]]`,
+          exo__DisplayNamePart_order: 2,
+          exo__PrintedLiteral_literal: " (TaskPrototype)",
+        },
+      },
+    ];
+  }
+
+  it("the vault spec (not a TS classTemplate seed) provides the TaskPrototype suffix with EMPTY classTemplates", () => {
+    // GREEN: the shipped-shape spec is present in the vault → an ems__TaskPrototype instance
+    // gets " (TaskPrototype)" through the real scanVault→compile→resolve pipeline, with the TS
+    // classTemplates seeds REMOVED (classTemplates: {}). This proves the suffix is vault-sourced.
+    const app = createMockApp(taskProtoSpecFiles());
+    const service = new PrintNameRuleService(app);
+    service.initialize();
+
+    const resolver = new DisplayNameResolver(
+      { defaultTemplate: "{{exo__Asset_label}}", classTemplates: {} },
+      service,
+    );
+    // prototype keyed by the REAL class UID (how real instances reference exo__Instance_class)
+    expect(
+      resolver.resolve({
+        metadata: {
+          exo__Instance_class: [`[[${TASK_PROTO_UID}]]`],
+          exo__Asset_label: "Measure HRV",
+        },
+        basename: TASK_PROTO_UID,
+      }),
+    ).toBe("Measure HRV (TaskPrototype)");
+  });
+
+  it("REVERT-VERIFY: without the vault spec, the same prototype instance falls to the plain label (proves the spec — not a seed — drives the suffix)", () => {
+    // RED direction executable: remove the exo__DisplayNameSpec from the fixture vault → the
+    // service finds no rule → the resolver falls to the (empty) classTemplates → defaultTemplate
+    // → plain label. If a TS classTemplate seed still existed, this would STILL be suffixed.
+    const app = createMockApp([]); // no spec in the vault
+    const service = new PrintNameRuleService(app);
+    service.initialize();
+
+    const resolver = new DisplayNameResolver(
+      { defaultTemplate: "{{exo__Asset_label}}", classTemplates: {} },
+      service,
+    );
+    expect(
+      resolver.resolve({
+        metadata: {
+          exo__Instance_class: [`[[${TASK_PROTO_UID}]]`],
+          exo__Asset_label: "Measure HRV",
+        },
+        basename: TASK_PROTO_UID,
+      }),
+    ).toBe("Measure HRV");
+  });
+
+  it("no regression: EMPTY classTemplates leaves a plain non-prototype class at the plain label", () => {
+    // A class with NO spec + empty classTemplates → plain label (unchanged from the seeded world,
+    // where the pure-label classes had already been dropped as byte-identical to the default).
+    const app = createMockApp(taskProtoSpecFiles());
+    const service = new PrintNameRuleService(app);
+    service.initialize();
+
+    const resolver = new DisplayNameResolver(
+      { defaultTemplate: "{{exo__Asset_label}}", classTemplates: {} },
+      service,
+    );
+    expect(
+      resolver.resolve({
+        metadata: {
+          exo__Instance_class: ["[[ems__Task]]"],
+          exo__Asset_label: "Fix bug",
+        },
+        basename: "fix-bug",
+      }),
+    ).toBe("Fix bug");
+  });
+});
+
+describe("PrintNameRuleService — appliesToClass second-hop symmetry (#3838 part 2)", () => {
+  const TASK_PROTO_UID = "df7e579d-02d4-4f3a-971f-3d1d785b689b";
+  const LABEL_PROP_UID = "12a6151b-801f-4be2-bd6e-a787eedd56ae";
+  const SPEC_UID = "bare-uid-appliesto-spec";
+
+  // A spec authored appliesToClass in the UID-canon strip-alias form `[[<uid>]]` (NO alias),
+  // plus the TaskPrototype CLASS asset (so the compile-time second hop can read its uid + label),
+  // plus its two ordered parts. With the second-hop symmetry (resolveIdentityForms), the spec
+  // registers under BOTH df7e579d AND ems__TaskPrototype.
+  function bareUidAppliesToFiles(
+    opts: { includeClassAsset?: boolean } = { includeClassAsset: true },
+  ): Array<{ path: string; frontmatter: Record<string, unknown> }> {
+    const files: Array<{ path: string; frontmatter: Record<string, unknown> }> = [];
+    if (opts.includeClassAsset) {
+      files.push({
+        // the class def asset — second hop reads its exo__Asset_uid + exo__Asset_label
+        path: `${TASK_PROTO_UID}.md`,
+        frontmatter: {
+          exo__Asset_uid: TASK_PROTO_UID,
+          exo__Instance_class: ["[[8619c4fc-64f1-4869-b17e-e34186cacca9|exo__Class]]"],
+          exo__Asset_label: "ems__TaskPrototype",
+        },
+      });
+    }
+    files.push(
+      {
+        path: `${SPEC_UID}.md`,
+        frontmatter: {
+          exo__Asset_uid: SPEC_UID,
+          exo__Instance_class: ["[[07eab746-0874-4676-9d98-dbaad1bc6fb8|exo__DisplayNameSpec]]"],
+          // BARE UID — no `|label` alias. Without the second hop only df7e579d is indexed.
+          exo__DisplayNameSpec_appliesToClass: `[[${TASK_PROTO_UID}]]`,
+          exo__DisplayNameSpec_priority: 100,
+        },
+      },
+      {
+        path: "p2-prop.md",
+        frontmatter: {
+          exo__Asset_uid: "p2-prop",
+          exo__Instance_class: ["[[7d58de40-d941-4a66-88e2-13afc4fdc41d|exo__PrintedProperty]]"],
+          exo__DisplayNamePart_of: `[[${SPEC_UID}]]`,
+          exo__DisplayNamePart_order: 1,
+          exo__PrintedProperty_property: `[[${LABEL_PROP_UID}|exo__Asset_label]]`,
+        },
+      },
+      {
+        path: "p2-literal.md",
+        frontmatter: {
+          exo__Asset_uid: "p2-literal",
+          exo__Instance_class: ["[[4d5437c9-788e-4a6d-9be0-4af3a84554f4|exo__PrintedLiteral]]"],
+          exo__DisplayNamePart_of: `[[${SPEC_UID}]]`,
+          exo__DisplayNamePart_order: 2,
+          exo__PrintedLiteral_literal: " (TaskPrototype)",
+        },
+      },
+    );
+    return files;
+  }
+
+  it("a bare-UID-authored appliesToClass matches a LABEL-keyed instance via the second hop", () => {
+    // GREEN: appliesToClass `[[df7e579d]]` (bare UID) + the class asset present → the second hop
+    // reads the class asset's exo__Asset_label (ems__TaskPrototype) and registers the spec under
+    // BOTH df7e579d AND ems__TaskPrototype. An instance keying exo__Instance_class by the LABEL
+    // form `[[ems__TaskPrototype]]` therefore matches and gets the suffix.
+    const app = createMockApp(bareUidAppliesToFiles());
+    const service = new PrintNameRuleService(app);
+    service.initialize();
+
+    // registered under BOTH forms:
+    expect(service.getTemplateForClass(TASK_PROTO_UID)!.template).toBe(
+      "{{exo__Asset_label}} (TaskPrototype)",
+    );
+    expect(service.getTemplateForClass("ems__TaskPrototype")!.template).toBe(
+      "{{exo__Asset_label}} (TaskPrototype)",
+    );
+
+    const resolver = new DisplayNameResolver(
+      { defaultTemplate: "{{exo__Asset_label}}", classTemplates: {} },
+      service,
+    );
+    // instance keyed by the LABEL form (the form NOT literally present in appliesToClass).
+    expect(
+      resolver.resolve({
+        metadata: {
+          exo__Instance_class: ["[[ems__TaskPrototype]]"],
+          exo__Asset_label: "Morning routine",
+        },
+        basename: "morning-routine",
+      }),
+    ).toBe("Morning routine (TaskPrototype)");
+    // and the UID form still matches (both indexed).
+    expect(
+      resolver.resolve({
+        metadata: {
+          exo__Instance_class: [`[[${TASK_PROTO_UID}]]`],
+          exo__Asset_label: "Morning routine",
+        },
+        basename: "morning-routine",
+      }),
+    ).toBe("Morning routine (TaskPrototype)");
+  });
+
+  it("REVERT-VERIFY (data control): without the class asset the second hop finds no label → the LABEL-keyed instance does NOT match", () => {
+    // The second hop DEPENDS on reading the referenced class asset's label. Remove the class
+    // asset → resolveIdentityForms('[[df7e579d]]') yields only df7e579d → the LABEL-keyed
+    // instance falls through to the plain label. (This is also exactly the behaviour the OLD
+    // plain-extractClassKeys code produced for a bare-UID appliesToClass — a functional RED.)
+    const app = createMockApp(bareUidAppliesToFiles({ includeClassAsset: false }));
+    const service = new PrintNameRuleService(app);
+    service.initialize();
+
+    // only the bare UID is indexed now:
+    expect(service.getTemplateForClass(TASK_PROTO_UID)!.template).toBe(
+      "{{exo__Asset_label}} (TaskPrototype)",
+    );
+    expect(service.getTemplateForClass("ems__TaskPrototype")).toBeNull();
+
+    const resolver = new DisplayNameResolver(
+      { defaultTemplate: "{{exo__Asset_label}}", classTemplates: {} },
+      service,
+    );
+    expect(
+      resolver.resolve({
+        metadata: {
+          exo__Instance_class: ["[[ems__TaskPrototype]]"],
+          exo__Asset_label: "Morning routine",
+        },
+        basename: "morning-routine",
+      }),
+    ).toBe("Morning routine");
+  });
+
+  it("byte-identical for shipped alias-form appliesToClass — `[[uid|label]]` still registers under both forms (the hop adds nothing)", () => {
+    // The shipped specs author appliesToClass `[[uid|label]]`; extractClassKeys already returns
+    // both forms, so resolveIdentityForms is a no-op superset → no behavioural change for them.
+    const app = createMockApp([
+      {
+        path: `${SPEC_UID}.md`,
+        frontmatter: {
+          exo__Asset_uid: SPEC_UID,
+          exo__Instance_class: ["[[07eab746-0874-4676-9d98-dbaad1bc6fb8|exo__DisplayNameSpec]]"],
+          exo__DisplayNameSpec_appliesToClass: `[[${TASK_PROTO_UID}|ems__TaskPrototype]]`,
+          exo__DisplayNameSpec_priority: 100,
+        },
+      },
+      {
+        path: "p2-literal.md",
+        frontmatter: {
+          exo__Asset_uid: "p2-literal",
+          exo__Instance_class: ["[[4d5437c9-788e-4a6d-9be0-4af3a84554f4|exo__PrintedLiteral]]"],
+          exo__DisplayNamePart_of: `[[${SPEC_UID}]]`,
+          exo__DisplayNamePart_order: 1,
+          exo__PrintedLiteral_literal: "PROTO",
+        },
+      },
+    ]);
+    const service = new PrintNameRuleService(app);
+    service.initialize();
+    expect(service.getTemplateForClass(TASK_PROTO_UID)!.template).toBe("PROTO");
+    expect(service.getTemplateForClass("ems__TaskPrototype")!.template).toBe("PROTO");
+  });
+});


### PR DESCRIPTION
## Summary
`#3838` parts **2 + 3** (part 1 already shipped). Both are **refactor / robustness — byte-identical for shipped data** (per `/feature-sdd` Step 0, **no new requirement**), but engine changes → revert-verified production-shape tests + CI. Un-gated by the orchestrator's live **8-surface Phase-6 production smoke on plugin v16.183.0** (🔄 Doing / 👥 Task+Meeting / ✅ Done / `(TaskPrototype)` suffix all render live from vault `exo__DisplayNameSpec`).

## Part 3 — remove TS cold-start `classTemplates` seeds (full homoiconic)
`DEFAULT_DISPLAY_NAME_SETTINGS.classTemplates` → `{}` (kept `defaultTemplate`). Every per-class displayName is now sourced **entirely** from vault `exo__DisplayNameSpec` assets read by `PrintNameRuleService`, which already **win** over any classTemplate (`compileDisplayNameSpecs` registers them as HIGH-priority `PrintNameRule`s) — the seeds were dead-overridden once the vault scanned.
- Coverage lives in the vault: unconditional TaskPrototype spec **`e20fda38`** + MeetingPrototype **`d7bdca33`** render the `(…Prototype)` suffix.
- `pn__DailyNote: {{_basename}}` was already **dead**: real DailyNotes key `exo__Instance_class` by the bare UID `[[b04e7a3e]]`, never the label `pn__DailyNote` (dn-2110 sweep). Removal = no-op.
- Only difference: a brief cold-start window before the vault scan — identical eventual-consistency to the status emojis (also vault-served, already re-render on store-settle). No steady-state user-visible change.

## Part 2 — `appliesToClass` second-hop symmetry
The dual-IRI second hop (read the referenced asset's `exo__Asset_uid` + `exo__Asset_label`) that `resolveMatchValues` already did for **matchValue** is extracted into a shared `resolveIdentityForms` and now also used for the **appliesToClass** registration. A spec authored bare-UID `[[<uid>]]` or bare-label `[[<label>]]` now registers under **both** the class UID **and** its label — closing the same dual-IRI gap `matchValue` already closed.
- **Byte-identical for shipped data:** all shipped specs author `appliesToClass: [[uid|label]]`; `extractClassKeys` already returns both forms, so the hop adds nothing for them. It only helps future bare-UID/bare-label-authored specs.

## Revert-verify (production-shape, real `scanVault → compile → DisplayNameResolver.resolve`, per `test-fixture-realism`)
- **Part 3:** spec-present → `<label> (TaskPrototype)` (GREEN) / spec-absent → plain label (RED, executable). Code-revert (restore a DEFAULT seed) → the `classTemplates`-empty assertion goes **RED** (verified locally, restored).
- **Part 2:** bare-UID-authored `appliesToClass` + class asset present → a **label-keyed** instance matches via the hop (GREEN); code-revert (`resolveIdentityForms` → plain `extractClassKeys`) → the label-keyed instance no longer matches → **RED** (verified locally, restored). Plus a data-control (class asset absent → hop finds no label → no match) and a byte-identical alias-form assertion.

## Verification
- `npm run check:types` clean; **200 plugin tests green** across the displayName + settings + link-patch suites (146 + 255 above; 54 in the two touched suites).
- Lint-job guards all pass: `validate-shard-assignments` ✓, `check-test-antipatterns` (method-exists 55/55 — no new anti-patterns) ✓, `check-coverage-monotonic` ✓. `eslint` clean on both source files.
- **Minimal-conflict footprint:** only `ExocortexSettings.ts` + `PrintNameRuleService.ts` (+ their test files). `DisplayNameResolver` / renderers untouched.
- Code-only PR (no vault changes) → no ExoSync.

Closes #3838 (parts 1/2/3 all done).
