### PR TITLE
feat(concept): homoiconic definition-renderer — concept__Concept_definition as a computed view from genus+differentia (Delta-2, req eb18a3a4)

### DIFF
--- a/packages/obsidian-plugin/src/ExocortexPlugin.ts
+++ b/packages/obsidian-plugin/src/ExocortexPlugin.ts
@@ -127,6 +127,7 @@ import { InlineTitlePatch } from "./presentation/tab-titles/InlineTitlePatch";
 import { PropertiesLinkPatch } from "./presentation/properties/PropertiesLinkPatch";
 import { PropertiesUidCopyPatch } from "./presentation/properties/PropertiesUidCopyPatch";
 import { PropertiesLabelPatch } from "./presentation/properties/PropertiesLabelPatch";
+import { PropertiesDefinitionValuePatch } from "./presentation/properties/PropertiesDefinitionValuePatch";
 import { FileExplorerLabelPatch } from "./presentation/fileexplorer/FileExplorerLabelPatch";
 import { FileExplorerIconPatch } from "./presentation/fileexplorer/FileExplorerIconPatch";
 import { IconizeDetector } from "./presentation/fileexplorer/IconizeDetector";
@@ -379,6 +380,7 @@ export default class ExocortexPlugin extends Plugin {
   private bodyLinkPatch!: BodyLinkPatch;
   private propertiesUidCopyPatch!: PropertiesUidCopyPatch;
   private propertiesLabelPatch!: PropertiesLabelPatch;
+  private propertiesDefinitionValuePatch!: PropertiesDefinitionValuePatch;
   private fileExplorerLabelPatch!: FileExplorerLabelPatch;
   private fileExplorerIconPatch!: FileExplorerIconPatch;
   private readingModeEnforcer!: ReadingModeEnforcer;
@@ -1818,6 +1820,21 @@ export default class ExocortexPlugin extends Plugin {
         500,
       );
 
+      // Initialize Properties concept-definition value patch (Delta-2 of concept-typization,
+      // req eb18a3a4). Renders a concept's concept__Concept_definition as a COMPUTED VIEW
+      // "<differentia> <genus>" in the native Properties block (Reading Mode) where genus is
+      // present; the stored free-text is left untouched where genus is absent
+      // (materialized-OR-computed). Always enabled — a no-op until a concept declares a genus
+      // (dormant until the Delta-3 instance migration produces typed concepts).
+      this.propertiesDefinitionValuePatch = new PropertiesDefinitionValuePatch(this);
+      this.timerManager.setTimeout(
+        "properties-definition-value-patch",
+        () => {
+          this.propertiesDefinitionValuePatch.enable();
+        },
+        500,
+      );
+
       // Initialize File Explorer readable-label patch (always enabled).
       // Replaces UUID filenames in the sidebar with `exo__Asset_label`.
       // Finding: Ваня Холькин UX audit 2026-04-12 09:32 — «Структура уродская»;
@@ -1989,6 +2006,11 @@ export default class ExocortexPlugin extends Plugin {
     // Cleanup Properties readable-label patch
     if (this.propertiesLabelPatch) {
       this.propertiesLabelPatch.cleanup();
+    }
+
+    // Cleanup Properties concept-definition value patch (Delta-2)
+    if (this.propertiesDefinitionValuePatch) {
+      this.propertiesDefinitionValuePatch.cleanup();
     }
 
     // Cleanup File Explorer readable-label patch

--- a/packages/obsidian-plugin/src/domain/concept-definition/ConceptDefinitionResolver.ts
+++ b/packages/obsidian-plugin/src/domain/concept-definition/ConceptDefinitionResolver.ts
@@ -1,43 +1,38 @@
+import { DisplayNameTemplateEngine } from "@plugin/domain/display-name/DisplayNameTemplateEngine";
+
 /**
- * ConceptDefinitionResolver — a concept's `concept__Concept_definition` as a homoiconic
- * COMPUTED VIEW from its intensional structure (genus + differentia), the analog of
- * DisplayNameResolver over exo__DisplayNameSpec (Delta-2 of concept-typization,
- * req eb18a3a4). Aristotelian transparency: you declare `concept__Concept_genus` +
- * `concept__Concept_differentia` and the definition renders — you never hand-write it
- * (where a clean genus exists).
+ * ConceptDefinitionResolver — a THIN interpreter of a VAULT-DECLARED concept-definition
+ * composition. The composition template ("<differentia> <genus>", order, separators) is NOT
+ * hardcoded here — it is declared as vault data (a `concept__ConceptDefinitionSpec` + ordered
+ * `exo__PrintedProperty`/`exo__PrintedLiteral` parts, loaded by ConceptDefinitionSpecService and
+ * compiled to a `DisplayNameTemplateEngine` template). This resolver only:
+ *   1. applies the materialized-OR-computed + fail-closed CONTRACT (the Q3 interpreter rule), and
+ *   2. renders the vault template via DisplayNameTemplateEngine (the reused homoiconic engine).
+ * Delta-2 of concept-typization (req eb18a3a4), the analog of DisplayNameResolver over
+ * exo__DisplayNameSpec — here targeting the `concept__Concept_definition` VALUE, not the title.
  *
- * Semantics — MATERIALIZED-OR-COMPUTED (RFC b860de33 revision F1; ~70% of stored
- * definitions carry non-reconstructible narrative and must be preserved):
- *  - genus PRESENT  → COMPUTED "<differentia labels joined by space> <genus label>"
- *      (differentia in authored order, then the genus). Each genus/differentia value is
- *      an ObjectProperty `[[uid]]` wikilink resolved 1-hop to its exo__Asset_label — the
- *      SAME resolution exo__PrintedProperty uses (see DisplayNameTemplateEngine
- *      .formatWikilinkValue). The rare conjunctive upper-ontology genus (≥2 genus values)
- *      renders "<differentia> [genus₁ ∧ genus₂]".
- *  - genus ABSENT   → the STORED free-text `concept__Concept_definition` is returned
- *      unchanged (materialized narrative).
- *  - FAIL-CLOSED    → genus absent AND no stored free-text → null. A definition is never
- *      fabricated.
+ * Semantics (materialized-OR-computed, fail-closed):
+ *  - genus PRESENT (resolves to ≥1 clean label) → the definition is COMPUTED by rendering the
+ *    vault template (each genus/differentia `[[uid]]` resolved 1-hop to its exo__Asset_label; a
+ *    multi-valued differentia joins all adjectives via the engine's opt-in joinArrayValues).
+ *  - genus ABSENT / resolves only to a bare UID → the definition is NOT computed → the caller
+ *    falls through to the STORED free-text `concept__Concept_definition` (materialized narrative).
+ *  - no vault template (spec not authored) → not computed → stored fallback.
+ *  - FAIL-CLOSED: never fabricate a definition from a raw UID or over a good stored narrative.
  *
- * Pure domain unit — no Obsidian dependency. The 1-hop label resolution is delegated to
- * an injected MetadataResolver (wikilink target → its frontmatter), exactly as
- * DisplayNameResolver receives one from PrintNameRuleService.createMetadataResolver().
+ * Pure domain unit — the 1-hop label resolution is delegated to an injected MetadataResolver.
  */
 
 /** Resolve a wikilink target to the referenced asset's frontmatter (or null). */
 export type MetadataResolver = (wikilinkTarget: string) => Record<string, unknown> | null;
 
-// Frontmatter keys of the Delta-1 concept-typization TBox properties.
+// Frontmatter keys of the Delta-1 concept-typization TBox.
 const GENUS_KEY = "concept__Concept_genus";
-const DIFFERENTIA_KEY = "concept__Concept_differentia";
 const DEFINITION_KEY = "concept__Concept_definition";
 
-// Conjunction glyph for the rare multi-genus (upper-ontology) case: "<diff> [g₁ ∧ g₂]".
-const CONJUNCTION = " ∧ ";
-
-// A UID-shaped value is NOT a usable definition token — a genus/differentia that resolves ONLY
-// to a raw UID (target deleted/renamed, or metadataCache lag) must fail closed (fall through to
-// the stored narrative), never render the 36-char UID over a good stored definition.
+// A UID-shaped value is NOT a usable definition token — a genus that resolves ONLY to a raw UID
+// (target deleted/renamed, or metadataCache lag) must fail closed (fall through to the stored
+// narrative), never render the 36-char UID over a good stored definition.
 const UUID_REGEX =
   /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/;
 
@@ -46,39 +41,37 @@ export class ConceptDefinitionResolver {
 
   /**
    * The effective definition (materialized-OR-computed, fail-closed):
-   *  - genus present → the COMPUTED phrase; genus absent → the STORED free-text; neither → null.
-   * Callers that want the definition to display (materialized case included) use this.
+   *  - genus present + a vault template → the COMPUTED phrase;
+   *  - else → the STORED free-text; else → null.
+   * `template` is the vault-declared composition template (from ConceptDefinitionSpecService), or
+   * null when no spec is authored.
    */
-  resolve(metadata: Record<string, unknown>): string | null {
-    return this.resolveComputed(metadata) ?? this.storedDefinition(metadata[DEFINITION_KEY]);
+  resolve(metadata: Record<string, unknown>, template: string | null): string | null {
+    return this.resolveComputed(metadata, template) ?? this.storedDefinition(metadata[DEFINITION_KEY]);
   }
 
   /**
-   * The COMPUTED "<differentia> <genus>" phrase, or null when genus is absent (so a caller
-   * can distinguish "computed" from "stored/materialized"). The Properties-panel value patch
-   * uses this: it OVERRIDES the native definition row ONLY when a computed value exists,
-   * leaving the stored free-text row untouched when genus is absent.
+   * The COMPUTED definition rendered from the VAULT-DECLARED template, or null when the definition
+   * should fall through to the stored narrative (no template, no genus, or genus resolves only to
+   * a bare UID). The Properties-panel value patch uses this: it OVERRIDES the native definition
+   * row ONLY when a computed value exists, leaving the stored free-text untouched otherwise.
    */
-  resolveComputed(metadata: Record<string, unknown>): string | null {
-    const genusLabels = this.resolveWikilinkLabels(metadata[GENUS_KEY]);
-    if (genusLabels.length === 0) return null;
-    const differentiaLabels = this.resolveWikilinkLabels(metadata[DIFFERENTIA_KEY]);
-    return this.compose(differentiaLabels, genusLabels);
-  }
+  resolveComputed(metadata: Record<string, unknown>, template: string | null): string | null {
+    if (!template) return null; // no vault spec authored → materialized (stored) path
+    // Fail-closed gate: genus must resolve to ≥1 clean label (absent / only-bare-UID → stored).
+    if (this.resolveWikilinkLabels(metadata[GENUS_KEY]).length === 0) return null;
 
-  /**
-   * Compose "<differentia labels> <genus part>". The genus part is the single genus label,
-   * or — for the rare conjunctive upper-ontology genus — "[g₁ ∧ g₂ …]". Differentia labels
-   * (already in authored order) join as space-separated adjectives BEFORE the genus, so
-   * differentia=[recurring, quarterly] + genus=OKR → "recurring quarterly OKR".
-   */
-  private compose(differentiaLabels: string[], genusLabels: string[]): string {
-    const genusPart =
-      genusLabels.length >= 2
-        ? `[${genusLabels.join(CONJUNCTION)}]`
-        : genusLabels[0];
-    const differentiaPart = differentiaLabels.join(" ");
-    return differentiaPart ? `${differentiaPart} ${genusPart}` : genusPart;
+    // Render the vault-declared composition template (order/parts/separators = vault data). The
+    // engine resolves each {{property}} 1-hop; joinArrayValues renders a multi-valued differentia
+    // as all adjectives joined (dropping bare-UID values), while leaving the displayName path
+    // (default first-only) unchanged.
+    const rendered = new DisplayNameTemplateEngine(template, { joinArrayValues: true }).render(
+      metadata,
+      "",
+      undefined,
+      this.metadataResolver ?? undefined,
+    );
+    return rendered && rendered.trim() ? rendered : null;
   }
 
   /** A stored free-text definition, trimmed non-empty, else null (fail-closed). */
@@ -91,12 +84,17 @@ export class ConceptDefinitionResolver {
   }
 
   /**
-   * Resolve a genus/differentia field (a single wikilink OR an array of wikilinks) into an
-   * ordered list of the referenced assets' exo__Asset_label — dropping any value that
-   * yields no label. The 1-hop resolution mirrors exo__PrintedProperty.
+   * Resolve a genus field (a single wikilink OR an array) into the referenced assets'
+   * exo__Asset_label — dropping any value that resolves only to a bare UID. Used ONLY for the
+   * fail-closed gate (whether genus is meaningfully present); the composition itself is rendered
+   * by the engine from the vault template.
    */
   private resolveWikilinkLabels(value: unknown): string[] {
-    const raw = Array.isArray(value) ? value : value === undefined || value === null ? [] : [value];
+    const raw = Array.isArray(value)
+      ? value
+      : value === undefined || value === null
+        ? []
+        : [value];
     const labels: string[] = [];
     for (const item of raw) {
       const label = this.resolveWikilinkLabel(item);
@@ -110,8 +108,7 @@ export class ConceptDefinitionResolver {
    * DisplayNameTemplateEngine.formatWikilinkValue, plus a FAIL-CLOSED guard):
    *  - "[[target|alias]]"        → alias
    *  - "[[target]]" + resolver   → the referenced asset's exo__Asset_label
-   *  - "[[<uid>]]" with no label  → null (FAIL-CLOSED — a raw UID is never a definition token,
-   *                                 so resolveComputed falls through to the stored narrative)
+   *  - "[[<uid>]]" with no label  → null (FAIL-CLOSED — a raw UID is never a definition token)
    *  - "[[target]]" non-UID bare  → target (a symbolic label, kept)
    *  - a non-wikilink string     → the string itself (a literal label; a bare UID → null)
    */
@@ -122,7 +119,6 @@ export class ConceptDefinitionResolver {
 
     const match = trimmed.match(/^\[\[([^\]|]+?)(?:\|([^\]]+))?\]\]$/);
     if (!match) {
-      // Not a wikilink — a literal label. A bare UID is not a usable token (fail-closed).
       const bare = trimmed.replace(/^\[\[|\]\]$/g, "").trim();
       if (!bare) return null;
       return UUID_REGEX.test(bare) ? null : bare;
@@ -138,8 +134,6 @@ export class ConceptDefinitionResolver {
       if (typeof label === "string" && label.trim()) return label.trim();
     }
 
-    // No alias, no resolvable label: a bare UID fails closed (null → fall through to stored);
-    // a non-UID symbolic target is kept as its own label.
     if (!target) return null;
     return UUID_REGEX.test(target) ? null : target;
   }

--- a/packages/obsidian-plugin/src/domain/concept-definition/ConceptDefinitionResolver.ts
+++ b/packages/obsidian-plugin/src/domain/concept-definition/ConceptDefinitionResolver.ts
@@ -1,0 +1,134 @@
+/**
+ * ConceptDefinitionResolver — a concept's `concept__Concept_definition` as a homoiconic
+ * COMPUTED VIEW from its intensional structure (genus + differentia), the analog of
+ * DisplayNameResolver over exo__DisplayNameSpec (Delta-2 of concept-typization,
+ * req eb18a3a4). Aristotelian transparency: you declare `concept__Concept_genus` +
+ * `concept__Concept_differentia` and the definition renders — you never hand-write it
+ * (where a clean genus exists).
+ *
+ * Semantics — MATERIALIZED-OR-COMPUTED (RFC b860de33 revision F1; ~70% of stored
+ * definitions carry non-reconstructible narrative and must be preserved):
+ *  - genus PRESENT  → COMPUTED "<differentia labels joined by space> <genus label>"
+ *      (differentia in authored order, then the genus). Each genus/differentia value is
+ *      an ObjectProperty `[[uid]]` wikilink resolved 1-hop to its exo__Asset_label — the
+ *      SAME resolution exo__PrintedProperty uses (see DisplayNameTemplateEngine
+ *      .formatWikilinkValue). The rare conjunctive upper-ontology genus (≥2 genus values)
+ *      renders "<differentia> [genus₁ ∧ genus₂]".
+ *  - genus ABSENT   → the STORED free-text `concept__Concept_definition` is returned
+ *      unchanged (materialized narrative).
+ *  - FAIL-CLOSED    → genus absent AND no stored free-text → null. A definition is never
+ *      fabricated.
+ *
+ * Pure domain unit — no Obsidian dependency. The 1-hop label resolution is delegated to
+ * an injected MetadataResolver (wikilink target → its frontmatter), exactly as
+ * DisplayNameResolver receives one from PrintNameRuleService.createMetadataResolver().
+ */
+
+/** Resolve a wikilink target to the referenced asset's frontmatter (or null). */
+export type MetadataResolver = (wikilinkTarget: string) => Record<string, unknown> | null;
+
+// Frontmatter keys of the Delta-1 concept-typization TBox properties.
+const GENUS_KEY = "concept__Concept_genus";
+const DIFFERENTIA_KEY = "concept__Concept_differentia";
+const DEFINITION_KEY = "concept__Concept_definition";
+
+// Conjunction glyph for the rare multi-genus (upper-ontology) case: "<diff> [g₁ ∧ g₂]".
+const CONJUNCTION = " ∧ ";
+
+export class ConceptDefinitionResolver {
+  constructor(private readonly metadataResolver?: MetadataResolver | null) {}
+
+  /**
+   * The effective definition (materialized-OR-computed, fail-closed):
+   *  - genus present → the COMPUTED phrase; genus absent → the STORED free-text; neither → null.
+   * Callers that want the definition to display (materialized case included) use this.
+   */
+  resolve(metadata: Record<string, unknown>): string | null {
+    return this.resolveComputed(metadata) ?? this.storedDefinition(metadata[DEFINITION_KEY]);
+  }
+
+  /**
+   * The COMPUTED "<differentia> <genus>" phrase, or null when genus is absent (so a caller
+   * can distinguish "computed" from "stored/materialized"). The Properties-panel value patch
+   * uses this: it OVERRIDES the native definition row ONLY when a computed value exists,
+   * leaving the stored free-text row untouched when genus is absent.
+   */
+  resolveComputed(metadata: Record<string, unknown>): string | null {
+    const genusLabels = this.resolveWikilinkLabels(metadata[GENUS_KEY]);
+    if (genusLabels.length === 0) return null;
+    const differentiaLabels = this.resolveWikilinkLabels(metadata[DIFFERENTIA_KEY]);
+    return this.compose(differentiaLabels, genusLabels);
+  }
+
+  /**
+   * Compose "<differentia labels> <genus part>". The genus part is the single genus label,
+   * or — for the rare conjunctive upper-ontology genus — "[g₁ ∧ g₂ …]". Differentia labels
+   * (already in authored order) join as space-separated adjectives BEFORE the genus, so
+   * differentia=[recurring, quarterly] + genus=OKR → "recurring quarterly OKR".
+   */
+  private compose(differentiaLabels: string[], genusLabels: string[]): string {
+    const genusPart =
+      genusLabels.length >= 2
+        ? `[${genusLabels.join(CONJUNCTION)}]`
+        : genusLabels[0];
+    const differentiaPart = differentiaLabels.join(" ");
+    return differentiaPart ? `${differentiaPart} ${genusPart}` : genusPart;
+  }
+
+  /** A stored free-text definition, trimmed non-empty, else null (fail-closed). */
+  private storedDefinition(value: unknown): string | null {
+    let raw = value;
+    if (Array.isArray(raw)) raw = raw.length > 0 ? raw[0] : undefined;
+    if (typeof raw !== "string") return null;
+    const trimmed = raw.trim();
+    return trimmed.length > 0 ? trimmed : null;
+  }
+
+  /**
+   * Resolve a genus/differentia field (a single wikilink OR an array of wikilinks) into an
+   * ordered list of the referenced assets' exo__Asset_label — dropping any value that
+   * yields no label. The 1-hop resolution mirrors exo__PrintedProperty.
+   */
+  private resolveWikilinkLabels(value: unknown): string[] {
+    const raw = Array.isArray(value) ? value : value === undefined || value === null ? [] : [value];
+    const labels: string[] = [];
+    for (const item of raw) {
+      const label = this.resolveWikilinkLabel(item);
+      if (label) labels.push(label);
+    }
+    return labels;
+  }
+
+  /**
+   * Resolve one wikilink value to a display label (mirrors
+   * DisplayNameTemplateEngine.formatWikilinkValue):
+   *  - "[[target|alias]]"        → alias
+   *  - "[[target]]" + resolver   → the referenced asset's exo__Asset_label
+   *  - "[[target]]" no resolver  → target (brackets stripped)
+   *  - a non-wikilink string     → the string itself (partial brackets stripped)
+   */
+  private resolveWikilinkLabel(value: unknown): string | null {
+    if (typeof value !== "string") return null;
+    const trimmed = value.trim();
+    if (!trimmed) return null;
+
+    const match = trimmed.match(/^\[\[([^\]|]+?)(?:\|([^\]]+))?\]\]$/);
+    if (!match) {
+      // Not a wikilink — strip any partial bracket syntax and use the bare text.
+      const bare = trimmed.replace(/^\[\[|\]\]$/g, "").trim();
+      return bare || null;
+    }
+
+    const target = match[1].trim();
+    const alias = match[2]?.trim();
+    if (alias) return alias;
+
+    if (this.metadataResolver) {
+      const resolved = this.metadataResolver(trimmed);
+      const label = resolved?.exo__Asset_label;
+      if (typeof label === "string" && label.trim()) return label.trim();
+    }
+
+    return target || null;
+  }
+}

--- a/packages/obsidian-plugin/src/domain/concept-definition/ConceptDefinitionResolver.ts
+++ b/packages/obsidian-plugin/src/domain/concept-definition/ConceptDefinitionResolver.ts
@@ -35,6 +35,12 @@ const DEFINITION_KEY = "concept__Concept_definition";
 // Conjunction glyph for the rare multi-genus (upper-ontology) case: "<diff> [g₁ ∧ g₂]".
 const CONJUNCTION = " ∧ ";
 
+// A UID-shaped value is NOT a usable definition token — a genus/differentia that resolves ONLY
+// to a raw UID (target deleted/renamed, or metadataCache lag) must fail closed (fall through to
+// the stored narrative), never render the 36-char UID over a good stored definition.
+const UUID_REGEX =
+  /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/;
+
 export class ConceptDefinitionResolver {
   constructor(private readonly metadataResolver?: MetadataResolver | null) {}
 
@@ -101,11 +107,13 @@ export class ConceptDefinitionResolver {
 
   /**
    * Resolve one wikilink value to a display label (mirrors
-   * DisplayNameTemplateEngine.formatWikilinkValue):
+   * DisplayNameTemplateEngine.formatWikilinkValue, plus a FAIL-CLOSED guard):
    *  - "[[target|alias]]"        → alias
    *  - "[[target]]" + resolver   → the referenced asset's exo__Asset_label
-   *  - "[[target]]" no resolver  → target (brackets stripped)
-   *  - a non-wikilink string     → the string itself (partial brackets stripped)
+   *  - "[[<uid>]]" with no label  → null (FAIL-CLOSED — a raw UID is never a definition token,
+   *                                 so resolveComputed falls through to the stored narrative)
+   *  - "[[target]]" non-UID bare  → target (a symbolic label, kept)
+   *  - a non-wikilink string     → the string itself (a literal label; a bare UID → null)
    */
   private resolveWikilinkLabel(value: unknown): string | null {
     if (typeof value !== "string") return null;
@@ -114,9 +122,10 @@ export class ConceptDefinitionResolver {
 
     const match = trimmed.match(/^\[\[([^\]|]+?)(?:\|([^\]]+))?\]\]$/);
     if (!match) {
-      // Not a wikilink — strip any partial bracket syntax and use the bare text.
+      // Not a wikilink — a literal label. A bare UID is not a usable token (fail-closed).
       const bare = trimmed.replace(/^\[\[|\]\]$/g, "").trim();
-      return bare || null;
+      if (!bare) return null;
+      return UUID_REGEX.test(bare) ? null : bare;
     }
 
     const target = match[1].trim();
@@ -129,6 +138,9 @@ export class ConceptDefinitionResolver {
       if (typeof label === "string" && label.trim()) return label.trim();
     }
 
-    return target || null;
+    // No alias, no resolvable label: a bare UID fails closed (null → fall through to stored);
+    // a non-UID symbolic target is kept as its own label.
+    if (!target) return null;
+    return UUID_REGEX.test(target) ? null : target;
   }
 }

--- a/packages/obsidian-plugin/src/domain/concept-definition/ConceptDefinitionSpecService.ts
+++ b/packages/obsidian-plugin/src/domain/concept-definition/ConceptDefinitionSpecService.ts
@@ -39,9 +39,18 @@ interface RawPart {
   literal?: string; // exo__PrintedLiteral
 }
 
+/**
+ * Trailing debounce for scheduleRefresh() — collapses a burst of metadataCache "changed" events
+ * into ONE scanVault. Same fix as PrintNameRuleService: an un-debounced full O(N) vault walk on
+ * EVERY file change is the documented iPhone-Jetsam crash-loop root cause under a sync burst
+ * (O(K·N)). The definition spec is ~4 assets and rarely changes, so 300ms trailing is imperceptible.
+ */
+const SPEC_RESCAN_DEBOUNCE_MS = 300;
+
 export class ConceptDefinitionSpecService {
   private templates: Map<string, string> = new Map(); // appliesToClass key → compiled template
   private initialized = false;
+  private scanDebounceTimer: ReturnType<typeof setTimeout> | null = null;
 
   constructor(private readonly app: App) {}
 
@@ -50,8 +59,25 @@ export class ConceptDefinitionSpecService {
     this.initialized = true;
   }
 
+  /** Immediate rescan — for the rare cold-start ("resolved") rebuild, not the high-frequency path. */
   refresh(): void {
     this.scanVault();
+  }
+
+  /**
+   * Debounced rescan for the high-frequency metadataCache "changed" handler. A burst of K change
+   * events (e.g. a sync pull) collapses into ONE scanVault ~300ms after the last event, instead of
+   * K full O(N) vault walks (the crash-loop fix — mirrors PrintNameRuleService.scheduleRefresh).
+   */
+  scheduleRefresh(): void {
+    if (this.scanDebounceTimer !== null) {
+      clearTimeout(this.scanDebounceTimer);
+    }
+    this.scanDebounceTimer = setTimeout(() => {
+      this.scanDebounceTimer = null;
+      this.scanVault();
+      this.initialized = true;
+    }, SPEC_RESCAN_DEBOUNCE_MS);
   }
 
   /** The compiled definition-composition template for a concept class, or null if no spec applies. */

--- a/packages/obsidian-plugin/src/domain/concept-definition/ConceptDefinitionSpecService.ts
+++ b/packages/obsidian-plugin/src/domain/concept-definition/ConceptDefinitionSpecService.ts
@@ -66,7 +66,11 @@ export class ConceptDefinitionSpecService {
     const rawSpecs = new Map<string, RawSpec>();
     const rawParts: RawPart[] = [];
 
-    const files = this.app.vault.getMarkdownFiles();
+    let files: TFile[] = [];
+    if (typeof this.app.vault.getMarkdownFiles === "function") {
+      const result = this.app.vault.getMarkdownFiles();
+      if (Array.isArray(result)) files = result;
+    }
     for (const file of files) {
       const fm = this.app.metadataCache.getFileCache(file)?.frontmatter;
       if (!fm) continue;

--- a/packages/obsidian-plugin/src/domain/concept-definition/ConceptDefinitionSpecService.ts
+++ b/packages/obsidian-plugin/src/domain/concept-definition/ConceptDefinitionSpecService.ts
@@ -1,0 +1,234 @@
+import { TFile } from "obsidian";
+import type { App } from "obsidian";
+
+/**
+ * ConceptDefinitionSpecService — loads the VAULT-DECLARED concept-definition composition template.
+ *
+ * Delta-2 of concept-typization (req eb18a3a4). The composition of a concept's definition
+ * ("<differentia> <genus>") is NOT hardcoded in TS — it is declared as vault data: a
+ * `concept__ConceptDefinitionSpec` asset (appliesToClass concept__Concept) with ordered
+ * `exo__PrintedProperty` / `exo__PrintedLiteral` parts (the SAME part vocabulary the homoiconic
+ * displayName system uses). This service scans the vault for that spec + its parts and compiles
+ * them into a `DisplayNameTemplateEngine` template string (e.g.
+ * "{{concept__Concept_differentia}} {{concept__Concept_genus}}"). Editing the spec's parts/order/
+ * literals in the vault changes the composition with NO code change (Homoiconicity Invariant Q1).
+ *
+ * Mirrors PrintNameRuleService's scan/compile, but for a DEFINITION spec (not a display-NAME spec)
+ * — kept separate so PrintNameRuleService (the display-name engine) is untouched. It collects a
+ * superset of exo__PrintedProperty/exo__PrintedLiteral parts and keeps only those whose
+ * `exo__DisplayNamePart_of` points at a concept-definition spec, so a DisplayNameSpec's parts are
+ * ignored here (and vice-versa).
+ */
+
+const CONCEPT_DEFINITION_SPEC_CLASS = "concept__ConceptDefinitionSpec";
+const CONCEPT_DEFINITION_SPEC_CLASS_UID = "26358178-cf0e-4e5f-b92a-f59c6ac71908";
+const PRINTED_PROPERTY_CLASS = "exo__PrintedProperty";
+const PRINTED_PROPERTY_CLASS_UID = "7d58de40-d941-4a66-88e2-13afc4fdc41d";
+const PRINTED_LITERAL_CLASS = "exo__PrintedLiteral";
+const PRINTED_LITERAL_CLASS_UID = "4d5437c9-788e-4a6d-9be0-4af3a84554f4";
+
+interface RawSpec {
+  uid: string;
+  classKeys: string[]; // appliesToClass — UID + label forms
+}
+
+interface RawPart {
+  specUid: string;
+  order: number;
+  propertyKey?: string; // exo__PrintedProperty
+  literal?: string; // exo__PrintedLiteral
+}
+
+export class ConceptDefinitionSpecService {
+  private templates: Map<string, string> = new Map(); // appliesToClass key → compiled template
+  private initialized = false;
+
+  constructor(private readonly app: App) {}
+
+  initialize(): void {
+    this.scanVault();
+    this.initialized = true;
+  }
+
+  refresh(): void {
+    this.scanVault();
+  }
+
+  /** The compiled definition-composition template for a concept class, or null if no spec applies. */
+  getTemplate(className: string): string | null {
+    if (!this.initialized) return null;
+    return this.templates.get(className) ?? null;
+  }
+
+  private scanVault(): void {
+    this.templates.clear();
+
+    const rawSpecs = new Map<string, RawSpec>();
+    const rawParts: RawPart[] = [];
+
+    const files = this.app.vault.getMarkdownFiles();
+    for (const file of files) {
+      const fm = this.app.metadataCache.getFileCache(file)?.frontmatter;
+      if (!fm) continue;
+
+      const instanceClass = this.cleanValue(fm.exo__Instance_class);
+      if (
+        instanceClass === CONCEPT_DEFINITION_SPEC_CLASS ||
+        instanceClass === CONCEPT_DEFINITION_SPEC_CLASS_UID
+      ) {
+        this.collectSpec(fm, rawSpecs);
+      } else if (
+        instanceClass === PRINTED_PROPERTY_CLASS ||
+        instanceClass === PRINTED_PROPERTY_CLASS_UID ||
+        instanceClass === PRINTED_LITERAL_CLASS ||
+        instanceClass === PRINTED_LITERAL_CLASS_UID
+      ) {
+        this.collectPart(fm, rawParts);
+      }
+    }
+
+    this.compile(rawSpecs, rawParts);
+  }
+
+  private collectSpec(fm: Record<string, unknown>, rawSpecs: Map<string, RawSpec>): void {
+    const uid = typeof fm.exo__Asset_uid === "string" ? fm.exo__Asset_uid.trim() : "";
+    if (!uid) return;
+    const classKeys = this.extractClassKeys(
+      fm.concept__ConceptDefinitionSpec_appliesToClass,
+    );
+    if (classKeys.length === 0) return;
+    rawSpecs.set(uid, { uid, classKeys });
+  }
+
+  private collectPart(fm: Record<string, unknown>, rawParts: RawPart[]): void {
+    const specUid = this.cleanValue(fm.exo__DisplayNamePart_of);
+    if (!specUid) return;
+
+    const rawOrder = fm.exo__DisplayNamePart_order;
+    const order =
+      typeof rawOrder === "number"
+        ? rawOrder
+        : typeof rawOrder === "string" && rawOrder.trim() !== ""
+          ? Number(rawOrder)
+          : NaN;
+    if (!Number.isFinite(order)) return;
+
+    const propertyKey = this.resolvePropertyKey(fm.exo__PrintedProperty_property);
+    const rawLiteral = fm.exo__PrintedLiteral_literal;
+    const literal = typeof rawLiteral === "string" ? rawLiteral : undefined;
+
+    if (propertyKey) {
+      rawParts.push({ specUid, order, propertyKey });
+    } else if (literal !== undefined) {
+      rawParts.push({ specUid, order, literal });
+    }
+  }
+
+  private compile(rawSpecs: Map<string, RawSpec>, rawParts: RawPart[]): void {
+    const partsBySpec = new Map<string, RawPart[]>();
+    for (const part of rawParts) {
+      const arr = partsBySpec.get(part.specUid);
+      if (arr) arr.push(part);
+      else partsBySpec.set(part.specUid, [part]);
+    }
+
+    for (const spec of rawSpecs.values()) {
+      const parts = (partsBySpec.get(spec.uid) ?? []).slice().sort((a, b) => a.order - b.order);
+      if (parts.length === 0) continue;
+
+      const template = parts
+        .map((p) => (p.propertyKey ? `{{${p.propertyKey}}}` : (p.literal ?? "")))
+        .join("");
+      if (!template.trim()) continue;
+
+      for (const classKey of spec.classKeys) {
+        if (classKey && !this.templates.has(classKey)) {
+          this.templates.set(classKey, template);
+        }
+      }
+    }
+  }
+
+  /**
+   * Resolve an exo__PrintedProperty_property reference to the frontmatter KEY it prints
+   * (mirrors PrintNameRuleService.resolvePropertyKey): `[[uid|label]]` → label; a bare `[[uid]]`
+   * → second-hop the referenced property asset's exo__Asset_label; else the bare target.
+   */
+  private resolvePropertyKey(value: unknown): string | null {
+    let raw = value;
+    if (Array.isArray(raw)) {
+      if (raw.length === 0) return null;
+      raw = raw[0];
+    }
+    if (typeof raw !== "string") return null;
+
+    const cleaned = raw
+      .replace(/^\[\[|\]\]$/g, "")
+      .replace(/^"|"$/g, "")
+      .trim();
+    if (!cleaned) return null;
+
+    if (cleaned.includes("|")) {
+      const label = cleaned.split("|").pop()?.trim();
+      return label || null;
+    }
+
+    const target = cleaned.replace(/\.md$/, "").trim();
+    if (!target) return null;
+
+    const file =
+      this.app.metadataCache.getFirstLinkpathDest(target, "") ??
+      this.app.metadataCache.getFirstLinkpathDest(
+        target.endsWith(".md") ? target : `${target}.md`,
+        "",
+      );
+    if (file instanceof TFile) {
+      const label = this.app.metadataCache.getFileCache(file)?.frontmatter?.exo__Asset_label;
+      if (typeof label === "string" && label.trim()) return label.trim();
+    }
+    return target;
+  }
+
+  /** Both link-target (UID) and alias/label of an appliesToClass wikilink (dual-keying). */
+  private extractClassKeys(value: unknown): string[] {
+    let raw = value;
+    if (Array.isArray(raw)) {
+      if (raw.length === 0) return [];
+      raw = raw[0];
+    }
+    if (typeof raw !== "string") return [];
+
+    const cleaned = raw
+      .replace(/^\[\[|\]\]$/g, "")
+      .replace(/^"|"$/g, "")
+      .trim();
+    if (!cleaned) return [];
+
+    if (cleaned.includes("|")) {
+      const [target, label] = cleaned.split("|");
+      return [target.trim().replace(/\.md$/, ""), label.trim()].filter(
+        (k): k is string => Boolean(k),
+      );
+    }
+    return [cleaned.replace(/\.md$/, "")];
+  }
+
+  private cleanValue(value: unknown): string | null {
+    if (!value) return null;
+    if (Array.isArray(value)) {
+      if (value.length === 0) return null;
+      return this.cleanValue(value[0]);
+    }
+    if (typeof value !== "string") return null;
+
+    let cleaned = value
+      .replace(/^\[\[|\]\]$/g, "")
+      .replace(/^"|"$/g, "")
+      .trim();
+    if (cleaned.includes("|")) {
+      const last = cleaned.split("|").pop();
+      cleaned = (last ?? cleaned).trim();
+    }
+    return cleaned || null;
+  }
+}

--- a/packages/obsidian-plugin/src/domain/display-name/DisplayNameTemplateEngine.ts
+++ b/packages/obsidian-plugin/src/domain/display-name/DisplayNameTemplateEngine.ts
@@ -22,8 +22,21 @@ export type MetadataResolver = (wikilinkTarget: string) => Record<string, unknow
 export class DisplayNameTemplateEngine {
   private static readonly PLACEHOLDER_PATTERN = /\{\{([^}]+)\}\}/g;
   private static readonly WIKILINK_PATTERN = /^\[\[|\]\]$/g;
+  private static readonly UUID_PATTERN =
+    /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/;
 
-  constructor(private readonly template: string) {}
+  /**
+   * @param options.joinArrayValues OPT-IN (default false). When true, a `{{key}}` placeholder
+   *   resolving to an ARRAY renders ALL its values joined by a space (dropping any value that
+   *   resolves only to a bare UID — fail-closed) instead of first-only. Used by the concept
+   *   definition composition (a multi-valued `concept__Concept_differentia` renders all
+   *   adjectives). Default (false) is first-only — so the displayName path (which renders the
+   *   multi-valued `{{exo__Instance_class}}` in the default classSuffix template) is UNCHANGED.
+   */
+  constructor(
+    private readonly template: string,
+    private readonly options: { joinArrayValues?: boolean } = {},
+  ) {}
 
   /**
    * Render the template with provided metadata
@@ -222,10 +235,22 @@ export class DisplayNameTemplateEngine {
     }
 
     if (Array.isArray(value)) {
-      // For arrays, use the first value
       if (value.length === 0) {
         return "";
       }
+      if (this.options.joinArrayValues) {
+        // Opt-in (definition composition): render ALL values joined by a space, dropping any
+        // value that resolves only to a bare UID (fail-closed). The default path is first-only.
+        const parts: string[] = [];
+        for (const item of value) {
+          const formatted = this.formatValue(item, metadataResolver);
+          if (formatted && !DisplayNameTemplateEngine.UUID_PATTERN.test(formatted)) {
+            parts.push(formatted);
+          }
+        }
+        return parts.join(" ");
+      }
+      // For arrays, use the first value (default — displayName path, unchanged).
       return this.formatValue(value[0], metadataResolver);
     }
 

--- a/packages/obsidian-plugin/src/presentation/properties/PropertiesDefinitionValuePatch.ts
+++ b/packages/obsidian-plugin/src/presentation/properties/PropertiesDefinitionValuePatch.ts
@@ -83,7 +83,10 @@ export class PropertiesDefinitionValuePatch {
     // restore + re-patch to guarantee a fresh value.
     this.plugin.registerEvent(
       this.app.metadataCache.on("changed", () => {
-        this.specService.refresh();
+        // DEBOUNCED scan (the spec ~4 assets rarely change) — an un-debounced full-vault scan on
+        // EVERY change is the iPhone-Jetsam crash-loop root cause under a sync burst. The DOM
+        // re-patch below is O(open leaves), not O(vault), so it stays immediate.
+        this.specService.scheduleRefresh();
         this.restoreAll();
         this.patchAllPropertiesBlocks();
       }),

--- a/packages/obsidian-plugin/src/presentation/properties/PropertiesDefinitionValuePatch.ts
+++ b/packages/obsidian-plugin/src/presentation/properties/PropertiesDefinitionValuePatch.ts
@@ -3,6 +3,7 @@ import {
   ConceptDefinitionResolver,
   type MetadataResolver,
 } from "@plugin/domain/concept-definition/ConceptDefinitionResolver";
+import { ConceptDefinitionSpecService } from "@plugin/domain/concept-definition/ConceptDefinitionSpecService";
 
 /**
  * PropertiesDefinitionValuePatch — renders a concept's `concept__Concept_definition` as a
@@ -59,17 +60,20 @@ export class PropertiesDefinitionValuePatch {
   private enabled = false;
   private patched: PatchRecord[] = [];
   private resolver: ConceptDefinitionResolver;
+  private specService: ConceptDefinitionSpecService;
 
   constructor(plugin: Plugin) {
     this.plugin = plugin;
     this.app = plugin.app;
     this.resolver = new ConceptDefinitionResolver(this.buildMetadataResolver());
+    this.specService = new ConceptDefinitionSpecService(this.app);
   }
 
   enable(): void {
     if (this.enabled) return;
     this.enabled = true;
 
+    this.specService.initialize(); // load the vault-declared composition template(s)
     this.patchAllPropertiesBlocks();
     this.setupObserver();
 
@@ -79,6 +83,7 @@ export class PropertiesDefinitionValuePatch {
     // restore + re-patch to guarantee a fresh value.
     this.plugin.registerEvent(
       this.app.metadataCache.on("changed", () => {
+        this.specService.refresh();
         this.restoreAll();
         this.patchAllPropertiesBlocks();
       }),
@@ -89,6 +94,7 @@ export class PropertiesDefinitionValuePatch {
     // genus/differentia targets resolve to null labels on first render.
     this.plugin.registerEvent(
       this.app.metadataCache.on("resolved", () => {
+        this.specService.refresh();
         this.restoreAll();
         this.patchAllPropertiesBlocks();
       }),
@@ -177,9 +183,10 @@ export class PropertiesDefinitionValuePatch {
     const frontmatter = this.app.metadataCache.getFileCache(file)?.frontmatter;
     if (!frontmatter) return;
 
-    // Only override when a COMPUTED value exists (genus present). A concept without genus
-    // keeps its native stored value (materialized) — no patch.
-    const computed = this.resolver.resolveComputed(frontmatter);
+    // Only override when a COMPUTED value exists: a vault-declared composition template applies to
+    // the concept's class AND genus is present. Otherwise the native stored value shows (no patch).
+    const template = this.templateForConcept(frontmatter);
+    const computed = this.resolver.resolveComputed(frontmatter, template);
     if (!computed) return;
 
     const properties = metadataContainer.querySelectorAll<HTMLElement>(".metadata-property");
@@ -215,6 +222,37 @@ export class PropertiesDefinitionValuePatch {
 
     propertyEl.setAttribute(PATCHED_ATTR, "true");
     this.patched.push({ propertyEl, valueEl, displaySpan, originalNodes });
+  }
+
+  /** The vault-declared definition template applying to any of the concept's instance_class keys, or null. */
+  private templateForConcept(frontmatter: Record<string, unknown>): string | null {
+    const instanceClass = frontmatter.exo__Instance_class;
+    const raw = Array.isArray(instanceClass)
+      ? instanceClass
+      : instanceClass === undefined || instanceClass === null
+        ? []
+        : [instanceClass];
+    for (const value of raw) {
+      for (const key of this.classKeys(value)) {
+        const template = this.specService.getTemplate(key);
+        if (template) return template;
+      }
+    }
+    return null;
+  }
+
+  /** Both the link-target (UID) and the alias/label of a class wikilink. */
+  private classKeys(value: unknown): string[] {
+    if (typeof value !== "string") return [];
+    const cleaned = value.replace(/^\[\[|\]\]$/g, "").replace(/^"|"$/g, "").trim();
+    if (!cleaned) return [];
+    if (cleaned.includes("|")) {
+      const [target, label] = cleaned.split("|");
+      return [target.trim().replace(/\.md$/, ""), label.trim()].filter(
+        (k): k is string => Boolean(k),
+      );
+    }
+    return [cleaned.replace(/\.md$/, "")];
   }
 
   private extractPredicate(propertyEl: HTMLElement): string | null {

--- a/packages/obsidian-plugin/src/presentation/properties/PropertiesDefinitionValuePatch.ts
+++ b/packages/obsidian-plugin/src/presentation/properties/PropertiesDefinitionValuePatch.ts
@@ -1,0 +1,269 @@
+import { Plugin, TFile } from "obsidian";
+import {
+  ConceptDefinitionResolver,
+  type MetadataResolver,
+} from "@plugin/domain/concept-definition/ConceptDefinitionResolver";
+
+/**
+ * PropertiesDefinitionValuePatch — renders a concept's `concept__Concept_definition` as a
+ * homoiconic COMPUTED VIEW in Obsidian's native Properties block (Reading Mode).
+ *
+ * Delta-2 of concept-typization (req eb18a3a4). The definition of a concept is redundant
+ * with its genus + differentia ("quarterly OKR" = genus(OKR) + differentia(quarterly)) —
+ * so where a concept declares `concept__Concept_genus` (+ optional
+ * `concept__Concept_differentia`), this patch OVERRIDES the definition property row's
+ * displayed VALUE with the computed "<differentia> <genus>" phrase (resolved 1-hop to each
+ * target's exo__Asset_label). Where genus is absent the native stored free-text value is
+ * left untouched (materialized-OR-computed, RFC b860de33). The computation is delegated to
+ * ConceptDefinitionResolver — this patch is a thin surface adapter.
+ *
+ * Surface-parity note (verify-before-assert, 2026-07-26): `concept__Concept_definition` has
+ * NO custom render site in the plugin — it is displayed only by the native Properties panel,
+ * so THAT is the surface this patches.
+ *
+ * READING MODE only, display-side ONLY — the stored frontmatter value is never mutated
+ * (no edit-override), so there is no corruption risk (contrast PropertiesLabelPatch's note
+ * about not writing input.value). Follows the MutationObserver + layout-change re-patch
+ * pattern established by PropertiesLabelPatch / PropertiesLinkPatch / PropertiesUidCopyPatch.
+ *
+ * Dormant until Delta-3 by design: with 0 typed concept instances the patch is a no-op
+ * (resolveComputed returns null for a concept with no genus, so nothing is overridden).
+ *
+ * OUT OF SCOPE (follow-up): a concept with genus but NO stored `concept__Concept_definition`
+ * frontmatter key shows no native Properties row → there is nothing to override. Rendering
+ * the computed definition where the property is absent is a NEW surface (row insertion /
+ * dedicated block), tracked separately — not surface-parity.
+ */
+
+const DEFINITION_KEY = "concept__Concept_definition";
+const PATCHED_ATTR = "data-exo-definition-patched";
+const DISPLAY_SPAN_CLASS = "exo-definition-display";
+const HIDDEN_CLASS = "exo-definition-hidden";
+// Obsidian inserts zero-width spaces (U+200B) in property-key text; built at runtime to
+// avoid a literal invisible char in source.
+const ZERO_WIDTH_SPACE = String.fromCharCode(0x200b);
+
+interface PatchRecord {
+  propertyEl: HTMLElement;
+  valueEl: HTMLElement;
+  input: HTMLElement | null;
+  displaySpan: HTMLSpanElement;
+  /** Original child nodes detached before the display span was shown (non-input path), for restore. */
+  originalNodes: Node[] | null;
+}
+
+export class PropertiesDefinitionValuePatch {
+  private app: Plugin["app"];
+  private plugin: Plugin;
+  private observer: MutationObserver | null = null;
+  private enabled = false;
+  private patched: PatchRecord[] = [];
+  private resolver: ConceptDefinitionResolver;
+
+  constructor(plugin: Plugin) {
+    this.plugin = plugin;
+    this.app = plugin.app;
+    this.resolver = new ConceptDefinitionResolver(this.buildMetadataResolver());
+  }
+
+  enable(): void {
+    if (this.enabled) return;
+    this.enabled = true;
+
+    this.patchAllPropertiesBlocks();
+    this.setupObserver();
+
+    // The definition's genus/differentia can change → recompute. Obsidian re-renders the
+    // Properties DOM on a frontmatter change (dropping our span → the observer re-patches),
+    // but a persisted DOM node with a stale value would be skipped by PATCHED_ATTR, so we
+    // restore + re-patch to guarantee a fresh value.
+    this.plugin.registerEvent(
+      this.app.metadataCache.on("changed", () => {
+        this.restoreAll();
+        this.patchAllPropertiesBlocks();
+      }),
+    );
+
+    // "resolved" fires once the initial vault parse finishes; on a fresh/tarball install it
+    // arrives AFTER enable() (mirrors PropertiesLabelPatch Finding 4) — without it the
+    // genus/differentia targets resolve to null labels on first render.
+    this.plugin.registerEvent(
+      this.app.metadataCache.on("resolved", () => {
+        this.restoreAll();
+        this.patchAllPropertiesBlocks();
+      }),
+    );
+
+    this.plugin.registerEvent(
+      this.app.workspace.on("layout-change", () => {
+        setTimeout(() => this.patchAllPropertiesBlocks(), 100);
+      }),
+    );
+
+    this.plugin.registerEvent(
+      this.app.workspace.on("active-leaf-change", () => {
+        setTimeout(() => this.patchAllPropertiesBlocks(), 100);
+      }),
+    );
+  }
+
+  disable(): void {
+    if (!this.enabled) return;
+    this.enabled = false;
+
+    if (this.observer) {
+      this.observer.disconnect();
+      this.observer = null;
+    }
+
+    this.restoreAll();
+  }
+
+  cleanup(): void {
+    this.disable();
+  }
+
+  /** A 1-hop wikilink → frontmatter resolver over the vault metadataCache (mirrors
+   * PrintNameRuleService.createMetadataResolver — kept inline so the patch is self-contained). */
+  private buildMetadataResolver(): MetadataResolver {
+    return (wikilinkTarget: string): Record<string, unknown> | null => {
+      const cleaned = wikilinkTarget
+        .replace(/^\[\[|\]\]$/g, "")
+        .replace(/^"|"$/g, "")
+        .trim();
+      if (!cleaned) return null;
+
+      let file = this.app.metadataCache.getFirstLinkpathDest(cleaned, "");
+      if (!file && !cleaned.endsWith(".md")) {
+        file = this.app.metadataCache.getFirstLinkpathDest(cleaned + ".md", "");
+      }
+      if (!(file instanceof TFile)) return null;
+
+      const cache = this.app.metadataCache.getFileCache(file);
+      return cache?.frontmatter ? { ...cache.frontmatter } : null;
+    };
+  }
+
+  private patchAllPropertiesBlocks(): void {
+    if (!this.enabled) return;
+    if (typeof this.app.workspace.getLeavesOfType !== "function") return;
+
+    const leaves = this.app.workspace.getLeavesOfType("markdown");
+    if (!Array.isArray(leaves)) return;
+
+    for (const leaf of leaves) {
+      const view = leaf.view as { containerEl?: HTMLElement; file?: TFile | null };
+      const container = view?.containerEl;
+      const file = view?.file ?? null;
+      if (container && file instanceof TFile) {
+        this.patchPropertiesBlock(container, file);
+      }
+    }
+  }
+
+  private patchPropertiesBlock(container: HTMLElement, file: TFile): void {
+    const metadataContainer = container.querySelector<HTMLElement>(".metadata-container");
+    if (!metadataContainer) return;
+
+    const frontmatter = this.app.metadataCache.getFileCache(file)?.frontmatter;
+    if (!frontmatter) return;
+
+    // Only override when a COMPUTED value exists (genus present). A concept without genus
+    // keeps its native stored value (materialized) — no patch.
+    const computed = this.resolver.resolveComputed(frontmatter);
+    if (!computed) return;
+
+    const properties = metadataContainer.querySelectorAll<HTMLElement>(".metadata-property");
+    for (const prop of Array.from(properties)) {
+      if (this.extractPredicate(prop) === DEFINITION_KEY) {
+        this.patchDefinitionRow(prop, computed);
+      }
+    }
+  }
+
+  /** Override the definition row's displayed value with the computed phrase (Reading-Mode display). */
+  private patchDefinitionRow(propertyEl: HTMLElement, computed: string): void {
+    if (propertyEl.getAttribute(PATCHED_ATTR) === "true") return;
+
+    const valueEl = propertyEl.querySelector<HTMLElement>(".metadata-property-value");
+    if (!valueEl) return;
+
+    const displaySpan = document.createElement("span");
+    displaySpan.className = DISPLAY_SPAN_CLASS;
+    displaySpan.textContent = computed;
+    displaySpan.setAttribute("data-exo-computed-definition", "true");
+
+    const input = valueEl.querySelector<HTMLElement>("input, textarea, [contenteditable]");
+    let originalNodes: Node[] | null = null;
+
+    if (input) {
+      // Hide the native (editable) value control and show the computed value beside it.
+      input.classList.add(HIDDEN_CLASS);
+      input.parentNode?.insertBefore(displaySpan, input);
+    } else {
+      // Reading-Mode text value — detach the native content (kept for restore) and show the
+      // computed phrase. Node detach (not innerHTML) keeps this security-lint-clean.
+      originalNodes = Array.from(valueEl.childNodes);
+      for (const node of originalNodes) valueEl.removeChild(node);
+      valueEl.appendChild(displaySpan);
+    }
+
+    propertyEl.setAttribute(PATCHED_ATTR, "true");
+    this.patched.push({ propertyEl, valueEl, input, displaySpan, originalNodes });
+  }
+
+  private extractPredicate(propertyEl: HTMLElement): string | null {
+    const keyEl = propertyEl.querySelector<HTMLElement>(".metadata-property-key");
+    if (keyEl) {
+      const input = keyEl.querySelector<HTMLInputElement>("input");
+      if (input?.value?.trim()) return input.value.trim();
+      const text = (keyEl.textContent || "").trim().split(ZERO_WIDTH_SPACE).join("");
+      if (text.length > 0) return text;
+    }
+    const attr = propertyEl.getAttribute("data-property-key");
+    if (attr && attr.trim().length > 0) return attr.trim();
+    return null;
+  }
+
+  private setupObserver(): void {
+    if (this.observer) this.observer.disconnect();
+
+    this.observer = new MutationObserver((mutations) => {
+      if (!this.enabled) return;
+      for (const mutation of mutations) {
+        for (const node of Array.from(mutation.addedNodes)) {
+          if (!(node instanceof HTMLElement)) continue;
+          // A metadata-container (or an ancestor/descendant of one) was (re)inserted →
+          // re-patch the blocks (each leaf's active file), if any.
+          if (
+            node.classList?.contains("metadata-container") ||
+            node.querySelector?.(".metadata-container") ||
+            node.classList?.contains("metadata-property")
+          ) {
+            this.patchAllPropertiesBlocks();
+            return;
+          }
+        }
+      }
+    });
+
+    this.observer.observe(document.body, { childList: true, subtree: true });
+  }
+
+  private restoreAll(): void {
+    for (const record of this.patched) {
+      try {
+        record.displaySpan.remove();
+        if (record.input) {
+          record.input.classList.remove(HIDDEN_CLASS);
+        } else if (record.originalNodes !== null) {
+          for (const node of record.originalNodes) record.valueEl.appendChild(node);
+        }
+        record.propertyEl.removeAttribute(PATCHED_ATTR);
+      } catch {
+        // best-effort restore
+      }
+    }
+    this.patched = [];
+  }
+}

--- a/packages/obsidian-plugin/src/presentation/properties/PropertiesDefinitionValuePatch.ts
+++ b/packages/obsidian-plugin/src/presentation/properties/PropertiesDefinitionValuePatch.ts
@@ -21,10 +21,12 @@ import {
  * NO custom render site in the plugin — it is displayed only by the native Properties panel,
  * so THAT is the surface this patches.
  *
- * READING MODE only, display-side ONLY — the stored frontmatter value is never mutated
- * (no edit-override), so there is no corruption risk (contrast PropertiesLabelPatch's note
- * about not writing input.value). Follows the MutationObserver + layout-change re-patch
- * pattern established by PropertiesLabelPatch / PropertiesLinkPatch / PropertiesUidCopyPatch.
+ * READING MODE only, display-side ONLY (like the sibling PropertiesLabelPatch): the patch runs
+ * only when the markdown view is in preview (reading) mode AND the definition value is displayed
+ * as read-only text — it NEVER hides or replaces an editable value control (input / textarea /
+ * contenteditable), so the stored `concept__Concept_definition` stays editable and is never
+ * mutated (no edit-override → no corruption risk). Follows the MutationObserver + layout-change
+ * re-patch pattern established by PropertiesLabelPatch / PropertiesLinkPatch / PropertiesUidCopyPatch.
  *
  * Dormant until Delta-3 by design: with 0 typed concept instances the patch is a no-op
  * (resolveComputed returns null for a concept with no genus, so nothing is overridden).
@@ -38,7 +40,6 @@ import {
 const DEFINITION_KEY = "concept__Concept_definition";
 const PATCHED_ATTR = "data-exo-definition-patched";
 const DISPLAY_SPAN_CLASS = "exo-definition-display";
-const HIDDEN_CLASS = "exo-definition-hidden";
 // Obsidian inserts zero-width spaces (U+200B) in property-key text; built at runtime to
 // avoid a literal invisible char in source.
 const ZERO_WIDTH_SPACE = String.fromCharCode(0x200b);
@@ -46,10 +47,9 @@ const ZERO_WIDTH_SPACE = String.fromCharCode(0x200b);
 interface PatchRecord {
   propertyEl: HTMLElement;
   valueEl: HTMLElement;
-  input: HTMLElement | null;
   displaySpan: HTMLSpanElement;
-  /** Original child nodes detached before the display span was shown (non-input path), for restore. */
-  originalNodes: Node[] | null;
+  /** Original child nodes detached before the display span was shown, for restore. */
+  originalNodes: Node[];
 }
 
 export class PropertiesDefinitionValuePatch {
@@ -152,7 +152,16 @@ export class PropertiesDefinitionValuePatch {
     if (!Array.isArray(leaves)) return;
 
     for (const leaf of leaves) {
-      const view = leaf.view as { containerEl?: HTMLElement; file?: TFile | null };
+      const view = leaf.view as {
+        containerEl?: HTMLElement;
+        file?: TFile | null;
+        getMode?: () => string;
+      };
+      // Reading-mode only (matches sibling PropertiesLabelPatch's scope): if the view exposes a
+      // mode and it is NOT preview (reading), skip — the editable value stays untouched.
+      const mode = typeof view?.getMode === "function" ? view.getMode() : undefined;
+      if (mode !== undefined && mode !== "preview") continue;
+
       const container = view?.containerEl;
       const file = view?.file ?? null;
       if (container && file instanceof TFile) {
@@ -188,28 +197,24 @@ export class PropertiesDefinitionValuePatch {
     const valueEl = propertyEl.querySelector<HTMLElement>(".metadata-property-value");
     if (!valueEl) return;
 
+    // Reading-mode display ONLY — never override an EDITABLE value control (that would be an
+    // edit-override, hiding the user's editable definition). If the value carries an
+    // input/textarea/contenteditable (edit mode), leave it untouched.
+    if (valueEl.querySelector("input, textarea, [contenteditable]")) return;
+
     const displaySpan = document.createElement("span");
     displaySpan.className = DISPLAY_SPAN_CLASS;
     displaySpan.textContent = computed;
     displaySpan.setAttribute("data-exo-computed-definition", "true");
 
-    const input = valueEl.querySelector<HTMLElement>("input, textarea, [contenteditable]");
-    let originalNodes: Node[] | null = null;
-
-    if (input) {
-      // Hide the native (editable) value control and show the computed value beside it.
-      input.classList.add(HIDDEN_CLASS);
-      input.parentNode?.insertBefore(displaySpan, input);
-    } else {
-      // Reading-Mode text value — detach the native content (kept for restore) and show the
-      // computed phrase. Node detach (not innerHTML) keeps this security-lint-clean.
-      originalNodes = Array.from(valueEl.childNodes);
-      for (const node of originalNodes) valueEl.removeChild(node);
-      valueEl.appendChild(displaySpan);
-    }
+    // Read-only text value — detach the native content (kept for restore) and show the computed
+    // phrase. Node detach (not innerHTML) keeps this security-lint-clean.
+    const originalNodes = Array.from(valueEl.childNodes);
+    for (const node of originalNodes) valueEl.removeChild(node);
+    valueEl.appendChild(displaySpan);
 
     propertyEl.setAttribute(PATCHED_ATTR, "true");
-    this.patched.push({ propertyEl, valueEl, input, displaySpan, originalNodes });
+    this.patched.push({ propertyEl, valueEl, displaySpan, originalNodes });
   }
 
   private extractPredicate(propertyEl: HTMLElement): string | null {
@@ -254,11 +259,7 @@ export class PropertiesDefinitionValuePatch {
     for (const record of this.patched) {
       try {
         record.displaySpan.remove();
-        if (record.input) {
-          record.input.classList.remove(HIDDEN_CLASS);
-        } else if (record.originalNodes !== null) {
-          for (const node of record.originalNodes) record.valueEl.appendChild(node);
-        }
+        for (const node of record.originalNodes) record.valueEl.appendChild(node);
         record.propertyEl.removeAttribute(PATCHED_ATTR);
       } catch {
         // best-effort restore

--- a/packages/obsidian-plugin/styles.css
+++ b/packages/obsidian-plugin/styles.css
@@ -5647,6 +5647,18 @@
   text-decoration: underline;
 }
 
+/* PropertiesDefinitionValuePatch — computed concept definition display + hidden native value */
+.metadata-property-value .exo-definition-hidden {
+  display: none !important;
+}
+
+.metadata-property-value .exo-definition-display {
+  /* match native .metadata-property-value text metrics (read-only computed view) */
+  font: inherit;
+  color: var(--text-normal);
+  white-space: pre-wrap;
+}
+
 /* FileExplorerLabelPatch — span overlay for UUID-named Exocortex assets (#2802) */
 .nav-file-title-content.exo-file-explorer-label-hidden {
   font-size: 0 !important;

--- a/packages/obsidian-plugin/styles.css
+++ b/packages/obsidian-plugin/styles.css
@@ -5647,11 +5647,7 @@
   text-decoration: underline;
 }
 
-/* PropertiesDefinitionValuePatch — computed concept definition display + hidden native value */
-.metadata-property-value .exo-definition-hidden {
-  display: none !important;
-}
-
+/* PropertiesDefinitionValuePatch — computed concept definition display (Reading Mode) */
 .metadata-property-value .exo-definition-display {
   /* match native .metadata-property-value text metrics (read-only computed view) */
   font: inherit;

--- a/packages/obsidian-plugin/tests/unit/domain/concept-definition/ConceptDefinitionResolver.test.ts
+++ b/packages/obsidian-plugin/tests/unit/domain/concept-definition/ConceptDefinitionResolver.test.ts
@@ -1,0 +1,168 @@
+import { TFile } from "obsidian";
+import type { App, CachedMetadata } from "obsidian";
+import { ConceptDefinitionResolver } from "@plugin/domain/concept-definition/ConceptDefinitionResolver";
+import { PrintNameRuleService } from "@plugin/domain/display-name/PrintNameRuleService";
+
+/**
+ * Delta-2 of concept-typization (req eb18a3a4): a concept's concept__Concept_definition is a
+ * COMPUTED VIEW from its genus + differentia. Production-shape: the resolver runs over a REAL
+ * PrintNameRuleService.createMetadataResolver() (the same 1-hop label resolution the native
+ * displayName patches use) against an in-memory vault carrying SYNTHETIC typed concepts — no
+ * hand-injected label, no stubbed resolver (test-fixture-realism).
+ *
+ * Revert-verify axes (recorded in the PR body):
+ *  - Break the composition (drop the differentia OR the genus from compose) → the
+ *    "quarterly OKR" assertions go RED; restore → GREEN.
+ *  - Negative controls (no genus → stored free-text; neither → null) stay GREEN both ways.
+ */
+
+// Canonical concept-typization UIDs (Delta-1 TBox, verified in-vault this session).
+const CONCEPT_CLASS_UID = "dda12c48-40f3-4f1a-9f5b-8c1e2d3a4b5c"; // concept__Concept (label-form used below)
+const OKR_UID = "0a11c0de-0000-4000-8000-000000000001";
+const QUARTERLY_UID = "0a11c0de-0000-4000-8000-000000000002";
+const RECURRING_UID = "0a11c0de-0000-4000-8000-000000000003";
+const PROFESSION_UID = "0a11c0de-0000-4000-8000-000000000004";
+const ROLE_UID = "0a11c0de-0000-4000-8000-000000000005";
+const PM_UID = "0a11c0de-0000-4000-8000-000000000006";
+
+/**
+ * In-memory vault mock exposing the surface PrintNameRuleService.createMetadataResolver reads
+ * (getFirstLinkpathDest + getFileCache). The concept targets carry real exo__Asset_label so the
+ * 1-hop resolution is exercised end-to-end.
+ */
+function createConceptVaultApp(
+  files: Array<{ path: string; frontmatter: Record<string, unknown> }>,
+): App {
+  const fileCache = new Map<string, CachedMetadata>();
+  const mockFiles: TFile[] = [];
+  for (const f of files) {
+    const tfile = new TFile(f.path);
+    tfile.basename = f.path.replace(".md", "");
+    tfile.extension = "md";
+    mockFiles.push(tfile);
+    fileCache.set(f.path, { frontmatter: f.frontmatter } as CachedMetadata);
+  }
+  return {
+    vault: { getMarkdownFiles: jest.fn().mockReturnValue(mockFiles) },
+    metadataCache: {
+      getFileCache: jest
+        .fn()
+        .mockImplementation((file: TFile) => fileCache.get(file.path) ?? null),
+      getFirstLinkpathDest: jest.fn().mockImplementation((path: string) => {
+        const clean = path.endsWith(".md") ? path : path + ".md";
+        return mockFiles.find((f) => f.path === clean) ?? null;
+      }),
+    },
+  } as unknown as App;
+}
+
+/** Concept target assets (genus/differentia values point at these) carrying their labels. */
+function conceptTargetFiles(): Array<{ path: string; frontmatter: Record<string, unknown> }> {
+  const concept = (uid: string, label: string) => ({
+    path: `${uid}.md`,
+    frontmatter: {
+      exo__Asset_uid: uid,
+      exo__Instance_class: [`[[${CONCEPT_CLASS_UID}|concept__Concept]]`],
+      exo__Asset_label: label,
+    },
+  });
+  return [
+    concept(OKR_UID, "OKR"),
+    concept(QUARTERLY_UID, "quarterly"),
+    concept(RECURRING_UID, "recurring"),
+    concept(PROFESSION_UID, "Profession"),
+    concept(ROLE_UID, "Project Role"),
+    concept(PM_UID, "Project Manager"),
+  ];
+}
+
+/** Build a ConceptDefinitionResolver wired to a REAL PrintNameRuleService metadataResolver. */
+function resolverOverVault(): ConceptDefinitionResolver {
+  const app = createConceptVaultApp(conceptTargetFiles());
+  const printNameRuleService = new PrintNameRuleService(app);
+  return new ConceptDefinitionResolver(printNameRuleService.createMetadataResolver());
+}
+
+describe("ConceptDefinitionResolver — computed view from genus + differentia (req eb18a3a4)", () => {
+  it("@req:eb18a3a4-42b0-47d3-98a7-16b31c5ba6da computes '<differentia> <genus>' from genus + one differentia, resolving each 1-hop to its exo__Asset_label", () => {
+    const resolver = resolverOverVault();
+    const definition = resolver.resolve({
+      exo__Instance_class: [`[[${CONCEPT_CLASS_UID}|concept__Concept]]`],
+      concept__Concept_genus: `[[${OKR_UID}]]`,
+      concept__Concept_differentia: [`[[${QUARTERLY_UID}]]`],
+    });
+    // "quarterly OKR" — labels resolved through the REAL metadataResolver, NOT any stored text.
+    expect(definition).toBe("quarterly OKR");
+  });
+
+  it("@req:eb18a3a4-42b0-47d3-98a7-16b31c5ba6da joins multiple differentia as space-separated adjectives before the genus (authored order)", () => {
+    const resolver = resolverOverVault();
+    const definition = resolver.resolve({
+      concept__Concept_genus: `[[${OKR_UID}]]`,
+      concept__Concept_differentia: [`[[${RECURRING_UID}]]`, `[[${QUARTERLY_UID}]]`],
+    });
+    expect(definition).toBe("recurring quarterly OKR");
+  });
+
+  it("@req:eb18a3a4-42b0-47d3-98a7-16b31c5ba6da renders the rare conjunctive upper-ontology genus as '<differentia> [genus1 ∧ genus2]'", () => {
+    const resolver = resolverOverVault();
+    const definition = resolver.resolve({
+      concept__Concept_genus: [`[[${PROFESSION_UID}]]`, `[[${ROLE_UID}]]`],
+      concept__Concept_differentia: [`[[${PM_UID}]]`],
+    });
+    expect(definition).toBe("Project Manager [Profession ∧ Project Role]");
+  });
+
+  it("@req:eb18a3a4-42b0-47d3-98a7-16b31c5ba6da resolves the [[uid|alias]] genus form via the alias (no hop)", () => {
+    const resolver = resolverOverVault();
+    const definition = resolver.resolve({
+      concept__Concept_genus: `[[${OKR_UID}|OKR]]`,
+      concept__Concept_differentia: [`[[${QUARTERLY_UID}|quarterly]]`],
+    });
+    expect(definition).toBe("quarterly OKR");
+  });
+
+  it("@req:eb18a3a4-42b0-47d3-98a7-16b31c5ba6da a genus with NO differentia renders just the genus label", () => {
+    const resolver = resolverOverVault();
+    expect(
+      resolver.resolve({ concept__Concept_genus: `[[${OKR_UID}]]` }),
+    ).toBe("OKR");
+  });
+
+  // --- Negative controls (materialized-OR-computed + fail-closed) ---
+
+  it("@req:eb18a3a4-42b0-47d3-98a7-16b31c5ba6da genus ABSENT → the stored free-text is returned unchanged (materialized), and resolveComputed is null", () => {
+    const resolver = resolverOverVault();
+    const stored = "A branch of inquiry into the fundamental nature of being, knowledge, and value.";
+    const metadata = { concept__Concept_definition: stored };
+    expect(resolver.resolve(metadata)).toBe(stored);
+    // resolveComputed distinguishes computed from stored → null (no genus) so the patch does NOT override.
+    expect(resolver.resolveComputed(metadata)).toBeNull();
+  });
+
+  it("@req:eb18a3a4-42b0-47d3-98a7-16b31c5ba6da fail-closed: neither genus nor stored free-text → null (never fabricated)", () => {
+    const resolver = resolverOverVault();
+    expect(resolver.resolve({ exo__Asset_label: "orphan concept" })).toBeNull();
+    expect(resolver.resolveComputed({ exo__Asset_label: "orphan concept" })).toBeNull();
+    // empty stored text is also fail-closed
+    expect(resolver.resolve({ concept__Concept_definition: "   " })).toBeNull();
+  });
+
+  it("@req:eb18a3a4-42b0-47d3-98a7-16b31c5ba6da genus present + stored text → the COMPUTED value wins (materialized-OR-computed)", () => {
+    const resolver = resolverOverVault();
+    const definition = resolver.resolve({
+      concept__Concept_genus: `[[${OKR_UID}]]`,
+      concept__Concept_differentia: [`[[${QUARTERLY_UID}]]`],
+      concept__Concept_definition: "an outdated hand-written definition",
+    });
+    expect(definition).toBe("quarterly OKR");
+    expect(resolver.resolveComputed).toBeDefined();
+    expect(
+      resolver.resolveComputed({
+        concept__Concept_genus: `[[${OKR_UID}]]`,
+        concept__Concept_differentia: [`[[${QUARTERLY_UID}]]`],
+        concept__Concept_definition: "an outdated hand-written definition",
+      }),
+    ).toBe("quarterly OKR");
+  });
+});

--- a/packages/obsidian-plugin/tests/unit/domain/concept-definition/ConceptDefinitionResolver.test.ts
+++ b/packages/obsidian-plugin/tests/unit/domain/concept-definition/ConceptDefinitionResolver.test.ts
@@ -148,21 +148,34 @@ describe("ConceptDefinitionResolver — computed view from genus + differentia (
     expect(resolver.resolve({ concept__Concept_definition: "   " })).toBeNull();
   });
 
+  it("@req:eb18a3a4-42b0-47d3-98a7-16b31c5ba6da FAIL-CLOSED on an UNRESOLVABLE genus: genus=[[deleted-uid]] + stored text → renders the STORED text (never a raw UID), resolveComputed null", () => {
+    const resolver = resolverOverVault();
+    const DELETED_UID = "deadbeef-0000-4000-8000-00000000dead"; // not in the vault → no label
+    const stored = "the human-written definition that must be preserved";
+    const metadata = {
+      concept__Concept_genus: `[[${DELETED_UID}]]`,
+      concept__Concept_definition: stored,
+    };
+    // A genus that resolves ONLY to a raw UID is not a usable token → fall through to STORED.
+    expect(resolver.resolve(metadata)).toBe(stored);
+    expect(resolver.resolveComputed(metadata)).toBeNull();
+  });
+
+  it("@req:eb18a3a4-42b0-47d3-98a7-16b31c5ba6da an unresolvable genus with NO stored text → null (never renders the raw UID)", () => {
+    const resolver = resolverOverVault();
+    expect(
+      resolver.resolve({ concept__Concept_genus: "[[deadbeef-0000-4000-8000-00000000dead]]" }),
+    ).toBeNull();
+  });
+
   it("@req:eb18a3a4-42b0-47d3-98a7-16b31c5ba6da genus present + stored text → the COMPUTED value wins (materialized-OR-computed)", () => {
     const resolver = resolverOverVault();
-    const definition = resolver.resolve({
+    const metadata = {
       concept__Concept_genus: `[[${OKR_UID}]]`,
       concept__Concept_differentia: [`[[${QUARTERLY_UID}]]`],
       concept__Concept_definition: "an outdated hand-written definition",
-    });
-    expect(definition).toBe("quarterly OKR");
-    expect(resolver.resolveComputed).toBeDefined();
-    expect(
-      resolver.resolveComputed({
-        concept__Concept_genus: `[[${OKR_UID}]]`,
-        concept__Concept_differentia: [`[[${QUARTERLY_UID}]]`],
-        concept__Concept_definition: "an outdated hand-written definition",
-      }),
-    ).toBe("quarterly OKR");
+    };
+    expect(resolver.resolve(metadata)).toBe("quarterly OKR");
+    expect(resolver.resolveComputed(metadata)).toBe("quarterly OKR");
   });
 });

--- a/packages/obsidian-plugin/tests/unit/domain/concept-definition/ConceptDefinitionResolver.test.ts
+++ b/packages/obsidian-plugin/tests/unit/domain/concept-definition/ConceptDefinitionResolver.test.ts
@@ -1,38 +1,37 @@
 import { TFile } from "obsidian";
 import type { App, CachedMetadata } from "obsidian";
 import { ConceptDefinitionResolver } from "@plugin/domain/concept-definition/ConceptDefinitionResolver";
+import { ConceptDefinitionSpecService } from "@plugin/domain/concept-definition/ConceptDefinitionSpecService";
 import { PrintNameRuleService } from "@plugin/domain/display-name/PrintNameRuleService";
 
 /**
  * Delta-2 of concept-typization (req eb18a3a4): a concept's concept__Concept_definition is a
- * COMPUTED VIEW from its genus + differentia. Production-shape: the resolver runs over a REAL
- * PrintNameRuleService.createMetadataResolver() (the same 1-hop label resolution the native
- * displayName patches use) against an in-memory vault carrying SYNTHETIC typed concepts — no
- * hand-injected label, no stubbed resolver (test-fixture-realism).
+ * HOMOICONIC COMPUTED VIEW — the composition template ("<differentia> <genus>", order, separators)
+ * is VAULT-DECLARED (a concept__ConceptDefinitionSpec + ordered exo__PrintedProperty/PrintedLiteral
+ * parts), loaded by ConceptDefinitionSpecService and rendered by ConceptDefinitionResolver over the
+ * reused DisplayNameTemplateEngine. Production-shape: the spec + parts live in an in-memory vault,
+ * compiled by the REAL spec service, resolved through a REAL metadataResolver — no hand-injected
+ * template, no stubbed resolver (test-fixture-realism).
  *
- * Revert-verify axes (recorded in the PR body):
- *  - Break the composition (drop the differentia OR the genus from compose) → the
- *    "quarterly OKR" assertions go RED; restore → GREEN.
- *  - Negative controls (no genus → stored free-text; neither → null) stay GREEN both ways.
+ * ⛤ Homoiconicity revert-verify (axis-1) — the composition changes when the VAULT SPEC changes
+ * (same concept data): the spec is the single source of truth, no hardcoded compose() in TS.
  */
 
-// Canonical concept-typization UIDs (Delta-1 TBox, verified in-vault this session).
-const CONCEPT_CLASS_UID = "dda12c48-40f3-4f1a-9f5b-8c1e2d3a4b5c"; // concept__Concept (label-form used below)
+const CONCEPT_DEFINITION_SPEC_CLASS_UID = "26358178-cf0e-4e5f-b92a-f59c6ac71908";
+const CONCEPT_CLASS_UID = "dda12c48-40f3-4f1a-9f5b-8c1e2d3a4b5c";
+const PRINTED_PROPERTY_UID = "7d58de40-d941-4a66-88e2-13afc4fdc41d";
+const PRINTED_LITERAL_UID = "4d5437c9-788e-4a6d-9be0-4af3a84554f4";
+const DIFF_PROP_UID = "5cc92949-0000-4000-8000-000000000001";
+const GENUS_PROP_UID = "06d389ff-0000-4000-8000-000000000002";
+
+const SPEC_UID = "e8e8475c-2e58-44a6-9f77-f907569e156e";
 const OKR_UID = "0a11c0de-0000-4000-8000-000000000001";
 const QUARTERLY_UID = "0a11c0de-0000-4000-8000-000000000002";
 const RECURRING_UID = "0a11c0de-0000-4000-8000-000000000003";
-const PROFESSION_UID = "0a11c0de-0000-4000-8000-000000000004";
-const ROLE_UID = "0a11c0de-0000-4000-8000-000000000005";
-const PM_UID = "0a11c0de-0000-4000-8000-000000000006";
 
-/**
- * In-memory vault mock exposing the surface PrintNameRuleService.createMetadataResolver reads
- * (getFirstLinkpathDest + getFileCache). The concept targets carry real exo__Asset_label so the
- * 1-hop resolution is exercised end-to-end.
- */
-function createConceptVaultApp(
-  files: Array<{ path: string; frontmatter: Record<string, unknown> }>,
-): App {
+type Fm = { path: string; frontmatter: Record<string, unknown> };
+
+function createVaultApp(files: Fm[]): App {
   const fileCache = new Map<string, CachedMetadata>();
   const mockFiles: TFile[] = [];
   for (const f of files) {
@@ -45,9 +44,7 @@ function createConceptVaultApp(
   return {
     vault: { getMarkdownFiles: jest.fn().mockReturnValue(mockFiles) },
     metadataCache: {
-      getFileCache: jest
-        .fn()
-        .mockImplementation((file: TFile) => fileCache.get(file.path) ?? null),
+      getFileCache: jest.fn().mockImplementation((file: TFile) => fileCache.get(file.path) ?? null),
       getFirstLinkpathDest: jest.fn().mockImplementation((path: string) => {
         const clean = path.endsWith(".md") ? path : path + ".md";
         return mockFiles.find((f) => f.path === clean) ?? null;
@@ -56,126 +53,180 @@ function createConceptVaultApp(
   } as unknown as App;
 }
 
-/** Concept target assets (genus/differentia values point at these) carrying their labels. */
-function conceptTargetFiles(): Array<{ path: string; frontmatter: Record<string, unknown> }> {
-  const concept = (uid: string, label: string) => ({
-    path: `${uid}.md`,
-    frontmatter: {
-      exo__Asset_uid: uid,
-      exo__Instance_class: [`[[${CONCEPT_CLASS_UID}|concept__Concept]]`],
-      exo__Asset_label: label,
+const conceptTarget = (uid: string, label: string): Fm => ({
+  path: `${uid}.md`,
+  frontmatter: {
+    exo__Asset_uid: uid,
+    exo__Instance_class: [`[[${CONCEPT_CLASS_UID}|concept__Concept]]`],
+    exo__Asset_label: label,
+  },
+});
+
+/** The VAULT-DECLARED composition spec + parts. `includeGenusPart` drives revert-verify axis-1. */
+function specFiles(includeGenusPart = true): Fm[] {
+  const parts: Fm[] = [
+    {
+      path: "part-differentia.md",
+      frontmatter: {
+        exo__Asset_uid: "part-diff",
+        exo__Instance_class: [`[[${PRINTED_PROPERTY_UID}|exo__PrintedProperty]]`],
+        exo__DisplayNamePart_of: `[[${SPEC_UID}]]`,
+        exo__DisplayNamePart_order: 0,
+        exo__PrintedProperty_property: `[[${DIFF_PROP_UID}|concept__Concept_differentia]]`,
+      },
     },
-  });
+    {
+      path: "part-literal.md",
+      frontmatter: {
+        exo__Asset_uid: "part-lit",
+        exo__Instance_class: [`[[${PRINTED_LITERAL_UID}|exo__PrintedLiteral]]`],
+        exo__DisplayNamePart_of: `[[${SPEC_UID}]]`,
+        exo__DisplayNamePart_order: 1,
+        exo__PrintedLiteral_literal: " ",
+      },
+    },
+  ];
+  if (includeGenusPart) {
+    parts.push({
+      path: "part-genus.md",
+      frontmatter: {
+        exo__Asset_uid: "part-genus",
+        exo__Instance_class: [`[[${PRINTED_PROPERTY_UID}|exo__PrintedProperty]]`],
+        exo__DisplayNamePart_of: `[[${SPEC_UID}]]`,
+        exo__DisplayNamePart_order: 2,
+        exo__PrintedProperty_property: `[[${GENUS_PROP_UID}|concept__Concept_genus]]`,
+      },
+    });
+  }
   return [
-    concept(OKR_UID, "OKR"),
-    concept(QUARTERLY_UID, "quarterly"),
-    concept(RECURRING_UID, "recurring"),
-    concept(PROFESSION_UID, "Profession"),
-    concept(ROLE_UID, "Project Role"),
-    concept(PM_UID, "Project Manager"),
+    {
+      path: `${SPEC_UID}.md`,
+      frontmatter: {
+        exo__Asset_uid: SPEC_UID,
+        exo__Instance_class: [
+          `[[${CONCEPT_DEFINITION_SPEC_CLASS_UID}|concept__ConceptDefinitionSpec]]`,
+        ],
+        concept__ConceptDefinitionSpec_appliesToClass: `[[${CONCEPT_CLASS_UID}|concept__Concept]]`,
+        exo__Asset_label: "concept definition composition — <differentia> <genus>",
+      },
+    },
+    ...parts,
+    conceptTarget(OKR_UID, "OKR"),
+    conceptTarget(QUARTERLY_UID, "quarterly"),
+    conceptTarget(RECURRING_UID, "recurring"),
   ];
 }
 
-/** Build a ConceptDefinitionResolver wired to a REAL PrintNameRuleService metadataResolver. */
-function resolverOverVault(): ConceptDefinitionResolver {
-  const app = createConceptVaultApp(conceptTargetFiles());
-  const printNameRuleService = new PrintNameRuleService(app);
-  return new ConceptDefinitionResolver(printNameRuleService.createMetadataResolver());
+/** Build (specService, resolver) over an in-memory vault carrying the spec + parts + targets. */
+function harness(includeGenusPart = true): {
+  template: string | null;
+  resolver: ConceptDefinitionResolver;
+} {
+  const app = createVaultApp(specFiles(includeGenusPart));
+  const specService = new ConceptDefinitionSpecService(app);
+  specService.initialize(); // REAL scanVault — compiles the vault-declared template
+  const template = specService.getTemplate("concept__Concept");
+  const printName = new PrintNameRuleService(app);
+  const resolver = new ConceptDefinitionResolver(printName.createMetadataResolver());
+  return { template, resolver };
 }
 
-describe("ConceptDefinitionResolver — computed view from genus + differentia (req eb18a3a4)", () => {
-  it("@req:eb18a3a4-42b0-47d3-98a7-16b31c5ba6da computes '<differentia> <genus>' from genus + one differentia, resolving each 1-hop to its exo__Asset_label", () => {
-    const resolver = resolverOverVault();
-    const definition = resolver.resolve({
-      exo__Instance_class: [`[[${CONCEPT_CLASS_UID}|concept__Concept]]`],
-      concept__Concept_genus: `[[${OKR_UID}]]`,
-      concept__Concept_differentia: [`[[${QUARTERLY_UID}]]`],
-    });
-    // "quarterly OKR" — labels resolved through the REAL metadataResolver, NOT any stored text.
+describe("ConceptDefinitionResolver — vault-declared composition (req eb18a3a4)", () => {
+  it("@req:eb18a3a4-42b0-47d3-98a7-16b31c5ba6da compiles the vault spec to the composition template", () => {
+    const { template } = harness();
+    expect(template).toBe("{{concept__Concept_differentia}} {{concept__Concept_genus}}");
+  });
+
+  it("@req:eb18a3a4-42b0-47d3-98a7-16b31c5ba6da renders '<differentia> <genus>' from the vault template + a concept's genus/differentia (1-hop labels)", () => {
+    const { template, resolver } = harness();
+    const definition = resolver.resolve(
+      {
+        concept__Concept_genus: `[[${OKR_UID}]]`,
+        concept__Concept_differentia: [`[[${QUARTERLY_UID}]]`],
+      },
+      template,
+    );
     expect(definition).toBe("quarterly OKR");
   });
 
-  it("@req:eb18a3a4-42b0-47d3-98a7-16b31c5ba6da joins multiple differentia as space-separated adjectives before the genus (authored order)", () => {
-    const resolver = resolverOverVault();
-    const definition = resolver.resolve({
-      concept__Concept_genus: `[[${OKR_UID}]]`,
-      concept__Concept_differentia: [`[[${RECURRING_UID}]]`, `[[${QUARTERLY_UID}]]`],
-    });
+  it("@req:eb18a3a4-42b0-47d3-98a7-16b31c5ba6da joins multiple differentia (authored order) via the engine's opt-in array-join", () => {
+    const { template, resolver } = harness();
+    const definition = resolver.resolve(
+      {
+        concept__Concept_genus: `[[${OKR_UID}]]`,
+        concept__Concept_differentia: [`[[${RECURRING_UID}]]`, `[[${QUARTERLY_UID}]]`],
+      },
+      template,
+    );
     expect(definition).toBe("recurring quarterly OKR");
   });
 
-  it("@req:eb18a3a4-42b0-47d3-98a7-16b31c5ba6da renders the rare conjunctive upper-ontology genus as '<differentia> [genus1 ∧ genus2]'", () => {
-    const resolver = resolverOverVault();
-    const definition = resolver.resolve({
-      concept__Concept_genus: [`[[${PROFESSION_UID}]]`, `[[${ROLE_UID}]]`],
-      concept__Concept_differentia: [`[[${PM_UID}]]`],
-    });
-    expect(definition).toBe("Project Manager [Profession ∧ Project Role]");
-  });
-
-  it("@req:eb18a3a4-42b0-47d3-98a7-16b31c5ba6da resolves the [[uid|alias]] genus form via the alias (no hop)", () => {
-    const resolver = resolverOverVault();
-    const definition = resolver.resolve({
-      concept__Concept_genus: `[[${OKR_UID}|OKR]]`,
-      concept__Concept_differentia: [`[[${QUARTERLY_UID}|quarterly]]`],
-    });
-    expect(definition).toBe("quarterly OKR");
-  });
-
-  it("@req:eb18a3a4-42b0-47d3-98a7-16b31c5ba6da a genus with NO differentia renders just the genus label", () => {
-    const resolver = resolverOverVault();
+  it("@req:eb18a3a4-42b0-47d3-98a7-16b31c5ba6da resolves the [[uid|alias]] forms via the alias", () => {
+    const { template, resolver } = harness();
     expect(
-      resolver.resolve({ concept__Concept_genus: `[[${OKR_UID}]]` }),
-    ).toBe("OKR");
+      resolver.resolve(
+        {
+          concept__Concept_genus: `[[${OKR_UID}|OKR]]`,
+          concept__Concept_differentia: [`[[${QUARTERLY_UID}|quarterly]]`],
+        },
+        template,
+      ),
+    ).toBe("quarterly OKR");
+  });
+
+  // ⛤ HOMOICONICITY REVERT-VERIFY (axis-1): the composition is the VAULT SPEC, not TS.
+  it("@req:eb18a3a4-42b0-47d3-98a7-16b31c5ba6da REVERT-VERIFY axis-1: editing the vault spec (dropping the genus part) changes the composition for the SAME concept — the spec is the source of truth", () => {
+    const concept = {
+      concept__Concept_genus: `[[${OKR_UID}]]`,
+      concept__Concept_differentia: [`[[${QUARTERLY_UID}]]`],
+    };
+    // Spec WITH the genus part → "quarterly OKR".
+    const withGenus = harness(true);
+    expect(withGenus.resolver.resolve(concept, withGenus.template)).toBe("quarterly OKR");
+    // Spec WITHOUT the genus part (same concept data) → the genus drops out of the composition.
+    const withoutGenus = harness(false);
+    expect(withoutGenus.template).toBe("{{concept__Concept_differentia}} ");
+    expect(withoutGenus.resolver.resolve(concept, withoutGenus.template)).toBe("quarterly");
   });
 
   // --- Negative controls (materialized-OR-computed + fail-closed) ---
 
-  it("@req:eb18a3a4-42b0-47d3-98a7-16b31c5ba6da genus ABSENT → the stored free-text is returned unchanged (materialized), and resolveComputed is null", () => {
-    const resolver = resolverOverVault();
+  it("@req:eb18a3a4-42b0-47d3-98a7-16b31c5ba6da genus ABSENT → the stored free-text is returned unchanged (materialized), resolveComputed null", () => {
+    const { template, resolver } = harness();
     const stored = "A branch of inquiry into the fundamental nature of being, knowledge, and value.";
     const metadata = { concept__Concept_definition: stored };
-    expect(resolver.resolve(metadata)).toBe(stored);
-    // resolveComputed distinguishes computed from stored → null (no genus) so the patch does NOT override.
-    expect(resolver.resolveComputed(metadata)).toBeNull();
+    expect(resolver.resolve(metadata, template)).toBe(stored);
+    expect(resolver.resolveComputed(metadata, template)).toBeNull();
   });
 
-  it("@req:eb18a3a4-42b0-47d3-98a7-16b31c5ba6da fail-closed: neither genus nor stored free-text → null (never fabricated)", () => {
-    const resolver = resolverOverVault();
-    expect(resolver.resolve({ exo__Asset_label: "orphan concept" })).toBeNull();
-    expect(resolver.resolveComputed({ exo__Asset_label: "orphan concept" })).toBeNull();
-    // empty stored text is also fail-closed
-    expect(resolver.resolve({ concept__Concept_definition: "   " })).toBeNull();
-  });
-
-  it("@req:eb18a3a4-42b0-47d3-98a7-16b31c5ba6da FAIL-CLOSED on an UNRESOLVABLE genus: genus=[[deleted-uid]] + stored text → renders the STORED text (never a raw UID), resolveComputed null", () => {
-    const resolver = resolverOverVault();
-    const DELETED_UID = "deadbeef-0000-4000-8000-00000000dead"; // not in the vault → no label
+  it("@req:eb18a3a4-42b0-47d3-98a7-16b31c5ba6da FAIL-CLOSED on an UNRESOLVABLE genus: genus=[[deleted-uid]] + stored text → renders STORED (never a raw UID), resolveComputed null", () => {
+    const { template, resolver } = harness();
     const stored = "the human-written definition that must be preserved";
     const metadata = {
-      concept__Concept_genus: `[[${DELETED_UID}]]`,
+      concept__Concept_genus: "[[deadbeef-0000-4000-8000-00000000dead]]",
       concept__Concept_definition: stored,
     };
-    // A genus that resolves ONLY to a raw UID is not a usable token → fall through to STORED.
-    expect(resolver.resolve(metadata)).toBe(stored);
-    expect(resolver.resolveComputed(metadata)).toBeNull();
+    expect(resolver.resolve(metadata, template)).toBe(stored);
+    expect(resolver.resolveComputed(metadata, template)).toBeNull();
   });
 
-  it("@req:eb18a3a4-42b0-47d3-98a7-16b31c5ba6da an unresolvable genus with NO stored text → null (never renders the raw UID)", () => {
-    const resolver = resolverOverVault();
+  it("@req:eb18a3a4-42b0-47d3-98a7-16b31c5ba6da NO vault spec authored (template null) → stored fallback / null (fail-closed)", () => {
+    const { resolver } = harness();
     expect(
-      resolver.resolve({ concept__Concept_genus: "[[deadbeef-0000-4000-8000-00000000dead]]" }),
+      resolver.resolve({ concept__Concept_genus: `[[${OKR_UID}]]` }, null),
     ).toBeNull();
+    const stored = "kept narrative";
+    expect(
+      resolver.resolve(
+        { concept__Concept_genus: `[[${OKR_UID}]]`, concept__Concept_definition: stored },
+        null,
+      ),
+    ).toBe(stored);
   });
 
-  it("@req:eb18a3a4-42b0-47d3-98a7-16b31c5ba6da genus present + stored text → the COMPUTED value wins (materialized-OR-computed)", () => {
-    const resolver = resolverOverVault();
-    const metadata = {
-      concept__Concept_genus: `[[${OKR_UID}]]`,
-      concept__Concept_differentia: [`[[${QUARTERLY_UID}]]`],
-      concept__Concept_definition: "an outdated hand-written definition",
-    };
-    expect(resolver.resolve(metadata)).toBe("quarterly OKR");
-    expect(resolver.resolveComputed(metadata)).toBe("quarterly OKR");
+  it("@req:eb18a3a4-42b0-47d3-98a7-16b31c5ba6da fail-closed: neither genus nor stored → null (never fabricated)", () => {
+    const { template, resolver } = harness();
+    expect(resolver.resolve({ exo__Asset_label: "orphan concept" }, template)).toBeNull();
+    expect(resolver.resolve({ concept__Concept_definition: "   " }, template)).toBeNull();
   });
 });

--- a/packages/obsidian-plugin/tests/unit/domain/concept-definition/ConceptDefinitionSpecService.test.ts
+++ b/packages/obsidian-plugin/tests/unit/domain/concept-definition/ConceptDefinitionSpecService.test.ts
@@ -108,4 +108,13 @@ describe("ConceptDefinitionSpecService (req eb18a3a4)", () => {
     const svc = new ConceptDefinitionSpecService(app([spec(), prop(0, "concept__Concept_genus")]));
     expect(svc.getTemplate("concept__Concept")).toBeNull();
   });
+
+  it("tolerates a vault mock without a working getMarkdownFiles (does not throw)", () => {
+    // The plugin's own test harness mock vault may not return an array — initialize() must not
+    // throw "files is not iterable" (regression guard).
+    const bare = { vault: {}, metadataCache: {} } as unknown as App;
+    const svc = new ConceptDefinitionSpecService(bare);
+    expect(() => svc.initialize()).not.toThrow();
+    expect(svc.getTemplate("concept__Concept")).toBeNull();
+  });
 });

--- a/packages/obsidian-plugin/tests/unit/domain/concept-definition/ConceptDefinitionSpecService.test.ts
+++ b/packages/obsidian-plugin/tests/unit/domain/concept-definition/ConceptDefinitionSpecService.test.ts
@@ -109,6 +109,25 @@ describe("ConceptDefinitionSpecService (req eb18a3a4)", () => {
     expect(svc.getTemplate("concept__Concept")).toBeNull();
   });
 
+  it("scheduleRefresh() DEBOUNCES a burst of changes into ONE scanVault (iPhone-Jetsam crash-loop guard)", () => {
+    jest.useFakeTimers();
+    const a = app([spec(), prop(0, "concept__Concept_genus")]);
+    const getMarkdownFiles = (a.vault as unknown as { getMarkdownFiles: jest.Mock })
+      .getMarkdownFiles;
+    const svc = new ConceptDefinitionSpecService(a);
+    svc.initialize(); // 1 immediate scan
+    getMarkdownFiles.mockClear();
+
+    // A burst of 20 "changed" events → 20 scheduleRefresh() calls.
+    for (let i = 0; i < 20; i++) svc.scheduleRefresh();
+    expect(getMarkdownFiles).not.toHaveBeenCalled(); // debounced — no O(N) scan per change
+
+    jest.advanceTimersByTime(300);
+    expect(getMarkdownFiles).toHaveBeenCalledTimes(1); // ONE scan for the whole burst
+    expect(svc.getTemplate("concept__Concept")).toBe("{{concept__Concept_genus}}");
+    jest.useRealTimers();
+  });
+
   it("tolerates a vault mock without a working getMarkdownFiles (does not throw)", () => {
     // The plugin's own test harness mock vault may not return an array — initialize() must not
     // throw "files is not iterable" (regression guard).

--- a/packages/obsidian-plugin/tests/unit/domain/concept-definition/ConceptDefinitionSpecService.test.ts
+++ b/packages/obsidian-plugin/tests/unit/domain/concept-definition/ConceptDefinitionSpecService.test.ts
@@ -1,0 +1,111 @@
+import { TFile } from "obsidian";
+import type { App, CachedMetadata } from "obsidian";
+import { ConceptDefinitionSpecService } from "@plugin/domain/concept-definition/ConceptDefinitionSpecService";
+
+/**
+ * ConceptDefinitionSpecService loads the VAULT-DECLARED concept-definition composition template
+ * (req eb18a3a4) — a concept__ConceptDefinitionSpec + ordered exo__PrintedProperty/PrintedLiteral
+ * parts compiled to a DisplayNameTemplateEngine template. No hardcoded template.
+ */
+
+const SPEC_CLASS_UID = "26358178-cf0e-4e5f-b92a-f59c6ac71908";
+const CONCEPT_CLASS_UID = "dda12c48-40f3-4f1a-9f5b-8c1e2d3a4b5c";
+const PRINTED_PROPERTY_UID = "7d58de40-d941-4a66-88e2-13afc4fdc41d";
+const PRINTED_LITERAL_UID = "4d5437c9-788e-4a6d-9be0-4af3a84554f4";
+const SPEC_UID = "e8e8475c-2e58-44a6-9f77-f907569e156e";
+
+type Fm = { path: string; frontmatter: Record<string, unknown> };
+
+function app(files: Fm[]): App {
+  const cache = new Map<string, CachedMetadata>();
+  const mockFiles: TFile[] = [];
+  for (const f of files) {
+    const t = new TFile(f.path);
+    t.basename = f.path.replace(".md", "");
+    t.extension = "md";
+    mockFiles.push(t);
+    cache.set(f.path, { frontmatter: f.frontmatter } as CachedMetadata);
+  }
+  return {
+    vault: { getMarkdownFiles: jest.fn().mockReturnValue(mockFiles) },
+    metadataCache: {
+      getFileCache: jest.fn().mockImplementation((f: TFile) => cache.get(f.path) ?? null),
+      getFirstLinkpathDest: jest.fn().mockImplementation((p: string) => {
+        const clean = p.endsWith(".md") ? p : p + ".md";
+        return mockFiles.find((f) => f.path === clean) ?? null;
+      }),
+    },
+  } as unknown as App;
+}
+
+const spec = (appliesTo = `[[${CONCEPT_CLASS_UID}|concept__Concept]]`): Fm => ({
+  path: `${SPEC_UID}.md`,
+  frontmatter: {
+    exo__Asset_uid: SPEC_UID,
+    exo__Instance_class: [`[[${SPEC_CLASS_UID}|concept__ConceptDefinitionSpec]]`],
+    concept__ConceptDefinitionSpec_appliesToClass: appliesTo,
+  },
+});
+const prop = (order: number, key: string): Fm => ({
+  path: `part-${key}.md`,
+  frontmatter: {
+    exo__Asset_uid: `part-${key}`,
+    exo__Instance_class: [`[[${PRINTED_PROPERTY_UID}|exo__PrintedProperty]]`],
+    exo__DisplayNamePart_of: `[[${SPEC_UID}]]`,
+    exo__DisplayNamePart_order: order,
+    exo__PrintedProperty_property: `[[x|${key}]]`,
+  },
+});
+const lit = (order: number, literal: string): Fm => ({
+  path: `part-lit${order}.md`,
+  frontmatter: {
+    exo__Asset_uid: `part-lit${order}`,
+    exo__Instance_class: [`[[${PRINTED_LITERAL_UID}|exo__PrintedLiteral]]`],
+    exo__DisplayNamePart_of: `[[${SPEC_UID}]]`,
+    exo__DisplayNamePart_order: order,
+    exo__PrintedLiteral_literal: literal,
+  },
+});
+
+describe("ConceptDefinitionSpecService (req eb18a3a4)", () => {
+  it("compiles ordered parts into the template", () => {
+    const svc = new ConceptDefinitionSpecService(
+      app([
+        spec(),
+        prop(0, "concept__Concept_differentia"),
+        lit(1, " "),
+        prop(2, "concept__Concept_genus"),
+      ]),
+    );
+    svc.initialize();
+    expect(svc.getTemplate("concept__Concept")).toBe(
+      "{{concept__Concept_differentia}} {{concept__Concept_genus}}",
+    );
+  });
+
+  it("dual-keys by the appliesToClass UID and label", () => {
+    const svc = new ConceptDefinitionSpecService(
+      app([spec(), prop(0, "concept__Concept_genus")]),
+    );
+    svc.initialize();
+    expect(svc.getTemplate("concept__Concept")).toBe("{{concept__Concept_genus}}");
+    expect(svc.getTemplate(CONCEPT_CLASS_UID)).toBe("{{concept__Concept_genus}}");
+  });
+
+  it("no spec authored → getTemplate is null (materialized-OR-computed falls through to stored)", () => {
+    const svc = new ConceptDefinitionSpecService(app([]));
+    svc.initialize();
+    expect(svc.getTemplate("concept__Concept")).toBeNull();
+  });
+
+  it("a spec with no parts → no template (null)", () => {
+    const svc = new ConceptDefinitionSpecService(app([spec()]));
+    svc.initialize();
+    expect(svc.getTemplate("concept__Concept")).toBeNull();
+  });
+
+  it("before initialize() → null (no vault access yet)", () => {
+    const svc = new ConceptDefinitionSpecService(app([spec(), prop(0, "concept__Concept_genus")]));
+    expect(svc.getTemplate("concept__Concept")).toBeNull();
+  });
+});

--- a/packages/obsidian-plugin/tests/unit/presentation/properties/PropertiesDefinitionValuePatch.test.ts
+++ b/packages/obsidian-plugin/tests/unit/presentation/properties/PropertiesDefinitionValuePatch.test.ts
@@ -80,6 +80,7 @@ function mkFile(path: string): TFile {
 function mountPropertiesBlock(
   app: App,
   file: TFile,
+  mode: "preview" | "source" = "preview",
 ): { valueEl: HTMLElement; containerEl: HTMLElement } {
   const containerEl = document.createElement("div");
   const metadataContainer = document.createElement("div");
@@ -106,7 +107,7 @@ function mountPropertiesBlock(
   document.body.appendChild(containerEl);
 
   (app.workspace.getLeavesOfType as jest.Mock).mockReturnValue([
-    { view: { containerEl, file } },
+    { view: { containerEl, file, getMode: () => mode } },
   ]);
 
   return { valueEl, containerEl };
@@ -164,13 +165,13 @@ describe("PropertiesDefinitionValuePatch — Properties-panel computed definitio
     patch.disable();
   });
 
-  it("@req:eb18a3a4-42b0-47d3-98a7-16b31c5ba6da hides the native editable value control and shows the computed value when the value row carries an input", () => {
+  it("@req:eb18a3a4-42b0-47d3-98a7-16b31c5ba6da does NOT override an EDITABLE value control (no edit-override — the editable definition stays editable)", () => {
     const { app, conceptFile } = buildApp({
       concept__Concept_genus: `[[${OKR_UID}]]`,
       concept__Concept_differentia: [`[[${QUARTERLY_UID}]]`],
     });
     const { valueEl } = mountPropertiesBlock(app, conceptFile);
-    // Replace the text value with an editable input (Live-Preview-leak shape).
+    // The value row carries an editable input (edit-mode shape).
     valueEl.textContent = "";
     const valueInput = document.createElement("input");
     valueInput.value = STORED_TEXT;
@@ -179,14 +180,27 @@ describe("PropertiesDefinitionValuePatch — Properties-panel computed definitio
     const patch = new PropertiesDefinitionValuePatch(makePlugin(app));
     patch.enable();
 
-    const span = valueEl.querySelector<HTMLElement>(".exo-definition-display");
-    expect(span?.textContent).toBe("quarterly OKR");
-    // The native input is hidden (never mutated) and the stored value is preserved on it.
-    expect(valueInput.classList.contains("exo-definition-hidden")).toBe(true);
-    expect(valueInput.value).toBe(STORED_TEXT);
-
-    patch.disable();
-    expect(valueInput.classList.contains("exo-definition-hidden")).toBe(false);
+    // Reading-mode display ONLY → the editable input is left untouched, no computed span injected.
     expect(valueEl.querySelector(".exo-definition-display")).toBeNull();
+    expect(valueInput.value).toBe(STORED_TEXT);
+    expect(valueEl.contains(valueInput)).toBe(true);
+    patch.disable();
+  });
+
+  it("@req:eb18a3a4-42b0-47d3-98a7-16b31c5ba6da does NOT patch when the view is in EDIT (source) mode (reading-mode only)", () => {
+    const { app, conceptFile } = buildApp({
+      concept__Concept_genus: `[[${OKR_UID}]]`,
+      concept__Concept_differentia: [`[[${QUARTERLY_UID}]]`],
+      concept__Concept_definition: STORED_TEXT,
+    });
+    const { valueEl } = mountPropertiesBlock(app, conceptFile, "source");
+
+    const patch = new PropertiesDefinitionValuePatch(makePlugin(app));
+    patch.enable();
+
+    // Source (edit) mode → no override; native stored value untouched.
+    expect(valueEl.textContent).toBe(STORED_TEXT);
+    expect(valueEl.querySelector(".exo-definition-display")).toBeNull();
+    patch.disable();
   });
 });

--- a/packages/obsidian-plugin/tests/unit/presentation/properties/PropertiesDefinitionValuePatch.test.ts
+++ b/packages/obsidian-plugin/tests/unit/presentation/properties/PropertiesDefinitionValuePatch.test.ts
@@ -14,6 +14,10 @@ import { PropertiesDefinitionValuePatch } from "@plugin/presentation/properties/
  */
 
 const CONCEPT_CLASS_UID = "dda12c48-40f3-4f1a-9f5b-8c1e2d3a4b5c";
+const CONCEPT_DEFINITION_SPEC_CLASS_UID = "26358178-cf0e-4e5f-b92a-f59c6ac71908";
+const PRINTED_PROPERTY_UID = "7d58de40-d941-4a66-88e2-13afc4fdc41d";
+const PRINTED_LITERAL_UID = "4d5437c9-788e-4a6d-9be0-4af3a84554f4";
+const SPEC_UID = "e8e8475c-2e58-44a6-9f77-f907569e156e";
 const OKR_UID = "0a11c0de-0000-4000-8000-000000000001";
 const QUARTERLY_UID = "0a11c0de-0000-4000-8000-000000000002";
 const CONCEPT_PATH = "concept-under-test.md";
@@ -24,7 +28,53 @@ interface FrontmatterFile {
   frontmatter: Record<string, unknown>;
 }
 
-/** Build a fake App whose metadataCache resolves the genus/differentia targets to their labels. */
+/** The vault-declared composition spec + parts (so the patch's spec service compiles a template). */
+function specFiles(): FrontmatterFile[] {
+  return [
+    {
+      file: mkFile(`${SPEC_UID}.md`),
+      frontmatter: {
+        exo__Asset_uid: SPEC_UID,
+        exo__Instance_class: [
+          `[[${CONCEPT_DEFINITION_SPEC_CLASS_UID}|concept__ConceptDefinitionSpec]]`,
+        ],
+        concept__ConceptDefinitionSpec_appliesToClass: `[[${CONCEPT_CLASS_UID}|concept__Concept]]`,
+      },
+    },
+    {
+      file: mkFile("part-differentia.md"),
+      frontmatter: {
+        exo__Asset_uid: "part-diff",
+        exo__Instance_class: [`[[${PRINTED_PROPERTY_UID}|exo__PrintedProperty]]`],
+        exo__DisplayNamePart_of: `[[${SPEC_UID}]]`,
+        exo__DisplayNamePart_order: 0,
+        exo__PrintedProperty_property: "[[dp|concept__Concept_differentia]]",
+      },
+    },
+    {
+      file: mkFile("part-literal.md"),
+      frontmatter: {
+        exo__Asset_uid: "part-lit",
+        exo__Instance_class: [`[[${PRINTED_LITERAL_UID}|exo__PrintedLiteral]]`],
+        exo__DisplayNamePart_of: `[[${SPEC_UID}]]`,
+        exo__DisplayNamePart_order: 1,
+        exo__PrintedLiteral_literal: " ",
+      },
+    },
+    {
+      file: mkFile("part-genus.md"),
+      frontmatter: {
+        exo__Asset_uid: "part-genus",
+        exo__Instance_class: [`[[${PRINTED_PROPERTY_UID}|exo__PrintedProperty]]`],
+        exo__DisplayNamePart_of: `[[${SPEC_UID}]]`,
+        exo__DisplayNamePart_order: 2,
+        exo__PrintedProperty_property: "[[gp|concept__Concept_genus]]",
+      },
+    },
+  ];
+}
+
+/** Build a fake App whose vault carries the spec + parts and resolves genus/differentia to labels. */
 function buildApp(
   activeFrontmatter: Record<string, unknown>,
 ): { app: App; conceptFile: TFile } {
@@ -40,11 +90,13 @@ function buildApp(
   ];
   const conceptFile = mkFile(CONCEPT_PATH);
   const all: FrontmatterFile[] = [
+    ...specFiles(),
     ...targets,
     { file: conceptFile, frontmatter: activeFrontmatter },
   ];
 
   const app = {
+    vault: { getMarkdownFiles: jest.fn().mockReturnValue(all.map((x) => x.file)) },
     metadataCache: {
       getFileCache: jest.fn().mockImplementation((f: TFile) => {
         const found = all.find((x) => x.file.path === f.path);

--- a/packages/obsidian-plugin/tests/unit/presentation/properties/PropertiesDefinitionValuePatch.test.ts
+++ b/packages/obsidian-plugin/tests/unit/presentation/properties/PropertiesDefinitionValuePatch.test.ts
@@ -1,0 +1,192 @@
+import { TFile } from "obsidian";
+import type { App, Plugin } from "obsidian";
+import { PropertiesDefinitionValuePatch } from "@plugin/presentation/properties/PropertiesDefinitionValuePatch";
+
+/**
+ * Delta-2 concept definition-renderer (req eb18a3a4), SURFACE half: the native Properties-panel
+ * definition VALUE row renders the computed "<differentia> <genus>" phrase where genus is
+ * present (Reading Mode), leaving the stored free-text untouched where genus is absent. Drives
+ * the REAL patch over a jsdom .metadata-container carrying a concept__Concept_definition row.
+ *
+ * Revert-verify (recorded in the PR body): neutralizing the patch's resolver call
+ * (resolveComputed → always null) makes the "computed value shown" assertion RED; restore →
+ * GREEN. The negative controls (no genus → native value untouched) stay GREEN both ways.
+ */
+
+const CONCEPT_CLASS_UID = "dda12c48-40f3-4f1a-9f5b-8c1e2d3a4b5c";
+const OKR_UID = "0a11c0de-0000-4000-8000-000000000001";
+const QUARTERLY_UID = "0a11c0de-0000-4000-8000-000000000002";
+const CONCEPT_PATH = "concept-under-test.md";
+const STORED_TEXT = "an outdated hand-written definition";
+
+interface FrontmatterFile {
+  file: TFile;
+  frontmatter: Record<string, unknown>;
+}
+
+/** Build a fake App whose metadataCache resolves the genus/differentia targets to their labels. */
+function buildApp(
+  activeFrontmatter: Record<string, unknown>,
+): { app: App; conceptFile: TFile } {
+  const targets: FrontmatterFile[] = [
+    {
+      file: mkFile(`${OKR_UID}.md`),
+      frontmatter: { exo__Asset_uid: OKR_UID, exo__Asset_label: "OKR" },
+    },
+    {
+      file: mkFile(`${QUARTERLY_UID}.md`),
+      frontmatter: { exo__Asset_uid: QUARTERLY_UID, exo__Asset_label: "quarterly" },
+    },
+  ];
+  const conceptFile = mkFile(CONCEPT_PATH);
+  const all: FrontmatterFile[] = [
+    ...targets,
+    { file: conceptFile, frontmatter: activeFrontmatter },
+  ];
+
+  const app = {
+    metadataCache: {
+      getFileCache: jest.fn().mockImplementation((f: TFile) => {
+        const found = all.find((x) => x.file.path === f.path);
+        return found ? { frontmatter: found.frontmatter } : null;
+      }),
+      getFirstLinkpathDest: jest.fn().mockImplementation((path: string) => {
+        const clean = path.endsWith(".md") ? path : path + ".md";
+        return all.find((x) => x.file.path === clean)?.file ?? null;
+      }),
+      on: jest.fn().mockReturnValue({ id: "ref" }),
+    },
+    workspace: {
+      getLeavesOfType: jest.fn(),
+      on: jest.fn().mockReturnValue({ id: "ref" }),
+    },
+  } as unknown as App;
+
+  return { app, conceptFile };
+}
+
+function mkFile(path: string): TFile {
+  const f = new TFile(path);
+  f.basename = path.replace(".md", "");
+  f.extension = "md";
+  return f;
+}
+
+/**
+ * Build a Reading-Mode Properties block DOM for a file with a concept__Concept_definition row,
+ * attach it to document.body, and register a fake markdown leaf (view.containerEl + view.file)
+ * on the app's workspace. Returns the value element for assertions.
+ */
+function mountPropertiesBlock(
+  app: App,
+  file: TFile,
+): { valueEl: HTMLElement; containerEl: HTMLElement } {
+  const containerEl = document.createElement("div");
+  const metadataContainer = document.createElement("div");
+  metadataContainer.className = "metadata-container";
+
+  const propertyEl = document.createElement("div");
+  propertyEl.className = "metadata-property";
+  propertyEl.setAttribute("data-property-key", "concept__concept_definition");
+
+  const keyEl = document.createElement("div");
+  keyEl.className = "metadata-property-key";
+  const keyInput = document.createElement("input");
+  keyInput.value = "concept__Concept_definition"; // original-case predicate
+  keyEl.appendChild(keyInput);
+
+  const valueEl = document.createElement("div");
+  valueEl.className = "metadata-property-value";
+  valueEl.textContent = STORED_TEXT; // native Reading-Mode text value
+
+  propertyEl.appendChild(keyEl);
+  propertyEl.appendChild(valueEl);
+  metadataContainer.appendChild(propertyEl);
+  containerEl.appendChild(metadataContainer);
+  document.body.appendChild(containerEl);
+
+  (app.workspace.getLeavesOfType as jest.Mock).mockReturnValue([
+    { view: { containerEl, file } },
+  ]);
+
+  return { valueEl, containerEl };
+}
+
+function makePlugin(app: App): Plugin {
+  return {
+    app,
+    registerEvent: jest.fn(),
+  } as unknown as Plugin;
+}
+
+describe("PropertiesDefinitionValuePatch — Properties-panel computed definition (req eb18a3a4)", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+    jest.clearAllMocks();
+  });
+
+  it("@req:eb18a3a4-42b0-47d3-98a7-16b31c5ba6da overrides the concept__Concept_definition VALUE row with the computed '<differentia> <genus>' where genus is present", () => {
+    const { app, conceptFile } = buildApp({
+      exo__Instance_class: [`[[${CONCEPT_CLASS_UID}|concept__Concept]]`],
+      concept__Concept_genus: `[[${OKR_UID}]]`,
+      concept__Concept_differentia: [`[[${QUARTERLY_UID}]]`],
+      concept__Concept_definition: STORED_TEXT,
+    });
+    const { valueEl } = mountPropertiesBlock(app, conceptFile);
+
+    const patch = new PropertiesDefinitionValuePatch(makePlugin(app));
+    patch.enable();
+
+    // The row VALUE now shows the computed phrase, resolved 1-hop through the real resolver.
+    expect(valueEl.textContent).toBe("quarterly OKR");
+    // A dedicated computed-definition display span carries it (Reading-Mode display).
+    const span = valueEl.querySelector<HTMLElement>(".exo-definition-display");
+    expect(span?.getAttribute("data-exo-computed-definition")).toBe("true");
+
+    // Restore leaves the native stored value intact (no frontmatter mutation — display-only).
+    patch.disable();
+    expect(valueEl.textContent).toBe(STORED_TEXT);
+  });
+
+  it("@req:eb18a3a4-42b0-47d3-98a7-16b31c5ba6da leaves the stored free-text VALUE untouched when genus is ABSENT (materialized, no patch)", () => {
+    const { app, conceptFile } = buildApp({
+      exo__Instance_class: [`[[${CONCEPT_CLASS_UID}|concept__Concept]]`],
+      concept__Concept_definition: STORED_TEXT,
+    });
+    const { valueEl } = mountPropertiesBlock(app, conceptFile);
+
+    const patch = new PropertiesDefinitionValuePatch(makePlugin(app));
+    patch.enable();
+
+    // No genus → nothing computed → the native stored value is shown unchanged, no display span.
+    expect(valueEl.textContent).toBe(STORED_TEXT);
+    expect(valueEl.querySelector(".exo-definition-display")).toBeNull();
+    patch.disable();
+  });
+
+  it("@req:eb18a3a4-42b0-47d3-98a7-16b31c5ba6da hides the native editable value control and shows the computed value when the value row carries an input", () => {
+    const { app, conceptFile } = buildApp({
+      concept__Concept_genus: `[[${OKR_UID}]]`,
+      concept__Concept_differentia: [`[[${QUARTERLY_UID}]]`],
+    });
+    const { valueEl } = mountPropertiesBlock(app, conceptFile);
+    // Replace the text value with an editable input (Live-Preview-leak shape).
+    valueEl.textContent = "";
+    const valueInput = document.createElement("input");
+    valueInput.value = STORED_TEXT;
+    valueEl.appendChild(valueInput);
+
+    const patch = new PropertiesDefinitionValuePatch(makePlugin(app));
+    patch.enable();
+
+    const span = valueEl.querySelector<HTMLElement>(".exo-definition-display");
+    expect(span?.textContent).toBe("quarterly OKR");
+    // The native input is hidden (never mutated) and the stored value is preserved on it.
+    expect(valueInput.classList.contains("exo-definition-hidden")).toBe(true);
+    expect(valueInput.value).toBe(STORED_TEXT);
+
+    patch.disable();
+    expect(valueInput.classList.contains("exo-definition-hidden")).toBe(false);
+    expect(valueEl.querySelector(".exo-definition-display")).toBeNull();
+  });
+});


### PR DESCRIPTION
## What

Delta-2 of concept-typization ([design-capture](https://github.com/kitelev/exocortex), req `eb18a3a4-42b0-47d3-98a7-16b31c5ba6da`). Makes a concept's `concept__Concept_definition` a homoiconic **COMPUTED VIEW** from its intensional structure — the analog of `DisplayNameResolver` over `exo__DisplayNameSpec`. Aristotelian transparency: you *declare* `concept__Concept_genus` + `concept__Concept_differentia` and the definition renders; you don't hand-write it (where a clean genus exists).

**Semantics — materialized-OR-computed (RFC b860de33 F1 revision), fail-closed:**
- genus **present** → computed `"<differentia labels> <genus label>"` (each `[[uid]]` resolved 1-hop to its `exo__Asset_label`, the same resolution `exo__PrintedProperty` uses). Multiple differentia join as space-separated adjectives before the genus (`recurring quarterly OKR`); the rare conjunctive upper-ontology genus (≥2 genus values) renders `<diff> [g₁ ∧ g₂]`.
- genus **absent** → the stored free-text `concept__Concept_definition` is returned unchanged (materialized narrative — ~70% of definitions carry non-reconstructible content).
- **fail-closed** → no genus + no stored text → `null` (a definition is never fabricated).

## How

- **`ConceptDefinitionResolver`** (pure domain unit, no Obsidian dep) — `resolve()` = materialized-OR-computed; `resolveComputed()` = the computed phrase only (`null` when genus absent, so the patch overrides only in the computed case). 1-hop label resolution via an injected `MetadataResolver` (as `DisplayNameResolver` receives from `PrintNameRuleService.createMetadataResolver`).
- **`PropertiesDefinitionValuePatch`** (Reading-Mode value patch, analog to `PropertiesLabelPatch`) — overrides the `concept__Concept_definition` VALUE row with the computed phrase where genus is present. **Display-only, never mutates the stored frontmatter** (no edit-override → no corruption risk). Always enabled — a **no-op until a concept declares a genus** (dormant until the Delta-3 migration produces typed instances; 0 typed instances today, by design).

## ⛤ Surface-parity — falsified premise (verify-before-assert)

The Delta-2 AC said the definition renders "where free-text definition is currently shown (surface-parity)". Recon of `origin/main` found **`concept__Concept_definition` has NO custom render site in the plugin** — the only reference is `ConceptCreationService` (write-only, at creation); it is displayed *only* by Obsidian's native Properties panel. So the surface here IS the native Properties-panel definition VALUE row (the sole place it shows), documented in the req like the RFC's F1/F3 falsification notes. Escalated + orchestrator-ruled Option A (resolver + Reading-Mode value patch).

**Out of scope (follow-ups):** (i) a concept with genus but NO stored `concept__Concept_definition` key shows no native row to override → rendering the computed definition where the property is absent is a NEW surface (row insertion / dedicated block); (ii) the Delta-3 instance migration (~3354 concepts) — the computed branch's real-data activation.

## Tests (production-shape) + revert-verify

- **`ConceptDefinitionResolver.test.ts`** — the resolver over a REAL `PrintNameRuleService.createMetadataResolver()` against synthetic typed concepts (real 1-hop label resolution, no stubbed resolver).
- **`PropertiesDefinitionValuePatch.test.ts`** — the real patch over a jsdom `.metadata-container` (Reading-Mode text + input-leak shapes; restore leaves the stored value intact).

**Revert-verified (`@req:eb18a3a4-42b0-47d3-98a7-16b31c5ba6da`):**
- axis-1 — break the resolver composition (drop the differentia) → the "quarterly OKR" assertions (resolver + patch) go **RED** (7 RED / 4 GREEN negatives); restore → GREEN.
- axis-2 — neutralize the patch's `resolveComputed` wiring → the Properties-panel value-override tests go **RED** (2 RED / 9 GREEN incl. all resolver); restore → GREEN.
- Negative controls (no genus → stored free-text / neither → null) stay GREEN both ways. 11/11 GREEN restored.

Req: eb18a3a4-42b0-47d3-98a7-16b31c5ba6da