### PR TITLE
fix(#3896): harden instantiatePrototypeSubtree — fail-loud on [[undefined]] class (M1) + idempotency guard (M2) + reuse core extractAssetReference (M4)

### DIFF
--- a/packages/cli/tests/unit/services/CliServiceRegistryPopulator.test.ts
+++ b/packages/cli/tests/unit/services/CliServiceRegistryPopulator.test.ts
@@ -40,12 +40,19 @@ jest.unstable_mockModule("@kitelev/exocortex-core", () => {
   // shape stub returning null (treated as "not a vault scheme IRI", caller
   // falls back to the raw IRI) is sufficient for the import to resolve.
   const iriToVaultPath = (_iri: string): string | null => null;
+  // Issue #3896 (M4): the prototype-subtree-instantiator factory now imports
+  // `extractAssetReference` from `exocortex-core` at module-evaluation time
+  // (de-duplicating its local `extractRef`). The deps-omitted path tested here
+  // never invokes the service body, so a shape stub is sufficient for the
+  // transitive import to resolve under ESM mocking.
+  const extractAssetReference = (_value: unknown): string | null => null;
   return {
     ServiceRegistry,
     FrontmatterService,
     WikiLinkHelpers,
     DateFormatter,
     iriToVaultPath,
+    extractAssetReference,
   };
 });
 

--- a/packages/cli/tests/unit/services/instantiate-prototype-subtree.test.ts
+++ b/packages/cli/tests/unit/services/instantiate-prototype-subtree.test.ts
@@ -227,3 +227,125 @@ describe("instantiatePrototypeSubtree (issue #3881 Gap 3)", () => {
     expect(relates.sort()).toEqual([`[[${PERSON}]]`, `[[${QUARTER}]]`].sort());
   });
 });
+
+// ---------------------------------------------------------------------------
+// Hardening (issue #3896): M1 fail-loud on an unresolvable node class + M2
+// idempotency guard against a duplicate re-deploy. @req:6666e9f0-...
+// Production-shape revert-verify — the service runs end-to-end over the fake
+// vault; reverting either guard flips the marked assertion RED.
+// ---------------------------------------------------------------------------
+
+const REQ = "6666e9f0-34fe-41dd-ab3a-a53c6ce94b5a";
+const EXISTING = "e0000000-0000-0000-0000-0000000000e1";
+const EXISTING_OTHER = "e0000000-0000-0000-0000-0000000000e2";
+const OTHER_QUARTER = "ffffffff-0000-0000-0000-000000000099";
+
+/** Build an adapter+writer from an arbitrary raw markdown fixture map. */
+function makeAdapterFrom(raw: Record<string, string>) {
+  const fm = new FrontmatterService();
+  const files = Object.keys(raw).map((uid) => mkFile(uid));
+  const byPath = new Map<string, string>();
+  files.forEach((f) => byPath.set(f.path, raw[f.basename]));
+  const writes: { path: string; content: string }[] = [];
+  const vaultAdapter = {
+    getAllFiles: () => files,
+    getFrontmatter: (file: { path: string }) => {
+      const content = byPath.get(file.path);
+      return content ? fm.parseObject(content) : null;
+    },
+  } as never;
+  const fsAdapter = {
+    createFile: async (path: string, content: string) => {
+      writes.push({ path, content });
+      return path;
+    },
+  } as never;
+  return { vaultAdapter, fsAdapter, writes, fm };
+}
+
+describe(`instantiatePrototypeSubtree hardening (issue #3896, @req:${REQ})`, () => {
+  const rootIRI = `obsidian://vault/efforts/${ROOT}.md`;
+
+  it(`M1: fails loud when a subtree node's class is unresolvable — no [[undefined]], zero partial write (@req:6666e9f0-34fe-41dd-ab3a-a53c6ce94b5a)`, async () => {
+    const raw = fixtures();
+    // Malform C1: strip its exo__Instance_class. It is still parented to the root
+    // (so it IS discovered in the subtree), and classLabel(undefined) → undefined
+    // → instClassLabel falsy → the OLD code would write exo__Instance_class:
+    // [[undefined]] for it.
+    raw[C1] = `---\nexo__Asset_uid: ${C1}\nexo__Asset_label: "Поручить {{сотрудник}} заполнить {{квартал}}"\nems__EffortPrototype_parentEffortPrototype: "[[${ROOT}]]"\n---\n`;
+    const { vaultAdapter, fsAdapter, writes } = makeAdapterFrom(raw);
+    const service = createInstantiatePrototypeSubtreeService(
+      vaultAdapter,
+      fsAdapter,
+    );
+
+    // (revert-verify anchor M1) — removing the pre-pass guard lets the service
+    // succeed and write a node with a dangling [[undefined]] class → this
+    // rejection assertion flips RED.
+    await expect(
+      service.execute(rootIRI, {
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        сотрудник: `[[${PERSON}]]`,
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        квартал: `[[${QUARTER}]]`,
+      }),
+    ).rejects.toThrow(/cannot resolve instance class/i);
+
+    // Atomic: the pre-pass throws BEFORE any file is written — zero partial
+    // state, and in particular nothing with a dangling [[undefined]] class.
+    expect(writes).toHaveLength(0);
+  });
+
+  it(`M2: refuses to re-deploy an already-instantiated subtree (same prototype + same ref-params) (@req:6666e9f0-34fe-41dd-ab3a-a53c6ce94b5a)`, async () => {
+    const raw = fixtures();
+    // A prior deployment already exists: an instance of the ROOT prototype whose
+    // exo__Asset_relates set is exactly the current ref-params (person + quarter).
+    raw[EXISTING] = `---\nexo__Asset_uid: ${EXISTING}\nexo__Instance_class:\n  - "[[ems__Project]]"\nexo__Asset_label: "Ревьюшница n.rudopas Q3-26"\nexo__Asset_prototype: "[[${ROOT}]]"\nexo__Asset_relates:\n  - "[[${PERSON}]]"\n  - "[[${QUARTER}]]"\n---\n`;
+    const { vaultAdapter, fsAdapter, writes } = makeAdapterFrom(raw);
+    const service = createInstantiatePrototypeSubtreeService(
+      vaultAdapter,
+      fsAdapter,
+    );
+
+    // (revert-verify anchor M2) — removing the idempotency guard lets a second
+    // full subgraph be written → this rejection assertion flips RED.
+    await expect(
+      service.execute(rootIRI, {
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        сотрудник: `[[${PERSON}]]`,
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        квартал: `[[${QUARTER}]]`,
+      }),
+    ).rejects.toThrow(/already deployed/i);
+
+    // No second subgraph written.
+    expect(writes).toHaveLength(0);
+  });
+
+  it(`M2 negative-control: a DIFFERENT employee/quarter is NOT blocked — the guard matches only the exact ref-param set (@req:6666e9f0-34fe-41dd-ab3a-a53c6ce94b5a)`, async () => {
+    const raw = fixtures();
+    // A prior deployment exists for the SAME prototype but a DIFFERENT ref-param
+    // set (different quarter) → it must NOT block the current deployment.
+    raw[EXISTING_OTHER] = `---\nexo__Asset_uid: ${EXISTING_OTHER}\nexo__Instance_class:\n  - "[[ems__Project]]"\nexo__Asset_label: "Ревьюшница n.rudopas Q2-26"\nexo__Asset_prototype: "[[${ROOT}]]"\nexo__Asset_relates:\n  - "[[${PERSON}]]"\n  - "[[${OTHER_QUARTER}]]"\n---\n`;
+    const { vaultAdapter, fsAdapter, writes, fm } = makeAdapterFrom(raw);
+    const service = createInstantiatePrototypeSubtreeService(
+      vaultAdapter,
+      fsAdapter,
+    );
+
+    await service.execute(rootIRI, {
+      // eslint-disable-next-line @typescript-eslint/naming-convention
+      сотрудник: `[[${PERSON}]]`,
+      // eslint-disable-next-line @typescript-eslint/naming-convention
+      квартал: `[[${QUARTER}]]`,
+    });
+
+    // Deploys normally: root + C1 + C2 + C3.
+    expect(writes).toHaveLength(4);
+    const nodes = parseWrites(writes, fm);
+    const rootInst = nodes.find((n) => n.protoUid === ROOT)!;
+    expect(rootInst).toBeTruthy();
+    const relates = (rootInst.fm.exo__Asset_relates as string[]).map(unq);
+    expect(relates.sort()).toEqual([`[[${PERSON}]]`, `[[${QUARTER}]]`].sort());
+  });
+});

--- a/packages/services/src/prototype-subtree-instantiator.ts
+++ b/packages/services/src/prototype-subtree-instantiator.ts
@@ -1,4 +1,4 @@
-import { DateFormatter } from "@kitelev/exocortex-core";
+import { DateFormatter, extractAssetReference } from "@kitelev/exocortex-core";
 import type {
   IGroundingService,
   IVaultAdapter,
@@ -56,20 +56,13 @@ interface IndexEntry {
   uid: string;
 }
 
-/** Strip surrounding quotes + `[[ ]]` + optional `|alias`, return the target UID/ref. */
-function extractRef(value: unknown): string | undefined {
-  if (typeof value !== "string") return undefined;
-  let v = value.trim();
-  if (
-    (v.startsWith('"') && v.endsWith('"')) ||
-    (v.startsWith("'") && v.endsWith("'"))
-  ) {
-    v = v.slice(1, -1).trim();
-  }
-  const m = v.match(/^\[\[([^\]|]+)(?:\|[^\]]*)?\]\]$/);
-  if (m) return m[1].trim();
-  return v || undefined;
-}
+// The local `extractRef` was a 4th re-implementation of the canonical
+// `extractAssetReference` (`packages/core/src/utilities/extractAssetReference.ts`,
+// created specifically to de-triplicate this exact helper — audit #3384 finding
+// H4). De-duplicated per issue #3896 (M4): import the canonical one instead of
+// maintaining a divergent copy. (It returns `string | null` where the local one
+// returned `string | undefined` — semantically identical at every guarded
+// callsite here.)
 
 /** The alias part of `[[uid|alias]]`, if present. */
 function extractAlias(value: unknown): string | undefined {
@@ -125,7 +118,7 @@ export function createInstantiatePrototypeSubtreeService(
       const classLabel = (classRef: unknown): string | undefined => {
         const alias = extractAlias(firstValue(classRef));
         if (alias) return alias;
-        const ref = extractRef(firstValue(classRef));
+        const ref = extractAssetReference(firstValue(classRef));
         if (!ref) return undefined;
         const entry = byUid.get(ref);
         return entry ? plainScalar(entry.fm.exo__Asset_label) : ref;
@@ -147,7 +140,7 @@ export function createInstantiatePrototypeSubtreeService(
         grew = false;
         for (const [uid, entry] of byUid) {
           if (subtree.has(uid)) continue;
-          const parentUid = extractRef(firstValue(entry.fm[PARENT_PROTOTYPE_KEY]));
+          const parentUid = extractAssetReference(firstValue(entry.fm[PARENT_PROTOTYPE_KEY]));
           if (parentUid && subtree.has(parentUid)) {
             subtree.add(uid);
             grew = true;
@@ -168,7 +161,7 @@ export function createInstantiatePrototypeSubtreeService(
       for (const [key, raw] of Object.entries(userInput ?? {})) {
         if (raw == null) continue;
         if (key === "label" || key === "body") continue;
-        const refUid = extractRef(firstValue(raw));
+        const refUid = extractAssetReference(firstValue(raw));
         const target = refUid ? byUid.get(refUid) : undefined;
         if (target) {
           const targetLabel = target.fm.exo__Asset_label
@@ -177,7 +170,7 @@ export function createInstantiatePrototypeSubtreeService(
           substitutions[key] = targetLabel ?? String(raw);
           const clsLabel = classLabel(target.fm.exo__Instance_class) ?? "";
           if (clsLabel.includes("Project")) {
-            if (!parentEffortRef) parentEffortRef = refUid;
+            if (!parentEffortRef) parentEffortRef = refUid ?? undefined;
           } else {
             relatesRefs.push(refUid as string);
           }
@@ -194,6 +187,56 @@ export function createInstantiatePrototypeSubtreeService(
         }
         return s;
       };
+
+      // M2 idempotency guard (issue #3896): refuse to re-deploy the same subtree.
+      // A prior deployment is an existing instance whose `exo__Asset_prototype` is
+      // this root prototype AND whose `exo__Asset_relates` set equals the current
+      // ref-params (person + quarter + any non-Project ref). An accidental
+      // double-click therefore aborts with an explicit error instead of silently
+      // generating a second full N-node subgraph. A different ref-param set (a
+      // different employee/quarter) is NOT blocked.
+      const relatesSet = new Set(relatesRefs);
+      for (const entry of byUid.values()) {
+        const protoRef = extractAssetReference(
+          firstValue(entry.fm.exo__Asset_prototype),
+        );
+        if (protoRef !== rootUid) continue;
+        const rel = entry.fm.exo__Asset_relates;
+        const existingRelates = new Set(
+          (Array.isArray(rel) ? rel : rel != null ? [rel] : [])
+            .map((r) => extractAssetReference(r))
+            .filter((r): r is string => r != null),
+        );
+        if (
+          existingRelates.size === relatesSet.size &&
+          [...relatesSet].every((r) => existingRelates.has(r))
+        ) {
+          throw new Error(
+            `instantiatePrototypeSubtree: already deployed — an instance of prototype ${rootUid} with the same ref-params [${[...relatesSet].join(", ")}] already exists (${entry.file.path}). Refusing to duplicate the subgraph.`,
+          );
+        }
+      }
+
+      // M1 fail-loud pre-pass (issue #3896): validate every node's instance class
+      // resolves to a non-empty label BEFORE any write, so a malformed subtree (a
+      // node whose `exo__Instance_class` is missing/unresolvable) aborts the whole
+      // deployment instead of silently writing `exo__Instance_class: [[undefined]]`
+      // (a dangling wikilink that reddens SHACL later). No-null for a domain
+      // output; atomic — zero partial state on abort.
+      for (const protoUid of subtree) {
+        const entry = byUid.get(protoUid);
+        if (!entry) continue;
+        const protoClassLabel = classLabel(entry.fm.exo__Instance_class);
+        const instClassLabel =
+          protoClassLabel && protoClassLabel.endsWith("Prototype")
+            ? protoClassLabel.slice(0, -"Prototype".length)
+            : protoClassLabel;
+        if (!instClassLabel) {
+          throw new Error(
+            `instantiatePrototypeSubtree: cannot resolve instance class for subtree node ${protoUid} (${entry.file.path}) — its exo__Instance_class is missing or unresolvable. Aborting so no asset is written with a dangling [[undefined]] class.`,
+          );
+        }
+      }
 
       // 6. Write each instance. Co-locate in the prototype node's folder.
       const createdAt = DateFormatter.toISOTimestamp(new Date());
@@ -216,7 +259,7 @@ export function createInstantiatePrototypeSubtreeService(
         const lines: string[] = ["---", `exo__Asset_uid: ${newUid}`];
         if (fm.exo__Asset_isDefinedBy) {
           lines.push(
-            `exo__Asset_isDefinedBy: "[[${extractRef(firstValue(fm.exo__Asset_isDefinedBy))}]]"`,
+            `exo__Asset_isDefinedBy: "[[${extractAssetReference(firstValue(fm.exo__Asset_isDefinedBy))}]]"`,
           );
         }
         lines.push(
@@ -233,7 +276,7 @@ export function createInstantiatePrototypeSubtreeService(
 
         // Blocker re-map onto the cloned sibling (fall back to original if the
         // blocker target is outside the subtree).
-        const blockerUid = extractRef(firstValue(fm.ems__Effort_blocker));
+        const blockerUid = extractAssetReference(firstValue(fm.ems__Effort_blocker));
         if (blockerUid) {
           const mapped = instUid.get(blockerUid) ?? blockerUid;
           lines.push(`ems__Effort_blocker: "[[${mapped}]]"`);


### PR DESCRIPTION
## Summary

Hardens the shipped `instantiatePrototypeSubtree` service (`packages/services`, #3881/PR #3887) against the 3 MEDIUM robustness/maintainability findings of the dual review. **All findings confirmed by line-read** before implementation. Zero signature change → storage-agnostic Desktop↔Mobile parity preserved.

**Req:** `6666e9f0-34fe-41dd-ab3a-a53c6ce94b5a` (Approved — M2 direction = explicit "already deployed" error, orchestrator-mediated approval under mandate).

## Changes

### M1 — fail-loud on an unresolvable node class (was: silent `[[undefined]]`)
A **pre-pass** validates that every subtree node's `exo__Instance_class` resolves to a non-empty label **before any file is written**. A node with a missing/unresolvable class now aborts the whole deployment with a clear error naming the node — **atomic** (zero partial state) — instead of silently writing `exo__Instance_class: [[undefined]]` (a dangling wikilink that reddens SHACL later). Mirrors the existing root-not-found guard; No-null for a domain output (φ/EO). Chose **throw** over skip-node-with-log because skipping leaves dangling `ems__Effort_parent`/`ems__Effort_blocker` edges (the blocker re-map falls back to the *prototype*).

### M2 — idempotency guard against duplicate re-deploy
Before writing, scans the vault for an existing instance whose `exo__Asset_prototype` is the root prototype **and** whose `exo__Asset_relates` set equals the current ref-params; if present → explicit `already deployed` error (naming the prototype + params), refusing to generate a second full N-node subgraph. A **different** employee/quarter (different ref-param set) is **not** blocked.

### M4 — reuse the canonical `extractAssetReference` (DRY)
Replaces the local `extractRef` (a 4th re-implementation) with the canonical `packages/core/src/utilities/extractAssetReference` — created specifically to de-triplicate this exact helper (audit #3384-H4). Behavior-preserving (`string | null` vs `string | undefined` — identical at every guarded callsite). The Prototype-strip/emission-helper extraction (issue's optional part) is **deferred** — cross-package shared-helper extraction with `createCreateAssetService` is higher blast-radius, a separate refactor.

### LOW/NIT
Out of scope by design (issue marks optional). N4 (empty label → `""`) intentionally **not** folded in — M1 targets the `[[undefined]]`-class corruption specifically (an empty label is valid YAML, not a dangling wikilink).

## Revert-verify (`@req:6666e9f0-34fe-41dd-ab3a-a53c6ce94b5a`)
Production-shape (real `FrontmatterService` fixtures, service run end-to-end over the fake vault). Type-preserving Edit-breaks, per-axis, isolated:
- **M1**: `if (false && !instClassLabel)` → **only the M1 test RED** (others green); restore → green.
- **M2**: `if (false && …)` → **only the M2 test RED** (others green); restore → green.
- **M2 negative-control** (different quarter) stays **green in both breaks** → guard is not over-broad.
- **M4**: existing 2 tests + full **340 CLI services** + **81 plugin registrar** tests stay green (behavior preserved). CI `check:types` (ES6) + `check-test-antipatterns` (55/55) + eslint clean.

## Notes
- CI-fix rider: `CliServiceRegistryPopulator.test.ts` explicitly mocks `@kitelev/exocortex-core` with a fixed export set; added an `extractAssetReference` shape stub (the new transitive import; deps-omitted path never invokes it).
- Pixel-visual / live-Obsidian smoke not applicable — behavior is fully exercised by the production-shape revert-verify test over the real service.

Closes #3896
