### PR TITLE
feat(grounding): create_instance may deliberately omit exo__Asset_label

### DIFF
--- a/packages/core/src/domain/models/CommandDefinition.ts
+++ b/packages/core/src/domain/models/CommandDefinition.ts
@@ -394,6 +394,44 @@ export interface GroundingDefinition {
    * (xsd:boolean — `true`/`false`; absent → click-target).
    */
   readonly targetsCreatedInstance?: boolean;
+  /**
+   * Opt-in for `create_instance`: an ABSENT `exo__Asset_label` is the INTENDED
+   * end state, not a degraded fallback.
+   *
+   * By default, when nothing supplies a label (no `userInput.label`, no
+   * `labelTemplate`, or a template that substitutes to blank), the executor
+   * writes the literal `"Untitled"`, derives `aliases: ["Untitled"]`-free but
+   * flags `exo__Asset_label` in `missing[]`, which logs "Vault may be in an
+   * unhealthy state". That default is right for an ACCIDENTAL blank and stays
+   * unchanged.
+   *
+   * It is wrong for a class whose name is DERIVED at render time from an
+   * `exo__DisplayNameSpec` (e.g. `ems__Action`, whose display name composes the
+   * prototype's label with the action's timestamp). There a stored label is not
+   * missing data — it is duplicated, stale-prone data: the asset would carry a
+   * frozen string next to a spec that recomputes the name on every render, and
+   * the two would disagree the moment either side changes.
+   *
+   * When `true` AND nothing resolved a label, the executor:
+   *   - REMOVES `exo__Asset_label` from the written frontmatter (rather than
+   *     writing `"Untitled"` or an empty literal — an empty literal is worse
+   *     than either, see the blank-substitution guard);
+   *   - writes no label-derived `aliases`;
+   *   - does NOT push `exo__Asset_label` to `missing[]`, so the unhealthy-vault
+   *     ERROR is not raised for a designed outcome.
+   *
+   * A label that IS supplied still wins: `userInput.label` and a
+   * `labelTemplate` that substitutes non-blank both take the normal path, so
+   * this flag only ever changes the FALLBACK, never an explicit name. Absent /
+   * `false` (the default) → byte-identical to prior behaviour.
+   *
+   * ⛔ Only meaningful for `create_instance`; other grounding types never reach
+   * the label top-up.
+   *
+   * Authored as the `exocmd__Grounding_omitLabel` RDF triple
+   * (xsd:boolean — `true`/`false`; absent → the `"Untitled"` fallback).
+   */
+  readonly omitLabel?: boolean;
 }
 
 /**

--- a/packages/core/src/domain/models/GroundingFrontmatterParser.ts
+++ b/packages/core/src/domain/models/GroundingFrontmatterParser.ts
@@ -128,6 +128,13 @@ export function parseGroundingDefinitionFromFrontmatter(
   const targetsCreatedInstance =
     rawTargetsCreatedInstance === true || rawTargetsCreatedInstance === "true";
 
+  // create_instance opt-in: an absent `exo__Asset_label` is INTENDED (the class
+  // derives its display name from an exo__DisplayNameSpec), so the executor omits
+  // the key instead of writing "Untitled". Same boolean-tolerant coercion.
+  // (Parity with CommandResolver — the production loader.)
+  const rawOmitLabel = fm["exocmd__Grounding_omitLabel"];
+  const omitLabel = rawOmitLabel === true || rawOmitLabel === "true";
+
   // req faf269bf — TARGET-side NamedQuery ref (which asset the step writes
   // INTO). Wikilink → bare UID, same normalization as `templateRef`, mirroring
   // the production loader's `getObsidianName` unwrap.
@@ -170,6 +177,7 @@ export function parseGroundingDefinitionFromFrontmatter(
     templateRef,
     cloneTargetBody,
     targetsCreatedInstance,
+    omitLabel,
     targetQuery,
     steps,
   };

--- a/packages/core/src/services/CommandResolver.ts
+++ b/packages/core/src/services/CommandResolver.ts
@@ -2036,6 +2036,21 @@ export class CommandResolver {
       targetsCreatedInstanceRaw !== null &&
       String(targetsCreatedInstanceRaw).trim().toLowerCase() === "true";
 
+    // create_instance opt-in: an absent label is INTENDED (the class derives its
+    // display name from an exo__DisplayNameSpec), so the executor must omit
+    // `exo__Asset_label` instead of writing "Untitled" + flagging an unhealthy
+    // vault. Boolean coercion mirrors `targetsCreatedInstance`. MUST be read HERE
+    // (the production loader — plugin button + CLI both go through
+    // CommandResolver.loadCommand); the sibling GroundingFrontmatterParser has no
+    // production consumers, so reading it only there leaves the flag inert.
+    const omitLabelRaw = await this.getLiteralValue(
+      subject,
+      Namespace.EXOCMD.term("Grounding_omitLabel"),
+    );
+    const omitLabel =
+      omitLabelRaw !== null &&
+      String(omitLabelRaw).trim().toLowerCase() === "true";
+
     const grounding: GroundingDefinition = {
       id: uid,
       label,
@@ -2066,6 +2081,7 @@ export class CommandResolver {
       templateRef: templateRef ?? undefined,
       cloneTargetBody: cloneTargetBody || undefined,
       targetsCreatedInstance: targetsCreatedInstance || undefined,
+      omitLabel: omitLabel || undefined,
     };
 
     if (inputSchema) {

--- a/packages/core/src/services/GroundingExecutor.ts
+++ b/packages/core/src/services/GroundingExecutor.ts
@@ -1984,33 +1984,56 @@ export class GroundingExecutor {
       // blank resolved label as absent → "Untitled" fallback (which is then
       // flagged below). The labelTemplate path already guards blank at its
       // substitution site, so only the userInput.label === "" path reaches here.
-      const finalLabel =
-        label !== undefined && label.trim().length > 0 ? label : "Untitled";
-      properties.exo__Asset_label = finalLabel;
-      // ⛤ Test the CANONICAL spelling, not just the bare one. `createFrontmatter`
-      // collapses `exo__Asset_aliases` onto `aliases` (req 869561bf), but that
-      // happens LATER — so a template / propertyDefault / inheritance-rule
-      // supplying the prefixed key would leave `properties.aliases` undefined
-      // here, this guard would add the label-derived aliases anyway, and the
-      // collapse would then keep whichever landed last. On origin/main both keys
-      // survived (ugly, half-dead); silently dropping one would be worse.
-      const aliasesAlreadySet = Object.keys(properties).some(
-        (k) => canonicalYamlKey(k) === "aliases",
-      );
-      if (finalLabel !== "Untitled" && !aliasesAlreadySet) {
-        properties.aliases = [finalLabel];
-      }
-      // Only the genuine degraded fallthrough ("Untitled") is an
-      // unhealthy-state signal. Reaching this block is NORMAL for the one-click
-      // / CLI flow: Universal Default Template PD #3 (`exo__Asset_label =
-      // $userInputLabel`) writes an empty literal when no input modal supplies
-      // a label, and the labelTemplate / userInput path above is the *designed*
-      // completion — not a TS-fallback rescue. Pushing "exo__Asset_label" to
-      // `missing[]` unconditionally falsely tripped the "Vault may be in an
-      // unhealthy state" ERROR on every healthy labelTemplate-driven create
-      // (bug-fix: false-alarm log). Flag only the real "Untitled" fallback.
-      if (finalLabel === "Untitled") {
-        missing.push("exo__Asset_label");
+      // `omitLabel` opt-in: for a class whose display name is DERIVED at render
+      // time from an `exo__DisplayNameSpec`, an absent label is the intended end
+      // state — a stored one would be duplicated, stale-prone data sitting next to
+      // a spec that recomputes the name on every render. Honoured ONLY when
+      // nothing resolved a label, so an explicit `userInput.label` (or a
+      // `labelTemplate` that substitutes non-blank) still wins and takes the
+      // normal path below. DELETE rather than leave the key: an upstream
+      // PropertyDefault may have written a blank literal, and `exo__Asset_label: ""`
+      // on disk is worse than either a name or no key at all. No label-derived
+      // `aliases`, and no `missing[]` entry — the unhealthy-vault ERROR must not
+      // fire for a designed outcome. Absent/`false` → byte-identical to before.
+      //
+      // ⛔ Branch, do NOT early-return: the `exo__Instance_class` top-up and the
+      // `missing[]` report both live BELOW this block, and returning here would
+      // silently skip them for every omit-label create.
+      const omitLabelWins =
+        grounding?.omitLabel === true &&
+        (label === undefined || label.trim().length === 0);
+
+      if (omitLabelWins) {
+        delete properties.exo__Asset_label;
+      } else {
+        const finalLabel =
+          label !== undefined && label.trim().length > 0 ? label : "Untitled";
+        properties.exo__Asset_label = finalLabel;
+        // ⛤ Test the CANONICAL spelling, not just the bare one. `createFrontmatter`
+        // collapses `exo__Asset_aliases` onto `aliases` (req 869561bf), but that
+        // happens LATER — so a template / propertyDefault / inheritance-rule
+        // supplying the prefixed key would leave `properties.aliases` undefined
+        // here, this guard would add the label-derived aliases anyway, and the
+        // collapse would then keep whichever landed last. On origin/main both keys
+        // survived (ugly, half-dead); silently dropping one would be worse.
+        const aliasesAlreadySet = Object.keys(properties).some(
+          (k) => canonicalYamlKey(k) === "aliases",
+        );
+        if (finalLabel !== "Untitled" && !aliasesAlreadySet) {
+          properties.aliases = [finalLabel];
+        }
+        // Only the genuine degraded fallthrough ("Untitled") is an
+        // unhealthy-state signal. Reaching this block is NORMAL for the one-click
+        // / CLI flow: Universal Default Template PD #3 (`exo__Asset_label =
+        // $userInputLabel`) writes an empty literal when no input modal supplies
+        // a label, and the labelTemplate / userInput path above is the *designed*
+        // completion — not a TS-fallback rescue. Pushing "exo__Asset_label" to
+        // `missing[]` unconditionally falsely tripped the "Vault may be in an
+        // unhealthy state" ERROR on every healthy labelTemplate-driven create
+        // (bug-fix: false-alarm log). Flag only the real "Untitled" fallback.
+        if (finalLabel === "Untitled") {
+          missing.push("exo__Asset_label");
+        }
       }
     }
 

--- a/packages/core/tests/unit/services/GroundingExecutor.omitLabel.test.ts
+++ b/packages/core/tests/unit/services/GroundingExecutor.omitLabel.test.ts
@@ -1,0 +1,300 @@
+/**
+ * `create_instance` may DELIBERATELY omit `exo__Asset_label`
+ * (`exocmd__Grounding_omitLabel`).
+ *
+ * Default behaviour, unchanged: when nothing supplies a label the executor writes
+ * the literal `"Untitled"` and flags `exo__Asset_label` in `missing[]`, which logs
+ * "Vault may be in an unhealthy state". That is right for an ACCIDENTAL blank.
+ *
+ * It is wrong for a class whose name is DERIVED at render time from an
+ * `exo__DisplayNameSpec` (e.g. `ems__Action`: prototype label + action timestamp).
+ * There a stored label is not missing data — it is duplicated, stale-prone data
+ * sitting next to a spec that recomputes the name on every render.
+ *
+ * The flag is opt-in BY SHAPE and only ever changes the FALLBACK: an explicit
+ * `userInput.label`, or a `labelTemplate` that substitutes non-blank, still wins.
+ *
+ * Production-shape: the executor axes drive the REAL `GroundingExecutor.execute`
+ * over a real `create_instance` grounding with an in-memory fs honouring
+ * read-after-write; the loader axis drives the REAL
+ * `CommandResolver.loadGroundingByUid` over a real `InMemoryTripleStore` seeded
+ * with the `exocmd__Grounding_omitLabel` triple — nothing hand-injected.
+ *
+ * ⛔ The loader axis is NOT redundant with the executor ones: `GroundingExecutor`
+ * receives an already-built `GroundingDefinition`, so an executor-only suite stays
+ * green even when the production loader never reads the triple and the flag is
+ * inert in every real apply (plugin button and CLI both go through
+ * `CommandResolver.loadCommand`; the sibling `GroundingFrontmatterParser` has no
+ * production consumers).
+ *
+ * Revert-verify (each mutation in isolation):
+ *   - drop the executor `omitLabelWins` branch  → the 2 omit axes RED, controls GREEN
+ *   - drop the CommandResolver read             → the loader axis RED, rest GREEN
+ */
+
+import {
+  GroundingExecutor,
+  ServiceRegistry,
+} from "../../../src/services/GroundingExecutor";
+import {
+  clearResolvers,
+  installDefaultResolvers,
+} from "../../../src/services/SubstitutionResolverRegistry";
+import { GroundingType } from "../../../src/domain/constants/GroundingType";
+import { GroundingDefinition } from "../../../src/domain/models/CommandDefinition";
+import { CommandResolver } from "../../../src/services/CommandResolver";
+import { InMemoryTripleStore } from "../../../src/infrastructure/rdf/InMemoryTripleStore";
+import { Triple } from "../../../src/domain/models/rdf/Triple";
+import { IRI } from "../../../src/domain/models/rdf/IRI";
+import { Literal } from "../../../src/domain/models/rdf/Literal";
+import { Namespace } from "../../../src/domain/models/rdf/Namespace";
+import type { ILogger } from "../../../src/interfaces/ILogger";
+
+/** In-memory fs that honours read-after-write (mirrors the real contract). */
+function makeFs(seed: Record<string, string> = {}) {
+  const files = new Map<string, string>(Object.entries(seed));
+  const reader = {
+    readFile: jest.fn(async (path: string) => {
+      if (!files.has(path)) throw new Error(`ENOENT: ${path}`);
+      return files.get(path) as string;
+    }),
+    fileExists: jest.fn(async (path: string) => files.has(path)),
+    getMarkdownFiles: jest.fn().mockResolvedValue([]),
+  };
+  const writer = {
+    createFile: jest.fn(async (path: string, content: string) => {
+      files.set(path, content);
+      return "";
+    }),
+    updateFile: jest.fn(async (path: string, content: string) => {
+      files.set(path, content);
+    }),
+    writeFile: jest.fn(async (path: string, content: string) => {
+      files.set(path, content);
+    }),
+    deleteFile: jest.fn(async (path: string) => {
+      files.delete(path);
+    }),
+    renameFile: jest.fn().mockResolvedValue(undefined),
+  };
+  return { files, reader, writer };
+}
+
+function gnd(overrides: Record<string, unknown>): GroundingDefinition {
+  return {
+    id: "gnd-omit-label",
+    label: "omit-label",
+    ...overrides,
+  } as unknown as GroundingDefinition;
+}
+
+const TARGET_IRI = "https://exocortex.my/assets/proto-omit";
+const TARGET_PATH = "/vault/protos/proto-omit.md";
+const TARGET_SEED =
+  "---\nexo__Asset_uid: proto-omit\nexo__Asset_label: Выпить Пантокальцин после обеда\n---\nProto body";
+
+function createInstance(overrides: Record<string, unknown> = {}) {
+  return gnd({
+    type: GroundingType.CREATE_INSTANCE,
+    targetClass: "ems__Action",
+    targetFolder: "/vault/actions",
+    ...overrides,
+  });
+}
+
+/** The single created file (the only entry outside the seeded click-target). */
+function createdContent(files: Map<string, string>): string {
+  const created = [...files.entries()].find(([p]) => p !== TARGET_PATH);
+  expect(created).toBeDefined();
+  return (created as [string, string])[1];
+}
+
+/** The frontmatter block only — so `toContain` cannot match body text. */
+function frontmatter(content: string): string {
+  const m = /^---\n([\s\S]*?)\n---/.exec(content);
+  expect(m).not.toBeNull();
+  return (m as RegExpExecArray)[1];
+}
+
+async function run(grounding: GroundingDefinition, userInput?: unknown) {
+  const { files, reader, writer } = makeFs({ [TARGET_PATH]: TARGET_SEED });
+  const exec = new GroundingExecutor(reader, writer, new ServiceRegistry());
+  const res = await exec.execute(
+    grounding,
+    TARGET_IRI,
+    TARGET_PATH,
+    userInput as never,
+  );
+  expect(res.success).toBe(true);
+  return { files, content: createdContent(files) };
+}
+
+describe("GroundingExecutor — create_instance omitLabel", () => {
+  beforeEach(() => {
+    clearResolvers();
+    installDefaultResolvers();
+  });
+
+  it("omits exo__Asset_label entirely when the flag is set and nothing supplied one", async () => {
+    const errorSpy = jest
+      .spyOn(
+        require("../../../src/services/LoggingService").LoggingService,
+        "error",
+      )
+      .mockImplementation();
+
+    const { content } = await run(createInstance({ omitLabel: true }));
+    const fm = frontmatter(content);
+
+    // No key at all — NOT "Untitled", and NOT an empty literal (which would be
+    // worse than either: it renders as a blank name rather than falling through
+    // to the DisplayNameSpec).
+    expect(fm).not.toContain("exo__Asset_label");
+    expect(fm).not.toContain("Untitled");
+    // No label-derived aliases either.
+    expect(fm).not.toContain("aliases");
+
+    // …and the label must NOT be reported as missing. Scoped to the label on
+    // purpose: this bare fixture carries no Universal Default Template
+    // PropertyDefaults, so `exo__Asset_uid` / `exo__Asset_createdAt` /
+    // `exo__Instance_class` are legitimately filled by the TS safety net and DO
+    // appear in the same ERROR. Asserting "no unhealthy ERROR at all" would be a
+    // claim this fixture cannot support — the discriminating fact is that
+    // `exo__Asset_label` is absent from it (and present in the control below).
+    const calls = errorSpy.mock.calls.flat().map(String);
+    const unhealthy = calls.filter((s) =>
+      s.includes("did not cover essential scalar primitives"),
+    );
+    expect(unhealthy.some((s) => s.includes("exo__Asset_label"))).toBe(false);
+
+    errorSpy.mockRestore();
+  });
+
+  it("still writes exo__Instance_class under omitLabel (the top-up below the label block must not be skipped)", async () => {
+    // Pins the shape of the fix: the label block is BRANCHED, not early-returned.
+    // An early return would silently skip this top-up — and the created asset
+    // would have no class at all, which is far worse than a missing label.
+    const { content } = await run(createInstance({ omitLabel: true }));
+    const fm = frontmatter(content);
+    expect(fm).toContain("exo__Instance_class");
+    expect(fm).toContain("exo__Asset_uid");
+  });
+
+  it("control: WITHOUT the flag the Untitled fallback and its unhealthy-state ERROR are unchanged", async () => {
+    const errorSpy = jest
+      .spyOn(
+        require("../../../src/services/LoggingService").LoggingService,
+        "error",
+      )
+      .mockImplementation();
+
+    const { content } = await run(createInstance());
+    expect(frontmatter(content)).toContain("exo__Asset_label: Untitled");
+
+    const calls = errorSpy.mock.calls.flat().map(String);
+    expect(
+      calls.some(
+        (s) =>
+          s.includes("did not cover essential scalar primitives") &&
+          s.includes("exo__Asset_label"),
+      ),
+    ).toBe(true);
+
+    errorSpy.mockRestore();
+  });
+
+  it("control: an explicit userInput.label WINS over the flag (it only changes the fallback)", async () => {
+    const { content } = await run(createInstance({ omitLabel: true }), {
+      label: "Явное имя",
+    });
+    const fm = frontmatter(content);
+    expect(fm).toContain("exo__Asset_label: Явное имя");
+    expect(fm).toContain("aliases");
+  });
+
+  it("control: a labelTemplate that substitutes non-blank WINS over the flag", async () => {
+    const { content } = await run(
+      createInstance({
+        omitLabel: true,
+        labelTemplate: "$target.exo__Asset_label",
+      }),
+    );
+    expect(frontmatter(content)).toContain(
+      "exo__Asset_label: Выпить Пантокальцин после обеда",
+    );
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────────────
+// Loader axis — the flag must be read by the PRODUCTION loader, or it is inert.
+// ────────────────────────────────────────────────────────────────────────────
+
+function silentLogger(): ILogger {
+  return { debug() {}, info() {}, warn() {}, error() {} };
+}
+
+/** `create_instance` grounding, optionally carrying the omitLabel triple. */
+async function seedGrounding(
+  store: InMemoryTripleStore,
+  uid: string,
+  omitLabel?: string,
+): Promise<void> {
+  const subject = new IRI(`obsidian://vault/${uid}.md`);
+  const triples: Triple[] = [
+    new Triple(
+      subject,
+      Namespace.RDF.term("type"),
+      Namespace.EXOCMD.term("Grounding"),
+    ),
+    new Triple(subject, Namespace.EXO.term("Asset_uid"), new Literal(uid)),
+    new Triple(subject, Namespace.EXO.term("Asset_label"), new Literal(uid)),
+    new Triple(
+      subject,
+      Namespace.EXOCMD.term("Grounding_type"),
+      // Wikilink-form UID ref into the exocmd__GroundingType catalog
+      // (create_instance → 4367e2d6); a bare string resolves to null.
+      new Literal("[[4367e2d6-6c92-450a-becb-abce1fb07682]]"),
+    ),
+  ];
+  if (omitLabel !== undefined) {
+    triples.push(
+      new Triple(
+        subject,
+        Namespace.EXOCMD.term("Grounding_omitLabel"),
+        new Literal(omitLabel),
+      ),
+    );
+  }
+  await store.addAll(triples);
+}
+
+describe("CommandResolver — reads exocmd__Grounding_omitLabel", () => {
+  it("loads omitLabel: true from the triple store", async () => {
+    const store = new InMemoryTripleStore();
+    await seedGrounding(store, "gnd-omit-true", "true");
+    const resolver = new CommandResolver(store, silentLogger());
+
+    const grounding = await resolver.loadGroundingByUid("gnd-omit-true");
+    expect(grounding).not.toBeNull();
+    expect(grounding?.omitLabel).toBe(true);
+  });
+
+  it("control: absent triple → undefined (byte-identical to every existing grounding)", async () => {
+    const store = new InMemoryTripleStore();
+    await seedGrounding(store, "gnd-omit-absent");
+    const resolver = new CommandResolver(store, silentLogger());
+
+    const grounding = await resolver.loadGroundingByUid("gnd-omit-absent");
+    expect(grounding).not.toBeNull();
+    expect(grounding?.omitLabel).toBeUndefined();
+  });
+
+  it("control: an explicit 'false' literal does NOT enable the flag", async () => {
+    const store = new InMemoryTripleStore();
+    await seedGrounding(store, "gnd-omit-false", "false");
+    const resolver = new CommandResolver(store, silentLogger());
+
+    const grounding = await resolver.loadGroundingByUid("gnd-omit-false");
+    expect(grounding?.omitLabel).toBeUndefined();
+  });
+});


### PR DESCRIPTION
feat(grounding): create_instance may deliberately omit exo__Asset_label

`exocmd__Grounding_omitLabel: true` tells `create_instance` that an ABSENT
`exo__Asset_label` is the INTENDED end state, not a degraded fallback.

Why: for a class whose name is DERIVED at render time from an
`exo__DisplayNameSpec` — `ems__Action`, whose display name composes the
prototype's label with the action's timestamp — a stored label is not missing
data. It is duplicated, stale-prone data: the asset carries a frozen string
next to a spec that recomputes the name on every render, and the two disagree
the moment either side changes. Today the executor writes the literal
`"Untitled"` there, derives no aliases, and pushes `exo__Asset_label` to
`missing[]`, which logs "Vault may be in an unhealthy state" — a false alarm for
a designed outcome, and `"Untitled"` itself is the wrong name.

Default behaviour is UNCHANGED and stays right for an ACCIDENTAL blank. The flag
is opt-in by shape and only ever changes the FALLBACK — an explicit
`userInput.label`, or a `labelTemplate` that substitutes non-blank, still wins
and takes the normal path.

When it fires (flag set AND nothing resolved a label) the executor:
  - DELETES `exo__Asset_label` rather than writing `"Untitled"`. Deleting, not
    leaving the key: an upstream PropertyDefault (Universal Default Template
    PD #3, `exo__Asset_label = $userInputLabel`) writes a blank literal in the
    one-click flow, and `exo__Asset_label: ""` on disk is worse than either a
    name or no key — it renders as a blank name instead of falling through to
    the DisplayNameSpec;
  - writes no label-derived `aliases`;
  - does not push `exo__Asset_label` to `missing[]`.

⛔ The label block is BRANCHED, not early-returned. `exo__Instance_class`'s
top-up and the `missing[]` report both live BELOW it, and an early `return`
would silently skip them — the created asset would carry no class at all, which
is far worse than a missing label. An axis pins this (see MUT-3 below); it is
the one mutation the other axes cannot see.

Read in BOTH parsers, per the multi-parser rule:
  - `CommandResolver.loadGroundingDefinition` — the PRODUCTION loader. Plugin
    button and CLI `apply` both go through `loadCommand`, so a flag read only in
    the sibling parser is inert in every real apply;
  - `GroundingFrontmatterParser` — CLI-BDD parity.
Boolean coercion mirrors `targetsCreatedInstance` (`true` boolean or `"true"`
literal); `omitLabel || undefined` keeps the field off every existing grounding.

Tests: 8 axes — 5 executor (real `GroundingExecutor.execute` over a real
create_instance grounding, in-memory fs honouring read-after-write) + 3 loader
(real `CommandResolver.loadGroundingByUid` over a real `InMemoryTripleStore`
seeded with the triple). The loader axes are NOT redundant: the executor
receives an already-built `GroundingDefinition`, so an executor-only suite stays
green while the flag is inert in production.

⛤ The "no unhealthy ERROR" assertion is scoped to `exo__Asset_label`, not to the
ERROR as a whole. The bare fixture carries no Universal Default Template
PropertyDefaults, so `exo__Asset_uid` / `_createdAt` / `exo__Instance_class` are
legitimately filled by the TS safety net and DO appear in the same message. The
discriminating fact is that the label is absent from it — and present in the
control. Asserting more would be a claim this fixture cannot support.

Revert-verify, each mutation in isolation on a /tmp copy:
  - executor reads a mismatched key (type-preserving)  → 1 RED (the omit axis)
  - drop the CommandResolver read                      → 1 RED (the loader axis)
  - reintroduce the early `return`                     → 1 RED (the class axis)
Restore → 8/8. Each mutation reds exactly its own axis; none is vacuous.
(A first attempt at mutation 1 used `false &&` and produced `Tests: 0 total` —
a broken compile, not a RED. Redone type-preserving.)

Local gates: core 364/364 suites (8521 tests), plugin 340/340 (6073), CLI
156/157 — `sparql-exo003.integration.test.ts` is pre-existing, proved ON THIS
TREE by restoring all four touched sources from origin/main and re-running that
suite: identical 1 failed / 9 passed either way. Root `tsc --noEmit` clean; all
three lint-job guard scripts pass. Prettier: the new test is formatted; both
files I added code to (`CommandResolver.ts`, `CommandDefinition.ts`) are clean —
they were clean on origin/main (blast-radius 0) and my lines kept them so.
`GroundingExecutor.ts` (393) and `GroundingFrontmatterParser.ts` (23) are
prettier-dirty on origin/main and are left alone.

Vault-side counterpart (the `exocmd__Grounding_omitLabel` property def and the
`ems__Action` DisplayNameSpec) ships separately as data.

Claude-Session: https://claude.ai/code/session_01Xp6ceD53nG2HvWFtFWMoFX
