### PR TITLE
feat(sparql): query-time class-hierarchy resolver (req 9fddda62)

### DIFF
--- a/packages/core/src/infrastructure/sparql/ClassHierarchyResolvingStore.ts
+++ b/packages/core/src/infrastructure/sparql/ClassHierarchyResolvingStore.ts
@@ -1,0 +1,337 @@
+import type {
+  ITripleStore,
+  ITransaction,
+  GraphName,
+} from "../../interfaces/ITripleStore";
+import {
+  Triple,
+  type Subject,
+  type Predicate,
+  type Object as RDFObject,
+} from "../../domain/models/rdf/Triple";
+import { IRI } from "../../domain/models/rdf/IRI";
+import { Namespace } from "../../domain/models/rdf/Namespace";
+
+/**
+ * Query-time class-hierarchy resolver (RFC 78572fa9 Candidate B Phase 0,
+ * req `9fddda62`) — the QUERY-TIME replacement for the abandoned A2
+ * store-materialization approach.
+ *
+ * ## The dual-IRI seam it heals
+ *
+ * `NoteToRDFConverter` emits an asset's `exo__Instance_class` as the SYMBOLIC
+ * class IRI (`https://exocortex.my/ontology/<prefix>#<Local>`), while the class
+ * file's `exo__Class_superClass` / `rdfs:subClassOf` hierarchy edges key on the
+ * class file's FILE IRI subject (`obsidian://vault/<uid>.md`). So a pure-SPARQL
+ * transitive walk
+ *
+ * ```sparql
+ * ?s exo:Instance_class ?c . ?c exo:Class_superClass* <X>
+ * ```
+ *
+ * truncates at the first symbolic node: `match(<symbolic-class>, Class_superClass,
+ * undefined)` returns nothing because the edges live on the file IRI. TS consumers
+ * (`CommandResolver.getClassAncestorsWithDepth`, SHACL `TripleClassHierarchy`)
+ * bridge this internally; vault-declared pure-SPARQL preconditions / Competency
+ * Queries / analytics cannot.
+ *
+ * ## What this decorator does
+ *
+ * A thin `ITripleStore` decorator injected ONCE inside `ExoQLQueryExecutor`'s
+ * constructor, so both `BGPExecutor` and `PropertyPathExecutor` (which share the
+ * single `store.match` call) inherit it — ASK preconditions AND SELECT analytics
+ * are fixed by one mechanism.
+ *
+ * `match(subject, predicate, object)` is a **pure pass-through** for every
+ * predicate except `exo__Class_superClass` and its `rdfs:subClassOf` mirror
+ * (RFC 871 vocabulary map). For a hierarchy predicate queried with a symbolic
+ * class subject that has no direct edges, it lazily builds a memoized
+ * `symbolic-IRI → file-IRI` class index, delegates to the underlying store using
+ * the file IRI, and rewrites the returned triples' subject back to the symbolic
+ * form the caller queried (so `PropertyPathExecutor`'s per-node visited-set stays
+ * consistent across the bridge).
+ *
+ * - **Predicate-scoped** — non-hierarchy queries are byte-identical pass-through
+ *   → zero behaviour change for the rest of the engine.
+ * - **Symmetric** — a file-IRI subject with native edges short-circuits (its first
+ *   hop is direct); only symbolic subjects are bridged. So it heals BOTH the
+ *   symbolic-form and the file-IRI-form instances (whose first hop is native and
+ *   whose subsequent symbolic ancestor hops are bridged).
+ * - **Zero store growth** — the resolution is per-match and discarded; nothing is
+ *   written to the store, so `RDFSInferenceEngine` is never fed (the anti-A2
+ *   guarantee — A2 grew the store +22-27% via materialized ancestor triples).
+ * - **Reversible** — the `resolveClassHierarchy` config toggle on
+ *   `ExoQLQueryExecutor` disables the decorator entirely → baseline behaviour.
+ *
+ * ## Index lifecycle
+ *
+ * The `symbolic → file-IRI` index is built lazily on the first hierarchy match and
+ * memoized for the decorator's lifetime (one build per store-instance, O(number of
+ * classes ≈ hundreds), then per-hop O(1) lookup + the same `match` the walk already
+ * does). Because the decorator is constructed inside `ExoQLQueryExecutor`, its
+ * lifetime equals the executor's; callers that reindex the underlying store
+ * construct a fresh executor (the existing pattern), so the cache never goes stale
+ * under a live reindex.
+ */
+export class ClassHierarchyResolvingStore implements ITripleStore {
+  private static readonly EXO_CLASS_SUPER_CLASS =
+    Namespace.EXO.term("Class_superClass").value;
+  private static readonly RDFS_SUBCLASS_OF =
+    Namespace.RDFS.term("subClassOf").value;
+  private static readonly RDFS_LABEL = Namespace.RDFS.term("label").value;
+  private static readonly EXO_ASSET_LABEL =
+    Namespace.EXO.term("Asset_label").value;
+
+  private static readonly HIERARCHY_PREDICATES: ReadonlySet<string> = new Set([
+    ClassHierarchyResolvingStore.EXO_CLASS_SUPER_CLASS,
+    ClassHierarchyResolvingStore.RDFS_SUBCLASS_OF,
+  ]);
+
+  /**
+   * Memoized `symbolic class IRI value → class file IRI` map, built lazily on the
+   * first hierarchy match. The promise (not the resolved map) is memoized so that
+   * concurrent hierarchy matches trigger exactly one build.
+   */
+  private indexPromise: Promise<Map<string, IRI>> | null = null;
+
+  // ===== Optional ITripleStore surface — mirrored from the wrapped store =====
+  // Declared optional and assigned in the constructor only when the underlying
+  // store provides them, so the decorator's method-presence exactly matches the
+  // real store (callers that gate on `store.matchInGraph` / `findSubjectsByUUIDSync`
+  // see identical behaviour with or without the decorator).
+  findSubjectsByUUID?: (uuid: string) => Promise<Subject[]>;
+  findSubjectsByUUIDSync?: (uuid: string) => Subject[];
+  addToGraph?: (triple: Triple, graph: GraphName) => Promise<void>;
+  removeFromGraph?: (triple: Triple, graph: GraphName) => Promise<boolean>;
+  matchInGraph?: (
+    subject?: Subject,
+    predicate?: Predicate,
+    object?: RDFObject,
+    graph?: GraphName,
+  ) => Promise<Triple[]>;
+  getNamedGraphs?: () => Promise<IRI[]>;
+  hasGraph?: (graph: IRI) => Promise<boolean>;
+  clearGraph?: (graph: GraphName) => Promise<void>;
+  countInGraph?: (graph: GraphName) => Promise<number>;
+
+  constructor(private readonly real: ITripleStore) {
+    // Mirror the wrapped store's optional-method presence exactly. `?.bind(real)`
+    // yields the bound method when the store provides it and `undefined` when it
+    // does not — behaviourally identical to the wrapped store for the codebase's
+    // truthy / optional-chain gates (`if (!store.matchInGraph)`, `store.findSubjectsByUUIDSync?.(...)`).
+    this.findSubjectsByUUID = real.findSubjectsByUUID?.bind(real);
+    this.findSubjectsByUUIDSync = real.findSubjectsByUUIDSync?.bind(real);
+    this.addToGraph = real.addToGraph?.bind(real);
+    this.removeFromGraph = real.removeFromGraph?.bind(real);
+    this.matchInGraph = real.matchInGraph?.bind(real);
+    this.getNamedGraphs = real.getNamedGraphs?.bind(real);
+    this.hasGraph = real.hasGraph?.bind(real);
+    this.clearGraph = real.clearGraph?.bind(real);
+    this.countInGraph = real.countInGraph?.bind(real);
+  }
+
+  // ===== The one intercepted method =====
+
+  async match(
+    subject?: Subject,
+    predicate?: Predicate,
+    object?: RDFObject,
+  ): Promise<Triple[]> {
+    // Predicate-scoped early-out: only intercept the class-hierarchy predicates
+    // with a concrete IRI subject. Everything else — wildcard-predicate scans,
+    // non-hierarchy predicates, variable/blank/quoted subjects — is a byte-identical
+    // pass-through (the decorator is invisible to the rest of the engine).
+    if (
+      !predicate ||
+      !ClassHierarchyResolvingStore.HIERARCHY_PREDICATES.has(predicate.value) ||
+      !(subject instanceof IRI)
+    ) {
+      return this.real.match(subject, predicate, object);
+    }
+
+    // A subject with native hierarchy edges (a class queried by its FILE IRI —
+    // the file-IRI-form instances' first hop) resolves directly; no bridge needed.
+    // This is what makes the decorator symmetric: file-IRI first hop is native,
+    // subsequent symbolic ancestor hops are bridged below.
+    const direct = await this.real.match(subject, predicate, object);
+    if (direct.length > 0) {
+      return direct;
+    }
+
+    // No direct edges → the subject is a symbolic class IRI whose hierarchy edges
+    // live on its file IRI. Resolve it and delegate; if the subject is not a known
+    // symbolic class, the (empty) direct result stands.
+    const fileIri = await this.resolveSymbolicToFileIri(subject.value);
+    if (!fileIri) {
+      return direct;
+    }
+
+    const bridged = await this.real.match(fileIri, predicate, object);
+    if (bridged.length === 0) {
+      return bridged;
+    }
+
+    // Rewrite each bridged triple's subject back to the symbolic form the caller
+    // queried, so PropertyPathExecutor's per-node identity (visited-set keyed on
+    // `node.toString()`) stays consistent as the transitive walk climbs symbolic
+    // nodes. The predicate and object (the symbolic parent class) are preserved.
+    return bridged.map((t) => new Triple(subject, t.predicate, t.object));
+  }
+
+  private async resolveSymbolicToFileIri(
+    symbolicValue: string,
+  ): Promise<IRI | null> {
+    const index = await this.getIndex();
+    return index.get(symbolicValue) ?? null;
+  }
+
+  private getIndex(): Promise<Map<string, IRI>> {
+    if (this.indexPromise === null) {
+      this.indexPromise = this.buildIndex();
+    }
+    return this.indexPromise;
+  }
+
+  /**
+   * Build the `symbolic class IRI value → class file IRI` index by scanning the
+   * store's hierarchy triples for class file-IRI subjects, then deriving each
+   * class's symbolic form from its label — mirroring exactly what
+   * `NoteToRDFConverter.expandClassValue` emits for the instance/superclass
+   * references the walk queries.
+   */
+  private async buildIndex(): Promise<Map<string, IRI>> {
+    const index = new Map<string, IRI>();
+
+    const superPred = new IRI(ClassHierarchyResolvingStore.EXO_CLASS_SUPER_CLASS);
+    const subClassPred = new IRI(ClassHierarchyResolvingStore.RDFS_SUBCLASS_OF);
+    const hierarchyTriples = [
+      ...(await this.real.match(undefined, superPred, undefined)),
+      ...(await this.real.match(undefined, subClassPred, undefined)),
+    ];
+
+    // Class file IRIs = the subjects of hierarchy edges (a class with an OUTGOING
+    // superclass edge is the only kind of node the transitive walk ever needs to
+    // bridge — a leaf ancestor with no outgoing edge is reached as an object and
+    // never re-queried as a subject).
+    const classFileIris = new Set<string>();
+    for (const t of hierarchyTriples) {
+      if (t.subject instanceof IRI) {
+        classFileIris.add(t.subject.value);
+      }
+    }
+
+    for (const fileIriValue of classFileIris) {
+      const fileIri = new IRI(fileIriValue);
+      const symbolic = await this.deriveSymbolicForm(fileIri);
+      if (symbolic) {
+        index.set(symbolic, fileIri);
+      }
+    }
+
+    return index;
+  }
+
+  /**
+   * Derive the symbolic ontology IRI for a class file IRI from its label
+   * (`rdfs:label` preferred, `exo__Asset_label` fallback — both emitted by the
+   * converter for a class asset). Uses the SAME `prefix__Local → base/prefix#Local`
+   * rule as `NoteToRDFConverter.expandClassValue`, so the derived key exactly
+   * equals the symbolic form the walk queries.
+   */
+  private async deriveSymbolicForm(fileIri: IRI): Promise<string | null> {
+    const labelTriples = [
+      ...(await this.real.match(
+        fileIri,
+        new IRI(ClassHierarchyResolvingStore.RDFS_LABEL),
+        undefined,
+      )),
+      ...(await this.real.match(
+        fileIri,
+        new IRI(ClassHierarchyResolvingStore.EXO_ASSET_LABEL),
+        undefined,
+      )),
+    ];
+
+    for (const t of labelTriples) {
+      const value = ClassHierarchyResolvingStore.literalValue(t.object);
+      if (value === null) continue;
+      const symbolic = ClassHierarchyResolvingStore.labelToSymbolicIRI(value);
+      if (symbolic) return symbolic;
+    }
+    return null;
+  }
+
+  private static literalValue(object: RDFObject): string | null {
+    // A label object is a Literal — read its `.value` without importing Literal
+    // (avoids a circular-ish coupling; the decorator only needs the string).
+    if (
+      typeof object === "object" &&
+      object !== null &&
+      "value" in object &&
+      !(object instanceof IRI) &&
+      typeof (object as { value: unknown }).value === "string"
+    ) {
+      return (object as { value: string }).value;
+    }
+    return null;
+  }
+
+  /**
+   * `prefix__Local` label → `https://exocortex.my/ontology/prefix#Local`.
+   * Mirrors `NoteToRDFConverter.expandClassValue` exactly (same
+   * `Namespace.fromPropertyKey` + whitespace/paren guard) so the index key equals
+   * the converter's emitted class IRI.
+   */
+  private static labelToSymbolicIRI(label: string): string | null {
+    const parsed = Namespace.fromPropertyKey(label);
+    if (!parsed) return null;
+    if (/[\s()]/.test(parsed.localName)) return null;
+    return parsed.namespace.term(parsed.localName).value;
+  }
+
+  // ===== Required ITripleStore surface — pure pass-through =====
+
+  add(triple: Triple): Promise<void> {
+    return this.real.add(triple);
+  }
+
+  remove(triple: Triple): Promise<boolean> {
+    return this.real.remove(triple);
+  }
+
+  has(triple: Triple): Promise<boolean> {
+    return this.real.has(triple);
+  }
+
+  addAll(triples: Triple[]): Promise<void> {
+    return this.real.addAll(triples);
+  }
+
+  removeAll(triples: Triple[]): Promise<number> {
+    return this.real.removeAll(triples);
+  }
+
+  clear(): Promise<void> {
+    return this.real.clear();
+  }
+
+  count(): Promise<number> {
+    return this.real.count();
+  }
+
+  subjects(): Promise<Subject[]> {
+    return this.real.subjects();
+  }
+
+  predicates(): Promise<Predicate[]> {
+    return this.real.predicates();
+  }
+
+  objects(): Promise<RDFObject[]> {
+    return this.real.objects();
+  }
+
+  beginTransaction(): Promise<ITransaction> {
+    return this.real.beginTransaction();
+  }
+}

--- a/packages/core/src/infrastructure/sparql/ClassHierarchyResolvingStore.ts
+++ b/packages/core/src/infrastructure/sparql/ClassHierarchyResolvingStore.ts
@@ -52,7 +52,12 @@ import { Namespace } from "../../domain/models/rdf/Namespace";
  * consistent across the bridge).
  *
  * - **Predicate-scoped** — non-hierarchy queries are byte-identical pass-through
- *   → zero behaviour change for the rest of the engine.
+ *   → zero behaviour change for the rest of the engine. Only the DEFAULT-graph,
+ *   FORWARD transitive walk is bridged: `GRAPH { … }` named-graph hierarchy walks
+ *   (they route through `matchInGraph`, a pass-through here) and inverse
+ *   `^exo:Class_superClass` (find-subclasses; `match(undefined, pred, start)` →
+ *   variable subject → pass-through) are out of scope — the RFC targets the
+ *   default-graph forward walk.
  * - **Symmetric** — a file-IRI subject with native edges short-circuits (its first
  *   hop is direct); only symbolic subjects are bridged. So it heals BOTH the
  *   symbolic-form and the file-IRI-form instances (whose first hop is native and
@@ -63,15 +68,27 @@ import { Namespace } from "../../domain/models/rdf/Namespace";
  * - **Reversible** — the `resolveClassHierarchy` config toggle on
  *   `ExoQLQueryExecutor` disables the decorator entirely → baseline behaviour.
  *
- * ## Index lifecycle
+ * ## Index lifecycle (store-scoped, count-invalidated)
  *
  * The `symbolic → file-IRI` index is built lazily on the first hierarchy match and
- * memoized for the decorator's lifetime (one build per store-instance, O(number of
- * classes ≈ hundreds), then per-hop O(1) lookup + the same `match` the walk already
- * does). Because the decorator is constructed inside `ExoQLQueryExecutor`, its
- * lifetime equals the executor's; callers that reindex the underlying store
- * construct a fresh executor (the existing pattern), so the cache never goes stale
- * under a live reindex.
+ * cached in a process-wide `WeakMap` keyed on the WRAPPED STORE INSTANCE (not the
+ * decorator / executor), tagged with the store's triple count at build time. This
+ * matters because `ExoQLQueryExecutor` — hence this decorator — can outlive a
+ * reindex: the plugin's `SPARQLQueryService` constructs the executor ONCE and holds
+ * it for the whole session while `VaultRDFIndexer.refresh()` / `updateFile()` /
+ * `reindexPathsFromDisk()` mutate the SAME `InMemoryTripleStore` in place
+ * (`clear()`/`removeAll()` + `addAll()`). Keying on the store instance + its count:
+ *   - a reindex that adds/removes triples (class created/deleted, any file change)
+ *     changes `count()` → the next hierarchy match rebuilds the index (no staleness);
+ *   - all executors over the SAME store (e.g. `PreconditionEvaluator`'s fresh
+ *     per-evaluation executor) share the one built index → no per-evaluation
+ *     O(#classes) rebuild.
+ *
+ * Cost: one O(#classes) build per store-content change, then per-hop O(1) lookup +
+ * one cheap `count()` per hierarchy match. Known limit (rare): a mutation that keeps
+ * the triple count IDENTICAL (e.g. relabelling a class in place) is not detected
+ * until the next count-changing edit or a plugin reload — `count()` is the store's
+ * only cheap content fingerprint (no mutation/version signal is exposed).
  */
 export class ClassHierarchyResolvingStore implements ITripleStore {
   private static readonly EXO_CLASS_SUPER_CLASS =
@@ -88,11 +105,17 @@ export class ClassHierarchyResolvingStore implements ITripleStore {
   ]);
 
   /**
-   * Memoized `symbolic class IRI value → class file IRI` map, built lazily on the
-   * first hierarchy match. The promise (not the resolved map) is memoized so that
-   * concurrent hierarchy matches trigger exactly one build.
+   * Store-scoped, count-invalidated cache of the `symbolic class IRI value → class
+   * file IRI` map. Keyed on the WRAPPED store instance (so every decorator/executor
+   * over the same store shares one build) and tagged with the store's triple count
+   * at build time (so an in-place reindex that changes the count triggers a rebuild
+   * — see the class doc's "Index lifecycle"). A `WeakMap` never leaks: an entry is
+   * collected with its store.
    */
-  private indexPromise: Promise<Map<string, IRI>> | null = null;
+  private static readonly INDEX_CACHE = new WeakMap<
+    ITripleStore,
+    { count: number; index: Map<string, IRI> }
+  >();
 
   // ===== Optional ITripleStore surface — mirrored from the wrapped store =====
   // Declared optional and assigned in the constructor only when the underlying
@@ -152,7 +175,11 @@ export class ClassHierarchyResolvingStore implements ITripleStore {
     // A subject with native hierarchy edges (a class queried by its FILE IRI —
     // the file-IRI-form instances' first hop) resolves directly; no bridge needed.
     // This is what makes the decorator symmetric: file-IRI first hop is native,
-    // subsequent symbolic ancestor hops are bridged below.
+    // subsequent symbolic ancestor hops are bridged below. Load-bearing invariant:
+    // the converter NEVER emits a symbolic class IRI as a hierarchy-triple SUBJECT
+    // (Class_superClass subjects are always the class FILE IRI), so `direct` is
+    // empty for a symbolic subject — the short-circuit only fires for file-IRI
+    // subjects and never suppresses a needed bridge.
     const direct = await this.real.match(subject, predicate, object);
     if (direct.length > 0) {
       return direct;
@@ -185,11 +212,22 @@ export class ClassHierarchyResolvingStore implements ITripleStore {
     return index.get(symbolicValue) ?? null;
   }
 
-  private getIndex(): Promise<Map<string, IRI>> {
-    if (this.indexPromise === null) {
-      this.indexPromise = this.buildIndex();
+  /**
+   * Return the store-scoped index, rebuilding it when the wrapped store's triple
+   * count has changed since the cached build (an in-place reindex). Concurrent
+   * misses may both build — the result is identical, so the redundant build is
+   * harmless; within a single query the count is stable, so exactly one build runs
+   * and every later hierarchy hop hits the cache.
+   */
+  private async getIndex(): Promise<Map<string, IRI>> {
+    const count = await this.real.count();
+    const cached = ClassHierarchyResolvingStore.INDEX_CACHE.get(this.real);
+    if (cached && cached.count === count) {
+      return cached.index;
     }
-    return this.indexPromise;
+    const index = await this.buildIndex();
+    ClassHierarchyResolvingStore.INDEX_CACHE.set(this.real, { count, index });
+    return index;
   }
 
   /**

--- a/packages/core/src/infrastructure/sparql/executors/QueryExecutor.ts
+++ b/packages/core/src/infrastructure/sparql/executors/QueryExecutor.ts
@@ -34,6 +34,7 @@ import { AggregateExecutor } from "./AggregateExecutor";
 import { ConstructExecutor } from "./ConstructExecutor";
 import { ServiceExecutor, ServiceExecutorConfig } from "./ServiceExecutor";
 import { GraphExecutor } from "./GraphExecutor";
+import { ClassHierarchyResolvingStore } from "../ClassHierarchyResolvingStore";
 import { SPARQLGenerator } from "../algebra/SPARQLGenerator";
 import { IRI } from "../../../domain/models/rdf/IRI";
 import { Literal } from "../../../domain/models/rdf/Literal";
@@ -79,6 +80,20 @@ export interface QueryExecutorConfig {
    * Configuration for the ServiceExecutor (federated queries).
    */
   serviceConfig?: ServiceExecutorConfig;
+
+  /**
+   * Query-time class-hierarchy resolution (RFC 78572fa9 Candidate B Phase 0,
+   * req `9fddda62`). When enabled (the default), the triple store is wrapped in a
+   * {@link ClassHierarchyResolvingStore} decorator that bridges the symbolic↔file
+   * IRI seam for `exo__Class_superClass` / `rdfs:subClassOf` at match-time, so a
+   * pure-SPARQL transitive walk `?c exo:Class_superClass* <X>` resolves for the
+   * ~99.8% of instances whose `exo__Instance_class` object is the symbolic class
+   * IRI — with zero store growth (nothing is materialized).
+   *
+   * Set to `false` to disable the decorator entirely and restore the baseline
+   * behaviour (the reversibility / revert-verify axis).
+   */
+  resolveClassHierarchy?: boolean;
 }
 
 export class ExoQLQueryExecutor {
@@ -99,8 +114,19 @@ export class ExoQLQueryExecutor {
   private currentGraphContext?: IRI;
 
   constructor(tripleStore: ITripleStore, config: QueryExecutorConfig = {}) {
-    this.tripleStore = tripleStore;
-    this.bgpExecutor = new BGPExecutor(tripleStore);
+    // Query-time class-hierarchy resolution (req 9fddda62): wrap the store ONCE,
+    // at the very top of the ctor, so every sub-executor below (BGP →
+    // PropertyPath, Graph, Filter's UUID lookup) inherits the decorated store and
+    // both the ASK-precondition and SELECT surfaces are fixed by one mechanism.
+    // Predicate-scoped pass-through → byte-identical for every non-hierarchy query.
+    // Disabled via `resolveClassHierarchy: false` (baseline / revert-verify axis).
+    const store =
+      config.resolveClassHierarchy === false
+        ? tripleStore
+        : new ClassHierarchyResolvingStore(tripleStore);
+
+    this.tripleStore = store;
+    this.bgpExecutor = new BGPExecutor(store);
     this.filterExecutor = new FilterExecutor();
     this.optionalExecutor = new OptionalExecutor();
     this.unionExecutor = new UnionExecutor();
@@ -109,7 +135,7 @@ export class ExoQLQueryExecutor {
     this.aggregateExecutor = new AggregateExecutor();
     this.constructExecutor = new ConstructExecutor();
     this.serviceExecutor = new ServiceExecutor(config.serviceConfig);
-    this.graphExecutor = new GraphExecutor(tripleStore);
+    this.graphExecutor = new GraphExecutor(store);
     this.sparqlGenerator = new SPARQLGenerator();
 
     // Set up EXISTS evaluator for FilterExecutor
@@ -118,7 +144,7 @@ export class ExoQLQueryExecutor {
     });
 
     // Set up triple store for UUID lookup functions (exo:byUUID)
-    this.filterExecutor.setTripleStore(tripleStore);
+    this.filterExecutor.setTripleStore(store);
   }
 
   /**

--- a/packages/core/tests/integration/sparql/class-hierarchy-resolver.test.ts
+++ b/packages/core/tests/integration/sparql/class-hierarchy-resolver.test.ts
@@ -1,0 +1,299 @@
+/**
+ * Production-shape integration test for the query-time class-hierarchy resolver
+ * (RFC 78572fa9 Candidate B Phase 0, req 9fddda62).
+ *
+ * The store is built by the REAL {@link NoteToRDFConverter} over a fixture vault
+ * (NOT hand-authored triples) so the symbolic↔file-IRI seam the decorator heals is
+ * exactly the shape the converter emits in production: instances carry
+ * `exo__Instance_class` as the SYMBOLIC class IRI, while class files carry
+ * `exo__Class_superClass` / `rdfs:subClassOf` hierarchy edges on their FILE IRI.
+ *
+ * Revert-verify axis = the `resolveClassHierarchy` config toggle on
+ * ExoQLQueryExecutor (type-preserving, NOT a git-checkout): resolver ON → the
+ * transitive walk resolves for symbolic-form instances (GREEN); resolver OFF →
+ * only the zero-length seed (RED). See ~/dotfiles/.claude/rules/integration-test-revert-verify.md.
+ */
+
+import "reflect-metadata";
+import { NoteToRDFConverter } from "../../../src/services/NoteToRDFConverter";
+import type { IVaultAdapter, IFile, IFrontmatter } from "../../../src/interfaces/IVaultAdapter";
+import { InMemoryTripleStore } from "../../../src/infrastructure/rdf/InMemoryTripleStore";
+import { ExoQLQueryExecutor } from "../../../src/infrastructure/sparql/executors/QueryExecutor";
+import { SPARQLParser } from "../../../src/infrastructure/sparql/SPARQLParser";
+import { ExoQLAlgebraTranslator } from "../../../src/infrastructure/sparql/algebra/AlgebraTranslator";
+import type { AskOperation } from "../../../src/infrastructure/sparql/algebra/AlgebraOperation";
+import { IRI } from "../../../src/domain/models/rdf/IRI";
+import { Namespace } from "../../../src/domain/models/rdf/Namespace";
+
+// Symbolic class IRIs the walk queries — derived by the SAME rule the converter
+// uses (Namespace.forPrefix("test").term("Cx")). The `test` prefix is a valid
+// ad-hoc namespace (Namespace.forPrefix: /^[a-z][a-zA-Z0-9]*$/).
+const C1 = Namespace.forPrefix("test")!.term("C1").value; // .../ontology/test#C1
+const C2 = Namespace.forPrefix("test")!.term("C2").value;
+const C3 = Namespace.forPrefix("test")!.term("C3").value;
+const CY_A = Namespace.forPrefix("test")!.term("CyA").value;
+const CY_B = Namespace.forPrefix("test")!.term("CyB").value;
+
+interface FixtureNote {
+  uid: string;
+  frontmatter: IFrontmatter;
+}
+
+function makeFile(uid: string): IFile {
+  return {
+    path: `${uid}.md`,
+    basename: uid,
+    name: `${uid}.md`,
+    extension: "md",
+    parent: null,
+  } as unknown as IFile;
+}
+
+/**
+ * Build a real store from fixture notes through NoteToRDFConverter — the
+ * production emission path (converts each note's frontmatter + resolves its
+ * wikilinks via the mock vault, then aggregates into an InMemoryTripleStore).
+ */
+async function buildStore(notes: FixtureNote[]): Promise<InMemoryTripleStore> {
+  const files = notes.map((n) => makeFile(n.uid));
+  const fmByPath = new Map<string, IFrontmatter>();
+  const fileByBasename = new Map<string, IFile>();
+  notes.forEach((n, i) => {
+    fmByPath.set(files[i].path, n.frontmatter);
+    fileByBasename.set(n.uid, files[i]);
+  });
+
+  const mockVault = {
+    getAllFiles: jest.fn(() => files),
+    getFrontmatter: jest.fn((f: IFile) => fmByPath.get(f.path) ?? null),
+    getFirstLinkpathDest: jest.fn(
+      (linkpath: string) => fileByBasename.get(linkpath) ?? null,
+    ),
+    read: jest.fn().mockResolvedValue(""),
+    create: jest.fn(),
+    modify: jest.fn(),
+    delete: jest.fn(),
+    exists: jest.fn(),
+    getAbstractFileByPath: jest.fn(),
+    updateFrontmatter: jest.fn(),
+    rename: jest.fn(),
+    createFolder: jest.fn(),
+    process: jest.fn(),
+    updateLinks: jest.fn(),
+    getDefaultNewFileParent: jest.fn(),
+  } as unknown as jest.Mocked<IVaultAdapter>;
+
+  const converter = new NoteToRDFConverter(mockVault);
+  const store = new InMemoryTripleStore();
+  for (const file of files) {
+    const triples = await converter.convertNote(file);
+    await store.addAll(triples);
+  }
+  return store;
+}
+
+const parser = new SPARQLParser();
+const translator = new ExoQLAlgebraTranslator();
+
+async function runSelect(
+  store: InMemoryTripleStore,
+  sparql: string,
+  variable: string,
+  resolveClassHierarchy: boolean,
+): Promise<string[]> {
+  const algebra = translator.translate(parser.parse(sparql));
+  const executor = new ExoQLQueryExecutor(store, { resolveClassHierarchy });
+  const solutions = await executor.executeAll(algebra);
+  return solutions
+    .map((s) => {
+      const v = s.get(variable);
+      return v instanceof IRI ? v.value : undefined;
+    })
+    .filter((v): v is string => v !== undefined);
+}
+
+async function runAsk(
+  store: InMemoryTripleStore,
+  sparql: string,
+  resolveClassHierarchy: boolean,
+): Promise<boolean> {
+  const algebra = translator.translate(parser.parse(sparql));
+  const executor = new ExoQLQueryExecutor(store, { resolveClassHierarchy });
+  // Mirrors PreconditionEvaluator.evaluateSparqlAsk → executor.executeAsk.
+  return executor.executeAsk(algebra as AskOperation);
+}
+
+const PREFIX = `PREFIX exo: <https://exocortex.my/ontology/exo#>`;
+
+// C1 ⊑ C2 ⊑ C3. Instance A → C1 via UID-form ref to a LABELED class (converter
+// emits the SYMBOLIC class IRI — the ~99.8% real-vault shape). Instance B → a
+// LABELLESS class C1b (whose Instance_class value the converter emits as the FILE
+// IRI, the #3242 form) that itself ⊑ C2, exercising the symmetric first-hop-native
+// / subsequent-hop-bridged path.
+const HIERARCHY_NOTES: FixtureNote[] = [
+  { uid: "c3000000-0000-4000-8000-000000000000", frontmatter: { exo__Asset_uid: "c3000000-0000-4000-8000-000000000000", exo__Asset_label: "test__C3" } },
+  { uid: "c2000000-0000-4000-8000-000000000000", frontmatter: { exo__Asset_uid: "c2000000-0000-4000-8000-000000000000", exo__Asset_label: "test__C2", exo__Class_superClass: "[[c3000000-0000-4000-8000-000000000000]]" } },
+  { uid: "c1000000-0000-4000-8000-000000000000", frontmatter: { exo__Asset_uid: "c1000000-0000-4000-8000-000000000000", exo__Asset_label: "test__C1", exo__Class_superClass: "[[c2000000-0000-4000-8000-000000000000]]" } },
+  // A — symbolic-form instance (Instance_class object = <test#C1>)
+  { uid: "aaaa0000-0000-4000-8000-000000000000", frontmatter: { exo__Asset_uid: "aaaa0000-0000-4000-8000-000000000000", exo__Asset_label: "Instance A", exo__Instance_class: "[[c1000000-0000-4000-8000-000000000000]]" } },
+  // C1b — LABELLESS class ⊑ C2 (its Instance_class value emits as a FILE IRI)
+  { uid: "c1b00000-0000-4000-8000-000000000000", frontmatter: { exo__Asset_uid: "c1b00000-0000-4000-8000-000000000000", exo__Class_superClass: "[[c2000000-0000-4000-8000-000000000000]]" } },
+  // B — file-IRI-form instance (Instance_class object = <obsidian://vault/c1b....md>)
+  { uid: "bbbb0000-0000-4000-8000-000000000000", frontmatter: { exo__Asset_uid: "bbbb0000-0000-4000-8000-000000000000", exo__Asset_label: "Instance B", exo__Instance_class: "[[c1b00000-0000-4000-8000-000000000000]]" } },
+];
+
+describe("query-time class-hierarchy resolver (req 9fddda62)", () => {
+  describe("CQ1 — transitive walk resolves at match-time for symbolic-form instances", () => {
+    // The walk `?s exo:Instance_class ?c . ?c exo:Class_superClass* <C3>` — the two
+    // BGP-triple form. Both `?s Instance_class ?c` (BGPExecutor) and the property
+    // path (PropertyPathExecutor) route through the single decorated store.match.
+    const cq1 = `${PREFIX}
+      SELECT ?s WHERE {
+        ?s exo:Instance_class ?c .
+        ?c exo:Class_superClass* <${C3}> .
+      }`;
+
+    it("@req:9fddda62-be7f-453f-9f69-94f7d6835f1c returns the symbolic-form instance A when the resolver is ON (GREEN)", async () => {
+      const store = await buildStore(HIERARCHY_NOTES);
+      const instances = await runSelect(store, cq1, "s", true);
+      expect(instances).toContain("obsidian://vault/aaaa0000-0000-4000-8000-000000000000.md");
+    });
+
+    it("@req:9fddda62-be7f-453f-9f69-94f7d6835f1c does NOT return A when the resolver is OFF (RED — revert-verify)", async () => {
+      const store = await buildStore(HIERARCHY_NOTES);
+      const instances = await runSelect(store, cq1, "s", false);
+      // Without the decorator, the walk truncates at the first symbolic node —
+      // A is unreachable (the zero-length `*` seed only matches ?c = <C3> itself,
+      // and no instance is directly Instance_class = <C3>).
+      expect(instances).not.toContain("obsidian://vault/aaaa0000-0000-4000-8000-000000000000.md");
+    });
+
+    it("@req:9fddda62-be7f-453f-9f69-94f7d6835f1c also resolves the DIRECT-parent walk (C1 ⊑ C2) for symbolic instances", async () => {
+      const store = await buildStore(HIERARCHY_NOTES);
+      const cq = `${PREFIX}
+        SELECT ?s WHERE {
+          ?s exo:Instance_class ?c .
+          ?c exo:Class_superClass* <${C2}> .
+        }`;
+      expect(await runSelect(store, cq, "s", true)).toContain("obsidian://vault/aaaa0000-0000-4000-8000-000000000000.md");
+      expect(await runSelect(store, cq, "s", false)).not.toContain("obsidian://vault/aaaa0000-0000-4000-8000-000000000000.md");
+    });
+  });
+
+  describe("CQ2 — file-IRI-form instances heal too (symmetric bridge)", () => {
+    const cq = `${PREFIX}
+      SELECT ?s WHERE {
+        ?s exo:Instance_class ?c .
+        ?c exo:Class_superClass* <${C3}> .
+      }`;
+
+    it("@req:9fddda62-be7f-453f-9f69-94f7d6835f1c returns the file-IRI-form instance B when the resolver is ON (first hop native, ancestor hops bridged)", async () => {
+      const store = await buildStore(HIERARCHY_NOTES);
+      const instances = await runSelect(store, cq, "s", true);
+      expect(instances).toContain("obsidian://vault/bbbb0000-0000-4000-8000-000000000000.md");
+    });
+
+    it("@req:9fddda62-be7f-453f-9f69-94f7d6835f1c does NOT return B when the resolver is OFF (its C2→C3 hop truncates at the symbolic node)", async () => {
+      const store = await buildStore(HIERARCHY_NOTES);
+      const instances = await runSelect(store, cq, "s", false);
+      expect(instances).not.toContain("obsidian://vault/bbbb0000-0000-4000-8000-000000000000.md");
+    });
+  });
+
+  describe("ZERO store growth — the anti-A2 guarantee", () => {
+    it("@req:9fddda62-be7f-453f-9f69-94f7d6835f1c the store triple-count is identical before/after the resolver-enabled query and equal whether the resolver is ON or OFF", async () => {
+      const store = await buildStore(HIERARCHY_NOTES);
+      const cq = `${PREFIX}
+        SELECT ?s WHERE {
+          ?s exo:Instance_class ?c .
+          ?c exo:Class_superClass* <${C3}> .
+        }`;
+
+      const before = await store.count();
+      // Sanity: the resolver actually did something (A resolved) — otherwise the
+      // count-equality below would be vacuous.
+      expect(await runSelect(store, cq, "s", true)).toContain("obsidian://vault/aaaa0000-0000-4000-8000-000000000000.md");
+      const afterOn = await store.count();
+      await runSelect(store, cq, "s", false);
+      const afterOff = await store.count();
+
+      expect(afterOn).toBe(before); // nothing materialized during the resolved walk
+      expect(afterOff).toBe(before);
+      // No inferred/ancestor Instance_class triple ever entered the store: A's
+      // rdf:type / Instance_class edges point ONLY at its direct class <C1>.
+      const ancestorTypeTriples = await store.match(
+        new IRI("obsidian://vault/aaaa0000-0000-4000-8000-000000000000.md"),
+        new IRI(Namespace.EXO.term("Instance_class").value),
+        undefined,
+      );
+      const objects = ancestorTypeTriples.map((t) => (t.object as IRI).value);
+      expect(objects).toEqual([C1]);
+      expect(objects).not.toContain(C2);
+      expect(objects).not.toContain(C3);
+    });
+  });
+
+  describe("predicate-scoped — non-hierarchy queries are byte-identical", () => {
+    it("@req:9fddda62-be7f-453f-9f69-94f7d6835f1c a query that never references the hierarchy predicates returns an identical result set ON vs OFF (pure pass-through)", async () => {
+      const store = await buildStore(HIERARCHY_NOTES);
+      const cq = `${PREFIX}
+        SELECT ?s WHERE { ?s exo:Instance_class ?c }`;
+      const on = (await runSelect(store, cq, "s", true)).sort();
+      const off = (await runSelect(store, cq, "s", false)).sort();
+      expect(on).toEqual(off);
+      expect(on).toContain("obsidian://vault/aaaa0000-0000-4000-8000-000000000000.md");
+    });
+  });
+
+  describe("both surfaces resolve — ASK precondition (PreconditionEvaluator.executeAsk path) + SELECT", () => {
+    // CQ3 — the precondition shape: a sequence path Instance_class/Class_superClass*.
+    // Runs through executor.executeAsk, exactly as PreconditionEvaluator does.
+    const askFor = (target: string, ancestor: string) => `${PREFIX}
+      ASK { <${target}> exo:Instance_class/exo:Class_superClass* <${ancestor}> }`;
+    const A_IRI = "obsidian://vault/aaaa0000-0000-4000-8000-000000000000.md";
+
+    it("@req:9fddda62-be7f-453f-9f69-94f7d6835f1c ASK gates TRUE for a symbolic-form instance when the resolver is ON, FALSE when OFF", async () => {
+      const store = await buildStore(HIERARCHY_NOTES);
+      expect(await runAsk(store, askFor(A_IRI, C3), true)).toBe(true);
+      expect(await runAsk(store, askFor(A_IRI, C3), false)).toBe(false);
+    });
+
+    it("@req:9fddda62-be7f-453f-9f69-94f7d6835f1c ASK is FALSE for a NON-ancestor class even with the resolver ON (negative control — non-vacuity)", async () => {
+      const store = await buildStore(HIERARCHY_NOTES);
+      const unrelated = Namespace.forPrefix("test")!.term("Unrelated").value;
+      expect(await runAsk(store, askFor(A_IRI, unrelated), true)).toBe(false);
+    });
+  });
+
+  describe("cycle-safe walk", () => {
+    // Malformed hierarchy: CyA ⊑ CyB ⊑ CyA. The transitive walk must terminate
+    // (PropertyPathExecutor's visited-set / MAX_DEPTH holds across the bridge).
+    // UIDs are valid-hex so the class refs resolve to SYMBOLIC parents (the
+    // UID-canon shape) — `isUUID` gates the symbolic-emission path in the converter.
+    const CYCLE_NOTES: FixtureNote[] = [
+      { uid: "ca100000-0000-4000-8000-000000000000", frontmatter: { exo__Asset_uid: "ca100000-0000-4000-8000-000000000000", exo__Asset_label: "test__CyA", exo__Class_superClass: "[[cb100000-0000-4000-8000-000000000000]]" } },
+      { uid: "cb100000-0000-4000-8000-000000000000", frontmatter: { exo__Asset_uid: "cb100000-0000-4000-8000-000000000000", exo__Asset_label: "test__CyB", exo__Class_superClass: "[[ca100000-0000-4000-8000-000000000000]]" } },
+      { uid: "c1100000-0000-4000-8000-000000000000", frontmatter: { exo__Asset_uid: "c1100000-0000-4000-8000-000000000000", exo__Asset_label: "Cycle instance", exo__Instance_class: "[[ca100000-0000-4000-8000-000000000000]]" } },
+    ];
+
+    it("@req:9fddda62-be7f-453f-9f69-94f7d6835f1c terminates and resolves CyA ⊑ CyB across the cyclic bridge", async () => {
+      const store = await buildStore(CYCLE_NOTES);
+      const cq = `${PREFIX}
+        SELECT ?s WHERE {
+          ?s exo:Instance_class ?c .
+          ?c exo:Class_superClass* <${CY_B}> .
+        }`;
+      // If the visited-set were not honoured across the bridge this would hang.
+      const instances = await runSelect(store, cq, "s", true);
+      expect(instances).toContain("obsidian://vault/c1100000-0000-4000-8000-000000000000.md");
+      // And a walk to a class OUTSIDE the cycle still terminates (returns nothing).
+      const outside = `${PREFIX}
+        SELECT ?s WHERE {
+          ?s exo:Instance_class ?c .
+          ?c exo:Class_superClass* <${Namespace.forPrefix("test")!.term("Outside").value}> .
+        }`;
+      expect(await runSelect(store, outside, "s", true)).toEqual([]);
+      void [CY_A]; // referenced for symmetry / documentation
+    });
+  });
+});

--- a/packages/core/tests/integration/sparql/class-hierarchy-resolver.test.ts
+++ b/packages/core/tests/integration/sparql/class-hierarchy-resolver.test.ts
@@ -50,11 +50,12 @@ function makeFile(uid: string): IFile {
 }
 
 /**
- * Build a real store from fixture notes through NoteToRDFConverter — the
+ * Convert fixture notes to triples through the real NoteToRDFConverter — the
  * production emission path (converts each note's frontmatter + resolves its
- * wikilinks via the mock vault, then aggregates into an InMemoryTripleStore).
+ * wikilinks via a mock vault). The mock resolves ANY of `notes` (so a class ref
+ * from one note resolves to its target note).
  */
-async function buildStore(notes: FixtureNote[]): Promise<InMemoryTripleStore> {
+async function convertNotes(notes: FixtureNote[]) {
   const files = notes.map((n) => makeFile(n.uid));
   const fmByPath = new Map<string, IFrontmatter>();
   const fileByBasename = new Map<string, IFile>();
@@ -84,11 +85,20 @@ async function buildStore(notes: FixtureNote[]): Promise<InMemoryTripleStore> {
   } as unknown as jest.Mocked<IVaultAdapter>;
 
   const converter = new NoteToRDFConverter(mockVault);
-  const store = new InMemoryTripleStore();
+  const out = [];
   for (const file of files) {
-    const triples = await converter.convertNote(file);
-    await store.addAll(triples);
+    out.push(...(await converter.convertNote(file)));
   }
+  return out;
+}
+
+/**
+ * Build a real store from fixture notes (aggregate `convertNotes` into an
+ * InMemoryTripleStore).
+ */
+async function buildStore(notes: FixtureNote[]): Promise<InMemoryTripleStore> {
+  const store = new InMemoryTripleStore();
+  await store.addAll(await convertNotes(notes));
   return store;
 }
 
@@ -294,6 +304,50 @@ describe("query-time class-hierarchy resolver (req 9fddda62)", () => {
         }`;
       expect(await runSelect(store, outside, "s", true)).toEqual([]);
       void [CY_A]; // referenced for symmetry / documentation
+    });
+  });
+
+  describe("index invalidates on store mutation — a LONG-LIVED executor survives a reindex", () => {
+    // The plugin's SPARQLQueryService constructs the executor ONCE and mutates the
+    // SAME store in place on reindex (clear/removeAll + addAll). A class added after
+    // the first hierarchy match (which builds the index) MUST become visible without
+    // reconstructing the executor — the store-scoped, count-invalidated index cache.
+    it("@req:9fddda62-be7f-453f-9f69-94f7d6835f1c a class added to the store after the index was built resolves through the SAME executor", async () => {
+      const store = await buildStore(HIERARCHY_NOTES);
+      // ONE long-lived executor, reused across queries (the SPARQLQueryService shape).
+      const executor = new ExoQLQueryExecutor(store, { resolveClassHierarchy: true });
+      const cq = translator.translate(
+        parser.parse(`${PREFIX}
+          SELECT ?s WHERE {
+            ?s exo:Instance_class ?c .
+            ?c exo:Class_superClass* <${C3}> .
+          }`),
+      );
+      const values = async () =>
+        (await executor.executeAll(cq))
+          .map((s) => (s.get("s") instanceof IRI ? (s.get("s") as IRI).value : undefined))
+          .filter((v): v is string => v !== undefined);
+
+      // First query builds the index (count = N).
+      expect(await values()).toContain("obsidian://vault/aaaa0000-0000-4000-8000-000000000000.md");
+      const A0 = "obsidian://vault/a0000000-0000-4000-8000-000000000000.md";
+      expect(await values()).not.toContain(A0);
+
+      // Mid-session reindex-add: a NEW class C0 ⊑ C1 + instance A0 → C0, mutated into
+      // the SAME store (count changes). The C1 note is included only so C0's parent
+      // ref resolves (its triples dedup on addAll).
+      const delta = await convertNotes([
+        HIERARCHY_NOTES[2], // C1 (for resolution; dedup)
+        { uid: "c0000000-0000-4000-8000-000000000000", frontmatter: { exo__Asset_uid: "c0000000-0000-4000-8000-000000000000", exo__Asset_label: "test__C0", exo__Class_superClass: "[[c1000000-0000-4000-8000-000000000000]]" } },
+        { uid: "a0000000-0000-4000-8000-000000000000", frontmatter: { exo__Asset_uid: "a0000000-0000-4000-8000-000000000000", exo__Asset_label: "Instance A0", exo__Instance_class: "[[c0000000-0000-4000-8000-000000000000]]" } },
+      ]);
+      await store.addAll(delta);
+
+      // The SAME executor now resolves A0 (index rebuilt because count changed).
+      // Without count-invalidation the stale index would omit C0 → A0 missing (RED).
+      expect(await values()).toContain(A0);
+      // ...and the original instance A still resolves.
+      expect(await values()).toContain("obsidian://vault/aaaa0000-0000-4000-8000-000000000000.md");
     });
   });
 });


### PR DESCRIPTION
## Query-time class-hierarchy resolver (req `9fddda62`, RFC 78572fa9 Candidate B Phase 0)

The QUERY-TIME replacement for the abandoned A2 store-materialization (req `0cf3f6ed`, Deprecated) — A2 grew the store +22-27% by materializing inferred ancestor triples via `RDFSInferenceEngine`. This resolves the same #3805 Facet-1 seam with **zero store growth**.

### The seam

`NoteToRDFConverter` emits an asset's `exo__Instance_class` as the **symbolic** class IRI (`.../ontology/<prefix>#<Local>`), while the class file's `exo__Class_superClass` / `rdfs:subClassOf` hierarchy edges key on the class file's **file** IRI. So a pure-SPARQL walk `?s exo:Instance_class ?c . ?c exo:Class_superClass* <X>` truncates at the first symbolic node — `match(<symbolic-class>, Class_superClass, undefined)` is empty. TS consumers bridge this internally; vault-declared pure-SPARQL preconditions / Competency Queries could not.

### Design (Andrey R22-decided — Approach A)

`ClassHierarchyResolvingStore implements ITripleStore`, injected **once** at the top of `ExoQLQueryExecutor`'s constructor → both `BGPExecutor` and `PropertyPathExecutor` (which share `store.match`) inherit it, and both the **ASK precondition** and **SELECT** surfaces are fixed by one mechanism.

- **Predicate-scoped** — pass-through for every predicate except `exo__Class_superClass` / `rdfs:subClassOf` → byte-identical for the rest of the engine (mitigates the RFC's "hidden global behaviour" concern).
- **Memoized `symbolic → file-IRI` index** — built lazily on first hierarchy match (O(#classes), one build per store-instance), derived from each class's label via the same `Namespace.fromPropertyKey` rule the converter's `expandClassValue` uses → the index key exactly equals the emitted class IRI.
- **Symmetric** — a subject with native edges (file-IRI-form instances' first hop) resolves directly; only symbolic subjects are bridged → heals both the symbolic-form and the file-IRI-form instances.
- **Zero store growth** — resolution is per-match and discarded; nothing is written → `RDFSInferenceEngine` is never fed.
- **Reversible** — `resolveClassHierarchy` config toggle (default ON) disables the decorator → baseline.

### Files
- `packages/core/src/infrastructure/sparql/ClassHierarchyResolvingStore.ts` (new)
- `packages/core/src/infrastructure/sparql/executors/QueryExecutor.ts` (config flag + single-point injection)
- `packages/core/tests/integration/sparql/class-hierarchy-resolver.test.ts` (new, `@req`-tagged)

### Revert-verified (`@req:9fddda62-be7f-453f-9f69-94f7d6835f1c`)

Production-shape store built via the **real** `NoteToRDFConverter` over a fixture vault (NOT hand-authored triples). Revert axis = the `resolveClassHierarchy` config toggle (type-preserving, not git-checkout):

- CQ1 transitive walk: resolver **ON → symbolic-form instance A returned (GREEN)**; **OFF → NOT returned (RED)**.
- CQ2 symmetric bridge: file-IRI-form instance B **ON → returned / OFF → not**.
- Zero-store-growth: `store.count()` identical before/after + ON vs OFF; A's `Instance_class` objects = `[<test#C1>]` only (no ancestor materialized).
- Predicate-scoped: a non-hierarchy query is identical ON vs OFF.
- ASK (PreconditionEvaluator.executeAsk path): TRUE ON / FALSE OFF + negative-control (non-ancestor → FALSE ON).
- Cycle-safe: malformed `CyA ⊑ CyB ⊑ CyA` terminates across the bridge.

Full `packages/core` suite: **8467 passed** (the 3 wall-clock timing suites that flaked locally under load all pass under `CI=true` / are `tests/performance/**` CI-excluded — `perf-tests-dont-hard-gate-ci`). No behaviour regression from the default-ON decorator.

**Auto-merge discipline** (`packages/core/src/infrastructure/sparql/**` engine path): code-reviewer + manual squash-merge (no `--auto`).

Req: 9fddda62-be7f-453f-9f69-94f7d6835f1c
