### PR TITLE
chore(deps): patch qs + uuid advisories (safe subset; brace-expansion deferred upstream)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "react-dom": "^19.2.3",
         "reflect-metadata": "^0.2.2",
         "tsyringe": "^4.10.0",
-        "uuid": "^13.0.0"
+        "uuid": "^13.0.1"
       },
       "devDependencies": {
         "@babel/core": "^7.28.5",
@@ -12944,13 +12944,14 @@
       "license": "MIT"
     },
     "node_modules/qs": {
-      "version": "6.15.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
-      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
-        "side-channel": "^1.1.0"
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
       },
       "engines": {
         "node": ">=0.6"
@@ -13523,15 +13524,15 @@
       }
     },
     "node_modules/side-channel": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
-      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3",
-        "side-channel-list": "^1.0.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
         "side-channel-map": "^1.0.1",
         "side-channel-weakmap": "^1.0.2"
       },
@@ -13543,14 +13544,14 @@
       }
     },
     "node_modules/side-channel-list": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
-      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3"
+        "object-inspect": "^1.13.4"
       },
       "engines": {
         "node": ">= 0.4"
@@ -14966,9 +14967,9 @@
       }
     },
     "node_modules/uuid": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.0.tgz",
-      "integrity": "sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==",
+      "version": "13.0.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.2.tgz",
+      "integrity": "sha512-vzi9uRZ926x4XV73S/4qQaTwPXM2JBj6/6lI/byHH1jOpCzb0zDbfytgA9LcN/hzb2l7WQSQnxITOVx5un/wGw==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"

--- a/package.json
+++ b/package.json
@@ -50,6 +50,9 @@
   ],
   "author": "A. Kitelev",
   "license": "MIT",
+  "overrides": {
+    "qs": "^6.15.3"
+  },
   "devDependencies": {
     "@babel/core": "^7.28.5",
     "@babel/preset-env": "^7.28.5",
@@ -106,6 +109,6 @@
     "react-dom": "^19.2.3",
     "reflect-metadata": "^0.2.2",
     "tsyringe": "^4.10.0",
-    "uuid": "^13.0.0"
+    "uuid": "^13.0.1"
   }
 }


### PR DESCRIPTION
## What

Patches the **two cleanly-fixable** `npm audit` advisories, WITHOUT the minimatch/brace-expansion force that broke the test pipeline in #3938.

- **qs** (GHSA-q8mj-m7cp-5q26, DoS) → override `^6.15.3` (transitive, API-stable).
- **uuid 13.0.0** (GHSA-w5hq-g745-h8pq, buffer bounds — the only **runtime** dep) → dependency `^13.0.0` → `^13.0.1` (in-range patch; transitive `uuid@11` untouched).

## Why not brace-expansion (deferred to upstream)

`brace-expansion ≤5.0.7` (the 36 high) cascades through the dev toolchain via nested old `minimatch`. Reaching patched `brace-expansion@5.x` requires `minimatch@10`, which **removed the callable default export** that jest+babel coverage tooling (istanbul / test-exclude) relies on — forcing it broke all 6 `test-coverage-shard` + `test-coverage-cli` (`minimatch is not a function`, #3938). The two API requirements are irreconcilable until upstream (jest / babel-plugin-istanbul / typescript-eslint) bump their minimatch usage. So it's **left for upstream**; the non-required `npm-audit` check stays red on the brace-expansion highs until then (does not block merge; `main`'s own run is green — predates the advisories).

## Safe — does NOT regress the test pipeline

`minimatch` stays at its baseline mix (3.x/8.x/9.x/10.x), so the coverage pipeline is intact. Validated: the two plugin suites #3938 broke (`PluginVaultCheckReader`, `LayoutServiceRowUri`) **pass**; `check:types` ✓. Full CI is the authoritative gate.

https://claude.ai/code/session_01Lzk1cejAQeEPsj6GtFQrRo