### PR TITLE
ci: bump archgate pin 0.48.4 -> 0.50.0 (rule files adapted; keep pinned) (#3916)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -223,14 +223,14 @@ jobs:
           key: archgate-${{ runner.os }}
 
       - name: Install Archgate
-        # Pinned: archgate 0.49.0 (2026-07-16) tightened the rule-file import
-        # security scanner to allow only node:* imports, which blocks the repo's
-        # own `.archgate/adrs/*.rules.ts` helpers (e.g. MOBILE-004 →
-        # `../lint/desktopOnlyCommandGate`) → archgate check fails on every run
-        # once `npm install -g archgate` (unpinned) resolves 0.49.0. Pin to the
-        # last-known-good 0.48.4 for determinism; upgrade + adapt the rule files
-        # to 0.49.0's stricter policy deliberately as a follow-up.
-        run: npm install -g archgate@0.48.4
+        # PINNED — never a bare `npm install -g archgate` (an unpinned CI tool
+        # silently drifts: archgate 0.49.0/0.50.0 tightened the rule-file import
+        # security scanner to allow only node:* imports, which broke every run
+        # repo-wide, #3915). The rule files were adapted to the stricter policy
+        # (MOBILE-004 inlined its detection helper, #3914), so we now pin the
+        # current 0.50.0. Bump this pin deliberately after re-verifying archgate
+        # green under the new version — do NOT un-pin.
+        run: npm install -g archgate@0.50.0
 
       - name: Run ADR compliance checks
         run: archgate check --ci


### PR DESCRIPTION
Follow-up to #3915. Rule files adapted to archgate 0.49.0/0.50.0's stricter rule-file import policy (MOBILE-004 inlined its detection helper in #3914; no other rule file imports a non-node local path) → the emergency `0.48.4` pin can advance to current `0.50.0`.

**Kept PINNED** (not un-pinned): an unpinned `npm install -g archgate` is exactly what drifted into the repo-wide break (#3915, rule `unpinned-ci-tool-version-drift`). This PR's own archgate run (0.50.0) load-scans all rule files → verifies the inline-fixed MOBILE-004 loads clean + no new 0.50.0 ADR check flags the repo.

Closes #3916.

https://claude.ai/code/session_01L2EFGtzcrp6W57xJ5HrGxZ