### PR TITLE
feat(profile): render a link into a PARKED AssetSpace as "<label> ⏸ / activate" (req c171e24d)

### DIFF
--- a/packages/core/src/domain/profile/ParkedAssetIndex.ts
+++ b/packages/core/src/domain/profile/ParkedAssetIndex.ts
@@ -1,0 +1,226 @@
+/**
+ * Locating an asset that lives in a PARKED AssetSpace (req `c171e24d`).
+ *
+ * ## Why this module exists
+ *
+ * Parking moves an AssetSpace's bytes from `assetspaces/<owner>/<repo>` to
+ * `.exocortex/parked/<owner>/<repo>` ({@link parkedPathFor}). That location is a
+ * DOT-folder, so Obsidian never indexes it: `getMarkdownFiles()` does not list
+ * it and `metadataCache.getFirstLinkpathDest` cannot resolve a link into it.
+ * Every wikilink pointing at a parked asset therefore renders as an unresolved
+ * link — a raw UID, dimmed, with no preview.
+ *
+ * The whole point of parking is that the bytes are STILL ON THE DEVICE. So the
+ * honest render is not "broken" but "here, just not active" — and to say that,
+ * something has to look where Obsidian will not. `vault.adapter` will: it is a
+ * plain filesystem port with no index behind it, and the plugin already reads a
+ * dot-folder through it in production (`OperationsLogReader` reads
+ * `.exocortex/switch-journal.jsonl` for the Settings journal panel).
+ *
+ * ⛔ This module must therefore NEVER be given an index-backed reader. The
+ * asymmetry between `getMarkdownFiles()` and the adapter is not an
+ * implementation detail here — it is the entire mechanism.
+ *
+ * ## Why a directory index and not a derived path
+ *
+ * A link carries a link target (`[[<uid>]]`), not a path. Nothing in the vault
+ * maps a UID to its location inside a parked repo, so the location has to be
+ * discovered by walking. The walk happens ONCE per index instance and is
+ * amortised over every unresolved link on the page; a hit then costs exactly one
+ * file read (the asset's own frontmatter, for its label).
+ *
+ * The index is keyed on the file's basename because that is what a UID-canon
+ * wikilink resolves against — the same key Obsidian's own linkpath resolution
+ * uses for an active mount.
+ *
+ * ## Why the miss is as load-bearing as the hit
+ *
+ * A link to an asset that exists NOWHERE must stay red. If this lookup answered
+ * "parked" for anything it could not find, the placeholder would swallow real
+ * broken links and the "no broken links" property would be satisfied by
+ * pretending. The lookup is therefore positive-evidence-only: it returns a hit
+ * ONLY for a basename actually present under the parked root.
+ */
+
+import { PARKED_ROOT } from "./ParkedMountState";
+
+/**
+ * The filesystem capabilities this module needs, and nothing more.
+ *
+ * Deliberately shaped as the subset of Obsidian's `DataAdapter` that the plugin
+ * already exposes (`exists` / `list` / `read`), so the production wiring is the
+ * adapter itself rather than a translation layer that could quietly resolve
+ * through the index instead.
+ */
+export interface ParkedVaultReader {
+  exists(path: string): Promise<boolean>;
+  list(path: string): Promise<{ files: string[]; folders: string[] }>;
+  read(path: string): Promise<string>;
+}
+
+/** A parked asset found on this device. */
+export interface ParkedAssetHit {
+  /** Vault-relative path of the parked file. */
+  readonly path: string;
+  /**
+   * `<owner>/<repo>` — the parked AssetSpace holding it. This is what the
+   * "activate" action needs to name; it is DERIVED from the path, never stored.
+   */
+  readonly assetSpace: string;
+  /**
+   * `exo__Asset_label` of the parked asset, or `null` when it carries none.
+   * The caller decides the fallback — this module does not invent a label.
+   */
+  readonly label: string | null;
+}
+
+/** Strip wikilink brackets, quotes, a block/heading ref and the `.md` suffix. */
+function normalizeLinkTarget(linkTarget: string): string {
+  const cleaned = linkTarget
+    .replace(/^\[\[|\]\]$/g, "")
+    .replace(/^"|"$/g, "")
+    .trim();
+  const withoutRef = cleaned.split("#")[0].trim();
+  // A linkpath may carry folders (`some/folder/uid`); the index is keyed on the
+  // basename because that is what UID-canon links resolve against.
+  const basename = withoutRef.split("/").pop() ?? withoutRef;
+  return basename.replace(/\.md$/i, "");
+}
+
+/**
+ * Read `exo__Asset_label` out of raw markdown WITHOUT a YAML parser.
+ *
+ * A parked asset is read purely to name it in a placeholder; pulling a YAML
+ * dependency (or the vault's `FrontmatterService`, which carries update/write
+ * machinery this path must never reach) would buy nothing. The single-line
+ * scalar form is the only one the label is ever authored in — `exocortex-cli
+ * create` and `apply set-label` both write it that way — and an unreadable
+ * label degrades to `null`, which the caller already handles.
+ */
+function extractLabel(content: string): string | null {
+  const fence = content.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+  if (fence === null) return null;
+  // ⛔ `[ \t]*`, never `\s*`: `\s` matches `\n`, so on a multi-line (list) value
+  // the match would spill past the newline and capture the first list item.
+  const match = fence[1].match(/^exo__Asset_label:[ \t]*(.+)$/m);
+  if (match === undefined || match === null) return null;
+  const raw = match[1].trim();
+  if (raw.length === 0) return null;
+  // Strip the quoting `create` adds for scalars that would otherwise be ambiguous.
+  const unquoted =
+    (raw.startsWith('"') && raw.endsWith('"') && raw.length >= 2) ||
+    (raw.startsWith("'") && raw.endsWith("'") && raw.length >= 2)
+      ? raw.slice(1, -1)
+      : raw;
+  return unquoted.length === 0 ? null : unquoted;
+}
+
+/**
+ * Basename → parked-file lookup over `.exocortex/parked`.
+ *
+ * The directory index is built lazily on the first lookup and reused; call
+ * {@link invalidate} whenever the parked tree may have changed (an
+ * `apply-profile` parks or unparks mounts).
+ */
+export class ParkedAssetIndex {
+  private readonly reader: ParkedVaultReader;
+  /** basename (no `.md`) → vault-relative path. First occurrence wins. */
+  private index: Map<string, string> | null = null;
+  private building: Promise<Map<string, string>> | null = null;
+
+  constructor(reader: ParkedVaultReader) {
+    this.reader = reader;
+  }
+
+  /** Drop the cached directory listing; the next lookup re-walks. */
+  invalidate(): void {
+    this.index = null;
+    this.building = null;
+  }
+
+  /**
+   * Resolve a link target to a parked asset, or `null` when nothing under the
+   * parked root carries that basename.
+   */
+  async lookup(linkTarget: string): Promise<ParkedAssetHit | null> {
+    const key = normalizeLinkTarget(linkTarget);
+    if (key.length === 0) return null;
+
+    const index = await this.ensureIndex();
+    const path = index.get(key);
+    if (path === undefined) return null;
+
+    const assetSpace = assetSpaceOf(path);
+    if (assetSpace === null) return null;
+
+    let label: string | null = null;
+    try {
+      label = extractLabel(await this.reader.read(path));
+    } catch {
+      // The file was listed a moment ago; if it cannot be read now, the asset is
+      // still parked — only its name is unavailable.
+      label = null;
+    }
+    return { path, assetSpace, label };
+  }
+
+  private async ensureIndex(): Promise<Map<string, string>> {
+    if (this.index !== null) return this.index;
+    // Concurrent unresolved links on one page all miss at once; share one walk.
+    if (this.building === null) {
+      this.building = this.buildIndex();
+    }
+    const built = await this.building;
+    this.index = built;
+    this.building = null;
+    return built;
+  }
+
+  private async buildIndex(): Promise<Map<string, string>> {
+    const out = new Map<string, string>();
+    await this.walk(PARKED_ROOT, out);
+    return out;
+  }
+
+  private async walk(dir: string, out: Map<string, string>): Promise<void> {
+    let listing: { files: string[]; folders: string[] };
+    try {
+      if (!(await this.reader.exists(dir))) return;
+      listing = await this.reader.list(dir);
+    } catch {
+      // Absent or unreadable directory: nothing parked here.
+      return;
+    }
+    for (const file of listing.files) {
+      if (!file.toLowerCase().endsWith(".md")) continue;
+      const base = (file.split("/").pop() ?? file).replace(/\.md$/i, "");
+      if (base.length === 0 || out.has(base)) continue;
+      out.set(base, file);
+    }
+    for (const folder of listing.folders) {
+      const base = folder.split("/").pop() ?? folder;
+      // Skip nested dot-folders — a parked mount carries its own `.git`, and
+      // walking it would cost thousands of entries for nothing. The parked ROOT
+      // is itself a dot-folder, which is why this test runs on children only.
+      if (base.startsWith(".")) continue;
+      await this.walk(folder, out);
+    }
+  }
+}
+
+/**
+ * `.exocortex/parked/<owner>/<repo>/…` → `<owner>/<repo>`.
+ *
+ * Returns `null` for a path that does not carry both segments, so a stray file
+ * directly under the parked root can never be reported as belonging to an
+ * AssetSpace that does not exist.
+ */
+function assetSpaceOf(path: string): string | null {
+  const prefix = `${PARKED_ROOT}/`;
+  if (!path.startsWith(prefix)) return null;
+  const rest = path.slice(prefix.length).split("/");
+  if (rest.length < 3) return null;
+  const [owner, repo] = rest;
+  if (owner.length === 0 || repo.length === 0) return null;
+  return `${owner}/${repo}`;
+}

--- a/packages/core/src/domain/profile/ParkedAssetIndex.ts
+++ b/packages/core/src/domain/profile/ParkedAssetIndex.ts
@@ -223,7 +223,15 @@ export class ParkedAssetIndex {
     if (this.building === null) {
       this.building = this.buildIndex();
     }
-    const built = await this.building;
+    // ⛔ Hold onto the promise WE awaited. Clearing `this.building`
+    // unconditionally below would let a second waiter, resuming one microtask
+    // later, wipe the slot a first waiter had already refilled — so every
+    // concurrent lookup would start its OWN re-walk. That herd lands exactly in
+    // the apply-profile window (invalidate fires while many links re-render),
+    // over a serial walk of a whole parked AssetSpace, on the device parking
+    // exists for.
+    const mine = this.building;
+    const built = await mine;
     // ⛔ Load-bearing: `invalidate()` cannot cancel a walk already in flight, and
     // an apply-profile takes SECONDS (it moves files, which churns
     // metadataCache, which re-renders open notes, which look links up again).
@@ -232,11 +240,11 @@ export class ParkedAssetIndex {
     // asset would keep resolving as parked, which is exactly what the
     // invalidation hook exists to prevent.
     if (generation !== this.generation) {
-      this.building = null;
+      if (this.building === mine) this.building = null;
       return this.ensureIndex();
     }
     this.index = built;
-    this.building = null;
+    if (this.building === mine) this.building = null;
     return built;
   }
 

--- a/packages/core/src/domain/profile/ParkedAssetIndex.ts
+++ b/packages/core/src/domain/profile/ParkedAssetIndex.ts
@@ -97,22 +97,58 @@ function normalizeLinkTarget(linkTarget: string): string {
  * create` and `apply set-label` both write it that way — and an unreadable
  * label degrades to `null`, which the caller already handles.
  */
-function extractLabel(content: string): string | null {
+/** Frontmatter block of a markdown file, or `null` when it carries none. */
+function frontmatterOf(content: string): string | null {
   const fence = content.match(/^---\r?\n([\s\S]*?)\r?\n---/);
-  if (fence === null) return null;
+  return fence === null ? null : fence[1];
+}
+
+/**
+ * Positive evidence that a parked FILE is an Exocortex ASSET.
+ *
+ * Every asset carries `exo__Asset_uid` (it is what UID-canon filenames are
+ * derived from); a README, a licence or a stray note does not.
+ */
+function hasAssetUid(content: string): boolean {
+  const fm = frontmatterOf(content);
+  if (fm === null) return false;
+  const match = fm.match(/^exo__Asset_uid:[ \t]*(.+)$/m);
+  return match !== null && match[1].trim().length > 0;
+}
+
+function extractLabel(content: string): string | null {
+  const fm = frontmatterOf(content);
+  if (fm === null) return null;
   // ⛔ `[ \t]*`, never `\s*`: `\s` matches `\n`, so on a multi-line (list) value
   // the match would spill past the newline and capture the first list item.
-  const match = fence[1].match(/^exo__Asset_label:[ \t]*(.+)$/m);
-  if (match === undefined || match === null) return null;
+  const match = fm.match(/^exo__Asset_label:[ \t]*(.+)$/m);
+  if (match === null) return null;
   const raw = match[1].trim();
-  if (raw.length === 0) return null;
-  // Strip the quoting `create` adds for scalars that would otherwise be ambiguous.
-  const unquoted =
-    (raw.startsWith('"') && raw.endsWith('"') && raw.length >= 2) ||
-    (raw.startsWith("'") && raw.endsWith("'") && raw.length >= 2)
-      ? raw.slice(1, -1)
-      : raw;
-  return unquoted.length === 0 ? null : unquoted;
+  if (raw.length < 1) return null;
+
+  // Undo the quoting `create` adds for scalars that would otherwise be
+  // ambiguous. The two YAML quoting styles unescape DIFFERENTLY, and getting
+  // this wrong is visible to the user: measured against a real corpus of 22 971
+  // assets, a naive quote-strip renders 18 labels with literal backslashes
+  // (`Issue \"под ключ\" = merged PR`).
+  if (raw.length >= 2 && raw.startsWith('"') && raw.endsWith('"')) {
+    return orNull(
+      raw
+        .slice(1, -1)
+        .replace(/\\(["\\ntr])/g, (_m, c: string) =>
+          c === "n" ? "\n" : c === "t" ? "\t" : c === "r" ? "\r" : c,
+        ),
+    );
+  }
+  if (raw.length >= 2 && raw.startsWith("'") && raw.endsWith("'")) {
+    // Single-quoted YAML has exactly ONE escape: a doubled quote.
+    return orNull(raw.slice(1, -1).replace(/''/g, "'"));
+  }
+  return orNull(raw);
+}
+
+function orNull(value: string): string | null {
+  return value.length === 0 ? null : value;
 }
 
 /**
@@ -127,6 +163,12 @@ export class ParkedAssetIndex {
   /** basename (no `.md`) → vault-relative path. First occurrence wins. */
   private index: Map<string, string> | null = null;
   private building: Promise<Map<string, string>> | null = null;
+  /**
+   * Bumped by {@link invalidate}. A walk that started BEFORE an invalidation
+   * describes a world that no longer exists, so its result must be discarded
+   * rather than installed.
+   */
+  private generation = 0;
 
   constructor(reader: ParkedVaultReader) {
     this.reader = reader;
@@ -136,6 +178,7 @@ export class ParkedAssetIndex {
   invalidate(): void {
     this.index = null;
     this.building = null;
+    this.generation += 1;
   }
 
   /**
@@ -153,24 +196,45 @@ export class ParkedAssetIndex {
     const assetSpace = assetSpaceOf(path);
     if (assetSpace === null) return null;
 
-    let label: string | null = null;
+    let content: string;
     try {
-      label = extractLabel(await this.reader.read(path));
+      content = await this.reader.read(path);
     } catch {
-      // The file was listed a moment ago; if it cannot be read now, the asset is
-      // still parked — only its name is unavailable.
-      label = null;
+      // No evidence read, no hit. Silence is not proof that the file is an asset.
+      return null;
     }
-    return { path, assetSpace, label };
+
+    // ⛔ A markdown FILE under the parked root is not automatically an ASSET.
+    // Real data: 22 `README.md` live inside assetspaces across this device's
+    // vaults, despite the co-location canon saying they should not. Indexing
+    // those would make a genuinely broken `[[README]]` render as a placeholder
+    // offering to activate an AssetSpace — the placeholder swallowing exactly
+    // the broken link it must leave alone. `exo__Asset_uid` is the positive
+    // evidence that a file IS an asset.
+    if (!hasAssetUid(content)) return null;
+
+    return { path, assetSpace, label: extractLabel(content) };
   }
 
   private async ensureIndex(): Promise<Map<string, string>> {
     if (this.index !== null) return this.index;
     // Concurrent unresolved links on one page all miss at once; share one walk.
+    const generation = this.generation;
     if (this.building === null) {
       this.building = this.buildIndex();
     }
     const built = await this.building;
+    // ⛔ Load-bearing: `invalidate()` cannot cancel a walk already in flight, and
+    // an apply-profile takes SECONDS (it moves files, which churns
+    // metadataCache, which re-renders open notes, which look links up again).
+    // Installing this snapshot unconditionally would therefore write the
+    // PRE-invalidation world back over the invalidation — i.e. a just-activated
+    // asset would keep resolving as parked, which is exactly what the
+    // invalidation hook exists to prevent.
+    if (generation !== this.generation) {
+      this.building = null;
+      return this.ensureIndex();
+    }
     this.index = built;
     this.building = null;
     return built;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -82,6 +82,11 @@ export type {
   MountTransition,
   MountTransitionInput,
 } from "./domain/profile/ParkedMountState";
+export { ParkedAssetIndex } from "./domain/profile/ParkedAssetIndex";
+export type {
+  ParkedAssetHit,
+  ParkedVaultReader,
+} from "./domain/profile/ParkedAssetIndex";
 export type { IPropertyValidationService, ValidationResult } from "./domain/services/IPropertyValidationService";
 
 // Property definition types

--- a/packages/core/tests/domain/profile/ParkedAssetIndex.test.ts
+++ b/packages/core/tests/domain/profile/ParkedAssetIndex.test.ts
@@ -318,6 +318,49 @@ describe("ParkedAssetIndex", () => {
     );
   });
 
+  it("@req:c171e24d-15d3-4073-a34b-f6e78d3bc15f still shares ONE re-walk between concurrent lookups when an invalidation interrupts them", async () => {
+    // The existing single-walk test never invalidates, so it cannot see this:
+    // concurrent waiters resume in separate microtasks, and a naive slot-clear
+    // lets the second waiter wipe the re-walk the first had already started.
+    // The herd lands in exactly the apply-profile window this feature cares about.
+    const visible: Record<string, string> = {
+      [`${PARKED_ROOT}/kitelev/exoas-other/ns/decoy.md`]:
+        "---\nexo__Asset_uid: decoy\n---\n",
+    };
+    let releaseWalk: (() => void) | null = null;
+    const held = new Promise<void>((resolve) => {
+      releaseWalk = resolve;
+    });
+    const base = makeReader(visible);
+    let suspended = false;
+    let rootWalks = 0;
+    const slow: ParkedVaultReader = {
+      exists: base.exists.bind(base),
+      read: base.read.bind(base),
+      list: async (path) => {
+        if (path === PARKED_ROOT) rootWalks += 1;
+        const result = await base.list(path);
+        if (!suspended && path.endsWith("/ns")) {
+          suspended = true;
+          await held;
+        }
+        return result;
+      },
+    };
+    const index = new ParkedAssetIndex(slow);
+
+    const a = index.lookup(PARKED_UID);
+    const b = index.lookup("decoy");
+    while (!suspended) await new Promise((r) => setTimeout(r, 0));
+
+    index.invalidate();
+    (releaseWalk as unknown as () => void)();
+    await Promise.all([a, b]);
+
+    // One walk before the invalidation, one after — not one per waiter.
+    expect(rootWalks).toBe(2);
+  });
+
   it("@req:c171e24d-15d3-4073-a34b-f6e78d3bc15f walks the parked root only once for concurrent lookups", async () => {
     const reader = makeReader(PARKED_FILES);
     let listCalls = 0;

--- a/packages/core/tests/domain/profile/ParkedAssetIndex.test.ts
+++ b/packages/core/tests/domain/profile/ParkedAssetIndex.test.ts
@@ -134,7 +134,7 @@ describe("ParkedAssetIndex", () => {
     const index = new ParkedAssetIndex(
       makeReader({
         [`${PARKED_ROOT}/kitelev/exoas-x/ns/${uid}.md`]:
-          `---\nexo__Asset_label: "Курс: БАД"\n---\n`,
+          `---\nexo__Asset_uid: ${uid}\nexo__Asset_label: "Курс: БАД"\n---\n`,
       }),
     );
 
@@ -147,6 +147,7 @@ describe("ParkedAssetIndex", () => {
       makeReader({
         [`${PARKED_ROOT}/kitelev/exoas-x/ns/${uid}.md`]: [
           "---",
+          `exo__Asset_uid: ${uid}`,
           "exo__Asset_label:",
           "  - first",
           "  - second",
@@ -174,26 +175,147 @@ describe("ParkedAssetIndex", () => {
     const uid = "aaaaaaaa-0000-0000-0000-000000000005";
     const index = new ParkedAssetIndex(
       makeReader({
-        [`${PARKED_ROOT}/${uid}.md`]: `---\nexo__Asset_label: Stray\n---\n`,
+        [`${PARKED_ROOT}/${uid}.md`]:
+          `---\nexo__Asset_uid: ${uid}\nexo__Asset_label: Stray\n---\n`,
       }),
     );
 
     await expect(index.lookup(uid)).resolves.toBeNull();
   });
 
-  it("@req:c171e24d-15d3-4073-a34b-f6e78d3bc15f re-walks after invalidate, so an asset activated by apply-profile stops reading as parked", async () => {
-    const files = { ...PARKED_FILES };
+  it("@req:c171e24d-15d3-4073-a34b-f6e78d3bc15f re-walks after invalidate, so an AssetSpace parked by apply-profile becomes visible", async () => {
+    // The ADD direction is the discriminating one. In the REMOVE direction a
+    // stale index is indistinguishable from a fresh one — the file it points at
+    // is gone, so the read fails and the lookup returns null either way.
+    const files: Record<string, string> = {};
     const index = new ParkedAssetIndex(makeReader(files));
 
-    expect(await index.lookup(PARKED_UID)).not.toBeNull();
+    expect(await index.lookup(PARKED_UID)).toBeNull();
 
-    // Simulate the unpark: the file is no longer under the parked root. Without
-    // invalidation the cached directory listing would still report it.
-    delete files[PARKED_PATH];
-    expect(await index.lookup(PARKED_UID)).not.toBeNull();
+    // apply-profile parks the AssetSpace: its files appear under the parked root.
+    files[PARKED_PATH] = PARKED_FILES[PARKED_PATH];
+    expect(await index.lookup(PARKED_UID)).toBeNull(); // still the cached listing
 
     index.invalidate();
-    expect(await index.lookup(PARKED_UID)).toBeNull();
+    expect(await index.lookup(PARKED_UID)).not.toBeNull();
+  });
+
+  it("@req:c171e24d-15d3-4073-a34b-f6e78d3bc15f discards a walk that STARTED BEFORE an invalidation instead of installing the stale world", async () => {
+    // The window this closes is wide, not a hairline race: an apply flow takes
+    // seconds, churns metadataCache, re-renders open notes and therefore calls
+    // lookup() again — all while the first walk is still running.
+    // ⛔ The ADD direction is the only discriminating one: in the REMOVE
+    // direction a stale index is indistinguishable from a fresh one, because the
+    // file it points at is gone and the read fails either way.
+    const DECOY = `${PARKED_ROOT}/kitelev/exoas-other/ns/decoy.md`;
+    const visible: Record<string, string> = {
+      // Keeps the parked root non-empty, so walk #1 actually walks.
+      [DECOY]: "---\nexo__Asset_uid: decoy\n---\n",
+    };
+    let releaseWalk: (() => void) | null = null;
+    const held = new Promise<void>((resolve) => {
+      releaseWalk = resolve;
+    });
+    const base = makeReader(visible);
+    let suspended = false;
+    const slow: ParkedVaultReader = {
+      exists: base.exists.bind(base),
+      read: base.read.bind(base),
+      list: async (path) => {
+        const result = await base.list(path);
+        // Suspend walk #1 at its DEEPEST listing — by then it has already
+        // enumerated the whole old world, so making the new AssetSpace appear
+        // cannot leak into it. That is what makes this test discriminating
+        // rather than a coin flip on listing order.
+        if (!suspended && path.endsWith("/ns")) {
+          suspended = true;
+          await held;
+        }
+        return result;
+      },
+    };
+    const index = new ParkedAssetIndex(slow);
+
+    const inFlight = index.lookup(PARKED_UID);
+    // ⛔ Wait for the ACTUAL suspension, never a fixed number of ticks: the walk
+    // is four levels deep with several awaits per level, so releasing early lets
+    // walk #1 observe the new world and the axis becomes vacuous (verified — it
+    // stayed green with the guard removed until this loop replaced a single
+    // `await Promise.resolve()`).
+    while (!suspended) await new Promise((r) => setTimeout(r, 0));
+
+    // The apply parks a NEW AssetSpace and invalidates — while walk #1 is still
+    // in flight, holding a listing that predates both.
+    visible[PARKED_PATH] = PARKED_FILES[PARKED_PATH];
+    index.invalidate();
+    (releaseWalk as unknown as () => void)();
+    await inFlight;
+
+    // Installing walk #1's result would hide the freshly parked asset forever.
+    expect(await index.lookup(PARKED_UID)).not.toBeNull();
+  });
+
+  it("@req:c171e24d-15d3-4073-a34b-f6e78d3bc15f NEGATIVE CONTROL — a non-asset markdown file under the parked root is not a hit", async () => {
+    // Real data: 22 README.md live inside assetspaces across this device's
+    // vaults. Indexing them would decorate a genuinely broken [[README]] link.
+    const index = new ParkedAssetIndex(
+      makeReader({
+        [`${PARKED_ROOT}/kitelev/exoas-public/README.md`]:
+          "# exoas-public\n\nA knowledge pack.\n",
+      }),
+    );
+
+    await expect(index.lookup("README")).resolves.toBeNull();
+  });
+
+  it("@req:c171e24d-15d3-4073-a34b-f6e78d3bc15f NEGATIVE CONTROL — an unreadable file is not evidence of an asset", async () => {
+    const uid = "aaaaaaaa-0000-0000-0000-000000000006";
+    const base = makeReader({
+      [`${PARKED_ROOT}/kitelev/exoas-x/ns/${uid}.md`]: `---\nexo__Asset_uid: ${uid}\n---\n`,
+    });
+    const index = new ParkedAssetIndex({
+      exists: base.exists.bind(base),
+      list: base.list.bind(base),
+      read: () => Promise.reject(new Error("EACCES")),
+    });
+
+    await expect(index.lookup(uid)).resolves.toBeNull();
+  });
+
+  it("@req:c171e24d-15d3-4073-a34b-f6e78d3bc15f unescapes a double-quoted label instead of showing literal backslashes", async () => {
+    const uid = "aaaaaaaa-0000-0000-0000-000000000007";
+    const index = new ParkedAssetIndex(
+      makeReader({
+        [`${PARKED_ROOT}/kitelev/exoas-x/ns/${uid}.md`]: [
+          "---",
+          `exo__Asset_uid: ${uid}`,
+          String.raw`exo__Asset_label: "Issue \"под ключ\" = merged PR"`,
+          "---",
+        ].join("\n"),
+      }),
+    );
+
+    expect((await index.lookup(uid))?.label).toBe(
+      'Issue "под ключ" = merged PR',
+    );
+  });
+
+  it("@req:c171e24d-15d3-4073-a34b-f6e78d3bc15f unescapes a single-quoted label by YAML's own rule (doubled quote), not the double-quoted one", async () => {
+    const uid = "aaaaaaaa-0000-0000-0000-000000000008";
+    const index = new ParkedAssetIndex(
+      makeReader({
+        [`${PARKED_ROOT}/kitelev/exoas-x/ns/${uid}.md`]: [
+          "---",
+          `exo__Asset_uid: ${uid}`,
+          String.raw`exo__Asset_label: 'it''s a path C:\n not a newline'`,
+          "---",
+        ].join("\n"),
+      }),
+    );
+
+    expect((await index.lookup(uid))?.label).toBe(
+      String.raw`it's a path C:\n not a newline`,
+    );
   });
 
   it("@req:c171e24d-15d3-4073-a34b-f6e78d3bc15f walks the parked root only once for concurrent lookups", async () => {

--- a/packages/core/tests/domain/profile/ParkedAssetIndex.test.ts
+++ b/packages/core/tests/domain/profile/ParkedAssetIndex.test.ts
@@ -1,0 +1,224 @@
+import {
+  ParkedAssetIndex,
+  type ParkedVaultReader,
+} from "../../../src/domain/profile/ParkedAssetIndex";
+import { PARKED_ROOT } from "../../../src/domain/profile/ParkedMountState";
+
+/**
+ * req `c171e24d-15d3-4073-a34b-f6e78d3bc15f` — an asset in a PARKED AssetSpace
+ * is findable through the adapter, and an asset that exists nowhere is not.
+ *
+ * The fake reader models a FILESYSTEM, not an index: it answers `list`/`read`
+ * for anything actually written into it, including dot-folders. That is the
+ * production contract of `vault.adapter` and the exact property this feature
+ * stands on — an index-backed fake would make every assertion here vacuous
+ * (it could not see the parked root at all).
+ */
+function makeReader(files: Record<string, string>): ParkedVaultReader {
+  const dirsOf = (path: string): string => {
+    const parts = path.split("/");
+    parts.pop();
+    return parts.join("/");
+  };
+  // ⛔ Read the map on EVERY call, never snapshot it: the invalidate test mutates
+  // `files` mid-run to model an unpark, and a snapshot would make the fake — not
+  // the index — the thing under test.
+  const currentPaths = (): string[] => Object.keys(files);
+  const currentDirs = (): Set<string> => {
+    const dirs = new Set<string>();
+    for (const p of currentPaths()) {
+      let d = dirsOf(p);
+      while (d.length > 0) {
+        dirs.add(d);
+        d = dirsOf(d);
+      }
+    }
+    return dirs;
+  };
+  return {
+    exists: (path) =>
+      Promise.resolve(currentDirs().has(path) || files[path] !== undefined),
+    list: (path) => {
+      const prefix = `${path}/`;
+      const childFiles: string[] = [];
+      const childFolders = new Set<string>();
+      for (const p of currentPaths()) {
+        if (!p.startsWith(prefix)) continue;
+        const rest = p.slice(prefix.length);
+        if (rest.includes("/")) {
+          childFolders.add(`${prefix}${rest.split("/")[0]}`);
+        } else {
+          childFiles.push(p);
+        }
+      }
+      return Promise.resolve({
+        files: childFiles,
+        folders: Array.from(childFolders),
+      });
+    },
+    read: (path) => {
+      const content = files[path];
+      if (content === undefined) {
+        return Promise.reject(new Error(`ENOENT: ${path}`));
+      }
+      return Promise.resolve(content);
+    },
+  };
+}
+
+const PARKED_UID = "1b20a8f0-d745-4e93-91db-4531b3df120e";
+const PARKED_PATH = `${PARKED_ROOT}/kitelev/exoas-concepts/concepts/${PARKED_UID}.md`;
+
+const PARKED_FILES: Record<string, string> = {
+  [PARKED_PATH]: [
+    "---",
+    `exo__Asset_uid: ${PARKED_UID}`,
+    "exo__Asset_label: МОЧИ",
+    "exo__Instance_class:",
+    '  - "[[65b58c34-7451-4b89-bea3-483f7c65fe73]]"',
+    "---",
+    "",
+    "body",
+  ].join("\n"),
+  "assetspaces/kitelev/exoas-my/my/active.md": "---\nexo__Asset_label: Active\n---\n",
+};
+
+describe("ParkedAssetIndex", () => {
+  it("@req:c171e24d-15d3-4073-a34b-f6e78d3bc15f finds a parked asset and reports its own label plus the AssetSpace holding it", async () => {
+    const index = new ParkedAssetIndex(makeReader(PARKED_FILES));
+
+    const hit = await index.lookup(PARKED_UID);
+
+    expect(hit).not.toBeNull();
+    expect(hit?.label).toBe("МОЧИ");
+    expect(hit?.assetSpace).toBe("kitelev/exoas-concepts");
+    expect(hit?.path).toBe(PARKED_PATH);
+  });
+
+  it("@req:c171e24d-15d3-4073-a34b-f6e78d3bc15f NEGATIVE CONTROL — an asset that exists nowhere yields no hit, so a genuinely broken link stays broken", async () => {
+    const index = new ParkedAssetIndex(makeReader(PARKED_FILES));
+
+    await expect(index.lookup("00000000-0000-0000-0000-000000000000")).resolves.toBeNull();
+  });
+
+  it("@req:c171e24d-15d3-4073-a34b-f6e78d3bc15f NEGATIVE CONTROL — an ACTIVE (non-parked) asset is not reported as parked", async () => {
+    const index = new ParkedAssetIndex(makeReader(PARKED_FILES));
+
+    await expect(index.lookup("active")).resolves.toBeNull();
+  });
+
+  it("@req:c171e24d-15d3-4073-a34b-f6e78d3bc15f normalizes wikilink brackets, a heading ref and the .md suffix before lookup", async () => {
+    const index = new ParkedAssetIndex(makeReader(PARKED_FILES));
+
+    await expect(index.lookup(`[[${PARKED_UID}.md#Section]]`)).resolves.toMatchObject({
+      assetSpace: "kitelev/exoas-concepts",
+    });
+  });
+
+  it("@req:c171e24d-15d3-4073-a34b-f6e78d3bc15f reports a labelless parked asset with a null label rather than inventing one", async () => {
+    const uid = "aaaaaaaa-0000-0000-0000-000000000001";
+    const index = new ParkedAssetIndex(
+      makeReader({
+        [`${PARKED_ROOT}/kitelev/exoas-x/ns/${uid}.md`]: `---\nexo__Asset_uid: ${uid}\n---\n`,
+      }),
+    );
+
+    const hit = await index.lookup(uid);
+
+    expect(hit).not.toBeNull();
+    expect(hit?.label).toBeNull();
+  });
+
+  it("@req:c171e24d-15d3-4073-a34b-f6e78d3bc15f reads a quoted label without its quotes", async () => {
+    const uid = "aaaaaaaa-0000-0000-0000-000000000002";
+    const index = new ParkedAssetIndex(
+      makeReader({
+        [`${PARKED_ROOT}/kitelev/exoas-x/ns/${uid}.md`]:
+          `---\nexo__Asset_label: "Курс: БАД"\n---\n`,
+      }),
+    );
+
+    expect((await index.lookup(uid))?.label).toBe("Курс: БАД");
+  });
+
+  it("@req:c171e24d-15d3-4073-a34b-f6e78d3bc15f does not spill a multi-line list value into the label", async () => {
+    const uid = "aaaaaaaa-0000-0000-0000-000000000003";
+    const index = new ParkedAssetIndex(
+      makeReader({
+        [`${PARKED_ROOT}/kitelev/exoas-x/ns/${uid}.md`]: [
+          "---",
+          "exo__Asset_label:",
+          "  - first",
+          "  - second",
+          "---",
+        ].join("\n"),
+      }),
+    );
+
+    expect((await index.lookup(uid))?.label).toBeNull();
+  });
+
+  it("@req:c171e24d-15d3-4073-a34b-f6e78d3bc15f skips a nested dot-folder so a parked repo's own .git is never walked", async () => {
+    const uid = "aaaaaaaa-0000-0000-0000-000000000004";
+    const index = new ParkedAssetIndex(
+      makeReader({
+        [`${PARKED_ROOT}/kitelev/exoas-x/.git/objects/${uid}.md`]:
+          `---\nexo__Asset_label: Hidden\n---\n`,
+      }),
+    );
+
+    await expect(index.lookup(uid)).resolves.toBeNull();
+  });
+
+  it("@req:c171e24d-15d3-4073-a34b-f6e78d3bc15f ignores a stray file that does not sit under an <owner>/<repo> pair", async () => {
+    const uid = "aaaaaaaa-0000-0000-0000-000000000005";
+    const index = new ParkedAssetIndex(
+      makeReader({
+        [`${PARKED_ROOT}/${uid}.md`]: `---\nexo__Asset_label: Stray\n---\n`,
+      }),
+    );
+
+    await expect(index.lookup(uid)).resolves.toBeNull();
+  });
+
+  it("@req:c171e24d-15d3-4073-a34b-f6e78d3bc15f re-walks after invalidate, so an asset activated by apply-profile stops reading as parked", async () => {
+    const files = { ...PARKED_FILES };
+    const index = new ParkedAssetIndex(makeReader(files));
+
+    expect(await index.lookup(PARKED_UID)).not.toBeNull();
+
+    // Simulate the unpark: the file is no longer under the parked root. Without
+    // invalidation the cached directory listing would still report it.
+    delete files[PARKED_PATH];
+    expect(await index.lookup(PARKED_UID)).not.toBeNull();
+
+    index.invalidate();
+    expect(await index.lookup(PARKED_UID)).toBeNull();
+  });
+
+  it("@req:c171e24d-15d3-4073-a34b-f6e78d3bc15f walks the parked root only once for concurrent lookups", async () => {
+    const reader = makeReader(PARKED_FILES);
+    let listCalls = 0;
+    const counting: ParkedVaultReader = {
+      exists: reader.exists.bind(reader),
+      read: reader.read.bind(reader),
+      list: (path) => {
+        listCalls += 1;
+        return reader.list(path);
+      },
+    };
+    const index = new ParkedAssetIndex(counting);
+
+    await Promise.all([
+      index.lookup(PARKED_UID),
+      index.lookup(PARKED_UID),
+      index.lookup("nothing"),
+    ]);
+    const afterFirstWalk = listCalls;
+
+    await index.lookup(PARKED_UID);
+
+    expect(afterFirstWalk).toBeGreaterThan(0);
+    expect(listCalls).toBe(afterFirstWalk);
+  });
+});

--- a/packages/obsidian-plugin/src/ExocortexPlugin.ts
+++ b/packages/obsidian-plugin/src/ExocortexPlugin.ts
@@ -169,6 +169,8 @@ import {
   assessUnmountRisk,
   formatUnmountRiskWarning,
 } from "./domain/profile/unmountSafety";
+import { ParkedAssetIndex } from "@kitelev/exocortex-core";
+import { ParkedLinkPlaceholder } from "./presentation/parked/ParkedLinkPlaceholder";
 import { lookupAssetSpaceUidByFolder } from "./infrastructure/adapters/AssetSpaceLookupHelper";
 import { createAssetSpacePusher } from "./infrastructure/adapters/AssetSpacePusherFactory";
 import { LocalSecretsStore } from "./infrastructure/adapters/LocalSecretsStore";
@@ -440,6 +442,15 @@ export default class ExocortexPlugin extends Plugin {
    * call succeeds.
    */
   public profileApplyManager: ProfileApplyManager | null = null;
+  /**
+   * req `c171e24d` — basename → parked-file index over `.exocortex/parked`,
+   * read through `vault.adapter` (the parked root is a dot-folder Obsidian does
+   * not index). Invalidated after every apply flow, which is what parks and
+   * unparks mounts.
+   */
+  public parkedAssetIndex: ParkedAssetIndex | null = null;
+  /** req `c171e24d` — read by `BodyLinkPatch` / `PropertiesLinkPatch`. */
+  public parkedLinkPlaceholder: ParkedLinkPlaceholder | null = null;
 
   /**
    * Issue #3320 — profile choice lister hoisted alongside the switch
@@ -3567,6 +3578,36 @@ export default class ExocortexPlugin extends Plugin {
       notify: (message) => this.notifier.info(message),
     });
 
+    // req `c171e24d` — a link into a PARKED AssetSpace renders as
+    // "<label> ⏸ / activate" instead of a broken link.
+    //
+    // The lookup is deliberately built on `this.app.vault.adapter`: the parked
+    // root is a DOT-folder, so `getMarkdownFiles()` / `metadataCache` cannot see
+    // it, and an index-backed lookup would make the placeholder unreachable by
+    // construction. The same asymmetry already carries a production feature
+    // (`OperationsLogReader` reads `.exocortex/switch-journal.jsonl`).
+    const parkedAssetIndex = new ParkedAssetIndex({
+      exists: (path) => this.app.vault.adapter.exists(path),
+      list: (path) => this.app.vault.adapter.list(path),
+      read: (path) => this.app.vault.adapter.read(path),
+    });
+    this.parkedAssetIndex = parkedAssetIndex;
+    this.parkedLinkPlaceholder = new ParkedLinkPlaceholder({
+      lookup: (linkTarget) => parkedAssetIndex.lookup(linkTarget),
+      activate: (hit) => {
+        // ⛔ The AssetSpace name travels on the TAP, never on a tooltip — a
+        // touch device generates no hover, so a tooltip would hide it exactly
+        // on the iPhone parking exists for.
+        this.notifier.info(
+          `«${hit.label ?? hit.assetSpace}» is parked in ${this.describeAssetSpace(hit.assetSpace)}. Pick a profile that includes it to activate.`,
+        );
+        // Activation goes through the ONE existing apply path, never a private
+        // copy of unpark logic: apply-profile owns the transition table, the
+        // TS-floor assertion and the crash-recovery journal.
+        void commandsHandler.invokeApplyProfile();
+      },
+    });
+
     // RFC 0002 §3.2 (P3) — de-jargon: «Push current assetspace» → «Push current
     // knowledge pack». Name sourced from the palette grooming contract.
     this.addCommand({
@@ -3672,6 +3713,11 @@ export default class ExocortexPlugin extends Plugin {
       const refreshIndicatorAfter = (flow: Promise<void>): void => {
         void flow.finally(() => {
           void this.profileIndicator?.refresh();
+          // req `c171e24d` — an apply is the ONLY thing that parks or unparks a
+          // mount, so it is the exact moment the parked directory index goes
+          // stale. Dropping it here is what keeps a just-activated asset from
+          // still rendering as a placeholder.
+          this.parkedAssetIndex?.invalidate();
         });
       };
 
@@ -4690,6 +4736,29 @@ export default class ExocortexPlugin extends Plugin {
    * This split lets the Switch command remain fully operational regardless
    * of PAT presence, while the Push command degrades gracefully.
    */
+  /**
+   * req `c171e24d` — human name of a parked AssetSpace for the activate action.
+   *
+   * Prefers the descriptor's `exo__AssetSpace_namespace` (the short name the
+   * user sees everywhere else) and falls back to the repo segment, so the action
+   * always names SOMETHING even when the registry descriptor is unreachable.
+   */
+  private describeAssetSpace(assetSpace: string): string {
+    const repo = assetSpace.split("/").pop() ?? assetSpace;
+    try {
+      const infos = this.profileApplyManager?.listAllAssetSpaceInfos() ?? [];
+      const match = infos.find(
+        (info) => info.folderName === `assetspaces/${assetSpace}`,
+      );
+      const namespace = match?.namespace;
+      return namespace !== undefined && namespace.length > 0
+        ? namespace
+        : repo;
+    } catch {
+      return repo;
+    }
+  }
+
   private async buildAssetSpacePusher(): Promise<IAssetSpacePusher> {
     const secretsStore = new LocalSecretsStore({ app: this.app });
     const pat = await secretsStore.getSecret("pat");

--- a/packages/obsidian-plugin/src/presentation/body/BodyLinkPatch.ts
+++ b/packages/obsidian-plugin/src/presentation/body/BodyLinkPatch.ts
@@ -3,6 +3,7 @@ import { DisplayNameResolver } from "@plugin/domain/display-name/DisplayNameReso
 import { DEFAULT_DISPLAY_NAME_TEMPLATE } from "@plugin/domain/display-name/DisplayNameTemplateEngine";
 import type { PrintNameRuleService } from "@plugin/domain/display-name/PrintNameRuleService";
 import type { ExocortexSettings, DisplayNameSettings } from "@plugin/domain/settings/ExocortexSettings";
+import type { ParkedLinkPlaceholder } from "@plugin/presentation/parked/ParkedLinkPlaceholder";
 
 /**
  * BodyLinkPatch - Patches markdown body content to show display names for asset links
@@ -24,6 +25,12 @@ import type { ExocortexSettings, DisplayNameSettings } from "@plugin/domain/sett
 interface PluginWithSettings extends Plugin {
   settings: ExocortexSettings;
   printNameRuleService?: PrintNameRuleService;
+  /**
+   * req `c171e24d` — renders a link into a PARKED AssetSpace as a placeholder
+   * instead of a broken link. Optional: absent (unwired) leaves every
+   * unresolved link exactly as Obsidian rendered it.
+   */
+  parkedLinkPlaceholder?: ParkedLinkPlaceholder;
 }
 
 export class BodyLinkPatch {
@@ -203,7 +210,14 @@ export class BodyLinkPatch {
 
     // Try to find the linked file
     const file = this.resolveFile(dataHref);
-    if (!file) return;
+    if (!file) {
+      // req `c171e24d` — the link is unresolved. It may still point at an asset
+      // that IS on this device, parked under a dot-folder Obsidian does not
+      // index; the placeholder checks that via `vault.adapter` and leaves a
+      // genuinely broken link untouched.
+      this.plugin.parkedLinkPlaceholder?.decorate(linkEl, dataHref);
+      return;
+    }
 
     // Clean the data-href to get what Obsidian would show for a bare wikilink
     const cleanedDataHref = dataHref

--- a/packages/obsidian-plugin/src/presentation/parked/ParkedLinkPlaceholder.ts
+++ b/packages/obsidian-plugin/src/presentation/parked/ParkedLinkPlaceholder.ts
@@ -1,0 +1,126 @@
+import type { ParkedAssetHit } from "@kitelev/exocortex-core";
+
+/**
+ * Renders an unresolved link that points into a PARKED AssetSpace as
+ * "<asset label> ⏸" with an activate action, instead of leaving it broken
+ * (req `c171e24d`).
+ *
+ * ## Why the asset's own label and not the AssetSpace's name
+ *
+ * A link is an identity reference: the reader wants to know WHAT was linked.
+ * A placeholder reading `⏸ Concepts` answers "where it lives" and destroys the
+ * sentence the moment a paragraph carries two links into the same AssetSpace
+ * (`… helps ⏸ Concepts through ⏸ Concepts in ⏸ Concepts`). The asset's label
+ * costs only the click-through; the paragraph still says what it said.
+ *
+ * ## ⛔ Why the AssetSpace name is in the ACTION and never in a tooltip
+ *
+ * Touch devices generate no hover, so a `title`/`aria-label` tooltip would put
+ * the AssetSpace name exactly out of reach on the iPhone — the device parking
+ * exists for. The name therefore travels on the ONE channel a phone has: the
+ * tap. {@link ParkedPlaceholderDeps.activate} receives the hit and is
+ * responsible for naming the AssetSpace in whatever it opens.
+ *
+ * ## Why a miss must leave the link untouched
+ *
+ * A link to an asset that exists nowhere stays red. This class decorates ONLY
+ * on a positive hit from the parked lookup; every other outcome (miss, thrown
+ * lookup) leaves the element byte-identical, so genuinely broken links keep
+ * looking broken.
+ */
+
+/** Marks a link whose parked-lookup already ran, so it is never re-checked. */
+export const PARKED_CHECKED_ATTR = "data-parked-checked";
+/** Set on a decorated link; carries the parked AssetSpace for inspection/tests. */
+export const PARKED_SPACE_ATTR = "data-parked-assetspace";
+/**
+ * Class of a rendered placeholder.
+ *
+ * ⛤ The `exocortex-` prefix is load-bearing beyond styling: `BodyLinkPatch`
+ * skips any link inside `[class*='exocortex']`, and `closest()` matches the
+ * element itself — so a decorated link is naturally exempt from later
+ * display-name patching that would overwrite the placeholder text.
+ */
+export const PARKED_PLACEHOLDER_CLASS = "exocortex-parked-link";
+
+/** The pause glyph appended to the asset label. */
+const PAUSE_GLYPH = "⏸";
+
+export interface ParkedPlaceholderDeps {
+  /**
+   * Resolve a link target to a parked asset, or `null`.
+   *
+   * ⛔ MUST be backed by `vault.adapter`, never by `getMarkdownFiles()` /
+   * `metadataCache`: the parked root is a dot-folder that Obsidian does not
+   * index, so an index-backed lookup returns `null` for every parked asset and
+   * the placeholder becomes unreachable by construction.
+   */
+  lookup(linkTarget: string): Promise<ParkedAssetHit | null>;
+  /** Open the activate flow for this hit; MUST name the AssetSpace itself. */
+  activate(hit: ParkedAssetHit): void;
+}
+
+export class ParkedLinkPlaceholder {
+  private readonly deps: ParkedPlaceholderDeps;
+
+  constructor(deps: ParkedPlaceholderDeps) {
+    this.deps = deps;
+  }
+
+  /**
+   * Check an UNRESOLVED link and, if it points into a parked AssetSpace, render
+   * the placeholder.
+   *
+   * Fire-and-forget by design: the callers are synchronous DOM patches driven by
+   * a MutationObserver, and the lookup is I/O. The element is marked before the
+   * await so a re-patch of the same element cannot start a second lookup.
+   */
+  decorate(linkEl: HTMLElement, linkTarget: string): void {
+    if (linkEl.hasAttribute(PARKED_CHECKED_ATTR)) return;
+    linkEl.setAttribute(PARKED_CHECKED_ATTR, "true");
+    void this.resolveAndRender(linkEl, linkTarget);
+  }
+
+  private async resolveAndRender(
+    linkEl: HTMLElement,
+    linkTarget: string,
+  ): Promise<void> {
+    let hit: ParkedAssetHit | null;
+    try {
+      hit = await this.deps.lookup(linkTarget);
+    } catch {
+      // A failed lookup is NOT evidence that the asset is parked — leave the
+      // link exactly as Obsidian rendered it.
+      return;
+    }
+    if (hit === null) return;
+    this.render(linkEl, hit);
+  }
+
+  private render(linkEl: HTMLElement, hit: ParkedAssetHit): void {
+    const fallback = (hit.path.split("/").pop() ?? hit.path).replace(
+      /\.md$/i,
+      "",
+    );
+    const display = hit.label ?? fallback;
+
+    linkEl.textContent = `${display} ${PAUSE_GLYPH}`;
+    linkEl.classList.add(PARKED_PLACEHOLDER_CLASS);
+    linkEl.setAttribute(PARKED_SPACE_ATTR, hit.assetSpace);
+    // ⛔ No AssetSpace name here: a tooltip is unreachable on touch.
+    linkEl.setAttribute("aria-label", `${display} — parked on this device`);
+
+    linkEl.addEventListener(
+      "click",
+      (event: Event) => {
+        // Obsidian would otherwise offer to CREATE the missing note — the exact
+        // wrong outcome for an asset that already exists on this device.
+        event.preventDefault();
+        event.stopPropagation();
+        this.deps.activate(hit);
+      },
+      // Capture: Obsidian's own handler sits on an ancestor.
+      true,
+    );
+  }
+}

--- a/packages/obsidian-plugin/src/presentation/parked/ParkedLinkPlaceholder.ts
+++ b/packages/obsidian-plugin/src/presentation/parked/ParkedLinkPlaceholder.ts
@@ -119,7 +119,11 @@ export class ParkedLinkPlaceholder {
         event.stopPropagation();
         this.deps.activate(hit);
       },
-      // Capture: Obsidian's own handler sits on an ancestor.
+      // ⛔ Capture, and per-element on purpose: Obsidian's own handler sits on an
+      // ancestor, so only a capture-phase listener ON the link runs first. Do
+      // NOT "tidy" this into one delegated ancestor handler — that loses the
+      // ordering this depends on. The listener is not a leak: it lives on the
+      // element, dies with it, and is attached only on a positive hit.
       true,
     );
   }

--- a/packages/obsidian-plugin/src/presentation/properties/PropertiesLinkPatch.ts
+++ b/packages/obsidian-plugin/src/presentation/properties/PropertiesLinkPatch.ts
@@ -3,6 +3,7 @@ import { DisplayNameResolver } from "@plugin/domain/display-name/DisplayNameReso
 import { DEFAULT_DISPLAY_NAME_TEMPLATE } from "@plugin/domain/display-name/DisplayNameTemplateEngine";
 import type { PrintNameRuleService } from "@plugin/domain/display-name/PrintNameRuleService";
 import type { ExocortexSettings, DisplayNameSettings } from "@plugin/domain/settings/ExocortexSettings";
+import type { ParkedLinkPlaceholder } from "@plugin/presentation/parked/ParkedLinkPlaceholder";
 
 /**
  * PropertiesLinkPatch - Patches Obsidian's Properties block to show display names for links
@@ -22,6 +23,12 @@ import type { ExocortexSettings, DisplayNameSettings } from "@plugin/domain/sett
 interface PluginWithSettings extends Plugin {
   settings: ExocortexSettings;
   printNameRuleService?: PrintNameRuleService;
+  /**
+   * req `c171e24d` — renders a link into a PARKED AssetSpace as a placeholder
+   * instead of a broken link. Optional: absent (unwired) leaves every
+   * unresolved link exactly as Obsidian rendered it.
+   */
+  parkedLinkPlaceholder?: ParkedLinkPlaceholder;
 }
 
 export class PropertiesLinkPatch {
@@ -183,7 +190,14 @@ export class PropertiesLinkPatch {
 
     // Try to find the linked file
     const file = this.resolveFile(dataHref);
-    if (!file) return;
+    if (!file) {
+      // req `c171e24d` — the link is unresolved. It may still point at an asset
+      // that IS on this device, parked under a dot-folder Obsidian does not
+      // index; the placeholder checks that via `vault.adapter` and leaves a
+      // genuinely broken link untouched.
+      this.plugin.parkedLinkPlaceholder?.decorate(linkEl, dataHref);
+      return;
+    }
 
     // Clean the data-href to get what Obsidian would show for a bare wikilink
     const cleanedDataHref = dataHref

--- a/packages/obsidian-plugin/styles.css
+++ b/packages/obsidian-plugin/styles.css
@@ -6403,3 +6403,37 @@
   flex: 1 1 auto;
   min-width: 0;
 }
+
+/* ==========================================================================
+   Parked-link placeholder (req c171e24d)
+   ==========================================================================
+   A link into a PARKED AssetSpace stays an UNRESOLVED link as far as Obsidian
+   is concerned, so it keeps `.is-unresolved` and its "this is broken" colour.
+   That colour is exactly the claim the placeholder exists to deny: the asset is
+   on this device, it is simply not active.
+
+   ⛔ The rule therefore has to out-specify `.internal-link.is-unresolved` (0,2,0),
+   which is why the second selector carries BOTH classes (0,3,0) rather than the
+   placeholder class alone — alone it only TIES and wins on source order. The
+   first selector is the harmless fallback should Obsidian ever drop the state
+   class. Colour comes from theme variables, never a literal, so the placeholder
+   follows the reader's theme.
+
+   ⚠ This out-specifies OBSIDIAN's own rule, not every theme's: a theme rule such
+   as `.markdown-preview-view .internal-link.is-unresolved` is also (0,3,0) and
+   theme CSS loads after plugin CSS, so it would win. Tightening that is a
+   deliberate escalation, not an oversight. */
+.internal-link.exocortex-parked-link,
+.internal-link.is-unresolved.exocortex-parked-link {
+  color: var(--text-muted);
+  opacity: 1;
+  text-decoration: none;
+  border-bottom: 1px dashed var(--text-faint);
+  cursor: pointer;
+}
+
+.internal-link.exocortex-parked-link:hover,
+.internal-link.is-unresolved.exocortex-parked-link:hover {
+  color: var(--text-normal);
+  border-bottom-color: var(--text-muted);
+}

--- a/packages/obsidian-plugin/tests/unit/presentation/parked/ParkedLinkPlaceholder.test.ts
+++ b/packages/obsidian-plugin/tests/unit/presentation/parked/ParkedLinkPlaceholder.test.ts
@@ -1,0 +1,302 @@
+import {
+  ParkedLinkPlaceholder,
+  PARKED_PLACEHOLDER_CLASS,
+  PARKED_SPACE_ATTR,
+} from "../../../../src/presentation/parked/ParkedLinkPlaceholder";
+import { BodyLinkPatch } from "../../../../src/presentation/body/BodyLinkPatch";
+import { PropertiesLinkPatch } from "../../../../src/presentation/properties/PropertiesLinkPatch";
+import type { ParkedAssetHit } from "@kitelev/exocortex-core";
+
+/**
+ * req `c171e24d-15d3-4073-a34b-f6e78d3bc15f` — an unresolved link into a PARKED
+ * AssetSpace renders as "<label> ⏸ / activate"; an unresolved link to an asset
+ * that exists nowhere stays exactly as Obsidian left it.
+ *
+ * Both render channels are covered through their REAL entry points
+ * (`BodyLinkPatch.enable()` / `PropertiesLinkPatch.enable()`), not by calling the
+ * placeholder directly — the wiring being present in the production path is a
+ * separate guarantee from the placeholder doing its job, and only these two
+ * suites lock it.
+ */
+
+const PARKED_UID = "1b20a8f0-d745-4e93-91db-4531b3df120e";
+const HIT: ParkedAssetHit = {
+  path: `.exocortex/parked/kitelev/exoas-concepts/concepts/${PARKED_UID}.md`,
+  assetSpace: "kitelev/exoas-concepts",
+  label: "МОЧИ",
+};
+
+/** Let the fire-and-forget lookup settle. */
+const settle = (): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, 0));
+
+function makeLink(): HTMLElement {
+  const link = document.createElement("a");
+  link.className = "internal-link";
+  link.setAttribute("data-href", PARKED_UID);
+  link.textContent = PARKED_UID;
+  return link;
+}
+
+describe("ParkedLinkPlaceholder", () => {
+  it("@req:c171e24d-15d3-4073-a34b-f6e78d3bc15f renders the ASSET's own label with a pause glyph", async () => {
+    const link = makeLink();
+    const placeholder = new ParkedLinkPlaceholder({
+      lookup: () => Promise.resolve(HIT),
+      activate: () => undefined,
+    });
+
+    placeholder.decorate(link, PARKED_UID);
+    await settle();
+
+    expect(link.textContent).toBe("МОЧИ ⏸");
+    expect(link.classList.contains(PARKED_PLACEHOLDER_CLASS)).toBe(true);
+    expect(link.getAttribute(PARKED_SPACE_ATTR)).toBe("kitelev/exoas-concepts");
+  });
+
+  it("@req:c171e24d-15d3-4073-a34b-f6e78d3bc15f keeps the AssetSpace name OUT of the tooltip — a touch device generates no hover", async () => {
+    const link = makeLink();
+    const placeholder = new ParkedLinkPlaceholder({
+      lookup: () => Promise.resolve(HIT),
+      activate: () => undefined,
+    });
+
+    placeholder.decorate(link, PARKED_UID);
+    await settle();
+
+    const tooltip = `${link.getAttribute("aria-label") ?? ""}${link.getAttribute("title") ?? ""}`;
+    expect(tooltip).not.toContain("exoas-concepts");
+    expect(tooltip).not.toContain("kitelev/");
+    expect(tooltip).toContain("МОЧИ");
+  });
+
+  it("@req:c171e24d-15d3-4073-a34b-f6e78d3bc15f routes a tap to the activate action instead of Obsidian's create-missing-note", async () => {
+    const link = makeLink();
+    const activated: ParkedAssetHit[] = [];
+    const placeholder = new ParkedLinkPlaceholder({
+      lookup: () => Promise.resolve(HIT),
+      activate: (hit) => activated.push(hit),
+    });
+
+    placeholder.decorate(link, PARKED_UID);
+    await settle();
+
+    const event = new MouseEvent("click", { bubbles: true, cancelable: true });
+    link.dispatchEvent(event);
+
+    expect(activated).toEqual([HIT]);
+    expect(event.defaultPrevented).toBe(true);
+  });
+
+  it("@req:c171e24d-15d3-4073-a34b-f6e78d3bc15f NEGATIVE CONTROL — a link to an asset that exists nowhere is left untouched (stays broken)", async () => {
+    const link = makeLink();
+    const placeholder = new ParkedLinkPlaceholder({
+      lookup: () => Promise.resolve(null),
+      activate: () => undefined,
+    });
+
+    placeholder.decorate(link, PARKED_UID);
+    await settle();
+
+    expect(link.textContent).toBe(PARKED_UID);
+    expect(link.classList.contains(PARKED_PLACEHOLDER_CLASS)).toBe(false);
+    expect(link.hasAttribute(PARKED_SPACE_ATTR)).toBe(false);
+  });
+
+  it("@req:c171e24d-15d3-4073-a34b-f6e78d3bc15f NEGATIVE CONTROL — a failed lookup is not evidence of parking, the link is left untouched", async () => {
+    const link = makeLink();
+    const placeholder = new ParkedLinkPlaceholder({
+      lookup: () => Promise.reject(new Error("adapter unavailable")),
+      activate: () => undefined,
+    });
+
+    placeholder.decorate(link, PARKED_UID);
+    await settle();
+
+    expect(link.textContent).toBe(PARKED_UID);
+    expect(link.classList.contains(PARKED_PLACEHOLDER_CLASS)).toBe(false);
+  });
+
+  it("@req:c171e24d-15d3-4073-a34b-f6e78d3bc15f falls back to the file's own basename when the parked asset carries no label", async () => {
+    const link = makeLink();
+    const placeholder = new ParkedLinkPlaceholder({
+      lookup: () => Promise.resolve({ ...HIT, label: null }),
+      activate: () => undefined,
+    });
+
+    placeholder.decorate(link, PARKED_UID);
+    await settle();
+
+    expect(link.textContent).toBe(`${PARKED_UID} ⏸`);
+  });
+
+  it("@req:c171e24d-15d3-4073-a34b-f6e78d3bc15f checks a given link only once, however many times the patch re-runs", async () => {
+    const link = makeLink();
+    let lookups = 0;
+    const placeholder = new ParkedLinkPlaceholder({
+      lookup: () => {
+        lookups += 1;
+        return Promise.resolve(HIT);
+      },
+      activate: () => undefined,
+    });
+
+    placeholder.decorate(link, PARKED_UID);
+    placeholder.decorate(link, PARKED_UID);
+    await settle();
+    placeholder.decorate(link, PARKED_UID);
+    await settle();
+
+    expect(lookups).toBe(1);
+  });
+});
+
+/**
+ * Both channels, through their real entry points. These are the axes that lock
+ * the WIRING: deleting the `decorate(...)` call from either patch reddens the
+ * corresponding test while everything above stays green.
+ */
+describe("parked placeholder reaches BOTH render channels", () => {
+  let container: HTMLElement;
+
+  function makePlugin(
+    placeholder: ParkedLinkPlaceholder | undefined,
+    root: HTMLElement,
+  ): Record<string, unknown> {
+    return {
+      app: {
+        workspace: {
+          getLeavesOfType: () => [{ view: { containerEl: root } }],
+          on: () => ({ id: "t" }),
+        },
+        vault: { getAbstractFileByPath: () => null },
+        metadataCache: {
+          // The parked asset is invisible to the index BY CONSTRUCTION — that
+          // asymmetry is the whole mechanism, so the fake must reproduce it.
+          getFirstLinkpathDest: () => null,
+          getFileCache: () => null,
+          on: () => ({ id: "t" }),
+        },
+      },
+      registerEvent: () => undefined,
+      settings: {
+        displayNameSettings: { defaultTemplate: "{{exo__Asset_label}}", classTemplates: {} },
+      },
+      parkedLinkPlaceholder: placeholder,
+    };
+  }
+
+  afterEach(() => {
+    if (container.parentNode !== null) container.parentNode.removeChild(container);
+  });
+
+  it("@req:c171e24d-15d3-4073-a34b-f6e78d3bc15f body channel — a wikilink in the note body renders the placeholder", async () => {
+    const preview = document.createElement("div");
+    preview.className = "markdown-preview-view";
+    const link = makeLink();
+    preview.appendChild(link);
+    container = document.createElement("div");
+    container.appendChild(preview);
+    document.body.appendChild(container);
+
+    const placeholder = new ParkedLinkPlaceholder({
+      lookup: () => Promise.resolve(HIT),
+      activate: () => undefined,
+    });
+    const patch = new BodyLinkPatch(
+      makePlugin(placeholder, container) as never,
+    );
+    patch.enable();
+    await settle();
+    patch.cleanup();
+
+    expect(link.textContent).toBe("МОЧИ ⏸");
+  });
+
+  it("@req:c171e24d-15d3-4073-a34b-f6e78d3bc15f body channel NEGATIVE CONTROL — with no parked hit the body link stays broken", async () => {
+    const preview = document.createElement("div");
+    preview.className = "markdown-preview-view";
+    const link = makeLink();
+    preview.appendChild(link);
+    container = document.createElement("div");
+    container.appendChild(preview);
+    document.body.appendChild(container);
+
+    const placeholder = new ParkedLinkPlaceholder({
+      lookup: () => Promise.resolve(null),
+      activate: () => undefined,
+    });
+    const patch = new BodyLinkPatch(
+      makePlugin(placeholder, container) as never,
+    );
+    patch.enable();
+    await settle();
+    patch.cleanup();
+
+    expect(link.textContent).toBe(PARKED_UID);
+  });
+
+  it("@req:c171e24d-15d3-4073-a34b-f6e78d3bc15f frontmatter channel — a link in the Properties block renders the placeholder", async () => {
+    const metadata = document.createElement("div");
+    metadata.className = "metadata-container";
+    const link = makeLink();
+    metadata.appendChild(link);
+    container = document.createElement("div");
+    container.appendChild(metadata);
+    document.body.appendChild(container);
+
+    const placeholder = new ParkedLinkPlaceholder({
+      lookup: () => Promise.resolve(HIT),
+      activate: () => undefined,
+    });
+    const patch = new PropertiesLinkPatch(
+      makePlugin(placeholder, container) as never,
+    );
+    patch.enable();
+    await settle();
+    patch.cleanup();
+
+    expect(link.textContent).toBe("МОЧИ ⏸");
+  });
+
+  it("@req:c171e24d-15d3-4073-a34b-f6e78d3bc15f frontmatter channel NEGATIVE CONTROL — with no parked hit the property link stays broken", async () => {
+    const metadata = document.createElement("div");
+    metadata.className = "metadata-container";
+    const link = makeLink();
+    metadata.appendChild(link);
+    container = document.createElement("div");
+    container.appendChild(metadata);
+    document.body.appendChild(container);
+
+    const placeholder = new ParkedLinkPlaceholder({
+      lookup: () => Promise.resolve(null),
+      activate: () => undefined,
+    });
+    const patch = new PropertiesLinkPatch(
+      makePlugin(placeholder, container) as never,
+    );
+    patch.enable();
+    await settle();
+    patch.cleanup();
+
+    expect(link.textContent).toBe(PARKED_UID);
+  });
+
+  it("@req:c171e24d-15d3-4073-a34b-f6e78d3bc15f NEGATIVE CONTROL — an unwired placeholder leaves both channels byte-identical", async () => {
+    const preview = document.createElement("div");
+    preview.className = "markdown-preview-view";
+    const link = makeLink();
+    preview.appendChild(link);
+    container = document.createElement("div");
+    container.appendChild(preview);
+    document.body.appendChild(container);
+
+    const patch = new BodyLinkPatch(makePlugin(undefined, container) as never);
+    patch.enable();
+    await settle();
+    patch.cleanup();
+
+    expect(link.textContent).toBe(PARKED_UID);
+    expect(link.hasAttribute("data-parked-checked")).toBe(false);
+  });
+});


### PR DESCRIPTION
## What

A wikilink into a **parked** AssetSpace now renders as `«<asset label> ⏸»` with a tap that opens activation, instead of Obsidian's native unresolved form (a raw UID, dimmed, no preview).

Parking moves an AssetSpace's bytes to `.exocortex/parked/<owner>/<repo>` (req `d4ccc901`) — a dot-folder Obsidian never indexes. Both link patches therefore bailed at their `if (!file) return` seam. The bytes are still on the device, so the honest render is *"here, just not active"*.

Req: c171e24d-15d3-4073-a34b-f6e78d3bc15f

## How

- **`ParkedAssetIndex`** (core) walks `.exocortex/parked` through a port shaped as the `exists`/`list`/`read` subset of `vault.adapter` — ⛔ never `getMarkdownFiles()`, which cannot see dot-folders by construction (the same asymmetry `OperationsLogReader` already depends on in production). Resolves a link target to `{path, assetSpace, label}`.
  **Positive-evidence only**: a basename it cannot find yields `null`, so a genuinely broken link stays broken.
- **`ParkedLinkPlaceholder`** (plugin) renders the **asset's own label** + `⏸`. ⛔ The AssetSpace name is carried into the **action**, never into the text and never into a tooltip — a touch device generates no hover, so a tooltip would hide it exactly on the iPhone parking exists for.
- Wired into **both** render channels at their existing unresolved-link seam (`BodyLinkPatch` = prose, `PropertiesLinkPatch` = frontmatter), through an **optional** plugin field: unwired, both channels are byte-identical.
- **Activation reuses the ONE existing path** — `ProfileCommands.invokeApplyProfile()`, which owns the transition table, the TS-floor assertion and the crash-recovery journal. No private unpark logic.
- The parked index is invalidated **only** after an apply flow — the one thing that parks/unparks a mount — so it is never rebuilt from a `metadataCache` event (the documented indexing-storm / iPhone-Jetsam class).

## Revert-verified (each break reds exactly its own axis)

| Break | RED | GREEN |
|---|---|---|
| drop `out.set(base, file)` in the parked walk | 6 positive core tests | both NEGATIVE CONTROLs |
| make `lookup` guess a path instead of requiring evidence | 4 must-stay-null tests | positives |
| delete the `decorate(...)` call in `BodyLinkPatch` | ONLY the body-channel test | frontmatter channel |
| delete the `decorate(...)` call in `PropertiesLinkPatch` | ONLY the frontmatter test | body channel |
| put the AssetSpace name into `aria-label` | ONLY the no-tooltip test | rest |

23 new tests (11 core + 12 plugin); `packages/core/tests/domain/profile` 57/57, plugin presentation suites 144/144, `check:types` clean, all three `lint`-job guard scripts OK.

## Deliberately out of scope

The parent task also asks for a **native-runner CI E2E** (`tests/e2e/eka-gui`) proving the placeholder renders in a real Obsidian. That is a separate deliverable with its own vault-fixture setup and is carved out as a follow-up task under the same parent; this PR claims only what its bound tests prove — the DOM output of both channels and the lookup semantics. ⛔ Local Docker E2E is not an option (QEMU emulation has produced kernel panics).
