### PR TITLE
feat(sync): ExoSync honors GitHub Retry-After in rate-limit backoff (RFC 6a1a6518 / A)

### DIFF
--- a/packages/cli/src/services/RestPushService.ts
+++ b/packages/cli/src/services/RestPushService.ts
@@ -18,8 +18,10 @@
 import { execFileSync } from "node:child_process";
 import {
   restCreateCommit,
+  enrichRateLimitError,
   type RestCommitTransport,
   type RestCommitResponse,
+  type HeaderGetter,
 } from "@kitelev/exocortex-core";
 
 export interface RestPushServiceOptions {
@@ -163,13 +165,21 @@ export class RestPushService {
       }
       const text = await resp.text().catch(() => "");
       if (resp.status < 200 || resp.status >= 300) {
-        throw new Error(
-          truncate(
-            redact(
-              `GitHub request ${req.method} ${req.url} → HTTP ${resp.status}: ${text}`,
+        // RFC 6a1a6518 A: attach Retry-After / x-ratelimit-* (own-props,
+        // .message preserved) so the backoff can honor the exact wait. `fetch`
+        // `Headers.get()` is already case-insensitive; tolerate a headerless
+        // response (some test fakes omit it).
+        const get: HeaderGetter = (name) => resp.headers?.get?.(name) ?? undefined;
+        throw enrichRateLimitError(
+          new Error(
+            truncate(
+              redact(
+                `GitHub request ${req.method} ${req.url} → HTTP ${resp.status}: ${text}`,
+              ),
+              512,
             ),
-            512,
           ),
+          get,
         );
       }
       let json: unknown;

--- a/packages/cli/tests/unit/services/RestPushService.test.ts
+++ b/packages/cli/tests/unit/services/RestPushService.test.ts
@@ -24,6 +24,16 @@ function res(status: number, body: unknown): Response {
   } as unknown as Response;
 }
 
+/** Response with rate-limit headers (fetch `Headers` is case-insensitive). */
+function resH(status: number, body: string, headers: Record<string, string>): Response {
+  return {
+    status,
+    ok: status >= 200 && status < 300,
+    text: () => Promise.resolve(body),
+    headers: new Headers(headers),
+  } as unknown as Response;
+}
+
 function happyFetch(): jest.Mock {
   return jest
     .fn()
@@ -120,6 +130,46 @@ describe("RestPushService", () => {
       expect(svc.redact({ toString: () => `x ${FAKE_PAT} y` })).toContain(
         "***REDACTED***",
       );
+    });
+  });
+
+  // RFC 6a1a6518 A — the transport attaches rate-limit headers to the thrown
+  // error (own-props), preserving .message so isRateLimitError/isAuthError/
+  // isNonFastForwardError still classify it. @req:0fd4c819-0a48-43e5-9e4b-2a1cc3eef1c2
+  describe("rate-limit header enrichment (Retry-After)", () => {
+    async function capture(response: Response): Promise<Error> {
+      const svc = new RestPushService({
+        token: FAKE_PAT,
+        fetchImpl: jest.fn().mockResolvedValueOnce(response) as unknown as typeof fetch,
+      });
+      try {
+        await svc.transport()({ method: "GET", url: "https://api.github.com/x" });
+      } catch (e) {
+        return e as Error;
+      }
+      throw new Error("expected the transport to throw");
+    }
+
+    it("attaches retryAfterMs / rateLimitReset while preserving .message byte-for-byte", async () => {
+      const err = (await capture(
+        resH(403, "You have exceeded a secondary rate limit", {
+          "Retry-After": "120",
+          "X-RateLimit-Reset": "1700000000",
+          "X-RateLimit-Remaining": "0",
+        }),
+      )) as Error & { retryAfterMs?: number; rateLimitReset?: number };
+      expect(err.retryAfterMs).toBe(120_000);
+      expect(err.rateLimitReset).toBe(1700000000);
+      // .message is the unchanged production shape the parsers key off.
+      expect(err.message).toMatch(/HTTP 403: You have exceeded a secondary rate limit/);
+    });
+
+    it("attaches nothing (and does not throw) when there are no rate-limit headers", async () => {
+      const err = (await capture(resH(404, "Not Found", {})) as Error & {
+        retryAfterMs?: number;
+      });
+      expect(err.retryAfterMs).toBeUndefined();
+      expect(err.message).toMatch(/HTTP 404/);
     });
   });
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -759,8 +759,25 @@ export {
 export {
   isRateLimitError,
   withRateLimitBackoff,
+  createRateLimitBudget,
+  MIN_RATE_LIMIT_WAIT_MS,
+  DEFAULT_MAX_RETRIES,
   type BackoffOptions,
+  type RateLimitBudget,
 } from "./services/sync/transportBackoff";
+// RFC 6a1a6518 A — GitHub rate-limit header extraction + error enrichment
+// (both transports attach Retry-After / x-ratelimit-* to the thrown error,
+// preserving .message; the backoff honors the exact wait).
+export {
+  caseInsensitiveHeaderGetter,
+  parseRetryAfterMs,
+  extractRateLimitFields,
+  getRateLimitFields,
+  attachRateLimitFields,
+  enrichRateLimitError,
+  type RateLimitErrorFields,
+  type HeaderGetter,
+} from "./infrastructure/github/rateLimitHeaders";
 export {
   redactSecrets,
   scanForSecrets,

--- a/packages/core/src/infrastructure/github/rateLimitHeaders.ts
+++ b/packages/core/src/infrastructure/github/rateLimitHeaders.ts
@@ -1,0 +1,155 @@
+/**
+ * GitHub rate-limit header extraction + error enrichment (ExoSync A, RFC
+ * 6a1a6518 Phase 1).
+ *
+ * The transport-agnostic `restCreateCommit` core only ever observes SUCCESS
+ * responses — both transports (CLI `fetch`, plugin Obsidian `requestUrl`)
+ * throw on a non-2xx status and discard the Response, so the `Retry-After` /
+ * `x-ratelimit-*` headers GitHub sends on a rate-limited response are lost by
+ * the time `withRateLimitBackoff` catches the error. This helper lets BOTH
+ * transports read those headers just before they throw and ATTACH the parsed
+ * values as own-properties on the thrown Error — the backoff then honors the
+ * exact `Retry-After` instead of blindly guessing an exponential.
+ *
+ * ⛔ CRITICAL — attach, never replace. Three parsers key off `Error.message`
+ * (`isRateLimitError`, `isAuthError`, `isNonFastForwardError`); enrichment
+ * MUST leave `.message` byte-for-byte identical so they classify the enriched
+ * error exactly as they would the bare one. The attached fields are therefore
+ * NON-ENUMERABLE own-properties — invisible to `JSON.stringify` / `Object.keys`
+ * / telemetry walkers (matching the codebase's `#private`-field discipline),
+ * readable only by explicit property access (the backoff decorator).
+ *
+ * Header casing: desktop `fetch` exposes a `Headers` object whose `.get()` is
+ * case-insensitive; Obsidian `requestUrl().headers` is a plain
+ * `Record<string, string>` whose casing varies by platform (desktop vs iOS).
+ * {@link caseInsensitiveHeaderGetter} normalizes the plain-record path so both
+ * `Retry-After` and `retry-after` resolve on the plugin transport (iOS parity).
+ */
+
+/**
+ * Own-properties attached to a rate-limited transport Error (ExoSync A).
+ * All optional — absent when GitHub did not send the corresponding header.
+ */
+export interface RateLimitErrorFields {
+  /** Milliseconds to wait, parsed from the `Retry-After` header. */
+  retryAfterMs?: number;
+  /** `x-ratelimit-reset` — Unix epoch SECONDS the primary bucket refills. */
+  rateLimitReset?: number;
+  /** `x-ratelimit-remaining` — primary-bucket requests remaining. */
+  rateLimitRemaining?: number;
+}
+
+/** Case-insensitive-capable header accessor (`fetch` `Headers.get` already is). */
+export type HeaderGetter = (name: string) => string | null | undefined;
+
+/**
+ * Build a case-insensitive getter over an arbitrary-casing header record
+ * (Obsidian `requestUrl().headers`). Tolerates an absent/undefined record.
+ */
+export function caseInsensitiveHeaderGetter(
+  headers: Record<string, string> | undefined | null,
+): HeaderGetter {
+  const lower = new Map<string, string>();
+  if (headers && typeof headers === "object") {
+    for (const [k, v] of Object.entries(headers)) {
+      if (typeof v === "string") lower.set(k.toLowerCase(), v);
+    }
+  }
+  return (name: string): string | undefined => lower.get(name.toLowerCase());
+}
+
+/** Parse a strict base-10 integer header value; `undefined` when unparseable. */
+function parseIntHeader(v: string | null | undefined): number | undefined {
+  if (v === null || v === undefined) return undefined;
+  const t = v.trim();
+  if (!/^-?\d+$/.test(t)) return undefined;
+  const n = Number(t);
+  return Number.isFinite(n) ? n : undefined;
+}
+
+/**
+ * Parse `Retry-After` → milliseconds. Per the HTTP spec the value is either
+ * delta-seconds (GitHub's form for rate limits) OR an HTTP-date; both are
+ * handled. Returns `undefined` when absent/unparseable. Never negative.
+ */
+export function parseRetryAfterMs(
+  v: string | null | undefined,
+  now: () => number = Date.now,
+): number | undefined {
+  if (v === null || v === undefined) return undefined;
+  const t = v.trim();
+  if (t.length === 0) return undefined;
+  const secs = parseIntHeader(t);
+  if (secs !== undefined) return Math.max(0, secs * 1000);
+  const dateMs = Date.parse(t);
+  if (!Number.isNaN(dateMs)) return Math.max(0, dateMs - now());
+  return undefined;
+}
+
+/** Extract the rate-limit fields from a header getter. */
+export function extractRateLimitFields(
+  get: HeaderGetter,
+  now: () => number = Date.now,
+): RateLimitErrorFields {
+  const fields: RateLimitErrorFields = {};
+  const retryAfterMs = parseRetryAfterMs(get("retry-after"), now);
+  if (retryAfterMs !== undefined) fields.retryAfterMs = retryAfterMs;
+  const reset = parseIntHeader(get("x-ratelimit-reset"));
+  if (reset !== undefined) fields.rateLimitReset = reset;
+  const remaining = parseIntHeader(get("x-ratelimit-remaining"));
+  if (remaining !== undefined) fields.rateLimitRemaining = remaining;
+  return fields;
+}
+
+/** Read the attached rate-limit fields off an already-enriched error. */
+export function getRateLimitFields(err: unknown): RateLimitErrorFields {
+  if (err === null || typeof err !== "object") return {};
+  const e = err as RateLimitErrorFields;
+  const fields: RateLimitErrorFields = {};
+  if (typeof e.retryAfterMs === "number") fields.retryAfterMs = e.retryAfterMs;
+  if (typeof e.rateLimitReset === "number")
+    fields.rateLimitReset = e.rateLimitReset;
+  if (typeof e.rateLimitRemaining === "number")
+    fields.rateLimitRemaining = e.rateLimitRemaining;
+  return fields;
+}
+
+function defineHidden(target: object, key: string, value: number): void {
+  Object.defineProperty(target, key, {
+    value,
+    enumerable: false, // invisible to JSON.stringify / Object.keys / telemetry
+    writable: true,
+    configurable: true,
+  });
+}
+
+/**
+ * ATTACH the rate-limit fields as NON-ENUMERABLE own-properties, preserving
+ * `Error.message` byte-for-byte. Returns the same Error instance. No-op for a
+ * non-object err.
+ */
+export function attachRateLimitFields(
+  err: Error,
+  fields: RateLimitErrorFields,
+): Error {
+  if (fields.retryAfterMs !== undefined)
+    defineHidden(err, "retryAfterMs", fields.retryAfterMs);
+  if (fields.rateLimitReset !== undefined)
+    defineHidden(err, "rateLimitReset", fields.rateLimitReset);
+  if (fields.rateLimitRemaining !== undefined)
+    defineHidden(err, "rateLimitRemaining", fields.rateLimitRemaining);
+  return err;
+}
+
+/**
+ * One-call transport helper: read the rate-limit headers via `get` and attach
+ * the parsed fields to `err` (preserving `.message`). Called by each transport
+ * immediately before throwing a non-2xx error.
+ */
+export function enrichRateLimitError(
+  err: Error,
+  get: HeaderGetter,
+  now: () => number = Date.now,
+): Error {
+  return attachRateLimitFields(err, extractRateLimitFields(get, now));
+}

--- a/packages/core/src/infrastructure/github/restCommit.ts
+++ b/packages/core/src/infrastructure/github/restCommit.ts
@@ -25,6 +25,14 @@
  *     `redact` param below is a defence-in-depth pass over this core's own
  *     structural error strings (which never embed a PAT, but are redacted
  *     anyway for parity with the plugin original).
+ *   - Rate-limit signalling (RFC 6a1a6518 A): the response `headers` are NOT
+ *     part of {@link RestCommitResponse} (this core reads only `json`). On a
+ *     non-2xx rate-limited response the transport reads the response headers
+ *     and ATTACHES `Retry-After` / `x-ratelimit-*` to the thrown Error as
+ *     own-properties (preserving `.message`) via
+ *     `rateLimitHeaders.enrichRateLimitError`, so `withRateLimitBackoff` can
+ *     honor the exact wait. This core never sees those errors (it only ever
+ *     observes successful responses).
  *
  * Partial-failure contract (unchanged from the plugin original): if steps 1-3
  * succeed but step 4 (PATCH ref) fails (network glitch, 422 non-fast-forward,

--- a/packages/core/src/services/sync/SyncEngine.ts
+++ b/packages/core/src/services/sync/SyncEngine.ts
@@ -81,7 +81,12 @@ import {
 } from "./LocalOutboxStore";
 import { isAuthError } from "./CredentialStore";
 import { scanForSecrets } from "./secretScan";
-import { withRateLimitBackoff, type BackoffOptions } from "./transportBackoff";
+import {
+  withRateLimitBackoff,
+  createRateLimitBudget,
+  type BackoffOptions,
+  type RateLimitBudget,
+} from "./transportBackoff";
 import {
   DEFAULT_MAX_FILE_BYTES,
   contentEquals,
@@ -110,6 +115,17 @@ import {
 
 /** D16: retries after the first non-fast-forward failure. */
 export const DEFAULT_MAX_PUSH_RETRIES = 3;
+
+/**
+ * RFC 6a1a6518 A — default GLOBAL per-sync rate-limit wait budget (ms). Bounds
+ * the TOTAL time one top-level `syncAll`/`sync` may sleep on rate-limit backoff
+ * across ALL repos + requests. Sequential single-flight means without this cap
+ * one locked repo could stall the whole 18-repo run for tens of minutes; when
+ * it is spent the backoff warn-defers (rethrows) instead of sleeping again.
+ * ~5 min: enough for a couple of full Retry-After waits, bounded so it can't
+ * run away. Override via `deps.backoff.maxTotalRateLimitWaitMs`.
+ */
+export const DEFAULT_MAX_TOTAL_RATELIMIT_WAIT_MS = 300_000;
 
 /**
  * Zero-loss safety valve for the mtime-manifest (perf, ExoSync Phase 1).
@@ -690,12 +706,26 @@ export class SyncEngine {
   } | null = null;
   /** D11 — one sync/apply operation at a time. */
   private opInProgress = false;
+  /**
+   * RFC 6a1a6518 A — the GLOBAL per-sync rate-limit wait budget. Shared by the
+   * per-request backoff decorator; reset at the start of every top-level
+   * `syncAll`/`sync` so one sync's rate-limit waiting can't bleed into the next.
+   */
+  private readonly rateLimitBudget: RateLimitBudget;
 
   constructor(deps: SyncEngineDeps) {
     this.deps = deps;
     this.now = deps.now ?? ((): number => Date.now());
+    this.rateLimitBudget = createRateLimitBudget(
+      deps.backoff?.maxTotalRateLimitWaitMs ??
+        DEFAULT_MAX_TOTAL_RATELIMIT_WAIT_MS,
+    );
     this.transport = this.instrumentTransport(
-      withRateLimitBackoff(deps.transport, deps.backoff),
+      withRateLimitBackoff(deps.transport, {
+        ...deps.backoff,
+        budget: this.rateLimitBudget,
+        now: this.now,
+      }),
     );
     this.sha1 = this.instrumentSha1(deps.sha1);
   }
@@ -900,6 +930,8 @@ export class SyncEngine {
   ): Promise<RepoSyncResult[]> {
     if (this.opInProgress) return specs.map((spec) => this.busyResult(spec));
     this.opInProgress = true;
+    // RFC 6a1a6518 A — fresh rate-limit wait budget per top-level sync.
+    this.rateLimitBudget.reset();
     try {
       const results: RepoSyncResult[] = [];
       for (const spec of specs) {
@@ -919,6 +951,8 @@ export class SyncEngine {
   ): Promise<RepoSyncResult> {
     if (this.opInProgress) return this.busyResult(spec);
     this.opInProgress = true;
+    // RFC 6a1a6518 A — fresh rate-limit wait budget per top-level sync.
+    this.rateLimitBudget.reset();
     try {
       return await this.syncLocked(spec, direction, onProgress);
     } finally {

--- a/packages/core/src/services/sync/transportBackoff.ts
+++ b/packages/core/src/services/sync/transportBackoff.ts
@@ -1,20 +1,33 @@
 /**
- * ExoSync rate-limit backoff (RFC 4e4dc453 A3 engineering baseline, R6).
+ * ExoSync rate-limit backoff (RFC 4e4dc453 A3 baseline R6; RFC 6a1a6518 A —
+ * honor Retry-After).
  *
- * Transport decorator: retries a request that failed on a GitHub
- * rate-limit signal with bounded exponential backoff + jitter. Everything
- * else (404, 401/403 auth, 422 non-fast-forward — the D16 loop's job)
- * is rethrown immediately, so the decorator never masks the engine's own
- * error handling.
+ * Transport decorator: retries a request that failed on a GitHub rate-limit
+ * signal. Everything else (404, 401/403 auth, 422 non-fast-forward — the D16
+ * loop's job) is rethrown immediately, so the decorator never masks the
+ * engine's own error handling.
  *
- * `Retry-After` is unrecoverable through the thrown-Error transport
- * contract (response headers are lost) — jittered exponential is the
- * deliberate fallback. Retrying failed POSTs is safe: a 403/429 response
- * means nothing was created server-side.
+ * Retry-After (RFC 6a1a6518 A): the transports now ATTACH the rate-limit
+ * response headers to the thrown Error as own-properties (`retryAfterMs` /
+ * `rateLimitReset` / `rateLimitRemaining`, see `rateLimitHeaders.ts`),
+ * preserving `.message` byte-for-byte. This decorator reads `retryAfterMs` and
+ * sleeps EXACTLY that; when it is absent it waits at least 60s (the documented
+ * secondary-limit fallback) then exponential; when the primary bucket is
+ * exhausted (`rateLimitRemaining === 0` with a `rateLimitReset`) it waits until
+ * reset. Retrying failed POSTs is safe: a 403/429 response means nothing was
+ * created server-side.
  *
- * Sleep and random are injected for deterministic tests; per-call retry
- * state means failures in one repo's cycle never delay another repo
- * (per-repo backoff semantics).
+ * A GLOBAL per-sync time-budget (see `RateLimitBudget`) bounds the TOTAL wait a
+ * single top-level sync may spend here across ALL repos + requests — `syncAll`
+ * is a strictly-sequential single-flight, so without a shared cap one locked
+ * repo could stall the whole run for `maxRetries × Retry-After`. When the
+ * budget can't cover the next wait, the decorator rethrows the rate-limit error
+ * (warn-not-block, D12) instead of sleeping again; the engine resets the budget
+ * at the start of each sync.
+ *
+ * Sleep, random, and now are injected for deterministic tests; per-call retry
+ * state means failures in one repo's cycle never delay another repo (per-repo
+ * backoff semantics), while the shared budget bounds the run as a whole.
  */
 
 import type {
@@ -22,6 +35,7 @@ import type {
   RestCommitResponse,
   RestCommitTransport,
 } from "../../infrastructure/github/restCommit";
+import { getRateLimitFields } from "../../infrastructure/github/rateLimitHeaders";
 
 /**
  * GitHub rate-limit detection over the transport error-message contract
@@ -40,35 +54,141 @@ export function isRateLimitError(err: unknown): boolean {
   );
 }
 
+/**
+ * Absent-`Retry-After` fallback floor (RFC 6a1a6518 A): GitHub's own secondary
+ * rate-limit guidance is "wait at least one minute before retrying" when there
+ * is no `Retry-After`. Never go below this.
+ */
+export const MIN_RATE_LIMIT_WAIT_MS = 60_000;
+
+/**
+ * Default retry cap AFTER the first rate-limited failure. RFC 6a1a6518 A raises
+ * this from 3 to 6 — a minutes-long secondary window needs several full waits;
+ * the global {@link RateLimitBudget} bounds the aggregate so this cap can be
+ * generous without a single locked repo stalling the whole run.
+ */
+export const DEFAULT_MAX_RETRIES = 6;
+
+/**
+ * Global per-sync rate-limit wait budget (RFC 6a1a6518 A). The engine OWNS one
+ * instance, passes it into the (per-request) backoff decorator, and resets it
+ * at the start of each top-level `syncAll`/`sync`. When a wait can't be
+ * reserved the decorator rethrows → warn-defer (never a hard block).
+ */
+export interface RateLimitBudget {
+  /** Restore the remaining allowance to the full per-sync total. */
+  reset(): void;
+  /**
+   * Reserve `ms` of rate-limit wait. Returns `true` (and consumes it) when the
+   * FULL `ms` fits in the remaining allowance; `false` when it would overrun —
+   * the caller must then stop waiting (warn-defer). A partial reservation is
+   * never granted: sleeping less than `Retry-After` just re-hits the limit.
+   */
+  tryReserve(ms: number): boolean;
+}
+
+/** In-memory {@link RateLimitBudget}. `totalMs <= 0` ⇒ effectively unbounded. */
+export function createRateLimitBudget(totalMs: number): RateLimitBudget {
+  const unbounded = !(totalMs > 0);
+  let remaining = unbounded ? Number.POSITIVE_INFINITY : totalMs;
+  return {
+    reset(): void {
+      remaining = unbounded ? Number.POSITIVE_INFINITY : totalMs;
+    },
+    tryReserve(ms: number): boolean {
+      if (ms <= 0) return true;
+      if (ms <= remaining) {
+        remaining -= ms;
+        return true;
+      }
+      return false;
+    },
+  };
+}
+
 export interface BackoffOptions {
-  /** Retries AFTER the first rate-limited failure. Default 3. */
+  /** Retries AFTER the first rate-limited failure. Default {@link DEFAULT_MAX_RETRIES} (6). */
   maxRetries?: number;
-  /** First delay; doubles each retry. Default 1000 ms. */
+  /** First delay for the absent-header exponential; doubles each retry. Default 1000 ms. */
   baseDelayMs?: number;
+  /** Absent-`Retry-After` floor. Clamped up to {@link MIN_RATE_LIMIT_WAIT_MS} (≥60s). */
+  minRateLimitWaitMs?: number;
+  /**
+   * Global per-sync wait budget instance (RFC 6a1a6518 A). Absent ⇒ unbounded
+   * (historical behaviour). The engine builds this from
+   * {@link maxTotalRateLimitWaitMs} and resets it per sync.
+   */
+  budget?: RateLimitBudget;
+  /**
+   * Per-sync total rate-limit wait cap (ms) the ENGINE reads to construct its
+   * {@link RateLimitBudget}. The decorator itself uses {@link budget}, not this
+   * value. Kept here so all backoff tuning lives in one options object.
+   */
+  maxTotalRateLimitWaitMs?: number;
   /** Injected for tests. Default: real setTimeout. */
   sleep?: (ms: number) => Promise<void>;
   /** Injected for tests. Defaults to Math.random — jitter source. */
   random?: () => number;
+  /** Injected for tests — clock for the `x-ratelimit-reset` branch. Default Date.now. */
+  now?: () => number;
 }
 
 const defaultSleep = (ms: number): Promise<void> =>
   new Promise((resolve) => setTimeout(resolve, ms));
 
 /**
- * Wrap a transport with per-request exponential backoff on rate-limit
- * errors. After `maxRetries` rate-limited attempts the last error is
- * rethrown — the per-repo sync cycle then fails warn-not-block (D12).
+ * Compute how long to wait before the next rate-limit retry, honoring GitHub's
+ * documented secondary-limit guidance:
+ *   1. `Retry-After` present → wait EXACTLY that (no jitter guess).
+ *   2. else primary bucket exhausted (`rateLimitRemaining === 0` + a future
+ *      `rateLimitReset`) → wait until reset.
+ *   3. else → at least `minWaitMs` (≥60s), then exponential-with-jitter.
+ */
+function computeRateLimitDelay(
+  err: unknown,
+  attempt: number,
+  baseDelayMs: number,
+  minWaitMs: number,
+  random: () => number,
+  now: () => number,
+): number {
+  const f = getRateLimitFields(err);
+  // 1. Explicit Retry-After — honor exactly.
+  if (typeof f.retryAfterMs === "number" && f.retryAfterMs >= 0) {
+    return f.retryAfterMs;
+  }
+  // 2. Primary bucket exhausted → wait until reset (epoch seconds → ms).
+  if (f.rateLimitRemaining === 0 && typeof f.rateLimitReset === "number") {
+    const untilReset = f.rateLimitReset * 1000 - now();
+    if (untilReset > 0) return untilReset;
+    // reset already passed → fall through to the floor+exponential fallback
+  }
+  // 3. Absent header — ≥60s floor, then exponential with jitter.
+  const exp = baseDelayMs * 2 ** attempt * (1 + random());
+  return Math.max(minWaitMs, exp);
+}
+
+/**
+ * Wrap a transport with rate-limit backoff. After `maxRetries` rate-limited
+ * attempts (or when the global budget can't cover the next wait) the last error
+ * is rethrown — the per-repo sync cycle then fails warn-not-block (D12).
  */
 export function withRateLimitBackoff(
   transport: RestCommitTransport,
   options: BackoffOptions = {},
 ): RestCommitTransport {
-  const maxRetries = options.maxRetries ?? 3;
+  const maxRetries = options.maxRetries ?? DEFAULT_MAX_RETRIES;
   const baseDelayMs = options.baseDelayMs ?? 1000;
+  const minWaitMs = Math.max(
+    MIN_RATE_LIMIT_WAIT_MS,
+    options.minRateLimitWaitMs ?? MIN_RATE_LIMIT_WAIT_MS,
+  );
+  const budget = options.budget;
   const sleep = options.sleep ?? defaultSleep;
   // SECURITY CONTEXT: jitter source for retry timing only — deliberately
   // not cryptographically secure (no IDs/tokens are derived from it).
   const random = options.random ?? Math.random;
+  const now = options.now ?? ((): number => Date.now());
 
   return async (req: RestCommitRequest): Promise<RestCommitResponse> => {
     let attempt = 0;
@@ -77,7 +197,18 @@ export function withRateLimitBackoff(
         return await transport(req);
       } catch (err) {
         if (!isRateLimitError(err) || attempt >= maxRetries) throw err;
-        const delay = baseDelayMs * 2 ** attempt * (1 + random());
+        const delay = computeRateLimitDelay(
+          err,
+          attempt,
+          baseDelayMs,
+          minWaitMs,
+          random,
+          now,
+        );
+        // Global per-sync budget: if this wait would overrun the total the
+        // sync may spend on rate limits, stop retrying (warn-defer) rather
+        // than let one locked repo stall the whole sequential run.
+        if (budget !== undefined && !budget.tryReserve(delay)) throw err;
         attempt++;
         await sleep(delay);
       }

--- a/packages/core/tests/integration/sync/syncEngine.retry-after.integration.test.ts
+++ b/packages/core/tests/integration/sync/syncEngine.retry-after.integration.test.ts
@@ -1,0 +1,137 @@
+/**
+ * ExoSync A (RFC 6a1a6518) — Retry-After honoring, end-to-end through the REAL
+ * SyncEngine over the production-shape `FakeGitHubRepo` transport (NO network).
+ *
+ * This is the CI-reliable integration binding for req
+ * 0fd4c819-0a48-43e5-9e4b-2a1cc3eef1c2. It composes the real engine + its real
+ * `withRateLimitBackoff` wrapper + the real global per-sync budget, and drives
+ * a transport that ENRICHES its rate-limit errors exactly as the production
+ * CLI/plugin transports do (via the real `enrichRateLimitError` helper). It
+ * proves the two engine-side halves of A:
+ *   1. the backoff sleeps EXACTLY the attached Retry-After (not a jittered guess);
+ *   2. the GLOBAL per-sync budget warn-defers — one locked repo cannot make
+ *      every later repo wait a full window (bounded total, later repos fail fast).
+ *
+ * @req:0fd4c819-0a48-43e5-9e4b-2a1cc3eef1c2
+ */
+
+import {
+  SyncEngine,
+  enrichRateLimitError,
+  type RestCommitTransport,
+  type SyncEngineDeps,
+} from "../../../src";
+import {
+  FakeGitHubRepo,
+  FakeLocalFiles,
+  FakeWatermarkStore,
+  alwaysMaterialized,
+  mdAsset,
+  sha1Hex,
+} from "../../unit/services/sync/fakeGitHub";
+
+const FILE_A = "assets/a.md";
+
+/** A rate-limit error enriched exactly as the real transport would. */
+function rateLimited(req: { method: string; url: string }, retryAfterSec: string): Error {
+  const get = (name: string): string | undefined =>
+    name.toLowerCase() === "retry-after" ? retryAfterSec : undefined;
+  return enrichRateLimitError(
+    new Error(
+      `GitHub request ${req.method} ${req.url} → HTTP 403: API rate limit exceeded`,
+    ),
+    get,
+  );
+}
+
+function makeEngine(
+  gh: FakeGitHubRepo,
+  local: FakeLocalFiles,
+  transport: RestCommitTransport,
+  backoff: SyncEngineDeps["backoff"],
+): SyncEngine {
+  return new SyncEngine({
+    transport,
+    watermarkStore: new FakeWatermarkStore(),
+    materializationCheck: alwaysMaterialized(),
+    localFilesFor: () => local,
+    sha1: sha1Hex,
+    backoff,
+  });
+}
+
+describe("ExoSync A — Retry-After honored end-to-end through SyncEngine", () => {
+  it("@req:0fd4c819-0a48-43e5-9e4b-2a1cc3eef1c2 sleeps EXACTLY the transport's Retry-After, then completes the sync", async () => {
+    const gh = new FakeGitHubRepo({ [FILE_A]: mdAsset("u1") });
+    const local = new FakeLocalFiles({ [FILE_A]: mdAsset("u1") });
+    const inner = gh.transport();
+    const sleeps: number[] = [];
+
+    // The first two transport CALLS rate-limit (Retry-After: 90s), then the
+    // real transport takes over — the engine's first request eats both throttles.
+    let failures = 2;
+    const transport: RestCommitTransport = async (req) => {
+      if (failures > 0) {
+        failures--;
+        throw rateLimited(req, "90");
+      }
+      return inner(req);
+    };
+
+    const engine = makeEngine(gh, local, transport, {
+      random: () => 0.99, // would inflate a guess; must be ignored
+      sleep: async (ms) => {
+        sleeps.push(ms);
+      },
+    });
+
+    const result = await engine.sync(gh.spec());
+
+    expect(result.status).toBe("synced"); // survived the throttle
+    // Revert-verify anchor: drop the retryAfterMs read → these become 60000
+    // (the ≥60s fallback) → RED.
+    expect(sleeps).toEqual([90_000, 90_000]);
+  });
+
+  it("@req:0fd4c819-0a48-43e5-9e4b-2a1cc3eef1c2 the global per-sync budget warn-defers: one locked repo cannot stall the whole syncAll", async () => {
+    // Two repos, both perpetually rate-limited (Retry-After: 90s). The default
+    // maxRetries is 6 (=> up to 6 waits per repo => 12 total without a cap), but
+    // a per-sync budget of 200s allows only ~2 waits for the WHOLE run.
+    const gh = new FakeGitHubRepo({ [FILE_A]: mdAsset("u1") });
+    const local = new FakeLocalFiles({ [FILE_A]: mdAsset("u1") });
+    const specA = { ...gh.spec(), repoKey: "o/a#main", localPath: "assetspaces/a" };
+    const specB = { ...gh.spec(), repoKey: "o/b#main", localPath: "assetspaces/b" };
+    const sleeps: number[] = [];
+
+    const transport: RestCommitTransport = async (req) => {
+      throw rateLimited(req, "90"); // never succeeds
+    };
+
+    // Both repos share ONE engine (one budget).
+    const engine = new SyncEngine({
+      transport,
+      watermarkStore: new FakeWatermarkStore(),
+      materializationCheck: alwaysMaterialized(),
+      localFilesFor: () => local,
+      sha1: sha1Hex,
+      backoff: {
+        maxTotalRateLimitWaitMs: 200_000, // room for exactly 2 waits of 90s
+        random: () => 0,
+        sleep: async (ms) => {
+          sleeps.push(ms);
+        },
+      },
+    });
+
+    const results = await engine.syncAll([specA, specB]);
+
+    // Neither repo synced (both perpetually throttled) — warn-not-block (D12).
+    expect(results).toHaveLength(2);
+    for (const r of results) expect(r.status).not.toBe("synced");
+    // The budget bounded the WHOLE run to 2 waits — NOT 6-per-repo. The second
+    // repo failed fast (budget already spent) rather than waiting its own window.
+    // Revert-verify anchor: neutralize the budget guard → this balloons to the
+    // full per-repo maxRetries (≫2) → RED.
+    expect(sleeps).toEqual([90_000, 90_000]);
+  });
+});

--- a/packages/core/tests/unit/infrastructure/github/rateLimitHeaders.test.ts
+++ b/packages/core/tests/unit/infrastructure/github/rateLimitHeaders.test.ts
@@ -1,0 +1,168 @@
+/**
+ * ExoSync A (RFC 6a1a6518) — GitHub rate-limit header extraction + error
+ * enrichment. Covers the ⛔ data-loss constraint: enrichment ATTACHES fields
+ * and preserves `.message` byte-for-byte, so the three string-matching parsers
+ * (`isRateLimitError` / `isAuthError` / `isNonFastForwardError`) classify the
+ * enriched error IDENTICALLY to the bare one.
+ *
+ * @req:0fd4c819-0a48-43e5-9e4b-2a1cc3eef1c2
+ */
+
+import {
+  caseInsensitiveHeaderGetter,
+  parseRetryAfterMs,
+  extractRateLimitFields,
+  getRateLimitFields,
+  attachRateLimitFields,
+  enrichRateLimitError,
+  isRateLimitError,
+  isAuthError,
+  isNonFastForwardError,
+  type HeaderGetter,
+} from "../../../../src";
+
+const REQ_URL = "https://api.github.com/repos/o/r/git/trees";
+const http = (status: number, body: string, method = "POST"): string =>
+  `GitHub request ${method} ${REQ_URL} → HTTP ${status}: ${body}`;
+
+describe("caseInsensitiveHeaderGetter", () => {
+  it("resolves any casing (iOS Obsidian requestUrl Record parity)", () => {
+    const get = caseInsensitiveHeaderGetter({
+      "Retry-After": "120",
+      "X-RateLimit-Reset": "1700000000",
+    });
+    expect(get("retry-after")).toBe("120");
+    expect(get("Retry-After")).toBe("120");
+    expect(get("RETRY-AFTER")).toBe("120");
+    expect(get("x-ratelimit-reset")).toBe("1700000000");
+    expect(get("missing")).toBeUndefined();
+  });
+
+  it("tolerates an absent/undefined header record", () => {
+    expect(caseInsensitiveHeaderGetter(undefined)("retry-after")).toBeUndefined();
+    expect(caseInsensitiveHeaderGetter(null)("retry-after")).toBeUndefined();
+    expect(caseInsensitiveHeaderGetter({})("retry-after")).toBeUndefined();
+  });
+});
+
+describe("parseRetryAfterMs", () => {
+  it("parses delta-seconds → milliseconds (GitHub's rate-limit form)", () => {
+    expect(parseRetryAfterMs("120")).toBe(120_000);
+    expect(parseRetryAfterMs("  60 ")).toBe(60_000);
+    expect(parseRetryAfterMs("0")).toBe(0);
+  });
+
+  it("parses an HTTP-date relative to `now`", () => {
+    const now = () => Date.parse("2026-01-01T00:00:00Z");
+    expect(
+      parseRetryAfterMs("Thu, 01 Jan 2026 00:02:00 GMT", now),
+    ).toBe(120_000);
+    // a past date clamps to 0 (never negative)
+    expect(parseRetryAfterMs("Thu, 01 Jan 2020 00:00:00 GMT", now)).toBe(0);
+  });
+
+  it("returns undefined for absent / garbage", () => {
+    expect(parseRetryAfterMs(undefined)).toBeUndefined();
+    expect(parseRetryAfterMs(null)).toBeUndefined();
+    expect(parseRetryAfterMs("")).toBeUndefined();
+    expect(parseRetryAfterMs("soon")).toBeUndefined();
+  });
+});
+
+describe("extractRateLimitFields", () => {
+  it("pulls Retry-After / x-ratelimit-reset / x-ratelimit-remaining", () => {
+    const get: HeaderGetter = (n) =>
+      ({
+        "retry-after": "90",
+        "x-ratelimit-reset": "1700000000",
+        "x-ratelimit-remaining": "0",
+      })[n.toLowerCase()];
+    expect(extractRateLimitFields(get)).toEqual({
+      retryAfterMs: 90_000,
+      rateLimitReset: 1700000000,
+      rateLimitRemaining: 0,
+    });
+  });
+
+  it("omits absent fields", () => {
+    expect(extractRateLimitFields(() => undefined)).toEqual({});
+  });
+});
+
+describe("attachRateLimitFields / getRateLimitFields — non-enumerable own-props", () => {
+  it("attaches as NON-enumerable (invisible to JSON.stringify / Object.keys)", () => {
+    const err = attachRateLimitFields(new Error("boom"), {
+      retryAfterMs: 120_000,
+      rateLimitReset: 42,
+    });
+    expect(getRateLimitFields(err)).toEqual({
+      retryAfterMs: 120_000,
+      rateLimitReset: 42,
+    });
+    // Read back directly.
+    expect((err as { retryAfterMs?: number }).retryAfterMs).toBe(120_000);
+    // Invisible to serialization / enumeration.
+    expect(Object.keys(err)).not.toContain("retryAfterMs");
+    expect(JSON.stringify(err)).toBe("{}");
+  });
+
+  it("getRateLimitFields returns {} for a bare error / non-object", () => {
+    expect(getRateLimitFields(new Error("x"))).toEqual({});
+    expect(getRateLimitFields("str")).toEqual({});
+    expect(getRateLimitFields(null)).toEqual({});
+  });
+});
+
+describe("enrichRateLimitError — ⛔ .message preserved, parsers classify identically", () => {
+  const withHeaders = (headers: Record<string, string>): HeaderGetter =>
+    caseInsensitiveHeaderGetter(headers);
+
+  it("attaches retryAfterMs while keeping .message BYTE-FOR-BYTE identical", () => {
+    const msg = http(403, "You have exceeded a secondary rate limit");
+    const bare = new Error(msg);
+    const enriched = enrichRateLimitError(new Error(msg), withHeaders({ "Retry-After": "120" }));
+
+    // .message is untouched (attach, never replace) — the CRITICAL invariant.
+    expect(enriched.message).toBe(bare.message);
+    expect(enriched.message).toBe(msg);
+    // The field is available for the backoff.
+    expect(getRateLimitFields(enriched).retryAfterMs).toBe(120_000);
+  });
+
+  // Revert-verify anchor: if enrichment ever MUTATED/replaced `.message`, the
+  // 422 case below would stop being isNonFastForwardError (→ contended push
+  // bypasses quarantine → silent data loss) and the plain-403 case would stop
+  // being isAuthError. These identity checks pin that it does not.
+  it("@req:0fd4c819-0a48-43e5-9e4b-2a1cc3eef1c2 the three parsers classify the enriched error identically to the bare error", () => {
+    const cases: Array<{ msg: string; rate: boolean; auth: boolean; nff: boolean }> = [
+      { msg: http(429, "too many requests"), rate: true, auth: false, nff: false },
+      { msg: http(403, "API rate limit exceeded"), rate: true, auth: false, nff: false },
+      { msg: http(403, "You have triggered an abuse detection mechanism"), rate: true, auth: false, nff: false },
+      { msg: http(403, "Forbidden"), rate: false, auth: true, nff: false },
+      { msg: http(401, "Bad credentials", "GET"), rate: false, auth: true, nff: false },
+      { msg: `GitHub request PATCH ${REQ_URL.replace("/trees", "/refs/heads/main")} → HTTP 422: Update is not a fast forward`, rate: false, auth: false, nff: true },
+    ];
+    // Enrich with a full rate-limit header set (worst case for byte-preservation).
+    const get = withHeaders({
+      "Retry-After": "60",
+      "X-RateLimit-Reset": "1700000000",
+      "X-RateLimit-Remaining": "0",
+    });
+    for (const c of cases) {
+      const bare = new Error(c.msg);
+      const enriched = enrichRateLimitError(new Error(c.msg), get);
+
+      expect(enriched.message).toBe(bare.message); // byte-for-byte
+
+      // Each parser: same verdict for bare and enriched (identity).
+      expect(isRateLimitError(enriched)).toBe(isRateLimitError(bare));
+      expect(isAuthError(enriched)).toBe(isAuthError(bare));
+      expect(isNonFastForwardError(enriched)).toBe(isNonFastForwardError(bare));
+
+      // …and that verdict matches the expected classification.
+      expect(isRateLimitError(enriched)).toBe(c.rate);
+      expect(isAuthError(enriched)).toBe(c.auth);
+      expect(isNonFastForwardError(enriched)).toBe(c.nff);
+    }
+  });
+});

--- a/packages/core/tests/unit/services/sync/transportBackoff.test.ts
+++ b/packages/core/tests/unit/services/sync/transportBackoff.test.ts
@@ -1,11 +1,21 @@
-/** ExoSync A3 — rate-limit backoff transport decorator (R6). */
+/**
+ * ExoSync A3 — rate-limit backoff transport decorator (R6) + RFC 6a1a6518 A
+ * (honor Retry-After, absent → ≥60s, global per-sync budget, maxRetries ≥6).
+ *
+ * @req:0fd4c819-0a48-43e5-9e4b-2a1cc3eef1c2
+ */
 
 import {
   isAuthError,
   isRateLimitError,
   withRateLimitBackoff,
+  createRateLimitBudget,
+  attachRateLimitFields,
+  MIN_RATE_LIMIT_WAIT_MS,
+  DEFAULT_MAX_RETRIES,
   type RestCommitRequest,
   type RestCommitTransport,
+  type RateLimitErrorFields,
 } from "../../../../src";
 
 const REQ: RestCommitRequest = {
@@ -13,8 +23,17 @@ const REQ: RestCommitRequest = {
   url: "https://api.github.com/repos/o/r/git/refs/heads/main",
 };
 
+const http = (status: number, body: string): string =>
+  `GitHub request GET ${REQ.url} → HTTP ${status}: ${body}`;
+
+/** Rate-limit error, optionally enriched with the fields the transport attaches. */
+function rl(body: string, fields: RateLimitErrorFields = {}): Error {
+  return attachRateLimitFields(new Error(http(403, body)), fields);
+}
+
+/** Transport that throws each given Error in turn, then succeeds. */
 function failingTransport(
-  errors: string[],
+  errors: Error[],
   finalJson: unknown = { ok: true },
 ): { transport: RestCommitTransport; calls: () => number } {
   let n = 0;
@@ -22,15 +41,12 @@ function failingTransport(
     transport: async () => {
       n++;
       const err = errors.shift();
-      if (err !== undefined) throw new Error(err);
+      if (err !== undefined) throw err;
       return { status: 200, json: finalJson };
     },
     calls: () => n,
   };
 }
-
-const http = (status: number, body: string): string =>
-  `GitHub request GET ${REQ.url} → HTTP ${status}: ${body}`;
 
 describe("isRateLimitError / isAuthError discrimination", () => {
   it("429 and 403+rate-limit/abuse are rate limits, not auth errors", () => {
@@ -58,31 +74,153 @@ describe("isRateLimitError / isAuthError discrimination", () => {
   });
 });
 
-describe("withRateLimitBackoff", () => {
-  it("retries rate-limited requests with exponential delays + jitter", async () => {
+describe("withRateLimitBackoff — honor Retry-After (RFC 6a1a6518 A)", () => {
+  it("@req:0fd4c819-0a48-43e5-9e4b-2a1cc3eef1c2 sleeps EXACTLY the attached Retry-After (not a jittered guess)", async () => {
     const delays: number[] = [];
+    // Two rate-limited failures, each carrying Retry-After: 120s.
     const { transport, calls } = failingTransport([
-      http(403, "API rate limit exceeded"),
-      http(429, "slow down"),
+      rl("secondary rate limit", { retryAfterMs: 120_000 }),
+      rl("secondary rate limit", { retryAfterMs: 120_000 }),
     ]);
     const wrapped = withRateLimitBackoff(transport, {
-      baseDelayMs: 100,
+      baseDelayMs: 100, // deliberately tiny — proves Retry-After overrides it
+      minRateLimitWaitMs: MIN_RATE_LIMIT_WAIT_MS,
+      random: () => 0.99, // would inflate a guess; must be ignored
       sleep: async (ms) => {
         delays.push(ms);
       },
-      random: () => 0.5,
     });
 
     const resp = await wrapped(REQ);
 
     expect(resp.json).toEqual({ ok: true });
     expect(calls()).toBe(3);
-    expect(delays).toEqual([150, 300]); // 100*2^0*1.5, 100*2^1*1.5
+    // Revert-verify anchor: remove the retryAfterMs read in
+    // computeRateLimitDelay and these become the ≥60s fallback (60000) → RED.
+    expect(delays).toEqual([120_000, 120_000]);
   });
 
-  it("rethrows after the retry cap", async () => {
+  it("@req:0fd4c819-0a48-43e5-9e4b-2a1cc3eef1c2 absent Retry-After waits at least 60s (documented secondary fallback), then exponential", async () => {
+    const delays: number[] = [];
+    // Bare rate-limit errors — no attached header.
+    const { transport } = failingTransport([
+      new Error(http(429, "slow down")),
+      new Error(http(429, "slow down")),
+    ]);
+    const wrapped = withRateLimitBackoff(transport, {
+      baseDelayMs: 100, // exp term stays < 60s → floor dominates
+      random: () => 0.5,
+      sleep: async (ms) => {
+        delays.push(ms);
+      },
+    });
+
+    await wrapped(REQ);
+
+    expect(delays).toHaveLength(2);
+    for (const d of delays) expect(d).toBeGreaterThanOrEqual(MIN_RATE_LIMIT_WAIT_MS);
+    expect(delays).toEqual([60_000, 60_000]);
+  });
+
+  it("the exponential term dominates the floor once it exceeds 60s", async () => {
+    const delays: number[] = [];
+    // baseDelayMs large enough that base*2^attempt eventually beats 60s.
+    const { transport } = failingTransport([
+      new Error(http(429, "x")),
+      new Error(http(429, "x")),
+    ]);
+    const wrapped = withRateLimitBackoff(transport, {
+      baseDelayMs: 50_000, // attempt0: 50k → floored 60k; attempt1: 100k → 100k
+      random: () => 0, // no jitter
+      sleep: async (ms) => {
+        delays.push(ms);
+      },
+    });
+    await wrapped(REQ);
+    expect(delays).toEqual([60_000, 100_000]);
+  });
+
+  it("waits until x-ratelimit-reset when the primary bucket is exhausted (remaining=0)", async () => {
+    const delays: number[] = [];
+    const NOW = 1_700_000_000_000; // fixed ms
+    const RESET = 1_700_000_090; // epoch seconds → 90s after NOW
+    const { transport } = failingTransport([
+      rl("API rate limit exceeded", { rateLimitRemaining: 0, rateLimitReset: RESET }),
+    ]);
+    const wrapped = withRateLimitBackoff(transport, {
+      now: () => NOW,
+      sleep: async (ms) => {
+        delays.push(ms);
+      },
+    });
+    await wrapped(REQ);
+    expect(delays).toEqual([90_000]);
+  });
+});
+
+describe("withRateLimitBackoff — global per-sync budget (RFC 6a1a6518 A)", () => {
+  it("@req:0fd4c819-0a48-43e5-9e4b-2a1cc3eef1c2 warn-defers instead of stalling every repo: the SHARED budget bounds the whole sync and later repos fail fast", async () => {
+    // One shared budget across two 'repos' (two wrapped calls, budget NOT reset
+    // between them — the engine resets once per syncAll). Retry-After = 60s.
+    const budget = createRateLimitBudget(150_000); // room for exactly 2 waits
+    const delays: number[] = [];
+    const sleep = async (ms: number): Promise<void> => {
+      delays.push(ms);
+    };
+    const wrap = (
+      errors: Error[],
+    ): { transport: RestCommitTransport; calls: () => number } => {
+      const ft = failingTransport(errors);
+      return {
+        transport: withRateLimitBackoff(ft.transport, { budget, sleep }),
+        calls: ft.calls,
+      };
+    };
+
+    // Repo 1: keeps rate-limiting (never succeeds). maxRetries default is 6, but
+    // the budget (2×60s) cuts it off after 2 waits → warn-defer (rethrow).
+    // Revert-verify anchor: neutralize the `!budget.tryReserve(delay)` guard and
+    // this sleeps 6 times (the full maxRetries) → the [60000,60000] assertion RED.
+    const repo1 = wrap(
+      Array.from({ length: 8 }, () => rl("rate limit", { retryAfterMs: 60_000 })),
+    );
+    await expect(repo1.transport(REQ)).rejects.toThrow(/HTTP 403/);
+    expect(delays).toEqual([60_000, 60_000]); // budget cut it off at 2, NOT 6
+    expect(repo1.calls()).toBe(3); // initial + 2 retries, then budget-defer
+
+    // Repo 2: with the budget already spent, the FIRST rate-limit fails fast —
+    // no wait — so one locked repo cannot make every later repo wait a window.
+    const repo2 = wrap([rl("rate limit", { retryAfterMs: 60_000 })]);
+    await expect(repo2.transport(REQ)).rejects.toThrow(/HTTP 403/);
+    expect(delays).toEqual([60_000, 60_000]); // unchanged — repo 2 did NOT sleep
+    expect(repo2.calls()).toBe(1); // fail-fast
+
+    // Reset (as the engine does per syncAll) restores the full allowance: a
+    // rate-limit is honored (one 60s wait) and the request then succeeds.
+    budget.reset();
+    const repo3 = wrap([rl("rate limit", { retryAfterMs: 60_000 })]);
+    const ok = await repo3.transport(REQ);
+    expect(ok.json).toEqual({ ok: true });
+    expect(delays).toEqual([60_000, 60_000, 60_000]); // reset let it wait again
+    expect(repo3.calls()).toBe(2); // initial (throttled) + retry (success)
+  });
+});
+
+describe("withRateLimitBackoff — retry cap + pass-through", () => {
+  it("defaults maxRetries to 6 (RFC 6a1a6518 A raised it from 3)", async () => {
+    expect(DEFAULT_MAX_RETRIES).toBe(6);
     const { transport, calls } = failingTransport(
-      Array(5).fill(http(429, "still limited")),
+      Array.from({ length: 10 }, () => new Error(http(429, "still limited"))),
+    );
+    // No maxRetries, no budget → unbounded budget, default cap of 6.
+    const wrapped = withRateLimitBackoff(transport, { sleep: async () => {} });
+    await expect(wrapped(REQ)).rejects.toThrow(/HTTP 429/);
+    expect(calls()).toBe(7); // initial + 6 retries
+  });
+
+  it("rethrows after an explicit retry cap", async () => {
+    const { transport, calls } = failingTransport(
+      Array(5).fill(0).map(() => new Error(http(429, "still limited"))),
     );
     const wrapped = withRateLimitBackoff(transport, {
       maxRetries: 2,
@@ -99,7 +237,7 @@ describe("withRateLimitBackoff", () => {
       http(404, "Not Found"),
       http(401, "Bad credentials"),
     ]) {
-      const { transport, calls } = failingTransport([msg]);
+      const { transport, calls } = failingTransport([new Error(msg)]);
       const wrapped = withRateLimitBackoff(transport, {
         sleep: async () => {
           throw new Error("sleep must not be called");

--- a/packages/obsidian-plugin/src/infrastructure/adapters/GitHubRestClient.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/GitHubRestClient.ts
@@ -2,7 +2,12 @@ import type { App, RequestUrlParam, RequestUrlResponse } from "obsidian";
 import { requestUrl } from "obsidian";
 import { parseTarGzip } from "nanotar";
 import type { TarFileItem } from "nanotar";
-import { restCreateCommit, type RestCommitTransport } from "@kitelev/exocortex-core";
+import {
+  restCreateCommit,
+  enrichRateLimitError,
+  caseInsensitiveHeaderGetter,
+  type RestCommitTransport,
+} from "@kitelev/exocortex-core";
 
 export interface GitHubRestClientOptions {
   pat: string;
@@ -467,11 +472,18 @@ export class GitHubRestClient {
       // Redact BEFORE truncating so a PAT near the 256-char boundary cannot
       // be sliced mid-token (which would shorten it below the regex floor
       // and escape redaction).
-      throw new Error(
-        truncate(
-          this.redact(`GitHub request ${param.method ?? "GET"} ${param.url} → HTTP ${resp.status}: ${body}`),
-          512,
+      // RFC 6a1a6518 A: attach Retry-After / x-ratelimit-* (own-props,
+      // .message preserved) so the backoff can honor the exact wait. Obsidian
+      // `requestUrl().headers` is a Record with platform-varying casing → a
+      // case-insensitive getter is required (iOS parity).
+      throw enrichRateLimitError(
+        new Error(
+          truncate(
+            this.redact(`GitHub request ${param.method ?? "GET"} ${param.url} → HTTP ${resp.status}: ${body}`),
+            512,
+          ),
         ),
+        caseInsensitiveHeaderGetter(resp.headers),
       );
     }
     return resp;

--- a/packages/obsidian-plugin/tests/unit/GitHubRestClient.test.ts
+++ b/packages/obsidian-plugin/tests/unit/GitHubRestClient.test.ts
@@ -785,4 +785,48 @@ describe("GitHubRestClient", () => {
       await expect(c.getRepoHead("o", "r")).resolves.toEqual({ sha: "z" });
     });
   });
+
+  // ─── rate-limit header enrichment — iOS parity (RFC 6a1a6518 A) ────────────
+  // Obsidian `requestUrl().headers` is a Record<string,string> whose casing
+  // varies by platform (desktop vs iOS). The plugin transport did NOT read
+  // `.headers` before — the case-insensitive getter must resolve Retry-After
+  // regardless of casing so the backoff can honor it on iOS.
+  // @req:0fd4c819-0a48-43e5-9e4b-2a1cc3eef1c2
+  describe("rate-limit header enrichment (iOS parity)", () => {
+    async function captureVia403(headers: Record<string, string>): Promise<Error> {
+      requestUrlMock.mockResolvedValue(
+        ok({
+          status: 403,
+          text: "You have exceeded a secondary rate limit",
+          headers,
+        }),
+      );
+      const c = new GitHubRestClient({ pat: FAKE_PAT, app: fakeApp });
+      try {
+        await c.restTransport()({ method: "GET", url: "https://api.github.com/x" });
+      } catch (e) {
+        return e as Error;
+      }
+      throw new Error("expected the transport to throw on 403");
+    }
+
+    it.each([
+      ["lowercase", "retry-after"],
+      ["Header-Case", "Retry-After"],
+      ["UPPERCASE", "RETRY-AFTER"],
+    ])("resolves Retry-After from %s casing", async (_label, key) => {
+      const err = (await captureVia403({ [key]: "90" })) as Error & {
+        retryAfterMs?: number;
+      };
+      expect(err.retryAfterMs).toBe(90_000);
+      // .message keeps the production shape the string parsers key off.
+      expect(err.message).toMatch(/HTTP 403: You have exceeded a secondary rate limit/);
+    });
+
+    it("attaches nothing when there are no rate-limit headers", async () => {
+      const err = (await captureVia403({})) as Error & { retryAfterMs?: number };
+      expect(err.retryAfterMs).toBeUndefined();
+      expect(err.message).toMatch(/HTTP 403/);
+    });
+  });
 });


### PR DESCRIPTION
## What

ExoSync rate-limit backoff now **honors GitHub's `Retry-After`** (RFC `6a1a6518` Phase 1 / A; child of baseline RFC `4e4dc453` R6). Implements req `0fd4c819-0a48-43e5-9e4b-2a1cc3eef1c2` (Active-on-merge) via `/feature-sdd`.

**Incident it fixes (2026-07-27):** a 1204-file bulk push hit a GitHub **secondary** 403 on `POST git/trees`; the transport discarded response headers on throw, so the backoff never saw `Retry-After` and blindly slept ~1-8s ×3 — never surviving the minutes-long secondary window → `pushed 0` → ~15 min manual recovery.

## Mechanism

- **Both transports** (CLI `RestPushService` / fetch, plugin `GitHubRestClient` / requestUrl) read `Retry-After` / `x-ratelimit-reset` / `x-ratelimit-remaining` on a non-2xx and **ATTACH** them as **non-enumerable own-props** (`retryAfterMs` / `rateLimitReset` / `rateLimitRemaining`) via a shared core helper `rateLimitHeaders.enrichRateLimitError` — **`.message` preserved byte-for-byte** (never replaced).
- `withRateLimitBackoff` reads `retryAfterMs` and sleeps **exactly** that; absent → **≥60s** floor then exponential; primary-exhausted (`remaining===0` + `reset`) → wait until reset. `maxRetries` default **3 → 6**.
- **Case-insensitive** header lookup — Obsidian `requestUrl().headers` is a `Record` with platform-varying casing (desktop vs iOS); the plugin transport did not read `.headers` before → iOS-parity test.
- **GLOBAL per-sync time-budget** (`SyncEngine`, reset each `syncAll`/`sync`) bounds total rate-limit waiting; when it can't cover the next wait the backoff **warn-defers** (rethrows, D12) rather than stalling every repo in the sequential single-flight — later repos fail fast.

## ⛔ Data-loss constraint honored

`.message` is byte-for-byte preserved so the three string parsers — `isRateLimitError`, `isAuthError`, `isNonFastForwardError` (the D16 non-fast-forward → quarantine gate) — classify the enriched error **identically** to the bare one. Breaking `.message` would route a contended 422 push around quarantine → silent data loss; a revert-verify test pins this.

## Revert-verified (RED pre-fix / GREEN post-fix, type-preserving Edit-breaks)

| Axis | Break | Result |
|---|---|---|
| Honor Retry-After | `void` the `retryAfterMs` read | "sleeps ~N" tests RED (fall to ≥60s) |
| Preserve `.message` (data-loss) | replace `.message` | 422 → not `isNonFastForwardError`, 403-auth → not `isAuthError` RED |
| Global budget warn-defer | neutralize budget guard | warn-defer / fail-fast tests RED |

Each break reds only its own axis (non-vacuity); all restore GREEN.

## Tests

- core sync suites **446 pass, 0 regressions** + **24 new** (`transportBackoff` honor/floor/reset/budget/maxRetries≥6, `rateLimitHeaders` parse/attach/case-insensitive + 3-parser identity, `syncEngine.retry-after` integration honor + global-budget).
- plugin **89** (GitHubRestClient iOS-parity + ExoSyncRequestUrlParity regression), cli **13** (transport enrich).
- `@req:0fd4c819-0a48-43e5-9e4b-2a1cc3eef1c2` bound in unit + integration.

## Scope

**A only.** C (concurrent pull) = RFC Phase 2 (separate `/feature-sdd`). D/B/E/secret-scan deferred to issues #3973–#3976.

Req: 0fd4c819-0a48-43e5-9e4b-2a1cc3eef1c2
