### PR TITLE
feat(cli): validate schema reports term-IRI collisions

### DIFF
--- a/packages/cli/src/commands/validate-schema.ts
+++ b/packages/cli/src/commands/validate-schema.ts
@@ -200,9 +200,7 @@ export interface SchemaValidationResult {
  * Extract frontmatter from a .md file's raw content.
  * Returns null if no valid frontmatter block is found.
  */
-export function extractFrontmatter(
-  content: string,
-): Record<string, unknown> | null {
+export function extractFrontmatter(content: string): Record<string, unknown> | null {
   const match = content.match(/^---\r?\n([\s\S]*?)\r?\n---/);
   if (!match) {
     // Handle empty frontmatter: ---\n---
@@ -270,10 +268,9 @@ export function uriToKey(uri: string): string | null {
  * Keys without a known prefix that are NOT in the whitelist are flagged
  * with reason "unknown_prefix".
  */
-export function classifyKeys(keys: string[]): {
-  toValidate: string[];
-  unknownPrefix: string[];
-} {
+export function classifyKeys(
+  keys: string[],
+): { toValidate: string[]; unknownPrefix: string[] } {
   const toValidate: string[] = [];
   const unknownPrefix: string[] = [];
 
@@ -391,7 +388,7 @@ export async function loadDeclaredProperties(
         FILTER(!CONTAINS(STR(?class), "PropertyCardinality"))
       }
       OPTIONAL { ?s exo:Asset_label ?label }
-    }`,
+    }`
   );
 
   const ast = parser.parse(queryString);
@@ -420,10 +417,7 @@ export async function loadDeclaredProperties(
 
     // Source 2: IRI labels (full ontology URIs stored as exo:Asset_label)
     const label = json.label;
-    if (
-      typeof label === "string" &&
-      label.startsWith("https://exocortex.my/ontology/")
-    ) {
+    if (typeof label === "string" && label.startsWith("https://exocortex.my/ontology/")) {
       declaredProperties.add(label);
     }
   }
@@ -446,9 +440,7 @@ export function detectUnparseableFrontmatter(content: string): string | null {
     yaml.load(match[1]);
     return null;
   } catch (error) {
-    return error instanceof Error
-      ? error.message.split("\n")[0]
-      : String(error);
+    return error instanceof Error ? error.message.split("\n")[0] : String(error);
   }
 }
 
@@ -512,8 +504,7 @@ export function validateFile(
 }
 
 const RDFS_SUBCLASS_OF = "http://www.w3.org/2000/01/rdf-schema#subClassOf";
-const EXO_CLASS_SUPER_CLASS =
-  "https://exocortex.my/ontology/exo#Class_superClass";
+const EXO_CLASS_SUPER_CLASS = "https://exocortex.my/ontology/exo#Class_superClass";
 const RDFS_LABEL = "http://www.w3.org/2000/01/rdf-schema#label";
 
 /**
@@ -578,12 +569,7 @@ function fileIriToOntologyURIFromFilename(fileIri: string): string | null {
 }
 
 type AlgebraIRI = { type: "iri"; value: string };
-type AlgebraLiteral = {
-  type: "literal";
-  value: string;
-  datatype?: string;
-  language?: string;
-};
+type AlgebraLiteral = { type: "literal"; value: string; datatype?: string; language?: string };
 type AlgebraBlank = { type: "blank"; value: string };
 type AlgebraNode = AlgebraIRI | AlgebraLiteral | AlgebraBlank;
 
@@ -597,9 +583,7 @@ interface AlgebraStyleTriple {
  * Converts domain Triple[] (class-based) to algebra-compatible Triple[] (interface-based).
  * Required because ShaclLiteValidator.validate() expects algebra Triple types.
  */
-export function domainToAlgebraTriples(
-  triples: DomainTriple[],
-): AlgebraStyleTriple[] {
+export function domainToAlgebraTriples(triples: DomainTriple[]): AlgebraStyleTriple[] {
   const mapNode = (node: unknown): AlgebraNode | null => {
     if (node instanceof DomainIRI) return { type: "iri", value: node.value };
     if (node instanceof DomainLiteral) {
@@ -864,10 +848,7 @@ export interface EARLReport {
 /**
  * Formats a ValidationReport as W3C EARL JSON-LD.
  */
-export function buildEARLReport(
-  vaultPath: string,
-  report: ValidationReport,
-): EARLReport {
+export function buildEARLReport(vaultPath: string, report: ValidationReport): EARLReport {
   const subjectId = `file://${vaultPath}`;
   const assertorId = "https://exocortex.my/cli/shacl-validator";
 
@@ -925,8 +906,7 @@ export function buildEARLReport(
   return { "@context": context, "@graph": graph };
 }
 
-const LEGACY_EXCEPTION_IRI =
-  "https://exocortex.my/ontology/exo#Asset_legacyValidationException";
+const LEGACY_EXCEPTION_IRI = "https://exocortex.my/ontology/exo#Asset_legacyValidationException";
 
 /**
  * P4.3: Filters out violations for assets marked with exo__Asset_legacyValidationException.
@@ -938,20 +918,14 @@ export function applyLegacyExceptionFilter(
 ): ValidationReport {
   const exemptNodes = new Set<string>(
     triples
-      .filter(
-        (t) =>
-          t.predicate instanceof DomainIRI &&
-          t.predicate.value === LEGACY_EXCEPTION_IRI,
-      )
-      .map((t) => (t.subject instanceof DomainIRI ? t.subject.value : null))
+      .filter(t => t.predicate instanceof DomainIRI && t.predicate.value === LEGACY_EXCEPTION_IRI)
+      .map(t => (t.subject instanceof DomainIRI ? t.subject.value : null))
       .filter((v): v is string => v !== null),
   );
   if (exemptNodes.size === 0) return report;
-  const violations = report.violations.filter(
-    (v) => !exemptNodes.has(v.focusNode),
-  );
+  const violations = report.violations.filter(v => !exemptNodes.has(v.focusNode));
   return {
-    conforms: violations.every((v) => v.severity !== "sh:Violation"),
+    conforms: violations.every(v => v.severity !== "sh:Violation"),
     violations,
   };
 }
@@ -1102,22 +1076,12 @@ export async function runShapesModeAction(
     // (errors); `sh:Warning` are unresolvable cross-vault / symbolic / external
     // references that cannot be hard-failed under open-world semantics. Warnings
     // are reported with a dedicated counter but do NOT break the exit code.
-    const errorResults = report.violations.filter(
-      (v) => v.severity === "sh:Violation",
-    );
-    const warningResults = report.violations.filter(
-      (v) => v.severity !== "sh:Violation",
-    );
-    const crossVaultRefWarnings = warningResults.filter(
-      (v) => v.constraint === "class",
-    ).length;
-    const collisionWarningCount = warningResults.filter(
-      (v) => v.constraint === "term-iri-collision",
-    ).length;
+    const errorResults = report.violations.filter((v) => v.severity === "sh:Violation");
+    const warningResults = report.violations.filter((v) => v.severity !== "sh:Violation");
+    const crossVaultRefWarnings = warningResults.filter((v) => v.constraint === "class").length;
+    const collisionWarningCount = warningResults.filter((v) => v.constraint === "term-iri-collision").length;
     const collidingIris = new Set(
-      warningResults
-        .filter((v) => v.constraint === "term-iri-collision")
-        .map((v) => v.actualValue ?? ""),
+      warningResults.filter((v) => v.constraint === "term-iri-collision").map((v) => v.actualValue ?? ""),
     );
 
     if (fmt === "earl") {
@@ -1147,9 +1111,7 @@ export async function runShapesModeAction(
           existing.push(v);
           byNode.set(v.focusNode, existing);
         }
-        console.log(
-          `⚠️  Found ${errorResults.length} SHACL violation(s) in ${byNode.size} node(s):\n`,
-        );
+        console.log(`⚠️  Found ${errorResults.length} SHACL violation(s) in ${byNode.size} node(s):\n`);
         for (const [node, violations] of byNode) {
           console.log(`   ❌ ${node}`);
           for (const v of violations) {
@@ -1195,12 +1157,6 @@ export async function runShapesModeAction(
 }
 
 /**
- * Creates the 'validate schema' subcommand for checking frontmatter
- * properties against the ontology.
- *
- * Issue #2713: Schema linter for frontmatter properties.
- */
-/**
  * Assemble the final shapes report: shape-engine findings PLUS term-IRI collisions,
  * then both report filters.
  *
@@ -1216,9 +1172,19 @@ export async function runShapesModeAction(
  *     AFTER the filters (the shape review measured this) made every commit in a
  *     vault with old collisions carry warnings about unrelated files.
  *
- * Folding in early cannot flip `conforms`: both filters recompute it as
- * `violations.every(v => v.severity !== "sh:Violation")`, and collisions are always
- * `sh:Warning`.
+ * ⛔ Why folding in early cannot flip `conforms` — and the trap in the obvious
+ * explanation. It is NOT that "both filters recompute conforms": with no
+ * exemptions `applyLegacyExceptionFilter` returns the report object untouched
+ * (see its `exemptNodes.size === 0` early return), and the staged filter only
+ * runs under `--staged`, so on the DEFAULT path nothing recomputes it — `conforms`
+ * is a passthrough from `rawReport`. Collisions are safe for two separate reasons,
+ * one per path: on the default path we never touch `conforms`, and on the paths
+ * that DO recompute it the predicate is
+ * `violations.every(v => v.severity !== "sh:Violation")`, which warnings satisfy.
+ * ⚠ Consequence for anyone extending this: folding a `sh:Violation`-severity
+ * finding in here would NOT flip `conforms` on the default path — it would ship a
+ * silent exit 0. Such a finding must set `conforms` explicitly.
+ * (Measured 2026-08-17 by review round 3, probe P4.)
  *
  * req `00e8079e-fb36-4ce3-b33f-abb18c212143`
  */
@@ -1230,10 +1196,7 @@ export function assembleShapesReport(
   const collisionWarnings = detectTermIriCollisions(triples);
   const withCollisions =
     collisionWarnings.length > 0
-      ? {
-          ...rawReport,
-          violations: [...rawReport.violations, ...collisionWarnings],
-        }
+      ? { ...rawReport, violations: [...rawReport.violations, ...collisionWarnings] }
       : rawReport;
 
   let report = applyLegacyExceptionFilter(triples, withCollisions);
@@ -1243,33 +1206,22 @@ export function assembleShapesReport(
   return report;
 }
 
+/**
+ * Creates the 'validate schema' subcommand for checking frontmatter
+ * properties against the ontology.
+ *
+ * Issue #2713: Schema linter for frontmatter properties.
+ */
 export function validateSchemaCommand(): Command {
   return new Command("schema")
     .description("Check frontmatter properties against ontology (Issue #2713)")
     .option("--vault <path>", "Path to Obsidian vault", process.cwd())
-    .option(
-      "--output <type>",
-      "Response format: text|json (for MCP tools)",
-      "text",
-    )
-    .option(
-      "--staged",
-      "Only validate git-staged .md files (for pre-commit hooks)",
-    )
+    .option("--output <type>", "Response format: text|json (for MCP tools)", "text")
+    .option("--staged", "Only validate git-staged .md files (for pre-commit hooks)")
     .option("--use-cache", "Use persistent triple cache (faster vault loading)")
-    .option(
-      "--shapes-mode",
-      "Run SHACL-lite shapes validation instead of schema linting",
-    )
-    .option(
-      "--format <type>",
-      "Output format for shapes-mode: text|json|earl",
-      "text",
-    )
-    .option(
-      "--class <iri>",
-      "Only validate assets whose exo__Instance_class matches this IRI/slug (RFC 8e83442b T1.4)",
-    )
+    .option("--shapes-mode", "Run SHACL-lite shapes validation instead of schema linting")
+    .option("--format <type>", "Output format for shapes-mode: text|json|earl", "text")
+    .option("--class <iri>", "Only validate assets whose exo__Instance_class matches this IRI/slug (RFC 8e83442b T1.4)")
     .action(async (options: ValidateSchemaOptions) => {
       const outputFormat = (options.output || "text") as OutputFormat;
       ErrorHandler.setFormat(outputFormat);
@@ -1312,10 +1264,7 @@ export function validateSchemaCommand(): Command {
           const classFilter = options.class;
           targetFiles = targetFiles.filter((relPath) => {
             try {
-              const content = readFileSync(
-                resolve(vaultPath, relPath),
-                "utf-8",
-              );
+              const content = readFileSync(resolve(vaultPath, relPath), "utf-8");
               const fm = extractFrontmatter(content);
               return frontmatterMatchesClass(fm, classFilter);
             } catch {
@@ -1329,8 +1278,10 @@ export function validateSchemaCommand(): Command {
           console.log(`📦 Loading vault: ${vaultPath}...`);
         }
 
-        const { triples: loadedTriples, cacheHit } =
-          await loadTriplesFromAllVaults(vaultPath, Boolean(options.useCache));
+        const { triples: loadedTriples, cacheHit } = await loadTriplesFromAllVaults(
+          vaultPath,
+          Boolean(options.useCache),
+        );
         const triples: Triple[] = loadedTriples as Triple[];
         if (outputFormat === "text" && cacheHit) {
           console.log("🚀 Cache hit! Loading from persistent cache...");
@@ -1345,9 +1296,7 @@ export function validateSchemaCommand(): Command {
         const declaredPropertyURIs = await loadDeclaredProperties(triples);
 
         if (outputFormat === "text") {
-          console.log(
-            `📋 Found ${declaredPropertyURIs.size} declared properties in ontology`,
-          );
+          console.log(`📋 Found ${declaredPropertyURIs.size} declared properties in ontology`);
           console.log(`🔍 Validating ${targetFiles.length} file(s)...\n`);
         }
 
@@ -1355,11 +1304,7 @@ export function validateSchemaCommand(): Command {
         const allViolations: SchemaViolation[] = [];
         for (const relPath of targetFiles) {
           const fullPath = resolve(vaultPath, relPath);
-          const violations = validateFile(
-            fullPath,
-            relPath,
-            declaredPropertyURIs,
-          );
+          const violations = validateFile(fullPath, relPath, declaredPropertyURIs);
           allViolations.push(...violations);
         }
 
@@ -1376,9 +1321,7 @@ export function validateSchemaCommand(): Command {
           console.log(JSON.stringify(response, null, 2));
         } else {
           if (allViolations.length === 0) {
-            console.log(
-              `✅ All ${targetFiles.length} file(s) pass schema validation.`,
-            );
+            console.log(`✅ All ${targetFiles.length} file(s) pass schema validation.`);
           } else {
             // Group violations by file
             const byFile = new Map<string, SchemaViolation[]>();
@@ -1388,9 +1331,7 @@ export function validateSchemaCommand(): Command {
               byFile.set(v.file, existing);
             }
 
-            console.log(
-              `⚠️  Found ${allViolations.length} schema violation(s) in ${byFile.size} file(s):\n`,
-            );
+            console.log(`⚠️  Found ${allViolations.length} schema violation(s) in ${byFile.size} file(s):\n`);
             for (const [file, violations] of byFile) {
               console.log(`   ❌ ${file}`);
               for (const v of violations) {
@@ -1399,9 +1340,7 @@ export function validateSchemaCommand(): Command {
             }
             console.log("\n📝 To fix these issues:");
             console.log("   - Remove undeclared properties from frontmatter");
-            console.log(
-              "   - Or declare them in the ontology as Property instances",
-            );
+            console.log("   - Or declare them in the ontology as Property instances");
           }
         }
 

--- a/packages/cli/src/commands/validate-schema.ts
+++ b/packages/cli/src/commands/validate-schema.ts
@@ -200,7 +200,9 @@ export interface SchemaValidationResult {
  * Extract frontmatter from a .md file's raw content.
  * Returns null if no valid frontmatter block is found.
  */
-export function extractFrontmatter(content: string): Record<string, unknown> | null {
+export function extractFrontmatter(
+  content: string,
+): Record<string, unknown> | null {
   const match = content.match(/^---\r?\n([\s\S]*?)\r?\n---/);
   if (!match) {
     // Handle empty frontmatter: ---\n---
@@ -268,9 +270,10 @@ export function uriToKey(uri: string): string | null {
  * Keys without a known prefix that are NOT in the whitelist are flagged
  * with reason "unknown_prefix".
  */
-export function classifyKeys(
-  keys: string[],
-): { toValidate: string[]; unknownPrefix: string[] } {
+export function classifyKeys(keys: string[]): {
+  toValidate: string[];
+  unknownPrefix: string[];
+} {
   const toValidate: string[] = [];
   const unknownPrefix: string[] = [];
 
@@ -388,7 +391,7 @@ export async function loadDeclaredProperties(
         FILTER(!CONTAINS(STR(?class), "PropertyCardinality"))
       }
       OPTIONAL { ?s exo:Asset_label ?label }
-    }`
+    }`,
   );
 
   const ast = parser.parse(queryString);
@@ -417,7 +420,10 @@ export async function loadDeclaredProperties(
 
     // Source 2: IRI labels (full ontology URIs stored as exo:Asset_label)
     const label = json.label;
-    if (typeof label === "string" && label.startsWith("https://exocortex.my/ontology/")) {
+    if (
+      typeof label === "string" &&
+      label.startsWith("https://exocortex.my/ontology/")
+    ) {
       declaredProperties.add(label);
     }
   }
@@ -440,7 +446,9 @@ export function detectUnparseableFrontmatter(content: string): string | null {
     yaml.load(match[1]);
     return null;
   } catch (error) {
-    return error instanceof Error ? error.message.split("\n")[0] : String(error);
+    return error instanceof Error
+      ? error.message.split("\n")[0]
+      : String(error);
   }
 }
 
@@ -504,7 +512,8 @@ export function validateFile(
 }
 
 const RDFS_SUBCLASS_OF = "http://www.w3.org/2000/01/rdf-schema#subClassOf";
-const EXO_CLASS_SUPER_CLASS = "https://exocortex.my/ontology/exo#Class_superClass";
+const EXO_CLASS_SUPER_CLASS =
+  "https://exocortex.my/ontology/exo#Class_superClass";
 const RDFS_LABEL = "http://www.w3.org/2000/01/rdf-schema#label";
 
 /**
@@ -569,7 +578,12 @@ function fileIriToOntologyURIFromFilename(fileIri: string): string | null {
 }
 
 type AlgebraIRI = { type: "iri"; value: string };
-type AlgebraLiteral = { type: "literal"; value: string; datatype?: string; language?: string };
+type AlgebraLiteral = {
+  type: "literal";
+  value: string;
+  datatype?: string;
+  language?: string;
+};
 type AlgebraBlank = { type: "blank"; value: string };
 type AlgebraNode = AlgebraIRI | AlgebraLiteral | AlgebraBlank;
 
@@ -583,7 +597,9 @@ interface AlgebraStyleTriple {
  * Converts domain Triple[] (class-based) to algebra-compatible Triple[] (interface-based).
  * Required because ShaclLiteValidator.validate() expects algebra Triple types.
  */
-export function domainToAlgebraTriples(triples: DomainTriple[]): AlgebraStyleTriple[] {
+export function domainToAlgebraTriples(
+  triples: DomainTriple[],
+): AlgebraStyleTriple[] {
   const mapNode = (node: unknown): AlgebraNode | null => {
     if (node instanceof DomainIRI) return { type: "iri", value: node.value };
     if (node instanceof DomainLiteral) {
@@ -848,7 +864,10 @@ export interface EARLReport {
 /**
  * Formats a ValidationReport as W3C EARL JSON-LD.
  */
-export function buildEARLReport(vaultPath: string, report: ValidationReport): EARLReport {
+export function buildEARLReport(
+  vaultPath: string,
+  report: ValidationReport,
+): EARLReport {
   const subjectId = `file://${vaultPath}`;
   const assertorId = "https://exocortex.my/cli/shacl-validator";
 
@@ -906,7 +925,8 @@ export function buildEARLReport(vaultPath: string, report: ValidationReport): EA
   return { "@context": context, "@graph": graph };
 }
 
-const LEGACY_EXCEPTION_IRI = "https://exocortex.my/ontology/exo#Asset_legacyValidationException";
+const LEGACY_EXCEPTION_IRI =
+  "https://exocortex.my/ontology/exo#Asset_legacyValidationException";
 
 /**
  * P4.3: Filters out violations for assets marked with exo__Asset_legacyValidationException.
@@ -918,14 +938,20 @@ export function applyLegacyExceptionFilter(
 ): ValidationReport {
   const exemptNodes = new Set<string>(
     triples
-      .filter(t => t.predicate instanceof DomainIRI && t.predicate.value === LEGACY_EXCEPTION_IRI)
-      .map(t => (t.subject instanceof DomainIRI ? t.subject.value : null))
+      .filter(
+        (t) =>
+          t.predicate instanceof DomainIRI &&
+          t.predicate.value === LEGACY_EXCEPTION_IRI,
+      )
+      .map((t) => (t.subject instanceof DomainIRI ? t.subject.value : null))
       .filter((v): v is string => v !== null),
   );
   if (exemptNodes.size === 0) return report;
-  const violations = report.violations.filter(v => !exemptNodes.has(v.focusNode));
+  const violations = report.violations.filter(
+    (v) => !exemptNodes.has(v.focusNode),
+  );
   return {
-    conforms: violations.every(v => v.severity !== "sh:Violation"),
+    conforms: violations.every((v) => v.severity !== "sh:Violation"),
     violations,
   };
 }
@@ -1068,24 +1094,7 @@ export async function runShapesModeAction(
     }
 
     const rawReport = await runShapesValidation(vaultPath, triples);
-    let report = applyLegacyExceptionFilter(triples, rawReport);
-    if (stagedFilter) {
-      report = filterReportToStagedFocusNodes(report, stagedFilter);
-    }
-
-    // req 00e8079e — term-IRI collisions are a GLOBAL graph invariant, not a
-    // per-node shape: two assets whose labels parse as `<prefix>__<LocalName>`
-    // emit the same term IRI, and a join "predicate → definition" then returns
-    // both. The shape engine cannot see this (it validates one focus node at a
-    // time), so the check runs over the loaded triples and its results are folded
-    // in as warnings — they raise warningCount but never flip `conforms`.
-    const collisionWarnings = detectTermIriCollisions(triples);
-    if (collisionWarnings.length > 0) {
-      report = {
-        ...report,
-        violations: [...report.violations, ...collisionWarnings],
-      };
-    }
+    const report = assembleShapesReport(rawReport, triples, stagedFilter);
 
     const qualifyNode = (focusNode: string): string => focusNode;
 
@@ -1093,9 +1102,23 @@ export async function runShapesModeAction(
     // (errors); `sh:Warning` are unresolvable cross-vault / symbolic / external
     // references that cannot be hard-failed under open-world semantics. Warnings
     // are reported with a dedicated counter but do NOT break the exit code.
-    const errorResults = report.violations.filter((v) => v.severity === "sh:Violation");
-    const warningResults = report.violations.filter((v) => v.severity !== "sh:Violation");
-    const crossVaultRefWarnings = warningResults.filter((v) => v.constraint === "class").length;
+    const errorResults = report.violations.filter(
+      (v) => v.severity === "sh:Violation",
+    );
+    const warningResults = report.violations.filter(
+      (v) => v.severity !== "sh:Violation",
+    );
+    const crossVaultRefWarnings = warningResults.filter(
+      (v) => v.constraint === "class",
+    ).length;
+    const collisionWarningCount = warningResults.filter(
+      (v) => v.constraint === "term-iri-collision",
+    ).length;
+    const collidingIris = new Set(
+      warningResults
+        .filter((v) => v.constraint === "term-iri-collision")
+        .map((v) => v.actualValue ?? ""),
+    );
 
     if (fmt === "earl") {
       const earl = buildEARLReport(vaultPath, report);
@@ -1111,6 +1134,7 @@ export async function runShapesModeAction(
         violationCount: errorResults.length,
         warningCount: warningResults.length,
         crossVaultRefWarnings,
+        termIriCollisionWarnings: collisionWarningCount,
         violations: errorResults.map(annotate),
         warnings: warningResults.map(annotate),
       });
@@ -1123,7 +1147,9 @@ export async function runShapesModeAction(
           existing.push(v);
           byNode.set(v.focusNode, existing);
         }
-        console.log(`⚠️  Found ${errorResults.length} SHACL violation(s) in ${byNode.size} node(s):\n`);
+        console.log(
+          `⚠️  Found ${errorResults.length} SHACL violation(s) in ${byNode.size} node(s):\n`,
+        );
         for (const [node, violations] of byNode) {
           console.log(`   ❌ ${node}`);
           for (const v of violations) {
@@ -1142,6 +1168,21 @@ export async function runShapesModeAction(
               : "") +
             ` — these do not affect the exit code.`,
         );
+        // req 00e8079e — name the colliding IRIs here. The point of the check is
+        // that the condition was previously INVISIBLE; reporting it only as a few
+        // extra units inside a several-hundred-warning aggregate would leave it
+        // just as invisible on the default surface. Detail lines above are printed
+        // for errors only, so warnings need their own breakdown.
+        if (collisionWarningCount > 0) {
+          console.log(
+            `   ⚠️  ${collidingIris.size} term-IRI collision(s) — one IRI emitted by several assets ` +
+              `(${collisionWarningCount} entr${collisionWarningCount === 1 ? "y" : "ies"}):`,
+          );
+          for (const iri of [...collidingIris].sort()) {
+            console.log(`      • ${iri}`);
+          }
+          console.log(`   Run with --format json for the emitting assets.`);
+        }
       }
     }
 
@@ -1159,16 +1200,76 @@ export async function runShapesModeAction(
  *
  * Issue #2713: Schema linter for frontmatter properties.
  */
+/**
+ * Assemble the final shapes report: shape-engine findings PLUS term-IRI collisions,
+ * then both report filters.
+ *
+ * ⛔ Ordering is the whole point of extracting this, and it is asserted by tests.
+ * Collisions are folded in BEFORE `applyLegacyExceptionFilter` and the staged
+ * filter, deliberately:
+ *   • the legacy-exception filter must be able to exempt a collision like any other
+ *     finding on that asset;
+ *   • `--staged` must scope collisions too. The per-emitter fan-out is what makes
+ *     that correct — a commit INTRODUCING a collision still surfaces (the staged
+ *     file is itself an emitter), while pre-existing collisions among untouched
+ *     files fall away, which is exactly what `--staged` advertises. Appending
+ *     AFTER the filters (the shape review measured this) made every commit in a
+ *     vault with old collisions carry warnings about unrelated files.
+ *
+ * Folding in early cannot flip `conforms`: both filters recompute it as
+ * `violations.every(v => v.severity !== "sh:Violation")`, and collisions are always
+ * `sh:Warning`.
+ *
+ * req `00e8079e-fb36-4ce3-b33f-abb18c212143`
+ */
+export function assembleShapesReport(
+  rawReport: ValidationReport,
+  triples: DomainTriple[],
+  stagedFilter: ReadonlySet<string> | null,
+): ValidationReport {
+  const collisionWarnings = detectTermIriCollisions(triples);
+  const withCollisions =
+    collisionWarnings.length > 0
+      ? {
+          ...rawReport,
+          violations: [...rawReport.violations, ...collisionWarnings],
+        }
+      : rawReport;
+
+  let report = applyLegacyExceptionFilter(triples, withCollisions);
+  if (stagedFilter) {
+    report = filterReportToStagedFocusNodes(report, stagedFilter);
+  }
+  return report;
+}
+
 export function validateSchemaCommand(): Command {
   return new Command("schema")
     .description("Check frontmatter properties against ontology (Issue #2713)")
     .option("--vault <path>", "Path to Obsidian vault", process.cwd())
-    .option("--output <type>", "Response format: text|json (for MCP tools)", "text")
-    .option("--staged", "Only validate git-staged .md files (for pre-commit hooks)")
+    .option(
+      "--output <type>",
+      "Response format: text|json (for MCP tools)",
+      "text",
+    )
+    .option(
+      "--staged",
+      "Only validate git-staged .md files (for pre-commit hooks)",
+    )
     .option("--use-cache", "Use persistent triple cache (faster vault loading)")
-    .option("--shapes-mode", "Run SHACL-lite shapes validation instead of schema linting")
-    .option("--format <type>", "Output format for shapes-mode: text|json|earl", "text")
-    .option("--class <iri>", "Only validate assets whose exo__Instance_class matches this IRI/slug (RFC 8e83442b T1.4)")
+    .option(
+      "--shapes-mode",
+      "Run SHACL-lite shapes validation instead of schema linting",
+    )
+    .option(
+      "--format <type>",
+      "Output format for shapes-mode: text|json|earl",
+      "text",
+    )
+    .option(
+      "--class <iri>",
+      "Only validate assets whose exo__Instance_class matches this IRI/slug (RFC 8e83442b T1.4)",
+    )
     .action(async (options: ValidateSchemaOptions) => {
       const outputFormat = (options.output || "text") as OutputFormat;
       ErrorHandler.setFormat(outputFormat);
@@ -1211,7 +1312,10 @@ export function validateSchemaCommand(): Command {
           const classFilter = options.class;
           targetFiles = targetFiles.filter((relPath) => {
             try {
-              const content = readFileSync(resolve(vaultPath, relPath), "utf-8");
+              const content = readFileSync(
+                resolve(vaultPath, relPath),
+                "utf-8",
+              );
               const fm = extractFrontmatter(content);
               return frontmatterMatchesClass(fm, classFilter);
             } catch {
@@ -1225,10 +1329,8 @@ export function validateSchemaCommand(): Command {
           console.log(`📦 Loading vault: ${vaultPath}...`);
         }
 
-        const { triples: loadedTriples, cacheHit } = await loadTriplesFromAllVaults(
-          vaultPath,
-          Boolean(options.useCache),
-        );
+        const { triples: loadedTriples, cacheHit } =
+          await loadTriplesFromAllVaults(vaultPath, Boolean(options.useCache));
         const triples: Triple[] = loadedTriples as Triple[];
         if (outputFormat === "text" && cacheHit) {
           console.log("🚀 Cache hit! Loading from persistent cache...");
@@ -1243,7 +1345,9 @@ export function validateSchemaCommand(): Command {
         const declaredPropertyURIs = await loadDeclaredProperties(triples);
 
         if (outputFormat === "text") {
-          console.log(`📋 Found ${declaredPropertyURIs.size} declared properties in ontology`);
+          console.log(
+            `📋 Found ${declaredPropertyURIs.size} declared properties in ontology`,
+          );
           console.log(`🔍 Validating ${targetFiles.length} file(s)...\n`);
         }
 
@@ -1251,7 +1355,11 @@ export function validateSchemaCommand(): Command {
         const allViolations: SchemaViolation[] = [];
         for (const relPath of targetFiles) {
           const fullPath = resolve(vaultPath, relPath);
-          const violations = validateFile(fullPath, relPath, declaredPropertyURIs);
+          const violations = validateFile(
+            fullPath,
+            relPath,
+            declaredPropertyURIs,
+          );
           allViolations.push(...violations);
         }
 
@@ -1268,7 +1376,9 @@ export function validateSchemaCommand(): Command {
           console.log(JSON.stringify(response, null, 2));
         } else {
           if (allViolations.length === 0) {
-            console.log(`✅ All ${targetFiles.length} file(s) pass schema validation.`);
+            console.log(
+              `✅ All ${targetFiles.length} file(s) pass schema validation.`,
+            );
           } else {
             // Group violations by file
             const byFile = new Map<string, SchemaViolation[]>();
@@ -1278,7 +1388,9 @@ export function validateSchemaCommand(): Command {
               byFile.set(v.file, existing);
             }
 
-            console.log(`⚠️  Found ${allViolations.length} schema violation(s) in ${byFile.size} file(s):\n`);
+            console.log(
+              `⚠️  Found ${allViolations.length} schema violation(s) in ${byFile.size} file(s):\n`,
+            );
             for (const [file, violations] of byFile) {
               console.log(`   ❌ ${file}`);
               for (const v of violations) {
@@ -1287,7 +1399,9 @@ export function validateSchemaCommand(): Command {
             }
             console.log("\n📝 To fix these issues:");
             console.log("   - Remove undeclared properties from frontmatter");
-            console.log("   - Or declare them in the ontology as Property instances");
+            console.log(
+              "   - Or declare them in the ontology as Property instances",
+            );
           }
         }
 

--- a/packages/cli/src/commands/validate-schema.ts
+++ b/packages/cli/src/commands/validate-schema.ts
@@ -23,6 +23,7 @@ import {
 } from "@kitelev/exocortex-core";
 import { FileSystemVaultAdapter } from "../adapters/FileSystemVaultAdapter.js";
 import { ErrorHandler, type OutputFormat } from "../utils/ErrorHandler.js";
+import { detectTermIriCollisions } from "../services/termIriCollisions.js";
 import { VaultNotFoundError } from "../utils/errors/index.js";
 import { ResponseBuilder } from "../responses/index.js";
 import { CacheManager } from "../cache/CacheManager.js";
@@ -1070,6 +1071,20 @@ export async function runShapesModeAction(
     let report = applyLegacyExceptionFilter(triples, rawReport);
     if (stagedFilter) {
       report = filterReportToStagedFocusNodes(report, stagedFilter);
+    }
+
+    // req 00e8079e — term-IRI collisions are a GLOBAL graph invariant, not a
+    // per-node shape: two assets whose labels parse as `<prefix>__<LocalName>`
+    // emit the same term IRI, and a join "predicate → definition" then returns
+    // both. The shape engine cannot see this (it validates one focus node at a
+    // time), so the check runs over the loaded triples and its results are folded
+    // in as warnings — they raise warningCount but never flip `conforms`.
+    const collisionWarnings = detectTermIriCollisions(triples);
+    if (collisionWarnings.length > 0) {
+      report = {
+        ...report,
+        violations: [...report.violations, ...collisionWarnings],
+      };
     }
 
     const qualifyNode = (focusNode: string): string => focusNode;

--- a/packages/cli/src/services/termIriCollisions.ts
+++ b/packages/cli/src/services/termIriCollisions.ts
@@ -1,0 +1,83 @@
+import {
+  DomainIRI,
+  Namespace,
+  type Triple,
+  type Violation,
+} from "@kitelev/exocortex-core";
+
+/**
+ * Detect **term-IRI collisions**: two or more assets emitting the SAME term IRI.
+ *
+ * An asset whose `exo__Asset_label` parses as `<prefix>__<LocalName>` is emitted
+ * into the graph as a **term IRI**, not as a literal (see `Namespace.fromPropertyKey`
+ * → `Namespace.term`). When two assets carry the same such label they emit the
+ * same IRI, and every join "predicate → its definition" then yields BOTH — the
+ * graph can no longer say which asset defines the term.
+ *
+ * Measured on the live vaults (2026-08-17): a reified statement whose
+ * `exo__Statement_predicate` is `http://www.w3.org/2002/07/owl#sameAs` resolves to
+ * two definitions at once — an `exo__ObjectProperty` and a `concept__Concept` that
+ * happen to share the label. Nothing reported this; `audit-ontology-imports`
+ * quietly WORKS AROUND it by grouping on UID instead ("labels have had duplicates
+ * — R12"), so the condition was known, routed around, and invisible.
+ *
+ * ⛔ Only IRI-valued labels count. Plain literal labels are duplicated legitimately
+ * and en masse — the same measurement found **214** distinct literal labels shared
+ * by more than one asset (`Initiative`, `Idea`, `Area`, `Bug`, `OKR`, …). Reporting
+ * those would bury the three real collisions under 214 lines of noise, so the
+ * `instanceof DomainIRI` filter is load-bearing, not incidental.
+ *
+ * Severity is `sh:Warning`, never `sh:Violation`: three collisions already exist in
+ * the live vaults and must not turn `conforms` false the moment this ships
+ * (founder's call, 2026-08-17). The check makes them visible; deciding each case
+ * (genuine duplicate vs. homonym across classes) is separate work.
+ *
+ * req `00e8079e-fb36-4ce3-b33f-abb18c212143`
+ */
+export function detectTermIriCollisions(
+  triples: readonly Triple[],
+): Violation[] {
+  const labelPredicate = Namespace.EXO.term("Asset_label").value;
+
+  // term IRI -> the subjects emitting it (Set: one asset stating the same label
+  // twice is not a collision).
+  const emitters = new Map<string, Set<string>>();
+
+  for (const triple of triples) {
+    if (triple.predicate.value !== labelPredicate) continue;
+    if (!(triple.object instanceof DomainIRI)) continue;
+    // `Subject` is IRI | BlankNode; only an IRI subject is an addressable asset,
+    // and a blank node could not be reported to a reader anyway.
+    if (!(triple.subject instanceof DomainIRI)) continue;
+
+    const iri = triple.object.value;
+    let subjects = emitters.get(iri);
+    if (!subjects) {
+      subjects = new Set<string>();
+      emitters.set(iri, subjects);
+    }
+    subjects.add(triple.subject.value);
+  }
+
+  const violations: Violation[] = [];
+  for (const [iri, subjects] of emitters) {
+    if (subjects.size < 2) continue;
+    const sorted = [...subjects].sort();
+    for (const focusNode of sorted) {
+      const others = sorted.filter((s) => s !== focusNode);
+      violations.push({
+        focusNode,
+        propertyPath: labelPredicate,
+        severity: "sh:Warning",
+        message:
+          `term-IRI collision: <${iri}> is emitted by ${sorted.length} assets — ` +
+          `a join from a predicate to its definition resolves to all of them. ` +
+          `Also emitted by: ${others.join(", ")}`,
+        constraint: "term-iri-collision",
+        actualValue: iri,
+      });
+    }
+  }
+
+  return violations;
+}

--- a/packages/cli/src/services/termIriCollisions.ts
+++ b/packages/cli/src/services/termIriCollisions.ts
@@ -30,8 +30,11 @@ import {
  * by more than one asset (`Initiative`, `Idea`, `Area`, `Bug`, `OKR`, …). Reporting
  * those would bury the real collisions under 214 lines of noise. ⛔ But `instanceof
  * DomainIRI` alone is NOT sufficient (see the comment at the filter): the actual
- * discriminator is `Namespace.fromTermIRI`, and both halves are load-bearing —
- * dropping either has its own reddening axis.
+ * discriminator is `Namespace.fromTermIRI`. Both halves are load-bearing and each
+ * now HAS its own reddening axis — the literal-text-that-looks-like-an-IRI fixture
+ * pins `instanceof`, the file-IRI fixtures pin `fromTermIRI`. ⚠ That sentence was
+ * asserted here before either axis existed, and review measured that dropping
+ * `instanceof` reddened nothing; the fixture was added in response.
  *
  * Severity is `sh:Warning`, never `sh:Violation`: three collisions already exist in
  * the live vaults and must not turn `conforms` false the moment this ships
@@ -70,11 +73,18 @@ export function detectTermIriCollisions(
     // ⛔ `instanceof DomainIRI` is NOT the "is a term IRI" test. A label written
     // as a wikilink (`exo__Asset_label: "[[<uid>]]"`) is emitted by the converter
     // as the TARGET'S FILE IRI (`obsidian://vault/…/<uid>.md`) — also a DomainIRI,
-    // and three assets in the live vault do exactly this. Such an IRI is never a
-    // predicate, so the message below ("a join from a predicate to its definition
-    // resolves to all of them") would be false for them. `Namespace.fromTermIRI`
-    // is the documented inverse of the forward path `fromPropertyKey` → `term`,
-    // so it accepts exactly the IRIs that path can produce and nothing else.
+    // and three assets in the live vault do exactly this. That particular IRI is
+    // used as a predicate 0 times, so the message below ("a join from a predicate
+    // to its definition resolves to all of them") would be false for it.
+    // ⚠ Do NOT generalise that to "file IRIs are never predicates" — they can be.
+    // Measured: `adapter-exo-ims__relatesToConcept` has a hyphenated prefix, which
+    // `Namespace.forPrefix` rejects (`^[a-z][a-zA-Z0-9]*$`), so it never gets a term
+    // IRI and is used by FILE IRI in the predicate slot 64× (vault-my) / 102×
+    // (vault-exodev). The guard is therefore justified by that one IRI's measured
+    // 0 predicate uses, not by an invariant about file IRIs.
+    // `Namespace.fromTermIRI` is the documented inverse of the forward path
+    // `fromPropertyKey` → `term`, so it accepts exactly the IRIs that path can
+    // produce and nothing else.
     if (Namespace.fromTermIRI(triple.object.value) === null) continue;
 
     const iri = triple.object.value;

--- a/packages/cli/src/services/termIriCollisions.ts
+++ b/packages/cli/src/services/termIriCollisions.ts
@@ -1,4 +1,5 @@
 import {
+  DomainBlankNode,
   DomainIRI,
   Namespace,
   type Triple,
@@ -83,8 +84,16 @@ export function detectTermIriCollisions(
     // (vault-exodev). The guard is therefore justified by that one IRI's measured
     // 0 predicate uses, not by an invariant about file IRIs.
     // `Namespace.fromTermIRI` is the documented inverse of the forward path
-    // `fromPropertyKey` → `term`, so it accepts exactly the IRIs that path can
-    // produce and nothing else.
+    // `fromPropertyKey` → `term`. ⛔ It is NOT an exact inverse, and claiming so
+    // here was false (review round 3, probe P3): `Namespace.term()` will mint an
+    // IRI for a local name containing `/` or `#` (label `exo__Asset/Sub` →
+    // `…/exo#Asset/Sub`), while `fromTermIRI` rejects those by design — its own
+    // docstring says the narrowing "is reachable by construction". So this guard
+    // has a small FALSE-NEGATIVE class: a collision on such a label goes
+    // unreported. Accepted deliberately — widening the inverse to admit `/` and
+    // `#` would make the local-name boundary ambiguous, which is the reason the
+    // narrowing exists. What the guard does guarantee is the direction that
+    // matters here: nothing it accepts is a file IRI or a literal.
     if (Namespace.fromTermIRI(triple.object.value) === null) continue;
 
     const iri = triple.object.value;
@@ -93,15 +102,33 @@ export function detectTermIriCollisions(
       subjects = new Set<string>();
       emitters.set(iri, subjects);
     }
-    // `Subject` is IRI | BlankNode. A blank node is kept in the COUNT (it is a
-    // genuine second emitter and its presence is what makes the term ambiguous)
-    // but cannot be a focusNode a reader could open — it is skipped at render
-    // time below. Filtering it here instead would suppress the report for the
-    // addressable half too.
+    // `Subject` is IRI | BlankNode | QuotedTriple, and the three carry their
+    // identity under DIFFERENT accessors: `IRI.value`, `BlankNode.id`,
+    // `QuotedTriple.toString()`. ⛔ Reading `.value` off the non-IRI branch (as
+    // this did until review round 3) type-errors AND collapses every blank
+    // emitter to one key, so N distinct blank nodes rendered as a single
+    // `_:blank` and the reported emitter count was wrong. The fixture hid it by
+    // faking the node as `{ value }` — a shape the real class does not have
+    // (test-fixture-realism). The axis below now uses a real `BlankNode`.
+    //
+    // A blank node is kept in the COUNT (it is a genuine second emitter and its
+    // presence is what makes the term ambiguous) but cannot be a focusNode a
+    // reader could open — it is skipped at render time below. Filtering it here
+    // instead would suppress the report for the addressable half too.
+    // ⚠ The third branch (QuotedTriple, RDF-star) has NO axis, and cannot have
+    // one from this package: `QuotedTriple` is not re-exported from the core
+    // barrel (verified — `grep QuotedTriple packages/core/src/index.ts` is
+    // empty), so a test here cannot construct one. It is handled rather than
+    // dropped because the `Subject` union admits it; `toString()` is its only
+    // stable identity. Stated explicitly so a later reader reads this as a
+    // measured gap, not a forgotten axis.
+    const subject = triple.subject;
     subjects.add(
-      triple.subject instanceof DomainIRI
-        ? triple.subject.value
-        : `_:${String(triple.subject.value ?? "blank")}`,
+      subject instanceof DomainIRI
+        ? subject.value
+        : subject instanceof DomainBlankNode
+          ? `_:${subject.id}`
+          : `<<${String(subject)}>>`,
     );
   }
 
@@ -110,8 +137,9 @@ export function detectTermIriCollisions(
     if (subjects.size < 2) continue;
     const sorted = [...subjects].sort();
     for (const focusNode of sorted) {
-      // Blank nodes are counted above but cannot anchor a report entry.
-      if (focusNode.startsWith("_:")) continue;
+      // Blank nodes and quoted triples are counted above but cannot anchor a
+      // report entry — a reader cannot open them.
+      if (focusNode.startsWith("_:") || focusNode.startsWith("<<")) continue;
       const others = sorted.filter((s) => s !== focusNode);
       violations.push({
         focusNode,

--- a/packages/cli/src/services/termIriCollisions.ts
+++ b/packages/cli/src/services/termIriCollisions.ts
@@ -1,5 +1,4 @@
 import {
-  DomainBlankNode,
   DomainIRI,
   Namespace,
   type Triple,
@@ -115,21 +114,27 @@ export function detectTermIriCollisions(
     // presence is what makes the term ambiguous) but cannot be a focusNode a
     // reader could open — it is skipped at render time below. Filtering it here
     // instead would suppress the report for the addressable half too.
-    // ⚠ The third branch (QuotedTriple, RDF-star) has NO axis, and cannot have
-    // one from this package: `QuotedTriple` is not re-exported from the core
-    // barrel (verified — `grep QuotedTriple packages/core/src/index.ts` is
-    // empty), so a test here cannot construct one. It is handled rather than
-    // dropped because the `Subject` union admits it; `toString()` is its only
-    // stable identity. Stated explicitly so a later reader reads this as a
-    // measured gap, not a forgotten axis.
+    // Non-IRI subjects key on `toString()`, which each class already defines in
+    // its canonical form: `BlankNode` → `_:${id}`, `QuotedTriple` → `<< … >>`
+    // (both measured by execution, not read). That is why two branches suffice
+    // and no per-class accessor is needed.
+    //
+    // ⛔ History, because both mistakes are instructive. (1) This read
+    // `subject.value` on the non-IRI branch — a property `BlankNode` does not
+    // have — so every blank emitter collapsed to one key and the reported count
+    // was wrong; the fixture hid it by faking the node as `{ value }`. (2) The
+    // replacement then hand-rolled `_:${id}` and wrapped the quoted form in
+    // literal `<<…>>` — but `QuotedTriple.toString()` ALREADY returns `<< … >>`,
+    // so that produced `<<<< … >>>>`. Alongside it stood the claim that a
+    // QuotedTriple axis "cannot exist in this package because QuotedTriple is
+    // not re-exported from the core barrel", justified by a grep of
+    // `packages/core/src/index.ts`. The grep was true and measured the wrong
+    // thing: that barrel does `export * from "./domain/models/rdf"`, which
+    // re-exports it. A probe imported and constructed one in this package on the
+    // first try. ⇒ before writing "X cannot be done", RUN the thing that would
+    // do X. The axis that claim said was impossible is now below.
     const subject = triple.subject;
-    subjects.add(
-      subject instanceof DomainIRI
-        ? subject.value
-        : subject instanceof DomainBlankNode
-          ? `_:${subject.id}`
-          : `<<${String(subject)}>>`,
-    );
+    subjects.add(subject instanceof DomainIRI ? subject.value : String(subject));
   }
 
   const violations: Violation[] = [];

--- a/packages/cli/src/services/termIriCollisions.ts
+++ b/packages/cli/src/services/termIriCollisions.ts
@@ -18,19 +18,40 @@ import {
  * `exo__Statement_predicate` is `http://www.w3.org/2002/07/owl#sameAs` resolves to
  * two definitions at once — an `exo__ObjectProperty` and a `concept__Concept` that
  * happen to share the label. Nothing reported this; `audit-ontology-imports`
- * quietly WORKS AROUND it by grouping on UID instead ("labels have had duplicates
- * — R12"), so the condition was known, routed around, and invisible.
+ * quietly WORKS AROUND it by grouping on UID instead — the comment at
+ * `audit-ontology-imports.ts:871` reads verbatim "UID is the grouping key (labels
+ * have had duplicates — R12)". (Quote verified against origin/main; the "R12"
+ * identifier itself is defined nowhere in the repo, so treat it as an unresolved
+ * reference rather than a citation a reader can follow.) The condition was known,
+ * routed around, and invisible.
  *
  * ⛔ Only IRI-valued labels count. Plain literal labels are duplicated legitimately
  * and en masse — the same measurement found **214** distinct literal labels shared
  * by more than one asset (`Initiative`, `Idea`, `Area`, `Bug`, `OKR`, …). Reporting
- * those would bury the three real collisions under 214 lines of noise, so the
- * `instanceof DomainIRI` filter is load-bearing, not incidental.
+ * those would bury the real collisions under 214 lines of noise. ⛔ But `instanceof
+ * DomainIRI` alone is NOT sufficient (see the comment at the filter): the actual
+ * discriminator is `Namespace.fromTermIRI`, and both halves are load-bearing —
+ * dropping either has its own reddening axis.
  *
  * Severity is `sh:Warning`, never `sh:Violation`: three collisions already exist in
  * the live vaults and must not turn `conforms` false the moment this ships
  * (founder's call, 2026-08-17). The check makes them visible; deciding each case
  * (genuine duplicate vs. homonym across classes) is separate work.
+ *
+ * ⚠ SCOPE, measured — this finds AMBIGUOUS definitions, not MISSING ones. An asset
+ * with no `exo__Asset_label` key gets a synthesised `Literal(file.basename)`
+ * (`NoteToRDFConverter.ts:454`), so a class file named `kitelev__ReadArticleTask.md`
+ * emits its label as a LITERAL even though the name parses. Live consequence in
+ * vault-my: that term has 2 uses as an IRI in the graph and **0** definitions
+ * reachable by `?def exo:Asset_label <term>`. A second asset declaring the same
+ * label in frontmatter would create exactly the ambiguity hunted here and stay
+ * silent (one IRI emitter, one Literal emitter). The mirror defect — zero
+ * definitions — is arguably more common and is deliberately out of scope.
+ *
+ * ⚠ CLI-only by design (UI/CLI parity #3417 noted, not met): the plugin's
+ * `PluginVaultCheckReader` and core's `shaclCheck` do not run this. It is wired
+ * into `validate schema` because that is the surface the vault-mutation floor
+ * already runs after every change; a plugin-side equivalent is separate work.
  *
  * req `00e8079e-fb36-4ce3-b33f-abb18c212143`
  */
@@ -46,9 +67,15 @@ export function detectTermIriCollisions(
   for (const triple of triples) {
     if (triple.predicate.value !== labelPredicate) continue;
     if (!(triple.object instanceof DomainIRI)) continue;
-    // `Subject` is IRI | BlankNode; only an IRI subject is an addressable asset,
-    // and a blank node could not be reported to a reader anyway.
-    if (!(triple.subject instanceof DomainIRI)) continue;
+    // ⛔ `instanceof DomainIRI` is NOT the "is a term IRI" test. A label written
+    // as a wikilink (`exo__Asset_label: "[[<uid>]]"`) is emitted by the converter
+    // as the TARGET'S FILE IRI (`obsidian://vault/…/<uid>.md`) — also a DomainIRI,
+    // and three assets in the live vault do exactly this. Such an IRI is never a
+    // predicate, so the message below ("a join from a predicate to its definition
+    // resolves to all of them") would be false for them. `Namespace.fromTermIRI`
+    // is the documented inverse of the forward path `fromPropertyKey` → `term`,
+    // so it accepts exactly the IRIs that path can produce and nothing else.
+    if (Namespace.fromTermIRI(triple.object.value) === null) continue;
 
     const iri = triple.object.value;
     let subjects = emitters.get(iri);
@@ -56,7 +83,16 @@ export function detectTermIriCollisions(
       subjects = new Set<string>();
       emitters.set(iri, subjects);
     }
-    subjects.add(triple.subject.value);
+    // `Subject` is IRI | BlankNode. A blank node is kept in the COUNT (it is a
+    // genuine second emitter and its presence is what makes the term ambiguous)
+    // but cannot be a focusNode a reader could open — it is skipped at render
+    // time below. Filtering it here instead would suppress the report for the
+    // addressable half too.
+    subjects.add(
+      triple.subject instanceof DomainIRI
+        ? triple.subject.value
+        : `_:${String(triple.subject.value ?? "blank")}`,
+    );
   }
 
   const violations: Violation[] = [];
@@ -64,6 +100,8 @@ export function detectTermIriCollisions(
     if (subjects.size < 2) continue;
     const sorted = [...subjects].sort();
     for (const focusNode of sorted) {
+      // Blank nodes are counted above but cannot anchor a report entry.
+      if (focusNode.startsWith("_:")) continue;
       const others = sorted.filter((s) => s !== focusNode);
       violations.push({
         focusNode,

--- a/packages/cli/tests/unit/commands/validate-schema.test.ts
+++ b/packages/cli/tests/unit/commands/validate-schema.test.ts
@@ -21,8 +21,19 @@ jest.unstable_mockModule("@kitelev/exocortex-core", () => ({
   // link needs this export too (see the note above about named exports).
   Namespace: {
     EXO: { term: (local: string) => ({ value: `https://exocortex.my/ontology/exo#${local}` }) },
+    // ⛔ `fromTermIRI` is stubbed too, not just `EXO.term`: termIriCollisions
+    // calls BOTH. Omitting it (the shape until review round 3) is latent only
+    // while no fixture here feeds an IRI-valued `exo__Asset_label` — the first
+    // one that does fails with `Namespace.fromTermIRI is not a function`, far
+    // from its cause. Mirrors the real contract's DIRECTION: term IRIs in,
+    // file IRIs and other schemes out.
+    fromTermIRI: (iri: string) => {
+      const m = /^(https?:\/\/[^#]*[#/])([^#/]+)$/.exec(iri);
+      return m ? { namespace: { iri: { value: m[1] } }, localName: m[2] } : null;
+    },
   },
   DomainIRI: class { constructor(public value: string) {} },
+  DomainBlankNode: class { constructor(public id: string) {} },
   DomainLiteral: class { constructor(public value: string) {} },
   DomainTriple: class {
     constructor(public subject: unknown, public predicate: unknown, public object: unknown) {}

--- a/packages/cli/tests/unit/commands/validate-schema.test.ts
+++ b/packages/cli/tests/unit/commands/validate-schema.test.ts
@@ -16,6 +16,12 @@ jest.unstable_mockModule("@kitelev/exocortex-core", () => ({
   ShapeLoader: { loadFromVaultFS: jest.fn().mockResolvedValue({ getAll: jest.fn().mockReturnValue([]) }) },
   ShaclShapeRegistry: jest.fn().mockImplementation(() => ({})),
   shaclValidate: jest.fn().mockReturnValue({ conforms: true, violations: [] }),
+  // req 00e8079e — termIriCollisions (reached via validate-schema) resolves the
+  // label predicate through Namespace rather than hardcoding the IRI, so the ESM
+  // link needs this export too (see the note above about named exports).
+  Namespace: {
+    EXO: { term: (local: string) => ({ value: `https://exocortex.my/ontology/exo#${local}` }) },
+  },
   DomainIRI: class { constructor(public value: string) {} },
   DomainLiteral: class { constructor(public value: string) {} },
   DomainTriple: class {

--- a/packages/cli/tests/unit/commands/validate.test.ts
+++ b/packages/cli/tests/unit/commands/validate.test.ts
@@ -26,6 +26,12 @@ jest.unstable_mockModule("@kitelev/exocortex-core", () => ({
   ShapeLoader: { loadFromVaultFS: jest.fn().mockResolvedValue({ getAll: jest.fn().mockReturnValue([]) }) },
   ShaclShapeRegistry: jest.fn().mockImplementation(() => ({})),
   shaclValidate: jest.fn().mockReturnValue({ conforms: true, violations: [] }),
+  // req 00e8079e — termIriCollisions (reached via validate-schema) resolves the
+  // label predicate through Namespace rather than hardcoding the IRI, so the ESM
+  // link needs this export too (see the note above about named exports).
+  Namespace: {
+    EXO: { term: (local: string) => ({ value: `https://exocortex.my/ontology/exo#${local}` }) },
+  },
   DomainIRI: class { constructor(public value: string) {} },
   DomainLiteral: class { constructor(public value: string) {} },
   DomainTriple: jest.fn(),

--- a/packages/cli/tests/unit/commands/validate.test.ts
+++ b/packages/cli/tests/unit/commands/validate.test.ts
@@ -31,8 +31,15 @@ jest.unstable_mockModule("@kitelev/exocortex-core", () => ({
   // link needs this export too (see the note above about named exports).
   Namespace: {
     EXO: { term: (local: string) => ({ value: `https://exocortex.my/ontology/exo#${local}` }) },
+    // ⛔ See the sibling note in validate-schema.test.ts: termIriCollisions calls
+    // `fromTermIRI` as well as `EXO.term`, and omitting it fails far from cause.
+    fromTermIRI: (iri: string) => {
+      const m = /^(https?:\/\/[^#]*[#/])([^#/]+)$/.exec(iri);
+      return m ? { namespace: { iri: { value: m[1] } }, localName: m[2] } : null;
+    },
   },
   DomainIRI: class { constructor(public value: string) {} },
+  DomainBlankNode: class { constructor(public id: string) {} },
   DomainLiteral: class { constructor(public value: string) {} },
   DomainTriple: jest.fn(),
   // M1.5: the `validate vault` subcommand pulls validate-vault.ts →

--- a/packages/cli/tests/unit/services/termIriCollisions.test.ts
+++ b/packages/cli/tests/unit/services/termIriCollisions.test.ts
@@ -1,0 +1,138 @@
+import {
+  DomainIRI as IRI,
+  DomainLiteral as Literal,
+  Namespace,
+  DomainTriple as Triple,
+  type Violation,
+} from "@kitelev/exocortex-core";
+import { detectTermIriCollisions } from "../../../src/services/termIriCollisions.js";
+
+const REQ = "@req:00e8079e-fb36-4ce3-b33f-abb18c212143";
+
+const LABEL = Namespace.EXO.term("Asset_label").value;
+
+const asset = (uid: string): IRI =>
+  new IRI(`obsidian://vault/assetspaces/kitelev/exoas-x/x/${uid}.md`);
+
+/** `<asset> exo:Asset_label <term-iri>` — the shape a parseable label emits. */
+const labelledWithIri = (uid: string, termIri: string): Triple =>
+  new Triple(asset(uid), new IRI(LABEL), new IRI(termIri));
+
+/** `<asset> exo:Asset_label "text"` — the shape a plain human label emits. */
+const labelledWithLiteral = (uid: string, text: string): Triple =>
+  new Triple(asset(uid), new IRI(LABEL), new Literal(text));
+
+const iris = (vs: Violation[]): string[] =>
+  [...new Set(vs.map((v) => v.actualValue ?? ""))].sort();
+
+describe("detectTermIriCollisions", () => {
+  const OWL_SAME_AS = "http://www.w3.org/2002/07/owl#sameAs";
+
+  it(`${REQ} reports a term IRI emitted by two assets, naming both`, () => {
+    // The live case this was written for: an exo__ObjectProperty and a
+    // concept__Concept sharing the label `owl__sameAs`.
+    const found = detectTermIriCollisions([
+      labelledWithIri("9d2128de", OWL_SAME_AS),
+      labelledWithIri("3c6240a5", OWL_SAME_AS),
+    ]);
+
+    expect(iris(found)).toEqual([OWL_SAME_AS]);
+    // one entry per emitter, so whichever asset a reader opens, the report is there
+    expect(found).toHaveLength(2);
+    expect(found.map((v) => v.focusNode).sort()).toEqual([
+      asset("3c6240a5").value,
+      asset("9d2128de").value,
+    ]);
+    // each entry names the OTHER emitter — that is what makes it actionable
+    const forFirst = found.find(
+      (v) => v.focusNode === asset("9d2128de").value,
+    )!;
+    expect(forFirst.message).toContain("3c6240a5");
+    expect(forFirst.message).not.toContain("9d2128de.md,"); // not listed against itself
+  });
+
+  it(`${REQ} classifies collisions as sh:Warning so conforms is never flipped`, () => {
+    const found = detectTermIriCollisions([
+      labelledWithIri("a", OWL_SAME_AS),
+      labelledWithIri("b", OWL_SAME_AS),
+    ]);
+
+    expect(found.length).toBeGreaterThan(0);
+    for (const v of found) {
+      expect(v.severity).toBe("sh:Warning");
+      expect(v.severity).not.toBe("sh:Violation");
+      expect(v.constraint).toBe("term-iri-collision");
+    }
+  });
+
+  it(`${REQ} stays silent when a term IRI has exactly one emitter`, () => {
+    const found = detectTermIriCollisions([
+      labelledWithIri(
+        "only",
+        "http://www.w3.org/2000/01/rdf-schema#subClassOf",
+      ),
+      labelledWithIri("other", OWL_SAME_AS),
+    ]);
+
+    expect(found).toEqual([]);
+  });
+
+  /**
+   * ⛔ NEGATIVE CONTROL, and the reason the `instanceof IRI` filter exists.
+   * Plain literal labels repeat legitimately and en masse — the live measurement
+   * found 214 distinct literal labels shared by more than one asset. If this axis
+   * ever goes green while the detector reports literals, the check has become
+   * noise rather than a signal.
+   */
+  it(`${REQ} does NOT report duplicated PLAIN labels (214 such labels exist live)`, () => {
+    const found = detectTermIriCollisions([
+      labelledWithLiteral("x1", "Initiative"),
+      labelledWithLiteral("x2", "Initiative"),
+      labelledWithLiteral("x3", "OKR"),
+      labelledWithLiteral("x4", "OKR"),
+      labelledWithLiteral("x5", "OKR"),
+    ]);
+
+    expect(found).toEqual([]);
+  });
+
+  it(`${REQ} ignores predicates other than exo__Asset_label`, () => {
+    const otherPredicate = Namespace.EXO.term("Asset_relates").value;
+    const found = detectTermIriCollisions([
+      new Triple(asset("p"), new IRI(otherPredicate), new IRI(OWL_SAME_AS)),
+      new Triple(asset("q"), new IRI(otherPredicate), new IRI(OWL_SAME_AS)),
+    ]);
+
+    expect(found).toEqual([]);
+  });
+
+  it(`${REQ} treats one asset restating the same label as a single emitter`, () => {
+    // A duplicated triple is not two assets — de-duplication is on the SUBJECT.
+    const found = detectTermIriCollisions([
+      labelledWithIri("same", OWL_SAME_AS),
+      labelledWithIri("same", OWL_SAME_AS),
+    ]);
+
+    expect(found).toEqual([]);
+  });
+
+  it(`${REQ} reports every colliding IRI, not just the first`, () => {
+    const LIT_URL = "https://exocortex.my/ontology/lit#WebPage_url";
+    const found = detectTermIriCollisions([
+      labelledWithIri("a", OWL_SAME_AS),
+      labelledWithIri("b", OWL_SAME_AS),
+      labelledWithIri("c", LIT_URL),
+      labelledWithIri("d", LIT_URL),
+      labelledWithIri(
+        "solo",
+        "https://exocortex.my/ontology/ems#Effort_status",
+      ),
+    ]);
+
+    expect(iris(found)).toEqual([OWL_SAME_AS, LIT_URL].sort());
+  });
+
+  it(`${REQ} returns nothing for an empty graph`, () => {
+    expect(detectTermIriCollisions([])).toEqual([]);
+  });
+});

--- a/packages/cli/tests/unit/services/termIriCollisions.test.ts
+++ b/packages/cli/tests/unit/services/termIriCollisions.test.ts
@@ -3,6 +3,7 @@ import {
   DomainIRI as IRI,
   DomainLiteral as Literal,
   Namespace,
+  QuotedTriple,
   DomainTriple as Triple,
   type Violation,
 } from "@kitelev/exocortex-core";
@@ -226,6 +227,42 @@ describe("detectTermIriCollisions", () => {
     expect(found[0]!.message).toContain("3 assets");
     expect(found[0]!.message).toContain("_:b1");
     expect(found[0]!.message).toContain("_:b2");
+  });
+
+  /**
+   * ⛔ The axis a comment here once declared impossible. It claimed a QuotedTriple
+   * emitter could not be exercised from this package because `QuotedTriple` is
+   * "not re-exported from the core barrel" — justified by grepping
+   * `packages/core/src/index.ts`, which is true and measures the wrong thing:
+   * that barrel does `export * from "./domain/models/rdf"`. Importing and
+   * constructing one worked on the first attempt.
+   *
+   * Pins two things at once: the quoted subject is keyed by its own `toString()`
+   * (so two DIFFERENT quoted triples count as two emitters, not one), and the
+   * render skip covers `<<` as well as `_:` — the report must not anchor an
+   * entry on a node a reader cannot open. Also pins the rendered form itself:
+   * `toString()` already yields `<< … >>`, so wrapping it again (as the first
+   * fix did) would produce `<<<< … >>>>`.
+   */
+  it(`${REQ} counts QuotedTriple emitters distinctly but never anchors an entry on one`, () => {
+    const quoted = (n: string) =>
+      new QuotedTriple(
+        new IRI(`obsidian://vault/s-${n}.md`),
+        new IRI("http://example.org/p"),
+        new IRI(`obsidian://vault/o-${n}.md`),
+      );
+    const found = detectTermIriCollisions([
+      labelledWithIri("addressable", OWL_SAME_AS),
+      new Triple(quoted("one"), new IRI(LABEL), new IRI(OWL_SAME_AS)),
+      new Triple(quoted("two"), new IRI(LABEL), new IRI(OWL_SAME_AS)),
+    ]);
+
+    expect(found).toHaveLength(1);
+    expect(found[0]!.focusNode).toBe(asset("addressable").value);
+    expect(found[0]!.message).toContain("3 assets");
+    // `<< …` not `<<<< …` — the class stringifies itself, we must not re-wrap.
+    expect(found[0]!.message).toContain("<< <obsidian://vault/s-one.md>");
+    expect(found[0]!.message).not.toContain("<<<<");
   });
 
   /**

--- a/packages/cli/tests/unit/services/termIriCollisions.test.ts
+++ b/packages/cli/tests/unit/services/termIriCollisions.test.ts
@@ -1,4 +1,5 @@
 import {
+  DomainBlankNode as BlankNode,
   DomainIRI as IRI,
   DomainLiteral as Literal,
   Namespace,
@@ -104,11 +105,17 @@ describe("detectTermIriCollisions", () => {
   });
 
   /**
-   * ⛔ NEGATIVE CONTROL, and the reason the `instanceof IRI` filter exists.
-   * Plain literal labels repeat legitimately and en masse — the live measurement
-   * found 214 distinct literal labels shared by more than one asset. If this axis
-   * ever goes green while the detector reports literals, the check has become
-   * noise rather than a signal.
+   * ⛔ NEGATIVE CONTROL. Plain literal labels repeat legitimately and en masse —
+   * the live measurement found 214 distinct literal labels shared by more than
+   * one asset. If this axis ever goes green while the detector reports literals,
+   * the check has become noise rather than a signal.
+   *
+   * ⚠ This axis is DEFENCE IN DEPTH, not the pin for `instanceof IRI` — the
+   * claim that it was (asserted here until review round 3) is false: it stays
+   * green under BOTH mutants, because either guard alone rejects a literal. The
+   * pin for `instanceof` is the "literal text that LOOKS like a term IRI" axis
+   * below; the pin for `fromTermIRI` is the file-IRI axis. Measured: dropping
+   * `instanceof` reds exactly one axis, and it is not this one.
    */
   it(`${REQ} does NOT report duplicated PLAIN labels (214 such labels exist live)`, () => {
     const found = detectTermIriCollisions([
@@ -197,17 +204,69 @@ describe("detectTermIriCollisions", () => {
    * but it cannot anchor an entry a reader could open. Filtering it out before
    * counting (the earlier shape) suppressed the report for the addressable asset
    * too, which is the half that is actionable.
+   *
+   * ⛔ Uses a REAL `BlankNode`. The earlier fixture faked it as
+   * `{ value: "b0" } as unknown as IRI` — a shape the real class does not have
+   * (`BlankNode` exposes `.id`, not `.value`), so the axis could not observe
+   * production behaviour and the detector's `.value` read shipped through two
+   * review rounds: every blank emitter collapsed to the single key `_:blank`.
+   * TWO blank nodes below, deliberately — one cannot distinguish "keyed by id"
+   * from "all blanks share one key" (test-fixture-realism).
    */
-  it(`${REQ} counts a blank-node co-emitter but reports only the addressable one`, () => {
-    const blank = { value: "b0" } as unknown as IRI; // not a DomainIRI instance
+  it(`${REQ} counts blank-node co-emitters DISTINCTLY but reports only the addressable one`, () => {
     const found = detectTermIriCollisions([
       labelledWithIri("addressable", OWL_SAME_AS),
-      new Triple(blank, new IRI(LABEL), new IRI(OWL_SAME_AS)),
+      new Triple(new BlankNode("b1"), new IRI(LABEL), new IRI(OWL_SAME_AS)),
+      new Triple(new BlankNode("b2"), new IRI(LABEL), new IRI(OWL_SAME_AS)),
     ]);
 
     expect(found).toHaveLength(1);
     expect(found[0]!.focusNode).toBe(asset("addressable").value);
-    expect(found[0]!.message).toContain("2 assets");
+    // 3 emitters, not 2: keying both blanks as one `_:blank` was the bug.
+    expect(found[0]!.message).toContain("3 assets");
+    expect(found[0]!.message).toContain("_:b1");
+    expect(found[0]!.message).toContain("_:b2");
+  });
+
+  /**
+   * Two blank nodes alone still collide — nothing addressable to anchor an entry,
+   * so the detector must report NOTHING rather than fabricate a focusNode a
+   * reader cannot open. Pins the render-time skip independently of the count.
+   */
+  it(`${REQ} reports nothing when every emitter is a blank node`, () => {
+    const found = detectTermIriCollisions([
+      new Triple(new BlankNode("b1"), new IRI(LABEL), new IRI(OWL_SAME_AS)),
+      new Triple(new BlankNode("b2"), new IRI(LABEL), new IRI(OWL_SAME_AS)),
+    ]);
+
+    expect(found).toEqual([]);
+  });
+
+  /**
+   * ⚠ `.sort()` on the emitter list had NO axis until review round 3 measured a
+   * mutant (`.sort()` → `.reverse()`) surviving the whole suite. Order is not
+   * cosmetic: the `Also emitted by:` text is read across runs, and `Set`
+   * iteration order follows insertion, i.e. triple order — filesystem-dependent.
+   *
+   * ⛔ Insertion order here is `bbb, aaa, ccc`, NOT reverse-alphabetical. The
+   * first version of this axis used `ccc, bbb, aaa` and the `.reverse()` mutant
+   * SURVIVED it: reversing a reverse-sorted list yields the sorted list, so the
+   * fixture made the two implementations indistinguishable. With `bbb, aaa, ccc`
+   * sort gives `aaa,bbb,ccc` while reverse gives `ccc,aaa,bbb` — the axis can
+   * now tell them apart, which is the only reason it is worth having.
+   */
+  it(`${REQ} names co-emitters in a stable (sorted) order regardless of triple order`, () => {
+    const found = detectTermIriCollisions([
+      labelledWithIri("bbb", OWL_SAME_AS),
+      labelledWithIri("aaa", OWL_SAME_AS),
+      labelledWithIri("ccc", OWL_SAME_AS),
+    ]);
+
+    const forAaa = found.find((v) => v.focusNode === asset("aaa").value);
+    expect(forAaa).toBeDefined();
+    expect(forAaa!.message).toContain(
+      `Also emitted by: ${asset("bbb").value}, ${asset("ccc").value}`,
+    );
   });
 });
 

--- a/packages/cli/tests/unit/services/termIriCollisions.test.ts
+++ b/packages/cli/tests/unit/services/termIriCollisions.test.ts
@@ -22,6 +22,21 @@ const labelledWithIri = (uid: string, termIri: string): Triple =>
 const labelledWithLiteral = (uid: string, text: string): Triple =>
   new Triple(asset(uid), new IRI(LABEL), new Literal(text));
 
+/**
+ * `<asset> exo:Asset_label <obsidian://…/uid.md>` — what a label written as a
+ * WIKILINK emits: the converter returns the target's FILE IRI, which is an IRI
+ * like any other. Three live assets do exactly this, so `instanceof IRI` alone
+ * cannot be the "is a term IRI" test.
+ */
+const labelledWithFileIri = (uid: string, targetUid: string): Triple =>
+  new Triple(
+    asset(uid),
+    new IRI(LABEL),
+    new IRI(
+      `obsidian://vault/assetspaces/kitelev/exoas-exocmd/exocmd/${targetUid}.md`,
+    ),
+  );
+
 const iris = (vs: Violation[]): string[] =>
   [...new Set(vs.map((v) => v.actualValue ?? ""))].sort();
 
@@ -43,7 +58,18 @@ describe("detectTermIriCollisions", () => {
       asset("3c6240a5").value,
       asset("9d2128de").value,
     ]);
-    // each entry names the OTHER emitter — that is what makes it actionable
+    // ⛔ Each entry names the OTHER emitters and NEVER itself. Checking one entry
+    // is not enough: with sorted emitters, an entry that wrongly includes itself
+    // is only detectable on the one where self does NOT sort last (a trailing-comma
+    // assertion silently passes on the last). Both entries are therefore asserted.
+    for (const v of found) {
+      const others = found
+        .map((o) => o.focusNode)
+        .filter((f) => f !== v.focusNode);
+      const listed = v.message.split("Also emitted by: ")[1] ?? "";
+      expect(listed).not.toContain(v.focusNode);
+      for (const other of others) expect(listed).toContain(other);
+    }
     const forFirst = found.find(
       (v) => v.focusNode === asset("9d2128de").value,
     )!;
@@ -134,5 +160,157 @@ describe("detectTermIriCollisions", () => {
 
   it(`${REQ} returns nothing for an empty graph`, () => {
     expect(detectTermIriCollisions([])).toEqual([]);
+  });
+
+  /**
+   * ⛔ The discriminator is `Namespace.fromTermIRI`, NOT `instanceof IRI`.
+   * A label written as a wikilink emits the target's FILE IRI — an IRI that is
+   * never used as a predicate, so the message ("a join from a predicate to its
+   * definition resolves to all of them") would be factually false for it. Three
+   * live assets in vault-my share one such file IRI; before this guard they made
+   * up 3 of 7 reported entries.
+   */
+  it(`${REQ} does NOT report a shared FILE IRI (wikilink label), only real term IRIs`, () => {
+    const found = detectTermIriCollisions([
+      labelledWithFileIri("8816b3c7", "ecd68426"),
+      labelledWithFileIri("78c05b6b", "ecd68426"),
+      labelledWithFileIri("c82ef048", "ecd68426"),
+    ]);
+
+    expect(found).toEqual([]);
+  });
+
+  it(`${REQ} still reports real term IRIs when file-IRI labels are present`, () => {
+    const found = detectTermIriCollisions([
+      labelledWithFileIri("8816b3c7", "ecd68426"),
+      labelledWithFileIri("78c05b6b", "ecd68426"),
+      labelledWithIri("9d2128de", OWL_SAME_AS),
+      labelledWithIri("3c6240a5", OWL_SAME_AS),
+    ]);
+
+    expect(iris(found)).toEqual([OWL_SAME_AS]);
+    expect(found).toHaveLength(2);
+  });
+
+  /**
+   * A blank-node co-emitter still makes the term ambiguous, so it must COUNT —
+   * but it cannot anchor an entry a reader could open. Filtering it out before
+   * counting (the earlier shape) suppressed the report for the addressable asset
+   * too, which is the half that is actionable.
+   */
+  it(`${REQ} counts a blank-node co-emitter but reports only the addressable one`, () => {
+    const blank = { value: "b0" } as unknown as IRI; // not a DomainIRI instance
+    const found = detectTermIriCollisions([
+      labelledWithIri("addressable", OWL_SAME_AS),
+      new Triple(blank, new IRI(LABEL), new IRI(OWL_SAME_AS)),
+    ]);
+
+    expect(found).toHaveLength(1);
+    expect(found[0]!.focusNode).toBe(asset("addressable").value);
+    expect(found[0]!.message).toContain("2 assets");
+  });
+});
+
+/**
+ * The collisions are folded into the report BEFORE `filterReportToStagedFocusNodes`
+ * and `applyLegacyExceptionFilter`, so that `--staged` scopes them like any other
+ * finding. Review measured the earlier shape (append AFTER the filters) emitting
+ * warnings for untouched files on every pre-commit run in a vault with pre-existing
+ * collisions. These axes pin the two properties that makes the new placement correct.
+ *
+ * The vaults here are git-free, so `--staged` cannot be exercised end-to-end on live
+ * data; the real filter is therefore driven directly.
+ */
+describe("collision warnings under the report filters", () => {
+  const REQ2 = "@req:00e8079e-fb36-4ce3-b33f-abb18c212143";
+  const OWL = "http://www.w3.org/2002/07/owl#sameAs";
+
+  const collisionsFor = (uids: string[]): Violation[] =>
+    detectTermIriCollisions(uids.map((u) => labelledWithIri(u, OWL)));
+
+  it(`${REQ2} --staged keeps only the emitters that are staged`, async () => {
+    const { filterReportToStagedFocusNodes } =
+      await import("../../../src/commands/validate-schema.js");
+    const violations = collisionsFor(["A", "B"]);
+    expect(violations).toHaveLength(2); // canary: the filter has something to drop
+
+    const stagedA = "assetspaces/kitelev/exoas-x/x/A.md";
+    const filtered = filterReportToStagedFocusNodes(
+      { conforms: true, violations },
+      new Set([stagedA]),
+    );
+
+    // introducing a collision still surfaces (the staged file is itself an emitter)
+    expect(filtered.violations).toHaveLength(1);
+    expect(filtered.violations[0]!.focusNode).toContain("A.md");
+    // …and the untouched co-emitter no longer nags on every unrelated commit
+    expect(filtered.violations.some((v) => v.focusNode.includes("B.md"))).toBe(
+      false,
+    );
+  });
+
+  it(`${REQ2} --staged drops collisions entirely when no emitter is staged`, async () => {
+    const { filterReportToStagedFocusNodes } =
+      await import("../../../src/commands/validate-schema.js");
+    const violations = collisionsFor(["A", "B"]);
+    const filtered = filterReportToStagedFocusNodes(
+      { conforms: true, violations },
+      new Set(["assetspaces/kitelev/exoas-x/x/UNRELATED.md"]),
+    );
+
+    expect(filtered.violations).toEqual([]);
+  });
+
+  it(`${REQ2} passing through a filter never flips conforms (warnings only)`, async () => {
+    const { filterReportToStagedFocusNodes } =
+      await import("../../../src/commands/validate-schema.js");
+    const violations = collisionsFor(["A", "B"]);
+    const filtered = filterReportToStagedFocusNodes(
+      { conforms: true, violations },
+      new Set(["assetspaces/kitelev/exoas-x/x/A.md"]),
+    );
+
+    expect(filtered.violations.length).toBeGreaterThan(0);
+    expect(filtered.conforms).toBe(true);
+  });
+});
+
+/**
+ * ORDERING axis. The three axes above drive `filterReportToStagedFocusNodes`
+ * directly, so they cannot see WHERE the collisions are folded in — a mutant that
+ * moves the append back after the filters leaves them green. `assembleShapesReport`
+ * exists to make that ordering observable.
+ */
+describe("assembleShapesReport ordering", () => {
+  const REQ3 = "@req:00e8079e-fb36-4ce3-b33f-abb18c212143";
+  const OWL = "http://www.w3.org/2002/07/owl#sameAs";
+
+  it(`${REQ3} collisions go THROUGH the staged filter, not around it`, async () => {
+    const { assembleShapesReport } =
+      await import("../../../src/commands/validate-schema.js");
+    const triples = [labelledWithIri("A", OWL), labelledWithIri("B", OWL)];
+    const empty = { conforms: true, violations: [] };
+
+    // canary: without a staged filter both emitters are reported
+    const unfiltered = assembleShapesReport(empty, triples, null);
+    expect(
+      unfiltered.violations.filter(
+        (v: Violation) => v.constraint === "term-iri-collision",
+      ),
+    ).toHaveLength(2);
+
+    // with only A staged, exactly A survives — proving the append happens BEFORE
+    // the filter. Appending afterwards yields 2 here.
+    const staged = assembleShapesReport(
+      empty,
+      triples,
+      new Set(["assetspaces/kitelev/exoas-x/x/A.md"]),
+    );
+    const collisions = staged.violations.filter(
+      (v: Violation) => v.constraint === "term-iri-collision",
+    );
+    expect(collisions).toHaveLength(1);
+    expect(collisions[0]!.focusNode).toContain("A.md");
+    expect(staged.conforms).toBe(true);
   });
 });

--- a/packages/cli/tests/unit/services/termIriCollisions.test.ts
+++ b/packages/cli/tests/unit/services/termIriCollisions.test.ts
@@ -314,3 +314,71 @@ describe("assembleShapesReport ordering", () => {
     expect(staged.conforms).toBe(true);
   });
 });
+
+/**
+ * Two axes closing mutants that survived the round-2 review.
+ *
+ * ⛔ Both existed as CLAIMS before they existed as tests, which is the failure mode
+ * this file is supposed to prevent: the docstring asserted "dropping either half has
+ * its own reddening axis" while dropping `instanceof DomainIRI` reddened nothing, and
+ * the ordering axis pinned only the staged filter, so moving the append BETWEEN the
+ * two filters passed the whole suite while live-reproducing half the original bug.
+ */
+describe("guards that were asserted before they were tested", () => {
+  const REQ4 = "@req:00e8079e-fb36-4ce3-b33f-abb18c212143";
+  const OWL = "http://www.w3.org/2002/07/owl#sameAs";
+  const LEGACY_EXCEPTION =
+    "https://exocortex.my/ontology/exo#Asset_legacyValidationException";
+
+  /**
+   * `instanceof DomainIRI` is load-bearing SEPARATELY from `fromTermIRI`: a literal
+   * whose TEXT happens to be a term IRI must not be reported — a literal never
+   * participates in a "predicate → definition" join. Live exposure is zero today
+   * (no IRI-shaped literal labels in either vault), which is exactly why it needs a
+   * fixture rather than a live measurement.
+   */
+  it(`${REQ4} does NOT report LITERAL labels whose text looks like a term IRI`, () => {
+    const found = detectTermIriCollisions([
+      labelledWithLiteral("p", "https://exocortex.my/ontology/lit#WebPage_url"),
+      labelledWithLiteral("q", "https://exocortex.my/ontology/lit#WebPage_url"),
+    ]);
+
+    expect(found).toEqual([]);
+  });
+
+  /**
+   * The ordering axis above pins the STAGED filter only. Moving the append to sit
+   * between the two filters keeps collisions flowing into the staged filter and so
+   * stays green there — while a legacy-exempted asset starts being reported again.
+   * Verified live by review: that one-line move yields 2 emitters where HEAD yields 1.
+   */
+  it(`${REQ4} collisions go THROUGH the legacy-exception filter too`, async () => {
+    const { assembleShapesReport } =
+      await import("../../../src/commands/validate-schema.js");
+    const triples = [
+      labelledWithIri("A", OWL),
+      labelledWithIri("B", OWL),
+      // A is grandfathered — its findings, collisions included, must be dropped
+      new Triple(asset("A"), new IRI(LEGACY_EXCEPTION), new Literal("true")),
+    ];
+
+    const assembled = assembleShapesReport(
+      { conforms: true, violations: [] },
+      triples,
+      null,
+    );
+    const collisions = assembled.violations.filter(
+      (v: Violation) => v.constraint === "term-iri-collision",
+    );
+
+    // canary: without the exemption both emitters are reported
+    const both = detectTermIriCollisions([
+      labelledWithIri("A", OWL),
+      labelledWithIri("B", OWL),
+    ]);
+    expect(both).toHaveLength(2);
+
+    expect(collisions).toHaveLength(1);
+    expect(collisions[0]!.focusNode).toContain("B.md");
+  });
+});

--- a/packages/core/src/services/ShaclLiteValidator.ts
+++ b/packages/core/src/services/ShaclLiteValidator.ts
@@ -18,7 +18,12 @@ export type ViolationConstraint =
   | 'maxCount'
   | 'class'
   | 'datatype'
-  | 'unknown-property';
+  | 'unknown-property'
+  // Two or more assets emit the SAME term IRI (their `exo__Asset_label` parses as
+  // `<prefix>__<LocalName>`), so a join "predicate → its definition" resolves to
+  // all of them. Reported as sh:Warning by `validate schema`; not produced by the
+  // shape engine itself. req `00e8079e-fb36-4ce3-b33f-abb18c212143`.
+  | 'term-iri-collision';
 
 export interface Violation {
   focusNode: string;


### PR DESCRIPTION
Adds a `validate schema --shapes-mode` check for **term-IRI collisions**: two or more assets
emitting the same term IRI, so a join "predicate → its definition" resolves to all of them.

req `00e8079e-fb36-4ce3-b33f-abb18c212143` (approved).

## Why

An asset whose `exo__Asset_label` parses as `<prefix>__<LocalName>` is emitted as a term IRI, not
a literal. Two assets with the same such label emit the same IRI.

Found while verifying req `aceaa2cc` end-to-end on live data: a reified statement whose
`exo__Statement_predicate` is `owl#sameAs` resolves to **two** definitions — an
`exo__ObjectProperty` and a `concept__Concept` sharing the label.

⛔ Nothing reported this, and the condition was already known and routed around:
`audit-ontology-imports.ts:871` groups on UID with the comment *"labels have had duplicates —
R12"*. Known → worked around → invisible.

⛤ The collision is **not** introduced by the W3C canonicalisation (#4069). Before it both assets
emitted the same *ad-hoc* IRI — the split was identical; canonicalisation only made it visible.

## Design decisions (each measured, not assumed)

| decision | why |
|---|---|
| only **IRI-valued** labels | plain literal labels repeat legitimately: **214** distinct literal labels are shared by >1 asset live (`Initiative`, `Idea`, `Area`, `Bug`, `OKR`…). Reporting them buries 3 real collisions under 214 lines. Pinned by a negative-control axis. |
| **`sh:Warning`**, never Violation | collisions already exist live; shipping must not flip `conforms` (founder's call) |
| **one entry per emitter** | SHACL reports group by `focusNode` — a reader who opens an asset must see it there |
| detection **beside** the shape engine | it is a global graph invariant; the engine validates one focus node at a time. `MergeShaclGate` deliberately unchanged. |

`ViolationConstraint` gains `term-iri-collision`. All five consumers of `.constraint` were
enumerated first — two compare to `"class"`, three only print, no exhaustive switch — so the
union widening is additive.

⛔ **Correction I owe the record:** the requirement's acceptance first said "exactly 3 warnings".
That was wrong — the code emits one entry per *emitter* (3 IRI → 7 entries), which is the right
design. The requirement now records the correction instead of being quietly rewritten.

## Verification

- 8 unit axes; **revert-verify with 5 mutants**, each reddening a distinct set (control 8/8 green):
  dropping the IRI filter reds *exactly* the literal-duplicates control; escalating severity reds
  *exactly* the severity axis.
- `npm run check:types` (what CI runs): **0 errors**.
- core **368/368** suites / 8558 tests · cli **159/159** suites / 1895 tests.
- **Live acceptance, two vaults** — matches an independent SPARQL measurement taken before the
  code existed:

| vault | collisions | entries | `violations` | `conforms` |
|---|---|---|---|---|
| vault-my | 3 | 7 | 4 → 4 | False (pre-existing `ztlk#FleetingNote_type`) |
| vault-exodev | 1 | 2 | 0 → 0 | **true** |

⛔ `packages/cli/dist/index.js` intentionally **not** committed (rebuilt locally only to run the
live acceptance).

https://claude.ai/code/session_015QdGEKFfUAiVYTkvXcDhJ2
