### PR TITLE
feat(#3781): pn__DailyNote 'Closed today' daily-efforts partition

### DIFF
--- a/packages/core/src/domain/layout/LayoutBlock.ts
+++ b/packages/core/src/domain/layout/LayoutBlock.ts
@@ -254,7 +254,7 @@ export function createLayoutBlockFromFrontmatter(
     );
     if (partition === null) {
       warn(
-        `DailyEffortsByClassBlock ${base.uid}: exo__DailyEffortsByClassBlock_partition must be one of actions|tasks|projects (${options.sourcePath})`,
+        `DailyEffortsByClassBlock ${base.uid}: exo__DailyEffortsByClassBlock_partition must be one of actions|tasks|projects|closed (${options.sourcePath})`,
       );
       return null;
     }

--- a/packages/core/src/domain/layout/LayoutBlock.ts
+++ b/packages/core/src/domain/layout/LayoutBlock.ts
@@ -53,15 +53,28 @@ export interface BacklinksTableBlock extends LayoutBlockBase {
 }
 
 /**
- * Which class-partition of the day's efforts a `daily-efforts-by-class` block
- * shows (RL#4b / VL#4, RFC pn__DailyNote toggles):
+ * Which partition of the day's efforts a `daily-efforts-by-class` block shows
+ * (RL#4b / VL#4, RFC pn__DailyNote toggles; `closed` axis added by req
+ * b2a33efc / issue #3781):
  *   - `actions`  — `ems__Action` instances of the day.
  *   - `tasks`    — the day's efforts EXCEPT Action and Project (so meetings /
  *                  `ems__Meeting` and any other Effort subclass stay here —
  *                  RL#1 inclusive carve-out).
  *   - `projects` — `ems__Project` instances of the day.
+ *   - `closed`   — efforts CLOSED on the note's day: those whose
+ *                  `ems__Effort_resolutionTimestamp` (or `ems__Effort_endTimestamp`
+ *                  fallback) falls on the day. This is an ORTHOGONAL axis to the
+ *                  class buckets above — a closed effort can also appear in its
+ *                  class bucket (Done tasks) or ONLY here (Trashed-only closures,
+ *                  which carry no start/end/planned timestamp so are absent from
+ *                  the class buckets). The date-match is computed local-tz by the
+ *                  renderer's provider, NOT by this partition function.
  */
-export type DailyEffortsPartition = "actions" | "tasks" | "projects";
+export type DailyEffortsPartition =
+  | "actions"
+  | "tasks"
+  | "projects"
+  | "closed";
 
 export interface DailyEffortsByClassBlock extends LayoutBlockBase {
   readonly kind: "daily-efforts-by-class";
@@ -86,6 +99,7 @@ const DAILY_EFFORTS_PARTITIONS: readonly DailyEffortsPartition[] = [
   "actions",
   "tasks",
   "projects",
+  "closed",
 ];
 
 function parseDailyEffortsPartition(

--- a/packages/core/src/domain/layout/blockVisibility.ts
+++ b/packages/core/src/domain/layout/blockVisibility.ts
@@ -5,7 +5,7 @@
  *
  *   per-note frontmatter override  >  exo__Layout per-block default  >  built-in
  *
- * The built-in default for the three daily-efforts partitions is
+ * The built-in default for the daily-efforts partitions is
  * {@link BUILTIN_DAILY_EFFORTS_VISIBILITY}: Actions shown, Tasks shown,
  * Projects HIDDEN (VL#3 — a deliberate, accepted partial regression).
  *
@@ -24,7 +24,8 @@
 import type { DailyEffortsPartition } from "./LayoutBlock";
 
 /**
- * Out-of-the-box visibility for the three daily-efforts partitions (VL#3).
+ * Out-of-the-box visibility for the daily-efforts partitions (VL#3;
+ * `closed` added by req b2a33efc / issue #3781, shown by default).
  * Used as the lowest precedence layer when neither a frontmatter override nor
  * an `exo__Layout` per-block default is present.
  */
@@ -34,10 +35,13 @@ export const BUILTIN_DAILY_EFFORTS_VISIBILITY: Readonly<
   actions: true,
   tasks: true,
   projects: false,
+  // `closed` (req b2a33efc / issue #3781) — the "Closed today" review section is
+  // shown out of the box; a per-note `pn__DailyNote_showClosed: false` hides it.
+  closed: true,
 });
 
 /**
- * Per-note frontmatter override keys for the three daily-efforts partitions
+ * Per-note frontmatter override keys for the daily-efforts partitions
  * (VL#2). Present on the `pn__DailyNote` instance; absent keys fall through to
  * the Layout / built-in default.
  */
@@ -47,6 +51,7 @@ export const DAILY_EFFORTS_OVERRIDE_KEYS: Readonly<
   actions: "pn__DailyNote_showActions",
   tasks: "pn__DailyNote_showTasks",
   projects: "pn__DailyNote_showProjects",
+  closed: "pn__DailyNote_showClosed",
 });
 
 /**

--- a/packages/core/src/domain/layout/dailyEffortsPartition.ts
+++ b/packages/core/src/domain/layout/dailyEffortsPartition.ts
@@ -37,6 +37,16 @@ export interface DailyEffortsPartitioned<T> {
   readonly actions: readonly T[];
   readonly tasks: readonly T[];
   readonly projects: readonly T[];
+  /**
+   * Efforts CLOSED on the note's day (req b2a33efc / issue #3781). This axis is
+   * ORTHOGONAL to the three class buckets: `partitionDailyEffortsByClass` fills
+   * only the class buckets and leaves `closed` empty; the `closed` list is
+   * supplied by the caller (the renderer), which computes it from a local-tz
+   * closure-date match (`ExoLayoutRenderer.computeDailyPartition`). An effort
+   * can appear in BOTH its class bucket and `closed` (Done tasks) or ONLY in
+   * `closed` (Trashed-only closures with no start/end/planned timestamp).
+   */
+  readonly closed: readonly T[];
 }
 
 function toClassArray(value: unknown): string[] {
@@ -100,7 +110,10 @@ export function partitionDailyEffortsByClass<
     }
   }
 
-  return { actions, tasks, projects };
+  // `closed` is an orthogonal axis filled by the caller (the renderer computes
+  // it from a local-tz closure-date match); this class-partition function only
+  // fills the class buckets. Default empty keeps existing callers/tests intact.
+  return { actions, tasks, projects, closed: [] };
 }
 
 function defaultClassesOf(e: { metadata?: Record<string, unknown> }): string[] {

--- a/packages/core/tests/domain/layout/LayoutBlock.test.ts
+++ b/packages/core/tests/domain/layout/LayoutBlock.test.ts
@@ -97,7 +97,26 @@ describe("LayoutBlock — daily-efforts-by-class kind (RL#4b, req a38ac95b)", ()
     }
   });
 
-  test.each(["actions", "tasks", "projects", "PROJECTS", "  Tasks "])(
+  test("@req:b2a33efc-1b6c-4c9a-ab76-ecff66ffab08 parses a daily-efforts-by-class block with the 'closed' partition (issue #3781)", () => {
+    const block = createLayoutBlockFromFrontmatter(
+      {
+        exo__Asset_uid: "daily-closed",
+        exo__Asset_label: "Closed today",
+        exo__Instance_class: [`[[${DAILY_EFFORTS_BY_CLASS_BLOCK_CLASS_UID}]]`],
+        exo__DailyEffortsByClassBlock_partition: "closed",
+      },
+      SRC,
+    );
+    expect(block).not.toBeNull();
+    expect(block?.kind).toBe("daily-efforts-by-class");
+    expect(block && isDailyEffortsByClassBlock(block)).toBe(true);
+    if (block && isDailyEffortsByClassBlock(block)) {
+      expect(block.partition).toBe("closed");
+      expect(block.title).toBe("Closed today");
+    }
+  });
+
+  test.each(["actions", "tasks", "projects", "closed", "CLOSED", "  Closed "])(
     "accepts and normalises partition %p",
     (raw) => {
       const block = createLayoutBlockFromFrontmatter(

--- a/packages/obsidian-plugin/src/presentation/renderers/ExoLayoutRenderer.tsx
+++ b/packages/obsidian-plugin/src/presentation/renderers/ExoLayoutRenderer.tsx
@@ -50,13 +50,24 @@ import {
 /**
  * A day-scoped effort surfaced to a `daily-efforts-by-class` block. The
  * provider (wired in `UniversalLayoutRenderer`) scans the vault for efforts
- * whose timestamps fall in the note's day (`isEffortInDay`) and returns this
- * minimal shape; the renderer partitions it by class once per render.
+ * relevant to the note's day and returns this minimal shape; the renderer
+ * partitions it once per render.
+ *
+ * The provider stamps two orthogonal relevance flags (req b2a33efc / issue
+ * #3781): `inDay` (matched `isEffortInDay` — start/end/planned; feeds the
+ * Actions/Tasks/Projects class buckets) and `closedInDay` (matched
+ * `isEffortClosedInDay` — resolution/end on the day; feeds the "closed" axis).
+ * Both are optional for back-compat: a legacy/test item without flags is
+ * treated as `inDay` (in the class buckets) and not closed.
  */
 export interface DailyEffortItem {
   readonly path: string;
   readonly title: string;
   readonly metadata: Record<string, unknown>;
+  /** Whether the effort matched `isEffortInDay` (feeds the class buckets). */
+  readonly inDay?: boolean;
+  /** Whether the effort was closed on the day (feeds the "closed" axis). */
+  readonly closedInDay?: boolean;
 }
 
 export interface ExoLayoutRendererDeps {
@@ -148,7 +159,15 @@ export class ExoLayoutRenderer {
     });
     if (!hasDailyBlock) return null;
     const efforts = this.deps.dailyEffortsProvider(file) ?? [];
-    return partitionDailyEffortsByClass(efforts);
+    // Class buckets (Actions/Tasks/Projects) are computed ONLY over the `inDay`
+    // subset → byte-identical to req a38ac95b (a Trashed-only closure, inDay
+    // false, is excluded from the class buckets). The "closed" axis (req
+    // b2a33efc / issue #3781) is the `closedInDay` subset — orthogonal to the
+    // class buckets, may overlap them (a Done task appears in both). Items
+    // without the flags (legacy/test shape) default to inDay + not-closed.
+    const inDayEfforts = efforts.filter((e) => e.inDay !== false);
+    const closed = efforts.filter((e) => e.closedInDay === true);
+    return { ...partitionDailyEffortsByClass(inDayEfforts), closed };
   }
 
   private isBlockVisible(

--- a/packages/obsidian-plugin/src/presentation/renderers/helpers/DailyEffortsCollector.ts
+++ b/packages/obsidian-plugin/src/presentation/renderers/helpers/DailyEffortsCollector.ts
@@ -6,12 +6,17 @@ import { DailyNoteHelpers } from "./DailyNoteHelpers";
 /**
  * collectDayEfforts — gathers the efforts of a daily note's day for the
  * `daily-efforts-by-class` Layout blocks (RFC pn__DailyNote toggles, req
- * a38ac95b).
+ * a38ac95b; `closed` axis added by req b2a33efc / issue #3781).
  *
  * Returns `null` when `file` is not a daily note (or no day can be derived) —
  * the renderer then renders the daily-efforts blocks empty. Otherwise returns
- * every effort whose timestamps fall in the day (`isEffortInDay`), in vault
- * order, as the minimal `{ path, title, metadata }` shape the partition needs.
+ * every effort that is EITHER in the day (`isEffortInDay` — start/end/planned)
+ * OR closed on the day (`isEffortClosedInDay` — resolution/end), in vault
+ * order, each stamped with `inDay` / `closedInDay` so the renderer can build
+ * the class buckets from the `inDay` subset (ZERO regression to a38ac95b) and
+ * the "closed" list from the `closedInDay` subset. A single O(n) scan feeds
+ * both axes. A Trashed-only closure (resolution only, no start/end/planned) is
+ * collected here via `closedInDay` and appears ONLY in the closed axis.
  *
  * Read-path is Obsidian-core only via `vaultAdapter` (no Node `fs`, no
  * `Platform` gate) — identical on desktop and mobile (Desktop↔Mobile parity).
@@ -29,13 +34,22 @@ export function collectDayEfforts(
   const efforts: DailyEffortItem[] = [];
   for (const candidate of vaultAdapter.getAllFiles()) {
     const metadata = metadataExtractor.extractMetadata(candidate);
-    if (!DailyNoteHelpers.isEffortInDay(metadata, day)) continue;
+    const inDay = DailyNoteHelpers.isEffortInDay(metadata, day);
+    const closedInDay = DailyNoteHelpers.isEffortClosedInDay(metadata, day);
+    // Union: collect an effort relevant to the day on EITHER axis.
+    if (!inDay && !closedInDay) continue;
     const label =
       typeof metadata.exo__Asset_label === "string" &&
       metadata.exo__Asset_label.trim().length > 0
         ? (metadata.exo__Asset_label as string)
         : candidate.basename;
-    efforts.push({ path: candidate.path, title: label, metadata });
+    efforts.push({
+      path: candidate.path,
+      title: label,
+      metadata,
+      inDay,
+      closedInDay,
+    });
   }
   return efforts;
 }

--- a/packages/obsidian-plugin/src/presentation/renderers/helpers/DailyNoteHelpers.ts
+++ b/packages/obsidian-plugin/src/presentation/renderers/helpers/DailyNoteHelpers.ts
@@ -155,4 +155,66 @@ export class DailyNoteHelpers {
 
     return false; // No timestamps in day interval
   }
+
+  /**
+   * Checks if an effort was CLOSED on a given day (req b2a33efc / issue #3781):
+   * its `ems__Effort_resolutionTimestamp` OR (fallback) its
+   * `ems__Effort_endTimestamp` falls within the day's local-timezone interval.
+   *
+   * This is the "Closed today" signal, distinct from {@link isEffortInDay}
+   * (which matches start/end/plannedStart/plannedEnd). Both a DONE closure (sets
+   * end + resolution) and a TRASHED closure (sets ONLY resolution) surface here;
+   * a Trashed-only effort carries no start/end/planned timestamp so is invisible
+   * to `isEffortInDay` — this predicate is the one that catches it.
+   *
+   * The day interval is computed in LOCAL timezone (identical to
+   * `isEffortInDay`): a store-side SPARQL `STRSTARTS` on the UTC `xsd:dateTime`
+   * literal would match the UTC day, off-by-tz from the note's local day in the
+   * window near local midnight (issue #3781 design fork — the TS interval match
+   * is tz-correct).
+   *
+   * @param metadata - Effort frontmatter metadata
+   * @param dayStr - Day string in format "YYYY-MM-DD" (e.g., "2025-11-02")
+   * @returns true if resolution OR end timestamp falls within the day interval
+   */
+  static isEffortClosedInDay(
+    metadata: Record<string, unknown>,
+    dayStr: string,
+  ): boolean {
+    const parts = dayStr.split("-").map(Number);
+    if (parts.length !== 3 || parts.some(isNaN)) {
+      return false; // Invalid day format
+    }
+
+    const [year, month, day] = parts;
+
+    // Create the day interval in local timezone (month is 0-indexed).
+    const dayStart = new Date(year, month - 1, day, 0, 0, 0, 0);
+    if (isNaN(dayStart.getTime())) {
+      return false; // Invalid date
+    }
+    const dayEnd = new Date(year, month - 1, day, 23, 59, 59, 999);
+
+    // Closure signals only: resolution (primary) OR end (fallback). NOT
+    // start/planned — those are "touched the day", not "closed on the day".
+    const closureFields = [
+      metadata.ems__Effort_resolutionTimestamp,
+      metadata.ems__Effort_endTimestamp,
+    ];
+
+    for (const timestampValue of closureFields) {
+      if (!timestampValue) continue; // Skip empty fields
+
+      const timestamp = new Date(timestampValue as string | number);
+      if (isNaN(timestamp.getTime())) {
+        continue; // Skip invalid timestamps
+      }
+
+      if (timestamp >= dayStart && timestamp <= dayEnd) {
+        return true;
+      }
+    }
+
+    return false; // No closure timestamp in day interval
+  }
 }

--- a/packages/obsidian-plugin/tests/unit/DailyNoteHelpers.closedInDay.test.ts
+++ b/packages/obsidian-plugin/tests/unit/DailyNoteHelpers.closedInDay.test.ts
@@ -1,0 +1,101 @@
+/**
+ * DailyNoteHelpers.isEffortClosedInDay — the "closed today" date-match predicate
+ * (req b2a33efc / issue #3781). An effort is "closed on the day" iff its
+ * ems__Effort_resolutionTimestamp OR ems__Effort_endTimestamp falls within the
+ * day's LOCAL-timezone interval. Distinct from isEffortInDay (start/end/planned):
+ * a Trashed-only closure (resolution only, no start/end/planned) is caught here.
+ *
+ * @req:b2a33efc-1b6c-4c9a-ab76-ecff66ffab08
+ *
+ * revert-verify: reverting isEffortClosedInDay to drop the resolutionTimestamp
+ * field (or to always return false) → the "resolution on the day" + "Trashed-only
+ * closure" assertions go RED; restoring → GREEN.
+ *
+ * tz-robustness: timestamps are written WITHOUT a timezone suffix
+ * ("2026-07-12T12:00:00"), so `new Date(...)` parses them as LOCAL noon — which
+ * is inside the LOCAL [00:00, 23:59:59.999] interval the predicate builds, in
+ * any runner timezone (no process.env.TZ dependence; jest-timezone rule).
+ */
+
+import { DailyNoteHelpers } from "../../src/presentation/renderers/helpers/DailyNoteHelpers";
+
+const DAY = "2026-07-12";
+const NOON_ON_DAY = "2026-07-12T12:00:00"; // local noon → inside the local day
+const NOON_PREV_DAY = "2026-07-11T12:00:00";
+
+describe("DailyNoteHelpers.isEffortClosedInDay (req b2a33efc / #3781)", () => {
+  it("@req:b2a33efc-1b6c-4c9a-ab76-ecff66ffab08 matches an effort whose resolutionTimestamp falls on the day", () => {
+    expect(
+      DailyNoteHelpers.isEffortClosedInDay(
+        { ems__Effort_resolutionTimestamp: NOON_ON_DAY },
+        DAY,
+      ),
+    ).toBe(true);
+  });
+
+  it("@req:b2a33efc-1b6c-4c9a-ab76-ecff66ffab08 matches an effort whose endTimestamp falls on the day (fallback signal)", () => {
+    expect(
+      DailyNoteHelpers.isEffortClosedInDay(
+        { ems__Effort_endTimestamp: NOON_ON_DAY },
+        DAY,
+      ),
+    ).toBe(true);
+  });
+
+  it("@req:b2a33efc-1b6c-4c9a-ab76-ecff66ffab08 matches a Trashed-only closure (resolution only, no start/end/planned)", () => {
+    // DefaultWorkflows: TRASHED sets ONLY resolutionTimestamp — the exact gap
+    // isEffortInDay misses (it checks start/end/plannedStart/plannedEnd).
+    const trashed = { ems__Effort_resolutionTimestamp: NOON_ON_DAY };
+    expect(DailyNoteHelpers.isEffortClosedInDay(trashed, DAY)).toBe(true);
+    // sanity: isEffortInDay does NOT see it (no start/end/planned)
+    expect(DailyNoteHelpers.isEffortInDay(trashed, DAY)).toBe(false);
+  });
+
+  it("@req:b2a33efc-1b6c-4c9a-ab76-ecff66ffab08 does NOT match a merely-started effort (start on day, no resolution/end)", () => {
+    // startTimestamp on the day is a "touched today" signal, not a closure.
+    const started = { ems__Effort_startTimestamp: NOON_ON_DAY };
+    expect(DailyNoteHelpers.isEffortClosedInDay(started, DAY)).toBe(false);
+    // sanity: isEffortInDay DOES see it (start on day)
+    expect(DailyNoteHelpers.isEffortInDay(started, DAY)).toBe(true);
+  });
+
+  it("@req:b2a33efc-1b6c-4c9a-ab76-ecff66ffab08 does NOT match a plannedEnd on the day (planning, not a closure)", () => {
+    expect(
+      DailyNoteHelpers.isEffortClosedInDay(
+        { ems__Effort_plannedEndTimestamp: NOON_ON_DAY },
+        DAY,
+      ),
+    ).toBe(false);
+  });
+
+  it("@req:b2a33efc-1b6c-4c9a-ab76-ecff66ffab08 does NOT match a closure on a DIFFERENT day", () => {
+    expect(
+      DailyNoteHelpers.isEffortClosedInDay(
+        { ems__Effort_resolutionTimestamp: NOON_PREV_DAY },
+        DAY,
+      ),
+    ).toBe(false);
+  });
+
+  it("@req:b2a33efc-1b6c-4c9a-ab76-ecff66ffab08 returns false for no closure timestamps at all", () => {
+    expect(DailyNoteHelpers.isEffortClosedInDay({}, DAY)).toBe(false);
+  });
+
+  it("returns false for an invalid day string", () => {
+    expect(
+      DailyNoteHelpers.isEffortClosedInDay(
+        { ems__Effort_resolutionTimestamp: NOON_ON_DAY },
+        "not-a-day",
+      ),
+    ).toBe(false);
+  });
+
+  it("returns false for an invalid closure timestamp value", () => {
+    expect(
+      DailyNoteHelpers.isEffortClosedInDay(
+        { ems__Effort_resolutionTimestamp: "garbage" },
+        DAY,
+      ),
+    ).toBe(false);
+  });
+});

--- a/packages/obsidian-plugin/tests/unit/presentation/renderers/ExoLayoutRenderer.dailyEffortsClosed.test.ts
+++ b/packages/obsidian-plugin/tests/unit/presentation/renderers/ExoLayoutRenderer.dailyEffortsClosed.test.ts
@@ -1,0 +1,312 @@
+/**
+ * ExoLayoutRenderer — the "Closed today" daily-efforts partition (req b2a33efc /
+ * issue #3781). A `daily-efforts-by-class` block with partition "closed" lists
+ * the day's efforts stamped `closedInDay` by the provider; the class buckets
+ * (Actions/Tasks/Projects) are computed only over the `inDay` subset, so a
+ * Trashed-only closure (inDay=false, closedInDay=true) appears ONLY in the
+ * closed block — zero regression to req a38ac95b's class partitions.
+ *
+ * @req:b2a33efc-1b6c-4c9a-ab76-ecff66ffab08
+ *
+ * revert-verify (production-shape — real ExoLayoutRenderer.computeDailyPartition
+ * + partitionDailyEffortsByClass + renderDailyEffortsBlock, only reactRenderer +
+ * app boundaries faked):
+ *  - neutralising the closed-axis filter in `computeDailyPartition`
+ *    (`e.closedInDay === true` → always-false) → the closed block renders empty
+ *    while the class blocks stay populated → the "closed lists the closures" +
+ *    "Trashed-only appears in closed" assertions go RED; restoring → GREEN.
+ *  - reverting the class buckets to run over ALL efforts (drop the
+ *    `e.inDay !== false` filter) → the "Trashed-only NOT in Tasks" zero-regression
+ *    assertion goes RED (the Trashed-only closure leaks into Tasks); restoring →
+ *    GREEN.
+ */
+
+import type { Layout, LayoutBlock } from "@kitelev/exocortex-core";
+import { ExoLayoutRenderer } from "../../../../src/presentation/renderers/ExoLayoutRenderer";
+import type { DailyEffortItem } from "../../../../src/presentation/renderers/ExoLayoutRenderer";
+import type { ExoLayoutSnapshot } from "../../../../src/infrastructure/repositories";
+
+function enhance(el: HTMLElement): HTMLElement {
+  (el as unknown as { setAttr: (k: string, v: string) => void }).setAttr = (
+    k,
+    v,
+  ) => el.setAttribute(k, v);
+  (el as unknown as { createDiv: (options?: unknown) => HTMLElement }).createDiv =
+    (options?: { cls?: string | string[]; attr?: Record<string, string> }) => {
+      const child = document.createElement("div");
+      if (options?.cls) {
+        child.className = Array.isArray(options.cls)
+          ? options.cls.join(" ")
+          : options.cls;
+      }
+      if (options?.attr) {
+        for (const [k, v] of Object.entries(options.attr)) {
+          child.setAttribute(k, v);
+        }
+      }
+      el.appendChild(child);
+      return enhance(child);
+    };
+  return el;
+}
+
+function makeEl(): HTMLElement {
+  return enhance(document.createElement("div"));
+}
+
+function makeLayout(blocks: string[]): Layout {
+  return {
+    uid: "daily-layout",
+    label: "Daily",
+    targetClass: "pn__DailyNote",
+    blocks,
+    priority: 0,
+    coexistsWithDefault: true,
+    sourcePath: "layout.md",
+  };
+}
+
+function dailyBlock(
+  uid: string,
+  partition: "actions" | "tasks" | "projects" | "closed",
+  visible?: boolean,
+): LayoutBlock {
+  return {
+    kind: "daily-efforts-by-class",
+    uid,
+    title: partition,
+    collapsed: false,
+    visible,
+    sourcePath: `${uid}.md`,
+    partition,
+  } as LayoutBlock;
+}
+
+function makeSnapshot(blocks: LayoutBlock[]): ExoLayoutSnapshot {
+  const byUid = new Map<string, LayoutBlock>();
+  const byLabel = new Map<string, LayoutBlock>();
+  for (const b of blocks) {
+    byUid.set(b.uid, b);
+    byLabel.set(b.uid, b);
+  }
+  return {
+    layouts: [],
+    blocks: [...blocks],
+    blocksByUid: byUid,
+    blocksByLabel: byLabel,
+  };
+}
+
+/** A day-relevant effort stamped with the two orthogonal relevance flags. */
+function effort(
+  path: string,
+  classes: string[],
+  flags: { inDay: boolean; closedInDay: boolean },
+): DailyEffortItem {
+  return {
+    path,
+    title: path.replace(/\.md$/, ""),
+    metadata: { exo__Instance_class: classes },
+    inDay: flags.inDay,
+    closedInDay: flags.closedInDay,
+  };
+}
+
+function makeRenderer(
+  snapshot: ExoLayoutSnapshot,
+  opts: { dayEfforts?: DailyEffortItem[] | null } = {},
+) {
+  const reactRenderer = {
+    render: jest.fn(),
+    cleanup: jest.fn(),
+  };
+  const logger = {
+    warn: jest.fn(),
+    info: jest.fn(),
+    debug: jest.fn(),
+    error: jest.fn(),
+  };
+  const app = {
+    metadataCache: { getFileCache: jest.fn(() => ({ frontmatter: {} })) },
+    workspace: { openLinkText: jest.fn() },
+  };
+  const renderer = new ExoLayoutRenderer({
+    app: app as never,
+    reactRenderer: reactRenderer as never,
+    logger: logger as never,
+    snapshotProvider: () => snapshot,
+    dailyEffortsProvider:
+      opts.dayEfforts === undefined ? undefined : () => opts.dayEfforts ?? null,
+  });
+  return { renderer, reactRenderer };
+}
+
+/** Pull the props of the i-th React element passed to reactRenderer.render. */
+function propsAt(reactRenderer: { render: jest.Mock }, i: number): any {
+  return (reactRenderer.render as jest.Mock).mock.calls[i][1].props;
+}
+
+describe("ExoLayoutRenderer — 'closed' daily-efforts partition (req b2a33efc / #3781)", () => {
+  // A day with three efforts of distinct relevance:
+  //  - done.md    : DONE task (inDay via endTimestamp, AND closedInDay)
+  //  - trashed.md : TRASHED-only task (resolution only → closedInDay, NOT inDay)
+  //  - started.md : merely started today (inDay, NOT closedInDay)
+  const dayEfforts = [
+    effort("done.md", ["[[ems__Task]]"], { inDay: true, closedInDay: true }),
+    effort("trashed.md", ["[[ems__Task]]"], {
+      inDay: false,
+      closedInDay: true,
+    }),
+    effort("started.md", ["[[ems__Task]]"], {
+      inDay: true,
+      closedInDay: false,
+    }),
+  ];
+
+  test("@req:b2a33efc-1b6c-4c9a-ab76-ecff66ffab08 the 'closed' block lists efforts closed on the day (Done + Trashed-only)", async () => {
+    const blocks = [dailyBlock("c", "closed", true)];
+    const snap = makeSnapshot(blocks);
+    const { renderer, reactRenderer } = makeRenderer(snap, { dayEfforts });
+    const el = makeEl();
+
+    await renderer.render(
+      el,
+      { path: "2026-07-12.md" } as never,
+      makeLayout(["c"]),
+      [],
+    );
+
+    expect(reactRenderer.render).toHaveBeenCalledTimes(1);
+    const closed = propsAt(reactRenderer, 0);
+    expect(closed.title).toBe("closed");
+    expect(closed.items.map((i: { path: string }) => i.path).sort()).toEqual([
+      "done.md",
+      "trashed.md",
+    ]);
+  });
+
+  test("@req:b2a33efc-1b6c-4c9a-ab76-ecff66ffab08 a Trashed-only closure appears ONLY in 'closed', NEVER in the Tasks class bucket (zero regression to a38ac95b)", async () => {
+    const blocks = [
+      dailyBlock("t", "tasks", true),
+      dailyBlock("c", "closed", true),
+    ];
+    const snap = makeSnapshot(blocks);
+    const { renderer, reactRenderer } = makeRenderer(snap, { dayEfforts });
+    const el = makeEl();
+
+    await renderer.render(
+      el,
+      { path: "2026-07-12.md" } as never,
+      makeLayout(["t", "c"]),
+      [],
+    );
+
+    expect(reactRenderer.render).toHaveBeenCalledTimes(2);
+    const tasks = propsAt(reactRenderer, 0);
+    const closed = propsAt(reactRenderer, 1);
+
+    // Tasks (class bucket) is computed over the inDay subset only → Done +
+    // Started, but NOT the Trashed-only closure. This is the a38ac95b behavior
+    // unchanged: the Trashed-only effort has no start/end/planned timestamp so
+    // isEffortInDay is false → it must not appear here.
+    expect(tasks.items.map((i: { path: string }) => i.path).sort()).toEqual([
+      "done.md",
+      "started.md",
+    ]);
+    expect(
+      tasks.items.some((i: { path: string }) => i.path === "trashed.md"),
+    ).toBe(false);
+
+    // The closed axis carries the Trashed-only closure (and the Done closure).
+    expect(closed.items.map((i: { path: string }) => i.path).sort()).toEqual([
+      "done.md",
+      "trashed.md",
+    ]);
+  });
+
+  test("@req:b2a33efc-1b6c-4c9a-ab76-ecff66ffab08 a day with nothing closed renders an empty 'closed' block (no error, no items)", async () => {
+    const nothingClosed = [
+      effort("started.md", ["[[ems__Task]]"], {
+        inDay: true,
+        closedInDay: false,
+      }),
+    ];
+    const blocks = [dailyBlock("c", "closed", true)];
+    const snap = makeSnapshot(blocks);
+    const { renderer, reactRenderer } = makeRenderer(snap, {
+      dayEfforts: nothingClosed,
+    });
+    const el = makeEl();
+
+    const result = await renderer.render(
+      el,
+      { path: "2026-07-12.md" } as never,
+      makeLayout(["c"]),
+      [],
+    );
+
+    // The block still renders (empty-state "No efforts" is DailyEffortsBlockView's
+    // job); no throw, zero closed items.
+    expect(result.blockCount).toBe(1);
+    const closed = propsAt(reactRenderer, 0);
+    expect(closed.items).toEqual([]);
+  });
+
+  test("@req:b2a33efc-1b6c-4c9a-ab76-ecff66ffab08 the 'closed' partition is shown out of the box (VL built-in default) with no visibility flag", async () => {
+    // No per-note override, no Layout per-block default (visible undefined) →
+    // built-in default for 'closed' is shown.
+    const blocks = [dailyBlock("c", "closed")]; // visible undefined
+    const snap = makeSnapshot(blocks);
+    const { renderer, reactRenderer } = makeRenderer(snap, { dayEfforts });
+    const el = makeEl();
+
+    const result = await renderer.render(
+      el,
+      { path: "2026-07-12.md" } as never,
+      makeLayout(["c"]),
+      [],
+    );
+
+    expect(result.blockCount).toBe(1);
+    expect(reactRenderer.render).toHaveBeenCalledTimes(1);
+    expect(propsAt(reactRenderer, 0).title).toBe("closed");
+  });
+
+  test("@req:b2a33efc-1b6c-4c9a-ab76-ecff66ffab08 pn__DailyNote_showClosed:false hides the 'closed' block (override > built-in)", async () => {
+    const blocks = [dailyBlock("c", "closed")]; // visible undefined → built-in
+    const snap = makeSnapshot(blocks);
+    const reactRenderer = { render: jest.fn(), cleanup: jest.fn() };
+    const logger = {
+      warn: jest.fn(),
+      info: jest.fn(),
+      debug: jest.fn(),
+      error: jest.fn(),
+    };
+    const app = {
+      metadataCache: {
+        getFileCache: jest.fn(() => ({
+          frontmatter: { pn__DailyNote_showClosed: false },
+        })),
+      },
+      workspace: { openLinkText: jest.fn() },
+    };
+    const renderer = new ExoLayoutRenderer({
+      app: app as never,
+      reactRenderer: reactRenderer as never,
+      logger: logger as never,
+      snapshotProvider: () => snap,
+      dailyEffortsProvider: () => dayEfforts,
+    });
+    const el = makeEl();
+
+    const result = await renderer.render(
+      el,
+      { path: "2026-07-12.md" } as never,
+      makeLayout(["c"]),
+      [],
+    );
+
+    expect(result.blockCount).toBe(0);
+    expect(reactRenderer.render).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

Closes #3781 (LOW/QoL) — a `pn__DailyNote` had no "closed today" feed. Adds a fourth daily-efforts partition, **`closed`**, to the exo__Layout `daily-efforts-by-class` block: it lists efforts **closed on the note's day** — `ems__Effort_resolutionTimestamp` OR (fallback) `ems__Effort_endTimestamp` on the `pn__DailyNote_day`.

The homoiconic daily-note feed already existed (`daily-efforts-by-class` block, req `a38ac95b`) but its provider filtered via `isEffortInDay` (start/end/plannedStart/plannedEnd) — so a **Trashed-only** closure (which sets ONLY `resolutionTimestamp`) was invisible, and there was no "closed" axis. This PR closes both gaps.

## Design (req `b2a33efc`, feature-sdd)

- **Additive, zero-regression.** The collector broadens to collect `isEffortInDay OR closed-in-day` efforts in one O(n) scan, each stamped `inDay`/`closedInDay`. The Actions/Tasks/Projects class buckets are computed **only over the `inDay` subset**, so a38ac95b's behavior is byte-identical and a Trashed-only closure appears **ONLY** in the Closed section.
- **Homoiconic.** The Layout + Block are vault assets (`daily-efforts-by-class` block, `partition: closed`). Visibility is user-configurable: built-in default **shown**, per-note override `pn__DailyNote_showClosed`.
- **AC2 (SPARQL) deviation — ruled Option A by the orchestrator.** SPARQL day-filtering IS feasible on the clean `xsd:dateTime` literals (`STRSTARTS(STR(?r),"YYYY-MM-DD")` verified against the live vault-my store — the #3805 dual-IRI налог applies to class/enum IRIs, not timestamp literals), **but** it matches the UTC day, off-by-tz from the note's local day near local midnight. The engine `isEffortClosedInDay` local-interval match is tz-correct; the feed stays homoiconic (Layout+Block = vault assets).
- **Desktop↔Mobile parity.** Read-path via `vault.adapter`, no `Platform` gate.

## Changes

- `packages/core/src/domain/layout/LayoutBlock.ts` — `closed` in `DailyEffortsPartition` union + parse array.
- `packages/core/src/domain/layout/dailyEffortsPartition.ts` — `closed` field on `DailyEffortsPartitioned` (filled by the renderer, empty from the class-partition fn — back-compat).
- `packages/core/src/domain/layout/blockVisibility.ts` — `closed` built-in default (shown) + override key `pn__DailyNote_showClosed`.
- `packages/obsidian-plugin/.../helpers/DailyNoteHelpers.ts` — new `isEffortClosedInDay` (resolution/end on day, local-tz).
- `packages/obsidian-plugin/.../helpers/DailyEffortsCollector.ts` — union collect + stamp flags.
- `packages/obsidian-plugin/.../ExoLayoutRenderer.tsx` — `DailyEffortItem.inDay/closedInDay`; `computeDailyPartition` splits (class buckets over `inDay`, closed over `closedInDay`).

## Tests (revert-verified RED→GREEN, @req:b2a33efc)

- **Unit** `DailyNoteHelpers.closedInDay.test.ts` — resolution/end match, Trashed-only closure caught, started-only/plannedEnd excluded, wrong-day/empty/invalid → false. tz-robust (local-noon timestamps).
- **Component** `ExoLayoutRenderer.dailyEffortsClosed.test.ts` — closed block lists Done+Trashed; Trashed-only ONLY in closed (never in Tasks — zero regression); empty day → empty block no error; built-in shown + `pn__DailyNote_showClosed:false` hides.
- **Core** `LayoutBlock.test.ts` — `closed` partition parses + normalises.

Revert-verify (3 axes, type-preserving Edit-break): closed-filter → closed-content tests RED (2); drop inDay filter → zero-regression test RED (1); neutralise `isEffortClosedInDay` → positive-match tests RED (3); all restored → GREEN. Local: typecheck 0, plugin 54/54 (incl. a38ac95b regression + suppression), core 44/44.

## Deployment note

Activating any `pn__DailyNote` exo__Layout **suppresses** the legacy `DailyTasksRenderer` feed, so a live layout must carry the full block set (Actions/Tasks/Projects + Closed). The live-activating layout vault assets are authored + temp-vault-verified separately; the live pixel-visual on a real daily note is a ~1-min user-confirm (ui-smoke-transitive-proof — the daily-efforts render + `DailyEffortsBlockView` are the a38ac95b-verified code-path; the delta is the added partition).
