### PR TITLE
feat(sync): ExoSync bounded-concurrency blob-fetch on pull (RFC 6a1a6518 / C)

### DIFF
--- a/packages/core/src/services/sync/SyncEngine.ts
+++ b/packages/core/src/services/sync/SyncEngine.ts
@@ -345,6 +345,15 @@ const BLOB_PROGRESS_MIN_TOTAL = 25;
 /** Emit a `fetching-blobs` tick every N blobs fetched. */
 const BLOB_PROGRESS_STEP = 10;
 /**
+ * Bounded blob-fetch concurrency on pull (RFC 6a1a6518 / C). A big remote delta
+ * fetched one blob at a time (~0.4s each) makes the sync look hung; a small pool
+ * cuts the wall-clock. Cap 6 is ~20× under GitHub's 100-concurrent ceiling —
+ * safe ONLY because Phase 1 / A already ships solid Retry-After backoff + a
+ * global per-sync time-budget, so a concurrency-induced secondary limit is
+ * honored, not ignored. A fixed const (the RFC fixes the cap at 4-6), not a dep.
+ */
+const BLOB_FETCH_CONCURRENCY = 6;
+/**
  * Local-IO progress throttle. Reads are many + fast per file (a cold snapshot
  * hashes thousands at ~1-2ms each), writes are fewer + slower (a pull-apply
  * writes hundreds at tens of ms each) — so the two phases tick at different
@@ -3550,9 +3559,20 @@ export class SyncEngine {
         total: totalBlobs,
       });
     }
+    // Bounded-concurrency blob fetch (RFC 6a1a6518 / C). INDEXED WRITE-BACK —
+    // each result lands at its position in the `changed` order (NOT completion
+    // order), so `changes[]` is byte-identical to the old sequential loop; the
+    // order-sensitive consumer `matchLocalVsRemote` (rename-pairs / duplicate
+    // uids) must see a deterministic array. FAIL-FAST — the first blob error
+    // stops the pool from scheduling any new fetch and is rethrown, so the whole
+    // pull rejects BEFORE `matchLocalVsRemote`/apply → ZERO partial apply.
+    const changeResults: RemoteChange[] = new Array<RemoteChange>(
+      changed.length,
+    );
+    let nextIdx = 0;
     let fetched = 0;
-    const changes: RemoteChange[] = [];
-    for (const c of changed) {
+    let firstError: unknown;
+    const fetchOne = async (c: RemoteTreeEntry): Promise<RemoteChange> => {
       if (mode.fileMode) {
         // Opaque blobs: byte-exact fetch, no uid identity (D18).
         const bytes = await getBlobBytes(
@@ -3562,40 +3582,61 @@ export class SyncEngine {
           c.blobSha,
           this.deps.baseURL,
         );
-        changes.push({
-          path: c.path,
-          kind: "change",
-          blobSha: c.blobSha,
-          content: bytes,
-        });
-      } else {
-        const content = await getBlobText(
-          this.transport,
-          spec.owner,
-          spec.repo,
-          c.blobSha,
-          this.deps.baseURL,
-        );
-        changes.push({
-          path: c.path,
-          kind: "change",
-          blobSha: c.blobSha,
-          content,
-          uid: extractAssetUid(content),
-        });
+        return { path: c.path, kind: "change", blobSha: c.blobSha, content: bytes };
       }
-      fetched += 1;
-      if (
-        totalBlobs >= BLOB_PROGRESS_MIN_TOTAL &&
-        fetched % BLOB_PROGRESS_STEP === 0 &&
-        fetched < totalBlobs
-      ) {
-        this.emitProgress(onProgress, spec.repoKey, "fetching-blobs", {
-          done: fetched,
-          total: totalBlobs,
-        });
+      const content = await getBlobText(
+        this.transport,
+        spec.owner,
+        spec.repo,
+        c.blobSha,
+        this.deps.baseURL,
+      );
+      return {
+        path: c.path,
+        kind: "change",
+        blobSha: c.blobSha,
+        content,
+        uid: extractAssetUid(content),
+      };
+    };
+    const worker = async (): Promise<void> => {
+      // Single-threaded JS: `nextIdx++` / `fetched += 1` are atomic between
+      // awaits — no lock needed. A set `firstError` stops scheduling new work.
+      for (;;) {
+        if (firstError !== undefined) return;
+        const i = nextIdx++;
+        if (i >= changed.length) return;
+        try {
+          changeResults[i] = await fetchOne(changed[i]);
+        } catch (err) {
+          if (firstError === undefined) firstError = err;
+          return;
+        }
+        fetched += 1;
+        if (
+          totalBlobs >= BLOB_PROGRESS_MIN_TOTAL &&
+          fetched % BLOB_PROGRESS_STEP === 0 &&
+          fetched < totalBlobs
+        ) {
+          this.emitProgress(onProgress, spec.repoKey, "fetching-blobs", {
+            done: fetched,
+            total: totalBlobs,
+          });
+        }
       }
+    };
+    const poolSize = Math.min(BLOB_FETCH_CONCURRENCY, changed.length);
+    await Promise.all(Array.from({ length: poolSize }, () => worker()));
+    // Fail-fast: one failed blob → reject the whole pull (no partial apply).
+    // The transport always throws an Error (httpError / malformed-blob guard),
+    // so this re-throw preserves the original error; the wrap is a type-safety
+    // guard for a hypothetical non-Error throw.
+    if (firstError !== undefined) {
+      throw firstError instanceof Error
+        ? firstError
+        : new Error(String(firstError));
     }
+    const changes: RemoteChange[] = changeResults;
     for (const d of deleted) {
       changes.push({ path: d.path, kind: "delete", uid: d.uid });
     }

--- a/packages/core/src/services/sync/SyncEngine.ts
+++ b/packages/core/src/services/sync/SyncEngine.ts
@@ -350,7 +350,10 @@ const BLOB_PROGRESS_STEP = 10;
  * cuts the wall-clock. Cap 6 is ~20× under GitHub's 100-concurrent ceiling —
  * safe ONLY because Phase 1 / A already ships solid Retry-After backoff + a
  * global per-sync time-budget, so a concurrency-induced secondary limit is
- * honored, not ignored. A fixed const (the RFC fixes the cap at 4-6), not a dep.
+ * honored, not ignored. Note the per-sync rate-limit budget is now SHARED across
+ * these concurrent waiters (it can drain up to `cap`× faster on a genuine
+ * secondary burst) — still safe: the outcome is fail-fast + warn-defer, never a
+ * silent bad apply. A fixed const (the RFC fixes the cap at 4-6), not a dep.
  */
 const BLOB_FETCH_CONCURRENCY = 6;
 /**

--- a/packages/core/tests/integration/sync/syncEngine.concurrent-pull.integration.test.ts
+++ b/packages/core/tests/integration/sync/syncEngine.concurrent-pull.integration.test.ts
@@ -1,0 +1,240 @@
+/**
+ * ExoSync C (RFC 6a1a6518 Phase 2) — bounded-concurrency blob-fetch on pull,
+ * end-to-end through the REAL SyncEngine over the production-shape
+ * `FakeGitHubRepo` transport (NO network).
+ *
+ * This is the CI-reliable integration binding for req
+ * a04c4fce-c77b-4754-a3eb-b074289173f3. It composes the real engine + its real
+ * `collectRemoteChanges` pull path, driving a transport that (per test) delays
+ * or fails individual `GET git/blobs/{sha}` calls. It proves the three
+ * load-bearing halves of C:
+ *   1. INDEXED WRITE-BACK — even when the blobs COMPLETE out of the `changed`
+ *      order, the `changes[]` array handed to the order-sensitive consumer
+ *      `matchLocalVsRemote` is in `changed` order (byte-identical to sequential);
+ *   2. FAIL-FAST — one failing blob rejects the whole pull with ZERO partial
+ *      apply (all files keep their pre-sync content);
+ *   3. BOUNDED CONCURRENCY — peak in-flight blob fetches reach the cap on a big
+ *      delta (real parallelism, deterministic) and the wall-clock is >=3x under
+ *      the sequential lower bound (measured, CI-skipped via expectFasterThan).
+ *
+ * @req:a04c4fce-c77b-4754-a3eb-b074289173f3
+ */
+
+import { createHash } from "node:crypto";
+import {
+  SyncEngine,
+  type RestCommitRequest,
+  type RestCommitResponse,
+  type RestCommitTransport,
+  type SyncProgressEvent,
+} from "../../../src";
+import {
+  FakeGitHubRepo,
+  FakeLocalFiles,
+  FakeWatermarkStore,
+  alwaysMaterialized,
+  mdAsset,
+  sha1Hex,
+} from "../../unit/services/sync/fakeGitHub";
+import { expectFasterThan } from "../../helpers/perfAssert";
+
+const REQ = "a04c4fce-c77b-4754-a3eb-b074289173f3";
+
+/** Real git blob SHA over UTF-8 text — mirrors the fake, so a v2 asset's SHA
+ *  can be mapped back to its `changed` index for index-tied fetch latency. */
+function gitSha(content: string): string {
+  const body = Buffer.from(content, "utf-8");
+  return createHash("sha1")
+    .update(Buffer.concat([Buffer.from(`blob ${body.byteLength}\0`), body]))
+    .digest("hex");
+}
+
+const path = (i: number): string => `assets/f${String(i).padStart(3, "0")}.md`;
+/** N assets, version-tagged body so v1 and v2 have DISTINCT blob SHAs (edits
+ *  of the SAME uid — no rename, no new asset). */
+function nFiles(n: number, ver: string): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (let i = 0; i < n; i++)
+    out[path(i)] = mdAsset(`u${i}`, `body-${ver}-${i}`);
+  return out;
+}
+
+function makeEngine(
+  transport: RestCommitTransport,
+  wm: FakeWatermarkStore,
+  local: FakeLocalFiles,
+): SyncEngine {
+  return new SyncEngine({
+    transport,
+    watermarkStore: wm,
+    materializationCheck: alwaysMaterialized(),
+    localFilesFor: () => local,
+    sha1: sha1Hex,
+  });
+}
+
+/**
+ * Build an N-file remote delta ready to PULL: local + remote both start at v1
+ * (a first sync establishes the watermark, so the pull afterwards is a clean
+ * N-file remote CHANGE), then the remote advances every file to v2.
+ * Returns the shared stores + the raw fake transport for the caller to decorate.
+ */
+async function buildDelta(n: number): Promise<{
+  gh: FakeGitHubRepo;
+  local: FakeLocalFiles;
+  wm: FakeWatermarkStore;
+  inner: RestCommitTransport;
+  v2: Record<string, string>;
+}> {
+  const v1 = nFiles(n, "v1");
+  const gh = new FakeGitHubRepo(v1);
+  const local = new FakeLocalFiles(v1);
+  const wm = new FakeWatermarkStore();
+  const inner = gh.transport();
+  // Establish the watermark at v1 (local == remote → synced, no apply).
+  const first = await makeEngine(inner, wm, local).sync(gh.spec());
+  expect(first.status).toBe("synced");
+  const v2 = nFiles(n, "v2");
+  gh.commitDirect(gh.branch, v2, "bulk v2");
+  return { gh, local, wm, inner, v2 };
+}
+
+const isBlobGet = (req: RestCommitRequest): RegExpExecArray | null =>
+  req.method === "GET"
+    ? /\/git\/blobs\/([^/?]+)/.exec(req.url.replace(/^https?:\/\/[^/]+/, ""))
+    : null;
+
+const sleep = (ms: number): Promise<void> =>
+  new Promise((r) => setTimeout(r, ms));
+
+/** Capture the `remote` array (arg #3) handed to the private matchLocalVsRemote,
+ *  running the REAL method unchanged — observation only. */
+function captureRemote(engine: SyncEngine): {
+  get: () => Array<{ path: string; kind: string }> | undefined;
+} {
+  const proto = Object.getPrototypeOf(engine) as Record<string, unknown>;
+  const orig = proto.matchLocalVsRemote as (
+    this: unknown,
+    ...a: unknown[]
+  ) => unknown;
+  let captured: Array<{ path: string; kind: string }> | undefined;
+  (engine as unknown as Record<string, unknown>).matchLocalVsRemote = function (
+    this: unknown,
+    ...args: unknown[]
+  ) {
+    captured = args[3] as Array<{ path: string; kind: string }>;
+    return orig.apply(this, args);
+  };
+  return { get: () => captured };
+}
+
+describe("ExoSync C — bounded-concurrency blob-fetch on pull", () => {
+  it(`@req:${REQ} indexed write-back keeps changes[] in \`changed\` order even when blobs complete out of order`, async () => {
+    const N = 20;
+    const { gh, local, wm, inner, v2 } = await buildDelta(N);
+
+    // Index-tied REVERSE latency: f000 (idx 0) resolves LAST, f019 resolves
+    // FIRST → completion order is the reverse of the `changed` order. A
+    // completion-order push would surface as a reversed changes[]; indexed
+    // write-back must not.
+    const shaToIdx = new Map<string, number>();
+    for (let i = 0; i < N; i++) shaToIdx.set(gitSha(v2[path(i)]), i);
+    const UNIT = 3;
+    const transport: RestCommitTransport = async (req) => {
+      const m = isBlobGet(req);
+      if (m) {
+        const idx = shaToIdx.get(m[1]);
+        if (idx !== undefined) await sleep((N - idx) * UNIT);
+      }
+      return inner(req);
+    };
+
+    const engine = makeEngine(transport, wm, local);
+    const cap = captureRemote(engine);
+    const res = await engine.sync(gh.spec());
+    expect(res.status).toBe("synced");
+
+    // The array handed to the order-sensitive consumer is in `changed` order.
+    const changePaths = (cap.get() ?? [])
+      .filter((r) => r.kind === "change")
+      .map((r) => r.path);
+    const expected = Array.from({ length: N }, (_, i) => path(i));
+    expect(changePaths).toEqual(expected); // NOT the reverse completion order
+    // …and the pull applied the same v2 content to disk (correctness).
+    for (let i = 0; i < N; i++) {
+      expect(local.files.get(path(i))).toBe(v2[path(i)]);
+    }
+  });
+
+  it(`@req:${REQ} one failing blob fails-fast the whole pull with ZERO partial apply`, async () => {
+    const N = 50;
+    const { gh, local, wm, inner, v2 } = await buildDelta(N);
+    const v1 = nFiles(N, "v1");
+
+    // Exactly one blob fetch fails (a malformed / 404-shape response).
+    const failSha = gitSha(v2[path(25)]);
+    const transport: RestCommitTransport = async (req) => {
+      const m = isBlobGet(req);
+      if (m && m[1] === failSha) {
+        throw new Error(`GitHub request GET ${req.url} → HTTP 404: Not Found`);
+      }
+      return inner(req);
+    };
+
+    const res = await makeEngine(transport, wm, local).sync(gh.spec());
+    expect(res.status).not.toBe("synced"); // pull aborted (fail-fast)
+    // ZERO partial apply — every file still holds its pre-sync v1 content.
+    // (A per-blob swallow would apply the 49 non-failing v2 blobs → RED.)
+    for (let i = 0; i < N; i++) {
+      expect(local.files.get(path(i))).toBe(v1[path(i)]);
+    }
+  });
+
+  it(`@req:${REQ} the fetch runs with bounded concurrency (peak reaches the cap, never exceeds it) and is >=3x faster than sequential`, async () => {
+    const N = 50;
+    const L = 15; // per-blob latency
+    const { gh, local, wm, inner } = await buildDelta(N);
+
+    let inFlight = 0;
+    let maxInFlight = 0;
+    const progress: SyncProgressEvent[] = [];
+    const transport: RestCommitTransport = async (
+      req,
+    ): Promise<RestCommitResponse> => {
+      if (isBlobGet(req)) {
+        inFlight += 1;
+        maxInFlight = Math.max(maxInFlight, inFlight);
+        try {
+          await sleep(L);
+          return await inner(req);
+        } finally {
+          inFlight -= 1;
+        }
+      }
+      return inner(req);
+    };
+
+    const engine = makeEngine(transport, wm, local);
+    const t0 = Date.now();
+    const res = await engine.sync(gh.spec(), "sync", (ev) => progress.push(ev));
+    const elapsed = Date.now() - t0;
+
+    expect(res.status).toBe("synced");
+    // Real parallelism: peak in-flight reaches the cap (6). A sequential loop
+    // caps at 1 → RED. And it never EXCEEDS the cap (bounded).
+    expect(maxInFlight).toBeGreaterThanOrEqual(5);
+    expect(maxInFlight).toBeLessThanOrEqual(6);
+    // Wall-clock (CI-skipped, perf-flake rule): concurrent < sequential floor / 3.
+    // Sequential would be >= N*L ms (each of 50 blobs awaited serially @15ms).
+    expectFasterThan(elapsed, (N * L) / 3);
+
+    // Visible progress: a growing `fetching-blobs done/total` tick.
+    const ticks = progress.filter((e) => e.phase === "fetching-blobs");
+    expect(ticks.length).toBeGreaterThan(0);
+    const dones = ticks
+      .map((e) => e.detail?.done)
+      .filter((d): d is number => typeof d === "number");
+    expect(dones).toContain(10); // BLOB_PROGRESS_STEP
+    expect(Math.max(...dones)).toBeGreaterThan(Math.min(...dones)); // grows
+  });
+});


### PR DESCRIPTION
## What

Phase 2 / C of RFC `6a1a6518` — `collectRemoteChanges` fetches changed blobs with a **bounded worker pool** (cap `BLOB_FETCH_CONCURRENCY=6`) instead of one-at-a-time. A big remote delta previously ran ~0.4s × N sequentially after one "pulling remote tree…" line with nothing after → the sync **looked hung**.

Implements req `a04c4fce-c77b-4754-a3eb-b074289173f3` (Approved; RFC C). Phase 1 / A (Retry-After backoff + global per-sync budget) shipped as v16.195.0 (PR #3977), so the "solid backoff before concurrency" precondition is satisfied.

## Three load-bearing guarantees

- **INDEXED WRITE-BACK** — each fetched blob's `RemoteChange` lands at its position in a pre-sized array indexed by the `changed` order (NOT completion order). The `changes[]` array handed to the order-sensitive consumer `matchLocalVsRemote` (rename-pairs / duplicate-uid groups) is **byte-identical** to the old sequential loop.
- **FAIL-FAST** — the first blob error stops the pool from scheduling any new fetch and is rethrown **before** `matchLocalVsRemote`/apply → a failed pull applies **ZERO** files (no half-applied bulk; no unhandled rejection — each worker captures its own error).
- **BOUNDED** — cap 6 (~20× under GitHub's 100-concurrent ceiling). The visible `fetching-blobs done/total` tick is preserved (monotonic completion counter). Speed is measured with real `Date.now()`, NOT `SyncPhaseTimer` (which sums per-call durations and wouldn't drop under concurrency).

**Scope:** only the `collectRemoteChanges` pull loop. Push, the `buildWatermarkFiles` merge-base fetch, and RFC A/D/B/E/secret-scan are untouched.

## Revert-verified (production-shape integration: real `SyncEngine` over `FakeGitHubRepo`, no network)

`packages/core/tests/integration/sync/syncEngine.concurrent-pull.integration.test.ts` (`@req:a04c4fce-c77b-4754-a3eb-b074289173f3`):

| Axis | Revert mutation | Result |
|---|---|---|
| Determinism (indexed write-back) | `changeResults[i]` → completion-order write | out-of-order completion reorders `changes[]` and flips the pull outcome to `error` → **RED**; restore → **GREEN** |
| Atomicity (fail-fast) | per-blob swallow (compact) instead of rethrow | 49/50 v2 blobs partial-apply to disk → **RED**; restore → **GREEN** |
| Concurrency (bounded pool) | cap 6 → 1 (sequential) | peak in-flight = 1 (< 5) → **RED**; restore → **GREEN** |

Plus (both ways GREEN, non-vacuity + no-regression): peak in-flight ≤ 6 (cap respected), `fetching-blobs` tick grows, wall-clock ≥3× under the sequential floor (via the CI-skipping `expectFasterThan` helper — a hard wall-clock threshold would flake the CI gate).

## Testing

- New suite: 3/3 green.
- **0 sync-suite regressions** — all 37 sync-path suites (449 tests) green.
- `npm run check:types` clean; guard scripts (validate-shard-assignments / check-test-antipatterns 55/55 / check-coverage-monotonic) all pass; `eslint --max-warnings=0` clean on the changed src.

(3 pre-existing `dynamic-commands/*` submodule-fixture suites fail identically in a fresh worktree **with this change stashed** — a stale-local-submodule artifact, causally isolated: none import sync.)

Req: a04c4fce-c77b-4754-a3eb-b074289173f3
