### PR TITLE
feat(cli): create rejects unknown property NAMES against the mounted TBox (RFC 430e84f1)

### DIFF
--- a/packages/cli/src/commands/create.ts
+++ b/packages/cli/src/commands/create.ts
@@ -12,6 +12,7 @@ import { NodeFsAdapter } from "../adapters/NodeFsAdapter.js";
 import { FileSystemVaultAdapter } from "../adapters/FileSystemVaultAdapter.js";
 import { ClassResolverService } from "../services/ClassResolverService.js";
 import { WikilinkValidator } from "../services/WikilinkValidator.js";
+import { PropertyNameValidator } from "../services/PropertyNameValidator.js";
 import { EffortStatusResolver } from "../services/EffortStatusResolver.js";
 import { ErrorHandler } from "../utils/ErrorHandler.js";
 import { VaultNotFoundError } from "../utils/errors/index.js";
@@ -268,6 +269,20 @@ export function createCommand(): Command {
         // status default can be injected (issue #3849) before `propertyValues`
         // is finalised below.
         const properties = parseProperties(options.property);
+
+        // Validate property NAMES against the mounted TBox (RFC 430e84f1, P1).
+        // `create` already rejects a dangling wikilink VALUE (WikilinkValidator);
+        // this closes the twin fail-silent hole on the KEY — a `--property` key
+        // whose name does not exist in the mounted TBox is rejected fail-loud
+        // with a fuzzy suggestion + a machine-readable `{ unknown, suggestions }`
+        // structured error, so an LLM agent's typo (`ems__Effort_parentEffort`)
+        // cannot silently land a DEAD property. There is deliberately NO skip
+        // flag — the guarantee has no bot-accessible escape-hatch (must-have #6);
+        // validation is fail-open when NO property definitions are mounted
+        // (degenerate/partial profile). Validates the raw USER keys only (the
+        // CLI injects its own well-known keys downstream).
+        const propertyNameValidator = new PropertyNameValidator(vaultPath);
+        await propertyNameValidator.validate(Object.keys(properties));
 
         // Resolve body content and parse escape sequences
         let body = await resolveBody(options);

--- a/packages/cli/src/services/PropertyNameValidator.ts
+++ b/packages/cli/src/services/PropertyNameValidator.ts
@@ -1,0 +1,273 @@
+import { UnknownPropertyError } from "../utils/errors/UnknownPropertyError.js";
+
+/**
+ * The set of known property NAMES + their namespace prefixes, collected once
+ * per process from the MOUNTED vault (RFC 430e84f1 must-have #1).
+ */
+interface PropertyNameSet {
+  /** Known property names in `prefix__Name` label form (e.g. `ems__Effort_parent`). */
+  names: Set<string>;
+  /** Namespace prefixes seen among the known names (e.g. `ems`, `exo`). */
+  prefixes: Set<string>;
+}
+
+/**
+ * Validates that `--property KEY=value` KEYS name a property that exists in the
+ * MOUNTED TBox (RFC 430e84f1, P1). `create` already rejects a dangling wikilink
+ * VALUE (`WikilinkValidator`); this closes the twin fail-silent hole on the KEY
+ * — an LLM agent's typo (`ems__Effort_parentEffort` for `ems__Effort_parent`)
+ * used to land a DEAD property no query/layout/graph-relation reads.
+ *
+ * Design (verify-before-assert, 2026-07-27):
+ *  - The set is collected in ONE pass over the mounted vault, matching ALL three
+ *    property metaclasses — `exo__Property`, `exo__ObjectProperty`,
+ *    `exo__DatatypeProperty`. `ShapeLoader` (the existing introspection) is NOT
+ *    reused because it is domain-filtered (`if domain.length===0 return`) and
+ *    never matches `exo__DatatypeProperty`, so it would false-reject valid
+ *    domainless / datatype properties. Empirically the dedicated collector found
+ *    256 names in real vault-my with every structural/ems property present.
+ *  - The NAME is read from `exo__Asset_label` (the `prefix__Name` label form),
+ *    and the `--property` KEY is also `prefix__Name`, so matching is direct
+ *    string equality on the label. The symbolic↔UID dual-IRI налог
+ *    (sparql-iri-form-pre-verify) applies only to STORE-IRI collection, which
+ *    this does NOT use.
+ *
+ * Rules (must-haves #2-#7):
+ *  - Non-`prefix__Name`-shaped keys (`aliases`, `tags`, `title`) are SKIPPED (#2/#3).
+ *  - Empty mounted set (degenerate / no property TBox mounted) → SKIP all,
+ *    fail-open — never brick a partial/degenerate profile (#7).
+ *  - Name in set → PASS (#3 no false-positive).
+ *  - Known prefix, unknown name → REJECT + fuzzy-suggest closest same-prefix
+ *    name (#4).
+ *  - Unknown prefix → REJECT (no near suggestion) (#4).
+ *  - There is NO skip flag — property-name validation always runs (#6).
+ */
+export class PropertyNameValidator {
+  /** `prefix__Local` shape; group 1 = prefix. Bare YAML keys never match. */
+  private static readonly KEY_SHAPE = /^([A-Za-z][A-Za-z0-9]*)__.+$/;
+
+  /**
+   * Property metaclass identifiers, in every wikilink form the collector may
+   * encounter (bare UID `[[<uid>]]`, alias `[[<uid>|label]]`, label `[[label]]`).
+   */
+  private static readonly PROPERTY_METACLASS_UIDS: ReadonlyArray<string> = [
+    "38277bfa-d7f9-4a75-b856-b23276ab0db3", // exo__Property
+    "9a1cf31c-9d41-4ef3-9023-584a8d087d16", // exo__ObjectProperty
+    "ae56ca4c-b610-42a4-a25d-058c23673296", // exo__DatatypeProperty
+  ];
+  private static readonly PROPERTY_METACLASS_LABELS: ReadonlyArray<string> = [
+    "exo__Property",
+    "exo__ObjectProperty",
+    "exo__DatatypeProperty",
+  ];
+
+  private cache: PropertyNameSet | null = null;
+
+  constructor(private readonly vaultPath: string) {}
+
+  /**
+   * Validate the given `--property` KEYS against the mounted TBox.
+   *
+   * @throws UnknownPropertyError on the first key that is `prefix__Name`-shaped
+   *   yet not a known mounted property name (only when the mounted set is
+   *   non-empty).
+   */
+  async validate(propertyKeys: string[]): Promise<void> {
+    const { names, prefixes } = await this.collect();
+
+    // Fail-open: no property definitions mounted at all (degenerate / unmounted
+    // TBox) → cannot judge, so skip rather than reject everything (must-have #7).
+    if (names.size === 0) return;
+
+    for (const key of propertyKeys) {
+      const shape = PropertyNameValidator.KEY_SHAPE.exec(key);
+      if (!shape) continue; // bare YAML key (aliases/tags/title) → skip (#2/#3)
+      if (names.has(key)) continue; // known property name → pass (#3)
+
+      const prefix = shape[1];
+      const scopeToPrefix = prefixes.has(prefix) ? prefix : undefined;
+      const suggestions = PropertyNameValidator.suggest(key, names, scopeToPrefix);
+      throw new UnknownPropertyError(key, suggestions);
+    }
+  }
+
+  /** Collect the known property-name set from the mounted vault (cached). */
+  async collect(): Promise<PropertyNameSet> {
+    if (this.cache) return this.cache;
+
+    // eslint-disable-next-line import/no-nodejs-modules
+    const { readdir, readFile } = await import("fs/promises");
+
+    const names = new Set<string>();
+    const prefixes = new Set<string>();
+
+    const walk = async (dir: string): Promise<void> => {
+      let entries: import("fs").Dirent[];
+      try {
+        entries = await readdir(dir, { withFileTypes: true });
+      } catch {
+        return;
+      }
+      for (const entry of entries) {
+        const full = `${dir}/${entry.name}`;
+        if (entry.isDirectory()) {
+          await walk(full);
+        } else if (entry.isFile() && entry.name.endsWith(".md")) {
+          let content: string;
+          try {
+            content = await readFile(full, "utf-8");
+          } catch {
+            continue;
+          }
+          PropertyNameValidator.harvest(content, names, prefixes);
+        }
+      }
+    };
+
+    await walk(this.vaultPath);
+    this.cache = { names, prefixes };
+    return this.cache;
+  }
+
+  /** If `content` is a property definition, add its name + prefix to the sets. */
+  private static harvest(
+    content: string,
+    names: Set<string>,
+    prefixes: Set<string>,
+  ): void {
+    const fm = PropertyNameValidator.parseFrontmatter(content);
+    if (!fm) return;
+
+    const classes = PropertyNameValidator.asArray(fm["exo__Instance_class"]);
+    if (!classes.some((c) => PropertyNameValidator.isPropertyMetaclass(c))) {
+      return;
+    }
+
+    const labelRaw = fm["exo__Asset_label"];
+    if (typeof labelRaw !== "string") return;
+    const label = labelRaw.replace(/^["']|["']$/g, "").trim();
+    if (!PropertyNameValidator.KEY_SHAPE.test(label)) return;
+
+    names.add(label);
+    const m = PropertyNameValidator.KEY_SHAPE.exec(label);
+    if (m) prefixes.add(m[1]);
+  }
+
+  /** True when a wikilink value references any property metaclass. */
+  private static isPropertyMetaclass(value: string): boolean {
+    const ref = PropertyNameValidator.extractWikilinkRef(value);
+    if (!ref) return false;
+    // ref may be `<uid>`, `<label>`, or `<uid>|<alias>` — check every half.
+    const halves = ref.split("|").map((h) => h.trim());
+    for (const half of halves) {
+      if (PropertyNameValidator.PROPERTY_METACLASS_LABELS.includes(half)) {
+        return true;
+      }
+      if (PropertyNameValidator.PROPERTY_METACLASS_UIDS.includes(half)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /** Extract the inner ref of `[[ref]]` / `[[ref|alias]]`, stripping quotes. */
+  private static extractWikilinkRef(value: string): string | null {
+    const clean = String(value).replace(/^["']|["']$/g, "").trim();
+    const m = /\[\[([^\]]+)\]\]/.exec(clean);
+    return m ? m[1] : clean;
+  }
+
+  private static asArray(v: unknown): string[] {
+    if (Array.isArray(v)) return v.map(String);
+    if (typeof v === "string") return [v];
+    return [];
+  }
+
+  /**
+   * Minimal YAML frontmatter parser (mirrors ShapeLoader): `key: value` and
+   * `key:\n  - item` arrays. Sufficient for the fields harvested here.
+   */
+  private static parseFrontmatter(
+    content: string,
+  ): Record<string, string | string[]> | null {
+    const match = /^---\r?\n([\s\S]*?)\r?\n---/.exec(content);
+    if (!match) return null;
+
+    const result: Record<string, string | string[]> = {};
+    const lines = match[1].split(/\r?\n/);
+    let currentKey: string | null = null;
+    let currentArray: string[] | null = null;
+
+    for (const line of lines) {
+      const arrayItem = /^ {2}- (.*)$/.exec(line);
+      if (arrayItem) {
+        if (currentKey && currentArray) currentArray.push(arrayItem[1].trim());
+        continue;
+      }
+      if (currentKey && currentArray) {
+        result[currentKey] = currentArray;
+        currentKey = null;
+        currentArray = null;
+      }
+      const kv = /^([^:]+):\s*(.*)$/.exec(line);
+      if (!kv) continue;
+      const key = kv[1].trim();
+      const value = kv[2].trim();
+      if (value === "") {
+        currentKey = key;
+        currentArray = [];
+      } else {
+        result[key] = value;
+      }
+    }
+    if (currentKey && currentArray) result[currentKey] = currentArray;
+    return result;
+  }
+
+  /**
+   * Closest known names to `key` by Levenshtein distance, best-first (≤3).
+   * Restricted to the same prefix when the prefix is known (so a typo in
+   * `ems__` suggests `ems__` names, not cross-namespace noise); otherwise all
+   * names are candidates (an unknown prefix rarely has a near match, so this
+   * usually yields no suggestion — a plain reject).
+   */
+  private static suggest(
+    key: string,
+    names: Set<string>,
+    samePrefix: string | undefined,
+  ): string[] {
+    const candidates = samePrefix
+      ? [...names].filter((n) => n.startsWith(`${samePrefix}__`))
+      : [...names];
+    const threshold = Math.max(3, Math.floor(key.length * 0.4));
+
+    return candidates
+      .map((name) => ({
+        name,
+        distance: PropertyNameValidator.levenshtein(key, name),
+      }))
+      .filter((c) => c.distance <= threshold)
+      .sort((a, b) => a.distance - b.distance || a.name.localeCompare(b.name))
+      .slice(0, 3)
+      .map((c) => c.name);
+  }
+
+  /** Standard iterative Levenshtein edit distance. */
+  private static levenshtein(a: string, b: string): number {
+    const m = a.length;
+    const n = b.length;
+    if (m === 0) return n;
+    if (n === 0) return m;
+    let prev = Array.from({ length: n + 1 }, (_, j) => j);
+    let curr = new Array<number>(n + 1);
+    for (let i = 1; i <= m; i++) {
+      curr[0] = i;
+      for (let j = 1; j <= n; j++) {
+        const cost = a[i - 1] === b[j - 1] ? 0 : 1;
+        curr[j] = Math.min(prev[j] + 1, curr[j - 1] + 1, prev[j - 1] + cost);
+      }
+      [prev, curr] = [curr, prev];
+    }
+    return prev[n];
+  }
+}

--- a/packages/cli/src/utils/errors/UnknownPropertyError.ts
+++ b/packages/cli/src/utils/errors/UnknownPropertyError.ts
@@ -1,0 +1,56 @@
+import { ExitCodes } from "../ExitCodes.js";
+import { CLIError } from "./CLIError.js";
+import { ErrorCode } from "../../responses/index.js";
+
+/**
+ * Error thrown when a `--property KEY=value` uses a property NAME that does not
+ * exist in the mounted TBox (RFC 430e84f1). This turns a fail-silent hole —
+ * `create` previously accepted ANY `prefix__Name` key, so an LLM agent's typo
+ * (`ems__Effort_parentEffort` for `ems__Effort_parent`) landed a DEAD property —
+ * into a fail-loud, structured rejection.
+ *
+ * The `{ unknown, suggestions }` pair is exposed BOTH as typed fields and (via
+ * the base {@link CLIError} `context`) in the structured JSON response, so an
+ * LLM consumer can auto-correct without a human (RFC must-have #5). There is
+ * deliberately NO `--allow-unknown-property` escape-hatch (must-have #6): a flag
+ * an assistant could add would nullify the guarantee. New properties are
+ * authored through the TBox path (a new `exo__Property` asset), not by writing
+ * an unknown key via `create`.
+ */
+export class UnknownPropertyError extends CLIError {
+  readonly exitCode = ExitCodes.INVALID_ARGUMENTS;
+  readonly errorCode = ErrorCode.VALIDATION_INVALID_ARGUMENTS;
+  readonly guidance: string;
+
+  /** The rejected property name (e.g. `ems__Effort_parentEffort`). */
+  readonly unknown: string;
+  /** Closest known property names (Levenshtein), best-first; may be empty. */
+  readonly suggestions: string[];
+
+  constructor(unknown: string, suggestions: string[]) {
+    const didYouMean =
+      suggestions.length > 0 ? ` Did you mean '${suggestions[0]}'?` : "";
+    const message = `Unknown property '${unknown}' — not in the mounted TBox.${didYouMean}`;
+
+    super(
+      message,
+      // Structured, machine-readable form for an LLM consumer (must-have #5).
+      { unknown, suggestions },
+      {
+        message:
+          suggestions.length > 0
+            ? `Use '${suggestions[0]}' (or another property that exists in the mounted TBox).`
+            : "Use a property name that exists in the mounted TBox.",
+        suggestion:
+          "New properties are authored through the TBox (a new exo__Property asset), not via create.",
+      },
+    );
+
+    this.unknown = unknown;
+    this.suggestions = suggestions;
+    this.guidance =
+      "The property name does not exist in the mounted TBox. Fix the spelling" +
+      (suggestions.length > 0 ? ` (e.g. '${suggestions[0]}')` : "") +
+      ", or author the new property through the TBox path — `create` does not mint properties.";
+  }
+}

--- a/packages/cli/src/utils/errors/index.ts
+++ b/packages/cli/src/utils/errors/index.ts
@@ -18,3 +18,4 @@ export { InvalidStateTransitionError } from "./InvalidStateTransitionError.js";
 export { OperationFailedError } from "./OperationFailedError.js";
 export { PermissionDeniedError } from "./PermissionDeniedError.js";
 export { QueryTimeoutError } from "./QueryTimeoutError.js";
+export { UnknownPropertyError } from "./UnknownPropertyError.js";

--- a/packages/cli/tests/integration/create-property-name-validation.integration.test.ts
+++ b/packages/cli/tests/integration/create-property-name-validation.integration.test.ts
@@ -1,0 +1,294 @@
+/**
+ * RFC 430e84f1 (P1) — `exocortex-cli create` must REJECT a `--property KEY=value`
+ * whose property NAME does not exist in the MOUNTED TBox. `create` already
+ * rejects a dangling wikilink VALUE (`WikilinkValidator`); this closes the twin
+ * fail-silent hole on the KEY. Real bug (project ab52aee1): an LLM bot wrote
+ * `ems__Effort_parentEffort` (typo of `ems__Effort_parent`) → a DEAD property no
+ * SPARQL/layout/graph-relation reads → the task silently vanished from its
+ * project's sub-tasks.
+ *
+ * Exercises the REAL `createCommand()` action end-to-end against a temp fixture
+ * vault that contains genuine property definitions (a non-empty mounted
+ * property-name set), so the collector runs for real — including a UID-form
+ * `exo__ObjectProperty` and a DOMAINLESS `exo__DatatypeProperty` (the two shapes
+ * `ShapeLoader` drops, proving the dedicated collector is needed). Plus
+ * service-level assertions for the structured-error form, the bare-key skip, and
+ * the degenerate-mount fail-open.
+ *
+ * Revert-verify (~/dotfiles/.claude/rules/integration-test-revert-verify.md):
+ * commenting out the `propertyNameValidator.validate(...)` call in create.ts
+ * (type-preserving) makes the unknown-prefix + misspelled-name scenarios PASS
+ * the create (exit 0) → those assertions go RED; the no-false-positive + bare-key
+ * skip + degenerate fail-open + no-flag negative-controls stay GREEN in both
+ * states, proving non-vacuity.
+ */
+import { jest, describe, it, expect, beforeEach, afterEach } from "@jest/globals";
+import * as fs from "fs";
+import * as path from "path";
+import * as os from "os";
+
+const { createCommand } = await import("../../src/commands/create.js");
+const { PropertyNameValidator } = await import(
+  "../../src/services/PropertyNameValidator.js"
+);
+const { UnknownPropertyError } = await import(
+  "../../src/utils/errors/UnknownPropertyError.js"
+);
+
+const REQ = "40a9a81b-729e-4dc1-9bc1-53295515a4b2";
+
+// Full-UUID class → `--class <uid>` pass-through fires without a class-def file.
+const CLASS_UID = "1b20a8f0-d745-4e93-91db-4531b3df120e"; // ems__Task
+// A resolvable wikilink target for property VALUES (name validation is
+// independent, but we skip wikilink validation anyway to isolate the KEY check).
+const VALID_TARGET = "cafe0000-0000-0000-0000-000000000001";
+
+const OBJECT_PROPERTY_UID = "9a1cf31c-9d41-4ef3-9023-584a8d087d16";
+const DATATYPE_PROPERTY_UID = "ae56ca4c-b610-42a4-a25d-058c23673296";
+
+function md(frontmatter: Record<string, string | string[]>): string {
+  const lines = ["---"];
+  for (const [k, v] of Object.entries(frontmatter)) {
+    if (Array.isArray(v)) {
+      lines.push(`${k}:`);
+      for (const item of v) lines.push(`  - ${item}`);
+    } else {
+      lines.push(`${k}: ${v}`);
+    }
+  }
+  lines.push("---", "");
+  return lines.join("\n");
+}
+
+/** Write a property-definition file (UID-named, like the real UID-canon TBox). */
+function writeProp(
+  vault: string,
+  uid: string,
+  label: string,
+  metaclassRef: string,
+  extra: Record<string, string | string[]> = {},
+): void {
+  const dir = path.join(vault, "assetspaces/kitelev/exoas-exo/exo");
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(
+    path.join(dir, `${uid}.md`),
+    md({
+      exo__Asset_uid: uid,
+      exo__Instance_class: `"${metaclassRef}"`,
+      exo__Asset_label: label,
+      ...extra,
+    }),
+  );
+}
+
+/**
+ * Build a fixture vault with a non-empty mounted property-name set:
+ *  - ems__Effort_parent      (ObjectProperty, label-form metaclass ref, has domain)
+ *  - ems__Effort_status      (ObjectProperty, UID-form metaclass ref)
+ *  - ems__Effort_startTimestamp (DatatypeProperty, UID-form, NO domain — the two
+ *                                shapes ShapeLoader drops)
+ *  - exo__Asset_isDefinedBy  (ObjectProperty) — so structural keys pass
+ *  - exo__Asset_relates      (ObjectProperty)
+ * → knownPrefixes = {ems, exo}; 5 known names.
+ */
+function buildFixtureVault(vault: string): void {
+  fs.mkdirSync(path.join(vault, "01 Inbox"), { recursive: true });
+  writeProp(vault, "0000-prop-1", "ems__Effort_parent", "[[exo__ObjectProperty]]", {
+    exo__Property_domain: '"[[ems__Effort]]"',
+  });
+  writeProp(
+    vault,
+    "0000-prop-2",
+    "ems__Effort_status",
+    `[[${OBJECT_PROPERTY_UID}|exo__ObjectProperty]]`,
+  );
+  // DatatypeProperty + NO domain → the pair ShapeLoader silently skips.
+  writeProp(
+    vault,
+    "0000-prop-3",
+    "ems__Effort_startTimestamp",
+    `[[${DATATYPE_PROPERTY_UID}]]`,
+  );
+  writeProp(vault, "0000-prop-4", "exo__Asset_isDefinedBy", "[[exo__ObjectProperty]]");
+  writeProp(vault, "0000-prop-5", "exo__Asset_relates", "[[exo__ObjectProperty]]");
+}
+
+describe("RFC 430e84f1: `cli create` validates property NAMES against the mounted TBox", () => {
+  let vault: string;
+  let exitSpy: ReturnType<typeof jest.spyOn>;
+  let stdoutSpy: ReturnType<typeof jest.spyOn>;
+  let stderrSpy: ReturnType<typeof jest.spyOn>;
+  let logSpy: ReturnType<typeof jest.spyOn>;
+  let errorSpy: ReturnType<typeof jest.spyOn>;
+  let stdoutChunks: string[];
+  let exitCodes: number[];
+
+  beforeEach(() => {
+    vault = fs.mkdtempSync(path.join(os.tmpdir(), "cli-propval-"));
+    buildFixtureVault(vault);
+
+    stdoutChunks = [];
+    exitCodes = [];
+    exitSpy = jest.spyOn(process, "exit").mockImplementation(((code?: number) => {
+      exitCodes.push(code ?? 0);
+      return undefined as never;
+    }) as never);
+    stdoutSpy = jest
+      .spyOn(process.stdout, "write")
+      .mockImplementation(((chunk: unknown) => {
+        stdoutChunks.push(String(chunk));
+        return true;
+      }) as never);
+    stderrSpy = jest
+      .spyOn(process.stderr, "write")
+      .mockImplementation((() => true) as never);
+    logSpy = jest.spyOn(console, "log").mockImplementation(() => {});
+    errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    exitSpy.mockRestore();
+    stdoutSpy.mockRestore();
+    stderrSpy.mockRestore();
+    logSpy.mockRestore();
+    errorSpy.mockRestore();
+    fs.rmSync(vault, { recursive: true, force: true });
+  });
+
+  async function runCreate(extraArgs: string[]): Promise<void> {
+    const cmd = createCommand();
+    await cmd.parseAsync(
+      [
+        "--class",
+        CLASS_UID,
+        "--label",
+        "E2E-TEST property-name validation",
+        "--vault",
+        vault,
+        "--skip-wikilink-validation",
+        ...extraArgs,
+      ],
+      { from: "user" },
+    );
+  }
+
+  /** Count asset files anywhere under the vault (excludes the 5 fixture props). */
+  function createdAssetCount(): number {
+    const walk = (dir: string): number => {
+      let n = 0;
+      for (const e of fs.readdirSync(dir, { withFileTypes: true })) {
+        const full = path.join(dir, e.name);
+        if (e.isDirectory()) n += walk(full);
+        else if (e.name.endsWith(".md") && !e.name.startsWith("0000-prop-")) n++;
+      }
+      return n;
+    };
+    return walk(vault);
+  }
+
+  it(`rejects an UNKNOWN-PREFIX property name — exit != 0, no asset created @req:${REQ}`, async () => {
+    await runCreate(["--property", "nonExisting__Prop=x"]);
+
+    expect(exitCodes).not.toContain(0);
+    expect(exitCodes).toContain(2); // INVALID_ARGUMENTS
+    const stderr = errorSpy.mock.calls.flat().join("\n");
+    expect(stderr).toContain("Unknown property");
+    expect(stderr).toContain("nonExisting__Prop");
+    expect(createdAssetCount()).toBe(0);
+    expect(stdoutChunks.join("")).toBe(""); // no success JSON
+  });
+
+  it(`rejects a KNOWN-PREFIX MISSPELLED name and fuzzy-suggests the closest @req:${REQ}`, async () => {
+    await runCreate(["--property", `ems__Effort_parentEffort=[[${VALID_TARGET}]]`]);
+
+    expect(exitCodes).not.toContain(0);
+    const stderr = errorSpy.mock.calls.flat().join("\n");
+    expect(stderr).toContain("ems__Effort_parent"); // the suggestion
+    expect(createdAssetCount()).toBe(0);
+  });
+
+  it(`a REAL (known) property passes — no false-positive @req:${REQ}`, async () => {
+    await runCreate([
+      "--property",
+      `ems__Effort_parent=[[${VALID_TARGET}]]`,
+      "--property",
+      "exo__Asset_isDefinedBy=[[!kitelev]]",
+    ]);
+
+    expect(exitCodes).toContain(0);
+    expect(exitCodes).not.toContain(2);
+    const json = JSON.parse(stdoutChunks.join("").trim());
+    expect(json.uuid).toBeTruthy();
+    expect(createdAssetCount()).toBe(1);
+  });
+
+  it(`a DOMAINLESS DatatypeProperty name passes (the shape ShapeLoader drops) @req:${REQ}`, async () => {
+    await runCreate([
+      "--property",
+      `ems__Effort_startTimestamp=2026-07-27T10:00:00`,
+    ]);
+
+    expect(exitCodes).toContain(0);
+    expect(exitCodes).not.toContain(2);
+  });
+
+  // ── Service-level assertions (real collector over the real fixture files) ──
+
+  it(`structured error carries a machine-readable { unknown, suggestions } @req:${REQ}`, async () => {
+    const validator = new PropertyNameValidator(vault);
+    let caught: unknown;
+    try {
+      await validator.validate(["ems__Effort_parentEffort"]);
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeInstanceOf(UnknownPropertyError);
+    const err = caught as InstanceType<typeof UnknownPropertyError>;
+    expect(err.unknown).toBe("ems__Effort_parentEffort");
+    expect(err.suggestions).toContain("ems__Effort_parent");
+    // Also surfaced in the base CLIError structured context (JSON mode).
+    expect(err.context).toEqual({
+      unknown: "ems__Effort_parentEffort",
+      suggestions: err.suggestions,
+    });
+  });
+
+  it(`skips bare Obsidian-native YAML keys (aliases/tags/title) @req:${REQ}`, async () => {
+    const validator = new PropertyNameValidator(vault);
+    await expect(
+      validator.validate(["aliases", "tags", "title", "cssclasses"]),
+    ).resolves.toBeUndefined();
+  });
+
+  it(`known property names pass at the service level (incl. UID-form + domainless) @req:${REQ}`, async () => {
+    const validator = new PropertyNameValidator(vault);
+    await expect(
+      validator.validate([
+        "ems__Effort_parent",
+        "ems__Effort_status", // UID-form ObjectProperty metaclass ref
+        "ems__Effort_startTimestamp", // domainless DatatypeProperty
+        "exo__Asset_relates",
+      ]),
+    ).resolves.toBeUndefined();
+  });
+
+  it(`degenerate mount (ZERO property definitions) → fail-open, no reject @req:${REQ}`, async () => {
+    const emptyVault = fs.mkdtempSync(path.join(os.tmpdir(), "cli-propval-empty-"));
+    try {
+      const validator = new PropertyNameValidator(emptyVault);
+      await expect(
+        validator.validate(["anything__Prop", "fake__Whatever"]),
+      ).resolves.toBeUndefined();
+    } finally {
+      fs.rmSync(emptyVault, { recursive: true, force: true });
+    }
+  });
+
+  it("exposes NO bot-accessible escape-hatch flag (--allow-unknown-property)", () => {
+    const flags = createCommand()
+      .options.map((o) => o.long)
+      .filter((l): l is string => Boolean(l));
+    expect(flags).not.toContain("--allow-unknown-property");
+    expect(flags.some((f) => /allow.*(unknown|property)/i.test(f))).toBe(false);
+  });
+});


### PR DESCRIPTION
## What

`exocortex-cli create` now **rejects a `--property KEY=value` whose property NAME does not exist in the mounted TBox** (RFC `430e84f1`, P1). It already rejected a dangling wikilink VALUE (`WikilinkValidator`); this closes the twin fail-silent hole on the KEY.

**Bug trigger** (project `ab52aee1`): an LLM bot wrote `ems__Effort_parentEffort` (typo of `ems__Effort_parent`; the value-ref was valid) → a DEAD property no SPARQL/layout/graph-relation reads → the task silently vanished from its project's sub-tasks.

## How

- **New `PropertyNameValidator`** (`packages/cli/src/services/`) — collects the known-property-name set one-pass from the **mounted** vault, matching all 3 property metaclasses (`exo__Property` / `exo__ObjectProperty` / `exo__DatatypeProperty`). `ShapeLoader` is deliberately **not** reused: it is domain-filtered (`if domain.length===0 return`) and DatatypeProperty-blind, so it would false-reject valid domainless/datatype props (empirically **19 domainless + 40 datatype** in vault-my).
- **Four-outcome rule:** known name → pass; known prefix + unknown name → **reject + Levenshtein fuzzy-suggest**; unknown prefix → reject; non-`prefix__Name` key (`aliases`/`tags`/`title`) → skip. **Fail-open** when NO property defs are mounted (degenerate/partial profile).
- **New `UnknownPropertyError`** (CLIError) — human message + machine-readable `{ unknown, suggestions }` context so an LLM agent auto-corrects without a human (RFC must-have #5).
- **NO bot-accessible escape-hatch** flag (RFC must-have #6).

Names are read from `exo__Asset_label` (the `prefix__Name` label form) and matched directly against the `--property` key — the symbolic↔UID dual-IRI налог applies only to store-IRI collection, which this does not use.

## Scope

`packages/cli` only (`create.ts` + new cli service + new cli error). No core/plugin change.

## Verification

- **Revert-verify** (`if (false) validate(...)`): reds **exactly** the unknown-prefix + misspelled-name scenarios; no-false-positive + skip + degenerate fail-open + no-flag controls stay green in both states (non-vacuity).
- **60 existing create tests green** (create-multivalue/neighbour/status-defaults/co-location/cardinality/colocate-renest + create.test unit) — zero regression. (create-cardinality uses the core service directly, unaffected; all `createCommand` fixtures are property-def-free → fail-open.)
- **Real-vault dry-run dogfood** (vault-my, 256 real property names): `ems__Effort_parent` passes; `fake__Prop` → exit 2 "Unknown property"; `ems__Effort_parentEffort` → exit 2 "Did you mean 'ems__Effort_parent'?".

## Acceptance Criteria (RFC §DoD)

- [x] `create --property nonExisting__Prop=x` → exit≠0 + "Unknown property", asset not created
- [x] `create --property ems__Effort_parent=[[valid]]` → passes (no false-positive)
- [x] Partial profile: valid property of mounted class passes; degenerate mount → fail-open
- [x] Fuzzy-suggest: `ems__Effort_parentEffort` → message contains `ems__Effort_parent`
- [x] Structured error `{ unknown, suggestions }` for machine consumer
- [x] revert-verify (production-shape store): RED without / GREEN with

Req: `40a9a81b-729e-4dc1-9bc1-53295515a4b2` (Approved) · RFC `430e84f1`
