### PR TITLE
feat(profile): type dependsOn edges (hard/soft), read the kind from the graph

### DIFF
--- a/packages/obsidian-plugin/src/domain/profile/closureGap.ts
+++ b/packages/obsidian-plugin/src/domain/profile/closureGap.ts
@@ -1,5 +1,6 @@
 import { transitiveDependsOnClosure } from "@kitelev/exocortex-core";
 import type { AssetSpaceInfo } from "../../infrastructure/adapters/AssetSpaceManager";
+import { resolveDependencyKind } from "./dependencyKind";
 
 /**
  * issue #3956 — one member of a mount's `exo__AssetSpace_dependsOn` closure that
@@ -16,28 +17,43 @@ export interface UnmountedClosureMember {
   /**
    * True when this AssetSpace supplies class / command-binding-resolution TBox
    * whose absence silently breaks homoiconic commands + SHACL validation
-   * (#3956): the `exo` SDK floor + the `exocmd` command TBox. Only knowable when
-   * the descriptor is scanned (namespace present).
+   * (#3956).
+   *
+   * req `18ecf16f` — read from the graph (`exo__AssetSpace_dependsOnKind` on the
+   * AssetSpace's own registry descriptor), no longer from a hardcoded namespace
+   * list. A member with NO scanned descriptor is therefore now reported as
+   * `true`, not `false` — it can never be materialized, and defaulting an
+   * unknown to "harmless content" is the one direction that loses types
+   * silently.
    */
   providesTBox: boolean;
 }
 
 /**
- * The namespaces whose AssetSpace supplies command/binding-resolution TBox.
- * `exo` = the class/property defs + the RDF engine floor; `exocmd` = the
- * `exocmd__Command`/`Precondition`/`Grounding`/`CommandBinding` class defs +
- * grounding-type enums that `CommandResolver.loadCommand` matches `rdf:type`
- * against. Their absence is the exact gap that left the alpha tester's entire
- * homoiconic command system silently dead (RFC 430e84f1 P3).
- *
- * Exported so the REVERSE check (`unmountSafety.ts`, req `d5bc68f6` — "who
- * still needs the pack I am about to remove?") shares this single source of
- * truth with the forward check below, instead of duplicating the list.
+ * req `18ecf16f` — a HARD-edge closure member the effective set omits. Thrown
+ * BEFORE any mount-state mutation, beside the TS-floor assertion, so a profile
+ * that would leave a class-definition provider unmounted refuses loudly instead
+ * of producing a vault whose assets silently lose their type.
  */
-export const TBOX_PROVIDER_NAMESPACES: ReadonlySet<string> = new Set([
-  "exo",
-  "exocmd",
-]);
+export class OmittedHardDependencyError extends Error {
+  /** The omitted hard members, in closure order. */
+  public readonly omitted: ReadonlyArray<UnmountedClosureMember>;
+
+  constructor(omitted: ReadonlyArray<UnmountedClosureMember>) {
+    const names = omitted.map((m) => m.label).join(", ");
+    const one = omitted.length === 1;
+    super(
+      `Profile omits {${names}}, which ${one ? "supplies" : "supply"} class / ` +
+        `command definitions (exo__AssetSpace_dependsOnKind = ` +
+        `exo__DependencyKindTBox). Applying it would leave assets without a ` +
+        `resolvable type. Add ${one ? "it" : "them"} to the profile, or mark ` +
+        `${one ? "it" : "them"} exo__DependencyKindReference if ` +
+        `${one ? "it supplies" : "they supply"} content only.`,
+    );
+    this.name = "OmittedHardDependencyError";
+    this.omitted = omitted;
+  }
+}
 
 /**
  * issue #3956 — the transitive `exo__AssetSpace_dependsOn` closure members of
@@ -75,17 +91,61 @@ export function detectUnmountedClosureMembers(
     }
   }
   const closure = transitiveDependsOnClosure(new Set(roots), dependsOnMap);
+  return describeOmittedMembers(closure, materializedUids, infoByUid);
+}
+
+/**
+ * req `18ecf16f` — the shared "closure minus present" description used by both
+ * the post-apply WARNING ({@link detectUnmountedClosureMembers}) and the
+ * pre-mutation REFUSAL ({@link assertHardDependenciesSatisfied}), so the two
+ * gates can never disagree about which members are hard.
+ */
+function describeOmittedMembers(
+  closure: Iterable<string>,
+  presentUids: ReadonlySet<string>,
+  infoByUid: ReadonlyMap<string, AssetSpaceInfo>,
+): UnmountedClosureMember[] {
   const missing: UnmountedClosureMember[] = [];
   for (const uid of closure) {
-    if (materializedUids.has(uid)) continue;
-    const namespace = infoByUid.get(uid)?.namespace ?? "";
+    if (presentUids.has(uid)) continue;
+    const info = infoByUid.get(uid);
+    const namespace = info?.namespace ?? "";
     missing.push({
       uid,
       label: namespace.length > 0 ? namespace : uid.slice(0, 8),
-      providesTBox: TBOX_PROVIDER_NAMESPACES.has(namespace),
+      providesTBox: resolveDependencyKind(info?.dependsOnKind) === "tbox",
     });
   }
   return missing;
+}
+
+/**
+ * req `18ecf16f` — REFUSE, before any mutation, when the effective set omits a
+ * HARD-edge member of the dependsOn closure.
+ *
+ * Pure. The caller passes the closure it already computed (so this gate judges
+ * exactly the set the apply will act on) plus the effective set. A member with
+ * no scanned descriptor counts as hard — `resolveDependencyKind(undefined)` is
+ * `"tbox"` — which is deliberate: such a member can never be materialized, and
+ * it is precisely the silent-drop path
+ * (`resolveDeclaredAndEffective` keeps only closure members that have a
+ * descriptor) that this gate exists to make loud.
+ *
+ * @throws OmittedHardDependencyError when at least one hard member is omitted.
+ */
+export function assertHardDependenciesSatisfied(
+  closure: Iterable<string>,
+  effectiveUids: ReadonlySet<string>,
+  allInfos: ReadonlyArray<AssetSpaceInfo>,
+): void {
+  const infoByUid = new Map<string, AssetSpaceInfo>();
+  for (const info of allInfos) infoByUid.set(info.uid, info);
+  const omittedHard = describeOmittedMembers(
+    closure,
+    effectiveUids,
+    infoByUid,
+  ).filter((m) => m.providesTBox);
+  if (omittedHard.length > 0) throw new OmittedHardDependencyError(omittedHard);
 }
 
 /**

--- a/packages/obsidian-plugin/src/domain/profile/dependencyKind.ts
+++ b/packages/obsidian-plugin/src/domain/profile/dependencyKind.ts
@@ -1,0 +1,83 @@
+/**
+ * req `18ecf16f` — the KIND of an `exo__AssetSpace_dependsOn` dependency, read
+ * from the graph instead of a hardcoded namespace list.
+ *
+ * ## Why this is a property of the TARGET node, not of the edge
+ *
+ * `exo__AssetSpace_dependsOn` is 0..N while `exo__AssetSpace_dependsOnKind` is
+ * 0..1, so a per-edge reading is not expressible: an AssetSpace with three
+ * dependencies would have one slot for all three. The kind therefore lives on
+ * the **target's** registry descriptor and answers "what does depending on THIS
+ * AssetSpace mean?". Measured 2026-08-06 across all 47 `dependsOn` edges of the
+ * live registry: no target is a TBox provider for one depender and mere content
+ * for another, so nothing is lost by the node reading. The namespace allow-list
+ * this replaces was already evaluated against the TARGET's namespace, i.e. it
+ * was a node property in all but name.
+ *
+ * ## Why the hardcode had to go (homoiconicity Q1 — and it was also wrong)
+ *
+ * Which AssetSpaces supply class definitions is user-configurable semantics: the
+ * user adds AssetSpaces, so the answer cannot live in a TS `Set`. It was also
+ * factually wrong — measured on the live graph, `exoas-public` supplies class
+ * definitions to 13478 cross-boundary assets and `exoas-dec` to 2163, against
+ * `exocmd`'s 268, yet only `{exo, exocmd}` counted as providers.
+ *
+ * ## Why the enum UIDs stay in TS
+ *
+ * The MAPPING (which AssetSpace is which kind) is graph data; these two UIDs are
+ * the vocabulary needed to interpret it — the same shape as the class UIDs other
+ * homoiconic subsystems pin (`SETTING_CLASS_UID`, `DISPLAY_NAME_SPEC_CLASS_UID`,
+ * `PRINTED_PROPERTY_CLASS_UID`). That is Q3 (core processing), not Q1.
+ */
+
+/** `exo__DependencyKindTBox` — hard edge: supplies definitions, cannot be parked. */
+export const DEPENDENCY_KIND_TBOX_UID = "e1d7fb5c-d334-448d-935b-953b7b033e78";
+
+/** `exo__DependencyKindReference` — soft edge: content only, parkable. */
+export const DEPENDENCY_KIND_REFERENCE_UID =
+  "fe529085-5370-4ac0-bbe4-1c7351242dee";
+
+/**
+ * `"tbox"` — depending on this AssetSpace means depending on its class /
+ * command definitions; unmounting it silently breaks type resolution.
+ * `"reference"` — content only; unmounting it costs reachability, not types.
+ */
+export type DependencyKind = "tbox" | "reference";
+
+/** Lower-cased symbolic local name the RDF converter emits for the soft value. */
+const REFERENCE_LOCAL_NAME = "dependencykindreference";
+
+/**
+ * req `18ecf16f` — resolve `exo__AssetSpace_dependsOnKind` from raw frontmatter.
+ *
+ * **The safe default is structural, not a fallback branch:** `"reference"` is
+ * returned ONLY on a positive match of the known soft value. Absent, empty,
+ * unrecognised, wrong-typed — every other input yields `"tbox"`. A wrong
+ * `"reference"` silently loses a class type at runtime; a wrong `"tbox"` only
+ * costs an extra refusal, so the unsafe outcome is the one made to require
+ * evidence.
+ *
+ * Accepts every form the value can reach the plugin in, because the plugin reads
+ * FRONTMATTER (`metadataCache`) while the graph emits the same value as a
+ * symbolic IRI (its label parses as `prefix__Local`, so the converter substitutes
+ * it) — an author or a migration may legitimately produce either:
+ * `[[<uid>]]`, `[[<uid>|exo__DependencyKindReference]]`, a bare UID,
+ * `exo__DependencyKindReference`, or the full `…/exo#DependencyKindReference` IRI.
+ * A one-element array is unwrapped (`Single` cardinality, but `metadataCache`
+ * hands back a list when the author writes YAML list syntax).
+ *
+ * When BOTH a known UID and a conflicting symbolic name are present (a
+ * mismatched alias such as `[[<tbox-uid>|exo__DependencyKindReference]]`), the
+ * UID wins — it is the link target, i.e. what the graph actually resolves.
+ */
+export function resolveDependencyKind(raw: unknown): DependencyKind {
+  const value = Array.isArray(raw) ? raw[0] : raw;
+  if (typeof value !== "string") return "tbox";
+  const normalized = value.toLowerCase();
+  // UID first: it is the link target and therefore authoritative over an alias.
+  if (normalized.includes(DEPENDENCY_KIND_TBOX_UID)) return "tbox";
+  if (normalized.includes(DEPENDENCY_KIND_REFERENCE_UID)) return "reference";
+  // No known UID — fall back to the symbolic form the RDF converter emits.
+  if (normalized.includes(REFERENCE_LOCAL_NAME)) return "reference";
+  return "tbox";
+}

--- a/packages/obsidian-plugin/src/domain/profile/unmountSafety.ts
+++ b/packages/obsidian-plugin/src/domain/profile/unmountSafety.ts
@@ -1,6 +1,6 @@
 import { transitiveDependsOnClosure } from "@kitelev/exocortex-core";
 import type { AssetSpaceInfo } from "../../infrastructure/adapters/AssetSpaceManager";
-import { TBOX_PROVIDER_NAMESPACES } from "./closureGap";
+import { resolveDependencyKind } from "./dependencyKind";
 
 /**
  * req `d5bc68f6` — the blast radius of REMOVING a knowledge pack, assessed
@@ -52,9 +52,14 @@ export interface UnmountRisk {
   /** Distinct files outside the pack that contain those links. */
   linkingFiles: number;
   /**
-   * The pack supplies the class / command-binding-resolution TBox
-   * ({@link TBOX_PROVIDER_NAMESPACES}) — removing it breaks homoiconic commands
-   * and validation silently rather than loudly.
+   * The pack supplies the class / command-binding-resolution TBox — removing it
+   * breaks homoiconic commands and validation silently rather than loudly.
+   *
+   * req `18ecf16f` — resolved from the graph (`exo__AssetSpace_dependsOnKind` on
+   * the pack's own registry descriptor) via {@link resolveDependencyKind}, not
+   * from a hardcoded namespace list. A pack with no scanned descriptor, or with
+   * no kind recorded, counts as a provider — the safe direction for a
+   * DESTRUCTIVE operation.
    */
   providesTBox: boolean;
 }
@@ -155,6 +160,10 @@ export function assessUnmountRisk(
     target.submodulePath,
     resolvedLinks,
   );
+  // req 18ecf16f — the kind lives on the pack's own descriptor, so it is looked
+  // up in the catalogue this function already receives; `UnmountTarget` keeps
+  // its shape (the pick sites need not learn about the kind).
+  const kindRaw = allInfos.find((i) => i.uid === target.uid)?.dependsOnKind;
   return {
     dependents: findDependentMountedAssetSpaces(
       target.uid,
@@ -163,7 +172,7 @@ export function assessUnmountRisk(
     ),
     incomingLinks: links,
     linkingFiles: files,
-    providesTBox: TBOX_PROVIDER_NAMESPACES.has(target.namespace),
+    providesTBox: resolveDependencyKind(kindRaw) === "tbox",
   };
 }
 

--- a/packages/obsidian-plugin/src/infrastructure/adapters/AssetSpaceManager.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/AssetSpaceManager.ts
@@ -46,6 +46,14 @@ export interface AssetSpaceInfo {
    * Empty/absent when the descriptor declares no dependencies.
    */
   dependsOn?: string[];
+  /**
+   * req `18ecf16f` — RAW `exo__AssetSpace_dependsOnKind` value: what depending
+   * on THIS AssetSpace means (`exo__DependencyKindTBox` = hard, supplies class /
+   * command definitions; `exo__DependencyKindReference` = soft, content only).
+   * Kept raw and interpreted by `resolveDependencyKind`, which treats absent and
+   * unrecognised alike as HARD — the safe default.
+   */
+  dependsOnKind?: string;
 }
 
 export interface AssetSpaceManagerOptions {

--- a/packages/obsidian-plugin/src/infrastructure/adapters/ProfileApplyManager.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/ProfileApplyManager.ts
@@ -12,6 +12,7 @@ import {
 } from "@kitelev/exocortex-core";
 
 import {
+  assertHardDependenciesSatisfied,
   detectUnmountedClosureMembers,
   formatClosureGapWarning,
 } from "../../domain/profile/closureGap";
@@ -2658,6 +2659,18 @@ export class ProfileApplyManager {
       declaredAsUids,
       namespaceByUid,
     );
+    // req 18ecf16f — REFUSE before any mutation when the effective set omits a
+    // HARD-edge closure member (a class / command-definition provider). Runs
+    // AFTER the floor reconcile so it judges the set apply will actually mount,
+    // and beside assertTsFloor so both pre-mutation invariants live at one gate.
+    // The closure is passed in (not recomputed) so the gate and the apply can
+    // never disagree; a closure member with no scanned descriptor is exactly the
+    // silent-drop path `declaredAsUids` filters out above, and counts as hard.
+    assertHardDependenciesSatisfied(
+      declaredOntologySet,
+      effectiveAsUids,
+      allInfos,
+    );
     return { declaredAsUids, declaredNamespaces, effectiveAsUids };
   }
 
@@ -2742,13 +2755,25 @@ export class ProfileApplyManager {
       // EKA Alpha D18 dependsOn DAG (issue #3511) — transitive-dep edges so a
       // leaf-only profile can be expanded to its closure.
       const dependsOn = parseDependsOnWikilinks(fm["exo__AssetSpace_dependsOn"]);
+      // req 18ecf16f — kept RAW; `resolveDependencyKind` interprets every form
+      // the value can arrive in and defaults absent/unrecognised to HARD.
+      const rawKind = fm["exo__AssetSpace_dependsOnKind"];
+      const dependsOnKind = typeof rawKind === "string" ? rawKind : undefined;
       // RFC 01a83de8 Phase 1b T3 — folder = derived mount path
       // (`assetspaces/<owner>/<repo>`), not the descriptor's parent folder
       // (post-migration the descriptor lives in the registry). parentFolderOf
       // is a defensive fallback for unresolvable sources.
       const folderName = derivePath(git) ?? parentFolderOf(file.path);
       seen.add(uid);
-      out.push({ uid, git, namespace, folderName, lastPulledSha, dependsOn });
+      out.push({
+        uid,
+        git,
+        namespace,
+        folderName,
+        lastPulledSha,
+        dependsOn,
+        dependsOnKind,
+      });
     }
     return out;
   }

--- a/packages/obsidian-plugin/tests/unit/ProfileApplyManager.restApply.test.ts
+++ b/packages/obsidian-plugin/tests/unit/ProfileApplyManager.restApply.test.ts
@@ -36,6 +36,7 @@ import {
   type ProfileResolution,
   type SwitchSettings,
 } from "../../src/infrastructure/adapters/ProfileApplyManager";
+import { OmittedHardDependencyError } from "../../src/domain/profile/closureGap";
 import { PluginLockManager } from "../../src/infrastructure/adapters/PluginLockManager";
 import {
   TS_FLOOR_AS_UID_EXO,
@@ -540,6 +541,111 @@ describe("ProfileApplyManager.applyProfileViaRest — central-registry (#3511)",
     );
     expect(restMount.mounted).toEqual([]);
     expect(restMount.unmounted).toEqual([]);
+  });
+});
+
+// ─── req 18ecf16f — the hard-dependency guard is WIRED into apply ────────────
+//
+// The unit tests for `assertHardDependenciesSatisfied` prove the guard refuses;
+// they say nothing about it being CALLED. Neutralising the call site in
+// `resolveDeclaredAndEffective` reddened zero tests before this block existed —
+// a guard nobody invokes is indistinguishable from a guard that does not exist.
+//
+// The reachable shape at this call site is the SILENT-DROP path: the closure is
+// computed from the registry's `dependsOn` edges, but only members that HAVE a
+// scanned descriptor survive into the effective set (`folderMapValues.has`).
+// A member whose descriptor is absent therefore vanished without a word — and
+// with no descriptor there is no kind to read, so it defaults to hard. That is
+// exactly the P5 shape: the profile resolves, apply proceeds, and assets are
+// left without a resolvable type (two `sh:class` violations).
+describe("ProfileApplyManager.applyProfileViaRest — hard-dependency guard (req 18ecf16f)", () => {
+  const AS_LEAF = "leaf-uid-0000-0000-0000-000000000000";
+  const AS_EXO_EKA = "e5c47526-e72f-42e3-8535-3d243dd2db94";
+  const AS_GHOST = "9999aaaa-0000-0000-0000-0000000000gg";
+  const MOUNT_EXO = "assetspaces/kitelev/exoas-exo";
+
+  /** @param leafDeps UIDs the leaf declares as `dependsOn`. */
+  function build(leafDeps: string[]) {
+    const files: FakeFile[] = [
+      {
+        path: "assetspaces/kitelev/exoas-profiles/profiles/p-leaf.md",
+        basename: "p-leaf",
+        frontmatter: {
+          exo__Asset_uid: "p-leaf",
+          exo__Asset_label: "$$leaf",
+          exo__Instance_class: ["[[exo__Profile]]"],
+        },
+      },
+      {
+        path: "assetspaces/kitelev/exoas-registry/registry/leaf.md",
+        basename: "leaf",
+        frontmatter: {
+          exo__Asset_uid: AS_LEAF,
+          exo__Asset_label: "kitelev/leaf",
+          exo__Instance_class: ["[[exo__AssetSpace]]"],
+          exo__AssetSpace_source: "https://github.com/kitelev/exoas-leaf",
+          exo__AssetSpace_namespace: "leaf",
+          exo__AssetSpace_dependsOn: leafDeps,
+        },
+      },
+      {
+        path: "assetspaces/kitelev/exoas-registry/registry/exo.md",
+        basename: "exo",
+        frontmatter: {
+          exo__Asset_uid: AS_EXO_EKA,
+          exo__Asset_label: "kitelev/exo",
+          exo__Instance_class: ["[[exo__AssetSpace]]"],
+          exo__AssetSpace_source: "https://github.com/kitelev/exoas-exo",
+          exo__AssetSpace_namespace: "exo",
+        },
+      },
+      // NOTE: no descriptor for AS_GHOST — that absence IS the scenario.
+    ];
+    const { app, fsFolders } = makeFakeApp(files);
+    fsFolders.set(MOUNT_EXO, { files: [`${MOUNT_EXO}/f.md`], folders: [] });
+    const restMount = new FakeRestMount();
+    const mgr = new ProfileApplyManager({
+      app,
+      lockMgr: new PluginLockManager({ app }),
+      resolver: new FakeResolver(
+        new Map<string, ProfileResolution>([
+          ["p-leaf", { uid: "p-leaf", includes: [AS_LEAF], label: "$$leaf" }],
+        ]),
+      ),
+      rdfIndexer: new FakeIndexer(),
+      settingsStore: new FakeSettingsStore(),
+      notify: () => {},
+      confirmGate: new FakeConfirmGate(),
+      localDataStore:
+        new FakeLocalDataStore() as unknown as ConstructorParameters<
+          typeof ProfileApplyManager
+        >[0]["localDataStore"],
+      restMount: restMount as unknown as ConstructorParameters<
+        typeof ProfileApplyManager
+      >[0]["restMount"],
+    });
+    return { mgr, restMount };
+  }
+
+  it("REFUSES before any mount/unmount when the closure loses a hard member @req:18ecf16f-a163-4b78-9bee-605db7e75f8e", async () => {
+    const { mgr, restMount } = build([
+      `[[${AS_EXO_EKA}|exoas-exo]]`,
+      `[[${AS_GHOST}|exoas-ghost]]`,
+    ]);
+
+    await expect(mgr.applyProfileViaRest("p-leaf")).rejects.toThrow(
+      OmittedHardDependencyError,
+    );
+    // Pre-mutation, like the TS-floor guard beside it.
+    expect(restMount.mounted).toEqual([]);
+    expect(restMount.unmounted).toEqual([]);
+  });
+
+  it("control: the SAME profile applies once nothing is omitted @req:18ecf16f-a163-4b78-9bee-605db7e75f8e", async () => {
+    // Non-vacuity: the refusal above is caused by the omitted member, not by
+    // the fixture. Drop the ghost edge and the identical apply succeeds.
+    const { mgr } = build([`[[${AS_EXO_EKA}|exoas-exo]]`]);
+    await expect(mgr.applyProfileViaRest("p-leaf")).resolves.toBeUndefined();
   });
 });
 

--- a/packages/obsidian-plugin/tests/unit/domain/profile/closureGap.test.ts
+++ b/packages/obsidian-plugin/tests/unit/domain/profile/closureGap.test.ts
@@ -1,14 +1,24 @@
 import {
+  assertHardDependenciesSatisfied,
   detectUnmountedClosureMembers,
   formatClosureGapWarning,
+  OmittedHardDependencyError,
 } from "../../../../src/domain/profile/closureGap";
+import {
+  DEPENDENCY_KIND_REFERENCE_UID,
+  DEPENDENCY_KIND_TBOX_UID,
+} from "../../../../src/domain/profile/dependencyKind";
 import type { AssetSpaceInfo } from "../../../../src/infrastructure/adapters/AssetSpaceManager";
+
+const HARD = `[[${DEPENDENCY_KIND_TBOX_UID}]]`;
+const SOFT = `[[${DEPENDENCY_KIND_REFERENCE_UID}]]`;
 
 /** Minimal AssetSpaceInfo fixture (only the fields the helper reads). */
 function info(
   uid: string,
   namespace: string,
   dependsOn?: string[],
+  dependsOnKind?: string,
 ): AssetSpaceInfo {
   return {
     uid,
@@ -16,6 +26,7 @@ function info(
     namespace,
     folderName: `assetspaces/kitelev/exoas-${namespace}`,
     ...(dependsOn ? { dependsOn } : {}),
+    ...(dependsOnKind ? { dependsOnKind } : {}),
   };
 }
 
@@ -26,11 +37,13 @@ const W3C = "dddd4444-0000-0000-0000-000000000004";
 
 describe("detectUnmountedClosureMembers (#3956)", () => {
   // exoas-public --dependsOn--> {exoas-exocmd, exoas-w3c}; exoas-exocmd --> exoas-exo.
+  // req 18ecf16f — the kind now comes from each descriptor, not from a
+  // namespace allow-list: exocmd/exo are marked HARD, w3c SOFT.
   const catalogue: AssetSpaceInfo[] = [
-    info(PUBLIC, "public", [EXOCMD, W3C]),
-    info(EXOCMD, "exocmd", [EXO]),
-    info(EXO, "exo"),
-    info(W3C, "w3c"),
+    info(PUBLIC, "public", [EXOCMD, W3C], HARD),
+    info(EXOCMD, "exocmd", [EXO], HARD),
+    info(EXO, "exo", undefined, HARD),
+    info(W3C, "w3c", undefined, SOFT),
   ];
 
   it("reports the unmaterialized closure members of a root (the subset-add gap)", () => {
@@ -44,7 +57,7 @@ describe("detectUnmountedClosureMembers (#3956)", () => {
     expect(uids).toEqual([EXO, EXOCMD, W3C].sort());
   });
 
-  it("flags the TBox-provider closure members (exo + exocmd), not the rest (AC3)", () => {
+  it("flags the TBox-provider closure members, not the rest (AC3)", () => {
     const missing = detectUnmountedClosureMembers(
       [PUBLIC],
       catalogue,
@@ -80,7 +93,7 @@ describe("detectUnmountedClosureMembers (#3956)", () => {
   it("reports a closure member with no scanned descriptor using its short UID", () => {
     // exoas-public depends on a UID that has no descriptor in the catalogue.
     const orphan = "ffff9999-0000-0000-0000-000000000099";
-    const cat = [info(PUBLIC, "public", [orphan])];
+    const cat = [info(PUBLIC, "public", [orphan], HARD)];
     const missing = detectUnmountedClosureMembers(
       [PUBLIC],
       cat,
@@ -89,7 +102,10 @@ describe("detectUnmountedClosureMembers (#3956)", () => {
     expect(missing).toHaveLength(1);
     expect(missing[0].uid).toBe(orphan);
     expect(missing[0].label).toBe(orphan.slice(0, 8)); // no namespace known
-    expect(missing[0].providesTBox).toBe(false);
+    // req 18ecf16f — DELIBERATE change from `false`: an unscannable member can
+    // never be materialized, so calling it "harmless content" is the one
+    // direction that loses class types silently.
+    expect(missing[0].providesTBox).toBe(true);
   });
 
   it("returns [] when a root has no dependsOn edges (nothing to check)", () => {
@@ -99,6 +115,146 @@ describe("detectUnmountedClosureMembers (#3956)", () => {
       new Set([W3C]),
     );
     expect(missing).toEqual([]);
+  });
+
+  // ---- req 18ecf16f: providesTBox comes from the GRAPH, not from a namespace list ----
+
+  it("marks a NON-floor namespace as a TBox provider when the graph says so @req:18ecf16f-a163-4b78-9bee-605db7e75f8e", () => {
+    // Decisive against the removed allow-list: "public" was never in {exo, exocmd},
+    // so under the hardcode this could only have been false. Measured on the real
+    // registry, exoas-public supplies class definitions to 13478 cross-boundary
+    // assets — the allow-list was not merely non-homoiconic, it was wrong.
+    const root = "eeee5555-0000-0000-0000-000000000005";
+    const cat = [
+      info(root, "my", [PUBLIC], HARD),
+      info(PUBLIC, "public", undefined, HARD),
+    ];
+    const missing = detectUnmountedClosureMembers(
+      [root],
+      cat,
+      new Set([root]),
+    );
+    expect(missing.map((m) => m.uid)).toEqual([PUBLIC]);
+    expect(missing[0].providesTBox).toBe(true);
+  });
+
+  it("marks a FLOOR namespace as NOT a provider when the graph says so @req:18ecf16f-a163-4b78-9bee-605db7e75f8e", () => {
+    // The mirror axis, and the one the hardcode structurally could not express:
+    // namespace "exo" was unconditionally true. The graph is now authoritative.
+    const root = "eeee5555-0000-0000-0000-000000000005";
+    const cat = [
+      info(root, "my", [EXO], HARD),
+      info(EXO, "exo", undefined, SOFT),
+    ];
+    const missing = detectUnmountedClosureMembers([root], cat, new Set([root]));
+    expect(missing.map((m) => m.uid)).toEqual([EXO]);
+    expect(missing[0].providesTBox).toBe(false);
+  });
+
+  it("treats a descriptor with NO kind as a provider (safe default) @req:18ecf16f-a163-4b78-9bee-605db7e75f8e", () => {
+    const root = "eeee5555-0000-0000-0000-000000000005";
+    const cat = [
+      info(root, "my", [W3C], HARD),
+      info(W3C, "w3c"), // no dependsOnKind at all
+    ];
+    const missing = detectUnmountedClosureMembers([root], cat, new Set([root]));
+    expect(missing[0].providesTBox).toBe(true);
+  });
+});
+
+describe("assertHardDependenciesSatisfied (req 18ecf16f)", () => {
+  const MY = "eeee5555-0000-0000-0000-000000000005";
+  const SHARED_PRIVATE = "aaaa6666-0000-0000-0000-000000000006";
+
+  /** The P5 topology: a leaf that pulls a class provider in transitively. */
+  function p5Catalogue(kind?: string): AssetSpaceInfo[] {
+    return [
+      info(MY, "my", [SHARED_PRIVATE], HARD),
+      info(SHARED_PRIVATE, "shared-private", undefined, kind),
+    ];
+  }
+
+  it("REFUSES when a HARD-edge closure member is omitted from the effective set @req:18ecf16f-a163-4b78-9bee-605db7e75f8e", () => {
+    // The exact shape that produced the two sh:class violations in the parent
+    // project's P5 spike: the provider is dropped, and today nothing stops it.
+    expect(() =>
+      assertHardDependenciesSatisfied(
+        [MY, SHARED_PRIVATE],
+        new Set([MY]),
+        p5Catalogue(HARD),
+      ),
+    ).toThrow(OmittedHardDependencyError);
+  });
+
+  it("names the omitted provider and the remedy in the error @req:18ecf16f-a163-4b78-9bee-605db7e75f8e", () => {
+    let caught: unknown;
+    try {
+      assertHardDependenciesSatisfied(
+        [MY, SHARED_PRIVATE],
+        new Set([MY]),
+        p5Catalogue(HARD),
+      );
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeInstanceOf(OmittedHardDependencyError);
+    const err = caught as OmittedHardDependencyError;
+    expect(err.omitted.map((m) => m.uid)).toEqual([SHARED_PRIVATE]);
+    expect(err.message).toContain("shared-private");
+    expect(err.message).toContain("exo__DependencyKindReference");
+  });
+
+  it("ALLOWS the same omission when the edge is SOFT @req:18ecf16f-a163-4b78-9bee-605db7e75f8e", () => {
+    // The whole point of typing: a content-only pack may be left out.
+    expect(() =>
+      assertHardDependenciesSatisfied(
+        [MY, SHARED_PRIVATE],
+        new Set([MY]),
+        p5Catalogue(SOFT),
+      ),
+    ).not.toThrow();
+  });
+
+  it("REFUSES when the omitted member has NO kind at all (safe default) @req:18ecf16f-a163-4b78-9bee-605db7e75f8e", () => {
+    // AC4 — the branch that would otherwise never execute: "kind not set" must
+    // read as hard, not as "no kind ⇒ parkable".
+    expect(() =>
+      assertHardDependenciesSatisfied(
+        [MY, SHARED_PRIVATE],
+        new Set([MY]),
+        p5Catalogue(undefined),
+      ),
+    ).toThrow(OmittedHardDependencyError);
+  });
+
+  it("REFUSES when the omitted member has NO scanned descriptor @req:18ecf16f-a163-4b78-9bee-605db7e75f8e", () => {
+    // The silent-drop path: resolveDeclaredAndEffective keeps only closure
+    // members that have a descriptor, so this one vanished without a word.
+    const orphan = "ffff9999-0000-0000-0000-000000000099";
+    expect(() =>
+      assertHardDependenciesSatisfied(
+        [MY, orphan],
+        new Set([MY]),
+        [info(MY, "my", [orphan], HARD)],
+      ),
+    ).toThrow(OmittedHardDependencyError);
+  });
+
+  it("does NOT throw when the whole closure is in the effective set @req:18ecf16f-a163-4b78-9bee-605db7e75f8e", () => {
+    // No false-positive: the normal apply must stay byte-identical in behaviour.
+    expect(() =>
+      assertHardDependenciesSatisfied(
+        [MY, SHARED_PRIVATE],
+        new Set([MY, SHARED_PRIVATE]),
+        p5Catalogue(HARD),
+      ),
+    ).not.toThrow();
+  });
+
+  it("does NOT throw on an empty closure @req:18ecf16f-a163-4b78-9bee-605db7e75f8e", () => {
+    expect(() =>
+      assertHardDependenciesSatisfied([], new Set(), []),
+    ).not.toThrow();
   });
 });
 

--- a/packages/obsidian-plugin/tests/unit/domain/profile/dependencyKind.test.ts
+++ b/packages/obsidian-plugin/tests/unit/domain/profile/dependencyKind.test.ts
@@ -1,0 +1,76 @@
+import {
+  DEPENDENCY_KIND_REFERENCE_UID,
+  DEPENDENCY_KIND_TBOX_UID,
+  resolveDependencyKind,
+} from "../../../../src/domain/profile/dependencyKind";
+
+describe("resolveDependencyKind", () => {
+  it("resolves every emitted form of the SOFT value @req:18ecf16f-a163-4b78-9bee-605db7e75f8e", () => {
+    // The plugin reads FRONTMATTER while the graph emits the same value as a
+    // symbolic IRI (the enum label parses as `prefix__Local`), so both shapes
+    // are legitimate authoring/migration outputs and both must resolve.
+    expect(resolveDependencyKind(`[[${DEPENDENCY_KIND_REFERENCE_UID}]]`)).toBe(
+      "reference",
+    );
+    expect(
+      resolveDependencyKind(
+        `[[${DEPENDENCY_KIND_REFERENCE_UID}|exo__DependencyKindReference]]`,
+      ),
+    ).toBe("reference");
+    expect(resolveDependencyKind(DEPENDENCY_KIND_REFERENCE_UID)).toBe(
+      "reference",
+    );
+    expect(resolveDependencyKind("exo__DependencyKindReference")).toBe(
+      "reference",
+    );
+    expect(
+      resolveDependencyKind(
+        "https://exocortex.my/ontology/exo#DependencyKindReference",
+      ),
+    ).toBe("reference");
+    // `Single` cardinality, but metadataCache hands back a list when the author
+    // writes YAML list syntax.
+    expect(
+      resolveDependencyKind([`[[${DEPENDENCY_KIND_REFERENCE_UID}]]`]),
+    ).toBe("reference");
+  });
+
+  it("resolves the HARD value in the same forms @req:18ecf16f-a163-4b78-9bee-605db7e75f8e", () => {
+    expect(resolveDependencyKind(`[[${DEPENDENCY_KIND_TBOX_UID}]]`)).toBe(
+      "tbox",
+    );
+    expect(
+      resolveDependencyKind(
+        `[[${DEPENDENCY_KIND_TBOX_UID}|exo__DependencyKindTBox]]`,
+      ),
+    ).toBe("tbox");
+    expect(resolveDependencyKind("exo__DependencyKindTBox")).toBe("tbox");
+  });
+
+  it("defaults ABSENT / empty / wrong-typed input to HARD, never soft @req:18ecf16f-a163-4b78-9bee-605db7e75f8e", () => {
+    // AC4 boundary: "kind not set" must NOT read as "parkable".
+    for (const raw of [undefined, null, "", "   ", 42, true, {}, []]) {
+      expect(resolveDependencyKind(raw)).toBe("tbox");
+    }
+  });
+
+  it("defaults an UNRECOGNISED value to HARD @req:18ecf16f-a163-4b78-9bee-605db7e75f8e", () => {
+    // Soft is the outcome that silently loses a class type, so it is the one
+    // made to require positive evidence — a typo must not park an AssetSpace.
+    expect(resolveDependencyKind("[[00000000-0000-0000-0000-000000000000]]")).toBe(
+      "tbox",
+    );
+    expect(resolveDependencyKind("exo__DependencyKindRefrence")).toBe("tbox");
+    expect(resolveDependencyKind("soft")).toBe("tbox");
+  });
+
+  it("lets the UID win over a CONFLICTING alias @req:18ecf16f-a163-4b78-9bee-605db7e75f8e", () => {
+    // A mismatched alias is authoring drift; the UID is the link target, i.e.
+    // what the graph actually resolves — and here it is also the safe side.
+    expect(
+      resolveDependencyKind(
+        `[[${DEPENDENCY_KIND_TBOX_UID}|exo__DependencyKindReference]]`,
+      ),
+    ).toBe("tbox");
+  });
+});

--- a/packages/obsidian-plugin/tests/unit/domain/profile/unmountSafety.test.ts
+++ b/packages/obsidian-plugin/tests/unit/domain/profile/unmountSafety.test.ts
@@ -1,4 +1,8 @@
 import {
+  DEPENDENCY_KIND_REFERENCE_UID,
+  DEPENDENCY_KIND_TBOX_UID,
+} from "../../../../src/domain/profile/dependencyKind";
+import {
   assessUnmountRisk,
   countIncomingLinks,
   findDependentMountedAssetSpaces,
@@ -14,7 +18,7 @@ import type { AssetSpaceInfo } from "../../../../src/infrastructure/adapters/Ass
  * The catalogue below mirrors the REAL vault-my `dependsOn` graph measured by
  * the project's falsification gate (task 8b8466bb, 2026-08-02):
  *
- *   my → shared-private, shared-identities
+ *   my → shared-private, shared-identities, shared-kalashnikova
  *   shared-private → public
  *   shared-identities → public
  *   public → exo, exocmd
@@ -32,12 +36,14 @@ const UID = {
   exocmd: "10000000-0000-0000-0000-000000000005",
   exo: "10000000-0000-0000-0000-000000000006",
   detached: "10000000-0000-0000-0000-000000000007",
+  collab: "10000000-0000-0000-0000-000000000008",
 } as const;
 
 function info(
   uid: string,
   namespace: string,
   dependsOn?: string[],
+  dependsOnKind?: string,
 ): AssetSpaceInfo {
   return {
     uid,
@@ -45,17 +51,30 @@ function info(
     namespace,
     folderName: `assetspaces/kitelev/exoas-${namespace}`,
     ...(dependsOn === undefined ? {} : { dependsOn }),
+    ...(dependsOnKind === undefined ? {} : { dependsOnKind }),
   };
 }
 
+/**
+ * req 18ecf16f — the kinds below are the ones actually marked on the live
+ * registry 2026-08-06, by measured cross-boundary class-definition supply:
+ * public/exo/exocmd/shared-private/shared-identities are HARD (13478 / 3625 /
+ * 268 / 954 / 652 cross-boundary references respectively); a seed-empty
+ * collaborator space supplies none and is SOFT. `my` is nobody's dependency, so
+ * it carries no kind — and therefore defaults to HARD.
+ */
+const HARD = `[[${DEPENDENCY_KIND_TBOX_UID}]]`;
+const SOFT = `[[${DEPENDENCY_KIND_REFERENCE_UID}]]`;
+
 const CATALOGUE: AssetSpaceInfo[] = [
-  info(UID.my, "my", [UID.sharedPrivate, UID.sharedIdentities]),
-  info(UID.sharedPrivate, "shared-private", [UID.public]),
-  info(UID.sharedIdentities, "shared-identities", [UID.public]),
-  info(UID.public, "public", [UID.exo, UID.exocmd]),
-  info(UID.exocmd, "exocmd", [UID.exo]),
-  info(UID.exo, "exo"),
-  info(UID.detached, "detached"),
+  info(UID.my, "my", [UID.sharedPrivate, UID.sharedIdentities, UID.collab]),
+  info(UID.sharedPrivate, "shared-private", [UID.public], HARD),
+  info(UID.sharedIdentities, "shared-identities", [UID.public], HARD),
+  info(UID.public, "public", [UID.exo, UID.exocmd], HARD),
+  info(UID.exocmd, "exocmd", [UID.exo], HARD),
+  info(UID.exo, "exo", undefined, HARD),
+  info(UID.collab, "shared-kalashnikova", undefined, SOFT),
+  info(UID.detached, "detached", undefined, SOFT),
 ];
 
 const ALL_MOUNTED = Object.values(UID);
@@ -204,12 +223,42 @@ describe("assessUnmountRisk + formatUnmountRiskWarning", () => {
     ]);
     expect(risk.incomingLinks).toBe(2);
     expect(risk.linkingFiles).toBe(1);
-    expect(risk.providesTBox).toBe(false);
+    // req 18ecf16f — DELIBERATE flip from `false`. Under the removed namespace
+    // allow-list `{exo, exocmd}` this could only ever be false; the graph says
+    // `public` IS a provider (13478 cross-boundary class references, the largest
+    // supplier in the registry), and the graph is now authoritative.
+    expect(risk.providesTBox).toBe(true);
 
     const warning = formatUnmountRiskWarning(risk, "public");
     expect(warning).toContain("my, shared-identities, shared-private");
     expect(warning).toContain("are still mounted and declare a dependency");
     expect(warning).toContain("2 links from 1 file outside it");
+    expect(warning).toContain("class / command TBox");
+  });
+
+  it("omits the TBox note for a SOFT pack that is still at risk @req:18ecf16f-a163-4b78-9bee-605db7e75f8e", () => {
+    // The coverage the flip above moved off `public`: risk WITHOUT the TBox note.
+    // A seed-empty collaborator pack supplies no class definitions, so removing
+    // it costs reachability (dependents + dangling links) but never types — and
+    // the warning must not claim otherwise.
+    const links: ResolvedLinks = {
+      "assetspaces/kitelev/exoas-my/a.md": {
+        "assetspaces/kitelev/exoas-shared-kalashnikova/c.md": 2,
+      },
+    };
+    const risk = assessUnmountRisk(
+      target(UID.collab, "shared-kalashnikova"),
+      ALL_MOUNTED,
+      CATALOGUE,
+      links,
+    );
+
+    expect(risk.dependents).toEqual(["my"]);
+    expect(risk.incomingLinks).toBe(2);
+    expect(risk.providesTBox).toBe(false);
+
+    const warning = formatUnmountRiskWarning(risk, "shared-kalashnikova");
+    expect(warning).toContain("my is still mounted and declares a dependency");
     expect(warning).not.toContain("class / command TBox");
   });
 


### PR DESCRIPTION
## What

`exo__AssetSpace_dependsOn` edges are now **typed** (hard / soft), and the kind is read **from the graph** instead of a hardcoded namespace allow-list.

Requirement: `18ecf16f-a163-4b78-9bee-605db7e75f8e` (Approved, P1, bindingClass Integration) — [exoas-exo-reqs](https://github.com/kitelev/exoas-exo-reqs/blob/main/exo-reqs/18ecf16f-a163-4b78-9bee-605db7e75f8e.md).
Task: `9441acb4` (Шаг 0 of the AssetSpace-parking project) — typing only; **nothing is migrated or parked here**.

## Why

`TBOX_PROVIDER_NAMESPACES = { exo, exocmd }` decided which AssetSpaces supply class definitions. Two problems:

1. **Homoiconicity Q1.** Which AssetSpaces supply definitions is user-configurable semantics — the user adds AssetSpaces — so it cannot live in a TS `Set`.
2. **It was factually wrong.** Measured across the live registry (cross-boundary class-definition supply, defs/refs):

   | AssetSpace | cross-boundary refs | in the old allow-list? |
   |---|---:|---|
   | `exoas-public` | **13478** | ✗ |
   | `exoas-exo` | 3625 | ✓ |
   | `exoas-dec` | 2163 | ✗ |
   | `exoas-aiknow` | 1708 | ✗ |
   | `exoas-shared-private` | 954 | ✗ |
   | `exoas-exocmd` | 268 | ✓ |

## How

- **New** `domain/profile/dependencyKind.ts` — resolves the kind from raw frontmatter. Accepts every form the value can reach the plugin in (the plugin reads `metadataCache`, while the RDF converter emits the same value as a **symbolic IRI** because the enum label parses as `prefix__Local`).
  The safe default is **structural, not a fallback branch**: `reference` is returned only on a positive match of the known soft value; absent / empty / unrecognised / wrong-typed all yield `tbox`. A wrong `reference` silently loses a class type; a wrong `tbox` only costs an extra refusal.
- `AssetSpaceInfo.dependsOnKind` carries the raw value; `ProfileApplyManager.listAllAssetSpaceInfos` scans it beside `dependsOn`.
- `closureGap` + `unmountSafety` derive `providesTBox` from the graph. `TBOX_PROVIDER_NAMESPACES` is **deleted**.
- **New** `assertHardDependenciesSatisfied` — makes the silent-drop path fail loud. A profile whose effective set omits a hard-edge closure member is now **refused before any mutation**, beside `assertTsFloor`, instead of quietly losing class resolution. The warning and the refusal share one private `describeOmittedMembers`, so they cannot disagree.

### Behaviour changes worth naming

- A closure member with **no scanned descriptor** now reports `providesTBox: true` (was `false`). Deliberate: such a member can never be materialised, so calling it "harmless content" is the one direction that loses types silently.
- `exoas-public` is now a TBox provider in the unmount warning (it is the registry's largest supplier). Under the removed allow-list this could only ever have been `false`.

## Vault side (already pushed, not in this PR)

4 TBox assets in `exoas-exo` (`exo__DependencyKind` enum class, its two individuals, and the `exo__AssetSpace_dependsOnKind` ObjectProperty) + the **17** registry descriptors that are `dependsOn` targets, marked 13 hard / 4 soft. Every `dependsOn` target has a descriptor, so there are **zero** spurious refusals today. SHACL no-regress in both affected vaults (`vault-exodev` 0 violations / 537 warnings before and after; `vault-my` verified on a throwaway copy — the live mirror was not mutated).

## Tests — per-guard revert-verify

Baseline **323 passed / 0 failed** across the 20 Profile suites. Each guard was neutralised on its own; a guard whose neutralisation reddens nothing is not under test:

| Mutation | Red |
|---|---:|
| graph read removed (`normalized = ""`) | 5 — SOFT resolution, floor-ns-not-provider, w3c-soft, ALLOWS-SOFT, unmount SOFT-note |
| safe default inverted (final `return "reference"`) | 3 — the AC4 absent / unrecognised boundary |
| refusal body removed | 5 — 4 guard tests + the wiring test |
| **call site removed** | **1** — exactly the wiring test |

The last row is why `ProfileApplyManager.restApply.test.ts` gained a block: before it, removing the call site reddened **zero** tests — the guard was proven to refuse but not proven to be *invoked*.

Full plugin suite: **5898 passed, 0 failed, 3 skipped**. Three suites fail to *load* locally with `SyntaxError: Unexpected token 'export'` (uuid v13 pure-ESM through a `cp -a`'d `node_modules`) — identical in an untouched sibling worktree, so pre-existing environment, not this change; CI runs a fresh `npm ci`.
