### PR TITLE
feat(grounding): address a command step at the asset a named query finds (req faf269bf)

### DIFF
--- a/packages/core/src/domain/models/CommandDefinition.ts
+++ b/packages/core/src/domain/models/CommandDefinition.ts
@@ -181,6 +181,28 @@ export interface GroundingDefinition {
    *  `exocmd__Grounding_targetValueQuery` (wikilink → bare UID). Generic /
    *  reusable; C5 (ontological archive) is the first consumer. */
   readonly targetValueQuery?: string;
+  /**
+   * req faf269bf — TARGET-side NamedQuery: UUID of a `query__NamedQuery` asset
+   * whose first projection identifies the asset this `property_set` step writes
+   * INTO. Orthogonal to `targetValueQuery` (which computes the VALUE): this one
+   * answers "which asset", not "which value", so the two compose freely.
+   *
+   * The query runs read-only with `$currentAsset` auto-injected = the
+   * click-target IRI, so a reified link can be found FROM one of its ends —
+   * the gap this closes. A reified statement is neither the click-target nor an
+   * asset a previous step created, so before this field it was unaddressable.
+   *
+   * Absent (every existing grounding) → the step targets the click-target, or
+   * the created instance when `targetsCreatedInstance` is set: byte-identical
+   * prior behaviour. Mutually exclusive with `targetsCreatedInstance` — two
+   * incompatible addressings must never be silently arbitrated. A query that
+   * matches nothing is fail-loud: the click-target is NEVER a fallback, since
+   * writing to it would put the value on the wrong asset.
+   *
+   * Authored as the `exocmd__Grounding_targetQuery` RDF triple (wikilink → bare
+   * UID, resolved by `CommandResolver.loadGroundingDefinition`).
+   */
+  readonly targetQuery?: string;
   /** RFC 918a2b65 Phase 1: Opaque JSON config payload for `service_call`
    *  groundings. Resolved through `substituteVariables` before `JSON.parse`;
    *  merged into `userInput` defaults at `GroundingExecutor.executeServiceCall`.

--- a/packages/core/src/domain/models/GroundingFrontmatterParser.ts
+++ b/packages/core/src/domain/models/GroundingFrontmatterParser.ts
@@ -128,6 +128,16 @@ export function parseGroundingDefinitionFromFrontmatter(
   const targetsCreatedInstance =
     rawTargetsCreatedInstance === true || rawTargetsCreatedInstance === "true";
 
+  // req faf269bf — TARGET-side NamedQuery ref (which asset the step writes
+  // INTO). Wikilink → bare UID, same normalization as `templateRef`, mirroring
+  // the production loader's `getObsidianName` unwrap.
+  const rawTargetQuery = fm["exocmd__Grounding_targetQuery"] as
+    | string
+    | undefined;
+  const targetQuery = rawTargetQuery
+    ? normalizeGroundingRef(rawTargetQuery)
+    : undefined;
+
   return {
     id: uid,
     label: (fm["exo__Asset_label"] as string) ?? "",
@@ -160,6 +170,7 @@ export function parseGroundingDefinitionFromFrontmatter(
     templateRef,
     cloneTargetBody,
     targetsCreatedInstance,
+    targetQuery,
     steps,
   };
 }

--- a/packages/core/src/services/CommandResolver.ts
+++ b/packages/core/src/services/CommandResolver.ts
@@ -1786,6 +1786,15 @@ export class CommandResolver {
       subject,
       Namespace.EXOCMD.term("Grounding_targetValueQuery"),
     );
+    // req faf269bf — `targetQuery` TARGET-source: wikilink ref to a
+    // `query__NamedQuery` whose first projection identifies the asset the step
+    // writes INTO (vs `targetValueQuery` above, which computes the VALUE).
+    // Same `getObsidianName` unwrap to the bare UID the executor hands to the
+    // NamedQueryRunner.
+    const targetQuery = await this.getObsidianName(
+      subject,
+      Namespace.EXOCMD.term("Grounding_targetQuery"),
+    );
     // RFC 918a2b65 Phase 1 typed predicates for service_call + property_append.
     // Plain string literals (JSON config / substitution expression); resolution
     // is identical to `targetValueLiteral`. Phase 4 (#3242) removed the legacy
@@ -2036,6 +2045,7 @@ export class CommandResolver {
       targetValueLiteral: targetValueLiteral ?? undefined,
       targetValueSubstitution: targetValueSubstitution ?? undefined,
       targetValueQuery: targetValueQuery ?? undefined,
+      targetQuery: targetQuery ?? undefined,
       serviceCallPayload: serviceCallPayload ?? undefined,
       appendExpression: appendExpression ?? undefined,
       sparqlUpdate: sparqlUpdate ?? undefined,

--- a/packages/core/src/services/GroundingExecutor.ts
+++ b/packages/core/src/services/GroundingExecutor.ts
@@ -22,6 +22,7 @@ import {
   STRING_SCALAR_PROPERTIES,
 } from "../utilities/yamlScalar";
 import type { NamedQueryRunnerPort } from "./NamedQueryRunner";
+import { iriToVaultPath } from "../infrastructure/vault/iri";
 import { DateFormatter } from "../utilities/DateFormatter";
 import { DateTimeParsing } from "../infrastructure/sparql/filters/functions/DateTimeParsing";
 import { LoggingService } from "./LoggingService";
@@ -541,6 +542,22 @@ export class GroundingExecutor {
       return { success: false, error: "property_set requires targetProperty" };
     }
 
+    // req faf269bf Scenario 2 — the two TARGET addressings are mutually
+    // exclusive. `targetsCreatedInstance` says "write into the asset the
+    // previous step created"; `targetQuery` says "write into the asset this
+    // query finds". Both set = an ambiguity the engine must NOT arbitrate
+    // silently, so refuse before doing any work (nothing is written).
+    if (
+      grounding.targetQuery !== undefined &&
+      grounding.targetsCreatedInstance === true
+    ) {
+      return {
+        success: false,
+        error:
+          "property_set: targetQuery and targetsCreatedInstance are mutually exclusive (both address the step's TARGET — pick one).",
+      };
+    }
+
     // RFC 31c1a0be Phase 5a — typed predicates only.
     // Multiple typed predicates simultaneously = fail-loud (RFC §4 cardinality).
     // RFC 78c2b7d0 C4 — `targetValueQuery` joins the mutually-exclusive set as a
@@ -636,15 +653,98 @@ export class GroundingExecutor {
       ? serializeYamlScalar(substitutedValue, true)
       : substitutedValue;
 
-    const content = await this.fileReader.readFile(filePath);
+    // req faf269bf Scenarios 1+3 — resolve WHICH asset this step writes into.
+    // Absent `targetQuery` (every existing grounding) keeps `filePath` exactly
+    // as handed in — click-target, or the created instance when the composite
+    // threaded it — so prior behaviour is byte-identical (Scenario 4).
+    let effectiveFilePath = filePath;
+    if (grounding.targetQuery !== undefined) {
+      const targetPathResult = await this.resolveTargetQuery(
+        grounding.targetQuery,
+        targetIRI,
+      );
+      if (!targetPathResult.success) {
+        return targetPathResult;
+      }
+      effectiveFilePath = targetPathResult.path;
+    }
+
+    const content = await this.fileReader.readFile(effectiveFilePath);
     const updated = this.frontmatterService.updateProperty(
       content,
       grounding.targetProperty,
       valueToWrite,
     );
-    await this.fileWriter.updateFile(filePath, updated);
+    await this.fileWriter.updateFile(effectiveFilePath, updated);
 
     return { success: true };
+  }
+
+  /**
+   * req faf269bf — resolve a `property_set` `targetQuery` to the vault-relative
+   * path of the asset the step must write INTO, via the read-side
+   * {@link NamedQueryRunner}. Auto-injects `$currentAsset` = the click-target
+   * IRI, so a reified link is found FROM one of its ends.
+   *
+   * Fail-loud on every degraded path, and — critically — the click-target is
+   * NEVER a fallback (Scenario 3): a query that matches nothing means the
+   * intended target does not exist, and writing to the click-target instead
+   * would silently put the value on the wrong asset.
+   *
+   * Mirrors {@link resolveTargetValueQuery}'s structure; the difference is what
+   * is extracted — the RAW `iri` (converted to a path) rather than the
+   * reverse-mapped display name, because a basename cannot address a file.
+   */
+  private async resolveTargetQuery(
+    queryUid: string,
+    targetIRI: string,
+  ): Promise<
+    { success: true; path: string } | { success: false; error: string }
+  > {
+    if (!this.namedQueryRunner) {
+      return {
+        success: false,
+        error:
+          "property_set targetQuery requires NamedQueryRunner injection (options.namedQueryRunner). Wire the plugin/CLI before using this target-source.",
+      };
+    }
+    let scalar;
+    try {
+      scalar = await this.namedQueryRunner.runScalar(queryUid, {
+        currentAsset: targetIRI,
+      });
+    } catch (error) {
+      return {
+        success: false,
+        error: `property_set targetQuery: NamedQuery '${queryUid}' failed — ${error instanceof Error ? error.message : String(error)}`,
+      };
+    }
+    if (scalar === null) {
+      return {
+        success: false,
+        error: `property_set targetQuery: NamedQuery '${queryUid}' matched no asset (empty result set) — refusing to fall back to the click-target.`,
+      };
+    }
+    if (scalar.kind !== "iri") {
+      return {
+        success: false,
+        error: `property_set targetQuery: NamedQuery '${queryUid}' returned a literal ('${scalar.value}'), not an asset reference — a target must be an asset.`,
+      };
+    }
+    if (scalar.iri === undefined) {
+      return {
+        success: false,
+        error: `property_set targetQuery: NamedQuery '${queryUid}' returned an asset reference without its source IRI, so its file path cannot be resolved.`,
+      };
+    }
+    const path = iriToVaultPath(scalar.iri);
+    if (path === null) {
+      return {
+        success: false,
+        error: `property_set targetQuery: NamedQuery '${queryUid}' matched '${scalar.iri}', which is not a vault asset IRI (no resolvable file path).`,
+      };
+    }
+    return { success: true, path };
   }
 
   /**

--- a/packages/core/src/services/NamedQueryRunner.ts
+++ b/packages/core/src/services/NamedQueryRunner.ts
@@ -70,6 +70,21 @@ export interface NamedQueryContext {
 export interface NamedQueryScalar {
   readonly value: string;
   readonly kind: "iri" | "literal";
+  /**
+   * req faf269bf — the RAW IRI term, verbatim, present only when
+   * `kind === "iri"`. Purely additive: `value` and `kind` are unchanged, so the
+   * `targetValueQuery` value-source (the only other consumer) is untouched.
+   *
+   * Why it is needed: `value` comes from {@link iriToObsidianName}, which
+   * collapses a vault file IRI to its BASENAME — the folder is discarded. That
+   * is exactly right for building a `"[[<name>]]"` wikilink, but insufficient to
+   * ADDRESS the asset (a target needs a vault-relative path). Keeping the raw
+   * IRI lets `targetQuery` recover that path via `iriToVaultPath` — the exact
+   * inverse of the `vaultPathToIRI` the converter used to mint this subject —
+   * so addressing works for ANY asset, including the two label-named classes
+   * (`pn__DailyNote`, `period__Week`) whose basename is NOT their UID.
+   */
+  readonly iri?: string;
 }
 
 /**
@@ -156,7 +171,9 @@ export class NamedQueryRunner implements NamedQueryRunnerPort {
 
     if (term instanceof IRI) {
       const name = iriToObsidianName(term.value) ?? term.value;
-      return { value: name, kind: "iri" };
+      // `iri` is additive (req faf269bf) — `value`/`kind` keep their exact
+      // prior semantics for the `targetValueQuery` value-source.
+      return { value: name, kind: "iri", iri: term.value };
     }
     if (term instanceof Literal) {
       return { value: term.value, kind: "literal" };

--- a/packages/core/tests/integration/dynamic-commands/targetquery-target-source.test.ts
+++ b/packages/core/tests/integration/dynamic-commands/targetquery-target-source.test.ts
@@ -1,0 +1,355 @@
+/**
+ * Integration: RDF → CommandResolver → NamedQueryRunner → GroundingExecutor
+ * (req faf269bf — `exocmd__Grounding_targetQuery` TARGET-source).
+ *
+ * A command step could address exactly two things: the click-target, and the
+ * asset a previous step created. A REIFIED link is neither — it has to be FOUND
+ * from one of its ends. This suite proves the whole requirement end-to-end
+ * against a realistic triple store + file system: nothing about the grounding is
+ * mocked, `CommandResolver` parses `exocmd__Grounding_targetQuery` for real and
+ * the real `NamedQueryRunner` runs the real SPARQL.
+ *
+ * The fixture mirrors the live consumer (RFC 85fa0652 — agreement audit): a
+ * norm, and a separate reified "last audit" statement pointing at it. The
+ * command is clicked on the NORM, but the date must land on the STATEMENT.
+ *
+ * ⛤ The reified link deliberately lives in a DIFFERENT folder from the norm, so
+ * addressing it requires a real vault-relative PATH. A basename alone (what the
+ * NamedQuery scalar's display `value` carries) could not locate it — which is
+ * exactly why the resolver reads the raw `iri` and converts it via
+ * `iriToVaultPath`.
+ *
+ * REVERT-VERIFY (integration-test-revert-verify rule) — one axis per guarantee,
+ * each reddening only its own scenario:
+ *   - neutralise the `targetQuery` branch in `executePropertySet`
+ *       → Scenario 1 RED, Scenario 4 (back-compat) GREEN;
+ *   - drop the mutual-exclusivity guard
+ *       → Scenario 2 RED;
+ *   - let an empty query fall back to the click-target
+ *       → Scenario 3 RED.
+ *
+ * Regression control for the additive `NamedQueryScalar.iri` field: the sibling
+ * suite `namedquery-value-source.test.ts` (the `targetValueQuery` VALUE-source,
+ * which reads `value`/`kind`) must stay green — it is the contract-change gate.
+ */
+
+import { CommandResolver } from "../../../src/services/CommandResolver";
+import {
+  GroundingExecutor,
+  ServiceRegistry,
+} from "../../../src/services/GroundingExecutor";
+import { NamedQueryRunner } from "../../../src/services/NamedQueryRunner";
+import type { IQueryBodyResolver } from "../../../src/interfaces/IQueryBodyResolver";
+import type {
+  IFileSystemReader,
+  IFileSystemWriter,
+} from "../../../src/interfaces/IFileSystemAdapter";
+import { InMemoryTripleStore } from "../../../src/infrastructure/rdf/InMemoryTripleStore";
+import { Triple } from "../../../src/domain/models/rdf/Triple";
+import { IRI } from "../../../src/domain/models/rdf/IRI";
+import { Literal } from "../../../src/domain/models/rdf/Literal";
+import { Namespace } from "../../../src/domain/models/rdf/Namespace";
+
+// -- in-memory fs (mirrors namedquery-value-source.test.ts) --
+class InMemoryFileSystem implements IFileSystemReader, IFileSystemWriter {
+  private files = new Map<string, string>();
+  constructor(initial?: Record<string, string>) {
+    if (initial)
+      for (const [p, c] of Object.entries(initial)) this.files.set(p, c);
+  }
+  async readFile(path: string): Promise<string> {
+    const c = this.files.get(path);
+    if (c === undefined) throw new Error(`File not found: ${path}`);
+    return c;
+  }
+  async fileExists(path: string): Promise<boolean> {
+    return this.files.has(path);
+  }
+  async getMarkdownFiles(): Promise<string[]> {
+    return Array.from(this.files.keys()).filter((p) => p.endsWith(".md"));
+  }
+  async createFile(path: string, content: string): Promise<string> {
+    this.files.set(path, content);
+    return path;
+  }
+  async updateFile(path: string, content: string): Promise<void> {
+    this.files.set(path, content);
+  }
+  async writeFile(path: string, content: string): Promise<void> {
+    this.files.set(path, content);
+  }
+  async deleteFile(path: string): Promise<void> {
+    this.files.delete(path);
+  }
+  async renameFile(oldPath: string, newPath: string): Promise<void> {
+    const c = this.files.get(oldPath);
+    if (c !== undefined) {
+      this.files.set(newPath, c);
+      this.files.delete(oldPath);
+    }
+  }
+  get(path: string): string | undefined {
+    return this.files.get(path);
+  }
+}
+
+class MapQueryBodyResolver implements IQueryBodyResolver {
+  constructor(private readonly bodies: Record<string, string>) {}
+  async resolveSparql(uid: string): Promise<string | null> {
+    return this.bodies[uid] ?? null;
+  }
+}
+
+// -- ABox: a norm, and the reified "last audit" statement about it -----------
+// The statement lives in a DIFFERENT folder than the norm on purpose (see the
+// header note): only a real path can address it.
+const NORM_IRI = "obsidian://vault/agreements/norm-flowers.md";
+const NORM_PATH = "agreements/norm-flowers.md";
+const LINK_IRI = "obsidian://vault/agreements/audits/last-audit-flowers.md";
+const LINK_PATH = "agreements/audits/last-audit-flowers.md";
+
+// A second norm that has NO audit statement — drives Scenario 3.
+const UNAUDITED_NORM_IRI = "obsidian://vault/agreements/norm-dishes.md";
+const UNAUDITED_NORM_PATH = "agreements/norm-dishes.md";
+
+const AGR = "https://exocortex.my/ontology/agr";
+const LAST_AUDIT_OF = `${AGR}#LastAudit_norm`;
+
+const QUERY_UID = "faf10001-0000-4000-8000-0000000000aa";
+const CMD_UID = "cmd-confirm-audit";
+const GND_QUERY_UID = "gnd-audit-via-targetquery";
+const GND_BOTH_UID = "gnd-audit-both-addressings";
+const GND_PLAIN_UID = "gnd-audit-no-targetquery";
+
+// property_set grounding-type UID (GroundingTypeUIDs.ts)
+const PROPERTY_SET_TYPE = "[[cf3bb923-f1f1-40be-b728-782844402426]]";
+
+const AUDIT_DATE = "2026-08-03";
+const TARGET_PROPERTY = "agr__LastAudit_on";
+
+/** Find the reified statement whose subject-end is the clicked norm. */
+const FIND_LAST_AUDIT_BODY = `SELECT ?link WHERE { ?link <${LAST_AUDIT_OF}> $currentAsset }`;
+
+/** Seed one property_set grounding; `extra` adds the variant-specific triples. */
+function groundingTriples(uid: string, extra: Triple[] = []): Triple[] {
+  const gnd = new IRI(`obsidian://vault/${uid}.md`);
+  return [
+    new Triple(
+      gnd,
+      Namespace.RDF.term("type"),
+      Namespace.EXOCMD.term("Grounding"),
+    ),
+    new Triple(gnd, Namespace.EXO.term("Asset_uid"), new Literal(uid)),
+    new Triple(
+      gnd,
+      Namespace.EXO.term("Asset_label"),
+      new Literal("Record last audit date"),
+    ),
+    new Triple(
+      gnd,
+      Namespace.EXOCMD.term("Grounding_type"),
+      new Literal(PROPERTY_SET_TYPE),
+    ),
+    new Triple(
+      gnd,
+      Namespace.EXOCMD.term("Grounding_targetProperty"),
+      new Literal(TARGET_PROPERTY),
+    ),
+    new Triple(
+      gnd,
+      Namespace.EXOCMD.term("Grounding_targetValueLiteral"),
+      new Literal(AUDIT_DATE),
+    ),
+    ...extra,
+  ];
+}
+
+async function seedCommandGraph(store: InMemoryTripleStore): Promise<void> {
+  const queryRef = new IRI(`obsidian://vault/${QUERY_UID}.md`);
+  const cmd = new IRI(`obsidian://vault/${CMD_UID}.md`);
+
+  await store.addAll([
+    // (a) the requirement's grounding: target addressed by NamedQuery
+    ...groundingTriples(GND_QUERY_UID, [
+      new Triple(
+        new IRI(`obsidian://vault/${GND_QUERY_UID}.md`),
+        Namespace.EXOCMD.term("Grounding_targetQuery"),
+        queryRef,
+      ),
+    ]),
+    // (b) both addressings at once — Scenario 2
+    ...groundingTriples(GND_BOTH_UID, [
+      new Triple(
+        new IRI(`obsidian://vault/${GND_BOTH_UID}.md`),
+        Namespace.EXOCMD.term("Grounding_targetQuery"),
+        queryRef,
+      ),
+      new Triple(
+        new IRI(`obsidian://vault/${GND_BOTH_UID}.md`),
+        Namespace.EXOCMD.term("Grounding_targetsCreatedInstance"),
+        new Literal("true"),
+      ),
+    ]),
+    // (c) no targetQuery at all — Scenario 4 (every existing grounding)
+    ...groundingTriples(GND_PLAIN_UID),
+    // Command → the requirement's grounding
+    new Triple(
+      cmd,
+      Namespace.RDF.term("type"),
+      Namespace.EXOCMD.term("Command"),
+    ),
+    new Triple(cmd, Namespace.EXO.term("Asset_uid"), new Literal(CMD_UID)),
+    new Triple(
+      cmd,
+      Namespace.EXO.term("Asset_label"),
+      new Literal("Confirm audit"),
+    ),
+    new Triple(
+      cmd,
+      Namespace.EXOCMD.term("Command_grounding"),
+      new IRI(`obsidian://vault/${GND_QUERY_UID}.md`),
+    ),
+  ]);
+}
+
+/** The reified statement points at the norm; the unaudited norm has none. */
+async function seedAuditLink(store: InMemoryTripleStore): Promise<void> {
+  store.add(
+    new Triple(new IRI(LINK_IRI), new IRI(LAST_AUDIT_OF), new IRI(NORM_IRI)),
+  );
+}
+
+function seedFiles(): InMemoryFileSystem {
+  return new InMemoryFileSystem({
+    [NORM_PATH]: [
+      "---",
+      "exo__Asset_uid: norm-flowers",
+      'exo__Asset_label: "Цветы раз в месяц"',
+      "---",
+      "# Norm",
+    ].join("\n"),
+    [LINK_PATH]: [
+      "---",
+      "exo__Asset_uid: last-audit-flowers",
+      `${TARGET_PROPERTY}: 2026-06-01`,
+      "---",
+      "# Last audit",
+    ].join("\n"),
+    [UNAUDITED_NORM_PATH]: [
+      "---",
+      "exo__Asset_uid: norm-dishes",
+      'exo__Asset_label: "Посуда"',
+      "---",
+      "# Norm",
+    ].join("\n"),
+  });
+}
+
+describe("req faf269bf — Grounding_targetQuery target-source (integration)", () => {
+  let store: InMemoryTripleStore;
+  let resolver: CommandResolver;
+  let runner: NamedQueryRunner;
+  let fs: InMemoryFileSystem;
+  let executor: GroundingExecutor;
+
+  beforeEach(async () => {
+    store = new InMemoryTripleStore();
+    await seedCommandGraph(store);
+    await seedAuditLink(store);
+    resolver = new CommandResolver(store);
+    runner = new NamedQueryRunner(
+      new MapQueryBodyResolver({ [QUERY_UID]: FIND_LAST_AUDIT_BODY }),
+      store,
+    );
+    fs = seedFiles();
+    executor = new GroundingExecutor(fs, fs, new ServiceRegistry(), undefined, {
+      namedQueryRunner: runner,
+    });
+  });
+
+  it("@req:faf269bf-d4ff-4e84-b0ea-c41bf46da035 resolver parses Grounding_targetQuery to the bare query UID", async () => {
+    const grounding = await resolver.loadGroundingByUid(GND_QUERY_UID);
+    expect(grounding).not.toBeNull();
+    expect(grounding?.targetQuery).toBe(QUERY_UID);
+    // The VALUE-source stays untouched — the two are orthogonal.
+    expect(grounding?.targetValueQuery).toBeUndefined();
+  });
+
+  // -- Scenario 1 -----------------------------------------------------------
+  it("@req:faf269bf-d4ff-4e84-b0ea-c41bf46da035 Scenario 1: writes into the asset the query found, leaving the click-target untouched", async () => {
+    const command = await resolver.loadCommand(CMD_UID);
+    expect(command).not.toBeNull();
+
+    const normBefore = fs.get(NORM_PATH)!;
+
+    const result = await executor.execute(
+      command!.grounding,
+      NORM_IRI,
+      NORM_PATH,
+    );
+    expect(result.success).toBe(true);
+
+    // The date landed on the reified statement — addressed purely by the query,
+    // and reachable only via its full path (it sits in a nested folder).
+    const link = fs.get(LINK_PATH) ?? "";
+    expect(link).toContain(`${TARGET_PROPERTY}: ${AUDIT_DATE}`);
+    expect(link).not.toContain("2026-06-01");
+
+    // …and the clicked norm is byte-for-byte untouched.
+    expect(fs.get(NORM_PATH)).toBe(normBefore);
+  });
+
+  // -- Scenario 2 -----------------------------------------------------------
+  it("@req:faf269bf-d4ff-4e84-b0ea-c41bf46da035 Scenario 2: refuses when targetQuery and targetsCreatedInstance are both set, writing nothing", async () => {
+    const grounding = await resolver.loadGroundingByUid(GND_BOTH_UID);
+    expect(grounding?.targetQuery).toBe(QUERY_UID);
+    expect(grounding?.targetsCreatedInstance).toBe(true);
+
+    const normBefore = fs.get(NORM_PATH)!;
+    const linkBefore = fs.get(LINK_PATH)!;
+
+    const result = await executor.execute(grounding!, NORM_IRI, NORM_PATH);
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("mutually exclusive");
+    // Nothing was written — neither addressing was silently chosen.
+    expect(fs.get(NORM_PATH)).toBe(normBefore);
+    expect(fs.get(LINK_PATH)).toBe(linkBefore);
+  });
+
+  // -- Scenario 3 -----------------------------------------------------------
+  it("@req:faf269bf-d4ff-4e84-b0ea-c41bf46da035 Scenario 3: fails loudly when the query matches nothing and never falls back to the click-target", async () => {
+    const command = await resolver.loadCommand(CMD_UID);
+    const unauditedBefore = fs.get(UNAUDITED_NORM_PATH)!;
+
+    // This norm has no reified audit statement → the query returns no rows.
+    const result = await executor.execute(
+      command!.grounding,
+      UNAUDITED_NORM_IRI,
+      UNAUDITED_NORM_PATH,
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("matched no asset");
+    // The click-target must NOT have absorbed the write.
+    expect(fs.get(UNAUDITED_NORM_PATH)).toBe(unauditedBefore);
+    expect(fs.get(UNAUDITED_NORM_PATH)).not.toContain(AUDIT_DATE);
+  });
+
+  // -- Scenario 4 (back-compat control) -------------------------------------
+  it("@req:faf269bf-d4ff-4e84-b0ea-c41bf46da035 Scenario 4: a grounding without targetQuery still writes into the click-target", async () => {
+    const grounding = await resolver.loadGroundingByUid(GND_PLAIN_UID);
+    expect(grounding?.targetQuery).toBeUndefined();
+
+    const linkBefore = fs.get(LINK_PATH)!;
+
+    const result = await executor.execute(grounding!, NORM_IRI, NORM_PATH);
+
+    expect(result.success).toBe(true);
+    expect(fs.get(NORM_PATH) ?? "").toContain(
+      `${TARGET_PROPERTY}: ${AUDIT_DATE}`,
+    );
+    // The query-found asset is irrelevant here — untouched.
+    expect(fs.get(LINK_PATH)).toBe(linkBefore);
+  });
+});

--- a/packages/core/tests/unit/services/NamedQueryRunner.test.ts
+++ b/packages/core/tests/unit/services/NamedQueryRunner.test.ts
@@ -62,7 +62,14 @@ describe("NamedQueryRunner.runScalar", () => {
 
     const scalar = await runner.runScalar("q1", { currentAsset: ASSET });
 
-    expect(scalar).toEqual({ value: "9f1c0b2a-archive", kind: "iri" });
+    // req faf269bf — `value`/`kind` are unchanged (the `targetValueQuery`
+    // value-source reads only those); `iri` is the additive raw term the
+    // `targetQuery` TARGET-source needs to recover a vault path from.
+    expect(scalar).toEqual({
+      value: "9f1c0b2a-archive",
+      kind: "iri",
+      iri: ARCHIVE_ONTO_FILE,
+    });
   });
 
   it("returns literal scalar with its lexical value", async () => {
@@ -110,7 +117,7 @@ describe("NamedQueryRunner.runScalar", () => {
       currentClass: CLASS,
     });
 
-    expect(scalar).toEqual({ value: "asset-1", kind: "iri" });
+    expect(scalar).toEqual({ value: "asset-1", kind: "iri", iri: ASSET });
   });
 
   it("substitutes explicit IRI params (controlled <iri> form)", async () => {
@@ -124,7 +131,11 @@ describe("NamedQueryRunner.runScalar", () => {
       params: { srcOnto: { value: SRC_ONTO, kind: "iri" } },
     });
 
-    expect(scalar).toEqual({ value: "9f1c0b2a-archive", kind: "iri" });
+    expect(scalar).toEqual({
+      value: "9f1c0b2a-archive",
+      kind: "iri",
+      iri: ARCHIVE_ONTO_FILE,
+    });
   });
 
   it("returns null when the SELECT produces no rows", async () => {


### PR DESCRIPTION
## Что и зачем

Шаг гомоиконичной команды умел адресовать ровно две вещи: **click-target** и **ассет, созданный предыдущим шагом**. Реифицированная связь — ни то, ни другое: её надо *найти* по одному из концов. Поэтому состояние про отношение приходилось денормализовать на один из его концов.

`exocmd__Grounding_targetQuery` закрывает это: указанный `query__NamedQuery` выполняется read-only с `$currentAsset` = click-target, и шаг пишет **в найденный ассет**.

Req: `faf269bf-d4ff-4e84-b0ea-c41bf46da035` (Approved)

## Дизайн-развилка и её цена (зафиксировано осознанно)

Движок уже умел выполнять NamedQuery ради **значения** (`targetValueQuery`). Не хватало ровно одного — применить это к **цели**. Но `runScalar` отдаёт `value` = reverse-mapped **basename**, а basename не адресует файл.

Рассматривались два пути:

| | взято: аддитивное `iri?` в `NamedQueryScalar` | отвергнуто: `refToPath`-сиблинг |
|---|---|---|
| Трогает контракт работающего `targetValueQuery` | да, **аддитивно** (опциональное readonly-поле) | нет |
| Новая проводка | **нет** | тип + 2 фабрики + 2 места (CLI, плагин) |
| Работает для label-named классов (`pn__DailyNote`, `period__Week`) | **да** | **нет** — резолвит по `exo__Asset_uid`, а у них basename ≠ UID |
| Можно развести наполовину | **нет** — оба пути уже инжектят реальный `NamedQueryRunner` | да — забытая проводка = фича инертна на поверхности |

Blast-radius измерен, а не оценён: у `NamedQueryScalar` **ровно один** production-потребитель (`resolveTargetValueQuery`, читает `value`/`kind`); поле опциональное ⇒ все реализаторы и фейки типизируются, рантайм-дельта = один добавленный ключ.

**Цена выбора:** контракт `NamedQueryScalar` расширен. Удерживается явным regression-контролем — сиблинг-сьют `namedquery-value-source.test.ts` (VALUE-source) обязан оставаться зелёным; он зелёный.

## Изменения

- `NamedQueryScalar.iri?` — сырой IRI (только при `kind === "iri"`). Путь восстанавливается `iriToVaultPath` — точным инверсом `vaultPathToIRI`, которым конвертер и чеканил subject.
- Чтение в `CommandResolver.loadGroundingDefinition` (**production-загрузчик**: через него идут и кнопка плагина, и CLI) + паритет в `GroundingFrontmatterParser`.
- Взаимная исключительность с `targetsCreatedInstance` — отказ, а не молчаливый выбор одной из двух адресаций.
- Пустой результат запроса — **fail-loud**; click-target намеренно не запасная цель.
- Поля нет (все существующие основания) → поведение байт-в-байт прежнее.

## TBox

`exo__Property` `exocmd__Grounding_targetQuery` (`b9e4e96a-2f3a-4527-91c0-1555529259dd`) задеклариро­ван **сразу**, зеркалит сиблинг `targetValueQuery`; запушен в `exoas-exocmd@a55e443`, remote проверен по содержимому. SHACL байт-в-байт с baseline (0 violations / 406 warnings).

⚠ Попутно подтверждено: `exocmd__Grounding_targetsCreatedInstance` и `cloneTargetBody` **не задекларированы** как `exo__Property` (объявлено 7 `Grounding_target*`, этих нет) — поэтому `owl__propertyDisjointWith` на пару поставить нельзя (dangling); взаимная исключительность зафиксирована прозой и назван gap.

## Проверка

**Revert-verified** (`@req:faf269bf-d4ff-4e84-b0ea-c41bf46da035`) — по оси на гарантию, каждая роняет **только свой** сценарий:

| Слом | RED | остальные |
|---|---|---|
| нейтрализовать пере-адресацию | Сценарий 1 | Сценарий 4 (обратная совместимость) GREEN |
| убрать проверку взаимной исключительности | Сценарий 2 | GREEN |
| разрешить откат на click-target | Сценарий 3 | GREEN |

Реифицированная связь в фикстуре лежит **в другой папке**, чем норма, — так что адресация требует настоящего пути; basename её бы не нашёл.

Полный core-сьют: **357/357 сьютов, 8450 тестов, 0 падений**. Гейты `lint`-джоба зелёные (ratchet 55/55 · 21/21 · 19/19 · 0/0, shard-assignments, coverage-monotonic, eslint).
