### PR TITLE
test(sync): bind the mount-walk resilience checks to req ccae1563

### DIFF
--- a/packages/obsidian-plugin/tests/unit/sync/SyncDepsFactory.test.ts
+++ b/packages/obsidian-plugin/tests/unit/sync/SyncDepsFactory.test.ts
@@ -229,7 +229,7 @@ describe("collectSyncRepoSpecs", () => {
       }
     }
 
-    it("isolates the outer swallow — an unlistable mount root degrades to []", async () => {
+    it("isolates the outer swallow — an unlistable mount root degrades to [] @req:ccae1563-ae89-4c45-ad1b-1645405870d6", async () => {
       const adapter = new UnreadableRootAdapter();
       adapter.mkdirAll("assetspaces/o/r");
       const app = makeApp({
@@ -254,7 +254,7 @@ describe("collectSyncRepoSpecs", () => {
       expect(result.mountedNotDeclared).toEqual([]);
     });
 
-    it("pair axis for the absent-root fast path — no `assetspaces` folder at all", async () => {
+    it("pair axis for the absent-root fast path — no `assetspaces` folder at all @req:ccae1563-ae89-4c45-ad1b-1645405870d6", async () => {
       const adapter = new InMemoryAdapter();
       const app = makeApp({
         adapter,


### PR DESCRIPTION
## What

Tags two already-shipped checks in `packages/obsidian-plugin/tests/unit/sync/SyncDepsFactory.test.ts` with `@req:ccae1563-ae89-4c45-ad1b-1645405870d6`. **Test-only — no production code touched** (the diff is 2 lines, both `it()` titles).

## Why

PR #4035 shipped those two checks **without a `@req:` binding**. They specify a resilience contract of `enumerateMountFolders` (the FINDING-3 mount walk) — *a missing or unlistable `assetspaces` root degrades to an empty list rather than throwing into the sync path* — and that spec was invisible to `requirements-trace`. An unbound guard is a guard the next refactor can drop under a green CI, which is precisely the failure mode those checks exist to prevent.

## Routing — why a NEW req rather than extending `@req:4eca4900`

`/feature-sdd` Step 0's discriminator is the **mutant matrix**, and it was already measured (on a copy of `origin/main`, before the checks existed) and recorded in the file's own docstring:

| mutation | red before | red after |
|---|---|---|
| B2 alone | 0 | 0 |
| C alone | **0** | 1 |
| B2 + C together | 3 | 5 |

`C alone → 0 red before` is the *property-true-but-unlocked* row → **new requirement**, not an extension. The neighbouring req `4eca4900-fd1f-42d2-a111-46f90a35d6f4` covers **parking only** (an AssetSpace whose derived mount path is absent is not enumerated as a sync unit); it says nothing about the walk's own failure modes.

⛤ The debt exists because that matrix was measured as a *step of the work* and never applied to the *routing decision* — the skill was not opened and the exemption was reasoned from prose. Recorded in task `1d002b6b` and in the correction comment on #4035.

## The requirement

[`ccae1563-ae89-4c45-ad1b-1645405870d6`](https://github.com/kitelev/exoas-exo-reqs/blob/main/exo-reqs/ccae1563-ae89-4c45-ad1b-1645405870d6.md) — status **Approved**, `bindingClass: unit`, three Gherkin scenarios (absent root / unlistable root / negative control).

**Approval provenance:** the queued ALP task `e3f061b8` names the contract, both Gherkin scenarios and the binding class verbatim, leaving nothing open to choose — `/feature-sdd` §"Autonomous-loop (ALP) worker", the *task-text-names-the-design* row, under which the worker formalises the one named option and flips `proposed → approved` itself rather than escalating. No scope was expanded: the requirement states exactly the two scenarios already shipped.

## Measurement

`requirements audit` against the same reqs clone, so the only variable is the tags. Baseline taken from `git archive origin/main | tar -x -C /tmp/base-tree` — the working tree was never mutated to obtain it.

| metric | baseline | after | Δ |
|---|---|---|---|
| `tagCount` | 526 | 528 | **+2** |
| `bound` | 156 | 157 | +1 |
| `orphans` | 7 | **6** | **−1** |
| `activeViolations` | 0 | 0 | 0 |
| `floorViolations` | 3 | 3 | 0 |
| `requirementCount` | 164 | 164 | 0 |

`orphans −1` is the load-bearing signal: the approved requirement was an orphan before these tags and is bound after them.

The two bindings surface under `duplicates` (one UID at two file locations, lines 232 and 257) — the documented warning class, not a failure; the repo carries 87 such entries.

Tag form: all three `@req:` tokens are full 36-char UUIDs. A truncated 8-char prefix would be an orphan that `archgate REQ-001` only *warns* about while the active-gate hard-blocks the whole repo — see the `ec019a32` incident.

## Verification

- Suite green: **26 passed / 26 total** in `SyncDepsFactory.test.ts`
- `archgate` pre-commit: 24/24 pass; `REQ-001 well-formed-req-tags` clean for these tags (the 8 malformed tags it lists are pre-existing in other files)
- Requirement pushed to `exoas-exo-reqs@71d7c4b`, verified on remote by content

## Ordering

⛔ The requirement stays **Approved** until this merges. Flipping it to Active beforehand would red the active-gate on **every** open PR in the repo and block Auto Release for everyone (`req-first-sdd-ci-binding`). The Active flip, and a `requirements-trace` run whose `started_at` is later than the flip, follow the merge.

Task: `e3f061b8-475c-4054-ba7c-7e8c71663cbc`
