### PR TITLE
fix(req): literal @req token binds create-property-name req (unblocks all PRs)

### DIFF
--- a/packages/cli/tests/integration/create-property-name-validation.integration.test.ts
+++ b/packages/cli/tests/integration/create-property-name-validation.integration.test.ts
@@ -36,6 +36,10 @@ const { UnknownPropertyError } = await import(
 );
 
 const REQ = "40a9a81b-729e-4dc1-9bc1-53295515a4b2";
+// requirements-trace binds ONLY via a literal `@req:<uid>` token — the
+// `@req:${REQ}` interpolation in the it() titles below is not statically
+// resolvable, so declare the binding as a literal here:
+// @req:40a9a81b-729e-4dc1-9bc1-53295515a4b2
 
 // Full-UUID class → `--class <uid>` pass-through fires without a class-def file.
 const CLASS_UID = "1b20a8f0-d745-4e93-91db-4531b3df120e"; // ems__Task


### PR DESCRIPTION
## Repo-wide blocker

PR #3949 (RFC 430e84f1) added `create-property-name-validation.integration.test.ts` and its requirement `40a9a81b` was flipped **Active** on the reqs-remote. But that test binds via **`@req:${REQ}`** — a `const REQ = "40a9a81b-…"` template-literal interpolated into the `it()` titles. `requirements-trace`'s static scanner matches ONLY a literal `@req:<uuid>` token, so it saw `40a9a81b` as **unbound** → the active-requirement gate went **RED on every open PR and blocked Auto Release**.

(#3949 itself merged green because its `requirements-trace` ran a moment before the req was activated.)

## Fix

Add a literal `@req:40a9a81b-729e-4dc1-9bc1-53295515a4b2` token in a comment next to `const REQ`. The behavior is **already covered** by the existing tests — only the static binding form was broken. No logic change.

Sibling rule: `req-first-sdd-ci-binding.md` addendum 2026-07-11 — "a test that references the req via prose / a `const REQ` is invisible to the audit; add the literal `@req:<uid>` token".

Unblocks all open PRs (incl. the mutation-removal #3950) + Auto Release.

https://claude.ai/code/session_011yAmSqaohWgrz8xdc1gACq