### PR TITLE
chore(deps): bump brace-expansion@5.x override 5.0.8 → 5.0.9 (GHSA-rgw5-rvv9-x895)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11245,9 +11245,9 @@
       }
     },
     "node_modules/minimatch/node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
   "license": "MIT",
   "overrides": {
     "qs": "^6.15.3",
-    "brace-expansion@5.x": "5.0.8"
+    "brace-expansion@5.x": "5.0.9"
   },
   "devDependencies": {
     "@babel/core": "^7.28.5",


### PR DESCRIPTION
## What

Bump the root `overrides` pin `"brace-expansion@5.x"` from `5.0.8` → `5.0.9` and regenerate the root lock.

Diff is exactly 2 files / 4 lines: `package.json` + `package-lock.json` (single lock node: `node_modules/minimatch/node_modules/brace-expansion`).

## Why

**GHSA-rgw5-rvv9-x895** — `high`, published 2026-08-03 — *"brace-expansion: DoS via unbounded intermediate arrays, bypassing the CVE-2026-14257 mitigation"*. Affected range is `>= 4.0.0, < 5.0.9` (**exclusive** upper bound), patched in **5.0.9**.

The advisory has **four** ranges — `< 1.1.18`, `2.0.0 – 2.1.4`, `3.0.0 – 3.0.6`, and the one above. Every other node in this lock is already on the corresponding patch version; the 5.x node is the only one left behind, which is the whole point of the next section.

The July pin (`5.0.8`, added in the split-exposure fix of 2026-07-27) therefore **became vulnerable itself**. In **our resolved lock** the affected node sits on a production path reachable from `packages/cli`:

```
packages/cli → glob@11 → minimatch@10.2.5 → brace-expansion@5.0.8   (dev not set)
```

⛤ Scope of that exposure — see the correction at the end of this body: it is **our tree and CI**, not npm consumers.

## ⛤ The pin was not just stale — it was *blocking* the fix

An exact-version override is simultaneously a **floor and a ceiling**. Verified by control experiment on an isolated worktree off `origin/main`:

| Worktree | override | `npm audit fix --package-lock-only` | 5.x node after | lock diff |
|---|---|---|---|---|
| control | `5.0.8` (unchanged) | rc=1, vulnerabilities remain | **5.0.8** | **empty** |
| this PR | `5.0.9` | rc=0, `found 0 vulnerabilities` | **5.0.9** | 1 node |

Same tool, same command, same base commit — the only difference is the pin's ceiling. npm knows the advisory (it moved the *unpinned* 1.x → 1.1.18 and 2.x → 2.1.4 automatically in #4034, which are exactly this advisory's patch versions); it simply could not move the pinned node.

**Two rival explanations were tested and refuted** (independently, in review):

| Rival hypothesis | Probe | Outcome |
|---|---|---|
| "npm can't fix a nested node at all" | override **removed entirely** | node moved to 5.0.9 unaided ⇒ refuted |
| "any `overrides` entry no-ops the fix" | override set to the **range** `^5.0.9` | node moved to 5.0.9 ⇒ refuted |

So it is specifically the **exact ceiling** that blocks — not the presence of an override. Single-variable isolation.

⚠ Methodology note for anyone repeating the control in this monorepo: it must be a real `git worktree`. Copying just `package.json` + `package-lock.json` into a scratch dir yields a misleading `found 0 vulnerabilities`, because without `packages/*` on disk npm prunes the entire workspace graph.

Side note for whoever repeats this: `npm install --package-lock-only` is **not** sufficient here — it does not re-resolve a node that already satisfies its range (`^5.0.5`), and the lock records no `overrides` key at all, so nothing signals a change. `npm audit fix --package-lock-only` (non-force) is the tool that moves it — the same one used in #4034. ⛔ Not `--force` (documented no-op here, and it broke the jest coverage pipeline in the closed #3938).

## ⚠ Honest scope: this closes a real vulnerability, it does **not** turn a red gate green

Measured `npm audit --audit-level=high --omit=dev`, before and after, on three surfaces:

| Surface | before | after |
|---|---|---|
| repo root | **2 high**, rc=1 | **0**, rc=0 |
| `packages/core` — the CI job's `working-directory` | **0**, rc=0 | **0**, rc=0 |
| `packages/cli` — the published npm package | **2 high**, rc=1 | **0**, rc=0 |

So the change is **gate-neutral**: `npm-audit-exocortex` read 0 before and reads 0 after. What it *does* fix is a live high-severity advisory on a production path of **our resolved lock** — the tree this repo builds, tests and runs CI against. (An earlier draft of this body said "the package users install"; that was stronger than measured — corrected at the end.)

**Mechanism established (a prior candidate hypothesis is refuted).** The open question was why audit reported 0 while a vulnerable prod node was live; the standing guess was *"npm audit suppresses nodes whose version is forced by `overrides`"*. That is **wrong** — root and `packages/cli` both flag the override-pinned `5.0.8` loudly. The actual cause is **prod-graph scoping by working directory**: the CI job runs from `packages/core`, which does not depend on `packages/cli`, so `--omit=dev` prunes the `cli → glob → minimatch → brace-expansion` chain out of its reachable graph. Same root lock, different reachable subgraph.

## 📋 Observations, filed not fixed (out of scope here)

1. **Gate placement.** Following from the table above: the `npm-audit-exocortex` gate is positioned in a working directory that **structurally cannot see** `packages/cli`'s production path — i.e. the package that actually ships to npm. That is why a live high advisory coexisted with a green gate. A gate-placement defect independent of this bump; changing `working-directory` alters what gates *every* PR repo-wide and needs its own verification.
2. **The override is now redundant — and re-arms the same trap.** The "override removed" probe above shows npm reaches 5.0.9 with **no pin at all**, because `minimatch@10.2.5` requires `^5.0.5`. The pin's original purpose (forcing the 5.x line up when 5.0.7 was the natural resolution) no longer holds. Keeping an *exact* pin means the next 5.x advisory will block itself identically — this is the third touch of this one override in two weeks (07-25 defer → 07-27 pin → 08-07 bump). Candidate follow-up: switch to `"^5.0.9"` (verified working in review) so future patches flow on their own.
3. **Stale comment in `ci.yml`.** Lines 157-164 still describe `GHSA-mh99-v99m-4gvg` and `brace-expansion@5.0.8` as the live state; this PR supersedes that. Not touched here (deps-only change), but it will mislead the next reader.

## Verification

- `npm ci` → rc=0
- `npm audit --audit-level=high --omit=dev` → 0 on **all three** surfaces (root, `packages/core`, `packages/cli`)
- `npm run check:types` → rc=0, 0 TS errors
- `packages/core` suite, CI-exact invocation (`--testPathIgnorePatterns '/node_modules/' '/tests/performance/'`) → **360/360 suites, rc=0**
- `packages/obsidian-plugin --coverage` → green (see below)
- Both changed files are already prettier-clean (measured on copies: 0-line delta), so lint-staged's `prettier --write` is a no-op — no bundled reformat.

No source files touched: 0 changes under `packages/*/src`, 0 test files.

## ⛤ Correction (post-merge, 2026-08-07) — who was exposed

An earlier revision of this body described the fixed advisory as sitting on *"the production dependency path of the package users install"*. **The decision is unchanged and correct; that justification was stronger than measured.** Recording the correction rather than rewriting it away, so the next reader sees the trap rather than only the answer.

| | claim | status |
|---|---|---|
| ⛔ draft | npm consumers of `@kitelev/exocortex-cli` were exposed to the 5.0.8 node | **not measured — and refuted** |
| ✅ measured | our resolved lock (this tree + every CI runner doing `npm ci`) carried 5.0.8 on a cli-reachable prod path | holds |

**Why the draft was wrong:** `npm view @kitelev/exocortex-cli dependencies.glob` → `^11.0.0` — the *published manifest* declares a **range**, not a pin, and a published npm package does not ship `package-lock.json`. A consumer therefore resolves `glob@^11 → minimatch@^10 → brace-expansion@^5.x` **fresh at their install time** and has been landing on 5.0.9 since it was published on 08-03. The `overrides` pin lived in this repo's **root** manifest, which is not published — so it constrained **our** lock and nothing downstream of it.

⇒ The bump closes a real high-severity advisory in **our** supply chain and CI, and is **gate-neutral** for `npm-audit-exocortex`. Both halves stated by measurement.

⚠ This does not weaken observation 1 below: the gate still structurally cannot see the cli production subgraph of the root lock. It weakens only the *consequence* attached to it — a gate blind spot is a statement about **what we build and ship from**, and whether any particular uncovered advisory reaches end users is a separate question (it depends on the published manifest being a range vs a pin) that this gate also does not answer.
