### PR TITLE
fix(core): stop writing EffortStatus values deleted from the ontology

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1141,7 +1141,7 @@ services depend on platform-agnostic interfaces (`IVaultAdapter`,
    ```
 4. **Update Status**:
    ```typescript
-   ems__Effort_status: "[[ems__EffortStatusToDo]]";
+   ems__Effort_status: "[[ems__EffortStatusBacklog]]";
    ```
 5. **No Timestamp**: ToDo doesn't trigger timestamps
 6. **Save**: `Vault.modify(file, updatedContent)`

--- a/docs/how-to/ONTOLOGY_EXTENSION.md
+++ b/docs/how-to/ONTOLOGY_EXTENSION.md
@@ -357,7 +357,7 @@ exo__Instance_class:
   - "[[ems__Task]]"
 exo__Asset_label: "Implement login form"
 ems__Effort_team: "[[Frontend Team]]"
-ems__Effort_status: "[[ems__EffortStatusToDo]]"
+ems__Effort_status: "[[ems__EffortStatusBacklog]]"
 ---
 ```
 

--- a/docs/how-to/Troubleshooting.md
+++ b/docs/how-to/Troubleshooting.md
@@ -322,7 +322,7 @@ parity); sync and apply use a REST/tarball transport instead of `git`.
 1. **Check Status Format**: Must be wiki-link format
 
    ```yaml
-   ems__Effort_status: "[[ems__EffortStatusToDo]]"  # Correct
+   ems__Effort_status: "[[ems__EffortStatusBacklog]]"  # Correct
    ems__Effort_status: "ToDo"  # Wrong
    ```
 

--- a/docs/how-to/WORKFLOW_CUSTOMIZATION.md
+++ b/docs/how-to/WORKFLOW_CUSTOMIZATION.md
@@ -337,8 +337,7 @@ Validation checks:
 
 - `ems__EffortStatusDraft`
 - `ems__EffortStatusBacklog`
-- `ems__EffortStatusAnalysis`
-- `ems__EffortStatusToDo`
+- `ems__EffortStatusWaiting`
 - `ems__EffortStatusDoing`
 - `ems__EffortStatusDone`
 - `ems__EffortStatusTrashed`

--- a/docs/reference/Core-API.md
+++ b/docs/reference/Core-API.md
@@ -89,7 +89,7 @@ const file = await service.createAsset({
   className: "ems__Task",
   label: "Build API endpoint",
   propertyValues: {
-    ems__Effort_status: '"[[ems__EffortStatusToDo]]"',
+    ems__Effort_status: '"[[ems__EffortStatusBacklog]]"',
   },
 });
 
@@ -760,8 +760,7 @@ import { EffortStatus } from "@kitelev/exocortex-core";
 enum EffortStatus {
   DRAFT = "ems__EffortStatusDraft",
   BACKLOG = "ems__EffortStatusBacklog",
-  ANALYSIS = "ems__EffortStatusAnalysis",
-  TODO = "ems__EffortStatusToDo",
+  WAITING = "ems__EffortStatusWaiting",
   DOING = "ems__EffortStatusDoing",
   DONE = "ems__EffortStatusDone",
   TRASHED = "ems__EffortStatusTrashed",

--- a/docs/reference/PROPERTY_SCHEMA.md
+++ b/docs/reference/PROPERTY_SCHEMA.md
@@ -333,8 +333,7 @@ Draft → Backlog → Analysis → ToDo → Doing → Done
 
 - `ems__EffortStatusDraft` - Initial state
 - `ems__EffortStatusBacklog` - Queued for future
-- `ems__EffortStatusAnalysis` - Being analyzed/planned
-- `ems__EffortStatusToDo` - Ready to start
+- `ems__EffortStatusWaiting` - Parked, waiting on someone or something
 - `ems__EffortStatusDoing` - Currently active
 - `ems__EffortStatusDone` - Completed
 - `ems__EffortStatusTrashed` - Cancelled/deleted
@@ -1386,7 +1385,7 @@ exo__Asset_createdAt: 2025-10-20T10:00:00
 exo__Asset_isDefinedBy: "[[f6e01f7a-d727-494a-82a3-815597d33e86]]" # $ems ontology asset
 exo__Instance_class:
   - "[[7db5eeff-718a-49b0-8d2b-39b084a356e3]]" # ems__Project
-ems__Effort_status: "[[ems__EffortStatusToDo]]"
+ems__Effort_status: "[[ems__EffortStatusBacklog]]"
 ems__Effort_area: "[[Work]]"
 ems__Effort_votes: 8
 aliases:

--- a/docs/tutorials/Getting-Started.md
+++ b/docs/tutorials/Getting-Started.md
@@ -277,7 +277,7 @@ REST API for the mobile app.
 
 ### Available Status Values
 
-EMS ships a status lifecycle — `Draft → Backlog → Analysis → ToDo → Doing → Done` (plus `Trashed`). The individual status values (`ems__EffortStatusBacklog`, `ems__EffortStatusToDo`, …) and their exact meaning are part of the **EMS domain model**, documented in the **[EMS AssetSpace README](https://github.com/kitelev/exoas-public)** — kept there (not duplicated here) so the two never drift.
+EMS ships a status lifecycle — `Draft → Backlog → Doing → Done` (plus `Trashed`). The individual status values (`ems__EffortStatusBacklog`, `ems__EffortStatusDoing`, …) and their exact meaning are part of the **EMS domain model**, documented in the **[EMS AssetSpace README](https://github.com/kitelev/exoas-public)** — kept there (not duplicated here) so the two never drift.
 
 ### What You'll See
 
@@ -308,7 +308,7 @@ exo__Instance_class:
 exo__Asset_label: Set up Express server
 ems__Effort_area: "[[Development]]"
 ems__Effort_parent: "[[Build API Server]]"
-ems__Effort_status: "[[ems__EffortStatusToDo]]"
+ems__Effort_status: "[[ems__EffortStatusBacklog]]"
 ---
 # Set up Express server
 
@@ -608,7 +608,7 @@ This is usually enough to identify the root cause on the first pass.
 | `exo__Asset_label`                  | Display name        | `"Build API Server"`                                      |
 | `ems__Effort_area`                  | Parent area         | `"[[Development]]"`                                       |
 | `ems__Effort_parent`                | Parent project/task | `"[[Build API Server]]"`                                  |
-| `ems__Effort_status`                | Workflow status     | `"[[ems__EffortStatusToDo]]"`                             |
+| `ems__Effort_status`                | Workflow status     | `"[[ems__EffortStatusBacklog]]"`                             |
 | `ems__Effort_plannedStartTimestamp` | Planned start date  | `"2025-11-10"`                                            |
 | `pn__DailyNote_day`                 | Daily note date     | `"2025-11-10"`                                            |
 

--- a/packages/cli/VERSIONING.md
+++ b/packages/cli/VERSIONING.md
@@ -202,8 +202,8 @@ Commands and options documented in [CLI_API_REFERENCE.md](docs/CLI_API_REFERENCE
 | `exocortex command trash`            | **Stable** |
 | `exocortex command archive`          | **Stable** |
 | `exocortex command move-to-backlog`  | **Stable** |
-| `exocortex command move-to-analysis` | **Stable** |
-| `exocortex command move-to-todo`     | **Stable** |
+| `exocortex command move-to-analysis` | **Removed** |
+| `exocortex command move-to-todo`     | **Removed** |
 | `exocortex command create-task`      | **Stable** |
 | `exocortex command create-meeting`   | **Stable** |
 | `exocortex command create-project`   | **Stable** |

--- a/packages/cli/docs/ONTOLOGY_REFERENCE.md
+++ b/packages/cli/docs/ONTOLOGY_REFERENCE.md
@@ -435,8 +435,7 @@ SELECT ?area ?label ?parent WHERE {
 |--------|-----|-------------------|
 | Draft | `ems:EffortStatusDraft` | `ems__EffortStatusDraft` |
 | Backlog | `ems:EffortStatusBacklog` | `ems__EffortStatusBacklog` |
-| Analysis | `ems:EffortStatusAnalysis` | `ems__EffortStatusAnalysis` |
-| ToDo | `ems:EffortStatusToDo` | `ems__EffortStatusToDo` |
+| Waiting | `ems:EffortStatusWaiting` | `ems__EffortStatusWaiting` |
 | Doing | `ems:EffortStatusDoing` | `ems__EffortStatusDoing` |
 | Done | `ems:EffortStatusDone` | `ems__EffortStatusDone` |
 | Trashed | `ems:EffortStatusTrashed` | `ems__EffortStatusTrashed` |

--- a/packages/cli/src/commands/propertyMutationShared.ts
+++ b/packages/cli/src/commands/propertyMutationShared.ts
@@ -49,7 +49,7 @@ export { canonicalYamlKey };
 export const GUARDED_PROPERTIES: Record<string, string> = {
   // Status state machine (transitions carry preconditions).
   ems__Effort_status:
-    "apply mark-done|move-to-backlog|move-to-todo|start-effort|set-draft-status <path>",
+    "apply mark-done|move-to-backlog|rollback-to-backlog|start-effort|set-draft-status <path>",
   // Criticality zone (not-a-prototype precondition guard).
   ems__Task_zone: "apply set-criticality-high|medium|low <path>",
   // Parent / label — dedicated guarded commands (#3779).

--- a/packages/cli/src/executors/BatchExecutor.ts
+++ b/packages/cli/src/executors/BatchExecutor.ts
@@ -306,21 +306,10 @@ export class BatchExecutor {
             "Moved to backlog",
           );
 
-        case "move-to-analysis":
-          return await this.executeStatusUpdate(
-            relativePath,
-            operation,
-            "ems__EffortStatusAnalysis",
-            "Moved to analysis",
-          );
-
-        case "move-to-todo":
-          return await this.executeStatusUpdate(
-            relativePath,
-            operation,
-            "ems__EffortStatusToDo",
-            "Moved to todo",
-          );
+        // `move-to-analysis` / `move-to-todo` removed — see the note in
+        // `commands/StatusCommandExecutor.ts`
+        // (req fcbde537-f09a-410e-8bee-d3d607a70302). They now fall through
+        // to the `default` branch and report an unknown command.
 
         case "update-label":
           return await this.executeUpdateLabel(relativePath, operation);

--- a/packages/cli/src/executors/CommandExecutor.ts
+++ b/packages/cli/src/executors/CommandExecutor.ts
@@ -100,13 +100,8 @@ export class CommandExecutor {
     return this.statusExecutor.executeMoveToBacklog(filepath);
   }
 
-  async executeMoveToAnalysis(filepath: string): Promise<void> {
-    return this.statusExecutor.executeMoveToAnalysis(filepath);
-  }
-
-  async executeMoveToToDo(filepath: string): Promise<void> {
-    return this.statusExecutor.executeMoveToToDo(filepath);
-  }
+  // `executeMoveToAnalysis` / `executeMoveToToDo` removed — see the note in
+  // `commands/StatusCommandExecutor.ts` (req fcbde537-f09a-410e-8bee-d3d607a70302).
 
   // Asset creation commands
   async executeCreateTask(

--- a/packages/cli/src/executors/commands/StatusCommandExecutor.ts
+++ b/packages/cli/src/executors/commands/StatusCommandExecutor.ts
@@ -183,29 +183,13 @@ export class StatusCommandExecutor extends BaseCommandExecutor {
     }
   }
 
-  /**
-   * Transitions project to Analysis status.
-   */
-  async executeMoveToAnalysis(filepath: string): Promise<void> {
-    try {
-      await this.updateStatus(filepath, "ems__EffortStatusAnalysis", "Analysis");
-      process.exit(ExitCodes.SUCCESS);
-    } catch (error) {
-      ErrorHandler.handle(error as Error);
-    }
-  }
-
-  /**
-   * Transitions task/project to ToDo status.
-   */
-  async executeMoveToToDo(filepath: string): Promise<void> {
-    try {
-      await this.updateStatus(filepath, "ems__EffortStatusToDo", "ToDo");
-      process.exit(ExitCodes.SUCCESS);
-    } catch (error) {
-      ErrorHandler.handle(error as Error);
-    }
-  }
+  // `executeMoveToAnalysis` / `executeMoveToToDo` removed with req
+  // fcbde537-f09a-410e-8bee-d3d607a70302: both wrote a status whose TBox
+  // instance was deleted from the shared ontology (exoas-public@c35a660d),
+  // i.e. a dangling wikilink no workflow can express. Neither was reachable
+  // from the CLI — the `command` and `batch` entrypoints were retired earlier
+  // (see the note in `program.ts`) — so this is not a breaking change.
+  // `move-to-backlog` is the live equivalent.
 
   /**
    * Helper method to update status

--- a/packages/cli/tests/integration/command-dry-run.integration.test.ts
+++ b/packages/cli/tests/integration/command-dry-run.integration.test.ts
@@ -3,7 +3,7 @@
  *
  * Audits dry-run contract across all `command` subcommands that mutate fs/frontmatter:
  * rename-to-uid, update-label, start, complete, trash, archive,
- * move-to-backlog, move-to-analysis, move-to-todo, schedule, set-deadline,
+ * move-to-backlog, schedule, set-deadline,
  * create-task, create-meeting, create-project, create-area.
  *
  * Uses real filesystem (temp dir), not mocks — to guarantee fs contract.
@@ -126,8 +126,6 @@ describe("Issue #3111: `command --dry-run` filesystem contract", () => {
       ["trash", (e) => e.executeTrash("task.md")],
       ["archive", (e) => e.executeArchive("task.md")],
       ["move-to-backlog", (e) => e.executeMoveToBacklog("task.md")],
-      ["move-to-analysis", (e) => e.executeMoveToAnalysis("task.md")],
-      ["move-to-todo", (e) => e.executeMoveToToDo("task.md")],
     ];
 
     it.each(cases)("%s does not mutate file", async (_name, fn) => {

--- a/packages/cli/tests/unit/executors/BatchExecutor.test.ts
+++ b/packages/cli/tests/unit/executors/BatchExecutor.test.ts
@@ -449,36 +449,20 @@ describe("BatchExecutor", () => {
       });
     });
 
-    describe("move-to-analysis command", () => {
-      it("should update status to Analysis", async () => {
-        const result = await executor.executeBatch([
-          { command: "move-to-analysis", filepath: "task.md" },
-        ]);
+    // `move-to-analysis` / `move-to-todo` were removed with req
+    // fcbde537-f09a-410e-8bee-d3d607a70302 — both wrote a status whose TBox
+    // instance no longer exists. They now fall through to the unknown-command
+    // branch instead of silently writing a dangling wikilink.
+    describe("removed dead-status commands", () => {
+      it.each(["move-to-analysis", "move-to-todo"])(
+        "@req:fcbde537-f09a-410e-8bee-d3d607a70302 %s is rejected as unknown",
+        async (command) => {
+          const result = await executor.executeBatch([{ command, filepath: "task.md" }]);
 
-        expect(result.results[0].success).toBe(true);
-        expect(result.results[0].action).toBe("Moved to analysis");
-        expect(mockFrontmatterService.updateProperty).toHaveBeenCalledWith(
-          expect.any(String),
-          "ems__Effort_status",
-          '"[[ems__EffortStatusAnalysis]]"',
-        );
-      });
-    });
-
-    describe("move-to-todo command", () => {
-      it("should update status to ToDo", async () => {
-        const result = await executor.executeBatch([
-          { command: "move-to-todo", filepath: "task.md" },
-        ]);
-
-        expect(result.results[0].success).toBe(true);
-        expect(result.results[0].action).toBe("Moved to todo");
-        expect(mockFrontmatterService.updateProperty).toHaveBeenCalledWith(
-          expect.any(String),
-          "ems__Effort_status",
-          '"[[ems__EffortStatusToDo]]"',
-        );
-      });
+          expect(result.results[0].success).toBe(false);
+          expect(mockFrontmatterService.updateProperty).not.toHaveBeenCalled();
+        },
+      );
     });
 
     describe("update-label command", () => {

--- a/packages/cli/tests/unit/executors/CommandExecutor.test.ts
+++ b/packages/cli/tests/unit/executors/CommandExecutor.test.ts
@@ -548,48 +548,6 @@ describe("CommandExecutor", () => {
     });
   });
 
-  describe("executeMoveToAnalysis()", () => {
-    beforeEach(() => {
-      mockPathResolverInstance.resolve.mockReturnValue("/test/vault/project.md");
-      mockFsAdapterInstance.readFile.mockResolvedValue("---\nexo__Asset_label: My Project\n---\n# Content");
-    });
-
-    it("should transition to Analysis status", async () => {
-      await executor.executeMoveToAnalysis("project.md");
-
-      expect(processExitSpy).toHaveBeenCalledWith(0);
-      expect(mockFsAdapterInstance.updateFile).toHaveBeenCalled();
-    });
-
-    it("should display status confirmation", async () => {
-      await executor.executeMoveToAnalysis("project.md");
-
-      expect(processExitSpy).toHaveBeenCalledWith(0);
-      expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining("Moved to Analysis:"));
-    });
-  });
-
-  describe("executeMoveToToDo()", () => {
-    beforeEach(() => {
-      mockPathResolverInstance.resolve.mockReturnValue("/test/vault/task.md");
-      mockFsAdapterInstance.readFile.mockResolvedValue("---\nexo__Asset_label: My Task\n---\n# Content");
-    });
-
-    it("should transition to ToDo status", async () => {
-      await executor.executeMoveToToDo("task.md");
-
-      expect(processExitSpy).toHaveBeenCalledWith(0);
-      expect(mockFsAdapterInstance.updateFile).toHaveBeenCalled();
-    });
-
-    it("should display status confirmation", async () => {
-      await executor.executeMoveToToDo("task.md");
-
-      expect(processExitSpy).toHaveBeenCalledWith(0);
-      expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining("Moved to ToDo:"));
-    });
-  });
-
   describe("executeCreateTask()", () => {
     beforeEach(() => {
       mockPathResolverInstance.resolve.mockReturnValue("/test/vault/task.md");

--- a/packages/core/src/domain/constants/EffortStatus.ts
+++ b/packages/core/src/domain/constants/EffortStatus.ts
@@ -28,13 +28,21 @@
  *
  * New code should not introduce additional dependencies on this enum.
  * Resolve UUIDs at runtime via the TBox lookup instead.
+ *
+ * **This enum MIRRORS the shared ontology — a member without a TBox instance
+ * is a defect** (req `fcbde537-f09a-410e-8bee-d3d607a70302`). `ToDo`
+ * (`6a0e933a-…`) and `Analysis` (`cde3525c-…`) were deleted from
+ * `exoas-public` on 2026-08-13 (commit `c35a660d`) and removed here; the
+ * parking status `Waiting` (`0610947c-…`) shipped in their place. Before
+ * adding a member, resolve its `ems__EffortStatus<Name>` asset on disk —
+ * every value below is written into user frontmatter, so a value with no
+ * asset becomes a dangling wikilink no workflow can express.
  */
 export enum EffortStatus {
   DRAFT = "ems__EffortStatusDraft",
   BACKLOG = "ems__EffortStatusBacklog",
-  ANALYSIS = "ems__EffortStatusAnalysis",
-  TODO = "ems__EffortStatusToDo",
   DOING = "ems__EffortStatusDoing",
+  WAITING = "ems__EffortStatusWaiting",
   DONE = "ems__EffortStatusDone",
   TRASHED = "ems__EffortStatusTrashed",
 }

--- a/packages/core/src/domain/constants/EffortStatusOptions.ts
+++ b/packages/core/src/domain/constants/EffortStatusOptions.ts
@@ -26,6 +26,11 @@
  *
  * Sole production consumer: `StatusSelectPropertyField`
  * (`packages/obsidian-plugin/src/presentation/components/property-fields/StatusSelectPropertyField.ts`).
+ *
+ * Every entry is written verbatim into user frontmatter, so the list MUST
+ * mirror the shared ontology (req `fcbde537-f09a-410e-8bee-d3d607a70302`):
+ * `Analysis` / `To Do` were removed when their TBox instances were deleted
+ * (`exoas-public@c35a660d`), `Waiting` added in their place.
  */
 export const EFFORT_STATUS_OPTIONS: ReadonlyArray<{
   readonly value: string;
@@ -33,9 +38,8 @@ export const EFFORT_STATUS_OPTIONS: ReadonlyArray<{
 }> = [
   { value: "[[ems__EffortStatusDraft]]", label: "Draft" },
   { value: "[[ems__EffortStatusBacklog]]", label: "Backlog" },
-  { value: "[[ems__EffortStatusAnalysis]]", label: "Analysis" },
-  { value: "[[ems__EffortStatusToDo]]", label: "To Do" },
   { value: "[[ems__EffortStatusDoing]]", label: "Doing" },
+  { value: "[[ems__EffortStatusWaiting]]", label: "Waiting" },
   { value: "[[ems__EffortStatusDone]]", label: "Done" },
   { value: "[[ems__EffortStatusTrashed]]", label: "Trashed" },
 ] as const;

--- a/packages/core/src/domain/defaults/DefaultWorkflows.ts
+++ b/packages/core/src/domain/defaults/DefaultWorkflows.ts
@@ -12,8 +12,18 @@ import { MetadataHelpers } from "../../utilities/MetadataHelpers";
 /**
  * Default workflow definition for ems__Project assets.
  *
- * States: Draft -> Backlog -> Analysis -> ToDo -> Doing -> Done | Trashed
+ * States: Draft -> Backlog -> Doing -> Done | Trashed
  * Issue #2363
+ *
+ * The intermediate `Analysis` / `ToDo` states were dropped with req
+ * `fcbde537-f09a-410e-8bee-d3d607a70302`: their TBox instances were deleted
+ * from the shared ontology (`exoas-public@c35a660d`, 2026-08-13), so every
+ * transition into them wrote a dangling wikilink. `Waiting` (the parking
+ * status that replaced them) is deliberately NOT a state here — the workflow
+ * engine keys transitions on `(from, isRollback)`, so a state can offer at
+ * most one forward and one rollback target; parking is a side branch reached
+ * by the vault-declared `park-waiting` command (a `property_set`), not a
+ * workflow transition.
  */
 export const PROJECT_DEFAULT_WORKFLOW: WorkflowDefinition = {
   id: "a1b2c3d4-1111-4000-a000-000000000001",
@@ -25,22 +35,16 @@ export const PROJECT_DEFAULT_WORKFLOW: WorkflowDefinition = {
   states: [
     { status: EffortStatus.DRAFT, order: 1, optional: false, timestampOnEnter: [] },
     { status: EffortStatus.BACKLOG, order: 2, optional: false, timestampOnEnter: [] },
-    { status: EffortStatus.ANALYSIS, order: 3, optional: true, timestampOnEnter: [] },
-    { status: EffortStatus.TODO, order: 4, optional: true, timestampOnEnter: [] },
-    { status: EffortStatus.DOING, order: 5, optional: false, timestampOnEnter: ["ems__Effort_startTimestamp"] },
-    { status: EffortStatus.DONE, order: 6, optional: false, timestampOnEnter: ["ems__Effort_endTimestamp", "ems__Effort_resolutionTimestamp"] },
-    { status: EffortStatus.TRASHED, order: 7, optional: false, timestampOnEnter: ["ems__Effort_resolutionTimestamp"] },
+    { status: EffortStatus.DOING, order: 3, optional: false, timestampOnEnter: ["ems__Effort_startTimestamp"] },
+    { status: EffortStatus.DONE, order: 4, optional: false, timestampOnEnter: ["ems__Effort_endTimestamp", "ems__Effort_resolutionTimestamp"] },
+    { status: EffortStatus.TRASHED, order: 5, optional: false, timestampOnEnter: ["ems__Effort_resolutionTimestamp"] },
   ],
   transitions: [
     { from: EffortStatus.DRAFT, to: EffortStatus.BACKLOG, label: "\u2192 Backlog", isRollback: false },
-    { from: EffortStatus.BACKLOG, to: EffortStatus.ANALYSIS, label: "\u2192 Analysis", isRollback: false },
-    { from: EffortStatus.ANALYSIS, to: EffortStatus.TODO, label: "\u2192 ToDo", isRollback: false },
-    { from: EffortStatus.TODO, to: EffortStatus.DOING, label: "\u25B6 Start", isRollback: false },
+    { from: EffortStatus.BACKLOG, to: EffortStatus.DOING, label: "\u25B6 Start", isRollback: false },
     { from: EffortStatus.DOING, to: EffortStatus.DONE, label: "\u2713 Done", isRollback: false },
     { from: EffortStatus.BACKLOG, to: EffortStatus.DRAFT, label: "\u2190 Draft", isRollback: true },
-    { from: EffortStatus.ANALYSIS, to: EffortStatus.BACKLOG, label: "\u2190 Backlog", isRollback: true },
-    { from: EffortStatus.TODO, to: EffortStatus.ANALYSIS, label: "\u2190 Analysis", isRollback: true },
-    { from: EffortStatus.DOING, to: EffortStatus.TODO, label: "\u2190 ToDo", isRollback: true },
+    { from: EffortStatus.DOING, to: EffortStatus.BACKLOG, label: "\u2190 Backlog", isRollback: true },
     { from: EffortStatus.DONE, to: EffortStatus.DOING, label: "\u2190 Doing", isRollback: true },
   ],
 };

--- a/packages/core/src/services/GroundingExecutor.ts
+++ b/packages/core/src/services/GroundingExecutor.ts
@@ -57,9 +57,8 @@ import { LoggingService } from "./LoggingService";
 export const STATUS_UID_BY_ENUM: Readonly<Record<EffortStatus, string>> = {
   [EffortStatus.DRAFT]:    "c42245d0-01de-4c35-bfcf-d910445ea28e",
   [EffortStatus.BACKLOG]:  "753a44d5-846c-4b82-9196-4fd9a4d48777",
-  [EffortStatus.ANALYSIS]: "cde3525c-57ea-4efc-b477-2e7e7ccd3a1e",
-  [EffortStatus.TODO]:     "6a0e933a-6653-46f4-95ae-ed7508177c73",
   [EffortStatus.DOING]:    "027e78f4-6e16-4b36-b8fb-5510507d5745",
+  [EffortStatus.WAITING]:  "0610947c-6a62-41c8-9d44-7863d3ba3a8e",
   [EffortStatus.DONE]:     "7b9b3116-7c3c-438c-9618-94fe301320a6",
   [EffortStatus.TRASHED]:  "5d14f18d-db2b-4847-9ac1-144cb93b2541",
 };

--- a/packages/core/tests/domain/constants/EffortStatus.test.ts
+++ b/packages/core/tests/domain/constants/EffortStatus.test.ts
@@ -9,16 +9,12 @@ describe("EffortStatus", () => {
     expect(EffortStatus.BACKLOG).toBe("ems__EffortStatusBacklog");
   });
 
-  it("should have ANALYSIS constant", () => {
-    expect(EffortStatus.ANALYSIS).toBe("ems__EffortStatusAnalysis");
-  });
-
-  it("should have TODO constant", () => {
-    expect(EffortStatus.TODO).toBe("ems__EffortStatusToDo");
-  });
-
   it("should have DOING constant", () => {
     expect(EffortStatus.DOING).toBe("ems__EffortStatusDoing");
+  });
+
+  it("should have WAITING constant", () => {
+    expect(EffortStatus.WAITING).toBe("ems__EffortStatusWaiting");
   });
 
   it("should have DONE constant", () => {
@@ -29,8 +25,8 @@ describe("EffortStatus", () => {
     expect(EffortStatus.TRASHED).toBe("ems__EffortStatusTrashed");
   });
 
-  it("should have exactly 7 statuses", () => {
+  it("should have exactly 6 statuses", () => {
     const values = Object.values(EffortStatus);
-    expect(values).toHaveLength(7);
+    expect(values).toHaveLength(6);
   });
 });

--- a/packages/core/tests/domain/constants/EffortStatusOptions.test.ts
+++ b/packages/core/tests/domain/constants/EffortStatusOptions.test.ts
@@ -1,8 +1,8 @@
 import { EFFORT_STATUS_OPTIONS } from "../../../src/domain/constants";
 
 describe("EFFORT_STATUS_OPTIONS (RFC 31c1a0be Phase 4 PR-D, #3194)", () => {
-  it("should expose 7 options with value and label", () => {
-    expect(EFFORT_STATUS_OPTIONS).toHaveLength(7);
+  it("should expose 6 options with value and label", () => {
+    expect(EFFORT_STATUS_OPTIONS).toHaveLength(6);
     for (const opt of EFFORT_STATUS_OPTIONS) {
       expect(opt.value).toMatch(/^\[\[ems__EffortStatus\w+\]\]$/);
       expect(opt.label).toBeTruthy();

--- a/packages/core/tests/domain/defaults/DefaultWorkflows.test.ts
+++ b/packages/core/tests/domain/defaults/DefaultWorkflows.test.ts
@@ -12,12 +12,12 @@ describe("DefaultWorkflows", () => {
       expect(PROJECT_DEFAULT_WORKFLOW.targetClass).toBe(AssetClass.PROJECT);
     });
 
-    it("should have 7 states", () => {
-      expect(PROJECT_DEFAULT_WORKFLOW.states).toHaveLength(7);
+    it("should have 5 states", () => {
+      expect(PROJECT_DEFAULT_WORKFLOW.states).toHaveLength(5);
     });
 
-    it("should have 10 transitions", () => {
-      expect(PROJECT_DEFAULT_WORKFLOW.transitions).toHaveLength(10);
+    it("should have 6 transitions", () => {
+      expect(PROJECT_DEFAULT_WORKFLOW.transitions).toHaveLength(6);
     });
 
     it("should have DRAFT as initial state", () => {
@@ -37,14 +37,14 @@ describe("DefaultWorkflows", () => {
 
     it("should have states in correct order", () => {
       const orders = PROJECT_DEFAULT_WORKFLOW.states.map((s) => s.order);
-      expect(orders).toEqual([1, 2, 3, 4, 5, 6, 7]);
+      expect(orders).toEqual([1, 2, 3, 4, 5]);
     });
 
-    it("should have Analysis and ToDo as optional states", () => {
+    it("should have no optional states (Analysis/ToDo dropped with req fcbde537)", () => {
       const optionalStates = PROJECT_DEFAULT_WORKFLOW.states
         .filter((s) => s.optional)
         .map((s) => s.status);
-      expect(optionalStates).toEqual([EffortStatus.ANALYSIS, EffortStatus.TODO]);
+      expect(optionalStates).toEqual([]);
     });
 
     it("should set startTimestamp when entering DOING", () => {
@@ -62,11 +62,11 @@ describe("DefaultWorkflows", () => {
       expect(doneState?.timestampOnEnter).toContain("ems__Effort_resolutionTimestamp");
     });
 
-    it("should have 5 forward and 5 rollback transitions", () => {
+    it("should have 3 forward and 3 rollback transitions", () => {
       const forward = PROJECT_DEFAULT_WORKFLOW.transitions.filter((t) => !t.isRollback);
       const rollback = PROJECT_DEFAULT_WORKFLOW.transitions.filter((t) => t.isRollback);
-      expect(forward).toHaveLength(5);
-      expect(rollback).toHaveLength(5);
+      expect(forward).toHaveLength(3);
+      expect(rollback).toHaveLength(3);
     });
   });
 
@@ -119,8 +119,8 @@ describe("DefaultWorkflows", () => {
   describe("buildWorkflowAssetContent", () => {
     it("should generate correct number of files for project workflow", () => {
       const files = buildWorkflowAssetContent(PROJECT_DEFAULT_WORKFLOW);
-      // 1 workflow + 7 states + 10 transitions = 18
-      expect(files).toHaveLength(18);
+      // 1 workflow + 5 states + 6 transitions = 12
+      expect(files).toHaveLength(12);
     });
 
     it("should generate correct number of files for task workflow", () => {

--- a/packages/core/tests/integration/status-model/dead-status-values.integration.test.ts
+++ b/packages/core/tests/integration/status-model/dead-status-values.integration.test.ts
@@ -1,0 +1,109 @@
+/**
+ * @req:fcbde537-f09a-410e-8bee-d3d607a70302 — no code path writes an
+ * `ems__EffortStatus*` value that has no TBox instance.
+ *
+ * `ems__EffortStatusToDo` (`6a0e933a-…`) and `ems__EffortStatusAnalysis`
+ * (`cde3525c-…`) were deleted from the shared ontology on 2026-08-13
+ * (`exoas-public@c35a660d`); the parking status `ems__EffortStatusWaiting`
+ * (`0610947c-…`) shipped in their place. Every constant asserted here is
+ * written verbatim into user frontmatter, so a value with no asset behind it
+ * becomes a dangling wikilink that no workflow can express.
+ *
+ * Each `describe` block is an independent revert-verify axis: restoring a dead
+ * value in ONE source reddens ONLY that block.
+ */
+import { EffortStatus } from "../../../src/domain/constants/EffortStatus";
+import { EFFORT_STATUS_OPTIONS } from "../../../src/domain/constants";
+import { STATUS_UID_BY_ENUM } from "../../../src/services/GroundingExecutor";
+import {
+  PROJECT_DEFAULT_WORKFLOW,
+  TASK_DEFAULT_WORKFLOW,
+} from "../../../src/domain/defaults/DefaultWorkflows";
+
+/** Symbolic + UUID forms of every status deleted from the shared ontology. */
+const DELETED_STATUS_TOKENS = [
+  "ems__EffortStatusToDo",
+  "ems__EffortStatusAnalysis",
+  "6a0e933a-6653-46f4-95ae-ed7508177c73",
+  "cde3525c-57ea-4efc-b477-2e7e7ccd3a1e",
+] as const;
+
+const WAITING_SYMBOLIC = "ems__EffortStatusWaiting";
+const WAITING_UID = "0610947c-6a62-41c8-9d44-7863d3ba3a8e";
+
+/** Both wikilink forms a value can reach frontmatter in. */
+function tokensIn(value: unknown): string {
+  return JSON.stringify(value);
+}
+
+describe("@req:fcbde537-f09a-410e-8bee-d3d607a70302 EffortStatus enum mirrors the ontology", () => {
+  it("carries no status whose TBox instance was deleted", () => {
+    const serialized = tokensIn(Object.values(EffortStatus));
+    for (const dead of DELETED_STATUS_TOKENS) {
+      expect(serialized).not.toContain(dead);
+    }
+  });
+
+  it("carries the parking status that replaced them", () => {
+    expect(Object.values(EffortStatus)).toContain(WAITING_SYMBOLIC);
+  });
+});
+
+describe("@req:fcbde537-f09a-410e-8bee-d3d607a70302 STATUS_UID_BY_ENUM resolves to live TBox files", () => {
+  it("maps no enum member onto a deleted status UID", () => {
+    const serialized = tokensIn(STATUS_UID_BY_ENUM);
+    for (const dead of DELETED_STATUS_TOKENS) {
+      expect(serialized).not.toContain(dead);
+    }
+  });
+
+  it("maps WAITING onto the shipped Waiting UID", () => {
+    expect(STATUS_UID_BY_ENUM[EffortStatus.WAITING]).toBe(WAITING_UID);
+  });
+
+  it("covers every enum member exactly once", () => {
+    const members = Object.values(EffortStatus);
+    expect(Object.keys(STATUS_UID_BY_ENUM).sort()).toEqual([...members].sort());
+    expect(new Set(Object.values(STATUS_UID_BY_ENUM)).size).toBe(members.length);
+  });
+});
+
+describe("@req:fcbde537-f09a-410e-8bee-d3d607a70302 EFFORT_STATUS_OPTIONS offers only live statuses", () => {
+  it("offers no deleted status in the dropdown", () => {
+    const serialized = tokensIn(EFFORT_STATUS_OPTIONS);
+    for (const dead of DELETED_STATUS_TOKENS) {
+      expect(serialized).not.toContain(dead);
+    }
+  });
+
+  it("offers Waiting", () => {
+    const waiting = EFFORT_STATUS_OPTIONS.find((o) => o.label === "Waiting");
+    expect(waiting?.value).toBe(`[[${WAITING_SYMBOLIC}]]`);
+  });
+});
+
+describe("@req:fcbde537-f09a-410e-8bee-d3d607a70302 default workflows never transition into a deleted status", () => {
+  for (const [name, workflow] of [
+    ["PROJECT_DEFAULT_WORKFLOW", PROJECT_DEFAULT_WORKFLOW],
+    ["TASK_DEFAULT_WORKFLOW", TASK_DEFAULT_WORKFLOW],
+  ] as const) {
+    it(`${name} references no deleted status in its states or transitions`, () => {
+      const serialized = tokensIn({
+        states: workflow.states,
+        transitions: workflow.transitions,
+        initialState: workflow.initialState,
+        terminalStates: workflow.terminalStates,
+      });
+      for (const dead of DELETED_STATUS_TOKENS) {
+        expect(serialized).not.toContain(dead);
+      }
+    });
+  }
+
+  it("keeps Backlog → Doing reachable in the Project fallback", () => {
+    const forward = PROJECT_DEFAULT_WORKFLOW.transitions.find(
+      (t) => t.from === EffortStatus.BACKLOG && !t.isRollback,
+    );
+    expect(forward?.to).toBe(EffortStatus.DOING);
+  });
+});

--- a/packages/core/tests/unit/services/GroundingExecutor.status_uid_integrity.test.ts
+++ b/packages/core/tests/unit/services/GroundingExecutor.status_uid_integrity.test.ts
@@ -53,9 +53,9 @@ describe("RFC 36347daf Phase 2 — STATUS_UID_BY_ENUM integrity", () => {
     }
   });
 
-  it("7 unique UIDs (no collisions)", () => {
+  it("6 unique UIDs (no collisions)", () => {
     const uids = Object.values(STATUS_UID_BY_ENUM);
-    expect(new Set(uids).size).toBe(7);
+    expect(new Set(uids).size).toBe(6);
   });
 
   it("pins the known status UIDs (drift catches when this fixture lies)", () => {
@@ -69,14 +69,11 @@ describe("RFC 36347daf Phase 2 — STATUS_UID_BY_ENUM integrity", () => {
     expect(STATUS_UID_BY_ENUM[EffortStatus.BACKLOG]).toBe(
       "753a44d5-846c-4b82-9196-4fd9a4d48777",
     );
-    expect(STATUS_UID_BY_ENUM[EffortStatus.ANALYSIS]).toBe(
-      "cde3525c-57ea-4efc-b477-2e7e7ccd3a1e",
-    );
-    expect(STATUS_UID_BY_ENUM[EffortStatus.TODO]).toBe(
-      "6a0e933a-6653-46f4-95ae-ed7508177c73",
-    );
     expect(STATUS_UID_BY_ENUM[EffortStatus.DOING]).toBe(
       "027e78f4-6e16-4b36-b8fb-5510507d5745",
+    );
+    expect(STATUS_UID_BY_ENUM[EffortStatus.WAITING]).toBe(
+      "0610947c-6a62-41c8-9d44-7863d3ba3a8e",
     );
     expect(STATUS_UID_BY_ENUM[EffortStatus.DONE]).toBe(
       "7b9b3116-7c3c-438c-9618-94fe301320a6",

--- a/packages/core/tests/unit/services/VisibilityGenerator.test.ts
+++ b/packages/core/tests/unit/services/VisibilityGenerator.test.ts
@@ -23,16 +23,16 @@ describe("VisibilityGenerator", () => {
       gen = new VisibilityGenerator(getProjectEngine());
     });
 
-    it("should return Analysis as forward command from Backlog", () => {
+    it("should return Doing as forward command from Backlog", () => {
       const cmds = gen.getForwardCommands(EffortStatus.BACKLOG);
       const targets = cmds.map(c => c.targetStatus);
-      expect(targets).toContain(EffortStatus.ANALYSIS);
+      expect(targets).toContain(EffortStatus.DOING);
     });
 
-    it("should return ToDo as rollback command from Doing", () => {
+    it("should return Backlog as rollback command from Doing", () => {
       const cmds = gen.getRollbackCommands(EffortStatus.DOING);
       const targets = cmds.map(c => c.targetStatus);
-      expect(targets).toContain(EffortStatus.TODO);
+      expect(targets).toContain(EffortStatus.BACKLOG);
     });
 
     it("should include both forward and rollback in getVisibleCommands", () => {
@@ -50,11 +50,10 @@ describe("VisibilityGenerator", () => {
       gen = new VisibilityGenerator(getTaskEngine());
     });
 
-    it("should return Doing as forward command from Backlog (no Analysis)", () => {
+    it("should return Doing as the only forward command from Backlog", () => {
       const cmds = gen.getForwardCommands(EffortStatus.BACKLOG);
       const targets = cmds.map(c => c.targetStatus);
-      expect(targets).toContain(EffortStatus.DOING);
-      expect(targets).not.toContain(EffortStatus.ANALYSIS);
+      expect(targets).toEqual([EffortStatus.DOING]);
     });
 
     it("should return Backlog as rollback from Doing", () => {

--- a/packages/core/tests/unit/services/WorkflowCommandAdapter.test.ts
+++ b/packages/core/tests/unit/services/WorkflowCommandAdapter.test.ts
@@ -18,7 +18,7 @@ function createMinimalWorkflow(
     isDefault: true,
     states: [
       { status: EffortStatus.BACKLOG, order: 0, optional: false, timestampOnEnter: [] },
-      { status: EffortStatus.TODO, order: 1, optional: false, timestampOnEnter: [] },
+      { status: EffortStatus.WAITING, order: 1, optional: false, timestampOnEnter: [] },
       {
         status: EffortStatus.DOING,
         order: 2,
@@ -34,10 +34,10 @@ function createMinimalWorkflow(
       { status: EffortStatus.TRASHED, order: 4, optional: false, timestampOnEnter: [] },
     ],
     transitions: [
-      { from: EffortStatus.BACKLOG, to: EffortStatus.TODO, label: "→ Todo", isRollback: false },
-      { from: EffortStatus.TODO, to: EffortStatus.DOING, label: "▶ Start", icon: "play", isRollback: false },
+      { from: EffortStatus.BACKLOG, to: EffortStatus.WAITING, label: "→ Todo", isRollback: false },
+      { from: EffortStatus.WAITING, to: EffortStatus.DOING, label: "▶ Start", icon: "play", isRollback: false },
       { from: EffortStatus.DOING, to: EffortStatus.DONE, label: "✓ Done", icon: "check", isRollback: false },
-      { from: EffortStatus.DOING, to: EffortStatus.TODO, label: "← Back", icon: "undo", isRollback: true },
+      { from: EffortStatus.DOING, to: EffortStatus.WAITING, label: "← Back", icon: "undo", isRollback: true },
       { from: EffortStatus.BACKLOG, to: EffortStatus.TRASHED, label: "🗑 Trash", icon: "trash", isRollback: false },
     ],
     ...overrides,
@@ -82,25 +82,25 @@ describe("WorkflowCommandAdapter", () => {
     it("should generate deterministic command IDs", () => {
       const commands = adapter.adaptTransitions(EffortStatus.BACKLOG);
 
-      expect(commands[0].id).toBe("workflow-backlog-to-todo");
+      expect(commands[0].id).toBe("workflow-backlog-to-waiting");
       expect(commands[1].id).toBe("workflow-backlog-to-trashed");
     });
 
     it("should preserve transition label as command name", () => {
-      const commands = adapter.adaptTransitions(EffortStatus.TODO);
+      const commands = adapter.adaptTransitions(EffortStatus.WAITING);
 
       expect(commands[0].name).toBe("▶ Start");
     });
 
     it("should preserve transition icon", () => {
-      const commands = adapter.adaptTransitions(EffortStatus.TODO);
+      const commands = adapter.adaptTransitions(EffortStatus.WAITING);
 
       expect(commands[0].icon).toBe("play");
     });
 
     it("should handle transitions without icon", () => {
       const commands = adapter.adaptTransitions(EffortStatus.BACKLOG);
-      const todoCmd = commands.find((c) => c.id === "workflow-backlog-to-todo");
+      const todoCmd = commands.find((c) => c.id === "workflow-backlog-to-waiting");
 
       expect(todoCmd?.icon).toBeUndefined();
     });
@@ -110,19 +110,19 @@ describe("WorkflowCommandAdapter", () => {
 
   describe("preconditions", () => {
     it("should build precondition with SPARQL ASK checking from-status", () => {
-      const commands = adapter.adaptTransitions(EffortStatus.TODO);
+      const commands = adapter.adaptTransitions(EffortStatus.WAITING);
       const precondition = commands[0].precondition;
 
       expect(precondition).toBeDefined();
-      expect(precondition!.id).toBe("precond-workflow-todo-to-doing");
-      expect(precondition!.sparqlAsk).toContain(EffortStatus.TODO);
+      expect(precondition!.id).toBe("precond-workflow-waiting-to-doing");
+      expect(precondition!.sparqlAsk).toContain(EffortStatus.WAITING);
       expect(precondition!.sparqlAsk).toContain("$target");
     });
 
     it("should include human-readable label in precondition", () => {
-      const commands = adapter.adaptTransitions(EffortStatus.TODO);
+      const commands = adapter.adaptTransitions(EffortStatus.WAITING);
 
-      expect(commands[0].precondition!.label).toContain("todo");
+      expect(commands[0].precondition!.label).toContain("waiting");
     });
   });
 
@@ -130,7 +130,7 @@ describe("WorkflowCommandAdapter", () => {
 
   describe("grounding", () => {
     it("should build composite grounding with status + timestamps", () => {
-      const commands = adapter.adaptTransitions(EffortStatus.TODO);
+      const commands = adapter.adaptTransitions(EffortStatus.WAITING);
       const startCmd = commands[0]; // Todo → Doing
 
       // Doing has timestampOnEnter: ["ems__Effort_startTimestamp"]
@@ -139,7 +139,7 @@ describe("WorkflowCommandAdapter", () => {
     });
 
     it("should set status property as first grounding step", () => {
-      const commands = adapter.adaptTransitions(EffortStatus.TODO);
+      const commands = adapter.adaptTransitions(EffortStatus.WAITING);
       const steps = commands[0].grounding.steps!;
 
       // RFC 31c1a0be Phase 1 + RFC 918a2b65 Phase 4: status emitted via
@@ -150,7 +150,7 @@ describe("WorkflowCommandAdapter", () => {
     });
 
     it("should set timestamps as subsequent grounding steps", () => {
-      const commands = adapter.adaptTransitions(EffortStatus.TODO);
+      const commands = adapter.adaptTransitions(EffortStatus.WAITING);
       const steps = commands[0].grounding.steps!;
 
       // Timestamp emitted via typed `targetValueSubstitution` ($now token).
@@ -161,12 +161,12 @@ describe("WorkflowCommandAdapter", () => {
 
     it("should return simple grounding when no timestamps", () => {
       const commands = adapter.adaptTransitions(EffortStatus.BACKLOG);
-      const todoCmd = commands.find((c) => c.id === "workflow-backlog-to-todo");
+      const todoCmd = commands.find((c) => c.id === "workflow-backlog-to-waiting");
 
       // Todo has no timestampOnEnter → single property_set, not composite
       expect(todoCmd!.grounding.type).toBe(GroundingType.PROPERTY_SET);
       expect(todoCmd!.grounding.targetProperty).toBe("ems__Effort_status");
-      expect(todoCmd!.grounding.targetValueRef).toBe(EffortStatus.TODO);
+      expect(todoCmd!.grounding.targetValueRef).toBe(EffortStatus.WAITING);
       expect(todoCmd!.grounding.steps).toBeUndefined();
     });
 
@@ -206,7 +206,7 @@ describe("WorkflowCommandAdapter", () => {
 
   describe("category", () => {
     it("should set category to 'workflow' for forward transitions", () => {
-      const commands = adapter.adaptTransitions(EffortStatus.TODO);
+      const commands = adapter.adaptTransitions(EffortStatus.WAITING);
 
       expect(commands[0].category).toBe("workflow");
     });
@@ -216,7 +216,7 @@ describe("WorkflowCommandAdapter", () => {
       const rollbackCmd = commands.find((c) => c.category === "rollback");
 
       expect(rollbackCmd).toBeDefined();
-      expect(rollbackCmd!.id).toBe("workflow-doing-to-todo");
+      expect(rollbackCmd!.id).toBe("workflow-doing-to-waiting");
     });
   });
 
@@ -228,17 +228,17 @@ describe("WorkflowCommandAdapter", () => {
       const rollbackCmd = commands.find((c) => c.category === "rollback");
 
       expect(rollbackCmd!.confirmMessage).toContain("Rollback");
-      expect(rollbackCmd!.confirmMessage).toContain("todo");
+      expect(rollbackCmd!.confirmMessage).toContain("waiting");
     });
 
     it("should not set confirmMessage for forward transitions", () => {
-      const commands = adapter.adaptTransitions(EffortStatus.TODO);
+      const commands = adapter.adaptTransitions(EffortStatus.WAITING);
 
       expect(commands[0].confirmMessage).toBeUndefined();
     });
 
     it("should set successMessage for all transitions", () => {
-      const commands = adapter.adaptTransitions(EffortStatus.TODO);
+      const commands = adapter.adaptTransitions(EffortStatus.WAITING);
 
       expect(commands[0].successMessage).toContain("doing");
     });
@@ -262,7 +262,7 @@ describe("WorkflowCommandAdapter", () => {
 
       expect(commands).toHaveLength(1);
       expect(commands[0].category).toBe("rollback");
-      expect(commands[0].id).toBe("workflow-doing-to-todo");
+      expect(commands[0].id).toBe("workflow-doing-to-waiting");
     });
 
     it("should return empty when no rollback available", () => {
@@ -278,7 +278,7 @@ describe("WorkflowCommandAdapter", () => {
     it("should expose the underlying WorkflowEngine", () => {
       const engine = adapter.getEngine();
 
-      expect(engine.canTransition(EffortStatus.BACKLOG, EffortStatus.TODO)).toBe(true);
+      expect(engine.canTransition(EffortStatus.BACKLOG, EffortStatus.WAITING)).toBe(true);
     });
   });
 
@@ -307,7 +307,7 @@ describe("WorkflowCommandAdapter", () => {
     it("should match VisibilityGenerator command ID format", () => {
       // VisibilityGenerator uses: workflow-{fromShort}-to-{toShort}
       // where fromShort = t.from.replace("ems__EffortStatus", "").toLowerCase()
-      const commands = adapter.adaptTransitions(EffortStatus.TODO);
+      const commands = adapter.adaptTransitions(EffortStatus.WAITING);
 
       expect(commands[0].id).toMatch(/^workflow-[a-z]+-to-[a-z]+$/);
     });

--- a/packages/core/tests/unit/services/WorkflowEngine.test.ts
+++ b/packages/core/tests/unit/services/WorkflowEngine.test.ts
@@ -48,19 +48,14 @@ describe("WorkflowEngine", () => {
       engine = new WorkflowEngine(getProjectWorkflow());
     });
 
-    it("should return Analysis as next state from Backlog", () => {
+    it("should return Doing as next state from Backlog", () => {
       const next = engine.getNextStates(EffortStatus.BACKLOG);
-      expect(next).toContain(EffortStatus.ANALYSIS);
-    });
-
-    it("should return ToDo as next state from Analysis", () => {
-      const next = engine.getNextStates(EffortStatus.ANALYSIS);
-      expect(next).toContain(EffortStatus.TODO);
-    });
-
-    it("should return Doing as next state from ToDo", () => {
-      const next = engine.getNextStates(EffortStatus.TODO);
       expect(next).toContain(EffortStatus.DOING);
+    });
+
+    it("should return Done as next state from Doing", () => {
+      const next = engine.getNextStates(EffortStatus.DOING);
+      expect(next).toContain(EffortStatus.DONE);
     });
 
     it("should allow transition from Draft to Backlog", () => {
@@ -71,9 +66,9 @@ describe("WorkflowEngine", () => {
       expect(engine.canTransition(EffortStatus.DRAFT, EffortStatus.DOING)).toBe(false);
     });
 
-    it("should rollback DOING to ToDo (not Backlog)", () => {
+    it("should rollback DOING to Backlog", () => {
       const prev = engine.getPreviousStatus(EffortStatus.DOING);
-      expect(prev).toBe(EffortStatus.TODO);
+      expect(prev).toBe(EffortStatus.BACKLOG);
     });
 
     it("should rollback DONE to DOING", () => {
@@ -114,13 +109,12 @@ describe("WorkflowEngine", () => {
       engine = new WorkflowEngine(getTaskWorkflow());
     });
 
-    it("should skip Analysis — Backlog goes directly to Doing", () => {
+    it("should go from Backlog directly to Doing", () => {
       const next = engine.getNextStates(EffortStatus.BACKLOG);
-      expect(next).toContain(EffortStatus.DOING);
-      expect(next).not.toContain(EffortStatus.ANALYSIS);
+      expect(next).toEqual([EffortStatus.DOING]);
     });
 
-    it("should rollback DOING to Backlog (not ToDo)", () => {
+    it("should rollback DOING to Backlog", () => {
       expect(engine.getPreviousStatus(EffortStatus.DOING)).toBe(EffortStatus.BACKLOG);
     });
 
@@ -182,7 +176,7 @@ describe("WorkflowEngine", () => {
 
     it("should return empty array for unknown status", () => {
       const engine = new WorkflowEngine(buildMinimalWorkflow());
-      expect(engine.getTimestampsForStatus(EffortStatus.ANALYSIS)).toHaveLength(0);
+      expect(engine.getTimestampsForStatus(EffortStatus.WAITING)).toHaveLength(0);
     });
   });
 
@@ -212,7 +206,7 @@ describe("WorkflowEngine", () => {
 
     it("should fail when initial state not in states list", () => {
       const engine = new WorkflowEngine(
-        buildMinimalWorkflow({ initialState: EffortStatus.ANALYSIS }),
+        buildMinimalWorkflow({ initialState: EffortStatus.WAITING }),
       );
       const result = engine.validate();
       expect(result.valid).toBe(false);
@@ -232,7 +226,7 @@ describe("WorkflowEngine", () => {
       const engine = new WorkflowEngine(
         buildMinimalWorkflow({
           transitions: [
-            { from: EffortStatus.DRAFT, to: EffortStatus.ANALYSIS, label: "bad", isRollback: false },
+            { from: EffortStatus.DRAFT, to: EffortStatus.WAITING, label: "bad", isRollback: false },
           ],
         }),
       );

--- a/packages/core/tests/unit/services/WorkflowResolver.perProject.test.ts
+++ b/packages/core/tests/unit/services/WorkflowResolver.perProject.test.ts
@@ -302,13 +302,13 @@ describe("WorkflowResolver — per-project workflow override (ems__Effort_workfl
       isDefault: false,
       states: [
         { status: EffortStatus.BACKLOG, order: 1 },
-        { status: EffortStatus.TODO, order: 2 },
+        { status: EffortStatus.WAITING, order: 2 },
         { status: EffortStatus.DOING, order: 3 },
         { status: EffortStatus.DONE, order: 4 },
       ],
       transitions: [
-        { from: EffortStatus.BACKLOG, to: EffortStatus.TODO, label: "Refine" },
-        { from: EffortStatus.TODO, to: EffortStatus.DOING, label: "Start" },
+        { from: EffortStatus.BACKLOG, to: EffortStatus.WAITING, label: "Refine" },
+        { from: EffortStatus.WAITING, to: EffortStatus.DOING, label: "Start" },
         { from: EffortStatus.DOING, to: EffortStatus.DONE, label: "Complete" },
       ],
     });

--- a/packages/core/tests/unit/services/WorkflowResolver.test.ts
+++ b/packages/core/tests/unit/services/WorkflowResolver.test.ts
@@ -159,23 +159,33 @@ describe("WorkflowResolver", () => {
   });
 
   describe("getHardcodedFallback", () => {
-    it("should return Project fallback with Analysis and ToDo states", () => {
+    it("should return Project fallback with the ontology-backed states only", () => {
       const workflow = resolver.getHardcodedFallback(AssetClass.PROJECT);
 
       expect(workflow.targetClass).toBe(AssetClass.PROJECT);
       expect(workflow.initialState).toBe(EffortStatus.DRAFT);
       expect(workflow.terminalStates).toContain(EffortStatus.DONE);
       expect(workflow.terminalStates).toContain(EffortStatus.TRASHED);
-      expect(workflow.states.map((s) => s.status)).toContain(EffortStatus.ANALYSIS);
-      expect(workflow.states.map((s) => s.status)).toContain(EffortStatus.TODO);
+      expect(workflow.states.map((s) => s.status)).toEqual([
+        EffortStatus.DRAFT,
+        EffortStatus.BACKLOG,
+        EffortStatus.DOING,
+        EffortStatus.DONE,
+        EffortStatus.TRASHED,
+      ]);
     });
 
-    it("should return Task fallback without Analysis and ToDo", () => {
+    it("should return the same state set for the Task fallback", () => {
       const workflow = resolver.getHardcodedFallback(AssetClass.TASK);
 
       expect(workflow.targetClass).toBe(AssetClass.TASK);
-      expect(workflow.states.map((s) => s.status)).not.toContain(EffortStatus.ANALYSIS);
-      expect(workflow.states.map((s) => s.status)).not.toContain(EffortStatus.TODO);
+      expect(workflow.states.map((s) => s.status)).toEqual([
+        EffortStatus.DRAFT,
+        EffortStatus.BACKLOG,
+        EffortStatus.DOING,
+        EffortStatus.DONE,
+        EffortStatus.TRASHED,
+      ]);
     });
 
     it("should include timestamp properties on Doing and Done states", () => {
@@ -195,12 +205,12 @@ describe("WorkflowResolver", () => {
       expect(rollbacks.length).toBeGreaterThan(0);
     });
 
-    it("should have Project DOING rollback to ToDo (not Backlog)", () => {
+    it("should have Project DOING rollback to Backlog", () => {
       const workflow = resolver.getHardcodedFallback(AssetClass.PROJECT);
       const doingRollback = workflow.transitions.find(
         (t) => t.from === EffortStatus.DOING && t.isRollback,
       );
-      expect(doingRollback?.to).toBe(EffortStatus.TODO);
+      expect(doingRollback?.to).toBe(EffortStatus.BACKLOG);
     });
 
     it("should have Task DOING rollback to Backlog", () => {
@@ -403,7 +413,7 @@ describe("WorkflowResolver", () => {
 
       await addWorkflowState(store, {
         workflowSubject,
-        status: EffortStatus.ANALYSIS,
+        status: EffortStatus.WAITING,
         order: 2,
         optional: true,
       });
@@ -417,7 +427,7 @@ describe("WorkflowResolver", () => {
 
       const workflow = await resolver.resolveForClass(AssetClass.PROJECT);
 
-      const analysisState = workflow.states.find((s) => s.status === EffortStatus.ANALYSIS);
+      const analysisState = workflow.states.find((s) => s.status === EffortStatus.WAITING);
       expect(analysisState?.optional).toBe(true);
 
       const draftState = workflow.states.find((s) => s.status === EffortStatus.DRAFT);

--- a/packages/obsidian-plugin/src/domain/property-editor/PropertySchemas.ts
+++ b/packages/obsidian-plugin/src/domain/property-editor/PropertySchemas.ts
@@ -40,11 +40,17 @@ export interface SizeEnumValue {
 // load). Resolved path (EnumValueResolver) still emits symbolic-form short
 // names — Stage 5 will migrate that. UUID-form `value` ensures property
 // writes from this fallback are UUID-canon even when the resolver fails.
+//
+// Because the UUIDs are written into user frontmatter verbatim, a UUID whose
+// TBox asset no longer exists becomes a dangling wikilink. Analysis
+// (cde3525c-…) and To Do (6a0e933a-…) were deleted from the shared ontology
+// (exoas-public@c35a660d, 2026-08-13) and dropped here; Waiting (0610947c-…)
+// took their place — req fcbde537-f09a-410e-8bee-d3d607a70302. Resolve any
+// new UUID on disk before adding it.
 const FALLBACK_EFFORT_STATUS_VALUES: StatusEnumValue[] = [
   { value: "[[753a44d5-846c-4b82-9196-4fd9a4d48777]]", wikilink: "[[753a44d5-846c-4b82-9196-4fd9a4d48777|Backlog]]", label: "Backlog" },
-  { value: "[[cde3525c-57ea-4efc-b477-2e7e7ccd3a1e]]", wikilink: "[[cde3525c-57ea-4efc-b477-2e7e7ccd3a1e|Analysis]]", label: "Analysis" },
-  { value: "[[6a0e933a-6653-46f4-95ae-ed7508177c73]]", wikilink: "[[6a0e933a-6653-46f4-95ae-ed7508177c73|To Do]]", label: "To Do" },
   { value: "[[027e78f4-6e16-4b36-b8fb-5510507d5745]]", wikilink: "[[027e78f4-6e16-4b36-b8fb-5510507d5745|Doing]]", label: "Doing" },
+  { value: "[[0610947c-6a62-41c8-9d44-7863d3ba3a8e]]", wikilink: "[[0610947c-6a62-41c8-9d44-7863d3ba3a8e|Waiting]]", label: "Waiting" },
   { value: "[[7b9b3116-7c3c-438c-9618-94fe301320a6]]", wikilink: "[[7b9b3116-7c3c-438c-9618-94fe301320a6|Done]]", label: "Done" },
   { value: "[[5d14f18d-db2b-4847-9ac1-144cb93b2541]]", wikilink: "[[5d14f18d-db2b-4847-9ac1-144cb93b2541|Trashed]]", label: "Trashed" },
   { value: "[[c42245d0-01de-4c35-bfcf-d910445ea28e]]", wikilink: "[[c42245d0-01de-4c35-bfcf-d910445ea28e|Draft]]", label: "Draft" },
@@ -215,12 +221,18 @@ export function getPropertyByName(
 // values written before the UUID-canon migration; this preserves the
 // human-readable label for both forms. Stage 5 will remove this map alongside
 // the `EffortStatus` enum deletion.
+// This map is READ-only (rendering), never a write path, so it deliberately
+// KEEPS `analysis` / `todo` even though those TBox instances were deleted
+// (req fcbde537-f09a-410e-8bee-d3d607a70302): assets written before the
+// 2026-08-13 migration may still carry those values, and rendering "To Do"
+// beats rendering a raw URI. Do not prune them — add new statuses instead.
 const SYMBOLIC_STATUS_LABEL_FALLBACK: Record<string, string> = {
   emseffortstatusdraft: "Draft",
   emseffortstatusbacklog: "Backlog",
   emseffortstatusanalysis: "Analysis",
   emseffortstatustodo: "To Do",
   emseffortstatusdoing: "Doing",
+  emseffortstatuswaiting: "Waiting",
   emseffortstatusdone: "Done",
   emseffortstatustrashed: "Trashed",
 };

--- a/packages/obsidian-plugin/src/presentation/components/property-fields/StatusSelectPropertyField.ts
+++ b/packages/obsidian-plugin/src/presentation/components/property-fields/StatusSelectPropertyField.ts
@@ -2,6 +2,7 @@ import { Setting } from "obsidian";
 import type { StatusSelectPropertyFieldProps, ValidationResult } from "./types";
 import { WikilinkLabelResolver } from "@plugin/presentation/utils/WikilinkLabelResolver";
 import { EFFORT_STATUS_OPTIONS } from "@kitelev/exocortex-core";
+import { getStatusLabel } from "@plugin/domain/property-editor/PropertySchemas";
 export { EFFORT_STATUS_OPTIONS };
 
 /**
@@ -166,6 +167,16 @@ export class StatusSelectPropertyField {
       if (cleanOption === cleanValue) {
         return option.label;
       }
+    }
+
+    // A status that is no longer OFFERED can still be PRESENT in an older
+    // asset (`Analysis` / `To Do` lost their TBox instances on 2026-08-13 —
+    // req fcbde537-f09a-410e-8bee-d3d607a70302). `EFFORT_STATUS_OPTIONS` is a
+    // write-path list, so it must not carry them; rendering, however, should
+    // still show a human label rather than the raw URI.
+    const legacyLabel = getStatusLabel(cleanValue);
+    if (legacyLabel !== "-" && legacyLabel !== cleanValue) {
+      return legacyLabel;
     }
 
     return value;

--- a/packages/obsidian-plugin/tests/unit/EffortStatusWorkflow.test.ts
+++ b/packages/obsidian-plugin/tests/unit/EffortStatusWorkflow.test.ts
@@ -26,20 +26,16 @@ describe("EffortStatusWorkflow", () => {
       expect(result).toBe('"[[ems__EffortStatusDraft]]"');
     });
 
-    it("should return Backlog for Analysis status", () => {
-      const result = workflow.getPreviousStatus(
-        '"[[ems__EffortStatusAnalysis]]"',
-        null,
-      );
-      expect(result).toBe('"[[ems__EffortStatusBacklog]]"');
-    });
-
-    it("should return Analysis for ToDo status", () => {
-      const result = workflow.getPreviousStatus(
-        '"[[ems__EffortStatusToDo]]"',
-        null,
-      );
-      expect(result).toBe('"[[ems__EffortStatusAnalysis]]"');
+    // `Analysis` / `ToDo` lost their TBox instances on 2026-08-13 and were
+    // dropped from the default workflows (req fcbde537-f09a-410e-8bee-d3d607a70302),
+    // so they are no longer states: a rollback from them is undefined.
+    it("should return undefined for a status that is no longer a workflow state", () => {
+      expect(
+        workflow.getPreviousStatus('"[[ems__EffortStatusAnalysis]]"', null),
+      ).toBeUndefined();
+      expect(
+        workflow.getPreviousStatus('"[[ems__EffortStatusToDo]]"', null),
+      ).toBeUndefined();
     });
 
     it("should return Backlog for Doing status when Task", () => {
@@ -50,12 +46,12 @@ describe("EffortStatusWorkflow", () => {
       expect(result).toBe('"[[ems__EffortStatusBacklog]]"');
     });
 
-    it("should return ToDo for Doing status when Project", () => {
+    it("should return Backlog for Doing status when Project", () => {
       const result = workflow.getPreviousStatus(
         '"[[ems__EffortStatusDoing]]"',
         '"[[ems__Project]]"',
       );
-      expect(result).toBe('"[[ems__EffortStatusToDo]]"');
+      expect(result).toBe('"[[ems__EffortStatusBacklog]]"');
     });
 
     it("should return Doing for Done status", () => {
@@ -79,7 +75,7 @@ describe("EffortStatusWorkflow", () => {
         '"[[ems__EffortStatusDoing]]"',
         ['"[[ems__Project]]"', '"[[ems__Effort]]"'],
       );
-      expect(result).toBe('"[[ems__EffortStatusToDo]]"');
+      expect(result).toBe('"[[ems__EffortStatusBacklog]]"');
     });
 
     it("should handle array of instance classes for Task", () => {

--- a/packages/obsidian-plugin/tests/unit/property-editor/PropertySchemas.test.ts
+++ b/packages/obsidian-plugin/tests/unit/property-editor/PropertySchemas.test.ts
@@ -129,19 +129,38 @@ describe("PropertySchemas", () => {
   });
 
   describe("FALLBACK_EFFORT_STATUS_VALUES", () => {
-    it("should have 7 status values", () => {
-      expect(FALLBACK_EFFORT_STATUS_VALUES).toHaveLength(7);
+    it("should have 6 status values", () => {
+      expect(FALLBACK_EFFORT_STATUS_VALUES).toHaveLength(6);
     });
 
     it("should have all required status values", () => {
       const labels = FALLBACK_EFFORT_STATUS_VALUES.map((s) => s.label);
       expect(labels).toContain("Draft");
       expect(labels).toContain("Backlog");
-      expect(labels).toContain("Analysis");
-      expect(labels).toContain("To Do");
       expect(labels).toContain("Doing");
+      expect(labels).toContain("Waiting");
       expect(labels).toContain("Done");
       expect(labels).toContain("Trashed");
+    });
+
+    // @req:fcbde537-f09a-410e-8bee-d3d607a70302 — this fallback writes the raw
+    // UUID into user frontmatter, so a UUID whose TBox asset was deleted
+    // (exoas-public@c35a660d, 2026-08-13) becomes a dangling wikilink. Grepping
+    // the symbolic `EffortStatusToDo` name does NOT find these — they are
+    // UUID-form only, which is why this axis is asserted separately.
+    it("@req:fcbde537-f09a-410e-8bee-d3d607a70302 offers no status whose TBox asset was deleted", () => {
+      const serialized = JSON.stringify(FALLBACK_EFFORT_STATUS_VALUES);
+      for (const deadUid of [
+        "6a0e933a-6653-46f4-95ae-ed7508177c73", // ems__EffortStatusToDo
+        "cde3525c-57ea-4efc-b477-2e7e7ccd3a1e", // ems__EffortStatusAnalysis
+      ]) {
+        expect(serialized).not.toContain(deadUid);
+      }
+    });
+
+    it("@req:fcbde537-f09a-410e-8bee-d3d607a70302 offers the Waiting status that replaced them", () => {
+      const waiting = FALLBACK_EFFORT_STATUS_VALUES.find((s) => s.label === "Waiting");
+      expect(waiting?.value).toBe("[[0610947c-6a62-41c8-9d44-7863d3ba3a8e]]");
     });
 
     it("should have UUID-form wikilink values (RFC 31c1a0be Phase 4 PR-C)", () => {
@@ -175,7 +194,7 @@ describe("PropertySchemas", () => {
 
   describe("EFFORT_STATUS_VALUES (mutable, initially equals fallback)", () => {
     it("should initially contain fallback values", () => {
-      expect(EFFORT_STATUS_VALUES).toHaveLength(7);
+      expect(EFFORT_STATUS_VALUES).toHaveLength(6);
       expect(EFFORT_STATUS_VALUES.map((s) => s.label)).toContain("Doing");
     });
   });
@@ -256,7 +275,7 @@ describe("PropertySchemas", () => {
   describe("refreshEnumValues", () => {
     it("should do nothing when no enum resolver is set", async () => {
       await refreshEnumValues();
-      expect(EFFORT_STATUS_VALUES).toHaveLength(7);
+      expect(EFFORT_STATUS_VALUES).toHaveLength(6);
       expect(TASK_SIZE_VALUES).toHaveLength(6);
     });
 
@@ -584,26 +603,25 @@ describe("PropertySchemas", () => {
       expect(getStatusLabel("ems__EffortStatusTrashed")).toBe("Trashed");
       expect(getStatusLabel("ems__EffortStatusDraft")).toBe("Draft");
       expect(getStatusLabel("ems__EffortStatusBacklog")).toBe("Backlog");
-      expect(getStatusLabel("ems__EffortStatusAnalysis")).toBe("Analysis");
-      expect(getStatusLabel("ems__EffortStatusToDo")).toBe("To Do");
+      expect(getStatusLabel("ems__EffortStatusWaiting")).toBe("Waiting");
     });
 
     it("should return human-readable label for wiki-link wrapped URI", () => {
       expect(getStatusLabel("[[ems__EffortStatusDoing]]")).toBe("Doing");
       expect(getStatusLabel("[[ems__EffortStatusDone]]")).toBe("Done");
-      expect(getStatusLabel("[[ems__EffortStatusToDo]]")).toBe("To Do");
+      expect(getStatusLabel("[[ems__EffortStatusWaiting]]")).toBe("Waiting");
     });
 
     it("should return the label as-is if already human-readable", () => {
       expect(getStatusLabel("Doing")).toBe("Doing");
       expect(getStatusLabel("Done")).toBe("Done");
-      expect(getStatusLabel("To Do")).toBe("To Do");
+      expect(getStatusLabel("Waiting")).toBe("Waiting");
     });
 
     it("should handle case-insensitive label matching", () => {
       expect(getStatusLabel("doing")).toBe("Doing");
       expect(getStatusLabel("DONE")).toBe("Done");
-      expect(getStatusLabel("to do")).toBe("To Do");
+      expect(getStatusLabel("waiting")).toBe("Waiting");
     });
 
     it("should return dash for null or undefined", () => {

--- a/packages/obsidian-plugin/tests/unit/property-fields/StatusSelectPropertyField.test.ts
+++ b/packages/obsidian-plugin/tests/unit/property-fields/StatusSelectPropertyField.test.ts
@@ -100,9 +100,8 @@ describe("StatusSelectPropertyField", () => {
       const expectedLabels = [
         "Draft",
         "Backlog",
-        "Analysis",
-        "To Do",
         "Doing",
+        "Waiting",
         "Done",
         "Trashed",
       ];
@@ -155,8 +154,8 @@ describe("StatusSelectPropertyField", () => {
       ) as HTMLSelectElement | null;
       const options = select!.querySelectorAll("option");
 
-      // "Not specified" + 7 status options = 8 total
-      expect(options.length).toBe(8);
+      // "Not specified" + 6 status options = 7 total
+      expect(options.length).toBe(7);
       expect(options[0].textContent).toBe("Not specified");
     });
 

--- a/packages/test-utils/src/factories/meeting.factory.ts
+++ b/packages/test-utils/src/factories/meeting.factory.ts
@@ -101,7 +101,7 @@ export const MeetingFactory = {
    */
   scheduled(scheduledAt: number, overrides: Partial<MeetingFixture> = {}): MeetingFixture {
     return MeetingFactory.create({
-      status: "To Do",
+      status: "Backlog",
       scheduledAt,
       ...overrides,
     });
@@ -187,10 +187,10 @@ export const MeetingFactory = {
     const id = generateId();
     const basename = overrides.file?.basename ?? id;
     const path = overrides.path ?? overrides.file?.path ?? `meetings/${basename}.md`;
-    const status = overrides.status ?? "ems__EffortStatusToDo";
+    const status = overrides.status ?? "ems__EffortStatusBacklog";
     const normalizedStatus = status.startsWith("ems__")
       ? status
-      : STATUS_MAP[status as EffortStatusName] ?? "ems__EffortStatusToDo";
+      : STATUS_MAP[status as EffortStatusName] ?? "ems__EffortStatusBacklog";
 
     return {
       file: {

--- a/packages/test-utils/src/factories/project.factory.ts
+++ b/packages/test-utils/src/factories/project.factory.ts
@@ -95,17 +95,10 @@ export const ProjectFactory = {
   },
 
   /**
-   * Create an Analysis project.
+   * Create a Waiting (parked) project.
    */
-  analysis(overrides: Partial<ProjectFixture> = {}): ProjectFixture {
-    return ProjectFactory.create({ status: "Analysis", ...overrides });
-  },
-
-  /**
-   * Create a To Do project.
-   */
-  todo(overrides: Partial<ProjectFixture> = {}): ProjectFixture {
-    return ProjectFactory.create({ status: "To Do", ...overrides });
+  waiting(overrides: Partial<ProjectFixture> = {}): ProjectFixture {
+    return ProjectFactory.create({ status: "Waiting", ...overrides });
   },
 
   /**

--- a/packages/test-utils/src/factories/task.factory.ts
+++ b/packages/test-utils/src/factories/task.factory.ts
@@ -11,7 +11,7 @@
  * // Task with custom properties
  * const customTask = TaskFactory.create({
  *   label: "Custom Task",
- *   status: "To Do",
+ *   status: "Backlog",
  *   votes: 5,
  * });
  *
@@ -134,17 +134,10 @@ export const TaskFactory = {
   },
 
   /**
-   * Create an Analysis task.
+   * Create a Waiting (parked) task.
    */
-  analysis(overrides: Partial<TaskFixture> = {}): TaskFixture {
-    return TaskFactory.create({ status: "Analysis", ...overrides });
-  },
-
-  /**
-   * Create a To Do task.
-   */
-  todo(overrides: Partial<TaskFixture> = {}): TaskFixture {
-    return TaskFactory.create({ status: "To Do", ...overrides });
+  waiting(overrides: Partial<TaskFixture> = {}): TaskFixture {
+    return TaskFactory.create({ status: "Waiting", ...overrides });
   },
 
   /**

--- a/packages/test-utils/src/helpers/status.helpers.ts
+++ b/packages/test-utils/src/helpers/status.helpers.ts
@@ -15,9 +15,8 @@ import type { EffortStatus, EffortStatusName } from "../types";
 export const STATUS_MAP: Record<EffortStatusName, EffortStatus> = {
   Draft: "ems__EffortStatusDraft",
   Backlog: "ems__EffortStatusBacklog",
-  Analysis: "ems__EffortStatusAnalysis",
-  "To Do": "ems__EffortStatusToDo",
   Doing: "ems__EffortStatusDoing",
+  Waiting: "ems__EffortStatusWaiting",
   Done: "ems__EffortStatusDone",
   Trashed: "ems__EffortStatusTrashed",
 };

--- a/packages/test-utils/src/types.ts
+++ b/packages/test-utils/src/types.ts
@@ -9,9 +9,8 @@
 export type EffortStatus =
   | "ems__EffortStatusDraft"
   | "ems__EffortStatusBacklog"
-  | "ems__EffortStatusAnalysis"
-  | "ems__EffortStatusToDo"
   | "ems__EffortStatusDoing"
+  | "ems__EffortStatusWaiting"
   | "ems__EffortStatusDone"
   | "ems__EffortStatusTrashed";
 
@@ -21,9 +20,8 @@ export type EffortStatus =
 export type EffortStatusName =
   | "Draft"
   | "Backlog"
-  | "Analysis"
-  | "To Do"
   | "Doing"
+  | "Waiting"
   | "Done"
   | "Trashed";
 

--- a/packages/test-utils/tests/factories.test.ts
+++ b/packages/test-utils/tests/factories.test.ts
@@ -30,12 +30,12 @@ describe("TaskFactory", () => {
     it("should create a task with custom values", () => {
       const task = TaskFactory.create({
         label: "Custom Task",
-        status: "To Do",
+        status: "Waiting",
         votes: 5,
       });
 
       expect(task.label).toBe("Custom Task");
-      expect(task.status).toBe("ems__EffortStatusToDo");
+      expect(task.status).toBe("ems__EffortStatusWaiting");
       expect(task.votes).toBe(5);
     });
 
@@ -80,14 +80,9 @@ describe("TaskFactory", () => {
       expect(task.status).toBe("ems__EffortStatusBacklog");
     });
 
-    it("should create analysis task", () => {
-      const task = TaskFactory.analysis();
-      expect(task.status).toBe("ems__EffortStatusAnalysis");
-    });
-
-    it("should create todo task", () => {
-      const task = TaskFactory.todo();
-      expect(task.status).toBe("ems__EffortStatusToDo");
+    it("should create waiting task", () => {
+      const task = TaskFactory.waiting();
+      expect(task.status).toBe("ems__EffortStatusWaiting");
     });
 
     it("should create doing task with startTimestamp", () => {
@@ -180,7 +175,7 @@ describe("TaskFactory", () => {
     it("should convert task fixture to metadata format", () => {
       const task = TaskFactory.create({
         label: "Test",
-        status: "To Do",
+        status: "Waiting",
         votes: 3,
         size: "M",
         area: "work-area",
@@ -191,7 +186,7 @@ describe("TaskFactory", () => {
 
       expect(metadata.exo__Instance_class).toBe("[[ems__Task]]");
       expect(metadata.exo__Asset_label).toBe("Test");
-      expect(metadata.ems__Effort_status).toBe("[[ems__EffortStatusToDo]]");
+      expect(metadata.ems__Effort_status).toBe("[[ems__EffortStatusWaiting]]");
       expect(metadata.ems__Effort_votes).toBe(3);
       expect(metadata.ems__Task_size).toBe("[[ems__TaskSize_M]]");
       expect(metadata.ems__Effort_area).toBe("[[work-area]]");
@@ -308,7 +303,7 @@ describe("MeetingFactory", () => {
     const scheduledAt = Date.now() + 86400000; // tomorrow
     const meeting = MeetingFactory.scheduled(scheduledAt);
 
-    expect(meeting.status).toBe("ems__EffortStatusToDo");
+    expect(meeting.status).toBe("ems__EffortStatusBacklog");
     expect(meeting.scheduledAt).toBe(scheduledAt);
   });
 


### PR DESCRIPTION
## Что и почему

`ems__EffortStatusToDo` (`6a0e933a`) и `ems__EffortStatusAnalysis` (`cde3525c`) удалены из `exoas-public` 2026-08-13 (`c35a660d`); вместо них отгружен статус парковки `ems__EffortStatusWaiting` (`0610947c`). Код продолжал писать удалённые значения дословно во frontmatter пользователя → **висячий wikilink**, статус невыразим ни одним workflow, ассет молча выпадает из любой выборки по статусу.

Хвост найден адверсарным ревью задачи `ceae3805` (возврат парковки) и вынесен отдельно намеренно.

## Изменения

- `EffortStatus` / `STATUS_UID_BY_ENUM` / `EFFORT_STATUS_OPTIONS` — сняты `TODO` + `ANALYSIS`, добавлен `WAITING`
- CLI-вербы `move-to-todo` / `move-to-analysis` удалены; в `VERSIONING.md` помечены **Removed**
- default workflows, plugin `PropertySchemas` + `StatusSelectPropertyField`, фабрики `test-utils` — приведены к живому набору статусов
- доки (ARCHITECTURE, how-to, reference, tutorials, ONTOLOGY_REFERENCE) синхронизированы

## Приёмка

- `git grep 'EffortStatusToDo' -- 'packages/*/src'` → **0**
- Новый `packages/core/tests/integration/status-model/dead-status-values.integration.test.ts` — 10 тестов, каждый `describe` = независимая ось revert-verify (возврат мёртвого значения в ОДНОМ источнике краснит ТОЛЬКО свой блок); покрыты обе формы (symbolic + UUID)
- Локальный прогон: **core 369/369 сьютов (8557 тестов)**, **plugin 339/339 (6057)**, **cli 155/156** — единственное падение `sparql-exo003.integration.test.ts` воспроизводится идентично на чистом `main` (pre-existing, к этому дифу отношения не имеет)

Requirement: `fcbde537-f09a-410e-8bee-d3d607a70302` (Approved, bindingClass Integration) — флип в Active после мержа.

https://claude.ai/code/session_01Q2DYJHJq7hZNYM3T3H7rUf