### PR TITLE
fix(cli): remove existsSync check-then-write TOCTOU in set-property (#3907)

### DIFF
--- a/packages/cli/src/commands/set-property.ts
+++ b/packages/cli/src/commands/set-property.ts
@@ -291,9 +291,6 @@ export function setPropertyCommand(): Command {
         // Resolve + guard the target path (must be inside the vault). Mirrors
         // `apply`'s vault-relative canonicalisation (issue #3788).
         const targetPath = resolve(vaultPath, pathArg);
-        if (!existsSync(targetPath)) {
-          throw new Error(`Target file not found: ${pathArg}`);
-        }
         const vaultRelative = relative(vaultPath, targetPath);
         if (
           vaultRelative === ".." ||
@@ -305,7 +302,19 @@ export function setPropertyCommand(): Command {
           );
         }
 
-        const original = readFileSync(targetPath, "utf-8");
+        // Read directly and surface a friendly not-found on ENOENT — avoids an
+        // `existsSync` check-then-read/write pair (js/file-system-race, #3907):
+        // the file could change between the check and the later write. Mirrors
+        // the same fix already applied in `repair-frontmatter.ts`.
+        let original: string;
+        try {
+          original = readFileSync(targetPath, "utf-8");
+        } catch (readError) {
+          if ((readError as NodeJS.ErrnoException).code === "ENOENT") {
+            throw new Error(`Target file not found: ${pathArg}`);
+          }
+          throw readError;
+        }
         // Only mutate a real asset (has an exo__Asset_uid). Refuse a bare
         // markdown file so `set-property` never silently mutates a non-asset.
         if (!/^\s*exo__Asset_uid:/m.test(original)) {

--- a/packages/cli/tests/integration/set-property.integration.test.ts
+++ b/packages/cli/tests/integration/set-property.integration.test.ts
@@ -411,4 +411,38 @@ describe("Issues #3795 / #3848: `cli set-property` generic guarded mutation prim
     // File is byte-identical — nothing written.
     expect(out.content).toBe(before);
   });
+
+  // ── Nonexistent target (#3907 — read-directly, ENOENT→friendly, no TOCTOU) ──
+
+  it("a missing target file surfaces a friendly 'Target file not found' via the ENOENT read path (no existsSync check-then-write race) @req:3800d995-2bae-401f-a23a-dac914505e9d", async () => {
+    // A target that does not exist on disk. The `run` helper reads the file
+    // back afterwards (which would itself throw for a missing file), so drive
+    // the command directly and inspect the error log / exit codes.
+    const missingRel = `${MOVIES_DIR}/00000000-0000-4000-8000-000000000000.md`;
+    expect(fs.existsSync(path.join(vault, missingRel))).toBe(false);
+
+    const cmd = setPropertyCommand();
+    await cmd.parseAsync(
+      [
+        missingRel,
+        "--vault",
+        vault,
+        "--frozen-clock",
+        FROZEN_CLOCK,
+        "--input",
+        '{"property":"concept__Movie_watched","value":true}',
+      ],
+      { from: "user" },
+    );
+    const errorLog = errorSpy.mock.calls.flat().join("\n");
+
+    // Non-zero exit + the FRIENDLY not-found message, mapped from ENOENT — NOT
+    // a raw `ENOENT: no such file or directory` leak. Removing the `existsSync`
+    // check WITHOUT the ENOENT→friendly mapping reddens both assertions (the raw
+    // readFileSync error surfaces): this is the revert-verify axis for the
+    // read-directly refactor that closed the js/file-system-race (#3907).
+    expect(exitCodes).not.toContain(0);
+    expect(errorLog).toMatch(/Target file not found/);
+    expect(errorLog).not.toMatch(/no such file or directory/i);
+  });
 });


### PR DESCRIPTION
## Symptom
CodeQL code-scanning alert **#314** (`js/file-system-race`, **HIGH**, P0) — `packages/cli/src/commands/set-property.ts:395` (`writeFileSync`): *"The file may have changed since it was checked."* Closes #3907.

## Root cause
Check-then-use TOCTOU: `existsSync(targetPath)` (line 294) guards the target, which is then read (308) and written (395). Between the `existsSync` check and the write the file can change/disappear. CodeQL anchors the alert on the final write sink.

## Fix
Remove the `existsSync(targetPath)` check-half; read the file directly and map `ENOENT` → the same friendly `Target file not found: <path>` error.
- **In-repo precedent:** `repair-frontmatter.ts:152-162` already fixed the identical alert with this exact read-directly pattern.
- The outside-vault path guard (pure path math) runs before the read.
- `existsSync(vaultPath)` (line 287) stays — a different path, not a flagged sink (CodeQL didn't flag it; consistent with `repair-frontmatter.ts`).
- **Scope:** CLI-command layer only — not a parser/schema/sync path.

## Verification
- **Revert-verify (RED→GREEN):** new integration test `set-property.integration.test.ts` — a missing target must surface the friendly `Target file not found`. Removing the `existsSync` check **without** the ENOENT map leaks the raw `ENOENT: no such file or directory` (RED); with the map the friendly message survives (GREEN). Empirically verified: RED (`Received: "❌ Error: ENOENT: no such file or directory..."`), GREEN (27/27 pass).
- The **race property itself** is authoritatively verified by **CodeQL alert #314 clearing** — a TOCTOU window is not deterministically unit-testable.
- Local gates: cli jest 27/27, tsc 0 errors in changed file, 3 lint guard scripts green, archgate 23/23.

https://claude.ai/code/session_01L2EFGtzcrp6W57xJ5HrGxZ
