### PR TITLE
fix(ci): copy packages/cli/scripts before npm ci in Dockerfile.ci

### DIFF
--- a/packages/obsidian-plugin/Dockerfile.ci
+++ b/packages/obsidian-plugin/Dockerfile.ci
@@ -59,6 +59,11 @@ COPY packages/core/package*.json ./packages/core/
 COPY packages/obsidian-plugin/package*.json ./packages/obsidian-plugin/
 COPY packages/cli/package*.json ./packages/cli/
 COPY packages/test-utils/package*.json ./packages/test-utils/
+# packages/cli declares a `postinstall` (node ./scripts/postinstall.cjs) that
+# npm runs during `npm ci`. The manifest-only copy above does not include that
+# script, so `npm ci` fails with MODULE_NOT_FOUND. Copy it before the install
+# (it is idempotent and no-ops when packages/cli/bin is absent, as it is here).
+COPY packages/cli/scripts/ ./packages/cli/scripts/
 RUN npm ci --prefer-offline --no-audit --no-fund
 
 ENV DISPLAY=:99


### PR DESCRIPTION
## Problem

The **CI Docker Image** workflow (`ci-image.yml`) — which pre-builds & publishes the e2e base image to GHCR — has been **red since 2026-06-22** (4 consecutive runs: 07-25, 07-21, 06-28, 06-22).

Root cause: `Dockerfile.ci` copies only the `package*.json` manifests before `npm ci` (a layer-caching optimization), but `packages/cli` declares a `postinstall` lifecycle script (`node ./scripts/postinstall.cjs`, added in #3077) that npm runs during the install. That file was **not** in the build context, so `npm ci` died with:

```
npm error Cannot find module '/app/packages/cli/scripts/postinstall.cjs'
ERROR: process "/bin/sh -c npm ci ..." did not complete successfully: exit code: 1
```

The bug was latent since #3077 (2026-05-03) and **surfaced on 06-22** when #3713 (M5a rename) changed `package-lock.json` — one of `ci-image.yml`'s path triggers.

## Fix

`COPY packages/cli/scripts/ ./packages/cli/scripts/` before the `npm ci`. The postinstall is idempotent and **no-ops** in this context (its `BIN_SRC = packages/cli/bin` is absent → each copy is skipped → `process.exit(0)`), so `npm ci` succeeds.

Chose this over a blanket `--ignore-scripts` because esbuild@0.27 (and Playwright/husky) declare their own lifecycle scripts — disabling all of them risks breaking the build. This targeted copy restores the exact pre-06-22 behavior plus the cli postinstall.

## Verification

Dispatched `ci-image.yml` on this branch (`gh workflow run ci-image.yml --ref fix-ci-docker-postinstall`) to run the exact failing `npm ci` with the fix. _(watching)_

## Impact

Non-required, non-release-blocking (e2e-shard falls back to the stale GHCR `:latest`). But the failure means the pre-built base image is never republished — so every e2e run has used a **>5-week-old** base image. This restores fresh base-image publishing.

https://claude.ai/code/session_011yAmSqaohWgrz8xdc1gACq