### PR TITLE
test(sync): lock parking-is-invisible-to-enumeration on both collectors

### DIFF
--- a/packages/cli/tests/unit/commands/exosync-parity.test.ts
+++ b/packages/cli/tests/unit/commands/exosync-parity.test.ts
@@ -6,7 +6,13 @@
  * vault on the real node fs + an injected fake GitHub transport — no
  * network, no process.exit.
  */
-import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import {
+  mkdtempSync,
+  mkdirSync,
+  writeFileSync,
+  rmSync,
+  existsSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { createHash } from "node:crypto";
 import * as path from "node:path";
@@ -29,6 +35,9 @@ function gitBlobShaSync(content: string): string {
     .update(Buffer.concat([Buffer.from(`blob ${body.byteLength}\0`), body]))
     .digest("hex");
 }
+
+/** Where a parked mount is moved to — deliberately OUTSIDE `assetspaces/`. */
+const PARKED = `.exocortex/parked/${OWNER}/${REPO}`;
 
 const FILE_A = "assets/a.md";
 const CONTENT_A = `---\nexo__Asset_uid: u-a\n---\n\nbody A\n`;
@@ -93,6 +102,8 @@ interface VaultFixture {
 
 function makeVault(opts: {
   mountFiles?: Record<string, string>;
+  /** Same files, but under {@link PARKED} instead of {@link MOUNT}. */
+  parkedFiles?: Record<string, string>;
   watermarkFiles?: Record<string, string>;
   declaration?: boolean;
 }): VaultFixture {
@@ -105,6 +116,11 @@ function makeVault(opts: {
   }
   for (const [rel, content] of Object.entries(opts.mountFiles ?? {})) {
     const full = path.join(vault, MOUNT, rel);
+    mkdirSync(path.dirname(full), { recursive: true });
+    writeFileSync(full, content);
+  }
+  for (const [rel, content] of Object.entries(opts.parkedFiles ?? {})) {
+    const full = path.join(vault, PARKED, rel);
     mkdirSync(path.dirname(full), { recursive: true });
     writeFileSync(full, content);
   }
@@ -169,6 +185,74 @@ describe("collectVaultSpecs", () => {
     const fx = makeVault({});
     try {
       expect(collectVaultSpecs(fx.vault).specs).toEqual([]);
+    } finally {
+      fx.cleanup();
+    }
+  });
+});
+
+/**
+ * Parking safety (T3a — AC5 of task d8371554).
+ *
+ * Moving a mount out of the DERIVED path `assetspaces/<owner>/<repo>` and into
+ * `.exocortex/parked/<owner>/<repo>` must be INERT for ExoSync: the AssetSpace
+ * must not be enumerated as a sync unit, so its deletion set is never computed
+ * and `push` never deletes its files on the remote.
+ *
+ * The guard being locked here is the `existsSync` gate in `collectVaultSpecs`,
+ * which sits BETWEEN `offer()` and `commit()`. Its sibling — the plugin's
+ * `adapter.exists` gate in `SyncDepsFactory.collectSyncRepoSpecs` — is a
+ * different function using a different primitive, so it is locked by its own
+ * check in `packages/obsidian-plugin/tests/unit/sync/SyncDepsFactory.test.ts`;
+ * green here says nothing about green there.
+ *
+ * The fixture declares only `exo__AssetSpace_source`; `localPath` is DERIVED by
+ * `AssetSpacePathDeriver` inside `classifySpaceDeclaration`. A hand-written
+ * `localPath` would keep this suite green against a dead deriver.
+ */
+describe("parking is invisible to sync-unit enumeration @req:4eca4900-fd1f-42d2-a111-46f90a35d6f4", () => {
+  it("does not enumerate an AssetSpace whose mount was parked out of the derived path", () => {
+    const fx = makeVault({ parkedFiles: { [FILE_A]: CONTENT_A } });
+    try {
+      // Precondition — the copy really is on disk, just not where the derived
+      // path points. Without this the assertion below would be vacuous.
+      expect(existsSync(path.join(fx.vault, PARKED, FILE_A))).toBe(true);
+      expect(existsSync(path.join(fx.vault, MOUNT))).toBe(false);
+
+      expect(collectVaultSpecs(fx.vault).specs).toEqual([]);
+    } finally {
+      fx.cleanup();
+    }
+  });
+
+  it("negative control — the same declaration IS enumerated at the derived path", () => {
+    const fx = makeVault({ mountFiles: { [FILE_A]: CONTENT_A } });
+    try {
+      expect(collectVaultSpecs(fx.vault).specs).toEqual([
+        {
+          owner: OWNER,
+          repo: REPO,
+          branch: "main",
+          repoKey: `${OWNER}/${REPO}#main`,
+          localPath: MOUNT,
+        },
+      ]);
+    } finally {
+      fx.cleanup();
+    }
+  });
+
+  it("a parked copy does not resurrect enumeration when the mount is also absent", () => {
+    // Both shapes at once: the declaration is present, a full copy of the mount
+    // sits in the park, and NOTHING is materialized — so `push` for this repo is
+    // never even considered, let alone given a deletion set.
+    const fx = makeVault({
+      parkedFiles: { [FILE_A]: CONTENT_A, "assets/b.md": CONTENT_A },
+    });
+    try {
+      const { specs, warnings } = collectVaultSpecs(fx.vault);
+      expect(specs).toEqual([]);
+      expect(warnings).toEqual([]); // parking is silent, not a warning
     } finally {
       fx.cleanup();
     }

--- a/packages/obsidian-plugin/tests/unit/sync/SyncDepsFactory.test.ts
+++ b/packages/obsidian-plugin/tests/unit/sync/SyncDepsFactory.test.ts
@@ -90,6 +90,79 @@ describe("collectSyncRepoSpecs", () => {
     expect(result.specs).toEqual([]);
   });
 
+  /**
+   * Parking safety (T3a — AC5 of task d8371554).
+   *
+   * Moving a mount out of the DERIVED path `assetspaces/<owner>/<repo>` and
+   * into `.exocortex/parked/<owner>/<repo>` must be INERT for ExoSync: the
+   * AssetSpace must not be enumerated as a sync unit, so its deletion set is
+   * never computed and `push` never deletes its files on the remote.
+   *
+   * The guard locked here is the `adapter.exists` gate in
+   * `collectSyncRepoSpecs`, which sits BETWEEN `offer()` and `commit()`. Its
+   * sibling — the CLI's `existsSync` gate in `collectVaultSpecs` — is a
+   * different function in a different package using a different primitive, so
+   * it is locked by its own check in
+   * `packages/cli/tests/unit/commands/exosync-parity.test.ts`; green here says
+   * nothing about green there.
+   *
+   * `assetSpaceFm` declares only `exo__AssetSpace_source` — `localPath` is
+   * DERIVED by `AssetSpacePathDeriver` inside `classifySpaceDeclaration`, so a
+   * dead deriver cannot leave this check green.
+   */
+  describe("parking is invisible to enumeration @req:4eca4900-fd1f-42d2-a111-46f90a35d6f4", () => {
+    const PARKED = ".exocortex/parked/o/r";
+
+    it("excludes a parked AssetSpace while still enumerating a live one", async () => {
+      const adapter = new InMemoryAdapter();
+      // `o/r` is PARKED: a full copy on disk, outside `assetspaces/`.
+      adapter.seedFile(`${PARKED}/assets/a.md`, "---\nexo__Asset_uid: u-a\n---\n");
+      // `o/live` stays materialized — it makes the mount walk actually run and
+      // doubles as an inline control: exclusion must be selective, not blanket.
+      adapter.mkdirAll("assetspaces/o/live");
+      const app = makeApp({
+        adapter,
+        mdFiles: [{ path: "parked.md" }, { path: "live.md" }],
+        frontmatters: new Map([
+          ["parked.md", assetSpaceFm("uid-parked", "https://github.com/o/r")],
+          ["live.md", assetSpaceFm("uid-live", "https://github.com/o/live")],
+        ]),
+      });
+
+      // Precondition — the parked copy really is on disk, just not at the
+      // derived path. Without this the assertions below would be vacuous.
+      expect(await adapter.exists(PARKED)).toBe(true);
+      expect(await adapter.exists("assetspaces/o/r")).toBe(false);
+
+      const result = await collectSyncRepoSpecs(app as unknown as App);
+
+      expect(result.specs).toEqual([
+        spec({ repo: "live", repoKey: `o/live#${SYNC_BRANCH}`, localPath: "assetspaces/o/live" }),
+      ]);
+      // …and the parked copy is not mistaken for an ad-hoc mount either
+      // (FINDING-3 walks `assetspaces/` only).
+      expect(result.mountedNotDeclared).toEqual([]);
+      expect(result.warnings).toEqual([]);
+    });
+
+    it("negative control — the same declaration IS enumerated at the derived path", async () => {
+      const adapter = new InMemoryAdapter();
+      adapter.seedFile(`${PARKED}/assets/a.md`, "---\nexo__Asset_uid: u-a\n---\n");
+      adapter.mkdirAll("assetspaces/o/r"); // now materialized as well
+      const app = makeApp({
+        adapter,
+        mdFiles: [{ path: "as1.md" }],
+        frontmatters: new Map([
+          ["as1.md", assetSpaceFm("uid-1", "https://github.com/o/r")],
+        ]),
+      });
+
+      const result = await collectSyncRepoSpecs(app as unknown as App);
+
+      expect(result.specs).toEqual([spec()]);
+    });
+  });
+
   it("skips non-GitHub sources with a warning", async () => {
     const adapter = new InMemoryAdapter();
     const app = makeApp({

--- a/packages/obsidian-plugin/tests/unit/sync/SyncDepsFactory.test.ts
+++ b/packages/obsidian-plugin/tests/unit/sync/SyncDepsFactory.test.ts
@@ -120,6 +120,10 @@ describe("collectSyncRepoSpecs", () => {
       // `o/live` stays materialized — it makes the mount walk actually run and
       // doubles as an inline control: exclusion must be selective, not blanket.
       adapter.mkdirAll("assetspaces/o/live");
+      // `o/adhoc` is mounted but NOT declared. It gives the FINDING-3 assertion
+      // below a POSITIVE expected value: an empty `mountedNotDeclared` would
+      // otherwise be indistinguishable from a dead `enumerateMountFolders`.
+      adapter.mkdirAll("assetspaces/o/adhoc");
       const app = makeApp({
         adapter,
         mdFiles: [{ path: "parked.md" }, { path: "live.md" }],
@@ -140,8 +144,10 @@ describe("collectSyncRepoSpecs", () => {
         spec({ repo: "live", repoKey: `o/live#${SYNC_BRANCH}`, localPath: "assetspaces/o/live" }),
       ]);
       // …and the parked copy is not mistaken for an ad-hoc mount either
-      // (FINDING-3 walks `assetspaces/` only).
-      expect(result.mountedNotDeclared).toEqual([]);
+      // (FINDING-3 walks `assetspaces/` only). The expected value is the REAL
+      // ad-hoc mount, not `[]`: that keeps the assertion discriminating — it
+      // reds both when the parked copy leaks in AND when the mount walk dies.
+      expect(result.mountedNotDeclared).toEqual(["assetspaces/o/adhoc"]);
       expect(result.warnings).toEqual([]);
     });
 


### PR DESCRIPTION
Test-only. Locks an already-working safety property as an executable spec, on **both** call-sites separately.

`@req:4eca4900-fd1f-42d2-a111-46f90a35d6f4` — *parking an AssetSpace is invisible to sync-unit enumeration* (P1, `approved`).

## What is being locked

An AssetSpace whose **derived** mount path `assetspaces/<owner>/<repo>` is absent must **not** be enumerated as a sync unit — even when a full copy of that mount sits under `.exocortex/parked/<owner>/<repo>`. No spec ⇒ its deletion set is never computed ⇒ `push` never deletes its files on the remote (and no other device receives that deletion on its next pull).

Nothing enforced this today. A refactor that moved the existence check, widened it to *"a copy exists anywhere"*, or dropped it on **one** of the two call-sites would silently turn parking into a remote-wide deletion.

## Why two checks, not one

Enumeration is two independent functions in two packages around one shared platform-free classification core (`packages/core/src/services/sync/spaceSpecCore.ts`). That core deliberately leaves the existence step to the caller, **between `offer()` and `commit()`** — and the two callers use different primitives:

| call-site | primitive |
|---|---|
| `collectVaultSpecs` (`packages/cli/src/commands/exosync-parity.ts:171`) | `node:fs` `existsSync` |
| `collectSyncRepoSpecs` (`packages/obsidian-plugin/src/infrastructure/adapters/SyncDepsFactory.ts:130-136`) | `app.vault.adapter.exists` |

Green on one says nothing about the other, so each is locked by its own check.

## Revert-verified — one axis per guard, each reds ONLY its own side

| mutant (applied to a pristine tree, restored after) | CLI suite | plugin suite |
|---|---|---|
| `existsSync` gate removed from `collectVaultSpecs` | **3 failed** / 9 passed | 24/24 passed |
| `!exists` gate removed from `collectSyncRepoSpecs` | 12/12 passed | **2 failed** / 22 passed |
| `enumerateMountFolders` killed (early `return out`) | 12/12 passed | **2 failed** / 22 passed |
| `derivePath` stubbed to a constant | **negative control failed** | **negative control + parked check failed** |

On the first two axes the negative controls stayed **green** — those axes discriminate, they do not simply red everything. Mutations were line-level edits (real behaviour change, never a semantic no-op), applied with a `count == 1` anchor assertion, and the tree was verified clean (`git status --porcelain` empty) after each restore.

### Two findings the review process actually produced

**1. A tautological assertion, found by hand-tracing my own weakest claim.** The plugin check first asserted `mountedNotDeclared` `toEqual([])`. Tracing `enumerateMountFolders` against the fixture showed `[]` arises for *two* different reasons — the parked copy correctly staying out of the walk, **and the walk being dead** — so the assertion could not tell them apart. Fixed by seeding a real undeclared ad-hoc mount, making the expected value positive content. Axis 3 above exists only because of that fix: before it, killing `enumerateMountFolders` did **not** red this check.

**2. A reviewer concern refuted by measurement, not argument.** An adversarial review raised that a stubbed `derivePath` might leave both checks green, on the assumption that the fixtures place their files *at whatever the deriver returns*. They do not — both fixtures write to a hardcoded mount path while the guard consults the derived one, so a dead deriver desynchronises the two. Axis 4 above confirms it empirically: the negative controls red on both sides. AC "a hand-written `localPath` would keep the tests green against a dead deriver" therefore holds as an executable property, not a claim.

## Non-vacuity

- **Negative control on each side** — the same declaration **IS** enumerated once its derived path exists, and its `localPath` equals the derived path. Without it, *"not enumerated"* would be tautologically true.
- **Real deriver, not a hand-written path** — both fixtures declare only `exo__AssetSpace_source`; `localPath` is computed by `AssetSpacePathDeriver` inside `classifySpaceDeclaration`. A dead deriver cannot leave either check green.
- **Precondition assertions** — each parked check first asserts the copy really is on disk at `.exocortex/parked/...` and really is absent at the derived path, so the parked shape is exercised rather than assumed.
- **Plugin check also runs the mount walk** — a second, *live* AssetSpace stays materialized, so `enumerateMountFolders` genuinely executes and the parked copy is proven not to leak into `mountedNotDeclared` (FINDING-3 walks `assetspaces/` only).

## Scope

Test-only; **no production file is modified**. `apply-profile`'s handling of a parked state, `reconcileToLocal`, and the fate of `SwitchCacheLayer` are deliberately **out of scope** — they belong to the sibling task T3b, which depends on this guard as a proven property.

Task: `567552e2-2e14-456f-81b4-1d8520bd9a7e` (T3a — AC5 of T3 `d8371554`).
