### PR TITLE
feat(sync): report how stale a PARKED AssetSpace is (req 75dba148)

### DIFF
--- a/packages/cli/src/commands/exosync-parity.ts
+++ b/packages/cli/src/commands/exosync-parity.ts
@@ -30,10 +30,13 @@ import {
   ParityValidator,
   SpaceSpecAccumulator,
   WATERMARK_STORE_FILENAME,
+  checkParkedStaleness,
   classifySpaceDeclaration,
+  parkedPathFor,
   summarizeParityRound,
   type LocalFilesPort,
   type ParityRoundRecord,
+  type ParkedStalenessVerdict,
   type RestCommitTransport,
   type Sha1Fn,
   type SyncRepoSpec,
@@ -147,7 +150,33 @@ function nodeLocalFilesPort(root: string): LocalFilesPort {
 
 interface CollectedSpecs {
   specs: SyncRepoSpec[];
+  /**
+   * Declarations whose DERIVED mount is absent while a copy sits in the park.
+   * Kept strictly apart from {@link CollectedSpecs.specs}: a parked repo is not
+   * a sync unit and must never reach the parity round (req 4eca4900).
+   */
+  parked: SyncRepoSpec[];
   warnings: string[];
+}
+
+/**
+ * A declaration is PARKED when its derived mount is gone but a copy lives under
+ * `.exocortex/parked/<owner>/<repo>`.
+ *
+ * `parkedPathFor` THROWS on a mount folder it refuses to map (a legacy flat path,
+ * a traversal segment) — a deliberate fail-loud for the parking command, which
+ * must never move bytes to a path it cannot reason about. Here the same throw
+ * would abort enumeration of every OTHER declaration in the vault, so it degrades
+ * to "not parked" instead.
+ */
+function isParked(vaultPath: string, localPath: string): boolean {
+  let parkedRel: string;
+  try {
+    parkedRel = parkedPathFor(localPath);
+  } catch {
+    return false;
+  }
+  return existsSync(path.join(vaultPath, parkedRel));
 }
 
 /**
@@ -155,10 +184,16 @@ interface CollectedSpecs {
  * classification core the plugin's `collectSyncRepoSpecs` delegates to
  * (one parser, no drift); only the walk (node fs) and the existence check
  * differ.
+ *
+ * Parked declarations are collected ALONGSIDE, never into `specs`: `commit()` is
+ * still reached only for a materialized mount, so the parity round, its
+ * `ok`/`vacuous` flags and the process exit code stay byte-identical. Parking
+ * also stays silent — it is a state, not a warning.
  */
 export function collectVaultSpecs(vaultPath: string): CollectedSpecs {
   const adapter = new FileSystemVaultAdapter(vaultPath);
   const acc = new SpaceSpecAccumulator();
+  const parked: SyncRepoSpec[] = [];
   for (const file of adapter.getAllFiles()) {
     const fm = adapter.getFrontmatter(file) as Record<string, unknown> | null;
     if (!fm) continue;
@@ -168,10 +203,13 @@ export function collectVaultSpecs(vaultPath: string): CollectedSpecs {
     if (verdict.kind === "skip") continue;
     const spec = acc.offer(verdict.candidate);
     if (spec === null) continue;
-    if (!existsSync(path.join(vaultPath, spec.localPath))) continue;
+    if (!existsSync(path.join(vaultPath, spec.localPath))) {
+      if (isParked(vaultPath, spec.localPath)) parked.push(spec);
+      continue;
+    }
     acc.commit(verdict.candidate);
   }
-  return { specs: acc.specs, warnings: acc.warnings };
+  return { specs: acc.specs, parked, warnings: acc.warnings };
 }
 
 function printHumanReport(
@@ -195,6 +233,44 @@ function printHumanReport(
   out(summarizeParityRound(record));
 }
 
+/**
+ * Report how far each PARKED AssetSpace has drifted (req 75dba148).
+ *
+ * Printed even when there is no parity round to run: a vault whose AssetSpaces
+ * are ALL parked is exactly the case where "Nothing to check" would otherwise be
+ * the whole answer.
+ */
+function printParkedSection(
+  verdicts: ParkedStalenessVerdict[],
+  out: (line: string) => void,
+): void {
+  if (verdicts.length === 0) return;
+  out(
+    `Parked AssetSpaces (frozen on this device, not synced): ${verdicts.length}`,
+  );
+  for (const v of verdicts) {
+    const synced =
+      v.lastSyncedSha !== null ? v.lastSyncedSha.slice(0, 7) : "never";
+    const head =
+      v.remoteHeadSha !== null ? v.remoteHeadSha.slice(0, 7) : "unread";
+    switch (v.freshness) {
+      case "behind":
+        out(
+          `  ${v.repoKey}: BEHIND — parked at ${synced}, remote head is ${head}`,
+        );
+        break;
+      case "current":
+        out(
+          `  ${v.repoKey}: current — parked at ${synced}, matches the remote head`,
+        );
+        break;
+      case "unknown":
+        out(`  ${v.repoKey}: unknown — ${v.reason ?? "no verdict"}`);
+        break;
+    }
+  }
+}
+
 /** Core flow, exported for tests. Returns the intended exit code. */
 export async function runExosyncParity(
   opts: ExosyncParityOptions,
@@ -214,14 +290,8 @@ export async function runExosyncParity(
   const transport =
     deps.transportFactory?.(token, opts.apiBase) ?? pushService.transport();
 
-  const { specs, warnings } = collectVaultSpecs(vaultPath);
+  const { specs, parked, warnings } = collectVaultSpecs(vaultPath);
   for (const w of warnings) out(`warn: ${w}`);
-  if (specs.length === 0) {
-    out(
-      "Nothing to check — no materialized AssetSpaces with a GitHub source found in this vault.",
-    );
-    return 2;
-  }
 
   const configDir = opts.configDir ?? ".obsidian";
   const watermarkPath = path.join(
@@ -246,6 +316,32 @@ export async function runExosyncParity(
     },
   });
 
+  // Parked staleness (req 75dba148) — ONE refs call per parked repo, none on
+  // behalf of an active one (they never enter this loop). Sequential so the
+  // report order is deterministic and the call budget is countable.
+  const parkedVerdicts: ParkedStalenessVerdict[] = [];
+  for (const spec of parked) {
+    parkedVerdicts.push(
+      await checkParkedStaleness(spec, {
+        transport,
+        watermarks: { get: (repoKey) => watermarks.get(repoKey) },
+        redact: (m) => pushService.redact(m),
+        ...(opts.apiBase !== undefined ? { baseURL: opts.apiBase } : {}),
+      }),
+    );
+  }
+  if (opts.json !== true) printParkedSection(parkedVerdicts, out);
+
+  if (specs.length === 0) {
+    if (opts.json === true && parkedVerdicts.length > 0) {
+      out(JSON.stringify({ parked: parkedVerdicts }, null, 2));
+    }
+    out(
+      "Nothing to check — no materialized AssetSpaces with a GitHub source found in this vault.",
+    );
+    return 2;
+  }
+
   const validator = new ParityValidator({
     transport,
     sha1: nodeSha1,
@@ -263,7 +359,9 @@ export async function runExosyncParity(
   const record = await validator.runRound(specs, { trigger: "standalone" });
 
   if (opts.json === true) {
-    out(JSON.stringify(record, null, 2));
+    // Additive key — the round record's own shape is untouched, so existing
+    // consumers keep reading `version`/`ok`/`repos` exactly as before.
+    out(JSON.stringify({ ...record, parked: parkedVerdicts }, null, 2));
   } else {
     printHumanReport(record, out);
   }

--- a/packages/cli/src/commands/exosync-parity.ts
+++ b/packages/cli/src/commands/exosync-parity.ts
@@ -168,6 +168,12 @@ interface CollectedSpecs {
  * must never move bytes to a path it cannot reason about. Here the same throw
  * would abort enumeration of every OTHER declaration in the vault, so it degrades
  * to "not parked" instead.
+ *
+ * Today that catch is defence in depth, not a live path: `localPath` only ever
+ * comes from `AssetSpacePathDeriver`, whose charset guard already rejects empty
+ * and traversal segments, so no derived value can be refused. It stays because
+ * the day that stops being true, one malformed declaration must not blind the
+ * probe to the whole vault.
  */
 function isParked(vaultPath: string, localPath: string): boolean {
   let parkedRel: string;

--- a/packages/cli/tests/unit/commands/exosync-parity.test.ts
+++ b/packages/cli/tests/unit/commands/exosync-parity.test.ts
@@ -112,6 +112,12 @@ function makeVault(opts: {
    */
   watermarkSha?: string;
   declaration?: boolean;
+  /**
+   * A SECOND declaration, materialized at its derived path — i.e. an ACTIVE
+   * AssetSpace living in the same vault as the parked one. Lets a single run
+   * observe both branches at once instead of inferring one from the other.
+   */
+  activeRepo?: string;
 }): VaultFixture {
   const vault = mkdtempSync(path.join(tmpdir(), "exosync-parity-test-"));
   if (opts.declaration !== false) {
@@ -119,6 +125,15 @@ function makeVault(opts: {
       path.join(vault, "space-decl.md"),
       `---\nexo__Asset_uid: decl-uid\nexo__Instance_class:\n  - "[[${ASSET_SPACE_CLASS_UID}]]"\nexo__AssetSpace_source: https://github.com/${OWNER}/${REPO}\n---\n\nDeclaration\n`,
     );
+  }
+  if (opts.activeRepo !== undefined) {
+    writeFileSync(
+      path.join(vault, "space-decl-active.md"),
+      `---\nexo__Asset_uid: decl-uid-active\nexo__Instance_class:\n  - "[[${ASSET_SPACE_CLASS_UID}]]"\nexo__AssetSpace_source: https://github.com/${OWNER}/${opts.activeRepo}\n---\n\nActive declaration\n`,
+    );
+    const full = path.join(vault, "assetspaces", OWNER, opts.activeRepo, FILE_A);
+    mkdirSync(path.dirname(full), { recursive: true });
+    writeFileSync(full, CONTENT_A);
   }
   for (const [rel, content] of Object.entries(opts.mountFiles ?? {})) {
     const full = path.join(vault, MOUNT, rel);
@@ -169,18 +184,29 @@ function run(
   ).then((code) => ({ code, lines }));
 }
 
-/** Wraps a transport to count the `GET git/refs/heads/*` calls it sees. */
+/**
+ * Wraps a transport to count the `GET git/refs/heads/*` calls it sees, both in
+ * total and PER REPO — the per-repo tally is what makes "no extra call on behalf
+ * of an active repo" a measurement rather than an inference.
+ */
 function countingRefs(inner: RestCommitTransport): {
   transport: RestCommitTransport;
   refsCalls: () => number;
+  refsFor: (repo: string) => number;
 } {
   let calls = 0;
+  const byRepo = new Map<string, number>();
   return {
     transport: async (req) => {
-      if (req.method === "GET" && /\/git\/refs\/heads\//.test(req.url)) calls++;
+      const m = /\/repos\/[^/]+\/([^/]+)\/git\/refs\/heads\//.exec(req.url);
+      if (req.method === "GET" && m !== null) {
+        calls++;
+        byRepo.set(m[1], (byRepo.get(m[1]) ?? 0) + 1);
+      }
       return inner(req);
     },
     refsCalls: () => calls,
+    refsFor: (repo) => byRepo.get(repo) ?? 0,
   };
 }
 
@@ -420,6 +446,49 @@ describe("parked AssetSpaces report their staleness @req:75dba148-15c4-401e-a7b5
       // next sync, so a staleness verdict here would be noise, not signal.
       expect(text).not.toMatch(/Parked AssetSpaces/);
       expect(text).not.toMatch(/BEHIND — parked at/);
+    } finally {
+      fx.cleanup();
+    }
+  });
+
+  it("mixed vault — the parked repo costs ONE refs call and the ACTIVE one costs no extra", async () => {
+    const ACTIVE_REPO = "exoas-active";
+    const fx = makeVault({
+      parkedFiles: { [FILE_A]: CONTENT_A },
+      watermarkFiles: {},
+      watermarkSha: "d".repeat(40),
+      activeRepo: ACTIVE_REPO,
+    });
+    try {
+      // One vault, both branches, one run — so the discrimination is observed
+      // rather than inferred from two separately-shaped fixtures.
+      const counted = countingRefs(fakeTransport({ [FILE_A]: CONTENT_A }));
+      const { lines } = await run(fx.vault, {}, {}, counted.transport);
+
+      // The parked repo: exactly the one staleness call (it is not a sync unit,
+      // so the parity round never touches it).
+      expect(counted.refsFor(REPO)).toBe(1);
+      // The active repo: exactly the parity round's own head read — the parked
+      // feature adds nothing on its behalf.
+      expect(counted.refsFor(ACTIVE_REPO)).toBe(1);
+
+      const text = lines.join("\n");
+      expect(text).toMatch(new RegExp(`${OWNER}/${REPO}#main: BEHIND`));
+      expect(text).not.toMatch(new RegExp(`${OWNER}/${ACTIVE_REPO}#main: (BEHIND|current|unknown) —`));
+    } finally {
+      fx.cleanup();
+    }
+  });
+
+  it("--json stays byte-identical to the old empty-vault path when nothing is parked", async () => {
+    // Locks the `parkedVerdicts.length > 0` guard: without it this path would
+    // start emitting `{"parked": []}`, which the pre-parked CLI never printed.
+    const fx = makeVault({ declaration: false });
+    try {
+      const { code, lines } = await run(fx.vault, {}, { json: true });
+      expect(code).toBe(2);
+      expect(lines.filter((l) => l.startsWith("{"))).toEqual([]);
+      expect(lines.join("\n")).toMatch(/Nothing to check/);
     } finally {
       fx.cleanup();
     }

--- a/packages/cli/tests/unit/commands/exosync-parity.test.ts
+++ b/packages/cli/tests/unit/commands/exosync-parity.test.ts
@@ -105,6 +105,12 @@ function makeVault(opts: {
   /** Same files, but under {@link PARKED} instead of {@link MOUNT}. */
   parkedFiles?: Record<string, string>;
   watermarkFiles?: Record<string, string>;
+  /**
+   * The commit this device last synced. Defaults to the fake remote's head, so
+   * a test must opt IN to a drifted device copy — the freshness verdict is then
+   * driven by the fixture, not by a coincidence of two hard-coded constants.
+   */
+  watermarkSha?: string;
   declaration?: boolean;
 }): VaultFixture {
   const vault = mkdtempSync(path.join(tmpdir(), "exosync-parity-test-"));
@@ -128,7 +134,7 @@ function makeVault(opts: {
     const wmDir = path.join(vault, ".obsidian", "plugins", "exocortex");
     mkdirSync(wmDir, { recursive: true });
     const record = {
-      lastSyncedSha: "a".repeat(40),
+      lastSyncedSha: opts.watermarkSha ?? "a".repeat(40),
       rootTreeSha: "b".repeat(40),
       files: Object.entries(opts.watermarkFiles).map(([p, c]) => ({
         path: p,
@@ -150,16 +156,32 @@ function run(
   vault: string,
   remoteFiles: Record<string, string>,
   over: Partial<ExosyncParityOptions> = {},
+  transport?: RestCommitTransport,
 ): Promise<{ code: number; lines: string[] }> {
   const lines: string[] = [];
   return runExosyncParity(
     { vault, token: FAKE_PAT, ...over },
     {
-      transportFactory: () => fakeTransport(remoteFiles),
+      transportFactory: () => transport ?? fakeTransport(remoteFiles),
       out: (l) => lines.push(l),
       env: {},
     },
   ).then((code) => ({ code, lines }));
+}
+
+/** Wraps a transport to count the `GET git/refs/heads/*` calls it sees. */
+function countingRefs(inner: RestCommitTransport): {
+  transport: RestCommitTransport;
+  refsCalls: () => number;
+} {
+  let calls = 0;
+  return {
+    transport: async (req) => {
+      if (req.method === "GET" && /\/git\/refs\/heads\//.test(req.url)) calls++;
+      return inner(req);
+    },
+    refsCalls: () => calls,
+  };
 }
 
 describe("collectVaultSpecs", () => {
@@ -253,6 +275,177 @@ describe("parking is invisible to sync-unit enumeration @req:4eca4900-fd1f-42d2-
       const { specs, warnings } = collectVaultSpecs(fx.vault);
       expect(specs).toEqual([]);
       expect(warnings).toEqual([]); // parking is silent, not a warning
+    } finally {
+      fx.cleanup();
+    }
+  });
+});
+
+/**
+ * Visibility of a parked AssetSpace's staleness (req 75dba148).
+ *
+ * Sibling req `4eca4900` (above) locks the *silence*: a parked mount must never
+ * become a sync unit. This block locks the *signal* that silence made necessary —
+ * a frozen copy converges never, so the one explicit "am I in sync?" probe has
+ * to say how far it drifted, while an ACTIVE repo gets no such verdict at all.
+ *
+ * Everything runs through the real exported `collectVaultSpecs` /
+ * `runExosyncParity` over a real temp vault on the real node fs; only the GitHub
+ * transport is faked, which is what makes the refs-call budget countable.
+ */
+describe("parked AssetSpaces report their staleness @req:75dba148-15c4-401e-a7b5-be2392557c58", () => {
+  it("enumerates a parked declaration into `parked`, never into the sync units", () => {
+    const fx = makeVault({ parkedFiles: { [FILE_A]: CONTENT_A } });
+    try {
+      // Precondition — the copy is on disk, just not where the derived path
+      // points. Without it the assertions below could pass vacuously.
+      expect(existsSync(path.join(fx.vault, PARKED, FILE_A))).toBe(true);
+      expect(existsSync(path.join(fx.vault, MOUNT))).toBe(false);
+
+      const { specs, parked, warnings } = collectVaultSpecs(fx.vault);
+      expect(specs).toEqual([]); // still not a sync unit — req 4eca4900 holds
+      expect(parked).toEqual([
+        {
+          owner: OWNER,
+          repo: REPO,
+          branch: "main",
+          repoKey: `${OWNER}/${REPO}#main`,
+          localPath: MOUNT,
+        },
+      ]);
+      expect(warnings).toEqual([]); // parking is a state, not a warning
+    } finally {
+      fx.cleanup();
+    }
+  });
+
+  it("negative control — an ACTIVE declaration is a sync unit and is absent from `parked`", () => {
+    const fx = makeVault({ mountFiles: { [FILE_A]: CONTENT_A } });
+    try {
+      const { specs, parked } = collectVaultSpecs(fx.vault);
+      expect(specs).toHaveLength(1);
+      expect(parked).toEqual([]);
+    } finally {
+      fx.cleanup();
+    }
+  });
+
+  it("reports BEHIND with both SHAs when the remote moved past the parked copy", async () => {
+    const fx = makeVault({
+      parkedFiles: { [FILE_A]: CONTENT_A },
+      watermarkFiles: {},
+      watermarkSha: "d".repeat(40), // the remote head is "a"×40 → drifted
+    });
+    try {
+      const { lines } = await run(fx.vault, { [FILE_A]: CONTENT_A });
+      const text = lines.join("\n");
+      expect(text).toMatch(/Parked AssetSpaces \(frozen on this device/);
+      expect(text).toMatch(
+        new RegExp(`${OWNER}/${REPO}#main: BEHIND — parked at ddddddd, remote head is aaaaaaa`),
+      );
+    } finally {
+      fx.cleanup();
+    }
+  });
+
+  it("reports current when the parked copy still is the remote head", async () => {
+    const fx = makeVault({
+      parkedFiles: { [FILE_A]: CONTENT_A },
+      watermarkFiles: {}, // watermark sha defaults to the fake remote head
+    });
+    try {
+      const { lines } = await run(fx.vault, { [FILE_A]: CONTENT_A });
+      expect(lines.join("\n")).toMatch(
+        new RegExp(`${OWNER}/${REPO}#main: current — parked at aaaaaaa`),
+      );
+    } finally {
+      fx.cleanup();
+    }
+  });
+
+  it("canary — an unreachable remote reports unknown, NEVER current", async () => {
+    const fx = makeVault({
+      parkedFiles: { [FILE_A]: CONTENT_A },
+      watermarkFiles: {},
+    });
+    try {
+      const offline: RestCommitTransport = async () => {
+        throw new Error("getaddrinfo ENOTFOUND api.github.com");
+      };
+      const { lines } = await run(fx.vault, {}, {}, offline);
+      const text = lines.join("\n");
+      expect(text).toMatch(
+        new RegExp(`${OWNER}/${REPO}#main: unknown — remote unreachable`),
+      );
+      // The whole point of the third value: silence must not read as freshness.
+      expect(text).not.toMatch(/: current —/);
+    } finally {
+      fx.cleanup();
+    }
+  });
+
+  it("costs exactly ONE refs call per parked repo, and still exits 2 with no sync units", async () => {
+    const fx = makeVault({
+      parkedFiles: { [FILE_A]: CONTENT_A },
+      watermarkFiles: {},
+      watermarkSha: "d".repeat(40),
+    });
+    try {
+      // No materialized mount ⇒ no parity round ⇒ every refs call observed here
+      // was made on the parked repo's behalf. That is what makes the budget
+      // countable instead of inferred.
+      const counted = countingRefs(fakeTransport({ [FILE_A]: CONTENT_A }));
+      const { code, lines } = await run(fx.vault, {}, {}, counted.transport);
+
+      expect(counted.refsCalls()).toBe(1);
+      expect(code).toBe(2); // staleness is informational — the exit contract is untouched
+      const text = lines.join("\n");
+      expect(text).toMatch(/BEHIND — parked at ddddddd/);
+      expect(text).toMatch(/Nothing to check/); // …and the old message still stands
+    } finally {
+      fx.cleanup();
+    }
+  });
+
+  it("negative control — an ACTIVE repo gets no staleness verdict at all", async () => {
+    const fx = makeVault({
+      mountFiles: { [FILE_A]: CONTENT_A },
+      watermarkFiles: { [FILE_A]: CONTENT_A },
+      watermarkSha: "d".repeat(40), // drifted — yet it must still say nothing
+    });
+    try {
+      const { lines } = await run(fx.vault, { [FILE_A]: CONTENT_A });
+      const text = lines.join("\n");
+      // A drifted ACTIVE repo is the parity round's business; it converges on the
+      // next sync, so a staleness verdict here would be noise, not signal.
+      expect(text).not.toMatch(/Parked AssetSpaces/);
+      expect(text).not.toMatch(/BEHIND — parked at/);
+    } finally {
+      fx.cleanup();
+    }
+  });
+
+  it("--json carries the parked verdicts on the all-parked path too", async () => {
+    const fx = makeVault({
+      parkedFiles: { [FILE_A]: CONTENT_A },
+      watermarkFiles: {},
+      watermarkSha: "d".repeat(40),
+    });
+    try {
+      const { code, lines } = await run(
+        fx.vault,
+        { [FILE_A]: CONTENT_A },
+        { json: true },
+      );
+      expect(code).toBe(2);
+      const json = JSON.parse(
+        lines.filter((l) => l.startsWith("{")).join("\n"),
+      ) as { parked: { repoKey: string; freshness: string }[] };
+      expect(json.parked).toHaveLength(1);
+      expect(json.parked[0]).toMatchObject({
+        repoKey: `${OWNER}/${REPO}#main`,
+        freshness: "behind",
+      });
     } finally {
       fx.cleanup();
     }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -656,6 +656,16 @@ export {
   type RemoteCommitInfo,
   type RemoteTreeEntry,
 } from "./services/sync/githubRepoReader";
+// Staleness of a PARKED AssetSpace (req 75dba148): a frozen mount never
+// converges, so the one explicit «am I in sync?» probe has to say how far it
+// drifted. Platform-free on purpose — the CLI consumes it today, a plugin
+// surface can consume the SAME verdict later without duplicating the logic.
+export {
+  checkParkedStaleness,
+  type ParkedFreshness,
+  type ParkedStalenessDeps,
+  type ParkedStalenessVerdict,
+} from "./services/sync/parkedStaleness";
 export {
   DEFAULT_MAX_PUSH_RETRIES,
   DEFAULT_LOCAL_MANIFEST_REHASH_MS,

--- a/packages/core/src/services/sync/parkedStaleness.ts
+++ b/packages/core/src/services/sync/parkedStaleness.ts
@@ -1,0 +1,149 @@
+/**
+ * Staleness of a PARKED AssetSpace (req 75dba148).
+ *
+ * A parked AssetSpace is **frozen at the moment it was parked**: its bytes stay
+ * on the device under `.exocortex/parked/<owner>/<repo>`, but the derived mount
+ * is gone, so sync-unit enumeration skips it by construction (req 4eca4900).
+ * An active mount converges on every sync round; a parked one converges
+ * **never** — and until this module nothing reported how far it had drifted.
+ *
+ * The verdict is deliberately three-valued. `unknown` is not a failure state to
+ * be smoothed over: an empty or failed response is **not** evidence of freshness,
+ * and reporting "current" for an unreachable remote would turn the indicator into
+ * a weak verifier that can only ever look green.
+ *
+ * `current` is therefore reachable ONLY from the single branch where BOTH a
+ * watermark was found AND the head read returned a SHA. That is a property of
+ * the control flow — not a defensive `if` a later edit could invert.
+ *
+ * ## Cost
+ * At most **one** `GET git/refs/heads/{branch}` per parked repo, and none at all
+ * when the device has no watermark for it (nothing to compare against, so the
+ * call would buy nothing). Callers drive this from an explicit probe, never from
+ * a `metadataCache` event — an un-debounced whole-vault traversal on a cache
+ * event is the documented cause of an indexing storm and iPhone Jetsam.
+ *
+ * ## Why a boolean fact and not "N commits behind"
+ * `GET git/refs/heads/{branch}` returns the head SHA and nothing else — no date,
+ * no distance. A commit distance would need a second, differently-priced call per
+ * repo. The missing signal was "is this frozen copy still the remote's head?";
+ * the distance is a separate decision with its own budget.
+ */
+
+import type { RestCommitTransport } from "../../infrastructure/github/restCommit";
+import { getHeadSha } from "./githubRepoReader";
+import type { SyncRepoSpec, WatermarkStorePort } from "./syncTypes";
+
+/**
+ * `behind` — the device copy is pinned to a commit that is no longer the remote
+ * head. (A parked mount is read-only for ExoSync: it is never pushed from, so a
+ * divergence can only mean the remote moved on without it.)
+ *
+ * `current` — the pinned commit IS the remote head.
+ *
+ * `unknown` — the question could not be answered: no watermark on this device,
+ * or the remote could not be read. Never conflate with `current`.
+ */
+export type ParkedFreshness = "behind" | "current" | "unknown";
+
+export interface ParkedStalenessVerdict {
+  /** `owner/repo#branch` — the watermark key, stable across mount/park moves. */
+  readonly repoKey: string;
+  /** The DERIVED mount path the AssetSpace would occupy if it were active. */
+  readonly localPath: string;
+  readonly freshness: ParkedFreshness;
+  /** The commit this device last synced, or `null` when it never synced it. */
+  readonly lastSyncedSha: string | null;
+  /** The remote head, or `null` when it was not read (or not readable). */
+  readonly remoteHeadSha: string | null;
+  /** Why the verdict is `unknown`. Absent for `behind` / `current`. */
+  readonly reason?: string;
+}
+
+export interface ParkedStalenessDeps {
+  readonly transport: RestCommitTransport;
+  /** Read-only watermark access — this check never writes. */
+  readonly watermarks: Pick<WatermarkStorePort, "get">;
+  readonly baseURL?: string;
+  /**
+   * Strip secrets from transport error text before it lands in a report.
+   * Defence in depth: the transport redacts its own messages, but a verdict
+   * `reason` is printed and serialised into `--json` output too.
+   */
+  readonly redact?: (message: string) => string;
+}
+
+/**
+ * Resolve ONE parked sync unit to a freshness verdict.
+ *
+ * Never throws: a transport failure is part of the answer (`unknown`), not an
+ * abort — one unreachable repo must not hide the verdict of every other parked
+ * repo in the same report.
+ */
+export async function checkParkedStaleness(
+  spec: SyncRepoSpec,
+  deps: ParkedStalenessDeps,
+): Promise<ParkedStalenessVerdict> {
+  const base = { repoKey: spec.repoKey, localPath: spec.localPath } as const;
+  const redact = deps.redact ?? ((m: string): string => m);
+
+  let lastSyncedSha: string | null = null;
+  try {
+    const record = await deps.watermarks.get(spec.repoKey);
+    const sha = record?.lastSyncedSha ?? "";
+    if (sha.length > 0) lastSyncedSha = sha;
+  } catch (error) {
+    return {
+      ...base,
+      freshness: "unknown",
+      lastSyncedSha: null,
+      remoteHeadSha: null,
+      reason: `watermark unreadable: ${redact(errorText(error))}`,
+    };
+  }
+
+  // No watermark ⇒ nothing to compare a head against, so the refs call is not
+  // made at all. This is the cost cap's floor, not an optimisation: the verdict
+  // would be `unknown` either way.
+  if (lastSyncedSha === null) {
+    return {
+      ...base,
+      freshness: "unknown",
+      lastSyncedSha: null,
+      remoteHeadSha: null,
+      reason: "never synced on this device (no watermark)",
+    };
+  }
+
+  let remoteHeadSha: string;
+  try {
+    remoteHeadSha = await getHeadSha(
+      deps.transport,
+      spec.owner,
+      spec.repo,
+      spec.branch,
+      deps.baseURL,
+    );
+  } catch (error) {
+    return {
+      ...base,
+      freshness: "unknown",
+      lastSyncedSha,
+      remoteHeadSha: null,
+      reason: `remote unreachable: ${redact(errorText(error))}`,
+    };
+  }
+
+  // The ONLY branch that can yield `current`: a watermark was found above AND
+  // the head read succeeded.
+  return {
+    ...base,
+    freshness: remoteHeadSha === lastSyncedSha ? "current" : "behind",
+    lastSyncedSha,
+    remoteHeadSha,
+  };
+}
+
+function errorText(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/packages/core/tests/unit/services/sync/parkedStaleness.test.ts
+++ b/packages/core/tests/unit/services/sync/parkedStaleness.test.ts
@@ -1,0 +1,178 @@
+/**
+ * Staleness of a PARKED AssetSpace (req 75dba148).
+ *
+ * The two seams the production code depends on — the watermark store and the
+ * REST transport — are injected, so BOTH the failure branch and the call budget
+ * are directly observable here. That is what this suite locks:
+ *
+ *  - the verdict is derived from `lastSyncedSha` vs the remote head, and the
+ *    head is read with a **refs** call (never a tree/blob download);
+ *  - `current` is reachable ONLY when a watermark exists AND the head read
+ *    succeeded — an unreachable remote must report `unknown`, never `current`;
+ *  - the cost cap: at most ONE refs call per repo, and ZERO when there is no
+ *    watermark to compare against.
+ *
+ * The transport fake records every request, so "exactly one refs call" is an
+ * assertion over observed traffic rather than a claim about the code's shape.
+ */
+
+import {
+  checkParkedStaleness,
+  type ParkedStalenessDeps,
+  type RestCommitTransport,
+  type SyncRepoSpec,
+  type WatermarkRecord,
+} from "../../../../src";
+
+const OWNER = "test-owner";
+const REPO = "exoas-parked";
+const BRANCH = "main";
+
+const SPEC: SyncRepoSpec = {
+  owner: OWNER,
+  repo: REPO,
+  branch: BRANCH,
+  repoKey: `${OWNER}/${REPO}#${BRANCH}`,
+  localPath: `assetspaces/${OWNER}/${REPO}`,
+};
+
+const SYNCED_SHA = "a".repeat(40);
+const MOVED_SHA = "b".repeat(40);
+
+function watermark(lastSyncedSha: string): WatermarkRecord {
+  return { lastSyncedSha, rootTreeSha: "c".repeat(40), files: [] };
+}
+
+interface Recorded {
+  transport: RestCommitTransport;
+  requests: string[];
+}
+
+/** Transport fake that answers ONLY `GET git/refs/heads/*` and logs traffic. */
+function refsTransport(headSha: string | Error): Recorded {
+  const requests: string[] = [];
+  const transport: RestCommitTransport = async (req) => {
+    requests.push(`${req.method} ${req.url}`);
+    if (req.method === "GET" && /\/git\/refs\/heads\//.test(req.url)) {
+      if (headSha instanceof Error) throw headSha;
+      return { status: 200, json: { object: { sha: headSha } } };
+    }
+    throw new Error(`unexpected request: ${req.method} ${req.url}`);
+  };
+  return { transport, requests };
+}
+
+function deps(
+  recorded: Recorded,
+  record: WatermarkRecord | null,
+  over: Partial<ParkedStalenessDeps> = {},
+): ParkedStalenessDeps {
+  return {
+    transport: recorded.transport,
+    watermarks: { get: async () => record },
+    ...over,
+  };
+}
+
+describe("checkParkedStaleness @req:75dba148-15c4-401e-a7b5-be2392557c58", () => {
+  it("reports BEHIND with both SHAs when the remote moved on, using exactly one refs call", async () => {
+    const recorded = refsTransport(MOVED_SHA);
+
+    const verdict = await checkParkedStaleness(
+      SPEC,
+      deps(recorded, watermark(SYNCED_SHA)),
+    );
+
+    expect(verdict.freshness).toBe("behind");
+    expect(verdict.lastSyncedSha).toBe(SYNCED_SHA);
+    expect(verdict.remoteHeadSha).toBe(MOVED_SHA);
+    expect(verdict.repoKey).toBe(SPEC.repoKey);
+
+    // Cost cap: ONE call, and it is the refs primitive — not a tree walk or a
+    // blob download. Asserting the URL shape is what makes "not a full download"
+    // observable rather than assumed.
+    expect(recorded.requests).toHaveLength(1);
+    expect(recorded.requests[0]).toBe(
+      `GET https://api.github.com/repos/${OWNER}/${REPO}/git/refs/heads/${BRANCH}`,
+    );
+  });
+
+  it("reports current when the parked copy still is the remote head", async () => {
+    const recorded = refsTransport(SYNCED_SHA);
+
+    const verdict = await checkParkedStaleness(
+      SPEC,
+      deps(recorded, watermark(SYNCED_SHA)),
+    );
+
+    expect(verdict.freshness).toBe("current");
+    expect(verdict.remoteHeadSha).toBe(SYNCED_SHA);
+    expect(recorded.requests).toHaveLength(1);
+  });
+
+  it("canary — an unreachable remote reports unknown, NEVER current", async () => {
+    const recorded = refsTransport(new Error("getaddrinfo ENOTFOUND api.github.com"));
+
+    const verdict = await checkParkedStaleness(
+      SPEC,
+      deps(recorded, watermark(SYNCED_SHA)),
+    );
+
+    // Both halves matter: an empty/failed response is not evidence of freshness,
+    // so the indicator must not be able to look green when it learned nothing.
+    expect(verdict.freshness).toBe("unknown");
+    expect(verdict.freshness).not.toBe("current");
+    expect(verdict.remoteHeadSha).toBeNull();
+    expect(verdict.lastSyncedSha).toBe(SYNCED_SHA); // what we DO know is kept
+    expect(verdict.reason).toMatch(/remote unreachable/);
+    expect(recorded.requests).toHaveLength(1); // it tried once, and only once
+  });
+
+  it("reports unknown WITHOUT any refs call when the device never synced the repo", async () => {
+    const recorded = refsTransport(SYNCED_SHA);
+
+    const verdict = await checkParkedStaleness(SPEC, deps(recorded, null));
+
+    expect(verdict.freshness).toBe("unknown");
+    expect(verdict.lastSyncedSha).toBeNull();
+    expect(verdict.reason).toMatch(/never synced/);
+    // The floor of the cost cap: with nothing to compare against, the call is
+    // not worth making — the verdict would be `unknown` either way.
+    expect(recorded.requests).toEqual([]);
+  });
+
+  it("redacts transport error text before it reaches the report", async () => {
+    const secret = "ghp_" + "S".repeat(36);
+    const recorded = refsTransport(new Error(`HTTP 401 for token ${secret}`));
+
+    const verdict = await checkParkedStaleness(
+      SPEC,
+      deps(recorded, watermark(SYNCED_SHA), {
+        redact: (m) => m.replace(secret, "***"),
+      }),
+    );
+
+    expect(verdict.freshness).toBe("unknown");
+    expect(verdict.reason).not.toContain(secret);
+    expect(verdict.reason).toContain("***");
+  });
+
+  it("treats an unreadable watermark store as unknown rather than throwing", async () => {
+    const recorded = refsTransport(SYNCED_SHA);
+
+    const verdict = await checkParkedStaleness(SPEC, {
+      transport: recorded.transport,
+      watermarks: {
+        get: async () => {
+          throw new Error("watermark file is corrupt");
+        },
+      },
+    });
+
+    // One unreadable repo must not abort the verdict of every other parked repo
+    // sharing the same report.
+    expect(verdict.freshness).toBe("unknown");
+    expect(verdict.reason).toMatch(/watermark unreadable/);
+    expect(recorded.requests).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Why

A parked AssetSpace is **frozen at the moment it was parked**. Its bytes stay on the device under `.exocortex/parked/<owner>/<repo>`, but the derived mount is gone — so sync-unit enumeration skips it *by construction* (req `4eca4900`, PR #4032). An active mount converges on every sync round; a parked one converges **never**.

`exosync-parity` — the one explicit "am I in sync?" probe — said nothing about it at all. Staleness was therefore not merely unreported: it was **unbounded and invisible**.

Requirement: [`75dba148-15c4-401e-a7b5-be2392557c58`](https://github.com/kitelev/exoas-exo-reqs/blob/main/exo-reqs/75dba148-15c4-401e-a7b5-be2392557c58.md) (Approved).

## What

**`packages/core/src/services/sync/parkedStaleness.ts`** (new, platform-free) — `checkParkedStaleness(spec, deps)` resolves ONE parked sync unit to a three-valued verdict:

| verdict | meaning |
|---|---|
| `behind` | the device is pinned to a commit that is no longer the remote head |
| `current` | the pinned commit **is** the remote head |
| `unknown` | never synced here, or the remote could not be read |

**`packages/cli/src/commands/exosync-parity.ts`** — `collectVaultSpecs` additionally enumerates parked declarations into a separate `parked` list, and `runExosyncParity` prints a staleness section:

```
Parked AssetSpaces (frozen on this device, not synced): 1
  kitelev/exoas-archive#main: BEHIND — parked at 9f2c1ab, remote head is 4d7e88c
```

## The three load-bearing properties

1. **`current` is structurally unreachable on failure.** It is returned from exactly one branch — the one where BOTH a watermark was found AND the head read returned a SHA. Everything else (transport error, missing watermark, unreadable store) resolves to `unknown`. An empty or failed response is not evidence of freshness; without this the indicator would be a weak verifier that can only ever look green.
2. **Cost: at most ONE `GET git/refs/heads/{branch}` per parked repo** — never a tree walk or blob download — and **zero** when there is no watermark (nothing to compare against, so the verdict is `unknown` either way), and **zero** on behalf of an active repo (they never enter the loop). Driven by an explicit probe invocation, so it cannot be attached to a `metadataCache` event — the un-debounced-traversal failure class that produced an indexing storm and iPhone Jetsam is unreachable here by construction.
3. **A boolean fact, not a commit distance.** `GET git/refs/heads/{branch}` returns the head SHA and nothing else — no date, no distance. A distance would need a second, differently-priced call per repo. The missing signal was "is this frozen copy still the remote's head?"; the distance is a separate decision with its own budget. Issue #3975 (ETag / `If-None-Match` on head reads) is **orthogonal and complementary** — it would make this same call cheaper, never redundant. Verified open and non-overlapping before writing code.

## Zero-regression

Enumeration is **additive**: `SpaceSpecAccumulator.commit()` is still reached only for a materialized mount, so `collectVaultSpecs().specs`, the parity round, its `ok`/`vacuous` flags and the process exit code are byte-identical. Staleness is informational — it never changes the parity exit contract. Parking also stays **silent** (a state, not a warning), which the pre-existing `4eca4900` assertion `expect(warnings).toEqual([])` continues to prove.

An all-parked vault still exits `2` — but now says *why*, instead of only "Nothing to check". `parkedPathFor` throws on a mount folder it refuses to map (a deliberate fail-loud for the parking command); enumeration wraps that call so a legacy flat path degrades to "not parked" rather than aborting the probe for every other declaration in the vault.

## Revert-verify — 8 axes, each reddening its own tests

Each mutation was applied to the committed source, the suites run, then restored (`git checkout HEAD -- <file>`); the untouched tests stayed green each time (non-vacuity control).

| # | Mutation | RED |
|---|---|---|
| A | parked enumeration removed from `collectVaultSpecs` | 6 CLI (all parked tests) — active negative control stayed green |
| B | `behind`/`current` comparison → always `current` | 1 core + 3 CLI |
| C | **canary** — transport-failure branch → `current` | 2 core + 1 CLI |
| D | zero-call guard removed (call made without a watermark) | 1 core ("no refs call") |
| E | `printParkedSection` suppressed | 4 CLI human-mode — `--json` stayed green |
| F | active `specs` swept into the staleness loop | 1 CLI — **the negative control**, and only it |
| G | `parkedVerdicts.length > 0` emptiness guard removed | 1 CLI (`--json` byte-identity on the empty-vault path) |
| H | active `specs` swept in, re-run against the mixed-vault axis | 2 CLI — the negative control **and** the per-repo call count |

Axis F is what makes AC2 real: a *drifted* ACTIVE repo still produces no verdict, so both branches are reachable and the indicator genuinely discriminates rather than being identically green.

## Review round (commit `ed776d97`)

`code-reviewer` returned **APPROVE — 0 CRITICAL / 0 HIGH / 0 MEDIUM**, having mutated the production source itself and confirmed by measurement that `current` is unreachable on failure (14 adversarial inputs), the cost cap holds (1 / 1 / 0 calls, zero tree/blob traffic), the negative control discriminates, the empty-specs path is byte-identical to `origin/main`, and req `4eca4900` stays locked (5 tests redden when violated).

It also found **two guards whose neutralization reddened nothing** — precisely the defect class this PR's own discipline exists to catch, so they are closed here rather than shipped:

- **G**: the `parkedVerdicts.length > 0` guard on the all-parked `--json` path was correct but unlocked — without it, `--json` over a vault with neither specs nor parked repos would start emitting `{"parked": []}`, which the pre-parked CLI never printed.
- **H**: "no extra refs call on behalf of an ACTIVE repo" was **inferred** from the absence of a parity round (the cost test runs on an all-parked vault), not measured. The new axis drives ONE vault holding both a parked and an active declaration and counts refs calls **per repo** — parked 1, active 1 (the parity round's own head read, unchanged).

The third finding (LOW) was that `isParked`'s try/catch is a dead branch today; it is kept as defence in depth and the docstring now records *why* it is unreachable (`AssetSpacePathDeriver`'s charset guard) so a later reader does not mistake it for a live path.

CLI suite 20 → 22 checks; core sync 449 unchanged.

## Tests

`@req:75dba148-15c4-401e-a7b5-be2392557c58` — **6 core unit** checks over the injected transport/watermark seams (so the failure branch and the observed refs-call budget are directly assertable, including the exact refs URL — that is what makes "not a full download" observable rather than assumed) + **8 CLI** checks over a real temp vault on the real node fs via the real exported `collectVaultSpecs` / `runExosyncParity`.

Local: core sync suite 449/449 · full CLI suite 1870 passed, with **one pre-existing** failure (`tests/integration/sparql-exo003.integration.test.ts` — reproduced identically on a clean sibling worktree carrying none of these changes). `check:types` clean; eslint clean; all three CI `lint` guard scripts green (shard assignments, test-antipattern ratchet 55/21/19/0 unchanged, coverage-monotonic).

## Notes

Live parked population on this device is currently **zero** (`.exocortex/parked/` is absent in every vault), so the parked branch is exercised by the tests and by future parking, not by present data — stated explicitly so an empty section is not later mistaken for a dead feature. Parking itself is a shipped capability (req `d4ccc901`).

Out of scope, deliberately: the commit distance; a plugin-side surface (the core module is platform-free precisely so a plugin can consume the same verdict later without duplicating the logic); any change to what parking or `apply-profile` do. `exosync-parity` is a CLI-only diagnostic with no plugin counterpart, so this introduces no Desktop↔Mobile command asymmetry.
