### PR TITLE
feat(cli): set-body — overwrite an asset's markdown body (#3943)

### DIFF
--- a/packages/cli/src/commands/set-body.ts
+++ b/packages/cli/src/commands/set-body.ts
@@ -1,0 +1,215 @@
+import { Command } from "commander";
+import { resolve, relative, isAbsolute, sep as pathSep } from "path";
+import { existsSync, readFileSync, writeFileSync } from "fs";
+import { FrontmatterService } from "@kitelev/exocortex-core";
+import { NodeFsAdapter } from "../adapters/NodeFsAdapter.js";
+import { WikilinkValidator } from "../services/WikilinkValidator.js";
+import { ErrorHandler } from "../utils/ErrorHandler.js";
+import { VaultNotFoundError } from "../utils/errors/index.js";
+import {
+  DEFAULT_TIMEZONE,
+  UPDATED_AT_KEY,
+  stampTimestamp,
+} from "./propertyMutationShared.js";
+
+interface SetBodyOptions {
+  vault: string;
+  body?: string;
+  bodyFile?: string;
+  dryRun?: boolean;
+  timezone?: string;
+  frozenClock?: string;
+  skipWikilinkValidation?: boolean;
+}
+
+/** Read the whole of stdin as a string (for `--body -`). */
+function readStdin(timeoutMs: number): Promise<string> {
+  return new Promise((resolvePromise, rejectPromise) => {
+    const chunks: Buffer[] = [];
+    const timer = setTimeout(() => {
+      rejectPromise(new Error(`Timed out reading body from stdin after ${timeoutMs}ms`));
+    }, timeoutMs);
+    process.stdin.on("data", (c) => chunks.push(Buffer.from(c)));
+    process.stdin.on("end", () => {
+      clearTimeout(timer);
+      resolvePromise(Buffer.concat(chunks).toString("utf-8"));
+    });
+    process.stdin.on("error", (e) => {
+      clearTimeout(timer);
+      rejectPromise(e);
+    });
+  });
+}
+
+/**
+ * Resolve the new body content from `--body-file` / `--body` / `--body -`
+ * (stdin). `--body-file` takes precedence. Returns undefined when neither is
+ * given (the caller rejects that).
+ */
+async function resolveNewBody(
+  options: SetBodyOptions,
+): Promise<string | undefined> {
+  if (options.bodyFile) {
+    if (!existsSync(options.bodyFile)) {
+      throw new Error(`Body file not found: ${options.bodyFile}`);
+    }
+    return readFileSync(options.bodyFile, "utf-8");
+  }
+  if (options.body === "-") {
+    return readStdin(30_000);
+  }
+  if (options.body !== undefined) {
+    return options.body;
+  }
+  return undefined;
+}
+
+/**
+ * `set-body <path>` — OVERWRITE the markdown BODY (everything after the
+ * frontmatter block) of an existing vault asset, leaving the frontmatter block
+ * byte-identical EXCEPT bumping `exo__Asset_updatedAt`. The dogfood body-rewrite
+ * path (issue #3943): closes the gap where a body rewrite required a raw
+ * `backup → rm → Write` (bypassing the PreToolUse hook-coverage + SHACL floor,
+ * and — since the 2026-07-26 dogfood-cli-mutation hardening — needing an audited
+ * sentinel window for CLI-creatable instance classes). Complements
+ * `set-property` (#3795, frontmatter mutation) and `create --body-file` (#3744,
+ * body on a NEW asset).
+ *
+ * Guards mirror `set-property`: refuses a target outside the vault, refuses a
+ * non-asset (no `exo__Asset_uid`), and validates wikilinks in the NEW body
+ * (the CLI/Bash write bypasses the validate-wikilinks hook) — an invalid
+ * `[[uuid]]` is rejected fail-loud with the file left byte-unchanged.
+ */
+export function setBodyCommand(): Command {
+  return new Command("set-body")
+    .description(
+      "Overwrite the markdown BODY of an existing vault asset (frontmatter untouched, exo__Asset_updatedAt bumped, new-body wikilinks validated). The dogfood body-rewrite path — no raw backup→rm→Write. Issue #3943.",
+    )
+    .argument("<path>", "Vault-relative path to the asset to rewrite")
+    .option("--vault <path>", "Path to Obsidian vault", process.cwd())
+    .option("--body-file <path>", "Read the new body from a file")
+    .option("--body <text>", "New body text ('-' reads from stdin)")
+    .option(
+      "--timezone <tz>",
+      "Timezone for the exo__Asset_updatedAt bump (defaults to Asia/Almaty)",
+    )
+    .option(
+      "--frozen-clock <iso>",
+      "Freeze the updatedAt clock to an ISO timestamp for test/replay",
+    )
+    .option("--dry-run", "Preview the resulting content without writing")
+    .option(
+      "--skip-wikilink-validation",
+      "Skip wikilink existence validation for the new body",
+    )
+    .action(async (pathArg: string, options: SetBodyOptions) => {
+      try {
+        const vaultPath = resolve(options.vault);
+        if (!existsSync(vaultPath)) {
+          throw new VaultNotFoundError(vaultPath);
+        }
+
+        // Resolve + guard the target path (must be inside the vault). Mirrors
+        // set-property / apply's vault-relative canonicalisation (#3788).
+        const targetPath = resolve(vaultPath, pathArg);
+        const vaultRelative = relative(vaultPath, targetPath);
+        if (
+          vaultRelative === ".." ||
+          vaultRelative.startsWith(`..${pathSep}`) ||
+          isAbsolute(vaultRelative)
+        ) {
+          throw new Error(
+            `Target is outside the vault: ${pathArg} (vault: ${vaultPath})`,
+          );
+        }
+
+        if (options.bodyFile === undefined && options.body === undefined) {
+          throw new Error(
+            "Provide the new body via --body-file <path>, --body <text>, or --body - (stdin).",
+          );
+        }
+
+        // Read directly and surface a friendly not-found on ENOENT (avoids an
+        // existsSync check-then-read race, #3907; mirrors set-property).
+        let original: string;
+        try {
+          original = readFileSync(targetPath, "utf-8");
+        } catch (readError) {
+          if ((readError as NodeJS.ErrnoException).code === "ENOENT") {
+            throw new Error(`Target file not found: ${pathArg}`);
+          }
+          throw readError;
+        }
+
+        // Only mutate a real asset (has an exo__Asset_uid). Refuse a bare
+        // markdown file so set-body never silently rewrites a non-asset.
+        if (!/^\s*exo__Asset_uid:/m.test(original)) {
+          throw new Error(
+            `Not a vault asset (no exo__Asset_uid): ${vaultRelative}. set-body only rewrites existing assets.`,
+          );
+        }
+
+        // The frontmatter block MUST exist (guaranteed by the uid check above).
+        const fm = new FrontmatterService();
+        const parsed = fm.parse(original);
+        if (!parsed.exists) {
+          throw new Error(
+            `No frontmatter block found in ${vaultRelative}; set-body preserves the frontmatter and only rewrites the body.`,
+          );
+        }
+        // Reconstruct the exact original frontmatter block (byte-identical to
+        // FRONTMATTER_REGEX's match: `---\n<yaml>\n---`).
+        const frontmatterBlock = `---\n${parsed.content}\n---`;
+
+        // Resolve + normalise the new body (parse `\n` escapes like create).
+        let newBody = (await resolveNewBody(options)) ?? "";
+        newBody = newBody.replace(/\\n/g, "\n");
+
+        // Validate wikilinks in the NEW body (the CLI/Bash write bypasses the
+        // PreToolUse validate-wikilinks hook — validate here like create /
+        // set-property). An invalid [[uuid]] throws → file untouched.
+        if (!options.skipWikilinkValidation) {
+          const validator = new WikilinkValidator(new NodeFsAdapter(vaultPath));
+          await validator.validateValue(newBody);
+        }
+
+        // Rebuild content: original frontmatter block + a single newline + the
+        // new body (ensure a trailing newline for a non-empty body). Then bump
+        // exo__Asset_updatedAt — updateProperty re-matches ONLY the frontmatter
+        // block, leaving the just-written body intact.
+        const bodyPart =
+          newBody.length > 0
+            ? newBody.endsWith("\n")
+              ? newBody
+              : `${newBody}\n`
+            : "";
+        const rebuilt = `${frontmatterBlock}\n${bodyPart}`;
+
+        const now = options.frozenClock
+          ? new Date(options.frozenClock)
+          : new Date();
+        const timezone = options.timezone ?? DEFAULT_TIMEZONE;
+        const updatedAt = stampTimestamp(now, timezone);
+        const updated = fm.updateProperty(rebuilt, UPDATED_AT_KEY, updatedAt);
+
+        if (options.dryRun) {
+          process.stderr.write(
+            `--- DRY RUN PREVIEW ---\n${updated}\n--- END PREVIEW ---\n`,
+          );
+        } else {
+          writeFileSync(targetPath, updated, "utf-8");
+        }
+
+        const output = {
+          path: vaultRelative,
+          updatedAt,
+          bodyBytes: bodyPart.length,
+        };
+        process.stdout.write(JSON.stringify(output) + "\n");
+
+        process.exit(0);
+      } catch (error) {
+        ErrorHandler.handle(error as Error);
+      }
+    });
+}

--- a/packages/cli/src/program.ts
+++ b/packages/cli/src/program.ts
@@ -10,6 +10,7 @@ import { runQueryCommand } from "./commands/run-query.js";
 import { createCommand } from "./commands/create.js";
 import { setPropertyCommand } from "./commands/set-property.js";
 import { removePropertyCommand } from "./commands/remove-property.js";
+import { setBodyCommand } from "./commands/set-body.js";
 import { repairFrontmatterCommand } from "./commands/repair-frontmatter.js";
 import { findCommand } from "./commands/find.js";
 import { applyCommand } from "./commands/apply.js";
@@ -76,6 +77,10 @@ export function createProgram(version?: string): Command {
   // remove-property — the DELETE-side counterpart of set-property (#3926):
   // deletes a non-guarded frontmatter property, sharing the same guard denylists.
   program.addCommand(removePropertyCommand());
+  // set-body — overwrite the markdown BODY of an existing asset (#3943): the
+  // body-rewrite counterpart of set-property (frontmatter) / create --body-file
+  // (new asset). Closes the "raw backup→rm→Write to rewrite a body" dogfood gap.
+  program.addCommand(setBodyCommand());
   // repair-frontmatter — raw-text dedupe of duplicated top-level YAML keys
   // (keep-last). The dogfood-clean repair for the invisible/unrepairable
   // duplicate-key class (#3800): fixes a file the parser itself cannot read.

--- a/packages/cli/tests/integration/set-body.integration.test.ts
+++ b/packages/cli/tests/integration/set-body.integration.test.ts
@@ -1,0 +1,199 @@
+/**
+ * Issue #3943 — `exocortex set-body <path>` overwrites the markdown BODY of an
+ * existing vault asset (frontmatter block byte-identical except an
+ * exo__Asset_updatedAt bump), validating wikilinks in the new body, refusing a
+ * non-asset. The dogfood body-rewrite path — no raw backup→rm→Write.
+ *
+ * Drives the REAL `setBodyCommand()` action end-to-end against a temp fixture
+ * vault, reads the written file back from disk, and asserts on the real bytes —
+ * the production pipeline (FrontmatterService.parse + updateProperty +
+ * WikilinkValidator), not hand-injected content (test-fixture-realism).
+ *
+ * Revert-verify (~/dotfiles/.claude/rules/integration-test-revert-verify.md) —
+ * THREE independent axes in `set-body.ts`, each reddening exactly its own
+ * assertion when Edit-broken and GREEN when restored:
+ *   1. body replacement — neutralise `newBody` (force `= ""` / keep original)
+ *      → the body-replaced assertions RED.
+ *   2. updatedAt bump   — neutralise the `updateProperty(UPDATED_AT_KEY)` call
+ *      → the updatedAt-bump assertion RED.
+ *   3. wikilink validate — neutralise the `validateValue(newBody)` call → the
+ *      invalid-wikilink refusal RED (the file would be written).
+ * The non-asset refusal + valid-wikilink happy path isolate non-vacuity.
+ */
+import { jest, describe, it, expect, beforeEach, afterEach } from "@jest/globals";
+import * as fs from "fs";
+import * as path from "path";
+import * as os from "os";
+
+const { setBodyCommand } = await import("../../src/commands/set-body.js");
+
+const TASKS_DIR = "assetspaces/kitelev/exoas-my/tasks";
+
+const TASK_UID = "c1c1c1c1-0000-4000-8000-000000000001";
+const TARGET_UID = "d2d2d2d2-0000-4000-8000-000000000002";
+const NONEXISTENT_UID = "eeeeeeee-0000-4000-8000-000000000009";
+const STALE_UPDATED_AT = "2020-01-01T00:00:00";
+
+/** Frozen-clock instant → 2026-07-30T15:00:00 rendered in Asia/Almaty (UTC+5). */
+const FROZEN_CLOCK = "2026-07-30T10:00:00Z";
+const EXPECTED_UPDATED_AT = "2026-07-30T15:00:00";
+
+describe("Issue #3943: `cli set-body` overwrites the markdown body of an existing asset", () => {
+  let vault: string;
+  let exitSpy: ReturnType<typeof jest.spyOn>;
+  let stdoutSpy: ReturnType<typeof jest.spyOn>;
+  let stderrSpy: ReturnType<typeof jest.spyOn>;
+  let logSpy: ReturnType<typeof jest.spyOn>;
+  let errorSpy: ReturnType<typeof jest.spyOn>;
+  let stdoutChunks: string[];
+  let exitCodes: number[];
+
+  const taskPath = `${TASKS_DIR}/${TASK_UID}.md`;
+  // A vault asset with frontmatter (incl. a STALE updatedAt) + an old body.
+  const originalContent =
+    `---\n` +
+    `exo__Asset_uid: ${TASK_UID}\n` +
+    `exo__Asset_label: "A task"\n` +
+    `exo__Asset_updatedAt: ${STALE_UPDATED_AT}\n` +
+    `---\n` +
+    `OLD BODY LINE 1\nOLD BODY LINE 2\n`;
+
+  beforeEach(() => {
+    vault = fs.mkdtempSync(path.join(os.tmpdir(), "cli-3943-"));
+    const tasksDir = path.join(vault, TASKS_DIR);
+    fs.mkdirSync(tasksDir, { recursive: true });
+
+    fs.writeFileSync(path.join(vault, taskPath), originalContent);
+    // A resolvable target for a valid [[uuid]] body wikilink.
+    fs.writeFileSync(
+      path.join(tasksDir, `${TARGET_UID}.md`),
+      `---\nexo__Asset_uid: ${TARGET_UID}\nexo__Asset_label: "Target"\n---\nbody\n`,
+    );
+    // A bare markdown file (NO exo__Asset_uid) — set-body must refuse it.
+    fs.writeFileSync(
+      path.join(tasksDir, "not-an-asset.md"),
+      `# Just notes\n\nno frontmatter here\n`,
+    );
+
+    stdoutChunks = [];
+    exitCodes = [];
+    exitSpy = jest
+      .spyOn(process, "exit")
+      .mockImplementation(((code?: number) => {
+        exitCodes.push(code ?? 0);
+        return undefined as never;
+      }) as never);
+    stdoutSpy = jest
+      .spyOn(process.stdout, "write")
+      .mockImplementation(((chunk: unknown) => {
+        stdoutChunks.push(String(chunk));
+        return true;
+      }) as never);
+    stderrSpy = jest
+      .spyOn(process.stderr, "write")
+      .mockImplementation((() => true) as never);
+    logSpy = jest.spyOn(console, "log").mockImplementation(() => {});
+    errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    exitSpy.mockRestore();
+    stdoutSpy.mockRestore();
+    stderrSpy.mockRestore();
+    logSpy.mockRestore();
+    errorSpy.mockRestore();
+    fs.rmSync(vault, { recursive: true, force: true });
+  });
+
+  /** Run the real set-body command; returns exit codes + on-disk content. */
+  async function runSetBody(
+    relPath: string,
+    extraArgs: string[],
+  ): Promise<{ exit: number[]; content: string }> {
+    const cmd = setBodyCommand();
+    await cmd.parseAsync(
+      [relPath, "--vault", vault, "--frozen-clock", FROZEN_CLOCK, ...extraArgs],
+      { from: "user" },
+    );
+    const abs = path.join(vault, relPath);
+    const content = fs.existsSync(abs) ? fs.readFileSync(abs, "utf-8") : "";
+    return { exit: [...exitCodes], content };
+  }
+
+  it("overwrites the body, preserves frontmatter, bumps updatedAt @req:664123d3-5b91-4793-8085-485d48471546", async () => {
+    const bodyFile = path.join(vault, "new-body.md");
+    fs.writeFileSync(bodyFile, "BRAND NEW BODY\nsecond line\n");
+
+    const out = await runSetBody(taskPath, ["--body-file", bodyFile]);
+
+    expect(out.exit).toContain(0);
+    expect(out.exit).not.toContain(1);
+    // New body present, old body gone.
+    expect(out.content).toContain("BRAND NEW BODY");
+    expect(out.content).toContain("second line");
+    expect(out.content).not.toContain("OLD BODY LINE 1");
+    expect(out.content).not.toContain("OLD BODY LINE 2");
+    // Frontmatter keys preserved.
+    expect(out.content).toContain(`exo__Asset_uid: ${TASK_UID}`);
+    expect(out.content).toContain(`exo__Asset_label: "A task"`);
+    // updatedAt bumped away from the stale value.
+    expect(out.content).toContain(`exo__Asset_updatedAt: ${EXPECTED_UPDATED_AT}`);
+    expect(out.content).not.toContain(STALE_UPDATED_AT);
+  });
+
+  it("accepts a valid [[uuid]] wikilink in the new body @req:664123d3-5b91-4793-8085-485d48471546", async () => {
+    const out = await runSetBody(taskPath, [
+      "--body",
+      `See [[${TARGET_UID}]] for context.`,
+    ]);
+
+    expect(out.exit).toContain(0);
+    expect(out.exit).not.toContain(1);
+    expect(out.content).toContain(`[[${TARGET_UID}]]`);
+    expect(out.content).not.toContain("OLD BODY LINE 1");
+  });
+
+  it("rejects an invalid wikilink in the new body, leaving the file byte-unchanged @req:664123d3-5b91-4793-8085-485d48471546", async () => {
+    const out = await runSetBody(taskPath, [
+      "--body",
+      `Broken [[${NONEXISTENT_UID}]] link.`,
+    ]);
+
+    // Handled via ErrorHandler → non-zero exit; the file must be untouched.
+    expect(out.exit).not.toContain(0);
+    expect(out.content).toBe(originalContent);
+    expect(out.content).toContain("OLD BODY LINE 1");
+    expect(out.content).not.toContain(NONEXISTENT_UID);
+  });
+
+  it("refuses a non-asset (no exo__Asset_uid) @req:664123d3-5b91-4793-8085-485d48471546", async () => {
+    const before = fs.readFileSync(
+      path.join(vault, `${TASKS_DIR}/not-an-asset.md`),
+      "utf-8",
+    );
+    const out = await runSetBody(`${TASKS_DIR}/not-an-asset.md`, [
+      "--body",
+      "should not be written",
+    ]);
+
+    expect(out.exit).not.toContain(0);
+    // File byte-unchanged; the refused body never landed.
+    expect(out.content).toBe(before);
+    expect(out.content).not.toContain("should not be written");
+    const stderrLog = errorSpy.mock.calls.flat().join("\n");
+    expect(stderrLog).toMatch(/not a vault asset/i);
+  });
+
+  it("--dry-run previews the result without writing @req:664123d3-5b91-4793-8085-485d48471546", async () => {
+    const out = await runSetBody(taskPath, [
+      "--body",
+      "PREVIEW ONLY BODY",
+      "--dry-run",
+    ]);
+
+    expect(out.exit).toContain(0);
+    // The file on disk is unchanged (dry-run wrote nothing).
+    expect(out.content).toBe(originalContent);
+    expect(out.content).toContain("OLD BODY LINE 1");
+  });
+});


### PR DESCRIPTION
## Summary
Adds `exocortex set-body <path>` (issue #3943): OVERWRITES the markdown **body** (everything after the frontmatter block) of an existing vault asset via `--body-file <file>` (or `--body <text>` / `--body -` stdin), leaving the frontmatter block byte-identical **except** bumping `exo__Asset_updatedAt`. The body-rewrite counterpart of `set-property` (#3795, frontmatter) and `create --body-file` (#3744, body on a NEW asset) — closes the recurring dogfood gap where a body rewrite required a raw `backup → rm → Write` (bypassing the PreToolUse hook-coverage + SHACL floor, and — since the 2026-07-26 `dogfood-cli-mutation` hardening — an audited sentinel window for CLI-creatable instance classes).

Guards mirror `set-property`:
- Refuses a target **outside the vault** and a **non-asset** (no `exo__Asset_uid`).
- Validates **wikilinks in the new body** (the CLI/Bash write bypasses the validate-wikilinks hook) — an invalid `[[uuid]]` is rejected fail-loud, file left **byte-unchanged**; `--skip-wikilink-validation` opts out.
- `--dry-run` previews the result without writing.

CLI-only change (new `packages/cli/src/commands/set-body.ts` + `program.ts` registration); reuses `FrontmatterService` (parse + updateProperty, `$`-safe function-replacer) + `WikilinkValidator`. No core change.

## Requirement (feature-sdd)
`664123d3-5b91-4793-8085-485d48471546` (Approved) — `exoas-exo-reqs`. Flips to Active after merge (binding `@req:664123d3-…` lands in main).

## Revert-verified (3 axes, each reds exactly its own assertion, restored → 5/5 GREEN)
1. Body replacement (keep original) → the body-replaced tests RED.
2. `updatedAt` bump neutralised → the bump assertion RED.
3. Wikilink validation neutralised → the invalid-wikilink refusal RED.

`set-property` integration 29/29 (no regression). (3 local suites — `BootstrapAssetSpaceService`, `cross-runtime-mount-parity`, `sparql-exo003` — fail identically WITHOUT this change = pre-existing env-only, resolved by CI's fresh install.)

Req: 664123d3-5b91-4793-8085-485d48471546
Closes #3943
