### PR TITLE
fix(sync): converge phantom-watermark rename-with-conflicting-edit (#3835, #3886)

### DIFF
--- a/packages/core/src/services/sync/SyncEngine.ts
+++ b/packages/core/src/services/sync/SyncEngine.ts
@@ -3685,19 +3685,33 @@ export class SyncEngine {
           r.path === local.basePath
         ) {
           // Convergent rename (A2 deferred MEDIUM): both sides renamed
-          // basePath → path. The remote delete of the OLD path is only
-          // convergent when the remote also carries the SAME content at the
-          // NEW path — anything weaker (a genuine remote delete, or a rename
-          // with an edit) must keep conflicting: silently consuming it would
-          // let the next sync push the renamed copy and resurrect a
-          // remotely-deleted asset.
+          // basePath → path. The remote delete of the OLD path is convergent
+          // whenever the remote also carries the SAME asset at the NEW path —
+          // either byte-identical content (`blobSha === local.blobSha`), OR the
+          // same uid with a content divergence (#3835). In BOTH cases the asset
+          // exists at the new path on both sides, so the old-path delete is the
+          // rename's own convergent old-path drop, NOT a delete-of-the-asset —
+          // consuming it cannot resurrect anything. The content divergence at
+          // the new path (if any) then stands as the SINGLE real conflict, which
+          // converges (keep-local push) or registers a normal single-remote
+          // quarantine. The strict `blobSha === local.blobSha`-only guard left a
+          // rename-with-conflicting-edit's old-path delete conflicting →
+          // `group.remotes.length === 2` → "ambiguous conflict: local change
+          // overlaps 2 remote changes" pinned WITHOUT registering in
+          // `quarantine list` — the unresolvable #3835 loop. Resurrection is
+          // still barred: a GENUINE remote delete-of-the-asset carries NO change
+          // at the new path (`remoteAtNewPath === undefined`) or a DIFFERENT uid
+          // there, so neither branch below fires and the old-path delete keeps
+          // conflicting (surfaced for the merge/quarantine layer to arbitrate).
           const remoteAtNewPath = remoteByPath.get(local.path);
           if (
             remoteAtNewPath !== undefined &&
             remoteAtNewPath.kind === "change" &&
-            remoteAtNewPath.blobSha === local.blobSha
+            (remoteAtNewPath.blobSha === local.blobSha ||
+              (remoteAtNewPath.uid !== undefined &&
+                remoteAtNewPath.uid === local.uid))
           ) {
-            consumed.add(r); // old path gone on both sides
+            consumed.add(r); // old path gone on both sides — asset moved on both
             continue;
           }
         }

--- a/packages/core/tests/unit/services/sync/SyncEngine.phantom-rename-sync.test.ts
+++ b/packages/core/tests/unit/services/sync/SyncEngine.phantom-rename-sync.test.ts
@@ -1,0 +1,204 @@
+/**
+ * ExoSync phantom-watermark re-derive loop — sync()-level convergence
+ * (Issue #3835 corrected root cause + Issue #3886 downstream coverage).
+ *
+ * The live loop on `vault-exodev`/`exoas-shared-private` asset `617d340c`
+ * (folder-anchor `$shared-private-assets/to-tbank`) is NOT an unrelated
+ * cross-path delete (the shape PR #3885 guarded — `r.path !== local.basePath`).
+ * It is a **uid-matched RENAME whose old (tmp) path was deleted on the remote
+ * while the new path was edited on both sides with divergent content**:
+ *
+ *   base (watermark): asset uid at the dead `tmp-to-tbank` path
+ *   local disk:       asset uid at `to-tbank`, WITH the correct trailing `#`
+ *   remote head:      asset uid at `to-tbank`, WITHOUT the `#`, `tmp-to-tbank` gone
+ *
+ * `detectChanges` derives a local RENAME `tmp-to-tbank → to-tbank`
+ * (`local.basePath === tmp-to-tbank`); `collectRemoteChanges` emits a remote
+ * CHANGE at `to-tbank` (no-`#`) plus a remote DELETE of `tmp-to-tbank`. The
+ * remote delete of the OLD path is the rename's OWN old-path delete — but the
+ * convergent-rename branch consumed it ONLY when the remote carried *identical*
+ * content at the new path (`blobSha === local.blobSha`). Here both sides moved
+ * to `to-tbank` with DIFFERENT content (the `#` divergence) → the delete stayed
+ * conflicting → `group.remotes.length === 2` → "ambiguous conflict: local change
+ * overlaps 2 remote changes" → pinned to re-derive WITHOUT registering in
+ * `quarantine list` → an unresolvable loop (deterministic across sessions).
+ *
+ * The #3885 method-level test used a PLAIN local edit (no `basePath`), so it
+ * exercised a shape that never reproduces the live rename — which is exactly
+ * why the shipped v16.184.1 guard missed. These tests drive the REAL
+ * `SyncEngine.sync()` derivation (bootstrap → diverge via a real remote commit
+ * + real local file ops → `detectChanges`/`collectRemoteChanges` produce the
+ * rename+delete themselves), asserting the user-visible downstream: the loop
+ * CONVERGES (keep-local push) after the fix, and stays a 2-remote ambiguous pin
+ * before it.
+ */
+
+import { SyncEngine, type MergeLayerPort } from "../../../../src";
+import {
+  FakeGitHubRepo,
+  FakeLocalFiles,
+  FakeWatermarkStore,
+  alwaysMaterialized,
+  mdAsset,
+  sha1Hex,
+} from "./fakeGitHub";
+import type { SyncEngineDeps, SyncRepoSpec } from "../../../../src";
+
+/** Keep-local resolver: the divergence is cosmetic, local is authoritative. */
+const keepLocalMerger: MergeLayerPort = {
+  resolve: async (input) => ({
+    action: "use-merged",
+    content: input.local ?? "",
+  }),
+};
+
+/** Quarantine-everything resolver: a 1-remote conflict registers (not merged). */
+const quarantineAllMerger: MergeLayerPort = {
+  resolve: async () => ({
+    action: "quarantine",
+    reason: "test: always quarantine",
+  }),
+};
+
+function makeEngine(
+  gh: FakeGitHubRepo,
+  local: FakeLocalFiles,
+  overrides: Partial<SyncEngineDeps> = {},
+): { engine: SyncEngine; watermarks: FakeWatermarkStore } {
+  const watermarks = new FakeWatermarkStore();
+  const engine = new SyncEngine({
+    transport: gh.transport(),
+    watermarkStore: watermarks,
+    materializationCheck: alwaysMaterialized(),
+    localFilesFor: () => local,
+    sha1: sha1Hex,
+    ...overrides,
+  });
+  return { engine, watermarks };
+}
+
+async function bootstrap(engine: SyncEngine, spec: SyncRepoSpec): Promise<void> {
+  const result = await engine.sync(spec);
+  expect(result.status).toBe("synced");
+}
+
+const UID = "617d340c-abc7-4cb3-824d-ef97b70e9943";
+// Dead tmp/transient path — present only in the stale watermark base.
+const PHANTOM = "shared-private-assets/tmp-to-tbank/617d340c.md";
+// Live folder-anchor path — carries the correct trailing `#` locally.
+const REAL = "shared-private-assets/to-tbank/617d340c.md";
+
+// Same asset, divergent `exo__Ontology_url` bodies (the `#` is the divergence).
+const BASE_AT_TMP = mdAsset(UID, "url: .../tmp-to-tbank");
+const LOCAL_HASH = mdAsset(UID, "url: .../to-tbank#");
+const REMOTE_NOHASH = mdAsset(UID, "url: .../to-tbank");
+
+describe("SyncEngine.sync() — #3835 phantom-watermark rename-with-conflicting-edit converges (real derivation)", () => {
+  it("converges keep-local (pushes the `#`) — NOT an ambiguous 2-remote re-derive pin", async () => {
+    const gh = new FakeGitHubRepo({ [PHANTOM]: BASE_AT_TMP });
+    const local = new FakeLocalFiles({ [PHANTOM]: BASE_AT_TMP });
+    const { engine, watermarks } = makeEngine(gh, local, {
+      mergeLayer: keepLocalMerger,
+    });
+    await bootstrap(engine, gh.spec());
+
+    // Watermark base now carries the asset at the (soon-to-be-dead) tmp path —
+    // the exact stale-base precondition, produced by a REAL sync, not injected.
+    expect(
+      watermarks.records.get(gh.spec().repoKey)!.files.map((f) => f.path),
+    ).toEqual([PHANTOM]);
+
+    // Remote (device B): rename tmp → to-tbank with the no-`#` content; drop tmp.
+    gh.commitDirect(
+      "main",
+      { [REAL]: REMOTE_NOHASH },
+      "device B: rename tmp→to-tbank (no #)",
+      [PHANTOM],
+    );
+    // Local: rename tmp → to-tbank with the `#` content.
+    local.files.delete(PHANTOM);
+    local.files.set(REAL, LOCAL_HASH);
+
+    const result = await engine.sync(gh.spec());
+
+    // FIX: the tmp delete is the rename's OWN old-path delete AND the asset
+    // exists at the new path on BOTH sides (same uid) → convergent, dropped →
+    // the group collapses to the single new-path content conflict → keep-local
+    // merge pushes the `#`. Reverting the fix leaves remotes.length === 2 →
+    // "ambiguous conflict ... 2 remote changes" → nothing merged, `#` never
+    // converges (the live #3835 loop).
+    expect(result.status).toBe("synced");
+    expect(result.warnings.join(" ")).not.toMatch(/ambiguous conflict/);
+    expect(result.quarantinedCount).toBe(0);
+    expect(result.mergedPaths ?? []).toContain(REAL);
+    // The `#` reached the remote HEAD — the correct local change converged.
+    expect(gh.headFiles().get(REAL)).toBe(LOCAL_HASH);
+    // The dead tmp path is gone on the remote (never resurrected).
+    expect(gh.headFiles().has(PHANTOM)).toBe(false);
+
+    // And it does NOT loop: the next sync is a clean no-op (watermark converged).
+    const next = await engine.sync(gh.spec());
+    expect(next.status).toBe("synced");
+    expect(next.quarantinedCount).toBe(0);
+    expect(next.pushedSha).toBeUndefined();
+    expect(next.warnings).toEqual([]);
+  });
+
+  it("registers a single-remote quarantine (resolvable) when the merge layer declines — not the unregistered 2-remote pin", async () => {
+    const gh = new FakeGitHubRepo({ [PHANTOM]: BASE_AT_TMP });
+    const local = new FakeLocalFiles({ [PHANTOM]: BASE_AT_TMP });
+    const { engine } = makeEngine(gh, local, {
+      mergeLayer: quarantineAllMerger,
+    });
+    await bootstrap(engine, gh.spec());
+
+    gh.commitDirect(
+      "main",
+      { [REAL]: REMOTE_NOHASH },
+      "device B: rename tmp→to-tbank (no #)",
+      [PHANTOM],
+    );
+    local.files.delete(PHANTOM);
+    local.files.set(REAL, LOCAL_HASH);
+
+    const result = await engine.sync(gh.spec());
+
+    // With the fix the group is a NORMAL single-remote conflict → it registers
+    // as one quarantine entry on the LIVE path (`exosync quarantine list` shows
+    // it → `--take local` is applicable). Before the fix it was the
+    // "ambiguous conflict ... 2 remote changes" pin instead.
+    expect(result.status).toBe("synced");
+    expect(result.warnings.join(" ")).not.toMatch(/ambiguous conflict/);
+    expect(result.quarantinedCount).toBe(1);
+    expect(result.quarantinedPaths ?? []).toEqual([REAL]);
+  });
+
+  it("negative control: a GENUINE remote delete of the asset (no remote copy at the new path) keeps conflicting → NOT silently resurrected", async () => {
+    const OLD = "assets/old.md";
+    const NEW = "assets/new.md";
+    const KEEP = "assets/keep.md"; // survives so the remote tree is never empty
+    const BASE = mdAsset(UID, "base at old path");
+    const gh = new FakeGitHubRepo({ [OLD]: BASE, [KEEP]: mdAsset("keep") });
+    const local = new FakeLocalFiles({ [OLD]: BASE, [KEEP]: mdAsset("keep") });
+    const { engine } = makeEngine(gh, local, {
+      mergeLayer: quarantineAllMerger,
+    });
+    await bootstrap(engine, gh.spec());
+
+    // Remote genuinely deletes the asset (both old AND new absent remotely).
+    gh.commitDirect("main", {}, "device B: delete the asset entirely", [OLD]);
+    // Local renames old → new (still wants the asset, just moved).
+    local.files.delete(OLD);
+    local.files.set(NEW, mdAsset(UID, "local rename"));
+
+    const result = await engine.sync(gh.spec());
+
+    // The remote carries NO change at NEW (it deleted the asset) →
+    // `remoteAtNewPath` is undefined → the old-path delete stays conflicting
+    // (unchanged by the fix, which only relaxes the SAME-uid-at-new-path case).
+    // With a quarantining merge layer the rename is NOT pushed → no resurrection.
+    expect(result.status).toBe("synced");
+    expect(gh.headFiles().has(NEW)).toBe(false); // asset NOT resurrected
+    expect(result.quarantinedCount).toBeGreaterThanOrEqual(1);
+  });
+});


### PR DESCRIPTION
## Summary
Fixes the ExoSync phantom-watermark re-derive loop (**#3835**) and adds the sync()-level test-gate (**#3886**). Closes #3835, closes #3886.

The live loop on `vault-exodev`/`exoas-shared-private` asset `617d340c` (folder-anchor `$shared-private-assets/to-tbank`) prints `quarantined 1` + `ambiguous conflict: local change overlaps 2 remote changes (to-tbank/617d340c.md, tmp-to-tbank/617d340c.md)` on every `exosync sync`, while `quarantine list` stays empty (an unregistered pin → `quarantine resolve` inapplicable). The `tmp-to-tbank` path is a phantom (404 remote, absent locally). The correct local `#` edit never converges.

## ⛔ PR #3885 (v16.184.1) missed the real shape
#3885 guarded an **unrelated cross-path DELETE** (`r.path !== local.basePath`). Live-smoke of the shipped v16.184.1 still reproduced the loop.

## Corrected root cause
It is a **uid-matched RENAME with a conflicting edit**:
- watermark base carries the uid at the dead `tmp-to-tbank` path;
- local disk carries it at `to-tbank` **with** the `#` → `detectChanges` emits a local **RENAME** (`local.basePath === tmp-to-tbank`);
- remote carries `to-tbank` **without** the `#` and dropped `tmp-to-tbank` → a remote **CHANGE**@`to-tbank` + a remote **DELETE**@`tmp-to-tbank`.

`matchLocalVsRemote`'s convergent-rename branch consumed the old-path delete **only** when the remote carried *byte-identical* content at the new path (`blobSha === local.blobSha`). With the `#` divergence content differs → the delete stays conflicting → `group.remotes.length === 2` → the ambiguous pin. The #3885 guard's `r.path !== local.basePath` **structurally excludes** this shape (the phantom delete *is* the rename base).

## Fix
Relax the convergent-rename old-path-delete consumption: also consume when the remote carries a CHANGE at the new path with the **same uid** (any content). Then the asset exists at the new path on **both** sides → the old-path delete is the rename's own convergent drop, not a delete-of-the-asset → **no resurrection risk**. The content divergence at the new path becomes the **single** real conflict → converges (keep-local push) or registers a normal single-remote quarantine (`quarantine list` shows it → `--take local` applies).

Resurrection stays barred: a **genuine** remote delete-of-the-asset carries no same-uid change at the new path (`remoteAtNewPath === undefined` or a different uid) → the old-path delete keeps conflicting. The strict `blobSha` branch is retained (identical-content convergent rename); the #3885 guard is retained (unrelated dead cross-path delete).

30-line diff, one method (`SyncEngine.matchLocalVsRemote`), one added condition.

## Test-gate (#3886) — REAL sync() derivation
`SyncEngine.phantom-rename-sync.test.ts` drives the public `SyncEngine.sync()`: bootstrap with the asset at `tmp-to-tbank` → diverge via a **real remote commit** (rename → `to-tbank` no-`#`, drop `tmp`) + **real local rename** (→ `to-tbank` with `#`) → `detectChanges`/`collectRemoteChanges` produce the rename+delete themselves. This is **not** hand-built `RemoteChange[]` (the shape #3885's method-level test misrepresented — which is why it passed while the live case broke).

**Revert-verify (empirical):**
- **RED** (fix reverted): the exact live message reproduces — `ambiguous conflict ... overlaps 2 remote changes (to-tbank/617d340c.md, tmp-to-tbank/617d340c.md)` + `pinned to re-derive on the next sync (#3477)`; the `#` never converges.
- **GREEN** (fix applied): converges keep-local — the `#` reaches the remote HEAD, `quarantinedCount 0`, no ambiguous warning; the next sync is a clean no-op (no loop). A second variant asserts the single-remote quarantine registers on the live path when the merge layer declines.
- **Negative control:** a genuine remote delete-of-the-asset (no same-uid copy at the new path) keeps conflicting → **not** silently resurrected.

## Regression
Full sync suite **439 passed / 4 skipped, 35 suites** — zero regression. The #3885 `SyncEngine.phantom-watermark.test.ts` coexists (both guards handle different shapes). `tsc --noEmit` clean; 3 CI `lint` guard scripts pass.

## Note on the live `617d340c` converge
This fix unblocks the `#`-converge on the live shared-private asset (a real remote mutation), which will be applied under supervision (backup + confirm) — not part of this code PR's CI/merge.

Bug: `ems__Bug 83bf8904` (vault-exodev)
