### PR TITLE
feat(core): property_set refuses an unquoted wikilink value (req 29e0d1b6)

### DIFF
--- a/packages/core/src/services/GroundingExecutor.ts
+++ b/packages/core/src/services/GroundingExecutor.ts
@@ -292,9 +292,20 @@ const MAX_COMPOSITE_DEPTH = 20;
  * quoted form (`"[[uid]]"`, quotes part of the value) is the correct shape and
  * is deliberately NOT matched here.
  *
- * Deliberately narrow: it matches only a value that is ENTIRELY a wikilink
- * (after trimming). A prose value that merely CONTAINS a wikilink is left alone
- * — it is a string either way, so it carries no silent-literal risk.
+ * Scope: the value must be ENTIRELY bracketed (after trimming) — so `[[a]]`, but
+ * also `[[a]] and [[b]]` / `[[a]]\n[[b]]`, which are just as flow-sequence-shaped
+ * and just as lossy; refusing them is intended. A wikilink embedded in
+ * surrounding prose (`see [[a]] for details`) is a string either way, carries no
+ * silent-literal risk, and passes.
+ *
+ * ⛤ Live `targetValueSubstitution` groundings DO carry a wikilink literally
+ * (`"[[8bc0c038-…]]"` → the `$nowLocal` token; 5 occurrences in the pinned
+ * exocmd assetspace). They never reach this guard in that shape because
+ * `CommandResolver` dereferences the wikilink to the target's label first, so
+ * the executor sees `$nowLocal`. That safety is a property of the RESOLVER, not
+ * of the data: were that dereference to stop, those groundings would start
+ * failing here — loudly, which is the correct failure, but the coupling is worth
+ * knowing.
  */
 function isUnquotedWikilink(value: string): boolean {
   // `[\s\S]` rather than `.` + the `s` flag: the root tsconfig targets ES6 and

--- a/packages/core/src/services/GroundingExecutor.ts
+++ b/packages/core/src/services/GroundingExecutor.ts
@@ -284,6 +284,25 @@ export class ServiceRegistry {
 const MAX_COMPOSITE_DEPTH = 20;
 
 /**
+ * req 29e0d1b6 — is this about-to-be-written frontmatter value a BARE (unquoted)
+ * wikilink?
+ *
+ * `[[uid]]` written without surrounding quotes is a YAML flow SEQUENCE, not a
+ * string, so the RDF converter emits a literal and the reference is lost. The
+ * quoted form (`"[[uid]]"`, quotes part of the value) is the correct shape and
+ * is deliberately NOT matched here.
+ *
+ * Deliberately narrow: it matches only a value that is ENTIRELY a wikilink
+ * (after trimming). A prose value that merely CONTAINS a wikilink is left alone
+ * — it is a string either way, so it carries no silent-literal risk.
+ */
+function isUnquotedWikilink(value: string): boolean {
+  // `[\s\S]` rather than `.` + the `s` flag: the root tsconfig targets ES6 and
+  // the dotAll flag is ES2018+ (`TS1501` in CI typecheck).
+  return /^\[\[[\s\S]*\]\]$/.test(value.trim());
+}
+
+/**
  * Executes grounding actions for dynamic commands (RFC-009 §5.4).
  *
  * The "write side" of the Dynamic Command System. Once a precondition passes,
@@ -652,6 +671,40 @@ export class GroundingExecutor {
     const valueToWrite = STRING_SCALAR_PROPERTIES.has(normalizedTargetProperty)
       ? serializeYamlScalar(substitutedValue, true)
       : substitutedValue;
+
+    // req 29e0d1b6 — refuse an UNQUOTED wikilink instead of writing it.
+    //
+    // `updateProperty` writes the value VERBATIM, so a bare `[[uid]]` lands in
+    // the frontmatter unquoted — which YAML parses as a flow SEQUENCE, not a
+    // string. `NoteToRDFConverter` then emits the object as a LITERAL, and the
+    // asset silently drops out of every join on that property. Nothing fails:
+    // the command reports success and `repairFolder` (whose resolver tolerates
+    // both shapes) even relocates the file, so the two parsers disagree with no
+    // error surfacing anywhere. That silent literal is the worst of the three
+    // possible outcomes, and today it is the only one that LOOKS like success.
+    //
+    // We refuse loudly rather than normalize: normalizing (accepting `[[uid]]`,
+    // `"[[uid]]"` and a bare uid alike) would fix the symptom while HIDING the
+    // asymmetry between the two value-source contracts —
+    //   - `targetValueSubstitution` writes the substituted value verbatim, so a
+    //     reference must arrive ALREADY quoted (`"\"[[uid]]\""` from the CLI;
+    //     the plugin's ReferencePicker commits exactly that via
+    //     `toReferenceWikilink`), and
+    //   - `targetValueRef` takes a BARE uid because the executor wraps it here.
+    // The asymmetry is the actual source of confusion; a loud refusal teaches
+    // it. String-scalar properties (label/aliases) are unaffected — they go
+    // through `serializeYamlScalar`, which quotes them before this check.
+    if (isUnquotedWikilink(valueToWrite)) {
+      return {
+        success: false,
+        error:
+          `property_set: value ${valueToWrite} is an UNQUOTED wikilink — YAML reads it as a flow ` +
+          `sequence, so the graph would receive a literal instead of a link (silent data loss). ` +
+          `Pass the QUOTED form for a substituted reference (the quotes are part of the string, ` +
+          `e.g. --input '{"<key>":"\\"[[<uid>]]\\""}'), or use targetValueRef, which takes a BARE ` +
+          `uid and wraps it itself.`,
+      };
+    }
 
     // req faf269bf Scenarios 1+3 — resolve WHICH asset this step writes into.
     // Absent `targetQuery` (every existing grounding) keeps `filePath` exactly

--- a/packages/core/tests/integration/grounding-unquoted-wikilink-guard.integration.test.ts
+++ b/packages/core/tests/integration/grounding-unquoted-wikilink-guard.integration.test.ts
@@ -1,0 +1,174 @@
+/**
+ * req 29e0d1b6 — `property_set` refuses an UNQUOTED wikilink instead of writing
+ * a silent literal into the graph.
+ *
+ * Production-shape: drives the REAL `GroundingExecutor.execute` over the REAL
+ * `FrontmatterService` write path (only the filesystem ports are faked), and
+ * parses the written frontmatter with the REAL YAML parser — because the whole
+ * defect is a YAML-parse disagreement (a bare `[[uid]]` is a flow SEQUENCE, so
+ * the converter emits a literal and the reference is lost) that no assertion on
+ * the raw string could honestly demonstrate.
+ */
+import * as yaml from "js-yaml";
+
+import {
+  GroundingExecutor,
+  ServiceRegistry,
+} from "../../src/services/GroundingExecutor";
+import { GroundingType } from "../../src/domain/constants/GroundingType";
+import { GroundingDefinition } from "../../src/domain/models/CommandDefinition";
+
+const TARGET_IRI = "obsidian://vault/assetspaces/kitelev/exoas-my/task.md";
+const FILE_PATH = "assetspaces/kitelev/exoas-my/task.md";
+const ONTOLOGY_UID = "9d1d2e9d-3f9e-4c6a-9a3f-0f2a1c6b7e11";
+
+const TARGET_CONTENT = [
+  "---",
+  "exo__Asset_uid: 11111111-2222-3333-4444-555555555555",
+  'exo__Asset_label: "Some task"',
+  'exo__Asset_isDefinedBy: "[[00000000-0000-4000-8000-000000000000]]"',
+  "---",
+  "Body",
+].join("\n");
+
+function makeReader(content = TARGET_CONTENT) {
+  return {
+    readFile: jest.fn().mockResolvedValue(content),
+    fileExists: jest.fn().mockResolvedValue(true),
+    getMarkdownFiles: jest.fn().mockResolvedValue([]),
+  };
+}
+
+function makeWriter() {
+  return {
+    createFile: jest.fn().mockResolvedValue(""),
+    writeFile: jest.fn().mockResolvedValue(undefined),
+    updateFile: jest.fn().mockResolvedValue(undefined),
+    deleteFile: jest.fn().mockResolvedValue(undefined),
+    renameFile: jest.fn().mockResolvedValue(undefined),
+  };
+}
+
+function makeGrounding(overrides: Record<string, unknown>): GroundingDefinition {
+  return {
+    id: "gnd-req-29e0d1b6",
+    label: "Set Ontology (fixture)",
+    type: GroundingType.PROPERTY_SET,
+    ...overrides,
+  } as unknown as GroundingDefinition;
+}
+
+/** Parse the frontmatter block of a written note with the real YAML parser. */
+function parseFrontmatter(written: string): Record<string, unknown> {
+  const match = /^---\n([\s\S]*?)\n---/.exec(written);
+  expect(match).not.toBeNull();
+  return yaml.load((match as RegExpExecArray)[1]) as Record<string, unknown>;
+}
+
+describe("req 29e0d1b6 — property_set rejects an unquoted wikilink value", () => {
+  let reader: ReturnType<typeof makeReader>;
+  let writer: ReturnType<typeof makeWriter>;
+  let executor: GroundingExecutor;
+
+  beforeEach(() => {
+    reader = makeReader();
+    writer = makeWriter();
+    executor = new GroundingExecutor(reader, writer, new ServiceRegistry());
+  });
+
+  const substitutionGrounding = () =>
+    makeGrounding({
+      targetProperty: "exo__Asset_isDefinedBy",
+      targetValueSubstitution: "$input.ontology",
+    });
+
+  it("Scenario 1: @req:29e0d1b6 refuses the bare [[uid]] form and writes nothing", async () => {
+    const result = await executor.execute(
+      substitutionGrounding(),
+      TARGET_IRI,
+      FILE_PATH,
+      { ontology: `[[${ONTOLOGY_UID}]]` },
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/UNQUOTED wikilink/);
+    // The message must teach BOTH contracts — the asymmetry is the defect.
+    expect(result.error).toMatch(/targetValueRef/);
+    expect(result.error).toContain(ONTOLOGY_UID);
+    expect(writer.updateFile).not.toHaveBeenCalled();
+  });
+
+  it('Scenario 2: @req:29e0d1b6 accepts the quoted "[[uid]]" form and YAML reads it as a string', async () => {
+    const result = await executor.execute(
+      substitutionGrounding(),
+      TARGET_IRI,
+      FILE_PATH,
+      { ontology: `"[[${ONTOLOGY_UID}]]"` },
+    );
+
+    expect(result.success).toBe(true);
+    expect(writer.updateFile).toHaveBeenCalledTimes(1);
+    const written = writer.updateFile.mock.calls[0][1] as string;
+    expect(written).toContain(`exo__Asset_isDefinedBy: "[[${ONTOLOGY_UID}]]"`);
+
+    // The load-bearing half: a STRING (resolvable reference), never a sequence.
+    const fm = parseFrontmatter(written);
+    expect(typeof fm.exo__Asset_isDefinedBy).toBe("string");
+    expect(fm.exo__Asset_isDefinedBy).toBe(`[[${ONTOLOGY_UID}]]`);
+  });
+
+  it("Scenario 3: @req:29e0d1b6 the sibling targetValueRef contract (bare uid) is unaffected", async () => {
+    const result = await executor.execute(
+      makeGrounding({
+        targetProperty: "exo__Asset_isDefinedBy",
+        targetValueRef: ONTOLOGY_UID,
+      }),
+      TARGET_IRI,
+      FILE_PATH,
+    );
+
+    expect(result.success).toBe(true);
+    const written = writer.updateFile.mock.calls[0][1] as string;
+    const fm = parseFrontmatter(written);
+    expect(typeof fm.exo__Asset_isDefinedBy).toBe("string");
+    expect(fm.exo__Asset_isDefinedBy).toBe(`[[${ONTOLOGY_UID}]]`);
+  });
+
+  it("Scenario 4: @req:29e0d1b6 non-reference substituted values are unaffected", async () => {
+    // (a) a plain label on a string-scalar property — quoted by
+    //     serializeYamlScalar BEFORE the guard, so it must still pass.
+    const labelResult = await executor.execute(
+      makeGrounding({
+        targetProperty: "exo__Asset_label",
+        targetValueSubstitution: "$input.label",
+      }),
+      TARGET_IRI,
+      FILE_PATH,
+      { label: "Quarterly review" },
+    );
+    expect(labelResult.success).toBe(true);
+
+    // (b) prose that merely CONTAINS a wikilink is a string either way — it
+    //     carries no silent-literal risk, so the guard must leave it alone.
+    const proseWriter = makeWriter();
+    const proseExecutor = new GroundingExecutor(
+      makeReader(),
+      proseWriter,
+      new ServiceRegistry(),
+    );
+    const proseResult = await proseExecutor.execute(
+      makeGrounding({
+        targetProperty: "ems__Effort_result",
+        targetValueSubstitution: "$input.note",
+      }),
+      TARGET_IRI,
+      FILE_PATH,
+      { note: `see [[${ONTOLOGY_UID}]] for details` },
+    );
+    expect(proseResult.success).toBe(true);
+    const proseWritten = proseWriter.updateFile.mock.calls[0][1] as string;
+    expect(proseWritten).toContain(
+      `ems__Effort_result: see [[${ONTOLOGY_UID}]] for details`,
+    );
+  });
+});

--- a/packages/core/tests/unit/services/GroundingExecutor.test.ts
+++ b/packages/core/tests/unit/services/GroundingExecutor.test.ts
@@ -184,7 +184,11 @@ describe("GroundingExecutor", () => {
       const grounding = makeGrounding({
         type: GroundingType.PROPERTY_SET,
         targetProperty: "exo__Asset_isDefinedBy",
-        targetValueLiteral: "[[some-anchor]]",
+        // req 29e0d1b6 — the reference is spelled in its QUOTED form (the quotes
+        // are part of the value). A bare `[[some-anchor]]` would be written
+        // verbatim and read back by YAML as a flow sequence, so it is now
+        // refused. Immaterial to THIS test, whose axis is the write KEY.
+        targetValueLiteral: '"[[some-anchor]]"',
       });
 
       const result = await executor.execute(grounding, TARGET_IRI, FILE_PATH);


### PR DESCRIPTION
## Что и почему

`property_set` пишет разрешённое значение во frontmatter **дословно**. Поэтому естественная
CLI-форма ссылки — `--input '{"ontology":"[[uid]]"}'` — попадает в файл **незакавыченной**, а это
YAML **flow-sequence**, не строка:

```js
yaml.load('exo__Asset_isDefinedBy: [[uid]]')    // -> { exo__Asset_isDefinedBy: [ [ 'uid' ] ] }
yaml.load('exo__Asset_isDefinedBy: "[[uid]]"')  // -> { exo__Asset_isDefinedBy: '[[uid]]' }
```

`NoteToRDFConverter` эмитит объект **литералом**, и ассет выпадает из любого join по этому
свойству. При этом команда **рапортует успех**, а `repairFolder` (его резолвер толерантен к обеим
формам) даже корректно переносит файл — два парсера расходятся, и наружу не выходит ни ошибки,
ни предупреждения. Молчаливый литерал — худший из трёх исходов, и сейчас он же единственный,
который выглядит успехом.

## Решение — громкий отказ, НЕ нормализация

Нормализация («приму и `[[uid]]`, и `"[[uid]]"`, и голый UID») починила бы симптом и **спрятала
асимметрию** двух value-source-контрактов:

| value-source | что делает executor | что обязан передать вызывающий |
|---|---|---|
| `targetValueSubstitution` | пишет подставленное **дословно** | **уже закавыченный** `"[[uid]]"` (ровно это коммитит `ReferencePicker` → `toReferenceWikilink`) |
| `targetValueRef` | оборачивает сам | **голый** uid |

Именно эта асимметрия — источник путаницы, и громкий отказ ей учит. Поверхность шире одной
команды: её имеет **любой** `property_set`, чьё значение — ссылка.

## Не затронуто

- **String-scalar свойства** (`exo__Asset_label`, `aliases`) — они проходят через
  `serializeYamlScalar` **до** гарда, то есть приезжают уже закавыченными.
- **`targetValueRef` / `targetValueQuery`** — они и так производят закавыченную форму.
- **Проза, лишь СОДЕРЖАЩАЯ** wikilink, — это строка в любом случае, риска молчаливого литерала
  нет, гард её не трогает (матчится только значение, целиком являющееся wikilink).

Регрессий нет эмпирически: полный `packages/core` — **365 сьютов / 8515 тестов зелёные**
(⇒ ни один существующий grounding не пишет голый wikilink).

## Revert-verify

`if (false && isUnquotedWikilink(valueToWrite))` → **RED ровно Scenario 1** (голая форма снова
пишется молча, `Expected: false / Received: true`); Scenarios 2-4 (закавыченная форма,
`targetValueRef`, не-ссылочные значения) остаются GREEN — non-vacuity. Restore → 4/4 GREEN.

Req: `29e0d1b6-3863-4af3-8807-02e546b0817a`
(approved, https://github.com/kitelev/exoas-exo-reqs/blob/main/exo-reqs/29e0d1b6-3863-4af3-8807-02e546b0817a.md)

Источник задачи: vault `34376823-9fc2-44a1-a5cf-7ae07afce4e3` (ALP).
