### PR TITLE
fix(core): strip the ALIAS off ems__Effort_blocker before the port sees it

### DIFF
--- a/packages/core/src/domain/display-name/hostFunctions.ts
+++ b/packages/core/src/domain/display-name/hostFunctions.ts
@@ -39,6 +39,19 @@ const DAY_KEY_RE = /^\d{4}-\d{2}-\d{2}$/;
  * incidence (49 of 58 blockers, 8 efforts with a wrong 🚩) and for why the lookup goes through the
  * vault rather than a UID table.
  *
+ * ⛤ The ALIAS defect is fixed here too (issue #4057, same req-d6cd2371 conformance): the blocker
+ * link is now unwrapped AND alias-stripped before the port sees it. It is inert today — measured
+ * 2026-08-16, **0 of 74** live blockers carry an alias — but the reason to fix it is not the count,
+ * it is that the surfaces DISAGREED: the CLI adapter strips the alias itself
+ * (`FileSystemVaultAdapter.getFirstLinkpathDest` → `linkpath.split("|")[0]`) while Obsidian's
+ * `metadataCache.getFirstLinkpathDest` does not, so `[[<uid>|label]]` resolved on one surface and
+ * failed open on the other. That divergence is precisely what `FsVaultMetadataAdapter`'s docstring
+ * promises cannot happen, and one implementation in core is what makes the promise keepable.
+ *
+ * ⛔ Count that incidence from RAW FRONTMATTER, never from SPARQL: the store emits the wikilink
+ * TARGET and DISCARDS the alias, so a SPARQL count of "how many blockers are aliased" is
+ * structurally blind and answers zero regardless of the data.
+ *
  * ⛔ Still verbatim, and still deferred: a multi-valued `ems__Effort_blocker` (16 of the 74
  * measured) is flattened by `String(...)` into a comma-joined string that resolves to nothing, so
  * the predicate answers "not blocked". Characterised by test; its own fix, its own req.
@@ -57,7 +70,11 @@ export function isEffortBlocked(
     return false;
   }
 
-  const blockerPath = String(effortBlocker).replace(/^\[\[|\]\]$/g, "");
+  // ⛔ The ALIAS must come off before the port sees it. This is the port's own documented input
+  // contract ({@link VaultMetadataPort.resolveLinkpathFrontmatter}: the engine hands over an
+  // "unwrapped, alias-stripped target"), and the predicate was the one caller breaking it —
+  // it stripped brackets only, so `[[<uid>|label]]` reached the adapter as `<uid>|label`.
+  const blockerPath = unwrapWikilink(String(effortBlocker)).split("|")[0].trim();
   // The two Obsidian calls this replaces — getFirstLinkpathDest, then
   // getFileCache(...)?.frontmatter — are exactly what this port method does, on both adapters.
   const blockerMetadata = vault.resolveLinkpathFrontmatter(blockerPath);
@@ -69,6 +86,32 @@ export function isEffortBlocked(
   const label = resolveStatusLabel(vault, blockerMetadata.ems__Effort_status);
 
   return label !== EffortStatus.DONE && label !== EffortStatus.TRASHED;
+}
+
+/**
+ * Unwrap a frontmatter wikilink into the string the port expects: quotes off, `[[ ]]` off, a
+ * trailing `.md` off, trimmed.
+ *
+ * ⛔ Deliberately does NOT split the alias, because the two callers disagree about what an alias
+ * MEANS: for a status, `[[<uid>|ems__EffortStatusDone]]` may itself be the answer (an alias that
+ * is a symbolic label is honoured); for a blocker it is display text and nothing else. Sharing the
+ * split would have to pick one of those, so the split stays at each call site and only the
+ * unwrapping — where the two agree exactly — is shared.
+ *
+ * ⛤ Shared rather than copied on purpose: this is the third site in the display-name path that
+ * needs it (`resolveStatusLabel` here, `createMetadataResolver` in PrintNameRuleService), and a
+ * third inline copy is how the dual-IRI defect survived in the first place — each copy is only
+ * ever checked by its own caller's tests.
+ */
+function unwrapWikilink(raw: string): string {
+  return raw
+    .trim()
+    .replace(/^["']/, "")
+    .replace(/["']$/, "")
+    .replace(/^\[\[/, "")
+    .replace(/\]\]$/, "")
+    .replace(/\.md$/, "")
+    .trim();
 }
 
 /**
@@ -141,14 +184,7 @@ function resolveStatusLabel(vault: VaultMetadataPort, rawStatus: unknown): strin
     raw = raw[0];
   }
 
-  const inside = String(raw)
-    .trim()
-    .replace(/^["']/, "")
-    .replace(/["']$/, "")
-    .replace(/^\[\[/, "")
-    .replace(/\]\]$/, "")
-    .replace(/\.md$/, "")
-    .trim();
+  const inside = unwrapWikilink(String(raw));
   if (inside === "") return "";
 
   if (SYMBOLIC_STATUS_RE.test(inside)) return inside;

--- a/packages/core/src/domain/display-name/hostFunctions.ts
+++ b/packages/core/src/domain/display-name/hostFunctions.ts
@@ -52,9 +52,16 @@ const DAY_KEY_RE = /^\d{4}-\d{2}-\d{2}$/;
  * TARGET and DISCARDS the alias, so a SPARQL count of "how many blockers are aliased" is
  * structurally blind and answers zero regardless of the data.
  *
- * ⛔ Still verbatim, and still deferred: a multi-valued `ems__Effort_blocker` (16 of the 74
- * measured) is flattened by `String(...)` into a comma-joined string that resolves to nothing, so
- * the predicate answers "not blocked". Characterised by test; its own fix, its own req.
+ * ⛔ Still verbatim, and still deferred: a multi-valued `ems__Effort_blocker` is flattened by
+ * `String(...)` into a comma-joined string that resolves to nothing, so the predicate answers
+ * "not blocked". Characterised by test; its own fix, its own req.
+ *
+ * ⛔ Its incidence was recorded here as "16 of the 74" and that does NOT reproduce. Re-measured
+ * 2026-08-16 across the three canonical vaults: **2** assets of the 70 carrying the property are
+ * genuinely multi-valued (6 of the 74 values). 13 use YAML-list syntax, but 11 of those hold a
+ * single item, and a one-element list flattens harmlessly. Corrected rather than quietly dropped:
+ * the wrong number sat on the same line as a denominator that WAS verified, which is what made
+ * the whole claim read as measured.
  *
  * ⚠ ONE delta is not verbatim and is accepted deliberately: the port retries the linkpath with a
  * `.md` suffix, which the inline original did not. It can only turn a previously UNRESOLVABLE
@@ -75,6 +82,14 @@ export function isEffortBlocked(
   // "unwrapped, alias-stripped target"), and the predicate was the one caller breaking it —
   // it stripped brackets only, so `[[<uid>|label]]` reached the adapter as `<uid>|label`.
   const blockerPath = unwrapWikilink(String(effortBlocker)).split("|")[0].trim();
+  // ⛤ Both siblings guard the empty target (`resolveStatusLabel`: `if (inside === "") return ""`;
+  // `createMetadataResolver`: `if (!cleaned) return null`) and this one did not. The truthiness
+  // check above does NOT cover it: `"   "`, `"[[]]"`, `'""'`, `"[[.md]]"`, `"[[|label]]"` are all
+  // truthy and all normalise to "". Harmless today — both adapters return null for an empty
+  // linkpath — so this is consistency, not a fix, and it keeps the three callers reading alike.
+  if (!blockerPath) {
+    return false;
+  }
   // The two Obsidian calls this replaces — getFirstLinkpathDest, then
   // getFileCache(...)?.frontmatter — are exactly what this port method does, on both adapters.
   const blockerMetadata = vault.resolveLinkpathFrontmatter(blockerPath);
@@ -98,10 +113,19 @@ export function isEffortBlocked(
  * split would have to pick one of those, so the split stays at each call site and only the
  * unwrapping — where the two agree exactly — is shared.
  *
- * ⛤ Shared rather than copied on purpose: this is the third site in the display-name path that
- * needs it (`resolveStatusLabel` here, `createMetadataResolver` in PrintNameRuleService), and a
- * third inline copy is how the dual-IRI defect survived in the first place — each copy is only
- * ever checked by its own caller's tests.
+ * ⛤ Shared by the TWO callers in this file (`isEffortBlocked` and `resolveStatusLabel`) rather
+ * than copied a third time, because a third inline copy is how the dual-IRI defect survived in
+ * the first place — each copy is only ever checked by its own caller's tests.
+ *
+ * ⛔ It does NOT serve the whole display-name path, and unifying the rest is NOT a tidy-up.
+ * Seven other inline unwrap chains remain (`toDayKey` below in this file;
+ * `PrintNameRuleService` ×5; `DisplayNameResolver` ×1), and they are **deliberately** left alone:
+ * measured over 36 inputs, this helper and the `PrintNameRuleService` chain disagree on **11** —
+ * the copies strip brackets BEFORE quotes (so `[["weird"]]` → `weird` here but `"weird"` there),
+ * this one also accepts `'`, and this one strips a trailing `.md` (`[[Note.md]]` → `Note` vs
+ * `Note.md`). Replacing them with this helper would silently change matcher identity, key-path
+ * resolution and the printed-property label hop. That is a behaviour change and needs its own req
+ * — see #4056 for the sibling consolidation question.
  */
 function unwrapWikilink(raw: string): string {
   return raw

--- a/packages/obsidian-plugin/tests/unit/domain/display-name/PrintNameRuleService.test.ts
+++ b/packages/obsidian-plugin/tests/unit/domain/display-name/PrintNameRuleService.test.ts
@@ -846,6 +846,59 @@ describe("PrintNameRuleService — host-function exo__DisplayNameSpec (v2 comput
     expect(notBlocked).toBe("Ship the release");
   });
 
+  it("@req:d6cd2371-bdf2-460e-840e-841480273869 an ALIASED blocker link still blocks — the link form must not decide the answer (issue #4057)", () => {
+    // ⛤ The discriminating axis. Pre-fix `isEffortBlocked` stripped BRACKETS only, so
+    // `[[<basename>|display text]]` reached the port as `<basename>|display text`, which resolves
+    // to nothing → "no such blocker" → fail-OPEN (no 🚩) on a genuinely blocked task.
+    //
+    // ⛔ This fixture is faithful precisely because `getFirstLinkpathDest` above does NOT strip the
+    // alias — that mirrors Obsidian. The CLI adapter DOES strip it
+    // (`FileSystemVaultAdapter.getFirstLinkpathDest` → `linkpath.split("|")[0]`), which is why the
+    // defect was surface-ASYMMETRIC: the same vault rendered 🚩 through the CLI naming oracle and
+    // not in the plugin. A fake that stripped the alias would be green both ways — decoration.
+    //
+    // ⚠ Inert as of 2026-08-16: 0 of 74 live blockers carry an alias (counted from RAW frontmatter,
+    // since SPARQL discards the alias and is structurally blind to this question). The reason to
+    // close it is the divergence, not the incidence — stated rather than implied.
+    const { resolver } = blockedHostFnVault({ blockerStatus: "[[ems__EffortStatusDoing]]" });
+
+    expect(
+      resolver.resolve({
+        metadata: taskMeta({ blocker: `[[${BLOCKER_BASENAME}|Some display text]]` }),
+        basename: "t1",
+      }),
+    ).toBe("🚩 Ship the release");
+  });
+
+  it("@req:d6cd2371-bdf2-460e-840e-841480273869 CONTROL — an ALIASED blocker that is DONE still unblocks, so the fix is not 'always blocked'", () => {
+    // Same aliased form, terminal blocker. Green both ways — pre-fix because the link did not
+    // resolve, post-fix because it resolves and reads Done. Recorded so that a future "simplify"
+    // cannot reduce the pair to this case, which discriminates nothing on its own.
+    const { resolver } = blockedHostFnVault({ blockerStatus: "[[ems__EffortStatusDone]]" });
+
+    expect(
+      resolver.resolve({
+        metadata: taskMeta({ blocker: `[[${BLOCKER_BASENAME}|Some display text]]` }),
+        basename: "t1",
+      }),
+    ).toBe("Ship the release");
+  });
+
+  it("@req:d6cd2371-bdf2-460e-840e-841480273869 CONTROL — an aliased link to a NON-EXISTENT blocker stays fail-safe (no 🚩)", () => {
+    // The asymmetry documented on `resolveStatusLabel` must survive the fix: an unresolvable
+    // BLOCKER yields "not blocked" (a blocker that does not exist cannot block), whereas an
+    // unresolvable STATUS yields "still blocking". Stripping the alias must not turn the first
+    // into the second by accident.
+    const { resolver } = blockedHostFnVault({ blockerStatus: "[[ems__EffortStatusDoing]]" });
+
+    expect(
+      resolver.resolve({
+        metadata: taskMeta({ blocker: "[[no-such-asset|Some display text]]" }),
+        basename: "t1",
+      }),
+    ).toBe("Ship the release");
+  });
+
   it("evaluates the condition PER-RENDER — the SAME loaded spec flips 🚩 on/off as the referenced BLOCKER's status changes (cross-asset, no re-scan)", () => {
     const { resolver, setBlockerStatus } = blockedHostFnVault({
       blockerStatus: "[[ems__EffortStatusDoing]]",


### PR DESCRIPTION
Closes #4057. Extends `@req:d6cd2371` — **conformance**, not a new requirement (same routing as #4055's dual-IRI fix in this same predicate).

## The defect

`isEffortBlocked` stripped **brackets only**, so `[[<uid>|display text]]` reached `VaultMetadataPort` as `<uid>|display text`. That is not a link target → the port returns `null` → the predicate answers **"not blocked"**. Fail-**open**, which is the wrong direction for a blocked marker.

## Why it matters, and it is NOT the incidence

⚠ **Inert today: 0 of 74** live blockers carry an alias (measured 2026-08-16). The reason to close it is that the two **surfaces disagreed**:

| surface | `getFirstLinkpathDest` | result for `[[<uid>\|label]]` |
|---|---|---|
| CLI (`FileSystemVaultAdapter`) | strips the alias itself (`linkpath.split("\|")[0]`) | resolves → correct answer |
| Plugin (Obsidian `metadataCache`) | does **not** | null → fail-open, no 🚩 |

The same vault rendered the flag through the CLI naming oracle and not in the plugin — which is exactly what `FsVaultMetadataAdapter`'s own docstring promises **cannot** happen. One implementation in core is what makes that promise keepable; this restores it.

⛔ **Count that incidence from RAW FRONTMATTER, never SPARQL.** The store emits the wikilink **target** and **discards the alias**, so a SPARQL count of "how many blockers are aliased" is structurally blind and answers zero regardless of the data. The same trap produced a false claim in #4060 (corrected there); the rule now lives at the read site.

## The unwrap is extracted, not copied

It was already inline in `resolveStatusLabel` a hundred lines below. A third inline copy is how the dual-IRI defect survived in the first place — each copy is only ever checked by its own caller's tests.

⛤ The alias **split** deliberately stays at the call sites: for a status, `[[<uid>|ems__EffortStatusDone]]` may itself **be** the answer; for a blocker it is display text and nothing else. Sharing the split would have to pick one of those.

## Axes — plugin-side on purpose

The fixture's `getFirstLinkpathDest` does **not** strip the alias, mirroring Obsidian. A fake that stripped it would be **green both ways**, i.e. decoration.

| axis | wiring reverted |
|---|---|
| **ALIASED blocker, non-terminal status → blocked** | ❌ **red** — the discriminator |
| CONTROL — ALIASED blocker, **Done** → not blocked | ✅ green (fix is not "always blocked") |
| CONTROL — ALIASED link to a **non-existent** asset → not blocked | ✅ green (fail-safe direction preserved) |

**Revert-verify** on an out-of-repo copy (worktree never mutated): restoring the bracket-only strip reds **exactly** the discriminator, with the symptom it names — `"Ship the release"` where `"🚩 Ship the release"` was expected.

⛤ That run first reported `Tests: 0 total` — the suite **failed to run** (the scratch copy could not resolve `tslib`). Recorded because a suite that does not run contributes **0**, so "nothing failed" and "the axis passed" look identical; the same class as the `node_modules` note in #4060.

## Verification

- core **9 failed / 8480 passed** — the 3 failing suites are the same unrelated `PrototypePrecondition*` / `grounding-type-vault-fixture-parity` as on `main`; the count is unchanged, since these axes are plugin-side.
- plugin display-name **190/190** (187 + these 3).
- CLI `resolve-display-name.hostFunctions` integration **16/16** — this is what covers the `resolveStatusLabel` refactor.
- `tsc` clean; archgate 24/24 on pre-commit.

## Non-goals

- ⛔ Not fixing the multi-valued `ems__Effort_blocker` flattening (16 of 74) — still deferred, characterised by test, its own req.
- ⛔ Not unifying the three status parsers — that is #4056.
- ⛔ Not touching `DisplayNameResolver.classTemplates` — that is #4061 (it **throws** rather than failing open; different trigger field, own req).


---

## Round-1 review (0 CRITICAL / 0 HIGH / 2 MEDIUM / 3 LOW — verdict APPROVE)

Everything was checked **by execution**, not reading: a 43-input differential probe of the `resolveStatusLabel` refactor (**0 divergences**), five mutants on an out-of-repo copy, an independent raw-frontmatter vault walk with a **live canary** (4288 aliased wikilinks found among 50 208 scanned — so the zero is a real zero), and all four published numbers re-run.

⛤ **The mutant matrix says more than my single revert-verify did.** `M1` (exact pre-fix line) and `M2` (keep the unwrap, drop **only** `.split("|")[0]`) each red **exactly one** test — the discriminator. `M2` is the sharper one: it isolates the alias split specifically, not the wider unwrap. `M4` (`!blockerMetadata → true`) reds **only** the non-existent-blocker control, in all 11 display-name suites — so that control is uniquely load-bearing, which I had guessed but not shown.

| # | applied |
|---|---|
| **MEDIUM-1** — the axes were tagged to a req whose spec never described a link form | req `d6cd2371` gained a **"the LINK FORM of the blocker does not decide the answer"** scenario, citing `fedeaa6e` Scenario 3 as the in-corpus precedent. Pushed and verified on the reqs remote. |
| **MEDIUM-2** — my docstring **undercounted** the copies and **invited an unsafe consolidation** | corrected in place — see below |
| **LOW-1** — the diff widens beyond the alias | stated below |
| **LOW-2** — "16 of the 74" does not reproduce | re-measured: **2** assets of 70, **6** of 74 values |
| **LOW-3** — missing empty-target guard both siblings have | added |

### MEDIUM-2 was the one worth catching

I wrote that the helper was "the third site that needs it", naming `createMetadataResolver` beside it. Both halves were wrong, and the second was **actively dangerous**: measured over 36 inputs, this helper and that chain **disagree on 11** — the copies strip brackets *before* quotes (`[["weird"]]` → `weird` here, `"weird"` there), this one also accepts `'`, and this one strips a trailing `.md`. A reader who accepted my premise and unified them would have shipped a silent behaviour change across matcher identity, key-path resolution and the printed-property label hop. Seven inline chains remain; the helper serves **2 of 9** sites, and the docstring now says so and says why the rest are deliberately left alone.

### LOW-1 — the change is wider than "alias", and that is deliberate

The call site now uses the shared unwrap, so surrounding quotes, a trailing `.md` and outer whitespace are handled too — **26** behaviour changes over the 43 probed inputs. All move in the **fail-safe** direction (previously-unresolvable → resolvable → the conservative "blocked"), and all are parity with `resolveStatusLabel`, which is the point of one implementation. Live impact **zero**: all 74 values are clean `"[[uid]]"`.

### ⛤ Blast radius is larger than this PR claimed

`BlockerHelpers` is a thin wrapper over core, so the fix also reaches **`DailyTasksRenderer:252`, `RelationsRenderer:422/653`, `AssetMetadataService:129`, `ExocortexAPI:200`** — the renderer-side 🚩 residual that `d6cd2371` deliberately retained pending prefix composition. Not a scope change (one call site, one behaviour), but the original body understated who benefits.

### ⛤ The harness trap fired on the reviewer too — with a different root cause

My own revert-verify first reported `Tests: 0 total` (`tslib` unresolvable from the out-of-repo copy). The reviewer's control run reported `Tests: 5 passed` — ten suites failing to run for an **unrelated** reason: `packages/core/node_modules/uuid` is **v11 (CJS)** while the root hoists **v13 (pure ESM)**, so excluding `node_modules` from the copy silently promoted the ESM build. Two different causes, one identical symptom — a green-looking count that is really "the suite never ran". Recorded because the control run is the only thing that catches it: **a mutant result is meaningless until the unmutated copy reproduces the baseline.**
