### PR TITLE
feat(#3824): audit ontology-url — flag exocortex.my exo__Ontology_url without trailing '#'

### DIFF
--- a/packages/cli/src/commands/audit-ontology-url.ts
+++ b/packages/cli/src/commands/audit-ontology-url.ts
@@ -1,0 +1,247 @@
+import { Command } from "commander";
+import { existsSync, statSync } from "fs";
+import { resolve } from "path";
+import { CachingNodeFsAdapter } from "../adapters/CachingNodeFsAdapter.js";
+import {
+  isNodeModulesPath,
+  isTemplatesPath,
+} from "../utils/vaultPathFilters.js";
+import { ErrorHandler, type OutputFormat } from "../utils/ErrorHandler.js";
+import { VaultNotFoundError } from "../utils/errors/index.js";
+
+/**
+ * The canonical namespace host whose ontologies MUST carry a trailing `#`
+ * separator. Foreign vocabularies (any other host) define their own form and
+ * are skipped — `/` and `#` are both valid for them.
+ */
+export const EXOCORTEX_MY_HOST = "exocortex.my";
+
+/**
+ * Reasons an ontology-url asset is fail-open SKIPPED (not a violation, but also
+ * not proven canonical). Reported explicitly so "0 violations" never masks
+ * "every exocortex.my ontology checked".
+ * - `foreign-vocab`: the URL parsed but its host is not {@link EXOCORTEX_MY_HOST};
+ *   the vocabulary author defines the form ('/' or '#' both valid).
+ * - `unparseable-url`: `exo__Ontology_url` is present but not a parseable URL, so
+ *   it cannot be classified as exocortex.my — not this check's concern.
+ */
+export type OntologyUrlSkipReason = "foreign-vocab" | "unparseable-url";
+
+export interface OntologyUrlViolation {
+  path: string;
+  /** The current (hash-less) `exo__Ontology_url` value. */
+  url: string;
+  /** The expected canonical form: trailing slashes stripped + a single `#`. */
+  expected: string;
+}
+
+export interface OntologyUrlResult {
+  vaultPath: string;
+  totalFiles: number;
+  /** Assets carrying a non-empty `exo__Ontology_url` (the audit scope). */
+  ontologiesFound: number;
+  /** exocortex.my ontologies actually checked for the trailing `#`. */
+  checked: number;
+  violations: OntologyUrlViolation[];
+  skips: Record<OntologyUrlSkipReason, number>;
+  /** Up to a few example paths per skip reason, for human triage. */
+  skipExamples: Record<OntologyUrlSkipReason, string[]>;
+}
+
+const MAX_SKIP_EXAMPLES = 5;
+
+/** First string value of a frontmatter field (arrays → first string element). */
+function firstString(value: unknown): string | null {
+  if (Array.isArray(value)) {
+    const s = value.find((v) => typeof v === "string");
+    return (s as string) ?? null;
+  }
+  return typeof value === "string" ? value : null;
+}
+
+/** Host of a URL string, or null if it does not parse as a URL. */
+function urlHost(url: string): string | null {
+  try {
+    return new URL(url).host;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Canonical form for a hash-less exocortex.my URL: strip trailing slashes, then
+ * append a single `#`. `.../ems` → `.../ems#`; `.../ems/` → `.../ems#`. Only
+ * called for URLs that do NOT already end with `#` (i.e. real violations), so
+ * the result always ends with exactly one `#`.
+ */
+export function expectedCanonicalForm(url: string): string {
+  return `${url.replace(/\/+$/, "")}#`;
+}
+
+/**
+ * Audit a single vault for the `exo__Ontology_url` trailing-separator invariant:
+ * every asset whose `exo__Ontology_url` is an `exocortex.my` namespace URL must
+ * end with a `#` separator (term-IRI = `Ontology_url + localName`, so
+ * `https://exocortex.my/ontology/ems#` + `Task` = `ems#Task`; a hash-less
+ * `.../ems` concatenates to `emsTask` and a hash-less SPARQL PREFIX expands
+ * `ems:Task` wrongly, silently returning 0 rows).
+ *
+ * Scope = any asset carrying a non-empty `exo__Ontology_url` (the property is
+ * the discriminator — only ontologies carry it, form-agnostic to the
+ * `exo__Instance_class` UID-vs-label representation).
+ *
+ * Fail-open: FOREIGN vocabularies (host ≠ exocortex.my) and unparseable URLs are
+ * skipped and counted by reason — never reported as violations. Sub-ontologies
+ * with a hierarchical path (`.../kitelev-period/quarters#`) pass: the path is
+ * preserved, only the trailing `#` is required.
+ */
+export async function scanVaultForOntologyUrl(
+  vaultPath: string,
+): Promise<OntologyUrlResult> {
+  const adapter = new CachingNodeFsAdapter(vaultPath);
+  const assets = await adapter.indexedAssets();
+
+  const violations: OntologyUrlViolation[] = [];
+  const skips: Record<OntologyUrlSkipReason, number> = {
+    "foreign-vocab": 0,
+    "unparseable-url": 0,
+  };
+  const skipExamples: Record<OntologyUrlSkipReason, string[]> = {
+    "foreign-vocab": [],
+    "unparseable-url": [],
+  };
+  let ontologiesFound = 0;
+  let checked = 0;
+
+  const addExample = (reason: OntologyUrlSkipReason, filePath: string): void => {
+    if (skipExamples[reason].length < MAX_SKIP_EXAMPLES) {
+      skipExamples[reason].push(filePath);
+    }
+  };
+
+  for (const { path: relPath, metadata } of assets) {
+    // Not vault content: node_modules (glob keeps them) + Templater templates
+    // (intentional placeholder syntax; never migrated).
+    if (isNodeModulesPath(relPath) || isTemplatesPath(relPath)) continue;
+
+    const url = firstString(metadata["exo__Ontology_url"]);
+    if (!url) continue; // not an ontology-url-bearing asset — silently ignored
+
+    ontologiesFound++;
+
+    const host = urlHost(url);
+    if (host === null) {
+      skips["unparseable-url"]++;
+      addExample("unparseable-url", relPath);
+      continue;
+    }
+    if (host !== EXOCORTEX_MY_HOST) {
+      skips["foreign-vocab"]++;
+      addExample("foreign-vocab", relPath);
+      continue;
+    }
+
+    checked++;
+    if (!url.endsWith("#")) {
+      violations.push({
+        path: relPath,
+        url,
+        expected: expectedCanonicalForm(url),
+      });
+    }
+  }
+
+  return {
+    vaultPath,
+    totalFiles: assets.length,
+    ontologiesFound,
+    checked,
+    violations,
+    skips,
+    skipExamples,
+  };
+}
+
+export interface AuditOntologyUrlOptions {
+  vault: string;
+  output?: OutputFormat;
+}
+
+/**
+ * Issue #3824 (SDD req `df6c979e`) — `exo__Ontology_url` trailing-`#` audit
+ * (source of truth, CI). Mirrors `audit co-location` / `audit ontology-imports`.
+ *
+ * `exocortex audit ontology-url --vault <path>` walks the vault and reports any
+ * exocortex.my ontology whose `exo__Ontology_url` lacks a trailing `#`. Exit 0 =
+ * 0 violations (foreign/unparseable skips are still reported); exit 1 = ≥1
+ * violation. Skips never affect the exit code — fail-open by design.
+ */
+export function auditOntologyUrlCommand(): Command {
+  return new Command("ontology-url")
+    .description(
+      "Detect exocortex.my ontologies whose exo__Ontology_url lacks the canonical trailing '#' separator (foreign vocabularies skipped, path hierarchy preserved, fail-open + skip-accounted)",
+    )
+    .requiredOption("--vault <path>", "Vault root directory")
+    .option("--output <type>", "Response format: text|json", "text")
+    .action(async (options: AuditOntologyUrlOptions) => {
+      const outputFormat = (options.output ?? "text") as OutputFormat;
+      ErrorHandler.setFormat(outputFormat);
+
+      try {
+        const vaultPath = resolve(options.vault);
+        if (!existsSync(vaultPath) || !statSync(vaultPath).isDirectory()) {
+          throw new VaultNotFoundError(vaultPath);
+        }
+
+        const result = await scanVaultForOntologyUrl(vaultPath);
+        const skipTotal =
+          result.skips["foreign-vocab"] + result.skips["unparseable-url"];
+
+        if (outputFormat === "json") {
+          console.log(
+            JSON.stringify(
+              {
+                vaultPath: result.vaultPath,
+                totalFiles: result.totalFiles,
+                ontologiesFound: result.ontologiesFound,
+                checked: result.checked,
+                violationCount: result.violations.length,
+                violations: result.violations,
+                skips: result.skips,
+                skipTotal,
+                skipExamples: result.skipExamples,
+                clean: result.violations.length === 0,
+              },
+              null,
+              2,
+            ),
+          );
+        } else {
+          if (result.violations.length === 0) {
+            console.log(
+              `OK ${vaultPath}: 0 ontology-url violations (${result.checked}/${result.ontologiesFound} exocortex.my ontologies checked)`,
+            );
+          } else {
+            console.error(
+              `FAIL ${vaultPath}: ${result.violations.length} ontology-url violation(s) (${result.checked}/${result.ontologiesFound} exocortex.my ontologies checked):`,
+            );
+            for (const v of result.violations) {
+              console.error(
+                `  ${v.path}\n      url=${v.url} expected=${v.expected}`,
+              );
+            }
+          }
+          // Skip-accounting is always printed — "0 violations" ≠ "every ontology canonical".
+          console.error(
+            `\nSkipped (fail-open, NOT verified): ${skipTotal} — ` +
+              `foreign-vocab=${result.skips["foreign-vocab"]}, ` +
+              `unparseable-url=${result.skips["unparseable-url"]}`,
+          );
+        }
+
+        if (result.violations.length > 0) process.exitCode = 1;
+      } catch (error) {
+        ErrorHandler.handle(error as Error);
+      }
+    });
+}

--- a/packages/cli/src/commands/audit.ts
+++ b/packages/cli/src/commands/audit.ts
@@ -1,15 +1,18 @@
 import { Command } from "commander";
 import { auditCoLocationCommand } from "./audit-co-location.js";
 import { auditOntologyImportsCommand } from "./audit-ontology-imports.js";
+import { auditOntologyUrlCommand } from "./audit-ontology-url.js";
 
 /**
  * Creates the 'audit' parent command with regression-detection subcommands:
  * - audit co-location — RFC 0b7a2fad asset–ontology co-location invariant.
  * - audit ontology-imports — RFC df39007b ontology imports DAG invariant.
+ * - audit ontology-url — issue #3824 exo__Ontology_url trailing-# separator invariant.
  *
  * @example
  * exocortex audit co-location --vault /path/to/vault
  * exocortex audit ontology-imports --vault /path/to/vault
+ * exocortex audit ontology-url --vault /path/to/vault
  */
 export function auditCommand(): Command {
   const cmd = new Command("audit").description(
@@ -18,6 +21,7 @@ export function auditCommand(): Command {
 
   cmd.addCommand(auditCoLocationCommand());
   cmd.addCommand(auditOntologyImportsCommand());
+  cmd.addCommand(auditOntologyUrlCommand());
 
   return cmd;
 }

--- a/packages/cli/tests/integration/commands/audit-ontology-url.integration.test.ts
+++ b/packages/cli/tests/integration/commands/audit-ontology-url.integration.test.ts
@@ -1,0 +1,202 @@
+import { describe, it, expect, beforeEach, afterEach, jest } from "@jest/globals";
+import { mkdirSync, rmSync, writeFileSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import {
+  scanVaultForOntologyUrl,
+  auditOntologyUrlCommand,
+} from "../../../src/commands/audit-ontology-url.js";
+
+const ONTOLOGY_CLASS = "829b9b3b-6fc3-4276-be6a-27d3398c012e";
+
+/** Write a real ontology asset with the given exo__Ontology_url. */
+function writeOntology(dir: string, uid: string, url: string): string {
+  mkdirSync(dir, { recursive: true });
+  const file = join(dir, `${uid}.md`);
+  writeFileSync(
+    file,
+    `---
+exo__Asset_uid: ${uid}
+exo__Asset_label: Fixture Ontology ${uid}
+exo__Instance_class:
+  - "[[${ONTOLOGY_CLASS}|exo__Ontology]]"
+exo__Ontology_url: ${url}
+---
+
+# Ontology ${uid}
+`,
+    "utf-8",
+  );
+  return file;
+}
+
+/**
+ * Empirical revert→fail / restore→pass proof for `audit ontology-url` (issue
+ * #3824 AC5). This is NOT a cyclic metric: the verdict is driven purely by the
+ * on-disk `exo__Ontology_url` value. We physically REMOVE the trailing `#` from
+ * a real exocortex.my ontology (audit must FAIL=1 violation), then RESTORE it
+ * (audit must PASS=0). If the audit reported 0 in BOTH states it would be a
+ * false-positive guard — this test would catch that.
+ */
+describe("audit ontology-url — revert→fail / restore→pass (integration)", () => {
+  let vault: string;
+  let ontoDir: string;
+
+  beforeEach(() => {
+    vault = join(
+      tmpdir(),
+      `onturl-integration-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    );
+    ontoDir = join(vault, "assetspaces", "kitelev", "exoas-public", "ems");
+    mkdirSync(vault, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(vault, { recursive: true, force: true });
+  });
+
+  it("@req:df6c979e-d432-4ce8-b652-aff31cba151c GREEN with trailing '#', RED when removed, GREEN when restored", async () => {
+    const uid = "aaaa1111-2222-3333-4444-555555555555";
+
+    // --- State 1: canonical (trailing '#') → audit GREEN (0 violations) ---
+    writeOntology(ontoDir, uid, "https://exocortex.my/ontology/ems#");
+    let r = await scanVaultForOntologyUrl(vault);
+    expect(r.violations).toHaveLength(0);
+    expect(r.checked).toBe(1);
+
+    // --- State 2: revert — REMOVE the '#' → audit RED (1 violation) ---
+    writeOntology(ontoDir, uid, "https://exocortex.my/ontology/ems");
+    r = await scanVaultForOntologyUrl(vault);
+    expect(r.violations).toHaveLength(1);
+    expect(r.violations[0].path).toBe(
+      "assetspaces/kitelev/exoas-public/ems/" + uid + ".md",
+    );
+    expect(r.violations[0].url).toBe("https://exocortex.my/ontology/ems");
+    expect(r.violations[0].expected).toBe("https://exocortex.my/ontology/ems#");
+
+    // --- State 3: restore the '#' → audit GREEN again (0 violations) ---
+    writeOntology(ontoDir, uid, "https://exocortex.my/ontology/ems#");
+    r = await scanVaultForOntologyUrl(vault);
+    expect(r.violations).toHaveLength(0);
+  });
+});
+
+/**
+ * Full-vault acceptance (issue #3824 AC1–AC4) over a mixed real ontology set,
+ * driven end-to-end through the Commander action (output + exit code).
+ */
+describe("audit ontology-url — mixed-vault acceptance (integration)", () => {
+  let vault: string;
+  let logSpy: ReturnType<typeof jest.spyOn>;
+  let errSpy: ReturnType<typeof jest.spyOn>;
+  let prevExit: number | undefined;
+
+  beforeEach(() => {
+    vault = join(
+      tmpdir(),
+      `onturl-mixed-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    );
+    mkdirSync(vault, { recursive: true });
+    logSpy = jest.spyOn(console, "log").mockImplementation(() => {});
+    errSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+    prevExit = process.exitCode;
+    process.exitCode = undefined;
+  });
+
+  afterEach(() => {
+    logSpy.mockRestore();
+    errSpy.mockRestore();
+    process.exitCode = prevExit;
+    rmSync(vault, { recursive: true, force: true });
+  });
+
+  const emsDir = () =>
+    join(vault, "assetspaces", "kitelev", "exoas-public", "ems");
+  const w3cDir = () =>
+    join(vault, "assetspaces", "kitelev", "exoas-w3c", "w3c");
+  const periodDir = () =>
+    join(vault, "assetspaces", "kitelev", "exoas-public", "kitelev-period");
+
+  it("AC1 flags a hash-less exocortex.my ontology with the expected form; AC2 skips a foreign vocab; AC3 passes a hierarchical-path sub-ontology; exit 1", async () => {
+    // AC1: exocortex.my WITHOUT '#' → violation
+    writeOntology(
+      emsDir(),
+      "bad00000-0000-0000-0000-000000000001",
+      "https://exocortex.my/ontology/ems",
+    );
+    // AC2: foreign vocab (w3.org) → skipped (foreign-vocab), NEVER a violation
+    writeOntology(
+      w3cDir(),
+      "for00000-0000-0000-0000-000000000002",
+      "https://www.w3.org/2000/01/rdf-schema#",
+    );
+    // AC3: hierarchical-path sub-ontology WITH '#' → passes
+    writeOntology(
+      periodDir(),
+      "sub00000-0000-0000-0000-000000000003",
+      "https://exocortex.my/ontology/kitelev-period/quarters#",
+    );
+
+    const r = await scanVaultForOntologyUrl(vault);
+    expect(r.ontologiesFound).toBe(3);
+    expect(r.checked).toBe(2); // ems (bad) + quarters (ok); w3c skipped
+    expect(r.violations).toHaveLength(1);
+    expect(r.violations[0].url).toBe("https://exocortex.my/ontology/ems");
+    expect(r.violations[0].expected).toBe("https://exocortex.my/ontology/ems#");
+    expect(r.skips["foreign-vocab"]).toBe(1);
+
+    // Drive the command action → text output + exit code 1
+    const cmd = auditOntologyUrlCommand();
+    await cmd.parseAsync(["--vault", vault], { from: "user" });
+    expect(process.exitCode).toBe(1);
+    const err = errSpy.mock.calls.map((c) => c.join(" ")).join("\n");
+    expect(err).toMatch(/1 ontology-url violation/);
+    expect(err).toMatch(/expected=https:\/\/exocortex\.my\/ontology\/ems#/);
+    expect(err).toMatch(/foreign-vocab=1/);
+  });
+
+  it("AC4 all-normalized vault → zero violations + exit 0", async () => {
+    writeOntology(
+      emsDir(),
+      "ok000000-0000-0000-0000-000000000010",
+      "https://exocortex.my/ontology/ems#",
+    );
+    writeOntology(
+      periodDir(),
+      "ok000000-0000-0000-0000-000000000011",
+      "https://exocortex.my/ontology/kitelev-period/quarters#",
+    );
+    // A foreign vocab is present but must not affect the exit code.
+    writeOntology(
+      w3cDir(),
+      "ok000000-0000-0000-0000-000000000012",
+      "http://www.w3.org/2002/07/owl#",
+    );
+
+    const cmd = auditOntologyUrlCommand();
+    await cmd.parseAsync(["--vault", vault], { from: "user" });
+    expect(process.exitCode).toBeFalsy();
+    const out = logSpy.mock.calls.map((c) => c.join(" ")).join("\n");
+    expect(out).toMatch(/0 ontology-url violations/);
+  });
+
+  it("json output emits structured result with expected canonical form", async () => {
+    writeOntology(
+      emsDir(),
+      "bad00000-0000-0000-0000-000000000020",
+      "https://exocortex.my/ontology/ems",
+    );
+    const cmd = auditOntologyUrlCommand();
+    await cmd.parseAsync(["--vault", vault, "--output", "json"], {
+      from: "user",
+    });
+    const out = logSpy.mock.calls.map((c) => c.join(" ")).join("\n");
+    const parsed = JSON.parse(out);
+    expect(parsed.violationCount).toBe(1);
+    expect(parsed.clean).toBe(false);
+    expect(parsed.violations[0].expected).toBe(
+      "https://exocortex.my/ontology/ems#",
+    );
+    expect(parsed.skips).toBeDefined();
+  });
+});

--- a/packages/cli/tests/unit/commands/audit-ontology-url.test.ts
+++ b/packages/cli/tests/unit/commands/audit-ontology-url.test.ts
@@ -1,0 +1,188 @@
+import { describe, it, expect, beforeEach, afterEach } from "@jest/globals";
+import { mkdirSync, rmSync, writeFileSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import {
+  scanVaultForOntologyUrl,
+  auditOntologyUrlCommand,
+  expectedCanonicalForm,
+} from "../../../src/commands/audit-ontology-url.js";
+import { auditCommand } from "../../../src/commands/audit.js";
+
+const ONTOLOGY_CLASS = "829b9b3b-6fc3-4276-be6a-27d3398c012e";
+
+/** Write an ontology asset (optional exo__Ontology_url line). */
+function writeOntology(dir: string, uid: string, url?: string): void {
+  mkdirSync(dir, { recursive: true });
+  const urlLine = url !== undefined ? `exo__Ontology_url: ${url}\n` : "";
+  writeFileSync(
+    join(dir, `${uid}.md`),
+    `---
+exo__Asset_uid: ${uid}
+exo__Asset_label: Onto ${uid}
+exo__Instance_class:
+  - "[[${ONTOLOGY_CLASS}|exo__Ontology]]"
+${urlLine}---
+
+Body.
+`,
+    "utf-8",
+  );
+}
+
+describe("audit ontology-url — Commander wiring", () => {
+  it("registers under 'audit' parent command", () => {
+    const parent = auditCommand();
+    expect(parent.name()).toBe("audit");
+    const sub = parent.commands.find((c) => c.name() === "ontology-url");
+    expect(sub).toBeDefined();
+  });
+
+  it("subcommand declares --vault required + --output options", () => {
+    const sub = auditOntologyUrlCommand();
+    expect(sub.name()).toBe("ontology-url");
+    const opts = sub.options.map((o) => o.long);
+    expect(opts).toContain("--vault");
+    expect(opts).toContain("--output");
+  });
+
+  it("--help references the trailing-# / exo__Ontology_url semantics", () => {
+    const sub = auditOntologyUrlCommand();
+    expect(sub.helpInformation()).toMatch(/exo__Ontology_url|trailing/i);
+  });
+});
+
+describe("expectedCanonicalForm", () => {
+  it("appends '#' to a hash-less URL", () => {
+    expect(expectedCanonicalForm("https://exocortex.my/ontology/ems")).toBe(
+      "https://exocortex.my/ontology/ems#",
+    );
+  });
+
+  it("strips trailing slashes before appending '#'", () => {
+    expect(expectedCanonicalForm("https://exocortex.my/ontology/ems/")).toBe(
+      "https://exocortex.my/ontology/ems#",
+    );
+    expect(expectedCanonicalForm("https://exocortex.my/ontology/ems//")).toBe(
+      "https://exocortex.my/ontology/ems#",
+    );
+  });
+
+  it("preserves an internal hierarchical path", () => {
+    expect(
+      expectedCanonicalForm("https://exocortex.my/ontology/kitelev-period/quarters"),
+    ).toBe("https://exocortex.my/ontology/kitelev-period/quarters#");
+  });
+});
+
+describe("audit ontology-url — scanVaultForOntologyUrl", () => {
+  let vault: string;
+
+  beforeEach(() => {
+    vault = join(
+      tmpdir(),
+      `onturl-unit-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    );
+    mkdirSync(vault, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(vault, { recursive: true, force: true });
+  });
+
+  const emsDir = () =>
+    join(vault, "assetspaces", "kitelev", "exoas-public", "ems");
+
+  it("flags an exocortex.my URL without a trailing '#'", async () => {
+    writeOntology(emsDir(), "u1", "https://exocortex.my/ontology/ems");
+    const r = await scanVaultForOntologyUrl(vault);
+    expect(r.checked).toBe(1);
+    expect(r.violations).toHaveLength(1);
+    expect(r.violations[0].expected).toBe("https://exocortex.my/ontology/ems#");
+  });
+
+  it("flags an exocortex.my URL that ends with '/' (must be '#')", async () => {
+    writeOntology(emsDir(), "u2", "https://exocortex.my/ontology/ems/");
+    const r = await scanVaultForOntologyUrl(vault);
+    expect(r.violations).toHaveLength(1);
+    expect(r.violations[0].expected).toBe("https://exocortex.my/ontology/ems#");
+  });
+
+  it("passes an exocortex.my URL that already ends with '#'", async () => {
+    writeOntology(emsDir(), "u3", "https://exocortex.my/ontology/ems#");
+    const r = await scanVaultForOntologyUrl(vault);
+    expect(r.checked).toBe(1);
+    expect(r.violations).toHaveLength(0);
+  });
+
+  it("passes a hierarchical-path sub-ontology with '#'", async () => {
+    writeOntology(
+      emsDir(),
+      "u4",
+      "https://exocortex.my/ontology/kitelev-period/quarters#",
+    );
+    const r = await scanVaultForOntologyUrl(vault);
+    expect(r.violations).toHaveLength(0);
+  });
+
+  it("skips a foreign vocabulary (host ≠ exocortex.my), counted as foreign-vocab", async () => {
+    writeOntology(emsDir(), "u5", "https://www.w3.org/2000/01/rdf-schema#");
+    const r = await scanVaultForOntologyUrl(vault);
+    expect(r.checked).toBe(0);
+    expect(r.violations).toHaveLength(0);
+    expect(r.skips["foreign-vocab"]).toBe(1);
+    expect(r.skipExamples["foreign-vocab"].length).toBe(1);
+  });
+
+  it("skips a foreign vocab that ITSELF lacks a '#' (e.g. path-style) — never a violation", async () => {
+    writeOntology(emsDir(), "u5b", "http://xmlns.com/foaf/0.1");
+    const r = await scanVaultForOntologyUrl(vault);
+    expect(r.violations).toHaveLength(0);
+    expect(r.skips["foreign-vocab"]).toBe(1);
+  });
+
+  it("skips an unparseable exo__Ontology_url, counted as unparseable-url", async () => {
+    writeOntology(emsDir(), "u6", "not-a-url");
+    const r = await scanVaultForOntologyUrl(vault);
+    expect(r.checked).toBe(0);
+    expect(r.skips["unparseable-url"]).toBe(1);
+    expect(r.violations).toHaveLength(0);
+  });
+
+  it("ignores assets with no exo__Ontology_url (not counted)", async () => {
+    writeOntology(emsDir(), "u7"); // no url
+    const r = await scanVaultForOntologyUrl(vault);
+    expect(r.ontologiesFound).toBe(0);
+    expect(r.checked).toBe(0);
+    expect(r.violations).toHaveLength(0);
+  });
+
+  it("counts multiple violations across folders", async () => {
+    writeOntology(emsDir(), "m1", "https://exocortex.my/ontology/ems");
+    writeOntology(
+      join(vault, "assetspaces", "kitelev", "exoas-public", "concept"),
+      "m2",
+      "https://exocortex.my/ontology/concept",
+    );
+    writeOntology(
+      join(vault, "assetspaces", "kitelev", "exoas-public", "pn"),
+      "ok",
+      "https://exocortex.my/ontology/pn#",
+    );
+    const r = await scanVaultForOntologyUrl(vault);
+    expect(r.ontologiesFound).toBe(3);
+    expect(r.checked).toBe(3);
+    expect(r.violations).toHaveLength(2);
+  });
+
+  it("does not scan node_modules", async () => {
+    writeOntology(
+      join(vault, "node_modules", "pkg"),
+      "nm1",
+      "https://exocortex.my/ontology/ems",
+    );
+    const r = await scanVaultForOntologyUrl(vault);
+    expect(r.ontologiesFound).toBe(0);
+    expect(r.violations).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
Closes #3824. **SDD req-first** (RFC 0003): `df6c979e-d432-4ce8-b652-aff31cba151c` (Approved → Active on merge).

`Req: df6c979e-d432-4ce8-b652-aff31cba151c`

## What

New CLI regression-detector `exocortex audit ontology-url --vault <path>` (a subcommand under the `audit` parent, mirroring `audit co-location` / `audit ontology-imports`). It walks the vault and flags every asset whose `exo__Ontology_url` is an **exocortex.my** namespace URL **without a trailing `#`** separator.

**Why it matters:** term-IRI = `Ontology_url + localName`, so a hash-less `https://exocortex.my/ontology/ems` concatenates to `emsTask` (instead of `ems#Task`) and a hash-less SPARQL `PREFIX` expands `ems:Task` wrongly → 0 rows silently. On 2026-07-04 ~60 of ~80 exocortex.my ontologies had drifted hash-less and were normalized by hand across 3 vaults. This gate stops the recurrence (copy-from-neighbour re-drift).

## Behaviour (all 5 BDD-AC of #3824)

- **AC1** — exocortex.my URL without `#` → **violation** naming the file, current URL, and expected canonical form (`<url>#`); exit 1.
- **AC2** — foreign vocabulary (host ≠ `exocortex.my`, e.g. `www.w3.org`) → **SKIPPED** (fail-open, counted `foreign-vocab`), never a violation — the author defines the form.
- **AC3** — hierarchical-path sub-ontology (`.../kitelev-period/quarters#`) → **passes** (path hierarchy preserved; only trailing `#` required).
- **AC4** — all-normalized vault → **zero violations + exit 0** (foreign skips never affect the exit code).
- **AC5 (revert-verify)** — the integration test physically removes the `#` from a real fixture ontology → RED (1 violation), restores it → GREEN (0). Plus the SDD production revert (below).

Discriminator = **presence of a non-empty `exo__Ontology_url`** (form-agnostic to the `exo__Instance_class` UID-vs-label representation). Unparseable URLs → skip `unparseable-url`. `--output text|json`. Skip-accounting always printed.

## Verification

- **Revert-verified** `@req:df6c979e-d432-4ce8-b652-aff31cba151c`: neutralizing the production check (`!url.endsWith("#")` → `!url.endsWith("")`, type-preserving) turns the `@req` + AC1 + json assertions **RED (3 failed)**; restored → **20/20 GREEN**.
- Production-shape integration test builds a temp vault of **real ontology `.md` files** and runs the real `scanVaultForOntologyUrl` + `auditOntologyUrlCommand` action end-to-end (no hand-injected triples).
- typecheck 0 errors; 3 `lint`-job guard scripts green (check-test-antipatterns 55/55, validate-shard, coverage-monotonic); 65 audit-cluster tests green (siblings intact).

## Dogfood finding (out of THIS PR's scope — follow-up)

Running the new audit on the live vaults caught **genuine re-drift** the gate is designed to prevent — 2 shared-repo ontologies missing the trailing `#`:
- `assetspaces/kitelev/exoas-shared-private/shared-private-notes/9692ac37-…` → `https://exocortex.my/ontology/shared-private-notes` (all 3 vaults)
- `assetspaces/kitelev/exoas-shared-private/shared-private-assets/to-tbank/617d340c-…` → `https://exocortex.my/ontology/shared-private-assets/to-tbank` (vault-my + vault-tbank; the one previously seen in ExoSync quarantine #3835)

These are **data** (not audit tooling = this PR's scope) in a shared submodule — normalizing them is a separate follow-up (filed after merge). This PR does **not** wire the audit into CI, so those violations don't affect this PR's CI.

## Scope

CLI-only: new `packages/cli/src/commands/audit-ontology-url.ts` + one `addCommand` line in `audit.ts` + unit & integration tests. No engine/parser/TBox/schema code touched.
