### PR TITLE
feat(cli): bound query-result cache growth (eviction) + `cache clear`/`cache stats` (#3981)

### DIFF
--- a/packages/cli/src/cache/QueryResultCache.ts
+++ b/packages/cli/src/cache/QueryResultCache.ts
@@ -4,11 +4,34 @@ import os from "os";
 import fs from "fs-extra";
 
 /**
+ * Default eviction caps (Issue #3981). When either the entry count or the
+ * total size of the query-results cache exceeds its cap after a `set`, the
+ * oldest entries are pruned until both are back under the cap. These prevent
+ * the unbounded growth observed pre-#3979 (18,094 files / 191 MB on a real
+ * machine — distinct queries each write one file and were never proactively
+ * evicted). Cached SPARQL results are freely regenerable, so pruning is safe.
+ */
+export const DEFAULT_MAX_ENTRIES = 500;
+export const DEFAULT_MAX_SIZE_BYTES = 50 * 1024 * 1024; // 50 MB
+
+/**
  * Options for QueryResultCache constructor
  */
 export interface QueryResultCacheOptions {
   /** Custom cache directory. Defaults to ~/.exocortex/cache/query-results */
   cacheDir?: string;
+  /**
+   * Maximum number of cache entries before oldest-first eviction kicks in on
+   * `set`. Defaults to {@link DEFAULT_MAX_ENTRIES}. A non-positive / non-finite
+   * value disables the count cap.
+   */
+  maxEntries?: number;
+  /**
+   * Maximum total cache size in bytes before oldest-first eviction kicks in on
+   * `set`. Defaults to {@link DEFAULT_MAX_SIZE_BYTES}. A non-positive /
+   * non-finite value disables the size cap.
+   */
+  maxSizeBytes?: number;
 }
 
 /**
@@ -53,10 +76,14 @@ export interface QueryCacheStats {
  */
 export class QueryResultCache {
   private readonly cacheDir: string;
+  private readonly maxEntries: number;
+  private readonly maxSizeBytes: number;
 
   constructor(options: QueryResultCacheOptions = {}) {
     this.cacheDir = options.cacheDir ??
       path.join(os.homedir(), ".exocortex", "cache", "query-results");
+    this.maxEntries = options.maxEntries ?? DEFAULT_MAX_ENTRIES;
+    this.maxSizeBytes = options.maxSizeBytes ?? DEFAULT_MAX_SIZE_BYTES;
   }
 
   /**
@@ -141,6 +168,89 @@ export class QueryResultCache {
     // Write atomically to prevent corruption
     // fs-extra's writeJson creates a temp file and renames it
     await fs.writeJson(cachePath, data, { spaces: 0 });
+
+    // Issue #3981 — enforce size/count caps with oldest-first eviction so the
+    // cache directory does not grow unbounded from distinct queries. Best-effort:
+    // never let a prune failure fail the write we just committed, and never evict
+    // the entry we just wrote.
+    await this.prune(cacheKey);
+  }
+
+  /**
+   * Enforces the entry-count and total-size caps by evicting the oldest cache
+   * entries (by file mtime) until both are back within their caps. Expired
+   * entries — being the oldest writes — are naturally evicted first.
+   *
+   * Best-effort: swallows all errors (a prune failure must never fail the
+   * `set` that triggered it) and never evicts the just-written entry.
+   *
+   * @param keepKey - Cache key of the just-written entry to preserve.
+   */
+  private async prune(keepKey: string): Promise<void> {
+    try {
+      const countCapped = Number.isFinite(this.maxEntries) && this.maxEntries > 0;
+      const sizeCapped = Number.isFinite(this.maxSizeBytes) && this.maxSizeBytes > 0;
+      if (!countCapped && !sizeCapped) {
+        return;
+      }
+
+      const files = await fs.readdir(this.cacheDir);
+      const jsonFiles = files.filter(f => f.endsWith(".json"));
+
+      const entries: { path: string; mtimeMs: number; size: number }[] = [];
+      let totalSizeBytes = 0;
+      const keepFile = `${keepKey}.json`;
+      for (const file of jsonFiles) {
+        if (file === keepFile) {
+          // The just-written entry always counts toward totals but is never a
+          // prune candidate.
+          try {
+            const stat = await fs.stat(path.join(this.cacheDir, file));
+            totalSizeBytes += stat.size;
+          } catch {
+            // File vanished (concurrent prune) — ignore.
+          }
+          continue;
+        }
+        try {
+          const filePath = path.join(this.cacheDir, file);
+          const stat = await fs.stat(filePath);
+          entries.push({ path: filePath, mtimeMs: stat.mtimeMs, size: stat.size });
+          totalSizeBytes += stat.size;
+        } catch {
+          // File vanished between readdir and stat — ignore.
+        }
+      }
+
+      // +1 for the always-kept just-written entry (excluded from `entries`).
+      let entryCount = entries.length + 1;
+
+      const overCap = () =>
+        (countCapped && entryCount > this.maxEntries) ||
+        (sizeCapped && totalSizeBytes > this.maxSizeBytes);
+
+      if (!overCap()) {
+        return;
+      }
+
+      // Oldest first (smallest mtime). Expired entries sort to the front.
+      entries.sort((a, b) => a.mtimeMs - b.mtimeMs);
+
+      for (const entry of entries) {
+        if (!overCap()) {
+          break;
+        }
+        try {
+          await fs.remove(entry.path);
+          entryCount--;
+          totalSizeBytes -= entry.size;
+        } catch {
+          // Ignore — another process may have removed it.
+        }
+      }
+    } catch {
+      // Prune is best-effort — never fail the caller's `set`.
+    }
   }
 
   /**

--- a/packages/cli/src/commands/cache.ts
+++ b/packages/cli/src/commands/cache.ts
@@ -1,0 +1,106 @@
+import { Command } from "commander";
+import { QueryResultCache } from "../cache/QueryResultCache.js";
+
+/**
+ * `exocortex cache` (Issue #3981) — maintenance for the SPARQL **query-result**
+ * cache (`~/.exocortex/cache/query-results/`), the on-disk store that `query`
+ * uses to serve identical repeat queries without re-running them.
+ *
+ * Subcommands:
+ *   - `cache clear` — remove every cached query result (durable equivalent of
+ *     `find ~/.exocortex/cache/query-results -name '*.json' -delete`). Safe:
+ *     cached results are freely regenerable.
+ *   - `cache stats` — report the current entry count and total size on disk.
+ *
+ * Growth is now additionally bounded automatically: `QueryResultCache.set`
+ * evicts oldest-first once the count/size caps are exceeded (Issue #3981).
+ *
+ * Note on staleness (separate, deferred by #3981): the query-result cache
+ * invalidates by TTL only (default 300s) — a `set-property`/`apply` mutation can
+ * leave a stale cached result until the TTL elapses. For read-after-write flows
+ * prefer `query --no-cache` or a short `query --cache-ttl <seconds>`.
+ */
+export function cacheCommand(): Command {
+  const cmd = new Command("cache").description(
+    "SPARQL query-result cache maintenance (clear / stats). " +
+      "For read-after-write, prefer `query --no-cache` or a short `--cache-ttl`.",
+  );
+
+  cmd.addCommand(cacheClearCommand());
+  cmd.addCommand(cacheStatsCommand());
+
+  return cmd;
+}
+
+interface CacheClearOptions {
+  output?: "text" | "json";
+}
+
+function cacheClearCommand(): Command {
+  return new Command("clear")
+    .description("Remove all cached SPARQL query results from disk")
+    .option("--output <format>", "Output format: text | json", "text")
+    .action(async (options: CacheClearOptions) => {
+      const cache = new QueryResultCache();
+      const before = await cache.getCacheStats();
+      await cache.clear();
+
+      if (options.output === "json") {
+        console.log(
+          JSON.stringify({
+            success: true,
+            data: {
+              action: "clear",
+              cacheDir: cache.getCacheDir(),
+              clearedEntries: before.entryCount,
+              freedBytes: before.totalSizeBytes,
+            },
+          }),
+        );
+        return;
+      }
+
+      console.log(
+        `🗑️  Cleared ${before.entryCount} cached query result(s) ` +
+          `(${formatBytes(before.totalSizeBytes)} freed) from ${cache.getCacheDir()}`,
+      );
+    });
+}
+
+interface CacheStatsOptions {
+  output?: "text" | "json";
+}
+
+function cacheStatsCommand(): Command {
+  return new Command("stats")
+    .description("Show query-result cache entry count and total size")
+    .option("--output <format>", "Output format: text | json", "text")
+    .action(async (options: CacheStatsOptions) => {
+      const cache = new QueryResultCache();
+      const stats = await cache.getCacheStats();
+
+      if (options.output === "json") {
+        console.log(
+          JSON.stringify({
+            success: true,
+            data: {
+              cacheDir: cache.getCacheDir(),
+              entryCount: stats.entryCount,
+              totalSizeBytes: stats.totalSizeBytes,
+            },
+          }),
+        );
+        return;
+      }
+
+      console.log(`📊 SPARQL query-result cache: ${cache.getCacheDir()}`);
+      console.log(`   Entries: ${stats.entryCount.toLocaleString()}`);
+      console.log(`   Size:    ${formatBytes(stats.totalSizeBytes)}`);
+    });
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}

--- a/packages/cli/src/program.ts
+++ b/packages/cli/src/program.ts
@@ -22,6 +22,7 @@ import { resolveDepsCommand } from "./commands/resolve-deps.js";
 import { exosyncParityCommand } from "./commands/exosync-parity.js";
 import { exosyncCommand } from "./commands/exosync-sync.js";
 import { requirementsCommand } from "./commands/requirements.js";
+import { cacheCommand } from "./commands/cache.js";
 
 // Version injected at build time by esbuild (see esbuild.config.mjs)
 declare const __CLI_VERSION__: string;
@@ -101,6 +102,10 @@ export function createProgram(version?: string): Command {
 
   // RFC 0003 (requirements management) P1 — traceability checker
   program.addCommand(requirementsCommand());
+
+  // Issue #3981 — SPARQL query-result cache maintenance (clear / stats).
+  // Complements the automatic size/count-cap eviction in QueryResultCache.set.
+  program.addCommand(cacheCommand());
 
   return program;
 }

--- a/packages/cli/tests/integration/cache-eviction-and-clear-3981.integration.test.ts
+++ b/packages/cli/tests/integration/cache-eviction-and-clear-3981.integration.test.ts
@@ -1,0 +1,225 @@
+/**
+ * Integration test for Issue #3981 — query-result cache eviction + `cache clear`.
+ *
+ * Follow-up to #3979 (which fixed the write-only cache key so identical repeats
+ * HIT). Two concerns remained: the query-result cache grows unbounded from
+ * distinct queries (no proactive eviction) and there was no durable way to purge
+ * the accumulated bloat (18,094 files / 191 MB observed on a real machine).
+ *
+ * This test drives:
+ *  1. the REAL `QueryResultCache` (real fs I/O in a hermetic temp dir) to prove
+ *     that `set` enforces the entry-count and total-size caps with oldest-first
+ *     eviction; and
+ *  2. the REAL `cache clear` / `cache stats` CLI subcommands in-process (via
+ *     `cacheCommand().parseAsync`, with `os.homedir` redirected to a hermetic
+ *     temp home) to prove the durable purge / reporting mechanism.
+ *
+ * In-process (not spawn/dist) so it actually RUNS in the `test-coverage-cli`
+ * CI job (that job sets CI=true and does NOT build the CLI dist).
+ *
+ * Revert-verify:
+ *  - Eviction: remove the `await this.prune(cacheKey)` call at the end of
+ *    `QueryResultCache.set` → the entry count / total size grow past the caps
+ *    → the count/size assertions RED. Restore → GREEN.
+ *  - `cache clear`: turn the `await cache.clear()` call in the clear action into
+ *    a no-op → cached files remain → the empty-dir assertion RED. Restore → GREEN.
+ */
+import {
+  jest,
+  describe,
+  it,
+  expect,
+  beforeEach,
+  afterEach,
+} from "@jest/globals";
+import * as fs from "fs";
+import * as path from "path";
+// Default import (mutable CJS exports) so jest.spyOn(os, "homedir") works —
+// `import * as os` yields a frozen ESM namespace whose props are read-only.
+import os from "os";
+
+const { QueryResultCache } =
+  await import("../../src/cache/QueryResultCache.js");
+const { cacheCommand } = await import("../../src/commands/cache.js");
+
+const TTL = 3600; // large so nothing expires mid-test
+
+describe("QueryResultCache eviction (Issue #3981)", () => {
+  let cacheDir: string;
+
+  beforeEach(() => {
+    cacheDir = fs.mkdtempSync(path.join(os.tmpdir(), "exo-3981-evict-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(cacheDir, { recursive: true, force: true });
+  });
+
+  function countFiles(): number {
+    return fs.existsSync(cacheDir)
+      ? fs.readdirSync(cacheDir).filter((f) => f.endsWith(".json")).length
+      : 0;
+  }
+
+  it("@req:acc1b360-f923-49db-aeca-698944872f80 evicts oldest-first once the entry-count cap is exceeded on set", async () => {
+    const MAX = 3;
+    const cache = new QueryResultCache({
+      cacheDir,
+      maxEntries: MAX,
+      maxSizeBytes: Number.POSITIVE_INFINITY, // isolate the count cap
+    });
+
+    // Write 6 distinct queries. Without eviction the dir would hold 6 files;
+    // with the cap every set prunes back to MAX.
+    for (let i = 0; i < 6; i++) {
+      await cache.set(`SELECT ?s WHERE { ?s ?p ${i} }`, { row: i }, TTL);
+    }
+
+    const stats = await cache.getCacheStats();
+    // Core invariant — the discriminator that reverts to RED without prune:
+    expect(stats.entryCount).toBeLessThanOrEqual(MAX);
+    expect(countFiles()).toBeLessThanOrEqual(MAX);
+
+    // The just-written (newest) entry is never evicted.
+    const newest = await cache.get("SELECT ?s WHERE { ?s ?p 5 }", TTL);
+    expect(newest).toEqual({ row: 5 });
+  }, 30000);
+
+  it("@req:acc1b360-f923-49db-aeca-698944872f80 evicts the oldest entry (by mtime) first, keeping the newest", async () => {
+    const cache = new QueryResultCache({
+      cacheDir,
+      maxEntries: 2,
+      maxSizeBytes: Number.POSITIVE_INFINITY,
+    });
+
+    // Write the entry that must be evicted, then back-date its mtime so it is
+    // deterministically the oldest regardless of same-millisecond writes.
+    await cache.set("OLDEST { ?s ?p ?o }", { tag: "oldest" }, TTL);
+    const oldestFile = fs
+      .readdirSync(cacheDir)
+      .find((f) => f.endsWith(".json"))!;
+    const past = new Date(Date.now() - 60_000);
+    fs.utimesSync(path.join(cacheDir, oldestFile), past, past);
+
+    // Write 3 newer entries → count (4) exceeds cap (2) → prune runs.
+    await cache.set("NEWER_A { ?s ?p ?o }", { tag: "a" }, TTL);
+    await cache.set("NEWER_B { ?s ?p ?o }", { tag: "b" }, TTL);
+    await cache.set("NEWER_C { ?s ?p ?o }", { tag: "c" }, TTL);
+
+    // The back-dated oldest entry must be gone; the newest must survive.
+    expect(await cache.get("OLDEST { ?s ?p ?o }", TTL)).toBeNull();
+    expect(await cache.get("NEWER_C { ?s ?p ?o }", TTL)).toEqual({ tag: "c" });
+  }, 30000);
+
+  it("@req:acc1b360-f923-49db-aeca-698944872f80 evicts once the total-size cap is exceeded on set", async () => {
+    // Each result serializes to well over 1 KB; cap the cache at ~4 KB so a
+    // handful of writes must trigger size-based eviction.
+    const big = "x".repeat(2000);
+    const cache = new QueryResultCache({
+      cacheDir,
+      maxEntries: Number.POSITIVE_INFINITY, // isolate the size cap
+      maxSizeBytes: 4096,
+    });
+
+    for (let i = 0; i < 8; i++) {
+      await cache.set(`SIZE_${i} { ?s ?p ?o }`, { i, big }, TTL);
+    }
+
+    const stats = await cache.getCacheStats();
+    expect(stats.totalSizeBytes).toBeLessThanOrEqual(4096);
+    // Newest survives even under the size cap.
+    expect(await cache.get("SIZE_7 { ?s ?p ?o }", TTL)).toEqual({ i: 7, big });
+  }, 30000);
+});
+
+describe("cache clear / cache stats subcommands (Issue #3981)", () => {
+  let homeDir: string;
+  let cacheDir: string;
+  let logged: string[];
+  let consoleLogSpy: jest.SpiedFunction<typeof console.log>;
+
+  beforeEach(() => {
+    homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "exo-3981-home-"));
+    cacheDir = path.join(homeDir, ".exocortex", "cache", "query-results");
+    // os.homedir() is memoized under jest (a process.env.HOME override does NOT
+    // take effect), so spy on os.homedir directly — restored in afterEach.
+    jest.spyOn(os, "homedir").mockReturnValue(homeDir);
+
+    logged = [];
+    consoleLogSpy = jest
+      .spyOn(console, "log")
+      .mockImplementation((...args: unknown[]) => {
+        logged.push(args.map((a) => String(a)).join(" "));
+      });
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    fs.rmSync(homeDir, { recursive: true, force: true });
+  });
+
+  async function populate(n: number): Promise<void> {
+    // Populate the DEFAULT cache dir (homedir-derived) that the command reads.
+    const cache = new QueryResultCache({ cacheDir });
+    for (let i = 0; i < n; i++) {
+      await cache.set(`POP_${i} { ?s ?p ?o }`, { i }, TTL);
+    }
+  }
+
+  function jsonLine(): { success: boolean; data?: Record<string, unknown> } {
+    const line = [...logged].reverse().find((l) => {
+      try {
+        const p = JSON.parse(l);
+        return p && typeof p === "object" && "success" in p;
+      } catch {
+        return false;
+      }
+    });
+    expect(line).toBeDefined();
+    return JSON.parse(line as string);
+  }
+
+  it("@req:acc1b360-f923-49db-aeca-698944872f80 `cache clear` removes every cached query result and reports the count freed", async () => {
+    await populate(4);
+    expect(
+      fs.readdirSync(cacheDir).filter((f) => f.endsWith(".json")).length,
+    ).toBe(4);
+
+    await cacheCommand().parseAsync([
+      "node",
+      "cache",
+      "clear",
+      "--output",
+      "json",
+    ]);
+
+    // Directory is now empty of cache files.
+    const remaining = fs.existsSync(cacheDir)
+      ? fs.readdirSync(cacheDir).filter((f) => f.endsWith(".json")).length
+      : 0;
+    expect(remaining).toBe(0);
+
+    // JSON response reports what was cleared.
+    const res = jsonLine();
+    expect(res.success).toBe(true);
+    expect(res.data?.action).toBe("clear");
+    expect(res.data?.clearedEntries).toBe(4);
+  }, 30000);
+
+  it("@req:acc1b360-f923-49db-aeca-698944872f80 `cache stats` reports the current entry count", async () => {
+    await populate(3);
+
+    await cacheCommand().parseAsync([
+      "node",
+      "cache",
+      "stats",
+      "--output",
+      "json",
+    ]);
+
+    const res = jsonLine();
+    expect(res.success).toBe(true);
+    expect(res.data?.entryCount).toBe(3);
+    expect(typeof res.data?.totalSizeBytes).toBe("number");
+  }, 30000);
+});


### PR DESCRIPTION
## Summary

Follow-up to #3979 (result-cache **key** fix). Closes the two deferred concerns of #3981 for the CLI SPARQL **query-result** cache (`~/.exocortex/cache/query-results/`):

### 1. Eviction (size/count cap) — main deliverable
`QueryResultCache` previously only removed a file when an **expired** entry was **read** (`get` → delete-on-expired). Distinct queries each wrote one file and were never proactively evicted → unbounded growth (**18,094 files / 191 MB** observed on a real machine).

Now `QueryResultCache.set`, after writing the new entry, enforces caps: if `entryCount` > `maxEntries` (**default 500**) OR `totalSizeBytes` > `maxSizeBytes` (**default 50 MB**), it **prunes oldest-first** (by file mtime — so expired / least-recently-written entries go first) until both are back within cap. It **never evicts the just-written entry** and is **best-effort** (a prune failure never fails the `set`). Caps are constructor-configurable (`QueryResultCacheOptions.maxEntries` / `.maxSizeBytes`; a non-positive/non-finite value disables that cap).

### 2. `cache clear` / `cache stats` subcommands — durable cleanup
- `exocortex cache clear` — removes every cached query result (durable equivalent of `find ~/.exocortex/cache/query-results -name '*.json' -delete`, reusing `QueryResultCache.clear()`) and reports the count/bytes freed.
- `exocortex cache stats` — reports the current entry count + total size.
- Both accept `--output json`.

### Deferred (explicitly out of scope, per the issue)
Vault-mtime-aware TTL invalidation (a `set-property`/`apply` can leave a stale result until the TTL elapses). Not implemented; the `cache` command help + this PR document the guidance: for read-after-write flows prefer `query --no-cache` or a short `query --cache-ttl <seconds>`.

## Test discipline (req-first SDD, RFC 0003)
- Requirement `acc1b360-f923-49db-aeca-698944872f80` (Integration, P2) — Approved on `exoas-exo-reqs`; will be flipped **Active** only after this `@req:` token lands in `main`.
- Production-shape, CI-gated (`packages/cli/tests/integration/`), in-process (real engine, no spawn/dist so it runs in `test-coverage-cli`).
- **Revert-verified**: neutralizing `await this.prune(cacheKey)` in `QueryResultCache.set` → the 3 eviction assertions RED; neutralizing `await cache.clear()` in the clear action → the empty-dir assertion RED. Both restored → GREEN.
- `check:types` 0 errors; the 3 `lint` guard scripts (shard-assignments, test-antipatterns 55/55, coverage-monotonic) pass; existing `QueryResultCache.test.ts` (18) still green.

Closes #3981
