### PR TITLE
fix(#3929): stamp plannedEnd from endTime-only prototype (ActionPrototype intake)

### DIFF
--- a/packages/core/src/services/GroundingExecutor.ts
+++ b/packages/core/src/services/GroundingExecutor.ts
@@ -1316,10 +1316,12 @@ export class GroundingExecutor {
    * dateTime `"YYYY-MM-DDTHH:MM:SS"` (Asia/Almaty convention — matches the
    * existing `ems__Effort_plannedStartTimestamp` frontmatter shape).
    *
-   * No-op when the prototype declares no `startTime` → zero regression for
-   * prototypes / create flows without a time-of-day. Never overwrites a planned
-   * timestamp that an explicit `userInput` already wrote into `properties` (the
-   * prototype time is a default, not an override).
+   * No-op only when the prototype declares NO time-of-day at all (neither
+   * `startTime` nor `endTime`) → zero regression for create flows without a
+   * time. A prototype with only `_endTime` (e.g. an `ems__ActionPrototype`
+   * point-in-time intake) stamps just `_plannedEndTimestamp` (#3929). Never
+   * overwrites a planned timestamp that an explicit `userInput` already wrote
+   * into `properties` (the prototype time is a default, not an override).
    *
    * Reads from `targetFm`, which is only populated when `needsTargetRead` is
    * true (InheritanceRule / `__SUBSTITUTE` PropertyDefault / `$target.`
@@ -1336,9 +1338,20 @@ export class GroundingExecutor {
     const startTime = GroundingExecutor.firstScalar(
       targetFm["ems__EffortPrototype_startTime"],
     );
-    if (!startTime) return; // prototype declares no time-of-day → no-op
+    const endTime = GroundingExecutor.firstScalar(
+      targetFm["ems__EffortPrototype_endTime"],
+    );
+    // No-op only when the prototype declares NO time-of-day at all. A prototype
+    // with only `_endTime` and no `_startTime` (e.g. an ems__ActionPrototype —
+    // a point-in-time БАД/med intake at its `_endTime`) must still stamp its
+    // planned end timestamp; the earlier `if (!startTime) return` dropped it
+    // entirely (#3929).
+    if (!startTime && !endTime) return;
     const instanceDate = this.resolveInstanceDate(userInput);
-    if (properties["ems__Effort_plannedStartTimestamp"] === undefined) {
+    if (
+      startTime &&
+      properties["ems__Effort_plannedStartTimestamp"] === undefined
+    ) {
       const startTs = GroundingExecutor.combineDateAndTime(
         instanceDate,
         startTime,
@@ -1351,9 +1364,6 @@ export class GroundingExecutor {
         );
       }
     }
-    const endTime = GroundingExecutor.firstScalar(
-      targetFm["ems__EffortPrototype_endTime"],
-    );
     if (endTime && properties["ems__Effort_plannedEndTimestamp"] === undefined) {
       const endTs = GroundingExecutor.combineDateAndTime(instanceDate, endTime);
       if (endTs !== null) {

--- a/packages/core/tests/integration/asset-creation/proto-time-propagation.test.ts
+++ b/packages/core/tests/integration/asset-creation/proto-time-propagation.test.ts
@@ -170,6 +170,19 @@ const PROTO_BAD_TIME = [
 ].join("\n");
 const PROTO_BAD_TIME_PATH = "/vault/broken-proto.md";
 
+/** Prototype with ONLY a MALFORMED end time (no start) → must be skipped (#3929 edge). */
+const PROTO_BAD_END = [
+  "---",
+  'exo__Asset_uid: "proto-badend-uid"',
+  'exo__Asset_label: "Broken intake"',
+  "exo__Instance_class:",
+  '  - "[[93d74dfd-1994-4673-853c-65f1fde80df3]]"',
+  'ems__EffortPrototype_endTime: "25:99"',
+  "---",
+  "",
+].join("\n");
+const PROTO_BAD_END_PATH = "/vault/broken-end-proto.md";
+
 // create-task-instance-shaped grounding: InheritanceRule writes the prototype
 // backlink (so needsTargetRead → targetFm is the prototype frontmatter), and a
 // labelTemplate uses $today so we can assert the label denotes the chosen date.
@@ -223,6 +236,7 @@ describe(`Integration: create_instance prototype-time propagation (ec15f83e) ${R
     await fs.createFile(PROTO_ONLY_END_PATH, PROTO_ONLY_END);
     await fs.createFile(PROTO_NO_TIME_PATH, PROTO_WITHOUT_TIME);
     await fs.createFile(PROTO_BAD_TIME_PATH, PROTO_BAD_TIME);
+    await fs.createFile(PROTO_BAD_END_PATH, PROTO_BAD_END);
     const serviceRegistry = new ServiceRegistry();
     groundingExecutor = new GroundingExecutor(fs, fs, serviceRegistry, undefined, {
       clock: frozenClock(`${FROZEN_TODAY}T12:00:00Z`),
@@ -237,6 +251,7 @@ describe(`Integration: create_instance prototype-time propagation (ec15f83e) ${R
       PROTO_ONLY_END_PATH,
       PROTO_NO_TIME_PATH,
       PROTO_BAD_TIME_PATH,
+      PROTO_BAD_END_PATH,
     ]);
     const path = fs.getAllPaths().find((p) => !protos.has(p));
     if (!path) throw new Error("No created file");
@@ -383,6 +398,23 @@ describe(`Integration: create_instance prototype-time propagation (ec15f83e) ${R
     expect(result.success).toBe(true);
 
     const content = createdContent();
+    expect(content).not.toContain("ems__Effort_plannedStartTimestamp");
+    expect(content).not.toContain("25:99");
+  });
+
+  // Hardening (code-reviewer LOW, #3929 edge): a malformed END-only time must be
+  // skipped too — the new endTime-only path relies on combineDateAndTime → null.
+  it(`${REQ} malformed end-only prototype time is skipped, not written as garbage (#3929)`, async () => {
+    const result = await groundingExecutor.execute(
+      GROUNDING,
+      "https://exocortex.my/assets/broken-end-proto",
+      PROTO_BAD_END_PATH,
+      undefined,
+    );
+    expect(result.success).toBe(true);
+
+    const content = createdContent();
+    expect(content).not.toContain("ems__Effort_plannedEndTimestamp");
     expect(content).not.toContain("ems__Effort_plannedStartTimestamp");
     expect(content).not.toContain("25:99");
   });

--- a/packages/core/tests/integration/asset-creation/proto-time-propagation.test.ts
+++ b/packages/core/tests/integration/asset-creation/proto-time-propagation.test.ts
@@ -10,8 +10,10 @@
  *   (B) auto-stamps `ems__Effort_plannedStartTimestamp` (and `_plannedEnd...`
  *       when endTime present) = chosenDate + that time, a FULL timezone-naive
  *       local dateTime "YYYY-MM-DDTHH:MM:SS".
- * When the prototype declares no time-of-day → unchanged (no planned timestamps,
- * no date prompt) — zero regression.
+ * A prototype with ONLY `_endTime` (an ems__ActionPrototype point-in-time БАД
+ * intake) stamps just `_plannedEndTimestamp` (#3929). When the prototype
+ * declares no time-of-day at all → unchanged (no planned timestamps, no date
+ * prompt) — zero regression.
  *
  * Exercises the real `create_instance` pipeline through GroundingExecutor with
  * an in-memory file system (executor logic NOT mocked) + a frozen clock for a
@@ -127,6 +129,23 @@ const PROTO_ONLY_START = [
   "",
 ].join("\n");
 
+/**
+ * Prototype with ONLY an end time and NO start time — an `ems__ActionPrototype`
+ * point-in-time intake (Выпить Зодак 08:15). #3929: the earlier
+ * `if (!startTime) return` dropped this entirely; it must stamp `_plannedEnd`.
+ */
+const PROTO_ONLY_END = [
+  "---",
+  'exo__Asset_uid: "proto-zodak-uid"',
+  'exo__Asset_label: "Выпить Зодак"',
+  "exo__Instance_class:",
+  '  - "[[93d74dfd-1994-4673-853c-65f1fde80df3]]"',
+  'ems__EffortPrototype_endTime: "08:15"',
+  "---",
+  "",
+].join("\n");
+const PROTO_ONLY_END_PATH = "/vault/zodak-proto.md";
+
 /** Prototype declaring NO time-of-day (control — no-op expected). */
 const PROTO_WITHOUT_TIME = [
   "---",
@@ -201,6 +220,7 @@ describe(`Integration: create_instance prototype-time propagation (ec15f83e) ${R
     fs = new InMemoryFileSystem();
     await fs.createFile(PROTO_PATH, PROTO_WITH_TIMES);
     await fs.createFile(PROTO_NO_END_PATH, PROTO_ONLY_START);
+    await fs.createFile(PROTO_ONLY_END_PATH, PROTO_ONLY_END);
     await fs.createFile(PROTO_NO_TIME_PATH, PROTO_WITHOUT_TIME);
     await fs.createFile(PROTO_BAD_TIME_PATH, PROTO_BAD_TIME);
     const serviceRegistry = new ServiceRegistry();
@@ -214,6 +234,7 @@ describe(`Integration: create_instance prototype-time propagation (ec15f83e) ${R
     const protos = new Set([
       PROTO_PATH,
       PROTO_NO_END_PATH,
+      PROTO_ONLY_END_PATH,
       PROTO_NO_TIME_PATH,
       PROTO_BAD_TIME_PATH,
     ]);
@@ -290,6 +311,24 @@ describe(`Integration: create_instance prototype-time propagation (ec15f83e) ${R
       /ems__Effort_plannedStartTimestamp:\s*"?2026-07-02T20:00:00"?/,
     );
     expect(fm).not.toContain("ems__Effort_plannedEndTimestamp");
+  });
+
+  // Scenario (#3929): prototype (ems__ActionPrototype — point-in-time БАД/med
+  // intake) declares ONLY an endTime and NO startTime → instance gets only
+  // plannedEnd. The earlier `if (!startTime) return` dropped it entirely.
+  it(`${REQ} prototype with only endTime → instance gets only plannedEnd (#3929)`, async () => {
+    await groundingExecutor.execute(
+      GROUNDING,
+      "https://exocortex.my/assets/zodak-proto",
+      PROTO_ONLY_END_PATH,
+      { plannedDate: "2026-07-03" },
+    );
+    const { fm } = splitFrontmatterAndBody(createdContent());
+
+    expect(fm).toMatch(
+      /ems__Effort_plannedEndTimestamp:\s*"?2026-07-03T08:15:00"?/,
+    );
+    expect(fm).not.toContain("ems__Effort_plannedStartTimestamp");
   });
 
   // Scenario: prototype declares NO time-of-day → unchanged (no-op, no regression).


### PR DESCRIPTION
## Summary
Closes #3929. `GroundingExecutor.applyPrototypeTimePropagation` did `if (!startTime) return`, dropping prototypes that declare **only** `ems__EffortPrototype_endTime` (no `startTime`) — e.g. an `ems__ActionPrototype` point-in-time БАД/med intake. So `create-action-instance` never stamped any planned timestamp, while `create-task-instance` (start+end) did.

## Root cause (verified)
`applyPrototypeTimePropagation` read `startTime`, early-returned on its absence, and only then read `endTime` — so the endTime-stamping block was unreachable for endTime-only prototypes.

## Fix
- Read `endTime` **before** the guard.
- No-op only when **neither** start nor end is present (`if (!startTime && !endTime) return`).
- Guard the `plannedStart` block on `startTime` (may now be null).
- Task (start+end) → unchanged (plannedStart=start, plannedEnd=end). Action (endTime only) → plannedEnd = date + endTime. No-time prototype → still no-op.

## Revert-verify ([[integration-test-revert-verify]])
New `proto-time-propagation.test.ts` scenario «prototype with only endTime → only plannedEnd (#3929)»:
- **RED** with the old `if (!startTime) return` (empirically confirmed: 1 failed / 6 passed).
- **GREEN** restored. The 6 pre-existing scenarios stay GREEN both ways.

## Local gates
- `proto-time-propagation` + `GroundingExecutor.test.ts` → 177 passed.
- `tsc --noEmit` core → 0 errors.
- 3 lint guard scripts (check-test-antipatterns / validate-shard-assignments / check-coverage-monotonic) → OK.

## Decision
Point-in-time prototype (only endTime) → `plannedEnd` (product-owner decision). Follow-up: 77 existing Action-instances for 2026-07-20..26 were stamped `plannedStart` via a workaround; will reconcile separately.

https://claude.ai/code/session_015ZQewB7cSJgqwTEwJjUcdY