### PR TITLE
feat(#3881): one-click WBS prototype-subtree instantiation (instantiatePrototypeSubtree service)

### DIFF
--- a/packages/cli/src/services/CliServiceRegistryPopulator.ts
+++ b/packages/cli/src/services/CliServiceRegistryPopulator.ts
@@ -27,6 +27,7 @@ import {
   createUpdatePropertyService,
   createRemovePropertyService,
   createSetStatusService,
+  createInstantiatePrototypeSubtreeService,
   type IPathResolver,
 } from "@kitelev/exocortex-services";
 
@@ -202,6 +203,7 @@ export {
   createUpdatePropertyService,
   createRemovePropertyService,
   createSetStatusService,
+  createInstantiatePrototypeSubtreeService,
 };
 
 /**
@@ -306,6 +308,17 @@ export function populateCliServiceRegistry(
           deps.vaultAdapter,
           deps.fsAdapter,
           createCliClassResolver(deps.vaultAdapter),
+        ),
+      );
+
+      // Issue #3881 (Gap 3) — one-shot WBS prototype-subtree instantiation.
+      // Needs vaultAdapter (getAllFiles + getFrontmatter for discovery) and
+      // fsAdapter (createFile for the clones); stub remains when fsAdapter absent.
+      registry.register(
+        "instantiatePrototypeSubtree",
+        createInstantiatePrototypeSubtreeService(
+          deps.vaultAdapter,
+          deps.fsAdapter,
         ),
       );
     }

--- a/packages/cli/tests/unit/services/instantiate-prototype-subtree.test.ts
+++ b/packages/cli/tests/unit/services/instantiate-prototype-subtree.test.ts
@@ -1,0 +1,212 @@
+import { describe, it, expect } from "@jest/globals";
+import { createInstantiatePrototypeSubtreeService } from "@kitelev/exocortex-services";
+import { FrontmatterService } from "@kitelev/exocortex-core";
+
+/**
+ * Production-shape revert-verify test for the `instantiatePrototypeSubtree`
+ * `service_call` service (issue #3881, Gap 3).
+ *
+ * Fixtures are RAW markdown parsed through the real `FrontmatterService`
+ * (test-fixture-realism) — the fake `IVaultAdapter.getFrontmatter` returns
+ * exactly what the production adapter would. The service is exercised end to
+ * end; assertions cover: subtree discovery, label substitution, per-node
+ * instance-class derivation, blocker re-mapping onto clones, WBS containment,
+ * structured relates (person + quarter), and Project-classed parent linking.
+ *
+ * Revert-verify: temporarily breaking the substitution loop OR the blocker
+ * re-map in `prototype-subtree-instantiator.ts` flips the marked assertions
+ * RED; restoring returns them GREEN (integration-test-revert-verify).
+ */
+
+// --- fixed fixture UIDs (deterministic) ---
+const PROJ_PROTO = "b2a49bb7-0000-0000-0000-000000000001";
+const TASK_PROTO = "df7e579d-0000-0000-0000-000000000002";
+const WCT_PROTO = "a67fc3b8-0000-0000-0000-000000000003";
+const ROOT = "d4b5bbf8-0000-0000-0000-000000000010";
+const C1 = "00000001-0000-0000-0000-000000000011"; // task, no blocker
+const C2 = "00000002-0000-0000-0000-000000000012"; // waiting, blocker→C1
+const C3 = "00000003-0000-0000-0000-000000000013"; // task, blocker→C2
+const PERSON = "d350b625-0000-0000-0000-000000000020";
+const QUARTER = "ed8e4fbb-0000-0000-0000-000000000021";
+const PARENT_PROJ = "11111111-0000-0000-0000-000000000030";
+
+interface FakeFile {
+  path: string;
+  basename: string;
+  name: string;
+  parent: { path: string; name: string } | null;
+}
+
+function mkFile(uid: string, folder = "efforts"): FakeFile {
+  return {
+    path: `${folder}/${uid}.md`,
+    basename: uid,
+    name: `${uid}.md`,
+    parent: { path: folder, name: folder },
+  };
+}
+
+// Raw markdown fixtures (parsed via real FrontmatterService in the fake adapter).
+function fixtures(): Record<string, string> {
+  return {
+    [PROJ_PROTO]: `---\nexo__Asset_uid: ${PROJ_PROTO}\nexo__Instance_class:\n  - "[[8619c4fc-64f1-4869-b17e-e34186cacca9]]"\nexo__Asset_label: ems__ProjectPrototype\n---\n`,
+    [TASK_PROTO]: `---\nexo__Asset_uid: ${TASK_PROTO}\nexo__Instance_class:\n  - "[[8619c4fc-64f1-4869-b17e-e34186cacca9]]"\nexo__Asset_label: ems__TaskPrototype\n---\n`,
+    [WCT_PROTO]: `---\nexo__Asset_uid: ${WCT_PROTO}\nexo__Instance_class:\n  - "[[8619c4fc-64f1-4869-b17e-e34186cacca9]]"\nexo__Asset_label: ems__WaitingCheckTaskPrototype\n---\n`,
+    [PERSON]: `---\nexo__Asset_uid: ${PERSON}\nexo__Instance_class:\n  - "[[person__Person]]"\nexo__Asset_label: n.rudopas\n---\n`,
+    [QUARTER]: `---\nexo__Asset_uid: ${QUARTER}\nexo__Instance_class:\n  - "[[period__Quarter]]"\nexo__Asset_label: Q3-26\n---\n`,
+    [PARENT_PROJ]: `---\nexo__Asset_uid: ${PARENT_PROJ}\nexo__Instance_class:\n  - "[[ems__Project]]"\nexo__Asset_label: Team Q3-26\n---\n`,
+    [ROOT]: `---\nexo__Asset_uid: ${ROOT}\nexo__Instance_class:\n  - "[[${PROJ_PROTO}]]"\nexo__Asset_isDefinedBy: "[[95c3de47-4c16-4dc8-a696-6e2f01993b6d]]"\nexo__Asset_label: "Ревьюшница {{сотрудник}} {{квартал}}"\n---\n`,
+    [C1]: `---\nexo__Asset_uid: ${C1}\nexo__Instance_class:\n  - "[[${TASK_PROTO}]]"\nexo__Asset_label: "Поручить {{сотрудник}} заполнить {{квартал}}"\nems__EffortPrototype_parentEffortPrototype: "[[${ROOT}]]"\n---\n`,
+    [C2]: `---\nexo__Asset_uid: ${C2}\nexo__Instance_class:\n  - "[[${WCT_PROTO}]]"\nexo__Asset_label: "{{сотрудник}} заполнил {{квартал}}"\nems__EffortPrototype_parentEffortPrototype: "[[${ROOT}]]"\nems__Effort_blocker: "[[${C1}]]"\n---\n`,
+    [C3]: `---\nexo__Asset_uid: ${C3}\nexo__Instance_class:\n  - "[[${TASK_PROTO}]]"\nexo__Asset_label: "Согласовать {{сотрудник}} {{квартал}}"\nems__EffortPrototype_parentEffortPrototype: "[[${ROOT}]]"\nems__Effort_blocker: "[[${C2}]]"\n---\n`,
+  };
+}
+
+function makeAdapterAndWriter(extraParams?: Record<string, string>) {
+  const fm = new FrontmatterService();
+  const raw = fixtures();
+  const files = Object.keys(raw).map((uid) => mkFile(uid));
+  const byPath = new Map<string, string>();
+  files.forEach((f) => byPath.set(f.path, raw[f.basename]));
+
+  const writes: { path: string; content: string }[] = [];
+
+  const vaultAdapter = {
+    getAllFiles: () => files,
+    getFrontmatter: (file: { path: string }) => {
+      const content = byPath.get(file.path);
+      return content ? fm.parseObject(content) : null;
+    },
+  } as never;
+
+  const fsAdapter = {
+    createFile: async (path: string, content: string) => {
+      writes.push({ path, content });
+      return path;
+    },
+  } as never;
+
+  return { vaultAdapter, fsAdapter, writes, fm };
+}
+
+/**
+ * Strip a single layer of surrounding double-quotes. `FrontmatterService.parseObject`
+ * (the test reader) keeps the YAML quotes the service writes for safety; the real
+ * store's YAML parser strips them. Normalising here mirrors production semantics
+ * (the quoted-wikilink write format is the established `createCreateAssetService`
+ * convention — required so colon-containing labels like «На 1-2-1: …» stay valid YAML).
+ */
+const unq = (s: unknown): string => String(s ?? "").replace(/^"(.*)"$/s, "$1");
+
+/** Parse a created instance's frontmatter + identify its source prototype. */
+function parseWrites(
+  writes: { path: string; content: string }[],
+  fm: FrontmatterService,
+) {
+  return writes.map((w) => {
+    const parsed = fm.parseObject(w.content) as Record<string, unknown>;
+    const protoUid =
+      unq(parsed.exo__Asset_prototype).match(/\[\[([^\]|]+)/)?.[1] ?? "";
+    return { path: w.path, fm: parsed, protoUid, content: w.content };
+  });
+}
+
+// @req:61206fe4-a599-4fc9-862d-9289e33c79e7
+describe("instantiatePrototypeSubtree (issue #3881 Gap 3)", () => {
+  const rootIRI = `obsidian://vault/efforts/${ROOT}.md`;
+
+  it("clones the whole subtree with substitution, derived classes, blocker re-map, relates + parent (@req:61206fe4-a599-4fc9-862d-9289e33c79e7)", async () => {
+    const { vaultAdapter, fsAdapter, writes, fm } = makeAdapterAndWriter();
+    const service = createInstantiatePrototypeSubtreeService(
+      vaultAdapter,
+      fsAdapter,
+    );
+
+    await service.execute(rootIRI, {
+      // eslint-disable-next-line @typescript-eslint/naming-convention
+      сотрудник: `[[${PERSON}]]`,
+      // eslint-disable-next-line @typescript-eslint/naming-convention
+      квартал: `[[${QUARTER}]]`,
+      // eslint-disable-next-line @typescript-eslint/naming-convention
+      родитель: `[[${PARENT_PROJ}]]`,
+    });
+
+    // 4-node subtree: root + C1 + C2 + C3.
+    expect(writes).toHaveLength(4);
+
+    const nodes = parseWrites(writes, fm);
+    const byProto = new Map(nodes.map((n) => [n.protoUid, n]));
+    const rootInst = byProto.get(ROOT)!;
+    const c1Inst = byProto.get(C1)!;
+    const c2Inst = byProto.get(C2)!;
+    const c3Inst = byProto.get(C3)!;
+    expect(rootInst && c1Inst && c2Inst && c3Inst).toBeTruthy();
+
+    // (revert-verify anchor #1) label substitution — no {{ }} survives, values applied.
+    for (const n of nodes) {
+      expect(unq(n.fm.exo__Asset_label)).not.toContain("{{");
+    }
+    expect(unq(rootInst.fm.exo__Asset_label)).toBe("Ревьюшница n.rudopas Q3-26");
+    expect(unq(c1Inst.fm.exo__Asset_label)).toBe(
+      "Поручить n.rudopas заполнить Q3-26",
+    );
+
+    // instance-class derivation (Prototype-suffix strip).
+    const cls = (n: { fm: Record<string, unknown> }) =>
+      unq((n.fm.exo__Instance_class as string[])[0]);
+    expect(cls(rootInst)).toBe("[[ems__Project]]");
+    expect(cls(c1Inst)).toBe("[[ems__Task]]");
+    expect(cls(c2Inst)).toBe("[[ems__WaitingCheckTask]]");
+    expect(cls(c3Inst)).toBe("[[ems__Task]]");
+
+    // (revert-verify anchor #2) blocker re-map onto CLONED siblings, not prototypes.
+    const c1NewUid = unq(c1Inst.fm.exo__Asset_uid);
+    const c2NewUid = unq(c2Inst.fm.exo__Asset_uid);
+    expect(unq(c2Inst.fm.ems__Effort_blocker)).toBe(`[[${c1NewUid}]]`);
+    expect(unq(c3Inst.fm.ems__Effort_blocker)).toBe(`[[${c2NewUid}]]`);
+    // never points at a prototype uid.
+    expect(unq(c2Inst.fm.ems__Effort_blocker)).not.toContain(C1);
+
+    // WBS containment: children parent to the root INSTANCE.
+    const rootNewUid = unq(rootInst.fm.exo__Asset_uid);
+    expect(unq(c1Inst.fm.ems__Effort_parent)).toBe(`[[${rootNewUid}]]`);
+    expect(unq(c2Inst.fm.ems__Effort_parent)).toBe(`[[${rootNewUid}]]`);
+    expect(unq(c3Inst.fm.ems__Effort_parent)).toBe(`[[${rootNewUid}]]`);
+
+    // Fork A: structured relates on root (person + quarter, differentiated by class).
+    const relates = (rootInst.fm.exo__Asset_relates as string[]).map(unq);
+    expect(relates).toContain(`[[${PERSON}]]`);
+    expect(relates).toContain(`[[${QUARTER}]]`);
+    // Fork B: Project-classed ref → root Effort_parent (not relates).
+    expect(unq(rootInst.fm.ems__Effort_parent)).toBe(`[[${PARENT_PROJ}]]`);
+    expect(relates).not.toContain(`[[${PARENT_PROJ}]]`);
+
+    // provenance + status + co-location.
+    expect(unq(rootInst.fm.exo__Asset_prototype)).toBe(`[[${ROOT}]]`);
+    expect(unq(rootInst.fm.ems__Effort_status)).toContain(
+      "753a44d5-846c-4b82-9196-4fd9a4d48777",
+    );
+    for (const n of nodes) expect(n.path.startsWith("efforts/")).toBe(true);
+  });
+
+  it("standalone when no Project-classed param is supplied (Fork B else-branch)", async () => {
+    const { vaultAdapter, fsAdapter, writes, fm } = makeAdapterAndWriter();
+    const service = createInstantiatePrototypeSubtreeService(
+      vaultAdapter,
+      fsAdapter,
+    );
+    await service.execute(rootIRI, {
+      // eslint-disable-next-line @typescript-eslint/naming-convention
+      сотрудник: `[[${PERSON}]]`,
+      // eslint-disable-next-line @typescript-eslint/naming-convention
+      квартал: `[[${QUARTER}]]`,
+    });
+    const nodes = parseWrites(writes, fm);
+    const rootInst = nodes.find((n) => n.protoUid === ROOT)!;
+    // no parent project provided → root has no Effort_parent (standalone).
+    expect(rootInst.fm.ems__Effort_parent).toBeUndefined();
+    // relates still carries person + quarter.
+    const relates = (rootInst.fm.exo__Asset_relates as string[]).map(unq);
+    expect(relates.sort()).toEqual([`[[${PERSON}]]`, `[[${QUARTER}]]`].sort());
+  });
+});

--- a/packages/cli/tests/unit/services/instantiate-prototype-subtree.test.ts
+++ b/packages/cli/tests/unit/services/instantiate-prototype-subtree.test.ts
@@ -97,7 +97,7 @@ function makeAdapterAndWriter(extraParams?: Record<string, string>) {
  * (the quoted-wikilink write format is the established `createCreateAssetService`
  * convention — required so colon-containing labels like «На 1-2-1: …» stay valid YAML).
  */
-const unq = (s: unknown): string => String(s ?? "").replace(/^"(.*)"$/s, "$1");
+const unq = (s: unknown): string => String(s ?? "").replace(/^"(.*)"$/, "$1");
 
 /** Parse a created instance's frontmatter + identify its source prototype. */
 function parseWrites(

--- a/packages/cli/tests/unit/services/instantiate-prototype-subtree.test.ts
+++ b/packages/cli/tests/unit/services/instantiate-prototype-subtree.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from "@jest/globals";
+import yaml from "js-yaml";
 import { createInstantiatePrototypeSubtreeService } from "@kitelev/exocortex-services";
 import { FrontmatterService } from "@kitelev/exocortex-core";
 
@@ -187,6 +188,22 @@ describe("instantiatePrototypeSubtree (issue #3881 Gap 3)", () => {
       "753a44d5-846c-4b82-9196-4fd9a4d48777",
     );
     for (const n of nodes) expect(n.path.startsWith("efforts/")).toBe(true);
+
+    // Production-parser realism (code-reviewer MEDIUM): the real CLI/plugin read
+    // path is `js-yaml.load` (NodeFsAdapter/FileSystemVaultAdapter), not the naive
+    // FrontmatterService.parseObject the fake adapter uses. Assert the written
+    // frontmatter round-trips through the ACTUAL production YAML parser — labels
+    // containing «:» (e.g. «На 1-2-1: …») stay valid because they are JSON-quoted.
+    const rootWrite = writes.find((w) =>
+      w.content.includes(`exo__Asset_prototype: "[[${ROOT}]]"`),
+    )!;
+    const fmBlock = rootWrite.content.split("---")[1];
+    const y = yaml.load(fmBlock) as Record<string, unknown>;
+    expect(y.exo__Asset_label).toBe("Ревьюшница n.rudopas Q3-26"); // js-yaml strips quotes
+    expect(y.exo__Instance_class).toEqual(["[[ems__Project]]"]);
+    expect(y.exo__Asset_relates).toEqual(
+      expect.arrayContaining([`[[${PERSON}]]`, `[[${QUARTER}]]`]),
+    );
   });
 
   it("standalone when no Project-classed param is supplied (Fork B else-branch)", async () => {

--- a/packages/obsidian-plugin/src/infrastructure/services/ServiceRegistryPopulator.ts
+++ b/packages/obsidian-plugin/src/infrastructure/services/ServiceRegistryPopulator.ts
@@ -52,6 +52,7 @@ import {
   createRemovePropertyService,
   createSetStatusService,
   createDuplicateAssetService,
+  createInstantiatePrototypeSubtreeService,
   type IPathResolver,
 } from "@kitelev/exocortex-services";
 import type { SPARQLApi } from "../../application/api/SPARQLApi";
@@ -316,6 +317,11 @@ export function populateServiceRegistry(
     registry.register(
       "archiveAsset",
       createArchiveAssetService(vaultAdapter, archiveAssetService, targetResolver),
+    );
+
+    registry.register(
+      "instantiatePrototypeSubtree",
+      createInstantiatePrototypeSubtreeService(vaultAdapter, fileSystemAdapter),
     );
 
     registry.register(

--- a/packages/services/src/index.ts
+++ b/packages/services/src/index.ts
@@ -39,3 +39,5 @@ export {
   type ITargetResolver,
   type IPathResolver,
 } from "./grounding-service-factories";
+
+export { createInstantiatePrototypeSubtreeService } from "./prototype-subtree-instantiator";

--- a/packages/services/src/prototype-subtree-instantiator.ts
+++ b/packages/services/src/prototype-subtree-instantiator.ts
@@ -86,7 +86,7 @@ function extractAlias(value: unknown): string | undefined {
  */
 function plainScalar(value: unknown): string {
   const raw = String(firstValue(value) ?? "");
-  const m = raw.match(/^"(.*)"$|^'(.*)'$/s);
+  const m = raw.match(/^"(.*)"$|^'(.*)'$/);
   return m ? (m[1] ?? m[2] ?? "") : raw;
 }
 

--- a/packages/services/src/prototype-subtree-instantiator.ts
+++ b/packages/services/src/prototype-subtree-instantiator.ts
@@ -1,0 +1,267 @@
+import { DateFormatter } from "@kitelev/exocortex-core";
+import type {
+  IGroundingService,
+  IVaultAdapter,
+  IFile,
+  IFileSystemWriter,
+  UserInput,
+} from "@kitelev/exocortex-core";
+
+/**
+ * `instantiatePrototypeSubtree` — generic `service_call` grounding that clones a
+ * whole WBS **prototype subtree** into a concrete instance graph in one shot.
+ *
+ * Issue kitelev/exocortex#3881 (Gap 3). Motivating use case: the quarterly
+ * review-sheet (`ems__ProjectPrototype` «Ревьюшница {{сотрудник}} {{квартал}}»
+ * `d4b5bbf8` + 9 `ems__TaskPrototype`/`ems__WaitingCheckTaskPrototype` children
+ * with an `ems__Effort_blocker` chain). One click deploys the whole 10-node
+ * subgraph for one employee × one quarter — but the mechanism is domain-agnostic
+ * (any prototype subtree, any substitution params).
+ *
+ * The command is a button ON the root prototype, so `targetIRI` = the root. The
+ * command's `inputSchema` collects the substitution params (e.g. `сотрудник`,
+ * `квартал`) — each an asset ref.
+ *
+ * Per node it:
+ *  - **discovers** the subtree = root + all descendants reachable via
+ *    `ems__EffortPrototype_parentEffortPrototype` (transitive BFS);
+ *  - **derives the instance class** by stripping the `Prototype` suffix from the
+ *    prototype node's class label (the existing `createCreateAssetService`
+ *    convention): `ems__ProjectPrototype`→`ems__Project`,
+ *    `ems__TaskPrototype`→`ems__Task`,
+ *    `ems__WaitingCheckTaskPrototype`→`ems__WaitingCheckTask`;
+ *  - **substitutes** every `{{key}}` in the label/aliases with the resolved label
+ *    of `userInput[key]` (person label, quarter label, …);
+ *  - **re-maps** the `ems__Effort_blocker` edge onto the CLONED sibling (not the
+ *    prototype) via a prototype-uid → new-instance-uid map;
+ *  - links children to the root INSTANCE via `ems__Effort_parent` (WBS
+ *    containment) and records provenance via `exo__Asset_prototype` → the source
+ *    prototype node;
+ *  - on the root, adds **structured `exo__Asset_relates`** for every non-Project
+ *    ref-param (person + quarter — differentiated by target class, req #3881
+ *    Fork A) and sets `ems__Effort_parent` to a Project-classed ref-param when
+ *    one is supplied, else standalone (Fork B).
+ *
+ * Storage-agnostic: all reads go through `IVaultAdapter` (`getAllFiles` +
+ * `getFrontmatter`), all writes through `IFileSystemWriter.createFile`, so the
+ * plugin (Obsidian) and CLI (Node fs) runtimes produce identical state.
+ */
+
+const BACKLOG_STATUS_UID = "753a44d5-846c-4b82-9196-4fd9a4d48777";
+const PARENT_PROTOTYPE_KEY = "ems__EffortPrototype_parentEffortPrototype";
+
+interface IndexEntry {
+  file: IFile;
+  fm: Record<string, unknown>;
+  uid: string;
+}
+
+/** Strip surrounding quotes + `[[ ]]` + optional `|alias`, return the target UID/ref. */
+function extractRef(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  let v = value.trim();
+  if (
+    (v.startsWith('"') && v.endsWith('"')) ||
+    (v.startsWith("'") && v.endsWith("'"))
+  ) {
+    v = v.slice(1, -1).trim();
+  }
+  const m = v.match(/^\[\[([^\]|]+)(?:\|[^\]]*)?\]\]$/);
+  if (m) return m[1].trim();
+  return v || undefined;
+}
+
+/** The alias part of `[[uid|alias]]`, if present. */
+function extractAlias(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const m = value.match(/\[\[[^\]|]+\|([^\]]+)\]\]/);
+  return m ? m[1].trim() : undefined;
+}
+
+/**
+ * Read a scalar frontmatter value as plain text, stripping a single layer of
+ * surrounding quotes. The Obsidian adapter (metadataCache) already returns
+ * unquoted values; the CLI adapter may surface the raw quoted YAML scalar — so
+ * we normalise defensively (a label read twice must not accumulate quotes).
+ */
+function plainScalar(value: unknown): string {
+  const raw = String(firstValue(value) ?? "");
+  const m = raw.match(/^"(.*)"$|^'(.*)'$/s);
+  return m ? (m[1] ?? m[2] ?? "") : raw;
+}
+
+function firstValue(v: unknown): unknown {
+  return Array.isArray(v) ? v[0] : v;
+}
+
+/** UID from an `obsidian://vault/…/<uid>.md` IRI, a bare path, or a bare uid. */
+function uidFromIRI(iri: string): string {
+  const noQuery = iri.replace(/\.md$/, "");
+  const last = noQuery.substring(noQuery.lastIndexOf("/") + 1);
+  return decodeURIComponent(last);
+}
+
+export function createInstantiatePrototypeSubtreeService(
+  vaultAdapter: IVaultAdapter,
+  fsAdapter: IFileSystemWriter,
+): IGroundingService {
+  return {
+    async execute(targetIRI: string, userInput?: UserInput): Promise<void> {
+      // 1. Index the vault once: uid → {file, frontmatter}.
+      const byUid = new Map<string, IndexEntry>();
+      for (const file of vaultAdapter.getAllFiles()) {
+        const fm = vaultAdapter.getFrontmatter(file) as Record<
+          string,
+          unknown
+        > | null;
+        if (!fm) continue;
+        const uid = (fm.exo__Asset_uid as string | undefined) ?? file.basename;
+        byUid.set(uid, { file, fm, uid });
+      }
+
+      // Resolve a class ref to its label. Alias-form (`[[uid|ems__Project]]`)
+      // wins; a UID-form ref resolves via uid→label; a symbolic ref
+      // (`[[ems__Project]]`) IS already the label, so use it verbatim.
+      const classLabel = (classRef: unknown): string | undefined => {
+        const alias = extractAlias(firstValue(classRef));
+        if (alias) return alias;
+        const ref = extractRef(firstValue(classRef));
+        if (!ref) return undefined;
+        const entry = byUid.get(ref);
+        return entry ? plainScalar(entry.fm.exo__Asset_label) : ref;
+      };
+
+      // 2. Resolve the root prototype.
+      const rootUid = uidFromIRI(targetIRI);
+      const root = byUid.get(rootUid);
+      if (!root) {
+        throw new Error(
+          `instantiatePrototypeSubtree: root prototype not found for target "${targetIRI}" (uid ${rootUid})`,
+        );
+      }
+
+      // 3. BFS-discover the subtree via parentEffortPrototype (transitive).
+      const subtree = new Set<string>([rootUid]);
+      let grew = true;
+      while (grew) {
+        grew = false;
+        for (const [uid, entry] of byUid) {
+          if (subtree.has(uid)) continue;
+          const parentUid = extractRef(firstValue(entry.fm[PARENT_PROTOTYPE_KEY]));
+          if (parentUid && subtree.has(parentUid)) {
+            subtree.add(uid);
+            grew = true;
+          }
+        }
+      }
+
+      // 4. prototype-uid → new-instance-uid.
+      const instUid = new Map<string, string>();
+      for (const uid of subtree) instUid.set(uid, crypto.randomUUID());
+
+      // 5. Resolve substitution params + classify ref-params (Fork A/B).
+      //    `{{key}}` → resolved label of userInput[key]; person/quarter refs →
+      //    root `exo__Asset_relates`; Project-classed ref → root Effort_parent.
+      const substitutions: Record<string, string> = {};
+      const relatesRefs: string[] = [];
+      let parentEffortRef: string | undefined;
+      for (const [key, raw] of Object.entries(userInput ?? {})) {
+        if (raw == null) continue;
+        if (key === "label" || key === "body") continue;
+        const refUid = extractRef(firstValue(raw));
+        const target = refUid ? byUid.get(refUid) : undefined;
+        if (target) {
+          const targetLabel = target.fm.exo__Asset_label
+            ? plainScalar(target.fm.exo__Asset_label)
+            : undefined;
+          substitutions[key] = targetLabel ?? String(raw);
+          const clsLabel = classLabel(target.fm.exo__Instance_class) ?? "";
+          if (clsLabel.includes("Project")) {
+            if (!parentEffortRef) parentEffortRef = refUid;
+          } else {
+            relatesRefs.push(refUid as string);
+          }
+        } else {
+          // Raw scalar param (e.g. a quarter typed as text) — substitute literally.
+          substitutions[key] = String(raw);
+        }
+      }
+
+      const substitute = (text: unknown): string => {
+        let s = String(text ?? "");
+        for (const [key, val] of Object.entries(substitutions)) {
+          s = s.split(`{{${key}}}`).join(val);
+        }
+        return s;
+      };
+
+      // 6. Write each instance. Co-locate in the prototype node's folder.
+      const createdAt = DateFormatter.toISOTimestamp(new Date());
+      // Deterministic order (root first) so any read-back is stable.
+      const ordered = [rootUid, ...[...subtree].filter((u) => u !== rootUid)];
+      for (const protoUid of ordered) {
+        const entry = byUid.get(protoUid);
+        if (!entry) continue;
+        const { file, fm } = entry;
+        const newUid = instUid.get(protoUid) as string;
+
+        const protoClassLabel = classLabel(fm.exo__Instance_class);
+        const instClassLabel =
+          protoClassLabel && protoClassLabel.endsWith("Prototype")
+            ? protoClassLabel.slice(0, -"Prototype".length)
+            : protoClassLabel;
+
+        const label = substitute(plainScalar(fm.exo__Asset_label));
+
+        const lines: string[] = ["---", `exo__Asset_uid: ${newUid}`];
+        if (fm.exo__Asset_isDefinedBy) {
+          lines.push(
+            `exo__Asset_isDefinedBy: "[[${extractRef(firstValue(fm.exo__Asset_isDefinedBy))}]]"`,
+          );
+        }
+        lines.push(
+          `exo__Asset_createdAt: ${createdAt}`,
+          `exo__Asset_updatedAt: ${createdAt}`,
+          "exo__Instance_class:",
+          `  - "[[${instClassLabel}]]"`,
+          `exo__Asset_label: ${JSON.stringify(label)}`,
+          "aliases:",
+          `  - ${JSON.stringify(label)}`,
+          `exo__Asset_prototype: "[[${protoUid}]]"`,
+          `ems__Effort_status: "[[${BACKLOG_STATUS_UID}]]"`,
+        );
+
+        // Blocker re-map onto the cloned sibling (fall back to original if the
+        // blocker target is outside the subtree).
+        const blockerUid = extractRef(firstValue(fm.ems__Effort_blocker));
+        if (blockerUid) {
+          const mapped = instUid.get(blockerUid) ?? blockerUid;
+          lines.push(`ems__Effort_blocker: "[[${mapped}]]"`);
+        }
+
+        if (protoUid === rootUid) {
+          if (relatesRefs.length > 0) {
+            lines.push("exo__Asset_relates:");
+            for (const ref of relatesRefs) lines.push(`  - "[[${ref}]]"`);
+          }
+          if (parentEffortRef) {
+            lines.push(`ems__Effort_parent: "[[${parentEffortRef}]]"`);
+          }
+        } else {
+          // WBS containment: every non-root clone parents to the root instance.
+          lines.push(
+            `ems__Effort_parent: "[[${instUid.get(rootUid) as string}]]"`,
+          );
+        }
+
+        lines.push("---", "");
+        const content = lines.join("\n");
+
+        const slash = file.path.lastIndexOf("/");
+        const folder = slash >= 0 ? file.path.substring(0, slash) : "";
+        const filePath = folder ? `${folder}/${newUid}.md` : `${newUid}.md`;
+        await fsAdapter.createFile(filePath, content);
+      }
+    },
+  };
+}


### PR DESCRIPTION
## What

Generic `instantiatePrototypeSubtree` `service_call` grounding service (issue #3881 Gap 3) — clones a whole WBS **prototype subtree** into a concrete instance graph in one shot. Motivating case: the quarterly review-sheet prototype (`ems__ProjectPrototype` `d4b5bbf8` + 9 children with a blocker chain) deployed for one employee × quarter with a single command.

Per node it: discovers the subtree (root + transitive `ems__EffortPrototype_parentEffortPrototype` descendants) · derives the instance class by stripping the `Prototype` suffix (`ProjectPrototype`→`Project`, `TaskPrototype`→`Task`, `WaitingCheckTaskPrototype`→`WaitingCheckTask`) · substitutes `{{param}}` in labels/aliases with resolved parameter labels · re-maps `ems__Effort_blocker` onto the **cloned sibling** · parents children to the root instance (`ems__Effort_parent`) + records `exo__Asset_prototype` provenance · on the root adds structured `exo__Asset_relates` (person + quarter, differentiated by target class) and `ems__Effort_parent` to a Project-classed ref (else standalone) · starts each at Backlog, co-located. Domain-agnostic — zero domain hardcoding.

## Where
- `packages/services/src/prototype-subtree-instantiator.ts` — the storage-agnostic `IGroundingService`.
- Registered as serviceId `instantiatePrototypeSubtree` in **both** `ServiceRegistryPopulator` (plugin) + `CliServiceRegistryPopulator` (CLI).

## Onto prerequisites (shipped as vault data, shared `exoas-public/ems`, SHACL 0 regressions across vault-my/tbank/exodev)
- Gap 1: `ems__ProjectPrototype` gains `ems__EffortPrototype` superClass (so the root participates in the `parentEffortPrototype` hierarchy).
- Gap 2: new class `ems__WaitingCheckTaskPrototype` (`a67fc3b8`) — instantiates to `ems__WaitingCheckTask`.

## Verified
Production-shape revert-verify test `packages/cli/tests/unit/services/instantiate-prototype-subtree.test.ts` (`@req:61206fe4-a599-4fc9-862d-9289e33c79e7`) — real service over a 4-node subtree parsed through the real `FrontmatterService`; 2/2 GREEN. Revert-verified non-vacuous on **both** axes: disabling substitution → label keeps `{{сотрудник}}` (RED); disabling blocker re-map → clone blocker points at the prototype uid (RED); restoring → GREEN.

Closes #3881 (Gap 3; Gaps 1+2 shipped as onto data).