### PR TITLE
ci: pin archgate@0.48.4 — 0.49.0 rule-file import scanner breaks all archgate runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -223,7 +223,14 @@ jobs:
           key: archgate-${{ runner.os }}
 
       - name: Install Archgate
-        run: npm install -g archgate
+        # Pinned: archgate 0.49.0 (2026-07-16) tightened the rule-file import
+        # security scanner to allow only node:* imports, which blocks the repo's
+        # own `.archgate/adrs/*.rules.ts` helpers (e.g. MOBILE-004 →
+        # `../lint/desktopOnlyCommandGate`) → archgate check fails on every run
+        # once `npm install -g archgate` (unpinned) resolves 0.49.0. Pin to the
+        # last-known-good 0.48.4 for determinism; upgrade + adapt the rule files
+        # to 0.49.0's stricter policy deliberately as a follow-up.
+        run: npm install -g archgate@0.48.4
 
       - name: Run ADR compliance checks
         run: archgate check --ci


### PR DESCRIPTION
## Problem
`archgate` **0.49.0** (published 2026-07-16 15:18Z) tightened the rule-file import security scanner to allow only `node:*` imports. That blocks the repo's own `.archgate/adrs/*.rules.ts` helper imports — e.g. `MOBILE-004-no-desktop-only-gated-addcommand.rules.ts` imports `../lint/desktopOnlyCommandGate` — so `archgate check --ci` fails on **every** run once the unpinned `npm install -g archgate` resolves 0.49.0.

## Evidence (version drift, not a flake)
- main-push run of `d845e20e` passed archgate at ~13:12Z → archgate **0.48.4**.
- Identical base on PR #3913 failed at 15:27Z → archgate **0.49.0** (published 15:18Z). Re-ran fresh, still fails — deterministic.
- This blocks **all** PRs (archgate is a required check).

## Fix
Pin `npm install -g archgate@0.48.4` (last-known-good). Restores determinism + unblocks all PRs. This PR's own archgate step installs the pinned 0.48.4 → passes (self-unblocking).

## Follow-up
Separate issue: adapt `.archgate/adrs/*.rules.ts` to 0.49.0's stricter import policy (inline the lint helpers / use RuleContext API), then bump the pin to latest.

https://claude.ai/code/session_01L2EFGtzcrp6W57xJ5HrGxZ