### PR TITLE
fix(create-instance): resolve nowTimestamp at execute time (createdAt/updatedAt froze to Obsidian launch)

### DIFF
--- a/packages/core/src/services/CommandResolver.ts
+++ b/packages/core/src/services/CommandResolver.ts
@@ -119,11 +119,13 @@ const KNOWN_SUBSTITUTION_RESOLVER_IDS: ReadonlySet<string> = new Set([
 ]);
 
 /**
- * Marker for context-dependent SubstitutionToken resolvers — executor
+ * Marker for execute-time SubstitutionToken resolvers — the executor
  * substitutes at runtime when the click target IRI / file path / userInput /
- * Grounding metadata are known. Context-independent resolvers (today,
- * todayStart, nowDate, nowYear, nowMonth, nowTimestamp, randomUUIDv4) are
- * resolved at parse time and never produce this marker.
+ * Grounding metadata are known, OR when the value must be fresh per execution
+ * (`nowTimestamp` — second precision; `randomUUIDv4`), so it is NOT baked at
+ * parse time. The DAY-granularity date resolvers (today, tomorrow, todayStart,
+ * nowDate, nowYear, nowMonth) ARE resolved at parse time and never produce this
+ * marker — see {@link PARSE_TIME_RESOLVERS}.
  *
  * Shape: `__SUBSTITUTE__<resolver-id>__<token-uid>__`
  *

--- a/packages/core/src/services/CommandResolver.ts
+++ b/packages/core/src/services/CommandResolver.ts
@@ -165,13 +165,22 @@ const UNIVERSAL_DEFAULT_TEMPLATE_CLASS_UID =
 const UNIVERSAL_DEFAULT_TEMPLATE_CTX = "universal-default-template";
 
 /**
- * RFC 727572d2 — context-independent date/time resolvers safely baked at
- * parse time. Matches the existing behaviour for `today` / `todayStart`
- * (resolved when CommandResolver parses Groundings; cached for session).
+ * RFC 727572d2 — context-independent DAY-granularity date resolvers safely
+ * baked at parse time. Matches the existing behaviour for `today` / `todayStart`
+ * (resolved when CommandResolver parses Groundings; cached for session — a
+ * session rarely crosses local midnight, so a baked calendar day is tolerable).
  *
  * `randomUUIDv4` is intentionally NOT here: parse-time UUID baking would
  * produce the same UUID for every click on a cached Grounding until cache
  * invalidates — unsafe. It emits a marker for runtime resolution instead.
+ *
+ * `nowTimestamp` is intentionally NOT here for the SAME reason (bug
+ * 33d362e5): it is a SECOND-precision timestamp used for `exo__Asset_createdAt`
+ * / `exo__Asset_updatedAt`. Parse-time baking + session cache froze every
+ * instance created in one Obsidian session to the SAME launch-time timestamp
+ * (the plugin process is long-lived; the CLI is not, so CLI was unaffected).
+ * It emits a marker resolved fresh per-execution by the live registry
+ * resolver instead.
  */
 const PARSE_TIME_RESOLVERS: ReadonlySet<string> = new Set([
   "today",
@@ -179,7 +188,6 @@ const PARSE_TIME_RESOLVERS: ReadonlySet<string> = new Set([
   // time exactly like `$today` (same session-cache semantics).
   "tomorrow",
   "todayStart",
-  "nowTimestamp",
   "nowDate",
   "nowYear",
   "nowMonth",
@@ -2673,8 +2681,10 @@ export class CommandResolver {
         // UTC Z-instant (`...T00:00:00.000Z`) — same instant, different string
         // shape that disagreed with the executor form.
         return DateFormatter.getTodayStartTimestamp();
-      case "nowTimestamp":
-        return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}:${pad(d.getSeconds())}`;
+      // `nowTimestamp` (second-precision, used for createdAt/updatedAt) is
+      // deliberately NOT parse-time (bug 33d362e5) — it resolves at execute
+      // time via the live registry resolver so it is never frozen to the
+      // session's launch instant. See PARSE_TIME_RESOLVERS.
       case "nowDate":
         return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`;
       case "nowYear":

--- a/packages/core/tests/unit/services/CommandResolver.substitutionToken.test.ts
+++ b/packages/core/tests/unit/services/CommandResolver.substitutionToken.test.ts
@@ -165,6 +165,7 @@ const TOKEN_TODAY_UID         = "22222222-2222-4222-8222-222222222222";
 const TOKEN_TARGET_FOLDER_UID = "33333333-3333-4333-8333-333333333333";
 const TOKEN_UNKNOWN_UID       = "44444444-4444-4444-8444-444444444444";
 const TOKEN_TODAY_START_UID   = "66666666-6666-4666-8666-666666666666";
+const TOKEN_NOW_TIMESTAMP_UID = "77777777-7777-4777-8777-777777777777";
 
 const PD_UID  = "55555555-5555-4555-8555-555555555555";
 
@@ -245,6 +246,47 @@ describe("CommandResolver — RFC v2 Phase 3a SubstitutionToken dispatch", () =>
     expect(value).toMatch(/^\d{4}-\d{2}-\d{2}T00:00:00$/);
     expect(value).not.toContain("Z");
     expect(value).not.toContain(".000");
+    expect(logger.warnings).toHaveLength(0);
+  });
+
+  // Bug 33d362e5 — `nowTimestamp` (second-precision, used for
+  // exo__Asset_createdAt / exo__Asset_updatedAt) MUST emit an execute-time
+  // marker, NOT a parse-time-baked literal. Parse-time baking + the session
+  // command/Universal-Template cache froze every prototype instance created in
+  // one Obsidian session to the SAME launch-time timestamp. It is the
+  // second-precision sibling of `randomUUIDv4` (also marker-only): a cached
+  // baked value is wrong for BOTH. Revert-verify: re-adding "nowTimestamp" to
+  // PARSE_TIME_RESOLVERS makes `value` a baked `YYYY-MM-DDTHH:mm:ss` literal →
+  // the marker `.toBe(...)` assertion fails (RED).
+  it("encodes a `nowTimestamp` SubstitutionToken as an execute-time marker (createdAt/updatedAt must not freeze to session launch)", async () => {
+    await addSubstitutionToken(store, {
+      uid: TOKEN_NOW_TIMESTAMP_UID,
+      label: "$nowTimestamp",
+      resolverId: "nowTimestamp",
+    });
+    await addPropertyDefault(store, {
+      uid: PD_UID,
+      propertyRefUid: PROP_UID,
+      valueRefUid: TOKEN_NOW_TIMESTAMP_UID,
+    });
+    await addGrounding(store, {
+      uid: GROUNDING_UID,
+      label: "Grounding with $nowTimestamp PD",
+      propertyDefaultRefs: [PD_UID],
+    });
+    await addCommand(store, COMMAND_UID, GROUNDING_UID);
+
+    const cmd = await resolver.loadCommand(COMMAND_UID);
+
+    expect(cmd!.grounding.propertyDefault).toHaveLength(1);
+    const value = cmd!.grounding.propertyDefault![0].value;
+    // Execute-time marker — resolved fresh per instance creation by the live
+    // registry resolver, so createdAt/updatedAt reflect the real creation time.
+    expect(value).toBe(
+      `__SUBSTITUTE__nowTimestamp__${TOKEN_NOW_TIMESTAMP_UID}__`,
+    );
+    // Must NOT be a parse-time-baked timestamp literal (the frozen-launch bug).
+    expect(value).not.toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}$/);
     expect(logger.warnings).toHaveLength(0);
   });
 


### PR DESCRIPTION
## Bug

Creating a **prototype instance** in the Obsidian plugin set `exo__Asset_createdAt` and `exo__Asset_updatedAt` to the **Obsidian launch instant** instead of the real creation time — every instance created in one session got an identical frozen timestamp.

Tracked as `ems__Bug` `33d362e5` (vault-exodev).

## Root cause

The Universal Default Template's `createdAt`/`updatedAt` PropertyDefaults resolve through a `nowTimestamp` SubstitutionToken (`69177795`; PD assets `f8e816fa` / `f6936a3f`).

`nowTimestamp` was a member of `PARSE_TIME_RESOLVERS`, so `CommandResolver.dispatchSubstitutionToken` baked a **second-precision** `YYYY-MM-DDTHH:mm:ss` at command **parse time** and cached it in the session-lived Universal Template cache (`_universalCacheValue`). The long-lived plugin process reused that frozen value for every `executeCreateInstance` until reload. The CLI was unaffected (fresh process per `apply` → parse ≈ execute).

This is the second-precision sibling of `randomUUIDv4`, which was already **intentionally excluded** from `PARSE_TIME_RESOLVERS` for the exact same "baked-and-cached is wrong" reason.

## Fix

Remove `nowTimestamp` from `PARSE_TIME_RESOLVERS`. It now emits an execute-time marker `__SUBSTITUTE__nowTimestamp__<uid>__` that `GroundingExecutor.applyPropertyDefaultStep` resolves fresh via the live registry resolver (`new Date()`) **per instance creation** → correct createdAt/updatedAt.

Day-granularity resolvers (`today`/`tomorrow`/`todayStart`/`nowDate`/`nowYear`/`nowMonth`) stay parse-time — documented session-cache trade-off (a session rarely crosses local midnight); out of scope.

## Verification

Revert-verify in `CommandResolver.substitutionToken.test.ts`: a `nowTimestamp` PropertyDefault must resolve to a **marker**, not a baked timestamp.
- **RED** (fix reverted): `Received: "2026-07-12T15:11:15"` (baked launch timestamp)
- **GREEN** (fixed): `__SUBSTITUTE__nowTimestamp__<uid>__`

Local: 378 related tests green (CommandResolver.* 89, GroundingExecutor.* 241, asset-creation integration 48), `tsc` 0 errors, guard scripts OK (test-antipatterns 55/55, shard-assignments, coverage-monotonic), eslint clean.

https://claude.ai/code/session_01NEDFCd3tcSyABPUAZnboPz