### PR TITLE
feat(display-name): matchPath supports a dot-notation key-path (req fedeaa6e)

### DIFF
--- a/packages/obsidian-plugin/src/domain/display-name/DisplayNameTemplateEngine.ts
+++ b/packages/obsidian-plugin/src/domain/display-name/DisplayNameTemplateEngine.ts
@@ -17,7 +17,9 @@
  * - "[{{exo__Instance_class}}] {{exo__Asset_label}}" - Class prefix
  * - "{{_basename}} - {{exo__Asset_label}}" - Filename with label
  */
-export type MetadataResolver = (wikilinkTarget: string) => Record<string, unknown> | null;
+import { resolveKeyPath, type MetadataResolver } from "./keyPathResolver";
+
+export type { MetadataResolver };
 
 export class DisplayNameTemplateEngine {
   private static readonly PLACEHOLDER_PATTERN = /\{\{([^}]+)\}\}/g;
@@ -356,40 +358,17 @@ export class DisplayNameTemplateEngine {
   }
 
   /**
-   * Get nested value from object using dot notation
+   * Get nested value from object using dot notation.
+   *
+   * Delegates to the shared `resolveKeyPath` so a `{{a.b}}` template placeholder and an
+   * `exo__DisplayNameSpec_matchPath` dot-path (req fedeaa6e) resolve by the SAME rules.
    */
   private getNestedValue(
     obj: Record<string, unknown>,
     path: string,
     metadataResolver?: MetadataResolver
   ): unknown {
-    const parts = path.split(".");
-    let current: unknown = obj;
-
-    for (const part of parts) {
-      if (current === null || current === undefined) {
-        return undefined;
-      }
-
-      if (typeof current !== "object") {
-        if (typeof current === "string" && metadataResolver && this.isWikilink(current)) {
-          const resolved = metadataResolver(current);
-          if (resolved) {
-            current = (resolved as Record<string, unknown>)[part];
-            continue;
-          }
-        }
-        return undefined;
-      }
-
-      current = (current as Record<string, unknown>)[part];
-    }
-
-    return current;
-  }
-
-  private isWikilink(value: string): boolean {
-    return value.startsWith("[[") && value.endsWith("]]");
+    return resolveKeyPath(obj, path, metadataResolver);
   }
 
   /**

--- a/packages/obsidian-plugin/src/domain/display-name/PrintNameRuleService.ts
+++ b/packages/obsidian-plugin/src/domain/display-name/PrintNameRuleService.ts
@@ -1,5 +1,6 @@
 import { TFile } from "obsidian";
 import type { App } from "obsidian";
+import { resolveKeyPath, type MetadataResolver } from "./keyPathResolver";
 
 /**
  * A per-render VALUE-EQUALITY condition compiled from an exo__DisplayNameSpec's
@@ -95,7 +96,6 @@ export interface ParticipatingRule {
   separator?: string;
 }
 
-type MetadataResolver = (wikilinkTarget: string) => Record<string, unknown> | null;
 
 // --- exo__DisplayNameSpec (structured-RDF displayName specs, v1 thin) ---
 // TBox: PMBOK project 47d57acf, onto-RFC 92b91345, req b4ee3caa. Match a spec/part
@@ -282,7 +282,15 @@ export class PrintNameRuleService {
       if (!fn) return false;
       return fn(this.app, metadata);
     }
-    const instanceForms = this.extractClassKeys(metadata[matcher.matchKey]);
+    // A matchKey CONTAINING a dot is a cross-asset key-path (req fedeaa6e): walk it with
+    // the shared resolveKeyPath, hopping across the wikilink reference(s) it crosses. The
+    // resolver is built LAZILY — only a dot-path pays for it. A single-component key takes
+    // the flat read below, byte-for-byte the pre-fedeaa6e line, so the no-dot path cannot
+    // regress structurally.
+    const raw = matcher.matchKey.includes(".")
+      ? resolveKeyPath(metadata, matcher.matchKey, this.createMetadataResolver())
+      : metadata[matcher.matchKey];
+    const instanceForms = this.extractClassKeys(raw);
     if (instanceForms.length === 0) return false;
     return instanceForms.some((form) => matcher.matchValues.includes(form));
   }
@@ -348,10 +356,18 @@ export class PrintNameRuleService {
 
   createMetadataResolver(): MetadataResolver {
     return (wikilinkTarget: string): Record<string, unknown> | null => {
-      const cleaned = wikilinkTarget
+      const unwrapped = wikilinkTarget
         .replace(/^\[\[|\]\]$/g, "")
         .replace(/^"|"$/g, "")
         .trim();
+
+      // Strip a display alias: `[[<uid>|<label>]]` points at <uid> exactly as `[[<uid>]]`
+      // does, but getFirstLinkpathDest("<uid>|<label>") never resolves — so before this the
+      // aliased form produced a SILENT non-match (req fedeaa6e scenario 3). Both wikilink
+      // forms must resolve identically; that is the dual-IRI floor the corpus mandates.
+      const cleaned = unwrapped.includes("|")
+        ? (unwrapped.split("|")[0]?.trim() ?? "")
+        : unwrapped;
 
       if (!cleaned) return null;
 

--- a/packages/obsidian-plugin/src/domain/display-name/keyPathResolver.ts
+++ b/packages/obsidian-plugin/src/domain/display-name/keyPathResolver.ts
@@ -1,0 +1,66 @@
+/**
+ * Shared dot-notation key-path resolution for the display-name domain.
+ *
+ * ONE mechanism serves BOTH consumers so their semantics cannot drift:
+ *  - `DisplayNameTemplateEngine` — a `{{a.b}}` placeholder inside a display template;
+ *  - `PrintNameRuleService.matcherSatisfied` — an `exo__DisplayNameSpec_matchPath`
+ *    authored as a dot-path (req fedeaa6e), which lets ONE conditional spec address a
+ *    property of a RELATED asset (`exo__Asset_prototype.exo__Instance_class`) instead of
+ *    needing one spec per prototype.
+ *
+ * A path segment hops across a wikilink reference when the current value is a wikilink
+ * STRING and a `MetadataResolver` is supplied: the resolver dereferences it to the
+ * referenced asset's frontmatter and the next segment reads from there. Without a
+ * resolver (or when the target does not resolve) the walk yields `undefined` — the
+ * fail-closed behaviour both consumers rely on.
+ *
+ * Extracted verbatim from `DisplayNameTemplateEngine.getNestedValue` — the template
+ * behaviour is unchanged byte-for-byte; the engine now delegates here.
+ */
+
+export type MetadataResolver = (
+  wikilinkTarget: string,
+) => Record<string, unknown> | null;
+
+/** True for a `[[…]]`-shaped value (the only form a key-path hop dereferences). */
+export function isWikilink(value: string): boolean {
+  return value.startsWith("[[") && value.endsWith("]]");
+}
+
+/**
+ * Walk `path` (dot-separated) through `obj`, hopping across wikilink references via
+ * `metadataResolver`. Returns `undefined` when any segment is missing or unresolvable.
+ */
+export function resolveKeyPath(
+  obj: Record<string, unknown>,
+  path: string,
+  metadataResolver?: MetadataResolver,
+): unknown {
+  const parts = path.split(".");
+  let current: unknown = obj;
+
+  for (const part of parts) {
+    if (current === null || current === undefined) {
+      return undefined;
+    }
+
+    if (typeof current !== "object") {
+      if (
+        typeof current === "string" &&
+        metadataResolver &&
+        isWikilink(current)
+      ) {
+        const resolved = metadataResolver(current);
+        if (resolved) {
+          current = (resolved as Record<string, unknown>)[part];
+          continue;
+        }
+      }
+      return undefined;
+    }
+
+    current = (current as Record<string, unknown>)[part];
+  }
+
+  return current;
+}

--- a/packages/obsidian-plugin/src/domain/display-name/keyPathResolver.ts
+++ b/packages/obsidian-plugin/src/domain/display-name/keyPathResolver.ts
@@ -44,6 +44,27 @@ export function resolveKeyPath(
       return undefined;
     }
 
+    // A reference authored as a YAML LIST hops via its FIRST element — the same
+    // first-element convention `PrintNameRuleService.extractClassKeys` /
+    // `resolvePropertyKey` / `resolveIdentityForms` already apply to a multi-valued
+    // frontmatter value. Without this an array falls into the plain-object branch below
+    // (`typeof [] === "object"`), where `arr["exo__Instance_class"]` is `undefined` — a
+    // SILENT non-match. Both forms are live: 545 scalar / 68 list across the vaults
+    // (189 / 11 for ems__Meeting), so the list form is 5.5% of the req's own trigger class.
+    // A list whose first element is NOT a resolvable wikilink falls through unchanged, so
+    // plain index access (e.g. a numeric segment) keeps its previous meaning.
+    if (Array.isArray(current)) {
+      const first = current[0];
+      if (typeof first === "string" && metadataResolver && isWikilink(first)) {
+        const resolved = metadataResolver(first);
+        if (resolved) {
+          current = (resolved as Record<string, unknown>)[part];
+          continue;
+        }
+        return undefined;
+      }
+    }
+
     if (typeof current !== "object") {
       if (
         typeof current === "string" &&

--- a/packages/obsidian-plugin/src/presentation/properties/PropertiesDefinitionValuePatch.ts
+++ b/packages/obsidian-plugin/src/presentation/properties/PropertiesDefinitionValuePatch.ts
@@ -132,8 +132,23 @@ export class PropertiesDefinitionValuePatch {
     this.disable();
   }
 
-  /** A 1-hop wikilink → frontmatter resolver over the vault metadataCache (mirrors
-   * PrintNameRuleService.createMetadataResolver — kept inline so the patch is self-contained). */
+  /**
+   * A 1-hop wikilink → frontmatter resolver over the vault metadataCache, kept inline so the
+   * patch stays self-contained (it deliberately does not depend on PrintNameRuleService).
+   *
+   * ⚠ It is NO LONGER a mirror of `PrintNameRuleService.createMetadataResolver`, and the
+   * divergence is deliberate rather than an oversight: that one strips a display alias
+   * (`[[uid|label]]` → `uid`, req fedeaa6e), this copy does not. Consequence — a
+   * concept-definition dot-path over an ALIASED intermediate reference keeps the older
+   * silent non-match, while the same authoring form resolves on the matcher and
+   * display-name template surfaces. The shared `resolveKeyPath` (and therefore the
+   * first-element list hop) IS reached from here, so the two changes land on a different
+   * number of surfaces — three vs two.
+   *
+   * Unifying the two would change concept-definition RENDERING, a consumer req fedeaa6e
+   * does not cover, so it needs its own requirement + revert-verify rather than a drive-by
+   * edit: tracked in https://github.com/kitelev/exocortex/issues/4041.
+   */
   private buildMetadataResolver(): MetadataResolver {
     return (wikilinkTarget: string): Record<string, unknown> | null => {
       const cleaned = wikilinkTarget

--- a/packages/obsidian-plugin/tests/unit/domain/display-name/PrintNameRuleService.matchPathKeyPath.test.ts
+++ b/packages/obsidian-plugin/tests/unit/domain/display-name/PrintNameRuleService.matchPathKeyPath.test.ts
@@ -1,5 +1,6 @@
 import { PrintNameRuleService } from "@plugin/domain/display-name/PrintNameRuleService";
 import { DisplayNameResolver } from "@plugin/domain/display-name/DisplayNameResolver";
+import { DisplayNameTemplateEngine } from "@plugin/domain/display-name/DisplayNameTemplateEngine";
 import { TFile } from "obsidian";
 import type { App, CachedMetadata } from "obsidian";
 
@@ -15,10 +16,13 @@ import type { App, CachedMetadata } from "obsidian";
  * pattern (verified: `jest --listTests` yields 0 files there), so a @req binding parked
  * there would satisfy the requirements-trace grep while never executing.
  *
- * Fixture shapes mirror the live vault (verified against vault-my):
- *   exo__Asset_prototype: "[[<uid>]]"        — a SCALAR string (so the walk's step 1 takes
- *                                              the wikilink-hop branch)
- *   exo__Instance_class:  ["[[<uid>]]"]      — an ARRAY (reduced by extractClassKeys)
+ * Fixture shapes mirror the live vault — MEASURED over all three vaults (29 574 files),
+ * not inferred from one sample:
+ *   exo__Asset_prototype  545 scalar "[[<uid>]]" / 68 YAML list  — BOTH forms are live;
+ *                         for ems__Meeting (the req's trigger class) 189 / 11, i.e. the
+ *                         list form is 5.5% of it. Scenario 5 covers the list form; without
+ *                         the first-element hop it fails SILENTLY.
+ *   exo__Instance_class   a list (reduced by extractClassKeys' first-element convention)
  */
 function createMockApp(
   files: Array<{ path: string; frontmatter: Record<string, unknown> }>,
@@ -136,8 +140,9 @@ describe("PrintNameRuleService — matchPath dot-notation key-path [req fedeaa6e
     ]);
   }
 
+  /** `prototypeValue` takes BOTH live authoring forms: a scalar wikilink or a YAML list. */
   function meetingMeta(
-    prototypeValue?: string,
+    prototypeValue?: string | string[],
     label = "Sync 2026-08-12",
   ): Record<string, unknown> {
     return {
@@ -231,6 +236,69 @@ describe("PrintNameRuleService — matchPath dot-notation key-path [req fedeaa6e
         basename: "m7",
       }),
     ).toBe("Sync 2026-08-12");
+  });
+
+  it("@req:fedeaa6e-1619-4a2c-8b45-86fdc9ffaf03 scenario 5 — a reference authored as a YAML LIST resolves like the scalar form", () => {
+    const resolver = keyPathResolverUnderTest();
+
+    // 68 of 613 exo__Asset_prototype values across the vaults are YAML lists (11 of 200
+    // ems__Meeting instances — the req's own trigger class). Before the first-element hop
+    // an array fell into the plain-object branch and silently failed to match, which would
+    // have made the Job Story's "ONE spec covers ALL prototypes" false for 5.5% of meetings.
+    //
+    // Revert-verify axis 3 (RED anchor): remove the Array.isArray hop in resolveKeyPath →
+    // ONLY this scenario goes RED; scenarios 1/3 (scalar + aliased scalar) stay GREEN.
+    expect(
+      resolver.resolve({
+        metadata: meetingMeta([`[[${MEETING_PROTO_ASSET}]]`]),
+        basename: "m8",
+      }),
+    ).toBe("📅 Sync 2026-08-12");
+
+    // the list form must honour the alias strip too (both fixes compose)
+    expect(
+      resolver.resolve({
+        metadata: meetingMeta([
+          `[[${MEETING_PROTO_ASSET}|Weekly sync (prototype)]]`,
+        ]),
+        basename: "m9",
+      }),
+    ).toBe("📅 Sync 2026-08-12");
+
+    // negative control — a list pointing at the WRONG class must still not match
+    expect(
+      resolver.resolve({
+        metadata: meetingMeta([`[[${TASK_PROTO_ASSET}]]`]),
+        basename: "m10",
+      }),
+    ).toBe("Sync 2026-08-12");
+
+    // negative control — an EMPTY list is fail-closed, not a crash
+    expect(
+      resolver.resolve({ metadata: meetingMeta([]), basename: "m11" }),
+    ).toBe("Sync 2026-08-12");
+  });
+
+  it("@req:fedeaa6e-1619-4a2c-8b45-86fdc9ffaf03 the |alias strip also reaches TEMPLATE dot-paths (shared resolver — documented blast radius)", () => {
+    // createMetadataResolver is shared with DisplayNameTemplateEngine's {{a.b}} walk, so the
+    // alias strip changes template rendering too: an intermediate reference authored
+    // [[uid|label]] used to resolve to null (empty render) and now dereferences. The req
+    // itself cites this authoring form, so the effect is intended — this pins it.
+    const service = new PrintNameRuleService(meetingKeyPathVault());
+    service.initialize();
+    const engine = new DisplayNameTemplateEngine(
+      "{{exo__Asset_prototype.exo__Asset_label}}",
+    );
+
+    const rendered = engine.render(
+      {
+        exo__Asset_prototype: `[[${MEETING_PROTO_ASSET}|Weekly sync (prototype)]]`,
+      },
+      "basename",
+      undefined,
+      service.createMetadataResolver(),
+    );
+    expect(rendered).toBe("Weekly sync (prototype)");
   });
 });
 

--- a/packages/obsidian-plugin/tests/unit/domain/display-name/PrintNameRuleService.matchPathKeyPath.test.ts
+++ b/packages/obsidian-plugin/tests/unit/domain/display-name/PrintNameRuleService.matchPathKeyPath.test.ts
@@ -1,0 +1,336 @@
+import { PrintNameRuleService } from "@plugin/domain/display-name/PrintNameRuleService";
+import { DisplayNameResolver } from "@plugin/domain/display-name/DisplayNameResolver";
+import { TFile } from "obsidian";
+import type { App, CachedMetadata } from "obsidian";
+
+/**
+ * req fedeaa6e-1619-4a2c-8b45-86fdc9ffaf03 — `exo__DisplayNameSpec_matchPath` supports a
+ * dot-notation key-path, so ONE conditional spec covers every prototype of a class
+ * (`exo__Asset_prototype.exo__Instance_class`) instead of N specs for N prototypes.
+ *
+ * Integration-STYLE by nature (real scanVault → compile → per-render matcher → real
+ * DisplayNameResolver over a production-shape vault; nothing about the key-path walk is
+ * stubbed), placed under tests/unit/** because that is what the plugin jest config
+ * actually runs — `packages/obsidian-plugin/tests/integration/**` matches NO testMatch
+ * pattern (verified: `jest --listTests` yields 0 files there), so a @req binding parked
+ * there would satisfy the requirements-trace grep while never executing.
+ *
+ * Fixture shapes mirror the live vault (verified against vault-my):
+ *   exo__Asset_prototype: "[[<uid>]]"        — a SCALAR string (so the walk's step 1 takes
+ *                                              the wikilink-hop branch)
+ *   exo__Instance_class:  ["[[<uid>]]"]      — an ARRAY (reduced by extractClassKeys)
+ */
+function createMockApp(
+  files: Array<{ path: string; frontmatter: Record<string, unknown> }>,
+): App {
+  const fileCache = new Map<string, CachedMetadata>();
+  const mockFiles: TFile[] = [];
+
+  for (const f of files) {
+    const tfile = new TFile(f.path);
+    tfile.basename = f.path.replace(".md", "");
+    tfile.extension = "md";
+    mockFiles.push(tfile);
+    fileCache.set(f.path, { frontmatter: f.frontmatter } as CachedMetadata);
+  }
+
+  return {
+    vault: {
+      getMarkdownFiles: jest.fn().mockReturnValue(mockFiles),
+    },
+    metadataCache: {
+      getFileCache: jest
+        .fn()
+        .mockImplementation((file: TFile) => fileCache.get(file.path) ?? null),
+      getFirstLinkpathDest: jest.fn().mockImplementation((path: string) => {
+        const cleanPath = path.endsWith(".md") ? path : path + ".md";
+        return mockFiles.find((f) => f.path === cleanPath) ?? null;
+      }),
+    },
+  } as unknown as App;
+}
+
+describe("PrintNameRuleService — matchPath dot-notation key-path [req fedeaa6e]", () => {
+  const MEETING_UID = "3f2a1c88-1d4e-4b7a-9c33-51a0e7d9b204"; // ems__Meeting (class)
+  const MEETING_PROTO_UID = "7c9e4b10-88a2-42f5-b6d1-2e0c5a37f9ab"; // ems__MeetingPrototype (class)
+  const TASK_PROTO_UID = "df7e579d-02d4-4f3a-971f-3d1d785b689b"; // ems__TaskPrototype (class)
+  const PROTO_PROP_UID = "5f830626-42d5-409d-9bf6-331129812038"; // exo__Asset_prototype (property)
+  const LABEL_PROP_UID = "12a6151b-801f-4be2-bd6e-a787eedd56ae"; // exo__Asset_label (property)
+  const MEETING_PROTO_ASSET = "a1b2c3d4-5e6f-4071-8293-0a1b2c3d4e5f"; // a MeetingPrototype INSTANCE
+  const TASK_PROTO_ASSET = "b2c3d4e5-6f70-4182-93a4-1b2c3d4e5f60"; // a TaskPrototype INSTANCE
+
+  const SPEC_UID = "spec-meeting-keypath-uid";
+
+  /**
+   * Production-shape vault: a conditional spec whose matchPath is a DOT-PATH authored the
+   * canonical way — an aliased wikilink whose alias IS the key-path (resolvePropertyKey
+   * takes the alias verbatim, so it arrives at matcher.matchKey unchanged).
+   */
+  function meetingKeyPathVault(): App {
+    return createMockApp([
+      {
+        path: `${PROTO_PROP_UID}.md`,
+        frontmatter: {
+          exo__Asset_uid: PROTO_PROP_UID,
+          exo__Instance_class: [
+            "[[9a1cf31c-9d41-4ef3-9023-584a8d087d16|exo__ObjectProperty]]",
+          ],
+          exo__Asset_label: "exo__Asset_prototype",
+        },
+      },
+      {
+        path: `${SPEC_UID}.md`,
+        frontmatter: {
+          exo__Asset_uid: SPEC_UID,
+          exo__Instance_class: [
+            "[[07eab746-0874-4676-9d98-dbaad1bc6fb8|exo__DisplayNameSpec]]",
+          ],
+          exo__DisplayNameSpec_appliesToClass: `[[${MEETING_UID}|ems__Meeting]]`,
+          exo__DisplayNameSpec_priority: 50,
+          // The dot-path addresses a property of the RELATED prototype asset.
+          exo__DisplayNameSpec_matchPath: `[[${PROTO_PROP_UID}|exo__Asset_prototype.exo__Instance_class]]`,
+          exo__DisplayNameSpec_matchValue: `[[${MEETING_PROTO_UID}]]`,
+        },
+      },
+      {
+        path: "kp-literal.md",
+        frontmatter: {
+          exo__Asset_uid: "kp-literal",
+          exo__Instance_class: [
+            "[[4d5437c9-788e-4a6d-9be0-4af3a84554f4|exo__PrintedLiteral]]",
+          ],
+          exo__DisplayNamePart_of: `[[${SPEC_UID}]]`,
+          exo__DisplayNamePart_order: 0,
+          exo__PrintedLiteral_literal: "📅 ",
+        },
+      },
+      {
+        path: "kp-prop.md",
+        frontmatter: {
+          exo__Asset_uid: "kp-prop",
+          exo__Instance_class: [
+            "[[7d58de40-d941-4a66-88e2-13afc4fdc41d|exo__PrintedProperty]]",
+          ],
+          exo__DisplayNamePart_of: `[[${SPEC_UID}]]`,
+          exo__DisplayNamePart_order: 1,
+          exo__PrintedProperty_property: `[[${LABEL_PROP_UID}|exo__Asset_label]]`,
+        },
+      },
+      // The RELATED assets the key-path hops onto.
+      {
+        path: `${MEETING_PROTO_ASSET}.md`,
+        frontmatter: {
+          exo__Asset_uid: MEETING_PROTO_ASSET,
+          exo__Instance_class: [`[[${MEETING_PROTO_UID}]]`],
+          exo__Asset_label: "Weekly sync (prototype)",
+        },
+      },
+      {
+        path: `${TASK_PROTO_ASSET}.md`,
+        frontmatter: {
+          exo__Asset_uid: TASK_PROTO_ASSET,
+          exo__Instance_class: [`[[${TASK_PROTO_UID}]]`],
+          exo__Asset_label: "Recurring chore (prototype)",
+        },
+      },
+    ]);
+  }
+
+  function meetingMeta(
+    prototypeValue?: string,
+    label = "Sync 2026-08-12",
+  ): Record<string, unknown> {
+    return {
+      exo__Instance_class: [`[[${MEETING_UID}]]`],
+      exo__Asset_label: label,
+      ...(prototypeValue === undefined
+        ? {}
+        : { exo__Asset_prototype: prototypeValue }),
+    };
+  }
+
+  function keyPathResolverUnderTest(): DisplayNameResolver {
+    const service = new PrintNameRuleService(meetingKeyPathVault());
+    service.initialize();
+    // EMPTY classTemplates — proves the VAULT spec drives the 📅, not a TS hardcode.
+    return new DisplayNameResolver(
+      { defaultTemplate: "{{exo__Asset_label}}", classTemplates: {} },
+      service,
+    );
+  }
+
+  it("@req:fedeaa6e-1619-4a2c-8b45-86fdc9ffaf03 scenario 1 — a dot-notation key-path matches a property of the RELATED asset (bare wikilink form)", () => {
+    const resolver = keyPathResolverUnderTest();
+
+    // Revert-verify axis 1 (RED anchor): neutralize the dot-branch in matcherSatisfied
+    // (fall back to the flat metadata[matchKey] read) → the key-path never resolves →
+    // this assertion goes RED while scenario 4 stays GREEN.
+    expect(
+      resolver.resolve({
+        metadata: meetingMeta(`[[${MEETING_PROTO_ASSET}]]`),
+        basename: "m1",
+      }),
+    ).toBe("📅 Sync 2026-08-12");
+  });
+
+  it("@req:fedeaa6e-1619-4a2c-8b45-86fdc9ffaf03 scenario 2 — fail-closed when the related asset is of another class, or the reference is absent", () => {
+    const resolver = keyPathResolverUnderTest();
+
+    // prototype exists but is a TaskPrototype, not a MeetingPrototype
+    expect(
+      resolver.resolve({
+        metadata: meetingMeta(`[[${TASK_PROTO_ASSET}]]`),
+        basename: "m2",
+      }),
+    ).toBe("Sync 2026-08-12");
+
+    // no exo__Asset_prototype at all
+    expect(
+      resolver.resolve({ metadata: meetingMeta(undefined), basename: "m3" }),
+    ).toBe("Sync 2026-08-12");
+
+    // the reference points at an asset that does not exist in the vault
+    expect(
+      resolver.resolve({
+        metadata: meetingMeta("[[99999999-0000-4000-8000-000000000000]]"),
+        basename: "m4",
+      }),
+    ).toBe("Sync 2026-08-12");
+  });
+
+  it("@req:fedeaa6e-1619-4a2c-8b45-86fdc9ffaf03 scenario 3 — both wikilink forms resolve identically: [[uid]] and [[uid|alias]]", () => {
+    const resolver = keyPathResolverUnderTest();
+
+    // Revert-verify axis 2 (RED anchor): neutralize the |alias strip in
+    // createMetadataResolver → getFirstLinkpathDest("<uid>|<label>") fails → SILENT
+    // non-match → ONLY this aliased assertion goes RED; scenario 1 stays GREEN.
+    expect(
+      resolver.resolve({
+        metadata: meetingMeta(
+          `[[${MEETING_PROTO_ASSET}|Weekly sync (prototype)]]`,
+        ),
+        basename: "m5",
+      }),
+    ).toBe("📅 Sync 2026-08-12");
+
+    // bare form — the control that keeps axis 2 honest (must stay GREEN under that revert)
+    expect(
+      resolver.resolve({
+        metadata: meetingMeta(`[[${MEETING_PROTO_ASSET}]]`),
+        basename: "m6",
+      }),
+    ).toBe("📅 Sync 2026-08-12");
+
+    // negative control: an aliased reference to the WRONG class must still not match,
+    // so the alias strip cannot be "fixed" by matching everything.
+    expect(
+      resolver.resolve({
+        metadata: meetingMeta(
+          `[[${TASK_PROTO_ASSET}|Recurring chore (prototype)]]`,
+        ),
+        basename: "m7",
+      }),
+    ).toBe("Sync 2026-08-12");
+  });
+});
+
+describe("PrintNameRuleService — single-component matchPath is byte-identical [req fedeaa6e scenario 4]", () => {
+  const TASK_UID = "1b20a8f0-d745-4e93-91db-4531b3df120e";
+  const STATUS_PROP_UID = "44c6e9e3-955f-4afc-9ca5-b4bd70667051"; // ems__Effort_status
+  const DOING_UID = "027e78f4-6e16-4b36-b8fb-5510507d5745";
+  const DONE_UID = "7b9b3116-7c3c-438c-9618-94fe301320a6";
+  const LABEL_PROP_UID = "12a6151b-801f-4be2-bd6e-a787eedd56ae";
+  const SPEC_UID = "spec-nodot-uid";
+
+  /** A conditional spec whose matchPath has NO dot — the pre-fedeaa6e code path. */
+  function flatSpecVault(): App {
+    return createMockApp([
+      {
+        path: `${STATUS_PROP_UID}.md`,
+        frontmatter: {
+          exo__Asset_uid: STATUS_PROP_UID,
+          exo__Instance_class: [
+            "[[9a1cf31c-9d41-4ef3-9023-584a8d087d16|exo__ObjectProperty]]",
+          ],
+          exo__Asset_label: "ems__Effort_status",
+        },
+      },
+      {
+        path: `${SPEC_UID}.md`,
+        frontmatter: {
+          exo__Asset_uid: SPEC_UID,
+          exo__Instance_class: [
+            "[[07eab746-0874-4676-9d98-dbaad1bc6fb8|exo__DisplayNameSpec]]",
+          ],
+          exo__DisplayNameSpec_appliesToClass: `[[${TASK_UID}|ems__Task]]`,
+          exo__DisplayNameSpec_priority: 50,
+          exo__DisplayNameSpec_matchPath: `[[${STATUS_PROP_UID}]]`,
+          exo__DisplayNameSpec_matchValue: `[[${DOING_UID}]]`,
+        },
+      },
+      {
+        path: "flat-literal.md",
+        frontmatter: {
+          exo__Asset_uid: "flat-literal",
+          exo__Instance_class: [
+            "[[4d5437c9-788e-4a6d-9be0-4af3a84554f4|exo__PrintedLiteral]]",
+          ],
+          exo__DisplayNamePart_of: `[[${SPEC_UID}]]`,
+          exo__DisplayNamePart_order: 0,
+          exo__PrintedLiteral_literal: "🔄 ",
+        },
+      },
+      {
+        path: "flat-prop.md",
+        frontmatter: {
+          exo__Asset_uid: "flat-prop",
+          exo__Instance_class: [
+            "[[7d58de40-d941-4a66-88e2-13afc4fdc41d|exo__PrintedProperty]]",
+          ],
+          exo__DisplayNamePart_of: `[[${SPEC_UID}]]`,
+          exo__DisplayNamePart_order: 1,
+          exo__PrintedProperty_property: `[[${LABEL_PROP_UID}|exo__Asset_label]]`,
+        },
+      },
+    ]);
+  }
+
+  function taskMeta(statusValue: string): Record<string, unknown> {
+    return {
+      exo__Instance_class: [`[[${TASK_UID}]]`],
+      exo__Asset_label: "Fix the parser",
+      ems__Effort_status: statusValue,
+    };
+  }
+
+  it("@req:fedeaa6e-1619-4a2c-8b45-86fdc9ffaf03 scenario 4 — a dot-free matchPath behaves exactly as before (zero-regression)", () => {
+    const service = new PrintNameRuleService(flatSpecVault());
+    service.initialize();
+    const resolver = new DisplayNameResolver(
+      { defaultTemplate: "{{exo__Asset_label}}", classTemplates: {} },
+      service,
+    );
+
+    // Stays GREEN under BOTH revert-verify axes — the dot-free key takes the untouched
+    // flat read, so scenarios 1/3 going RED cannot be explained by a broken matcher.
+    expect(
+      resolver.resolve({
+        metadata: taskMeta(`[[${DOING_UID}]]`),
+        basename: "t1",
+      }),
+    ).toBe("🔄 Fix the parser");
+    expect(
+      resolver.resolve({
+        metadata: taskMeta(`[[${DONE_UID}]]`),
+        basename: "t2",
+      }),
+    ).toBe("Fix the parser");
+    // dual-IRI alias form on the FLAT path — unchanged by the key-path work
+    expect(
+      resolver.resolve({
+        metadata: taskMeta(`[[${DOING_UID}|ems__EffortStatusDoing]]`),
+        basename: "t3",
+      }),
+    ).toBe("🔄 Fix the parser");
+  });
+});

--- a/packages/obsidian-plugin/tests/unit/domain/display-name/PrintNameRuleService.matchPathKeyPath.test.ts
+++ b/packages/obsidian-plugin/tests/unit/domain/display-name/PrintNameRuleService.matchPathKeyPath.test.ts
@@ -300,6 +300,56 @@ describe("PrintNameRuleService — matchPath dot-notation key-path [req fedeaa6e
     );
     expect(rendered).toBe("Weekly sync (prototype)");
   });
+
+  it("@req:fedeaa6e-1619-4a2c-8b45-86fdc9ffaf03 the first-element LIST hop also reaches TEMPLATE dot-paths (second shared-code effect)", () => {
+    // resolveKeyPath is shared, so the list hop added for the matcher ALSO changes template
+    // rendering: `{{a.b}}` over a LIST-valued reference used to yield undefined (an empty
+    // render, because `typeof [] === "object"` sent it to plain indexing) and now
+    // dereferences the first element. Same direction as the scalar/aliased forms — the
+    // rendered value is the referenced asset's, not a new invention — but it is a genuine
+    // behaviour change on a surface the requirement does not mention, so it is pinned here
+    // rather than left to be discovered later.
+    const service = new PrintNameRuleService(meetingKeyPathVault());
+    service.initialize();
+    const engine = new DisplayNameTemplateEngine(
+      "{{exo__Asset_prototype.exo__Asset_label}}",
+    );
+
+    // bare list element
+    expect(
+      engine.render(
+        { exo__Asset_prototype: [`[[${MEETING_PROTO_ASSET}]]`] },
+        "basename",
+        undefined,
+        service.createMetadataResolver(),
+      ),
+    ).toBe("Weekly sync (prototype)");
+
+    // list + alias — both fixes compose on the template surface too
+    expect(
+      engine.render(
+        {
+          exo__Asset_prototype: [
+            `[[${MEETING_PROTO_ASSET}|Weekly sync (prototype)]]`,
+          ],
+        },
+        "basename",
+        undefined,
+        service.createMetadataResolver(),
+      ),
+    ).toBe("Weekly sync (prototype)");
+
+    // NEGATIVE CONTROL — a list whose first element is NOT a wikilink keeps the previous
+    // meaning (plain indexing), so the hop cannot be "fixing" everything indiscriminately.
+    expect(
+      engine.render(
+        { exo__Asset_prototype: ["plain string, not a link"] },
+        "basename",
+        undefined,
+        service.createMetadataResolver(),
+      ),
+    ).toBeNull();
+  });
 });
 
 describe("PrintNameRuleService — single-component matchPath is byte-identical [req fedeaa6e scenario 4]", () => {


### PR DESCRIPTION
## What

`exo__DisplayNameSpec_matchPath` now accepts a **dot-notation key-path**, so ONE conditional
spec covers every prototype of a class (`exo__Asset_prototype.exo__Instance_class`) instead of
needing one spec (plus its parts) per prototype.

**Req:** `fedeaa6e-1619-4a2c-8b45-86fdc9ffaf03` (approved by a.kitelev)

## How

1. **`keyPathResolver.ts` (new)** — `getNestedValue` + `isWikilink` extracted **verbatim** from
   `DisplayNameTemplateEngine`; the engine delegates, so the extraction is byte-for-byte.
2. **`matcherSatisfied` gates on the dot.** A single-component key takes the *literal* pre-existing
   line, so scenario 4 (zero-regression) holds **structurally**. The resolver is built **lazily**.
3. **`createMetadataResolver` strips `|alias`** — `[[uid|label]]` points at `uid` exactly as
   `[[uid]]` does, but `getFirstLinkpathDest("uid|label")` never resolves, so the aliased form was a
   **silent non-match**.
4. **A LIST-valued reference hops via its first element** (review HIGH, below).

## Review HIGH — `exo__Asset_prototype` has TWO live forms

**Measured over all three vaults (29 574 files): 545 scalar / 68 YAML list.** For `ems__Meeting`
— the requirement's own trigger class — **189 / 11**, so the list form is **5.5 %** of it.

A list never reached the wikilink-hop branch (`typeof [] === "object"`) and fell to plain indexing,
where `arr["exo__Instance_class"]` is `undefined` → **silent non-match**. That would have made the
Job Story's *"ONE spec covers **all** prototypes of a class"* false for 11 live meetings.

Not a regression (on `origin/main` no dot-path resolved at all) — an unclosed half of the mechanism.
Fixed by hopping via the **first element**, the same convention `extractClassKeys` /
`resolvePropertyKey` / `resolveIdentityForms` already apply.

## Blast radius — THREE consumer surfaces, and the two changes reach a DIFFERENT number of them

⛔ An earlier revision of this PR claimed *"ONE mechanism means a `{{a.b}}` placeholder and a
`matchPath` dot-path cannot drift apart"*. **That claim was false** and is retracted: there is a
third consumer, and the two changes do not cover it equally.

| Surface | first-element **list** hop (`resolveKeyPath`) | **`\|alias`** strip (`createMetadataResolver`) |
|---|---|---|
| `matcherSatisfied` — the req's own path | ✅ reached | ✅ reached |
| `DisplayNameTemplateEngine` dot-path `{{a.b}}` | ✅ reached | ✅ reached |
| **concept-definition** (`PropertiesDefinitionValuePatch.buildMetadataResolver` → `ConceptDefinitionResolver`) | ✅ reached (shared `resolveKeyPath`) | ❌ **NOT reached** — inline resolver copy, no alias strip |

Flat `{{prop}}` is unaffected by both (no dot ⇒ `resolveKeyPath` is never called; and
`formatWikilinkValue` returns the alias by early return without consulting the resolver).

The third surface's docstring used to say it "mirrors `createMetadataResolver`" — this PR corrects
that to state the divergence explicitly. **Deliberately documented, not unified**: pointing it at the
shared resolver would change concept-definition *rendering*, a consumer req `fedeaa6e` does not
cover, so it needs its own requirement + revert-verify — tracked as **#4041**.

**Numeric path segment (narrowing, measured).** `{{arr.0}}` over a list whose first element is a
*resolvable* wikilink previously yielded the resolved label and now yields `undefined`, because the
list hop takes precedence over plain indexing. An earlier revision said numeric indexing was
"untouched" — **also false**, and retracted. Live consumers measured across all three vaults
(29 687 files): **0** `exo__PrintedProperty` key-paths and **0** template placeholders with a
numeric segment (the single textual match is this PR's own progress note quoted into a session log).
Outcome is fail-closed, and the in-code comment was already hedged correctly.

## Revert-verify — 3 axes, each reds a DISTINCT set

Re-measured on the current head after every change. ⛔ A previous revision reported axis 2 as
**3** RED; the true count is **4** — the fourth is this PR's own round-3 list-template test, added
after that axis was last run. Corrected below.

| Axis neutralized | RED | GREEN (controls) |
|---|---|---|
| dot-branch in `matcherSatisfied` | scenarios **1 + 3 + 5** (3 failed) | scenario **4**, both template tests, 8 sibling suites |
| `\|alias` strip in `createMetadataResolver` | scenario **3**, scenario 5's list-with-alias, alias-template test, **list-template test** (**4 failed**) | scenario **1** (bare form), scenario 4 |
| first-element list hop in `resolveKeyPath` | scenario **5** + list-template test — both surfaces (2 failed) | scenarios **1 + 3** (scalar + aliased scalar) |

Note the heading: *distinct*, not "exactly its own". Axis 3's RED set is a strict **subset** of axis
2's, because a list-with-alias needs both mechanisms. Independence still holds — axis 2 reds
scenario 3 and the alias-template test, which axis 3 leaves green — but the earlier phrasing
overpromised. Breaks are type-preserving (`&& false`).

## Verification

- **Full plugin suite: 339/339 suites, 6056 passed, 0 failed.**
- `check:types` clean; `eslint` clean on every changed file.
- All three `lint`-job guard scripts pass — anti-pattern ratchet unchanged
  (`method-exists=55/55, vacuous-length=21/21, non-canon-service-dir=19/19, over-mock=0/0`).
- `PrintNameRuleService.ts`, `DisplayNameTemplateEngine.ts` and `PropertiesDefinitionValuePatch.ts`
  are prettier-dirty on `origin/main` (205 / 230 / 96-line blast radius **measured**), so only the
  touched lines are hand-formatted; the two new files are `prettier --write`-clean.

## Test placement (deliberate)

Integration-*style* (real `scanVault` → compile → per-render matcher → real `DisplayNameResolver`)
but under `tests/unit/**`, because `packages/obsidian-plugin/tests/integration/**` matches **no**
`testMatch` pattern — `jest --listTests` returns **0** files there. A `@req` binding parked in that
folder would satisfy the `requirements-trace` grep while **never executing**.

## Scope note on scenario 2

Scenario 2 (fail-closed: wrong class / absent reference / unresolvable target) asserts the req's
Scenario 2 and is legitimate as such — but all three of its assertions expect a **negative** outcome,
so it stays green even with the feature fully dead. It is **not** revert-verify evidence; the
discriminating controls are **scenario 4** and, per axis, scenario 1.

## Out of scope (req Non-goals)

Matcher conjunctions (`exo__DisplayNameMatcher`), `matchHostFunction` semantics, the meeting
vault-spec itself, and the resolver unification (**#4041**). `extractClassKeys` reading only element
`[0]` of the terminal component is pre-existing and shared with the flat path — measured **0**
ordering misses on real meeting data, so it is left untouched.
