### PR TITLE
fix(cli): tolerant frontmatter parse — duplicated YAML key no longer makes an asset invisible (#3800)

### DIFF
--- a/packages/cli/src/adapters/FileSystemVaultAdapter.ts
+++ b/packages/cli/src/adapters/FileSystemVaultAdapter.ts
@@ -1,7 +1,13 @@
 import fs from "fs-extra";
 import path from "path";
 import yaml from "js-yaml";
-import { IVaultAdapter, IFile, IFolder, IFrontmatter } from "@kitelev/exocortex-core";
+import {
+  IVaultAdapter,
+  IFile,
+  IFolder,
+  IFrontmatter,
+  parseYamlFrontmatterTolerant,
+} from "@kitelev/exocortex-core";
 import { rewriteInboundWikilinks } from "../utils/wikilinkRewriter.js";
 
 /** UUID v4 pattern for wikilink resolution */
@@ -363,14 +369,9 @@ export class FileSystemVaultAdapter implements IVaultAdapter {
       return null;
     }
 
-    try {
-      const parsed = yaml.load(match[1]);
-      return typeof parsed === "object" && parsed !== null
-        ? (parsed as IFrontmatter)
-        : null;
-    } catch (error) {
-      return null;
-    }
+    // #3800: tolerant parse — a duplicated mapping key would otherwise throw
+    // and collapse the asset to `null` (0 triples → invisible & unrepairable).
+    return parseYamlFrontmatterTolerant(match[1]) as IFrontmatter | null;
   }
 
   private replaceFrontmatter(

--- a/packages/cli/src/adapters/NodeFsAdapter.ts
+++ b/packages/cli/src/adapters/NodeFsAdapter.ts
@@ -1,11 +1,11 @@
 import fs from "fs-extra";
 import path from "path";
 import * as glob from "glob";
-import yaml from "js-yaml";
 import {
   IFileSystemAdapter,
   FileNotFoundError,
   FileAlreadyExistsError,
+  parseYamlFrontmatterTolerant,
 } from "@kitelev/exocortex-core";
 
 export class NodeFsAdapter implements IFileSystemAdapter {
@@ -203,14 +203,9 @@ export class NodeFsAdapter implements IFileSystemAdapter {
       return {};
     }
 
-    try {
-      const parsed = yaml.load(match[1]);
-      return typeof parsed === "object" && parsed !== null
-        ? (parsed as Record<string, any>)
-        : {};
-    } catch (error) {
-      return {};
-    }
+    // #3800: tolerant parse — a duplicated mapping key would otherwise throw
+    // and collapse the asset to `{}` (0 triples → invisible & unrepairable).
+    return parseYamlFrontmatterTolerant(match[1]) ?? {};
   }
 
   private matchesQuery(

--- a/packages/cli/src/commands/repair-frontmatter.ts
+++ b/packages/cli/src/commands/repair-frontmatter.ts
@@ -1,0 +1,177 @@
+import { Command } from "commander";
+import { resolve, relative, isAbsolute, sep as pathSep } from "path";
+import { existsSync, readFileSync, writeFileSync } from "fs";
+import { ErrorHandler } from "../utils/ErrorHandler.js";
+import { VaultNotFoundError } from "../utils/errors/index.js";
+
+interface RepairFrontmatterOptions {
+  vault: string;
+  dryRun?: boolean;
+  yes?: boolean;
+}
+
+/** One deduplicated key + how many earlier occurrences were dropped. */
+export interface RemovedKey {
+  key: string;
+  removedOccurrences: number;
+}
+
+export interface DedupeResult {
+  changed: boolean;
+  content: string;
+  removed: RemovedKey[];
+}
+
+/**
+ * A raw frontmatter "segment": a top-level key line plus every following
+ * indented / blank / comment / array-item line that belongs to it, so a
+ * multi-line value (array, block scalar) is kept as one unit.
+ */
+interface Segment {
+  key: string | null;
+  lines: string[];
+}
+
+// A NEW top-level key starts a segment: a line that begins with a non-space,
+// non-`#` character and has a `:` (either `key:` or `key: value`). Everything
+// else (indented lines, blank lines, comments, `  - array` items) attaches to
+// the current segment.
+const TOP_LEVEL_KEY = /^([^\s#][^:]*):(?:\s.*)?$/;
+
+/**
+ * Remove duplicated top-level frontmatter keys, keeping the LAST occurrence of
+ * each. Last-wins matches js-yaml's `{ json: true }` tolerant parse (#3800) and
+ * `FrontmatterService.parseObject`'s line parser, so the on-disk file after
+ * repair reads identically to how the tolerant parser already read it.
+ *
+ * Operates purely on raw text — it does NOT require the file to parse — so it
+ * is the dogfood-clean repair for the invisible/unrepairable duplicate-key
+ * class: the CLI can fix a file it could not itself parse.
+ *
+ * A no-op (returns `changed: false`, original content) when there is no
+ * frontmatter block or no duplicated top-level key.
+ */
+export function dedupeFrontmatterKeys(content: string): DedupeResult {
+  const match = content.match(/^(---\r?\n)([\s\S]*?)(\r?\n---)/);
+  if (!match) {
+    return { changed: false, content, removed: [] };
+  }
+  const [, open, block, close] = match;
+  const eol = open.includes("\r\n") ? "\r\n" : "\n";
+  const lines = block.split(/\r?\n/);
+
+  const segments: Segment[] = [];
+  for (const line of lines) {
+    const keyMatch = TOP_LEVEL_KEY.exec(line);
+    if (keyMatch) {
+      segments.push({ key: keyMatch[1], lines: [line] });
+    } else if (segments.length > 0) {
+      segments[segments.length - 1].lines.push(line);
+    } else {
+      // Leading line(s) before the first key (e.g. a blank line) — keyless.
+      segments.push({ key: null, lines: [line] });
+    }
+  }
+
+  // Count occurrences and the last index of each key.
+  const counts = new Map<string, number>();
+  const lastIndex = new Map<string, number>();
+  segments.forEach((seg, i) => {
+    if (seg.key !== null) {
+      counts.set(seg.key, (counts.get(seg.key) ?? 0) + 1);
+      lastIndex.set(seg.key, i);
+    }
+  });
+
+  const removed = new Map<string, number>();
+  const kept = segments.filter((seg, i) => {
+    if (seg.key === null || (counts.get(seg.key) ?? 0) <= 1) return true;
+    if (i === lastIndex.get(seg.key)) return true; // keep the last occurrence
+    removed.set(seg.key, (removed.get(seg.key) ?? 0) + 1);
+    return false;
+  });
+
+  if (removed.size === 0) {
+    return { changed: false, content, removed: [] };
+  }
+
+  const newBlock = kept.map((s) => s.lines.join(eol)).join(eol);
+  const newContent = content.replace(match[0], `${open}${newBlock}${close}`);
+  return {
+    changed: true,
+    content: newContent,
+    removed: [...removed.entries()].map(([key, removedOccurrences]) => ({
+      key,
+      removedOccurrences,
+    })),
+  };
+}
+
+export function repairFrontmatterCommand(): Command {
+  return new Command("repair-frontmatter")
+    .description(
+      "Remove duplicated top-level YAML frontmatter keys (keep-last) — the dogfood-clean repair for the invisible/unrepairable duplicate-key class (#3800). Operates on raw text, so it fixes a file the parser itself cannot read.",
+    )
+    .argument("<path>", "Vault-relative path to the target asset")
+    .option("--vault <path>", "Path to Obsidian vault", process.cwd())
+    .option("--dry-run", "Preview the dedupe diff without writing")
+    .option(
+      "--yes",
+      "Accepted for symmetry with the apply/create subcommands (repair-frontmatter is non-interactive; no-op)",
+    )
+    .action(async (pathArg: string, options: RepairFrontmatterOptions) => {
+      try {
+        const vaultPath = resolve(options.vault);
+        if (!existsSync(vaultPath)) {
+          throw new VaultNotFoundError(vaultPath);
+        }
+
+        // Resolve + guard the target path (must be inside the vault). Mirrors
+        // set-property / apply's vault-relative canonicalisation (#3788).
+        const targetPath = resolve(vaultPath, pathArg);
+        if (!existsSync(targetPath)) {
+          throw new Error(`Target file not found: ${pathArg}`);
+        }
+        const vaultRelative = relative(vaultPath, targetPath);
+        if (
+          vaultRelative === ".." ||
+          vaultRelative.startsWith(`..${pathSep}`) ||
+          isAbsolute(vaultRelative)
+        ) {
+          throw new Error(
+            `Target is outside the vault: ${pathArg} (vault: ${vaultPath})`,
+          );
+        }
+
+        const original = readFileSync(targetPath, "utf-8");
+        const result = dedupeFrontmatterKeys(original);
+
+        if (!result.changed) {
+          process.stdout.write(
+            JSON.stringify({
+              path: vaultRelative,
+              changed: false,
+              dryRun: Boolean(options.dryRun),
+              removed: [],
+            }) + "\n",
+          );
+          return;
+        }
+
+        if (!options.dryRun) {
+          writeFileSync(targetPath, result.content, "utf-8");
+        }
+
+        process.stdout.write(
+          JSON.stringify({
+            path: vaultRelative,
+            changed: true,
+            dryRun: Boolean(options.dryRun),
+            removed: result.removed,
+          }) + "\n",
+        );
+      } catch (error) {
+        ErrorHandler.handle(error as Error);
+      }
+    });
+}

--- a/packages/cli/src/commands/repair-frontmatter.ts
+++ b/packages/cli/src/commands/repair-frontmatter.ts
@@ -96,7 +96,13 @@ export function dedupeFrontmatterKeys(content: string): DedupeResult {
   }
 
   const newBlock = kept.map((s) => s.lines.join(eol)).join(eol);
-  const newContent = content.replace(match[0], `${open}${newBlock}${close}`);
+  // Splice by index rather than `content.replace(match[0], replacement)` — a
+  // string replacement interprets `$$` / `$&` / `$1` / `` $` `` in the frontmatter
+  // VALUES as special patterns and would silently corrupt them (a repair tool
+  // must never mangle content; same class as #3795 H1). The block is `^`-anchored
+  // so it always sits at index 0; the rest of the file follows it verbatim.
+  const newContent =
+    `${open}${newBlock}${close}` + content.slice(match[0].length);
   return {
     changed: true,
     content: newContent,
@@ -127,11 +133,10 @@ export function repairFrontmatterCommand(): Command {
         }
 
         // Resolve + guard the target path (must be inside the vault). Mirrors
-        // set-property / apply's vault-relative canonicalisation (#3788).
+        // set-property / apply's vault-relative canonicalisation (#3788). This is
+        // a pure path computation (no filesystem poll), so it does not create a
+        // check-then-use TOCTOU race (js/file-system-race).
         const targetPath = resolve(vaultPath, pathArg);
-        if (!existsSync(targetPath)) {
-          throw new Error(`Target file not found: ${pathArg}`);
-        }
         const vaultRelative = relative(vaultPath, targetPath);
         if (
           vaultRelative === ".." ||
@@ -143,7 +148,17 @@ export function repairFrontmatterCommand(): Command {
           );
         }
 
-        const original = readFileSync(targetPath, "utf-8");
+        // Read directly and surface a friendly not-found on ENOENT — avoids an
+        // `existsSync` check-then-read/write pair (js/file-system-race).
+        let original: string;
+        try {
+          original = readFileSync(targetPath, "utf-8");
+        } catch (readError) {
+          if ((readError as NodeJS.ErrnoException).code === "ENOENT") {
+            throw new Error(`Target file not found: ${pathArg}`);
+          }
+          throw readError;
+        }
         const result = dedupeFrontmatterKeys(original);
 
         if (!result.changed) {

--- a/packages/cli/src/commands/validate-schema.ts
+++ b/packages/cli/src/commands/validate-schema.ts
@@ -2,6 +2,7 @@ import { Command } from "commander";
 import { existsSync, readFileSync, readdirSync, statSync } from "fs";
 import { resolve, relative, join } from "path";
 import { execSync } from "child_process";
+import yaml from "js-yaml";
 import {
   InMemoryTripleStore,
   ExoQLParser,
@@ -415,6 +416,25 @@ export async function loadDeclaredProperties(
 }
 
 /**
+ * Detect frontmatter that a STRICT YAML parser rejects — most notably a
+ * duplicated mapping key (#3800). Such files are invisible to
+ * SPARQL/preconditions (an adapter falls back to `{}` → 0 triples) yet the
+ * regex-based {@link extractFrontmatter} above still key-extracts them, so
+ * `validate schema` used to skip them silently. Returns a one-line reason, or
+ * null when the frontmatter parses strictly (or there is no frontmatter block).
+ */
+export function detectUnparseableFrontmatter(content: string): string | null {
+  const match = content.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+  if (!match) return null;
+  try {
+    yaml.load(match[1]);
+    return null;
+  } catch (error) {
+    return error instanceof Error ? error.message.split("\n")[0] : String(error);
+  }
+}
+
+/**
  * Validate a single file's frontmatter against the declared properties set.
  */
 export function validateFile(
@@ -431,8 +451,20 @@ export function validateFile(
     return [];
   }
 
+  // #3800: surface frontmatter a strict YAML parser rejects (e.g. a duplicated
+  // mapping key) — otherwise the file is invisible to SPARQL/preconditions AND
+  // to this validator. Reported so the user can fix it via `repair-frontmatter`.
+  const parseError = detectUnparseableFrontmatter(content);
+  if (parseError) {
+    violations.push({
+      file: relativePath,
+      property: "(frontmatter)",
+      reason: `Unparseable YAML frontmatter (${parseError}) — invisible to SPARQL/preconditions; repair with: exocortex repair-frontmatter "${relativePath}"`,
+    });
+  }
+
   const frontmatter = extractFrontmatter(content);
-  if (!frontmatter) return [];
+  if (!frontmatter) return violations;
 
   const keys = Object.keys(frontmatter);
   const { toValidate, unknownPrefix } = classifyKeys(keys);

--- a/packages/cli/src/program.ts
+++ b/packages/cli/src/program.ts
@@ -9,6 +9,7 @@ import { classesCommand } from "./commands/classes.js";
 import { runQueryCommand } from "./commands/run-query.js";
 import { createCommand } from "./commands/create.js";
 import { setPropertyCommand } from "./commands/set-property.js";
+import { repairFrontmatterCommand } from "./commands/repair-frontmatter.js";
 import { recoverCommand } from "./commands/recover.js";
 import { findCommand } from "./commands/find.js";
 import { applyCommand } from "./commands/apply.js";
@@ -71,6 +72,10 @@ export function createProgram(version?: string): Command {
   // Refuses state-machine-guarded properties (status/zone/parent/label/…) so their
   // dedicated `apply` commands are not bypassed.
   program.addCommand(setPropertyCommand());
+  // repair-frontmatter — raw-text dedupe of duplicated top-level YAML keys
+  // (keep-last). The dogfood-clean repair for the invisible/unrepairable
+  // duplicate-key class (#3800): fixes a file the parser itself cannot read.
+  program.addCommand(repairFrontmatterCommand());
   // recover — retained: live launchd consumer (com.exocortex.aitask-recover
   // hourly job calls `exocortex-cli recover --apply`). RFC 7c7859d1 reclassifies
   // it from W0 cheap-remove to migration-first (retire/port that consumer first).

--- a/packages/cli/tests/integration/dupkey-invisible-asset.integration.test.ts
+++ b/packages/cli/tests/integration/dupkey-invisible-asset.integration.test.ts
@@ -1,0 +1,133 @@
+/**
+ * Issue #3800 — a duplicated YAML mapping key must NOT make an asset invisible.
+ *
+ * Production-shape revert-verify (test-fixture-realism +
+ * integration-test-revert-verify): a real dup-key `.md` is written to a temp
+ * vault on disk, then read back through the REAL adapters and the REAL
+ * `NoteToRDFConverter.convertNote` — the exact pipeline `apply`/`query` use to
+ * build the triple store that every precondition ASK runs against. Nothing is
+ * hand-injected past the buggy `extractFrontmatter` stage.
+ *
+ * With the tolerant-parse fix (`parseYamlFrontmatterTolerant`, `{ json: true }`
+ * last-wins), the adapters return the frontmatter and the converter emits the
+ * asset's triples. Revert the fix (bare `yaml.load` throws → `{}`/null) and:
+ *   - FileSystemVaultAdapter.getFrontmatter → null   → status assertion RED
+ *   - NodeFsAdapter.getFileMetadata        → {}      → status assertion RED
+ *   - NoteToRDFConverter.convertNote       → []      → triple assertions RED
+ * The clean-asset negative control stays GREEN either way (non-vacuity).
+ */
+import { describe, it, expect, beforeEach, afterEach } from "@jest/globals";
+import * as fs from "fs";
+import * as path from "path";
+import * as os from "os";
+import { NoteToRDFConverter, NullLogger, type IFile } from "@kitelev/exocortex-core";
+
+const { FileSystemVaultAdapter } = await import(
+  "../../src/adapters/FileSystemVaultAdapter.js"
+);
+const { NodeFsAdapter } = await import("../../src/adapters/NodeFsAdapter.js");
+
+const DUPKEY_UID = "16458983-1302-403a-bc70-b23896d1caec";
+const CLEAN_UID = "c1eanc1e-0000-4000-8000-000000000001";
+
+/** A freshly-seeded dup-key repro: exo__Asset_prototype twice (lines 3 & 5). */
+const DUPKEY_MD = [
+  "---",
+  `exo__Asset_uid: ${DUPKEY_UID}`,
+  'exo__Instance_class: "[[1b20a8f0-d745-4e93-91db-4531b3df120e|ems__Task]]"',
+  'exo__Asset_prototype: "[[aaa]]"',
+  'ems__Effort_status: "[[753a44d5-846c-4b82-9196-4fd9a4d48777|ems__EffortStatusBacklog]]"',
+  'exo__Asset_prototype: "[[bbb]]"',
+  'exo__Asset_label: "Dup key repro"',
+  "---",
+  "body",
+  "",
+].join("\n");
+
+const CLEAN_MD = [
+  "---",
+  `exo__Asset_uid: ${CLEAN_UID}`,
+  'exo__Instance_class: "[[1b20a8f0-d745-4e93-91db-4531b3df120e|ems__Task]]"',
+  'ems__Effort_status: "[[753a44d5-846c-4b82-9196-4fd9a4d48777|ems__EffortStatusBacklog]]"',
+  'exo__Asset_label: "Clean asset"',
+  "---",
+  "body",
+  "",
+].join("\n");
+
+describe("#3800: duplicated YAML key keeps the asset visible", () => {
+  let vault: string;
+  const dupRel = `assets/${DUPKEY_UID}.md`;
+  const cleanRel = `assets/${CLEAN_UID}.md`;
+
+  beforeEach(() => {
+    vault = fs.mkdtempSync(path.join(os.tmpdir(), "cli-3800-"));
+    fs.mkdirSync(path.join(vault, "assets"), { recursive: true });
+    fs.writeFileSync(path.join(vault, dupRel), DUPKEY_MD);
+    fs.writeFileSync(path.join(vault, cleanRel), CLEAN_MD);
+  });
+
+  afterEach(() => {
+    fs.rmSync(vault, { recursive: true, force: true });
+  });
+
+  it("FileSystemVaultAdapter.getFrontmatter returns the dup-key frontmatter (last-wins)", () => {
+    const adapter = new FileSystemVaultAdapter(vault);
+    const file = adapter.getAllFiles().find((f: IFile) => f.path.includes(DUPKEY_UID));
+    expect(file).toBeDefined();
+
+    const fm = adapter.getFrontmatter(file!);
+
+    // The bug returned null here → precondition ASK found no binding.
+    expect(fm).not.toBeNull();
+    expect(fm!.ems__Effort_status).toBe(
+      "[[753a44d5-846c-4b82-9196-4fd9a4d48777|ems__EffortStatusBacklog]]",
+    );
+    // last-wins: the second exo__Asset_prototype value survives.
+    expect(fm!.exo__Asset_prototype).toBe("[[bbb]]");
+  });
+
+  it("NodeFsAdapter.getFileMetadata returns the dup-key frontmatter (not {})", async () => {
+    const adapter = new NodeFsAdapter(vault);
+    const fm = await adapter.getFileMetadata(dupRel);
+
+    expect(Object.keys(fm).length).toBeGreaterThan(0);
+    expect(fm.ems__Effort_status).toBe(
+      "[[753a44d5-846c-4b82-9196-4fd9a4d48777|ems__EffortStatusBacklog]]",
+    );
+    expect(fm.exo__Asset_prototype).toBe("[[bbb]]");
+  });
+
+  it("NoteToRDFConverter.convertNote emits the asset's triples (0 → visible)", async () => {
+    const adapter = new FileSystemVaultAdapter(vault);
+    const converter = new NoteToRDFConverter(adapter, NullLogger);
+    const dupFile = adapter
+      .getAllFiles()
+      .find((f: IFile) => f.path.includes(DUPKEY_UID))!;
+
+    const triples = await converter.convertNote(dupFile);
+
+    // The bug: getFrontmatter → null → convertNote → [] (0 triples = invisible).
+    expect(triples.length).toBeGreaterThan(0);
+    const hasStatus = triples.some((t) =>
+      t.predicate.value.includes("Effort_status"),
+    );
+    expect(hasStatus).toBe(true);
+  });
+
+  it("negative control: a clean asset is visible both ways (non-vacuity)", async () => {
+    const adapter = new FileSystemVaultAdapter(vault);
+    const cleanFile = adapter
+      .getAllFiles()
+      .find((f: IFile) => f.path.includes(CLEAN_UID))!;
+
+    const fm = adapter.getFrontmatter(cleanFile);
+    expect(fm!.ems__Effort_status).toBeDefined();
+
+    const converter = new NoteToRDFConverter(adapter, NullLogger);
+    const triples = await converter.convertNote(cleanFile);
+    expect(
+      triples.some((t) => t.predicate.value.includes("Effort_status")),
+    ).toBe(true);
+  });
+});

--- a/packages/cli/tests/integration/repair-frontmatter.integration.test.ts
+++ b/packages/cli/tests/integration/repair-frontmatter.integration.test.ts
@@ -103,6 +103,26 @@ describe("#3800 (b) dedupeFrontmatterKeys (pure)", () => {
     expect(r.content).not.toContain("a: 2");
   });
 
+  it("does NOT corrupt `$`-sequences in surviving values (M1: no string-replace $ interpretation)", () => {
+    // A string `content.replace(match[0], newBlock)` would interpret `$$`, `$&`,
+    // `$1`, `` $` `` in the frontmatter VALUES → silent corruption. A repair tool
+    // must keep every surviving value byte-identical.
+    const dollarValue = 'label: "cost $$100 & $& and $1 ref plus $`tail"';
+    const content = ["---", "a: 1", dollarValue, "a: 2", "---", "body"].join(
+      "\n",
+    );
+
+    const r = dedupeFrontmatterKeys(content);
+
+    expect(r.changed).toBe(true);
+    // The `a` key deduped (keep-last), the $-laden label untouched.
+    expect(r.content).toContain(dollarValue);
+    expect(r.content).toContain("a: 2");
+    expect(r.content).not.toContain("a: 1");
+    // Nothing from the regex machinery leaked into the value.
+    expect(r.content).not.toContain("---\n---\n"); // no group/whole-match splice
+  });
+
   it("preserves CRLF line endings", () => {
     const content = ["---", "a: 1", "a: 2", "---", "body"].join("\r\n");
     const r = dedupeFrontmatterKeys(content);

--- a/packages/cli/tests/integration/repair-frontmatter.integration.test.ts
+++ b/packages/cli/tests/integration/repair-frontmatter.integration.test.ts
@@ -1,0 +1,212 @@
+/**
+ * Issue #3800 (b) — `exocortex repair-frontmatter <path>`: the dogfood-clean
+ * repair for the invisible/unrepairable duplicate-key class. Removes duplicated
+ * top-level YAML keys keeping the LAST occurrence (matches the `{ json: true }`
+ * tolerant parse), operating on raw text so it can fix a file the parser itself
+ * cannot read.
+ *
+ * Tests the pure `dedupeFrontmatterKeys` (single-line, array-valued, multi-key,
+ * CRLF, no-op cases) AND drives the REAL `repairFrontmatterCommand()` action
+ * end-to-end against a temp fixture, reading the written bytes back from disk
+ * (test-fixture-realism — no hand-injected result).
+ *
+ * Revert-verify: replace the keep-last filter with `return true` (keep all) and
+ * the "duplicate removed" assertions go RED; the no-op cases stay GREEN.
+ */
+import { describe, it, expect, beforeEach, afterEach, jest } from "@jest/globals";
+import * as fs from "fs";
+import * as path from "path";
+import * as os from "os";
+
+const { dedupeFrontmatterKeys, repairFrontmatterCommand } = await import(
+  "../../src/commands/repair-frontmatter.js"
+);
+
+describe("#3800 (b) dedupeFrontmatterKeys (pure)", () => {
+  it("removes a single-line duplicated key, keeping the last occurrence", () => {
+    const content = [
+      "---",
+      "exo__Asset_uid: abc",
+      'exo__Asset_prototype: "[[aaa]]"',
+      "ems__Effort_status: Backlog",
+      'exo__Asset_prototype: "[[bbb]]"',
+      "---",
+      "body",
+    ].join("\n");
+
+    const r = dedupeFrontmatterKeys(content);
+
+    expect(r.changed).toBe(true);
+    expect(r.removed).toEqual([
+      { key: "exo__Asset_prototype", removedOccurrences: 1 },
+    ]);
+    // Exactly one prototype line remains, and it is the LAST (bbb).
+    const protoLines = r.content
+      .split("\n")
+      .filter((l) => l.startsWith("exo__Asset_prototype:"));
+    expect(protoLines).toEqual(['exo__Asset_prototype: "[[bbb]]"']);
+    // Non-duplicated keys and the body are preserved untouched.
+    expect(r.content).toContain("exo__Asset_uid: abc");
+    expect(r.content).toContain("ems__Effort_status: Backlog");
+    expect(r.content).toContain("\nbody");
+  });
+
+  it("keeps the last occurrence of a duplicated ARRAY-valued key (whole block)", () => {
+    const content = [
+      "---",
+      "exo__Asset_uid: abc",
+      "exo__Instance_class:",
+      '  - "[[first]]"',
+      "exo__Asset_label: L",
+      "exo__Instance_class:",
+      '  - "[[second]]"',
+      '  - "[[third]]"',
+      "---",
+    ].join("\n");
+
+    const r = dedupeFrontmatterKeys(content);
+
+    expect(r.changed).toBe(true);
+    expect(r.removed).toEqual([
+      { key: "exo__Instance_class", removedOccurrences: 1 },
+    ]);
+    // The surviving block is the LAST one, kept whole (both array items).
+    expect(r.content).toContain('  - "[[second]]"');
+    expect(r.content).toContain('  - "[[third]]"');
+    expect(r.content).not.toContain('  - "[[first]]"');
+    // The non-duplicated key that sat BETWEEN the two blocks is preserved.
+    expect(r.content).toContain("exo__Asset_label: L");
+  });
+
+  it("handles MULTIPLE distinct duplicated keys in one pass", () => {
+    const content = [
+      "---",
+      "a: 1",
+      "b: 1",
+      "a: 2",
+      "b: 2",
+      "a: 3",
+      "---",
+    ].join("\n");
+
+    const r = dedupeFrontmatterKeys(content);
+
+    expect(r.changed).toBe(true);
+    const removedByKey = Object.fromEntries(
+      r.removed.map((x) => [x.key, x.removedOccurrences]),
+    );
+    expect(removedByKey).toEqual({ a: 2, b: 1 });
+    // last-wins per key.
+    expect(r.content).toContain("a: 3");
+    expect(r.content).toContain("b: 2");
+    expect(r.content).not.toContain("a: 1");
+    expect(r.content).not.toContain("a: 2");
+  });
+
+  it("preserves CRLF line endings", () => {
+    const content = ["---", "a: 1", "a: 2", "---", "body"].join("\r\n");
+    const r = dedupeFrontmatterKeys(content);
+    expect(r.changed).toBe(true);
+    expect(r.content).toContain("\r\n");
+    expect(r.content).toContain("a: 2");
+    expect(r.content).not.toContain("a: 1");
+  });
+
+  it("is a no-op when there are no duplicated keys", () => {
+    const content = ["---", "a: 1", "b: 2", "---", "body"].join("\n");
+    const r = dedupeFrontmatterKeys(content);
+    expect(r.changed).toBe(false);
+    expect(r.content).toBe(content);
+    expect(r.removed).toEqual([]);
+  });
+
+  it("is a no-op when there is no frontmatter block", () => {
+    const content = "just a body\nwith no frontmatter";
+    const r = dedupeFrontmatterKeys(content);
+    expect(r.changed).toBe(false);
+    expect(r.content).toBe(content);
+  });
+});
+
+describe("#3800 (b) repairFrontmatterCommand end-to-end", () => {
+  let vault: string;
+  let stdoutSpy: ReturnType<typeof jest.spyOn>;
+  let exitSpy: ReturnType<typeof jest.spyOn>;
+  let stdoutChunks: string[];
+  let exitCodes: number[];
+  const dupRel = "assets/16458983.md";
+
+  const DUP_MD = [
+    "---",
+    "exo__Asset_uid: 16458983",
+    'exo__Asset_prototype: "[[aaa]]"',
+    "ems__Effort_status: Backlog",
+    'exo__Asset_prototype: "[[bbb]]"',
+    "---",
+    "body",
+    "",
+  ].join("\n");
+
+  beforeEach(() => {
+    vault = fs.mkdtempSync(path.join(os.tmpdir(), "cli-3800b-"));
+    fs.mkdirSync(path.join(vault, "assets"), { recursive: true });
+    fs.writeFileSync(path.join(vault, dupRel), DUP_MD);
+    stdoutChunks = [];
+    exitCodes = [];
+    stdoutSpy = jest
+      .spyOn(process.stdout, "write")
+      .mockImplementation(((chunk: unknown) => {
+        stdoutChunks.push(String(chunk));
+        return true;
+      }) as never);
+    exitSpy = jest.spyOn(process, "exit").mockImplementation(((code?: number) => {
+      exitCodes.push(code ?? 0);
+      return undefined as never;
+    }) as never);
+  });
+
+  afterEach(() => {
+    stdoutSpy.mockRestore();
+    exitSpy.mockRestore();
+    fs.rmSync(vault, { recursive: true, force: true });
+  });
+
+  async function run(extraArgs: string[]): Promise<{ stdout: string }> {
+    const cmd = repairFrontmatterCommand();
+    await cmd.parseAsync([dupRel, "--vault", vault, ...extraArgs], {
+      from: "user",
+    });
+    return { stdout: stdoutChunks.join("") };
+  }
+
+  it("--dry-run reports the dedupe WITHOUT writing", async () => {
+    const { stdout } = await run(["--dry-run"]);
+    const out = JSON.parse(stdout.trim());
+    expect(out).toMatchObject({
+      changed: true,
+      dryRun: true,
+      removed: [{ key: "exo__Asset_prototype", removedOccurrences: 1 }],
+    });
+    // File on disk is UNCHANGED (still two prototype lines).
+    const onDisk = fs.readFileSync(path.join(vault, dupRel), "utf-8");
+    expect(
+      onDisk.split("\n").filter((l) => l.startsWith("exo__Asset_prototype:"))
+        .length,
+    ).toBe(2);
+  });
+
+  it("writes the deduped file (keep-last) and reports the removed key", async () => {
+    const { stdout } = await run([]);
+    const out = JSON.parse(stdout.trim());
+    expect(out).toMatchObject({ changed: true, dryRun: false });
+
+    const onDisk = fs.readFileSync(path.join(vault, dupRel), "utf-8");
+    const protoLines = onDisk
+      .split("\n")
+      .filter((l) => l.startsWith("exo__Asset_prototype:"));
+    expect(protoLines).toEqual(['exo__Asset_prototype: "[[bbb]]"']);
+    // Other content preserved.
+    expect(onDisk).toContain("exo__Asset_uid: 16458983");
+    expect(onDisk).toContain("ems__Effort_status: Backlog");
+  });
+});

--- a/packages/cli/tests/unit/adapters/FileSystemVaultAdapter.test.ts
+++ b/packages/cli/tests/unit/adapters/FileSystemVaultAdapter.test.ts
@@ -1,6 +1,10 @@
 import { jest, describe, it, expect, beforeEach, afterEach } from "@jest/globals";
 import fs from "fs-extra";
 import path from "path";
+// #3800: FileSystemVaultAdapter.extractFrontmatter delegates to core's tolerant
+// parser — the barrel mock must provide the REAL implementation (not a stub);
+// imported straight from source so it is not intercepted by the mock.
+import { parseYamlFrontmatterTolerant } from "../../../../core/src/utilities/parseYamlFrontmatter.js";
 
 // Mock exocortex module before import
 jest.unstable_mockModule("@kitelev/exocortex-core", () => ({
@@ -8,6 +12,7 @@ jest.unstable_mockModule("@kitelev/exocortex-core", () => ({
   IFile: class {},
   IFolder: class {},
   IFrontmatter: class {},
+  parseYamlFrontmatterTolerant,
 }));
 
 const { FileSystemVaultAdapter } = await import("../../../src/adapters/FileSystemVaultAdapter.js");

--- a/packages/cli/tests/unit/adapters/NodeFsAdapter.test.ts
+++ b/packages/cli/tests/unit/adapters/NodeFsAdapter.test.ts
@@ -1,5 +1,10 @@
 import { jest, describe, it, expect, beforeEach, afterEach } from "@jest/globals";
 import fs from "fs-extra";
+// #3800: NodeFsAdapter.extractFrontmatter delegates to core's tolerant parser.
+// The barrel mock below must provide the REAL implementation (not a stub) or
+// frontmatter extraction returns `{}`; imported straight from source so it is
+// not intercepted by the `@kitelev/exocortex-core` mock.
+import { parseYamlFrontmatterTolerant } from "../../../../core/src/utilities/parseYamlFrontmatter.js";
 
 // Create mock for glob
 const mockGlob = jest.fn();
@@ -23,6 +28,7 @@ jest.unstable_mockModule("@kitelev/exocortex-core", () => ({
     }
   },
   IFileSystemAdapter: class {},
+  parseYamlFrontmatterTolerant,
 }));
 
 const { NodeFsAdapter } = await import("../../../src/adapters/NodeFsAdapter.js");

--- a/packages/cli/tests/unit/commands/create.test.ts
+++ b/packages/cli/tests/unit/commands/create.test.ts
@@ -54,6 +54,9 @@ jest.unstable_mockModule("@kitelev/exocortex-core", () => ({
       size: 0,
     })),
   },
+  // #3800: NodeFsAdapter (in the graph) now imports this. Not exercised here
+  // (only option registration) → a stub satisfies the ESM named-import binding.
+  parseYamlFrontmatterTolerant: jest.fn(),
 }));
 
 // Mock fs-extra (NodeFsAdapter dependency)

--- a/packages/cli/tests/unit/commands/validate-schema.test.ts
+++ b/packages/cli/tests/unit/commands/validate-schema.test.ts
@@ -33,6 +33,11 @@ jest.unstable_mockModule("@kitelev/exocortex-core", () => ({
   KNOWN_CHECK_IDS: new Set<string>(),
   extractAssetReference: jest.fn(),
   readEnabledCheckIds: jest.fn(() => []),
+  // #3800: NodeFsAdapter (pulled into the graph via validate-vault →
+  // CachingNodeFsAdapter) now imports this — must be a named export or the
+  // mocked-core ESM link fails. Not exercised here (validateFile uses the
+  // regex extractFrontmatter + real js-yaml detectUnparseableFrontmatter).
+  parseYamlFrontmatterTolerant: jest.fn(),
 }));
 
 // Mock fs-extra (CacheManager dependency)
@@ -66,6 +71,7 @@ const {
   uriToKey,
   classifyKeys,
   validateFile,
+  detectUnparseableFrontmatter,
   extractPropertyNameFromURI,
   TripleClassHierarchy,
   labelToOntologyIRI,
@@ -357,6 +363,44 @@ aliases:
         declaredProperties
       );
       expect(violations).toHaveLength(0);
+    });
+
+    // #3800 (c) — surface files a strict YAML parser rejects (dup key) instead
+    // of silently skipping them (previously found only by an external scan).
+    it("should report a duplicated-key (unparseable) frontmatter file", () => {
+      writeFileSync(
+        `${TMP_DIR}/dupkey.md`,
+        `---
+exo__Asset_uid: some-uuid
+exo__Asset_label: A
+exo__Asset_label: B
+---
+# Content`
+      );
+
+      const violations = validateFile(
+        `${TMP_DIR}/dupkey.md`,
+        "dupkey.md",
+        declaredProperties
+      );
+
+      const parseViolation = violations.find(
+        (v) => v.property === "(frontmatter)"
+      );
+      expect(parseViolation).toBeDefined();
+      expect(parseViolation!.reason).toContain("Unparseable YAML frontmatter");
+      expect(parseViolation!.reason).toContain("duplicated mapping key");
+      expect(parseViolation!.reason).toContain("repair-frontmatter");
+    });
+
+    it("detectUnparseableFrontmatter: dup key → reason; clean → null; no-fm → null", () => {
+      expect(
+        detectUnparseableFrontmatter("---\na: 1\na: 2\n---\nbody")
+      ).toContain("duplicated mapping key");
+      expect(
+        detectUnparseableFrontmatter("---\na: 1\nb: 2\n---\nbody")
+      ).toBeNull();
+      expect(detectUnparseableFrontmatter("no frontmatter here")).toBeNull();
     });
 
     it("should report undeclared properties with known prefix", () => {

--- a/packages/cli/tests/unit/commands/validate.test.ts
+++ b/packages/cli/tests/unit/commands/validate.test.ts
@@ -40,6 +40,9 @@ jest.unstable_mockModule("@kitelev/exocortex-core", () => ({
   KNOWN_CHECK_IDS: new Set<string>(),
   extractAssetReference: jest.fn(),
   readEnabledCheckIds: jest.fn(() => []),
+  // #3800: NodeFsAdapter (pulled via validate-vault → CachingNodeFsAdapter) now
+  // imports this — must be a named export or the mocked-core ESM link fails.
+  parseYamlFrontmatterTolerant: jest.fn(),
 }));
 
 // Mock fs-extra (CacheManager dependency)

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -240,6 +240,10 @@ export { FrontmatterService } from "./utilities/FrontmatterService";
 // pre-format values the same way the create / property_set paths do before
 // handing them to FrontmatterService.updateProperty (which writes verbatim).
 export { serializeYamlScalar } from "./utilities/yamlScalar";
+// Tolerant YAML frontmatter parse (#3800) — bare yaml.load throws on a
+// duplicated mapping key → the whole asset collapses to {} at every read
+// (invisible & unrepairable). Retries `{ json: true }` (last-wins) on throw.
+export { parseYamlFrontmatterTolerant } from "./utilities/parseYamlFrontmatter";
 export { DateFormatter } from "./utilities/DateFormatter";
 export { WikiLinkHelpers } from "./utilities/WikiLinkHelpers";
 export { MetadataHelpers } from "./utilities/MetadataHelpers";

--- a/packages/core/src/utilities/parseYamlFrontmatter.ts
+++ b/packages/core/src/utilities/parseYamlFrontmatter.ts
@@ -1,0 +1,58 @@
+import yaml from "js-yaml";
+
+/**
+ * Tolerantly parse a YAML frontmatter block.
+ *
+ * A bare `yaml.load` throws on a **duplicated mapping key**, which makes the
+ * whole asset collapse to `{}`/`null` at every read (0 triples → every `apply`
+ * precondition false-fails → the asset is invisible AND unrepairable, #3800 —
+ * same throw→`{}` mechanism as #3701).
+ *
+ * This helper keeps the STRICT parse for the common (well-formed) case, so a
+ * non-duplicate file is byte-for-byte unaffected (zero behaviour change). Only
+ * when the strict parse throws does it retry with `{ json: true }` — js-yaml's
+ * JSON-compatibility mode, in which a duplicated key resolves **last-wins**
+ * instead of throwing (empirically verified; matches the line-based
+ * `FrontmatterService.parseObject` and the raw-text `repair-frontmatter`
+ * dedupe, which both keep the last occurrence). A one-line WARN is emitted so
+ * the malformed asset is observable rather than silently swallowed.
+ *
+ * Genuinely-unparseable frontmatter (bad indentation, unterminated quote, …)
+ * still throws even in tolerant mode → returns `null` (same as the old
+ * throw→`{}` behaviour), so this only ever RESCUES the duplicate-key class.
+ *
+ * @param yamlBlock the raw YAML text between the `---` fences
+ * @param context   optional label (e.g. file path) surfaced in the WARN log
+ * @returns the parsed mapping, or `null` when it is not a non-null object or is
+ *          genuinely unparseable even in tolerant mode
+ */
+export function parseYamlFrontmatterTolerant(
+  yamlBlock: string,
+  context?: string,
+): Record<string, unknown> | null {
+  let parsed: unknown;
+  try {
+    parsed = yaml.load(yamlBlock);
+  } catch (strictError) {
+    try {
+      // JSON-compat mode: duplicate keys resolve last-wins instead of throwing.
+      parsed = yaml.load(yamlBlock, { json: true });
+    } catch {
+      // Not a mere duplicate-key issue — genuinely malformed. Preserve the
+      // historical throw→null/`{}` fallback rather than crash the caller.
+      return null;
+    }
+    const detail =
+      strictError instanceof Error
+        ? strictError.message.split("\n")[0]
+        : String(strictError);
+    console.warn(
+      `[frontmatter] tolerant-parsed malformed YAML${
+        context ? ` (${context})` : ""
+      } — resolving last-wins: ${detail}`,
+    );
+  }
+  return typeof parsed === "object" && parsed !== null
+    ? (parsed as Record<string, unknown>)
+    : null;
+}

--- a/packages/core/tests/unit/utilities/parseYamlFrontmatter.test.ts
+++ b/packages/core/tests/unit/utilities/parseYamlFrontmatter.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, jest, afterEach } from "@jest/globals";
+import yaml from "js-yaml";
+import { parseYamlFrontmatterTolerant } from "../../../src/utilities/parseYamlFrontmatter";
+
+/**
+ * #3800 — `parseYamlFrontmatterTolerant`: a bare `yaml.load` throws on a
+ * duplicated mapping key, which used to collapse the whole asset to `{}`/null
+ * at every read (0 triples → every precondition false-fails → invisible &
+ * unrepairable). The helper keeps the strict parse for well-formed input and
+ * only retries `{ json: true }` (last-wins) + WARN on a throw.
+ *
+ * Revert-verify: swap the `{ json: true }` retry back to a re-throw / `return
+ * null` and the "duplicate key resolves last-wins" cases go RED; the
+ * clean/malformed cases stay GREEN (negative controls isolate non-vacuity).
+ */
+describe("#3800 parseYamlFrontmatterTolerant", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("resolves a duplicated mapping key last-wins instead of throwing", () => {
+    const warn = jest.spyOn(console, "warn").mockImplementation(() => {});
+    const block = [
+      "exo__Asset_uid: 16458983",
+      'exo__Asset_prototype: "[[aaa]]"',
+      'ems__Effort_status: "[[Backlog]]"',
+      'exo__Asset_prototype: "[[bbb]]"',
+    ].join("\n");
+
+    const parsed = parseYamlFrontmatterTolerant(block, "repro.md");
+
+    expect(parsed).not.toBeNull();
+    // last-wins: the SECOND exo__Asset_prototype survives.
+    expect(parsed!.exo__Asset_prototype).toBe("[[bbb]]");
+    expect(parsed!.ems__Effort_status).toBe("[[Backlog]]");
+    expect(parsed!.exo__Asset_uid).toBe(16458983);
+    // WARN emitted so the malformed asset is observable, not silently swallowed.
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(String(warn.mock.calls[0][0])).toContain("duplicated mapping key");
+    expect(String(warn.mock.calls[0][0])).toContain("repro.md");
+  });
+
+  it("parses well-formed frontmatter identically to a bare yaml.load, with NO warn", () => {
+    const warn = jest.spyOn(console, "warn").mockImplementation(() => {});
+    const block = [
+      "exo__Asset_uid: abc",
+      "exo__Instance_class:",
+      '  - "[[ems__Task]]"',
+      'exo__Asset_label: "Hello"',
+    ].join("\n");
+
+    const parsed = parseYamlFrontmatterTolerant(block);
+
+    // Byte-for-byte identical result to the strict parser for clean input.
+    expect(parsed).toEqual(yaml.load(block));
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it("keeps the last occurrence for a duplicated ARRAY-valued key", () => {
+    jest.spyOn(console, "warn").mockImplementation(() => {});
+    const block = [
+      "exo__Asset_uid: abc",
+      "ems__Instance_class:",
+      '  - "[[first]]"',
+      "ems__Instance_class:",
+      '  - "[[second]]"',
+    ].join("\n");
+
+    const parsed = parseYamlFrontmatterTolerant(block);
+
+    expect(parsed!.ems__Instance_class).toEqual(["[[second]]"]);
+  });
+
+  it("returns null for genuinely-malformed YAML (not a mere duplicate key)", () => {
+    const warn = jest.spyOn(console, "warn").mockImplementation(() => {});
+    // Unterminated flow sequence → throws even in json:true mode.
+    const parsed = parseYamlFrontmatterTolerant('key: "unterminated\n  bad: [1, 2');
+    expect(parsed).toBeNull();
+    // No last-wins rescue happened → no misleading warn.
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it("returns null for empty / null-scalar frontmatter (no object)", () => {
+    // Preserves the pre-fix adapter contract exactly: `typeof parsed ===
+    // "object" && parsed !== null`. An empty block / null scalar → null.
+    expect(parseYamlFrontmatterTolerant("")).toBeNull();
+    expect(parseYamlFrontmatterTolerant("null")).toBeNull();
+  });
+});

--- a/packages/obsidian-plugin/src/adapters/ObsidianFileSystemAdapter.ts
+++ b/packages/obsidian-plugin/src/adapters/ObsidianFileSystemAdapter.ts
@@ -1,9 +1,9 @@
 import { Vault, TFolder } from "obsidian";
-import yaml from "js-yaml";
 import {
   IFileSystemAdapter,
   FileNotFoundError,
   FileAlreadyExistsError,
+  parseYamlFrontmatterTolerant,
 } from "@kitelev/exocortex-core";
 
 export class ObsidianFileSystemAdapter implements IFileSystemAdapter {
@@ -115,14 +115,9 @@ export class ObsidianFileSystemAdapter implements IFileSystemAdapter {
     if (!match) {
       return {};
     }
-    try {
-      const parsed = yaml.load(match[1]);
-      return typeof parsed === "object" && parsed !== null
-        ? (parsed as Record<string, unknown>)
-        : {};
-    } catch {
-      return {};
-    }
+    // #3800: tolerant parse — a duplicated mapping key would otherwise throw
+    // and collapse the asset to `{}` (0 triples → invisible & unrepairable).
+    return parseYamlFrontmatterTolerant(match[1]) ?? {};
   }
 
   private matchesQuery(


### PR DESCRIPTION
## Problem (#3800)

An asset whose frontmatter has a **duplicated YAML mapping key** was **invisible and unrepairable** through the dogfood surface:

1. `js-yaml` throws `duplicated mapping key` → `extractFrontmatter` falls back to `{}`/`null` (same throw→`{}` mechanism as #3701) → the asset emits **0 triples**.
2. Every `apply` command **false-fails its precondition** (e.g. `Trash`'s `$target ems:Effort_status ?s` finds no binding → ASK false), though the visible frontmatter clearly satisfies it.
3. The repair (deleting the duplicated line) is a frontmatter edit → blocked by the dogfood-cli-mutation hook, and no CLI command could parse the file it needed to mutate → **chicken-egg deadlock**.

Root cause verified on origin/main: three js-yaml `extractFrontmatter` paths all do a bare `yaml.load` → `catch → {}`/null — `packages/cli/src/adapters/{FileSystemVaultAdapter,NodeFsAdapter}.ts` and `packages/obsidian-plugin/src/adapters/ObsidianFileSystemAdapter.ts`. The invisibility path is `apply` → `NoteToRDFConverter.convertNote` → `vault.getFrontmatter` → `extractFrontmatter` → throw → 0 triples.

## Fix (a + b + c)

**(a) Tolerant parse — the class-killer.** New `packages/core/src/utilities/parseYamlFrontmatter.ts` → `parseYamlFrontmatterTolerant`. It keeps the **strict** parse for well-formed input (byte-for-byte identical → zero behaviour change for the 99% case) and, only on a throw, retries `{ json: true }` (js-yaml JSON-compat = duplicate keys resolve **last-wins** instead of throwing, empirically verified) + emits a one-line WARN so the malformed asset is observable. Wired into **all three** js-yaml `extractFrontmatter` paths (cli `FileSystemVaultAdapter`, cli `NodeFsAdapter` → `CachingNodeFsAdapter` by inheritance, plugin `ObsidianFileSystemAdapter`).

**(b) `exocortex repair-frontmatter <path>`** — new top-level CLI command. Raw-text dedupe of duplicated top-level keys, **keep-last** (matches the tolerant parse), `--dry-run`, JSON summary. Operates on raw text, so it fixes a file the parser itself cannot read — the dogfood-clean repair path that breaks the chicken-egg.

**(c) `validate schema` reports dup-key / unparseable frontmatter** (property-linting mode) instead of silently skipping — surfaces files needing repair (previously found only by an external scan). Each violation names `repair-frontmatter <path>`. Deliberately **not** wired into `--shapes-mode`: after (a) a dup-key file is valid/conforming, and adding a hygiene report to the canonical SHACL gate would red downstream `exoas-*` CI.

## Revert-verify (production-shape — exercises the REAL extract pipeline)

- **(a)** `packages/cli/tests/integration/dupkey-invisible-asset.integration.test.ts` writes a freshly-seeded dup-key `.md` to disk, then reads it back through the real `NodeFsAdapter.getFileMetadata` / `FileSystemVaultAdapter.getFrontmatter` **and the real `NoteToRDFConverter.convertNote`** (the exact pipeline `apply`/`query` build the store from). Reverting the `{ json: true }` retry → `getFrontmatter` null / `convertNote` **0 triples** → the 3 dup-key tests RED; the clean-asset negative control stays GREEN. Verified RED→GREEN.
- **(b)** `repair-frontmatter.integration.test.ts` — reverting the keep-last filter to keep-all → the 5 dedupe tests RED, the no-op cases GREEN. Verified.
- **(c)** `validate-schema.test.ts` (+ `detectUnparseableFrontmatter`) — reverting to never-report → the 2 dup-key report tests RED. Verified.
- Core unit: `packages/core/tests/unit/utilities/parseYamlFrontmatter.test.ts` (last-wins + WARN, clean == bare-yaml with no warn, array dup, malformed → null).

## Local gates

- `npm run check:types` clean; 3 CI `lint`-job guard scripts pass (`check-test-antipatterns` 55/55, `validate-shard-assignments`, `check-coverage-monotonic`); eslint clean on changed core/plugin src.
- Directly-affected + full cli suite green (142/143 suites; the one pre-existing `sparql-exo003.integration.test.ts` failure reproduces identically on **clean origin/main without these changes** — a local build-env artifact of that spawn-based test; `test-coverage-cli` is green on origin/main HEAD, and this change is byte-identical for well-formed frontmatter, so it is unrelated).
- `dist/index.js` intentionally not committed (32-commit-stale on main; Auto Release rebuilds from source).

Closes #3800

## Review follow-ups (orchestrator code-review)

- **M1 (fixed in this PR):** `repair-frontmatter` built the new file via `content.replace(match[0], newBlock)` — a string replacement interprets `$$`/`$&`/`$1`/`` $` `` in frontmatter **values** and would silently corrupt them (same class as #3795 H1). Fixed with an index-splice (`^`-anchored block at index 0), zero `$`-interpretation. Added a `$`-value dedupe test (revert-verified RED with the string-replace, GREEN with the splice). Also hardened the command against `js/file-system-race` (removed the `existsSync(targetPath)` check-then-use; read directly + ENOENT→friendly error).
- **M2 (deliberate out-of-scope):** the "3 paths" are the `extractFrontmatter` readers on the **#3800 invisibility path** (`NoteToRDFConverter.convertNote` → `vault.getFrontmatter` → `extractFrontmatter` → 0 triples). Five other bare `yaml.load` readers remain — `RegistryDependencyResolver`, `CliProfileResolver`, `CliApplyProfileService`, `ClaimService`, `AtomicFrontmatterService` — but they parse specific config/profile/claim files, **not** the general asset scan that feeds the triple store, so a dup key there does not make an *asset* invisible to SPARQL/preconditions. Intentionally not touched here; tracked as a follow-up.
