### PR TITLE
fix(deps): js-yaml 4.3.0 — namespace import (supersedes #3933)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16240,7 +16240,7 @@
         "typescript": "^5.9.3"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "packages/cli/node_modules/chalk": {

--- a/packages/cli/src/adapters/FileSystemVaultAdapter.ts
+++ b/packages/cli/src/adapters/FileSystemVaultAdapter.ts
@@ -1,6 +1,6 @@
 import fs from "fs-extra";
 import path from "path";
-import yaml from "js-yaml";
+import * as yaml from "js-yaml";
 import {
   IVaultAdapter,
   IFile,

--- a/packages/cli/src/commands/exosync-parity.ts
+++ b/packages/cli/src/commands/exosync-parity.ts
@@ -24,7 +24,7 @@ import { Command } from "commander";
 import { promises as fsp, existsSync } from "node:fs";
 import { webcrypto } from "node:crypto";
 import * as path from "node:path";
-import yaml from "js-yaml";
+import * as yaml from "js-yaml";
 import {
   FileWatermarkStore,
   ParityValidator,

--- a/packages/cli/src/commands/exosync-sync.ts
+++ b/packages/cli/src/commands/exosync-sync.ts
@@ -37,7 +37,7 @@ import { webcrypto } from "node:crypto";
 import { execFile as execFileCb } from "node:child_process";
 import { promisify } from "node:util";
 import * as path from "node:path";
-import yaml from "js-yaml";
+import * as yaml from "js-yaml";
 import {
   CONFLICT_CACHE_STORE_FILENAME,
   FileLocalManifestStore,

--- a/packages/cli/src/commands/validate-schema.ts
+++ b/packages/cli/src/commands/validate-schema.ts
@@ -2,7 +2,7 @@ import { Command } from "commander";
 import { existsSync, readFileSync, readdirSync, statSync } from "fs";
 import { resolve, relative, join } from "path";
 import { execSync } from "child_process";
-import yaml from "js-yaml";
+import * as yaml from "js-yaml";
 import {
   InMemoryTripleStore,
   ExoQLParser,

--- a/packages/cli/src/services/AtomicFrontmatterService.ts
+++ b/packages/cli/src/services/AtomicFrontmatterService.ts
@@ -7,7 +7,7 @@ import {
 } from "fs";
 import path from "path";
 import { randomBytes } from "crypto";
-import yaml from "js-yaml";
+import * as yaml from "js-yaml";
 import { parseYamlFrontmatterTolerant } from "@kitelev/exocortex-core";
 
 export type AtomicUpdateFailureReason =

--- a/packages/core/src/utilities/parseYamlFrontmatter.ts
+++ b/packages/core/src/utilities/parseYamlFrontmatter.ts
@@ -1,4 +1,4 @@
-import yaml from "js-yaml";
+import * as yaml from "js-yaml";
 
 /**
  * Tolerantly parse a YAML frontmatter block.

--- a/packages/obsidian-plugin/src/infrastructure/adapters/ExoSyncParityFactory.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/ExoSyncParityFactory.ts
@@ -21,7 +21,7 @@
  */
 
 import type { App, DataAdapter } from "obsidian";
-import yaml from "js-yaml";
+import * as yaml from "js-yaml";
 import {
   FileWatermarkStore,
   ParityValidator,

--- a/packages/obsidian-plugin/src/infrastructure/adapters/SyncDepsFactory.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/SyncDepsFactory.ts
@@ -1,5 +1,5 @@
 import type { App, DataAdapter } from "obsidian";
-import yaml from "js-yaml";
+import * as yaml from "js-yaml";
 import {
   CONFLICT_CACHE_STORE_FILENAME,
   FileLocalManifestStore,


### PR DESCRIPTION
## Problem

Dependabot #3933 bumps `js-yaml` 4.1.1 → 4.3.0 (patching GHSA-h67p-54hq-rp68, quadratic-DoS in merge-key handling) — but **it breaks the build**: js-yaml **4.3.0 removed the `default` ESM export**, so the codebase's `import yaml from "js-yaml"` fails esbuild (`No matching export … for import "default"`). That's #3933's red `build` check.

## Fix

All **8** js-yaml consumers → `import * as yaml from "js-yaml"` (namespace import). Every usage is `yaml.load`/`yaml.dump`/`yaml.CORE_SCHEMA`, unchanged against named exports. Patches both js-yaml advisories (4.x → 4.3.0; nested 3.14.2 under @istanbuljs → 3.15.0).

## Verification (local)

- **plugin esbuild bundle → OK** (the exact failing check on #3933)
- typecheck 0 errors; core frontmatter + cli js-yaml-consumer suites **191/191 pass**

Supersedes #3933.

https://claude.ai/code/session_011yAmSqaohWgrz8xdc1gACq