### PR TITLE
feat(sync): R5 secret-scan per-file skip+quarantine, not whole-repo refuse (#3976)

### DIFF
--- a/packages/core/src/services/sync/SyncEngine.ts
+++ b/packages/core/src/services/sync/SyncEngine.ts
@@ -2338,6 +2338,14 @@ export class SyncEngine {
     // REDACTED copy. Accumulated across the D16 retry loop (which rebuilds
     // pushFiles from pushFilesAll each attempt) — re-skipped every iteration
     // but quarantined once per path via `handledSecretPaths`.
+    //
+    // These are threaded out ONLY on the `done` outcome (flushed by the
+    // caller). On a `conflict` / `retry-exhausted` early-return the redacted
+    // record is not persisted this cycle — but the skipped file is untouched
+    // on disk and un-pushed, so it re-derives and re-quarantines on a later
+    // sync (self-healing; code-reviewer LOW1). The prod LocalConflictCacheStore
+    // upserts by (repoKey, path), so a re-quarantine refreshes the record
+    // rather than duplicating it (code-reviewer LOW2).
     const secretQuarantineEntries: QuarantineEntry[] = [];
     const handledSecretPaths = new Set<string>();
 
@@ -2676,6 +2684,22 @@ export class SyncEngine {
             .map(([p, k]) => `${p} (${k.join(", ")})`)
             .join(", ")}`,
         );
+        // Rename atomicity (code-reviewer MEDIUM): a rename old→new whose NEW
+        // path carries the secret has its add-half skipped above, but the
+        // delete-half of `old` (owner=new in pushDeletionsAll) was already
+        // derived into `pushDeletions` BEFORE the R5 scan. Shipping it alone
+        // would delete `old` on the remote while `new` is withheld → the
+        // renamed file transiently vanishes AND the delete propagates to
+        // other devices (the exact atomicity the old whole-repo-defer kept).
+        // Withhold any deletion owned by a skipped path (mirror of the
+        // convergedPushPaths withhold) so BOTH halves defer and re-derive
+        // together once the secret is removed.
+        for (const [delPath, owner] of pushDeletionsAll) {
+          if (handledSecretPaths.has(owner) && pushDeletions.has(delPath)) {
+            pushDeletions.delete(delPath);
+            withheldDeletions.push(delPath);
+          }
+        }
         // Nothing left to push (all files were secret-bearing) — the repo
         // still syncs, carrying only the skip warning; the skipped files
         // re-derive on a later sync once the secret is removed.

--- a/packages/core/src/services/sync/SyncEngine.ts
+++ b/packages/core/src/services/sync/SyncEngine.ts
@@ -80,7 +80,7 @@ import {
   type OutboxStorePort,
 } from "./LocalOutboxStore";
 import { isAuthError } from "./CredentialStore";
-import { scanForSecrets } from "./secretScan";
+import { redactSecrets, scanForSecrets } from "./secretScan";
 import {
   withRateLimitBackoff,
   createRateLimitBudget,
@@ -596,7 +596,6 @@ type PushLoopOutcome =
       /** Last iteration's merge resolution — its quarantine entries must not be lost. */
       merge: MergeResolution;
     }
-  | { kind: "secret-detected"; detail: string }
   | {
       kind: "done";
       examinedHead: string;
@@ -641,6 +640,13 @@ type PushLoopOutcome =
        * the D16 retry loop would duplicate them per attempt).
        */
       deferredWarnings: string[];
+      /**
+       * R5 secret-scan (#3976): files skipped from the push because they
+       * matched a secret shape — each carrying a REDACTED copy. The caller
+       * flushes them via a SEPARATE flushQuarantine (decoupled from the merge
+       * flush's D18 gate). Empty on a clean push.
+       */
+      secretQuarantineEntries: QuarantineEntry[];
     };
 
 /**
@@ -1486,9 +1492,6 @@ export class SyncEngine {
       if (loop.kind === "conflict") {
         return result("conflict", { detail: loop.detail });
       }
-      if (loop.kind === "secret-detected") {
-        return result("error", { detail: loop.detail });
-      }
       if (loop.kind === "retry-exhausted") {
         // D16 terminal-quarantine: the contended files of the last attempt
         // PLUS any pending merge-quarantine entries (they would otherwise be
@@ -1542,6 +1545,15 @@ export class SyncEngine {
         [...merge.quarantineEntries, ...merge.resolvedQuarantineEntries],
         warnings,
       );
+
+      // #3976: R5 secret-skipped files flush via a SEPARATE call — decoupled
+      // from `flushed` so a secret-entry flush failure does NOT gate the D18
+      // resolved-remote-wins withhold below. The security floor already holds
+      // (the secret file was dropped from the push); a failed flush only loses
+      // the redacted-copy record (warned), the file stays untouched on disk.
+      if (loop.secretQuarantineEntries.length > 0) {
+        await this.flushQuarantine(loop.secretQuarantineEntries, warnings);
+      }
 
       // Reviewer CRITICAL (AC2): the remote-wins apply DESTROYS the local
       // version, whose only surviving copy is the quarantine entry — when
@@ -2321,6 +2333,13 @@ export class SyncEngine {
     let deferredRemoteChanges: RemoteChange[] = [];
     let deferredWarnings: string[] = [];
     const remoteOversized = new Set<string>();
+    // #3976: R5 secret-scan per-file skip. Files matching a secret shape are
+    // dropped from the push (the secret NEVER ships) and quarantined with a
+    // REDACTED copy. Accumulated across the D16 retry loop (which rebuilds
+    // pushFiles from pushFilesAll each attempt) — re-skipped every iteration
+    // but quarantined once per path via `handledSecretPaths`.
+    const secretQuarantineEntries: QuarantineEntry[] = [];
+    const handledSecretPaths = new Set<string>();
 
     for (;;) {
       // Reuse the head pre-fetched in syncLocked on the FIRST attempt — but
@@ -2600,8 +2619,13 @@ export class SyncEngine {
       }
       if (pushFiles.size === 0 && pushDeletions.size === 0) break;
 
-      // R5 secret-scan — refuse the WHOLE push (a partial set could ship an
-      // inconsistent asset graph). Findings carry path+kind, never the
+      // R5 secret-scan (#3976) — SKIP only the offending file(s), never the
+      // whole repo. A file matching a secret shape is removed from the commit
+      // (the secret is NEVER shipped — the security floor holds regardless of
+      // quarantine) and quarantined with a REDACTED copy for the user's
+      // security decision; the rest of the changeset ships. Previously ANY
+      // finding refused the entire repo push (`pushed 0`), blocking every
+      // clean file in the changeset. Findings carry path+kind, never the
       // secret. File mode: UTF-8-decodable contents (plain notes inside a
       // FileSpace) still scan; true binary (non-UTF-8) is skipped — secret
       // patterns are text-shaped (R5 residual, documented).
@@ -2616,12 +2640,46 @@ export class SyncEngine {
       }
       const findings = scanForSecrets(scannable);
       if (findings.length > 0) {
-        return {
-          kind: "secret-detected",
-          detail: `secret-scan: refusing to push — ${findings
-            .map((f) => `${f.path} (${f.kind})`)
-            .join(", ")} (R5); remove the secret and re-sync`,
-        };
+        const kindsByPath = new Map<string, string[]>();
+        for (const f of findings) {
+          const kinds = kindsByPath.get(f.path);
+          if (kinds === undefined) kindsByPath.set(f.path, [f.kind]);
+          else if (!kinds.includes(f.kind)) kinds.push(f.kind);
+        }
+        for (const [path, kinds] of kindsByPath) {
+          if (!handledSecretPaths.has(path)) {
+            handledSecretPaths.add(path);
+            // scannable.get(path) is the exact UTF-8 text that matched (every
+            // finding comes from `scannable`); redact it for the durable copy.
+            const scanned = scannable.get(path);
+            const redacted =
+              scanned !== undefined ? redactSecrets(scanned) : undefined;
+            const uid =
+              redacted !== undefined ? extractAssetUid(redacted) : undefined;
+            secretQuarantineEntries.push({
+              repoKey: spec.repoKey,
+              path,
+              ...(uid !== undefined ? { uid } : {}),
+              reason: `secret-scan (R5): detected ${kinds.join(
+                ", ",
+              )} — skipped from the push (the secret is NEVER shipped); a redacted copy is quarantined. REVOKE the credential, then re-sync once it is removed.`,
+              ...(redacted !== undefined ? { localContent: redacted } : {}),
+            });
+          }
+          // Re-skip every iteration: the D16 retry rebuilds pushFiles.
+          pushFiles.delete(path);
+        }
+        warnings.push(
+          `secret-scan (R5): skipped ${kindsByPath.size} file(s) with a detected secret from the push — the rest of the changeset shipped; REVOKE the credential(s): ${[
+            ...kindsByPath,
+          ]
+            .map(([p, k]) => `${p} (${k.join(", ")})`)
+            .join(", ")}`,
+        );
+        // Nothing left to push (all files were secret-bearing) — the repo
+        // still syncs, carrying only the skip warning; the skipped files
+        // re-derive on a later sync once the secret is removed.
+        if (pushFiles.size === 0 && pushDeletions.size === 0) break;
       }
 
       try {
@@ -2676,6 +2734,7 @@ export class SyncEngine {
       deferredPaths,
       deferredRemoteChanges,
       deferredWarnings,
+      secretQuarantineEntries,
     };
   }
 

--- a/packages/core/tests/unit/services/sync/SyncEngine.test.ts
+++ b/packages/core/tests/unit/services/sync/SyncEngine.test.ts
@@ -1897,6 +1897,39 @@ describe("SyncEngine — A3: D11 one-operation guard, R8 auth, R5 secret-scan", 
     expect(entry?.localContent).toContain("[REDACTED:github-token]");
     expect(entry?.localContent).not.toContain(pat);
   });
+
+  it("R5 per-file skip preserves rename atomicity: a rename whose TARGET carries a PAT ships NEITHER half (#3976, code-reviewer MEDIUM)", async () => {
+    const OLD_R = "assets/old-rename.md";
+    const NEW_R = "assets/new-rename.md";
+    const gh = new FakeGitHubRepo({ [OLD_R]: mdAsset("u-ren", "content") });
+    const local = new FakeLocalFiles({ [OLD_R]: mdAsset("u-ren", "content") });
+    const quarantine = new InMemoryQuarantineStore();
+    const { engine } = makeEngine(gh, local, { quarantine });
+    await bootstrap(engine, gh.spec());
+    const headBefore = gh.headSha();
+
+    const pat = `ghp_${"a1B2".repeat(10)}`;
+    // Rename OLD_R → NEW_R (unique uid ⇒ ChangeDetector infers basePath), and
+    // the NEW path carries a pasted PAT.
+    local.files.delete(OLD_R);
+    local.files.set(NEW_R, mdAsset("u-ren", `renamed, oops a token: ${pat}`));
+
+    const result = await engine.sync(gh.spec());
+
+    // The repo syncs (no whole-repo error) but NEITHER half of the rename
+    // ships — atomicity preserved: the add-half is R5-skipped and the
+    // delete-half of OLD (owned by the skipped NEW) is withheld with it.
+    expect(result.status).toBe("synced");
+    expect(gh.headSha()).toBe(headBefore); // nothing pushed at all
+    expect(gh.headFiles().has(NEW_R)).toBe(false); // add-half withheld
+    expect(gh.headFiles().has(OLD_R)).toBe(true); // ⛤ delete-half withheld — OLD not deleted
+    expect(result.pushedDeletes ?? []).not.toContain(OLD_R);
+    for (const c of gh.headFiles().values()) expect(c).not.toContain(pat);
+    // NEW_R quarantined redacted for the user's security decision.
+    const entry = quarantine.entries.find((e) => e.path === NEW_R);
+    expect(entry?.localContent).toContain("[REDACTED:github-token]");
+    expect(entry?.localContent).not.toContain(pat);
+  });
 });
 
 describe("SyncEngine — #3475 phantom/empty commits (detected content already in HEAD)", () => {

--- a/packages/core/tests/unit/services/sync/SyncEngine.test.ts
+++ b/packages/core/tests/unit/services/sync/SyncEngine.test.ts
@@ -1833,10 +1833,11 @@ describe("SyncEngine — A3: D11 one-operation guard, R8 auth, R5 secret-scan", 
     expect(result.status).toBe("synced"); // bootstrap survived the throttle
   });
 
-  it("a push payload containing a PAT is refused outright (R5) — secret never leaves the device", async () => {
+  it("a push payload whose ONLY file carries a PAT skips that file (R5) — secret never leaves the device, no whole-repo error (#3976)", async () => {
     const gh = new FakeGitHubRepo({ [FILE_A]: mdAsset("u1") });
     const local = new FakeLocalFiles({ [FILE_A]: mdAsset("u1") });
-    const { engine } = makeEngine(gh, local);
+    const quarantine = new InMemoryQuarantineStore();
+    const { engine } = makeEngine(gh, local, { quarantine });
     await bootstrap(engine, gh.spec());
     const headBefore = gh.headSha();
 
@@ -1844,11 +1845,57 @@ describe("SyncEngine — A3: D11 one-operation guard, R8 auth, R5 secret-scan", 
     local.files.set(FILE_A, mdAsset("u1", `oops, pasted a token: ${pat}`));
     const result = await engine.sync(gh.spec());
 
-    expect(result.status).toBe("error");
-    expect(result.detail).toMatch(/secret-scan/);
-    expect(result.detail).toMatch(/github-token/);
-    expect(result.detail).not.toContain(pat); // path+kind only, never the secret
-    expect(gh.headSha()).toBe(headBefore); // nothing pushed
+    // The only file was secret-bearing → nothing ships, but the repo does NOT
+    // error out — it syncs with a skip warning (the secret never left).
+    expect(result.status).toBe("synced");
+    expect(gh.headSha()).toBe(headBefore); // nothing pushed (the file was skipped)
+    const warned = result.warnings.join(" ");
+    expect(warned).toMatch(/secret-scan/);
+    expect(warned).toMatch(/github-token/);
+    expect(warned).not.toContain(pat); // path+kind only, never the secret
+    // A redacted copy is quarantined for the user's security decision.
+    const entry = quarantine.entries.find((e) => e.path === FILE_A);
+    expect(entry?.localContent).toContain("[REDACTED:github-token]");
+    expect(entry?.localContent).not.toContain(pat);
+  });
+
+  it("R5 per-file skip: a PAT-bearing file is skipped+quarantined (redacted) while the clean files still ship (#3976) @req:526fc6a8-b6c9-4fca-b30f-7439b4ab304b", async () => {
+    const gh = new FakeGitHubRepo({
+      [FILE_A]: mdAsset("u1"),
+      [FILE_B]: mdAsset("u2"),
+    });
+    const local = new FakeLocalFiles({
+      [FILE_A]: mdAsset("u1"),
+      [FILE_B]: mdAsset("u2"),
+    });
+    const quarantine = new InMemoryQuarantineStore();
+    const { engine } = makeEngine(gh, local, { quarantine });
+    await bootstrap(engine, gh.spec());
+    const bBefore = gh.headFiles().get(FILE_B);
+
+    const pat = `ghp_${"a1B2".repeat(10)}`;
+    const cleanEdit = mdAsset("u1", "a clean edit that must ship");
+    local.files.set(FILE_A, cleanEdit);
+    local.files.set(FILE_B, mdAsset("u2", `oops, pasted a token: ${pat}`));
+
+    const result = await engine.sync(gh.spec());
+
+    // The repo SYNCS — no whole-repo refusal. The clean file A ships.
+    expect(result.status).toBe("synced");
+    expect(gh.headFiles().get(FILE_A)).toBe(cleanEdit);
+    // B is NOT shipped — the raw PAT reached NOTHING on the remote (the floor).
+    expect(gh.headFiles().get(FILE_B)).toBe(bBefore);
+    for (const c of gh.headFiles().values()) expect(c).not.toContain(pat);
+    // The skip is surfaced to the user (path + kind, never the secret).
+    const warned = result.warnings.join(" ");
+    expect(warned).toMatch(/secret-scan/);
+    expect(warned).toMatch(/github-token/);
+    expect(warned).not.toContain(pat);
+    // A redacted copy of B is quarantined for the user's security decision.
+    const entry = quarantine.entries.find((e) => e.path === FILE_B);
+    expect(entry).toBeDefined();
+    expect(entry?.localContent).toContain("[REDACTED:github-token]");
+    expect(entry?.localContent).not.toContain(pat);
   });
 });
 


### PR DESCRIPTION
Closes #3976. RFC `6a1a6518` secret-scan deferral — flagged by the RFC's contrarian reviewer as the **actual first blocker** of the incident that motivated the whole RFC.

## Problem
ExoSync R5 secret-scan refused the **entire repo push** (`pushed 0`) on ANY single secret finding → every clean file in the changeset was blocked. Empirical 2026-07-27: 2 PAT-bearing files blocked **915 legit files** of `exoas-shared-private`.

## Fix
`runPushLoop` now **skips only the offending file(s)**:
- The secret file is removed from the commit — **never shipped** (the security floor holds regardless of quarantine success).
- It's quarantined with a **REDACTED** copy (`redactSecrets`) for the user's security decision — the credential still needs revoking.
- The **rest of the changeset ships** normally.
- The skip is surfaced (path + kind, **never** the secret). The skipped file is untouched on disk and re-derives on a later sync once the secret is removed.
- Secret entries flush via a **SEPARATE** `flushQuarantine` — decoupled from the merge-flush `flushed` boolean so a secret-entry flush failure does NOT gate the D18 resolved-remote-wins withhold logic.
- Dedup across D16 retries (the loop rebuilds `pushFiles` each attempt) via `handledSecretPaths`.

## Safety
- **No message-parser risk** (`error-enrich-preserve-message`): the secret detail is a `RepoSyncResult` warning field, never a thrown `Error` classified by `isNonFastForwardError` / `isRateLimitError` / `isAuthError`.
- Scope: only the R5 branch of `runPushLoop` + its `syncLocked` consumer + the internal `PushLoopOutcome.done` type. Scan patterns, `redactSecrets`, quarantine store — unchanged.

## Verification
- **Revert-verified** (integration, production-shape — real `SyncEngine` over `FakeGitHubRepo`, real `InMemoryQuarantineStore`, no network): restore the whole-repo refuse → the clean file A does **not** ship and the result is non-`synced` → **RED** (both #3976 tests); restore per-file skip → clean file ships, B quarantined redacted, `synced` → **GREEN**.
- Full sync suite: **454 tests / 37 suites green** (0 regressions). Typecheck (whole core) 0 errors. Guard scripts (shard / anti-pattern ratchet 55/55 / coverage-monotonic) all pass.
- `@req:526fc6a8-b6c9-4fca-b30f-7439b4ab304b` (exoas-exo-reqs, Approved → flips **Active** after this binding lands in main).

⚠ Touches `packages/core/src/services/sync/` (elevated-risk) — **no auto-merge**; awaiting code-reviewer.