### PR TITLE
feat(settings): fully bidirectional plugin-settings live-mirror (req 4425f655)

### DIFF
--- a/docs/explanation/settings-homoiconization.md
+++ b/docs/explanation/settings-homoiconization.md
@@ -25,6 +25,40 @@ The TypeScript binding table
 is pinned to the graph by a parity unit test — adding a settings field
 without deciding its homoiconization fails CI.
 
+## Two-way live sync (the live-mirror)
+
+When settings homoiconization is on, your settings and their vault
+`exo__Setting` assets stay in **continuous two-way sync on this device**
+(req `4425f655`):
+
+- **UI → asset:** change a setting in the plugin's Settings tab and the
+  new value is auto-written (a moment later — the write is debounced)
+  into that setting's `exo__Setting` asset. Nothing to remember, nothing
+  to click.
+- **asset → UI:** edit the `exo__Setting` asset directly (in source mode),
+  or receive it from another device via ExoSync, and the change is applied
+  back to the live setting (and its side-effects re-run) without a reload.
+
+So your settings become real, editable, syncable vault data — the same
+uniform way everything else in Exocortex is.
+
+### Enabling it
+
+Two-way sync is **opt-in and off by default.** Turn on
+**«Homoiconize plugin settings»** (`settingsHomoiconizationEnabled`) in the
+plugin settings, then reload Obsidian (the switch is read once on load).
+When it is off, the plugin behaves exactly as before — settings live only
+in `data.json`, and no `exo__Setting` assets are created or written.
+
+### Relationship to «Exocortex: Export settings»
+
+The live-mirror is **continuous**. The **«Exocortex: Export settings»**
+command is a separate, **manual one-shot snapshot** of your settings into a
+chosen ontology — the two coexist. Use the live-mirror for everyday two-way
+sync; use «Export settings» when you want to deliberately publish a settings
+snapshot (e.g. to distribute to a fresh vault). «Export settings» is always
+available and is not gated by the homoiconization switch.
+
 ## Architecture: data.json as write-through mirror
 
 - **Boot:** `loadSettings()` reads `data.json` exactly as before —

--- a/packages/obsidian-plugin/playwright-shard-assignments.json
+++ b/packages/obsidian-plugin/playwright-shard-assignments.json
@@ -18,7 +18,8 @@
       "featured-binding-promotion.spec.ts",
       "create-fleeting-note-palette.spec.ts",
       "focus-profile-picker.spec.ts",
-      "command-capability-inheritance.spec.ts"
+      "command-capability-inheritance.spec.ts",
+      "settings-live-mirror.spec.ts"
     ],
     [
       "area-tree-collapsible.spec.ts",

--- a/packages/obsidian-plugin/src/ExocortexPlugin.ts
+++ b/packages/obsidian-plugin/src/ExocortexPlugin.ts
@@ -2115,14 +2115,11 @@ export default class ExocortexPlugin extends Plugin {
 
   async saveSettings(): Promise<void> {
     await this.saveData(this.settings);
-    // RFC f402002b M2.3 — the live-mirror UI→asset auto-write is DEPRECATED in
-    // favour of the explicit «Exocortex: Export settings» command. The store is
-    // constructed read-only (outboundWriteEnabled defaults false), so this call
-    // is now a no-op that logs a one-time deprecation notice (the asset→UI
-    // watcher stays read-only; the RDF asset is canonical, data.json a derived
-    // cache). The call is kept here (rather than removed) so the deprecation
-    // notice fires from the single saveSettings() funnel; the whole store is
-    // scheduled for removal ≥1 release after the deprecation window.
+    // req 4425f655 — the live-mirror is bidirectional: when homoiconic settings
+    // are enabled the store auto-writes changed registry fields into their
+    // exo__Setting vault assets (trailing-debounced, own-echo-swallowed). This
+    // is the single funnel for that UI→asset mirror. When homoiconization is
+    // off, vaultSettingsStore is null and this is a no-op (optional-chained).
     this.vaultSettingsStore?.pushChangedFields();
   }
 
@@ -2156,20 +2153,26 @@ export default class ExocortexPlugin extends Plugin {
       return;
     }
 
-    // RFC f402002b M2.3 — read-only transitional: the store keeps the asset→UI
-    // inbound watcher + load-overlay + one-shot migrate, but the continuous
-    // UI→asset auto-write is deprecated (outboundWriteEnabled defaults false).
-    // Canonical authority = the RDF asset; data.json = derived cache. Persist UI
-    // changes to assets via «Exocortex: Export settings».
+    // req 4425f655 — the live-mirror is a fully BIDIRECTIONAL feature: with the
+    // master switch on, the store keeps the asset→UI inbound watcher +
+    // load-overlay + one-shot migrate AND continuously auto-writes UI changes
+    // back into their exo__Setting vault assets (outboundWriteEnabled: true),
+    // so settings stay in two-way sync within a device (data.json remains a
+    // write-through boot cache). «Exocortex: Export settings» coexists as a
+    // manual full-snapshot distribution path.
     this.logger.info(
-      "[D2] vault-settings live-mirror is read-only (RFC f402002b M2.3 deprecation) — " +
-        "asset→UI inbound only; use «Export settings» to persist UI changes to assets",
+      "[D2] vault-settings live-mirror is bidirectional (req 4425f655) — " +
+        "asset→UI inbound + UI→asset auto-write; settings stay two-way in sync",
     );
     const store = new VaultSettingsStore({
       app: this.app,
       logger: this.logger,
       getSettings: () => this.settings as Record<string, unknown>,
       baseline: this.settingsBaseline,
+      // req 4425f655 — enable the continuous UI→asset auto-write (the live-mirror
+      // outbound half). Gated at the layer level by settingsHomoiconizationEnabled
+      // (checked above); default users (switch off) never construct this store.
+      outboundWriteEnabled: true,
       applyRemote: async (field, value) => {
         (this.settings as Record<string, unknown>)[field] = value;
         this.applySettingSideEffect(field, value);
@@ -3658,8 +3661,9 @@ export default class ExocortexPlugin extends Plugin {
 
     // RFC f402002b M2.1 — «Export/Import settings», registered on
     // BOTH desktop AND mobile (Desktop↔Mobile Command Parity). Additive
-    // snapshot/restore via the generic Settings Distribution engine — does NOT
-    // touch the live-mirror (VaultSettingsStore); M2.3 deprecates that.
+    // snapshot/restore via the generic Settings Distribution engine — a manual
+    // full-snapshot path that COEXISTS with the bidirectional live-mirror
+    // (VaultSettingsStore, req 4425f655); it does not touch that store.
     this.registerSettingsDistributionCommands();
 
     // Issue #3707 — «Register for sync»: write an exo__AssetSpace descriptor into
@@ -4218,8 +4222,9 @@ export default class ExocortexPlugin extends Plugin {
    * Settings Distribution engine. Both commands register UNCONDITIONALLY
    * (Desktop↔Mobile Command Parity — Export writes via vault.adapter, Import
    * reads the warm metadataCache; no Platform.isMobile gate). Additive:
-   * an explicit, frictionless snapshot/restore that does not touch the
-   * live-mirror (VaultSettingsStore) — M2.3 deprecates that.
+   * an explicit, frictionless snapshot/restore that COEXISTS with the
+   * bidirectional live-mirror (VaultSettingsStore, req 4425f655) — it does not
+   * touch that store.
    *
    * NOT gated by `settingsHomoiconizationEnabled` (#3539) by design: that
    * master switch gates the AUTOMATIC live-mirror (background watcher +

--- a/packages/obsidian-plugin/src/infrastructure/adapters/VaultSettingsStore.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/VaultSettingsStore.ts
@@ -17,23 +17,23 @@ import {
  * VaultSettingsStore — reads/writes `exo__Setting` vault assets
  * (onto-RFC 981b6070 Phase 5 / ExoSync Phase D, task D2).
  *
- * DEPRECATED — RFC f402002b M2.3 — the bidirectional **live-mirror** is being
- * replaced by the explicit Settings-Distribution Export/Import engine (M2.1).
- * As of M2.3 the store is a **READ-ONLY transitional watcher**: the continuous
- * UI→asset auto-write ({@link pushChangedFields}, gated by
- * {@link VaultSettingsStoreOptions.outboundWriteEnabled}, default false) is
- * disabled and logs a one-time deprecation notice; the asset→UI inbound watcher
- * + load-overlay + one-shot migrate remain. **Canonical authority = the RDF
- * asset; data.json = derived runtime cache.** UI changes are persisted to assets
- * only via «Exocortex: Export settings». The whole store is scheduled for removal
- * ≥1 release after this deprecation window (RFC §6 R2).
+ * BIDIRECTIONAL live-mirror (req 4425f655): the store keeps plugin settings and
+ * their `exo__Setting` vault assets in continuous two-way sync within a device.
+ *  - **asset→UI (inbound):** the `metadataCache` watcher + load-overlay
+ *    (`applyScan`) + one-shot `migrateMissing` apply vault / synced asset
+ *    changes to the live settings.
+ *  - **UI→asset (outbound):** {@link pushChangedFields} (gated by
+ *    {@link VaultSettingsStoreOptions.outboundWriteEnabled}) auto-writes changed
+ *    registry fields back into their assets — trailing-debounced, own-echo
+ *    swallowed via `pendingWrites`, resurface-protected via `deferredPushFields`
+ *    (a write skipped during an unmount is re-pushed when the asset returns).
+ *    `data.json` remains a write-through boot cache.
  *
- * Read-only consequence (accepted, §6 R2 — un-Exported UI changes are not
- * durable): a UI toggle not persisted via «Export settings» reverts to the
- * canonical asset value whenever the asset is re-read — via a
- * `metadataCache.changed` re-fire, a profile-switch unmount→remount, OR a plugin
- * reload (the `applyScan` load-overlay). The `deferredPushFields` resurface
- * protection is inert here (reachable only from the now-disabled outbound path).
+ * The whole layer is opt-in behind the `settingsHomoiconizationEnabled` master
+ * switch; the explicit «Exocortex: Export settings» command (M2.1) coexists as a
+ * manual full-snapshot distribution path. (History: RFC f402002b M2.3 temporarily
+ * gated the outbound half off — `outboundWriteEnabled` default false, a read-only
+ * transitional — that decision was reversed for req 4425f655.)
  *
  * Architecture: data.json stays a write-through mirror (instant boot
  * baseline + fallback for non-homoiconized keys); the vault asset is the
@@ -96,15 +96,13 @@ export interface VaultSettingsStoreOptions {
   /** Folder where migrateMissing materialises assets. */
   settingsFolder?: string;
   /**
-   * Continuous UI→asset auto-write (the "live-mirror" outbound half).
-   * DEPRECATED — RFC f402002b M2.3 — the live-mirror is being replaced by the
-   * explicit Export/Import engine. Default **false**: the store is a
-   * READ-ONLY transitional watcher (asset→UI inbound + load-overlay +
-   * one-shot migrate still work; UI changes are persisted to assets only via
-   * «Exocortex: Export settings»). Canonical authority = the RDF asset;
-   * data.json = derived runtime cache. The whole store is scheduled for
-   * removal ≥1 release after this deprecation window. Pass `true` only to
-   * exercise the legacy outbound path (tests / the deprecation window).
+   * Enable the continuous UI→asset auto-write (the live-mirror outbound half).
+   * When `true`, a UI setting change is written back (trailing-debounced) into
+   * its `exo__Setting` vault asset — so the vault asset and the UI stay in
+   * two-way sync (req 4425f655). Default **false** (read-only: asset→UI inbound
+   * + load-overlay + one-shot migrate still work, but no outbound write) — used
+   * by tests that assert the read-only path. Production constructs the store
+   * with `true` when `settingsHomoiconizationEnabled` is enabled.
    */
   outboundWriteEnabled?: boolean;
 }
@@ -140,10 +138,8 @@ export class VaultSettingsStore {
   ) => Promise<void>;
   private readonly writeDebounceMs: number;
   private readonly settingsFolder: string;
-  /** DEPRECATED — RFC f402002b M2.3 — see {@link VaultSettingsStoreOptions.outboundWriteEnabled}. */
+  /** Whether the UI→asset live-mirror outbound write is active (req 4425f655). */
   private readonly outboundWriteEnabled: boolean;
-  /** One-shot guard so the deprecation notice is logged at most once. */
-  private outboundDeprecationWarned = false;
 
   /** field → vault path of the winning asset. */
   private readonly knownFiles = new Map<string, string>();
@@ -180,7 +176,8 @@ export class VaultSettingsStore {
     this.applyRemote = options.applyRemote;
     this.writeDebounceMs = options.writeDebounceMs ?? 1000;
     this.settingsFolder = options.settingsFolder ?? DEFAULT_SETTINGS_FOLDER;
-    // RFC f402002b M2.3 — default read-only (no continuous UI→asset auto-write).
+    // Default read-only (no outbound write) when unset; production passes true
+    // to enable the bidirectional live-mirror (req 4425f655).
     this.outboundWriteEnabled = options.outboundWriteEnabled ?? false;
   }
 
@@ -266,14 +263,13 @@ export class VaultSettingsStore {
             this.queueWrite(field, settings[field]);
           }
         } else {
-          // Read-only transitional (M2.3): no outbound write. The user's
-          // pre-scan UI value is kept (not overlaid). lastApplied has no live
-          // reader in read-only mode (pushChangedFields, its only consumer,
+          // Read-only mode (outboundWriteEnabled false): no outbound write. The
+          // user's pre-scan UI value is kept (not overlaid). lastApplied has no
+          // live reader in this mode (pushChangedFields, its only consumer,
           // no-ops) — set to the canonical asset value purely for consistency
-          // if outbound is ever re-enabled. The inbound watcher
-          // (onMetadataChanged) dedups against the LIVE settings value, not
-          // lastApplied, so a later real asset change still applies
-          // (canonical = RDF); an un-Exported UI change is not durable (§6 R2).
+          // if outbound is later enabled. The inbound watcher (onMetadataChanged)
+          // dedups against the LIVE settings value, not lastApplied, so a later
+          // real asset change still applies (canonical = RDF).
           this.lastApplied.set(field, effectiveCanonical);
         }
         continue;
@@ -363,35 +359,18 @@ export class VaultSettingsStore {
   // ────────────────────────────────────────────────────────────────
 
   /**
-   * Called from the `saveSettings()` funnel: diffs registry fields
-   * against the last applied/pushed value and queues vault writes for
-   * the changed ones. Cheap no-op when nothing relevant changed.
-   *
-   * DEPRECATED — RFC f402002b M2.3 — the continuous UI→asset auto-write (the
-   * "live-mirror" outbound half) is deprecated in favour of the explicit
-   * «Exocortex: Export settings» command. When {@link outboundWriteEnabled}
-   * is false (the default), this is a no-op that logs a one-time deprecation
-   * notice — the watcher stays READ-ONLY (asset→UI still works) and the RDF
-   * asset is the canonical authority. Scheduled for removal ≥1 release on.
+   * The UI→asset live-mirror outbound write (req 4425f655): diffs the registry
+   * fields against the last applied/pushed value and queues a trailing-debounced
+   * vault write for each changed one. Called from the `saveSettings()` funnel;
+   * a cheap no-op when nothing relevant changed. When {@link outboundWriteEnabled}
+   * is false (read-only mode — tests / opt-out), this is a no-op and the asset→UI
+   * inbound watcher still applies asset/synced changes.
    */
   pushChangedFields(): void {
-    if (!this.outboundWriteEnabled) {
-      // Read-only transitional (M2.3): never write assets from UI changes.
-      // lastApplied is left untouched. It has no live reader in read-only mode
-      // (this method, its only consumer, returns here); the inbound watcher
-      // (onMetadataChanged) dedups against live settings, not lastApplied.
-      if (!this.outboundDeprecationWarned) {
-        this.outboundDeprecationWarned = true;
-        this.logger.warn(
-          "[VaultSettingsStore] live-mirror UI→asset auto-write is deprecated " +
-            "(RFC f402002b M2.3, read-only transitional). Use «Exocortex: Export " +
-            "settings» to persist settings to assets; the asset→UI watcher remains " +
-            "read-only and the RDF asset is canonical. This store is scheduled for " +
-            "removal ≥1 release after the deprecation window.",
-        );
-      }
-      return;
-    }
+    // Read-only mode (outboundWriteEnabled false): no UI→asset write. The
+    // inbound watcher (onMetadataChanged) dedups against live settings, not
+    // lastApplied, so asset→UI still applies.
+    if (!this.outboundWriteEnabled) return;
     if (!this.scanned) return; // pre-scan changes handled as dirty fields
     const settings = this.getSettings();
     for (const d of VAULT_SETTINGS_REGISTRY) {

--- a/packages/obsidian-plugin/tests/e2e/specs/settings-live-mirror.spec.ts
+++ b/packages/obsidian-plugin/tests/e2e/specs/settings-live-mirror.spec.ts
@@ -1,0 +1,146 @@
+import { test, expect } from "@playwright/test";
+import { ObsidianLauncher } from "../utils/obsidian-launcher";
+import { waitForExocortexPluginViaPlaywright } from "../utils/waitForExocortexPlugin";
+import * as path from "path";
+
+/**
+ * E2E (req 4425f655) — the bidirectional plugin-settings live-mirror:
+ * a UI setting change is auto-written (live) into its `exo__Setting` vault
+ * asset. Drives the REAL production path in real Obsidian:
+ *   settingsHomoiconizationEnabled → initVaultSettings (constructs the store
+ *   with outboundWriteEnabled: true — the feature under test) → migrateMissing
+ *   → saveSettings → pushChangedFields → the vault asset is updated.
+ *
+ * Revert (production-tied): removing `outboundWriteEnabled: true` from
+ * `ExocortexPlugin.initVaultSettings` makes the store read-only → the outbound
+ * assertion + the asset-value poll fail.
+ *
+ * @flaky-track — Docker metadataCache + a trailing write-debounce; the sibling
+ * `alias-sync-on-label-change` write test carries the same tag. Serial + a
+ * best-effort afterAll that leaves the shared test-vault as found.
+ */
+test.describe.configure({ mode: "serial" });
+
+test.describe(
+  "Settings live-mirror — bidirectional UI→asset auto-write (req 4425f655)",
+  { tag: ["@flaky-track"] },
+  () => {
+    let launcher: ObsidianLauncher;
+
+    test.beforeAll(async () => {
+      const vaultPath = path.join(__dirname, "../test-vault");
+      launcher = new ObsidianLauncher(vaultPath);
+      await launcher.launch();
+    });
+
+    test.afterAll(async () => {
+      // Leave the shared test-vault as found: disable homoiconization and
+      // delete any exocortex-settings/ assets this spec migrated.
+      try {
+        const window = await launcher.getWindow();
+        await window.evaluate(async () => {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          const app = (window as any).app;
+          const plugin = app?.plugins?.plugins?.exocortex;
+          if (plugin) {
+            plugin.settings.settingsHomoiconizationEnabled = false;
+            plugin.vaultSettingsStore = null;
+            await plugin.saveData(plugin.settings);
+          }
+          if (app?.vault) {
+            const created = app.vault
+              .getMarkdownFiles()
+              // eslint-disable-next-line @typescript-eslint/no-explicit-any
+              .filter((f: any) => f.path.startsWith("exocortex-settings/"));
+            for (const f of created) {
+              try {
+                await app.vault.delete(f);
+              } catch {
+                /* best-effort */
+              }
+            }
+          }
+        });
+      } catch {
+        /* best-effort cleanup */
+      }
+      if (launcher) {
+        await launcher.close();
+      }
+    });
+
+    test("@req:4425f655-e034-44b8-9258-db1650dd8b12 a UI setting change is auto-written into its exo__Setting vault asset (bidirectional live-mirror)", async () => {
+      await launcher.openFile("e2e-icon-target-task.md");
+      const window = await launcher.getWindow();
+      await waitForExocortexPluginViaPlaywright(window, {
+        specName: "settings-live-mirror",
+      });
+
+      // 1. Enable homoiconization and run the REAL production initVaultSettings
+      //    — it constructs the store with outboundWriteEnabled:true (the
+      //    feature under test) and migrates an exo__Setting asset per field.
+      const setup = await window.evaluate(async () => {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const app = (window as any).app;
+        const plugin = app?.plugins?.plugins?.exocortex;
+        if (!plugin) return { ok: false as const, error: "plugin not loaded" };
+        plugin.settings.settingsHomoiconizationEnabled = true;
+        plugin.settingsBaseline = { ...plugin.settings };
+        await plugin.saveData(plugin.settings);
+        plugin.vaultSettingsStore = null;
+        await plugin.initVaultSettings();
+        const store = plugin.vaultSettingsStore;
+        const field = "showArchivedAssets";
+        const assetPath =
+          store && typeof store.knownFiles?.get === "function"
+            ? (store.knownFiles.get(field) ?? null)
+            : null;
+        return {
+          ok: !!store,
+          outboundWriteEnabled: store ? store.outboundWriteEnabled : null,
+          field,
+          assetPath,
+          before: plugin.settings[field] as boolean,
+        };
+      });
+
+      expect(setup.ok).toBe(true);
+      // The production wiring MUST construct the store outbound-ENABLED.
+      expect(setup.outboundWriteEnabled).toBe(true);
+      expect(setup.assetPath).toBeTruthy();
+
+      // 2. Change the setting in the UI (saveSettings → pushChangedFields →
+      //    trailing-debounced outbound write) to the OPPOSITE value.
+      const next = !setup.before;
+      await window.evaluate(
+        async ({ field, next }) => {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          const app = (window as any).app;
+          const plugin = app.plugins.plugins.exocortex;
+          plugin.settings[field] = next;
+          await plugin.saveSettings();
+          // Flush the trailing debounce so the write lands deterministically.
+          await plugin.vaultSettingsStore.flushWrites();
+        },
+        { field: setup.field, next },
+      );
+
+      // 3. The exo__Setting asset now carries the NEW value (UI→asset mirror).
+      await expect
+        .poll(
+          async () =>
+            window.evaluate(async (assetPath: string) => {
+              // eslint-disable-next-line @typescript-eslint/no-explicit-any
+              const app = (window as any).app;
+              const file = app.vault.getAbstractFileByPath(assetPath);
+              if (!file) return null;
+              const content: string = await app.vault.read(file);
+              const m = content.match(/^exo__Setting_value:\s*(.+)$/m);
+              return m ? m[1].trim() : null;
+            }, setup.assetPath as string),
+          { timeout: 10_000, intervals: [200, 500, 500, 1000, 1000, 2000] },
+        )
+        .toBe(String(next));
+    });
+  },
+);

--- a/packages/obsidian-plugin/tests/unit/ExocortexPlugin.settingsHomoiconizationGate.test.ts
+++ b/packages/obsidian-plugin/tests/unit/ExocortexPlugin.settingsHomoiconizationGate.test.ts
@@ -147,5 +147,22 @@ describe("ExocortexPlugin.initVaultSettings — #3539 master-switch gate", () =>
       expect(vaultOn).toHaveBeenCalledWith("rename", expect.any(Function));
       expect(registerEvent).toHaveBeenCalledTimes(3);
     });
+
+    it("@req:4425f655-e034-44b8-9258-db1650dd8b12 constructs the store with the bidirectional live-mirror outbound write ENABLED (UI→asset auto-write active, not read-only)", async () => {
+      // req 4425f655 — when settings-homoiconization is on, initVaultSettings
+      // must wire the store with outboundWriteEnabled:true so a UI change is
+      // auto-mirrored into its exo__Setting vault asset (two-way sync). Revert:
+      // removing `outboundWriteEnabled: true` from initVaultSettings → this
+      // assertion goes RED (the store falls back to the read-only default).
+      const { plugin } = makePlugin(true);
+
+      await plugin.initVaultSettings();
+
+      const store = plugin.vaultSettingsStore as unknown as {
+        outboundWriteEnabled: boolean;
+      } | null;
+      expect(store).not.toBeNull();
+      expect(store!.outboundWriteEnabled).toBe(true);
+    });
   });
 });

--- a/packages/obsidian-plugin/tests/unit/infrastructure/adapters/VaultSettingsStore.test.ts
+++ b/packages/obsidian-plugin/tests/unit/infrastructure/adapters/VaultSettingsStore.test.ts
@@ -160,8 +160,8 @@ function makeStore(
   overrides: {
     baseline?: Record<string, unknown>;
     applyRemote?: jest.Mock;
-    // RFC f402002b M2.3 — opt into the legacy/deprecated outbound UI→asset
-    // auto-write (default false = read-only transitional watcher).
+    // req 4425f655 — enable the bidirectional outbound UI→asset auto-write
+    // (default false = read-only mode; production passes true).
     outboundWriteEnabled?: boolean;
     logger?: { warn: jest.Mock } & Record<string, jest.Mock>;
   } = {},
@@ -254,7 +254,7 @@ describe("VaultSettingsStore", () => {
       settings.showArchivedAssets = true; // user toggled pre-scan
       const { store, applyRemote } = makeStore(fake, settings, {
         baseline,
-        outboundWriteEnabled: true, // M2.3: this test asserts the deprecated dirty-field push
+        outboundWriteEnabled: true, // req 4425f655: asserts the dirty-field outbound push
       });
 
       await store.applyScan(store.scanAll());
@@ -493,8 +493,9 @@ describe("VaultSettingsStore", () => {
     async function setupMigrated() {
       const fake = new FakeApp();
       const settings = freshSettings();
-      // M2.3: these blocks exercise the (now-deprecated) outbound UI→asset
-      // auto-write path → opt in explicitly.
+      // req 4425f655 — these blocks exercise the bidirectional live-mirror
+      // outbound UI→asset auto-write path → construct with it enabled (as
+      // production does when settings-homoiconization is on).
       const { store, applyRemote } = makeStore(fake, settings, {
         outboundWriteEnabled: true,
       });
@@ -503,7 +504,7 @@ describe("VaultSettingsStore", () => {
       return { fake, settings, store, applyRemote };
     }
 
-    it("pushChangedFields writes the changed field to the asset", async () => {
+    it("@req:4425f655-e034-44b8-9258-db1650dd8b12 pushChangedFields writes the changed UI field to its exo__Setting vault asset (bidirectional live-mirror outbound write)", async () => {
       const { fake, settings, store } = await setupMigrated();
       const d = descriptorByField("enableShaclValidation")!;
 
@@ -532,7 +533,7 @@ describe("VaultSettingsStore", () => {
       const fake = new FakeApp();
       const settings = freshSettings();
       const { store } = makeStore(fake, settings, {
-        outboundWriteEnabled: true, // M2.3: exercises the deprecated push path
+        outboundWriteEnabled: true, // req 4425f655: exercises the outbound push path
       });
       store.scanAll(); // no assets at all, no migration
 
@@ -558,13 +559,12 @@ describe("VaultSettingsStore", () => {
     });
   });
 
-  // @req:5c08b7ad-0e82-4dfa-b258-316a2d21c143
-  describe("read-only transitional deprecation (M2.3, RFC f402002b §6 R2)", () => {
-    async function setupReadOnly(logger?: { warn: jest.Mock } & Record<string, jest.Mock>) {
+  describe("read-only mode (outboundWriteEnabled false — the no-outbound-write opt-out / test default)", () => {
+    async function setupReadOnly() {
       const fake = new FakeApp();
       const settings = freshSettings();
       // Default makeStore = read-only (outboundWriteEnabled defaults false).
-      const { store, applyRemote } = makeStore(fake, settings, { logger });
+      const { store, applyRemote } = makeStore(fake, settings);
       store.scanAll();
       await store.migrateMissing();
       return { fake, settings, store, applyRemote };
@@ -590,28 +590,6 @@ describe("VaultSettingsStore", () => {
       expect(fake.processCalls.length).toBe(processCallsBefore);
     });
 
-    it("logs the deprecation notice at most once across many UI saves", async () => {
-      const logger = {
-        debug: jest.fn(),
-        info: jest.fn(),
-        warn: jest.fn(),
-        error: jest.fn(),
-      };
-      const { settings, store } = await setupReadOnly(logger);
-      logger.warn.mockClear(); // ignore any scan/migrate warnings
-
-      settings.enableShaclValidation = true;
-      store.pushChangedFields();
-      settings.showArchivedAssets = true;
-      store.pushChangedFields();
-      store.pushChangedFields();
-
-      const deprecationWarns = logger.warn.mock.calls.filter((c) =>
-        String(c[0]).includes("deprecated"),
-      );
-      expect(deprecationWarns).toHaveLength(1);
-    });
-
     it("KEEPS the asset→UI inbound watcher (read-only): a synced asset change still applies", async () => {
       const { fake, settings, store, applyRemote } = await setupReadOnly();
       const d = descriptorByField("showArchivedAssets")!;
@@ -635,10 +613,9 @@ describe("VaultSettingsStore", () => {
       await store.applyScan(store.scanAll());
       await store.flushWrites();
 
-      // No overlay (UI keeps the user's value during the session) and — the
-      // M2.3 invariant — NO outbound write: the asset is untouched. (canonical
-      // = RDF: the un-Exported UI value is not durable; a later asset change
-      // applies via the inbound watcher, covered above.)
+      // No overlay (UI keeps the user's value during the session) and — in
+      // read-only mode — NO outbound write: the asset is untouched. (A later
+      // asset change applies via the inbound watcher, covered above.)
       expect(applyRemote).not.toHaveBeenCalled();
       expect(settings.showArchivedAssets).toBe(true);
       expect(fake.files.get(path)!.frontmatter!.exo__Setting_value).toBe(false);
@@ -650,8 +627,8 @@ describe("VaultSettingsStore", () => {
     async function setupMigrated() {
       const fake = new FakeApp();
       const settings = freshSettings();
-      // M2.3: these blocks exercise the (now-deprecated) outbound UI→asset
-      // auto-write path → opt in explicitly.
+      // req 4425f655 — these blocks exercise the bidirectional outbound
+      // UI→asset auto-write + echo suppression → construct with it enabled.
       const { store, applyRemote } = makeStore(fake, settings, {
         outboundWriteEnabled: true,
       });


### PR DESCRIPTION
## Summary

Fully implements (re-enables) the plugin-settings **bidirectional live-mirror** per Andrey's directive 2026-07-27 — reversing the RFC f402002b **M2.3 read-only** decision (**supersedes + deprecates** the Active read-only requirement `5c08b7ad`, was GitHub issue #3958's removal, now inverted).

When the existing `settingsHomoiconizationEnabled` master switch (opt-in, **default OFF**) is enabled, a UI setting change is auto-written (trailing-debounced) into its `exo__Setting` vault asset, **and** asset/synced changes still flow back to the UI — continuous two-way sync within a device. **Default users (switch OFF) are unaffected.**

The outbound machinery already existed and is battle-tested (F1–F12 concurrency discipline: sequential `writeChain`, per-field debounce, own-echo swallow, deferred-push resurface) — M2.3 deliberately **gated it off**. This turns it back on and de-deprecates the framing.

`Req: 4425f655-e034-44b8-9258-db1650dd8b12`

## Changes

- **`ExocortexPlugin.initVaultSettings`** constructs the store with `outboundWriteEnabled: true`; `saveSettings` + all "M2.3 deprecated / read-only / scheduled-for-removal" comments updated to describe the live feature.
- **`VaultSettingsStore.ts`** — class + `pushChangedFields` JSDoc de-deprecated; removed the one-time deprecation `warn` (read-only is now just a valid test/opt-out mode) + its now-unused guard field.
- **«Export settings» (M2.1) coexists** as a manual full-snapshot path — consciously overriding RFC f402002b's rejected alternative D ("two mechanisms"), per Andrey.
- **User docs** (`docs/explanation/settings-homoiconization.md`): new "Two-way live sync" section (what it does, enabling via the master switch, Export coexistence).

## Tests — `@req:4425f655`, revert-verified RED→GREEN

- **Production wiring (gate test):** `ExocortexPlugin.settingsHomoiconizationGate.test.ts` asserts `initVaultSettings` wires the store **outbound-ENABLED**. Revert = drop `outboundWriteEnabled: true` from `initVaultSettings` → this test goes RED (verified: 1 failed / 5 passed), restore → GREEN. This binds the actual production change.
- **Outbound behavior:** `VaultSettingsStore.test.ts` write-through path (UI change → asset written) tagged `@req:4425f655`.
- **e2e (`@flaky-track`, CI Docker):** `settings-live-mirror.spec.ts` drives the **real production path** in real Obsidian — enable homoiconization → `initVaultSettings` → migrate → change setting → poll the `exo__Setting` asset for the new value. (Can't run Docker locally; validates in CI. Isolated + cleans up the shared test-vault in `afterAll`.)

## Verification (local)

- `check:types` 0 errors; `lint` clean; CI `lint`-job guards (shard-assignments 21 balanced, test-antipatterns, coverage-monotonic) all pass; VaultSettingsStore + gate suites **43/43**.

## ⚠️ Elevated-risk path (VaultSettings*)

Per the repo auto-merge discipline (settings-corruption sensitive): merged manually (**no `--auto`**) after code-reviewer + advisor round-2.

7 files changed, +281 / −122.

https://claude.ai/code/session_01Waz7n3pzVrAUFzzo7RkCVB