### PR TITLE
feat(cli): remove-property — delete a non-guarded frontmatter property (#3926)

### DIFF
--- a/packages/cli/src/commands/propertyMutationShared.ts
+++ b/packages/cli/src/commands/propertyMutationShared.ts
@@ -1,0 +1,136 @@
+import { UNPREFIXED_ASSET_FIELDS } from "@kitelev/exocortex-core";
+
+/**
+ * Shared guards + helpers for the generic frontmatter-mutation CLI verbs
+ * `set-property` (#3795 / #3848) and `remove-property` (#3926). Both apply the
+ * SAME state-machine / immutable denylists, the SAME canonical-YAML-key mapping
+ * (#3944), and the SAME timezone-deterministic `exo__Asset_updatedAt` bump — a
+ * single source of truth so a guard added here protects every mutation primitive.
+ */
+
+/**
+ * Default timezone for the `exo__Asset_updatedAt` bump. Matches `cli create`'s
+ * Asia/Almaty default; overridable with `--timezone`.
+ */
+export const DEFAULT_TIMEZONE = "Asia/Almaty";
+
+export const UPDATED_AT_KEY = "exo__Asset_updatedAt";
+
+/** `exo__Asset_<field>` shape; group 1 = the bare field name. */
+const ASSET_PREFIXED_SHAPE = /^exo__Asset_(.+)$/;
+
+/**
+ * Map an RDF property name to the canonical Obsidian YAML frontmatter KEY it is
+ * stored under (issue #3944). Most properties use their own name, but the
+ * `UNPREFIXED_ASSET_FIELDS` whitelist (`aliases`, `draft`, `pinned`, `archived`)
+ * is stored under the BARE key `<field>:` — the same key `NoteToRDFConverter`
+ * reads back as `exo:Asset_<field>`. Without this mapping, a mutation of
+ * `exo__Asset_aliases` would write/delete a literal `exo__Asset_aliases:` key
+ * instead of the canonical `aliases:` (Obsidian recognises aliases only via
+ * `aliases:`).
+ *
+ * Property NAME guards + TBox validation still run on the RDF/prefixed form
+ * (unchanged); only the physical YAML key is canonicalised here. A bare
+ * `aliases` (no `exo__Asset_` prefix) passes through unchanged — already the
+ * canonical key, no regression. `archived` is routed to a dedicated command by
+ * the guard before reaching this point, so in practice this only affects the
+ * non-guarded fields (`aliases`, `draft`, `pinned`).
+ */
+export function canonicalYamlKey(property: string): string {
+  const m = ASSET_PREFIXED_SHAPE.exec(property);
+  if (m && UNPREFIXED_ASSET_FIELDS.has(m[1])) return m[1];
+  return property;
+}
+
+/**
+ * Properties the generic mutation primitives REFUSE because a dedicated guarded
+ * `exocmd__Command` owns them — each enforces a state-machine transition or a
+ * precondition guard, so mutating the property directly would bypass that guard.
+ * The value is the dedicated command to use instead. This is a SUPERSET of the
+ * `dogfood-cli-mutation` hook's routing table: every property that has a
+ * dedicated command is refused here and routed to that command, so the generic
+ * primitives only ever handle the "everything else" class the hook leaves to them.
+ *
+ * NOT guarded (so the primitives handle them): `exo__Asset_isDefinedBy` (issue
+ * #3848 — set-property allows it with a co-location warning), and any other
+ * scalar / boolean / enum / wikilink property with no dedicated command.
+ *
+ * Looked up via {@link guardedReason} (own-key `hasOwnProperty` check) so a
+ * user-supplied property name like `toString` / `constructor` never matches an
+ * inherited Object.prototype key (#3795 review M2).
+ */
+export const GUARDED_PROPERTIES: Record<string, string> = {
+  // Status state machine (transitions carry preconditions).
+  ems__Effort_status:
+    "apply mark-done|move-to-backlog|move-to-todo|start-effort|set-draft-status <path>",
+  // Criticality zone (not-a-prototype precondition guard).
+  ems__Task_zone: "apply set-criticality-high|medium|low <path>",
+  // Parent / label — dedicated guarded commands (#3779).
+  ems__Effort_parent: 'apply set-parent <path> --input \'{"parent":"<uid>"}\'',
+  exo__Asset_label: 'apply set-label <path> --input \'{"label":"<text>"}\'',
+  // Reclassing — dedicated Convert commands (raw set desyncs class vs co-location).
+  exo__Instance_class:
+    "apply convert-to-task|convert-to-project <path>  (reclassing is a semantic operation with a precondition)",
+  // Status-transition FACT timestamps (set only as status-transition side effects).
+  ems__Effort_startTimestamp:
+    "apply start-effort <path>  (or apply remove-start-timestamp <path>)",
+  ems__Effort_endTimestamp:
+    "apply mark-done <path>  (or apply remove-end-timestamp <path>)",
+  ems__Effort_resolutionTimestamp: "apply mark-done <path>",
+  // Plan / schedule dates — dedicated commands.
+  ems__Effort_plannedStartTimestamp:
+    "apply set-planned-start|plan-on-today|plan-for-evening|shift-day-forward|shift-day-backward <path>",
+  ems__Effort_plannedEndTimestamp: "apply set-planned-end <path>",
+  ems__Effort_scheduledDate: "apply set-scheduled-date <path>",
+  // Votes — dedicated command.
+  ems__Effort_votes: "apply vote-on-effort <path>",
+  // Archive flag (bare `archived:` in frontmatter; `exo__Asset_archived` when
+  // prefixed) — dedicated archive/un-archive commands (un-archive has a Done
+  // precondition).
+  archived: "apply archive-completed|archive-ontologically|un-archive <path>",
+  exo__Asset_archived:
+    "apply archive-completed|archive-ontologically|un-archive <path>",
+};
+
+/**
+ * Properties the generic mutation primitives REFUSE as immutable identity /
+ * self-managed. The value is the reason surfaced to the user.
+ */
+export const IMMUTABLE_PROPERTIES: Record<string, string> = {
+  exo__Asset_uid:
+    "the asset identity — changing it breaks UID-canon filenames and every inbound [[uid]] wikilink",
+  [UPDATED_AT_KEY]: "auto-managed (bumped on every mutation)",
+};
+
+/** Own-key lookup on a denylist that never matches inherited Object.prototype keys. */
+export function guardedReason(
+  denylist: Record<string, string>,
+  property: string,
+): string | undefined {
+  return Object.prototype.hasOwnProperty.call(denylist, property)
+    ? denylist[property]
+    : undefined;
+}
+
+/**
+ * Render `YYYY-MM-DDTHH:MM:SS` for the given instant in `timezone`. Uses
+ * `Intl.DateTimeFormat` with an explicit `timeZone`, so the result is
+ * deterministic regardless of the runner's local timezone (mirrors
+ * `GenericAssetCreationService.generateTimestampInTimezone`).
+ */
+export function stampTimestamp(now: Date, timezone: string): string {
+  const formatter = new Intl.DateTimeFormat("en-CA", {
+    timeZone: timezone,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+    hour12: false,
+  });
+  const parts = formatter.formatToParts(now);
+  const get = (type: string): string =>
+    parts.find((p) => p.type === type)?.value ?? "00";
+  return `${get("year")}-${get("month")}-${get("day")}T${get("hour")}:${get("minute")}:${get("second")}`;
+}

--- a/packages/cli/src/commands/remove-property.ts
+++ b/packages/cli/src/commands/remove-property.ts
@@ -1,0 +1,239 @@
+import { Command } from "commander";
+import { resolve, relative, isAbsolute, sep as pathSep } from "path";
+import { existsSync, readFileSync, writeFileSync } from "fs";
+import { FrontmatterService } from "@kitelev/exocortex-core";
+import { PropertyNameValidator } from "../services/PropertyNameValidator.js";
+import { ErrorHandler } from "../utils/ErrorHandler.js";
+import {
+  VaultNotFoundError,
+  InvalidArgumentsError,
+} from "../utils/errors/index.js";
+import {
+  DEFAULT_TIMEZONE,
+  UPDATED_AT_KEY,
+  GUARDED_PROPERTIES,
+  IMMUTABLE_PROPERTIES,
+  canonicalYamlKey,
+  guardedReason,
+  stampTimestamp,
+} from "./propertyMutationShared.js";
+
+interface RemovePropertyOptions {
+  vault: string;
+  input?: string;
+  property?: string;
+  timezone?: string;
+  frozenClock?: string;
+  dryRun?: boolean;
+  yes?: boolean;
+}
+
+/**
+ * Resolve the property NAME from either `--input '{"property":"<name>"}'` (a JSON
+ * object, symmetric with `set-property`'s `--input`) or the `--property <name>`
+ * convenience form. Mutually exclusive. Removal has no value, so `--input` only
+ * carries `{"property":"<name>"}`.
+ */
+function resolveProperty(options: RemovePropertyOptions): string {
+  const hasInput = options.input !== undefined;
+  const hasProperty = options.property !== undefined;
+
+  if (hasInput && hasProperty) {
+    throw new InvalidArgumentsError(
+      "Pass --input OR --property, not both.",
+      `remove-property <path> --property <name>`,
+    );
+  }
+
+  if (hasInput) {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(options.input as string);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      throw new Error(`--input: invalid JSON (${msg})`);
+    }
+    if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+      throw new Error(
+        `--input must be a JSON object of the form {"property":"<name>"}`,
+      );
+    }
+    const property = (parsed as Record<string, unknown>).property;
+    if (typeof property !== "string" || property.trim().length === 0) {
+      throw new Error(`--input.property must be a non-empty string`);
+    }
+    return property.trim();
+  }
+
+  if (hasProperty) {
+    const property = (options.property as string).trim();
+    if (property.length === 0) {
+      throw new Error(`--property must be a non-empty name`);
+    }
+    return property;
+  }
+
+  throw new InvalidArgumentsError(
+    "No property provided.",
+    `remove-property <path> --property <name>  OR  remove-property <path> --input '{"property":"<name>"}'`,
+  );
+}
+
+/**
+ * `exocortex remove-property <path>` — the DELETE-side counterpart of
+ * `set-property` (#3795 / #3848). Removes a non-guarded frontmatter property
+ * (scalar or multi-value list) from an EXISTING vault asset, closing the
+ * "I had to raw-Edit / Bash-strip a frontmatter line" dogfooding gap (issue
+ * #3926) — a Bash strip bypasses the PreToolUse hook-coverage + SHACL floor.
+ *
+ * It shares `set-property`'s guard denylists, canonical-YAML-key mapping (#3944)
+ * and mounted-TBox property-name validation (RFC 430e84f1): a state-machine /
+ * precondition-guarded property (status/zone/parent/label/reclass/fact-timestamps/
+ * plan-dates/votes/archive) is REFUSED (naming its dedicated `apply` command) so
+ * the guard is not bypassed; the immutable identity properties (exo__Asset_uid,
+ * exo__Asset_updatedAt) are refused too. Removing a property that is already
+ * absent is an idempotent no-op success (updatedAt is bumped only when a change
+ * actually occurred).
+ *
+ * Delegates the actual deletion to `FrontmatterService.removeProperty`.
+ */
+export function removePropertyCommand(): Command {
+  return new Command("remove-property")
+    .description(
+      "Delete a non-guarded frontmatter property from an existing vault asset (bumps exo__Asset_updatedAt when a change occurs). The delete-side counterpart of set-property; refuses state-machine-guarded properties (status/zone/parent/label/fact-timestamps) — those keep their dedicated `apply` commands. Issue #3926.",
+    )
+    .argument("<path>", "Vault-relative path to the target asset")
+    .option("--vault <path>", "Path to Obsidian vault", process.cwd())
+    .option(
+      "--input <json>",
+      'JSON {"property":"<name>"} — the property to remove (symmetric with set-property\'s --input).',
+    )
+    .option(
+      "--property <name>",
+      "Property name to remove (convenience form; use --input for scripting)",
+    )
+    .option(
+      "--timezone <tz>",
+      "Timezone for the exo__Asset_updatedAt bump (defaults to Asia/Almaty)",
+    )
+    .option(
+      "--frozen-clock <iso>",
+      "Freeze the updatedAt clock to an ISO timestamp for test/replay",
+    )
+    .option("--dry-run", "Preview the resulting frontmatter without writing")
+    .option(
+      "--yes",
+      "Accepted for symmetry with the apply/create subcommands (remove-property is non-interactive; no-op)",
+    )
+    .action(async (pathArg: string, options: RemovePropertyOptions) => {
+      try {
+        const vaultPath = resolve(options.vault);
+        if (!existsSync(vaultPath)) {
+          throw new VaultNotFoundError(vaultPath);
+        }
+
+        // Resolve + guard the target path (must be inside the vault). Mirrors
+        // `set-property`'s vault-relative canonicalisation (issue #3788).
+        const targetPath = resolve(vaultPath, pathArg);
+        const vaultRelative = relative(vaultPath, targetPath);
+        if (
+          vaultRelative === ".." ||
+          vaultRelative.startsWith(`..${pathSep}`) ||
+          isAbsolute(vaultRelative)
+        ) {
+          throw new Error(
+            `Target is outside the vault: ${pathArg} (vault: ${vaultPath})`,
+          );
+        }
+
+        // Read directly and surface a friendly not-found on ENOENT — avoids an
+        // `existsSync` check-then-read/write pair (js/file-system-race, #3907).
+        let original: string;
+        try {
+          original = readFileSync(targetPath, "utf-8");
+        } catch (readError) {
+          if ((readError as NodeJS.ErrnoException).code === "ENOENT") {
+            throw new Error(`Target file not found: ${pathArg}`);
+          }
+          throw readError;
+        }
+        // Only mutate a real asset (has an exo__Asset_uid).
+        if (!/^\s*exo__Asset_uid:/m.test(original)) {
+          throw new Error(
+            `Not a vault asset (no exo__Asset_uid): ${vaultRelative}. remove-property only mutates existing assets.`,
+          );
+        }
+
+        const rawProperty = resolveProperty(options);
+        // Normalise a full-IRI-shaped property to prefixed form so the guard
+        // denylists (prefixed keys) still match (mirrors set-property).
+        const property = FrontmatterService.normalizeIRI(rawProperty);
+
+        // ── Guards (checked BEFORE any write → the file is untouched on a refusal) ──
+        const immutableReason = guardedReason(IMMUTABLE_PROPERTIES, property);
+        if (immutableReason !== undefined) {
+          throw new Error(
+            `Refusing to remove "${property}" — ${immutableReason}.`,
+          );
+        }
+        const guardedCommand = guardedReason(GUARDED_PROPERTIES, property);
+        if (guardedCommand !== undefined) {
+          throw new Error(
+            `Refusing to remove "${property}" via remove-property — it has a dedicated guarded command so the state machine / precondition is not bypassed. Use:  exocortex ${guardedCommand} --vault <v>`,
+          );
+        }
+
+        // Validate the property NAME against the mounted TBox (RFC 430e84f1 —
+        // parity with set-property / create). A NON-guarded `prefix__Name` key
+        // that does not exist in the mounted TBox is rejected fail-loud with a
+        // fuzzy suggestion; a bare YAML key (aliases/tags) is skipped; fail-open
+        // when NO property defs are mounted (degenerate/partial profile).
+        const propertyNameValidator = new PropertyNameValidator(vaultPath);
+        await propertyNameValidator.validate([property]);
+
+        // Remove under the CANONICAL YAML key (issue #3944): removing
+        // `exo__Asset_aliases` deletes the bare `aliases:` key, not a literal
+        // `exo__Asset_aliases:`. `removeProperty` returns the content UNCHANGED
+        // when the key is absent → an idempotent no-op.
+        const fm = new FrontmatterService();
+        const afterRemove = fm.removeProperty(
+          original,
+          canonicalYamlKey(property),
+        );
+        const changed = afterRemove !== original;
+
+        // Bump exo__Asset_updatedAt ONLY when a change actually occurred (an
+        // idempotent no-op removal leaves the file byte-identical).
+        let updated = afterRemove;
+        let updatedAt: string | undefined;
+        if (changed) {
+          const now = options.frozenClock
+            ? new Date(options.frozenClock)
+            : new Date();
+          const timezone = options.timezone ?? DEFAULT_TIMEZONE;
+          updatedAt = stampTimestamp(now, timezone);
+          updated = fm.updateProperty(afterRemove, UPDATED_AT_KEY, updatedAt);
+        }
+
+        if (options.dryRun) {
+          process.stderr.write(
+            `--- DRY RUN PREVIEW ---\n${updated}\n--- END PREVIEW ---\n`,
+          );
+        } else if (changed) {
+          writeFileSync(targetPath, updated, "utf-8");
+        }
+
+        const output = {
+          path: vaultRelative,
+          property,
+          removed: changed,
+          ...(updatedAt ? { updatedAt } : {}),
+        };
+        process.stdout.write(JSON.stringify(output) + "\n");
+
+        process.exit(0);
+      } catch (error) {
+        ErrorHandler.handle(error as Error);
+      }
+    });
+}

--- a/packages/cli/src/commands/set-property.ts
+++ b/packages/cli/src/commands/set-property.ts
@@ -10,7 +10,6 @@ import { existsSync, readFileSync, writeFileSync } from "fs";
 import {
   FrontmatterService,
   serializeYamlScalar,
-  UNPREFIXED_ASSET_FIELDS,
 } from "@kitelev/exocortex-core";
 import { NodeFsAdapter } from "../adapters/NodeFsAdapter.js";
 import { WikilinkValidator } from "../services/WikilinkValidator.js";
@@ -21,112 +20,17 @@ import {
   InvalidArgumentsError,
 } from "../utils/errors/index.js";
 import { resolveCoLocationFolder } from "../executors/folderRepairHelpers.js";
+import {
+  DEFAULT_TIMEZONE,
+  UPDATED_AT_KEY,
+  GUARDED_PROPERTIES,
+  IMMUTABLE_PROPERTIES,
+  canonicalYamlKey,
+  guardedReason,
+  stampTimestamp,
+} from "./propertyMutationShared.js";
 
-/**
- * Default timezone for the `exo__Asset_updatedAt` bump. Matches `cli create`'s
- * Asia/Almaty default; overridable with `--timezone`.
- */
-const DEFAULT_TIMEZONE = "Asia/Almaty";
-
-const UPDATED_AT_KEY = "exo__Asset_updatedAt";
 const ISDEFINEDBY_KEY = "exo__Asset_isDefinedBy";
-
-/** `exo__Asset_<field>` shape; group 1 = the bare field name. */
-const ASSET_PREFIXED_SHAPE = /^exo__Asset_(.+)$/;
-
-/**
- * Map an RDF property name to the canonical Obsidian YAML frontmatter KEY it
- * must be WRITTEN under (issue #3944). Most properties write under their own
- * name, but the `UNPREFIXED_ASSET_FIELDS` whitelist (`aliases`, `draft`,
- * `pinned`, `archived`) is stored under the BARE key `<field>:` — the same key
- * `NoteToRDFConverter` reads back as `exo:Asset_<field>`. Without this mapping,
- * `set-property exo__Asset_aliases` wrote a literal `exo__Asset_aliases:` key
- * ALONGSIDE the canonical `aliases:`, producing a duplicate/dead declaration
- * (Obsidian recognises aliases only via `aliases:`).
- *
- * The property NAME guards + TBox validation still run on the RDF/prefixed form
- * (unchanged); only the write key is canonicalised here. A bare `aliases` (no
- * `exo__Asset_` prefix) passes through unchanged — already the canonical key,
- * no regression (AC-2). `archived` is routed to a dedicated command by the
- * guard before reaching this point, so in practice this only affects the
- * non-guarded fields (`aliases`, `draft`, `pinned`).
- */
-function canonicalYamlKey(property: string): string {
-  const m = ASSET_PREFIXED_SHAPE.exec(property);
-  if (m && UNPREFIXED_ASSET_FIELDS.has(m[1])) return m[1];
-  return property;
-}
-
-/**
- * Properties `set-property` REFUSES because a dedicated guarded `exocmd__Command`
- * owns them — each enforces a state-machine transition or a precondition guard,
- * so setting the property directly would bypass that guard. The value is the
- * dedicated command to use instead. This is a SUPERSET of the `dogfood-cli-mutation`
- * hook's routing table: every property that has a dedicated command is refused
- * here and routed to that command, so `set-property` only ever handles the
- * "everything else" class the hook leaves to it.
- *
- * NOT guarded (so `set-property` handles them): `exo__Asset_isDefinedBy` (issue
- * #3848 — allowed, with a co-location warning), and any other scalar / boolean /
- * enum / wikilink property with no dedicated command.
- *
- * Looked up via {@link guardedReason} (own-key `hasOwnProperty` check) so a
- * user-supplied property name like `toString` / `constructor` never matches an
- * inherited Object.prototype key (#3795 review M2).
- */
-const GUARDED_PROPERTIES: Record<string, string> = {
-  // Status state machine (transitions carry preconditions).
-  ems__Effort_status:
-    "apply mark-done|move-to-backlog|move-to-todo|start-effort|set-draft-status <path>",
-  // Criticality zone (not-a-prototype precondition guard).
-  ems__Task_zone: "apply set-criticality-high|medium|low <path>",
-  // Parent / label — dedicated guarded commands (#3779).
-  ems__Effort_parent: 'apply set-parent <path> --input \'{"parent":"<uid>"}\'',
-  exo__Asset_label: 'apply set-label <path> --input \'{"label":"<text>"}\'',
-  // Reclassing — dedicated Convert commands (raw set desyncs class vs co-location).
-  exo__Instance_class:
-    "apply convert-to-task|convert-to-project <path>  (reclassing is a semantic operation with a precondition)",
-  // Status-transition FACT timestamps (set only as status-transition side effects).
-  ems__Effort_startTimestamp:
-    "apply start-effort <path>  (or apply remove-start-timestamp <path>)",
-  ems__Effort_endTimestamp:
-    "apply mark-done <path>  (or apply remove-end-timestamp <path>)",
-  ems__Effort_resolutionTimestamp: "apply mark-done <path>",
-  // Plan / schedule dates — dedicated commands.
-  ems__Effort_plannedStartTimestamp:
-    "apply set-planned-start|plan-on-today|plan-for-evening|shift-day-forward|shift-day-backward <path>",
-  ems__Effort_plannedEndTimestamp: "apply set-planned-end <path>",
-  ems__Effort_scheduledDate: "apply set-scheduled-date <path>",
-  // Votes — dedicated command.
-  ems__Effort_votes: "apply vote-on-effort <path>",
-  // Archive flag (bare `archived:` in frontmatter; `exo__Asset_archived` when
-  // prefixed) — dedicated archive/un-archive commands (un-archive has a Done
-  // precondition).
-  archived: "apply archive-completed|archive-ontologically|un-archive <path>",
-  exo__Asset_archived:
-    "apply archive-completed|archive-ontologically|un-archive <path>",
-};
-
-/**
- * Properties `set-property` REFUSES as immutable identity / self-managed. The
- * value is the reason surfaced to the user.
- */
-const IMMUTABLE_PROPERTIES: Record<string, string> = {
-  exo__Asset_uid:
-    "the asset identity — changing it breaks UID-canon filenames and every inbound [[uid]] wikilink",
-  [UPDATED_AT_KEY]:
-    "auto-managed by set-property (bumped on every mutation)",
-};
-
-/** Own-key lookup on a denylist that never matches inherited Object.prototype keys. */
-function guardedReason(
-  denylist: Record<string, string>,
-  property: string,
-): string | undefined {
-  return Object.prototype.hasOwnProperty.call(denylist, property)
-    ? denylist[property]
-    : undefined;
-}
 
 /**
  * A settable value must be a scalar (string / number / boolean) or an array of
@@ -160,29 +64,6 @@ interface SetPropertyOptions {
   frozenClock?: string;
   dryRun?: boolean;
   yes?: boolean;
-}
-
-/**
- * Render `YYYY-MM-DDTHH:MM:SS` for the given instant in `timezone`. Uses
- * `Intl.DateTimeFormat` with an explicit `timeZone`, so the result is
- * deterministic regardless of the runner's local timezone (mirrors
- * `GenericAssetCreationService.generateTimestampInTimezone`).
- */
-function stampTimestamp(now: Date, timezone: string): string {
-  const formatter = new Intl.DateTimeFormat("en-CA", {
-    timeZone: timezone,
-    year: "numeric",
-    month: "2-digit",
-    day: "2-digit",
-    hour: "2-digit",
-    minute: "2-digit",
-    second: "2-digit",
-    hour12: false,
-  });
-  const parts = formatter.formatToParts(now);
-  const get = (type: string): string =>
-    parts.find((p) => p.type === type)?.value ?? "00";
-  return `${get("year")}-${get("month")}-${get("day")}T${get("hour")}:${get("minute")}:${get("second")}`;
 }
 
 /**

--- a/packages/cli/src/program.ts
+++ b/packages/cli/src/program.ts
@@ -9,6 +9,7 @@ import { classesCommand } from "./commands/classes.js";
 import { runQueryCommand } from "./commands/run-query.js";
 import { createCommand } from "./commands/create.js";
 import { setPropertyCommand } from "./commands/set-property.js";
+import { removePropertyCommand } from "./commands/remove-property.js";
 import { repairFrontmatterCommand } from "./commands/repair-frontmatter.js";
 import { findCommand } from "./commands/find.js";
 import { applyCommand } from "./commands/apply.js";
@@ -72,6 +73,9 @@ export function createProgram(version?: string): Command {
   // Refuses state-machine-guarded properties (status/zone/parent/label/…) so their
   // dedicated `apply` commands are not bypassed.
   program.addCommand(setPropertyCommand());
+  // remove-property — the DELETE-side counterpart of set-property (#3926):
+  // deletes a non-guarded frontmatter property, sharing the same guard denylists.
+  program.addCommand(removePropertyCommand());
   // repair-frontmatter — raw-text dedupe of duplicated top-level YAML keys
   // (keep-last). The dogfood-clean repair for the invisible/unrepairable
   // duplicate-key class (#3800): fixes a file the parser itself cannot read.

--- a/packages/cli/tests/integration/remove-property.integration.test.ts
+++ b/packages/cli/tests/integration/remove-property.integration.test.ts
@@ -1,0 +1,351 @@
+/**
+ * Issue #3926 — `exocortex remove-property <path>` DELETES a non-guarded
+ * frontmatter property from an existing asset (the delete-side counterpart of
+ * `set-property` #3795 / #3848), closing the "raw-Edit / Bash-strip a frontmatter
+ * line" dogfooding gap — while REFUSING state-machine / precondition-guarded
+ * properties (so their dedicated `apply` commands are not bypassed) and the
+ * immutable identity properties.
+ *
+ * Drives the REAL `removePropertyCommand()` action end-to-end against a temp
+ * fixture vault and reads the written file back from disk — the production
+ * remove-property pipeline (FrontmatterService.removeProperty + the shared guard
+ * denylists + the canonical-YAML-key mapping), not hand-injected frontmatter
+ * (test-fixture-realism).
+ *
+ * Revert-verify (~/dotfiles/.claude/rules/integration-test-revert-verify.md) —
+ * THREE independent axes in `remove-property.ts` + `propertyMutationShared.ts`,
+ * each reddening exactly its own assertion when Edit-broken and GREEN restored:
+ *   1. removal        — neutralise `fm.removeProperty(...)` (afterRemove =
+ *      original) → the delete + updatedAt-bump assertions RED.
+ *   2. guard          — remove the `GUARDED_PROPERTIES` / `IMMUTABLE_PROPERTIES`
+ *      refusal → the guard assertions (status/label/uid/updatedAt) RED.
+ *   3. canonical key  — neutralise `canonicalYamlKey` → removing
+ *      `exo__Asset_aliases` no longer deletes the bare `aliases:` key → the
+ *      canonical-key assertion RED.
+ * The idempotent-no-op + dry-run + not-a-vault-asset negative controls isolate
+ * non-vacuity.
+ */
+import { jest, describe, it, expect, beforeEach, afterEach } from "@jest/globals";
+import * as fs from "fs";
+import * as path from "path";
+import * as os from "os";
+
+const { removePropertyCommand } = await import(
+  "../../src/commands/remove-property.js"
+);
+
+const REQ = "@req:b160178e-309f-4ef8-9402-8dc8ee9494de";
+
+const PROTOS_DIR = "assetspaces/kitelev/exoas-my/prototypes";
+const TASKS_DIR = "assetspaces/kitelev/exoas-my/tasks";
+
+const PROTO_UID = "b1b1b1b1-0000-4000-8000-000000000003";
+const TASK_UID = "c1c1c1c1-0000-4000-8000-000000000004";
+const ALIASED_UID = "e1e1e1e1-0000-4000-8000-000000000006";
+const STALE_UPDATED_AT = "2020-01-01T00:00:00";
+
+/** Frozen-clock instant → 2026-07-12T15:00:00 rendered in Asia/Almaty (UTC+5). */
+const FROZEN_CLOCK = "2026-07-12T10:00:00Z";
+const EXPECTED_UPDATED_AT = "2026-07-12T15:00:00";
+
+describe("Issue #3926: `cli remove-property` deletes a non-guarded frontmatter property", () => {
+  let vault: string;
+  let exitSpy: ReturnType<typeof jest.spyOn>;
+  let stdoutSpy: ReturnType<typeof jest.spyOn>;
+  let stderrSpy: ReturnType<typeof jest.spyOn>;
+  let logSpy: ReturnType<typeof jest.spyOn>;
+  let errorSpy: ReturnType<typeof jest.spyOn>;
+  let stdoutChunks: string[];
+  let stderrChunks: string[];
+  let exitCodes: number[];
+
+  const protoPath = `${PROTOS_DIR}/${PROTO_UID}.md`;
+  const taskPath = `${TASKS_DIR}/${TASK_UID}.md`;
+  const aliasedPath = `${PROTOS_DIR}/${ALIASED_UID}.md`;
+
+  beforeEach(() => {
+    vault = fs.mkdtempSync(path.join(os.tmpdir(), "cli-3926-"));
+    fs.mkdirSync(path.join(vault, PROTOS_DIR), { recursive: true });
+    fs.mkdirSync(path.join(vault, TASKS_DIR), { recursive: true });
+
+    // A recurring prototype carrying a non-guarded scalar property to remove.
+    fs.writeFileSync(
+      path.join(vault, protoPath),
+      [
+        "---",
+        `exo__Asset_uid: ${PROTO_UID}`,
+        'exo__Asset_label: "Weekly BAD course"',
+        "ems__EffortPrototype_startTime: 09:00",
+        "ems__EffortPrototype_endTime: 10:00",
+        `exo__Asset_updatedAt: ${STALE_UPDATED_AT}`,
+        "---",
+        "body",
+        "",
+      ].join("\n"),
+    );
+
+    // A task asset for the guard cases (has exo__Asset_uid).
+    fs.writeFileSync(
+      path.join(vault, taskPath),
+      [
+        "---",
+        `exo__Asset_uid: ${TASK_UID}`,
+        'exo__Asset_label: "A task"',
+        'ems__Effort_status: "[[done-uid]]"',
+        `exo__Asset_updatedAt: ${STALE_UPDATED_AT}`,
+        "---",
+        "body",
+        "",
+      ].join("\n"),
+    );
+
+    // An asset with a bare `aliases:` list (canonical-key case).
+    fs.writeFileSync(
+      path.join(vault, aliasedPath),
+      [
+        "---",
+        `exo__Asset_uid: ${ALIASED_UID}`,
+        'exo__Asset_label: "Dreyfus model"',
+        "aliases:",
+        '  - "Модель Дрейфуса"',
+        '  - "Dreyfus model"',
+        `exo__Asset_updatedAt: ${STALE_UPDATED_AT}`,
+        "---",
+        "body",
+        "",
+      ].join("\n"),
+    );
+
+    stdoutChunks = [];
+    stderrChunks = [];
+    exitCodes = [];
+    exitSpy = jest
+      .spyOn(process, "exit")
+      .mockImplementation(((code?: number) => {
+        exitCodes.push(code ?? 0);
+        return undefined as never;
+      }) as never);
+    stdoutSpy = jest
+      .spyOn(process.stdout, "write")
+      .mockImplementation(((chunk: unknown) => {
+        stdoutChunks.push(String(chunk));
+        return true;
+      }) as never);
+    stderrSpy = jest
+      .spyOn(process.stderr, "write")
+      .mockImplementation(((chunk: unknown) => {
+        stderrChunks.push(String(chunk));
+        return true;
+      }) as never);
+    logSpy = jest.spyOn(console, "log").mockImplementation(() => {});
+    errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    exitSpy.mockRestore();
+    stdoutSpy.mockRestore();
+    stderrSpy.mockRestore();
+    logSpy.mockRestore();
+    errorSpy.mockRestore();
+    fs.rmSync(vault, { recursive: true, force: true });
+  });
+
+  /** Run the real remove-property command; returns exit codes + on-disk content. */
+  async function run(
+    relPath: string,
+    extraArgs: string[],
+  ): Promise<{
+    exit: number[];
+    content: string;
+    stdout: string;
+    stderr: string;
+    errorLog: string;
+  }> {
+    const cmd = removePropertyCommand();
+    await cmd.parseAsync(
+      [relPath, "--vault", vault, "--frozen-clock", FROZEN_CLOCK, ...extraArgs],
+      { from: "user" },
+    );
+    return {
+      exit: [...exitCodes],
+      content: fs.readFileSync(path.join(vault, relPath), "utf-8"),
+      stdout: stdoutChunks.join(""),
+      stderr: stderrChunks.join(""),
+      errorLog: errorSpy.mock.calls.flat().join("\n"),
+    };
+  }
+
+  // ── happy path (revert axis: removal) ──
+
+  it(`deletes a non-guarded scalar property + bumps updatedAt ${REQ}`, async () => {
+    const out = await run(protoPath, [
+      "--property",
+      "ems__EffortPrototype_startTime",
+    ]);
+
+    expect(out.exit).toContain(0);
+    expect(out.exit).not.toContain(1);
+    // The key is gone; the sibling non-target property survives.
+    expect(out.content).not.toContain("ems__EffortPrototype_startTime");
+    expect(out.content).toContain("ems__EffortPrototype_endTime: 10:00");
+    // updatedAt bumped away from the stale value (a change occurred).
+    expect(out.content).toContain(`exo__Asset_updatedAt: ${EXPECTED_UPDATED_AT}`);
+    expect(out.content).not.toContain(STALE_UPDATED_AT);
+    expect(out.stdout).toContain('"removed":true');
+  });
+
+  it(`--input '{"property":"<name>"}' form removes the property (scripting parity) ${REQ}`, async () => {
+    const out = await run(protoPath, [
+      "--input",
+      '{"property":"ems__EffortPrototype_endTime"}',
+    ]);
+
+    expect(out.exit).toContain(0);
+    expect(out.content).not.toContain("ems__EffortPrototype_endTime");
+    expect(out.content).toContain("ems__EffortPrototype_startTime: 09:00");
+  });
+
+  // ── idempotent no-op negative control ──
+
+  it(`removing an ABSENT property is an idempotent no-op (file byte-unchanged, no updatedAt bump) ${REQ}`, async () => {
+    const before = fs.readFileSync(path.join(vault, protoPath), "utf-8");
+    const out = await run(protoPath, [
+      "--property",
+      "ems__EffortPrototype_recurrence",
+    ]);
+
+    expect(out.exit).toContain(0);
+    expect(out.exit).not.toContain(1);
+    // No change → file byte-identical, stale updatedAt NOT bumped.
+    expect(out.content).toBe(before);
+    expect(out.content).toContain(`exo__Asset_updatedAt: ${STALE_UPDATED_AT}`);
+    expect(out.stdout).toContain('"removed":false');
+  });
+
+  // ── #3944 canonical YAML key (revert axis: canonical key) ──
+
+  it(`remove-property exo__Asset_aliases deletes the canonical bare \`aliases:\` key ${REQ}`, async () => {
+    const out = await run(aliasedPath, [
+      "--property",
+      "exo__Asset_aliases",
+    ]);
+
+    expect(out.exit).toContain(0);
+    // The bare `aliases:` key AND its list items are gone.
+    expect(out.content).not.toMatch(/^aliases:/m);
+    expect(out.content).not.toContain("Модель Дрейфуса");
+    // No literal `exo__Asset_aliases:` key was ever present or created.
+    expect(out.content).not.toMatch(/^exo__Asset_aliases:/m);
+    // The label (a different key) survives.
+    expect(out.content).toContain('exo__Asset_label: "Dreyfus model"');
+    expect(out.stdout).toContain('"removed":true');
+  });
+
+  // ── Guard: state-machine / precondition-guarded property (revert axis: guard) ──
+
+  it(`REFUSES ems__Effort_status, naming the dedicated command, leaving the file unchanged ${REQ}`, async () => {
+    const before = fs.readFileSync(path.join(vault, taskPath), "utf-8");
+    const out = await run(taskPath, [
+      "--property",
+      "ems__Effort_status",
+    ]);
+
+    expect(out.exit).toContain(1);
+    expect(out.exit).not.toContain(0);
+    expect(out.errorLog).toMatch(/Refusing to remove "ems__Effort_status"/);
+    expect(out.errorLog).toMatch(/mark-done|move-to-backlog|start-effort/);
+    // File byte-identical — the guard did not delete anything.
+    expect(out.content).toBe(before);
+  });
+
+  it.each([
+    ["exo__Asset_label", /set-label/],
+    ["ems__Effort_parent", /set-parent/],
+    ["ems__Task_zone", /set-criticality/],
+    ["ems__Effort_plannedStartTimestamp", /set-planned-start/],
+    ["archived", /archive-completed|un-archive/],
+  ])(
+    `REFUSES guarded property %s → dedicated command, file unchanged ${REQ}`,
+    async (prop, expectedCommand) => {
+      const before = fs.readFileSync(path.join(vault, taskPath), "utf-8");
+      const out = await run(taskPath, ["--property", prop]);
+      expect(out.exit).toContain(1);
+      expect(out.errorLog).toMatch(
+        new RegExp(`Refusing to remove "${prop}"`),
+      );
+      expect(out.errorLog).toMatch(expectedCommand);
+      expect(out.content).toBe(before);
+    },
+  );
+
+  // ── Guard: immutable identity / self-managed (revert axis: guard) ──
+
+  it.each([
+    ["exo__Asset_uid", /asset identity|UID-canon/],
+    ["exo__Asset_updatedAt", /auto-managed/],
+  ])(
+    `REFUSES immutable property %s, leaving the file unchanged ${REQ}`,
+    async (prop, reason) => {
+      const before = fs.readFileSync(path.join(vault, taskPath), "utf-8");
+      const out = await run(taskPath, ["--property", prop]);
+      expect(out.exit).toContain(1);
+      expect(out.errorLog).toMatch(
+        new RegExp(`Refusing to remove "${prop}"`),
+      );
+      expect(out.errorLog).toMatch(reason);
+      expect(out.content).toBe(before);
+    },
+  );
+
+  // ── dry-run + not-a-vault-asset negative controls ──
+
+  it(`--dry-run previews the removal without writing ${REQ}`, async () => {
+    const before = fs.readFileSync(path.join(vault, protoPath), "utf-8");
+    const out = await run(protoPath, [
+      "--property",
+      "ems__EffortPrototype_startTime",
+      "--dry-run",
+    ]);
+
+    expect(out.exit).toContain(0);
+    // File on disk UNCHANGED; the preview went to stderr.
+    expect(out.content).toBe(before);
+    expect(out.stderr).toContain("DRY RUN PREVIEW");
+    expect(out.stderr).not.toContain("ems__EffortPrototype_startTime");
+  });
+
+  it(`refuses a bare markdown file with no exo__Asset_uid ${REQ}`, async () => {
+    const bareRel = `${PROTOS_DIR}/bare.md`;
+    fs.writeFileSync(path.join(vault, bareRel), "# just a note\n");
+    const out = await run(bareRel, ["--property", "ems__Effort_votes"]);
+    // ems__Effort_votes IS guarded, but the not-a-vault-asset check runs first.
+    expect(out.exit).not.toContain(0);
+    expect(out.errorLog).toMatch(/Not a vault asset/);
+  });
+
+  it(`a missing target file surfaces a friendly 'Target file not found' ${REQ}`, async () => {
+    // The `run` helper reads the file back afterwards (which would itself throw
+    // for a missing file), so drive the command directly (mirrors set-property).
+    const missingRel = `${PROTOS_DIR}/00000000-0000-4000-8000-000000000000.md`;
+    expect(fs.existsSync(path.join(vault, missingRel))).toBe(false);
+    const cmd = removePropertyCommand();
+    await cmd.parseAsync(
+      [
+        missingRel,
+        "--vault",
+        vault,
+        "--frozen-clock",
+        FROZEN_CLOCK,
+        "--property",
+        "ems__EffortPrototype_startTime",
+      ],
+      { from: "user" },
+    );
+    const errorLog = errorSpy.mock.calls.flat().join("\n");
+    // Non-zero exit + the FRIENDLY not-found message mapped from ENOENT — NOT a
+    // raw `ENOENT: no such file or directory` leak.
+    expect(exitCodes).not.toContain(0);
+    expect(errorLog).toMatch(/Target file not found/);
+    expect(errorLog).not.toMatch(/no such file or directory/i);
+  });
+});


### PR DESCRIPTION
## Summary
Closes #3926. A dedicated `exocortex remove-property <path>` verb — the **delete-side counterpart of `set-property`** (#3795/#3848). It deletes a non-guarded frontmatter property (scalar or multi-value list) from an existing vault asset, closing the recurring "I had to raw-Edit / Bash-strip a frontmatter line" dogfooding gap (a Bash strip bypasses the PreToolUse hook-coverage + SHACL floor). Empirical (2026-07-20): `/weekly-recurring-tasks` needed to remove `ems__EffortPrototype_startTime`/`_endTime` from prototypes.

## Design decision (chosen autonomously — option 2 of the issue)
A dedicated `remove-property` verb over overloading `set-property --unset` (a "set" verb that deletes is confusing UX; symmetric to set-property, mirrors `FrontmatterService.removeProperty`).

## Behavior (reuses set-property's guarantees)
- Deletes a non-guarded property via `--property <name>` or `--input '{"property":"<name>"}'`, delegating to `FrontmatterService.removeProperty`, bumping `exo__Asset_updatedAt` **only when a change occurs**.
- **REFUSES** every state-machine / precondition-guarded property (same denylist as set-property: status/zone/parent/label/instance_class/fact-timestamps/plan-dates/votes/archive), naming the dedicated `apply` command; file left byte-unchanged on refusal.
- **REFUSES** the immutable identity properties `exo__Asset_uid` / `exo__Asset_updatedAt`.
- Validates the property NAME against the mounted TBox (parity with set-property/create); removing an **absent** property is an **idempotent no-op** success.
- Canonical-YAML-key mapping (#3944): removing `exo__Asset_aliases` deletes the bare `aliases:` key (not a literal `exo__Asset_aliases:`).
- `--dry-run` previews without writing.

## Refactor (behavior-preserving, rides exempt)
The shared guard denylists + `canonicalYamlKey` (#3944) + `guardedReason` + `stampTimestamp` are extracted from `set-property.ts` into a new `packages/cli/src/commands/propertyMutationShared.ts` (single source of truth; set-property's 36 tests stay green).

## Test (revert-verified)
`packages/cli/tests/integration/remove-property.integration.test.ts` — 15 tests, `@req:b160178e-309f-4ef8-9402-8dc8ee9494de`, drive the real command end-to-end + read bytes back. **Revert-verified 3 axes:** removal (neutralise `removeProperty` → deletion RED), guard (neutralise guard → refusal RED), canonical-key (neutralise `canonicalYamlKey` → the `exo__Asset_aliases` case RED); all GREEN restored. Full CLI suite: 148/149 suites (the 1 failure is pre-existing env-only `sparql-exo003`, unrelated). Built-CLI smoke: `remove-property --help` + real removal confirmed.

Req: b160178e-309f-4ef8-9402-8dc8ee9494de
