### PR TITLE
feat(cli): opt-in `create --validate` — pre-write SHACL-lite conformance gate (W3)

### DIFF
--- a/packages/cli/src/commands/create.ts
+++ b/packages/cli/src/commands/create.ts
@@ -6,6 +6,8 @@ import {
   ShapeLoader,
   ShapeRegistry,
   GenericAssetCreationService,
+  liveClock,
+  liveUidGenerator,
   type GenericAssetCreationConfig,
 } from "@kitelev/exocortex-core";
 import { NodeFsAdapter } from "../adapters/NodeFsAdapter.js";
@@ -15,7 +17,10 @@ import { WikilinkValidator } from "../services/WikilinkValidator.js";
 import { PropertyNameValidator } from "../services/PropertyNameValidator.js";
 import { EffortStatusResolver } from "../services/EffortStatusResolver.js";
 import { ErrorHandler } from "../utils/ErrorHandler.js";
-import { VaultNotFoundError } from "../utils/errors/index.js";
+import {
+  ShaclConformanceError,
+  VaultNotFoundError,
+} from "../utils/errors/index.js";
 import { registerOrderSpecFromVault } from "../services/registerOrderSpec.js";
 import {
   resolveCoLocationFolder,
@@ -76,6 +81,11 @@ interface CreateCommandOptions {
   yes?: boolean;
   timezone?: string;
   skipWikilinkValidation?: boolean;
+  /**
+   * Opt-in SHACL-lite conformance gate (project 38800c80 W3). Default OFF —
+   * without it `create` is byte-identical (no vault load, no extra output).
+   */
+  validate?: boolean;
 }
 
 /**
@@ -252,6 +262,10 @@ export function createCommand(): Command {
     .option("--yes", "Accepted for symmetry with the apply subcommands (create is non-interactive; no-op)")
     .option("--timezone <tz>", "Timezone for timestamps (defaults to Asia/Almaty)")
     .option("--skip-wikilink-validation", "Skip wikilink existence validation")
+    .option(
+      "--validate",
+      "Run SHACL-lite conformance validation on the new asset BEFORE writing it; a non-conformant asset is refused and no file is created (same shapes as `validate schema --shapes-mode`). Opt-in: omit the flag and create behaves exactly as before.",
+    )
     .action(async (options: CreateCommandOptions) => {
       try {
         const vaultPath = resolve(options.vault);
@@ -467,6 +481,58 @@ export function createCommand(): Command {
           propertyValues,
           shapeRegistry,
         };
+
+        // Opt-in SHACL-lite conformance gate (project 38800c80 W3) — the last
+        // hook-gap of the CLI creation path. A CLI `create` runs through Bash,
+        // so the PreToolUse Write hook `validate-asset.sh` (which gives the
+        // Write path this guarantee via `validate schema --shapes-mode`) never
+        // fires. `--validate` runs the SAME shapes pipeline BEFORE the write,
+        // scoped to this candidate, and refuses a non-conformant asset so
+        // nothing lands on disk.
+        //
+        // Determinism is pinned FIRST so the bytes validated here are the exact
+        // bytes written below: `buildAsset` mints a fresh uid and stamps the
+        // timestamps from the clock on EVERY call, so without pinning the
+        // validated candidate and the written asset would differ
+        // (dry-run-preview-not-real-output). The generators are the same live
+        // ones the service uses by default — only their values are frozen for
+        // this invocation, and only when `--validate` is passed (the default
+        // path is untouched and byte-identical).
+        if (options.validate) {
+          const pinnedUid = liveUidGenerator().next();
+          const pinnedNow = liveClock().now();
+          creationService.withDeterminism({
+            uidGenerator: { next: () => pinnedUid },
+            clock: { now: () => new Date(pinnedNow.getTime()) },
+          });
+
+          const candidate = creationService.buildAsset(config);
+          // Lazily imported: the validator pulls in the whole shapes/SPARQL
+          // module graph, and the flag is opt-in — the DEFAULT `create` path
+          // must not pay that load cost (nor widen its module graph).
+          const { CandidateShaclValidator } = await import(
+            "../services/CandidateShaclValidator.js"
+          );
+          const shaclValidator = new CandidateShaclValidator(vaultPath);
+          const { violations, warnings } =
+            await shaclValidator.validateCandidate(
+              candidate.path,
+              candidate.content,
+            );
+
+          // Warnings never gate (open-world: unresolvable / cross-vault /
+          // symbolic refs, issue #3488) — same exit-code semantics shapes-mode
+          // applies. Reported on stderr so stdout stays a single JSON document.
+          for (const warning of warnings) {
+            process.stderr.write(
+              `⚠ SHACL warning on ${warning.propertyPath} (${warning.constraint}): ${warning.message}\n`,
+            );
+          }
+
+          if (violations.length > 0) {
+            throw new ShaclConformanceError(candidate.path, violations);
+          }
+        }
 
         let uuid: string;
         let path: string;

--- a/packages/cli/src/services/CandidateShaclValidator.ts
+++ b/packages/cli/src/services/CandidateShaclValidator.ts
@@ -1,0 +1,175 @@
+import { basename, extname } from "path";
+import {
+  NoteToRDFConverter,
+  parseYamlFrontmatterTolerant,
+  DomainTriple,
+  type IFile,
+} from "@kitelev/exocortex-core";
+import { FileSystemVaultAdapter } from "../adapters/FileSystemVaultAdapter.js";
+import {
+  runShapesValidation,
+  applyLegacyExceptionFilter,
+  filterReportToStagedFocusNodes,
+} from "../commands/validate-schema.js";
+import type { ShaclConformanceViolation } from "../utils/errors/ShaclConformanceError.js";
+
+/**
+ * The candidate-scoped verdict of a SHACL-lite conformance run.
+ */
+export interface CandidateConformanceResult {
+  /** Gating `sh:Violation` results whose focus node IS the candidate. */
+  violations: ShaclConformanceViolation[];
+  /**
+   * Non-gating `sh:Warning` results for the candidate — unresolvable /
+   * cross-vault / symbolic references that open-world semantics cannot
+   * hard-fail (issue #3488). Surfaced, never blocking.
+   */
+  warnings: ShaclConformanceViolation[];
+}
+
+/** Matches the frontmatter block of an assembled asset (same regex the adapter uses). */
+const FRONTMATTER_REGEX = /^---\n([\s\S]*?)\n---/;
+
+/**
+ * Runs the SAME SHACL-lite pipeline as `validate schema --shapes-mode` against a
+ * single **not-yet-written** candidate asset, scoped to that candidate's own
+ * violations (project 38800c80 W3).
+ *
+ * ## Why this exists
+ *
+ * A CLI `create` runs through Bash, so the PreToolUse Write/Edit hooks never
+ * fire. `create` already re-implements three of the four guarantees those hooks
+ * give — co-location by `exo__Asset_isDefinedBy` (#3520/#3934), dangling
+ * wikilink VALUE rejection (`WikilinkValidator`), and unknown property NAME
+ * rejection (`PropertyNameValidator`, RFC 430e84f1). The fourth, SHACL-lite
+ * conformance, had no CLI counterpart: the `ShapeRegistry` `create` already
+ * loads is used only for cardinality-aware property *serialization*
+ * (#3099/#3179), never for validation. The opt-in `create --validate` flag
+ * closes that last gap.
+ *
+ * ## Design
+ *
+ * - **Reuse, do not re-implement.** The verdict comes from the very functions
+ *   `validate schema --shapes-mode` uses (`runShapesValidation` —
+ *   `ShapeLoader.loadFromRDFGraph` + `TripleClassHierarchy` — then
+ *   `applyLegacyExceptionFilter`), so the CLI verdict is *by construction*
+ *   identical to the hook's, and a shapes-semantics change lands in both at
+ *   once. The Write-path hook gets the same answer by writing a temp file into
+ *   the vault and filtering violations to that file's focus node; this class
+ *   does the equivalent entirely in memory.
+ * - **Pre-write.** The candidate's triples are produced from the exact bytes a
+ *   real write would produce (`GenericAssetCreationService.buildAsset`), parsed
+ *   with the SAME tolerant YAML parser `FileSystemVaultAdapter.getFrontmatter`
+ *   uses, and converted through the production
+ *   `NoteToRDFConverter.convertNoteFromFrontmatter` (documented to accept a
+ *   synthetic `IFile` — only `path`/`basename` are read). Nothing touches disk.
+ * - **Candidate-scoped.** LOAD-BEARING: without the focus-node filter every
+ *   create would fail on any vault that already has violations elsewhere
+ *   (vault-tbank has 7). Mirrors the hook's temp-file filter
+ *   (`filterReportToStagedFocusNodes`, #3245).
+ * - **Severity parity.** Only `sh:Violation` gates; `sh:Warning` is surfaced but
+ *   never blocks — the same exit-code semantics `shapes-mode` applies (#3488).
+ */
+export class CandidateShaclValidator {
+  constructor(private readonly vaultPath: string) {}
+
+  /**
+   * Validate one candidate asset that has NOT been written yet.
+   *
+   * @param relPath - Vault-relative path the asset WOULD be written to
+   *                  (`<folder>/<uid>.md`), used as the focus-node key.
+   * @param content - The exact bytes the write would produce.
+   */
+  async validateCandidate(
+    relPath: string,
+    content: string,
+  ): Promise<CandidateConformanceResult> {
+    const adapter = new FileSystemVaultAdapter(this.vaultPath);
+    const converter = new NoteToRDFConverter(adapter);
+
+    // Vault context: the shapes (TBox) plus every existing asset, so `sh:class`
+    // range checks can resolve the candidate's references.
+    const vaultTriples = (await converter.convertVault()) as DomainTriple[];
+
+    // Candidate triples from the assembled bytes — no temp file, no disk write.
+    const candidateTriples = (await converter.convertNoteFromFrontmatter(
+      syntheticFile(relPath),
+      extractFrontmatter(content),
+    )) as DomainTriple[];
+
+    const allTriples = [...vaultTriples, ...candidateTriples];
+    const rawReport = await runShapesValidation(this.vaultPath, allTriples);
+    const report = applyLegacyExceptionFilter(allTriples, rawReport);
+    const scoped = filterReportToStagedFocusNodes(
+      report,
+      new Set([relPath]),
+    );
+
+    const violations: ShaclConformanceViolation[] = [];
+    const warnings: ShaclConformanceViolation[] = [];
+    for (const v of scoped.violations) {
+      const entry: ShaclConformanceViolation = {
+        propertyPath: iriToFrontmatterKey(v.propertyPath),
+        propertyIri: v.propertyPath,
+        constraint: String(v.constraint),
+        message: v.message,
+        ...(v.actualValue !== undefined ? { actualValue: v.actualValue } : {}),
+        ...(v.expectedRange !== undefined
+          ? { expectedRange: v.expectedRange }
+          : {}),
+      };
+      if (v.severity === "sh:Violation") {
+        violations.push(entry);
+      } else {
+        warnings.push(entry);
+      }
+    }
+
+    return { violations, warnings };
+  }
+}
+
+/**
+ * `https://exocortex.my/ontology/<ns>#<Local>` → `<ns>__<Local>` — the
+ * frontmatter KEY the caller typed, so a reported violation maps straight back
+ * to the offending `--property` flag. Namespace-agnostic on purpose (unlike
+ * `uriToKey`, which is limited to the curated `NAMESPACE_PREFIX_MAP` and would
+ * return null for any newer namespace). Returns the raw IRI unchanged when the
+ * path is not an Exocortex ontology term (a foreign/W3C predicate).
+ */
+function iriToFrontmatterKey(iri: string): string {
+  const match = iri.match(
+    /^https:\/\/exocortex\.my\/ontology\/([A-Za-z][A-Za-z0-9_]*)#(.+)$/,
+  );
+  return match ? `${match[1]}__${match[2]}` : iri;
+}
+
+/**
+ * A minimal `IFile` for a path that does not exist on disk yet.
+ * `convertNoteFromFrontmatter` reads only `path` / `basename`.
+ */
+function syntheticFile(relPath: string): IFile {
+  const name = basename(relPath);
+  return {
+    path: relPath,
+    basename: basename(relPath, extname(relPath)),
+    name,
+    parent: null,
+  };
+}
+
+/**
+ * Parse the candidate's frontmatter with the SAME tolerant parser
+ * `FileSystemVaultAdapter.getFrontmatter` applies when reading a real file back,
+ * so the candidate's triples equal the ones a post-write `convertVault` would
+ * emit. Returns `null` when the content has no frontmatter block (the converter
+ * then yields no triples — nothing to validate).
+ */
+function extractFrontmatter(content: string): Record<string, unknown> | null {
+  const match = content.match(FRONTMATTER_REGEX);
+  if (!match) return null;
+  return parseYamlFrontmatterTolerant(match[1]) as Record<
+    string,
+    unknown
+  > | null;
+}

--- a/packages/cli/src/services/CandidateShaclValidator.ts
+++ b/packages/cli/src/services/CandidateShaclValidator.ts
@@ -86,16 +86,66 @@ export class CandidateShaclValidator {
   ): Promise<CandidateConformanceResult> {
     const adapter = new FileSystemVaultAdapter(this.vaultPath);
     const converter = new NoteToRDFConverter(adapter);
+    const file = syntheticFile(relPath);
+    const frontmatter = extractFrontmatter(content);
+
+    // Parity with `convertVault`'s two-phase commit (#2997 Phase 2): it
+    // validates file-level invariants BEFORE converting, and SKIPS any file
+    // that fails one (or throws mid-conversion) so a malformed asset cannot
+    // leak partial triples. Calling `convertNoteFromFrontmatter` directly would
+    // bypass that gate — an empty `ems__Effort_status` would surface as a raw
+    // `Literal value cannot be empty` crash instead of a structured verdict.
+    //
+    // For a PRE-WRITE gate an unindexable candidate is a WORSE outcome than a
+    // shape violation: it contributes ZERO triples, so the asset would be
+    // invisible to every query / layout / graph relation — the exact
+    // "silently dead asset" class this workstream exists to prevent. So it is
+    // reported as a gate failure (fail-closed, structured), not passed. Checked
+    // FIRST so a malformed candidate fails fast, before the vault-wide load.
+    const invariant = frontmatter
+      ? converter.validateExocortexAsset(frontmatter, file.basename)
+      : null;
+    if (invariant) {
+      return {
+        violations: [
+          {
+            propertyPath: invariant.property,
+            propertyIri: invariant.property,
+            constraint: invariant.code,
+            message: `${invariant.message} — the asset would be SKIPPED by the indexer (no triples emitted), making it invisible to every query, layout and graph relation.`,
+          },
+        ],
+        warnings: [],
+      };
+    }
 
     // Vault context: the shapes (TBox) plus every existing asset, so `sh:class`
     // range checks can resolve the candidate's references.
     const vaultTriples = (await converter.convertVault()) as DomainTriple[];
 
     // Candidate triples from the assembled bytes — no temp file, no disk write.
-    const candidateTriples = (await converter.convertNoteFromFrontmatter(
-      syntheticFile(relPath),
-      extractFrontmatter(content),
-    )) as DomainTriple[];
+    // The try/catch is the backstop half of the parity above: `convertVault`
+    // discards the buffer and skips the file on ANY conversion throw, so a
+    // throw here means the same thing — unindexable, hence a gate failure.
+    let candidateTriples: DomainTriple[];
+    try {
+      candidateTriples = (await converter.convertNoteFromFrontmatter(
+        file,
+        frontmatter,
+      )) as DomainTriple[];
+    } catch (error) {
+      return {
+        violations: [
+          {
+            propertyPath: relPath,
+            propertyIri: relPath,
+            constraint: "indexability",
+            message: `The asset could not be converted to RDF (${error instanceof Error ? error.message : String(error)}) — the indexer would SKIP it, making it invisible to every query, layout and graph relation.`,
+          },
+        ],
+        warnings: [],
+      };
+    }
 
     const allTriples = [...vaultTriples, ...candidateTriples];
     const rawReport = await runShapesValidation(this.vaultPath, allTriples);
@@ -160,10 +210,13 @@ function syntheticFile(relPath: string): IFile {
 
 /**
  * Parse the candidate's frontmatter with the SAME tolerant parser
- * `FileSystemVaultAdapter.getFrontmatter` applies when reading a real file back,
- * so the candidate's triples equal the ones a post-write `convertVault` would
- * emit. Returns `null` when the content has no frontmatter block (the converter
- * then yields no triples — nothing to validate).
+ * `FileSystemVaultAdapter.getFrontmatter` applies when reading a real file back
+ * (byte-identical block regex + `parseYamlFrontmatterTolerant`), so the
+ * candidate's triples equal the ones a post-write `convertVault` would emit —
+ * with the deliberate exception of the SKIP case: where `convertVault` silently
+ * drops an unindexable file, the gate reports it as a violation (see
+ * `validateCandidate`). Returns `null` when the content has no frontmatter block
+ * (the converter then yields no triples — nothing to validate).
  */
 function extractFrontmatter(content: string): Record<string, unknown> | null {
   const match = content.match(FRONTMATTER_REGEX);

--- a/packages/cli/src/utils/errors/ShaclConformanceError.ts
+++ b/packages/cli/src/utils/errors/ShaclConformanceError.ts
@@ -1,0 +1,90 @@
+import { ExitCodes } from "../ExitCodes.js";
+import { CLIError } from "./CLIError.js";
+import { ErrorCode } from "../../responses/index.js";
+
+/**
+ * A single SHACL-lite constraint failure on the candidate asset, in the shape
+ * an LLM consumer can act on without re-parsing a human message.
+ */
+export interface ShaclConformanceViolation {
+  /**
+   * The frontmatter KEY the constraint is attached to (`ems__Task_count`) — the
+   * form the caller actually typed as `--property`, so a fix is mechanical. Falls
+   * back to the raw IRI when the path is not an Exocortex ontology term.
+   */
+  propertyPath: string;
+  /** The raw SHACL property-path IRI, kept for traceability. */
+  propertyIri: string;
+  /** Which constraint failed (`minCount` / `maxCount` / `class` / `datatype` / …). */
+  constraint: string;
+  /** Human-readable explanation from the validator. */
+  message: string;
+  /** The offending value, when the validator could name one. */
+  actualValue?: string;
+  /** The expected class/datatype, when the constraint declares one. */
+  expectedRange?: string;
+}
+
+/**
+ * Error thrown when `create --validate` finds the about-to-be-created asset
+ * non-conformant to the vault's SHACL-lite shapes (project 38800c80 W3).
+ *
+ * This is the CLI counterpart of the PreToolUse Write hook `validate-asset.sh`,
+ * which gives the Write path the same guarantee by shelling out to
+ * `validate schema --shapes-mode`. Because a CLI `create` runs through Bash the
+ * hook never fires, so `create` re-implements the guarantees itself: co-location
+ * (#3520/#3934), dangling-wikilink VALUE rejection (`WikilinkValidator`),
+ * unknown property NAME rejection (`PropertyNameValidator`, RFC 430e84f1) — and,
+ * with the opt-in `--validate` flag, SHACL conformance.
+ *
+ * The gate runs BEFORE the write, so a rejected candidate leaves **no file on
+ * disk** — strictly better than the hook, which must materialise a temp file
+ * inside the vault to get its verdict.
+ *
+ * The `{ path, violations }` pair is exposed both as typed fields and (via the
+ * base {@link CLIError} `context`) in the structured JSON response, so an agent
+ * can repair the frontmatter and retry without a human reading the message.
+ */
+export class ShaclConformanceError extends CLIError {
+  readonly exitCode = ExitCodes.INVALID_ARGUMENTS;
+  readonly errorCode = ErrorCode.VALIDATION_INVALID_FORMAT;
+  readonly guidance: string;
+
+  /** Vault-relative path the candidate WOULD have been written to. */
+  readonly assetPath: string;
+  /** The gating `sh:Violation` results scoped to this candidate. */
+  readonly violations: ShaclConformanceViolation[];
+
+  constructor(assetPath: string, violations: ShaclConformanceViolation[]) {
+    const detail = violations
+      .map(
+        (v) =>
+          `  • ${v.propertyPath} (${v.constraint}): ${v.message}` +
+          (v.expectedRange ? ` [expected: ${v.expectedRange}]` : "") +
+          (v.actualValue ? ` [actual: ${v.actualValue}]` : ""),
+      )
+      .join("\n");
+    const message =
+      `SHACL-lite validation failed for the new asset — nothing was written.\n` +
+      `${violations.length} violation(s) in ${assetPath}:\n${detail}`;
+
+    super(
+      message,
+      // Structured, machine-readable form for an LLM consumer.
+      { path: assetPath, violations },
+      {
+        message:
+          "Fix the frontmatter so the asset satisfies its class shapes, then re-run create.",
+        suggestion:
+          "Run `validate schema --shapes-mode` on the vault to see the same shapes the gate applied.",
+      },
+    );
+
+    this.assetPath = assetPath;
+    this.violations = violations;
+    this.guidance =
+      "The asset does not conform to the SHACL-lite shapes declared for its class. " +
+      "Add the missing required properties (or correct the offending value's class/datatype) " +
+      "and re-run `create --validate`. Omitting `--validate` skips the gate entirely.";
+  }
+}

--- a/packages/cli/src/utils/errors/index.ts
+++ b/packages/cli/src/utils/errors/index.ts
@@ -19,3 +19,7 @@ export { OperationFailedError } from "./OperationFailedError.js";
 export { PermissionDeniedError } from "./PermissionDeniedError.js";
 export { QueryTimeoutError } from "./QueryTimeoutError.js";
 export { UnknownPropertyError } from "./UnknownPropertyError.js";
+export {
+  ShaclConformanceError,
+  type ShaclConformanceViolation,
+} from "./ShaclConformanceError.js";

--- a/packages/cli/tests/integration/create-validate-shacl.integration.test.ts
+++ b/packages/cli/tests/integration/create-validate-shacl.integration.test.ts
@@ -1,0 +1,269 @@
+/**
+ * Project 38800c80 W3 (RFC 7c7859d1) — opt-in `exocortex-cli create --validate`
+ * runs the SAME SHACL-lite conformance gate the Write-path PreToolUse hook
+ * (`validate-asset.sh` → `validate schema --shapes-mode`) runs, PRE-WRITE and
+ * scoped to the new asset. Closes the last hook-gap of the CLI creation path:
+ * `create` already re-implements co-location (#3520/#3934), dangling-wikilink
+ * VALUE rejection (`WikilinkValidator`) and unknown property NAME rejection
+ * (`PropertyNameValidator`, RFC 430e84f1) — SHACL conformance was the only one
+ * missing (the `ShapeRegistry` create already loads is used ONLY for
+ * cardinality-aware serialization, #3099/#3179).
+ *
+ * Exercises the REAL `createCommand()` action end-to-end against a temp fixture
+ * vault carrying genuine SHACL-lite shapes (the same shape shape as
+ * `tests/fixtures/shacl-integration`) AND a PRE-EXISTING violating asset, so the
+ * candidate-scoping is proven on real data rather than asserted.
+ *
+ * Revert-verify (~/dotfiles/.claude/rules/integration-test-revert-verify.md):
+ * a type-preserving Edit-break of the `--validate` gate in create.ts (skip the
+ * conformance check) makes the NON-CONFORMANT scenarios pass the create (exit 0
+ * + a file on disk) → those assertions go RED. The negative controls —
+ * default-OFF byte-identical, conformant-candidate-passes, and
+ * pre-existing-other-asset-violation-does-not-block — stay GREEN in both states,
+ * proving the delta is exactly the candidate-scoped gate and not a blanket
+ * refusal. Restoring makes all GREEN.
+ */
+import { jest, describe, it, expect, beforeEach, afterEach } from "@jest/globals";
+import * as fs from "fs";
+import * as path from "path";
+import * as os from "os";
+
+const { createCommand } = await import("../../src/commands/create.js");
+
+const REQ = "dd9ab956-80c7-45c6-b71b-5834f50ce6f8";
+// requirements-trace binds ONLY via a literal `@req:<uid>` token — the
+// `@req:${REQ}` interpolation in the it() titles below is not statically
+// resolvable, so declare the binding as a literal here:
+// @req:dd9ab956-80c7-45c6-b71b-5834f50ce6f8
+
+/** Real `ems__Task` UID — the candidate's class (a class-def file is written). */
+const CLASS_UID = "1b20a8f0-d745-4e93-91db-4531b3df120e";
+/** Shape: `ems__Task_count` must be an xsd:integer (sh:datatype). */
+const COUNT_PROP_UID = "bbb22222-2222-2222-2222-222222222222";
+/** A PRE-EXISTING asset that already violates the shape (never our candidate). */
+const PREEXISTING_BAD_UID = "22222222-bbbb-2222-bbbb-222222222222";
+/** `exo__Property` metaclass — makes `ems__Task_count` a known property NAME. */
+const PROPERTY_METACLASS_UID = "38277bfa-d7f9-4a75-b856-b23276ab0db3";
+/** `exo__Class` metaclass — for the `ems__Task` class-def. */
+const CLASS_METACLASS_UID = "8619c4fc-64f1-4869-b17e-e34186cacca9";
+
+/** Fixture files that exist BEFORE any create (excluded from the created count). */
+const FIXTURE_BASENAMES = new Set([
+  `${CLASS_UID}.md`,
+  `${COUNT_PROP_UID}.md`,
+  `${PREEXISTING_BAD_UID}.md`,
+]);
+
+function md(frontmatter: Record<string, string | string[]>): string {
+  const lines = ["---"];
+  for (const [k, v] of Object.entries(frontmatter)) {
+    if (Array.isArray(v)) {
+      lines.push(`${k}:`);
+      for (const item of v) lines.push(`  - ${item}`);
+    } else {
+      lines.push(`${k}: ${v}`);
+    }
+  }
+  lines.push("---", "");
+  return lines.join("\n");
+}
+
+/**
+ * A fixture vault with REAL SHACL-lite shapes:
+ *  - `ems__Task` class-def (UID-named, so the candidate's UID-form
+ *    `exo__Instance_class` resolves to the symbolic `ems#Task` the shape's
+ *    domain also resolves to — the dual-IRI bridge, sparql-iri-form-pre-verify).
+ *  - `ems__Task_count` property-def: domain `ems__Task`, range xsd:integer →
+ *    a `sh:datatype` shape (and, incidentally, a KNOWN property name so the
+ *    RFC-430e84f1 name guard passes and the two guards are proven to compose).
+ *  - A PRE-EXISTING `ems__Task` that ALREADY violates that shape — the vault is
+ *    non-conformant before we start, exactly like a real vault (vault-tbank has
+ *    7 pre-existing violations).
+ */
+function buildFixtureVault(vault: string): void {
+  const tbox = path.join(vault, "assetspaces/kitelev/exoas-exo/exo");
+  const data = path.join(vault, "assetspaces/kitelev/exoas-my/my");
+  fs.mkdirSync(tbox, { recursive: true });
+  fs.mkdirSync(data, { recursive: true });
+  fs.mkdirSync(path.join(vault, "01 Inbox"), { recursive: true });
+
+  fs.writeFileSync(
+    path.join(tbox, `${CLASS_UID}.md`),
+    md({
+      exo__Asset_uid: CLASS_UID,
+      exo__Instance_class: `"[[${CLASS_METACLASS_UID}|exo__Class]]"`,
+      exo__Asset_label: "ems__Task",
+    }),
+  );
+
+  fs.writeFileSync(
+    path.join(tbox, `${COUNT_PROP_UID}.md`),
+    md({
+      exo__Asset_uid: COUNT_PROP_UID,
+      exo__Instance_class: `"[[${PROPERTY_METACLASS_UID}|exo__Property]]"`,
+      exo__Asset_label: "ems__Task_count",
+      exo__Property_domain: '"[[ems__Task]]"',
+      exo__Property_range: "http://www.w3.org/2001/XMLSchema#integer",
+      exo__Property_severity: "sh:Violation",
+    }),
+  );
+
+  // Pre-existing NON-conformant asset (string where xsd:integer is required).
+  fs.writeFileSync(
+    path.join(data, `${PREEXISTING_BAD_UID}.md`),
+    md({
+      exo__Asset_uid: PREEXISTING_BAD_UID,
+      exo__Instance_class: `"[[${CLASS_UID}]]"`,
+      exo__Asset_label: "Pre-existing violating task",
+      ems__Task_count: '"already-bad"',
+    }),
+  );
+}
+
+describe("W3: `cli create --validate` — opt-in pre-write SHACL-lite conformance gate", () => {
+  let vault: string;
+  let exitSpy: ReturnType<typeof jest.spyOn>;
+  let stdoutSpy: ReturnType<typeof jest.spyOn>;
+  let stderrSpy: ReturnType<typeof jest.spyOn>;
+  let logSpy: ReturnType<typeof jest.spyOn>;
+  let errorSpy: ReturnType<typeof jest.spyOn>;
+  let stdoutChunks: string[];
+  let exitCodes: number[];
+
+  beforeEach(() => {
+    vault = fs.mkdtempSync(path.join(os.tmpdir(), "cli-shaclgate-"));
+    buildFixtureVault(vault);
+
+    stdoutChunks = [];
+    exitCodes = [];
+    exitSpy = jest.spyOn(process, "exit").mockImplementation(((code?: number) => {
+      exitCodes.push(code ?? 0);
+      return undefined as never;
+    }) as never);
+    stdoutSpy = jest
+      .spyOn(process.stdout, "write")
+      .mockImplementation(((chunk: unknown) => {
+        stdoutChunks.push(String(chunk));
+        return true;
+      }) as never);
+    stderrSpy = jest
+      .spyOn(process.stderr, "write")
+      .mockImplementation((() => true) as never);
+    logSpy = jest.spyOn(console, "log").mockImplementation(() => {});
+    errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    exitSpy.mockRestore();
+    stdoutSpy.mockRestore();
+    stderrSpy.mockRestore();
+    logSpy.mockRestore();
+    errorSpy.mockRestore();
+    fs.rmSync(vault, { recursive: true, force: true });
+  });
+
+  async function runCreate(extraArgs: string[]): Promise<void> {
+    const cmd = createCommand();
+    await cmd.parseAsync(
+      [
+        "--class",
+        "ems__Task",
+        "--label",
+        "E2E-TEST shacl gate",
+        "--vault",
+        vault,
+        "--skip-wikilink-validation",
+        ...extraArgs,
+      ],
+      { from: "user" },
+    );
+  }
+
+  /** Assets created by THIS run (fixture files excluded). */
+  function createdAssetCount(): number {
+    const walk = (dir: string): number => {
+      let n = 0;
+      for (const e of fs.readdirSync(dir, { withFileTypes: true })) {
+        const full = path.join(dir, e.name);
+        if (e.isDirectory()) n += walk(full);
+        else if (e.name.endsWith(".md") && !FIXTURE_BASENAMES.has(e.name)) n++;
+      }
+      return n;
+    };
+    return walk(vault);
+  }
+
+  it(`--validate REFUSES a non-conformant candidate BEFORE writing — exit != 0, no file @req:${REQ}`, async () => {
+    await runCreate([
+      "--property",
+      "ems__Task_count=not-a-number",
+      "--validate",
+    ]);
+
+    expect(exitCodes).not.toContain(0);
+    const stderr = errorSpy.mock.calls.flat().join("\n");
+    expect(stderr).toContain("SHACL-lite validation failed");
+    expect(stderr).toContain("ems__Task_count");
+    expect(stderr).toContain("datatype");
+    // PRE-WRITE gate: the refusal must leave nothing on disk.
+    expect(createdAssetCount()).toBe(0);
+    expect(stdoutChunks.join("")).toBe(""); // no success JSON
+  });
+
+  it(`--validate ACCEPTS a conformant candidate even though the vault already has violations elsewhere @req:${REQ}`, async () => {
+    await runCreate(["--validate"]);
+
+    expect(exitCodes).toContain(0);
+    // Candidate-scoped: the PRE-EXISTING violating asset must NOT block us.
+    expect(createdAssetCount()).toBe(1);
+    const json = JSON.parse(stdoutChunks.join("").trim());
+    expect(json.label).toBe("E2E-TEST shacl gate");
+    expect(fs.existsSync(path.join(vault, json.path))).toBe(true);
+    // stdout stays exactly ONE JSON document (validation chatter → stderr).
+    expect(stdoutChunks.join("").trim().split("\n")).toHaveLength(1);
+  });
+
+  it(`WITHOUT --validate the gate never runs — a non-conformant asset is still created (default OFF, byte-identical) @req:${REQ}`, async () => {
+    await runCreate(["--property", "ems__Task_count=not-a-number"]);
+
+    expect(exitCodes).toContain(0);
+    expect(createdAssetCount()).toBe(1);
+    const json = JSON.parse(stdoutChunks.join("").trim());
+    const written = fs.readFileSync(path.join(vault, json.path), "utf-8");
+    expect(written).toContain("ems__Task_count");
+  });
+
+  it(`--dry-run --validate refuses a non-conformant candidate and writes nothing @req:${REQ}`, async () => {
+    await runCreate([
+      "--property",
+      "ems__Task_count=not-a-number",
+      "--dry-run",
+      "--validate",
+    ]);
+
+    expect(exitCodes).not.toContain(0);
+    expect(createdAssetCount()).toBe(0);
+    expect(stdoutChunks.join("")).toBe("");
+  });
+
+  it(`--dry-run --validate passes a conformant candidate and still writes nothing @req:${REQ}`, async () => {
+    await runCreate(["--dry-run", "--validate"]);
+
+    expect(exitCodes).toContain(0);
+    expect(createdAssetCount()).toBe(0);
+    const json = JSON.parse(stdoutChunks.join("").trim());
+    expect(json.uuid).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i,
+    );
+  });
+
+  it(`the validated bytes are the bytes written — uid + timestamps are pinned across the gate @req:${REQ}`, async () => {
+    await runCreate(["--validate"]);
+
+    const json = JSON.parse(stdoutChunks.join("").trim());
+    const written = fs.readFileSync(path.join(vault, json.path), "utf-8");
+    // The uid the gate validated is the uid on disk (and in the path/filename).
+    expect(written).toContain(`exo__Asset_uid: ${json.uuid}`);
+    expect(path.basename(json.path)).toBe(`${json.uuid}.md`);
+  });
+});

--- a/packages/cli/tests/integration/create-validate-shacl.integration.test.ts
+++ b/packages/cli/tests/integration/create-validate-shacl.integration.test.ts
@@ -42,6 +42,14 @@ const CLASS_UID = "1b20a8f0-d745-4e93-91db-4531b3df120e";
 const COUNT_PROP_UID = "bbb22222-2222-2222-2222-222222222222";
 /** A PRE-EXISTING asset that already violates the shape (never our candidate). */
 const PREEXISTING_BAD_UID = "22222222-bbbb-2222-bbbb-222222222222";
+/**
+ * A DOMAINLESS property-def: it adds a known property NAME (so the
+ * RFC-430e84f1 name guard passes) but NO shape (ShapeLoader skips a domainless
+ * property), and it is one of the converter's OPTIONAL-non-empty invariants —
+ * so an EMPTY value makes the candidate unindexable without adding a
+ * SHACL constraint.
+ */
+const STATUS_PROP_UID = "ccc33333-3333-3333-3333-333333333333";
 /** `exo__Property` metaclass — makes `ems__Task_count` a known property NAME. */
 const PROPERTY_METACLASS_UID = "38277bfa-d7f9-4a75-b856-b23276ab0db3";
 /** `exo__Class` metaclass — for the `ems__Task` class-def. */
@@ -51,6 +59,7 @@ const CLASS_METACLASS_UID = "8619c4fc-64f1-4869-b17e-e34186cacca9";
 const FIXTURE_BASENAMES = new Set([
   `${CLASS_UID}.md`,
   `${COUNT_PROP_UID}.md`,
+  `${STATUS_PROP_UID}.md`,
   `${PREEXISTING_BAD_UID}.md`,
 ]);
 
@@ -105,6 +114,18 @@ function buildFixtureVault(vault: string): void {
       exo__Property_domain: '"[[ems__Task]]"',
       exo__Property_range: "http://www.w3.org/2001/XMLSchema#integer",
       exo__Property_severity: "sh:Violation",
+    }),
+  );
+
+  // Domainless property-def → a KNOWN name, but no shape (ShapeLoader skips a
+  // domainless property), so an empty value trips the converter's
+  // EMPTY_OPTIONAL_PROPERTY invariant rather than any SHACL constraint.
+  fs.writeFileSync(
+    path.join(tbox, `${STATUS_PROP_UID}.md`),
+    md({
+      exo__Asset_uid: STATUS_PROP_UID,
+      exo__Instance_class: `"[[${PROPERTY_METACLASS_UID}|exo__Property]]"`,
+      exo__Asset_label: "ems__Effort_status",
     }),
   );
 
@@ -255,6 +276,24 @@ describe("W3: `cli create --validate` — opt-in pre-write SHACL-lite conformanc
     expect(json.uuid).toMatch(
       /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i,
     );
+  });
+
+  it(`--validate reports an UNINDEXABLE candidate as a structured violation, not a raw crash @req:${REQ}`, async () => {
+    // An empty optional property makes `convertVault` SKIP the file entirely
+    // (#2997 two-phase commit) → zero triples → invisible to every query /
+    // layout / graph relation. Calling the converter directly would instead
+    // throw a raw `Literal value cannot be empty`. The gate must surface a
+    // structured, machine-readable verdict and write nothing.
+    await runCreate(["--property", "ems__Effort_status=", "--validate"]);
+
+    expect(exitCodes).not.toContain(0);
+    const stderr = errorSpy.mock.calls.flat().join("\n");
+    expect(stderr).toContain("SHACL-lite validation failed");
+    expect(stderr).toContain("ems__Effort_status");
+    expect(stderr).toContain("SKIPPED by the indexer");
+    expect(stderr).not.toContain("Literal value cannot be empty");
+    expect(createdAssetCount()).toBe(0);
+    expect(stdoutChunks.join("")).toBe("");
   });
 
   it(`the validated bytes are the bytes written — uid + timestamps are pinned across the gate @req:${REQ}`, async () => {

--- a/packages/cli/tests/unit/commands/create.test.ts
+++ b/packages/cli/tests/unit/commands/create.test.ts
@@ -57,6 +57,12 @@ jest.unstable_mockModule("@kitelev/exocortex-core", () => ({
   // #3800: NodeFsAdapter (in the graph) now imports this. Not exercised here
   // (only option registration) → a stub satisfies the ESM named-import binding.
   parseYamlFrontmatterTolerant: jest.fn(),
+  // W3 (`create --validate`): create.ts pins the uid + clock before the
+  // pre-write SHACL gate so the validated bytes are the written bytes. Never
+  // invoked here (no `--validate` in these option-registration tests) → a
+  // shape-stub satisfies the ESM named-import binding.
+  liveClock: jest.fn(() => ({ now: () => new Date(0) })),
+  liveUidGenerator: jest.fn(() => ({ next: () => "00000000-0000-0000-0000-000000000000" })),
 }));
 
 // Mock fs-extra (NodeFsAdapter dependency)
@@ -212,8 +218,16 @@ describe("Issue #2333: create command", () => {
     expect(option!.mandatory).toBeFalsy();
   });
 
-  it("should register exactly 14 options", () => {
+  it("should register exactly 15 options", () => {
     const cmd = createCommand();
-    expect(cmd.options).toHaveLength(14);
+    // 15th = `--validate` (W3: opt-in pre-write SHACL-lite conformance gate).
+    expect(cmd.options).toHaveLength(15);
+  });
+
+  it("should register --validate as an optional opt-in flag", () => {
+    const cmd = createCommand();
+    const option = cmd.options.find((o) => o.long === "--validate");
+    expect(option).toBeDefined();
+    expect(option!.mandatory).toBeFalsy();
   });
 });


### PR DESCRIPTION
## What

Adds an **opt-in `--validate` flag to `exocortex-cli create`** that runs the SAME SHACL-lite
conformance check the Write-path PreToolUse hook runs — **before** the write and **scoped to the
new asset**. A non-conformant candidate is refused and **no file is created**.

Project `38800c80` **W3** (RFC `7c7859d1`) — "Опц. inline-SHACL `--validate` в `create` (закрыть
последний hook-gap CLI-пути)".

## Why

A CLI `create` runs through Bash, so the PreToolUse Write/Edit hooks never fire. `create` already
re-implements **three of the four** guarantees those hooks give:

| Guarantee | Write path (hook) | CLI `create` |
|---|---|---|
| Co-location by `exo__Asset_isDefinedBy` | `co-location-enforce.sh` | ✅ #3520 / #3934 |
| Dangling wikilink **VALUE** rejection | `validate-wikilinks.sh` | ✅ `WikilinkValidator` |
| Unknown property **NAME** rejection | — | ✅ RFC 430e84f1 (req `40a9a81b`) |
| **SHACL-lite conformance** | `validate-asset.sh` | ❌ → ✅ **this PR** |

The `ShapeRegistry` `create` already loads was used **only** for cardinality-aware property
*serialization* (#3099/#3179), never for validation. This closes the gap.

## Design

- **Reuse, do not re-implement.** The verdict comes from the very functions
  `validate schema --shapes-mode` uses (`runShapesValidation` = `ShapeLoader.loadFromRDFGraph` +
  `TripleClassHierarchy`, then `applyLegacyExceptionFilter`) → the CLI verdict is *by construction*
  identical to the hook's, and a shapes-semantics change lands in both at once.
- **Pre-write, not write-then-rollback.** The candidate is built in memory (`buildAsset` — the exact
  bytes a write would produce), parsed with the SAME tolerant YAML parser
  `FileSystemVaultAdapter.getFrontmatter` uses, and converted through the production
  `convertNoteFromFrontmatter`. The uid + clock are **pinned first**, so the bytes validated are the
  bytes written (`dry-run-preview-not-real-output`). Strictly better than the hook, which must
  materialise a temp file inside the vault to get its verdict.
- **Candidate-scoped** (load-bearing): without the focus-node filter every create would fail on any
  vault that already has violations elsewhere. Mirrors the hook's temp-file filter (#3245).
- **Severity parity**: only `sh:Violation` gates; `sh:Warning` (open-world unresolvable /
  cross-vault / symbolic refs, #3488) is surfaced on stderr but never blocks.
- **Opt-in, default OFF**: the validator is **lazily imported** inside the flag branch, so the
  default path neither loads the shapes/SPARQL module graph nor changes behaviour. Every validation
  message goes to **stderr** so stdout stays exactly one `{uuid,path,label}` JSON document.
- Composes with `--dry-run` (validates the preview, writes nothing either way).

## Revert-verify

Type-preserving Edit-break of the gate (`throw new ShaclConformanceError(...)` →
`void new ShaclConformanceError(...)`):

```
✕ --validate REFUSES a non-conformant candidate BEFORE writing        ← RED
✓ --validate ACCEPTS a conformant candidate (vault has violations)    ← GREEN (control)
✓ WITHOUT --validate the gate never runs (default OFF)                ← GREEN (control)
✕ --dry-run --validate refuses a non-conformant candidate             ← RED
✓ --dry-run --validate passes a conformant candidate                  ← GREEN (control)
✓ the validated bytes are the bytes written (uid/timestamps pinned)   ← GREEN (control)
Tests: 2 failed, 4 passed
```

Restored → **6/6 GREEN**. Exactly the 2 gate scenarios flip; the 4 negative controls hold in both
states, proving the delta is the candidate-scoped gate and not a blanket refusal.

## Real-vault dogfood (vault-exodev, ~140k triples, `--dry-run` → nothing written)

**Conformant** → `exit 0`, stdout is one clean JSON line, **zero false positives** despite the full
production vault:

```
{"uuid":"743849d9-…","path":"assetspaces/kitelev/exoas-exodev/exodev/743849d9-….md",…}
```

**Non-conformant** (`ems__Effort_status` pointing at an `ems__Project` instead of an
`ems__EffortStatus`) → `exit 2`, **nothing written**:

```
❌ ShaclConformanceError: SHACL-lite validation failed for the new asset — nothing was written.
1 violation(s) in assetspaces/kitelev/exoas-exodev/exodev/b6ac8002-….md:
  • ems__Effort_status (class): sh:class violation: … does not conform to expected class
    https://exocortex.my/ontology/ems#EffortStatus
📋 Context:
  violations: [{"propertyPath":"ems__Effort_status","propertyIri":"…#Effort_status", …}]
```

The error names the **frontmatter KEY** the caller typed (`ems__Effort_status`), not the internal
IRI, plus a machine-readable `{ path, violations }` context an agent can auto-correct from —
exactly the class of typo an LLM agent makes. Verified afterwards: **0 files on disk** for both
candidate uids, vault SHACL still `conforms: true` / 0 violations.

## Test / gate status

- New `@req` integration test: **6/6** (production-shape — real `createCommand()` over a temp vault
  with genuine shapes **and a pre-existing violating asset**).
- Full `packages/cli` suite: **1890 passed**, 1 pre-existing failure
  (`sparql-exo003.integration.test.ts` — fails identically on origin/main with my changes stashed;
  causally isolated).
- `npm run check:types` → **0 errors**. `npm run lint` → clean.
- `lint`-job guard scripts: shard-assignments ✅ · test-antipatterns ratchet ✅ (`55/55`, no
  recurrence) · coverage-monotonic ✅.
- Bumped the brittle `create.test.ts` option count 14 → 15 (additive) + added a `--validate`
  registration assertion.
- `packages/cli/dist/index.js` deliberately **not** committed (vestigial tracked artifact rebuilt
  fresh by CI/`prepublishOnly`; committing a local rebuild is pure minification churn).

Req: dd9ab956-80c7-45c6-b71b-5834f50ce6f8
