### PR TITLE
feat(archgate): guard against template-literal-only @req bindings (#3953)

### DIFF
--- a/.archgate/adrs/REQ-001-requirements-traceability.md
+++ b/.archgate/adrs/REQ-001-requirements-traceability.md
@@ -1,6 +1,6 @@
 ---
 id: REQ-001
-title: Requirements traceability — well-formed @req tags
+title: Requirements traceability — statically-resolvable @req bindings
 domain: process
 rules: true
 files:
@@ -12,7 +12,7 @@ files:
   ]
 ---
 
-# Requirements traceability — well-formed `@req` tags
+# Requirements traceability — statically-resolvable `@req` bindings
 
 ## Context
 
@@ -29,11 +29,24 @@ repo-scoped: `glob` / `grep` / `readFile`, no vault assets, no diff delta). That
 resolution is the job of the **`requirements-trace`** CI job (it clones the reqs
 assetspace and has graph access).
 
-What archgate **can** enforce, whole-tree and deterministically, is the one
-repo-expressible invariant: **every `@req:` tag in a test title is a
-syntactically well-formed UUID**. A truncated or mistyped tag (the realistic
-copy-paste failure) can never resolve, so catching it at the syntax layer keeps
-the binding corpus clean before the graph-aware job even runs.
+What archgate **can** enforce, whole-tree and deterministically, are two
+repo-expressible invariants:
+
+1. **Every `@req:` tag in a test title is a syntactically well-formed UUID.** A
+   truncated or mistyped tag (the realistic copy-paste failure) can never
+   resolve, so catching it at the syntax layer keeps the binding corpus clean
+   before the graph-aware job even runs.
+
+2. **A requirement binding is statically resolvable.** The `requirements-trace`
+   scanner binds ONLY on a literal `@req:<uuid>` token — it never evaluates a
+   template literal. A test that DRYs the UID (`const REQ = "…"` +
+   ``it(`… @req:${REQ}`)``) therefore has an **invisible** binding: the audit
+   sees zero coverage for that requirement. Harmless while the requirement is
+   `proposed`, but the moment it is activated the active-gate reds
+   `requirements-trace` for **every** PR in the repo and blocks Auto Release —
+   an expensive, repo-wide incident (see #3949/#3951) for a one-line omission.
+   archgate catches this at the syntax layer: a template-literal binding must be
+   accompanied by a literal `@req:<uuid>` token somewhere in the file.
 
 ## Decision
 
@@ -51,21 +64,48 @@ This is a **soft** discipline rule (`severity: warning`) — it surfaces malform
 tags without blocking. Existence/resolution remains the `requirements-trace`
 job's responsibility (soft in P1, hard in P3 per RFC 0003 §3.7).
 
+### `no-template-literal-only-req-binding` (error)
+
+A test that binds a requirement **only** through a template literal —
+``it(`… @req:${UID}`)`` / ``describe(`… @req:${uid}`)`` / ``test(`… @req:${x}`)`` —
+is invisible to the static `requirements-trace` scanner. This is a **hard** rule
+(`severity: error`): the file **must** also carry a literal
+`@req:<full-uuid>` token (a comment next to the interpolated `const`, or a
+literal title) so the binding survives when the requirement is activated.
+
+Detection is precise: it flags only a title opener (`it(`/`describe(`/`test(`)
+immediately followed by a backtick then `@req:${` — it does **not** flag a
+fixture STRING like `` `it("@req:${UID}…")` `` (backtick-first, so `it(` is
+followed by `"`), which is how `requirements-audit.integration.test.ts`
+constructs its test-corpus fixtures. And a single literal token anywhere in the
+file clears the rule, so a DRY `const REQ` + interpolated titles stays legal as
+long as one literal token anchors the binding.
+
 ## Do's and Don'ts
 
 ### Do
 
-- Write the full UID in the test title: `it("@req:449f29ce-cbd5-4ac8-94d4-28aa56a013c2 …", …)`.
-- Keep the tag inside the `it()`/`test()` title (it travels with the assertion).
+- Write the full UID as a **literal** in the test title: `it("@req:449f29ce-cbd5-4ac8-94d4-28aa56a013c2 …", …)`.
+- Keep the literal tag inside the `it()`/`test()` title (it travels with the assertion).
+- If you DRY the UID (`const REQ = "…"` + ``it(`… @req:${REQ}`)``), add a literal
+  anchor token next to the const — `// @req:<full-uuid>` — so the binding is
+  statically resolvable. The `@req:${REQ}` titles remain for readability; the
+  comment is what `requirements-trace` (and archgate) actually bind on.
 - Record the binding's class + revert-verify evidence in the requirement asset.
 
 ### Don't
 
 - Truncate or mistype the UUID (`@req:449f29ce` — dangling, never resolves).
-- Put the tag in a detachable comment instead of the title.
+- Bind a requirement **only** through a template literal (``it(`… @req:${UID}`)``)
+  with no literal token anywhere — the static scanner can't see it, so activating
+  that requirement reds `requirements-trace` for every PR. (A detachable comment
+  is fine _as the literal anchor_ when titles interpolate; what's forbidden is
+  having **no** literal token at all.)
 
 ## References
 
 - [RFC 0003 — requirements management](../../docs/rfc/0003-requirements-management.md) §3.6, §3.7
 - [Authoring functional requirements](../../docs/requirements-authoring.md)
 - `exocortex requirements audit` — the graph-aware traceability checker (CLI)
+- Incident #3949/#3951 — a template-literal-only binding (`@req:${REQ}`) went
+  active and red `requirements-trace` repo-wide; #3953 added the preventive rule.

--- a/.archgate/adrs/REQ-001-requirements-traceability.rules.ts
+++ b/.archgate/adrs/REQ-001-requirements-traceability.rules.ts
@@ -1,18 +1,25 @@
 /// <reference path="../rules.d.ts" />
 
 /**
- * REQ-001: Requirements traceability — well-formed `@req` tags.
+ * REQ-001: Requirements traceability — statically-resolvable `@req` bindings.
  *
- * Whole-tree, repo-expressible invariant (archgate has no vault-graph access):
- * any `@req:<token>` in a test title whose token *starts like a UUID* (hex/dash)
- * must be a complete 8-4-4-4-12 UUID. Catches the realistic copy-paste failure —
- * a truncated/mistyped tag that can never resolve — at the syntax layer, before
- * the graph-aware `requirements-trace` CI job runs.
+ * Whole-tree, repo-expressible invariants (archgate has no vault-graph access)
+ * that fail BEFORE the graph-aware `requirements-trace` CI job runs:
  *
- * Conservative by construction: the candidate matcher requires `@req:` to be
- * IMMEDIATELY followed by a hex char, so template interpolations (`@req:${uid}`)
- * and doc placeholders (`@req:<uid>`) are never flagged — the checker's own
- * tests and the authoring guide stay clean.
+ * 1. `well-formed-req-tags` (warning): any `@req:<token>` in a test title whose
+ *    token *starts like a UUID* (hex/dash) must be a complete 8-4-4-4-12 UUID —
+ *    catches truncated/mistyped tags that can never resolve. Conservative: the
+ *    candidate matcher requires `@req:` to be IMMEDIATELY followed by a hex char,
+ *    so template interpolations (`@req:${uid}`) and doc placeholders (`@req:<uid>`)
+ *    are never flagged here.
+ *
+ * 2. `no-template-literal-only-req-binding` (error): a requirement bound ONLY via
+ *    a template literal — `it(`… @req:${UID}`)` — is invisible to the static
+ *    `requirements-trace` scanner (which binds solely on literal `@req:<uuid>`
+ *    tokens). If that requirement is later activated, `requirements-trace` reds
+ *    for EVERY PR + blocks Auto Release. The fix (a literal token in a comment or
+ *    title) is cheap; the guard makes it mandatory. See #3949/#3951 (the incident
+ *    this rule prevents) and #3953 (this rule).
  */
 
 const TEST_GLOBS = [
@@ -28,6 +35,23 @@ const TAG_CANDIDATE = /@req:([0-9a-fA-F][0-9a-fA-F-]*)/g;
 // Strict 8-4-4-4-12 UUID.
 const FULL_UUID =
   /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/;
+
+// A requirement bound via a TEMPLATE LITERAL in a test title:
+//   it(`… @req:${UID} …`)  /  describe(`… @req:${uid}`)  /  test(`… @req:${x}`)
+// The signature is `it(`/`describe(`/`test(` IMMEDIATELY followed (after optional
+// whitespace) by an opening backtick, then `@req:${` before the first closing
+// backtick. This interpolation is NOT statically resolvable, so the graph-aware
+// `requirements-trace` CI job never sees the binding.
+//
+// ⚠️ It deliberately does NOT match a fixture STRING like `it("@req:${UID}…")` —
+// there the backtick comes BEFORE `it`, so `it(` is followed by `"`, not a
+// backtick (e.g. requirements-audit.integration.test.ts builds such fixtures and
+// must stay unflagged).
+const TEMPLATE_REQ_BINDING = /\b(?:it|describe|test)\s*\(\s*`[^`]*@req:\$\{/;
+// A statically-resolvable literal `@req:<full-uuid>` token — exactly what the
+// `requirements-trace` scanner binds on. May live in a comment OR a title.
+const LITERAL_REQ_TOKEN =
+  /@req:[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}/;
 
 export default {
   rules: {
@@ -64,6 +88,44 @@ export default {
               }
             }
           }
+        }
+      },
+    },
+
+    "no-template-literal-only-req-binding": {
+      description:
+        "A requirement bound ONLY via a template literal — it(`… @req:${UID}`) — is invisible to requirements-trace's static scanner (it binds solely on literal @req:<uuid> tokens). Activating such a requirement reds requirements-trace for EVERY PR and blocks Auto Release until fixed. The file must also carry a literal @req:<full-uuid> token.",
+      severity: "error",
+      async check(ctx) {
+        const seen = new Set<string>();
+        const files: string[] = [];
+        for (const pattern of TEST_GLOBS) {
+          for (const f of await ctx.glob(pattern)) {
+            if (!seen.has(f)) {
+              seen.add(f);
+              files.push(f);
+            }
+          }
+        }
+
+        for (const file of files) {
+          // A real binding via a template-literal test title.
+          const bindingHits = await ctx.grep(file, TEMPLATE_REQ_BINDING);
+          if (bindingHits.length === 0) continue;
+          // Any statically-resolvable literal token in the file (comment OR
+          // title) is what requirements-trace binds on — then the template
+          // form is harmless.
+          const literalHits = await ctx.grep(file, LITERAL_REQ_TOKEN);
+          if (literalHits.length > 0) continue;
+
+          const first = bindingHits[0];
+          ctx.report.violation({
+            message:
+              "Requirement bound only via a template literal (it(`… @req:${…}`)) — invisible to requirements-trace's static scanner; add a literal @req:<full-uuid> token (a comment next to the const, or a literal title) so the binding survives activation.",
+            file: first.file,
+            line: first.line,
+            fix: "Add a literal token, e.g. `// @req:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx` next to the interpolated const.",
+          });
         }
       },
     },

--- a/packages/cli/tests/integration/set-property-name-validation.integration.test.ts
+++ b/packages/cli/tests/integration/set-property-name-validation.integration.test.ts
@@ -30,6 +30,11 @@ const { PropertyNameValidator } = await import(
   "../../src/services/PropertyNameValidator.js"
 );
 
+// requirements-trace binds ONLY on a literal `@req:<uuid>` token — the
+// `@req:${REQ}` interpolation in the it() titles below is not statically
+// resolvable, so declare the binding as a literal here (archgate REQ-001
+// no-template-literal-only-req-binding):
+// @req:c616a289-8870-4426-86d3-2b30e7c37f5e
 const REQ = "c616a289-8870-4426-86d3-2b30e7c37f5e";
 const VALID_TARGET = "cafe0000-0000-0000-0000-000000000002";
 const OBJECT_PROPERTY_UID = "9a1cf31c-9d41-4ef3-9023-584a8d087d16";


### PR DESCRIPTION
## What

New archgate REQ-001 rule **`no-template-literal-only-req-binding`** (severity: `error`) — a requirement bound *only* via a template literal (`` it(`… @req:${UID}`) ``) must also carry a literal `@req:<full-uuid>` token somewhere in the file.

Closes #3953.

## Why

`requirements-trace` binds ONLY on a **literal** `@req:<uuid>` token — it never evaluates a template literal. A test that DRYs the UID (`const REQ = "…"` + `` it(`… @req:${REQ}`) ``) has an **invisible** binding. Harmless while the requirement is `proposed`, but the moment it goes active the active-gate reds `requirements-trace` for **every** PR and blocks Auto Release repo-wide — an expensive incident (#3949/#3951) for a one-line omission.

## How

- Precise detection: flags only an `it(`/`describe(`/`test(` opener immediately followed by a backtick then `@req:${`. It does **not** flag a fixture STRING like `` `it("@req:${UID}…")` `` (backtick-first → `it(` followed by `"`), so `requirements-audit.integration.test.ts` fixtures stay clean. A single literal token anywhere in the file clears the rule (DRY `const REQ` + interpolated titles stays legal, anchored by one literal comment).
- Fixes the sole current offender — `set-property-name-validation.integration.test.ts` (req `c616a289`, #3952): adds a literal `@req` anchor comment next to its `const REQ`.
- ADR doc (REQ-001.md) updated: Context, Decision subsection, Do's/Don'ts reconciled (a comment anchor is fine *when titles interpolate*; what's forbidden is **no** literal token at all).

## Verification

**Revert-verified against the archgate binary** (0.43.0 local): `check failed: 1 error` with the literal token stripped, `check passed: 0 failed` with it present. Same result via a python-equivalent regex scan over the whole test tree (flags exactly set-property before fix, 0 after; requirements-audit fixture excluded).

https://claude.ai/code/session_011yAmSqaohWgrz8xdc1gACq