### PR TITLE
feat(core): W3C vocabulary prefixes emit canonical IRIs, not exocortex.my ad-hoc

### DIFF
--- a/packages/cli/src/commands/validate-schema.ts
+++ b/packages/cli/src/commands/validate-schema.ts
@@ -80,9 +80,18 @@ export const NAMESPACE_PREFIX_MAP: ReadonlyMap<string, string> = new Map([
   ["place__", "https://exocortex.my/ontology/place#"],
   ["pn__", "https://exocortex.my/ontology/pn#"],
   ["period__", "https://exocortex.my/ontology/period#"],
+  // External W3C vocabularies — canonical bases, matching core's
+  // Namespace.KNOWN_NAMESPACES (req aceaa2cc-15b6-4e1c-bf63-72c7c209de51).
+  // `xsd__`/`sh__` were absent while rdf/rdfs/owl were already canonical here;
+  // once core emits all five canonically, a missing entry means this map builds
+  // subClassOf edges under a DIFFERENT IRI than the converter emits, so
+  // isSubClassOf returns false → false `sh:class` violations (the `person__`
+  // incident documented at labelToOntologyIRI below).
   ["rdf__", "http://www.w3.org/1999/02/22-rdf-syntax-ns#"],
   ["rdfs__", "http://www.w3.org/2000/01/rdf-schema#"],
   ["owl__", "http://www.w3.org/2002/07/owl#"],
+  ["xsd__", "http://www.w3.org/2001/XMLSchema#"],
+  ["sh__", "http://www.w3.org/ns/shacl#"],
 ]);
 
 export type ShapesFormat = "text" | "json" | "earl";

--- a/packages/core/src/domain/models/rdf/Namespace.ts
+++ b/packages/core/src/domain/models/rdf/Namespace.ts
@@ -56,6 +56,8 @@ export class Namespace {
     "http://www.w3.org/2001/XMLSchema#"
   );
 
+  static readonly SHACL = new Namespace("sh", "http://www.w3.org/ns/shacl#");
+
   static readonly EXO = new Namespace("exo", "https://exocortex.my/ontology/exo#");
 
   static readonly EMS = new Namespace("ems", "https://exocortex.my/ontology/ems#");
@@ -90,6 +92,20 @@ export class Namespace {
    * the canonical {@link Namespace} singletons (so reference equality and
    * prefix display remain stable), falling back to a derived namespace for
    * any other lowercase-leading prefix.
+   *
+   * The list has two groups:
+   *
+   * 1. **Exocortex namespaces** — resolve to `EXOCORTEX_ONTOLOGY_BASE` anyway;
+   *    listed so that the canonical singleton (not a fresh equal-valued object)
+   *    is returned.
+   * 2. **External W3C vocabularies** (`rdf`, `rdfs`, `owl`, `xsd`, `sh`) — these
+   *    MUST be listed, because their canonical IRIs are NOT derivable from
+   *    `EXOCORTEX_ONTOLOGY_BASE`. Without them a vault asset labelled
+   *    `rdfs__subClassOf` would emit `https://exocortex.my/ontology/rdfs#subClassOf`,
+   *    while {@link RDFVocabularyMapper} already emits the very same term as a
+   *    PREDICATE under `http://www.w3.org/2000/01/rdf-schema#subClassOf` — so the
+   *    asset DEFINING a term and the usages OF that term would sit under two
+   *    different IRIs and never join. See req `aceaa2cc-15b6-4e1c-bf63-72c7c209de51`.
    */
   private static readonly KNOWN_NAMESPACES: ReadonlyArray<Namespace> = [
     Namespace.EXO,
@@ -101,6 +117,12 @@ export class Namespace {
     Namespace.LIT,
     Namespace.INBOX,
     Namespace.PMBOK,
+    // External W3C vocabularies — canonical IRIs, not exocortex.my-derivable.
+    Namespace.RDF,
+    Namespace.RDFS,
+    Namespace.OWL,
+    Namespace.XSD,
+    Namespace.SHACL,
   ];
 
   /**

--- a/packages/core/src/domain/models/rdf/Namespace.ts
+++ b/packages/core/src/domain/models/rdf/Namespace.ts
@@ -155,4 +155,69 @@ export class Namespace {
     if (!namespace) return null;
     return { namespace, localName: match[2] };
   }
+
+  /**
+   * INVERSE of {@link fromPropertyKey} + {@link Namespace.term}: recover the
+   * namespace + local name from a term IRI.
+   *
+   * Resolution order mirrors {@link forPrefix} exactly — the whitelist first
+   * (so an external W3C IRI such as `http://www.w3.org/2000/01/rdf-schema#subClassOf`
+   * resolves to {@link RDFS}), then the ad-hoc `EXOCORTEX_ONTOLOGY_BASE` convention
+   * (so `https://exocortex.my/ontology/aiKnow#Memory` still resolves).
+   *
+   * ⛔ Both directions MUST be derived from the SAME `KNOWN_NAMESPACES` array.
+   * A second literal list of bases is how the two drift apart: registering a
+   * vocabulary forward-only makes the emitter produce IRIs its own inverse
+   * cannot read, which silently breaks every consumer that maps a term IRI back
+   * to a frontmatter key (reified-predicate de-reification, wikilink naming).
+   * See req `aceaa2cc-15b6-4e1c-bf63-72c7c209de51`.
+   *
+   * Returns `null` when the IRI belongs to no known/derivable namespace, or when
+   * the local name is empty or itself contains `#`/`/` (not a clean `ns#Local`
+   * term — a path-form `obsidian://…/<uid>.md` ref lands here).
+   */
+  static fromTermIRI(
+    iri: string,
+  ): { namespace: Namespace; localName: string } | null {
+    if (typeof iri !== "string" || iri.length === 0) return null;
+
+    const cleanLocal = (localName: string): string | null =>
+      localName.length > 0 &&
+      !localName.includes("#") &&
+      !localName.includes("/")
+        ? localName
+        : null;
+
+    // 1. Registered namespaces (both exocortex.my and external W3C vocabularies).
+    for (const ns of Namespace.KNOWN_NAMESPACES) {
+      const base = ns.iri.value;
+      if (iri.startsWith(base)) {
+        const localName = cleanLocal(iri.slice(base.length));
+        if (localName === null) return null;
+        return { namespace: ns, localName };
+      }
+    }
+
+    // 2. Ad-hoc `EXOCORTEX_ONTOLOGY_BASE<prefix>#<LocalName>` convention.
+    if (!iri.startsWith(Namespace.EXOCORTEX_ONTOLOGY_BASE)) return null;
+    const rest = iri.slice(Namespace.EXOCORTEX_ONTOLOGY_BASE.length);
+    const hash = rest.indexOf("#");
+    if (hash <= 0) return null;
+    const prefix = rest.slice(0, hash);
+    if (!/^[a-z][a-zA-Z0-9]*$/.test(prefix)) return null;
+    const localName = cleanLocal(rest.slice(hash + 1));
+    if (localName === null) return null;
+    const namespace = Namespace.forPrefix(prefix);
+    if (!namespace) return null;
+    return { namespace, localName };
+  }
+
+  /**
+   * The registered namespaces, for consumers that must enumerate them (e.g. a
+   * round-trip invariant test). Exposed read-only so the single source of truth
+   * stays {@link KNOWN_NAMESPACES}.
+   */
+  static knownNamespaces(): ReadonlyArray<Namespace> {
+    return Namespace.KNOWN_NAMESPACES;
+  }
 }

--- a/packages/core/src/domain/models/rdf/Namespace.ts
+++ b/packages/core/src/domain/models/rdf/Namespace.ts
@@ -175,6 +175,18 @@ export class Namespace {
    * Returns `null` when the IRI belongs to no known/derivable namespace, or when
    * the local name is empty or itself contains `#`/`/` (not a clean `ns#Local`
    * term — a path-form `obsidian://…/<uid>.md` ref lands here).
+   *
+   * ⛤ The `/`-rejection DELIBERATELY NARROWS one of the two call sites this
+   * replaced. `iriToObsidianName`'s hand-rolled regex ended in `([^#]+)$`, which
+   * permitted a slash (`…/ontology/exo#Asset/Sub` → `exo__Asset/Sub`); the
+   * plugin's `symbolicIriToPropertyKey` rejected it. Unifying them adopts the
+   * STRICTER of the two prior semantics on purpose: a slash-bearing local name is
+   * not a `prefix__LocalName` frontmatter key, and treating it as one produced a
+   * property key no reader could resolve. `Namespace.term()` can still MINT such
+   * an IRI (the IRI ctor rejects spaces, not slashes), so the narrowing is
+   * reachable by construction — but a sweep of all three vaults found 40 distinct
+   * slash-bearing ontology-base values and ZERO that the old regex resolved (each
+   * is an `exo__Ontology_url` literal ending in `#`, e.g. `…/ems/docs#`).
    */
   static fromTermIRI(
     iri: string,

--- a/packages/core/src/services/ShaclLiteValidator.ts
+++ b/packages/core/src/services/ShaclLiteValidator.ts
@@ -89,8 +89,12 @@ const RDF_TYPE_IRI = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type';
  *
  * 2. **Exocortex ad-hoc IRIs** — when `Namespace.forPrefix` falls back to the ad-hoc
  *    convention `https://exocortex.my/ontology/<prefix>#` for prefixes that are not in
- *    the static whitelist (`KNOWN_NAMESPACES` in Namespace.ts). This currently affects
- *    `xsd__`, `rdf__`, `rdfs__`, `owl__` keys in vault frontmatter:
+ *    the static whitelist (`KNOWN_NAMESPACES` in Namespace.ts).
+ *
+ *    ⛤ As of req `aceaa2cc-15b6-4e1c-bf63-72c7c209de51` the five W3C prefixes
+ *    (`rdf`, `rdfs`, `owl`, `xsd`, `sh`) ARE whitelisted, so freshly-emitted
+ *    triples use form 1. The ad-hoc entries below remain for LEGACY data — a
+ *    store built before that change, or a serialized graph persisted then:
  *      • `xsd__Date`  → `https://exocortex.my/ontology/xsd#Date`
  *      • `rdf__Statement` → `https://exocortex.my/ontology/rdf#Statement`
  *      • `rdfs__Resource` → `https://exocortex.my/ontology/rdfs#Resource`
@@ -108,6 +112,7 @@ const EXTERNAL_ONTOLOGY_IRI_PREFIXES: readonly string[] = [
   'http://www.w3.org/1999/02/22-rdf-syntax-ns#',  // rdf (canonical)
   'http://www.w3.org/2000/01/rdf-schema#',         // rdfs (canonical)
   'http://www.w3.org/2002/07/owl#',                // owl (canonical)
+  'http://www.w3.org/ns/shacl#',                   // sh (canonical)
   'http://www.w3.org/2004/02/skos/core#',          // skos
   'http://purl.org/dc/elements/1.1/',              // dc
   'http://purl.org/dc/terms/',                     // dcterms

--- a/packages/core/src/utilities/iriToObsidianName.ts
+++ b/packages/core/src/utilities/iriToObsidianName.ts
@@ -1,14 +1,19 @@
+import { Namespace } from "../domain/models/rdf/Namespace";
+
 /**
  * Reverse-map an RDF IRI back to its Obsidian property-key / asset-name form.
  *
  * Two recognised IRI shapes (both produced by the forward RDF emission path):
  *
- *   1. Symbolic ontology term —
- *      `https://exocortex.my/ontology/<prefix>#<local>` → `<prefix>__<local>`.
- *      Mirrors the forward path (`Namespace.fromPropertyKey` →
- *      `Namespace.forPrefix`), which auto-extends to ad-hoc namespaces under
- *      the same base. Issue #3274 — a prior hardcoded prefix whitelist silently
- *      dropped ad-hoc namespaces (`kitelev__`, `aiKnow__`, …).
+ *   1. Symbolic ontology term — `<namespace-base><local>` → `<prefix>__<local>`,
+ *      resolved by {@link Namespace.fromTermIRI}, the shared inverse of the
+ *      forward path (`Namespace.fromPropertyKey` → `Namespace.forPrefix`). This
+ *      covers BOTH the ad-hoc `https://exocortex.my/ontology/<prefix>#` convention
+ *      AND the registered external W3C vocabularies (`rdf`, `rdfs`, `owl`, `xsd`,
+ *      `sh`), whose canonical bases are not derivable from the exocortex.my base.
+ *      Issue #3274 — a prior hardcoded prefix whitelist silently dropped ad-hoc
+ *      namespaces (`kitelev__`, `aiKnow__`, …); req `aceaa2cc-15b6-4e1c-bf63-72c7c209de51`
+ *      — a hand-rolled exocortex.my regex here silently dropped the W3C ones.
  *
  *   2. Vault file URL — `obsidian://vault/<path>/<basename>.md` (or any path
  *      ending in `/<basename>.md`) → `<basename>` (a UID-canon basename or a
@@ -23,14 +28,14 @@
  * resolver now delegates to this single source of truth.
  */
 export function iriToObsidianName(iri: string): string | null {
-  const baseMatch = iri.match(
-    /^https:\/\/exocortex\.my\/ontology\/([a-z][a-zA-Z0-9]*)#([^#]+)$/,
-  );
-  if (baseMatch) {
-    const [, prefix, local] = baseMatch;
-    return `${prefix}__${local}`;
-  }
-  // Handle obsidian:// vault URLs (e.g., obsidian://vault/ems/ems__EffortStatusDoing.md)
+  // Shape 1 — a term IRI in ANY registered namespace (exocortex.my ad-hoc AND the
+  // external W3C vocabularies) via the shared inverse, so this direction cannot
+  // drift from the forward emission path. Hand-rolling the exocortex.my regex
+  // here is what made `rdfs__subClassOf` unreadable once the forward path started
+  // emitting the canonical `http://www.w3.org/2000/01/rdf-schema#` base.
+  const term = Namespace.fromTermIRI(iri);
+  if (term) return `${term.namespace.prefix}__${term.localName}`;
+  // Shape 2 — obsidian:// vault URLs (e.g. obsidian://vault/ems/ems__EffortStatusDoing.md)
   const obsMatch = iri.match(/\/([^/]+)\.md$/);
   if (obsMatch) return obsMatch[1];
   return null;

--- a/packages/core/tests/integration/rdf/w3c-canonical-namespace-emission.test.ts
+++ b/packages/core/tests/integration/rdf/w3c-canonical-namespace-emission.test.ts
@@ -1,0 +1,222 @@
+/**
+ * Production-shape verification for req aceaa2cc: a vault asset whose
+ * `exo__Asset_label` parses as `<w3c-prefix>__<LocalName>` must emit the
+ * CANONICAL vocabulary IRI, not the ad-hoc `https://exocortex.my/ontology/<prefix>#`
+ * fallback.
+ *
+ * WHY the wiring axis matters (and a helper-only test would NOT be enough):
+ * `Namespace.forPrefix` is a pure string function with ~10 call sites. Asserting
+ * on it alone proves the whitelist, not that LABEL EMISSION routes through it —
+ * a test calling `forPrefix` directly stays green even if the converter derived
+ * IRIs some other way. So the store here is built by the REAL
+ * {@link NoteToRDFConverter} over fixture notes (NOT hand-authored triples), and
+ * the assertions read the emitted triples.
+ *
+ * The stakes: `RDFVocabularyMapper` ALREADY emits `exo__Class_superClass` as the
+ * canonical `rdfs:subClassOf` predicate (319 uses in vault-my, measured
+ * 2026-08-16). Before this change the ASSET DEFINING that term emitted
+ * `https://exocortex.my/ontology/rdfs#subClassOf` — definition and usage sat under
+ * two IRIs that never joined. The `subClassOf` case below asserts exactly that
+ * join.
+ *
+ * @req:aceaa2cc-15b6-4e1c-bf63-72c7c209de51
+ */
+
+import "reflect-metadata";
+import { NoteToRDFConverter } from "../../../src/services/NoteToRDFConverter";
+import type {
+  IVaultAdapter,
+  IFile,
+  IFrontmatter,
+} from "../../../src/interfaces/IVaultAdapter";
+import { Namespace } from "../../../src/domain/models/rdf/Namespace";
+
+const REQ = "@req:aceaa2cc-15b6-4e1c-bf63-72c7c209de51";
+
+const EXO_ASSET_LABEL = "https://exocortex.my/ontology/exo#Asset_label";
+const ADHOC_BASE = "https://exocortex.my/ontology/";
+
+/** Canonical W3C namespace IRIs — the values this change makes reachable from a label. */
+const CANONICAL = {
+  rdf: "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+  rdfs: "http://www.w3.org/2000/01/rdf-schema#",
+  owl: "http://www.w3.org/2002/07/owl#",
+  xsd: "http://www.w3.org/2001/XMLSchema#",
+  sh: "http://www.w3.org/ns/shacl#",
+} as const;
+
+interface FixtureNote {
+  uid: string;
+  frontmatter: IFrontmatter;
+}
+
+function makeFile(uid: string): IFile {
+  return {
+    path: `${uid}.md`,
+    basename: uid,
+    name: `${uid}.md`,
+    extension: "md",
+    parent: null,
+  } as unknown as IFile;
+}
+
+/** Convert fixture notes through the REAL converter (mirrors the sibling emission tests). */
+async function convertNotes(notes: FixtureNote[]) {
+  const files = notes.map((n) => makeFile(n.uid));
+  const fmByPath = new Map<string, IFrontmatter>();
+  const fileByBasename = new Map<string, IFile>();
+  notes.forEach((n, i) => {
+    fmByPath.set(files[i].path, n.frontmatter);
+    fileByBasename.set(n.uid, files[i]);
+  });
+
+  const mockVault = {
+    getAllFiles: jest.fn(() => files),
+    getFrontmatter: jest.fn((f: IFile) => fmByPath.get(f.path) ?? null),
+    getFirstLinkpathDest: jest.fn(
+      (linkpath: string) => fileByBasename.get(linkpath) ?? null,
+    ),
+    read: jest.fn().mockResolvedValue(""),
+    create: jest.fn(),
+    modify: jest.fn(),
+    delete: jest.fn(),
+    exists: jest.fn(),
+    getAbstractFileByPath: jest.fn(),
+    updateFrontmatter: jest.fn(),
+    rename: jest.fn(),
+    createFolder: jest.fn(),
+    process: jest.fn(),
+    updateLinks: jest.fn(),
+    getDefaultNewFileParent: jest.fn(),
+  } as unknown as jest.Mocked<IVaultAdapter>;
+
+  const converter = new NoteToRDFConverter(mockVault);
+  const out = [];
+  for (const file of files) {
+    out.push(...(await converter.convertNote(file)));
+  }
+  return out;
+}
+
+/** The object of this note's `exo__Asset_label` triple, as emitted. */
+async function emittedLabelObject(uid: string, label: string): Promise<string> {
+  const triples = await convertNotes([
+    {
+      uid,
+      frontmatter: {
+        exo__Asset_uid: uid,
+        exo__Asset_label: label,
+      } as unknown as IFrontmatter,
+    },
+  ]);
+  const labelTriple = triples.find(
+    (t) => t.predicate.value === EXO_ASSET_LABEL,
+  );
+  if (!labelTriple) {
+    throw new Error(
+      `no exo__Asset_label triple emitted for ${uid} (${triples.length} triples)`,
+    );
+  }
+  const object = labelTriple.object as { value?: unknown };
+  if (typeof object.value !== "string") {
+    throw new Error(
+      `exo__Asset_label object for ${uid} is not a valued term: ${String(labelTriple.object)}`,
+    );
+  }
+  return object.value;
+}
+
+const UID = {
+  subClassOf: "5c1a0000-0000-4000-8000-000000000000",
+  rdfType: "5d1a0000-0000-4000-8000-000000000000",
+  owlClass: "5e1a0000-0000-4000-8000-000000000000",
+  xsdDate: "5f1a0000-0000-4000-8000-000000000000",
+  shSeverity: "5a1a0000-0000-4000-8000-000000000000",
+  emsTask: "5b1a0000-0000-4000-8000-000000000000",
+  aiKnow: "5abc0000-0000-4000-8000-000000000000",
+} as const;
+
+describe(`W3C vocabulary prefixes emit canonical IRIs (${REQ})`, () => {
+  describe("A. wiring — the REAL converter derives the canonical IRI from a label", () => {
+    it(`${REQ} rdfs__subClassOf emits the canonical RDFS IRI, joining the term's definition with its 319 predicate usages`, async () => {
+      const emitted = await emittedLabelObject(
+        UID.subClassOf,
+        "rdfs__subClassOf",
+      );
+
+      expect(emitted).toBe(`${CANONICAL.rdfs}subClassOf`);
+      expect(emitted).not.toContain(ADHOC_BASE);
+      // The join that motivated the requirement: identical to what
+      // RDFVocabularyMapper already emits for the predicate position.
+      expect(emitted).toBe(Namespace.RDFS.term("subClassOf").value);
+    });
+
+    it(`${REQ} sh__severity emits the canonical SHACL IRI (new Namespace.SHACL constant)`, async () => {
+      const emitted = await emittedLabelObject(UID.shSeverity, "sh__severity");
+
+      expect(emitted).toBe(`${CANONICAL.sh}severity`);
+      expect(emitted).not.toContain(ADHOC_BASE);
+    });
+
+    it.each([
+      ["rdf__type", `${CANONICAL.rdf}type`, UID.rdfType],
+      ["owl__Class", `${CANONICAL.owl}Class`, UID.owlClass],
+      ["xsd__date", `${CANONICAL.xsd}date`, UID.xsdDate],
+    ])(
+      `${REQ} %s emits %s`,
+      async (label: string, expected: string, uid: string) => {
+        expect(await emittedLabelObject(uid, label)).toBe(expected);
+      },
+    );
+
+    it(`${REQ} NEGATIVE CONTROL: an exocortex.my prefix is byte-identical (backward compatibility)`, async () => {
+      const emitted = await emittedLabelObject(UID.emsTask, "ems__Task");
+
+      expect(emitted).toBe("https://exocortex.my/ontology/ems#Task");
+    });
+
+    it(`${REQ} NEGATIVE CONTROL: an unregistered prefix still uses the ad-hoc fallback`, async () => {
+      const emitted = await emittedLabelObject(
+        UID.aiKnow,
+        "aiKnow__Memory_aboutConcept",
+      );
+
+      expect(emitted).toBe(
+        "https://exocortex.my/ontology/aiKnow#Memory_aboutConcept",
+      );
+    });
+  });
+
+  describe("B. helper — Namespace.forPrefix returns the canonical singletons", () => {
+    it.each([
+      ["rdf", Namespace.RDF],
+      ["rdfs", Namespace.RDFS],
+      ["owl", Namespace.OWL],
+      ["xsd", Namespace.XSD],
+      ["sh", Namespace.SHACL],
+    ])(
+      `${REQ} forPrefix("%s") returns the canonical singleton (reference equality)`,
+      (prefix: string, expected: Namespace) => {
+        expect(Namespace.forPrefix(prefix)).toBe(expected);
+        expect(Namespace.forPrefix(prefix)!.iri.value).toBe(
+          CANONICAL[prefix as keyof typeof CANONICAL],
+        );
+      },
+    );
+
+    it(`${REQ} Namespace.SHACL carries the canonical SHACL namespace`, () => {
+      expect(Namespace.SHACL.prefix).toBe("sh");
+      expect(Namespace.SHACL.iri.value).toBe("http://www.w3.org/ns/shacl#");
+    });
+
+    it(`${REQ} NEGATIVE CONTROL: fromPropertyKey keeps ad-hoc derivation for user namespaces`, () => {
+      const parsed = Namespace.fromPropertyKey("aiKnow__Memory_aboutConcept");
+
+      expect(parsed).not.toBeNull();
+      expect(parsed!.namespace.iri.value).toBe(
+        "https://exocortex.my/ontology/aiKnow#",
+      );
+      expect(parsed!.localName).toBe("Memory_aboutConcept");
+    });
+  });
+});

--- a/packages/core/tests/integration/rdf/w3c-canonical-namespace-emission.test.ts
+++ b/packages/core/tests/integration/rdf/w3c-canonical-namespace-emission.test.ts
@@ -258,6 +258,37 @@ describe(`W3C vocabulary prefixes emit canonical IRIs (${REQ})`, () => {
       }
     });
 
+    /**
+     * `fromTermIRI` walks KNOWN_NAMESPACES first-match-wins, so a base that is a
+     * string PREFIX of another shadows it: the earlier entry claims the IRI and
+     * returns a local name still carrying the rest of the later base. No pair
+     * shadows today, but that holds because every base ends in `#` — a property
+     * of the CURRENT data, not of the code.
+     *
+     * ⛤ This axis adds NO coverage — measured, not assumed. Simulating the three
+     * shadowing shapes (hash-terminated, slash-terminated `http://purl.org/dc/`
+     * vs `…/dc/terms/`, and a no-hash inner base) shows the round-trip axes above
+     * catch all three: two resolve to `null`, the third to the WRONG namespace.
+     * What this axis adds is a READABLE failure — it names the offending pair,
+     * where round-trip only reports "expected namespace to be <X>" on whichever
+     * vocabulary happened to be registered second. Keeping it is a diagnostics
+     * ratchet, not a second line of defence; do not cite it as one.
+     */
+    it(`${REQ} no registered namespace base is a prefix of another (first-match-wins is safe)`, () => {
+      const bases = Namespace.knownNamespaces().map((ns) => ns.iri.value);
+      expect(bases.length).toBeGreaterThan(0); // canary
+
+      const shadowing: string[] = [];
+      for (const outer of bases) {
+        for (const inner of bases) {
+          if (outer !== inner && inner.startsWith(outer)) {
+            shadowing.push(`${outer} shadows ${inner}`);
+          }
+        }
+      }
+      expect(shadowing).toEqual([]);
+    });
+
     it(`${REQ} iriToObsidianName inverts label emission for EVERY registered namespace`, async () => {
       const namespaces = Namespace.knownNamespaces();
       expect(namespaces.length).toBeGreaterThan(0);

--- a/packages/core/tests/integration/rdf/w3c-canonical-namespace-emission.test.ts
+++ b/packages/core/tests/integration/rdf/w3c-canonical-namespace-emission.test.ts
@@ -13,11 +13,18 @@
  * the assertions read the emitted triples.
  *
  * The stakes: `RDFVocabularyMapper` ALREADY emits `exo__Class_superClass` as the
- * canonical `rdfs:subClassOf` predicate (319 uses in vault-my, measured
- * 2026-08-16). Before this change the ASSET DEFINING that term emitted
- * `https://exocortex.my/ontology/rdfs#subClassOf` — definition and usage sat under
- * two IRIs that never joined. The `subClassOf` case below asserts exactly that
- * join.
+ * canonical `rdfs:subClassOf` predicate — measured 2026-08-16 at **319 uses in
+ * vault-my** (and 293 / 378 in vault-tbank / vault-exodev respectively, so the
+ * phenomenon is not vault-my-specific). Before this change the ASSET DEFINING
+ * that term emitted `https://exocortex.my/ontology/rdfs#subClassOf` — definition
+ * and usage sat under two IRIs that never joined. The `subClassOf` case below
+ * asserts exactly that join.
+ *
+ * SECOND EMISSION SURFACE: `exo__Asset_aliases` runs through the same
+ * `expandClassValue` path as the label (`NoteToRDFConverter:1648`), so alias
+ * values flip form too — 19 alias triples per vault currently carry the ad-hoc
+ * W3C form. Same mechanism, same fix; named here so the blast radius is stated
+ * rather than implied.
  *
  * @req:aceaa2cc-15b6-4e1c-bf63-72c7c209de51
  */
@@ -30,6 +37,7 @@ import type {
   IFrontmatter,
 } from "../../../src/interfaces/IVaultAdapter";
 import { Namespace } from "../../../src/domain/models/rdf/Namespace";
+import { iriToObsidianName } from "../../../src/utilities/iriToObsidianName";
 
 const REQ = "@req:aceaa2cc-15b6-4e1c-bf63-72c7c209de51";
 
@@ -217,6 +225,82 @@ describe(`W3C vocabulary prefixes emit canonical IRIs (${REQ})`, () => {
         "https://exocortex.my/ontology/aiKnow#",
       );
       expect(parsed!.localName).toBe("Memory_aboutConcept");
+    });
+  });
+
+  /**
+   * C. THE ROUND-TRIP INVARIANT.
+   *
+   * Registering a vocabulary FORWARD-ONLY makes the emitter produce IRIs that its
+   * own inverse cannot read. That failure is invisible to axes A and B (both test
+   * the forward direction) and to the whole core suite — it surfaces only in
+   * consumers that map a term IRI back to a frontmatter key: reified-predicate
+   * de-reification (`ems__Bug f68bf750` / #3904) and wikilink naming.
+   *
+   * The axis is therefore stated over EVERY registered namespace, enumerated from
+   * `Namespace.knownNamespaces()` rather than a literal list — a vocabulary added
+   * later is covered automatically, which is the property that would have caught
+   * the gap this section was written for.
+   */
+  describe("C. round-trip — every registered namespace survives forward→inverse", () => {
+    it(`${REQ} fromTermIRI inverts term() for EVERY registered namespace`, () => {
+      const namespaces = Namespace.knownNamespaces();
+      expect(namespaces.length).toBeGreaterThan(0); // canary: an empty list would pass vacuously
+
+      for (const ns of namespaces) {
+        const iri = ns.term("SomeLocalName").value;
+        const back = Namespace.fromTermIRI(iri);
+
+        expect(back).not.toBeNull();
+        // Reference equality — the canonical singleton, not an equal-valued clone.
+        expect(back!.namespace).toBe(ns);
+        expect(back!.localName).toBe("SomeLocalName");
+      }
+    });
+
+    it(`${REQ} iriToObsidianName inverts label emission for EVERY registered namespace`, async () => {
+      const namespaces = Namespace.knownNamespaces();
+      expect(namespaces.length).toBeGreaterThan(0);
+
+      for (const ns of namespaces) {
+        const key = `${ns.prefix}__RoundTripProbe`;
+        // Forward: exactly what the converter derives from a label.
+        const parsed = Namespace.fromPropertyKey(key);
+        expect(parsed).not.toBeNull();
+        const emitted = parsed!.namespace.term(parsed!.localName).value;
+
+        // Inverse: must recover the original key.
+        expect(iriToObsidianName(emitted)).toBe(key);
+      }
+    });
+
+    it(`${REQ} the live case: owl__sameAs survives the round trip (reified predicate-def, present in all vaults)`, () => {
+      const emitted =
+        Namespace.fromPropertyKey("owl__sameAs")!.namespace.term(
+          "sameAs",
+        ).value;
+
+      expect(emitted).toBe("http://www.w3.org/2002/07/owl#sameAs");
+      expect(iriToObsidianName(emitted)).toBe("owl__sameAs");
+      expect(Namespace.fromTermIRI(emitted)!.namespace).toBe(Namespace.OWL);
+    });
+
+    it(`${REQ} ad-hoc user namespaces still round-trip (backward compatibility)`, () => {
+      const emitted =
+        "https://exocortex.my/ontology/aiKnow#Memory_aboutConcept";
+
+      expect(iriToObsidianName(emitted)).toBe("aiKnow__Memory_aboutConcept");
+      expect(Namespace.fromTermIRI(emitted)!.localName).toBe(
+        "Memory_aboutConcept",
+      );
+    });
+
+    it(`${REQ} NEGATIVE CONTROL: a path-form vault IRI is not mistaken for a term`, () => {
+      const path = "obsidian://vault/assetspaces/kitelev/exo/abc123.md";
+
+      expect(Namespace.fromTermIRI(path)).toBeNull();
+      // iriToObsidianName still handles it via its second shape (basename).
+      expect(iriToObsidianName(path)).toBe("abc123");
     });
   });
 });

--- a/packages/core/tests/services/ShaclLiteValidator.test.ts
+++ b/packages/core/tests/services/ShaclLiteValidator.test.ts
@@ -1218,7 +1218,11 @@ describe('validate — external ontology IRI allowlist', () => {
   });
 
   it('T-EXT-05: Exocortex ad-hoc xsd IRI (xsd__ prefix) as superClass → no violation', () => {
-    // Produced by Namespace.forPrefix('xsd') when xsd is not in KNOWN_NAMESPACES
+    // LEGACY form: produced by Namespace.forPrefix('xsd') BEFORE req
+    // aceaa2cc-15b6-4e1c-bf63-72c7c209de51 put xsd in KNOWN_NAMESPACES.
+    // Fresh emissions now use the canonical http://www.w3.org/2001/XMLSchema# base
+    // (covered by T-EXT-02); this case pins that a store still holding the old
+    // form stays exempt from sh:class checks.
     const XSD_ADHOC = 'https://exocortex.my/ontology/xsd#';
     const triples: Triple[] = [
       typeTriple('asset:LocalDate', exoClass),

--- a/packages/obsidian-plugin/src/presentation/renderers/layout/getReifiedRelations.ts
+++ b/packages/obsidian-plugin/src/presentation/renderers/layout/getReifiedRelations.ts
@@ -118,9 +118,11 @@ export function labelToSymbolicIRI(label: string | null | undefined): IRI | null
 
 /**
  * Inverse of {@link labelToSymbolicIRI}: recover the frontmatter predicate KEY
- * (`<prefix>__<LocalName>`) from an ontology symbolic IRI
- * (`<EXOCORTEX_ONTOLOGY_BASE><prefix>#<LocalName>`). Returns `null` for a
- * non-ontology IRI (a path-form `obsidian://…/<uid>.md` ref, an arbitrary IRI).
+ * (`<prefix>__<LocalName>`) from an ontology symbolic IRI — either the ad-hoc
+ * `<EXOCORTEX_ONTOLOGY_BASE><prefix>#<LocalName>` form or a registered external
+ * vocabulary's canonical form (`http://www.w3.org/2000/01/rdf-schema#subClassOf`
+ * → `rdfs__subClassOf`). Returns `null` for a non-ontology IRI (a path-form
+ * `obsidian://…/<uid>.md` ref, an arbitrary IRI).
  *
  * The RDF converter emits a `prefix__LocalName`-shaped `exo__Asset_label` as a
  * symbolic IRI, NOT a Literal (dual-IRI — `sparql-iri-form-pre-verify`). Any
@@ -132,18 +134,16 @@ export function labelToSymbolicIRI(label: string | null | undefined): IRI | null
  * name containing `#`/`/` is rejected here — such keys are not valid anyway).
  */
 export function symbolicIriToPropertyKey(iri: string): string | null {
-  const base = Namespace.EXOCORTEX_ONTOLOGY_BASE;
-  if (typeof iri !== "string" || !iri.startsWith(base)) return null;
-  const rest = iri.slice(base.length); // "<prefix>#<LocalName>"
-  const hash = rest.indexOf("#");
-  if (hash <= 0 || hash >= rest.length - 1) return null;
-  const prefix = rest.slice(0, hash);
-  const localName = rest.slice(hash + 1);
-  // Same prefix shape guard as `Namespace.forPrefix`.
-  if (!/^[a-z][a-zA-Z0-9]*$/.test(prefix)) return null;
-  // A further `#` / `/` means this is not a clean `ns#Local` term.
-  if (localName.includes("#") || localName.includes("/")) return null;
-  return `${prefix}__${localName}`;
+  // Delegates to the SHARED inverse so this direction cannot drift from the
+  // forward path: `Namespace.fromTermIRI` resolves the registered namespaces
+  // (incl. the external W3C vocabularies, whose canonical bases are NOT under
+  // EXOCORTEX_ONTOLOGY_BASE) before falling back to the ad-hoc convention.
+  // Anchoring on EXOCORTEX_ONTOLOGY_BASE alone silently dropped every
+  // W3C-prefixed predicate-def (e.g. `owl__sameAs`, live in all three vaults),
+  // re-opening the de-reify failure ems__Bug f68bf750 / #3904.
+  const term = Namespace.fromTermIRI(iri);
+  if (!term) return null;
+  return `${term.namespace.prefix}__${term.localName}`;
 }
 
 /**

--- a/packages/obsidian-plugin/tests/unit/getReifiedRelations.test.ts
+++ b/packages/obsidian-plugin/tests/unit/getReifiedRelations.test.ts
@@ -264,13 +264,59 @@ describe("symbolicIriToPropertyKey (inverse of labelToSymbolicIRI)", () => {
     }
   });
 
-  it("returns null for a non-ontology IRI (path-form ref, w3.org, empty)", () => {
+  it("returns null for a non-ontology IRI (path-form ref, unregistered host, empty)", () => {
     expect(
       symbolicIriToPropertyKey("obsidian://vault/assetspaces/x/1234.md"),
     ).toBeNull();
-    expect(symbolicIriToPropertyKey("http://www.w3.org/2002/07/owl#sameAs")).toBeNull();
+    // An UNREGISTERED external vocabulary still yields null (SKOS is not in
+    // KNOWN_NAMESPACES) — the exemption is per-registered-namespace, not
+    // "anything on w3.org".
+    expect(
+      symbolicIriToPropertyKey("http://www.w3.org/2004/02/skos/core#broader"),
+    ).toBeNull();
     expect(symbolicIriToPropertyKey("https://exocortex.my/ontology/exo#")).toBeNull();
     expect(symbolicIriToPropertyKey("")).toBeNull();
+  });
+
+  /**
+   * @req:aceaa2cc-15b6-4e1c-bf63-72c7c209de51
+   *
+   * INTENDED BEHAVIOUR CHANGE. This case previously asserted
+   * `symbolicIriToPropertyKey("http://www.w3.org/2002/07/owl#sameAs") === null`,
+   * pinning the state where the five W3C prefixes were NOT registered.
+   *
+   * Once the forward path emits `owl__sameAs` as the canonical
+   * `http://www.w3.org/2002/07/owl#sameAs`, a null here means the de-reify
+   * resolution loses every W3C-prefixed predicate-def — re-opening
+   * `ems__Bug f68bf750` / #3904 ("could not be mapped back to a frontmatter key"),
+   * which this very function exists to fix. The IRI below is not hypothetical:
+   * `exo__Statement_predicate → owl#sameAs` is present in vault-my, vault-tbank
+   * and vault-exodev.
+   */
+  it("@req:aceaa2cc-15b6-4e1c-bf63-72c7c209de51 recovers the key from a REGISTERED external vocabulary IRI (de-reify must not lose W3C predicates)", () => {
+    expect(
+      symbolicIriToPropertyKey("http://www.w3.org/2002/07/owl#sameAs"),
+    ).toBe("owl__sameAs");
+    expect(
+      symbolicIriToPropertyKey(
+        "http://www.w3.org/2000/01/rdf-schema#subClassOf",
+      ),
+    ).toBe("rdfs__subClassOf");
+  });
+
+  it("@req:aceaa2cc-15b6-4e1c-bf63-72c7c209de51 round-trips for W3C-prefixed keys, upholding the invariant this function documents", () => {
+    for (const key of [
+      "owl__sameAs",
+      "rdfs__subClassOf",
+      "rdf__type",
+      "xsd__date",
+      "sh__severity",
+    ]) {
+      const iri = labelToSymbolicIRI(key);
+      expect(iri).not.toBeNull();
+      // The documented invariant: symbolicIriToPropertyKey(labelToSymbolicIRI(k)) === k
+      expect(symbolicIriToPropertyKey(iri!.value)).toBe(key);
+    }
   });
 });
 

--- a/packages/obsidian-plugin/tests/unit/getReifiedRelations.test.ts
+++ b/packages/obsidian-plugin/tests/unit/getReifiedRelations.test.ts
@@ -264,7 +264,7 @@ describe("symbolicIriToPropertyKey (inverse of labelToSymbolicIRI)", () => {
     }
   });
 
-  it("returns null for a non-ontology IRI (path-form ref, unregistered host, empty)", () => {
+  it("returns null for a non-ontology IRI (path-form ref, unregistered vocabulary, empty)", () => {
     expect(
       symbolicIriToPropertyKey("obsidian://vault/assetspaces/x/1234.md"),
     ).toBeNull();


### PR DESCRIPTION
## Что и почему

Ассет, чей `exo__Asset_label` парсится как `<w3c-prefix>__<LocalName>`, теперь эмитит **канонический** IRI словаря вместо ad-hoc `https://exocortex.my/ontology/<prefix>#`.

**Расщепление, которое это закрывает.** `RDFVocabularyMapper` уже эмитит `exo__Class_superClass` как канонический предикат `rdfs:subClassOf` — **319 употреблений** в vault-my. При этом ассет, **определяющий** тот же термин (label `rdfs__subClassOf`), эмитил `https://exocortex.my/ontology/rdfs#subClassOf`. Определение и употребление жили под разными IRI и никогда не соединялись: запрос «что известно о `rdfs:subClassOf`» находил 319 употреблений, но не находил описание.

Канонические константы `Namespace.RDF/RDFS/OWL/XSD` **уже существовали** и уже использовались маппером — их просто не было в whitelist `KNOWN_NAMESPACES`, который читает `Namespace.forPrefix`, поэтому любой W3C-префиксованный label падал в ad-hoc ветку.

## Изменения

- регистрация `rdf`/`rdfs`/`owl`/`xsd` в `KNOWN_NAMESPACES`;
- новая константа `Namespace.SHACL` (`http://www.w3.org/ns/shacl#`) + регистрация;
- докстринг, объясняющий, **почему** внешняя группа обязана быть в списке (её IRI не выводимы из `EXOCORTEX_ONTOLOGY_BASE`).

## Замеренный blast radius (vault-my, 2026-08-16)

| | |
|---|---|
| ассетов с W3C-префиксованным label | **26** (owl 10, rdfs 7, rdf 7, sh 1, xsd 1) |
| литералов в vault, цитирующих ad-hoc форму | **0** — ни один precondition ASK / NamedQuery / grounding не меняет смысл |
| `ShaclLiteValidator` | уже allowlist'ит **обе** формы (канонические W3C + ad-hoc) ⇒ поведение не меняется **по построению** |
| exocortex.my префиксы и незарегистрированные пользовательские (`aiKnow__` и т.п.) | байт-идентичны |

## Тесты

- `packages/core`: **375/375** сьютов, **8613** тестов
- `packages/obsidian-plugin`: **342/342**, **6092**
- `packages/cli`: 158/159 — единственное падение (`exo003 mixed format`) **воспроизведено на `origin/main` без этой правки**; `exosync-sync` в одном прогоне флакнул, при повторном полном прогоне зелен
- `npm run check:types`: 0 ошибок

## Revert-verified

Снятие пяти W3C-записей из `KNOWN_NAMESPACES` роняет **ровно 10** ассертов канонической эмиссии, тогда как **все три негативных контроля** остаются GREEN:

- exocortex.my префикс байт-идентичен,
- незарегистрированный префикс по-прежнему идёт в ad-hoc fallback,
- `fromPropertyKey` сохраняет ad-hoc деривацию для пользовательских namespace.

⇒ дельта — именно регистрация W3C, а не резолюция namespace вообще (не-вакуумность).

⛤ Тест намеренно имеет **две оси**: ось A гоняет **реальный `NoteToRDFConverter`** над фикстурными нотами (проводка — иначе тест на один `forPrefix` остался бы зелёным даже если эмиссия label'а шла бы другим путём), ось B проверяет сам хелпер.

## Не входит в scope (явно)

- Чтение `exo__Ontology_url` для деривации namespace-баз при эмиссии — замерено: **1 внешний `Ontology_url` из 138** в vault-my, и тот (`$w3c → https://www.w3.org/`) — корень сайта, не пригодный как namespace-база. Данных для механизма пока нет; плюс он превращает `Namespace.forPrefix` из чистой строковой функции в vault-зависимую (~10 call-site + 2 задокументированных зеркала в CLI).
- Раскол `exoas-w3c-aggregated` на per-vocab онтологии — это vault-ДАННЫЕ, отдельная работа. Этот PR — движковая половина, которая делает такой раскол осмысленным.
- Словари с нулевым присутствием в vault (`skos`, `dc`, `foaf`) — хардкод вперёд потребности.

Req: `aceaa2cc-15b6-4e1c-bf63-72c7c209de51`

https://claude.ai/code/session_015QdGEKFfUAiVYTkvXcDhJ2


---

## Review rounds (2) + corrections I owe to the record

**Round 1 — WARNING, 2 HIGH.** Both were regressions *this PR introduced*, and
both were found by executing the real modules, not by reading the diff:

- **HIGH-1** — registering the W3C vocabularies forward-only broke the INVERSE.
  `owl__sameAs` is a live reified predicate-def in all three vaults, so
  de-reification and wikilink naming returned `undefined` for it. Fixed with a
  shared `Namespace.fromTermIRI` that both inverses delegate to, derived from the
  same `KNOWN_NAMESPACES` array — the drift that caused this is now structurally
  impossible, and the round-trip axis enumerates `knownNamespaces()` so a
  vocabulary registered later is covered without touching the test.
- **HIGH-2** — core↔CLI divergence: `xsd__`/`sh__` were missing from
  `NAMESPACE_PREFIX_MAP`, so `validate-schema` would have built subClassOf edges
  under a different IRI than the converter emits.

**Round 2 — APPROVE, 0 CRITICAL/HIGH/MEDIUM.** Two LOW notes applied in
`652d76c4`.

⛔ **Correction 1 (mine).** The no-shadowing axis I added for LOW-2 was committed
with a comment claiming it holds the guarantee "by construction" where round-trip
would miss it. Not derived from the mechanism. Simulating all three shadowing
shapes shows the round-trip axes catch every one; the mutant confirms it (a
shadowing pair reds three axes, not one). The axis adds **no coverage** — it adds
a readable failure that names the offending pair. The comment now says exactly
that, and says not to cite it as a second line of defence.

⛔ **Correction 2 (mine).** I described both CLI failures as "submodule-backed
suites that pass in isolation". True for `exosync-sync` (17/17 in isolation),
**false** for `sparql-exo003`, which fails in isolation too. Its actual mechanism:
`runCLI` spawns the prebuilt `dist/index.js`, whose mtime predates this fix
(`grep -c fromTermIRI dist/index.js` = 0) so the suite never exercised the change,
and it is `describe.skip`-ped when `CI === "true"` so it gates nothing. Unrelated
to this diff — but for a different reason than I gave.

**Scope claims, per vault** (measured, not generalised): the canonical W3C IRIs
this PR makes readable appear as reified predicate-defs — `owl__sameAs` is present
in all three vaults; `rdfs__`/`rdf__`/`xsd__`/`sh__` counts differ per vault and are
recorded in the requirement's `covers`.
