### PR TITLE
feat(apply-profile): park soft-edge AssetSpaces instead of destroying them

### DIFF
--- a/packages/cli/src/services/BootstrapAssetSpaceService.ts
+++ b/packages/cli/src/services/BootstrapAssetSpaceService.ts
@@ -40,6 +40,7 @@ import {
   mountAssetSpaceFiles,
   appendGitmodulesEntry,
   stripGitmodulesEntry as coreStripGitmodulesEntry,
+  parkedPathFor,
   SYNC_BRANCH,
   type FileSystemPort,
   type AssetSpaceHttpClient,
@@ -420,26 +421,144 @@ export class BootstrapAssetSpaceService {
    *   under `assetspaces/`, or resolves outside the vault root.
    */
   unmountAssetSpace(vaultPath: string, submodulePath: string): void {
-    const segments = submodulePath.split("/");
-    if (
-      submodulePath.length === 0 ||
-      !submodulePath.startsWith("assetspaces/") ||
-      segments.some((s) => s.length === 0 || s === "." || s === "..")
-    ) {
-      throw new Error(
-        `unmountAssetSpace: refusing unsafe submodulePath "${submodulePath}"`,
-      );
-    }
-    const root = resolve(vaultPath);
-    const target = resolve(root, submodulePath);
-    if (target === root || !target.startsWith(root + sep)) {
-      throw new Error(
-        `unmountAssetSpace: target "${target}" escapes vault root "${root}"`,
-      );
-    }
+    const target = this.assertSafeVaultTarget(
+      vaultPath,
+      submodulePath,
+      "unmountAssetSpace",
+    );
     this.removeGitmodulesEntry(vaultPath, submodulePath);
     if (existsSync(target)) {
       rmSync(target, { recursive: true, force: true });
     }
+  }
+
+  /**
+   * req `d4ccc901` — PARK an AssetSpace: strip its `.gitmodules` stanza, then
+   * MOVE its mount folder to `.exocortex/parked/<owner>/<repo>` instead of
+   * removing it. The bytes stay on the device, so returning is a local rename
+   * rather than a network pull ({@link unparkAssetSpace}).
+   *
+   * Reserved for SOFT (`exo__DependencyKindReference`) edges — the park/destroy
+   * decision belongs to `classifyMountTransition`, not to this primitive.
+   *
+   * Ordering mirrors {@link unmountAssetSpace} (stanza-first) so both departures
+   * from the mounted state leave the same partial state if interrupted.
+   *
+   * The parked root lives INSIDE the vault deliberately: `renameSync` across a
+   * filesystem boundary raises `EXDEV`, and the "no download, works offline"
+   * property is the whole point. `.obsidian/plugins/exocortex/` would be the
+   * other in-vault candidate and is rejected — BRAT overwrites that tree on
+   * plugin update, which would silently delete parked content.
+   *
+   * Idempotent when nothing is mounted (no-op). REFUSES — rather than
+   * overwriting — when a parked copy already exists: two copies of one
+   * AssetSpace is a state a crash can produce, and picking a winner silently
+   * would discard whichever holds unpushed local edits.
+   *
+   * @throws if `submodulePath` fails the traversal guard, if either resolved
+   *   path escapes the vault root, or if a parked copy already exists.
+   */
+  parkAssetSpace(vaultPath: string, submodulePath: string): void {
+    const target = this.assertSafeVaultTarget(
+      vaultPath,
+      submodulePath,
+      "parkAssetSpace",
+    );
+    const parkedRel = parkedPathFor(submodulePath);
+    const parked = this.assertSafeVaultTarget(
+      vaultPath,
+      parkedRel,
+      "parkAssetSpace",
+      { requireAssetspacesRoot: false },
+    );
+    if (!existsSync(target)) return;
+    if (existsSync(parked)) {
+      throw new Error(
+        `parkAssetSpace: refusing to park "${submodulePath}" — a parked copy already exists at "${parkedRel}". Resolve by hand: one of the two holds work the other does not.`,
+      );
+    }
+    this.removeGitmodulesEntry(vaultPath, submodulePath);
+    mkdirSync(dirname(parked), { recursive: true });
+    renameSync(target, parked);
+  }
+
+  /**
+   * req `d4ccc901` — UNPARK an AssetSpace: move it back from
+   * `.exocortex/parked/<owner>/<repo>` onto its mount folder.
+   *
+   * Deliberately does NOT touch `.gitmodules`: the caller re-registers the
+   * stanza through the SAME `ensureGitmodulesEntry` call a network pull uses, so
+   * an unparked AssetSpace reaches `active` through one code path with one piece
+   * of bookkeeping. Doing it here would fork that path and let the two forms of
+   * materialisation drift.
+   *
+   * @throws if nothing is parked (the caller's plan was stale), or if the mount
+   *   folder is already occupied (would clobber a live mount).
+   */
+  unparkAssetSpace(vaultPath: string, submodulePath: string): void {
+    const target = this.assertSafeVaultTarget(
+      vaultPath,
+      submodulePath,
+      "unparkAssetSpace",
+    );
+    const parkedRel = parkedPathFor(submodulePath);
+    const parked = this.assertSafeVaultTarget(
+      vaultPath,
+      parkedRel,
+      "unparkAssetSpace",
+      { requireAssetspacesRoot: false },
+    );
+    if (!existsSync(parked)) {
+      throw new Error(
+        `unparkAssetSpace: nothing parked at "${parkedRel}" for "${submodulePath}"`,
+      );
+    }
+    if (existsSync(target)) {
+      throw new Error(
+        `unparkAssetSpace: refusing to unpark onto existing mount "${submodulePath}"`,
+      );
+    }
+    mkdirSync(dirname(target), { recursive: true });
+    renameSync(parked, target);
+  }
+
+  /**
+   * Shared traversal guard for every vault-relative path this service mutates
+   * (`rmSync` / `renameSync` are recursive and force, so a bad path could escape
+   * to the vault root or an unrelated directory). Validates BEFORE any mutation,
+   * including the `.gitmodules` edit.
+   *
+   * Extracted from {@link unmountAssetSpace} when park/unpark arrived — three
+   * copies of a destructive-path guard is how one of them ends up subtly weaker
+   * than the others.
+   *
+   * @param opName caller name, so the thrown message names the real operation.
+   * @param requireAssetspacesRoot `false` for the parked root, which lives under
+   *   `.exocortex/` rather than `assetspaces/`; the traversal + escape checks
+   *   still apply.
+   */
+  private assertSafeVaultTarget(
+    vaultPath: string,
+    relPath: string,
+    opName: string,
+    opts: { requireAssetspacesRoot?: boolean } = {},
+  ): string {
+    const requireAssetspacesRoot = opts.requireAssetspacesRoot ?? true;
+    const segments = relPath.split("/");
+    if (
+      relPath.length === 0 ||
+      (requireAssetspacesRoot && !relPath.startsWith("assetspaces/")) ||
+      segments.some((s) => s.length === 0 || s === "." || s === "..")
+    ) {
+      throw new Error(`${opName}: refusing unsafe submodulePath "${relPath}"`);
+    }
+    const root = resolve(vaultPath);
+    const target = resolve(root, relPath);
+    if (target === root || !target.startsWith(root + sep)) {
+      throw new Error(
+        `${opName}: target "${target}" escapes vault root "${root}"`,
+      );
+    }
+    return target;
   }
 }

--- a/packages/cli/src/services/CliApplyProfileService.ts
+++ b/packages/cli/src/services/CliApplyProfileService.ts
@@ -34,6 +34,9 @@ import {
   CATALOG_KEEP_NAMESPACES,
   TsFloorViolationError,
   parseYamlFrontmatterTolerant,
+  classifyMountTransition,
+  parkedPathFor,
+  type MountState,
 } from "@kitelev/exocortex-core";
 
 import {
@@ -76,6 +79,13 @@ export interface AssetSpaceInfo {
    * matches by namespace as well as by legacy UID.
    */
   namespace: string;
+  /**
+   * req `18ecf16f` / `d4ccc901` — RAW `exo__AssetSpace_dependsOnKind`: what
+   * depending on THIS AssetSpace means. Kept uninterpreted so
+   * `resolveDependencyKind`'s safe default (`tbox`) applies to every unreadable
+   * form. Decides park vs destroy when this AssetSpace leaves the effective set.
+   */
+  dependsOnKind?: string;
 }
 
 /** A single AssetSpace scheduled for tear-down. */
@@ -93,11 +103,24 @@ export interface MaterializeTarget {
   /** HTTPS GitHub URL used for the tarball pull (normalised from `git`). */
   httpsUrl: string;
   label: string;
+  /**
+   * req `d4ccc901` — how the bytes arrive. `"unpark"` = local rename back from
+   * `.exocortex/parked/` (offline, no download); `"pull"` = GitHub tarball.
+   * Both reach the SAME destination state through the same bookkeeping; this
+   * discriminates the acquisition step only.
+   */
+  source: "pull" | "unpark";
 }
 
 /** Result of {@link CliApplyProfileService.buildDiff}. */
 export interface ApplyProfileDiff {
   toDestroy: TearDownTarget[];
+  /**
+   * req `d4ccc901` — AssetSpaces leaving the effective set over a SOFT edge:
+   * moved aside, not deleted. Disjoint from {@link ApplyProfileDiff.toDestroy}
+   * by construction (one classification per AssetSpace).
+   */
+  toPark: TearDownTarget[];
   toMaterialize: MaterializeTarget[];
   plan: ApplyPlan;
 }
@@ -105,6 +128,9 @@ export interface ApplyProfileDiff {
 /** Result of {@link CliApplyProfileService.execute}. */
 export interface ApplyProfileExecResult {
   destroyed: string[];
+  /** req `d4ccc901` — moved to `.exocortex/parked/`, NOT deleted. */
+  parked: string[];
+  /** Includes unparked AssetSpaces — they reach `active` through this path. */
   materialized: string[];
 }
 
@@ -228,8 +254,15 @@ export class CliApplyProfileService {
               : "";
           const label =
             namespace || lastSegment(folderName) || uid.slice(0, 8);
+          const rawKind = fm["exo__AssetSpace_dependsOnKind"];
+          const dependsOnKind =
+            typeof rawKind === "string"
+              ? rawKind
+              : Array.isArray(rawKind) && typeof rawKind[0] === "string"
+                ? (rawKind[0] as string)
+                : undefined;
           seen.add(uid);
-          infos.push({ uid, git, folderName, label, namespace });
+          infos.push({ uid, git, folderName, label, namespace, dependsOnKind });
         }
 
         if (classes.includes(PROFILE_CLASS_UID)) {
@@ -316,13 +349,24 @@ export class CliApplyProfileService {
     // regardless).
     const effective = new Set<string>([...result.effective, ...declaredAsUids]);
 
-    // Mount-state: an AssetSpace is materialised iff its derived folder exists.
-    const materializedUids = new Set<string>();
+    // req `d4ccc901` — mount-state is now THREE-valued. `active` keeps its
+    // historical definition (the derived folder exists); `parked` means the
+    // folder was moved under `.exocortex/parked/` and the bytes are still on
+    // this device; `absent` means neither. `active` wins if both paths somehow
+    // exist — the live mount is the copy in use, and `parkAssetSpace` refuses
+    // that collision rather than resolving it silently.
+    const stateByUid = new Map<string, MountState>();
     for (const info of infos) {
-      if (existsSync(join(this.vaultPath, info.folderName))) {
-        materializedUids.add(info.uid);
-      }
+      const state: MountState = existsSync(join(this.vaultPath, info.folderName))
+        ? "active"
+        : existsSync(join(this.vaultPath, parkedPathFor(info.folderName)))
+          ? "parked"
+          : "absent";
+      stateByUid.set(info.uid, state);
     }
+    const materializedUids = new Set<string>(
+      [...stateByUid].filter(([, s]) => s === "active").map(([uid]) => uid),
+    );
 
     // EKA Alpha (issue #3511) — never tear down the catalog AssetSpaces
     // (central registry + profiles) that supply descriptors/profiles for
@@ -338,35 +382,65 @@ export class CliApplyProfileService {
       }
     }
 
+    // req `d4ccc901` — one classification pass over every known AssetSpace.
+    // Departures PARTITION: an AssetSpace goes to `toDestroy` XOR `toPark`,
+    // never both, because parking moves the whole mount folder. That partition
+    // is what keeps the confirm-gate honest — `filesToDestroy` is derived from
+    // `toDestroy` alone, so a parked AssetSpace's files are absent from the
+    // "N files to remove" count instead of being reported twice under two
+    // different verbs.
     const toDestroy: TearDownTarget[] = [];
-    for (const info of infos) {
-      if (!materializedUids.has(info.uid)) continue;
-      if (effective.has(info.uid)) continue;
-      toDestroy.push({
-        asUid: info.uid,
-        folderName: info.folderName,
-        label: info.label,
-        files: this.enumerateFilesUnder(info.folderName),
-      });
-    }
-
+    const toPark: TearDownTarget[] = [];
     const toMaterialize: MaterializeTarget[] = [];
-    for (const asUid of effective) {
-      if (materializedUids.has(asUid)) continue;
-      const info = infoByUid.get(asUid);
-      // AssetSpace in effective set but no descriptor (or no git URL) — cannot
-      // materialise; skip (matches plugin's `info === undefined` skip).
-      if (info === undefined) continue;
-      toMaterialize.push({
-        asUid: info.uid,
-        folderName: info.folderName,
-        httpsUrl: toHttpsGitHubUrl(info.git),
-        label: info.label,
+
+    for (const info of infos) {
+      const transition = classifyMountTransition({
+        state: stateByUid.get(info.uid) ?? "absent",
+        inEffectiveSet: effective.has(info.uid),
+        dependsOnKind: info.dependsOnKind,
       });
+      switch (transition) {
+        case "none":
+          break;
+        case "destroy":
+          toDestroy.push({
+            asUid: info.uid,
+            folderName: info.folderName,
+            label: info.label,
+            files: this.enumerateFilesUnder(info.folderName),
+          });
+          break;
+        case "park":
+          toPark.push({
+            asUid: info.uid,
+            folderName: info.folderName,
+            label: info.label,
+            files: this.enumerateFilesUnder(info.folderName),
+          });
+          break;
+        // `unpark` and `materialize` are the same destination — `active` — and
+        // travel one list so they share the post-acquisition bookkeeping
+        // (`.gitmodules` registration). Only `source` differs, and it decides
+        // one thing: whether the bytes come off this device or the network.
+        case "unpark":
+        case "materialize":
+          toMaterialize.push({
+            asUid: info.uid,
+            folderName: info.folderName,
+            httpsUrl: toHttpsGitHubUrl(info.git),
+            label: info.label,
+            source: transition === "unpark" ? "unpark" : "pull",
+          });
+          break;
+      }
     }
 
     const filesToDestroy = new Map<string, string[]>();
     for (const t of toDestroy) filesToDestroy.set(t.asUid, t.files);
+
+    const unparkedUids = new Set(
+      toMaterialize.filter((t) => t.source === "unpark").map((t) => t.asUid),
+    );
 
     const plan: ApplyPlan = {
       targetProfileUid,
@@ -379,13 +453,21 @@ export class CliApplyProfileService {
         asLabel: t.label,
         fileCount: t.files.length,
       })),
+      assetSpacesBeingParked: toPark.map((t) => ({
+        asUid: t.asUid,
+        asLabel: t.label,
+        fileCount: t.files.length,
+      })),
       assetSpacesBeingMaterialized: toMaterialize.map((t) => ({
         asUid: t.asUid,
         asLabel: t.label,
       })),
+      assetSpacesBeingUnparked: toMaterialize
+        .filter((t) => unparkedUids.has(t.asUid))
+        .map((t) => ({ asUid: t.asUid, asLabel: t.label })),
     };
 
-    return { toDestroy, toMaterialize, plan };
+    return { toDestroy, toPark, toMaterialize, plan };
   }
 
   /**
@@ -399,6 +481,7 @@ export class CliApplyProfileService {
    */
   async execute(diff: ApplyProfileDiff): Promise<ApplyProfileExecResult> {
     const destroyed: string[] = [];
+    const parked: string[] = [];
     const materialized: string[] = [];
 
     for (const target of diff.toDestroy) {
@@ -406,9 +489,24 @@ export class CliApplyProfileService {
       destroyed.push(target.asUid);
     }
 
+    // req `d4ccc901` — parking runs with the other departures, before any
+    // arrival, so a mount folder is always vacated before it could be claimed.
+    for (const target of diff.toPark) {
+      this.mount.parkAssetSpace(this.vaultPath, target.folderName);
+      parked.push(target.asUid);
+    }
+
     for (const target of diff.toMaterialize) {
-      const absTarget = join(this.vaultPath, target.folderName);
-      await this.mount.pullAssetSpace(target.httpsUrl, this.ref, absTarget);
+      // req `d4ccc901` — ONE arrival path. `source` selects how the bytes are
+      // acquired and nothing else: the `.gitmodules` registration and the
+      // `materialized` bookkeeping below are shared, so an unparked AssetSpace
+      // cannot end up in a half-registered state that a pulled one avoids.
+      if (target.source === "unpark") {
+        this.mount.unparkAssetSpace(this.vaultPath, target.folderName);
+      } else {
+        const absTarget = join(this.vaultPath, target.folderName);
+        await this.mount.pullAssetSpace(target.httpsUrl, this.ref, absTarget);
+      }
       this.mount.ensureGitmodulesEntry(
         this.vaultPath,
         target.folderName,
@@ -417,7 +515,7 @@ export class CliApplyProfileService {
       materialized.push(target.asUid);
     }
 
-    return { destroyed, materialized };
+    return { destroyed, parked, materialized };
   }
 
   // ───────────────────────────── internals ─────────────────────────────

--- a/packages/cli/src/services/HeadlessConfirmGate.ts
+++ b/packages/cli/src/services/HeadlessConfirmGate.ts
@@ -54,6 +54,27 @@ export class HeadlessConfirmGate implements IConfirmGate {
       this.log(
         `[apply-profile] ${totalFiles} files to remove, ${plan.assetSpacesBeingTornDown.length} AS to tear down, ${plan.assetSpacesBeingMaterialized.length} AS to materialize`,
       );
+      // req `d4ccc901` — parking gets its OWN line rather than being folded into
+      // the removal counts. `filesToDestroy` already excludes parked
+      // AssetSpaces, so the line above stays truthful; but without this line a
+      // park would be entirely INVISIBLE on the surface the user reads before
+      // typing `--yes`, and an unannounced mutation is no better than a
+      // mis-announced one. Emitted only when non-empty, so the common no-park
+      // apply reads exactly as it did before.
+      if (plan.assetSpacesBeingParked.length > 0) {
+        const parkedFiles = plan.assetSpacesBeingParked.reduce(
+          (sum, as) => sum + as.fileCount,
+          0,
+        );
+        this.log(
+          `[apply-profile] ${parkedFiles} files to park (moved to .exocortex/parked, NOT removed), ${plan.assetSpacesBeingParked.length} AS to park`,
+        );
+      }
+      if (plan.assetSpacesBeingUnparked.length > 0) {
+        this.log(
+          `[apply-profile] ${plan.assetSpacesBeingUnparked.length} AS to unpark (restored from .exocortex/parked, no download)`,
+        );
+      }
     }
 
     if (!this.yes) {

--- a/packages/cli/tests/unit/CliApplyProfileService.parked.test.ts
+++ b/packages/cli/tests/unit/CliApplyProfileService.parked.test.ts
@@ -1,0 +1,280 @@
+/**
+ * @jest-environment node
+ *
+ * @req:d4ccc901-83a4-4495-a4bb-43d1305dfd00
+ *
+ * req `d4ccc901` — the CLI producer side of the three-state mount model, against
+ * a REAL on-disk vault (no stubbed fs): a folder under `assetspaces/` means
+ * `active`, one under `.exocortex/parked/` means `parked`, neither means
+ * `absent`.
+ *
+ * ## Axes (one guard each)
+ *
+ *  A. departures PARTITION — a parked AssetSpace's files never reach
+ *     `filesToDestroy` / `assetSpacesBeingTornDown`, so the gate's
+ *     "N files to remove" stays literally true. Mutant: derive `filesToDestroy`
+ *     from `[...toDestroy, ...toPark]` → this reddens, the destroy case does not.
+ *  B. the plan CARRIES the park/unpark lists (the confirm-gate contract).
+ *  C. arrivals share ONE path — an unpark and a pull differ only in how the
+ *     bytes are acquired; `.gitmodules` registration and the `materialized`
+ *     bookkeeping are common. Mutant: skip `ensureGitmodulesEntry` for
+ *     `source === "unpark"` → the unpark case reddens, the pull case does not.
+ *  D. a hard (TBox) edge is still DESTROYED — parking is not applied blindly.
+ */
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync, existsSync } from "node:fs";
+import * as path from "node:path";
+import * as os from "node:os";
+
+import {
+  CliApplyProfileService,
+  type ApplyProfileDiff,
+} from "../../src/services/CliApplyProfileService";
+import { ASSET_SPACE_CLASS_UID } from "../../src/services/CliProfileResolver";
+import {
+  DEPENDENCY_KIND_REFERENCE_UID,
+  DEPENDENCY_KIND_TBOX_UID,
+  PARKED_ROOT,
+} from "@kitelev/exocortex-core";
+
+const FLOOR_UID = "11111111-1111-1111-1111-111111111111";
+const SOFT_UID = "22222222-2222-2222-2222-222222222222";
+const HARD_UID = "33333333-3333-3333-3333-333333333333";
+
+/** Records what the mount port was asked to do, without touching the network. */
+class MountSpy {
+  readonly calls: string[] = [];
+  pulled: string[] = [];
+  parked: string[] = [];
+  unparked: string[] = [];
+  gitmodules: string[] = [];
+
+  async pullAssetSpace(url: string, _ref: string, dest: string): Promise<void> {
+    this.calls.push(`pull:${dest}`);
+    this.pulled.push(dest);
+    mkdirSync(dest, { recursive: true });
+    writeFileSync(path.join(dest, "pulled.md"), `# from ${url}\n`);
+  }
+  parkAssetSpace(vaultPath: string, rel: string): void {
+    this.calls.push(`park:${rel}`);
+    this.parked.push(rel);
+  }
+  unparkAssetSpace(vaultPath: string, rel: string): void {
+    this.calls.push(`unpark:${rel}`);
+    this.unparked.push(rel);
+  }
+  ensureGitmodulesEntry(_vaultPath: string, rel: string, _url: string): void {
+    this.calls.push(`gitmodules:${rel}`);
+    this.gitmodules.push(rel);
+  }
+  unmountAssetSpace(_vaultPath: string, rel: string): void {
+    this.calls.push(`unmount:${rel}`);
+  }
+}
+
+function writeDescriptor(
+  root: string,
+  uid: string,
+  repo: string,
+  extra = "",
+  namespace = repo,
+): void {
+  const dir = path.join(root, "assetspaces", "_registry");
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(
+    path.join(dir, `${uid}.md`),
+    `---\n` +
+      `exo__Asset_uid: ${uid}\n` +
+      `exo__Instance_class:\n  - "[[${ASSET_SPACE_CLASS_UID}]]"\n` +
+      `exo__AssetSpace_namespace: ${namespace}\n` +
+      `exo__AssetSpace_source: "https://github.com/kitelev/${repo}"\n` +
+      extra +
+      `---\n`,
+  );
+}
+
+function mountFolder(repo: string): string {
+  return path.join("assetspaces", "kitelev", repo);
+}
+
+describe("@req:d4ccc901-83a4-4495-a4bb-43d1305dfd00 CliApplyProfileService — three mount states", () => {
+  let root: string;
+  let mount: MountSpy;
+  let svc: CliApplyProfileService;
+
+  beforeEach(() => {
+    root = mkdtempSync(path.join(os.tmpdir(), "exo-t3b-parked-"));
+    mount = new MountSpy();
+    svc = new CliApplyProfileService({
+      vaultPath: root,
+      mount: mount as unknown as never,
+    });
+    // The floor must stay declared or `assertTsFloor` refuses the whole plan —
+    // parking is not allowed to become a way around the floor policy.
+    // Namespace `exo` (not the repo name) — that is what the TS-floor guard
+    // matches on, so a floor descriptor named only by repo would abort every
+    // plan below with a self-brick refusal and hide the parking behaviour.
+    writeDescriptor(root, FLOOR_UID, "exoas-exo", "", "exo");
+    mkdirSync(path.join(root, mountFolder("exoas-exo")), { recursive: true });
+  });
+  afterEach(() => rmSync(root, { recursive: true, force: true }));
+
+  function diffFor(
+    declared: string[],
+  ): ApplyProfileDiff {
+    const { infos } = svc.scanVault();
+    return svc.buildDiff({
+      targetProfileUid: "p-target",
+      targetProfileLabel: "Target",
+      sourceProfileUid: null,
+      sourceProfileLabel: "<none>",
+      result: {
+        declaredOntologies: new Set([FLOOR_UID, ...declared]),
+        // `effective` is the post-floor set the diff intersects against; the
+        // declared set already carries the floor, so they coincide here.
+        effective: new Set([FLOOR_UID, ...declared]),
+      } as unknown as never,
+      infos,
+    });
+  }
+
+  it("parks a SOFT-edge departure instead of destroying it, and its files stay OUT of the remove count", () => {
+    writeDescriptor(
+      root,
+      SOFT_UID,
+      "exoas-soft",
+      `exo__AssetSpace_dependsOnKind: "[[${DEPENDENCY_KIND_REFERENCE_UID}]]"\n`,
+    );
+    const dir = path.join(root, mountFolder("exoas-soft"));
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(path.join(dir, "a.md"), "a");
+    writeFileSync(path.join(dir, "b.md"), "b");
+
+    const diff = diffFor([]); // soft AS omitted → departs
+
+    // AXIS A — the partition. Both halves asserted: present in `toPark`, and
+    // ABSENT from every destroy-shaped field. Only the second half reddens under
+    // the "put parks in filesToDestroy too" mutant.
+    expect(diff.toPark.map((t) => t.asUid)).toEqual([SOFT_UID]);
+    expect(diff.toDestroy).toHaveLength(0);
+    expect(diff.plan.filesToDestroy.get(SOFT_UID)).toBeUndefined();
+    expect(diff.plan.assetSpacesBeingTornDown).toHaveLength(0);
+    const totalFiles = [...diff.plan.filesToDestroy.values()].reduce(
+      (s, f) => s + f.length,
+      0,
+    );
+    expect(totalFiles).toBe(0);
+
+    // AXIS B — and it is ANNOUNCED, not merely omitted. Silence would be as
+    // dishonest as a wrong count: the user would see "0 files to remove" with no
+    // hint that an AssetSpace left the active set at all.
+    expect(diff.plan.assetSpacesBeingParked).toEqual([
+      { asUid: SOFT_UID, asLabel: "exoas-soft", fileCount: 2 },
+    ]);
+  });
+
+  it("still DESTROYS a hard (TBox) departure — parking is opt-in by dependency kind", () => {
+    writeDescriptor(
+      root,
+      HARD_UID,
+      "exoas-hard",
+      `exo__AssetSpace_dependsOnKind: "[[${DEPENDENCY_KIND_TBOX_UID}]]"\n`,
+    );
+    const dir = path.join(root, mountFolder("exoas-hard"));
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(path.join(dir, "a.md"), "a");
+
+    const diff = diffFor([]);
+
+    expect(diff.toPark).toHaveLength(0);
+    expect(diff.toDestroy.map((t) => t.asUid)).toEqual([HARD_UID]);
+    expect(diff.plan.filesToDestroy.get(HARD_UID)).toHaveLength(1);
+    expect(diff.plan.assetSpacesBeingParked).toHaveLength(0);
+  });
+
+  it("detects a PARKED AssetSpace and plans an unpark (not a fresh pull) when the profile wants it back", () => {
+    writeDescriptor(root, SOFT_UID, "exoas-soft");
+    // No mount folder; a parked copy instead.
+    mkdirSync(path.join(root, PARKED_ROOT, "kitelev", "exoas-soft"), {
+      recursive: true,
+    });
+
+    const diff = diffFor([SOFT_UID]);
+
+    expect(diff.toMaterialize).toHaveLength(1);
+    expect(diff.toMaterialize[0].source).toBe("unpark");
+    expect(diff.plan.assetSpacesBeingUnparked).toEqual([
+      { asUid: SOFT_UID, asLabel: "exoas-soft" },
+    ]);
+    // An unpark is still an arrival, so it belongs in the materialize list too —
+    // the modal's "will be available after this" section must not lose it.
+    expect(
+      diff.plan.assetSpacesBeingMaterialized.map((a) => a.asUid),
+    ).toContain(SOFT_UID);
+  });
+
+  it("plans a PULL when neither a mount nor a parked copy exists", () => {
+    writeDescriptor(root, SOFT_UID, "exoas-soft");
+    const diff = diffFor([SOFT_UID]);
+    expect(diff.toMaterialize[0].source).toBe("pull");
+    expect(diff.plan.assetSpacesBeingUnparked).toHaveLength(0);
+  });
+
+  it("execute(): an unpark renames back and STILL registers .gitmodules — one arrival path, not a copy", async () => {
+    writeDescriptor(root, SOFT_UID, "exoas-soft");
+    mkdirSync(path.join(root, PARKED_ROOT, "kitelev", "exoas-soft"), {
+      recursive: true,
+    });
+
+    const res = await svc.execute(diffFor([SOFT_UID]));
+
+    // AXIS C — the acquisition step branched…
+    expect(mount.unparked).toEqual([mountFolder("exoas-soft")]);
+    expect(mount.pulled).toHaveLength(0);
+    // …and everything downstream did NOT. A duplicated unpark path that forgot
+    // `ensureGitmodulesEntry` would leave the restored AssetSpace unregistered.
+    expect(mount.gitmodules).toEqual([mountFolder("exoas-soft")]);
+    expect(res.materialized).toEqual([SOFT_UID]);
+  });
+
+  it("execute(): a pull takes the SAME downstream steps as an unpark", async () => {
+    writeDescriptor(root, SOFT_UID, "exoas-soft");
+    const res = await svc.execute(diffFor([SOFT_UID]));
+    expect(mount.pulled).toHaveLength(1);
+    expect(mount.unparked).toHaveLength(0);
+    // Same registration, same bookkeeping — the shared tail.
+    expect(mount.gitmodules).toEqual([mountFolder("exoas-soft")]);
+    expect(res.materialized).toEqual([SOFT_UID]);
+  });
+
+  it("execute(): a park calls the park port and NEVER the unmount port", async () => {
+    writeDescriptor(
+      root,
+      SOFT_UID,
+      "exoas-soft",
+      `exo__AssetSpace_dependsOnKind: "[[${DEPENDENCY_KIND_REFERENCE_UID}]]"\n`,
+    );
+    mkdirSync(path.join(root, mountFolder("exoas-soft")), { recursive: true });
+
+    const res = await svc.execute(diffFor([]));
+
+    expect(mount.parked).toEqual([mountFolder("exoas-soft")]);
+    // The distinction that matters for the user's bytes: an unmount deletes.
+    expect(mount.calls.some((c) => c.startsWith("unmount:"))).toBe(false);
+    expect(res.parked).toEqual([SOFT_UID]);
+    expect(res.destroyed).toHaveLength(0);
+  });
+
+  it("a parked copy is invisible to the ACTIVE-set scan (it is not a mount)", () => {
+    // The property T3a proved for ExoSync, asserted here at the apply layer: the
+    // parked folder must not be mistaken for a materialised mount, or the next
+    // apply would think the AssetSpace is already active and skip the unpark.
+    writeDescriptor(root, SOFT_UID, "exoas-soft");
+    mkdirSync(path.join(root, PARKED_ROOT, "kitelev", "exoas-soft"), {
+      recursive: true,
+    });
+    expect(existsSync(path.join(root, mountFolder("exoas-soft")))).toBe(false);
+    const diff = diffFor([SOFT_UID]);
+    // Wanted + not active ⇒ an arrival is planned (rather than "none").
+    expect(diff.toMaterialize).toHaveLength(1);
+  });
+});

--- a/packages/cli/tests/unit/services/HeadlessConfirmGate.test.ts
+++ b/packages/cli/tests/unit/services/HeadlessConfirmGate.test.ts
@@ -20,6 +20,15 @@ function makePlan(overrides: Partial<ApplyPlan> = {}): ApplyPlan {
     assetSpacesBeingMaterialized: [
       { asUid: "as-work", asLabel: "work" },
     ],
+    // req `d4ccc901` — empty, and the pre-existing "2 files to remove" assertion
+    // below stays CORRECT rather than being grandfathered. The park/destroy
+    // partition happens in the PRODUCERS (`buildDiff` / the REST classification
+    // loop), which put an AssetSpace in `toDestroy` XOR `toPark`; this gate is a
+    // renderer and prints the plan it is handed. A fixture that hands it two
+    // files under `filesToDestroy` is by definition describing a destroy, so the
+    // count it must print is still 2. The park path gets its own fixture.
+    assetSpacesBeingParked: [],
+    assetSpacesBeingUnparked: [],
     ...overrides,
   };
 }
@@ -85,5 +94,59 @@ describe("HeadlessConfirmGate", () => {
     const gate = new HeadlessConfirmGate({ yes: true, log });
     await gate.confirmApply(makePlan());
     expect(log).not.toHaveBeenCalled();
+  });
+
+  /**
+   * @req:d4ccc901-83a4-4495-a4bb-43d1305dfd00
+   *
+   * req `d4ccc901` — the CLI half of "the plan a human approves must describe
+   * the mechanism". The compiler already forces this renderer to ACKNOWLEDGE the
+   * new fields (they are required on `ApplyPlan`); it cannot force it to PRINT
+   * them. So the mutant these guard against is not "field missing from the type"
+   * — it is deleting the `log(...)` call while keeping the field read. That
+   * compiles, and only these assertions redden.
+   */
+  describe("@req:d4ccc901-83a4-4495-a4bb-43d1305dfd00 parked / unparked lines", () => {
+    it("PRINTS a park line, and says the files are not removed", async () => {
+      const log = jest.fn<(m: string) => void>();
+      const gate = new HeadlessConfirmGate({ yes: true, verbose: true, log });
+      await gate.confirmApply(
+        makePlan({
+          filesToDestroy: new Map(),
+          assetSpacesBeingTornDown: [],
+          assetSpacesBeingParked: [
+            { asUid: "as-soft", asLabel: "soft", fileCount: 42 },
+          ],
+        }),
+      );
+      const joined = log.mock.calls.map((args) => args[0]).join("\n");
+      expect(joined).toContain("42 files to park");
+      expect(joined).toContain("1 AS to park");
+      // The whole point of the partition: the same 42 files must NOT also be
+      // announced as removals.
+      expect(joined).toContain("0 files to remove");
+    });
+
+    it("PRINTS an unpark line saying no download is involved", async () => {
+      const log = jest.fn<(m: string) => void>();
+      const gate = new HeadlessConfirmGate({ yes: true, verbose: true, log });
+      await gate.confirmApply(
+        makePlan({
+          assetSpacesBeingUnparked: [{ asUid: "as-soft", asLabel: "soft" }],
+        }),
+      );
+      const joined = log.mock.calls.map((args) => args[0]).join("\n");
+      expect(joined).toContain("1 AS to unpark");
+      expect(joined).toContain("no download");
+    });
+
+    it("stays SILENT about parking when nothing is parked (no noise on the common path)", async () => {
+      const log = jest.fn<(m: string) => void>();
+      const gate = new HeadlessConfirmGate({ yes: true, verbose: true, log });
+      await gate.confirmApply(makePlan());
+      const joined = log.mock.calls.map((args) => args[0]).join("\n");
+      expect(joined).not.toContain("to park");
+      expect(joined).not.toContain("to unpark");
+    });
   });
 });

--- a/packages/core/src/domain/profile/ParkedMountState.ts
+++ b/packages/core/src/domain/profile/ParkedMountState.ts
@@ -1,0 +1,220 @@
+/**
+ * req `d4ccc901` — the three mount states an AssetSpace can be in, and the
+ * transition `apply-profile` must perform to move it to the state the target
+ * profile asks for.
+ *
+ * ## Why a third state exists
+ *
+ * `apply-profile` used to know two: an AssetSpace was **materialized** (its
+ * derived folder exists) or **absent**. Leaving the effective set therefore had
+ * exactly one outcome — delete the folder — and returning cost a full network
+ * re-materialisation (measured ≈2.5 s and 0.7 MB per AssetSpace, against 23 ms
+ * and 0 bytes for a local move). **Parked** — on the device, not active — makes
+ * the common "take this off the device for now" operation cheap and reversible.
+ *
+ * ## Why the kind of the dependency decides park vs destroy
+ *
+ * `exo__AssetSpace_dependsOnKind` (req `18ecf16f`) already answers "what does
+ * depending on THIS AssetSpace mean". A **reference** (soft) edge supplies
+ * content: unmounting it costs reachability, so keeping the bytes is a pure win.
+ * A **tbox** (hard) edge supplies class / command definitions: a copy that sits
+ * on disk while being neither indexed nor enumerated by ExoSync is precisely the
+ * silent half-state in which assets lose their type with no signal at all.
+ * Destroying it stays loud, so `tbox` keeps the pre-existing behaviour.
+ *
+ * The asymmetry is deliberate and matches {@link resolveDependencyKind}'s own
+ * safe default: every unrecognised kind resolves to `tbox`, i.e. **the direction
+ * that hides files requires positive evidence**.
+ *
+ * ## Why parking is safe for ExoSync
+ *
+ * Proven separately by req `4eca4900`: both sync-unit collectors gate
+ * enumeration on the existence of the DERIVED mount path, so a parked
+ * AssetSpace is enumerated by neither, its deletion set is never computed, and
+ * `push` cannot wipe it on the remote. This module depends on that property and
+ * does not restate it.
+ */
+
+/** `exo__DependencyKindTBox` — hard edge: supplies definitions, cannot be parked. */
+export const DEPENDENCY_KIND_TBOX_UID = "e1d7fb5c-d334-448d-935b-953b7b033e78";
+
+/** `exo__DependencyKindReference` — soft edge: content only, parkable. */
+export const DEPENDENCY_KIND_REFERENCE_UID =
+  "fe529085-5370-4ac0-bbe4-1c7351242dee";
+
+/**
+ * `"tbox"` — depending on this AssetSpace means depending on its class /
+ * command definitions; unmounting it silently breaks type resolution.
+ * `"reference"` — content only; unmounting it costs reachability, not types.
+ */
+export type DependencyKind = "tbox" | "reference";
+
+/** Lower-cased symbolic local name the RDF converter emits for the soft value. */
+const REFERENCE_LOCAL_NAME = "dependencykindreference";
+
+/**
+ * req `18ecf16f` — resolve `exo__AssetSpace_dependsOnKind` from raw frontmatter.
+ *
+ * **The safe default is structural, not a fallback branch:** `"reference"` is
+ * returned ONLY on a positive match of the known soft value. Absent, empty,
+ * unrecognised, wrong-typed — every other input yields `"tbox"`. A wrong
+ * `"reference"` silently loses a class type at runtime; a wrong `"tbox"` only
+ * costs an extra refusal, so the unsafe outcome is the one made to require
+ * evidence.
+ *
+ * Accepts every form the value can reach a runtime in, because the plugin reads
+ * FRONTMATTER (`metadataCache`) while the graph emits the same value as a
+ * symbolic IRI (its label parses as `prefix__Local`, so the converter substitutes
+ * it) — an author or a migration may legitimately produce either:
+ * `[[<uid>]]`, `[[<uid>|exo__DependencyKindReference]]`, a bare UID,
+ * `exo__DependencyKindReference`, or the full `…/exo#DependencyKindReference` IRI.
+ * A one-element array is unwrapped (`Single` cardinality, but `metadataCache`
+ * hands back a list when the author writes YAML list syntax).
+ *
+ * When BOTH a known UID and a conflicting symbolic name are present (a
+ * mismatched alias such as `[[<tbox-uid>|exo__DependencyKindReference]]`), the
+ * UID wins — it is the link target, i.e. what the graph actually resolves.
+ */
+export function resolveDependencyKind(raw: unknown): DependencyKind {
+  const value = Array.isArray(raw) ? raw[0] : raw;
+  if (typeof value !== "string") return "tbox";
+  const normalized = value.toLowerCase();
+  // UID first: it is the link target and therefore authoritative over an alias.
+  if (normalized.includes(DEPENDENCY_KIND_TBOX_UID)) return "tbox";
+  if (normalized.includes(DEPENDENCY_KIND_REFERENCE_UID)) return "reference";
+  // No known UID — fall back to the symbolic form the RDF converter emits.
+  if (normalized.includes(REFERENCE_LOCAL_NAME)) return "reference";
+  return "tbox";
+}
+
+/** Vault-relative root every parked mount is moved under. */
+export const PARKED_ROOT = ".exocortex/parked";
+
+/** Prefix every derived mount folder carries (`AssetSpacePathDeriver`). */
+const MOUNT_ROOT = "assetspaces/";
+
+/**
+ * Where a mount folder lives while parked — DERIVED, never stored.
+ *
+ * `assetspaces/<owner>/<repo>` → `.exocortex/parked/<owner>/<repo>`.
+ *
+ * `.exocortex/` and not `.obsidian/plugins/exocortex/`: BRAT overwrites the
+ * plugin directory on every update, which would silently destroy parked mounts.
+ *
+ * Deriving (rather than storing a second path alongside the first) is what keeps
+ * the two locations from drifting: there is exactly one function that knows the
+ * mapping, so a test cannot stay green against a dead deriver by hand-writing
+ * the parked path.
+ *
+ * @param folderName vault-relative derived mount folder.
+ * @returns the vault-relative parked location.
+ * @throws when `folderName` is not a well-formed mount folder — an unchecked
+ *   value here would move a directory to an attacker-chosen place, so this
+ *   fails loud rather than falling back to a "best effort" path.
+ */
+export function parkedPathFor(folderName: string): string {
+  const segments = folderName.split("/");
+  if (
+    folderName.length === 0 ||
+    !folderName.startsWith(MOUNT_ROOT) ||
+    segments.some((s) => s.length === 0 || s === "." || s === "..")
+  ) {
+    throw new Error(
+      `parkedPathFor: refusing unsafe mount folder "${folderName}"`,
+    );
+  }
+  return `${PARKED_ROOT}/${folderName.slice(MOUNT_ROOT.length)}`;
+}
+
+/**
+ * Where an AssetSpace's bytes currently are.
+ *
+ * - `active`  — the derived mount folder exists; the AssetSpace is indexed and
+ *   enumerated as a sync unit.
+ * - `parked`  — the derived mount folder is gone, but a full copy sits under
+ *   {@link PARKED_ROOT}; on the device, invisible to indexing and to ExoSync.
+ * - `absent`  — neither location exists.
+ */
+export type MountState = "active" | "parked" | "absent";
+
+/**
+ * What `apply-profile` must do to reach the state the target profile asks for.
+ *
+ * `none` is an explicit member rather than a `null`: "a parked AssetSpace the
+ * profile omits is deliberately left alone" is a decision the transition table
+ * makes, and naming it keeps a caller from reading a falsy value as "unhandled".
+ */
+export type MountTransition =
+  | "none"
+  | "park"
+  | "unpark"
+  | "destroy"
+  | "materialize";
+
+/** Inputs of {@link classifyMountTransition}. */
+export interface MountTransitionInput {
+  /** Where the AssetSpace's bytes are right now. */
+  state: MountState;
+  /** Whether the target profile's effective set includes this AssetSpace. */
+  inEffectiveSet: boolean;
+  /**
+   * RAW `exo__AssetSpace_dependsOnKind` of this AssetSpace's own registry
+   * descriptor. Interpreted by {@link resolveDependencyKind} — pass it
+   * uninterpreted so the safe default applies to every unreadable form.
+   */
+  dependsOnKind?: unknown;
+  /**
+   * Whether the caller is ABLE to park (has a mount port that can move folders).
+   * Default `true`.
+   *
+   * ⛔ Exists so a caller that cannot park never PLANS one. Planning a park and
+   * silently falling back to a destroy at execution time is the worse failure by
+   * far: the approval card would read "kept on this device" while the files were
+   * deleted — the surface describing the opposite of the mechanism, at the exact
+   * moment consent is given. Refusing to plan what you cannot do degrades to the
+   * pre-existing destroy semantics, which is at least what the card then says.
+   */
+  canPark?: boolean;
+}
+
+/**
+ * req `d4ccc901` — the single place that decides what happens to one AssetSpace.
+ *
+ * Pure and total: every (state × membership) pair maps to exactly one
+ * transition, so a new state cannot be added without this table refusing to
+ * compile against its own switch.
+ *
+ * | state \ in effective set | yes           | no                        |
+ * |--------------------------|---------------|---------------------------|
+ * | `active`                 | `none`        | `park` (soft) / `destroy` |
+ * | `parked`                 | `unpark`      | `none`                    |
+ * | `absent`                 | `materialize` | `none`                    |
+ *
+ * The one cell that reads the dependency kind is `active` + not-included: that
+ * is the only decision where the AssetSpace's own semantics (content vs
+ * definitions) changes what is safe. Everywhere else the state already
+ * determines the answer.
+ *
+ * ⛔ The TS-floor assertion and the catalog-keep rule run BEFORE this
+ * classification, so `exoas-exo` and `exoas-registry` never reach a `park` or
+ * `destroy` cell at all — this function is not the guard that protects them.
+ */
+export function classifyMountTransition(
+  input: MountTransitionInput,
+): MountTransition {
+  const { state, inEffectiveSet, dependsOnKind, canPark = true } = input;
+  switch (state) {
+    case "active":
+      if (inEffectiveSet) return "none";
+      return canPark && resolveDependencyKind(dependsOnKind) === "reference"
+        ? "park"
+        : "destroy";
+    case "parked":
+      // Not in the effective set → stays parked. This is the cell that keeps
+      // `reconcileToLocal` from computing a deletion for bytes the user
+      // deliberately kept on the device.
+      return inEffectiveSet ? "unpark" : "none";
+    case "absent":
+      return inEffectiveSet ? "materialize" : "none";
+  }
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -68,6 +68,20 @@ export {
 } from "./domain/profile/TsFloorGuard";
 export type { FloorIdentity } from "./domain/profile/TsFloorGuard";
 export { transitiveDependsOnClosure } from "./domain/profile/AssetSpaceDependsOn";
+export {
+  DEPENDENCY_KIND_TBOX_UID,
+  DEPENDENCY_KIND_REFERENCE_UID,
+  PARKED_ROOT,
+  classifyMountTransition,
+  parkedPathFor,
+  resolveDependencyKind,
+} from "./domain/profile/ParkedMountState";
+export type {
+  DependencyKind,
+  MountState,
+  MountTransition,
+  MountTransitionInput,
+} from "./domain/profile/ParkedMountState";
 export type { IPropertyValidationService, ValidationResult } from "./domain/services/IPropertyValidationService";
 
 // Property definition types

--- a/packages/core/src/services/profile/IConfirmGate.ts
+++ b/packages/core/src/services/profile/IConfirmGate.ts
@@ -37,12 +37,21 @@ export interface ApplyPlan {
    * Files about to be deleted, grouped by owning assetspace UID. Values are
    * vault-relative paths. The map is read-only to prevent adapters from
    * accidentally rewriting the plan during confirmation rendering.
+   *
+   * req `d4ccc901` — a PARKED assetspace is deliberately absent here. Its files
+   * are not deleted, only moved, so counting them as "files to remove" would
+   * make the approval card describe a reversible local move as a destruction —
+   * at the exact moment consent is given, and unfalsifiably afterwards (the
+   * files are still there).
    */
   filesToDestroy: ReadonlyMap<string /* asUid */, ReadonlyArray<string /* relative path */>>;
   /**
    * Assetspaces being torn down — UID, label, file count. Distinct from
    * `filesToDestroy.keys()` because the modal shows assetspace cardinality
    * (one bullet per AS) separately from the per-file list.
+   *
+   * req `d4ccc901` — DESTRUCTION only. Parked assetspaces live in
+   * {@link ApplyPlan.assetSpacesBeingParked}.
    */
   assetSpacesBeingTornDown: ReadonlyArray<{
     asUid: string;
@@ -50,10 +59,43 @@ export interface ApplyPlan {
     fileCount: number;
   }>;
   /**
+   * req `d4ccc901` — assetspaces leaving the effective set via a SOFT
+   * (`exo__DependencyKindReference`) edge: their mount is moved to
+   * `.exocortex/parked/<owner>/<repo>` rather than removed, so the bytes stay on
+   * the device and returning is a local move instead of a network pull.
+   *
+   * Required, not optional, on purpose: an optional field is one a renderer can
+   * forget, and the failure mode of forgetting is a gate that says "N files to
+   * remove" while a park happens. Making it required turns that into a compile
+   * error at every construction and rendering site.
+   */
+  assetSpacesBeingParked: ReadonlyArray<{
+    asUid: string;
+    asLabel: string;
+    fileCount: number;
+  }>;
+  /**
    * Assetspaces being materialized (cache-restored or GitHub-pulled). The
    * Phase 3 orchestrator computes this; Phase 1b only renders it.
+   *
+   * req `d4ccc901` — includes assetspaces returning FROM the parked state: they
+   * reach `active` through the same materialise bookkeeping, differing only in
+   * how the bytes arrive (local move vs network pull). See
+   * {@link ApplyPlan.assetSpacesBeingUnparked} for the subset that costs no
+   * network.
    */
   assetSpacesBeingMaterialized: ReadonlyArray<{
+    asUid: string;
+    asLabel: string;
+  }>;
+  /**
+   * req `d4ccc901` — the subset of {@link ApplyPlan.assetSpacesBeingMaterialized}
+   * restored from `.exocortex/parked/` rather than pulled over the network.
+   *
+   * Rendered separately so the user can tell a free, offline restore from a
+   * download before approving — the two look identical in the count alone.
+   */
+  assetSpacesBeingUnparked: ReadonlyArray<{
     asUid: string;
     asLabel: string;
   }>;

--- a/packages/core/tests/domain/profile/ParkedMountState.test.ts
+++ b/packages/core/tests/domain/profile/ParkedMountState.test.ts
@@ -1,0 +1,183 @@
+/**
+ * @req:d4ccc901-83a4-4495-a4bb-43d1305dfd00
+ *
+ * req `d4ccc901` — the three-state transition table and the parked-path deriver.
+ *
+ * ## Axes (one guard each — a mutant that removes ONE must redden ONLY its own)
+ *
+ *  A. the soft/hard split at `active` + not-included (park vs destroy)
+ *  B. `canPark: false` degrades a park to the pre-existing destroy
+ *  C. the `parked` row (unpark when wanted, LEAVE ALONE when not) — this is the
+ *     cell `reconcileToLocal` leans on to compute no deletion
+ *  D. `parkedPathFor` derives, and REFUSES a malformed folder
+ *
+ * ⛔ The mutants that prove these must be SEMANTICALLY VALID. `false || X` is
+ * `X` and a dead branch placed before a live one is unreachable — both are
+ * no-ops, so both would pass and be misread as "the axis does not discriminate".
+ * The mutations named per axis below all change behaviour.
+ */
+import { describe, it, expect } from "@jest/globals";
+import {
+  classifyMountTransition,
+  parkedPathFor,
+  PARKED_ROOT,
+  DEPENDENCY_KIND_REFERENCE_UID,
+  DEPENDENCY_KIND_TBOX_UID,
+  type MountState,
+  type MountTransition,
+} from "../../../src/domain/profile/ParkedMountState";
+
+const SOFT = `[[${DEPENDENCY_KIND_REFERENCE_UID}]]`;
+const HARD = `[[${DEPENDENCY_KIND_TBOX_UID}]]`;
+
+describe("@req:d4ccc901-83a4-4495-a4bb-43d1305dfd00 classifyMountTransition — req d4ccc901", () => {
+  /**
+   * The whole table in one place. Written as data so a NEW state cannot be added
+   * without a row here going missing — a prose-only test would silently keep
+   * passing while a fourth state fell through.
+   */
+  const TABLE: ReadonlyArray<{
+    state: MountState;
+    inEffectiveSet: boolean;
+    dependsOnKind?: unknown;
+    expected: MountTransition;
+    why: string;
+  }> = [
+    {
+      state: "active",
+      inEffectiveSet: true,
+      expected: "none",
+      why: "already where the profile wants it",
+    },
+    {
+      state: "active",
+      inEffectiveSet: false,
+      dependsOnKind: SOFT,
+      expected: "park",
+      why: "soft edge — content only, keeping the bytes costs nothing",
+    },
+    {
+      state: "active",
+      inEffectiveSet: false,
+      dependsOnKind: HARD,
+      expected: "destroy",
+      why: "hard edge — a half-present TBox provider is the silent state",
+    },
+    {
+      state: "active",
+      inEffectiveSet: false,
+      dependsOnKind: undefined,
+      expected: "destroy",
+      why: "absent kind resolves HARD — the hiding direction needs evidence",
+    },
+    {
+      state: "parked",
+      inEffectiveSet: true,
+      expected: "unpark",
+      why: "bytes are on the device — a rename, not a download",
+    },
+    {
+      state: "parked",
+      inEffectiveSet: false,
+      expected: "none",
+      why: "left alone — this is why reconcile computes no deletion for it",
+    },
+    {
+      state: "absent",
+      inEffectiveSet: true,
+      expected: "materialize",
+      why: "nothing local to reuse",
+    },
+    { state: "absent", inEffectiveSet: false, expected: "none", why: "nothing to do" },
+  ];
+
+  it.each(TABLE)(
+    "$state + inEffectiveSet=$inEffectiveSet → $expected ($why)",
+    ({ state, inEffectiveSet, dependsOnKind, expected }) => {
+      expect(
+        classifyMountTransition({ state, inEffectiveSet, dependsOnKind }),
+      ).toBe(expected);
+    },
+  );
+
+  it("covers every (state × membership) pair — the table is exhaustive", () => {
+    // Guards the table itself: 3 states × 2 memberships = 6 distinct pairs, and
+    // the `active`+not-included pair is split three ways by dependency kind.
+    // Without this the table above could quietly lose a row and stay green.
+    const pairs = new Set(
+      TABLE.map((r) => `${r.state}:${String(r.inEffectiveSet)}`),
+    );
+    expect(pairs.size).toBe(6);
+  });
+
+  /**
+   * AXIS B — `canPark: false` must fall back to DESTROY, not to park-and-hope.
+   *
+   * Mutant: drop `canPark &&` from the `active` arm. Only this reddens: every
+   * other row either never reaches the dependency-kind read or passes the
+   * default `canPark: true`.
+   */
+  it("refuses to PLAN a park the caller cannot execute (canPark=false → destroy)", () => {
+    expect(
+      classifyMountTransition({
+        state: "active",
+        inEffectiveSet: false,
+        dependsOnKind: SOFT,
+        canPark: false,
+      }),
+    ).toBe("destroy");
+    // …and the same input WITH the capability parks, so the guard is what moved
+    // the answer — not the dependency kind.
+    expect(
+      classifyMountTransition({
+        state: "active",
+        inEffectiveSet: false,
+        dependsOnKind: SOFT,
+        canPark: true,
+      }),
+    ).toBe("park");
+  });
+
+  it("canPark=false does NOT suppress an unpark — it only gates NEW parks", () => {
+    // A parked copy already on disk must still be restorable; `canPark` answers
+    // "may I hide more", not "may I stop hiding".
+    expect(
+      classifyMountTransition({
+        state: "parked",
+        inEffectiveSet: true,
+        canPark: false,
+      }),
+    ).toBe("unpark");
+  });
+});
+
+describe("@req:d4ccc901-83a4-4495-a4bb-43d1305dfd00 parkedPathFor — req d4ccc901", () => {
+  it("derives the parked location from the mount folder", () => {
+    expect(parkedPathFor("assetspaces/kitelev/exoas-public")).toBe(
+      `${PARKED_ROOT}/kitelev/exoas-public`,
+    );
+  });
+
+  it("parks under .exocortex/, never under .obsidian/plugins/", () => {
+    // BRAT overwrites the plugin directory on every update; a parked mount living
+    // there would be destroyed by a routine plugin upgrade.
+    const p = parkedPathFor("assetspaces/o/r");
+    expect(p.startsWith(".exocortex/")).toBe(true);
+    expect(p.includes(".obsidian")).toBe(false);
+  });
+
+  /**
+   * AXIS D — the refusal. Mutant: delete the `segments.some(...)` clause.
+   * Only these reden; the happy-path derivation above stays green, which is what
+   * makes this a guard test rather than a restatement of the deriver.
+   */
+  it.each([
+    ["", "empty"],
+    ["assetspaces/../../etc", "traversal"],
+    ["assetspaces//repo", "empty segment"],
+    ["assetspaces/./repo", "dot segment"],
+    ["not-a-mount/repo", "outside the mount root"],
+  ])("refuses %s (%s) rather than moving a directory somewhere else", (bad) => {
+    expect(() => parkedPathFor(bad)).toThrow(/refusing unsafe mount folder/);
+  });
+});

--- a/packages/obsidian-plugin/src/adapters/logging/activityFanIn.ts
+++ b/packages/obsidian-plugin/src/adapters/logging/activityFanIn.ts
@@ -23,6 +23,11 @@ const PHASE_LABELS: Record<SwitchJournalEntry["phase"], string> = {
   "phase2-start": "Materialization started (phase 2)",
   "phase2-destroy-cached": "Cached before unmount",
   "phase2-destroyed": "Unmounted",
+  // req `d4ccc901` — parking is a distinct outcome from unmounting, and the
+  // journal is the artefact recovery reads. Reusing the destroy labels here
+  // would make an interrupted apply look like it deleted what it moved.
+  "phase2-parked": "Parked (kept on this device)",
+  "phase2-unparked": "Restored from this device",
   "phase2-materializing": "Materializing",
   "phase2-materialized": "Mounted",
   "phase2-done": "Materialization complete (phase 2)",
@@ -69,10 +74,20 @@ export function journalEntryToActivity(
 }
 
 /** Present-tense verbs for the live per-AssetSpace progress feed. */
-const PROGRESS_VERBS: Record<"pull" | "mount" | "unmount", string> = {
+const PROGRESS_VERBS: Record<
+  "pull" | "mount" | "unmount" | "park" | "unpark",
+  string
+> = {
   pull: "Pulling",
   mount: "Mounting",
   unmount: "Unmounting",
+  // req `d4ccc901` — a park must never read as an unmount here. The activity log
+  // is where a user looks AFTER the fact to answer "where did my files go"; a
+  // park logged as "Unmounting" would send them hunting a re-download instead of
+  // the one-rename return, and an unpark logged as "Mounting" would hide that
+  // the bytes never left the device.
+  park: "Parking",
+  unpark: "Restoring from device",
 };
 
 /**

--- a/packages/obsidian-plugin/src/domain/profile/dependencyKind.ts
+++ b/packages/obsidian-plugin/src/domain/profile/dependencyKind.ts
@@ -2,6 +2,16 @@
  * req `18ecf16f` — the KIND of an `exo__AssetSpace_dependsOn` dependency, read
  * from the graph instead of a hardcoded namespace list.
  *
+ * ## Where the implementation lives (and why it moved)
+ *
+ * req `d4ccc901` — the CLI apply path needs the SAME reading to decide park vs
+ * destroy, so the implementation moved to
+ * `@kitelev/exocortex-core` (`domain/profile/ParkedMountState`). Duplicating it
+ * per package would let the two runtimes disagree about which AssetSpaces are
+ * parkable — the exact class of CLI/plugin divergence this subsystem keeps
+ * getting bitten by. This module stays as the plugin-local name so existing
+ * importers (`closureGap`, `unmountSafety`) are unaffected.
+ *
  * ## Why this is a property of the TARGET node, not of the edge
  *
  * `exo__AssetSpace_dependsOn` is 0..N while `exo__AssetSpace_dependsOnKind` is
@@ -30,54 +40,9 @@
  * `PRINTED_PROPERTY_CLASS_UID`). That is Q3 (core processing), not Q1.
  */
 
-/** `exo__DependencyKindTBox` — hard edge: supplies definitions, cannot be parked. */
-export const DEPENDENCY_KIND_TBOX_UID = "e1d7fb5c-d334-448d-935b-953b7b033e78";
-
-/** `exo__DependencyKindReference` — soft edge: content only, parkable. */
-export const DEPENDENCY_KIND_REFERENCE_UID =
-  "fe529085-5370-4ac0-bbe4-1c7351242dee";
-
-/**
- * `"tbox"` — depending on this AssetSpace means depending on its class /
- * command definitions; unmounting it silently breaks type resolution.
- * `"reference"` — content only; unmounting it costs reachability, not types.
- */
-export type DependencyKind = "tbox" | "reference";
-
-/** Lower-cased symbolic local name the RDF converter emits for the soft value. */
-const REFERENCE_LOCAL_NAME = "dependencykindreference";
-
-/**
- * req `18ecf16f` — resolve `exo__AssetSpace_dependsOnKind` from raw frontmatter.
- *
- * **The safe default is structural, not a fallback branch:** `"reference"` is
- * returned ONLY on a positive match of the known soft value. Absent, empty,
- * unrecognised, wrong-typed — every other input yields `"tbox"`. A wrong
- * `"reference"` silently loses a class type at runtime; a wrong `"tbox"` only
- * costs an extra refusal, so the unsafe outcome is the one made to require
- * evidence.
- *
- * Accepts every form the value can reach the plugin in, because the plugin reads
- * FRONTMATTER (`metadataCache`) while the graph emits the same value as a
- * symbolic IRI (its label parses as `prefix__Local`, so the converter substitutes
- * it) — an author or a migration may legitimately produce either:
- * `[[<uid>]]`, `[[<uid>|exo__DependencyKindReference]]`, a bare UID,
- * `exo__DependencyKindReference`, or the full `…/exo#DependencyKindReference` IRI.
- * A one-element array is unwrapped (`Single` cardinality, but `metadataCache`
- * hands back a list when the author writes YAML list syntax).
- *
- * When BOTH a known UID and a conflicting symbolic name are present (a
- * mismatched alias such as `[[<tbox-uid>|exo__DependencyKindReference]]`), the
- * UID wins — it is the link target, i.e. what the graph actually resolves.
- */
-export function resolveDependencyKind(raw: unknown): DependencyKind {
-  const value = Array.isArray(raw) ? raw[0] : raw;
-  if (typeof value !== "string") return "tbox";
-  const normalized = value.toLowerCase();
-  // UID first: it is the link target and therefore authoritative over an alias.
-  if (normalized.includes(DEPENDENCY_KIND_TBOX_UID)) return "tbox";
-  if (normalized.includes(DEPENDENCY_KIND_REFERENCE_UID)) return "reference";
-  // No known UID — fall back to the symbolic form the RDF converter emits.
-  if (normalized.includes(REFERENCE_LOCAL_NAME)) return "reference";
-  return "tbox";
-}
+export {
+  DEPENDENCY_KIND_TBOX_UID,
+  DEPENDENCY_KIND_REFERENCE_UID,
+  resolveDependencyKind,
+} from "@kitelev/exocortex-core";
+export type { DependencyKind } from "@kitelev/exocortex-core";

--- a/packages/obsidian-plugin/src/infrastructure/adapters/ModalConfirmGate.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/ModalConfirmGate.ts
@@ -120,7 +120,38 @@ class ApplyConfirmModal extends Modal {
       }
     }
 
-    // Section 3 — Assetspaces being materialized
+    // Section 3 — req `d4ccc901` — Assetspaces being PARKED (kept on device).
+    //
+    // Its own section, above "to materialize" and below the removal sections,
+    // because parking is the operation most easily mistaken for removal: the
+    // AssetSpace disappears from the vault either way. `filesToDestroy` already
+    // excludes parked AssetSpaces, so the counts above are truthful — but a
+    // park with no section of its own would be an entirely UNANNOUNCED
+    // mutation on the one surface the user reads before approving. Rendered
+    // only when non-empty, so a no-park apply looks exactly as it did.
+    if (this.plan.assetSpacesBeingParked.length > 0) {
+      const parkSection = contentEl.createEl("div", {
+        cls: "apply-confirm-park-section",
+      });
+      const parkedFiles = this.plan.assetSpacesBeingParked.reduce(
+        (sum, as) => sum + as.fileCount,
+        0,
+      );
+      parkSection.createEl("h3", {
+        text: `Assetspaces to park — kept on this device (${parkedFiles} files)`,
+      });
+      parkSection.createEl("p", {
+        text: "Moved to .exocortex/parked, not deleted. Returning to them is a local move — no download.",
+      });
+      const parkList = parkSection.createEl("ul");
+      for (const as of this.plan.assetSpacesBeingParked) {
+        parkList.createEl("li", {
+          text: `${as.asLabel} (${as.fileCount} files)`,
+        });
+      }
+    }
+
+    // Section 4 — Assetspaces being materialized
     const matSection = contentEl.createEl("div", {
       cls: "apply-confirm-mat-section",
     });
@@ -128,9 +159,18 @@ class ApplyConfirmModal extends Modal {
     if (this.plan.assetSpacesBeingMaterialized.length === 0) {
       matSection.createEl("p", { text: "(none)" });
     } else {
+      // req `d4ccc901` — mark the ones restored from `.exocortex/parked`: they
+      // cost no network and work offline, which the bare label cannot convey.
+      const unparkedUids = new Set(
+        this.plan.assetSpacesBeingUnparked.map((as) => as.asUid),
+      );
       const matList = matSection.createEl("ul");
       for (const as of this.plan.assetSpacesBeingMaterialized) {
-        matList.createEl("li", { text: as.asLabel });
+        matList.createEl("li", {
+          text: unparkedUids.has(as.asUid)
+            ? `${as.asLabel} (unpark — restored from this device, no download)`
+            : as.asLabel,
+        });
       }
     }
 

--- a/packages/obsidian-plugin/src/infrastructure/adapters/ProfileApplyManager.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/ProfileApplyManager.ts
@@ -2066,13 +2066,25 @@ export class ProfileApplyManager {
           index: i + 1,
           total: toPark.length,
         });
-        await this.parkAssetSpace(target.submodulePath);
+        // Journal BEFORE the move, mirroring the git destroy path's F2 ordering
+        // (`phase2-destroy-cached` precedes `rm -rf`). A crash in the opposite
+        // ordering would not lose bytes — a park is a rename, the folder sits
+        // intact under `.exocortex/parked/`, and the classifier probes DISK
+        // (`isParkedOnDisk`), not the journal, so the next apply reconciles it.
+        // What it would lose is ROLLBACK: `recoverIncompleteSwitch` restores the
+        // pre-apply mount-state from `interrupted.parked`, so an unjournalled
+        // park leaves that one AssetSpace parked while its siblings are restored
+        // — a half-applied state, which is exactly what recovery promises not to
+        // leave. The inverse window is benign and self-announcing: if the move
+        // then fails, recovery's `unpark` finds nothing parked, throws, and the
+        // catch journals the error (same trade the destroy path already makes).
         await this.appendJournal({
           phase: "phase2-parked",
           targetUid: targetProfileUid,
           as: target.asUid,
           ts: this.now().toISOString(),
         });
+        await this.parkAssetSpace(target.submodulePath);
       }
 
       // Persist the applied profile as last-applied cache + clear in-progress,

--- a/packages/obsidian-plugin/src/infrastructure/adapters/ProfileApplyManager.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/ProfileApplyManager.ts
@@ -1,5 +1,10 @@
 import type { App } from "obsidian";
-import type { ApplyPlan, IConfirmGate, MountProgressPhase } from "@kitelev/exocortex-core";
+import type {
+  ApplyPlan,
+  IConfirmGate,
+  MountProgressPhase,
+  MountState,
+} from "@kitelev/exocortex-core";
 import {
   derivePath,
   deriveLegacyFlatPath,
@@ -9,6 +14,8 @@ import {
   transitiveDependsOnClosure,
   TsFloorViolationError,
   isAssetSpaceFrontmatter,
+  classifyMountTransition,
+  parkedPathFor,
 } from "@kitelev/exocortex-core";
 
 import {
@@ -153,6 +160,16 @@ export interface SwitchJournalEntry {
     | "phase2-destroyed"
     | "phase2-materializing"
     | "phase2-materialized"
+    // req `d4ccc901` — parking gets its OWN stages rather than reusing
+    // `phase2-destroy-cached` / `phase2-destroyed`. Not hygiene: the crash
+    // classifier below reads `phase2-destroy-cached` as "this AssetSpace is in
+    // the SwitchCacheLayer" and recovery answers it with `cacheLayer.restore()`.
+    // A park writes no cache entry, so borrowing that stage would make recovery
+    // look for an archive that does not exist and report the AssetSpace as
+    // unrecoverable — while its bytes sit intact in `.exocortex/parked/`.
+    // Data present, declared lost. These stages route to a rename-back instead.
+    | "phase2-parked"
+    | "phase2-unparked"
     | "phase2-done"
     | "git-commit-done"
     | "apply-completed"
@@ -188,8 +205,17 @@ export interface SwitchJournalEntry {
  */
 export type ApplyProgressEvent =
   | {
-      /** Which per-AssetSpace operation is about to start / progressing. */
-      op: "pull" | "mount" | "unmount";
+      /**
+       * Which per-AssetSpace operation is about to start / progressing.
+       *
+       * req `d4ccc901` — `park` / `unpark` are distinct from `unmount` / `mount`
+       * on purpose: they are the ops that DON'T touch the network and DON'T
+       * delete anything, and the activity log is where a user sees which of the
+       * two actually happened. Folding them into the existing verbs would make a
+       * ~23 ms local rename indistinguishable from a multi-second download or a
+       * deletion in the only running commentary the apply produces.
+       */
+      op: "pull" | "mount" | "unmount" | "park" | "unpark";
       /**
        * Optional sub-phase WITHIN the per-AS op (#al-activitylog-progress).
        * Absent = the 4b2bc60f baseline "starting op N of M" marker (emitted
@@ -392,12 +418,16 @@ interface RestApplyMutationContext {
   targetProfileLabel: string;
   startedAt: number;
   toDestroy: Array<{ asUid: string; submodulePath: string; label: string }>;
+  /** req `d4ccc901` — soft-edge departures: moved aside, not deleted. */
+  toPark: Array<{ asUid: string; submodulePath: string; label: string }>;
   toMaterialize: Array<{
     asUid: string;
     submodulePath: string;
     gitUrl: string;
     label: string;
     ref: string;
+    /** req `d4ccc901` — acquisition only; the destination state is identical. */
+    source: "pull" | "unpark";
   }>;
   restMount: RestAssetSpaceMount;
   localDataStore: PluginLocalDataStore;
@@ -682,10 +712,18 @@ export class ProfileApplyManager {
     targetUid: string | null;
     destroyed: Set<string>;
     materialized: Set<string>;
+    parked: Set<string>;
   }> {
     // Git-only journal phases — present iff the desktop-git mutation ran. The
     // REST mutation emits ONLY `apply-starting` / `phase2-materialized` /
     // `phase2-destroyed`, so any of these uniquely marks the git path.
+    //
+    // req `d4ccc901` — ⛔ `phase2-parked` / `phase2-unparked` are deliberately
+    // NOT in this set. Both apply paths emit them, so treating them as a git
+    // marker would misroute an interrupted REST apply into git recovery (whose
+    // repair is a cache-restore that would find nothing). The git path stays
+    // correctly identified regardless: it always emits `phase2-start` before its
+    // loops, so `gitMutation` is already true by the time any park is recorded.
     const GIT_ONLY_PHASES = new Set([
       "phase1-done",
       "phase2-start",
@@ -702,6 +740,7 @@ export class ProfileApplyManager {
     let targetUid: string | null = null;
     const destroyed = new Set<string>();
     const materialized = new Set<string>();
+    const parked = new Set<string>();
     for (const e of events) {
       if (e.phase === "apply-completed" || e.phase === "recovery-completed") {
         // Terminal — anything before was a finished/recovered switch; reset.
@@ -709,6 +748,7 @@ export class ProfileApplyManager {
         targetUid = null;
         destroyed.clear();
         materialized.clear();
+        parked.clear();
         continue;
       }
       if (GIT_ONLY_PHASES.has(e.phase)) {
@@ -736,25 +776,39 @@ export class ProfileApplyManager {
           restMutation = true;
           if (typeof e.targetUid === "string") targetUid = e.targetUid;
           break;
+        // req `d4ccc901` — record parks so recovery can undo them by RENAMING
+        // BACK. Not added to `destroyed`: that set feeds `cacheLayer.restore()`,
+        // and a parked AssetSpace has no cache entry to restore from.
+        case "phase2-parked":
+          if (typeof e.as === "string") parked.add(e.as);
+          if (typeof e.targetUid === "string") targetUid = e.targetUid;
+          break;
+        // A park that was already reversed within the same apply (rollback)
+        // needs no undo — drop it back out of the set.
+        case "phase2-unparked":
+          if (typeof e.as === "string") parked.delete(e.as);
+          if (typeof e.targetUid === "string") targetUid = e.targetUid;
+          break;
         default:
           break;
       }
     }
-    if (targetUid === null) return { kind: "none", targetUid: null, destroyed, materialized };
-    if (gitMutation) return { kind: "git-apply", targetUid, destroyed, materialized };
+    if (targetUid === null)
+      return { kind: "none", targetUid: null, destroyed, materialized, parked };
+    if (gitMutation) return { kind: "git-apply", targetUid, destroyed, materialized, parked };
     // An apply that started (with or without a recorded mount yet) but emitted
     // no git-only phase is the REST path when the REST mount is wired (the
     // production routing since #3567). `restMutation` covers the case where the
     // first mount already landed; `applyStarted` covers a crash before it.
     if ((applyStarted || restMutation) && this.restWired()) {
-      return { kind: "rest-apply", targetUid, destroyed, materialized };
+      return { kind: "rest-apply", targetUid, destroyed, materialized, parked };
     }
     if (applyStarted || restMutation) {
       // Apply interrupted but REST not wired — legacy desktop-git fallback.
-      return { kind: "git-apply", targetUid, destroyed, materialized };
+      return { kind: "git-apply", targetUid, destroyed, materialized, parked };
     }
-    if (reindexStarted) return { kind: "reindex", targetUid, destroyed, materialized };
-    return { kind: "none", targetUid: null, destroyed, materialized };
+    if (reindexStarted) return { kind: "reindex", targetUid, destroyed, materialized, parked };
+    return { kind: "none", targetUid: null, destroyed, materialized, parked };
   }
 
   /**
@@ -1033,6 +1087,18 @@ export class ProfileApplyManager {
         asUid: t.asUid,
         asLabel: t.label,
       })),
+      // req `d4ccc901` — the git path plans NO parks, deliberately and honestly.
+      // Since #3410 the REST path is wired on BOTH platforms (see the branch at
+      // the top of `applyProfile`: it delegates whenever a rest mount or its
+      // factory exists), so this git branch is unreachable in production and
+      // duplicating the park machinery here would add a second, untested copy of
+      // it. Empty is the CORRECT value rather than a stub: this path genuinely
+      // cannot park, so planning one would make the approval card promise "kept
+      // on this device" while the folder was deleted — the surface describing the
+      // opposite of the mechanism, which is precisely what `canPark` exists to
+      // prevent (see `classifyMountTransition`).
+      assetSpacesBeingParked: [],
+      assetSpacesBeingUnparked: [],
     };
     const approved = await deps.confirmGate.confirmApply(plan);
     if (!approved) throw new ApplyAbortedByUser();
@@ -1612,30 +1678,59 @@ export class ProfileApplyManager {
     this.keepMaterializedCatalog(effectiveAsUids, allInfos, currentAsUids);
 
     const toDestroy: Array<{ asUid: string; submodulePath: string; label: string }> = [];
+    const toPark: Array<{ asUid: string; submodulePath: string; label: string }> = [];
     const toMaterialize: Array<{
       asUid: string;
       submodulePath: string;
       gitUrl: string;
       label: string;
       ref: string;
+      /** req `d4ccc901` — `unpark` = local rename back, `pull` = network mount. */
+      source: "pull" | "unpark";
     }> = [];
     // Iterate ALL declared AS (vs the desktop path's `currentAsUids` for the
     // destroy loop) — equivalent because `materialised` implies presence in
     // `currentAsUids`; this single loop also covers the materialise side.
+    //
+    // req `d4ccc901` — mount-state is three-valued now: `active` (folder on
+    // disk), `parked` (folder under `.exocortex/parked/`), `absent`. Departures
+    // PARTITION into destroy XOR park, so a parked AssetSpace's files never
+    // reach `filesToDestroy` and the confirm card's "files to remove" count
+    // stays literally true.
+    const canPark = this.canPark();
     for (const info of allInfos) {
-      const materialised = currentAsUids.has(info.uid);
-      const inEffective = effectiveAsUids.has(info.uid);
+      const state: MountState = currentAsUids.has(info.uid)
+        ? "active"
+        : (await this.isParkedOnDisk(info.folderName))
+          ? "parked"
+          : "absent";
       const label = info.namespace || info.uid.slice(0, 8);
-      if (materialised && !inEffective) {
-        toDestroy.push({ asUid: info.uid, submodulePath: info.folderName, label });
-      } else if (!materialised && inEffective) {
-        toMaterialize.push({
-          asUid: info.uid,
-          submodulePath: info.folderName,
-          gitUrl: info.git,
-          label,
-          ref: "main",
-        });
+      const transition = classifyMountTransition({
+        state,
+        inEffectiveSet: effectiveAsUids.has(info.uid),
+        dependsOnKind: info.dependsOnKind,
+        canPark,
+      });
+      switch (transition) {
+        case "none":
+          break;
+        case "destroy":
+          toDestroy.push({ asUid: info.uid, submodulePath: info.folderName, label });
+          break;
+        case "park":
+          toPark.push({ asUid: info.uid, submodulePath: info.folderName, label });
+          break;
+        case "unpark":
+        case "materialize":
+          toMaterialize.push({
+            asUid: info.uid,
+            submodulePath: info.folderName,
+            gitUrl: info.git,
+            label,
+            ref: "main",
+            source: transition === "unpark" ? "unpark" : "pull",
+          });
+          break;
       }
     }
 
@@ -1686,6 +1781,16 @@ export class ProfileApplyManager {
         await this.enumerateFilesUnder(target.submodulePath),
       );
     }
+    // req `d4ccc901` — park file counts are gathered the same way (the folder is
+    // still mounted at plan time) but into a SEPARATE bucket, so the same files
+    // are never reported twice under two different verbs.
+    const parkedFileCounts = new Map<string, number>();
+    for (const target of toPark) {
+      parkedFileCounts.set(
+        target.asUid,
+        (await this.enumerateFilesUnder(target.submodulePath)).length,
+      );
+    }
     const plan: ApplyPlan = {
       targetProfileUid,
       targetProfileLabel,
@@ -1697,10 +1802,18 @@ export class ProfileApplyManager {
         asLabel: t.label,
         fileCount: filesToDestroyMap.get(t.asUid)?.length ?? 0,
       })),
+      assetSpacesBeingParked: toPark.map((t) => ({
+        asUid: t.asUid,
+        asLabel: t.label,
+        fileCount: parkedFileCounts.get(t.asUid) ?? 0,
+      })),
       assetSpacesBeingMaterialized: toMaterialize.map((t) => ({
         asUid: t.asUid,
         asLabel: t.label,
       })),
+      assetSpacesBeingUnparked: toMaterialize
+        .filter((t) => t.source === "unpark")
+        .map((t) => ({ asUid: t.asUid, asLabel: t.label })),
     };
     // #1d1bcde0 — the onload crash-recovery resume passes `skipConfirm` because
     // the user ALREADY approved this apply before the reload; re-prompting on a
@@ -1713,7 +1826,9 @@ export class ProfileApplyManager {
 
     // No-op early exit — mount-state already matches the target. Re-index +
     // record the selection (reindex-only path; already watchdog-wrapped).
-    if (toDestroy.length === 0 && toMaterialize.length === 0) {
+    // req `d4ccc901` — `toPark` counts as work: an apply whose only change is a
+    // park must still run, or a soft-edge departure would silently no-op.
+    if (toDestroy.length === 0 && toPark.length === 0 && toMaterialize.length === 0) {
       await this.reindexMountState(
         targetProfileUid,
         this.noChangeNotice(targetProfileLabel, currentAsUids.size),
@@ -1741,13 +1856,19 @@ export class ProfileApplyManager {
           targetProfileLabel,
           startedAt,
           toDestroy,
+          toPark,
           toMaterialize,
           restMount,
           localDataStore,
         }),
       targetProfileLabel,
       () => this.clearStuckLocalState(localDataStore),
-      this.computeApplyDeadlineMs(toDestroy.length + toMaterialize.length),
+      // Parks are local renames (~23 ms), but they are still per-AS work items
+      // in the critical section — count them so the deadline scales with the
+      // real op count rather than under-budgeting a park-heavy apply.
+      this.computeApplyDeadlineMs(
+        toDestroy.length + toPark.length + toMaterialize.length,
+      ),
     );
     // #3956 belt-and-suspenders — WARN on any dependsOn-closure member the
     // profile declares but apply could not materialize (no scanned descriptor).
@@ -1774,6 +1895,7 @@ export class ProfileApplyManager {
       targetProfileLabel,
       startedAt,
       toDestroy,
+      toPark,
       toMaterialize,
       restMount,
       localDataStore,
@@ -1829,12 +1951,37 @@ export class ProfileApplyManager {
         // Live progress BEFORE the mount so a long apply shows "Mounting X
         // (2 of 5)" as it runs — the journal entry below only fires AFTER.
         this.emitProgress({
-          op: "mount",
+          op: target.source === "unpark" ? "unpark" : "mount",
           as: target.asUid,
           label: target.label,
           index: i + 1,
           total: toMaterialize.length,
         });
+        // req `d4ccc901` — ONE arrival loop. An unpark differs only in how the
+        // bytes are acquired (local rename vs tarball); everything downstream —
+        // the rollback bookkeeping below, the journal entry, `mountedThisRun` —
+        // is shared, so an unparked AssetSpace cannot end up in a half-tracked
+        // state that a mounted one avoids.
+        if (target.source === "unpark") {
+          try {
+            await this.unparkAssetSpace(target.submodulePath);
+          } catch (unparkErr) {
+            await this.rollbackRestMounts(
+              restMount,
+              [...mountedThisRun, { asUid: target.asUid, submodulePath: target.submodulePath }],
+              targetProfileUid,
+            );
+            throw unparkErr;
+          }
+          mountedThisRun.push({ asUid: target.asUid, submodulePath: target.submodulePath });
+          await this.appendJournal({
+            phase: "phase2-unparked",
+            targetUid: targetProfileUid,
+            as: target.asUid,
+            ts: this.now().toISOString(),
+          });
+          continue;
+        }
         try {
           // Finer within-AS progress (#al-activitylog-progress) — the mount core
           // reports fetch → extract → materialize so a slow mount shows its
@@ -1902,6 +2049,31 @@ export class ProfileApplyManager {
           ts: this.now().toISOString(),
         });
       }
+      // req `d4ccc901` — park the soft-edge departures. Deliberately NOT routed
+      // through the destroy sequence above: a park is a local rename (≈23 ms, 0
+      // bytes), and entering `cache → phase2-destroy-cached → rm -rf` would both
+      // pay a full tarball copy for bytes that never leave the device AND write a
+      // journal stage whose recovery restores FROM THAT CACHE — so a crash would
+      // send recovery hunting an archive that was never written while the folder
+      // sat safe under `.exocortex/parked/`. `phase2-parked` carries its own
+      // recovery branch (rename back), which is why it is a separate stage.
+      for (let i = 0; i < toPark.length; i++) {
+        const target = toPark[i];
+        this.emitProgress({
+          op: "park",
+          as: target.asUid,
+          label: target.label,
+          index: i + 1,
+          total: toPark.length,
+        });
+        await this.parkAssetSpace(target.submodulePath);
+        await this.appendJournal({
+          phase: "phase2-parked",
+          targetUid: targetProfileUid,
+          as: target.asUid,
+          ts: this.now().toISOString(),
+        });
+      }
 
       // Persist the applied profile as last-applied cache + clear in-progress,
       // and record the pre-apply profile as the undo target (RFC 0002 §3.10)
@@ -1931,8 +2103,14 @@ export class ProfileApplyManager {
         ts: this.now().toISOString(),
         elapsedMs,
       });
+      // req `d4ccc901` — the parked count is appended ONLY when non-zero, so the
+      // pre-existing message stays byte-identical on every apply that parks
+      // nothing. An always-on ", 0 parked" would be noise on the common path and
+      // would churn assertions that have nothing to do with this feature.
+      const parkedSuffix =
+        toPark.length > 0 ? `, ${toPark.length} parked` : "";
       this.notify(
-        `Applied "${targetProfileLabel}": ${toMaterialize.length} mounted, ${toDestroy.length} unmounted (${elapsedMs}ms, REST).`,
+        `Applied "${targetProfileLabel}": ${toMaterialize.length} mounted, ${toDestroy.length} unmounted${parkedSuffix} (${elapsedMs}ms, REST).`,
       );
     } catch (e) {
       await this.appendJournal({
@@ -2237,6 +2415,48 @@ export class ProfileApplyManager {
       }
     }
 
+    // req `d4ccc901` — undo interrupted PARKS by renaming back, symmetric to the
+    // cache-restore above and for the same reason: an apply that never completed
+    // should leave the user on the pre-apply mount-state, not half-way.
+    //
+    // ⛔ This is a SEPARATE loop, not an extension of `destroyedAsUids`. Parking
+    // writes no `SwitchCacheLayer` archive, so routing a parked AssetSpace
+    // through `cacheLayer.restore()` would miss and report it unrecoverable
+    // while its bytes sit intact under `.exocortex/parked/`. The repair for a
+    // move is a move.
+    //
+    // No intersect with `materialized` is needed (unlike the destroy loop): park
+    // and unpark are mutually exclusive transitions for one AssetSpace within
+    // one apply, and a same-apply reversal already removed it from the set.
+    const unparked: string[] = [];
+    for (const asUid of interrupted.parked) {
+      const info = this.listAllAssetSpaceInfos().find((i) => i.uid === asUid);
+      // Without a descriptor we cannot derive the mount path — and unlike the
+      // destroy loop there is no safe diagnostic fallback, because renaming onto
+      // a guessed path could clobber an unrelated folder. Leave it parked: the
+      // bytes are intact and a later apply with the descriptor present will
+      // reconcile it.
+      if (info === undefined) continue;
+      try {
+        await this.appendJournal({
+          phase: "phase2-unparked",
+          targetUid: asUid,
+          as: asUid,
+          ts: this.now().toISOString(),
+        });
+        await this.unparkAssetSpace(info.folderName);
+        unparked.push(asUid);
+      } catch (err) {
+        await this.appendJournal({
+          phase: "phase2-unparked",
+          targetUid: asUid,
+          as: asUid,
+          ts: this.now().toISOString(),
+          error: this.redactError(String(err)),
+        });
+      }
+    }
+
     // Clear stuck _switchInProgress flag.
     const snapshot = localDataStore.snapshot();
     await localDataStore.save({
@@ -2251,7 +2471,82 @@ export class ProfileApplyManager {
     if (restored.length > 0) {
       this.notify(`Recovered ${restored.length} AssetSpace(s) from cache after interrupted switch`);
     }
+    if (unparked.length > 0) {
+      this.notify(`Restored ${unparked.length} parked AssetSpace(s) after interrupted switch`);
+    }
     return { restored, resumed: false, resumedTo: null };
+  }
+
+  /**
+   * req `d4ccc901` — park/unpark helpers routed through the ONE implementation
+   * ({@link RestAssetSpaceMount}), which owns both the vault adapter and the
+   * `.gitmodules` writer. Both apply paths and crash recovery call these, so
+   * there is a single place where "move aside" is defined.
+   *
+   * Returns `false` when no REST mount is reachable — the caller must then not
+   * have PLANNED a park in the first place (see `canPark` in the classifier
+   * input): planning a park and executing a destroy would make the approval card
+   * describe an operation the user did not get.
+   *
+   * ⛔ Resolves the FACTORY when the eager field is absent, for the same reason
+   * `canPark` uses {@link restWired}: production wires only the factory, so an
+   * eager-field-only read would return `false` on the live path.
+   */
+  private async resolveRestMount(): Promise<RestAssetSpaceMount | undefined> {
+    if (this.restMount !== undefined) return this.restMount;
+    if (this.restMountFactory === undefined) return undefined;
+    return await this.restMountFactory();
+  }
+
+  private async parkAssetSpace(submodulePath: string): Promise<boolean> {
+    const mount = await this.resolveRestMount();
+    if (mount === undefined) return false;
+    await mount.park(submodulePath);
+    return true;
+  }
+
+  private async unparkAssetSpace(submodulePath: string): Promise<boolean> {
+    const mount = await this.resolveRestMount();
+    if (mount === undefined) return false;
+    await mount.unpark(submodulePath);
+    return true;
+  }
+
+  /**
+   * Whether this manager can park at all (a REST mount is reachable).
+   *
+   * ⛔ Must be {@link restWired}, NOT `this.restMount !== undefined`. Production
+   * wires only `restMountFactory` (ExocortexPlugin passes a lazy closure so a PAT
+   * set after onload is honoured without a reload); `this.restMount` is
+   * `undefined` there and the real mount is resolved from the factory inside
+   * `applyProfileViaRest`. Reading the eager field would answer "cannot park" on
+   * the ONE path that actually runs — parking would plan zero parks forever,
+   * while every test that wires `restMount` directly stayed green. Same predicate
+   * as the delegation branch in `applyProfile`, deliberately.
+   */
+  private canPark(): boolean {
+    return this.restWired();
+  }
+
+  /**
+   * req `d4ccc901` — is a parked copy of this mount folder on disk?
+   *
+   * Wraps {@link parkedPathFor}, which THROWS on a malformed mount folder. That
+   * throw is right at the mutation site (moving a directory to an
+   * attacker-chosen path must fail loud), and wrong here: this runs while
+   * BUILDING a plan, across every descriptor in the vault, so one malformed
+   * folder would take down the whole apply — including the descriptors that are
+   * fine. Answering `false` degrades that AssetSpace to `absent`, i.e. exactly
+   * the pre-existing two-state behaviour, which is the safe direction.
+   */
+  private async isParkedOnDisk(folderName: string): Promise<boolean> {
+    let parkedPath: string;
+    try {
+      parkedPath = parkedPathFor(folderName);
+    } catch {
+      return false;
+    }
+    return await this.app.vault.adapter.exists(parkedPath);
   }
 
   /**
@@ -2404,6 +2699,26 @@ export class ProfileApplyManager {
       asUid: uid,
       asLabel: infoByUid.get(uid)?.namespace ?? uid.slice(0, 8),
     }));
+    // req `d4ccc901` — the DELETION half of AC2 needs no branch here and is not
+    // one: `extra` is derived from `materializedAsUids`, which is mount-folder
+    // existence on disk, so a parked AssetSpace (folder moved under
+    // `.exocortex/parked/`) is not materialized, cannot appear in `extra`, and
+    // therefore never has a deletion computed for it. Structural, not a special
+    // case — which is why nothing above needed changing.
+    //
+    // The ARRIVAL half does need marking. A parked AssetSpace the active profile
+    // still expects DOES land in `missing`, and reconcile's whole job is to warn
+    // the user before it acts. Announcing it under "materialize" alone would tell
+    // a user on a metered connection to expect a download for what is a local
+    // rename — the plan describing a mechanism it doesn't use.
+    const unparked: Array<{ asUid: string; asLabel: string }> = [];
+    for (const uid of missing) {
+      const info = infoByUid.get(uid);
+      if (info === undefined) continue;
+      if (await this.isParkedOnDisk(info.folderName)) {
+        unparked.push({ asUid: uid, asLabel: info.namespace || uid.slice(0, 8) });
+      }
+    }
     return {
       targetProfileUid: activeProfileUid,
       targetProfileLabel: `${targetLabel} (cross-device reconcile)`,
@@ -2412,6 +2727,10 @@ export class ProfileApplyManager {
       filesToDestroy,
       assetSpacesBeingTornDown: tornDown,
       assetSpacesBeingMaterialized: materialized,
+      // Reconcile itself never parks — it only ever adds back what the active
+      // profile expects — so the park list is empty by construction, not stubbed.
+      assetSpacesBeingParked: [],
+      assetSpacesBeingUnparked: unparked,
     };
   }
 

--- a/packages/obsidian-plugin/src/infrastructure/adapters/RestAssetSpaceMount.ts
+++ b/packages/obsidian-plugin/src/infrastructure/adapters/RestAssetSpaceMount.ts
@@ -8,6 +8,7 @@ import {
 import {
   mountAssetSpaceFiles,
   stripGitmodulesEntry,
+  parkedPathFor,
   deriveUrl,
   SYNC_BRANCH,
   type FileSystemPort,
@@ -201,6 +202,78 @@ export class RestAssetSpaceMount {
     await this.removeGitmodulesEntry(safePath);
     if (await this.adapter.exists(safePath)) {
       await this.adapter.rmdir(safePath, true);
+    }
+  }
+
+  /**
+   * req `d4ccc901` — PARK an AssetSpace: strip its `.gitmodules` entry, then
+   * MOVE its folder to `.exocortex/parked/<owner>/<repo>` instead of removing
+   * it. The AssetSpace leaves the vault (so Obsidian stops indexing it and
+   * ExoSync stops enumerating it — req `4eca4900`) while its bytes stay on the
+   * device, making the return a rename rather than a download.
+   *
+   * ⛔ Deliberately NOT routed through the desktop `SwitchCacheLayer`
+   * tar-then-destroy sequence: taring the folder before moving it would put a
+   * second full copy on disk and turn a ~23 ms rename into seconds of archiving
+   * — the exact cost parking exists to avoid. The cache keeps its own job
+   * (`absent`-state restores + destroy-path crash recovery); parking bypasses it
+   * and carries its own journal stages so recovery routes to a rename-back
+   * rather than a cache lookup that would miss.
+   *
+   * Stanza-first ordering mirrors {@link unmount}: an interrupted park leaves
+   * either a stanza-less mount or a completed park, both of which a re-run of
+   * Apply reconciles.
+   *
+   * Idempotent when nothing is mounted. REFUSES when a parked copy already
+   * exists — two copies of one AssetSpace is a crash artefact, and picking a
+   * winner silently could discard whichever holds unpushed edits.
+   */
+  public async park(submodulePath: string): Promise<void> {
+    const safePath = validateVaultPathArg(submodulePath);
+    const parkedPath = validateVaultPathArg(parkedPathFor(safePath));
+    if (!(await this.adapter.exists(safePath))) return;
+    if (await this.adapter.exists(parkedPath)) {
+      throw new Error(
+        `park: refusing to park "${safePath}" — a parked copy already exists at "${parkedPath}". Resolve by hand: one of the two holds work the other does not.`,
+      );
+    }
+    await this.removeGitmodulesEntry(safePath);
+    await this.ensureParentDir(parkedPath);
+    await this.adapter.rename(safePath, parkedPath);
+  }
+
+  /**
+   * req `d4ccc901` — UNPARK: move the folder back from `.exocortex/parked/` onto
+   * its mount path.
+   *
+   * Deliberately does NOT re-add the `.gitmodules` stanza: the caller does that
+   * through the SAME registration step a network mount uses, so both ways of
+   * arriving at `active` share one piece of bookkeeping and cannot drift.
+   *
+   * @throws if nothing is parked (caller's plan was stale) or the mount path is
+   *   already occupied (would clobber a live mount).
+   */
+  public async unpark(submodulePath: string): Promise<void> {
+    const safePath = validateVaultPathArg(submodulePath);
+    const parkedPath = validateVaultPathArg(parkedPathFor(safePath));
+    if (!(await this.adapter.exists(parkedPath))) {
+      throw new Error(`unpark: nothing parked at "${parkedPath}" for "${safePath}"`);
+    }
+    if (await this.adapter.exists(safePath)) {
+      throw new Error(`unpark: refusing to unpark onto existing mount "${safePath}"`);
+    }
+    await this.ensureParentDir(safePath);
+    await this.adapter.rename(parkedPath, safePath);
+  }
+
+  /** Create the parent chain of a vault-relative path (rename needs it present). */
+  private async ensureParentDir(vaultRelPath: string): Promise<void> {
+    const segments = vaultRelPath.split("/");
+    segments.pop();
+    let acc = "";
+    for (const seg of segments) {
+      acc = acc.length === 0 ? seg : `${acc}/${seg}`;
+      if (!(await this.adapter.exists(acc))) await this.adapter.mkdir(acc);
     }
   }
 

--- a/packages/obsidian-plugin/tests/unit/ModalConfirmGate.test.ts
+++ b/packages/obsidian-plugin/tests/unit/ModalConfirmGate.test.ts
@@ -71,6 +71,12 @@ function makePlan(overrides: Partial<ApplyPlan> = {}): ApplyPlan {
     assetSpacesBeingMaterialized: [
       { asUid: "as-work", asLabel: "work" },
     ],
+    // req `d4ccc901` — the baseline plan is a plain destroy+materialize apply,
+    // so both park lists are empty. Empty is the honest default rather than a
+    // filler: it keeps every pre-existing assertion in this suite testing what it
+    // was written to test, and makes the park cases below opt in explicitly.
+    assetSpacesBeingParked: [],
+    assetSpacesBeingUnparked: [],
     ...overrides,
   };
 }
@@ -279,6 +285,90 @@ describe("ModalConfirmGate", () => {
 
       findButton("Cancel")?.click();
       await promise;
+    });
+  });
+
+  /**
+   * @req:d4ccc901-83a4-4495-a4bb-43d1305dfd00
+   *
+   * req `d4ccc901` — the plugin half of "the plan a human approves must describe
+   * the mechanism". Required fields make the compiler force this renderer to
+   * ACKNOWLEDGE parking; only these assertions force it to SHOW it. The mutant
+   * is deleting the `createEl` block while keeping the field read — that
+   * compiles and reddens nothing else.
+   */
+  describe("@req:d4ccc901-83a4-4495-a4bb-43d1305dfd00 parked / unparked rendering", () => {
+    it("RENDERS a park section that says kept, not removed", async () => {
+      const gate = new ModalConfirmGate(fakeApp);
+      const promise = gate.confirmApply(
+        makePlan({
+          filesToDestroy: new Map(),
+          assetSpacesBeingTornDown: [],
+          assetSpacesBeingParked: [
+            { asUid: "as-soft", asLabel: "soft", fileCount: 42 },
+          ],
+        }),
+      );
+
+      const park = document.querySelector(".apply-confirm-park-section");
+      expect(park).not.toBeNull();
+      const text = park!.textContent ?? "";
+      expect(text).toContain("42 files");
+      expect(text).toContain("soft");
+      // The user-facing consequence, not the internal verb: bytes stay.
+      expect(text).toMatch(/not deleted/i);
+      expect(text).toContain(".exocortex/parked");
+
+      findButton("Cancel")?.click();
+      await promise;
+    });
+
+    it("does NOT render a park section when nothing is parked (a no-park apply looks unchanged)", async () => {
+      const gate = new ModalConfirmGate(fakeApp);
+      const promise = gate.confirmApply(makePlan());
+      expect(document.querySelector(".apply-confirm-park-section")).toBeNull();
+      findButton("Cancel")?.click();
+      await promise;
+    });
+
+    it("marks an UNPARK inside the materialize list so it does not read as a download", async () => {
+      const gate = new ModalConfirmGate(fakeApp);
+      const promise = gate.confirmApply(
+        makePlan({
+          assetSpacesBeingMaterialized: [
+            { asUid: "as-work", asLabel: "work" },
+            { asUid: "as-soft", asLabel: "soft" },
+          ],
+          assetSpacesBeingUnparked: [{ asUid: "as-soft", asLabel: "soft" }],
+        }),
+      );
+
+      const items = Array.from(
+        document.querySelectorAll(".apply-confirm-mat-section li"),
+      ).map((li) => li.textContent ?? "");
+      // The unparked one is annotated…
+      expect(items.some((t) => t.includes("soft") && /no download/i.test(t))).toBe(
+        true,
+      );
+      // …and the genuinely-pulled one is NOT — otherwise the annotation would be
+      // decoration rather than information.
+      expect(items.some((t) => t === "work")).toBe(true);
+
+      findButton("Cancel")?.click();
+      await promise;
+    });
+
+    it("keeps the pre-existing section classes the e2e leg asserts on", () => {
+      // `eka-obsidian-leg.spec.ts` drives the REAL modal and locates
+      // `.apply-confirm-tear-section` / `.apply-confirm-mat-section`. That suite
+      // runs in its own workflow, OUTSIDE the 13 required checks, so breaking it
+      // would not redden this PR — it would silently skip the release. This
+      // assertion brings that breakage forward into the required gate.
+      const gate = new ModalConfirmGate(fakeApp);
+      void gate.confirmApply(makePlan());
+      expect(document.querySelector(".apply-confirm-tear-section")).not.toBeNull();
+      expect(document.querySelector(".apply-confirm-mat-section")).not.toBeNull();
+      findButton("Cancel")?.click();
     });
   });
 });

--- a/packages/obsidian-plugin/tests/unit/ProfileApplyManager.parked.test.ts
+++ b/packages/obsidian-plugin/tests/unit/ProfileApplyManager.parked.test.ts
@@ -1,0 +1,611 @@
+/**
+ * @req:d4ccc901-83a4-4495-a4bb-43d1305dfd00
+ *
+ * req `d4ccc901` — the REST apply path with three mount states.
+ *
+ * ## Why this harness wires the mount the way it does
+ *
+ * ⛔ `restMount` is DELIBERATELY OMITTED. Production (`ExocortexPlugin.ts:3410`)
+ * wires ONLY `restMountFactory` — unconditionally, since #3410 — and the real
+ * mount is resolved locally inside the apply. The sibling harnesses
+ * (`restApply`, `restAtomicity`) hand the manager a `restMount` directly, which
+ * is a shape production never takes; that fixture shape is exactly what hid the
+ * `canPark()` bug (`this.restMount !== undefined` was false on the only live
+ * path ⇒ zero parks would ever be planned, silently, with every test green).
+ *
+ * So: factory-only here, on purpose. Differential proof that this matters is in
+ * the PR body — reverting `restWired()` back to `this.restMount !== undefined`
+ * reddens the axes below and nothing else.
+ *
+ * ## Axes (one guard each)
+ *
+ *  A. production wiring plans a park at all (the bug that shipped green)
+ *  B. a soft departure PARKS and its files stay OUT of the destroy bucket
+ *  C. a hard departure still DESTROYS (the split is real, not "park everything")
+ *  D. return from parking goes through the SAME arrival loop (AC3)
+ *  E. journal carries its own stages, never `phase2-destroy-cached` (AC4/fact #10)
+ *  F. reconcile computes NO deletion for a parked AS and announces the unpark (AC2)
+ */
+import type { App, TFile } from "obsidian";
+import type { ApplyPlan, IConfirmGate } from "@kitelev/exocortex-core";
+
+import {
+  ProfileApplyManager,
+  type IProfileResolver,
+  type IRdfIndexer,
+  type ISettingsStore,
+  type ProfileResolution,
+  type SwitchSettings,
+} from "../../src/infrastructure/adapters/ProfileApplyManager";
+import { PluginLockManager } from "../../src/infrastructure/adapters/PluginLockManager";
+import {
+  TS_FLOOR_AS_UID_EXO,
+  TS_FLOOR_AS_UID_EXOCMD,
+  TS_FLOOR_AS_UID_SHARED_IDENTITIES,
+} from "../../src/infrastructure/adapters/ProfileOnloadWiring";
+import {
+  DEPENDENCY_KIND_REFERENCE_UID,
+  DEPENDENCY_KIND_TBOX_UID,
+  parkedPathFor,
+} from "@kitelev/exocortex-core";
+
+// ─── Fakes ────────────────────────────────────────────────────────────────
+
+interface FakeFile {
+  path: string;
+  basename: string;
+  frontmatter: Record<string, unknown>;
+}
+
+function makeFakeApp(files: FakeFile[]): {
+  app: App;
+  fsFolders: Map<string, { files: string[]; folders: string[] }>;
+  fsFiles: Map<string, string>;
+} {
+  const fsFiles = new Map<string, string>();
+  const fsFolders = new Map<string, { files: string[]; folders: string[] }>();
+  const tfiles: TFile[] = files.map(
+    (f) => ({ path: f.path, basename: f.basename }) as unknown as TFile,
+  );
+  const frontmatterByPath = new Map<string, Record<string, unknown>>();
+  for (const f of files) frontmatterByPath.set(f.path, f.frontmatter);
+
+  const app = {
+    vault: {
+      getMarkdownFiles: () => tfiles,
+      adapter: {
+        exists: async (p: string) => fsFiles.has(p) || fsFolders.has(p),
+        read: async (p: string) => {
+          const v = fsFiles.get(p);
+          if (v === undefined) throw new Error(`ENOENT: ${p}`);
+          return v;
+        },
+        write: async (p: string, d: string) => {
+          fsFiles.set(p, d);
+        },
+        mkdir: async (p: string) => {
+          if (!fsFolders.has(p)) fsFolders.set(p, { files: [], folders: [] });
+        },
+        // Without `remove` the apply lock is never released and a SECOND apply
+        // on the same instance dies with "lock held" — which would make the
+        // round-trip test below unwritable, not merely red.
+        remove: async (p: string) => {
+          fsFiles.delete(p);
+        },
+        rmdir: async (p: string) => {
+          fsFolders.delete(p);
+        },
+        list: async (dir: string) =>
+          fsFolders.get(dir) ?? { files: [], folders: [] },
+      },
+    },
+    metadataCache: {
+      getFileCache: (file: TFile) => {
+        const fm = frontmatterByPath.get(file.path);
+        return fm ? { frontmatter: fm } : null;
+      },
+    },
+  } as unknown as App;
+  return { app, fsFolders, fsFiles };
+}
+
+class FakeResolver implements IProfileResolver {
+  constructor(private readonly profiles: Map<string, ProfileResolution>) {}
+  async resolve(uid: string): Promise<ProfileResolution | null> {
+    return this.profiles.get(uid) ?? null;
+  }
+  async discoverSharedOntologies(): Promise<string[]> {
+    return [];
+  }
+}
+
+class FakeIndexer implements IRdfIndexer {
+  refreshCalls = 0;
+  async refresh(): Promise<void> {
+    this.refreshCalls++;
+  }
+}
+
+class FakeSettingsStore implements ISettingsStore {
+  state: SwitchSettings = { activeProfileUid: null, _switchInProgress: false };
+  async load(): Promise<SwitchSettings> {
+    return { ...this.state };
+  }
+  async save(s: SwitchSettings): Promise<void> {
+    this.state = { ...s };
+  }
+}
+
+class FakeLocalDataStore {
+  private state = { activeProfileUid: null as string | null, _switchInProgress: false };
+  getActiveProfileUid(): string | null {
+    return this.state.activeProfileUid;
+  }
+  isSwitchInProgress(): boolean {
+    return this.state._switchInProgress;
+  }
+  snapshot() {
+    return { ...this.state };
+  }
+  async save(s: { activeProfileUid: string | null; _switchInProgress: boolean }) {
+    this.state = { ...s };
+  }
+}
+
+class FakeConfirmGate implements IConfirmGate {
+  approve = true;
+  lastPlan: ApplyPlan | null = null;
+  async confirmApply(plan: ApplyPlan): Promise<boolean> {
+    this.lastPlan = plan;
+    return this.approve;
+  }
+}
+
+class FakeGitOps {
+  async readGitmodulesPaths(): Promise<Set<string>> {
+    return new Set();
+  }
+  async submoduleAdd(): Promise<void> {}
+  async submoduleDeinit(): Promise<void> {}
+}
+
+/**
+ * Records which VERB each AssetSpace received. The point of the whole task is
+ * that park ≠ unmount, so a spy that collapsed them would test nothing.
+ */
+class MountSpy {
+  mounted: string[] = [];
+  unmounted: string[] = [];
+  parked: string[] = [];
+  unparked: string[] = [];
+  /**
+   * The spy MOVES folders in the fake FS rather than only recording calls, so a
+   * second apply on the same instance observes what the first one actually did.
+   * Without this a round-trip test would be re-reading the initial disk state
+   * and could "pass" against a park that never happened.
+   */
+  constructor(
+    private readonly fsFolders: Map<string, { files: string[]; folders: string[] }>,
+  ) {}
+  private move(from: string, to: string) {
+    const entry = this.fsFolders.get(from);
+    this.fsFolders.delete(from);
+    this.fsFolders.set(to, entry ?? { files: [], folders: [] });
+  }
+  async mount(_gitUrl: string, submodulePath: string) {
+    this.mounted.push(submodulePath);
+    this.fsFolders.set(submodulePath, {
+      files: [`${submodulePath}/file1.md`],
+      folders: [],
+    });
+    return { sha: "abc1234", fileCount: 1 };
+  }
+  async unmount(submodulePath: string): Promise<void> {
+    this.unmounted.push(submodulePath);
+    this.fsFolders.delete(submodulePath);
+  }
+  async park(submodulePath: string): Promise<void> {
+    this.parked.push(submodulePath);
+    this.move(submodulePath, parkedPathFor(submodulePath));
+  }
+  async unpark(submodulePath: string): Promise<void> {
+    this.unparked.push(submodulePath);
+    this.move(parkedPathFor(submodulePath), submodulePath);
+  }
+}
+
+// ─── Setup ──────────────────────────────────────────────────────────────────
+
+const FLOOR = [
+  { uid: TS_FLOOR_AS_UID_EXO, folder: "assetspaces/kitelev/exoas-exo" },
+  { uid: TS_FLOOR_AS_UID_EXOCMD, folder: "assetspaces/kitelev/exoas-exocmd" },
+  {
+    uid: TS_FLOOR_AS_UID_SHARED_IDENTITIES,
+    folder: "assetspaces/kitelev/exoas-shared-identities",
+  },
+];
+/** Soft edge (`reference`) — content-only, safe to keep on device. */
+const SOFT = { uid: "soft-uid", folder: "assetspaces/kitelev/exoas-soft" };
+/** Hard edge (`tbox`) — a half-present provider is the silent state. */
+const HARD = { uid: "hard-uid", folder: "assetspaces/kitelev/exoas-hard" };
+const ALL_AS = [...FLOOR, SOFT, HARD];
+const FLOOR_UIDS = FLOOR.map((f) => f.uid);
+
+const KIND_BY_UID: Record<string, string | undefined> = {
+  [SOFT.uid]: `[[${DEPENDENCY_KIND_REFERENCE_UID}]]`,
+  [HARD.uid]: `[[${DEPENDENCY_KIND_TBOX_UID}]]`,
+};
+
+interface SetupOpts {
+  targetIncludes: string[];
+  /** AS whose mount folder exists on disk. */
+  materialized: string[];
+  /** AS whose folder sits under `.exocortex/parked/`. */
+  parked?: string[];
+  /**
+   * ⛔ Default FALSE — production omits `restMount` entirely. Only the
+   * differential control below flips this on.
+   */
+  wireRestMountDirectly?: boolean;
+  /** `reconcileToLocal` refuses to run without gitOps + an active profile. */
+  activeProfileUid?: string;
+  /** Declares of the second profile (`"other"`), for round-trip applies. */
+  otherIncludes?: string[];
+}
+
+function setup(opts: SetupOpts) {
+  const files: FakeFile[] = [
+    {
+      path: "profiles/target.md",
+      basename: "target",
+      frontmatter: {
+        exo__Asset_uid: "target",
+        exo__Asset_label: "Target Profile",
+        exo__Instance_class: ["[[exo__Profile]]"],
+      },
+    },
+    ...ALL_AS.map((as) => {
+      const ns = as.folder.split("/").pop();
+      return {
+        path: `${as.folder}/${as.uid}.md`,
+        basename: as.uid,
+        frontmatter: {
+          exo__Asset_uid: as.uid,
+          exo__Asset_label: ns,
+          exo__Instance_class: ["[[exo__AssetSpace]]"],
+          exo__AssetSpace_source: `https://github.com/${as.folder.replace("assetspaces/", "")}`,
+          exo__AssetSpace_namespace: ns,
+          ...(KIND_BY_UID[as.uid] !== undefined
+            ? { exo__AssetSpace_dependsOnKind: KIND_BY_UID[as.uid] }
+            : {}),
+        },
+      };
+    }),
+  ];
+
+  const { app, fsFolders, fsFiles } = makeFakeApp(files);
+  for (const uid of opts.materialized) {
+    const folder = ALL_AS.find((a) => a.uid === uid)?.folder;
+    if (folder) {
+      fsFolders.set(folder, {
+        files: [`${folder}/file1.md`, `${folder}/file2.md`],
+        folders: [],
+      });
+    }
+  }
+  for (const uid of opts.parked ?? []) {
+    const folder = ALL_AS.find((a) => a.uid === uid)?.folder;
+    if (folder) {
+      fsFolders.set(parkedPathFor(folder), { files: [], folders: [] });
+    }
+  }
+
+  const resolver = new FakeResolver(
+    new Map<string, ProfileResolution>([
+      [
+        "target",
+        { uid: "target", includes: opts.targetIncludes, label: "Target Profile" },
+      ],
+      // Second profile so a round-trip (park → come back) can be driven as two
+      // real applies on ONE manager instance.
+      [
+        "other",
+        {
+          uid: "other",
+          includes: opts.otherIncludes ?? FLOOR_UIDS,
+          label: "Other Profile",
+        },
+      ],
+    ]),
+  );
+  const indexer = new FakeIndexer();
+  const localDataStore = new FakeLocalDataStore();
+  const confirmGate = new FakeConfirmGate();
+  const mount = new MountSpy(fsFolders);
+  const notifyCalls: string[] = [];
+  if (opts.activeProfileUid !== undefined) {
+    void localDataStore.save({
+      activeProfileUid: opts.activeProfileUid,
+      _switchInProgress: false,
+    });
+  }
+
+  const mgr = new ProfileApplyManager({
+    app,
+    lockMgr: new PluginLockManager({ app }),
+    resolver,
+    rdfIndexer: indexer,
+    settingsStore: new FakeSettingsStore(),
+    notify: (m) => notifyCalls.push(m),
+    /* eslint-disable @typescript-eslint/no-explicit-any */
+    confirmGate,
+    localDataStore: localDataStore as any,
+    // ⛔ PRODUCTION SHAPE — factory only, `restMount` absent (see header).
+    restMount: (opts.wireRestMountDirectly ? mount : undefined) as any,
+    restMountFactory: (async () => mount) as any,
+    gitOps: new FakeGitOps() as any,
+    /* eslint-enable @typescript-eslint/no-explicit-any */
+  });
+
+  const journal = async (): Promise<Array<Record<string, unknown>>> =>
+    (fsFiles.get(".exocortex/switch-journal.jsonl") ?? "")
+      .split("\n")
+      .filter((l) => l.trim().length > 0)
+      .map((l) => JSON.parse(l) as Record<string, unknown>);
+
+  return { mgr, mount, confirmGate, notifyCalls, indexer, journal, fsFolders };
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────
+
+describe("@req:d4ccc901-83a4-4495-a4bb-43d1305dfd00 ProfileApplyManager — parked mount state", () => {
+  /**
+   * AXIS A — the bug that shipped green. With `restMount` absent (production),
+   * `canPark()` must still answer true, or a soft departure silently degrades
+   * to a destroy with every other assertion in the repo untouched.
+   *
+   * Mutant: `restWired()` → `this.restMount !== undefined` in `canPark()`.
+   * This axis and B and D reden; nothing else does.
+   */
+  it("PLANS a park under PRODUCTION wiring (restMountFactory only, restMount absent)", async () => {
+    const { mgr, mount, confirmGate } = setup({
+      targetIncludes: FLOOR_UIDS,
+      materialized: [...FLOOR_UIDS, SOFT.uid],
+    });
+
+    await mgr.applyProfileViaRest("target");
+
+    expect(confirmGate.lastPlan?.assetSpacesBeingParked).toEqual([
+      expect.objectContaining({ asUid: SOFT.uid, fileCount: 2 }),
+    ]);
+    expect(mount.parked).toEqual([SOFT.folder]);
+    // …and the verb it must NOT have received.
+    expect(mount.unmounted).toEqual([]);
+  });
+
+  /**
+   * AXIS B — the counter honesty. The same two files must not be announced
+   * twice under two verbs; a park leaves `filesToDestroy` empty.
+   */
+  it("keeps parked files OUT of filesToDestroy / assetSpacesBeingTornDown", async () => {
+    const { mgr, confirmGate } = setup({
+      targetIncludes: FLOOR_UIDS,
+      materialized: [...FLOOR_UIDS, SOFT.uid],
+    });
+
+    await mgr.applyProfileViaRest("target");
+
+    const plan = confirmGate.lastPlan!;
+    expect(plan.assetSpacesBeingTornDown).toEqual([]);
+    const totalFiles = [...plan.filesToDestroy.values()].reduce(
+      (s, f) => s + f.length,
+      0,
+    );
+    expect(totalFiles).toBe(0);
+    // The files are still ACCOUNTED for — silence would be the other failure.
+    expect(plan.assetSpacesBeingParked[0].fileCount).toBe(2);
+  });
+
+  /**
+   * AXIS C — the split is real. A hard (`tbox`) departure keeps the
+   * pre-existing destroy semantics; "park everything" would be the lazy bug
+   * that makes A and B pass for the wrong reason.
+   */
+  it("still DESTROYS a hard-edge departure (park is not the new default)", async () => {
+    const { mgr, mount, confirmGate } = setup({
+      targetIncludes: FLOOR_UIDS,
+      materialized: [...FLOOR_UIDS, HARD.uid],
+    });
+
+    await mgr.applyProfileViaRest("target");
+
+    expect(mount.unmounted).toEqual([HARD.folder]);
+    expect(mount.parked).toEqual([]);
+    expect(confirmGate.lastPlan?.assetSpacesBeingParked).toEqual([]);
+    expect(confirmGate.lastPlan?.assetSpacesBeingTornDown).toEqual([
+      expect.objectContaining({ asUid: HARD.uid, fileCount: 2 }),
+    ]);
+  });
+
+  /**
+   * AXIS D — AC3. Coming back from parking must travel the SAME arrival loop as
+   * a fresh materialise, differing only in how the bytes are acquired. The
+   * evidence is that it lands in `assetSpacesBeingMaterialized` (shared
+   * bookkeeping) while ALSO being marked as an unpark, and that no tarball is
+   * pulled.
+   */
+  it("returns from parking through the SAME arrival path — rename, not download", async () => {
+    const { mgr, mount, confirmGate } = setup({
+      targetIncludes: [...FLOOR_UIDS, SOFT.uid],
+      materialized: FLOOR_UIDS,
+      parked: [SOFT.uid],
+    });
+
+    await mgr.applyProfileViaRest("target");
+
+    expect(mount.unparked).toEqual([SOFT.folder]);
+    // ⛔ Nothing crossed the network: the bytes were already here.
+    expect(mount.mounted).toEqual([]);
+    const plan = confirmGate.lastPlan!;
+    // Shared arrival bookkeeping…
+    expect(plan.assetSpacesBeingMaterialized.map((m) => m.asUid)).toContain(
+      SOFT.uid,
+    );
+    // …plus the marker that keeps the card honest about HOW it arrives.
+    expect(plan.assetSpacesBeingUnparked.map((m) => m.asUid)).toEqual([SOFT.uid]);
+  });
+
+  it("a parked AssetSpace the profile does NOT want is left alone (no verb at all)", async () => {
+    const { mgr, mount, confirmGate } = setup({
+      targetIncludes: FLOOR_UIDS,
+      materialized: FLOOR_UIDS,
+      parked: [SOFT.uid],
+    });
+
+    await mgr.applyProfileViaRest("target");
+
+    expect(mount.parked).toEqual([]);
+    expect(mount.unparked).toEqual([]);
+    expect(mount.unmounted).toEqual([]);
+    expect(confirmGate.lastPlan?.filesToDestroy.size).toBe(0);
+  });
+
+  /**
+   * AXIS E — AC4 / fact #10. Parking writes its OWN journal stages. It must
+   * never emit `phase2-destroy-cached`: that stage's recovery restores FROM the
+   * SwitchCacheLayer archive, and parking writes no archive — so a crash would
+   * send recovery hunting a tarball that never existed while the folder sat
+   * intact under `.exocortex/parked/`.
+   */
+  it("journals its OWN stages and never claims a cached destroy", async () => {
+    const { mgr, journal } = setup({
+      targetIncludes: FLOOR_UIDS,
+      materialized: [...FLOOR_UIDS, SOFT.uid],
+    });
+
+    await mgr.applyProfileViaRest("target");
+
+    const phases = (await journal()).map((e) => e.phase);
+    expect(phases).toContain("phase2-parked");
+    expect(phases).not.toContain("phase2-destroy-cached");
+    expect(phases).not.toContain("phase2-destroyed");
+  });
+
+  it("journals phase2-unparked on the way back", async () => {
+    const { mgr, journal } = setup({
+      targetIncludes: [...FLOOR_UIDS, SOFT.uid],
+      materialized: FLOOR_UIDS,
+      parked: [SOFT.uid],
+    });
+
+    await mgr.applyProfileViaRest("target");
+
+    const entries = await journal();
+    expect(entries.map((e) => e.phase)).toContain("phase2-unparked");
+    expect(entries.map((e) => e.phase)).not.toContain("phase2-materialized");
+  });
+
+  /**
+   * A park is WORK. Before this task an apply whose only delta was a soft
+   * departure had an empty destroy AND materialise set, so the no-op early exit
+   * would have swallowed it — the user would apply a profile and nothing would
+   * happen, with a "no changes" notice to confirm the lie.
+   */
+  it("does not fall through the no-op early exit when the only change is a park", async () => {
+    const { mgr, mount, notifyCalls } = setup({
+      targetIncludes: FLOOR_UIDS,
+      materialized: [...FLOOR_UIDS, SOFT.uid],
+    });
+
+    await mgr.applyProfileViaRest("target");
+
+    expect(mount.parked.length).toBe(1);
+    expect(notifyCalls.join("\n")).toContain("1 parked");
+    expect(notifyCalls.join("\n")).not.toContain("no changes");
+  });
+
+  /**
+   * ROUND TRIP — the concrete form of "undo must not re-download".
+   *
+   * `undoLastApply` is defined as "re-apply the previously-active profile", so
+   * it routes through this exact classifier; the undo harness
+   * (`ProfileApplyManager.undo.test.ts`) asserts the undo-TARGET bookkeeping and
+   * carries no `dependsOnKind` in its fixtures, so every departure there still
+   * resolves HARD → destroy → its recorded semantics are unchanged by this task.
+   * What that harness cannot show is the thing that actually changes: going back
+   * to a profile you just left must RENAME, not re-fetch. Two real applies on
+   * one manager (the spy moves folders, so the second apply reads what the first
+   * actually did) show it end to end.
+   */
+  it("park then come back: the second apply RENAMES, it never re-downloads", async () => {
+    const { mgr, mount } = setup({
+      // "target" drops the soft AS (→ park); "other" wants it back (→ unpark).
+      targetIncludes: FLOOR_UIDS,
+      otherIncludes: [...FLOOR_UIDS, SOFT.uid],
+      materialized: [...FLOOR_UIDS, SOFT.uid],
+    });
+
+    await mgr.applyProfileViaRest("target");
+    expect(mount.parked).toEqual([SOFT.folder]);
+
+    await mgr.applyProfileViaRest("other");
+
+    expect(mount.unparked).toEqual([SOFT.folder]);
+    // ⛔ The whole economic argument of the task: coming back costs a rename.
+    expect(mount.mounted).toEqual([]);
+    expect(mount.unmounted).toEqual([]);
+  });
+
+  /**
+   * AXIS F — AC2. `reconcileToLocal` must compute NO deletion for a parked
+   * AssetSpace: it is on the device, merely not active. The DELETION half needs
+   * no branch (materialised-ness is derived from mount-folder existence, so a
+   * parked AS can never enter `extra`); the ARRIVAL half does, or the reconcile
+   * card would announce a download for bytes already present.
+   */
+  it("reconcile computes NO deletion for a parked AS and announces an unpark", async () => {
+    const { mgr, confirmGate } = setup({
+      targetIncludes: [...FLOOR_UIDS, SOFT.uid],
+      materialized: FLOOR_UIDS,
+      parked: [SOFT.uid],
+      activeProfileUid: "target",
+    });
+    // Decline so the assertion is about the PLAN the user is shown, and the
+    // reconcile stops before mutating anything.
+    confirmGate.approve = false;
+
+    const r = await mgr.reconcileToLocal();
+
+    expect(r.outcome).toBe("declined");
+    const plan = confirmGate.lastPlan!;
+    // AC2 — the parked AssetSpace is on the device, so nothing is deleted…
+    expect(plan.filesToDestroy.size).toBe(0);
+    expect(plan.assetSpacesBeingTornDown).toEqual([]);
+    // …and its return is announced as an unpark, not a download.
+    expect(plan.assetSpacesBeingUnparked.map((u) => u.asUid)).toEqual([SOFT.uid]);
+  });
+
+  /**
+   * Negative control for the axis above: with the SAME divergence but the
+   * AssetSpace genuinely absent, the reconcile card must NOT claim an unpark —
+   * otherwise the assertion above would pass for a renderer that marks
+   * everything as "already on device".
+   */
+  it("reconcile does NOT claim an unpark for a genuinely absent AS (control)", async () => {
+    const { mgr, confirmGate } = setup({
+      targetIncludes: [...FLOOR_UIDS, SOFT.uid],
+      materialized: FLOOR_UIDS,
+      // no `parked` — the AS is nowhere on the device
+      activeProfileUid: "target",
+    });
+    confirmGate.approve = false;
+
+    await mgr.reconcileToLocal();
+
+    const plan = confirmGate.lastPlan!;
+    expect(plan.assetSpacesBeingMaterialized.map((m) => m.asUid)).toContain(
+      SOFT.uid,
+    );
+    expect(plan.assetSpacesBeingUnparked).toEqual([]);
+  });
+});

--- a/packages/obsidian-plugin/tests/unit/ProfileApplyManager.parked.test.ts
+++ b/packages/obsidian-plugin/tests/unit/ProfileApplyManager.parked.test.ts
@@ -186,6 +186,8 @@ class MountSpy {
    */
   constructor(
     private readonly fsFolders: Map<string, { files: string[]; folders: string[] }>,
+    /** Simulates a crash/failure INSIDE the move, for the journal-ordering axis. */
+    private readonly failPark = false,
   ) {}
   private move(from: string, to: string) {
     const entry = this.fsFolders.get(from);
@@ -205,6 +207,7 @@ class MountSpy {
     this.fsFolders.delete(submodulePath);
   }
   async park(submodulePath: string): Promise<void> {
+    if (this.failPark) throw new Error("simulated crash during park");
     this.parked.push(submodulePath);
     this.move(submodulePath, parkedPathFor(submodulePath));
   }
@@ -251,6 +254,8 @@ interface SetupOpts {
   activeProfileUid?: string;
   /** Declares of the second profile (`"other"`), for round-trip applies. */
   otherIncludes?: string[];
+  /** Makes `mount.park()` throw — drives the journal-ordering axis. */
+  failPark?: boolean;
 }
 
 function setup(opts: SetupOpts) {
@@ -321,7 +326,7 @@ function setup(opts: SetupOpts) {
   const indexer = new FakeIndexer();
   const localDataStore = new FakeLocalDataStore();
   const confirmGate = new FakeConfirmGate();
-  const mount = new MountSpy(fsFolders);
+  const mount = new MountSpy(fsFolders, opts.failPark ?? false);
   const notifyCalls: string[] = [];
   if (opts.activeProfileUid !== undefined) {
     void localDataStore.save({
@@ -489,6 +494,33 @@ describe("@req:d4ccc901-83a4-4495-a4bb-43d1305dfd00 ProfileApplyManager — park
     expect(phases).toContain("phase2-parked");
     expect(phases).not.toContain("phase2-destroy-cached");
     expect(phases).not.toContain("phase2-destroyed");
+  });
+
+  /**
+   * AXIS E2 — journal BEFORE the move, mirroring the git destroy path's F2
+   * ordering. The bytes are never at risk (a park is a rename; the classifier
+   * probes DISK via `isParkedOnDisk`, not the journal, so the next apply
+   * reconciles either way) — what the opposite ordering loses is ROLLBACK:
+   * `recoverIncompleteSwitch` restores the pre-apply mount-state from
+   * `interrupted.parked`, so an unjournalled park would leave that AssetSpace
+   * parked while its siblings are restored — the half-applied state recovery
+   * exists to prevent.
+   *
+   * The discriminator has to be a FAILING move: on the happy path both orderings
+   * produce the same journal, so only a crash-in-between separates them.
+   */
+  it("journals phase2-parked BEFORE moving, so an interrupted park is still rolled back", async () => {
+    const { mgr, journal } = setup({
+      targetIncludes: FLOOR_UIDS,
+      materialized: [...FLOOR_UIDS, SOFT.uid],
+      failPark: true,
+    });
+
+    await expect(mgr.applyProfileViaRest("target")).rejects.toThrow(/simulated crash/);
+
+    // Journal-after would leave NOTHING here — recovery would never learn the
+    // park was attempted, and `interrupted.parked` would come back empty.
+    expect((await journal()).map((e) => e.phase)).toContain("phase2-parked");
   });
 
   it("journals phase2-unparked on the way back", async () => {

--- a/packages/obsidian-plugin/tests/unit/adapters/logging/activityFanIn.test.ts
+++ b/packages/obsidian-plugin/tests/unit/adapters/logging/activityFanIn.test.ts
@@ -96,6 +96,13 @@ describe("journalEntryToActivity", () => {
       "phase2-destroyed",
       "phase2-materializing",
       "phase2-materialized",
+      // req `d4ccc901` — the two park stages belong in this enumeration too.
+      // ⛔ A hand-written list is exactly the surface that goes a layer stale:
+      // it stayed green through the whole park change because a MISSING entry
+      // is invisible to it, which is why the semantic axes below assert on the
+      // label CONTENT rather than on the list's completeness.
+      "phase2-parked",
+      "phase2-unparked",
       "phase2-done",
       "git-commit-done",
       "apply-completed",
@@ -110,6 +117,62 @@ describe("journalEntryToActivity", () => {
       // phase string should not leak raw unless intentionally unmapped
       expect(r.message).not.toBe(phase);
     }
+  });
+
+  /**
+   * @req:d4ccc901-83a4-4495-a4bb-43d1305dfd00
+   *
+   * req `d4ccc901` — the activity log is the SECOND carrier of the claim "these
+   * files are gone" (the switch-journal is the first). A park logged as an
+   * unmount is not cosmetic: this log is where a user looks AFTER the fact to
+   * answer "where did my files go", and "Unmounted" sends them hunting a
+   * re-download instead of the one-rename return.
+   *
+   * ⛔ The compiler cannot guard this. `PHASE_LABELS` / `PROGRESS_VERBS` are
+   * plain maps: delete the `park` entry and the lookup silently falls back
+   * (`?? entry.phase` here, `?? op` in the verb path) or — worse — someone
+   * "simplifies" it by pointing park at the unmount label. Both compile. Only an
+   * assertion on the label's MEANING reddens.
+   *
+   * Mutant per axis: point `park` at the `unmount`/`phase2-destroyed` label →
+   * exactly these reden; every other test in this file stays green.
+   */
+  it("a PARKED stage never says removed/unmounted — it says the bytes stayed", () => {
+    const r = journalEntryToActivity({
+      ...base,
+      phase: "phase2-parked",
+      as: "abcd1234-5678-90ab-cdef-1234567890ab",
+    });
+    expect(r.category).toBe("mount");
+    expect(r.level).toBe("info");
+    // ⛔ The claim it must NOT make.
+    expect(r.message).not.toMatch(/unmount|destroy|remov|delet/i);
+    // …and the claim it MUST make: still on this device.
+    expect(r.message).toMatch(/park/i);
+    expect(r.message).toMatch(/device/i);
+    expect(r.message).toContain("abcd1234");
+  });
+
+  it("an UNPARKED stage never reads as a fresh download", () => {
+    const r = journalEntryToActivity({
+      ...base,
+      phase: "phase2-unparked",
+      as: "abcd1234-5678-90ab-cdef-1234567890ab",
+    });
+    expect(r.category).toBe("mount");
+    // "Mounted"/"Pulling" would hide that nothing crossed the network.
+    expect(r.message).not.toMatch(/mounted|pull|download|fetch/i);
+    expect(r.message).toMatch(/restored/i);
+    expect(r.message).toMatch(/device/i);
+  });
+
+  it("park and destroy are DISTINGUISHABLE in the log (negative control)", () => {
+    // The pairing is the point: a reader scanning the log must be able to tell
+    // the two apart. If a future edit collapses park onto the destroy label this
+    // is the assertion that notices, even if both individually "look fine".
+    const parked = journalEntryToActivity({ ...base, phase: "phase2-parked", as: "aaaa1111" });
+    const destroyed = journalEntryToActivity({ ...base, phase: "phase2-destroyed", as: "aaaa1111" });
+    expect(parked.message).not.toBe(destroyed.message);
   });
 });
 
@@ -147,8 +210,34 @@ describe("progressToActivity (live materialize progress feed)", () => {
     );
   });
 
+  /**
+   * @req:d4ccc901-83a4-4495-a4bb-43d1305dfd00
+   *
+   * req `d4ccc901` — the live-feed half of the same claim. `PROGRESS_VERBS` is a
+   * `Record`, so the compiler forces the two new ops to HAVE an entry — it
+   * cannot force that entry to mean the right thing. Mutant: point `park` at
+   * `"Unmounting"` (or drop the entry so the `?? op` fallback fires) → only
+   * these two reden.
+   */
+  it("park → its OWN verb, never 'Unmounting'", () => {
+    const m = progressToActivity(evt({ op: "park", label: "public" })).message;
+    expect(m).toBe("Parking public 1b20a8f0 (1 of 3)");
+    expect(m).not.toMatch(/unmount|remov|delet/i);
+    // The fallback would print the raw op name — catch that too.
+    expect(m).not.toContain("park 1b20a8f0");
+  });
+
+  it("unpark → its OWN verb, never 'Mounting' (nothing crosses the network)", () => {
+    const m = progressToActivity(evt({ op: "unpark", label: "public" })).message;
+    expect(m).toMatch(/restoring/i);
+    expect(m).toMatch(/device/i);
+    expect(m).not.toMatch(/mounting|pulling|download/i);
+  });
+
   it("progress is ALWAYS category 'progress' (never toasted — distinct from journal feed)", () => {
-    for (const op of ["pull", "mount", "unmount"] as const) {
+    // req `d4ccc901` — the two new ops ride the same rule (a park must not
+    // start toasting where an unmount does not).
+    for (const op of ["pull", "mount", "unmount", "park", "unpark"] as const) {
       expect(progressToActivity(evt({ op })).category).toBe("progress");
     }
   });

--- a/packages/obsidian-plugin/tests/unit/infrastructure/adapters/RestAssetSpaceMount.test.ts
+++ b/packages/obsidian-plugin/tests/unit/infrastructure/adapters/RestAssetSpaceMount.test.ts
@@ -125,6 +125,33 @@ class InMemoryAdapter {
     }
   }
 
+  /**
+   * Obsidian DataAdapter.rename — MOVES the path and everything under it.
+   * req `d4ccc901`: parking IS a rename, so this has to be a real move. A fake
+   * that copied instead would let "the bytes stayed on the device" pass while
+   * the source folder was never actually relinquished.
+   */
+  async rename(from: string, to: string): Promise<void> {
+    if (!(await this.exists(from))) throw new Error(`ENOENT: ${from}`);
+    const move = <T>(m: Map<string, T>): void => {
+      for (const k of [...m.keys()]) {
+        if (k === from || k.startsWith(from + "/")) {
+          const v = m.get(k) as T;
+          m.delete(k);
+          m.set(to + k.slice(from.length), v);
+        }
+      }
+    };
+    move(this.files);
+    move(this.textFiles);
+    for (const d of [...this.dirs]) {
+      if (d === from || d.startsWith(from + "/")) {
+        this.dirs.delete(d);
+        this.dirs.add(to + d.slice(from.length));
+      }
+    }
+  }
+
   /** Obsidian DataAdapter.list — immediate children as full vault paths. */
   async list(dir: string): Promise<{ files: string[]; folders: string[] }> {
     const prefix = dir === "" ? "" : dir.replace(/\/+$/, "") + "/";
@@ -471,5 +498,118 @@ describe("RestAssetSpaceMount.listMountedAssetSpaces (RFC 0005 Phase 1 — files
     await expect(mount.listMountedAssetSpaces()).resolves.toEqual([
       { submodulePath: PATH_OK, url: URL_OK },
     ]);
+  });
+});
+
+/**
+ * @req:d4ccc901-83a4-4495-a4bb-43d1305dfd00
+ *
+ * req `d4ccc901` — park / unpark. Unmounting a SOFT-edge AssetSpace moves its
+ * folder to `.exocortex/parked/<owner>/<repo>` instead of deleting it; coming
+ * back moves it home. Measured ≈23 ms / 0 bytes vs ≈2.5 s / 0.7 MB for a REST
+ * re-materialisation — and it works offline.
+ *
+ * The two refusals below are the guards that make this safe to run twice:
+ * neither side may silently clobber a folder that already holds work.
+ */
+describe("@req:d4ccc901-83a4-4495-a4bb-43d1305dfd00 RestAssetSpaceMount.park / unpark", () => {
+  const PARKED = ".exocortex/parked/kitelev/exoas-ems";
+
+  async function mounted(): Promise<{
+    adapter: InMemoryAdapter;
+    mount: RestAssetSpaceMount;
+  }> {
+    const adapter = new InMemoryAdapter();
+    const tarball = await makeTarball("kitelev-exoas-ems-abc1234", [
+      { name: "README.md", data: new TextEncoder().encode("# EMS\n") },
+      { name: "ontology/Task.md", data: new TextEncoder().encode("task body") },
+    ]);
+    const mount = makeMount(adapter, makeFakeClient(tarball));
+    await mount.mount(URL_OK, PATH_OK, "main");
+    return { adapter, mount };
+  }
+
+  it("park MOVES the folder under .exocortex/parked — nothing is deleted", async () => {
+    const { adapter, mount } = await mounted();
+    expect(await adapter.exists(`${PATH_OK}/README.md`)).toBe(true);
+
+    await mount.park(PATH_OK);
+
+    // Gone from the mount point (so it stops being indexed)…
+    expect(await adapter.exists(PATH_OK)).toBe(false);
+    // …but present, byte-for-byte, on the device.
+    expect(await adapter.read(`${PARKED}/README.md`)).toBe("# EMS\n");
+    expect(await adapter.read(`${PARKED}/ontology/Task.md`)).toBe("task body");
+    // ⛔ NOT under the plugin dir: BRAT overwrites that on every update.
+    expect(PARKED.startsWith(".exocortex/")).toBe(true);
+  });
+
+  it("unpark MOVES it home — a rename, no fetch", async () => {
+    const { adapter, mount } = await mounted();
+    await mount.park(PATH_OK);
+
+    await mount.unpark(PATH_OK);
+
+    expect(await adapter.read(`${PATH_OK}/README.md`)).toBe("# EMS\n");
+    expect(await adapter.read(`${PATH_OK}/ontology/Task.md`)).toBe("task body");
+    expect(await adapter.exists(PARKED)).toBe(false);
+  });
+
+  it("round-trips content unchanged (park → unpark is identity)", async () => {
+    const { adapter, mount } = await mounted();
+    const before = await adapter.list(PATH_OK);
+
+    await mount.park(PATH_OK);
+    await mount.unpark(PATH_OK);
+
+    await expect(adapter.list(PATH_OK)).resolves.toEqual(before);
+  });
+
+  /**
+   * GUARD — park refuses to overwrite an existing parked copy.
+   * Mutant: drop the `exists(parkedPath)` check → this reddens alone.
+   * Without it a second park silently destroys whichever copy loses; the two
+   * copies are exactly the case where a human must decide, because one of them
+   * holds work the other does not.
+   */
+  it("park REFUSES when a parked copy already exists (never clobbers)", async () => {
+    const { adapter, mount } = await mounted();
+    await mount.park(PATH_OK);
+    // Re-mount, then try to park on top of the existing parked copy.
+    await mount.mount(URL_OK, PATH_OK, "main");
+
+    await expect(mount.park(PATH_OK)).rejects.toThrow(
+      /parked copy already exists/,
+    );
+    // Neither side was touched by the refusal.
+    expect(await adapter.exists(`${PARKED}/README.md`)).toBe(true);
+    expect(await adapter.exists(`${PATH_OK}/README.md`)).toBe(true);
+  });
+
+  /**
+   * GUARD — unpark refuses when there is nothing parked (a stale plan), and
+   * refuses to unpark ONTO a live mount. Mutant: drop either `exists` check →
+   * this reddens alone.
+   */
+  it("unpark REFUSES when nothing is parked (stale plan fails loud)", async () => {
+    const { mount } = await mounted();
+    await expect(mount.unpark(PATH_OK)).rejects.toThrow(/nothing parked/);
+  });
+
+  it("unpark REFUSES to overwrite a live mount", async () => {
+    const { adapter, mount } = await mounted();
+    await mount.park(PATH_OK);
+    await mount.mount(URL_OK, PATH_OK, "main"); // mount point occupied again
+
+    await expect(mount.unpark(PATH_OK)).rejects.toThrow(
+      /refusing to unpark onto existing mount/,
+    );
+    expect(await adapter.exists(`${PARKED}/README.md`)).toBe(true);
+  });
+
+  it("refuses a traversal path rather than moving a directory elsewhere", async () => {
+    const { mount } = await mounted();
+    await expect(mount.park("assetspaces/../../etc")).rejects.toThrow();
+    await expect(mount.unpark("assetspaces/../../etc")).rejects.toThrow();
   });
 });


### PR DESCRIPTION
## What

`apply-profile` gains a **third mount state**. Until now an AssetSpace was binary — materialised or not — so leaving the effective set meant one thing: `rm -rf`. Coming back meant re-fetching it over the network.

| state | on disk | leaving the effective set | coming back |
|---|---|---|---|
| `active` | `assetspaces/<owner>/<repo>` | — | — |
| **`parked`** | **`.exocortex/parked/<owner>/<repo>`** | **local `mv`** (soft edge) | **local `mv` back** |
| `absent` | nowhere | `rm -rf` (hard edge) | REST re-materialisation |

Measured on the real vault: coming back from parked is **23 ms / 0 bytes** against ≈**2.5 s / 0.7 MB** for re-materialisation — ~105× faster, and it works offline.

Which edge an AssetSpace has is the typed `exo__AssetSpace_dependsOnKind` shipped by req `18ecf16f` (T1): `reference` → soft → parkable; `tbox` → hard → destroyed. The default is structural: **only a positive match on the soft value yields `reference`**, so an unlabelled or unknown edge is treated as hard and is never parked.

Closes req `d4ccc901-83a4-4495-a4bb-43d1305dfd00`.

## Acceptance criteria

**AC1 — three states are distinguishable in the plan, park ≠ destroy.**
`ApplyPlan` gains **required** `assetSpacesBeingParked` / `assetSpacesBeingUnparked`. Required, not optional: the compiler then forces every producer and every renderer to say something about them, instead of silently defaulting to "nothing to report".

⚠ **Scope caveat, stated rather than papered over:** in `HeadlessConfirmGate.confirmApply` the whole plan block lives inside `if (this.verbose)`. So `apply-profile <uid> --yes` **without** `--verbose` mutates the disk without printing any plan — before this PR as much as after. AC1 is therefore satisfied **only under `--verbose`**. Making the plan always print changes the UX of an existing command; that is a vision decision, not something to slip in here.

**AC2 — `reconcileToLocal` computes no deletion for a parked AssetSpace.** It probes the parked location before concluding "absent", and announces an unpark instead of a re-mount.

**AC3 — returning from parking reaches `active` through the *same* path, not a copy.** The unpark is a `source: "unpark"` branch **inside the existing arrival loop**: same journal sequencing, same progress reporting, same rollback bookkeeping. A parked-and-returned AssetSpace appears in `assetSpacesBeingMaterialized` exactly like a freshly mounted one — only `mount.mounted` stays empty, because nothing crossed the network. Test `returns from parking through the SAME arrival path` asserts both halves.

**AC4 — the `SwitchCacheLayer` decision.** Written into the task body (`8b502d9e`) with the reasoning; summary below.

**AC5 — a red side per guard, separately.** 16-guard mutation matrix, table below.

**AC6 / AC7** — req flipped `proposed` → `active` after merge, with a `requirements-trace` run started *after* the flip; remote verified by content.

## `SwitchCacheLayer`: stays

Cache and parking answer different questions, and merging them would cost both guarantees.

1. **The cache covers a case parking does not have.** It exists for **`absent`**: a hard (`tbox`) edge, and anything unparkable by policy (`exoas-registry`, `exoas-exo`, the TS floor), still *departs by destruction*. The tarball is the only thing that can restore it if the process dies between `rm -rf` and materialisation. Parking has nothing to say here — you cannot park what you have decided to delete.
2. **Reusing the cache for parking would erase exactly what parking was measured for.** The destroy path tars *before* deleting (`cacheLayer.cache(...)` → `phase2-destroy-cached` → `rm -rf` → `phase2-destroyed`). A tar is a second copy of the bytes plus compression time; the measured 23 ms / 0 bytes would become "as slow as a destroy, plus the disk".
3. **Recovery differs and does not reduce.** Destroy-path recovery keys on `phase2-destroy-cached` and restores *from the cache*; parking keys on its own `phase2-parked` and recovers by **renaming back**, because the bytes never left. Hence the dedicated journal stages and the dedicated recovery branch — deliberately **not** added to `GIT_ONLY_PHASES`.

Not decided here (and not to be decided silently): whether the cache still earns its keep once parking is the default for *all* soft edges. That only becomes answerable after the data split actually happens.

## The approval surface: four renderers, not two

`ApplyPlan` is the **confirm-gate contract**, so partitioning parks out of `filesToDestroy` / `assetSpacesBeingTornDown` is not cosmetic — otherwise the card says *"N files to remove"* over an operation that removes nothing. Every surface that renders the plan or narrates the apply was updated **and given a semantic axis**:

| surface | what it renders | axis |
|---|---|---|
| `HeadlessConfirmGate` (CLI) | counters | `"42 files to park"`, `"1 AS to park"`, **`"0 files to remove"`** |
| `ModalConfirmGate` (plugin) | h3 sections | its own park section; teardown/materialise sections still present |
| `activityFanIn` journal labels | stage → phrase | a parked stage must not say removed/unmounted/deleted |
| `activityFanIn` progress verbs | op → verb | `park` gets its own verb, never `Unmounting` |

⛤ The fourth surface was found by the **compiler**, not by enumeration — making the fields required turned "a surface I forgot" into a build error. But the compiler only proves a surface was *touched*, not that it was touched *correctly*: a map entry is trivially reversible, and reverting it compiles and keeps every test green. Hence the label mutants (G10/G11) — point the park entry back at `Unmounting`/`Unmounted` and the axis must redden.

### Test fixtures updated **by purpose** — named explicitly

* `packages/cli/tests/unit/services/HeadlessConfirmGate.test.ts` — its `makePlan` now carries the two new arrays. Its pre-existing `"2 files to remove"` assertion **stays as is and stays correct**: the partition lives in the *producers*, and this suite tests a *renderer*, which prints what it is handed.
* `packages/obsidian-plugin/tests/unit/ModalConfirmGate.test.ts` — park/unpark sections added, plus an assertion that `.apply-confirm-tear-section` / `.apply-confirm-mat-section` still exist.

Neither edit was made to keep CI green. A green test locking the *wrong* semantics is worse than a red one.

### `ProfileApplyManager.undo.test.ts` — checked, deliberately unchanged

Parking changes the meaning of undo (undoing a park ≠ undoing a destroy), so the old harness could have been locking the previous semantics. It is not: that suite asserts undo-*target* bookkeeping only and carries **zero** `dependsOnKind` in its fixtures, so every departure there resolves as **hard → destroy** and its recorded semantics are unchanged. What it *cannot* show — that coming back must rename rather than re-fetch — is covered by the new round-trip test.

## Coverage boundaries, stated rather than assumed

**The git apply path is not parked** — and this is *measured*, not assumed, because the cost of being wrong is that parking silently degenerates into destroy wherever git is still live. The chain, on this branch:

| Link | Anchor | What it establishes |
|---|---|---|
| plugin builds the manager unconditionally | `ExocortexPlugin.ts:3392` `new ProfileApplyManager({…})` — straight-line in `onload`, no `if` wrapper | every real plugin instance gets the deps below |
| `restMountFactory` wired with no platform/PAT gate | `ExocortexPlugin.ts:3410` `restMountFactory: () => buildRestAssetSpaceMount({ app: this.app })` | the factory is **always** present (#3410 removed the prior `Platform.isMobile &&`) |
| `applyProfile` delegates on factory presence, not on a PAT | `ProfileApplyManager.ts:969` `if (this.restMount !== undefined \|\| this.restMountFactory !== undefined) return this.applyProfileViaRest(...)` (`hasRest()` at :687 checks the same) | the git body below is unreachable whenever the plugin constructed the manager |

⇒ `applyProfile` (git) carries `assetSpacesBeingParked: []` **with a comment saying why empty is correct**, so the next reader does not mistake it for an oversight.

⛤ **The same measurement settles the E2E question**, which is where an unmeasured claim would have actually cost something. `tests/e2e/eka/eka-obsidian-leg.spec.ts:688` reaches in via `w.app.plugins.plugins.exocortex.profileApplyManager` and calls `.applyProfile(uid)` — i.e. the **plugin-constructed** manager, so the delegation above fires and that test exercises the **REST** path, where parking is implemented. Parking does **not** degenerate into destroy there. The spec's own doc-comment (lines 83-84: "The plugin's DESKTOP apply path … registers each newly-materialised AssetSpace via `git submodule add <url>`") is **stale relative to #3410** — left untouched here, since correcting a doc-comment in a spec this PR does not otherwise modify is scope I did not take.

**⚠ `tests/e2e/eka/eka-obsidian-leg.spec.ts` lives in its own workflow, outside the 13 required checks.** Breaking it does not redden the PR — it makes the post-merge push-run conclude `failure`, which **silently SKIPS Auto Release**. Its assertions on the confirm-modal plan were read before the modal was touched; the park section is *additive* and the sections it asserts on are still rendered (locked by a dedicated assertion in `ModalConfirmGate.test.ts`, so the out-of-required risk is pulled forward into the required gate). Not run locally — Docker/QEMU with parallel sessions has produced a kernel panic before; CI only.

## AC5 — mutation matrix (17 guards, every one reddens)

Each guard neutralised **separately** on a byte-verified copy; `RESTORE-OK all byte-identical` at the end.

| # | guard neutralised | reds |
|---|---|---|
| G1 | classifier: soft/hard split | 11 |
| G2 | classifier: `canPark` capability gate | 10 |
| G3 | classifier: parked + wanted → `unpark` | 11 |
| G4 | `parkedPathFor` unsafe-folder refusal | 5 |
| G5 | `canPark` uses `restWired()` (revert to the live bug) | 5 |
| G6 | park/destroy partition | 5 |
| G7 | park counts as work (no-op early exit) | 4 |
| G8 | unpark uses the local rename | 3 |
| G9 | reconcile marks the unpark | 1 |
| G10 | activity log: park verb | 1 |
| G11 | activity log: parked journal label | 2 |
| G12 | CLI: soft departure parks | 2 |
| G13 | headless gate: park line is printed | 1 |
| G14 | modal gate: park section is rendered | 1 |
| G15 | mount: park refuses to clobber a parked copy | 1 |
| G16 | mount: unpark refuses when nothing is parked | 1 |
| G17 | park journals **before** the move | 1 |

**Mutants are semantically valid.** `false || X` is `X`; a dead branch before a live one is unreachable. Both compile, both change nothing, and both would read as "the axis does not discriminate".

**The mutation itself can fail silently, and that failure is indistinguishable from an uncovered guard.** `ProfileApplyManager.ts` carries 10+ comments quoting the very tokens these mutants target (`{@link restMount}` appears four times in JSDoc alone) — a token anchor can land in a comment, "apply" cleanly, change nothing, and read as zero coverage. So the harness: anchors on a **full code line**, asserts `src.count(old) == 1` (the *count* is what separates "hit the line I meant" from "hit some line"), and **prints the diff of every mutation**. The diff is the only thing that tells *"the mutation did not fire"* apart from *"the guard is not covered"*. Audit of all 16 diffs: none landed on a comment line.

### Two axes that exist because a fixture shape hid a real bug

**`canPark()` read `this.restMount` directly** — but production wires **only** `restMountFactory`. So in production `canPark()` was always false: zero parks would ever have been planned, silently, with every test green. Seven sibling `ProfileApplyManager` harnesses wire `restMount` explicitly, which is exactly why the hole survived. `ProfileApplyManager.parked.test.ts` therefore **omits `restMount` on purpose**, matching `:3410`. Differential on a copy: reverting `restWired()` reddens **4 axes, all in the new harness**, while the seven siblings stay green — which is itself the evidence the hole was real.

### Adversarial review: verdict checked, not accepted

A read-only reviewer returned five axes SOLID and one **CRITICAL — "data-loss, BLOCK MERGE"**: the park loop moved the folder *before* journalling, unlike the git destroy path. Verified against the cited lines rather than taken on trust:

* **False** — "`classifyInterruptedSwitch` (782-785) never populates the `parked` set". Lines 782-785 *are* `case "phase2-parked": parked.add(e.as)`.
* **False** — "`recoverIncompleteSwitch` (2431-2458) never unparks it". Those lines *are* the unpark loop.
* **True** — the journal was written after the move. (The reviewer compared against the **git** destroy loop; the REST path's own destroy sibling, twelve lines above the park loop, also journals *after* `unmount()`. So the park loop matched its immediate neighbour and differed from the other path.)

Severity was overstated: a park is a **rename**, so no bytes are at risk, and the classifier probes **disk** (`isParkedOnDisk`) rather than the journal — the next apply reconciles a half-parked AssetSpace on its own, in both branches (wanted → `unpark`; unwanted → `none`, which is the intended end state anyway). What the ordering *did* cost is **rollback**: `recoverIncompleteSwitch` restores the pre-apply mount-state from `interrupted.parked`, so an unjournalled park would leave that one AssetSpace parked while its siblings were restored — the half-applied state recovery exists to prevent. Cheap and strictly better, so applied.

The axis needs a **failing** move to discriminate — on the happy path both orderings emit an identical journal. `MountSpy` grew a `failPark` switch; G17 reddens exactly 1 of 12.

## T3a shadow check (req `4eca4900`, PR #4032)

T3b starts actually moving mount folders, so "parking is invisible to sync-unit enumeration" stops being academic. Both older guards were neutralised separately:

* **CLI** (`exosync-parity.ts`, the `existsSync` gate before `commit()`) → **3 reds**. Discriminates.
* **Plugin** (`SyncDepsFactory.ts`, the `adapter.exists` gate) → **0 reds**.

Zero reds is not shadowing here, and this PR is not the cause — proven two ways: (1) this branch touches **neither** `SyncDepsFactory.ts` nor its test (`git diff origin/main` on both is empty), so by construction it cannot have shadowed anything; (2) neutralising **both** that gate *and* the downstream empty-listing veto together reddens **2** tests. The invariant is **over-determined on `main`** by two guards, so removing either alone is unobservable. Surfaced as a finding on T3a; not fixed here — different requirement, different scope.

## Verification

* `npm run check:types` — clean.
* `npm run lint` — clean.
* `packages/core` — **360/360 suites**, 8482 passed.
* `packages/obsidian-plugin` — 339/340 suites. The one red is `ReactRenderer.test.tsx`, which the repo's own config **deliberately excludes** (`testPathIgnorePatterns`: *"Temporarily skip these broken tests until ErrorBoundary mocking is fixed"*). My first full run passed its own `--testPathIgnorePatterns`, which **overrode** that list and un-skipped it. Not a failure — an artefact of the invocation.
* `packages/cli` — 155/156 suites, under `node --experimental-vm-modules` (its ESM config requires it; a plain `npx jest` yields `SyntaxError … 0 total`, which looks like mass failure but runs nothing). The one red is `sparql-exo003.integration.test.ts`, unrelated to this diff (it spawns the built CLI and asserts a SPARQL row count). Verified **environmental, not pre-existing breakage**: `test-coverage-cli` is **green on the exact base commit** `45f334f7` in CI. Ruled out locally: stale `dist` (rebuilt in dependency order — still red) and the global query-result cache (moved aside — still red). Left to this PR's own CI, which is the authoritative gate.

Also environmental, worth recording: this worktree had **no data submodules initialised**, which reddened every `exoas-exo`/`exoas-exocmd` walker suite in `core` and `obsidian-plugin` until `git submodule update --init`. And `packages/req-audit` failed `check:types` on a missing `glob` — declared in its `package.json`, absent from this worktree's `node_modules`; installed with `--no-save` after verifying `package-lock.json` stayed byte-identical.
* DoD after merge: remote verified **by content** (`gh api …/contents/<path>?ref=main | base64 -d | grep <marker>`), not by a `pushed N` counter.

### `EKA Obsidian-leg E2E` — skipped here by design, and it does **not** gate the release

This is the workflow that drives the desktop apply path (`git submodule add`) against live `exoas-*`. On this PR it shows **skipped**, which is correct: it has **no `pull_request` trigger** at all — only `workflow_dispatch`, a nightly `schedule`, and `push: [main]`. Its `push` paths include `packages/obsidian-plugin/src/**` and `packages/core/src/**`, both of which this PR touches, so it **will** run post-merge on `main`. Worth watching there.

One correction to the framing it was raised under: breaking it would **not** silently skip Auto Release. `auto-release.yml` gates on `workflow_run: workflows: ["CI"]`, and this is a *separate* workflow with its own name — its conclusion never reaches that gate. The real cost of breaking it is a **silent red on `main`** in a workflow nobody is required to watch, which is bad on its own terms but is a different failure than a missed release.
