### PR TITLE
docs(core): mark archiveAsset terminal and irreversible

### DIFF
--- a/packages/core/src/services/ArchiveAssetService.ts
+++ b/packages/core/src/services/ArchiveAssetService.ts
@@ -14,6 +14,20 @@ import { FrontmatterService } from "../utilities/FrontmatterService";
  * (StatusCommandExecutor): in-place frontmatter mutation, no physical
  * file move. Batch cross-vault archival remains the separate domain of
  * `ArchiveService` / `cli archive`.
+ *
+ * ⛔ TERMINAL AND IRREVERSIBLE — do not reuse for reversible archiving.
+ * The `aliases` removal above is DESTRUCTIVE: the values are dropped, not
+ * stashed anywhere, so nothing can restore them. There is deliberately no
+ * `unarchive` service in this codebase; the similarly-named
+ * "Un-archive Ontologically" command reverses a DIFFERENT operation
+ * ("Archive Ontologically" — isDefinedBy re-anchor + folder relocate) and
+ * is not this service's counterpart. Name adjacency in the command palette
+ * makes that easy to misread.
+ *
+ * For archiving that must be undoable (e.g. an `ems__Area` that can become
+ * active again once efforts appear under it), use a plain
+ * `property_set archived="true"` grounding instead — it leaves `aliases`
+ * untouched, so the round-trip diff is a single `updatedAt` line.
  */
 @injectable()
 export class ArchiveAssetService {


### PR DESCRIPTION
Комментарий-только, поведение не меняется.

## Почему
`archiveAsset` удаляет `aliases` **без резерва** — восстановить нечем. Сервиса `unarchive` в кодовой базе нет вовсе; похоже названная команда «Un-archive Ontologically» отменяет **другую** операцию (переанкеривание `isDefinedBy` + перенос папки), а не эту. Соседство имён в палитре читается как обратимость.

Это едва не привело к переиспользованию команды для **обратимой** архивации зон (`ems__Area`, которые оживают при появлении эффортов) — там потеря алиасов была бы безвозвратной. Сессия отказалась от неё и взяла чистый `property_set archived=true`, round-trip на котором даёт дифф в одну строку `updatedAt`.

## Что сделано
Docstring `ArchiveAssetService` теперь называет операцию терминальной, объясняет, что «Un-archive Ontologically» ей не парный, и указывает канон для обратимого случая.

Зеркальные предупреждения уже отгружены в vault (`exoas-exocmd@dc7d235`) на командe «Archive Completed» (`52c88678`) и на самом grounding (`eb3bb751`) — там их читает тот, кто выбирает команду.

## Проверка
Изменение — только блок комментария; `git diff --stat` = 14 insertions, 0 deletions в одном файле.

https://claude.ai/code/session_01K5pPx7vBfetRsisLyPMQPL