### PR TITLE
fix(cli): set-property maps exo__Asset_aliases to canonical `aliases:` key (#3944)

### DIFF
--- a/packages/cli/src/commands/set-property.ts
+++ b/packages/cli/src/commands/set-property.ts
@@ -10,6 +10,7 @@ import { existsSync, readFileSync, writeFileSync } from "fs";
 import {
   FrontmatterService,
   serializeYamlScalar,
+  UNPREFIXED_ASSET_FIELDS,
 } from "@kitelev/exocortex-core";
 import { NodeFsAdapter } from "../adapters/NodeFsAdapter.js";
 import { WikilinkValidator } from "../services/WikilinkValidator.js";
@@ -29,6 +30,32 @@ const DEFAULT_TIMEZONE = "Asia/Almaty";
 
 const UPDATED_AT_KEY = "exo__Asset_updatedAt";
 const ISDEFINEDBY_KEY = "exo__Asset_isDefinedBy";
+
+/** `exo__Asset_<field>` shape; group 1 = the bare field name. */
+const ASSET_PREFIXED_SHAPE = /^exo__Asset_(.+)$/;
+
+/**
+ * Map an RDF property name to the canonical Obsidian YAML frontmatter KEY it
+ * must be WRITTEN under (issue #3944). Most properties write under their own
+ * name, but the `UNPREFIXED_ASSET_FIELDS` whitelist (`aliases`, `draft`,
+ * `pinned`, `archived`) is stored under the BARE key `<field>:` — the same key
+ * `NoteToRDFConverter` reads back as `exo:Asset_<field>`. Without this mapping,
+ * `set-property exo__Asset_aliases` wrote a literal `exo__Asset_aliases:` key
+ * ALONGSIDE the canonical `aliases:`, producing a duplicate/dead declaration
+ * (Obsidian recognises aliases only via `aliases:`).
+ *
+ * The property NAME guards + TBox validation still run on the RDF/prefixed form
+ * (unchanged); only the write key is canonicalised here. A bare `aliases` (no
+ * `exo__Asset_` prefix) passes through unchanged — already the canonical key,
+ * no regression (AC-2). `archived` is routed to a dedicated command by the
+ * guard before reaching this point, so in practice this only affects the
+ * non-guarded fields (`aliases`, `draft`, `pinned`).
+ */
+function canonicalYamlKey(property: string): string {
+  const m = ASSET_PREFIXED_SHAPE.exec(property);
+  if (m && UNPREFIXED_ASSET_FIELDS.has(m[1])) return m[1];
+  return property;
+}
 
 /**
  * Properties `set-property` REFUSES because a dedicated guarded `exocmd__Command`
@@ -379,9 +406,12 @@ export function setPropertyCommand(): Command {
         const timezone = options.timezone ?? DEFAULT_TIMEZONE;
         const updatedAt = stampTimestamp(now, timezone);
 
+        // Write under the CANONICAL YAML key (issue #3944): `exo__Asset_aliases`
+        // maps to the bare `aliases:` key so we update it in place rather than
+        // adding a duplicate literal `exo__Asset_aliases:` alongside it.
         let updated = fm.updateProperty(
           original,
-          property,
+          canonicalYamlKey(property),
           serializeForWrite(value),
         );
         updated = fm.updateProperty(updated, UPDATED_AT_KEY, updatedAt);

--- a/packages/cli/tests/integration/set-property.integration.test.ts
+++ b/packages/cli/tests/integration/set-property.integration.test.ts
@@ -207,6 +207,67 @@ describe("Issues #3795 / #3848: `cli set-property` generic guarded mutation prim
     );
   });
 
+  // ── #3944: exo__Asset_aliases maps to the canonical bare `aliases:` YAML key ──
+  // (revert axis: neutralise canonicalYamlKey → set-property writes a literal
+  //  `exo__Asset_aliases:` alongside `aliases:` → the AC assertions RED).
+
+  const ALIASED_UID = "e1e1e1e1-0000-4000-8000-000000000006";
+  const aliasedRel = `${OTHER_DIR}/${ALIASED_UID}.md`;
+
+  /** Write an asset that already carries a single-value `aliases:` list. */
+  function writeAliasedAsset(): void {
+    fs.writeFileSync(
+      path.join(vault, aliasedRel),
+      [
+        "---",
+        `exo__Asset_uid: ${ALIASED_UID}`,
+        'exo__Asset_label: "Dreyfus model"',
+        "aliases:",
+        '  - "Модель Дрейфуса"',
+        `exo__Asset_updatedAt: ${STALE_UPDATED_AT}`,
+        "---",
+        "body",
+        "",
+      ].join("\n"),
+    );
+  }
+
+  it("set-property exo__Asset_aliases updates the canonical `aliases:` key in place — NO literal exo__Asset_aliases: key (#3944)", async () => {
+    writeAliasedAsset();
+    const out = await run(aliasedRel, [
+      "--input",
+      '{"property":"exo__Asset_aliases","value":["Dreyfus Model","Модель Дрейфуса","Dreyfus Hum Model"]}',
+    ]);
+
+    expect(out.exit).toContain(0);
+    expect(out.exit).not.toContain(1);
+    // Canonical bare `aliases:` key updated in place with all 3 values.
+    expect(out.content).toContain("aliases:");
+    expect(out.content).toContain("  - Dreyfus Model");
+    expect(out.content).toContain("  - Модель Дрейфуса");
+    expect(out.content).toContain("  - Dreyfus Hum Model");
+    // ⛔ The bug: a literal `exo__Asset_aliases:` key MUST NOT appear.
+    expect(out.content).not.toMatch(/^exo__Asset_aliases:/m);
+    // updatedAt bumped (write happened via the canonical key).
+    expect(out.content).toContain(`exo__Asset_updatedAt: ${EXPECTED_UPDATED_AT}`);
+  });
+
+  it("bare `aliases` property updates the canonical `aliases:` key (no regression, AC-2) (#3944)", async () => {
+    writeAliasedAsset();
+    const out = await run(aliasedRel, [
+      "--input",
+      '{"property":"aliases","value":["Alpha","Beta"]}',
+    ]);
+
+    expect(out.exit).toContain(0);
+    expect(out.content).toContain("aliases:");
+    expect(out.content).toContain("  - Alpha");
+    expect(out.content).toContain("  - Beta");
+    // The stale single value is replaced, not appended.
+    expect(out.content).not.toContain("Модель Дрейфуса");
+    expect(out.content).not.toMatch(/^exo__Asset_aliases:/m);
+  });
+
   // ── Guard: state-machine / precondition-guarded properties (revert axis: guard) ──
 
   it("REFUSES ems__Effort_status, naming the dedicated command, leaving the file unchanged @req:3800d995-2bae-401f-a23a-dac914505e9d", async () => {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -285,6 +285,7 @@ export {
   NoteToRDFConverter,
   normaliseExcludedFolders,
   isPathExcluded,
+  UNPREFIXED_ASSET_FIELDS,
   type ExocortexInvariantCode,
   type ExocortexInvariantViolation,
 } from "./services/NoteToRDFConverter";

--- a/packages/core/src/services/NoteToRDFConverter.ts
+++ b/packages/core/src/services/NoteToRDFConverter.ts
@@ -46,8 +46,13 @@ export interface ExocortexInvariantViolation {
  * frontmatter keys that index as `exo:Asset_<key>` triples. The whitelist is
  * intentionally narrow — extending it requires an explicit decision because
  * every entry trades indexer simplicity for triple-graph growth.
+ *
+ * Exported so consumers that WRITE these properties (e.g. CLI `set-property`,
+ * issue #3944) can map the RDF property name `exo__Asset_<field>` back to its
+ * canonical bare YAML key `<field>` — the same mapping this converter applies
+ * when READING `<field>:` → `exo:Asset_<field>`.
  */
-const UNPREFIXED_ASSET_FIELDS: ReadonlySet<string> = new Set([
+export const UNPREFIXED_ASSET_FIELDS: ReadonlySet<string> = new Set([
   "archived",
   "draft",
   "pinned",


### PR DESCRIPTION
## Summary
Fixes #3944. `cli set-property` wrote a literal `exo__Asset_aliases:` frontmatter key **alongside** the canonical Obsidian `aliases:` key, producing a duplicate/dead alias declaration (Obsidian resolves aliases only via `aliases:`; `NoteToRDFConverter` then saw two alias sources → duplicate triples).

## Fix
Map an RDF property in the `UNPREFIXED_ASSET_FIELDS` whitelist (`aliases`/`draft`/`pinned`/`archived`) to its **canonical bare YAML write key** — the same key `NoteToRDFConverter` reads back as `exo:Asset_<field>`. Property-name guards + TBox validation still run on the prefixed/RDF form; only the WRITE key is canonicalised.

- **core**: export `UNPREFIXED_ASSET_FIELDS` (single source of truth; was a private const in `NoteToRDFConverter`).
- **cli/set-property**: `canonicalYamlKey()` helper resolves the write key.

## Acceptance Criteria
- [x] **Given** `aliases: [X]` **When** `set-property {property: exo__Asset_aliases, value: [A,B,C]}` **Then** a single `aliases:` key with `[A,B,C]` AND **no** literal `exo__Asset_aliases:` key.
- [x] **Given** bare `aliases` **When** set-property runs **Then** same canonical `aliases:` update (no regression).

## Test (revert-verified)
`packages/cli/tests/integration/set-property.integration.test.ts` — 2 new tests, drive the real command end-to-end and read bytes back. Revert-verify: neutralising `canonicalYamlKey` → the `exo__Asset_aliases` case goes **RED** (writes the literal key), restore → **GREEN**. The bare-`aliases` test is a no-regression control (passes both ways by design). Full CLI set-property suite: 29/29.

Bug-fix (exempt from req-first SDD per feature-sdd Step 0).
