### PR TITLE
fix(e2e): write eka-gui req-evidence.json into the CI artifact, not under testDir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ playwright-report/
 playwright-report-ct/
 playwright-report-ct*/
 test-results/
+test-results-eka-gui/
 playwright/.cache/
 build-meta.json
 flaky-report.json

--- a/packages/obsidian-plugin/tests/e2e/eka-gui/req-evidence-reporter.ts
+++ b/packages/obsidian-plugin/tests/e2e/eka-gui/req-evidence-reporter.ts
@@ -1,5 +1,6 @@
 import type {
   FullConfig,
+  FullProject,
   Reporter,
   TestCase,
   TestResult,
@@ -62,21 +63,49 @@ export function extractReqUids(title: string): string[] {
   return uids;
 }
 
-function resolveOutputPath(rootDir: string): string {
+/**
+ * The subset of `FullConfig` the output-path resolution reads. Declared
+ * structurally so a unit test can exercise the resolution without building a
+ * whole `FullConfig`; a real `FullConfig` satisfies it.
+ */
+export type ReqEvidenceOutputConfig = Pick<FullConfig, "rootDir"> & {
+  configFile?: string;
+  projects: readonly Pick<FullProject, "outputDir">[];
+};
+
+export function resolveOutputPath(config: ReqEvidenceOutputConfig): string {
   const envOverride = process.env.EKA_GUI_REQ_EVIDENCE_OUTPUT;
   if (envOverride) return envOverride;
-  // `outputDir: "test-results-eka-gui"` (playwright-eka-gui.config.ts) is the
-  // Docker volume mount (-v $PWD/eka-gui-results:/app/.../test-results-eka-gui),
-  // so writing here ensures the manifest is picked up as a CI artifact.
-  return path.join(rootDir, "test-results-eka-gui", "req-evidence.json");
+  // ⛔ NOT `config.rootDir`: Playwright derives rootDir from `testDir`
+  // (`./tests/e2e/eka-gui`), so writing there put the manifest at
+  // packages/obsidian-plugin/tests/e2e/eka-gui/test-results-eka-gui/ — outside
+  // the Docker volume mount AND outside the `upload-artifact` path, i.e. it
+  // never reached the eka-gui-req-evidence artifact.
+  //
+  // `outputDir: "test-results-eka-gui"` (playwright-eka-gui.config.ts) is
+  // resolved by Playwright against the CONFIG directory and surfaced already
+  // absolute on each project. That resolved directory IS the mount
+  // (-v $PWD/eka-gui-results:/app/packages/obsidian-plugin/test-results-eka-gui)
+  // and the uploaded path, so writing there is what puts the manifest in the
+  // CI artifact.
+  const projectOutputDir = config.projects[0]?.outputDir;
+  if (projectOutputDir) return path.join(projectOutputDir, "req-evidence.json");
+  // Defensive fallback (a loaded config always has ≥1 project): the config
+  // directory, which is what `outputDir` would have been resolved against.
+  const base = config.configFile
+    ? path.dirname(config.configFile)
+    : config.rootDir;
+  return path.join(base, "test-results-eka-gui", "req-evidence.json");
 }
 
 export default class ReqEvidenceReporter implements Reporter {
   private rootDir: string = process.cwd();
+  private outPath: string = path.join(process.cwd(), "req-evidence.json");
   private entries: ReqEvidenceEntry[] = [];
 
   onBegin(config: FullConfig): void {
     this.rootDir = config.rootDir || process.cwd();
+    this.outPath = resolveOutputPath(config);
   }
 
   onTestEnd(test: TestCase, result: TestResult): void {
@@ -107,12 +136,12 @@ export default class ReqEvidenceReporter implements Reporter {
         reqUids: [...new Set(this.entries.map((e) => e.reqUid))].sort(),
         entries: this.entries,
       };
-      const outPath = resolveOutputPath(this.rootDir);
+      const outPath = this.outPath;
       fs.mkdirSync(path.dirname(outPath), { recursive: true });
       fs.writeFileSync(outPath, JSON.stringify(manifest, null, 2), "utf-8");
       console.log(
         `[req-evidence-reporter] ${manifest.totalReqScenarios} @req scenario(s) for ` +
-          `${manifest.reqUids.length} requirement(s) → ${path.relative(this.rootDir, outPath)}`,
+          `${manifest.reqUids.length} requirement(s) → ${path.relative(process.cwd(), outPath)}`,
       );
     } catch (err) {
       console.warn("[req-evidence-reporter] manifest write failed:", err);

--- a/packages/obsidian-plugin/tests/e2e/eka-gui/req-evidence-reporter.ts
+++ b/packages/obsidian-plugin/tests/e2e/eka-gui/req-evidence-reporter.ts
@@ -76,8 +76,9 @@ export type ReqEvidenceOutputConfig = Pick<FullConfig, "rootDir"> & {
 export function resolveOutputPath(config: ReqEvidenceOutputConfig): string {
   const envOverride = process.env.EKA_GUI_REQ_EVIDENCE_OUTPUT;
   if (envOverride) return envOverride;
-  // ⛔ NOT `config.rootDir`: Playwright derives rootDir from `testDir`
-  // (`./tests/e2e/eka-gui`), so writing there put the manifest at
+  // ⛔ NOT `config.rootDir`: Playwright sets it to the resolved `testDir`
+  // (`rootDir: pathResolve(configDir, userConfig.testDir) || configDir`), i.e.
+  // `./tests/e2e/eka-gui` here — so writing there put the manifest at
   // packages/obsidian-plugin/tests/e2e/eka-gui/test-results-eka-gui/ — outside
   // the Docker volume mount AND outside the `upload-artifact` path, i.e. it
   // never reached the eka-gui-req-evidence artifact.
@@ -88,6 +89,14 @@ export function resolveOutputPath(config: ReqEvidenceOutputConfig): string {
   // (-v $PWD/eka-gui-results:/app/packages/obsidian-plugin/test-results-eka-gui)
   // and the uploaded path, so writing there is what puts the manifest in the
   // CI artifact.
+  //
+  // `projects[0]` is unambiguous here, and that is a property of the config, not
+  // a guess: playwright-eka-gui.config.ts declares NO `projects` array, and
+  // Playwright then synthesises exactly one project from the top level
+  // (`projectConfigs = cliOverrides.projects || userConfig.projects || [{...userConfig}]`
+  // in playwright/lib/common/config.js, v1.56). If this suite ever grows a real
+  // `projects` array with differing outputDirs, revisit — the first project's
+  // directory would then be pinned for every scenario.
   const projectOutputDir = config.projects[0]?.outputDir;
   if (projectOutputDir) return path.join(projectOutputDir, "req-evidence.json");
   // Defensive fallback (a loaded config always has ≥1 project): the config

--- a/packages/obsidian-plugin/tests/unit/eka-gui-req-evidence-reporter.test.ts
+++ b/packages/obsidian-plugin/tests/unit/eka-gui-req-evidence-reporter.test.ts
@@ -1,5 +1,11 @@
-import { describe, it, expect } from "@jest/globals";
-import { extractReqUids } from "../e2e/eka-gui/req-evidence-reporter";
+import { describe, it, expect, afterEach } from "@jest/globals";
+import * as fs from "fs";
+import * as path from "path";
+import {
+  extractReqUids,
+  resolveOutputPath,
+  type ReqEvidenceOutputConfig,
+} from "../e2e/eka-gui/req-evidence-reporter";
 
 // al-gui-ci-runner — the eka-gui req-evidence reporter binds an eka-gui scenario
 // to a requirement by a `@req:<uid>` token in the test title (the AUTOMATED
@@ -37,5 +43,89 @@ describe("eka-gui req-evidence reporter — extractReqUids", () => {
 
   it("ignores a malformed (non-UUID) @req token", () => {
     expect(extractReqUids(`${TAG}not-a-uuid`)).toEqual([]);
+  });
+});
+
+// The manifest is the machine-readable ui-acceptance evidence, and it only
+// counts if it reaches the `eka-gui-req-evidence` CI artifact. The artifact is
+// Playwright's resolved `outputDir` (= the Docker volume mount = the
+// upload-artifact path). Writing to `config.rootDir` instead put the manifest
+// under tests/e2e/eka-gui/ — Playwright derives rootDir from `testDir`, NOT from
+// the config directory — so it never reached the artifact at all.
+describe("eka-gui req-evidence reporter — resolveOutputPath", () => {
+  // Playwright surfaces `outputDir` already resolved (absolute) on each project.
+  const PROJECT_OUTPUT_DIR =
+    "/repo/packages/obsidian-plugin/test-results-eka-gui";
+  // …whereas rootDir is derived from `testDir`, which is much deeper.
+  const ROOT_DIR = "/repo/packages/obsidian-plugin/tests/e2e/eka-gui";
+  const CONFIG_FILE =
+    "/repo/packages/obsidian-plugin/playwright-eka-gui.config.ts";
+
+  const fullConfig: ReqEvidenceOutputConfig = {
+    rootDir: ROOT_DIR,
+    configFile: CONFIG_FILE,
+    projects: [{ outputDir: PROJECT_OUTPUT_DIR }],
+  };
+
+  afterEach(() => {
+    delete process.env.EKA_GUI_REQ_EVIDENCE_OUTPUT;
+  });
+
+  it("writes into the project outputDir (the CI artifact), NOT under rootDir", () => {
+    const out = resolveOutputPath(fullConfig);
+    expect(out).toBe(path.join(PROJECT_OUTPUT_DIR, "req-evidence.json"));
+    // The regression this pins: rootDir is testDir, so a rootDir-based path
+    // lands outside the artifact.
+    expect(out.startsWith(ROOT_DIR)).toBe(false);
+  });
+
+  it("honours the EKA_GUI_REQ_EVIDENCE_OUTPUT override", () => {
+    process.env.EKA_GUI_REQ_EVIDENCE_OUTPUT = "/tmp/custom/evidence.json";
+    expect(resolveOutputPath(fullConfig)).toBe("/tmp/custom/evidence.json");
+  });
+
+  it("falls back to the CONFIG directory (not rootDir) when no project is present", () => {
+    const out = resolveOutputPath({
+      rootDir: ROOT_DIR,
+      configFile: CONFIG_FILE,
+      projects: [],
+    });
+    expect(out).toBe(
+      path.join(
+        path.dirname(CONFIG_FILE),
+        "test-results-eka-gui",
+        "req-evidence.json",
+      ),
+    );
+  });
+});
+
+// Coupling axis: the fix only holds while Playwright's `outputDir`, the Docker
+// volume mount and the uploaded path name the SAME directory. Changing one of
+// the three silently re-opens the defect (manifest written somewhere the
+// artifact does not collect), and no unit test of the reporter alone can see it.
+describe("eka-gui req-evidence — outputDir ↔ Docker mount ↔ artifact coupling", () => {
+  // __dirname = packages/obsidian-plugin/tests/unit
+  const repoRoot = path.resolve(__dirname, "../../../..");
+  const readRepoFile = (rel: string): string =>
+    fs.readFileSync(path.join(repoRoot, rel), "utf-8");
+
+  it("playwright outputDir, the docker -v target and upload-artifact agree", () => {
+    const pwConfig = readRepoFile(
+      "packages/obsidian-plugin/playwright-eka-gui.config.ts",
+    );
+    const workflow = readRepoFile(".github/workflows/eka-gui-e2e.yml");
+
+    const outputDir = /outputDir:\s*"([^"]+)"/.exec(pwConfig)?.[1];
+    expect(outputDir).toBe("test-results-eka-gui");
+
+    // The mount target is the config dir + outputDir, inside the image's /app.
+    expect(workflow).toContain(
+      `:/app/packages/obsidian-plugin/${outputDir as string}`,
+    );
+    // …and the host side of that mount is what upload-artifact publishes.
+    const hostDir = /-v "\$PWD\/([^:]+):/.exec(workflow)?.[1];
+    expect(hostDir).toBe("eka-gui-results");
+    expect(workflow).toContain(`path: ${hostDir as string}`);
   });
 });


### PR DESCRIPTION
## Problem

`packages/obsidian-plugin/tests/e2e/eka-gui/req-evidence-reporter.ts` resolved its
manifest path against `config.rootDir`:

```ts
path.join(rootDir, "test-results-eka-gui", "req-evidence.json")
```

Playwright derives `rootDir` from `testDir` (`./tests/e2e/eka-gui`), **not** from the
config directory. So the manifest landed at

```
packages/obsidian-plugin/tests/e2e/eka-gui/test-results-eka-gui/req-evidence.json
```

while the Docker volume mount and `upload-artifact` in `.github/workflows/eka-gui-e2e.yml`
collect `packages/obsidian-plugin/test-results-eka-gui`.

⇒ the machine-readable ui-acceptance evidence — the whole reason the artifact is
retained on **successful** runs — **never reached the artifact**, even though the
reporter's own comment claimed «writing here ensures the manifest is picked up as a
CI artifact» and its log line printed a plausible-looking relative path.

Pre-existing defect, found by adversarial review of #4044; filed separately rather
than patched in passing.

Evidence it was real (three independent ways, by the reviewer):

1. the artifact of the last green `main` run (`31734410745`) contains only screenshot
   dirs — no `req-evidence.json`;
2. same in failing run `31741854258`, despite the log line
   `[req-evidence-reporter] N @req scenario(s) … → test-results-eka-gui/req-evidence.json`;
3. a local `--list` produced an **untracked, non-ignored**
   `packages/obsidian-plugin/tests/e2e/eka-gui/test-results-eka-gui/req-evidence.json`.

## Fix

Resolve against `config.projects[0].outputDir`. Playwright resolves `outputDir`
(`playwright-eka-gui.config.ts`) against the **config** directory and surfaces it
already absolute on each project — that resolved directory **is** the mount
(`-v $PWD/eka-gui-results:/app/packages/obsidian-plugin/test-results-eka-gui`) and the
uploaded path. The `EKA_GUI_REQ_EVIDENCE_OUTPUT` override still wins; a config-dir
fallback covers the (unreachable) no-project case.

Chose the code fix over setting `EKA_GUI_REQ_EVIDENCE_OUTPUT` in the workflow's
`docker run`: the env route would leave local runs writing to the wrong place and
would duplicate the path in a second file.

Also: `.gitignore` gains `test-results-eka-gui/` — the stray artifact was untracked
and **not** ignored, so a `git add -A` would have committed run output.

## Verification

**Empirical, `npx playwright test -c packages/obsidian-plugin/playwright-eka-gui.config.ts --list`:**

| | manifest path |
|---|---|
| before | `packages/obsidian-plugin/tests/e2e/eka-gui/test-results-eka-gui/req-evidence.json` |
| after | `packages/obsidian-plugin/test-results-eka-gui/req-evidence.json` |

and `git check-ignore` now matches the artifact dir.

**Revert-verify — 4 axes, each mutant reddens exactly its own axis** (harness ran
against a hardlinked copy; the working tree was never mutated):

| mutant | RED axis |
|---|---|
| resolve against `rootDir` (the original defect) | `writes into the project outputDir` |
| drop the env override | `honours EKA_GUI_REQ_EVIDENCE_OUTPUT` |
| fallback via `rootDir` | `falls back to the CONFIG directory` |
| drift playwright `outputDir` | coupling axis |

Unmutated copy: 8/8 green.

The coupling axis pins the invariant the defect broke: playwright `outputDir`, the
`docker -v` target and the `upload-artifact` path must name the same directory —
changing one of the three silently re-opens the defect, and no reporter-only unit
test can see that.

**Gates:** `check:types` rc=0 · `lint` rc=0 · all three `lint`-job guard scripts rc=0 ·
prettier clean · unit suite 8/8.

## Acceptance

This PR touches `packages/obsidian-plugin/tests/e2e/eka-gui/**`, so the (non-required)
`eka-gui` suite runs on it via the paths filter — a green run's
`eka-gui-req-evidence` artifact should now **contain** `req-evidence.json` with a
non-empty `@req` scenario list. That is the acceptance criterion.

Task: `3d763c7b-9dd6-4c7d-9768-d9a89b1bb631`

https://claude.ai/code/session_01VSriicEMN85KR5WyPjmevH
