### PR TITLE
feat(profile): surface the transitive dependsOn CLOSURE file-cost in both mount pickers

### DIFF
--- a/packages/obsidian-plugin/src/ExocortexPlugin.ts
+++ b/packages/obsidian-plugin/src/ExocortexPlugin.ts
@@ -155,7 +155,15 @@ import { PluginSettingsStoreAdapter } from "./infrastructure/adapters/PluginSett
 import { PluginLocalDataStore } from "./infrastructure/adapters/PluginLocalDataStore";
 import { StagingDirTracker } from "./infrastructure/adapters/StagingDirTracker";
 import { ProfileFuzzyModal } from "./infrastructure/adapters/ProfileFuzzyModal";
-import { buildProfileChoice } from "./infrastructure/adapters/profileChoiceFactory";
+import {
+  buildProfileChoice,
+  extractIncludeUids,
+} from "./infrastructure/adapters/profileChoiceFactory";
+import {
+  computeClosureIndexCost,
+  formatAssetSpaceIndexCost,
+  formatIndexCost,
+} from "./domain/profile/indexCost";
 import { lookupAssetSpaceUidByFolder } from "./infrastructure/adapters/AssetSpaceLookupHelper";
 import { createAssetSpacePusher } from "./infrastructure/adapters/AssetSpacePusherFactory";
 import { LocalSecretsStore } from "./infrastructure/adapters/LocalSecretsStore";
@@ -3455,6 +3463,9 @@ export default class ExocortexPlugin extends Plugin {
       files: TFile[],
       activeUid: string | null,
       presentUids: Set<string>,
+      // req 6171f443 — resolve one profile's index cost from its declared
+      // `exo__Profile_includes`. Omitted (or returning undefined) ⇒ no cost line.
+      indexCostFor?: (includeUids: string[]) => string | undefined,
     ): ProfileChoice[] => {
       const choices: ProfileChoice[] = [];
       for (const file of files) {
@@ -3467,7 +3478,13 @@ export default class ExocortexPlugin extends Plugin {
           activeUid,
           presentUids,
         );
-        if (choice !== null) choices.push(choice);
+        if (choice !== null) {
+          const cost = indexCostFor?.(
+            extractIncludeUids(fm["exo__Profile_includes"]),
+          );
+          if (cost !== undefined) choice.indexCost = cost;
+          choices.push(choice);
+        }
       }
       // Sort alphabetically by label so picker order is stable across
       // vault scans (vault.getMarkdownFiles() is filesystem-order, not
@@ -3479,12 +3496,30 @@ export default class ExocortexPlugin extends Plugin {
     // RFC 0a0791c1 Phase 5 T2 — single `exo__Profile` picker (the former dual
     // soft/Knowledge listers collapsed into one). `activeProfileUid` is the
     // last-applied selection; Item #3 — device-local store (no Sync replication).
-    const profileLister: () => Promise<ProfileChoice[]> = async () =>
-      buildProfileChoices(
+    const profileLister: () => Promise<ProfileChoice[]> = async () => {
+      // req 6171f443 — derive the per-AssetSpace file counts ONCE per picker
+      // open, then price every profile against them. Best-effort: any failure
+      // leaves `indexCostFor` undefined, so the rows render exactly as they did
+      // before this feature (the zero-regression path).
+      let indexCostFor:
+        | ((includeUids: string[]) => string | undefined)
+        | undefined;
+      try {
+        const { infos, fileCountByUid } = await switchMgr.getIndexCostInputs();
+        indexCostFor = (includeUids) =>
+          formatIndexCost(
+            computeClosureIndexCost(includeUids, infos, fileCountByUid),
+          ) ?? undefined;
+      } catch {
+        // Preview only — never let costing break the picker.
+      }
+      return buildProfileChoices(
         resolver.listProfileFiles(),
         localDataStore.getActiveProfileUid(),
         this.collectPresentAssetUids(),
+        indexCostFor,
       );
+    };
 
     // Issue #3320 — share the same lister с Settings UI so its dropdown
     // matches the Cmd+P fuzzy-pick ordering exactly.
@@ -4397,11 +4432,32 @@ export default class ExocortexPlugin extends Plugin {
       },
       // Reuse the shared ProfileFuzzyModal (keyed by submodulePath) — floor
       // entries are decorated so the user sees why they cannot be removed.
-      fuzzyPick: (items, title) =>
-        new Promise<UnmountableAssetSpace | null>((resolve) => {
+      fuzzyPick: async (items, title) => {
+        // req 6171f443 — price each pack: its OWN size plus what its transitive
+        // dependsOn closure costs, so removing it reads honestly (the own size
+        // alone is the misleading number — see domain/profile/indexCost.ts).
+        // Best-effort: on failure no cost is attached and rows render as before.
+        let costOf: (m: UnmountableAssetSpace) => string | undefined = () =>
+          undefined;
+        try {
+          const { infos, fileCountByUid } = await switchMgr.getIndexCostInputs();
+          costOf = (m) => {
+            if (m.uid.length === 0) return undefined;
+            return (
+              formatAssetSpaceIndexCost(
+                fileCountByUid.get(m.uid),
+                computeClosureIndexCost([m.uid], infos, fileCountByUid),
+              ) ?? undefined
+            );
+          };
+        } catch {
+          // Preview only — never let costing break the picker.
+        }
+        return new Promise<UnmountableAssetSpace | null>((resolve) => {
           const choices: ProfileChoice[] = items.map((m) => ({
             uid: m.submodulePath,
             label: m.isFloor ? `${m.label} ✕ floor (protected)` : m.label,
+            indexCost: costOf(m),
           }));
           const byPath = new Map(items.map((m) => [m.submodulePath, m]));
           const modal = new ProfileFuzzyModal(
@@ -4414,7 +4470,8 @@ export default class ExocortexPlugin extends Plugin {
               ),
           );
           modal.open();
-        }),
+        });
+      },
       confirm: (message) =>
         new Promise<boolean>((resolve) => {
           new SimpleConfirmModal(
@@ -4432,7 +4489,12 @@ export default class ExocortexPlugin extends Plugin {
       unmount: (submodulePath) => restMount.unmount(submodulePath),
       // #3540 follow-up — toast auto-records into the activity log via notifier.
       notify: (message) => this.notifier.info(message),
-      onUnmounted: () => this.refreshAndInjectAssetSpaceMaterialization(),
+      onUnmounted: () => {
+        // req 6171f443 — an unmount changes what is mounted, so the memoized
+        // per-AssetSpace file counts no longer describe the vault.
+        switchMgr.invalidateIndexCostCache();
+        return this.refreshAndInjectAssetSpaceMaterialization();
+      },
     });
 
     // RFC 0002 §3.2 (P3/P4) — de-jargon + destructive flag: «Unmount assetspace»

--- a/packages/obsidian-plugin/src/ExocortexPlugin.ts
+++ b/packages/obsidian-plugin/src/ExocortexPlugin.ts
@@ -4129,7 +4129,12 @@ export default class ExocortexPlugin extends Plugin {
               ? void bootstrapCommands.invokeBootstrap()
               : void bootstrapCommands.invokeAddAssetSpace(),
         }).open(),
-      onMaterialized: () => this.refreshAndInjectAssetSpaceMaterialization(),
+      onMaterialized: () => {
+        // req 6171f443 — bootstrap / add-assetspace mount new AssetSpaces, so
+        // the memoized per-AssetSpace file counts no longer describe the vault.
+        this.profileApplyManager?.invalidateIndexCostCache();
+        return this.refreshAndInjectAssetSpaceMaterialization();
+      },
       // #3956 — delegate the dependsOn-closure completeness check to the mount
       // authority so «Add AssetSpace by URL» warns specifically when the added
       // AssetSpace's dependsOn (esp. the exocmd class-TBox) is left unmounted.
@@ -4399,7 +4404,12 @@ export default class ExocortexPlugin extends Plugin {
       writeDescriptor: (mountPath, fileName, content) =>
         this.app.vault.adapter.write(`${mountPath}/${fileName}`, content),
       notify: (message) => this.notifier.info(message),
-      onMaterialized: () => this.refreshAndInjectAssetSpaceMaterialization(),
+      onMaterialized: () => {
+        // req 6171f443 — registering an AssetSpace for sync materializes it, so
+        // the memoized per-AssetSpace file counts no longer describe the vault.
+        this.profileApplyManager?.invalidateIndexCostCache();
+        return this.refreshAndInjectAssetSpaceMaterialization();
+      },
     });
 
     this.addCommand({

--- a/packages/obsidian-plugin/src/domain/profile/indexCost.ts
+++ b/packages/obsidian-plugin/src/domain/profile/indexCost.ts
@@ -102,7 +102,8 @@ export function computeClosureIndexCost(
 
 /** Group digits so a five-figure file count stays readable (`8 738`). */
 function formatFileCount(files: number): string {
-  return files.toLocaleString("en-US").replace(/,/g, " ");
+  const grouped = files.toLocaleString("en-US").replace(/,/g, " ");
+  return `${grouped} ${files === 1 ? "file" : "files"}`;
 }
 
 /**
@@ -122,7 +123,7 @@ export function formatIndexCost(cost: IndexCost): string | null {
   const files = formatFileCount(cost.files);
   const bound = cost.uncountedAssetSpaces > 0 ? "≥ " : "";
   const packs = cost.closureSize === 1 ? "assetspace" : "assetspaces";
-  const base = `${bound}${files} files · ${cost.closureSize} ${packs}`;
+  const base = `${bound}${files} · ${cost.closureSize} ${packs}`;
   if (cost.uncountedAssetSpaces === 0) return base;
   return `${base} (${cost.uncountedAssetSpaces} not mounted, uncounted)`;
 }
@@ -142,7 +143,7 @@ export function formatAssetSpaceIndexCost(
   closure: IndexCost,
 ): string | null {
   if (ownFiles === undefined) return formatIndexCost(closure);
-  const own = `${formatFileCount(ownFiles)} files`;
+  const own = formatFileCount(ownFiles);
   if (closure.closureSize <= 1) return own;
   const closureLine = formatIndexCost(closure);
   if (closureLine === null) return own;

--- a/packages/obsidian-plugin/src/domain/profile/indexCost.ts
+++ b/packages/obsidian-plugin/src/domain/profile/indexCost.ts
@@ -1,0 +1,150 @@
+import { transitiveDependsOnClosure } from "@kitelev/exocortex-core";
+import type { AssetSpaceInfo } from "../../infrastructure/adapters/AssetSpaceManager";
+
+/**
+ * req 6171f443 — the index cost of a mount decision, measured over the whole
+ * `exo__AssetSpace_dependsOn` CLOSURE rather than a single AssetSpace.
+ *
+ * ## Why the closure and not the AssetSpace
+ *
+ * The parent project's falsification gate (task `8b8466bb`, measured 2026-08-02
+ * on the real vaults) found that mounting less through profiles does NOT
+ * materially help: the active profile already resolves to 100 % of vault-my
+ * (8 738 / 8 738) and 99.4 % of vault-exodev. The limiter is not the
+ * always-mounted TS floor (`{exo}` = 300 files = 3.4 %) — it is the transitive
+ * `dependsOn` closure. Mounting the personal `exoas-my` (3 763 files) *forces*
+ * another 4 862, so the "minimal profile that still has my data" saves 58 files
+ * (0.7 %).
+ *
+ * Surfacing an AssetSpace's OWN size alone would therefore actively mislead —
+ * it is precisely the number that makes "just turn the extra ones off" look
+ * promising. The closure figure is the honest one, and showing it is what the
+ * gate explicitly recommended keeping this work for.
+ *
+ * ## Why no millisecond estimate
+ *
+ * The same measurement established that index time is strictly linear in file
+ * count (`index_ms = 0.677 × files + 181`, R² = 0.9995; an independent
+ * parse-proxy gave R² = 0.996). But the *constant* is device-specific (desktop
+ * ≠ iPhone) while the *ratio* is stable. A file count is therefore the honest,
+ * device-independent weight; a millisecond figure would bake a fabricated
+ * constant into TS.
+ */
+export interface IndexCost {
+  /**
+   * Total files across the closure members whose count is KNOWN. When
+   * {@link uncountedAssetSpaces} is non-zero this is a LOWER BOUND, not the
+   * full cost.
+   */
+  files: number;
+  /** Size of the transitive `dependsOn` closure (roots included). */
+  closureSize: number;
+  /** Closure members with a known file count (materialized and counted). */
+  countedAssetSpaces: number;
+  /**
+   * Closure members with NO known count — not materialized, so their files
+   * cannot be walked. Non-zero ⇒ {@link files} is a lower bound.
+   */
+  uncountedAssetSpaces: number;
+}
+
+/**
+ * req 6171f443 — compute the index cost of mounting `roots`, expanded through
+ * the transitive `exo__AssetSpace_dependsOn` closure.
+ *
+ * Pure. Uses the SAME shared {@link transitiveDependsOnClosure} helper that
+ * `ProfileApplyManager.resolveDeclaredAndEffective` and `CliProfileResolver`
+ * use, so the previewed set matches what an apply would actually resolve
+ * (multi-parser-predicate-migration parity rule).
+ *
+ * ⛔ Deliberately does NOT call `resolveDeclaredAndEffective`: that method
+ * asserts the TS floor and THROWS on a floor-violating profile, which would
+ * break the picker for every other row. A preview must never throw.
+ *
+ * @param roots The directly-declared AssetSpace UIDs (a profile's
+ *   `exo__Profile_includes`, or a single AssetSpace being inspected).
+ * @param allInfos The scanned AssetSpace catalogue (carries `dependsOn` edges).
+ * @param fileCountByUid Known per-AssetSpace file counts. Absent ⇒ uncounted.
+ */
+export function computeClosureIndexCost(
+  roots: Iterable<string>,
+  allInfos: ReadonlyArray<AssetSpaceInfo>,
+  fileCountByUid: ReadonlyMap<string, number>,
+): IndexCost {
+  const dependsOnMap = new Map<string, string[]>();
+  for (const info of allInfos) {
+    if (info.dependsOn !== undefined && info.dependsOn.length > 0) {
+      dependsOnMap.set(info.uid, info.dependsOn);
+    }
+  }
+  const closure = transitiveDependsOnClosure(new Set(roots), dependsOnMap);
+
+  let files = 0;
+  let countedAssetSpaces = 0;
+  let uncountedAssetSpaces = 0;
+  for (const uid of closure) {
+    const count = fileCountByUid.get(uid);
+    if (count === undefined) {
+      uncountedAssetSpaces += 1;
+      continue;
+    }
+    files += count;
+    countedAssetSpaces += 1;
+  }
+
+  return {
+    files,
+    closureSize: closure.size,
+    countedAssetSpaces,
+    uncountedAssetSpaces,
+  };
+}
+
+/** Group digits so a five-figure file count stays readable (`8 738`). */
+function formatFileCount(files: number): string {
+  return files.toLocaleString("en-US").replace(/,/g, " ");
+}
+
+/**
+ * req 6171f443 — render an {@link IndexCost} as one muted picker line.
+ *
+ * Returns `null` when NOTHING is known (no closure member could be counted).
+ * That null is what makes the zero-regression guarantee structural rather than
+ * argued: with no counts available the caller attaches no cost, and the picker
+ * rows render byte-identically to the pre-feature behaviour.
+ *
+ * An uncounted closure member is never silently absorbed — the total is marked
+ * as a lower bound (`≥`) and the number of uncounted AssetSpaces is stated.
+ */
+export function formatIndexCost(cost: IndexCost): string | null {
+  if (cost.countedAssetSpaces === 0) return null;
+
+  const files = formatFileCount(cost.files);
+  const bound = cost.uncountedAssetSpaces > 0 ? "≥ " : "";
+  const packs = cost.closureSize === 1 ? "assetspace" : "assetspaces";
+  const base = `${bound}${files} files · ${cost.closureSize} ${packs}`;
+  if (cost.uncountedAssetSpaces === 0) return base;
+  return `${base} (${cost.uncountedAssetSpaces} not mounted, uncounted)`;
+}
+
+/**
+ * req 6171f443 — render the cost line for ONE AssetSpace in the pack list: its
+ * OWN size plus the cost of its closure, so removing it reads honestly.
+ *
+ * The own size alone is the misleading number (see the module docstring); the
+ * closure suffix is appended only when the closure is genuinely larger than the
+ * AssetSpace itself, so a dependency-free pack stays a single clean figure.
+ *
+ * Returns `null` when nothing is known (zero-regression, as above).
+ */
+export function formatAssetSpaceIndexCost(
+  ownFiles: number | undefined,
+  closure: IndexCost,
+): string | null {
+  if (ownFiles === undefined) return formatIndexCost(closure);
+  const own = `${formatFileCount(ownFiles)} files`;
+  if (closure.closureSize <= 1) return own;
+  const closureLine = formatIndexCost(closure);
+  if (closureLine === null) return own;
+  return `${own} · with dependencies: ${closureLine}`;
+}

--- a/packages/obsidian-plugin/src/infrastructure/adapters/ProfileApplyManager.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/ProfileApplyManager.ts
@@ -472,6 +472,13 @@ export class ProfileApplyManager {
   private readonly onPhase: (entry: SwitchJournalEntry) => void;
   private readonly onProgress: (event: ApplyProgressEvent) => void;
 
+  /**
+   * req 6171f443 — memoized per-AssetSpace file counts backing the index-cost
+   * preview (see {@link getIndexCostInputs}). `null` = not yet walked. Dropped
+   * by {@link invalidateIndexCostCache} after any mount-state mutation.
+   */
+  private indexCostCache: Map<string, number> | null = null;
+
   // Apply dependencies (may be undefined when only reindex wired).
   private readonly assetSpaceManager?: AssetSpaceManager;
   private readonly cacheLayer?: ICacheLayer;
@@ -866,6 +873,10 @@ export class ProfileApplyManager {
     if (typeof targetProfileUid !== "string" || targetProfileUid.length === 0) {
       throw new Error("applyProfile: targetProfileUid is required");
     }
+    // req 6171f443 — an apply is precisely the operation that invalidates the
+    // memoized per-AssetSpace file counts (it changes what is mounted), so drop
+    // them here: the next picker open re-walks instead of pricing a stale set.
+    this.invalidateIndexCostCache();
     // ExoSync D11 composition (RFC 4e4dc453 Phase B): refuse to start a
     // destructive mount-state switch while a sync run is reading/writing the
     // same folders. The sync side vetoes on `_switchInProgress` symmetrically.
@@ -2515,6 +2526,52 @@ export class ProfileApplyManager {
       }
     }
     return { infos, materializedUids };
+  }
+
+  /**
+   * req 6171f443 — the inputs an index-cost preview needs: the scanned
+   * AssetSpace catalogue (`dependsOn` edges) + a per-AssetSpace file count for
+   * every AssetSpace currently materialized on disk.
+   *
+   * The counts are **runtime-derived** from `vault.adapter` (exactly like
+   * `exo__AssetSpace_materialized`) and never persisted to frontmatter, so a
+   * manual `rm`/`cp` of an assetspaces directory cannot create stale state.
+   * Counting uses only `vault.adapter.exists` + `vault.adapter.list` — the same
+   * walk `applyProfile` already relies on — so it works unchanged on iOS where
+   * `node:fs` does not exist (Desktop↔Mobile parity invariant).
+   *
+   * A non-materialized AssetSpace is simply ABSENT from the map: its files
+   * cannot be walked, so its cost is unknown rather than zero. Callers surface
+   * that as an explicit lower bound instead of silently under-reporting.
+   *
+   * Cached for the plugin session (the walk is the vault-wide one) and
+   * invalidated by {@link invalidateIndexCostCache} after a mount changes.
+   */
+  public async getIndexCostInputs(): Promise<{
+    infos: AssetSpaceInfo[];
+    fileCountByUid: Map<string, number>;
+  }> {
+    const infos = this.listAllAssetSpaceInfos();
+    if (this.indexCostCache !== null) {
+      return { infos, fileCountByUid: this.indexCostCache };
+    }
+    const fileCountByUid = new Map<string, number>();
+    for (const info of infos) {
+      if (!(await this.app.vault.adapter.exists(info.folderName))) continue;
+      const files = await this.enumerateFilesUnder(info.folderName);
+      fileCountByUid.set(info.uid, files.length);
+    }
+    this.indexCostCache = fileCountByUid;
+    return { infos, fileCountByUid };
+  }
+
+  /**
+   * req 6171f443 — drop the memoized per-AssetSpace file counts so the next
+   * preview re-walks. Called after any mount-state mutation (apply / unmount),
+   * whose whole purpose is to change what those counts measure.
+   */
+  public invalidateIndexCostCache(): void {
+    this.indexCostCache = null;
   }
 
   /**

--- a/packages/obsidian-plugin/src/infrastructure/adapters/ProfileCommands.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/ProfileCommands.ts
@@ -95,6 +95,15 @@ export interface ProfileChoice {
    * rather than applying anything.
    */
   kind?: "show-all";
+  /**
+   * req 6171f443 — one muted line stating what mounting this row COSTS, in
+   * files, measured over the transitive `exo__AssetSpace_dependsOn` closure
+   * (see `domain/profile/indexCost.ts` for why the closure and not the
+   * AssetSpace's own size). Runtime-derived from `vault.adapter`, never
+   * persisted. Absent ⇒ nothing is rendered and the row is byte-identical to
+   * the pre-feature behaviour — that is the zero-regression guarantee.
+   */
+  indexCost?: string;
 }
 
 export interface ProfileCommandsDeps {

--- a/packages/obsidian-plugin/src/infrastructure/adapters/ProfileFuzzyModal.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/ProfileFuzzyModal.ts
@@ -160,6 +160,16 @@ export class ProfileFuzzyModal extends FuzzySuggestModal<ProfileChoice> {
         text: item.description,
       });
     }
+
+    // req 6171f443 — what mounting this row COSTS, in files, over the transitive
+    // dependsOn CLOSURE. Its own muted line so it never competes with the
+    // description. Absent ⇒ nothing rendered (the zero-regression guarantee).
+    if (item.indexCost !== undefined && item.indexCost.length > 0) {
+      el.createDiv({
+        cls: "exocortex-profile-suggestion__cost",
+        text: item.indexCost,
+      });
+    }
   }
 
   onChooseItem(item: ProfileChoice): void {

--- a/packages/obsidian-plugin/styles.css
+++ b/packages/obsidian-plugin/styles.css
@@ -2037,6 +2037,21 @@
   text-overflow: ellipsis;
 }
 
+/*
+ * req 6171f443 — the index-cost line (files this row costs to mount, over the
+ * transitive dependsOn closure). Muted like `__desc` so it never competes with
+ * the human label; slightly fainter still, since it is a secondary figure.
+ */
+.exocortex-profile-suggestion__cost {
+  font-size: 0.8em;
+  color: var(--text-faint);
+  margin-top: 2px;
+  /* Single-line truncate — ellipsis needs nowrap to take effect. */
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
 .exocortex-profile-suggestion--show-all .exocortex-profile-suggestion__title {
   color: var(--text-faint);
   font-style: italic;

--- a/packages/obsidian-plugin/tests/unit/domain/profile/indexCost.test.ts
+++ b/packages/obsidian-plugin/tests/unit/domain/profile/indexCost.test.ts
@@ -1,0 +1,175 @@
+import {
+  computeClosureIndexCost,
+  formatAssetSpaceIndexCost,
+  formatIndexCost,
+} from "../../../../src/domain/profile/indexCost";
+import { ProfileFuzzyModal } from "../../../../src/infrastructure/adapters/ProfileFuzzyModal";
+import type { ProfileChoice } from "../../../../src/infrastructure/adapters/ProfileCommands";
+import type { AssetSpaceInfo } from "../../../../src/infrastructure/adapters/AssetSpaceManager";
+
+/** Minimal AssetSpaceInfo fixture (only the fields the helper reads). */
+function info(
+  uid: string,
+  namespace: string,
+  dependsOn?: string[],
+): AssetSpaceInfo {
+  return {
+    uid,
+    git: `https://github.com/kitelev/exoas-${namespace}`,
+    namespace,
+    folderName: `assetspaces/kitelev/exoas-${namespace}`,
+    ...(dependsOn ? { dependsOn } : {}),
+  };
+}
+
+const MY = "aaaa1111-0000-0000-0000-000000000001";
+const SHARED_PRIVATE = "bbbb2222-0000-0000-0000-000000000002";
+const PUBLIC = "cccc3333-0000-0000-0000-000000000003";
+const EXO = "dddd4444-0000-0000-0000-000000000004";
+
+// The real vault-my shape the P0 measurement found (task 8b8466bb):
+//   my -> shared-private -> public -> exo
+// i.e. mounting the personal leaf force-mounts everything beneath it.
+const CATALOGUE: AssetSpaceInfo[] = [
+  info(MY, "my", [SHARED_PRIVATE]),
+  info(SHARED_PRIVATE, "shared-private", [PUBLIC]),
+  info(PUBLIC, "public", [EXO]),
+  info(EXO, "exo"),
+];
+
+const ALL_COUNTED = new Map<string, number>([
+  [MY, 3],
+  [SHARED_PRIVATE, 5],
+  [PUBLIC, 2],
+  [EXO, 1],
+]);
+
+describe("computeClosureIndexCost (req 6171f443)", () => {
+  it("@req:6171f443-a57f-4d3a-bad6-8d964decb308 prices a profile over its whole dependsOn CLOSURE, not the declared leaf alone", () => {
+    // AC1 — the picker must show what a profile actually costs to mount.
+    const cost = computeClosureIndexCost([MY], CATALOGUE, ALL_COUNTED);
+
+    expect(cost.files).toBe(11); // 3 + 5 + 2 + 1 — NOT the 3 files of `my`
+    expect(cost.closureSize).toBe(4);
+    expect(cost.countedAssetSpaces).toBe(4);
+    expect(cost.uncountedAssetSpaces).toBe(0);
+    expect(formatIndexCost(cost)).toBe("11 files · 4 assetspaces");
+  });
+
+  it("@req:6171f443-a57f-4d3a-bad6-8d964decb308 marks the total a LOWER BOUND when a closure member is not mounted (uncountable)", () => {
+    // `exo` is not materialized ⇒ its files cannot be walked ⇒ unknown, not zero.
+    const partial = new Map<string, number>([
+      [MY, 3],
+      [SHARED_PRIVATE, 5],
+      [PUBLIC, 2],
+    ]);
+    const cost = computeClosureIndexCost([MY], CATALOGUE, partial);
+
+    expect(cost.files).toBe(10);
+    expect(cost.uncountedAssetSpaces).toBe(1);
+    expect(formatIndexCost(cost)).toBe(
+      "≥ 10 files · 4 assetspaces (1 not mounted, uncounted)",
+    );
+  });
+
+  it("@req:6171f443-a57f-4d3a-bad6-8d964decb308 renders NOTHING when no closure member is countable (zero-regression path)", () => {
+    const cost = computeClosureIndexCost([MY], CATALOGUE, new Map());
+
+    expect(cost.countedAssetSpaces).toBe(0);
+    expect(formatIndexCost(cost)).toBeNull();
+  });
+
+  it("is cycle-safe and idempotent on a malformed dependsOn DAG", () => {
+    const cyclic: AssetSpaceInfo[] = [
+      info(MY, "my", [SHARED_PRIVATE]),
+      info(SHARED_PRIVATE, "shared-private", [MY]),
+    ];
+    const cost = computeClosureIndexCost(
+      [MY],
+      cyclic,
+      new Map([
+        [MY, 3],
+        [SHARED_PRIVATE, 5],
+      ]),
+    );
+
+    expect(cost.closureSize).toBe(2);
+    expect(cost.files).toBe(8);
+  });
+
+  it("prices a dependency-free AssetSpace as itself only", () => {
+    const cost = computeClosureIndexCost([EXO], CATALOGUE, ALL_COUNTED);
+
+    expect(cost.closureSize).toBe(1);
+    expect(formatIndexCost(cost)).toBe("1 files · 1 assetspace");
+  });
+});
+
+describe("formatAssetSpaceIndexCost (req 6171f443)", () => {
+  it("@req:6171f443-a57f-4d3a-bad6-8d964decb308 shows a pack's OWN size AND what its closure costs", () => {
+    // AC2 — own size alone is the misleading number; the closure is the honest one.
+    const line = formatAssetSpaceIndexCost(
+      ALL_COUNTED.get(PUBLIC),
+      computeClosureIndexCost([PUBLIC], CATALOGUE, ALL_COUNTED),
+    );
+
+    expect(line).toBe("2 files · with dependencies: 3 files · 2 assetspaces");
+  });
+
+  it("omits the dependency suffix for a pack that depends on nothing", () => {
+    const line = formatAssetSpaceIndexCost(
+      ALL_COUNTED.get(EXO),
+      computeClosureIndexCost([EXO], CATALOGUE, ALL_COUNTED),
+    );
+
+    expect(line).toBe("1 files");
+  });
+
+  it("renders nothing when the pack is uncountable and so is its closure", () => {
+    const line = formatAssetSpaceIndexCost(
+      undefined,
+      computeClosureIndexCost([PUBLIC], CATALOGUE, new Map()),
+    );
+
+    expect(line).toBeNull();
+  });
+});
+
+describe("ProfileFuzzyModal renders the index cost (req 6171f443)", () => {
+  function renderRow(choice: ProfileChoice): HTMLElement {
+    const modal = new ProfileFuzzyModal(
+      {} as never,
+      [choice],
+      "Apply profile",
+      () => undefined,
+    );
+    const el = document.createElement("div");
+    modal.renderSuggestion(
+      { item: choice, match: { score: 0, matches: [] } },
+      el,
+    );
+    return el;
+  }
+
+  it("@req:6171f443-a57f-4d3a-bad6-8d964decb308 surfaces the cost line in the picker row, before anything is applied", () => {
+    const el = renderRow({
+      uid: "profile-uid",
+      label: "$$kitelev-my",
+      indexCost: "11 files · 4 assetspaces",
+    });
+
+    expect(
+      el.querySelector(".exocortex-profile-suggestion__cost"),
+    ).not.toBeNull();
+    expect(el.textContent).toContain("11 files · 4 assetspaces");
+    // The human label is still the primary line (never replaced by the cost).
+    expect(el.textContent).toContain("$$kitelev-my");
+  });
+
+  it("@req:6171f443-a57f-4d3a-bad6-8d964decb308 renders no cost node at all when the cost is unknown (zero-regression)", () => {
+    const el = renderRow({ uid: "profile-uid", label: "$$kitelev-my" });
+
+    expect(el.querySelector(".exocortex-profile-suggestion__cost")).toBeNull();
+    expect(el.textContent).toBe("$$kitelev-my");
+  });
+});

--- a/packages/obsidian-plugin/tests/unit/domain/profile/indexCost.test.ts
+++ b/packages/obsidian-plugin/tests/unit/domain/profile/indexCost.test.ts
@@ -101,7 +101,8 @@ describe("computeClosureIndexCost (req 6171f443)", () => {
     const cost = computeClosureIndexCost([EXO], CATALOGUE, ALL_COUNTED);
 
     expect(cost.closureSize).toBe(1);
-    expect(formatIndexCost(cost)).toBe("1 files · 1 assetspace");
+    // Both units are pluralised — a lone AssetSpace reads `1 file · 1 assetspace`.
+    expect(formatIndexCost(cost)).toBe("1 file · 1 assetspace");
   });
 });
 
@@ -122,7 +123,7 @@ describe("formatAssetSpaceIndexCost (req 6171f443)", () => {
       computeClosureIndexCost([EXO], CATALOGUE, ALL_COUNTED),
     );
 
-    expect(line).toBe("1 files");
+    expect(line).toBe("1 file");
   });
 
   it("renders nothing when the pack is uncountable and so is its closure", () => {


### PR DESCRIPTION
## What

The two mount pickers now state **what a mount decision costs, in files** — measured over the transitive `exo__AssetSpace_dependsOn` **closure**:

- **`Apply profile`** — each profile row shows its closure cost **before** anything is applied.
- **`Remove knowledge pack`** — each pack row shows its **own** size *and* what its closure costs.

Runtime-derived from `vault.adapter` (mobile-safe), never persisted.

## Why the CLOSURE, not the AssetSpace

This is P1 of project `17c173dd`, **re-scoped by the verdict of its own falsification gate** (task `8b8466bb`, measured on the real vaults 2026-08-02):

| vault | total `.md` | active profile resolves to | % |
|---|---|---|---|
| vault-my | 8 738 | 8 738 | **100 %** |
| vault-tbank | 5 964 | 5 964 | **100 %** |
| vault-exodev | 8 379 | 8 333 | **99.4 %** |

The limiter is **not** the always-mounted TS floor (`{exo}` = 300 files = 3.4 %) — it is the closure. Mounting the personal `exoas-my` (3 763 files) *forces* another 4 862, so the "minimal profile that still has my data" saves **58 files (0.7 %)**.

So an AssetSpace's **own size alone is the misleading number** — it is precisely what makes "just turn the extra ones off" look promising. The gate's explicit recommendation was: *keep P1, re-scope it to show the CLOSURE cost, because that is what explains why turning things off does not work.* That is what this PR implements.

**Deliberately no millisecond estimate.** The same measurement established index time is linear in file count (`index_ms = 0.677 × files + 181`, R² = 0.9995), but the *constant* is device-specific while the *ratio* is stable — so a file count is the honest, device-independent weight; a ms figure would bake a fabricated constant into TS.

## Mechanism (no engine change)

1. **Pure** `domain/profile/indexCost.ts` (sibling of the shipped `closureGap.ts`) — reuses the **shared** `transitiveDependsOnClosure` that `ProfileApplyManager.resolveDeclaredAndEffective` and `CliProfileResolver` already use, so the preview matches what an apply resolves.
2. **`ProfileApplyManager.getIndexCostInputs()`** — counts each materialized AssetSpace with the manager's existing `vault.adapter.exists`/`.list` recursive walk. No `node:fs` ⇒ works on iOS (Desktop↔Mobile parity). Session-cached; invalidated on apply and on unmount.
3. **One render point** — the pack picker already maps `UnmountableAssetSpace → ProfileChoice` and reuses `ProfileFuzzyModal`, so a single optional `ProfileChoice.indexCost` rendered once serves **both** surfaces.

**Preview-only, never the apply path.** It deliberately does *not* call `resolveDeclaredAndEffective` — that asserts the TS floor and **throws** on a floor-violating profile, which would break the picker for every other row.

`exo__Profile_imports` is not walked; verified no profile in any of the three vaults uses it. Were one to, the preview would under-report, never over-report.

## Zero-regression (structural, not argued)

`formatIndexCost` returns `null` when nothing is countable ⇒ no cost is attached ⇒ rows render **byte-identically** to before. Both wiring points are wrapped so any failure degrades to today's rendering.

## Revert-verified

| axis | neutralized | result |
|---|---|---|
| 1 — closure expansion | price roots only, no closure | **4 closure-dependent RED**, 6 GREEN — incl. the dependency-free pack and *both* zero-regression controls |
| 2 — cost render | skip the cost node | **exactly the render test RED**, 9 GREEN — incl. the zero-regression render control |

Restored ⇒ 10/10 GREEN. Regression sweep over profile/assetspace/modal surfaces: **35 suites / 534 tests green**. All three `lint`-job guard scripts pass (`method-exists=55/55` unchanged).

Req: 6171f443-a57f-4d3a-bad6-8d964decb308
