### PR TITLE
ci: add workflow_dispatch lever to CI (Closes #3925)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,15 @@ on:
     types: [opened, synchronize, reopened, ready_for_review]
     branches:
       - main
+  # Manual re-trigger lever (Issue #3925). GitHub intermittently accepts a push
+  # to `main` WITHOUT emitting the push event to Actions: the commit lands, but
+  # no workflow run and no check-suite are ever created (3rd observed occurrence,
+  # merge `b11f8cb5`). Because `auto-release.yml` is reachable ONLY via
+  # `workflow_run: workflows: ["CI"]`, such a commit is stranded unreleased until
+  # some later, unrelated push happens to fire CI. On a PR branch the recovery
+  # levers are `update-branch` / close+reopen; on `main` there was NO lever at
+  # all. This gives one: `gh workflow run ci.yml --ref main`.
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -33,7 +42,12 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 1
     outputs:
-      code: ${{ steps.filter.outputs.code }}
+      # A manual `workflow_dispatch` is the recovery lever for a stranded `main`
+      # commit (Issue #3925), so it must behave like push-to-main: run EVERYTHING,
+      # never a docs-only subset. `dorny/paths-filter` has no meaningful base to
+      # diff against on a dispatch, so the filter step is skipped and `code` is
+      # forced to `true` instead of relying on its (undefined) output.
+      code: ${{ github.event_name == 'workflow_dispatch' && 'true' || steps.filter.outputs.code }}
       force: ${{ steps.force.outputs.force }}
 
     steps:
@@ -42,6 +56,7 @@ jobs:
 
       - name: Detect code changes
         id: filter
+        if: github.event_name != 'workflow_dispatch'
         uses: dorny/paths-filter@v3
         with:
           filters: |


### PR DESCRIPTION
Closes #3925.

## Why

GitHub intermittently accepts a push to `main` **without emitting the push event to Actions**: the commit lands in the branch, but no workflow run and no check-suite are ever created. Third observed occurrence — merge `b11f8cb5` (PR #3923).

Diagnostics at the time (all local causes excluded): `check-suites` on the SHA = **0**; no run for `CI` / `Security Scan` / `ci-image`; Actions `enabled` + `allowed_actions: all`; `CI` and `Auto Release` both `active`; repo public (no minutes quota); githubstatus All Systems Operational; the *previous* push (`7b7820be`) ran CI normally; the PR's own `pull_request` runs passed minutes earlier.

`auto-release.yml` is reachable **only** via `workflow_run: workflows: ["CI"]`, so a commit stranded this way is never released — it ships only when some later, unrelated push happens to fire CI. On a PR branch the recovery levers are `update-branch` / close+reopen; on `main` there was **no lever at all**.

## What

Adds `workflow_dispatch:` to `ci.yml`, so a stranded `main` commit can be re-triggered:

```
gh workflow run ci.yml --ref main
```

Insurance lever, **not** a root-cause fix — the trigger loss is on GitHub's side and is not observable from outside.

## Dispatch-correctness details

A dispatch must behave like push-to-main (run **everything**, never a docs-only subset), otherwise the lever would publish a release off a partial run:

- `dorny/paths-filter` has no meaningful base to diff against on a dispatch → the filter step is skipped (`if: github.event_name != 'workflow_dispatch'`) and `detect-changes.outputs.code` is forced to `'true'` rather than relying on its undefined output.
- The existing `github.event_name == 'push' || needs.detect-changes.outputs.code == 'true'` gates (e2e-shard, test-component, performance) therefore admit dispatch runs unchanged — no edits needed at the 4 call sites.
- `toJSON(github.event.pull_request.labels.*.name)` in the force-e2e step yields `null` on a dispatch; the `grep` misses and `force=false` — no failure.

YAML validated (`yaml.safe_load`): triggers `[push, pull_request, workflow_dispatch]`, 19 jobs intact.

## Verification

This PR's own CI run exercises the `pull_request` path (unchanged). The dispatch path is verified after merge by invoking the lever on `main` — which is also what unblocks the stranded `b11f8cb5` release.