### PR TITLE
feat(display-name): vault-declared separator + value format for printName (#4012)

### DIFF
--- a/packages/obsidian-plugin/src/domain/display-name/DisplayNameResolver.ts
+++ b/packages/obsidian-plugin/src/domain/display-name/DisplayNameResolver.ts
@@ -54,8 +54,11 @@ export class DisplayNameResolver {
     const projection = this.computeTBoxNamingProjection(assetClasses, metadata);
     if (projection !== null) return projection;
 
-    const template = this.getTemplateForClasses(assetClasses, metadata);
-    const engine = new DisplayNameTemplateEngine(template);
+    const { template, separator } = this.resolveRenderSpec(assetClasses, metadata);
+    const engine = new DisplayNameTemplateEngine(
+      template,
+      separator ? { separator } : {},
+    );
 
     return engine.render(
       metadata,
@@ -84,6 +87,22 @@ export class DisplayNameResolver {
     assetClasses: string[],
     metadata?: Record<string, unknown>,
   ): string {
+    return this.resolveRenderSpec(assetClasses, metadata).template;
+  }
+
+  /**
+   * The template PLUS its vault-declared separator (issue #4012). The separator must travel as
+   * METADATA beside the template, never inside it: composeTemplates collapses N specs into ONE
+   * string, after which an embedded separator would be indistinguishable from an ordinary
+   * literal. When several specs compose, the separator is taken from the spec that contributed
+   * the CORE (the highest-priority participating spec carrying a placeholder) — deterministic.
+   * getTemplateForClasses stays a string-returning wrapper, so every existing caller is
+   * untouched.
+   */
+  private resolveRenderSpec(
+    assetClasses: string[],
+    metadata?: Record<string, unknown>,
+  ): { template: string; separator?: string } {
     if (this.ruleService && assetClasses.length > 0) {
       // Gather EVERY participating spec across all of the note's classes, de-duped by spec UID so a
       // spec that applies to more than one of the note's classes contributes at most one prefix.
@@ -103,17 +122,20 @@ export class DisplayNameResolver {
           (a, b) => b.priority - a.priority || a.sourceFile.localeCompare(b.sourceFile),
         );
         return gathered.length === 1
-          ? gathered[0].template
+          ? {
+              template: gathered[0].template,
+              ...(gathered[0].separator ? { separator: gathered[0].separator } : {}),
+            }
           : this.composeTemplates(gathered);
       }
     }
 
     const firstClass = assetClasses[0];
     if (firstClass && this.settings.classTemplates[firstClass]) {
-      return this.settings.classTemplates[firstClass];
+      return { template: this.settings.classTemplates[firstClass] };
     }
 
-    return this.settings.defaultTemplate;
+    return { template: this.settings.defaultTemplate };
   }
 
   /**
@@ -129,12 +151,17 @@ export class DisplayNameResolver {
    * NOTE: composition treats each side as space-separated marker tokens — the shipped combined specs
    * (e.g. "✅ 👥 ") space their markers, so re-baked markers de-dup correctly.
    */
-  private composeTemplates(rules: ParticipatingRule[]): string {
+  private composeTemplates(rules: ParticipatingRule[]): {
+    template: string;
+    separator?: string;
+  } {
     const seenPrefix = new Set<string>();
     const seenSuffix = new Set<string>();
     const prefixMarkers: string[] = [];
     const suffixMarkers: string[] = [];
     let core: string | null = null;
+    // The separator belongs to whichever spec contributes the CORE (issue #4012).
+    let coreSeparator: string | undefined;
     const collect = (raw: string, seen: Set<string>, into: string[]) => {
       for (const token of raw.trim().split(/\s+/)) {
         if (!token || seen.has(token)) continue;
@@ -145,7 +172,10 @@ export class DisplayNameResolver {
     for (const rule of rules) {
       const { prefix, core: ruleCore, suffix } = this.splitTemplate(rule.template);
       // Core (the label placeholder) = the first (highest-priority) spec that carries one.
-      if (core === null && ruleCore !== "") core = ruleCore;
+      if (core === null && ruleCore !== "") {
+        core = ruleCore;
+        coreSeparator = rule.separator;
+      }
       collect(prefix, seenPrefix, prefixMarkers);
       collect(suffix, seenSuffix, suffixMarkers);
     }
@@ -153,7 +183,10 @@ export class DisplayNameResolver {
     const composedCore = core ?? "";
     const composedPrefix = prefixMarkers.map((m) => `${m} `).join("");
     const composedSuffix = suffixMarkers.length ? ` ${suffixMarkers.join(" ")}` : "";
-    return `${composedPrefix}${composedCore}${composedSuffix}`;
+    return {
+      template: `${composedPrefix}${composedCore}${composedSuffix}`,
+      ...(coreSeparator ? { separator: coreSeparator } : {}),
+    };
   }
 
   /**

--- a/packages/obsidian-plugin/src/domain/display-name/DisplayNameTemplateEngine.ts
+++ b/packages/obsidian-plugin/src/domain/display-name/DisplayNameTemplateEngine.ts
@@ -32,10 +32,16 @@ export class DisplayNameTemplateEngine {
    *   definition composition (a multi-valued `concept__Concept_differentia` renders all
    *   adjectives). Default (false) is first-only — so the displayName path (which renders the
    *   multi-valued `{{exo__Instance_class}}` in the default classSuffix template) is UNCHANGED.
+   * @param options.separator OPT-IN (default undefined). The vault-declared
+   *   `exo__DisplayNameSpec_separator`. When a non-empty string, the template renders in
+   *   SEPARATOR MODE: it is split into FIELDS on this literal separator, each field is rendered
+   *   and cleaned INDEPENDENTLY, a field that renders empty is DROPPED together with its
+   *   adjacent separator, and the survivors are re-joined by the separator. Absent → the
+   *   original single-pass path, byte-identical (onto-RFC 0ba349ed, issue #4012).
    */
   constructor(
     private readonly template: string,
-    private readonly options: { joinArrayValues?: boolean } = {},
+    private readonly options: { joinArrayValues?: boolean; separator?: string } = {},
   ) {}
 
   /**
@@ -56,12 +62,23 @@ export class DisplayNameTemplateEngine {
       return null;
     }
 
-    const result = this.template.replace(
-      DisplayNameTemplateEngine.PLACEHOLDER_PATTERN,
-      (_, key: string) => {
-        const trimmedKey = key.trim();
-        return this.resolveValue(trimmedKey, metadata, basename, createdDate, metadataResolver);
-      }
+    const separator = this.options.separator;
+    if (separator) {
+      return this.renderWithSeparator(
+        separator,
+        metadata,
+        basename,
+        createdDate,
+        metadataResolver,
+      );
+    }
+
+    const result = this.renderSegment(
+      this.template,
+      metadata,
+      basename,
+      createdDate,
+      metadataResolver,
     );
 
     // Clean up the result to handle edge cases from missing values
@@ -73,6 +90,94 @@ export class DisplayNameTemplateEngine {
     }
 
     return cleanedResult;
+  }
+
+  /** Substitute every {{placeholder}} in a template segment. */
+  private renderSegment(
+    segment: string,
+    metadata: Record<string, unknown>,
+    basename: string,
+    createdDate?: Date,
+    metadataResolver?: MetadataResolver,
+  ): string {
+    return segment.replace(
+      DisplayNameTemplateEngine.PLACEHOLDER_PATTERN,
+      (_, key: string) => {
+        const trimmedKey = key.trim();
+        return this.resolveValue(trimmedKey, metadata, basename, createdDate, metadataResolver);
+      },
+    );
+  }
+
+  /**
+   * SEPARATOR MODE (opt-in, `exo__DisplayNameSpec_separator`): join the NON-EMPTY fields.
+   *
+   * The split happens on the TEMPLATE — deliberately BEFORE substitution — so a rendered VALUE
+   * that itself contains the separator (a dish called "Кофе · Латте") is never cut into pieces.
+   * Each field is cleaned with the SAME cleanupResult as the default path, so a field is
+   * considered empty when its cleaned render is "" (value missing OR whitespace-only). Survivors
+   * are re-joined by the separator verbatim, so a hanging separator around a dropped field is
+   * structurally impossible.
+   *
+   * Only the CORE region is split into fields — the leading literal (before the first
+   * placeholder) and the trailing literal (after the last placeholder) are AFFIXES, not fields.
+   * That is what keeps a composed prefix marker attached to the name rather than becoming a
+   * field of its own: composing a "🍽 " prefix spec over a separator-bearing core must render
+   * "🍽 Тирамису · Teplo", never "🍽 · Тирамису · Teplo" (req 1a6525eb, AC-D).
+   */
+  private renderWithSeparator(
+    separator: string,
+    metadata: Record<string, unknown>,
+    basename: string,
+    createdDate?: Date,
+    metadataResolver?: MetadataResolver,
+  ): string | null {
+    const first = this.template.indexOf("{{");
+    const last = this.template.lastIndexOf("}}");
+    if (first === -1 || last === -1 || last < first) {
+      // No placeholder at all → nothing to collapse; fall back to the default single pass.
+      const cleaned = this.cleanupResult(
+        this.renderSegment(this.template, metadata, basename, createdDate, metadataResolver),
+      );
+      return cleaned === "" ? null : cleaned;
+    }
+
+    const prefix = this.template.slice(0, first);
+    const core = this.template.slice(first, last + 2);
+    const suffix = this.template.slice(last + 2);
+
+    const rendered: string[] = [];
+    for (const field of core.split(separator)) {
+      const cleaned = this.cleanupResult(
+        this.renderSegment(field, metadata, basename, createdDate, metadataResolver),
+      );
+      if (cleaned !== "") {
+        rendered.push(cleaned);
+      }
+    }
+
+    // Every field empty → the affixes alone are not a name; fall back (null) to label/basename.
+    if (rendered.length === 0) {
+      return null;
+    }
+
+    const renderedPrefix = this.renderSegment(
+      prefix,
+      metadata,
+      basename,
+      createdDate,
+      metadataResolver,
+    );
+    const renderedSuffix = this.renderSegment(
+      suffix,
+      metadata,
+      basename,
+      createdDate,
+      metadataResolver,
+    );
+
+    const joined = `${renderedPrefix}${rendered.join(separator)}${renderedSuffix}`.trim();
+    return joined === "" ? null : joined;
   }
 
   /**
@@ -142,9 +247,112 @@ export class DisplayNameTemplateEngine {
       return "";
     }
 
+    // Optional per-part value format (`exo__PrintedProperty_format`), compiled into the
+    // placeholder as `{{key::FORMAT}}`. The format MUST travel with the placeholder because it
+    // is declared per PART, while the compiled artifact is ONE template string per spec.
+    // `::` is a reserved sequence of the template micro-syntax: frontmatter keys have the shape
+    // `prefix__Name` and never contain it. Split on the FIRST `::`; a trailing empty format is
+    // ignored (the key is then used verbatim).
+    const { path, format } = DisplayNameTemplateEngine.splitKeyAndFormat(key);
+
     // Handle dot notation for nested fields (with cross-asset resolution)
-    const value = this.getNestedValue(metadata, key, metadataResolver);
+    const value = this.getNestedValue(metadata, path, metadataResolver);
+
+    if (format) {
+      // Format the RAW value — BEFORE formatValue, which would JSON.stringify a Date into
+      // `"2026-01-24T13:50:17.000Z"` (quotes included) and lose the literal digits.
+      const formatted = DisplayNameTemplateEngine.applyValueFormat(value, format);
+      if (formatted !== null) {
+        return formatted;
+      }
+      // Fail-open: unrecognised value → fall through and print it as usual.
+    }
+
     return this.formatValue(value, metadataResolver);
+  }
+
+  /** Split a placeholder key into its frontmatter path and its optional value format. */
+  private static splitKeyAndFormat(key: string): { path: string; format?: string } {
+    const idx = key.indexOf("::");
+    if (idx <= 0) return { path: key };
+    const path = key.slice(0, idx).trim();
+    const format = key.slice(idx + 2).trim();
+    if (!path || !format) return { path: key };
+    return { path, format };
+  }
+
+  /**
+   * Apply a vault-declared value format (`exo__PrintedProperty_format`) to a raw frontmatter
+   * value. v1 vocabulary — date/time only: YYYY, YY, MM, DD, HH, mm, ss (every other character
+   * of the format is a literal, so "DD.MM" → "31.07").
+   *
+   * The components are taken LITERALLY from the stored value — a regex over the ISO string, and
+   * UTC getters for a Date (YAML reads a zone-less timestamp as UTC). No local-time conversion,
+   * so the printed digits equal the digits written in the file and the result does not depend on
+   * the machine's timezone.
+   *
+   * Returns null (→ the caller prints the value unchanged, FAIL-OPEN) when the value is not a
+   * recognisable date/time, OR when any token of the format cannot be filled from it — the
+   * engine never fabricates zeros for missing components.
+   */
+  private static applyValueFormat(value: unknown, format: string): string | null {
+    let raw = value;
+    if (Array.isArray(raw)) {
+      if (raw.length === 0) return null;
+      raw = raw[0];
+    }
+
+    let year: string, month: string, day: string;
+    let hours: string | undefined, minutes: string | undefined, seconds: string | undefined;
+
+    if (raw instanceof Date) {
+      if (Number.isNaN(raw.getTime())) return null;
+      const pad = (n: number) => String(n).padStart(2, "0");
+      year = String(raw.getUTCFullYear()).padStart(4, "0");
+      month = pad(raw.getUTCMonth() + 1);
+      day = pad(raw.getUTCDate());
+      hours = pad(raw.getUTCHours());
+      minutes = pad(raw.getUTCMinutes());
+      seconds = pad(raw.getUTCSeconds());
+    } else if (typeof raw === "string") {
+      const m = /^\s*(\d{4})-(\d{2})-(\d{2})(?:[T ](\d{2}):(\d{2})(?::(\d{2}))?)?/.exec(raw);
+      if (!m) return null;
+      year = m[1];
+      month = m[2];
+      day = m[3];
+      hours = m[4];
+      minutes = m[5];
+      seconds = m[6];
+    } else {
+      return null;
+    }
+
+    let unfillable = false;
+    const out = format.replace(/YYYY|YY|MM|DD|HH|mm|ss/g, (token) => {
+      switch (token) {
+        case "YYYY":
+          return year;
+        case "YY":
+          return year.slice(-2);
+        case "MM":
+          return month;
+        case "DD":
+          return day;
+        case "HH":
+          if (hours === undefined) unfillable = true;
+          return hours ?? "";
+        case "mm":
+          if (minutes === undefined) unfillable = true;
+          return minutes ?? "";
+        case "ss":
+          if (seconds === undefined) unfillable = true;
+          return seconds ?? "";
+        default:
+          return token;
+      }
+    });
+
+    return unfillable ? null : out;
   }
 
   /**

--- a/packages/obsidian-plugin/src/domain/display-name/PrintNameRuleService.ts
+++ b/packages/obsidian-plugin/src/domain/display-name/PrintNameRuleService.ts
@@ -72,6 +72,12 @@ export interface PrintNameRule {
    * unconditional (v1 path).
    */
   matcher?: DisplayNameMatcher;
+  /**
+   * Present iff the spec declared `exo__DisplayNameSpec_separator` — the vault-declared string
+   * joining this name's NON-EMPTY parts (a part rendering empty drops together with its adjacent
+   * separator). Absent = the v1 `join("")` path, byte-identical (onto-RFC 0ba349ed, issue #4012).
+   */
+  separator?: string;
 }
 
 /**
@@ -85,6 +91,8 @@ export interface ParticipatingRule {
   template: string;
   priority: number;
   sourceFile: string;
+  /** The spec's vault-declared separator, if any — see PrintNameRule.separator. */
+  separator?: string;
 }
 
 type MetadataResolver = (wikilinkTarget: string) => Record<string, unknown> | null;
@@ -110,12 +118,14 @@ interface RawDisplayNameSpec {
   matchValues?: string[]; // accepted identities (UID + label) from exo__DisplayNameSpec_matchValue
   // Host-function specialization (v2 slice — RFC 92b91345, req d6cd2371).
   hostFunction?: string; // registered host-function name from exo__DisplayNameSpec_matchHostFunction
+  separator?: string; // verbatim exo__DisplayNameSpec_separator (issue #4012)
 }
 
 interface RawDisplayNamePart {
   specUid: string;
   order: number;
   propertyKey?: string; // frontmatter key for exo__PrintedProperty
+  format?: string; // exo__PrintedProperty_format — value format applied before substitution
   literal?: string; // static text for exo__PrintedLiteral
 }
 
@@ -230,6 +240,7 @@ export class PrintNameRuleService {
           template: rule.template,
           priority: rule.priority,
           sourceFile: rule.sourceFile,
+          ...(rule.separator ? { separator: rule.separator } : {}),
         });
       }
     }
@@ -463,12 +474,19 @@ export class PrintNameRuleService {
     // spec stays unconditional (v1 path).
     const hostFunction = this.resolveHostFunctionName(fm.exo__DisplayNameSpec_matchHostFunction);
 
+    // Separator (issue #4012). Taken VERBATIM — the surrounding spaces of " · " are
+    // meaningful. Absent/empty → the v1 join("") path, byte-identical.
+    const rawSeparator = fm.exo__DisplayNameSpec_separator;
+    const separator =
+      typeof rawSeparator === "string" && rawSeparator !== "" ? rawSeparator : undefined;
+
     rawSpecs.set(uid, {
       uid,
       classKeys,
       priority: Number.isFinite(priority) ? priority : 0,
       ...(hasValueMatcher ? { matchKey: matchKey ?? undefined, matchValues } : {}),
       ...(hostFunction ? { hostFunction } : {}),
+      ...(separator ? { separator } : {}),
     });
   }
 
@@ -494,8 +512,13 @@ export class PrintNameRuleService {
     const rawLiteral = fm.exo__PrintedLiteral_literal;
     const literal = typeof rawLiteral === "string" ? rawLiteral : undefined;
 
+    // Per-part value format (issue #4012) — only meaningful for a printed PROPERTY.
+    const rawFormat = fm.exo__PrintedProperty_format;
+    const format =
+      typeof rawFormat === "string" && rawFormat.trim() !== "" ? rawFormat.trim() : undefined;
+
     if (propertyKey) {
-      rawParts.push({ specUid, order, propertyKey });
+      rawParts.push({ specUid, order, propertyKey, ...(format ? { format } : {}) });
     } else if (literal !== undefined) {
       rawParts.push({ specUid, order, literal });
     }
@@ -522,8 +545,13 @@ export class PrintNameRuleService {
       if (parts.length === 0) continue;
 
       const template = parts
-        .map((p) => (p.propertyKey ? `{{${p.propertyKey}}}` : (p.literal ?? "")))
-        .join("");
+        .map((p) => {
+          if (!p.propertyKey) return p.literal ?? "";
+          // A declared format rides INSIDE the placeholder (`{{key::FORMAT}}`) because it is a
+          // per-PART setting while the compiled artifact is one string per spec.
+          return p.format ? `{{${p.propertyKey}::${p.format}}}` : `{{${p.propertyKey}}}`;
+        })
+        .join(spec.separator ?? "");
       if (!template.trim()) continue;
 
       const priority = DISPLAY_NAME_SPEC_BASE_PRIORITY + spec.priority;
@@ -547,6 +575,7 @@ export class PrintNameRuleService {
           priority,
           sourceFile: spec.uid,
           ...(matcher ? { matcher } : {}),
+          ...(spec.separator ? { separator: spec.separator } : {}),
         };
         const existing = this.rules.get(classKey);
         if (existing) {

--- a/packages/obsidian-plugin/tests/unit/domain/display-name/DisplayNameSeparatorAndFormat.test.ts
+++ b/packages/obsidian-plugin/tests/unit/domain/display-name/DisplayNameSeparatorAndFormat.test.ts
@@ -1,0 +1,315 @@
+/**
+ * printName: vault-declared separator + value format (issue #4012, onto-RFC 0ba349ed).
+ *
+ * Production-shape: the fixture vault carries the real CLASS-DEF and real PROPERTY-DEFs, and the
+ * test drives the REAL PrintNameRuleService.scanVault() → DisplayNameResolver.resolve() pipeline.
+ * Nothing is hand-injected: the templates under test are COMPILED from the fixture's
+ * exo__DisplayNameSpec + exo__PrintedProperty/exo__PrintedLiteral assets, exactly as the plugin
+ * compiles the live vault.
+ */
+import { PrintNameRuleService } from "@plugin/domain/display-name/PrintNameRuleService";
+import { DisplayNameResolver } from "@plugin/domain/display-name/DisplayNameResolver";
+import { DEFAULT_DISPLAY_NAME_SETTINGS } from "@plugin/domain/settings/ExocortexSettings";
+import { TFile } from "obsidian";
+import type { App, CachedMetadata } from "obsidian";
+
+const EXO_CLASS_METACLASS = "8619c4fc-64f1-4869-b17e-e34186cacca9";
+const DISPLAY_NAME_SPEC_UID = "07eab746-0874-4676-9d98-dbaad1bc6fb8";
+const PRINTED_PROPERTY_UID = "7d58de40-d941-4a66-88e2-13afc4fdc41d";
+const PRINTED_LITERAL_UID = "4d5437c9-788e-4a6d-9be0-4af3a84554f4";
+const DATATYPE_PROPERTY_UID = "ae56ca4c-b610-42a4-a25d-058c23673296";
+
+const DISH_CLASS_UID = "cc78dcc2-e01f-4e9c-98eb-b734f41b1e63";
+const SPEC_UID = "aaaaaaaa-0000-4000-8000-000000000001";
+const PLAIN_SPEC_UID = "aaaaaaaa-0000-4000-8000-000000000002";
+const PREFIX_SPEC_UID = "aaaaaaaa-0000-4000-8000-000000000003";
+
+interface Fixture {
+  path: string;
+  frontmatter: Record<string, unknown>;
+}
+
+function createMockApp(files: Fixture[]): App {
+  const fileCache = new Map<string, CachedMetadata>();
+  const mockFiles: TFile[] = [];
+  for (const f of files) {
+    const tfile = new TFile(f.path);
+    tfile.basename = f.path.replace(/\.md$/, "");
+    tfile.extension = "md";
+    mockFiles.push(tfile);
+    fileCache.set(f.path, { frontmatter: f.frontmatter } as CachedMetadata);
+  }
+  return {
+    vault: { getMarkdownFiles: () => mockFiles },
+    metadataCache: {
+      getFileCache: (file: TFile) => fileCache.get(file.path) ?? null,
+      getFirstLinkpathDest: (p: string) => {
+        const clean = p.endsWith(".md") ? p : `${p}.md`;
+        return mockFiles.find((f) => f.path === clean) ?? null;
+      },
+    },
+  } as unknown as App;
+}
+
+/** A property DEF asset — so resolvePropertyKey's second hop resolves for real. */
+function propertyDef(uid: string, label: string): Fixture {
+  return {
+    path: `${uid}.md`,
+    frontmatter: {
+      exo__Asset_uid: uid,
+      exo__Instance_class: [`[[${DATATYPE_PROPERTY_UID}]]`],
+      exo__Asset_label: label,
+    },
+  };
+}
+
+const PROP_RATING = "bbbbbbbb-0000-4000-8000-00000000000a";
+const PROP_DISH = "bbbbbbbb-0000-4000-8000-00000000000b";
+const PROP_PLACE = "bbbbbbbb-0000-4000-8000-00000000000c";
+const PROP_TS = "bbbbbbbb-0000-4000-8000-00000000000d";
+const PROP_LABEL = "bbbbbbbb-0000-4000-8000-00000000000e";
+
+/** The shared production-shape base: class-def + property-defs. */
+function baseFixtures(): Fixture[] {
+  return [
+    {
+      // CLASS-DEF — without it the spec's appliesToClass would not resolve to the label form.
+      path: `${DISH_CLASS_UID}.md`,
+      frontmatter: {
+        exo__Asset_uid: DISH_CLASS_UID,
+        exo__Instance_class: [`[[${EXO_CLASS_METACLASS}]]`],
+        exo__Asset_label: "meal__DishServing",
+      },
+    },
+    propertyDef(PROP_RATING, "meal__DishServing_rating"),
+    propertyDef(PROP_DISH, "meal__DishServing_dish"),
+    propertyDef(PROP_PLACE, "meal__DishServing_place"),
+    propertyDef(PROP_TS, "exo__Event_timestamp"),
+    propertyDef(PROP_LABEL, "exo__Asset_label"),
+  ];
+}
+
+function printedProperty(
+  uid: string,
+  specUid: string,
+  order: number,
+  propUid: string,
+  format?: string,
+): Fixture {
+  return {
+    path: `${uid}.md`,
+    frontmatter: {
+      exo__Asset_uid: uid,
+      exo__Instance_class: [`[[${PRINTED_PROPERTY_UID}]]`],
+      exo__DisplayNamePart_of: `[[${specUid}]]`,
+      exo__DisplayNamePart_order: order,
+      exo__PrintedProperty_property: `[[${propUid}]]`,
+      ...(format ? { exo__PrintedProperty_format: format } : {}),
+    },
+  };
+}
+
+/** The separator-bearing serving spec: rating · dish · place · timestamp(DD.MM). */
+function servingSpecFixtures(separator?: string): Fixture[] {
+  return [
+    {
+      path: `${SPEC_UID}.md`,
+      frontmatter: {
+        exo__Asset_uid: SPEC_UID,
+        exo__Instance_class: [`[[${DISPLAY_NAME_SPEC_UID}]]`],
+        exo__DisplayNameSpec_appliesToClass: `[[${DISH_CLASS_UID}|meal__DishServing]]`,
+        exo__DisplayNameSpec_priority: 100,
+        ...(separator === undefined ? {} : { exo__DisplayNameSpec_separator: separator }),
+      },
+    },
+    printedProperty("cccccccc-0000-4000-8000-000000000001", SPEC_UID, 1, PROP_RATING),
+    printedProperty("cccccccc-0000-4000-8000-000000000002", SPEC_UID, 2, PROP_DISH),
+    printedProperty("cccccccc-0000-4000-8000-000000000003", SPEC_UID, 3, PROP_PLACE),
+    printedProperty("cccccccc-0000-4000-8000-000000000004", SPEC_UID, 4, PROP_TS, "DD.MM"),
+  ];
+}
+
+function resolverFor(files: Fixture[]): DisplayNameResolver {
+  const app = createMockApp(files);
+  const service = new PrintNameRuleService(app);
+  service.initialize();
+  return new DisplayNameResolver(
+    DEFAULT_DISPLAY_NAME_SETTINGS,
+    service,
+    service.createMetadataResolver(),
+  );
+}
+
+function serving(fm: Record<string, unknown>): Record<string, unknown> {
+  return { exo__Instance_class: [`[[${DISH_CLASS_UID}|meal__DishServing]]`], ...fm };
+}
+
+const FULL = {
+  meal__DishServing_rating: 6.5,
+  meal__DishServing_dish: "Панкейки",
+  meal__DishServing_place: "Teplo",
+  exo__Event_timestamp: "2026-07-31T11:30:00",
+};
+
+describe("printName separator + value format [@req:1a6525eb-0c6e-4063-980b-8c1bd7bef0ff]", () => {
+  describe("AC-A — separator joins only NON-EMPTY parts", () => {
+    it("@req:1a6525eb-0c6e-4063-980b-8c1bd7bef0ff renders every field when all are present", () => {
+      const r = resolverFor([...baseFixtures(), ...servingSpecFixtures(" · ")]);
+      expect(r.resolve({ metadata: serving(FULL), basename: "x" })).toBe(
+        "6.5 · Панкейки · Teplo · 31.07",
+      );
+    });
+
+    it("@req:1a6525eb-0c6e-4063-980b-8c1bd7bef0ff drops the LEADING separator when the first field is empty", () => {
+      const r = resolverFor([...baseFixtures(), ...servingSpecFixtures(" · ")]);
+      const { meal__DishServing_rating: _drop, ...noRating } = FULL;
+      expect(r.resolve({ metadata: serving(noRating), basename: "x" })).toBe(
+        "Панкейки · Teplo · 31.07",
+      );
+    });
+
+    it("@req:1a6525eb-0c6e-4063-980b-8c1bd7bef0ff drops the TRAILING separator when the last field is empty", () => {
+      const r = resolverFor([...baseFixtures(), ...servingSpecFixtures(" · ")]);
+      const { exo__Event_timestamp: _drop, ...noTs } = FULL;
+      expect(r.resolve({ metadata: serving(noTs), basename: "x" })).toBe(
+        "6.5 · Панкейки · Teplo",
+      );
+    });
+
+    it("@req:1a6525eb-0c6e-4063-980b-8c1bd7bef0ff leaves exactly ONE separator when both ends are empty", () => {
+      const r = resolverFor([...baseFixtures(), ...servingSpecFixtures(" · ")]);
+      const name = r.resolve({
+        metadata: serving({
+          meal__DishServing_dish: "Тирамису",
+          meal__DishServing_place: "Teplo",
+        }),
+        basename: "x",
+      });
+      expect(name).toBe("Тирамису · Teplo");
+    });
+
+    it("@req:1a6525eb-0c6e-4063-980b-8c1bd7bef0ff collapses a MIDDLE empty field without doubling the separator", () => {
+      const r = resolverFor([...baseFixtures(), ...servingSpecFixtures(" · ")]);
+      const name = r.resolve({
+        metadata: serving({
+          meal__DishServing_dish: "Омлет",
+          exo__Event_timestamp: "2026-07-31T09:40:00",
+        }),
+        basename: "x",
+      });
+      expect(name).toBe("Омлет · 31.07");
+      expect(name).not.toContain("·  ·");
+    });
+
+    it("@req:1a6525eb-0c6e-4063-980b-8c1bd7bef0ff never splits a VALUE that itself contains the separator", () => {
+      const r = resolverFor([...baseFixtures(), ...servingSpecFixtures(" · ")]);
+      const name = r.resolve({
+        metadata: serving({ ...FULL, meal__DishServing_dish: "Кофе · Латте" }),
+        basename: "x",
+      });
+      expect(name).toBe("6.5 · Кофе · Латте · Teplo · 31.07");
+    });
+  });
+
+  describe("AC-B — vault-declared value format", () => {
+    it("@req:1a6525eb-0c6e-4063-980b-8c1bd7bef0ff formats an ISO string per the declared DD.MM", () => {
+      const r = resolverFor([...baseFixtures(), ...servingSpecFixtures(" · ")]);
+      const name = r.resolve({
+        metadata: serving({ ...FULL, exo__Event_timestamp: "2026-01-31T13:28:20" }),
+        basename: "x",
+      });
+      expect(name).toBe("6.5 · Панкейки · Teplo · 31.01");
+    });
+
+    it("@req:1a6525eb-0c6e-4063-980b-8c1bd7bef0ff formats a Date to the SAME literal digits (no tz shift, no quotes, no .000Z)", () => {
+      const r = resolverFor([...baseFixtures(), ...servingSpecFixtures(" · ")]);
+      const name = r.resolve({
+        // A zone-less YAML timestamp parses to a Date read as UTC.
+        metadata: serving({ ...FULL, exo__Event_timestamp: new Date("2026-01-31T13:28:20Z") }),
+        basename: "x",
+      });
+      expect(name).toBe("6.5 · Панкейки · Teplo · 31.01");
+      expect(name).not.toContain("Z");
+      expect(name).not.toContain('"');
+    });
+
+    it("@req:1a6525eb-0c6e-4063-980b-8c1bd7bef0ff FAILS OPEN — a non-date value prints unchanged", () => {
+      const r = resolverFor([...baseFixtures(), ...servingSpecFixtures(" · ")]);
+      const name = r.resolve({
+        metadata: serving({ ...FULL, exo__Event_timestamp: "как-нибудь потом" }),
+        basename: "x",
+      });
+      expect(name).toBe("6.5 · Панкейки · Teplo · как-нибудь потом");
+    });
+
+    it("@req:1a6525eb-0c6e-4063-980b-8c1bd7bef0ff never fabricates a component the value does not carry", () => {
+      const files = [
+        ...baseFixtures(),
+        {
+          path: `${SPEC_UID}.md`,
+          frontmatter: {
+            exo__Asset_uid: SPEC_UID,
+            exo__Instance_class: [`[[${DISPLAY_NAME_SPEC_UID}]]`],
+            exo__DisplayNameSpec_appliesToClass: `[[${DISH_CLASS_UID}|meal__DishServing]]`,
+            exo__DisplayNameSpec_priority: 100,
+          },
+        },
+        // HH cannot be filled from a date-only value → print the value unchanged.
+        printedProperty("cccccccc-0000-4000-8000-00000000000f", SPEC_UID, 1, PROP_TS, "DD.MM HH:mm"),
+      ];
+      const r = resolverFor(files);
+      expect(
+        r.resolve({ metadata: serving({ exo__Event_timestamp: "2026-01-31" }), basename: "x" }),
+      ).toBe("2026-01-31");
+    });
+  });
+
+  describe("AC-C — no separator declared ⇒ the v1 path, unchanged", () => {
+    it("@req:1a6525eb-0c6e-4063-980b-8c1bd7bef0ff keeps the legacy join(\"\") behaviour when no separator is declared", () => {
+      const r = resolverFor([...baseFixtures(), ...servingSpecFixtures(undefined)]);
+      // Parts are concatenated with no separator, exactly as before this change.
+      expect(r.resolve({ metadata: serving(FULL), basename: "x" })).toBe(
+        "6.5ПанкейкиTeplo31.07",
+      );
+    });
+  });
+
+  describe("AC-D — composition keeps the core spec's separator", () => {
+    it("@req:1a6525eb-0c6e-4063-980b-8c1bd7bef0ff composes a prefix spec over a separator-bearing core spec", () => {
+      const files: Fixture[] = [
+        ...baseFixtures(),
+        ...servingSpecFixtures(" · "),
+        // A higher-priority spec contributing ONLY a prefix marker.
+        {
+          path: `${PREFIX_SPEC_UID}.md`,
+          frontmatter: {
+            exo__Asset_uid: PREFIX_SPEC_UID,
+            exo__Instance_class: [`[[${DISPLAY_NAME_SPEC_UID}]]`],
+            exo__DisplayNameSpec_appliesToClass: `[[${DISH_CLASS_UID}|meal__DishServing]]`,
+            exo__DisplayNameSpec_priority: 200,
+          },
+        },
+        {
+          path: `${PLAIN_SPEC_UID}.md`,
+          frontmatter: {
+            exo__Asset_uid: PLAIN_SPEC_UID,
+            exo__Instance_class: [`[[${PRINTED_LITERAL_UID}]]`],
+            exo__DisplayNamePart_of: `[[${PREFIX_SPEC_UID}]]`,
+            exo__DisplayNamePart_order: 1,
+            exo__PrintedLiteral_literal: "🍽 ",
+          },
+        },
+      ];
+      const r = resolverFor(files);
+      const name = r.resolve({
+        metadata: serving({
+          meal__DishServing_dish: "Тирамису",
+          meal__DishServing_place: "Teplo",
+        }),
+        basename: "x",
+      });
+      // Prefix marker preserved AND the core's separator semantics still collapse the empties.
+      expect(name).toBe("🍽 Тирамису · Teplo");
+    });
+  });
+});


### PR DESCRIPTION
Closes #4012. Req: `1a6525eb-0c6e-4063-980b-8c1bd7bef0ff`. onto-RFC: `0ba349ed`.

## What

Two **opt-in, vault-declared** properties of the displayName family, so a printName can be expressed as *"join the NON-EMPTY parts, with a formatted date"*:

| Property | Cardinality | Meaning |
|---|---|---|
| `exo__DisplayNameSpec_separator` | 0..1 | joins only the **non-empty** parts; a part rendering empty drops together with its adjacent separator |
| `exo__PrintedProperty_format` | 0..1 | v1 date/time vocabulary (`YYYY/YY/MM/DD/HH/mm/ss`) applied to the value **before** substitution |

Target format (chosen by the user) for `meal__DishServing`: `6.5 · Панкейки · Teplo · 31.07`.

Both absent ⇒ the previous code path, so the 39 live displayName assets are byte-identical **by construction**, not by luck.

## Byte-identity (hard gate)

Ran the **real** `PrintNameRuleService` + `DisplayNameResolver` over the **real** vault — 8696 files, 11 `exo__DisplayNameSpec`, 174 rendered instances of every specified class — before and after. Every compiled template and every rendered name is **byte-identical**. (The only diff line was the vault file counter, +2 = the two new TBox defs this change adds.)

## Revert-verified — two independent axes

| Revert | Reds | Stays green |
|---|---|---|
| separator interpreter neutralised | the 5 collapse tests (leading / trailing / both-ends / middle / composition) | **all 4 format tests** |
| format interpreter neutralised | the format tests | **the 2 date-free collapse tests** |

Restored → 12/12 green. So each feature falls by its own axis.

## Design notes (each one is a defect the panel or a test caught)

- The split happens on the **template**, before substitution → a value that itself contains the separator (a dish `Кофе · Латте`) is never cut into fields.
- Only the **core** region is split; leading/trailing literals are **affixes**. This keeps a composed prefix marker attached (`🍽 Тирамису · Teplo`) instead of it becoming a field of its own (`🍽 · Тирамису · Teplo`) — caught by the AC-D test, not by review.
- The separator travels as **metadata beside** the template (`PrintNameRule` → `ParticipatingRule` → `resolveRenderSpec`), never inside the string: `composeTemplates` collapses N specs into ONE string, after which an embedded separator would be indistinguishable from an ordinary literal. On composition it is taken from the spec that contributed the core.
- The format is applied to the **raw** value — before `formatValue` would `JSON.stringify` a `Date` into `"2026-01-24T13:50:17.000Z"` (quotes included) and lose the literal digits. Components are read **literally** (regex over the ISO string; UTC getters for a `Date`), so the printed digits equal the digits in the file and do not depend on the machine timezone.
- **Fail-open**: an unrecognised value, or a token the value cannot fill (`HH` over a date-only value), prints the value unchanged — the engine never fabricates zeros.
- `getTemplateForClasses` / `getTemplateForClass` keep returning a `string`, so every existing caller and test is untouched.

## Tests

- New `@req`-tagged suite: 12 tests, production-shape (fixture carries the real **class-def** and **property-defs**; templates are COMPILED from fixture spec assets by the real `scanVault`, nothing hand-injected).
- Regression: 26 suites / 327 tests green across display-name, concept-definition, renderers, processors.
- `check:types` exit 0; eslint clean; shard/anti-pattern/coverage guards all pass.

⚠ The three touched files are prettier-dirty on `origin/main`, so added lines were hand-formatted rather than blanket `--write` (which would bundle hundreds of unrelated reformatting lines).