### PR TITLE
feat(profile): warn about the blast radius before removing a knowledge pack (req d5bc68f6)

### DIFF
--- a/packages/obsidian-plugin/src/ExocortexPlugin.ts
+++ b/packages/obsidian-plugin/src/ExocortexPlugin.ts
@@ -164,6 +164,10 @@ import {
   formatAssetSpaceIndexCost,
   formatIndexCost,
 } from "./domain/profile/indexCost";
+import {
+  assessUnmountRisk,
+  formatUnmountRiskWarning,
+} from "./domain/profile/unmountSafety";
 import { lookupAssetSpaceUidByFolder } from "./infrastructure/adapters/AssetSpaceLookupHelper";
 import { createAssetSpacePusher } from "./infrastructure/adapters/AssetSpacePusherFactory";
 import { LocalSecretsStore } from "./infrastructure/adapters/LocalSecretsStore";
@@ -4496,6 +4500,28 @@ export default class ExocortexPlugin extends Plugin {
             resolve,
           ).open();
         }),
+      // req d5bc68f6 — read-only blast radius for the pick, shown above the
+      // destructive confirm. Both axes are cheap: the dependent-mount check
+      // reuses the already-scanned catalogue + the shared closure helper, and
+      // the dangling-link count reads Obsidian's already-computed
+      // `metadataCache.resolvedLinks` (no vault walk, no node:fs → identical on
+      // iOS). Returns null when nothing is at risk → wording unchanged.
+      assessRisk: async (chosen) => {
+        const infos = switchMgr.listAllAssetSpaceInfos();
+        const mountedUids = (await restMount.listMountedAssetSpaces()).flatMap(
+          (e) => {
+            const info = infos.find((i) => i.folderName === e.submodulePath);
+            return info === undefined ? [] : [info.uid];
+          },
+        );
+        const risk = assessUnmountRisk(
+          chosen,
+          mountedUids,
+          infos,
+          this.app.metadataCache.resolvedLinks,
+        );
+        return formatUnmountRiskWarning(risk, chosen.label);
+      },
       unmount: (submodulePath) => restMount.unmount(submodulePath),
       // #3540 follow-up — toast auto-records into the activity log via notifier.
       notify: (message) => this.notifier.info(message),

--- a/packages/obsidian-plugin/src/domain/profile/closureGap.ts
+++ b/packages/obsidian-plugin/src/domain/profile/closureGap.ts
@@ -29,8 +29,15 @@ export interface UnmountedClosureMember {
  * grounding-type enums that `CommandResolver.loadCommand` matches `rdf:type`
  * against. Their absence is the exact gap that left the alpha tester's entire
  * homoiconic command system silently dead (RFC 430e84f1 P3).
+ *
+ * Exported so the REVERSE check (`unmountSafety.ts`, req `d5bc68f6` — "who
+ * still needs the pack I am about to remove?") shares this single source of
+ * truth with the forward check below, instead of duplicating the list.
  */
-const TBOX_PROVIDER_NAMESPACES: ReadonlySet<string> = new Set(["exo", "exocmd"]);
+export const TBOX_PROVIDER_NAMESPACES: ReadonlySet<string> = new Set([
+  "exo",
+  "exocmd",
+]);
 
 /**
  * issue #3956 — the transitive `exo__AssetSpace_dependsOn` closure members of

--- a/packages/obsidian-plugin/src/domain/profile/unmountSafety.ts
+++ b/packages/obsidian-plugin/src/domain/profile/unmountSafety.ts
@@ -1,0 +1,210 @@
+import { transitiveDependsOnClosure } from "@kitelev/exocortex-core";
+import type { AssetSpaceInfo } from "../../infrastructure/adapters/AssetSpaceManager";
+import { TBOX_PROVIDER_NAMESPACES } from "./closureGap";
+
+/**
+ * req `d5bc68f6` — the blast radius of REMOVING a knowledge pack, assessed
+ * read-only before the destructive confirm.
+ *
+ * ## Why the warning is the load-bearing half of P2
+ *
+ * The parent project's falsification gate (task `8b8466bb`, measured 2026-08-02
+ * on the real vaults) found that mounting less through profiles does NOT
+ * materially help — the active profile already resolves to ~100 % of every
+ * vault, because the transitive `exo__AssetSpace_dependsOn` closure is forced.
+ * Its verdict for this task was explicit: granularity buys nothing where the
+ * closure is forced, and is useful **only together with the reverse-reference
+ * warning**, which the same measurement quantified as real — 3 684 wikilinks
+ * from 1 464 personal assets point into `shared-private` alone.
+ *
+ * So the danger is not "the user cannot trim enough"; it is "the user CAN
+ * remove a pack the rest of the vault still needs". Two independent ways that
+ * bites, both assessed here:
+ *
+ * 1. **A declared dependency.** Another still-mounted AssetSpace has this one in
+ *    its `dependsOn` closure. This is the exact mirror of
+ *    {@link detectUnmountedClosureMembers} — that one asks "what did I forget to
+ *    mount?", this one asks "who still needs what I am about to remove?".
+ *    Removing a TBox provider is the worst case: `exocmd` is OPTIONAL (not
+ *    TS-floor), so it CAN be removed today, and its absence leaves homoiconic
+ *    commands and SHACL validation **silently** dead.
+ * 2. **Incoming links.** Notes that stay behind link into the pack's files.
+ *    After the removal those links dangle.
+ *
+ * ## Why `resolvedLinks` is the right (and free) source
+ *
+ * Obsidian already maintains `metadataCache.resolvedLinks`
+ * (`Record<source, Record<target, count>>`) — no vault walk, no `node:fs`, so
+ * this costs nothing extra and behaves identically on iOS (Desktop↔Mobile
+ * parity). It carries only links whose target EXISTS, which is exactly what is
+ * wanted: the pack is still mounted at assessment time, so a link into it
+ * resolves now and would dangle after the removal.
+ */
+export interface UnmountRisk {
+  /**
+   * Labels of the still-mounted AssetSpaces whose transitive `dependsOn`
+   * closure contains the pack being removed. Empty ⇒ nothing declared depends
+   * on it.
+   */
+  dependents: string[];
+  /** Resolved links pointing from OUTSIDE the pack into files INSIDE it. */
+  incomingLinks: number;
+  /** Distinct files outside the pack that contain those links. */
+  linkingFiles: number;
+  /**
+   * The pack supplies the class / command-binding-resolution TBox
+   * ({@link TBOX_PROVIDER_NAMESPACES}) — removing it breaks homoiconic commands
+   * and validation silently rather than loudly.
+   */
+  providesTBox: boolean;
+}
+
+/** The subset of a picked AssetSpace this assessment needs. */
+export interface UnmountTarget {
+  uid: string;
+  /** Vault-relative mount folder — the folder the removal deletes. */
+  submodulePath: string;
+  namespace: string;
+}
+
+/** Obsidian's `metadataCache.resolvedLinks` shape. */
+export type ResolvedLinks = Readonly<Record<string, Record<string, number>>>;
+
+/** `assetspaces/kitelev/exoas-x` → `assetspaces/kitelev/exoas-x/` (idempotent). */
+function asFolderPrefix(mountPath: string): string {
+  return mountPath.endsWith("/") ? mountPath : `${mountPath}/`;
+}
+
+/**
+ * req `d5bc68f6` — the still-mounted AssetSpaces that declare a dependency on
+ * `targetUid`, i.e. the REVERSE of {@link detectUnmountedClosureMembers}.
+ *
+ * Pure. Expands each mounted AssetSpace through the SAME shared
+ * {@link transitiveDependsOnClosure} helper that
+ * `ProfileApplyManager.resolveDeclaredAndEffective` and `CliProfileResolver`
+ * use, so "depends on" here means exactly what an apply would resolve. The
+ * target itself is never reported as its own dependent.
+ *
+ * @param targetUid The AssetSpace about to be removed.
+ * @param mountedUids The AssetSpace UIDs currently mounted.
+ * @param allInfos The scanned AssetSpace catalogue (carries `dependsOn` edges).
+ * @returns Sorted, de-duplicated labels (`namespace`, else the short UID).
+ */
+export function findDependentMountedAssetSpaces(
+  targetUid: string,
+  mountedUids: Iterable<string>,
+  allInfos: ReadonlyArray<AssetSpaceInfo>,
+): string[] {
+  if (targetUid.length === 0) return [];
+  const dependsOnMap = new Map<string, string[]>();
+  const infoByUid = new Map<string, AssetSpaceInfo>();
+  for (const info of allInfos) {
+    infoByUid.set(info.uid, info);
+    if (info.dependsOn !== undefined && info.dependsOn.length > 0) {
+      dependsOnMap.set(info.uid, info.dependsOn);
+    }
+  }
+  const labels = new Set<string>();
+  for (const uid of mountedUids) {
+    if (uid === targetUid || uid.length === 0) continue;
+    const closure = transitiveDependsOnClosure(new Set([uid]), dependsOnMap);
+    if (!closure.has(targetUid)) continue;
+    const namespace = infoByUid.get(uid)?.namespace ?? "";
+    labels.add(namespace.length > 0 ? namespace : uid.slice(0, 8));
+  }
+  return [...labels].sort((a, b) => a.localeCompare(b));
+}
+
+/**
+ * req `d5bc68f6` — links pointing from OUTSIDE `mountPath` into files INSIDE it.
+ *
+ * Pure. A source inside the folder is skipped (an internal link survives the
+ * removal along with both of its ends — only links whose SOURCE stays behind
+ * can dangle).
+ */
+export function countIncomingLinks(
+  mountPath: string,
+  resolvedLinks: ResolvedLinks,
+): { links: number; files: number } {
+  if (mountPath.length === 0) return { links: 0, files: 0 };
+  const prefix = asFolderPrefix(mountPath);
+  let links = 0;
+  const sources = new Set<string>();
+  for (const [source, targets] of Object.entries(resolvedLinks)) {
+    if (source.startsWith(prefix)) continue; // internal — removed together
+    for (const [target, count] of Object.entries(targets)) {
+      if (!target.startsWith(prefix)) continue;
+      links += count;
+      sources.add(source);
+    }
+  }
+  return { links, files: sources.size };
+}
+
+/**
+ * req `d5bc68f6` — assess both risk axes for one pick. Pure; the caller supplies
+ * the already-scanned catalogue, the mounted set and Obsidian's link index.
+ */
+export function assessUnmountRisk(
+  target: UnmountTarget,
+  mountedUids: Iterable<string>,
+  allInfos: ReadonlyArray<AssetSpaceInfo>,
+  resolvedLinks: ResolvedLinks,
+): UnmountRisk {
+  const { links, files } = countIncomingLinks(
+    target.submodulePath,
+    resolvedLinks,
+  );
+  return {
+    dependents: findDependentMountedAssetSpaces(
+      target.uid,
+      mountedUids,
+      allInfos,
+    ),
+    incomingLinks: links,
+    linkingFiles: files,
+    providesTBox: TBOX_PROVIDER_NAMESPACES.has(target.namespace),
+  };
+}
+
+/**
+ * req `d5bc68f6` — render the blast radius as one warning line to prepend to the
+ * destructive confirmation.
+ *
+ * Returns `null` when NOTHING is at risk — no dependent mount and no incoming
+ * link. That null is what makes the zero-regression guarantee structural rather
+ * than argued: the caller prepends nothing and the confirmation wording stays
+ * byte-identical to the one shipped before this requirement.
+ *
+ * The TBox note is deliberately attached only when there IS a risk to report —
+ * on its own, "this pack supplies TBox" is not a reason to warn about a removal
+ * nothing depends on.
+ */
+export function formatUnmountRiskWarning(
+  risk: UnmountRisk,
+  label: string,
+): string | null {
+  const clauses: string[] = [];
+  if (risk.dependents.length > 0) {
+    const one = risk.dependents.length === 1;
+    clauses.push(
+      `${risk.dependents.join(", ")} ${one ? "is" : "are"} still mounted and ` +
+        `${one ? "declares" : "declare"} a dependency on it`,
+    );
+  }
+  if (risk.incomingLinks > 0) {
+    const oneLink = risk.incomingLinks === 1;
+    const oneFile = risk.linkingFiles === 1;
+    clauses.push(
+      `${risk.incomingLinks} link${oneLink ? "" : "s"} from ` +
+        `${risk.linkingFiles} file${oneFile ? "" : "s"} outside it ` +
+        `would be left dangling`,
+    );
+  }
+  if (clauses.length === 0) return null;
+  const tbox = risk.providesTBox
+    ? " It also supplies the class / command TBox — without it, homoiconic " +
+      "commands and validation break silently."
+    : "";
+  return `⚠ Removing «${label}» is not isolated: ${clauses.join("; ")}.${tbox}`;
+}

--- a/packages/obsidian-plugin/src/infrastructure/adapters/UnmountAssetSpaceCommand.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/UnmountAssetSpaceCommand.ts
@@ -74,6 +74,18 @@ export interface UnmountAssetSpaceCommandDeps {
   confirm: (message: string) => Promise<boolean>;
   /** Unmount the AssetSpace — `RestAssetSpaceMount.unmount` (git-free). */
   unmount: (submodulePath: string) => Promise<void>;
+  /**
+   * req `d5bc68f6` — OPTIONAL read-only blast-radius assessment for the picked
+   * AssetSpace, rendered ABOVE the destructive confirmation: which still-mounted
+   * packs declare a dependency on it, and how many links from the notes that
+   * stay behind would be left dangling (see `domain/profile/unmountSafety.ts`).
+   *
+   * Returns `null` when nothing is at risk — the confirmation then reads exactly
+   * as it did before this requirement (structural zero-regression). Optional and
+   * best-effort by design: unwired or throwing, the removal stays possible with
+   * the unchanged wording. It informs the destructive gate; it never refuses.
+   */
+  assessRisk?: (chosen: UnmountableAssetSpace) => Promise<string | null>;
   /** User-facing Notice. */
   notify: (message: string) => void;
   /**
@@ -179,9 +191,15 @@ export class UnmountAssetSpaceCommand {
       return;
     }
 
-    const ok = await this.d.confirm(
+    // req d5bc68f6 — state the blast radius ABOVE the destructive wording, so it
+    // is the first thing read. `null` (nothing at risk / unwired / threw) keeps
+    // the message byte-identical to the pre-requirement wording.
+    const baseMessage =
       `Unmount «${chosen.label}» (${chosen.submodulePath})? ` +
-        "This strips its .gitmodules entry and deletes the folder from the vault.",
+      "This strips its .gitmodules entry and deletes the folder from the vault.";
+    const warning = await this.assessRiskSafely(chosen);
+    const ok = await this.d.confirm(
+      warning === null ? baseMessage : `${warning}\n\n${baseMessage}`,
     );
     if (!ok) return; // user declined
 
@@ -197,6 +215,22 @@ export class UnmountAssetSpaceCommand {
         "Reload Obsidian if the removed assets still appear.",
     );
     await this.runOnUnmounted();
+  }
+
+  /**
+   * req `d5bc68f6` — run the optional blast-radius assessment. Never throws: an
+   * assessment failure degrades to the unchanged confirmation rather than
+   * blocking a removal the user is entitled to make.
+   */
+  private async assessRiskSafely(
+    chosen: UnmountableAssetSpace,
+  ): Promise<string | null> {
+    if (this.d.assessRisk === undefined) return null;
+    try {
+      return await this.d.assessRisk(chosen);
+    } catch {
+      return null;
+    }
   }
 
   private async runOnUnmounted(): Promise<void> {

--- a/packages/obsidian-plugin/tests/unit/domain/profile/unmountSafety.test.ts
+++ b/packages/obsidian-plugin/tests/unit/domain/profile/unmountSafety.test.ts
@@ -1,0 +1,274 @@
+import {
+  assessUnmountRisk,
+  countIncomingLinks,
+  findDependentMountedAssetSpaces,
+  formatUnmountRiskWarning,
+  type ResolvedLinks,
+} from "../../../../src/domain/profile/unmountSafety";
+import type { AssetSpaceInfo } from "../../../../src/infrastructure/adapters/AssetSpaceManager";
+
+/**
+ * req d5bc68f6 — the pure blast-radius assessment behind the «Remove knowledge
+ * pack» confirmation.
+ *
+ * The catalogue below mirrors the REAL vault-my `dependsOn` graph measured by
+ * the project's falsification gate (task 8b8466bb, 2026-08-02):
+ *
+ *   my → shared-private, shared-identities
+ *   shared-private → public
+ *   shared-identities → public
+ *   public → exo, exocmd
+ *   exocmd → exo
+ *
+ * That shape is what makes the check non-trivial: `public` is reachable from
+ * `my` only TRANSITIVELY, and `exo`/`exocmd` only at depth 3-4 — a direct-edge
+ * check would miss every one of them.
+ */
+const UID = {
+  my: "10000000-0000-0000-0000-000000000001",
+  sharedPrivate: "10000000-0000-0000-0000-000000000002",
+  sharedIdentities: "10000000-0000-0000-0000-000000000003",
+  public: "10000000-0000-0000-0000-000000000004",
+  exocmd: "10000000-0000-0000-0000-000000000005",
+  exo: "10000000-0000-0000-0000-000000000006",
+  detached: "10000000-0000-0000-0000-000000000007",
+} as const;
+
+function info(
+  uid: string,
+  namespace: string,
+  dependsOn?: string[],
+): AssetSpaceInfo {
+  return {
+    uid,
+    git: `https://github.com/kitelev/exoas-${namespace}`,
+    namespace,
+    folderName: `assetspaces/kitelev/exoas-${namespace}`,
+    ...(dependsOn === undefined ? {} : { dependsOn }),
+  };
+}
+
+const CATALOGUE: AssetSpaceInfo[] = [
+  info(UID.my, "my", [UID.sharedPrivate, UID.sharedIdentities]),
+  info(UID.sharedPrivate, "shared-private", [UID.public]),
+  info(UID.sharedIdentities, "shared-identities", [UID.public]),
+  info(UID.public, "public", [UID.exo, UID.exocmd]),
+  info(UID.exocmd, "exocmd", [UID.exo]),
+  info(UID.exo, "exo"),
+  info(UID.detached, "detached"),
+];
+
+const ALL_MOUNTED = Object.values(UID);
+
+describe("findDependentMountedAssetSpaces", () => {
+  it("reports every mounted pack that reaches the target TRANSITIVELY", () => {
+    // `public` is a direct dependency of neither `my` nor the shared packs'
+    // callers — it is reached at depth 2 from `my`.
+    expect(
+      findDependentMountedAssetSpaces(UID.public, ALL_MOUNTED, CATALOGUE),
+    ).toEqual(["my", "shared-identities", "shared-private"]);
+  });
+
+  it("reaches the deepest member (exo, depth 3-4 from my)", () => {
+    expect(
+      findDependentMountedAssetSpaces(UID.exo, ALL_MOUNTED, CATALOGUE),
+    ).toEqual([
+      "exocmd",
+      "my",
+      "public",
+      "shared-identities",
+      "shared-private",
+    ]);
+  });
+
+  it("a leaf nothing depends on has no dependents", () => {
+    expect(
+      findDependentMountedAssetSpaces(UID.my, ALL_MOUNTED, CATALOGUE),
+    ).toEqual([]);
+  });
+
+  it("an UNMOUNTED dependent is not reported (it cannot break)", () => {
+    // Only `detached` is mounted; it declares nothing.
+    expect(
+      findDependentMountedAssetSpaces(UID.public, [UID.detached], CATALOGUE),
+    ).toEqual([]);
+  });
+
+  it("never reports the target as its own dependent", () => {
+    expect(
+      findDependentMountedAssetSpaces(UID.exocmd, ALL_MOUNTED, CATALOGUE),
+    ).not.toContain("exocmd");
+  });
+
+  it("a dependent with no scanned descriptor falls back to its short UID", () => {
+    const orphanUid = "99999999-aaaa-bbbb-cccc-dddddddddddd";
+    const catalogue = [
+      ...CATALOGUE,
+      { ...info(orphanUid, "", [UID.exo]), namespace: "" },
+    ];
+    expect(
+      findDependentMountedAssetSpaces(UID.exo, [orphanUid], catalogue),
+    ).toEqual(["99999999"]);
+  });
+
+  it("an empty target uid yields nothing (degenerate input, never a false alarm)", () => {
+    expect(findDependentMountedAssetSpaces("", ALL_MOUNTED, CATALOGUE)).toEqual(
+      [],
+    );
+  });
+});
+
+describe("countIncomingLinks", () => {
+  const PACK = "assetspaces/kitelev/exoas-shared-private";
+  const LINKS: ResolvedLinks = {
+    // Two notes that STAY BEHIND, linking into the pack.
+    "assetspaces/kitelev/exoas-my/notes/a.md": {
+      [`${PACK}/concepts/x.md`]: 3,
+      [`${PACK}/concepts/y.md`]: 1,
+      "assetspaces/kitelev/exoas-my/notes/b.md": 5, // unrelated target
+    },
+    "assetspaces/kitelev/exoas-my/notes/b.md": {
+      [`${PACK}/concepts/x.md`]: 2,
+    },
+    // A note INSIDE the pack — it is removed together with its target.
+    [`${PACK}/concepts/y.md`]: {
+      [`${PACK}/concepts/x.md`]: 9,
+    },
+    // A note that stays behind but links nowhere near the pack.
+    "assetspaces/kitelev/exoas-my/notes/c.md": {
+      "assetspaces/kitelev/exoas-my/notes/a.md": 1,
+    },
+  };
+
+  it("counts links from OUTSIDE into the pack, and the distinct files holding them", () => {
+    expect(countIncomingLinks(PACK, LINKS)).toEqual({ links: 6, files: 2 });
+  });
+
+  it("ignores links whose SOURCE is inside the pack (both ends leave together)", () => {
+    const onlyInternal: ResolvedLinks = {
+      [`${PACK}/concepts/y.md`]: { [`${PACK}/concepts/x.md`]: 9 },
+    };
+    expect(countIncomingLinks(PACK, onlyInternal)).toEqual({
+      links: 0,
+      files: 0,
+    });
+  });
+
+  it("does not match a sibling folder sharing the pack's prefix", () => {
+    // `exoas-shared-private-concepts` must NOT be treated as inside
+    // `exoas-shared-private` — the trailing separator is what prevents it.
+    const sibling: ResolvedLinks = {
+      "assetspaces/kitelev/exoas-my/n.md": {
+        "assetspaces/kitelev/exoas-shared-private-concepts/z.md": 4,
+      },
+    };
+    expect(countIncomingLinks(PACK, sibling)).toEqual({ links: 0, files: 0 });
+  });
+
+  it("tolerates a trailing slash on the mount path", () => {
+    expect(countIncomingLinks(`${PACK}/`, LINKS)).toEqual({
+      links: 6,
+      files: 2,
+    });
+  });
+
+  it("an empty mount path counts nothing (never a vault-wide false alarm)", () => {
+    expect(countIncomingLinks("", LINKS)).toEqual({ links: 0, files: 0 });
+  });
+});
+
+describe("assessUnmountRisk + formatUnmountRiskWarning", () => {
+  const target = (uid: string, namespace: string) => ({
+    uid,
+    submodulePath: `assetspaces/kitelev/exoas-${namespace}`,
+    namespace,
+  });
+
+  it("both axes at risk → one line naming the dependents and the dangling links", () => {
+    const links: ResolvedLinks = {
+      "assetspaces/kitelev/exoas-my/a.md": {
+        "assetspaces/kitelev/exoas-public/c.md": 2,
+      },
+    };
+    const risk = assessUnmountRisk(
+      target(UID.public, "public"),
+      ALL_MOUNTED,
+      CATALOGUE,
+      links,
+    );
+
+    expect(risk.dependents).toEqual([
+      "my",
+      "shared-identities",
+      "shared-private",
+    ]);
+    expect(risk.incomingLinks).toBe(2);
+    expect(risk.linkingFiles).toBe(1);
+    expect(risk.providesTBox).toBe(false);
+
+    const warning = formatUnmountRiskWarning(risk, "public");
+    expect(warning).toContain("my, shared-identities, shared-private");
+    expect(warning).toContain("are still mounted and declare a dependency");
+    expect(warning).toContain("2 links from 1 file outside it");
+    expect(warning).not.toContain("class / command TBox");
+  });
+
+  it("removing a TBox provider says so explicitly (exocmd is NOT floor-protected)", () => {
+    const risk = assessUnmountRisk(
+      target(UID.exocmd, "exocmd"),
+      ALL_MOUNTED,
+      CATALOGUE,
+      {},
+    );
+
+    expect(risk.providesTBox).toBe(true);
+    const warning = formatUnmountRiskWarning(risk, "exocmd");
+    expect(warning).toContain("class / command TBox");
+    expect(warning).toContain("break silently");
+  });
+
+  it("nothing at risk → null (the caller then leaves the wording untouched)", () => {
+    const risk = assessUnmountRisk(
+      target(UID.my, "my"),
+      ALL_MOUNTED,
+      CATALOGUE,
+      {},
+    );
+
+    expect(risk.dependents).toEqual([]);
+    expect(risk.incomingLinks).toBe(0);
+    expect(formatUnmountRiskWarning(risk, "my")).toBeNull();
+  });
+
+  it("a TBox provider nothing depends on still yields null — the note is not a reason on its own", () => {
+    const risk = assessUnmountRisk(
+      target(UID.exo, "exo"),
+      [UID.exo], // nothing else mounted
+      CATALOGUE,
+      {},
+    );
+
+    expect(risk.providesTBox).toBe(true);
+    expect(formatUnmountRiskWarning(risk, "exo")).toBeNull();
+  });
+
+  it("singular wording for exactly one dependent and one link", () => {
+    const links: ResolvedLinks = {
+      "assetspaces/kitelev/exoas-my/a.md": {
+        "assetspaces/kitelev/exoas-exo/c.md": 1,
+      },
+    };
+    const risk = assessUnmountRisk(
+      target(UID.exo, "exo"),
+      [UID.exocmd],
+      CATALOGUE,
+      links,
+    );
+
+    const warning = formatUnmountRiskWarning(risk, "exo");
+    expect(warning).toContain(
+      "exocmd is still mounted and declares a dependency",
+    );
+    expect(warning).toContain("1 link from 1 file outside it");
+  });
+});

--- a/packages/obsidian-plugin/tests/unit/infrastructure/adapters/UnmountAssetSpaceCommand.test.ts
+++ b/packages/obsidian-plugin/tests/unit/infrastructure/adapters/UnmountAssetSpaceCommand.test.ts
@@ -49,6 +49,10 @@ function makeHarness(opts: {
   pickPath?: string | null;
   confirm?: boolean;
   unmountThrows?: boolean;
+  /** req d5bc68f6 — omit to leave `assessRisk` UNWIRED (pre-requirement path). */
+  riskWarning?: string | null;
+  /** req d5bc68f6 — the assessment itself blows up. */
+  riskThrows?: boolean;
 }): Harness {
   const notices: string[] = [];
   const unmountCalls: string[] = [];
@@ -85,6 +89,16 @@ function makeHarness(opts: {
       state.onUnmountedCalls++;
     },
   };
+
+  // req d5bc68f6 — wired ONLY when the scenario asks for it, so the other tests
+  // keep exercising the unwired (pre-requirement) path.
+  if (opts.riskThrows === true) {
+    deps.assessRisk = async () => {
+      throw new Error("assessment boom");
+    };
+  } else if (opts.riskWarning !== undefined) {
+    deps.assessRisk = async () => opts.riskWarning ?? null;
+  }
 
   return {
     cmd: new UnmountAssetSpaceCommand(deps),
@@ -265,5 +279,94 @@ describe("buildUnmountableList — .gitmodules ∩ descriptor join + dual floor 
     );
     expect(orphan.isFloor).toBe(false);
     expect(orphan.label).toBe("exoas-orphan");
+  });
+});
+
+/**
+ * req d5bc68f6 — the blast-radius warning is prepended to the destructive
+ * confirmation, and its ABSENCE leaves that confirmation byte-identical to the
+ * wording shipped before this requirement.
+ *
+ * The exact pre-requirement string is pinned as a constant here on purpose: it
+ * is what the zero-regression claim MEANS, so a future edit to the wording has
+ * to be a deliberate act rather than an accident.
+ */
+const PRE_REQ_CONFIRM =
+  "Unmount «pmbok» (assetspaces/kitelev/exoas-pmbok-ontology)? " +
+  "This strips its .gitmodules entry and deletes the folder from the vault.";
+
+describe("UnmountAssetSpaceCommand — removal blast radius", () => {
+  it("@req:d5bc68f6-c4ed-45a4-8eab-a4bd77798fdf warning is prepended above the destructive confirmation", async () => {
+    const h = makeHarness({
+      mounted: [PMBOK],
+      pickPath: PMBOK.submodulePath,
+      riskWarning: "⚠ Removing «pmbok» is not isolated: exo is still mounted.",
+      confirm: false,
+    });
+
+    await h.cmd.invokeUnmount();
+
+    expect(h.confirmCalls).toHaveLength(1);
+    const [message] = h.confirmCalls;
+    expect(message).toContain("⚠ Removing «pmbok» is not isolated");
+    // The warning must come FIRST — it is the reason to reconsider.
+    expect(message.indexOf("⚠")).toBeLessThan(message.indexOf("Unmount «pmbok»"));
+    // …and the destructive wording is preserved underneath it, unedited.
+    expect(message.endsWith(PRE_REQ_CONFIRM)).toBe(true);
+  });
+
+  it("@req:d5bc68f6-c4ed-45a4-8eab-a4bd77798fdf nothing at risk → confirmation byte-identical to the pre-requirement wording", async () => {
+    const h = makeHarness({
+      mounted: [PMBOK],
+      pickPath: PMBOK.submodulePath,
+      riskWarning: null,
+      confirm: false,
+    });
+
+    await h.cmd.invokeUnmount();
+
+    expect(h.confirmCalls).toEqual([PRE_REQ_CONFIRM]);
+  });
+
+  it("@req:d5bc68f6-c4ed-45a4-8eab-a4bd77798fdf assessment throws → wording unchanged and the removal still proceeds", async () => {
+    const h = makeHarness({
+      mounted: [PMBOK],
+      pickPath: PMBOK.submodulePath,
+      riskThrows: true,
+      confirm: true,
+    });
+
+    await h.cmd.invokeUnmount();
+
+    expect(h.confirmCalls).toEqual([PRE_REQ_CONFIRM]);
+    expect(h.unmountCalls).toEqual([PMBOK.submodulePath]);
+  });
+
+  it("a floor pick is refused before any assessment or confirmation", async () => {
+    // The assessment sits between the floor refusal and the confirm, so "no
+    // confirm was raised" is exactly "the refusal short-circuited first".
+    const h = makeHarness({
+      mounted: [EXO],
+      pickPath: EXO.submodulePath,
+      riskWarning: "⚠ should never be rendered",
+    });
+
+    await h.cmd.invokeUnmount();
+
+    expect(h.confirmCalls).toEqual([]);
+    expect(h.unmountCalls).toEqual([]);
+    expect(h.notices.some((n) => n.includes("Unmount refused"))).toBe(true);
+  });
+
+  it("unwired assessment (dep omitted) → confirmation byte-identical", async () => {
+    const h = makeHarness({
+      mounted: [PMBOK],
+      pickPath: PMBOK.submodulePath,
+      confirm: false,
+    });
+
+    await h.cmd.invokeUnmount();
+
+    expect(h.confirmCalls).toEqual([PRE_REQ_CONFIRM]);
   });
 });


### PR DESCRIPTION
feat(profile): warn about the blast radius before removing a knowledge pack

Req: d5bc68f6-c4ed-45a4-8eab-a4bd77798fdf

«Remove knowledge pack (advanced)» now states what the removal would break,
above the destructive confirmation:

- which STILL-MOUNTED packs declare a transitive `exo__AssetSpace_dependsOn`
  on the one being removed (the reverse of the shipped `closureGap` check),
  calling out explicitly when the pack supplies the class / command TBox —
  `exocmd` is OPTIONAL, not TS-floor, so it can be removed today and its
  absence leaves homoiconic commands and SHACL validation silently dead;
- how many resolved links from how many files that STAY BEHIND point into it
  and would be left dangling.

This is P2 of project 17c173dd, re-scoped to the warning half per the explicit
verdict of its own falsification gate P0 (task 8b8466bb): granularity buys
nothing where the closure is forced (~0.7 % of files), and is useful ONLY
together with this reverse-reference warning, which P0 measured as real —
3 684 links from 1 464 personal assets point into shared-private alone. A
free-form mount/unmount panel is therefore deliberately NOT built: it would
sell an outcome that measures at −0.6 % while inviting the removal that
breaks the vault.

Mechanism (zero new engine code): a pure `domain/profile/unmountSafety.ts`
reusing the shared `transitiveDependsOnClosure` from core, plus Obsidian's
already-computed `metadataCache.resolvedLinks` — no vault walk, no `node:fs`,
so it is free and identical on iOS (Desktop↔Mobile parity).
`TBOX_PROVIDER_NAMESPACES` is now exported from `closureGap.ts` so the forward
(mount-gap) and reverse (unmount-risk) checks share one source of truth.

Zero-regression is structural: with nothing at risk the formatter returns
`null`, nothing is prepended, and the confirmation is byte-identical to the
shipped wording. The assessment dep is optional and best-effort — unwired or
throwing, the removal still proceeds with the unchanged message. It informs
the destructive gate; it never refuses.

Revert-verified: @req:d5bc68f6-c4ed-45a4-8eab-a4bd77798fdf, each break
reddening only its own assertions —
  - neutralise the warning prepend  → 1 RED (the 4 zero-regression / negative
    controls stay GREEN)
  - neutralise dependent detection  → 6 RED (link-counting stays GREEN)
  - link counting decomposes into THREE independent sub-guards, so no single
    type-preserving break reddens all four link tests at once: target filter
    → 3 RED, source filter → 3 RED, folder separator → 1 RED (union: the 4
    distinct link tests). Corrected after the reviewer reproduced it — the
    axis is locked more finely than "4 RED" would suggest.
restore → 35/35 GREEN (twice). Regression sweep: 33 suites / 503 tests green.

Reviewed by the `code-reviewer` agent: **APPROVE**, 0 CRITICAL / 0 HIGH /
0 MEDIUM. It re-ran every revert axis itself, checked the reverse-closure
against `ProfileApplyManager.resolveDeclaredAndEffective` (same helper, same
map construction), and confirmed via `obsidian.d.ts` that `resolvedLinks`
keys are vault-absolute paths — so the count is a floor (an already-unresolved
link cannot be newly broken), never an overcount.

Two LOW notes left unapplied on the approved+green head: the second
`listMountedAssetSpaces()` read inside `assessRisk` is **intentional** (keeps
the dep self-contained and re-reads mount state after the picker, which may
sit open for a while), and the `infos.find` join is O(mounts x infos) at ~20
AssetSpaces once per removal.

---

**Out of scope (deliberate):** a new panel listing every AssetSpace with mount-state + a free-form toggle. The mounted list with own+closure size already exists («Remove knowledge pack», req `6171f443`), mounting already exists («Add a knowledge pack» / `assetspace-add`), and P0 measured free-form trimming at ~0.7%. Also out of scope: changing what is mounted, and a CLI blast-radius equivalent for `assetspace-remove` (sibling surface).
