### PR TITLE
feat(req-audit): blocking active-gate refuses an empty requirements corpus (activeTotal floor)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -357,7 +357,9 @@ jobs:
         if: always()
         # ⛔ NO continue-on-error. This is the ALWAYS-ON invariant (Andrey,
         # 2026-06-21): an `active` requirement MUST carry a verification binding,
-        # else CI is red. Vacuous while zero requirements are `active`; arms
+        # else CI is red. ⛔ "Vacuous while zero requirements are `active`" — NO
+        # LONGER TRUE: zero active requirements is now an INPUT-integrity failure
+        # (req 99e06488-2da6-48fe-bd64-30c1e20bca0f), not a vacuous pass. Arms
         # per-requirement the moment one is flipped to `active`. The bound test
         # being GREEN is enforced by the test suite itself (the bound test runs
         # in CI); THIS step enforces the binding EXISTS (anti-orphan/dangling for
@@ -386,6 +388,14 @@ jobs:
             // reqs assetspace moved elsewhere, or a failed clone turn THIS
             // blocking gate GREEN. The reason string is produced by the audit
             // (production-owned + unit-tested), printed verbatim here.
+            if (!("inputIntegrityViolation" in r)) {
+              console.error(
+                "Active-gate: the report carries no `inputIntegrityViolation` field — " +
+                  "it predates the population floor, so the floor was NOT evaluated. " +
+                  "Failing closed rather than silently reverting to the pre-floor behaviour.",
+              );
+              process.exit(1);
+            }
             if (r.inputIntegrityViolation) {
               console.error(
                 "❌ Active-gate INPUT integrity failure — " +

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -378,6 +378,26 @@ jobs:
               );
               process.exit(1);
             }
+            // Population floor FIRST (req 99e06488-2da6-48fe-bd64-30c1e20bca0f):
+            // `activeViolations` is necessarily empty when the corpus never
+            // arrived, so checking it first would print "OK" on a broken input.
+            // A requirement is detected purely by the PRESENCE of a
+            // `req__Requirement_status` predicate — so a renamed predicate, a
+            // reqs assetspace moved elsewhere, or a failed clone turn THIS
+            // blocking gate GREEN. The reason string is produced by the audit
+            // (production-owned + unit-tested), printed verbatim here.
+            if (r.inputIntegrityViolation) {
+              console.error(
+                "❌ Active-gate INPUT integrity failure — " +
+                  r.inputIntegrityViolation,
+              );
+              console.error(
+                "Fix: restore the requirements corpus (the `req__Requirement_status` " +
+                  "predicate + the `exoas-*-reqs` clones in the step above), OR — if every " +
+                  "requirement really was withdrawn — retire this gate deliberately.",
+              );
+              process.exit(1);
+            }
             const v = r.activeViolations || [];
             if (v.length > 0) {
               console.error(

--- a/packages/req-audit/src/audit.ts
+++ b/packages/req-audit/src/audit.ts
@@ -201,9 +201,10 @@ export interface FloorViolationFinding {
  * itself (the bound test runs in CI; if the behavior breaks, that test goes
  * red). Together: an active requirement whose behavior is broken turns CI red,
  * unless it is explicitly moved to `Deprecated`. This is an ALWAYS-ON hard
- * finding (independent of the soft→hard P0 ramp): it is vacuous while zero
- * requirements are `active`, and arms per-requirement the moment one is flipped
- * to `active`.
+ * finding (independent of the soft→hard P0 ramp): it arms per-requirement the
+ * moment one is flipped to `active`. ⛔ It is NO LONGER vacuous while zero
+ * requirements are `active` — zero active requirements is now an INPUT-integrity
+ * failure (req 99e06488-2da6-48fe-bd64-30c1e20bca0f), not a vacuous pass.
  */
 export interface ActiveViolationFinding {
   uid: string;
@@ -866,7 +867,9 @@ function renderText(report: TraceabilityReport, gate: GateMode = "soft"): void {
  *    `requirements-trace` CI job's `continue-on-error` (Phase-1/2); the
  *    **active-requirement invariant** is enforced by a SEPARATE blocking CI
  *    step (no `continue-on-error`) so an unbound `active` requirement blocks a
- *    merge in any phase (always-on, vacuous at zero active reqs).
+ *    merge in any phase (always-on). ⛔ NOT "vacuous at zero active reqs" any
+ *    more: zero active requirements is an INPUT-integrity failure (req
+ *    99e06488-2da6-48fe-bd64-30c1e20bca0f), not a vacuous pass.
  *  - `hard`: additionally exit 1 when the report is **not ramp-ready** (any
  *    enumerated P0 requirement unbound). This is the Phase-3 gate — at the
  *    M3-closure flip the CI job switches to `--gate hard`, drops

--- a/packages/req-audit/src/audit.ts
+++ b/packages/req-audit/src/audit.ts
@@ -288,6 +288,25 @@ export interface TraceabilityReport {
    */
   activeViolations: ActiveViolationFinding[];
   /**
+   * Population floor for the always-on active-gate: non-null iff `activeTotal`
+   * is 0, i.e. the gate has NOTHING to enforce (req `99e06488-2da6-48fe-bd64-30c1e20bca0f`).
+   *
+   * `activeViolations` alone cannot distinguish "no violations" from "the corpus
+   * never arrived": a requirement is detected purely by the PRESENCE of a
+   * `req__Requirement_status` predicate (see the `continue` in `loadRequirements`),
+   * so a renamed predicate, a reqs assetspace moved out of `exoas-*-reqs`, or a
+   * failed clone all collapse to `requirementCount = 0 → activeTotal = 0 →
+   * activeViolations = []` — the blocking gate's GREENEST possible input. The
+   * mirror of `rampReady`'s `p0Total > 0` fail-safe, which already guards the
+   * soft→hard ramp against exactly this vacuity.
+   *
+   * The string is the human-readable REASON, and it is deliberately phrased as a
+   * broken INPUT rather than an absence of findings — the blocking CI step prints
+   * it verbatim, so the wording is production-owned (and therefore testable).
+   * Purely additive: `clean` and the `--gate soft|hard` exit code are untouched.
+   */
+  inputIntegrityViolation: string | null;
+  /**
    * Enumerated P0 checklist — total P0-priority requirements (the set that arms
    * the hard-gate flip, RFC 0003 §3.7).
    */
@@ -673,6 +692,26 @@ export function auditTraceability(
     activeViolations.length === 0 &&
     danglingEvidence.length === 0;
 
+  // Population floor for the always-on active-gate (req 99e06488-2da6-48fe-bd64-30c1e20bca0f).
+  // `activeTotal === 0` makes the blocking gate vacuous, and vacuous reads as
+  // GREEN — so it must be reported as a broken INPUT, never as "no findings".
+  // Deliberately NOT folded into `clean` / the exit code: `--gate soft|hard`
+  // semantics stay byte-identical; only the blocking CI step consumes this.
+  const inputIntegrityViolation =
+    activeTotal > 0
+      ? null
+      : requirementCount === 0
+        ? "the requirements corpus is EMPTY — not one asset carries a " +
+          "`req__Requirement_status` predicate. The gate's INPUT is broken, not clean: " +
+          "a renamed status predicate, requirements moved out of the `exoas-*-reqs` " +
+          "assetspaces, or a failed clone all look exactly like this, and are " +
+          "indistinguishable from 'no violations'."
+        : `the corpus loaded ${requirementCount} requirement(s), but NOT ONE is ` +
+          "`active` — the always-on active-requirement invariant has nothing to " +
+          "enforce. The gate's INPUT is broken, not clean: either every requirement " +
+          "was deliberately withdrawn to Deprecated, or the status values stopped " +
+          "parsing (renamed enum / changed wikilink form).";
+
   // The auto-flip criterion: every enumerated P0 req bound, all P0 floors met,
   // no dangling tags. Requires p0Total > 0 so `--gate hard` fails-safe (blocks)
   // on an empty / failed-to-clone reqs set rather than passing vacuously.
@@ -702,6 +741,7 @@ export function auditTraceability(
     clean,
     activeTotal,
     activeViolations,
+    inputIntegrityViolation,
     p0Total,
     p0Bound,
     p0Orphans,
@@ -734,6 +774,12 @@ function renderText(report: TraceabilityReport, gate: GateMode = "soft"): void {
       `manual (committed evidence): ${report.uiAcceptanceManual} | ` +
       `missing evidence: ${report.uiAcceptanceMissingEvidence}`,
   );
+
+  if (report.inputIntegrityViolation !== null) {
+    console.error(
+      `\nActive-gate INPUT integrity (HARD, always blocks) — ${report.inputIntegrityViolation}`,
+    );
+  }
 
   if (report.activeViolations.length > 0) {
     console.error(

--- a/packages/req-audit/tests/integration/active-gate-input-integrity.integration.test.ts
+++ b/packages/req-audit/tests/integration/active-gate-input-integrity.integration.test.ts
@@ -104,7 +104,16 @@ function extractGateScript(): string {
   return js[1];
 }
 
-/** Run the REAL blocking gate over a report; returns its exit code + output. */
+/**
+ * Run the REAL blocking gate over a report; returns its exit code + output.
+ *
+ * Driven through `bash -e -c "node -e '<js>'"` — the SAME surface the workflow
+ * uses (`run: |` executes under `bash -e`, and the payload is single-quoted).
+ * Handing the payload to `execFile("node", ["-e", js])` instead would pass it as
+ * an argv element, i.e. through a DIFFERENT interpretation layer than production:
+ * a lone apostrophe added to any message would terminate the shell string and
+ * break CI while an argv-based test stayed green.
+ */
 function runBlockingGate(report: unknown): {
   code: number;
   stdout: string;
@@ -118,11 +127,15 @@ function runBlockingGate(report: unknown): {
     "utf-8",
   );
   try {
-    const stdout = execFileSync("node", ["-e", extractGateScript()], {
-      env: { ...process.env, RUNNER_TEMP: runnerTemp },
-      encoding: "utf-8",
-      stdio: ["ignore", "pipe", "pipe"],
-    });
+    const stdout = execFileSync(
+      "bash",
+      ["-e", "-c", `node -e '${extractGateScript()}'`],
+      {
+        env: { ...process.env, RUNNER_TEMP: runnerTemp },
+        encoding: "utf-8",
+        stdio: ["ignore", "pipe", "pipe"],
+      },
+    );
     return { code: 0, stdout, stderr: "" };
   } catch (e) {
     const err = e as { status?: number; stdout?: string; stderr?: string };
@@ -172,7 +185,26 @@ describe("active-gate input integrity — the corpus must actually arrive", () =
     expect(reason).toMatch(/INPUT is broken, not clean/);
     expect(reason).toMatch(/EMPTY/); // root #1: the corpus is empty
     expect(reason).toMatch(/req__Requirement_status/); // root #2: predicate not found
-    expect(reason).not.toMatch(/no violations found/i);
+    // Negate the COMPETING shipped wording, not a phrase nobody would write:
+    // the OK line this refusal replaces starts with "✅ Active-gate OK".
+    expect(reason).not.toMatch(/^\s*(OK|clean)\b/i);
+  });
+
+  it("@req:99e06488-2da6-48fe-bd64-30c1e20bca0f the gate payload stays single-quote-safe — an apostrophe would break the shell in production", () => {
+    // The workflow embeds this script as `node -e '<js>'` under `bash -e`, so a
+    // lone apostrophe anywhere in it (easiest to introduce via a message edit —
+    // "gate's input") terminates the string and breaks CI. Locked here because
+    // the failure is in the SHELL layer, not in any behaviour the other axes see.
+    expect(extractGateScript()).not.toContain("'");
+  });
+
+  it("@req:99e06488-2da6-48fe-bd64-30c1e20bca0f a report predating the floor fails CLOSED, not open", () => {
+    // A report with no `inputIntegrityViolation` field means the floor was never
+    // evaluated. Treating that as "no violation" would silently restore exactly
+    // the pre-floor behaviour this requirement removes.
+    const gate = runBlockingGate({ activeTotal: 0, activeViolations: [] });
+    expect(gate.code).toBe(1);
+    expect(gate.stderr).toMatch(/predates the population floor/);
   });
 
   it("@req:99e06488-2da6-48fe-bd64-30c1e20bca0f a RENAMED status predicate empties the corpus — the very failure the floor exists for", async () => {

--- a/packages/req-audit/tests/integration/active-gate-input-integrity.integration.test.ts
+++ b/packages/req-audit/tests/integration/active-gate-input-integrity.integration.test.ts
@@ -1,0 +1,253 @@
+import { describe, it, expect, beforeEach, afterEach } from "@jest/globals";
+import { execFileSync } from "child_process";
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "fs";
+import { dirname, join, resolve } from "path";
+import { tmpdir } from "os";
+import { loadRequirements, auditTraceability } from "../../src/audit.js";
+
+/**
+ * Population floor for the always-on active-gate — req
+ * `99e06488-2da6-48fe-bd64-30c1e20bca0f`.
+ *
+ * The gate's blocking step reports "✅ Active-gate OK" whenever `activeViolations`
+ * is empty — which is ALSO what a corpus that never arrived looks like, because a
+ * requirement is detected purely by the PRESENCE of a `req__Requirement_status`
+ * predicate. Measured on `origin/main` f116f447 against the real clones: an empty
+ * corpus and a corpus whose predicate was renamed in all 172 files BOTH produced
+ * `BLOCKING GATE EXIT: 0`.
+ *
+ * Two independent axes are bound here, per the revert-verify discipline:
+ *   (a) the AUDIT reports the broken input (`inputIntegrityViolation`);
+ *   (b) the real blocking step in `.github/workflows/ci.yml` ACTS on it.
+ * Axis (b) drives the workflow's own `node -e` script, extracted from the YAML —
+ * never a hand-kept copy, which would only verify itself.
+ */
+
+const REQ_CLASS_UID = "8c5af681-3413-4219-8636-0ac229d1b253";
+const UID_ACTIVE = "449f29ce-cbd5-4ac8-94d4-28aa56a013c2";
+const UID_SECOND = "830ef788-0631-42cf-8b78-481ec6cfdeac";
+
+interface ReqSpec {
+  uid: string;
+  status?: string;
+  /** Overrides the frontmatter key carrying the status (the detection predicate). */
+  statusKey?: string;
+  /** Overrides `exo__Instance_class` (the property the audit deliberately ignores). */
+  instanceClassUid?: string;
+}
+
+function writeRequirement(dir: string, spec: ReqSpec): void {
+  mkdirSync(dir, { recursive: true });
+  const statusKey = spec.statusKey ?? "req__Requirement_status";
+  const lines = [
+    "---",
+    `exo__Asset_uid: ${spec.uid}`,
+    `exo__Asset_isDefinedBy: "[[anchor]]"`,
+    "exo__Instance_class:",
+    `  - "[[${spec.instanceClassUid ?? REQ_CLASS_UID}|req__Requirement]]"`,
+    `exo__Asset_label: "req(exo): behavior ${spec.uid}"`,
+    `${statusKey}: "[[s|req__RequirementStatus${spec.status ?? "Active"}]]"`,
+    `req__Requirement_priority: "[[p|req__RequirementPriorityP1]]"`,
+    "req__Requirement_bindingClass:",
+    `  - "[[b|req__RequirementBindingClassIntegration]]"`,
+    "---",
+    "",
+    "## Statement (Gherkin)",
+    "",
+  ];
+  writeFileSync(join(dir, `${spec.uid}.md`), lines.join("\n"), "utf-8");
+}
+
+/** Walk up from cwd until the repo root (the one carrying the CI workflow). */
+function repoRoot(): string {
+  let dir = process.cwd();
+  for (let i = 0; i < 8; i++) {
+    if (existsSync(join(dir, ".github", "workflows", "ci.yml"))) return dir;
+    const parent = dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  throw new Error(
+    `could not locate .github/workflows/ci.yml walking up from ${process.cwd()}`,
+  );
+}
+
+/**
+ * Extract the `node -e '<js>'` body of the BLOCKING "Active-requirement gate"
+ * step out of the workflow. Extracting (rather than duplicating) is what makes
+ * this a test of the shipped gate: a hand-kept copy would stay green after the
+ * step is edited or deleted.
+ */
+function extractGateScript(): string {
+  const yaml = readFileSync(
+    resolve(repoRoot(), ".github", "workflows", "ci.yml"),
+    "utf-8",
+  );
+  const step =
+    /- name: Active-requirement gate[\s\S]*?\n(\s+)run: \|\n([\s\S]*?)(?=\n\s+- name: )/.exec(
+      yaml,
+    );
+  if (step === null) {
+    throw new Error(
+      "the blocking 'Active-requirement gate' step is gone from ci.yml",
+    );
+  }
+  const pad = step[1].length + 2;
+  const body = step[2]
+    .split("\n")
+    .map((line) => (line.length >= pad ? line.slice(pad) : line))
+    .join("\n");
+  const js = /node -e '([\s\S]*)'\s*$/.exec(body.trim());
+  if (js === null) {
+    throw new Error("the gate step is no longer a `node -e '...'` invocation");
+  }
+  return js[1];
+}
+
+/** Run the REAL blocking gate over a report; returns its exit code + output. */
+function runBlockingGate(report: unknown): {
+  code: number;
+  stdout: string;
+  stderr: string;
+} {
+  const runnerTemp = join(tmpdir(), `req-gate-${Date.now()}-${Math.random()}`);
+  mkdirSync(runnerTemp, { recursive: true });
+  writeFileSync(
+    join(runnerTemp, "req-report.json"),
+    JSON.stringify(report),
+    "utf-8",
+  );
+  try {
+    const stdout = execFileSync("node", ["-e", extractGateScript()], {
+      env: { ...process.env, RUNNER_TEMP: runnerTemp },
+      encoding: "utf-8",
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    return { code: 0, stdout, stderr: "" };
+  } catch (e) {
+    const err = e as { status?: number; stdout?: string; stderr?: string };
+    return {
+      code: err.status ?? -1,
+      stdout: err.stdout ?? "",
+      stderr: err.stderr ?? "",
+    };
+  } finally {
+    rmSync(runnerTemp, { recursive: true, force: true });
+  }
+}
+
+describe("active-gate input integrity — the corpus must actually arrive", () => {
+  let root: string;
+  let reqDir: string;
+
+  beforeEach(() => {
+    root = join(tmpdir(), `req-audit-integrity-${Date.now()}-${Math.random()}`);
+    reqDir = join(root, "exoas-exo-reqs", "exo-reqs");
+    mkdirSync(reqDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it("@req:99e06488-2da6-48fe-bd64-30c1e20bca0f an EMPTY corpus is a broken input, and the blocking gate refuses it", async () => {
+    // Scenario 1 — nothing on disk carries the detection predicate.
+    const report = auditTraceability(await loadRequirements(root), []);
+    expect(report.requirementCount).toBe(0);
+    expect(report.activeTotal).toBe(0);
+    expect(report.activeViolations).toHaveLength(0); // vacuous — the whole point
+    expect(report.inputIntegrityViolation).not.toBeNull();
+
+    // Axis (b): the SHIPPED blocking step must act on it.
+    const gate = runBlockingGate(report);
+    expect(gate.code).toBe(1);
+    expect(gate.stderr).toContain("INPUT integrity failure");
+    expect(gate.stdout).not.toContain("Active-gate OK");
+  });
+
+  it("@req:99e06488-2da6-48fe-bd64-30c1e20bca0f the refusal names a broken INPUT and both of its roots, never an absence of findings", async () => {
+    // Scenario 2 — wording is production-owned, so it is assertable.
+    const report = auditTraceability(await loadRequirements(root), []);
+    const reason = report.inputIntegrityViolation ?? "";
+    expect(reason).toMatch(/INPUT is broken, not clean/);
+    expect(reason).toMatch(/EMPTY/); // root #1: the corpus is empty
+    expect(reason).toMatch(/req__Requirement_status/); // root #2: predicate not found
+    expect(reason).not.toMatch(/no violations found/i);
+  });
+
+  it("@req:99e06488-2da6-48fe-bd64-30c1e20bca0f a RENAMED status predicate empties the corpus — the very failure the floor exists for", async () => {
+    // Scenario 2 (the migration hazard) — the asset is still a requirement by
+    // class, but detection keys off the PREDICATE, so the corpus reads as 0.
+    writeRequirement(reqDir, {
+      uid: UID_ACTIVE,
+      status: "Active",
+      statusKey: "flow__Requirement_state",
+    });
+    const report = auditTraceability(await loadRequirements(root), []);
+    expect(report.requirementCount).toBe(0);
+    expect(report.inputIntegrityViolation).not.toBeNull();
+    expect(runBlockingGate(report).code).toBe(1);
+  });
+
+  it("@req:99e06488-2da6-48fe-bd64-30c1e20bca0f a live corpus passes byte-identically — the gate still prints its OK line and exits 0", async () => {
+    // Scenario 3 — the no-regression control.
+    writeRequirement(reqDir, { uid: UID_ACTIVE, status: "Active" });
+    const report = auditTraceability(await loadRequirements(root), [
+      { uid: UID_ACTIVE, file: "a.test.ts", line: 1 },
+    ]);
+    expect(report.activeTotal).toBe(1);
+    expect(report.activeViolations).toHaveLength(0);
+    expect(report.inputIntegrityViolation).toBeNull();
+
+    const gate = runBlockingGate(report);
+    expect(gate.code).toBe(0);
+    expect(gate.stdout).toContain(
+      "✅ Active-gate OK — 1 active requirement(s)",
+    );
+  });
+
+  it("@req:99e06488-2da6-48fe-bd64-30c1e20bca0f changing exo__Instance_class is a no-op — the predicate stays the only detection key", async () => {
+    // Scenario 4 — the RFC's migration invariant, asserted by execution.
+    writeRequirement(reqDir, {
+      uid: UID_ACTIVE,
+      status: "Active",
+      instanceClassUid: "11111111-1111-4111-8111-111111111111", // a different class
+    });
+    const report = auditTraceability(await loadRequirements(root), [
+      { uid: UID_ACTIVE, file: "a.test.ts", line: 1 },
+    ]);
+    expect(report.requirementCount).toBe(1);
+    expect(report.activeTotal).toBe(1);
+    expect(report.inputIntegrityViolation).toBeNull();
+    expect(runBlockingGate(report).code).toBe(0);
+  });
+
+  it("@req:99e06488-2da6-48fe-bd64-30c1e20bca0f a loaded-but-nothing-active corpus is refused with its OWN reason", async () => {
+    // The second sub-case: the corpus arrived, but the gate has nothing to
+    // enforce — reported distinctly so the diagnosis is not guesswork.
+    writeRequirement(reqDir, { uid: UID_ACTIVE, status: "Proposed" });
+    writeRequirement(reqDir, { uid: UID_SECOND, status: "Deprecated" });
+    const report = auditTraceability(await loadRequirements(root), []);
+    expect(report.requirementCount).toBe(2);
+    expect(report.activeTotal).toBe(0);
+    const reason = report.inputIntegrityViolation ?? "";
+    expect(reason).toMatch(/loaded 2 requirement\(s\)/);
+    expect(reason).toMatch(/INPUT is broken, not clean/);
+    expect(runBlockingGate(report).code).toBe(1);
+  });
+
+  it("does not touch the pre-existing hard findings — an unbound active req still fails on ITS own reason", async () => {
+    // Negative control for the `clean` / exit-code Non-goal: the floor must not
+    // absorb or mask the invariant it sits next to.
+    writeRequirement(reqDir, { uid: UID_ACTIVE, status: "Active" });
+    const report = auditTraceability(await loadRequirements(root), []); // no @req tag
+    expect(report.inputIntegrityViolation).toBeNull(); // 1 active → floor satisfied
+    expect(report.activeViolations).toHaveLength(1);
+    expect(report.clean).toBe(false);
+
+    const gate = runBlockingGate(report);
+    expect(gate.code).toBe(1);
+    expect(gate.stderr).toContain("Active-requirement invariant violated");
+    expect(gate.stderr).not.toContain("INPUT integrity failure");
+  });
+});


### PR DESCRIPTION
## Problem — the mandatory gate is GREENEST when its input is gone

The always-on **`Active-requirement gate`** (`requirements-trace`, required check) refuses only when `activeViolations` is non-empty. But an asset is detected as a requirement purely by the **presence** of a `req__Requirement_status` predicate:

```ts
// packages/req-audit/src/audit.ts
if (metadata["req__Requirement_status"] === undefined) continue;
```

So a renamed status predicate, requirements moved out of `exoas-*-reqs`, or a failed clone in the step above all collapse to `requirementCount = 0 → activeTotal = 0 → activeViolations = []` — and the gate prints **"✅ Active-gate OK"** and exits 0. **161 active requirements lose enforcement silently.** The risk is inverted relative to intuition: it is not that a migration *reddens* CI, it is that it *disarms* it.

### Measured by execution on `origin/main` f116f447 (not by reasoning)

Against the real clones the CI job uses (`exoas-exo-reqs` + `exoas-ems-reqs`), running the workflow's **own** `node -e` gate script extracted from `ci.yml`:

| corpus | reqCount | activeTotal | activeViolations | blocking gate |
|---|---|---|---|---|
| unchanged | 172 | **161** | 0 | exit 0 — correct |
| empty directory | 0 | 0 | 0 | ⛔ **exit 0** — `✅ Active-gate OK — 0 active requirement(s), all bound.` |
| status predicate renamed in **172** files | 0 | 0 | 0 | ⛔ **exit 0** — identical text |

## Change

`auditTraceability` now reports **`inputIntegrityViolation`** — the population floor mirroring the `p0Total > 0` fail-safe that `rampReady` already has (and whose comment names this exact vacuity). The blocking step refuses on it **before** interpreting `activeViolations`, which is necessarily empty on a broken input.

The reason string is **production-owned**, so its wording is asserted rather than trusted: it names a broken **INPUT** and both of its roots (empty corpus / predicate not found), never an absence of findings. A second, distinct reason covers "the corpus loaded N requirements but not one is `active`".

**Purely additive** (319 insertions, 0 deletions): `clean` and the `--gate soft|hard` exit code are untouched, so `soft`/`hard` semantics are byte-identical; a live corpus keeps printing the same OK line.

### Same three scenarios, with the fix

| corpus | integrity | blocking gate |
|---|---|---|
| unchanged (172 / 161 active) | `null` | exit 0 — `✅ Active-gate OK — 161 active requirement(s), all bound.` |
| empty directory | set | **exit 1** — `❌ Active-gate INPUT integrity failure — …INPUT is broken, not clean…` |
| predicate renamed in 172 files | set | **exit 1** |

## Revert-verified — TWO independent axes

The change **adds a call** into an existing path, so one axis is not enough: the audit can report correctly while the gate ignores it. Both were neutralised type-preservingly and the suite re-run (control 0 failed / 98 passed; restore verified byte-clean via `git status --porcelain`).

| axis neutralised | RED | which |
|---|---|---|
| (a) the audit's finding (`activeTotal > 0` → `>= 0`) | **4** | empty-corpus · wording · renamed-predicate · nothing-active |
| (b) the **wiring** — `ci.yml` stops consuming it | **3** | empty-corpus · renamed-predicate · nothing-active |

The asymmetry is the proof they are independent: the **wording** test is pure-report, so it survives (b) and dies on (a); the three gate-exit tests need both halves. **Axis (b) reddening a non-empty set is what shows the gate's consumption is enforced** rather than merely written.

Axis (b) is possible because the test drives the workflow's **own** `node -e` script, extracted from `ci.yml` at run time — never a hand-kept copy, which would only verify itself. Deleting or renaming the step throws rather than silently passing.

## Non-goals (recorded in the requirement)

- Not a **ratchet** (`activeTotal < stored baseline ⇒ fail`): stricter, but it needs a number committed in the repo and bumped on every legitimate `Deprecated` flip — i.e. it introduces its own false-red + maintenance mode. The zero floor has neither: `activeTotal = 0` cannot occur legitimately while any requirement is in force (161 today).
- `activeViolations.length > 0` is unchanged, and so are `clean` / the audit exit code.
- This does **not** move requirements or rename the predicate — it is the safety net in case anyone ever does.

## Tests

`packages/req-audit/tests/integration/active-gate-input-integrity.integration.test.ts` — 7 scenarios over a real temp corpus via `loadRequirements`, incl. the RFC's migration invariant asserted by execution: **changing `exo__Instance_class` is a no-op** (the predicate is the only detection key), and a negative control proving the floor does not absorb or mask the pre-existing unbound-active-req finding.

`packages/req-audit` suite: **98 passed** (91 pre-existing + 7 new). Lint guards: shard-assignments ✅, test-antipatterns ✅ (55/55, no recurrence), coverage-monotonic ✅. `check:types`: 0 errors in changed files (3 pre-existing `nanotar` module-resolution errors are worktree `node_modules` drift — the package is genuinely absent locally, CI installs fresh).

Req: 99e06488-2da6-48fe-bd64-30c1e20bca0f

https://claude.ai/code/session_01FmtVN7YufSHQzKX52jqdva
