### PR TITLE
feat(cli): create --no-status suppresses the default ems__Effort_status (#3928)

### DIFF
--- a/packages/cli/src/commands/create.ts
+++ b/packages/cli/src/commands/create.ts
@@ -70,7 +70,9 @@ interface CreateCommandOptions {
   bodyFile?: string;
   dryRun?: boolean;
   createdBy?: string;
-  status?: string;
+  // `--status <name>` → string; `--no-status` → false (Commander pairs the
+  // `--no-` flag with the `status` key; issue #3928); neither → undefined.
+  status?: string | boolean;
   yes?: boolean;
   timezone?: string;
   skipWikilinkValidation?: boolean;
@@ -246,6 +248,7 @@ export function createCommand(): Command {
     .option("--dry-run", "Preview frontmatter without writing file")
     .option("--created-by <uuid>", "Creator UUID (defaults to ExoAssistant)")
     .option("--status <name>", "ems__Effort_status for status-bearing classes (default: Backlog; e.g. Draft, Doing, Done). Errors for non-status-bearing classes.")
+    .option("--no-status", "For a status-bearing class, do NOT inject the default ems__Effort_status — create a status-less prototype/template (issue #3928). No-op for a non-status-bearing class. Mutually exclusive with --status / --property ems__Effort_status.")
     .option("--yes", "Accepted for symmetry with the apply subcommands (create is non-interactive; no-op)")
     .option("--timezone <tz>", "Timezone for timestamps (defaults to Asia/Almaty)")
     .option("--skip-wikilink-validation", "Skip wikilink existence validation")
@@ -306,27 +309,41 @@ export function createCommand(): Command {
         // `set-draft-status → move-to-backlog` chain. A non-status-bearing
         // class never gets a status. An explicit `--property
         // ems__Effort_status=...` always wins (and conflicts with --status).
+        //
+        // `--no-status` (issue #3928) is the explicit opt-out: for a
+        // status-bearing class it SUPPRESSES the default injection so a
+        // recurring/template prototype is created without a status (matching
+        // its status-less siblings) — a no-op for a non-status-bearing class
+        // (none was injected anyway). Commander pairs `--no-status` with the
+        // `status` key → `options.status === false`; `--status <name>` → a
+        // string; neither → undefined.
         const statusResolver = new EffortStatusResolver(fsAdapter);
+        const noStatus = options.status === false;
+        const statusName =
+          typeof options.status === "string" ? options.status : undefined;
         const explicitStatus = EFFORT_STATUS_KEY in properties;
-        if (options.status && explicitStatus) {
+        if (noStatus && explicitStatus) {
+          throw new Error(
+            `Cannot pass both --no-status and --property ${EFFORT_STATUS_KEY}=... (ambiguous — cannot both suppress and set the status). Use one.`,
+          );
+        }
+        if (statusName && explicitStatus) {
           throw new Error(
             `Cannot pass both --status and --property ${EFFORT_STATUS_KEY}=... (ambiguous). Use one.`,
           );
         }
-        if (!explicitStatus) {
+        if (!explicitStatus && !noStatus) {
           const statusBearing = await statusResolver.isStatusBearing(classUid);
-          if (options.status) {
+          if (statusName) {
             if (!statusBearing) {
               throw new Error(
                 `--status only applies to status-bearing classes (ems__Effort subclasses); '${options.class}' is not one.`,
               );
             }
-            const statusUid = await statusResolver.resolveStatusUid(
-              options.status,
-            );
+            const statusUid = await statusResolver.resolveStatusUid(statusName);
             if (!statusUid) {
               throw new Error(
-                `Unknown status '${options.status}' — no matching ems__EffortStatus<Name> enum asset found in the vault.`,
+                `Unknown status '${statusName}' — no matching ems__EffortStatus<Name> enum asset found in the vault.`,
               );
             }
             properties[EFFORT_STATUS_KEY] = `[[${statusUid}]]`;

--- a/packages/cli/tests/integration/create-no-status.integration.test.ts
+++ b/packages/cli/tests/integration/create-no-status.integration.test.ts
@@ -1,0 +1,232 @@
+/**
+ * Issue #3928 — `cli create --no-status` suppresses the default
+ * `ems__Effort_status` injection (#3849) for a status-bearing class, so a
+ * recurring/template prototype is created WITHOUT a status. Without the flag
+ * the #3849 default is unchanged (backward-compat). `--no-status` combined with
+ * an explicit `--property ems__Effort_status=...` is an ambiguity error.
+ *
+ * Drives the REAL `createCommand()` action end-to-end against a temp fixture
+ * vault (class defs + status enums + inbox), reads the written file back from
+ * disk, and asserts the emitted frontmatter — the production create pipeline,
+ * not hand-injected frontmatter (test-fixture-realism).
+ *
+ * Status-bearing detection uses real class-hierarchy walking: the fixture's
+ * ems__TaskPrototype → ems__Task → ems__Effort chain reaches ems__Effort, so
+ * WITHOUT --no-status it injects Backlog; WITH --no-status it does not.
+ * concept__Concept has no Effort ancestor → never a status either way (isolates
+ * the --no-status no-op for a non-status-bearing class).
+ *
+ * Revert-verify (~/dotfiles/.claude/rules/integration-test-revert-verify.md):
+ * Edit-break the `!noStatus` guard in create.ts (drop the `&& !noStatus`) → the
+ * prototype gets Backlog again → the --no-status suppression assertion goes RED;
+ * restored → GREEN. The backward-compat scenario proves the default still fires
+ * (non-vacuity); the ambiguity scenario reds if the guard is removed.
+ */
+import { jest, describe, it, expect, beforeEach, afterEach } from "@jest/globals";
+import * as fs from "fs";
+import * as path from "path";
+import * as os from "os";
+
+const { createCommand } = await import("../../src/commands/create.js");
+
+// Real production UIDs so assertions mirror live output.
+const TASK_CLASS_UID = "1b20a8f0-d745-4e93-91db-4531b3df120e";
+const EFFORT_CLASS_UID = "086f71fa-dd30-4284-90cf-e609f2a6c461";
+const BACKLOG_UID = "753a44d5-846c-4b82-9196-4fd9a4d48777";
+const DRAFT_UID = "c42245d0-01de-4c35-bfcf-d910445ea28e";
+const EXOASSISTANT_UID = "4ef3962d-b8a7-42b5-bd28-88ec846f1d13";
+// A status-bearing PROTOTYPE class (the AC's `--class <Prototype>`): its
+// superClass chain reaches ems__Effort via ems__Task → status-bearing.
+const TASK_PROTOTYPE_UID = "df7e579d-0000-4000-8000-000000000001";
+// Non-status-bearing class (superClass → exo__Asset, undefined here → the walk
+// terminates without reaching ems__Effort).
+const CONCEPT_CLASS_UID = "c0c0c0c0-1111-2222-3333-444444444444";
+
+const EMS_DIR = "assetspaces/kitelev/exoas-public/ems";
+
+function md(frontmatter: Record<string, string | string[]>): string {
+  const lines = ["---"];
+  for (const [k, v] of Object.entries(frontmatter)) {
+    if (Array.isArray(v)) {
+      lines.push(`${k}:`);
+      for (const item of v) lines.push(`  - "${item}"`);
+    } else {
+      lines.push(`${k}: ${v}`);
+    }
+  }
+  lines.push("---");
+  lines.push("");
+  return lines.join("\n");
+}
+
+describe("Issue #3928: `cli create --no-status` suppresses the default ems__Effort_status", () => {
+  let vault: string;
+  let exitSpy: ReturnType<typeof jest.spyOn>;
+  let stdoutSpy: ReturnType<typeof jest.spyOn>;
+  let stderrSpy: ReturnType<typeof jest.spyOn>;
+  let logSpy: ReturnType<typeof jest.spyOn>;
+  let errorSpy: ReturnType<typeof jest.spyOn>;
+  let stdoutChunks: string[];
+  let exitCodes: number[];
+
+  beforeEach(() => {
+    vault = fs.mkdtempSync(path.join(os.tmpdir(), "cli-3928-"));
+
+    const emsDir = path.join(vault, EMS_DIR);
+    fs.mkdirSync(emsDir, { recursive: true });
+
+    // ems__Effort root class (carries ems__Effort_status).
+    fs.writeFileSync(
+      path.join(emsDir, `${EFFORT_CLASS_UID}.md`),
+      md({ exo__Asset_uid: EFFORT_CLASS_UID, exo__Asset_label: "ems__Effort" }),
+    );
+    // ems__Task — subclass of ems__Effort → status-bearing.
+    fs.writeFileSync(
+      path.join(emsDir, `${TASK_CLASS_UID}.md`),
+      md({
+        exo__Asset_uid: TASK_CLASS_UID,
+        exo__Asset_label: "ems__Task",
+        exo__Class_superClass: [`[[${EFFORT_CLASS_UID}]]`],
+      }),
+    );
+    // ems__TaskPrototype — subclass of ems__Task → transitively status-bearing.
+    fs.writeFileSync(
+      path.join(emsDir, `${TASK_PROTOTYPE_UID}.md`),
+      md({
+        exo__Asset_uid: TASK_PROTOTYPE_UID,
+        exo__Asset_label: "ems__TaskPrototype",
+        exo__Class_superClass: [`[[${TASK_CLASS_UID}]]`],
+      }),
+    );
+    // concept__Concept — superClass → exo__Asset (undefined here) → NOT
+    // status-bearing (the walk never reaches ems__Effort).
+    fs.writeFileSync(
+      path.join(emsDir, `${CONCEPT_CLASS_UID}.md`),
+      md({
+        exo__Asset_uid: CONCEPT_CLASS_UID,
+        exo__Asset_label: "concept__Concept",
+        exo__Class_superClass: ["[[exo__Asset]]"],
+      }),
+    );
+    // Status enums.
+    fs.writeFileSync(
+      path.join(emsDir, `${BACKLOG_UID}.md`),
+      md({ exo__Asset_uid: BACKLOG_UID, exo__Asset_label: "ems__EffortStatusBacklog" }),
+    );
+    fs.writeFileSync(
+      path.join(emsDir, `${DRAFT_UID}.md`),
+      md({ exo__Asset_uid: DRAFT_UID, exo__Asset_label: "ems__EffortStatusDraft" }),
+    );
+    // ExoAssistant identity (createdBy default target).
+    fs.writeFileSync(
+      path.join(emsDir, `${EXOASSISTANT_UID}.md`),
+      md({ exo__Asset_uid: EXOASSISTANT_UID, exo__Asset_label: "ExoAssistant" }),
+    );
+
+    fs.mkdirSync(path.join(vault, "01 Inbox"), { recursive: true });
+
+    stdoutChunks = [];
+    exitCodes = [];
+    exitSpy = jest
+      .spyOn(process, "exit")
+      .mockImplementation(((code?: number) => {
+        exitCodes.push(code ?? 0);
+        return undefined as never;
+      }) as never);
+    stdoutSpy = jest
+      .spyOn(process.stdout, "write")
+      .mockImplementation(((chunk: unknown) => {
+        stdoutChunks.push(String(chunk));
+        return true;
+      }) as never);
+    stderrSpy = jest
+      .spyOn(process.stderr, "write")
+      .mockImplementation((() => true) as never);
+    logSpy = jest.spyOn(console, "log").mockImplementation(() => {});
+    errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    exitSpy.mockRestore();
+    stdoutSpy.mockRestore();
+    stderrSpy.mockRestore();
+    logSpy.mockRestore();
+    errorSpy.mockRestore();
+    fs.rmSync(vault, { recursive: true, force: true });
+  });
+
+  /** Run the real create command; returns parsed JSON + on-disk content. */
+  async function runCreate(
+    classUid: string,
+    extraArgs: string[],
+  ): Promise<{ uuid: string; path: string; content: string; exit: number[] }> {
+    const cmd = createCommand();
+    const argv = [
+      "--class",
+      classUid,
+      "--label",
+      "E2E-3928 no-status",
+      "--vault",
+      vault,
+      ...extraArgs,
+    ];
+    await cmd.parseAsync(argv, { from: "user" });
+
+    const json = stdoutChunks.join("").trim();
+    if (!json) {
+      return { uuid: "", path: "", content: "", exit: [...exitCodes] };
+    }
+    const parsed = JSON.parse(json) as { uuid: string; path: string };
+    const content = fs.readFileSync(path.join(vault, parsed.path), "utf-8");
+    return { uuid: parsed.uuid, path: parsed.path, content, exit: [...exitCodes] };
+  }
+
+  it("--no-status on a status-bearing prototype → NO ems__Effort_status @req:d214c122-e09b-4826-a827-242c5e5745a1", async () => {
+    const out = await runCreate(TASK_PROTOTYPE_UID, ["--no-status"]);
+
+    expect(out.exit).toContain(0);
+    expect(out.exit).not.toContain(1);
+    expect(out.uuid).not.toBe("");
+    // The default Backlog was suppressed — no status of any form.
+    expect(out.content).not.toContain("ems__Effort_status");
+    expect(out.content).not.toContain(BACKLOG_UID);
+    // createdBy default still applies (not status-gated).
+    expect(out.content).toContain(`exo__Asset_createdBy: "[[${EXOASSISTANT_UID}]]"`);
+  });
+
+  it("WITHOUT --no-status the #3849 Backlog default is unchanged (backward-compat) @req:d214c122-e09b-4826-a827-242c5e5745a1", async () => {
+    const out = await runCreate(TASK_PROTOTYPE_UID, []);
+
+    expect(out.exit).toContain(0);
+    // The default DOES fire without the flag → proves the suppression above is
+    // non-vacuous (the flag is what removes it).
+    expect(out.content).toContain(`ems__Effort_status: "[[${BACKLOG_UID}]]"`);
+  });
+
+  it("--no-status + explicit --property ems__Effort_status → fail-loud ambiguity error @req:d214c122-e09b-4826-a827-242c5e5745a1", async () => {
+    const out = await runCreate(TASK_PROTOTYPE_UID, [
+      "--no-status",
+      "--property",
+      `ems__Effort_status=[[${DRAFT_UID}]]`,
+      "--skip-wikilink-validation",
+    ]);
+
+    // Handled via ErrorHandler → exit(1), no success JSON, file not written.
+    expect(out.uuid).toBe("");
+    expect(out.exit).toContain(1);
+    const stderrLog = errorSpy.mock.calls.flat().join("\n");
+    expect(stderrLog).toMatch(/no-status/i);
+    expect(stderrLog).toMatch(/ambiguous/i);
+  });
+
+  it("--no-status on a non-status-bearing class → harmless no-op success @req:d214c122-e09b-4826-a827-242c5e5745a1", async () => {
+    const out = await runCreate(CONCEPT_CLASS_UID, ["--no-status"]);
+
+    expect(out.exit).toContain(0);
+    expect(out.exit).not.toContain(1);
+    expect(out.uuid).not.toBe("");
+    // No status was injected anyway; --no-status is a no-op here.
+    expect(out.content).not.toContain("ems__Effort_status");
+    expect(out.content).toContain(`exo__Asset_createdBy: "[[${EXOASSISTANT_UID}]]"`);
+  });
+});

--- a/packages/cli/tests/unit/commands/create.test.ts
+++ b/packages/cli/tests/unit/commands/create.test.ts
@@ -212,8 +212,8 @@ describe("Issue #2333: create command", () => {
     expect(option!.mandatory).toBeFalsy();
   });
 
-  it("should register exactly 13 options", () => {
+  it("should register exactly 14 options", () => {
     const cmd = createCommand();
-    expect(cmd.options).toHaveLength(13);
+    expect(cmd.options).toHaveLength(14);
   });
 });


### PR DESCRIPTION
## Summary
Adds `exocortex create --no-status` (issue #3928): for a status-bearing class (an `ems__Effort` subclass) the flag SUPPRESSES the #3849 default `ems__Effort_status` injection, so a recurring/template prototype is created **without** a status — the shape its status-less siblings need (empirically 0 of 35 recurring prototypes carry a status). Previously the only opt-out was a raw Bash strip of the frontmatter line (bypassing the PreToolUse hook-coverage + SHACL floor).

- **`--no-status`** on a status-bearing class → no `ems__Effort_status` written.
- **No flag** → the #3849 default (Backlog / explicit `--status`) is unchanged (backward-compat).
- **Non-status-bearing class** → `--no-status` is a harmless no-op (none was injected).
- **`--no-status` + explicit `--property ems__Effort_status=...`** → fail-loud ambiguity error (cannot both suppress and set).

CLI-only change (`packages/cli/src/commands/create.ts`); the core `GenericAssetCreationService` and plugin/apply paths stay byte-identical.

## Requirement (feature-sdd)
`d214c122-e09b-4826-a827-242c5e5745a1` (Approved) — `exoas-exo-reqs`. Flips to Active after this PR merges (binding `@req:d214c122-…` lands in main).

## Revert-verified
- Drop the `&& !noStatus` guard → the `--no-status` suppression test RED (prototype regains Backlog); backward-compat / ambiguity / no-op GREEN.
- Neutralise the ambiguity throw → the ambiguity test RED; others GREEN.
- Both restored → 4/4 GREEN; sibling `create-status-defaults` 8/8 (no regression); `create.test` option-count bumped 13 → 14 (additive).

Req: d214c122-e09b-4826-a827-242c5e5745a1
Closes #3928
