### PR TITLE
feat(cli): MCP-MVP — `exocortex mcp` stdio server (create_asset / create_effort + inline-SHACL)

### DIFF
--- a/packages/cli/src/commands/mcp.ts
+++ b/packages/cli/src/commands/mcp.ts
@@ -1,0 +1,85 @@
+import { Command } from "commander";
+import { createInterface } from "readline";
+import {
+  McpServer,
+  JSON_RPC_PARSE_ERROR,
+  type JsonRpcMessage,
+  type JsonRpcResponse,
+} from "../mcp/McpServer.js";
+import { createSelfCliRunner } from "../mcp/cliRunner.js";
+
+interface McpCommandOptions {
+  entry?: string;
+}
+
+/**
+ * Drive an {@link McpServer} over newline-delimited JSON on stdio.
+ *
+ * Exported for testing: the caller supplies the streams, so the loop can be
+ * exercised without spawning a process.
+ */
+export async function runStdioServer(
+  server: McpServer,
+  input: NodeJS.ReadableStream,
+  write: (line: string) => void,
+): Promise<void> {
+  const rl = createInterface({ input, crlfDelay: Infinity });
+
+  for await (const rawLine of rl) {
+    const line = rawLine.trim();
+    if (line.length === 0) {
+      continue;
+    }
+
+    let message: JsonRpcMessage;
+    try {
+      message = JSON.parse(line) as JsonRpcMessage;
+    } catch {
+      const parseError: JsonRpcResponse = {
+        jsonrpc: "2.0",
+        id: null,
+        error: {
+          code: JSON_RPC_PARSE_ERROR,
+          message: "Parse error: invalid JSON",
+        },
+      };
+      write(JSON.stringify(parseError) + "\n");
+      continue;
+    }
+
+    const response = await server.handle(message);
+    if (response !== null) {
+      write(JSON.stringify(response) + "\n");
+    }
+  }
+}
+
+/**
+ * `exocortex mcp` — MCP (Model Context Protocol) stdio server exposing the
+ * Exocortex asset-creation tools (project 38800c80 W6, req 264ccef6).
+ *
+ * This is a TRANSPORT entry-point, not a domain verb: it adds no new creation
+ * semantics. Each tool re-invokes this same CLI with an explicit argument
+ * vector (no shell), so every guarantee of the creation path is inherited and
+ * no caller-supplied value can be reinterpreted by a shell.
+ */
+export function mcpCommand(version?: string): Command {
+  return new Command("mcp")
+    .description(
+      "Run an MCP (Model Context Protocol) stdio server exposing create_asset / create_effort tools backed by this CLI",
+    )
+    .option(
+      "--entry <path>",
+      "Path to the CLI entry script the tools invoke (defaults to this process's script)",
+    )
+    .action(async (options: McpCommandOptions) => {
+      const entryPath = options.entry ?? process.argv[1];
+      const server = new McpServer({
+        runCli: createSelfCliRunner(entryPath),
+        version: version ?? "unknown",
+      });
+      await runStdioServer(server, process.stdin, (line) =>
+        process.stdout.write(line),
+      );
+    });
+}

--- a/packages/cli/src/commands/mcp.ts
+++ b/packages/cli/src/commands/mcp.ts
@@ -3,6 +3,7 @@ import { createInterface } from "readline";
 import {
   McpServer,
   JSON_RPC_PARSE_ERROR,
+  JSON_RPC_INTERNAL_ERROR,
   type JsonRpcMessage,
   type JsonRpcResponse,
 } from "../mcp/McpServer.js";
@@ -47,7 +48,26 @@ export async function runStdioServer(
       continue;
     }
 
-    const response = await server.handle(message);
+    // The server is long-lived: no single message may terminate it. Any
+    // unexpected throw (a hostile payload shape, a runner that rejects) becomes
+    // an internal-error response instead of escaping the loop.
+    let response: JsonRpcResponse | null;
+    try {
+      response = await server.handle(message);
+    } catch (error) {
+      response = {
+        jsonrpc: "2.0",
+        id:
+          typeof message?.id === "string" || typeof message?.id === "number"
+            ? message.id
+            : null,
+        error: {
+          code: JSON_RPC_INTERNAL_ERROR,
+          message: `Internal error: ${error instanceof Error ? error.message : String(error)}`,
+        },
+      };
+    }
+
     if (response !== null) {
       write(JSON.stringify(response) + "\n");
     }

--- a/packages/cli/src/mcp/McpServer.ts
+++ b/packages/cli/src/mcp/McpServer.ts
@@ -3,6 +3,7 @@ import {
   MCP_TOOLS,
   buildCreateAssetArgs,
   buildCreateEffortArgs,
+  invalidCreateAssetShape,
   type CreateAssetInput,
   type CreateEffortInput,
 } from "./tools.js";
@@ -17,6 +18,7 @@ export const MCP_PROTOCOL_VERSION = "2024-11-05";
 export const JSON_RPC_PARSE_ERROR = -32700;
 export const JSON_RPC_INVALID_REQUEST = -32600;
 export const JSON_RPC_METHOD_NOT_FOUND = -32601;
+export const JSON_RPC_INTERNAL_ERROR = -32603;
 
 /** A decoded incoming JSON-RPC message (request OR notification). */
 export interface JsonRpcMessage {
@@ -108,6 +110,25 @@ export class McpServer {
    *   notification (JSON-RPC forbids answering those).
    */
   async handle(message: JsonRpcMessage): Promise<JsonRpcResponse | null> {
+    // A bare `null` / scalar / array line is valid JSON, so it survives the
+    // transport's parse guard and reaches here. Property access on it would
+    // throw and — since the stdio loop is long-lived — take the whole server
+    // down with one malformed line.
+    if (
+      typeof message !== "object" ||
+      message === null ||
+      Array.isArray(message)
+    ) {
+      return {
+        jsonrpc: "2.0",
+        id: null,
+        error: {
+          code: JSON_RPC_INVALID_REQUEST,
+          message: "Invalid request: expected a JSON-RPC object",
+        },
+      };
+    }
+
     const id = message.id;
     const isNotification = id === undefined;
 
@@ -190,6 +211,10 @@ export class McpServer {
           `create_asset: missing required argument(s): ${missing.join(", ")}`,
           true,
         );
+      }
+      const badShape = invalidCreateAssetShape(args);
+      if (badShape !== null) {
+        return textResult(`create_asset: ${badShape}`, true);
       }
       argv = buildCreateAssetArgs(args as unknown as CreateAssetInput);
     } else if (name === "create_effort") {

--- a/packages/cli/src/mcp/McpServer.ts
+++ b/packages/cli/src/mcp/McpServer.ts
@@ -1,0 +1,224 @@
+import type { CliRunner } from "./cliRunner.js";
+import {
+  MCP_TOOLS,
+  buildCreateAssetArgs,
+  buildCreateEffortArgs,
+  type CreateAssetInput,
+  type CreateEffortInput,
+} from "./tools.js";
+
+/**
+ * MCP revision this server speaks. The handshake echoes it back so a client can
+ * detect a mismatch.
+ */
+export const MCP_PROTOCOL_VERSION = "2024-11-05";
+
+/** JSON-RPC 2.0 error codes used by this server. */
+export const JSON_RPC_PARSE_ERROR = -32700;
+export const JSON_RPC_INVALID_REQUEST = -32600;
+export const JSON_RPC_METHOD_NOT_FOUND = -32601;
+
+/** A decoded incoming JSON-RPC message (request OR notification). */
+export interface JsonRpcMessage {
+  jsonrpc?: string;
+  id?: string | number | null;
+  method?: string;
+  params?: Record<string, unknown>;
+}
+
+/** A JSON-RPC response this server writes back. */
+export interface JsonRpcResponse {
+  jsonrpc: "2.0";
+  id: string | number | null;
+  result?: unknown;
+  error?: { code: number; message: string };
+}
+
+/** MCP `tools/call` result payload. */
+export interface McpToolResult {
+  content: { type: "text"; text: string }[];
+  isError?: boolean;
+}
+
+export interface McpServerDeps {
+  runCli: CliRunner;
+  /** CLI version, reported in the `initialize` handshake. */
+  version: string;
+}
+
+function textResult(text: string, isError = false): McpToolResult {
+  return isError
+    ? { content: [{ type: "text", text }], isError: true }
+    : { content: [{ type: "text", text }] };
+}
+
+/**
+ * Parse the LAST non-empty stdout line as JSON.
+ *
+ * `create` and `apply --json` each emit exactly one JSON document on stdout
+ * (all diagnostics go to stderr), but reading the last line keeps the parse
+ * robust if a future command prefixes a banner.
+ */
+function parseLastJsonLine(stdout: string): unknown {
+  const lines = stdout
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+  const last = lines[lines.length - 1];
+  if (last === undefined) {
+    return undefined;
+  }
+  try {
+    return JSON.parse(last);
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Return the names of required string fields that are missing or blank.
+ *
+ * Checked before building the argv so the agent gets a precise, structured
+ * complaint instead of the CLI failing on a literal `undefined` argument.
+ */
+function missingStringFields(
+  args: Record<string, unknown>,
+  required: readonly string[],
+): string[] {
+  return required.filter((field) => {
+    const value = args[field];
+    return typeof value !== "string" || value.trim().length === 0;
+  });
+}
+
+/**
+ * MCP server for the Exocortex asset-creation tools (project 38800c80 W6).
+ *
+ * Transport-agnostic: {@link handle} maps one decoded JSON-RPC message to a
+ * response (or `null` for a notification), so it is driven identically by the
+ * stdio loop and by tests.
+ */
+export class McpServer {
+  constructor(private readonly deps: McpServerDeps) {}
+
+  /**
+   * Handle one decoded message.
+   *
+   * @returns the response to write, or `null` when the message is a
+   *   notification (JSON-RPC forbids answering those).
+   */
+  async handle(message: JsonRpcMessage): Promise<JsonRpcResponse | null> {
+    const id = message.id;
+    const isNotification = id === undefined;
+
+    if (typeof message.method !== "string") {
+      if (isNotification) {
+        return null;
+      }
+      return {
+        jsonrpc: "2.0",
+        id: id ?? null,
+        error: {
+          code: JSON_RPC_INVALID_REQUEST,
+          message: "Invalid request: missing method",
+        },
+      };
+    }
+
+    if (isNotification) {
+      // `notifications/initialized` and friends are acknowledged by silence.
+      return null;
+    }
+
+    const responseId = id ?? null;
+
+    switch (message.method) {
+      case "initialize":
+        return {
+          jsonrpc: "2.0",
+          id: responseId,
+          result: {
+            protocolVersion: MCP_PROTOCOL_VERSION,
+            capabilities: { tools: {} },
+            serverInfo: { name: "exocortex", version: this.deps.version },
+          },
+        };
+
+      case "ping":
+        return { jsonrpc: "2.0", id: responseId, result: {} };
+
+      case "tools/list":
+        return { jsonrpc: "2.0", id: responseId, result: { tools: MCP_TOOLS } };
+
+      case "tools/call":
+        return {
+          jsonrpc: "2.0",
+          id: responseId,
+          result: await this.callTool(message.params ?? {}),
+        };
+
+      default:
+        return {
+          jsonrpc: "2.0",
+          id: responseId,
+          error: {
+            code: JSON_RPC_METHOD_NOT_FOUND,
+            message: `Method not found: ${message.method}`,
+          },
+        };
+    }
+  }
+
+  /**
+   * Dispatch a `tools/call`.
+   *
+   * A bad tool name or a failing CLI run is reported as an MCP tool error
+   * (`isError: true`) — never as a JSON-RPC protocol error and never as a
+   * thrown exception, so the server survives every tool failure.
+   */
+  private async callTool(
+    params: Record<string, unknown>,
+  ): Promise<McpToolResult> {
+    const name = params.name;
+    const args = (params.arguments ?? {}) as Record<string, unknown>;
+
+    let argv: string[];
+    if (name === "create_asset") {
+      const missing = missingStringFields(args, ["vault", "class", "label"]);
+      if (missing.length > 0) {
+        return textResult(
+          `create_asset: missing required argument(s): ${missing.join(", ")}`,
+          true,
+        );
+      }
+      argv = buildCreateAssetArgs(args as unknown as CreateAssetInput);
+    } else if (name === "create_effort") {
+      const missing = missingStringFields(args, ["vault", "command", "target"]);
+      if (missing.length > 0) {
+        return textResult(
+          `create_effort: missing required argument(s): ${missing.join(", ")}`,
+          true,
+        );
+      }
+      argv = buildCreateEffortArgs(args as unknown as CreateEffortInput);
+    } else {
+      return textResult(`Unknown tool: ${String(name)}`, true);
+    }
+
+    const run = await this.deps.runCli(argv);
+
+    if (run.exitCode !== 0) {
+      const detail =
+        run.stderr.trim() || run.stdout.trim() || "(no diagnostic output)";
+      return textResult(
+        `exocortex-cli exited ${run.exitCode}\n${detail}`,
+        true,
+      );
+    }
+
+    const parsed = parseLastJsonLine(run.stdout);
+    return textResult(
+      parsed === undefined ? run.stdout.trim() : JSON.stringify(parsed),
+    );
+  }
+}

--- a/packages/cli/src/mcp/cliRunner.ts
+++ b/packages/cli/src/mcp/cliRunner.ts
@@ -1,0 +1,64 @@
+import { execFile } from "child_process";
+
+/**
+ * Result of one wrapped `exocortex-cli` invocation.
+ *
+ * The runner NEVER rejects: a non-zero exit is data (`exitCode`), not an
+ * exception, so a failing CLI call becomes an MCP tool error rather than a
+ * crash of the long-lived stdio server (req 264ccef6, design point 6).
+ */
+export interface CliRunResult {
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+}
+
+/**
+ * Executes the CLI with an explicit argument VECTOR.
+ *
+ * The vector is the whole point of the MCP server: because the arguments are
+ * passed as an array to `execFile` (which does NOT spawn a shell), no value can
+ * be reinterpreted — `$`, backticks, `()`, quotes, globs and newlines all reach
+ * the CLI byte-identically. This is the transport defect class the MCP surface
+ * exists to remove.
+ */
+export type CliRunner = (args: readonly string[]) => Promise<CliRunResult>;
+
+/**
+ * 32 MiB — a `create` body or an `apply --json` envelope is orders of magnitude
+ * smaller, but a generous ceiling keeps a large body from truncating silently.
+ */
+const MAX_BUFFER_BYTES = 32 * 1024 * 1024;
+
+/**
+ * Build a {@link CliRunner} that re-invokes THIS CLI as a child process.
+ *
+ * Running the real CLI (rather than re-implementing creation in-process) is what
+ * makes the MCP tools inherit every guarantee the creation path already has —
+ * co-location by `exo__Asset_isDefinedBy`, dangling-wikilink VALUE rejection,
+ * unknown-property-NAME rejection (req 40a9a81b) and SHACL-lite conformance
+ * (req dd9ab956) — with zero changes to `create.ts` / `apply.ts`.
+ *
+ * @param entryPath Path to the CLI entry script (normally `process.argv[1]`).
+ */
+export function createSelfCliRunner(entryPath: string): CliRunner {
+  return (args) =>
+    new Promise<CliRunResult>((resolvePromise) => {
+      execFile(
+        process.execPath,
+        [entryPath, ...args],
+        { maxBuffer: MAX_BUFFER_BYTES },
+        (error, stdout, stderr) => {
+          let exitCode = 0;
+          if (error) {
+            const raw = (error as { code?: unknown }).code;
+            // `code` is the child's exit status for a normal non-zero exit; a
+            // spawn failure (ENOENT, killed by signal) surfaces as a string or
+            // undefined — normalise those to 1 so callers only branch on 0/non-0.
+            exitCode = typeof raw === "number" ? raw : 1;
+          }
+          resolvePromise({ stdout, stderr, exitCode });
+        },
+      );
+    });
+}

--- a/packages/cli/src/mcp/tools.ts
+++ b/packages/cli/src/mcp/tools.ts
@@ -1,0 +1,213 @@
+/**
+ * MCP tool definitions and their argv builders (project 38800c80 W6,
+ * req 264ccef6).
+ *
+ * The builders are pure and exported so tests can assert the EXACT argument
+ * vector — the vector is the contract that makes shell metacharacters
+ * un-interpretable.
+ */
+
+/** A tool as advertised by `tools/list`. */
+export interface McpToolDefinition {
+  name: string;
+  description: string;
+  inputSchema: Record<string, unknown>;
+}
+
+/** Input accepted by the `create_asset` tool. */
+export interface CreateAssetInput {
+  vault: string;
+  class: string;
+  label: string;
+  properties?: Record<string, string | string[]>;
+  aliases?: string[];
+  body?: string;
+  /** `false` → `--no-status`; a string → `--status <name>`; omitted → CLI default. */
+  status?: string | false;
+  /** Defaults to TRUE on the MCP surface (req 264ccef6, design point 5). */
+  validate?: boolean;
+  dryRun?: boolean;
+}
+
+/** Input accepted by the `create_effort` tool. */
+export interface CreateEffortInput {
+  vault: string;
+  command: string;
+  target: string;
+  /** `userInput` for the grounding, serialised into `--input <json>`. */
+  input?: Record<string, unknown>;
+  dryRun?: boolean;
+}
+
+/**
+ * Build the argv for `create_asset` → the generic `create` verb.
+ *
+ * Every caller-supplied value becomes its OWN argv element, so no character in
+ * a label, body or property value is ever interpreted.
+ */
+export function buildCreateAssetArgs(input: CreateAssetInput): string[] {
+  const args: string[] = [
+    "create",
+    "--vault",
+    input.vault,
+    "--class",
+    input.class,
+    "--label",
+    input.label,
+  ];
+
+  if (input.aliases && input.aliases.length > 0) {
+    // `--aliases <names...>` is variadic; Commander stops collecting at the next
+    // `--flag`, and every following token we emit is one.
+    args.push("--aliases", ...input.aliases);
+  }
+
+  for (const [key, value] of Object.entries(input.properties ?? {})) {
+    // A repeated key accumulates into a YAML array downstream (#3759), so a
+    // multi-value property is emitted as one `--property` per element.
+    const values = Array.isArray(value) ? value : [value];
+    for (const single of values) {
+      args.push("--property", `${key}=${single}`);
+    }
+  }
+
+  if (input.body !== undefined) {
+    args.push("--body", input.body);
+  }
+
+  if (input.status === false) {
+    args.push("--no-status");
+  } else if (typeof input.status === "string") {
+    args.push("--status", input.status);
+  }
+
+  // Inline-SHACL is ON unless the caller explicitly opts out: the MCP surface is
+  // the agent surface, where landing a non-conformant asset is the expensive
+  // outcome (the CLI keeps `--validate` opt-in for interactive use).
+  if (input.validate !== false) {
+    args.push("--validate");
+  }
+
+  if (input.dryRun) {
+    args.push("--dry-run");
+  }
+
+  return args;
+}
+
+/**
+ * Build the argv for `create_effort` → the HOMOICONIC `apply` path.
+ *
+ * Effort creation is already homoiconic (RFC 7c7859d1 alternative E: the
+ * `Create Task` / `Create Project` exocmd commands), so this tool drives
+ * `apply <cmd> <target> --json --yes` rather than the generic `create`.
+ */
+export function buildCreateEffortArgs(input: CreateEffortInput): string[] {
+  const args: string[] = [
+    "apply",
+    input.command,
+    input.target,
+    "--vault",
+    input.vault,
+    "--json",
+    "--yes",
+  ];
+
+  if (input.input !== undefined) {
+    args.push("--input", JSON.stringify(input.input));
+  }
+
+  if (input.dryRun) {
+    args.push("--dry-run");
+  }
+
+  return args;
+}
+
+const PROPERTY_VALUE_SCHEMA = {
+  oneOf: [{ type: "string" }, { type: "array", items: { type: "string" } }],
+} as const;
+
+/** The two MVP tools advertised by `tools/list`. */
+export const MCP_TOOLS: readonly McpToolDefinition[] = [
+  {
+    name: "create_asset",
+    description:
+      "Create a vault asset through the Exocortex creation pipeline (co-location by exo__Asset_isDefinedBy, dangling-wikilink rejection, unknown-property-name rejection and — by default — SHACL-lite conformance validation before the file is written). Values are passed as an argument vector, so labels, bodies and property values containing $, backticks, quotes, parentheses or newlines are preserved byte-identically.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        vault: { type: "string", description: "Path to the Obsidian vault." },
+        class: {
+          type: "string",
+          description: "Class UUID or short name (e.g. ems__Task).",
+        },
+        label: {
+          type: "string",
+          description: "exo__Asset_label for the new asset.",
+        },
+        properties: {
+          type: "object",
+          description:
+            "Frontmatter properties. A string sets one value; an array of strings sets a multi-value (YAML array) property.",
+          additionalProperties: PROPERTY_VALUE_SCHEMA,
+        },
+        aliases: {
+          type: "array",
+          items: { type: "string" },
+          description: "Additional aliases.",
+        },
+        body: { type: "string", description: "Markdown body of the asset." },
+        status: {
+          type: ["string", "boolean"],
+          description:
+            "ems__Effort_status name for a status-bearing class (e.g. Backlog, Doing). Pass false to create a status-less asset. Omit for the CLI default.",
+        },
+        validate: {
+          type: "boolean",
+          default: true,
+          description:
+            "Run the pre-write SHACL-lite conformance gate. Defaults to true; pass false to skip it.",
+        },
+        dryRun: {
+          type: "boolean",
+          description: "Preview without writing the file.",
+        },
+      },
+      required: ["vault", "class", "label"],
+      additionalProperties: false,
+    },
+  },
+  {
+    name: "create_effort",
+    description:
+      "Create an effort (Task / Project / Area / …) by applying a homoiconic Exocortex command to a target asset — the canonical effort-creation path. Returns the {command,target,created:[{uuid,path,label}]} envelope.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        vault: { type: "string", description: "Path to the Obsidian vault." },
+        command: {
+          type: "string",
+          description:
+            "Command cliName slug (e.g. create-task) or command UUID.",
+        },
+        target: {
+          type: "string",
+          description:
+            "Vault-relative path to the target asset the command is applied to.",
+        },
+        input: {
+          type: "object",
+          description:
+            'userInput for the command\'s grounding (serialised as JSON), e.g. {"value":"New label"}.',
+        },
+        dryRun: {
+          type: "boolean",
+          description: "Preview without writing.",
+        },
+      },
+      required: ["vault", "command", "target"],
+      additionalProperties: false,
+    },
+  },
+];

--- a/packages/cli/src/mcp/tools.ts
+++ b/packages/cli/src/mcp/tools.ts
@@ -40,6 +40,48 @@ export interface CreateEffortInput {
 }
 
 /**
+ * Reject `create_asset` arguments whose SHAPE the schema forbids.
+ *
+ * Without this, a non-string property value stringifies into the vault as
+ * `[object Object]`, and a bare string passed as `aliases` spreads one argv
+ * element PER CHARACTER. Both are silent corruption, so they fail loud with a
+ * message naming the offending field.
+ *
+ * @returns an error message, or `null` when the shape is acceptable.
+ */
+export function invalidCreateAssetShape(
+  args: Record<string, unknown>,
+): string | null {
+  const aliases = args.aliases;
+  if (aliases !== undefined) {
+    if (!Array.isArray(aliases) || aliases.some((a) => typeof a !== "string")) {
+      return "`aliases` must be an array of strings";
+    }
+  }
+
+  const properties = args.properties;
+  if (properties !== undefined) {
+    if (
+      typeof properties !== "object" ||
+      properties === null ||
+      Array.isArray(properties)
+    ) {
+      return "`properties` must be an object";
+    }
+    for (const [key, value] of Object.entries(
+      properties as Record<string, unknown>,
+    )) {
+      const values = Array.isArray(value) ? value : [value];
+      if (values.some((single) => typeof single !== "string")) {
+        return `property \`${key}\` must be a string or an array of strings`;
+      }
+    }
+  }
+
+  return null;
+}
+
+/**
  * Build the argv for `create_asset` → the generic `create` verb.
  *
  * Every caller-supplied value becomes its OWN argv element, so no character in
@@ -56,10 +98,16 @@ export function buildCreateAssetArgs(input: CreateAssetInput): string[] {
     input.label,
   ];
 
-  if (input.aliases && input.aliases.length > 0) {
-    // `--aliases <names...>` is variadic; Commander stops collecting at the next
-    // `--flag`, and every following token we emit is one.
-    args.push("--aliases", ...input.aliases);
+  // `--aliases <names...>` is VARIADIC: Commander consumes the first token
+  // unconditionally but parses every subsequent `--`-prefixed token as a real
+  // flag. Emitting the whole array after one `--aliases` would therefore let a
+  // caller-supplied alias inject CLI options (`--vault`, `--body-file`,
+  // `--skip-wikilink-validation`, …) — argument injection into the CLI's own
+  // parser, a second interpretation layer that `execFile` does not close.
+  // One `--aliases` per value keeps each alias in the absorbed-first-token slot,
+  // exactly as the `--property` loop below already does.
+  for (const alias of input.aliases ?? []) {
+    args.push("--aliases", alias);
   }
 
   for (const [key, value] of Object.entries(input.properties ?? {})) {

--- a/packages/cli/src/mcp/tools.ts
+++ b/packages/cli/src/mcp/tools.ts
@@ -59,6 +59,21 @@ export function invalidCreateAssetShape(
     }
   }
 
+  // A non-string `body` is string-coerced by execFile and lands in the vault as
+  // `[object Object]`; a non-string, non-`false` `status` matches neither branch
+  // of the builder and is SILENTLY dropped (the asset quietly gets the default).
+  // Both are the same silent-corruption class as the checks below.
+  if (args.body !== undefined && typeof args.body !== "string") {
+    return "`body` must be a string";
+  }
+  if (
+    args.status !== undefined &&
+    typeof args.status !== "string" &&
+    args.status !== false
+  ) {
+    return "`status` must be a status name or false";
+  }
+
   const properties = args.properties;
   if (properties !== undefined) {
     if (

--- a/packages/cli/src/program.ts
+++ b/packages/cli/src/program.ts
@@ -25,6 +25,7 @@ import { exosyncParityCommand } from "./commands/exosync-parity.js";
 import { exosyncCommand } from "./commands/exosync-sync.js";
 import { requirementsCommand } from "./commands/requirements.js";
 import { cacheCommand } from "./commands/cache.js";
+import { mcpCommand } from "./commands/mcp.js";
 
 // Version injected at build time by esbuild (see esbuild.config.mjs)
 declare const __CLI_VERSION__: string;
@@ -115,6 +116,12 @@ export function createProgram(version?: string): Command {
   // Issue #3981 — SPARQL query-result cache maintenance (clear / stats).
   // Complements the automatic size/count-cap eviction in QueryResultCache.set.
   program.addCommand(cacheCommand());
+
+  // Project 38800c80 W6 / req 264ccef6 — MCP stdio server (TRANSPORT entry-point,
+  // not a domain verb): exposes create_asset / create_effort tools that re-invoke
+  // this CLI with an argument VECTOR, so agent-supplied labels, bodies and
+  // property values are never reinterpreted by a shell.
+  program.addCommand(mcpCommand(version ?? __CLI_VERSION__));
 
   return program;
 }

--- a/packages/cli/tests/integration/mcp-server.test.ts
+++ b/packages/cli/tests/integration/mcp-server.test.ts
@@ -232,7 +232,37 @@ describe("exocortex-cli mcp — MCP stdio server", () => {
     expect(badAliases.isError).toBe(true);
     expect(badAliases.content[0].text).toContain("aliases");
 
-    expect(calls).toHaveLength(0);
+    // Would otherwise be string-coerced by execFile into `[object Object]` and
+    // written into the vault as the asset's body.
+    const badBody = await callTool(server, "create_asset", {
+      vault: "/v",
+      class: "ems__Task",
+      label: "L",
+      body: { a: 1 },
+    });
+    expect(badBody.isError).toBe(true);
+    expect(badBody.content[0].text).toContain("body");
+
+    // Would otherwise match neither builder branch and be SILENTLY dropped.
+    const badStatus = await callTool(server, "create_asset", {
+      vault: "/v",
+      class: "ems__Task",
+      label: "L",
+      status: 42,
+    });
+    expect(badStatus.isError).toBe(true);
+    expect(badStatus.content[0].text).toContain("status");
+
+    // `status: false` remains legitimate (→ --no-status).
+    const okStatus = await callTool(server, "create_asset", {
+      vault: "/v",
+      class: "ems__Task",
+      label: "L",
+      status: false,
+    });
+    expect(okStatus.isError).toBeUndefined();
+    expect(calls).toHaveLength(1);
+    expect(calls[0].args).toContain("--no-status");
   });
 
   it("@req:264ccef6-4737-4076-95d8-053326c9ee1d create_asset enables inline-SHACL by default and omits it only when validate is false", async () => {

--- a/packages/cli/tests/integration/mcp-server.test.ts
+++ b/packages/cli/tests/integration/mcp-server.test.ts
@@ -8,6 +8,8 @@ import {
   MCP_PROTOCOL_VERSION,
   JSON_RPC_METHOD_NOT_FOUND,
   JSON_RPC_PARSE_ERROR,
+  JSON_RPC_INVALID_REQUEST,
+  JSON_RPC_INTERNAL_ERROR,
   type JsonRpcResponse,
   type McpToolResult,
 } from "../../src/mcp/McpServer.js";
@@ -169,6 +171,70 @@ describe("exocortex-cli mcp — MCP stdio server", () => {
     expect(args).toContain("p__x=value with $ and ` and (parens)");
   });
 
+  it("@req:264ccef6-4737-4076-95d8-053326c9ee1d a flag-shaped alias cannot inject a CLI option into the create invocation", async () => {
+    const { server, calls } = makeServer();
+
+    await callTool(server, "create_asset", {
+      vault: "/legit",
+      class: "ems__Task",
+      label: "L",
+      // A hostile alias array: without one `--aliases` per value, Commander's
+      // variadic parsing would treat these as REAL flags and redirect the write
+      // to another vault while disabling wikilink validation.
+      aliases: [
+        "RealAlias",
+        "--vault",
+        "/attacker",
+        "--skip-wikilink-validation",
+      ],
+    });
+
+    const args = calls[0].args;
+
+    // The only `--vault` that Commander can read as a FLAG is the caller's, in
+    // the fixed head position; the vault is never redirected.
+    expect(args.slice(0, 3)).toEqual(["create", "--vault", "/legit"]);
+
+    // Every hostile token sits in the absorbed-first-token slot of its OWN
+    // `--aliases`, so Commander parses it as a value, never as an option.
+    for (const hostile of [
+      "--vault",
+      "/attacker",
+      "--skip-wikilink-validation",
+    ]) {
+      const at = args.lastIndexOf(hostile);
+      expect(at).toBeGreaterThan(0);
+      expect(args[at - 1]).toBe("--aliases");
+    }
+    expect(args.filter((a) => a === "--aliases")).toHaveLength(4);
+  });
+
+  it("@req:264ccef6-4737-4076-95d8-053326c9ee1d malformed argument shapes are refused instead of corrupting the asset", async () => {
+    const { server, calls } = makeServer();
+
+    // Would otherwise serialise as `--property o=[object Object]`.
+    const badProperty = await callTool(server, "create_asset", {
+      vault: "/v",
+      class: "ems__Task",
+      label: "L",
+      properties: { o: { nested: 1 } },
+    });
+    expect(badProperty.isError).toBe(true);
+    expect(badProperty.content[0].text).toContain("`o`");
+
+    // Would otherwise spread one argv element PER CHARACTER.
+    const badAliases = await callTool(server, "create_asset", {
+      vault: "/v",
+      class: "ems__Task",
+      label: "L",
+      aliases: "notanarray",
+    });
+    expect(badAliases.isError).toBe(true);
+    expect(badAliases.content[0].text).toContain("aliases");
+
+    expect(calls).toHaveLength(0);
+  });
+
   it("@req:264ccef6-4737-4076-95d8-053326c9ee1d create_asset enables inline-SHACL by default and omits it only when validate is false", async () => {
     const withDefault = makeServer();
     await callTool(withDefault.server, "create_asset", {
@@ -294,6 +360,47 @@ describe("exocortex-cli mcp — MCP stdio server", () => {
       MCP_PROTOCOL_VERSION,
     );
     expect(JSON.parse(written[1]).error.code).toBe(JSON_RPC_PARSE_ERROR);
+  });
+
+  it("@req:264ccef6-4737-4076-95d8-053326c9ee1d the long-lived loop survives a null line and a throwing runner, still serving later messages", async () => {
+    const exploding = new McpServer({
+      runCli: async () => {
+        throw new Error("spawn exploded");
+      },
+      version: "1.2.3",
+    });
+    const written: string[] = [];
+
+    await runStdioServer(
+      exploding,
+      Readable.from([
+        // Valid JSON, but not an object — property access on it would throw and
+        // terminate the whole server.
+        "null\n",
+        JSON.stringify({
+          jsonrpc: "2.0",
+          id: 2,
+          method: "tools/call",
+          params: {
+            name: "create_asset",
+            arguments: { vault: "/v", class: "c", label: "l" },
+          },
+        }) + "\n",
+        // The session must still be alive to answer this.
+        JSON.stringify({ jsonrpc: "2.0", id: 3, method: "ping" }) + "\n",
+      ]),
+      (line) => written.push(line),
+    );
+
+    expect(written).toHaveLength(3);
+    expect(JSON.parse(written[0]).error.code).toBe(JSON_RPC_INVALID_REQUEST);
+    expect(JSON.parse(written[1]).error.code).toBe(JSON_RPC_INTERNAL_ERROR);
+    // Proof the loop was never killed.
+    expect(JSON.parse(written[2])).toEqual({
+      jsonrpc: "2.0",
+      id: 3,
+      result: {},
+    });
   });
 });
 

--- a/packages/cli/tests/integration/mcp-server.test.ts
+++ b/packages/cli/tests/integration/mcp-server.test.ts
@@ -1,0 +1,347 @@
+import { mkdtempSync, writeFileSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { Readable } from "stream";
+
+import {
+  McpServer,
+  MCP_PROTOCOL_VERSION,
+  JSON_RPC_METHOD_NOT_FOUND,
+  JSON_RPC_PARSE_ERROR,
+  type JsonRpcResponse,
+  type McpToolResult,
+} from "../../src/mcp/McpServer.js";
+import {
+  createSelfCliRunner,
+  type CliRunResult,
+} from "../../src/mcp/cliRunner.js";
+import { runStdioServer } from "../../src/commands/mcp.js";
+
+/**
+ * Requirement 264ccef6 (project 38800c80 W6) — `exocortex-cli mcp` MCP-MVP
+ * stdio server exposing create_asset / create_effort with inline-SHACL.
+ *
+ * The wrapped CLI is a PROCESS boundary, so the fake runner replaces the
+ * process (not any feature logic): argv construction, protocol handling and
+ * result mapping — the whole feature — run for real.
+ */
+
+interface RecordedCall {
+  args: readonly string[];
+}
+
+function makeServer(result: Partial<CliRunResult> = {}) {
+  const calls: RecordedCall[] = [];
+  const runCli = async (args: readonly string[]): Promise<CliRunResult> => {
+    calls.push({ args });
+    return {
+      stdout: result.stdout ?? "{}",
+      stderr: result.stderr ?? "",
+      exitCode: result.exitCode ?? 0,
+    };
+  };
+  const server = new McpServer({ runCli, version: "1.2.3" });
+  return { server, calls, runCli };
+}
+
+async function callTool(
+  server: McpServer,
+  name: string,
+  args: Record<string, unknown>,
+): Promise<McpToolResult> {
+  const response = (await server.handle({
+    jsonrpc: "2.0",
+    id: 7,
+    method: "tools/call",
+    params: { name, arguments: args },
+  })) as JsonRpcResponse;
+  return response.result as McpToolResult;
+}
+
+describe("exocortex-cli mcp — MCP stdio server", () => {
+  it("@req:264ccef6-4737-4076-95d8-053326c9ee1d initialize advertises protocol version, tools capability and serverInfo", async () => {
+    const { server } = makeServer();
+
+    const response = (await server.handle({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "initialize",
+      params: {},
+    })) as JsonRpcResponse;
+
+    expect(response.id).toBe(1);
+    expect(response.result).toEqual({
+      protocolVersion: MCP_PROTOCOL_VERSION,
+      capabilities: { tools: {} },
+      serverInfo: { name: "exocortex", version: "1.2.3" },
+    });
+  });
+
+  it("@req:264ccef6-4737-4076-95d8-053326c9ee1d tools/list advertises exactly create_asset and create_effort with input schemas", async () => {
+    const { server } = makeServer();
+
+    const response = (await server.handle({
+      jsonrpc: "2.0",
+      id: 2,
+      method: "tools/list",
+    })) as JsonRpcResponse;
+
+    const tools = (
+      response.result as {
+        tools: { name: string; inputSchema: Record<string, unknown> }[];
+      }
+    ).tools;
+    expect(tools.map((t) => t.name).sort()).toEqual([
+      "create_asset",
+      "create_effort",
+    ]);
+
+    const createAsset = tools.find((t) => t.name === "create_asset");
+    expect(createAsset?.inputSchema.required).toEqual([
+      "vault",
+      "class",
+      "label",
+    ]);
+    const createEffort = tools.find((t) => t.name === "create_effort");
+    expect(createEffort?.inputSchema.required).toEqual([
+      "vault",
+      "command",
+      "target",
+    ]);
+  });
+
+  it("@req:264ccef6-4737-4076-95d8-053326c9ee1d create_asset invokes the create verb with each value as its own argv element and returns the {uuid,path,label} JSON", async () => {
+    const created = { uuid: "u-1", path: "space/u-1.md", label: "My Asset" };
+    const { server, calls } = makeServer({
+      stdout: JSON.stringify(created) + "\n",
+    });
+
+    const result = await callTool(server, "create_asset", {
+      vault: "/v",
+      class: "ems__Task",
+      label: "My Asset",
+      properties: { exo__Asset_relates: ["[[a]]", "[[b]]"], custom__key: "v" },
+      aliases: ["Alias One"],
+      body: "line one",
+      validate: false,
+    });
+
+    const args = calls[0].args;
+    expect(args.slice(0, 7)).toEqual([
+      "create",
+      "--vault",
+      "/v",
+      "--class",
+      "ems__Task",
+      "--label",
+      "My Asset",
+    ]);
+    // A multi-value property emits one --property per element (#3759).
+    expect(args).toContain("exo__Asset_relates=[[a]]");
+    expect(args).toContain("exo__Asset_relates=[[b]]");
+    expect(args).toContain("custom__key=v");
+    expect(args).toContain("--aliases");
+    expect(args).toContain("Alias One");
+    expect(args).toContain("--body");
+    expect(args).toContain("line one");
+
+    expect(result.isError).toBeUndefined();
+    expect(JSON.parse(result.content[0].text)).toEqual(created);
+  });
+
+  it("@req:264ccef6-4737-4076-95d8-053326c9ee1d create_asset preserves shell metacharacters byte-identically in argv", async () => {
+    const { server, calls } = makeServer();
+    const nastyLabel = 'Cost $100 `id` $(whoami) $& (x) "q" \\n';
+    const nastyBody = "para one\n\n$HOME `pwd` ${x} 100% *";
+
+    await callTool(server, "create_asset", {
+      vault: "/v",
+      class: "ems__Task",
+      label: nastyLabel,
+      body: nastyBody,
+      properties: { p__x: "value with $ and ` and (parens)" },
+    });
+
+    const args = calls[0].args;
+    // Each hostile value is exactly ONE argv element, unchanged.
+    expect(args[args.indexOf("--label") + 1]).toBe(nastyLabel);
+    expect(args[args.indexOf("--body") + 1]).toBe(nastyBody);
+    expect(args).toContain("p__x=value with $ and ` and (parens)");
+  });
+
+  it("@req:264ccef6-4737-4076-95d8-053326c9ee1d create_asset enables inline-SHACL by default and omits it only when validate is false", async () => {
+    const withDefault = makeServer();
+    await callTool(withDefault.server, "create_asset", {
+      vault: "/v",
+      class: "ems__Task",
+      label: "L",
+    });
+    expect(withDefault.calls[0].args).toContain("--validate");
+
+    const optedOut = makeServer();
+    await callTool(optedOut.server, "create_asset", {
+      vault: "/v",
+      class: "ems__Task",
+      label: "L",
+      validate: false,
+    });
+    expect(optedOut.calls[0].args).not.toContain("--validate");
+  });
+
+  it("@req:264ccef6-4737-4076-95d8-053326c9ee1d create_effort applies the homoiconic command and returns the created envelope", async () => {
+    const envelope = {
+      command: "create-task",
+      target: "areas/a.md",
+      created: [{ uuid: "u-2", path: "efforts/u-2.md", label: "New Task" }],
+    };
+    const { server, calls } = makeServer({
+      stdout: JSON.stringify(envelope) + "\n",
+    });
+
+    const result = await callTool(server, "create_effort", {
+      vault: "/v",
+      command: "create-task",
+      target: "areas/a.md",
+      input: { value: "New Task" },
+    });
+
+    expect(calls[0].args).toEqual([
+      "apply",
+      "create-task",
+      "areas/a.md",
+      "--vault",
+      "/v",
+      "--json",
+      "--yes",
+      "--input",
+      '{"value":"New Task"}',
+    ]);
+    expect(JSON.parse(result.content[0].text)).toEqual(envelope);
+  });
+
+  it("@req:264ccef6-4737-4076-95d8-053326c9ee1d a non-zero CLI exit becomes a tool error carrying the diagnostic and exit code", async () => {
+    const { server } = makeServer({
+      exitCode: 2,
+      stderr:
+        "❌ Unknown property 'ems__Effort_parentEffort'. Did you mean 'ems__Effort_parent'?",
+    });
+
+    const result = await callTool(server, "create_asset", {
+      vault: "/v",
+      class: "ems__Task",
+      label: "L",
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("exited 2");
+    expect(result.content[0].text).toContain("ems__Effort_parent");
+  });
+
+  it("@req:264ccef6-4737-4076-95d8-053326c9ee1d missing required arguments and unknown tools are tool errors, not protocol errors", async () => {
+    const { server, calls } = makeServer();
+
+    const missing = await callTool(server, "create_asset", { vault: "/v" });
+    expect(missing.isError).toBe(true);
+    expect(missing.content[0].text).toContain("class");
+    expect(missing.content[0].text).toContain("label");
+
+    const unknown = await callTool(server, "nope", {});
+    expect(unknown.isError).toBe(true);
+    expect(unknown.content[0].text).toContain("Unknown tool: nope");
+
+    // Neither reached the CLI.
+    expect(calls).toHaveLength(0);
+  });
+
+  it("@req:264ccef6-4737-4076-95d8-053326c9ee1d an unsupported method returns JSON-RPC method-not-found and a notification returns no response", async () => {
+    const { server } = makeServer();
+
+    const unsupported = (await server.handle({
+      jsonrpc: "2.0",
+      id: 9,
+      method: "resources/list",
+    })) as JsonRpcResponse;
+    expect(unsupported.error?.code).toBe(JSON_RPC_METHOD_NOT_FOUND);
+
+    // A notification has no `id` — JSON-RPC forbids answering it.
+    const notification = await server.handle({
+      jsonrpc: "2.0",
+      method: "notifications/initialized",
+    });
+    expect(notification).toBeNull();
+  });
+
+  it("@req:264ccef6-4737-4076-95d8-053326c9ee1d the stdio loop answers requests, stays silent for notifications and reports malformed JSON", async () => {
+    const { server } = makeServer();
+    const written: string[] = [];
+
+    await runStdioServer(
+      server,
+      Readable.from([
+        JSON.stringify({ jsonrpc: "2.0", id: 1, method: "initialize" }) + "\n",
+        JSON.stringify({
+          jsonrpc: "2.0",
+          method: "notifications/initialized",
+        }) + "\n",
+        "{ not json\n",
+      ]),
+      (line) => written.push(line),
+    );
+
+    // 2 writes: the initialize reply and the parse error — the notification is silent.
+    expect(written).toHaveLength(2);
+    expect(JSON.parse(written[0]).result.protocolVersion).toBe(
+      MCP_PROTOCOL_VERSION,
+    );
+    expect(JSON.parse(written[1]).error.code).toBe(JSON_RPC_PARSE_ERROR);
+  });
+});
+
+describe("createSelfCliRunner — real execFile round-trip (no shell)", () => {
+  let dir: string;
+  let script: string;
+
+  beforeAll(() => {
+    dir = mkdtempSync(join(tmpdir(), "mcp-argv-"));
+    script = join(dir, "echo-argv.cjs");
+    // Prints the argument vector it actually received.
+    writeFileSync(
+      script,
+      "process.stdout.write(JSON.stringify(process.argv.slice(2)));\n",
+    );
+  });
+
+  afterAll(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("@req:264ccef6-4737-4076-95d8-053326c9ee1d passes hostile values to the CLI verbatim, with no shell interpolation or word splitting", async () => {
+    const runner = createSelfCliRunner(script);
+    const hostile = [
+      "$(whoami) `id` $HOME",
+      "two  spaces",
+      "semi; ls",
+      "glob *.md",
+      "$&",
+    ];
+
+    const result = await runner(["create", "--label", ...hostile]);
+
+    expect(result.exitCode).toBe(0);
+    expect(JSON.parse(result.stdout)).toEqual([
+      "create",
+      "--label",
+      ...hostile,
+    ]);
+  });
+
+  it("@req:264ccef6-4737-4076-95d8-053326c9ee1d surfaces a non-zero child exit as data instead of rejecting", async () => {
+    const failing = join(dir, "fail.cjs");
+    writeFileSync(failing, "process.stderr.write('boom'); process.exit(3);\n");
+
+    const result = await createSelfCliRunner(failing)([]);
+
+    expect(result.exitCode).toBe(3);
+    expect(result.stderr).toContain("boom");
+  });
+});


### PR DESCRIPTION
## What

Adds `exocortex mcp` — an **MCP (Model Context Protocol) stdio server** exposing two asset-creation tools, as a CLI **transport** entry-point.

- `create_asset` → the generic `create` verb (inline-SHACL `--validate` **ON by default**)
- `create_effort` → `apply <cmd> <target> --json --yes` (the *homoiconic* effort path)

Project `38800c80` **W6**, RFC `7c7859d1`.
Req: `264ccef6-4737-4076-95d8-053326c9ee1d` (approved).

## Why

The dogfood-canonical creation path is invoked through a **shell**, and shell quoting is the most-recurring mechanical failure class in this environment: word-splitting of multi-word variables, `$`/backtick command substitution inside `--label`, `()` parse errors, glob expansion of unquoted `?`/`*`. Those are **transport** defects, not pipeline defects.

An MCP client hands over a JSON object; the server builds an **argument vector** and runs this same CLI with `execFile` (**no shell**), so no character in any label, body or property value can be reinterpreted.

## Design

- **Purely additive.** New `packages/cli/src/mcp/**` + `commands/mcp.ts` + 2 lines in `program.ts`. **Zero changes to `create.ts` / `apply.ts`**, so regression risk on the creation path is zero.
- **Zero new runtime dependencies.** The required MCP subset (`initialize`, `notifications/initialized`, `ping`, `tools/list`, `tools/call`) is a small JSON-RPC 2.0 dialogue over newline-delimited JSON — hand-rolled, leaving a *published* package's supply chain unchanged. Adopting the official SDK is a documented follow-up once value is proven.
- **Inherits every existing guarantee** by shelling out to the real CLI: co-location by `exo__Asset_isDefinedBy`, dangling-wikilink VALUE rejection, unknown-property-NAME rejection (req `40a9a81b`), SHACL-lite conformance (req `dd9ab956`), canonical property ordering.
- **inline-SHACL ON by default** on the MCP surface (the CLI keeps `--validate` opt-in for interactive use); overridable per call.
- **A failing CLI run is an MCP tool error, never a crash** — non-zero exit → `isError: true` carrying the CLI's own stderr diagnostic + exit code.
- `mcp` is a **transport** entry-point, not a domain verb — it does not count against the RFC's 22→18→17 domain-command surface metric.

## Verification

**Revert-verified** (`@req:264ccef6-4737-4076-95d8-053326c9ee1d`), each break reddening **exactly** its own test with the other 11 green:

| break | RED test |
|---|---|
| route `execFile` through a shell (`shell: true`) | byte-identical-argv |
| `validate !== false` → `validate === true` | inline-SHACL default-ON |
| neutralise the non-zero-exit branch | CLI-failure → tool error |

Restored → **12/12 GREEN**.

**End-to-end against the built CLI** (real MCP stdio session, real vault):
- handshake / `tools/list` / `tools/call` all correct; notification correctly **unanswered**
- a real asset was created whose hostile label `$(whoami) \`id\` $HOME $& (paren) "q" 100%` and body (`; echo pwned`) are **byte-identical on disk**, with **no shell side-effects**
- unknown tool → `isError`; unsupported method → `-32601`
- `create_effort` against a bogus command → `isError` with the CLI diagnostic, server survived (exit 0)

**Gates:** `check:types` 0 errors · CLI suite 153/154 suites, 1903 passed · archgate 24/24 pass, 0 errors · all 3 `lint`-job guard scripts exit 0 (ratchet unchanged: method-exists 55/55, vacuous-length 21/21).

> The single failing suite (`sparql-exo003.integration.test.ts`) is **pre-existing on `origin/main`** — independently reproduced in a clean worktree containing zero MCP code.

## Out of scope (documented, not dropped)

`@modelcontextprotocol/sdk` adoption · MCP `resources`/`prompts` capabilities · read/query tools (RFC read-axis = W5, deferred) · making MCP mandatory (W8 hard-hook, gated on the W7 metric).
