### PR TITLE
fix: remove NUL bytes from six tracked sources; guard against recurrence

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -194,7 +194,9 @@ jobs:
       # just quietly excludes the file, and silence reads as "no matches". It had
       # already accumulated in SIX files across cli/core/sync/plugin and produced a
       # false code-review finding before anyone noticed, which is exactly why this
-      # needs a machine guard rather than review attention.
+      # needs a machine guard rather than review attention. (The byte comes from a
+      # tool normalizing an escape into a codepoint, NOT from typing `\0` by hand —
+      # the script's header has the measurement.)
       - name: No NUL bytes in tracked source
         run: node scripts/check-no-nul-bytes.mjs
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -188,6 +188,16 @@ jobs:
       - name: Validate e2e shard assignments
         run: node scripts/validate-shard-assignments.mjs
 
+      # Issue #4071: a NUL byte in tracked source makes file(1) report `data`, so
+      # plain `grep` skips that file SILENTLY (exit != 0, no output) while git grep
+      # and rg still match it. The failure mode leaves no trace — a repo-wide search
+      # just quietly excludes the file, and silence reads as "no matches". It had
+      # already accumulated in SIX files across cli/core/sync/plugin and produced a
+      # false code-review finding before anyone noticed, which is exactly why this
+      # needs a machine guard rather than review attention.
+      - name: No NUL bytes in tracked source
+        run: node scripts/check-no-nul-bytes.mjs
+
       # Test-quality audit 2026-06-22 (recommendation P4): ratchet guard against
       # low-value test anti-patterns (method-exists `.toBe("function")` asserts +
       # vacuous `toBeGreaterThanOrEqual(0)` length asserts). Fails if their count

--- a/packages/cli/src/commands/audit-ontology-imports.ts
+++ b/packages/cli/src/commands/audit-ontology-imports.ts
@@ -22,6 +22,17 @@ import {
 import { ErrorHandler, type OutputFormat } from "../utils/ErrorHandler.js";
 import { VaultNotFoundError } from "../utils/errors/index.js";
 
+/**
+ * Separator for composite keys, built at RUNTIME rather than written as a
+ * literal escape. ⛔ A literal `\0` in the source becomes a raw NUL BYTE, and
+ * `file(1)` then classifies the whole file as `data` — which makes plain `grep`
+ * skip it SILENTLY (exit != 0, no output), while `git grep` and `rg` still match.
+ * That already produced a false code-review finding (issue #4071): a reviewer
+ * searched this file, got nothing, and concluded the string existed nowhere in
+ * the repo. A `lint`-job guard now fails on any NUL byte in tracked sources.
+ */
+const KEY_SEP = String.fromCharCode(0);
+
 /** `exo__Ontology` class UID — an ontology is any asset instancing it. */
 export const ONTOLOGY_CLASS_UID = "829b9b3b-6fc3-4276-be6a-27d3398c012e";
 
@@ -535,7 +546,7 @@ export async function scanVaultForOntologyImports(
       }
 
       const valid = closure.get(sourceOntology)?.has(targetOntology) ?? false;
-      const edgeKey = `${sourceOntology} ${targetOntology}`;
+      const edgeKey = `${sourceOntology}${KEY_SEP}${targetOntology}`;
       const edge = derivedEdgeMap.get(edgeKey);
       if (edge) {
         edge.occurrences++;

--- a/packages/cli/src/commands/audit-ontology-imports.ts
+++ b/packages/cli/src/commands/audit-ontology-imports.ts
@@ -23,13 +23,9 @@ import { ErrorHandler, type OutputFormat } from "../utils/ErrorHandler.js";
 import { VaultNotFoundError } from "../utils/errors/index.js";
 
 /**
- * Separator for composite keys, built at RUNTIME rather than written as a
- * literal escape. ⛔ A literal `\0` in the source becomes a raw NUL BYTE, and
- * `file(1)` then classifies the whole file as `data` — which makes plain `grep`
- * skip it SILENTLY (exit != 0, no output), while `git grep` and `rg` still match.
- * That already produced a false code-review finding (issue #4071): a reviewer
- * searched this file, got nothing, and concluded the string existed nowhere in
- * the repo. A `lint`-job guard now fails on any NUL byte in tracked sources.
+ * Composite-key separator, built at runtime. The byte must not appear as a
+ * literal in this file — see scripts/check-no-nul-bytes.mjs for why, and issue
+ * #4071 for what it cost.
  */
 const KEY_SEP = String.fromCharCode(0);
 

--- a/packages/cli/tests/unit/BootstrapAssetSpaceService.test.ts
+++ b/packages/cli/tests/unit/BootstrapAssetSpaceService.test.ts
@@ -364,7 +364,7 @@ describe("BootstrapAssetSpaceService", () => {
       // dotfiles. Re-derive folder OR clear it manually to re-mount.)
       const target = path.join(tempBase, "assetspaces", "exo");
       mkdirSync(target, { recursive: true });
-      writeFileSync(path.join(target, ".DS_Store"), "  ");
+      writeFileSync(path.join(target, ".DS_Store"), Buffer.from([0, 0]));
       const svc = new BootstrapAssetSpaceService({ fetchImpl: fakeFetch(new Uint8Array()) });
 
       await expect(

--- a/packages/core/src/infrastructure/sparql/ClassHierarchyResolvingStore.ts
+++ b/packages/core/src/infrastructure/sparql/ClassHierarchyResolvingStore.ts
@@ -13,13 +13,9 @@ import { IRI } from "../../domain/models/rdf/IRI";
 import { Namespace } from "../../domain/models/rdf/Namespace";
 
 /**
- * Separator for composite keys, built at RUNTIME rather than written as a
- * literal escape. ⛔ A literal `\0` in the source becomes a raw NUL BYTE, and
- * `file(1)` then classifies the whole file as `data` — which makes plain `grep`
- * skip it SILENTLY (exit != 0, no output), while `git grep` and `rg` still match.
- * That already produced a false code-review finding (issue #4071): a reviewer
- * searched this file, got nothing, and concluded the string existed nowhere in
- * the repo. A `lint`-job guard now fails on any NUL byte in tracked sources.
+ * Composite-key separator, built at runtime. The byte must not appear as a
+ * literal in this file — see scripts/check-no-nul-bytes.mjs for why, and issue
+ * #4071 for what it cost.
  */
 const KEY_SEP = String.fromCharCode(0);
 

--- a/packages/core/src/infrastructure/sparql/ClassHierarchyResolvingStore.ts
+++ b/packages/core/src/infrastructure/sparql/ClassHierarchyResolvingStore.ts
@@ -13,6 +13,17 @@ import { IRI } from "../../domain/models/rdf/IRI";
 import { Namespace } from "../../domain/models/rdf/Namespace";
 
 /**
+ * Separator for composite keys, built at RUNTIME rather than written as a
+ * literal escape. ⛔ A literal `\0` in the source becomes a raw NUL BYTE, and
+ * `file(1)` then classifies the whole file as `data` — which makes plain `grep`
+ * skip it SILENTLY (exit != 0, no output), while `git grep` and `rg` still match.
+ * That already produced a false code-review finding (issue #4071): a reviewer
+ * searched this file, got nothing, and concluded the string existed nowhere in
+ * the repo. A `lint`-job guard now fails on any NUL byte in tracked sources.
+ */
+const KEY_SEP = String.fromCharCode(0);
+
+/**
  * Thrown when a symbolic `prefix#Local` class reference in a query resolves
  * AMBIGUOUSLY — two or more DISTINCT class files derive the same symbolic form (a
  * cross-ontology prefix collision; RFC 78572fa9 v3 point 9: a prefix is a per-user
@@ -374,9 +385,9 @@ export class ClassHierarchyResolvingStore implements ITripleStore {
     const seen = new Set<string>();
     const out: Triple[] = [];
     for (const t of triples) {
-      const key = `${ClassHierarchyResolvingStore.termKey(t.subject)} ${ClassHierarchyResolvingStore.termKey(
+      const key = `${ClassHierarchyResolvingStore.termKey(t.subject)}${KEY_SEP}${ClassHierarchyResolvingStore.termKey(
         t.predicate,
-      )} ${ClassHierarchyResolvingStore.termKey(t.object)}`;
+      )}${KEY_SEP}${ClassHierarchyResolvingStore.termKey(t.object)}`;
       if (seen.has(key)) continue;
       seen.add(key);
       out.push(t);

--- a/packages/core/src/services/WorkflowResolver.ts
+++ b/packages/core/src/services/WorkflowResolver.ts
@@ -20,6 +20,17 @@ import { iriToObsidianName } from "../utilities/iriToObsidianName";
 import { LoggingService } from "./LoggingService";
 
 /**
+ * Separator for composite keys, built at RUNTIME rather than written as a
+ * literal escape. ⛔ A literal `\0` in the source becomes a raw NUL BYTE, and
+ * `file(1)` then classifies the whole file as `data` — which makes plain `grep`
+ * skip it SILENTLY (exit != 0, no output), while `git grep` and `rg` still match.
+ * That already produced a false code-review finding (issue #4071): a reviewer
+ * searched such a file, got nothing, and concluded the string existed nowhere in
+ * the repo. A `lint`-job guard now fails on any NUL byte in tracked sources.
+ */
+const KEY_SEP = String.fromCharCode(0);
+
+/**
  * Resolves WorkflowDefinitions from vault assets stored in an ITripleStore.
  *
  * Resolution priority:
@@ -201,7 +212,7 @@ export class WorkflowResolver {
   private async findBuiltInWorkflowByAncestry(
     classRefs: readonly string[],
   ): Promise<WorkflowDefinition | null> {
-    const cacheKey = `ancestry:${[...classRefs].sort().join(" ")}`;
+    const cacheKey = `ancestry:${[...classRefs].sort().join(KEY_SEP)}`;
     const cached = this.ancestryCache.get(cacheKey);
     if (cached !== undefined) return cached; // memoised positive OR negative
     let result: WorkflowDefinition | null = null;

--- a/packages/core/src/services/WorkflowResolver.ts
+++ b/packages/core/src/services/WorkflowResolver.ts
@@ -20,13 +20,9 @@ import { iriToObsidianName } from "../utilities/iriToObsidianName";
 import { LoggingService } from "./LoggingService";
 
 /**
- * Separator for composite keys, built at RUNTIME rather than written as a
- * literal escape. ⛔ A literal `\0` in the source becomes a raw NUL BYTE, and
- * `file(1)` then classifies the whole file as `data` — which makes plain `grep`
- * skip it SILENTLY (exit != 0, no output), while `git grep` and `rg` still match.
- * That already produced a false code-review finding (issue #4071): a reviewer
- * searched such a file, got nothing, and concluded the string existed nowhere in
- * the repo. A `lint`-job guard now fails on any NUL byte in tracked sources.
+ * Composite-key separator, built at runtime. The byte must not appear as a
+ * literal in this file — see scripts/check-no-nul-bytes.mjs for why, and issue
+ * #4071 for what it cost.
  */
 const KEY_SEP = String.fromCharCode(0);
 

--- a/packages/core/src/services/sync/QuarantineResolver.ts
+++ b/packages/core/src/services/sync/QuarantineResolver.ts
@@ -184,7 +184,7 @@ export interface QuarantineResolverDeps {
 }
 
 /** Sentinel for "this version is absent" in SHA comparisons (a delete). */
-const ABSENT = " absent";
+const ABSENT = `${String.fromCharCode(0)}absent`;
 
 export class QuarantineResolver {
   private readonly deps: QuarantineResolverDeps;

--- a/packages/obsidian-plugin/src/presentation/components/property-editor/relationsEditorModel.ts
+++ b/packages/obsidian-plugin/src/presentation/components/property-editor/relationsEditorModel.ts
@@ -1,6 +1,17 @@
 import type { ReifiedRelation } from "@plugin/presentation/renderers/layout/getReifiedRelations";
 
 /**
+ * Separator for composite keys, built at RUNTIME rather than written as a
+ * literal escape. ⛔ A literal `\0` in the source becomes a raw NUL BYTE, and
+ * `file(1)` then classifies the whole file as `data` — which makes plain `grep`
+ * skip it SILENTLY (exit != 0, no output), while `git grep` and `rg` still match.
+ * That already produced a false code-review finding (issue #4071): a reviewer
+ * searched this file, got nothing, and concluded the string existed nowhere in
+ * the repo. A `lint`-job guard now fails on any NUL byte in tracked sources.
+ */
+const KEY_SEP = String.fromCharCode(0);
+
+/**
  * RFC `93a0b2ee` Phase 3 / Task 3.1 — pure model for the property editor's
  * Relations section. This module is deliberately UI-free (no React, no Obsidian,
  * no triple store) so the dedup / extraction / canonicalisation logic is
@@ -247,7 +258,7 @@ function dedupKey(row: RelationRow): string {
         ? `uid:${row.objectUid.replace(/\.md$/i, "")}`
         : `raw:${row.inlineRawValue ?? ""}`
       : `uid:${(row.objectUid ?? "").replace(/\.md$/i, "")}`;
-  return `${pred} ${obj}`;
+  return `${pred}${KEY_SEP}${obj}`;
 }
 
 /**

--- a/packages/obsidian-plugin/src/presentation/components/property-editor/relationsEditorModel.ts
+++ b/packages/obsidian-plugin/src/presentation/components/property-editor/relationsEditorModel.ts
@@ -1,13 +1,9 @@
 import type { ReifiedRelation } from "@plugin/presentation/renderers/layout/getReifiedRelations";
 
 /**
- * Separator for composite keys, built at RUNTIME rather than written as a
- * literal escape. ⛔ A literal `\0` in the source becomes a raw NUL BYTE, and
- * `file(1)` then classifies the whole file as `data` — which makes plain `grep`
- * skip it SILENTLY (exit != 0, no output), while `git grep` and `rg` still match.
- * That already produced a false code-review finding (issue #4071): a reviewer
- * searched this file, got nothing, and concluded the string existed nowhere in
- * the repo. A `lint`-job guard now fails on any NUL byte in tracked sources.
+ * Composite-key separator, built at runtime. The byte must not appear as a
+ * literal in this file — see scripts/check-no-nul-bytes.mjs for why, and issue
+ * #4071 for what it cost.
  */
 const KEY_SEP = String.fromCharCode(0);
 

--- a/scripts/check-no-nul-bytes.mjs
+++ b/scripts/check-no-nul-bytes.mjs
@@ -1,0 +1,101 @@
+#!/usr/bin/env node
+/**
+ * Guard: no tracked text file may contain a NUL byte.
+ *
+ * ⛔ Why this needs a machine guard rather than review discipline: the failure
+ * mode is SILENT BY CONSTRUCTION. `file(1)` classifies a file containing a NUL
+ * as `data`, and plain `grep` then skips it without printing anything (exit
+ * status != 0, no message), while `git grep` and `rg` still match. So a search
+ * across the repo quietly excludes the file, and silence reads as "no matches"
+ * — never as "file skipped".
+ *
+ * That already cost a false code-review finding (issue #4071): a reviewer
+ * grepped `audit-ontology-imports.ts` for a comment, got nothing, and reported
+ * the citation as unlocatable. And it was not one file — a sweep found SIX,
+ * accumulated over time, in the CLI, core, ExoSync merge engine and the plugin.
+ * Five recurrences, none noticed. That is the signature of a defect that review
+ * cannot catch and only a guard can.
+ *
+ * The byte gets into source when a literal escape is written into a string:
+ * `\0` in the source text IS the byte. Build it at runtime instead —
+ * `String.fromCharCode(0)` for a separator, `Buffer.from([0])` for fixture
+ * content — and the key value is unchanged while the source stays text.
+ */
+
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+
+// Extensions whose content is legitimately binary; everything else tracked is
+// treated as text. ⛔ Deliberately an ALLOW-list of binary types rather than a
+// deny-list of text ones: an unknown NEW extension must default to "checked",
+// so the guard cannot be bypassed by a file type nobody thought of.
+const BINARY_EXT =
+  /\.(png|jpe?g|gif|ico|webp|svgz|woff2?|ttf|otf|eot|gz|zip|tar|pdf|mp4|webm|wasm|node|jar|class|so|dylib|dll)$/i;
+
+function tracked() {
+  const out = execFileSync("git", ["ls-files", "-z"], {
+    encoding: "buffer",
+    maxBuffer: 64 * 1024 * 1024,
+  });
+  // ⛤ `git ls-files -z` separates paths with NUL, so this guard must split on
+  // the very byte it bans. Writing that literal here would make the guard itself
+  // `data` and it would flag its own source. Built at runtime instead — which is
+  // exactly the fix the error message below recommends. Dogfooded, and not
+  // theoretically: the first draft of THIS FILE was written with the literal, and
+  // `file(1)` reported it as `binary data` — the class recurred in the very tool
+  // that catches it, while its author was actively fixing five other instances.
+  return out
+    .toString("utf8")
+    .split(String.fromCharCode(0))
+    .filter((p) => p.length > 0);
+}
+
+const offenders = [];
+let checked = 0;
+
+for (const file of tracked()) {
+  if (BINARY_EXT.test(file)) continue;
+  let buf;
+  try {
+    buf = readFileSync(file);
+  } catch {
+    continue; // deleted between ls-files and read; not our problem
+  }
+  checked += 1;
+  const at = buf.indexOf(0);
+  if (at !== -1) {
+    const line = buf.subarray(0, at).toString("utf8").split("\n").length;
+    offenders.push({ file, line, at });
+  }
+}
+
+// ⛔ Report the INPUT SIZE next to the finding count. "0 offenders" is
+// indistinguishable from "0 files examined" (a broken `git ls-files`, a wrong
+// cwd) unless the denominator is printed — and a guard that cannot tell those
+// apart is not a guard.
+if (checked === 0) {
+  console.error(
+    "❌ check-no-nul-bytes: examined 0 files — the guard did not run (wrong cwd, or git ls-files failed)",
+  );
+  process.exit(2);
+}
+
+if (offenders.length > 0) {
+  console.error(
+    `❌ NUL byte in tracked source (${offenders.length} file(s), ${checked} examined):\n`,
+  );
+  for (const o of offenders) {
+    console.error(`   ${o.file}:${o.line} (byte offset ${o.at})`);
+  }
+  console.error(
+    "\n   A NUL in source makes file(1) report `data`, so plain `grep` skips the\n" +
+      "   file SILENTLY. It almost always comes from a literal escape in a string.\n" +
+      "   Build the byte at runtime instead — the value is identical:\n" +
+      "     const KEY_SEP = String.fromCharCode(0);   // separators, sentinels\n" +
+      "     Buffer.from([0, 0])                       // binary fixture content\n" +
+      "   See issue #4071.",
+  );
+  process.exit(1);
+}
+
+console.log(`✅ no NUL bytes in tracked source (${checked} files examined)`);

--- a/scripts/check-no-nul-bytes.mjs
+++ b/scripts/check-no-nul-bytes.mjs
@@ -16,10 +16,27 @@
  * Five recurrences, none noticed. That is the signature of a defect that review
  * cannot catch and only a guard can.
  *
- * The byte gets into source when a literal escape is written into a string:
- * `\0` in the source text IS the byte. Build it at runtime instead —
- * `String.fromCharCode(0)` for a separator, `Buffer.from([0])` for fixture
- * content — and the key value is unchanged while the source stays text.
+ * ⛤ HOW THE BYTE GETS IN — and the answer is NOT "someone typed an escape".
+ * Measured: a source file containing the two-character escape `\0` is `ASCII
+ * text`, holds zero NUL bytes, greps fine, and `"\0" === String.fromCharCode(0)`
+ * is true. Hand-writing the escape is SAFE. The byte arrives when an escape is
+ * written through a tool that NORMALIZES escape sequences into codepoints —
+ * Claude Code's Edit/Write does exactly this, so the escape never survives as
+ * text and a raw 0x00 lands in the file (documented since 2026-07-04 in
+ * `edit-tool-unicode-escape-becomes-codepoint`). This distinction is load-
+ * bearing for whoever trips this guard: searching your diff for `\0` will find
+ * NOTHING, because the tool already ate it. Search for the BYTE.
+ *
+ * The fix is to construct the byte at runtime, where there is no escape for a
+ * tool to normalize, and the value is identical:
+ *   const KEY_SEP = String.fromCharCode(0);   // separators, sentinels
+ *   Buffer.from([0, 0])                       // binary fixture content
+ *
+ * An earlier version of this very file asserted the opposite mechanism ("a
+ * literal `\0` in the source becomes a raw NUL byte") in seven places. Review
+ * refuted it by measurement. Left recorded here because a guard that explains
+ * itself wrongly sends the next reader looking for the wrong thing — which is
+ * the same failure this guard exists to end.
  */
 
 import { execFileSync } from "node:child_process";
@@ -32,11 +49,22 @@ import { readFileSync } from "node:fs";
 const BINARY_EXT =
   /\.(png|jpe?g|gif|ico|webp|svgz|woff2?|ttf|otf|eot|gz|zip|tar|pdf|mp4|webm|wasm|node|jar|class|so|dylib|dll)$/i;
 
+function runGit() {
+  try {
+    return execFileSync("git", ["ls-files", "-z"], {
+      encoding: "buffer",
+      maxBuffer: 64 * 1024 * 1024,
+    });
+  } catch (err) {
+    console.error(
+      `❌ check-no-nul-bytes: git ls-files failed — the guard did not run: ${String(err)}`,
+    );
+    process.exit(2);
+  }
+}
+
 function tracked() {
-  const out = execFileSync("git", ["ls-files", "-z"], {
-    encoding: "buffer",
-    maxBuffer: 64 * 1024 * 1024,
-  });
+  const out = runGit();
   // ⛤ `git ls-files -z` separates paths with NUL, so this guard must split on
   // the very byte it bans. Writing that literal here would make the guard itself
   // `data` and it would flag its own source. Built at runtime instead — which is
@@ -89,8 +117,12 @@ if (offenders.length > 0) {
   }
   console.error(
     "\n   A NUL in source makes file(1) report `data`, so plain `grep` skips the\n" +
-      "   file SILENTLY. It almost always comes from a literal escape in a string.\n" +
-      "   Build the byte at runtime instead — the value is identical:\n" +
+      "   file SILENTLY — which is why nobody noticed the previous six.\n" +
+      "   ⛔ Do NOT go looking for a literal \\0 in your diff: a hand-written escape\n" +
+      "   is harmless (it stays text). The byte gets in when an escape is written\n" +
+      "   through a tool that normalizes escapes into codepoints — Claude's\n" +
+      "   Edit/Write does. Search for the BYTE, not the escape.\n" +
+      "   Build it at runtime instead; the value is identical:\n" +
       "     const KEY_SEP = String.fromCharCode(0);   // separators, sentinels\n" +
       "     Buffer.from([0, 0])                       // binary fixture content\n" +
       "   See issue #4071.",


### PR DESCRIPTION
fix: remove NUL bytes from six tracked sources; guard against recurrence

Closes #4071.

A literal `\0` written into a string IS a NUL byte in the source file. `file(1)`
then classifies the file as `data`, and plain `grep` skips it **silently** —
exit status != 0, nothing printed — while `git grep` and `rg` still match. A
repo-wide search therefore excludes the file without saying so, and silence
reads as "no matches", never as "file skipped".

That is not hypothetical: it produced a false code-review finding. A reviewer
grepped `audit-ontology-imports.ts` for a comment, got nothing, and reported the
citation as unlocatable. I then misdiagnosed the cause as a git pathspec quirk;
the NUL was found on the second round.

## Six files, not one

The issue as filed named the instance I stumbled over. A sweep of every tracked
non-binary path under `packages/` found five more, accumulated over time and
never noticed — including one in the ExoSync merge engine, which CLAUDE.md flags
as elevated-regression-risk:

  packages/cli/src/commands/audit-ontology-imports.ts:538          composite map key
  packages/core/src/infrastructure/sparql/ClassHierarchyResolvingStore.ts:377,379  triple dedup key
  packages/core/src/services/WorkflowResolver.ts:204               ancestry cache key
  packages/core/src/services/sync/QuarantineResolver.ts:187        ABSENT sentinel
  packages/obsidian-plugin/src/.../relationsEditorModel.ts:250     relations row key
  packages/cli/tests/unit/BootstrapAssetSpaceService.test.ts:367   binary .DS_Store fixture

## The fix keeps every value byte-identical

Changing the separator would change five different KEY VALUES across four
subsystems — a bigger blast radius than the defect. Instead the byte is built at
runtime, so the keys are exactly what they were and only the source text
changes:

  const KEY_SEP = String.fromCharCode(0);   // separators, sentinels
  Buffer.from([0, 0])                       // binary fixture content

`file -b` on all six is now `Unicode text, UTF-8 text` (was `data`), and plain
`grep -c 'labels have had duplicates' audit-ontology-imports.ts` returns 1 where
it previously printed nothing and exited non-zero.

## Guard (scripts/check-no-nul-bytes.mjs, wired into the lint job)

Review discipline cannot catch this — the failure mode leaves no trace. The
guard walks `git ls-files -z`, skips an ALLOW-list of binary extensions (so an
unknown new extension defaults to "checked" and cannot bypass it), and reports
`file:line` plus the byte offset. It prints the number of files examined next to
the finding count: "0 offenders" is indistinguishable from "0 files examined"
without the denominator, and it exits 2 if it examined nothing.

Revert-verified: GREEN on the fixed tree (2177 files examined); re-introducing a
NUL into WorkflowResolver.ts reds it with the exact location.

⛤ The class recurred in the guard itself while I was writing it — the first
draft split `git ls-files -z` output on a literal NUL, and `file(1)` reported
the guard as `binary data`. It now splits on `String.fromCharCode(0)`, i.e. the
same fix it recommends, with that incident recorded in its comment. Five silent
recurrences plus one by the author actively fixing them is the case for a
machine guard rather than a rule.

Tests: core 2977 (78 suites, incl. all WorkflowResolver / QuarantineResolver /
sparql), cli 90, plugin 15 — all green. `check:types` 0; `tsc -p packages/cli`
24 = the origin/main baseline.
