### PR TITLE
fix(reify): de-reify a clean-prefix reified relation (#3904, symmetric to #3903)

### DIFF
--- a/packages/obsidian-plugin/src/presentation/modals/PropertyEditorModal.tsx
+++ b/packages/obsidian-plugin/src/presentation/modals/PropertyEditorModal.tsx
@@ -22,6 +22,7 @@ import type { AssetRefCandidate } from '@plugin/presentation/builders/button-gro
 import {
   getReifiedRelations,
   predicateKeyFromLabelObjects,
+  reifiedPredicateFrontmatterKey,
   type ReifiedRelation,
 } from '@plugin/presentation/renderers/layout/getReifiedRelations';
 import {
@@ -215,8 +216,14 @@ export class PropertyEditorModal extends Modal {
     // Enrich the reified rows with the frontmatter key they map back to (so
     // de-reify writes the restored relation under the right key without guessing).
     this.reifiedRows = reifiedToRows(reified).map((r) => {
-      const defUid = uidFromIri(r.predicateKey);
-      const key = defUid ? this.keyByPredicateDefUid.get(defUid) : undefined;
+      // The reified predicate is stored as a symbolic IRI for clean-prefix
+      // predicates (dual-IRI) → recover the key directly; only fall back to the
+      // def-UID reverse map for path-form (hyphen-prefix) predicates (#3904).
+      const key = reifiedPredicateFrontmatterKey(
+        r.predicateKey,
+        uidFromIri,
+        this.keyByPredicateDefUid,
+      );
       return key ? { ...r, predicateFrontmatterKey: key } : r;
     });
     // Incoming reified rows (A is the object) — read-only, object-side (Task 3.3).

--- a/packages/obsidian-plugin/src/presentation/renderers/layout/getReifiedRelations.ts
+++ b/packages/obsidian-plugin/src/presentation/renderers/layout/getReifiedRelations.ts
@@ -176,6 +176,36 @@ export function predicateKeyFromLabelObjects(
 }
 
 /**
+ * The frontmatter predicate KEY (`<prefix>__<LocalName>`) that a reified row's
+ * predicate IRI maps back to — used by de-reify to restore the inline relation
+ * under the right key (RFC §C3 Task 3.2; ems__Bug `f68bf750` / #3904).
+ *
+ * The predicate slot of an `exo__Statement` (`exo__Statement_predicate → [[uid]]`)
+ * resolves to one of two IRI forms (dual-IRI — `sparql-iri-form-pre-verify`):
+ *  - a **symbolic** IRI (`…/exo#Asset_relates`) when the predicate-def's label
+ *    is a clean `prefix__LocalName` → recover the key directly via
+ *    {@link symbolicIriToPropertyKey} (the def UID is not even needed);
+ *  - a **path-form** IRI (`obsidian://…/<uid>.md`) when the def label stays a
+ *    Literal (hyphen-prefix, e.g. `adapter-exo-ims__relatesToConcept`) → resolve
+ *    the def UID and look it up in the reverse map.
+ *
+ * A symbolic-only OR UID-only lookup silently drops half the predicates: keying
+ * `keyByDefUid` by def UID means the symbolic form (whose `uidOf` yields the
+ * LOCAL NAME, not the UID) never matches → de-reify fails with "could not be
+ * mapped back to a frontmatter key". Trying the symbolic form first fixes that.
+ */
+export function reifiedPredicateFrontmatterKey(
+  predicateIri: string,
+  uidOf: (iri: string) => string | null,
+  keyByDefUid: ReadonlyMap<string, string>,
+): string | undefined {
+  const symbolic = symbolicIriToPropertyKey(predicateIri);
+  if (symbolic) return symbolic;
+  const defUid = uidOf(predicateIri);
+  return defUid ? keyByDefUid.get(defUid) : undefined;
+}
+
+/**
  * The union of all IRI forms under which A may appear as a statement's
  * subject/object (R5 dual-IRI):
  *  1. path-form `obsidian://vault/<prefix><path>` via the injected `notePathToIRI`;

--- a/packages/obsidian-plugin/tests/unit/getReifiedRelations.test.ts
+++ b/packages/obsidian-plugin/tests/unit/getReifiedRelations.test.ts
@@ -314,15 +314,18 @@ describe("predicateKeyFromLabelObjects (label→key, both emitted forms)", () =>
  * "symbolic-IRI predicate" case return undefined (de-reify then throws).
  */
 describe("reifiedPredicateFrontmatterKey (de-reify key resolution)", () => {
-  // Mirrors PropertyEditorModal.uidFromIri: `#`->localname, path->basename-uid.
+  // Faithful mirror of PropertyEditorModal.uidFromIri (trim + `#`->localname +
+  // path->decodeURIComponent(basename-uid)) so the fallback double can't drift.
   const uidOf = (iri: string): string | null => {
-    const hash = iri.lastIndexOf("#");
-    if (hash >= 0 && hash < iri.length - 1) return iri.slice(hash + 1);
-    if (iri.includes("/")) {
-      const last = iri.split("/").pop();
-      return last ? last.replace(/\.md$/i, "") : null;
+    const trimmed = iri.trim();
+    const hash = trimmed.lastIndexOf("#");
+    if (hash >= 0 && hash < trimmed.length - 1) return trimmed.slice(hash + 1);
+    if (trimmed.includes("/")) {
+      const last = trimmed.split("/").pop();
+      if (!last) return null;
+      return decodeURIComponent(last.replace(/\.md$/i, ""));
     }
-    return iri.length > 0 ? iri : null;
+    return trimmed.length > 0 ? trimmed : null;
   };
 
   it("recovers the key from a symbolic-IRI predicate (the bug) — no def-UID needed", () => {

--- a/packages/obsidian-plugin/tests/unit/getReifiedRelations.test.ts
+++ b/packages/obsidian-plugin/tests/unit/getReifiedRelations.test.ts
@@ -10,6 +10,7 @@ import {
   getReifiedRelations,
   labelToSymbolicIRI,
   predicateKeyFromLabelObjects,
+  reifiedPredicateFrontmatterKey,
   symbolicIriToPropertyKey,
   ReifiedRelation,
 } from "../../src/presentation/renderers/layout/getReifiedRelations";
@@ -301,5 +302,72 @@ describe("predicateKeyFromLabelObjects (label→key, both emitted forms)", () =>
     ).toBeNull();
     expect(predicateKeyFromLabelObjects([new Literal("   ")])).toBeNull();
     expect(predicateKeyFromLabelObjects([])).toBeNull();
+  });
+});
+
+/**
+ * ems__Bug `f68bf750` / #3904 — de-reify mapped the reified predicate back to a
+ * frontmatter key via `uidFromIri(predicate) -> keyByDefUid`, which misses for a
+ * clean-prefix predicate (its stored form is a symbolic IRI, so uidFromIri gives
+ * the LOCAL NAME, not the def UID). `reifiedPredicateFrontmatterKey` tries the
+ * symbolic form first. Revert-verify: removing the symbolic branch makes the
+ * "symbolic-IRI predicate" case return undefined (de-reify then throws).
+ */
+describe("reifiedPredicateFrontmatterKey (de-reify key resolution)", () => {
+  // Mirrors PropertyEditorModal.uidFromIri: `#`->localname, path->basename-uid.
+  const uidOf = (iri: string): string | null => {
+    const hash = iri.lastIndexOf("#");
+    if (hash >= 0 && hash < iri.length - 1) return iri.slice(hash + 1);
+    if (iri.includes("/")) {
+      const last = iri.split("/").pop();
+      return last ? last.replace(/\.md$/i, "") : null;
+    }
+    return iri.length > 0 ? iri : null;
+  };
+
+  it("recovers the key from a symbolic-IRI predicate (the bug) — no def-UID needed", () => {
+    // Clean-prefix predicate: stored as a symbolic IRI, keyByDefUid is empty for
+    // it (it is keyed by def UID, not local name) — exactly the failing shape.
+    expect(
+      reifiedPredicateFrontmatterKey(
+        "https://exocortex.my/ontology/exo#Asset_relates",
+        uidOf,
+        new Map(),
+      ),
+    ).toBe("exo__Asset_relates");
+  });
+
+  it("falls back to the def-UID reverse map for a path-form predicate", () => {
+    // Hyphen-prefix def label stays a Literal → predicate stored as path-form IRI.
+    const keyByDefUid = new Map([
+      ["0967a771-c5cf-4fee-9707-9837104977f3", "adapter-exo-ims__relatesToConcept"],
+    ]);
+    expect(
+      reifiedPredicateFrontmatterKey(
+        "obsidian://vault/assetspaces/x/0967a771-c5cf-4fee-9707-9837104977f3.md",
+        uidOf,
+        keyByDefUid,
+      ),
+    ).toBe("adapter-exo-ims__relatesToConcept");
+  });
+
+  it("prefers the symbolic form even when the reverse map would also miss", () => {
+    expect(
+      reifiedPredicateFrontmatterKey(
+        "https://exocortex.my/ontology/ems#Effort_area",
+        uidOf,
+        new Map([["Effort_area", "WRONG"]]),
+      ),
+    ).toBe("ems__Effort_area");
+  });
+
+  it("returns undefined when neither form yields a key", () => {
+    expect(
+      reifiedPredicateFrontmatterKey(
+        "obsidian://vault/x/unknown-uid.md",
+        uidOf,
+        new Map(),
+      ),
+    ).toBeUndefined();
   });
 });


### PR DESCRIPTION
Fixes #3904. Symmetric follow-up to #3903 (reify fix, v16.185.6) — that fix enabled creating clean-prefix reified statements, which then could not be de-reified.

## Symptom
De-reify (the `↩` toggle in the Property Editor) of a reified relation whose predicate has a **clean prefix** (`exo__Asset_relates`, `ems__*`, `concept__*`) failed with:

> `Failed to de-reify relation: Cannot de-reify: the reified predicate could not be mapped back to a frontmatter key (no definition asset / no label).`

The relation stayed reified (atomic, no data loss). Confirmed LIVE on `ems__Agent` (v16.185.6) de-reifying a reified `exo__Asset_relates` statement.

## Root cause
`PropertyEditorModal.recomputeRelations` enriched each reified row with `predicateFrontmatterKey` via `uidFromIri(r.predicateKey) -> keyByPredicateDefUid.get(defUid)`. For a clean-prefix predicate, `r.predicateKey` is the **symbolic IRI** (`…/exo#Asset_relates`, dual-IRI), so `uidFromIri` returns the **local name** `"Asset_relates"`, not the def UID — and `keyByPredicateDefUid` is keyed by def **UID** → miss → empty key → `deReifyRelation` throws. Same dual-IRI root class as #3903, reverse direction.

## Fix
Extract `reifiedPredicateFrontmatterKey` (`getReifiedRelations.ts`): try `symbolicIriToPropertyKey(predicate)` first (recovers the key directly for symbolic IRIs — no def UID needed), then fall back to the def-UID reverse map for path-form (hyphen-prefix) predicates. `recomputeRelations` delegates to it.

## Revert-verify (RED/GREEN)
Removing the symbolic branch → the two symbolic-IRI-predicate unit tests go RED (`reifiedPredicateFrontmatterKey` returns undefined for `exo#Asset_relates` / `ems#Effort_area`); restored → GREEN. Path-form fallback + others stay green. 77 related tests pass. tsc clean; lint (src) + 3 CI guard scripts pass.

## Tracking
`ems__Bug f68bf750`.

https://claude.ai/code/session_013MJBJpbRciRgjuAy7w2Tyc
