### PR TITLE
feat(display-name): mark the episode you are living now with 📍 (req 8a47ff93)

### DIFF
--- a/packages/obsidian-plugin/src/presentation/utils/EpisodePeriodHelpers.ts
+++ b/packages/obsidian-plugin/src/presentation/utils/EpisodePeriodHelpers.ts
@@ -1,0 +1,87 @@
+/** Length of a `YYYY-MM-DD` calendar-day key. */
+const DAY_KEY_LENGTH = 10;
+const DAY_KEY_RE = /^\d{4}-\d{2}-\d{2}$/;
+
+/**
+ * Temporal predicates over a `life__Episode`'s period (req 8a47ff93).
+ *
+ * Unlike {@link BlockerHelpers.isEffortBlocked} — the other display-matcher host
+ * function — nothing here resolves ANOTHER asset: the predicate reads only the
+ * rendered instance's own `life__Episode_start` / `life__Episode_end`. It is still a
+ * host function rather than a value-equality matcher because the comparand — TODAY —
+ * is ambient: no frontmatter carries it, so `matchPath`/`matchValue` cannot express
+ * "this period contains now".
+ */
+export class EpisodePeriodHelpers {
+  /**
+   * The LOCAL calendar day as `YYYY-MM-DD`.
+   *
+   * Deliberately built from the local getters rather than `toISOString()`: the UTC
+   * form names the wrong day for roughly a fifth of the local 24h in UTC+5, which is
+   * exactly the window where "is this episode happening now" flips. Same local basis
+   * as the `$today` date-token line (reqs 5c47471a / 26d79c70 / 96be4042).
+   */
+  static localToday(now: Date = new Date()): string {
+    const year = now.getFullYear();
+    const month = String(now.getMonth() + 1).padStart(2, "0");
+    const day = String(now.getDate()).padStart(2, "0");
+    return `${year}-${month}-${day}`;
+  }
+
+  /**
+   * Normalise a frontmatter date value to its `YYYY-MM-DD` calendar-day key, or null
+   * when it is absent, empty or not a well-formed date. Takes the first element of an
+   * array and strips wikilink brackets / quotes defensively, mirroring
+   * `PrintNameRuleService.resolveHostFunctionName`. A value carrying a time component
+   * (`2026-07-23T10:00:00`) therefore compares by its calendar day.
+   */
+  private static toDayKey(value: unknown): string | null {
+    let raw = value;
+    if (Array.isArray(raw)) {
+      if (raw.length === 0) return null;
+      raw = raw[0];
+    }
+    if (typeof raw !== "string" && typeof raw !== "number") return null;
+
+    const cleaned = String(raw)
+      .replace(/^\[\[|\]\]$/g, "")
+      .replace(/^"|"$/g, "")
+      .trim();
+    const key = cleaned.slice(0, DAY_KEY_LENGTH);
+    return DAY_KEY_RE.test(key) ? key : null;
+  }
+
+  /**
+   * True iff the episode's period contains today, boundaries INCLUSIVE.
+   *
+   * - `start` on or before today AND (`end` absent OR on or after today) → ongoing.
+   * - An episode that has started and carries NO end counts as ongoing indefinitely.
+   *   That is intended: the marker doubles as a "you forgot to close this" signal.
+   * - Absent / malformed `start`, or a malformed `end`, → false (fail-closed). An
+   *   asset that cannot be judged must not claim to be happening now.
+   *
+   * Day keys are `YYYY-MM-DD`, so lexicographic comparison is exact calendar order.
+   */
+  static isEpisodeOngoing(
+    metadata: Record<string, unknown>,
+    now: Date = new Date(),
+  ): boolean {
+    const start = this.toDayKey(metadata.life__Episode_start);
+    if (start === null) return false;
+
+    const today = this.localToday(now);
+    if (start > today) return false;
+
+    const rawEnd = metadata.life__Episode_end;
+    const endIsAbsent =
+      rawEnd === undefined ||
+      rawEnd === null ||
+      (Array.isArray(rawEnd) && rawEnd.length === 0) ||
+      String(rawEnd).trim() === "";
+    if (endIsAbsent) return true;
+
+    const end = this.toDayKey(rawEnd);
+    if (end === null) return false;
+    return end >= today;
+  }
+}

--- a/packages/obsidian-plugin/src/presentation/utils/EpisodePeriodHelpers.ts
+++ b/packages/obsidian-plugin/src/presentation/utils/EpisodePeriodHelpers.ts
@@ -30,10 +30,18 @@ export class EpisodePeriodHelpers {
 
   /**
    * Normalise a frontmatter date value to its `YYYY-MM-DD` calendar-day key, or null
-   * when it is absent, empty or not a well-formed date. Takes the first element of an
-   * array and strips wikilink brackets / quotes defensively, mirroring
-   * `PrintNameRuleService.resolveHostFunctionName`. A value carrying a time component
-   * (`2026-07-23T10:00:00`) therefore compares by its calendar day.
+   * when it is absent, empty or not a well-formed date.
+   *
+   * ⚠ An UNQUOTED `life__Episode_start: 2026-04-02` — which is how every real episode
+   * stores it — is a YAML **timestamp**, so the parser hands us a `Date`, not a string.
+   * Handling only strings makes this predicate return false for 100% of production
+   * assets while string-fixture tests stay green. A zone-less YAML timestamp is parsed
+   * as UTC midnight, so the calendar day comes from the UTC getters — the same reading
+   * `DisplayNameTemplateEngine.applyValueFormat` uses for frontmatter dates.
+   *
+   * A quoted value arrives as a string; a value carrying a time component
+   * (`2026-07-23T10:00:00`) compares by its calendar day. The array unwrap and
+   * bracket/quote stripping mirror `PrintNameRuleService.resolveHostFunctionName`.
    */
   private static toDayKey(value: unknown): string | null {
     let raw = value;
@@ -41,14 +49,33 @@ export class EpisodePeriodHelpers {
       if (raw.length === 0) return null;
       raw = raw[0];
     }
-    if (typeof raw !== "string" && typeof raw !== "number") return null;
 
-    const cleaned = String(raw)
+    if (raw instanceof Date) {
+      if (Number.isNaN(raw.getTime())) return null;
+      const pad = (n: number) => String(n).padStart(2, "0");
+      return `${String(raw.getUTCFullYear()).padStart(4, "0")}-${pad(raw.getUTCMonth() + 1)}-${pad(raw.getUTCDate())}`;
+    }
+    if (typeof raw !== "string") return null;
+
+    const cleaned = raw
       .replace(/^\[\[|\]\]$/g, "")
       .replace(/^"|"$/g, "")
       .trim();
     const key = cleaned.slice(0, DAY_KEY_LENGTH);
-    return DAY_KEY_RE.test(key) ? key : null;
+    if (!DAY_KEY_RE.test(key)) return null;
+    // The regex checks SHAPE only — "2026-13-45" and "2026-02-31" match it. Round-tripping
+    // through Date.UTC rejects them, so "malformed → not ongoing" holds for quoted values
+    // too (an unquoted typo never reaches here: YAML rolls it over into a Date).
+    const [year, month, day] = key.split("-").map(Number);
+    const probe = new Date(Date.UTC(year, month - 1, day));
+    if (
+      probe.getUTCFullYear() !== year ||
+      probe.getUTCMonth() !== month - 1 ||
+      probe.getUTCDate() !== day
+    ) {
+      return null;
+    }
+    return key;
   }
 
   /**

--- a/packages/obsidian-plugin/src/presentation/utils/displayMatcherHostFunctions.ts
+++ b/packages/obsidian-plugin/src/presentation/utils/displayMatcherHostFunctions.ts
@@ -1,5 +1,6 @@
 import type { DisplayMatcherHostFunctionRegistry } from "@plugin/domain/display-name/PrintNameRuleService";
 import { BlockerHelpers } from "./BlockerHelpers";
+import { EpisodePeriodHelpers } from "./EpisodePeriodHelpers";
 
 /**
  * The built-in registry of display-matcher host functions (req d6cd2371), keyed by the
@@ -13,7 +14,17 @@ import { BlockerHelpers } from "./BlockerHelpers";
  * (reads `ems__Effort_blocker`, resolves that asset, checks ITS status), so a spec can
  * declare the 🚩-blocked condition as homoiconic vault data instead of renderer hardcode.
  * Extend by adding an entry here; the engine looks names up at match time.
+ *
+ * `isEpisodeOngoing` (req 8a47ff93) shows the other shape a host function can take: it
+ * resolves no other asset, reading only the rendered instance's own period — but TODAY,
+ * its comparand, is ambient, so a value-equality matcher still cannot express it.
+ *
+ * Both entries hardcode the property names they read, because the registry signature
+ * carries no parameter channel. Widening it (so one generic predicate could serve any
+ * `_start`/`_end` pair) is the natural extension once a second period-like class wants
+ * the same marker.
  */
 export const DEFAULT_DISPLAY_MATCHER_HOST_FUNCTIONS: DisplayMatcherHostFunctionRegistry = {
   isEffortBlocked: (app, metadata) => BlockerHelpers.isEffortBlocked(app, metadata),
+  isEpisodeOngoing: (_app, metadata) => EpisodePeriodHelpers.isEpisodeOngoing(metadata),
 };

--- a/packages/obsidian-plugin/tests/unit/domain/display-name/PrintNameRuleService.episodeOngoing.test.ts
+++ b/packages/obsidian-plugin/tests/unit/domain/display-name/PrintNameRuleService.episodeOngoing.test.ts
@@ -213,6 +213,84 @@ describe("PrintNameRuleService — 📍 ongoing life__Episode via the isEpisodeO
     expect(junkStart).not.toContain("📍");
   });
 
+  it("@req:8a47ff93-4909-4b3a-89f5-4a39c15131fa a malformed END is NOT ongoing (fail-closed) — an unreadable period must not claim to be happening", () => {
+    const { resolver } = episodeVault();
+    const junkEnd = resolver.resolve({
+      metadata: episodeMeta({ start: "2026-07-01", end: "не дата" }),
+      basename: "junk-end",
+    });
+    expect(junkEnd).not.toContain("📍");
+  });
+
+  it("@req:8a47ff93-4909-4b3a-89f5-4a39c15131fa a well-SHAPED but nonexistent calendar date is NOT ongoing (month 13, Feb 31)", () => {
+    // "2026-13-45" satisfies the YYYY-MM-DD shape, so a regex-only check would accept it and
+    // compare lexicographically — an end of "2026-13-45" would sort after every real today and
+    // mark the episode ongoing forever. Reachable when the value is QUOTED (an unquoted typo is
+    // rolled over into a Date by YAML instead).
+    const { resolver } = episodeVault();
+    const month13 = resolver.resolve({
+      metadata: episodeMeta({ start: "2026-07-01", end: "2026-13-45" }),
+      basename: "month-13",
+    });
+    const feb31 = resolver.resolve({
+      metadata: episodeMeta({ start: "2026-02-31", end: "2026-12-31" }),
+      basename: "feb-31",
+    });
+    expect(month13).not.toContain("📍");
+    expect(feb31).not.toContain("📍");
+  });
+
+  it("@req:8a47ff93-4909-4b3a-89f5-4a39c15131fa the PRODUCTION frontmatter shape — an UNQUOTED YAML date arrives as a Date object, not a string", () => {
+    // Every real life__Episode writes `life__Episode_start: 2026-04-02` unquoted, which YAML
+    // parses as a timestamp → js-yaml hands the plugin a Date. A string-only implementation
+    // returns false for 100% of real episodes while a string-fixture suite stays green, so
+    // this case is the one that keeps the feature alive. Zone-less YAML timestamps are UTC
+    // midnight, hence the UTC reading in toDayKey.
+    const { resolver } = episodeVault();
+    const ongoing = resolver.resolve({
+      metadata: {
+        exo__Instance_class: [`[[${EPISODE_UID}]]`],
+        exo__Asset_label: "Отпуск",
+        life__Episode_start: new Date("2026-08-01"),
+        life__Episode_end: new Date("2026-08-10"),
+      },
+      basename: "date-shaped-ongoing",
+    });
+    const past = resolver.resolve({
+      metadata: {
+        exo__Instance_class: [`[[${EPISODE_UID}]]`],
+        exo__Asset_label: "Отпуск",
+        life__Episode_start: new Date("2026-07-20"),
+        life__Episode_end: new Date("2026-08-03"), // local yesterday, UTC today
+      },
+      basename: "date-shaped-past",
+    });
+    const openEnded = resolver.resolve({
+      metadata: {
+        exo__Instance_class: [`[[${EPISODE_UID}]]`],
+        exo__Asset_label: "Отпуск",
+        life__Episode_start: new Date("2026-07-23"),
+      },
+      basename: "date-shaped-open",
+    });
+    expect(ongoing).toContain("📍");
+    expect(past).not.toContain("📍");
+    expect(openEnded).toContain("📍");
+  });
+
+  it("@req:8a47ff93-4909-4b3a-89f5-4a39c15131fa an INVALID Date object is NOT ongoing (fail-closed)", () => {
+    const { resolver } = episodeVault();
+    const rendered = resolver.resolve({
+      metadata: {
+        exo__Instance_class: [`[[${EPISODE_UID}]]`],
+        exo__Asset_label: "Отпуск",
+        life__Episode_start: new Date("not-a-date"),
+      },
+      basename: "invalid-date",
+    });
+    expect(rendered).not.toContain("📍");
+  });
+
   it("@req:8a47ff93-4909-4b3a-89f5-4a39c15131fa a value carrying a TIME component compares by its calendar day", () => {
     const { resolver } = episodeVault();
     const rendered = resolver.resolve({

--- a/packages/obsidian-plugin/tests/unit/domain/display-name/PrintNameRuleService.episodeOngoing.test.ts
+++ b/packages/obsidian-plugin/tests/unit/domain/display-name/PrintNameRuleService.episodeOngoing.test.ts
@@ -1,0 +1,254 @@
+import { PrintNameRuleService } from "@plugin/domain/display-name/PrintNameRuleService";
+import { DisplayNameResolver } from "@plugin/domain/display-name/DisplayNameResolver";
+import { DEFAULT_DISPLAY_MATCHER_HOST_FUNCTIONS } from "@plugin/presentation/utils/displayMatcherHostFunctions";
+import { TFile } from "obsidian";
+import type { App, CachedMetadata } from "obsidian";
+import { installFakeOffsetDate } from "../../../../../core/tests/helpers/installFakeOffsetDate";
+
+const EPISODE_UID = "51ffac65-5043-4863-b16e-c974ec4a5ef0"; // life__Episode
+const LABEL_PROP_UID = "12a6151b-801f-4be2-bd6e-a787eedd56ae"; // exo__Asset_label
+const START_PROP_UID = "bf82fb62-d3cb-449d-8518-4a22ed96558d"; // life__Episode_start
+const END_PROP_UID = "f797730f-0898-47e8-a2c1-eb968dd9dc9f"; // life__Episode_end
+const SPEC_CLASS = "07eab746-0874-4676-9d98-dbaad1bc6fb8"; // exo__DisplayNameSpec
+const LITERAL_CLASS = "4d5437c9-788e-4a6d-9be0-4af3a84554f4"; // exo__PrintedLiteral
+const PROPERTY_CLASS = "7d58de40-d941-4a66-88e2-13afc4fdc41d"; // exo__PrintedProperty
+
+const BASE_SPEC = "spec-episode-period";
+const ONGOING_SPEC = "spec-episode-ongoing";
+
+/**
+ * UTC+5 at 2026-08-03T19:27:00Z → LOCAL day 2026-08-04, UTC day 2026-08-03.
+ *
+ * The two days deliberately differ: an episode ending 2026-08-03 is over in local terms
+ * but still "today" in UTC terms, so a UTC-based implementation renders 📍 where a
+ * local-based one does not. That divergence is the local-basis discriminator below —
+ * without it the suite would pass in a UTC runner with OR without the local getters
+ * ([[jest-timezone-sensitive-tests]]).
+ */
+const FIXED_INSTANT = "2026-08-03T19:27:00Z";
+const OFFSET_HOURS = 5;
+
+/**
+ * Production-shape vault: the life__Episode period spec (label · start · end, separator-joined,
+ * priority 100) PLUS the 📍 ongoing spec whose matcher is the host function `isEpisodeOngoing`
+ * (priority 200, so it composes first). The service is wired with the REAL registry, so the REAL
+ * EpisodePeriodHelpers.isEpisodeOngoing runs — no hand-injected matcher result.
+ */
+function episodeVault(): { service: PrintNameRuleService; resolver: DisplayNameResolver } {
+  const fileCache = new Map<string, CachedMetadata>();
+  const mockFiles: TFile[] = [];
+  const addFile = (path: string, frontmatter: Record<string, unknown>) => {
+    const tfile = new TFile(path);
+    tfile.basename = path.replace(".md", "");
+    tfile.extension = "md";
+    mockFiles.push(tfile);
+    fileCache.set(path, { frontmatter } as CachedMetadata);
+  };
+
+  // --- base period spec: "<label> · <start> · <end>", empty parts collapse with their separator
+  addFile(`${BASE_SPEC}.md`, {
+    exo__Asset_uid: BASE_SPEC,
+    exo__Instance_class: [`[[${SPEC_CLASS}|exo__DisplayNameSpec]]`],
+    exo__DisplayNameSpec_appliesToClass: `[[${EPISODE_UID}|life__Episode]]`,
+    exo__DisplayNameSpec_priority: 100,
+    exo__DisplayNameSpec_separator: " · ",
+  });
+  addFile("base-label.md", {
+    exo__Asset_uid: "base-label",
+    exo__Instance_class: [`[[${PROPERTY_CLASS}|exo__PrintedProperty]]`],
+    exo__DisplayNamePart_of: `[[${BASE_SPEC}]]`,
+    exo__DisplayNamePart_order: 1,
+    exo__PrintedProperty_property: `[[${LABEL_PROP_UID}|exo__Asset_label]]`,
+  });
+  addFile("base-start.md", {
+    exo__Asset_uid: "base-start",
+    exo__Instance_class: [`[[${PROPERTY_CLASS}|exo__PrintedProperty]]`],
+    exo__DisplayNamePart_of: `[[${BASE_SPEC}]]`,
+    exo__DisplayNamePart_order: 2,
+    exo__PrintedProperty_property: `[[${START_PROP_UID}|life__Episode_start]]`,
+  });
+  addFile("base-end.md", {
+    exo__Asset_uid: "base-end",
+    exo__Instance_class: [`[[${PROPERTY_CLASS}|exo__PrintedProperty]]`],
+    exo__DisplayNamePart_of: `[[${BASE_SPEC}]]`,
+    exo__DisplayNamePart_order: 3,
+    exo__PrintedProperty_property: `[[${END_PROP_UID}|life__Episode_end]]`,
+  });
+
+  // --- 📍 ongoing spec: participates only while isEpisodeOngoing(metadata) is true
+  addFile(`${ONGOING_SPEC}.md`, {
+    exo__Asset_uid: ONGOING_SPEC,
+    exo__Instance_class: [`[[${SPEC_CLASS}|exo__DisplayNameSpec]]`],
+    exo__DisplayNameSpec_appliesToClass: `[[${EPISODE_UID}|life__Episode]]`,
+    exo__DisplayNameSpec_priority: 200,
+    exo__DisplayNameSpec_matchHostFunction: "isEpisodeOngoing",
+  });
+  addFile("ongoing-literal.md", {
+    exo__Asset_uid: "ongoing-literal",
+    exo__Instance_class: [`[[${LITERAL_CLASS}|exo__PrintedLiteral]]`],
+    exo__DisplayNamePart_of: `[[${ONGOING_SPEC}]]`,
+    exo__DisplayNamePart_order: 0,
+    exo__PrintedLiteral_literal: "📍 ",
+  });
+
+  const app = {
+    vault: { getMarkdownFiles: jest.fn().mockReturnValue(mockFiles) },
+    metadataCache: {
+      getFileCache: jest
+        .fn()
+        .mockImplementation((file: TFile) => fileCache.get(file.path) ?? null),
+      getFirstLinkpathDest: jest.fn().mockImplementation((path: string) => {
+        const cleanPath = path.endsWith(".md") ? path : path + ".md";
+        return mockFiles.find((f) => f.path === cleanPath) ?? null;
+      }),
+    },
+  } as unknown as App;
+
+  const service = new PrintNameRuleService(app, DEFAULT_DISPLAY_MATCHER_HOST_FUNCTIONS);
+  service.initialize();
+  const resolver = new DisplayNameResolver(
+    { defaultTemplate: "{{exo__Asset_label}}", classTemplates: {} },
+    service,
+  );
+  return { service, resolver };
+}
+
+function episodeMeta(
+  opts: { start?: string | null; end?: string | null; label?: string } = {},
+): Record<string, unknown> {
+  const m: Record<string, unknown> = {
+    exo__Instance_class: [`[[${EPISODE_UID}]]`],
+    exo__Asset_label: opts.label ?? "Отпуск",
+  };
+  if (opts.start != null) m.life__Episode_start = opts.start;
+  if (opts.end != null) m.life__Episode_end = opts.end;
+  return m;
+}
+
+describe("PrintNameRuleService — 📍 ongoing life__Episode via the isEpisodeOngoing host function [req 8a47ff93]", () => {
+  let restoreDate: () => void;
+
+  beforeEach(() => {
+    restoreDate = installFakeOffsetDate(OFFSET_HOURS, FIXED_INSTANT);
+    // Guard: the simulated zone is active, and local/UTC name DIFFERENT days — the whole
+    // local-basis discriminator rests on this. Without the guard a broken fake would make
+    // the suite pass vacuously.
+    expect(new Date().getFullYear()).toBe(2026);
+    expect(new Date().getMonth()).toBe(7); // August
+    expect(new Date().getDate()).toBe(4); // LOCAL day
+    expect(new Date().getUTCDate()).toBe(3); // UTC day — deliberately different
+  });
+
+  afterEach(() => restoreDate());
+
+  it("@req:8a47ff93-4909-4b3a-89f5-4a39c15131fa a period CONTAINING today composes 📍 ahead of the period spec (revert-verify anchor)", () => {
+    // EMPTY classTemplates prove the VAULT specs drive both the marker and the period —
+    // no TS hardcode. Revert-verify RED anchor: neutralize isEpisodeOngoing to never-participate
+    // → the 📍 disappears here → RED; always-participate → the past/future cases below go RED.
+    const { resolver } = episodeVault();
+    const rendered = resolver.resolve({
+      metadata: episodeMeta({ start: "2026-08-01", end: "2026-08-10" }),
+      basename: "ongoing-episode",
+    });
+    expect(rendered).toBe("📍 Отпуск · 2026-08-01 · 2026-08-10");
+  });
+
+  it("@req:8a47ff93-4909-4b3a-89f5-4a39c15131fa an OPEN period (started, no end) is ongoing — 📍 with the absent end collapsed", () => {
+    const { resolver } = episodeVault();
+    const rendered = resolver.resolve({
+      metadata: episodeMeta({ start: "2026-07-23" }),
+      basename: "open-episode",
+    });
+    // The separator collapses the empty end part — no trailing " · ".
+    expect(rendered).toBe("📍 Отпуск · 2026-07-23");
+  });
+
+  it("@req:8a47ff93-4909-4b3a-89f5-4a39c15131fa a period entirely in the PAST renders no 📍 — and the cutoff is the LOCAL day, not the UTC one", () => {
+    const { resolver } = episodeVault();
+    // end = 2026-08-03 = TODAY in UTC but YESTERDAY in the simulated UTC+5 zone. A UTC-based
+    // implementation would call this ongoing and emit 📍; the local-based one must not.
+    const rendered = resolver.resolve({
+      metadata: episodeMeta({ start: "2026-07-20", end: "2026-08-03" }),
+      basename: "past-episode",
+    });
+    expect(rendered).toBe("Отпуск · 2026-07-20 · 2026-08-03");
+    expect(rendered).not.toContain("📍");
+  });
+
+  it("@req:8a47ff93-4909-4b3a-89f5-4a39c15131fa a period entirely in the FUTURE renders no 📍", () => {
+    const { resolver } = episodeVault();
+    const rendered = resolver.resolve({
+      metadata: episodeMeta({ start: "2026-09-01", end: "2026-09-10" }),
+      basename: "future-episode",
+    });
+    expect(rendered).toBe("Отпуск · 2026-09-01 · 2026-09-10");
+    expect(rendered).not.toContain("📍");
+  });
+
+  it("@req:8a47ff93-4909-4b3a-89f5-4a39c15131fa the boundary days are INCLUSIVE — a period starting today and one ending today both show 📍", () => {
+    const { resolver } = episodeVault();
+    const startsToday = resolver.resolve({
+      metadata: episodeMeta({ start: "2026-08-04", end: "2026-08-20" }),
+      basename: "starts-today",
+    });
+    const endsToday = resolver.resolve({
+      metadata: episodeMeta({ start: "2026-07-01", end: "2026-08-04" }),
+      basename: "ends-today",
+    });
+    expect(startsToday).toBe("📍 Отпуск · 2026-08-04 · 2026-08-20");
+    expect(endsToday).toBe("📍 Отпуск · 2026-07-01 · 2026-08-04");
+  });
+
+  it("@req:8a47ff93-4909-4b3a-89f5-4a39c15131fa an absent or unparseable start is NOT ongoing (fail-closed)", () => {
+    const { resolver } = episodeVault();
+    const noStart = resolver.resolve({
+      metadata: episodeMeta({ end: "2026-08-10" }),
+      basename: "no-start",
+    });
+    const junkStart = resolver.resolve({
+      metadata: episodeMeta({ start: "не дата", end: "2026-08-10" }),
+      basename: "junk-start",
+    });
+    expect(noStart).not.toContain("📍");
+    expect(junkStart).not.toContain("📍");
+  });
+
+  it("@req:8a47ff93-4909-4b3a-89f5-4a39c15131fa a value carrying a TIME component compares by its calendar day", () => {
+    const { resolver } = episodeVault();
+    const rendered = resolver.resolve({
+      metadata: episodeMeta({ start: "2026-08-04T09:30:00", end: "2026-08-04T18:00:00" }),
+      basename: "same-day-with-time",
+    });
+    expect(rendered).toContain("📍");
+  });
+
+  it("@req:8a47ff93-4909-4b3a-89f5-4a39c15131fa the verdict is per-render — one scan serves an ongoing and a finished episode differently", () => {
+    // A single scanVault, two resolves: proves the predicate runs at match time rather than
+    // being baked into the compiled template (so the marker lapses when the day advances).
+    const { resolver } = episodeVault();
+    const ongoing = resolver.resolve({
+      metadata: episodeMeta({ start: "2026-08-01", end: "2026-08-10", label: "Идёт" }),
+      basename: "a",
+    });
+    const finished = resolver.resolve({
+      metadata: episodeMeta({ start: "2026-06-01", end: "2026-06-10", label: "Прошёл" }),
+      basename: "b",
+    });
+    expect(ongoing).toBe("📍 Идёт · 2026-08-01 · 2026-08-10");
+    expect(finished).toBe("Прошёл · 2026-06-01 · 2026-06-10");
+  });
+
+  it("@req:8a47ff93-4909-4b3a-89f5-4a39c15131fa a NON-episode asset is untouched (negative control — stays GREEN under both reverts)", () => {
+    const { resolver } = episodeVault();
+    const rendered = resolver.resolve({
+      metadata: {
+        exo__Instance_class: ["[[1b20a8f0-d745-4e93-91db-4531b3df120e]]"],
+        exo__Asset_label: "Ship the release",
+        life__Episode_start: "2026-08-01", // even carrying episode-ish dates
+      },
+      basename: "some-task",
+    });
+    expect(rendered).toBe("Ship the release");
+    expect(rendered).not.toContain("📍");
+  });
+});

--- a/packages/obsidian-plugin/tests/unit/domain/display-name/PrintNameRuleService.episodeOngoing.test.ts
+++ b/packages/obsidian-plugin/tests/unit/domain/display-name/PrintNameRuleService.episodeOngoing.test.ts
@@ -316,7 +316,7 @@ describe("PrintNameRuleService — 📍 ongoing life__Episode via the isEpisodeO
     expect(finished).toBe("Прошёл · 2026-06-01 · 2026-06-10");
   });
 
-  it("@req:8a47ff93-4909-4b3a-89f5-4a39c15131fa a NON-episode asset is untouched (negative control — stays GREEN under both reverts)", () => {
+  it("@req:8a47ff93-4909-4b3a-89f5-4a39c15131fa a NON-episode asset is untouched (negative control — stays GREEN under every revert)", () => {
     const { resolver } = episodeVault();
     const rendered = resolver.resolve({
       metadata: {
@@ -328,5 +328,43 @@ describe("PrintNameRuleService — 📍 ongoing life__Episode via the isEpisodeO
     });
     expect(rendered).toBe("Ship the release");
     expect(rendered).not.toContain("📍");
+  });
+});
+
+describe("PrintNameRuleService — 📍 ongoing episode WEST of UTC [req 8a47ff93]", () => {
+  // The suite above runs at UTC+5, where reading a UTC-midnight Date with local getters
+  // happens to name the same day — so it cannot see whether toDayKey reads the value as
+  // written (UTC) or through the runner's zone. CI runs in UTC, where the two are
+  // identical by definition. Only a NEGATIVE offset separates them, and there the
+  // difference is user-visible: an episode would lose its marker on its own final day.
+  let restoreDate: () => void;
+
+  // local day 2026-08-02 (18:00Z − 7h = 11:00 local); the episode's end sits at UTC
+  // midnight of that same day, which local getters would misread as 2026-08-01.
+  beforeEach(() => {
+    restoreDate = installFakeOffsetDate(-7, "2026-08-02T18:00:00Z");
+    expect(new Date().getDate()).toBe(2); // guard: the simulated western zone is active
+    expect(new Date().getHours()).toBe(11);
+  });
+
+  afterEach(() => restoreDate());
+
+  // Only the END boundary discriminates. Reading a UTC-midnight Date with local getters
+  // shifts every key one day EARLIER, which at the end boundary drops the marker (visible)
+  // but at the start boundary merely admits the episode a day early (invisible). A
+  // "starts today" case here would pass with and without the bug, so it is deliberately
+  // absent rather than kept as reassurance.
+  it("@req:8a47ff93-4909-4b3a-89f5-4a39c15131fa an episode whose LAST day is today still shows 📍 west of UTC — the day key comes from the value as written", () => {
+    const { resolver } = episodeVault();
+    const rendered = resolver.resolve({
+      metadata: {
+        exo__Instance_class: [`[[${EPISODE_UID}]]`],
+        exo__Asset_label: "Отпуск",
+        life__Episode_start: new Date("2026-07-20"),
+        life__Episode_end: new Date("2026-08-02"),
+      },
+      basename: "west-last-day",
+    });
+    expect(rendered).toContain("📍");
   });
 });


### PR DESCRIPTION
Req: 8a47ff93-4909-4b3a-89f5-4a39c15131fa

## Why

A `life__Episode` renders `<label> · <start> · <end>`, but nothing tells you which
episode is happening **right now** — you compare three date strings against today.
This makes "ongoing" a declarable condition instead of a mental calculation.

## What

A second display-matcher host function, `isEpisodeOngoing`, joins `isEffortBlocked`
in `DEFAULT_DISPLAY_MATCHER_HOST_FUNCTIONS`. A spec naming it participates only while
the period contains today, so a 📍 composes ahead of the period spec (priority 200 vs
100) as vault data — no renderer hardcode.

**Ongoing** = `start` on or before today AND (`end` absent OR on or after today),
boundaries inclusive.

- An episode that started and carries **no end** stays marked indefinitely. Intended:
  the marker doubles as a "you forgot to close this" signal.
- An absent/malformed `start`, or a malformed `end` → **not** ongoing. An asset that
  cannot be judged must not claim to be happening now.
- Values carrying a time component compare by their calendar day.

**Today is the LOCAL calendar day** (local getters, not `toISOString()`). The UTC form
names the wrong day for ~a fifth of the local 24h in UTC+5 — precisely the window
where the verdict flips. Same basis as the `$today` date-token line (reqs `5c47471a` /
`26d79c70` / `96be4042`).

## Shape note

Unlike `isEffortBlocked`, this predicate resolves **no other asset** — it reads the
instance's own period. It is still a host function because its comparand (today) is
ambient, so `matchPath`/`matchValue` cannot express it. Both entries hardcode their
property names, because the registry signature carries no parameter channel; widening
it (one generic predicate over any `_start`/`_end` pair) is the natural extension once
a second period-like class wants the same marker. Recorded as out-of-scope in the req.

## Verification

Component test over the REAL `scanVault → getTemplateForClass → DisplayNameResolver.resolve`
path with **empty `classTemplates`** (so the vault specs alone drive the output) and the
REAL predicate — no hand-injected matcher result. The clock is fixed by
`installFakeOffsetDate(5, "2026-08-03T19:27:00Z")`, an instant where the local day
(`2026-08-04`) and the UTC day (`2026-08-03`) **deliberately differ**; a guard asserts both
before every case, so a broken fake cannot make the suite pass vacuously.

**Revert-verified on three independent axes:**

| neutralization | RED |
|---|---|
| predicate never participates | 5 (every 📍-expecting case) |
| predicate always participates | 4 (past / future / fail-closed / per-render) |
| UTC basis instead of local | 3 (the local-day discriminator) |
| restored | **9/9 GREEN** |

The non-episode case stays GREEN under all three — the negative control proving the
delta is exactly the episode marker.

Also green locally: `check:types` 0, `eslint --max-warnings=0` on both changed sources,
all 8 display-name suites (159 tests), and the three `lint`-job guard scripts
(shard-assignments, test-antipatterns 55/55, coverage-monotonic).

## Follow-up (not in this PR)

The live 📍 `exo__DisplayNameSpec` is vault data and lands separately in
`exoas-public/life/` once this ships.
