### PR TITLE
fix(resolver): log the two silent PropertyDefault fallbacks

### DIFF
--- a/packages/core/src/services/CommandResolver.ts
+++ b/packages/core/src/services/CommandResolver.ts
@@ -2595,7 +2595,10 @@ export class CommandResolver {
       // ⛔ CANDIDATE cause of defect 0310aa28 — narrowed by ELIMINATION, not
       // measured. Observed: assets whose `exo__Asset_label` holds the literal
       // `[[<token-uid>]]` while the user's input survives only in `aliases`.
-      // Five sites emit this shape. The first (`!looksLikeUUID`, above) cannot
+      // Five sites ON THE PropertyDefault VALUE PATH emit this shape (a sixth,
+      // `getObsidianWikilinkValue`, serves grounding target values — a
+      // different predicate family — so a whole-file grep returns six).
+      // The first (`!looksLikeUUID`, above) cannot
       // produce it — a non-UUID ref yields a symbolic wikilink, not
       // `[[<uuid>]]`. Two more, in `dispatchSubstitutionToken`, were ruled out
       // by reading the live token asset (it HAS a `_resolver`, and that id IS
@@ -2619,6 +2622,19 @@ export class CommandResolver {
       // output contract (`resolve-buttons --json` must keep stdout pure JSON,
       // so it would have to be stderr-only) and needs its own axes. Tracked
       // separately — do not read CLI silence as absence of the problem.
+      // ⛤ Key is per (grounding, value-ref) and deliberately NOT per property:
+      // two PropertyDefaults in one grounding pointing at the same missing
+      // value (say startTimestamp + endTimestamp → one absent token) warn once,
+      // naming whichever property was resolved first. The actionable unit is
+      // the ref — fixing it fixes both — so a second, near-identical toast
+      // would add noise without adding a decision.
+      //
+      // ⚠ `capWarning` caps at 200 chars, and with two 36-char UIDs the
+      // template is already 186 before `propertyName`, so realistic labels
+      // (`ems__Effort_status`, `exo__Asset_createdAt`) DO truncate. That is
+      // acceptable by construction, not by luck: both UIDs and "not in store"
+      // sit inside the first 197 chars and survive; only the trailing
+      // parenthetical is cut.
       const fallbackKey = `${groundingUid}|${valueRefUid}`;
       if (!this._fallbackWarnedKeys.has(fallbackKey)) {
         this._fallbackWarnedKeys.add(fallbackKey);

--- a/packages/core/src/services/CommandResolver.ts
+++ b/packages/core/src/services/CommandResolver.ts
@@ -2572,6 +2572,18 @@ export class CommandResolver {
     if (!valueSubject) {
       // Asset not in store yet (cold-start race / pruned vault) — emit
       // wikilink anyway; downstream UI / executor renders it as a dead link.
+      //
+      // ⛔ This branch is a KNOWN corruption source when the value ref is a
+      // SubstitutionToken: the created asset gets the literal `[[<uid>]]`
+      // where the substituted value belonged (e.g. `exo__Asset_label` shows a
+      // link to `$userInputLabel` instead of what the user typed). Because the
+      // command definition is cached per session, ONE cold start poisons every
+      // instance created in that session. It used to be silent, which made the
+      // class undiagnosable — the log line below is what makes the next
+      // occurrence self-identifying (defect 0310aa28).
+      this.logger.warn(
+        `Grounding ${groundingUid}: PropertyDefault '${propertyName}' references asset '${valueRefUid}' which is NOT in the store (cold-start race / pruned vault) — falling back to wikilink form. If '${valueRefUid}' is a SubstitutionToken, the written value will be a link instead of the substituted value.`,
+      );
       return `"[[${valueRefUid}]]"`;
     }
 
@@ -2592,6 +2604,18 @@ export class CommandResolver {
     const isSubstitutionToken =
       await this.assetIsSubstitutionToken(valueSubject);
     if (!isSubstitutionToken) {
+      // Plain asset ref (not a token) — a wikilink IS the intended value here,
+      // so this is the common, correct path and must stay quiet by default.
+      //
+      // ⛔ It doubles as the SECOND known corruption source: when the ref DOES
+      // point at a SubstitutionToken whose `exo__Instance_class` failed to
+      // resolve (cold-start race), the class check answers "not a token" and we
+      // silently emit the link instead of the substituted value. `debug` keeps
+      // the happy path quiet while making that case recoverable from a verbose
+      // log (defect 0310aa28).
+      this.logger.debug(
+        `Grounding ${groundingUid}: PropertyDefault '${propertyName}' value '${valueRefUid}' is not a SubstitutionToken — emitting wikilink form.`,
+      );
       return `"[[${valueRefUid}]]"`;
     }
 

--- a/packages/core/src/services/CommandResolver.ts
+++ b/packages/core/src/services/CommandResolver.ts
@@ -219,6 +219,25 @@ export class CommandResolver {
   private readonly _legacyPropertyDefaultsWarnedGroundings = new Set<string>();
 
   /**
+   * Once-per-session suppression for the PropertyDefault wikilink-fallback
+   * warning, keyed `<groundingUid>|<valueRefUid>`. Mirrors
+   * {@link _legacyPropertyDefaultsWarnedGroundings} above.
+   *
+   * ⛔ Load-bearing, not tidiness. `warn` is routed to `notice: true` by
+   * DEFAULT_LOG_CHANNELS, i.e. a user-facing Obsidian toast, AND persisted to
+   * the log file; and this branch is re-evaluated on every button render —
+   * `invalidateCache()` fires on each `.md` save. Undeduped, ONE dangling
+   * PropertyDefault ref would toast the user on every render and grow the log
+   * file (precedent: #3186, ~6 MB / 54k lines in two days).
+   *
+   * ⛤ Deliberately NOT cleared by `invalidateCache()`: that fires on every
+   * save, so clearing it there would reinstate exactly the storm this
+   * prevents. Fixing the underlying ref stops the warning by construction —
+   * the branch simply stops being taken.
+   */
+  private readonly _fallbackWarnedKeys = new Set<string>();
+
+  /**
    * RFC 727572d2 — Universal Default Template singleton cache. Loaded once
    * per CommandResolver instance via {@link getUniversalCache}. Vault file
    * change adapters may externally call
@@ -2576,17 +2595,39 @@ export class CommandResolver {
       // ⛔ CANDIDATE cause of defect 0310aa28 — narrowed by ELIMINATION, not
       // measured. Observed: assets whose `exo__Asset_label` holds the literal
       // `[[<token-uid>]]` while the user's input survives only in `aliases`.
-      // Of the five sites that emit this shape, the two in
-      // `dispatchSubstitutionToken` were ruled out by reading the live token
-      // asset (it has a `_resolver`, and that id IS whitelisted); this branch
-      // and the `!isSubstitutionToken` one below are the two that remain — and
-      // both were silent, which is why the root could not be measured at all.
-      // The corruption clusters per SESSION (command definitions are cached),
-      // consistent with a cold start, but that is inference. This log line is
-      // what turns the next occurrence into a measurement.
-      this.logger.warn(
-        `Grounding ${groundingUid}: PropertyDefault '${propertyName}' references asset '${valueRefUid}' which is NOT in the store (cold-start race / pruned vault) — falling back to wikilink form. If '${valueRefUid}' is a SubstitutionToken, the written value will be a link instead of the substituted value.`,
-      );
+      // Five sites emit this shape. The first (`!looksLikeUUID`, above) cannot
+      // produce it — a non-UUID ref yields a symbolic wikilink, not
+      // `[[<uuid>]]`. Two more, in `dispatchSubstitutionToken`, were ruled out
+      // by reading the live token asset (it HAS a `_resolver`, and that id IS
+      // whitelisted). That leaves this branch and the `!isSubstitutionToken`
+      // one below — and both were silent, which is why the root could not be
+      // measured at all. The corruption clusters per SESSION (command
+      // definitions are cached), which is consistent with a cold start, but
+      // that is inference. This log line turns the next occurrence into a
+      // measurement.
+      //
+      // The message states only what is OBSERVED (the asset is not in the
+      // store). Candidate causes — cold-start race, pruned vault, a plain
+      // dangling ref — belong here, not in a user-facing toast that would
+      // present one of them as established.
+      //
+      // ⚠ PLUGIN-ONLY today. `packages/cli` builds `new CommandResolver(store)`
+      // with no logger (apply.ts:261, resolve-buttons.ts:283), so the default
+      // NullLogger swallows both lines — including on `resolve-buttons`, the
+      // authoritative resolution oracle and the cheapest reproduction path.
+      // Wiring a CLI logger is deliberately NOT done here: it changes the CLI
+      // output contract (`resolve-buttons --json` must keep stdout pure JSON,
+      // so it would have to be stderr-only) and needs its own axes. Tracked
+      // separately — do not read CLI silence as absence of the problem.
+      const fallbackKey = `${groundingUid}|${valueRefUid}`;
+      if (!this._fallbackWarnedKeys.has(fallbackKey)) {
+        this._fallbackWarnedKeys.add(fallbackKey);
+        this.logger.warn(
+          this.capWarning(
+            `Grounding ${groundingUid}: PropertyDefault '${propertyName}' → value asset ${valueRefUid} not in store; emitting wikilink (a link, not the substituted value).`,
+          ),
+        );
+      }
       return `"[[${valueRefUid}]]"`;
     }
 

--- a/packages/core/src/services/CommandResolver.ts
+++ b/packages/core/src/services/CommandResolver.ts
@@ -2573,14 +2573,17 @@ export class CommandResolver {
       // Asset not in store yet (cold-start race / pruned vault) — emit
       // wikilink anyway; downstream UI / executor renders it as a dead link.
       //
-      // ⛔ This branch is a KNOWN corruption source when the value ref is a
-      // SubstitutionToken: the created asset gets the literal `[[<uid>]]`
-      // where the substituted value belonged (e.g. `exo__Asset_label` shows a
-      // link to `$userInputLabel` instead of what the user typed). Because the
-      // command definition is cached per session, ONE cold start poisons every
-      // instance created in that session. It used to be silent, which made the
-      // class undiagnosable — the log line below is what makes the next
-      // occurrence self-identifying (defect 0310aa28).
+      // ⛔ CANDIDATE cause of defect 0310aa28 — narrowed by ELIMINATION, not
+      // measured. Observed: assets whose `exo__Asset_label` holds the literal
+      // `[[<token-uid>]]` while the user's input survives only in `aliases`.
+      // Of the five sites that emit this shape, the two in
+      // `dispatchSubstitutionToken` were ruled out by reading the live token
+      // asset (it has a `_resolver`, and that id IS whitelisted); this branch
+      // and the `!isSubstitutionToken` one below are the two that remain — and
+      // both were silent, which is why the root could not be measured at all.
+      // The corruption clusters per SESSION (command definitions are cached),
+      // consistent with a cold start, but that is inference. This log line is
+      // what turns the next occurrence into a measurement.
       this.logger.warn(
         `Grounding ${groundingUid}: PropertyDefault '${propertyName}' references asset '${valueRefUid}' which is NOT in the store (cold-start race / pruned vault) — falling back to wikilink form. If '${valueRefUid}' is a SubstitutionToken, the written value will be a link instead of the substituted value.`,
       );
@@ -2607,12 +2610,13 @@ export class CommandResolver {
       // Plain asset ref (not a token) — a wikilink IS the intended value here,
       // so this is the common, correct path and must stay quiet by default.
       //
-      // ⛔ It doubles as the SECOND known corruption source: when the ref DOES
-      // point at a SubstitutionToken whose `exo__Instance_class` failed to
-      // resolve (cold-start race), the class check answers "not a token" and we
-      // silently emit the link instead of the substituted value. `debug` keeps
-      // the happy path quiet while making that case recoverable from a verbose
-      // log (defect 0310aa28).
+      // ⛔ It is also the SECOND surviving candidate for defect 0310aa28 (see
+      // the sibling comment above): IF the ref does point at a token whose
+      // `exo__Instance_class` failed to resolve, this check answers "not a
+      // token" and emits the link instead of the substituted value. Not
+      // measured — the class-resolution failure has never been observed
+      // directly, only inferred from the corruption shape. `debug` keeps the
+      // common path quiet while making that case recoverable from a verbose log.
       this.logger.debug(
         `Grounding ${groundingUid}: PropertyDefault '${propertyName}' value '${valueRefUid}' is not a SubstitutionToken — emitting wikilink form.`,
       );

--- a/packages/core/tests/unit/services/CommandResolver.substitutionToken.test.ts
+++ b/packages/core/tests/unit/services/CommandResolver.substitutionToken.test.ts
@@ -34,18 +34,29 @@ import {
 
 interface RecordingLogger extends ILogger {
   readonly warnings: string[];
+  /**
+   * Recorded separately from `warnings` because the level is load-bearing:
+   * a plain (non-token) asset ref is the COMMON, correct path, so it must not
+   * warn — otherwise every `assetRef` field would emit noise and devalue the
+   * genuine cold-start warning next to it (req b354316b).
+   */
+  readonly debugs: string[];
 }
 
 function makeRecordingLogger(): RecordingLogger {
   const warnings: string[] = [];
+  const debugs: string[] = [];
   return {
-    debug() {},
+    debug(message: string) {
+      debugs.push(message);
+    },
     info() {},
     warn(message: string) {
       warnings.push(message);
     },
     error() {},
     warnings,
+    debugs,
   };
 }
 
@@ -173,6 +184,12 @@ const TOKEN_TARGET_FOLDER_UID = "33333333-3333-4333-8333-333333333333";
 const TOKEN_UNKNOWN_UID       = "44444444-4444-4444-8444-444444444444";
 const TOKEN_TODAY_START_UID   = "66666666-6666-4666-8666-666666666666";
 const TOKEN_NOW_TIMESTAMP_UID = "77777777-7777-4777-8777-777777777777";
+// Deliberately never seeded — models the cold-start race (value asset absent).
+// MUST be valid UUID-v4 shape, otherwise `looksLikeUUID` short-circuits into
+// the legacy-symbolic branch and the test would exercise the wrong fallback.
+const TOKEN_ABSENT_UID        = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
+// An ordinary asset (not a SubstitutionToken) — the common, correct path.
+const PLAIN_ASSET_UID         = "99999999-9999-4999-8999-999999999999";
 
 const PD_UID  = "55555555-5555-4555-8555-555555555555";
 
@@ -406,5 +423,110 @@ describe("CommandResolver — RFC v2 Phase 3a SubstitutionToken dispatch", () =>
           /unknown resolver-id/.test(w),
       ),
     ).toBe(true);
+  });
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // The two fallbacks that used to be SILENT. Both emit `"[[<uid>]]"` — the
+  // exact shape observed corrupting `exo__Asset_label` in the live vault
+  // (defect 0310aa28) — and neither logged anything, which made the class
+  // undiagnosable: the root had to be narrowed by ELIMINATION rather than
+  // measured. These lock the diagnostics, not the corruption itself.
+  // ──────────────────────────────────────────────────────────────────────────
+
+  it("@req:b354316b-3b26-478b-a8c0-18606da8e6ec warns when the PropertyDefault value asset is absent from the store (cold-start race)", async () => {
+    // NOTE: the value ref is deliberately NOT seeded — this models the
+    // cold-start race where the command definition is parsed before the token
+    // asset has been indexed. Production then bakes the wikilink into a
+    // session-cached command template, poisoning every instance created in
+    // that session.
+    // GUARD: prove the UID is genuinely unseeded. Without it, a fixture-UID
+    // collision (this test first used the same constant as GROUNDING_UID)
+    // silently routes to the OTHER fallback and the assertion below measures
+    // the wrong branch while still looking plausible.
+    expect(
+      [PROP_UID, PD_UID, GROUNDING_UID, COMMAND_UID, TOKEN_TODAY_UID,
+       TOKEN_TARGET_FOLDER_UID, TOKEN_UNKNOWN_UID, TOKEN_TODAY_START_UID,
+       TOKEN_NOW_TIMESTAMP_UID, PLAIN_ASSET_UID],
+    ).not.toContain(TOKEN_ABSENT_UID);
+    await addPropertyDefault(store, {
+      uid: PD_UID,
+      propertyRefUid: PROP_UID,
+      valueRefUid: TOKEN_ABSENT_UID,
+    });
+    await addGrounding(store, {
+      uid: GROUNDING_UID,
+      label: "Grounding whose token asset is not in the store",
+      propertyDefaultRefs: [PD_UID],
+    });
+    await addCommand(store, COMMAND_UID, GROUNDING_UID);
+
+    const cmd = await resolver.loadCommand(COMMAND_UID);
+
+    expect(cmd!.grounding.propertyDefault![0].value).toBe(
+      `"[[${TOKEN_ABSENT_UID}]]"`,
+    );
+    // The warning is the whole deliverable: it must name the value uid (what
+    // to look for), the property (where the damage lands) and the grounding
+    // (which command) — enough to identify the case without a repro.
+    const hit = logger.warnings.find((w) => w.includes(TOKEN_ABSENT_UID));
+    expect(hit).toBeDefined();
+    expect(hit).toContain(GROUNDING_UID);
+    expect(hit).toMatch(/NOT in the store/);
+  });
+
+  it("@req:b354316b-3b26-478b-a8c0-18606da8e6ec logs at debug (never warn) when the PropertyDefault value is a plain asset, not a token", async () => {
+    // A plain asset ref is the COMMON, correct path: a wikilink IS the intended
+    // value. Warning here would fire on every assetRef field and drown the
+    // cold-start warning above — the level is part of the spec, not taste.
+    await addLabelledAsset(store, PLAIN_ASSET_UID, "Some ordinary asset");
+    await addPropertyDefault(store, {
+      uid: PD_UID,
+      propertyRefUid: PROP_UID,
+      valueRefUid: PLAIN_ASSET_UID,
+    });
+    await addGrounding(store, {
+      uid: GROUNDING_UID,
+      label: "Grounding with a plain asset ref",
+      propertyDefaultRefs: [PD_UID],
+    });
+    await addCommand(store, COMMAND_UID, GROUNDING_UID);
+
+    const cmd = await resolver.loadCommand(COMMAND_UID);
+
+    expect(cmd!.grounding.propertyDefault![0].value).toBe(
+      `"[[${PLAIN_ASSET_UID}]]"`,
+    );
+    expect(logger.warnings).toHaveLength(0);
+    expect(
+      logger.debugs.some((d) => d.includes(PLAIN_ASSET_UID)),
+    ).toBe(true);
+  });
+
+  it("@req:b354316b-3b26-478b-a8c0-18606da8e6ec stays silent on the happy path (valid token resolves, no fallback taken)", async () => {
+    // Non-vacuity control: without this, both assertions above could pass on a
+    // build that logs unconditionally.
+    await addSubstitutionToken(store, {
+      uid: TOKEN_TODAY_UID,
+      label: "$today",
+      resolverId: "today",
+    });
+    await addPropertyDefault(store, {
+      uid: PD_UID,
+      propertyRefUid: PROP_UID,
+      valueRefUid: TOKEN_TODAY_UID,
+    });
+    await addGrounding(store, {
+      uid: GROUNDING_UID,
+      label: "Grounding with a valid token",
+      propertyDefaultRefs: [PD_UID],
+    });
+    await addCommand(store, COMMAND_UID, GROUNDING_UID);
+
+    const cmd = await resolver.loadCommand(COMMAND_UID);
+
+    // Marker, not a wikilink — no fallback was taken.
+    expect(cmd!.grounding.propertyDefault![0].value).toContain("__SUBSTITUTE__");
+    expect(logger.warnings).toHaveLength(0);
+    expect(logger.debugs.some((d) => d.includes(TOKEN_TODAY_UID))).toBe(false);
   });
 });

--- a/packages/core/tests/unit/services/CommandResolver.substitutionToken.test.ts
+++ b/packages/core/tests/unit/services/CommandResolver.substitutionToken.test.ts
@@ -451,6 +451,13 @@ describe("CommandResolver — RFC v2 Phase 3a SubstitutionToken dispatch", () =>
       (tr) => tr.object instanceof Literal && tr.object.value === TOKEN_ABSENT_UID,
     );
     expect(seeded).toHaveLength(0);
+    // …and the index `findSubjectByUID` consults FIRST: it keys on the UUID
+    // inside the SUBJECT IRI, not on Asset_uid triples. Asserting only the
+    // Asset_uid scan would pass for a fixture seeded as
+    // `obsidian://vault/<uid>.md` with no Asset_uid triple — routing this test
+    // to the OTHER fallback while the guard still reported "unseeded", which is
+    // verbatim the failure the guard exists to prevent.
+    expect(await store.findSubjectsByUUID(TOKEN_ABSENT_UID)).toHaveLength(0);
     await addPropertyDefault(store, {
       uid: PD_UID,
       propertyRefUid: PROP_UID,
@@ -480,12 +487,18 @@ describe("CommandResolver — RFC v2 Phase 3a SubstitutionToken dispatch", () =>
     expect(hit).not.toMatch(/cold-start|pruned vault/);
   });
 
-  it("@req:b354316b-3b26-478b-a8c0-18606da8e6ec warns ONCE per (grounding, value) even across cache invalidation", async () => {
+  it("@req:b354316b-3b26-478b-a8c0-18606da8e6ec warns ONCE per (grounding, value) across repeated resolves", async () => {
     // `warn` is routed to a user-facing Obsidian toast AND the log file, and
-    // this branch re-runs on every button render — `invalidateCache()` fires on
-    // each `.md` save. Undeduped, one dangling ref would toast on every render
-    // (precedent: #3186, ~6 MB of log in two days). invalidateCache() models the
-    // production trigger exactly.
+    // this branch re-runs on every button render. Undeduped, one dangling ref
+    // would toast on every render (precedent: #3186, ~6 MB of log in two days).
+    //
+    // ⛤ The production re-entry chain is: `.md` save → reindex +
+    // `invalidateCache()` (ExocortexPlugin.ts:2867) → next render misses the
+    // `resolveForAsset` caches → `loadCommand` → here. `loadCommand` itself is
+    // UNCACHED, so two direct loads reproduce the repetition exactly; an
+    // `invalidateCache()` call in this test would be INERT (proven: removing it
+    // left the suite green), and asserting otherwise would be one more comment
+    // claiming a mechanism it does not have.
     await addPropertyDefault(store, {
       uid: PD_UID,
       propertyRefUid: PROP_UID,
@@ -502,7 +515,6 @@ describe("CommandResolver — RFC v2 Phase 3a SubstitutionToken dispatch", () =>
     const afterFirst = logger.warnings.length;
     expect(afterFirst).toBe(1);
 
-    resolver.invalidateCache();
     await resolver.loadCommand(COMMAND_UID);
 
     expect(logger.warnings).toHaveLength(afterFirst);

--- a/packages/core/tests/unit/services/CommandResolver.substitutionToken.test.ts
+++ b/packages/core/tests/unit/services/CommandResolver.substitutionToken.test.ts
@@ -439,15 +439,18 @@ describe("CommandResolver — RFC v2 Phase 3a SubstitutionToken dispatch", () =>
     // asset has been indexed. Production then bakes the wikilink into a
     // session-cached command template, poisoning every instance created in
     // that session.
-    // GUARD: prove the UID is genuinely unseeded. Without it, a fixture-UID
-    // collision (this test first used the same constant as GROUNDING_UID)
-    // silently routes to the OTHER fallback and the assertion below measures
-    // the wrong branch while still looking plausible.
-    expect(
-      [PROP_UID, PD_UID, GROUNDING_UID, COMMAND_UID, TOKEN_TODAY_UID,
-       TOKEN_TARGET_FOLDER_UID, TOKEN_UNKNOWN_UID, TOKEN_TODAY_START_UID,
-       TOKEN_NOW_TIMESTAMP_UID, PLAIN_ASSET_UID],
-    ).not.toContain(TOKEN_ABSENT_UID);
+    // GUARD: ask the STORE whether the UID is seeded, rather than diffing
+    // against a hand-listed set of fixture constants. The enumeration form
+    // silently stops covering fixtures added later; this asks the same
+    // question `findSubjectByUID` asks. (This test first used the same
+    // constant as GROUNDING_UID and so measured the OTHER fallback while
+    // still looking plausible.)
+    const seeded = (
+      await store.match(undefined, Namespace.EXO.term("Asset_uid"), undefined)
+    ).filter(
+      (tr) => tr.object instanceof Literal && tr.object.value === TOKEN_ABSENT_UID,
+    );
+    expect(seeded).toHaveLength(0);
     await addPropertyDefault(store, {
       uid: PD_UID,
       propertyRefUid: PROP_UID,
@@ -471,7 +474,38 @@ describe("CommandResolver — RFC v2 Phase 3a SubstitutionToken dispatch", () =>
     const hit = logger.warnings.find((w) => w.includes(TOKEN_ABSENT_UID));
     expect(hit).toBeDefined();
     expect(hit).toContain(GROUNDING_UID);
-    expect(hit).toMatch(/NOT in the store/);
+    expect(hit).toMatch(/not in store/);
+    // The user-facing string must NOT assert a cause the PR itself calls
+    // unmeasured — candidate causes live in the code comment.
+    expect(hit).not.toMatch(/cold-start|pruned vault/);
+  });
+
+  it("@req:b354316b-3b26-478b-a8c0-18606da8e6ec warns ONCE per (grounding, value) even across cache invalidation", async () => {
+    // `warn` is routed to a user-facing Obsidian toast AND the log file, and
+    // this branch re-runs on every button render — `invalidateCache()` fires on
+    // each `.md` save. Undeduped, one dangling ref would toast on every render
+    // (precedent: #3186, ~6 MB of log in two days). invalidateCache() models the
+    // production trigger exactly.
+    await addPropertyDefault(store, {
+      uid: PD_UID,
+      propertyRefUid: PROP_UID,
+      valueRefUid: TOKEN_ABSENT_UID,
+    });
+    await addGrounding(store, {
+      uid: GROUNDING_UID,
+      label: "Grounding re-resolved after invalidation",
+      propertyDefaultRefs: [PD_UID],
+    });
+    await addCommand(store, COMMAND_UID, GROUNDING_UID);
+
+    await resolver.loadCommand(COMMAND_UID);
+    const afterFirst = logger.warnings.length;
+    expect(afterFirst).toBe(1);
+
+    resolver.invalidateCache();
+    await resolver.loadCommand(COMMAND_UID);
+
+    expect(logger.warnings).toHaveLength(afterFirst);
   });
 
   it("@req:b354316b-3b26-478b-a8c0-18606da8e6ec logs at debug (never warn) when the PropertyDefault value is a plain asset, not a token", async () => {


### PR DESCRIPTION
## Что и зачем

`CommandResolver.resolvePropertyDefaultValue` имеет **пять** мест, возвращающих
`"[[<uid>]]"`. Три штатных (значение и есть ссылка) и **две аварийных**, при которых
созданный ассет получает ссылку на сам токен подстановки там, где должно стоять
подставленное значение. Обе **молчали**, тогда как две соседние аварийные ветки в
`dispatchSubstitutionToken` уже пишут `warn` — асимметрия историческая, не намеренная.

Наблюдаемая цена: у шести ассетов живого vault `exo__Asset_label` = `[[ecd68426-…]]`
(токен `$userInputLabel`), а введённое пользователем значение уцелело только в `aliases`.

| строка | условие | было | стало |
|---|---|---|---|
| `!valueSubject` | ассета нет в store (cold-start race / pruned vault) | тишина | `warn` (uid + свойство + grounding) |
| `!isSubstitutionToken` | значение — обычный ассет | тишина | `debug` |

## Почему `debug`, а не `warn`, во второй ветке

Обычная ссылка — **штатный и частый** путь (любое `assetRef`-поле). `warn` там стал бы
шумом и обесценил бы соседнее предупреждение. Уровень — часть спецификации, и он заперт
мутантом M3.

## Чего этот PR НЕ делает

Не чинит порчу. Fail-loud вместо записи ссылки меняет поведение команд и требует своей
оценки — отдельная работа. Здесь закрывается то, что делало класс **недиагностируемым**:
корень пришлось сужать исключением, а не замером, потому что в логе не было ни строки.

⛤ Порча кластеризуется **по сессии** (два случая 2026-08-17 в 23 секундах друг от друга,
остальные в разные дни): определение команды кэшируется, поэтому один холодный старт
травит все создания этой сессии. Значит одной строки лога достаточно, чтобы следующий
случай назвал себя сам.

## Revert-verify

Контроль без мутаций — 0 падений из 14. Каждый мутант роняет **ровно свою** ось:

| мутант | результат |
|---|---|
| M1 — снять `warn` | RED: «warns when the PropertyDefault value asset is absent» |
| M2 — снять `debug` | RED: «logs at debug (never warn) when … plain asset» |
| M3 — `debug` → `warn` | RED: та же ось (заперт **уровень**, не только факт вызова) |

Плюс третья ось «happy path молчит» — контроль невакуумности: без неё первые две прошли бы
и на сборке, логирующей безусловно.

⚠ В тесте есть **гвард отсутствия** фикстурного UID: первая редакция взяла тот же
константный UID, что `GROUNDING_UID`, — «отсутствующий» ассет оказался присутствующим,
и тест молча мерил другую ветку. Гвард запирает этот класс.

## Прогоны

- `packages/core` полностью: **368 сьютов / 8561 тест**, 0 падений
- `check:types` чисто, archgate 24/24 (0 errors), anti-pattern ratchet без рецидива
- ⛤ Три `dynamic-commands`-сьюта краснели до `git submodule update --init` — фикстуры
  сабмодуля, не регрессия; после инициализации 15/15 зелёных

Requirement: `b354316b-3b26-478b-a8c0-18606da8e6ec` (approved)
Defect: `0310aa28-e0c8-437e-ba8d-0f2c1bf4c1ac` (vault-exodev)

https://claude.ai/code/session_015QdGEKFfUAiVYTkvXcDhJ2
