### PR TITLE
feat(#3934): create co-locates by class-neighbour for bang-anchor assets

### DIFF
--- a/packages/cli/src/commands/create.ts
+++ b/packages/cli/src/commands/create.ts
@@ -16,7 +16,10 @@ import { EffortStatusResolver } from "../services/EffortStatusResolver.js";
 import { ErrorHandler } from "../utils/ErrorHandler.js";
 import { VaultNotFoundError } from "../utils/errors/index.js";
 import { registerOrderSpecFromVault } from "../services/registerOrderSpec.js";
-import { resolveCoLocationFolder } from "../executors/folderRepairHelpers.js";
+import {
+  resolveCoLocationFolder,
+  resolveNeighbourFolderByClass,
+} from "../executors/folderRepairHelpers.js";
 
 /**
  * Fallback folder for new assets whose `exo__Asset_isDefinedBy` cannot be
@@ -362,6 +365,28 @@ export function createCommand(): Command {
           // live under assetspaces/<ns>/).
           if (coLocatedFolder) {
             folderPath = coLocatedFolder;
+          }
+        }
+
+        // Priority 2 (issue #3934): when isDefinedBy did NOT resolve a folder
+        // (bang-anchor `[[!kitelev]]` / `[[!aiKnow]]`, empty, or unresolvable —
+        // folderPath is still the inbox default), co-locate the new asset next
+        // to existing sibling instances of the SAME class, deriving the folder
+        // from where those instances already live. Data-driven neighbour
+        // co-location (no hardcoded class→folder map): the product obeys the
+        // co-location invariant itself instead of requiring an explicit
+        // `--folder`. Fail-open to the inbox default when the class has no
+        // existing instances. `options.class` may be a UID or a short-name; it
+        // is matched (alongside the resolved classUid) against each instance's
+        // `exo__Instance_class` wikilink target in any of its forms.
+        if (folderPath === DEFAULT_INBOX_FOLDER) {
+          const neighbourFolder = await resolveNeighbourFolderByClass(
+            fsAdapter,
+            classUid,
+            options.class,
+          );
+          if (neighbourFolder) {
+            folderPath = neighbourFolder;
           }
         }
 

--- a/packages/cli/src/executors/folderRepairHelpers.ts
+++ b/packages/cli/src/executors/folderRepairHelpers.ts
@@ -150,6 +150,28 @@ export async function resolveCoLocationFolder(
  * branch (isDefinedBy already failed to resolve a folder), i.e. the rare
  * bang-anchor RFC/aiKnow create, so the cost is bounded to that path.
  */
+/**
+ * Resolve the wikilink *target* of one `exo__Instance_class` reference to a
+ * comparable token, robust to how YAML parsed it. A QUOTED wikilink
+ * (`"[[uid|label]]"`) parses to a string and goes straight through
+ * {@link extractAssetReference}. An UNQUOTED wikilink (`[[uid]]` /
+ * `- [[uid]]`) is treated by YAML as a nested flow-sequence and parses to a
+ * nested array (`["uid"]` / `[["uid"]]`) whose innermost string is the
+ * already-bracket-stripped linkpath — so descend to that string first, then run
+ * the same extractor (which also strips a `|alias` suffix). Returns null for
+ * anything that doesn't reduce to a string.
+ */
+function classRefTarget(ref: unknown): string | null {
+  let cur: unknown = ref;
+  while (Array.isArray(cur)) {
+    if (cur.length === 0) {
+      return null;
+    }
+    cur = cur[0];
+  }
+  return extractAssetReference(cur);
+}
+
 export async function resolveNeighbourFolderByClass(
   fsAdapter: NodeFsAdapter,
   classUid: string,
@@ -175,7 +197,7 @@ export async function resolveNeighbourFolderByClass(
     const rawClass = metadata["exo__Instance_class"];
     const refs = Array.isArray(rawClass) ? rawClass : [rawClass];
     const isSibling = refs.some((ref) => {
-      const target = extractAssetReference(ref);
+      const target = classRefTarget(ref);
       return target !== null && targets.has(target);
     });
     if (!isSibling) {

--- a/packages/cli/src/executors/folderRepairHelpers.ts
+++ b/packages/cli/src/executors/folderRepairHelpers.ts
@@ -120,3 +120,88 @@ export async function resolveCoLocationFolder(
   const dir = path.dirname(ontologyPath);
   return dir === "." ? "" : dir;
 }
+
+/**
+ * Resolve the co-location target folder for a NEW instance-asset by
+ * CLASS-neighbour (issue #3934) — the fail-open successor to
+ * {@link resolveCoLocationFolder} for the case where the asset's
+ * `exo__Asset_isDefinedBy` yields no folder (bang-anchor `[[!kitelev]]` /
+ * `[[!aiKnow]]`, empty, or unresolvable). Places the new asset next to its
+ * EXISTING sibling instances of the same class, deriving the folder from where
+ * instances already live — data-driven, with NO hardcoded class→folder map, so
+ * the product obeys the co-location invariant itself rather than requiring an
+ * explicit `--folder` (Andrey's design decision, #3934).
+ *
+ * A file is a sibling instance iff any value of its `exo__Instance_class`
+ * (a string OR a YAML list) resolves via {@link extractAssetReference} (the
+ * wikilink *target*) to the created asset's class UID OR its short-name label —
+ * matching bare-uid `[[uid]]`, alias `[[uid|label]]`, and label `[[label]]`
+ * forms uniformly. (The class-def file itself references the `exo__Class`
+ * metaclass, never this class UID, so it is never a false sibling.)
+ *
+ * Returns the vault-relative folder holding the MOST sibling instances (the
+ * canonical home; deterministic lexicographic tie-break), or `null` when the
+ * class has no existing instances anywhere in the vault. A root-level majority
+ * (`path.dirname` → ".") returns "" so the caller — whose truthiness check
+ * mirrors {@link resolveCoLocationFolder} — keeps its `01 Inbox` default rather
+ * than writing a brand-new asset to the vault root.
+ *
+ * This performs one full-vault frontmatter scan; it runs ONLY in the fail-open
+ * branch (isDefinedBy already failed to resolve a folder), i.e. the rare
+ * bang-anchor RFC/aiKnow create, so the cost is bounded to that path.
+ */
+export async function resolveNeighbourFolderByClass(
+  fsAdapter: NodeFsAdapter,
+  classUid: string,
+  classLabel: string,
+): Promise<string | null> {
+  const targets = new Set<string>();
+  if (classUid) targets.add(classUid);
+  if (classLabel) targets.add(classLabel);
+  if (targets.size === 0) {
+    return null;
+  }
+
+  const allFiles = await fsAdapter.getMarkdownFiles();
+  const folderCounts = new Map<string, number>();
+
+  for (const file of allFiles) {
+    let metadata: Record<string, unknown>;
+    try {
+      metadata = await fsAdapter.getFileMetadata(file);
+    } catch {
+      continue;
+    }
+    const rawClass = metadata["exo__Instance_class"];
+    const refs = Array.isArray(rawClass) ? rawClass : [rawClass];
+    const isSibling = refs.some((ref) => {
+      const target = extractAssetReference(ref);
+      return target !== null && targets.has(target);
+    });
+    if (!isSibling) {
+      continue;
+    }
+    const dir = path.dirname(file);
+    const folder = dir === "." ? "" : dir;
+    folderCounts.set(folder, (folderCounts.get(folder) ?? 0) + 1);
+  }
+
+  if (folderCounts.size === 0) {
+    return null;
+  }
+
+  // Canonical home = the folder with the most sibling instances. Iterate in a
+  // lexicographically-sorted order so ties resolve deterministically.
+  let best: string | null = null;
+  let bestCount = -1;
+  const sorted = Array.from(folderCounts.entries()).sort((a, b) =>
+    a[0] < b[0] ? -1 : a[0] > b[0] ? 1 : 0,
+  );
+  for (const [folder, count] of sorted) {
+    if (count > bestCount) {
+      best = folder;
+      bestCount = count;
+    }
+  }
+  return best;
+}

--- a/packages/cli/tests/integration/create-neighbour-co-location.integration.test.ts
+++ b/packages/cli/tests/integration/create-neighbour-co-location.integration.test.ts
@@ -1,0 +1,257 @@
+/**
+ * Issue #3934 — `cli create` must co-locate a new asset by CLASS-neighbour when
+ * `exo__Asset_isDefinedBy` yields no folder (a bang-anchor `[[!kitelev]]` /
+ * `[[!aiKnow]]`, empty, or unresolvable). Instead of the `01 Inbox/` fallback,
+ * the new asset is placed next to its EXISTING sibling instances of the same
+ * class — the folder derived from where those instances already live
+ * (data-driven, no hardcoded class→folder map; Andrey's design decision — the
+ * product obeys the co-location invariant itself, no `--folder` flag).
+ *
+ * Exercises the REAL `createCommand()` action end-to-end against a temp fixture
+ * vault (no service-level shortcut), parsing the command's JSON stdout
+ * (`{ uuid, path, label }`) and stat-ing where the file physically lands.
+ *
+ * Revert-verify (~/dotfiles/.claude/rules/integration-test-revert-verify.md):
+ * the "bang-anchor + sibling → neighbour folder" case FAILS pre-fix (the asset
+ * lands in `01 Inbox/`) and PASSES post-fix. Reverting the priority-2
+ * class-neighbour fallback in `create.ts` reds exactly this axis; the negative
+ * controls (resolvable-isDefinedBy priority-1 wins; no-sibling → inbox) stay
+ * green in both states, proving non-vacuity.
+ */
+import { jest, describe, it, expect, beforeEach, afterEach } from "@jest/globals";
+import * as fs from "fs";
+import * as path from "path";
+import * as os from "os";
+
+const { createCommand } = await import("../../src/commands/create.js");
+
+// Full-UUID class so `--class <uid>` pass-through fires deterministically and
+// the resolver's UID-index branches match without a class-def file.
+const CLASS_UID = "b0474610-5fa7-4ec4-a947-f85f26e93455";
+const CLASS_LABEL = "inbox__ExoAssistantKnowledge";
+// The sibling folder where existing instances of CLASS_UID already live.
+const SIBLING_DIR = "assetspaces/kitelev/exoas-exodev/inbox";
+// A second folder holding fewer siblings (for the majority-home case).
+const MINORITY_DIR = "assetspaces/kitelev/exoas-exodev/misc";
+// A resolvable ontology (priority-1) for the negative-control.
+const ONTOLOGY_UID = "32d2374c-aaaa-bbbb-cccc-000000000000";
+const ONTOLOGY_DIR = "assetspaces/kitelev/exoas-exodev/exodev";
+
+function md(frontmatter: Record<string, string | string[]>): string {
+  const lines = ["---"];
+  for (const [k, v] of Object.entries(frontmatter)) {
+    if (Array.isArray(v)) {
+      lines.push(`${k}:`);
+      for (const item of v) lines.push(`  - ${item}`);
+    } else {
+      lines.push(`${k}: ${v}`);
+    }
+  }
+  lines.push("---");
+  lines.push("");
+  return lines.join("\n");
+}
+
+/** Write a sibling instance of CLASS_UID at `dir/<uid>.md`, referencing the
+ *  class by the given wikilink form(s). */
+function writeSibling(
+  vault: string,
+  dir: string,
+  uid: string,
+  classRef: string | string[],
+): void {
+  const abs = path.join(vault, dir);
+  fs.mkdirSync(abs, { recursive: true });
+  fs.writeFileSync(
+    path.join(abs, `${uid}.md`),
+    md({
+      exo__Asset_uid: uid,
+      exo__Asset_isDefinedBy: '"[[!kitelev]]"',
+      exo__Instance_class: Array.isArray(classRef)
+        ? classRef.map((r) => `"${r}"`)
+        : `"${classRef}"`,
+      exo__Asset_label: `sibling ${uid}`,
+    }),
+  );
+}
+
+describe("Issue #3934: `cli create` co-locates by class-neighbour for bang-anchor assets", () => {
+  let vault: string;
+  let exitSpy: ReturnType<typeof jest.spyOn>;
+  let stdoutSpy: ReturnType<typeof jest.spyOn>;
+  let stderrSpy: ReturnType<typeof jest.spyOn>;
+  let logSpy: ReturnType<typeof jest.spyOn>;
+  let errorSpy: ReturnType<typeof jest.spyOn>;
+  let stdoutChunks: string[];
+  let exitCodes: number[];
+
+  beforeEach(() => {
+    vault = fs.mkdtempSync(path.join(os.tmpdir(), "cli-3934-"));
+    // Inbox default must exist for the fail-open cases.
+    fs.mkdirSync(path.join(vault, "01 Inbox"), { recursive: true });
+
+    stdoutChunks = [];
+    exitCodes = [];
+    exitSpy = jest
+      .spyOn(process, "exit")
+      .mockImplementation(((code?: number) => {
+        exitCodes.push(code ?? 0);
+        return undefined as never;
+      }) as never);
+    stdoutSpy = jest
+      .spyOn(process.stdout, "write")
+      .mockImplementation(((chunk: unknown) => {
+        stdoutChunks.push(String(chunk));
+        return true;
+      }) as never);
+    stderrSpy = jest
+      .spyOn(process.stderr, "write")
+      .mockImplementation((() => true) as never);
+    logSpy = jest.spyOn(console, "log").mockImplementation(() => {});
+    errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    exitSpy.mockRestore();
+    stdoutSpy.mockRestore();
+    stderrSpy.mockRestore();
+    logSpy.mockRestore();
+    errorSpy.mockRestore();
+    fs.rmSync(vault, { recursive: true, force: true });
+  });
+
+  async function runCreate(
+    classArg: string,
+    extraArgs: string[],
+  ): Promise<{ uuid: string; path: string; label: string }> {
+    const cmd = createCommand();
+    const argv = [
+      "--class",
+      classArg,
+      "--label",
+      "E2E-TEST neighbour co-location",
+      "--vault",
+      vault,
+      "--skip-wikilink-validation",
+      ...extraArgs,
+    ];
+    await cmd.parseAsync(argv, { from: "user" });
+
+    const stderrLog = errorSpy.mock.calls.flat().join("\n");
+    expect(exitCodes).toContain(0);
+    expect(exitCodes).not.toContain(1);
+    const json = stdoutChunks.join("").trim();
+    if (!json) {
+      throw new Error(`create emitted no stdout JSON. stderr: ${stderrLog}`);
+    }
+    return JSON.parse(json);
+  }
+
+  it("bang-anchor isDefinedBy + existing sibling instances → neighbour folder, not inbox @req:cec6af2c-420e-4a09-a5d3-6ecaf4c5413e", async () => {
+    // Two siblings in SIBLING_DIR: one references the class by BARE-uid form
+    // (like real inbox__ExoAssistantKnowledge), one by ALIAS form (like real
+    // aiKnow__Memory*) — both must be matched via extractAssetReference.
+    writeSibling(vault, SIBLING_DIR, "aaaaaaaa-0000-0000-0000-000000000001", `[[${CLASS_UID}]]`);
+    writeSibling(
+      vault,
+      SIBLING_DIR,
+      "aaaaaaaa-0000-0000-0000-000000000002",
+      `[[${CLASS_UID}|${CLASS_LABEL}]]`,
+    );
+
+    const result = await runCreate(CLASS_UID, [
+      "--property",
+      "exo__Asset_isDefinedBy=[[!kitelev]]",
+    ]);
+
+    expect(result.path).toBe(`${SIBLING_DIR}/${result.uuid}.md`);
+    expect(result.path.startsWith("01 Inbox/")).toBe(false);
+    expect(fs.existsSync(path.join(vault, result.path))).toBe(true);
+    expect(
+      fs.existsSync(path.join(vault, "01 Inbox", `${result.uuid}.md`)),
+    ).toBe(false);
+  });
+
+  it("negative control: resolvable isDefinedBy still wins (priority 1) even when class-neighbours exist elsewhere", async () => {
+    // A resolvable ontology anchor…
+    const ontologyDir = path.join(vault, ONTOLOGY_DIR);
+    fs.mkdirSync(ontologyDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(ontologyDir, `${ONTOLOGY_UID}.md`),
+      md({ exo__Asset_uid: ONTOLOGY_UID, exo__Asset_label: "$exodev" }),
+    );
+    // …plus class-neighbours in a DIFFERENT folder (must be ignored here).
+    writeSibling(vault, SIBLING_DIR, "aaaaaaaa-0000-0000-0000-000000000003", `[[${CLASS_UID}]]`);
+
+    const result = await runCreate(CLASS_UID, [
+      "--property",
+      `exo__Asset_isDefinedBy=[[${ONTOLOGY_UID}]]`,
+    ]);
+
+    expect(result.path).toBe(`${ONTOLOGY_DIR}/${result.uuid}.md`);
+    expect(result.path.startsWith(SIBLING_DIR)).toBe(false);
+    expect(result.path.startsWith("01 Inbox/")).toBe(false);
+  });
+
+  it("fail-open: bang-anchor but NO sibling instances of the class → inbox default", async () => {
+    // Vault has an UNRELATED-class instance, but zero instances of CLASS_UID.
+    writeSibling(
+      vault,
+      SIBLING_DIR,
+      "aaaaaaaa-0000-0000-0000-000000000004",
+      "[[cccccccc-1111-1111-1111-111111111111]]",
+    );
+
+    const result = await runCreate(CLASS_UID, [
+      "--property",
+      "exo__Asset_isDefinedBy=[[!kitelev]]",
+    ]);
+
+    expect(result.path).toBe(`01 Inbox/${result.uuid}.md`);
+    expect(fs.existsSync(path.join(vault, result.path))).toBe(true);
+  });
+
+  it("canonical home = the folder holding the MOST sibling instances", async () => {
+    // 2 siblings in SIBLING_DIR, 1 in MINORITY_DIR → SIBLING_DIR wins.
+    writeSibling(vault, SIBLING_DIR, "aaaaaaaa-0000-0000-0000-000000000005", `[[${CLASS_UID}]]`);
+    writeSibling(vault, SIBLING_DIR, "aaaaaaaa-0000-0000-0000-000000000006", `[[${CLASS_UID}]]`);
+    writeSibling(vault, MINORITY_DIR, "aaaaaaaa-0000-0000-0000-000000000007", `[[${CLASS_UID}]]`);
+
+    const result = await runCreate(CLASS_UID, [
+      "--property",
+      "exo__Asset_isDefinedBy=[[!kitelev]]",
+    ]);
+
+    expect(result.path).toBe(`${SIBLING_DIR}/${result.uuid}.md`);
+    expect(result.path.startsWith(MINORITY_DIR)).toBe(false);
+  });
+
+  it("class-neighbour matches the LABEL-form class ref via the short-name (classLabel branch)", async () => {
+    // A class-def so `--class <short-name>` resolves to CLASS_UID, and a
+    // sibling that references the class by LABEL form `[[<short-name>]]`.
+    const clsDir = path.join(vault, "assetspaces/kitelev/exoas-inbox/inbox");
+    fs.mkdirSync(clsDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(clsDir, `${CLASS_UID}.md`),
+      md({
+        exo__Asset_uid: CLASS_UID,
+        exo__Instance_class: '"[[exo__Class]]"',
+        exo__Asset_label: CLASS_LABEL,
+      }),
+    );
+    writeSibling(
+      vault,
+      SIBLING_DIR,
+      "aaaaaaaa-0000-0000-0000-000000000008",
+      `[[${CLASS_LABEL}]]`,
+    );
+
+    const result = await runCreate(CLASS_LABEL, [
+      "--property",
+      "exo__Asset_isDefinedBy=[[!kitelev]]",
+    ]);
+
+    expect(result.path).toBe(`${SIBLING_DIR}/${result.uuid}.md`);
+    expect(result.path.startsWith("01 Inbox/")).toBe(false);
+  });
+});

--- a/packages/cli/tests/integration/create-neighbour-co-location.integration.test.ts
+++ b/packages/cli/tests/integration/create-neighbour-co-location.integration.test.ts
@@ -53,13 +53,18 @@ function md(frontmatter: Record<string, string | string[]>): string {
 }
 
 /** Write a sibling instance of CLASS_UID at `dir/<uid>.md`, referencing the
- *  class by the given wikilink form(s). */
+ *  class by the given wikilink form(s). By default the class ref is QUOTED
+ *  (the product's own `create` output form); pass `{ quoted: false }` to write
+ *  the UNQUOTED form (common in hand-authored / raw-Write RFC/aiKnow assets). */
 function writeSibling(
   vault: string,
   dir: string,
   uid: string,
   classRef: string | string[],
+  opts: { quoted?: boolean } = {},
 ): void {
+  const quoted = opts.quoted !== false;
+  const q = (r: string): string => (quoted ? `"${r}"` : r);
   const abs = path.join(vault, dir);
   fs.mkdirSync(abs, { recursive: true });
   fs.writeFileSync(
@@ -68,8 +73,8 @@ function writeSibling(
       exo__Asset_uid: uid,
       exo__Asset_isDefinedBy: '"[[!kitelev]]"',
       exo__Instance_class: Array.isArray(classRef)
-        ? classRef.map((r) => `"${r}"`)
-        : `"${classRef}"`,
+        ? classRef.map(q)
+        : q(classRef),
       exo__Asset_label: `sibling ${uid}`,
     }),
   );
@@ -224,6 +229,42 @@ describe("Issue #3934: `cli create` co-locates by class-neighbour for bang-ancho
 
     expect(result.path).toBe(`${SIBLING_DIR}/${result.uuid}.md`);
     expect(result.path.startsWith(MINORITY_DIR)).toBe(false);
+  });
+
+  it("class-neighbour matches the UNQUOTED `- [[uid]]` list form (hand-authored assets)", async () => {
+    // Hand-authored / raw-Write RFC/aiKnow assets frequently write the class
+    // ref UNQUOTED, which YAML parses as a nested flow-sequence. The neighbour
+    // scan must still match it (the feature's own target population).
+    writeSibling(
+      vault,
+      SIBLING_DIR,
+      "aaaaaaaa-0000-0000-0000-000000000009",
+      `[[${CLASS_UID}]]`,
+      { quoted: false },
+    );
+
+    const result = await runCreate(CLASS_UID, [
+      "--property",
+      "exo__Asset_isDefinedBy=[[!kitelev]]",
+    ]);
+
+    expect(result.path).toBe(`${SIBLING_DIR}/${result.uuid}.md`);
+    expect(result.path.startsWith("01 Inbox/")).toBe(false);
+  });
+
+  it("tie-break: equal sibling counts across folders → lexicographically-smallest folder wins", async () => {
+    // 1 sibling each in MINORITY_DIR (…/misc) and SIBLING_DIR (…/inbox) →
+    // deterministic lexicographic tie-break picks "…/inbox" (< "…/misc").
+    writeSibling(vault, SIBLING_DIR, "aaaaaaaa-0000-0000-0000-00000000000a", `[[${CLASS_UID}]]`);
+    writeSibling(vault, MINORITY_DIR, "aaaaaaaa-0000-0000-0000-00000000000b", `[[${CLASS_UID}]]`);
+
+    const result = await runCreate(CLASS_UID, [
+      "--property",
+      "exo__Asset_isDefinedBy=[[!kitelev]]",
+    ]);
+
+    // "assetspaces/kitelev/exoas-exodev/inbox" < "…/misc" lexicographically.
+    expect(result.path).toBe(`${SIBLING_DIR}/${result.uuid}.md`);
   });
 
   it("class-neighbour matches the LABEL-form class ref via the short-name (classLabel branch)", async () => {


### PR DESCRIPTION
## What

`exocortex create` now co-locates a new asset by **class-neighbour** when `exo__Asset_isDefinedBy` yields no folder (bang-anchor `[[!kitelev]]` / `[[!aiKnow]]`, empty, or unresolvable) — instead of the `01 Inbox/` fallback. The asset is placed next to existing sibling instances of the same class, deriving the folder from where those instances already live.

Design (Andrey, issue #3934 comment 2026-07-25): **co-location by ontology/class, NOT a `--folder` flag** — the product enforces the co-location invariant itself. Rejected variant (a) `--folder` because it pushes the invariant onto the caller.

**Folder resolution priority:**
1. `exo__Asset_isDefinedBy` resolves to an on-disk ontology file → that ontology's folder (**unchanged**).
2. **NEW** — fallback for bang-anchor / empty / unresolvable isDefinedBy → **class-neighbour**: place next to existing sibling instances of the same class (data-driven; e.g. `inbox__ExoAssistantKnowledge`→`exoas-exodev/inbox/`, `aiKnow__Memory*`→`exoas-exoass/exoass/` — derived, not hardcoded).
3. Neither → `01 Inbox/` (fail-open preserved).

New `resolveNeighbourFolderByClass` helper (`folderRepairHelpers`) matches siblings by `extractAssetReference(exo__Instance_class) == class UID OR short-name label`, handling bare-uid `[[uid]]`, alias `[[uid|label]]`, and label `[[label]]` forms + YAML-list multi-valued class refs. Canonical home = the majority folder. Runs only in the fail-open branch (bounded to the rare bang-anchor RFC/aiKnow create).

## Why (dogfooding)

homoiconic-first precedence demands `create` first, raw `Write` only when the CLI truly can't. Today `create` mis-places RFC/aiKnow → forces raw `Write` past the product (onto-rfc / session-retrospective / vault-asset-creation exception #6). This closes that gap.

## Scope

`packages/cli` only — `packages/core` untouched.

## Spec + revert-verify

- **Req:** `cec6af2c-420e-4a09-a5d3-6ecaf4c5413e` (exoas-exo-reqs, Approved by Andrey)
- **Revert-verified** (`@req:cec6af2c-...`): disabling the priority-2 fallback → the 3 class-neighbour tests go RED (land in `01 Inbox/`); the 2 negative controls (resolvable-isDefinedBy priority-1 wins; no-sibling fail-open) stay GREEN → non-vacuity proven. Restore → 5/5 GREEN.
- Full co-location family regression: 94/94 green.

Closes #3934
