### PR TITLE
fix(resolver): recognise a SubstitutionToken by its resolver property when the class triple is absent

### DIFF
--- a/packages/core/src/services/CommandResolver.ts
+++ b/packages/core/src/services/CommandResolver.ts
@@ -2845,20 +2845,35 @@ export class CommandResolver {
 
     // ⛔ Secondary tell — the token's OWN resolver property.
     //
-    // `Instance_class` is the primary discriminator, and it is precisely what
-    // is missing in the failure this guards: when the class triple has not
-    // loaded, a real SubstitutionToken is classified "not a token", its ref is
-    // emitted as `"[[<uid>]]"`, and that literal lands where the substituted
-    // value belonged — the shape that corrupted `exo__Asset_label` on six live
-    // assets (defect 0310aa28; the user's typed text survived only in
-    // `aliases`). The ambiguity cannot be resolved by the class triple, because
-    // the class triple is the thing that is absent.
+    // EITHER signal suffices — this is a disjunction, not a precedence chain.
+    // The class loop above can only return true; it never exits false, so on
+    // the (today non-existent) input where the class says "not a token" while
+    // the resolver property is present, the resolver wins. The class check
+    // merely runs first because it is the cheaper and more common one.
+    //
+    // The class triple is precisely what is missing in the failure this guards:
+    // when it has not loaded, a real SubstitutionToken is classified "not a
+    // token", its ref is emitted as `"[[<uid>]]"`, and that literal lands where
+    // the substituted value belonged — the shape that corrupted
+    // `exo__Asset_label` on six live assets (defect 0310aa28; the user's typed
+    // text survived only in `aliases`). The ambiguity cannot be resolved by the
+    // class triple, because the class triple is the thing that is absent.
     //
     // `exocmd__SubstitutionToken_resolver` breaks the tie: it is exclusive to
-    // the class. MEASURED, not assumed — on both live vaults every carrier is a
-    // SubstitutionToken (17/17 in vault-my, 17/17 in vault-exodev). A plain
-    // asset ref never carries it, so a wikilink-valued PropertyDefault keeps
-    // resolving to a wikilink exactly as before.
+    // the class. MEASURED, not assumed, on three corpora — the two live vaults
+    // (17/17 emitted triples each) and, reproducibly for any reviewer, the
+    // pinned `packages/exoas-exocmd` submodule (16/16 frontmatter carriers are
+    // SubstitutionToken; the 7 `SubstitutionTokenLegacy` instances carry none).
+    //
+    // ⚠ Re-measuring by grep alone reads as 16/17 and looks like a hole: a
+    // 17th file (`ac573e5d`, a property definition) mentions the key inside a
+    // ```yaml fence in its BODY. That emits no triple — `NoteToRDFConverter`
+    // iterates frontmatter only (`Object.entries(frontmatter)`), and the body
+    // contributes just `Asset_bodyLink`. Discriminate frontmatter from body
+    // before concluding the premise leaks.
+    //
+    // A plain asset ref never carries the property, so a wikilink-valued
+    // PropertyDefault keeps resolving to a wikilink exactly as before.
     const resolverTriples = await this.tripleStore.match(
       subject,
       Namespace.EXOCMD.term("SubstitutionToken_resolver"),

--- a/packages/core/src/services/CommandResolver.ts
+++ b/packages/core/src/services/CommandResolver.ts
@@ -2842,6 +2842,38 @@ export class CommandResolver {
         if (unwrapped === SUBSTITUTION_TOKEN_CLASS_UID) return true;
       }
     }
+
+    // ⛔ Secondary tell — the token's OWN resolver property.
+    //
+    // `Instance_class` is the primary discriminator, and it is precisely what
+    // is missing in the failure this guards: when the class triple has not
+    // loaded, a real SubstitutionToken is classified "not a token", its ref is
+    // emitted as `"[[<uid>]]"`, and that literal lands where the substituted
+    // value belonged — the shape that corrupted `exo__Asset_label` on six live
+    // assets (defect 0310aa28; the user's typed text survived only in
+    // `aliases`). The ambiguity cannot be resolved by the class triple, because
+    // the class triple is the thing that is absent.
+    //
+    // `exocmd__SubstitutionToken_resolver` breaks the tie: it is exclusive to
+    // the class. MEASURED, not assumed — on both live vaults every carrier is a
+    // SubstitutionToken (17/17 in vault-my, 17/17 in vault-exodev). A plain
+    // asset ref never carries it, so a wikilink-valued PropertyDefault keeps
+    // resolving to a wikilink exactly as before.
+    const resolverTriples = await this.tripleStore.match(
+      subject,
+      Namespace.EXOCMD.term("SubstitutionToken_resolver"),
+      undefined,
+    );
+    if (resolverTriples.length > 0) {
+      // `debug`, not `warn`: this path RECOVERS — dispatch proceeds and no
+      // corrupt value is written. A warn here would be a user-facing toast on
+      // every render for a condition the engine just handled.
+      this.logger.debug(
+        `Asset ${subject.value} classified as SubstitutionToken via its resolver property; exo__Instance_class was absent or unresolved.`,
+      );
+      return true;
+    }
+
     return false;
   }
 

--- a/packages/core/src/services/CommandResolver.ts
+++ b/packages/core/src/services/CommandResolver.ts
@@ -2847,9 +2847,25 @@ export class CommandResolver {
     //
     // EITHER signal suffices — this is a disjunction, not a precedence chain.
     // The class loop above can only return true; it never exits false, so on
-    // the (today non-existent) input where the class says "not a token" while
-    // the resolver property is present, the resolver wins. The class check
-    // merely runs first because it is the cheaper and more common one.
+    // the (today non-existent) input where the class resolves to something else
+    // while the resolver property is present, the resolver wins.
+    //
+    // ⛔ The order is NOT a performance choice, and reordering is NOT free:
+    //   - it is not cheaper — both are `match(subject, <predicate>, undefined)`,
+    //     i.e. the same `matchSP` walk of the same `spo` index; the class branch
+    //     then does strictly MORE work (iterate + unwrapWikilink per triple);
+    //   - it does not short-circuit the common case — the common case is a PLAIN
+    //     asset ref (see the call-site comment on the `!isSubstitutionToken`
+    //     branch), which falls through the class loop and runs BOTH lookups
+    //     whatever the order.
+    //
+    // What the order DOES buy is the honesty of the debug line below, which
+    // asserts `exo__Instance_class was absent or unresolved`. Every valid token
+    // carries the resolver property (16/16 on the pinned corpus), so running the
+    // resolver check first would fire that line on EVERY correctly-classified
+    // token — making it a lie. VERIFIED BY PERMUTATION, not argued: moving this
+    // block above the class loop reddens exactly one axis, `@req:b354316b… stays
+    // silent on the happy path` (1 failed / 16 passed).
     //
     // The class triple is precisely what is missing in the failure this guards:
     // when it has not loaded, a real SubstitutionToken is classified "not a
@@ -2859,18 +2875,22 @@ export class CommandResolver {
     // text survived only in `aliases`). The ambiguity cannot be resolved by the
     // class triple, because the class triple is the thing that is absent.
     //
-    // `exocmd__SubstitutionToken_resolver` breaks the tie: it is exclusive to
-    // the class. MEASURED, not assumed, on three corpora — the two live vaults
-    // (17/17 emitted triples each) and, reproducibly for any reviewer, the
-    // pinned `packages/exoas-exocmd` submodule (16/16 frontmatter carriers are
-    // SubstitutionToken; the 7 `SubstitutionTokenLegacy` instances carry none).
+    // `exocmd__SubstitutionToken_resolver` breaks the tie: on the pinned
+    // `packages/exoas-exocmd@829e06bc` the relation is biconditional — all 16
+    // frontmatter carriers are SubstitutionToken, and all 16 SubstitutionToken
+    // instances carry it. The 7 `exocmd__SubstitutionTokenLegacy` instances
+    // (class referenced BY UID `[[660e7539…]]`, not by symbolic name — searching
+    // for the name yields a false zero) carry none.
     //
-    // ⚠ Re-measuring by grep alone reads as 16/17 and looks like a hole: a
-    // 17th file (`ac573e5d`, a property definition) mentions the key inside a
-    // ```yaml fence in its BODY. That emits no triple — `NoteToRDFConverter`
-    // iterates frontmatter only (`Object.entries(frontmatter)`), and the body
-    // contributes just `Asset_bodyLink`. Discriminate frontmatter from body
-    // before concluding the premise leaks.
+    // ⚠ Re-measuring by grep: anchored (`^exocmd__SubstitutionToken_resolver:`)
+    // reads 17, unanchored reads 19 — neither is a hole. The extras mention the
+    // key where it emits no triple with this predicate:
+    //   `ac573e5d` — this property's own def; key inside a ```yaml fence in the BODY
+    //   `08cec529` — the SubstitutionToken class def; prose bullet in the body
+    //   `2f5fe019` — `TokenInvocation_token` def; key inside `Property_description`,
+    //                i.e. a frontmatter VALUE, not a frontmatter key
+    // `NoteToRDFConverter` iterates frontmatter KEYS only
+    // (`Object.entries(frontmatter)`); the body contributes just `Asset_bodyLink`.
     //
     // A plain asset ref never carries the property, so a wikilink-valued
     // PropertyDefault keeps resolving to a wikilink exactly as before.

--- a/packages/core/tests/unit/services/CommandResolver.substitutionToken.test.ts
+++ b/packages/core/tests/unit/services/CommandResolver.substitutionToken.test.ts
@@ -100,6 +100,27 @@ async function addSubstitutionToken(
   ]);
 }
 
+/**
+ * A SubstitutionToken whose `exo__Instance_class` triple did NOT load — the
+ * cold-start shape behind defect 0310aa28. Everything else about the asset is
+ * intact, including its resolver property.
+ */
+async function addTokenWithoutClassTriple(
+  store: InMemoryTripleStore,
+  opts: { uid: string; label: string; resolverId: string },
+): Promise<void> {
+  const subject = new IRI(`obsidian://vault/${opts.uid}.md`);
+  await store.addAll([
+    new Triple(subject, Namespace.EXO.term("Asset_uid"), new Literal(opts.uid)),
+    new Triple(subject, Namespace.EXO.term("Asset_label"), new Literal(opts.label)),
+    new Triple(
+      subject,
+      Namespace.EXOCMD.term("SubstitutionToken_resolver"),
+      new Literal(opts.resolverId),
+    ),
+  ]);
+}
+
 async function addPropertyDefault(
   store: InMemoryTripleStore,
   opts: { uid: string; propertyRefUid: string; valueRefUid: string },
@@ -432,6 +453,78 @@ describe("CommandResolver — RFC v2 Phase 3a SubstitutionToken dispatch", () =>
   // undiagnosable: the root had to be narrowed by ELIMINATION rather than
   // measured. These lock the diagnostics, not the corruption itself.
   // ──────────────────────────────────────────────────────────────────────────
+
+  it("@req:ef825945-62a8-4a9d-b5ea-5992903d3bff dispatches a token whose exo__Instance_class did not load, instead of writing a link into the value", async () => {
+    // THE defect: with the class triple missing, the token was classified
+    // "not a token" and its ref was emitted as `"[[<uid>]]"` — landing in
+    // exo__Asset_label where the substituted value belonged. The resolver
+    // property breaks the tie; it is exclusive to the class (measured 17/17 on
+    // both live vaults), so plain asset refs are unaffected.
+    await addTokenWithoutClassTriple(store, {
+      uid: TOKEN_TODAY_UID,
+      label: "$today",
+      resolverId: "today",
+    });
+    await addPropertyDefault(store, {
+      uid: PD_UID,
+      propertyRefUid: PROP_UID,
+      valueRefUid: TOKEN_TODAY_UID,
+    });
+    await addGrounding(store, {
+      uid: GROUNDING_UID,
+      label: "Grounding whose token lost its class triple",
+      propertyDefaultRefs: [PD_UID],
+    });
+    await addCommand(store, COMMAND_UID, GROUNDING_UID);
+
+    const cmd = await resolver.loadCommand(COMMAND_UID);
+    const value = cmd!.grounding.propertyDefault![0].value;
+
+    // Dispatched — a marker, NOT the corrupting wikilink.
+    expect(value).toContain("__SUBSTITUTE__");
+    expect(value).not.toContain(`[[${TOKEN_TODAY_UID}]]`);
+    // Recovery is quiet on the warn channel: nothing was damaged.
+    expect(logger.warnings).toHaveLength(0);
+  });
+
+  it("@req:ef825945-62a8-4a9d-b5ea-5992903d3bff still emits a wikilink for a plain asset that merely lacks a class triple", async () => {
+    // Non-vacuity control for the tie-breaker: the fallback must key on the
+    // RESOLVER property, not merely on "class triple missing" — otherwise every
+    // unindexed plain ref would be mis-dispatched as a token.
+    //
+    // ⛔ The emitted VALUE alone cannot prove this, and asserting only that was
+    // this test's first, vacuous form: a mis-dispatched plain asset reaches
+    // `dispatchSubstitutionToken`, finds no `_resolver`, and falls back to the
+    // SAME `"[[<uid>]]"` string. The discriminator is the WARN it emits on that
+    // path — proven by the mutant that makes the tie-breaker fire on any
+    // class-less asset.
+    await store.addAll([
+      new Triple(
+        new IRI(`obsidian://vault/${PLAIN_ASSET_UID}.md`),
+        Namespace.EXO.term("Asset_uid"),
+        new Literal(PLAIN_ASSET_UID),
+      ),
+    ]);
+    await addPropertyDefault(store, {
+      uid: PD_UID,
+      propertyRefUid: PROP_UID,
+      valueRefUid: PLAIN_ASSET_UID,
+    });
+    await addGrounding(store, {
+      uid: GROUNDING_UID,
+      label: "Grounding with a class-less plain asset ref",
+      propertyDefaultRefs: [PD_UID],
+    });
+    await addCommand(store, COMMAND_UID, GROUNDING_UID);
+
+    const cmd = await resolver.loadCommand(COMMAND_UID);
+
+    expect(cmd!.grounding.propertyDefault![0].value).toBe(
+      `"[[${PLAIN_ASSET_UID}]]"`,
+    );
+    // Never entered token dispatch: that path warns about the missing resolver.
+    expect(logger.warnings).toHaveLength(0);
+  });
 
   it("@req:b354316b-3b26-478b-a8c0-18606da8e6ec warns when the PropertyDefault value asset is absent from the store (cold-start race)", async () => {
     // NOTE: the value ref is deliberately NOT seeded — this models the


### PR DESCRIPTION
## Чинит саму порчу, а не диагностику

#4076 сделал отказ видимым. Этот PR его **устраняет**.

`assetIsSubstitutionToken` опознавал токен **исключительно** по `exo__Instance_class` — и именно этого трипла нет в том отказе, который надо пережить. Класс не загрузился ⇒ настоящий токен классифицируется как «не токен» ⇒ его ссылка эмитится как `"[[<uid>]]"` ⇒ литерал оказывается там, где должно было стоять подставленное значение.

Живой ущерб: шесть ассетов с `exo__Asset_label` = `[[ecd68426…]]` (= `$userInputLabel`), введённый текст уцелел только в `aliases`. Пять меток восстановлены вручную, шестая невосстановима.

⛔ **Неоднозначность неразрешима самим классом — класс и есть отсутствующее.**

## Разрешающий признак измерен, а не предположен

`exocmd__SubstitutionToken_resolver` эксклюзивен для класса:

| vault | носителей | из них токены |
|---|---|---|
| vault-my | 17 | **17** |
| vault-exodev | 17 | **17** |

⇒ обычная ссылка его не несёт, поэтому wikilink-значения резолвятся ровно как раньше.

## Уровень лога

На пути восстановления — `debug`, не `warn`: движок отказ **обработал**, ничего неверного не записано, а `warn` здесь есть пользовательский тост (установлено в #4076).

## Revert-verify (контроль 0/17)

| мутант | результат |
|---|---|
| N1 — снять вторичный признак | RED: ось дефекта |
| N2 — срабатывать на ЛЮБОМ ассете без класса | RED: **обе** контрольные оси на обычный ассет |

⛤ N2 — несущий, и он первым делом вскрыл **мою собственную ось как вакуумную**: мис-диспатчнутый обычный ассет доходит до `dispatchSubstitutionToken`, не находит resolver и откатывается к **той же** строке `"[[uid]]"` — то есть проверка значения не доказывала ничего. Различает их **warn**, который эмитится на том пути; контроль теперь его и проверяет.

## Границы

Ветка «ассета нет в store вовсе» намеренно **не** тронута: там неоднозначность реальна — для обычной ссылки `[[uid]]` и есть верное значение, оно резолвится после индексации. Она остаётся ссылкой + warn из #4076.

Requirement: `ef825945-62a8-4a9d-b5ea-5992903d3bff` (approved)
Defect: `0310aa28-e0c8-437e-ba8d-0f2c1bf4c1ac`

368 сьютов / 8564 теста зелёные; `check:types` чист; anti-pattern ratchet без рецидива.

https://claude.ai/code/session_015QdGEKFfUAiVYTkvXcDhJ2

---

## ⛔ Граница: закрыт ОДИН из ДВУХ путей к этой порче

Адверсарное ревью нашло **вторую дверь**, и она стоит **раньше** по пути резолва:
`assetIsTokenInvocation` (`CommandResolver.ts`, вызывается из
`resolvePropertyDefaultValue` до проверяемой здесь функции) классифицирует ассет
**исключительно** по `exo__Instance_class` — то есть несёт ровно тот же пробел,
ту же причину отказа и ту же наблюдаемую порчу (`"[[<uid>]]"` вместо
подставленного значения).

Признак для неё эксклюзивен так же, как здесь, и это **замерено** на запиненном
`packages/exoas-exocmd@829e06b`: `exocmd__TokenInvocation_token` во frontmatter
несут **2** ассета, оба `exo__Instance_class = 3f28af98` (`exocmd__TokenInvocation`);
третье попадание наивного grep — property-def с ключом в теле, трипла не эмитит.

**Почему не в этом PR.** Требование `ef825945-62a8-4a9d-b5ea-5992903d3bff`
описывает распознавание токена **по его resolver-свойству**. Здесь другой признак
(`_token`) на другом классе — в его Gherkin это не входит ⇒ по `/feature-sdd`
Step 0 это отдельное требование, а не расширение уже отревьюенного PR.

Вынесено: **#4079** (зеркало в графе — `ems__Task 8cf8a6fa`).

⇒ Читать этот PR как «закрыт путь SubstitutionToken», **не** как «порча
устранена целиком».
