### PR TITLE
fix(grounding): write the legacy prototype backlink only for prototypes, by UID

### DIFF
--- a/packages/core/src/services/GroundingExecutor.ts
+++ b/packages/core/src/services/GroundingExecutor.ts
@@ -1235,7 +1235,13 @@ export class GroundingExecutor {
     // linkBackProperty. Safety-net for degraded mode where Universal singleton
     // is fully absent (IRs missing → no rule wrote backlink). Bug #5 returns
     // here, but a corrupt asset is preferable to creation failure.
-    this.applyMissingBacklinkTopUp(properties, grounding, targetIRI, targetFilePath);
+    await this.applyMissingBacklinkTopUp(
+      properties,
+      grounding,
+      targetIRI,
+      targetFilePath,
+      targetFm,
+    );
 
     // Per-Grounding explicit linkBackProperty (legacy escape hatch) — still
     // honoured when set. Universal IRs handle the default case; per-Grounding
@@ -1783,15 +1789,24 @@ export class GroundingExecutor {
    *     key (exo__Asset_prototype, ems__Effort_parent)
    *
    * This guards the safety net from double-writing backlink when the IR step
-   * already produced one. When it does fire, Bug #5 returns (Project gets
-   * the wrong key), but a corrupt asset is preferable to creation failure.
+   * already produced one.
+   *
+   * req 0bb06beb — and it fires ONLY when the target IS a prototype. The old
+   * comment framed the choice as «a corrupt asset is preferable to creation
+   * failure»; that dilemma was false, because writing NOTHING was never on the
+   * table. A missing backlink is a normal state, while an invented one is a lie
+   * the graph then carries — measured at 112 assets across the three vaults,
+   * each asserting `exo__Asset_prototype` toward a daily note / area / any class
+   * without a backlink rule. The net is kept where it is truthful: a real
+   * prototype whose Universal InheritanceRules are absent still gets its link.
    */
-  private applyMissingBacklinkTopUp(
+  private async applyMissingBacklinkTopUp(
     properties: Record<string, unknown>,
     grounding: GroundingDefinition,
     targetIRI: string,
     targetFilePath: string,
-  ): void {
+    targetFm?: Record<string, string | string[]> | null,
+  ): Promise<void> {
     if (!targetIRI || grounding.linkBackProperty) return;
     if (
       properties.exo__Asset_prototype !== undefined ||
@@ -1819,10 +1834,130 @@ export class GroundingExecutor {
     if (GroundingExecutor.propertiesReferenceTarget(properties, backLinkTarget)) {
       return;
     }
-    properties.exo__Asset_prototype = `"[[${backLinkTarget}]]"`;
+    // req 0bb06beb — the gate. `exo__Asset_prototype` means «this asset was
+    // instantiated from that prototype», so writing it toward a non-prototype
+    // is false by definition. `targetFm` is only pre-read when the grounding
+    // needed it (inheritanceRule / $target tokens / cloneTargetBody), and the
+    // degraded path this net exists for is exactly the one where it was NOT —
+    // so read the target here rather than defaulting to a guess. Unreadable or
+    // unresolvable target → write nothing: an absent backlink is recoverable,
+    // an invented one silently corrupts the graph.
+    const fm =
+      targetFm ?? (await this.readTargetFrontmatter(targetIRI, targetFilePath));
+    if (!(await this.targetIsPrototype(fm))) return;
+    // req 0bb06beb — UID-canon reference. `extractBacklinkTarget` falls back to
+    // the full vault path for a label-named target, which breaks the moment the
+    // target is renamed or moved. The asset's own uid is stable, so prefer it.
+    // The raw value may still carry YAML quoting (`exo__Asset_uid: "<uid>"`),
+    // which would nest inside the wikilink and corrupt the reference.
+    const rawUid = fm?.["exo__Asset_uid"];
+    const uid =
+      typeof rawUid === "string" ? rawUid.trim().replace(/^"+|"+$/g, "").trim() : "";
+    const canonicalTarget = uid.length > 0 ? uid : backLinkTarget;
+    properties.exo__Asset_prototype = `"[[${canonicalTarget}]]"`;
     LoggingService.error(
-      "[GroundingExecutor] No backlink rule fired (Universal IRs absent or no class match). Falling back to legacy exo__Asset_prototype default. Bug #5 may surface if target is not a prototype-instance.",
+      "[GroundingExecutor] No backlink rule fired (Universal IRs absent or no class match). Falling back to legacy exo__Asset_prototype default — the target is a prototype, so the link is valid.",
     );
+  }
+
+  /**
+   * req 0bb06beb — read the click-target's frontmatter on the degraded backlink
+   * path, where `executeCreateInstance` had no reason to read it earlier. Any
+   * failure yields `null`, which the caller treats as «cannot confirm» and so
+   * writes no backlink at all.
+   */
+  private async readTargetFrontmatter(
+    targetIRI: string,
+    targetFilePath: string,
+  ): Promise<Record<string, string | string[]> | null> {
+    // Prefer the caller's path verbatim — `resolveTargetPath` normalises it for
+    // wikilink use (strips a leading slash and the `.md`), which is exactly what
+    // a file reader must NOT receive. Fall back to deriving it from the IRI so
+    // the IRI-only call shape (Issue #3195's fallback branch) is covered too.
+    let path = targetFilePath;
+    if (!path) {
+      const base = GroundingExecutor.resolveTargetPath(targetIRI, "");
+      if (!base) return null;
+      path = /\.md$/i.test(base) ? base : `${base}.md`;
+    }
+    try {
+      const content = await this.fileReader.readFile(path);
+      return this.frontmatterService.parseObject(content) ?? null;
+    } catch {
+      return null;
+    }
+  }
+
+  /**
+   * req 0bb06beb — true when the click-target is a prototype, i.e. one of its
+   * `exo__Instance_class` refs is `exo__Prototype` or reaches it through
+   * `exo__Class_superClass`.
+   *
+   * The walk (rather than a `*Prototype` name-suffix test) is deliberate: the
+   * suffix heuristic is exactly what req 5579ffa1 de-hacked, because a prototype
+   * subclass need not be named `…Prototype`. Class refs are UID-form under
+   * UID-canon (`[[<uid>]]` — verified on live prototypes), so the label is not
+   * available inline and the class asset has to be dereferenced.
+   */
+  private async targetIsPrototype(
+    targetFm: Record<string, string | string[]> | null | undefined,
+  ): Promise<boolean> {
+    if (!targetFm) return false;
+    const refs = this.resolveClassRefsFromFrontmatter(targetFm);
+    const seen = new Set<string>();
+    for (const ref of refs) {
+      if (await this.classRefReachesPrototype(ref, 0, seen)) return true;
+    }
+    return false;
+  }
+
+  /**
+   * req 0bb06beb — depth- and cycle-bounded `exo__Class_superClass` walk looking
+   * for `exo__Prototype`. Without a wired {@link RefToFrontmatterResolver} only
+   * the inline label form can be judged, and an unresolvable class yields
+   * `false` (fail-closed — see {@link applyMissingBacklinkTopUp}).
+   */
+  private async classRefReachesPrototype(
+    ref: string,
+    depth: number,
+    seen: Set<string>,
+  ): Promise<boolean> {
+    if (depth > GroundingExecutor.MAX_PROTOTYPE_CLASS_WALK_DEPTH) return false;
+    const trimmed = ref.trim();
+    if (!trimmed || seen.has(trimmed)) return false;
+    seen.add(trimmed);
+    // `<uid>|<label>` and bare `<label>` both carry the label inline.
+    const parts = trimmed.split("|");
+    const key = parts[0].trim();
+    const inlineLabel = (parts[1] ?? parts[0]).trim();
+    if (inlineLabel === GroundingExecutor.PROTOTYPE_CLASS_LABEL) return true;
+    if (!this.refToFrontmatter || !key) return false;
+    let classFm: Record<string, unknown> | null;
+    try {
+      classFm = await this.refToFrontmatter(key);
+    } catch {
+      return false;
+    }
+    if (!classFm) return false;
+    if (
+      String(classFm["exo__Asset_label"] ?? "").trim() ===
+      GroundingExecutor.PROTOTYPE_CLASS_LABEL
+    ) {
+      return true;
+    }
+    const supers = classFm["exo__Class_superClass"];
+    const list = Array.isArray(supers)
+      ? supers
+      : supers === undefined || supers === null
+        ? []
+        : [supers];
+    for (const parent of list) {
+      const inner = this.extractWikilinkInner(String(parent));
+      if (inner && (await this.classRefReachesPrototype(inner, depth + 1, seen))) {
+        return true;
+      }
+    }
+    return false;
   }
 
   /**
@@ -2863,6 +2998,16 @@ export class GroundingExecutor {
    */
   private static readonly UUID_BASENAME_RE =
     /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+  /** req 0bb06beb — root prototype class the backlink gate walks toward. */
+  private static readonly PROTOTYPE_CLASS_LABEL = "exo__Prototype";
+
+  /**
+   * req 0bb06beb — bound on the `exo__Class_superClass` walk. Real chains are
+   * shallow (`ems__TaskPrototype` reaches `exo__Prototype` in one hop); the cap
+   * plus the visited-set keeps a malformed or cyclic hierarchy from spinning.
+   */
+  private static readonly MAX_PROTOTYPE_CLASS_WALK_DEPTH = 6;
 
   /**
    * Derive a stable wikilink target (vault-relative path, no `.md` suffix) for

--- a/packages/core/src/services/GroundingExecutor.ts
+++ b/packages/core/src/services/GroundingExecutor.ts
@@ -1852,7 +1852,12 @@ export class GroundingExecutor {
     // which would nest inside the wikilink and corrupt the reference.
     const rawUid = fm?.["exo__Asset_uid"];
     const uid =
-      typeof rawUid === "string" ? rawUid.trim().replace(/^"+|"+$/g, "").trim() : "";
+      typeof rawUid === "string"
+        ? rawUid
+            .trim()
+            .replace(/^['"]+|['"]+$/g, "")
+            .trim()
+        : "";
     const canonicalTarget = uid.length > 0 ? uid : backLinkTarget;
     properties.exo__Asset_prototype = `"[[${canonicalTarget}]]"`;
     LoggingService.error(

--- a/packages/core/tests/integration/asset-creation/create-instance-grounding.test.ts
+++ b/packages/core/tests/integration/asset-creation/create-instance-grounding.test.ts
@@ -297,7 +297,20 @@ describe("Integration: create_instance grounding → NoteToRDFConverter", () => 
     await fs.createFile(PARENT_FILE_PATH, PARENT_FILE_CONTENT);
     vaultAdapter = new InMemoryVaultAdapter(fs);
     const serviceRegistry = new ServiceRegistry();
-    groundingExecutor = new GroundingExecutor(fs, fs, serviceRegistry);
+    // req 0bb06beb — the legacy `exo__Asset_prototype` top-up fires only for a
+    // target that really is a prototype, which the executor establishes by
+    // dereferencing the target's class through `refToFrontmatter`. Production
+    // always injects this port (cli/apply.ts, ExocortexPlugin.ts); the fixture
+    // parent above IS a prototype-instance, so wire it here too.
+    groundingExecutor = new GroundingExecutor(fs, fs, serviceRegistry, undefined, {
+      refToFrontmatter: async (ref: string) =>
+        ref === "ems__TaskPrototype"
+          ? {
+              exo__Asset_label: "ems__TaskPrototype",
+              exo__Class_superClass: ['"[[exo__Prototype]]"'],
+            }
+          : null,
+    });
     converter = new NoteToRDFConverter(vaultAdapter);
   });
 
@@ -545,7 +558,10 @@ describe("Integration: create_instance grounding → NoteToRDFConverter", () => 
       const allPaths = createdPaths;
 
       const content = fs.getContent(allPaths[0])!;
-      expect(content).toContain('exo__Asset_prototype: "[[vault/parent]]"');
+      // req 0bb06beb — the reference is the target's own uid (UID-canon), not
+      // the vault path it used to emit.
+      expect(content).toContain('exo__Asset_prototype: "[[parent-uid]]"');
+      expect(content).not.toContain("[[vault/parent]]");
       // Issue #3184 B2: legacy `exo__Asset_source` default no longer
       // applied for create_instance.
       expect(content).not.toContain("exo__Asset_source:");

--- a/packages/core/tests/integration/asset-creation/create-instance-grounding.test.ts
+++ b/packages/core/tests/integration/asset-creation/create-instance-grounding.test.ts
@@ -287,7 +287,11 @@ describe("Integration: create_instance grounding → NoteToRDFConverter", () => 
     'exo__Asset_uid: "parent-uid"',
     'exo__Asset_label: "Parent prototype"',
     "exo__Instance_class:",
-    '  - "[[ems__TaskPrototype]]"',
+    // UID-canon class ref — this is the form real vault assets carry, and it is
+    // the ONLY form the production `refToFrontmatter` resolvers can dereference
+    // (both are UID keyed). A label-form ref here would exercise a lookup that
+    // cannot happen in production.
+    '  - "[[df7e579d-02d4-4f3a-971f-3d1d785b689b]]"',
     "---",
     "Body",
   ].join("\n");
@@ -304,7 +308,7 @@ describe("Integration: create_instance grounding → NoteToRDFConverter", () => 
     // parent above IS a prototype-instance, so wire it here too.
     groundingExecutor = new GroundingExecutor(fs, fs, serviceRegistry, undefined, {
       refToFrontmatter: async (ref: string) =>
-        ref === "ems__TaskPrototype"
+        ref === "df7e579d-02d4-4f3a-971f-3d1d785b689b"
           ? {
               exo__Asset_label: "ems__TaskPrototype",
               exo__Class_superClass: ['"[[exo__Prototype]]"'],

--- a/packages/core/tests/unit/services/GroundingExecutor.test.ts
+++ b/packages/core/tests/unit/services/GroundingExecutor.test.ts
@@ -4604,6 +4604,59 @@ describe("GroundingExecutor — RFC v2 Phase 3b 5-step pipeline", () => {
       errorSpy.mockRestore();
     });
 
+    // The #3561 dedup (`propertiesReferenceTarget`) is the ONLY thing standing
+    // between an IR-written backlink and a duplicate legacy one — but every
+    // other test here uses a non-prototype target, where req 0bb06beb's class
+    // gate already blocks the top-up and thus SHADOWS the dedup. This case is
+    // the one configuration where the dedup must carry the weight alone: the
+    // target IS a prototype (gate passes) AND an InheritanceRule already linked
+    // it. Neutralising `propertiesReferenceTarget` must red THIS test.
+    // NB the IR key must sit OUTSIDE the two named early-exit checks
+    // (`exo__Asset_prototype`, `ems__Effort_parent`) — otherwise that earlier
+    // guard returns first and shunts the value-based dedup, which is exactly
+    // the stale-key-list bug class #3561 replaced.
+    it("prototype target whose IR already linked it: dedup alone suppresses the legacy backlink (Issue #3561)", async () => {
+      // UID-canon shape: a UUID basename makes the backlink target and the
+      // IR-written value the same string, which is what lets the dedup see the
+      // existing reference (a non-UUID name would emit a path and silently miss).
+      const PROTO_UID = "4b571141-5fc3-4ddd-8f07-ca681fc8410a";
+      reader.readFile.mockResolvedValue(prototypeTargetContent(PROTO_UID));
+      const errorSpy = spyOnError();
+
+      const grounding = makeGrounding({
+        type: GroundingType.CREATE_INSTANCE,
+        targetClass: "ems__Task",
+        targetFolder: "01 Inbox",
+        inheritanceRule: [
+          {
+            sourcePropertyName: "exo__Asset_uid",
+            targetPropertyName: "exo__Asset_relates",
+            targetClassCondition: PROTOTYPE_CLASS_UID,
+            targetClassExclusion: [],
+            priority: 100,
+          },
+        ],
+      });
+
+      const result = await executor.execute(
+        grounding,
+        TARGET_IRI,
+        `assetspaces/kitelev/exoas-my/my-efforts/${PROTO_UID}.md`,
+        { label: "Instance of a prototype" },
+      );
+
+      expect(result.success).toBe(true);
+      const [, content] = writer.createFile.mock.calls[0];
+      // The IR's relationship is the one that survives …
+      expect(content).toContain(`exo__Asset_relates: "[[${PROTO_UID}]]"`);
+      // … and the legacy key is NOT written a second time alongside it.
+      expect(content).not.toContain("exo__Asset_prototype:");
+      const calls = errorSpy.mock.calls.flat().map(String);
+      expect(calls.some((s) => s.includes("No backlink rule fired"))).toBe(false);
+
+      errorSpy.mockRestore();
+    });
+
     it("child Area created on an Area: ems__Area_parent IR fires → NO exo__Asset_prototype, NO error", async () => {
       reader.readFile.mockResolvedValue(AREA_TARGET_FM);
       const errorSpy = spyOnError();

--- a/packages/core/tests/unit/services/GroundingExecutor.test.ts
+++ b/packages/core/tests/unit/services/GroundingExecutor.test.ts
@@ -12,11 +12,46 @@ import { GroundingDefinition } from "../../../src/domain/models/CommandDefinitio
 // -- Mocks --
 
 function createMockReader(content?: string) {
-  const defaultContent = content || "---\nfoo: bar\n---\nBody";
+  // req 0bb06beb — the default click-target is a prototype-instance, which is
+  // what the create_instance suites have always meant by "$target" (see the
+  // Issue #3195 describe: "UUID-named prototype-instance targets"). Making the
+  // fixture say so keeps those assertions meaningful now that the legacy
+  // backlink top-up refuses to invent a prototype link for a non-prototype.
+  const defaultContent =
+    content ||
+    `---\nfoo: bar\nexo__Instance_class:\n  - "[[${PROTOTYPE_CLASS_UID}]]"\n---\nBody`;
   return {
     readFile: jest.fn().mockResolvedValue(defaultContent),
     fileExists: jest.fn().mockResolvedValue(true),
     getMarkdownFiles: jest.fn().mockResolvedValue([]),
+  };
+}
+
+// req 0bb06beb — the legacy `exo__Asset_prototype` top-up now fires only when
+// the click-target really is a prototype, so a fixture that expects the backlink
+// must say so. These helpers make the target's frontmatter carry a class whose
+// `exo__Class_superClass` chain reaches `exo__Prototype` (the shape live vaults
+// have: `ems__TaskPrototype` → … → `exo__Prototype`) and wire the
+// `refToFrontmatter` port the executor dereferences that class through — which
+// production always injects (cli/apply.ts, ExocortexPlugin.ts).
+const PROTOTYPE_CLASS_UID = "df7e579d-02d4-4f3a-971f-3d1d785b689b";
+
+function prototypeTargetContent(uid = "target-uid"): string {
+  return `---\nexo__Asset_uid: ${uid}\nexo__Instance_class:\n  - "[[${PROTOTYPE_CLASS_UID}]]"\n---\nBody`;
+}
+
+/** Resolves the prototype class above; anything else is unknown. */
+async function prototypeClassResolver(
+  ref: string,
+): Promise<Record<string, unknown> | null> {
+  // The suites use two spellings of the same prototype class: the real UID and
+  // the legacy readable stand-in inside PROTOTYPE_INSTANCE_FM.
+  if (ref !== PROTOTYPE_CLASS_UID && ref !== "df7e579d-classid-emsTaskPrototype") {
+    return null;
+  }
+  return {
+    exo__Asset_label: "ems__TaskPrototype",
+    exo__Class_superClass: ['"[[exo__Prototype]]"'],
   };
 }
 
@@ -53,7 +88,9 @@ describe("GroundingExecutor", () => {
     reader = createMockReader();
     writer = createMockWriter();
     registry = new ServiceRegistry();
-    executor = new GroundingExecutor(reader, writer, registry);
+    executor = new GroundingExecutor(reader, writer, registry, undefined, {
+      refToFrontmatter: prototypeClassResolver,
+    });
   });
 
   // -- property_set --
@@ -2144,7 +2181,7 @@ describe("GroundingExecutor", () => {
       });
 
       it("falls back to exo__Asset_prototype when linkBackProperty is absent (Issue #3184 B2)", async () => {
-        reader.readFile.mockResolvedValue("---\nfoo: bar\n---\n");
+        reader.readFile.mockResolvedValue(prototypeTargetContent());
 
         const grounding = makeGrounding({
           type: GroundingType.CREATE_INSTANCE,
@@ -2156,7 +2193,7 @@ describe("GroundingExecutor", () => {
 
         const [, content] = writer.createFile.mock.calls[0];
         expect(content).toContain(
-          'exo__Asset_prototype: "[[vault/test-asset]]"',
+          'exo__Asset_prototype: "[[target-uid]]"',
         );
         expect(content).not.toContain("exo__Asset_source:");
         expect(content).not.toContain("ems__Effort_prevIteration:");
@@ -2233,7 +2270,7 @@ describe("GroundingExecutor", () => {
       } as const;
 
       it("vault grounding without linkBackProperty defaults to exo__Asset_prototype", async () => {
-        reader.readFile.mockResolvedValue("---\nfoo: bar\n---\nBody");
+        reader.readFile.mockResolvedValue(prototypeTargetContent());
 
         const grounding = makeGrounding({ ...LEGACY_MEETING_GROUNDING });
 
@@ -2244,7 +2281,7 @@ describe("GroundingExecutor", () => {
         expect(result.success).toBe(true);
         const [, content] = writer.createFile.mock.calls[0];
         expect(content).toContain(
-          'exo__Asset_prototype: "[[vault/test-asset]]"',
+          'exo__Asset_prototype: "[[target-uid]]"',
         );
         expect(content).not.toContain("exo__Asset_source:");
         expect(content).not.toMatch(/ems__Effort_parent: "\[\[https/);
@@ -2252,7 +2289,7 @@ describe("GroundingExecutor", () => {
       });
 
       it("grounding with targetClass only (no prototype, no linkBackProperty) defaults to exo__Asset_prototype", async () => {
-        reader.readFile.mockResolvedValue("---\nfoo: bar\n---\n");
+        reader.readFile.mockResolvedValue(prototypeTargetContent());
 
         const grounding = makeGrounding({
           type: GroundingType.CREATE_INSTANCE,
@@ -2266,7 +2303,7 @@ describe("GroundingExecutor", () => {
         const [, content] = writer.createFile.mock.calls[0];
         expect(content).toContain('exo__Instance_class:\n  - "[[ems__Task]]"');
         expect(content).toContain(
-          'exo__Asset_prototype: "[[vault/test-asset]]"',
+          'exo__Asset_prototype: "[[target-uid]]"',
         );
         expect(content).not.toContain("exo__Asset_source:");
       });
@@ -2293,7 +2330,7 @@ describe("GroundingExecutor", () => {
       });
 
       it("grounding with linkBackProperty=undefined still uses the new default (no fallback drift)", async () => {
-        reader.readFile.mockResolvedValue("---\nfoo: bar\n---\n");
+        reader.readFile.mockResolvedValue(prototypeTargetContent());
 
         const grounding = makeGrounding({
           type: GroundingType.CREATE_INSTANCE,
@@ -2307,7 +2344,7 @@ describe("GroundingExecutor", () => {
         expect(result.success).toBe(true);
         const [, content] = writer.createFile.mock.calls[0];
         expect(content).toContain(
-          'exo__Asset_prototype: "[[vault/test-asset]]"',
+          'exo__Asset_prototype: "[[target-uid]]"',
         );
         expect(content).not.toContain("exo__Asset_source:");
       });
@@ -2357,7 +2394,7 @@ describe("GroundingExecutor", () => {
         expect(result.success).toBe(true);
         const [, content] = writer.createFile.mock.calls[0];
         expect(content).toContain(
-          'exo__Asset_prototype: "[[vault/test-asset]]"',
+          'exo__Asset_prototype: "[[4b571141-5fc3-4ddd-8f07-ca681fc8410a]]"',
         );
         expect(content).not.toContain("df7e579d-classid-emsTaskPrototype");
       });
@@ -2567,7 +2604,9 @@ describe("substituteVariables — $input/$value user-input resolution (Findings 
     reader = createMockReader();
     writer = createMockWriter();
     registry = new ServiceRegistry();
-    executor = new GroundingExecutor(reader, writer, registry);
+    executor = new GroundingExecutor(reader, writer, registry, undefined, {
+      refToFrontmatter: prototypeClassResolver,
+    });
   });
 
   it("resolves $input placeholder to user-provided value, not literal (Set Planned Start, Finding 3)", async () => {
@@ -2774,7 +2813,9 @@ describe("Convert to Task grounding — end-to-end wiring (Finding 5)", () => {
     reader = createMockReader();
     writer = createMockWriter();
     registry = new ServiceRegistry();
-    executor = new GroundingExecutor(reader, writer, registry);
+    executor = new GroundingExecutor(reader, writer, registry, undefined, {
+      refToFrontmatter: prototypeClassResolver,
+    });
   });
 
   it("clicking Convert to Task on ems__Project flips exo__Instance_class to [[ems__Task]] via grounding path", async () => {
@@ -2909,7 +2950,9 @@ describe("Convert commands — production-shape dispatch (Finding 5 completion)"
       reader = createConvertReader("ems__Project");
       writer = createWriter();
       registry = new ServiceRegistry();
-      executor = new GroundingExecutor(reader, writer, registry);
+      executor = new GroundingExecutor(reader, writer, registry, undefined, {
+      refToFrontmatter: prototypeClassResolver,
+    });
     });
 
     it("flips class to ems__Task when serviceId=updateProperty + targetValue=ems__Task", async () => {
@@ -2964,7 +3007,9 @@ describe("Convert commands — production-shape dispatch (Finding 5 completion)"
       reader = createConvertReader("ems__Task");
       writer = createWriter();
       registry = new ServiceRegistry();
-      executor = new GroundingExecutor(reader, writer, registry);
+      executor = new GroundingExecutor(reader, writer, registry, undefined, {
+      refToFrontmatter: prototypeClassResolver,
+    });
     });
 
     it("flips class to ems__Project when serviceId=updateProperty + targetValue=ems__Project", async () => {
@@ -3016,7 +3061,9 @@ describe("Convert commands — production-shape dispatch (Finding 5 completion)"
       reader = createConvertReader("ems__Task");
       writer = createWriter();
       registry = new ServiceRegistry();
-      executor = new GroundingExecutor(reader, writer, registry);
+      executor = new GroundingExecutor(reader, writer, registry, undefined, {
+      refToFrontmatter: prototypeClassResolver,
+    });
     });
 
     it("dispatches to registered updateProperty service when targetProperty !== exo__Instance_class", async () => {
@@ -3266,7 +3313,9 @@ describe("GroundingExecutor — RFC v2 Phase 3b 5-step pipeline", () => {
     reader = createMockReader();
     writer = createMockWriter();
     registry = new ServiceRegistry();
-    executor = new GroundingExecutor(reader, writer, registry);
+    executor = new GroundingExecutor(reader, writer, registry, undefined, {
+      refToFrontmatter: prototypeClassResolver,
+    });
   });
 
   // -- Test fixtures --
@@ -4591,9 +4640,11 @@ describe("GroundingExecutor — RFC v2 Phase 3b 5-step pipeline", () => {
       errorSpy.mockRestore();
     });
 
-    it("regression: genuine degraded mode (no IR, nothing links to target) STILL writes legacy exo__Asset_prototype + error", async () => {
-      // No inheritanceRule → no backlink established → the degraded-mode safety
-      // net must remain intact (the asset would otherwise be orphaned).
+    it("@req:0bb06beb-9d7f-448a-bfa3-fd3ab1c3476b — degraded mode on a NON-prototype target writes NO backlink and logs nothing", async () => {
+      // No inheritanceRule → nothing established a backlink. The net used to
+      // write `exo__Asset_prototype: [[<area>]]` here, asserting that a Task is
+      // an instance of the Area — which is simply false. An absent backlink is
+      // a normal state; an invented one is a lie the graph then carries.
       reader.readFile.mockResolvedValue(AREA_TARGET_FM);
       const errorSpy = spyOnError();
 
@@ -4612,9 +4663,42 @@ describe("GroundingExecutor — RFC v2 Phase 3b 5-step pipeline", () => {
 
       expect(result.success).toBe(true);
       const [, content] = writer.createFile.mock.calls[0];
-      expect(content).toContain(`exo__Asset_prototype: "[[${AREA_UID}]]"`);
+      // The create still succeeds — only the invented link is gone.
+      expect(content).not.toContain("exo__Asset_prototype:");
+      expect(content).toContain("exo__Asset_label: Orphan");
       const calls = errorSpy.mock.calls.flat().map(String);
-      expect(calls.some((s) => s.includes("No backlink rule fired"))).toBe(true);
+      expect(calls.some((s) => s.includes("No backlink rule fired"))).toBe(false);
+
+      errorSpy.mockRestore();
+    });
+
+    // req 0bb06beb — the other half: the net is KEPT where it is truthful. A
+    // real prototype whose Universal InheritanceRules are absent still gets its
+    // prototype link, and in UID-canon form (never a vault path).
+    it("@req:0bb06beb-9d7f-448a-bfa3-fd3ab1c3476b — degraded mode on a PROTOTYPE target still writes the backlink, by UID", async () => {
+      reader.readFile.mockResolvedValue(prototypeTargetContent("proto-uid-42"));
+      const errorSpy = spyOnError();
+
+      const grounding = makeGrounding({
+        type: GroundingType.CREATE_INSTANCE,
+        targetClass: "ems__Task",
+        targetFolder: "01 Inbox",
+      });
+
+      const result = await executor.execute(
+        grounding,
+        TARGET_IRI,
+        "assetspaces/kitelev/exoas-my/my-efforts/proto-uid-42.md",
+        { label: "Lunch instance" },
+      );
+
+      expect(result.success).toBe(true);
+      const [, content] = writer.createFile.mock.calls[0];
+      expect(content).toContain('exo__Asset_prototype: "[[proto-uid-42]]"');
+      // UID-canon: the vault path must never leak into the reference.
+      expect(content).not.toContain("assetspaces/kitelev");
+      const calls = errorSpy.mock.calls.flat().map(String);
+      expect(calls.some((s) => s.includes("the target is a prototype"))).toBe(true);
 
       errorSpy.mockRestore();
     });


### PR DESCRIPTION
## What

`GroundingExecutor.applyMissingBacklinkTopUp` wrote `exo__Asset_prototype` toward whatever the click-target happened to be whenever no backlink InheritanceRule matched — so creating anything from a daily note or an area asserted that the new asset is an *instance of* that note/area.

The existing comment framed the choice as «a corrupt asset is preferable to creation failure». That dilemma is false: the third option — write nothing — was never on the table. A missing backlink is a normal state; an invented one is a lie the graph then carries.

## Measured before changing anything

| | assets |
|---|---|
| `exo__Asset_prototype` → **non-prototype** (the parasitic class this ends) | **112** (my 86 / tbank 17 / exodev 9) |
| → real `ems__TaskPrototype` (legitimate, untouched) | 282 in vault-my alone |

So this is systemic, not one asset — and the legitimate population is the larger one, which is why the net is gated rather than deleted.

## Change

1. **Gate.** The top-up fires only when the target really is a prototype: its class is walked through `exo__Class_superClass` to `exo__Prototype` via the `refToFrontmatter` port that **both** production paths already inject (`cli/apply.ts`, `ExocortexPlugin.ts` — verified whole-repo). Unresolvable target → write nothing, rather than guess.
   - A `*Prototype` name-suffix test was deliberately **not** used — that is exactly the heuristic req `5579ffa1` de-hacked, because a prototype subclass need not be named that way.
2. **Reference form.** The value is now the target's own `exo__Asset_uid` instead of a vault path, so renaming or moving the target no longer breaks it. (Empirically every real prototype is UID-named, so the gate alone already removed the path form in practice — reading the uid makes it a guarantee.)

## Existing tests: updated, not deleted

15 suites asserted the old shape. They were not weakened — their fixtures now *say* the target is a prototype, which their own names always meant («UUID-named **prototype-instance** targets», «references the **prototype-INSTANCE**»), and they expect the UID-canon reference. One test that literally encoded the defect (`…genuine degraded mode STILL writes legacy exo__Asset_prototype`) is rewritten to the new contract, plus a new sibling proving the net still fires for a real prototype.

Two real bugs surfaced while doing this and are fixed here:
- the uid could arrive YAML-quoted and nested inside the wikilink (`"[["uid"]]"`);
- the reader was handed a path normalised for wikilink use (leading `/` and `.md` stripped), so the target was never found on a real filesystem — caught only by the integration suite.

## Verification

**Revert-verified on two independent axes** (`@req:0bb06beb-9d7f-448a-bfa3-fd3ab1c3476b`):

| neutralize | RED | stays GREEN |
|---|---|---|
| the class-gate | NON-prototype test | PROTOTYPE test |
| the uid preference | by-UID test | NON-prototype test |

Both restored → green. Full core suite: **356 suites / 8444 tests**, 0 regressions.

## Review round-1 (code-reviewer): WARNING → resolved

**HIGH — coverage regression.** The Issue #3561 `propertiesReferenceTarget` dedup
lost all test coverage: every test in that describe used a NON-prototype target,
where this PR's new class gate returns *first* and shadows the dedup — so
neutralising the guard left the suite green. Restored with the one configuration
where the dedup carries the weight alone: a **prototype** target (gate passes)
that an InheritanceRule already linked, under a key **outside** the two named
early-exit checks. Production code was confirmed correct; this was purely
coverage.

**MEDIUM — fixture realism.** The integration fixture's class ref was label-form
and the fake resolver keyed on that label, but both production
`refToFrontmatter` resolvers are UID-keyed. Switched to UID-canon so the test
exercises a lookup that can actually occur in production.

**LOW** — uid normalisation strips single quotes too.

Revert-verify after the fixes — three independent axes, each reds only its own:

| neutralise | RED |
|---|---|
| `propertiesReferenceTarget` (dedup) | 3 (incl. the new test failing on the **write**, not just the log assertion) |
| the prototype class gate | 2 |
| UID-canon (fall back to path form) | 7 |

Full core suite after all fixes: **356 suites / 8445 tests**, tsc clean.

Requirement: https://github.com/kitelev/exoas-exo-reqs/blob/main/exo-reqs/0bb06beb-9d7f-448a-bfa3-fd3ab1c3476b.md (approved)

Task: `626a630c-9780-45b6-acd6-e3b8dca55c5a`

https://claude.ai/code/session_015z5mmZwoioiaytoi51TQEf

