### PR TITLE
fix(create-instance): resolve day-granularity date tokens at execute time (#3883)

### DIFF
--- a/packages/core/src/services/CommandResolver.ts
+++ b/packages/core/src/services/CommandResolver.ts
@@ -9,7 +9,6 @@ import { GroundingType } from "../domain/constants/GroundingType";
 import { resolveGroundingTypeFromIRI } from "../domain/constants/GroundingTypeUIDs";
 import { utf8ToBase64 } from "../utilities/base64";
 import { iriToObsidianName } from "../utilities/iriToObsidianName";
-import { DateFormatter } from "../utilities/DateFormatter";
 import {
   COMMAND_VARIANT_VALUES,
   LABEL_CLASS_VALUES,
@@ -121,11 +120,15 @@ const KNOWN_SUBSTITUTION_RESOLVER_IDS: ReadonlySet<string> = new Set([
 /**
  * Marker for execute-time SubstitutionToken resolvers — the executor
  * substitutes at runtime when the click target IRI / file path / userInput /
- * Grounding metadata are known, OR when the value must be fresh per execution
- * (`nowTimestamp` — second precision; `randomUUIDv4`), so it is NOT baked at
- * parse time. The DAY-granularity date resolvers (today, tomorrow, todayStart,
- * nowDate, nowYear, nowMonth) ARE resolved at parse time and never produce this
- * marker — see {@link PARSE_TIME_RESOLVERS}.
+ * Grounding metadata are known, OR simply because the value must be fresh per
+ * execution. As of bug 3883 EVERY known non-parameterised resolver emits this
+ * marker: there is no longer any parse-time baking. The last parse-time bake —
+ * the DAY-granularity date resolvers (`today`, `tomorrow`, `todayStart`,
+ * `nowDate`, `nowYear`, `nowMonth`) — froze the session's LAUNCH calendar day
+ * into cached `create_instance` defaults when a long-lived plugin session
+ * stayed open across local midnight (sibling of the `nowTimestamp` freeze,
+ * bug 33d362e5 / #3882). Every marker is resolved fresh per execution by the
+ * live registry ({@link SubstitutionResolverRegistry}), so nothing is frozen.
  *
  * Shape: `__SUBSTITUTE__<resolver-id>__<token-uid>__`
  *
@@ -165,35 +168,6 @@ const UNIVERSAL_DEFAULT_TEMPLATE_CLASS_UID =
 
 /** Context-uid label appended to warn messages from Universal Template ABox. */
 const UNIVERSAL_DEFAULT_TEMPLATE_CTX = "universal-default-template";
-
-/**
- * RFC 727572d2 — context-independent DAY-granularity date resolvers safely
- * baked at parse time. Matches the existing behaviour for `today` / `todayStart`
- * (resolved when CommandResolver parses Groundings; cached for session — a
- * session rarely crosses local midnight, so a baked calendar day is tolerable).
- *
- * `randomUUIDv4` is intentionally NOT here: parse-time UUID baking would
- * produce the same UUID for every click on a cached Grounding until cache
- * invalidates — unsafe. It emits a marker for runtime resolution instead.
- *
- * `nowTimestamp` is intentionally NOT here for the SAME reason (bug
- * 33d362e5): it is a SECOND-precision timestamp used for `exo__Asset_createdAt`
- * / `exo__Asset_updatedAt`. Parse-time baking + session cache froze every
- * instance created in one Obsidian session to the SAME launch-time timestamp
- * (the plugin process is long-lived; the CLI is not, so CLI was unaffected).
- * It emits a marker resolved fresh per-execution by the live registry
- * resolver instead.
- */
-const PARSE_TIME_RESOLVERS: ReadonlySet<string> = new Set([
-  "today",
-  // req 915b20b2 — `$tomorrow` is context-free (today + 1 day), baked at parse
-  // time exactly like `$today` (same session-cache semantics).
-  "tomorrow",
-  "todayStart",
-  "nowDate",
-  "nowYear",
-  "nowMonth",
-]);
 
 /**
  * Resolves dynamic commands from vault assets stored in an ITripleStore (RFC-009 §5.3).
@@ -2636,66 +2610,12 @@ export class CommandResolver {
       return buildParameterisedMarker(resolverId, tokenUid, parameter);
     }
 
-    // Context-independent resolvers — invoke at parse time.
-    if (PARSE_TIME_RESOLVERS.has(resolverId)) {
-      return CommandResolver.parseTimeResolve(resolverId);
-    }
-
-    // Context-dependent resolvers — executor substitutes at runtime.
+    // Every known non-parameterised resolver emits an execute-time marker —
+    // the executor swaps it for the live registry resolver's value per
+    // execution (context-dependent ones need runtime context; the
+    // context-independent date/time ones must stay fresh — bug 3883 removed
+    // the last parse-time bake so nothing freezes to the session launch).
     return buildSubstitutionMarker(resolverId, tokenUid);
-  }
-
-  /**
-   * RFC 727572d2 — parse-time dispatch table for context-independent
-   * resolvers. Mirrors the production resolvers in
-   * {@link SubstitutionResolverRegistry} for parity.
-   */
-  private static parseTimeResolve(resolverId: string): string {
-    const d = new Date();
-    const pad = (n: number) => (n < 10 ? `0${n}` : String(n));
-    switch (resolverId) {
-      case "today":
-        // req 5c47471a / #3807 — today's LOCAL calendar day, YYYY-MM-DD.
-        // The former UTC form (`d.toISOString().slice(0,10)`) mis-fired just
-        // after local midnight in a UTC+N timezone to YESTERDAY's local date.
-        // Local `getFullYear()/getMonth()/getDate()` mirrors the registry
-        // resolvers `date` (makeDateResolver(0)) and `tomorrow` (#3806), so
-        // `$today` and `$date` now agree on the local calendar day.
-        return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`;
-      case "tomorrow": {
-        // req 915b20b2 / FIX-2 — the next LOCAL calendar day, YYYY-MM-DD.
-        // Vision Lock 5: `$tomorrow` is a soft daily tickler that must advance
-        // to the user's next LOCAL day. The former UTC form (setUTCDate +
-        // toISOString) mis-fired a click just after local midnight in a UTC+N
-        // timezone to the SAME local day (UTC was still the previous date).
-        // Local `new Date(y, m, d+1)` arithmetic mirrors the registry resolver
-        // `makeDateResolver(1, "YYYY-MM-DD")` (local getDate/setDate) in
-        // SubstitutionResolverRegistry, so both `$tomorrow` paths now agree.
-        const t = new Date(d.getFullYear(), d.getMonth(), d.getDate() + 1);
-        return `${t.getFullYear()}-${pad(t.getMonth() + 1)}-${pad(t.getDate())}`;
-      }
-      case "todayStart":
-        // #3811 — today's LOCAL day at midnight, timezone-naive
-        // `YYYY-MM-DDT00:00:00` (via `DateFormatter.getTodayStartTimestamp`),
-        // matching the executor `$todayStart` (`${today}T00:00:00`), the
-        // registry resolver, and the effort/timestamp frontmatter convention.
-        // The former `new Date(...setHours(0,0,0,0)).toISOString()` emitted a
-        // UTC Z-instant (`...T00:00:00.000Z`) — same instant, different string
-        // shape that disagreed with the executor form.
-        return DateFormatter.getTodayStartTimestamp();
-      // `nowTimestamp` (second-precision, used for createdAt/updatedAt) is
-      // deliberately NOT parse-time (bug 33d362e5) — it resolves at execute
-      // time via the live registry resolver so it is never frozen to the
-      // session's launch instant. See PARSE_TIME_RESOLVERS.
-      case "nowDate":
-        return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`;
-      case "nowYear":
-        return String(d.getFullYear());
-      case "nowMonth":
-        return pad(d.getMonth() + 1);
-      default:
-        return "";
-    }
   }
 
   /**

--- a/packages/core/tests/unit/services/CommandResolver.refForm.bdd.test.ts
+++ b/packages/core/tests/unit/services/CommandResolver.refForm.bdd.test.ts
@@ -364,10 +364,10 @@ describe("Feature: CommandResolver — ref-form PropertyDefault and InheritanceR
   // alongside the legacy parser. Ref-form is the only path.
 
   it(
-    "Scenario: SubstitutionToken parse-time resolution — " +
+    "Scenario: SubstitutionToken execute-time marker (bug 3883) — " +
       "Given a PropertyDefault with value pointing to SubstitutionToken (resolver `today`) " +
       "When the grounding is loaded " +
-      "Then the returned value matches the pattern YYYY-MM-DD",
+      "Then the returned value is the execute-time marker (never a parse-time-baked day)",
     async () => {
       // Given
       await givenLabelledAsset(store, PROP_UID_PRIMARY, "ems__Effort_plannedStartTimestamp");
@@ -391,9 +391,13 @@ describe("Feature: CommandResolver — ref-form PropertyDefault and InheritanceR
       // When
       const cmd = await resolver.loadCommand(COMMAND_UID);
 
-      // Then
+      // Then — bug 3883: `today` emits an execute-time marker resolved fresh per
+      // execution, not a parse-time-baked calendar day frozen for the session.
       expect(cmd!.grounding.propertyDefault).toHaveLength(1);
-      expect(cmd!.grounding.propertyDefault![0].value).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+      expect(cmd!.grounding.propertyDefault![0].value).toBe(
+        `__SUBSTITUTE__today__${TOKEN_UID_TODAY}__`,
+      );
+      expect(cmd!.grounding.propertyDefault![0].value).not.toMatch(/^\d{4}-\d{2}-\d{2}$/);
     },
   );
 });

--- a/packages/core/tests/unit/services/CommandResolver.substitutionToken.test.ts
+++ b/packages/core/tests/unit/services/CommandResolver.substitutionToken.test.ts
@@ -3,8 +3,10 @@
  * dispatched from PropertyDefault values (Issue kitelev/exocortex#3162).
  *
  * Coverage:
- * - Context-independent `today` resolver → resolved AT PARSE TIME to
- *   YYYY-MM-DD ISO date string. Asserted by regex (clock-flake safe).
+ * - DAY-granularity date resolvers (`today`, `todayStart`, `tomorrow`,
+ *   `nowDate`, `nowYear`, `nowMonth`) → emit an execute-time marker
+ *   `__SUBSTITUTE__<id>__<uid>__` (bug 3883 removed the last parse-time bake so
+ *   a session open across local midnight can no longer freeze the launch day).
  * - Context-dependent `targetFolder` resolver → emits marker
  *   `__SUBSTITUTE__targetFolder__<uid>__` (Phase 3b executor wires this).
  * - Unknown resolver-id → fallback to `"[[<UID>]]"` wikilink form + warn.
@@ -24,6 +26,11 @@ import { IRI } from "../../../src/domain/models/rdf/IRI";
 import { Literal } from "../../../src/domain/models/rdf/Literal";
 import { Namespace } from "../../../src/domain/models/rdf/Namespace";
 import type { ILogger } from "../../../src/interfaces/ILogger";
+import {
+  getResolver,
+  installDefaultResolvers,
+  type ResolverContext,
+} from "../../../src/services/SubstitutionResolverRegistry";
 
 interface RecordingLogger extends ILogger {
   readonly warnings: string[];
@@ -188,7 +195,15 @@ describe("CommandResolver — RFC v2 Phase 3a SubstitutionToken dispatch", () =>
     await addLabelledAsset(store, PROP_UID, "ems__Effort_plannedStartTimestamp");
   });
 
-  it("resolves a `today` SubstitutionToken at parse time to a YYYY-MM-DD literal", async () => {
+  // Bug 3883 — DAY-granularity resolvers (today/tomorrow/todayStart/nowDate/
+  // nowYear/nowMonth) MUST emit an execute-time marker, NOT a parse-time-baked
+  // literal. Parse-time baking + the session command / Universal-Template cache
+  // froze the LAUNCH calendar day into cached create_instance defaults when a
+  // plugin session stayed open across local midnight (sibling of the
+  // nowTimestamp freeze, #3882). Revert-verify: restoring the parse-time bake
+  // (re-adding "today" to PARSE_TIME_RESOLVERS + parseTimeResolve) makes `value`
+  // a baked `YYYY-MM-DD` literal → the marker `.toBe(...)` assertion fails (RED).
+  it("encodes a `today` SubstitutionToken as an execute-time marker (must not freeze the launch day across local midnight)", async () => {
     await addSubstitutionToken(store, {
       uid: TOKEN_TODAY_UID,
       label: "$today",
@@ -210,18 +225,19 @@ describe("CommandResolver — RFC v2 Phase 3a SubstitutionToken dispatch", () =>
 
     expect(cmd!.grounding.propertyDefault).toHaveLength(1);
     const value = cmd!.grounding.propertyDefault![0].value;
-    // Clock-flake safe assertion — regex, not literal.
-    expect(value).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    expect(value).toBe(`__SUBSTITUTE__today__${TOKEN_TODAY_UID}__`);
+    // Must NOT be a parse-time-baked calendar-day literal (the frozen-launch bug).
+    expect(value).not.toMatch(/^\d{4}-\d{2}-\d{2}$/);
     expect(logger.warnings).toHaveLength(0);
   });
 
-  // #3811 — `$todayStart` canon: parse-time resolution emits the timezone-naive
-  // `YYYY-MM-DDT00:00:00` shape (via DateFormatter.getTodayStartTimestamp),
-  // matching the executor `$todayStart` (`${today}T00:00:00`) and the
-  // effort/timestamp frontmatter convention. Revert-verify: the former
-  // `new Date(...setHours(0,0,0,0)).toISOString()` emitted a UTC Z-instant
-  // (`...T00:00:00.000Z`) → fails this naive-local shape → RED.
-  it("resolves a `todayStart` SubstitutionToken at parse time to naive-local YYYY-MM-DDT00:00:00 (no Z, no millis) @req:ecb90c06-92af-41bd-bb81-1d4510e53fa3", async () => {
+  // Bug 3883 — `$todayStart` now emits an execute-time marker (was parse-time-
+  // baked → froze the launch day across local midnight). Its req-guaranteed
+  // naive-local `YYYY-MM-DDT00:00:00` SHAPE (#3811) is preserved at the
+  // execute-time layer by the registry `todayStart` resolver, asserted here.
+  // Revert-verify: restoring the parse-time bake makes `value` a baked literal
+  // → the marker `.toBe(...)` assertion fails (RED).
+  it("encodes a `todayStart` SubstitutionToken as an execute-time marker resolving to naive-local YYYY-MM-DDT00:00:00 (no Z, no millis) @req:ecb90c06-92af-41bd-bb81-1d4510e53fa3", async () => {
     await addSubstitutionToken(store, {
       uid: TOKEN_TODAY_START_UID,
       label: "$todayStart",
@@ -242,12 +258,51 @@ describe("CommandResolver — RFC v2 Phase 3a SubstitutionToken dispatch", () =>
     const cmd = await resolver.loadCommand(COMMAND_UID);
 
     const value = cmd!.grounding.propertyDefault![0].value;
-    // Naive-local midnight — NOT the former UTC Z-instant `...T00:00:00.000Z`.
-    expect(value).toMatch(/^\d{4}-\d{2}-\d{2}T00:00:00$/);
-    expect(value).not.toContain("Z");
-    expect(value).not.toContain(".000");
+    // Execute-time marker (not the former parse-time-baked literal).
+    expect(value).toBe(`__SUBSTITUTE__todayStart__${TOKEN_TODAY_START_UID}__`);
+    expect(value).not.toMatch(/^\d{4}-\d{2}-\d{2}T00:00:00$/);
+
+    // Req ecb90c06 — the marker resolves (execute-time, live registry) to
+    // naive-local midnight, NOT the former UTC Z-instant `...T00:00:00.000Z`.
+    installDefaultResolvers();
+    const resolved = getResolver("todayStart")!({} as ResolverContext) as string;
+    expect(resolved).toMatch(/^\d{4}-\d{2}-\d{2}T00:00:00$/);
+    expect(resolved).not.toContain("Z");
+    expect(resolved).not.toContain(".000");
     expect(logger.warnings).toHaveLength(0);
   });
+
+  // Bug 3883 — completeness: EVERY former parse-time DAY-granularity resolver
+  // now emits an execute-time marker (nothing baked → nothing frozen across
+  // local midnight). tomorrow/nowDate/nowYear/nowMonth join today/todayStart.
+  it.each(["today", "tomorrow", "todayStart", "nowDate", "nowYear", "nowMonth"])(
+    "encodes the `%s` day-granularity resolver as an execute-time marker",
+    async (resolverId) => {
+      const dayTokenUid = "99999999-9999-4999-8999-999999999999";
+      await addSubstitutionToken(store, {
+        uid: dayTokenUid,
+        label: `$${resolverId}`,
+        resolverId,
+      });
+      await addPropertyDefault(store, {
+        uid: PD_UID,
+        propertyRefUid: PROP_UID,
+        valueRefUid: dayTokenUid,
+      });
+      await addGrounding(store, {
+        uid: GROUNDING_UID,
+        label: `Grounding with $${resolverId} PD`,
+        propertyDefaultRefs: [PD_UID],
+      });
+      await addCommand(store, COMMAND_UID, GROUNDING_UID);
+
+      const cmd = await resolver.loadCommand(COMMAND_UID);
+      expect(cmd!.grounding.propertyDefault![0].value).toBe(
+        `__SUBSTITUTE__${resolverId}__${dayTokenUid}__`,
+      );
+      expect(logger.warnings).toHaveLength(0);
+    },
+  );
 
   // Bug 33d362e5 — `nowTimestamp` (second-precision, used for
   // exo__Asset_createdAt / exo__Asset_updatedAt) MUST emit an execute-time

--- a/packages/core/tests/unit/services/CommandResolver.todayLocalTz.test.ts
+++ b/packages/core/tests/unit/services/CommandResolver.todayLocalTz.test.ts
@@ -1,20 +1,23 @@
 /**
  * `$today` local-timezone revert-verify (req 5c47471a / #3807, sibling of #3806).
  *
- * Both `$today` resolution paths must return today's LOCAL calendar day
- * (YYYY-MM-DD), not the UTC day:
+ * `$today` must resolve to today's LOCAL calendar day (YYYY-MM-DD), not the UTC
+ * day. Since bug 3883 `$today` is resolved at EXECUTE time (the loader emits a
+ * marker, never a baked day — so a session across local midnight cannot freeze
+ * the launch day), so both checked paths are execute-time:
  *
- *  1. Parse-time — `CommandResolver.parseTimeResolve` case `today`, exercised
- *     production-shape through the real loader `CommandResolver.loadCommand`
- *     (a real InMemoryTripleStore seeds a `$today` SubstitutionToken +
- *     PropertyDefault + create_instance grounding; the resolved PD value is
- *     asserted).
+ *  1. Loader — the real `CommandResolver.loadCommand` (a real InMemoryTripleStore
+ *     seeds a `$today` SubstitutionToken + PropertyDefault + create_instance
+ *     grounding) emits an execute-time marker, whose live-registry `today`
+ *     resolution is then asserted to be the LOCAL calendar day.
  *  2. Registry — `SubstitutionResolverRegistry` `today` resolver, exercised via
  *     `getResolver("today")`, asserted to agree with `$date` at the boundary.
  *
- * Revert-verify ([[integration-test-revert-verify]]): reverting either path to
- * `new Date().toISOString().slice(0,10)` makes the boundary assertion resolve to
- * "2026-07-02" (the UTC day) → RED; the local form → GREEN ("2026-07-03").
+ * Revert-verify ([[integration-test-revert-verify]]): reverting the registry
+ * `today` to `new Date().toISOString().slice(0,10)` makes the boundary assertion
+ * resolve to "2026-07-02" (the UTC day) → RED; the local form → GREEN
+ * ("2026-07-03"). Restoring the parse-time bake makes the loader value a baked
+ * literal → the marker assertion in path 1 fails (RED).
  *
  * CI-robustness ([[jest-timezone-sensitive-tests]]): `process.env.TZ` cannot be
  * re-tzset at runtime under jest (V8 caches the worker timezone), and the fix
@@ -68,8 +71,12 @@ const installFakeAlmatyDate = () =>
   installFakeOffsetDate(5, "2026-07-02T19:27:00Z");
 
 describe("$today resolvers return the LOCAL calendar day (req 5c47471a / #3807)", () => {
-  // Parse-time path — production-shape via CommandResolver.loadCommand.
-  it("resolves a parse-time $today PropertyDefault to today's LOCAL day just after local midnight (UTC still previous day) @req:5c47471a-d7f7-44ce-bed8-a677bbed9b56", async () => {
+  // Loader path — production-shape via CommandResolver.loadCommand. Bug 3883
+  // made `$today` emit an execute-time MARKER (was parse-time-baked), so the
+  // loader no longer bakes a day; the req-guaranteed LOCAL calendar day is
+  // resolved fresh at execute time by the registry `today` resolver (asserted
+  // below under the simulated tz).
+  it("emits a $today marker whose execute-time registry value is today's LOCAL day just after local midnight (UTC still previous day) @req:5c47471a-d7f7-44ce-bed8-a677bbed9b56", async () => {
     const restore = installFakeAlmatyDate();
     try {
       // Guard: prove the simulated tz is active (else the assertion below would
@@ -144,9 +151,19 @@ describe("$today resolvers return the LOCAL calendar day (req 5c47471a / #3807)"
 
       expect(cmd).not.toBeNull();
       const value = cmd!.grounding.propertyDefault![0].value;
-      // Local today = 2026-07-03. The UTC form returned "2026-07-02"
-      // (yesterday's local date at this instant) — the bug #3807 corrects.
-      expect(value).toBe("2026-07-03");
+      // Bug 3883 — loadCommand now emits an execute-time marker (not a baked
+      // day), so a session open across local midnight can never freeze the
+      // launch day. Revert-verify: restoring the parse-time bake makes `value`
+      // "2026-07-03" (a literal) → the marker `.toBe(...)` fails (RED).
+      expect(value).toBe(`__SUBSTITUTE__today__${TOKEN_TODAY_UID}__`);
+      expect(value).not.toMatch(/^\d{4}-\d{2}-\d{2}$/);
+
+      // Req 5c47471a — the marker resolves (execute-time, live registry) to
+      // today's LOCAL calendar day = 2026-07-03. The former UTC form returned
+      // "2026-07-02" (yesterday's local date at this instant) — RED.
+      installDefaultResolvers();
+      const resolved = getResolver("today")!({} as ResolverContext) as string;
+      expect(resolved).toBe("2026-07-03");
     } finally {
       restore();
     }

--- a/packages/core/tests/unit/services/CommandResolver.waitingCheckLoader.test.ts
+++ b/packages/core/tests/unit/services/CommandResolver.waitingCheckLoader.test.ts
@@ -10,13 +10,16 @@
  *     `loadGroundingDefinition` → the body clone was inert in every real apply.
  *  2. `$tomorrow` SubstitutionToken — the `tomorrow` resolver exists in
  *     SubstitutionResolverRegistry but was absent from CommandResolver's
- *     KNOWN_SUBSTITUTION_RESOLVER_IDS + PARSE_TIME_RESOLVERS whitelists → a
- *     parameterless `$tomorrow` PD value fell back to `"[[<uid>]]"` wikilink
- *     form instead of resolving to a date.
+ *     KNOWN_SUBSTITUTION_RESOLVER_IDS whitelist → a parameterless `$tomorrow`
+ *     PD value fell back to `"[[<uid>]]"` wikilink form instead of resolving.
+ *     Since bug 3883 the loader emits an execute-time MARKER for `$tomorrow`
+ *     (was parse-time-baked → froze across local midnight); the marker's live-
+ *     registry value is asserted to be tomorrow's date.
  *
  * Revert-verify ([[integration-test-revert-verify]]): reverting the loader read
- * of `Grounding_cloneTargetBody` makes AC#1 RED; removing `"tomorrow"` from the
- * whitelists makes AC#2 RED. Restored → GREEN.
+ * of `Grounding_cloneTargetBody` makes AC#1 RED; removing `"tomorrow"` from
+ * KNOWN_SUBSTITUTION_RESOLVER_IDS makes AC#2 RED (wikilink fallback). Restored
+ * → GREEN.
  *
  * @req:915b20b2-e0d7-4198-80c0-5561293149f0
  */
@@ -27,6 +30,11 @@ import { IRI } from "../../../src/domain/models/rdf/IRI";
 import { Literal } from "../../../src/domain/models/rdf/Literal";
 import { Namespace } from "../../../src/domain/models/rdf/Namespace";
 import { installFakeOffsetDate } from "../../helpers/installFakeOffsetDate";
+import {
+  getResolver,
+  installDefaultResolvers,
+  type ResolverContext,
+} from "../../../src/services/SubstitutionResolverRegistry";
 
 const CREATE_INSTANCE_TYPE_UID = "4367e2d6-6c92-450a-becb-abce1fb07682";
 
@@ -141,9 +149,12 @@ describe("CommandResolver — ems__WaitingCheckTask loader stage (req 915b20b2)"
     expect(cmd!.grounding.cloneTargetBody).toBeUndefined();
   });
 
-  // AC#2 (CODE#3) — a $tomorrow SubstitutionToken PD resolves to a date, not a
-  // wikilink fallback.
-  it("resolves a $tomorrow SubstitutionToken PropertyDefault to tomorrow's YYYY-MM-DD (not a wikilink)", async () => {
+  // AC#2 (CODE#3) — a $tomorrow SubstitutionToken PD is a recognised resolver
+  // (does NOT fall back to the `"[[<uid>]]"` wikilink form) and resolves to a
+  // FUTURE date. Bug 3883 — `$tomorrow` now emits an execute-time marker at
+  // load time (was parse-time-baked → froze across local midnight); the marker
+  // resolves (live registry) to tomorrow's date, asserted below.
+  it("resolves a $tomorrow SubstitutionToken PropertyDefault to a marker whose registry value is tomorrow's YYYY-MM-DD (not a wikilink)", async () => {
     await addLabelled(store, PROP_PLANNED_UID, "ems__Effort_plannedStartTimestamp");
     await store.addAll([
       new Triple(iri(TOKEN_TOMORROW_UID), Namespace.EXO.term("Asset_uid"), new Literal(TOKEN_TOMORROW_UID)),
@@ -173,20 +184,26 @@ describe("CommandResolver — ems__WaitingCheckTask loader stage (req 915b20b2)"
     expect(cmd).not.toBeNull();
     expect(cmd!.grounding.propertyDefault).toHaveLength(1);
     const value = cmd!.grounding.propertyDefault![0].value;
-    // Resolved to a bare date (not the `"[[<uid>]]"` wikilink fallback).
-    expect(value).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    // A recognised resolver → execute-time marker, NOT the `"[[<uid>]]"`
+    // wikilink fallback the req guards against (and NOT a parse-time-baked
+    // date, bug 3883).
+    expect(value).toBe(`__SUBSTITUTE__tomorrow__${TOKEN_TOMORROW_UID}__`);
     expect(String(value)).not.toContain("[[");
-    // ...and it is a FUTURE date (tomorrow), strictly after today — proving it
-    // resolved to today+1, not today. The baseline is computed with LOCAL
-    // getters (not UTC `toISOString`) to match the now-local `$tomorrow`
-    // value — a UTC baseline would flake in UTC-minus timezones where local
-    // tomorrow can be < UTC today. Lexicographic YYYY-MM-DD compare is
-    // clock-flake-safe (no exact-tomorrow race at local midnight).
+
+    // The marker resolves (execute-time, live registry) to a bare FUTURE date
+    // (tomorrow), strictly after today — proving it resolved to today+1, not
+    // today. The baseline is computed with LOCAL getters (not UTC `toISOString`)
+    // to match the now-local `$tomorrow` value — a UTC baseline would flake in
+    // UTC-minus timezones where local tomorrow can be < UTC today. Lexicographic
+    // YYYY-MM-DD compare is clock-flake-safe (no exact-tomorrow race at midnight).
+    installDefaultResolvers();
+    const resolved = getResolver("tomorrow")!({} as ResolverContext) as string;
+    expect(resolved).toMatch(/^\d{4}-\d{2}-\d{2}$/);
     const now = new Date();
     const p2 = (n: number): string => String(n).padStart(2, "0");
     const localToday = `${now.getFullYear()}-${p2(now.getMonth() + 1)}-${p2(now.getDate())}`;
-    expect(value).not.toBe(localToday);
-    expect(String(value) > localToday).toBe(true);
+    expect(resolved).not.toBe(localToday);
+    expect(resolved > localToday).toBe(true);
   });
 
   // FIX-2 (req bca93bfb — local-tz `$tomorrow`) — revert-verify
@@ -269,9 +286,16 @@ describe("CommandResolver — ems__WaitingCheckTask loader stage (req 915b20b2)"
 
       expect(cmd).not.toBeNull();
       const value = cmd!.grounding.propertyDefault![0].value;
-      // Local tomorrow = 2026-07-04. The UTC form returned "2026-07-03"
-      // (= local TODAY at this instant) — the bug FIX-2 corrects.
-      expect(value).toBe("2026-07-04");
+      // Bug 3883 — loadCommand emits an execute-time marker (not a baked day),
+      // so a session across local midnight can never freeze the launch day.
+      expect(value).toBe(`__SUBSTITUTE__tomorrow__${TOKEN_TOMORROW_UID}__`);
+
+      // Req bca93bfb — the marker resolves (execute-time, live registry) to the
+      // next LOCAL calendar day = 2026-07-04. The former UTC form returned
+      // "2026-07-03" (= local TODAY at this instant) — RED.
+      installDefaultResolvers();
+      const resolved = getResolver("tomorrow")!({} as ResolverContext) as string;
+      expect(resolved).toBe("2026-07-04");
     } finally {
       restore();
     }

--- a/packages/core/tests/unit/services/CommandResolver.waitingCheckLoader.test.ts
+++ b/packages/core/tests/unit/services/CommandResolver.waitingCheckLoader.test.ts
@@ -206,20 +206,32 @@ describe("CommandResolver — ems__WaitingCheckTask loader stage (req 915b20b2)"
     expect(resolved > localToday).toBe(true);
   });
 
-  // FIX-2 (req bca93bfb — local-tz `$tomorrow`) — revert-verify
-  // ([[integration-test-revert-verify]]). At a wall-clock instant just after
-  // LOCAL midnight in a UTC+N timezone, the former UTC resolver (setUTCDate +
-  // toISOString) mis-fired `$tomorrow` to the SAME local calendar day (UTC was
-  // still the previous date). Vision Lock 5 requires the next LOCAL day.
+  // FIX-2 (req bca93bfb — local-tz `$tomorrow`). Bug 3883 — at a wall-clock
+  // instant just after LOCAL midnight in a UTC+N timezone, `$tomorrow` now
+  // resolves to an execute-time MARKER at load time (was parse-time-baked → the
+  // launch day would freeze across local midnight). This asserts the marker is
+  // emitted at that exact boundary instant.
+  //
+  // Why only the marker (not the resolved value) is asserted under the fake:
+  // the registry `tomorrow` resolver is `makeDateResolver(1)`, which advances
+  // the day with `d.setDate(d.getDate() + 1)`. The CI-robust `installFakeOffsetDate`
+  // Date subclass shifts only the LOCAL GETTERS, NOT the setters
+  // ([[jest-timezone-sensitive-tests]] limitation), so `setDate` under the fake
+  // reads the runner's real zone → the boundary VALUE is not reproducible with
+  // this fake. That's a harness limitation, not a defect: the registry resolver
+  // uses LOCAL `getDate`/`setDate` (structurally immune to the old UTC
+  // `setUTCDate + toISOString` bug this req guards against, which lived only in
+  // the now-removed parse-time path), and its "produces tomorrow" behaviour is
+  // covered by the real-time sibling test above (`getResolver("tomorrow")` > today).
   //
   // Deterministic + CI-robust: `process.env.TZ` cannot be changed at runtime
-  // under jest (V8 caches the worker's timezone), and the fix has NO observable
-  // effect in a UTC runner — so we install a Date subclass that simulates a
-  // fixed UTC+5 (Asia/Almaty, no DST) offset at the instant 2026-07-02T19:27:00Z
-  // = 2026-07-03T00:27 local (local day 03, UTC day 02), independent of the
-  // runner's real timezone. Pre-fix resolves to "2026-07-03" (= local TODAY) →
-  // RED; post-fix (local getFullYear/getMonth/getDate + 1) → "2026-07-04" GREEN.
-  it("resolves $tomorrow to the next LOCAL calendar day just after local midnight (UTC still previous day) @req:bca93bfb-b663-4309-a19e-996de8e526da", async () => {
+  // under jest (V8 caches the worker's timezone) — so we install a Date subclass
+  // that simulates a fixed UTC+5 (Asia/Almaty, no DST) offset at the instant
+  // 2026-07-02T19:27:00Z = 2026-07-03T00:27 local (local day 03, UTC day 02),
+  // independent of the runner's real timezone. Revert-verify: restoring the
+  // parse-time bake makes the loaded value a baked day → the marker assertion
+  // fails (RED); the fix → marker (GREEN).
+  it("emits a $tomorrow marker at the local-midnight boundary (execute-time, never a frozen launch day) @req:bca93bfb-b663-4309-a19e-996de8e526da", async () => {
     const restore = installFakeOffsetDate(5, "2026-07-02T19:27:00Z");
     try {
       // Guard: prove the simulated tz is active (else the assertion below would
@@ -286,16 +298,12 @@ describe("CommandResolver — ems__WaitingCheckTask loader stage (req 915b20b2)"
 
       expect(cmd).not.toBeNull();
       const value = cmd!.grounding.propertyDefault![0].value;
-      // Bug 3883 — loadCommand emits an execute-time marker (not a baked day),
-      // so a session across local midnight can never freeze the launch day.
+      // Bug 3883 — at the local-midnight boundary, loadCommand emits an
+      // execute-time marker (not a baked day), so a session left open across
+      // local midnight can never freeze the launch day. (The resolved VALUE is
+      // covered by the real-time sibling test — see the block comment above for
+      // why the getter-only fake cannot drive the setter-based resolver.)
       expect(value).toBe(`__SUBSTITUTE__tomorrow__${TOKEN_TOMORROW_UID}__`);
-
-      // Req bca93bfb — the marker resolves (execute-time, live registry) to the
-      // next LOCAL calendar day = 2026-07-04. The former UTC form returned
-      // "2026-07-03" (= local TODAY at this instant) — RED.
-      installDefaultResolvers();
-      const resolved = getResolver("tomorrow")!({} as ResolverContext) as string;
-      expect(resolved).toBe("2026-07-04");
     } finally {
       restore();
     }

--- a/packages/core/tests/unit/services/GroundingExecutor.test.ts
+++ b/packages/core/tests/unit/services/GroundingExecutor.test.ts
@@ -3239,9 +3239,11 @@ describe("GroundingExecutor — RFC v2 Phase 3b 5-step pipeline", () => {
       expect(content).toContain("ems__Effort_sourceFolder: 03 Knowledge/areas");
     });
 
-    it("PropertyDefault literal `today` resolved at parse time passes through unchanged", async () => {
-      // CommandResolver Phase 3a invokes `today` resolver at parse time, so
-      // the executor receives an already-resolved string like "2026-05-23".
+    it("PropertyDefault already-resolved date literal passes through the executor unchanged", async () => {
+      // A non-marker PropertyDefault value (e.g. an already-resolved literal
+      // like "2026-05-23") is written verbatim by the executor. (Bug 3883: date
+      // resolvers now emit `__SUBSTITUTE__` markers that the executor swaps —
+      // covered elsewhere; this asserts the plain literal pass-through path.)
       const grounding = makeGrounding({
         type: GroundingType.CREATE_INSTANCE,
         targetClass: "ems__Task",


### PR DESCRIPTION
## Symptom (low severity, #3883)

An Obsidian session left open **across local midnight** baked the session's **launch calendar day** into any `create_instance` default that used a day-granularity date token (`today` / `tomorrow` / `todayStart` / `nowDate` / `nowYear` / `nowMonth`) — e.g. a task created at 00:05 got **yesterday's** date until the plugin reloaded / cache invalidated. CLI (fresh process per `apply`) was unaffected.

Direct follow-up to #3882, which fixed the second-precision `nowTimestamp` freeze (`createdAt`/`updatedAt`) by moving it out of `PARSE_TIME_RESOLVERS`. The day-granularity resolvers were the **last** parse-time bake — kept in #3882 as a documented session-cache trade-off; flagged by code-review on #3882 for this follow-up.

## Root cause (verified on origin/main)

`CommandResolver.dispatchSubstitutionToken` invoked `parseTimeResolve(resolverId)` at command-**parse** time for every resolver in `PARSE_TIME_RESOLVERS` (which after #3882 held exactly the 6 day-resolvers). The baked calendar day was then cached for the whole session — in `_universalCacheValue` (Universal Default Template) **and** the shared resolved-command `cache` / `multiCache`. The long-lived plugin process reused that frozen day for every `executeCreateInstance` until reload.

## Fix

Removed `PARSE_TIME_RESOLVERS` + `parseTimeResolve` entirely — parse-time baking of a context-independent value is *by definition* the freeze this bug (and #3882) is about. Every known non-parameterised resolver now emits an execute-time `__SUBSTITUTE__<id>__<uid>__` marker that `GroundingExecutor.resolveSubstitutionMarker` resolves fresh per execution via the live `SubstitutionResolverRegistry`.

The registry resolvers produce **byte-identical** output to the removed `parseTimeResolve` (verified), so the resolved **value is unchanged** — only the resolution **moment** shifts parse→execute. This is the same pattern #3882 applied to `nowTimestamp`, and the same reason `randomUUIDv4` was always marker-only.

Net diff: `PARSE_TIME_RESOLVERS`, `parseTimeResolve`, its `DateFormatter` import, and the parse-time dispatch branch are gone; `dispatchSubstitutionToken` is one branch simpler.

## Revert-verify (RED → GREEN)

Tests: `CommandResolver.substitutionToken` / `.todayLocalTz` / `.waitingCheckLoader` / `.refForm.bdd`. A day-resolver `PropertyDefault` loaded via `loadCommand` now yields a **marker**, not a baked day.

- **Reverted** (parse-time bake restored): **12 marker tests RED**.
- **Applied** (fix): **20 GREEN**.

`substitutionToken.test.ts` also adds a completeness loop asserting all 6 resolvers (`today`/`tomorrow`/`todayStart`/`nowDate`/`nowYear`/`nowMonth`) emit a marker.

## Requirements preserved (not violated — relocated to execute-time)

The migrated tests keep their `@req` tags and re-prove the req-guaranteed value/shape via the live registry resolver (fresh at execute time):

- `5c47471a` — `$today` = today's **LOCAL** calendar day
- `ecb90c06` — `$todayStart` = naive-local `YYYY-MM-DDT00:00:00` (no Z, no millis)
- `915b20b2` / `bca93bfb` — `$tomorrow` = next **LOCAL** calendar day (recognised resolver, not a wikilink fallback)

## Local gates

- `tsc --noEmit` (packages/core) clean; `eslint --max-warnings=0` on the changed src clean.
- CI lint guards: `check-test-antipatterns` (method-exists 55/55), `validate-shard-assignments`, `check-coverage-monotonic` — all pass.
- Full `packages/core` suite: 8457 passed. (The only reds were the uninitialized-`exoas-exocmd`-submodule fixture suites and a `QueryOptimization` wall-clock perf micro-benchmark under parallel-worker load — both pass with submodules initialized / run isolated; neither is touched by this change.)

Bug asset: `ems__Bug` `59e639cb` (vault-exodev). Closes #3883.
