### PR TITLE
fix(#3936): full-refresh on reified-statement live edit to purge stale materialized edge

### DIFF
--- a/packages/obsidian-plugin/src/infrastructure/VaultRDFIndexer.ts
+++ b/packages/obsidian-plugin/src/infrastructure/VaultRDFIndexer.ts
@@ -297,6 +297,28 @@ export class VaultRDFIndexer {
       return;
     }
 
+    // Issue #3936: a reified `exo__Statement` note emits a materialized LOGICAL
+    // EDGE `<subject> <predicate> <object>` (convertLegacyNote, EKA D5) whose
+    // SUBJECT is the statement's referent — NOT this file's IRI. So the
+    // incremental path below (`removeFileTriples` is subject-scoped to the file
+    // IRI) cannot purge the OLD edge on re-index, leaving it stale alongside the
+    // freshly-emitted one after any edit to the statement's subject/predicate/
+    // object. A graph edit is graph-wide; mirror the FileSpace-declaration
+    // branch above and do a full `refresh()` (clear + rebuild), which purges the
+    // stale edge. Detected from the CURRENT (pre-edit) store state — the file is
+    // still typed `exo#Statement` there — so this also covers the removal case
+    // (edited to no longer be a statement, whose old edge would otherwise
+    // linger). Reified statements are rare, so the full-refresh cost is
+    // acceptable (same trade-off as the FileSpace branch). (Enum `rdf:type`
+    // shadow triples are NOT covered here on purpose: they are globally-true,
+    // idempotent facts about the enum instance, never stale-divergent. The A2
+    // symbolic superclass edges the issue also cited do not exist on this
+    // branch — their PR #3935 was closed, not merged.)
+    if (await this.wasReifiedStatement(file.path)) {
+      await this.refresh();
+      return;
+    }
+
     await this.errorHandler.executeWithRetry(
       async () => {
         const fileIRI = new IRI(`obsidian://vault/${encodeURI(file.path)}`);
@@ -320,6 +342,26 @@ export class VaultRDFIndexer {
     return instances.length > 0;
   }
 
+  /**
+   * Issue #3936: is `path` CURRENTLY indexed as a reified `exo__Statement`
+   * (i.e. the store holds `<fileIRI> rdf:type exo#Statement`, emitted by the
+   * converter for a note whose `exo__Instance_class` is `exo__Statement`)?
+   *
+   * A reified statement emits an extra materialized edge on a NON-file-IRI
+   * subject that the subject-scoped `removeFileTriples` cannot evict, so an
+   * incremental re-index leaves the OLD edge stale. Callers route such a file
+   * to a full `refresh()` instead. Reading the PRE-mutation store state means
+   * this also fires when a statement is edited to no longer BE a statement (its
+   * old edge must still be purged) and when a statement is deleted.
+   */
+  private async wasReifiedStatement(path: string): Promise<boolean> {
+    const fileIRI = new IRI(`obsidian://vault/${encodeURI(path)}`);
+    const rdfType = Namespace.RDF.term("type");
+    const statementClass = Namespace.EXO.term("Statement");
+    const typed = await this.tripleStore.match(fileIRI, rdfType, statementClass);
+    return typed.length > 0;
+  }
+
   async removeFile(file: TFile): Promise<void> {
     if (this.refreshInFlight !== null) {
       await this.refreshInFlight;
@@ -332,6 +374,14 @@ export class VaultRDFIndexer {
         await this.refresh();
         return;
       }
+    }
+    // Issue #3936: deleting a reified exo__Statement leaves its materialized
+    // logical edge (non-file-IRI subject) stale — subject-scoped
+    // removeFileTriples cannot evict it. Full refresh purges it (same rationale
+    // as updateFile).
+    if (await this.wasReifiedStatement(file.path)) {
+      await this.refresh();
+      return;
     }
     await this.errorHandler.executeWithRetry(
       async () => this.removeFileTriples(file.path),

--- a/packages/obsidian-plugin/tests/unit/infrastructure/VaultRDFIndexer.excluded-folders.test.ts
+++ b/packages/obsidian-plugin/tests/unit/infrastructure/VaultRDFIndexer.excluded-folders.test.ts
@@ -152,6 +152,14 @@ describe("VaultRDFIndexer — excludedFolders plumbing", () => {
     (Namespace as any).EXO = {
       term: jest.fn().mockReturnValue(mockPrototypePredicate),
     };
+    // #3936: updateFile now probes Namespace.RDF.term("type") +
+    // Namespace.EXO.term("Statement") to detect a reified statement (store
+    // match returns [] here → not a statement → incremental path preserved).
+    (Namespace as any).RDF = {
+      term: jest
+        .fn()
+        .mockReturnValue({ value: "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" }),
+    };
   });
 
   describe("initialize", () => {

--- a/packages/obsidian-plugin/tests/unit/infrastructure/VaultRDFIndexer.reified-statement-reindex.test.ts
+++ b/packages/obsidian-plugin/tests/unit/infrastructure/VaultRDFIndexer.reified-statement-reindex.test.ts
@@ -1,0 +1,197 @@
+/**
+ * Issue #3936 — an incremental re-index of a reified `exo__Statement` note must
+ * NOT leave its OLD materialized logical edge stale in the store.
+ *
+ * `convertLegacyNote` (EKA D5) emits, for a note typed `exo__Statement`, an
+ * extra edge `<subject> <predicate> <object>` whose SUBJECT is the statement's
+ * referent — NOT the statement file's IRI. `VaultRDFIndexer.removeFileTriples`
+ * is subject-scoped to the file IRI (`match(fileIRI)`), so on a live edit that
+ * changes the statement's object A→B the OLD edge `<subj> <pred> A` survives the
+ * incremental purge and lingers alongside the new `<subj> <pred> B` — a
+ * stale-divergent triple a SPARQL `<subj> <pred> ?o` query would wrongly see as
+ * {A, B} until the next FULL refresh (reload / profile-apply) self-heals it.
+ *
+ * Fix: `updateFile` detects (from the PRE-edit store state) that the file is a
+ * reified statement and does a full `refresh()` (clear + rebuild) instead of the
+ * subject-scoped incremental path, purging the stale edge.
+ *
+ * Production-shape: this uses the REAL `InMemoryTripleStore` (asserts actual
+ * store contents), the REAL `Namespace`/`IRI`/`Triple`, and the REAL `updateFile`
+ * dispatch. Only the converter (emission source) and the inference scaffolding
+ * are mocked, so the store-mutation behaviour under test is genuine. Empirically
+ * verified to FAIL pre-fix (old edge lingers) and PASS post-fix (old edge gone).
+ *
+ * Scope note (issue premise re-scoped on this branch): the A2 symbolic
+ * superclass edges the issue also cited do NOT exist here (their PR #3935 was
+ * CLOSED, not merged). The enum `rdf:type` shadow is intentionally out of scope
+ * — those are globally-true, idempotent facts about the enum instance, never
+ * stale-divergent. The reified-statement edge is the one real stale case.
+ */
+import { VaultRDFIndexer } from "../../../src/infrastructure/VaultRDFIndexer";
+import type { App, TFile } from "obsidian";
+import {
+  InMemoryTripleStore,
+  DomainIRI,
+  DomainTriple,
+  Namespace,
+  ApplicationErrorHandler,
+  NoteToRDFConverter,
+} from "@kitelev/exocortex-core";
+
+// Real core everything (store, IRI, Triple, Namespace, isPathExcluded, …),
+// overriding ONLY the converter (emission source we control) + inference
+// scaffolding + error handler (run-inline). This keeps the store mutation and
+// the updateFile dispatch genuine — the crux of the regression.
+jest.mock("@kitelev/exocortex-core", () => {
+  const actual = jest.requireActual("@kitelev/exocortex-core");
+  return {
+    ...actual,
+    NoteToRDFConverter: jest.fn(),
+    ApplicationErrorHandler: jest.fn(),
+    RDFSInferenceEngine: jest.fn(),
+    NonInheritablePropertyRegistry: jest.fn(),
+    PropertyCardinalityRegistry: jest.fn(),
+    PrototypeChainMaterializer: jest.fn(),
+  };
+});
+jest.mock("../../../src/adapters/ObsidianVaultAdapter");
+
+const STMT_PATH = "concepts/stmt.md";
+const stmtFileIRI = new DomainIRI(`obsidian://vault/${STMT_PATH}`);
+const subjIRI = new DomainIRI("obsidian://vault/concepts/subject.md");
+const predIRI = new DomainIRI("https://exocortex.my/ontology/exo#related");
+const objAIRI = new DomainIRI("obsidian://vault/concepts/objA.md");
+const objBIRI = new DomainIRI("obsidian://vault/concepts/objB.md");
+
+const statementClass = Namespace.EXO.term("Statement");
+const rdfType = Namespace.RDF.term("type");
+const stmtSubjectPred = Namespace.EXO.term("Statement_subject");
+
+// Statement-file triples + the materialized reified edge. The rdf:type triple
+// (subject = file IRI) is what `wasReifiedStatement` detects; the reified edge
+// (subject = subjIRI) is the non-file-IRI-subject triple `removeFileTriples`
+// cannot evict.
+const stmtTriples = (objIRI: DomainIRI): DomainTriple[] => [
+  new DomainTriple(stmtFileIRI, rdfType, statementClass),
+  new DomainTriple(stmtFileIRI, stmtSubjectPred, subjIRI),
+  new DomainTriple(subjIRI, predIRI, objIRI),
+];
+
+function makeFile(path: string): TFile {
+  return {
+    path,
+    extension: "md",
+    basename: path.split("/").pop()!.replace(/\.md$/, ""),
+    name: path.split("/").pop()!,
+  } as unknown as TFile;
+}
+
+describe("Issue #3936 — reified exo__Statement incremental re-index purges the stale edge", () => {
+  let mockApp: App;
+  let mockConverter: jest.Mocked<NoteToRDFConverter>;
+  // The current full-vault emission (what a refresh re-reads); flipped to the
+  // post-edit state before firing updateFile.
+  let currentFull: DomainTriple[];
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    currentFull = stmtTriples(objAIRI); // initial: object = A
+
+    (
+      ApplicationErrorHandler as jest.MockedClass<typeof ApplicationErrorHandler>
+    ).mockImplementation(
+      () =>
+        ({
+          executeWithRetry: jest
+            .fn()
+            .mockImplementation(async (op: () => Promise<unknown>) => op()),
+          handle: jest.fn(),
+        }) as any,
+    );
+
+    mockApp = {
+      vault: {
+        on: jest.fn().mockReturnValue({}),
+        off: jest.fn(),
+        offref: jest.fn(),
+        getMarkdownFiles: jest.fn().mockReturnValue([]),
+        getAllFiles: jest.fn().mockReturnValue([]),
+      },
+      metadataCache: {
+        on: jest.fn(),
+        off: jest.fn(),
+        getFileCache: jest.fn().mockReturnValue(null),
+      },
+    } as unknown as App;
+
+    mockConverter = {
+      convertVault: jest.fn().mockImplementation(async () => currentFull),
+      convertVaultWithValidation: jest.fn().mockImplementation(async () => ({
+        triples: currentFull,
+        skippedFiles: [],
+        summary: { total: 1, indexed: 1, skipped: 0 },
+        fileSpaces: { prefixes: [], declarationPaths: [], warnings: [] },
+      })),
+      // Only reached on the incremental (pre-fix) path — returns the NEW note.
+      convertNote: jest.fn().mockImplementation(async () => stmtTriples(objBIRI)),
+    } as any;
+
+    (
+      NoteToRDFConverter as jest.MockedClass<typeof NoteToRDFConverter>
+    ).mockImplementation(() => mockConverter);
+
+    const mocked = jest.requireMock("@kitelev/exocortex-core") as any;
+    for (const cls of [
+      "RDFSInferenceEngine",
+      "NonInheritablePropertyRegistry",
+      "PropertyCardinalityRegistry",
+      "PrototypeChainMaterializer",
+    ]) {
+      mocked[cls].mockImplementation(() => ({
+        materialize: jest.fn().mockResolvedValue(undefined),
+        initialize: jest.fn().mockResolvedValue(undefined),
+      }));
+    }
+  });
+
+  it("purges the OLD reified edge on a live statement edit (KEY: fails pre-fix)", async () => {
+    const indexer = new VaultRDFIndexer(mockApp);
+    await indexer.initialize();
+    const store: InMemoryTripleStore = indexer.getTripleStore();
+
+    // Sanity: initial store has the A edge, not B.
+    expect(await store.match(subjIRI, predIRI, objAIRI)).toHaveLength(1);
+    expect(await store.match(subjIRI, predIRI, objBIRI)).toHaveLength(0);
+
+    // Simulate the on-disk edit (object A→B) a refresh will re-read.
+    currentFull = stmtTriples(objBIRI);
+
+    await indexer.updateFile(makeFile(STMT_PATH));
+
+    // KEY: the OLD A edge must be GONE (stale-divergent otherwise).
+    expect(await store.match(subjIRI, predIRI, objAIRI)).toHaveLength(0);
+    // And the NEW B edge is present.
+    expect((await store.match(subjIRI, predIRI, objBIRI)).length).toBeGreaterThan(0);
+  });
+
+  it("does NOT full-refresh an ordinary (non-statement) note edit — incremental path preserved", async () => {
+    // A non-statement note: no rdf:type exo__Statement in the store.
+    currentFull = [
+      new DomainTriple(
+        new DomainIRI("obsidian://vault/concepts/plain.md"),
+        Namespace.EXO.term("Asset_label"),
+        // a literal-ish; label value irrelevant to the dispatch assertion
+        new DomainIRI("obsidian://vault/concepts/whatever.md"),
+      ),
+    ];
+    const indexer = new VaultRDFIndexer(mockApp);
+    await indexer.initialize();
+
+    const refreshSpy = jest.spyOn(indexer, "refresh");
+    await indexer.updateFile(makeFile("concepts/plain.md"));
+
+    // Ordinary edit → incremental path (convertNote), NOT a full refresh.
+    expect(refreshSpy).not.toHaveBeenCalled();
+    expect(mockConverter.convertNote).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #3936 — incremental re-index of a reified `exo__Statement` no longer leaves its OLD materialized logical edge stale in the triple store.

`VaultRDFIndexer.removeFileTriples` is subject-scoped (`match(fileIRI)`), but `convertLegacyNote` (EKA D5) emits, for a note typed `exo__Statement`, an extra edge `<subject> <predicate> <object>` whose **subject is the statement's referent, not the file IRI**. So a live edit changing the statement's object A→B left the old `<subj> <pred> A` edge alongside the new one until a full refresh self-healed it — a SPARQL `<subj> <pred> ?o` would wrongly see `{A, B}`.

`updateFile` (live edit) and `removeFile` (delete) now detect — from the **pre-edit store state** (`match(fileIRI, rdf:type, exo#Statement)`) — that the file is a reified statement and route to a full `refresh()` (clear + rebuild), which purges the stale edge. Reading the pre-edit state also covers the removal case (edited to no longer be a statement). Mirrors the existing FileSpace-declaration → refresh branch; reified statements are rare so the cost is acceptable.

## Scope re-scoped vs the issue (verify-before-assert)

The issue was a follow-up to PR #3935 (A2 symbolic superclass edges). On `origin/main`:
- **A2 symbolic superclass edges do NOT exist** — PR #3935 was **closed, not merged** (`emitSymbolicSuperClassEdges` absent). The issue's "Reproduced" A2 example cannot occur here.
- **Enum `rdf:type` shadow** is intentionally **out of scope** — those are globally-true, idempotent facts about the enum instance, never stale-divergent.
- The **reified-statement edge** is the one real stale-divergent case; this PR fixes it.

## Test

`VaultRDFIndexer.reified-statement-reindex.test.ts` — production-shape (real `InMemoryTripleStore` / `Namespace` / `IRI` / `Triple`; only converter + inference mocked) asserting the **actual store contents**. Empirically verified: **FAILS pre-fix** (old A edge lingers, length 1) / **PASSES post-fix** (old edge gone). A non-statement control edit stays on the incremental path (no over-triggering). All 4 VaultRDFIndexer suites green (44 tests); typecheck + 3 lint-job guard scripts clean.

_(Bug-fix, exempt from req-first per RFC 0003 Step 0. No code-reviewer subagent run — this was executed in a headless autonomous session where subagents are disabled; compensated with production-shape revert-verify + full-suite + typecheck + guards.)_
