### PR TITLE
fix(relations): surface reified exo__Class_superClass edges

### DIFF
--- a/packages/obsidian-plugin/src/presentation/renderers/layout/RelationsRenderer.ts
+++ b/packages/obsidian-plugin/src/presentation/renderers/layout/RelationsRenderer.ts
@@ -95,14 +95,33 @@ const RDFS_BASE: string = Namespace.RDFS.iri.value;
 const OWL_BASE: string = Namespace.OWL.iri.value;
 /**
  * `exo#` local-name prefixes that are purely TBox-structural / reification-plumbing
- * — never user-data relations (`Instance_class`, `Class_superClass`, the three
- * `Statement_` slots). Safe to drop wholesale by prefix.
+ * — never user-data relations (`Instance_class`, the three `Statement_` slots).
+ * Safe to drop wholesale by prefix.
+ *
+ * ⛔ `Class_` is deliberately NOT a wholesale prefix here (ems__Bug `2c7b99a3`):
+ * the `exo#Class_*` family, like `exo#Asset_*`, mixes LITERAL definition metadata
+ * with genuine OBJECT relations — `Class_superClass` is an `exo#ObjectProperty`
+ * modelling a real class-to-class edge. Dropping the whole prefix made a manually
+ * reified `Class_superClass` statement invisible EVERYWHERE: the raw backlink is
+ * suppressed as reification plumbing (see {@link REIFICATION_PLUMBING_KEYS}) in
+ * the expectation that the reified path renders the logical edge — and the
+ * reified path then discarded it here. Only the literal / definition-metadata
+ * `Class_*` properties are dropped, mirroring the `Asset_*` treatment below.
  */
-const EXO_NON_RELATION_LOCALNAME_PREFIXES = [
-  "Instance_",
-  "Class_",
-  "Statement_",
-];
+const EXO_NON_RELATION_LOCALNAME_PREFIXES = ["Instance_", "Statement_"];
+/**
+ * The LITERAL / definition-metadata `exo#Class_*` properties — dropped explicitly.
+ * The OBJECT relation `Class_superClass` is intentionally ABSENT so it passes as a
+ * relation (ems__Bug `2c7b99a3`): a hand-authored `exo__Statement` reifying it is a
+ * deliberate user act of surfacing that edge. Note this denylist gates ONLY the
+ * reified path ({@link getReifiedRelationsGated}) — inline frontmatter
+ * `exo__Class_superClass` is unaffected and still yields no relation-block noise.
+ */
+const EXO_NON_RELATION_CLASS_LOCALNAMES: ReadonlySet<string> = new Set([
+  "Class_name",
+  "Class_description",
+  "Class_ontology",
+]);
 /**
  * The LITERAL `exo#Asset_*` metadata properties (string / datetime / boolean
  * values) — dropped explicitly. The OBJECT `exo:Asset_*` relations
@@ -131,6 +150,7 @@ export function isNonRelationPredicate(predicateIri: string): boolean {
   if (predicateIri.startsWith(EXO_BASE)) {
     const localName = predicateIri.slice(EXO_BASE.length);
     if (EXO_NON_RELATION_ASSET_LOCALNAMES.has(localName)) return true;
+    if (EXO_NON_RELATION_CLASS_LOCALNAMES.has(localName)) return true;
     return EXO_NON_RELATION_LOCALNAME_PREFIXES.some((p) =>
       localName.startsWith(p),
     );

--- a/packages/obsidian-plugin/src/presentation/renderers/layout/RelationsRenderer.ts
+++ b/packages/obsidian-plugin/src/presentation/renderers/layout/RelationsRenderer.ts
@@ -71,9 +71,9 @@ const REIFICATION_PLUMBING_KEYS: ReadonlySet<string> = new Set([
  * object properties such as `ems#Effort_area`, `exo-ims#relatesToConcept`); a
  * statement whose `_predicate` is a SYSTEM / metadata / plumbing predicate
  * (`rdf:type`, the literal `exo:Asset_*` frontmatter metadata, the TBox-structural
- * `exo:Instance_*` / `exo:Class_*`, or the `exo:Statement_*` reification slots
- * themselves) is noise, not a relation, and must be dropped. RDFS / OWL schema
- * predicates (inferred noise) are likewise excluded.
+ * `exo:Instance_*` and the literal `exo:Class_*` subset, or the `exo:Statement_*`
+ * reification slots themselves) is noise, not a relation, and must be dropped.
+ * RDFS / OWL schema predicates (inferred noise) are likewise excluded.
  *
  * The exclusion is deliberately a CLOSED, narrow set — NOT a coarse `exo#Asset_`
  * prefix. The `exo:Asset_*` family contains genuine OBJECT relations the inline
@@ -94,9 +94,14 @@ const EXO_BASE: string = Namespace.EXO.iri.value;
 const RDFS_BASE: string = Namespace.RDFS.iri.value;
 const OWL_BASE: string = Namespace.OWL.iri.value;
 /**
- * `exo#` local-name prefixes that are purely TBox-structural / reification-plumbing
- * — never user-data relations (`Instance_class`, the three `Statement_` slots).
- * Safe to drop wholesale by prefix.
+ * `exo#` local-name prefixes dropped WHOLESALE from the reified path.
+ *
+ * Note `Instance_class` / `Instance_prototype` are themselves `exo#ObjectProperty`
+ * — so `Instance_` is kept wholesale NOT on the "its members are literals" grounds
+ * that motivate the enumerated `Class_*` set below, but on VOLUME grounds: every
+ * instance of a class backlinks to it, and those class-membership / prototype edges
+ * are already surfaced by the inline path at a scale that would swamp the block.
+ * The `Statement_` slots are pure reification plumbing.
  *
  * ⛔ `Class_` is deliberately NOT a wholesale prefix here (ems__Bug `2c7b99a3`):
  * the `exo#Class_*` family, like `exo#Asset_*`, mixes LITERAL definition metadata
@@ -113,9 +118,18 @@ const EXO_NON_RELATION_LOCALNAME_PREFIXES = ["Instance_", "Statement_"];
  * The LITERAL / definition-metadata `exo#Class_*` properties — dropped explicitly.
  * The OBJECT relation `Class_superClass` is intentionally ABSENT so it passes as a
  * relation (ems__Bug `2c7b99a3`): a hand-authored `exo__Statement` reifying it is a
- * deliberate user act of surfacing that edge. Note this denylist gates ONLY the
- * reified path ({@link getReifiedRelationsGated}) — inline frontmatter
- * `exo__Class_superClass` is unaffected and still yields no relation-block noise.
+ * deliberate user act of surfacing that edge.
+ *
+ * This denylist gates ONLY the reified path ({@link getReifiedRelationsGated}) —
+ * the inline backlink path applies no predicate denylist at all, so an inline
+ * `exo__Class_superClass` is surfaced there regardless of this set.
+ *
+ * `Class_ontology` is denied on a "TBD-semantics stub → deny until defined" basis,
+ * NOT because it is literal: in the live TBox it is an auto-generated ABox stub with
+ * no declared range. Were its semantics defined as a class→ontology OBJECT relation
+ * it would be the analogue of `exo:Asset_isDefinedBy` (allowed below) and should move
+ * out of this set. `Class_name` / `Class_description` are literal-valued, so a real
+ * reified statement of them is dropped by the `objectIsLiteral` guard anyway.
  */
 const EXO_NON_RELATION_CLASS_LOCALNAMES: ReadonlySet<string> = new Set([
   "Class_name",

--- a/packages/obsidian-plugin/tests/unit/RelationsRenderer.test.ts
+++ b/packages/obsidian-plugin/tests/unit/RelationsRenderer.test.ts
@@ -1623,10 +1623,17 @@ describe("RelationsRenderer", () => {
           isNonRelationPredicate(Namespace.EXO.term("Instance_class").value),
         ).toBe(true);
         expect(
-          isNonRelationPredicate(Namespace.EXO.term("Class_superClass").value),
+          isNonRelationPredicate(Namespace.EXO.term("Statement_subject").value),
+        ).toBe(true);
+        // LITERAL / definition-metadata exo:Class_* properties stay filtered.
+        expect(
+          isNonRelationPredicate(Namespace.EXO.term("Class_name").value),
         ).toBe(true);
         expect(
-          isNonRelationPredicate(Namespace.EXO.term("Statement_subject").value),
+          isNonRelationPredicate(Namespace.EXO.term("Class_description").value),
+        ).toBe(true);
+        expect(
+          isNonRelationPredicate(Namespace.EXO.term("Class_ontology").value),
         ).toBe(true);
         expect(
           isNonRelationPredicate(Namespace.RDFS.term("label").value),
@@ -1649,6 +1656,15 @@ describe("RelationsRenderer", () => {
         ).toBe(false);
         expect(
           isNonRelationPredicate(Namespace.EXO.term("Asset_isDefinedBy").value),
+        ).toBe(false);
+        // ems__Bug `2c7b99a3` — `Class_superClass` is an exo#ObjectProperty (a real
+        // class-to-class edge), so a hand-authored reified statement of it MUST
+        // pass. Filtering the whole `Class_` prefix made such a statement invisible
+        // everywhere: the raw backlink is suppressed as reification plumbing in the
+        // expectation that the reified path renders it, and the reified path then
+        // dropped it here.
+        expect(
+          isNonRelationPredicate(Namespace.EXO.term("Class_superClass").value),
         ).toBe(false);
       });
     });
@@ -1762,6 +1778,96 @@ describe("RelationsRenderer", () => {
       // predicate rendered in frontmatter-key form (handles the dash prefix).
       expect(result[0].propertyName).toBe("exo-ims__relatesToConcept");
       expect(result[0].isBodyLink).toBe(false);
+    });
+
+    // ems__Bug `2c7b99a3` — a hand-authored `exo__Statement` reifying
+    // `exo__Class_superClass` (a mixin edge between two class assets) rendered
+    // NOWHERE: the raw `exo__Statement_object` backlink is suppressed as
+    // reification plumbing in the expectation that the reified path surfaces the
+    // logical edge, and the reified path then discarded it because the whole
+    // `Class_` local-name prefix was denylisted as TBox-structural.
+    //
+    // Mirrors the real vault shape (`8a2136de`: ztlk__Note --superClass--> mm__Resource):
+    // BOTH ends are class assets whose `prefix__LocalName` labels the converter emits
+    // as SYMBOLIC IRIs (dual-IRI), never as path-form IRIs.
+    //
+    //   Revert-verified: restoring "Class_" to EXO_NON_RELATION_LOCALNAME_PREFIXES
+    //   drops the relation → `toHaveLength(1)` RED; removed → GREEN.
+    it("surfaces a reified Class_superClass edge between two symbolic-IRI class assets", async () => {
+      const store = new InMemoryTripleStore();
+      const CLASS_SUPER_CLASS = Namespace.EXO.term("Class_superClass");
+      const ZTLK_NOTE = Namespace.forPrefix("ztlk").term("Note"); // subject class
+      const MM_RESOURCE = Namespace.forPrefix("mm").term("Resource"); // object class = open asset
+      const RESOURCE_PATH =
+        "assetspaces/kitelev/exoas-my/my-mixins/f9bc503f-0000-0000-0000-000000000001.md";
+      const RESOURCE_UID = "f9bc503f-0000-0000-0000-000000000001";
+      const STMT_PATH =
+        "assetspaces/kitelev/exoas-my/my-mixins/8a2136de-0000-0000-0000-000000000002.md";
+
+      await seedStatement(
+        store,
+        STMT_PATH,
+        ZTLK_NOTE,
+        CLASS_SUPER_CLASS,
+        MM_RESOURCE,
+      );
+      mockBacklinksCacheManager.getBacklinks.mockReturnValue([]); // plumbing backlink suppressed
+      registerFiles(
+        {
+          [RESOURCE_PATH]: {
+            exo__Asset_uid: RESOURCE_UID,
+            exo__Asset_label: "mm__Resource",
+          },
+        },
+        { [RESOURCE_PATH]: "mm__Resource" },
+      );
+
+      const result = await makeRenderer(store).getAssetRelations(
+        createTestTFile(RESOURCE_PATH),
+        {},
+      );
+
+      expect(result).toHaveLength(1);
+      expect(result[0].provenance).toBe("reified");
+      expect(result[0].statementPath).toBe(STMT_PATH);
+      expect(result[0].propertyName).toBe("exo__Class_superClass");
+      // incoming (the open asset is the OBJECT) → the related asset is the SUBJECT.
+      expect(result[0].title).toBe("ztlk__Note");
+    });
+
+    it("keeps a reified LITERAL Class_* definition property out of the relations block", async () => {
+      const store = new InMemoryTripleStore();
+      const CLASS_DESCRIPTION = Namespace.EXO.term("Class_description");
+      const MM_RESOURCE = Namespace.forPrefix("mm").term("Resource");
+      const RESOURCE_PATH =
+        "assetspaces/kitelev/exoas-my/my-mixins/f9bc503f-0000-0000-0000-000000000001.md";
+      const STMT_PATH =
+        "assetspaces/kitelev/exoas-my/my-mixins/cccccccc-0000-0000-0000-000000000003.md";
+
+      await seedStatement(
+        store,
+        STMT_PATH,
+        Namespace.forPrefix("ztlk").term("Note"),
+        CLASS_DESCRIPTION,
+        MM_RESOURCE,
+      );
+      mockBacklinksCacheManager.getBacklinks.mockReturnValue([]);
+      registerFiles(
+        {
+          [RESOURCE_PATH]: {
+            exo__Asset_uid: "f9bc503f-0000-0000-0000-000000000001",
+            exo__Asset_label: "mm__Resource",
+          },
+        },
+        { [RESOURCE_PATH]: "mm__Resource" },
+      );
+
+      const result = await makeRenderer(store).getAssetRelations(
+        createTestTFile(RESOURCE_PATH),
+        {},
+      );
+
+      expect(result).toEqual([]);
     });
 
     it("renders an incoming reified relation with the SUBJECT as the related asset", async () => {

--- a/packages/obsidian-plugin/tests/unit/RelationsRenderer.test.ts
+++ b/packages/obsidian-plugin/tests/unit/RelationsRenderer.test.ts
@@ -1835,6 +1835,11 @@ describe("RelationsRenderer", () => {
       expect(result[0].title).toBe("ztlk__Note");
     });
 
+    // Deliberate isolation: a REAL `Class_description` statement carries a Literal
+    // object and is already dropped by the `objectIsLiteral` guard regardless of the
+    // denylist. Seeding an IRI object bypasses that guard so this test is sensitive to
+    // EXO_NON_RELATION_CLASS_LOCALNAMES specifically (mutation-verified: removing the
+    // set-check turns it RED). It does NOT cover literal-object reification end-to-end.
     it("keeps a reified LITERAL Class_* definition property out of the relations block", async () => {
       const store = new InMemoryTripleStore();
       const CLASS_DESCRIPTION = Namespace.EXO.term("Class_description");


### PR DESCRIPTION
## Symptom

A hand-authored `exo__Statement` reifying `exo__Class_superClass` renders **nowhere** in the Relations block — not on the subject page, not on the object page.

Real vault repro (`vault-my`, `exoas-my/my-mixins/`) — a mixin hierarchy:

| statement | edge |
|---|---|
| `8a2136de-…` | `ztlk__Note` --`exo__Class_superClass`--> `mm__Resource` |
| `446296f6-…` | `ems__Effort` --`exo__Class_superClass`--> `mm__ResourceAware` |

Both are correct in the triple store (verified via SPARQL); the predicate is emitted symbolically as `https://exocortex.my/ontology/exo#Class_superClass`.

## Root cause

Two RFC `93a0b2ee` filters contradict each other:

1. **The raw backlink is suppressed.** The statement references the open asset only via `exo__Statement_object` — a `REIFICATION_PLUMBING_KEYS` member — so the backlink is skipped wholesale (`RelationsRenderer.ts` ~373). By RFC design this is safe *because the reified path is expected to render the logical edge*.
2. **The reified edge is then discarded.** `getReifiedRelationsGated` filters through `isNonRelationPredicate` (`RelationsRenderer.ts:265`). For `exo#Class_superClass` the local name starts with the `Class_` prefix in `EXO_NON_RELATION_LOCALNAME_PREFIXES`, so it is treated as TBox-structural noise.

Filter 1 suppresses the edge's representation counting on path 2, and path 2 drops it — the edge renders nowhere.

The chain up to the filter is healthy: `getReifiedRelations` finds the statement correctly (`assetIriForms` yields the symbolic `mm#Resource` form for label `mm__Resource`, `direction=incoming`).

## Fix

`exo#Class_superClass` is an `exo#ObjectProperty` — a genuine class-to-class edge. So the `exo#Class_*` family mixes literal definition metadata with real object relations, **exactly like `exo#Asset_*` already does**, where the denylist deliberately lists only the literal metadata (`Asset_label`, `Asset_uid`, timestamps…) and lets the object relations (`Asset_relates`, `Asset_prototype`, …) pass.

Mirror that treatment for `Class_*`:

- drop `Class_` from `EXO_NON_RELATION_LOCALNAME_PREFIXES`;
- deny only the literal / definition-metadata members explicitly — `Class_name`, `Class_description`, `Class_ontology`;
- `Class_superClass` now passes as a relation.

Rationale: hand-authoring an `exo__Statement` is a deliberate user act of surfacing that edge, unlike inline frontmatter `exo__Class_superClass` (which would produce TBox noise on every superclass). **The denylist gates only the reified path** — the inline path is untouched.

`Instance_` and `Statement_` prefixes remain denylisted (out of scope).

## Blast radius

`isNonRelationPredicate` is local to `RelationsRenderer.ts`; the only consumers are the renderer itself and its unit test (`git grep` verified).

## Tests — revert-verified RED → GREEN

Added to `RelationsRenderer.test.ts`:

1. **Production-shape** `getAssetRelations` case over a real `InMemoryTripleStore`, mirroring the vault shape — **both** edge ends are class assets emitted as SYMBOLIC IRIs (dual-IRI), incoming direction, subject surfaced as the related asset.
2. **Negative control** — a reified *literal* `Class_description` statement stays filtered (`toEqual([])`).
3. Unit spec for `isNonRelationPredicate` updated: `Class_superClass` → `false`; `Class_name` / `Class_description` / `Class_ontology` → `true`.

Revert-verify (restoring `"Class_"` to the prefix denylist):

```
Tests: 2 failed, 87 passed, 89 total
  ● isNonRelationPredicate …                    Expected: false / Received: true
  ● surfaces a reified Class_superClass edge …  Expected length: 1 / Received length: 0
```

`Received length: 0` is exactly the reported symptom. With the fix: **89/89 pass**.

## Local gates

- `RelationsRenderer.test.ts` — 89/89
- full obsidian-plugin unit suite — 5949 passed / 332 suites (the single failure was `VaultSettingsRegistry.test.ts` reading the un-initialised `packages/exoas-exo` submodule in a fresh worktree — an env artifact; 13/13 green after `git submodule update --init`)
- `npm run check:types` — 0 errors
- `check-test-antipatterns.sh` (55/55, 21/21, 24/24, 0/0), `validate-shard-assignments.mjs`, `check-coverage-monotonic.mjs` — all exit 0
- `eslint --max-warnings=0` on the changed src — clean
- archgate pre-commit — 23/23 pass

ems__Bug: `2c7b99a3-96da-4d72-8c53-343cae147599`
