### PR TITLE
docs(cli): apply --help + error surface the required --input '{"value":...}' (#3930)

### DIFF
--- a/packages/cli/src/commands/apply.ts
+++ b/packages/cli/src/commands/apply.ts
@@ -520,7 +520,10 @@ export function applyCommand(): Command {
     .option("--vault <path>", "Path to Obsidian vault", process.cwd())
     .option("--dry-run", "Preview without writing")
     .option("--yes", "Skip destructive-command confirmation")
-    .option("--input <json>", "JSON userInput for service_call groundings")
+    .option(
+      "--input <json>",
+      `JSON userInput for a grounding. Value-setting commands need a value key, e.g. set-planned-start / set-scheduled-date: --input '{"value":"<ISO>"}'; set-label: --input '{"value":"New label"}'. The required key is named in the error if omitted.`,
+    )
     .option(
       "--seed <uuid>",
       "Deterministic UID seed for test/replay (uses seededUidGenerator)",

--- a/packages/services/src/grounding-service-factories.ts
+++ b/packages/services/src/grounding-service-factories.ts
@@ -538,10 +538,14 @@ export function createUpdatePropertyService(
       const property = userInput?.property as string | undefined;
       const value = userInput?.value;
       if (!property) {
-        throw new Error("updateProperty requires userInput.property");
+        throw new Error(
+          `updateProperty requires userInput.property — pass it via --input '{"property":"<name>","value":"<value>"}'`,
+        );
       }
       if (value === undefined) {
-        throw new Error("updateProperty requires userInput.value");
+        throw new Error(
+          `updateProperty requires userInput.value — pass it via --input '{"value":"<value>"}' (e.g. set-planned-start: --input '{"value":"2026-07-25T09:00:00"}')`,
+        );
       }
       const filePath = await pathResolver.resolveTargetPath(targetIRI);
       const content = await fsAdapter.readFile(filePath);


### PR DESCRIPTION
## Summary
`apply set-planned-start <path>` (and other value-setting `apply` groundings) require `--input '{"value":"<ISO>"}'`, but neither `--help` nor the runtime error revealed the required key/shape — users learned it only via trial-and-error (issue #3930).

- **`apply --input <json>` help** now gives concrete examples: `set-planned-start` / `set-scheduled-date` need `{"value":"<ISO>"}`, `set-label` needs `{"value":"..."}`, and the required key is named in the error if omitted.
- **The `updateProperty requires userInput.value` / `.property` errors** now append the actionable form `--input '{"value":"<value>"}'` (with a concrete `set-planned-start` example). The `requires userInput.value` / `.property` substrings are preserved so the existing regex assertion in `grounding-service-factories.test.ts` stays green.

## Scope
Docs/UX only — **no behaviour change** (same trigger, same exit code). Exempt from the req-first SDD loop (feature-sdd Step 0: docs). Message-string edits in `apply.ts` (CLI) + `grounding-service-factories.ts` (shared services; the error is surfaced by every `apply` value-grounding, so both plugin and CLI benefit).

typecheck clean (my files 0 errors); `apply.test.ts` 6/6; only a code COMMENT (not an assertion) referenced the old string.

Closes #3930
