### PR TITLE
fix(set-label): bump updatedAt + sync single canonical alias (no accumulation) (#3798)

### DIFF
--- a/packages/cli/tests/integration/apply-mutation-parity.integration.test.ts
+++ b/packages/cli/tests/integration/apply-mutation-parity.integration.test.ts
@@ -38,6 +38,12 @@ const { applyCommand } = await import("../../src/commands/apply.js");
 const GT_PROPERTY_SET = "cf3bb923-f1f1-40be-b728-782844402426";
 const GT_PROPERTY_APPEND = "572f7e69-a8a1-42f6-8113-5aa65cc4b552";
 const GT_COMPOSITE = "8f9a57db-3865-4886-92fb-c5ab7f3c3fa3";
+const GT_PROPERTY_DELETE = "4bdf1d0b-e9da-4d96-bafe-c5aaef8c2bd5"; // #3798
+// SubstitutionToken instance for `$nowLocal` — the REAL exoas-exocmd token UID
+// (8bc0c038), mirrored here so CommandResolver resolves the updatedAt step's
+// `[[<uid>]]` wikilink to the token's exo__Asset_label ("$nowLocal") exactly as
+// it does against the production grounding (#3798).
+const NOWLOCAL_TOKEN = "8bc0c038-1fd1-4ad3-a4a4-178a64b492b8";
 
 const TASK_CLASS = "1b20a8f0-d745-4e93-91db-4531b3df120e"; // ems__Task
 
@@ -46,6 +52,17 @@ const SET_LABEL_CMD = "f7790001-0000-0000-0000-000000000001";
 const SET_LABEL_GROUNDING = "f7790001-0000-0000-0000-000000000002";
 const SET_LABEL_STEP_LABEL = "f7790001-0000-0000-0000-000000000003";
 const SET_LABEL_STEP_ALIAS = "f7790001-0000-0000-0000-000000000004";
+// #3798 — two new steps in the composite: clear aliases (property_delete) +
+// bump updatedAt (property_set $nowLocal). Mirror the production grounding
+// 3dfa3379 [set label, DELETE aliases, append alias, set updatedAt].
+const SET_LABEL_STEP_DELETE = "f7790001-0000-0000-0000-000000000005";
+const SET_LABEL_STEP_UPDATED = "f7790001-0000-0000-0000-000000000006";
+
+// --- LEGACY (pre-#3798) 2-step set-label — used ONLY by the self-contained
+//     revert-verify test to prove the OLD grounding exhibits the bug
+//     (accumulates aliases, does not bump updatedAt). integration-test-revert-verify.
+const SET_LABEL_LEGACY_CMD = "f7790001-0000-0000-0000-0000000000a1";
+const SET_LABEL_LEGACY_GROUNDING = "f7790001-0000-0000-0000-0000000000a2";
 
 // --- set-parent command + grounding ------------------------------------------
 const SET_PARENT_CMD = "f7790002-0000-0000-0000-000000000001";
@@ -61,6 +78,8 @@ const SET_LABEL_CMD_MD = fm([
   `exocmd__Command_cliName: set-label`,
 ]);
 
+// #3798 — 4-step composite: set label → CLEAR aliases → re-mirror single alias
+// → bump updatedAt. Mirrors production grounding 3dfa3379 exactly.
 const SET_LABEL_GROUNDING_MD = fm([
   `exo__Asset_uid: ${SET_LABEL_GROUNDING}`,
   `exo__Asset_label: "Set label composite"`,
@@ -68,7 +87,9 @@ const SET_LABEL_GROUNDING_MD = fm([
   `exocmd__Grounding_type: "[[${GT_COMPOSITE}]]"`,
   `exocmd__Grounding_steps:`,
   `  - "[[${SET_LABEL_STEP_LABEL}|set label]]"`,
+  `  - "[[${SET_LABEL_STEP_DELETE}|clear aliases]]"`,
   `  - "[[${SET_LABEL_STEP_ALIAS}|append alias]]"`,
+  `  - "[[${SET_LABEL_STEP_UPDATED}|bump updatedAt]]"`,
 ]);
 
 const SET_LABEL_STEP_LABEL_MD = fm([
@@ -81,6 +102,16 @@ const SET_LABEL_STEP_LABEL_MD = fm([
   `exocmd__Grounding_targetValueLiteral: "$input.label"`,
 ]);
 
+// #3798 step 2 — clear the entire aliases list so the next append re-mirrors
+// ONLY the new canonical label (no stale accumulation).
+const SET_LABEL_STEP_DELETE_MD = fm([
+  `exo__Asset_uid: ${SET_LABEL_STEP_DELETE}`,
+  `exo__Asset_label: "Clear aliases before re-mirroring label"`,
+  `exo__Instance_class: ["[[exocmd__Grounding]]"]`,
+  `exocmd__Grounding_type: "[[${GT_PROPERTY_DELETE}]]"`,
+  `exocmd__Grounding_targetProperty: "aliases"`,
+]);
+
 const SET_LABEL_STEP_ALIAS_MD = fm([
   `exo__Asset_uid: ${SET_LABEL_STEP_ALIAS}`,
   `exo__Asset_label: "Append new label to aliases"`,
@@ -88,6 +119,43 @@ const SET_LABEL_STEP_ALIAS_MD = fm([
   `exocmd__Grounding_type: "[[${GT_PROPERTY_APPEND}]]"`,
   `exocmd__Grounding_targetProperty: "aliases"`,
   `exocmd__Grounding_appendExpression: "$input.label"`,
+]);
+
+// #3798 step 4 — stamp the last-modified invariant via the $nowLocal token
+// (wikilink → CommandResolver resolves to the token's exo__Asset_label).
+const SET_LABEL_STEP_UPDATED_MD = fm([
+  `exo__Asset_uid: ${SET_LABEL_STEP_UPDATED}`,
+  `exo__Asset_label: "Bump updatedAt on set-label"`,
+  `exo__Instance_class: ["[[exocmd__Grounding]]"]`,
+  `exocmd__Grounding_type: "[[${GT_PROPERTY_SET}]]"`,
+  `exocmd__Grounding_targetProperty: "exo__Asset_updatedAt"`,
+  `exocmd__Grounding_targetValueSubstitution: "[[${NOWLOCAL_TOKEN}]]"`,
+]);
+
+// SubstitutionToken instance — its exo__Asset_label IS the token string the
+// executor's substituteVariables regex resolves ($nowLocal → local timestamp).
+const NOWLOCAL_TOKEN_MD = fm([
+  `exo__Asset_uid: ${NOWLOCAL_TOKEN}`,
+  `exo__Asset_label: "$nowLocal"`,
+  `exo__Instance_class: ["[[exocmd__SubstitutionToken]]"]`,
+]);
+
+// LEGACY (pre-#3798) 2-step composite — reused by the revert-verify test.
+const SET_LABEL_LEGACY_CMD_MD = fm([
+  `exo__Asset_uid: ${SET_LABEL_LEGACY_CMD}`,
+  `exo__Asset_label: "Set Label (legacy)"`,
+  `exo__Instance_class: ["[[exocmd__Command]]"]`,
+  `exocmd__Command_grounding: "[[${SET_LABEL_LEGACY_GROUNDING}|g]]"`,
+  `exocmd__Command_cliName: set-label-legacy`,
+]);
+const SET_LABEL_LEGACY_GROUNDING_MD = fm([
+  `exo__Asset_uid: ${SET_LABEL_LEGACY_GROUNDING}`,
+  `exo__Asset_label: "Set label composite (legacy 2-step)"`,
+  `exo__Instance_class: ["[[exocmd__Grounding]]"]`,
+  `exocmd__Grounding_type: "[[${GT_COMPOSITE}]]"`,
+  `exocmd__Grounding_steps:`,
+  `  - "[[${SET_LABEL_STEP_LABEL}|set label]]"`,
+  `  - "[[${SET_LABEL_STEP_ALIAS}|append alias]]"`,
 ]);
 
 const SET_PARENT_CMD_MD = fm([
@@ -109,13 +177,25 @@ const SET_PARENT_GROUNDING_MD = fm([
   `exocmd__Grounding_targetValueRef: "$input.parent"`,
 ]);
 
-function targetMd(uid: string, label: string, withAlias: boolean): string {
+function targetMd(
+  uid: string,
+  label: string,
+  withAlias: boolean,
+  // #3798 — extra pre-existing aliases (simulate accumulation from prior
+  // relabels) so "no accumulation" assertions are meaningful; also seed an old
+  // updatedAt so "updatedAt bumped" is observable.
+  opts: { aliases?: string[]; updatedAt?: string } = {},
+): string {
   const lines = [
     `exo__Asset_uid: ${uid}`,
     `exo__Asset_label: "${label}"`,
   ];
-  if (withAlias) {
-    lines.push(`aliases:`, `  - "${label}"`);
+  const aliases = opts.aliases ?? (withAlias ? [label] : []);
+  if (aliases.length > 0) {
+    lines.push(`aliases:`, ...aliases.map((a) => `  - "${a}"`));
+  }
+  if (opts.updatedAt) {
+    lines.push(`exo__Asset_updatedAt: ${opts.updatedAt}`);
   }
   lines.push(`exo__Instance_class: ["[[${TASK_CLASS}]]"]`);
   return [...fm(lines).split("\n").slice(0, -1), `# ${label}`, ""].join("\n");
@@ -128,7 +208,12 @@ function buildVault(): { root: string } {
   write(SET_LABEL_CMD, SET_LABEL_CMD_MD);
   write(SET_LABEL_GROUNDING, SET_LABEL_GROUNDING_MD);
   write(SET_LABEL_STEP_LABEL, SET_LABEL_STEP_LABEL_MD);
+  write(SET_LABEL_STEP_DELETE, SET_LABEL_STEP_DELETE_MD); // #3798
   write(SET_LABEL_STEP_ALIAS, SET_LABEL_STEP_ALIAS_MD);
+  write(SET_LABEL_STEP_UPDATED, SET_LABEL_STEP_UPDATED_MD); // #3798
+  write(NOWLOCAL_TOKEN, NOWLOCAL_TOKEN_MD); // #3798
+  write(SET_LABEL_LEGACY_CMD, SET_LABEL_LEGACY_CMD_MD); // #3798 revert-verify
+  write(SET_LABEL_LEGACY_GROUNDING, SET_LABEL_LEGACY_GROUNDING_MD);
   write(SET_PARENT_CMD, SET_PARENT_CMD_MD);
   write(SET_PARENT_GROUNDING, SET_PARENT_GROUNDING_MD);
   return { root };
@@ -178,9 +263,14 @@ describe("Issue #3779 — CLI apply mutation parity (relabel + explicit parent)"
     uid: string,
     label: string,
     withAlias = true,
+    opts: { aliases?: string[]; updatedAt?: string } = {},
   ): string {
     const rel = `${uid}.md`;
-    fs.writeFileSync(path.join(root, rel), targetMd(uid, label, withAlias), "utf-8");
+    fs.writeFileSync(
+      path.join(root, rel),
+      targetMd(uid, label, withAlias, opts),
+      "utf-8",
+    );
     return rel;
   }
 
@@ -214,17 +304,36 @@ describe("Issue #3779 — CLI apply mutation parity (relabel + explicit parent)"
     expect(after).not.toContain("$input.parent");
   });
 
-  it("@req:f7790000-3779-4bbb-8bbb-000000000002 set-label relabels exo__Asset_label and appends the new label to aliases (Gap 1, real mutation)", async () => {
-    const rel = writeTarget("bbbbbbbb-3779-4000-8000-000000000001", "Old Label");
+  it("@req:f7790000-3779-4bbb-8bbb-000000000002 set-label relabels exo__Asset_label, syncs the single canonical alias (no accumulation) and bumps exo__Asset_updatedAt (Gap 1 + #3798, real mutation)", async () => {
+    // Seed pre-existing accumulated aliases + a stale updatedAt so the fix is
+    // observable (the OLD 2-step composite kept "Old Label" + "Stale Alias" and
+    // never touched updatedAt — see the revert-verify test below).
+    const rel = writeTarget(
+      "bbbbbbbb-3779-4000-8000-000000000001",
+      "Old Label",
+      true,
+      { aliases: ["Old Label", "Stale Alias"], updatedAt: "2020-01-01T00:00:00" },
+    );
 
     await runApply("set-label", rel, `{"label":"New Label"}`);
 
     const written = read(rel);
     expect(written).toMatch(/exo__Asset_label: New Label\b/);
-    // aliases mirror: old retained, new appended (set-based dedup).
-    expect(written).toContain(`- "Old Label"`);
+    // #3798 — aliases MIRROR the current label as the SINGLE canonical entry:
+    // the prior aliases are cleared, not accumulated.
     expect(written).toContain(`- "New Label"`);
+    expect(written).not.toContain(`- "Old Label"`); // stale label alias cleared
+    expect(written).not.toContain(`- "Stale Alias"`);
+    // exactly one alias entry.
+    expect((written.match(/^\s+- /gm) ?? []).length).toBe(1);
+    // #3798 — updatedAt is bumped (no longer the seeded 2020 value; local
+    // timestamp shape YYYY-MM-DDTHH:MM:SS).
+    expect(written).not.toContain("exo__Asset_updatedAt: 2020-01-01T00:00:00");
+    expect(written).toMatch(
+      /exo__Asset_updatedAt: \d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\b/,
+    );
     expect(written).not.toContain("$input.label");
+    expect(written).not.toContain("$nowLocal"); // token resolved, not literal
     // body H1 is left untouched (freeform) — decision documented in #3779.
     expect(written).toContain("# Old Label");
   });
@@ -240,6 +349,8 @@ describe("Issue #3779 — CLI apply mutation parity (relabel + explicit parent)"
     const written = read(rel);
     expect(written).toContain("exo__Asset_label: Fix $value handling");
     expect(written).toContain(`- "Fix $value handling"`);
+    // #3798 — single canonical alias (the seeded "Old Label" alias is cleared).
+    expect(written).not.toContain(`- "Old Label"`);
   });
 
   it("@req:f7790000-3779-4bbb-8bbb-000000000002 set-label YAML-quotes a label containing ': ' so the file stays parseable", async () => {
@@ -251,5 +362,35 @@ describe("Issue #3779 — CLI apply mutation parity (relabel + explicit parent)"
     // A label with `: ` MUST be double-quoted (else invalid YAML → unparseable).
     expect(written).toContain(`exo__Asset_label: "Meeting: Q3 review"`);
     expect(written).toContain(`- "Meeting: Q3 review"`);
+    // #3798 — single canonical alias (the seeded "Old Label" alias is cleared).
+    expect(written).not.toContain(`- "Old Label"`);
+  });
+
+  // ---------------------------------------------------------------------------
+  // #3798 revert-verify (integration-test-revert-verify): the OLD 2-step
+  // composite (property_set label + property_append aliases — NO delete, NO
+  // updatedAt) must EXHIBIT the bug the 4-step fix removes. This runs the legacy
+  // grounding through the SAME real `apply` pipeline, proving the assertions
+  // above are non-vacuous (they would fail on the pre-fix grounding).
+  // ---------------------------------------------------------------------------
+  it("@req:f7790000-3779-4bbb-8bbb-000000000002 REVERT-VERIFY: the legacy 2-step set-label ACCUMULATES aliases and does NOT bump updatedAt (the #3798 bug)", async () => {
+    const rel = writeTarget(
+      "bbbbbbbb-3779-4000-8000-0000000000af",
+      "Old Label",
+      true,
+      { aliases: ["Old Label", "Stale Alias"], updatedAt: "2020-01-01T00:00:00" },
+    );
+
+    await runApply("set-label-legacy", rel, `{"label":"New Label"}`);
+
+    const written = read(rel);
+    expect(written).toMatch(/exo__Asset_label: New Label\b/);
+    // BUG 1 — aliases accumulate: the old aliases are RETAINED, new is appended.
+    expect(written).toContain(`- "Old Label"`);
+    expect(written).toContain(`- "Stale Alias"`);
+    expect(written).toContain(`- "New Label"`);
+    expect((written.match(/^\s+- /gm) ?? []).length).toBeGreaterThan(1);
+    // BUG 2 — updatedAt is NOT bumped (stays the seeded 2020 value).
+    expect(written).toContain("exo__Asset_updatedAt: 2020-01-01T00:00:00");
   });
 });

--- a/packages/core/tests/integration/dynamic-commands/set-label-grounding-shape.test.ts
+++ b/packages/core/tests/integration/dynamic-commands/set-label-grounding-shape.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Data-guard (Issue #3798) — asserts the REAL `packages/exoas-exocmd` set-label
+ * composite grounding (3dfa3379) has the 4-step shape that fixes the two
+ * residual bugs:
+ *   1. property_set  exo__Asset_label   = $input.label   (f79e2d7d)
+ *   2. property_delete aliases                           (7f33c6c7, #3798)  ← clear stale
+ *   3. property_append aliases = $input.label            (b36996d5)         ← re-mirror single
+ *   4. property_set  exo__Asset_updatedAt = $nowLocal    (49e00287, #3798)  ← bump
+ *
+ * This walks the ACTUAL submodule data (not an inline fixture), so it guards
+ * against the grounding drifting back to the buggy 2-step form (revert-verify:
+ * bumping the submodule pointer to before the fix → RED; after → GREEN). It is
+ * the data-code coupling guard complementing the engine/pipeline behaviour test
+ * in packages/cli/tests/integration/apply-mutation-parity.integration.test.ts
+ * (cross-repo-submodule-sync.md §stale-walker, test-fixture-realism.md).
+ *
+ * @req:f7790000-3779-4bbb-8bbb-000000000002
+ */
+import * as fs from "fs";
+import * as path from "path";
+import { GroundingType } from "../../../src/domain/constants/GroundingType";
+import { GROUNDING_TYPE_UID_TO_ENUM } from "../../../src/domain/constants/GroundingTypeUIDs";
+
+const SUBMODULE_EXOCMD = path.resolve(__dirname, "../../../../exoas-exocmd/exocmd");
+const SET_LABEL_COMPOSITE = "3dfa3379-5cee-4717-97fe-e0885fec0549";
+const NOWLOCAL_TOKEN = "8bc0c038-1fd1-4ad3-a4a4-178a64b492b8";
+
+function parseFrontmatter(content: string): Record<string, string | string[]> {
+  const m = content.match(/^---\n([\s\S]*?)\n---/);
+  if (!m) return {};
+  const fm: Record<string, string | string[]> = {};
+  let key: string | null = null;
+  let list: string[] | null = null;
+  for (const line of m[1].split("\n")) {
+    const li = line.match(/^\s*-\s*(.+)$/);
+    if (li && list) {
+      list.push(li[1].trim().replace(/^"|"$/g, ""));
+      continue;
+    }
+    const kv = line.match(/^([a-zA-Z_][\w]*?):\s*(.*)$/);
+    if (kv) {
+      key = kv[1];
+      const v = kv[2].trim();
+      if (v === "") {
+        list = [];
+        fm[key] = list;
+      } else {
+        fm[key] = v.replace(/^"|"$/g, "");
+        list = null;
+      }
+    }
+  }
+  return fm;
+}
+
+const wikilinkUid = (v: string | undefined): string | null => {
+  if (!v) return null;
+  const m = v.match(/\[\[([0-9a-f-]{36})/i);
+  return m ? m[1].toLowerCase() : null;
+};
+
+function readAsset(uid: string): Record<string, string | string[]> {
+  const p = path.join(SUBMODULE_EXOCMD, `${uid}.md`);
+  if (!fs.existsSync(p)) {
+    throw new Error(
+      `exoas-exocmd asset ${uid}.md not found at ${p}. Run \`git submodule update --init packages/exoas-exocmd\` (or the submodule pointer predates #3798).`,
+    );
+  }
+  return parseFrontmatter(fs.readFileSync(p, "utf8"));
+}
+
+describe("#3798 set-label grounding shape (real exoas-exocmd data)", () => {
+  const submodulePresent = fs.existsSync(SUBMODULE_EXOCMD);
+
+  (submodulePresent ? it : it.skip)(
+    "@req:f7790000-3779-4bbb-8bbb-000000000002 the composite is [set label, DELETE aliases, append alias, set updatedAt=$nowLocal]",
+    () => {
+      const composite = readAsset(SET_LABEL_COMPOSITE);
+      expect(wikilinkUid(composite["exocmd__Grounding_type"] as string)).toBe(
+        // composite type
+        "8f9a57db-3865-4886-92fb-c5ab7f3c3fa3",
+      );
+
+      const stepsRaw = composite["exocmd__Grounding_steps"];
+      const stepUids = (Array.isArray(stepsRaw) ? stepsRaw : [stepsRaw])
+        .map((s) => wikilinkUid(s as string))
+        .filter((u): u is string => u !== null);
+
+      // Resolve each step to (GroundingType, targetProperty).
+      const steps = stepUids.map((uid) => {
+        const fm = readAsset(uid);
+        const typeUid = wikilinkUid(fm["exocmd__Grounding_type"] as string);
+        return {
+          uid,
+          type: typeUid ? GROUNDING_TYPE_UID_TO_ENUM[typeUid] : undefined,
+          targetProperty: fm["exocmd__Grounding_targetProperty"] as
+            | string
+            | undefined,
+          substitution: fm["exocmd__Grounding_targetValueSubstitution"] as
+            | string
+            | undefined,
+        };
+      });
+
+      // Exactly the 4-step fix shape (order matters: delete BEFORE append).
+      expect(
+        steps.map((s) => [s.type, s.targetProperty]),
+      ).toEqual([
+        [GroundingType.PROPERTY_SET, "exo__Asset_label"],
+        [GroundingType.PROPERTY_DELETE, "aliases"],
+        [GroundingType.PROPERTY_APPEND, "aliases"],
+        [GroundingType.PROPERTY_SET, "exo__Asset_updatedAt"],
+      ]);
+
+      // The updatedAt step stamps the $nowLocal token (8bc0c038).
+      const updatedAtStep = steps[3];
+      expect(wikilinkUid(updatedAtStep.substitution)).toBe(NOWLOCAL_TOKEN);
+      // …and that token's label IS "$nowLocal" (so the executor resolves it).
+      expect(readAsset(NOWLOCAL_TOKEN)["exo__Asset_label"]).toBe("$nowLocal");
+    },
+  );
+});


### PR DESCRIPTION
## Bug (#3798 residuals)

`apply set-label` had two residual bugs after the `.label`-suffix fix (v16.166.1):
1. **`exo__Asset_updatedAt` not bumped** — a relabel was not recorded as a modification.
2. **stale aliases accumulate** — every relabel appended the new label but kept the old ones (`property_append`).

## Root cause (verified, repro-first)

The `Set Label` composite grounding (`3dfa3379`, kitelev/exoas-exocmd) had **2 steps**:
`property_set exo__Asset_label = $input.label` + `property_append aliases = $input.label`.
There is **no** generic updatedAt-on-mutation in `GroundingExecutor` (only `executeCreateInstance` fills `updatedAt=createdAt` on creation) → nothing bumped `updatedAt`; and `property_append` accumulates by design. Confirmed via a production-shape probe over the real `GroundingExecutor`.

## Fix (DATA — homoiconic, zero engine change)

The composite is now **4 steps** (submodule pointer bumped `2450cb2`→`f6255b1`):

1. `property_set  exo__Asset_label   = $input.label`          (f79e2d7d, unchanged)
2. `property_delete aliases`                                   (**7f33c6c7, new**) — clear stale
3. `property_append aliases = $input.label`                    (b36996d5, unchanged) — re-mirror single
4. `property_set  exo__Asset_updatedAt = $nowLocal`            (**49e00287, new**) — bump

Delete-then-append yields a proper **single-element list** `aliases: [<new label>]` (matches the create-path `$labelAsArray` mirror; no accumulation), and the `$nowLocal` SubstitutionToken (`8bc0c038`) stamps the last-modified invariant. All steps reuse existing grounding types → **no `GroundingExecutor` change**.

## Verification

**End-to-end (real published CLI)** — `apply set-label` on a temp vault carrying the fixed grounding:
```
exo__Asset_label: "Renamed: Q3 report"
exo__Asset_updatedAt: 2026-07-12T19:34:43     ← bumped (was 2020-01-01)
aliases:
  - "Renamed: Q3 report"                       ← single canonical (Old Label + Stale Alias gone)
```

**Tests (both production-shape, CI-gated):**
- `packages/cli/tests/integration/apply-mutation-parity.integration.test.ts` — the REAL `apply` pipeline. The 4-step config syncs the single alias + bumps `updatedAt` (GREEN). A **self-contained revert-verify** runs the legacy 2-step config through the same pipeline and asserts it **EXHIBITS the bug** (aliases accumulate, `updatedAt` unchanged) → the fixed assertions are non-vacuous.
- `packages/core/tests/integration/dynamic-commands/set-label-grounding-shape.test.ts` — **data-guard** walking the REAL `exoas-exocmd` submodule, asserting the 4-step shape. Revert-verified via the submodule pointer: **RED** on the old 2-step composite, **GREEN** on the new.

`exoas-exocmd validate schema --shapes-mode`: **0 violations**. `check-test-antipatterns` / `validate-shard-assignments` / `check-coverage-monotonic`: pass. `tsc --noEmit`: 0 errors.

## Requirement

Active req `f7790000-3779-4bbb-8bbb-000000000002` (exoas-exo-reqs) updated: its Gherkin previously specified accumulation ("aliases contains both"), which #3798 reclassified as a bug → now specifies the single-canonical-alias + updatedAt-bump behavior. Same `@req` binding; status stays Active.

Closes #3798.
