### PR TITLE
fix(#3908): instantiatePrototypeSubtree writes canonical UID-alias class refs (not dangling [[label]])

### DIFF
--- a/packages/cli/tests/unit/services/instantiate-prototype-subtree.test.ts
+++ b/packages/cli/tests/unit/services/instantiate-prototype-subtree.test.ts
@@ -31,6 +31,21 @@ const PERSON = "d350b625-0000-0000-0000-000000000020";
 const QUARTER = "ed8e4fbb-0000-0000-0000-000000000021";
 const PARENT_PROJ = "11111111-0000-0000-0000-000000000030";
 
+// Real ems class-definition UIDs (production-shape) — the derived instance class
+// of each node MUST be written as the canonical UID-alias `[[uid|label]]`, which
+// requires the class-definition asset to be present in the scanned vault. These
+// mirror the real `exoas-public/ems/*.md` files (co-mounted with the prototypes).
+const EXO_CLASS_METACLASS = "8619c4fc-64f1-4869-b17e-e34186cacca9";
+const EMS_PROJECT_CLS = "7db5eeff-718a-49b0-8d2b-39b084a356e3";
+const EMS_TASK_CLS = "1b20a8f0-d745-4e93-91db-4531b3df120e";
+const EMS_WCT_CLS = "47dac51c-6332-467a-abb6-84498755a91e";
+// instance-class label → canonical UID-alias ref the service must write (#3906).
+const CLASS_UID_BY_LABEL: Record<string, string> = {
+  ems__Project: EMS_PROJECT_CLS,
+  ems__Task: EMS_TASK_CLS,
+  ems__WaitingCheckTask: EMS_WCT_CLS,
+};
+
 interface FakeFile {
   path: string;
   basename: string;
@@ -50,6 +65,11 @@ function mkFile(uid: string, folder = "efforts"): FakeFile {
 // Raw markdown fixtures (parsed via real FrontmatterService in the fake adapter).
 function fixtures(): Record<string, string> {
   return {
+    // Class definitions (UID-named class files) — needed so the derived instance
+    // class resolves to its canonical UID-alias ref (#3906). Metaclass-typed.
+    [EMS_PROJECT_CLS]: `---\nexo__Asset_uid: ${EMS_PROJECT_CLS}\nexo__Instance_class:\n  - "[[${EXO_CLASS_METACLASS}]]"\nexo__Class_superClass:\n  - "[[086f71fa-dd30-4284-90cf-e609f2a6c461]]"\nexo__Asset_label: ems__Project\n---\n`,
+    [EMS_TASK_CLS]: `---\nexo__Asset_uid: ${EMS_TASK_CLS}\nexo__Instance_class:\n  - "[[${EXO_CLASS_METACLASS}]]"\nexo__Class_superClass:\n  - "[[086f71fa-dd30-4284-90cf-e609f2a6c461]]"\nexo__Asset_label: ems__Task\n---\n`,
+    [EMS_WCT_CLS]: `---\nexo__Asset_uid: ${EMS_WCT_CLS}\nexo__Instance_class:\n  - "[[${EXO_CLASS_METACLASS}]]"\nexo__Class_superClass:\n  - "[[${EMS_TASK_CLS}]]"\nexo__Asset_label: ems__WaitingCheckTask\n---\n`,
     [PROJ_PROTO]: `---\nexo__Asset_uid: ${PROJ_PROTO}\nexo__Instance_class:\n  - "[[8619c4fc-64f1-4869-b17e-e34186cacca9]]"\nexo__Asset_label: ems__ProjectPrototype\n---\n`,
     [TASK_PROTO]: `---\nexo__Asset_uid: ${TASK_PROTO}\nexo__Instance_class:\n  - "[[8619c4fc-64f1-4869-b17e-e34186cacca9]]"\nexo__Asset_label: ems__TaskPrototype\n---\n`,
     [WCT_PROTO]: `---\nexo__Asset_uid: ${WCT_PROTO}\nexo__Instance_class:\n  - "[[8619c4fc-64f1-4869-b17e-e34186cacca9]]"\nexo__Asset_label: ems__WaitingCheckTaskPrototype\n---\n`,
@@ -152,13 +172,16 @@ describe("instantiatePrototypeSubtree (issue #3881 Gap 3)", () => {
       "Поручить n.rudopas заполнить Q3-26",
     );
 
-    // instance-class derivation (Prototype-suffix strip).
+    // (revert-verify anchor #3906) instance-class derivation (Prototype-suffix
+    // strip) written as the CANONICAL UID-alias `[[uid|label]]` — never a
+    // dangling symbolic `[[label]]` (class files are UID-named). Reverting the
+    // fix (writing `[[${instClassLabel}]]`) flips these RED.
     const cls = (n: { fm: Record<string, unknown> }) =>
       unq((n.fm.exo__Instance_class as string[])[0]);
-    expect(cls(rootInst)).toBe("[[ems__Project]]");
-    expect(cls(c1Inst)).toBe("[[ems__Task]]");
-    expect(cls(c2Inst)).toBe("[[ems__WaitingCheckTask]]");
-    expect(cls(c3Inst)).toBe("[[ems__Task]]");
+    expect(cls(rootInst)).toBe(`[[${EMS_PROJECT_CLS}|ems__Project]]`);
+    expect(cls(c1Inst)).toBe(`[[${EMS_TASK_CLS}|ems__Task]]`);
+    expect(cls(c2Inst)).toBe(`[[${EMS_WCT_CLS}|ems__WaitingCheckTask]]`);
+    expect(cls(c3Inst)).toBe(`[[${EMS_TASK_CLS}|ems__Task]]`);
 
     // (revert-verify anchor #2) blocker re-map onto CLONED siblings, not prototypes.
     const c1NewUid = unq(c1Inst.fm.exo__Asset_uid);
@@ -200,10 +223,42 @@ describe("instantiatePrototypeSubtree (issue #3881 Gap 3)", () => {
     const fmBlock = rootWrite.content.split("---")[1];
     const y = yaml.load(fmBlock) as Record<string, unknown>;
     expect(y.exo__Asset_label).toBe("Ревьюшница n.rudopas Q3-26"); // js-yaml strips quotes
-    expect(y.exo__Instance_class).toEqual(["[[ems__Project]]"]);
+    expect(y.exo__Instance_class).toEqual([
+      `[[${EMS_PROJECT_CLS}|ems__Project]]`,
+    ]);
     expect(y.exo__Asset_relates).toEqual(
       expect.arrayContaining([`[[${PERSON}]]`, `[[${QUARTER}]]`]),
     );
+  });
+
+  it("writes CANONICAL UID-alias class refs `[[uid|label]]`, never dangling symbolic `[[label]]` (#3906)", async () => {
+    const { vaultAdapter, fsAdapter, writes, fm } = makeAdapterAndWriter();
+    const service = createInstantiatePrototypeSubtreeService(
+      vaultAdapter,
+      fsAdapter,
+    );
+    await service.execute(rootIRI, {
+      // eslint-disable-next-line @typescript-eslint/naming-convention
+      сотрудник: `[[${PERSON}]]`,
+      // eslint-disable-next-line @typescript-eslint/naming-convention
+      квартал: `[[${QUARTER}]]`,
+    });
+
+    const nodes = parseWrites(writes, fm);
+    expect(nodes.length).toBeGreaterThan(0);
+    for (const n of nodes) {
+      const ref = unq((n.fm.exo__Instance_class as string[])[0]);
+      // (revert-verify anchor #3906) MUST be `[[uid|label]]`, not `[[label]]`.
+      // Reverting the fix writes a bare symbolic `[[ems__Project]]` → the alias
+      // regex fails to match → this assertion flips RED.
+      const m = ref.match(/^\[\[([^|\]]+)\|([^\]]+)\]\]$/);
+      expect(m).not.toBeNull();
+      const uid = m![1];
+      const label = m![2];
+      // the UID part is the REAL class-definition UID for that label (resolves to
+      // a UID-named class file that actually exists → not dangling in Obsidian).
+      expect(CLASS_UID_BY_LABEL[label]).toBe(uid);
+    }
   });
 
   it("standalone when no Project-classed param is supplied (Fork B else-branch)", async () => {

--- a/packages/cli/tests/unit/services/instantiate-prototype-subtree.test.ts
+++ b/packages/cli/tests/unit/services/instantiate-prototype-subtree.test.ts
@@ -39,7 +39,7 @@ const EXO_CLASS_METACLASS = "8619c4fc-64f1-4869-b17e-e34186cacca9";
 const EMS_PROJECT_CLS = "7db5eeff-718a-49b0-8d2b-39b084a356e3";
 const EMS_TASK_CLS = "1b20a8f0-d745-4e93-91db-4531b3df120e";
 const EMS_WCT_CLS = "47dac51c-6332-467a-abb6-84498755a91e";
-// instance-class label → canonical UID-alias ref the service must write (#3906).
+// instance-class label → canonical UID-alias ref the service must write (#3908).
 const CLASS_UID_BY_LABEL: Record<string, string> = {
   ems__Project: EMS_PROJECT_CLS,
   ems__Task: EMS_TASK_CLS,
@@ -66,7 +66,7 @@ function mkFile(uid: string, folder = "efforts"): FakeFile {
 function fixtures(): Record<string, string> {
   return {
     // Class definitions (UID-named class files) — needed so the derived instance
-    // class resolves to its canonical UID-alias ref (#3906). Metaclass-typed.
+    // class resolves to its canonical UID-alias ref (#3908). Metaclass-typed.
     [EMS_PROJECT_CLS]: `---\nexo__Asset_uid: ${EMS_PROJECT_CLS}\nexo__Instance_class:\n  - "[[${EXO_CLASS_METACLASS}]]"\nexo__Class_superClass:\n  - "[[086f71fa-dd30-4284-90cf-e609f2a6c461]]"\nexo__Asset_label: ems__Project\n---\n`,
     [EMS_TASK_CLS]: `---\nexo__Asset_uid: ${EMS_TASK_CLS}\nexo__Instance_class:\n  - "[[${EXO_CLASS_METACLASS}]]"\nexo__Class_superClass:\n  - "[[086f71fa-dd30-4284-90cf-e609f2a6c461]]"\nexo__Asset_label: ems__Task\n---\n`,
     [EMS_WCT_CLS]: `---\nexo__Asset_uid: ${EMS_WCT_CLS}\nexo__Instance_class:\n  - "[[${EXO_CLASS_METACLASS}]]"\nexo__Class_superClass:\n  - "[[${EMS_TASK_CLS}]]"\nexo__Asset_label: ems__WaitingCheckTask\n---\n`,
@@ -172,7 +172,7 @@ describe("instantiatePrototypeSubtree (issue #3881 Gap 3)", () => {
       "Поручить n.rudopas заполнить Q3-26",
     );
 
-    // (revert-verify anchor #3906) instance-class derivation (Prototype-suffix
+    // (revert-verify anchor #3908) instance-class derivation (Prototype-suffix
     // strip) written as the CANONICAL UID-alias `[[uid|label]]` — never a
     // dangling symbolic `[[label]]` (class files are UID-named). Reverting the
     // fix (writing `[[${instClassLabel}]]`) flips these RED.
@@ -231,7 +231,7 @@ describe("instantiatePrototypeSubtree (issue #3881 Gap 3)", () => {
     );
   });
 
-  it("writes CANONICAL UID-alias class refs `[[uid|label]]`, never dangling symbolic `[[label]]` (#3906)", async () => {
+  it("writes CANONICAL UID-alias class refs `[[uid|label]]`, never dangling symbolic `[[label]]` (#3908)", async () => {
     const { vaultAdapter, fsAdapter, writes, fm } = makeAdapterAndWriter();
     const service = createInstantiatePrototypeSubtreeService(
       vaultAdapter,
@@ -248,7 +248,7 @@ describe("instantiatePrototypeSubtree (issue #3881 Gap 3)", () => {
     expect(nodes.length).toBeGreaterThan(0);
     for (const n of nodes) {
       const ref = unq((n.fm.exo__Instance_class as string[])[0]);
-      // (revert-verify anchor #3906) MUST be `[[uid|label]]`, not `[[label]]`.
+      // (revert-verify anchor #3908) MUST be `[[uid|label]]`, not `[[label]]`.
       // Reverting the fix writes a bare symbolic `[[ems__Project]]` → the alias
       // regex fails to match → this assertion flips RED.
       const m = ref.match(/^\[\[([^|\]]+)\|([^\]]+)\]\]$/);

--- a/packages/services/src/prototype-subtree-instantiator.ts
+++ b/packages/services/src/prototype-subtree-instantiator.ts
@@ -133,23 +133,22 @@ export function createInstantiatePrototypeSubtreeService(
       };
 
       // Resolve an instance-class LABEL (e.g. «ems__Project») to the UID of its
-      // class-definition asset (the UID-named file whose `exo__Asset_label` is
-      // that label AND whose `exo__Instance_class` is the exo__Class metaclass).
-      // Prefer the genuine class definition; fall back to any label match. The
-      // class def is always co-mounted with the prototype it clones (the M1
+      // class-DEFINITION asset — the UID-named file whose `exo__Asset_label` is
+      // that label AND whose `exo__Instance_class` is the `exo__Class` metaclass.
+      // Strict: only a genuine class definition qualifies (never a same-labelled
+      // instance), so a miss means a genuinely absent class → fail-loud below.
+      // The class def is always co-mounted with the prototype it clones (the M1
       // pre-pass already resolves the prototype's own bare-UID class ref via the
-      // same TBox), so a miss means a genuinely absent class → fail-loud below.
+      // same TBox).
       const classUidByLabel = (label: string): string | undefined => {
-        let fallback: string | undefined;
         for (const [uid, entry] of byUid) {
           if (plainScalar(entry.fm.exo__Asset_label) !== label) continue;
           const isClassDef =
             extractAssetReference(firstValue(entry.fm.exo__Instance_class)) ===
             CLASS_METACLASS_UID;
           if (isClassDef) return uid;
-          fallback ??= uid;
         }
-        return fallback;
+        return undefined;
       };
 
       // 2. Resolve the root prototype.

--- a/packages/services/src/prototype-subtree-instantiator.ts
+++ b/packages/services/src/prototype-subtree-instantiator.ts
@@ -55,7 +55,7 @@ const PARENT_PROTOTYPE_KEY = "ems__EffortPrototype_parentEffortPrototype";
 // `exo__Instance_class` ref is the canonical UID-alias form `[[uid|label]]`
 // (what `apply create-task` writes) rather than a DANGLING symbolic-label
 // `[[ems__Project]]` (class files are UID-named, so `ems__Project.md` does not
-// exist → Obsidian shows a broken link). Issue #3906.
+// exist → Obsidian shows a broken link). Issue #3908.
 const CLASS_METACLASS_UID = "8619c4fc-64f1-4869-b17e-e34186cacca9";
 
 interface IndexEntry {
@@ -245,14 +245,14 @@ export function createInstantiatePrototypeSubtreeService(
         }
       }
 
-      // M1 fail-loud pre-pass (issue #3896, extended #3906): resolve every node's
+      // M1 fail-loud pre-pass (issue #3896, extended #3908): resolve every node's
       // canonical instance-class ref BEFORE any write, so a malformed subtree (a
       // node whose `exo__Instance_class` is missing/unresolvable) OR an absent
       // class definition aborts the whole deployment instead of silently writing
       // a dangling class wikilink. Two dangling forms are prevented:
       //   (a) `[[undefined]]` — the prototype's own class is unresolvable;
       //   (b) `[[ems__Project]]` — the derived instance-class LABEL cannot be
-      //       resolved to its UID-named class file (#3906). Both are dangling in
+      //       resolved to its UID-named class file (#3908). Both are dangling in
       //       Obsidian. The map caches `[[uid|label]]` per node for the write
       //       loop. No-null for a domain output; atomic — zero partial state.
       const instClassRef = new Map<string, string>();
@@ -289,7 +289,7 @@ export function createInstantiatePrototypeSubtreeService(
         const newUid = instUid.get(protoUid) as string;
 
         // Canonical `[[uid|label]]` class ref, resolved + validated in the M1
-        // pre-pass (#3906) — never a dangling `[[label]]` symbolic ref.
+        // pre-pass (#3908) — never a dangling `[[label]]` symbolic ref.
         const classRef = instClassRef.get(protoUid) as string;
 
         const label = substitute(plainScalar(fm.exo__Asset_label));

--- a/packages/services/src/prototype-subtree-instantiator.ts
+++ b/packages/services/src/prototype-subtree-instantiator.ts
@@ -49,6 +49,14 @@ import type {
 
 const BACKLOG_STATUS_UID = "753a44d5-846c-4b82-9196-4fd9a4d48777";
 const PARENT_PROTOTYPE_KEY = "ems__EffortPrototype_parentEffortPrototype";
+// The `exo__Class` metaclass — an asset is a CLASS DEFINITION iff its
+// `exo__Instance_class` is this metaclass. Used to resolve an instance-class
+// LABEL (e.g. «ems__Project») back to the class asset's UID so the written
+// `exo__Instance_class` ref is the canonical UID-alias form `[[uid|label]]`
+// (what `apply create-task` writes) rather than a DANGLING symbolic-label
+// `[[ems__Project]]` (class files are UID-named, so `ems__Project.md` does not
+// exist → Obsidian shows a broken link). Issue #3906.
+const CLASS_METACLASS_UID = "8619c4fc-64f1-4869-b17e-e34186cacca9";
 
 interface IndexEntry {
   file: IFile;
@@ -122,6 +130,26 @@ export function createInstantiatePrototypeSubtreeService(
         if (!ref) return undefined;
         const entry = byUid.get(ref);
         return entry ? plainScalar(entry.fm.exo__Asset_label) : ref;
+      };
+
+      // Resolve an instance-class LABEL (e.g. «ems__Project») to the UID of its
+      // class-definition asset (the UID-named file whose `exo__Asset_label` is
+      // that label AND whose `exo__Instance_class` is the exo__Class metaclass).
+      // Prefer the genuine class definition; fall back to any label match. The
+      // class def is always co-mounted with the prototype it clones (the M1
+      // pre-pass already resolves the prototype's own bare-UID class ref via the
+      // same TBox), so a miss means a genuinely absent class → fail-loud below.
+      const classUidByLabel = (label: string): string | undefined => {
+        let fallback: string | undefined;
+        for (const [uid, entry] of byUid) {
+          if (plainScalar(entry.fm.exo__Asset_label) !== label) continue;
+          const isClassDef =
+            extractAssetReference(firstValue(entry.fm.exo__Instance_class)) ===
+            CLASS_METACLASS_UID;
+          if (isClassDef) return uid;
+          fallback ??= uid;
+        }
+        return fallback;
       };
 
       // 2. Resolve the root prototype.
@@ -217,12 +245,17 @@ export function createInstantiatePrototypeSubtreeService(
         }
       }
 
-      // M1 fail-loud pre-pass (issue #3896): validate every node's instance class
-      // resolves to a non-empty label BEFORE any write, so a malformed subtree (a
-      // node whose `exo__Instance_class` is missing/unresolvable) aborts the whole
-      // deployment instead of silently writing `exo__Instance_class: [[undefined]]`
-      // (a dangling wikilink that reddens SHACL later). No-null for a domain
-      // output; atomic — zero partial state on abort.
+      // M1 fail-loud pre-pass (issue #3896, extended #3906): resolve every node's
+      // canonical instance-class ref BEFORE any write, so a malformed subtree (a
+      // node whose `exo__Instance_class` is missing/unresolvable) OR an absent
+      // class definition aborts the whole deployment instead of silently writing
+      // a dangling class wikilink. Two dangling forms are prevented:
+      //   (a) `[[undefined]]` — the prototype's own class is unresolvable;
+      //   (b) `[[ems__Project]]` — the derived instance-class LABEL cannot be
+      //       resolved to its UID-named class file (#3906). Both are dangling in
+      //       Obsidian. The map caches `[[uid|label]]` per node for the write
+      //       loop. No-null for a domain output; atomic — zero partial state.
+      const instClassRef = new Map<string, string>();
       for (const protoUid of subtree) {
         const entry = byUid.get(protoUid);
         if (!entry) continue;
@@ -236,6 +269,13 @@ export function createInstantiatePrototypeSubtreeService(
             `instantiatePrototypeSubtree: cannot resolve instance class for subtree node ${protoUid} (${entry.file.path}) — its exo__Instance_class is missing or unresolvable. Aborting so no asset is written with a dangling [[undefined]] class.`,
           );
         }
+        const classUid = classUidByLabel(instClassLabel);
+        if (!classUid) {
+          throw new Error(
+            `instantiatePrototypeSubtree: cannot resolve class UID for instance class «${instClassLabel}» (subtree node ${protoUid}, ${entry.file.path}) — no class-definition asset with that label is loaded. Aborting so no asset is written with a dangling [[${instClassLabel}]] class wikilink.`,
+          );
+        }
+        instClassRef.set(protoUid, `[[${classUid}|${instClassLabel}]]`);
       }
 
       // 6. Write each instance. Co-locate in the prototype node's folder.
@@ -248,11 +288,9 @@ export function createInstantiatePrototypeSubtreeService(
         const { file, fm } = entry;
         const newUid = instUid.get(protoUid) as string;
 
-        const protoClassLabel = classLabel(fm.exo__Instance_class);
-        const instClassLabel =
-          protoClassLabel && protoClassLabel.endsWith("Prototype")
-            ? protoClassLabel.slice(0, -"Prototype".length)
-            : protoClassLabel;
+        // Canonical `[[uid|label]]` class ref, resolved + validated in the M1
+        // pre-pass (#3906) — never a dangling `[[label]]` symbolic ref.
+        const classRef = instClassRef.get(protoUid) as string;
 
         const label = substitute(plainScalar(fm.exo__Asset_label));
 
@@ -266,7 +304,7 @@ export function createInstantiatePrototypeSubtreeService(
           `exo__Asset_createdAt: ${createdAt}`,
           `exo__Asset_updatedAt: ${createdAt}`,
           "exo__Instance_class:",
-          `  - "[[${instClassLabel}]]"`,
+          `  - "${classRef}"`,
           `exo__Asset_label: ${JSON.stringify(label)}`,
           "aliases:",
           `  - ${JSON.stringify(label)}`,


### PR DESCRIPTION
## Bug

`instantiatePrototypeSubtree` (review-sheet deploy, #3881 Gap 3) wrote each cloned node's class as a **bare symbolic label**:
```yaml
exo__Instance_class:
  - "[[ems__Project]]"     # ← DANGLING — class files are UID-named
```
Class definitions are UID-named files (`ems__Project` = `7db5eeff-…md`; `ems__Project.md` does not exist), so `[[ems__Project]]` is a **dangling wikilink** in Obsidian (Andrey flagged node `44f4822c`). The canonical form — what `apply create-task` writes — is the UID-alias:
```yaml
exo__Instance_class:
  - "[[7db5eeff-718a-49b0-8d2b-39b084a356e3|ems__Project]]"
```
Semantically it still resolved via dual-IRI (`ems#Project` symbolic), so SHACL passed — this is a **UX / canonical-hygiene** defect, but a real one (broken class link for the user). The #3896 review under-classified the symbolic ref as "grandfathered createCreateAssetService convention, acceptable" — but canonical create-task writes UID-alias, so the instantiator diverged.

## Fix

Resolve the derived instance-class label (`ems__Project`) to its class-definition UID (the UID-named file whose `exo__Instance_class` is the `exo__Class` metaclass `8619c4fc`) and emit `[[uid|label]]`. The **M1 fail-loud pre-pass (#3896) is extended** to also abort atomically if the class UID cannot be resolved — the class def is always co-mounted with the prototype (M1 already resolves the prototype's own bare-UID class ref via the same ems TBox; verified present in all 3 vaults under `exoas-public/ems/`), so a miss means a genuinely absent class, never a silent dangling write. Storage-agnostic, signature unchanged.

## Test (production-shape revert-verify)

- New assertion: every created node's `exo__Instance_class` is `[[uid|label]]` (regex-matched, uid = the real class-def UID for that label) — never bare `[[label]]`.
- Existing happy-path class assertions updated to UID-alias form; class-definition fixtures added (production-shape realism, mirroring real `exoas-public/ems/*.md`).
- **Revert-verify:** reverting to `[[${instClassLabel}]]` flips the 2 anchors RED (verified locally); restoring → GREEN. M1/M2 hardening tests unchanged.
- 6/6 instantiator + 52 services + 314 cli-services suites GREEN; lint-job guards (shard/antipatterns/coverage) pass.

## Data

~100 already-deployed review-sheet nodes carry the old symbolic form; a separate mechanical data-migration (backup → rewrite → SHACL no-regress → ExoSync) rewrites them to UID-alias.

Tracked as an `ems__Bug` vault asset (not GitHub issue #3906 — that is an unrelated `apply create-instance` issue; #3908 = this PR).