### PR TITLE
fix(#3921): delete orphaned create_instance assets on composite rollback

### DIFF
--- a/packages/core/src/services/GroundingExecutor.ts
+++ b/packages/core/src/services/GroundingExecutor.ts
@@ -763,8 +763,15 @@ export class GroundingExecutor {
           depth + 1,
         );
         if (!result.success) {
-          // Rollback completed steps by restoring original file content
-          await this.rollback(originalContent, filePath, completedSteps);
+          // Rollback completed steps: restore the click-target source content
+          // AND (Issue #3921) delete any assets an earlier create_instance step
+          // already wrote to disk, so a failing later step leaves no orphans.
+          await this.rollback(
+            originalContent,
+            filePath,
+            completedSteps,
+            createdPaths,
+          );
           return {
             success: false,
             error: `Composite step ${i} failed: ${result.error}`,
@@ -787,7 +794,14 @@ export class GroundingExecutor {
         ...(createdPaths.length > 0 ? { createdPaths } : {}),
       };
     } catch (error) {
-      await this.rollback(originalContent, filePath, completedSteps);
+      // Issue #3921 — pass createdPaths so a mid-composite throw after an
+      // earlier create_instance also cleans up the orphaned created asset.
+      await this.rollback(
+        originalContent,
+        filePath,
+        completedSteps,
+        createdPaths,
+      );
       return {
         success: false,
         error: `Composite execution failed: ${error instanceof Error ? error.message : String(error)}`,
@@ -2026,17 +2040,42 @@ export class GroundingExecutor {
     originalContent: string | undefined,
     filePath: string,
     _completedSteps: number[],
+    createdPaths: readonly string[] = [],
   ): Promise<void> {
-    if (originalContent === undefined) return;
+    // Restore the click-target source file to its pre-composite content.
+    // Skipped when there was nothing on disk to begin with (e.g. service_call-
+    // only composites where filePath never existed).
+    if (originalContent !== undefined) {
+      try {
+        await this.fileWriter.updateFile(filePath, originalContent);
+      } catch (rollbackError) {
+        // Log rollback failure but do not throw — prevents masking the original error
+        LoggingService.error(
+          `[GroundingExecutor] Rollback failed for ${filePath}`,
+          rollbackError instanceof Error ? rollbackError : new Error(String(rollbackError)),
+        );
+      }
+    }
 
-    try {
-      await this.fileWriter.updateFile(filePath, originalContent);
-    } catch (rollbackError) {
-      // Log rollback failure but do not throw — prevents masking the original error
-      LoggingService.error(
-        `[GroundingExecutor] Rollback failed for ${filePath}`,
-        rollbackError instanceof Error ? rollbackError : new Error(String(rollbackError)),
-      );
+    // Issue #3921 — best-effort remove any assets a successful EARLIER
+    // create_instance step wrote to disk before a later step failed. Without
+    // this the created files are orphaned (partial-composite artifacts). Each
+    // delete is fail-soft: a failure is logged and swallowed so it never masks
+    // the original step error nor blocks the source-restore above. `createdPaths`
+    // only ever holds newly-created instance paths (each a fresh-UID
+    // `<folder>/<uid>.md` from executeCreateInstance) — never the click-target
+    // `filePath` — so this cannot delete the source asset. Runs regardless of
+    // whether `originalContent` was defined, so created files are cleaned up
+    // even when the click-target had no on-disk content.
+    for (const createdPath of createdPaths) {
+      try {
+        await this.fileWriter.deleteFile(createdPath);
+      } catch (deleteError) {
+        LoggingService.error(
+          `[GroundingExecutor] Rollback: failed to delete orphaned created asset ${createdPath}`,
+          deleteError instanceof Error ? deleteError : new Error(String(deleteError)),
+        );
+      }
     }
   }
 

--- a/packages/core/tests/unit/services/GroundingExecutor.compositeRollbackOrphan.test.ts
+++ b/packages/core/tests/unit/services/GroundingExecutor.compositeRollbackOrphan.test.ts
@@ -249,6 +249,53 @@ describe("GroundingExecutor — composite rollback deletes orphaned created asse
     expect(files.get(CLICK_TARGET_PATH)).toBe(CLICK_TARGET_SEED);
   });
 
+  it("catch-branch: a composite step that THROWS also deletes the created file (revert-locks the L799 rollback call)", async () => {
+    const { files, reader, writer } = makeFs({
+      [CLICK_TARGET_PATH]: CLICK_TARGET_SEED,
+    });
+    const exec = new GroundingExecutor(reader, writer, new ServiceRegistry());
+
+    // executeComposite has TWO rollback call sites: the step-returned-
+    // {success:false} branch (covered by the cases above) AND the catch branch
+    // (a genuine throw in the loop body). `execute()` wraps every step throw
+    // into {success:false} (→ the step-failure branch), so the ONLY way to
+    // reach the catch branch is a real throw from executeStep. Force the SECOND
+    // step to throw; the FIRST (create_instance) runs for real so createdPaths
+    // is populated before the throw. This locks the catch-branch rollback so a
+    // future revert of its `createdPaths` argument fails RED.
+    type WithStep = {
+      executeStep: (...args: unknown[]) => Promise<unknown>;
+    };
+    const realStep = (exec as unknown as WithStep).executeStep.bind(exec);
+    let stepCall = 0;
+    (exec as unknown as WithStep).executeStep = async (...args: unknown[]) => {
+      stepCall += 1;
+      if (stepCall === 1) return realStep(...args); // real create_instance
+      throw new Error("boom: composite step 2 threw");
+    };
+
+    const composite = gnd({
+      type: GroundingType.COMPOSITE,
+      steps: [createInstanceStep(), failingServiceCallStep()],
+    });
+
+    const res = await exec.execute(
+      composite,
+      CLICK_TARGET_IRI,
+      CLICK_TARGET_PATH,
+    );
+
+    expect(res.success).toBe(false);
+    // Proves we hit the catch branch (L799), not the step-failure branch (L769).
+    expect(res.error).toContain("Composite execution failed");
+
+    const createdPath = firstCreatedPath(writer);
+    expect(writer.deleteFile).toHaveBeenCalledWith(createdPath);
+    expect(files.has(createdPath)).toBe(false);
+    // Source-restore still ran on the catch path.
+    expect(files.get(CLICK_TARGET_PATH)).toBe(CLICK_TARGET_SEED);
+  });
+
   it("success case is byte-identical: no delete, createdPaths still surfaced for apply --json #3918 (regression-lock)", async () => {
     const { files, reader, writer } = makeFs({
       [CLICK_TARGET_PATH]: CLICK_TARGET_SEED,

--- a/packages/core/tests/unit/services/GroundingExecutor.compositeRollbackOrphan.test.ts
+++ b/packages/core/tests/unit/services/GroundingExecutor.compositeRollbackOrphan.test.ts
@@ -1,0 +1,278 @@
+/**
+ * Unit tests — GroundingExecutor composite rollback deletes orphaned
+ * create_instance assets (Issue #3921).
+ *
+ * When a composite `[create_instance, <later step>]` runs and the LATER step
+ * fails, the executor rolls back. Before this fix, `rollback` only restored the
+ * click-target source file — files written by an EARLIER SUCCESSFUL
+ * create_instance step were left orphaned on disk (partial-composite
+ * artifacts). The fix threads the accumulated `createdPaths` into `rollback`
+ * and best-effort (fail-soft) deletes each created file.
+ *
+ * Production-shape: drives the REAL GroundingExecutor.executeComposite over a
+ * real create_instance step + a reliably-failing later step (a service_call to
+ * an unregistered serviceId), backed by an in-memory IFileSystemWriter that
+ * records writes AND deletes and honours the read-after-write contract (no
+ * hand-injected create result — createdPaths is populated by the real
+ * create_instance step's openPath, mirroring the real #3918 surfacing channel).
+ *
+ * Revert-verify (Issue #3921): with the delete loop reverted these tests go RED
+ * (created files remain / deleteFile never called); with it applied they pass.
+ */
+
+import {
+  GroundingExecutor,
+  ServiceRegistry,
+} from "../../../src/services/GroundingExecutor";
+import { GroundingType } from "../../../src/domain/constants/GroundingType";
+import { GroundingDefinition } from "../../../src/domain/models/CommandDefinition";
+
+/** In-memory fs that honours read-after-write (mirrors the real contract). */
+function makeFs(seed: Record<string, string> = {}) {
+  const files = new Map<string, string>(Object.entries(seed));
+  const reader = {
+    readFile: jest.fn(async (path: string) => {
+      if (!files.has(path)) throw new Error(`ENOENT: ${path}`);
+      return files.get(path) as string;
+    }),
+    fileExists: jest.fn(async (path: string) => files.has(path)),
+    getMarkdownFiles: jest.fn().mockResolvedValue([]),
+  };
+  const writer = {
+    createFile: jest.fn(async (path: string, content: string) => {
+      files.set(path, content);
+      return "";
+    }),
+    updateFile: jest.fn(async (path: string, content: string) => {
+      files.set(path, content);
+    }),
+    writeFile: jest.fn(async (path: string, content: string) => {
+      files.set(path, content);
+    }),
+    deleteFile: jest.fn(async (path: string) => {
+      files.delete(path);
+    }),
+    renameFile: jest.fn().mockResolvedValue(undefined),
+  };
+  return { files, reader, writer };
+}
+
+function gnd(overrides: Record<string, unknown>): GroundingDefinition {
+  return {
+    id: "gnd-cro",
+    label: "composite-rollback-orphan",
+    ...overrides,
+  } as unknown as GroundingDefinition;
+}
+
+const CLICK_TARGET_IRI = "https://exocortex.my/assets/proto-123";
+const CLICK_TARGET_PATH = "/vault/protos/proto-123.md";
+const CLICK_TARGET_SEED =
+  "---\nexo__Asset_uid: proto-123\nexo__Asset_label: Task Prototype\n---\nProto body";
+
+const BACKLOG_VALUE =
+  '"[[753a44d5-846c-4b82-9196-4fd9a4d48777|ems__EffortStatusBacklog]]"';
+
+/** Minimal create_instance step — no needsTargetRead, so it never reads the
+ * click-target; it writes a fresh `<folder>/<uid>.md` and returns its openPath. */
+function createInstanceStep(): GroundingDefinition {
+  return gnd({
+    id: "step-create",
+    type: GroundingType.CREATE_INSTANCE,
+    targetClass: "ems__Task",
+    targetFolder: "/vault/tasks",
+  });
+}
+
+/** A service_call to an UNREGISTERED serviceId → returns {success:false}. */
+function failingServiceCallStep(): GroundingDefinition {
+  return gnd({
+    id: "step-fail",
+    type: GroundingType.SERVICE_CALL,
+    targetProperty: "definitely-not-a-registered-service-3921",
+  });
+}
+
+/** A property_set on the CLICK-TARGET (succeeds, creates no new file). */
+function propertySetOnClickTargetStep(): GroundingDefinition {
+  return gnd({
+    id: "step-set",
+    type: GroundingType.PROPERTY_SET,
+    targetProperty: "ems__Effort_status",
+    targetValueLiteral: BACKLOG_VALUE,
+  });
+}
+
+/** The path the create_instance step wrote, captured from the real createFile call. */
+function firstCreatedPath(writer: { createFile: jest.Mock }): string {
+  const call = writer.createFile.mock.calls[0];
+  expect(call).toBeDefined();
+  return call[0] as string;
+}
+
+describe("GroundingExecutor — composite rollback deletes orphaned created assets (Issue #3921)", () => {
+  it("deletes the earlier create_instance file when a later step fails (RED→GREEN core case)", async () => {
+    const { files, reader, writer } = makeFs({
+      [CLICK_TARGET_PATH]: CLICK_TARGET_SEED,
+    });
+    const exec = new GroundingExecutor(reader, writer, new ServiceRegistry());
+
+    const composite = gnd({
+      type: GroundingType.COMPOSITE,
+      steps: [createInstanceStep(), failingServiceCallStep()],
+    });
+
+    const res = await exec.execute(
+      composite,
+      CLICK_TARGET_IRI,
+      CLICK_TARGET_PATH,
+    );
+
+    // Composite failed on the later step.
+    expect(res.success).toBe(false);
+
+    const createdPath = firstCreatedPath(writer);
+    // The earlier-created instance file MUST be removed (not orphaned).
+    expect(writer.deleteFile).toHaveBeenCalledWith(createdPath);
+    expect(files.has(createdPath)).toBe(false);
+
+    // The click-target source is restored to its original content.
+    expect(files.get(CLICK_TARGET_PATH)).toBe(CLICK_TARGET_SEED);
+  });
+
+  it("deletes the created file even when the click-target had no on-disk content (originalContent === undefined)", async () => {
+    // Click-target NOT seeded → executeComposite's originalContent is undefined.
+    // The minimal create_instance step still creates a file (no needsTargetRead).
+    const { files, reader, writer } = makeFs({});
+    const exec = new GroundingExecutor(reader, writer, new ServiceRegistry());
+
+    const composite = gnd({
+      type: GroundingType.COMPOSITE,
+      steps: [createInstanceStep(), failingServiceCallStep()],
+    });
+
+    const res = await exec.execute(
+      composite,
+      CLICK_TARGET_IRI,
+      CLICK_TARGET_PATH,
+    );
+
+    expect(res.success).toBe(false);
+    const createdPath = firstCreatedPath(writer);
+    // Early-return-on-undefined must NOT skip the created-file cleanup.
+    expect(writer.deleteFile).toHaveBeenCalledWith(createdPath);
+    expect(files.has(createdPath)).toBe(false);
+  });
+
+  it("deletes ALL created files when a composite created several before failing (edge b)", async () => {
+    const { files, reader, writer } = makeFs({
+      [CLICK_TARGET_PATH]: CLICK_TARGET_SEED,
+    });
+    const exec = new GroundingExecutor(reader, writer, new ServiceRegistry());
+
+    const composite = gnd({
+      type: GroundingType.COMPOSITE,
+      steps: [
+        createInstanceStep(),
+        createInstanceStep(),
+        failingServiceCallStep(),
+      ],
+    });
+
+    const res = await exec.execute(
+      composite,
+      CLICK_TARGET_IRI,
+      CLICK_TARGET_PATH,
+    );
+    expect(res.success).toBe(false);
+
+    // Both create_instance steps wrote a distinct fresh-UID file.
+    const paths = writer.createFile.mock.calls.map((c) => c[0] as string);
+    expect(paths.length).toBe(2);
+    expect(new Set(paths).size).toBe(2);
+    for (const p of paths) {
+      expect(writer.deleteFile).toHaveBeenCalledWith(p);
+      expect(files.has(p)).toBe(false);
+    }
+  });
+
+  it("is fail-soft: a deleteFile failure never masks the step error nor blocks source-restore (edge a)", async () => {
+    const { files, reader, writer } = makeFs({
+      [CLICK_TARGET_PATH]: CLICK_TARGET_SEED,
+    });
+    // Make delete throw — the rollback delete-loop must swallow it.
+    writer.deleteFile.mockRejectedValue(new Error("disk gone"));
+    const exec = new GroundingExecutor(reader, writer, new ServiceRegistry());
+
+    const composite = gnd({
+      type: GroundingType.COMPOSITE,
+      steps: [createInstanceStep(), failingServiceCallStep()],
+    });
+
+    // Must resolve (no throw) despite the deleteFile rejection.
+    const res = await exec.execute(
+      composite,
+      CLICK_TARGET_IRI,
+      CLICK_TARGET_PATH,
+    );
+
+    expect(res.success).toBe(false);
+    const createdPath = firstCreatedPath(writer);
+    // Delete WAS attempted (proves the new path ran)…
+    expect(writer.deleteFile).toHaveBeenCalledWith(createdPath);
+    // …and the source-restore still happened despite the delete failure.
+    expect(files.get(CLICK_TARGET_PATH)).toBe(CLICK_TARGET_SEED);
+  });
+
+  it("no created files → rollback is unchanged (source-restore only, no delete) (edge c, regression-lock)", async () => {
+    const { files, reader, writer } = makeFs({
+      [CLICK_TARGET_PATH]: CLICK_TARGET_SEED,
+    });
+    const exec = new GroundingExecutor(reader, writer, new ServiceRegistry());
+
+    const composite = gnd({
+      type: GroundingType.COMPOSITE,
+      steps: [propertySetOnClickTargetStep(), failingServiceCallStep()],
+    });
+
+    const res = await exec.execute(
+      composite,
+      CLICK_TARGET_IRI,
+      CLICK_TARGET_PATH,
+    );
+    expect(res.success).toBe(false);
+
+    // No create_instance step ran → nothing to delete.
+    expect(writer.createFile).not.toHaveBeenCalled();
+    expect(writer.deleteFile).not.toHaveBeenCalled();
+    // Source restored to original.
+    expect(files.get(CLICK_TARGET_PATH)).toBe(CLICK_TARGET_SEED);
+  });
+
+  it("success case is byte-identical: no delete, createdPaths still surfaced for apply --json #3918 (regression-lock)", async () => {
+    const { files, reader, writer } = makeFs({
+      [CLICK_TARGET_PATH]: CLICK_TARGET_SEED,
+    });
+    const exec = new GroundingExecutor(reader, writer, new ServiceRegistry());
+
+    const composite = gnd({
+      type: GroundingType.COMPOSITE,
+      steps: [createInstanceStep(), propertySetOnClickTargetStep()],
+    });
+
+    const res = await exec.execute(
+      composite,
+      CLICK_TARGET_IRI,
+      CLICK_TARGET_PATH,
+    );
+
+    expect(res.success).toBe(true);
+    // Successful composite must NOT delete anything.
+    expect(writer.deleteFile).not.toHaveBeenCalled();
+    // The created file remains on disk.
+    const createdPath = firstCreatedPath(writer);
+    expect(files.has(createdPath)).toBe(true);
+    // #3918 surfacing channel is intact.
+    expect(res.createdPaths).toContain(createdPath);
+  });
+});


### PR DESCRIPTION
## Symptom

`GroundingExecutor.executeComposite` — when a **later** composite step fails, rollback restored **only** the click-target source file. A file written by an **earlier successful `create_instance` step** was left **orphaned on disk** (partial-composite artifact), even though the composite reported `{success:false}`.

Example: composite `[create_instance, <later step that fails>]` → the created instance `.md` remained on disk after the rollback.

## Root cause (verified on origin/main)

- `executeComposite` already accumulates a `createdPaths: string[]` array (for the #3918 `apply --json` surfacing channel) — pushing each successful step's `openPath` / `createdPaths`.
- Both failure branches — the step-returned-`success:false` branch and the `catch` branch — called `this.rollback(originalContent, filePath, completedSteps)`. **`createdPaths` was never passed.**
- `rollback` only did `this.fileWriter.updateFile(filePath, originalContent)` (source-restore); its `_completedSteps` param was unused; it never deleted created files. It also had an early `if (originalContent === undefined) return;` that would have skipped any cleanup for service_call-only / non-existent click-targets.

## Fix

- Thread the accumulated `createdPaths` into `rollback` (both failure branches) and **best-effort, fail-soft delete** each created file there. `IFileSystemWriter.deleteFile` already exists → **no interface change**, fix is self-contained in `GroundingExecutor.ts`.
- Mirrors the existing rollback try/catch/log pattern: a delete failure is logged and swallowed — it never masks the original step error nor blocks the source-restore.
- Restructured the early-return-on-undefined so the created-file cleanup runs **even when the click-target had no on-disk content**.
- **Byte-identical on success** — the `createdPaths` surfacing for `apply --json` (#3918) is unchanged; no delete on success.
- `createdPaths` only ever holds newly-created instance paths (each a fresh-UID `<folder>/<uid>.md` from `executeCreateInstance`) — **never the click-target `filePath`** — so it can never delete the source asset.

## Revert-verify (RED → GREEN)

New production-shape test `packages/core/tests/unit/services/GroundingExecutor.compositeRollbackOrphan.test.ts` drives the **real** `GroundingExecutor.executeComposite` over a real `create_instance` step + a reliably-failing later step (a `service_call` to an unregistered serviceId), backed by an in-memory `IFileSystemWriter` recording writes **and** deletes (no hand-injected create result — `createdPaths` is populated by the real create step's `openPath`).

**FAILS pre-fix / PASSES post-fix** (empirically verified):
- pre-fix: 4 core "delete" cases RED (created file remains / `deleteFile` never called), 2 regression-locks GREEN
- post-fix: **6/6 GREEN**

Edge cases covered:
- **(a) delete fails** → fail-soft: composite still `{success:false}`, source-restore still runs, no throw
- **(b) multiple created files** → all deleted
- **(c) no created files** → rollback unchanged (source-restore only, `deleteFile` not called) — regression-lock, GREEN both ways
- **(d) `originalContent === undefined`** (click-target had no on-disk content) → created file still deleted (covers the early-return restructure)
- **success case** → no delete, `createdPaths` still surfaced (guards #3918) — regression-lock, GREEN both ways

## Local gates

- core `tsc --noEmit` → 0 errors
- 3 CI lint guard scripts (`check-test-antipatterns.sh` method-exists 55/55, `validate-shard-assignments.mjs`, `check-coverage-monotonic.mjs`) → all pass
- eslint on changed src → clean; archgate 23/23 pass
- broader `GroundingExecutor` + composite + asset-creation suites → 347 pass (the 3 pre-existing walker-suite failures were a fresh-worktree submodule env artifact — 52/52 pass once `exoas-exocmd` is initialized)

Closes #3921
