### PR TITLE
fix(exoql): time accessors return lexical components, not host-local shift (#3941)

### DIFF
--- a/packages/core/src/infrastructure/sparql/filters/functions/DateTimeAccessors.ts
+++ b/packages/core/src/infrastructure/sparql/filters/functions/DateTimeAccessors.ts
@@ -14,10 +14,66 @@ export class DateTimeAccessors {
   // =========================================================================
 
   /**
+   * Extract the lexical date/time components of an ISO 8601 date or dateTime
+   * string WITHOUT any timezone conversion.
+   *
+   * SPARQL 1.1 §17.4.5 accessors (YEAR/MONTH/DAY/HOURS/MINUTES/SECONDS) return the
+   * components of the value's OWN lexical representation: a naive-local timestamp
+   * yields its wall-clock components, a tz-annotated timestamp yields the
+   * components in its stated timezone. Neither is normalized to UTC nor to the
+   * host machine's local timezone.
+   *
+   * Going through `new Date(str).getHours()` instead re-interprets the instant
+   * against the host's timezone and double-shifts UTC-labeled naive-local values
+   * (issue #3941: a naive-local "11:36", surfaced as "…11:36:12Z", returned
+   * HOURS=16 on a UTC+5 host — the offset was applied twice).
+   *
+   * @returns lexical components, or null if the string is not a valid ISO 8601
+   *          date / dateTime (caller falls back to `new Date` for legacy formats).
+   */
+  private static lexicalComponents(dateStr: string): {
+    year: number;
+    month: number;
+    day: number;
+    hours: number;
+    minutes: number;
+    seconds: number;
+  } | null {
+    // YYYY-MM-DD[(T| )HH:MM:SS[.fff]][Z|±HH[:]MM] — a trailing tz designator is
+    // matched but deliberately ignored (lexical components are tz-agnostic).
+    const m = dateStr.match(
+      /^(-?\d{4,})-(\d{2})-(\d{2})(?:[T ](\d{2}):(\d{2}):(\d{2})(?:\.(\d+))?)?(?:Z|[+-]\d{2}:?\d{2})?$/,
+    );
+    if (!m) return null;
+
+    const year = parseInt(m[1], 10);
+    const month = parseInt(m[2], 10);
+    const day = parseInt(m[3], 10);
+    const hours = m[4] !== undefined ? parseInt(m[4], 10) : 0;
+    const minutes = m[5] !== undefined ? parseInt(m[5], 10) : 0;
+    const wholeSeconds = m[6] !== undefined ? parseInt(m[6], 10) : 0;
+    const seconds = m[7] ? wholeSeconds + parseFloat(`0.${m[7]}`) : wholeSeconds;
+
+    // Reject out-of-range components (e.g. "2025-13-45") so the caller's
+    // `new Date` fallback raises the same "invalid date string" error as before.
+    if (
+      month < 1 || month > 12 ||
+      day < 1 || day > 31 ||
+      hours > 24 || minutes > 59 || wholeSeconds > 60
+    ) {
+      return null;
+    }
+
+    return { year, month, day, hours, minutes, seconds };
+  }
+
+  /**
    * SPARQL 1.1 YEAR function.
-   * Returns the year component of a dateTime value.
+   * Returns the year component of a dateTime value (lexical, tz-agnostic).
    */
   static year(dateStr: string): number {
+    const c = DateTimeAccessors.lexicalComponents(dateStr);
+    if (c) return c.year;
     const date = new Date(dateStr);
     if (isNaN(date.getTime())) {
       throw new Error(`YEAR: invalid date string '${dateStr}'`);
@@ -27,9 +83,11 @@ export class DateTimeAccessors {
 
   /**
    * SPARQL 1.1 MONTH function.
-   * Returns the month component of a dateTime value (1-12).
+   * Returns the month component of a dateTime value (1-12, lexical, tz-agnostic).
    */
   static month(dateStr: string): number {
+    const c = DateTimeAccessors.lexicalComponents(dateStr);
+    if (c) return c.month;
     const date = new Date(dateStr);
     if (isNaN(date.getTime())) {
       throw new Error(`MONTH: invalid date string '${dateStr}'`);
@@ -39,9 +97,11 @@ export class DateTimeAccessors {
 
   /**
    * SPARQL 1.1 DAY function.
-   * Returns the day component of a dateTime value (1-31).
+   * Returns the day component of a dateTime value (1-31, lexical, tz-agnostic).
    */
   static day(dateStr: string): number {
+    const c = DateTimeAccessors.lexicalComponents(dateStr);
+    if (c) return c.day;
     const date = new Date(dateStr);
     if (isNaN(date.getTime())) {
       throw new Error(`DAY: invalid date string '${dateStr}'`);
@@ -51,9 +111,11 @@ export class DateTimeAccessors {
 
   /**
    * SPARQL 1.1 HOURS function.
-   * Returns the hours component of a dateTime value (0-23).
+   * Returns the hours component of a dateTime value (0-23, lexical, tz-agnostic).
    */
   static hours(dateStr: string): number {
+    const c = DateTimeAccessors.lexicalComponents(dateStr);
+    if (c) return c.hours;
     const date = new Date(dateStr);
     if (isNaN(date.getTime())) {
       throw new Error(`HOURS: invalid date string '${dateStr}'`);
@@ -63,9 +125,11 @@ export class DateTimeAccessors {
 
   /**
    * SPARQL 1.1 MINUTES function.
-   * Returns the minutes component of a dateTime value (0-59).
+   * Returns the minutes component of a dateTime value (0-59, lexical, tz-agnostic).
    */
   static minutes(dateStr: string): number {
+    const c = DateTimeAccessors.lexicalComponents(dateStr);
+    if (c) return c.minutes;
     const date = new Date(dateStr);
     if (isNaN(date.getTime())) {
       throw new Error(`MINUTES: invalid date string '${dateStr}'`);
@@ -75,9 +139,12 @@ export class DateTimeAccessors {
 
   /**
    * SPARQL 1.1 SECONDS function.
-   * Returns the seconds component of a dateTime value (0-59, may include decimal).
+   * Returns the seconds component of a dateTime value (0-59, may include a
+   * fractional part; lexical, tz-agnostic).
    */
   static seconds(dateStr: string): number {
+    const c = DateTimeAccessors.lexicalComponents(dateStr);
+    if (c) return c.seconds;
     const date = new Date(dateStr);
     if (isNaN(date.getTime())) {
       throw new Error(`SECONDS: invalid date string '${dateStr}'`);

--- a/packages/core/tests/sparql/compliance/built-in-functions.test.ts
+++ b/packages/core/tests/sparql/compliance/built-in-functions.test.ts
@@ -674,9 +674,10 @@ describe("SPARQL 1.1 Compliance - Built-in Functions", () => {
     });
 
     describe("HOURS / MINUTES / SECONDS", () => {
-      // HOURS returns local timezone-adjusted value instead of UTC value
-      // Expected "14" (UTC), got "19" (UTC+5)
-      it.skip("should extract time components from dateTime", async () => {
+      // #3941 fix: HOURS/MINUTES/SECONDS now return the lexical component in the
+      // value's own representation (tz-agnostic) instead of the host-local shift,
+      // so this is machine-timezone-independent (previously got "19" on UTC+5).
+      it("should extract time components from dateTime", async () => {
         const query = `
           PREFIX ex: <http://example.org/>
           SELECT (HOURS(?dt) AS ?h) (MINUTES(?dt) AS ?m) (SECONDS(?dt) AS ?s) WHERE {

--- a/packages/core/tests/unit/infrastructure/sparql/filters/DateTimeAccessors.naiveLocalTz.test.ts
+++ b/packages/core/tests/unit/infrastructure/sparql/filters/DateTimeAccessors.naiveLocalTz.test.ts
@@ -1,0 +1,71 @@
+import { BuiltInFunctions } from "../../../../../src/infrastructure/sparql/filters/BuiltInFunctions";
+import { installFakeOffsetDate } from "../../../../helpers/installFakeOffsetDate";
+
+/**
+ * Regression guard for issue #3941 — ExoQL time accessors double-shifted the
+ * timezone offset for naive-local timestamps. The vault stores timestamps as
+ * naive-local (Asia/Almaty, no tz suffix); a naive-local "11:36", surfaced as
+ * "…11:36:12Z" by the emission path, returned HOURS=16 on a UTC+5 host instead
+ * of 11 (the offset was applied twice via host-local `Date.getHours()`).
+ *
+ * tz contract (SPARQL 1.1 §17.4.5): YEAR/MONTH/DAY/HOURS/MINUTES/SECONDS return
+ * the components of the value's OWN lexical representation — no UTC / host-local
+ * conversion. A naive timestamp yields its wall-clock components; a tz-annotated
+ * timestamp yields the components in its stated timezone.
+ *
+ * These tests install a simulated UTC+5 zone via installFakeOffsetDate so the
+ * bug (host-local `.getHours()`/`.getDate()` shift) is reproducible even on a
+ * UTC CI runner, where local === UTC would otherwise hide it, causing the
+ * revert-verify to pass both with AND without the fix
+ * ([[jest-timezone-sensitive-tests]]). The primary discriminators use explicit
+ * `Z` values so RED reproduces on every runner regardless of its real zone.
+ */
+describe("ExoQL time accessors — naive-local tz contract (#3941)", () => {
+  it("HOURS/MINUTES/SECONDS return lexical components (no double tz shift)", () => {
+    // Simulate Asia/Almaty (UTC+5); fixed instant 06:36:12Z → local 11:36:12.
+    const restore = installFakeOffsetDate(5, "2026-07-05T06:36:12Z");
+    try {
+      // guard: the simulated UTC+5 zone is active under the fake Date
+      expect(new Date().getHours()).toBe(11);
+      expect(new Date().getUTCHours()).toBe(6);
+
+      // Primary repro from the issue — naive-local value surfaced UTC-labeled.
+      // With the bug, host-local getHours() would return 16 under UTC+5.
+      expect(BuiltInFunctions.hours("2026-07-05T11:36:12.000Z")).toBe(11);
+      expect(BuiltInFunctions.minutes("2026-07-05T11:36:12.000Z")).toBe(36);
+      expect(BuiltInFunctions.seconds("2026-07-05T11:36:12.000Z")).toBe(12);
+
+      // Bare naive form (no tz suffix) — same wall-clock components.
+      expect(BuiltInFunctions.hours("2026-07-05T11:36:12")).toBe(11);
+
+      // Explicit −03:00 offset — lexical hour as written, not UTC-normalized.
+      // (bug path would resolve the instant then read it in the simulated zone.)
+      expect(BuiltInFunctions.hours("2026-07-05T23:00:00-03:00")).toBe(23);
+
+      // Fractional seconds preserved.
+      expect(BuiltInFunctions.seconds("2026-07-05T11:36:12.815Z")).toBeCloseTo(
+        12.815,
+      );
+    } finally {
+      restore();
+    }
+  });
+
+  it("YEAR/MONTH/DAY return lexical components (no boundary rollover for a late-UTC value)", () => {
+    // Under a naive host-local read, a 23:30Z value + 5h crosses the day/month/
+    // year boundary (the latent YEAR/MONTH/DAY variant of the same bug).
+    const restore = installFakeOffsetDate(5, "2026-07-05T06:00:00Z");
+    try {
+      expect(new Date().getHours()).toBe(11); // guard: simulated UTC+5 active
+
+      // Bug path: +5h rolls to 2027-01-01 → YEAR would be 2027.
+      expect(BuiltInFunctions.year("2026-12-31T23:30:00Z")).toBe(2026);
+      // Bug path: +5h rolls to Aug 1 → MONTH would be 8.
+      expect(BuiltInFunctions.month("2026-07-31T23:30:00Z")).toBe(7);
+      // Bug path: +5h rolls to Jul 6 → DAY would be 6.
+      expect(BuiltInFunctions.day("2026-07-05T23:30:00Z")).toBe(5);
+    } finally {
+      restore();
+    }
+  });
+});


### PR DESCRIPTION
## Summary
Fixes #3941 — ExoQL time accessors double-shifted the timezone offset for naive-local timestamps. `YEAR/MONTH/DAY/HOURS/MINUTES/SECONDS` routed through `new Date(str).getHours()` (host-local), so a naive-local `11:36`, surfaced as `…11:36:12Z` by the emission path, returned `HOURS=16` on a UTC+5 host instead of `11` — the offset applied twice. Silent, forced time-of-day analytics out of ExoQL.

## tz contract (documented + enforced)
Per SPARQL 1.1 §17.4.5, the date/time accessors now return the components of the value's **own lexical representation** — no UTC/host-local conversion:
- a naive timestamp yields its wall-clock components;
- a tz-annotated timestamp yields the components in its stated timezone.

Implemented as lexical component extraction; a `new Date` fallback preserves legacy non-ISO parsing + the `"invalid date string"` error.

## Real-CLI acceptance (Almaty host, UTC+5)
Stored `ems__Effort_endTimestamp` surfaced as `2026-07-29T10:46:46.000Z`:
| | HOURS |
|---|---|
| published (buggy) CLI | `15` |
| this fix | `10` |

## Revert-verify (CI-robust)
`packages/core/tests/unit/infrastructure/sparql/filters/DateTimeAccessors.naiveLocalTz.test.ts` uses `installFakeOffsetDate` (simulated UTC+5) so the bug reproduces even on a UTC CI runner (where `local === UTC` would hide it — [[jest-timezone-sensitive-tests]]). Empirically: revert src → **RED** under `TZ=UTC` (`HOURS 11→16`, `YEAR 2026→2027`); restore → **GREEN**.

Also un-skips the compliance `HOURS/MINUTES/SECONDS` test (previously skipped as machine-tz-fragile; now tz-independent).

## Verification
- Full `packages/core` suite green (submodule-dependent prototype/grounding suites confirmed green with `exoas-exocmd`/`exoas-exo` initialized — unrelated to this change).
- typecheck 0; the 3 CI guard-scripts (shard-assignments, test-antipatterns ratchet 55/55 unchanged, coverage-monotonic) pass.

## Acceptance Criteria
- [x] naive-local `HOURS` returns the as-written hour (documented tz contract applied end-to-end)
- [x] `MINUTES/SECONDS`/`YEAR/MONTH/DAY` return lexical components consistently
- [x] Revert-verify: broken → RED, fixed → GREEN (CI-robust via simulated tz)
