### PR TITLE
feat(cli): vault-mtime-aware invalidation for the SPARQL query-result cache (#3983)

### DIFF
--- a/packages/cli/src/cache/QueryResultCache.ts
+++ b/packages/cli/src/cache/QueryResultCache.ts
@@ -42,6 +42,14 @@ interface CachedData {
   timestamp: number;
   /** The cached query result */
   result: unknown;
+  /**
+   * Coarse vault content signature at cache time (Issue #3983). When present and
+   * a signature is supplied to {@link QueryResultCache.get}, a mismatch means the
+   * vault changed since caching → the entry is treated as stale. Absent on
+   * entries written before this feature (and when the caller supplies no
+   * signature) → falls back to TTL-only invalidation (prior behaviour).
+   */
+  vaultSignature?: string;
 }
 
 /**
@@ -114,9 +122,17 @@ export class QueryResultCache {
    *
    * @param query - The SPARQL query string
    * @param ttlSeconds - Time-to-live in seconds
-   * @returns The cached result, or null if not found or expired
+   * @param vaultSignature - Optional coarse vault content signature (Issue #3983).
+   *   When both this and the stored signature are present and differ, the vault
+   *   changed since caching → the entry is stale (removed, cache miss). Omit (or
+   *   pass null) to keep TTL-only invalidation.
+   * @returns The cached result, or null if not found, expired, or stale
    */
-  async get(query: string, ttlSeconds: number): Promise<unknown | null> {
+  async get(
+    query: string,
+    ttlSeconds: number,
+    vaultSignature?: string | null,
+  ): Promise<unknown | null> {
     const cacheKey = this.getCacheKey(query);
     const cachePath = this.getCachePath(cacheKey);
 
@@ -137,6 +153,19 @@ export class QueryResultCache {
         return null;
       }
 
+      // Issue #3983: vault-mtime-aware invalidation. If the caller supplied a
+      // signature and the entry was cached with one, a mismatch means the vault
+      // changed since caching (e.g. a set-property / apply mutation) → stale.
+      // When either signature is absent, fall back to TTL-only (prior behaviour).
+      if (
+        vaultSignature &&
+        cached.vaultSignature &&
+        cached.vaultSignature !== vaultSignature
+      ) {
+        await fs.remove(cachePath);
+        return null;
+      }
+
       return cached.result;
     } catch {
       // If any error occurs reading cache, treat as cache miss
@@ -152,8 +181,16 @@ export class QueryResultCache {
    * @param query - The SPARQL query string
    * @param result - The query result to cache
    * @param ttlSeconds - Time-to-live in seconds (stored for reference)
+   * @param vaultSignature - Optional coarse vault content signature (Issue #3983)
+   *   captured at cache time, used by {@link QueryResultCache.get} to detect a
+   *   vault change. Omit (or pass null) to store a TTL-only entry.
    */
-  async set(query: string, result: unknown, ttlSeconds: number): Promise<void> {
+  async set(
+    query: string,
+    result: unknown,
+    ttlSeconds: number,
+    vaultSignature?: string | null,
+  ): Promise<void> {
     const cacheKey = this.getCacheKey(query);
     const cachePath = this.getCachePath(cacheKey);
 
@@ -163,6 +200,7 @@ export class QueryResultCache {
     const data: CachedData = {
       timestamp: Date.now(),
       result,
+      ...(vaultSignature ? { vaultSignature } : {}),
     };
 
     // Write atomically to prevent corruption

--- a/packages/cli/src/cache/vaultSignature.ts
+++ b/packages/cli/src/cache/vaultSignature.ts
@@ -1,0 +1,74 @@
+import fs from "fs-extra";
+import path from "path";
+import crypto from "crypto";
+
+/**
+ * Compute a coarse content signature of a vault's markdown assets: the SHA-256 of
+ * the sorted `relPath:mtimeMs` list of every `.md` file under `vaultPath`. Any
+ * in-place edit, addition, or deletion of an asset changes the signature (a write
+ * always advances the file mtime), so the query-result cache can detect a vault
+ * change and invalidate WITHOUT re-loading + re-parsing the whole vault.
+ *
+ * Why a file-mtime fingerprint and not the vault-DIR mtime (the CacheManager
+ * triple-cache precedent, issue #3983): a nested asset edit — the exact
+ * `set-property` / `apply` read-after-write case this feature targets — does NOT
+ * bump the vault root dir mtime. Only the edited file's own mtime (and, for an
+ * atomic temp+rename write, its immediate parent dir) change; the root stays put.
+ * So `fs.stat(vaultPath).mtimeMs` would silently miss the read-after-write
+ * mutation. The fingerprint catches it. Empirically ~74ms over ~8.5k files — a
+ * `stat`-only walk (no file reads), ~1.4% of a ~5s full vault load.
+ *
+ * Best-effort: returns `null` if the vault directory cannot be walked at all
+ * (the caller then falls back to TTL-only invalidation, i.e. prior behaviour);
+ * individual unreadable dirs/files are skipped rather than failing the walk.
+ *
+ * @param vaultPath absolute path to the vault root
+ * @returns 64-char hex signature, or null if the vault could not be walked
+ */
+export async function computeVaultSignature(
+  vaultPath: string,
+): Promise<string | null> {
+  const entries: string[] = [];
+
+  const walk = async (dir: string): Promise<void> => {
+    let dirents: fs.Dirent[];
+    try {
+      dirents = await fs.readdir(dir, { withFileTypes: true });
+    } catch {
+      return; // unreadable directory — skip (best-effort)
+    }
+    for (const d of dirents) {
+      const full = path.join(dir, d.name);
+      if (d.isDirectory()) {
+        // Skip VCS / dependency / derived-cache dirs — they hold no queried assets
+        // and would only add churn (e.g. .exocortex/cache is rebuilt independently).
+        if (d.name === ".git" || d.name === "node_modules" || d.name === ".exocortex") {
+          continue;
+        }
+        await walk(full);
+      } else if (d.name.endsWith(".md")) {
+        try {
+          const stat = await fs.stat(full);
+          entries.push(`${path.relative(vaultPath, full)}:${stat.mtimeMs}`);
+        } catch {
+          // file vanished between readdir and stat — skip
+        }
+      }
+    }
+  };
+
+  try {
+    await walk(vaultPath);
+  } catch {
+    return null;
+  }
+
+  // A vault path that resolved to nothing walkable yields an empty set; treat
+  // that as "cannot determine" so we never invalidate on a bogus empty signature.
+  if (entries.length === 0) {
+    return null;
+  }
+
+  entries.sort();
+  return crypto.createHash("sha256").update(entries.join("\n")).digest("hex");
+}

--- a/packages/cli/src/commands/sparql-query.ts
+++ b/packages/cli/src/commands/sparql-query.ts
@@ -28,6 +28,7 @@ import { ResponseBuilder, ErrorCode, type QueryResult, type ConstructResult } fr
 import { ExitCodes } from "../utils/ExitCodes.js";
 import { CacheManager } from "../cache/CacheManager.js";
 import { QueryResultCache } from "../cache/QueryResultCache.js";
+import { computeVaultSignature } from "../cache/vaultSignature.js";
 import { ProgressIndicator } from "../utils/ProgressIndicator.js";
 import { QueryAnalyzer } from "../utils/QueryAnalyzer.js";
 import { TemplateRegistry } from "../templates/TemplateRegistry.js";
@@ -324,10 +325,19 @@ export function sparqlQueryCommand(): Command {
 
         const vaultPath = resolve(options.vault);
 
+        // Issue #3983: coarse vault content signature for cache invalidation.
+        // Computed once (a stat-only walk, no file reads) and used for BOTH the
+        // get (detect a vault change since caching) and the set (record current
+        // state). Only when the result cache is in play. null on failure → the
+        // cache falls back to TTL-only invalidation.
+        const vaultSignature = useQueryResultCache
+          ? await computeVaultSignature(vaultPath)
+          : null;
+
         // Check query result cache first (before vault loading)
         if (useQueryResultCache) {
           const queryResultCache = new QueryResultCache();
-          const cachedResult = await queryResultCache.get(cacheKeyQuery, cacheTtlSeconds);
+          const cachedResult = await queryResultCache.get(cacheKeyQuery, cacheTtlSeconds, vaultSignature);
 
           if (cachedResult !== null) {
             const totalDuration = Date.now() - startTime;
@@ -531,7 +541,7 @@ export function sparqlQueryCommand(): Command {
               triples: JSON.parse(triplesFormatter.formatJson(resultTriples)),
             };
             const queryResultCache = new QueryResultCache();
-            await queryResultCache.set(cacheKeyQuery, cacheableResult, cacheTtlSeconds);
+            await queryResultCache.set(cacheKeyQuery, cacheableResult, cacheTtlSeconds, vaultSignature);
           }
 
           if (outputFormat === "json") {
@@ -598,7 +608,7 @@ export function sparqlQueryCommand(): Command {
               bindings,
             };
             const queryResultCache = new QueryResultCache();
-            await queryResultCache.set(cacheKeyQuery, cacheableResult, cacheTtlSeconds);
+            await queryResultCache.set(cacheKeyQuery, cacheableResult, cacheTtlSeconds, vaultSignature);
           }
 
           if (outputFormat === "json") {

--- a/packages/cli/tests/unit/cache/QueryResultCache.vaultSignature.test.ts
+++ b/packages/cli/tests/unit/cache/QueryResultCache.vaultSignature.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, beforeEach, afterEach } from "@jest/globals";
+import fs from "fs-extra";
+import path from "path";
+import os from "os";
+
+const { QueryResultCache } = await import("../../../src/cache/QueryResultCache.js");
+const { computeVaultSignature } = await import("../../../src/cache/vaultSignature.js");
+
+/**
+ * Issue #3983 — the query-result cache is now vault-mtime-aware: a coarse content
+ * signature captured at cache time is compared on read, so a `set-property` /
+ * `apply` mutation invalidates the stale cached result without `--no-cache`.
+ *
+ * Revert-verify: remove the signature comparison in `QueryResultCache.get` and
+ * the "vault changed" case returns the stale result instead of null → RED.
+ */
+describe("QueryResultCache — vault-signature invalidation (#3983)", () => {
+  let tempDir: string;
+  let cache: InstanceType<typeof QueryResultCache>;
+  const QUERY = "SELECT * WHERE { ?s ?p ?o }";
+  const RESULT = { type: "select", count: 1, bindings: [{ s: "x" }] };
+  const TTL = 300;
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "qcache-sig-"));
+    cache = new QueryResultCache({ cacheDir: tempDir });
+  });
+  afterEach(async () => {
+    await fs.remove(tempDir);
+  });
+
+  it("returns the cached result when the vault signature is unchanged", async () => {
+    await cache.set(QUERY, RESULT, TTL, "sigA");
+    expect(await cache.get(QUERY, TTL, "sigA")).toEqual(RESULT);
+  });
+
+  it("invalidates (returns null) when the vault signature has changed", async () => {
+    await cache.set(QUERY, RESULT, TTL, "sigA");
+    // vault changed since caching → different signature → stale
+    expect(await cache.get(QUERY, TTL, "sigB")).toBeNull();
+    // and the stale entry is removed (subsequent get with the SAME old sig misses)
+    expect(await cache.get(QUERY, TTL, "sigA")).toBeNull();
+  });
+
+  it("falls back to TTL-only when the caller supplies no signature (backward compat)", async () => {
+    await cache.set(QUERY, RESULT, TTL, "sigA");
+    // no signature passed → do not signature-check → still a hit
+    expect(await cache.get(QUERY, TTL)).toEqual(RESULT);
+  });
+
+  it("does not falsely invalidate a legacy entry stored without a signature", async () => {
+    // entry cached before this feature (no vaultSignature persisted)
+    await cache.set(QUERY, RESULT, TTL);
+    // a signature is now supplied on read, but the stored entry has none → TTL-only
+    expect(await cache.get(QUERY, TTL, "anySig")).toEqual(RESULT);
+  });
+
+  it("still honours TTL expiry regardless of signature", async () => {
+    await cache.set(QUERY, RESULT, 0, "sigA"); // ttl 0 → immediately expired
+    await new Promise((r) => setTimeout(r, 5));
+    expect(await cache.get(QUERY, 0, "sigA")).toBeNull();
+  });
+});
+
+describe("computeVaultSignature (#3983)", () => {
+  let vaultDir: string;
+
+  beforeEach(async () => {
+    vaultDir = await fs.mkdtemp(path.join(os.tmpdir(), "vault-sig-"));
+    await fs.ensureDir(path.join(vaultDir, "assetspaces", "kitelev", "ns"));
+    await fs.writeFile(path.join(vaultDir, "assetspaces", "kitelev", "ns", "a.md"), "a");
+    await fs.writeFile(path.join(vaultDir, "assetspaces", "kitelev", "ns", "b.md"), "b");
+  });
+  afterEach(async () => {
+    await fs.remove(vaultDir);
+  });
+
+  it("is stable for an unchanged vault", async () => {
+    const s1 = await computeVaultSignature(vaultDir);
+    const s2 = await computeVaultSignature(vaultDir);
+    expect(s1).not.toBeNull();
+    expect(s1).toMatch(/^[a-f0-9]{64}$/);
+    expect(s2).toBe(s1);
+  });
+
+  it("changes when a nested asset is edited in place (the set-property case)", async () => {
+    const before = await computeVaultSignature(vaultDir);
+    // advance mtime of a deeply-nested file (root dir mtime would NOT change)
+    const nested = path.join(vaultDir, "assetspaces", "kitelev", "ns", "a.md");
+    await new Promise((r) => setTimeout(r, 10));
+    await fs.utimes(nested, new Date(), new Date());
+    const after = await computeVaultSignature(vaultDir);
+    expect(after).not.toBe(before);
+  });
+
+  it("changes when an asset is added", async () => {
+    const before = await computeVaultSignature(vaultDir);
+    await fs.writeFile(path.join(vaultDir, "assetspaces", "kitelev", "ns", "c.md"), "c");
+    const after = await computeVaultSignature(vaultDir);
+    expect(after).not.toBe(before);
+  });
+
+  it("returns null for a non-existent vault (caller falls back to TTL-only)", async () => {
+    expect(await computeVaultSignature(path.join(vaultDir, "does-not-exist"))).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
Fixes #3983 (follow-up to #3981/#3979). The SPARQL query-result cache invalidated by **TTL only** — a `set-property`/`apply` mutation could leave a **stale cached result** for up to the TTL (default 300s), the read-after-write footgun that forced `query --no-cache`. The cache is now **vault-change aware**.

## Design (verify-before-assert changed the plan)
The issue suggested mirroring `CacheManager`'s `vaultMtime` (`fs.stat(vaultPath).mtimeMs`, the root-dir mtime). **Empirically that signal is ineffective for the target case:** a nested asset edit — the exact `set-property` scenario — does **not** bump the vault root-dir mtime (only the file's own mtime, and for an atomic temp+rename write its immediate parent dir, change). A root-dir-mtime mirror would silently miss the mutation.

So the cache stores a **coarse content signature** = SHA-256 of the sorted `relPath:mtimeMs` list of the vault's `.md` assets (the issue's "content hash" alternative). Any in-place edit / addition / deletion changes it. It is a **stat-only walk (no file reads): ~74 ms over ~8.5k files vs a ~5 s full vault load** (~1.4%).

## Real-CLI acceptance (temp HOME-isolated cache, temp vault)
```
run1: Loading vault   (MISS)
run2: (cached)        (HIT — vault unchanged)
run3: Loading vault   (MISS — nested asset edited → INVALIDATED)   ← the fix
run4: (cached)        (HIT)
```

## Backward compatible
`get`/`set` gain an **optional** `vaultSignature`. When the caller supplies none, or a stored entry predates this feature (no signature), it falls back to **TTL-only** (prior behaviour). Only `sparql-query` threads a signature — computed once, used for both `get` and `set`; best-effort `null` on walk failure → TTL-only. Only computed when the result cache is in play (`--no-cache` skips it).

## Revert-verify
`packages/cli/tests/unit/cache/QueryResultCache.vaultSignature.test.ts`: signature mismatch → `null` (**RED** when the `get` check is reverted); unchanged → hit; no-signature / legacy-entry → TTL-only; TTL still honoured. `computeVaultSignature`: stable for an unchanged vault, changes on a **nested in-place edit** and on an add, `null` for a missing vault.

## Verification
`packages/cli` unit+integration suite green (**148/149 suites**; the 1 failing suite — `sparql-exo003.integration` — is a **pre-existing local-env flake on Node v25.8.1, baseline-confirmed identical with this PR's source reverted to `origin/main`**, and is green on `main` CI). `check:types` 0; test-antipattern + coverage-monotonic guards pass.

Follow-up (deferred, per issue): finer per-query dependency tracking.
