### PR TITLE
feat(cli): apply <cmd> --json emits created uid/path (#3906)

### DIFF
--- a/packages/cli/src/commands/apply.ts
+++ b/packages/cli/src/commands/apply.ts
@@ -56,6 +56,34 @@ export interface ApplyOptions {
   input?: string;
   seed?: string;
   frozenClock?: string;
+  // Issue #3906 — emit a machine-readable JSON envelope describing what the
+  // apply invocation created, symmetric with `create`'s structured output and
+  // `query --format json`. When set, stdout is a single JSON object and the
+  // human-readable ✅/📊 notices are suppressed so the object parses cleanly.
+  json?: boolean;
+}
+
+/**
+ * Issue #3906 — a single asset written to disk by an apply run, mirroring the
+ * `create` command's `{uuid,path,label}` output shape. `uuid` is the created
+ * file's `exo__Asset_uid` (its UUID-canon basename), `path` is the file's
+ * vault-relative path, `label` its `exo__Asset_label`.
+ */
+interface CreatedAsset {
+  uuid: string;
+  path: string;
+  label: string;
+}
+
+/**
+ * Issue #3906 — per-target execution outcome: the success flag PLUS the assets
+ * created on disk (for `--json` / the human path-append). `executeOnTarget`
+ * returns this instead of a bare boolean so the action handler can aggregate a
+ * `created` array across a multi-target (stdin-piped) run.
+ */
+interface TargetResult {
+  ok: boolean;
+  created: CreatedAsset[];
 }
 
 const UUID_RE =
@@ -157,11 +185,13 @@ async function executeOnTarget(
   options: ApplyOptions,
   clock: IClock,
   uidGen: IUidGenerator,
-): Promise<boolean> {
+): Promise<TargetResult> {
+  // Issue #3906 — a failed target contributes no created assets.
+  const failed: TargetResult = { ok: false, created: [] };
   const targetPath = resolve(vaultPath, targetRelative);
   if (!existsSync(targetPath)) {
     console.error(`❌ Target file not found: ${targetRelative}`);
-    return false;
+    return failed;
   }
 
   // Issue #3788 — canonicalise the target to a vault-relative path before
@@ -191,7 +221,7 @@ async function executeOnTarget(
     console.error(
       `❌ Target is outside the vault: ${targetRelative} (vault: ${vaultPath})`,
     );
-    return false;
+    return failed;
   }
 
   const resolver = new CommandResolver(tripleStore);
@@ -199,7 +229,7 @@ async function executeOnTarget(
 
   if (!command) {
     console.error(`❌ Command with UID "${commandUid}" not found.`);
-    return false;
+    return failed;
   }
 
   // Destructive safety guard (T1.6)
@@ -209,7 +239,7 @@ async function executeOnTarget(
       `❌ Command "${command.name}" is marked destructive. ` +
         `Add --dry-run to preview, or --yes to apply.`,
     );
-    return false;
+    return failed;
   }
 
   const targetIRI = vaultPathToIRI(vaultRelative);
@@ -272,15 +302,19 @@ async function executeOnTarget(
     console.error(
       `❌ Precondition not satisfied for "${command.name}" on "${vaultRelative}".`,
     );
-    return false;
+    return failed;
   }
 
   // Dry-run
   if (options.dryRun) {
-    console.log(
-      `🔍 Dry-run: would apply "${command.name}" to "${vaultRelative}" (precondition passed).`,
-    );
-    return true;
+    // Issue #3906 — keep stdout clean in --json mode (the envelope is emitted
+    // once by the action handler); a dry-run creates nothing → empty `created`.
+    if (!options.json) {
+      console.log(
+        `🔍 Dry-run: would apply "${command.name}" to "${vaultRelative}" (precondition passed).`,
+      );
+    }
+    return { ok: true, created: [] };
   }
 
   // Execute grounding
@@ -377,7 +411,7 @@ async function executeOnTarget(
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       console.error(`❌ --input: invalid JSON object (${msg})`);
-      return false;
+      return failed;
     }
   }
 
@@ -389,16 +423,51 @@ async function executeOnTarget(
   );
 
   if (result.success) {
-    const msg =
-      command.successMessage ??
-      `Applied "${command.name}" to "${vaultRelative}".`;
-    console.log(`✅ ${msg}`);
-    return true;
+    // Issue #3906 — surface the created asset's identity. The grounding executor
+    // already threads the created path (`ExecutionResult.openPath`) — a direct
+    // create_instance grounding (e.g. create-task-instance) sets it. Read the
+    // created file FRESH from disk (getAbstractFileByPath = statSync,
+    // getFrontmatter = readFileSync — no stale index) for its uuid + label.
+    const created: CreatedAsset[] = [];
+    if (result.openPath) {
+      const createdNode = vaultAdapter.getAbstractFileByPath(result.openPath);
+      const createdFile =
+        createdNode !== null && "basename" in createdNode
+          ? (createdNode as IFile)
+          : null;
+      const createdFm = createdFile
+        ? vaultAdapter.getFrontmatter(createdFile)
+        : null;
+      const labelRaw =
+        createdFm && typeof createdFm === "object"
+          ? (createdFm as Record<string, unknown>).exo__Asset_label
+          : undefined;
+      created.push({
+        // UUID-canon: the file is written as `<uid>.md`, so its basename IS the
+        // uuid (mirrors `create`'s `uuid = file.basename`). Fall back to the
+        // path tail if the adapter could not stat the just-written file.
+        uuid:
+          createdFile?.basename ??
+          result.openPath.replace(/^.*\//, "").replace(/\.md$/, ""),
+        path: result.openPath,
+        label: typeof labelRaw === "string" ? labelRaw : "",
+      });
+    }
+    if (!options.json) {
+      const msg =
+        command.successMessage ??
+        `Applied "${command.name}" to "${vaultRelative}".`;
+      // Optionally append the created path for convenience (Issue #3906) — no
+      // suffix when the command created nothing, so existing output is unchanged.
+      const suffix = result.openPath ? ` → ${result.openPath}` : "";
+      console.log(`✅ ${msg}${suffix}`);
+    }
+    return { ok: true, created };
   } else {
     console.error(
       `❌ "${command.name}" failed on "${vaultRelative}": ${result.error}`,
     );
-    return false;
+    return failed;
   }
 }
 
@@ -431,6 +500,10 @@ export function applyCommand(): Command {
     .option(
       "--frozen-clock <iso>",
       "Freeze clock to ISO timestamp for test/replay (uses frozenClock)",
+    )
+    .option(
+      "--json",
+      "Emit a machine-readable JSON result ({command,target,created:[{uuid,path,label}]}) instead of human-readable output",
     )
     .action(
       async (
@@ -502,8 +575,11 @@ export function applyCommand(): Command {
           // Continue-on-error semantics
           let successCount = 0;
           let failCount = 0;
+          // Issue #3906 — aggregate the assets created across all targets for
+          // the `--json` envelope.
+          const allCreated: CreatedAsset[] = [];
           for (const target of targets) {
-            const ok = await executeOnTarget(
+            const targetResult = await executeOnTarget(
               vaultPath,
               tripleStore,
               workflowResolver,
@@ -513,14 +589,32 @@ export function applyCommand(): Command {
               clock,
               uidGen,
             );
-            if (ok) successCount++;
+            if (targetResult.ok) successCount++;
             else failCount++;
+            allCreated.push(...targetResult.created);
           }
 
-          if (targets.length > 1) {
+          // Issue #3906 — in --json mode the multi-target summary is suppressed
+          // so stdout stays a single valid JSON document.
+          if (targets.length > 1 && !options.json) {
             console.log(
               `\n📊 Applied to ${successCount}/${targets.length} target(s) (${failCount} failed).`,
             );
+          }
+
+          // Issue #3906 — emit the machine-readable envelope once for the whole
+          // invocation (after the loop, before the exit-code decision, so a
+          // partially-failing run still reports what it created + exits non-zero).
+          if (options.json) {
+            const envelope: Record<string, unknown> = {
+              command: cmdArg,
+              created: allCreated,
+            };
+            // `target` (singular) for a single explicit path arg; `targets`
+            // (array) for a stdin-piped batch — matches the issue's example.
+            if (pathArg) envelope.target = pathArg;
+            else envelope.targets = targets;
+            process.stdout.write(JSON.stringify(envelope) + "\n");
           }
 
           if (failCount > 0) {

--- a/packages/cli/tests/integration/apply-json-created.integration.test.ts
+++ b/packages/cli/tests/integration/apply-json-created.integration.test.ts
@@ -1,0 +1,265 @@
+/**
+ * Issue #3906 — integration test for `apply <cmd> <target> --json`.
+ *
+ * Builds a tiny vault with a create_instance-grounding command + prototype and
+ * drives the REAL `applyCommand().parseAsync([...--json...])` end-to-end, then
+ * reads the created file from disk (production-shape — not hand-injected). It
+ * asserts stdout parses to a `{command,target,created:[{uuid,path,label}]}`
+ * envelope whose `created[0]` matches the file actually written; that `--json`
+ * off keeps the human output and emits no stdout JSON; and that a non-creating
+ * (property_set) grounding yields an empty `created` array.
+ *
+ * Revert-verify axis (@req:55a79515-dd18-4116-9295-f7bee8949712): the `created[0]` assertion goes RED
+ * when the production `created`-surfacing in `apply.ts` is neutralized (the
+ * envelope's `created` stays empty → `created[0]` is undefined) and GREEN when
+ * restored — empirically checked before merge (see PR body).
+ *
+ * Uses programmatic `parseAsync` (no built-binary dependency), mirroring
+ * `apply-determinism.integration.test.ts`.
+ */
+import {
+  jest,
+  describe,
+  it,
+  expect,
+  beforeEach,
+  afterEach,
+} from "@jest/globals";
+import * as fs from "fs";
+import * as path from "path";
+import * as os from "os";
+
+const { applyCommand } = await import("../../src/commands/apply.js");
+
+const GT_CREATE_INSTANCE = "4367e2d6-6c92-450a-becb-abce1fb07682";
+const GT_PROPERTY_SET = "cf3bb923-f1f1-40be-b728-782844402426";
+
+const CREATE_CMD_UID = "aaaa0001-0000-0000-0000-000000000001";
+const CREATE_GROUNDING_UID = "aaaa0002-0000-0000-0000-000000000002";
+const PROTO_UID = "aaaa0003-0000-0000-0000-000000000003";
+const PSET_CMD_UID = "aaaa0004-0000-0000-0000-000000000004";
+const PSET_GROUNDING_UID = "aaaa0005-0000-0000-0000-000000000005";
+
+const INPUT_LABEL = "JSON child task";
+
+const CREATE_CMD_MD = [
+  "---",
+  `exo__Asset_uid: ${CREATE_CMD_UID}`,
+  `exo__Asset_label: "Create child task (json-test)"`,
+  `exo__Asset_isDefinedBy: "[[!kitelev]]"`,
+  `exo__Instance_class:`,
+  `  - "[[exocmd__Command]]"`,
+  `exocmd__Command_grounding: "[[${CREATE_GROUNDING_UID}|Create child task grounding]]"`,
+  `exocmd__Command_successMessage: "Child task created"`,
+  "---",
+  "",
+].join("\n");
+
+const CREATE_GROUNDING_MD = [
+  "---",
+  `exo__Asset_uid: ${CREATE_GROUNDING_UID}`,
+  `exo__Asset_label: "Create child task grounding"`,
+  `exo__Asset_isDefinedBy: "[[!kitelev]]"`,
+  `exo__Instance_class:`,
+  `  - "[[exocmd__Grounding]]"`,
+  `exocmd__Grounding_type: "[[${GT_CREATE_INSTANCE}]]"`,
+  `exocmd__Grounding_targetClass: "ems__Task"`,
+  `exocmd__Grounding_targetFolder: "Inbox"`,
+  "---",
+  "",
+].join("\n");
+
+const PROTO_MD = [
+  "---",
+  `exo__Asset_uid: ${PROTO_UID}`,
+  `exo__Asset_label: "Parent prototype asset"`,
+  `exo__Asset_isDefinedBy: "[[!kitelev]]"`,
+  `exo__Instance_class:`,
+  `  - "[[ems__TaskPrototype]]"`,
+  "---",
+  "",
+].join("\n");
+
+// A non-creating command: property_set writes a literal to the prototype's own
+// frontmatter → its ExecutionResult has NO `openPath` → `created` must be empty.
+const PSET_CMD_MD = [
+  "---",
+  `exo__Asset_uid: ${PSET_CMD_UID}`,
+  `exo__Asset_label: "Set a flag (json-test)"`,
+  `exo__Asset_isDefinedBy: "[[!kitelev]]"`,
+  `exo__Instance_class:`,
+  `  - "[[exocmd__Command]]"`,
+  `exocmd__Command_grounding: "[[${PSET_GROUNDING_UID}|Set flag grounding]]"`,
+  `exocmd__Command_successMessage: "Flag set"`,
+  "---",
+  "",
+].join("\n");
+
+const PSET_GROUNDING_MD = [
+  "---",
+  `exo__Asset_uid: ${PSET_GROUNDING_UID}`,
+  `exo__Asset_label: "Set flag grounding"`,
+  `exo__Asset_isDefinedBy: "[[!kitelev]]"`,
+  `exo__Instance_class:`,
+  `  - "[[exocmd__Grounding]]"`,
+  `exocmd__Grounding_type: "[[${GT_PROPERTY_SET}]]"`,
+  `exocmd__Grounding_targetProperty: "test__Flag"`,
+  `exocmd__Grounding_targetValueLiteral: "done"`,
+  "---",
+  "",
+].join("\n");
+
+interface VaultLayout {
+  root: string;
+  protoRelPath: string;
+  inboxDir: string;
+}
+
+function buildVault(): VaultLayout {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "exo-apply-json-"));
+  fs.writeFileSync(path.join(root, `${CREATE_CMD_UID}.md`), CREATE_CMD_MD, "utf-8");
+  fs.writeFileSync(
+    path.join(root, `${CREATE_GROUNDING_UID}.md`),
+    CREATE_GROUNDING_MD,
+    "utf-8",
+  );
+  fs.writeFileSync(path.join(root, `${PROTO_UID}.md`), PROTO_MD, "utf-8");
+  fs.writeFileSync(path.join(root, `${PSET_CMD_UID}.md`), PSET_CMD_MD, "utf-8");
+  fs.writeFileSync(
+    path.join(root, `${PSET_GROUNDING_UID}.md`),
+    PSET_GROUNDING_MD,
+    "utf-8",
+  );
+  fs.mkdirSync(path.join(root, "Inbox"), { recursive: true });
+  return { root, protoRelPath: `${PROTO_UID}.md`, inboxDir: path.join(root, "Inbox") };
+}
+
+describe("Issue #3906: apply --json emits created uid/path", () => {
+  let vault: VaultLayout;
+  let processExitSpy: jest.SpiedFunction<typeof process.exit>;
+  let consoleLogSpy: jest.SpiedFunction<typeof console.log>;
+  let consoleErrorSpy: jest.SpiedFunction<typeof console.error>;
+  let stdoutSpy: jest.SpiedFunction<typeof process.stdout.write>;
+  let stdoutChunks: string[];
+
+  beforeEach(() => {
+    vault = buildVault();
+    stdoutChunks = [];
+    processExitSpy = jest.spyOn(process, "exit").mockImplementation(((
+      code?: number,
+    ) => {
+      throw new Error(`__process_exit_${code ?? 0}__`);
+    }) as never);
+    consoleLogSpy = jest.spyOn(console, "log").mockImplementation(() => {});
+    consoleErrorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+    // Capture the JSON envelope (written via process.stdout.write). console.log
+    // is mocked to a no-op above, so it never reaches process.stdout.write —
+    // this spy therefore captures ONLY the apply envelope.
+    stdoutSpy = jest
+      .spyOn(process.stdout, "write")
+      .mockImplementation(((chunk: string | Uint8Array) => {
+        stdoutChunks.push(chunk.toString());
+        return true;
+      }) as never);
+  });
+
+  afterEach(() => {
+    stdoutSpy.mockRestore();
+    processExitSpy.mockRestore();
+    consoleLogSpy.mockRestore();
+    consoleErrorSpy.mockRestore();
+    fs.rmSync(vault.root, { recursive: true, force: true });
+  });
+
+  async function runApply(cmdUid: string, extraArgs: string[]): Promise<void> {
+    const cmd = applyCommand();
+    const args = [
+      "node",
+      "apply",
+      cmdUid,
+      vault.protoRelPath,
+      "--vault",
+      vault.root,
+      "--input",
+      JSON.stringify({ label: INPUT_LABEL }),
+      ...extraArgs,
+    ];
+    try {
+      await cmd.parseAsync(args);
+    } catch (err) {
+      if (!/^__process_exit_/.test(String((err as Error)?.message))) throw err;
+    }
+  }
+
+  it("@req:55a79515-dd18-4116-9295-f7bee8949712 --json emits created:[{uuid,path,label}] resolving to the file actually written", async () => {
+    await runApply(CREATE_CMD_UID, ["--json"]);
+
+    // stdout is exactly one JSON document (no ✅ / 📊 noise — console.log was
+    // suppressed, only the envelope was written to process.stdout).
+    const stdout = stdoutChunks.join("");
+    const parsed = JSON.parse(stdout);
+
+    expect(parsed.command).toBe(CREATE_CMD_UID);
+    expect(parsed.target).toBe(vault.protoRelPath);
+
+    // The core acceptance: created[0] carries uuid + path + label for the asset
+    // actually created (this assertion is the revert-verify axis — RED when the
+    // production surfacing is neutralized, since created would then be empty).
+    expect(Array.isArray(parsed.created)).toBe(true);
+    expect(parsed.created).toHaveLength(1);
+    const entry = parsed.created[0];
+    expect(typeof entry.uuid).toBe("string");
+    expect(typeof entry.path).toBe("string");
+    expect(typeof entry.label).toBe("string");
+
+    // path resolves to a real file on disk (AC verification)
+    const abs = path.join(vault.root, entry.path);
+    expect(fs.existsSync(abs)).toBe(true);
+    const content = fs.readFileSync(abs, "utf-8");
+
+    // uuid is the created file's exo__Asset_uid (its UUID-canon basename)
+    expect(entry.uuid).toBe(path.basename(entry.path, ".md"));
+    expect(content).toContain(`exo__Asset_uid: ${entry.uuid}`);
+
+    // label was read fresh from the created file's exo__Asset_label
+    expect(entry.label).toBe(INPUT_LABEL);
+    const onDiskLabel = /exo__Asset_label:\s*"?([^"\n]+?)"?\s*$/m.exec(content)?.[1];
+    expect(onDiskLabel).toBe(entry.label);
+
+    // the entry describes the file inside the grounding's target folder
+    expect(entry.path).toBe(path.join("Inbox", `${entry.uuid}.md`));
+  });
+
+  it("without --json output stays human-readable and emits NO stdout JSON (backward-compatible)", async () => {
+    await runApply(CREATE_CMD_UID, []);
+
+    // no JSON envelope on stdout
+    const stdout = stdoutChunks.join("");
+    expect(stdout).not.toContain('"created"');
+
+    // the human success message went to console.log (with the created path
+    // appended per #3906), and a file was still created
+    const logged = consoleLogSpy.mock.calls.map((c) => String(c[0])).join("\n");
+    expect(logged).toContain("✅");
+    expect(logged).toContain("Child task created");
+    const inbox = fs.readdirSync(vault.inboxDir).filter((f) => f.endsWith(".md"));
+    expect(inbox).toHaveLength(1);
+  });
+
+  it("@req:55a79515-dd18-4116-9295-f7bee8949712 --json on a non-creating (property_set) grounding yields an empty created array", async () => {
+    await runApply(PSET_CMD_UID, ["--json"]);
+
+    const parsed = JSON.parse(stdoutChunks.join(""));
+    expect(parsed.command).toBe(PSET_CMD_UID);
+    expect(Array.isArray(parsed.created)).toBe(true);
+    expect(parsed.created).toHaveLength(0);
+
+    // property_set really ran (the prototype gained the flag) — proving the
+    // empty `created` is "created nothing", not "did nothing".
+    const protoContent = fs.readFileSync(
+      path.join(vault.root, vault.protoRelPath),
+      "utf-8",
+    );
+    expect(protoContent).toContain("test__Flag: done");
+  });
+});


### PR DESCRIPTION
## Summary

Closes #3906. Adds a `--json` flag to `exocortex apply` so `create_instance`-grounding commands (e.g. `create-task-instance`) report the **uuid/path** of the asset they just created — symmetric with `create`'s structured output and `query --format json`. Callers no longer need a separate SPARQL round-trip (by `exo:Asset_prototype` + label/date) to discover what an `apply` produced — the grounding executor already had the created path (`ExecutionResult.openPath`), this surfaces it.

## Behavior

With `--json`, a successful run writes **one** machine-readable JSON object to stdout:

```json
{"command":"create-task-instance","target":"path/to/prototype.md","created":[{"uuid":"...","path":"Inbox/<uid>.md","label":"..."}]}
```

- `command` = the cliName/UUID the caller passed; `target` = the single vault-relative target path (or `targets` array for a stdin-piped batch).
- `created` entries: `uuid` = the written file's UUID-canon basename (mirrors `create`'s `uuid = file.basename`), `path` = vault-relative path, `label` = read **fresh from disk** (`getFrontmatter` → `readFileSync`).
- A non-creating grounding (e.g. `property_set`) → `created: []`.
- In `--json` mode the human ✅/📊/🔍 notices are **suppressed** so stdout parses cleanly as one JSON document; errors/warnings stay on **stderr**.
- **Without** `--json` the human output is byte-compatible with today's, optionally with the created path appended (`✅ … → path`) — no test asserts the exact message, and no existing apply suite regressed (18 tests across 4 suites green).

**Scope:** direct `create_instance` groundings — the real `create-task-instance` grounding-type is `4367e2d6-…` = direct (verified via SPARQL). Composite create-as-side-effect (`executeComposite` drops `openPath`) is a documented follow-up, not this PR.

## Requirement (req-first SDD, RFC 0003)

`@req:55a79515-dd18-4116-9295-f7bee8949712` — [exoas-exo-reqs](https://github.com/kitelev/exoas-exo-reqs/blob/main/exo-reqs/55a79515-dd18-4116-9295-f7bee8949712.md) (status **Approved**; flips → Active on merge).

Req: 55a79515-dd18-4116-9295-f7bee8949712

## Verification

- **Production-shape integration test** `packages/cli/tests/integration/apply-json-created.integration.test.ts` — builds a temp vault (real command + create_instance grounding + prototype), drives the real `applyCommand().parseAsync([…--json…])`, then reads the created file from disk. Asserts `created[0]` uuid/path/label match the file actually written; `--json` off emits no stdout JSON + keeps the human output; a `property_set` grounding → `created: []`.
- **Revert-verified** (`@req:55a79515-…`): neutralizing the `created`-surfacing (`if (false && result.openPath)`) turns the create test **RED** (`created: []`, expected length 1); restoring turns it **GREEN**. The backward-compat + property_set tests stay GREEN both ways (non-vacuity).
- **Real built-CLI smoke** (authoritative, not just the console.log-mocked jest): `node packages/cli/dist/index.js apply <cmd> <proto> --vault <temp> --json --yes` → RAW stdout is a single clean JSON object (no vault-load contamination), `JSON.parse(stdout).created[0].path` resolves to a real file on disk, `uuid === basename`.
- `check:types` clean; the 3 `lint`-job guard scripts green (`method-exists=55/55` — the new test asserts data types, not method-exists).

## Co-authored-by

Co-authored-by: Claude (Task 02c9c7f8) <claude@anthropic.com>
