### PR TITLE
fix(resolver): recognise a TokenInvocation by its _token property when the class triple is absent

### DIFF
--- a/packages/core/src/services/CommandResolver.ts
+++ b/packages/core/src/services/CommandResolver.ts
@@ -2838,12 +2838,15 @@ export class CommandResolver {
     // ⛔ The order is NOT a performance choice: both lookups are
     // `match(subject, <predicate>, undefined)` — the same `matchSP` walk of the
     // same `spo` index, and the class branch then does strictly MORE work
-    // (iterate + unwrapWikilink per triple).
+    // (iterate, unwrapping wikilinks on Literal objects).
     //
     // What it buys is the honesty of the debug line below, which asserts
-    // `exo__Instance_class was absent or unresolved`. EVERY well-formed
-    // invocation carries both signals, so checking `_token` first would fire
-    // that line on an invocation whose class is right there — a lie.
+    // `exo__Instance_class was absent or unresolved`. A well-formed invocation
+    // carries both signals — 2/2 on the pin, and `_token` is declared
+    // Required/cardinality-1 on `2f5fe019`, though in `exo__Property_description`
+    // prose, not as `exo__Property_cardinality`/`_minCount`, so SHACL does not
+    // enforce it. Checking `_token` first would therefore fire that line on an
+    // invocation whose class is right there — a lie.
     // VERIFIED BY PERMUTATION, not argued: moving this block above the class
     // loop reddens exactly one axis, `@req:81d2e07e… stays silent for a
     // well-formed invocation` (1 failed / 20 passed).

--- a/packages/core/src/services/CommandResolver.ts
+++ b/packages/core/src/services/CommandResolver.ts
@@ -2825,18 +2825,28 @@ export class CommandResolver {
     // frontmatter carriers are TokenInvocation, and both TokenInvocation
     // instances carry it.
     //
-    // ⚠ Re-measuring by grep finds 3 extra files that mention the key where it
+    // ⚠ Re-measuring by grep finds 3 extra files that mention the name where it
     // emits no triple with this predicate — `NoteToRDFConverter` iterates
-    // frontmatter KEYS only:
-    //   `606df367` — a SubstitutionToken instance; prose mention in the body
-    //   `3f28af98` — the TokenInvocation class def itself
-    //   `2f5fe019` — this property's own def; the key sits inside
-    //                `exo__Property_description`, i.e. a frontmatter VALUE
+    // frontmatter KEYS only, and in none of the three is it a key:
+    //   `606df367` — a SubstitutionToken instance; prose sentence in the body
+    //   `3f28af98` — the TokenInvocation class def; two prose bullets in the body
+    //   `2f5fe019` — this property's OWN definition, so its name is its
+    //                `exo__Asset_label` and an alias (frontmatter VALUES), plus a
+    //                heading and a key inside a ```yaml fence in the BODY
+    //                (frontmatter closes above it)
     //
-    // ⛔ Order, as in the sibling method, is NOT a performance choice: both are
+    // ⛔ The order is NOT a performance choice: both lookups are
     // `match(subject, <predicate>, undefined)` — the same `matchSP` walk of the
-    // same `spo` index. It keeps the debug line below honest, since that line
-    // asserts the class was absent.
+    // same `spo` index, and the class branch then does strictly MORE work
+    // (iterate + unwrapWikilink per triple).
+    //
+    // What it buys is the honesty of the debug line below, which asserts
+    // `exo__Instance_class was absent or unresolved`. EVERY well-formed
+    // invocation carries both signals, so checking `_token` first would fire
+    // that line on an invocation whose class is right there — a lie.
+    // VERIFIED BY PERMUTATION, not argued: moving this block above the class
+    // loop reddens exactly one axis, `@req:81d2e07e… stays silent for a
+    // well-formed invocation` (1 failed / 20 passed).
     const tokenTriples = await this.tripleStore.match(
       subject,
       Namespace.EXOCMD.term("TokenInvocation_token"),

--- a/packages/core/src/services/CommandResolver.ts
+++ b/packages/core/src/services/CommandResolver.ts
@@ -2807,6 +2807,57 @@ export class CommandResolver {
         if (unwrapped === TOKEN_INVOCATION_CLASS_UID) return true;
       }
     }
+
+    // ⛔ Secondary tell — the invocation's OWN `_token` property.
+    //
+    // This is the SECOND door to defect 0310aa28, and the earlier one: this
+    // method runs before `assetIsSubstitutionToken` (see
+    // `resolvePropertyDefaultValue`). When the class triple has not loaded, a
+    // real TokenInvocation is classified "not an invocation", falls through to
+    // the SubstitutionToken check — which cannot catch it either, because an
+    // invocation carries no `_resolver` — and the ref is emitted as
+    // `"[[<uid>]]"` where the substituted value belonged. The first door was
+    // closed by `@req:ef825945…`; without this one the corruption survives.
+    //
+    // The tie cannot be broken by the class triple: its absence IS the failure.
+    // `exocmd__TokenInvocation_token` breaks it — on the pinned
+    // `packages/exoas-exocmd@829e06bc` the relation is biconditional: both
+    // frontmatter carriers are TokenInvocation, and both TokenInvocation
+    // instances carry it.
+    //
+    // ⚠ Re-measuring by grep finds 3 extra files that mention the key where it
+    // emits no triple with this predicate — `NoteToRDFConverter` iterates
+    // frontmatter KEYS only:
+    //   `606df367` — a SubstitutionToken instance; prose mention in the body
+    //   `3f28af98` — the TokenInvocation class def itself
+    //   `2f5fe019` — this property's own def; the key sits inside
+    //                `exo__Property_description`, i.e. a frontmatter VALUE
+    //
+    // ⛔ Order, as in the sibling method, is NOT a performance choice: both are
+    // `match(subject, <predicate>, undefined)` — the same `matchSP` walk of the
+    // same `spo` index. It keeps the debug line below honest, since that line
+    // asserts the class was absent.
+    const tokenTriples = await this.tripleStore.match(
+      subject,
+      Namespace.EXOCMD.term("TokenInvocation_token"),
+      undefined,
+    );
+    if (tokenTriples.length > 0) {
+      // `debug`, not `warn`: this path RECOVERS — the invocation is dispatched
+      // and no corrupt value is written. A warn here would be a user-facing
+      // toast on every render for a condition the engine just handled.
+      //
+      // Naming the invocation explicitly also removes a mis-attribution: before
+      // this tell, such an asset fell through to the SubstitutionToken branch,
+      // whose log line says "is not a SubstitutionToken" — literally true, and
+      // it sends the reader to look for a `_resolver` an invocation can never
+      // have.
+      this.logger.debug(
+        `Asset ${subject.value} classified as TokenInvocation via its exocmd__TokenInvocation_token property; exo__Instance_class was absent or unresolved.`,
+      );
+      return true;
+    }
+
     return false;
   }
 

--- a/packages/core/tests/unit/services/CommandResolver.substitutionToken.test.ts
+++ b/packages/core/tests/unit/services/CommandResolver.substitutionToken.test.ts
@@ -128,6 +128,38 @@ async function addTokenWithoutClassTriple(
  * fixture (`CommandResolver.universalDefaultTemplate.test.ts`) minus the class
  * triple: `_token` is an IRI ref, `_parameter` a literal.
  */
+/**
+ * A well-formed TokenInvocation — class triple PRESENT. Shape mirrors the
+ * canonical fixture in `CommandResolver.universalDefaultTemplate.test.ts`.
+ * Exists so the happy path can be asserted against a RECORDING logger: that
+ * suite's logger is a no-op stub (`debug() {}`) and is structurally unable to
+ * assert silence.
+ */
+async function addTokenInvocation(
+  store: InMemoryTripleStore,
+  opts: { uid: string; tokenRefUid: string; parameter: string },
+): Promise<void> {
+  const subject = new IRI(`obsidian://vault/${opts.uid}.md`);
+  await store.addAll([
+    new Triple(subject, Namespace.EXO.term("Asset_uid"), new Literal(opts.uid)),
+    new Triple(
+      subject,
+      Namespace.EXO.term("Instance_class"),
+      Namespace.EXOCMD.term("TokenInvocation"),
+    ),
+    new Triple(
+      subject,
+      Namespace.EXOCMD.term("TokenInvocation_token"),
+      new IRI(`obsidian://vault/${opts.tokenRefUid}.md`),
+    ),
+    new Triple(
+      subject,
+      Namespace.EXOCMD.term("TokenInvocation_parameter"),
+      new Literal(opts.parameter),
+    ),
+  ]);
+}
+
 async function addInvocationWithoutClassTriple(
   store: InMemoryTripleStore,
   opts: { uid: string; tokenRefUid: string; parameter: string },
@@ -242,6 +274,9 @@ const PLAIN_ASSET_UID         = "99999999-9999-4999-8999-999999999999";
 // reusing an existing fixture constant is exactly how the earlier axis silently
 // measured the wrong branch (see the guard in the TOKEN_ABSENT_UID test).
 const INVOCATION_NO_CLASS_UID = "cccccccc-cccc-4ccc-8ccc-cccccccccccc";
+// …and its well-formed twin: class triple PRESENT. Locks the ORDER of the two
+// checks, which nothing else does.
+const INVOCATION_OK_UID       = "dddddddd-dddd-4ddd-8ddd-dddddddddddd";
 
 const PD_UID  = "55555555-5555-4555-8555-555555555555";
 
@@ -834,5 +869,56 @@ describe("CommandResolver — RFC v2 Phase 3a SubstitutionToken dispatch", () =>
       ),
     ).toBe(false);
     expect(logger.warnings).toHaveLength(0);
+  });
+
+  it("@req:81d2e07e-413e-4e40-9159-83ccdb813561 stays silent for a well-formed invocation (class present) — locks the ORDER of the two checks", async () => {
+    // This axis exists because the ordering rationale in the source comment was
+    // otherwise ARGUED, not locked: permuting the two checks left the whole
+    // suite green, so nothing would have caught it.
+    //
+    // Every well-formed invocation carries BOTH signals. Run the `_token` check
+    // first and the debug line — which asserts `exo__Instance_class was absent
+    // or unresolved` — fires on an invocation whose class is right there,
+    // i.e. it starts lying. The order is what keeps that line honest, and this
+    // test is what keeps the order.
+    //
+    // ⛤ The sibling suite has a happy-path invocation fixture already, but its
+    // logger is a no-op stub (`debug() {}`) — structurally unable to assert
+    // silence. Hence the fixture is rebuilt here against the recording logger.
+    await addSubstitutionToken(store, {
+      uid: TOKEN_TODAY_UID,
+      label: "$today",
+      resolverId: "today",
+    });
+    await addTokenInvocation(store, {
+      uid: INVOCATION_OK_UID,
+      tokenRefUid: TOKEN_TODAY_UID,
+      parameter: "+1d",
+    });
+    await addPropertyDefault(store, {
+      uid: PD_UID,
+      propertyRefUid: PROP_UID,
+      valueRefUid: INVOCATION_OK_UID,
+    });
+    await addGrounding(store, {
+      uid: GROUNDING_UID,
+      label: "Grounding with a well-formed invocation",
+      propertyDefaultRefs: [PD_UID],
+    });
+    await addCommand(store, COMMAND_UID, GROUNDING_UID);
+
+    const cmd = await resolver.loadCommand(COMMAND_UID);
+
+    // Dispatched normally — proves the fixture really exercises the happy path
+    // rather than silently failing somewhere before the diagnostic.
+    expect(cmd!.grounding.propertyDefault![0].value).toContain(
+      "__SUBSTITUTE_P__",
+    );
+    expect(logger.warnings).toHaveLength(0);
+    // The claim under lock: no line may assert the class was absent, because
+    // it is present.
+    expect(
+      logger.debugs.some((d) => /was absent or unresolved/.test(d)),
+    ).toBe(false);
   });
 });

--- a/packages/core/tests/unit/services/CommandResolver.substitutionToken.test.ts
+++ b/packages/core/tests/unit/services/CommandResolver.substitutionToken.test.ts
@@ -121,6 +121,33 @@ async function addTokenWithoutClassTriple(
   ]);
 }
 
+/**
+ * A TokenInvocation whose `exo__Instance_class` triple did NOT load — the SECOND
+ * door to defect 0310aa28, and the earlier one: `assetIsTokenInvocation` runs
+ * before `assetIsSubstitutionToken`. Shape mirrors the canonical invocation
+ * fixture (`CommandResolver.universalDefaultTemplate.test.ts`) minus the class
+ * triple: `_token` is an IRI ref, `_parameter` a literal.
+ */
+async function addInvocationWithoutClassTriple(
+  store: InMemoryTripleStore,
+  opts: { uid: string; tokenRefUid: string; parameter: string },
+): Promise<void> {
+  const subject = new IRI(`obsidian://vault/${opts.uid}.md`);
+  await store.addAll([
+    new Triple(subject, Namespace.EXO.term("Asset_uid"), new Literal(opts.uid)),
+    new Triple(
+      subject,
+      Namespace.EXOCMD.term("TokenInvocation_token"),
+      new IRI(`obsidian://vault/${opts.tokenRefUid}.md`),
+    ),
+    new Triple(
+      subject,
+      Namespace.EXOCMD.term("TokenInvocation_parameter"),
+      new Literal(opts.parameter),
+    ),
+  ]);
+}
+
 async function addPropertyDefault(
   store: InMemoryTripleStore,
   opts: { uid: string; propertyRefUid: string; valueRefUid: string },
@@ -211,6 +238,10 @@ const TOKEN_NOW_TIMESTAMP_UID = "77777777-7777-4777-8777-777777777777";
 const TOKEN_ABSENT_UID        = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
 // An ordinary asset (not a SubstitutionToken) — the common, correct path.
 const PLAIN_ASSET_UID         = "99999999-9999-4999-8999-999999999999";
+// @req:81d2e07e — an invocation whose class triple never loaded. Distinct UID:
+// reusing an existing fixture constant is exactly how the earlier axis silently
+// measured the wrong branch (see the guard in the TOKEN_ABSENT_UID test).
+const INVOCATION_NO_CLASS_UID = "cccccccc-cccc-4ccc-8ccc-cccccccccccc";
 
 const PD_UID  = "55555555-5555-4555-8555-555555555555";
 
@@ -667,5 +698,141 @@ describe("CommandResolver — RFC v2 Phase 3a SubstitutionToken dispatch", () =>
     expect(cmd!.grounding.propertyDefault![0].value).toContain("__SUBSTITUTE__");
     expect(logger.warnings).toHaveLength(0);
     expect(logger.debugs.some((d) => d.includes(TOKEN_TODAY_UID))).toBe(false);
+  });
+
+  it("@req:81d2e07e-413e-4e40-9159-83ccdb813561 dispatches an invocation whose exo__Instance_class did not load", async () => {
+    // The SECOND door to defect 0310aa28, and the one reached FIRST:
+    // `assetIsTokenInvocation` runs before `assetIsSubstitutionToken`. Without
+    // the `_token` tell, a class-less invocation is judged "not an invocation",
+    // falls through to the SubstitutionToken check — which cannot catch it
+    // either (an invocation carries no `_resolver`) — and the ref is emitted as
+    // a wikilink where the substituted value belonged.
+    await addSubstitutionToken(store, {
+      uid: TOKEN_TODAY_UID,
+      label: "$today",
+      resolverId: "today",
+    });
+    await addInvocationWithoutClassTriple(store, {
+      uid: INVOCATION_NO_CLASS_UID,
+      tokenRefUid: TOKEN_TODAY_UID,
+      parameter: "+1d",
+    });
+    await addPropertyDefault(store, {
+      uid: PD_UID,
+      propertyRefUid: PROP_UID,
+      valueRefUid: INVOCATION_NO_CLASS_UID,
+    });
+    await addGrounding(store, {
+      uid: GROUNDING_UID,
+      label: "Grounding whose value is an invocation with no class triple",
+      propertyDefaultRefs: [PD_UID],
+    });
+    await addCommand(store, COMMAND_UID, GROUNDING_UID);
+
+    const cmd = await resolver.loadCommand(COMMAND_UID);
+
+    const value = cmd!.grounding.propertyDefault![0].value;
+    // Assert BOTH: that the corruption shape is gone AND that the invocation
+    // actually dispatched. The first alone would pass on a build that emits any
+    // non-wikilink string; the second alone would pass if the wikilink form
+    // happened to contain a marker.
+    expect(value).not.toBe(`"[[${INVOCATION_NO_CLASS_UID}]]"`);
+    // `_P` is the PARAMETERISED marker — the bare-token path emits
+    // `__SUBSTITUTE__` without it, so this suffix alone proves the INVOCATION
+    // branch ran rather than a plain token dispatch.
+    expect(value).toContain("__SUBSTITUTE_P__");
+    expect(value).toContain(TOKEN_TODAY_UID);
+    // The parameter travels base64-encoded: "+1d" -> "KzFk". Asserted as the
+    // literal rather than re-deriving it in the test, so a change to the
+    // encoding surfaces here instead of being tracked silently.
+    expect(value).toContain("KzFk");
+
+    const hit = logger.debugs.find((d) => d.includes(INVOCATION_NO_CLASS_UID));
+    expect(hit).toBeDefined();
+    expect(hit).toMatch(/TokenInvocation/);
+  });
+
+  it("@req:81d2e07e-413e-4e40-9159-83ccdb813561 does not mis-attribute the invocation to the SubstitutionToken branch", async () => {
+    // Before the tell, this asset reached the `!isSubstitutionToken` branch,
+    // whose line reads "is not a SubstitutionToken" — literally true, and it
+    // sends the reader hunting for a `_resolver` an invocation can never carry.
+    // The diagnostic must name the door that was actually taken.
+    await addSubstitutionToken(store, {
+      uid: TOKEN_TODAY_UID,
+      label: "$today",
+      resolverId: "today",
+    });
+    await addInvocationWithoutClassTriple(store, {
+      uid: INVOCATION_NO_CLASS_UID,
+      tokenRefUid: TOKEN_TODAY_UID,
+      parameter: "+1d",
+    });
+    await addPropertyDefault(store, {
+      uid: PD_UID,
+      propertyRefUid: PROP_UID,
+      valueRefUid: INVOCATION_NO_CLASS_UID,
+    });
+    await addGrounding(store, {
+      uid: GROUNDING_UID,
+      label: "Grounding whose value is an invocation with no class triple",
+      propertyDefaultRefs: [PD_UID],
+    });
+    await addCommand(store, COMMAND_UID, GROUNDING_UID);
+
+    await resolver.loadCommand(COMMAND_UID);
+
+    const about = logger.debugs.filter((d) =>
+      d.includes(INVOCATION_NO_CLASS_UID),
+    );
+    expect(about.length).toBeGreaterThan(0);
+    expect(
+      about.some((d) => /is not a SubstitutionToken/.test(d)),
+    ).toBe(false);
+  });
+
+  it("@req:81d2e07e-413e-4e40-9159-83ccdb813561 leaves a plain class-less asset as a wikilink (tell keys on _token, not on 'class missing')", async () => {
+    // Non-vacuity control, and the one that matters most here: a tell that fired
+    // on ANY asset lacking a class triple would mis-dispatch every unindexed
+    // plain ref. Seeded WITHOUT a class triple on purpose — that is the input a
+    // too-broad tell would swallow.
+    const subject = new IRI(`obsidian://vault/${PLAIN_ASSET_UID}.md`);
+    await store.addAll([
+      new Triple(
+        subject,
+        Namespace.EXO.term("Asset_uid"),
+        new Literal(PLAIN_ASSET_UID),
+      ),
+      new Triple(
+        subject,
+        Namespace.EXO.term("Asset_label"),
+        new Literal("Ordinary asset, no class triple, no _token"),
+      ),
+    ]);
+    await addPropertyDefault(store, {
+      uid: PD_UID,
+      propertyRefUid: PROP_UID,
+      valueRefUid: PLAIN_ASSET_UID,
+    });
+    await addGrounding(store, {
+      uid: GROUNDING_UID,
+      label: "Grounding with a class-less plain asset ref",
+      propertyDefaultRefs: [PD_UID],
+    });
+    await addCommand(store, COMMAND_UID, GROUNDING_UID);
+
+    const cmd = await resolver.loadCommand(COMMAND_UID);
+
+    expect(cmd!.grounding.propertyDefault![0].value).toBe(
+      `"[[${PLAIN_ASSET_UID}]]"`,
+    );
+    // Value alone is a weak assertion — a mis-dispatched plain asset falls back
+    // to the SAME string further down. Assert the classification never claimed
+    // TokenInvocation, and that nothing escalated to a user-facing toast.
+    expect(
+      logger.debugs.some(
+        (d) => d.includes(PLAIN_ASSET_UID) && /TokenInvocation/.test(d),
+      ),
+    ).toBe(false);
+    expect(logger.warnings).toHaveLength(0);
   });
 });


### PR DESCRIPTION
Closes #4079. Requirement: `81d2e07e-413e-4e40-9159-83ccdb813561` (approved, `exoas-exo-reqs`).

## Что это закрывает

**Вторая дверь к порче дефекта `0310aa28` — и та, до которой доходят ПЕРВОЙ.**

`assetIsTokenInvocation` вызывается раньше `assetIsSubstitutionToken` (`resolvePropertyDefaultValue` :2654 против :2665) и опознавал ассет **исключительно** по `exo__Instance_class`. Этот трипл и отсутствует в отказе: настоящая `exocmd__TokenInvocation` признавалась «не инвокацией», проваливалась на проверку SubstitutionToken — которая её тоже не ловит, потому что у инвокации нет `_resolver`, — и ссылка уходила в `"[[<uid>]]"` туда, где ожидалось подставленное значение (:2680).

PR #4078 закрыл вторую половину развилки; эта оставалась открытой.

## Почему признак пригоден

Двусмысленность **нельзя** разрешить триплом класса: его отсутствие и есть отказ. Разрешает `exocmd__TokenInvocation_token`.

Замерено на запиненном `packages/exoas-exocmd@829e06bc` (воспроизводимо для CI и любого ревьюера), связь **биусловна**:

| | |
|---|---|
| frontmatter-носители `_token` | **2**, оба `exo__Instance_class = 3f28af98` |
| инстансов `exocmd__TokenInvocation` | **2**, **оба** несут `_token` |

⚠ Наивный греп найдёт ещё три файла — они упоминают ключ там, где он не эмитит трипла с этим предикатом (`NoteToRDFConverter` итерирует frontmatter-**ключи**): `606df367` (проза в теле), `3f28af98` (сам class-def), `2f5fe019` (ключ внутри `exo__Property_description`, то есть во frontmatter-**значении**). Все три названы в комментарии, чтобы перемер не читался как течь премиссы.

## Вторая половина: снята мис-атрибуция

До этого признака такой ассет доходил до ветки `!isSubstitutionToken`, чья строка гласит `… is not a SubstitutionToken`. Формально верно — и уводит читателя искать `_resolver`, которого у инвокации не бывает по построению. Новая `debug`-строка называет ту дверь, которая реально была взята.

`debug`, а не `warn`: путь **восстанавливается** (инвокация диспатчится, порчи не пишется), а `warn` идёт пользовательским тостом на каждый рендер.

## Revert-verify

Контроль **20/20**.

| мутант | ожидание | факт |
|---|---|---|
| **N1** снять признак целиком (= `origin/main`) | краснеют 2 оси дефекта | ✅ ровно они |
| **N2** ключеваться на «класс отсутствует» вместо `_token` | краснеет негативный контроль | ✅ 4 оси, все с class-less фикстурами |

⛤ Ширина N2 **законна, а не смешение осей**: мутант мис-диспатчит **каждый** class-less ассет, а четыре покрасневшие оси именно такие фикстуры и сеют (`addLabelledAsset` класс-трипл не пишет — проверено). Краснота следует из семантики мутанта на предмете каждой оси, поэтому перечислена явно, а не подогнана сужением фикстур.

⛔ Наивный мутант `if (true)` был отвергнут как **неизолирующий**: до этой точки доходят и ассеты, у которых класс ЕСТЬ, просто не тот (любой SubstitutionToken), поэтому он ронял 16 тестов и читался бы как дефект осей, хотя дефект был в мутанте.

## Регрессия

27 сьютов / 505 тестов зелёные (`CommandResolver`, `GroundingExecutor`, `TemplateBodyResolver`); `tsc --noEmit` чист.

## Что остаётся открытым

**Третья дверь того же корня — #4080**: кэш Universal Default Template латчится первым вызовом, а `clearUniversalCache()` имеет **ноль вызовов** во всём монорепо. Форма иная (не порча значения, а его отсутствие: молча нет `createdAt`/`updatedAt`), персистентность хуже (латч на сессию). Вынесена отдельно — другой предикат, другой механизм, своё требование.

⇒ Читать этот PR как «закрыта вторая из трёх дверей», не как «порча устранена целиком».
