### PR TITLE
feat(#3777): exo-layout action buttons execute via structural exocmd commands (#3654 Part 2)

### DIFF
--- a/packages/obsidian-plugin/src/application/processors/LayoutCodeBlockProcessor.ts
+++ b/packages/obsidian-plugin/src/application/processors/LayoutCodeBlockProcessor.ts
@@ -28,8 +28,19 @@ import { TableLayoutRenderer } from "@plugin/presentation/renderers/TableLayoutR
 import { WikilinkLabelResolver } from "@plugin/presentation/utils/WikilinkLabelResolver";
 import { DisplayNameResolver } from "@plugin/domain/display-name/DisplayNameResolver";
 import { DEFAULT_DISPLAY_NAME_SETTINGS } from "@plugin/domain/settings/ExocortexSettings";
-import type { TableLayout } from "@plugin/domain/layout";
+import type { TableLayout, CommandRef } from "@plugin/domain/layout";
 import { isTableLayout } from "@plugin/domain/layout";
+// #3654 Part 2 (#3777) — layout action buttons execute through the EXISTING
+// structural exocmd command pipeline (CommandExecutionFlow → GroundingExecutor),
+// the same path the structural inline command buttons use — NOT a parallel
+// raw-SPARQL-UPDATE engine (rejected in #3777).
+import {
+  CommandExecutionFlow,
+  createTripleStoreRequiredPropertyResolver,
+} from "@kitelev/exocortex-core";
+import type { ResolvedCommand, EvalContext } from "@kitelev/exocortex-core";
+import { ObsidianCommandPromptAdapter } from "@plugin/infrastructure/adapters/ObsidianCommandPromptAdapter";
+import { ObsidianFileOpener } from "@plugin/infrastructure/services/ObsidianFileOpener";
 
 /**
  * Tracks an active layout block for cleanup and refresh management.
@@ -43,6 +54,18 @@ interface ActiveLayout {
   refreshTimeout?: ReturnType<typeof setTimeout>;
   /** Timestamp when the layout was rendered (for TTL tracking) */
   startTime: number;
+}
+
+/**
+ * Identifies a rendered layout block so an executed action button can refresh
+ * it (#3654 Part 2 / #3777). The processor already has `refreshLayout(el,
+ * container, wikilink, sourcePath)`; this threads the three non-container args
+ * down to the action-button `onComplete` closure.
+ */
+interface LayoutRefreshContext {
+  el: HTMLElement;
+  wikilink: string;
+  sourcePath: string;
 }
 
 /**
@@ -100,6 +123,14 @@ export class LayoutCodeBlockProcessor {
   private readonly CLEANUP_INTERVAL_MS = 60 * 1000;
   private cleanupIntervalId: ReturnType<typeof setInterval> | null = null;
   private readonly logger = LoggerFactory.create("LayoutCodeBlockProcessor");
+
+  /**
+   * Lazily-built execution pipeline for structural exocmd layout actions
+   * (#3654 Part 2 / #3777). Built from the plugin's already-wired
+   * `GroundingExecutor` + `CommandResolver` + notifier the FIRST time an action
+   * button is clicked — the plugin services are not ready at construction time.
+   */
+  private commandExecutionFlow: CommandExecutionFlow | null = null;
 
   constructor(plugin: ExocortexPlugin) {
     this.plugin = plugin;
@@ -245,7 +276,11 @@ export class LayoutCodeBlockProcessor {
         return;
       }
 
-      this.renderLayoutResult(result, container);
+      this.renderLayoutResult(result, container, {
+        el,
+        wikilink,
+        sourcePath: ctx.sourcePath,
+      });
 
       // Track the active layout
       this.activeLayouts.set(el, {
@@ -342,7 +377,7 @@ export class LayoutCodeBlockProcessor {
       }
 
       container.innerHTML = "";
-      this.renderLayoutResult(result, container);
+      this.renderLayoutResult(result, container, { el, wikilink, sourcePath });
 
       // Reset TTL on successful refresh
       layout.startTime = Date.now();
@@ -358,7 +393,11 @@ export class LayoutCodeBlockProcessor {
    */
   private renderLayoutResult(
     result: LayoutRenderResult,
-    container: HTMLElement
+    container: HTMLElement,
+    // #3654 Part 2 (#3777) — identifies THIS layout block so an executed action
+    // button can refresh it (`onComplete`). Absent (e.g. some tests) → action
+    // execution still works; the post-run refresh is simply a no-op.
+    refreshCtx?: LayoutRefreshContext
   ): void {
     if (!result.layout || !result.rows) {
       this.showErrorState(container, "No layout data available", "");
@@ -367,7 +406,7 @@ export class LayoutCodeBlockProcessor {
 
     // Handle different layout types
     if (isTableLayout(result.layout)) {
-      this.renderTableLayout(result.layout, result.rows, container);
+      this.renderTableLayout(result.layout, result.rows, container, refreshCtx);
     } else {
       // Non-table layouts inside a code block are a documented limitation, not
       // an error — surface an informational notice instead of the red
@@ -382,8 +421,24 @@ export class LayoutCodeBlockProcessor {
   private renderTableLayout(
     layout: TableLayout,
     rows: import("@plugin/presentation/renderers/cell-renderers").TableRow[],
-    container: HTMLElement
+    container: HTMLElement,
+    // #3654 Part 2 (#3777) — identifies THIS block so an executed action button
+    // can refresh it. Absent → the post-run refresh is a no-op.
+    refreshCtx?: LayoutRefreshContext
   ): void {
+    // #3654 Part 2 (#3777) — refresh THIS layout block after a structural
+    // command executes (`CommandExecutionFlow` onComplete). No-op when the
+    // block's identity wasn't threaded down (some tests render directly).
+    const refresh = async (): Promise<void> => {
+      if (refreshCtx) {
+        await this.refreshLayout(
+          refreshCtx.el,
+          container,
+          refreshCtx.wikilink,
+          refreshCtx.sourcePath
+        );
+      }
+    };
     this.reactRenderer.render(
       container,
       React.createElement(TableLayoutRenderer, {
@@ -420,20 +475,24 @@ export class LayoutCodeBlockProcessor {
         getAssetLabel: (path: string) =>
           this.resolveHomoiconicDisplayName(path) ??
           this.wikilinkResolver.getAssetLabel(path),
-        // Gate action buttons by their `exo__Precondition_sparql` ASK (#3654
-        // Part 1): true ⇒ shown, false ⇒ hidden. Previously unwired → every
-        // button defaulted visible. The ASK boolean is surfaced via the new
-        // `SPARQLApi.ask` (the executor already computed it; `query()` discarded
-        // it). `$target` resolves to the row's REAL store subject IRI (threaded
-        // through `LayoutService` metadata), so the ASK matches the live asset.
-        onCheckPrecondition: (sparql: string, assetUri: string) =>
-          this.checkPrecondition(sparql, assetUri),
-        // NOTE: `onExecuteCommand` is intentionally NOT wired — the raw-SPARQL-
-        // UPDATE execution engine is #3654 Part 2 (deferred; the issue's own
-        // recommendation is to route layout actions through structural exocmd
-        // commands rather than build a parallel UPDATE engine). Until then a
-        // click on a precondition-passing button surfaces the #3628
-        // "no executor available" notice via onError below.
+        // Gate action buttons by precondition (#3654 Part 1 + Part 2, #3777):
+        // a structural exocmd command is gated by its own
+        // `exocmd__Command_precondition` via `PreconditionEvaluator` (unified
+        // with Part 1); a legacy raw command by its `exo__Precondition_sparql`
+        // ASK. true ⇒ shown, false ⇒ hidden. `$target`/`targetIRI` resolves to
+        // the row's REAL store subject IRI (threaded through `LayoutService`
+        // metadata), so the gate matches the live asset.
+        onCheckPrecondition: (cmd, assetUri, assetPath) =>
+          this.checkCommandPrecondition(cmd, assetUri, assetPath),
+        // #3654 Part 2 (#3777) — execute a structural exocmd layout action.
+        // Resolve the referenced structural command via `CommandResolver` and
+        // run it through the EXISTING `CommandExecutionFlow` → `GroundingExecutor`
+        // pipeline (the same path structural inline buttons use), targeting the
+        // row asset and refreshing THIS block on success. A raw-only /
+        // unresolvable command surfaces an honest notice (the raw-SPARQL-UPDATE
+        // engine was rejected in #3777), never a silent no-op (#3628).
+        onExecuteCommand: (cmd, assetUri, assetPath) =>
+          this.executeCommand(cmd, assetUri, assetPath, refresh),
         // Surface action-button failures to the user instead of failing silently
         // (#3628). Routed through the central notifier (eslint forbids `new
         // Notice` elsewhere).
@@ -532,6 +591,154 @@ export class LayoutCodeBlockProcessor {
     }
     const substituted = sparql.replace(/\$target/g, `<${assetUri}>`);
     return api.ask(substituted);
+  }
+
+  /**
+   * Command-oriented precondition gate for an `exo-layout` action button
+   * (#3654 Part 2 / #3777). Unifies the Part-1 raw ASK gate with the structural
+   * command's own precondition:
+   *
+   * - Structural command (`cmd.structural`) → resolve it via
+   *   {@link CommandResolver.loadCommand} and evaluate its
+   *   `exocmd__Command_precondition` through the SAME {@link PreconditionEvaluator}
+   *   the structural inline command buttons use. A structural command with no
+   *   precondition evaluates to `true` (shown). Unresolvable → keep visible; the
+   *   click handler surfaces the honest "no command" notice.
+   * - Legacy raw command with `cmd.preconditionSparql` → the Part-1
+   *   {@link checkPrecondition} SPARQL ASK gate (unchanged).
+   * - Neither → `true` (shown).
+   *
+   * Engine-not-ready (resolver / evaluator absent, e.g. cold start) → `true`
+   * (don't hide a button just because the graph is still warming up — matches
+   * the structural inline-button behaviour).
+   */
+  private async checkCommandPrecondition(
+    cmd: CommandRef,
+    assetUri: string,
+    assetPath?: string
+  ): Promise<boolean> {
+    if (cmd.structural) {
+      const resolver = this.plugin.commandResolver;
+      const evaluator = this.plugin.preconditionEvaluator;
+      if (!resolver || !evaluator) return true;
+      try {
+        const command = await resolver.loadCommand(cmd.uid);
+        if (!command) return true;
+        const evalContext: EvalContext = {
+          targetIRI: assetUri,
+          filePath: assetPath,
+          fileBasename: assetPath
+            ? (assetPath.split("/").pop() ?? undefined)
+            : undefined,
+          currentFolder: assetPath
+            ? assetPath.split("/").slice(0, -1).join("/") || undefined
+            : undefined,
+        };
+        return await evaluator.evaluate(
+          command.precondition,
+          assetUri,
+          evalContext
+        );
+      } catch {
+        // Conservative: hide on evaluation error (never a false-positive show),
+        // matching the raw-ASK gate's catch behaviour.
+        return false;
+      }
+    }
+    if (cmd.preconditionSparql) {
+      return this.checkPrecondition(cmd.preconditionSparql, assetUri);
+    }
+    return true;
+  }
+
+  /**
+   * Lazily build the structural-command execution pipeline (#3654 Part 2 /
+   * #3777) from the plugin's already-wired services. Returns `null` when the
+   * engine is not ready (no `GroundingExecutor` / `CommandResolver` yet).
+   *
+   * Mirrors the palette registrar's `CommandExecutionFlow` construction so
+   * layout action buttons and Command-Palette entries execute identically.
+   */
+  private getCommandExecutionFlow(): CommandExecutionFlow | null {
+    if (this.commandExecutionFlow) return this.commandExecutionFlow;
+    const groundingExecutor = this.plugin.groundingExecutor;
+    const commandResolver = this.plugin.commandResolver;
+    const notifier = this.plugin.notifier;
+    if (!groundingExecutor || !commandResolver || !notifier) return null;
+    const tripleStore = this.plugin.sparql?.getTripleStore?.();
+    this.commandExecutionFlow = new CommandExecutionFlow(
+      groundingExecutor,
+      notifier,
+      this.logger,
+      new ObsidianCommandPromptAdapter(this.plugin.app),
+      tripleStore,
+      new ObsidianFileOpener(this.plugin.app),
+      tripleStore
+        ? createTripleStoreRequiredPropertyResolver(tripleStore)
+        : undefined
+    );
+    return this.commandExecutionFlow;
+  }
+
+  /**
+   * Execute an `exo-layout` action button (#3654 Part 2 / #3777).
+   *
+   * Resolves the referenced STRUCTURAL exocmd command via
+   * {@link CommandResolver.loadCommand} and runs it through the EXISTING
+   * {@link CommandExecutionFlow} — the same pipeline the structural inline
+   * command buttons use — with the layout context: `targetIRI` = the row's real
+   * store subject IRI, `filePath` = the row's asset path, `onComplete` =
+   * refresh THIS layout block. `CommandExecutionFlow` handles confirm / input
+   * schema / grounding execution / success + error notices.
+   *
+   * A raw-only or unresolvable command (no structural typed grounding →
+   * `loadCommand` returns `null`) surfaces an honest notice instead of a silent
+   * no-op (#3628): the parallel raw-SPARQL-UPDATE engine was rejected in #3777,
+   * so a layout action must reference a structural exocmd command.
+   */
+  private async executeCommand(
+    cmd: CommandRef,
+    assetUri: string,
+    assetPath: string | undefined,
+    refresh: () => Promise<void>
+  ): Promise<void> {
+    const resolver = this.plugin.commandResolver;
+    const flow = this.getCommandExecutionFlow();
+    if (!resolver || !flow) {
+      this.plugin.notifier?.error(
+        `Cannot run "${cmd.label}": the command engine is not ready yet — try again once indexing completes.`
+      );
+      return;
+    }
+
+    const command = await resolver.loadCommand(cmd.uid);
+    if (!command) {
+      this.plugin.notifier?.error(
+        `Cannot run "${cmd.label}": no structural exocmd command was found for this layout action. ` +
+          `Layout actions must reference a structural exocmd command (with exocmd__Command_grounding); ` +
+          `the raw-SPARQL-UPDATE execution path is not supported.`
+      );
+      return;
+    }
+
+    const rc: ResolvedCommand = {
+      command,
+      // `CommandExecutionFlow.run` reads only `rc.command`; a minimal synthetic
+      // binding satisfies the type. Layout-action button metadata (label,
+      // position) lives in the LayoutActions asset, not a CommandBinding — so
+      // no real binding exists to resolve here (unlike inline command buttons).
+      binding: {
+        id: `layout-action-${cmd.uid}`,
+        label: cmd.label,
+        commandRef: cmd.uid,
+      },
+    };
+
+    await flow.run(rc, {
+      targetIRI: assetUri,
+      filePath: assetPath ?? null,
+      onComplete: refresh,
+    });
   }
 
   /**

--- a/packages/obsidian-plugin/src/domain/layout/LayoutActions.ts
+++ b/packages/obsidian-plugin/src/domain/layout/LayoutActions.ts
@@ -48,6 +48,25 @@ export interface CommandRef {
    * Uses $target for the asset URI and $now for current timestamp.
    */
   groundingSparql?: string;
+
+  /**
+   * True when the referenced command is a STRUCTURAL exocmd command — it
+   * declares `exocmd__Command_grounding` (a typed grounding resolvable by
+   * `CommandResolver.loadCommand`) and therefore executes through the existing
+   * `CommandExecutionFlow` → `GroundingExecutor` pipeline (#3654 Part 2 /
+   * #3777). A command WITHOUT this flag is the legacy raw-SPARQL model
+   * (`exo__Command_grounding` → raw `exo__Grounding_sparql`), which has no
+   * execution engine — the parallel raw-SPARQL-UPDATE engine was explicitly
+   * rejected in #3777 as duplicating `GroundingExecutor` semantics.
+   *
+   * Drives two behaviours: (1) a structural command's visibility is gated by
+   * its own `exocmd__Command_precondition` via `PreconditionEvaluator` (the
+   * same path the structural inline buttons use), unified with the Part-1 raw
+   * `exo__Precondition_sparql` ASK gate; (2) clicking a structural command
+   * resolves + runs it through `CommandExecutionFlow`, whereas a raw-only
+   * command surfaces an honest "no structural command" notice (#3628-aligned).
+   */
+  structural?: boolean;
 }
 
 /**

--- a/packages/obsidian-plugin/src/infrastructure/layout/LayoutParser.ts
+++ b/packages/obsidian-plugin/src/infrastructure/layout/LayoutParser.ts
@@ -698,12 +698,23 @@ export class LayoutParser {
       groundingSparql = await this.loadGroundingSparql(groundingLink, options);
     }
 
+    // #3654 Part 2 (#3777) — a command is STRUCTURAL when it declares
+    // `exocmd__Command_grounding` (a typed grounding resolvable by
+    // `CommandResolver.loadCommand`). Structural commands execute through the
+    // existing `CommandExecutionFlow` → `GroundingExecutor` pipeline and are
+    // precondition-gated by their own `exocmd__Command_precondition`. The
+    // legacy raw-SPARQL model (`exo__Command_grounding` above) has no execution
+    // engine (raw-SPARQL-UPDATE rejected in #3777). We only detect presence
+    // here — the processor resolves + runs it via the plugin's CommandResolver.
+    const structural = frontmatter["exocmd__Command_grounding"] !== undefined;
+
     return {
       uid: partial.uid,
       label: partial.label,
       icon: partial.icon,
       preconditionSparql,
       groundingSparql,
+      structural,
     };
   }
 

--- a/packages/obsidian-plugin/src/presentation/renderers/TableLayoutRenderer.tsx
+++ b/packages/obsidian-plugin/src/presentation/renderers/TableLayoutRenderer.tsx
@@ -14,7 +14,7 @@
 import React, { useState, useMemo, useCallback, useRef } from "react";
 import { useVirtualizer } from "@tanstack/react-virtual";
 
-import type { TableLayout, LayoutColumn } from "../../domain/layout";
+import type { TableLayout, LayoutColumn, CommandRef } from "../../domain/layout";
 import { getDefaultColumnHeader } from "../../domain/layout";
 import type {
   TableRow,
@@ -67,21 +67,33 @@ export interface TableLayoutRendererProps {
   className?: string;
 
   /**
-   * Callback to check if a command precondition is satisfied.
-   * Used for action buttons visibility.
-   * @param sparql - The SPARQL ASK query with $target placeholder
-   * @param assetUri - The URI to substitute for $target
-   * @returns true if the command should be visible/enabled
+   * Callback to check if a command's precondition is satisfied for a row.
+   * Used for action buttons visibility (command-oriented, #3654 Part 2).
+   * @param cmd - The command reference (uid, structural flag, raw sparql)
+   * @param assetUri - The row asset's real store subject IRI
+   * @param assetPath - The row asset's vault path
+   * @returns true if the command should be visible
    */
-  onCheckPrecondition?: (sparql: string, assetUri: string) => Promise<boolean>;
+  onCheckPrecondition?: (
+    cmd: CommandRef,
+    assetUri: string,
+    assetPath?: string,
+  ) => Promise<boolean>;
 
   /**
-   * Callback to execute a command grounding.
-   * Used when action buttons are clicked.
-   * @param sparql - The SPARQL UPDATE query with $target and $now placeholders
-   * @param assetUri - The URI to substitute for $target
+   * Callback to execute a command when an action button is clicked
+   * (command-oriented, #3654 Part 2). A structural exocmd command is resolved
+   * and run through `CommandExecutionFlow`; a raw-only command surfaces a
+   * notice (raw-SPARQL-UPDATE engine rejected in #3777).
+   * @param cmd - The command reference (uid, structural flag, raw sparql)
+   * @param assetUri - The row asset's real store subject IRI (targetIRI)
+   * @param assetPath - The row asset's vault path (filePath)
    */
-  onExecuteCommand?: (sparql: string, assetUri: string) => Promise<void>;
+  onExecuteCommand?: (
+    cmd: CommandRef,
+    assetUri: string,
+    assetPath?: string,
+  ) => Promise<void>;
 
   /**
    * Optional function to resolve asset labels for wikilinks without aliases.

--- a/packages/obsidian-plugin/src/presentation/renderers/cell-renderers/ActionsRenderer.tsx
+++ b/packages/obsidian-plugin/src/presentation/renderers/cell-renderers/ActionsRenderer.tsx
@@ -72,6 +72,27 @@ function getIcon(iconName?: string): string {
 }
 
 /**
+ * A command has a precondition to evaluate when it either carries a raw
+ * `preconditionSparql` (Part 1) OR is a structural exocmd command (Part 2 —
+ * its `exocmd__Command_precondition`, if any, is evaluated by the host; a
+ * structural command with no precondition resolves to visible). Commands with
+ * neither are shown by default without a check.
+ */
+function hasPrecondition(cmd: CommandRef): boolean {
+  return !!cmd.preconditionSparql || !!cmd.structural;
+}
+
+/**
+ * A command is executable when it either carries a raw `groundingSparql`
+ * (legacy model — surfaced by the host as an honest "no engine" notice) OR is
+ * a structural exocmd command (Part 2 — routed through `CommandExecutionFlow`).
+ * A command with neither is "no action configured".
+ */
+function hasExecutor(cmd: CommandRef): boolean {
+  return !!cmd.groundingSparql || !!cmd.structural;
+}
+
+/**
  * Props for ActionsRenderer component
  */
 export interface ActionsRendererProps {
@@ -91,19 +112,40 @@ export interface ActionsRendererProps {
   assetPath?: string;
 
   /**
-   * Callback to check if a command precondition is satisfied.
-   * Returns true if the command should be visible/enabled.
-   * @param sparql - The SPARQL ASK query with $target placeholder
-   * @param assetUri - The URI to substitute for $target
+   * Callback to check if a command's precondition is satisfied for this row.
+   * Returns true if the command button should be visible.
+   *
+   * Command-oriented (#3654 Part 2): the host decides HOW to gate — a structural
+   * exocmd command (`cmd.structural`) is gated by its own
+   * `exocmd__Command_precondition` via `PreconditionEvaluator`; a legacy raw
+   * command with `cmd.preconditionSparql` is gated by that SPARQL ASK (Part 1).
+   * @param cmd - The command reference (carries uid, structural flag, raw sparql)
+   * @param assetUri - The row asset's real store subject IRI (substitutes $target)
+   * @param assetPath - The row asset's vault path (for structural eval context)
    */
-  onCheckPrecondition?: (sparql: string, assetUri: string) => Promise<boolean>;
+  onCheckPrecondition?: (
+    cmd: CommandRef,
+    assetUri: string,
+    assetPath?: string,
+  ) => Promise<boolean>;
 
   /**
-   * Callback to execute a command grounding.
-   * @param sparql - The SPARQL UPDATE query with $target and $now placeholders
-   * @param assetUri - The URI to substitute for $target
+   * Callback to execute a command when its button is clicked.
+   *
+   * Command-oriented (#3654 Part 2): a structural exocmd command
+   * (`cmd.structural`) is resolved via `CommandResolver.loadCommand` and run
+   * through the existing `CommandExecutionFlow` → `GroundingExecutor` pipeline;
+   * a raw-only command has no execution engine (raw-SPARQL-UPDATE rejected in
+   * #3777) and the host surfaces an honest notice.
+   * @param cmd - The command reference (carries uid, structural flag, raw sparql)
+   * @param assetUri - The row asset's real store subject IRI (targetIRI)
+   * @param assetPath - The row asset's vault path (filePath)
    */
-  onExecuteCommand?: (sparql: string, assetUri: string) => Promise<void>;
+  onExecuteCommand?: (
+    cmd: CommandRef,
+    assetUri: string,
+    assetPath?: string,
+  ) => Promise<void>;
 
   /**
    * Whether buttons are disabled (e.g., during execution)
@@ -155,8 +197,8 @@ export const ActionsRenderer: React.FC<ActionsRendererProps> = ({
     const initial: Record<string, CommandState> = {};
     for (const cmd of commands) {
       initial[cmd.uid] = {
-        visible: !cmd.preconditionSparql, // Visible by default if no precondition
-        loading: !!cmd.preconditionSparql, // Loading if has precondition
+        visible: !hasPrecondition(cmd), // Visible by default if no precondition
+        loading: hasPrecondition(cmd), // Loading if a precondition must be checked
         executing: false,
       };
     }
@@ -180,7 +222,7 @@ export const ActionsRenderer: React.FC<ActionsRendererProps> = ({
 
       // Check each command's precondition
       for (const cmd of commands) {
-        if (!cmd.preconditionSparql) {
+        if (!hasPrecondition(cmd)) {
           setCommandStates((prev) => ({
             ...prev,
             [cmd.uid]: { ...prev[cmd.uid], visible: true, loading: false },
@@ -189,7 +231,7 @@ export const ActionsRenderer: React.FC<ActionsRendererProps> = ({
         }
 
         try {
-          const result = await onCheckPrecondition(cmd.preconditionSparql, assetUri);
+          const result = await onCheckPrecondition(cmd, assetUri, assetPath);
           setCommandStates((prev) => ({
             ...prev,
             [cmd.uid]: { ...prev[cmd.uid], visible: result, loading: false },
@@ -206,7 +248,7 @@ export const ActionsRenderer: React.FC<ActionsRendererProps> = ({
     };
 
     checkPreconditions();
-  }, [assetUri, commands, onCheckPrecondition]);
+  }, [assetUri, assetPath, commands, onCheckPrecondition]);
 
   // Handle button click
   const handleClick = useCallback(
@@ -215,9 +257,11 @@ export const ActionsRenderer: React.FC<ActionsRendererProps> = ({
       event.stopPropagation();
 
       // Surface why a click had no effect instead of silently bailing (#3628):
-      // a command with no grounding, or no executor wired by the host, used to
-      // log to the console and no-op — indistinguishable from a broken button.
-      if (!cmd.groundingSparql) {
+      // a command with no executor (neither a structural exocmd command nor a
+      // legacy raw grounding), or no executor callback wired by the host, used
+      // to log to the console and no-op — indistinguishable from a broken
+      // button.
+      if (!hasExecutor(cmd)) {
         const message = `No action is configured for "${cmd.label}".`;
         console.warn(message);
         onError?.(message);
@@ -237,14 +281,14 @@ export const ActionsRenderer: React.FC<ActionsRendererProps> = ({
       }));
 
       try {
-        await onExecuteCommand(cmd.groundingSparql, assetUri);
+        await onExecuteCommand(cmd, assetUri, assetPath);
 
         // After execution, re-check all preconditions (state may have changed)
         if (onCheckPrecondition) {
           for (const c of commands) {
-            if (!c.preconditionSparql) continue;
+            if (!hasPrecondition(c)) continue;
             try {
-              const result = await onCheckPrecondition(c.preconditionSparql, assetUri);
+              const result = await onCheckPrecondition(c, assetUri, assetPath);
               setCommandStates((prev) => ({
                 ...prev,
                 [c.uid]: { ...prev[c.uid], visible: result },
@@ -265,7 +309,7 @@ export const ActionsRenderer: React.FC<ActionsRendererProps> = ({
         }));
       }
     },
-    [assetUri, commands, onCheckPrecondition, onExecuteCommand, onError],
+    [assetUri, assetPath, commands, onCheckPrecondition, onExecuteCommand, onError],
   );
 
   // Render a single button

--- a/packages/obsidian-plugin/tests/unit/application/processors/LayoutActionExecution.integration.test.ts
+++ b/packages/obsidian-plugin/tests/unit/application/processors/LayoutActionExecution.integration.test.ts
@@ -1,0 +1,347 @@
+/**
+ * exo-layout action button EXECUTION via structural exocmd commands — INTEGRATION
+ * (#3654 Part 2 / #3777).
+ *
+ * Real engine end-to-end: a realistic in-memory Obsidian `App` (vault +
+ * metadataCache holding actual markdown frontmatter) is parsed by the REAL
+ * `SPARQLApi` (REAL `NoteToRDFConverter` → `InMemoryTripleStore`), then a REAL
+ * `CommandResolver`, a REAL `PreconditionEvaluator`, and a REAL
+ * `CommandExecutionFlow` drive the REAL
+ * `LayoutCodeBlockProcessor.executeCommand` / `.checkCommandPrecondition`. Only
+ * the LEAF `GroundingExecutor.execute` is mocked at the boundary — the
+ * established seam from `DynamicCommandButtonGroupBuilder.test.ts`;
+ * `GroundingExecutor` is exhaustively tested elsewhere and is unchanged by this
+ * feature. The command is resolved from the store by its ACTUAL structural
+ * grounding, not a synthetic shape (test-fixture-realism).
+ *
+ * Binds req 28731c06-b393-419b-b8ee-453ca6225b17.
+ */
+import { TFile } from "obsidian";
+import type { App } from "obsidian";
+import {
+  CommandResolver,
+  PreconditionEvaluator,
+  GroundingType,
+} from "@kitelev/exocortex-core";
+import { SPARQLApi } from "../../../../src/application/api/SPARQLApi";
+import { LayoutCodeBlockProcessor } from "../../../../src/application/processors/LayoutCodeBlockProcessor";
+import type { CommandRef } from "../../../../src/domain/layout";
+import type ExocortexPlugin from "../../../../src/ExocortexPlugin";
+
+const EXO = "https://exocortex.my/ontology/exo#";
+const REQ = "@req:28731c06-b393-419b-b8ee-453ca6225b17";
+
+// Real GroundingType catalog UID (packages/core/src/domain/constants/GroundingTypeUIDs.ts).
+const GT_PROPERTY_SET = "cf3bb923-f1f1-40be-b728-782844402426";
+
+const CMD_STRUCT = "aaaa0001-0000-0000-0000-000000000001";
+const GROUNDING = "aaaa0001-0000-0000-0000-000000000002";
+const CMD_GATED_TRUE = "aaaa0002-0000-0000-0000-000000000001";
+const CMD_GATED_FALSE = "aaaa0003-0000-0000-0000-000000000001";
+const PRECOND_TRUE = "aaaa0002-0000-0000-0000-000000000002";
+const PRECOND_FALSE = "aaaa0003-0000-0000-0000-000000000002";
+const CMD_RAW = "aaaa0004-0000-0000-0000-000000000001";
+
+interface SeedFile {
+  path: string;
+  frontmatter: Record<string, unknown>;
+}
+
+function buildApp(seed: SeedFile[]): App {
+  const files: TFile[] = [];
+  const fmByPath = new Map<string, Record<string, unknown>>();
+  const contentByPath = new Map<string, string>();
+  const renderYaml = (fm: Record<string, unknown>): string =>
+    "---\n" +
+    Object.entries(fm)
+      .map(([k, v]) => `${k}: ${JSON.stringify(v)}`)
+      .join("\n") +
+    "\n---\n";
+  for (const f of seed) {
+    const tfile = new TFile(f.path);
+    files.push(tfile);
+    fmByPath.set(f.path, f.frontmatter);
+    contentByPath.set(f.path, renderYaml(f.frontmatter));
+  }
+  const vault = {
+    getMarkdownFiles: () => files.filter((f) => f.extension === "md"),
+    getAbstractFileByPath: (p: string) =>
+      files.find((f) => f.path === p) ?? null,
+    read: async (f: TFile) => contentByPath.get(f.path) ?? "",
+    on: () => ({}) as unknown,
+    off: () => {},
+    offref: () => {},
+  };
+  const metadataCache = {
+    getFileCache: (f: TFile) => {
+      const fm = fmByPath.get(f.path);
+      return fm ? { frontmatter: fm } : null;
+    },
+    getFirstLinkpathDest: (linkpath: string) => {
+      const base = linkpath.replace(/\.md$/, "");
+      return files.find((f) => f.basename === base) ?? null;
+    },
+    resolvedLinks: {},
+  };
+  return { vault, metadataCache } as unknown as App;
+}
+
+// A real asset whose vault path contains slashes (dual-IRI: encodeURI keeps `/`).
+const TASK_ALPHA: SeedFile = {
+  path: "assetspaces/ems/task-alpha.md",
+  frontmatter: {
+    exo__Asset_uid: "task-alpha-uid",
+    exo__Asset_label: "Alpha Task",
+    exo__Instance_class: ["[[ems__Task]]"],
+  },
+};
+
+// A structural property_set grounding — a real typed grounding resolvable by
+// CommandResolver.loadCommand (same shape as apply-mutation-parity fixtures).
+// UID-canon filename (`<uid>.md` at root): the `exocmd__Command_grounding`
+// wikilink `[[<uid>]]` emits the file-form IRI `obsidian://vault/<uid>.md`, which
+// must equal this asset's own subject IRI for the resolver to follow the link
+// (matches apply-mutation-parity's flat UID-named temp-vault fixtures).
+const SET_STATUS_GROUNDING: SeedFile = {
+  path: `${GROUNDING}.md`,
+  frontmatter: {
+    exo__Asset_uid: GROUNDING,
+    exo__Asset_label: "Set status grounding",
+    exo__Instance_class: ["[[exocmd__Grounding]]"],
+    exocmd__Grounding_type: `[[${GT_PROPERTY_SET}]]`,
+    exocmd__Grounding_targetProperty: "ems__Effort_status",
+    exocmd__Grounding_targetValueLiteral: "done",
+  },
+};
+
+// STRUCTURAL command (has exocmd__Command_grounding → typed grounding).
+const SET_STATUS_CMD: SeedFile = {
+  path: "assetspaces/exocmd/set-status-cmd.md",
+  frontmatter: {
+    exo__Asset_uid: CMD_STRUCT,
+    exo__Asset_label: "Set Status Done",
+    exo__Instance_class: ["[[exocmd__Command]]"],
+    exocmd__Command_grounding: `[[${GROUNDING}|g]]`,
+    exocmd__Command_successMessage: "Status set to done",
+  },
+};
+
+// Structural precondition ASK that HOLDS for every asset (has a label).
+const PRECOND_TRUE_FILE: SeedFile = {
+  path: `${PRECOND_TRUE}.md`,
+  frontmatter: {
+    exo__Asset_uid: PRECOND_TRUE,
+    exo__Asset_label: "Has a label",
+    exo__Instance_class: ["[[exocmd__Precondition]]"],
+    exocmd__Precondition_sparqlAsk: `PREFIX exo: <${EXO}> ASK { $target exo:Asset_label ?l }`,
+  },
+};
+
+// Structural precondition ASK that does NOT hold (no such predicate).
+const PRECOND_FALSE_FILE: SeedFile = {
+  path: `${PRECOND_FALSE}.md`,
+  frontmatter: {
+    exo__Asset_uid: PRECOND_FALSE,
+    exo__Asset_label: "Never",
+    exo__Instance_class: ["[[exocmd__Precondition]]"],
+    exocmd__Precondition_sparqlAsk: `PREFIX exo: <${EXO}> ASK { $target exo:DefinitelyNotAPredicate ?l }`,
+  },
+};
+
+const CMD_GATED_TRUE_FILE: SeedFile = {
+  path: "assetspaces/exocmd/cmd-gated-true.md",
+  frontmatter: {
+    exo__Asset_uid: CMD_GATED_TRUE,
+    exo__Asset_label: "Gated (true)",
+    exo__Instance_class: ["[[exocmd__Command]]"],
+    exocmd__Command_grounding: `[[${GROUNDING}|g]]`,
+    exocmd__Command_precondition: `[[${PRECOND_TRUE}|p]]`,
+  },
+};
+
+const CMD_GATED_FALSE_FILE: SeedFile = {
+  path: "assetspaces/exocmd/cmd-gated-false.md",
+  frontmatter: {
+    exo__Asset_uid: CMD_GATED_FALSE,
+    exo__Asset_label: "Gated (false)",
+    exo__Instance_class: ["[[exocmd__Command]]"],
+    exocmd__Command_grounding: `[[${GROUNDING}|g]]`,
+    exocmd__Command_precondition: `[[${PRECOND_FALSE}|p]]`,
+  },
+};
+
+// A legacy RAW-only command (exo__Command_grounding, NOT exocmd__Command_grounding):
+// CommandResolver.loadCommand returns null (no typed grounding) → the raw-SPARQL
+// execution path was rejected in #3777 → the processor surfaces an honest notice.
+const CMD_RAW_FILE: SeedFile = {
+  path: "assetspaces/exocmd/cmd-raw.md",
+  frontmatter: {
+    exo__Asset_uid: CMD_RAW,
+    exo__Asset_label: "Raw Command",
+    exo__Instance_class: ["[[exocmd__Command]]"],
+    exo__Command_grounding: "[[raw-grounding]]",
+  },
+};
+
+interface ExecGate {
+  executeCommand(
+    cmd: CommandRef,
+    assetUri: string,
+    assetPath: string | undefined,
+    refresh: () => Promise<void>,
+  ): Promise<void>;
+  checkCommandPrecondition(
+    cmd: CommandRef,
+    assetUri: string,
+    assetPath?: string,
+  ): Promise<boolean>;
+}
+
+describe(`LayoutCodeBlockProcessor — action button execution via structural exocmd commands [${REQ}]`, () => {
+  let api: SPARQLApi;
+  let processor: LayoutCodeBlockProcessor;
+  let assetIri: string;
+  let mockExecute: jest.Mock;
+  let notifier: { error: jest.Mock; info: jest.Mock; success: jest.Mock };
+
+  beforeEach(async () => {
+    const app = buildApp([
+      TASK_ALPHA,
+      SET_STATUS_GROUNDING,
+      SET_STATUS_CMD,
+      PRECOND_TRUE_FILE,
+      PRECOND_FALSE_FILE,
+      CMD_GATED_TRUE_FILE,
+      CMD_GATED_FALSE_FILE,
+      CMD_RAW_FILE,
+    ]);
+    const apiPlugin = {
+      app,
+      settings: { excludedFolders: [] },
+    } as unknown as ExocortexPlugin;
+    api = new SPARQLApi(apiPlugin);
+
+    // Warm up + fetch the store's REAL subject IRI for the task (the value
+    // LayoutService threads into the row metadata, production-shape).
+    const res = await api.query(
+      `PREFIX exo: <${EXO}> SELECT ?s WHERE { ?s exo:Asset_label "Alpha Task" }`,
+    );
+    assetIri = String((res.bindings[0].get("s") as { value: unknown }).value);
+    expect(assetIri).toBe("obsidian://vault/assetspaces/ems/task-alpha.md");
+
+    const store = api.getTripleStore();
+    const logger = {
+      debug: () => {},
+      info: () => {},
+      warn: () => {},
+      error: () => {},
+    };
+    const commandResolver = new CommandResolver(store, logger);
+    const preconditionEvaluator = new PreconditionEvaluator(store);
+
+    mockExecute = jest.fn().mockResolvedValue({ success: true });
+    notifier = { error: jest.fn(), info: jest.fn(), success: jest.fn() };
+
+    const procPlugin = {
+      app,
+      getSPARQLApi: () => api,
+      sparql: api,
+      commandResolver,
+      preconditionEvaluator,
+      groundingExecutor: { execute: mockExecute },
+      notifier,
+    } as unknown as ExocortexPlugin;
+    processor = new LayoutCodeBlockProcessor(procPlugin);
+  });
+
+  afterEach(async () => {
+    processor.cleanup();
+    await api.dispose();
+  });
+
+  const exec = (
+    cmd: CommandRef,
+    refresh: () => Promise<void>,
+    path: string | undefined = "assetspaces/ems/task-alpha.md",
+  ): Promise<void> =>
+    (processor as unknown as ExecGate).executeCommand(
+      cmd,
+      assetIri,
+      path,
+      refresh,
+    );
+
+  const checkPre = (cmd: CommandRef): Promise<boolean> =>
+    (processor as unknown as ExecGate).checkCommandPrecondition(
+      cmd,
+      assetIri,
+      "assetspaces/ems/task-alpha.md",
+    );
+
+  it(`clicking a structural-command layout action resolves it and runs the typed grounding through CommandExecutionFlow, targeting the row asset [${REQ}]`, async () => {
+    const cmd: CommandRef = {
+      uid: CMD_STRUCT,
+      label: "Set Status Done",
+      structural: true,
+    };
+    const refresh = jest.fn().mockResolvedValue(undefined);
+
+    await exec(cmd, refresh);
+
+    // GroundingExecutor.execute (the leaf) was invoked with the RESOLVED typed
+    // grounding, the row's store subject IRI as targetIRI, and the row's path as
+    // filePath — i.e. the command really ran through CommandExecutionFlow.
+    expect(mockExecute).toHaveBeenCalledTimes(1);
+    const [grounding, targetIRI, filePath] = mockExecute.mock.calls[0];
+    expect((grounding as { type?: string }).type).toBe(
+      GroundingType.PROPERTY_SET,
+    );
+    expect(targetIRI).toBe(assetIri);
+    expect(filePath).toBe("assetspaces/ems/task-alpha.md");
+    // On success the layout block is refreshed (onComplete).
+    expect(refresh).toHaveBeenCalledTimes(1);
+    // No error notice on the happy path.
+    expect(notifier.error).not.toHaveBeenCalled();
+  });
+
+  it(`a raw-only / unresolvable command surfaces an honest notice and does NOT execute or refresh [${REQ}]`, async () => {
+    const cmd: CommandRef = { uid: CMD_RAW, label: "Raw Command" };
+    const refresh = jest.fn().mockResolvedValue(undefined);
+
+    await exec(cmd, refresh);
+
+    // No structural grounding → loadCommand returns null → honest notice, not a
+    // silent no-op (#3628); the raw-SPARQL-UPDATE engine was rejected (#3777).
+    expect(mockExecute).not.toHaveBeenCalled();
+    expect(refresh).not.toHaveBeenCalled();
+    expect(notifier.error).toHaveBeenCalledTimes(1);
+    expect(notifier.error.mock.calls[0][0]).toContain("Raw Command");
+  });
+
+  it(`a structural command whose precondition ASK holds is shown [${REQ}]`, async () => {
+    const cmd: CommandRef = {
+      uid: CMD_GATED_TRUE,
+      label: "Gated (true)",
+      structural: true,
+    };
+    await expect(checkPre(cmd)).resolves.toBe(true);
+  });
+
+  it(`a structural command whose precondition ASK does NOT hold is hidden [${REQ}]`, async () => {
+    const cmd: CommandRef = {
+      uid: CMD_GATED_FALSE,
+      label: "Gated (false)",
+      structural: true,
+    };
+    await expect(checkPre(cmd)).resolves.toBe(false);
+  });
+
+  it(`a structural command with NO precondition is shown (unified with Part 1) [${REQ}]`, async () => {
+    const cmd: CommandRef = {
+      uid: CMD_STRUCT,
+      label: "Set Status Done",
+      structural: true,
+    };
+    await expect(checkPre(cmd)).resolves.toBe(true);
+  });
+});

--- a/packages/obsidian-plugin/tests/unit/infrastructure/layout/LayoutParser.test.ts
+++ b/packages/obsidian-plugin/tests/unit/infrastructure/layout/LayoutParser.test.ts
@@ -308,6 +308,70 @@ describe("LayoutParser", () => {
       });
     });
 
+    describe("LayoutActions structural flag (#3654 Part 2 / #3777)", () => {
+      it("flags a command as structural when it declares exocmd__Command_grounding, and NOT when it only has the legacy raw exo__Command_grounding [@req:28731c06-b393-419b-b8ee-453ca6225b17]", async () => {
+        const files = new Map<string, IFrontmatter>([
+          [
+            "layouts/ActionTable.md",
+            {
+              exo__Asset_uid: "layout-act",
+              exo__Asset_label: "Action Table",
+              exo__Instance_class: ["[[exo__TableLayout]]"],
+              exo__Layout_targetClass: "[[ems__Task]]",
+              exo__Layout_actions: "[[layout-actions]]",
+            },
+          ],
+          [
+            "actions/layout-actions.md",
+            {
+              exo__Asset_uid: "actions-1",
+              exo__Asset_label: "Row Actions",
+              exo__Instance_class: ["[[exo__LayoutActions]]"],
+              exo__LayoutActions_commands: ["[[struct-cmd]]", "[[raw-cmd]]"],
+              exo__LayoutActions_position: "column",
+            },
+          ],
+          [
+            "commands/struct-cmd.md",
+            {
+              exo__Asset_uid: "struct-cmd-uid",
+              exo__Asset_label: "Structural Command",
+              exo__Instance_class: ["[[exocmd__Command]]"],
+              // Structural: a typed grounding resolvable by CommandResolver.
+              exocmd__Command_grounding: "[[some-typed-grounding]]",
+            },
+          ],
+          [
+            "commands/raw-cmd.md",
+            {
+              exo__Asset_uid: "raw-cmd-uid",
+              exo__Asset_label: "Raw Command",
+              exo__Instance_class: ["[[exocmd__Command]]"],
+              // Legacy raw-SPARQL model — NOT structural.
+              exo__Command_grounding: "[[some-raw-grounding]]",
+            },
+          ],
+        ]);
+        mockVaultAdapter = createMockVaultAdapter(files);
+        parser = new LayoutParser(mockVaultAdapter);
+
+        const result = await parser.parseFromFile(
+          createMockFile("layouts/ActionTable.md"),
+        );
+
+        expect(result.success).toBe(true);
+        const layout = result.layout as {
+          actions?: { commands: Array<{ uid: string; structural?: boolean }> };
+        };
+        const commands = layout.actions?.commands ?? [];
+        const struct = commands.find((c) => c.uid === "struct-cmd-uid");
+        const raw = commands.find((c) => c.uid === "raw-cmd-uid");
+
+        expect(struct?.structural).toBe(true);
+        expect(raw?.structural).toBeFalsy();
+      });
+    });
+
     describe("GraphLayout", () => {
       it("should parse GraphLayout with optional properties", async () => {
         const file = createMockFile("layouts/TaskGraph.md");

--- a/packages/obsidian-plugin/tests/unit/presentation/renderers/cell-renderers/ActionsRenderer.test.tsx
+++ b/packages/obsidian-plugin/tests/unit/presentation/renderers/cell-renderers/ActionsRenderer.test.tsx
@@ -113,9 +113,16 @@ describe("ActionsRenderer", () => {
       );
 
       await waitFor(() => {
+        // Command-oriented signature (#3654 Part 2): the callback receives the
+        // whole CommandRef + the row asset's IRI + path (the host decides how to
+        // gate — raw ASK here; structural PreconditionEvaluator for structural).
         expect(onCheckPrecondition).toHaveBeenCalledWith(
-          "ASK { ?s ?p ?o }",
-          defaultProps.assetUri
+          expect.objectContaining({
+            uid: "cmd-1",
+            preconditionSparql: "ASK { ?s ?p ?o }",
+          }),
+          defaultProps.assetUri,
+          defaultProps.assetPath
         );
       });
     });
@@ -216,9 +223,62 @@ describe("ActionsRenderer", () => {
       fireEvent.click(screen.getByRole("button"));
 
       await waitFor(() => {
+        // Command-oriented signature (#3654 Part 2): the host receives the whole
+        // CommandRef (to resolve a structural command) + the row IRI + path.
         expect(onExecuteCommand).toHaveBeenCalledWith(
-          groundingSparql,
-          defaultProps.assetUri
+          expect.objectContaining({ uid: "cmd-1", groundingSparql }),
+          defaultProps.assetUri,
+          defaultProps.assetPath
+        );
+      });
+    });
+
+    it("executes a STRUCTURAL command (no raw groundingSparql) and gates it by structural precondition [@req:28731c06-b393-419b-b8ee-453ca6225b17]", async () => {
+      // A structural exocmd command has NO raw preconditionSparql/groundingSparql
+      // — it is flagged `structural`. hasPrecondition/hasExecutor must be true via
+      // the flag so the host checks its structural precondition and routes the
+      // click through CommandExecutionFlow (#3654 Part 2 / #3777).
+      const onCheckPrecondition = jest.fn().mockResolvedValue(true);
+      const onExecuteCommand = jest.fn().mockResolvedValue(undefined);
+      const actions = createMockActions({
+        commands: [
+          {
+            uid: "cmd-structural",
+            label: "Set Status",
+            icon: "check-circle",
+            structural: true,
+          },
+        ],
+      });
+
+      render(
+        <ActionsRenderer
+          actions={actions}
+          {...defaultProps}
+          onCheckPrecondition={onCheckPrecondition}
+          onExecuteCommand={onExecuteCommand}
+        />
+      );
+
+      // The structural command's precondition IS checked (button visible on true).
+      await waitFor(() => {
+        expect(onCheckPrecondition).toHaveBeenCalledWith(
+          expect.objectContaining({ uid: "cmd-structural", structural: true }),
+          defaultProps.assetUri,
+          defaultProps.assetPath
+        );
+      });
+      await waitFor(() => {
+        expect(screen.getByRole("button")).toBeInTheDocument();
+      });
+
+      // Clicking routes the whole CommandRef to the executor (no groundingSparql).
+      fireEvent.click(screen.getByRole("button"));
+      await waitFor(() => {
+        expect(onExecuteCommand).toHaveBeenCalledWith(
+          expect.objectContaining({ uid: "cmd-structural", structural: true }),
+          defaultProps.assetUri,
+          defaultProps.assetPath
         );
       });
     });


### PR DESCRIPTION
Closes #3777 (exo-layout Part 2 — execution engine).

## What
Give `exo-layout` table **action buttons a real effect** by routing them through the **existing structural exocmd command pipeline** (`CommandExecutionFlow` → `GroundingExecutor`) — the same path the structural inline command buttons use — **NOT** a parallel raw-SPARQL-UPDATE engine (explicitly **rejected** in #3777 as duplicating `GroundingExecutor`).

Before: clicking a precondition-passing layout action button surfaced the #3628 "no executor available" notice (`onExecuteCommand` intentionally unwired). After: it resolves + runs the referenced structural command and refreshes the layout.

## How (3 parts from the issue's acceptance)
1. **Data-model** — `CommandRef` gains a `structural` flag; `LayoutParser` sets it when the referenced command asset declares `exocmd__Command_grounding` (a typed grounding resolvable by `CommandResolver.loadCommand`). Legacy raw fields (`exo__Command_grounding`/`exo__Precondition_sparql`) are still parsed for backward compat.
2. **Processor wiring** — `LayoutCodeBlockProcessor.executeCommand` resolves the structural command via `CommandResolver.loadCommand` and runs it through `CommandExecutionFlow.run` with the layout context: `targetIRI` = the row's real store subject IRI, `filePath` = the row's asset path, `onComplete` = refresh this layout block. A raw-only / unresolvable command surfaces an **honest notice** (#3628-aligned), never a silent no-op.
3. **Precondition unification** — `checkCommandPrecondition` gates a structural command by its own `exocmd__Command_precondition` via `PreconditionEvaluator` (the same evaluator the structural inline buttons use), unified with the Part-1 raw ASK gate.

The `ActionsRenderer`/`TableLayoutRenderer` callbacks are now **command-oriented** (pass the whole `CommandRef` + row IRI + path) so the host decides structural-vs-raw.

## Migration
A fresh **vault-wide SPARQL audit** (`exo:Grounding_sparql` / `exo:Precondition_sparql` / `exo:LayoutAction_command`) found **ZERO** existing raw-SPARQL LayoutActions across all three vaults → **nothing to migrate**; the backward-compatible raw parse path remains for safety.

## Tests (revert-verified)
- **NEW** `LayoutActionExecution.integration.test.ts` (production-shape): real `SPARQLApi`/`NoteToRDFConverter` store + real `CommandResolver` + real `PreconditionEvaluator` + real `CommandExecutionFlow`; only the leaf `GroundingExecutor.execute` is mocked at the boundary (the established seam from `DynamicCommandButtonGroupBuilder.test.ts`). Asserts execution routes through the flow targeting the row asset, layout refreshes on success, a raw/unresolvable command surfaces a notice, and structural preconditions gate visibility.
- **Revert-verified** ([[integration-test-revert-verify]]): neutralising the execution wiring reds the execution test (`GroundingExecutor.execute`/`onComplete` never called); neutralising the structural-precondition branch reds the false-precondition test. Both restored → GREEN.
- `LayoutParser.test.ts` + `ActionsRenderer.test.tsx` extended for the `structural` flag. Part-1 `LayoutActionPreconditionGating.integration.test.ts` unchanged and green. Regression sweep 729/729 (layout/renderers/processors/domain/builders).

## SDD
- Req **28731c06-b393-419b-b8ee-453ca6225b17** (exoas-exo-reqs), Approved. `@req` binding lands in this PR; flip → Active after merge.
- Homoiconicity-aligned: user-configurable command semantics stay in RDF (structural exocmd), reusing the existing execution infrastructure.

Req: 28731c06-b393-419b-b8ee-453ca6225b17

## Pixel-visual (deferred, ~1-min user-confirm)
Live click of a layout action button in Obsidian is deferred to a ~1-min user-confirm on a temp-vault (not mutating a live vault). The resolver-level behavior is proven by the production-shape integration test over the real engine.