### PR TITLE
refactor(resolver): delete the Universal Default Template loader registry — no host ever registered one (#4083)

### DIFF
--- a/packages/core/src/services/CommandResolver.ts
+++ b/packages/core/src/services/CommandResolver.ts
@@ -804,10 +804,13 @@ export class CommandResolver {
    *
    * ⛤ On COST: {@link findUniversalSingleton} takes an INDEXED path first
    * (bound object → `matchPO` → O(matches)), so this call is cheap on a healthy
-   * vault. It degrades to an O(vault) walk only when the singleton's class
-   * object is not the symbolic IRI — read the comment on that method for which
-   * forms those are and why the walk must stay. The walk, when taken, runs ONCE
-   * per invalidation (the latch re-arms on the first call).
+   * vault. It degrades to an O(vault) walk on ANY empty indexed result — which
+   * is TWO distinct situations, not one: the singleton's class object is not the
+   * symbolic IRI (read that method's comment for which forms and why the walk
+   * must stay), **or there is no singleton in the vault at all**. The second is
+   * a legitimate state (see {@link getUniversalCache}), and it is the cheaper
+   * way to end up paying the walk. The walk, when taken, runs ONCE per
+   * invalidation (the latch re-arms on the first call).
    *
    * ⛔ Do NOT re-derive the cost from "invalidateCache reloads everything
    * anyway, so one more walk drowns in it" — that was measured and is FALSE
@@ -2296,10 +2299,19 @@ export class CommandResolver {
    * registered a loader (#4083) — one path is cheaper than two, and a path
    * that cannot be exercised cannot be tested.
    *
-   * Universal singleton lookup is in-band — finds first asset whose
-   * `exo__Instance_class` includes the UniversalDefaultTemplate class UID
-   * (29e2c8f8) or IRI form. Multiple singletons → deterministic selection by
-   * lexicographic UID order with a warn.
+   * Universal singleton lookup is in-band, and it is TWO paths in order, not
+   * one — see {@link findUniversalSingleton} for the authoritative description:
+   * an indexed `matchPO` on the symbolic class term runs FIRST and early-returns
+   * on any hit; the substring criterion (`exo__Instance_class` *includes* the
+   * class UID 29e2c8f8 or IRI form) is the FALLBACK, taken only when the indexed
+   * lookup is empty.
+   *
+   * ⚠ Multiple singletons → deterministic selection by lexicographic UID order,
+   * but the accompanying warn fires only for duplicates found WITHIN one path's
+   * result set; the two sets are never unioned, so a duplicate split across the
+   * fast and fallback forms warns about neither. That is a known, deliberate
+   * consequence of the early return — `findUniversalSingleton`'s own ⛔ note
+   * spells it out. Do not read the sentence above as an unconditional warn.
    */
   private async getUniversalCache(): Promise<UniversalDefaultTemplate | null> {
     if (this._universalCacheReady) return this._universalCacheValue;
@@ -2341,9 +2353,12 @@ export class CommandResolver {
   /**
    * RFC 727572d2 — locate the UniversalDefaultTemplate singleton ABox
    * instance via an INDEXED `matchPO` lookup on the bound class term
-   * (O(matches), PR #4082), degrading to an unbound scan only for the
-   * non-symbolic class forms that index cannot reach. Returns first match;
-   * warns and picks lexicographically smallest UID when multiple are found.
+   * (O(matches), PR #4082), degrading to an unbound scan whenever that lookup
+   * comes back empty — i.e. for the non-symbolic class forms the index cannot
+   * reach, **or when the vault has no singleton at all**. Returns first match;
+   * warns and picks lexicographically smallest UID when multiple are found
+   * WITHIN the set it was handed (see the ⛔ note below on why that keeps the
+   * duplicate warn suppressed on the fast path).
    *
    * ⛤ The previous wording said plainly "via triple store scan", which had
    * contradicted {@link invalidateCache}'s own docstring ever since #4082 made

--- a/packages/core/src/services/CommandResolver.ts
+++ b/packages/core/src/services/CommandResolver.ts
@@ -18,8 +18,6 @@ import {
   type StyleSource,
 } from "../domain/constants/CommandBindingStyleEnums";
 import {
-  clearUniversalDefault,
-  loadUniversalDefault,
   mergePropertyDefaults,
   mergeInheritanceRules,
   type UniversalDefaultTemplate,
@@ -238,11 +236,11 @@ export class CommandResolver {
   private readonly _fallbackWarnedKeys = new Set<string>();
 
   /**
-   * RFC 727572d2 — Universal Default Template singleton cache. Loaded once
-   * per CommandResolver instance via {@link getUniversalCache}. Vault file
-   * change adapters may externally call
-   * {@link clearUniversalDefault} (UniversalDefaultTemplateResolver) AND
-   * recreate the CommandResolver to fully invalidate.
+   * RFC 727572d2 — Universal Default Template singleton cache. Resolved once
+   * per CommandResolver instance via {@link getUniversalCache} and dropped by
+   * {@link invalidateCache} / {@link clearUniversalCache}. This instance field
+   * is the ONLY cache of the singleton — the module-level loader cache that
+   * used to sit beside it was removed with its unregistered loader (#4083).
    */
   private _universalCacheReady = false;
   private _universalCacheValue: UniversalDefaultTemplate | null = null;
@@ -253,13 +251,11 @@ export class CommandResolver {
    * this when the singleton ABox asset (62907ff4) or any referenced
    * PropertyDefault / InheritanceRule changes on disk, then either
    * re-create the CommandResolver or simply rely on lazy re-load on next
-   * `resolvePropertyDefaults` invocation. Also clears the module-level
-   * loader cache so external loader sources stay aligned.
+   * `resolvePropertyDefaults` invocation.
    */
   clearUniversalCache(): void {
     this._universalCacheReady = false;
     this._universalCacheValue = null;
-    clearUniversalDefault();
   }
 
   /**
@@ -824,11 +820,11 @@ export class CommandResolver {
    * docstring; clearing warn-suppression on every save reinstates the toast
    * storm of #3186. Different field, different rationale.
    *
-   * ⚠ Scope note: {@link clearUniversalCache} also clears the MODULE-level
-   * loader cache (`clearUniversalDefault`), so this method is no longer purely
-   * instance-scoped. Moot today — no host calls `registerUniversalDefaultLoader`
-   * (issue #4083), so `loadUniversalDefault()` always returns null — but a host
-   * that wires one must expect it to be re-asked after every `.md` save.
+   * ⛤ Scope note (resolved by #4083): this method IS purely instance-scoped
+   * again. The previous note warned that {@link clearUniversalCache} also wiped
+   * a MODULE-level loader cache — that cache, and the loader registry it served,
+   * were removed once the measurement showed no host had ever registered a
+   * loader. Nothing outside this instance is touched here.
    */
   invalidateCache(): void {
     this.cache.clear();
@@ -2288,14 +2284,17 @@ export class CommandResolver {
   }
 
   /**
-   * RFC 727572d2 — Universal Default Template singleton lazy loader. Returns
-   * the cached UniversalDefaultTemplate or null when:
-   *   - Singleton asset not in vault (cold-start race or absent)
-   *   - Loader threw (logged once, falls back to null)
+   * RFC 727572d2 — Universal Default Template singleton lazy resolver. Returns
+   * the cached UniversalDefaultTemplate, or null when the singleton asset is
+   * not in the store (cold-start race, or a vault that genuinely has none).
    *
-   * The session-level cache is populated on first call; vault file-watcher
-   * adapters may call {@link clearUniversalDefault} to invalidate after a
-   * Universal Template asset change.
+   * The instance-level cache is populated on first call and dropped by
+   * {@link invalidateCache} / {@link clearUniversalCache}.
+   *
+   * ⛔ There is no host-loader short-circuit here any more. It existed, was
+   * awaited on every call, and always returned null because no host ever
+   * registered a loader (#4083) — one path is cheaper than two, and a path
+   * that cannot be exercised cannot be tested.
    *
    * Universal singleton lookup is in-band — finds first asset whose
    * `exo__Instance_class` includes the UniversalDefaultTemplate class UID
@@ -2306,15 +2305,6 @@ export class CommandResolver {
     if (this._universalCacheReady) return this._universalCacheValue;
     this._universalCacheReady = true;
 
-    // External loader takes precedence (lets host wire a cheaper lookup
-    // path, e.g. via metadataCache rather than triple-store scan).
-    const external = await loadUniversalDefault();
-    if (external) {
-      this._universalCacheValue = external;
-      return external;
-    }
-
-    // In-store fallback: scan triple store for the singleton.
     const singletonIRI = await this.findUniversalSingleton();
     if (!singletonIRI) {
       // req f3193399 — this branch used to be entirely silent, so a `null`

--- a/packages/core/src/services/CommandResolver.ts
+++ b/packages/core/src/services/CommandResolver.ts
@@ -2340,8 +2340,14 @@ export class CommandResolver {
 
   /**
    * RFC 727572d2 — locate the UniversalDefaultTemplate singleton ABox
-   * instance via triple store scan. Returns first match; warns and picks
-   * lexicographically smallest UID when multiple are found.
+   * instance via an INDEXED `matchPO` lookup on the bound class term
+   * (O(matches), PR #4082), degrading to an unbound scan only for the
+   * non-symbolic class forms that index cannot reach. Returns first match;
+   * warns and picks lexicographically smallest UID when multiple are found.
+   *
+   * ⛤ The previous wording said plainly "via triple store scan", which had
+   * contradicted {@link invalidateCache}'s own docstring ever since #4082 made
+   * the fast path the default — two docstrings about one method disagreeing.
    */
   private async findUniversalSingleton(): Promise<IRI | null> {
     const templateClassTerm = Namespace.EXOCMD.term("UniversalDefaultTemplate");

--- a/packages/core/src/services/UniversalDefaultTemplateResolver.ts
+++ b/packages/core/src/services/UniversalDefaultTemplateResolver.ts
@@ -1,15 +1,32 @@
 /**
- * UniversalDefaultTemplateResolver — lazy-loaded reference to the RFC 727572d2
- * `exocmd__UniversalDefaultTemplate` singleton ABox instance.
- *
- * Loader pattern mirrors {@link OrderSpecResolver}: callers (CLI / Obsidian
- * plugin) register a `UniversalDefaultLoader` at startup. The loader returns
- * the singleton's contents (or null if the asset is absent). Result is cached;
- * vault updates may call {@link clearUniversalDefault} to invalidate.
+ * UniversalDefaultTemplateResolver — the shape of the RFC 727572d2
+ * `exocmd__UniversalDefaultTemplate` singleton, plus the merge semantics that
+ * fold it into each Grounding.
  *
  * Engine-side (CommandResolver) merges Universal entries into each Grounding's
  * propertyDefault / inheritanceRule lists at parse time; Grounding entries
  * override Universal entries by propertyName / targetPropertyName key.
+ *
+ * ⛔ This module deliberately has NO host-loader registry. It used to expose
+ * one — `registerUniversalDefaultLoader` / `clearUniversalDefaultLoader` /
+ * `loadUniversalDefault` / `clearUniversalDefault`, mirroring OrderSpecResolver
+ * — and its docstring described hosts registering a loader at startup. No host
+ * ever did: the measurement in issue #4083 found ZERO production callers of
+ * `registerUniversalDefaultLoader` on `origin/main`, so `loadUniversalDefault()`
+ * returned null on every single call while `CommandResolver.getUniversalCache`
+ * awaited it. The description of intent read like a description of behaviour —
+ * the same defect class as issue #4080 (`clearUniversalCache`, zero callers,
+ * green test, no wiring), found in the same subsystem one issue apart.
+ *
+ * The singleton is resolved where it is actually used: `CommandResolver`
+ * queries the triple store directly (indexed `Instance_class` match, PR #4082),
+ * caches the verdict on the instance, and drops it in `invalidateCache()`.
+ * One path, and it is the one the tests exercise.
+ *
+ * ⚠ If a host-side fast path is ever wanted again, do NOT restore this registry
+ * as-is: a plugin loader would read `metadataCache`, which is COLD at startup,
+ * so a cached null verdict would strip `createdAt`/`updatedAt` from every asset
+ * created afterwards — see rules/obsidian-plugin-indicator-surface-and-cold-resolve.
  *
  * RFC 727572d2-194b-4a4d-8a5a-585a1d3bac8e.
  */
@@ -33,71 +50,6 @@ import type {
 export interface UniversalDefaultTemplate {
   readonly propertyDefaults: ReadonlyArray<PropertyDefaultResolved>;
   readonly inheritanceRules: ReadonlyArray<InheritanceRuleResolved>;
-}
-
-export type UniversalDefaultLoader = () =>
-  | UniversalDefaultTemplate
-  | null
-  | Promise<UniversalDefaultTemplate | null>;
-
-let _loader: UniversalDefaultLoader | null = null;
-let _cached: UniversalDefaultTemplate | null | undefined = undefined;
-let _warnedMissing = false;
-
-export function registerUniversalDefaultLoader(
-  loader: UniversalDefaultLoader,
-): void {
-  _loader = loader;
-  _cached = undefined;
-  _warnedMissing = false;
-}
-
-export function clearUniversalDefaultLoader(): void {
-  _loader = null;
-  _cached = undefined;
-  _warnedMissing = false;
-}
-
-/** Invalidate the cache; loader will be re-invoked on next access. */
-export function clearUniversalDefault(): void {
-  _cached = undefined;
-  _warnedMissing = false;
-}
-
-/**
- * Fetch the Universal Default Template singleton contents.
- *
- * Returns `null` when:
- *   - No loader registered (test/CLI harnesses that intentionally bypass)
- *   - Loader returned null (singleton absent from vault → safety-net fallback)
- *   - Loader threw (warn once, fall back to null)
- *
- * Callers (GroundingExecutor) treat `null` as a signal to fall back to legacy
- * TS primitives WITH a loud warn log — the RFC 727572d2 design intentionally
- * leaves this safety net active because Universal singleton can race with
- * cold-start file-watcher debounce on mobile boot paths.
- */
-export async function loadUniversalDefault(): Promise<UniversalDefaultTemplate | null> {
-  if (_cached !== undefined) return _cached;
-  if (!_loader) {
-    _cached = null;
-    return null;
-  }
-  try {
-    const result = await _loader();
-    _cached = result ?? null;
-  } catch (e) {
-    if (!_warnedMissing) {
-       
-      console.warn(
-        "[UniversalDefaultTemplateResolver] loader threw, falling back to legacy primitives:",
-        e,
-      );
-      _warnedMissing = true;
-    }
-    _cached = null;
-  }
-  return _cached;
 }
 
 /**

--- a/packages/core/tests/unit/services/CommandResolver.universalDefaultTemplate.test.ts
+++ b/packages/core/tests/unit/services/CommandResolver.universalDefaultTemplate.test.ts
@@ -22,7 +22,6 @@ import { IRI } from "../../../src/domain/models/rdf/IRI";
 import { Literal } from "../../../src/domain/models/rdf/Literal";
 import { Namespace } from "../../../src/domain/models/rdf/Namespace";
 import { ILogger } from "../../../src/interfaces/ILogger";
-import { clearUniversalDefaultLoader } from "../../../src/services/UniversalDefaultTemplateResolver";
 import { NoteToRDFConverter } from "../../../src/services/NoteToRDFConverter";
 import {
   IVaultAdapter,
@@ -267,7 +266,6 @@ describe("CommandResolver — RFC 727572d2 UniversalDefaultTemplate merge", () =
   let resolver: CommandResolver;
 
   beforeEach(async () => {
-    clearUniversalDefaultLoader();
     store = new InMemoryTripleStore();
     logger = makeRecordingLogger();
     resolver = new CommandResolver(store, logger);
@@ -403,9 +401,10 @@ async function addValueAssetForOverride(store: InMemoryTripleStore): Promise<voi
  * ⛤ Why `invalidateCache()` and not a direct `clearUniversalCache()` call in
  * the test: the requirement is about the WIRING, not the primitive. The
  * primitive already had a green test («clearUniversalDefault invalidates
- * cache», UniversalDefaultTemplateResolver.test.ts) — and it stayed green for
- * the whole time the feature was broken, because nobody called it. Asserting
- * through the wiring is the only form that can go red here.
+ * cache») — and it stayed green for the whole time the feature was broken,
+ * because nobody called it. Asserting through the wiring is the only form that
+ * can go red here. (That test is gone: #4083 deleted the loader registry it
+ * covered, since no host had ever registered a loader either.)
  * --------------------------------------------------------------------- */
 
 interface FullRecordingLogger extends ILogger {
@@ -461,7 +460,6 @@ describe("CommandResolver — req f3193399: UniversalDefaultTemplate cache inval
   let resolver: CommandResolver;
 
   beforeEach(async () => {
-    clearUniversalDefaultLoader();
     store = new InMemoryTripleStore();
     logger = makeFullRecordingLogger();
     resolver = new CommandResolver(store, logger);
@@ -605,7 +603,6 @@ async function addUniversalSingletonInFallbackForm(
 
 describe("CommandResolver — req f3193399: indexed singleton lookup", () => {
   beforeEach(() => {
-    clearUniversalDefaultLoader();
   });
 
   it("@req:f3193399-ae33-44cf-a20f-d0e59edf8b81 — IRI-форма резолвится БЕЗ обхода всех Instance_class", async () => {

--- a/packages/core/tests/unit/services/CommandResolver.universalDefaultTemplate.test.ts
+++ b/packages/core/tests/unit/services/CommandResolver.universalDefaultTemplate.test.ts
@@ -602,9 +602,6 @@ async function addUniversalSingletonInFallbackForm(
 }
 
 describe("CommandResolver — req f3193399: indexed singleton lookup", () => {
-  beforeEach(() => {
-  });
-
   it("@req:f3193399-ae33-44cf-a20f-d0e59edf8b81 — IRI-форма резолвится БЕЗ обхода всех Instance_class", async () => {
     const store = new ScanCountingStore();
     const resolver = new CommandResolver(store, makeFullRecordingLogger());

--- a/packages/core/tests/unit/services/UniversalDefaultTemplateResolver.test.ts
+++ b/packages/core/tests/unit/services/UniversalDefaultTemplateResolver.test.ts
@@ -2,12 +2,17 @@
  * Unit tests — UniversalDefaultTemplateResolver (RFC 727572d2 Phase C).
  *
  * Covers:
- * - registerUniversalDefaultLoader / loadUniversalDefault lifecycle
- * - Loader returning null → cached null, no double-invoke
- * - Loader throwing → warn-once + null fallback
  * - mergePropertyDefaults: Grounding overrides Universal by propertyName
  * - mergeInheritanceRules: Grounding overrides Universal by targetPropertyName
  * - Order preservation: overridden entries stay in Universal position
+ *
+ * ⛔ The "loader lifecycle" block that used to open this file is GONE with the
+ * loader itself (#4083). It specified «IF a loader is registered, it is used»
+ * and was green for the entire life of the feature — while no host registered
+ * one, so the branch it covered returned null on every production call. A test
+ * whose premise production never satisfies is not coverage; deleting the branch
+ * deletes its test with it. Singleton resolution is exercised where it actually
+ * happens: CommandResolver.universalDefaultTemplate.test.ts.
  */
 
 import type {
@@ -15,77 +20,9 @@ import type {
   PropertyDefaultResolved,
 } from "../../../src/domain/models/CommandDefinition";
 import {
-  clearUniversalDefault,
-  clearUniversalDefaultLoader,
-  loadUniversalDefault,
   mergeInheritanceRules,
   mergePropertyDefaults,
-  registerUniversalDefaultLoader,
 } from "../../../src/services/UniversalDefaultTemplateResolver";
-
-describe("UniversalDefaultTemplateResolver — loader lifecycle", () => {
-  beforeEach(() => {
-    clearUniversalDefaultLoader();
-  });
-
-  it("returns null when no loader registered", async () => {
-    const result = await loadUniversalDefault();
-    expect(result).toBeNull();
-  });
-
-  it("caches loader result across calls", async () => {
-    const loader = jest.fn(() => ({
-      propertyDefaults: [],
-      inheritanceRules: [],
-    }));
-    registerUniversalDefaultLoader(loader);
-    await loadUniversalDefault();
-    await loadUniversalDefault();
-    await loadUniversalDefault();
-    expect(loader).toHaveBeenCalledTimes(1);
-  });
-
-  it("clearUniversalDefault invalidates cache", async () => {
-    const loader = jest.fn(() => ({
-      propertyDefaults: [],
-      inheritanceRules: [],
-    }));
-    registerUniversalDefaultLoader(loader);
-    await loadUniversalDefault();
-    clearUniversalDefault();
-    await loadUniversalDefault();
-    expect(loader).toHaveBeenCalledTimes(2);
-  });
-
-  it("loader throwing → null fallback + warn once", async () => {
-    const loader = jest.fn(() => {
-      throw new Error("simulated load failure");
-    });
-    const warnSpy = jest.spyOn(console, "warn").mockImplementation();
-    registerUniversalDefaultLoader(loader);
-    const result = await loadUniversalDefault();
-    expect(result).toBeNull();
-    expect(warnSpy).toHaveBeenCalledTimes(1);
-    warnSpy.mockRestore();
-  });
-
-  it("loader returning null → returns null (no error)", async () => {
-    registerUniversalDefaultLoader(() => null);
-    const result = await loadUniversalDefault();
-    expect(result).toBeNull();
-  });
-
-  it("async loader is awaited", async () => {
-    registerUniversalDefaultLoader(async () => ({
-      propertyDefaults: [{ propertyName: "x", value: "v" }],
-      inheritanceRules: [],
-    }));
-    const result = await loadUniversalDefault();
-    expect(result?.propertyDefaults).toEqual([
-      { propertyName: "x", value: "v" },
-    ]);
-  });
-});
 
 describe("mergePropertyDefaults", () => {
   it("appends Grounding entries that don't conflict with Universal", () => {


### PR DESCRIPTION
refactor(resolver): delete the Universal Default Template loader registry — no host ever registered one (#4083)

Closes #4083.

## Что удалено

Весь loader/cache-концерн `UniversalDefaultTemplateResolver`:
`UniversalDefaultLoader`, `_loader`, `_cached`, `_warnedMissing`,
`registerUniversalDefaultLoader`, `clearUniversalDefaultLoader`,
`clearUniversalDefault`, `loadUniversalDefault` — и его ветка в
`CommandResolver.getUniversalCache`.

Живые части модуля (`UniversalDefaultTemplate`, `mergePropertyDefaults`,
`mergeInheritanceRules`) не тронуты.

## Почему удаление, а не подключение или комментарий

Issue перечисляет три исхода. Выбран второй, и не по вкусу:

1. **Подключить в плагине** — практическую выгоду снял PR #4082: разрешение
   синглтона стало индексированным (`matchPO`, O(matches)) вместо обхода
   store. Остался только риск: хостовый загрузчик читал бы `metadataCache`,
   который **холоден на старте**, а закэшированный null-вердикт снимает
   `createdAt`/`updatedAt` со всех создаваемых после этого ассетов. То есть
   вариант потерял выгоду и сохранил задокументированный дефект.
3. **Оставить и дописать в докстринг** — запрещено прямо:
   «⛔ Третьего („оставим, но припишем ⚠“) не существует: предупреждение
   читают те, кто и так осторожен».

⇒ 2. Один путь, и он тот, который упражняют тесты.

## Доказательство мёртвости — по построению, а не по выборке

`_loader` имеет **единственного** писателя (`registerUniversalDefaultLoader`),
и у него **ноль** вызовов в проде: `git grep` по `origin/main` без pathspec
даёт 1 определение + 6 употреблений в тестах. Значит `loadUniversalDefault()`
возвращал `null` на **каждом** продовом вызове, а `getUniversalCache` его
всё это время `await`-ил. Выборочный замер тут не нужен и не усилил бы вывод.

⚠ Ровно поэтому удалён и тест «loader lifecycle»: он специфицировал
«ЕСЛИ загрузчик зарегистрирован, он будет использован» и был зелёным всю
жизнь фичи — при том, что предусловие не выполнялось никогда. Тест, чью
посылку прод не удовлетворяет, покрытием не является.

## Routing (Step 0)

**Refactor → exempt**, требование не заводится. Дискриминатор: наблюдаемое
поведение не меняется — удаляемая ветка всегда возвращала null. Здесь не
запирается никакое свойство (это был бы случай, требующий req), а снимается
код, который свойств не имел.

## Попутно снята устаревшая подпись из #4082

Докстринг `invalidateCache` предупреждал, что `clearUniversalCache()` трогает
МОДУЛЬНЫЙ кэш и потому метод «не является чисто instance-scoped». После этого
PR он снова чисто instance-scoped — предупреждение заменено на констатацию с
указанием, что именно было снято.

## Гейты

- `typecheck core` rc=0 ⚠ покрывает `packages/core/src`; тест-файлы им НЕ
  покрыты (все три tsconfig исключают `tests/**` — issue #4084), их
  типизирует только ts-jest в момент прогона, и он зелёный.
- затронутые сьюты: 2/2 PASS, 17 тестов (5 merge + 12 wiring).
- полный core: **373/375 сьютов, 8608 passed, 0 failed**.
  Два падения — `AssetSpaceMount*`, `Cannot find module nanotar`: пакета нет
  в локально скопированных `node_modules` (в worktree-источнике его тоже нет),
  к диффу отношения не имеет — дифф трогает 4 файла, ни одного в assetspace.
  ⚠ Ещё одно падение оказалось флаки: исчезло на повторном прогоне при
  неизменном коде (3 failed → 2 failed, 1 failed test → 0).

Claude-Session: https://claude.ai/code/session_015QdGEKFfUAiVYTkvXcDhJ2
