### PR TITLE
fix(core): read classTemplates as an OWN property so a prototype-named class label cannot throw

### DIFF
--- a/packages/core/src/domain/display-name/DisplayNameResolver.ts
+++ b/packages/core/src/domain/display-name/DisplayNameResolver.ts
@@ -1,4 +1,5 @@
 import { DisplayNameTemplateEngine } from "./DisplayNameTemplateEngine";
+import { ownProperty } from "./keyPathResolver";
 import type { MetadataResolver } from "./DisplayNameTemplateEngine";
 import type { PrintNameRuleService, ParticipatingRule } from "./PrintNameRuleService";
 import type { DisplayNameSettings } from "./DisplayNameSettings";
@@ -168,10 +169,29 @@ export class DisplayNameResolver {
       }
     }
 
+    // ⛔ OWN property only, and a string (req 1da8e1bf). `firstClass` comes from the asset's
+    // `exo__Instance_class` via `cleanClassValue`, which returns the ALIAS after "|" — so the key
+    // is fully user-authored. `classTemplates` is a plain object literal ({} by default since
+    // #3838 part 3), and a bare index therefore walks up to `Object.prototype`: `toString` is
+    // TRUTHY, so the old guard PASSED and returned a FUNCTION as `template`, which
+    // `DisplayNameTemplateEngine` then called `.trim()` on → uncaught TypeError.
+    //
+    // ⛤ This is the FIFTH read of the same class and the only one that THREW rather than failing
+    // closed — its four siblings (`5cd9fffe` registry, `4a2e6b80` key-path walk, #4060 flat
+    // matcher read, #4062 blocker link) are all rescued downstream by a non-string being dropped.
+    // Neither `BodyLinkPatch` nor `GraphViewPatch` wraps `resolve()` in try/catch, so an uncaught
+    // throw here breaks naming wholesale rather than spoiling one name.
+    //
+    // ⚠ The `typeof` check is NOT redundant with the own-property one: `classTemplates` is typed
+    // `Record<string, string>`, and that type is a claim about data the USER writes. An own key
+    // holding a non-string satisfies the first guard and would still reach the engine.
     const firstClass = assetClasses[0];
-    if (firstClass && this.settings.classTemplates[firstClass]) {
+    const classTemplate = firstClass
+      ? ownProperty(this.settings.classTemplates, firstClass)
+      : undefined;
+    if (typeof classTemplate === "string" && classTemplate) {
       return {
-        template: this.settings.classTemplates[firstClass],
+        template: classTemplate,
         provenance: "classTemplate",
       };
     }

--- a/packages/core/src/domain/display-name/DisplayNameResolver.ts
+++ b/packages/core/src/domain/display-name/DisplayNameResolver.ts
@@ -434,12 +434,30 @@ export class DisplayNameResolver {
     return trimmed || null;
   }
 
+  /**
+   * ⛤ Same predicate as the render path above, deliberately. `Object.keys` is already own-only, so
+   * these were never exposed to the prototype hazard — but tightening `:192` to "a NON-EMPTY STRING
+   * applies" made a counting-by-`Object.keys` answer drift from it: an own key holding `""` or a
+   * non-string used to make `hasClassTemplates()` true while nothing would actually render. Closing
+   * the drift the change itself introduced, rather than leaving the two to disagree.
+   *
+   * ⚠ Both currently have ZERO consumers in this repo (verified across core / obsidian-plugin /
+   * cli src and tests). Left in place rather than deleted: removing a published method is an API
+   * change and does not belong in a bug-fix PR.
+   */
+  private configuredClassEntries(): Array<[string, string]> {
+    return Object.entries(this.settings.classTemplates).filter(
+      (entry): entry is [string, string] =>
+        typeof entry[1] === "string" && entry[1].length > 0,
+    );
+  }
+
   getConfiguredClasses(): string[] {
-    return Object.keys(this.settings.classTemplates);
+    return this.configuredClassEntries().map(([key]) => key);
   }
 
   hasClassTemplates(): boolean {
-    return Object.keys(this.settings.classTemplates).length > 0;
+    return this.configuredClassEntries().length > 0;
   }
 }
 

--- a/packages/core/tests/domain/display-name/classTemplatesOwnProperty.test.ts
+++ b/packages/core/tests/domain/display-name/classTemplatesOwnProperty.test.ts
@@ -94,4 +94,33 @@ describe("DisplayNameResolver — classTemplates is read own-only [req 1da8e1bf 
 
     expect(resolver.resolve(assetWithClassAlias("ems__Task"))).toBe("Ship the release");
   });
+
+  it(`${REQ} an OWN entry holding an EMPTY STRING falls through to the default, name AND provenance`, () => {
+    // ⛤ Locks the `&& classTemplate` sub-clause, which review showed was carrying real behaviour
+    // while no axis observed it: dropping only that clause reds NOTHING, yet an empty per-class
+    // template then reaches the engine and `displayName` becomes **null** — the name vanishes
+    // entirely — while provenance wrongly reports "classTemplate" to the CLI naming oracle.
+    //
+    // ⛔ Assert the PAIR, not just the name: provenance is the half that would still be wrong if
+    // someone "simplified" this to `typeof classTemplate === "string"` and the engine happened to
+    // fall back on its own.
+    const resolver = new DisplayNameResolver(settingsWith({ ems__Task: "" }));
+
+    expect(resolver.resolveWithProvenance(assetWithClassAlias("ems__Task"))).toEqual({
+      displayName: "Ship the release",
+      provenance: "default",
+    });
+  });
+
+  it(`${REQ} the CONFIGURED-CLASS counters agree with what actually renders`, () => {
+    // Tightening the render path to "a NON-EMPTY STRING applies" would otherwise leave
+    // `hasClassTemplates()` counting by `Object.keys` — true while nothing renders. Same predicate
+    // both places, so the two cannot drift.
+    const resolver = new DisplayNameResolver(
+      settingsWith({ ems__Task: "", ems__Project: { not: "a string" } }),
+    );
+
+    expect(resolver.hasClassTemplates()).toBe(false);
+    expect(resolver.getConfiguredClasses()).toEqual([]);
+  });
 });

--- a/packages/core/tests/domain/display-name/classTemplatesOwnProperty.test.ts
+++ b/packages/core/tests/domain/display-name/classTemplatesOwnProperty.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from "@jest/globals";
+import { DisplayNameResolver } from "../../../src/domain/display-name/DisplayNameResolver";
+import { DEFAULT_DISPLAY_NAME_SETTINGS } from "../../../src/domain/display-name/DisplayNameSettings";
+import type { DisplayNameSettings } from "../../../src/domain/display-name/DisplayNameSettings";
+
+/**
+ * req 1da8e1bf — `DisplayNameResolver.resolveRenderSpec` reads `settings.classTemplates` as an
+ * OWN property (issue #4061).
+ *
+ * ⛔ The FIFTH read of this class and the only one that THREW. Its four siblings — the
+ * host-function registry (`5cd9fffe`), the key-path walk (`4a2e6b80`), the flat matcher read
+ * (#4060) and the blocker link (#4062) — are all rescued downstream by a non-string being
+ * dropped, so their worst case is "the spec does not participate". Here the guard
+ * `if (firstClass && classTemplates[firstClass])` PASSED on `toString`, because
+ * `Function.prototype.toString` is truthy, and a FUNCTION left as `template` →
+ * `DisplayNameTemplateEngine` called `.trim()` on it → uncaught TypeError. Neither
+ * `BodyLinkPatch` nor `GraphViewPatch` wraps `resolve()`, so that breaks naming wholesale.
+ *
+ * ⛤ These drive the REAL `resolve()`, not `resolveRenderSpec` directly: the private method is
+ * where the guard lives, so asserting on it could not observe whether the public path routes
+ * through the guard — the same reason #4060's axis had to be a call-site axis.
+ *
+ * ⚠ Reachability is low (it needs a class LABEL equal to an `Object.prototype` member, and labels
+ * follow `prefix__Name`). Closed on principle, exactly as `4a2e6b80`'s own Known-boundaries say —
+ * stated rather than implied.
+ */
+const REQ = "@req:1da8e1bf-22e7-4f2b-b0ec-86dde1adf3e8";
+
+const TASK_UID = "1b20a8f0-d745-4e93-91db-4531b3df120e";
+
+function settingsWith(classTemplates: Record<string, unknown>): DisplayNameSettings {
+  return {
+    ...DEFAULT_DISPLAY_NAME_SETTINGS,
+    defaultTemplate: "{{exo__Asset_label}}",
+    classTemplates: classTemplates as Record<string, string>,
+  };
+}
+
+/** An ordinary ABox asset whose class ALIAS is `alias` — the shape `cleanClassValue` reads. */
+function assetWithClassAlias(alias: string): { metadata: Record<string, unknown>; basename: string } {
+  return {
+    metadata: {
+      exo__Instance_class: [`[[${TASK_UID}|${alias}]]`],
+      exo__Asset_label: "Ship the release",
+    },
+    basename: "t1",
+  };
+}
+
+describe("DisplayNameResolver — classTemplates is read own-only [req 1da8e1bf / #4061]", () => {
+  it(`${REQ} a class label equal to an Object.prototype member does NOT throw — the discriminating input`, () => {
+    // Pre-fix: `classTemplates["toString"]` walked the prototype chain, returned a function, the
+    // truthiness guard passed, and the engine threw `TypeError: this.template.trim is not a
+    // function`. `toThrow` is the wrong assertion to leave here — the point is the RESULT.
+    const resolver = new DisplayNameResolver(settingsWith({}));
+
+    expect(resolver.resolve(assetWithClassAlias("toString"))).toBe("Ship the release");
+  });
+
+  it(`${REQ} the same holds for every other Object.prototype member a label could collide with`, () => {
+    const resolver = new DisplayNameResolver(settingsWith({}));
+
+    for (const member of ["constructor", "valueOf", "hasOwnProperty", "toLocaleString", "isPrototypeOf"]) {
+      expect(resolver.resolve(assetWithClassAlias(member))).toBe("Ship the release");
+    }
+  });
+
+  it(`${REQ} an OWN non-string value does not reach the engine either`, () => {
+    // ⛤ NOT redundant with the own-property guard, and this axis is what proves it: the key here
+    // IS own, so `ownProperty` returns it; only the `typeof` check keeps a non-string out. The
+    // `Record<string, string>` type is a claim about data the USER writes, not a guarantee.
+    const resolver = new DisplayNameResolver(
+      settingsWith({ ems__Task: { not: "a string" } }),
+    );
+
+    expect(resolver.resolve(assetWithClassAlias("ems__Task"))).toBe("Ship the release");
+  });
+
+  it(`${REQ} CONTROL — an OWN classTemplates entry still applies byte-identically`, () => {
+    // The whole change is worthless if it also stops the feature working. Green both ways.
+    const resolver = new DisplayNameResolver(
+      settingsWith({ ems__Task: "📋 {{exo__Asset_label}}" }),
+    );
+
+    expect(resolver.resolve(assetWithClassAlias("ems__Task"))).toBe("📋 Ship the release");
+  });
+
+  it(`${REQ} CONTROL — an ordinary class with NO entry falls through to the default template`, () => {
+    // Guards the other direction: the fix must not turn "no entry" into something other than the
+    // default. Green both ways; recorded so the pair cannot be reduced to the discriminator alone.
+    const resolver = new DisplayNameResolver(
+      settingsWith({ ems__Project: "📁 {{exo__Asset_label}}" }),
+    );
+
+    expect(resolver.resolve(assetWithClassAlias("ems__Task"))).toBe("Ship the release");
+  });
+});


### PR DESCRIPTION
Closes #4061. Implements req `1da8e1bf` (Approved) — the **fifth** read of the own-property class, and the only one that **threw**.

## The defect

`DisplayNameResolver.resolveRenderSpec` indexed `settings.classTemplates` with a **fully user-authored** key: `firstClass` comes from `exo__Instance_class` via `cleanClassValue`, which returns the **alias after `|`**. `classTemplates` is a plain object literal (`{}` by default since #3838 part 3), so a bare index walked up to `Object.prototype`:

```
guard passes: true | typeof: function
downstream: TypeError: ct[k].trim is not a function
```

`Function.prototype.toString` is **truthy**, so `if (firstClass && classTemplates[firstClass])` **passed** and a **function** left as `template`; `DisplayNameTemplateEngine:63/:565` then called `.trim()` on it.

## Why this one is worse than its four siblings

| # | site | failure mode |
|---|---|---|
| `5cd9fffe` / #4052 | host-function registry | fail-closed |
| `4a2e6b80` / #4058 | key-path walk | fail-closed |
| #4060 | flat matcher read | fail-closed |
| #4062 | blocker link | fail-open |
| **this** | `classTemplates` | ⛔ **THROWS** |

The other four are rescued downstream by a non-string being dropped (`extractClassKeys` → `[]`), so their worst case is "the spec does not participate". Neither `BodyLinkPatch:389` nor `GraphViewPatch:416` wraps `resolve()` in try/catch, so an uncaught throw here breaks naming **wholesale** rather than spoiling one name.

## Own req, not an extension of `4a2e6b80`

By the same discriminator that split the registry out of #4052 — **all three** axes differ:

| axis | `4a2e6b80` | here |
|---|---|---|
| object | asset metadata | `settings.classTemplates` |
| function | `matcherSatisfied` / `resolveKeyPath` | `resolveRenderSpec` |
| field | `exo__DisplayNameSpec_matchPath` | `exo__Instance_class` |

## The `typeof` check is not redundant — M2 proves it

`Record<string, string>` is a **claim about data the user writes**, not a guarantee. An **own** key holding a non-string satisfies the own-property guard and would still reach the engine.

## Revert-verify — control first, then two mutants

⛔ On an out-of-repo copy; the worktree is never mutated. The **unmutated** copy is run first, because a mutant result is meaningless until the baseline reproduces (this is the trap that bit both me and the reviewer on #4060/#4062 — a suite that fails to RUN reports `Tests: 0`, which reads as "nothing failed").

| run | result |
|---|---|
| **CONTROL** — unmutated copy | **5/5** — harness sound |
| **M1** — bare index restored | **3 red**: both prototype-member axes **+** the non-string axis |
| **M2** — `ownProperty` kept, `typeof` dropped | ⛤ **exactly 1 red** — only the non-string axis |

Both CONTROL axes (own entry still applies; no entry → default) stay **green under both mutants**.

⛤ The axes drive the **real** `resolve()`, not the private `resolveRenderSpec` where the guard lives — asserting on the latter could not observe whether the public path routes through it, the same reason #4060's axis had to be a call-site axis.

## Verification

- core **9 failed / 8485 passed** — 8480 + these 5; the 3 failing suites are the same unrelated `PrototypePrecondition*` / `grounding-type-vault-fixture-parity` as on `main`.
- plugin display-name **190/190**; CLI `resolve-display-name.hostFunctions` **16/16** (the consumers of this resolver).
- `tsc` clean; archgate 24/24 on pre-commit.

## Known boundary, stated rather than implied

Reachability is **low** — it needs a class **label** equal to an `Object.prototype` member, and labels follow `prefix__Name`. Closed **on principle**, exactly as `4a2e6b80`'s own Known-boundaries do.

⛔ Count that incidence from **raw frontmatter**, never SPARQL: the store emits the wikilink target and **discards the alias**, while `cleanClassValue` reads the key **from** the alias — so a SPARQL count of this question is structurally blind and answers zero regardless of the data.

## Non-goals

- ⛔ Not wrapping `resolve()` in try/catch at the callers — that would hide the class, not close it.
- ⛔ Not touching the four already-closed sites.
- ⛔ Not unifying the three status parsers (#4056) nor the seven inline unwrap chains noted in #4062's review — both are behaviour changes needing their own req.


---

## Round-1 review (0 CRITICAL / 0 HIGH / 1 MEDIUM / 4 LOW — verdict APPROVE)

The M1/M2 matrix reproduced **byte-for-byte**, with CONTROL green first and after every restore, and both mutants kept type-preserving so neither red was a disguised compile failure. The import graph was walked **transitively** (6 modules, 0 cycles — `keyPathResolver` has zero imports of any kind, so a cycle back is impossible *by construction*). An 8-case old-vs-new probe found **no regression for any real input**, including the one that matters most: a user who deliberately names a class `toString` still gets their template.

| # | applied |
|---|---|
| **LOW-1** — the `&& classTemplate` clause was unguarded | **axis added** — see below |
| **LOW-2** — Gherkin/axis mismatch **both** ways | req now has **7 scenarios against 7 axes** |
| **LOW-3** — counters drifted from the render path | bound to one shared predicate (⛤ **bound, not deleted** — see below) |
| **LOW-4** — my own discriminator row was wrong | corrected in the req, shown not swapped |
| **MEDIUM** — systemic ratchet | ⛔ deliberately **not** here → **#4064** |

### LOW-1 was the one worth catching

`M3` (drop **only** `&& classTemplate`, keep `typeof`) reds **nothing** — so the clause shipped unguarded. And it is not cosmetic: an own key holding `""` then reaches the engine and

```
with sub-clause   : provenance=default       name="Ship the release"
without sub-clause: provenance=classTemplate name=null      ← the name vanishes entirely
```

The new axis asserts the **pair**, because provenance is the half a naive "simplification" would still get wrong — and it is what the CLI naming oracle reports.

### LOW-3 — bound rather than deleted, deliberately

Review verified **zero consumers** of `getConfiguredClasses`/`hasClassTemplates` across core / obsidian-plugin / cli src and tests, so deleting was the cheaper option. I bound them to the render path's predicate instead: **closing the drift this PR introduced is in scope; removing a published method is an API change and is not.**

### Mutant matrix — now one axis per guard

| run | result |
|---|---|
| **CONTROL** unmutated | **7/7** |
| **M1** bare index | 3 red (both prototype axes + non-string) |
| **M2** `typeof` dropped | 1 red (non-string) |
| **M3** `&& classTemplate` dropped | **1 red** (empty string) — was **0** before this round |
| **M4** counters → `Object.keys` | **1 red** (counters) — new guard, new axis |

### ⛤ LOW-4 — the reviewer flipped a row of *my* table with one grep

`1da8e1bf` claimed all three axes differ. The **field** row does not hold: `4a2e6b80`'s own worked example is literally `exo__Asset_prototype.exo__Instance_class`, so `exo__Instance_class` sits on **both** sides. Replaced with the distinction that does hold (*path segment* vs *settings-map key*), correction shown rather than quietly swapped. The routing verdict survives on the other two rows — and independently: on `origin/main`, `ownProperty` had exactly **two** consumer files, and `DisplayNameResolver.ts` was not one of them, so merging `4a2e6b80` demonstrably left this site untouched.

### MEDIUM → #4064, with its premise re-verified

The ratchet argument rests on `Object.hasOwn` type-checking cleanly here. I did not take that on report — measured against this repo's toolchain:

```
--lib ES2020        → error TS2550: Property 'hasOwn' does not exist on type 'ObjectConstructor'.
--lib ES2020,ES2022 → (no error)          ← packages/core/tsconfig.json's actual setting
```

With `target: ES2020` and `isDesktopOnly: false`, a "simplification" back to `Object.hasOwn` would pass build **and** CI and throw below Safari/iOS 15.4 — defended today by nothing but a comment. Filed as **#4064** with a revert-verify DoD that requires the rule to fire against the archgate **binary**, since a `check passed` count growing by one proves registration, not firing.

### Verification (re-run after these fixes)

- core **9 failed / 8487 passed** — 8485 + these 2 axes; the 3 failing suites are the same unrelated set, confirmed by the reviewer to be **identical at `origin/main`** (suites failing only at PR head: none).
- plugin display-name **190/190** with the selector pinned to `tests/unit/domain/display-name` (per review — a broader selector gives 207/207, also green).
- CLI `resolve-display-name.hostFunctions` **16/16**; `tsc` clean.
