### PR TITLE
chore(lint): type-aware eslint over packages/core/tests/** (tsconfig.eslint.json)

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -14,7 +14,12 @@ export default tseslint.config(
       parserOptions: {
         ecmaVersion: 2022,
         sourceType: 'module',
-        project: './tsconfig.json',
+        // ESLint-only TS project that re-includes test files (build tsconfig.json
+        // excludes packages/**/tests/**/*). Enables type-aware linting of the test
+        // corpus — `eslint packages/core/tests/**` otherwise errors 'file not found
+        // in provided project(s)'. Build/typecheck (tsc --noEmit) still uses
+        // tsconfig.json and never compiles tests. See task d7f89d46.
+        project: './tsconfig.eslint.json',
       },
     },
     rules: {

--- a/packages/core/tests/config/eslint-covers-tests.test.ts
+++ b/packages/core/tests/config/eslint-covers-tests.test.ts
@@ -1,0 +1,82 @@
+// eslint-disable-next-line import/no-nodejs-modules -- config-inspection test reads repo files off disk (Node-only, never bundled into the plugin)
+import * as fs from "fs";
+// eslint-disable-next-line import/no-nodejs-modules -- see above
+import * as path from "path";
+import * as ts from "typescript";
+
+/**
+ * Regression lock for task d7f89d46.
+ *
+ * Type-aware @typescript-eslint rules require every linted file to belong to
+ * the TS project named by `parserOptions.project` in eslint.config.mjs. The
+ * build tsconfig.json excludes `packages/**\/tests/**\/*`, so pointing eslint
+ * at it made `eslint packages/core/tests/**` fail with
+ * "The file was not found in any of the provided project(s)" — the entire
+ * core test corpus was un-lintable.
+ *
+ * The fix wires eslint at a dedicated `tsconfig.eslint.json` that re-includes
+ * tests. This test asserts the *actually-wired* project (read from
+ * eslint.config.mjs) resolves core test files into its program.
+ *
+ * Revert-verify:
+ *  - Repoint eslint.config.mjs `project` back to './tsconfig.json'  → RED.
+ *  - Re-add `packages/**\/tests/**\/*` to tsconfig.eslint.json exclude → RED.
+ */
+describe("eslint type-aware project covers packages/core/tests/** (d7f89d46)", () => {
+  function findRepoRoot(): string {
+    let dir = __dirname;
+    for (let i = 0; i < 12; i++) {
+      if (fs.existsSync(path.join(dir, "eslint.config.mjs"))) {
+        return dir;
+      }
+      const parent = path.dirname(dir);
+      if (parent === dir) break;
+      dir = parent;
+    }
+    throw new Error(
+      "repo root (eslint.config.mjs) not found from " + __dirname,
+    );
+  }
+
+  function eslintProjectPath(repoRoot: string): string {
+    const cfg = fs.readFileSync(
+      path.join(repoRoot, "eslint.config.mjs"),
+      "utf8",
+    );
+    const match = cfg.match(/project:\s*["']([^"']+)["']/);
+    if (match === null) {
+      throw new Error("parserOptions.project not found in eslint.config.mjs");
+    }
+    return path.resolve(repoRoot, match[1]);
+  }
+
+  function resolveProjectFiles(tsconfigPath: string): string[] {
+    // Arrow-wrap ts.sys members so the host does not carry unbound method
+    // references (@typescript-eslint/unbound-method).
+    const host: ts.ParseConfigFileHost = {
+      useCaseSensitiveFileNames: ts.sys.useCaseSensitiveFileNames,
+      readDirectory: (rootDir, extensions, excludes, includes, depth) =>
+        ts.sys.readDirectory(rootDir, extensions, excludes, includes, depth),
+      fileExists: (file) => ts.sys.fileExists(file),
+      readFile: (file) => ts.sys.readFile(file),
+      getCurrentDirectory: () => ts.sys.getCurrentDirectory(),
+      onUnRecoverableConfigFileDiagnostic: () => {
+        /* swallow — assertions below cover the failure */
+      },
+    };
+    const parsed = ts.getParsedCommandLineOfConfigFile(tsconfigPath, {}, host);
+    return parsed?.fileNames ?? [];
+  }
+
+  it("resolves core test files into the wired eslint TS project", () => {
+    const repoRoot = findRepoRoot();
+    const projectPath = eslintProjectPath(repoRoot);
+    const files = resolveProjectFiles(projectPath);
+
+    const coreTests = files.filter(
+      (f) => f.includes("/packages/core/tests/") && f.endsWith(".test.ts"),
+    );
+
+    expect(coreTests.length).toBeGreaterThan(0);
+  });
+});

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -1,0 +1,13 @@
+{
+  "//": "ESLint-only TS project. Extends the root build tsconfig.json but RE-INCLUDES test files, which the build tsconfig excludes (`packages/**/tests/**/*`). Type-aware @typescript-eslint rules require every linted file to belong to a `parserOptions.project`; without this, `eslint packages/core/tests/**` fails 'file was not found in any of the provided project(s)' and the whole test corpus is un-lintable (task d7f89d46). This config is referenced ONLY by eslint.config.mjs — the build/typecheck path (`tsc --noEmit`, `npm run build`) still uses tsconfig.json and never compiles tests into dist.",
+  "extends": "./tsconfig.json",
+  "include": ["packages/**/*.ts", "packages/**/*.tsx"],
+  "exclude": [
+    "node_modules",
+    "features/**/*",
+    "packages/**/dist/**/*",
+    "packages/cli/**/*",
+    "wdio.conf*.ts",
+    "playwright.config.ts"
+  ]
+}


### PR DESCRIPTION
## Problem (task d7f89d46)

`eslint.config.mjs` set `parserOptions.project: './tsconfig.json'`, but the build `tsconfig.json` excludes `packages/**/tests/**/*`. Type-aware `@typescript-eslint` rules require every linted file to belong to that project, so running eslint on **any** test file failed:

```
Parsing error: "parserOptions.project" has been provided ...
The file was not found in any of the provided project(s): packages/core/tests/.../*.test.ts
```

Verified: this affected **both** `packages/core/tests/**` **and** `packages/obsidian-plugin/tests/**` (the task's "obsidian tests are linted" premise was false — they hit the same error). The whole test corpus was un-lintable; a new test file could not be lint-verified locally.

## Fix

- **`tsconfig.eslint.json`** (new): extends the build `tsconfig.json`, re-includes tests, keeps `packages/cli/**` excluded. Referenced **only** by `eslint.config.mjs`.
- **`eslint.config.mjs`**: `parserOptions.project` → `./tsconfig.eslint.json` (+ rationale comment).

The build/typecheck path (`tsc --noEmit`, `npm run build`) still uses `tsconfig.json` and **never compiles tests into dist** — confirmed `tsc --showConfig` is clean and no build/typecheck config references `tsconfig.eslint.json`.

## Zero CI impact

- `npm run lint` scope is `packages/obsidian-plugin/src` (unchanged) — no test file is linted in CI (`lint` job's eslint step is also `continue-on-error`). Program-build cost for `npm run lint`: **7.4s → 8.2s**.
- **Dormant test lint-debt does NOT surface as CI failure.** Enabling per-file linting reveals pre-existing debt in the test corpus (`296 errors / 947 warnings`, dominated by `@typescript-eslint/no-non-null-assertion` (883) and `unbound-method` (214)). Since CI never lints tests, nothing newly fails. Cleanup / whether to extend CI lint scope to tests is out of scope for this PR (follow-up).

## Regression lock (revert-verified)

`packages/core/tests/config/eslint-covers-tests.test.ts` reads the actually-wired `parserOptions.project` from `eslint.config.mjs`, resolves it via the TypeScript config parser, and asserts core test files land in the program.

- Repoint eslint → `./tsconfig.json` **→ RED** (0 core tests in project).
- Re-add `packages/**/tests/**/*` to `tsconfig.eslint.json` exclude **→ RED**.
- Restore **→ GREEN** (361 core `.test.ts` in project).

Lives under `packages/core/tests/**` → CI-gated by `test-coverage-exocortex` (full core jest config). Ratchet baselines unchanged (55/55, 21/21, 19/19, 0/0); the new test file is itself eslint-clean.

## Methodology

CI/infra change → **feature-sdd Step 0 exempt** (no `req__Requirement` needed — "CI / infra: not user-facing behavior"). The valuable part of the SDD loop — the revert-verified executable-spec lock — is delivered via the regression test above.

## Verification

- `npm run lint` (obsidian src): clean, 8.2s.
- `npx eslint packages/core/tests/.../LayoutSelector.test.ts`: parsing error gone, 0 problems.
- Full core suite (submodules initialized): all green (the 9 transient fails in a fresh worktree were uninitialized-submodule environment failures — confirmed pass once `exoas-exocmd`/`exoas-exo` were populated).
- 3 guard scripts (shard-assignments, test-antipatterns ratchet, coverage-monotonic): pass.
