### PR TITLE
fix(cli): key SPARQL result cache on raw query so repeats HIT (#3979)

### DIFF
--- a/packages/cli/src/commands/sparql-query.ts
+++ b/packages/cli/src/commands/sparql-query.ts
@@ -305,6 +305,17 @@ export function sparqlQueryCommand(): Command {
           );
         }
 
+        // Issue #3979: fix the write-only result cache. The cache key MUST be
+        // computed from the RAW query (as loaded here), BEFORE the later
+        // shorthand + PREFIX-injection mutations of `queryString` (see
+        // transformShorthandNotation / injectExocortexPrefixes below). Using
+        // `queryString` for both get and set silently keyed the READ on the raw
+        // query but the WRITE on the prefix-injected query → different sha256 →
+        // permanent miss + a fresh cache file every run. Capture the key once
+        // and use `cacheKeyQuery` for BOTH get and set (below). The executed
+        // query is unchanged — only the cache key is fixed.
+        const cacheKeyQuery = queryString;
+
         // Dry-run mode: validate syntax only, no vault loading
         if (options.dryRun) {
           await executeDryRun(queryString, options, outputFormat);
@@ -316,7 +327,7 @@ export function sparqlQueryCommand(): Command {
         // Check query result cache first (before vault loading)
         if (useQueryResultCache) {
           const queryResultCache = new QueryResultCache();
-          const cachedResult = await queryResultCache.get(queryString, cacheTtlSeconds);
+          const cachedResult = await queryResultCache.get(cacheKeyQuery, cacheTtlSeconds);
 
           if (cachedResult !== null) {
             const totalDuration = Date.now() - startTime;
@@ -520,7 +531,7 @@ export function sparqlQueryCommand(): Command {
               triples: JSON.parse(triplesFormatter.formatJson(resultTriples)),
             };
             const queryResultCache = new QueryResultCache();
-            await queryResultCache.set(queryString, cacheableResult, cacheTtlSeconds);
+            await queryResultCache.set(cacheKeyQuery, cacheableResult, cacheTtlSeconds);
           }
 
           if (outputFormat === "json") {
@@ -587,7 +598,7 @@ export function sparqlQueryCommand(): Command {
               bindings,
             };
             const queryResultCache = new QueryResultCache();
-            await queryResultCache.set(queryString, cacheableResult, cacheTtlSeconds);
+            await queryResultCache.set(cacheKeyQuery, cacheableResult, cacheTtlSeconds);
           }
 
           if (outputFormat === "json") {

--- a/packages/cli/tests/integration/sparql-result-cache-key-3979.integration.test.ts
+++ b/packages/cli/tests/integration/sparql-result-cache-key-3979.integration.test.ts
@@ -1,0 +1,155 @@
+/**
+ * Integration test for Issue #3979 — SPARQL result-cache read-key ≠ write-key.
+ *
+ * Bug: `query` computed the result-cache lookup key from the RAW query string
+ * (READ, before shorthand/PREFIX injection) but the store key from the
+ * PREFIX-INJECTED query string (WRITE, after `injectExocortexPrefixes`
+ * prepends the missing PREFIX lines). Since the cache key is
+ * `sha256(normalize(query))`, and almost every query omits explicit PREFIX
+ * (that's why auto-injection exists), READ and WRITE hashed different strings
+ * → permanent cache miss + a fresh file written on every run (write-only).
+ *
+ * This test drives the REAL `sparqlQueryCommand()` action in-process (real
+ * core engine via jest moduleNameMapper → core/src, real FileSystemVaultAdapter,
+ * real NoteToRDFConverter, real prefix injection, real QueryResultCache) twice
+ * against a real temp vault, keying the internal default QueryResultCache to a
+ * hermetic temp dir via HOME override. It asserts the AUTHORITATIVE
+ * `meta.queryResultCacheHit` flag (not timing): the second identical run must
+ * be a cache HIT.
+ *
+ * Revert-verify: with the fix (single raw-query cache key for both get+set)
+ * run #2 is a HIT (GREEN). Revert the fix (key from `queryString` for both) →
+ * run #2 misses because the write went under the prefix-injected key → RED.
+ *
+ * In-process (not spawn/dist) so it actually RUNS in the `test-coverage-cli`
+ * CI job (that job sets CI=true and does NOT build the CLI dist).
+ */
+import {
+  jest,
+  describe,
+  it,
+  expect,
+  beforeEach,
+  afterEach,
+} from "@jest/globals";
+import * as fs from "fs";
+import * as path from "path";
+// Default import (mutable CJS exports) so jest.spyOn(os, "homedir") works —
+// `import * as os` yields a frozen ESM namespace whose props are read-only.
+import os from "os";
+
+const { sparqlQueryCommand } =
+  await import("../../src/commands/sparql-query.js");
+
+/** A query with NO explicit PREFIX and no shorthand → injectExocortexPrefixes
+ *  prepends the standard PREFIX block, so raw !== prefix-injected. This is the
+ *  exact shape that triggers the read-key ≠ write-key bug. */
+const QUERY = "SELECT ?s WHERE { ?s ?p ?o } LIMIT 1";
+
+interface CliResponse {
+  success: boolean;
+  data?: { type?: string; count?: number; bindings?: unknown[] };
+  meta?: { queryResultCacheHit?: boolean; [k: string]: unknown };
+}
+
+describe("SPARQL result-cache key (Issue #3979)", () => {
+  let vaultDir: string;
+  let homeDir: string;
+  let consoleLogSpy: jest.SpiedFunction<typeof console.log>;
+  let processExitSpy: jest.SpiedFunction<typeof process.exit>;
+  let logged: string[];
+
+  beforeEach(() => {
+    vaultDir = fs.mkdtempSync(path.join(os.tmpdir(), "exo-3979-vault-"));
+    homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "exo-3979-home-"));
+
+    // A couple of real legacy-format assets so the query has triples to scan.
+    fs.writeFileSync(
+      path.join(vaultDir, "asset-1.md"),
+      `---\nexo__Asset_label: "Asset One"\nexo__Instance_class: "[[ems__Task]]"\n---\n`,
+    );
+    fs.writeFileSync(
+      path.join(vaultDir, "asset-2.md"),
+      `---\nexo__Asset_label: "Asset Two"\nexo__Instance_class: "[[ems__Task]]"\n---\n`,
+    );
+
+    // Redirect the default QueryResultCache dir (~/.exocortex/cache/query-results)
+    // to a hermetic temp home. NOTE: os.homedir() is memoized under jest (a
+    // process.env.HOME override does NOT take effect), so we spy on os.homedir
+    // directly — restored by jest.restoreAllMocks() in afterEach.
+    jest.spyOn(os, "homedir").mockReturnValue(homeDir);
+
+    logged = [];
+    consoleLogSpy = jest
+      .spyOn(console, "log")
+      .mockImplementation((...args: unknown[]) => {
+        logged.push(args.map((a) => String(a)).join(" "));
+      });
+    // Surface any unexpected error path (handleSparqlError → process.exit)
+    // as a thrown error rather than silently exiting the jest process.
+    processExitSpy = jest.spyOn(process, "exit").mockImplementation(((
+      code?: number,
+    ) => {
+      throw new Error(`process.exit(${code}) called unexpectedly`);
+    }) as never);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    fs.rmSync(vaultDir, { recursive: true, force: true });
+    fs.rmSync(homeDir, { recursive: true, force: true });
+  });
+
+  /** Run the real `query` command in-process and return the parsed JSON response. */
+  async function runQuery(): Promise<CliResponse> {
+    logged.length = 0;
+    const cmd = sparqlQueryCommand();
+    await cmd.parseAsync([
+      "node",
+      "query",
+      QUERY,
+      "--vault",
+      vaultDir,
+      "--output",
+      "json",
+    ]);
+
+    // In --output json mode the command emits exactly one JSON response line.
+    const jsonLine = [...logged].reverse().find((line) => {
+      try {
+        const parsed = JSON.parse(line);
+        return parsed && typeof parsed === "object" && "success" in parsed;
+      } catch {
+        return false;
+      }
+    });
+    expect(jsonLine).toBeDefined();
+    return JSON.parse(jsonLine as string) as CliResponse;
+  }
+
+  it("keys the result cache on the RAW query so an identical repeat query is a cache HIT", async () => {
+    // Run #1: cold cache → MISS (writes the result under the raw-query key).
+    const first = await runQuery();
+    expect(first.success).toBe(true);
+    expect(first.meta?.queryResultCacheHit).toBe(false);
+
+    // Run #2: identical query → must be a cache HIT. This is the sole reliable
+    // discriminator (file count is 1 either way; timing is non-deterministic).
+    // With the #3979 fix: HIT (raw-query key read finds the raw-query key write).
+    // Reverting the fix (queryString for both get+set): MISS, because the write
+    // went under the prefix-injected key → RED.
+    const second = await runQuery();
+    expect(second.success).toBe(true);
+    expect(second.meta?.queryResultCacheHit).toBe(true);
+
+    // Sanity: a cache file was actually written under the hermetic home.
+    const cacheDir = path.join(homeDir, ".exocortex", "cache", "query-results");
+    const files = fs.existsSync(cacheDir)
+      ? fs.readdirSync(cacheDir).filter((f) => f.endsWith(".json"))
+      : [];
+    expect(files.length).toBeGreaterThanOrEqual(1);
+
+    expect(processExitSpy).not.toHaveBeenCalled();
+    expect(consoleLogSpy).toHaveBeenCalled();
+  }, 60000);
+});


### PR DESCRIPTION
## Summary

Fixes #3979 — the SPARQL result cache was **write-only** (read-key ≠ write-key), so it never hit and grew unbounded.

**Root cause:** `packages/cli/src/commands/sparql-query.ts` read the cache with `queryResultCache.get(queryString, …)` where `queryString` was still the **raw** query, but wrote with `queryResultCache.set(queryString, …)` **after** `transformShorthandNotation` + `injectExocortexPrefixes` had mutated `queryString` to prepend the missing `PREFIX` lines. Because the key is `sha256(normalize(query))` and almost every query omits explicit `PREFIX`, the read hash and write hash differed → permanent miss + a fresh cache file on every run (observed 18,094 files / 191 MB).

**Fix (minimal):** capture the cache key **once** from the raw query (`const cacheKeyQuery = queryString;`, right after `loadQuery`, before any mutation) and use it for **both** `get` and `set`. The executed (prefix-injected) query is unchanged — only the cache key is fixed.

## Test (production-shape, CI-gated, revert-verified)

`packages/cli/tests/integration/sparql-result-cache-key-3979.integration.test.ts` drives the **real** `sparqlQueryCommand()` action in-process (real core engine via jest `moduleNameMapper` → `core/src`, real `FileSystemVaultAdapter` / `NoteToRDFConverter` / prefix injection / `QueryResultCache`) **twice** against a real temp vault, with the default cache dir redirected to a hermetic temp home (via `jest.spyOn(os, "homedir")` — a `HOME` env override is memoized under jest). It asserts the authoritative `meta.queryResultCacheHit` flag (not timing): run #1 is a miss, run #2 must be a HIT.

- **RED** without the fix (`queryString` for both get+set): run #2 misses because the write went under the prefix-injected key. `Expected: true, Received: false`.
- **GREEN** with the fix.

In-process (not spawn/dist) so it actually runs in the `test-coverage-cli` job (which sets `CI=true` and does not build the CLI dist).

## Caveats / deferred

- The result cache still invalidates by TTL only (no vault-change invalidation) — unchanged by this PR.
- **Deferred to a follow-up:** real cache eviction (size/count cap) + a one-time cleanup of the existing bloat. The key fix stops the write-only per-run growth, but distinct queries still accumulate without eviction.

https://claude.ai/code/session_01LLb1v7dNuL4F68q7yy7iY9
