### PR TITLE
test(sync): lock the FINDING-3 mount-walk guards individually and as a pair

### DIFF
--- a/packages/obsidian-plugin/tests/unit/sync/SyncDepsFactory.test.ts
+++ b/packages/obsidian-plugin/tests/unit/sync/SyncDepsFactory.test.ts
@@ -177,13 +177,16 @@ describe("collectSyncRepoSpecs", () => {
    *   B2 — `if (!(await adapter.exists(root))) return out;`   (absent-root fast path)
    *   C  — the outer `catch` that swallows any listing failure
    *
-   * Measured on a hardlink copy of origin/main@0cc49ef2, this suite:
+   * Measured by mutating a hardlink copy of origin/main@0cc49ef2 and running
+   * this suite against it — one mutation per guard, exact-literal anchor, with
+   * the replacement count asserted so a mutation that fails to apply cannot
+   * pass for green:
    *
-   *   | mutation        | red |
-   *   |-----------------|-----|
-   *   | B2 alone        |  0  |
-   *   | C  alone        |  0  |
-   *   | B2 + C together |  3  |
+   *   | mutation        | red before | red after |
+   *   |-----------------|------------|-----------|
+   *   | B2 alone        |     0      |     0     |
+   *   | C  alone        |     0      |     1     |
+   *   | B2 + C together |     3      |     5     |
    *
    * ⛔ Zero-red-alone means the contract is held TWICE, NOT that it is
    * untested — neither guard may be deleted as «uncovered»
@@ -192,20 +195,36 @@ describe("collectSyncRepoSpecs", () => {
    * locked only as a PAIR. C, by contrast, IS isolable — a root that exists
    * but cannot be listed reaches C and nothing else.
    *
-   * Until these two checks the pair was locked only INCIDENTALLY, by three
-   * tests whose subject is something else entirely («skips non-GitHub
-   * sources», «warns on a FileSpace without a source», «excludes AssetSpaces
-   * whose mount folder is absent») — each green merely because its fixture
-   * happens to omit `assetspaces/`. The first fixture to add that folder would
-   * have unlocked the pair silently.
+   * The two checks below do DIFFERENT jobs, and only the first adds coverage:
+   *
+   *  - «isolates the outer swallow» moves C from 0 to 1 red — it is the only
+   *    red under `C alone`.
+   *  - «pair axis …» adds NO coverage: the pair already reds 4× without it.
+   *    The pair WAS locked before this commit, but only INCIDENTALLY — by
+   *    three tests whose subject is something else entirely («skips non-GitHub
+   *    sources», «warns on a FileSpace without a source», «excludes
+   *    AssetSpaces whose mount folder is absent»), each green merely because
+   *    its fixture happens to omit `assetspaces/`. Adding that folder to any
+   *    of them would unlock the pair silently. This check exists to state the
+   *    contract by NAME on a fixture whose root-absence is deliberate rather
+   *    than incidental — intent, not coverage.
    */
   describe("the FINDING-3 mount walk never throws into the sync path", () => {
-    /** Root present but unlistable (EACCES / iOS sandbox) — reaches only C. */
+    /**
+     * Root present but unlistable (EACCES / iOS sandbox) — reaches only C.
+     *
+     * Denies the subtree, not just the root: a real permission-denied folder
+     * denies its children too, and only `list` is denied — `exists` still
+     * answers, which is what keeps the B2 fast path from firing and lets the
+     * declared AssetSpace pass its own materialization gate.
+     */
     class UnreadableRootAdapter extends InMemoryAdapter {
       override async list(
         dir: string,
       ): Promise<{ files: string[]; folders: string[] }> {
-        if (dir === "assetspaces") throw new Error("EACCES: permission denied");
+        if (dir === "assetspaces" || dir.startsWith("assetspaces/")) {
+          throw new Error("EACCES: permission denied");
+        }
         return super.list(dir);
       }
     }

--- a/packages/obsidian-plugin/tests/unit/sync/SyncDepsFactory.test.ts
+++ b/packages/obsidian-plugin/tests/unit/sync/SyncDepsFactory.test.ts
@@ -169,6 +169,93 @@ describe("collectSyncRepoSpecs", () => {
     });
   });
 
+  /**
+   * Mount-walk resilience — `enumerateMountFolders` carries TWO guards for the
+   * single contract stated in its docstring: «a detection helper must never
+   * throw into the sync path».
+   *
+   *   B2 — `if (!(await adapter.exists(root))) return out;`   (absent-root fast path)
+   *   C  — the outer `catch` that swallows any listing failure
+   *
+   * Measured on a hardlink copy of origin/main@0cc49ef2, this suite:
+   *
+   *   | mutation        | red |
+   *   |-----------------|-----|
+   *   | B2 alone        |  0  |
+   *   | C  alone        |  0  |
+   *   | B2 + C together |  3  |
+   *
+   * ⛔ Zero-red-alone means the contract is held TWICE, NOT that it is
+   * untested — neither guard may be deleted as «uncovered»
+   * (integration-test-revert-verify §ДУБЛИРУЮЩИЕ гварды). B2 is a pure fast
+   * path: C covers the very same input, so B2 has no isolable behaviour and is
+   * locked only as a PAIR. C, by contrast, IS isolable — a root that exists
+   * but cannot be listed reaches C and nothing else.
+   *
+   * Until these two checks the pair was locked only INCIDENTALLY, by three
+   * tests whose subject is something else entirely («skips non-GitHub
+   * sources», «warns on a FileSpace without a source», «excludes AssetSpaces
+   * whose mount folder is absent») — each green merely because its fixture
+   * happens to omit `assetspaces/`. The first fixture to add that folder would
+   * have unlocked the pair silently.
+   */
+  describe("the FINDING-3 mount walk never throws into the sync path", () => {
+    /** Root present but unlistable (EACCES / iOS sandbox) — reaches only C. */
+    class UnreadableRootAdapter extends InMemoryAdapter {
+      override async list(
+        dir: string,
+      ): Promise<{ files: string[]; folders: string[] }> {
+        if (dir === "assetspaces") throw new Error("EACCES: permission denied");
+        return super.list(dir);
+      }
+    }
+
+    it("isolates the outer swallow — an unlistable mount root degrades to []", async () => {
+      const adapter = new UnreadableRootAdapter();
+      adapter.mkdirAll("assetspaces/o/r");
+      const app = makeApp({
+        adapter,
+        mdFiles: [{ path: "as1.md" }],
+        frontmatters: new Map([
+          ["as1.md", assetSpaceFm("uid-1", "https://github.com/o/r")],
+        ]),
+      });
+
+      // Preconditions — the root EXISTS (so the B2 fast path cannot fire) and
+      // listing it really does fail. Without both, the assertion is vacuous.
+      expect(await adapter.exists("assetspaces")).toBe(true);
+      await expect(adapter.list("assetspaces")).rejects.toThrow(/EACCES/);
+
+      const result = await collectSyncRepoSpecs(app as unknown as App);
+
+      // Positive expected value: the sync unit is STILL enumerated, so the
+      // walk failure is contained rather than fatal. An empty `specs` here
+      // would let the check pass for the wrong reason.
+      expect(result.specs).toEqual([spec()]);
+      expect(result.mountedNotDeclared).toEqual([]);
+    });
+
+    it("pair axis for the absent-root fast path — no `assetspaces` folder at all", async () => {
+      const adapter = new InMemoryAdapter();
+      const app = makeApp({
+        adapter,
+        mdFiles: [{ path: "as1.md" }],
+        frontmatters: new Map([
+          ["as1.md", assetSpaceFm("uid-1", "https://github.com/o/r")],
+        ]),
+      });
+
+      expect(await adapter.exists("assetspaces")).toBe(false);
+
+      // The discriminator is the ABSENCE of a throw: with both guards gone the
+      // adapter's ENOENT escapes `collectSyncRepoSpecs` and reds this await.
+      const result = await collectSyncRepoSpecs(app as unknown as App);
+
+      expect(result.mountedNotDeclared).toEqual([]);
+      expect(result.specs).toEqual([]);
+    });
+  });
+
   it("skips non-GitHub sources with a warning", async () => {
     const adapter = new InMemoryAdapter();
     const app = makeApp({


### PR DESCRIPTION
## What

Locks the two guards inside `enumerateMountFolders` (`SyncDepsFactory.ts`) that jointly hold one contract stated in its own docstring — «a detection helper must never throw into the sync path»:

- **B2** — `if (!(await adapter.exists(root))) return out;` (absent-root fast path)
- **C** — the outer `catch` that swallows any listing failure

**Test-only.** `SyncDepsFactory.ts` is byte-identical to `origin/main` (`git diff origin/main...HEAD -- <prod file>` = 0 lines).

## Measured (mutation on a hardlink copy of `origin/main@0cc49ef2`)

One mutation per guard, exact-literal anchor, **replacement count asserted** so a mutation that silently fails to apply cannot pass for green. The working tree is never touched (the mutated file's hardlink is broken first; the driver asserts `st_ino` differs).

| mutation | red before | red after |
|---|---|---|
| B2 alone | 0 | 0 |
| C alone | 0 | **1** |
| B2 + C together | 3 | 5 |

Two checks added, doing **different** jobs — only the first adds coverage:

- **«isolates the outer swallow»** — a mount root that EXISTS but cannot be listed (EACCES / iOS sandbox) reaches C and nothing else. Turns a previously non-isolable guard into an individually observable one; it is the only red under `C alone`.
- **«pair axis for the absent-root fast path»** — B2 has no isolable behaviour *by construction* (C covers the very same input), so it is locked as a pair. Adds **no** coverage (the pair reds 4x without it). The pair *was* already locked — but only **incidentally**, by three tests whose subject is unrelated («skips non-GitHub sources», «warns on a FileSpace without a source», «excludes AssetSpaces whose mount folder is absent»), each green merely because its fixture happens to omit `assetspaces/`. Adding that folder to any of them would unlock the pair silently. This check states the contract by **name** on a fixture whose root-absence is deliberate — intent, not coverage.

⛔ **Zero-red-alone means the contract is held TWICE, not that it is untested** — neither guard may be deleted as «uncovered» (`integration-test-revert-verify` §ДУБЛИРУЮЩИЕ гварды).

## The task's premise was false — recorded here so the numbers don't outlive it

The task claimed `adapter.exists` and the walk-root scoping were **individually uncovered** (0 red alone). Reproducing the measurement first (rather than trusting it) showed both are **already individually observable — 3 red each**. Cause: the file has **nine** `adapter.exists` call sites, and line 396 carries the same `exists(spec.localPath)` substring as line 132; the earlier measurement anchored on the wrong one. Its «both guards -> 2 red» reproduces exactly as my **A + B2**, which is the fingerprint of that mis-anchor.

So the genuine residual was not the pair the task named, but the **B2 + C** pair — which this PR locks.

| guard | gates | individually observable on `main`? |
|---|---|---|
| `exists(spec.localPath)` L132 | `specs` | yes — 3 red |
| walk-root scoping `const root = "assetspaces"` | `mountedNotDeclared` | yes — 3 red |
| B2 — `exists(root)` early return | fast path | no — 0 (non-isolable by construction) |
| C — outer `catch` | swallow | 0 -> **1 after this PR** |

## No `@req:` tag / no new requirement

This hardens an **existing internal resilience contract** (the helper's own docstring), not a new product invariant — `4eca4900` covers parking, a different invariant. `/feature-sdd` Step 0 exempts test-only hardening of an already-shipped contract.

## Gates

- target suite 26/26 · full plugin suite **338 suites / 6049 passed**
- `check:types` exit 0
- all three CI `lint` guard scripts exit 0 (`check-test-antipatterns.sh` ratchet unchanged: method-exists 55/55, vacuous-length 21/21)
- `code-reviewer`: **APPROVE** — all four claims verified empirically, matrix reproduced cell-for-cell. Its MEDIUM + two LOWs are applied in the second commit (the first commit's docstring overstated «the pair was locked only INCIDENTALLY *until these checks*» — measured, only one check moved coverage; corrected in a follow-up commit rather than silently rewritten).

Vault task: `1d002b6b-fd50-4eeb-abd2-11800fd0e62e`
