### PR TITLE
feat(#3956): plugin mount-closure completeness warning (Add-AssetSpace + Apply-profile)

### DIFF
--- a/packages/obsidian-plugin/src/ExocortexPlugin.ts
+++ b/packages/obsidian-plugin/src/ExocortexPlugin.ts
@@ -4095,6 +4095,14 @@ export default class ExocortexPlugin extends Plugin {
               : void bootstrapCommands.invokeAddAssetSpace(),
         }).open(),
       onMaterialized: () => this.refreshAndInjectAssetSpaceMaterialization(),
+      // #3956 — delegate the dependsOn-closure completeness check to the mount
+      // authority so «Add AssetSpace by URL» warns specifically when the added
+      // AssetSpace's dependsOn (esp. the exocmd class-TBox) is left unmounted.
+      // Lazily reads `this.profileApplyManager` (set later in onload); null-safe
+      // (an unwired manager → empty inputs → the generic advisory).
+      getClosureCheckInputs: () =>
+        this.profileApplyManager?.getClosureCheckInputs() ??
+        Promise.resolve({ infos: [], materializedUids: new Set<string>() }),
     });
 
     // RFC 0002 §3.2 (P3) — de-jargon: «Bootstrap vault» → «Set up the engine»

--- a/packages/obsidian-plugin/src/domain/profile/closureGap.ts
+++ b/packages/obsidian-plugin/src/domain/profile/closureGap.ts
@@ -1,0 +1,107 @@
+import { transitiveDependsOnClosure } from "@kitelev/exocortex-core";
+import type { AssetSpaceInfo } from "../../infrastructure/adapters/AssetSpaceManager";
+
+/**
+ * issue #3956 — one member of a mount's `exo__AssetSpace_dependsOn` closure that
+ * is NOT currently materialized on disk.
+ */
+export interface UnmountedClosureMember {
+  /** The AssetSpace UID. */
+  uid: string;
+  /**
+   * `exo__AssetSpace_namespace` (e.g. `"exocmd"`) when the descriptor is scanned,
+   * else the short UID — a user-legible name for the warning.
+   */
+  label: string;
+  /**
+   * True when this AssetSpace supplies class / command-binding-resolution TBox
+   * whose absence silently breaks homoiconic commands + SHACL validation
+   * (#3956): the `exo` SDK floor + the `exocmd` command TBox. Only knowable when
+   * the descriptor is scanned (namespace present).
+   */
+  providesTBox: boolean;
+}
+
+/**
+ * The namespaces whose AssetSpace supplies command/binding-resolution TBox.
+ * `exo` = the class/property defs + the RDF engine floor; `exocmd` = the
+ * `exocmd__Command`/`Precondition`/`Grounding`/`CommandBinding` class defs +
+ * grounding-type enums that `CommandResolver.loadCommand` matches `rdf:type`
+ * against. Their absence is the exact gap that left the alpha tester's entire
+ * homoiconic command system silently dead (RFC 430e84f1 P3).
+ */
+const TBOX_PROVIDER_NAMESPACES: ReadonlySet<string> = new Set(["exo", "exocmd"]);
+
+/**
+ * issue #3956 — the transitive `exo__AssetSpace_dependsOn` closure members of
+ * `roots` that are NOT in `materializedUids` (their folder is not present on
+ * disk). An incomplete closure leaves a declared dependency (especially the
+ * `exocmd` class-TBox) silently unmounted, so the RDF converter can't resolve
+ * `exo__Instance_class: [[<uid>]]` to the class label → homoiconic commands +
+ * bindings become silently dead. Surfacing this makes the gap fail LOUD.
+ *
+ * Pure: builds the `dependsOn` map from `allInfos`, computes the closure of
+ * `roots` via the shared {@link transitiveDependsOnClosure} (the SAME helper
+ * `ProfileApplyManager.resolveDeclaredAndEffective` + `CliProfileResolver` use),
+ * and returns each closure member whose UID is not materialized. A materialized
+ * root is skipped (it satisfies the check). A closure member with no scanned
+ * descriptor (not in `allInfos`) is still reported — it can never be
+ * materialized without adding it — but with the short UID as its label and
+ * `providesTBox=false` (namespace unknown).
+ *
+ * @param roots The directly-mounted / declared AssetSpace UIDs to check.
+ * @param allInfos The scanned AssetSpace catalogue (carries `dependsOn` edges).
+ * @param materializedUids The AssetSpace UIDs currently present on disk.
+ * @returns The unmounted closure members (empty when the closure is complete).
+ */
+export function detectUnmountedClosureMembers(
+  roots: Iterable<string>,
+  allInfos: ReadonlyArray<AssetSpaceInfo>,
+  materializedUids: ReadonlySet<string>,
+): UnmountedClosureMember[] {
+  const dependsOnMap = new Map<string, string[]>();
+  const infoByUid = new Map<string, AssetSpaceInfo>();
+  for (const info of allInfos) {
+    infoByUid.set(info.uid, info);
+    if (info.dependsOn !== undefined && info.dependsOn.length > 0) {
+      dependsOnMap.set(info.uid, info.dependsOn);
+    }
+  }
+  const closure = transitiveDependsOnClosure(new Set(roots), dependsOnMap);
+  const missing: UnmountedClosureMember[] = [];
+  for (const uid of closure) {
+    if (materializedUids.has(uid)) continue;
+    const namespace = infoByUid.get(uid)?.namespace ?? "";
+    missing.push({
+      uid,
+      label: namespace.length > 0 ? namespace : uid.slice(0, 8),
+      providesTBox: TBOX_PROVIDER_NAMESPACES.has(namespace),
+    });
+  }
+  return missing;
+}
+
+/**
+ * issue #3956 — render a single non-fatal WARNING line naming the unmounted
+ * closure members + the remedy. `contextLabel` describes what triggered the
+ * check (e.g. the added AssetSpace's namespace, or the applied profile). Returns
+ * `null` for an empty gap (nothing to warn about — no false-positive).
+ */
+export function formatClosureGapWarning(
+  members: ReadonlyArray<UnmountedClosureMember>,
+  contextLabel: string,
+): string | null {
+  if (members.length === 0) return null;
+  const names = members.map((m) => m.label).join(", ");
+  const tbox = members.filter((m) => m.providesTBox).map((m) => m.label);
+  const tboxNote =
+    tbox.length > 0
+      ? ` ${tbox.join(", ")} provide the class / command TBox — without them, ` +
+        `homoiconic commands and validation are silently broken.`
+      : "";
+  const plural = members.length === 1;
+  return (
+    `⚠ ${contextLabel} depends on {${names}} which ${plural ? "is" : "are"} not mounted.` +
+    `${tboxNote} Run «Apply profile» or add ${plural ? "it" : "them"} via «Add AssetSpace by URL».`
+  );
+}

--- a/packages/obsidian-plugin/src/infrastructure/adapters/BootstrapAssetSpaceCommands.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/BootstrapAssetSpaceCommands.ts
@@ -44,6 +44,11 @@
  */
 
 import { derivePath } from "@kitelev/exocortex-core";
+import {
+  detectUnmountedClosureMembers,
+  formatClosureGapWarning,
+} from "../../domain/profile/closureGap";
+import type { AssetSpaceInfo } from "./AssetSpaceManager";
 
 /** Subset of {@link AssetSpaceManager} used here (REST tarball pull). */
 export interface IAssetSpacePuller {
@@ -248,6 +253,19 @@ export interface BootstrapAssetSpaceCommandsDeps {
    * re-index the freshly added assets. Failures are swallowed (best-effort).
    */
   onMaterialized?: () => Promise<void>;
+  /**
+   * issue #3956 — the inputs for a dependsOn-closure completeness check: the
+   * scanned AssetSpace catalogue (with `exo__AssetSpace_dependsOn` edges) + the
+   * UIDs currently materialised on disk. Wired in production to delegate to
+   * `ProfileApplyManager.getClosureCheckInputs`. When present, `Add AssetSpace
+   * by URL` warns specifically (naming the missing member[s]) instead of the
+   * generic "dependencies are not auto-resolved" advisory; when absent (or the
+   * added AssetSpace has no scanned descriptor), the generic advisory is kept.
+   */
+  getClosureCheckInputs?: () => Promise<{
+    infos: AssetSpaceInfo[];
+    materializedUids: Set<string>;
+  }>;
   /** Branch ref to pull from. Default `"main"`. */
   ref?: string;
 }
@@ -427,9 +445,18 @@ export class BootstrapAssetSpaceCommands {
 
     try {
       const m = await this.materialize(res.url, submodulePath, isGit);
+      // #3956 — detect an INCOMPLETE dependsOn-closure at add time and warn
+      // SPECIFICALLY (naming the missing member[s] + flagging TBox-providers).
+      // This is the exact subset-add gap that left the alpha tester's homoiconic
+      // command system silently dead: `exoas-public` mounted, its dependsOn
+      // `exoas-exocmd` class-TBox never mounted → `CommandResolver.loadCommand`
+      // fails on every command. Falls back to the generic advisory when the
+      // closure-inputs dep is unwired or the added AssetSpace has no gap.
+      const gapNote = await this.closureGapNote(res.url, m.folderName);
       this.d.notify(
-        `AssetSpace added — ${m.folderName}@${m.sha} ← ${res.url}. ` +
-          "Add any AssetSpaces it depends on manually — dependencies are not auto-resolved.",
+        `AssetSpace added — ${m.folderName}@${m.sha} ← ${res.url}.` +
+          (gapNote ??
+            " Add any AssetSpaces it depends on manually — dependencies are not auto-resolved."),
       );
     } catch (e) {
       this.d.notify(`Add AssetSpace failed: ${this.msg(e)}`);
@@ -438,6 +465,41 @@ export class BootstrapAssetSpaceCommands {
       return;
     }
     await this.runOnMaterialized();
+  }
+
+  /**
+   * issue #3956 — the SPECIFIC dependsOn-closure gap warning for the AssetSpace
+   * just added (`url` / `folderName`), or `null` to fall back to the generic
+   * advisory. Locates the added AssetSpace's scanned descriptor (by source URL,
+   * then folder), computes its `exo__AssetSpace_dependsOn` closure, and warns for
+   * every closure member not currently materialised. Best-effort + non-fatal —
+   * any failure returns `null` (the add already succeeded).
+   */
+  private async closureGapNote(
+    url: string,
+    folderName: string,
+  ): Promise<string | null> {
+    const getInputs = this.d.getClosureCheckInputs;
+    if (getInputs === undefined) return null;
+    try {
+      const { infos, materializedUids } = await getInputs();
+      const added = infos.find(
+        (i) => i.git === url || i.folderName === folderName,
+      );
+      if (added === undefined) return null; // no scanned descriptor → generic
+      const missing = detectUnmountedClosureMembers(
+        [added.uid],
+        infos,
+        materializedUids,
+      );
+      const warning = formatClosureGapWarning(
+        missing,
+        added.namespace.length > 0 ? added.namespace : "The added AssetSpace",
+      );
+      return warning === null ? null : ` ${warning}`;
+    } catch {
+      return null; // best-effort — never fail the add on a diagnostic
+    }
   }
 
   // ─────────────────────────── internal ───────────────────────────

--- a/packages/obsidian-plugin/src/infrastructure/adapters/ProfileApplyManager.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/ProfileApplyManager.ts
@@ -11,6 +11,10 @@ import {
   isAssetSpaceFrontmatter,
 } from "@kitelev/exocortex-core";
 
+import {
+  detectUnmountedClosureMembers,
+  formatClosureGapWarning,
+} from "../../domain/profile/closureGap";
 import { PluginLockManager } from "./PluginLockManager";
 import { nodeFsPromises } from "./lazyNodeModules";
 import type { AssetSpaceManager, AssetSpaceInfo } from "./AssetSpaceManager";
@@ -925,10 +929,8 @@ export class ProfileApplyManager {
     // declared (closure) set — NOT resolveEffectiveSet — so the floor URIs it
     // would inject don't mask a profile that legitimately omits a floor AS.
     const allInfos = this.listAllAssetSpaceInfos();
-    const { effectiveAsUids } = await this.resolveDeclaredAndEffective(
-      targetProfileUid,
-      allInfos,
-    );
+    const { declaredAsUids, effectiveAsUids } =
+      await this.resolveDeclaredAndEffective(targetProfileUid, allInfos);
 
     // Compute toDestroy / toMaterialize via .gitmodules ∩ filesystem presence.
     // Phase 6 Vision Lock #9 amendment: `.gitmodules` entries persist post-destroy
@@ -1090,6 +1092,14 @@ export class ProfileApplyManager {
       targetProfileLabel,
       () => this.clearStuckLocalState(deps.localDataStore),
       this.computeApplyDeadlineMs(toDestroy.length + toMaterialize.length),
+    );
+    // #3956 belt-and-suspenders — WARN on any dependsOn-closure member the
+    // profile declares but apply could not materialize (no scanned descriptor).
+    this.emitClosureGapWarning(
+      declaredAsUids,
+      allInfos,
+      effectiveAsUids,
+      `Profile "${targetProfileLabel}"`,
     );
   }
 
@@ -1575,10 +1585,8 @@ export class ProfileApplyManager {
     // R24 floor (UID OR namespace). Uses the declared (closure) set — NOT
     // resolveEffectiveSet — which would silently inject floor ontologies.
     const allInfos = this.listAllAssetSpaceInfos();
-    const { effectiveAsUids } = await this.resolveDeclaredAndEffective(
-      targetProfileUid,
-      allInfos,
-    );
+    const { declaredAsUids, effectiveAsUids } =
+      await this.resolveDeclaredAndEffective(targetProfileUid, allInfos);
 
     // 2. Diff: materialised == folder exists on disk (mount-state, derivePath).
     const infoBySubmodulePath = new Map<string, AssetSpaceInfo>();
@@ -1728,6 +1736,14 @@ export class ProfileApplyManager {
       targetProfileLabel,
       () => this.clearStuckLocalState(localDataStore),
       this.computeApplyDeadlineMs(toDestroy.length + toMaterialize.length),
+    );
+    // #3956 belt-and-suspenders — WARN on any dependsOn-closure member the
+    // profile declares but apply could not materialize (no scanned descriptor).
+    this.emitClosureGapWarning(
+      declaredAsUids,
+      allInfos,
+      effectiveAsUids,
+      `Profile "${targetProfileLabel}"`,
     );
   }
 
@@ -2479,6 +2495,56 @@ export class ProfileApplyManager {
    * TS-floor) for the mount-state diff. Shared by the desktop + REST apply paths
    * to keep the resolution logic identical (parity invariant).
    */
+  /**
+   * issue #3956 — the inputs a dependsOn-closure completeness check needs: the
+   * scanned AssetSpace catalogue (`dependsOn` edges) + the UIDs currently
+   * materialized on disk (their folder exists). Cross-platform (folder presence,
+   * not `.gitmodules`). Exposed so the plugin's `Add AssetSpace by URL` command
+   * can detect an incomplete mount-closure at add time (the exact subset-add gap
+   * that left the alpha tester's homoiconic commands silently dead).
+   */
+  public async getClosureCheckInputs(): Promise<{
+    infos: AssetSpaceInfo[];
+    materializedUids: Set<string>;
+  }> {
+    const infos = this.listAllAssetSpaceInfos();
+    const materializedUids = new Set<string>();
+    for (const info of infos) {
+      if (await this.app.vault.adapter.exists(info.folderName)) {
+        materializedUids.add(info.uid);
+      }
+    }
+    return { infos, materializedUids };
+  }
+
+  /**
+   * issue #3956 — belt-and-suspenders: after an apply materializes, WARN (via
+   * `notify`) for any `exo__AssetSpace_dependsOn`-closure member of `roots` left
+   * unmaterialized (`materializedUids` is the set apply intended to mount — a
+   * closure member with no scanned descriptor is silently dropped by
+   * {@link resolveDeclaredAndEffective} and can never be materialized). Non-fatal
+   * + best-effort: never changes the apply outcome. NO warning when the closure
+   * is complete (no false-positive).
+   */
+  private emitClosureGapWarning(
+    roots: Iterable<string>,
+    allInfos: ReadonlyArray<AssetSpaceInfo>,
+    materializedUids: ReadonlySet<string>,
+    contextLabel: string,
+  ): void {
+    try {
+      const missing = detectUnmountedClosureMembers(
+        roots,
+        allInfos,
+        materializedUids,
+      );
+      const warning = formatClosureGapWarning(missing, contextLabel);
+      if (warning !== null) this.notify(warning);
+    } catch {
+      // Best-effort diagnostic — never let a closure-gap check fail the apply.
+    }
+  }
+
   private async resolveDeclaredAndEffective(
     targetProfileUid: string,
     allInfos: ReadonlyArray<AssetSpaceInfo>,

--- a/packages/obsidian-plugin/tests/unit/domain/profile/closureGap.test.ts
+++ b/packages/obsidian-plugin/tests/unit/domain/profile/closureGap.test.ts
@@ -1,0 +1,137 @@
+import {
+  detectUnmountedClosureMembers,
+  formatClosureGapWarning,
+} from "../../../../src/domain/profile/closureGap";
+import type { AssetSpaceInfo } from "../../../../src/infrastructure/adapters/AssetSpaceManager";
+
+/** Minimal AssetSpaceInfo fixture (only the fields the helper reads). */
+function info(
+  uid: string,
+  namespace: string,
+  dependsOn?: string[],
+): AssetSpaceInfo {
+  return {
+    uid,
+    git: `https://github.com/kitelev/exoas-${namespace}`,
+    namespace,
+    folderName: `assetspaces/kitelev/exoas-${namespace}`,
+    ...(dependsOn ? { dependsOn } : {}),
+  };
+}
+
+const PUBLIC = "aaaa1111-0000-0000-0000-000000000001";
+const EXOCMD = "bbbb2222-0000-0000-0000-000000000002";
+const EXO = "cccc3333-0000-0000-0000-000000000003";
+const W3C = "dddd4444-0000-0000-0000-000000000004";
+
+describe("detectUnmountedClosureMembers (#3956)", () => {
+  // exoas-public --dependsOn--> {exoas-exocmd, exoas-w3c}; exoas-exocmd --> exoas-exo.
+  const catalogue: AssetSpaceInfo[] = [
+    info(PUBLIC, "public", [EXOCMD, W3C]),
+    info(EXOCMD, "exocmd", [EXO]),
+    info(EXO, "exo"),
+    info(W3C, "w3c"),
+  ];
+
+  it("reports the unmaterialized closure members of a root (the subset-add gap)", () => {
+    // Only exoas-public itself is materialized (subset add).
+    const missing = detectUnmountedClosureMembers(
+      [PUBLIC],
+      catalogue,
+      new Set([PUBLIC]),
+    );
+    const uids = missing.map((m) => m.uid).sort();
+    expect(uids).toEqual([EXO, EXOCMD, W3C].sort());
+  });
+
+  it("flags the TBox-provider closure members (exo + exocmd), not the rest (AC3)", () => {
+    const missing = detectUnmountedClosureMembers(
+      [PUBLIC],
+      catalogue,
+      new Set([PUBLIC]),
+    );
+    const byUid = new Map(missing.map((m) => [m.uid, m]));
+    expect(byUid.get(EXOCMD)?.providesTBox).toBe(true);
+    expect(byUid.get(EXO)?.providesTBox).toBe(true);
+    expect(byUid.get(W3C)?.providesTBox).toBe(false);
+    // The member label = its namespace (user-legible).
+    expect(byUid.get(EXOCMD)?.label).toBe("exocmd");
+  });
+
+  it("emits NO gap when the full closure is materialized (no false-positive)", () => {
+    const missing = detectUnmountedClosureMembers(
+      [PUBLIC],
+      catalogue,
+      new Set([PUBLIC, EXOCMD, EXO, W3C]),
+    );
+    expect(missing).toEqual([]);
+  });
+
+  it("skips a materialized root but still reports its unmounted deps", () => {
+    const missing = detectUnmountedClosureMembers(
+      [PUBLIC],
+      catalogue,
+      new Set([PUBLIC, EXO, W3C]), // only exocmd missing
+    );
+    expect(missing.map((m) => m.uid)).toEqual([EXOCMD]);
+    expect(missing[0].providesTBox).toBe(true);
+  });
+
+  it("reports a closure member with no scanned descriptor using its short UID", () => {
+    // exoas-public depends on a UID that has no descriptor in the catalogue.
+    const orphan = "ffff9999-0000-0000-0000-000000000099";
+    const cat = [info(PUBLIC, "public", [orphan])];
+    const missing = detectUnmountedClosureMembers(
+      [PUBLIC],
+      cat,
+      new Set([PUBLIC]),
+    );
+    expect(missing).toHaveLength(1);
+    expect(missing[0].uid).toBe(orphan);
+    expect(missing[0].label).toBe(orphan.slice(0, 8)); // no namespace known
+    expect(missing[0].providesTBox).toBe(false);
+  });
+
+  it("returns [] when a root has no dependsOn edges (nothing to check)", () => {
+    const missing = detectUnmountedClosureMembers(
+      [W3C],
+      catalogue,
+      new Set([W3C]),
+    );
+    expect(missing).toEqual([]);
+  });
+});
+
+describe("formatClosureGapWarning (#3956)", () => {
+  it("returns null for an empty gap (no warning)", () => {
+    expect(formatClosureGapWarning([], "public")).toBeNull();
+  });
+
+  it("names the members + the TBox note + the remedy", () => {
+    const w = formatClosureGapWarning(
+      [
+        { uid: EXOCMD, label: "exocmd", providesTBox: true },
+        { uid: W3C, label: "w3c", providesTBox: false },
+      ],
+      "public",
+    );
+    expect(w).not.toBeNull();
+    expect(w).toContain("public depends on {exocmd, w3c}");
+    expect(w).toContain("are not mounted");
+    // TBox note names only the TBox providers.
+    expect(w).toContain("exocmd provide the class / command TBox");
+    expect(w).not.toContain("w3c provide the class");
+    // Remedy.
+    expect(w).toMatch(/Apply profile.*Add AssetSpace by URL/);
+  });
+
+  it("uses the singular form for one member + omits the TBox note when none", () => {
+    const w = formatClosureGapWarning(
+      [{ uid: W3C, label: "w3c", providesTBox: false }],
+      "public",
+    );
+    expect(w).toContain("{w3c} which is not mounted");
+    expect(w).not.toContain("provide the class / command TBox");
+    expect(w).toContain("add it via «Add AssetSpace by URL»");
+  });
+});

--- a/packages/obsidian-plugin/tests/unit/infrastructure/adapters/BootstrapAssetSpaceClosureGap.test.ts
+++ b/packages/obsidian-plugin/tests/unit/infrastructure/adapters/BootstrapAssetSpaceClosureGap.test.ts
@@ -1,0 +1,116 @@
+import {
+  BootstrapAssetSpaceCommands,
+  type BootstrapAssetSpaceCommandsDeps,
+  type IRestBootstrapMount,
+} from "../../../../src/infrastructure/adapters/BootstrapAssetSpaceCommands";
+import type { AssetSpaceInfo } from "../../../../src/infrastructure/adapters/AssetSpaceManager";
+
+// issue #3956 — the PLUGIN «Add AssetSpace by URL» command must warn SPECIFICALLY
+// when the just-added AssetSpace's exo__AssetSpace_dependsOn-closure member (esp.
+// the exocmd class-TBox) is not materialized — the exact subset-add gap that left
+// the alpha tester's homoiconic command system silently dead.
+
+const PUBLIC_URL = "https://github.com/kitelev/exoas-public";
+const PUBLIC_UID = "aaaa1111-0000-0000-0000-000000000001";
+const EXOCMD_UID = "bbbb2222-0000-0000-0000-000000000002";
+
+function info(
+  uid: string,
+  namespace: string,
+  git: string,
+  dependsOn?: string[],
+): AssetSpaceInfo {
+  return {
+    uid,
+    git,
+    namespace,
+    folderName: `assetspaces/kitelev/exoas-${namespace}`,
+    ...(dependsOn ? { dependsOn } : {}),
+  };
+}
+
+function makeAddHarness(opts: {
+  closureInputs?: { infos: AssetSpaceInfo[]; materializedUids: Set<string> };
+  wireDep?: boolean;
+}): { cmds: BootstrapAssetSpaceCommands; notices: string[] } {
+  const notices: string[] = [];
+  const restMount: IRestBootstrapMount = {
+    mount: jest.fn(async () => ({ sha: "abc1234" })),
+    listMountedAssetSpaces: jest.fn(async () => []),
+  };
+  const wireDep = opts.wireDep ?? true;
+  const deps: BootstrapAssetSpaceCommandsDeps = {
+    restMount,
+    vaultExists: async () => false,
+    listFolder: async () => ({ files: [], folders: [] }),
+    isGitVault: async () => false,
+    validateUrl: () => undefined,
+    deriveFolderName: (u) => u.split("/").pop()!.replace(/^exoas-/, ""),
+    promptBootstrapUrls: async () => null,
+    promptAddAssetSpaceUrl: async () => ({ url: PUBLIC_URL }),
+    confirm: async () => true,
+    notify: (m: string) => notices.push(m),
+    getClosureCheckInputs:
+      wireDep && opts.closureInputs !== undefined
+        ? async () => opts.closureInputs!
+        : undefined,
+  };
+  return { cmds: new BootstrapAssetSpaceCommands(deps), notices };
+}
+
+describe("BootstrapAssetSpaceCommands.invokeAddAssetSpace — dependsOn-closure gap (#3956)", () => {
+  it("warns specifically, naming the unmounted TBox closure member (exocmd) — @req:69f13500-5a86-4ca5-a98c-1be0ff9c6aa6", async () => {
+    const h = makeAddHarness({
+      closureInputs: {
+        infos: [
+          info(PUBLIC_UID, "public", PUBLIC_URL, [EXOCMD_UID]),
+          info(EXOCMD_UID, "exocmd", "https://github.com/kitelev/exoas-exocmd"),
+        ],
+        // exoas-public just added (materialized); exoas-exocmd NOT mounted.
+        materializedUids: new Set([PUBLIC_UID]),
+      },
+    });
+
+    await h.cmds.invokeAddAssetSpace();
+
+    // The add succeeded (a notice was emitted) AND it names the missing member
+    // + flags it as a TBox-provider + points to the remedy.
+    const gap = h.notices.find((n) => /not mounted/.test(n));
+    expect(gap).toBeDefined();
+    expect(gap).toContain("depends on {exocmd}");
+    expect(gap).toContain("class / command TBox");
+    expect(gap).toMatch(/Apply profile.*Add AssetSpace by URL/);
+    // The generic "dependencies are not auto-resolved" advisory is REPLACED by
+    // the specific warning (no double-advisory).
+    expect(gap).not.toContain("dependencies are not auto-resolved");
+  });
+
+  it("emits NO closure warning when the full closure is materialized (no false-positive)", async () => {
+    const h = makeAddHarness({
+      closureInputs: {
+        infos: [
+          info(PUBLIC_UID, "public", PUBLIC_URL, [EXOCMD_UID]),
+          info(EXOCMD_UID, "exocmd", "https://github.com/kitelev/exoas-exocmd"),
+        ],
+        materializedUids: new Set([PUBLIC_UID, EXOCMD_UID]),
+      },
+    });
+
+    await h.cmds.invokeAddAssetSpace();
+
+    expect(h.notices.some((n) => /not mounted/.test(n))).toBe(false);
+    // Add still completes with the success notice.
+    expect(h.notices.some((n) => /AssetSpace added/.test(n))).toBe(true);
+  });
+
+  it("falls back to the generic advisory when the closure-inputs dep is not wired", async () => {
+    const h = makeAddHarness({ wireDep: false });
+
+    await h.cmds.invokeAddAssetSpace();
+
+    expect(
+      h.notices.some((n) => /dependencies are not auto-resolved/.test(n)),
+    ).toBe(true);
+    expect(h.notices.some((n) => /not mounted/.test(n))).toBe(false);
+  });
+});


### PR DESCRIPTION
Closes #3956 (plugin/mobile surface). Req `69f13500-5a86-4ca5-a98c-1be0ff9c6aa6` (feature-sdd, Approved).

## Problem
The alpha-tester's entire homoiconic command system was silently dead — `resolve-buttons` returned 0 commands, `apply <cmd>` returned `not found` — because the exocmd **class-TBox** lives in `exoas-exocmd`, which was **not materialized**. Without the class file the RDF converter can't resolve `exo__Instance_class: [[790e5b16]]` to the class label (emits a raw literal instead of the symbolic type-IRI) → `CommandResolver.loadCommand`'s `rdf:type exocmd__Command` match fails. It went undetected because `create` works without the TBox. The gap arose because the vault got its assetspaces via a **subset `assetspace-add`** that bypassed a full `apply-profile` — `exoas-public` mounted, its `exo__AssetSpace_dependsOn` member `exoas-exocmd` never mounted. The plugin `Add AssetSpace by URL` command only emitted a **generic static advisory** ("dependencies are not auto-resolved").

## Fix (zero new engine code — reuses the shared `transitiveDependsOnClosure`)
- **New pure helper** `domain/profile/closureGap.ts`: `detectUnmountedClosureMembers(roots, allInfos, materializedUids)` computes the transitive `dependsOn` closure and returns members not on disk, tagging `providesTBox` (the `exo`/`exocmd` command-resolution TBox providers — AC3). `formatClosureGapWarning` renders one non-fatal warning line + remedy.
- **PRIMARY — `BootstrapAssetSpaceCommands.invokeAddAssetSpace`** (Olya's exact command): after add, warns **specifically** naming the missing member(s), replacing the generic advisory; falls back to the generic advisory when the closure-inputs dep is unwired or there is no gap. New optional DI dep `getClosureCheckInputs` wired in `ExocortexPlugin` → delegates to `ProfileApplyManager.getClosureCheckInputs()`.
- **BELT-AND-SUSPENDERS — `ProfileApplyManager.applyProfile` (desktop) + `applyProfileViaRest` (mobile)**: warns on any declared closure member apply could not materialize (no scanned descriptor). Non-fatal + best-effort (try/catch — never changes the apply outcome).

**Desktop↔Mobile Command Parity**: both apply paths + the Add command carry the warning (mobile has no CLI → the plugin warning is the only onboarding safety net). **NO false-positive**: a full closure emits no warning.

**Scope**: `packages/obsidian-plugin` only. The parallel CLI `assetspace-add`/`apply-profile` warning is a sibling for the CLI band (out of scope of this req).

## Test (`@req:69f13500-…`, revert-verified)
- Headline: drive the real `invokeAddAssetSpace` through fakes where `exoas-public` is materialized but its dependsOn `exoas-exocmd` is not → the emitted notice names `exocmd`, flags it TBox-critical, points to the remedy.
- No-false-positive: full closure → no closure warning.
- Fallback: unwired dep → generic advisory.
- Pure-helper unit tests (closure, TBox flag, no-gap, orphan descriptor, formatter).

**Revert-verify**: neutralizing `detectUnmountedClosureMembers` (return `[]`) makes the `@req` test RED (no specific warning); restored → GREEN. 12 new + 128 ProfileApplyManager + 55 Bootstrap tests green; typecheck + eslint + `check-test-antipatterns` ratchet clean. No `test-ui`/DOM-selector impact.

Req flip to Active follows after merge (binding-in-main first).
