### PR TITLE
fix(@req:5579ffa1): de-hack prototype precondition to native exo:Class_superClass* walk

### DIFF
--- a/packages/core/tests/integration/dynamic-commands/PrototypePreconditionForgetGuard.test.ts
+++ b/packages/core/tests/integration/dynamic-commands/PrototypePreconditionForgetGuard.test.ts
@@ -7,8 +7,10 @@
  * ems__Task/Project/Area/Meeting/Session — NOT exo__Asset, NOT a prototype
  * class, NOT a class metaclass) carries a command-level
  * `exocmd__Command_precondition` whose precondition tree ENFORCES the canonical
- * not-a-prototype clause
- * (`FILTER NOT EXISTS { … exo:Instance_class … STRENDS(…, "Prototype") … }`).
+ * not-a-prototype clause — the native transitive super-class walk
+ * (`FILTER NOT EXISTS { … exo:Instance_class … exo:Class_superClass* … exo:Prototype }`),
+ * de-hacked from the earlier STRENDS name-suffix check (req 5579ffa1 + resolver
+ * req 9fddda62).
  *
  * The clause may live on the direct precondition's flat `exocmd__Precondition_sparqlAsk`
  * OR nested inside a `exocmd__AllPrecondition_preconditions` / `exocmd__AnyPrecondition_preconditions`
@@ -48,9 +50,10 @@ const LIFECYCLE_TARGET_CLASSES = new Set([
 ]);
 const UNIVERSAL_TARGET_CLASSES = new Set(["exo__Asset"]);
 
-// STRENDS not-a-prototype clause (suffix check on the symbolic instance_class IRI).
+// Native not-a-prototype clause: a NOT-EXISTS over the transitive super-class walk
+// from the target's instance_class up to exo:Prototype (de-hacked from STRENDS).
 const NOT_A_PROTOTYPE_CLAUSE_RE =
-  /FILTER\s+NOT\s+EXISTS\s*\{[^}]*Instance_class[^}]*STRENDS\s*\(\s*STR\s*\(\s*\?\w+\s*\)\s*,\s*["']Prototype["']\s*\)[^}]*\}/i;
+  /FILTER\s+NOT\s+EXISTS\s*\{[^}]*Instance_class[^}]*Class_superClass[^}]*Prototype[^}]*\}/i;
 
 interface Asset {
   uid: string;
@@ -157,34 +160,36 @@ const IS_PROTOTYPE_ATOMIC_UIDS = new Set([
   "011eb4d6-c95d-4a22-b08d-29961e056961", // "Is prototype"
 ]);
 
-// Positive "is a prototype" check — the STRENDS suffix on the instance_class IRI
-// WITHOUT the `FILTER NOT EXISTS` wrapper. Shape FALLBACK for a hypothetical future
-// pure-IsPrototype atomic whose UID is not yet in IS_PROTOTYPE_ATOMIC_UIDS.
-const IS_PROTOTYPE_STRENDS_RE =
-  /Instance_class[\s\S]*?STRENDS\s*\(\s*STR\s*\(\s*\?\w+\s*\)\s*,\s*["']Prototype["']\s*\)/i;
+// Positive "is a prototype" check — the transitive super-class walk from
+// instance_class up to exo:Prototype, WITHOUT the `FILTER NOT EXISTS` wrapper.
+// Shape FALLBACK for a hypothetical future pure-IsPrototype atomic whose UID is
+// not yet in IS_PROTOTYPE_ATOMIC_UIDS.
+const IS_PROTOTYPE_WALK_RE =
+  /Instance_class[\s\S]*?Class_superClass[\s\S]*?Prototype/i;
 
 /**
- * True iff the ask is a PURE positive "target IS a prototype" check: the STRENDS
- * suffix, no `NOT EXISTS` wrapper, no `UNION` branch, and no ADDITIONAL narrowing
- * `FILTER` beyond the prototype one. A narrowed check (`… STRENDS "Prototype" …
- * FILTER(?extra)`) matches a strict *subset* of prototypes, so negating it (`¬child`)
- * would NOT guarantee not-a-prototype — rejecting a second `FILTER` closes that hole.
- * The SOUND recognition path is UID-identity (`IS_PROTOTYPE_ATOMIC_UIDS`); this shape
- * check is only the fallback for a future canonical atomic with a new UID.
+ * True iff the ask is a PURE positive "target IS a prototype" check: the
+ * `exo:Class_superClass*` walk reaching exo:Prototype, no `NOT EXISTS` wrapper, no
+ * `UNION` branch, and NO narrowing `FILTER`. A narrowed check (`… Class_superClass*
+ * exo:Prototype … FILTER(?extra)`) matches a strict *subset* of prototypes, so
+ * negating it (`¬child`) would NOT guarantee not-a-prototype — rejecting any FILTER
+ * closes that hole. The SOUND recognition path is UID-identity
+ * (`IS_PROTOTYPE_ATOMIC_UIDS`); this shape check is only the fallback for a future
+ * canonical atomic with a new UID.
  */
 function askIsPositivePrototypeCheck(ask: string): boolean {
-  if (!IS_PROTOTYPE_STRENDS_RE.test(ask)) return false;
+  if (!IS_PROTOTYPE_WALK_RE.test(ask)) return false;
   if (/NOT\s+EXISTS/i.test(ask) || /\bUNION\b/i.test(ask)) return false;
-  // A pure IsPrototype has exactly ONE FILTER (the STRENDS one); any extra FILTER
-  // narrows the match to a subset of prototypes → not sound to negate.
+  // A pure IsPrototype walk has NO FILTER; any FILTER narrows the match to a
+  // subset of prototypes → not sound to negate.
   const filterCount = (ask.match(/FILTER\s*\(/gi) || []).length;
-  return filterCount <= 1;
+  return filterCount === 0;
 }
 
 /**
  * True iff a flat ask ENFORCES not-a-prototype: it carries the canonical
- * `FILTER NOT EXISTS { … STRENDS "Prototype" … }` clause AND is not defeated by a
- * sibling `UNION` branch a prototype could satisfy.
+ * `FILTER NOT EXISTS { … exo:Class_superClass* … exo:Prototype }` clause AND is not
+ * defeated by a sibling `UNION` branch a prototype could satisfy.
  */
 function askEnforcesNotPrototypeFlat(ask: string): boolean {
   return NOT_A_PROTOTYPE_CLAUSE_RE.test(ask) && !/\bUNION\b/i.test(ask);
@@ -349,7 +354,7 @@ describe("prototype precondition — forget-leak guard (exoas-exocmd submodule) 
 // ---------------------------------------------------------------------------
 describe("enforcesNotPrototype — AND/OR composite detection semantics", () => {
   const CLAUSE =
-    'PREFIX exo: <https://exocortex.my/ontology/exo#> ASK { FILTER NOT EXISTS { $target exo:Instance_class ?p . FILTER(STRENDS(STR(?p), "Prototype")) } }';
+    'PREFIX exo: <https://exocortex.my/ontology/exo#> ASK { FILTER NOT EXISTS { $target exo:Instance_class ?p . ?p exo:Class_superClass* exo:Prototype } }';
   const PLAIN =
     "PREFIX exo: <https://exocortex.my/ontology/exo#> ASK { $target exo:Instance_class ?c . FILTER(?c != <x>) }";
 
@@ -439,7 +444,7 @@ describe("enforcesNotPrototype — AND/OR composite detection semantics", () => 
 
   // NotPrecondition(IsPrototype) — the composable not-a-prototype form (5b49ef19 → 011eb4d6).
   const IS_PROTO =
-    'ASK { $target <https://exocortex.my/ontology/exo#Instance_class> ?p . FILTER(STRENDS(STR(?p), "Prototype")) }';
+    'ASK { $target <https://exocortex.my/ontology/exo#Instance_class> ?p . ?p <https://exocortex.my/ontology/exo#Class_superClass>* <https://exocortex.my/ontology/exo#Prototype> }';
   const notWrap = (uid: string, child: string): Asset => ({
     uid,
     label: uid,
@@ -473,9 +478,9 @@ describe("enforcesNotPrototype — AND/OR composite detection semantics", () => 
   // Hardening (LOW#1): a clause defeated by a sibling UNION branch a prototype
   // could satisfy must NOT read as enforcing.
   const CLAUSE_UNION =
-    'ASK { { FILTER NOT EXISTS { $target exo:Instance_class ?p . FILTER(STRENDS(STR(?p), "Prototype")) } } UNION { $target exo:Instance_class ?anything } }';
+    'ASK { { FILTER NOT EXISTS { $target exo:Instance_class ?p . ?p exo:Class_superClass* exo:Prototype } } UNION { $target exo:Instance_class ?anything } }';
   const IS_PROTO_UNION =
-    'ASK { { $target exo:Instance_class ?p . FILTER(STRENDS(STR(?p), "Prototype")) } UNION { $target exo:Instance_class ?q } }';
+    'ASK { { $target exo:Instance_class ?p . ?p exo:Class_superClass* exo:Prototype } UNION { $target exo:Instance_class ?q } }';
 
   it("flat clause defeated by a sibling UNION → NOT enforced", () => {
     expect(enforcesNotPrototype(A, resolveOf([leaf(A, CLAUSE_UNION)]))).toBe(
@@ -495,7 +500,7 @@ describe("enforcesNotPrototype — AND/OR composite detection semantics", () => 
   // UID-identity (sound) — NotPrecondition(canonical IsPrototype atomic).
   const CANON_IS_PROTO = "011eb4d6-c95d-4a22-b08d-29961e056961";
   const IS_PROTO_NARROWED =
-    'ASK { $target exo:Instance_class ?p . FILTER(STRENDS(STR(?p), "Prototype")) FILTER(?p != <x>) }';
+    'ASK { $target exo:Instance_class ?p . ?p exo:Class_superClass* exo:Prototype FILTER(?p != <x>) }';
 
   it("NotPrecondition(canonical IsPrototype UID) → enforced BY IDENTITY (even with unresolvable/empty ask)", () => {
     // No asset for the canonical UID in the map — identity alone must suffice.

--- a/packages/core/tests/integration/dynamic-commands/PrototypePreconditionRevertVerify.test.ts
+++ b/packages/core/tests/integration/dynamic-commands/PrototypePreconditionRevertVerify.test.ts
@@ -8,13 +8,16 @@
  *     (`https://exocortex.my/ontology/ems#TaskPrototype`);
  *   - `exo:Class_superClass` triples live under the class FILE IRI
  *     (`obsidian://vault/<uid>.md`), NOT on the symbolic IRI.
- * These two representations are unconnected in SPARQL (the resolver bridges them
- * in code). The earlier transitive form
- * `$target exo:Instance_class/exo:Class_superClass* exo:Prototype` false-passed a
- * synthetic store that (wrongly) put superClass on the symbolic IRI; on the real
- * shape it never fires. The shipped precondition uses a STRENDS suffix check on
- * the symbolic instance_class IRI instead. A guard test below asserts the
- * transitive form would NOT hide on this real shape (documenting the gotcha).
+ * These two representations were unconnected in raw SPARQL. The shipped
+ * precondition now uses the SEMANTIC native walk
+ * `FILTER NOT EXISTS { $target exo:Instance_class ?c . ?c exo:Class_superClass* exo:Prototype }`
+ * — DE-HACKED (req 5579ffa1) from the interim STRENDS name-suffix check. It fires
+ * because the query-time class-hierarchy resolver (`ClassHierarchyResolvingStore`,
+ * req 9fddda62, default ON in `ExoQLQueryExecutor` / `PreconditionEvaluator`) heals
+ * the symbolic↔file-IRI seam at match-time, so the transitive super-class walk
+ * resolves for symbolic-form instances (see class-hierarchy-resolver.test.ts). The
+ * fixture therefore carries `TaskPrototype-file → exo:Prototype` (a real superClass
+ * edge on the class FILE IRI) so the walk reaches exo:Prototype exactly as in prod.
  *
  * Both layers run against the REAL `exoas-exocmd` submodule precondition strings.
  *
@@ -38,9 +41,11 @@ const SUBMODULE_EXOCMD = path.resolve(__dirname, "../../../../exoas-exocmd/exocm
 const START_EFFORT_PRECONDITION_UID = "575404fc"; // augmented status gate
 const STANDALONE_PRECONDITION_UID = "847c37e0"; // "Target is not a prototype"
 
-// The shipped STRENDS not-a-prototype clause (suffix check on the symbolic IRI).
+// The shipped native not-a-prototype clause: a transitive exo:Class_superClass*
+// walk from the target's instance_class up to exo:Prototype (de-hacked from the
+// STRENDS suffix check). Requires `Class_superClass` in the NOT-EXISTS block.
 const NOT_A_PROTOTYPE_CLAUSE_RE =
-  /FILTER\s+NOT\s+EXISTS\s*\{[^}]*Instance_class[^}]*STRENDS\s*\(\s*STR\s*\(\s*\?\w+\s*\)\s*,\s*["']Prototype["']\s*\)[^}]*\}\s*/i;
+  /FILTER\s+NOT\s+EXISTS\s*\{[^}]*Instance_class[^}]*Class_superClass[^}]*Prototype[^}]*\}\s*/i;
 
 const PROTO_ASSET = "obsidian://vault/my-task-template.md";
 const CONCRETE_ASSET = "obsidian://vault/buy-milk.md";
@@ -59,10 +64,11 @@ function readSparqlAsk(uidPrefix: string): string {
 
 /**
  * Production-shape store. ABox instance_class → SYMBOLIC class IRI. The
- * TaskPrototype CLASS file (file IRI) carries Asset_label/uid + a file-IRI
- * `Class_superClass` → symbolic `ems#Task` so the resolver's code-side
- * subclass-closure expands `ems__TaskPrototype` → `ems__Task` (matching the
- * lifecycle binding) — exactly as in production.
+ * TaskPrototype CLASS file (file IRI) carries Asset_label/uid + file-IRI
+ * `Class_superClass` edges → symbolic `ems#Task` (so the resolver's subclass-closure
+ * expands `ems__TaskPrototype` → `ems__Task` for the lifecycle binding) AND →
+ * `exo#Prototype` (so the native not-a-prototype walk reaches it) — exactly the
+ * multi-valued superClass shape of the real ems__TaskPrototype class.
  */
 function buildRealStore(): InMemoryTripleStore {
   const store = new InMemoryTripleStore();
@@ -72,10 +78,12 @@ function buildRealStore(): InMemoryTripleStore {
   const status = I(`${EMS}Effort_status`);
 
   // TaskPrototype class FILE (the resolver seeds the hierarchy walk from here,
-  // resolved via label→uid→file). superClass object is the SYMBOLIC ems#Task.
+  // resolved via label→uid→file). superClass objects are the SYMBOLIC ems#Task
+  // (lifecycle binding) AND exo#Prototype (not-a-prototype walk target).
   store.add(new Triple(I(TASK_PROTOTYPE_FILE), Namespace.EXO.term("Asset_uid"), new Literal("tp-uid")));
   store.add(new Triple(I(TASK_PROTOTYPE_FILE), Namespace.EXO.term("Asset_label"), new Literal("ems__TaskPrototype")));
   store.add(new Triple(I(TASK_PROTOTYPE_FILE), superClass, I(`${EMS}Task`)));
+  store.add(new Triple(I(TASK_PROTOTYPE_FILE), superClass, I(`${EXO}Prototype`)));
 
   // Prototype-TEMPLATE asset — instance_class is the SYMBOLIC prototype IRI.
   // Status set so a status gate would otherwise pass; the not-a-prototype clause
@@ -91,9 +99,12 @@ function buildRealStore(): InMemoryTripleStore {
 
 describe("prototype precondition — revert-verify on REAL store shape (@req:5579ffa1-a829-4fcf-b93d-4fb664b02d62)", () => {
   describe("A. PreconditionEvaluator on real augmented submodule strings", () => {
-    it("the shipped preconditions carry the STRENDS not-a-prototype clause (suffix form)", () => {
+    it("the shipped preconditions carry the native exo:Class_superClass* not-a-prototype clause (de-hacked from STRENDS)", () => {
       expect(readSparqlAsk(START_EFFORT_PRECONDITION_UID)).toMatch(NOT_A_PROTOTYPE_CLAUSE_RE);
       expect(readSparqlAsk(STANDALONE_PRECONDITION_UID)).toMatch(NOT_A_PROTOTYPE_CLAUSE_RE);
+      // The interim STRENDS suffix hack is gone from the shipped sparqlAsk.
+      expect(readSparqlAsk(START_EFFORT_PRECONDITION_UID)).not.toMatch(/STRENDS/i);
+      expect(readSparqlAsk(STANDALONE_PRECONDITION_UID)).not.toMatch(/STRENDS/i);
     });
 
     it("GREEN: augmented Start-Effort precondition HIDES on a status-bearing prototype-template", async () => {
@@ -118,13 +129,16 @@ describe("prototype precondition — revert-verify on REAL store shape (@req:557
       expect(await ev.evaluate({ id: "x", label: "x", sparqlAsk: reverted }, PROTO_ASSET)).toBe(true);
     });
 
-    it("GOTCHA guard: the OLD transitive form would NOT hide on the real dual-IRI shape", async () => {
-      // Documents why STRENDS replaced the transitive walk: on the real store,
-      // superClass lives on the file IRI, so the symbolic instance_class never
-      // reaches exo:Prototype → the transitive clause fails to hide.
+    it("DE-HACK: the native exo:Class_superClass* walk HIDES the prototype and SHOWS the concrete (resolver 9fddda62 bridges symbolic↔file)", async () => {
+      // The de-hack: on the real dual-IRI store, the query-time class-hierarchy
+      // resolver (default ON in PreconditionEvaluator's ExoQLQueryExecutor) heals
+      // the symbolic↔file seam so the transitive super-class walk fires. The
+      // two-triple form (matching the shipped preconditions) reaches exo:Prototype
+      // via the TaskPrototype-file's superClass edge → the template is hidden.
       const ev = new PreconditionEvaluator(buildRealStore());
-      const transitive = `PREFIX exo: <${EXO}> ASK { FILTER NOT EXISTS { $target exo:Instance_class/exo:Class_superClass* exo:Prototype } }`;
-      expect(await ev.evaluate({ id: "x", label: "x", sparqlAsk: transitive }, PROTO_ASSET)).toBe(true); // (would-be) leak
+      const walk = `ASK { FILTER NOT EXISTS { $target <${EXO}Instance_class> ?c . ?c <${EXO}Class_superClass>* <${EXO}Prototype> } }`;
+      expect(await ev.evaluate({ id: "x", label: "x", sparqlAsk: walk }, PROTO_ASSET)).toBe(false); // hidden
+      expect(await ev.evaluate({ id: "x", label: "x", sparqlAsk: walk }, CONCRETE_ASSET)).toBe(true); // shown
     });
   });
 


### PR DESCRIPTION
## Summary

De-hacks the prototype "not-a-prototype" precondition (req `5579ffa1`) from the
STRENDS name-suffix **workaround** to the **native `exo:Class_superClass*` walk**,
now that the query-time class-hierarchy resolver (req `9fddda62`, PR #3984, merged
`c8f8dab9`, Active) heals the symbolic↔file-IRI seam so the transitive walk
resolves for symbolic-form instances.

Req: 5579ffa1-a829-4fcf-b93d-4fb664b02d62

## What changed

- **16 exocmd preconditions** (`kitelev/exoas-exocmd@3e5759b6`, shipped via ExoSync; submodule pointer bumped here): the canonical `Is prototype` atomic `011eb4d6`, standalone `847c37e0`, 12 status-transition gates, 2 convert gates — each swapped `FILTER(STRENDS(STR(?c),"Prototype"))` → `?c exo:Class_superClass* exo:Prototype`.
- **2 tests** (`PrototypePreconditionRevertVerify` + `PrototypePreconditionForgetGuard`, both `@req:5579ffa1`): updated to the walk form. Revert-verify fixture now carries the real `TaskPrototype-file → exo:Prototype` superClass edge (so the resolver-bridged walk reaches it); forget-guard recognizes the `Class_superClass*` clause (UID-identity path unchanged).

## Scope-gate = bug-fix (behavior-preserving)

Per feature-sdd Step 0 (conformance-with-active-req): req `5579ffa1`'s own spec
states the semantic walk; STRENDS was the CLAUSE-FINDING workaround. This restores
the intended mechanism.

**`resolve-buttons` byte-identical before/after** on the real vault-my for every
difference-set instance (verified with `@16.198.0`, fresh caches):
- concrete Backlog task → full 14-command lifecycle set (Start/SetCriticality/Trash/…) — identical
- TaskPrototype-template + the 2 non-conforming user prototype-templates (Lunch, Дорога) → lifecycle hidden — identical

Exhaustive class-level enumeration: the STRENDS↔walk difference set is exactly
2 IS-A-prototype-but-not-`…Prototype`-named classes (both statusless → 0 delta)
and 6 `…Prototype`-named-but-not-IS-A-prototype classes (all 0 instances). The
walk is strictly *more correct* (catches prototype classes by class chain,
independent of naming) but produces **no observable visibility change** today.

## Verification

- Revert-verified `@req:5579ffa1` (RED on clause strip → prototype resolves Start; GREEN restored) — both test layers.
- `PrototypePreconditionRevertVerify` 8/8, `PrototypePreconditionForgetGuard` 41/41, all 15 dynamic-commands integration suites (114) + class-hierarchy-resolver + 2 affected CLI suites (10) green.
- SHACL no-regress (2 pre-existing violations, 0 new). `tsc` 0. Lint guards (ratchet 55/55) pass.
