### PR TITLE
fix(core): the no-dot matcher branch reads own properties too (closes #4059)

### DIFF
--- a/packages/core/src/domain/display-name/PrintNameRuleService.ts
+++ b/packages/core/src/domain/display-name/PrintNameRuleService.ts
@@ -1,5 +1,9 @@
 import type { VaultMetadataPort } from "./VaultMetadataPort";
-import { resolveKeyPath, type MetadataResolver } from "./keyPathResolver";
+import {
+  ownProperty,
+  resolveKeyPath,
+  type MetadataResolver,
+} from "./keyPathResolver";
 
 /**
  * A per-render VALUE-EQUALITY condition compiled from an exo__DisplayNameSpec's
@@ -313,21 +317,20 @@ export class PrintNameRuleService {
     // the flat read below, byte-for-byte the pre-fedeaa6e line, so the no-dot path cannot
     // regress structurally.
     //
-    // ⚠ That flat read is a bare index, so a one-component matchKey named after an
-    // Object.prototype member reads off the prototype — the same class req 4a2e6b80 closes in
-    // the walk. It is inert today: a prototype member is a function and `extractClassKeys`
-    // rejects a non-string, so the matcher returns false either way. But it is fail-closed BY
-    // ACCIDENT of that downstream guard rather than by decision here, and this branch is the one
-    // carrying live traffic (all 16 `matchPath` values in the vault are single-component).
-    // Deliberately NOT changed under req 4a2e6b80, whose non-goals exclude this file. ⛤ The
-    // reason is NOT scaffolding cost — the fixture is one line over the existing createMockApp.
-    // It is that the ONLY input separating the two versions is an inherited STRING, i.e.
-    // prototype-chained frontmatter, a shape no parser here can emit. So the axis would be a
-    // synthetic guard over an impossible input; whether that is worth having is a design
-    // question, and that is what makes it its own unit of work. Tracked in issue #4059.
+    // ⛤ BOTH branches read own-only (req 4a2e6b80, closed for this one by issue #4059). A
+    // one-component matchKey is a segment too — it comes from the same `matchPath` frontmatter —
+    // so a bare index put `toString`/`constructor` on the Object.prototype path exactly as the
+    // walk did. It read fail-closed only BY ACCIDENT of a downstream guard (`extractClassKeys`
+    // rejects a non-string), not by decision here, and the two branches disagreed about the same
+    // input. ⛤ This is also the branch that carries the traffic: all 16 `matchPath` values in
+    // the vault are single-component, so the walk hardened in #4058 has no live users yet.
+    //
+    // ⛔ The discriminating input is an inherited STRING, not a prototype function — a function
+    // is rejected downstream either way. See the call-site axis in
+    // keyPathResolver.ownProperty.test.ts; a helper-level assertion cannot observe this wiring.
     const raw = matcher.matchKey.includes(".")
       ? resolveKeyPath(metadata, matcher.matchKey, this.createMetadataResolver())
-      : metadata[matcher.matchKey];
+      : ownProperty(metadata, matcher.matchKey);
     const instanceForms = this.extractClassKeys(raw);
     if (instanceForms.length === 0) return false;
     return instanceForms.some((form) => matcher.matchValues.includes(form));

--- a/packages/core/src/domain/display-name/PrintNameRuleService.ts
+++ b/packages/core/src/domain/display-name/PrintNameRuleService.ts
@@ -322,12 +322,22 @@ export class PrintNameRuleService {
     // so a bare index put `toString`/`constructor` on the Object.prototype path exactly as the
     // walk did. It read fail-closed only BY ACCIDENT of a downstream guard (`extractClassKeys`
     // rejects a non-string), not by decision here, and the two branches disagreed about the same
-    // input. ⛤ This is also the branch that carries the traffic: all 16 `matchPath` values in
-    // the vault are single-component, so the walk hardened in #4058 has no live users yet.
+    // input. ⛤ This is also the branch that carries most of the traffic: 14 of the 16 `matchPath`
+    // values in vault-my are single-component (tbank 8 of 9, exodev 14 of 16). The remaining 2 ARE
+    // dot-paths (`exo__Asset_prototype.exo__Instance_class`), so #4058's walk has live users too —
+    // do not read this branch's majority as a reason to weaken that one.
+    //
+    // ⛔ Count `matchPath` shapes from RAW FRONTMATTER, never from SPARQL: the store emits the
+    // wikilink TARGET IRI and DISCARDS the alias, while `resolveSinglePropertyKey` reads the key
+    // from `split("|").pop()` — the alias. Every dot here lives in the alias, so a SPARQL count is
+    // structurally blind to the very thing it is counting and reports "zero dot-paths". Both the
+    // author and the reviewer of #4060 hit exactly that before catching it.
     //
     // ⛔ The discriminating input is an inherited STRING, not a prototype function — a function
     // is rejected downstream either way. See the call-site axis in
-    // keyPathResolver.ownProperty.test.ts; a helper-level assertion cannot observe this wiring.
+    // matcherSatisfied.noDotOwnProperty.test.ts; the helper-level axes in
+    // keyPathResolver.ownProperty.test.ts cannot observe THIS wiring, which is the whole reason
+    // that suite exists separately.
     const raw = matcher.matchKey.includes(".")
       ? resolveKeyPath(metadata, matcher.matchKey, this.createMetadataResolver())
       : ownProperty(metadata, matcher.matchKey);

--- a/packages/core/src/domain/display-name/keyPathResolver.ts
+++ b/packages/core/src/domain/display-name/keyPathResolver.ts
@@ -45,8 +45,12 @@ export function isWikilink(value: string): boolean {
  * function nor either of its callers has a try/catch, so the failure mode would be "every key-path
  * walk throws", not "one matcher fails closed". The two forms are behaviourally identical here
  * (verified across 42 input shapes); this one has no floor.
+ *
+ * ⛤ EXPORTED for `PrintNameRuleService.matcherSatisfied`'s no-dot branch (issue #4059): a
+ * one-component matchKey is a segment too, and it must not read differently from a dotted one.
+ * Keep it exported — a second copy there is exactly what this function exists to prevent.
  */
-function ownProperty(source: unknown, key: string): unknown {
+export function ownProperty(source: unknown, key: string): unknown {
   if (source === null || typeof source !== "object") return undefined;
   return Object.prototype.hasOwnProperty.call(source, key)
     ? (source as Record<string, unknown>)[key]

--- a/packages/core/tests/domain/display-name/matcherSatisfied.noDotOwnProperty.test.ts
+++ b/packages/core/tests/domain/display-name/matcherSatisfied.noDotOwnProperty.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect } from "@jest/globals";
+import { PrintNameRuleService } from "../../../src/domain/display-name/PrintNameRuleService";
+import type { VaultMetadataPort } from "../../../src/domain/display-name/VaultMetadataPort";
+
+/**
+ * req 4a2e6b80 — conformance for the OTHER read in `matcherSatisfied` (issue #4059).
+ *
+ * The req's Job Story says "каждый сегмент читался только как СОБСТВЕННОЕ поле ассета — чтобы
+ * имя, которое видит пользователь, нельзя было получить из Object.prototype". A one-component
+ * `matchKey` is a segment too: it comes from the same `exo__DisplayNameSpec_matchPath`
+ * frontmatter. #4058 closed the dotted walk; this closes the flat read.
+ *
+ * ⛤ This is a CALL-SITE axis on purpose. Asserting `ownProperty(...)` directly — which is what
+ * the first attempt did, and why it was reverted out of #4058 — cannot observe whether THIS
+ * branch routes through it: revert line 327 to `metadata[matcher.matchKey]` and a helper-level
+ * assertion stays green. True by construction, so such a test is decoration, not coverage.
+ *
+ * ⛔ The discriminating input is an INHERITED STRING, not a prototype function. A function is
+ * rejected downstream by `extractClassKeys` (non-string → []), so `toString`/`constructor` give
+ * the same answer either way — the old code was fail-closed BY ACCIDENT of that guard rather
+ * than by decision at the read site. Only a string up the prototype chain separates the two.
+ *
+ * ⚠ Prototype-chained frontmatter is a shape the parsers cannot emit (both VaultMetadataPort
+ * adapters return YAML/Obsidian-parsed plain objects). This axis therefore locks the READ
+ * SEMANTICS, not a live scenario — stated rather than implied, per the req's Known-boundaries.
+ */
+const REQ = "@req:4a2e6b80-bd46-47b1-a8c5-08c40837879a";
+
+const SPEC_CLASS_UID = "07eab746-0874-4676-9d98-dbaad1bc6fb8"; // exo__DisplayNameSpec
+const LITERAL_CLASS_UID = "4d5437c9-788e-4a6d-9be0-4af3a84554f4"; // exo__PrintedLiteral
+const TASK_UID = "1b20a8f0-d745-4e93-91db-4531b3df120e"; // ems__Task (class)
+const STATUS_PROP_UID = "9b1a77c4-0d2e-4a11-9f3c-7e5b21d0a844"; // ems__Effort_status (property)
+const DOING_UID = "027e78f4-6e16-4b36-b8fb-5510507d5745"; // ems__EffortStatusDoing (enum)
+const SPEC_UID = "spec-nodot-ownprop";
+
+/**
+ * Production-shape vault: ONE conditional spec whose matchPath is authored the canonical way —
+ * an aliased wikilink whose alias IS the frontmatter key (`resolvePropertyKey` takes the alias
+ * verbatim). The alias here has NO dot, so the spec takes the flat read.
+ */
+function vaultWithNoDotSpec(): VaultMetadataPort {
+  const assets: Record<string, Record<string, unknown>> = {
+    [STATUS_PROP_UID]: {
+      exo__Asset_uid: STATUS_PROP_UID,
+      exo__Instance_class: ["[[9a1cf31c-9d41-4ef3-9023-584a8d087d16|exo__ObjectProperty]]"],
+      exo__Asset_label: "ems__Effort_status",
+    },
+    [DOING_UID]: {
+      exo__Asset_uid: DOING_UID,
+      exo__Instance_class: ["[[6b3e9f21-5a7c-4d88-91bf-2c0a7d5e4b03|ems__EffortStatus]]"],
+      exo__Asset_label: "ems__EffortStatusDoing",
+    },
+    [SPEC_UID]: {
+      exo__Asset_uid: SPEC_UID,
+      exo__Instance_class: [`[[${SPEC_CLASS_UID}|exo__DisplayNameSpec]]`],
+      exo__DisplayNameSpec_appliesToClass: `[[${TASK_UID}|ems__Task]]`,
+      exo__DisplayNameSpec_priority: 50,
+      // ⛤ NO dot in the alias — this is what routes the matcher to the flat read.
+      exo__DisplayNameSpec_matchPath: `[[${STATUS_PROP_UID}|ems__Effort_status]]`,
+      exo__DisplayNameSpec_matchValue: `[[${DOING_UID}]]`,
+    },
+    "part-nodot": {
+      exo__Asset_uid: "part-nodot",
+      exo__Instance_class: [`[[${LITERAL_CLASS_UID}|exo__PrintedLiteral]]`],
+      exo__DisplayNamePart_of: `[[${SPEC_UID}]]`,
+      exo__DisplayNamePart_order: 0,
+      exo__PrintedLiteral_literal: "🔄 ",
+    },
+  };
+
+  return {
+    listFrontmatter: () => Object.values(assets),
+    resolveLinkpathFrontmatter: (linkpath: string) => {
+      const target = (linkpath.split("|")[0] ?? "").replace(/\.md$/, "").trim();
+      return assets[target] ?? null;
+    },
+  };
+}
+
+function serviceUnderTest(): PrintNameRuleService {
+  const s = new PrintNameRuleService(vaultWithNoDotSpec());
+  s.initialize();
+  return s;
+}
+
+describe("PrintNameRuleService.matcherSatisfied — the no-dot branch reads own-only [req 4a2e6b80 / #4059]", () => {
+  it(`${REQ} CONTROL — an OWN matchKey still matches, so the guard is not "reject everything"`, () => {
+    // The whole axis is worthless if the conditional spec never fires at all; this proves the
+    // fixture reaches the matcher and the flat read still works for real frontmatter.
+    const own = { ems__Effort_status: `[[${DOING_UID}]]` } as Record<string, unknown>;
+    expect(serviceUnderTest().getTemplateForClass("ems__Task", own)?.template).toContain("🔄");
+  });
+
+  it(`${REQ} an INHERITED matchKey does NOT match — the discriminating input`, () => {
+    // Pre-fix `metadata[matcher.matchKey]` walked up the prototype chain and read the string,
+    // so the spec matched on a value the asset does NOT carry — a wrongly-applied displayName.
+    const inherited = Object.create({
+      ems__Effort_status: `[[${DOING_UID}]]`,
+    }) as Record<string, unknown>;
+    expect(serviceUnderTest().getTemplateForClass("ems__Task", inherited)).toBeNull();
+  });
+
+  it(`${REQ} CONTROL — a prototype FUNCTION was already fail-closed, so it does NOT discriminate`, () => {
+    // Recorded deliberately: `toString` gives the same answer before and after the fix
+    // (extractClassKeys rejects a non-string). Anyone tempted to "simplify" this suite down to
+    // a toString case would produce an axis that is green both ways.
+    const svc = new PrintNameRuleService(vaultWithNoDotSpec());
+    svc.initialize();
+    expect(svc.getTemplateForClass("ems__Task", {} as Record<string, unknown>)).toBeNull();
+  });
+});

--- a/packages/core/tests/domain/display-name/matcherSatisfied.noDotOwnProperty.test.ts
+++ b/packages/core/tests/domain/display-name/matcherSatisfied.noDotOwnProperty.test.ts
@@ -100,12 +100,20 @@ describe("PrintNameRuleService.matcherSatisfied — the no-dot branch reads own-
     expect(serviceUnderTest().getTemplateForClass("ems__Task", inherited)).toBeNull();
   });
 
-  it(`${REQ} CONTROL — a prototype FUNCTION was already fail-closed, so it does NOT discriminate`, () => {
-    // Recorded deliberately: `toString` gives the same answer before and after the fix
-    // (extractClassKeys rejects a non-string). Anyone tempted to "simplify" this suite down to
-    // a toString case would produce an axis that is green both ways.
-    const svc = new PrintNameRuleService(vaultWithNoDotSpec());
-    svc.initialize();
-    expect(svc.getTemplateForClass("ems__Task", {} as Record<string, unknown>)).toBeNull();
+  it(`${REQ} CONTROL — an inherited FUNCTION does NOT discriminate, so it could not have found this`, () => {
+    // The deliberate sibling of the axis above, and the reason that one uses a STRING. Here the
+    // prototype carries the SAME key holding a function: pre-fix the bare index walks up and reads
+    // it, post-fix `ownProperty` returns undefined — and BOTH answers are null, because
+    // `extractClassKeys` rejects a non-string downstream. So the pair isolates the cause: what
+    // discriminates is the value's STRING-ness, not the fact of inheritance.
+    //
+    // ⛔ Its first form passed `{}` while matchKey was `ems__Effort_status` — that never touched a
+    // prototype member at all (own-absent → undefined), so it locked "absent key ⇒ no match" while
+    // claiming to record the prototype-function case. Found in review of #4060; the claim was true,
+    // the test simply did not demonstrate it.
+    const inheritedFn = Object.create({
+      ems__Effort_status: () => `[[${DOING_UID}]]`,
+    }) as Record<string, unknown>;
+    expect(serviceUnderTest().getTemplateForClass("ems__Task", inheritedFn)).toBeNull();
   });
 });


### PR DESCRIPTION
Closes #4059. Extends `@req:4a2e6b80` — **conformance**, not a new requirement.

## Routing, and a correction to my own

The req's Job Story: *«каждый сегмент читался только как **СОБСТВЕННОЕ** поле ассета — чтобы имя, которое видит пользователь, нельзя было получить из `Object.prototype`»*. A one-component `matchKey` **is** a segment — it comes from the same `exo__DisplayNameSpec_matchPath` frontmatter. #4058 closed the dotted walk; this closes the flat read.

⛤ **I routed this differently yesterday and am showing the correction rather than quietly switching.** The comment #4058 merged justified the descope by *«non-goals exclude this file»* and *«a design question»*. Re-reading the req: its non-goals exclude the **registry** (closed by `5cd9fffe`) and registry unification (#4054) — **not this file**. And «design question» was about whether to write the **axis**, not about whether the behaviour is wanted; the Job Story wants it. Comment corrected in place.

## Why it matters even though it is inert

No production input separates the two versions: a prototype member is a function, `extractClassKeys` rejects a non-string, the matcher returned `false` either way. But it was fail-closed **by accident of a downstream guard** rather than by decision at the read site, and the two branches of one function disagreed about the same input.

⛤ **And this is the branch carrying most of the traffic** — `14` of the `16` `matchPath` values in vault-my (tbank `8` of `9`, exodev `14` of `16`).

⛔ **Correction, round-1 review (was: "all 16 are single-component ⇒ #4058's walk has ZERO live users").** That was false, and the *mechanism* matters more than the number: I counted via **SPARQL**, which emits the wikilink **target IRI and discards the alias** — while `resolveSinglePropertyKey` reads the key from `split("|").pop()`, i.e. **the alias**. Every dot lives in the alias, so a SPARQL count is **structurally blind to the very thing it counts** and can only ever report zero dot-paths. Re-measured from **raw frontmatter**, independently of the reviewer (who hit the same trap first): the remaining 2 specs are `exo__Asset_prototype.exo__Instance_class` — so **#4058's walk does have live users**, and the false clause was an argument for weakening it later. The counting rule now lives at the read site, because the trap catches whoever measures next.

## The axis is a CALL-SITE axis, deliberately

The first attempt — reverted out of #4058 — asserted `ownProperty(...)` directly. That **cannot** observe whether this branch routes through it: revert the wiring and such a test stays green, true by construction. It was decoration, and shipping it would have been worse than shipping nothing.

This one drives `PrintNameRuleService.getTemplateForClass` over a fake `VaultMetadataPort` with a conditional spec whose `matchPath` has no dot. **Revert-verify: putting the bare index back reds EXACTLY ONE axis, and both controls stay green.**

| axis | wiring reverted |
|---|---|
| CONTROL — an **own** `matchKey` still matches | ✅ green (guard is not "reject everything") |
| **an INHERITED `matchKey` does NOT match** | ❌ **red** — the discriminating input |
| CONTROL — an **inherited function** does not discriminate | ✅ green (same answer both ways) |

The third case is recorded on purpose, and the pair isolates the cause: axis 2 (inherited **string**) discriminates, axis 3 (inherited **function**) does not — so what separates the two builds is the value's **string-ness**, not the fact of inheritance.

⛔ **Corrected in round-1 review.** Its first form passed `{}` while `matchKey` was `ems__Effort_status` — that never touches a prototype member at all (own-absent → `undefined`), so it locked "absent key ⇒ no match" while *claiming* to record the prototype-function case. The claim was true; the test simply did not demonstrate it. Now built with `Object.create({ ems__Effort_status: fn })`, re-verified green in both builds.

⚠ Prototype-chained frontmatter is a shape the parsers cannot emit (both `VaultMetadataPort` adapters return YAML/Obsidian-parsed plain objects). This axis therefore locks the **read semantics**, not a live scenario — stated, not implied.

## Verification

- core **9 failed / 8480 passed**; the 3 failing suites are unrelated (`PrototypePrecondition*`, `grounding-type-vault-fixture-parity`).
- plugin display-name **187/187**; the 7 `keyPathResolver` axes from #4058 stay **7/7**.
- `tsc` clean; archgate 24/24 on pre-commit. `eslint` clean **on the changed files** — repo-wide `npm run lint` exits 1 on one pre-existing error in an untouched plugin file (`ObsidianVaultMetadataAdapter.ts:49`, `obsidianmd/no-tfile-tfolder-cast`); CI's lint job runs with `continue-on-error: true`, so it is non-gating and not caused by this PR. (Scope corrected in round-1 review — "eslint clean" was not reproducible repo-wide.)

⛔ **Measurement note worth more than the number.** This worktree got a clean `npm install`, and **two** suites that failed to RUN in my earlier worktrees (`AssetSpaceMount`, `AssetSpaceMount.materializeProgress`) now pass — **23** of the `+26` in the total (the other **3** are this PR's own axes; corrected in round-1 review, the arithmetic closes: `8454 + 3 + 23 = 8480`). A **copied `node_modules`** had been suppressing them, and a suite that does not run contributes **0** tests, so "9 failed" looked identical while coverage was silently smaller. My earlier "= baseline exactly" claims in #4055/#4058 were comparing two equally-degraded runs: the delta was valid, the absolute was understated.

## Non-goals

- ⛔ Not changing the dotted walk — closed by #4058, untouched here.
- ⛔ Not touching the host-function registry (`5cd9fffe`) nor registry unification (#4054).


---

## Round-1 review (0 CRITICAL / 1 HIGH / 2 MEDIUM / 3 LOW — verdict WARNING)

The code was found correct, minimal and reproducible: the revert-verify was re-run independently and flips **exactly** the one axis; every published gate number reproduced, including archgate 24/24 and the identical 3 unrelated failing suites. **All findings were claim-level**, and all are applied above in place (marked ⛔ **Correction**) rather than silently rewritten.

| # | applied |
|---|---|
| **HIGH** — false `matchPath` measurement | corrected in body **and** at the read site, with the SPARQL-blindness mechanism recorded |
| **MEDIUM-1** — CONTROL-3 did not exercise its documented case | fixture reworked to `Object.create({ … : fn })`; re-verified green both ways |
| **MEDIUM-2** — a **fifth** unguarded read | ⛔ deliberately **not** here → **#4061**: `DisplayNameResolver.classTemplates`, which **throws** rather than failing closed. Different trigger field, different failure mode, own req. Mechanism re-verified independently before filing. |
| **LOW-1** — comment pointed at the counter-example suite | fixed |
| **LOW-2** — "eslint clean" not reproducible repo-wide | scoped |
| **LOW-3** — `+26` misattributed by 3 | corrected (`23` recovered + `3` own axes) |

### On the `@req` binding (reviewer's Q1 — raised, not filed as a finding)

The reviewer notes the req's `covers` and all 5 Scenarios name `resolveKeyPath`, which the flat branch never enters, so tagging these axes `@req:4a2e6b80` overstates that req's executable spec. **Agreed, and closed by adding Scenario 6 to the req** rather than by minting a sibling.

⛤ Why an amendment and not a sibling: the "different radius ⇒ its own req" argument that split the **registry** out (#4052 → #4054) turns on the registry being a *different object* — the `hostFunctions` map, not asset metadata. The flat read is the **same object** (asset metadata), reached by the **same function** (`matcherSatisfied`), from the **same frontmatter field** (`matchPath`) — differing only in that the path has one component. That is the req's own Job Story ("каждый сегмент … только как СОБСТВЕННОЕ поле") under-specified by its Gherkin, not a binding reaching beyond its req.
