### PR TITLE
chore(deps): unblock release gate — GHSA-5p4m-2wfm-xmqj

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2559,9 +2559,9 @@
       }
     },
     "node_modules/@eslint/config-array/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2650,9 +2650,9 @@
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2909,9 +2909,9 @@
       }
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
-      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
+      "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5575,9 +5575,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
-      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6971,9 +6971,9 @@
       }
     },
     "node_modules/eslint-plugin-import/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7233,9 +7233,9 @@
       }
     },
     "node_modules/eslint-plugin-react/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7332,9 +7332,9 @@
       }
     },
     "node_modules/eslint/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7622,9 +7622,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "dev": true,
       "funding": [
         {
@@ -10672,9 +10672,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "funding": [
         {
           "type": "github",
@@ -11312,9 +11312,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.17",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
+      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
       "dev": true,
       "funding": [
         {
@@ -11927,9 +11927,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.21",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.21.tgz",
-      "integrity": "sha512-v4sDNP3fdNiWMfabO7OwOQdOX8TiQSztKyT1Wj0w+j7LDallJThJRBBBmzVGyYj0crMh7jlV4zepPkiNu9UwDQ==",
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
       "dev": true,
       "funding": [
         {
@@ -11947,7 +11947,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.16",
+        "nanoid": "^3.3.17",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -13283,9 +13283,9 @@
       }
     },
     "node_modules/test-exclude/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -15146,7 +15146,7 @@
         "commander": "^14.0.2",
         "fs-extra": "^11.0.0",
         "glob": "^11.0.0",
-        "js-yaml": "^4.2.0",
+        "js-yaml": "^4.3.1",
         "minimatch": "^10.2.4",
         "nanotar": "0.3.0",
         "ora": "^9.0.0"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -51,7 +51,7 @@
     "commander": "^14.0.2",
     "fs-extra": "^11.0.0",
     "glob": "^11.0.0",
-    "js-yaml": "^4.2.0",
+    "js-yaml": "^4.3.1",
     "minimatch": "^10.2.4",
     "nanotar": "0.3.0",
     "ora": "^9.0.0"


### PR DESCRIPTION
## Why (release gate is red repo-wide)

`main` fails the **non-required** job `npm-audit-exocortex`. That reddens `CI.workflow_run.conclusion`, and Auto Release gates on `workflow_run.conclusion == 'success'` — so **the release has been silently SKIPPED for every merge**, repo-wide. `d75eaa07` (merged 2026-08-07) never shipped to the user.

This is the failure mode documented in `rules/auto-release-gated-on-ci-workflow-conclusion.md`: required-14 checks let PRs merge, but a non-required job still blocks the release.

## Root cause (verified, not inferred)

| | |
|---|---|
| Gate command | `npm audit --audit-level=high --omit=dev` |
| Gate cwd | `packages/core` |
| Advisory | **GHSA-5p4m-2wfm-xmqj** (high, prototype pollution), `js-yaml >=4.0.0 <4.3.1`, fixed in **4.3.1** |

⛤ **The audit input is the monorepo ROOT `package-lock.json`, not `packages/core/package-lock.json`.** `packages/core` is an npm **workspace member**, so npm walks up to the root lockfile. The `cache-dependency-path: packages/core/package-lock.json` line in `ci.yml` is only a **setup-node cache key** — conflating it with the audit input sends you to the wrong lockfile (I went there first).

In the root lockfile `node_modules/js-yaml` was pinned at **4.3.0** with `dev` unset ⇒ **production path** ⇒ `--omit=dev` correctly flagged it.

The gate already scopes to `--omit=dev` (shipped 2026-07-27), so no gate change was needed — the exposure is genuinely production.

## Fix (split-exposure — targeted consumer bump, no global override)

`packages/cli` is the **only PUBLISHED prod consumer** of js-yaml. Verified against `origin/main` manifests:

| package | js-yaml declared as | in `--omit=dev` prod graph? |
|---|---|---|
| `packages/cli` | `dependencies` | ✅ yes — and it is the **published** one |
| `packages/req-audit` | `dependencies` | ✅ yes (see Observation 1 — resolves to the same hoisted node) |
| `packages/core` | devDependencies | no |
| `packages/obsidian-plugin` | devDependencies | no |

⚠ Both `cli` and `req-audit` sit in the prod graph; `private: true` does **not** remove a workspace member's `dependencies` from it. Pinning `cli` suffices only because both resolve to the single hoisted `node_modules/js-yaml` — see Observation 1.

Its range `^4.2.0` **already permitted 4.3.1** — only the lockfile held the vulnerable resolution.

- `packages/cli/package.json`: `js-yaml ^4.2.0 → ^4.3.1` (same major, patch)
- `package-lock.json`: `npm audit fix --package-lock-only` (**non-force**)

⛔ Deliberately **no global `overrides`** — that path was tried in closed PR #3938 and broke the jest coverage pipeline (`minimatch@10` removed the callable default export that babel-plugin-istanbul still calls). Bumping the shipped consumer's own dep sidesteps it entirely.

### Lockfile delta

Net: `js-yaml 4.3.0 → 4.3.1` on the prod path. Incidental **patch-level** bumps of dev-only transitives: `brace-expansion` (1.1.16→1.1.18 ×6, 2.1.2→2.1.4), `js-yaml@3` under `@istanbuljs/load-nyc-config` (3.15.0→3.15.1), `fast-uri` 3.1.4→3.1.5, `nanoid` 3.3.16→3.3.17, `postcss` 8.5.21→8.5.26. **No major bumps.**

## Verification

Per `rules/auto-release-gated-on-ci-workflow-conclusion.md` §2026-07-25 — validate the packages that **USE** the bumped dep, not a core-only smoke (a core-only smoke is exactly what let PR #3938 look safe while breaking every coverage shard).

| check | result |
|---|---|
| `npm audit --audit-level=high --omit=dev` (cwd `packages/core`) | **exit 0** — `found 0 vulnerabilities` |
| `npm ci` | exit 0, 951 packages (lockfile ↔ manifest in sync) |
| `npm run check:types` | exit 0 |
| core js-yaml-heavy suites `--coverage` | **38 suites / 617 tests** pass |
| obsidian-plugin suites `--coverage` | **11 suites / 119 tests** pass |
| cli full suite | 155/156 suites, 1862 tests pass |

The single cli failure (`sparql-exo003.integration.test.ts`) is **pre-existing and local-environment-only** — proven by a flip: `npm install js-yaml@4.3.0 --no-save` reproduces the *identical* failure, and `test-coverage-cli` is green on `main`. Not caused by this change; not investigated further (out of scope).

⚠ `packages/exoas-exo` had to be `git submodule update --init` — 3 plugin parity tests fail on an uninitialised submodule. Environmental, unrelated to this diff.

## Observations (NOT actioned here — deliberately out of scope)

> **Corrected after orchestrator review** — my first draft of both items below stated a *false mechanism*. Both are now re-derived from the lockfile diff in this PR and from `gh api advisories`, not from plausibility. Recording the correction rather than silently overwriting, because a wrong-but-true-sounding mechanism in a durable artifact is worse than no note (the next reader treats it as verified).

### 1. `packages/req-audit` also declares js-yaml in `dependencies` — and that is fine, but NOT for the reason I first wrote

⛔ **Wrong reason (my first draft):** "it is `private: true`, so it is not shipped and the gate does not require it."

`private: true` governs **publication to npm**, not **classification in the audit graph**. A workspace member's `dependencies` land in npm's **production** graph regardless of `private` — so `--omit=dev` *does* see them. Left as written, that note would teach the next reader that private packages are exempt from the audit gate. They are not.

✅ **Actual mechanism:** the root lock contains exactly **two** js-yaml nodes —

```
node_modules/js-yaml                                        4.3.1  dev=None   <- hoisted, prod
node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml 3.15.1 dev=True
```

`packages/req-audit` has **no nested `node_modules` at all**, so it resolves to that same hoisted node — which this PR already moved to 4.3.1. Nothing to do, because it is *already covered*, not because it is exempt.

### 2. `brace-expansion` — the July override does not merely lag, it BLOCKS the patch

**GHSA-rgw5-rvv9-x895** (published 2026-08-03, high) patches four lines:

| vulnerable range | patched |
|---|---|
| `< 1.1.18` | 1.1.18 |
| `>= 2.0.0, < 2.1.4` | 2.1.4 |
| `>= 3.0.0, < 3.0.6` | 3.0.6 |
| `>= 4.0.0, < 5.0.9` | **5.0.9** |

(My first draft said the range topped out at 5.0.8. It does not — the patch is **5.0.9**, and 5.0.9 is published on npm.)

⛤ **The lockfile diff in this PR is itself the evidence.** `npm audit fix` moved every brace-expansion node it was *permitted* to move, straight to this advisory's patched versions:

```
1.1.16 -> 1.1.18   x6 nodes   dev=True    (no override on 1.x -> floated freely)
2.1.2  -> 2.1.4    x1 node    dev=True    (no override on 2.x -> floated freely)
5.0.8  -> 5.0.8    x1 node    dev=None    <- PINNED by overrides["brace-expansion@5.x"]="5.0.8"
```

The one node left vulnerable is the **production** one (`cli -> glob@11 -> minimatch@10.2.5 -> brace-expansion`, `dev` unset), and it is stuck precisely because the July override pins it *below* the 5.0.9 patch. So the override is now actively preventing the fix npm would otherwise have applied by itself.

`npm audit --omit=dev` does **not** flag it today, and did not flag it before this change either (the failing CI log showed exactly one high = js-yaml) — so this PR is not hiding a regression. But it is a live high-severity node on the prod path and a strong candidate for the next gate-reddening event.

**Not touched here on purpose** — bumping the override collides with this PR on the root lockfile. The orchestrator is taking it as a separate work-item after this merge.

## Definition of Done

- [x] `npm audit --audit-level=high --omit=dev` = 0
- [x] `git diff --stat` = only the 2 expected files
- [x] `check:types` + coverage smoke green on **consumer** packages
- [ ] push-run CI on `main` = `conclusion: success`
- [ ] Auto Release for that run = `completed/success`, new tag containing `d75eaa07`
