### PR TITLE
feat(cli): generic guarded `set-property` primitive + isDefinedBy repoint (#3795, #3848)

### DIFF
--- a/packages/cli/src/commands/set-property.ts
+++ b/packages/cli/src/commands/set-property.ts
@@ -33,28 +33,50 @@ const ISDEFINEDBY_KEY = "exo__Asset_isDefinedBy";
  * Properties `set-property` REFUSES because a dedicated guarded `exocmd__Command`
  * owns them — each enforces a state-machine transition or a precondition guard,
  * so setting the property directly would bypass that guard. The value is the
- * dedicated command to use instead (issue #3795 AC — "status/zone/parent/label
- * keep their dedicated guarded commands"). The status-transition FACT timestamps
- * (start/end/resolution) are included because they are set ONLY as side effects
- * of status transitions — writing one directly desyncs the status state machine.
+ * dedicated command to use instead. This is a SUPERSET of the `dogfood-cli-mutation`
+ * hook's routing table: every property that has a dedicated command is refused
+ * here and routed to that command, so `set-property` only ever handles the
+ * "everything else" class the hook leaves to it.
  *
- * NOT guarded (so `set-property` handles them — the "everything else" class):
- * plan/scheduled dates (plain user plans, not a state machine — their
- * `set-planned-*` / `set-scheduled-date` commands are conveniences, not guards),
- * `exo__Asset_isDefinedBy` (issue #3848 — allowed, with a co-location warning),
- * and any other scalar / boolean / enum / wikilink property.
+ * NOT guarded (so `set-property` handles them): `exo__Asset_isDefinedBy` (issue
+ * #3848 — allowed, with a co-location warning), and any other scalar / boolean /
+ * enum / wikilink property with no dedicated command.
+ *
+ * Looked up via {@link guardedReason} (own-key `hasOwnProperty` check) so a
+ * user-supplied property name like `toString` / `constructor` never matches an
+ * inherited Object.prototype key (#3795 review M2).
  */
 const GUARDED_PROPERTIES: Record<string, string> = {
+  // Status state machine (transitions carry preconditions).
   ems__Effort_status:
     "apply mark-done|move-to-backlog|move-to-todo|start-effort|set-draft-status <path>",
+  // Criticality zone (not-a-prototype precondition guard).
   ems__Task_zone: "apply set-criticality-high|medium|low <path>",
+  // Parent / label — dedicated guarded commands (#3779).
   ems__Effort_parent: 'apply set-parent <path> --input \'{"parent":"<uid>"}\'',
   exo__Asset_label: 'apply set-label <path> --input \'{"label":"<text>"}\'',
+  // Reclassing — dedicated Convert commands (raw set desyncs class vs co-location).
+  exo__Instance_class:
+    "apply convert-to-task|convert-to-project <path>  (reclassing is a semantic operation with a precondition)",
+  // Status-transition FACT timestamps (set only as status-transition side effects).
   ems__Effort_startTimestamp:
     "apply start-effort <path>  (or apply remove-start-timestamp <path>)",
   ems__Effort_endTimestamp:
     "apply mark-done <path>  (or apply remove-end-timestamp <path>)",
   ems__Effort_resolutionTimestamp: "apply mark-done <path>",
+  // Plan / schedule dates — dedicated commands.
+  ems__Effort_plannedStartTimestamp:
+    "apply set-planned-start|plan-on-today|plan-for-evening|shift-day-forward|shift-day-backward <path>",
+  ems__Effort_plannedEndTimestamp: "apply set-planned-end <path>",
+  ems__Effort_scheduledDate: "apply set-scheduled-date <path>",
+  // Votes — dedicated command.
+  ems__Effort_votes: "apply vote-on-effort <path>",
+  // Archive flag (bare `archived:` in frontmatter; `exo__Asset_archived` when
+  // prefixed) — dedicated archive/un-archive commands (un-archive has a Done
+  // precondition).
+  archived: "apply archive-completed|archive-ontologically|un-archive <path>",
+  exo__Asset_archived:
+    "apply archive-completed|archive-ontologically|un-archive <path>",
 };
 
 /**
@@ -67,6 +89,38 @@ const IMMUTABLE_PROPERTIES: Record<string, string> = {
   [UPDATED_AT_KEY]:
     "auto-managed by set-property (bumped on every mutation)",
 };
+
+/** Own-key lookup on a denylist that never matches inherited Object.prototype keys. */
+function guardedReason(
+  denylist: Record<string, string>,
+  property: string,
+): string | undefined {
+  return Object.prototype.hasOwnProperty.call(denylist, property)
+    ? denylist[property]
+    : undefined;
+}
+
+/**
+ * A settable value must be a scalar (string / number / boolean) or an array of
+ * scalars. A nested object would serialise to the literal `[object Object]`
+ * (silent corruption) and `null` is ambiguous with "unset" — reject both
+ * fail-loud (#3795 review M1).
+ */
+function assertScalarOrScalarArray(value: unknown): void {
+  const isScalar = (v: unknown): boolean =>
+    typeof v === "string" || typeof v === "number" || typeof v === "boolean";
+  if (isScalar(value)) return;
+  if (Array.isArray(value) && value.every(isScalar)) return;
+  const kind =
+    value === null
+      ? "null"
+      : Array.isArray(value)
+        ? "an array with non-scalar elements"
+        : typeof value;
+  throw new Error(
+    `--input.value must be a scalar (string/number/boolean) or an array of scalars, not ${kind}`,
+  );
+}
 
 interface SetPropertyOptions {
   vault: string;
@@ -266,16 +320,21 @@ export function setPropertyCommand(): Command {
         const property = FrontmatterService.normalizeIRI(rawProperty);
 
         // ── Guards (checked BEFORE any write → the file is untouched on a refusal) ──
-        if (property in IMMUTABLE_PROPERTIES) {
+        const immutableReason = guardedReason(IMMUTABLE_PROPERTIES, property);
+        if (immutableReason !== undefined) {
           throw new Error(
-            `Refusing to set "${property}" — ${IMMUTABLE_PROPERTIES[property]}.`,
+            `Refusing to set "${property}" — ${immutableReason}.`,
           );
         }
-        if (property in GUARDED_PROPERTIES) {
+        const guardedCommand = guardedReason(GUARDED_PROPERTIES, property);
+        if (guardedCommand !== undefined) {
           throw new Error(
-            `Refusing to set "${property}" via set-property — it has a dedicated guarded command so the state machine / precondition is not bypassed. Use:  exocortex ${GUARDED_PROPERTIES[property]} --vault <v>`,
+            `Refusing to set "${property}" via set-property — it has a dedicated guarded command so the state machine / precondition is not bypassed. Use:  exocortex ${guardedCommand} --vault <v>`,
           );
         }
+
+        // Reject a non-scalar / non-scalar-array value (fail-loud, #3795 review M1).
+        assertScalarOrScalarArray(value);
 
         // Wikilink existence validation — the CLI/Bash write path bypasses the
         // PreToolUse validate-wikilinks hook, so validate here like `create`.

--- a/packages/cli/src/commands/set-property.ts
+++ b/packages/cli/src/commands/set-property.ts
@@ -1,0 +1,356 @@
+import { Command } from "commander";
+import {
+  resolve,
+  relative,
+  dirname,
+  isAbsolute,
+  sep as pathSep,
+} from "path";
+import { existsSync, readFileSync, writeFileSync } from "fs";
+import {
+  FrontmatterService,
+  serializeYamlScalar,
+} from "@kitelev/exocortex-core";
+import { NodeFsAdapter } from "../adapters/NodeFsAdapter.js";
+import { WikilinkValidator } from "../services/WikilinkValidator.js";
+import { ErrorHandler } from "../utils/ErrorHandler.js";
+import {
+  VaultNotFoundError,
+  InvalidArgumentsError,
+} from "../utils/errors/index.js";
+import { resolveCoLocationFolder } from "../executors/folderRepairHelpers.js";
+
+/**
+ * Default timezone for the `exo__Asset_updatedAt` bump. Matches `cli create`'s
+ * Asia/Almaty default; overridable with `--timezone`.
+ */
+const DEFAULT_TIMEZONE = "Asia/Almaty";
+
+const UPDATED_AT_KEY = "exo__Asset_updatedAt";
+const ISDEFINEDBY_KEY = "exo__Asset_isDefinedBy";
+
+/**
+ * Properties `set-property` REFUSES because a dedicated guarded `exocmd__Command`
+ * owns them — each enforces a state-machine transition or a precondition guard,
+ * so setting the property directly would bypass that guard. The value is the
+ * dedicated command to use instead (issue #3795 AC — "status/zone/parent/label
+ * keep their dedicated guarded commands"). The status-transition FACT timestamps
+ * (start/end/resolution) are included because they are set ONLY as side effects
+ * of status transitions — writing one directly desyncs the status state machine.
+ *
+ * NOT guarded (so `set-property` handles them — the "everything else" class):
+ * plan/scheduled dates (plain user plans, not a state machine — their
+ * `set-planned-*` / `set-scheduled-date` commands are conveniences, not guards),
+ * `exo__Asset_isDefinedBy` (issue #3848 — allowed, with a co-location warning),
+ * and any other scalar / boolean / enum / wikilink property.
+ */
+const GUARDED_PROPERTIES: Record<string, string> = {
+  ems__Effort_status:
+    "apply mark-done|move-to-backlog|move-to-todo|start-effort|set-draft-status <path>",
+  ems__Task_zone: "apply set-criticality-high|medium|low <path>",
+  ems__Effort_parent: 'apply set-parent <path> --input \'{"parent":"<uid>"}\'',
+  exo__Asset_label: 'apply set-label <path> --input \'{"label":"<text>"}\'',
+  ems__Effort_startTimestamp:
+    "apply start-effort <path>  (or apply remove-start-timestamp <path>)",
+  ems__Effort_endTimestamp:
+    "apply mark-done <path>  (or apply remove-end-timestamp <path>)",
+  ems__Effort_resolutionTimestamp: "apply mark-done <path>",
+};
+
+/**
+ * Properties `set-property` REFUSES as immutable identity / self-managed. The
+ * value is the reason surfaced to the user.
+ */
+const IMMUTABLE_PROPERTIES: Record<string, string> = {
+  exo__Asset_uid:
+    "the asset identity — changing it breaks UID-canon filenames and every inbound [[uid]] wikilink",
+  [UPDATED_AT_KEY]:
+    "auto-managed by set-property (bumped on every mutation)",
+};
+
+interface SetPropertyOptions {
+  vault: string;
+  input?: string;
+  property?: string;
+  value?: string;
+  skipWikilinkValidation?: boolean;
+  timezone?: string;
+  frozenClock?: string;
+  dryRun?: boolean;
+  yes?: boolean;
+}
+
+/**
+ * Render `YYYY-MM-DDTHH:MM:SS` for the given instant in `timezone`. Uses
+ * `Intl.DateTimeFormat` with an explicit `timeZone`, so the result is
+ * deterministic regardless of the runner's local timezone (mirrors
+ * `GenericAssetCreationService.generateTimestampInTimezone`).
+ */
+function stampTimestamp(now: Date, timezone: string): string {
+  const formatter = new Intl.DateTimeFormat("en-CA", {
+    timeZone: timezone,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+    hour12: false,
+  });
+  const parts = formatter.formatToParts(now);
+  const get = (type: string): string =>
+    parts.find((p) => p.type === type)?.value ?? "00";
+  return `${get("year")}-${get("month")}-${get("day")}T${get("hour")}:${get("minute")}:${get("second")}`;
+}
+
+/**
+ * Resolve the (property, value) pair from either `--input '{...}'` (JSON-typed
+ * value) or the `--property <name> --value <string>` convenience form. Mutually
+ * exclusive.
+ */
+function resolvePropertyAndValue(options: SetPropertyOptions): {
+  property: string;
+  value: unknown;
+} {
+  const hasInput = options.input !== undefined;
+  const hasProperty = options.property !== undefined;
+
+  if (hasInput && hasProperty) {
+    throw new InvalidArgumentsError(
+      "Pass --input OR --property/--value, not both.",
+      `set-property <path> --input '{"property":"<name>","value":<v>}'`,
+    );
+  }
+
+  if (hasInput) {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(options.input as string);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      throw new Error(`--input: invalid JSON (${msg})`);
+    }
+    if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+      throw new Error(
+        `--input must be a JSON object of the form {"property":"<name>","value":<v>}`,
+      );
+    }
+    const obj = parsed as Record<string, unknown>;
+    const property = obj.property;
+    if (typeof property !== "string" || property.trim().length === 0) {
+      throw new Error(`--input.property must be a non-empty string`);
+    }
+    if (!("value" in obj)) {
+      throw new Error(`--input.value is required`);
+    }
+    return { property: property.trim(), value: obj.value };
+  }
+
+  if (hasProperty) {
+    if (options.value === undefined) {
+      throw new Error(
+        `--property requires --value (or use --input for a typed/array value)`,
+      );
+    }
+    return { property: (options.property as string).trim(), value: options.value };
+  }
+
+  throw new InvalidArgumentsError(
+    "No property provided.",
+    `set-property <path> --input '{"property":"<name>","value":<v>}'  OR  set-property <path> --property <name> --value <string>`,
+  );
+}
+
+/**
+ * Pre-format a value for `FrontmatterService.updateProperty` (which writes
+ * verbatim — callers pre-format, mirroring `GroundingExecutor.executePropertySet`
+ * and the create path). `serializeYamlScalar(v, true)` keeps booleans/numbers
+ * bare, keeps ISO datetimes bare (native date type), quotes wikilinks (`[[uid]]`
+ * → `"[[uid]]"`) and any YAML-unsafe / ambiguous scalar string so a JSON string
+ * round-trips as a string.
+ */
+function serializeForWrite(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map((v) => serializeYamlScalar(v, true));
+  }
+  return serializeYamlScalar(value, true);
+}
+
+/**
+ * `exocortex set-property <path>` — a generic, guarded CLI primitive that sets an
+ * arbitrary non-guarded frontmatter property on an EXISTING vault asset, closing
+ * the recurring "I had to raw-Edit a property" dogfooding gap (issue #3795) and
+ * subsuming the `exo__Asset_isDefinedBy` repoint (issue #3848, with a co-location
+ * re-validation warning).
+ *
+ * Homoiconicity Invariant (Q1/Q3): user-configurable SEMANTICS (status state
+ * machine, criticality zones, parent/label with their preconditions) stay
+ * homoiconic and keep their dedicated `exocmd__Command` groundings — the guard
+ * here REFUSES those properties so they are not bypassed. An arbitrary
+ * scalar/boolean/enum/wikilink property is not a state machine; per Q3 this is a
+ * core-of-processing concern (a bare CLI verb, like `create`, that bypasses
+ * groundings), so a single generic primitive is the right home.
+ */
+export function setPropertyCommand(): Command {
+  return new Command("set-property")
+    .description(
+      "Set an arbitrary non-guarded frontmatter property on an existing vault asset (bumps exo__Asset_updatedAt). Refuses state-machine-guarded properties (status/zone/parent/label/fact-timestamps) — those keep their dedicated `apply` commands. Issues #3795 / #3848.",
+    )
+    .argument("<path>", "Vault-relative path to the target asset")
+    .option("--vault <path>", "Path to Obsidian vault", process.cwd())
+    .option(
+      "--input <json>",
+      'JSON {"property":"<name>","value":<v>} — value is JSON-typed (boolean/number/string/array). Primary form.',
+    )
+    .option(
+      "--property <name>",
+      "Property name (string-value convenience form; pair with --value; use --input for boolean/number/array values)",
+    )
+    .option(
+      "--value <value>",
+      "Property value as a string (pair with --property; use --input for typed/array values)",
+    )
+    .option(
+      "--skip-wikilink-validation",
+      "Skip [[...]] wikilink existence validation",
+    )
+    .option(
+      "--timezone <tz>",
+      "Timezone for the exo__Asset_updatedAt bump (defaults to Asia/Almaty)",
+    )
+    .option(
+      "--frozen-clock <iso>",
+      "Freeze the updatedAt clock to an ISO timestamp for test/replay",
+    )
+    .option("--dry-run", "Preview the resulting frontmatter without writing")
+    .option(
+      "--yes",
+      "Accepted for symmetry with the apply/create subcommands (set-property is non-interactive; no-op)",
+    )
+    .action(async (pathArg: string, options: SetPropertyOptions) => {
+      try {
+        const vaultPath = resolve(options.vault);
+        if (!existsSync(vaultPath)) {
+          throw new VaultNotFoundError(vaultPath);
+        }
+
+        // Resolve + guard the target path (must be inside the vault). Mirrors
+        // `apply`'s vault-relative canonicalisation (issue #3788).
+        const targetPath = resolve(vaultPath, pathArg);
+        if (!existsSync(targetPath)) {
+          throw new Error(`Target file not found: ${pathArg}`);
+        }
+        const vaultRelative = relative(vaultPath, targetPath);
+        if (
+          vaultRelative === ".." ||
+          vaultRelative.startsWith(`..${pathSep}`) ||
+          isAbsolute(vaultRelative)
+        ) {
+          throw new Error(
+            `Target is outside the vault: ${pathArg} (vault: ${vaultPath})`,
+          );
+        }
+
+        const original = readFileSync(targetPath, "utf-8");
+        // Only mutate a real asset (has an exo__Asset_uid). Refuse a bare
+        // markdown file so `set-property` never silently mutates a non-asset.
+        if (!/^\s*exo__Asset_uid:/m.test(original)) {
+          throw new Error(
+            `Not a vault asset (no exo__Asset_uid): ${vaultRelative}. set-property only mutates existing assets.`,
+          );
+        }
+
+        const { property: rawProperty, value } = resolvePropertyAndValue(options);
+        // Normalise a full-IRI-shaped property to prefixed form so the guard
+        // denylists (prefixed keys) still match (mirrors executePropertySet).
+        const property = FrontmatterService.normalizeIRI(rawProperty);
+
+        // ── Guards (checked BEFORE any write → the file is untouched on a refusal) ──
+        if (property in IMMUTABLE_PROPERTIES) {
+          throw new Error(
+            `Refusing to set "${property}" — ${IMMUTABLE_PROPERTIES[property]}.`,
+          );
+        }
+        if (property in GUARDED_PROPERTIES) {
+          throw new Error(
+            `Refusing to set "${property}" via set-property — it has a dedicated guarded command so the state machine / precondition is not bypassed. Use:  exocortex ${GUARDED_PROPERTIES[property]} --vault <v>`,
+          );
+        }
+
+        // Wikilink existence validation — the CLI/Bash write path bypasses the
+        // PreToolUse validate-wikilinks hook, so validate here like `create`.
+        if (!options.skipWikilinkValidation) {
+          const validator = new WikilinkValidator(new NodeFsAdapter(vaultPath));
+          const values = Array.isArray(value) ? value : [value];
+          for (const v of values) {
+            if (typeof v === "string") {
+              await validator.validateValue(v);
+            }
+          }
+        }
+
+        // Apply the property, then bump exo__Asset_updatedAt.
+        const fm = new FrontmatterService();
+        const now = options.frozenClock
+          ? new Date(options.frozenClock)
+          : new Date();
+        const timezone = options.timezone ?? DEFAULT_TIMEZONE;
+        const updatedAt = stampTimestamp(now, timezone);
+
+        let updated = fm.updateProperty(
+          original,
+          property,
+          serializeForWrite(value),
+        );
+        updated = fm.updateProperty(updated, UPDATED_AT_KEY, updatedAt);
+
+        // Issue #3848 — co-location re-validation for an isDefinedBy repoint.
+        // The repoint itself succeeds; we WARN (non-fatal) when the file was not
+        // physically moved under the new anchor's ontology folder, pointing at
+        // `apply repair-folder` (which reads the just-written isDefinedBy). The
+        // clean workflow is: set-property (repoint) → apply repair-folder (move).
+        let coLocationWarning: string | undefined;
+        if (property === ISDEFINEDBY_KEY) {
+          const anchorRef = Array.isArray(value) ? value[0] : value;
+          const coFolder = await resolveCoLocationFolder(
+            new NodeFsAdapter(vaultPath),
+            anchorRef,
+          );
+          if (coFolder !== null) {
+            const currentDir = dirname(vaultRelative);
+            const normCurrent = currentDir === "." ? "" : currentDir;
+            if (normCurrent !== coFolder) {
+              coLocationWarning =
+                `⚠ co-location: exo__Asset_isDefinedBy now points at "${coFolder || "<vault root>"}" ` +
+                `but the file is in "${normCurrent || "<vault root>"}". Move it to match:  ` +
+                `exocortex apply repair-folder ${vaultRelative} --vault <v>`;
+            }
+          }
+        }
+
+        if (options.dryRun) {
+          process.stderr.write(
+            `--- DRY RUN PREVIEW ---\n${updated}\n--- END PREVIEW ---\n`,
+          );
+        } else {
+          writeFileSync(targetPath, updated, "utf-8");
+        }
+        if (coLocationWarning) {
+          process.stderr.write(coLocationWarning + "\n");
+        }
+
+        const output = {
+          path: vaultRelative,
+          property,
+          value,
+          updatedAt,
+          ...(coLocationWarning ? { coLocationWarning: true } : {}),
+        };
+        process.stdout.write(JSON.stringify(output) + "\n");
+
+        process.exit(0);
+      } catch (error) {
+        ErrorHandler.handle(error as Error);
+      }
+    });
+}

--- a/packages/cli/src/program.ts
+++ b/packages/cli/src/program.ts
@@ -8,6 +8,7 @@ import { validateCommand } from "./commands/validate.js";
 import { classesCommand } from "./commands/classes.js";
 import { runQueryCommand } from "./commands/run-query.js";
 import { createCommand } from "./commands/create.js";
+import { setPropertyCommand } from "./commands/set-property.js";
 import { recoverCommand } from "./commands/recover.js";
 import { findCommand } from "./commands/find.js";
 import { applyCommand } from "./commands/apply.js";
@@ -64,6 +65,12 @@ export function createProgram(version?: string): Command {
   // assets).
   program.addCommand(runQueryCommand());
   program.addCommand(createCommand());
+  // Issues #3795 / #3848 — generic guarded mutation primitive: set an arbitrary
+  // non-guarded frontmatter property (incl. exo__Asset_isDefinedBy repoint) on an
+  // existing asset via the CLI, closing the "raw-Edit a property" dogfooding gap.
+  // Refuses state-machine-guarded properties (status/zone/parent/label/…) so their
+  // dedicated `apply` commands are not bypassed.
+  program.addCommand(setPropertyCommand());
   // recover — retained: live launchd consumer (com.exocortex.aitask-recover
   // hourly job calls `exocortex-cli recover --apply`). RFC 7c7859d1 reclassifies
   // it from W0 cheap-remove to migration-first (retire/port that consumer first).

--- a/packages/cli/tests/integration/set-property.integration.test.ts
+++ b/packages/cli/tests/integration/set-property.integration.test.ts
@@ -1,0 +1,357 @@
+/**
+ * Issues #3795 / #3848 — `exocortex set-property <path>` sets an arbitrary
+ * non-guarded frontmatter property on an existing asset (closing the "raw-Edit a
+ * property" dogfooding gap), including the `exo__Asset_isDefinedBy` repoint with
+ * a co-location re-validation warning — while REFUSING state-machine /
+ * precondition-guarded properties so their dedicated `apply` commands are not
+ * bypassed.
+ *
+ * Drives the REAL `setPropertyCommand()` action end-to-end against a temp fixture
+ * vault, reads the written file back from disk, and asserts on the real bytes —
+ * the production set-property pipeline (FrontmatterService.updateProperty +
+ * serializeYamlScalar + resolveCoLocationFolder), not hand-injected frontmatter
+ * (test-fixture-realism).
+ *
+ * Revert-verify (~/dotfiles/.claude/rules/integration-test-revert-verify.md) —
+ * FOUR independent axes in `set-property.ts`, each reddening exactly its own
+ * assertion when Edit-broken and GREEN when restored:
+ *   1. property write   — neutralise the first `updateProperty(...)` → the
+ *      set-value assertions RED.
+ *   2. updatedAt bump    — neutralise the second `updateProperty(UPDATED_AT_KEY)`
+ *      → the updatedAt-bump assertion RED.
+ *   3. guard             — remove the `GUARDED_PROPERTIES` / `IMMUTABLE_PROPERTIES`
+ *      refusal → the guard assertions (status/zone/parent/label/timestamp/uid)
+ *      RED (the command would write them / exit 0).
+ *   4. co-location check — neutralise the `ISDEFINEDBY_KEY` block → the
+ *      co-location-warning assertion RED.
+ * The non-guarded happy path + the negative controls isolate non-vacuity.
+ */
+import { jest, describe, it, expect, beforeEach, afterEach } from "@jest/globals";
+import * as fs from "fs";
+import * as path from "path";
+import * as os from "os";
+
+const { setPropertyCommand } = await import("../../src/commands/set-property.js");
+
+const MOVIES_DIR = "assetspaces/kitelev/exoas-my/movies";
+const OTHER_DIR = "assetspaces/kitelev/exoas-my/other";
+const TASKS_DIR = "assetspaces/kitelev/exoas-my/tasks";
+
+const ANCHOR_MOVIES = "a1a1a1a1-0000-4000-8000-000000000001";
+const ANCHOR_OTHER = "a2a2a2a2-0000-4000-8000-000000000002";
+const MOVIE_UID = "b1b1b1b1-0000-4000-8000-000000000003";
+const TASK_UID = "c1c1c1c1-0000-4000-8000-000000000004";
+const PARENT_UID = "d1d1d1d1-0000-4000-8000-000000000005";
+const STALE_UPDATED_AT = "2020-01-01T00:00:00";
+
+/** Frozen-clock instant → 2026-07-12T15:00:00 rendered in Asia/Almaty (UTC+5). */
+const FROZEN_CLOCK = "2026-07-12T10:00:00Z";
+const EXPECTED_UPDATED_AT = "2026-07-12T15:00:00";
+
+function md(frontmatter: Record<string, string>): string {
+  const lines = ["---"];
+  for (const [k, v] of Object.entries(frontmatter)) lines.push(`${k}: ${v}`);
+  lines.push("---", "body", "");
+  return lines.join("\n");
+}
+
+describe("Issues #3795 / #3848: `cli set-property` generic guarded mutation primitive", () => {
+  let vault: string;
+  let exitSpy: ReturnType<typeof jest.spyOn>;
+  let stdoutSpy: ReturnType<typeof jest.spyOn>;
+  let stderrSpy: ReturnType<typeof jest.spyOn>;
+  let logSpy: ReturnType<typeof jest.spyOn>;
+  let errorSpy: ReturnType<typeof jest.spyOn>;
+  let stdoutChunks: string[];
+  let stderrChunks: string[];
+  let exitCodes: number[];
+
+  const moviePath = `${MOVIES_DIR}/${MOVIE_UID}.md`;
+  const taskPath = `${TASKS_DIR}/${TASK_UID}.md`;
+
+  beforeEach(() => {
+    vault = fs.mkdtempSync(path.join(os.tmpdir(), "cli-3795-"));
+
+    const moviesDir = path.join(vault, MOVIES_DIR);
+    const otherDir = path.join(vault, OTHER_DIR);
+    const tasksDir = path.join(vault, TASKS_DIR);
+    fs.mkdirSync(moviesDir, { recursive: true });
+    fs.mkdirSync(otherDir, { recursive: true });
+    fs.mkdirSync(tasksDir, { recursive: true });
+
+    // Ontology anchors (co-location targets).
+    fs.writeFileSync(
+      path.join(moviesDir, `${ANCHOR_MOVIES}.md`),
+      md({ exo__Asset_uid: ANCHOR_MOVIES, exo__Asset_label: "concept__Movies" }),
+    );
+    fs.writeFileSync(
+      path.join(otherDir, `${ANCHOR_OTHER}.md`),
+      md({ exo__Asset_uid: ANCHOR_OTHER, exo__Asset_label: "concept__Other" }),
+    );
+    // A parent asset so a valid [[uid]] wikilink value resolves.
+    fs.writeFileSync(
+      path.join(tasksDir, `${PARENT_UID}.md`),
+      md({ exo__Asset_uid: PARENT_UID, exo__Asset_label: "Parent task" }),
+    );
+    // The Movie asset (co-located under movies; concept__Movie_watched: false).
+    fs.writeFileSync(
+      path.join(moviesDir, `${MOVIE_UID}.md`),
+      md({
+        exo__Asset_uid: MOVIE_UID,
+        exo__Asset_isDefinedBy: `"[[${ANCHOR_MOVIES}]]"`,
+        exo__Asset_label: '"Chislo 23"',
+        concept__Movie_watched: "false",
+        exo__Asset_updatedAt: STALE_UPDATED_AT,
+      }),
+    );
+    // A task asset for the guard cases (has exo__Asset_uid).
+    fs.writeFileSync(
+      path.join(tasksDir, `${TASK_UID}.md`),
+      md({
+        exo__Asset_uid: TASK_UID,
+        exo__Asset_label: '"A task"',
+        ems__Effort_status: `"[[done-uid]]"`,
+        exo__Asset_updatedAt: STALE_UPDATED_AT,
+      }),
+    );
+
+    stdoutChunks = [];
+    stderrChunks = [];
+    exitCodes = [];
+    exitSpy = jest
+      .spyOn(process, "exit")
+      .mockImplementation(((code?: number) => {
+        exitCodes.push(code ?? 0);
+        return undefined as never;
+      }) as never);
+    stdoutSpy = jest
+      .spyOn(process.stdout, "write")
+      .mockImplementation(((chunk: unknown) => {
+        stdoutChunks.push(String(chunk));
+        return true;
+      }) as never);
+    stderrSpy = jest
+      .spyOn(process.stderr, "write")
+      .mockImplementation(((chunk: unknown) => {
+        stderrChunks.push(String(chunk));
+        return true;
+      }) as never);
+    logSpy = jest.spyOn(console, "log").mockImplementation(() => {});
+    errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    exitSpy.mockRestore();
+    stdoutSpy.mockRestore();
+    stderrSpy.mockRestore();
+    logSpy.mockRestore();
+    errorSpy.mockRestore();
+    fs.rmSync(vault, { recursive: true, force: true });
+  });
+
+  /** Run the real set-property command; returns exit codes + on-disk content. */
+  async function run(
+    relPath: string,
+    extraArgs: string[],
+  ): Promise<{
+    exit: number[];
+    content: string;
+    stdout: string;
+    stderr: string;
+    errorLog: string;
+  }> {
+    const cmd = setPropertyCommand();
+    await cmd.parseAsync(
+      [relPath, "--vault", vault, "--frozen-clock", FROZEN_CLOCK, ...extraArgs],
+      { from: "user" },
+    );
+    return {
+      exit: [...exitCodes],
+      content: fs.readFileSync(path.join(vault, relPath), "utf-8"),
+      stdout: stdoutChunks.join(""),
+      stderr: stderrChunks.join(""),
+      errorLog: errorSpy.mock.calls.flat().join("\n"),
+    };
+  }
+
+  // ── #3795 happy path (revert axes: property write + updatedAt bump) ──
+
+  it("sets concept__Movie_watched false → true (boolean stays bare) + bumps updatedAt @req:3800d995-2bae-401f-a23a-dac914505e9d", async () => {
+    const out = await run(moviePath, [
+      "--input",
+      '{"property":"concept__Movie_watched","value":true}',
+    ]);
+
+    expect(out.exit).toContain(0);
+    expect(out.exit).not.toContain(1);
+    // Boolean serialises bare (YAML-native), NOT quoted.
+    expect(out.content).toContain("concept__Movie_watched: true");
+    expect(out.content).not.toContain('concept__Movie_watched: "true"');
+    // updatedAt bumped away from the stale value to the frozen-clock instant.
+    expect(out.content).toContain(`exo__Asset_updatedAt: ${EXPECTED_UPDATED_AT}`);
+    expect(out.content).not.toContain(STALE_UPDATED_AT);
+  });
+
+  it("--property/--value string form quotes a YAML-unsafe value (colon-space) @req:3800d995-2bae-401f-a23a-dac914505e9d", async () => {
+    const out = await run(moviePath, [
+      "--property",
+      "youtube__Video_channel",
+      "--value",
+      "Some Channel: with colon",
+    ]);
+
+    expect(out.exit).toContain(0);
+    // A ': '-bearing value MUST be quoted or it breaks YAML parsing.
+    expect(out.content).toContain(
+      'youtube__Video_channel: "Some Channel: with colon"',
+    );
+  });
+
+  // ── Guard: state-machine / precondition-guarded properties (revert axis: guard) ──
+
+  it("REFUSES ems__Effort_status, naming the dedicated command, leaving the file unchanged @req:3800d995-2bae-401f-a23a-dac914505e9d", async () => {
+    const before = fs.readFileSync(path.join(vault, taskPath), "utf-8");
+    const out = await run(taskPath, [
+      "--input",
+      '{"property":"ems__Effort_status","value":"[[done-uid]]"}',
+    ]);
+
+    expect(out.exit).toContain(1);
+    expect(out.exit).not.toContain(0);
+    expect(out.errorLog).toMatch(/Refusing to set "ems__Effort_status"/);
+    expect(out.errorLog).toMatch(/mark-done|move-to-backlog|start-effort/);
+    // File byte-identical — the guard did not write anything.
+    expect(out.content).toBe(before);
+  });
+
+  it.each([
+    ["ems__Task_zone", "[[zone-uid]]", /set-criticality/],
+    ["ems__Effort_parent", `[[${PARENT_UID}]]`, /set-parent/],
+    ["exo__Asset_label", "New label", /set-label/],
+    ["ems__Effort_startTimestamp", "2026-07-12T10:00:00", /start-effort/],
+    ["ems__Effort_endTimestamp", "2026-07-12T10:00:00", /mark-done/],
+    ["ems__Effort_resolutionTimestamp", "2026-07-12T10:00:00", /mark-done/],
+  ])(
+    "REFUSES guarded property %s → dedicated command, file unchanged @req:3800d995-2bae-401f-a23a-dac914505e9d",
+    async (prop, value, cmdPattern) => {
+      const before = fs.readFileSync(path.join(vault, taskPath), "utf-8");
+      const out = await run(taskPath, [
+        "--input",
+        JSON.stringify({ property: prop, value }),
+        "--skip-wikilink-validation",
+      ]);
+
+      expect(out.exit).toContain(1);
+      expect(out.errorLog).toMatch(new RegExp(`Refusing to set "${prop}"`));
+      expect(out.errorLog).toMatch(cmdPattern);
+      expect(out.content).toBe(before);
+    },
+  );
+
+  // ── Guard: immutable identity / self-managed (revert axis: guard) ──
+
+  it.each([
+    ["exo__Asset_uid", /identity/],
+    ["exo__Asset_updatedAt", /auto-managed/],
+  ])(
+    "REFUSES immutable property %s, leaving the file unchanged @req:3800d995-2bae-401f-a23a-dac914505e9d",
+    async (prop, reasonPattern) => {
+      const before = fs.readFileSync(path.join(vault, moviePath), "utf-8");
+      const out = await run(moviePath, [
+        "--input",
+        JSON.stringify({ property: prop, value: "2099-01-01T00:00:00" }),
+      ]);
+
+      expect(out.exit).toContain(1);
+      expect(out.errorLog).toMatch(new RegExp(`Refusing to set "${prop}"`));
+      expect(out.errorLog).toMatch(reasonPattern);
+      expect(out.content).toBe(before);
+    },
+  );
+
+  // ── #3848 isDefinedBy repoint + co-location re-validation (revert axis: co-location) ──
+
+  it("repoints exo__Asset_isDefinedBy AND warns when the file is not co-located @req:3800d995-2bae-401f-a23a-dac914505e9d", async () => {
+    const out = await run(moviePath, [
+      "--input",
+      JSON.stringify({
+        property: "exo__Asset_isDefinedBy",
+        value: `[[${ANCHOR_OTHER}]]`,
+      }),
+    ]);
+
+    expect(out.exit).toContain(0);
+    // Wikilink value is quoted (not a broken bare `[[uid]]` flow sequence).
+    expect(out.content).toContain(
+      `exo__Asset_isDefinedBy: "[[${ANCHOR_OTHER}]]"`,
+    );
+    // The Movie file lives under movies/ but the new anchor is under other/ →
+    // a co-location warning naming `apply repair-folder` is emitted.
+    expect(out.stderr).toMatch(/co-location/);
+    expect(out.stderr).toMatch(/apply repair-folder/);
+    expect(out.stdout).toMatch(/"coLocationWarning":true/);
+  });
+
+  it("repoints exo__Asset_isDefinedBy to a CO-LOCATED anchor WITHOUT a warning (negative control) @req:3800d995-2bae-401f-a23a-dac914505e9d", async () => {
+    // Re-anchor the Movie to the movies/ anchor it already lives beside.
+    const out = await run(moviePath, [
+      "--input",
+      JSON.stringify({
+        property: "exo__Asset_isDefinedBy",
+        value: `[[${ANCHOR_MOVIES}]]`,
+      }),
+    ]);
+
+    expect(out.exit).toContain(0);
+    expect(out.content).toContain(
+      `exo__Asset_isDefinedBy: "[[${ANCHOR_MOVIES}]]"`,
+    );
+    // Already co-located → NO co-location warning.
+    expect(out.stderr).not.toMatch(/co-location/);
+    expect(out.stdout).not.toMatch(/coLocationWarning/);
+  });
+
+  // ── Wikilink existence validation (negative control) ──
+
+  it("rejects an unresolvable [[uid]] wikilink value @req:3800d995-2bae-401f-a23a-dac914505e9d", async () => {
+    const before = fs.readFileSync(path.join(vault, moviePath), "utf-8");
+    const out = await run(moviePath, [
+      "--input",
+      '{"property":"exo__Asset_relates","value":"[[99999999-9999-4999-8999-999999999999]]"}',
+    ]);
+
+    expect(out.exit).not.toContain(0);
+    expect(out.errorLog).toMatch(/not found/i);
+    expect(out.content).toBe(before);
+  });
+
+  it("accepts a resolvable [[uid]] wikilink value (non-guarded property) @req:3800d995-2bae-401f-a23a-dac914505e9d", async () => {
+    const out = await run(moviePath, [
+      "--input",
+      JSON.stringify({
+        property: "exo__Asset_relates",
+        value: `[[${PARENT_UID}]]`,
+      }),
+    ]);
+
+    expect(out.exit).toContain(0);
+    expect(out.content).toContain(`exo__Asset_relates: "[[${PARENT_UID}]]"`);
+  });
+
+  // ── --dry-run (no write) ──
+
+  it("--dry-run previews the frontmatter without writing @req:3800d995-2bae-401f-a23a-dac914505e9d", async () => {
+    const before = fs.readFileSync(path.join(vault, moviePath), "utf-8");
+    const out = await run(moviePath, [
+      "--input",
+      '{"property":"concept__Movie_watched","value":true}',
+      "--dry-run",
+    ]);
+
+    expect(out.exit).toContain(0);
+    expect(out.stderr).toMatch(/DRY RUN PREVIEW/);
+    expect(out.stderr).toMatch(/concept__Movie_watched: true/);
+    // File is byte-identical — nothing written.
+    expect(out.content).toBe(before);
+  });
+});

--- a/packages/cli/tests/integration/set-property.integration.test.ts
+++ b/packages/cli/tests/integration/set-property.integration.test.ts
@@ -228,9 +228,16 @@ describe("Issues #3795 / #3848: `cli set-property` generic guarded mutation prim
     ["ems__Task_zone", "[[zone-uid]]", /set-criticality/],
     ["ems__Effort_parent", `[[${PARENT_UID}]]`, /set-parent/],
     ["exo__Asset_label", "New label", /set-label/],
+    ["exo__Instance_class", `[[${PARENT_UID}]]`, /convert-to-task/],
     ["ems__Effort_startTimestamp", "2026-07-12T10:00:00", /start-effort/],
     ["ems__Effort_endTimestamp", "2026-07-12T10:00:00", /mark-done/],
     ["ems__Effort_resolutionTimestamp", "2026-07-12T10:00:00", /mark-done/],
+    ["ems__Effort_plannedStartTimestamp", "2026-07-12T10:00:00", /set-planned-start/],
+    ["ems__Effort_plannedEndTimestamp", "2026-07-12T10:00:00", /set-planned-end/],
+    ["ems__Effort_scheduledDate", "2026-07-12", /set-scheduled-date/],
+    ["ems__Effort_votes", "3", /vote-on-effort/],
+    ["archived", "true", /archive/],
+    ["exo__Asset_archived", "true", /archive/],
   ])(
     "REFUSES guarded property %s → dedicated command, file unchanged @req:3800d995-2bae-401f-a23a-dac914505e9d",
     async (prop, value, cmdPattern) => {
@@ -268,6 +275,56 @@ describe("Issues #3795 / #3848: `cli set-property` generic guarded mutation prim
       expect(out.content).toBe(before);
     },
   );
+
+  // ── #3795 review H1 — a `$`-bearing value must round-trip verbatim ──
+
+  it("preserves a $-bearing value verbatim (no capture-group / match splice) @req:3800d995-2bae-401f-a23a-dac914505e9d", async () => {
+    // A price-like `$1` / `$&` would corrupt the file if updateProperty spliced it
+    // as a String.replace pattern (FRONTMATTER_REGEX has a group 1 = the whole
+    // frontmatter) — the #3748 data-loss class.
+    const out = await run(moviePath, [
+      "--property",
+      "concept__Movie_price",
+      "--value",
+      "$1 & $& deal",
+    ]);
+
+    expect(out.exit).toContain(0);
+    // Exactly one frontmatter block — no duplicated `---` and no injected content.
+    expect((out.content.match(/^---$/gm) ?? []).length).toBe(2);
+    expect(out.content).toContain("concept__Movie_price: $1 & $& deal");
+  });
+
+  // ── #3795 review M1 — a non-scalar / non-scalar-array value is rejected ──
+
+  it("rejects a nested-object value fail-loud (no [object Object] corruption) @req:3800d995-2bae-401f-a23a-dac914505e9d", async () => {
+    const before = fs.readFileSync(path.join(vault, moviePath), "utf-8");
+    const out = await run(moviePath, [
+      "--input",
+      '{"property":"concept__Movie_meta","value":{"a":1}}',
+    ]);
+
+    expect(out.exit).not.toContain(0);
+    expect(out.errorLog).toMatch(/must be a scalar/i);
+    expect(out.content).toBe(before);
+  });
+
+  // ── #3795 review M2 — a prototype key (toString) is NOT falsely guarded ──
+
+  it("does NOT falsely guard an inherited Object.prototype key (toString) @req:3800d995-2bae-401f-a23a-dac914505e9d", async () => {
+    // `"toString" in GUARDED_PROPERTIES` would be true (inherited) with a bare
+    // `in` check; the own-key lookup must treat it as an ordinary property.
+    const out = await run(moviePath, [
+      "--property",
+      "custom__toString",
+      "--value",
+      "ok",
+    ]);
+
+    expect(out.exit).toContain(0);
+    expect(out.errorLog).not.toMatch(/Refusing to set/);
+    expect(out.content).toContain("custom__toString: ok");
+  });
 
   // ── #3848 isDefinedBy repoint + co-location re-validation (revert axis: co-location) ──
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -235,6 +235,11 @@ export {
 
 // Utilities exports
 export { FrontmatterService } from "./utilities/FrontmatterService";
+// serializeYamlScalar — quote-when-needed YAML scalar serializer (issue #3748/#3750).
+// Exposed so CLI-side mutation primitives (e.g. `set-property`, issue #3795) can
+// pre-format values the same way the create / property_set paths do before
+// handing them to FrontmatterService.updateProperty (which writes verbatim).
+export { serializeYamlScalar } from "./utilities/yamlScalar";
 export { DateFormatter } from "./utilities/DateFormatter";
 export { WikiLinkHelpers } from "./utilities/WikiLinkHelpers";
 export { MetadataHelpers } from "./utilities/MetadataHelpers";

--- a/packages/core/src/utilities/FrontmatterService.ts
+++ b/packages/core/src/utilities/FrontmatterService.ts
@@ -208,9 +208,14 @@ export class FrontmatterService {
         `${this.escapeRegex(property)}:.*(?:\n {2}- .*)*`,
         "m",
       );
+      // Function-replacer (not a string) so `$`-patterns in the value
+      // (`$&`, `$1`-`$9`, `` $` ``, `$'`, `$$`) are NOT interpreted by
+      // String.prototype.replace — an ordinary value like a price `$1` would
+      // otherwise splice a capture-group / duplicate the match into the
+      // frontmatter (data-loss, #3748 family / #3795 review H1).
       updatedFrontmatter = updatedFrontmatter.replace(
         propertyRegex,
-        serialized,
+        () => serialized,
       );
     } else {
       // Property doesn't exist - append to frontmatter
@@ -219,10 +224,12 @@ export class FrontmatterService {
       updatedFrontmatter += `${separator}${serialized}`;
     }
 
-    // Replace frontmatter block in original content
+    // Replace frontmatter block in original content. Function-replacer so a
+    // `$`-bearing value spliced into `updatedFrontmatter` is not re-interpreted
+    // as a String.replace pattern (#3748 family / #3795 review H1).
     return content.replace(
       FrontmatterService.FRONTMATTER_REGEX,
-      `---\n${updatedFrontmatter}\n---`,
+      () => `---\n${updatedFrontmatter}\n---`,
     );
   }
 
@@ -275,10 +282,12 @@ export class FrontmatterService {
     );
     const updatedFrontmatter = parsed.content.replace(propertyLineRegex, "");
 
-    // Replace frontmatter block in original content
+    // Replace frontmatter block in original content. Function-replacer so a
+    // surviving `$`-bearing value in `updatedFrontmatter` is not re-interpreted
+    // as a String.replace pattern (#3748 family / #3795 review H1).
     return content.replace(
       FrontmatterService.FRONTMATTER_REGEX,
-      `---\n${updatedFrontmatter}\n---`,
+      () => `---\n${updatedFrontmatter}\n---`,
     );
   }
 

--- a/packages/core/tests/utilities/FrontmatterService.dollar-splice.test.ts
+++ b/packages/core/tests/utilities/FrontmatterService.dollar-splice.test.ts
@@ -1,0 +1,62 @@
+/**
+ * #3795 review H1 — `FrontmatterService.updateProperty` / `removeProperty` must
+ * NOT interpret `$`-patterns (`$&`, `$1`-`$9`, `` $` ``, `$'`, `$$`) in the value
+ * as `String.prototype.replace` replacement patterns. An ordinary value like a
+ * price `$1` or `$&` would otherwise splice a capture group / the whole match
+ * (`FRONTMATTER_REGEX` has a group 1 = the entire frontmatter) into the file →
+ * duplicated `---` block / injected frontmatter = unparseable YAML data-loss
+ * (the #3748 corruption class).
+ *
+ * Revert-verify: reverting the function-replacers in updateProperty/removeProperty
+ * (back to string replacements) reds these; restored → GREEN.
+ */
+import { describe, it, expect } from "@jest/globals";
+import { FrontmatterService } from "../../src/utilities/FrontmatterService";
+
+const DOLLAR_VALUES = ["$1", "$&", "$$", "$`", "$'", "$100 & $2", "$9$1"];
+
+describe("FrontmatterService — `$`-bearing value splice safety (#3795 H1)", () => {
+  const fm = new FrontmatterService();
+
+  it.each(DOLLAR_VALUES)(
+    "updateProperty preserves a $-bearing value verbatim (existing property): %s",
+    (val) => {
+      const content = "---\ntitle: X\nprice: old\n---\nbody\n";
+      const out = fm.updateProperty(content, "price", val);
+
+      // Exactly ONE frontmatter block — no duplicated `---` (the #3748 tell).
+      expect((out.match(/^---$/gm) ?? []).length).toBe(2);
+      // The value round-trips literally through a real YAML parse.
+      const parsed = fm.parseObject(out);
+      expect(parsed?.price).toBe(val);
+      // Unrelated property untouched.
+      expect(parsed?.title).toBe("X");
+    },
+  );
+
+  it.each(DOLLAR_VALUES)(
+    "updateProperty preserves a $-bearing value verbatim (new property): %s",
+    (val) => {
+      const content = "---\ntitle: X\n---\nbody\n";
+      const out = fm.updateProperty(content, "note", val);
+
+      expect((out.match(/^---$/gm) ?? []).length).toBe(2);
+      const parsed = fm.parseObject(out);
+      expect(parsed?.note).toBe(val);
+      expect(parsed?.title).toBe("X");
+    },
+  );
+
+  it("removeProperty does not corrupt a surviving $-bearing value", () => {
+    // `price` carries a `$`-value; removing an UNRELATED property must not let
+    // the surviving `price: $1` be re-interpreted in the outer block replace.
+    const content = "---\ntitle: X\nprice: $1\ndrop: me\n---\nbody\n";
+    const out = fm.removeProperty(content, "drop");
+
+    expect((out.match(/^---$/gm) ?? []).length).toBe(2);
+    const parsed = fm.parseObject(out);
+    expect(parsed?.price).toBe("$1");
+    expect(parsed?.title).toBe("X");
+    expect(parsed?.drop).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## What

Adds `exocortex set-property <path>` — a generic, guarded CLI primitive that sets an **arbitrary non-guarded frontmatter property** on an existing vault asset, closing the recurring dogfooding-mutation gap (**#3795**, e.g. flip `concept__Movie_watched: false → true` after watching a film) and subsuming the **#3848** `exo__Asset_isDefinedBy` repoint.

```bash
# #3795 — set an arbitrary property (JSON-typed value)
exocortex set-property <path> --vault <v> --input '{"property":"concept__Movie_watched","value":true}'
# convenience string form
exocortex set-property <path> --vault <v> --property youtube__Video_channel --value "Some Channel"
# #3848 — repoint isDefinedBy (co-location re-validated)
exocortex set-property <path> --vault <v> --input '{"property":"exo__Asset_isDefinedBy","value":"[[<new-anchor>]]"}'
```

## Homoiconicity Invariant decision (Q1/Q3): chose (b) generic primitive

State-machine / precondition-guarded **semantics stay homoiconic** and keep their dedicated `exocmd__Command` groundings — the primitive **REFUSES** those properties (naming the dedicated command) so the guard is not bypassed:

| Refused property | Dedicated command |
|---|---|
| `ems__Effort_status` | `apply mark-done` / `move-to-backlog` / `move-to-todo` / `start-effort` / `set-draft-status` |
| `ems__Task_zone` (criticality zone) | `apply set-criticality-high\|medium\|low` |
| `ems__Effort_parent` | `apply set-parent` (#3779) |
| `exo__Asset_label` | `apply set-label` (#3779) |
| `ems__Effort_startTimestamp` / `endTimestamp` / `resolutionTimestamp` | `start-effort` / `mark-done` / `remove-*-timestamp` (status-transition side-effects) |
| `exo__Asset_uid` | immutable identity (breaks UID-canon + inbound wikilinks) |
| `exo__Asset_updatedAt` | auto-managed by set-property |

An arbitrary scalar/boolean/enum/wikilink property is **not** a state machine — per Q3 it's a core-of-processing concern (a bare CLI verb, like `create`, that bypasses groundings), so one generic primitive closes the whole recurring "I had to raw-Edit a property" class instead of proliferating one command per property. This guard is a **superset** of the `dogfood-cli-mutation` hook's routing table — every property that has a dedicated command is refused here and routed to it; `set-property` only handles the "everything else" (прочее) class the hook leaves to it.

## #3848 — isDefinedBy repoint + co-location re-validation

Setting `exo__Asset_isDefinedBy` is **allowed**. After repointing, the command re-validates co-location (dirname of the resolved new anchor via the same `resolveCoLocationFolder` used by `apply repair-folder`) against the file's current folder and **warns** (non-fatal, naming `apply repair-folder`) when the file was not physically moved. Clean workflow: `set-property` (repoint) → `apply repair-folder` (move).

## Details

- `exo__Asset_updatedAt` is bumped on every mutation (Asia/Almaty default via `Intl.DateTimeFormat`, `--timezone` overridable, `--frozen-clock` for tests — deterministic, not jest-worker-tz-sensitive).
- Wikilink `[[...]]` values are **existence-validated** (the CLI/Bash write path bypasses the `validate-wikilinks` PreToolUse hook), skippable with `--skip-wikilink-validation`.
- `--dry-run` previews the resulting frontmatter without writing.
- Values are pre-formatted with `serializeYamlScalar` (now exported from `@kitelev/exocortex-core`), so wikilinks/YAML-unsafe strings are quoted, and booleans/numbers/ISO-datetimes stay bare (JSON-type-faithful; mirrors the create / `property_set` paths).
- Standalone top-level subcommand (registered in `program.ts`) — not an `exocmd__Command`, so it is not routed through `apply`.

## Requirement (SDD)

`Req: 3800d995-2bae-401f-a23a-dac914505e9d` (req-first SDD, RFC 0003) — status **Approved** on push, flips **Active** after merge.
- https://github.com/kitelev/exoas-exo-reqs/blob/main/exo-reqs/3800d995-2bae-401f-a23a-dac914505e9d.md

## Revert-verify (production-shape)

`packages/cli/tests/integration/set-property.integration.test.ts` drives the REAL `setPropertyCommand()` end-to-end against a temp fixture vault and reads the file back from disk (test-fixture-realism). **Four independent axes**, each reddening exactly its own assertion when Edit-broken and GREEN when restored:

| Reverted axis | Tests RED |
|---|---|
| property write (`updateProperty(original, property, …)`) | 5 (set-value / colon-space quote / isDefinedBy value / resolvable-wikilink / dry-run preview) |
| `exo__Asset_updatedAt` bump | 1 |
| guard refusal (`GUARDED_PROPERTIES` / `IMMUTABLE_PROPERTIES`) | 9 (status + 6 guarded + 2 immutable) |
| co-location check (`ISDEFINEDBY_KEY` block) | 1 |

Restored → **16/16 GREEN**. Empirically verified per-axis (each reverts to RED and restores to GREEN independently).

## Verification

- `npm run check:types` clean (0 errors).
- Full CLI suite green for my change (the 2 unrelated failures — `sparql-exo003` SPARQL-count + `exosync-sync` real-git-submodule — reproduce on clean origin/main; environmental).
- Lint guards: `check-test-antipatterns.sh` (55/55, no new vacuous asserts), `validate-shard-assignments.mjs`, `check-coverage-monotonic.mjs` all pass. Archgate 23/23 (`@req` tag well-formed).

Closes #3795
Closes #3848


---

### Code-review follow-up (H1/H2/M1/M2 — commit `a0d71c3b`)

- **H1 [data-loss]** — `FrontmatterService.updateProperty`/`removeProperty` spliced the value as a `String.replace` *replacement string*, so a `$`-bearing value (`$&`, `$1`-`$9`, `` $` ``, `$'`, `$$`) was interpreted as a replacement pattern — an ordinary price `$1` / `$&` would inject a capture group / duplicate the whole match (`FRONTMATTER_REGEX` group 1 = the entire frontmatter) → unparseable-YAML data-loss (#3748 class), reachable by **all** callers (`apply set-label "Price $1 movie"`, `property_set` groundings, `set-property`). Fixed with function-replacers at all 3 dynamic-replacement sites + a core regression test (revert-verified: **15 RED** without the fix).
- **H2 [guard]** — expanded the denylist to **every** property with a dedicated command: added `exo__Instance_class` (convert-to-*), `ems__Effort_votes` (vote-on-effort), the plan/schedule dates (set-planned-*/set-scheduled-date), and the archive flag (`archived`/`exo__Asset_archived` → archive-completed|un-archive). The false "exact hook set" claim above is corrected (now a documented superset).
- **M1** — a non-scalar / non-scalar-array value is rejected fail-loud (a nested object would serialise to `[object Object]`).
- **M2** — guard via own-key `hasOwnProperty` so a property named `toString`/`constructor` is not falsely matched against inherited `Object.prototype` keys.

Re-revert-verified: core `$`-splice **15 RED** without fix; guard **16 RED** when neutralised; restored → core **15/15** + set-property **26/26** GREEN. `GroundingExecutor` 241/241 (function-replacer behaviour-preserving). typecheck 0.
