### PR TITLE
feat(profile): name the active context and put the previous one one tap away (req 38e2fdd5)

### DIFF
--- a/packages/obsidian-plugin/src/ExocortexPlugin.ts
+++ b/packages/obsidian-plugin/src/ExocortexPlugin.ts
@@ -3691,9 +3691,27 @@ export default class ExocortexPlugin extends Plugin {
       // registered on both platforms and is the mobile affordance.
       this.profileIndicator = new ProfileIndicator({
         getActiveProfileUid: () => localDataStore.getActiveProfileUid(),
-        // The SAME lister the picker uses, so the indicator can never disagree
-        // with the switcher about a profile's label.
-        listProfiles: profileLister,
+        // A LIGHT lister — the indicator needs only uid→label, so it reads the
+        // profile files' frontmatter and skips the two extra vault walks the
+        // picker's lister does (index-cost pricing + the present-UID set).
+        // It resolves the label from the same fields `buildProfileChoice` uses,
+        // so the indicator and the switcher can never disagree about a name.
+        listProfiles: async () =>
+          resolver.listProfileFiles().flatMap((file) => {
+            const fm = this.app.metadataCache.getFileCache(file)?.frontmatter as
+              | Record<string, unknown>
+              | undefined;
+            if (fm === undefined) return [];
+            const uid = fm["exo__Asset_uid"];
+            if (typeof uid !== "string" || uid.length === 0) return [];
+            const label = fm["exo__Asset_label"];
+            return [
+              {
+                uid,
+                label: typeof label === "string" ? label : file.basename,
+              },
+            ];
+          }),
         openSwitcher: () => {
           refreshIndicatorAfter(commandsHandler.invokeApplyProfile());
         },
@@ -3707,6 +3725,17 @@ export default class ExocortexPlugin extends Plugin {
       });
       this.profileIndicator.mount();
       void this.profileIndicator.refresh();
+
+      // At load the metadata cache is typically cold, so the first refresh
+      // cannot name the profile yet and would sit on "Unknown profile" until
+      // the user happened to apply one. Re-resolve when the vault reports
+      // itself indexed. `refreshIfUnsettled` is a no-op once the label has
+      // settled, so this hot event never carries a repeated vault walk.
+      this.registerEvent(
+        this.app.metadataCache.on("resolved", () => {
+          void this.profileIndicator?.refreshIfUnsettled();
+        }),
+      );
 
       // RFC 0002 §3.10 (resolves P15) — «Undo last profile apply»: revert to the
       // profile active before the most recent apply in one click. Gated like

--- a/packages/obsidian-plugin/src/ExocortexPlugin.ts
+++ b/packages/obsidian-plugin/src/ExocortexPlugin.ts
@@ -155,6 +155,7 @@ import { PluginSettingsStoreAdapter } from "./infrastructure/adapters/PluginSett
 import { PluginLocalDataStore } from "./infrastructure/adapters/PluginLocalDataStore";
 import { StagingDirTracker } from "./infrastructure/adapters/StagingDirTracker";
 import { ProfileFuzzyModal } from "./infrastructure/adapters/ProfileFuzzyModal";
+import { ProfileIndicator } from "./infrastructure/adapters/ProfileIndicator";
 import {
   buildProfileChoice,
   extractIncludeUids,
@@ -407,6 +408,10 @@ export default class ExocortexPlugin extends Plugin {
   // forbids `new Notice()` outside ObsidianNotificationService).
   notifier!: ObsidianNotificationService;
   private shaclStatusBar: HTMLElement | null = null;
+  // req 38e2fdd5 — names the active profile (mount context) and opens the
+  // switcher in one tap. Null until the apply path is wired (same gate as the
+  // «Apply profile» command — no indicator where switching cannot happen).
+  private profileIndicator: ProfileIndicator | null = null;
   // #3705 — the currently-open first-run onboarding panel (or null). Lets the
   // bootstrap-result modal's next-step CTA mark the matching panel step done
   // across the modal boundary; cleared when the panel closes.
@@ -3661,13 +3666,49 @@ export default class ExocortexPlugin extends Plugin {
     // on mobile). Without either, the filesystem materialisation can't run, so
     // the command stays hidden.
     if (applyDeps !== null || (Platform.isMobile && restMount !== null)) {
+      // req 38e2fdd5 — repaint the indicator once the flow settles, whichever
+      // way it settles (cancel / refuse / applied). Two-argument `then` rather
+      // than `finally` so the root tsconfig's ES6 lib suffices, and so a
+      // rejection can never leave the indicator stale or unhandled.
+      const refreshIndicatorAfter = (flow: Promise<void>): void => {
+        const repaint = (): void => {
+          void this.profileIndicator?.refresh();
+        };
+        void flow.then(repaint, repaint);
+      };
+
       this.addCommand({
         id: "apply-profile",
         name: "Apply profile",
         callback: () => {
-          void commandsHandler.invokeApplyProfile();
+          refreshIndicatorAfter(commandsHandler.invokeApplyProfile());
         },
       });
+
+      // req 38e2fdd5 — the always-visible "which context am I in" affordance
+      // that opens the switcher in one tap. Registered under the SAME gate as
+      // «Apply profile»: where switching cannot happen there is nothing to
+      // offer. `addStatusBarItem` is passed only off-mobile — the Obsidian API
+      // documents it as "Not available on mobile" — while the ribbon entry is
+      // registered on both platforms and is the mobile affordance.
+      this.profileIndicator = new ProfileIndicator({
+        getActiveProfileUid: () => localDataStore.getActiveProfileUid(),
+        // The SAME lister the picker uses, so the indicator can never disagree
+        // with the switcher about a profile's label.
+        listProfiles: profileLister,
+        openSwitcher: () => {
+          refreshIndicatorAfter(commandsHandler.invokeApplyProfile());
+        },
+        addRibbonIcon: (icon, title, callback) =>
+          this.addRibbonIcon(icon, title, () => {
+            callback();
+          }),
+        addStatusBarItem: Platform.isMobile
+          ? undefined
+          : () => this.addStatusBarItem(),
+      });
+      this.profileIndicator.mount();
+      void this.profileIndicator.refresh();
 
       // RFC 0002 §3.10 (resolves P15) — «Undo last profile apply»: revert to the
       // profile active before the most recent apply in one click. Gated like
@@ -3682,7 +3723,9 @@ export default class ExocortexPlugin extends Plugin {
           const hasUndoTarget = localDataStore.getPreviousProfileUid() !== null;
           if (checking) return hasUndoTarget;
           if (!hasUndoTarget) return false;
-          void commandsHandler.invokeUndoLastApply();
+          // req 38e2fdd5 — an undo also changes the active profile, so the
+          // indicator must follow it.
+          refreshIndicatorAfter(commandsHandler.invokeUndoLastApply());
           return true;
         },
       });

--- a/packages/obsidian-plugin/src/ExocortexPlugin.ts
+++ b/packages/obsidian-plugin/src/ExocortexPlugin.ts
@@ -3667,14 +3667,12 @@ export default class ExocortexPlugin extends Plugin {
     // the command stays hidden.
     if (applyDeps !== null || (Platform.isMobile && restMount !== null)) {
       // req 38e2fdd5 — repaint the indicator once the flow settles, whichever
-      // way it settles (cancel / refuse / applied). Two-argument `then` rather
-      // than `finally` so the root tsconfig's ES6 lib suffices, and so a
-      // rejection can never leave the indicator stale or unhandled.
+      // way it settles (cancel / refuse / applied), so a rejection can never
+      // leave the indicator naming a context the device is no longer in.
       const refreshIndicatorAfter = (flow: Promise<void>): void => {
-        const repaint = (): void => {
+        void flow.finally(() => {
           void this.profileIndicator?.refresh();
-        };
-        void flow.then(repaint, repaint);
+        });
       };
 
       this.addCommand({

--- a/packages/obsidian-plugin/src/domain/profile/quickSwitch.ts
+++ b/packages/obsidian-plugin/src/domain/profile/quickSwitch.ts
@@ -1,0 +1,97 @@
+/**
+ * req 38e2fdd5 — low-friction switching of the active profile, i.e. of the
+ * mount CONTEXT.
+ *
+ * ## Why "context switching" and not "speed-up"
+ *
+ * The parent project's falsification gate (task `8b8466bb`, measured 2026-08-02
+ * on the real vaults) found that mounting *less* through profiles does NOT
+ * materially help: the active profile already resolves to 100 % of vault-my
+ * (8 738 / 8 738) and 99.4 % of vault-exodev, because the transitive
+ * `exo__AssetSpace_dependsOn` closure drags almost the whole vault in. The
+ * "minimal profile that still has my data" saves 58 files (0.7 %), and the
+ * measured index delta was −0.6 %.
+ *
+ * The one lever the same measurement found to be large is *switching context*
+ * — mounting the work profile and unmounting the personal one — at **−44 %**
+ * (6 120 → 3 409 ms). That changes *what is available*, not the speed of the
+ * same thing. The gate's explicit recommendation for this task was therefore:
+ * keep it, but sell it as **fast context switching**, never as a speed-up.
+ *
+ * These helpers carry that: name the context you are in, and put the context
+ * you came from within one tap.
+ */
+
+/** Text shown when no profile has ever been applied on this device. */
+export const NO_ACTIVE_PROFILE_TEXT = "No profile";
+
+/**
+ * Text shown when a profile UID is recorded but no profile asset matches it —
+ * e.g. the profile was deleted or lives in an AssetSpace that is not currently
+ * mounted. Deliberately NOT the raw UID: the pickers never show UIDs to the
+ * user either (RFC 0002 §3.4 P10), and a bare UUID in the status bar is noise.
+ */
+export const UNRESOLVED_PROFILE_TEXT = "Unknown profile";
+
+/**
+ * Leading glyph for the status-bar item, so the entry reads as "a profile" at a
+ * glance rather than as an unlabelled word among the other status-bar items.
+ */
+export const INDICATOR_GLYPH = "◆";
+
+/**
+ * The short status-bar text naming the active profile.
+ *
+ * `null` ⇒ nothing has been applied yet, which is stated explicitly — the
+ * indicator is never blank and never silently keeps a stale label.
+ */
+export function formatActiveProfileIndicator(label: string | null): string {
+  const name =
+    label === null || label.length === 0 ? NO_ACTIVE_PROFILE_TEXT : label;
+  return `${INDICATOR_GLYPH} ${name}`;
+}
+
+/**
+ * The hover/long-press tooltip, also used as the ribbon entry's accessible
+ * label — on mobile, where Obsidian has no status bar, this is what names the
+ * active profile.
+ *
+ * It says "context", not "speed": per the gate above, switching profiles buys
+ * you a different working context, and the honest index-cost figure already
+ * lives inside the picker (req 6171f443).
+ */
+export function formatActiveProfileTooltip(label: string | null): string {
+  if (label === null || label.length === 0) {
+    return "No profile applied — choose a context";
+  }
+  return `Active profile: ${label} — switch context`;
+}
+
+/**
+ * Order the switcher's rows so the profile you came FROM is offered first.
+ *
+ * The dominant use of profiles is a two-context ping-pong (personal ↔ work), so
+ * the previously-active profile is nearly always the one being switched back
+ * to. `FuzzySuggestModal` presents `getItems()` in order while the query box is
+ * empty — which is exactly the state the picker opens in — so this is what the
+ * user sees on the tap that matters, and switching back costs one more tap.
+ *
+ * Everything else keeps its existing relative order (the callers sort
+ * alphabetically). When `previousUid` is `null` or matches nothing the input
+ * order is returned untouched — that is what makes the zero-regression
+ * guarantee structural rather than argued.
+ *
+ * The synthetic «Show all profiles…» sentinel can never be promoted: its UID is
+ * a constant that is never written to the previous-profile slot.
+ */
+export function orderProfilesForQuickSwitch<T extends { uid: string }>(
+  choices: readonly T[],
+  previousUid: string | null,
+): T[] {
+  if (previousUid === null || previousUid.length === 0) return [...choices];
+  const idx = choices.findIndex((c) => c.uid === previousUid);
+  if (idx < 0) return [...choices];
+  const promoted = choices[idx];
+  if (promoted === undefined) return [...choices];
+  return [promoted, ...choices.slice(0, idx), ...choices.slice(idx + 1)];
+}

--- a/packages/obsidian-plugin/src/infrastructure/adapters/ProfileCommands.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/ProfileCommands.ts
@@ -31,6 +31,7 @@
 
 import { isAuthError } from "@kitelev/exocortex-core";
 
+import { orderProfilesForQuickSwitch } from "../../domain/profile/quickSwitch";
 import type { ProfileApplyManager } from "./ProfileApplyManager";
 import {
   ApplyAbortedByUser,
@@ -406,6 +407,14 @@ export class ProfileCommands {
    * The fuzzy-pick wrapper is the {@link ProfileFuzzyModal}, which carries the
    * picker-selection fix (#3561 — record-in-choose, resolve-in-close-microtask);
    * this method only chooses which list to hand it.
+   *
+   * req 38e2fdd5 — the list is then passed through
+   * {@link orderProfilesForQuickSwitch}, which promotes the profile that was
+   * active BEFORE the current one to the first row: profiles are used as a
+   * two-context ping-pong, so that is nearly always the switch-back target, and
+   * `FuzzySuggestModal` shows `getItems()` in order while the query box is
+   * empty — the state the picker opens in. With no previous profile recorded
+   * the order is returned untouched (structural zero-regression).
    */
   private async pickProfileScoped(
     profiles: ProfileChoice[],
@@ -417,15 +426,25 @@ export class ProfileCommands {
     const scoped = relevant.length > 0 ? relevant : profiles;
     const hasHidden = scoped.length < profiles.length;
 
-    const firstList = hasHidden
-      ? [...scoped, ProfileCommands.showAllEntry(profiles.length - scoped.length)]
-      : scoped;
+    const previousUid = this.getPreviousProfileUid();
+    const firstList = orderProfilesForQuickSwitch(
+      hasHidden
+        ? [
+            ...scoped,
+            ProfileCommands.showAllEntry(profiles.length - scoped.length),
+          ]
+        : scoped,
+      previousUid,
+    );
 
     const first = await this.fuzzyPick(firstList, "Apply profile", initialQuery);
     if (first === null) return null;
     if (first.kind === "show-all") {
       // User broadened the list — re-open unscoped (no pre-narrow query).
-      const all = await this.fuzzyPick(profiles, "Apply profile");
+      const all = await this.fuzzyPick(
+        orderProfilesForQuickSwitch(profiles, previousUid),
+        "Apply profile",
+      );
       // A nested «show-all» is impossible (the full list contains no sentinel),
       // but guard against accidental re-selection so it never reaches apply.
       return all !== null && all.kind === "show-all" ? null : all;

--- a/packages/obsidian-plugin/src/infrastructure/adapters/ProfileIndicator.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/ProfileIndicator.ts
@@ -70,6 +70,13 @@ export class ProfileIndicator {
    * leave the indicator naming a context the device is no longer in.
    */
   private refreshGeneration = 0;
+  /**
+   * Whether the last paint produced a FINAL answer — a real profile label, or
+   * an honest "nothing applied yet". False while the active UID is recorded but
+   * unnameable (typically a cold metadata cache at load), which is what
+   * {@link refreshIfUnsettled} listens for.
+   */
+  private labelSettled = false;
 
   constructor(private readonly deps: ProfileIndicatorDeps) {}
 
@@ -109,10 +116,11 @@ export class ProfileIndicator {
    */
   async refresh(): Promise<void> {
     const generation = ++this.refreshGeneration;
-    const label = await this.resolveActiveLabel();
+    const { label, settled } = await this.resolveActive();
     // A newer refresh started while this one was resolving — it will paint the
     // fresher label, so this (now stale) result must not overwrite it.
     if (generation !== this.refreshGeneration) return;
+    this.labelSettled = settled;
 
     const text = formatActiveProfileIndicator(label);
     const tooltip = formatActiveProfileTooltip(label);
@@ -130,25 +138,59 @@ export class ProfileIndicator {
   }
 
   /**
-   * `null` ⇒ nothing applied yet. A recorded UID with no matching asset yields
-   * {@link UNRESOLVED_PROFILE_TEXT} rather than the raw UID or a misleading
-   * "No profile".
+   * Repaint ONLY while the label is still unresolved.
+   *
+   * At plugin load the metadata cache is usually cold, so the profile lister
+   * finds nothing and the first {@link refresh} can only paint "Unknown
+   * profile". Nothing else would ever re-resolve it — the indicator would sit
+   * wrong until the user happened to apply a profile. This is the hook the
+   * plugin drives from `metadataCache.on("resolved")`, i.e. "the vault finished
+   * indexing".
+   *
+   * It is a no-op once the label HAS settled, because listing profiles walks
+   * the vault: an unconditional repaint on every cache-resolution event would
+   * put an O(vault) scan on a hot Obsidian event, which is the shape that
+   * caused the documented iPhone index-storm. Settled means either a real
+   * label or an honest "no profile applied"; only the genuinely-unresolvable
+   * case (a recorded UID whose asset is missing) keeps listening, and that
+   * self-heals on the next apply.
    */
-  private async resolveActiveLabel(): Promise<string | null> {
+  async refreshIfUnsettled(): Promise<void> {
+    if (this.labelSettled) return;
+    await this.refresh();
+  }
+
+  /**
+   * `label: null` ⇒ nothing applied yet. A recorded UID with no matching asset
+   * yields {@link UNRESOLVED_PROFILE_TEXT} rather than the raw UID or a
+   * misleading "No profile".
+   *
+   * `settled` reports whether this answer is final: `false` means the lookup
+   * could not name the profile (cold cache, unmounted AssetSpace, deleted
+   * asset) and is worth retrying when the vault reports itself indexed.
+   */
+  private async resolveActive(): Promise<{
+    label: string | null;
+    settled: boolean;
+  }> {
     let uid: string | null;
     try {
       uid = this.deps.getActiveProfileUid();
     } catch {
-      return UNRESOLVED_PROFILE_TEXT;
+      return { label: UNRESOLVED_PROFILE_TEXT, settled: false };
     }
-    if (uid === null || uid.length === 0) return null;
+    if (uid === null || uid.length === 0) {
+      return { label: null, settled: true };
+    }
 
     try {
       const profiles = await this.deps.listProfiles();
       const match = profiles.find((p) => p.uid === uid);
-      return match !== undefined ? match.label : UNRESOLVED_PROFILE_TEXT;
+      return match !== undefined
+        ? { label: match.label, settled: true }
+        : { label: UNRESOLVED_PROFILE_TEXT, settled: false };
     } catch {
-      return UNRESOLVED_PROFILE_TEXT;
+      return { label: UNRESOLVED_PROFILE_TEXT, settled: false };
     }
   }
 }

--- a/packages/obsidian-plugin/src/infrastructure/adapters/ProfileIndicator.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/ProfileIndicator.ts
@@ -61,6 +61,15 @@ export interface ProfileIndicatorDeps {
 export class ProfileIndicator {
   private statusBarEl: HTMLElement | null = null;
   private ribbonEl: HTMLElement | null = null;
+  /**
+   * Monotonic refresh token. {@link refresh} resolves the label asynchronously
+   * (the lister walks the vault, so its latency varies), and refreshes overlap:
+   * one fires at load and one after every apply/undo settles. Without this
+   * guard the two would paint in COMPLETION order rather than call order, so a
+   * slow refresh started BEFORE a switch could overwrite the newer label and
+   * leave the indicator naming a context the device is no longer in.
+   */
+  private refreshGeneration = 0;
 
   constructor(private readonly deps: ProfileIndicatorDeps) {}
 
@@ -99,7 +108,12 @@ export class ProfileIndicator {
    * reports without a plugin reload.
    */
   async refresh(): Promise<void> {
+    const generation = ++this.refreshGeneration;
     const label = await this.resolveActiveLabel();
+    // A newer refresh started while this one was resolving — it will paint the
+    // fresher label, so this (now stale) result must not overwrite it.
+    if (generation !== this.refreshGeneration) return;
+
     const text = formatActiveProfileIndicator(label);
     const tooltip = formatActiveProfileTooltip(label);
 

--- a/packages/obsidian-plugin/src/infrastructure/adapters/ProfileIndicator.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/ProfileIndicator.ts
@@ -1,0 +1,140 @@
+import {
+  formatActiveProfileIndicator,
+  formatActiveProfileTooltip,
+  UNRESOLVED_PROFILE_TEXT,
+} from "../../domain/profile/quickSwitch";
+
+/** Lucide icon for the ribbon entry — stacked layers ≈ the mounted set. */
+export const PROFILE_RIBBON_ICON = "layers";
+
+/** CSS hook for the status-bar item (cursor + spacing live in styles.css). */
+export const PROFILE_STATUS_BAR_CLASS = "exocortex-profile-indicator";
+
+/** Minimal profile shape the indicator needs — a subset of `ProfileChoice`. */
+export interface IndicatorProfile {
+  uid: string;
+  label: string;
+}
+
+export interface ProfileIndicatorDeps {
+  /** Last-applied profile UID (device-local), or `null` when never applied. */
+  getActiveProfileUid: () => string | null;
+  /** The shared profile lister — same source the picker uses. */
+  listProfiles: () => Promise<IndicatorProfile[]>;
+  /**
+   * Opens the profile switcher. This is the EXISTING apply-profile invocation,
+   * not a copy — there is exactly one switching code path in the plugin.
+   */
+  openSwitcher: () => void;
+  /**
+   * Registers a ribbon entry. Present on BOTH platforms — on mobile it is the
+   * only affordance, since Obsidian has no status bar there.
+   */
+  addRibbonIcon: (
+    icon: string,
+    title: string,
+    callback: () => void,
+  ) => HTMLElement;
+  /**
+   * Registers a status-bar item. **Omitted on mobile** — `addStatusBarItem` is
+   * documented in the Obsidian API as "Not available on mobile", so the caller
+   * passes it only where it exists. The split is by SURFACE, never by
+   * capability: seeing the context and switching it in ≤2 taps works on both
+   * platforms (Desktop↔Mobile Command Parity forbids gating a *command* away,
+   * not declining to render chrome a platform has no concept of).
+   */
+  addStatusBarItem?: () => HTMLElement;
+}
+
+/**
+ * req 38e2fdd5 — the always-visible "which context am I in, and switch it"
+ * affordance.
+ *
+ * Owns two surfaces and one {@link refresh}; both surfaces activate the same
+ * injected {@link ProfileIndicatorDeps.openSwitcher}, so the switcher opened
+ * from the status bar, from the ribbon and from the command palette is
+ * literally the same flow.
+ *
+ * Best-effort throughout: a failing lister degrades to "Unknown profile" and
+ * never throws into plugin load or into a click handler.
+ */
+export class ProfileIndicator {
+  private statusBarEl: HTMLElement | null = null;
+  private ribbonEl: HTMLElement | null = null;
+
+  constructor(private readonly deps: ProfileIndicatorDeps) {}
+
+  /**
+   * Register the surfaces. Idempotent per instance — a second call is a no-op,
+   * so a re-entrant onload cannot stack duplicate ribbon entries.
+   */
+  mount(): void {
+    if (this.ribbonEl !== null || this.statusBarEl !== null) return;
+
+    // Ribbon FIRST and unconditionally: it is the mobile affordance.
+    this.ribbonEl = this.deps.addRibbonIcon(
+      PROFILE_RIBBON_ICON,
+      formatActiveProfileTooltip(null),
+      () => {
+        this.deps.openSwitcher();
+      },
+    );
+
+    // Status bar only where the API exists (desktop).
+    if (this.deps.addStatusBarItem !== undefined) {
+      const el = this.deps.addStatusBarItem();
+      el.classList.add(PROFILE_STATUS_BAR_CLASS);
+      el.addEventListener("click", () => {
+        this.deps.openSwitcher();
+      });
+      el.textContent = formatActiveProfileIndicator(null);
+      el.title = formatActiveProfileTooltip(null);
+      this.statusBarEl = el;
+    }
+  }
+
+  /**
+   * Re-read the active profile and repaint both surfaces. Called at load and
+   * after every apply/undo completes, so the indicator follows the profile it
+   * reports without a plugin reload.
+   */
+  async refresh(): Promise<void> {
+    const label = await this.resolveActiveLabel();
+    const text = formatActiveProfileIndicator(label);
+    const tooltip = formatActiveProfileTooltip(label);
+
+    if (this.statusBarEl !== null) {
+      this.statusBarEl.textContent = text;
+      this.statusBarEl.title = tooltip;
+    }
+    if (this.ribbonEl !== null) {
+      this.ribbonEl.title = tooltip;
+      // The ribbon has no visible text — the accessible label is how the
+      // active profile is announced on mobile / to assistive tech.
+      this.ribbonEl.setAttribute("aria-label", tooltip);
+    }
+  }
+
+  /**
+   * `null` ⇒ nothing applied yet. A recorded UID with no matching asset yields
+   * {@link UNRESOLVED_PROFILE_TEXT} rather than the raw UID or a misleading
+   * "No profile".
+   */
+  private async resolveActiveLabel(): Promise<string | null> {
+    let uid: string | null;
+    try {
+      uid = this.deps.getActiveProfileUid();
+    } catch {
+      return UNRESOLVED_PROFILE_TEXT;
+    }
+    if (uid === null || uid.length === 0) return null;
+
+    try {
+      const profiles = await this.deps.listProfiles();
+      const match = profiles.find((p) => p.uid === uid);
+      return match !== undefined ? match.label : UNRESOLVED_PROFILE_TEXT;
+    } catch {
+      return UNRESOLVED_PROFILE_TEXT;
+    }
+  }
+}

--- a/packages/obsidian-plugin/styles.css
+++ b/packages/obsidian-plugin/styles.css
@@ -2057,6 +2057,13 @@
   font-style: italic;
 }
 
+/* req 38e2fdd5 — the status-bar item naming the active profile (mount
+   context). Desktop only; on mobile Obsidian has no status bar and the ribbon
+   entry carries the same affordance. Clickable, so it reads as an action. */
+.exocortex-profile-indicator {
+  cursor: pointer;
+}
+
 /* «Insert template token» picker rows (homoiconic templating MVP) — mirrors
    the profile-suggestion layout: a title line and a muted description line. */
 .exocortex-token-suggestion__title {

--- a/packages/obsidian-plugin/tests/e2e/eka-gui/profile-quick-switch.spec.ts
+++ b/packages/obsidian-plugin/tests/e2e/eka-gui/profile-quick-switch.spec.ts
@@ -1,0 +1,259 @@
+import { test, expect } from "@playwright/test";
+import type { Page } from "@playwright/test";
+import { ObsidianLauncher } from "../utils/obsidian-launcher";
+import { execFileSync } from "child_process";
+import * as fs from "fs";
+import * as path from "path";
+import {
+  launchObsidianWithPlugin,
+  log,
+  pollUntil,
+  setupGuiVault,
+  waitForStoreSettled,
+} from "./eka-gui-helpers";
+
+/**
+ * ============================================================================
+ *  EKA GUI BDD — profile quick-switch indicator + ordering (req 38e2fdd5)
+ * ============================================================================
+ *
+ * The VISUAL gate for the quick-switch affordance. Its unit tests
+ * (`tests/unit/domain/profile/quickSwitch.test.ts`) prove the ordering
+ * arithmetic and the indicator text against injected fakes; this spec proves
+ * what a USER actually sees — a real status-bar item rendered by real Obsidian,
+ * a real ribbon entry, and a real `ProfileFuzzyModal` whose first row came out
+ * of the real `PluginLocalDataStore`.
+ *
+ * ---------------------------------------------------------------------------
+ * WHY an e2e (and why in CI, never locally)
+ * ---------------------------------------------------------------------------
+ * Standing directive (Andrey, 2026-08-02): anything that needs VISUAL
+ * verification gets an explicit E2E UI test with Docker, **run in CI** — local
+ * Docker/QEMU runs OOM the machine (and, per
+ * `rules/docker-qemu-e2e-multichild-panic.md`, can kernel-panic it).
+ *
+ * ---------------------------------------------------------------------------
+ * WHAT makes this non-vacuous (the discriminators)
+ * ---------------------------------------------------------------------------
+ * 1. **Ordering.** The fixture seeds three profiles whose labels sort
+ *    A < B < C, and writes `previousProfileUid` = the LAST one alphabetically
+ *    into the device-local store. The picker must therefore open with C first —
+ *    a regression that dropped the promotion would render the plain
+ *    alphabetical A, B, C, which is asserted against explicitly. No magic
+ *    numbers: the expectation is derived from the seeded UID, not from a
+ *    hard-coded position.
+ * 2. **Indicator.** `activeProfileUid` is seeded to the MIDDLE profile, so the
+ *    status bar must name that one specifically — not merely "some non-empty
+ *    text", and not the first or last row.
+ * 3. **Two taps.** The picker is opened by CLICKING the status-bar item, not by
+ *    invoking the command — that is the ≤2-tap claim, and it is the one thing a
+ *    unit test with an injected `openSwitcher` cannot establish.
+ *
+ * Render-only: the picker is dismissed with Escape and nothing is applied, so
+ * the ephemeral vault's mount state is never mutated
+ * (`rules/gui-mutation-test-on-temp-vault.md`).
+ *
+ * ---------------------------------------------------------------------------
+ * WHAT THIS SPEC DOES *NOT* COVER (stated honestly)
+ * ---------------------------------------------------------------------------
+ * The mobile half of AC3. Obsidian's `addStatusBarItem` is documented "Not
+ * available on mobile", which is exactly why the ribbon entry exists — but this
+ * container runs desktop Obsidian, so the spec asserts the ribbon is REGISTERED
+ * (the mobile affordance exists) without being able to assert how iOS chrome
+ * renders it. That remains a manual confirmation.
+ */
+
+/** `exo__Profile` class UID — what `VaultProfileResolver.listProfileFiles` matches. */
+const PROFILE_CLASS_UID = "3de846cd-1f0e-4f98-8613-b8587aa15174";
+
+/** Stable fixture UIDs (`e2e0 5w17ch` ≈ "e2e switch"), distinct from other specs. */
+const PROFILE_A_UID = "e2e05w17-0000-4000-a000-0000000000a1";
+const PROFILE_B_UID = "e2e05w17-0000-4000-a000-0000000000b2";
+const PROFILE_C_UID = "e2e05w17-0000-4000-a000-0000000000c3";
+
+// Labels chosen so the plain alphabetical order is unambiguously A, B, C —
+// that is the order a regression would render.
+const PROFILE_A_LABEL = "E2E Switch A (first alphabetically)";
+const PROFILE_B_LABEL = "E2E Switch B (seeded ACTIVE)";
+const PROFILE_C_LABEL = "E2E Switch C (seeded PREVIOUS)";
+
+const FIXTURE_DIR = "e2e-quick-switch";
+const STATUS_BAR_SELECTOR = ".exocortex-profile-indicator";
+
+function profileAsset(uid: string, label: string): string {
+  return (
+    `---\n` +
+    `exo__Asset_uid: ${uid}\n` +
+    `exo__Instance_class:\n  - "[[${PROFILE_CLASS_UID}]]"\n` +
+    `exo__Asset_label: "${label}"\n` +
+    `exo__Profile_includes: []\n` +
+    `---\n\nEphemeral e2e profile. Recreated fresh every run.\n`
+  );
+}
+
+/**
+ * Seed three profiles plus the device-local switch state.
+ *
+ * `data.local.json` is the store `PluginLocalDataStore` reads at onload, so
+ * writing it here is how the test says "you were in B, and before that you were
+ * in C" without performing an actual mount switch (which would mutate the vault
+ * and need git-backed AssetSpaces).
+ */
+function seedQuickSwitchFixture(vaultPath: string): void {
+  const dir = path.join(vaultPath, FIXTURE_DIR);
+  fs.mkdirSync(dir, { recursive: true });
+
+  fs.writeFileSync(
+    path.join(dir, `${PROFILE_A_UID}.md`),
+    profileAsset(PROFILE_A_UID, PROFILE_A_LABEL),
+  );
+  fs.writeFileSync(
+    path.join(dir, `${PROFILE_B_UID}.md`),
+    profileAsset(PROFILE_B_UID, PROFILE_B_LABEL),
+  );
+  fs.writeFileSync(
+    path.join(dir, `${PROFILE_C_UID}.md`),
+    profileAsset(PROFILE_C_UID, PROFILE_C_LABEL),
+  );
+
+  const pluginDir = path.join(vaultPath, ".obsidian", "plugins", "exocortex");
+  fs.mkdirSync(pluginDir, { recursive: true });
+  const localPath = path.join(pluginDir, "data.local.json");
+  const existing: Record<string, unknown> = fs.existsSync(localPath)
+    ? (JSON.parse(fs.readFileSync(localPath, "utf8")) as Record<
+        string,
+        unknown
+      >)
+    : {};
+  existing["activeProfileUid"] = PROFILE_B_UID;
+  existing["previousProfileUid"] = PROFILE_C_UID;
+  existing["_switchInProgress"] = false;
+  fs.writeFileSync(localPath, JSON.stringify(existing, null, 2));
+
+  const git = (args: string[]): void => {
+    execFileSync("git", args, {
+      cwd: vaultPath,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+  };
+  git(["add", "-A"]);
+  git([
+    "commit",
+    "-q",
+    "-m",
+    "seed quick-switch fixture (3 profiles + local state)",
+  ]);
+  log(`quick-switch fixture seeded under ${FIXTURE_DIR}/`);
+}
+
+test.describe.configure({ mode: "default" });
+
+test.describe("EKA GUI — profile quick-switch (req 38e2fdd5)", () => {
+  let vaultPath = "";
+  let launcher: ObsidianLauncher | null = null;
+  let window: Page;
+
+  test.beforeAll(async () => {
+    test.setTimeout(600_000);
+    vaultPath = setupGuiVault();
+    seedQuickSwitchFixture(vaultPath);
+    launcher = await launchObsidianWithPlugin(
+      vaultPath,
+      "eka-gui-quick-switch",
+    );
+    window = await launcher.getWindow();
+    await waitForStoreSettled(window);
+  });
+
+  test.afterAll(async () => {
+    if (launcher) await launcher.close().catch(() => undefined);
+    if (vaultPath && fs.existsSync(vaultPath)) {
+      fs.rmSync(vaultPath, { recursive: true, force: true });
+      log(`cleaned up vault ${vaultPath}`);
+    }
+  });
+
+  test("@req:38e2fdd5-8768-4354-8cb8-f1c77856ddb8 the status bar names the active context, one click opens the switcher, and the previous context is the first row", async () => {
+    test.setTimeout(300_000);
+
+    // ── AC1 — the indicator exists and names the ACTIVE profile ─────────────
+    const statusBar = window.locator(STATUS_BAR_SELECTOR);
+    await expect(
+      statusBar,
+      "the profile indicator must be registered in the status bar on desktop",
+    ).toBeVisible({ timeout: 60_000 });
+
+    // The label resolves asynchronously (the lister walks the vault), so poll
+    // for the resolved name rather than asserting the initial placeholder.
+    await pollUntil(
+      "status bar resolves the active profile label",
+      async () =>
+        ((await statusBar.textContent()) ?? "").includes("E2E Switch"),
+      120_000,
+    );
+    const indicatorText = (await statusBar.textContent()) ?? "";
+    log(`status bar reads: ${indicatorText}`);
+
+    // Specifically the seeded ACTIVE profile — not merely "some text", and not
+    // one of the two others.
+    expect(indicatorText).toContain(PROFILE_B_LABEL);
+    expect(indicatorText).not.toContain(PROFILE_A_LABEL);
+    expect(indicatorText).not.toContain(PROFILE_C_LABEL);
+
+    // ── AC3 (desktop half) — the ribbon entry is registered ─────────────────
+    // It is the ONLY affordance on mobile, where there is no status bar. This
+    // container is desktop, so we can assert registration but not iOS chrome.
+    const ribbonLabels: string[] = await window.evaluate(() =>
+      Array.from(
+        document.querySelectorAll(".side-dock-ribbon-action, .clickable-icon"),
+      ).map((el) => el.getAttribute("aria-label") ?? ""),
+    );
+    expect(
+      ribbonLabels.some((l) => l.includes("profile") || l.includes("Profile")),
+      `a profile ribbon entry must be registered (the mobile affordance). Ribbon: ${JSON.stringify(ribbonLabels)}`,
+    ).toBe(true);
+
+    // ── AC2b — ONE click on the indicator opens the switcher ────────────────
+    // Driving the click (not `executeCommandById`) is what makes this the
+    // two-tap claim rather than a restatement of the palette command.
+    await statusBar.click();
+    await expect(
+      window.locator(".exocortex-profile-suggestion").first(),
+      "clicking the indicator must open the profile switcher",
+    ).toBeVisible({ timeout: 60_000 });
+
+    // ── AC2 — the profile you came FROM is the first row ────────────────────
+    const rowLabels: string[] = await window.evaluate(() =>
+      Array.from(
+        document.querySelectorAll(".exocortex-profile-suggestion__label"),
+      ).map((el) => el.textContent ?? ""),
+    );
+    log(`picker rows: ${JSON.stringify(rowLabels)}`);
+
+    const seeded = rowLabels.filter((l) => l.includes("E2E Switch"));
+    expect(
+      seeded.length,
+      `all three seeded profiles must be listed. Got: ${JSON.stringify(rowLabels)}`,
+    ).toBe(3);
+
+    // The discriminator: alphabetically C is LAST, so a dropped promotion would
+    // render A, B, C. Promoted, it must be first.
+    expect(
+      seeded[0],
+      `the previously-active profile must lead the picker (alphabetical order would put "${PROFILE_A_LABEL}" first)`,
+    ).toContain(PROFILE_C_LABEL);
+    // …and the rest keep their alphabetical order behind it.
+    expect(seeded[1]).toContain(PROFILE_A_LABEL);
+    expect(seeded[2]).toContain(PROFILE_B_LABEL);
+
+    // Render-only: dismiss without applying — mount state is never mutated.
+    await window.keyboard.press("Escape");
+    await window
+      .waitForSelector(".exocortex-profile-suggestion", {
+        state: "hidden",
+        timeout: 5_000,
+      })
+      .catch(() => undefined);
+  });
+});

--- a/packages/obsidian-plugin/tests/e2e/eka-gui/profile-quick-switch.spec.ts
+++ b/packages/obsidian-plugin/tests/e2e/eka-gui/profile-quick-switch.spec.ts
@@ -184,8 +184,17 @@ test.describe("EKA GUI — profile quick-switch (req 38e2fdd5)", () => {
       "the profile indicator must be registered in the status bar on desktop",
     ).toBeVisible({ timeout: 60_000 });
 
-    // The label resolves asynchronously (the lister walks the vault), so poll
-    // for the resolved name rather than asserting the initial placeholder.
+    // Log what it says BEFORE polling: if the poll ever times out, this line is
+    // the difference between "the device-local store was not read" (reads
+    // "No profile") and "the profile list was not resolvable yet" (reads
+    // "Unknown profile"). The first run of this spec timed out here and that
+    // distinction was exactly what was missing.
+    log(`status bar (pre-poll): ${(await statusBar.textContent()) ?? "<null>"}`);
+
+    // The label resolves asynchronously, and the FIRST attempt happens at
+    // plugin load with a cold metadata cache — which is why the indicator
+    // re-resolves on `metadataCache.on("resolved")`. Poll for the resolved
+    // name rather than asserting the initial placeholder.
     await pollUntil(
       "status bar resolves the active profile label",
       async () =>

--- a/packages/obsidian-plugin/tests/unit/ProfileCommands.test.ts
+++ b/packages/obsidian-plugin/tests/unit/ProfileCommands.test.ts
@@ -560,6 +560,10 @@ describe("ProfileCommands.invokeApplyProfile (Apply profile)", () => {
 function makeScopedHarness(
   profiles: ProfileChoice[],
   pickResults: (ProfileChoice | null)[],
+  // req 38e2fdd5 — the quick-switch target (the profile active BEFORE the
+  // current one). Defaults to null so every pre-existing caller keeps the
+  // untouched, alphabetical picker order.
+  previousProfileUid: string | null = null,
 ): {
   switchMgr: FakeSwitchMgr;
   notices: string[];
@@ -584,7 +588,7 @@ function makeScopedHarness(
     },
     getActiveFilePath: () => null,
     getActiveProfileUid: () => null,
-      getPreviousProfileUid: () => null,
+    getPreviousProfileUid: () => previousProfileUid,
     notify: (m) => notices.push(m),
   });
   return { switchMgr, notices, pickCalls, cmd };
@@ -671,6 +675,83 @@ describe("ProfileCommands.invokeApplyProfile — user-scope (P7b)", () => {
     expect(opts.some((o) => o.kind === "show-all")).toBe(false);
     expect(opts.map((o) => o.uid)).toEqual(["hid"]);
     expect(h.switchMgr.applyCalls).toEqual(["hid"]);
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// req 38e2fdd5 — quick-switch ordering IS WIRED into the picker
+//
+// The pure helper is unit-tested in domain/profile/quickSwitch.test.ts; these
+// drive the REAL invokeApplyProfile so the ordering cannot ship inert.
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe("ProfileCommands.invokeApplyProfile — quick-switch ordering (req 38e2fdd5)", () => {
+  const PERSONAL: ProfileChoice = { uid: "personal", label: "Personal" };
+  const READING: ProfileChoice = { uid: "reading", label: "Reading" };
+  const WORK: ProfileChoice = { uid: "work", label: "Work" };
+
+  it("@req:38e2fdd5-8768-4354-8cb8-f1c77856ddb8 offers the profile you came FROM as the picker's first row", async () => {
+    const h = makeHarness({
+      profiles: [PERSONAL, READING, WORK],
+      pickResult: null, // cancel — we only care about what was OFFERED
+      activeProfileUid: "personal",
+      previousProfileUid: "work",
+    });
+    await h.cmd.invokeApplyProfile();
+
+    expect(h.pickCalls[0].options.map((o) => o.uid)).toEqual([
+      "work", // ← the switch-back target, one tap away
+      "personal",
+      "reading",
+    ]);
+  });
+
+  it("zero-regression: with no previous profile the picker order is untouched", async () => {
+    const h = makeHarness({
+      profiles: [PERSONAL, READING, WORK],
+      pickResult: null,
+      activeProfileUid: "personal",
+      previousProfileUid: null,
+    });
+    await h.cmd.invokeApplyProfile();
+
+    expect(h.pickCalls[0].options.map((o) => o.uid)).toEqual([
+      "personal",
+      "reading",
+      "work",
+    ]);
+  });
+
+  it("the unscoped «Show all» re-open is ordered too, and the sentinel is never promoted", async () => {
+    const relevant: ProfileChoice = {
+      uid: "personal",
+      label: "Personal",
+      isLocallyRelevant: true,
+    };
+    const hidden: ProfileChoice = {
+      uid: "work",
+      label: "Work",
+      isLocallyRelevant: false,
+    };
+    const showAll: ProfileChoice = {
+      uid: SHOW_ALL_PROFILES_UID,
+      label: "Show all profiles… (1 more)",
+      kind: "show-all",
+    };
+    const h = makeScopedHarness([relevant, hidden], [showAll, null], "work");
+    await h.cmd.invokeApplyProfile();
+
+    // First (scoped) view: the previous profile is hidden here, so the order
+    // stands and the sentinel keeps its appended position.
+    expect(h.pickCalls[0].options[0]?.uid).toBe("personal");
+    expect(
+      h.pickCalls[0].options[h.pickCalls[0].options.length - 1]?.kind,
+    ).toBe("show-all");
+    // Second (unscoped) view: the previous profile is now present → promoted.
+    expect(h.pickCalls[1].options.map((o) => o.uid)).toEqual([
+      "work",
+      "personal",
+    ]);
   });
 });
 

--- a/packages/obsidian-plugin/tests/unit/domain/profile/quickSwitch.test.ts
+++ b/packages/obsidian-plugin/tests/unit/domain/profile/quickSwitch.test.ts
@@ -1,0 +1,277 @@
+/**
+ * req 38e2fdd5 — one-tap profile CONTEXT switching.
+ *
+ * Two axes, revert-verified independently:
+ *   1. the switcher offers the context you came FROM first
+ *      (`orderProfilesForQuickSwitch`);
+ *   2. the indicator names the active context on both surfaces
+ *      (`formatActiveProfileIndicator` / `formatActiveProfileTooltip` driven
+ *      through the real {@link ProfileIndicator}).
+ *
+ * The zero-regression controls (no previous profile ⇒ untouched order; the
+ * «Show all profiles…» sentinel never promoted) stay GREEN under either
+ * revert, which is what proves each axis is non-vacuous.
+ */
+
+import {
+  formatActiveProfileIndicator,
+  formatActiveProfileTooltip,
+  orderProfilesForQuickSwitch,
+  INDICATOR_GLYPH,
+  NO_ACTIVE_PROFILE_TEXT,
+  UNRESOLVED_PROFILE_TEXT,
+} from "../../../../src/domain/profile/quickSwitch";
+import {
+  ProfileIndicator,
+  PROFILE_RIBBON_ICON,
+  PROFILE_STATUS_BAR_CLASS,
+  type IndicatorProfile,
+} from "../../../../src/infrastructure/adapters/ProfileIndicator";
+
+const PERSONAL = { uid: "uid-personal", label: "Personal" };
+const WORK = { uid: "uid-work", label: "Work" };
+const READING = { uid: "uid-reading", label: "Reading" };
+/** Mirrors `SHOW_ALL_PROFILES_UID` — the synthetic expander row. */
+const SHOW_ALL = { uid: "__exocortex_show_all_profiles__", label: "Show all…" };
+
+describe("quickSwitch — switcher ordering", () => {
+  it("@req:38e2fdd5-8768-4354-8cb8-f1c77856ddb8 AC2: offers the context you came FROM first, keeping every other row's relative order", () => {
+    // Alphabetical, as the caller sorts them: Personal, Reading, Work.
+    const ordered = orderProfilesForQuickSwitch(
+      [PERSONAL, READING, WORK],
+      WORK.uid,
+    );
+
+    // "Work" was active before "Personal" → it is the switch-back target.
+    expect(ordered.map((p) => p.label)).toEqual([
+      "Work",
+      "Personal",
+      "Reading",
+    ]);
+  });
+
+  it("promotes a profile that is already first without duplicating or dropping it", () => {
+    const ordered = orderProfilesForQuickSwitch(
+      [PERSONAL, READING, WORK],
+      PERSONAL.uid,
+    );
+    expect(ordered.map((p) => p.label)).toEqual([
+      "Personal",
+      "Reading",
+      "Work",
+    ]);
+    expect(ordered).toHaveLength(3);
+  });
+
+  it("zero-regression: with no previous profile the order is returned untouched", () => {
+    const input = [PERSONAL, READING, WORK];
+    expect(orderProfilesForQuickSwitch(input, null).map((p) => p.uid)).toEqual(
+      input.map((p) => p.uid),
+    );
+    expect(orderProfilesForQuickSwitch(input, "").map((p) => p.uid)).toEqual(
+      input.map((p) => p.uid),
+    );
+  });
+
+  it("zero-regression: an unmatched previous profile (deleted / unmounted) leaves the order untouched", () => {
+    const input = [PERSONAL, READING, WORK];
+    expect(
+      orderProfilesForQuickSwitch(input, "uid-that-no-longer-exists").map(
+        (p) => p.uid,
+      ),
+    ).toEqual(input.map((p) => p.uid));
+  });
+
+  it("never promotes the «Show all profiles…» sentinel", () => {
+    const ordered = orderProfilesForQuickSwitch(
+      [PERSONAL, WORK, SHOW_ALL],
+      WORK.uid,
+    );
+    expect(ordered[0]?.uid).toBe(WORK.uid);
+    // The sentinel stays last, where the caller appended it.
+    expect(ordered[ordered.length - 1]?.uid).toBe(SHOW_ALL.uid);
+  });
+
+  it("does not mutate the caller's array", () => {
+    const input = [PERSONAL, READING, WORK];
+    orderProfilesForQuickSwitch(input, WORK.uid);
+    expect(input.map((p) => p.label)).toEqual(["Personal", "Reading", "Work"]);
+  });
+});
+
+describe("quickSwitch — indicator text", () => {
+  it("names the active profile by its human label, never its UID", () => {
+    expect(formatActiveProfileIndicator("Personal")).toBe(
+      `${INDICATOR_GLYPH} Personal`,
+    );
+    expect(formatActiveProfileTooltip("Personal")).toContain("Personal");
+    expect(formatActiveProfileTooltip("Personal")).toContain("context");
+  });
+
+  it("states explicitly when nothing has been applied — never blank", () => {
+    expect(formatActiveProfileIndicator(null)).toContain(
+      NO_ACTIVE_PROFILE_TEXT,
+    );
+    expect(formatActiveProfileIndicator("")).toContain(NO_ACTIVE_PROFILE_TEXT);
+    expect(formatActiveProfileTooltip(null).length).toBeGreaterThan(0);
+  });
+});
+
+/** Records what the fake surfaces were asked to register. */
+function makeSurfaces() {
+  const ribbonEl = document.createElement("div");
+  const statusEl = document.createElement("div");
+  const ribbonCalls: Array<{ icon: string; title: string }> = [];
+  let ribbonCb: (() => void) | null = null;
+  let statusBarRegistered = 0;
+
+  return {
+    ribbonEl,
+    statusEl,
+    ribbonCalls,
+    get ribbonCb() {
+      return ribbonCb;
+    },
+    get statusBarRegistered() {
+      return statusBarRegistered;
+    },
+    addRibbonIcon: (icon: string, title: string, cb: () => void) => {
+      ribbonCalls.push({ icon, title });
+      ribbonCb = cb;
+      return ribbonEl;
+    },
+    addStatusBarItem: () => {
+      statusBarRegistered += 1;
+      return statusEl;
+    },
+  };
+}
+
+describe("ProfileIndicator — the two surfaces", () => {
+  const profiles: IndicatorProfile[] = [PERSONAL, WORK];
+
+  it("@req:38e2fdd5-8768-4354-8cb8-f1c77856ddb8 AC1+AC2b: the desktop status bar names the active profile and opens the switcher on click", async () => {
+    const s = makeSurfaces();
+    let opened = 0;
+    const indicator = new ProfileIndicator({
+      getActiveProfileUid: () => PERSONAL.uid,
+      listProfiles: async () => profiles,
+      openSwitcher: () => {
+        opened += 1;
+      },
+      addRibbonIcon: s.addRibbonIcon,
+      addStatusBarItem: s.addStatusBarItem,
+    });
+
+    indicator.mount();
+    await indicator.refresh();
+
+    expect(s.statusBarRegistered).toBe(1);
+    expect(s.statusEl.textContent).toBe(`${INDICATOR_GLYPH} Personal`);
+    expect(s.statusEl.classList.contains(PROFILE_STATUS_BAR_CLASS)).toBe(true);
+
+    // One tap on the indicator = the switcher opens (the second tap is the row).
+    s.statusEl.dispatchEvent(new MouseEvent("click"));
+    expect(opened).toBe(1);
+  });
+
+  it("@req:38e2fdd5-8768-4354-8cb8-f1c77856ddb8 AC3: on mobile — no status bar — the ribbon entry still names the profile and opens the switcher", async () => {
+    const s = makeSurfaces();
+    let opened = 0;
+    const indicator = new ProfileIndicator({
+      getActiveProfileUid: () => WORK.uid,
+      listProfiles: async () => profiles,
+      openSwitcher: () => {
+        opened += 1;
+      },
+      addRibbonIcon: s.addRibbonIcon,
+      // Mobile: `addStatusBarItem` is not available, so it is not passed.
+      addStatusBarItem: undefined,
+    });
+
+    indicator.mount();
+    await indicator.refresh();
+
+    expect(s.statusBarRegistered).toBe(0);
+    expect(s.ribbonCalls).toHaveLength(1);
+    expect(s.ribbonCalls[0]?.icon).toBe(PROFILE_RIBBON_ICON);
+    // The accessible label is how the active profile is announced on mobile.
+    expect(s.ribbonEl.getAttribute("aria-label")).toContain("Work");
+    expect(s.ribbonEl.title).toContain("Work");
+
+    s.ribbonCb?.();
+    expect(opened).toBe(1);
+  });
+
+  it("follows the active profile across a switch, without remounting", async () => {
+    const s = makeSurfaces();
+    let active: string | null = PERSONAL.uid;
+    const indicator = new ProfileIndicator({
+      getActiveProfileUid: () => active,
+      listProfiles: async () => profiles,
+      openSwitcher: () => undefined,
+      addRibbonIcon: s.addRibbonIcon,
+      addStatusBarItem: s.addStatusBarItem,
+    });
+
+    indicator.mount();
+    await indicator.refresh();
+    expect(s.statusEl.textContent).toContain("Personal");
+
+    active = WORK.uid; // an apply completed
+    await indicator.refresh();
+    expect(s.statusEl.textContent).toContain("Work");
+    expect(s.statusBarRegistered).toBe(1); // no duplicate surface
+  });
+
+  it("a recorded-but-unresolvable profile reads as unknown, not as «no profile» and not as a raw UID", async () => {
+    const s = makeSurfaces();
+    const indicator = new ProfileIndicator({
+      getActiveProfileUid: () => "uid-deleted-profile",
+      listProfiles: async () => profiles,
+      openSwitcher: () => undefined,
+      addRibbonIcon: s.addRibbonIcon,
+      addStatusBarItem: s.addStatusBarItem,
+    });
+
+    indicator.mount();
+    await indicator.refresh();
+
+    expect(s.statusEl.textContent).toContain(UNRESOLVED_PROFILE_TEXT);
+    expect(s.statusEl.textContent).not.toContain("uid-deleted-profile");
+  });
+
+  it("a failing lister degrades instead of throwing into the caller", async () => {
+    const s = makeSurfaces();
+    const indicator = new ProfileIndicator({
+      getActiveProfileUid: () => PERSONAL.uid,
+      listProfiles: async () => {
+        throw new Error("vault scan failed");
+      },
+      openSwitcher: () => undefined,
+      addRibbonIcon: s.addRibbonIcon,
+      addStatusBarItem: s.addStatusBarItem,
+    });
+
+    indicator.mount();
+    await expect(indicator.refresh()).resolves.toBeUndefined();
+    expect(s.statusEl.textContent).toContain(UNRESOLVED_PROFILE_TEXT);
+  });
+
+  it("mount is idempotent — a second call cannot stack duplicate surfaces", () => {
+    const s = makeSurfaces();
+    const indicator = new ProfileIndicator({
+      getActiveProfileUid: () => null,
+      listProfiles: async () => profiles,
+      openSwitcher: () => undefined,
+      addRibbonIcon: s.addRibbonIcon,
+      addStatusBarItem: s.addStatusBarItem,
+    });
+
+    indicator.mount();
+    indicator.mount();
+
+    expect(s.ribbonCalls).toHaveLength(1);
+    expect(s.statusBarRegistered).toBe(1);
+  });
+});

--- a/packages/obsidian-plugin/tests/unit/domain/profile/quickSwitch.test.ts
+++ b/packages/obsidian-plugin/tests/unit/domain/profile/quickSwitch.test.ts
@@ -289,6 +289,76 @@ describe("ProfileIndicator — the two surfaces", () => {
     expect(s.statusEl.textContent).not.toContain("Personal");
   });
 
+  it("re-resolves once the vault is indexed — a cold cache at load must not strand the label", async () => {
+    // Caught by the CI e2e: at plugin load the metadata cache is cold, so the
+    // lister finds no profiles and the first paint can only say "Unknown".
+    // Nothing else re-resolved it, so the indicator stayed wrong until the user
+    // happened to apply a profile.
+    const s = makeSurfaces();
+    let cacheWarm = false;
+    const indicator = new ProfileIndicator({
+      getActiveProfileUid: () => PERSONAL.uid,
+      listProfiles: async () => (cacheWarm ? profiles : []),
+      openSwitcher: () => undefined,
+      addRibbonIcon: s.addRibbonIcon,
+      addStatusBarItem: s.addStatusBarItem,
+    });
+
+    indicator.mount();
+    await indicator.refresh(); // load — cache cold
+    expect(s.statusEl.textContent).toContain(UNRESOLVED_PROFILE_TEXT);
+
+    cacheWarm = true; // metadataCache "resolved"
+    await indicator.refreshIfUnsettled();
+    expect(s.statusEl.textContent).toContain("Personal");
+  });
+
+  it("stops re-resolving once the label has settled — the cache event must not carry a repeated vault walk", async () => {
+    const s = makeSurfaces();
+    let listCalls = 0;
+    const indicator = new ProfileIndicator({
+      getActiveProfileUid: () => PERSONAL.uid,
+      listProfiles: async () => {
+        listCalls += 1;
+        return profiles;
+      },
+      openSwitcher: () => undefined,
+      addRibbonIcon: s.addRibbonIcon,
+      addStatusBarItem: s.addStatusBarItem,
+    });
+
+    indicator.mount();
+    await indicator.refresh(); // resolves "Personal" → settled
+    expect(listCalls).toBe(1);
+
+    // Several further cache-resolution events.
+    await indicator.refreshIfUnsettled();
+    await indicator.refreshIfUnsettled();
+    expect(listCalls).toBe(1);
+  });
+
+  it("an unset profile counts as settled — «no profile» is a final answer, not a pending one", async () => {
+    const s = makeSurfaces();
+    let listCalls = 0;
+    const indicator = new ProfileIndicator({
+      getActiveProfileUid: () => null,
+      listProfiles: async () => {
+        listCalls += 1;
+        return profiles;
+      },
+      openSwitcher: () => undefined,
+      addRibbonIcon: s.addRibbonIcon,
+      addStatusBarItem: s.addStatusBarItem,
+    });
+
+    indicator.mount();
+    await indicator.refresh();
+    await indicator.refreshIfUnsettled();
+
+    expect(s.statusEl.textContent).toContain(NO_ACTIVE_PROFILE_TEXT);
+    expect(listCalls).toBe(0); // never even listed — no UID to resolve
+  });
+
   it("mount is idempotent — a second call cannot stack duplicate surfaces", () => {
     const s = makeSurfaces();
     const indicator = new ProfileIndicator({

--- a/packages/obsidian-plugin/tests/unit/domain/profile/quickSwitch.test.ts
+++ b/packages/obsidian-plugin/tests/unit/domain/profile/quickSwitch.test.ts
@@ -21,6 +21,7 @@ import {
   NO_ACTIVE_PROFILE_TEXT,
   UNRESOLVED_PROFILE_TEXT,
 } from "../../../../src/domain/profile/quickSwitch";
+import { SHOW_ALL_PROFILES_UID } from "../../../../src/infrastructure/adapters/ProfileCommands";
 import {
   ProfileIndicator,
   PROFILE_RIBBON_ICON,
@@ -31,8 +32,8 @@ import {
 const PERSONAL = { uid: "uid-personal", label: "Personal" };
 const WORK = { uid: "uid-work", label: "Work" };
 const READING = { uid: "uid-reading", label: "Reading" };
-/** Mirrors `SHOW_ALL_PROFILES_UID` — the synthetic expander row. */
-const SHOW_ALL = { uid: "__exocortex_show_all_profiles__", label: "Show all…" };
+/** The synthetic expander row — the real constant, so a rename cannot pass. */
+const SHOW_ALL = { uid: SHOW_ALL_PROFILES_UID, label: "Show all…" };
 
 describe("quickSwitch — switcher ordering", () => {
   it("@req:38e2fdd5-8768-4354-8cb8-f1c77856ddb8 AC2: offers the context you came FROM first, keeping every other row's relative order", () => {
@@ -256,6 +257,36 @@ describe("ProfileIndicator — the two surfaces", () => {
     indicator.mount();
     await expect(indicator.refresh()).resolves.toBeUndefined();
     expect(s.statusEl.textContent).toContain(UNRESOLVED_PROFILE_TEXT);
+  });
+
+  it("a slow refresh started BEFORE a switch cannot overwrite the newer label", async () => {
+    // The lister walks the vault, so refresh latency varies; a refresh fired at
+    // load can still be resolving when the post-apply refresh runs. Painting in
+    // completion order would leave the indicator naming the previous context.
+    const s = makeSurfaces();
+    let active = PERSONAL.uid;
+    let delayMs = 30;
+    const indicator = new ProfileIndicator({
+      getActiveProfileUid: () => active,
+      listProfiles: async () => {
+        const wait = delayMs;
+        await new Promise((r) => setTimeout(r, wait));
+        return profiles;
+      },
+      openSwitcher: () => undefined,
+      addRibbonIcon: s.addRibbonIcon,
+      addStatusBarItem: s.addStatusBarItem,
+    });
+    indicator.mount();
+
+    const slow = indicator.refresh(); // reads "Personal", resolves last
+    active = WORK.uid; // an apply completes
+    delayMs = 0;
+    const fast = indicator.refresh(); // reads "Work", resolves first
+    await Promise.all([fast, slow]);
+
+    expect(s.statusEl.textContent).toContain("Work");
+    expect(s.statusEl.textContent).not.toContain("Personal");
   });
 
   it("mount is idempotent — a second call cannot stack duplicate surfaces", () => {


### PR DESCRIPTION
feat(profile): name the active context and put the previous one one tap away

Req: 38e2fdd5-8768-4354-8cb8-f1c77856ddb8

P3 of project 17c173dd, RE-SCOPED per the explicit recommendation of its own
falsification gate P0 (task 8b8466bb): mount-less through profiles does not
materially help (-0.6%), but SWITCHING CONTEXT does (-44%), so keep this task
and sell it as fast context switching rather than as a speed-up.

What ships:

- an indicator naming the active profile, on the status bar (desktop) and as a
  ribbon entry (both platforms). `Plugin.addStatusBarItem` is documented as
  "Not available on mobile", so the ribbon is the iPhone affordance; the split
  is by SURFACE, never by capability;
- both surfaces open the EXISTING apply-profile flow, so there is exactly one
  switching code path — from the status bar, the ribbon or the palette;
- the picker's first row is now the profile that was active BEFORE the current
  one, i.e. the switch-back target, so a two-context ping-pong costs two taps.

Deliberately not added: a granular per-AssetSpace toggle (the gate measured it
as worthless and it is a footgun — `exocmd` is not in the TS floor), a second
"switch to previous" command (Undo last profile apply already does that and is
hotkey-bindable), and any index-time estimate.

Zero-regression is structural: `orderProfilesForQuickSwitch` returns the input
order untouched when no previous profile is recorded, and the indicator is
additive UI that changes nothing about what is mounted.

Revert-verified (three independent axes, each redding exactly its own tests):
- neutralise the ordering promotion -> 4 RED (2 pure + 2 through the real
  `invokeApplyProfile`, proving the ordering is wired, not inert); every
  zero-regression control and every indicator test stays GREEN;
- neutralise the status-bar painting -> 4 RED; the mobile/ribbon test and all
  ordering tests stay GREEN;
- drop the ribbon registration -> 2 RED (AC3 + idempotency); the desktop
  status-bar tests stay GREEN.

Regression sweep: 335 plugin unit suites, 5862 passed, 0 failing tests.
