### PR TITLE
fix(#3924): dedup symbolic-IRI reified endpoint against inline (Relations)

### DIFF
--- a/packages/obsidian-plugin/src/presentation/renderers/layout/RelationsRenderer.ts
+++ b/packages/obsidian-plugin/src/presentation/renderers/layout/RelationsRenderer.ts
@@ -19,6 +19,7 @@ import { AssetRelation } from "./types";
 import {
   getReifiedRelations,
   labelToSymbolicIRI,
+  symbolicIriToPropertyKey,
   ReifiedRelation,
 } from "./getReifiedRelations";
 import { BlockerHelpers } from '@plugin/presentation/utils/BlockerHelpers';
@@ -534,18 +535,53 @@ export class RelationsRenderer {
       (aFm?.exo__Asset_label as string | undefined) ??
       null;
     const aSymbolic = labelToSymbolicIRI(aLabel)?.value;
+    const exoAssetLabel = Namespace.EXO.term("Asset_label");
 
-    const tokenFor = (iri: string): string => {
-      if (iri === aSymbolic) return aToken;
+    // Resolve a path-form (`obsidian://vault/…/<uid>.md`) IRI to a canonical
+    // dedup token via the referenced asset's vault frontmatter uid — the SAME
+    // source the inline seed reads (`rel.metadata.exo__Asset_uid`), so the two
+    // are guaranteed to canonicalise identically. `null` when `iri` is not a
+    // vault path IRI (e.g. a symbolic ontology IRI).
+    const pathIriToToken = (iri: string): string | null => {
       const path = iriToVaultPath(iri);
+      if (!path) return null;
       if (path === file.path) return aToken;
-      if (path) {
-        const f = this.vaultAdapter.getAbstractFileByPath(path);
-        const uid = f
-          ? this.vaultAdapter.getFrontmatter(f as IFile)?.exo__Asset_uid
-          : undefined;
-        if (typeof uid === "string" && uid) return `uid:${uid}`;
-        return `path:${path}`;
+      const f = this.vaultAdapter.getAbstractFileByPath(path);
+      const uid = f
+        ? this.vaultAdapter.getFrontmatter(f as IFile)?.exo__Asset_uid
+        : undefined;
+      return typeof uid === "string" && uid ? `uid:${uid}` : `path:${path}`;
+    };
+
+    const tokenFor = async (iri: string): Promise<string> => {
+      if (iri === aSymbolic) return aToken;
+      const pathToken = pathIriToToken(iri);
+      if (pathToken !== null) return pathToken;
+      // ems__Bug `2c7b99a3` sibling (#3924) — a symbolic ontology IRI (a
+      // class / property def whose label is a `prefix__LocalName` reference)
+      // belonging to the OTHER end of the edge. The inline seed keys that same
+      // endpoint as a `uid:` / `path:` token, so resolve the symbolic form back
+      // to its vault asset (the inverse of `labelToSymbolicIRI`: the RDF
+      // converter emits such a label as a SYMBOLIC-IRI `exo:Asset_label` object,
+      // dual-IRI — `sparql-iri-form-pre-verify`) so both forms canonicalise to
+      // the SAME `uid:` token and the inline-wins collision rule fires. Without
+      // this the symbolic endpoint falls through to `iri:<symbolic>` and never
+      // matches the inline `uid:` seed → the edge renders twice (display-only,
+      // but a duplicate row). Only attempted for a clean symbolic ontology IRI
+      // (guarded by `symbolicIriToPropertyKey`) so arbitrary non-vault IRIs
+      // don't trigger a pointless store scan.
+      if (this.store && symbolicIriToPropertyKey(iri)) {
+        const labelHits = await this.store.match(
+          undefined,
+          exoAssetLabel,
+          new IRI(iri),
+        );
+        for (const t of labelHits) {
+          if (t.subject instanceof IRI) {
+            const token = pathIriToToken(t.subject.value);
+            if (token !== null) return token;
+          }
+        }
       }
       return `iri:${iri}`;
     };
@@ -572,7 +608,9 @@ export class RelationsRenderer {
       // Literal object = a property value, not a relation (RFC R6).
       if (r.objectIsLiteral) continue;
 
-      const key = `${tokenFor(r.subject)}|${predicateIriToKey(r.predicate)}|${tokenFor(r.object)}`;
+      const subjToken = await tokenFor(r.subject);
+      const objToken = await tokenFor(r.object);
+      const key = `${subjToken}|${predicateIriToKey(r.predicate)}|${objToken}`;
       if (seenKeys.has(key)) continue; // inline-wins + reified-vs-reified dedup
       seenKeys.add(key);
 

--- a/packages/obsidian-plugin/tests/unit/RelationsRenderer.test.ts
+++ b/packages/obsidian-plugin/tests/unit/RelationsRenderer.test.ts
@@ -1935,6 +1935,97 @@ describe("RelationsRenderer", () => {
       expect(result.filter((r) => r.provenance === "reified")).toHaveLength(0);
     });
 
+    // ems__Bug #3924 — inline+reified dedup for a `Class_superClass` edge whose
+    // OTHER endpoint (the statement subject) is a SYMBOLIC-IRI class asset. The
+    // existing dedup test above uses a plain-labeled note ("Заметка X"), so the
+    // reified subject is a PATH-form IRI and canonicalises to `uid:` fine. Here
+    // both ends are `prefix__LocalName` class assets — the converter emits their
+    // labels as symbolic IRIs (dual-IRI), so the reified subject is a SYMBOLIC
+    // IRI. Before the fix `tokenFor` resolved only the open asset's own symbolic
+    // form + path-form IRIs → the OTHER end's symbolic IRI fell through to
+    // `iri:<symbolic>`, never matching the inline `uid:` seed → the edge rendered
+    // twice. Reachable since PR #3923 let `exo__Class_superClass` through the
+    // reified path (both-ends-symbolic case).
+    //
+    //   Revert-verified: dropping the symbolic→uid `store.match(⊥,Asset_label,…)`
+    //   branch in `tokenFor` makes this show 2 rows (RED); restored → GREEN.
+    it("dedups an inline+reified Class_superClass edge whose other endpoint is a symbolic-IRI class asset (inline-wins) — #3924", async () => {
+      const store = new InMemoryTripleStore();
+      const CLASS_SUPER_CLASS = Namespace.EXO.term("Class_superClass");
+      const EXO_ASSET_LABEL = Namespace.EXO.term("Asset_label");
+      const EXO_ASSET_UID = Namespace.EXO.term("Asset_uid");
+      // The OTHER end (statement subject) — a symbolic-IRI class asset.
+      const ZTLK_NOTE = Namespace.forPrefix("ztlk").term("Note");
+      // The open asset A — also a symbolic-IRI class asset (statement object).
+      const MM_RESOURCE = Namespace.forPrefix("mm").term("Resource");
+      const RESOURCE_PATH =
+        "assetspaces/kitelev/exoas-my/my-mixins/f9bc503f-0000-0000-0000-000000000001.md";
+      const RESOURCE_UID = "f9bc503f-0000-0000-0000-000000000001";
+      const NOTE_PATH =
+        "assetspaces/kitelev/exoas-public/ztlk/dddddddd-0000-0000-0000-000000000004.md";
+      const NOTE_UID = "dddddddd-0000-0000-0000-000000000004";
+      const STMT_PATH =
+        "assetspaces/kitelev/exoas-my/my-mixins/8a2136de-0000-0000-0000-000000000002.md";
+
+      // Reified: ztlk__Note --superClass--> mm__Resource, BOTH ends as SYMBOLIC IRIs.
+      await seedStatement(
+        store,
+        STMT_PATH,
+        ZTLK_NOTE,
+        CLASS_SUPER_CLASS,
+        MM_RESOURCE,
+      );
+      // Dual-IRI: the class assets' `prefix__LocalName` labels are emitted as
+      // SYMBOLIC-IRI `exo:Asset_label` objects (never Literal), so the
+      // symbolic→uid reverse lookup must go through these — mirrors
+      // NoteToRDFConverter's prefix-label emission.
+      await store.add(
+        new Triple(notePathToIRI(NOTE_PATH), EXO_ASSET_LABEL, ZTLK_NOTE),
+      );
+      await store.add(
+        new Triple(
+          notePathToIRI(NOTE_PATH),
+          EXO_ASSET_UID,
+          new Literal(NOTE_UID),
+        ),
+      );
+      await store.add(
+        new Triple(notePathToIRI(RESOURCE_PATH), EXO_ASSET_LABEL, MM_RESOURCE),
+      );
+
+      // Inline: ztlk__Note references mm__Resource via the SAME predicate key.
+      mockBacklinksCacheManager.getBacklinks.mockReturnValue([NOTE_PATH]);
+      registerFiles(
+        {
+          [RESOURCE_PATH]: {
+            exo__Asset_uid: RESOURCE_UID,
+            exo__Asset_label: "mm__Resource",
+          },
+          [NOTE_PATH]: {
+            exo__Asset_uid: NOTE_UID,
+            exo__Asset_label: "ztlk__Note",
+            exo__Class_superClass: `[[${RESOURCE_UID}]]`,
+          },
+        },
+        { [RESOURCE_PATH]: "mm__Resource", [NOTE_PATH]: "ztlk__Note" },
+      );
+      MetadataHelpers.findAllReferencingProperties.mockReturnValue([
+        "exo__Class_superClass",
+      ]);
+
+      const result = await makeRenderer(store).getAssetRelations(
+        createTestTFile(RESOURCE_PATH),
+        {},
+      );
+
+      // ONE row — inline-wins; the reified duplicate (symbolic-IRI endpoint) is
+      // deduped instead of rendering twice.
+      expect(result).toHaveLength(1);
+      expect(result[0].provenance).toBe("inline");
+      expect(result[0].path).toBe(NOTE_PATH);
+      expect(result.filter((r) => r.provenance === "reified")).toHaveLength(0);
+    });
+
     it("does NOT dedup a reified edge that has no inline counterpart (additive)", async () => {
       const store = new InMemoryTripleStore();
       // Inline: X --relatesTo--> A. Reified: A --relatesTo--> B (a DIFFERENT,


### PR DESCRIPTION
Closes #3924.

## Problem
`mergeReifiedRelations.tokenFor` canonicalised an edge endpoint resolving only the open asset's own symbolic IRI + `obsidian://vault/` path IRIs. A symbolic IRI belonging to the **other** end (a class/property def whose label is a `prefix__LocalName` reference) fell through to `iri:<symbolic>`. The inline seed keys the same endpoint as a `uid:`/`path:` token, so when an edge exists **both inline and reified** and the other end is a symbolic-IRI asset, the two keys never matched, the documented "inline-wins on collision" rule did not fire, and **the edge rendered twice** (display-only, no data corruption).

Reachable since PR #3923 let the ObjectProperty `exo__Class_superClass` through the reified path — for such an edge **both** ends are symbolic-IRI class assets. Found by the code-reviewer agent on #3923 (MEDIUM), deferred there as an out-of-scope sibling.

## Fix
Extend `tokenFor` so a symbolic ontology IRI is resolved back to its vault asset via `store.match(⊥, exo:Asset_label, <symbolic>)` — the inverse of `labelToSymbolicIRI` (the RDF converter emits a `prefix__LocalName`-shaped `exo__Asset_label` as a symbolic IRI, dual-IRI). Both the symbolic and path forms then canonicalise to the same `uid:` token and the inline-wins collision rule fires. Guarded by `symbolicIriToPropertyKey` so arbitrary non-vault IRIs don't trigger a pointless store scan. `pathIriToToken` extracted so the symbolic-resolved subject reuses the exact path→uid logic the direct path branch uses (same frontmatter-uid source as the inline seed → guaranteed identical canonicalisation).

## Test
New regression test (`@req`-free bug-fix path) seeds a genuine **inline + reified coexistence** of a `Class_superClass` edge whose endpoints are symbolic-IRI class assets and asserts it collapses to a single (inline) row. The existing dedup test uses a plain-labeled note (path-form IRI) and cannot catch this.

**Revert-verified:** dropping the symbolic→uid `store.match(…Asset_label…)` branch makes the new test show 2 rows (RED); restored → GREEN. Full `RelationsRenderer.test.ts` suite: 90/90 green. Typecheck clean, `check-test-antipatterns` ratchet unchanged (55/55).
