### PR TITLE
feat(grounding): per-ontology efforts routing via two-hop targetRefProperty resolver (req c03f9e3e)

### DIFF
--- a/docs/how-to/per-ontology-efforts-routing.md
+++ b/docs/how-to/per-ontology-efforts-routing.md
@@ -1,0 +1,72 @@
+# How to auto-file efforts per area-ontology (`exo__Ontology_effortsOntology`)
+
+> Requirement `c03f9e3e` — per-ontology efforts routing.
+
+## What it does
+
+When you create a task or project from an **area** page via the homoiconic
+**Create** button, its `exo__Asset_isDefinedBy` can be auto-derived so the new
+effort is filed into a **target efforts-ontology** declared on **that area's
+ontology** — without you picking `isDefinedBy` each time.
+
+This keeps your area-ontologies clean (they hold areas, not the growing mass of
+efforts) and routes efforts per-audience by a single declarative setting you
+change on the ontology (e.g. `my-areas → my-efforts`, `work-areas →
+work-efforts`).
+
+The routing is **two-hop**:
+
+```
+area A  →  A.exo__Asset_isDefinedBy (the area-ontology O)  →  O.exo__Ontology_effortsOntology (the target efforts-ontology E)
+```
+
+The new effort's `exo__Asset_isDefinedBy` is set to **E**, and the file
+co-locates in **E's folder** (co-location invariant) rather than the area's
+folder.
+
+## The setting: `exo__Ontology_effortsOntology`
+
+An `exo__ObjectProperty` (domain `exo__Ontology`, range `exo__Ontology`, single-
+valued). Add it to an **area-ontology** to declare where efforts created under
+that ontology's areas should be filed.
+
+```yaml
+# On your area-ontology asset (e.g. the "my-areas" ontology):
+exo__Ontology_effortsOntology: "[[<uid-of-the-target-efforts-ontology>]]"
+```
+
+## How to enable routing
+
+1. **Declare the target** on your area-ontology: set
+   `exo__Ontology_effortsOntology` to the efforts-ontology you want (e.g.
+   `my-efforts`).
+2. **Use a routing grounding**: the Create grounding for the effort must set
+   `exo__Asset_isDefinedBy` via the two-hop resolver and use
+   `targetFolder = $isDefinedByFolder`. Concretely, a
+   `create_instance` grounding whose `propertyDefault` for
+   `exo__Asset_isDefinedBy` wraps the `targetRefProperty` substitution token with
+   the parameter `exo__Asset_isDefinedBy|exo__Ontology_effortsOntology` (the
+   `refKey|propKey` pair — first hop reads the area's `exo__Asset_isDefinedBy`,
+   second hop reads that ontology's `exo__Ontology_effortsOntology`). This
+   per-grounding default **overrides** the built-in Universal Default (which
+   inherits `isDefinedBy` single-hop from the click target).
+
+Once both are in place, creating an effort from any area under that ontology
+files the effort into the target efforts-ontology's folder automatically.
+
+## Opt-in / no regression
+
+Routing is **opt-in and data-driven**:
+
+- An area-ontology that declares **no** `exo__Ontology_effortsOntology` → the
+  two-hop resolver yields nothing → `isDefinedBy` is not routed and the effort
+  co-locates with the area (unchanged behaviour).
+- Different area-ontologies can target different efforts-ontologies — routing is
+  strictly per-ontology (`O1 → E1`, `O2 → E2`).
+
+## Change the target later
+
+Because the routing decision lives in vault data (the
+`exo__Ontology_effortsOntology` value on the ontology), you can re-point an
+ontology's efforts elsewhere at any time by editing that one property — no code
+change, and previously-created efforts are unaffected.

--- a/packages/cli/src/commands/apply.ts
+++ b/packages/cli/src/commands/apply.ts
@@ -22,6 +22,7 @@ import {
   stripTemplateFrontmatter,
   createVaultFrontmatterClassLabelResolver,
   createVaultFrontmatterRefToFolderResolver,
+  createVaultFrontmatterRefToFrontmatterResolver,
   registerDefaultHostFunctions,
   vaultPathToIRI,
   IRI,
@@ -426,6 +427,11 @@ async function executeOnTarget(
       // their chosen ontology's folder via `$isDefinedByFolder` (UI/CLI parity,
       // Issue #3417). Mirrors the plugin's createObsidianRefToFolderResolver.
       refToFolder: createVaultFrontmatterRefToFolderResolver(nodeFsAdapter),
+      // req c03f9e3e — per-ontology efforts routing: resolve the SECOND hop
+      // (area's isDefinedBy ontology → its exo__Ontology_effortsOntology) for the
+      // `targetRefProperty` token (UI/CLI parity, Issue #3417). Mirrors the
+      // plugin's createObsidianRefToFrontmatterResolver.
+      refToFrontmatter: createVaultFrontmatterRefToFrontmatterResolver(nodeFsAdapter),
     },
   );
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -103,9 +103,11 @@ export {
   type IGroundingService,
   type ClassLabelToUidResolver,
   type RefToFolderResolver,
+  type RefToFrontmatterResolver,
 } from "./services/GroundingExecutor";
 export { createVaultFrontmatterClassLabelResolver } from "./services/VaultFrontmatterClassLabelResolver";
 export { createVaultFrontmatterRefToFolderResolver } from "./services/VaultFrontmatterRefToFolderResolver";
+export { createVaultFrontmatterRefToFrontmatterResolver } from "./services/VaultFrontmatterRefToFrontmatterResolver";
 export {
   NamedQueryRunner,
   type NamedQueryRunnerPort,

--- a/packages/core/src/services/CommandResolver.ts
+++ b/packages/core/src/services/CommandResolver.ts
@@ -109,6 +109,14 @@ const KNOWN_SUBSTITUTION_RESOLVER_IDS: ReadonlySet<string> = new Set([
   "userInputLabel",
   "userInput",
   "targetProperty",
+  // req c03f9e3e — per-ontology efforts routing (TWO-HOP). A parameterised
+  // `<refKey>|<propKey>` resolver: reads a property off the asset the click-
+  // target's own frontmatter points at (area → area-ontology → that ontology's
+  // `exo__Ontology_effortsOntology`). Whitelisted here so a vault TokenInvocation
+  // referencing it emits a parameterised marker instead of a wikilink fallback;
+  // resolved at execute time by GroundingExecutor after it pre-resolves the
+  // second-hop frontmatter into ResolverContext.targetRefFm.
+  "targetRefProperty",
   "labelAsArray",
   "groundingTargetClass",
   // T1 "Create Instance" homoiconic button (project bbe40f8c): host page IS

--- a/packages/core/src/services/GroundingExecutor.ts
+++ b/packages/core/src/services/GroundingExecutor.ts
@@ -202,6 +202,24 @@ export type RefToFolderResolver = (
   ref: string,
 ) => string | null | Promise<string | null>;
 
+/**
+ * req c03f9e3e — per-ontology efforts routing. Resolves a bare asset reference
+ * (a UID, after the executor strips quotes / `[[ ]]` / `|alias`) to that asset's
+ * parsed frontmatter, so the executor can make a SECOND hop from the click-target
+ * (area → the area's `exo__Asset_isDefinedBy` ontology → that ontology's
+ * `exo__Ontology_effortsOntology`). Sibling of {@link RefToFolderResolver}: the
+ * core executor is storage-agnostic, so the host injects a metadata-cache (plugin)
+ * or filesystem (CLI) backed implementation. A `null` return — no resolver wired,
+ * ref not found — makes the two-hop resolver yield nothing, so the create is not
+ * routed and co-locates with the click-target (opt-in / no failure on a gap).
+ */
+export type RefToFrontmatterResolver = (
+  ref: string,
+) =>
+  | Record<string, unknown>
+  | null
+  | Promise<Record<string, unknown> | null>;
+
 /** UUID-v4 sniff used to skip resolution for already-canonical class refs. */
 const UUID_V4_RE =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
@@ -343,6 +361,7 @@ export class GroundingExecutor {
   private readonly serviceRegistry: ServiceRegistry;
   private readonly classLabelToUid?: ClassLabelToUidResolver;
   private readonly refToFolder?: RefToFolderResolver;
+  private readonly refToFrontmatter?: RefToFrontmatterResolver;
   private readonly workflowResolver?: WorkflowResolverPort;
   private readonly groundingLoader?: GroundingLoaderPort;
   private readonly templateLoader?: TemplateLoaderPort;
@@ -376,6 +395,10 @@ export class GroundingExecutor {
       // target-folder token to the chosen ontology's folder. When absent,
       // create_instance falls back to the host folder (never fails).
       refToFolder?: RefToFolderResolver;
+      // req c03f9e3e — per-ontology efforts routing. Resolve a bare ref to that
+      // asset's frontmatter for the SECOND hop of `targetRefProperty`. When
+      // absent, the two-hop resolver yields nothing (no routing, no failure).
+      refToFrontmatter?: RefToFrontmatterResolver;
     },
   ) {
     this.frontmatterService = new FrontmatterService();
@@ -384,6 +407,7 @@ export class GroundingExecutor {
     this.serviceRegistry = serviceRegistry;
     this.classLabelToUid = classLabelToUid;
     this.refToFolder = options?.refToFolder;
+    this.refToFrontmatter = options?.refToFrontmatter;
     this.workflowResolver = options?.workflowResolver;
     this.groundingLoader = options?.groundingLoader;
     this.templateLoader = options?.templateLoader;
@@ -1126,11 +1150,21 @@ export class GroundingExecutor {
     // AT ALL (no Universal singleton in vault + no Grounding entries), fall
     // back to the legacy hardcoded primitives with a loud warn — protects
     // cold-start race on mobile boot paths from creating empty/invalid assets.
+    // req c03f9e3e — per-ontology efforts routing. The resolver chain is
+    // synchronous, so the SECOND hop (dereference an asset the click-target
+    // points at and read a property off it) is pre-resolved here, up front,
+    // into targetRefFm before applyPropertyDefaultStep. No-op (undefined) when
+    // no `targetRefProperty` marker is present or no `refToFrontmatter` is wired.
+    const targetRefFm = await this.preResolveTargetRefs(
+      grounding.propertyDefault,
+      targetFm,
+    );
     const ctx: ResolverContext = {
       userInput,
       targetIRI,
       targetFilePath,
       targetFm: targetFm ?? undefined,
+      targetRefFm,
       groundingTargetClassUid,
     };
     if (grounding.propertyDefault && grounding.propertyDefault.length > 0) {
@@ -1469,6 +1503,74 @@ export class GroundingExecutor {
     if (pipeIdx >= 0) ref = ref.slice(0, pipeIdx);
     ref = ref.trim();
     return ref.length > 0 ? ref : null;
+  }
+
+  /**
+   * req c03f9e3e — per-ontology efforts routing. Pre-resolve the SECOND hop for
+   * every `targetRefProperty(<refKey>|<propKey>)` marker in the grounding's
+   * PropertyDefaults. The resolver chain runs synchronously (see
+   * {@link resolveSubstitutionMarker}), so a dereference of another asset — which
+   * needs an async vault lookup — cannot happen inside a resolver. Instead this
+   * runs up front: for each distinct `refKey` referenced by a `targetRefProperty`
+   * marker, read the bare ref out of the click-target's own frontmatter
+   * (`targetFm[refKey]`), resolve THAT asset's frontmatter via the injected
+   * {@link RefToFrontmatterResolver}, and return a map `refKey → frontmatter`
+   * placed into {@link ResolverContext.targetRefFm}.
+   *
+   * Returns `undefined` (no async work, no context field) when there are no such
+   * markers, no `refToFrontmatter` resolver is wired, or no target frontmatter was
+   * read — the two-hop resolver then yields nothing and the create is not routed
+   * (opt-in / zero regression for unconfigured groundings). A resolution failure
+   * for one refKey is logged and stored as `null` rather than failing the create.
+   */
+  private async preResolveTargetRefs(
+    propertyDefault: ReadonlyArray<PropertyDefaultResolved> | undefined,
+    targetFm: Record<string, string | string[]> | null,
+  ): Promise<Record<string, Record<string, unknown> | null> | undefined> {
+    if (!propertyDefault || !this.refToFrontmatter || !targetFm) return undefined;
+    const refKeys = new Set<string>();
+    for (const { value } of propertyDefault) {
+      if (typeof value !== "string") continue;
+      const refKey = GroundingExecutor.extractTargetRefPropertyRefKey(value);
+      if (refKey) refKeys.add(refKey);
+    }
+    if (refKeys.size === 0) return undefined;
+
+    const map: Record<string, Record<string, unknown> | null> = {};
+    for (const refKey of refKeys) {
+      const ref = GroundingExecutor.extractBareRef(targetFm[refKey]);
+      if (!ref) {
+        map[refKey] = null;
+        continue;
+      }
+      try {
+        map[refKey] = await this.refToFrontmatter(ref);
+      } catch (error) {
+        LoggingService.error(
+          `[GroundingExecutor] targetRefProperty second-hop resolution failed for ref "${ref}" (refKey "${refKey}") — routing skipped, instance co-locates with the click-target.`,
+          error instanceof Error ? error : new Error(String(error)),
+        );
+        map[refKey] = null;
+      }
+    }
+    return map;
+  }
+
+  /**
+   * req c03f9e3e — when `value` is a parameterised `targetRefProperty` marker,
+   * decode its `<refKey>|<propKey>` parameter and return the `refKey` (the part
+   * before the first `|`); otherwise `null`. Used by {@link preResolveTargetRefs}
+   * to discover which of the click-target's own frontmatter refs must be
+   * dereferenced for the second hop.
+   */
+  private static extractTargetRefPropertyRefKey(value: string): string | null {
+    const m = value.match(PARAMETERISED_MARKER_RE);
+    if (!m || m[1] !== "targetRefProperty") return null;
+    const parameter = GroundingExecutor.decodeBase64UrlSafe(m[2]);
+    const sep = parameter.indexOf("|");
+    if (sep < 0) return null;
+    const refKey = parameter.slice(0, sep);
+    return refKey.length > 0 ? refKey : null;
   }
 
   /**

--- a/packages/core/src/services/GroundingExecutor.ts
+++ b/packages/core/src/services/GroundingExecutor.ts
@@ -1538,7 +1538,12 @@ export class GroundingExecutor {
 
     const map: Record<string, Record<string, unknown> | null> = {};
     for (const refKey of refKeys) {
-      const ref = GroundingExecutor.extractBareRef(targetFm[refKey]);
+      // First hop reads the click-target's own ref. isDefinedBy is single-valued
+      // per the co-location invariant, but tolerate a single-item YAML-list form
+      // (["[[O]]"]) — mirror the second-hop resolver's array unwrap for symmetry.
+      const raw = targetFm[refKey];
+      const refVal = Array.isArray(raw) ? raw[0] : raw;
+      const ref = GroundingExecutor.extractBareRef(refVal);
       if (!ref) {
         map[refKey] = null;
         continue;

--- a/packages/core/src/services/SubstitutionResolverRegistry.ts
+++ b/packages/core/src/services/SubstitutionResolverRegistry.ts
@@ -32,6 +32,15 @@ export interface ResolverContext {
   readonly targetFilePath?: string;
   /** Click-target asset's parsed frontmatter (read once per executeCreateInstance). */
   readonly targetFm?: Record<string, unknown>;
+  /**
+   * req c03f9e3e — pre-resolved SECOND-hop frontmatter, keyed by the refKey the
+   * executor dereferenced. For each `refKey` referenced by a `targetRefProperty`
+   * marker, the executor reads `targetFm[refKey]` (a bare ref), resolves THAT
+   * asset's frontmatter (async, via the injected `refToFrontmatter`), and stores
+   * it here as `targetRefFm[refKey]`. `null` when the ref could not be resolved.
+   * The async second hop is done up front so the resolver chain stays SYNC.
+   */
+  readonly targetRefFm?: Record<string, Record<string, unknown> | null>;
   /** UID-canon class ref baked into the active Grounding (already resolved by executor). */
   readonly groundingTargetClassUid?: string;
 }
@@ -438,6 +447,41 @@ export function installDefaultResolvers(): void {
     const v = ctx.targetFm[parameter];
     if (v === undefined || v === null) return null;
     if (Array.isArray(v)) return v.map(String);
+    return String(v);
+  });
+
+  // req c03f9e3e — per-ontology efforts routing (TWO-HOP dereference).
+  //
+  // `targetRefProperty(refKey|propKey)` reads a property off the asset that the
+  // click-target's OWN frontmatter points at — the second hop `targetProperty`
+  // cannot make. Parameter is `<refKey>|<propKey>`:
+  //   1. the executor read `ctx.targetFm[refKey]` (a bare ref, e.g. the clicked
+  //      area's `exo__Asset_isDefinedBy` → the area-ontology O),
+  //   2. resolved THAT ontology's frontmatter (async, via the injected
+  //      `refToFrontmatter`) into `ctx.targetRefFm[refKey]`,
+  //   3. this resolver reads `propKey` off it (e.g. `exo__Ontology_effortsOntology`
+  //      → the target efforts-ontology E).
+  //
+  // The async second hop happens in the executor BEFORE the (synchronous)
+  // resolver chain runs, so this resolver just reads the pre-resolved map. `null`
+  // when: no parameter, malformed parameter, the ref was not pre-resolved (no
+  // `refToFrontmatter` wired / ref not found), or the property is absent — in
+  // which case the PropertyDefault is skipped, isDefinedBy is not routed, and the
+  // instance co-locates with the click-target (opt-in / no regression). A single
+  // wikilink (isDefinedBy is single-valued) is returned verbatim, mirroring
+  // `targetProperty`.
+  registerResolver("targetRefProperty", (ctx, parameter) => {
+    if (!parameter) return null;
+    const sep = parameter.indexOf("|");
+    if (sep < 0) return null;
+    const refKey = parameter.slice(0, sep);
+    const propKey = parameter.slice(sep + 1);
+    if (!refKey || !propKey) return null;
+    const refFm = ctx.targetRefFm?.[refKey];
+    if (!refFm) return null;
+    const v = refFm[propKey];
+    if (v === undefined || v === null) return null;
+    if (Array.isArray(v)) return v.length > 0 ? String(v[0]) : null;
     return String(v);
   });
 

--- a/packages/core/src/services/VaultFrontmatterRefToFrontmatterResolver.ts
+++ b/packages/core/src/services/VaultFrontmatterRefToFrontmatterResolver.ts
@@ -1,0 +1,33 @@
+import type { IFileSystemMetadataProvider } from "../interfaces/IFileSystemAdapter";
+import type { RefToFrontmatterResolver } from "./GroundingExecutor";
+
+/**
+ * req c03f9e3e — per-ontology efforts routing — filesystem-frontmatter-backed
+ * {@link RefToFrontmatterResolver}, the CLI/headless counterpart of the plugin's
+ * metadata-cache resolver (`createObsidianRefToFrontmatterResolver`).
+ *
+ * `GroundingExecutor` makes a SECOND hop when a create-instance grounding uses
+ * the `targetRefProperty` token: from the click-target (an area) → the area's
+ * `exo__Asset_isDefinedBy` ontology → that ontology's `exo__Ontology_effortsOntology`.
+ * The core executor is storage-agnostic, so the host injects this resolver to map
+ * a bare asset UID to the parsed frontmatter of the file it points at.
+ *
+ * Wiring this in the CLI keeps `apply <create-instance> <area>` routing-correct,
+ * matching the plugin button (UI/CLI parity, Issue #3417). Returns `null` when
+ * nothing matches; the executor then leaves isDefinedBy unrouted and co-locates
+ * the new instance with the click-target rather than failing the create.
+ */
+export function createVaultFrontmatterRefToFrontmatterResolver(
+  metadataProvider: IFileSystemMetadataProvider,
+): RefToFrontmatterResolver {
+  return async (ref: string): Promise<Record<string, unknown> | null> => {
+    if (!ref) return null;
+
+    const matches = await metadataProvider.findFilesByMetadata({
+      exo__Asset_uid: ref,
+    });
+    if (matches.length === 0) return null;
+
+    return metadataProvider.getFileMetadata(matches[0]);
+  };
+}

--- a/packages/core/tests/unit/services/GroundingExecutor.test.ts
+++ b/packages/core/tests/unit/services/GroundingExecutor.test.ts
@@ -1112,6 +1112,180 @@ describe("GroundingExecutor", () => {
       });
     });
 
+    // -- req c03f9e3e "per-ontology efforts routing" (TWO-HOP) --
+    //
+    // When an Effort (task/project) is created from an AREA via a homoiconic
+    // Create button, its `exo__Asset_isDefinedBy` is auto-derived TWO-HOP:
+    //   area A → A's own `exo__Asset_isDefinedBy` (the area-ontology O)
+    //          → O's `exo__Ontology_effortsOntology` (the target efforts-ontology E)
+    // and the new Effort co-locates in E's folder (co-location invariant). This
+    // drives the REAL executeCreateInstance + the new `targetRefProperty` resolver
+    // + the injected `refToFrontmatter` second-hop (async pre-resolution).
+    describe("req c03f9e3e per-ontology efforts routing (two-hop)", () => {
+      const AREA_PATH =
+        "assetspaces/kitelev/exoas-my/my-areas/aaaaaaaa-1111-2222-3333-444444444444.md";
+      const AREA_IRI =
+        "obsidian://vault/aaaaaaaa-1111-2222-3333-444444444444.md";
+      const AREA_FOLDER = "assetspaces/kitelev/exoas-my/my-areas";
+      const AREA_ONTOLOGY = "bbbbbbbb-1111-2222-3333-444444444444"; // O
+      const EFFORTS_ONTOLOGY = "cccccccc-1111-2222-3333-444444444444"; // E
+      const EFFORTS_FOLDER = "assetspaces/kitelev/exoas-my/my-efforts";
+      const EFFORT_CLASS = "1b20a8f0-d745-4e93-91db-4531b3df120e"; // ems__Task
+
+      // Two-hop resolver marker. Parameter is `<refKey>|<propKey>` — the executor
+      // reads targetFm[refKey] (area's isDefinedBy → O), resolves O's frontmatter,
+      // and this resolver reads propKey (O's effortsOntology → E). Encoded exactly
+      // as CommandResolver.buildParameterisedMarker would (url-safe base64, no pad).
+      const REF_PROP_PARAM =
+        "exo__Asset_isDefinedBy|exo__Ontology_effortsOntology";
+      const REF_PROP_MARKER = `__SUBSTITUTE_P__targetRefProperty__22222222-2222-2222-2222-222222222222__${Buffer.from(
+        REF_PROP_PARAM,
+        "utf8",
+      ).toString("base64url")}__`;
+      // Non-parameterised marker for exo__Instance_class (host baked class).
+      const CLASS_MARKER =
+        "__SUBSTITUTE__groundingTargetClass__33333333-3333-3333-3333-333333333333__";
+
+      beforeEach(() => {
+        clearResolvers();
+        installDefaultResolvers();
+      });
+
+      function makeEffortGrounding(): GroundingDefinition {
+        return makeGrounding({
+          type: GroundingType.CREATE_INSTANCE,
+          targetClass: EFFORT_CLASS,
+          targetFolder: "$isDefinedByFolder",
+          propertyDefault: [
+            { propertyName: "exo__Asset_isDefinedBy", value: REF_PROP_MARKER },
+            { propertyName: "exo__Instance_class", value: CLASS_MARKER },
+          ],
+        });
+      }
+
+      it("@req:c03f9e3e-b47d-4a57-af9c-009ead5b9b34 routes the new Effort to the area-ontology's effortsOntology folder (two-hop)", async () => {
+        // Area A's own frontmatter: isDefinedBy → the area-ontology O.
+        reader.readFile.mockResolvedValue(
+          `---\nexo__Asset_isDefinedBy: "[[${AREA_ONTOLOGY}]]"\n---\n`,
+        );
+        // Second hop: O's frontmatter carries effortsOntology = E.
+        const refToFrontmatter = jest.fn(async (ref: string) =>
+          ref === AREA_ONTOLOGY
+            ? { exo__Ontology_effortsOntology: `"[[${EFFORTS_ONTOLOGY}]]"` }
+            : null,
+        );
+        // Folder resolution: routed isDefinedBy (E) → E's folder; O → area folder.
+        const refToFolder = jest.fn(async (ref: string) =>
+          ref === EFFORTS_ONTOLOGY
+            ? EFFORTS_FOLDER
+            : ref === AREA_ONTOLOGY
+              ? AREA_FOLDER
+              : null,
+        );
+        executor = new GroundingExecutor(reader, writer, registry, undefined, {
+          refToFolder,
+          refToFrontmatter,
+        });
+
+        const result = await executor.execute(
+          makeEffortGrounding(),
+          AREA_IRI,
+          AREA_PATH,
+          { label: "My Task" },
+        );
+
+        expect(result.success).toBe(true);
+        const [path, content] = writer.createFile.mock.calls[0];
+        // isDefinedBy auto-set to E (read two-hop A → O → O.effortsOntology).
+        expect(content).toContain(
+          `exo__Asset_isDefinedBy: "[[${EFFORTS_ONTOLOGY}]]"`,
+        );
+        // File co-located in E's folder, NOT the area folder.
+        expect(path.startsWith(`${EFFORTS_FOLDER}/`)).toBe(true);
+        expect(path.startsWith(`${AREA_FOLDER}/`)).toBe(false);
+        // First hop consulted the area-ontology; folder resolved for E (routed).
+        expect(refToFrontmatter).toHaveBeenCalledWith(AREA_ONTOLOGY);
+        expect(refToFolder).toHaveBeenCalledWith(EFFORTS_ONTOLOGY);
+      });
+
+      it("@req:c03f9e3e-b47d-4a57-af9c-009ead5b9b34 routes per-ontology: O1→E1 folder, O2→E2 folder", async () => {
+        const O1 = "d1111111-1111-2222-3333-444444444444";
+        const O2 = "d2222222-1111-2222-3333-444444444444";
+        const E1 = "e1111111-1111-2222-3333-444444444444";
+        const E2 = "e2222222-1111-2222-3333-444444444444";
+        const E1_FOLDER = "assetspaces/kitelev/exoas-my/my-efforts";
+        const E2_FOLDER = "assetspaces/kitelev/exoas-tbank/work-efforts";
+        const refToFrontmatter = jest.fn(async (ref: string) => {
+          if (ref === O1)
+            return { exo__Ontology_effortsOntology: `"[[${E1}]]"` };
+          if (ref === O2)
+            return { exo__Ontology_effortsOntology: `"[[${E2}]]"` };
+          return null;
+        });
+        const refToFolder = jest.fn(async (ref: string) => {
+          if (ref === E1) return E1_FOLDER;
+          if (ref === E2) return E2_FOLDER;
+          return null;
+        });
+        executor = new GroundingExecutor(reader, writer, registry, undefined, {
+          refToFolder,
+          refToFrontmatter,
+        });
+
+        // Effort from an area under O1.
+        reader.readFile.mockResolvedValue(
+          `---\nexo__Asset_isDefinedBy: "[[${O1}]]"\n---\n`,
+        );
+        await executor.execute(makeEffortGrounding(), AREA_IRI, AREA_PATH, {
+          label: "A1",
+        });
+        const path1 = writer.createFile.mock.calls[0][0];
+
+        // Effort from an area under O2.
+        reader.readFile.mockResolvedValue(
+          `---\nexo__Asset_isDefinedBy: "[[${O2}]]"\n---\n`,
+        );
+        await executor.execute(makeEffortGrounding(), AREA_IRI, AREA_PATH, {
+          label: "A2",
+        });
+        const path2 = writer.createFile.mock.calls[1][0];
+
+        expect(path1.startsWith(`${E1_FOLDER}/`)).toBe(true);
+        expect(path2.startsWith(`${E2_FOLDER}/`)).toBe(true);
+        expect(path1.startsWith(E2_FOLDER)).toBe(false);
+      });
+
+      it("@req:c03f9e3e-b47d-4a57-af9c-009ead5b9b34 negative control: area-ontology WITHOUT effortsOntology → no routing, Effort co-locates with the area", async () => {
+        reader.readFile.mockResolvedValue(
+          `---\nexo__Asset_isDefinedBy: "[[${AREA_ONTOLOGY}]]"\n---\n`,
+        );
+        // O exists but declares NO effortsOntology → second hop yields nothing.
+        const refToFrontmatter = jest.fn(async (ref: string) =>
+          ref === AREA_ONTOLOGY ? { exo__Ontology_url: "https://x/o#" } : null,
+        );
+        // isDefinedBy unrouted → resolveIsDefinedByFolder has no ref → host folder.
+        const refToFolder = jest.fn(async () => null);
+        executor = new GroundingExecutor(reader, writer, registry, undefined, {
+          refToFolder,
+          refToFrontmatter,
+        });
+
+        const result = await executor.execute(
+          makeEffortGrounding(),
+          AREA_IRI,
+          AREA_PATH,
+          { label: "Unrouted" },
+        );
+
+        expect(result.success).toBe(true);
+        const [path, content] = writer.createFile.mock.calls[0];
+        // No isDefinedBy written (routing yielded nothing — opt-in).
+        expect(content).not.toContain("exo__Asset_isDefinedBy:");
+        // Effort co-locates with the area (host folder = parent of AREA_PATH).
+        expect(path.startsWith(`${AREA_FOLDER}/`)).toBe(true);
+      });
+    });
+
     // -- W3 "Create Class" homoiconic button (project 85150d63) --
     //
     // Mirror of T1 Create Instance, but the host page IS an `exo__Ontology`

--- a/packages/core/tests/unit/services/GroundingExecutor.test.ts
+++ b/packages/core/tests/unit/services/GroundingExecutor.test.ts
@@ -1284,6 +1284,44 @@ describe("GroundingExecutor", () => {
         // Effort co-locates with the area (host folder = parent of AREA_PATH).
         expect(path.startsWith(`${AREA_FOLDER}/`)).toBe(true);
       });
+
+      it("@req:c03f9e3e-b47d-4a57-af9c-009ead5b9b34 routes when the ontology's effortsOntology is a BARE wikilink (realistic YAML-parsed shape)", async () => {
+        // Production `refToFrontmatter` (plugin metadataCache + CLI YAML parse)
+        // returns the value with outer YAML quotes stripped, i.e. the bare string
+        // `[[E]]` rather than `"[[E]]"`. Lock that realistic shape too — it must
+        // still serialize to a valid quoted isDefinedBy and route to E's folder.
+        reader.readFile.mockResolvedValue(
+          `---\nexo__Asset_isDefinedBy: "[[${AREA_ONTOLOGY}]]"\n---\n`,
+        );
+        const refToFrontmatter = jest.fn(async (ref: string) =>
+          ref === AREA_ONTOLOGY
+            ? { exo__Ontology_effortsOntology: `[[${EFFORTS_ONTOLOGY}]]` } // bare, no quotes
+            : null,
+        );
+        const refToFolder = jest.fn(async (ref: string) =>
+          ref === EFFORTS_ONTOLOGY ? EFFORTS_FOLDER : null,
+        );
+        executor = new GroundingExecutor(reader, writer, registry, undefined, {
+          refToFolder,
+          refToFrontmatter,
+        });
+
+        const result = await executor.execute(
+          makeEffortGrounding(),
+          AREA_IRI,
+          AREA_PATH,
+          { label: "Bare" },
+        );
+
+        expect(result.success).toBe(true);
+        const [path, content] = writer.createFile.mock.calls[0];
+        // Bare `[[E]]` still serializes to the quoted, valid isDefinedBy.
+        expect(content).toContain(
+          `exo__Asset_isDefinedBy: "[[${EFFORTS_ONTOLOGY}]]"`,
+        );
+        expect(path.startsWith(`${EFFORTS_FOLDER}/`)).toBe(true);
+        expect(refToFolder).toHaveBeenCalledWith(EFFORTS_ONTOLOGY);
+      });
     });
 
     // -- W3 "Create Class" homoiconic button (project 85150d63) --

--- a/packages/core/tests/unit/services/SubstitutionResolverRegistry.test.ts
+++ b/packages/core/tests/unit/services/SubstitutionResolverRegistry.test.ts
@@ -25,7 +25,7 @@ describe("SubstitutionResolverRegistry — RFC 727572d2 Phase A2 vocabulary", ()
     installDefaultResolvers();
   });
 
-  it("registers all 19 expected resolver-ids (4 legacy + 10 new + targetClassSelf + 4 date-modifier tokens Веха 5)", () => {
+  it("registers all 20 expected resolver-ids (4 legacy + 10 new + targetClassSelf + targetRefProperty + 4 date-modifier tokens Веха 5)", () => {
     const ids = getRegisteredResolverIds().sort();
     expect(ids).toEqual(
       [
@@ -40,6 +40,8 @@ describe("SubstitutionResolverRegistry — RFC 727572d2 Phase A2 vocabulary", ()
         "targetClassSelf",
         "targetFolder",
         "targetProperty",
+        // req c03f9e3e — per-ontology efforts routing (two-hop dereference)
+        "targetRefProperty",
         "today",
         "todayStart",
         "userInput",

--- a/packages/obsidian-plugin/src/ExocortexPlugin.ts
+++ b/packages/obsidian-plugin/src/ExocortexPlugin.ts
@@ -136,6 +136,7 @@ import { populateServiceRegistry } from "./infrastructure/services/ServiceRegist
 import { ObsidianFileOpener } from "./infrastructure/services/ObsidianFileOpener";
 import { createObsidianClassLabelResolver } from "./infrastructure/services/ObsidianClassLabelResolver";
 import { createObsidianRefToFolderResolver } from "./infrastructure/services/ObsidianRefToFolderResolver";
+import { createObsidianRefToFrontmatterResolver } from "./infrastructure/services/ObsidianRefToFrontmatterResolver";
 import { ExocmdCommandPaletteRegistrar } from "./application/services/ExocmdCommandPaletteRegistrar";
 import { ObsidianCommandPromptAdapter } from "./infrastructure/adapters/ObsidianCommandPromptAdapter";
 import {
@@ -718,6 +719,10 @@ export default class ExocortexPlugin extends Plugin {
           // T1 "Create Instance" (project bbe40f8c) — co-locate new instances in
           // their chosen ontology's folder via the `$isDefinedByFolder` token.
           refToFolder: createObsidianRefToFolderResolver(this.app),
+          // req c03f9e3e — per-ontology efforts routing: resolve the SECOND hop
+          // (area's isDefinedBy ontology → its exo__Ontology_effortsOntology) for
+          // the `targetRefProperty` token.
+          refToFrontmatter: createObsidianRefToFrontmatterResolver(this.app),
         },
       );
 

--- a/packages/obsidian-plugin/src/infrastructure/services/ObsidianRefToFrontmatterResolver.ts
+++ b/packages/obsidian-plugin/src/infrastructure/services/ObsidianRefToFrontmatterResolver.ts
@@ -1,0 +1,67 @@
+import type { App, CachedMetadata, TFile } from "obsidian";
+import type { RefToFrontmatterResolver } from "@kitelev/exocortex-core";
+
+/**
+ * req c03f9e3e — per-ontology efforts routing — metadata-cache backed
+ * {@link RefToFrontmatterResolver}, sibling of {@link createObsidianRefToFolderResolver}.
+ *
+ * # Why this lives in the plugin layer
+ *
+ * `GroundingExecutor` makes a SECOND hop for the `targetRefProperty` token —
+ * from the click-target (an area) → the area's `exo__Asset_isDefinedBy` ontology
+ * → that ontology's `exo__Ontology_effortsOntology` (the target efforts-ontology).
+ * The core executor is storage-agnostic and cannot scan the vault for the file a
+ * UID points at; the plugin injects this resolver, backed by the always-warm
+ * Obsidian metadata cache.
+ *
+ * # How it works
+ *
+ * Given a bare asset reference (a UID, after the executor strips quotes /
+ * `[[ ]]` / `|alias`), find the markdown file whose `exo__Asset_uid` equals it —
+ * or, as a fast path for UID-canon filenames, whose basename equals it — and
+ * return that file's parsed frontmatter.
+ *
+ * Returns `null` when nothing matches or the metadata-cache API is unavailable;
+ * the executor then leaves isDefinedBy unrouted and co-locates the new instance
+ * with the click-target rather than failing the create. Runs on both desktop and
+ * mobile (no `Platform.isMobile` gating) — the metadata cache is available on
+ * every platform.
+ *
+ * Cost is O(N) per lookup over markdown files; create_instance executions are
+ * infrequent (one per button click), so an index is deferred unless profiling
+ * shows it is hot.
+ */
+export function createObsidianRefToFrontmatterResolver(
+  app: App,
+): RefToFrontmatterResolver {
+  return (ref: string): Record<string, unknown> | null => {
+    if (!ref) return null;
+
+    const metadataCache = app.metadataCache;
+    const vault = app.vault;
+    if (!metadataCache || !vault) return null;
+
+    const getFileCache = metadataCache.getFileCache?.bind(metadataCache);
+    const getMarkdownFiles = vault.getMarkdownFiles?.bind(vault);
+    if (!getFileCache || !getMarkdownFiles) return null;
+
+    const files: TFile[] = getMarkdownFiles();
+    for (const file of files) {
+      // Fast path: UID-canon filenames are `<uid>.md`, so the basename match
+      // avoids reading frontmatter for the common case.
+      if (file.basename === ref) {
+        const cache: CachedMetadata | null = getFileCache(file);
+        return (cache?.frontmatter as Record<string, unknown> | undefined) ?? null;
+      }
+    }
+    for (const file of files) {
+      const cache: CachedMetadata | null = getFileCache(file);
+      const uid = cache?.frontmatter?.["exo__Asset_uid"];
+      if (typeof uid === "string" && uid === ref) {
+        return (cache?.frontmatter as Record<string, unknown> | undefined) ?? null;
+      }
+    }
+
+    return null;
+  };
+}


### PR DESCRIPTION
## req `c03f9e3e` — per-ontology efforts routing (two-hop)

When an Effort is created from an **area** via a homoiconic Create button, its
`exo__Asset_isDefinedBy` can be auto-derived **two-hop** — `area A → A's own
exo__Asset_isDefinedBy ontology O → O's exo__Ontology_effortsOntology E` — and
the new Effort co-locates in **E's folder**. Area-ontologies stay clean; efforts
are auto-filed per area-ontology (e.g. `my-areas → my-efforts`,
`work-areas → work-efforts`) with zero manual `isDefinedBy` selection.

### Design (ELEVATED-RISK: touches GroundingExecutor + SubstitutionResolverRegistry)

The substitution resolver chain is **synchronous** (`resolveSubstitutionMarker → fn(ctx)`),
so a resolver cannot `await` a vault lookup. The async **second hop** is therefore
pre-resolved by the executor into a new `ResolverContext.targetRefFm` **before**
`applyPropertyDefaultStep`, and a new **sync** `targetRefProperty(refKey|propKey)`
resolver reads it. (The orchestrator ruled this the approach — the prompt's literal
"Option A" of a resolver self-dereferencing async is infeasible without an async
cascade rewrite; A/B collapse into this hybrid.)

- **New injected `refToFrontmatter`** resolver (sibling of the existing `refToFolder`)
  makes the second hop — wired in the plugin (`ObsidianRefToFrontmatterResolver`,
  metadata-cache) and CLI (`VaultFrontmatterRefToFrontmatterResolver`, nodeFsAdapter).
- **`targetRefProperty` added to `KNOWN_SUBSTITUTION_RESOLVER_IDS`** so the parser
  emits the parameterised marker instead of a wikilink fallback (only multi-parser
  touchpoint — no new grounding predicate).
- **Opt-in / no regression**: no `effortsOntology` → resolver yields `null` →
  `isDefinedBy` not routed → Effort co-locates with the area.

### Verification

- **@req integration test** (revert-verified) — drives the **REAL**
  `GroundingExecutor.executeCreateInstance` + `targetRefProperty` + `refToFrontmatter`:
  two-hop route, per-ontology (`O1→E1`, `O2→E2`), and negative control. Break the
  second-hop deref → the two routing tests go **RED**, negative control stays GREEN;
  restore → GREEN. (`GroundingExecutor.test.ts`.)
- **Temp-vault real `apply` e2e** (locally-built CLI, not `--dry-run`): positive case
  → Effort routed to E's folder (`isDefinedBy=E`); negative case → co-locates with
  the area. Both pass.
- **TBox** `exo__Ontology_effortsOntology` (ObjectProperty, domain+range `exo__Ontology`)
  declared in `exoas-exo` (SHACL clean, 0 violations).
- Full core suite **347/347** suites green (8382 tests). CLI apply suites green.
- **Docs**: `docs/how-to/per-ontology-efforts-routing.md`.

### Scope / follow-up

Engine capability + TBox + tests + docs land here. **Live activation in the user's
real vault** (setting `exo__Ontology_effortsOntology` on the actual `my-areas`
ontology + authoring the live two-hop create-task/create-project grounding button)
is a **follow-up** — opt-in, no regression until enabled.

@req:c03f9e3e-b47d-4a57-af9c-009ead5b9b34
