### PR TITLE
feat(sparql): Instance_class object-position uid-only emission behind a default-OFF flag + query-time symbolic-name resolver (RFC 78572fa9 Phase 3 stage-1)

### DIFF
--- a/packages/core/src/infrastructure/sparql/ClassHierarchyResolvingStore.ts
+++ b/packages/core/src/infrastructure/sparql/ClassHierarchyResolvingStore.ts
@@ -21,6 +21,18 @@ import { Namespace } from "../../domain/models/rdf/Namespace";
  * the author disambiguates (by uid, or by narrowing the ontology). Verified zero
  * collisions on the real vaults today — this guards against future authored
  * collisions.
+ *
+ * ⚠ Scope of the throw: raised inside `resolveSymbolicToFileIri`, which is shared by
+ * BOTH the class-hierarchy SUBJECT path (pre-existing, req 9fddda62) and the new
+ * membership OBJECT path — so an ambiguous collision changes BOTH (a hierarchy walk
+ * over an ambiguous symbolic subject, which previously resolved last-write-wins, now
+ * throws too). This is contingent on the empty-ambiguous-set invariant; while it
+ * holds, both paths stay byte-identical.
+ *
+ * ⚠ Where the hint reaches: a SELECT / a direct `executeAsk` caller receives the
+ * error. A vault SPARQL PRECONDITION does NOT — `PreconditionEvaluator` swallows an
+ * ASK error into `false` (fail-CLOSED: an unevaluable gate hides the command), so the
+ * disambiguation hint is not user-visible for the precondition surface.
  */
 export class SymbolicClassAmbiguityError extends Error {
   constructor(public readonly symbolic: string) {
@@ -139,27 +151,36 @@ export class ClassHierarchyResolvingStore implements ITripleStore {
   private static readonly EXO_ASSET_LABEL =
     Namespace.EXO.term("Asset_label").value;
 
-  /**
-   * RFC 78572fa9 Phase 3 stage-1 — the `exo__Instance_class` predicate. When the
-   * emission flip makes an asset's Instance_class OBJECT a file IRI (uid), a query
-   * that references the class by its readable SYMBOLIC name is bridged object-side
-   * (see {@link matchInstanceClassObject}).
-   */
   private static readonly EXO_INSTANCE_CLASS =
     Namespace.EXO.term("Instance_class").value;
 
+  private static readonly RDF_TYPE = Namespace.RDF.term("type").value;
+
   /**
    * Symbolic ontology IRI base (`https://exocortex.my/ontology/`). A class reference
-   * in the Instance_class object position is a symbolic class IRI iff it starts with
-   * this base (a `<prefix>#<Local>` form). A file-IRI object
-   * (`obsidian://vault/<uid>.md`) or a W3C IRI is never bridged — it matches the
-   * store directly / is not an exocortex class ref.
+   * in a membership OBJECT position is a symbolic class IRI iff it starts with this
+   * base (a `<prefix>#<Local>` form). A file-IRI object (`obsidian://vault/<uid>.md`)
+   * or a W3C IRI is never bridged — it matches the store directly / is not an
+   * exocortex class ref.
    */
   private static readonly ONTOLOGY_BASE = "https://exocortex.my/ontology/";
 
   private static readonly HIERARCHY_PREDICATES: ReadonlySet<string> = new Set([
     ClassHierarchyResolvingStore.EXO_CLASS_SUPER_CLASS,
     ClassHierarchyResolvingStore.RDFS_SUBCLASS_OF,
+  ]);
+
+  /**
+   * RFC 78572fa9 Phase 3 stage-1 — the class-MEMBERSHIP predicates whose symbolic
+   * class OBJECT is bridged when the emission flip stores the class file IRI (uid)
+   * there. `NoteToRDFConverter.convertLegacyNote` emits BOTH `exo__Instance_class`
+   * AND `rdf:type` from the SAME flag-gated `valueToClassURI` object, so the flip
+   * couples them — bridging both keeps `?s exo:Instance_class <X>` and the RDF-standard
+   * `?s rdf:type <X>` membership queries working (see {@link matchMembershipObject}).
+   */
+  private static readonly MEMBERSHIP_PREDICATES: ReadonlySet<string> = new Set([
+    ClassHierarchyResolvingStore.EXO_INSTANCE_CLASS,
+    ClassHierarchyResolvingStore.RDF_TYPE,
   ]);
 
   /**
@@ -241,19 +262,21 @@ export class ClassHierarchyResolvingStore implements ITripleStore {
       return this.matchHierarchySubject(subject, predicate, object);
     }
 
-    // Branch 2 — Instance_class OBJECT-position bridge (RFC 78572fa9 Phase 3
+    // Branch 2 — class-MEMBERSHIP OBJECT-position bridge (RFC 78572fa9 Phase 3
     // stage-1): a direct-membership query `?s exo:Instance_class <symbolic-class-IRI>`
-    // whose OBJECT is a symbolic class IRI. Once the emission flip makes an asset's
-    // Instance_class object the class FILE IRI, a query written by the readable
-    // symbolic name is bridged object-side. Byte-identical when the store still holds
-    // symbolic objects (flag OFF) — the bridge's file-IRI match is empty then and the
-    // union collapses to the direct symbolic match.
+    // (or the co-emitted `?s rdf:type <symbolic-class-IRI>`) whose OBJECT is a symbolic
+    // class IRI. Once the emission flip makes an asset's membership object the class
+    // FILE IRI, a query written by the readable symbolic name is bridged object-side.
+    // Byte-identical when the store still holds symbolic objects (flag OFF) — the
+    // bridge's file-IRI match is empty then and the union collapses to the direct
+    // symbolic match.
     if (
-      predicate?.value === ClassHierarchyResolvingStore.EXO_INSTANCE_CLASS &&
+      predicate &&
+      ClassHierarchyResolvingStore.MEMBERSHIP_PREDICATES.has(predicate.value) &&
       object instanceof IRI &&
       object.value.startsWith(ClassHierarchyResolvingStore.ONTOLOGY_BASE)
     ) {
-      return this.matchInstanceClassObject(subject, predicate, object);
+      return this.matchMembershipObject(subject, predicate, object);
     }
 
     // Everything else — wildcard-predicate scans, non-hierarchy / non-membership
@@ -303,10 +326,10 @@ export class ClassHierarchyResolvingStore implements ITripleStore {
   }
 
   /**
-   * Instance_class OBJECT-position bridge (RFC 78572fa9 Phase 3 stage-1). A query
-   * `match(subject, exo:Instance_class, <symbolic-class-IRI>)` — direct membership by
-   * the class's readable symbolic name. After the emission flip the store holds the
-   * class FILE IRI as the Instance_class object, so:
+   * Class-MEMBERSHIP OBJECT-position bridge (RFC 78572fa9 Phase 3 stage-1). A query
+   * `match(subject, <exo:Instance_class | rdf:type>, <symbolic-class-IRI>)` — direct
+   * membership by the class's readable symbolic name. After the emission flip the
+   * store holds the class FILE IRI as the membership object, so:
    *   - resolve the queried symbolic class IRI → its class FILE IRI (uid);
    *   - UNION the direct symbolic-form matches (residual entries a MIXED store may
    *     still hold — unresolved-ref instances keep symbolic) with the bridged
@@ -317,7 +340,7 @@ export class ClassHierarchyResolvingStore implements ITripleStore {
    * match is empty then → the union collapses to the direct symbolic match. Zero
    * store growth. An ambiguous symbolic form throws (error-with-hint).
    */
-  private async matchInstanceClassObject(
+  private async matchMembershipObject(
     subject: Subject | undefined,
     predicate: Predicate,
     object: IRI,

--- a/packages/core/src/infrastructure/sparql/ClassHierarchyResolvingStore.ts
+++ b/packages/core/src/infrastructure/sparql/ClassHierarchyResolvingStore.ts
@@ -13,9 +13,35 @@ import { IRI } from "../../domain/models/rdf/IRI";
 import { Namespace } from "../../domain/models/rdf/Namespace";
 
 /**
- * Query-time class-hierarchy resolver (RFC 78572fa9 Candidate B Phase 0,
- * req `9fddda62`) — the QUERY-TIME replacement for the abandoned A2
- * store-materialization approach.
+ * Thrown when a symbolic `prefix#Local` class reference in a query resolves
+ * AMBIGUOUSLY — two or more DISTINCT class files derive the same symbolic form (a
+ * cross-ontology prefix collision; RFC 78572fa9 v3 point 9: a prefix is a per-user
+ * alias, not identity, so identity is the uid and the prefix may collide). Rather
+ * than silently resolve to one, the query-time resolver surfaces the ambiguity so
+ * the author disambiguates (by uid, or by narrowing the ontology). Verified zero
+ * collisions on the real vaults today — this guards against future authored
+ * collisions.
+ */
+export class SymbolicClassAmbiguityError extends Error {
+  constructor(public readonly symbolic: string) {
+    super(
+      `Ambiguous class reference '${symbolic}' — two or more class files derive ` +
+        `this symbolic form (a prefix collision). The prefix is an alias, not ` +
+        `identity: reference the class by its uid, or narrow the ontology.`,
+    );
+    this.name = "SymbolicClassAmbiguityError";
+  }
+}
+
+/**
+ * Query-time class-reference resolver (RFC 78572fa9 Candidate B) — the QUERY-TIME
+ * replacement for the abandoned A2 store-materialization approach. Started as the
+ * Phase-0 class-HIERARCHY-walk bridge (req `9fddda62`); generalized in Phase 3
+ * stage-1 (req `c359e3d2`) to ALSO resolve the `exo__Instance_class` OBJECT position
+ * so a direct-membership query written by the readable symbolic name keeps matching
+ * once the converter emits the class uid (file IRI) there. Despite the historical
+ * name, it now resolves class references at two positions (hierarchy subject +
+ * Instance_class object).
  *
  * ## The dual-IRI seam it heals
  *
@@ -42,14 +68,28 @@ import { Namespace } from "../../domain/models/rdf/Namespace";
  * single `store.match` call) inherit it — ASK preconditions AND SELECT analytics
  * are fixed by one mechanism.
  *
- * `match(subject, predicate, object)` is a **pure pass-through** for every
- * predicate except `exo__Class_superClass` and its `rdfs:subClassOf` mirror
- * (RFC 871 vocabulary map). For a hierarchy predicate queried with a symbolic
- * class subject that has no direct edges, it lazily builds a memoized
- * `symbolic-IRI → file-IRI` class index, delegates to the underlying store using
- * the file IRI, and rewrites the returned triples' subject back to the symbolic
- * form the caller queried (so `PropertyPathExecutor`'s per-node visited-set stays
- * consistent across the bridge).
+ * `match(subject, predicate, object)` is a **pure pass-through** for every query
+ * except two bridged positions, both keyed off the same memoized `symbolic-IRI →
+ * file-IRI` class index (built lazily, once per store-content change):
+ *
+ * 1. **Hierarchy SUBJECT position** (req `9fddda62`) — `exo__Class_superClass` / its
+ *    `rdfs:subClassOf` mirror (RFC 871) queried with a symbolic class subject that
+ *    has no direct edges: resolve subject → file IRI, delegate, rewrite the returned
+ *    triples' SUBJECT back to the symbolic form (so `PropertyPathExecutor`'s per-node
+ *    visited-set stays consistent across the transitive walk).
+ * 2. **Instance_class OBJECT position** (RFC 78572fa9 Phase 3 stage-1, req
+ *    `c359e3d2`) — `exo__Instance_class` queried with a symbolic class OBJECT: once
+ *    the emission flip stores the class uid there, resolve the queried symbolic
+ *    object → file IRI, UNION the direct symbolic-form matches (a MIXED store may
+ *    still hold residual symbolic entries) with the bridged file-IRI-form matches,
+ *    and rewrite each bridged triple's OBJECT back to the queried symbolic form.
+ *    Byte-identical when the store still holds symbolic objects (flip OFF).
+ *
+ * The index is COMPREHENSIVE over TBox (every `prefix__Local` label, not just
+ * hierarchy-edge subjects) so metaclasses (`exo__Class`) resolve for position 2.
+ * A symbolic form to which two DISTINCT class files map (a prefix collision) is
+ * ambiguous → a lookup throws {@link SymbolicClassAmbiguityError} (error-with-hint,
+ * RFC v3 point 9) rather than silently resolving to one.
  *
  * - **Predicate-scoped** — non-hierarchy queries are byte-identical pass-through
  *   → zero behaviour change for the rest of the engine. Only the DEFAULT-graph,
@@ -99,6 +139,24 @@ export class ClassHierarchyResolvingStore implements ITripleStore {
   private static readonly EXO_ASSET_LABEL =
     Namespace.EXO.term("Asset_label").value;
 
+  /**
+   * RFC 78572fa9 Phase 3 stage-1 — the `exo__Instance_class` predicate. When the
+   * emission flip makes an asset's Instance_class OBJECT a file IRI (uid), a query
+   * that references the class by its readable SYMBOLIC name is bridged object-side
+   * (see {@link matchInstanceClassObject}).
+   */
+  private static readonly EXO_INSTANCE_CLASS =
+    Namespace.EXO.term("Instance_class").value;
+
+  /**
+   * Symbolic ontology IRI base (`https://exocortex.my/ontology/`). A class reference
+   * in the Instance_class object position is a symbolic class IRI iff it starts with
+   * this base (a `<prefix>#<Local>` form). A file-IRI object
+   * (`obsidian://vault/<uid>.md`) or a W3C IRI is never bridged — it matches the
+   * store directly / is not an exocortex class ref.
+   */
+  private static readonly ONTOLOGY_BASE = "https://exocortex.my/ontology/";
+
   private static readonly HIERARCHY_PREDICATES: ReadonlySet<string> = new Set([
     ClassHierarchyResolvingStore.EXO_CLASS_SUPER_CLASS,
     ClassHierarchyResolvingStore.RDFS_SUBCLASS_OF,
@@ -114,7 +172,19 @@ export class ClassHierarchyResolvingStore implements ITripleStore {
    */
   private static readonly INDEX_CACHE = new WeakMap<
     ITripleStore,
-    { count: number; index: Map<string, IRI> }
+    {
+      count: number;
+      index: Map<string, IRI>;
+      /**
+       * Symbolic class forms that resolve AMBIGUOUSLY — two or more distinct class
+       * files derive the same `prefix#Local` (a cross-ontology prefix collision, RFC
+       * v3 point 9: prefixes are aliases, not identity). A lookup of an ambiguous
+       * form throws {@link SymbolicClassAmbiguityError} (error-with-hint) rather than
+       * silently resolving to one. Verified empty on the real vaults today; this is
+       * safe future-proofing for when prefix collisions are authored.
+       */
+      ambiguous: Set<string>;
+    }
   >();
 
   // ===== Optional ITripleStore surface — mirrored from the wrapped store =====
@@ -153,33 +223,60 @@ export class ClassHierarchyResolvingStore implements ITripleStore {
     this.countInGraph = real.countInGraph?.bind(real);
   }
 
-  // ===== The one intercepted method =====
+  // ===== The intercepted method =====
 
   async match(
     subject?: Subject,
     predicate?: Predicate,
     object?: RDFObject,
   ): Promise<Triple[]> {
-    // Predicate-scoped early-out: only intercept the class-hierarchy predicates
-    // with a concrete IRI subject. Everything else — wildcard-predicate scans,
-    // non-hierarchy predicates, variable/blank/quoted subjects — is a byte-identical
-    // pass-through (the decorator is invisible to the rest of the engine).
+    // Branch 1 — class-HIERARCHY SUBJECT-position bridge (req 9fddda62): a hierarchy
+    // predicate (`Class_superClass` / `rdfs:subClassOf`) queried with a concrete IRI
+    // subject. The symbolic-subject climb of a transitive walk is bridged file-side.
     if (
-      !predicate ||
-      !ClassHierarchyResolvingStore.HIERARCHY_PREDICATES.has(predicate.value) ||
-      !(subject instanceof IRI)
+      predicate &&
+      ClassHierarchyResolvingStore.HIERARCHY_PREDICATES.has(predicate.value) &&
+      subject instanceof IRI
     ) {
-      return this.real.match(subject, predicate, object);
+      return this.matchHierarchySubject(subject, predicate, object);
     }
 
-    // A subject with native hierarchy edges (a class queried by its FILE IRI —
-    // the file-IRI-form instances' first hop) resolves directly; no bridge needed.
-    // This is what makes the decorator symmetric: file-IRI first hop is native,
-    // subsequent symbolic ancestor hops are bridged below. Load-bearing invariant:
-    // the converter NEVER emits a symbolic class IRI as a hierarchy-triple SUBJECT
-    // (Class_superClass subjects are always the class FILE IRI), so `direct` is
-    // empty for a symbolic subject — the short-circuit only fires for file-IRI
-    // subjects and never suppresses a needed bridge.
+    // Branch 2 — Instance_class OBJECT-position bridge (RFC 78572fa9 Phase 3
+    // stage-1): a direct-membership query `?s exo:Instance_class <symbolic-class-IRI>`
+    // whose OBJECT is a symbolic class IRI. Once the emission flip makes an asset's
+    // Instance_class object the class FILE IRI, a query written by the readable
+    // symbolic name is bridged object-side. Byte-identical when the store still holds
+    // symbolic objects (flag OFF) — the bridge's file-IRI match is empty then and the
+    // union collapses to the direct symbolic match.
+    if (
+      predicate?.value === ClassHierarchyResolvingStore.EXO_INSTANCE_CLASS &&
+      object instanceof IRI &&
+      object.value.startsWith(ClassHierarchyResolvingStore.ONTOLOGY_BASE)
+    ) {
+      return this.matchInstanceClassObject(subject, predicate, object);
+    }
+
+    // Everything else — wildcard-predicate scans, non-hierarchy / non-membership
+    // predicates, variable/blank/quoted subjects, file-IRI or W3C objects — is a
+    // byte-identical pass-through (the decorator is invisible to the rest of the
+    // engine).
+    return this.real.match(subject, predicate, object);
+  }
+
+  /**
+   * Class-hierarchy SUBJECT-position bridge (req 9fddda62). A subject with native
+   * hierarchy edges (a class queried by its FILE IRI — the file-IRI-form instances'
+   * first hop) resolves directly; no bridge needed. Load-bearing invariant: the
+   * converter NEVER emits a symbolic class IRI as a hierarchy-triple SUBJECT
+   * (`Class_superClass` subjects are always the class FILE IRI), so `direct` is empty
+   * for a symbolic subject — the short-circuit only fires for file-IRI subjects and
+   * never suppresses a needed bridge.
+   */
+  private async matchHierarchySubject(
+    subject: IRI,
+    predicate: Predicate,
+    object?: RDFObject,
+  ): Promise<Triple[]> {
     const direct = await this.real.match(subject, predicate, object);
     if (direct.length > 0) {
       return direct;
@@ -198,17 +295,95 @@ export class ClassHierarchyResolvingStore implements ITripleStore {
       return bridged;
     }
 
-    // Rewrite each bridged triple's subject back to the symbolic form the caller
+    // Rewrite each bridged triple's SUBJECT back to the symbolic form the caller
     // queried, so PropertyPathExecutor's per-node identity (visited-set keyed on
     // `node.toString()`) stays consistent as the transitive walk climbs symbolic
     // nodes. The predicate and object (the symbolic parent class) are preserved.
     return bridged.map((t) => new Triple(subject, t.predicate, t.object));
   }
 
+  /**
+   * Instance_class OBJECT-position bridge (RFC 78572fa9 Phase 3 stage-1). A query
+   * `match(subject, exo:Instance_class, <symbolic-class-IRI>)` — direct membership by
+   * the class's readable symbolic name. After the emission flip the store holds the
+   * class FILE IRI as the Instance_class object, so:
+   *   - resolve the queried symbolic class IRI → its class FILE IRI (uid);
+   *   - UNION the direct symbolic-form matches (residual entries a MIXED store may
+   *     still hold — unresolved-ref instances keep symbolic) with the bridged
+   *     file-IRI-form matches, rewriting each bridged triple's OBJECT back to the
+   *     symbolic form the caller queried (so downstream comparisons / a SELECT ?c see
+   *     the readable form; identity stays uid, the readable form is computed).
+   * Byte-identical when the store holds symbolic objects (flag OFF): the file-IRI
+   * match is empty then → the union collapses to the direct symbolic match. Zero
+   * store growth. An ambiguous symbolic form throws (error-with-hint).
+   */
+  private async matchInstanceClassObject(
+    subject: Subject | undefined,
+    predicate: Predicate,
+    object: IRI,
+  ): Promise<Triple[]> {
+    const fileIri = await this.resolveSymbolicToFileIri(object.value);
+    const direct = await this.real.match(subject, predicate, object);
+    // Not a known symbolic class (e.g. a symbolic PROPERTY IRI, or a class not in the
+    // store) → only the direct result stands (usually empty).
+    if (!fileIri) {
+      return direct;
+    }
+    const bridged = await this.real.match(subject, predicate, fileIri);
+    if (bridged.length === 0) {
+      return direct;
+    }
+    // Rewrite each bridged triple's OBJECT back to the queried symbolic class IRI.
+    const rewritten = bridged.map(
+      (t) => new Triple(t.subject, t.predicate, object),
+    );
+    return ClassHierarchyResolvingStore.dedupTriples([...direct, ...rewritten]);
+  }
+
+  /**
+   * Dedup a union of matched triples by (subject, predicate, object) value. The
+   * direct + bridged sets are disjoint in the common case; this guards the rare
+   * MIXED-store edge where one asset references the same class both by a RESOLVED
+   * ref (file-IRI) and an UNRESOLVED prefix__Local ref (symbolic) — both forms then
+   * surface as the same rewritten triple.
+   */
+  private static dedupTriples(triples: Triple[]): Triple[] {
+    const seen = new Set<string>();
+    const out: Triple[] = [];
+    for (const t of triples) {
+      const key = `${ClassHierarchyResolvingStore.termKey(t.subject)} ${ClassHierarchyResolvingStore.termKey(
+        t.predicate,
+      )} ${ClassHierarchyResolvingStore.termKey(t.object)}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
+      out.push(t);
+    }
+    return out;
+  }
+
+  private static termKey(term: unknown): string {
+    if (term instanceof IRI) return `I:${term.value}`;
+    if (term && typeof term === "object" && "value" in term) {
+      const v = (term as { value: unknown }).value;
+      const dt = (term as { datatype?: { value?: string } }).datatype?.value ?? "";
+      return `L:${String(v)}^${dt}`;
+    }
+    return `?:${String(term)}`;
+  }
+
+  /**
+   * Resolve a symbolic `prefix#Local` class IRI to its class FILE IRI via the
+   * memoized index. Throws {@link SymbolicClassAmbiguityError} when the symbolic
+   * form is ambiguous (a prefix collision); returns null when it is not a known
+   * class.
+   */
   private async resolveSymbolicToFileIri(
     symbolicValue: string,
   ): Promise<IRI | null> {
-    const index = await this.getIndex();
+    const { index, ambiguous } = await this.getIndex();
+    if (ambiguous.has(symbolicValue)) {
+      throw new SymbolicClassAmbiguityError(symbolicValue);
+    }
     return index.get(symbolicValue) ?? null;
   }
 
@@ -219,84 +394,80 @@ export class ClassHierarchyResolvingStore implements ITripleStore {
    * harmless; within a single query the count is stable, so exactly one build runs
    * and every later hierarchy hop hits the cache.
    */
-  private async getIndex(): Promise<Map<string, IRI>> {
+  private async getIndex(): Promise<{
+    index: Map<string, IRI>;
+    ambiguous: Set<string>;
+  }> {
     const count = await this.real.count();
     const cached = ClassHierarchyResolvingStore.INDEX_CACHE.get(this.real);
     if (cached && cached.count === count) {
-      return cached.index;
+      return { index: cached.index, ambiguous: cached.ambiguous };
     }
-    const index = await this.buildIndex();
-    ClassHierarchyResolvingStore.INDEX_CACHE.set(this.real, { count, index });
-    return index;
+    const { index, ambiguous } = await this.buildIndex();
+    ClassHierarchyResolvingStore.INDEX_CACHE.set(this.real, {
+      count,
+      index,
+      ambiguous,
+    });
+    return { index, ambiguous };
   }
 
   /**
-   * Build the `symbolic class IRI value → class file IRI` index by scanning the
-   * store's hierarchy triples for class file-IRI subjects, then deriving each
-   * class's symbolic form from its label — mirroring exactly what
-   * `NoteToRDFConverter.expandClassValue` emits for the instance/superclass
-   * references the walk queries.
+   * Build the `symbolic class IRI value → class file IRI` index (+ the ambiguous
+   * set) by scanning EVERY subject's label (`exo__Asset_label` + its `rdfs:label`
+   * mirror) and deriving its symbolic `prefix#Local` form — mirroring exactly what
+   * `NoteToRDFConverter.expandClassValue` emits for a class reference.
+   *
+   * COMPREHENSIVE over TBox (broader than the hierarchy-edge-subject set the
+   * hierarchy bridge alone needs) so a class WITHOUT an outgoing superClass edge —
+   * a metaclass like `exo__Class`, a root marker like `exo__Prototype` — still
+   * resolves for the Instance_class OBJECT bridge (RFC 78572fa9 Phase 3 stage-1). It
+   * remains a SUPERSET of the hierarchy-subject set, so the hierarchy bridge's
+   * lookups are unaffected. Free-form ABox labels (not `prefix__Local`) yield null
+   * from `labelToSymbolicIRI` → excluded. One scan, memoized per store-instance.
+   *
+   * Two DISTINCT class files deriving the same `prefix#Local` (a cross-ontology
+   * prefix collision, RFC v3 point 9) are recorded as ambiguous → a lookup throws.
    */
-  private async buildIndex(): Promise<Map<string, IRI>> {
+  private async buildIndex(): Promise<{
+    index: Map<string, IRI>;
+    ambiguous: Set<string>;
+  }> {
     const index = new Map<string, IRI>();
+    const ambiguous = new Set<string>();
 
-    const superPred = new IRI(ClassHierarchyResolvingStore.EXO_CLASS_SUPER_CLASS);
-    const subClassPred = new IRI(ClassHierarchyResolvingStore.RDFS_SUBCLASS_OF);
-    const hierarchyTriples = [
-      ...(await this.real.match(undefined, superPred, undefined)),
-      ...(await this.real.match(undefined, subClassPred, undefined)),
-    ];
-
-    // Class file IRIs = the subjects of hierarchy edges (a class with an OUTGOING
-    // superclass edge is the only kind of node the transitive walk ever needs to
-    // bridge — a leaf ancestor with no outgoing edge is reached as an object and
-    // never re-queried as a subject).
-    const classFileIris = new Set<string>();
-    for (const t of hierarchyTriples) {
-      if (t.subject instanceof IRI) {
-        classFileIris.add(t.subject.value);
-      }
-    }
-
-    for (const fileIriValue of classFileIris) {
-      const fileIri = new IRI(fileIriValue);
-      const symbolic = await this.deriveSymbolicForm(fileIri);
-      if (symbolic) {
-        index.set(symbolic, fileIri);
-      }
-    }
-
-    return index;
-  }
-
-  /**
-   * Derive the symbolic ontology IRI for a class file IRI from its label
-   * (`rdfs:label` preferred, `exo__Asset_label` fallback — both emitted by the
-   * converter for a class asset). Uses the SAME `prefix__Local → base/prefix#Local`
-   * rule as `NoteToRDFConverter.expandClassValue`, so the derived key exactly
-   * equals the symbolic form the walk queries.
-   */
-  private async deriveSymbolicForm(fileIri: IRI): Promise<string | null> {
     const labelTriples = [
       ...(await this.real.match(
-        fileIri,
-        new IRI(ClassHierarchyResolvingStore.RDFS_LABEL),
+        undefined,
+        new IRI(ClassHierarchyResolvingStore.EXO_ASSET_LABEL),
         undefined,
       )),
       ...(await this.real.match(
-        fileIri,
-        new IRI(ClassHierarchyResolvingStore.EXO_ASSET_LABEL),
+        undefined,
+        new IRI(ClassHierarchyResolvingStore.RDFS_LABEL),
         undefined,
       )),
     ];
 
     for (const t of labelTriples) {
-      const value = ClassHierarchyResolvingStore.literalValue(t.object);
-      if (value === null) continue;
-      const symbolic = ClassHierarchyResolvingStore.labelToSymbolicIRI(value);
-      if (symbolic) return symbolic;
+      if (!(t.subject instanceof IRI)) continue;
+      const labelValue = ClassHierarchyResolvingStore.literalValue(t.object);
+      if (labelValue === null) continue;
+      const symbolic =
+        ClassHierarchyResolvingStore.labelToSymbolicIRI(labelValue);
+      if (!symbolic) continue;
+      const existing = index.get(symbolic);
+      if (!existing) {
+        index.set(symbolic, t.subject);
+      } else if (existing.value !== t.subject.value) {
+        // Two DIFFERENT class files derive the same symbolic form → ambiguous. Same
+        // subject via both label predicates (Asset_label + its rdfs:label mirror) is
+        // NOT a collision (existing.value === subject.value → no-op).
+        ambiguous.add(symbolic);
+      }
     }
-    return null;
+
+    return { index, ambiguous };
   }
 
   private static literalValue(object: RDFObject): string | null {

--- a/packages/core/src/services/NoteToRDFConverter.ts
+++ b/packages/core/src/services/NoteToRDFConverter.ts
@@ -375,6 +375,12 @@ export class NoteToRDFConverter {
 
       if (key === "exo__Instance_class") {
         for (const val of values) {
+          // `classNode` is the SAME object valueToClassURI produced above — so the
+          // RFC 78572fa9 Phase 3 stage-1 emission flip (uid vs symbolic) applies to
+          // this co-emitted `rdf:type` triple too. The query-time
+          // ClassHierarchyResolvingStore bridges BOTH `exo:Instance_class` AND
+          // `rdf:type` membership objects (its MEMBERSHIP_PREDICATES set) so both
+          // stay queryable by the symbolic name post-flip — keep them in lockstep.
           const classNode = this.valueToClassURI(val);
           if (classNode instanceof IRI) {
             const rdfType = Namespace.RDF.term("type");

--- a/packages/core/src/services/NoteToRDFConverter.ts
+++ b/packages/core/src/services/NoteToRDFConverter.ts
@@ -168,13 +168,30 @@ export class NoteToRDFConverter {
    */
   private readonly subjectIriPrefix: string;
 
+  /**
+   * RFC 78572fa9 Phase 3 stage-1 (Andrey design-interview §v6, F1/F4) — DEFAULT-OFF
+   * migration flag. When enabled, {@link valueToClassURI} (the `exo__Instance_class`
+   * emission path) emits an asset's `exo__Instance_class` OBJECT (a resolved class
+   * reference) as the class FILE IRI (uid) instead of the SYMBOLIC class IRI. Staged
+   * per-predicate: this flag covers
+   * ONLY the Instance_class object position (status/value and domain/range are later
+   * F1 stages). Default OFF ⇒ byte-identical to the historical symbolic emission, so
+   * merging is a no-op behaviour change; existing pure-SPARQL queries/preconditions
+   * that reference a class by its readable symbolic name keep working via the
+   * query-time `ClassHierarchyResolvingStore` (generalized to this position). An
+   * unresolved ref (no class-def in the store) keeps emitting symbolic — no uid can
+   * be synthesized — so a mixed store is possible and the resolver unions both forms.
+   */
+  private readonly emitInstanceClassAsUid: boolean;
+
   constructor(
     @inject(DI_TOKENS.IVaultAdapter) private readonly vault: IVaultAdapter,
     @inject(DI_TOKENS.ILogger) private readonly logger: ILogger = NullLogger,
-    options: { subjectIriPrefix?: string } = {},
+    options: { subjectIriPrefix?: string; emitInstanceClassAsUid?: boolean } = {},
   ) {
     this.vocabularyMapper = new RDFVocabularyMapper();
     this.subjectIriPrefix = normaliseSubjectIriPrefix(options.subjectIriPrefix);
+    this.emitInstanceClassAsUid = options.emitInstanceClassAsUid ?? false;
   }
 
   /**
@@ -1610,15 +1627,32 @@ export class NoteToRDFConverter {
     if (this.isUUID(classRef)) {
       const resolvedFile = this.vault.getFirstLinkpathDest(classRef, "");
       if (resolvedFile) {
+        // RFC 78572fa9 Phase 3 stage-1 (`valueToClassURI` is called ONLY for
+        // `exo__Instance_class`): when `emitInstanceClassAsUid` is on, emit the class
+        // FILE IRI (uid) instead of the symbolic class IRI for a RESOLVED class ref
+        // (the canonical UID-canon form `exo__Instance_class: "[[<class-uid>]]"`). The
+        // file IRI is the class-def subject and is graph-traversable via
+        // `exo__Class_superClass`; the query-time `ClassHierarchyResolvingStore`
+        // bridges a symbolic-name query back to it. A label-form / unresolved ref
+        // above keeps emitting symbolic (no uid to synthesize) and the resolver unions
+        // both forms.
         const basenameIRI = this.expandClassValue(resolvedFile.basename);
-        if (basenameIRI) return basenameIRI;
+        if (basenameIRI) {
+          return this.emitInstanceClassAsUid
+            ? this.notePathToIRI(resolvedFile.path)
+            : basenameIRI;
+        }
 
         const fm = this.vault.getFrontmatter(resolvedFile);
         if (fm) {
           const label = fm["exo__Asset_label"];
           if (typeof label === "string") {
             const labelIRI = this.expandClassValue(label);
-            if (labelIRI) return labelIRI;
+            if (labelIRI) {
+              return this.emitInstanceClassAsUid
+                ? this.notePathToIRI(resolvedFile.path)
+                : labelIRI;
+            }
           }
         }
 

--- a/packages/core/tests/integration/sparql/instance-class-emission-flip.test.ts
+++ b/packages/core/tests/integration/sparql/instance-class-emission-flip.test.ts
@@ -262,6 +262,17 @@ describe(`Instance_class emission flip + query-time resolver (${REQ})`, () => {
       const ask = `${PREFIX} ASK { <${F(UID_WIDGET)}> exo:Instance_class exo:Prototype }`;
       expect(await runAsk(store, ask, true)).toBe(false);
     });
+
+    it(`${REQ} the co-emitted rdf:type membership ALSO bridges (the converter emits rdf:type from the same flag-gated object) — ON GREEN, OFF RED`, async () => {
+      // NoteToRDFConverter.convertLegacyNote emits `<s> rdf:type <classObject>` from
+      // the SAME valueToClassURI object as exo:Instance_class, so the flip couples
+      // them. The RDF-standard membership query must keep working.
+      const store = await buildStore(BASE_NOTES, true);
+      const ask = (t: string) =>
+        `PREFIX exo: <${EXO}> PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> ASK { <${t}> rdf:type exo:Class }`;
+      expect(await runAsk(store, ask(F(UID_WIDGET)), true)).toBe(true);
+      expect(await runAsk(store, ask(F(UID_WIDGET)), false)).toBe(false);
+    });
   });
 
   describe("byte-identical when it should be (predicate/object-shape scoped)", () => {

--- a/packages/core/tests/integration/sparql/instance-class-emission-flip.test.ts
+++ b/packages/core/tests/integration/sparql/instance-class-emission-flip.test.ts
@@ -1,0 +1,379 @@
+/**
+ * Production-shape revert-verify for RFC 78572fa9 Phase 3 stage-1 (req c359e3d2):
+ * the `exo__Instance_class` OBJECT-position emission flip (uid-only, behind a
+ * default-OFF flag) + the query-time name-resolver that keeps direct-membership
+ * queries written by the readable SYMBOLIC name matching once the store holds the
+ * class FILE IRI.
+ *
+ * The store is built by the REAL {@link NoteToRDFConverter} (NOT hand-authored
+ * triples), toggling the `emitInstanceClassAsUid` flag, so the shape under test is
+ * exactly what production would emit. The revert-verify axis for F5 is the
+ * `resolveClassHierarchy` config toggle on {@link ExoQLQueryExecutor} — the same
+ * axis the shipped Phase-0 resolver test uses (type-preserving, no git-checkout /
+ * Edit-break): resolver ON = GREEN, resolver OFF = RED.
+ *
+ * @req:c359e3d2-d97d-4a88-8d13-e2bb4652c10b
+ */
+
+import "reflect-metadata";
+import { NoteToRDFConverter } from "../../../src/services/NoteToRDFConverter";
+import type {
+  IVaultAdapter,
+  IFile,
+  IFrontmatter,
+} from "../../../src/interfaces/IVaultAdapter";
+import { InMemoryTripleStore } from "../../../src/infrastructure/rdf/InMemoryTripleStore";
+import { ExoQLQueryExecutor } from "../../../src/infrastructure/sparql/executors/QueryExecutor";
+import { SymbolicClassAmbiguityError } from "../../../src/infrastructure/sparql/ClassHierarchyResolvingStore";
+import { SPARQLParser } from "../../../src/infrastructure/sparql/SPARQLParser";
+import { ExoQLAlgebraTranslator } from "../../../src/infrastructure/sparql/algebra/AlgebraTranslator";
+import type { AskOperation } from "../../../src/infrastructure/sparql/algebra/AlgebraOperation";
+import { IRI } from "../../../src/domain/models/rdf/IRI";
+import { Namespace } from "../../../src/domain/models/rdf/Namespace";
+
+const REQ = "@req:c359e3d2-d97d-4a88-8d13-e2bb4652c10b";
+
+const EXO = "https://exocortex.my/ontology/exo#";
+const EMS = "https://exocortex.my/ontology/ems#";
+const PREFIX = `PREFIX exo: <${EXO}>`;
+
+// Symbolic class IRIs the queries reference — derived by the SAME rule the converter
+// uses (Namespace.forPrefix(...).term(...)).
+const EXO_CLASS = Namespace.EXO.term("Class").value; // .../exo#Class (the metaclass)
+const EXO_PROTOTYPE = Namespace.EXO.term("Prototype").value;
+const EMS_WIDGET = Namespace.forPrefix("ems")!.term("Widget").value;
+
+// File IRIs (converter emits obsidian://vault/<uid>.md for each note).
+const F = (uid: string) => `obsidian://vault/${uid}.md`;
+
+// UUIDs (valid-hex so `isUUID` gates the class-emission path; see the sibling
+// class-hierarchy-resolver.test.ts cycle-note).
+const UID_EXO_CLASS = "ec1a0000-0000-4000-8000-000000000000"; // exo__Class metaclass def
+const UID_EXO_PROTO = "ec00b000-0000-4000-8000-000000000000"; // exo__Prototype def
+const UID_WIDGET = "01d70000-0000-4000-8000-000000000000"; // ems__Widget class def
+const UID_WIDGET_INST = "a5570000-0000-4000-8000-000000000000"; // instance → ems__Widget
+const UID_PROTO_MARKER = "9b0a0000-0000-4000-8000-000000000000"; // directly Instance_class = exo__Prototype
+
+interface FixtureNote {
+  uid: string;
+  frontmatter: IFrontmatter;
+}
+
+function makeFile(uid: string): IFile {
+  return {
+    path: `${uid}.md`,
+    basename: uid,
+    name: `${uid}.md`,
+    extension: "md",
+    parent: null,
+  } as unknown as IFile;
+}
+
+/**
+ * Convert fixture notes through the REAL NoteToRDFConverter, with the
+ * `emitInstanceClassAsUid` flip flag set as given. The mock vault resolves a
+ * `[[<uid>]]` wikilink to the note whose basename equals that uid (UID-canon), and
+ * a `[[prefix__Local]]` label wikilink to NOTHING (unresolved — the symbolic-emission
+ * path) unless a note happens to be named that.
+ */
+async function convertNotes(
+  notes: FixtureNote[],
+  emitInstanceClassAsUid: boolean,
+) {
+  const files = notes.map((n) => makeFile(n.uid));
+  const fmByPath = new Map<string, IFrontmatter>();
+  const fileByBasename = new Map<string, IFile>();
+  notes.forEach((n, i) => {
+    fmByPath.set(files[i].path, n.frontmatter);
+    fileByBasename.set(n.uid, files[i]);
+  });
+
+  const mockVault = {
+    getAllFiles: jest.fn(() => files),
+    getFrontmatter: jest.fn((f: IFile) => fmByPath.get(f.path) ?? null),
+    getFirstLinkpathDest: jest.fn(
+      (linkpath: string) => fileByBasename.get(linkpath) ?? null,
+    ),
+    read: jest.fn().mockResolvedValue(""),
+    create: jest.fn(),
+    modify: jest.fn(),
+    delete: jest.fn(),
+    exists: jest.fn(),
+    getAbstractFileByPath: jest.fn(),
+    updateFrontmatter: jest.fn(),
+    rename: jest.fn(),
+    createFolder: jest.fn(),
+    process: jest.fn(),
+    updateLinks: jest.fn(),
+    getDefaultNewFileParent: jest.fn(),
+  } as unknown as jest.Mocked<IVaultAdapter>;
+
+  const converter = new NoteToRDFConverter(mockVault, undefined, {
+    emitInstanceClassAsUid,
+  });
+  const out = [];
+  for (const file of files) {
+    out.push(...(await converter.convertNote(file)));
+  }
+  return out;
+}
+
+async function buildStore(
+  notes: FixtureNote[],
+  emitInstanceClassAsUid: boolean,
+): Promise<InMemoryTripleStore> {
+  const store = new InMemoryTripleStore();
+  await store.addAll(await convertNotes(notes, emitInstanceClassAsUid));
+  return store;
+}
+
+const parser = new SPARQLParser();
+const translator = new ExoQLAlgebraTranslator();
+
+async function runAsk(
+  store: InMemoryTripleStore,
+  sparql: string,
+  resolveClassHierarchy: boolean,
+): Promise<boolean> {
+  const algebra = translator.translate(parser.parse(sparql));
+  const executor = new ExoQLQueryExecutor(store, { resolveClassHierarchy });
+  return executor.executeAsk(algebra as AskOperation);
+}
+
+async function runSelect(
+  store: InMemoryTripleStore,
+  sparql: string,
+  variable: string,
+  resolveClassHierarchy: boolean,
+): Promise<string[]> {
+  const algebra = translator.translate(parser.parse(sparql));
+  const executor = new ExoQLQueryExecutor(store, { resolveClassHierarchy });
+  const solutions = await executor.executeAll(algebra);
+  return solutions
+    .map((s) => {
+      const v = s.get(variable);
+      return v instanceof IRI ? v.value : undefined;
+    })
+    .filter((v): v is string => v !== undefined);
+}
+
+// exo__Class metaclass def + exo__Prototype def + one domain class ems__Widget whose
+// Instance_class = the metaclass, one instance of that class, and a marker asset that
+// is DIRECTLY Instance_class = exo__Prototype.
+const BASE_NOTES: FixtureNote[] = [
+  {
+    uid: UID_EXO_CLASS,
+    frontmatter: { exo__Asset_uid: UID_EXO_CLASS, exo__Asset_label: "exo__Class" },
+  },
+  {
+    uid: UID_EXO_PROTO,
+    frontmatter: {
+      exo__Asset_uid: UID_EXO_PROTO,
+      exo__Asset_label: "exo__Prototype",
+    },
+  },
+  {
+    uid: UID_WIDGET,
+    frontmatter: {
+      exo__Asset_uid: UID_WIDGET,
+      exo__Asset_label: "ems__Widget",
+      // A class-def is an instance of the exo__Class metaclass.
+      exo__Instance_class: `[[${UID_EXO_CLASS}]]`,
+    },
+  },
+  {
+    uid: UID_WIDGET_INST,
+    frontmatter: {
+      exo__Asset_uid: UID_WIDGET_INST,
+      exo__Asset_label: "A widget instance",
+      exo__Instance_class: `[[${UID_WIDGET}]]`,
+    },
+  },
+  {
+    uid: UID_PROTO_MARKER,
+    frontmatter: {
+      exo__Asset_uid: UID_PROTO_MARKER,
+      exo__Asset_label: "A prototype marker",
+      exo__Instance_class: `[[${UID_EXO_PROTO}]]`,
+    },
+  },
+];
+
+describe(`Instance_class emission flip + query-time resolver (${REQ})`, () => {
+  describe("emission flip — the converter stores the class FILE IRI (uid) when ON, SYMBOLIC when OFF", () => {
+    const instanceClass = new IRI(Namespace.EXO.term("Instance_class").value);
+
+    it(`${REQ} flag OFF: the ems__Widget class-def's Instance_class object is the SYMBOLIC metaclass IRI (byte-identical to today)`, async () => {
+      const store = await buildStore(BASE_NOTES, false);
+      const triples = await store.match(new IRI(F(UID_WIDGET)), instanceClass, undefined);
+      const objects = triples.map((t) => (t.object as IRI).value);
+      expect(objects).toEqual([EXO_CLASS]);
+    });
+
+    it(`${REQ} flag ON: the same Instance_class object is the class FILE IRI (uid), not symbolic`, async () => {
+      const store = await buildStore(BASE_NOTES, true);
+      const triples = await store.match(new IRI(F(UID_WIDGET)), instanceClass, undefined);
+      const objects = triples.map((t) => (t.object as IRI).value);
+      expect(objects).toEqual([F(UID_EXO_CLASS)]);
+      expect(objects).not.toContain(EXO_CLASS);
+    });
+
+    it(`${REQ} flag ON: an instance's Instance_class = the domain class's FILE IRI`, async () => {
+      const store = await buildStore(BASE_NOTES, true);
+      const triples = await store.match(new IRI(F(UID_WIDGET_INST)), instanceClass, undefined);
+      expect(triples.map((t) => (t.object as IRI).value)).toEqual([F(UID_WIDGET)]);
+    });
+  });
+
+  describe("F5 — direct-membership queries by the readable symbolic name resolve post-flip (RED without resolver, GREEN with)", () => {
+    // The shipped "is a class-def" precondition shape (exocmd eead5d36):
+    // $target exo:Instance_class exo:Class.
+    const askIsClassDef = (target: string) =>
+      `${PREFIX} ASK { <${target}> exo:Instance_class exo:Class }`;
+
+    it(`${REQ} GREEN: "exo:Instance_class exo:Class" gates TRUE for a class-def when the resolver is ON`, async () => {
+      const store = await buildStore(BASE_NOTES, true); // flip ON → file-IRI store
+      expect(await runAsk(store, askIsClassDef(F(UID_WIDGET)), true)).toBe(true);
+    });
+
+    it(`${REQ} RED (revert-verify): the SAME query returns FALSE when the resolver is OFF (store holds file-IRI, query used the symbolic form)`, async () => {
+      const store = await buildStore(BASE_NOTES, true);
+      expect(await runAsk(store, askIsClassDef(F(UID_WIDGET)), false)).toBe(false);
+    });
+
+    it(`${REQ} the class metaclass resolves for a SELECT of all class-defs (?s exo:Instance_class exo:Class) — ON returns the class-def, OFF does not`, async () => {
+      const store = await buildStore(BASE_NOTES, true);
+      const q = `${PREFIX} SELECT ?s WHERE { ?s exo:Instance_class exo:Class }`;
+      expect(await runSelect(store, q, "s", true)).toContain(F(UID_WIDGET));
+      expect(await runSelect(store, q, "s", false)).not.toContain(F(UID_WIDGET));
+    });
+
+    it(`${REQ} exo:Prototype direct membership (the 3928f087 precondition shape) resolves ON, not OFF`, async () => {
+      const store = await buildStore(BASE_NOTES, true);
+      const ask = (t: string) =>
+        `${PREFIX} ASK { <${t}> exo:Instance_class exo:Prototype }`;
+      expect(await runAsk(store, ask(F(UID_PROTO_MARKER)), true)).toBe(true);
+      expect(await runAsk(store, ask(F(UID_PROTO_MARKER)), false)).toBe(false);
+    });
+
+    it(`${REQ} negative control (non-vacuity): the class-def is NOT an instance of an UNRELATED class even with the resolver ON`, async () => {
+      const store = await buildStore(BASE_NOTES, true);
+      // ems__Widget class-def's Instance_class is exo:Class, not exo:Prototype.
+      const ask = `${PREFIX} ASK { <${F(UID_WIDGET)}> exo:Instance_class exo:Prototype }`;
+      expect(await runAsk(store, ask, true)).toBe(false);
+    });
+  });
+
+  describe("byte-identical when it should be (predicate/object-shape scoped)", () => {
+    it(`${REQ} flag OFF: the same is-a-class-def query is TRUE regardless of the resolver (direct symbolic match)`, async () => {
+      const store = await buildStore(BASE_NOTES, false); // symbolic store
+      const ask = `${PREFIX} ASK { <${F(UID_WIDGET)}> exo:Instance_class exo:Class }`;
+      expect(await runAsk(store, ask, true)).toBe(true);
+      expect(await runAsk(store, ask, false)).toBe(true);
+    });
+
+    it(`${REQ} a VARIABLE-object Instance_class query is identical ON vs OFF (pure pass-through — object is not a symbolic IRI)`, async () => {
+      const store = await buildStore(BASE_NOTES, true);
+      const q = `${PREFIX} SELECT ?c WHERE { <${F(UID_WIDGET_INST)}> exo:Instance_class ?c }`;
+      const on = (await runSelect(store, q, "c", true)).sort();
+      const off = (await runSelect(store, q, "c", false)).sort();
+      expect(on).toEqual(off);
+      // With the flip ON the object is the FILE IRI (identity stays uid; the object
+      // is not rewritten for a variable query).
+      expect(on).toEqual([F(UID_WIDGET)]);
+    });
+
+    it(`${REQ} querying by the FILE IRI directly is identical ON vs OFF (already the stored form)`, async () => {
+      const store = await buildStore(BASE_NOTES, true);
+      const q = `${PREFIX} SELECT ?s WHERE { ?s exo:Instance_class <${F(UID_WIDGET)}> }`;
+      expect((await runSelect(store, q, "s", true)).sort()).toEqual(
+        (await runSelect(store, q, "s", false)).sort(),
+      );
+    });
+  });
+
+  describe("mixed store — an asset referencing the same class both RESOLVED and UNRESOLVED surfaces once (union + dedup)", () => {
+    // ems__Widget is referenced by an asset via BOTH a resolved `[[<uid>]]` (→ file
+    // IRI under the flip) AND an unresolved `[[ems__Widget]]` label wikilink (no note
+    // is basename-named "ems__Widget" → symbolic emission). So the asset holds BOTH
+    // the file-IRI form and the symbolic form for the SAME class.
+    const MIXED_NOTES: FixtureNote[] = [
+      ...BASE_NOTES,
+      {
+        uid: "111a0000-0000-4000-8000-000000000000",
+        frontmatter: {
+          exo__Asset_uid: "111a0000-0000-4000-8000-000000000000",
+          exo__Asset_label: "Mixed-ref asset",
+          exo__Instance_class: [`[[${UID_WIDGET}]]`, "[[ems__Widget]]"],
+        },
+      },
+    ];
+    const MIXED = F("111a0000-0000-4000-8000-000000000000");
+
+    it(`${REQ} querying by the symbolic name returns the mixed-ref asset exactly ONCE`, async () => {
+      const store = await buildStore(MIXED_NOTES, true);
+      const q = `${PREFIX} SELECT ?s WHERE { ?s exo:Instance_class <${EMS_WIDGET}> }`;
+      const results = await runSelect(store, q, "s", true);
+      expect(results.filter((r) => r === MIXED)).toEqual([MIXED]); // present, not duplicated
+    });
+
+    it(`${REQ} the mixed asset is unreachable by the symbolic name with the resolver OFF for its FILE-IRI ref (only the symbolic residual matches)`, async () => {
+      const store = await buildStore(MIXED_NOTES, true);
+      // Resolver OFF: only the residual symbolic `IC ems#Widget` triple matches → the
+      // asset is still returned (via the unresolved-ref residual), but NOT via the
+      // flipped file-IRI ref. Sanity that the residual symbolic form exists.
+      const q = `${PREFIX} SELECT ?s WHERE { ?s exo:Instance_class <${EMS_WIDGET}> }`;
+      expect(await runSelect(store, q, "s", false)).toContain(MIXED);
+    });
+  });
+
+  describe("ambiguous prefix → error with a disambiguation hint (RFC v3 point 9)", () => {
+    // Two DISTINCT class files derive the same symbolic `dup#Thing`.
+    const AMBIGUOUS_NOTES: FixtureNote[] = [
+      {
+        uid: "d000a000-0000-4000-8000-000000000000",
+        frontmatter: {
+          exo__Asset_uid: "d000a000-0000-4000-8000-000000000000",
+          exo__Asset_label: "dup__Thing",
+        },
+      },
+      {
+        uid: "d000b000-0000-4000-8000-000000000000",
+        frontmatter: {
+          exo__Asset_uid: "d000b000-0000-4000-8000-000000000000",
+          exo__Asset_label: "dup__Thing",
+        },
+      },
+      {
+        uid: "1a570000-0000-4000-8000-000000000000",
+        frontmatter: {
+          exo__Asset_uid: "1a570000-0000-4000-8000-000000000000",
+          exo__Asset_label: "Ambiguous-ref instance",
+          exo__Instance_class: "[[d000a000-0000-4000-8000-000000000000]]",
+        },
+      },
+    ];
+
+    it(`${REQ} a query resolving the ambiguous symbolic form throws SymbolicClassAmbiguityError with a hint`, async () => {
+      const store = await buildStore(AMBIGUOUS_NOTES, true);
+      const dupThing = Namespace.forPrefix("dup")!.term("Thing").value;
+      const q = `PREFIX exo: <${EXO}> ASK { <${F("1a570000-0000-4000-8000-000000000000")}> exo:Instance_class <${dupThing}> }`;
+      await expect(runAsk(store, q, true)).rejects.toBeInstanceOf(
+        SymbolicClassAmbiguityError,
+      );
+      await expect(runAsk(store, q, true)).rejects.toThrow(/uid/i);
+    });
+  });
+
+  describe("ZERO store growth — the anti-A2 guarantee holds for the object bridge", () => {
+    it(`${REQ} the store triple-count is identical before/after a resolver-enabled Instance_class-object query`, async () => {
+      const store = await buildStore(BASE_NOTES, true);
+      const before = await store.count();
+      // Sanity the resolver did something (matched via the bridge).
+      expect(
+        await runAsk(store, `${PREFIX} ASK { <${F(UID_WIDGET)}> exo:Instance_class exo:Class }`, true),
+      ).toBe(true);
+      expect(await store.count()).toBe(before); // nothing materialized
+    });
+  });
+});


### PR DESCRIPTION
## RFC 78572fa9 Phase 3 **stage-1** — the FIRST of the staged per-predicate emission flip (§v6 F1, Andrey design-interview 2026-07-30, decisions LOCKED)

**Req:** `c359e3d2-d97d-4a88-8d13-e2bb4652c10b` (Active-flip after merge) · **Scope this stage:** the `exo__Instance_class` **object position ONLY** (F1 staged; status/value and domain/range are later stages).

### What ships (F4: merge safely default-OFF → prove → flip on later)
1. **Emission-flip flag** on `NoteToRDFConverter` — a **DEFAULT-OFF** `emitInstanceClassAsUid` option. When ON, `valueToClassURI` (the Instance_class emission path — Issue #663, *not* `valueToRDFObject`) emits the resolved class **FILE IRI (uid)** instead of the symbolic class IRI. Default OFF ⇒ **byte-identical** behaviour, so merging is a no-op.
2. **Query-time resolver generalization (F3)** — `ClassHierarchyResolvingStore` (req `9fddda62`) now ALSO bridges the **Instance_class object position**: resolve a queried symbolic `prefix#Local` class IRI → the class file IRI at match-time, UNION the direct symbolic-form + bridged file-IRI-form matches (handles a MIXED store), rewrite the object back to the queried symbolic form. Index broadened to **comprehensive TBox labels** so metaclasses (`exo__Class`) resolve. **Zero store growth**; byte-identical pass-through when the object is not symbolic. An ambiguous prefix (cross-ontology collision) throws `SymbolicClassAmbiguityError` (error-with-hint, RFC v3 point 9; **verified zero collisions** on the real vaults).
3. **Production-shape revert-verify (F5)** — `instance-class-emission-flip.test.ts` builds the store via the REAL `NoteToRDFConverter` with the flip ON, then runs direct-membership queries by the readable symbolic name (the shipped `$target exo:Instance_class exo:Class` is-a-class-def precondition shape, `exo:Prototype`, mixed-store union, ambiguity). Revert axis = the `resolveClassHierarchy` toggle.

### Revert-verified (F5)
`@req:c359e3d2` — with the flip ON, a direct-membership query by the symbolic name resolves **only** with the resolver ON: **RED** without the resolver's Instance_class coverage (store holds file-IRI, query used the symbolic form), **GREEN** with it. This proves coverage empirically (dispelling the "rewrite thousands of tests" fear). 15/15 test cases green.

### No regression
Full core suite (CI config, `tests/performance/**` excluded): **356 suites / 8442 tests green, 0 failed**. Flag default-OFF ⇒ byte-identical.

### Deferred (a SEPARATE bounded stage)
The **default-ON flip** + the TS-consumer migration are deferred (F4 "merge safely, prove, then flip on"). **Measured** core blast-radius with the flip forced ON = **5 suites / 7 tests**, all `NoteToRDFConverter` emission-*form* assertions (intended to change when flipping) — a moderate follow-up, NOT a mega-migration. The plugin/e2e blast-radius is TBD in that stage.

### Discipline
Parser/TBox path (`NoteToRDFConverter`) → code-reviewer before merge, manual squash (no `--auto`).

Req: c359e3d2-d97d-4a88-8d13-e2bb4652c10b