### PR TITLE
feat(relations): clickable link-icon to backing exo__Statement for reified relations

### DIFF
--- a/packages/obsidian-plugin/src/presentation/components/AssetRelationsTable.tsx
+++ b/packages/obsidian-plugin/src/presentation/components/AssetRelationsTable.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useMemo, useRef, useLayoutEffect, useCallback, useEffect } from "react";
 import { useVirtualizer } from "@tanstack/react-virtual";
+import { setIcon } from "obsidian";
 
 const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
@@ -111,10 +112,18 @@ export interface AssetRelation {
   displayName?: string;
   /**
    * RFC `93a0b2ee` Task 2 (C2) — the AssetSpace (`exoas-<name>`) the backing
-   * statement asset lives in, for the factual "reified · <AS>" marker text.
-   * `undefined` → a `reified` relation shows a bare "reified".
+   * statement asset lives in. req `838c65d4` — surfaced in the reified
+   * statement-link's tooltip. `undefined` → the tooltip reads a bare "reified".
    */
   assetSpace?: string;
+  /**
+   * req `838c65d4` — the vault path of the backing `exo__Statement` asset for a
+   * `provenance: "reified"` relation (carried through by
+   * `RelationsRenderer.mergeReifiedRelations`, typed in `layout/types.ts`). When
+   * present, {@link renderRow} renders a clickable lucide `link` icon that opens
+   * this statement via `onAssetClick`. `undefined` → no icon (nothing to open).
+   */
+  statementPath?: string;
 }
 
 /**
@@ -171,11 +180,13 @@ export function getRelationSortLabel(relation: AssetRelation): string {
  *
  * Returns `"reified · <AS>"` (or a bare `"reified"` when the AssetSpace is not
  * derivable) for a relation backed by an `exo__Statement` asset; `null` for an
- * inline relation (the default — no marker). The marker is purely FACTUAL: it
- * states WHERE the backing statement lives, NEVER a privacy promise. Privacy
- * depends on whether that AssetSpace is shared, which is not a queryable RDF
- * fact (RFC §C2 decision H; `exo__AssetSpace_visibility` is an out-of-MVP
- * follow-up). Honest-marker metric: 0 unverifiable statements.
+ * inline relation (the default). req `838c65d4` — the former inline TEXT marker
+ * was replaced by a clickable {@link ReifiedStatementLink} icon; this helper now
+ * feeds that icon's factual tooltip (via {@link reifiedStatementTooltip}). It
+ * remains purely FACTUAL: it states WHERE the backing statement lives, NEVER a
+ * privacy promise. Privacy depends on whether that AssetSpace is shared, which
+ * is not a queryable RDF fact (RFC §C2 decision H; `exo__AssetSpace_visibility`
+ * is an out-of-MVP follow-up). Honest-marker metric: 0 unverifiable statements.
  */
 export function reifiedMarkerText(relation: AssetRelation): string | null {
   if (relation.provenance !== "reified") return null;
@@ -184,29 +195,79 @@ export function reifiedMarkerText(relation: AssetRelation): string | null {
 }
 
 /**
- * RFC `93a0b2ee` Task 2 (C2) — the accessible/title explanation of the marker.
- * Factual only (no privacy promise). Used for `title` (desktop hover) and
- * `aria-label`; the persistent on-screen explanation is {@link ReifiedLegend}
- * (the mobile/tap channel — hover is unavailable there).
+ * req `838c65d4` — the factual hover/aria tooltip for the reified statement-link
+ * icon. Combines an "open the statement" hint with {@link reifiedMarkerText} so
+ * the AssetSpace (`reified · <AS>`) is preserved on hover. Factual only — no
+ * privacy promise (decision H). `null` for a non-reified relation.
  */
-function reifiedMarkerExplanation(relation: AssetRelation): string {
-  const where = relation.assetSpace?.trim()
-    ? `в AssetSpace ${relation.assetSpace.trim()}`
-    : "в отдельном statement-ассете";
-  return `Связь вынесена ${where} (фактически — где лежит statement). Приватность зависит от того, шарится ли этот AssetSpace.`;
+export function reifiedStatementTooltip(relation: AssetRelation): string | null {
+  const marker = reifiedMarkerText(relation);
+  if (marker === null) return null;
+  return `Открыть связь · ${marker}`;
 }
 
 /**
- * RFC `93a0b2ee` Task 2 (C2) — persistent explanation of the `reified · <AS>`
- * marker, rendered below the table whenever a reified relation is present.
- * Persistent (always visible — NOT hover-only) so the marker is explained on
- * mobile where hover is unavailable. Factual only — no privacy promise.
+ * req `838c65d4` — a clickable lucide `link` icon opening the backing
+ * `exo__Statement` asset of a reified relation. Rendered in the name cell in
+ * place of the former grey `reified · <AS>` text marker. The Obsidian
+ * `setIcon(host, "link")` helper writes the bundled lucide SVG into the icon
+ * host from a `useEffect` (cleanup empties the host before unmount / StrictMode
+ * re-render) — the React/Obsidian boundary is explicit: Obsidian mutates the
+ * DOM, React owns the container ref. Click opens the statement via the SAME
+ * `onAssetClick` handler used for asset links (current pane; Cmd/Ctrl-click →
+ * new pane, resolved upstream in `RelationsRenderer`).
+ */
+const ReifiedStatementLink: React.FC<{
+  statementPath: string;
+  tooltip: string;
+  onAssetClick?: (path: string, event: React.MouseEvent) => void;
+}> = ({ statementPath, tooltip, onAssetClick }) => {
+  const iconRef = useRef<HTMLSpanElement | null>(null);
+
+  useEffect(() => {
+    const host = iconRef.current;
+    if (host === null) return;
+    setIcon(host, "link");
+    return () => {
+      while (host.firstChild) host.removeChild(host.firstChild);
+    };
+  }, []);
+
+  return (
+    <a
+      className="exocortex-reified-statement-link"
+      data-href={statementPath}
+      title={tooltip}
+      aria-label={tooltip}
+      onClick={(e) => {
+        e.preventDefault();
+        e.stopPropagation();
+        onAssetClick?.(statementPath, e);
+      }}
+      style={{ cursor: "pointer" }}
+    >
+      <span
+        ref={iconRef}
+        className="exocortex-reified-statement-link-icon"
+        aria-hidden="true"
+      />
+    </a>
+  );
+};
+
+/**
+ * req `838c65d4` — persistent explanation of the reified statement-link icon,
+ * rendered below the table whenever a reified relation WITH a statement path is
+ * present (i.e. whenever ≥1 icon is shown). Persistent (always visible — NOT
+ * hover-only) so the icon is explained on mobile where hover is unavailable.
+ * Factual only — states WHERE the statement lives, no privacy promise.
  */
 const ReifiedLegend: React.FC = () => (
   <p className="exocortex-reified-legend" role="note">
-    «reified · &lt;AS&gt;» — связь вынесена в statement-ассет в этом AssetSpace
-    (фактически, где лежит). Приватность зависит от того, шарится ли этот
-    AssetSpace.
+    Иконка-ссылка рядом со связью открывает statement-ассет, в который вынесена
+    реифицированная связь; AssetSpace, где он лежит, показан во всплывающей
+    подсказке (фактически — где лежит statement). Приватность зависит от того,
+    шарится ли этот AssetSpace.
   </p>
 );
 
@@ -587,17 +648,23 @@ const SingleTable: React.FC<SingleTableProps> = ({
             {getDisplayLabel(relation)}
           </a>
           {(() => {
-            const marker = reifiedMarkerText(relation);
-            if (!marker) return null;
-            const explanation = reifiedMarkerExplanation(relation);
+            // req `838c65d4` — a clickable lucide `link` icon (opens the backing
+            // exo__Statement) replaces the former grey `reified · <AS>` text
+            // marker. Rendered ONLY for a reified relation WITH a resolvable
+            // statementPath (nothing to open otherwise); the AssetSpace moves
+            // into the icon tooltip. Keys strictly off provenance + statementPath
+            // so inline/legacy rows never get an icon.
+            if (relation.provenance !== "reified" || !relation.statementPath) {
+              return null;
+            }
+            const tooltip = reifiedStatementTooltip(relation);
+            if (tooltip === null) return null;
             return (
-              <span
-                className="exocortex-reified-marker"
-                title={explanation}
-                aria-label={explanation}
-              >
-                {marker}
-              </span>
+              <ReifiedStatementLink
+                statementPath={relation.statementPath}
+                tooltip={tooltip}
+                onAssetClick={onAssetClick}
+              />
             );
           })()}
         </td>
@@ -793,10 +860,14 @@ export const AssetRelationsTable: React.FC<AssetRelationsTableProps> = ({
     </button>
   ) : null;
 
-  // RFC `93a0b2ee` Task 2 (C2) — show the persistent reified-marker legend iff
-  // at least one rendered relation is reified (mobile-safe explanation channel).
+  // req `838c65d4` — show the persistent icon-link legend iff ≥1 icon is
+  // rendered, i.e. a reified relation WITH a resolvable statementPath
+  // (mobile-safe explanation channel; RFC 93a0b2ee C2→C3).
   const hasReified = useMemo(
-    () => relations.some((r) => r.provenance === "reified"),
+    () =>
+      relations.some(
+        (r) => r.provenance === "reified" && Boolean(r.statementPath),
+      ),
     [relations],
   );
 

--- a/packages/obsidian-plugin/styles.css
+++ b/packages/obsidian-plugin/styles.css
@@ -6233,6 +6233,27 @@
   color: var(--text-muted);
 }
 
+/* req 838c65d4 — clickable reified statement-link icon in the Asset Relations
+   block. Replaces the former grey `reified · <AS>` text marker: a native lucide
+   `link` glyph (via setIcon) that opens the backing exo__Statement asset. */
+.exocortex-reified-statement-link {
+  margin-left: 0.4em;
+  color: var(--text-muted);
+  cursor: pointer;
+  vertical-align: middle;
+}
+.exocortex-reified-statement-link:hover {
+  color: var(--text-accent);
+}
+.exocortex-reified-statement-link-icon {
+  display: inline-flex;
+  align-items: center;
+}
+.exocortex-reified-statement-link-icon svg {
+  width: 0.9em;
+  height: 0.9em;
+}
+
 /* RFC 93a0b2ee Task 3.1 — property editor Relations section. */
 .property-editor-relations-list {
   list-style: none;

--- a/packages/obsidian-plugin/tests/unit/presentation/components/AssetRelationsTable.reified-marker.test.tsx
+++ b/packages/obsidian-plugin/tests/unit/presentation/components/AssetRelationsTable.reified-marker.test.tsx
@@ -1,26 +1,34 @@
 /**
- * AssetRelationsTable — RFC `93a0b2ee` Phase 2 / Task 2 (C2)
+ * AssetRelationsTable — reified-relation clickable statement-link
+ * (req `838c65d4`, RFC 93a0b2ee §C3; supersedes a4c8a9a0's §C2 text marker).
  *
- * Locks in the FACTUAL reified-relation marker: a relation carrying
- * `provenance: "reified"` renders an inline `.exocortex-reified-marker` reading
- * `reified · <AS>` (the AssetSpace the backing `exo__Statement` lives in); an
- * `inline` (or legacy, no-provenance) relation renders none. A persistent
- * `.exocortex-reified-legend` (mobile-safe, not hover-only) explains the marker
- * whenever a reified relation is present. The marker is purely factual — it
- * carries NO privacy claim ("🔒" / "не уедет"); privacy depends on whether the
- * AssetSpace is shared, which is not a queryable RDF fact (RFC §C2 decision H).
+ * Locks in the CLICKABLE reified statement-link: a relation carrying
+ * `provenance: "reified"` AND a resolvable `statementPath` renders a clickable
+ * `.exocortex-reified-statement-link` `<a>` whose icon host carries the native
+ * lucide `link` glyph (`data-icon-name="link"`), whose hover/aria tooltip names
+ * the AssetSpace (`reified · <AS>`) and hints at opening the statement, and
+ * whose click opens the backing `exo__Statement` via `onAssetClick(statementPath)`.
+ * The former grey `reified · <AS>` TEXT marker is GONE — the AssetSpace moved to
+ * the tooltip. An `inline` (or legacy) relation, and a reified relation WITHOUT a
+ * statementPath, render no icon. A persistent (mobile-safe, not hover-only)
+ * `.exocortex-reified-legend` describes the icon and renders iff ≥1 icon is
+ * shown. The tooltip/legend carry NO privacy claim (honest-marker, decision H).
  *
- * @req:a4c8a9a0-27aa-48ff-8365-eba1b40c6433
+ * @req:838c65d4-bfb3-4460-9835-01e7480c8560
  */
 
 import React from "react";
 import "@testing-library/jest-dom";
-import { render } from "@testing-library/react";
+import { render, fireEvent } from "@testing-library/react";
 import {
   AssetRelationsTable,
   AssetRelation,
   reifiedMarkerText,
+  reifiedStatementTooltip,
 } from "../../../../src/presentation/components/AssetRelationsTable";
+
+const STMT_PATH =
+  "assetspaces/kitelev/exoas-class-relations/class-relations/stmt.md";
 
 const baseRelation = (
   overrides: Partial<AssetRelation> = {},
@@ -35,7 +43,19 @@ const baseRelation = (
   ...overrides,
 });
 
-/** Privacy-claim tokens the honest marker must never contain (RFC §C2 decision H). */
+const reifiedRelation = (
+  overrides: Partial<AssetRelation> = {},
+): AssetRelation =>
+  baseRelation({
+    path: "concepts/c.md",
+    title: "Концепт C",
+    provenance: "reified",
+    assetSpace: "exoas-class-relations",
+    statementPath: STMT_PATH,
+    ...overrides,
+  });
+
+/** Privacy-claim tokens the honest tooltip/legend must never contain (RFC §C2 decision H). */
 const PRIVACY_CLAIM_TOKENS = [
   "🔒",
   "не уедет",
@@ -44,31 +64,87 @@ const PRIVACY_CLAIM_TOKENS = [
   "приватно и",
 ];
 
-describe("AssetRelationsTable — reified-relation marker (RFC 93a0b2ee C2)", () => {
-  it("renders a `reified · <AS>` marker for a reified relation (the AssetSpace from the backing statement path)", () => {
+describe("AssetRelationsTable — reified statement-link (req 838c65d4, RFC 93a0b2ee C3)", () => {
+  it("renders a clickable lucide `link` icon-link for a reified relation with a statementPath (NOT a text marker)", () => {
     const { container } = render(
-      <AssetRelationsTable
-        relations={[
-          baseRelation({
-            path: "concepts/c.md",
-            title: "Концепт C",
-            provenance: "reified",
-            assetSpace: "exoas-class-relations",
-            statementPath:
-              "assetspaces/kitelev/exoas-class-relations/class-relations/stmt.md",
-          }),
-        ]}
-      />,
+      <AssetRelationsTable relations={[reifiedRelation()]} />,
     );
 
-    const markers = container.querySelectorAll<HTMLElement>(
-      ".exocortex-reified-marker",
+    const links = container.querySelectorAll<HTMLAnchorElement>(
+      ".exocortex-reified-statement-link",
     );
-    expect(markers).toHaveLength(1);
-    expect(markers[0].textContent).toBe("reified · exoas-class-relations");
+    expect(links).toHaveLength(1);
+    // Native lucide `link` glyph via Obsidian setIcon (mock stamps data-icon-name).
+    const iconHost = links[0].querySelector<HTMLElement>(
+      ".exocortex-reified-statement-link-icon",
+    );
+    expect(iconHost).not.toBeNull();
+    expect(iconHost!.getAttribute("data-icon-name")).toBe("link");
+    // The former grey text marker is gone (replaced by the icon-link).
+    expect(container.querySelector(".exocortex-reified-marker")).toBeNull();
+    // No visible text marker string in the icon-link.
+    expect(links[0].textContent).toBe("");
   });
 
-  it("renders NO marker for an inline relation", () => {
+  it("the icon-link tooltip names the AssetSpace and hints at opening the statement", () => {
+    const { container } = render(
+      <AssetRelationsTable relations={[reifiedRelation()]} />,
+    );
+    const link = container.querySelector<HTMLElement>(
+      ".exocortex-reified-statement-link",
+    );
+    expect(link).not.toBeNull();
+    const tooltip = link!.getAttribute("title") ?? "";
+    expect(tooltip).toContain("reified · exoas-class-relations");
+    expect(tooltip).toContain("Открыть связь");
+    // aria-label mirrors the tooltip (accessible name).
+    expect(link!.getAttribute("aria-label")).toBe(tooltip);
+  });
+
+  it("clicking the icon opens the backing exo__Statement via onAssetClick(statementPath)", () => {
+    const onAssetClick = jest.fn();
+    const { container } = render(
+      <AssetRelationsTable
+        relations={[reifiedRelation()]}
+        onAssetClick={onAssetClick}
+      />,
+    );
+    const link = container.querySelector<HTMLElement>(
+      ".exocortex-reified-statement-link",
+    );
+    expect(link).not.toBeNull();
+    fireEvent.click(link!);
+    expect(onAssetClick).toHaveBeenCalledTimes(1);
+    expect(onAssetClick.mock.calls[0][0]).toBe(STMT_PATH);
+  });
+
+  it("renders a bare `reified` tooltip (no AS) but still a clickable icon when the AssetSpace is not derivable", () => {
+    const { container } = render(
+      <AssetRelationsTable
+        relations={[reifiedRelation({ assetSpace: undefined })]}
+      />,
+    );
+    const link = container.querySelector<HTMLElement>(
+      ".exocortex-reified-statement-link",
+    );
+    expect(link).not.toBeNull();
+    expect(link!.getAttribute("title")).toBe("Открыть связь · reified");
+  });
+
+  it("renders NO icon for a reified relation WITHOUT a statementPath (nothing to open)", () => {
+    const { container } = render(
+      <AssetRelationsTable
+        relations={[reifiedRelation({ statementPath: undefined })]}
+      />,
+    );
+    expect(
+      container.querySelector(".exocortex-reified-statement-link"),
+    ).toBeNull();
+    // ...and no legend (no icon is shown).
+    expect(container.querySelector(".exocortex-reified-legend")).toBeNull();
+  });
+
+  it("renders NO icon for an inline relation", () => {
     const { container } = render(
       <AssetRelationsTable
         relations={[
@@ -76,26 +152,29 @@ describe("AssetRelationsTable — reified-relation marker (RFC 93a0b2ee C2)", ()
             path: "concepts/b.md",
             title: "Концепт B",
             provenance: "inline",
+            statementPath: STMT_PATH,
           }),
         ]}
       />,
     );
-
-    expect(container.querySelector(".exocortex-reified-marker")).toBeNull();
+    expect(
+      container.querySelector(".exocortex-reified-statement-link"),
+    ).toBeNull();
     expect(container.querySelector(".exocortex-reified-legend")).toBeNull();
   });
 
-  it("renders NO marker for a legacy relation with no provenance field", () => {
+  it("renders NO icon for a legacy relation with no provenance field", () => {
     const { container } = render(
       <AssetRelationsTable
         relations={[baseRelation({ path: "legacy/a.md", title: "A" })]}
       />,
     );
-
-    expect(container.querySelector(".exocortex-reified-marker")).toBeNull();
+    expect(
+      container.querySelector(".exocortex-reified-statement-link"),
+    ).toBeNull();
   });
 
-  it("keys strictly off provenance — an inline relation gets NO marker even if it carries an assetSpace", () => {
+  it("keys strictly off provenance+statementPath — an inline relation gets NO icon even with assetSpace + statementPath", () => {
     const { container } = render(
       <AssetRelationsTable
         relations={[
@@ -104,87 +183,62 @@ describe("AssetRelationsTable — reified-relation marker (RFC 93a0b2ee C2)", ()
             title: "Концепт Dup",
             provenance: "inline",
             assetSpace: "exoas-class-relations",
+            statementPath: STMT_PATH,
           }),
         ]}
       />,
     );
-
-    expect(container.querySelector(".exocortex-reified-marker")).toBeNull();
+    expect(
+      container.querySelector(".exocortex-reified-statement-link"),
+    ).toBeNull();
   });
 
-  it("renders a bare `reified` marker when the AssetSpace is not derivable", () => {
+  it("ordinary (non-reified) rows are unchanged — the asset-name link still renders normally", () => {
     const { container } = render(
       <AssetRelationsTable
-        relations={[
-          baseRelation({
-            path: "concepts/e.md",
-            title: "Концепт E",
-            provenance: "reified",
-          }),
-        ]}
+        relations={[baseRelation({ path: "plain/x.md", title: "X" })]}
       />,
     );
-
-    const marker = container.querySelector<HTMLElement>(
-      ".exocortex-reified-marker",
+    const nameCellLink = container.querySelector<HTMLElement>(
+      "td.asset-name a.internal-link",
     );
-    expect(marker).not.toBeNull();
-    expect(marker!.textContent).toBe("reified");
+    expect(nameCellLink).not.toBeNull();
+    expect(nameCellLink!.textContent).toBe("X");
+    expect(
+      container.querySelector(".exocortex-reified-statement-link"),
+    ).toBeNull();
   });
 
-  it("renders a persistent (not hover-only) explanation legend when a reified relation is present", () => {
+  it("renders a persistent (not hover-only) legend describing the icon when a reified relation with a statementPath is present", () => {
     const { container } = render(
-      <AssetRelationsTable
-        relations={[
-          baseRelation({
-            path: "concepts/c.md",
-            title: "Концепт C",
-            provenance: "reified",
-            assetSpace: "exoas-class-relations",
-          }),
-        ]}
-      />,
+      <AssetRelationsTable relations={[reifiedRelation()]} />,
     );
-
     const legend = container.querySelector<HTMLElement>(
       ".exocortex-reified-legend",
     );
-    // Persistent: a plain on-screen element (role=note), NOT a hover-only title.
     expect(legend).not.toBeNull();
     expect(legend!.getAttribute("role")).toBe("note");
-    expect(legend!.textContent ?? "").toContain("reified");
+    // Describes the icon-link (open the statement), not a bygone text marker.
+    expect(legend!.textContent ?? "").toContain("Иконка-ссылка");
+    expect(legend!.textContent ?? "").toContain("открывает");
   });
 
-  it("the marker and its persistent legend contain NO privacy claim (honest-marker)", () => {
+  it("the icon-link tooltip and its persistent legend contain NO privacy claim (honest-marker)", () => {
     const { container } = render(
-      <AssetRelationsTable
-        relations={[
-          baseRelation({
-            path: "concepts/c.md",
-            title: "Концепт C",
-            provenance: "reified",
-            assetSpace: "exoas-class-relations",
-          }),
-        ]}
-      />,
+      <AssetRelationsTable relations={[reifiedRelation()]} />,
     );
-
-    const marker = container.querySelector<HTMLElement>(
-      ".exocortex-reified-marker",
+    const link = container.querySelector<HTMLElement>(
+      ".exocortex-reified-statement-link",
     );
     const legend = container.querySelector<HTMLElement>(
       ".exocortex-reified-legend",
     );
-    // The marker must actually be present (so this is a real honest-marker check,
-    // not a vacuous pass on an absent element).
-    expect(marker).not.toBeNull();
+    expect(link).not.toBeNull();
     expect(legend).not.toBeNull();
 
-    // Factual surfaces: visible text + the accessible title/aria explanation.
     const surfaces = [
-      marker!.textContent ?? "",
-      marker!.getAttribute("title") ?? "",
-      marker!.getAttribute("aria-label") ?? "",
+      link!.getAttribute("title") ?? "",
+      link!.getAttribute("aria-label") ?? "",
       legend!.textContent ?? "",
     ]
       .join(" ")
@@ -195,7 +249,7 @@ describe("AssetRelationsTable — reified-relation marker (RFC 93a0b2ee C2)", ()
     }
   });
 
-  it("reifiedMarkerText is a pure factual helper", () => {
+  it("reifiedMarkerText + reifiedStatementTooltip are pure factual helpers", () => {
     expect(
       reifiedMarkerText(
         baseRelation({ provenance: "reified", assetSpace: "exoas-foo" }),
@@ -204,9 +258,19 @@ describe("AssetRelationsTable — reified-relation marker (RFC 93a0b2ee C2)", ()
     expect(reifiedMarkerText(baseRelation({ provenance: "reified" }))).toBe(
       "reified",
     );
-    expect(
-      reifiedMarkerText(baseRelation({ provenance: "inline" })),
-    ).toBeNull();
+    expect(reifiedMarkerText(baseRelation({ provenance: "inline" }))).toBeNull();
     expect(reifiedMarkerText(baseRelation())).toBeNull();
+
+    expect(
+      reifiedStatementTooltip(
+        baseRelation({ provenance: "reified", assetSpace: "exoas-foo" }),
+      ),
+    ).toBe("Открыть связь · reified · exoas-foo");
+    expect(
+      reifiedStatementTooltip(baseRelation({ provenance: "reified" })),
+    ).toBe("Открыть связь · reified");
+    expect(
+      reifiedStatementTooltip(baseRelation({ provenance: "inline" })),
+    ).toBeNull();
   });
 });


### PR DESCRIPTION
## What

The **Asset Relations** block now renders a **clickable native lucide `link` icon** (Obsidian `setIcon(el, "link")`) for a reified relation (backed by an `exo__Statement` asset) that has a resolvable `statementPath` — **in place of** the former grey `reified · <AS>` text marker.

- **Click** → opens the backing `exo__Statement` via the same `onAssetClick` handler used for asset links (current pane; Cmd/Ctrl-click → new pane, resolved upstream in `RelationsRenderer`).
- **Tooltip** (hover/aria) carries `Открыть связь · reified · <AS>` — the AssetSpace moves into the tooltip; nothing about where the statement lives is lost.
- **Legend** below the table is rewritten to describe the icon (persistent, mobile-safe).
- Inline/legacy rows, and reified rows without a `statementPath`, show **no icon** (keys strictly off `provenance === "reified"` AND a present `statementPath`).
- **Honest-marker (decision H) preserved** — the tooltip is purely factual (WHERE the statement lives), never a privacy claim.

## Scope

Strictly `RelationsRenderer` → `AssetRelationsTable.tsx` (+ `styles.css`). The property-editor `RelationsSection` marker (`.exocortex-reified-marker`, a different surface) is **untouched**.

## req-first SDD (RFC 0003)

- **Req:** `838c65d4-bfb3-4460-9835-01e7480c8560` (proposed → approved by orchestrator on Andrey's behalf, expanded-autonomy mandate + interview 2026-07-12 → active after merge).
- **Supersedes** `a4c8a9a0` (the §C2 factual text-marker req) — now **Deprecated** (the literal text-marker Gherkin no longer holds; SDD invariant forbids "active but broken").
- Context: RFC `93a0b2ee` §C3 read-view follow-up.

## Verification

**Revert-verified** `@req:838c65d4-bfb3-4460-9835-01e7480c8560` (`packages/obsidian-plugin/tests/unit/presentation/components/AssetRelationsTable.reified-marker.test.tsx`, `@testing-library/react` over the real `AssetRelationsTable`): reverting the icon-link render to the former non-clickable text marker turns the **5** icon-render/click/tooltip cases **RED** (7 non-icon cases stay green); restored → **GREEN**. 12/12 pass with the fix; 134/134 across the 6 related suites; `check:types` 0 errors; test-antipattern guard 55/55.

Pixel-visual in live Obsidian is deferred to a ~1-min user-confirm (see comment) — not an autonomous live-mutation.