### PR TITLE
fix(#3934): class-neighbour co-location matches by isDefinedBy anchor too

### DIFF
--- a/packages/cli/src/commands/create.ts
+++ b/packages/cli/src/commands/create.ts
@@ -371,19 +371,25 @@ export function createCommand(): Command {
         // Priority 2 (issue #3934): when isDefinedBy did NOT resolve a folder
         // (bang-anchor `[[!kitelev]]` / `[[!aiKnow]]`, empty, or unresolvable —
         // folderPath is still the inbox default), co-locate the new asset next
-        // to existing sibling instances of the SAME class, deriving the folder
-        // from where those instances already live. Data-driven neighbour
-        // co-location (no hardcoded class→folder map): the product obeys the
-        // co-location invariant itself instead of requiring an explicit
-        // `--folder`. Fail-open to the inbox default when the class has no
-        // existing instances. `options.class` may be a UID or a short-name; it
-        // is matched (alongside the resolved classUid) against each instance's
+        // to existing sibling instances that share BOTH the SAME class AND the
+        // SAME isDefinedBy anchor, deriving the folder from where those siblings
+        // already live. Data-driven neighbour co-location (no hardcoded
+        // class→folder map): the product obeys the co-location invariant itself
+        // instead of requiring an explicit `--folder`. Matching on the anchor
+        // too (not class alone) is required because one class can span homes —
+        // e.g. `inbox__ExoAssistantKnowledge` is used for RFCs (`[[!kitelev]]` →
+        // exodev/inbox) AND for ExoAssistant infra knowledge (resolvable
+        // isDefinedBy → exoass); class alone would let the latter outvote the
+        // RFCs. Fail-open to the inbox default when no class+anchor sibling
+        // exists. `options.class` may be a UID or a short-name; it is matched
+        // (alongside the resolved classUid) against each instance's
         // `exo__Instance_class` wikilink target in any of its forms.
         if (folderPath === DEFAULT_INBOX_FOLDER) {
           const neighbourFolder = await resolveNeighbourFolderByClass(
             fsAdapter,
             classUid,
             options.class,
+            isDefinedBy,
           );
           if (neighbourFolder) {
             folderPath = neighbourFolder;

--- a/packages/cli/src/executors/folderRepairHelpers.ts
+++ b/packages/cli/src/executors/folderRepairHelpers.ts
@@ -122,46 +122,18 @@ export async function resolveCoLocationFolder(
 }
 
 /**
- * Resolve the co-location target folder for a NEW instance-asset by
- * CLASS-neighbour (issue #3934) — the fail-open successor to
- * {@link resolveCoLocationFolder} for the case where the asset's
- * `exo__Asset_isDefinedBy` yields no folder (bang-anchor `[[!kitelev]]` /
- * `[[!aiKnow]]`, empty, or unresolvable). Places the new asset next to its
- * EXISTING sibling instances of the same class, deriving the folder from where
- * instances already live — data-driven, with NO hardcoded class→folder map, so
- * the product obeys the co-location invariant itself rather than requiring an
- * explicit `--folder` (Andrey's design decision, #3934).
- *
- * A file is a sibling instance iff any value of its `exo__Instance_class`
- * (a string OR a YAML list) resolves via {@link extractAssetReference} (the
- * wikilink *target*) to the created asset's class UID OR its short-name label —
- * matching bare-uid `[[uid]]`, alias `[[uid|label]]`, and label `[[label]]`
- * forms uniformly. (The class-def file itself references the `exo__Class`
- * metaclass, never this class UID, so it is never a false sibling.)
- *
- * Returns the vault-relative folder holding the MOST sibling instances (the
- * canonical home; deterministic lexicographic tie-break), or `null` when the
- * class has no existing instances anywhere in the vault. A root-level majority
- * (`path.dirname` → ".") returns "" so the caller — whose truthiness check
- * mirrors {@link resolveCoLocationFolder} — keeps its `01 Inbox` default rather
- * than writing a brand-new asset to the vault root.
- *
- * This performs one full-vault frontmatter scan; it runs ONLY in the fail-open
- * branch (isDefinedBy already failed to resolve a folder), i.e. the rare
- * bang-anchor RFC/aiKnow create, so the cost is bounded to that path.
- */
-/**
- * Resolve the wikilink *target* of one `exo__Instance_class` reference to a
+ * Resolve the wikilink *target* of a single frontmatter reference to a
  * comparable token, robust to how YAML parsed it. A QUOTED wikilink
  * (`"[[uid|label]]"`) parses to a string and goes straight through
- * {@link extractAssetReference}. An UNQUOTED wikilink (`[[uid]]` /
- * `- [[uid]]`) is treated by YAML as a nested flow-sequence and parses to a
- * nested array (`["uid"]` / `[["uid"]]`) whose innermost string is the
- * already-bracket-stripped linkpath — so descend to that string first, then run
- * the same extractor (which also strips a `|alias` suffix). Returns null for
- * anything that doesn't reduce to a string.
+ * {@link extractAssetReference}. An UNQUOTED wikilink (`[[uid]]` / `- [[uid]]`)
+ * is treated by YAML as a nested flow-sequence and parses to a nested array
+ * (`["uid"]` / `[["uid"]]`) whose innermost string is the already-bracket-
+ * stripped linkpath — so descend to that string first, then run the same
+ * extractor (which also strips a `|alias` suffix). Returns null for anything
+ * that doesn't reduce to a string. Used for both `exo__Instance_class` refs and
+ * the `exo__Asset_isDefinedBy` anchor.
  */
-function classRefTarget(ref: unknown): string | null {
+function wikilinkTarget(ref: unknown): string | null {
   let cur: unknown = ref;
   while (Array.isArray(cur)) {
     if (cur.length === 0) {
@@ -172,10 +144,53 @@ function classRefTarget(ref: unknown): string | null {
   return extractAssetReference(cur);
 }
 
+/**
+ * Resolve the co-location target folder for a NEW instance-asset by
+ * CLASS-and-ANCHOR neighbour (issue #3934) — the fail-open successor to
+ * {@link resolveCoLocationFolder} for the case where the asset's
+ * `exo__Asset_isDefinedBy` yields no folder (bang-anchor `[[!kitelev]]` /
+ * `[[!aiKnow]]`, empty, or unresolvable). Places the new asset next to its
+ * EXISTING sibling instances, deriving the folder from where they already live —
+ * data-driven, with NO hardcoded class→folder map, so the product obeys the
+ * co-location invariant itself rather than requiring an explicit `--folder`
+ * (Andrey's design decision, #3934).
+ *
+ * A file is a sibling iff BOTH:
+ *   1. any value of its `exo__Instance_class` (a string OR a YAML list) resolves
+ *      via {@link wikilinkTarget} to the created asset's class UID OR its
+ *      short-name label — matching bare-uid `[[uid]]`, alias `[[uid|label]]`,
+ *      and label `[[label]]` forms uniformly (the class-def file references the
+ *      `exo__Class` metaclass, never this class UID, so it is never a false
+ *      sibling); AND
+ *   2. its `exo__Asset_isDefinedBy` resolves to the SAME anchor as the new
+ *      asset's (`newAnchor` = {@link wikilinkTarget} of the new isDefinedBy,
+ *      e.g. `!kitelev` / `!aiKnow`, or null for an empty isDefinedBy).
+ *
+ * The anchor is the audience/home signal: a single class can span multiple
+ * homes (e.g. `inbox__ExoAssistantKnowledge` is used both for RFCs anchored
+ * `[[!kitelev]]` living in `exoas-exodev/inbox/` AND for ExoAssistant infra
+ * knowledge anchored to the resolvable `$exoass` ontology living in
+ * `exoas-exoass/exoass/`). Matching class ALONE would let the larger, differently-
+ * anchored population outvote the true neighbours; matching class AND the same
+ * anchor selects exactly the assets whose placement was governed by the same
+ * (unresolvable/bang) anchor as the new one. The resolvable-isDefinedBy assets
+ * co-located via priority-1 never share a bang anchor, so they are excluded.
+ *
+ * Returns the vault-relative folder holding the MOST such siblings (canonical
+ * home; deterministic lexicographic tie-break), or `null` when no class+anchor
+ * sibling exists. A root-level majority (`path.dirname` → ".") returns "" so the
+ * caller — whose truthiness check mirrors {@link resolveCoLocationFolder} —
+ * keeps its `01 Inbox` default rather than writing to the vault root.
+ *
+ * One full-vault frontmatter scan; runs ONLY in the fail-open branch
+ * (isDefinedBy already failed to resolve a folder), so the cost is bounded to
+ * the rare bang-anchor RFC/aiKnow create.
+ */
 export async function resolveNeighbourFolderByClass(
   fsAdapter: NodeFsAdapter,
   classUid: string,
   classLabel: string,
+  isDefinedBy: unknown,
 ): Promise<string | null> {
   const targets = new Set<string>();
   if (classUid) targets.add(classUid);
@@ -183,6 +198,9 @@ export async function resolveNeighbourFolderByClass(
   if (targets.size === 0) {
     return null;
   }
+  // The new asset's audience anchor (`!kitelev` / `!aiKnow` / an unresolvable
+  // uid, or null for empty). Only siblings sharing this exact anchor count.
+  const newAnchor = wikilinkTarget(isDefinedBy);
 
   const allFiles = await fsAdapter.getMarkdownFiles();
   const folderCounts = new Map<string, number>();
@@ -194,10 +212,15 @@ export async function resolveNeighbourFolderByClass(
     } catch {
       continue;
     }
+    // 2. same isDefinedBy anchor as the new asset.
+    if (wikilinkTarget(metadata["exo__Asset_isDefinedBy"]) !== newAnchor) {
+      continue;
+    }
+    // 1. class matches (any wikilink form, list-aware).
     const rawClass = metadata["exo__Instance_class"];
     const refs = Array.isArray(rawClass) ? rawClass : [rawClass];
     const isSibling = refs.some((ref) => {
-      const target = classRefTarget(ref);
+      const target = wikilinkTarget(ref);
       return target !== null && targets.has(target);
     });
     if (!isSibling) {
@@ -212,7 +235,7 @@ export async function resolveNeighbourFolderByClass(
     return null;
   }
 
-  // Canonical home = the folder with the most sibling instances. Iterate in a
+  // Canonical home = the folder with the most siblings. Iterate in a
   // lexicographically-sorted order so ties resolve deterministically.
   let best: string | null = null;
   let bestCount = -1;

--- a/packages/cli/tests/integration/create-neighbour-co-location.integration.test.ts
+++ b/packages/cli/tests/integration/create-neighbour-co-location.integration.test.ts
@@ -54,24 +54,27 @@ function md(frontmatter: Record<string, string | string[]>): string {
 
 /** Write a sibling instance of CLASS_UID at `dir/<uid>.md`, referencing the
  *  class by the given wikilink form(s). By default the class ref is QUOTED
- *  (the product's own `create` output form); pass `{ quoted: false }` to write
- *  the UNQUOTED form (common in hand-authored / raw-Write RFC/aiKnow assets). */
+ *  (the product's own `create` output form) and the isDefinedBy anchor is
+ *  `[[!kitelev]]`; pass `{ quoted: false }` to write the UNQUOTED class-ref form
+ *  (common in hand-authored / raw-Write RFC/aiKnow assets), or `{ isDefinedBy }`
+ *  to give the sibling a different anchor. */
 function writeSibling(
   vault: string,
   dir: string,
   uid: string,
   classRef: string | string[],
-  opts: { quoted?: boolean } = {},
+  opts: { quoted?: boolean; isDefinedBy?: string } = {},
 ): void {
   const quoted = opts.quoted !== false;
   const q = (r: string): string => (quoted ? `"${r}"` : r);
+  const anchor = opts.isDefinedBy ?? "[[!kitelev]]";
   const abs = path.join(vault, dir);
   fs.mkdirSync(abs, { recursive: true });
   fs.writeFileSync(
     path.join(abs, `${uid}.md`),
     md({
       exo__Asset_uid: uid,
-      exo__Asset_isDefinedBy: '"[[!kitelev]]"',
+      exo__Asset_isDefinedBy: `"${anchor}"`,
       exo__Instance_class: Array.isArray(classRef)
         ? classRef.map(q)
         : q(classRef),
@@ -227,6 +230,33 @@ describe("Issue #3934: `cli create` co-locates by class-neighbour for bang-ancho
       "exo__Asset_isDefinedBy=[[!kitelev]]",
     ]);
 
+    expect(result.path).toBe(`${SIBLING_DIR}/${result.uuid}.md`);
+    expect(result.path.startsWith(MINORITY_DIR)).toBe(false);
+  });
+
+  it("anchor-discrimination: only siblings sharing the SAME isDefinedBy anchor count (a class can span homes) @req:cec6af2c-420e-4a09-a5d3-6ecaf4c5413e", async () => {
+    // Reproduces the real vault shape for inbox__ExoAssistantKnowledge: the SAME
+    // class C is used both for RFCs anchored [[!kitelev]] (few, in SIBLING_DIR)
+    // AND for infra assets with a DIFFERENT (resolvable-style) anchor (MANY, in
+    // MINORITY_DIR). Class-alone majority would pick the MANY (wrong folder);
+    // matching class AND the same [[!kitelev]] anchor must pick SIBLING_DIR.
+    // 1 same-anchor sibling in SIBLING_DIR:
+    writeSibling(vault, SIBLING_DIR, "aaaaaaaa-0000-0000-0000-0000000000c1", `[[${CLASS_UID}]]`, {
+      isDefinedBy: "[[!kitelev]]",
+    });
+    // 3 DIFFERENT-anchor siblings of the same class in MINORITY_DIR (outnumber):
+    for (const n of ["c2", "c3", "c4"]) {
+      writeSibling(vault, MINORITY_DIR, `aaaaaaaa-0000-0000-0000-0000000000${n}`, `[[${CLASS_UID}]]`, {
+        isDefinedBy: "[[32d2374c-aaaa-bbbb-cccc-000000000000]]",
+      });
+    }
+
+    const result = await runCreate(CLASS_UID, [
+      "--property",
+      "exo__Asset_isDefinedBy=[[!kitelev]]",
+    ]);
+
+    // The lone [[!kitelev]] sibling wins over the 3 differently-anchored ones.
     expect(result.path).toBe(`${SIBLING_DIR}/${result.uuid}.md`);
     expect(result.path.startsWith(MINORITY_DIR)).toBe(false);
   });


### PR DESCRIPTION
## What

Follow-up to #3937 (issue #3934). Refines the class-neighbour co-location to match siblings by **class AND the same `isDefinedBy` anchor** — not class alone.

## Why (DoD-verify caught this on the real vault)

The class-only majority in #3937 mis-places `inbox__ExoAssistantKnowledge`:
- **284** non-RFC ExoAssistant infra assets (validators/reports/domain-indexes) with a *resolvable* `isDefinedBy` (the `$exoass` anchor → co-located to `exoas-exoass/exoass/` via priority-1) …
- …**outvote** the **66** RFCs anchored `[[!kitelev]]` in `exoas-exodev/inbox/`.

So a new RFC (`inbox__ExoAssistantKnowledge` + `[[!kitelev]]`) landed in `exoas-exoass/exoass/` instead of `exoas-exodev/inbox/` — contradicting the DoD.

**Root cause:** one class can span homes; the `isDefinedBy` **anchor** is the audience/home signal. `resolveNeighbourFolderByClass` now counts a file as a sibling only when it shares **both** the same class **and** the same anchor as the new asset.

## Verified on the real vault (dry-run)

| create | folder |
|---|---|
| `inbox__ExoAssistantKnowledge` + `[[!kitelev]]` | `exoas-exodev/inbox/` ✅ (65/65 siblings) |
| `aiKnow__MemoryFeedback` + `[[!aiKnow]]` | `exoas-exoass/exoass/` ✅ (239/239 siblings) |

= exactly the DoD outcomes. Still data-driven (no hardcoded class→folder map).

## Spec + revert-verify

- **Req:** `cec6af2c-420e-4a09-a5d3-6ecaf4c5413e` (Active — this fix brings the implementation into conformance with its Gherkin "same anchor" scenario).
- **Revert-verified** (`@req:cec6af2c-...`): disabling the anchor filter → the anchor-discrimination test goes RED (picks the more-numerous different-anchor folder); disabling the priority-2 fallback → the class-neighbour tests go RED; restore → 8/8 GREEN.
- `classRefTarget` → `wikilinkTarget` (now serves both class refs and isDefinedBy; keeps the unquoted-form handling from #3937).

Scope: `packages/cli` only. Relates #3934.
