### PR TITLE
fix(cli): set-property decides scalar quoting per property (req 21ceea14)

### DIFF
--- a/packages/cli/src/commands/set-property.ts
+++ b/packages/cli/src/commands/set-property.ts
@@ -10,6 +10,7 @@ import { existsSync, readFileSync, writeFileSync } from "fs";
 import {
   FrontmatterService,
   serializeYamlScalar,
+  STRING_SCALAR_PROPERTIES,
 } from "@kitelev/exocortex-core";
 import { NodeFsAdapter } from "../adapters/NodeFsAdapter.js";
 import { WikilinkValidator } from "../services/WikilinkValidator.js";
@@ -127,16 +128,35 @@ function resolvePropertyAndValue(options: SetPropertyOptions): {
 /**
  * Pre-format a value for `FrontmatterService.updateProperty` (which writes
  * verbatim — callers pre-format, mirroring `GroundingExecutor.executePropertySet`
- * and the create path). `serializeYamlScalar(v, true)` keeps booleans/numbers
- * bare, keeps ISO datetimes bare (native date type), quotes wikilinks (`[[uid]]`
- * → `"[[uid]]"`) and any YAML-unsafe / ambiguous scalar string so a JSON string
- * round-trips as a string.
+ * and the create path). `serializeYamlScalar` keeps booleans/numbers bare, keeps
+ * ISO datetimes bare (native date type), and quotes wikilinks (`[[uid]]` →
+ * `"[[uid]]"`) plus any YAML-unsafe value.
+ *
+ * The second argument (`quoteAmbiguousScalars`) is decided PER PROPERTY, exactly
+ * as the create path does it (`MetadataHelpers` → `STRING_SCALAR_PROPERTIES.has(key)`).
+ * Passing a constant `true` — as this function used to — applied the
+ * string-semantic rule to EVERY property, so a scalar-shaped `--value` string
+ * (`2026-08-09`, `3`, `true`) was quoted and parsed back as a STRING on
+ * properties that should keep their native YAML type. The same property written
+ * by `create` stayed bare, so one property carried two types across the vault
+ * depending on which command touched it last (ems__Bug 34b0a52c).
+ *
+ * ⛤ The lookup uses the CANONICAL yaml key (#3944), not the raw `--property`
+ * value: `exo__Asset_aliases` is stored under the bare `aliases:` key, and
+ * `aliases` is the member of `STRING_SCALAR_PROPERTIES` — keying on the raw name
+ * would drop the quoting guarantee for that spelling. `exo__Asset_label` is not
+ * in `UNPREFIXED_ASSET_FIELDS`, so its canonical key is itself and it matches
+ * directly.
+ *
+ * The `--input` JSON path is unaffected: a JSON number/boolean is not a string,
+ * so `serializeYamlScalar` emits it bare regardless of this flag.
  */
-function serializeForWrite(value: unknown): unknown {
+function serializeForWrite(value: unknown, yamlKey: string): unknown {
+  const quoteAmbiguous = STRING_SCALAR_PROPERTIES.has(yamlKey);
   if (Array.isArray(value)) {
-    return value.map((v) => serializeYamlScalar(v, true));
+    return value.map((v) => serializeYamlScalar(v, quoteAmbiguous));
   }
-  return serializeYamlScalar(value, true);
+  return serializeYamlScalar(value, quoteAmbiguous);
 }
 
 /**
@@ -290,10 +310,11 @@ export function setPropertyCommand(): Command {
         // Write under the CANONICAL YAML key (issue #3944): `exo__Asset_aliases`
         // maps to the bare `aliases:` key so we update it in place rather than
         // adding a duplicate literal `exo__Asset_aliases:` alongside it.
+        const yamlKey = canonicalYamlKey(property);
         let updated = fm.updateProperty(
           original,
-          canonicalYamlKey(property),
-          serializeForWrite(value),
+          yamlKey,
+          serializeForWrite(value, yamlKey),
         );
         updated = fm.updateProperty(updated, UPDATED_AT_KEY, updatedAt);
 

--- a/packages/cli/src/commands/set-property.ts
+++ b/packages/cli/src/commands/set-property.ts
@@ -144,12 +144,17 @@ function resolvePropertyAndValue(options: SetPropertyOptions): {
  * ⛤ The lookup uses the CANONICAL yaml key (#3944), not the raw `--property`
  * value: `exo__Asset_aliases` is stored under the bare `aliases:` key, and
  * `aliases` is the member of `STRING_SCALAR_PROPERTIES` — keying on the raw name
- * would drop the quoting guarantee for that spelling. `exo__Asset_label` is not
- * in `UNPREFIXED_ASSET_FIELDS`, so its canonical key is itself and it matches
- * directly.
+ * would drop the quoting guarantee for that spelling. `exo__Asset_label` is the
+ * other member of the set, but it is guarded to `apply set-label` and never
+ * reaches this function — `aliases` is the only reachable member here.
  *
- * The `--input` JSON path is unaffected: a JSON number/boolean is not a string,
- * so `serializeYamlScalar` emits it bare regardless of this flag.
+ * The `--input` JSON path is unaffected for a NUMBER or BOOLEAN value: it is not
+ * a string, so `serializeYamlScalar` emits it bare regardless of this flag. A
+ * JSON STRING shares this serializer with `--value` and therefore behaves
+ * identically to it — by design, since the rule is per-property, not
+ * per-input-form. A caller that needs a scalar-shaped value to survive as a
+ * string on a non-string-semantic property pre-wraps it (`"value": "\"007\""`);
+ * `serializeYamlScalar` passes an already-double-quoted scalar through verbatim.
  */
 function serializeForWrite(value: unknown, yamlKey: string): unknown {
   const quoteAmbiguous = STRING_SCALAR_PROPERTIES.has(yamlKey);

--- a/packages/cli/tests/integration/set-property.scalar-typing.integration.test.ts
+++ b/packages/cli/tests/integration/set-property.scalar-typing.integration.test.ts
@@ -207,6 +207,26 @@ describe("ems__Bug 34b0a52c: set-property decides scalar quoting per property", 
     expect(typeof out.parsed.exo__DisplayNamePart_order).toBe("number");
   });
 
+  // ── the --input JSON *string* path DOES change, and that is intended ──
+  //
+  // A JSON string is a string, so it shares the serializer with `--value` and
+  // takes the same per-property branch. This is the third revert axis: unlike
+  // the two assertions above (a free-text value is not ambiguous, a JSON number
+  // is not a string — neither consults the flag in either state), this one is
+  // flag-sensitive and reds when the constant `true` is restored.
+  it("applies the same per-property rule to an --input JSON STRING value @req:21ceea14-50dd-4cf8-bd3b-5a50b7c97105", async () => {
+    const out = await setProp(episodePath, [
+      "--input",
+      '{"property":"exo__DisplayNamePart_order","value":"007"}',
+    ]);
+
+    expect(out.exit).not.toContain(1);
+    expect(out.content).toContain("exo__DisplayNamePart_order: 007");
+    expect(out.content).not.toContain('exo__DisplayNamePart_order: "007"');
+    expect(typeof out.parsed.exo__DisplayNamePart_order).toBe("number");
+    expect(out.parsed.exo__DisplayNamePart_order).toBe(7);
+  });
+
   // ── the user-facing point: create and set-property agree ──
 
   it("emits the same YAML form as `create` for the same property and value @req:21ceea14-50dd-4cf8-bd3b-5a50b7c97105", async () => {

--- a/packages/cli/tests/integration/set-property.scalar-typing.integration.test.ts
+++ b/packages/cli/tests/integration/set-property.scalar-typing.integration.test.ts
@@ -1,0 +1,281 @@
+/**
+ * ems__Bug 34b0a52c — `set-property` decided YAML quoting with a CONSTANT
+ * string-semantic flag (`serializeYamlScalar(value, true)`), so a scalar-shaped
+ * `--property/--value` string (`2026-08-09`, `3`, `true`) was quoted on EVERY
+ * property and parsed back as a STRING. The same property written by `create`
+ * (`MetadataHelpers` → `STRING_SCALAR_PROPERTIES.has(key)`) stayed bare, so one
+ * property carried two types across the vault depending on which command touched
+ * it last. The fix passes the flag PER PROPERTY, converging on the create rule.
+ *
+ * Drives the REAL `setPropertyCommand()` (and the REAL `createCommand()` for the
+ * parity scenario) against a temp fixture vault, reads the written file back from
+ * disk, and asserts the PARSED TYPE via js-yaml — the parser Obsidian's
+ * metadataCache uses, and the same one `yamlScalar.ts` replicates its resolvers
+ * from. Asserting the parsed type rather than the emitted characters is
+ * deliberate: `2026-08-09` and `"2026-08-09"` differ by two characters and by
+ * everything that matters, which is exactly how this survived until now
+ * (test-fixture-realism).
+ *
+ * Revert-verify (~/dotfiles/.claude/rules/integration-test-revert-verify.md):
+ * restore the constant in `serializeForWrite`
+ *   (`STRING_SCALAR_PROPERTIES.has(yamlKey)` → `true`)
+ * and the date + integer + parity assertions go RED, while the `aliases`,
+ * free-text and `--input` assertions stay GREEN. Those three are the negative
+ * controls: they prove the change is scoped to the ambiguous-scalar branch of a
+ * non-string-semantic property and did NOT simply switch quoting off (which
+ * would regress the #3750 MEDIUM-3 guarantee that a scalar-looking alias
+ * survives as a string).
+ */
+import { jest, describe, it, expect, beforeEach, afterEach } from "@jest/globals";
+import * as fs from "fs";
+import * as path from "path";
+import * as os from "os";
+import * as yaml from "js-yaml";
+
+const { setPropertyCommand } = await import("../../src/commands/set-property.js");
+const { createCommand } = await import("../../src/commands/create.js");
+
+const DIR = "assetspaces/kitelev/exoas-my/episodes";
+const ANCHOR_UID = "e1e1e1e1-0000-4000-8000-000000000001";
+const EPISODE_UID = "e2e2e2e2-0000-4000-8000-000000000002";
+const CLASS_UID = "e3e3e3e3-0000-4000-8000-000000000003";
+const STALE_UPDATED_AT = "2020-01-01T00:00:00";
+
+const FROZEN_CLOCK = "2026-07-12T10:00:00Z";
+
+/** A date-only value: the shape js-yaml resolves to a Date when emitted bare. */
+const DATE_VALUE = "2026-08-09";
+/** An integer value: bare → number, quoted → string (breaks numeric ordering). */
+const INT_VALUE = "3";
+
+function md(frontmatter: Record<string, string>): string {
+  const lines = ["---"];
+  for (const [k, v] of Object.entries(frontmatter)) lines.push(`${k}: ${v}`);
+  lines.push("---", "body", "");
+  return lines.join("\n");
+}
+
+/** Parse the written file the way the production reader (metadataCache) does. */
+function parseFrontmatter(content: string): Record<string, unknown> {
+  const m = /^---\n([\s\S]*?)\n---/.exec(content);
+  if (!m) throw new Error("no frontmatter in written file");
+  return (yaml.load(m[1]) ?? {}) as Record<string, unknown>;
+}
+
+describe("ems__Bug 34b0a52c: set-property decides scalar quoting per property", () => {
+  let vault: string;
+  let exitSpy: ReturnType<typeof jest.spyOn>;
+  let stdoutSpy: ReturnType<typeof jest.spyOn>;
+  let stderrSpy: ReturnType<typeof jest.spyOn>;
+  let logSpy: ReturnType<typeof jest.spyOn>;
+  let errorSpy: ReturnType<typeof jest.spyOn>;
+  let exitCodes: number[];
+
+  const episodePath = `${DIR}/${EPISODE_UID}.md`;
+
+  beforeEach(() => {
+    vault = fs.mkdtempSync(path.join(os.tmpdir(), "cli-34b0a52c-"));
+    const dir = path.join(vault, DIR);
+    fs.mkdirSync(dir, { recursive: true });
+
+    fs.writeFileSync(
+      path.join(dir, `${ANCHOR_UID}.md`),
+      md({ exo__Asset_uid: ANCHOR_UID, exo__Asset_label: "life__Episodes" }),
+    );
+    fs.writeFileSync(
+      path.join(dir, `${EPISODE_UID}.md`),
+      md({
+        exo__Asset_uid: EPISODE_UID,
+        exo__Asset_isDefinedBy: `"[[${ANCHOR_UID}]]"`,
+        exo__Asset_label: '"Summer break"',
+        exo__Asset_updatedAt: STALE_UPDATED_AT,
+      }),
+    );
+
+    exitCodes = [];
+    exitSpy = jest.spyOn(process, "exit").mockImplementation(((code?: number) => {
+      exitCodes.push(code ?? 0);
+      return undefined as never;
+    }) as never);
+    stdoutSpy = jest
+      .spyOn(process.stdout, "write")
+      .mockImplementation((() => true) as never);
+    stderrSpy = jest
+      .spyOn(process.stderr, "write")
+      .mockImplementation((() => true) as never);
+    logSpy = jest.spyOn(console, "log").mockImplementation(() => {});
+    errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    exitSpy.mockRestore();
+    stdoutSpy.mockRestore();
+    stderrSpy.mockRestore();
+    logSpy.mockRestore();
+    errorSpy.mockRestore();
+    fs.rmSync(vault, { recursive: true, force: true });
+  });
+
+  async function setProp(
+    relPath: string,
+    extraArgs: string[],
+  ): Promise<{ exit: number[]; content: string; parsed: Record<string, unknown> }> {
+    const cmd = setPropertyCommand();
+    await cmd.parseAsync(
+      [relPath, "--vault", vault, "--frozen-clock", FROZEN_CLOCK, ...extraArgs],
+      { from: "user" },
+    );
+    const content = fs.readFileSync(path.join(vault, relPath), "utf-8");
+    return { exit: [...exitCodes], content, parsed: parseFrontmatter(content) };
+  }
+
+  // ── the defect: a scalar-shaped --value on a NON-string-semantic property ──
+
+  it("writes a date-shaped --value BARE so it parses as a Date @req:21ceea14-50dd-4cf8-bd3b-5a50b7c97105", async () => {
+    const out = await setProp(episodePath, [
+      "--property",
+      "life__Episode_end",
+      "--value",
+      DATE_VALUE,
+    ]);
+
+    expect(out.exit).not.toContain(1);
+    expect(out.content).toContain(`life__Episode_end: ${DATE_VALUE}`);
+    expect(out.content).not.toContain(`life__Episode_end: "${DATE_VALUE}"`);
+    // The assertion that matters: the production reader yields a Date, not a string.
+    expect(out.parsed.life__Episode_end).toBeInstanceOf(Date);
+  });
+
+  it("writes an integer-shaped --value BARE so it parses as a number (ordering compares numerically) @req:21ceea14-50dd-4cf8-bd3b-5a50b7c97105", async () => {
+    const out = await setProp(episodePath, [
+      "--property",
+      "exo__DisplayNamePart_order",
+      "--value",
+      INT_VALUE,
+    ]);
+
+    expect(out.exit).not.toContain(1);
+    expect(out.content).toContain(`exo__DisplayNamePart_order: ${INT_VALUE}`);
+    expect(typeof out.parsed.exo__DisplayNamePart_order).toBe("number");
+    expect(out.parsed.exo__DisplayNamePart_order).toBe(3);
+  });
+
+  // ── negative control #1: the string-semantic property KEEPS its quoting ──
+
+  it("still QUOTES the same shaped value on aliases, so a scalar-looking alias survives as a string (#3750 MEDIUM-3) @req:21ceea14-50dd-4cf8-bd3b-5a50b7c97105", async () => {
+    // `exo__Asset_aliases` canonicalises to the bare `aliases:` key (#3944) — the
+    // member of STRING_SCALAR_PROPERTIES — so the lookup must use the CANONICAL
+    // key, not the raw --property spelling.
+    const out = await setProp(episodePath, [
+      "--property",
+      "exo__Asset_aliases",
+      "--value",
+      "2026-01-15",
+    ]);
+
+    expect(out.exit).not.toContain(1);
+    expect(out.content).toContain('aliases: "2026-01-15"');
+    expect(typeof out.parsed.aliases).toBe("string");
+    expect(out.parsed.aliases).toBe("2026-01-15");
+  });
+
+  // ── negative control #2: a non-scalar-shaped value is untouched ──
+
+  it("leaves a free-text --value exactly as before (only the ambiguous-scalar branch moved) @req:21ceea14-50dd-4cf8-bd3b-5a50b7c97105", async () => {
+    const out = await setProp(episodePath, [
+      "--property",
+      "life__Episode_note",
+      "--value",
+      "some free text",
+    ]);
+
+    expect(out.exit).not.toContain(1);
+    expect(out.content).toContain("life__Episode_note: some free text");
+    expect(out.parsed.life__Episode_note).toBe("some free text");
+  });
+
+  // ── negative control #3: the --input JSON path is byte-identical ──
+
+  it("leaves the --input JSON-typed path unchanged (a JSON number was already bare) @req:21ceea14-50dd-4cf8-bd3b-5a50b7c97105", async () => {
+    const out = await setProp(episodePath, [
+      "--input",
+      '{"property":"exo__DisplayNamePart_order","value":3}',
+    ]);
+
+    expect(out.exit).not.toContain(1);
+    expect(out.content).toContain("exo__DisplayNamePart_order: 3");
+    expect(typeof out.parsed.exo__DisplayNamePart_order).toBe("number");
+  });
+
+  // ── the user-facing point: create and set-property agree ──
+
+  it("emits the same YAML form as `create` for the same property and value @req:21ceea14-50dd-4cf8-bd3b-5a50b7c97105", async () => {
+    // `create` writes the property through MetadataHelpers, which already decides
+    // the flag per property; `set-property` must land on the identical form.
+    const created = createCommand();
+    await created.parseAsync(
+      [
+        "--vault",
+        vault,
+        "--class",
+        CLASS_UID,
+        "--label",
+        "Parity probe",
+        "--property",
+        `life__Episode_end=${DATE_VALUE}`,
+        "--format",
+        "json",
+      ],
+      { from: "user" },
+    );
+
+    const createdFiles = fs
+      .readdirSync(path.join(vault, DIR))
+      .filter((f) => ![ANCHOR_UID, EPISODE_UID].some((u) => f.startsWith(u)));
+    const createdPath = createdFiles.length
+      ? path.join(vault, DIR, createdFiles[0])
+      : findCreated(vault);
+    const createdLine = lineFor(
+      fs.readFileSync(createdPath, "utf-8"),
+      "life__Episode_end",
+    );
+
+    const out = await setProp(episodePath, [
+      "--property",
+      "life__Episode_end",
+      "--value",
+      DATE_VALUE,
+    ]);
+    const setLine = lineFor(out.content, "life__Episode_end");
+
+    expect(setLine).toBe(createdLine);
+    expect(setLine).toBe(`life__Episode_end: ${DATE_VALUE}`);
+  });
+});
+
+/** Locate the asset `create` wrote when it did not land in the episodes dir. */
+function findCreated(vault: string): string {
+  const stack = [vault];
+  while (stack.length) {
+    const dir = stack.pop() as string;
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) stack.push(full);
+      else if (
+        entry.name.endsWith(".md") &&
+        fs.readFileSync(full, "utf-8").includes("life__Episode_end")
+      ) {
+        return full;
+      }
+    }
+  }
+  throw new Error("create did not write an asset carrying life__Episode_end");
+}
+
+function lineFor(content: string, key: string): string {
+  const line = content
+    .split("\n")
+    .find((l) => l.startsWith(`${key}:`));
+  if (!line) throw new Error(`no ${key} line in written file`);
+  return line;
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -220,7 +220,10 @@ export { FrontmatterService } from "./utilities/FrontmatterService";
 // Exposed so CLI-side mutation primitives (e.g. `set-property`, issue #3795) can
 // pre-format values the same way the create / property_set paths do before
 // handing them to FrontmatterService.updateProperty (which writes verbatim).
-export { serializeYamlScalar } from "./utilities/yamlScalar";
+export {
+  serializeYamlScalar,
+  STRING_SCALAR_PROPERTIES,
+} from "./utilities/yamlScalar";
 // Tolerant YAML frontmatter parse (#3800) — bare yaml.load throws on a
 // duplicated mapping key → the whole asset collapses to {} at every read
 // (invisible & unrepairable). Retries `{ json: true }` (last-wins) on throw.


### PR DESCRIPTION
Closes the `set-property` half of a serialization divergence recorded as `ems__Bug` **34b0a52c** in vault-exodev.

## The defect

`serializeForWrite` passed `serializeYamlScalar(value, true)` **unconditionally**, so the string-semantic quoting rule was applied to every property. A scalar-shaped `--property/--value` string was therefore quoted and parsed back as a **string**:

| command | written | parses as |
|---|---|---|
| `create --property life__Episode_start=2026-08-09` | `life__Episode_start: 2026-08-09` | `Date` |
| `set-property --property life__Episode_start --value 2026-08-09` | `life__Episode_start: "2026-08-09"` | `string` |

Both measured with `--dry-run` on a real vault. Wider than dates — an integer property (`exo__DisplayNamePart_order`) came out as `"3"`, which sorts lexicographically (`"10" < "3"`). Datetimes were unaffected (`YAML_DATE` matches the date-only shape only), which is why `exo__Asset_updatedAt` always looked correct.

Consequence: one property carries two types across the vault depending on which command touched it last, so every consumer must accept both or silently drop half the data. That is not hypothetical — a `typeof raw !== "string"` guard shipped to review earlier the same day would have been dead on 100% of real assets for exactly this reason.

## The fix

The flag is decided **per property**, by the same expression the create path already uses (`MetadataHelpers.ts` → `STRING_SCALAR_PROPERTIES.has(key)`). This is convergence on one rule, not a parallel implementation.

Keyed on the **canonical** yaml key (#3944), not the raw `--property` spelling: `exo__Asset_aliases` is stored under the bare `aliases:` key and `aliases` is the member of `STRING_SCALAR_PROPERTIES`, so keying on the raw name would have silently dropped that spelling's quoting and reintroduced #3750.

`STRING_SCALAR_PROPERTIES` is re-exported from core (additive; no test mocks the core module and imports `set-property`, so the ESM-mock export-set hazard does not apply here).

## Scope

- **Changed:** every value that arrives as a **string** on a non-string-semantic property — both the `--property/--value` shell path and an `--input` JSON **string**. They share one serializer, and the rule is per-property, not per-input-form.
- **Unchanged:** an `--input` JSON **number/boolean** (not a string, so the flag is never consulted — asserted); `aliases` quoting (#3750 MEDIUM-3 — asserted); every non-scalar-shaped value (asserted).
- **Not reachable here:** `exo__Asset_label`, the other member of `STRING_SCALAR_PROPERTIES`, is guarded to `apply set-label` and never enters this function — `aliases` is the only reachable member. (An earlier revision of this body claimed both were asserted; only `aliases` is.)
- **Escape hatch:** a caller needing a scalar-shaped value to stay a string on such a property pre-wraps it (`--input '{"property":"<k>","value":"\"007\""}'`); an already-double-quoted scalar passes through verbatim. Now named in the docblock.

## Verification

`Req: 21ceea14-50dd-4cf8-bd3b-5a50b7c97105`

7 integration tests drive the real `setPropertyCommand()` (and the real `createCommand()` for parity) against a temp vault, read the file back from disk and assert the **parsed type** via `js-yaml` — the reader the CLI/RDF path actually uses. Asserting the type rather than the characters is deliberate: `2026-08-09` and `"2026-08-09"` differ by two characters and by everything that matters, which is how this survived.

**Two independent revert axes:**

- **Axis 1 — the flag.** Restoring the constant `true` reds 4: date, integer, `--input` JSON string, create-parity. The other 3 stay GREEN. Only one of them is a genuine control: `aliases` proves quoting was not switched off wholesale. The free-text and `--input`-number assertions are honest **unchanged-path** assertions, not discriminators — a free-text value is not ambiguous and a JSON number is not a string, so neither consults the flag in either state.
- **Axis 2 — the key.** Keying on the raw `--property` spelling instead of `canonicalYamlKey` reds the `aliases` test **alone**, proving the canonical-key decision is load-bearing rather than incidental.

Restored → 43/43 across all three `set-property` suites.

## Downstream consequence, stated deliberately

The RDF converter emits triples from the **parsed** value, so removing the quotes changes the emitted literal too: a date-only value goes from `Literal("2026-08-09")` to `Literal("2026-08-09T00:00:00.000Z", xsd:dateTime)`, an integer to `xsd:decimal`. A query matching such a value with a bare string stops matching for newly-set values; `FILTER(CONTAINS(STR(?d), …))` still matches. For a few shapes the round-trip also mutates the value itself (`007`→`7`, `1.50`→`1.5`, `null` reads as absent). All of this is what `create` has always done — the point of the change is one property, one type — and it is recorded in the requirement so a future reader does not diagnose convergence as a regression.

## Review

An adversarial `code-reviewer` pass returned **WARNING** with one HIGH that was **not a code defect** but a false clause in the requirement: the original spec asserted the whole `--input` path was unchanged, which holds only for number/boolean. Under req-first SDD that is worse than no clause — the next session reads it as verified fact — so it was corrected in the requirement and pinned by the 7th test (which doubled as the missing third revert axis). The reviewer also independently reproduced axis 1, and constructed axis 2 himself; both MEDIUMs were documentation drift and are fixed above.

`check:types`: 0 errors in the changed files (25 pre-existing errors in this worktree are identical with and without this branch's changes — an unbuilt sibling package locally, absent in CI's fresh install). Note that `npm run lint` resolves to `eslint packages/obsidian-plugin/src` and never sees these files; the gates that do apply (`validate-shard-assignments`, `check-test-antipatterns` 55/55 unchanged, `check-coverage-monotonic`, `archgate` 24/0) were run and pass.
