### PR TITLE
chore(cli): route 5 remaining bare yaml.load readers through parseYamlFrontmatterTolerant (#3901)

### DIFF
--- a/packages/cli/src/services/AtomicFrontmatterService.ts
+++ b/packages/cli/src/services/AtomicFrontmatterService.ts
@@ -8,6 +8,7 @@ import {
 import path from "path";
 import { randomBytes } from "crypto";
 import yaml from "js-yaml";
+import { parseYamlFrontmatterTolerant } from "@kitelev/exocortex-core";
 
 export type AtomicUpdateFailureReason =
   | "verify-mismatch"
@@ -48,7 +49,23 @@ function parseFile(content: string): ParsedFile | null {
   const match = content.match(FRONTMATTER_RE);
   if (!match) return null;
   const [, fm, body = ""] = match;
-  const parsed = yaml.load(fm);
+  // Read-modify-WRITE path — try the strict parse first (empty & non-dup files
+  // stay byte-identical). A duplicated YAML key makes `yaml.load` THROW; recover
+  // it last-wins via the tolerant parser (#3901 / #3800) so an atomic update
+  // self-heals a dup-key file instead of aborting. But a GENUINELY malformed
+  // block must still fail-loud (→ parse-error → NO write) so we never overwrite a
+  // broken file with empty frontmatter — the tolerant parser returns null for
+  // BOTH empty and malformed, but only a throw reaches this branch, so a null
+  // here means malformed → re-throw.
+  let parsed: unknown;
+  try {
+    parsed = yaml.load(fm);
+  } catch {
+    parsed = parseYamlFrontmatterTolerant(fm, "AtomicFrontmatterService");
+    if (parsed === null) {
+      throw new Error("frontmatter is not a YAML mapping");
+    }
+  }
   if (parsed === null || parsed === undefined) {
     return { frontmatter: {}, body };
   }

--- a/packages/cli/src/services/ClaimService.ts
+++ b/packages/cli/src/services/ClaimService.ts
@@ -1,7 +1,7 @@
 import * as fs from "fs";
 import * as path from "path";
 import * as os from "os";
-import yaml from "js-yaml";
+import { parseYamlFrontmatterTolerant } from "@kitelev/exocortex-core";
 import {
   atomicUpdateFrontmatter,
   AtomicUpdateOptions,
@@ -83,7 +83,11 @@ function readFrontmatter(filePath: string): Record<string, unknown> | null {
   const content = fs.readFileSync(filePath, "utf8");
   const match = content.match(FRONTMATTER_RE);
   if (!match) return null;
-  const parsed = yaml.load(match[1]);
+  // Tolerant parse (#3901 / #3800): a duplicated YAML key resolves last-wins
+  // instead of throwing — the bare `yaml.load` here had NO try/catch, so a
+  // dup-key claim file would CRASH claimTask; tolerant returns the mapping
+  // (or null on genuine malformed). Non-dup input is byte-identical.
+  const parsed = parseYamlFrontmatterTolerant(match[1], filePath);
   if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
     return null;
   }

--- a/packages/cli/src/services/CliApplyProfileService.ts
+++ b/packages/cli/src/services/CliApplyProfileService.ts
@@ -24,7 +24,6 @@
 
 import { existsSync, readdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
-import yaml from "js-yaml";
 
 import type { ApplyPlan } from "@kitelev/exocortex-core";
 import {
@@ -34,6 +33,7 @@ import {
   SDK_FLOOR,
   CATALOG_KEEP_NAMESPACES,
   TsFloorViolationError,
+  parseYamlFrontmatterTolerant,
 } from "@kitelev/exocortex-core";
 
 import {
@@ -460,7 +460,10 @@ export class CliApplyProfileService {
     const match = content.match(/^---\r?\n([\s\S]*?)\r?\n---/);
     if (match === null) return null;
     try {
-      const parsed = yaml.load(match[1]);
+      // Tolerant parse (#3901 / #3800): a duplicated YAML key resolves last-wins
+      // instead of throwing (which the bare `yaml.load` did → caught → null),
+      // so a dup-key asset still resolves. Non-dup input is byte-identical.
+      const parsed = parseYamlFrontmatterTolerant(match[1], filePath);
       if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
         return parsed as Record<string, unknown>;
       }

--- a/packages/cli/src/services/CliProfileResolver.ts
+++ b/packages/cli/src/services/CliProfileResolver.ts
@@ -25,12 +25,12 @@
 
 import fs from "fs-extra";
 import path from "path";
-import yaml from "js-yaml";
 
 import {
   SDK_FLOOR_ASSETSPACE_UIDS,
   derivePath,
   transitiveDependsOnClosure,
+  parseYamlFrontmatterTolerant,
 } from "@kitelev/exocortex-core";
 
 // TS-floor anchors (Vision Lock #17) — re-exported from the `exocortex` core
@@ -399,7 +399,10 @@ export class CliProfileResolver {
     const match = content.match(/^---\r?\n([\s\S]*?)\r?\n---/);
     if (match === null) return null;
     try {
-      const parsed = yaml.load(match[1]);
+      // Tolerant parse (#3901 / #3800): a duplicated YAML key resolves last-wins
+      // instead of throwing (which the bare `yaml.load` did → caught → null),
+      // so a dup-key profile still resolves. Non-dup input is byte-identical.
+      const parsed = parseYamlFrontmatterTolerant(match[1], filePath);
       if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
         return parsed as Record<string, unknown>;
       }

--- a/packages/cli/src/services/RegistryDependencyResolver.ts
+++ b/packages/cli/src/services/RegistryDependencyResolver.ts
@@ -25,9 +25,12 @@
 
 import fs from "fs-extra";
 import path from "path";
-import yaml from "js-yaml";
 
-import { transitiveDependsOnClosure, derivePath } from "@kitelev/exocortex-core";
+import {
+  transitiveDependsOnClosure,
+  derivePath,
+  parseYamlFrontmatterTolerant,
+} from "@kitelev/exocortex-core";
 
 import {
   ASSET_SPACE_CLASS_UID,
@@ -304,7 +307,10 @@ export class RegistryDependencyResolver {
     const match = content.match(/^---\r?\n([\s\S]*?)\r?\n---/);
     if (match === null) return null;
     try {
-      const parsed = yaml.load(match[1]);
+      // Tolerant parse (#3901 / #3800): a duplicated YAML key resolves last-wins
+      // instead of throwing (which the bare `yaml.load` did → caught → null),
+      // so a dup-key descriptor still resolves. Non-dup input is byte-identical.
+      const parsed = parseYamlFrontmatterTolerant(match[1], filePath);
       if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
         return parsed as Record<string, unknown>;
       }

--- a/packages/cli/tests/unit/CliApplyProfileService.test.ts
+++ b/packages/cli/tests/unit/CliApplyProfileService.test.ts
@@ -94,4 +94,26 @@ describe("CliApplyProfileService.scanVault", () => {
     const svc = new CliApplyProfileService({ vaultPath: root });
     expect(svc.scanVault().infos).toHaveLength(0);
   });
+
+  it("scans a descriptor whose frontmatter has a duplicated YAML key (tolerant last-wins) (#3901)", () => {
+    // A bare `yaml.load` THROWS on a dup key → the descriptor was silently
+    // skipped (caught → null → 0 infos). Tolerant resolves last-wins → scanned.
+    // REVERT-VERIFY: revert readFrontmatter to bare yaml.load → infos length 0
+    // → RED.
+    const uid = "dddddddd-dddd-dddd-dddd-dddddddddddd";
+    const dir = path.join(root, "assetspaces", "_registry");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(
+      path.join(dir, `${uid}.md`),
+      `---\nexo__Asset_uid: ${uid}\n` +
+        `exo__Instance_class:\n  - "[[${ASSET_SPACE_CLASS_UID}]]"\n` +
+        `exo__AssetSpace_source: "https://github.com/kitelev/exoas-dup"\n` +
+        `exo__AssetSpace_source: "https://github.com/kitelev/exoas-testlib"\n---\n`,
+    );
+    const svc = new CliApplyProfileService({ vaultPath: root });
+    const { infos } = svc.scanVault();
+    expect(infos).toHaveLength(1);
+    expect(infos[0].uid).toBe(uid);
+    expect(infos[0].folderName).toBe("assetspaces/kitelev/exoas-testlib"); // last-wins source
+  });
 });

--- a/packages/cli/tests/unit/services/AtomicFrontmatterService.test.ts
+++ b/packages/cli/tests/unit/services/AtomicFrontmatterService.test.ts
@@ -59,6 +59,46 @@ describe("AtomicFrontmatterService", () => {
     expect(r.reason).toBe("parse-error");
   });
 
+  // ── #3901: tolerant dup-key rescue + preserved malformed-abort (no data loss) ──
+
+  it("self-heals a duplicated YAML key (last-wins) instead of aborting parse-error (#3901)", () => {
+    // A bare `yaml.load` THROWS on a duplicated mapping key → the old code
+    // returned parse-error (the atomic update aborted). The tolerant parser
+    // resolves last-wins, so the update proceeds and rewrites the file deduped.
+    // REVERT-VERIFY: revert parseFile to a bare `yaml.load(fm)` → dup-key throws
+    // → r.success is false (parse-error) → RED. With the guarded tolerant route
+    // → GREEN.
+    writeFileSync(
+      target,
+      "---\nexo__Asset_uid: uuid-1\ndup: first\ndup: second\n---\n# Body\n",
+    );
+
+    const r = atomicUpdateFrontmatter(target, { aiTask__Task_claimedBy: "99999" });
+
+    expect(r.success).toBe(true);
+    const parsed = yaml.load(
+      readFileSync(target, "utf8").split("---")[1],
+    ) as Record<string, unknown>;
+    expect(parsed["dup"]).toBe("second"); // last-wins
+    expect(parsed["aiTask__Task_claimedBy"]).toBe("99999");
+    expect(parsed["exo__Asset_uid"]).toBe("uuid-1");
+  });
+
+  it("still aborts (parse-error, file byte-identical) for GENUINELY malformed YAML — the write path must never overwrite a broken file with empty frontmatter (#3901 negative control)", () => {
+    // Unterminated flow sequence → `yaml.load` throws even in JSON-compat mode,
+    // so the tolerant parser returns null → parseFile re-throws → parse-error.
+    // This proves the dup-key rescue did NOT weaken the malformed-abort safety:
+    // the atomic update aborts BEFORE any write, leaving the file untouched.
+    const original = "---\nkey: [unterminated\n---\noriginal body\n";
+    writeFileSync(target, original);
+
+    const r = atomicUpdateFrontmatter(target, { foo: "bar" });
+
+    expect(r.success).toBe(false);
+    expect(r.reason).toBe("parse-error");
+    expect(readFileSync(target, "utf8")).toBe(original); // no data loss
+  });
+
   it("returns fs-error when target file is missing", () => {
     const r = atomicUpdateFrontmatter(path.join(dir, "missing.md"), { foo: 1 });
     expect(r.success).toBe(false);

--- a/packages/cli/tests/unit/services/ClaimService.test.ts
+++ b/packages/cli/tests/unit/services/ClaimService.test.ts
@@ -83,4 +83,17 @@ describe("ClaimService", () => {
     await claimTask(target, 333);
     expect(existsSync(tmpLockDir)).toBe(true);
   });
+
+  it("claims a task whose frontmatter has a duplicated YAML key (tolerant parse, no crash) (#3901)", async () => {
+    // `readFrontmatter` had a bare `yaml.load` with NO try/catch → a dup key
+    // THREW and claimTask rejected. The tolerant parser resolves last-wins so
+    // the claim proceeds. REVERT-VERIFY: revert readFrontmatter to bare
+    // yaml.load → this rejects/returns false → RED.
+    writeFileSync(
+      target,
+      "---\nexo__Asset_uid: dup-uuid\nems__Effort_status: A\nems__Effort_status: B\n---\n",
+    );
+    const claimed = await claimTask(target, 2001);
+    expect(claimed).toBe(true);
+  });
 });

--- a/packages/cli/tests/unit/services/CliProfileResolver.test.ts
+++ b/packages/cli/tests/unit/services/CliProfileResolver.test.ts
@@ -170,6 +170,28 @@ describe("CliProfileResolver", () => {
       }
     });
 
+    it("resolves a profile whose frontmatter has a duplicated YAML key (tolerant last-wins) (#3901)", async () => {
+      await makeVault(tmpRoot, [
+        asAssetSpace(AS_EXO_UID, "exo"),
+        asProfile(PROFILE_BASE_UID, { label: "base" }),
+      ]);
+      // Overwrite the profile with a raw duplicated-key frontmatter. A bare
+      // `yaml.load` THROWS → tryReadFrontmatter returns null → the profile reads
+      // as not-a-profile → missing-profile. Tolerant resolves last-wins →
+      // engaged. REVERT-VERIFY: revert tryReadFrontmatter to bare yaml.load →
+      // out.outcome !== "engaged" → RED.
+      await fs.writeFile(
+        path.join(tmpRoot, "profiles", `${PROFILE_BASE_UID}.md`),
+        `---\nexo__Asset_uid: ${PROFILE_BASE_UID}\n` +
+          `exo__Instance_class:\n  - "[[${PROFILE_CLASS_UID}|exo__Profile]]"\n` +
+          `exo__Asset_label: first\nexo__Asset_label: base\n---\n`,
+        "utf-8",
+      );
+      const resolver = new CliProfileResolver({ vaultPath: tmpRoot });
+      const out = await resolver.resolveFilter(PROFILE_BASE_UID);
+      expect(out.outcome).toBe("engaged");
+    });
+
     it("resolves declared AS UIDs against the folder map (RFC 01a83de8 Phase 2)", async () => {
       await makeVault(tmpRoot, [
         asAssetSpace(AS_EXO_UID, "exo"),

--- a/packages/cli/tests/unit/services/RegistryDependencyResolver.test.ts
+++ b/packages/cli/tests/unit/services/RegistryDependencyResolver.test.ts
@@ -132,6 +132,27 @@ describe("RegistryDependencyResolver", () => {
       expect(descs.has(UID_EXO)).toBe(true);
     });
 
+    it("resolves a descriptor whose frontmatter has a duplicated YAML key (tolerant last-wins) (#3901)", async () => {
+      // A bare `yaml.load` THROWS on a dup key → the descriptor was silently
+      // skipped (caught → null). Tolerant resolves last-wins → discovered.
+      // REVERT-VERIFY: revert tryReadFrontmatter to bare yaml.load → dup throws
+      // → descs.has(UID_EXO) is false → RED.
+      const dir = path.join(tmp, "registry");
+      await fs.ensureDir(dir);
+      await fs.writeFile(
+        path.join(dir, `${UID_EXO}.md`),
+        `---\nexo__Asset_uid: ${UID_EXO}\n` +
+          `exo__Instance_class:\n  - "[[${ASSET_SPACE_CLASS_UID}]]"\n` +
+          `exo__AssetSpace_namespace: first\nexo__AssetSpace_namespace: exo\n` +
+          `exo__AssetSpace_source: "https://github.com/kitelev/exoas-exo"\n---\n`,
+        "utf-8",
+      );
+      const resolver = new RegistryDependencyResolver();
+      const descs = await resolver.scanRegistry(dir);
+      expect(descs.has(UID_EXO)).toBe(true);
+      expect(descs.get(UID_EXO)?.namespace).toBe("exo"); // last-wins
+    });
+
     it("returns an empty map (with a warn) for a non-existent registry path", async () => {
       const warnings: string[] = [];
       const resolver = new RegistryDependencyResolver({ warn: (m) => warnings.push(m) });


### PR DESCRIPTION
## Summary
Follow-up to #3800 / PR #3900 (orchestrator review M2). The tolerant YAML parser (#3800) was wired into the **3 asset-invisibility-path** readers; these **5 config/profile/claim** readers still did a bare `yaml.load` (dup key → throw). Routes each through core `parseYamlFrontmatterTolerant` (dup key → last-wins, non-dup byte-identical, malformed → null). Closes #3901.

## Per-file
| File | Change | Rationale |
|---|---|---|
| `RegistryDependencyResolver.ts` | straight swap | already `try/catch→null`; tolerant only *rescues* the dup-key case |
| `CliProfileResolver.ts` | straight swap | same |
| `CliApplyProfileService.ts` | straight swap | same |
| `ClaimService.ts` | straight swap | **also fixes a latent crash** — `readFrontmatter` had NO try/catch, so a dup-key claim file threw out of `claimTask` |
| `AtomicFrontmatterService.ts` | **guarded route** | read-modify-**WRITE** path — dup-key is rescued (atomic update self-heals), but a **genuinely malformed** block still fails-loud (`parse-error` → NO write) so the write path never overwrites a broken file with empty frontmatter (**data loss**) |

## Verification
- **Revert-verify (empirical):** reverting the 5 source edits → the **5 dup-key rescue tests** go RED (Registry/Profile/ApplyProfile/ClaimService/Atomic-dup-key), while the AtomicFrontmatterService **malformed-abort negative control** (asserts the file is byte-identical on `parse-error`) stays GREEN both ways — proving the dup-key rescue did not weaken the data-loss guard.
- 5 affected suites: **76/76** pass. tsc 0 errors in changed files. 3 lint guard scripts green. archgate 23/23.

https://claude.ai/code/session_01L2EFGtzcrp6W57xJ5HrGxZ
