### PR TITLE
feat(#3849): cli create default ems__Effort_status + createdBy + --status/--yes

### DIFF
--- a/packages/cli/src/commands/create.ts
+++ b/packages/cli/src/commands/create.ts
@@ -12,6 +12,7 @@ import { NodeFsAdapter } from "../adapters/NodeFsAdapter.js";
 import { FileSystemVaultAdapter } from "../adapters/FileSystemVaultAdapter.js";
 import { ClassResolverService } from "../services/ClassResolverService.js";
 import { WikilinkValidator } from "../services/WikilinkValidator.js";
+import { EffortStatusResolver } from "../services/EffortStatusResolver.js";
 import { ErrorHandler } from "../utils/ErrorHandler.js";
 import { VaultNotFoundError } from "../utils/errors/index.js";
 import { registerOrderSpecFromVault } from "../services/registerOrderSpec.js";
@@ -32,6 +33,27 @@ const DEFAULT_INBOX_FOLDER = "01 Inbox";
 const DEFAULT_TIMEZONE = "Asia/Almaty";
 
 /**
+ * Default creator for `cli create` assets — the ExoAssistant identity. When
+ * `--created-by` is not supplied the CLI stamps this (making the `--created-by`
+ * help text truthful). The core service applies no implicit default (the
+ * plugin / apply paths stay byte-identical); the default lives here so it is
+ * scoped to `cli create` only. Issue #3849.
+ */
+const DEFAULT_CREATED_BY_UID = "4ef3962d-b8a7-42b5-bd28-88ec846f1d13";
+
+/**
+ * Default effort status for a status-bearing class (an `ems__Effort` subclass)
+ * created via `cli create` with no `--status`. Mirrors the Backlog a
+ * Write-template gives for free, so a fresh Task/Project reaches its default
+ * status without the two-step `set-draft-status → move-to-backlog` chain
+ * (issue #3849).
+ */
+const DEFAULT_STATUS_NAME = "Backlog";
+
+/** Frontmatter key for the effort status wikilink. */
+const EFFORT_STATUS_KEY = "ems__Effort_status";
+
+/**
  * Options parsed from CLI flags for the create command.
  */
 interface CreateCommandOptions {
@@ -44,6 +66,8 @@ interface CreateCommandOptions {
   bodyFile?: string;
   dryRun?: boolean;
   createdBy?: string;
+  status?: string;
+  yes?: boolean;
   timezone?: string;
   skipWikilinkValidation?: boolean;
 }
@@ -217,6 +241,8 @@ export function createCommand(): Command {
     .option("--body-file <path>", "Read body content from file")
     .option("--dry-run", "Preview frontmatter without writing file")
     .option("--created-by <uuid>", "Creator UUID (defaults to ExoAssistant)")
+    .option("--status <name>", "ems__Effort_status for status-bearing classes (default: Backlog; e.g. Draft, Doing, Done). Errors for non-status-bearing classes.")
+    .option("--yes", "Accepted for symmetry with the apply subcommands (create is non-interactive; no-op)")
     .option("--timezone <tz>", "Timezone for timestamps (defaults to Asia/Almaty)")
     .option("--skip-wikilink-validation", "Skip wikilink existence validation")
     .action(async (options: CreateCommandOptions) => {
@@ -235,10 +261,10 @@ export function createCommand(): Command {
         }
         const trimmedLabel = options.label.trim();
 
-        // Parse properties from --property flags
+        // Parse properties from --property flags. Kept mutable so the effort
+        // status default can be injected (issue #3849) before `propertyValues`
+        // is finalised below.
         const properties = parseProperties(options.property);
-        const propertyValues =
-          Object.keys(properties).length > 0 ? properties : undefined;
 
         // Resolve body content and parse escape sequences
         let body = await resolveBody(options);
@@ -253,6 +279,59 @@ export function createCommand(): Command {
 
         // Resolve class short name → UUID (UID pass-through if already a UUID).
         const classUid = await classResolver.resolve(vaultPath, options.class);
+
+        // Effort status default (issue #3849): a status-bearing class
+        // (ems__Effort or a subclass, detected by walking exo__Class_superClass
+        // to ems__Effort — no hardcoded class list) gets a default
+        // ems__Effort_status of Backlog on create, the status a Write-template
+        // gives for free, so a fresh Task/Project skips the two-step
+        // `set-draft-status → move-to-backlog` chain. A non-status-bearing
+        // class never gets a status. An explicit `--property
+        // ems__Effort_status=...` always wins (and conflicts with --status).
+        const statusResolver = new EffortStatusResolver(fsAdapter);
+        const explicitStatus = EFFORT_STATUS_KEY in properties;
+        if (options.status && explicitStatus) {
+          throw new Error(
+            `Cannot pass both --status and --property ${EFFORT_STATUS_KEY}=... (ambiguous). Use one.`,
+          );
+        }
+        if (!explicitStatus) {
+          const statusBearing = await statusResolver.isStatusBearing(classUid);
+          if (options.status) {
+            if (!statusBearing) {
+              throw new Error(
+                `--status only applies to status-bearing classes (ems__Effort subclasses); '${options.class}' is not one.`,
+              );
+            }
+            const statusUid = await statusResolver.resolveStatusUid(
+              options.status,
+            );
+            if (!statusUid) {
+              throw new Error(
+                `Unknown status '${options.status}' — no matching ems__EffortStatus<Name> enum asset found in the vault.`,
+              );
+            }
+            properties[EFFORT_STATUS_KEY] = `[[${statusUid}]]`;
+          } else if (statusBearing) {
+            // Default Backlog — fail-open: if the enum can't be resolved
+            // (degenerate vault without the ems status enums mounted) keep the
+            // historical no-status behaviour rather than failing the create.
+            const backlogUid =
+              await statusResolver.resolveStatusUid(DEFAULT_STATUS_NAME);
+            if (backlogUid) {
+              properties[EFFORT_STATUS_KEY] = `[[${backlogUid}]]`;
+            } else {
+              process.stderr.write(
+                `⚠ status-bearing class but no ${DEFAULT_STATUS_NAME} status enum found in the vault — created without ems__Effort_status.\n`,
+              );
+            }
+          }
+        }
+
+        // Finalise propertyValues AFTER any status injection so the injected
+        // status is wikilink-validated and co-location still reads isDefinedBy.
+        const propertyValues =
+          Object.keys(properties).length > 0 ? properties : undefined;
 
         // Validate property wikilinks (unless skipped).
         if (propertyValues && !options.skipWikilinkValidation) {
@@ -303,7 +382,9 @@ export function createCommand(): Command {
         // ref, cardinality, timestamp, body) to the shared core service.
         // `cli create` opts into the domain fields the plugin/apply omit:
         //  - classRefForm 'uuid' → `[[<uuid>]]` strip-canon
-        //  - createdBy passed through verbatim (no implicit default)
+        //  - createdBy defaults to ExoAssistant when `--created-by` is omitted
+        //    (issue #3849 — the default is CLI-scoped; the core applies no
+        //    implicit default, so plugin/apply stay byte-identical)
         //  - folder = co-located ontology folder (or `01 Inbox` fail-open),
         //    aliases, timezone (Asia/Almaty default), body
         //  - shapeRegistry → cardinality-aware property emission
@@ -317,7 +398,7 @@ export function createCommand(): Command {
           label: trimmedLabel,
           aliases: options.aliases,
           folderPath,
-          createdBy: options.createdBy,
+          createdBy: options.createdBy || DEFAULT_CREATED_BY_UID,
           timezone: options.timezone || DEFAULT_TIMEZONE,
           body,
           propertyValues,

--- a/packages/cli/src/services/EffortStatusResolver.ts
+++ b/packages/cli/src/services/EffortStatusResolver.ts
@@ -1,0 +1,172 @@
+import { NodeFsAdapter } from "../adapters/NodeFsAdapter.js";
+
+/**
+ * Label of the ontology root class that carries `ems__Effort_status`. A class
+ * is "status-bearing" iff it is `ems__Effort` or a transitive subclass of it —
+ * i.e. `ems__Effort` appears in its `exo__Class_superClass` chain. Detected by
+ * walking the chain (no hardcoded list of status-bearing class names).
+ */
+const EFFORT_CLASS_LABEL = "ems__Effort";
+
+/** `exo__Asset_label` prefix for the effort-status enum assets. */
+const STATUS_ENUM_LABEL_PREFIX = "ems__EffortStatus";
+
+/**
+ * Resolves effort-status semantics for `cli create` against a vault's TBox
+ * (Node filesystem). Two concerns:
+ *
+ *  - {@link isStatusBearing} — does a class carry `ems__Effort_status`? (walks
+ *    `exo__Class_superClass` from the class up to `ems__Effort`).
+ *  - {@link resolveStatusUid} — map a status short name (e.g. `Backlog`,
+ *    `Draft`) to the `ems__EffortStatus<Name>` enum asset's UID.
+ *
+ * The bare `exocortex create` verb bypasses homoiconic groundings (per
+ * homoiconic-gap-triage), so its set-time status default is an engine concern
+ * (Homoiconicity Invariant Q3). Kept CLI-side because the determination needs
+ * vault TBox access; the core `GenericAssetCreationService` stays
+ * vault-agnostic and byte-identical for the plugin / apply paths.
+ */
+export class EffortStatusResolver {
+  /** Cache: status label → resolved enum UID (or `null` if not found). */
+  private statusUidCache = new Map<string, string | null>();
+
+  constructor(private readonly fsAdapter: NodeFsAdapter) {}
+
+  /**
+   * True iff `classUid`'s class definition is `ems__Effort` or a transitive
+   * subclass (so it can carry `ems__Effort_status`). Walks the
+   * `exo__Class_superClass` chain (cycle-safe). Returns `false` when the class
+   * definition is not found on disk (a made-up / pass-through UUID with no
+   * class file is treated as non-status-bearing — no default status injected).
+   *
+   * No hardcoded list of status-bearing class names: `ems__Effort` is
+   * identified by its `exo__Asset_label`, discovered by walking the vault.
+   */
+  async isStatusBearing(classUid: string): Promise<boolean> {
+    const visited = new Set<string>();
+    // The queue holds class references — either a UID (UID-canon superClass
+    // form) or a label (legacy `[[ems__Effort]]` form). Both are handled.
+    const queue: string[] = [classUid];
+
+    while (queue.length > 0) {
+      const ref = queue.shift();
+      if (ref === undefined) break;
+      if (visited.has(ref)) continue;
+      visited.add(ref);
+
+      // Direct label short-circuit — a legacy label-form superClass ref that
+      // is literally `ems__Effort` needs no file resolution.
+      if (ref === EFFORT_CLASS_LABEL) return true;
+
+      const file = await this.resolveClassFile(ref);
+      if (!file) continue;
+
+      let metadata: Record<string, unknown>;
+      try {
+        metadata = await this.fsAdapter.getFileMetadata(file);
+      } catch {
+        continue;
+      }
+
+      if (metadata.exo__Asset_label === EFFORT_CLASS_LABEL) return true;
+
+      const superClass = metadata.exo__Class_superClass;
+      const superRefs = Array.isArray(superClass)
+        ? superClass
+        : superClass !== null && superClass !== undefined
+          ? [superClass]
+          : [];
+      for (const raw of superRefs) {
+        const target = extractRef(String(raw));
+        if (target && !visited.has(target)) {
+          queue.push(target);
+        }
+      }
+    }
+
+    return false;
+  }
+
+  /**
+   * Resolve a status short name to the `ems__EffortStatus<Name>` enum asset's
+   * UID. Accepts either a bare name (`Backlog`, `Draft`, `Doing`) or the full
+   * enum label (`ems__EffortStatusBacklog`). Returns `null` when no enum with
+   * that label exists in the vault — the caller decides fail-open (default
+   * status → skip) vs fail-loud (explicit `--status` → error).
+   */
+  async resolveStatusUid(statusName: string): Promise<string | null> {
+    const label = toStatusEnumLabel(statusName);
+    const cached = this.statusUidCache.get(label);
+    if (cached !== undefined) return cached;
+
+    let uid: string | null = null;
+    const files = await this.fsAdapter.findFilesByMetadata({
+      exo__Asset_label: label,
+    });
+    for (const file of files) {
+      try {
+        const metadata = await this.fsAdapter.getFileMetadata(file);
+        if (metadata.exo__Asset_uid) {
+          uid = String(metadata.exo__Asset_uid);
+          break;
+        }
+      } catch {
+        continue;
+      }
+    }
+
+    this.statusUidCache.set(label, uid);
+    return uid;
+  }
+
+  /**
+   * Resolve a class reference (UID or label) to its on-disk file path.
+   * UID refs use the filename-based lookup (cheap, name-only walk); label refs
+   * fall back to a metadata scan (rare in UID-canon vaults, where
+   * `exo__Class_superClass` is stored UID-form).
+   */
+  private async resolveClassFile(ref: string): Promise<string | null> {
+    if (isUuid(ref)) {
+      return this.fsAdapter.findFileByUidFilename(ref);
+    }
+    const byLabel = await this.fsAdapter.findFilesByMetadata({
+      exo__Asset_label: ref,
+    });
+    return byLabel.length > 0 ? byLabel[0] : null;
+  }
+}
+
+/**
+ * Normalise a status short name to its `ems__EffortStatus<Name>` enum label.
+ * A name already in `ems__` form is used verbatim; otherwise the first letter
+ * is upper-cased (Backlog / Draft / Doing / WaitingCheck) and prefixed.
+ */
+function toStatusEnumLabel(name: string): string {
+  const trimmed = name.trim();
+  if (trimmed.startsWith("ems__")) return trimmed;
+  const cap = trimmed.charAt(0).toUpperCase() + trimmed.slice(1);
+  return `${STATUS_ENUM_LABEL_PREFIX}${cap}`;
+}
+
+/**
+ * Extract a class reference target from a wikilink value. Strips surrounding
+ * quotes and `[[ ]]`, then takes the target before any `|alias`. Mirrors the
+ * core `extractAssetReference` behaviour without importing it (keeps this
+ * module free of core mocks).
+ */
+function extractRef(raw: string): string | null {
+  const stripped = raw
+    .trim()
+    .replace(/^["']|["']$/g, "")
+    .replace(/^\[\[|\]\]$/g, "")
+    .split("|")[0]
+    .trim();
+  return stripped || null;
+}
+
+/** Test whether a string is a UUID (v4-shaped). */
+function isUuid(value: string): boolean {
+  return /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(
+    value,
+  );
+}

--- a/packages/cli/tests/integration/create-status-defaults.integration.test.ts
+++ b/packages/cli/tests/integration/create-status-defaults.integration.test.ts
@@ -1,0 +1,252 @@
+/**
+ * Issue #3849 — `cli create` must set a default `ems__Effort_status` (Backlog)
+ * for status-bearing classes (ems__Effort subclasses) and a default
+ * `exo__Asset_createdBy` (ExoAssistant), plus accept `--status` / `--yes`.
+ *
+ * Drives the REAL `createCommand()` action end-to-end against a temp fixture
+ * vault (class defs + status enums + inbox), reads the written file back from
+ * disk, and asserts the emitted frontmatter — the production create pipeline,
+ * not hand-injected frontmatter (test-fixture-realism).
+ *
+ * Status-bearing detection uses real class-hierarchy walking: the fixture's
+ * ems__Task class def has `exo__Class_superClass → ems__Effort`, so the walk
+ * reaches ems__Effort and injects Backlog. concept__Concept has no Effort
+ * ancestor → no status. Uses the real production UIDs (ems__Task / ems__Effort
+ * / Backlog / Draft / ExoAssistant) so the assertions mirror real output.
+ *
+ * Revert-verify (~/dotfiles/.claude/rules/integration-test-revert-verify.md):
+ * Edit-break the status/createdBy default injection in `create.ts` → the
+ * status-bearing / createdBy assertions go RED; restored → GREEN. The
+ * non-status-bearing case isolates non-vacuity (never gets a status either way).
+ */
+import { jest, describe, it, expect, beforeEach, afterEach } from "@jest/globals";
+import * as fs from "fs";
+import * as path from "path";
+import * as os from "os";
+
+const { createCommand } = await import("../../src/commands/create.js");
+
+// Real production UIDs so assertions mirror live output.
+const TASK_CLASS_UID = "1b20a8f0-d745-4e93-91db-4531b3df120e";
+const EFFORT_CLASS_UID = "086f71fa-dd30-4284-90cf-e609f2a6c461";
+const BACKLOG_UID = "753a44d5-846c-4b82-9196-4fd9a4d48777";
+const DRAFT_UID = "c42245d0-01de-4c35-bfcf-d910445ea28e";
+const EXOASSISTANT_UID = "4ef3962d-b8a7-42b5-bd28-88ec846f1d13";
+// Non-status-bearing class (its superClass points at exo__Asset, which the
+// fixture does NOT define → the walk terminates without reaching ems__Effort).
+const CONCEPT_CLASS_UID = "c0c0c0c0-1111-2222-3333-444444444444";
+
+const EMS_DIR = "assetspaces/kitelev/exoas-public/ems";
+
+function md(frontmatter: Record<string, string | string[]>): string {
+  const lines = ["---"];
+  for (const [k, v] of Object.entries(frontmatter)) {
+    if (Array.isArray(v)) {
+      lines.push(`${k}:`);
+      for (const item of v) lines.push(`  - "${item}"`);
+    } else {
+      lines.push(`${k}: ${v}`);
+    }
+  }
+  lines.push("---");
+  lines.push("");
+  return lines.join("\n");
+}
+
+describe("Issue #3849: `cli create` sets default ems__Effort_status + createdBy", () => {
+  let vault: string;
+  let exitSpy: ReturnType<typeof jest.spyOn>;
+  let stdoutSpy: ReturnType<typeof jest.spyOn>;
+  let stderrSpy: ReturnType<typeof jest.spyOn>;
+  let logSpy: ReturnType<typeof jest.spyOn>;
+  let errorSpy: ReturnType<typeof jest.spyOn>;
+  let stdoutChunks: string[];
+  let exitCodes: number[];
+
+  beforeEach(() => {
+    vault = fs.mkdtempSync(path.join(os.tmpdir(), "cli-3849-"));
+
+    const emsDir = path.join(vault, EMS_DIR);
+    fs.mkdirSync(emsDir, { recursive: true });
+
+    // ems__Effort root class (carries ems__Effort_status).
+    fs.writeFileSync(
+      path.join(emsDir, `${EFFORT_CLASS_UID}.md`),
+      md({ exo__Asset_uid: EFFORT_CLASS_UID, exo__Asset_label: "ems__Effort" }),
+    );
+    // ems__Task class — subclass of ems__Effort → status-bearing.
+    fs.writeFileSync(
+      path.join(emsDir, `${TASK_CLASS_UID}.md`),
+      md({
+        exo__Asset_uid: TASK_CLASS_UID,
+        exo__Asset_label: "ems__Task",
+        exo__Class_superClass: [`[[${EFFORT_CLASS_UID}]]`],
+      }),
+    );
+    // concept__Concept class — superClass → exo__Asset (undefined here) →
+    // NOT status-bearing (the walk never reaches ems__Effort).
+    fs.writeFileSync(
+      path.join(emsDir, `${CONCEPT_CLASS_UID}.md`),
+      md({
+        exo__Asset_uid: CONCEPT_CLASS_UID,
+        exo__Asset_label: "concept__Concept",
+        exo__Class_superClass: ["[[exo__Asset]]"],
+      }),
+    );
+    // Status enums.
+    fs.writeFileSync(
+      path.join(emsDir, `${BACKLOG_UID}.md`),
+      md({ exo__Asset_uid: BACKLOG_UID, exo__Asset_label: "ems__EffortStatusBacklog" }),
+    );
+    fs.writeFileSync(
+      path.join(emsDir, `${DRAFT_UID}.md`),
+      md({ exo__Asset_uid: DRAFT_UID, exo__Asset_label: "ems__EffortStatusDraft" }),
+    );
+    // ExoAssistant identity (createdBy default target).
+    fs.writeFileSync(
+      path.join(emsDir, `${EXOASSISTANT_UID}.md`),
+      md({ exo__Asset_uid: EXOASSISTANT_UID, exo__Asset_label: "ExoAssistant" }),
+    );
+
+    fs.mkdirSync(path.join(vault, "01 Inbox"), { recursive: true });
+
+    stdoutChunks = [];
+    exitCodes = [];
+    exitSpy = jest
+      .spyOn(process, "exit")
+      .mockImplementation(((code?: number) => {
+        exitCodes.push(code ?? 0);
+        return undefined as never;
+      }) as never);
+    stdoutSpy = jest
+      .spyOn(process.stdout, "write")
+      .mockImplementation(((chunk: unknown) => {
+        stdoutChunks.push(String(chunk));
+        return true;
+      }) as never);
+    stderrSpy = jest
+      .spyOn(process.stderr, "write")
+      .mockImplementation((() => true) as never);
+    logSpy = jest.spyOn(console, "log").mockImplementation(() => {});
+    errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    exitSpy.mockRestore();
+    stdoutSpy.mockRestore();
+    stderrSpy.mockRestore();
+    logSpy.mockRestore();
+    errorSpy.mockRestore();
+    fs.rmSync(vault, { recursive: true, force: true });
+  });
+
+  /** Run the real create command; returns parsed JSON + on-disk content. */
+  async function runCreate(
+    classUid: string,
+    extraArgs: string[],
+  ): Promise<{ uuid: string; path: string; content: string; exit: number[] }> {
+    const cmd = createCommand();
+    const argv = [
+      "--class",
+      classUid,
+      "--label",
+      "E2E-3849 status defaults",
+      "--vault",
+      vault,
+      ...extraArgs,
+    ];
+    await cmd.parseAsync(argv, { from: "user" });
+
+    const json = stdoutChunks.join("").trim();
+    if (!json) {
+      return { uuid: "", path: "", content: "", exit: [...exitCodes] };
+    }
+    const parsed = JSON.parse(json) as { uuid: string; path: string };
+    const content = fs.readFileSync(path.join(vault, parsed.path), "utf-8");
+    return { uuid: parsed.uuid, path: parsed.path, content, exit: [...exitCodes] };
+  }
+
+  it("status-bearing class → default Backlog + createdBy ExoAssistant @req:b341020e-8f27-452b-9df6-da4247408b2e", async () => {
+    const out = await runCreate(TASK_CLASS_UID, []);
+
+    expect(out.exit).toContain(0);
+    expect(out.exit).not.toContain(1);
+    // Default status = Backlog (scalar UID-canon wikilink).
+    expect(out.content).toContain(`ems__Effort_status: "[[${BACKLOG_UID}]]"`);
+    // Default creator = ExoAssistant.
+    expect(out.content).toContain(`exo__Asset_createdBy: "[[${EXOASSISTANT_UID}]]"`);
+  });
+
+  it("--status Draft → Draft status (status-bearing) @req:b341020e-8f27-452b-9df6-da4247408b2e", async () => {
+    const out = await runCreate(TASK_CLASS_UID, ["--status", "Draft"]);
+
+    expect(out.exit).toContain(0);
+    expect(out.content).toContain(`ems__Effort_status: "[[${DRAFT_UID}]]"`);
+    // The default Backlog must NOT also appear.
+    expect(out.content).not.toContain(BACKLOG_UID);
+  });
+
+  it("non-status-bearing class → no status, still createdBy @req:b341020e-8f27-452b-9df6-da4247408b2e", async () => {
+    const out = await runCreate(CONCEPT_CLASS_UID, []);
+
+    expect(out.exit).toContain(0);
+    expect(out.content).not.toContain("ems__Effort_status");
+    // createdBy default applies to every class (not status-gated).
+    expect(out.content).toContain(`exo__Asset_createdBy: "[[${EXOASSISTANT_UID}]]"`);
+  });
+
+  it("--status on a non-status-bearing class → fail-loud error @req:b341020e-8f27-452b-9df6-da4247408b2e", async () => {
+    const out = await runCreate(CONCEPT_CLASS_UID, ["--status", "Draft"]);
+
+    // The command handles the error via ErrorHandler → exit(1), no success JSON.
+    expect(out.uuid).toBe("");
+    expect(out.exit).toContain(1);
+    const stderrLog = errorSpy.mock.calls.flat().join("\n");
+    expect(stderrLog).toMatch(/status.bearing/i);
+  });
+
+  it("--created-by <uid> overrides the ExoAssistant default @req:b341020e-8f27-452b-9df6-da4247408b2e", async () => {
+    const customCreator = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+    const out = await runCreate(CONCEPT_CLASS_UID, ["--created-by", customCreator]);
+
+    expect(out.exit).toContain(0);
+    expect(out.content).toContain(`exo__Asset_createdBy: "[[${customCreator}]]"`);
+    expect(out.content).not.toContain(EXOASSISTANT_UID);
+  });
+
+  it("--yes is accepted (no 'unknown option'; create succeeds) @req:b341020e-8f27-452b-9df6-da4247408b2e", async () => {
+    const out = await runCreate(CONCEPT_CLASS_UID, ["--yes"]);
+
+    expect(out.exit).toContain(0);
+    expect(out.exit).not.toContain(1);
+    expect(out.uuid).not.toBe("");
+  });
+
+  it("explicit --property ems__Effort_status wins over the default @req:b341020e-8f27-452b-9df6-da4247408b2e", async () => {
+    const out = await runCreate(TASK_CLASS_UID, [
+      "--property",
+      `ems__Effort_status=[[${DRAFT_UID}]]`,
+      "--skip-wikilink-validation",
+    ]);
+
+    expect(out.exit).toContain(0);
+    expect(out.content).toContain(`ems__Effort_status: "[[${DRAFT_UID}]]"`);
+    // The Backlog default must NOT override an explicit value.
+    expect(out.content).not.toContain(BACKLOG_UID);
+  });
+
+  it("--status conflicts with --property ems__Effort_status → error @req:b341020e-8f27-452b-9df6-da4247408b2e", async () => {
+    const out = await runCreate(TASK_CLASS_UID, [
+      "--status",
+      "Draft",
+      "--property",
+      `ems__Effort_status=[[${DRAFT_UID}]]`,
+      "--skip-wikilink-validation",
+    ]);
+
+    expect(out.uuid).toBe("");
+    expect(out.exit).toContain(1);
+    const stderrLog = errorSpy.mock.calls.flat().join("\n");
+    expect(stderrLog).toMatch(/both --status and --property/i);
+  });
+});

--- a/packages/cli/tests/unit/commands/create.test.ts
+++ b/packages/cli/tests/unit/commands/create.test.ts
@@ -195,8 +195,22 @@ describe("Issue #2333: create command", () => {
     expect(option!.mandatory).toBeFalsy();
   });
 
-  it("should register exactly 11 options", () => {
+  it("should have optional --status option (issue #3849)", () => {
     const cmd = createCommand();
-    expect(cmd.options).toHaveLength(11);
+    const option = cmd.options.find((opt) => opt.long === "--status");
+    expect(option).toBeDefined();
+    expect(option!.mandatory).toBeFalsy();
+  });
+
+  it("should have optional --yes flag (issue #3849)", () => {
+    const cmd = createCommand();
+    const option = cmd.options.find((opt) => opt.long === "--yes");
+    expect(option).toBeDefined();
+    expect(option!.mandatory).toBeFalsy();
+  });
+
+  it("should register exactly 13 options", () => {
+    const cmd = createCommand();
+    expect(cmd.options).toHaveLength(13);
   });
 });


### PR DESCRIPTION
## Summary

Closes #3849 (re-scoped remaining work). `exocortex create` now sets sensible
default metadata for status-bearing classes so a fresh `ems__Task`/`ems__Project`
no longer needs the undocumented two-step `apply set-draft-status → apply move-to-backlog`
chain just to reach the default `Backlog` status.

- **Default `ems__Effort_status` = Backlog** for a **status-bearing** class (`ems__Effort`
  or any subclass). Status-bearing is detected by **walking `exo__Class_superClass` to
  `ems__Effort`** (no hardcoded class list — verify-before-assert). Non-status-bearing
  classes (concept/lit/…) never get a status.
- **`--status <name>`** overrides the default (name → `ems__EffortStatus<Name>` enum
  asset). Passing `--status` to a non-status-bearing class is a **fail-loud error**.
- **Default `exo__Asset_createdBy` = ExoAssistant** (`4ef3962d-…`) when `--created-by`
  is omitted — making the pre-existing `--created-by` "(defaults to ExoAssistant)"
  help text truthful.
- **`--yes`** flag accepted (no-op; `create` is non-interactive) for symmetry with the
  `apply` subcommands, so `create … --yes` no longer errors with `unknown option '--yes'`.

Precedence: an explicit `--property ems__Effort_status=…` always wins (and conflicts
with `--status`). The default Backlog is **fail-open** — a vault without the status
enums mounted keeps the historical no-status behaviour rather than failing the create.

## Scope / design

**CLI-only** (`packages/cli`): new `EffortStatusResolver` (hierarchy walk + status-name→UID
resolution over the vault TBox) + `create.ts`. The bare `exocortex create` verb bypasses
homoiconic groundings (homoiconic-gap-triage), so its set-time defaults are an engine
concern (Homoiconicity Invariant Q3). The core `GenericAssetCreationService` is **unchanged**,
so the plugin / `apply` / grounding paths stay **byte-identical** (they have their own
PropertyDefault / grounding mechanisms). `exo__Asset_updatedAt` is already set on create
(#3854/#3855) and is out of scope (audit-confirmed against origin/main).

## Requirement (feature-sdd, RFC 0003)

`Req: b341020e-8f27-452b-9df6-da4247408b2e` — [exoas-exo-reqs](https://github.com/kitelev/exoas-exo-reqs/blob/main/exo-reqs/b341020e-8f27-452b-9df6-da4247408b2e.md) (Approved; flips → Active on merge).

## Verification

**Revert-verified** (`@req:b341020e-8f27-452b-9df6-da4247408b2e`,
`packages/cli/tests/integration/create-status-defaults.integration.test.ts` — drives the
REAL `createCommand()` end-to-end against a temp fixture vault, reads the written file back
from disk): Edit-breaking the status/createdBy default injection in `create.ts` makes the
status-bearing / `--status Draft` / createdBy assertions go **RED (3 of 8)**; restored →
**GREEN (8/8)**. The 5 negative-control/error/override cases (non-status-bearing → no status,
`--status` on non-status-bearing → error, `--created-by` override, `--yes`, explicit
`--property` wins, conflict) stay **GREEN** under the revert — clean isolation, non-vacuity.

- New integration suite: 8/8 GREEN.
- `create.test.ts` option count 11 → 13 (additive; `--status`, `--yes`).
- `npm run check:types` → 0 errors.
- Lint-job guards (`validate-shard-assignments`, `check-test-antipatterns` 55/55, `check-coverage-monotonic`) → pass.
- Full `packages/cli` suite: 950 passed (1 unrelated `exosync-sync` flake — 17/17 in isolation, does not import the changed code).
