### PR TITLE
feat(cli): audit ontology-membership — KSD ArchUnit cohesion ratchet (req c23f6f50)

### DIFF
--- a/packages/cli/src/commands/audit-ontology-imports.ts
+++ b/packages/cli/src/commands/audit-ontology-imports.ts
@@ -38,9 +38,9 @@ export const ONTOLOGY_CLASS_UID = "829b9b3b-6fc3-4276-be6a-27d3398c012e";
  */
 export const ASSOCIATIVE_PREDICATES: readonly string[] = [
   "exo__Asset_relates",
-  "ims__Concept_related",
-  "ims__Concept_broader",
-  "ims__Concept_synonym",
+  "concept__Concept_related",
+  "concept__Concept_broader",
+  "concept__Concept_synonym",
   "exo__Asset_createdBy",
 ];
 
@@ -1059,7 +1059,7 @@ export function auditOntologyImportsCommand(): Command {
     )
     .option(
       "--structural-only",
-      "Exclude curated associative predicates (exo__Asset_relates, ims__Concept_related/broader/synonym, exo__Asset_createdBy) from edge extraction to measure the structural backbone import-DAG (EKA Phase B, Vision VL#30). Default: every wikilink counts.",
+      "Exclude curated associative predicates (exo__Asset_relates, concept__Concept_related/broader/synonym, exo__Asset_createdBy) from edge extraction to measure the structural backbone import-DAG (EKA Phase B, Vision VL#30). Default: every wikilink counts.",
     )
     .option(
       "--exclude-predicate <name>",

--- a/packages/cli/src/commands/audit-ontology-membership.ts
+++ b/packages/cli/src/commands/audit-ontology-membership.ts
@@ -1,0 +1,393 @@
+import { Command } from "commander";
+import { existsSync, statSync } from "fs";
+import { resolve } from "path";
+import { extractAssetReference } from "@kitelev/exocortex-core";
+import { CachingNodeFsAdapter } from "../adapters/CachingNodeFsAdapter.js";
+import { findReferencedFile } from "../executors/folderRepairHelpers.js";
+import {
+  isNodeModulesPath,
+  isTemplatesPath,
+} from "../utils/vaultPathFilters.js";
+import { ErrorHandler, type OutputFormat } from "../utils/ErrorHandler.js";
+import { VaultNotFoundError } from "../utils/errors/index.js";
+
+/** `exo__Ontology` class UID — an ontology is any asset instancing it. */
+export const ONTOLOGY_CLASS_UID = "829b9b3b-6fc3-4276-be6a-27d3398c012e";
+
+/**
+ * Why an asset mapped to no admits-checked ontology is fail-open SKIPPED (not a
+ * violation, but also not proven a member). Reported explicitly so "0
+ * violations" never masks "nothing was actually checked".
+ * - `no-isDefinedBy`: empty / `!`-prefixed `exo__Asset_isDefinedBy` — no
+ *   ontology to check against.
+ * - `ontology-unresolvable`: the `isDefinedBy` reference resolves to nothing (or
+ *   to a non-ontology) in this vault (cross-vault / missing / not an ontology).
+ * - `ontology-no-admits`: mapped to an ontology that declares NO
+ *   `exo__Ontology_admits` — audit-first / fail-open: no allow-list, no
+ *   constraint. This is the intended dormant state for ontologies not yet
+ *   opted into the ratchet.
+ * - `no-instance-class`: the asset carries no `exo__Instance_class` — its
+ *   membership cannot be classified.
+ * - `unresolvable-class`: the asset's `exo__Instance_class` refs resolve to no
+ *   known class UID (dangling / cross-vault class) — cannot classify.
+ */
+export type MembershipSkipReason =
+  | "no-isDefinedBy"
+  | "ontology-unresolvable"
+  | "ontology-no-admits"
+  | "no-instance-class"
+  | "unresolvable-class";
+
+export interface MembershipViolation {
+  path: string;
+  /** Ontology (uid|label|path) the asset is co-located under. */
+  ontologyUid: string;
+  ontologyLabel: string;
+  /** Resolved class UIDs of the asset (`exo__Instance_class`). */
+  classUids: string[];
+  /** The ontology's declared admits allow-list (resolved class UIDs). */
+  admits: string[];
+}
+
+export interface OntologyMembershipResult {
+  vaultPath: string;
+  totalFiles: number;
+  /** Ontologies (instances of exo__Ontology) discovered. */
+  ontologies: number;
+  /** Ontologies that DECLARED a non-empty exo__Ontology_admits allow-list. */
+  ontologiesWithAdmits: number;
+  /** Assets whose membership was actually checked (mapped to an admits ontology). */
+  checked: number;
+  violations: MembershipViolation[];
+  skips: Record<MembershipSkipReason, number>;
+  /** Up to a few example paths per skip reason, for human triage. */
+  skipExamples: Record<MembershipSkipReason, string[]>;
+}
+
+const MAX_SKIP_EXAMPLES = 5;
+
+/** First non-array string, or null. */
+function firstString(value: unknown): string | null {
+  if (Array.isArray(value)) {
+    const s = value.find((v) => typeof v === "string");
+    return (s as string) ?? null;
+  }
+  return typeof value === "string" ? value : null;
+}
+
+/**
+ * Extract the wikilink *targets* of a frontmatter value as a list of references
+ * (UID-form → the UID, label/symbolic-form → the label), robust to YAML parsing
+ * a bare `[[uid]]` into a nested array. Mirrors `audit ontology-imports`'
+ * `asRefList` + `folderRepairHelpers`' array descent.
+ */
+function asRefList(value: unknown): string[] {
+  const raw =
+    value === undefined || value === null
+      ? []
+      : Array.isArray(value)
+        ? value
+        : [value];
+  const refs: string[] = [];
+  for (const item of raw) {
+    // Descend nested arrays (unquoted `[[uid]]` parses to ["uid"] / [["uid"]]).
+    let cur: unknown = item;
+    while (Array.isArray(cur)) cur = cur[0];
+    const ref = extractAssetReference(cur);
+    if (ref) refs.push(ref);
+  }
+  return refs;
+}
+
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/**
+ * Audit a single vault for the ontology-MEMBERSHIP invariant (cohesion-side KSD
+ * ArchUnit): every asset co-located under an ontology O that DECLARES an
+ * `exo__Ontology_admits` allow-list must carry an `exo__Instance_class` that is
+ * admitted by O — i.e. the class, or one of its `exo__Class_superClass`
+ * ancestors, is in O's allow-list.
+ *
+ * Discovery + isDefinedBy asset→ontology mapping mirror `audit co-location` /
+ * `audit ontology-imports` (instances of {@link ONTOLOGY_CLASS_UID};
+ * {@link findReferencedFile} resolver). Subsumption (F8/F9) is a TS-side
+ * superClass BFS over class-def files — pure SPARQL cannot walk it because the
+ * store emits a symbolic Instance_class IRI with 0 superClass edges (dual-IRI
+ * gap). Every class ref (admits value, Instance_class, superClass) is unified to
+ * a canonical class UID: a UID-form ref is its own UID; a label/symbolic-form
+ * ref is resolved via a first-wins `exo__Asset_label → uid` index (class-def
+ * files are UID-named, so a label wikilink cannot resolve by basename).
+ *
+ * Fail-open (audit-first): an ontology with NO `_admits` has ALL its members
+ * skipped; assets with no `isDefinedBy` / no `Instance_class` / unresolvable
+ * refs are skip-accounted by reason, never violations.
+ */
+export async function scanVaultForOntologyMembership(
+  vaultPath: string,
+): Promise<OntologyMembershipResult> {
+  const adapter = new CachingNodeFsAdapter(vaultPath);
+  const assets = await adapter.indexedAssets();
+
+  // ---- indexes over all (non-excluded) assets ----
+  const metaByUid = new Map<string, Record<string, unknown>>(); // uid → metadata (first-wins)
+  const labelToUid = new Map<string, string>(); // label → uid (first-wins)
+  const ontologyByPath = new Map<string, string>(); // ontology file path → uid
+  const ontologyLabelByUid = new Map<string, string>();
+  // ontology uid → resolved admits class-UID set (only for ontologies that
+  // declared a NON-EMPTY exo__Ontology_admits).
+  const admitsByOntologyUid = new Map<string, Set<string>>();
+  const admitsRawByOntologyUid = new Map<string, string[]>(); // for reporting
+
+  for (const asset of assets) {
+    if (isNodeModulesPath(asset.path) || isTemplatesPath(asset.path)) continue;
+    const uid = firstString(asset.metadata["exo__Asset_uid"]);
+    if (uid) {
+      if (!metaByUid.has(uid)) metaByUid.set(uid, asset.metadata);
+      const label = firstString(asset.metadata["exo__Asset_label"]);
+      if (label && !labelToUid.has(label)) labelToUid.set(label, uid);
+    }
+    const classRefs = asRefList(asset.metadata["exo__Instance_class"]);
+    if (uid && classRefs.includes(ONTOLOGY_CLASS_UID)) {
+      ontologyByPath.set(asset.path, uid);
+      const label = firstString(asset.metadata["exo__Asset_label"]) ?? asset.path;
+      if (!ontologyLabelByUid.has(uid)) ontologyLabelByUid.set(uid, label);
+    }
+  }
+
+  // Resolve any class ref (UID-form or label/symbolic-form) to a canonical class
+  // UID. A UID-form ref IS its own canonical UID (trusted regardless of whether
+  // the class-def file is mounted in THIS vault — enables direct admits-match
+  // for a cross-vault class; subsumption still needs the class-def present, and
+  // degrades to direct-match-only when absent). A label/symbolic-form ref
+  // (`[[concept__Concept]]`) cannot resolve by basename (class-def files are
+  // UID-named), so it is resolved via the first-wins `label → uid` index.
+  const resolveClassRefToUid = (ref: string): string | null => {
+    if (UUID_RE.test(ref)) return ref;
+    return labelToUid.get(ref) ?? null;
+  };
+
+  // Populate admits sets (second pass — needs the resolver + label index built).
+  for (const asset of assets) {
+    if (isNodeModulesPath(asset.path) || isTemplatesPath(asset.path)) continue;
+    const uid = ontologyByPath.get(asset.path);
+    if (!uid) continue;
+    const admitRefs = asRefList(asset.metadata["exo__Ontology_admits"]);
+    if (admitRefs.length === 0) continue; // no allow-list → fail-open (not tracked)
+    const set = new Set<string>();
+    for (const ref of admitRefs) {
+      const cu = resolveClassRefToUid(ref);
+      if (cu) set.add(cu);
+    }
+    if (set.size > 0) {
+      admitsByOntologyUid.set(uid, set);
+      admitsRawByOntologyUid.set(uid, [...set]);
+    }
+  }
+
+  // Transitive superClass closure of a class UID (cycle-safe), memoized.
+  const closureCache = new Map<string, Set<string>>();
+  const classClosure = (startUid: string): Set<string> => {
+    const cached = closureCache.get(startUid);
+    if (cached) return cached;
+    const out = new Set<string>();
+    const queue = [startUid];
+    while (queue.length > 0) {
+      const cur = queue.shift()!;
+      if (out.has(cur)) continue;
+      out.add(cur);
+      const meta = metaByUid.get(cur);
+      if (!meta) continue;
+      for (const superRef of asRefList(meta["exo__Class_superClass"])) {
+        const superUid = resolveClassRefToUid(superRef);
+        if (superUid && !out.has(superUid)) queue.push(superUid);
+      }
+    }
+    closureCache.set(startUid, out);
+    return out;
+  };
+
+  // ---- per-asset membership check ----
+  const violations: MembershipViolation[] = [];
+  const skips: Record<MembershipSkipReason, number> = {
+    "no-isDefinedBy": 0,
+    "ontology-unresolvable": 0,
+    "ontology-no-admits": 0,
+    "no-instance-class": 0,
+    "unresolvable-class": 0,
+  };
+  const skipExamples: Record<MembershipSkipReason, string[]> = {
+    "no-isDefinedBy": [],
+    "ontology-unresolvable": [],
+    "ontology-no-admits": [],
+    "no-instance-class": [],
+    "unresolvable-class": [],
+  };
+  let checked = 0;
+
+  const skip = (reason: MembershipSkipReason, path: string): void => {
+    skips[reason]++;
+    if (skipExamples[reason].length < MAX_SKIP_EXAMPLES) {
+      skipExamples[reason].push(path);
+    }
+  };
+
+  for (const asset of assets) {
+    if (isNodeModulesPath(asset.path) || isTemplatesPath(asset.path)) continue;
+
+    const ref = extractAssetReference(asset.metadata["exo__Asset_isDefinedBy"]);
+    if (!ref || ref.startsWith("!")) {
+      skip("no-isDefinedBy", asset.path);
+      continue;
+    }
+    const ontologyPath = await findReferencedFile(adapter, ref, asset.path);
+    const ontologyUid = ontologyPath ? ontologyByPath.get(ontologyPath) : undefined;
+    if (!ontologyUid) {
+      skip("ontology-unresolvable", asset.path);
+      continue;
+    }
+    const admits = admitsByOntologyUid.get(ontologyUid);
+    if (!admits) {
+      skip("ontology-no-admits", asset.path);
+      continue;
+    }
+
+    const classRefs = asRefList(asset.metadata["exo__Instance_class"]);
+    if (classRefs.length === 0) {
+      skip("no-instance-class", asset.path);
+      continue;
+    }
+    const classUids = classRefs
+      .map(resolveClassRefToUid)
+      .filter((u): u is string => u !== null);
+    if (classUids.length === 0) {
+      skip("unresolvable-class", asset.path);
+      continue;
+    }
+
+    checked++;
+    // Admitted iff any of the asset's classes, or a superClass ancestor of one,
+    // is in the ontology's allow-list (subsumption — F8/F9 metaclass-mixing).
+    const admitted = classUids.some((cu) => {
+      for (const ancestor of classClosure(cu)) {
+        if (admits.has(ancestor)) return true;
+      }
+      return false;
+    });
+    if (!admitted) {
+      violations.push({
+        path: asset.path,
+        ontologyUid,
+        ontologyLabel: ontologyLabelByUid.get(ontologyUid) ?? ontologyUid,
+        classUids,
+        admits: admitsRawByOntologyUid.get(ontologyUid) ?? [...admits],
+      });
+    }
+  }
+
+  return {
+    vaultPath,
+    totalFiles: assets.length,
+    ontologies: ontologyByPath.size,
+    ontologiesWithAdmits: admitsByOntologyUid.size,
+    checked,
+    violations,
+    skips,
+    skipExamples,
+  };
+}
+
+export interface AuditOntologyMembershipOptions {
+  vault: string;
+  output?: OutputFormat;
+}
+
+/**
+ * KSD ArchUnit Phase 2 (req c23f6f50, project 531dd440, RFC 2a41ef6e v3 F5–F10)
+ * — cohesion-side ontology-membership audit (source of truth, CI). The
+ * coupling-side (`audit ontology-imports`) checks cross-ontology links; this
+ * checks that every member of an ontology is a class its `exo__Ontology_admits`
+ * allow-list permits (subsumption-aware).
+ *
+ * `exocortex audit ontology-membership --vault <path>` walks the vault and
+ * reports any asset whose `exo__Instance_class` is not admitted (directly or via
+ * superClass subsumption) by its `isDefinedBy` ontology's `_admits` allow-list.
+ * Exit 0 = 0 violations (fail-open skips are still reported); exit 1 = ≥1
+ * violation. Ontologies without a declared `_admits`, and unclassifiable assets,
+ * are skipped — never affect the exit code (audit-first, fail-open by design).
+ */
+export function auditOntologyMembershipCommand(): Command {
+  return new Command("ontology-membership")
+    .description(
+      "Detect ontology-membership violations: any asset whose exo__Instance_class (or a superClass ancestor) is not in its isDefinedBy ontology's exo__Ontology_admits allow-list (subsumption-aware superClass walk, dual-IRI-safe, fail-open when no allow-list is declared, skip-accounted)",
+    )
+    .requiredOption("--vault <path>", "Vault root directory")
+    .option("--output <type>", "Response format: text|json", "text")
+    .action(async (options: AuditOntologyMembershipOptions) => {
+      const outputFormat = (options.output ?? "text") as OutputFormat;
+      ErrorHandler.setFormat(outputFormat);
+
+      try {
+        const vaultPath = resolve(options.vault);
+        if (!existsSync(vaultPath) || !statSync(vaultPath).isDirectory()) {
+          throw new VaultNotFoundError(vaultPath);
+        }
+
+        const result = await scanVaultForOntologyMembership(vaultPath);
+        const skipTotal = Object.values(result.skips).reduce((a, b) => a + b, 0);
+
+        if (outputFormat === "json") {
+          console.log(
+            JSON.stringify(
+              {
+                vaultPath: result.vaultPath,
+                totalFiles: result.totalFiles,
+                ontologies: result.ontologies,
+                ontologiesWithAdmits: result.ontologiesWithAdmits,
+                checked: result.checked,
+                violationCount: result.violations.length,
+                violations: result.violations,
+                skips: result.skips,
+                skipTotal,
+                skipExamples: result.skipExamples,
+                clean: result.violations.length === 0,
+              },
+              null,
+              2,
+            ),
+          );
+        } else {
+          if (result.violations.length === 0) {
+            console.log(
+              `OK ${vaultPath}: 0 ontology-membership violations ` +
+                `(${result.checked} checked; ${result.ontologiesWithAdmits}/${result.ontologies} ontologies declare exo__Ontology_admits)`,
+            );
+          } else {
+            console.error(
+              `FAIL ${vaultPath}: ${result.violations.length} ontology-membership violation(s) ` +
+                `(${result.checked} checked; ${result.ontologiesWithAdmits}/${result.ontologies} ontologies declare exo__Ontology_admits):`,
+            );
+            for (const v of result.violations) {
+              console.error(
+                `  ${v.path}\n      isDefinedBy=${v.ontologyUid} (${v.ontologyLabel})` +
+                  ` instance_class=[${v.classUids.join(", ")}] not in admits=[${v.admits.join(", ")}]`,
+              );
+            }
+          }
+          // Skip-accounting is always printed — "0 violations" ≠ "everything checked".
+          console.error(
+            `\nSkipped (fail-open, NOT verified): ${skipTotal} — ` +
+              `no-isDefinedBy=${result.skips["no-isDefinedBy"]}, ` +
+              `ontology-unresolvable=${result.skips["ontology-unresolvable"]}, ` +
+              `ontology-no-admits=${result.skips["ontology-no-admits"]}, ` +
+              `no-instance-class=${result.skips["no-instance-class"]}, ` +
+              `unresolvable-class=${result.skips["unresolvable-class"]}`,
+          );
+        }
+
+        if (result.violations.length > 0) process.exitCode = 1;
+      } catch (error) {
+        ErrorHandler.handle(error as Error);
+      }
+    });
+}

--- a/packages/cli/src/commands/audit.ts
+++ b/packages/cli/src/commands/audit.ts
@@ -1,17 +1,20 @@
 import { Command } from "commander";
 import { auditCoLocationCommand } from "./audit-co-location.js";
 import { auditOntologyImportsCommand } from "./audit-ontology-imports.js";
+import { auditOntologyMembershipCommand } from "./audit-ontology-membership.js";
 import { auditOntologyUrlCommand } from "./audit-ontology-url.js";
 
 /**
  * Creates the 'audit' parent command with regression-detection subcommands:
  * - audit co-location — RFC 0b7a2fad asset–ontology co-location invariant.
- * - audit ontology-imports — RFC df39007b ontology imports DAG invariant.
+ * - audit ontology-imports — RFC df39007b ontology imports DAG invariant (coupling-side ArchUnit).
+ * - audit ontology-membership — KSD ArchUnit (req c23f6f50) ontology exo__Ontology_admits allow-list (cohesion-side).
  * - audit ontology-url — issue #3824 exo__Ontology_url trailing-# separator invariant.
  *
  * @example
  * exocortex audit co-location --vault /path/to/vault
  * exocortex audit ontology-imports --vault /path/to/vault
+ * exocortex audit ontology-membership --vault /path/to/vault
  * exocortex audit ontology-url --vault /path/to/vault
  */
 export function auditCommand(): Command {
@@ -21,6 +24,7 @@ export function auditCommand(): Command {
 
   cmd.addCommand(auditCoLocationCommand());
   cmd.addCommand(auditOntologyImportsCommand());
+  cmd.addCommand(auditOntologyMembershipCommand());
   cmd.addCommand(auditOntologyUrlCommand());
 
   return cmd;

--- a/packages/cli/tests/unit/commands/audit-ontology-imports.test.ts
+++ b/packages/cli/tests/unit/commands/audit-ontology-imports.test.ts
@@ -640,6 +640,20 @@ describe("audit ontology-imports — structural-only predicate exclusion (VL#30)
     expect(r.excludedPredicates).toBeUndefined();
   });
 
+  it("ASSOCIATIVE_PREDICATES tracks the post-rename concept predicate names (F5 — no stale ims__Concept_*)", () => {
+    // After the ims__Concept_* → concept__Concept_* rename (KSD Phase 1), the
+    // curated set must exclude the LIVE associative predicate keys; a stale
+    // ims__ key matches 0 frontmatter → --structural-only would silently fail to
+    // exclude the associative Zettelkasten layer it is designed to isolate.
+    expect(ASSOCIATIVE_PREDICATES).toContain("concept__Concept_related");
+    expect(ASSOCIATIVE_PREDICATES).toContain("concept__Concept_broader");
+    expect(ASSOCIATIVE_PREDICATES).toContain("concept__Concept_synonym");
+    expect(ASSOCIATIVE_PREDICATES.some((p) => p.startsWith("ims__"))).toBe(false);
+    // definitional/structural predicates must NOT be excluded.
+    expect(ASSOCIATIVE_PREDICATES).not.toContain("concept__Concept_genus");
+    expect(ASSOCIATIVE_PREDICATES).not.toContain("concept__Concept_differentia");
+  });
+
   it("drops the associative relates edge under --structural-only, keeps the structural body edge", async () => {
     buildAssociativeViolationVault();
     const r = await scanVaultForOntologyImports(vault, {

--- a/packages/cli/tests/unit/commands/audit-ontology-membership.test.ts
+++ b/packages/cli/tests/unit/commands/audit-ontology-membership.test.ts
@@ -1,0 +1,228 @@
+import { describe, it, expect, beforeEach, afterEach } from "@jest/globals";
+import { mkdirSync, rmSync, writeFileSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import {
+  scanVaultForOntologyMembership,
+  auditOntologyMembershipCommand,
+  ONTOLOGY_CLASS_UID,
+} from "../../../src/commands/audit-ontology-membership.js";
+import { auditCommand } from "../../../src/commands/audit.js";
+
+// ---- real class UIDs (verified on origin/main, vault-my) ----
+const CONCEPT = "dda12c48-6886-4624-8710-ed4ba92ce2b3"; // concept__Concept
+const PROPERTY = "38277bfa-d7f9-4a75-b856-b23276ab0db3"; // exo__Property
+const OBJECT_PROPERTY = "9a1cf31c-9d41-4ef3-9023-584a8d087d16"; // exo__ObjectProperty ⊑ exo__Property
+const EXO_CLASS = "8619c4fc-64f1-4869-b17e-e34186cacca9"; // exo__Class metaclass
+const EMS_TASK = "1b20a8f0-d745-4e93-91db-4531b3df120e"; // ems__Task (a non-concept class)
+
+// ---- synthetic fixture UIDs ----
+const O1 = "11111111-1111-4111-8111-111111111111"; // concept ontology, admits [concept, ontology]
+const O2 = "22222222-2222-4222-8222-222222222222"; // metaclass ontology, admits [property, ontology]
+const O3 = "33333333-3333-4333-8333-333333333333"; // ontology with NO admits (fail-open)
+const C1 = "aaaa0001-0000-4000-8000-000000000001"; // concept member of O1 (direct match)
+const V1 = "aaaa0002-0000-4000-8000-000000000002"; // ems__Task member of O1 (VIOLATION)
+const M2 = "aaaa0003-0000-4000-8000-000000000003"; // ObjectProperty member of O2 (subsumption)
+const M3 = "aaaa0004-0000-4000-8000-000000000004"; // ems__Task member of O3 (fail-open skip)
+
+interface AssetSpec {
+  uid: string;
+  label?: string;
+  isDefinedBy?: string; // raw string, e.g. `[[<uid>]]` or `[[!exo]]`
+  instanceClass?: string[]; // class UIDs
+  admits?: string[]; // exo__Ontology_admits class UIDs
+  superClass?: string[]; // exo__Class_superClass class UIDs
+}
+
+function writeAsset(dir: string, spec: AssetSpec): void {
+  mkdirSync(dir, { recursive: true });
+  const lines = [
+    "---",
+    `exo__Asset_uid: ${spec.uid}`,
+    `exo__Asset_label: "${spec.label ?? `Asset ${spec.uid}`}"`,
+  ];
+  if (spec.instanceClass) {
+    lines.push("exo__Instance_class:");
+    for (const c of spec.instanceClass) lines.push(`  - "[[${c}]]"`);
+  }
+  if (spec.isDefinedBy !== undefined) {
+    lines.push(`exo__Asset_isDefinedBy: "${spec.isDefinedBy}"`);
+  }
+  if (spec.admits) {
+    lines.push("exo__Ontology_admits:");
+    for (const a of spec.admits) lines.push(`  - "[[${a}]]"`);
+  }
+  if (spec.superClass) {
+    lines.push("exo__Class_superClass:");
+    for (const s of spec.superClass) lines.push(`  - "[[${s}]]"`);
+  }
+  lines.push("---", "", "Body.", "");
+  writeFileSync(join(dir, `${spec.uid}.md`), lines.join("\n"), "utf-8");
+}
+
+/**
+ * Build a fixture vault exercising every axis of the membership ratchet:
+ *   O1 admits [concept__Concept, exo__Ontology] — a concept member (C1) is
+ *      admitted directly, the self-anchor is admitted (F10), an ems__Task
+ *      member (V1) is the ONLY violation.
+ *   O2 admits [exo__Property, exo__Ontology] — an exo__ObjectProperty member
+ *      (M2) is admitted via the superClass walk (F9 metaclass-mixing).
+ *   O3 declares NO admits — its ems__Task member (M3) and its own anchor are
+ *      SKIPPED (fail-open, audit-first).
+ */
+function buildFixture(dir: string): void {
+  // O1 — concept ontology (self-anchored). F10: admits exo__Ontology so the
+  // anchor is a legitimate self-member.
+  writeAsset(dir, {
+    uid: O1,
+    label: "O1 (concepts)",
+    instanceClass: [ONTOLOGY_CLASS_UID],
+    isDefinedBy: `[[${O1}]]`,
+    admits: [CONCEPT, ONTOLOGY_CLASS_UID],
+  });
+  writeAsset(dir, {
+    uid: C1,
+    label: "A concept",
+    instanceClass: [CONCEPT],
+    isDefinedBy: `[[${O1}]]`,
+  });
+  writeAsset(dir, {
+    uid: V1,
+    label: "A misfiled task (violation)",
+    instanceClass: [EMS_TASK],
+    isDefinedBy: `[[${O1}]]`,
+  });
+
+  // O2 — metaclass ontology; admits exo__Property (subclasses admitted via walk).
+  writeAsset(dir, {
+    uid: O2,
+    label: "O2 (property TBox)",
+    instanceClass: [ONTOLOGY_CLASS_UID],
+    isDefinedBy: `[[${O2}]]`,
+    admits: [PROPERTY, ONTOLOGY_CLASS_UID],
+  });
+  writeAsset(dir, {
+    uid: M2,
+    label: "An object property",
+    instanceClass: [OBJECT_PROPERTY],
+    isDefinedBy: `[[${O2}]]`,
+  });
+  // The exo__ObjectProperty class-def — needed so the superClass walk can reach
+  // exo__Property. Not a member of any admits-ontology (bang-anchored → skipped).
+  writeAsset(dir, {
+    uid: OBJECT_PROPERTY,
+    label: "exo__ObjectProperty",
+    instanceClass: [EXO_CLASS],
+    isDefinedBy: "[[!exo]]",
+    superClass: [PROPERTY],
+  });
+
+  // O3 — declares NO admits (audit-first / fail-open).
+  writeAsset(dir, {
+    uid: O3,
+    label: "O3 (no allow-list)",
+    instanceClass: [ONTOLOGY_CLASS_UID],
+    isDefinedBy: `[[${O3}]]`,
+  });
+  writeAsset(dir, {
+    uid: M3,
+    label: "A task under an un-gated ontology",
+    instanceClass: [EMS_TASK],
+    isDefinedBy: `[[${O3}]]`,
+  });
+}
+
+describe("audit ontology-membership — @req:c23f6f50-0867-4fa9-90c7-f768199e7fa9 (KSD ArchUnit cohesion ratchet)", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = join(
+      tmpdir(),
+      `audit-membership-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    );
+    mkdirSync(dir, { recursive: true });
+    buildFixture(dir);
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("flags exactly the misfiled member (ems__Task under a concept ontology) and nothing else", async () => {
+    const r = await scanVaultForOntologyMembership(dir);
+
+    expect(r.ontologies).toBe(3);
+    expect(r.ontologiesWithAdmits).toBe(2); // O1, O2 (O3 has none)
+    expect(r.violations).toHaveLength(1);
+
+    const v = r.violations[0];
+    expect(v.path).toBe(`${V1}.md`);
+    expect(v.ontologyUid).toBe(O1);
+    expect(v.classUids).toContain(EMS_TASK);
+    expect(v.admits).toEqual(expect.arrayContaining([CONCEPT, ONTOLOGY_CLASS_UID]));
+
+    // none of the LEGITIMATE members/anchors are flagged
+    const flagged = r.violations.map((x) => x.path);
+    expect(flagged).not.toContain(`${C1}.md`); // direct concept match
+    expect(flagged).not.toContain(`${O1}.md`); // F10 self-anchor
+    expect(flagged).not.toContain(`${M2}.md`); // F9 subsumption
+    expect(flagged).not.toContain(`${O2}.md`); // F10 self-anchor
+    expect(flagged).not.toContain(`${M3}.md`); // fail-open (no admits)
+  });
+
+  it("admits a subclass via the superClass walk (F9 — admits exo__Property covers exo__ObjectProperty)", async () => {
+    const r = await scanVaultForOntologyMembership(dir);
+    // M2 (exo__ObjectProperty) under O2 (admits exo__Property) must NOT violate:
+    // subsumption resolves exo__ObjectProperty ⊑ exo__Property in TS (dual-IRI:
+    // pure SPARQL cannot walk it). This is the only member of O2 besides its
+    // self-anchor, so O2 contributes 0 violations.
+    expect(r.violations.some((v) => v.ontologyUid === O2)).toBe(false);
+    expect(r.checked).toBeGreaterThanOrEqual(2); // M2 + O2 anchor were checked
+  });
+
+  it("skips every member of an ontology that declares no admits (fail-open, audit-first)", async () => {
+    const r = await scanVaultForOntologyMembership(dir);
+    // O3 has no exo__Ontology_admits → M3 (ems__Task) and the O3 anchor are
+    // skipped, never violations (the ratchet only bites opted-in ontologies).
+    expect(r.violations.some((v) => v.path === `${M3}.md`)).toBe(false);
+    // M3 + O3 anchor → at least 2 no-admits skips
+    expect(r.skips["ontology-no-admits"]).toBeGreaterThanOrEqual(2);
+  });
+
+  it("admits the ontology's own self-anchor when the allow-list includes exo__Ontology (F10)", async () => {
+    const r = await scanVaultForOntologyMembership(dir);
+    // O1 admits exo__Ontology, so its own anchor (an exo__Ontology instance
+    // co-located under itself) is a legitimate self-member, not a false positive.
+    expect(r.violations.some((v) => v.path === `${O1}.md`)).toBe(false);
+    expect(r.violations.some((v) => v.path === `${O2}.md`)).toBe(false);
+  });
+
+  it("audit ontology-membership sets exit code 1 on a violation, 0 when clean", async () => {
+    // violating fixture → exit 1
+    const prev = process.exitCode;
+    process.exitCode = 0;
+    try {
+      const cmd = auditCommand();
+      await cmd.parseAsync(
+        ["ontology-membership", "--vault", dir, "--output", "json"],
+        { from: "user" },
+      );
+      expect(process.exitCode).toBe(1);
+    } finally {
+      process.exitCode = prev;
+    }
+
+    // remove the only violation → clean → exit 0
+    rmSync(join(dir, `${V1}.md`), { force: true });
+    process.exitCode = 0;
+    try {
+      const cmd2 = auditOntologyMembershipCommand();
+      await cmd2.parseAsync(["--vault", dir, "--output", "json"], {
+        from: "user",
+      });
+      expect(process.exitCode).toBe(0);
+    } finally {
+      process.exitCode = prev;
+    }
+  });
+});


### PR DESCRIPTION
## What

Adds `exocortex audit ontology-membership` — the **cohesion-side** fitness-function of the KSD ArchUnit pair (KSD project 531dd440, Phase 2 node bfa896a5, RFC 2a41ef6e v3 §Разрешения F5–F10). The coupling-side (`audit ontology-imports`) already existed; this is the missing half that **locks the Phase-1 concept redistribution** (~2340 concepts re-homed) against regression.

An asset co-located under an ontology that declares `exo__Ontology_admits` must carry an `exo__Instance_class` admitted by that allow-list — directly, or via a `exo__Class_superClass` subsumption walk.

## Requirement

`Req: c23f6f50-0867-4fa9-90c7-f768199e7fa9` (Approved) — https://github.com/kitelev/exoas-exo-reqs/blob/main/exo-reqs/c23f6f50-0867-4fa9-90c7-f768199e7fa9.md

Bound test: `@req:c23f6f50-0867-4fa9-90c7-f768199e7fa9` in `packages/cli/tests/unit/commands/audit-ontology-membership.test.ts`.

## Design (review-panel resolutions F5–F10)

- **F8** — subsumption is a **TS-side superClass BFS** (fs-side, cycle-safe), NOT pure SPARQL: the store emits a symbolic `exo__Instance_class` IRI with 0 superClass edges (dual-IRI gap), so class-hierarchy subsumption is unqueryable in SPARQL.
- **dual-IRI-safe** — every class ref (admits value / Instance_class / superClass) unifies to a canonical class UID: a UID-form ref is its own UID; a label/symbolic-form ref (`[[concept__Concept]]`) resolves via a first-wins `label → uid` index (class-def files are UID-named, so a label wikilink can't resolve by basename).
- **F9** — subsumption exists for TBox metaclass-mixing: `admits exo__Property` covers `exo__ObjectProperty`/`exo__DatatypeProperty` (both verified `superClass → exo__Property` on origin/main). Concept *domains* need no subsumption (a domain is a sub-ontology via isDefinedBy, not a subclass of `concept__Concept`).
- **F10** — an ontology's allow-list includes `exo__Ontology` so its own self-anchor is a legitimate member, not a false positive.
- **F7 / fail-open** — an ontology with NO `exo__Ontology_admits` has all its members **skipped** (audit-first — the ratchet only bites opted-in ontologies); assets with no Instance_class / unresolvable class-refs are skip-accounted by reason, never violations. Exit 1 on ≥1 violation, exit 0 clean. Mirrors `audit co-location` / `audit ontology-imports` / `audit ontology-url`.

## F5 prerequisite (exempt data-correctness, rides here)

`ASSOCIATIVE_PREDICATES` in `audit-ontology-imports.ts` still listed the pre-rename `ims__Concept_related/broader/synonym` (empirically **0 live** after the ims__→concept__ rename); updated to the live `concept__Concept_related/broader/synonym`. `genus`/`differentia` stay OUT (definitional/structural). `--structural-only` is opt-in and not used by exoas-ci → dormant-in-CI, a correctness cleanup.

## Revert-verified (RED→GREEN, type-preserving Edit-break, per axis)

- **(1) detection** — neutralize the admits check → the misfiled-member violation stops being reported (RED); restore → GREEN.
- **(2) subsumption (F9)** — break the superClass walk → the subsumed `exo__ObjectProperty` member becomes a false violation (RED); restore → GREEN.
- **(3) fail-open (F7)** — fall through the no-admits skip → the un-gated member becomes a false violation (RED); restore → GREEN.

Each axis reds exactly its own assertions; the must-stay-clean fixtures (direct concept match, self-anchor, subsumed member) prove non-vacuity.

## Dogfood (real vaults, local built CLI)

`audit ontology-membership --vault vault-my` → **0 violations, 1246 checked, 11/115 ontologies declare `exo__Ontology_admits`** (the Phase-1-cleaned concept ontologies). SHACL floor unchanged (7, no-regress). The `exo__Ontology_admits` TBox property + the 11 `_admits` allow-lists are shipped as vault-data (exoas-exo / exoas-my / exoas-shared-private). The exoas-ci per-AssetSpace gate is a follow-up PR to `kitelev/exoas-ci` (after this release, so `latest` carries the command).

## Tests

- New `audit-ontology-membership.test.ts` (5 tests, all axes) — production-shape over the real `scanVaultForOntologyMembership` + `findReferencedFile` resolver.
- F5 regression guard added to `audit-ontology-imports.test.ts` (no stale `ims__`).
- All 4 audit suites green (60 tests); check-test-antipatterns ratchet 55/55; tsc clean.

CLI-only (no `packages/core` change) — not the parser/engine auto-merge-discipline path.