### PR TITLE
feat(display-name): exo__PrintedProperty_property as an ordered preference list

### DIFF
--- a/packages/obsidian-plugin/src/domain/display-name/DisplayNameTemplateEngine.ts
+++ b/packages/obsidian-plugin/src/domain/display-name/DisplayNameTemplateEngine.ts
@@ -149,7 +149,10 @@ export class DisplayNameTemplateEngine {
     const suffix = this.template.slice(last + 2);
 
     const rendered: string[] = [];
-    for (const field of core.split(separator)) {
+    for (const field of DisplayNameTemplateEngine.splitOutsidePlaceholders(
+      core,
+      separator,
+    )) {
       const cleaned = this.cleanupResult(
         this.renderSegment(field, metadata, basename, createdDate, metadataResolver),
       );
@@ -180,6 +183,57 @@ export class DisplayNameTemplateEngine {
 
     const joined = `${renderedPrefix}${rendered.join(separator)}${renderedSuffix}`.trim();
     return joined === "" ? null : joined;
+  }
+
+  /**
+   * Split the core into fields on `separator`, but NEVER inside a `{{…}}`
+   * placeholder.
+   *
+   * A plain `core.split(separator)` cuts the TEMPLATE, and a placeholder can
+   * legitimately contain the separator inside its per-part value format:
+   * `{{ems__Effort_endTimestamp::YYYY-MM-DD HH:mm}}` under the (very common)
+   * `exo__DisplayNameSpec_separator: " "`. The naive split produced
+   * `{{…::YYYY-MM-DD` and `HH:mm}}`, neither of which is a placeholder, so the
+   * raw template text leaked into the rendered name — silently, and only for
+   * specs whose format happens to contain the separator character.
+   *
+   * Splitting outside placeholders is byte-identical for every template whose
+   * placeholders do NOT contain the separator (i.e. every spec authored before
+   * a space-bearing format existed), so this is a strict widening.
+   *
+   * An unterminated `{{` (malformed template) is treated as literal text — the
+   * scan falls through to the character-by-character branch rather than
+   * swallowing the remainder of the core.
+   */
+  private static splitOutsidePlaceholders(
+    core: string,
+    separator: string,
+  ): string[] {
+    if (separator.length === 0) return [core];
+
+    const fields: string[] = [];
+    let buffer = "";
+    let i = 0;
+    while (i < core.length) {
+      if (core.startsWith("{{", i)) {
+        const end = core.indexOf("}}", i + 2);
+        if (end !== -1) {
+          buffer += core.slice(i, end + 2);
+          i = end + 2;
+          continue;
+        }
+      }
+      if (core.startsWith(separator, i)) {
+        fields.push(buffer);
+        buffer = "";
+        i += separator.length;
+        continue;
+      }
+      buffer += core[i];
+      i += 1;
+    }
+    fields.push(buffer);
+    return fields;
   }
 
   /**
@@ -257,20 +311,50 @@ export class DisplayNameTemplateEngine {
     // ignored (the key is then used verbatim).
     const { path, format } = DisplayNameTemplateEngine.splitKeyAndFormat(key);
 
-    // Handle dot notation for nested fields (with cross-asset resolution)
-    const value = this.getNestedValue(metadata, path, metadataResolver);
+    // A part may declare an ORDERED PREFERENCE LIST rather than one key —
+    // `exo__PrintedProperty_property` as a multi-value wikilink list, compiled
+    // into `{{a|b|c::FORMAT}}` by PrintNameRuleService. Semantics: FIRST
+    // NON-EMPTY wins; the shared `format` applies to whichever candidate won.
+    //
+    // WHY a list and not N parts: N separate parts would print EVERY candidate
+    // that happens to be set (an effort with both an end and a start timestamp
+    // would render both), which is not a preference — it is a concatenation.
+    //
+    // `|` is safe as the separator for the same reason `::` is: a frontmatter
+    // key has the shape `prefix__Name` and a dot-path `a.b` — neither can
+    // contain it. A single-candidate path (every template authored before this)
+    // takes the loop's first iteration and behaves byte-identically.
+    const candidates = path.includes("|")
+      ? path
+          .split("|")
+          .map((c) => c.trim())
+          .filter((c) => c.length > 0)
+      : [path];
 
-    if (format) {
-      // Format the RAW value — BEFORE formatValue, which would JSON.stringify a Date into
-      // `"2026-01-24T13:50:17.000Z"` (quotes included) and lose the literal digits.
-      const formatted = DisplayNameTemplateEngine.applyValueFormat(value, format);
-      if (formatted !== null) {
-        return formatted;
+    let lastRendered = "";
+    for (const candidate of candidates) {
+      // Handle dot notation for nested fields (with cross-asset resolution)
+      const value = this.getNestedValue(metadata, candidate, metadataResolver);
+
+      let rendered: string;
+      if (format) {
+        // Format the RAW value — BEFORE formatValue, which would JSON.stringify a Date into
+        // `"2026-01-24T13:50:17.000Z"` (quotes included) and lose the literal digits.
+        const formatted = DisplayNameTemplateEngine.applyValueFormat(value, format);
+        // Fail-open: unrecognised value → print it as usual.
+        rendered = formatted !== null ? formatted : this.formatValue(value, metadataResolver);
+      } else {
+        rendered = this.formatValue(value, metadataResolver);
       }
-      // Fail-open: unrecognised value → fall through and print it as usual.
+
+      if (rendered !== "") return rendered;
+      lastRendered = rendered;
     }
 
-    return this.formatValue(value, metadataResolver);
+    // Every candidate resolved empty — return the empty string so the
+    // separator-mode join drops the field together with its separator, exactly
+    // as a single absent property already did.
+    return lastRendered;
   }
 
   /** Split a placeholder key into its frontmatter path and its optional value format. */

--- a/packages/obsidian-plugin/src/domain/display-name/DisplayNameTemplateEngine.ts
+++ b/packages/obsidian-plugin/src/domain/display-name/DisplayNameTemplateEngine.ts
@@ -191,11 +191,19 @@ export class DisplayNameTemplateEngine {
    *
    * A plain `core.split(separator)` cuts the TEMPLATE, and a placeholder can
    * legitimately contain the separator inside its per-part value format:
-   * `{{ems__Effort_endTimestamp::YYYY-MM-DD HH:mm}}` under the (very common)
+   * `{{ems__Effort_endTimestamp::YYYY-MM-DD HH:mm}}` under
    * `exo__DisplayNameSpec_separator: " "`. The naive split produced
    * `{{…::YYYY-MM-DD` and `HH:mm}}`, neither of which is a placeholder, so the
    * raw template text leaked into the rendered name — silently, and only for
    * specs whose format happens to contain the separator character.
+   *
+   * Reach, measured over all three canonical vaults on 2026-08-15 (the specs
+   * live in shared assetspaces, so the three vaults agree): 3 specs declare a
+   * separator — `06606775` uses `" "`, `b836acf7` and `4ee3522b` use `" · "` —
+   * and BOTH shipped space-bearing formats (`DD.MM.YYYY HH:mm`, on `e8ded318`
+   * and `e910fa27`) belong to `" · "` specs. So the naive split never cut a
+   * name shipped to date; the defect goes live with the first spec that pairs
+   * `separator: " "` with a time-bearing format. Prospective, not current.
    *
    * Splitting outside placeholders is byte-identical for every template whose
    * placeholders do NOT contain the separator (i.e. every spec authored before

--- a/packages/obsidian-plugin/src/domain/display-name/PrintNameRuleService.ts
+++ b/packages/obsidian-plugin/src/domain/display-name/PrintNameRuleService.ts
@@ -524,7 +524,7 @@ export class PrintNameRuleService {
     if (!Number.isFinite(order)) return;
 
     // exo__PrintedProperty → resolve the referenced property's frontmatter key (all wikilink forms).
-    const propertyKey = this.resolvePropertyKey(fm.exo__PrintedProperty_property);
+    const propertyKey = this.resolvePropertyKeyList(fm.exo__PrintedProperty_property);
     const rawLiteral = fm.exo__PrintedLiteral_literal;
     const literal = typeof rawLiteral === "string" ? rawLiteral : undefined;
 
@@ -605,7 +605,7 @@ export class PrintNameRuleService {
   }
 
   /**
-   * Resolve an exo__PrintedProperty_property reference to the frontmatter KEY it prints.
+   * Resolve a property reference to the ONE frontmatter KEY it names.
    * Handles every wikilink form so a spec authored either way works:
    *  - `[[uid|label]]` → the alias is the key (fast path, no hop);
    *  - `[[exo__Asset_label]]` → the bare target is already the key;
@@ -613,28 +613,44 @@ export class PrintNameRuleService {
    *    asset's exo__Asset_label (which equals its frontmatter key).
    */
   private resolvePropertyKey(value: unknown): string | null {
-    // A MULTI-VALUE `exo__PrintedProperty_property` is an ORDERED PREFERENCE
-    // LIST, not a set: "print the first of these that has a value". Compiled
-    // into the placeholder as `a|b|c`; `DisplayNameTemplateEngine.resolveValue`
-    // walks the candidates and returns the first non-empty render.
-    //
-    // WHY a list and not N parts: N parts would print EVERY candidate that is
-    // set (an effort carrying both an end and a start timestamp would render
-    // both), which is a concatenation, not a preference.
-    //
-    // Single-value input takes the `length === 1` path below and behaves
-    // byte-identically to the pre-list implementation.
+    // ⛔ SINGLE-key resolution — do NOT give this the preference-list semantics of
+    // `resolvePropertyKeyList` below. Its caller is `exo__DisplayNameSpec_matchPath`,
+    // whose matcher (`matcherSatisfied`) looks the resolved key up in the note's
+    // frontmatter: a joined `a|b` string is not a frontmatter key, so the lookup
+    // would yield `undefined` → `extractClassKeys([])` → the matcher NEVER fires and
+    // the conditional spec silently drops out of `getParticipatingRules`. A
+    // multi-value input therefore keeps the pre-list behaviour (take the first).
     if (Array.isArray(value)) {
       if (value.length === 0) return null;
-      if (value.length > 1) {
-        const keys = value
-          .map((v) => this.resolveSinglePropertyKey(v))
-          .filter((k): k is string => k !== null && k.length > 0);
-        return keys.length > 0 ? keys.join("|") : null;
-      }
       return this.resolveSinglePropertyKey(value[0]);
     }
     return this.resolveSinglePropertyKey(value);
+  }
+
+  /**
+   * Resolve an `exo__PrintedProperty_property` reference to the frontmatter key(s)
+   * the part prints.
+   *
+   * A MULTI-VALUE property is an ORDERED PREFERENCE LIST, not a set: "print the
+   * first of these that has a value". Compiled into the placeholder as `a|b|c`;
+   * `DisplayNameTemplateEngine.resolveValue` walks the candidates in order and
+   * returns the first non-empty render.
+   *
+   * WHY a list and not N parts: N parts would print EVERY candidate that is set
+   * (an effort carrying both an end and a start timestamp would render both dates),
+   * which is a concatenation, not a preference.
+   *
+   * Single-value input delegates to `resolvePropertyKey` and is byte-identical to
+   * the pre-list implementation.
+   */
+  private resolvePropertyKeyList(value: unknown): string | null {
+    if (Array.isArray(value) && value.length > 1) {
+      const keys = value
+        .map((v) => this.resolveSinglePropertyKey(v))
+        .filter((k): k is string => k !== null && k.length > 0);
+      return keys.length > 0 ? keys.join("|") : null;
+    }
+    return this.resolvePropertyKey(value);
   }
 
   /** Resolve ONE `exo__PrintedProperty_property` reference to its frontmatter key. */

--- a/packages/obsidian-plugin/src/domain/display-name/PrintNameRuleService.ts
+++ b/packages/obsidian-plugin/src/domain/display-name/PrintNameRuleService.ts
@@ -613,11 +613,32 @@ export class PrintNameRuleService {
    *    asset's exo__Asset_label (which equals its frontmatter key).
    */
   private resolvePropertyKey(value: unknown): string | null {
-    let raw = value;
-    if (Array.isArray(raw)) {
-      if (raw.length === 0) return null;
-      raw = raw[0];
+    // A MULTI-VALUE `exo__PrintedProperty_property` is an ORDERED PREFERENCE
+    // LIST, not a set: "print the first of these that has a value". Compiled
+    // into the placeholder as `a|b|c`; `DisplayNameTemplateEngine.resolveValue`
+    // walks the candidates and returns the first non-empty render.
+    //
+    // WHY a list and not N parts: N parts would print EVERY candidate that is
+    // set (an effort carrying both an end and a start timestamp would render
+    // both), which is a concatenation, not a preference.
+    //
+    // Single-value input takes the `length === 1` path below and behaves
+    // byte-identically to the pre-list implementation.
+    if (Array.isArray(value)) {
+      if (value.length === 0) return null;
+      if (value.length > 1) {
+        const keys = value
+          .map((v) => this.resolveSinglePropertyKey(v))
+          .filter((k): k is string => k !== null && k.length > 0);
+        return keys.length > 0 ? keys.join("|") : null;
+      }
+      return this.resolveSinglePropertyKey(value[0]);
     }
+    return this.resolveSinglePropertyKey(value);
+  }
+
+  /** Resolve ONE `exo__PrintedProperty_property` reference to its frontmatter key. */
+  private resolveSinglePropertyKey(raw: unknown): string | null {
     if (typeof raw !== "string") return null;
 
     const cleaned = raw

--- a/packages/obsidian-plugin/tests/unit/domain/display-name/DisplayNamePrintedPropertyFallback.test.ts
+++ b/packages/obsidian-plugin/tests/unit/domain/display-name/DisplayNamePrintedPropertyFallback.test.ts
@@ -370,3 +370,104 @@ describe("printName — exo__PrintedProperty_property as an ordered preference l
     ).toBe(PROTO_LABEL);
   });
 });
+
+/**
+ * The SECOND consumer of the key resolver: `exo__DisplayNameSpec_matchPath`.
+ *
+ * `resolvePropertyKey` is shared, and the preference-list semantics must NOT leak
+ * into it: `matcherSatisfied` looks the resolved key up in the note's frontmatter,
+ * so a joined `a|b` string is not a key, the lookup yields `undefined`, and the
+ * conditional spec silently stops matching — a behaviour regression with NO error,
+ * NO type change and no coverage from the list axes above (they never build a
+ * conditional spec). Hence a dedicated axis, on its own class so exactly one spec
+ * participates and the assertion has a single cause.
+ */
+describe("printName — matchPath keeps SINGLE-key semantics (list-resolution must not leak)", () => {
+  const COND_CLASS_UID = "6a99d2ca-d402-4734-a10b-33f5f1a1aa43";
+  const COND_SPEC_UID = "dddddddd-0000-4000-8000-000000000003";
+  const PROP_STATUS = "eeeeeeee-0000-4000-8000-00000000000f";
+  const STATUS_DOING = "cccccccc-0000-4000-8000-000000000001";
+
+  function condFixtures(matchPath: string | string[]): Fixture[] {
+    return [
+      propertyDef(PROP_STATUS, "ems__Effort_status"),
+      {
+        path: `${STATUS_DOING}.md`,
+        frontmatter: {
+          exo__Asset_uid: STATUS_DOING,
+          exo__Asset_label: "ems__EffortStatusDoing",
+        },
+      },
+      {
+        path: `${COND_SPEC_UID}.md`,
+        frontmatter: {
+          exo__Asset_uid: COND_SPEC_UID,
+          exo__Instance_class: [`[[${DISPLAY_NAME_SPEC_UID}]]`],
+          exo__DisplayNameSpec_appliesToClass: `[[${COND_CLASS_UID}|ems__CondAction]]`,
+          exo__DisplayNameSpec_priority: 400,
+          exo__DisplayNameSpec_separator: " ",
+          exo__DisplayNameSpec_matchPath: matchPath,
+          exo__DisplayNameSpec_matchValue: `[[${STATUS_DOING}|ems__EffortStatusDoing]]`,
+        },
+      },
+      printedProperty(
+        "ffffffff-0000-4000-8000-000000000021",
+        COND_SPEC_UID,
+        1,
+        [`[[${PROP_PROTOTYPE}]]`],
+      ),
+      printedProperty(
+        "ffffffff-0000-4000-8000-000000000022",
+        COND_SPEC_UID,
+        2,
+        `[[${PROP_END}]]`,
+        "YYYY",
+      ),
+    ];
+  }
+
+  /** Doing-status note of the conditional class; falls back to its raw label if unmatched. */
+  function condNote(): Record<string, unknown> {
+    return {
+      exo__Instance_class: [`[[${COND_CLASS_UID}|ems__CondAction]]`],
+      exo__Asset_prototype: `[[${PROTOTYPE_UID}]]`,
+      exo__Asset_label: "RAW LABEL",
+      ems__Effort_status: `[[${STATUS_DOING}|ems__EffortStatusDoing]]`,
+      ems__Effort_endTimestamp: "2026-08-14T17:23:18",
+    };
+  }
+
+  it("a MULTI-VALUE matchPath still matches on its FIRST element (pre-list behaviour)", () => {
+    const r = resolverFor([
+      ...baseFixtures(),
+      prototypeAsset(),
+      ...condFixtures([`[[${PROP_STATUS}]]`, `[[${PROP_END}]]`]),
+    ]);
+    // Giving matchPath the list semantics compiles matchKey to
+    // "ems__Effort_status|ems__Effort_endTimestamp", which is not a frontmatter
+    // key → matcher never fires → this renders "RAW LABEL" instead.
+    expect(r.resolve({ metadata: condNote(), basename: "x" })).toBe(
+      `${PROTO_LABEL} 2026`,
+    );
+  });
+
+  it("control: a SINGLE-value matchPath matches, and a non-matching value does not", () => {
+    const r = resolverFor([
+      ...baseFixtures(),
+      prototypeAsset(),
+      ...condFixtures(`[[${PROP_STATUS}]]`),
+    ]);
+    expect(r.resolve({ metadata: condNote(), basename: "x" })).toBe(
+      `${PROTO_LABEL} 2026`,
+    );
+    expect(
+      r.resolve({
+        metadata: {
+          ...condNote(),
+          ems__Effort_status: "[[something-else|ems__EffortStatusDone]]",
+        },
+        basename: "x",
+      }),
+    ).toBe("RAW LABEL");
+  });
+});

--- a/packages/obsidian-plugin/tests/unit/domain/display-name/DisplayNamePrintedPropertyFallback.test.ts
+++ b/packages/obsidian-plugin/tests/unit/domain/display-name/DisplayNamePrintedPropertyFallback.test.ts
@@ -1,0 +1,372 @@
+/**
+ * printName: `exo__PrintedProperty_property` as an ORDERED PREFERENCE LIST.
+ *
+ * A multi-value `exo__PrintedProperty_property` means "print the FIRST of these
+ * that has a value", not "print all of them". The motivating case is a date
+ * whose authoritative source degrades: `ems__Effort_endTimestamp` →
+ * `ems__Effort_plannedEndTimestamp` → `ems__Effort_startTimestamp` →
+ * `ems__Effort_plannedStartTimestamp`.
+ *
+ * ⛔ Why a list and NOT four separate parts: four parts print EVERY candidate
+ * that happens to be set, so an effort carrying both an end and a start
+ * timestamp would render both dates. That is a concatenation, not a preference.
+ *
+ * Production-shape: the fixture vault carries the real class-def and real
+ * property-defs, and the test drives the REAL
+ * `PrintNameRuleService.scanVault()` → `DisplayNameResolver.resolve()` pipeline.
+ * The template under test is COMPILED from the fixture's `exo__DisplayNameSpec`
+ * + `exo__PrintedProperty` assets exactly as the plugin compiles the live vault
+ * — nothing is hand-injected.
+ *
+ * Revert-verify: dropping the multi-candidate walk in
+ * `DisplayNameTemplateEngine.resolveValue` turns the fallback axes RED while the
+ * single-candidate axis stays GREEN; dropping the `join("|")` in
+ * `PrintNameRuleService.resolvePropertyKey` turns them RED the same way from the
+ * compile side.
+ */
+import { PrintNameRuleService } from "@plugin/domain/display-name/PrintNameRuleService";
+import { DisplayNameResolver } from "@plugin/domain/display-name/DisplayNameResolver";
+import { DEFAULT_DISPLAY_NAME_SETTINGS } from "@plugin/domain/settings/ExocortexSettings";
+import { TFile } from "obsidian";
+import type { App, CachedMetadata } from "obsidian";
+
+const EXO_CLASS_METACLASS = "8619c4fc-64f1-4869-b17e-e34186cacca9";
+const DISPLAY_NAME_SPEC_UID = "07eab746-0874-4676-9d98-dbaad1bc6fb8";
+const PRINTED_PROPERTY_UID = "7d58de40-d941-4a66-88e2-13afc4fdc41d";
+const DATATYPE_PROPERTY_UID = "ae56ca4c-b610-42a4-a25d-058c23673296";
+
+const ACTION_CLASS_UID = "6a99d2ca-d402-4734-a10b-33f5f1a1aa42";
+const SPEC_UID = "dddddddd-0000-4000-8000-000000000001";
+const SINGLE_SPEC_UID = "dddddddd-0000-4000-8000-000000000002";
+
+const PROP_END = "eeeeeeee-0000-4000-8000-00000000000a";
+const PROP_PLANNED_END = "eeeeeeee-0000-4000-8000-00000000000b";
+const PROP_START = "eeeeeeee-0000-4000-8000-00000000000c";
+const PROP_PLANNED_START = "eeeeeeee-0000-4000-8000-00000000000d";
+const PROP_PROTOTYPE = "eeeeeeee-0000-4000-8000-00000000000e";
+
+interface Fixture {
+  path: string;
+  frontmatter: Record<string, unknown>;
+}
+
+function createMockApp(files: Fixture[]): App {
+  const fileCache = new Map<string, CachedMetadata>();
+  const mockFiles: TFile[] = [];
+  for (const f of files) {
+    const tfile = new TFile(f.path);
+    tfile.basename = f.path.replace(/\.md$/, "");
+    tfile.extension = "md";
+    mockFiles.push(tfile);
+    fileCache.set(f.path, { frontmatter: f.frontmatter } as CachedMetadata);
+  }
+  return {
+    vault: { getMarkdownFiles: () => mockFiles },
+    metadataCache: {
+      getFileCache: (file: TFile) => fileCache.get(file.path) ?? null,
+      getFirstLinkpathDest: (p: string) => {
+        const clean = p.endsWith(".md") ? p : `${p}.md`;
+        return mockFiles.find((f) => f.path === clean) ?? null;
+      },
+    },
+  } as unknown as App;
+}
+
+/** A property DEF asset — so resolvePropertyKey's second hop resolves for real. */
+function propertyDef(uid: string, label: string): Fixture {
+  return {
+    path: `${uid}.md`,
+    frontmatter: {
+      exo__Asset_uid: uid,
+      exo__Instance_class: [`[[${DATATYPE_PROPERTY_UID}]]`],
+      exo__Asset_label: label,
+    },
+  };
+}
+
+function baseFixtures(): Fixture[] {
+  return [
+    {
+      path: `${ACTION_CLASS_UID}.md`,
+      frontmatter: {
+        exo__Asset_uid: ACTION_CLASS_UID,
+        exo__Instance_class: [`[[${EXO_CLASS_METACLASS}]]`],
+        exo__Asset_label: "ems__Action",
+      },
+    },
+    propertyDef(PROP_END, "ems__Effort_endTimestamp"),
+    propertyDef(PROP_PLANNED_END, "ems__Effort_plannedEndTimestamp"),
+    propertyDef(PROP_START, "ems__Effort_startTimestamp"),
+    propertyDef(PROP_PLANNED_START, "ems__Effort_plannedStartTimestamp"),
+    propertyDef(PROP_PROTOTYPE, "exo__Asset_prototype"),
+  ];
+}
+
+function printedProperty(
+  uid: string,
+  specUid: string,
+  order: number,
+  property: string | string[],
+  format?: string,
+): Fixture {
+  return {
+    path: `${uid}.md`,
+    frontmatter: {
+      exo__Asset_uid: uid,
+      exo__Instance_class: [`[[${PRINTED_PROPERTY_UID}]]`],
+      exo__DisplayNamePart_of: `[[${specUid}]]`,
+      exo__DisplayNamePart_order: order,
+      exo__PrintedProperty_property: property,
+      ...(format ? { exo__PrintedProperty_format: format } : {}),
+    },
+  };
+}
+
+/** Spec: one part carrying the 4-deep date preference list, formatted. */
+function fallbackSpecFixtures(): Fixture[] {
+  return [
+    {
+      path: `${SPEC_UID}.md`,
+      frontmatter: {
+        exo__Asset_uid: SPEC_UID,
+        exo__Instance_class: [`[[${DISPLAY_NAME_SPEC_UID}]]`],
+        exo__DisplayNameSpec_appliesToClass: `[[${ACTION_CLASS_UID}|ems__Action]]`,
+        exo__DisplayNameSpec_priority: 400,
+        exo__DisplayNameSpec_separator: " ",
+      },
+    },
+    printedProperty("ffffffff-0000-4000-8000-000000000001", SPEC_UID, 1, [
+      `[[${PROP_PROTOTYPE}]]`,
+    ]),
+    printedProperty(
+      "ffffffff-0000-4000-8000-000000000002",
+      SPEC_UID,
+      2,
+      [
+        `[[${PROP_END}]]`,
+        `[[${PROP_PLANNED_END}]]`,
+        `[[${PROP_START}]]`,
+        `[[${PROP_PLANNED_START}]]`,
+      ],
+      "YYYY-MM-DD HH:mm",
+    ),
+  ];
+}
+
+/** Control spec: the SAME shape with a single-value property (pre-list form). */
+function singleSpecFixtures(): Fixture[] {
+  return [
+    {
+      path: `${SINGLE_SPEC_UID}.md`,
+      frontmatter: {
+        exo__Asset_uid: SINGLE_SPEC_UID,
+        exo__Instance_class: [`[[${DISPLAY_NAME_SPEC_UID}]]`],
+        exo__DisplayNameSpec_appliesToClass: `[[${ACTION_CLASS_UID}|ems__Action]]`,
+        exo__DisplayNameSpec_priority: 400,
+        exo__DisplayNameSpec_separator: " ",
+      },
+    },
+    printedProperty(
+      "ffffffff-0000-4000-8000-000000000011",
+      SINGLE_SPEC_UID,
+      1,
+      [`[[${PROP_PROTOTYPE}]]`],
+    ),
+    printedProperty(
+      "ffffffff-0000-4000-8000-000000000012",
+      SINGLE_SPEC_UID,
+      2,
+      `[[${PROP_END}]]`,
+      "YYYY-MM-DD HH:mm",
+    ),
+  ];
+}
+
+function resolverFor(files: Fixture[]): DisplayNameResolver {
+  const app = createMockApp(files);
+  const service = new PrintNameRuleService(app);
+  service.initialize();
+  return new DisplayNameResolver(
+    DEFAULT_DISPLAY_NAME_SETTINGS,
+    service,
+    service.createMetadataResolver(),
+  );
+}
+
+/** A prototype asset the part's first slot dereferences to its label. */
+const PROTOTYPE_UID = "aaaa1111-0000-4000-8000-000000000001";
+function prototypeAsset(): Fixture {
+  return {
+    path: `${PROTOTYPE_UID}.md`,
+    frontmatter: {
+      exo__Asset_uid: PROTOTYPE_UID,
+      exo__Asset_label: "Выпить Пантокальцин после обеда",
+    },
+  };
+}
+
+function action(fm: Record<string, unknown>): Record<string, unknown> {
+  return {
+    exo__Instance_class: [`[[${ACTION_CLASS_UID}|ems__Action]]`],
+    exo__Asset_prototype: `[[${PROTOTYPE_UID}]]`,
+    ...fm,
+  };
+}
+
+const PROTO_LABEL = "Выпить Пантокальцин после обеда";
+
+describe("printName — exo__PrintedProperty_property as an ordered preference list", () => {
+  it("prints the FIRST candidate when every candidate is present", () => {
+    const r = resolverFor([
+      ...baseFixtures(),
+      prototypeAsset(),
+      ...fallbackSpecFixtures(),
+    ]);
+    const name = r.resolve({
+      metadata: action({
+        ems__Effort_endTimestamp: "2026-08-14T17:23:18",
+        ems__Effort_plannedEndTimestamp: "2026-08-13T10:00:00",
+        ems__Effort_startTimestamp: "2026-08-12T09:00:00",
+        ems__Effort_plannedStartTimestamp: "2026-08-11T08:00:00",
+      }),
+      basename: "x",
+    });
+    // Only ONE date — the first — not a concatenation of all four.
+    expect(name).toBe(`${PROTO_LABEL} 2026-08-14 17:23`);
+  });
+
+  it("falls through to the SECOND candidate when the first is absent", () => {
+    const r = resolverFor([
+      ...baseFixtures(),
+      prototypeAsset(),
+      ...fallbackSpecFixtures(),
+    ]);
+    const name = r.resolve({
+      metadata: action({
+        ems__Effort_plannedEndTimestamp: "2026-08-13T10:00:00",
+        ems__Effort_startTimestamp: "2026-08-12T09:00:00",
+      }),
+      basename: "x",
+    });
+    expect(name).toBe(`${PROTO_LABEL} 2026-08-13 10:00`);
+  });
+
+  it("falls through to the LAST candidate when only it is present", () => {
+    const r = resolverFor([
+      ...baseFixtures(),
+      prototypeAsset(),
+      ...fallbackSpecFixtures(),
+    ]);
+    const name = r.resolve({
+      metadata: action({
+        ems__Effort_plannedStartTimestamp: "2026-08-11T08:00:00",
+      }),
+      basename: "x",
+    });
+    expect(name).toBe(`${PROTO_LABEL} 2026-08-11 08:00`);
+  });
+
+  it("drops the field WITH its separator when no candidate has a value", () => {
+    const r = resolverFor([
+      ...baseFixtures(),
+      prototypeAsset(),
+      ...fallbackSpecFixtures(),
+    ]);
+    const name = r.resolve({ metadata: action({}), basename: "x" });
+    // Same behaviour a single absent property already had — no dangling space.
+    expect(name).toBe(PROTO_LABEL);
+  });
+
+  it("applies the part's format to whichever candidate won, not only to the first", () => {
+    const r = resolverFor([
+      ...baseFixtures(),
+      prototypeAsset(),
+      ...fallbackSpecFixtures(),
+    ]);
+    const name = r.resolve({
+      metadata: action({ ems__Effort_startTimestamp: "2026-08-12T09:07:00" }),
+      basename: "x",
+    });
+    // The raw value is a full ISO string; the declared YYYY-MM-DD HH:mm applied.
+    expect(name).toBe(`${PROTO_LABEL} 2026-08-12 09:07`);
+    expect(name).not.toContain("T09:07");
+  });
+
+  it("a format containing the SEPARATOR itself survives (space-bearing format under a space separator)", () => {
+    const r = resolverFor([
+      ...baseFixtures(),
+      prototypeAsset(),
+      ...singleSpecFixtures(),
+    ]);
+    const name = r.resolve({
+      metadata: action({ ems__Effort_endTimestamp: "2026-08-14T17:23:18" }),
+      basename: "x",
+    });
+    // Splitting the TEMPLATE naively on " " cut `{{key::YYYY-MM-DD HH:mm}}` in
+    // half and leaked the raw placeholder into the name.
+    expect(name).not.toContain("{{");
+    expect(name).not.toContain("::");
+    expect(name).toBe(`${PROTO_LABEL} 2026-08-14 17:23`);
+  });
+
+  it("no-regression control for the splitter: a format WITHOUT the separator is unaffected", () => {
+    const spaceFreeSpec: Fixture[] = [
+      {
+        path: `${SINGLE_SPEC_UID}.md`,
+        frontmatter: {
+          exo__Asset_uid: SINGLE_SPEC_UID,
+          exo__Instance_class: [`[[${DISPLAY_NAME_SPEC_UID}]]`],
+          exo__DisplayNameSpec_appliesToClass: `[[${ACTION_CLASS_UID}|ems__Action]]`,
+          exo__DisplayNameSpec_priority: 400,
+          exo__DisplayNameSpec_separator: " ",
+        },
+      },
+      printedProperty(
+        "ffffffff-0000-4000-8000-000000000021",
+        SINGLE_SPEC_UID,
+        1,
+        [`[[${PROP_PROTOTYPE}]]`],
+      ),
+      printedProperty(
+        "ffffffff-0000-4000-8000-000000000022",
+        SINGLE_SPEC_UID,
+        2,
+        `[[${PROP_END}]]`,
+        "YYYY-MM-DD",
+      ),
+    ];
+    const r = resolverFor([
+      ...baseFixtures(),
+      prototypeAsset(),
+      ...spaceFreeSpec,
+    ]);
+    expect(
+      r.resolve({
+        metadata: action({ ems__Effort_endTimestamp: "2026-08-14T17:23:18" }),
+        basename: "x",
+      }),
+    ).toBe(`${PROTO_LABEL} 2026-08-14`);
+  });
+
+  it("no-regression control: a SINGLE-value property behaves exactly as before", () => {
+    const r = resolverFor([
+      ...baseFixtures(),
+      prototypeAsset(),
+      ...singleSpecFixtures(),
+    ]);
+    expect(
+      r.resolve({
+        metadata: action({ ems__Effort_endTimestamp: "2026-08-14T17:23:18" }),
+        basename: "x",
+      }),
+    ).toBe(`${PROTO_LABEL} 2026-08-14 17:23`);
+    // …and still drops cleanly when that one property is absent — the single
+    // candidate must NOT accidentally pick up a sibling timestamp.
+    expect(
+      r.resolve({
+        metadata: action({ ems__Effort_startTimestamp: "2026-08-12T09:00:00" }),
+        basename: "x",
+      }),
+    ).toBe(PROTO_LABEL);
+  });
+});


### PR DESCRIPTION
Enables a displayName part to declare **several candidate properties** and print the **first that has a value** — a preference chain, not a concatenation.

Motivating requirement (Andrey, 2026-08-14): an `ems__Action` instance's name should be derived at render time from the prototype's label plus the moment the action happened, where "the moment" degrades through `ems__Effort_endTimestamp` → `ems__Effort_plannedEndTimestamp` → `ems__Effort_startTimestamp` → `ems__Effort_plannedStartTimestamp`.

## Why this needed engine work

⛔ Not expressible before, and **not** expressible as N separate parts: N parts print *every* candidate that happens to be set, so an effort carrying both an end and a start timestamp renders **both** dates. `resolvePropertyKey` also collapsed a multi-value `exo__PrintedProperty_property` to `raw[0]`, silently discarding the rest.

## Two halves, both opt-in by shape

| | change | when a single value is declared |
|---|---|---|
| `PrintNameRuleService.resolvePropertyKey` | array of length > 1 → each element through the existing single-value logic, joined with `\|` → placeholder `{{a\|b\|c::FORMAT}}` | old path, unchanged |
| `DisplayNameTemplateEngine.resolveValue` | walks candidates in order, returns the first non-empty render; the part's `format` applies to whichever candidate won | loop's first iteration — byte-identical |

All candidates empty → empty string, so separator mode drops the field together with its separator exactly as one absent property already did.

`\|` is safe as the separator for the same reason `::` already is: a frontmatter key has the shape `prefix__Name` and a dot-path `a.b` — neither can contain it. The wikilink alias form `[[uid\|label]]` is resolved to its label **before** the join, so the joined string carries only clean keys.

## Also fixes a pre-existing defect the first test run surfaced

Separator mode did `core.split(separator)` on the **template**, so a placeholder whose per-part format contains the separator — `{{…::YYYY-MM-DD HH:mm}}` under the very common `exo__DisplayNameSpec_separator: " "` — was cut in half and the **raw template text leaked into the rendered name**. Splitting now skips over `{{…}}` regions (`splitOutsidePlaceholders`), byte-identical for every template whose placeholders do not contain the separator (i.e. every spec authored to date).

⛤ Not optional polish: a date **with a time** is unrenderable without it, and the requirement above needs exactly that.

## Tests — 8 axes, production-shape

Real `PrintNameRuleService.scanVault()` → `DisplayNameResolver.resolve()`; the template under test is **compiled** from the fixture's `exo__DisplayNameSpec` + `exo__PrintedProperty` assets exactly as the plugin compiles the live vault. Nothing hand-injected.

Revert-verify, each mutation in isolation on a copy:

| Mutation | Result |
|---|---|
| naive `core.split(separator)` | **7 of 8 RED** |
| drop the multi-candidate walk (engine side) | **4 RED**, 4 GREEN |
| drop the `join("\|")` (compile side) | **3 RED**, 5 GREEN |

Restore → 8/8, and **179/179** across every display-name suite.

## Local gates

- plugin **341/341** suites, 6081 tests
- core **363/363**, 8513 tests
- CLI 155/156 — `sparql-exo003.integration.test.ts` reproduces on `origin/main` (pre-existing)
- root `tsc --noEmit` clean; all three `lint`-job guard scripts pass
- prettier: new test formatted; both touched sources left alone — pre-existing prettier-dirty on `origin/main` (206 / 215 lines), no objection to my own lines

Disjoint from #4047 (core executor + CLI test) — no shared files.

https://claude.ai/code/session_01Xp6ceD53nG2HvWFtFWMoFX