### PR TITLE
fix(resolver): invalidate the Universal Default Template cache, and stop paying an O(vault) scan for it

### DIFF
--- a/packages/core/src/services/CommandResolver.ts
+++ b/packages/core/src/services/CommandResolver.ts
@@ -821,6 +821,12 @@ export class CommandResolver {
    * ⛔ `_fallbackWarnedKeys` stays deliberately un-cleared here — see its own
    * docstring; clearing warn-suppression on every save reinstates the toast
    * storm of #3186. Different field, different rationale.
+   *
+   * ⚠ Scope note: {@link clearUniversalCache} also clears the MODULE-level
+   * loader cache (`clearUniversalDefault`), so this method is no longer purely
+   * instance-scoped. Moot today — no host calls `registerUniversalDefaultLoader`
+   * (issue #4083), so `loadUniversalDefault()` always returns null — but a host
+   * that wires one must expect it to be re-asked after every `.md` save.
    */
   invalidateCache(): void {
     this.cache.clear();
@@ -2354,18 +2360,41 @@ export class CommandResolver {
     // ⛤ Load-bearing, not micro-optimisation. Since that requirement wired
     // this lookup into `invalidateCache()`, it runs after EVERY `.md` save
     // instead of once per session — and the unbound-object scan below walks
-    // every `exo__Instance_class` triple in the vault. Measured share of a
-    // post-invalidation `loadCommand`, unbound scan only:
-    //   2 000 triples → 57 %   10 000 → 90 %   30 000 → 96 %
-    // i.e. it DOMINATES the reload rather than drowning in it, and the cost
-    // grows with the vault. `matchPO` goes through the `pos` index, so binding
-    // the object turns O(vault) into O(matches) on the healthy path.
+    // every `exo__Instance_class` triple in the vault, so its cost grows with
+    // the vault while everything else in a command reload does not. It
+    // DOMINATES that reload rather than drowning in it.
     //
-    // ⛔ The scan below is still REQUIRED and is not dead: `Instance_class` is
-    // emitted in two forms (bare `[[uid]]` → symbolic IRI, `[[label]]` →
-    // wikilink literal — the dual-IRI split), and only the IRI form can be
-    // bound here. A vault whose singleton is written label-first resolves
-    // solely through the fallback.
+    // `matchPO` goes through the `pos` index (see `InMemoryTripleStore`), so
+    // binding the object turns O(vault) into O(matches) on the healthy path.
+    // That is the durable argument; the share-of-reload figures that motivated
+    // it are a point measurement and live in the PR (#4082), not here — they
+    // would go stale, and the mechanism above does not.
+    //
+    // ⛔ The scan below is REQUIRED, and the reason is NOT "the label form".
+    // Read `NoteToRDFConverter.valueToClassURI` before touching it: BOTH
+    // canonical spellings end up symbolic, i.e. on the fast path —
+    //   `[[exocmd__UniversalDefaultTemplate]]` → `expandClassValue` is a pure
+    //      prefix parse, no vault access → symbolic IRI;
+    //   `[[<class-uid>]]`                     → file resolves, basename is a
+    //      UUID, so the class file's `exo__Asset_label` is read → symbolic IRI.
+    // What actually reaches the fallback is a FILE IRI or a Literal:
+    //   1. the class file resolves but `getFrontmatter` returns null — i.e. a
+    //      COLD `metadataCache`. ⛤ That is this requirement's OWN subject: the
+    //      warm-up window is exactly when a `null` verdict used to latch. The
+    //      fallback is the branch that catches the singleton in that window.
+    //   2. `emitInstanceClassAsUid: true` (RFC 78572fa9 stage-1) → file IRI.
+    //   3. the uid does not resolve to a file → `Literal("[[<uid>]]")`.
+    // Cases 1-2 land in the `includes(UNIVERSAL_DEFAULT_TEMPLATE_CLASS_UID)`
+    // branch, case 3 in the Literal branch. All three are covered by axes.
+    //
+    // ⛔ The early return below deliberately does NOT union the forms: once a
+    // symbolic candidate exists the other spellings are not considered, so the
+    // "multiple singletons" warn keys on the symbolic form alone. Unioning
+    // would mean always paying the scan — i.e. undoing this block. In a
+    // steady-state vault every singleton is symbolic, so the warn still fires;
+    // it is only suppressed in the mixed-form warm-up window, where the pick
+    // may differ from the pre-change lexicographic one (both are valid
+    // singletons).
     const indexed = await this.tripleStore.match(
       undefined,
       Namespace.EXO.term("Instance_class"),

--- a/packages/core/src/services/CommandResolver.ts
+++ b/packages/core/src/services/CommandResolver.ts
@@ -806,17 +806,19 @@ export class CommandResolver {
    * so the template — and, worse, a `null` verdict latched against a not-yet-
    * warm store — survived until the plugin was restarted.
    *
-   * ⛤ On COST, since {@link findUniversalSingleton} is O(vault) (it walks every
-   * `exo__Instance_class` triple; the object cannot be bound because it arrives
-   * in both IRI and wikilink-literal form): this method ALREADY clears `cache`
-   * and `multiCache`, which forces the next render to re-load every visible
-   * command together with its grounding, property-defaults and inheritance
-   * rules — dozens of store queries. The one extra in-memory walk runs ONCE per
-   * invalidation (the latch re-arms on the first call) and is dominated by that.
+   * ⛤ On COST: {@link findUniversalSingleton} takes an INDEXED path first
+   * (bound object → `matchPO` → O(matches)), so this call is cheap on a healthy
+   * vault. It degrades to an O(vault) walk only when the singleton's class
+   * object is not the symbolic IRI — read the comment on that method for which
+   * forms those are and why the walk must stay. The walk, when taken, runs ONCE
+   * per invalidation (the latch re-arms on the first call).
    *
-   * ⛔ NOT the `scanVault`-per-change shape that caused the iPhone Jetsam storm:
-   * that walk read FILES; this one walks an already-materialised in-memory
-   * index. Different cost class — see the PR for the measured numbers.
+   * ⛔ Do NOT re-derive the cost from "invalidateCache reloads everything
+   * anyway, so one more walk drowns in it" — that was measured and is FALSE
+   * (PR #4082): the unbound walk was 57 % / 90 % / 96 % of a post-invalidation
+   * `loadCommand` at 2k / 10k / 30k triples, i.e. it dominated and grew with the
+   * vault. The indexed path is what makes clearing here affordable; removing it
+   * re-introduces O(vault) work on every `.md` save.
    *
    * ⛔ `_fallbackWarnedKeys` stays deliberately un-cleared here — see its own
    * docstring; clearing warn-suppression on every save reinstates the toast
@@ -2361,8 +2363,9 @@ export class CommandResolver {
     // this lookup into `invalidateCache()`, it runs after EVERY `.md` save
     // instead of once per session — and the unbound-object scan below walks
     // every `exo__Instance_class` triple in the vault, so its cost grows with
-    // the vault while everything else in a command reload does not. It
-    // DOMINATES that reload rather than drowning in it.
+    // the vault while everything else in a command reload does not, so on a
+    // large vault it dominates that reload rather than drowning in it (figures
+    // in PR #4082).
     //
     // `matchPO` goes through the `pos` index (see `InMemoryTripleStore`), so
     // binding the object turns O(vault) into O(matches) on the healthy path.
@@ -2382,19 +2385,29 @@ export class CommandResolver {
     //      COLD `metadataCache`. ⛤ That is this requirement's OWN subject: the
     //      warm-up window is exactly when a `null` verdict used to latch. The
     //      fallback is the branch that catches the singleton in that window.
-    //   2. `emitInstanceClassAsUid: true` (RFC 78572fa9 stage-1) → file IRI.
+    //   2. `emitInstanceClassAsUid: true` (RFC 78572fa9 stage-1) → file IRI —
+    //      but only for the uid spelling: the label spelling returns symbolic
+    //      before the flag is ever consulted.
     //   3. the uid does not resolve to a file → `Literal("[[<uid>]]")`.
     // Cases 1-2 land in the `includes(UNIVERSAL_DEFAULT_TEMPLATE_CLASS_UID)`
-    // branch, case 3 in the Literal branch. All three are covered by axes.
+    // branch, case 3 in the Literal branch — i.e. three causes collapse into
+    // TWO store shapes, and both shapes have a resolver axis. ⚠ Only case 1 has
+    // a converter axis proving the shape is really emitted; 2 and 3 are read off
+    // `valueToClassURI`, not observed.
     //
     // ⛔ The early return below deliberately does NOT union the forms: once a
     // symbolic candidate exists the other spellings are not considered, so the
     // "multiple singletons" warn keys on the symbolic form alone. Unioning
-    // would mean always paying the scan — i.e. undoing this block. In a
-    // steady-state vault every singleton is symbolic, so the warn still fires;
-    // it is only suppressed in the mixed-form warm-up window, where the pick
-    // may differ from the pre-change lexicographic one (both are valid
-    // singletons).
+    // would mean always paying the walk — i.e. undoing this block.
+    //
+    // ⚠ Be precise about what that costs, because the enumeration above already
+    // refutes the comfortable version: only case 1 is a warm-up window. Cases 2
+    // and 3 are PERSISTENT states, so a vault holding one symbolic singleton
+    // plus one dangling-uid singleton keeps the duplicate warn suppressed
+    // FOREVER, not just during indexing. Accepted deliberately: the resolved
+    // value is still a valid singleton, and the alternative is paying O(vault)
+    // on every `.md` save. If the duplicate warn ever needs to be reliable,
+    // that is a separate change — key it on the union count, not on this path.
     const indexed = await this.tripleStore.match(
       undefined,
       Namespace.EXO.term("Instance_class"),
@@ -2431,7 +2444,7 @@ export class CommandResolver {
   /**
    * Shared tail of {@link findUniversalSingleton}: deterministic selection when
    * a vault carries more than one singleton. Extracted so the indexed fast path
-   * and the dual-IRI fallback cannot drift apart on the multi-singleton rule.
+   * and the non-symbolic fallback cannot drift apart on the multi-singleton rule.
    */
   private pickUniversalSingleton(candidates: IRI[]): IRI | null {
     if (candidates.length === 0) return null;

--- a/packages/core/src/services/CommandResolver.ts
+++ b/packages/core/src/services/CommandResolver.ts
@@ -800,11 +800,33 @@ export class CommandResolver {
   /**
    * Invalidate all cached command resolutions.
    * Call when vault files change.
+   *
+   * Includes the Universal Default Template cache (req f3193399). Before that
+   * requirement {@link clearUniversalCache} had ZERO call sites in production,
+   * so the template — and, worse, a `null` verdict latched against a not-yet-
+   * warm store — survived until the plugin was restarted.
+   *
+   * ⛤ On COST, since {@link findUniversalSingleton} is O(vault) (it walks every
+   * `exo__Instance_class` triple; the object cannot be bound because it arrives
+   * in both IRI and wikilink-literal form): this method ALREADY clears `cache`
+   * and `multiCache`, which forces the next render to re-load every visible
+   * command together with its grounding, property-defaults and inheritance
+   * rules — dozens of store queries. The one extra in-memory walk runs ONCE per
+   * invalidation (the latch re-arms on the first call) and is dominated by that.
+   *
+   * ⛔ NOT the `scanVault`-per-change shape that caused the iPhone Jetsam storm:
+   * that walk read FILES; this one walks an already-materialised in-memory
+   * index. Different cost class — see the PR for the measured numbers.
+   *
+   * ⛔ `_fallbackWarnedKeys` stays deliberately un-cleared here — see its own
+   * docstring; clearing warn-suppression on every save reinstates the toast
+   * storm of #3186. Different field, different rationale.
    */
   invalidateCache(): void {
     this.cache.clear();
     this.multiCache.clear();
     this._ancestorDepthCache.clear();
+    this.clearUniversalCache();
   }
 
   /**
@@ -2287,6 +2309,17 @@ export class CommandResolver {
     // In-store fallback: scan triple store for the singleton.
     const singletonIRI = await this.findUniversalSingleton();
     if (!singletonIRI) {
+      // req f3193399 — this branch used to be entirely silent, so a `null`
+      // latched against a not-yet-warm store was indistinguishable from a vault
+      // that genuinely has no template: every asset created afterwards simply
+      // came out without `createdAt`/`updatedAt`, with nothing in the log.
+      //
+      // `debug`, NOT `warn`: a vault without a UniversalDefaultTemplate is a
+      // legitimate state, and `warn` is routed to a user-facing toast by
+      // DEFAULT_LOG_CHANNELS (see `_fallbackWarnedKeys` for that precedent).
+      this.logger.debug(
+        `[CommandResolver] No exocmd__UniversalDefaultTemplate instance found in the store; universal property-defaults and inheritance-rules will not be applied. This verdict is cached until invalidateCache() is called — if the store was still warming up, the next invalidation re-resolves it.`,
+      );
       this._universalCacheValue = null;
       return null;
     }
@@ -2313,9 +2346,36 @@ export class CommandResolver {
    * lexicographically smallest UID when multiple are found.
    */
   private async findUniversalSingleton(): Promise<IRI | null> {
-    const templateClassIRI = Namespace.EXOCMD.term(
-      "UniversalDefaultTemplate",
-    ).value;
+    const templateClassTerm = Namespace.EXOCMD.term("UniversalDefaultTemplate");
+    const templateClassIRI = templateClassTerm.value;
+
+    // req f3193399 — indexed fast path FIRST.
+    //
+    // ⛤ Load-bearing, not micro-optimisation. Since that requirement wired
+    // this lookup into `invalidateCache()`, it runs after EVERY `.md` save
+    // instead of once per session — and the unbound-object scan below walks
+    // every `exo__Instance_class` triple in the vault. Measured share of a
+    // post-invalidation `loadCommand`, unbound scan only:
+    //   2 000 triples → 57 %   10 000 → 90 %   30 000 → 96 %
+    // i.e. it DOMINATES the reload rather than drowning in it, and the cost
+    // grows with the vault. `matchPO` goes through the `pos` index, so binding
+    // the object turns O(vault) into O(matches) on the healthy path.
+    //
+    // ⛔ The scan below is still REQUIRED and is not dead: `Instance_class` is
+    // emitted in two forms (bare `[[uid]]` → symbolic IRI, `[[label]]` →
+    // wikilink literal — the dual-IRI split), and only the IRI form can be
+    // bound here. A vault whose singleton is written label-first resolves
+    // solely through the fallback.
+    const indexed = await this.tripleStore.match(
+      undefined,
+      Namespace.EXO.term("Instance_class"),
+      templateClassTerm,
+    );
+    const fast = indexed
+      .map((t) => t.subject)
+      .filter((s): s is IRI => s instanceof IRI);
+    if (fast.length > 0) return this.pickUniversalSingleton(fast);
+
     const classTriples = await this.tripleStore.match(
       undefined,
       Namespace.EXO.term("Instance_class"),
@@ -2336,13 +2396,22 @@ export class CommandResolver {
       }
       if (match && t.subject instanceof IRI) candidates.push(t.subject);
     }
+    return this.pickUniversalSingleton(candidates);
+  }
+
+  /**
+   * Shared tail of {@link findUniversalSingleton}: deterministic selection when
+   * a vault carries more than one singleton. Extracted so the indexed fast path
+   * and the dual-IRI fallback cannot drift apart on the multi-singleton rule.
+   */
+  private pickUniversalSingleton(candidates: IRI[]): IRI | null {
     if (candidates.length === 0) return null;
     if (candidates.length === 1) return candidates[0];
-    candidates.sort((a, b) => a.value.localeCompare(b.value));
+    const sorted = [...candidates].sort((a, b) => a.value.localeCompare(b.value));
     this.logger.warn(
-      `Multiple UniversalDefaultTemplate singletons found (${candidates.length}); selecting deterministically by lexicographic UID order: ${candidates[0].value}`,
+      `Multiple UniversalDefaultTemplate singletons found (${sorted.length}); selecting deterministically by lexicographic UID order: ${sorted[0].value}`,
     );
-    return candidates[0];
+    return sorted[0];
   }
 
   /**

--- a/packages/core/tests/unit/services/CommandResolver.substitutionToken.test.ts
+++ b/packages/core/tests/unit/services/CommandResolver.substitutionToken.test.ts
@@ -270,7 +270,12 @@ const TOKEN_NOW_TIMESTAMP_UID = "77777777-7777-4777-8777-777777777777";
 const TOKEN_ABSENT_UID        = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
 // An ordinary asset (not a SubstitutionToken) — the common, correct path.
 const PLAIN_ASSET_UID         = "99999999-9999-4999-8999-999999999999";
-// @req:81d2e07e — an invocation whose class triple never loaded. Distinct UID:
+// req 81d2e07e — an invocation whose class triple never loaded. Distinct UID:
+// ⛤ Deliberately NOT written `@req:<8 chars>`: that is the BINDING syntax, and
+// a truncated one is malformed — `requirements-audit` matches full UUIDs only,
+// so it would be an orphan tag, while archgate REQ-001 flags it as a warning
+// (non-blocking, hence invisible in a green CI). The four real bindings for
+// this requirement are the `it(...)` titles below.
 // reusing an existing fixture constant is exactly how the earlier axis silently
 // measured the wrong branch (see the guard in the TOKEN_ABSENT_UID test).
 const INVOCATION_NO_CLASS_UID = "cccccccc-cccc-4ccc-8ccc-cccccccccccc";

--- a/packages/core/tests/unit/services/CommandResolver.universalDefaultTemplate.test.ts
+++ b/packages/core/tests/unit/services/CommandResolver.universalDefaultTemplate.test.ts
@@ -23,6 +23,12 @@ import { Literal } from "../../../src/domain/models/rdf/Literal";
 import { Namespace } from "../../../src/domain/models/rdf/Namespace";
 import { ILogger } from "../../../src/interfaces/ILogger";
 import { clearUniversalDefaultLoader } from "../../../src/services/UniversalDefaultTemplateResolver";
+import { NoteToRDFConverter } from "../../../src/services/NoteToRDFConverter";
+import {
+  IVaultAdapter,
+  IFile,
+  IFrontmatter,
+} from "../../../src/interfaces/IVaultAdapter";
 
 interface RecordingLogger extends ILogger {
   readonly warnings: string[];
@@ -384,7 +390,11 @@ async function addValueAssetForOverride(store: InMemoryTripleStore): Promise<voi
  * armed BEFORE the lookup (`_universalCacheReady = true` precedes
  * `findUniversalSingleton()`), which is why the `null` case latches too.
  *
- * The axes below are ISOLATING: each one is red for exactly one guard.
+ * The axes below are ISOLATING per GUARD, not per axis: the first two share
+ * one guard (the `clearUniversalCache()` call) but assert different
+ * behaviours — visibility of an edit vs. the latched `null`. No guard can be
+ * removed without reddening at least one axis, and no axis reddens for a
+ * guard it does not name.
  *
  *   - «правка шаблона действует…»  ← `this.clearUniversalCache()` in invalidateCache
  *   - «вердикт „шаблона нет“…»     ← the same call, exercised on the null branch
@@ -543,18 +553,33 @@ class ScanCountingStore extends InMemoryTripleStore {
   }
 }
 
-/** Singleton whose `Instance_class` is a wikilink LITERAL, not an IRI. */
-async function addUniversalSingletonAsWikilinkLiteral(
+/**
+ * Singleton whose `Instance_class` object is one of the NON-symbolic forms the
+ * converter actually emits — i.e. the ones only the fallback can catch.
+ *
+ * ⛔ Do NOT "simplify" this to `Literal("[[exocmd__UniversalDefaultTemplate]]")`.
+ * That spelling never reaches the store: `NoteToRDFConverter.expandClassValue`
+ * is a pure prefix parse, so the label form is emitted as a SYMBOLIC IRI and
+ * takes the fast path. Guarding a form the converter cannot produce is a green
+ * axis over a dead input — the premise axis below proves which form is real.
+ */
+async function addUniversalSingletonInFallbackForm(
   store: InMemoryTripleStore,
+  form: "file-iri" | "unresolved-literal",
   pdRefs: string[],
 ): Promise<void> {
   const s = new IRI(`obsidian://vault/${UNIVERSAL_SINGLETON_UID}.md`);
+  const classObject =
+    form === "file-iri"
+      ? // cold metadataCache (`getFrontmatter` → null) and the
+        // `emitInstanceClassAsUid` stage-1 flag both emit the class FILE IRI
+        new IRI(
+          `obsidian://vault/exocmd/${UNIVERSAL_DEFAULT_TEMPLATE_CLASS_UID}.md`,
+        )
+      : // the class uid does not resolve to a file at all
+        new Literal(`[[${UNIVERSAL_DEFAULT_TEMPLATE_CLASS_UID}]]`);
   const triples: Triple[] = [
-    new Triple(
-      s,
-      Namespace.EXO.term("Instance_class"),
-      new Literal("[[exocmd__UniversalDefaultTemplate]]"),
-    ),
+    new Triple(s, Namespace.EXO.term("Instance_class"), classObject),
     new Triple(
       s,
       Namespace.EXO.term("Asset_uid"),
@@ -598,19 +623,93 @@ describe("CommandResolver — req f3193399: indexed singleton lookup", () => {
     expect(store.unboundClassScans).toBe(before);
   });
 
-  it("@req:f3193399-ae33-44cf-a20f-d0e59edf8b81 — wikilink-литеральная форма (dual-IRI) резолвится через фолбэк", async () => {
-    const store = new ScanCountingStore();
-    const resolver = new CommandResolver(store, makeFullRecordingLogger());
-    await setupCommonTBox(store);
-    await addUniversalSingletonAsWikilinkLiteral(store, [PD_UID_UNIVERSAL_UID]);
-    await addGroundingWithPDRefs(store, []);
+  it.each([
+    ["file-iri" as const, "холодный metadataCache / emitInstanceClassAsUid"],
+    ["unresolved-literal" as const, "class-uid не резолвится в файл"],
+  ])(
+    "@req:f3193399-ae33-44cf-a20f-d0e59edf8b81 — не-symbolic форма (%s: %s) резолвится через фолбэк",
+    async (form, _why) => {
+      const store = new ScanCountingStore();
+      const resolver = new CommandResolver(store, makeFullRecordingLogger());
+      await setupCommonTBox(store);
+      await addUniversalSingletonInFallbackForm(store, form, [PD_UID_UNIVERSAL_UID]);
+      await addGroundingWithPDRefs(store, []);
 
-    const cmd = await resolver.loadCommand(COMMAND_UID);
+      const cmd = await resolver.loadCommand(COMMAND_UID);
 
-    // Фолбэк ОБЯЗАН оставаться живым: связать объект для этой формы нельзя.
-    expect((cmd!.grounding.propertyDefault ?? []).map((p) => p.propertyName)).toEqual([
-      "exo__Asset_uid",
-    ]);
-    expect(store.unboundClassScans).toBeGreaterThan(0);
+      // Фолбэк ОБЯЗАН оставаться живым: связать объект для этих форм нельзя.
+      expect((cmd!.grounding.propertyDefault ?? []).map((p) => p.propertyName)).toEqual([
+        "exo__Asset_uid",
+      ]);
+      expect(store.unboundClassScans).toBeGreaterThan(0);
+    },
+  );
+});
+
+describe("NoteToRDFConverter — посылка, на которой держится фолбэк выше", () => {
+  const CLASS_UID = "29e2c8f8-2d27-4e58-b467-2e85d46f8122";
+  const singletonFile: IFile = {
+    path: `exocmd/${UNIVERSAL_SINGLETON_UID}.md`,
+    basename: UNIVERSAL_SINGLETON_UID,
+    name: `${UNIVERSAL_SINGLETON_UID}.md`,
+    parent: null,
+  };
+  const classFile: IFile = {
+    path: `exocmd/${CLASS_UID}.md`,
+    basename: CLASS_UID,
+    name: `${CLASS_UID}.md`,
+    parent: null,
+  };
+
+  function makeVault(classFrontmatter: IFrontmatter | null): IVaultAdapter {
+    return {
+      getFrontmatter: (f: IFile) =>
+        f.path === singletonFile.path
+          ? ({ exo__Instance_class: `[[${CLASS_UID}]]` } as IFrontmatter)
+          : classFrontmatter,
+      getFirstLinkpathDest: (linkpath: string) =>
+        linkpath === CLASS_UID ? classFile : null,
+      read: async () => "",
+      getAllFiles: () => [],
+      create: async () => singletonFile,
+      modify: async () => {},
+      delete: async () => {},
+      exists: async () => true,
+      getAbstractFileByPath: () => null,
+      updateFrontmatter: async () => {},
+      rename: async () => {},
+      createFolder: async () => {},
+      process: async () => "",
+      updateLinks: async () => {},
+      getDefaultNewFileParent: () => null,
+    } as unknown as IVaultAdapter;
+  }
+
+  async function emittedClassObject(fm: IFrontmatter | null) {
+    const triples = await new NoteToRDFConverter(makeVault(fm)).convertNote(
+      singletonFile,
+    );
+    return triples.find((t) =>
+      (t.predicate as IRI).value.endsWith("#Instance_class"),
+    )?.object;
+  }
+
+  it("@req:f3193399-ae33-44cf-a20f-d0e59edf8b81 — при ХОЛОДНОМ metadataCache класс эмитится FILE-IRI, а не symbolic", async () => {
+    // ⛤ Эта ось — не про CommandResolver. Она доказывает ПОСЫЛКУ, на которой
+    // держится фолбэк: что форма, которую он ловит, вообще возникает. Первая
+    // редакция этого PR утверждала другую форму («label-first»), и утверждение
+    // было ЛОЖНЫМ — потому что форму предположили, а не наблюдали.
+    const obj = await emittedClassObject(null); // getFrontmatter класса → null
+    expect(obj).toBeInstanceOf(IRI);
+    expect((obj as IRI).value).toContain(CLASS_UID);
+    expect((obj as IRI).value).not.toContain("ontology/exocmd#");
+  });
+
+  it("@req:f3193399-ae33-44cf-a20f-d0e59edf8b81 — при ПРОГРЕТОМ metadataCache класс эмитится symbolic ⇒ идёт быстрым путём", async () => {
+    const obj = await emittedClassObject({
+      exo__Asset_label: "exocmd__UniversalDefaultTemplate",
+    } as IFrontmatter);
+    expect(obj).toBeInstanceOf(IRI);
+    expect((obj as IRI).value).toContain("ontology/exocmd#UniversalDefaultTemplate");
   });
 });

--- a/packages/core/tests/unit/services/CommandResolver.universalDefaultTemplate.test.ts
+++ b/packages/core/tests/unit/services/CommandResolver.universalDefaultTemplate.test.ts
@@ -528,8 +528,13 @@ describe("CommandResolver — req f3193399: UniversalDefaultTemplate cache inval
  * OPPOSITE directions:
  *   - it is not taken       → the O(vault) scan runs on every save (the cost
  *                             the wiring would otherwise introduce);
- *   - it REPLACES the scan  → a singleton written in wikilink-literal form
- *                             (dual-IRI) stops resolving, silently.
+ *   - it REPLACES the walk  → a singleton whose class object is NOT the
+ *                             symbolic IRI (cold-cache file IRI, or an
+ *                             unresolved-uid literal) stops resolving, silently.
+ *                             ⛔ NOT "the label form": that spelling is emitted
+ *                             symbolic and takes the fast path — see the
+ *                             premise axes at the bottom of this file, which
+ *                             observe the emission instead of assuming it.
  * A single axis cannot see both.
  * --------------------------------------------------------------------- */
 
@@ -635,19 +640,27 @@ describe("CommandResolver — req f3193399: indexed singleton lookup", () => {
       await addUniversalSingletonInFallbackForm(store, form, [PD_UID_UNIVERSAL_UID]);
       await addGroundingWithPDRefs(store, []);
 
+      const before = store.unboundClassScans;
       const cmd = await resolver.loadCommand(COMMAND_UID);
 
       // Фолбэк ОБЯЗАН оставаться живым: связать объект для этих форм нельзя.
       expect((cmd!.grounding.propertyDefault ?? []).map((p) => p.propertyName)).toEqual([
         "exo__Asset_uid",
       ]);
-      expect(store.unboundClassScans).toBeGreaterThan(0);
+      // ⛤ Симметрично оси выше — от baseline, не от абсолютного нуля: «0 после
+      // setup» сегодня верно (addAll не зовёт match), но это НЕзаписанный
+      // инвариант, и в день, когда хелпер setup'а прочитает store, абсолютная
+      // форма пройдёт вакуумно.
+      expect(store.unboundClassScans).toBeGreaterThan(before);
     },
   );
 });
 
 describe("NoteToRDFConverter — посылка, на которой держится фолбэк выше", () => {
-  const CLASS_UID = "29e2c8f8-2d27-4e58-b467-2e85d46f8122";
+  // ⛔ НЕ переобъявлять литерал: ось-посылка обязана доказывать механизм для
+  // ТОГО ЖЕ класса, который ловит фолбэк выше, иначе они разъедутся молча и
+  // обе останутся зелёными (механизм класс-агностичен).
+  const CLASS_UID = UNIVERSAL_DEFAULT_TEMPLATE_CLASS_UID;
   const singletonFile: IFile = {
     path: `exocmd/${UNIVERSAL_SINGLETON_UID}.md`,
     basename: UNIVERSAL_SINGLETON_UID,
@@ -682,7 +695,7 @@ describe("NoteToRDFConverter — посылка, на которой держи�
       process: async () => "",
       updateLinks: async () => {},
       getDefaultNewFileParent: () => null,
-    } as unknown as IVaultAdapter;
+    } as IVaultAdapter;
   }
 
   async function emittedClassObject(fm: IFrontmatter | null) {

--- a/packages/core/tests/unit/services/CommandResolver.universalDefaultTemplate.test.ts
+++ b/packages/core/tests/unit/services/CommandResolver.universalDefaultTemplate.test.ts
@@ -374,3 +374,243 @@ async function addValueAssetForOverride(store: InMemoryTripleStore): Promise<voi
     new Triple(s, Namespace.EXO.term("Asset_label"), new Literal("Override")),
   ]);
 }
+
+/* ------------------------------------------------------------------------
+ * req f3193399 — invalidation of the UniversalDefaultTemplate cache.
+ *
+ * Before this requirement `clearUniversalCache()` had ZERO production call
+ * sites, so the template — and, worse, a `null` verdict latched against a
+ * not-yet-warm store — survived until the plugin was restarted. The latch is
+ * armed BEFORE the lookup (`_universalCacheReady = true` precedes
+ * `findUniversalSingleton()`), which is why the `null` case latches too.
+ *
+ * The axes below are ISOLATING: each one is red for exactly one guard.
+ *
+ *   - «правка шаблона действует…»  ← `this.clearUniversalCache()` in invalidateCache
+ *   - «вердикт „шаблона нет“…»     ← the same call, exercised on the null branch
+ *   - «отсутствие диагностируемо»  ← the `logger.debug` on the null branch
+ *
+ * ⛤ Why `invalidateCache()` and not a direct `clearUniversalCache()` call in
+ * the test: the requirement is about the WIRING, not the primitive. The
+ * primitive already had a green test («clearUniversalDefault invalidates
+ * cache», UniversalDefaultTemplateResolver.test.ts) — and it stayed green for
+ * the whole time the feature was broken, because nobody called it. Asserting
+ * through the wiring is the only form that can go red here.
+ * --------------------------------------------------------------------- */
+
+interface FullRecordingLogger extends ILogger {
+  readonly warnings: string[];
+  readonly debugs: string[];
+}
+
+/**
+ * The file-level `makeRecordingLogger` drops `debug` on the floor, so it is
+ * structurally blind to the diagnosability axis. This one records both.
+ */
+function makeFullRecordingLogger(): FullRecordingLogger {
+  const warnings: string[] = [];
+  const debugs: string[] = [];
+  return {
+    debug(msg: string) {
+      debugs.push(msg);
+    },
+    info() {},
+    warn(msg: string) {
+      warnings.push(msg);
+    },
+    error() {},
+    warnings,
+    debugs,
+  };
+}
+
+/** Attach one more PropertyDefault ref to the already-present singleton. */
+async function attachPdToSingleton(
+  store: InMemoryTripleStore,
+  pdUid: string,
+): Promise<void> {
+  await store.addAll([
+    new Triple(
+      new IRI(`obsidian://vault/${UNIVERSAL_SINGLETON_UID}.md`),
+      Namespace.EXOCMD.term("Template_propertyDefault"),
+      new IRI(`obsidian://vault/${pdUid}.md`),
+    ),
+  ]);
+}
+
+async function pdNamesOf(
+  resolver: CommandResolver,
+): Promise<string[]> {
+  const cmd = await resolver.loadCommand(COMMAND_UID);
+  return (cmd!.grounding.propertyDefault ?? []).map((p) => p.propertyName).sort();
+}
+
+describe("CommandResolver — req f3193399: UniversalDefaultTemplate cache invalidation", () => {
+  let store: InMemoryTripleStore;
+  let logger: FullRecordingLogger;
+  let resolver: CommandResolver;
+
+  beforeEach(async () => {
+    clearUniversalDefaultLoader();
+    store = new InMemoryTripleStore();
+    logger = makeFullRecordingLogger();
+    resolver = new CommandResolver(store, logger);
+    await setupCommonTBox(store);
+  });
+
+  it("@req:f3193399-ae33-44cf-a20f-d0e59edf8b81 — правка шаблона действует после invalidateCache, без пересоздания резолвера", async () => {
+    await addUniversalDefaultTemplateSingleton(store, [PD_UID_UNIVERSAL_UID]);
+    await addGroundingWithPDRefs(store, []);
+
+    expect(await pdNamesOf(resolver)).toEqual(["exo__Asset_uid"]);
+
+    // The user edits the template: one more PropertyDefault is attached.
+    await attachPdToSingleton(store, PD_UID_UNIVERSAL_LABEL);
+
+    // The host reports the vault change the only way it knows how.
+    resolver.invalidateCache();
+
+    // ⛔ Without the wiring the command cache clears but the universal cache
+    // does not, so the second PD stays invisible for the rest of the session.
+    expect(await pdNamesOf(resolver)).toEqual([
+      "exo__Asset_label",
+      "exo__Asset_uid",
+    ]);
+  });
+
+  it("@req:f3193399-ae33-44cf-a20f-d0e59edf8b81 — вердикт «шаблона нет» не латчится на сессию", async () => {
+    // Cold store: the singleton's `exo__Instance_class` triple has not landed
+    // yet. This is the shape that silently strips createdAt/updatedAt from
+    // every asset created afterwards.
+    await addGroundingWithPDRefs(store, []);
+    expect(await pdNamesOf(resolver)).toEqual([]);
+
+    // The store finishes warming up.
+    await addUniversalDefaultTemplateSingleton(store, [PD_UID_UNIVERSAL_UID]);
+    resolver.invalidateCache();
+
+    expect(await pdNamesOf(resolver)).toEqual(["exo__Asset_uid"]);
+  });
+
+  it("@req:f3193399-ae33-44cf-a20f-d0e59edf8b81 — отсутствие шаблона диагностируемо: debug есть, warn нет", async () => {
+    await addGroundingWithPDRefs(store, []);
+    await resolver.loadCommand(COMMAND_UID);
+
+    const hit = logger.debugs.filter((m) =>
+      m.includes("No exocmd__UniversalDefaultTemplate instance found"),
+    );
+    expect(hit).toHaveLength(1);
+    // The message must name the consequence, not merely the fact — otherwise
+    // it does not answer the question a reader arrives with.
+    expect(hit[0]).toMatch(/invalidateCache\(\)/);
+
+    // Negative control: a vault without a template is a LEGITIMATE state, and
+    // `warn` is routed to a user-facing toast by DEFAULT_LOG_CHANNELS. Raising
+    // the severity here would toast every such user on every render.
+    expect(logger.warnings).toHaveLength(0);
+  });
+});
+
+/* ------------------------------------------------------------------------
+ * req f3193399 — the indexed fast path in findUniversalSingleton.
+ *
+ * Two axes, because the fast path has two ways to be wrong and they fail in
+ * OPPOSITE directions:
+ *   - it is not taken       → the O(vault) scan runs on every save (the cost
+ *                             the wiring would otherwise introduce);
+ *   - it REPLACES the scan  → a singleton written in wikilink-literal form
+ *                             (dual-IRI) stops resolving, silently.
+ * A single axis cannot see both.
+ * --------------------------------------------------------------------- */
+
+/** Counts unbound-object `Instance_class` scans made through the store. */
+class ScanCountingStore extends InMemoryTripleStore {
+  public unboundClassScans = 0;
+  override async match(
+    s?: Parameters<InMemoryTripleStore["match"]>[0],
+    p?: Parameters<InMemoryTripleStore["match"]>[1],
+    o?: Parameters<InMemoryTripleStore["match"]>[2],
+  ): ReturnType<InMemoryTripleStore["match"]> {
+    if (
+      s === undefined &&
+      o === undefined &&
+      p !== undefined &&
+      p.value === Namespace.EXO.term("Instance_class").value
+    ) {
+      this.unboundClassScans += 1;
+    }
+    return super.match(s, p, o);
+  }
+}
+
+/** Singleton whose `Instance_class` is a wikilink LITERAL, not an IRI. */
+async function addUniversalSingletonAsWikilinkLiteral(
+  store: InMemoryTripleStore,
+  pdRefs: string[],
+): Promise<void> {
+  const s = new IRI(`obsidian://vault/${UNIVERSAL_SINGLETON_UID}.md`);
+  const triples: Triple[] = [
+    new Triple(
+      s,
+      Namespace.EXO.term("Instance_class"),
+      new Literal("[[exocmd__UniversalDefaultTemplate]]"),
+    ),
+    new Triple(
+      s,
+      Namespace.EXO.term("Asset_uid"),
+      new Literal(UNIVERSAL_SINGLETON_UID),
+    ),
+  ];
+  for (const pd of pdRefs) {
+    triples.push(
+      new Triple(
+        s,
+        Namespace.EXOCMD.term("Template_propertyDefault"),
+        new IRI(`obsidian://vault/${pd}.md`),
+      ),
+    );
+  }
+  await store.addAll(triples);
+}
+
+describe("CommandResolver — req f3193399: indexed singleton lookup", () => {
+  beforeEach(() => {
+    clearUniversalDefaultLoader();
+  });
+
+  it("@req:f3193399-ae33-44cf-a20f-d0e59edf8b81 — IRI-форма резолвится БЕЗ обхода всех Instance_class", async () => {
+    const store = new ScanCountingStore();
+    const resolver = new CommandResolver(store, makeFullRecordingLogger());
+    await setupCommonTBox(store);
+    await addUniversalDefaultTemplateSingleton(store, [PD_UID_UNIVERSAL_UID]);
+    await addGroundingWithPDRefs(store, []);
+
+    const before = store.unboundClassScans;
+    const cmd = await resolver.loadCommand(COMMAND_UID);
+
+    // Ловится сам эффект: дефолт применён…
+    expect((cmd!.grounding.propertyDefault ?? []).map((p) => p.propertyName)).toEqual([
+      "exo__Asset_uid",
+    ]);
+    // …и при этом ни одного обхода с несвязанным объектом не понадобилось.
+    // ⛔ Именно этот счётчик, а не тайминг: тайминг флачет под нагрузкой
+    // раннера, а число обходов детерминировано.
+    expect(store.unboundClassScans).toBe(before);
+  });
+
+  it("@req:f3193399-ae33-44cf-a20f-d0e59edf8b81 — wikilink-литеральная форма (dual-IRI) резолвится через фолбэк", async () => {
+    const store = new ScanCountingStore();
+    const resolver = new CommandResolver(store, makeFullRecordingLogger());
+    await setupCommonTBox(store);
+    await addUniversalSingletonAsWikilinkLiteral(store, [PD_UID_UNIVERSAL_UID]);
+    await addGroundingWithPDRefs(store, []);
+
+    const cmd = await resolver.loadCommand(COMMAND_UID);
+
+    // Фолбэк ОБЯЗАН оставаться живым: связать объект для этой формы нельзя.
+    expect((cmd!.grounding.propertyDefault ?? []).map((p) => p.propertyName)).toEqual([
+      "exo__Asset_uid",
+    ]);
+    expect(store.unboundClassScans).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
fix(resolver): invalidate the Universal Default Template cache, and stop paying an O(vault) scan for it

Closes #4080. Requirement f3193399 (approved).

Третья — и самая тихая — дверь к дефекту 0310aa28. Первые две закрыты PR #4078
и #4081; те портили ЗНАЧЕНИЕ, эта убирает его вовсе и не оставляет следа.

## Что было

`clearUniversalCache()` имел НОЛЬ вызовов в проде (единственное вхождение
символа — своё определение). Латч взводится ДО поиска, а на ненайденном
синглтоне кэшируется `null`. Отсюда два следствия:

1. Правка Universal Default Template не действует до перезапуска плагина.
2. Холодный store ⇒ «универсальных дефолтов нет» на всю сессию, МОЛЧА: каждый
   созданный дальше ассет остаётся без createdAt/updatedAt, и у ветки не было
   ни одной лог-строки.

CLI не страдает (свежий процесс на вызов) — дефект чисто плагинный.

## Почему в PR ДВА изменения, а не одно

Первая редакция требования обосновывала стоимость так: «invalidateCache и так
вынуждает перезагрузку всех команд, поэтому один обход тонет в этой работе».
Это было выведено из механизма и НЕ измерено. Замер опроверг:

| Instance_class-триплов | доля обхода в loadCommand |
|---|---|
| 2 000 | 57 % |
| 10 000 | 90 % |
| 30 000 | 96 % |

Обход ДОМИНИРУЕТ и растёт с размером vault. Одна проводка внесла бы
O(vault)-работу на каждое сохранение .md — форма, давшая iPhone-Jetsam.

Поэтому добавлен индексированный быстрый путь: `matchPO` идёт через `pos`, то
есть связанный объект даёт O(matches). Связать можно только IRI-форму
`exo__Instance_class`; wikilink-литеральная форма (dual-IRI) остаётся за полным
обходом — фолбэк обязателен и покрыт своей осью.

| триплов | доля до | после | loadCommand до → после |
|---|---|---|---|
| 2 000 | 57 % | 56 % | 0.67 → 0.21 мс |
| 10 000 | 90 % | 38 % | 1.00 → 0.14 мс |
| 30 000 | 96 % | 30 % | 3.03 → 0.13 мс |

Было линейно по vault, стало плоско: O(vault) → O(1) на здоровом пути.

## revert-verify (4 мутанта, каждый краснит РОВНО свою ось)

Контроль 9/9 прогоняется ПЕРВЫМ — иначе числа мутантов нечитаемы.

| мутант | покраснело | ожидалось |
|---|---|---|
| снять проводку в invalidateCache | правка-шаблона + null-не-латчится | то же |
| снять debug на null-ветке | диагностируемость | то же |
| снять быстрый путь | IRI-без-обхода | то же |
| снять dual-IRI фолбэк | wikilink-литерал | то же |

Восстановление 9/9.

⛤ Мутант «снять фолбэк» сперва был написан вставкой `return null;` — код стал
недостижим, сьют не скомпилировался, и харнесс отдал `Tests: 0`, что читается
как «не покраснело». Переведён в type-preserving форму; в харнесс добавлен
fail-loud на «сьют не запустился», чтобы этот исход больше не выглядел красным.

## Гейты

- полный core-сьют: 368/368 сьютов, 8573 passed, 0 failed
- typecheck core: rc=0
- три guard-скрипта lint-джоба: shard OK · anti-patterns 55/55, 21/21, 19/19, 0/0 · coverage-monotonic OK

⚠ Первый прогон дал 3 красных сьюта — артефакт неинициализированного
сабмодуля `packages/exoas-exocmd` в свежем worktree, не правки. После
`git submodule update --init` — ноль падений.

## Housekeeping (записан в #4080)

`CommandResolver.substitutionToken.test.ts:273` нёс усечённый `@req:81d2e07e`
(8 символов) в комментарии к фикстуре. Это не привязка, а пояснение, но
написанное синтаксисом привязки: `requirements-audit` матчит только полный
UUID, archgate REQ-001 флагует такое warning-ом (не блокирует). Переписано
прозой + названо, почему форма запрещена.

## Вне области

- Узкая проводка (сброс только при изменении самого синглтона либо его ссылок) —
  требует механизма опознания файла в хосте; форма оставлена возможной.
- `registerUniversalDefaultLoader` — ВТОРОЙ мёртвый примитив той же подсистемы
  (ноль вызовов). Отдельная находка, отдельная работа.

Claude-Session: https://claude.ai/code/session_015QdGEKFfUAiVYTkvXcDhJ2
