### PR TITLE
fix(core): isEffortBlocked compares the status LABEL, not the raw wikilink (closes #4053)

### DIFF
--- a/packages/cli/tests/integration/resolve-display-name.hostFunctions.integration.test.ts
+++ b/packages/cli/tests/integration/resolve-display-name.hostFunctions.integration.test.ts
@@ -363,4 +363,91 @@ describe("resolve-display-name — host-function specs (req 5cd9fffe)", () => {
 
     expect(r.displayName).not.toContain("EF-9001");
   });
+  it(`${REQ_BLOCKED} a NON-symbolic alias is display text — the UID before the pipe decides`, async () => {
+    // ⛔ The axis the first version of this fix was missing. An Obsidian alias is arbitrary
+    // display text: `[[uid|Done]]` says nothing about the status. Trusting it made a FINISHED
+    // blocker read as blocking again — the same bug, one layer up. The port's own contract says
+    // `[[uid|label]]` must resolve identically to `[[uid]]`, and both in-repo precedents key on
+    // the target. The shipped alias case used `[[uid|ems__EffortStatusDone]]`, the one alias that
+    // happens to work, so the gap was invisible to the suite.
+    write(`assetspaces/t/${BLOCKER}.md`, {
+      exo__Asset_uid: BLOCKER,
+      exo__Asset_label: "the blocker",
+      ems__Effort_status: `[[${DONE_UID}|Done]]`,
+    });
+    write(`assetspaces/t/${TARGET}.md`, {
+      exo__Asset_uid: TARGET,
+      exo__Instance_class: [`[[${EFFORT_CLASS}]]`],
+      ems__Effort_blocker: `[[${BLOCKER}]]`,
+      t__Effort_serial: "EF-9001",
+    });
+
+    const r = await resolveDisplayName(vault, `assetspaces/t/${TARGET}.md`);
+
+    expect(r.displayName).not.toContain("EF-9001");
+  });
+
+  it(`${REQ_BLOCKED} the class-name + trailing-UUID shape resolves without a lookup`, async () => {
+    rmSync(path.join(vault, `assetspaces/t/${DONE_UID}.md`), { force: true });
+    // The shape PropertySchemas documents as occurring "after certain status transitions".
+    // A loose startsWith("ems__") accepted it verbatim and short-circuited the lookup, so it
+    // never matched a terminal label; the precise regex + trailing-UUID strip resolve it.
+    // TBox removed on purpose: this form must need no vault at all.
+    write(`assetspaces/t/${BLOCKER}.md`, {
+      exo__Asset_uid: BLOCKER,
+      exo__Asset_label: "the blocker",
+      ems__Effort_status: `[[ems__EffortStatusDone ${DONE_UID}]]`,
+    });
+    write(`assetspaces/t/${TARGET}.md`, {
+      exo__Asset_uid: TARGET,
+      exo__Instance_class: [`[[${EFFORT_CLASS}]]`],
+      ems__Effort_blocker: `[[${BLOCKER}]]`,
+      t__Effort_serial: "EF-9001",
+    });
+
+    const r = await resolveDisplayName(vault, `assetspaces/t/${TARGET}.md`);
+
+    expect(r.displayName).not.toContain("EF-9001");
+  });
+
+  it(`${REQ_BLOCKED} wrapping quotes do not defeat the comparison`, async () => {
+    // Every sibling normaliser strips wrapping quotes; this one did not, so a quoted value fell
+    // through to the raw string and read as blocking.
+    write(`assetspaces/t/${BLOCKER}.md`, {
+      exo__Asset_uid: BLOCKER,
+      exo__Asset_label: "the blocker",
+      ems__Effort_status: `"[[${DONE_UID}]]"`,
+    });
+    write(`assetspaces/t/${TARGET}.md`, {
+      exo__Asset_uid: TARGET,
+      exo__Instance_class: [`[[${EFFORT_CLASS}]]`],
+      ems__Effort_blocker: `[[${BLOCKER}]]`,
+      t__Effort_serial: "EF-9001",
+    });
+
+    const r = await resolveDisplayName(vault, `assetspaces/t/${TARGET}.md`);
+
+    expect(r.displayName).not.toContain("EF-9001");
+  });
+
+  it(`${REQ_BLOCKED} a MULTI-element status list is treated as unknown, not as its first element`, async () => {
+    // Cardinality is 1 per schema. Picking an arbitrary first element would silently contradict
+    // whatever the UI shows, so a multi-valued status is unknown ⇒ still blocking (fail-safe),
+    // mirroring the call GroundingExecutor.resolveStatusFromFrontmatter makes.
+    write(`assetspaces/t/${BLOCKER}.md`, {
+      exo__Asset_uid: BLOCKER,
+      exo__Asset_label: "the blocker",
+      ems__Effort_status: [`[[${DONE_UID}]]`, "[[some-other]]"],
+    });
+    write(`assetspaces/t/${TARGET}.md`, {
+      exo__Asset_uid: TARGET,
+      exo__Instance_class: [`[[${EFFORT_CLASS}]]`],
+      ems__Effort_blocker: `[[${BLOCKER}]]`,
+      t__Effort_serial: "EF-9001",
+    });
+
+    const r = await resolveDisplayName(vault, `assetspaces/t/${TARGET}.md`);
+
+    expect(r.displayName).toContain("EF-9001");
+  });
 });

--- a/packages/cli/tests/integration/resolve-display-name.hostFunctions.integration.test.ts
+++ b/packages/cli/tests/integration/resolve-display-name.hostFunctions.integration.test.ts
@@ -18,6 +18,8 @@ import path from "path";
 import { resolveDisplayName } from "../../src/commands/resolve-display-name.js";
 
 const REQ = "@req:5cd9fffe-1fa5-4fda-8e2a-bfe6d4c88379";
+/** The dual-IRI conformance fix guards req d6cd2371's contract ("checks ITS status"). */
+const REQ_BLOCKED = "@req:d6cd2371-bdf2-460e-840e-841480273869";
 
 const EFFORT_CLASS = "a1111111-1111-4222-8333-444444444444";
 const EFFORT_SPEC = "a2222222-1111-4222-8333-444444444444";
@@ -41,6 +43,21 @@ const BLOCKER = "d0000001-1111-4222-8333-444444444444";
 
 /** The UID the real vault uses for ems__EffortStatusDone — the bare form the CLI writes. */
 const DONE_UID = "7b9b3116-7c3c-438c-9618-94fe301320a6";
+
+/**
+ * ⛔ The status TBox has to EXIST in the fixture, because the dual-IRI fix resolves a bare-UID
+ * status through the vault rather than against a hardcoded UID table. Omitting it is not a
+ * neutral simplification: the lookup then fails and the predicate falls back to "unknown status ⇒
+ * still blocking", so the test would read as if the fix had not landed. A real vault always has
+ * `exoas-public` mounted; a fixture that does not mirror that is testing a different system
+ * (test-fixture-realism).
+ */
+function writeStatusTBox(): void {
+  write(`assetspaces/t/${DONE_UID}.md`, {
+    exo__Asset_uid: DONE_UID,
+    exo__Asset_label: "ems__EffortStatusDone",
+  });
+}
 
 let vault: string;
 
@@ -104,6 +121,7 @@ function writeRaw(rel: string, body: string): void {
 
 beforeEach(() => {
   vault = mkdtempSync(path.join(tmpdir(), "exo-rdn-hf-"));
+  writeStatusTBox();
   writeSpecTriple(EFFORT_CLASS, "t__Effort", EFFORT_SPEC, EFFORT_PART, "isEffortBlocked", "t__Effort_serial");
   writeSpecTriple(PERIOD_CLASS, "t__Period", PERIOD_SPEC, PERIOD_PART, "isEpisodeOngoing", "t__Period_serial");
   // Names a function that is registered NOWHERE — the fail-closed control.
@@ -161,16 +179,17 @@ describe("resolve-display-name — host-function specs (req 5cd9fffe)", () => {
     expect(r.source).not.toBe("spec");
   });
 
-  it(`${REQ} CHARACTERISES the inherited dual-IRI defect: a bare-UID Done blocker still reads as blocking`, async () => {
+  it(`${REQ_BLOCKED} a bare-UID Done blocker reads as FINISHED — the dual-IRI form the CLI writes`, async () => {
     write(`assetspaces/t/${BLOCKER}.md`, {
       exo__Asset_uid: BLOCKER,
       exo__Asset_label: "the blocker",
-      // ⛔ The form `exocortex-cli` actually writes. Stripping the brackets leaves a UID, which
-      // matches neither EffortStatus.DONE nor TRASHED, so a FINISHED blocker reads as active.
-      // Measured 2026-08-15 on live data: 49 of 58 single-valued blockers store this form and 8
-      // efforts carry a 🚩 they should not. Moved VERBATIM so both surfaces stay identical —
-      // parity is this requirement's point, and the fix (match both forms) gets its own req.
-      // ⛤ When that fix lands, THIS test is its revert-verify: it must flip.
+      // ⛔ The form `exocortex-cli` actually writes — and the one that used to make a FINISHED
+      // blocker read as active, because stripping the brackets left a UID that matched neither
+      // terminal label. Measured 2026-08-15: 49 of 58 single-valued blockers store it and 8
+      // efforts carried a 🚩 they should not.
+      // ⛤ This test SHIPPED ASSERTING THE DEFECT (req 5cd9fffe carried it verbatim so one fix
+      // could repair both surfaces at once). It is now flipped — which is exactly the revert-verify
+      // its own comment promised, so no new fixture was needed for the fix.
       ems__Effort_status: `[[${DONE_UID}]]`,
     });
     write(`assetspaces/t/${TARGET}.md`, {
@@ -182,8 +201,9 @@ describe("resolve-display-name — host-function specs (req 5cd9fffe)", () => {
 
     const r = await resolveDisplayName(vault, `assetspaces/t/${TARGET}.md`);
 
-    expect(r.displayName).toContain("EF-9001"); // ⛔ wrong in the domain, right as parity
-    expect(r.source).toBe("spec");
+    // The blocker IS finished, so the spec must NOT participate.
+    expect(r.displayName).not.toContain("EF-9001");
+    expect(r.source).not.toBe("spec");
   });
 
   it(`${REQ} applies an isEpisodeOngoing spec without touching the vault port (Scenario 5)`, async () => {
@@ -299,5 +319,48 @@ describe("resolve-display-name — host-function specs (req 5cd9fffe)", () => {
     const r = await resolveDisplayName(vault, `assetspaces/t/${TARGET}.md`);
 
     expect(r.displayName).not.toContain("EF-9001"); // ⛔ wrong in the domain, locked as parity
+  });
+  it(`${REQ_BLOCKED} falls back to "still blocking" when the status asset cannot be resolved`, async () => {
+    // The boundary the vault lookup introduces: with `exoas-public` unmounted there is nothing to
+    // resolve the bare UID against. The predicate must NOT silently report "not blocked" — an
+    // effort that cannot be judged keeps its 🚩. Same direction the pre-fix code took for an
+    // absent frontmatter, so the fail-safe is preserved rather than newly invented.
+    rmSync(path.join(vault, `assetspaces/t/${DONE_UID}.md`), { force: true });
+    write(`assetspaces/t/${BLOCKER}.md`, {
+      exo__Asset_uid: BLOCKER,
+      exo__Asset_label: "the blocker",
+      ems__Effort_status: `[[${DONE_UID}]]`,
+    });
+    write(`assetspaces/t/${TARGET}.md`, {
+      exo__Asset_uid: TARGET,
+      exo__Instance_class: [`[[${EFFORT_CLASS}]]`],
+      ems__Effort_blocker: `[[${BLOCKER}]]`,
+      t__Effort_serial: "EF-9001",
+    });
+
+    const r = await resolveDisplayName(vault, `assetspaces/t/${TARGET}.md`);
+
+    expect(r.displayName).toContain("EF-9001");
+  });
+
+  it(`${REQ_BLOCKED} reads the ALIAS form without any lookup at all`, async () => {
+    // `[[uid|ems__EffortStatusDone]]` — the third legal form. The label after the pipe is
+    // authoritative, so this one resolves even with the status TBox absent.
+    rmSync(path.join(vault, `assetspaces/t/${DONE_UID}.md`), { force: true });
+    write(`assetspaces/t/${BLOCKER}.md`, {
+      exo__Asset_uid: BLOCKER,
+      exo__Asset_label: "the blocker",
+      ems__Effort_status: `[[${DONE_UID}|ems__EffortStatusDone]]`,
+    });
+    write(`assetspaces/t/${TARGET}.md`, {
+      exo__Asset_uid: TARGET,
+      exo__Instance_class: [`[[${EFFORT_CLASS}]]`],
+      ems__Effort_blocker: `[[${BLOCKER}]]`,
+      t__Effort_serial: "EF-9001",
+    });
+
+    const r = await resolveDisplayName(vault, `assetspaces/t/${TARGET}.md`);
+
+    expect(r.displayName).not.toContain("EF-9001");
   });
 });

--- a/packages/core/src/domain/display-name/hostFunctions.ts
+++ b/packages/core/src/domain/display-name/hostFunctions.ts
@@ -31,25 +31,22 @@ const DAY_KEY_RE = /^\d{4}-\d{2}-\d{2}$/;
  * True iff the effort is blocked by another effort — i.e. it carries `ems__Effort_blocker`
  * pointing at an asset whose own status is neither DONE nor TRASHED.
  *
- * ⛔ MOVED VERBATIM, INCLUDING A LIVE DEFECT — deliberately, because parity is the point of
- * req 5cd9fffe and "correct here, wrong in the plugin" would be worse than "identical in both".
- * The comparison below is against the SYMBOLIC status label (`ems__EffortStatusDone`), but
- * `exocortex-cli` writes the status as a bare `[[<uid>]]`; stripping the brackets then leaves a
- * UID, no branch matches, and a FINISHED blocker is reported as still blocking. Measured
- * 2026-08-15 on live data: 49 of 58 single-valued blockers store the bare-UID form, and 8
- * efforts currently carry a 🚩 they should not. That is the dual-IRI class, fixed by matching
- * BOTH forms — and it gets its own requirement, because the fix changes what the user sees.
- * Landing that fix HERE, once, now repairs both surfaces at once: this move is its precondition.
+ * ⛤ The dual-IRI defect this function shipped with is FIXED here (req d6cd2371 conformance):
+ * the status is normalised to its symbolic label first, so all three legal wikilink forms compare
+ * identically. Req 5cd9fffe moved the predicate to core verbatim, defect included, precisely so
+ * that this one fix would repair BOTH surfaces at once — the plugin and the CLI now change
+ * together, which is what "one implementation" was for. See `resolveStatusLabel` for the measured
+ * incidence (49 of 58 blockers, 8 efforts with a wrong 🚩) and for why the lookup goes through the
+ * vault rather than a UID table.
  *
- * ⛔ Likewise verbatim: a multi-valued `ems__Effort_blocker` (16 of the 74 measured) is flattened
- * by `String(...)` into a comma-joined string that resolves to nothing, so the predicate answers
- * "not blocked". Same reasoning — a behaviour change needs its own req. Characterised by test.
+ * ⛔ Still verbatim, and still deferred: a multi-valued `ems__Effort_blocker` (16 of the 74
+ * measured) is flattened by `String(...)` into a comma-joined string that resolves to nothing, so
+ * the predicate answers "not blocked". Characterised by test; its own fix, its own req.
  *
- * ⚠ ONE delta is NOT verbatim and is accepted deliberately: the port retries the linkpath with a
+ * ⚠ ONE delta is not verbatim and is accepted deliberately: the port retries the linkpath with a
  * `.md` suffix, which the inline original did not. It can only turn a previously UNRESOLVABLE
- * blocker into a resolvable one — i.e. strictly more links resolve — and it is the same retry the
- * engine has always done, so the two callers now agree rather than differ. The alternative was a
- * second port method whose only purpose is to resolve links WORSE.
+ * blocker into a resolvable one, and it is the same retry the engine has always done, so the two
+ * callers now agree rather than differ.
  */
 export function isEffortBlocked(
   vault: VaultMetadataPort,
@@ -69,13 +66,54 @@ export function isEffortBlocked(
     return false;
   }
 
-  const blockerStatus = blockerMetadata.ems__Effort_status || "";
-  const blockerStatusStr = String(blockerStatus).replace(/^\[\[|\]\]$/g, "");
+  const label = resolveStatusLabel(vault, blockerMetadata.ems__Effort_status);
 
-  return (
-    blockerStatusStr !== EffortStatus.DONE &&
-    blockerStatusStr !== EffortStatus.TRASHED
-  );
+  return label !== EffortStatus.DONE && label !== EffortStatus.TRASHED;
+}
+
+/**
+ * Normalise `ems__Effort_status` to its SYMBOLIC label (`ems__EffortStatusDone`), whichever of the
+ * three legal wikilink forms it was written in (req d6cd2371 conformance).
+ *
+ * ⛔ This is the dual-IRI fix. The predicate always compared against the symbolic label, but the
+ * value is written three ways and only ONE of them survived the bracket strip:
+ *
+ *   `[[ems__EffortStatusDone]]`   → `ems__EffortStatusDone`                    matched
+ *   `[[<uid>]]`                   → `<uid>`                                    NEVER matched
+ *   `[[<uid>|ems__…Done]]`        → `<uid>|ems__…Done`                         NEVER matched
+ *
+ * The bare-UID form is what `exocortex-cli` writes, so it is the COMMON one: measured 2026-08-15
+ * across all three vaults, 49 of 58 single-valued blockers stored it, and 8 efforts were showing a
+ * 🚩 whose blocker was finished. `BlockerHelpers.isEffortBlocked`'s own docstring already promised
+ * "status that is not DONE or TRASHED", and req d6cd2371 promised it "checks ITS status" — the
+ * code simply did not implement either for two forms out of three.
+ *
+ * ⛤ Resolved through the vault rather than against a UID table: `EffortStatus`'s own docstring
+ * says new code should "resolve UUIDs at runtime via the TBox lookup instead", and a hardcoded
+ * table would be a third copy of UIDs that already exist in `STATUS_UID_BY_ENUM` — one that
+ * silently rots if a status asset is ever renamed. The hop costs one metadataCache read (plugin)
+ * or one file read (CLI), and only for efforts that actually carry a blocker.
+ *
+ * ⚠ Fail-safe preserved: if the status asset cannot be resolved (its assetspace not mounted, a
+ * dangling link), the raw value is returned unchanged and therefore matches neither terminal
+ * label — i.e. "unknown status ⇒ still blocking", exactly the direction the pre-fix code took
+ * for an absent frontmatter. An effort that cannot be judged must not silently look unblocked.
+ */
+function resolveStatusLabel(vault: VaultMetadataPort, rawStatus: unknown): string {
+  const stripped = String(rawStatus ?? "").replace(/^\[\[|\]\]$/g, "");
+  if (stripped === "") return "";
+
+  // Alias form: the label after `|` is authoritative and needs no lookup.
+  if (stripped.includes("|")) {
+    return stripped.slice(stripped.indexOf("|") + 1).trim();
+  }
+  // Already symbolic — the form the enum is written in.
+  if (stripped.startsWith("ems__")) return stripped;
+
+  // Bare UID (or basename): ask the vault what that asset calls itself.
+  const fm = vault.resolveLinkpathFrontmatter(stripped);
+  const label = fm?.exo__Asset_label;
+  return typeof label === "string" && label.trim() ? label.trim() : stripped;
 }
 
 /**

--- a/packages/core/src/domain/display-name/hostFunctions.ts
+++ b/packages/core/src/domain/display-name/hostFunctions.ts
@@ -72,48 +72,93 @@ export function isEffortBlocked(
 }
 
 /**
- * Normalise `ems__Effort_status` to its SYMBOLIC label (`ems__EffortStatusDone`), whichever of the
- * three legal wikilink forms it was written in (req d6cd2371 conformance).
+ * The exact shape of a symbolic status label. Deliberately the SAME regex the two sibling
+ * normalisers use (`GroundingExecutor.resolveStatusFromFrontmatter`) rather than a looser
+ * `startsWith("ems__")`: the loose test short-circuits the vault lookup for forms that are not
+ * labels at all, e.g. the documented `ems__EffortStatusDone <uuid>` shape.
+ */
+const SYMBOLIC_STATUS_RE = /^ems__EffortStatus[A-Za-z]+$/;
+const TRAILING_UUID_RE =
+  /\s+[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/**
+ * Normalise `ems__Effort_status` to its SYMBOLIC label (`ems__EffortStatusDone`), whichever legal
+ * shape it was written in (req d6cd2371 conformance).
  *
  * ⛔ This is the dual-IRI fix. The predicate always compared against the symbolic label, but the
- * value is written three ways and only ONE of them survived the bracket strip:
+ * value is written several ways and only one survived a bare bracket strip:
  *
- *   `[[ems__EffortStatusDone]]`   → `ems__EffortStatusDone`                    matched
- *   `[[<uid>]]`                   → `<uid>`                                    NEVER matched
- *   `[[<uid>|ems__…Done]]`        → `<uid>|ems__…Done`                         NEVER matched
+ *   `[[ems__EffortStatusDone]]`      → matched
+ *   `[[<uid>]]`                      → left a UID; NEVER matched
+ *   `[[<uid>|ems__…Done]]`           → left `<uid>|ems__…Done`; NEVER matched
  *
- * The bare-UID form is what `exocortex-cli` writes, so it is the COMMON one: measured 2026-08-15
- * across all three vaults, 49 of 58 single-valued blockers stored it, and 8 efforts were showing a
- * 🚩 whose blocker was finished. `BlockerHelpers.isEffortBlocked`'s own docstring already promised
- * "status that is not DONE or TRASHED", and req d6cd2371 promised it "checks ITS status" — the
- * code simply did not implement either for two forms out of three.
+ * Measured 2026-08-15 across all three vaults: of the 49 blockers carrying a status, **49 use the
+ * bare-UID form and zero use symbolic or alias** — i.e. broken for 100% of real blockers. It
+ * stayed invisible only because a blocker is rarely finished.
  *
- * ⛤ Resolved through the vault rather than against a UID table: `EffortStatus`'s own docstring
- * says new code should "resolve UUIDs at runtime via the TBox lookup instead", and a hardcoded
- * table would be a third copy of UIDs that already exist in `STATUS_UID_BY_ENUM` — one that
- * silently rots if a status asset is ever renamed. The hop costs one metadataCache read (plugin)
- * or one file read (CLI), and only for efforts that actually carry a blocker.
+ * ⛔ An ALIAS is arbitrary display text, not an identifier — `[[<uid>|Done]]` is legal and says
+ * nothing about the status. It is therefore honoured ONLY when it is itself a symbolic label;
+ * otherwise the UID before the pipe is resolved. That is the port's own documented floor
+ * ({@link VaultMetadataPort.resolveLinkpathFrontmatter}: "`[[uid|label]]` must resolve identically
+ * to `[[uid]]`") and it matches both in-repo precedents, which key on the target rather than on
+ * the alias.
  *
- * ⚠ Fail-safe preserved: if the status asset cannot be resolved (its assetspace not mounted, a
- * dangling link), the raw value is returned unchanged and therefore matches neither terminal
- * label — i.e. "unknown status ⇒ still blocking", exactly the direction the pre-fix code took
- * for an absent frontmatter. An effort that cannot be judged must not silently look unblocked.
+ * ⛤ Resolved through the vault rather than against a UID table. That table already exists TWICE —
+ * `STATUS_UID_BY_ENUM` (`GroundingExecutor`) and `FALLBACK_EFFORT_STATUS_VALUES`
+ * (`PropertySchemas`) — and BOTH had to be hand-edited when `ToDo`/`Analysis` were deleted on
+ * 2026-08-13 (both cite req `fcbde537`). A third copy would be a third proven drift point, and
+ * importing either into `domain/` would invert the layering.
+ *
+ * @see GroundingExecutor.resolveStatusFromFrontmatter — the same vocabulary, UID-table based
+ * @see getStatusLabel in PropertySchemas — the same vocabulary again, for the property editor
+ *
+ * ⚠ Fail-safe: an unresolvable status returns the raw target, which matches neither terminal
+ * label ⇒ "unknown status ⇒ still blocking". Note the deliberate ASYMMETRY with the caller — an
+ * unresolvable BLOCKER yields `false` (not blocked), an unresolvable STATUS yields `true`. That
+ * is not an oversight to be harmonised: the port distinguishes "no such asset" (`null`) from
+ * "asset with nothing in it" (`{}`), and a blocker that does not exist cannot block, whereas a
+ * blocker whose state is unknown must not be assumed finished.
  */
 function resolveStatusLabel(vault: VaultMetadataPort, rawStatus: unknown): string {
-  const stripped = String(rawStatus ?? "").replace(/^\[\[|\]\]$/g, "");
-  if (stripped === "") return "";
-
-  // Alias form: the label after `|` is authoritative and needs no lookup.
-  if (stripped.includes("|")) {
-    return stripped.slice(stripped.indexOf("|") + 1).trim();
+  let raw = rawStatus;
+  if (raw === undefined || raw === null) return "";
+  // Cardinality is 1 per schema. Tolerate a 1-element list (some YAML printers emit it) and treat
+  // a multi-element one as unknown rather than picking an arbitrary first — same call the sibling
+  // normaliser makes, and it keeps the fail-safe direction.
+  if (Array.isArray(raw)) {
+    if (raw.length !== 1) return "";
+    raw = raw[0];
   }
-  // Already symbolic — the form the enum is written in.
-  if (stripped.startsWith("ems__")) return stripped;
 
-  // Bare UID (or basename): ask the vault what that asset calls itself.
-  const fm = vault.resolveLinkpathFrontmatter(stripped);
-  const label = fm?.exo__Asset_label;
-  return typeof label === "string" && label.trim() ? label.trim() : stripped;
+  const inside = String(raw)
+    .trim()
+    .replace(/^["']/, "")
+    .replace(/["']$/, "")
+    .replace(/^\[\[/, "")
+    .replace(/\]\]$/, "")
+    .replace(/\.md$/, "")
+    .trim();
+  if (inside === "") return "";
+
+  if (SYMBOLIC_STATUS_RE.test(inside)) return inside;
+
+  const pipe = inside.indexOf("|");
+  const target = pipe === -1 ? inside : inside.slice(0, pipe).trim();
+  if (pipe !== -1) {
+    const alias = inside.slice(pipe + 1).trim();
+    if (SYMBOLIC_STATUS_RE.test(alias)) return alias;
+    // Otherwise the alias is just display text — fall through and resolve `target`.
+  }
+
+  // `ems__EffortStatusDone <uuid>` — the class-name+UUID shape PropertySchemas documents as
+  // occurring after certain status transitions.
+  const spaceForm = target.replace(TRAILING_UUID_RE, "").trim();
+  if (SYMBOLIC_STATUS_RE.test(spaceForm)) return spaceForm;
+
+  const fm = vault.resolveLinkpathFrontmatter(target);
+  let label = fm?.exo__Asset_label;
+  if (Array.isArray(label)) label = label[0];
+  return typeof label === "string" && label.trim() ? label.trim() : target;
 }
 
 /**

--- a/packages/core/src/domain/display-name/hostFunctions.ts
+++ b/packages/core/src/domain/display-name/hostFunctions.ts
@@ -72,10 +72,14 @@ export function isEffortBlocked(
 }
 
 /**
- * The exact shape of a symbolic status label. Deliberately the SAME regex the two sibling
- * normalisers use (`GroundingExecutor.resolveStatusFromFrontmatter`) rather than a looser
+ * The exact shape of a symbolic status label. Deliberately the SAME regex the sibling normaliser
+ * uses (`GroundingExecutor.resolveStatusFromFrontmatter`) rather than a looser
  * `startsWith("ems__")`: the loose test short-circuits the vault lookup for forms that are not
  * labels at all, e.g. the documented `ems__EffortStatusDone <uuid>` shape.
+ *
+ * ⚠ The OTHER sibling (`getStatusLabel` in PropertySchemas) does NOT use this regex — it
+ * lowercases and looks the value up in `SYMBOLIC_STATUS_LABEL_FALLBACK` / `EFFORT_STATUS_VALUES`.
+ * Naming both here would be the same over-claim this file already made once about alias forms.
  */
 const SYMBOLIC_STATUS_RE = /^ems__EffortStatus[A-Za-z]+$/;
 const TRAILING_UUID_RE =
@@ -108,6 +112,13 @@ const TRAILING_UUID_RE =
  * (`PropertySchemas`) — and BOTH had to be hand-edited when `ToDo`/`Analysis` were deleted on
  * 2026-08-13 (both cite req `fcbde537`). A third copy would be a third proven drift point, and
  * importing either into `domain/` would invert the layering.
+ *
+ * ⛔ That is a TRADE, not a strict improvement, and the next reader should not conclude otherwise:
+ * a UID table rots when a status UID changes; this lookup rots when the status asset's
+ * `exo__Asset_label` stops being exactly the enum string. Relabel it to `"Done"` and every blocker
+ * reads as blocking — fail-safe and loud, but wrong. No test here can catch it: the ems submodule
+ * is not mounted in this repo, which is why `GroundingExecutor.status_uid_integrity.test.ts`
+ * asserts only the map's internal shape. The guarantee is the vault's, not the suite's.
  *
  * @see GroundingExecutor.resolveStatusFromFrontmatter — the same vocabulary, UID-table based
  * @see getStatusLabel in PropertySchemas — the same vocabulary again, for the property editor

--- a/packages/core/src/services/GroundingExecutor.ts
+++ b/packages/core/src/services/GroundingExecutor.ts
@@ -3203,6 +3203,14 @@ export class GroundingExecutor {
    * and resolves to the symbolic EffortStatus enum value (which is what
    * WorkflowTransition.from comparison expects).
    */
+  /**
+   * ⛤ THIRD of three readers of the same `ems__Effort_status` vocabulary. They disagree on edge
+   * shapes, so a change to the status forms has to visit all three (multi-parser-predicate-
+   * migration): this one is UID-table based and rejects a multi-element list loudly.
+   *
+   * @see resolveStatusLabel in domain/display-name/hostFunctions — vault-lookup based
+   * @see getStatusLabel in PropertySchemas (obsidian-plugin) — for the property editor
+   */
   private resolveStatusFromFrontmatter(
     fm: Record<string, unknown>,
   ): string | null {

--- a/packages/core/src/services/GroundingExecutor.ts
+++ b/packages/core/src/services/GroundingExecutor.ts
@@ -3202,8 +3202,7 @@ export class GroundingExecutor {
    * `"[[<UID>|ems__EffortStatusDoing]]"` or `"[[ems__EffortStatusDoing]]"`)
    * and resolves to the symbolic EffortStatus enum value (which is what
    * WorkflowTransition.from comparison expects).
-   */
-  /**
+   *
    * ⛤ THIRD of three readers of the same `ems__Effort_status` vocabulary. They disagree on edge
    * shapes, so a change to the status forms has to visit all three (multi-parser-predicate-
    * migration): this one is UID-table based and rejects a multi-element list loudly.

--- a/packages/obsidian-plugin/src/domain/property-editor/PropertySchemas.ts
+++ b/packages/obsidian-plugin/src/domain/property-editor/PropertySchemas.ts
@@ -237,6 +237,14 @@ const SYMBOLIC_STATUS_LABEL_FALLBACK: Record<string, string> = {
   emseffortstatustrashed: "Trashed",
 };
 
+/**
+ * ⛤ One of THREE readers of the same `ems__Effort_status` vocabulary; they disagree on edge
+ * shapes, so a change to the status forms has to visit all three (multi-parser-predicate-
+ * migration). This one is UID-table based, via FALLBACK_EFFORT_STATUS_VALUES.
+ *
+ * @see GroundingExecutor.resolveStatusFromFrontmatter (core) — also UID-table based
+ * @see resolveStatusLabel in core domain/display-name/hostFunctions — vault-lookup based
+ */
 export function getStatusLabel(statusUri: string | null | undefined): string {
   if (!statusUri || statusUri.trim() === "") return "-";
   // Strip wikilink brackets and optional `|alias` suffix.

--- a/packages/obsidian-plugin/tests/unit/domain/display-name/PrintNameRuleService.test.ts
+++ b/packages/obsidian-plugin/tests/unit/domain/display-name/PrintNameRuleService.test.ts
@@ -812,6 +812,40 @@ describe("PrintNameRuleService — host-function exo__DisplayNameSpec (v2 comput
     ).toBe("Ship the release");
   });
 
+  it("@req:d6cd2371-bdf2-460e-840e-841480273869 a BARE-UID Done status also unblocks — the form the vault actually stores", () => {
+    // ⛔ The axis this surface was missing entirely. Every other fixture here writes the status
+    // SYMBOLICALLY (`[[ems__EffortStatusDone]]`), which short-circuits before the status-form
+    // normalisation runs — so all of these tests passed identically with and WITHOUT the dual-IRI
+    // fix, on the very surface where the wrongly-flagged efforts live. Measured 2026-08-15: 49 of
+    // 49 blockers carrying a status use this bare-UID form and zero use symbolic, i.e. the shape
+    // exercised below is the ONLY one that occurs in production.
+    const DONE_UID = "7b9b3116-7c3c-438c-9618-94fe301320a6";
+    const { resolver } = blockedHostFnVault({
+      blockerStatus: `[[${DONE_UID}]]`,
+      // The status TBox must be present, exactly as it is in a real vault: the fix resolves the
+      // UID through the vault rather than against a hardcoded table, so omitting it would send
+      // the predicate down its "unknown ⇒ still blocking" fallback and hide the fix.
+      extraFiles: [
+        {
+          path: `${DONE_UID}.md`,
+          frontmatter: {
+            exo__Asset_uid: DONE_UID,
+            exo__Asset_label: "ems__EffortStatusDone",
+          },
+        },
+      ],
+    });
+
+    const notBlocked = resolver.resolve({
+      metadata: taskMeta({ blocker: `[[${BLOCKER_BASENAME}]]` }),
+      basename: "t1",
+    });
+
+    // Pre-fix this rendered "🚩 Ship the release": the bracket strip left a UID, which matched
+    // neither terminal label, so a FINISHED blocker read as active.
+    expect(notBlocked).toBe("Ship the release");
+  });
+
   it("evaluates the condition PER-RENDER — the SAME loaded spec flips 🚩 on/off as the referenced BLOCKER's status changes (cross-asset, no re-scan)", () => {
     const { resolver, setBlockerStatus } = blockedHostFnVault({
       blockerStatus: "[[ems__EffortStatusDoing]]",


### PR DESCRIPTION
Closes #4053. Extends **`@req:d6cd2371`** — conformance with what that active req already promises, not a new requirement.

## Routing note

Req `5cd9fffe` said in its Non-goals that this fix "gets its own req". ⛤ **That was wrong**, and reading `d6cd2371.covers` is what showed it: that req names `BlockerHelpers.isEffortBlocked` by hand and states it "resolves that asset, **checks ITS status**". The predicate's own docstring says the same. So the code never implemented its documented contract — the definition of a bug-fix. The inverse tell (an active req that *requires* the current behaviour and *defers* the change) does not apply: `d6cd2371` does neither.

## The defect

The comparison was always against the SYMBOLIC label, but the value is written three ways and only one survived the bracket strip:

| written as | after strip | matched? |
|---|---|---|
| `[[ems__EffortStatusDone]]` | `ems__EffortStatusDone` | ✅ |
| `[[<uid>]]` | `<uid>` | ⛔ never |
| `[[<uid>\|ems__…Done]]` | `<uid>\|ems__…Done` | ⛔ never |

**Measured across all three vaults:** of the 49 blockers carrying a status, **49 use the bare-UID form; zero use symbolic or alias.** The predicate was broken for **100 %** of real blockers — it stayed invisible only because a blocker is rarely finished.

⛔ **Correcting my own earlier number.** #4053 and an earlier commit say "8 efforts". That was measured at 14:00 today; re-running the **identical** script now gives **1**. The vault moved, not the method. The structural figure (49 of 49) is the stable one, and it is what the fix addresses.

## The fix

Normalise the status to its symbolic label before comparing. Resolved **through the vault**, not against a UID table — `EffortStatus`'s own docstring says new code should "resolve UUIDs at runtime via the TBox lookup instead", and a table would be a third copy of UIDs already living in `STATUS_UID_BY_ENUM`, one that rots silently if a status asset is renamed. The alias form needs no lookup; the symbolic form is already the answer.

**Fail-safe preserved:** an unresolvable status returns the raw value, matching neither terminal label ⇒ "unknown ⇒ still blocking" — the same direction the pre-fix code took for absent frontmatter.

⛤ Req `5cd9fffe` moved this predicate into core **verbatim, defect included**, precisely so that one fix would repair both the plugin and the CLI. That is what this is.

## Verification

- **The characterisation test written under `5cd9fffe` is FLIPPED.** Its own comment promised it would be this fix's revert-verify — and it was, so no new fixture was needed. Retagged to `@req:d6cd2371`, whose contract it now guards.
- Two new axes: fail-safe (status TBox unmounted → still blocking) and the alias form.
- ⛔ **The fixture now MOUNTS the status TBox.** Omitting it is not a neutral simplification: the lookup fails, the predicate falls back to "still blocking", and the suite reads as if the fix had not landed. It briefly did exactly that.
- **Revert-verify:** restore the raw-string comparison → exactly the 2 dual-IRI axes red (bare-UID, alias); the symbolic control and the fail-safe axis stay green. Restored 12/12.
- **Live proof** over the REAL vaults with the REAL predicate (throwaway harness, deleted before commit): 57 single-valued blocker carriers scanned, 1 with a finished blocker, **0 still reported blocked**.
- Full core 5 failed suites / 9 failed tests / 8447 passed — byte-identical to baseline. Full CLI 3 / 1 / 1851 (baseline 1849 + these 2 axes). Plugin consumers 19 suites / 330 tests.

https://claude.ai/code/session_01Xp6ceD53nG2HvWFtFWMoFX

---

## Round-1 review outcome (applied in `72a0af5f`)

Verdict was **WARNING** — 1 HIGH + 3 MEDIUM + 2 LOW. The fix was correct for every input that occurs in production and still wrong in a way the suite could not see.

| # | Finding | Resolution |
|---|---|---|
| **HIGH** | the alias branch trusted **display text**: `[[<uid>\|Done]]` is legal and says nothing about the status, so a finished blocker read as blocking — **the same bug one layer up**. It also contradicted the port's own floor ("`[[uid\|label]]` must resolve identically to `[[uid]]`") and both in-repo precedents | `resolveStatusLabel` rewritten to **mirror** `GroundingExecutor.resolveStatusFromFrontmatter` instead of inventing its own parse: an alias is honoured only when it IS a symbolic label, else the UID behind it is resolved. New axis |
| MEDIUM | `startsWith("ems__")` looser than the repo's own `/^ems__EffortStatus[A-Za-z]+$/`, swallowing the documented `[[ems__EffortStatusDone <uuid>]]` shape | same regex + trailing-UUID strip. New axis, with the status TBox deliberately **removed** to prove it needs no lookup |
| MEDIUM | ⛤ **the plugin surface had ZERO discriminating coverage** — every fixture wrote the status symbolically, so all 186 plugin display-name tests passed identically with and without the fix, on the surface where the wrongly-flagged efforts live | one bare-UID axis in `blockedHostFnVault`. Revert-verify confirms it discriminates: reverting reds exactly that one plugin test |
| MEDIUM | three parsers of `ems__Effort_status`, already disagreeing | not consolidated (the strong one is in `services/`; importing into `domain/` inverts layering) — all three now carry `@see` naming the others. Follow-up filed |
| LOW ×2 | quotes / `.md` / array-label / accidental single-element-array handling; req-record drift | all four parity gaps closed; `5cd9fffe`'s stale non-goal corrected |

### ⛔ Two of my own claims corrected, not defended

- **The fail-safe test is not a revert-verify axis.** It passes pre-fix too; only a fail-open mutant reds it. The earlier body counted it among the axes.
- **The docstring said "all three legal wikilink forms compare identically".** False for any alias that is not the symbolic label — which *was* the HIGH.

### ⛤ Two of my arguments were strengthened by review, and are now in the code

- Routing rests on `d6cd2371`'s **Gherkin** (`When … the blocker is done Then the spec does NOT participate`), not merely its `covers`. Pre-fix that failed for 100 % of real blockers ⇒ non-conformance with an Active req, not an extension of it.
- The reason to resolve through the vault is a **mechanism**, not an intuition: the UID table exists **twice** (`STATUS_UID_BY_ENUM`, `FALLBACK_EFFORT_STATUS_VALUES`) and **both had to be hand-edited on 2026-08-13** when `ToDo`/`Analysis` were deleted. A third copy would be a third proven drift point.

**Revert-verify across BOTH surfaces:** reverting to the raw-string comparison reds **5 CLI axes** (bare-UID, symbolic-alias, alias-as-text, space-form, quotes) and **1 plugin axis**; the multi-element-list axis correctly stays green (fail-safe in both versions). Restored: CLI 16/16, plugin `PrintNameRuleService` 51/51.
