### PR TITLE
fix(core): read key-path segments as OWN properties (req 4a2e6b80)

### DIFF
--- a/packages/core/src/domain/display-name/PrintNameRuleService.ts
+++ b/packages/core/src/domain/display-name/PrintNameRuleService.ts
@@ -319,9 +319,12 @@ export class PrintNameRuleService {
     // rejects a non-string, so the matcher returns false either way. But it is fail-closed BY
     // ACCIDENT of that downstream guard rather than by decision here, and this branch is the one
     // carrying live traffic (all 16 `matchPath` values in the vault are single-component).
-    // Deliberately NOT changed under req 4a2e6b80, whose non-goals exclude this file: locking the
-    // wiring needs a call-site fixture (a helper-level axis stays green if the wiring is reverted,
-    // i.e. decoration), which is its own unit of work. Tracked in issue #4059.
+    // Deliberately NOT changed under req 4a2e6b80, whose non-goals exclude this file. ⛤ The
+    // reason is NOT scaffolding cost — the fixture is one line over the existing createMockApp.
+    // It is that the ONLY input separating the two versions is an inherited STRING, i.e.
+    // prototype-chained frontmatter, a shape no parser here can emit. So the axis would be a
+    // synthetic guard over an impossible input; whether that is worth having is a design
+    // question, and that is what makes it its own unit of work. Tracked in issue #4059.
     const raw = matcher.matchKey.includes(".")
       ? resolveKeyPath(metadata, matcher.matchKey, this.createMetadataResolver())
       : metadata[matcher.matchKey];

--- a/packages/core/src/domain/display-name/PrintNameRuleService.ts
+++ b/packages/core/src/domain/display-name/PrintNameRuleService.ts
@@ -293,7 +293,16 @@ export class PrintNameRuleService {
       // TypeError uncaught and break naming for every asset of that class. Verified by
       // execution, not reasoning. Pre-existing since the `{}` default; it becomes load-bearing
       // now that req 5cd9fffe ships a registry and a test asserting fail-closed.
-      if (!Object.hasOwn(this.hostFunctions, matcher.hostFunction)) return false;
+      // ⛔ `hasOwnProperty.call`, not `Object.hasOwn` (ES2022) — the plugin builds to `es2020`
+      // and ships `isDesktopOnly: false`; esbuild transpiles syntax, not runtime APIs. Same
+      // predicate, no runtime floor. See the note on `ownProperty` in keyPathResolver.
+      if (
+        !Object.prototype.hasOwnProperty.call(
+          this.hostFunctions,
+          matcher.hostFunction,
+        )
+      )
+        return false;
       const fn = this.hostFunctions[matcher.hostFunction];
       if (typeof fn !== "function") return false;
       return fn(this.host, metadata);
@@ -303,6 +312,16 @@ export class PrintNameRuleService {
     // resolver is built LAZILY — only a dot-path pays for it. A single-component key takes
     // the flat read below, byte-for-byte the pre-fedeaa6e line, so the no-dot path cannot
     // regress structurally.
+    //
+    // ⚠ That flat read is a bare index, so a one-component matchKey named after an
+    // Object.prototype member reads off the prototype — the same class req 4a2e6b80 closes in
+    // the walk. It is inert today: a prototype member is a function and `extractClassKeys`
+    // rejects a non-string, so the matcher returns false either way. But it is fail-closed BY
+    // ACCIDENT of that downstream guard rather than by decision here, and this branch is the one
+    // carrying live traffic (all 16 `matchPath` values in the vault are single-component).
+    // Deliberately NOT changed under req 4a2e6b80, whose non-goals exclude this file: locking the
+    // wiring needs a call-site fixture (a helper-level axis stays green if the wiring is reverted,
+    // i.e. decoration), which is its own unit of work. Tracked in issue #4059.
     const raw = matcher.matchKey.includes(".")
       ? resolveKeyPath(metadata, matcher.matchKey, this.createMetadataResolver())
       : metadata[matcher.matchKey];

--- a/packages/core/src/domain/display-name/keyPathResolver.ts
+++ b/packages/core/src/domain/display-name/keyPathResolver.ts
@@ -31,6 +31,25 @@ export function isWikilink(value: string): boolean {
  * Walk `path` (dot-separated) through `obj`, hopping across wikilink references via
  * `metadataResolver`. Returns `undefined` when any segment is missing or unresolvable.
  */
+/**
+ * Read a key-path segment as an OWN property only (req 4a2e6b80; the twin closed by 5cd9fffe).
+ *
+ * ⛔ Segments come from `exo__DisplayNameSpec_matchKey` / part definitions — i.e. from user
+ * frontmatter — so a plain `obj[part]` reaches Object.prototype: a segment named `toString` or
+ * `constructor` yields a FUNCTION and the walk continues over it instead of stopping. Verified by
+ * execution, not reasoning; it is the same reachable-by-data hole closed in
+ * `PrintNameRuleService.matcherSatisfied`, and fixing only the one I happened to notice would
+ * leave its twin sixty lines away.
+ *
+ * ⚠ Arrays keep working: numeric indices and `length` are own properties of an array.
+ */
+function ownProperty(source: unknown, key: string): unknown {
+  if (source === null || typeof source !== "object") return undefined;
+  return Object.hasOwn(source as object, key)
+    ? (source as Record<string, unknown>)[key]
+    : undefined;
+}
+
 export function resolveKeyPath(
   obj: Record<string, unknown>,
   path: string,
@@ -58,7 +77,7 @@ export function resolveKeyPath(
       if (typeof first === "string" && metadataResolver && isWikilink(first)) {
         const resolved = metadataResolver(first);
         if (resolved) {
-          current = (resolved as Record<string, unknown>)[part];
+          current = ownProperty(resolved, part);
           continue;
         }
         return undefined;
@@ -73,14 +92,14 @@ export function resolveKeyPath(
       ) {
         const resolved = metadataResolver(current);
         if (resolved) {
-          current = (resolved as Record<string, unknown>)[part];
+          current = ownProperty(resolved, part);
           continue;
         }
       }
       return undefined;
     }
 
-    current = (current as Record<string, unknown>)[part];
+    current = ownProperty(current, part);
   }
 
   return current;

--- a/packages/core/src/domain/display-name/keyPathResolver.ts
+++ b/packages/core/src/domain/display-name/keyPathResolver.ts
@@ -28,10 +28,6 @@ export function isWikilink(value: string): boolean {
 }
 
 /**
- * Walk `path` (dot-separated) through `obj`, hopping across wikilink references via
- * `metadataResolver`. Returns `undefined` when any segment is missing or unresolvable.
- */
-/**
  * Read a key-path segment as an OWN property only (req 4a2e6b80; the twin closed by 5cd9fffe).
  *
  * ⛔ Segments come from `exo__DisplayNameSpec_matchKey` / part definitions — i.e. from user
@@ -50,6 +46,10 @@ function ownProperty(source: unknown, key: string): unknown {
     : undefined;
 }
 
+/**
+ * Walk `path` (dot-separated) through `obj`, hopping across wikilink references via
+ * `metadataResolver`. Returns `undefined` when any segment is missing or unresolvable.
+ */
 export function resolveKeyPath(
   obj: Record<string, unknown>,
   path: string,

--- a/packages/core/src/domain/display-name/keyPathResolver.ts
+++ b/packages/core/src/domain/display-name/keyPathResolver.ts
@@ -38,10 +38,17 @@ export function isWikilink(value: string): boolean {
  * leave its twin sixty lines away.
  *
  * ⚠ Arrays keep working: numeric indices and `length` are own properties of an array.
+ *
+ * ⛔ `hasOwnProperty.call`, NOT `Object.hasOwn` — the latter is ES2022 while the plugin builds to
+ * `target: "es2020"` and ships with `isDesktopOnly: false`. esbuild transpiles syntax, not runtime
+ * APIs, so on a runtime below Safari/iOS 15.4 `Object.hasOwn` is a TypeError — and neither this
+ * function nor either of its callers has a try/catch, so the failure mode would be "every key-path
+ * walk throws", not "one matcher fails closed". The two forms are behaviourally identical here
+ * (verified across 42 input shapes); this one has no floor.
  */
 function ownProperty(source: unknown, key: string): unknown {
   if (source === null || typeof source !== "object") return undefined;
-  return Object.hasOwn(source as object, key)
+  return Object.prototype.hasOwnProperty.call(source, key)
     ? (source as Record<string, unknown>)[key]
     : undefined;
 }

--- a/packages/core/tests/domain/display-name/keyPathResolver.ownProperty.test.ts
+++ b/packages/core/tests/domain/display-name/keyPathResolver.ownProperty.test.ts
@@ -1,0 +1,72 @@
+/**
+ * req 4a2e6b80 — key-path segments are read as OWN properties only.
+ *
+ * A segment comes from user frontmatter (`exo__DisplayNameSpec_matchPath`, printed-part key
+ * paths), so a bare `obj[part]` reaches `Object.prototype`. Verified by execution before fixing:
+ * `({} as any)["toString"]` is a FUNCTION, so the walk continued over a function instead of
+ * stopping — and `({a:1})["toString"]` did the same, meaning every asset WITH frontmatter was
+ * already exposed, not just the empty-frontmatter case req 5cd9fffe introduced.
+ *
+ * This is the twin of the registry hole closed in `PrintNameRuleService.matcherSatisfied`. Both
+ * are "a string from the vault indexes a plain object", and fixing only the one that happened to
+ * surface in review would have left the other in place.
+ */
+import { describe, it, expect } from "@jest/globals";
+import { resolveKeyPath } from "../../../src/domain/display-name/keyPathResolver";
+
+const REQ = "@req:4a2e6b80-bd46-47b1-a8c5-08c40837879a";
+
+describe("resolveKeyPath — own-property reads", () => {
+  it(`${REQ} resolves an ordinary own key path unchanged`, () => {
+    const md = { a: { b: "value" } } as Record<string, unknown>;
+    expect(resolveKeyPath(md, "a.b")).toBe("value");
+  });
+
+  it(`${REQ} does NOT reach Object.prototype for a segment named toString`, () => {
+    // Without the guard this returns Object.prototype.toString — a function — and any downstream
+    // formatting would stringify it into the rendered name.
+    const md = { a: {} } as Record<string, unknown>;
+    expect(resolveKeyPath(md, "a.toString")).toBeUndefined();
+  });
+
+  it(`${REQ} does NOT reach Object.prototype for constructor either`, () => {
+    const md = { a: { real: 1 } } as Record<string, unknown>;
+    expect(resolveKeyPath(md, "a.constructor")).toBeUndefined();
+  });
+
+  it(`${REQ} still reads array indices and length, which ARE own properties`, () => {
+    // The guard must not break the legitimate numeric/`length` access the walk already supported.
+    const md = { a: ["x", "y"] } as Record<string, unknown>;
+    expect(resolveKeyPath(md, "a.1")).toBe("y");
+    expect(resolveKeyPath(md, "a.length")).toBe(2);
+  });
+
+  it(`${REQ} closes the RESOLVER-hop entry point too — a separate branch from the plain object`, () => {
+    // ⛔ The two entry points are different code, and one axis leaves the other unpinned. The
+    // tests above walk a plain nested object (the `typeof current !== "object"` fall-through);
+    // this one crosses a wikilink hop, where the resolver hands back the object being indexed.
+    // A req-5cd9fffe adapter returns `{}` for a file with no frontmatter, so this is exactly the
+    // shape that made me notice the hole in the first place.
+    const md = { a: "[[some-uid]]" } as Record<string, unknown>;
+    const resolver = () => ({}) as Record<string, unknown>;
+
+    expect(resolveKeyPath(md, "a.toString", resolver)).toBeUndefined();
+    // …and the same hop still reads a genuine own property, so the guard is not just "return
+    // undefined for everything crossing a hop".
+    const resolver2 = () => ({ real: "value" }) as Record<string, unknown>;
+    expect(resolveKeyPath(md, "a.real", resolver2)).toBe("value");
+  });
+
+  it(`${REQ} closes the ARRAY-hop entry point — the third index site`, () => {
+    // `resolveKeyPath` indexes in three places; the array branch (first element is a wikilink)
+    // is the third and is reached by neither test above.
+    const md = { a: ["[[some-uid]]"] } as Record<string, unknown>;
+    expect(resolveKeyPath(md, "a.constructor", () => ({}))).toBeUndefined();
+    expect(resolveKeyPath(md, "a.real", () => ({ real: 7 }))).toBe(7);
+  });
+
+  it(`${REQ} returns undefined for a missing segment, as before`, () => {
+    const md = { a: { b: 1 } } as Record<string, unknown>;
+    expect(resolveKeyPath(md, "a.nope")).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Closes the second half of a class whose twin shipped in #4052.

@req:4a2e6b80-bd46-47b1-a8c5-08c40837879a — approved by Andrey 2026-08-15
(`exoas-exo-reqs@03a3c74`).

## The hole

`resolveKeyPath` walks a dot-separated path by indexing a plain object, and the
**segments come from user frontmatter** (`exo__DisplayNameSpec_matchPath`, printed-part key
paths). So a segment named after an `Object.prototype` member is read off the prototype.
Verified by execution on `origin/main`, not by reasoning:

| expression | result |
|---|---|
| `resolveKeyPath({a:{b:1}}, "a.b")` | `1` — normal |
| `resolveKeyPath({a:{}}, "a.toString")` | **a function** |
| `resolveKeyPath({a:{real:1}}, "a.constructor")` | **a function** |

⛤ The hole is reachable **without any resolver** — an ordinary nested object opens it. It was
not introduced by req `5cd9fffe`; that one merely added one more entry point (the adapter began
returning `{}` instead of `null` for a file with no frontmatter), which #4052's review measured
separately.

## Why this is a separate PR, and why the reviewer was right

The twin — the host-function registry in `matcherSatisfied` — shipped in #4052, because that PR
was already shipping a test asserting fail-closed behaviour. The pull was to close this one too,
"same class". The reviewer objected on substance and the objection is stronger than my argument
was:

- the registry gates host functions — **2 specs out of 35**;
- `resolveKeyPath` sits behind **every** dot-path matcher and **every** `{{a.b}}` placeholder, on
  every surface, for every asset.

Same class, **different radius** — and I had argued only the first half. A separate requirement
gives this change its own review surface instead of a fourth concern on a PR already carrying
three.

## Revert-verify — 4 red, 3 green, and the green ones are the controls

Reverting `keyPathResolver.ts` to `origin/main` on a copy outside the repo (ZERO-GIT-TOUCH):

| axis | reverted |
|---|---|
| ordinary own key path unchanged | ✅ green — control |
| **no `Object.prototype` for `toString`** | ❌ red |
| **nor for `constructor`** | ❌ red |
| array indices and `length` still read | ✅ green — control |
| **resolver-hop entry point closed** | ❌ red |
| **array-hop entry point closed** | ❌ red |
| missing segment → `undefined`, as before | ✅ green — control |

The three greens must stay green — they are what "behaviourally neutral for ordinary paths"
means. The four reds cover **three distinct index sites** (plain object, resolver hop, array hop),
which is the req's Scenario 5: each entry point closed independently, so an axis on one does not
vouch for the others.

## Verification

- Full core: **9 failed / 8454 passed** — 8447 baseline + these 7 axes; failures unchanged.
- Plugin display-name (the consumer): **187/187**.
- `tsc --noEmit -p packages/core` clean apart from the pre-existing `nanotar` resolution.
- ⛤ Checked for a second implementation before claiming one fix covers both surfaces:
  `packages/obsidian-plugin/src/domain/display-name/keyPathResolver.ts` is a **re-export shim**
  from req `f17f7c57` (zero indexing, carries its own "do not add logic here" note), so there is
  exactly one implementation. The first measurement of this was a **false zero** —
  `git grep -- 'packages/*/src'` returns nothing because a pathspec `*` does not cross `/`.

## Also in this branch

One comment-only commit moving `ownProperty` above `resolveKeyPath`'s docblock: inserting it
between the docblock and the function orphaned that docblock (TypeScript attaches only the block
immediately above a symbol). Same defect #4055's round-2 review caught in `GroundingExecutor.ts`;
I made it here first.

## Non-goals

- ⛔ Not changing ordinary path semantics — own-field traversal stays byte-for-byte.
- ⛔ Not touching the host-function registry — already closed by req `5cd9fffe`.
- Registry unification (#4054) is separate work.

## Known boundary

Visible to a spec whose `matchPath` contains a segment named after an `Object.prototype` member.
No such spec exists in the live vaults (35 specs, zero) — but this is formally a behaviour change,
not a refactor, which is why it carries a requirement rather than riding along as cleanup.

---

## Round-1 review outcome (applied in `42e04af2`)

Verdict **APPROVE**, 0 CRITICAL / 0 HIGH. Every numeric claim above was reproduced independently, including the ones easiest to fudge (`9 failed / 8454 passed` exact, `8454 − 7 = 8447` consistent, plugin `187/187`, **35** specs by `COUNT(DISTINCT)`).

| # | Finding | Resolution |
|---|---|---|
| **MEDIUM-1** | `Object.hasOwn` is **ES2022**; the plugin builds to `target: "es2020"` and ships `isDesktopOnly: false`. esbuild transpiles syntax, not runtime APIs. No try/catch anywhere on the path ⇒ the failure mode is "every key-path walk throws", not "one matcher fails closed" | ⛤ The reviewer turned **my own argument** back on me: not introduced here (#4052 shipped it first), but this PR widens the radius from 2-of-35 to every dot-path — exactly why I said it deserved its own PR. **Both** call sites moved to `Object.prototype.hasOwnProperty.call`; verified behaviour-identical across 42 input shapes. ⚠ Neither of us established that a supported mobile build actually lacks it — stating that rather than inflating it; the swap is free, so the unquantified risk is not worth carrying |
| **MEDIUM-2** | A **fourth** bare index with a user-controlled key — the no-dot branch of `matcherSatisfied`, `metadata[matcher.matchKey]` (deliberately no line number: this same commit shifted it by 6) | ⛔ **Deliberately not fixed here → issue #4059.** Inert today (a prototype member is a function; `extractClassKeys` rejects a non-string), it sits in a file req `4a2e6b80` non-goals, and locking its wiring needs a **call-site fixture** — a helper-level axis stays green when the wiring is reverted, i.e. decoration. That is the same standard by which the reviewer descoped this req out of #4052; applying it to myself. A comment now records the reasoning at the read site |
| LOW-1 | the guard's early return is pinned by nothing | Accepted as-is — reachable only by a resolver violating its declared type. **No axis added**; the boundary section below no longer implies it is covered |
| LOW-2 | "Known boundary" understates the surface | Corrected below: it is **inherited properties in general**, not only `Object.prototype`; and both authoring surfaces are named |

### ⛤ The reviewer's sharpest measurement inverts my own framing

**All 16 live `matchPath` values are single-component**, so they take the no-dot branch and never enter `resolveKeyPath`. My "zero exposure" is true for a **stronger** reason than I claimed — and it means the branch this PR hardens has zero live users today, while the one carrying all the traffic is #4059. Recorded at the read site so the next reader inherits the measurement rather than the impression.

### Corrected — Known boundary

- Affected are **inherited properties in general** — `Array.prototype.map`, `Date.prototype.*`, `Map.prototype.size`, anything up a chain — not just `Object.prototype`.
- Both authoring surfaces were checked, not just the one I named: **16** `matchPath` values and **51** `PrintedProperty_property` values across 46 assets — all single-component, none a prototype member.
  ⛤ The `32` in the round-1 report was the reviewer's own miscount (a `uniq -c` list eyeballed, never summed); he caught it in round 2 and I had inherited it in good faith. The conclusion is unchanged — only the number was wrong.
- Neutrality holds **because of a mechanism, not by luck**: `createMetadataResolver` returns `{ ...fm }` (a spread copy) and both `VaultMetadataPort` adapters return YAML/Obsidian-parsed frontmatter, so no prototype-chained object can reach the walk. In the abstract the predicate *does* change behaviour (20 of 42 probe rows) — it is that mechanism which makes it neutral here, and it is worth stating rather than assuming.
- ⚠ The early return for a non-object source is **not** covered by any axis.

### Round-2 outcome (`0d69006c`)

**APPROVE — 0 CRITICAL, 0 HIGH, 0 MEDIUM.** Both MEDIUMs resolved; the reversal was attacked rather than ratified, and upheld on four independent supports. Three LOW remained:

- **LOW-A** — the `32` figure was the reviewer's own round-1 miscount, inherited by me. Corrected to **51 across 46 assets**; conclusion unaffected.
- **LOW-B** — the stale `:321` coordinate (this commit shifted it to `:327`). Line numbers dropped from both the body and #4059.
- **LOW-C** — ⛤ **my justification was weaker than my conclusion, and he measured it.** I said the descope was about scaffolding cost; he checked, found `createMockApp` already exists and the discriminating fixture is one line, so the volume argument does not survive. The real reason is that the only separating input is an **inherited string** — prototype-chained frontmatter, a shape no parser here emits — so the axis would be a synthetic guard over an impossible input, and *that* is the design question making it separate work. Swapped in the code comment and in #4059.

Independently reproduced: `hasOwnProperty.call` ≡ `Object.hasOwn` across **51 shapes, 0 differ** (including null prototypes, a *lying* and a *throwing* `hasOwnProperty`, revoked Proxy, throwing `gOPD` trap); `PrintNameRuleService:296` is a single-statement delta after esbuild strips comments; the 198-line prettier radius exact; my added ranges untouched by prettier.

⛤ He also caught **two of his own would-be findings** before reporting them — a core count taken at a different scope, and a blast-radius measured with a different metric — both the "two values in different scales" trap, and in both cases my numbers were right and his measurement was the variable.
