### PR TITLE
feat(cli): apply --json surfaces composite create-as-side-effect assets (#3918)

### DIFF
--- a/packages/cli/src/commands/apply.ts
+++ b/packages/cli/src/commands/apply.ts
@@ -86,6 +86,39 @@ interface TargetResult {
   created: CreatedAsset[];
 }
 
+/**
+ * Issue #3906/#3918 — build the `{uuid,path,label}` entry for a just-created
+ * file, reading it FRESH from disk (getAbstractFileByPath = statSync,
+ * getFrontmatter = readFileSync — no stale index). `uuid` is the created file's
+ * UUID-canon basename (mirrors `create`'s `uuid = file.basename`), falling back
+ * to the path tail if the adapter could not stat the just-written file; `label`
+ * is read fresh from the created file's `exo__Asset_label`.
+ */
+function buildCreatedAsset(
+  vaultAdapter: FileSystemVaultAdapter,
+  createdPath: string,
+): CreatedAsset {
+  const createdNode = vaultAdapter.getAbstractFileByPath(createdPath);
+  const createdFile =
+    createdNode !== null && "basename" in createdNode
+      ? (createdNode as IFile)
+      : null;
+  const createdFm = createdFile
+    ? vaultAdapter.getFrontmatter(createdFile)
+    : null;
+  const labelRaw =
+    createdFm && typeof createdFm === "object"
+      ? (createdFm as Record<string, unknown>).exo__Asset_label
+      : undefined;
+  return {
+    uuid:
+      createdFile?.basename ??
+      createdPath.replace(/^.*\//, "").replace(/\.md$/, ""),
+    path: createdPath,
+    label: typeof labelRaw === "string" ? labelRaw : "",
+  };
+}
+
 const UUID_RE =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
@@ -423,43 +456,32 @@ async function executeOnTarget(
   );
 
   if (result.success) {
-    // Issue #3906 — surface the created asset's identity. The grounding executor
-    // already threads the created path (`ExecutionResult.openPath`) — a direct
-    // create_instance grounding (e.g. create-task-instance) sets it. Read the
+    // Issue #3906/#3918 — surface the asset(s) this apply created. The grounding
+    // executor already tracked the created path(s): a DIRECT create_instance
+    // grounding reports its single created path via `result.openPath` (#3906); a
+    // `composite` grounding reports its side-effect creations via
+    // `result.createdPaths` (#3918, one per create_instance step). Read each
     // created file FRESH from disk (getAbstractFileByPath = statSync,
     // getFrontmatter = readFileSync — no stale index) for its uuid + label.
+    const createdPaths: string[] = [];
+    if (result.openPath) createdPaths.push(result.openPath);
+    if (result.createdPaths) createdPaths.push(...result.createdPaths);
     const created: CreatedAsset[] = [];
-    if (result.openPath) {
-      const createdNode = vaultAdapter.getAbstractFileByPath(result.openPath);
-      const createdFile =
-        createdNode !== null && "basename" in createdNode
-          ? (createdNode as IFile)
-          : null;
-      const createdFm = createdFile
-        ? vaultAdapter.getFrontmatter(createdFile)
-        : null;
-      const labelRaw =
-        createdFm && typeof createdFm === "object"
-          ? (createdFm as Record<string, unknown>).exo__Asset_label
-          : undefined;
-      created.push({
-        // UUID-canon: the file is written as `<uid>.md`, so its basename IS the
-        // uuid (mirrors `create`'s `uuid = file.basename`). Fall back to the
-        // path tail if the adapter could not stat the just-written file.
-        uuid:
-          createdFile?.basename ??
-          result.openPath.replace(/^.*\//, "").replace(/\.md$/, ""),
-        path: result.openPath,
-        label: typeof labelRaw === "string" ? labelRaw : "",
-      });
+    const seen = new Set<string>();
+    for (const createdPath of createdPaths) {
+      if (seen.has(createdPath)) continue; // dedup (openPath vs createdPaths overlap)
+      seen.add(createdPath);
+      created.push(buildCreatedAsset(vaultAdapter, createdPath));
     }
     if (!options.json) {
       const msg =
         command.successMessage ??
         `Applied "${command.name}" to "${vaultRelative}".`;
-      // Optionally append the created path for convenience (Issue #3906) — no
-      // suffix when the command created nothing, so existing output is unchanged.
-      const suffix = result.openPath ? ` → ${result.openPath}` : "";
+      // Optionally append the (first) created path for convenience (#3906/#3918)
+      // — no suffix when the command created nothing, so existing output is
+      // unchanged.
+      const firstPath = result.openPath ?? result.createdPaths?.[0];
+      const suffix = firstPath ? ` → ${firstPath}` : "";
       console.log(`✅ ${msg}${suffix}`);
     }
     return { ok: true, created };

--- a/packages/cli/tests/integration/apply-json-created-composite.integration.test.ts
+++ b/packages/cli/tests/integration/apply-json-created-composite.integration.test.ts
@@ -52,6 +52,10 @@ const PSET_COMP_GROUNDING_UID = "bbbb0007-0000-0000-0000-000000000007";
 const STEP_PSET_ONLY_UID = "bbbb0008-0000-0000-0000-000000000008";
 // --- DIRECT create_instance command (#3906 preservation) reusing STEP_CREATE ---
 const DIRECT_CMD_UID = "bbbb0009-0000-0000-0000-000000000009";
+// --- composite that creates TWO assets (>1 create_instance step) ---
+const MULTI_COMP_CMD_UID = "bbbb000a-0000-0000-0000-00000000000a";
+const MULTI_COMP_GROUNDING_UID = "bbbb000b-0000-0000-0000-00000000000b";
+const STEP_CREATE2_UID = "bbbb000c-0000-0000-0000-00000000000c";
 
 const INPUT_LABEL = "Composite child task";
 
@@ -183,6 +187,52 @@ const DIRECT_CMD_MD = [
   "",
 ].join("\n");
 
+// A second create_instance step (distinct grounding) — targets a separate
+// folder so a 2-create composite writes two distinct files.
+const STEP_CREATE2_MD = [
+  "---",
+  `exo__Asset_uid: ${STEP_CREATE2_UID}`,
+  `exo__Asset_label: "Create second child task step"`,
+  `exo__Asset_isDefinedBy: "[[!kitelev]]"`,
+  `exo__Instance_class:`,
+  `  - "[[exocmd__Grounding]]"`,
+  `exocmd__Grounding_type: "[[${GT_CREATE_INSTANCE}]]"`,
+  `exocmd__Grounding_targetClass: "ems__Task"`,
+  `exocmd__Grounding_targetFolder: "Inbox2"`,
+  "---",
+  "",
+].join("\n");
+
+const MULTI_COMP_CMD_MD = [
+  "---",
+  `exo__Asset_uid: ${MULTI_COMP_CMD_UID}`,
+  `exo__Asset_label: "Create two children (multi-create composite json-test)"`,
+  `exo__Asset_isDefinedBy: "[[!kitelev]]"`,
+  `exo__Instance_class:`,
+  `  - "[[exocmd__Command]]"`,
+  `exocmd__Command_grounding: "[[${MULTI_COMP_GROUNDING_UID}|Multi-create composite grounding]]"`,
+  `exocmd__Command_successMessage: "Two children created"`,
+  "---",
+  "",
+].join("\n");
+
+// A composite with TWO create_instance steps → the `createdPaths` array must
+// collect BOTH → apply --json emits two `created` entries (#3918 multi-create).
+const MULTI_COMP_GROUNDING_MD = [
+  "---",
+  `exo__Asset_uid: ${MULTI_COMP_GROUNDING_UID}`,
+  `exo__Asset_label: "Multi-create composite grounding"`,
+  `exo__Asset_isDefinedBy: "[[!kitelev]]"`,
+  `exo__Instance_class:`,
+  `  - "[[exocmd__Grounding]]"`,
+  `exocmd__Grounding_type: "[[${GT_COMPOSITE}]]"`,
+  `exocmd__Grounding_steps:`,
+  `  - "[[${STEP_CREATE_UID}|Create step 1]]"`,
+  `  - "[[${STEP_CREATE2_UID}|Create step 2]]"`,
+  "---",
+  "",
+].join("\n");
+
 interface VaultLayout {
   root: string;
   protoRelPath: string;
@@ -202,7 +252,11 @@ function buildVault(): VaultLayout {
   write(PSET_COMP_GROUNDING_UID, PSET_COMP_GROUNDING_MD);
   write(STEP_PSET_ONLY_UID, STEP_PSET_ONLY_MD);
   write(DIRECT_CMD_UID, DIRECT_CMD_MD);
+  write(MULTI_COMP_CMD_UID, MULTI_COMP_CMD_MD);
+  write(MULTI_COMP_GROUNDING_UID, MULTI_COMP_GROUNDING_MD);
+  write(STEP_CREATE2_UID, STEP_CREATE2_MD);
   fs.mkdirSync(path.join(root, "Inbox"), { recursive: true });
+  fs.mkdirSync(path.join(root, "Inbox2"), { recursive: true });
   return {
     root,
     protoRelPath: `${PROTO_UID}.md`,
@@ -348,6 +402,29 @@ describe("Issue #3918: apply --json surfaces composite create-as-side-effect ass
       "utf-8",
     );
     expect(protoContent).not.toContain("test__CompositeRan");
+  });
+
+  it("@req:8eaae6a9-3a11-42cd-a549-c988dae2073b --json on a composite with TWO create_instance steps emits TWO created entries (multi-create)", async () => {
+    await runApply(MULTI_COMP_CMD_UID, ["--json"]);
+
+    const parsed = JSON.parse(stdoutChunks.join(""));
+    expect(parsed.command).toBe(MULTI_COMP_CMD_UID);
+    expect(Array.isArray(parsed.created)).toBe(true);
+    // both create_instance steps ran → createdPaths collected both → two entries
+    expect(parsed.created).toHaveLength(2);
+
+    // each entry resolves to a distinct real file (one per target folder)
+    const paths = parsed.created.map((c: { path: string }) => c.path).sort();
+    expect(new Set(paths).size).toBe(2);
+    for (const entry of parsed.created) {
+      const abs = path.join(vault.root, entry.path);
+      expect(fs.existsSync(abs)).toBe(true);
+      expect(entry.uuid).toBe(path.basename(entry.path, ".md"));
+      expect(entry.label).toBe(INPUT_LABEL);
+    }
+    // one file landed in each step's target folder (Inbox + Inbox2)
+    expect(paths.some((p: string) => p.startsWith(`Inbox${path.sep}`))).toBe(true);
+    expect(paths.some((p: string) => p.startsWith(`Inbox2${path.sep}`))).toBe(true);
   });
 
   it("without --json a composite create surfaces the created path in the human message + emits NO stdout JSON", async () => {

--- a/packages/cli/tests/integration/apply-json-created-composite.integration.test.ts
+++ b/packages/cli/tests/integration/apply-json-created-composite.integration.test.ts
@@ -1,0 +1,367 @@
+/**
+ * Issue #3918 — integration test for `apply <cmd> <target> --json` surfacing
+ * assets created as a SIDE EFFECT by a `composite` grounding.
+ *
+ * Follow-up to #3906 (req 55a79515), which scoped `apply --json` `created[]` to
+ * DIRECT `create_instance` groundings (ExecutionResult.openPath). Today
+ * `executeComposite` drops the created path (returns `{ success: true }`), so a
+ * composite command yields an empty `created` array under `apply --json`. This
+ * test drives the REAL `applyCommand().parseAsync([...--json...])` over a temp
+ * vault holding a real `composite` command (a create_instance step + a
+ * property_set step on the source) and asserts the composite-created file is
+ * surfaced in `created[]` (production-shape — not hand-injected), that a
+ * property_set-only composite yields an empty `created`, and that a DIRECT
+ * create_instance command (#3906) is unchanged.
+ *
+ * Revert-verify axis (@req:8eaae6a9-3a11-42cd-a549-c988dae2073b): the composite
+ * `created[0]` assertion goes RED when the production `createdPaths` surfacing in
+ * `GroundingExecutor.executeComposite` is neutralized (the envelope's `created`
+ * stays empty for a composite) and GREEN when restored — empirically checked
+ * before merge (see PR body).
+ *
+ * Uses programmatic `parseAsync` (no built-binary dependency), mirroring
+ * `apply-json-created.integration.test.ts`.
+ */
+import {
+  jest,
+  describe,
+  it,
+  expect,
+  beforeEach,
+  afterEach,
+} from "@jest/globals";
+import * as fs from "fs";
+import * as path from "path";
+import * as os from "os";
+
+const { applyCommand } = await import("../../src/commands/apply.js");
+
+const GT_CREATE_INSTANCE = "4367e2d6-6c92-450a-becb-abce1fb07682";
+const GT_PROPERTY_SET = "cf3bb923-f1f1-40be-b728-782844402426";
+const GT_COMPOSITE = "8f9a57db-3865-4886-92fb-c5ab7f3c3fa3";
+
+// --- composite (create-as-side-effect) command ---
+const COMP_CMD_UID = "bbbb0001-0000-0000-0000-000000000001";
+const COMP_GROUNDING_UID = "bbbb0002-0000-0000-0000-000000000002";
+const STEP_CREATE_UID = "bbbb0003-0000-0000-0000-000000000003";
+const STEP_PSET_SOURCE_UID = "bbbb0004-0000-0000-0000-000000000004";
+const PROTO_UID = "bbbb0005-0000-0000-0000-000000000005";
+// --- composite that creates NOTHING (property_set-only) ---
+const PSET_COMP_CMD_UID = "bbbb0006-0000-0000-0000-000000000006";
+const PSET_COMP_GROUNDING_UID = "bbbb0007-0000-0000-0000-000000000007";
+const STEP_PSET_ONLY_UID = "bbbb0008-0000-0000-0000-000000000008";
+// --- DIRECT create_instance command (#3906 preservation) reusing STEP_CREATE ---
+const DIRECT_CMD_UID = "bbbb0009-0000-0000-0000-000000000009";
+
+const INPUT_LABEL = "Composite child task";
+
+const COMP_CMD_MD = [
+  "---",
+  `exo__Asset_uid: ${COMP_CMD_UID}`,
+  `exo__Asset_label: "Create child + flag source (composite json-test)"`,
+  `exo__Asset_isDefinedBy: "[[!kitelev]]"`,
+  `exo__Instance_class:`,
+  `  - "[[exocmd__Command]]"`,
+  `exocmd__Command_grounding: "[[${COMP_GROUNDING_UID}|Composite grounding]]"`,
+  `exocmd__Command_successMessage: "Composite ran"`,
+  "---",
+  "",
+].join("\n");
+
+// A composite whose steps create a task AND set a flag on the source (the
+// click-target) — the canonical "create-as-side-effect" shape.
+const COMP_GROUNDING_MD = [
+  "---",
+  `exo__Asset_uid: ${COMP_GROUNDING_UID}`,
+  `exo__Asset_label: "Composite grounding"`,
+  `exo__Asset_isDefinedBy: "[[!kitelev]]"`,
+  `exo__Instance_class:`,
+  `  - "[[exocmd__Grounding]]"`,
+  `exocmd__Grounding_type: "[[${GT_COMPOSITE}]]"`,
+  `exocmd__Grounding_steps:`,
+  `  - "[[${STEP_CREATE_UID}|Create step]]"`,
+  `  - "[[${STEP_PSET_SOURCE_UID}|Flag source step]]"`,
+  "---",
+  "",
+].join("\n");
+
+const STEP_CREATE_MD = [
+  "---",
+  `exo__Asset_uid: ${STEP_CREATE_UID}`,
+  `exo__Asset_label: "Create child task step"`,
+  `exo__Asset_isDefinedBy: "[[!kitelev]]"`,
+  `exo__Instance_class:`,
+  `  - "[[exocmd__Grounding]]"`,
+  `exocmd__Grounding_type: "[[${GT_CREATE_INSTANCE}]]"`,
+  `exocmd__Grounding_targetClass: "ems__Task"`,
+  `exocmd__Grounding_targetFolder: "Inbox"`,
+  "---",
+  "",
+].join("\n");
+
+const STEP_PSET_SOURCE_MD = [
+  "---",
+  `exo__Asset_uid: ${STEP_PSET_SOURCE_UID}`,
+  `exo__Asset_label: "Flag source step"`,
+  `exo__Asset_isDefinedBy: "[[!kitelev]]"`,
+  `exo__Instance_class:`,
+  `  - "[[exocmd__Grounding]]"`,
+  `exocmd__Grounding_type: "[[${GT_PROPERTY_SET}]]"`,
+  `exocmd__Grounding_targetProperty: "test__CompositeRan"`,
+  `exocmd__Grounding_targetValueLiteral: "yes"`,
+  "---",
+  "",
+].join("\n");
+
+const PROTO_MD = [
+  "---",
+  `exo__Asset_uid: ${PROTO_UID}`,
+  `exo__Asset_label: "Parent prototype asset"`,
+  `exo__Asset_isDefinedBy: "[[!kitelev]]"`,
+  `exo__Instance_class:`,
+  `  - "[[ems__TaskPrototype]]"`,
+  "---",
+  "",
+].join("\n");
+
+// A composite that runs a property_set-only step → creates NO asset → `created`
+// must be empty (proves the empty array is "created nothing", not "no
+// createdPaths surfacing at all").
+const PSET_COMP_CMD_MD = [
+  "---",
+  `exo__Asset_uid: ${PSET_COMP_CMD_UID}`,
+  `exo__Asset_label: "Set a flag composite (json-test)"`,
+  `exo__Asset_isDefinedBy: "[[!kitelev]]"`,
+  `exo__Instance_class:`,
+  `  - "[[exocmd__Command]]"`,
+  `exocmd__Command_grounding: "[[${PSET_COMP_GROUNDING_UID}|Pset composite grounding]]"`,
+  `exocmd__Command_successMessage: "Flag set"`,
+  "---",
+  "",
+].join("\n");
+
+const PSET_COMP_GROUNDING_MD = [
+  "---",
+  `exo__Asset_uid: ${PSET_COMP_GROUNDING_UID}`,
+  `exo__Asset_label: "Pset composite grounding"`,
+  `exo__Asset_isDefinedBy: "[[!kitelev]]"`,
+  `exo__Instance_class:`,
+  `  - "[[exocmd__Grounding]]"`,
+  `exocmd__Grounding_type: "[[${GT_COMPOSITE}]]"`,
+  `exocmd__Grounding_steps:`,
+  `  - "[[${STEP_PSET_ONLY_UID}|Set flag step]]"`,
+  "---",
+  "",
+].join("\n");
+
+const STEP_PSET_ONLY_MD = [
+  "---",
+  `exo__Asset_uid: ${STEP_PSET_ONLY_UID}`,
+  `exo__Asset_label: "Set flag step"`,
+  `exo__Asset_isDefinedBy: "[[!kitelev]]"`,
+  `exo__Instance_class:`,
+  `  - "[[exocmd__Grounding]]"`,
+  `exocmd__Grounding_type: "[[${GT_PROPERTY_SET}]]"`,
+  `exocmd__Grounding_targetProperty: "test__Flag"`,
+  `exocmd__Grounding_targetValueLiteral: "done"`,
+  "---",
+  "",
+].join("\n");
+
+// A DIRECT create_instance command reusing the SAME create step grounding — its
+// `openPath` surfacing (#3906) must be unchanged by the composite change.
+const DIRECT_CMD_MD = [
+  "---",
+  `exo__Asset_uid: ${DIRECT_CMD_UID}`,
+  `exo__Asset_label: "Create child task direct (json-test)"`,
+  `exo__Asset_isDefinedBy: "[[!kitelev]]"`,
+  `exo__Instance_class:`,
+  `  - "[[exocmd__Command]]"`,
+  `exocmd__Command_grounding: "[[${STEP_CREATE_UID}|Create child task step]]"`,
+  `exocmd__Command_successMessage: "Direct child created"`,
+  "---",
+  "",
+].join("\n");
+
+interface VaultLayout {
+  root: string;
+  protoRelPath: string;
+  inboxDir: string;
+}
+
+function buildVault(): VaultLayout {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "exo-apply-json-comp-"));
+  const write = (uid: string, md: string) =>
+    fs.writeFileSync(path.join(root, `${uid}.md`), md, "utf-8");
+  write(COMP_CMD_UID, COMP_CMD_MD);
+  write(COMP_GROUNDING_UID, COMP_GROUNDING_MD);
+  write(STEP_CREATE_UID, STEP_CREATE_MD);
+  write(STEP_PSET_SOURCE_UID, STEP_PSET_SOURCE_MD);
+  write(PROTO_UID, PROTO_MD);
+  write(PSET_COMP_CMD_UID, PSET_COMP_CMD_MD);
+  write(PSET_COMP_GROUNDING_UID, PSET_COMP_GROUNDING_MD);
+  write(STEP_PSET_ONLY_UID, STEP_PSET_ONLY_MD);
+  write(DIRECT_CMD_UID, DIRECT_CMD_MD);
+  fs.mkdirSync(path.join(root, "Inbox"), { recursive: true });
+  return {
+    root,
+    protoRelPath: `${PROTO_UID}.md`,
+    inboxDir: path.join(root, "Inbox"),
+  };
+}
+
+describe("Issue #3918: apply --json surfaces composite create-as-side-effect assets", () => {
+  let vault: VaultLayout;
+  let processExitSpy: jest.SpiedFunction<typeof process.exit>;
+  let consoleLogSpy: jest.SpiedFunction<typeof console.log>;
+  let consoleErrorSpy: jest.SpiedFunction<typeof console.error>;
+  let stdoutSpy: jest.SpiedFunction<typeof process.stdout.write>;
+  let stdoutChunks: string[];
+
+  beforeEach(() => {
+    vault = buildVault();
+    stdoutChunks = [];
+    processExitSpy = jest.spyOn(process, "exit").mockImplementation(((
+      code?: number,
+    ) => {
+      throw new Error(`__process_exit_${code ?? 0}__`);
+    }) as never);
+    consoleLogSpy = jest.spyOn(console, "log").mockImplementation(() => {});
+    consoleErrorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+    // Capture the JSON envelope (written via process.stdout.write). console.log
+    // is mocked to a no-op above, so it never reaches process.stdout.write —
+    // this spy therefore captures ONLY the apply envelope.
+    stdoutSpy = jest
+      .spyOn(process.stdout, "write")
+      .mockImplementation(((chunk: string | Uint8Array) => {
+        stdoutChunks.push(chunk.toString());
+        return true;
+      }) as never);
+  });
+
+  afterEach(() => {
+    stdoutSpy.mockRestore();
+    processExitSpy.mockRestore();
+    consoleLogSpy.mockRestore();
+    consoleErrorSpy.mockRestore();
+    fs.rmSync(vault.root, { recursive: true, force: true });
+  });
+
+  async function runApply(cmdUid: string, extraArgs: string[]): Promise<void> {
+    const cmd = applyCommand();
+    const args = [
+      "node",
+      "apply",
+      cmdUid,
+      vault.protoRelPath,
+      "--vault",
+      vault.root,
+      "--input",
+      JSON.stringify({ label: INPUT_LABEL }),
+      ...extraArgs,
+    ];
+    try {
+      await cmd.parseAsync(args);
+    } catch (err) {
+      if (!/^__process_exit_/.test(String((err as Error)?.message))) throw err;
+    }
+  }
+
+  it("@req:8eaae6a9-3a11-42cd-a549-c988dae2073b --json surfaces the composite-created asset in created:[{uuid,path,label}]", async () => {
+    await runApply(COMP_CMD_UID, ["--json"]);
+
+    // stdout is exactly one JSON document (no ✅ / 📊 noise).
+    const parsed = JSON.parse(stdoutChunks.join(""));
+    expect(parsed.command).toBe(COMP_CMD_UID);
+    expect(parsed.target).toBe(vault.protoRelPath);
+
+    // The core acceptance: the composite created a task as a side effect →
+    // created[0] surfaces it (this assertion is the revert-verify axis — RED
+    // when executeComposite drops the createdPaths surfacing).
+    expect(Array.isArray(parsed.created)).toBe(true);
+    expect(parsed.created).toHaveLength(1);
+    const entry = parsed.created[0];
+    expect(typeof entry.uuid).toBe("string");
+    expect(typeof entry.path).toBe("string");
+    expect(typeof entry.label).toBe("string");
+
+    // path resolves to a real file on disk (AC verification)
+    const abs = path.join(vault.root, entry.path);
+    expect(fs.existsSync(abs)).toBe(true);
+    const content = fs.readFileSync(abs, "utf-8");
+
+    // uuid = the created file's exo__Asset_uid (its UUID-canon basename)
+    expect(entry.uuid).toBe(path.basename(entry.path, ".md"));
+    expect(content).toContain(`exo__Asset_uid: ${entry.uuid}`);
+
+    // label read fresh from the created file's exo__Asset_label
+    expect(entry.label).toBe(INPUT_LABEL);
+
+    // the created file lives inside the create step's target folder
+    expect(entry.path).toBe(path.join("Inbox", `${entry.uuid}.md`));
+
+    // both composite steps ran: the SOURCE (click-target) gained the flag —
+    // proving the create is a genuine SIDE EFFECT of a real multi-step composite.
+    const protoContent = fs.readFileSync(
+      path.join(vault.root, vault.protoRelPath),
+      "utf-8",
+    );
+    expect(protoContent).toContain("test__CompositeRan: yes");
+  });
+
+  it("@req:8eaae6a9-3a11-42cd-a549-c988dae2073b --json on a property_set-only composite yields an empty created array", async () => {
+    await runApply(PSET_COMP_CMD_UID, ["--json"]);
+
+    const parsed = JSON.parse(stdoutChunks.join(""));
+    expect(parsed.command).toBe(PSET_COMP_CMD_UID);
+    expect(Array.isArray(parsed.created)).toBe(true);
+    expect(parsed.created).toHaveLength(0);
+
+    // the property_set step really ran (the source gained the flag) — proving
+    // the empty `created` is "created nothing", not "did nothing".
+    const protoContent = fs.readFileSync(
+      path.join(vault.root, vault.protoRelPath),
+      "utf-8",
+    );
+    expect(protoContent).toContain("test__Flag: done");
+    // and no task was created in Inbox
+    const inbox = fs.readdirSync(vault.inboxDir).filter((f) => f.endsWith(".md"));
+    expect(inbox).toHaveLength(0);
+  });
+
+  it("--json on a DIRECT create_instance command (#3906) still surfaces its created asset (composite change preserves direct behavior)", async () => {
+    await runApply(DIRECT_CMD_UID, ["--json"]);
+
+    const parsed = JSON.parse(stdoutChunks.join(""));
+    expect(parsed.command).toBe(DIRECT_CMD_UID);
+    expect(Array.isArray(parsed.created)).toBe(true);
+    expect(parsed.created).toHaveLength(1);
+    const entry = parsed.created[0];
+    const abs = path.join(vault.root, entry.path);
+    expect(fs.existsSync(abs)).toBe(true);
+    expect(entry.uuid).toBe(path.basename(entry.path, ".md"));
+    expect(entry.label).toBe(INPUT_LABEL);
+    // NO source flag: a direct create does not touch the source (only the
+    // composite's property_set step does — proving the two paths are distinct).
+    const protoContent = fs.readFileSync(
+      path.join(vault.root, vault.protoRelPath),
+      "utf-8",
+    );
+    expect(protoContent).not.toContain("test__CompositeRan");
+  });
+
+  it("without --json a composite create surfaces the created path in the human message + emits NO stdout JSON", async () => {
+    await runApply(COMP_CMD_UID, []);
+
+    const stdout = stdoutChunks.join("");
+    expect(stdout).not.toContain('"created"');
+
+    const logged = consoleLogSpy.mock.calls.map((c) => String(c[0])).join("\n");
+    expect(logged).toContain("✅");
+    expect(logged).toContain("Composite ran");
+    // the created path is appended (→ Inbox/<uid>.md)
+    expect(logged).toMatch(/→ .*Inbox\//);
+    const inbox = fs.readdirSync(vault.inboxDir).filter((f) => f.endsWith(".md"));
+    expect(inbox).toHaveLength(1);
+  });
+});

--- a/packages/core/src/services/GroundingExecutor.ts
+++ b/packages/core/src/services/GroundingExecutor.ts
@@ -100,6 +100,21 @@ export interface ExecutionResult {
   readonly error?: string;
   readonly openPath?: string;
   /**
+   * Issue #3918 — vault-relative paths of assets created as a SIDE EFFECT by a
+   * `composite` grounding (a composite whose steps include one or more
+   * `create_instance` steps, plus any created by nested composite steps). Set
+   * by `executeComposite`; consumed by `apply --json` to surface a `created`
+   * entry (uuid/path/label) per composite-created file.
+   *
+   * Deliberately DISTINCT from `openPath`: `openPath` is the single path the
+   * presentation layer (`CommandExecutionFlow`) opens in a new tab, so a
+   * composite leaves `openPath` UNSET and reports its creations via
+   * `createdPaths` instead — surfacing-only, no automatic tab-open. Omitted
+   * (undefined) when the composite created nothing → today's `{ success: true }`
+   * output is byte-identical.
+   */
+  readonly createdPaths?: readonly string[];
+  /**
    * Marks an unsuccessful result as a benign "not applicable" outcome rather
    * than a hard failure. Set by `workflow_transition` when the target asset's
    * class has no applicable status workflow (e.g. `ems__Action`, which has its
@@ -725,6 +740,13 @@ export class GroundingExecutor {
     // asset (link-back), and the just-created asset is not yet in the store.
     let lastCreatedPath: string | undefined;
 
+    // Issue #3918 — every asset written to disk by a create_instance step (and
+    // by any nested composite step), collected purely for surfacing via
+    // `apply --json`. Independent of `lastCreatedPath` (which drives step
+    // targeting) — this is the read-only "what did the composite create?"
+    // channel and does NOT set `openPath` (so plugin tab-open is unchanged).
+    const createdPaths: string[] = [];
+
     try {
       for (let i = 0; i < steps.length; i++) {
         const step = steps[i];
@@ -751,10 +773,19 @@ export class GroundingExecutor {
         // create_instance returns the new file's path — thread it to a later
         // body_template step.
         if (result.openPath) lastCreatedPath = result.openPath;
+        // Issue #3918 — record it (and any nested-composite creations) for
+        // surfacing. Additive only: the threading above is untouched.
+        if (result.openPath) createdPaths.push(result.openPath);
+        if (result.createdPaths && result.createdPaths.length > 0) {
+          createdPaths.push(...result.createdPaths);
+        }
         completedSteps.push(i);
       }
 
-      return { success: true };
+      return {
+        success: true,
+        ...(createdPaths.length > 0 ? { createdPaths } : {}),
+      };
     } catch (error) {
       await this.rollback(originalContent, filePath, completedSteps);
       return {


### PR DESCRIPTION
## Summary

Closes #3918 (follow-up to #3906, PR #3917 — `apply --json`, CLI v16.186.0). #3906
scoped `apply --json` `created[]` to **direct** `create_instance` groundings (via
`ExecutionResult.openPath`). A **composite** grounding that creates an asset as a
side effect (a composite whose steps include a `create_instance`) yielded an empty
`created[]` because `GroundingExecutor.executeComposite` threaded the created path
internally (`lastCreatedPath`) but returned `{ success: true }` — dropping it. This
surfaces those creations to `apply --json`.

## Design (approved: dedicated `createdPaths[]`, no plugin behavior change)

- **core** — new `ExecutionResult.createdPaths?: readonly string[]` (surfacing-only).
  `executeComposite` accumulates each step's `openPath` (+ any nested-composite
  `createdPaths`) into it; the existing `lastCreatedPath` threading to
  `body_template`/`targetsCreatedInstance` steps is **byte-identical**. The
  composite deliberately **leaves `openPath` UNSET** — `openPath` is what
  `CommandExecutionFlow` opens in a new tab, so composites do **not** start
  auto-opening a tab (the behavior change the issue flagged "needs review" is
  avoided). Empty → the key is omitted → today's `{ success: true }` output is
  byte-identical.
- **cli** — `apply.ts` maps `openPath` (direct) + each `createdPaths` entry
  (composite) into `created[]` via a shared `buildCreatedAsset` helper (uuid = the
  created file's UUID-canon basename; label read fresh from disk). Handles
  multi-create (a composite with >1 `create_instance` step → multiple `created`
  entries). **Direct `create_instance` behavior (#3906) is fully preserved.**

## Requirement (req-first SDD, RFC 0003)

`@req:8eaae6a9-3a11-42cd-a549-c988dae2073b` — [exoas-exo-reqs](https://github.com/kitelev/exoas-exo-reqs/blob/main/exo-reqs/8eaae6a9-3a11-42cd-a549-c988dae2073b.md) (status **Approved**; flips → Active on merge).

Req: 8eaae6a9-3a11-42cd-a549-c988dae2073b

## Verification

- **Production-shape integration test** `packages/cli/tests/integration/apply-json-created-composite.integration.test.ts` — builds a temp vault with a REAL `composite` command (a `create_instance` step + a `property_set` step on the source) + a prototype, drives the real `applyCommand().parseAsync([…--json…])`, then reads the composite-created file from disk. Asserts `created[0]` uuid/path/label match the file actually written; a property_set-only composite → `created: []`; a **direct** create_instance (#3906) still surfaces its asset; `--json` off keeps the human output + emits no stdout JSON.
- **Revert-verified** (`@req:8eaae6a9-…`): neutralizing the `executeComposite` `createdPaths` surfacing (`false && …` guard) turns the composite `created[0]` assertion **RED** (composite `created:[]`) — while the **direct** and **property_set-only** tests stay **GREEN** (non-vacuity); restoring turns it **GREEN**.
- **Real built-CLI smoke** (authoritative, not just the console.log-mocked jest): `node packages/cli/dist/index.js apply <composite-cmd> <proto> --vault <temp> --json --yes` → RAW stdout is a single clean JSON object (no vault-load contamination), `created[0].path` resolves to a real file on disk, `uuid === basename`, label read fresh.
- Full `GroundingExecutor` suite 241/241 GREEN (composite threading byte-identical); all 14 CLI `apply` suites (61) GREEN; #3906 `apply-json` suite 3/3 GREEN; `check:types` clean; the 3 `lint`-job guard scripts green (`method-exists=55/55` — the new test asserts data types, not method-exists).

## Auto-merge discipline

`packages/core/src/services/GroundingExecutor.ts` is a named parser/engine path →
code-reviewer + advisor round-2, **no `--auto`** (manual squash merge).

## Co-authored-by

Co-authored-by: Claude (Task 02c9c7f8) <claude@anthropic.com>
