### PR TITLE
feat(display): TBox entities display as prefix#slug computed projection (@req:318af6a2, RFC 78572fa9 Phase 2)

### DIFF
--- a/packages/obsidian-plugin/src/domain/display-name/DisplayNameResolver.ts
+++ b/packages/obsidian-plugin/src/domain/display-name/DisplayNameResolver.ts
@@ -9,6 +9,26 @@ export interface DisplayNameContext {
   createdDate?: Date;
 }
 
+/**
+ * The exo__Slugable-mixin metaclasses. A note whose exo__Instance_class is one of these
+ * (matched by UID OR label form) is a TBox naming entity that displays as `prefix#slug`
+ * (RFC 78572fa9 Candidate B Phase 2). exo__Class + exo__Property carry the exo__Slugable
+ * mixin directly; the three concrete property metaclasses inherit it via exo__Property.
+ * Verified against the live TBox (vault-my exoas-exo, 2026-07-29).
+ */
+const SLUGABLE_METACLASS_KEYS: ReadonlySet<string> = new Set<string>([
+  "8619c4fc-64f1-4869-b17e-e34186cacca9",
+  "exo__Class",
+  "38277bfa-d7f9-4a75-b856-b23276ab0db3",
+  "exo__Property",
+  "9a1cf31c-9d41-4ef3-9023-584a8d087d16",
+  "exo__ObjectProperty",
+  "ae56ca4c-b610-42a4-a25d-058c23673296",
+  "exo__DatatypeProperty",
+  "84756998-3b4e-4989-91cc-a5d5c23664d4",
+  "exo__URLProperty",
+]);
+
 export class DisplayNameResolver {
   constructor(
     private readonly settings: DisplayNameSettings,
@@ -25,6 +45,15 @@ export class DisplayNameResolver {
     // conditional spec (matchPath/matchValue) is evaluated per-render — the specialized
     // displayName tracks the instance's state.
     const assetClasses = this.extractAssetClasses(metadata);
+
+    // TBox naming display-projection (RFC 78572fa9 Candidate B Phase 2, req 318af6a2): a
+    // class-def / property-def displays as its COMPUTED `prefix#slug` (e.g. ems#TaskPrototype)
+    // instead of the raw exo__Asset_label. Subordinate to a participating exo__DisplayNameSpec
+    // and disabled by projectTBoxNames=false; never fires for ABox instances. Returns null to
+    // fall through to the normal template path.
+    const projection = this.computeTBoxNamingProjection(assetClasses, metadata);
+    if (projection !== null) return projection;
+
     const template = this.getTemplateForClasses(assetClasses, metadata);
     const engine = new DisplayNameTemplateEngine(template);
 
@@ -195,6 +224,126 @@ export class DisplayNameResolver {
     }
 
     return cleaned || null;
+  }
+
+  /**
+   * TBox naming display-projection (RFC 78572fa9 Candidate B Phase 2). A TBox naming entity —
+   * a class-def or property-def — displays as its COMPUTED symbolic projection `prefix#slug`
+   * (e.g. `ems#TaskPrototype`, `ems#Effort_status`) instead of its raw exo__Asset_label
+   * (`ems__TaskPrototype`). NEVER stored — composed per-render from the naming fields:
+   *
+   *   slug    = exo__Slugable_slug ?? <label local-name>  (the part after the label's first `__`)
+   *   prefix  = <isDefinedBy ontology>.exo__Ontology_shortName ?? <label prefix>  (before `__`)
+   *   display = prefix ? `${prefix}#${slug}` : slug
+   *
+   * Returns null (→ the normal template path) when: the projection is disabled
+   * (settings.projectTBoxNames === false); the note is not a TBox naming entity; a participating
+   * exo__DisplayNameSpec exists (an explicit author override wins); or no slug can be resolved.
+   * ABox instances never match the detection, so their displayName is byte-identical. The
+   * fallback chain covers entities/ontologies missing the Phase-1 naming fields (RFC v4: the 22
+   * orphan-namespace prefixes with no ontology anchor display via the label-prefix fallback).
+   */
+  private computeTBoxNamingProjection(
+    assetClasses: string[],
+    metadata: Record<string, unknown>,
+  ): string | null {
+    if (this.settings.projectTBoxNames === false) return null;
+    if (!this.isTBoxNamingEntity(assetClasses, metadata)) return null;
+
+    // A participating exo__DisplayNameSpec is an explicit author override → let it win.
+    if (this.ruleService) {
+      for (const assetClass of assetClasses) {
+        if (
+          this.ruleService.getParticipatingRules(assetClass, metadata).length >
+          0
+        ) {
+          return null;
+        }
+      }
+    }
+
+    const label =
+      typeof metadata.exo__Asset_label === "string"
+        ? metadata.exo__Asset_label.trim()
+        : "";
+    const [labelPrefix, labelLocal] = this.splitPrefixedLabel(label);
+
+    const slugField =
+      typeof metadata.exo__Slugable_slug === "string"
+        ? metadata.exo__Slugable_slug.trim()
+        : "";
+    const slug = slugField || labelLocal;
+    if (!slug) return null; // no slug field AND the label is not `prefix__Local` → cannot project.
+
+    const prefix = this.resolveOntologyShortName(metadata) ?? labelPrefix;
+    return prefix ? `${prefix}#${slug}` : slug;
+  }
+
+  /**
+   * True when a note is a TBox naming entity — its exo__Instance_class is one of the
+   * exo__Slugable-mixin metaclasses (class / property metaclasses), OR it carries a non-empty
+   * exo__Slugable_slug (forward-compat for any Slugable entity even before its metaclass is
+   * recognized). Detection is population-independent so the projection fires (with a
+   * label-derived fallback) even for an entity whose slug/shortName are not yet materialized.
+   */
+  private isTBoxNamingEntity(
+    assetClasses: string[],
+    metadata: Record<string, unknown>,
+  ): boolean {
+    if (
+      typeof metadata.exo__Slugable_slug === "string" &&
+      metadata.exo__Slugable_slug.trim()
+    ) {
+      return true;
+    }
+    return assetClasses.some((c) => SLUGABLE_METACLASS_KEYS.has(c));
+  }
+
+  /**
+   * Resolve the note's namespace ontology (exo__Asset_isDefinedBy → ontology frontmatter, via
+   * the metadataResolver two-hop) and return its exo__Ontology_shortName (trimmed) — the
+   * canonical prefix. null when there is no metadataResolver, no isDefinedBy, or the ontology
+   * carries no shortName (→ the caller falls back to the label-derived prefix). This reads the
+   * SAME field the future query-input name-resolver (Candidate E) will use, so DISPLAY and
+   * QUERY stay symmetric.
+   */
+  private resolveOntologyShortName(
+    metadata: Record<string, unknown>,
+  ): string | null {
+    if (!this.metadataResolver) return null;
+    const isDefinedBy = this.firstString(metadata.exo__Asset_isDefinedBy);
+    if (!isDefinedBy) return null;
+    const ontologyFm = this.metadataResolver(isDefinedBy);
+    const shortName = ontologyFm?.exo__Ontology_shortName;
+    return typeof shortName === "string" && shortName.trim()
+      ? shortName.trim()
+      : null;
+  }
+
+  /**
+   * Split a `prefix__LocalName` label into [prefix, localName] on the FIRST `__` separator
+   * (the prefix may itself contain single underscores, e.g. `ztlk_v2__X`; `__` is the
+   * separator). Returns [null, null] when the label has no `__` separator or an empty part.
+   */
+  private splitPrefixedLabel(label: string): [string | null, string | null] {
+    const idx = label.indexOf("__");
+    if (idx <= 0) return [null, null];
+    const prefix = label.slice(0, idx);
+    const local = label.slice(idx + 2);
+    if (!local) return [null, null];
+    return [prefix, local];
+  }
+
+  /** First trimmed non-empty string of a scalar-or-array value, else null. */
+  private firstString(value: unknown): string | null {
+    let raw = value;
+    if (Array.isArray(raw)) {
+      if (raw.length === 0) return null;
+      raw = raw[0];
+    }
+    if (typeof raw !== "string") return null;
+    const trimmed = raw.trim();
+    return trimmed || null;
   }
 
   getConfiguredClasses(): string[] {

--- a/packages/obsidian-plugin/src/domain/display-name/DisplayNameResolver.ts
+++ b/packages/obsidian-plugin/src/domain/display-name/DisplayNameResolver.ts
@@ -248,7 +248,7 @@ export class DisplayNameResolver {
     metadata: Record<string, unknown>,
   ): string | null {
     if (this.settings.projectTBoxNames === false) return null;
-    if (!this.isTBoxNamingEntity(assetClasses, metadata)) return null;
+    if (!this.isTBoxNamingEntity(assetClasses)) return null;
 
     // A participating exo__DisplayNameSpec is an explicit author override → let it win.
     if (this.ruleService) {
@@ -281,21 +281,15 @@ export class DisplayNameResolver {
 
   /**
    * True when a note is a TBox naming entity — its exo__Instance_class is one of the
-   * exo__Slugable-mixin metaclasses (class / property metaclasses), OR it carries a non-empty
-   * exo__Slugable_slug (forward-compat for any Slugable entity even before its metaclass is
-   * recognized). Detection is population-independent so the projection fires (with a
-   * label-derived fallback) even for an entity whose slug/shortName are not yet materialized.
+   * exo__Slugable-mixin metaclasses (class / property metaclasses). Detection is by the
+   * METACLASS ONLY, deliberately NOT by the mere presence of exo__Slugable_slug: the slug is a
+   * TBox concern (RFC 78572fa9 v3 points 8/11 — free-form ABox instances keep their label and
+   * never carry a slug), so keying detection on the metaclass is (a) population-independent — it
+   * fires for every one of the 762 Phase-1-populated defs AND every unpopulated one (with a
+   * label-derived fallback), and (b) cannot hijack the display of an ABox instance that happens
+   * to carry a slug field (an ABox instance is never a Slugable metaclass instance).
    */
-  private isTBoxNamingEntity(
-    assetClasses: string[],
-    metadata: Record<string, unknown>,
-  ): boolean {
-    if (
-      typeof metadata.exo__Slugable_slug === "string" &&
-      metadata.exo__Slugable_slug.trim()
-    ) {
-      return true;
-    }
+  private isTBoxNamingEntity(assetClasses: string[]): boolean {
     return assetClasses.some((c) => SLUGABLE_METACLASS_KEYS.has(c));
   }
 

--- a/packages/obsidian-plugin/src/domain/settings/ExocortexSettings.ts
+++ b/packages/obsidian-plugin/src/domain/settings/ExocortexSettings.ts
@@ -7,6 +7,17 @@ export interface DisplayNameSettings {
 
   /** Per-class template overrides (key = class name like "ems__Task") */
   classTemplates: Record<string, string>;
+
+  /**
+   * TBox naming display-projection (RFC 78572fa9 Candidate B Phase 2). When ON (default),
+   * a TBox class/property definition displays as its COMPUTED symbolic projection
+   * `prefix#slug` (e.g. `ems#TaskPrototype`) — composing the namespace ontology's
+   * `exo__Ontology_shortName` with the entity's `exo__Slugable_slug` (with a label-derived
+   * fallback) — instead of its raw `exo__Asset_label`. Never stored; computed per-render.
+   * OFF restores the raw-label display (the revert-verify axis + a user escape hatch).
+   * Optional so a persisted settings object without it defaults ON (backward-compatible).
+   */
+  projectTBoxNames?: boolean;
 }
 
 /**
@@ -34,6 +45,8 @@ export const DEFAULT_DISPLAY_NAME_SETTINGS: DisplayNameSettings = {
   defaultTemplate: "{{exo__Asset_label}}",
 
   classTemplates: {},
+
+  projectTBoxNames: true,
 };
 
 /**

--- a/packages/obsidian-plugin/tests/unit/domain/display-name/DisplayNameResolver.tboxProjection.test.ts
+++ b/packages/obsidian-plugin/tests/unit/domain/display-name/DisplayNameResolver.tboxProjection.test.ts
@@ -88,6 +88,14 @@ const TASK_FM = {
   exo__Asset_label: "Купить молоко",
   exo__Instance_class: ["[[ems__Task]]"],
 };
+// ABox instance that DEFENSIVELY carries a slug field — detection is metaclass-only, so it must
+// NOT be hijacked into a prefix#slug projection (RFC v3 points 8/11: slug is a TBox concern).
+const ABOX_WITH_SLUG_FM = {
+  exo__Asset_uid: "ffff8888-0000-4000-8000-000000000008",
+  exo__Asset_label: "Some Free-Form Label",
+  exo__Instance_class: ["[[ems__Task]]"],
+  exo__Slugable_slug: "ShouldNotProject",
+};
 
 const ONTOLOGY_FILES = [
   {
@@ -99,8 +107,13 @@ const ONTOLOGY_FILES = [
     },
   },
   {
+    // Mirrors today's PRODUCTION anchor shape: exo__Ontology_url present, NO shortName yet.
     path: `${NOSN_ONTO}.md`,
-    frontmatter: { exo__Asset_uid: NOSN_ONTO, exo__Asset_label: "$nosn" },
+    frontmatter: {
+      exo__Asset_uid: NOSN_ONTO,
+      exo__Asset_label: "$nosn",
+      exo__Ontology_url: "https://exocortex.my/ontology/nosn#",
+    },
   },
 ];
 
@@ -112,6 +125,7 @@ function namingVault(): App {
     { path: "wcheck.md", frontmatter: WCHECK_FM },
     { path: "okr.md", frontmatter: OKR_FM },
     { path: "task.md", frontmatter: TASK_FM },
+    { path: "abox-slug.md", frontmatter: ABOX_WITH_SLUG_FM },
   ]);
 }
 
@@ -181,6 +195,14 @@ describe("DisplayNameResolver — TBox naming projection prefix#slug (RFC 78572f
     expect(render(off, TASK_FM, "eeee5555-0000-4000-8000-000000000005")).toBe(
       "Купить молоко",
     );
+  });
+
+  it("@req:318af6a2-2c56-4db4-900e-dd0d0e36362b DETECTION is metaclass-only: an ABox instance that carries a slug field is NOT hijacked into a projection", () => {
+    const r = makeResolver(namingVault(), true);
+    // ems__Task is not a Slugable metaclass → the projection never fires, even with a slug field present.
+    expect(
+      render(r, ABOX_WITH_SLUG_FM, "ffff8888-0000-4000-8000-000000000008"),
+    ).toBe("Some Free-Form Label");
   });
 
   it("@req:318af6a2-2c56-4db4-900e-dd0d0e36362b PRECEDENCE: a participating exo__DisplayNameSpec wins over the projection", () => {

--- a/packages/obsidian-plugin/tests/unit/domain/display-name/DisplayNameResolver.tboxProjection.test.ts
+++ b/packages/obsidian-plugin/tests/unit/domain/display-name/DisplayNameResolver.tboxProjection.test.ts
@@ -1,0 +1,222 @@
+import { PrintNameRuleService } from "@plugin/domain/display-name/PrintNameRuleService";
+import { DisplayNameResolver } from "@plugin/domain/display-name/DisplayNameResolver";
+import type { DisplayNameSettings } from "@plugin/domain/settings/ExocortexSettings";
+import { TFile } from "obsidian";
+import type { App, CachedMetadata } from "obsidian";
+
+/**
+ * Production-shape fixture-vault harness (mirrors PrintNameRuleService.test.ts): a mock App
+ * whose metadataCache resolves getFirstLinkpathDest + getFileCache over authored fixture files,
+ * so the DisplayNameResolver's REAL metadataResolver (PrintNameRuleService.createMetadataResolver)
+ * performs the exo__Asset_isDefinedBy -> ontology-frontmatter two-hop just as in Obsidian.
+ */
+function createMockApp(
+  files: Array<{ path: string; frontmatter: Record<string, unknown> }>,
+): App {
+  const fileCache = new Map<string, CachedMetadata>();
+  const mockFiles: TFile[] = [];
+
+  for (const f of files) {
+    const tfile = new TFile(f.path);
+    tfile.basename = f.path.replace(".md", "");
+    tfile.extension = "md";
+    mockFiles.push(tfile);
+    fileCache.set(f.path, { frontmatter: f.frontmatter } as CachedMetadata);
+  }
+
+  return {
+    vault: {
+      getMarkdownFiles: jest.fn().mockReturnValue(mockFiles),
+    },
+    metadataCache: {
+      getFileCache: jest
+        .fn()
+        .mockImplementation((file: TFile) => fileCache.get(file.path) ?? null),
+      getFirstLinkpathDest: jest.fn().mockImplementation((path: string) => {
+        const cleanPath = path.endsWith(".md") ? path : path + ".md";
+        return mockFiles.find((f) => f.path === cleanPath) ?? null;
+      }),
+    },
+  } as unknown as App;
+}
+
+// --- Slugable-mixin metaclass UIDs (verified live TBox 2026-07-29) ---
+const EXO_CLASS = "8619c4fc-64f1-4869-b17e-e34186cacca9";
+const EXO_DATATYPE_PROPERTY = "ae56ca4c-b610-42a4-a25d-058c23673296";
+const DISPLAY_NAME_SPEC_UID = "07eab746-0874-4676-9d98-dbaad1bc6fb8";
+const PRINTED_LITERAL_UID = "4d5437c9-788e-4a6d-9be0-4af3a84554f4";
+
+// --- namespace ontologies ---
+const EMS_ONTO = "f6e01f7a-d727-494a-82a3-815597d33e86"; // has exo__Ontology_shortName "ems"
+const NOSN_ONTO = "aaaa1111-0000-4000-8000-000000000001"; // an ontology with NO shortName
+
+// --- fixture frontmatters (TBox naming entities + one ABox control) ---
+// Populated class-def: slug field + a namespace ontology that carries shortName.
+const TASK_PROTO_FM = {
+  exo__Asset_uid: "df7e579d-02d4-4f3a-971f-3d1d785b689b",
+  exo__Asset_label: "ems__TaskPrototype",
+  exo__Instance_class: [`[[${EXO_CLASS}]]`],
+  exo__Slugable_slug: "TaskPrototype",
+  exo__Asset_isDefinedBy: `[[${EMS_ONTO}]]`,
+};
+// Populated property-def.
+const EFFORT_STATUS_FM = {
+  exo__Asset_uid: "bbbb2222-0000-4000-8000-000000000002",
+  exo__Asset_label: "ems__Effort_status",
+  exo__Instance_class: [`[[${EXO_DATATYPE_PROPERTY}]]`],
+  exo__Slugable_slug: "Effort_status",
+  exo__Asset_isDefinedBy: `[[${EMS_ONTO}]]`,
+};
+// FALLBACK class-def: NO slug field, ontology has NO shortName → derive BOTH from the label.
+const WCHECK_FM = {
+  exo__Asset_uid: "cccc3333-0000-4000-8000-000000000003",
+  exo__Asset_label: "ems__WaitingCheckTaskPrototype",
+  exo__Instance_class: [`[[${EXO_CLASS}]]`],
+  exo__Asset_isDefinedBy: `[[${NOSN_ONTO}]]`,
+};
+// ORPHAN-NAMESPACE class-def: slug present, ontology has NO shortName → derive prefix from label.
+const OKR_FM = {
+  exo__Asset_uid: "dddd4444-0000-4000-8000-000000000004",
+  exo__Asset_label: "okr__Objective",
+  exo__Instance_class: [`[[${EXO_CLASS}]]`],
+  exo__Slugable_slug: "Objective",
+  exo__Asset_isDefinedBy: `[[${NOSN_ONTO}]]`,
+};
+// ABox instance control — NOT a Slugable metaclass, no slug → projection never fires.
+const TASK_FM = {
+  exo__Asset_uid: "eeee5555-0000-4000-8000-000000000005",
+  exo__Asset_label: "Купить молоко",
+  exo__Instance_class: ["[[ems__Task]]"],
+};
+
+const ONTOLOGY_FILES = [
+  {
+    path: `${EMS_ONTO}.md`,
+    frontmatter: {
+      exo__Asset_uid: EMS_ONTO,
+      exo__Asset_label: "$ems",
+      exo__Ontology_shortName: "ems",
+    },
+  },
+  {
+    path: `${NOSN_ONTO}.md`,
+    frontmatter: { exo__Asset_uid: NOSN_ONTO, exo__Asset_label: "$nosn" },
+  },
+];
+
+function namingVault(): App {
+  return createMockApp([
+    ...ONTOLOGY_FILES,
+    { path: "taskproto.md", frontmatter: TASK_PROTO_FM },
+    { path: "effortstatus.md", frontmatter: EFFORT_STATUS_FM },
+    { path: "wcheck.md", frontmatter: WCHECK_FM },
+    { path: "okr.md", frontmatter: OKR_FM },
+    { path: "task.md", frontmatter: TASK_FM },
+  ]);
+}
+
+function makeResolver(app: App, projectTBoxNames = true): DisplayNameResolver {
+  const settings: DisplayNameSettings = {
+    defaultTemplate: "{{exo__Asset_label}}",
+    classTemplates: {},
+    projectTBoxNames,
+  };
+  const svc = new PrintNameRuleService(app);
+  svc.initialize();
+  return new DisplayNameResolver(settings, svc, svc.createMetadataResolver());
+}
+
+const render = (
+  r: DisplayNameResolver,
+  fm: Record<string, unknown>,
+  basename: string,
+): string | null => r.resolve({ metadata: fm, basename });
+
+describe("DisplayNameResolver — TBox naming projection prefix#slug (RFC 78572fa9 Candidate B Phase 2)", () => {
+  it("@req:318af6a2-2c56-4db4-900e-dd0d0e36362b projects a populated class-def to prefix#slug, and the projectTBoxNames toggle is the revert axis (raw label OFF / prefix#slug ON)", () => {
+    const app = namingVault();
+
+    // GREEN: projection ON → the ontology shortName ("ems") + the slug ("TaskPrototype").
+    const on = makeResolver(app, true);
+    expect(
+      render(on, TASK_PROTO_FM, "df7e579d-02d4-4f3a-971f-3d1d785b689b"),
+    ).toBe("ems#TaskPrototype");
+
+    // RED: projection OFF → the raw exo__Asset_label (baseline, pre-projection behaviour).
+    const off = makeResolver(app, false);
+    expect(
+      render(off, TASK_PROTO_FM, "df7e579d-02d4-4f3a-971f-3d1d785b689b"),
+    ).toBe("ems__TaskPrototype");
+  });
+
+  it("@req:318af6a2-2c56-4db4-900e-dd0d0e36362b projects a populated property-def to prefix#slug", () => {
+    const r = makeResolver(namingVault(), true);
+    expect(
+      render(r, EFFORT_STATUS_FM, "bbbb2222-0000-4000-8000-000000000002"),
+    ).toBe("ems#Effort_status");
+  });
+
+  it("@req:318af6a2-2c56-4db4-900e-dd0d0e36362b FALLBACK: an unpopulated class-def (no slug, ontology no shortName) derives prefix+slug from the label", () => {
+    const r = makeResolver(namingVault(), true);
+    // slug ← label local-name "WaitingCheckTaskPrototype"; prefix ← label prefix "ems".
+    expect(render(r, WCHECK_FM, "cccc3333-0000-4000-8000-000000000003")).toBe(
+      "ems#WaitingCheckTaskPrototype",
+    );
+  });
+
+  it("@req:318af6a2-2c56-4db4-900e-dd0d0e36362b ORPHAN-NS: slug present but the ontology has no shortName → prefix derived from the label", () => {
+    const r = makeResolver(namingVault(), true);
+    expect(render(r, OKR_FM, "dddd4444-0000-4000-8000-000000000004")).toBe(
+      "okr#Objective",
+    );
+  });
+
+  it("@req:318af6a2-2c56-4db4-900e-dd0d0e36362b NO REGRESSION: an ABox instance is byte-identical (projection never fires — not a Slugable metaclass)", () => {
+    const on = makeResolver(namingVault(), true);
+    const off = makeResolver(namingVault(), false);
+    // The default template {{exo__Asset_label}} renders the label, identical whether the projection is on or off.
+    expect(render(on, TASK_FM, "eeee5555-0000-4000-8000-000000000005")).toBe(
+      "Купить молоко",
+    );
+    expect(render(off, TASK_FM, "eeee5555-0000-4000-8000-000000000005")).toBe(
+      "Купить молоко",
+    );
+  });
+
+  it("@req:318af6a2-2c56-4db4-900e-dd0d0e36362b PRECEDENCE: a participating exo__DisplayNameSpec wins over the projection", () => {
+    // A spec on the exo__Class metaclass (the override point for ALL class-def display) participates
+    // for the class-def (its exo__Instance_class = exo__Class) → the projection is subordinate.
+    const specVault = createMockApp([
+      ...ONTOLOGY_FILES,
+      { path: "taskproto.md", frontmatter: TASK_PROTO_FM },
+      {
+        path: "spec.md",
+        frontmatter: {
+          exo__Asset_uid: "ffff6666-0000-4000-8000-000000000006",
+          exo__Instance_class: [
+            `[[${DISPLAY_NAME_SPEC_UID}|exo__DisplayNameSpec]]`,
+          ],
+          exo__DisplayNameSpec_appliesToClass: `[[${EXO_CLASS}|exo__Class]]`,
+          exo__DisplayNameSpec_priority: 5,
+        },
+      },
+      {
+        path: "spec-part.md",
+        frontmatter: {
+          exo__Asset_uid: "aaaa7777-0000-4000-8000-000000000007",
+          exo__Instance_class: [
+            `[[${PRINTED_LITERAL_UID}|exo__PrintedLiteral]]`,
+          ],
+          exo__DisplayNamePart_of: "[[ffff6666-0000-4000-8000-000000000006]]",
+          exo__DisplayNamePart_order: 1,
+          exo__PrintedLiteral_literal: "CLASS-SPEC-WINS",
+        },
+      },
+    ]);
+    const r = makeResolver(specVault, true);
+    // The DisplayNameSpec template renders (NOT the ems#TaskPrototype projection).
+    expect(
+      render(r, TASK_PROTO_FM, "df7e579d-02d4-4f3a-971f-3d1d785b689b"),
+    ).toBe("CLASS-SPEC-WINS");
+  });
+});


### PR DESCRIPTION
## What

**RFC 78572fa9 Candidate B Phase 2** — the TBox **display-projection** layer. A TBox naming entity (a class-def / property-def) now displays as its computed symbolic projection `prefix#slug` (e.g. `ems#TaskPrototype`, `ems#Effort_status`) instead of its raw `exo__Asset_label` — composed per-render from the Phase-1 naming fields, **never stored** (RFC v3 point 6).

Phase 1 (req `ec019a32`, PR #3985) added + populated `exo__Slugable_slug` on 762 TBox class/property defs (via the `exo__Class`/`exo__Property` → `exo__Slugable` metaclass mixin) and `exo__Ontology_shortName` on 49 class-namespace ontologies. This PR makes those fields **show up**.

## How

`DisplayNameResolver.computeTBoxNamingProjection` wired at the top of `resolve()` — the single render point that **all 8 native-link/tab surfaces** (BodyLinkPatch, PropertiesLinkPatch, WikilinkLabelViewPlugin, GraphViewPatch, TabTitlePatch, InlineTitlePatch) **+ 3 plugin renderers** (DailyTasksRenderer, RelationsRenderer, LayoutCodeBlockProcessor) route through.

- **detection:** `exo__Instance_class` ∈ the Slugable-mixin metaclasses (`exo__Class` / `exo__Property` / `exo__{Object,Datatype,URL}Property`, matched UID **or** label) **OR** a non-empty `exo__Slugable_slug`.
- **slug** = `exo__Slugable_slug` ?? label local-name (after the first `__`)
- **prefix** = isDefinedBy ontology's `exo__Ontology_shortName` (metadataResolver two-hop) ?? label prefix (before the first `__`)
- **display** = `prefix ? prefix#slug : slug`

**Precedence / no-regression:**
- Subordinate to a participating `exo__DisplayNameSpec` (an explicit author override wins).
- **ABox instances byte-identical** — never a Slugable metaclass → the projection never fires; label/status-emoji display unchanged.
- **Fallback chain** covers entities/ontologies missing the Phase-1 fields (RFC v4: the 22 orphan-namespace prefixes display via the label-prefix fallback).
- **Store untouched** — additive display only; the converter still emits symbolic (Phase 3-4 flips emission to uid-only later, lockstep with the query name-resolver).
- **Revert axis:** `DisplayNameSettings.projectTBoxNames` (default ON, optional field → backward-compatible) → OFF restores the raw label.

Consistency: the projection reads the **same** source fields (`exo__Slugable_slug`, `exo__Ontology_shortName`) the future query-input name-resolver (Candidate E) will use → DISPLAY and QUERY stay symmetric.

## Tests

Production-shape revert-verified integration test (`@req:318af6a2-2c56-4db4-900e-dd0d0e36362b`) — builds a fixture vault via the real `PrintNameRuleService` mock-App harness (real `createMetadataResolver` isDefinedBy→ontology two-hop): populated class-def / property-def / label-fallback / orphan-ns / DisplayNameSpec-precedence / ABox-no-regression.

**Revert-verified:** `projectTBoxNames` OFF → raw label (RED) / ON → `prefix#slug` (GREEN); neutralizing `computeTBoxNamingProjection` → exactly **4 RED**, restore → 6 GREEN.

Local: typecheck 0, eslint 0, antipattern-ratchet OK, full display-name suite 137/137, settings-shape 61/61, SHACL +0 new.

## Out of scope (follow-ups)
Converter emission flip → uid-only (Phases 3-4); per-user ExoAlias (Phase 6); the 22 orphan-namespace ontology-anchor hygiene; enum-value slug population.

Req: 318af6a2-2c56-4db4-900e-dd0d0e36362b
