### PR TITLE
fix(core): single canonical-YAML-key source reachable by every frontmatter writer

### DIFF
--- a/packages/cli/src/commands/create.ts
+++ b/packages/cli/src/commands/create.ts
@@ -8,6 +8,7 @@ import {
   GenericAssetCreationService,
   liveClock,
   liveUidGenerator,
+  canonicalYamlKey,
   type GenericAssetCreationConfig,
 } from "@kitelev/exocortex-core";
 import { NodeFsAdapter } from "../adapters/NodeFsAdapter.js";
@@ -105,6 +106,27 @@ interface CreateCommandOptions {
  * parseProperties(["exo__Asset_relates=[[A]]", "exo__Asset_relates=[[B]]"])
  * // => { "exo__Asset_relates": ["[[A]]", "[[B]]"] }
  */
+/**
+ * Fields `create` populates itself, keyed by their CANONICAL YAML key, mapped to
+ * the dedicated flag a caller should use instead. Passing them through
+ * `--property` cannot work: the creation service skips them (it derives them
+ * from `--label` / `--aliases` / the generated identity), so the value would be
+ * dropped without a word. Refusing at parse time turns that silent loss into an
+ * actionable message (req 869561bf).
+ *
+ * ⚠ Keyed on the canonical key deliberately, so BOTH spellings are caught —
+ * `aliases` and `exo__Asset_aliases` canonicalise to the same entry.
+ *
+ * Deliberately holds ONLY `aliases`, which is what req 869561bf specifies. The
+ * other self-managed fields (`exo__Asset_label`, `exo__Instance_class`) are
+ * dropped just as silently today, but refusing them is a behaviour change no
+ * requirement states — widening this table without one would make the shipped
+ * behaviour exceed its spec. Tracked as a follow-up on `ems__Bug` 43e41c8f.
+ */
+const CREATE_SELF_MANAGED_FLAGS: Record<string, string> = {
+  aliases: "--aliases <a,b>",
+};
+
 function parseProperties(
   propertyArgs: string[] | undefined,
 ): Record<string, string | string[]> {
@@ -128,6 +150,19 @@ function parseProperties(
     if (!key) {
       throw new Error(
         `Invalid property format: "${prop}". Key cannot be empty.`,
+      );
+    }
+
+    // ⛤ Refuse the spellings whose CANONICAL key collides with something
+    // `create` manages itself (req 869561bf). Canonicalisation alone would send
+    // them into the self-managed skip-list and the value would vanish SILENTLY
+    // — strictly worse than today's dead literal key, because nothing tells the
+    // caller their input was ignored. Refusing mirrors how `set-property`
+    // rejects guarded properties: name the dedicated flag instead.
+    const dedicatedFlag = CREATE_SELF_MANAGED_FLAGS[canonicalYamlKey(key)];
+    if (dedicatedFlag !== undefined) {
+      throw new Error(
+        `Refusing to set "${key}" via --property — create manages this field itself. Use:  ${dedicatedFlag}`,
       );
     }
 

--- a/packages/cli/src/commands/propertyMutationShared.ts
+++ b/packages/cli/src/commands/propertyMutationShared.ts
@@ -1,4 +1,4 @@
-import { UNPREFIXED_ASSET_FIELDS } from "@kitelev/exocortex-core";
+import { canonicalYamlKey } from "@kitelev/exocortex-core";
 
 /**
  * Shared guards + helpers for the generic frontmatter-mutation CLI verbs
@@ -16,31 +16,18 @@ export const DEFAULT_TIMEZONE = "Asia/Almaty";
 
 export const UPDATED_AT_KEY = "exo__Asset_updatedAt";
 
-/** `exo__Asset_<field>` shape; group 1 = the bare field name. */
-const ASSET_PREFIXED_SHAPE = /^exo__Asset_(.+)$/;
-
 /**
- * Map an RDF property name to the canonical Obsidian YAML frontmatter KEY it is
- * stored under (issue #3944). Most properties use their own name, but the
- * `UNPREFIXED_ASSET_FIELDS` whitelist (`aliases`, `draft`, `pinned`, `archived`)
- * is stored under the BARE key `<field>:` — the same key `NoteToRDFConverter`
- * reads back as `exo:Asset_<field>`. Without this mapping, a mutation of
- * `exo__Asset_aliases` would write/delete a literal `exo__Asset_aliases:` key
- * instead of the canonical `aliases:` (Obsidian recognises aliases only via
- * `aliases:`).
+ * Canonical-YAML-key mapping (issue #3944) — re-exported from core, where it now
+ * lives next to the `UNPREFIXED_ASSET_FIELDS` whitelist it consults.
  *
- * Property NAME guards + TBox validation still run on the RDF/prefixed form
- * (unchanged); only the physical YAML key is canonicalised here. A bare
- * `aliases` (no `exo__Asset_` prefix) passes through unchanged — already the
- * canonical key, no regression. `archived` is routed to a dedicated command by
- * the guard before reaching this point, so in practice this only affects the
- * non-guarded fields (`aliases`, `draft`, `pinned`).
+ * ⛤ It used to be DEFINED here, and that was the defect: a rule every writer of
+ * frontmatter must obey sat inside one package's command folder, so the
+ * core-side writers (`GroundingExecutor`, `GenericAssetCreationService`) could
+ * not reach it and wrote raw keys instead. The re-export keeps this module's
+ * public surface unchanged for `set-property` / `remove-property` while making
+ * core the single source (req 869561bf).
  */
-export function canonicalYamlKey(property: string): string {
-  const m = ASSET_PREFIXED_SHAPE.exec(property);
-  if (m && UNPREFIXED_ASSET_FIELDS.has(m[1])) return m[1];
-  return property;
-}
+export { canonicalYamlKey };
 
 /**
  * Properties the generic mutation primitives REFUSE because a dedicated guarded

--- a/packages/cli/tests/integration/canonical-key-single-source.integration.test.ts
+++ b/packages/cli/tests/integration/canonical-key-single-source.integration.test.ts
@@ -1,0 +1,237 @@
+/**
+ * ems__Bug 43e41c8f / req 869561bf — the canonical-YAML-key rule (#3944) was
+ * DEFINED in `packages/cli/src/commands/propertyMutationShared.ts`, i.e. inside
+ * one package's command folder, while the whitelist it consults
+ * (`UNPREFIXED_ASSET_FIELDS`) already lived in core. The core-side frontmatter
+ * writers therefore could not reach it and wrote raw keys: `GroundingExecutor`
+ * emitted a literal, dead `exo__Asset_aliases:` key (and missed the string
+ * semantics), and `create` let the prefixed spelling fall through to a generic
+ * write. The divergence was UNREACHABILITY, not carelessness — so the fix moves
+ * the function to core next to its data rather than patching the call sites.
+ *
+ * These are the CLI-side axes. The `GroundingExecutor` axis lives with its own
+ * harness in `packages/core/tests/unit/services/GroundingExecutor.test.ts`.
+ *
+ * Revert-verify (~/dotfiles/.claude/rules/integration-test-revert-verify.md):
+ * neutralise the SINGLE core function — make `canonicalYamlKey` the identity
+ * (`return property;` in `NoteToRDFConverter.ts`) — and the axes go RED in BOTH
+ * suites. "Red in all of them" is precisely what proves the source is now one:
+ * if only some go red, the rule is still duplicated somewhere.
+ *
+ * The negative controls (a bare, already-canonical key; a prefixed property
+ * whose field is NOT whitelisted) must stay GREEN in every state — they prove
+ * canonicalisation did not start rewriting keys indiscriminately.
+ */
+import { jest, describe, it, expect, beforeEach, afterEach } from "@jest/globals";
+import * as fs from "fs";
+import * as path from "path";
+import * as os from "os";
+import * as yaml from "js-yaml";
+
+const { setPropertyCommand } = await import("../../src/commands/set-property.js");
+const { removePropertyCommand } = await import(
+  "../../src/commands/remove-property.js"
+);
+const { createCommand } = await import("../../src/commands/create.js");
+
+const DIR = "assetspaces/kitelev/exoas-my/notes";
+const ANCHOR_UID = "a1a1a1a1-0000-4000-8000-000000000001";
+const NOTE_UID = "a2a2a2a2-0000-4000-8000-000000000002";
+const CLASS_UID = "a3a3a3a3-0000-4000-8000-000000000003";
+const STALE_UPDATED_AT = "2020-01-01T00:00:00";
+
+function md(frontmatter: Record<string, string>): string {
+  const lines = ["---"];
+  for (const [k, v] of Object.entries(frontmatter)) lines.push(`${k}: ${v}`);
+  lines.push("---", "body", "");
+  return lines.join("\n");
+}
+
+function parseFrontmatter(content: string): Record<string, unknown> {
+  const m = /^---\n([\s\S]*?)\n---/.exec(content);
+  if (!m) throw new Error("no frontmatter in written file");
+  return (yaml.load(m[1]) ?? {}) as Record<string, unknown>;
+}
+
+describe("req 869561bf: one canonical-key source in core, used by every writer", () => {
+  let vault: string;
+  let exitSpy: ReturnType<typeof jest.spyOn>;
+  let stdoutSpy: ReturnType<typeof jest.spyOn>;
+  let stderrSpy: ReturnType<typeof jest.spyOn>;
+  let logSpy: ReturnType<typeof jest.spyOn>;
+  let errorSpy: ReturnType<typeof jest.spyOn>;
+  let exitCodes: number[];
+
+  const notePath = `${DIR}/${NOTE_UID}.md`;
+
+  beforeEach(() => {
+    vault = fs.mkdtempSync(path.join(os.tmpdir(), "cli-43e41c8f-"));
+    const dir = path.join(vault, DIR);
+    fs.mkdirSync(dir, { recursive: true });
+
+    fs.writeFileSync(
+      path.join(dir, `${ANCHOR_UID}.md`),
+      md({ exo__Asset_uid: ANCHOR_UID, exo__Asset_label: "notes__Anchor" }),
+    );
+    fs.writeFileSync(
+      path.join(dir, `${CLASS_UID}.md`),
+      md({ exo__Asset_uid: CLASS_UID, exo__Asset_label: "notes__Note" }),
+    );
+    fs.writeFileSync(
+      path.join(dir, `${NOTE_UID}.md`),
+      md({
+        exo__Asset_uid: NOTE_UID,
+        exo__Asset_isDefinedBy: `"[[${ANCHOR_UID}]]"`,
+        exo__Asset_label: '"Probe note"',
+        exo__Asset_updatedAt: STALE_UPDATED_AT,
+      }),
+    );
+
+    exitCodes = [];
+    exitSpy = jest.spyOn(process, "exit").mockImplementation(((code?: number) => {
+      exitCodes.push(code ?? 0);
+      return undefined as never;
+    }) as never);
+    stdoutSpy = jest
+      .spyOn(process.stdout, "write")
+      .mockImplementation((() => true) as never);
+    stderrSpy = jest
+      .spyOn(process.stderr, "write")
+      .mockImplementation((() => true) as never);
+    logSpy = jest.spyOn(console, "log").mockImplementation(() => {});
+    errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    exitSpy.mockRestore();
+    stdoutSpy.mockRestore();
+    stderrSpy.mockRestore();
+    logSpy.mockRestore();
+    errorSpy.mockRestore();
+    fs.rmSync(vault, { recursive: true, force: true });
+  });
+
+  function read(): { content: string; parsed: Record<string, unknown> } {
+    const content = fs.readFileSync(path.join(vault, notePath), "utf-8");
+    return { content, parsed: parseFrontmatter(content) };
+  }
+
+  async function run(
+    cmd: { parseAsync: (a: string[], o: { from: "user" }) => Promise<unknown> },
+    args: string[],
+  ): Promise<void> {
+    await cmd.parseAsync(["--vault", vault, ...args], { from: "user" });
+  }
+
+  // ── axis: set-property (already canonicalised — must stay so after the move) ──
+
+  it("set-property maps exo__Asset_aliases onto the canonical aliases key @req:869561bf-ae02-4028-bc6a-b32cfabda1ed", async () => {
+    await run(setPropertyCommand(), [
+      notePath,
+      "--skip-wikilink-validation",
+      "--property",
+      "exo__Asset_aliases",
+      "--value",
+      "Probe alias",
+    ]);
+
+    const { content, parsed } = read();
+    expect(content).not.toContain("exo__Asset_aliases:");
+    expect(parsed.aliases).toBe("Probe alias");
+  });
+
+  // ── axis: remove-property (same shared helper) ──
+
+  it("remove-property deletes the canonical aliases key given the prefixed name @req:869561bf-ae02-4028-bc6a-b32cfabda1ed", async () => {
+    // seed a canonical aliases key, then remove it via the PREFIXED spelling
+    await run(setPropertyCommand(), [
+      notePath,
+      "--skip-wikilink-validation",
+      "--property",
+      "aliases",
+      "--value",
+      "To be removed",
+    ]);
+    expect(read().parsed.aliases).toBe("To be removed");
+
+    await run(removePropertyCommand(), [
+      notePath,
+      "--property",
+      "exo__Asset_aliases",
+    ]);
+
+    expect(read().parsed.aliases).toBeUndefined();
+  });
+
+  // ── axis: create — refuses instead of silently dropping ──
+
+  /**
+   * `create` catches its own errors and exits non-zero rather than rejecting, so
+   * the refusal is asserted on the EXIT CODE plus the message the user actually
+   * sees — not on a rejected promise (which `process.exit` being mocked would
+   * swallow, making the assertion pass for the wrong reason).
+   */
+  function refusalOutput(): string {
+    return [...errorSpy.mock.calls, ...logSpy.mock.calls]
+      .map((c) => c.join(" "))
+      .join("\n");
+  }
+
+  it("create REFUSES --property exo__Asset_aliases and names the dedicated flag @req:869561bf-ae02-4028-bc6a-b32cfabda1ed", async () => {
+    await run(createCommand(), [
+      "--class",
+      CLASS_UID,
+      "--label",
+      "Refusal probe",
+      "--property",
+      "exo__Asset_aliases=Should not land",
+    ]);
+
+    expect(exitCodes).toContain(1);
+    expect(refusalOutput()).toMatch(/--aliases/);
+    expect(refusalOutput()).not.toMatch(/Should not land/);
+  });
+
+  it("create REFUSES the bare aliases spelling too (same canonical key) @req:869561bf-ae02-4028-bc6a-b32cfabda1ed", async () => {
+    await run(createCommand(), [
+      "--class",
+      CLASS_UID,
+      "--label",
+      "Refusal probe 2",
+      "--property",
+      "aliases=Should not land",
+    ]);
+
+    expect(exitCodes).toContain(1);
+    expect(refusalOutput()).toMatch(/--aliases/);
+  });
+
+  // ── negative controls: must stay GREEN in every state ──
+
+  it("leaves a prefixed property outside the whitelist untouched @req:869561bf-ae02-4028-bc6a-b32cfabda1ed", async () => {
+    await run(setPropertyCommand(), [
+      notePath,
+      "--skip-wikilink-validation",
+      "--property",
+      "exo__Asset_isDefinedBy",
+      "--value",
+      `[[${ANCHOR_UID}]]`,
+    ]);
+
+    // canonicalisation is the identity here — the key must survive verbatim
+    expect(read().content).toContain("exo__Asset_isDefinedBy:");
+  });
+
+  it("leaves an ordinary domain property untouched @req:869561bf-ae02-4028-bc6a-b32cfabda1ed", async () => {
+    await run(setPropertyCommand(), [
+      notePath,
+      "--skip-wikilink-validation",
+      "--property",
+      "notes__Note_mood",
+      "--value",
+      "calm",
+    ]);
+
+    expect(read().parsed.notes__Note_mood).toBe("calm");
+  });
+});

--- a/packages/cli/tests/integration/canonical-key-single-source.integration.test.ts
+++ b/packages/cli/tests/integration/canonical-key-single-source.integration.test.ts
@@ -206,6 +206,43 @@ describe("req 869561bf: one canonical-key source in core, used by every writer",
     expect(refusalOutput()).toMatch(/--aliases/);
   });
 
+  // ── axis: create's asset-building path (GenericAssetCreationService) ──
+
+  /**
+   * The second wired core writer. `create` refuses only the fields it manages
+   * ITSELF (`aliases`); the other three `UNPREFIXED_ASSET_FIELDS` are ordinary
+   * `--property` input and must land under their canonical key. Without this
+   * axis the `GenericAssetCreationService` edit ships unverified — its own 101
+   * tests stay green under a neutralised canonicaliser.
+   */
+  it("create writes exo__Asset_archived under the canonical archived key @req:869561bf-ae02-4028-bc6a-b32cfabda1ed", async () => {
+    await run(createCommand(), [
+      "--class",
+      CLASS_UID,
+      "--label",
+      "Archived probe",
+      "--property",
+      "exo__Asset_archived=true",
+    ]);
+
+    // `create` places the asset by co-location (isDefinedBy), which this probe
+    // does not pin — so locate it by content across the temp vault rather than
+    // assuming a folder.
+    const walk = (d: string): string[] =>
+      fs.readdirSync(d, { withFileTypes: true }).flatMap((e) => {
+        const p = path.join(d, e.name);
+        return e.isDirectory() ? walk(p) : p.endsWith(".md") ? [p] : [];
+      });
+    const created = walk(vault).filter((p) =>
+      fs.readFileSync(p, "utf-8").includes("Archived probe"),
+    );
+    expect(created).toHaveLength(1);
+
+    const content = fs.readFileSync(created[0], "utf-8");
+    expect(content).not.toContain("exo__Asset_archived:");
+    expect(parseFrontmatter(content).archived).toBe(true);
+  });
+
   // ── negative controls: must stay GREEN in every state ──
 
   it("leaves a prefixed property outside the whitelist untouched @req:869561bf-ae02-4028-bc6a-b32cfabda1ed", async () => {

--- a/packages/cli/tests/unit/commands/create.test.ts
+++ b/packages/cli/tests/unit/commands/create.test.ts
@@ -1,6 +1,14 @@
 import { jest } from "@jest/globals";
 import { Command } from "commander";
 
+// req 869561bf — pull the REAL canonicaliser in by its deep path. Only the
+// package specifier `@kitelev/exocortex-core` is mocked below, so this import
+// reaches the actual module and the mock stays honest (see the comment at the
+// `canonicalYamlKey` entry).
+const { canonicalYamlKey: realCanonicalYamlKey } = await import(
+  "../../../../core/src/services/NoteToRDFConverter.js"
+);
+
 // Mock uuid (transitively a GenericAssetCreationService dependency)
 jest.unstable_mockModule("uuid", () => ({
   v4: jest.fn(() => "mock-uuid"),
@@ -14,6 +22,18 @@ jest.unstable_mockModule("@kitelev/exocortex-core", () => ({
   MetadataHelpers: { buildFileContent: jest.fn(() => "---\n---\n") },
   GenericAssetCreationService: class GenericAssetCreationService {},
   ShapeRegistry: class ShapeRegistry {},
+  /**
+   * req 869561bf — `create.ts` consults the SINGLE canonical-key source in core
+   * to decide whether a `--property` names a field `create` manages itself.
+   *
+   * ⛤ The REAL function is wired in, not a hand-written mirror. A mirror would
+   * be a third copy of the very rule this requirement exists to de-duplicate:
+   * add a fifth entry to `UNPREFIXED_ASSET_FIELDS` and the copy diverges
+   * silently, so the suite would keep passing against a rule the product no
+   * longer has. Only the package specifier is mocked — the deep path resolves
+   * to the actual module.
+   */
+  canonicalYamlKey: realCanonicalYamlKey,
   // Transitively required: create.ts → folderRepairHelpers.ts imports this.
   extractAssetReference: jest.fn((v: unknown) =>
     typeof v === "string"

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -289,6 +289,7 @@ export {
   normaliseExcludedFolders,
   isPathExcluded,
   UNPREFIXED_ASSET_FIELDS,
+  canonicalYamlKey,
   type ExocortexInvariantCode,
   type ExocortexInvariantViolation,
 } from "./services/NoteToRDFConverter";

--- a/packages/core/src/services/GenericAssetCreationService.ts
+++ b/packages/core/src/services/GenericAssetCreationService.ts
@@ -3,6 +3,7 @@ import { DateFormatter } from "../utilities/DateFormatter";
 import { MetadataHelpers } from "../utilities/MetadataHelpers";
 import { WikiLinkHelpers } from "../utilities/WikiLinkHelpers";
 import { Namespace } from "../domain/models/rdf/Namespace";
+import { canonicalYamlKey } from "./NoteToRDFConverter";
 import type { IVaultAdapter, IFile } from "../interfaces/IVaultAdapter";
 import { DI_TOKENS } from "../interfaces/tokens";
 import { PropertyFieldType } from "../domain/types/PropertyFieldType";
@@ -346,7 +347,19 @@ export class GenericAssetCreationService {
 
     // Process additional property values
     if (config.propertyValues) {
-      for (const [propertyName, value] of Object.entries(config.propertyValues)) {
+      for (const [rawPropertyName, value] of Object.entries(
+        config.propertyValues,
+      )) {
+        // ⛤ Canonicalise the physical YAML key BEFORE anything else (req
+        // 869561bf): `exo__Asset_aliases` is stored under the bare `aliases:`
+        // key that Obsidian actually reads. Doing it here — rather than only in
+        // the CLI mutation verbs — is the point of the requirement: every
+        // frontmatter writer consults ONE source in core. It also makes the
+        // self-managed skip-list below see the canonical spelling, so a
+        // prefixed `exo__Asset_aliases` is skipped instead of landing as a
+        // literal, dead key alongside the real `aliases:`.
+        const propertyName = canonicalYamlKey(rawPropertyName);
+
         // Skip system properties already set
         if (
           propertyName === "exo__Asset_uid" ||

--- a/packages/core/src/services/GenericAssetCreationService.ts
+++ b/packages/core/src/services/GenericAssetCreationService.ts
@@ -358,6 +358,21 @@ export class GenericAssetCreationService {
         // self-managed skip-list below see the canonical spelling, so a
         // prefixed `exo__Asset_aliases` is skipped instead of landing as a
         // literal, dead key alongside the real `aliases:`.
+        //
+        // ⚠ Two consequences worth naming, both deliberate:
+        //  1. The downstream `propertyTypeMap` / `shouldEmitAsArray` lookups now
+        //     receive the BARE name, so `Namespace.fromPropertyKey("archived")`
+        //     returns null and a shape declared under `exo#Asset_archived` no
+        //     longer resolves. Benign for the four whitelisted fields (booleans
+        //     and `aliases`; `shouldEmitAsArray` only matters for `[[…]]`
+        //     values) — but it IS a coupling, not an accident.
+        //  2. Skipping is silent. `create.ts` therefore REFUSES
+        //     `--property exo__Asset_aliases` up front rather than letting the
+        //     value vanish here. That refusal is CLI-only: another caller
+        //     reaching this service directly (e.g. the plugin's asset-creation
+        //     modal) still hits the silent skip. Moving the refusal into the
+        //     service would change plugin UX and is out of this requirement's
+        //     scope — tracked on ems__Bug 43e41c8f.
         const propertyName = canonicalYamlKey(rawPropertyName);
 
         // Skip system properties already set

--- a/packages/core/src/services/GroundingExecutor.ts
+++ b/packages/core/src/services/GroundingExecutor.ts
@@ -1867,7 +1867,17 @@ export class GroundingExecutor {
       const finalLabel =
         label !== undefined && label.trim().length > 0 ? label : "Untitled";
       properties.exo__Asset_label = finalLabel;
-      if (finalLabel !== "Untitled" && properties.aliases === undefined) {
+      // ⛤ Test the CANONICAL spelling, not just the bare one. `createFrontmatter`
+      // collapses `exo__Asset_aliases` onto `aliases` (req 869561bf), but that
+      // happens LATER — so a template / propertyDefault / inheritance-rule
+      // supplying the prefixed key would leave `properties.aliases` undefined
+      // here, this guard would add the label-derived aliases anyway, and the
+      // collapse would then keep whichever landed last. On origin/main both keys
+      // survived (ugly, half-dead); silently dropping one would be worse.
+      const aliasesAlreadySet = Object.keys(properties).some(
+        (k) => canonicalYamlKey(k) === "aliases",
+      );
+      if (finalLabel !== "Untitled" && !aliasesAlreadySet) {
         properties.aliases = [finalLabel];
       }
       // Only the genuine degraded fallthrough ("Untitled") is an

--- a/packages/core/src/services/GroundingExecutor.ts
+++ b/packages/core/src/services/GroundingExecutor.ts
@@ -21,6 +21,7 @@ import {
   serializeYamlScalar,
   STRING_SCALAR_PROPERTIES,
 } from "../utilities/yamlScalar";
+import { canonicalYamlKey } from "./NoteToRDFConverter";
 import type { NamedQueryRunnerPort } from "./NamedQueryRunner";
 import { iriToVaultPath } from "../infrastructure/vault/iri";
 import { DateFormatter } from "../utilities/DateFormatter";
@@ -646,12 +647,30 @@ export class GroundingExecutor {
     // Non-string-scalar properties (timestamps, refs) are untouched. The
     // property name is normalized to prefixed form first so a full-IRI-shaped
     // `targetProperty` still matches the string-scalar set (#3779 review LOW).
+    // ⛤ Both the string-scalar lookup AND the physical write key must use the
+    // CANONICAL key (req 869561bf): `STRING_SCALAR_PROPERTIES` holds `aliases`,
+    // not `exo__Asset_aliases`, and Obsidian reads aliases only from `aliases:`.
+    // Before this, the lookup ran on the merely-normalized name (missing the
+    // string semantics for the prefixed spelling) and `updateProperty` received
+    // the RAW `grounding.targetProperty` (writing a literal, dead key).
     const normalizedTargetProperty = FrontmatterService.normalizeIRI(
       grounding.targetProperty,
     );
-    const valueToWrite = STRING_SCALAR_PROPERTIES.has(normalizedTargetProperty)
+    const canonicalTargetProperty = canonicalYamlKey(normalizedTargetProperty);
+    const valueToWrite = STRING_SCALAR_PROPERTIES.has(canonicalTargetProperty)
       ? serializeYamlScalar(substitutedValue, true)
       : substitutedValue;
+
+    // Strictly additive: the write key changes ONLY for the four
+    // `UNPREFIXED_ASSET_FIELDS`, where canonicalisation is not the identity.
+    // For every other property the raw `grounding.targetProperty` is preserved
+    // verbatim, so a full-IRI-shaped targetProperty keeps writing exactly the
+    // key it wrote before — normalisation stays confined to the lookup, which
+    // is what #3779 introduced it for.
+    const writeKey =
+      canonicalTargetProperty === normalizedTargetProperty
+        ? grounding.targetProperty
+        : canonicalTargetProperty;
 
     // req faf269bf Scenarios 1+3 — resolve WHICH asset this step writes into.
     // Absent `targetQuery` (every existing grounding) keeps `filePath` exactly
@@ -672,7 +691,7 @@ export class GroundingExecutor {
     const content = await this.fileReader.readFile(effectiveFilePath);
     const updated = this.frontmatterService.updateProperty(
       content,
-      grounding.targetProperty,
+      writeKey,
       valueToWrite,
     );
     await this.fileWriter.updateFile(effectiveFilePath, updated);

--- a/packages/core/src/services/GroundingExecutor.ts
+++ b/packages/core/src/services/GroundingExecutor.ts
@@ -661,16 +661,16 @@ export class GroundingExecutor {
       ? serializeYamlScalar(substitutedValue, true)
       : substitutedValue;
 
-    // Strictly additive: the write key changes ONLY for the four
-    // `UNPREFIXED_ASSET_FIELDS`, where canonicalisation is not the identity.
-    // For every other property the raw `grounding.targetProperty` is preserved
-    // verbatim, so a full-IRI-shaped targetProperty keeps writing exactly the
-    // key it wrote before — normalisation stays confined to the lookup, which
-    // is what #3779 introduced it for.
-    const writeKey =
-      canonicalTargetProperty === normalizedTargetProperty
-        ? grounding.targetProperty
-        : canonicalTargetProperty;
+    // ⛤ The WRITE KEY is not decided here. `FrontmatterService.updateProperty`
+    // canonicalises on entry, so every writer that reaches the primitive — this
+    // step, its `property_delete` / `property_append` / `property_increment` /
+    // `property_shift` siblings, the `service_call` twins in
+    // `packages/services`, and the plugin — gets the same key without each
+    // call site repeating the rule. Deciding it per-call-site is exactly the
+    // shape of defect this requirement removes. The canonical name is still
+    // needed HERE, but only for the `STRING_SCALAR_PROPERTIES` lookup above:
+    // `updateProperty` serialises without `quoteScalars`, so the string
+    // semantics for `aliases` have to be applied by the caller.
 
     // req faf269bf Scenarios 1+3 — resolve WHICH asset this step writes into.
     // Absent `targetQuery` (every existing grounding) keeps `filePath` exactly
@@ -691,7 +691,7 @@ export class GroundingExecutor {
     const content = await this.fileReader.readFile(effectiveFilePath);
     const updated = this.frontmatterService.updateProperty(
       content,
-      writeKey,
+      grounding.targetProperty,
       valueToWrite,
     );
     await this.fileWriter.updateFile(effectiveFilePath, updated);

--- a/packages/core/src/services/NoteToRDFConverter.ts
+++ b/packages/core/src/services/NoteToRDFConverter.ts
@@ -59,6 +59,36 @@ export const UNPREFIXED_ASSET_FIELDS: ReadonlySet<string> = new Set([
   "aliases",
 ]);
 
+/** `exo__Asset_<field>` shape; group 1 = the bare field name. */
+const ASSET_PREFIXED_SHAPE = /^exo__Asset_(.+)$/;
+
+/**
+ * Map an RDF property name to the canonical Obsidian YAML frontmatter KEY it is
+ * stored under (issue #3944). Most properties use their own name, but the
+ * {@link UNPREFIXED_ASSET_FIELDS} whitelist is stored under the BARE key
+ * `<field>:` — the same key this converter reads back as `exo:Asset_<field>`.
+ * Without this mapping a write of `exo__Asset_aliases` lands on a literal
+ * `exo__Asset_aliases:` key that Obsidian ignores (it recognises aliases only
+ * via `aliases:`) and that the converter never links to `exo:Asset_aliases`.
+ *
+ * ⛤ Lives HERE, next to the whitelist it consults, because **every** writer of
+ * frontmatter must reach it — not only the CLI verbs. It previously sat in
+ * `packages/cli/src/commands/propertyMutationShared.ts`, which made it
+ * unreachable from the core-side writers (`GroundingExecutor`,
+ * `GenericAssetCreationService`); they consequently wrote raw keys and diverged
+ * from `set-property` / `remove-property`. The divergence was not carelessness
+ * but *unreachability* — hence the move rather than a patch of the call sites.
+ *
+ * Property NAME guards and TBox validation still run on the RDF/prefixed form;
+ * only the physical YAML key is canonicalised here. A bare `aliases` (already
+ * canonical) passes through unchanged.
+ */
+export function canonicalYamlKey(property: string): string {
+  const m = ASSET_PREFIXED_SHAPE.exec(property);
+  if (m && UNPREFIXED_ASSET_FIELDS.has(m[1])) return m[1];
+  return property;
+}
+
 /**
  * Normalise a user-supplied list of folder-exclusion prefixes:
  *   - Treat `undefined` / non-array as empty.

--- a/packages/core/src/utilities/FrontmatterService.ts
+++ b/packages/core/src/utilities/FrontmatterService.ts
@@ -205,8 +205,9 @@ export class FrontmatterService {
 
     // Property already exists - replace value (including multi-line array items)
     if (this.hasProperty(updatedFrontmatter, property)) {
+      // `^` + `m`: match the key only at LINE START — see `hasProperty`.
       const propertyRegex = new RegExp(
-        `${this.escapeRegex(property)}:.*(?:\n {2}- .*)*`,
+        `^${this.escapeRegex(property)}:.*(?:\n {2}- .*)*`,
         "m",
       );
       // Function-replacer (not a string) so `$`-patterns in the value
@@ -278,9 +279,13 @@ export class FrontmatterService {
     }
 
     // Remove property line and any following array items (lines starting with "  - ")
+    // `(?:\n|^)` rather than a bare `^`: the key must start a line (see
+    // `hasProperty`), AND the preceding newline is consumed with it so removal
+    // leaves no blank line — which the previous unanchored `\n?` prefix did by
+    // accident while also matching mid-line.
     const propertyLineRegex = new RegExp(
-      `\n?${this.escapeRegex(property)}:.*(?:\n {2}- .*)*`,
-      "gm",
+      `(?:\n|^)${this.escapeRegex(property)}:.*(?:\n {2}- .*)*`,
+      "g",
     );
     const updatedFrontmatter = parsed.content.replace(propertyLineRegex, "");
 
@@ -307,7 +312,15 @@ export class FrontmatterService {
    * ```
    */
   hasProperty(frontmatterContent: string, property: string): boolean {
-    return frontmatterContent.includes(`${property}:`);
+    // ⛤ Anchored to LINE START. An unanchored `includes(\`${property}:\`)`
+    // reports a hit on any key that merely ENDS with the searched name —
+    // `namespace_aliases:` answers a search for `aliases:` — and the callers act
+    // on that hit by rewriting or deleting the neighbour's line. Canonicalising
+    // (req 869561bf) makes the searched key SHORTER, which turned that latent
+    // collision into a likely one; anchoring closes it for both spellings.
+    return new RegExp(`^${this.escapeRegex(property)}:`, "m").test(
+      frontmatterContent,
+    );
   }
 
   /** Namespace IRI → Obsidian property name prefix map */
@@ -417,8 +430,10 @@ export class FrontmatterService {
     frontmatterContent: string,
     property: string,
   ): string | null {
+    // Anchored for the same reason as the write paths: an unanchored match
+    // would return the NEIGHBOUR's value for any key ending in this name.
     const propertyRegex = new RegExp(
-      `${this.escapeRegex(property)}:\\s*(.*)$`,
+      `^${this.escapeRegex(property)}:\\s*(.*)$`,
       "m",
     );
     const match = frontmatterContent.match(propertyRegex);

--- a/packages/core/src/utilities/FrontmatterService.ts
+++ b/packages/core/src/utilities/FrontmatterService.ts
@@ -10,6 +10,7 @@
 
 import { loadDefaultSpec, orderProperties } from "../services/OrderSpecResolver";
 import { serializeYamlScalar, STRING_SCALAR_PROPERTIES } from "./yamlScalar";
+import { canonicalYamlKey } from "../services/NoteToRDFConverter";
 
 /**
  * Result of frontmatter parsing operation
@@ -187,7 +188,7 @@ export class FrontmatterService {
    * ```
    */
   updateProperty(content: string, property: string, value: unknown): string {
-    property = FrontmatterService.normalizeIRI(property);
+    property = canonicalYamlKey(FrontmatterService.normalizeIRI(property));
     if (typeof value === "string") {
       value = FrontmatterService.normalizeIRIValue(value);
     }
@@ -268,6 +269,7 @@ export class FrontmatterService {
    * ```
    */
   removeProperty(content: string, property: string): string {
+    property = canonicalYamlKey(property);
     const parsed = this.parse(content);
 
     // No frontmatter or property doesn't exist - return unchanged
@@ -371,7 +373,17 @@ export class FrontmatterService {
    * ```
    */
   createFrontmatter(content: string, properties: Record<string, unknown>): string {
-    const ordered = orderProperties(properties, loadDefaultSpec());
+    // req 869561bf — canonicalise BEFORE ordering, so the order spec and the
+    // `STRING_SCALAR_PROPERTIES` lookup inside `serializeValue` both see the key
+    // the file will actually carry. Doing it per-entry during the map instead
+    // would let `exo__Asset_aliases` and `aliases` both survive into the output
+    // as duplicate YAML keys; collapsing them here makes last-write-wins
+    // explicit and keeps the emitted document parseable.
+    const canonical: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(properties)) {
+      canonical[canonicalYamlKey(key)] = value;
+    }
+    const ordered = orderProperties(canonical, loadDefaultSpec());
     // Issue #3748: quote scalars on new-asset writes so a label / alias
     // containing `: ` (or another YAML indicator) stays valid YAML.
     const frontmatterLines = Object.entries(ordered).map(

--- a/packages/core/src/utilities/FrontmatterService.ts
+++ b/packages/core/src/utilities/FrontmatterService.ts
@@ -280,9 +280,13 @@ export class FrontmatterService {
 
     // Remove property line and any following array items (lines starting with "  - ")
     // `(?:\n|^)` rather than a bare `^`: the key must start a line (see
-    // `hasProperty`), AND the preceding newline is consumed with it so removal
-    // leaves no blank line — which the previous unanchored `\n?` prefix did by
-    // accident while also matching mid-line.
+    // `hasProperty`), AND the preceding newline is consumed with it, so removing
+    // a middle or last key leaves no blank line.
+    // ⚠ Not an invariant for the FIRST key — there is no preceding newline, `^`
+    // matches empty, and the trailing one survives as a blank line. That is
+    // byte-identical to the previous `\n?` behaviour (verified across
+    // first/middle/last/only × ±array items), so this anchoring changes WHERE a
+    // match may start, not what the removal leaves behind.
     const propertyLineRegex = new RegExp(
       `(?:\n|^)${this.escapeRegex(property)}:.*(?:\n {2}- .*)*`,
       "g",

--- a/packages/core/src/utilities/MetadataHelpers.ts
+++ b/packages/core/src/utilities/MetadataHelpers.ts
@@ -1,4 +1,5 @@
 import { loadDefaultSpec, orderProperties } from "../services/OrderSpecResolver";
+import { canonicalYamlKey } from "../services/NoteToRDFConverter";
 import {
   serializeYamlScalar,
   STRING_SCALAR_PROPERTIES,
@@ -147,7 +148,17 @@ export class MetadataHelpers {
     frontmatter: Record<string, unknown>,
     bodyContent?: string,
   ): string {
-    const ordered = orderProperties(frontmatter, loadDefaultSpec());
+    // req 869561bf — the asset-creation twin of
+    // `FrontmatterService.createFrontmatter`; canonicalise on the same terms so
+    // a caller passing `exo__Asset_aliases` gets the live `aliases:` key AND the
+    // `STRING_SCALAR_PROPERTIES` lookup below (which keys off the emitted name)
+    // keeps a scalar-looking alias a string instead of letting YAML coerce it
+    // to a Date — the #3750 MEDIUM-3 guarantee.
+    const canonical: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(frontmatter)) {
+      canonical[canonicalYamlKey(key)] = value;
+    }
+    const ordered = orderProperties(canonical, loadDefaultSpec());
     const frontmatterLines = Object.entries(ordered)
       .map(([key, value]) => {
         // #3750 MEDIUM-1: route through serializeYamlScalar so scalars with

--- a/packages/core/tests/unit/services/GroundingExecutor.test.ts
+++ b/packages/core/tests/unit/services/GroundingExecutor.test.ts
@@ -150,6 +150,31 @@ describe("GroundingExecutor", () => {
       expect(fm["exo__Asset_aliases"]).toBeUndefined();
     });
 
+    // Write-side twin of the collision axis in `property_delete`: the same
+    // unanchored match let `updateProperty` OVERWRITE the neighbour's value
+    // (`namespace_aliases: "X"`, list destroyed) instead of adding its own key.
+    it("adds its own key without overwriting a neighbour that ENDS with the canonical name @req:869561bf-ae02-4028-bc6a-b32cfabda1ed", async () => {
+      reader.readFile.mockResolvedValue(
+        '---\nfoo: bar\nnamespace_aliases:\n  - "ims"\n---\nBody',
+      );
+
+      const grounding = makeGrounding({
+        type: GroundingType.PROPERTY_SET,
+        targetProperty: "exo__Asset_aliases",
+        targetValueLiteral: "Mine",
+      });
+
+      const result = await executor.execute(grounding, TARGET_IRI, FILE_PATH);
+      expect(result.success).toBe(true);
+
+      const written = writer.updateFile.mock.calls[0][1];
+      const fm = yaml.load(
+        /^---\n([\s\S]*?)\n---/.exec(written)![1],
+      ) as Record<string, unknown>;
+      expect(fm.namespace_aliases).toEqual(["ims"]); // untouched
+      expect(fm.aliases).toBe("Mine"); // own key added
+    });
+
     // Negative control for the axis above: a PREFIXED property whose field is
     // NOT in UNPREFIXED_ASSET_FIELDS must keep its key verbatim. Proves the
     // canonicalisation did not start rewriting keys indiscriminately.
@@ -344,7 +369,15 @@ describe("GroundingExecutor", () => {
      * before (both halves were consistently broken), so a per-call-site fix
      * would have introduced a NEW inconsistency while claiming to remove one.
      * Canonicalising inside the FrontmatterService primitives keeps the two
-     * halves in step by construction.
+     * halves in step for PREFIXED spellings.
+     *
+     * ⚠ Scope, stated honestly: it does NOT put them in step for FULL-IRI
+     * input. `updateProperty` runs `normalizeIRI`, `removeProperty` does not —
+     * so an IRI-shaped `targetProperty` still sets but does not delete. That
+     * asymmetry predates this requirement (origin/main behaves identically) and
+     * is tracked on ems__Bug 43e41c8f rather than silently widened here:
+     * adding `normalizeIRI` to `removeProperty` would also turn today's silent
+     * no-op into a real delete for non-whitelisted IRI input.
      */
     it("removes the canonical aliases key when given the PREFIXED spelling @req:869561bf-ae02-4028-bc6a-b32cfabda1ed", async () => {
       reader.readFile.mockResolvedValue(
@@ -363,6 +396,47 @@ describe("GroundingExecutor", () => {
       expect(written).not.toContain("aliases:");
       expect(written).not.toContain("Existing");
       expect(written).toContain("foo: bar");
+    });
+
+    /**
+     * ⛔ The collision axis. Canonicalisation makes the searched key SHORTER
+     * (`exo__Asset_aliases` → `aliases`), and the primitives matched keys by
+     * UNANCHORED substring — so `aliases:` began answering for a neighbouring
+     * `namespace_aliases:`. Deleting then truncated that neighbour to a bare
+     * `namespace_`, which is not valid YAML at all: the whole frontmatter block
+     * stops parsing and the asset disappears from Obsidian AND the RDF graph.
+     *
+     * This is not hypothetical — `218ed4dd-…` in `exoas-shared-identities`
+     * carries `namespace_aliases` and is mounted in all three vaults. No prior
+     * fixture had a colliding neighbour, which is exactly why eight otherwise
+     * green revert-verify axes could not see it.
+     */
+    it("does NOT touch a neighbouring key that merely ENDS with the canonical name @req:869561bf-ae02-4028-bc6a-b32cfabda1ed", async () => {
+      reader.readFile.mockResolvedValue(
+        '---\nfoo: bar\nnamespace_aliases:\n  - "ims"\n  - "concept"\n---\nBody',
+      );
+
+      const grounding = makeGrounding({
+        type: GroundingType.PROPERTY_DELETE,
+        targetProperty: "exo__Asset_aliases",
+      });
+
+      const result = await executor.execute(grounding, TARGET_IRI, FILE_PATH);
+      expect(result.success).toBe(true);
+
+      // nothing to delete → the file must come back byte-identical
+      const written =
+        writer.updateFile.mock.calls.length > 0
+          ? (writer.updateFile.mock.calls[0][1] as string)
+          : '---\nfoo: bar\nnamespace_aliases:\n  - "ims"\n  - "concept"\n---\nBody';
+
+      // the neighbour survives WHOLE — key and both items
+      expect(written).toContain("namespace_aliases:");
+      expect(written).not.toContain("namespace_\n");
+      const fm = yaml.load(
+        /^---\n([\s\S]*?)\n---/.exec(written)![1],
+      ) as Record<string, unknown>;
+      expect(fm.namespace_aliases).toEqual(["ims", "concept"]);
     });
 
     it("should succeed when property does not exist (no-op)", async () => {

--- a/packages/core/tests/unit/services/GroundingExecutor.test.ts
+++ b/packages/core/tests/unit/services/GroundingExecutor.test.ts
@@ -113,6 +113,49 @@ describe("GroundingExecutor", () => {
       expect(writtenContent).toContain("ems__status: Done");
     });
 
+    // req 869561bf — the canonical-YAML-key rule now lives in core, so EVERY
+    // frontmatter writer consults it. Both halves of this executor were broken:
+    // it wrote the RAW `targetProperty` (a literal, dead `exo__Asset_aliases:`
+    // key that Obsidian ignores) and looked the string-scalar set up on the
+    // merely-normalized name (so the prefixed spelling lost its quoting).
+    it("writes exo__Asset_aliases under the canonical aliases key AND keeps string semantics @req:869561bf-ae02-4028-bc6a-b32cfabda1ed", async () => {
+      reader.readFile.mockResolvedValue("---\nfoo: bar\n---\nBody");
+
+      const grounding = makeGrounding({
+        type: GroundingType.PROPERTY_SET,
+        targetProperty: "exo__Asset_aliases",
+        targetValueLiteral: "2026-01-15",
+      });
+
+      const result = await executor.execute(grounding, TARGET_IRI, FILE_PATH);
+
+      expect(result.success).toBe(true);
+      const written = writer.updateFile.mock.calls[0][1];
+      // canonical key — the one Obsidian actually reads
+      expect(written).toContain('aliases: "2026-01-15"');
+      // and NOT the literal prefixed key
+      expect(written).not.toContain("exo__Asset_aliases:");
+    });
+
+    // Negative control for the axis above: a PREFIXED property whose field is
+    // NOT in UNPREFIXED_ASSET_FIELDS must keep its key verbatim. Proves the
+    // canonicalisation did not start rewriting keys indiscriminately.
+    it("leaves a prefixed property outside the whitelist untouched @req:869561bf-ae02-4028-bc6a-b32cfabda1ed", async () => {
+      reader.readFile.mockResolvedValue("---\nfoo: bar\n---\nBody");
+
+      const grounding = makeGrounding({
+        type: GroundingType.PROPERTY_SET,
+        targetProperty: "exo__Asset_isDefinedBy",
+        targetValueLiteral: "[[some-anchor]]",
+      });
+
+      const result = await executor.execute(grounding, TARGET_IRI, FILE_PATH);
+
+      expect(result.success).toBe(true);
+      const written = writer.updateFile.mock.calls[0][1];
+      expect(written).toContain("exo__Asset_isDefinedBy:");
+    });
+
     it("should substitute $now with ISO timestamp", async () => {
       reader.readFile.mockResolvedValue("---\nfoo: bar\n---\n");
 

--- a/packages/core/tests/unit/services/GroundingExecutor.test.ts
+++ b/packages/core/tests/unit/services/GroundingExecutor.test.ts
@@ -6,6 +6,7 @@ import {
   clearResolvers,
   installDefaultResolvers,
 } from "../../../src/services/SubstitutionResolverRegistry";
+import * as yaml from "js-yaml";
 import { GroundingType } from "../../../src/domain/constants/GroundingType";
 import { GroundingDefinition } from "../../../src/domain/models/CommandDefinition";
 
@@ -135,6 +136,18 @@ describe("GroundingExecutor", () => {
       expect(written).toContain('aliases: "2026-01-15"');
       // and NOT the literal prefixed key
       expect(written).not.toContain("exo__Asset_aliases:");
+
+      // ⛤ Assert the GUARANTEE (#3750 MEDIUM-3), not its current spelling: run
+      // the emitted frontmatter through a real YAML parser and check the TYPE.
+      // `2026-01-15` unquoted parses as a Date; quoted, it stays a string. A
+      // `toContain` on characters would keep passing if the quoting moved or
+      // the serializer changed shape — the parsed type cannot.
+      const fm = yaml.load(
+        /^---\n([\s\S]*?)\n---/.exec(written)![1],
+      ) as Record<string, unknown>;
+      expect(fm.aliases).toBe("2026-01-15");
+      expect(typeof fm.aliases).toBe("string");
+      expect(fm["exo__Asset_aliases"]).toBeUndefined();
     });
 
     // Negative control for the axis above: a PREFIXED property whose field is
@@ -318,6 +331,38 @@ describe("GroundingExecutor", () => {
       const writtenContent = writer.updateFile.mock.calls[0][1];
       expect(writtenContent).not.toContain("ems__Effort_startTimestamp");
       expect(writtenContent).toContain("foo: bar");
+    });
+
+    /**
+     * req 869561bf — the SET/DELETE symmetry axis.
+     *
+     * ⛤ This is the axis that decided WHERE the rule had to live. Wiring
+     * canonicalisation into `property_set` alone would have made a grounding
+     * able to WRITE an alias via the prefixed spelling but never REMOVE it:
+     * `removeProperty` would look for a key that no longer exists, and return
+     * the content unchanged — a silent no-op. That asymmetry did not exist
+     * before (both halves were consistently broken), so a per-call-site fix
+     * would have introduced a NEW inconsistency while claiming to remove one.
+     * Canonicalising inside the FrontmatterService primitives keeps the two
+     * halves in step by construction.
+     */
+    it("removes the canonical aliases key when given the PREFIXED spelling @req:869561bf-ae02-4028-bc6a-b32cfabda1ed", async () => {
+      reader.readFile.mockResolvedValue(
+        '---\nfoo: bar\naliases:\n  - "Existing"\n---\nBody',
+      );
+
+      const grounding = makeGrounding({
+        type: GroundingType.PROPERTY_DELETE,
+        targetProperty: "exo__Asset_aliases",
+      });
+
+      const result = await executor.execute(grounding, TARGET_IRI, FILE_PATH);
+
+      expect(result.success).toBe(true);
+      const written = writer.updateFile.mock.calls[0][1];
+      expect(written).not.toContain("aliases:");
+      expect(written).not.toContain("Existing");
+      expect(written).toContain("foo: bar");
     });
 
     it("should succeed when property does not exist (no-op)", async () => {

--- a/packages/core/tests/unit/services/GroundingExecutor.test.ts
+++ b/packages/core/tests/unit/services/GroundingExecutor.test.ts
@@ -406,10 +406,20 @@ describe("GroundingExecutor", () => {
      * `namespace_`, which is not valid YAML at all: the whole frontmatter block
      * stops parsing and the asset disappears from Obsidian AND the RDF graph.
      *
-     * This is not hypothetical — `218ed4dd-…` in `exoas-shared-identities`
-     * carries `namespace_aliases` and is mounted in all three vaults. No prior
-     * fixture had a colliding neighbour, which is exactly why eight otherwise
-     * green revert-verify axes could not see it.
+     * ⚠ Stated precisely: the collision is STRUCTURALLY reachable, not a
+     * demonstrated live corruption. An earlier draft of this docstring cited
+     * `218ed4dd-…` as proof; checking it showed `namespace_aliases` sits in that
+     * asset's BODY (inside a ```yaml fence), and these primitives only ever see
+     * `parse().content` — i.e. the frontmatter — so that occurrence is
+     * unreachable through them. What IS reachable: the searched name comes from
+     * vault data (`grounding.targetProperty`), CLI flags and user-edited
+     * property rows, so it is not a closed set, and canonicalisation shortened
+     * it to one of four ordinary English words. Both colliding SHAPES exist in
+     * shipped frontmatter — see `FrontmatterService.keyAnchoring.test.ts`, which
+     * covers the three anchors this axis cannot reach.
+     *
+     * No prior fixture had a colliding neighbour, which is exactly why eight
+     * otherwise-green revert-verify axes could not see this.
      */
     it("does NOT touch a neighbouring key that merely ENDS with the canonical name @req:869561bf-ae02-4028-bc6a-b32cfabda1ed", async () => {
       reader.readFile.mockResolvedValue(

--- a/packages/core/tests/utilities/FrontmatterService.keyAnchoring.test.ts
+++ b/packages/core/tests/utilities/FrontmatterService.keyAnchoring.test.ts
@@ -1,0 +1,131 @@
+/**
+ * req 869561bf — the frontmatter primitives must match a property key ONLY at
+ * line start.
+ *
+ * Why this file exists separately from the GroundingExecutor axes: `hasProperty`
+ * gates BOTH writers, so on a fixture that carries only the colliding neighbour
+ * the gate returns false and the inner regexes are never reached. Those axes
+ * therefore exercise exactly one of the four anchors. Un-anchoring
+ * `updateProperty` / `removeProperty` / `getPropertyValue` passes the whole
+ * suite green — which is the same shape of blind spot that let the original
+ * collision survive eight otherwise-green revert-verify axes. Reaching them
+ * needs a fixture where BOTH the real key and the colliding text are present.
+ *
+ * Two collision shapes, both present in shipped frontmatter:
+ *  1. a NEIGHBOURING KEY ending in the searched word (`namespace_aliases` vs
+ *     `aliases`);
+ *  2. the searched word followed by `:` INSIDE A VALUE or an array item — e.g.
+ *     `packages/exoas-exocmd/exocmd/059605d1-….md` carries
+ *     `exo__Asset_label: "PropertyDefault: exo__Instance_class = …"` and the
+ *     same string as an `aliases` item.
+ *
+ * The collision is STRUCTURALLY reachable rather than a demonstrated live
+ * corruption: the searched name comes from vault data (`grounding.targetProperty`),
+ * CLI flags and user-edited property rows, so it is not a closed set — and
+ * canonicalisation (req 869561bf) shortened the searched key to one of four
+ * ordinary English words, which widened the surface considerably.
+ *
+ * Revert-verify: removing the `^` / `(?:\n|^)` anchor from ANY of the three
+ * inner matchers reddens this file; `hasProperty`'s anchor is covered by the
+ * GroundingExecutor axes.
+ */
+import { describe, it, expect } from "@jest/globals";
+import * as yaml from "js-yaml";
+import { FrontmatterService } from "../../src/utilities/FrontmatterService";
+
+/** Neighbour FIRST, so the gate passes on the real key and the inner matchers run. */
+const NEIGHBOUR_THEN_REAL = [
+  "---",
+  'namespace_aliases:',
+  '  - "ims"',
+  '  - "concept"',
+  'aliases:',
+  '  - "Real alias"',
+  "foo: bar",
+  "---",
+  "Body",
+].join("\n");
+
+function frontmatterOf(content: string): Record<string, unknown> {
+  const m = /^---\n([\s\S]*?)\n---/.exec(content);
+  if (!m) throw new Error("no frontmatter");
+  return (yaml.load(m[1]) ?? {}) as Record<string, unknown>;
+}
+
+describe("FrontmatterService — key matching is anchored to line start (req 869561bf)", () => {
+  const fm = new FrontmatterService();
+
+  it("removeProperty removes ONLY the real key, leaving the colliding neighbour whole", () => {
+    const out = fm.removeProperty(NEIGHBOUR_THEN_REAL, "aliases");
+    const parsed = frontmatterOf(out);
+
+    expect(parsed.aliases).toBeUndefined();
+    // un-anchored, the match started inside `namespace_aliases:` and truncated
+    // it to a bare `namespace_` — not valid YAML, so the whole block stopped
+    // parsing and the asset dropped out of Obsidian AND the RDF graph
+    expect(parsed.namespace_aliases).toEqual(["ims", "concept"]);
+    expect(parsed.foo).toBe("bar");
+    expect(out).not.toContain("namespace_\n");
+  });
+
+  it("updateProperty rewrites ONLY the real key, leaving the colliding neighbour whole", () => {
+    const out = fm.updateProperty(NEIGHBOUR_THEN_REAL, "aliases", '"Replaced"');
+    const parsed = frontmatterOf(out);
+
+    expect(parsed.aliases).toBe("Replaced");
+    expect(parsed.namespace_aliases).toEqual(["ims", "concept"]);
+  });
+
+  it("getPropertyValue reads the real key, not the colliding neighbour", () => {
+    // Scalar values here, not block lists: `getPropertyValue` is a scalar
+    // reader (`\s*` in its pattern spans the newline), so a list fixture would
+    // blur the discriminator. With the neighbour FIRST an unanchored read
+    // matched mid-line inside `namespace_aliases:` and returned NEIGHBOUR.
+    const inner = [
+      "namespace_aliases: NEIGHBOUR",
+      "aliases: REAL",
+      "foo: bar",
+    ].join("\n");
+
+    expect(fm.getPropertyValue(inner, "aliases")).toBe("REAL");
+    expect(fm.getPropertyValue(inner, "namespace_aliases")).toBe("NEIGHBOUR");
+    expect(fm.getPropertyValue(inner, "foo")).toBe("bar");
+  });
+
+  it("does not match the searched word when it occurs INSIDE a value", () => {
+    const content = [
+      "---",
+      'exo__Asset_label: "PropertyDefault: exo__Instance_class = $targetClassSelf"',
+      "foo: bar",
+      "---",
+      "Body",
+    ].join("\n");
+
+    // no such KEY exists — the occurrence is inside a value
+    const inner = /^---\n([\s\S]*?)\n---/.exec(content)![1];
+    expect(fm.hasProperty(inner, "PropertyDefault")).toBe(false);
+    expect(fm.getPropertyValue(inner, "PropertyDefault")).toBeNull();
+
+    // …so removing it is a no-op rather than a mid-value cut
+    const out = fm.removeProperty(content, "PropertyDefault");
+    expect(frontmatterOf(out).exo__Asset_label).toBe(
+      "PropertyDefault: exo__Instance_class = $targetClassSelf",
+    );
+  });
+
+  it("does not match the searched word inside an ARRAY ITEM", () => {
+    const content = [
+      "---",
+      "aliases:",
+      '  - "PropertyDefault: exo__Instance_class = $targetClassSelf"',
+      "foo: bar",
+      "---",
+      "Body",
+    ].join("\n");
+
+    const out = fm.removeProperty(content, "PropertyDefault");
+    expect(frontmatterOf(out).aliases).toEqual([
+      "PropertyDefault: exo__Instance_class = $targetClassSelf",
+    ]);
+  });
+});


### PR DESCRIPTION
Req: 869561bf-ae02-4028-bc6a-b32cfabda1ed
Closes ems__Bug 43e41c8f-9c99-46ca-af6b-af99b29a329c

## Root: unreachability, not carelessness

The canonical-YAML-key rule (#3944) maps `exo__Asset_<field>` onto the bare `<field>:` key for the four `UNPREFIXED_ASSET_FIELDS` (`archived`, `draft`, `pinned`, `aliases`). It was **defined inside one package's command folder** (`packages/cli/src/commands/propertyMutationShared.ts`) while the whitelist it consults already lived in core. The core-side writers therefore **could not reach it**, and each diverged in its own way — `GroundingExecutor` wrote a literal, dead `exo__Asset_aliases:` key and lost the string-scalar semantics; `GenericAssetCreationService` checked its self-managed skip-list against the raw name.

So the fix is a **move**, not a patch: put the rule where every writer can reach it.

## Where the rule ended up — and why not at the call sites

Adversarial review found five further writers bypassing it (`property_delete` / `append` / `increment` / `shift`, the `service_call` twins in `packages/services`) plus `create_instance`. Its sharpest point: wiring only `property_set` **created an asymmetry that did not exist before** — a grounding could write an alias via the prefixed spelling but never remove it (`removeProperty` looked for a key that was no longer there → silent no-op).

Both offered remedies were rejected. Wiring five more call sites repeats the very defect this change removes, at larger N; narrowing the requirement would have hidden that the code did not do what it promised. Instead canonicalisation moved into the **four primitives every writer funnels through**:

| primitive | role |
|---|---|
| `FrontmatterService.updateProperty` | set |
| `FrontmatterService.removeProperty` | delete |
| `FrontmatterService.createFrontmatter` | `create_instance` |
| `MetadataHelpers.buildFileContent` | asset creation |

All 17 frontmatter writers across core / cli / services / obsidian-plugin now consult one source — including `PropertyEditorModal`, which review listed as a bypass but which already used the primitives. `GroundingExecutor` no longer decides a write key at all.

Canonicalising in `createFrontmatter` / `buildFileContent` **before** `orderProperties` closes both halves of the `create_instance` defect at once: the key becomes live, and the `STRING_SCALAR_PROPERTIES` lookup inside the serializer (which keys off the emitted name) again keeps a scalar-looking alias a string instead of letting YAML coerce it to a `Date` — the #3750 MEDIUM-3 guarantee.

## The regression that move introduced, and its fix

Round-2 caught it: the primitives matched a key by **unanchored substring**, and canonicalisation makes the searched key **shorter**. `aliases:` began matching any neighbouring key ending in that word, and any occurrence of `aliases:` inside a value. Deleting truncated a neighbouring `namespace_aliases:` to a bare `namespace_` — **not valid YAML**, so the whole frontmatter block stops parsing and the asset drops out of Obsidian *and* the RDF graph.

Fixed by anchoring all four matchers to line start rather than reverting the canonicalisation — anchoring also closes the class for the original long spelling, which was latent on `origin/main`.

⚠ Stated precisely: the collision is **structurally reachable**, not a demonstrated live corruption. An earlier draft of this PR cited asset `218ed4dd-…` as proof; checking it directly showed `namespace_aliases` sits in that asset's **body**, inside a ```yaml fence, and the primitives only ever see `parse().content`. What is reachable: both colliding shapes exist in shipped **frontmatter** (e.g. `packages/exoas-exocmd/exocmd/059605d1-….md` carries `exo__Asset_label: "PropertyDefault: …"` and the same string as an `aliases` item), and the searched name comes from vault data (`grounding.targetProperty`), CLI flags and user-edited property rows — not a closed set — which canonicalisation widened by shortening it to one of four ordinary English words.

## Revert-verify

| axis | neutralise `canonicalYamlKey` | un-anchor the matchers |
|---|---|---|
| core — `property_set` writes `aliases:` | **RED** | — |
| core — `property_delete` symmetry | **RED** | — |
| core — set/delete vs a colliding neighbour | **RED** | **RED** |
| core — `updateProperty` anchor | — | **RED** |
| core — `removeProperty` anchor | — | **RED** |
| core — `getPropertyValue` anchor | — | **RED** ×2 |
| cli — `set-property` / `remove-property` | **RED** ×2 | — |
| cli — `create` refuses the prefixed spelling | **RED** | — |
| cli — `create` writes `archived:` | **RED** | — |
| *controls* (bare key; `exo__Asset_isDefinedBy`; ordinary property) | GREEN | GREEN |

⛤ The per-anchor column exists because round-3 measured that three of the four anchors could be removed with CI still green — the two axes added for the CRITICAL exercised only `hasProperty`, which gates both writers and short-circuits before the inner regexes. That is the same blind spot that let the original collision survive eight otherwise-green axes, so it got its own file: `FrontmatterService.keyAnchoring.test.ts`.

## Requirement correction

Clause 1 of req `869561bf` said "**любой** писатель frontmatter". Review enumerated ~17 production writers that assemble frontmatter without reaching the primitives, so the universal quantifier was false. The requirement has been **narrowed** to the primitives that were actually made single-source, with the bypassers named explicitly — notably `ObsidianVaultAdapter.updateFrontmatter`, the one writer still able to *create* the dead key (pre-existing, not a regression). Published to `exoas-exo-reqs` and verified on remote.

Deliberate non-goals are recorded on `ems__Bug` `43e41c8f` rather than left to dissolve into "review addressed": the `ObsidianVaultAdapter` gap, the `removeProperty`/`normalizeIRI` asymmetry (IRI-shaped names set but do not delete — pre-existing), the CLI-only scope of the `create` refusal, and the sibling silent drop of `exo__Asset_label` / `exo__Instance_class`.

## Tests

- core **358/358** suites (8460 tests)
- cli **153/154** — the single failure, `sparql-exo003.integration`, is pre-existing and unrelated: it spawns the tracked `packages/cli/dist/index.js`, last rebuilt 198 commits ago, and is `describe.skip`-gated in CI. Verified by running it against `origin/main`'s `NoteToRDFConverter` (fails identically).

Three adversarial review rounds: round-1 (8 findings) and round-2 (1 CRITICAL, 1 HIGH, 2 MEDIUM) applied in full; round-3 returned APPROVE with 0 CRITICAL / 0 HIGH, its 1 MEDIUM + 2 LOW applied.
