### PR TITLE
feat(exoql): wire custom statistical aggregates (agg:median/stddev/percentile) into SPARQL (#3942)

### DIFF
--- a/packages/core/src/infrastructure/sparql/algebra/AggregateTranslator.ts
+++ b/packages/core/src/infrastructure/sparql/algebra/AggregateTranslator.ts
@@ -15,7 +15,9 @@ import type {
   Ordering,
   Variable as SparqljsVariable,
 } from "../SparqljsTypes";
-import { isVariableExpression } from "../SparqljsTypes";
+import { isVariableExpression, isFunctionCallExpression } from "../SparqljsTypes";
+import { CustomAggregateRegistry } from "../aggregates/CustomAggregateRegistry";
+import { BUILT_IN_AGGREGATES } from "../aggregates/BuiltInAggregates";
 
 /**
  * Translates SPARQL aggregate-related constructs from the sparqljs AST
@@ -70,7 +72,16 @@ export class AggregateTranslator {
         });
         aggregateVarMap.set(v.expression, v.variable.value);
       } else {
-        this.collectNestedAggregates(v.expression, aggregates, aggregateVarMap);
+        const customIri = this.customAggregateIri(v.expression);
+        if (customIri) {
+          aggregates.push({
+            variable: v.variable.value,
+            expression: this.translateCustomAggregateFunctionCall(v.expression, customIri),
+          });
+          aggregateVarMap.set(v.expression, v.variable.value);
+        } else {
+          this.collectNestedAggregates(v.expression, aggregates, aggregateVarMap);
+        }
       }
     }
 
@@ -237,6 +248,57 @@ export class AggregateTranslator {
   }
 
   /**
+   * If `expr` is a function-call to a registered custom aggregate, return its IRI.
+   *
+   * sparqljs only tags the built-in SPARQL aggregates (COUNT/SUM/AVG/MIN/MAX/
+   * GROUP_CONCAT/SAMPLE) as `type:"aggregate"`. A prefixed IRI call such as
+   * `agg:median(?x)` is parsed as a plain `functionCall`, so without this bridge it
+   * never reaches the aggregate path and its projection variable is silently dropped
+   * (issue #3942). The `agg:median`/`agg:stddev`/`agg:variance`/`agg:mode`/
+   * `agg:percentileNN` implementations already exist in BUILT_IN_AGGREGATES and the
+   * AggregateExecutor computes them — this recognizes the call so they are reachable.
+   *
+   * @returns the aggregate IRI if the call targets a registered custom aggregate
+   *          (built-in or user-registered), else null.
+   */
+  private customAggregateIri(expr: SparqljsExpression): string | null {
+    if (!isFunctionCallExpression(expr)) return null;
+    const fn = (expr as { function?: unknown }).function;
+    let iri: string | null = null;
+    if (typeof fn === "string") {
+      iri = fn;
+    } else if (fn && typeof fn === "object" && "value" in fn) {
+      iri = String((fn as { value: unknown }).value);
+    }
+    if (!iri) return null;
+    const registered =
+      iri in BUILT_IN_AGGREGATES ||
+      CustomAggregateRegistry.getInstance().get(iri) !== undefined;
+    return registered ? iri : null;
+  }
+
+  /**
+   * Translate a `functionCall` node targeting a registered custom aggregate into an
+   * aggregate expression (mirrors the IRI branch of translateAggregateExpression).
+   */
+  private translateCustomAggregateFunctionCall(
+    expr: SparqljsExpression,
+    iri: string
+  ): AggregateExpression {
+    const fc = expr as unknown as {
+      args?: SparqljsExpression[];
+      distinct?: boolean;
+    };
+    const arg = fc.args && fc.args.length > 0 ? fc.args[0] : undefined;
+    return {
+      type: "aggregate",
+      aggregation: { type: "custom", iri },
+      expression: arg ? this.translateExpressionFn(arg) : undefined,
+      distinct: fc.distinct || false,
+    };
+  }
+
+  /**
    * Recursively collect all aggregate expressions nested within an expression tree.
    */
   private collectNestedAggregates(
@@ -253,7 +315,21 @@ export class AggregateTranslator {
         expression: this.translateAggregateExpression(expr as SparqljsAggregateExpression),
       });
       aggregateVarMap.set(expr, varName);
-    } else if ("type" in expr && expr.type === "operation" && "args" in expr) {
+      return;
+    }
+
+    const customIri = this.customAggregateIri(expr);
+    if (customIri) {
+      const varName = `__agg${this.aggregateCounter++}`;
+      aggregates.push({
+        variable: varName,
+        expression: this.translateCustomAggregateFunctionCall(expr, customIri),
+      });
+      aggregateVarMap.set(expr, varName);
+      return;
+    }
+
+    if ("type" in expr && expr.type === "operation" && "args" in expr) {
       const opExpr = expr as OperationExpression;
       for (const arg of opExpr.args) {
         if (!Array.isArray(arg) && "type" in arg && !("patterns" in arg)) {

--- a/packages/core/tests/integration/sparql/custom-stats-aggregates.test.ts
+++ b/packages/core/tests/integration/sparql/custom-stats-aggregates.test.ts
@@ -1,0 +1,122 @@
+import { SPARQLParser } from "../../../src/infrastructure/sparql/SPARQLParser";
+import { AlgebraTranslator } from "../../../src/infrastructure/sparql/algebra/AlgebraTranslator";
+import { QueryExecutor } from "../../../src/infrastructure/sparql/executors/QueryExecutor";
+import { InMemoryTripleStore } from "../../../src/infrastructure/rdf/InMemoryTripleStore";
+import { Triple } from "../../../src/domain/models/rdf/Triple";
+import { IRI } from "../../../src/domain/models/rdf/IRI";
+import { Literal } from "../../../src/domain/models/rdf/Literal";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const getValue = (term: any): string | undefined => {
+  if (term === undefined || term === null) return undefined;
+  if (typeof term === "number") return String(term);
+  if (typeof term === "string") return term;
+  if (term && typeof term === "object") {
+    if ("value" in term) return term.value;
+    if ("id" in term) return term.id;
+  }
+  return undefined;
+};
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const num = (term: any): number => Number(getValue(term));
+
+const EX = "http://example.org/";
+const AGG = "https://exocortex.my/ontology/agg#";
+const XSD_INTEGER = new IRI("http://www.w3.org/2001/XMLSchema#integer");
+
+/**
+ * Regression guard for issue #3942 — the built-in statistical aggregates
+ * (`agg:median` / `agg:stddev` / `agg:variance` / `agg:mode` / `agg:percentileNN`)
+ * are implemented in BUILT_IN_AGGREGATES and computed by AggregateExecutor, but
+ * were UNREACHABLE from SPARQL: sparqljs parses `agg:median(?x)` as a plain
+ * `functionCall` (not an `aggregate` node), so AggregateTranslator never created an
+ * aggregate binding and the projection variable silently vanished from the group
+ * row (the median/σ/quartile columns were absent — forcing analytics to Python).
+ * AggregateTranslator now recognizes a function-call to a registered custom
+ * aggregate and wires it into the aggregation path.
+ *
+ * Revert-verify: remove the `customAggregateIri` wiring in AggregateTranslator and
+ * the `agg:*` columns disappear from the group row → `?med`/`?sd`/`?q1`/`?q3`
+ * become undefined → `num(...)` is NaN → these assertions go RED.
+ */
+describe("ExoQL custom statistical aggregates reachable from SPARQL (#3942)", () => {
+  let parser: SPARQLParser;
+  let translator: AlgebraTranslator;
+  let executor: QueryExecutor;
+  let store: InMemoryTripleStore;
+
+  const val = (i: number, v: number): Triple =>
+    new Triple(
+      new IRI(`${EX}s${i}`),
+      new IRI(`${EX}val`),
+      new Literal(String(v), XSD_INTEGER),
+    );
+
+  beforeEach(async () => {
+    parser = new SPARQLParser();
+    translator = new AlgebraTranslator();
+    store = new InMemoryTripleStore();
+    executor = new QueryExecutor(store);
+    // values 10,20,30,40,50 → median 30, population σ = √200 ≈ 14.142, p25 20, p75 40
+    await store.addAll([10, 20, 30, 40, 50].map((v, i) => val(i, v)));
+  });
+
+  const run = async (q: string) => {
+    const algebra = translator.translate(parser.parse(q));
+    return executor.executeAll(algebra);
+  };
+
+  it("agg:median / agg:stddev / agg:percentileNN produce result columns in an aggregation query", async () => {
+    const rows = await run(`
+      PREFIX ex: <${EX}>
+      PREFIX agg: <${AGG}>
+      SELECT (COUNT(?v) AS ?n) (agg:median(?v) AS ?med) (agg:stddev(?v) AS ?sd)
+             (agg:percentile25(?v) AS ?q1) (agg:percentile75(?v) AS ?q3)
+      WHERE { ?s ex:val ?v }
+    `);
+    expect(rows).toHaveLength(1);
+    const r = rows[0];
+    expect(num(r.get("n"))).toBe(5);
+    expect(num(r.get("med"))).toBe(30);
+    expect(num(r.get("sd"))).toBeCloseTo(Math.sqrt(200), 6);
+    expect(num(r.get("q1"))).toBe(20);
+    expect(num(r.get("q3"))).toBe(40);
+  });
+
+  it("agg:median composes with GROUP BY (per-group medians)", async () => {
+    await store.addAll([
+      new Triple(new IRI(`${EX}s0`), new IRI(`${EX}cat`), new Literal("A")),
+      new Triple(new IRI(`${EX}s1`), new IRI(`${EX}cat`), new Literal("A")),
+      new Triple(new IRI(`${EX}s2`), new IRI(`${EX}cat`), new Literal("A")),
+      new Triple(new IRI(`${EX}s3`), new IRI(`${EX}cat`), new Literal("B")),
+      new Triple(new IRI(`${EX}s4`), new IRI(`${EX}cat`), new Literal("B")),
+    ]);
+    const rows = await run(`
+      PREFIX ex: <${EX}>
+      PREFIX agg: <${AGG}>
+      SELECT ?cat (agg:median(?v) AS ?med)
+      WHERE { ?s ex:val ?v ; ex:cat ?cat } GROUP BY ?cat ORDER BY ?cat
+    `);
+    expect(rows).toHaveLength(2);
+    expect(getValue(rows[0].get("cat"))).toBe("A"); // 10,20,30 → 20
+    expect(num(rows[0].get("med"))).toBe(20);
+    expect(getValue(rows[1].get("cat"))).toBe("B"); // 40,50 → 45
+    expect(num(rows[1].get("med"))).toBe(45);
+  });
+
+  it("agg:mode returns the most frequent value", async () => {
+    const s = new InMemoryTripleStore();
+    const ex2 = new QueryExecutor(s);
+    await s.addAll([5, 5, 7, 5, 9].map((v, i) => val(i, v)));
+    const algebra = translator.translate(
+      parser.parse(`
+        PREFIX ex: <${EX}>
+        PREFIX agg: <${AGG}>
+        SELECT (agg:mode(?v) AS ?mode) (COUNT(?v) AS ?n) WHERE { ?s ex:val ?v }
+      `),
+    );
+    const rows = await ex2.executeAll(algebra);
+    expect(rows).toHaveLength(1);
+    expect(num(rows[0].get("mode"))).toBe(5);
+  });
+});


### PR DESCRIPTION
## Summary
Addresses #3942 (Gap 1). Audit-first finding: the statistical aggregates the self-audit needed — **`agg:median` / `agg:stddev` / `agg:variance` / `agg:mode` / `agg:percentile{25,50,75,90,95,99}`** — were **already implemented** in `BUILT_IN_AGGREGATES` and computed by `AggregateExecutor`, but were **unreachable from SPARQL**: sparqljs parses `agg:median(?x)` as a plain `functionCall` (not an `aggregate` node), so `AggregateTranslator` never created an aggregate binding and the projection variable **silently vanished** from the group row — which is exactly why the breakfast self-audit escaped to Python.

## Fix (pure wiring — compute already existed)
`AggregateTranslator` now recognizes a `functionCall` whose IRI is a **registered** custom aggregate (`BUILT_IN_AGGREGATES` or a `CustomAggregateRegistry` entry) and wires it into the aggregation path — both the direct projection (`extractAggregatesWithMapping`) and the nested/arithmetic/HAVING collection (`collectNestedAggregates`). No misclassification risk: only IRIs in the aggregate registry are treated as aggregates; a query with a bare `agg:*` call now also correctly triggers the aggregation (`GROUP`) operation. DISTINCT and value extraction are unchanged (the executor already supported custom aggregates).

## Real-CLI acceptance (over the real vault, `HOURS(?e)` of end timestamps)
Before this PR these columns were **absent**; now:
```
median=14.5  stddev=5.93  p25=10  p75=19  mode=23   (n=140, mean=14.25)
```

## Revert-verify
`packages/core/tests/integration/sparql/custom-stats-aggregates.test.ts` runs the full `parse → translate → executeAll` pipeline over a hand-computable fixture (`10,20,30,40,50` → median 30, σ=√200, p25 20, p75 40). Empirically: revert the `customAggregateIri` wiring → the `agg:*` columns drop → values become `NaN` → **RED** (3/3); restore → **GREEN**. Also covers `agg:median` composing with `GROUP BY` (per-group medians) and `agg:mode`.

## Scope decision (AC#3) + deferred follow-ups
- **Decision recorded:** *extend ExoQL aggregates* (wire the existing registry) rather than a dedicated `stats` subcommand — the aggregates compose with `GROUP BY`/`ORDER BY`/`HAVING` and were 90% built.
- **Histogram bucketing** — already achievable today via `(FLOOR(?x / bucket) AS ?b) … GROUP BY (FLOOR(…))` (no new feature; will document).
- **Deferred (separate follow-ups):** multivariate `CORR(?x,?y)` / linear regression (two-argument aggregate shape — needs its own design); and Gap 2 archive-aware `--include-archive` flag (CLI + registry-descriptor resolution). I'll file these as follow-up issues.

## Verification
Full `packages/core` suite green (354 suites / 8424 tests, submodules initialized); typecheck 0; the 3 CI guard-scripts pass (ratchet 55/55 unchanged).
