### PR TITLE
feat(ci): ratchet type errors in test files (closes #4084)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -221,6 +221,16 @@ jobs:
       - name: No new type errors in packages/cli
         run: node scripts/check-cli-types.mjs
 
+      # Issue #4084 — the OTHER half of the same hole. No tsconfig in the repo includes
+      # packages/**/tests/**, so all 975 test files are type-checked only by ts-jest at
+      # run time, where a failure reads as "Test suite failed to run / Tests: 0". Measured
+      # 2026-08-19: 505 (file, code) pairs / 2502 diagnostics of pre-existing debt —
+      # including tests that import a module which MOVED packages and still pass green,
+      # because the import is type-only and ts-jest erases it without resolving (the
+      # annotation silently degrades to `any`). Reuses the build step above.
+      - name: No new type errors in test files
+        run: node scripts/check-test-types.mjs
+
       # Test-quality audit 2026-06-22 (recommendation P4): ratchet guard against
       # low-value test anti-patterns (method-exists `.toBe("function")` asserts +
       # vacuous `toBeGreaterThanOrEqual(0)` length asserts). Fails if their count

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -222,12 +222,14 @@ jobs:
         run: node scripts/check-cli-types.mjs
 
       # Issue #4084 — the OTHER half of the same hole. No tsconfig in the repo includes
-      # packages/**/tests/**, so all 975 test files are type-checked only by ts-jest at
-      # run time, where a failure reads as "Test suite failed to run / Tests: 0". Measured
-      # 2026-08-19: 505 (file, code) pairs / 2502 diagnostics of pre-existing debt —
-      # including tests that import a module which MOVED packages and still pass green,
-      # because the import is type-only and ts-jest erases it without resolving (the
-      # annotation silently degrades to `any`). Reuses the build step above.
+      # packages/**/tests/**, so no standalone tsc run covers the 975 test files. This is a
+      # STRICTER SUPERSET of what ts-jest checks, NOT a reproduction of it: main is green
+      # today with all 2396 baselined diagnostics present, so a red here does not imply a
+      # failing suite. What it uniquely covers: tests/component/** (Playwright CT — type-
+      # checked by nothing), and tests importing a module that MOVED packages while still
+      # passing green, because the import is type-only and ts-jest erases it without
+      # resolving (the annotation silently degrades to `any`). Measured 2026-08-19:
+      # 433 (file, code) pairs / 2396 diagnostics. Reuses the build step above.
       - name: No new type errors in test files
         run: node scripts/check-test-types.mjs
 

--- a/docs/reference/ci/required-checks.md
+++ b/docs/reference/ci/required-checks.md
@@ -42,12 +42,15 @@ So a green `typecheck` says **nothing** about:
   one of which — a `BlankNode.value` read — shipped through two review rounds of #4070 while
   the compiler had been flagging it the whole time.
 - **`packages/**/tests/**`** — all 975 test files. Gated separately by
-  `scripts/check-test-types.mjs` (ratchet, issue #4084; baseline 505 `(file, code)` pairs /
-  2502 diagnostics at introduction). Their only other type-checking is ts-jest **at run
-  time**, where a type error surfaces as `Test suite failed to run / Tests: 0` — a shape that
-  reads as "nothing failed". ⛔ Worse, a **type-only** import is *erased* by ts-jest without
-  ever being resolved, so a test importing a module that has since MOVED still passes green
-  while its annotation silently degrades to `any`.
+  `scripts/check-test-types.mjs` (ratchet, issue #4084; baseline 433 `(file, code)` pairs /
+  2396 diagnostics at introduction).
+
+  ⛔ That gate is a **stricter superset** of what ts-jest checks, not a reproduction of it —
+  `main` is green today with all 2396 diagnostics present, so a red there does **not** mean a
+  suite fails at run time. What it uniquely covers: `tests/component/**` runs under Playwright
+  CT (bundler transpile) and is type-checked by **nothing** otherwise; and a **type-only**
+  import is *erased* by ts-jest without ever being resolved, so a test importing a module that
+  has since MOVED still passes green while its annotation silently degrades to `any`.
 
 ⇒ When reporting gate results on a PR, state **what the run covered**, not just its exit
 code: `typecheck rc=0 (⚠ does not cover test files or packages/cli)`. A bare "typecheck

--- a/docs/reference/ci/required-checks.md
+++ b/docs/reference/ci/required-checks.md
@@ -22,6 +22,38 @@ gh api repos/kitelev/exocortex/branches/main/protection/required_status_checks \
 
 If this page and the API disagree, the API wins — update this page.
 
+## ⛔ What `typecheck` actually covers (it is narrower than the name)
+
+`typecheck` runs `npm run check:types` → `tsc --noEmit -p tsconfig.json` (root). Measured
+2026-08-19 against `origin/main`, that config covers **`packages/<non-cli>/src` and nothing
+else**:
+
+| tsconfig | `include` | `exclude` |
+|---|---|---|
+| root `tsconfig.json` | `packages/**/*.ts(x)` | `packages/**/tests/**/*`, **`packages/cli/**/*`**, `packages/*/dist` |
+| `packages/core/tsconfig.json` | `src/**/*` | `node_modules`, `dist`, **`tests`** |
+| `packages/cli/tsconfig.json` | `src/**/*` | (tests simply not included) |
+| `packages/obsidian-plugin/` | — | *(no package tsconfig at all)* |
+
+So a green `typecheck` says **nothing** about:
+
+- **`packages/cli/src`** — excluded from the root config. Gated separately by
+  `scripts/check-cli-types.mjs` (ratchet, issue #4074). It had accumulated 24 unseen errors,
+  one of which — a `BlankNode.value` read — shipped through two review rounds of #4070 while
+  the compiler had been flagging it the whole time.
+- **`packages/**/tests/**`** — all 975 test files. Gated separately by
+  `scripts/check-test-types.mjs` (ratchet, issue #4084; baseline 505 `(file, code)` pairs /
+  2502 diagnostics at introduction). Their only other type-checking is ts-jest **at run
+  time**, where a type error surfaces as `Test suite failed to run / Tests: 0` — a shape that
+  reads as "nothing failed". ⛔ Worse, a **type-only** import is *erased* by ts-jest without
+  ever being resolved, so a test importing a module that has since MOVED still passes green
+  while its annotation silently degrades to `any`.
+
+⇒ When reporting gate results on a PR, state **what the run covered**, not just its exit
+code: `typecheck rc=0 (⚠ does not cover test files or packages/cli)`. A bare "typecheck
+green" reads as "the whole diff was checked" and is false for any PR whose main artefact is
+a test.
+
 ## Gotchas
 
 - **Matrix contexts use the parenthesised form** `<job> (<shard>)` (e.g. `e2e-shard (4)`).

--- a/scripts/check-test-types.mjs
+++ b/scripts/check-test-types.mjs
@@ -10,26 +10,47 @@
  *   packages/cli/tsconfig.json      include src/**\/*   (tests not included)
  *   packages/obsidian-plugin/       has no package tsconfig at all
  *   tsconfig.json (root)            exclude packages/**\/tests/**\/*, packages/cli/**\/*
- * So all 975 test files are type-checked ONLY by ts-jest at run time.
+ * So no standalone `tsc` run covers the 975 test files.
  *
- * That is not equivalent, and the difference is the point: a type error in a test
- * surfaces as `● Test suite failed to run` + `Tests: 0` — a shape that reads as
- * "nothing failed" (see rules/integration-test-revert-verify.md §A3). It also makes
- * "typecheck rc=0" in a PR report a FALSE guarantee whenever the PR's main artifact
- * is a test file. Observed on PR #4082: the report said `typecheck core rc=0` while
- * the test file it shipped was type-checked by nothing; a round-2 review caught it,
- * not a gate.
+ * ⛔ What this gate is, precisely: a STRICTER SUPERSET program, not a reproduction of
+ * what ts-jest checks. Do not claim equivalence — it is measurably false. ExocortexAPI
+ * .test.ts carries 4 baselined diagnostics (TS2345 ×3, TS2554 ×1) and runs 28/28 GREEN;
+ * CI is green on main today with all 2396 of them present. So a NEW pair here does NOT
+ * imply a suite that fails at run time, and the failure text must not say it does — an
+ * author who reads "your suite is broken" goes hunting a runtime failure that does not
+ * exist, and concludes the gate is noise.
  *
- * ⛤ Why a RATCHET, not turning the check on: the debt is ~3.1K diagnostics across
- * ~386 files, wildly uneven by package (measured 2026-08-19, workspace deps built):
- *   core            379 test files →     2   ← nearly clean despite being the largest suite
- *   services          1              →     9
- *   test-utils        3              →     9
- *   cli             161              →   654
- *   obsidian-plugin ~431             → ~2475
+ * The coverage the gate genuinely adds, in descending order of value:
+ *   - packages/obsidian-plugin/tests/component/** (22 pairs) runs under Playwright CT
+ *     (bundler transpile) — type-checked by NOTHING otherwise.
+ *   - type-only imports of MOVED modules: ts-jest erases them without resolving, so the
+ *     annotation degrades to `any` and the suite passes green while its type safety is
+ *     fiction. 13 × TS2307 in the baseline are exactly this.
+ *   - it makes "typecheck rc=0" in a PR report stop being a false guarantee when the
+ *     PR's main artifact is a test file. Observed on PR #4082: the report said
+ *     `typecheck core rc=0` while the test it shipped was type-checked by nothing; a
+ *     round-2 review caught that, not a gate.
+ * (A type error CAN also surface through jest as `● Test suite failed to run` + `Tests: 0`
+ *  — a shape that reads as "nothing failed", rules/integration-test-revert-verify.md §A3
+ *  — but that is a possible symptom, not the mechanism, and most of this debt is silent.)
+ *
+ * ⛤ Why a RATCHET, not turning the check on. Measured 2026-08-19 through THIS config
+ * (tsconfig.tests.json, target ES2020, workspace deps built) — 433 (file, code) pairs /
+ * 2396 diagnostics, wildly uneven by package:
+ *   obsidian-plugin  326 pairs
+ *   cli               69
+ *   core              37   ← nearly clean despite holding the largest suite
+ *   test-utils         1
  * An always-red gate gets ignored, which is worse than no gate (the rationale
  * check-cli-types.mjs already documents). The ratchet freezes the debt and makes it
  * impossible to GROW.
+ *
+ * ⚠ An earlier draft of this docstring quoted a DIFFERENT measurement here (per-package
+ * configs, one tsc run each: core 2, cli 654, obsidian-plugin ~2475). Those numbers are
+ * not wrong, they answer a different question — a separate program per package resolves
+ * cross-package imports differently, so its counts do not transfer. Numbers in a gate's
+ * docstring must say WHICH program produced them, or the next reader compares two scales
+ * and "explains" the gap. The figures above are from the config this script actually runs.
  *
  * ⛤ Per-package baselines are NOT needed even though the debt is uneven: the baseline
  * is a set of (file, code) PAIRS, so a new error in core is a new pair regardless of
@@ -62,14 +83,34 @@ const LINE_RE = /^(.+?)\((\d+),(\d+)\): error (TS\d+):/;
 /** Only test files are ratcheted; src is present purely for import resolution. */
 const isTestPath = (f) => f.replace(/\\/g, "/").includes("/tests/");
 
+/**
+ * ⛤ `--listFiles` is what makes the scope proof POSITIVE, and that is the whole point.
+ *
+ * Deriving "did the run examine the tests?" from the DIAGNOSTICS is negative evidence:
+ * it works only while errors exist. Two states break it, and both end in the same trap —
+ * the stale-baseline branch tells the operator to run `--update`, and obeying that writes
+ * an EMPTY baseline that greens the gate forever (check-cli-types.mjs calls this "the tool
+ * talked the operator into disarming it"; reproduced here on a stubbed tsc, probes E→F→G):
+ *
+ *   (1) the config breaks in a way that yields a POSITION-LESS error (TS18003 "No inputs
+ *       were found", TS5058 "The specified path does not exist") → nothing parses at all;
+ *   (2) the debt is fully PAID → tsc exits 0 → no diagnostics at all. The reward for
+ *       fixing every error would be a silently disarmed gate.
+ *
+ * `--listFiles` names every file in the program regardless of whether any error exists,
+ * so "N test files were compiled" is an assertion about the RUN, not about its findings.
+ * That is the same discipline this script already applies to diagnostics ("report the
+ * INPUT SIZE beside the findings" — a bare 0 is indistinguishable from a dead run).
+ */
 function runTsc() {
+  const args = ["tsc", "--noEmit", "--listFiles", "-p", CONFIG];
+  // --listFiles adds one line per file in the program (lib.d.ts + node_modules types
+  // included), so the default 1 MB stdout buffer is not enough.
+  const opts = { cwd: ROOT, encoding: "utf8", stdio: ["ignore", "pipe", "pipe"], maxBuffer: 64 * 1024 * 1024 };
   try {
-    execFileSync("npx", ["tsc", "--noEmit", "-p", CONFIG], {
-      cwd: ROOT,
-      encoding: "utf8",
-      stdio: ["ignore", "pipe", "pipe"],
-    });
-    return "";
+    // rc=0 — no diagnostics. NOT "nothing to check": the file listing still arrives, and
+    // it is the only thing that distinguishes "clean" from "compiled nothing".
+    return String(execFileSync("npx", args, opts) ?? "");
   } catch (err) {
     const out = String(err.stdout ?? "");
     if (out.trim().length === 0) {
@@ -84,6 +125,16 @@ function runTsc() {
 }
 
 const raw = runTsc();
+
+/**
+ * Files tsc actually put in the program (from --listFiles). A listing line is a bare path;
+ * a diagnostic line carries `(line,col): error TSxxxx`. Filter to the repo's own tests.
+ */
+const compiledTestFiles = raw
+  .split("\n")
+  .map((l) => l.trim())
+  .filter((l) => l.length > 0 && !LINE_RE.test(l) && /\.tsx?$/.test(l))
+  .filter((l) => isTestPath(l) && !l.includes("/node_modules/"));
 const all = new Map(); // "file|code" -> count, EVERY diagnostic (src included)
 const found = new Map(); // "file|code" -> count, tests only
 let diagnostics = 0;
@@ -111,7 +162,38 @@ for (const line of raw.split("\n")) {
  * leaving `found` empty and the run looking like "no test errors". The only signal
  * that survives is SCOPE: a real run names files under packages/**\/tests/.
  */
+/** Below this many compiled test files the run is not describing this repo. ~975 exist. */
+const MIN_COMPILED_TEST_FILES = 200;
+
 function assertRunIsMeaningful() {
+  // ⛤ POSITIVE scope proof, from --listFiles. Holds whether or not any error exists, so
+  // it survives both a broken config (nothing compiled) and a fully-paid debt (rc=0).
+  if (compiledTestFiles.length < MIN_COMPILED_TEST_FILES) {
+    console.error(
+      `❌ check-test-types: tsc compiled ${compiledTestFiles.length} file(s) under\n` +
+        `   packages/**/tests/ — expected at least ${MIN_COMPILED_TEST_FILES}. The run is\n` +
+        "   NOT describing this repository's tests, so it has no verdict to give.\n" +
+        "   ⛔ Do NOT run --update to make this go away. --update would write a baseline\n" +
+        "   derived from this same empty run — i.e. an empty baseline — and every later\n" +
+        "   run would exit 0 green while compiling nothing. Fix the invocation instead.\n" +
+        "   Likely causes: unparseable/renamed tsconfig, an `include` that matches nothing,\n" +
+        "   a bad `extends`, or tsc not resolving at all.\n" +
+        (raw.trim().length > 0
+          ? "   tsc said:\n" +
+            raw
+              .split("\n")
+              .filter((l) => l.trim().length > 0 && !/\.tsx?$/.test(l.trim()))
+              .slice(0, 5)
+              .map((l) => `      ${l.trim()}`)
+              .join("\n")
+          : "   (tsc produced no output at all)"),
+    );
+    process.exit(2);
+  }
+
+  // Kept as a second, cheaper signal with its own message: the program DID include tests,
+  // yet every diagnostic names something else. Subsumed by the floor above in practice,
+  // but it names a different failure and costs nothing.
   const compiledFiles = new Set([...all.keys()].map((k) => k.split("|")[0]));
   const testFiles = [...compiledFiles].filter(isTestPath);
 
@@ -151,7 +233,11 @@ function assertRunIsMeaningful() {
   //
   // Discriminator: (a) is a BARE workspace-package specifier; (b) is a relative path
   // or a deep subpath. Only (a) aborts the run.
-  const WORKSPACE_BARE = /Cannot find module '@kitelev\/exocortex-(core|services)'/;
+  // ⛤ Matches ANY bare @kitelev/exocortex-* specifier, not a hardcoded two-name list: a
+  // future workspace package that needs building would otherwise be diagnosed as "fix the
+  // error" instead of "build the dep". The trailing quote is load-bearing — it keeps DEEP
+  // SUBPATHS (`@kitelev/exocortex-core/domain/errors`) out, so those stay real debt (b).
+  const WORKSPACE_BARE = /Cannot find module '@kitelev\/exocortex-[a-z-]+'/;
   const envUnresolved = raw.split("\n").filter((l) => WORKSPACE_BARE.test(l));
   const unresolved = envUnresolved.length > 0 ? [...new Set(envUnresolved)] : [];
   if (unresolved.length > 0) {
@@ -181,6 +267,31 @@ if (UPDATE) {
     })
     .sort((a, b) => a.file.localeCompare(b.file) || a.code.localeCompare(b.code));
   writeFileSync(BASELINE, JSON.stringify({ entries }, null, 2) + "\n", "utf8");
+
+  // ⛤ Print the SHAPE of what was just frozen, not only its size. The generated baseline
+  // is the most reviewable artifact in a PR like this, and nothing else surfaces its
+  // distribution — so a config artifact hides in it as a plain "N pairs". Concretely:
+  // the first draft of this gate inherited target ES6 and baked in 70 × TS1378
+  // ("top-level await requires es2017+"), 14% of the baseline, 100% of it in one package.
+  // A per-code histogram makes that anomaly announce itself; a total never can.
+  const byCode = new Map();
+  const byPkg = new Map();
+  for (const e of entries) {
+    byCode.set(e.code, (byCode.get(e.code) ?? 0) + 1);
+    const pkg = /^packages\/([^/]+)\//.exec(e.file.replace(/\\/g, "/"))?.[1] ?? "?";
+    byPkg.set(pkg, (byPkg.get(pkg) ?? 0) + 1);
+  }
+  const fmt = (m) =>
+    [...m.entries()].sort((a, b) => b[1] - a[1]).map(([k, v]) => `${k} ${v}`);
+  console.log(`   by package: ${fmt(byPkg).join(", ")}`);
+  console.log(`   by code:    ${fmt(byCode).slice(0, 10).join(", ")}${byCode.size > 10 ? `, … (${byCode.size} codes)` : ""}`);
+  const [topCode, topN] = [...byCode.entries()].sort((a, b) => b[1] - a[1])[0] ?? [];
+  if (topN && topN / entries.length >= 0.1) {
+    console.log(
+      `   ⚠ ${topCode} is ${Math.round((topN / entries.length) * 100)}% of the baseline — ` +
+        "check it is real debt and not a config artifact before committing.",
+    );
+  }
   console.log(
     `✅ baseline written: ${entries.length} (file, code) pair(s), ${diagnostics} diagnostic(s)`,
   );
@@ -217,8 +328,9 @@ const shrunk = [...found.entries()]
 // Report the INPUT SIZE beside the findings: "0 new" is indistinguishable from
 // "tsc emitted nothing at all" without it.
 console.log(
-  `check-test-types: ${diagnostics} diagnostic(s) in ${found.size} (file, code) pair(s) ` +
-    `across test files; baseline has ${known.size}`,
+  `check-test-types: compiled ${compiledTestFiles.length} test file(s); ` +
+    `${diagnostics} diagnostic(s) in ${found.size} (file, code) pair(s) ` +
+    `across them; baseline has ${known.size}`,
 );
 
 if (newPairs.length > 0) {
@@ -231,10 +343,15 @@ if (newPairs.length > 0) {
     }
   }
   console.error(
-    "\n   Nothing else type-checks test files — ts-jest only reports them at run time,\n" +
-      "   where the failure looks like 'Test suite failed to run / Tests: 0'. Fix the\n" +
-      "   error — do NOT add it to the baseline. The baseline freezes the EXISTING debt,\n" +
-      "   it is not a place to put new debt (that is how a ratchet becomes a licence).",
+    "\n   Fix the error — do NOT add it to the baseline. The baseline freezes the EXISTING\n" +
+      "   debt; it is not a place to put new debt (that is how a ratchet becomes a licence).\n" +
+      "\n" +
+      "   ⚠ This gate is a STRICTER SUPERSET of what ts-jest checks, so a red here does NOT\n" +
+      "   mean your suite fails at run time — it may well pass. Measured: ExocortexAPI.test.ts\n" +
+      "   carries 4 baselined diagnostics and runs 28/28 green. Do not go hunting a runtime\n" +
+      "   failure; the compiler is telling you something jest is not configured to tell you.\n" +
+      "   That gap is the point — packages/obsidian-plugin/tests/component/** runs under\n" +
+      "   Playwright CT (bundler transpile), where nothing type-checks it at all.",
   );
   process.exit(1);
 }

--- a/scripts/check-test-types.mjs
+++ b/scripts/check-test-types.mjs
@@ -1,0 +1,267 @@
+#!/usr/bin/env node
+/**
+ * Ratchet: type-check `packages/**\/tests/**` and fail on any NEW error.
+ *
+ * ⛔ Why this exists — the second half of the hole that check-cli-types.mjs closed.
+ * That script covered `packages/cli/src`, which was type-checked nowhere. Tests are
+ * the other uncovered half, and they are LARGER: measured on origin/main 2026-08-19,
+ * NO tsconfig in the repo includes `packages/**\/tests/**` —
+ *   packages/core/tsconfig.json     include src/**\/*   exclude [..., "tests"]
+ *   packages/cli/tsconfig.json      include src/**\/*   (tests not included)
+ *   packages/obsidian-plugin/       has no package tsconfig at all
+ *   tsconfig.json (root)            exclude packages/**\/tests/**\/*, packages/cli/**\/*
+ * So all 975 test files are type-checked ONLY by ts-jest at run time.
+ *
+ * That is not equivalent, and the difference is the point: a type error in a test
+ * surfaces as `● Test suite failed to run` + `Tests: 0` — a shape that reads as
+ * "nothing failed" (see rules/integration-test-revert-verify.md §A3). It also makes
+ * "typecheck rc=0" in a PR report a FALSE guarantee whenever the PR's main artifact
+ * is a test file. Observed on PR #4082: the report said `typecheck core rc=0` while
+ * the test file it shipped was type-checked by nothing; a round-2 review caught it,
+ * not a gate.
+ *
+ * ⛤ Why a RATCHET, not turning the check on: the debt is ~3.1K diagnostics across
+ * ~386 files, wildly uneven by package (measured 2026-08-19, workspace deps built):
+ *   core            379 test files →     2   ← nearly clean despite being the largest suite
+ *   services          1              →     9
+ *   test-utils        3              →     9
+ *   cli             161              →   654
+ *   obsidian-plugin ~431             → ~2475
+ * An always-red gate gets ignored, which is worse than no gate (the rationale
+ * check-cli-types.mjs already documents). The ratchet freezes the debt and makes it
+ * impossible to GROW.
+ *
+ * ⛤ Per-package baselines are NOT needed even though the debt is uneven: the baseline
+ * is a set of (file, code) PAIRS, so a new error in core is a new pair regardless of
+ * how many pairs obsidian-plugin holds. It cannot be absorbed by the large package's
+ * count — that is exactly why the pair-set beats a counter.
+ *
+ * ⛔ src is compiled but NOT gated here. The program cannot resolve test imports
+ * without it; `check:types` and check-cli-types.mjs own the src half. Diagnostics are
+ * filtered to `/tests/` before anything is compared.
+ *
+ * Fail-loud in BOTH directions (same contract as check-cli-types.mjs):
+ *   rc=1  a (file, code) pair NOT in the baseline appeared            → regression
+ *   rc=1  a baselined pair grew (more instances)                      → still growth
+ *   rc=1  a baselined pair is GONE / shrank                           → debt paid, update
+ *   rc=2  the check could not run                                     → NOT "clean"
+ */
+
+import { execFileSync } from "node:child_process";
+import { readFileSync, writeFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
+const BASELINE = join(ROOT, "scripts", "test-type-errors.baseline.json");
+const CONFIG = "tsconfig.tests.json";
+const UPDATE = process.argv.includes("--update");
+
+/** `path/file.ts(12,34): error TS2339: msg` → { file, code } */
+const LINE_RE = /^(.+?)\((\d+),(\d+)\): error (TS\d+):/;
+/** Only test files are ratcheted; src is present purely for import resolution. */
+const isTestPath = (f) => f.replace(/\\/g, "/").includes("/tests/");
+
+function runTsc() {
+  try {
+    execFileSync("npx", ["tsc", "--noEmit", "-p", CONFIG], {
+      cwd: ROOT,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    return "";
+  } catch (err) {
+    const out = String(err.stdout ?? "");
+    if (out.trim().length === 0) {
+      console.error(
+        "❌ check-test-types: tsc produced no output — the check did not run.\n" +
+          `   ${String(err.stderr ?? err).slice(0, 400)}`,
+      );
+      process.exit(2);
+    }
+    return out;
+  }
+}
+
+const raw = runTsc();
+const all = new Map(); // "file|code" -> count, EVERY diagnostic (src included)
+const found = new Map(); // "file|code" -> count, tests only
+let diagnostics = 0;
+for (const line of raw.split("\n")) {
+  const m = LINE_RE.exec(line.trim());
+  if (!m) continue;
+  const key = `${m[1]}|${m[4]}`;
+  all.set(key, (all.get(key) ?? 0) + 1);
+  if (!isTestPath(m[1])) continue;
+  diagnostics += 1;
+  found.set(key, (found.get(key) ?? 0) + 1);
+}
+
+/**
+ * Refuse to conclude anything from a run that did not actually compile the tests.
+ *
+ * ⛔ REFINEMENT over check-cli-types.mjs, measured 2026-08-19: that script treats
+ * "diagnostic without a file position" as the signature of a config failure. That is
+ * NECESSARY BUT NOT SUFFICIENT — `TS5069` (declarationMap without declaration) is a
+ * config error that ABORTS the run while printing a perfectly positioned diagnostic:
+ *
+ *   tsconfig.m-core-both.json(3,68): error TS5069: Option 'declarationMap' cannot be …
+ *
+ * It parses, it has a line and a column, and it sails past a position-based guard —
+ * leaving `found` empty and the run looking like "no test errors". The only signal
+ * that survives is SCOPE: a real run names files under packages/**\/tests/.
+ */
+function assertRunIsMeaningful() {
+  const compiledFiles = new Set([...all.keys()].map((k) => k.split("|")[0]));
+  const testFiles = [...compiledFiles].filter(isTestPath);
+
+  if (compiledFiles.size > 0 && testFiles.length === 0) {
+    console.error(
+      "❌ check-test-types: tsc emitted diagnostics but NONE of them name a file under\n" +
+        "   packages/**/tests/ — the run did not compile the tests.\n" +
+        "   ⛔ A config error can carry a file position (it points at the tsconfig), so\n" +
+        "   'the output parsed' is NOT evidence the check ran. Scope is.\n" +
+        "   tsc said:\n" +
+        raw
+          .split("\n")
+          .filter((l) => l.trim().length > 0)
+          .slice(0, 5)
+          .map((l) => `      ${l.trim()}`)
+          .join("\n"),
+    );
+    process.exit(2);
+  }
+
+  // ⛔ TS2307 is TWO different things here, and conflating them is the trap.
+  //
+  //  (a) ENVIRONMENT — the workspace deps are not built, so `@kitelev/exocortex-core`
+  //      resolves to `dist/index.d.ts` which does not exist yet. Measured: before
+  //      building core+services the cli control showed 174 diagnostics (64 × TS2307
+  //      + cascade); after building, 24 — exactly the debt check-cli-types.mjs
+  //      baselines. This is "the check did not run" → rc=2.
+  //
+  //  (b) REAL DEBT — a test imports a module that MOVED and was never updated. This
+  //      is the most valuable thing this gate finds, so it must be BASELINED, never
+  //      rc=2. Measured example: `ILogger` moved from
+  //      packages/obsidian-plugin/src/infrastructure/logging/ to
+  //      packages/core/src/interfaces/, yet 4+ test files still import the old path
+  //      — AND THEY PASS. The import is type-only (`jest.Mocked<ILogger>`), so
+  //      ts-jest erases it without resolving; the annotation silently degrades to
+  //      `any` and the suite's type safety is fiction. Nothing but this gate sees it.
+  //
+  // Discriminator: (a) is a BARE workspace-package specifier; (b) is a relative path
+  // or a deep subpath. Only (a) aborts the run.
+  const WORKSPACE_BARE = /Cannot find module '@kitelev\/exocortex-(core|services)'/;
+  const envUnresolved = raw.split("\n").filter((l) => WORKSPACE_BARE.test(l));
+  const unresolved = envUnresolved.length > 0 ? [...new Set(envUnresolved)] : [];
+  if (unresolved.length > 0) {
+    console.error(
+      `❌ check-test-types: the workspace packages are not built (${unresolved.length} bare\n` +
+        "   @kitelev/exocortex-* import(s) unresolved), so this run describes a resolution\n" +
+        "   cascade rather than the tests' type health. Build them first:\n" +
+        "      npm run build -w @kitelev/exocortex-core\n" +
+        "      npm run build -w @kitelev/exocortex-services\n" +
+        "   (~3.5s combined; the CI step does this.)\n" +
+        unresolved
+          .slice(0, 3)
+          .map((l) => `      ${l.trim()}`)
+          .join("\n"),
+    );
+    process.exit(2);
+  }
+}
+
+assertRunIsMeaningful();
+
+if (UPDATE) {
+  const entries = [...found.entries()]
+    .map(([key, count]) => {
+      const [file, code] = key.split("|");
+      return { file, code, count };
+    })
+    .sort((a, b) => a.file.localeCompare(b.file) || a.code.localeCompare(b.code));
+  writeFileSync(BASELINE, JSON.stringify({ entries }, null, 2) + "\n", "utf8");
+  console.log(
+    `✅ baseline written: ${entries.length} (file, code) pair(s), ${diagnostics} diagnostic(s)`,
+  );
+  process.exit(0);
+}
+
+let baseline;
+try {
+  baseline = JSON.parse(readFileSync(BASELINE, "utf8"));
+} catch (err) {
+  console.error(`❌ check-test-types: cannot read ${BASELINE}: ${String(err)}`);
+  process.exit(2);
+}
+if (!Array.isArray(baseline?.entries)) {
+  console.error(
+    `❌ check-test-types: ${BASELINE} parsed but has no \`entries\` array — the\n` +
+      "   baseline is unusable, so the check cannot run (rc=2, not a finding).",
+  );
+  process.exit(2);
+}
+
+const known = new Set(baseline.entries.map((e) => `${e.file}|${e.code}`));
+const baseCount = new Map(baseline.entries.map((e) => [`${e.file}|${e.code}`, e.count ?? 0]));
+
+const newPairs = [...found.keys()].filter((k) => !known.has(k)).sort();
+const gonePairs = [...known].filter((k) => !found.has(k)).sort();
+const grown = [...found.entries()]
+  .filter(([key, count]) => known.has(key) && count > (baseCount.get(key) ?? 0))
+  .sort();
+const shrunk = [...found.entries()]
+  .filter(([key, count]) => known.has(key) && count < (baseCount.get(key) ?? 0))
+  .sort();
+
+// Report the INPUT SIZE beside the findings: "0 new" is indistinguishable from
+// "tsc emitted nothing at all" without it.
+console.log(
+  `check-test-types: ${diagnostics} diagnostic(s) in ${found.size} (file, code) pair(s) ` +
+    `across test files; baseline has ${known.size}`,
+);
+
+if (newPairs.length > 0) {
+  console.error(`\n❌ NEW type error(s) in test files — ${newPairs.length} pair(s):\n`);
+  for (const key of newPairs) {
+    const [file, code] = key.split("|");
+    console.error(`   ${file} — ${code}`);
+    for (const line of raw.split("\n")) {
+      if (line.includes(file) && line.includes(code)) console.error(`      ${line.trim()}`);
+    }
+  }
+  console.error(
+    "\n   Nothing else type-checks test files — ts-jest only reports them at run time,\n" +
+      "   where the failure looks like 'Test suite failed to run / Tests: 0'. Fix the\n" +
+      "   error — do NOT add it to the baseline. The baseline freezes the EXISTING debt,\n" +
+      "   it is not a place to put new debt (that is how a ratchet becomes a licence).",
+  );
+  process.exit(1);
+}
+
+if (grown.length > 0) {
+  console.error(`\n❌ ${grown.length} baselined pair(s) grew — new instances of known debt:\n`);
+  for (const [key, count] of grown) {
+    const [file, code] = key.split("|");
+    console.error(`   ${file} — ${code}: ${baseCount.get(key)} → ${count}`);
+  }
+  process.exit(1);
+}
+
+if (gonePairs.length > 0 || shrunk.length > 0) {
+  console.error(
+    `\n❌ ${gonePairs.length + shrunk.length} baselined entr(y/ies) no longer match — the baseline is stale:\n`,
+  );
+  for (const key of gonePairs) {
+    const [file, code] = key.split("|");
+    console.error(`   ${file} — ${code}  (fixed — thank you)`);
+  }
+  for (const [key, count] of shrunk) {
+    const [file, code] = key.split("|");
+    console.error(`   ${file} — ${code}: ${baseCount.get(key)} → ${count}  (partly fixed)`);
+  }
+  console.error("\n   Run: node scripts/check-test-types.mjs --update");
+  process.exit(1);
+}
+
+console.log("✅ no new type errors in test files");

--- a/scripts/test-type-errors.baseline.json
+++ b/scripts/test-type-errors.baseline.json
@@ -1,83 +1,13 @@
 {
   "entries": [
     {
-      "file": "packages/cli/tests/integration/apply-absolute-path-precondition.integration.test.ts",
-      "code": "TS1378",
-      "count": 1
-    },
-    {
-      "file": "packages/cli/tests/integration/apply-class-resolver.integration.test.ts",
-      "code": "TS1378",
-      "count": 1
-    },
-    {
-      "file": "packages/cli/tests/integration/apply-clean-properties-precondition.integration.test.ts",
-      "code": "TS1378",
-      "count": 1
-    },
-    {
-      "file": "packages/cli/tests/integration/apply-determinism.integration.test.ts",
-      "code": "TS1378",
-      "count": 1
-    },
-    {
-      "file": "packages/cli/tests/integration/apply-json-created-composite.integration.test.ts",
-      "code": "TS1378",
-      "count": 1
-    },
-    {
-      "file": "packages/cli/tests/integration/apply-json-created.integration.test.ts",
-      "code": "TS1378",
-      "count": 1
-    },
-    {
-      "file": "packages/cli/tests/integration/apply-mutation-parity.integration.test.ts",
-      "code": "TS1378",
-      "count": 1
-    },
-    {
-      "file": "packages/cli/tests/integration/apply-ontological-archive.integration.test.ts",
-      "code": "TS1378",
-      "count": 1
-    },
-    {
-      "file": "packages/cli/tests/integration/apply-ontological-unarchive.integration.test.ts",
-      "code": "TS1378",
-      "count": 2
-    },
-    {
-      "file": "packages/cli/tests/integration/apply-targetvaluequery.integration.test.ts",
-      "code": "TS1378",
-      "count": 1
-    },
-    {
-      "file": "packages/cli/tests/integration/apply-workflow-transition.integration.test.ts",
-      "code": "TS1378",
-      "count": 1
-    },
-    {
-      "file": "packages/cli/tests/integration/cache-eviction-and-clear-3981.integration.test.ts",
-      "code": "TS1378",
-      "count": 2
-    },
-    {
       "file": "packages/cli/tests/integration/cache-eviction-and-clear-3981.integration.test.ts",
       "code": "TS6133",
       "count": 1
-    },
-    {
-      "file": "packages/cli/tests/integration/canonical-key-single-source.integration.test.ts",
-      "code": "TS1378",
-      "count": 3
     },
     {
       "file": "packages/cli/tests/integration/cli-plugin-triple-parity.integration.test.ts",
       "code": "TS6133",
-      "count": 1
-    },
-    {
-      "file": "packages/cli/tests/integration/command-dry-run.integration.test.ts",
-      "code": "TS1378",
       "count": 1
     },
     {
@@ -111,143 +41,8 @@
       "count": 5
     },
     {
-      "file": "packages/cli/tests/integration/create-cardinality.integration.test.ts",
-      "code": "TS1378",
-      "count": 2
-    },
-    {
-      "file": "packages/cli/tests/integration/create-co-location.integration.test.ts",
-      "code": "TS1378",
-      "count": 1
-    },
-    {
-      "file": "packages/cli/tests/integration/create-multivalue.integration.test.ts",
-      "code": "TS1378",
-      "count": 1
-    },
-    {
-      "file": "packages/cli/tests/integration/create-neighbour-co-location.integration.test.ts",
-      "code": "TS1378",
-      "count": 1
-    },
-    {
-      "file": "packages/cli/tests/integration/create-no-status.integration.test.ts",
-      "code": "TS1378",
-      "count": 1
-    },
-    {
-      "file": "packages/cli/tests/integration/create-property-name-validation.integration.test.ts",
-      "code": "TS1378",
-      "count": 3
-    },
-    {
-      "file": "packages/cli/tests/integration/create-status-defaults.integration.test.ts",
-      "code": "TS1378",
-      "count": 1
-    },
-    {
-      "file": "packages/cli/tests/integration/create-validate-shacl.integration.test.ts",
-      "code": "TS1378",
-      "count": 1
-    },
-    {
-      "file": "packages/cli/tests/integration/cross-runtime-parity.test.ts",
-      "code": "TS1378",
-      "count": 3
-    },
-    {
-      "file": "packages/cli/tests/integration/dupkey-invisible-asset.integration.test.ts",
-      "code": "TS1378",
-      "count": 2
-    },
-    {
-      "file": "packages/cli/tests/integration/remove-property-unknown-name.integration.test.ts",
-      "code": "TS1378",
-      "count": 2
-    },
-    {
-      "file": "packages/cli/tests/integration/remove-property.integration.test.ts",
-      "code": "TS1378",
-      "count": 1
-    },
-    {
-      "file": "packages/cli/tests/integration/rename-to-uid-update-inbound-links.integration.test.ts",
-      "code": "TS1378",
-      "count": 1
-    },
-    {
-      "file": "packages/cli/tests/integration/repair-frontmatter.integration.test.ts",
-      "code": "TS1378",
-      "count": 1
-    },
-    {
-      "file": "packages/cli/tests/integration/resolve-buttons.integration.test.ts",
-      "code": "TS1378",
-      "count": 2
-    },
-    {
-      "file": "packages/cli/tests/integration/run-query-namedquery.integration.test.ts",
-      "code": "TS1378",
-      "count": 4
-    },
-    {
-      "file": "packages/cli/tests/integration/set-body.integration.test.ts",
-      "code": "TS1378",
-      "count": 1
-    },
-    {
-      "file": "packages/cli/tests/integration/set-property-name-validation.integration.test.ts",
-      "code": "TS1378",
-      "count": 2
-    },
-    {
-      "file": "packages/cli/tests/integration/set-property.integration.test.ts",
-      "code": "TS1378",
-      "count": 1
-    },
-    {
-      "file": "packages/cli/tests/integration/set-property.scalar-typing.integration.test.ts",
-      "code": "TS1378",
-      "count": 2
-    },
-    {
-      "file": "packages/cli/tests/integration/sparql-result-cache-key-3979.integration.test.ts",
-      "code": "TS1378",
-      "count": 1
-    },
-    {
-      "file": "packages/cli/tests/integration/validate-schema-labelless-class.integration.test.ts",
-      "code": "TS1378",
-      "count": 3
-    },
-    {
-      "file": "packages/cli/tests/integration/validate-schema-metaclass-inference.integration.test.ts",
-      "code": "TS1378",
-      "count": 3
-    },
-    {
-      "file": "packages/cli/tests/integration/validate-schema-namedquery-range.integration.test.ts",
-      "code": "TS1378",
-      "count": 3
-    },
-    {
-      "file": "packages/cli/tests/integration/validate-schema-person-subclass.integration.test.ts",
-      "code": "TS1378",
-      "count": 3
-    },
-    {
-      "file": "packages/cli/tests/integration/validate-schema-shapes-iri-false-positives.integration.test.ts",
-      "code": "TS1378",
-      "count": 1
-    },
-    {
       "file": "packages/cli/tests/integration/validate-schema-shapes-iri-false-positives.integration.test.ts",
       "code": "TS2339",
-      "count": 1
-    },
-    {
-      "file": "packages/cli/tests/integration/validate-schema-shapes-staged.integration.test.ts",
-      "code": "TS1378",
       "count": 1
     },
     {
@@ -261,24 +56,9 @@
       "count": 5
     },
     {
-      "file": "packages/cli/tests/integration/validate-schema-shapes.integration.test.ts",
-      "code": "TS1378",
-      "count": 3
-    },
-    {
-      "file": "packages/cli/tests/integration/validate-schema.integration.test.ts",
-      "code": "TS1378",
-      "count": 3
-    },
-    {
       "file": "packages/cli/tests/integration/validate-schema.integration.test.ts",
       "code": "TS6133",
       "count": 2
-    },
-    {
-      "file": "packages/cli/tests/unit/adapters/FileSystemVaultAdapter.test.ts",
-      "code": "TS1378",
-      "count": 1
     },
     {
       "file": "packages/cli/tests/unit/adapters/FileSystemVaultAdapter.test.ts",
@@ -288,11 +68,6 @@
     {
       "file": "packages/cli/tests/unit/adapters/FileSystemVaultAdapter.test.ts",
       "code": "TS6133",
-      "count": 1
-    },
-    {
-      "file": "packages/cli/tests/unit/adapters/NodeFsAdapter.test.ts",
-      "code": "TS1378",
       "count": 1
     },
     {
@@ -312,23 +87,8 @@
     },
     {
       "file": "packages/cli/tests/unit/cache/CacheManager.test.ts",
-      "code": "TS1378",
-      "count": 1
-    },
-    {
-      "file": "packages/cli/tests/unit/cache/CacheManager.test.ts",
       "code": "TS2345",
       "count": 4
-    },
-    {
-      "file": "packages/cli/tests/unit/cache/QueryResultCache.test.ts",
-      "code": "TS1378",
-      "count": 1
-    },
-    {
-      "file": "packages/cli/tests/unit/cache/QueryResultCache.vaultSignature.test.ts",
-      "code": "TS1378",
-      "count": 2
     },
     {
       "file": "packages/cli/tests/unit/CliApplyProfileService.parked.test.ts",
@@ -347,11 +107,6 @@
     },
     {
       "file": "packages/cli/tests/unit/commands/classes.test.ts",
-      "code": "TS1378",
-      "count": 1
-    },
-    {
-      "file": "packages/cli/tests/unit/commands/classes.test.ts",
       "code": "TS2345",
       "count": 8
     },
@@ -359,11 +114,6 @@
       "file": "packages/cli/tests/unit/commands/classes.test.ts",
       "code": "TS6133",
       "count": 1
-    },
-    {
-      "file": "packages/cli/tests/unit/commands/create.test.ts",
-      "code": "TS1378",
-      "count": 2
     },
     {
       "file": "packages/cli/tests/unit/commands/create.test.ts",
@@ -378,11 +128,6 @@
     {
       "file": "packages/cli/tests/unit/commands/exosync-sync.test.ts",
       "code": "TS2353",
-      "count": 1
-    },
-    {
-      "file": "packages/cli/tests/unit/commands/resolve.test.ts",
-      "code": "TS1378",
       "count": 1
     },
     {
@@ -402,18 +147,8 @@
     },
     {
       "file": "packages/cli/tests/unit/commands/sparql-index.test.ts",
-      "code": "TS1378",
-      "count": 1
-    },
-    {
-      "file": "packages/cli/tests/unit/commands/sparql-index.test.ts",
       "code": "TS2345",
       "count": 15
-    },
-    {
-      "file": "packages/cli/tests/unit/commands/sparql-query-debug.test.ts",
-      "code": "TS1378",
-      "count": 1
     },
     {
       "file": "packages/cli/tests/unit/commands/sparql-query-debug.test.ts",
@@ -427,17 +162,7 @@
     },
     {
       "file": "packages/cli/tests/unit/commands/sparql-query-timeout.test.ts",
-      "code": "TS1378",
-      "count": 1
-    },
-    {
-      "file": "packages/cli/tests/unit/commands/sparql-query-timeout.test.ts",
       "code": "TS6133",
-      "count": 1
-    },
-    {
-      "file": "packages/cli/tests/unit/commands/sparql-query.test.ts",
-      "code": "TS1378",
       "count": 1
     },
     {
@@ -448,11 +173,6 @@
     {
       "file": "packages/cli/tests/unit/commands/sparql-query.test.ts",
       "code": "TS6133",
-      "count": 2
-    },
-    {
-      "file": "packages/cli/tests/unit/commands/validate-schema.test.ts",
-      "code": "TS1378",
       "count": 2
     },
     {
@@ -472,17 +192,7 @@
     },
     {
       "file": "packages/cli/tests/unit/commands/validate.test.ts",
-      "code": "TS1378",
-      "count": 1
-    },
-    {
-      "file": "packages/cli/tests/unit/commands/validate.test.ts",
       "code": "TS2345",
-      "count": 1
-    },
-    {
-      "file": "packages/cli/tests/unit/executors/AssetCreationExecutor.test.ts",
-      "code": "TS1378",
       "count": 1
     },
     {
@@ -497,22 +207,12 @@
     },
     {
       "file": "packages/cli/tests/unit/executors/BatchExecutor.repair-folder.test.ts",
-      "code": "TS1378",
-      "count": 1
-    },
-    {
-      "file": "packages/cli/tests/unit/executors/BatchExecutor.repair-folder.test.ts",
       "code": "TS2345",
       "count": 45
     },
     {
       "file": "packages/cli/tests/unit/executors/BatchExecutor.repair-folder.test.ts",
       "code": "TS6133",
-      "count": 1
-    },
-    {
-      "file": "packages/cli/tests/unit/executors/BatchExecutor.test.ts",
-      "code": "TS1378",
       "count": 1
     },
     {
@@ -527,11 +227,6 @@
     },
     {
       "file": "packages/cli/tests/unit/executors/CommandExecutor.error.test.ts",
-      "code": "TS1378",
-      "count": 1
-    },
-    {
-      "file": "packages/cli/tests/unit/executors/CommandExecutor.error.test.ts",
       "code": "TS2345",
       "count": 27
     },
@@ -542,22 +237,12 @@
     },
     {
       "file": "packages/cli/tests/unit/executors/CommandExecutor.test.ts",
-      "code": "TS1378",
-      "count": 1
-    },
-    {
-      "file": "packages/cli/tests/unit/executors/CommandExecutor.test.ts",
       "code": "TS2345",
       "count": 72
     },
     {
       "file": "packages/cli/tests/unit/executors/CommandExecutor.test.ts",
       "code": "TS6133",
-      "count": 2
-    },
-    {
-      "file": "packages/cli/tests/unit/executors/FolderRepairExecutor.test.ts",
-      "code": "TS1378",
       "count": 2
     },
     {
@@ -581,11 +266,6 @@
       "count": 1
     },
     {
-      "file": "packages/cli/tests/unit/services/ClassResolverService.test.ts",
-      "code": "TS1378",
-      "count": 1
-    },
-    {
       "file": "packages/cli/tests/unit/services/CliProfileResolver.test.ts",
       "code": "TS6133",
       "count": 1
@@ -594,11 +274,6 @@
       "file": "packages/cli/tests/unit/services/instantiate-prototype-subtree.test.ts",
       "code": "TS6133",
       "count": 1
-    },
-    {
-      "file": "packages/cli/tests/unit/services/registerOrderSpec.test.ts",
-      "code": "TS1378",
-      "count": 2
     },
     {
       "file": "packages/cli/tests/unit/services/registerOrderSpec.test.ts",
@@ -626,11 +301,6 @@
       "count": 2
     },
     {
-      "file": "packages/cli/tests/unit/services/WikilinkValidator.test.ts",
-      "code": "TS1378",
-      "count": 1
-    },
-    {
       "file": "packages/cli/tests/unit/utils/ErrorHandler.test.ts",
       "code": "TS2345",
       "count": 1
@@ -647,11 +317,6 @@
     },
     {
       "file": "packages/cli/tests/unit/utils/ProgressIndicator.test.ts",
-      "code": "TS1378",
-      "count": 1
-    },
-    {
-      "file": "packages/cli/tests/unit/utils/ProgressIndicator.test.ts",
       "code": "TS2322",
       "count": 2
     },
@@ -662,27 +327,12 @@
     },
     {
       "file": "packages/cli/tests/unit/utils/QueryAnalyzer.test.ts",
-      "code": "TS1378",
-      "count": 1
-    },
-    {
-      "file": "packages/cli/tests/unit/utils/QueryAnalyzer.test.ts",
       "code": "TS6133",
       "count": 1
     },
     {
       "file": "packages/cli/tests/unit/utils/SPARQLErrorEnhancer.test.ts",
-      "code": "TS1378",
-      "count": 1
-    },
-    {
-      "file": "packages/cli/tests/unit/utils/SPARQLErrorEnhancer.test.ts",
       "code": "TS6133",
-      "count": 1
-    },
-    {
-      "file": "packages/cli/tests/unit/utils/TransactionManager.test.ts",
-      "code": "TS1378",
       "count": 1
     },
     {
@@ -2167,11 +1817,6 @@
     },
     {
       "file": "packages/obsidian-plugin/tests/unit/ProfileApplyManager.apply.test.ts",
-      "code": "TS1501",
-      "count": 1
-    },
-    {
-      "file": "packages/obsidian-plugin/tests/unit/ProfileApplyManager.apply.test.ts",
       "code": "TS2322",
       "count": 1
     },
@@ -2419,11 +2064,6 @@
       "file": "packages/obsidian-plugin/tests/unit/services/ClassDiscoveryService.test.ts",
       "code": "TS2769",
       "count": 2
-    },
-    {
-      "file": "packages/obsidian-plugin/tests/unit/services/OntologySchemaService.test.ts",
-      "code": "TS1501",
-      "count": 1
     },
     {
       "file": "packages/obsidian-plugin/tests/unit/services/OntologySchemaService.test.ts",

--- a/scripts/test-type-errors.baseline.json
+++ b/scripts/test-type-errors.baseline.json
@@ -1,0 +1,2529 @@
+{
+  "entries": [
+    {
+      "file": "packages/cli/tests/integration/apply-absolute-path-precondition.integration.test.ts",
+      "code": "TS1378",
+      "count": 1
+    },
+    {
+      "file": "packages/cli/tests/integration/apply-class-resolver.integration.test.ts",
+      "code": "TS1378",
+      "count": 1
+    },
+    {
+      "file": "packages/cli/tests/integration/apply-clean-properties-precondition.integration.test.ts",
+      "code": "TS1378",
+      "count": 1
+    },
+    {
+      "file": "packages/cli/tests/integration/apply-determinism.integration.test.ts",
+      "code": "TS1378",
+      "count": 1
+    },
+    {
+      "file": "packages/cli/tests/integration/apply-json-created-composite.integration.test.ts",
+      "code": "TS1378",
+      "count": 1
+    },
+    {
+      "file": "packages/cli/tests/integration/apply-json-created.integration.test.ts",
+      "code": "TS1378",
+      "count": 1
+    },
+    {
+      "file": "packages/cli/tests/integration/apply-mutation-parity.integration.test.ts",
+      "code": "TS1378",
+      "count": 1
+    },
+    {
+      "file": "packages/cli/tests/integration/apply-ontological-archive.integration.test.ts",
+      "code": "TS1378",
+      "count": 1
+    },
+    {
+      "file": "packages/cli/tests/integration/apply-ontological-unarchive.integration.test.ts",
+      "code": "TS1378",
+      "count": 2
+    },
+    {
+      "file": "packages/cli/tests/integration/apply-targetvaluequery.integration.test.ts",
+      "code": "TS1378",
+      "count": 1
+    },
+    {
+      "file": "packages/cli/tests/integration/apply-workflow-transition.integration.test.ts",
+      "code": "TS1378",
+      "count": 1
+    },
+    {
+      "file": "packages/cli/tests/integration/cache-eviction-and-clear-3981.integration.test.ts",
+      "code": "TS1378",
+      "count": 2
+    },
+    {
+      "file": "packages/cli/tests/integration/cache-eviction-and-clear-3981.integration.test.ts",
+      "code": "TS6133",
+      "count": 1
+    },
+    {
+      "file": "packages/cli/tests/integration/canonical-key-single-source.integration.test.ts",
+      "code": "TS1378",
+      "count": 3
+    },
+    {
+      "file": "packages/cli/tests/integration/cli-plugin-triple-parity.integration.test.ts",
+      "code": "TS6133",
+      "count": 1
+    },
+    {
+      "file": "packages/cli/tests/integration/command-dry-run.integration.test.ts",
+      "code": "TS1378",
+      "count": 1
+    },
+    {
+      "file": "packages/cli/tests/integration/command-dry-run.integration.test.ts",
+      "code": "TS6133",
+      "count": 1
+    },
+    {
+      "file": "packages/cli/tests/integration/commands/apply-profile.integration.test.ts",
+      "code": "TS2345",
+      "count": 1
+    },
+    {
+      "file": "packages/cli/tests/integration/commands/apply-profile.integration.test.ts",
+      "code": "TS6133",
+      "count": 1
+    },
+    {
+      "file": "packages/cli/tests/integration/commands/audit-ontology-url.integration.test.ts",
+      "code": "TS2322",
+      "count": 1
+    },
+    {
+      "file": "packages/cli/tests/integration/commands/audit-ontology-url.integration.test.ts",
+      "code": "TS7006",
+      "count": 3
+    },
+    {
+      "file": "packages/cli/tests/integration/commands/validate-vault.integration.test.ts",
+      "code": "TS2322",
+      "count": 5
+    },
+    {
+      "file": "packages/cli/tests/integration/create-cardinality.integration.test.ts",
+      "code": "TS1378",
+      "count": 2
+    },
+    {
+      "file": "packages/cli/tests/integration/create-co-location.integration.test.ts",
+      "code": "TS1378",
+      "count": 1
+    },
+    {
+      "file": "packages/cli/tests/integration/create-multivalue.integration.test.ts",
+      "code": "TS1378",
+      "count": 1
+    },
+    {
+      "file": "packages/cli/tests/integration/create-neighbour-co-location.integration.test.ts",
+      "code": "TS1378",
+      "count": 1
+    },
+    {
+      "file": "packages/cli/tests/integration/create-no-status.integration.test.ts",
+      "code": "TS1378",
+      "count": 1
+    },
+    {
+      "file": "packages/cli/tests/integration/create-property-name-validation.integration.test.ts",
+      "code": "TS1378",
+      "count": 3
+    },
+    {
+      "file": "packages/cli/tests/integration/create-status-defaults.integration.test.ts",
+      "code": "TS1378",
+      "count": 1
+    },
+    {
+      "file": "packages/cli/tests/integration/create-validate-shacl.integration.test.ts",
+      "code": "TS1378",
+      "count": 1
+    },
+    {
+      "file": "packages/cli/tests/integration/cross-runtime-parity.test.ts",
+      "code": "TS1378",
+      "count": 3
+    },
+    {
+      "file": "packages/cli/tests/integration/dupkey-invisible-asset.integration.test.ts",
+      "code": "TS1378",
+      "count": 2
+    },
+    {
+      "file": "packages/cli/tests/integration/remove-property-unknown-name.integration.test.ts",
+      "code": "TS1378",
+      "count": 2
+    },
+    {
+      "file": "packages/cli/tests/integration/remove-property.integration.test.ts",
+      "code": "TS1378",
+      "count": 1
+    },
+    {
+      "file": "packages/cli/tests/integration/rename-to-uid-update-inbound-links.integration.test.ts",
+      "code": "TS1378",
+      "count": 1
+    },
+    {
+      "file": "packages/cli/tests/integration/repair-frontmatter.integration.test.ts",
+      "code": "TS1378",
+      "count": 1
+    },
+    {
+      "file": "packages/cli/tests/integration/resolve-buttons.integration.test.ts",
+      "code": "TS1378",
+      "count": 2
+    },
+    {
+      "file": "packages/cli/tests/integration/run-query-namedquery.integration.test.ts",
+      "code": "TS1378",
+      "count": 4
+    },
+    {
+      "file": "packages/cli/tests/integration/set-body.integration.test.ts",
+      "code": "TS1378",
+      "count": 1
+    },
+    {
+      "file": "packages/cli/tests/integration/set-property-name-validation.integration.test.ts",
+      "code": "TS1378",
+      "count": 2
+    },
+    {
+      "file": "packages/cli/tests/integration/set-property.integration.test.ts",
+      "code": "TS1378",
+      "count": 1
+    },
+    {
+      "file": "packages/cli/tests/integration/set-property.scalar-typing.integration.test.ts",
+      "code": "TS1378",
+      "count": 2
+    },
+    {
+      "file": "packages/cli/tests/integration/sparql-result-cache-key-3979.integration.test.ts",
+      "code": "TS1378",
+      "count": 1
+    },
+    {
+      "file": "packages/cli/tests/integration/validate-schema-labelless-class.integration.test.ts",
+      "code": "TS1378",
+      "count": 3
+    },
+    {
+      "file": "packages/cli/tests/integration/validate-schema-metaclass-inference.integration.test.ts",
+      "code": "TS1378",
+      "count": 3
+    },
+    {
+      "file": "packages/cli/tests/integration/validate-schema-namedquery-range.integration.test.ts",
+      "code": "TS1378",
+      "count": 3
+    },
+    {
+      "file": "packages/cli/tests/integration/validate-schema-person-subclass.integration.test.ts",
+      "code": "TS1378",
+      "count": 3
+    },
+    {
+      "file": "packages/cli/tests/integration/validate-schema-shapes-iri-false-positives.integration.test.ts",
+      "code": "TS1378",
+      "count": 1
+    },
+    {
+      "file": "packages/cli/tests/integration/validate-schema-shapes-iri-false-positives.integration.test.ts",
+      "code": "TS2339",
+      "count": 1
+    },
+    {
+      "file": "packages/cli/tests/integration/validate-schema-shapes-staged.integration.test.ts",
+      "code": "TS1378",
+      "count": 1
+    },
+    {
+      "file": "packages/cli/tests/integration/validate-schema-shapes-staged.integration.test.ts",
+      "code": "TS2322",
+      "count": 1
+    },
+    {
+      "file": "packages/cli/tests/integration/validate-schema-shapes-staged.integration.test.ts",
+      "code": "TS2741",
+      "count": 5
+    },
+    {
+      "file": "packages/cli/tests/integration/validate-schema-shapes.integration.test.ts",
+      "code": "TS1378",
+      "count": 3
+    },
+    {
+      "file": "packages/cli/tests/integration/validate-schema.integration.test.ts",
+      "code": "TS1378",
+      "count": 3
+    },
+    {
+      "file": "packages/cli/tests/integration/validate-schema.integration.test.ts",
+      "code": "TS6133",
+      "count": 2
+    },
+    {
+      "file": "packages/cli/tests/unit/adapters/FileSystemVaultAdapter.test.ts",
+      "code": "TS1378",
+      "count": 1
+    },
+    {
+      "file": "packages/cli/tests/unit/adapters/FileSystemVaultAdapter.test.ts",
+      "code": "TS2345",
+      "count": 19
+    },
+    {
+      "file": "packages/cli/tests/unit/adapters/FileSystemVaultAdapter.test.ts",
+      "code": "TS6133",
+      "count": 1
+    },
+    {
+      "file": "packages/cli/tests/unit/adapters/NodeFsAdapter.test.ts",
+      "code": "TS1378",
+      "count": 1
+    },
+    {
+      "file": "packages/cli/tests/unit/adapters/NodeFsAdapter.test.ts",
+      "code": "TS2345",
+      "count": 75
+    },
+    {
+      "file": "packages/cli/tests/unit/adapters/NodeFsAdapter.test.ts",
+      "code": "TS2554",
+      "count": 13
+    },
+    {
+      "file": "packages/cli/tests/unit/BootstrapAssetSpaceService.test.ts",
+      "code": "TS6133",
+      "count": 1
+    },
+    {
+      "file": "packages/cli/tests/unit/cache/CacheManager.test.ts",
+      "code": "TS1378",
+      "count": 1
+    },
+    {
+      "file": "packages/cli/tests/unit/cache/CacheManager.test.ts",
+      "code": "TS2345",
+      "count": 4
+    },
+    {
+      "file": "packages/cli/tests/unit/cache/QueryResultCache.test.ts",
+      "code": "TS1378",
+      "count": 1
+    },
+    {
+      "file": "packages/cli/tests/unit/cache/QueryResultCache.vaultSignature.test.ts",
+      "code": "TS1378",
+      "count": 2
+    },
+    {
+      "file": "packages/cli/tests/unit/CliApplyProfileService.parked.test.ts",
+      "code": "TS6133",
+      "count": 2
+    },
+    {
+      "file": "packages/cli/tests/unit/commands/audit-co-location.test.ts",
+      "code": "TS2322",
+      "count": 1
+    },
+    {
+      "file": "packages/cli/tests/unit/commands/audit-co-location.test.ts",
+      "code": "TS7006",
+      "count": 3
+    },
+    {
+      "file": "packages/cli/tests/unit/commands/classes.test.ts",
+      "code": "TS1378",
+      "count": 1
+    },
+    {
+      "file": "packages/cli/tests/unit/commands/classes.test.ts",
+      "code": "TS2345",
+      "count": 8
+    },
+    {
+      "file": "packages/cli/tests/unit/commands/classes.test.ts",
+      "code": "TS6133",
+      "count": 1
+    },
+    {
+      "file": "packages/cli/tests/unit/commands/create.test.ts",
+      "code": "TS1378",
+      "count": 2
+    },
+    {
+      "file": "packages/cli/tests/unit/commands/create.test.ts",
+      "code": "TS6133",
+      "count": 1
+    },
+    {
+      "file": "packages/cli/tests/unit/commands/exosync-parity.test.ts",
+      "code": "TS6133",
+      "count": 1
+    },
+    {
+      "file": "packages/cli/tests/unit/commands/exosync-sync.test.ts",
+      "code": "TS2353",
+      "count": 1
+    },
+    {
+      "file": "packages/cli/tests/unit/commands/resolve.test.ts",
+      "code": "TS1378",
+      "count": 1
+    },
+    {
+      "file": "packages/cli/tests/unit/commands/resolve.test.ts",
+      "code": "TS2551",
+      "count": 1
+    },
+    {
+      "file": "packages/cli/tests/unit/commands/resolve.test.ts",
+      "code": "TS6133",
+      "count": 2
+    },
+    {
+      "file": "packages/cli/tests/unit/commands/sparql-index-strict.test.ts",
+      "code": "TS2554",
+      "count": 2
+    },
+    {
+      "file": "packages/cli/tests/unit/commands/sparql-index.test.ts",
+      "code": "TS1378",
+      "count": 1
+    },
+    {
+      "file": "packages/cli/tests/unit/commands/sparql-index.test.ts",
+      "code": "TS2345",
+      "count": 15
+    },
+    {
+      "file": "packages/cli/tests/unit/commands/sparql-query-debug.test.ts",
+      "code": "TS1378",
+      "count": 1
+    },
+    {
+      "file": "packages/cli/tests/unit/commands/sparql-query-debug.test.ts",
+      "code": "TS2345",
+      "count": 11
+    },
+    {
+      "file": "packages/cli/tests/unit/commands/sparql-query-debug.test.ts",
+      "code": "TS6133",
+      "count": 4
+    },
+    {
+      "file": "packages/cli/tests/unit/commands/sparql-query-timeout.test.ts",
+      "code": "TS1378",
+      "count": 1
+    },
+    {
+      "file": "packages/cli/tests/unit/commands/sparql-query-timeout.test.ts",
+      "code": "TS6133",
+      "count": 1
+    },
+    {
+      "file": "packages/cli/tests/unit/commands/sparql-query.test.ts",
+      "code": "TS1378",
+      "count": 1
+    },
+    {
+      "file": "packages/cli/tests/unit/commands/sparql-query.test.ts",
+      "code": "TS2345",
+      "count": 8
+    },
+    {
+      "file": "packages/cli/tests/unit/commands/sparql-query.test.ts",
+      "code": "TS6133",
+      "count": 2
+    },
+    {
+      "file": "packages/cli/tests/unit/commands/validate-schema.test.ts",
+      "code": "TS1378",
+      "count": 2
+    },
+    {
+      "file": "packages/cli/tests/unit/commands/validate-schema.test.ts",
+      "code": "TS2345",
+      "count": 19
+    },
+    {
+      "file": "packages/cli/tests/unit/commands/validate-schema.test.ts",
+      "code": "TS2741",
+      "count": 1
+    },
+    {
+      "file": "packages/cli/tests/unit/commands/validate-schema.test.ts",
+      "code": "TS6133",
+      "count": 1
+    },
+    {
+      "file": "packages/cli/tests/unit/commands/validate.test.ts",
+      "code": "TS1378",
+      "count": 1
+    },
+    {
+      "file": "packages/cli/tests/unit/commands/validate.test.ts",
+      "code": "TS2345",
+      "count": 1
+    },
+    {
+      "file": "packages/cli/tests/unit/executors/AssetCreationExecutor.test.ts",
+      "code": "TS1378",
+      "count": 1
+    },
+    {
+      "file": "packages/cli/tests/unit/executors/AssetCreationExecutor.test.ts",
+      "code": "TS2345",
+      "count": 3
+    },
+    {
+      "file": "packages/cli/tests/unit/executors/AssetCreationExecutor.test.ts",
+      "code": "TS6133",
+      "count": 2
+    },
+    {
+      "file": "packages/cli/tests/unit/executors/BatchExecutor.repair-folder.test.ts",
+      "code": "TS1378",
+      "count": 1
+    },
+    {
+      "file": "packages/cli/tests/unit/executors/BatchExecutor.repair-folder.test.ts",
+      "code": "TS2345",
+      "count": 45
+    },
+    {
+      "file": "packages/cli/tests/unit/executors/BatchExecutor.repair-folder.test.ts",
+      "code": "TS6133",
+      "count": 1
+    },
+    {
+      "file": "packages/cli/tests/unit/executors/BatchExecutor.test.ts",
+      "code": "TS1378",
+      "count": 1
+    },
+    {
+      "file": "packages/cli/tests/unit/executors/BatchExecutor.test.ts",
+      "code": "TS2345",
+      "count": 15
+    },
+    {
+      "file": "packages/cli/tests/unit/executors/BatchExecutor.test.ts",
+      "code": "TS6133",
+      "count": 1
+    },
+    {
+      "file": "packages/cli/tests/unit/executors/CommandExecutor.error.test.ts",
+      "code": "TS1378",
+      "count": 1
+    },
+    {
+      "file": "packages/cli/tests/unit/executors/CommandExecutor.error.test.ts",
+      "code": "TS2345",
+      "count": 27
+    },
+    {
+      "file": "packages/cli/tests/unit/executors/CommandExecutor.error.test.ts",
+      "code": "TS6133",
+      "count": 2
+    },
+    {
+      "file": "packages/cli/tests/unit/executors/CommandExecutor.test.ts",
+      "code": "TS1378",
+      "count": 1
+    },
+    {
+      "file": "packages/cli/tests/unit/executors/CommandExecutor.test.ts",
+      "code": "TS2345",
+      "count": 72
+    },
+    {
+      "file": "packages/cli/tests/unit/executors/CommandExecutor.test.ts",
+      "code": "TS6133",
+      "count": 2
+    },
+    {
+      "file": "packages/cli/tests/unit/executors/FolderRepairExecutor.test.ts",
+      "code": "TS1378",
+      "count": 2
+    },
+    {
+      "file": "packages/cli/tests/unit/executors/FolderRepairExecutor.test.ts",
+      "code": "TS2345",
+      "count": 61
+    },
+    {
+      "file": "packages/cli/tests/unit/executors/FolderRepairExecutor.test.ts",
+      "code": "TS6133",
+      "count": 1
+    },
+    {
+      "file": "packages/cli/tests/unit/formatters/CsvFormatter.test.ts",
+      "code": "TS6133",
+      "count": 3
+    },
+    {
+      "file": "packages/cli/tests/unit/index/UUIDIndex.test.ts",
+      "code": "TS2554",
+      "count": 1
+    },
+    {
+      "file": "packages/cli/tests/unit/services/ClassResolverService.test.ts",
+      "code": "TS1378",
+      "count": 1
+    },
+    {
+      "file": "packages/cli/tests/unit/services/CliProfileResolver.test.ts",
+      "code": "TS6133",
+      "count": 1
+    },
+    {
+      "file": "packages/cli/tests/unit/services/instantiate-prototype-subtree.test.ts",
+      "code": "TS6133",
+      "count": 1
+    },
+    {
+      "file": "packages/cli/tests/unit/services/registerOrderSpec.test.ts",
+      "code": "TS1378",
+      "count": 2
+    },
+    {
+      "file": "packages/cli/tests/unit/services/registerOrderSpec.test.ts",
+      "code": "TS6133",
+      "count": 1
+    },
+    {
+      "file": "packages/cli/tests/unit/services/RestPushService.test.ts",
+      "code": "TS18046",
+      "count": 8
+    },
+    {
+      "file": "packages/cli/tests/unit/services/RestPushService.test.ts",
+      "code": "TS2322",
+      "count": 7
+    },
+    {
+      "file": "packages/cli/tests/unit/services/RestPushService.test.ts",
+      "code": "TS2345",
+      "count": 8
+    },
+    {
+      "file": "packages/cli/tests/unit/services/SpawnService.test.ts",
+      "code": "TS6133",
+      "count": 2
+    },
+    {
+      "file": "packages/cli/tests/unit/services/WikilinkValidator.test.ts",
+      "code": "TS1378",
+      "count": 1
+    },
+    {
+      "file": "packages/cli/tests/unit/utils/ErrorHandler.test.ts",
+      "code": "TS2345",
+      "count": 1
+    },
+    {
+      "file": "packages/cli/tests/unit/utils/ErrorHandler.test.ts",
+      "code": "TS2554",
+      "count": 2
+    },
+    {
+      "file": "packages/cli/tests/unit/utils/ErrorHandler.test.ts",
+      "code": "TS2694",
+      "count": 3
+    },
+    {
+      "file": "packages/cli/tests/unit/utils/ProgressIndicator.test.ts",
+      "code": "TS1378",
+      "count": 1
+    },
+    {
+      "file": "packages/cli/tests/unit/utils/ProgressIndicator.test.ts",
+      "code": "TS2322",
+      "count": 2
+    },
+    {
+      "file": "packages/cli/tests/unit/utils/ProgressIndicator.test.ts",
+      "code": "TS6133",
+      "count": 3
+    },
+    {
+      "file": "packages/cli/tests/unit/utils/QueryAnalyzer.test.ts",
+      "code": "TS1378",
+      "count": 1
+    },
+    {
+      "file": "packages/cli/tests/unit/utils/QueryAnalyzer.test.ts",
+      "code": "TS6133",
+      "count": 1
+    },
+    {
+      "file": "packages/cli/tests/unit/utils/SPARQLErrorEnhancer.test.ts",
+      "code": "TS1378",
+      "count": 1
+    },
+    {
+      "file": "packages/cli/tests/unit/utils/SPARQLErrorEnhancer.test.ts",
+      "code": "TS6133",
+      "count": 1
+    },
+    {
+      "file": "packages/cli/tests/unit/utils/TransactionManager.test.ts",
+      "code": "TS1378",
+      "count": 1
+    },
+    {
+      "file": "packages/cli/tests/unit/utils/TransactionManager.test.ts",
+      "code": "TS2345",
+      "count": 33
+    },
+    {
+      "file": "packages/cli/tests/unit/utils/TransactionManager.test.ts",
+      "code": "TS2554",
+      "count": 1
+    },
+    {
+      "file": "packages/core/tests/integration/sparql/critical-paths.test.ts",
+      "code": "TS6133",
+      "count": 1
+    },
+    {
+      "file": "packages/core/tests/integration/sparql/instance-class-emission-flip.test.ts",
+      "code": "TS6133",
+      "count": 2
+    },
+    {
+      "file": "packages/core/tests/integration/sparql/sparql-1.2-directional.test.ts",
+      "code": "TS6133",
+      "count": 1
+    },
+    {
+      "file": "packages/core/tests/integration/sync/syncEngine.retry-after.integration.test.ts",
+      "code": "TS6133",
+      "count": 1
+    },
+    {
+      "file": "packages/core/tests/services/PropertySchemaResolver.test.ts",
+      "code": "TS6133",
+      "count": 1
+    },
+    {
+      "file": "packages/core/tests/services/RenameToUidService.test.ts",
+      "code": "TS6133",
+      "count": 27
+    },
+    {
+      "file": "packages/core/tests/services/ShaclLiteValidator.test.ts",
+      "code": "TS6133",
+      "count": 2
+    },
+    {
+      "file": "packages/core/tests/sparql/compliance/aggregates.test.ts",
+      "code": "TS6133",
+      "count": 1
+    },
+    {
+      "file": "packages/core/tests/sparql/compliance/built-in-functions.test.ts",
+      "code": "TS6133",
+      "count": 2
+    },
+    {
+      "file": "packages/core/tests/sparql/compliance/query-forms.test.ts",
+      "code": "TS6133",
+      "count": 1
+    },
+    {
+      "file": "packages/core/tests/sparql/compliance/solution-modifiers.test.ts",
+      "code": "TS6133",
+      "count": 1
+    },
+    {
+      "file": "packages/core/tests/unit/domain/defaults/DefaultWorkflows.branch.test.ts",
+      "code": "TS6196",
+      "count": 1
+    },
+    {
+      "file": "packages/core/tests/unit/domain/models/GraphData.test.ts",
+      "code": "TS6133",
+      "count": 2
+    },
+    {
+      "file": "packages/core/tests/unit/infrastructure/rdf/RDFSInferenceEngine.test.ts",
+      "code": "TS6133",
+      "count": 1
+    },
+    {
+      "file": "packages/core/tests/unit/infrastructure/sparql/aggregates/CustomAggregateIntegration.test.ts",
+      "code": "TS6133",
+      "count": 1
+    },
+    {
+      "file": "packages/core/tests/unit/infrastructure/sparql/aggregates/CustomAggregateIntegration.test.ts",
+      "code": "TS6196",
+      "count": 1
+    },
+    {
+      "file": "packages/core/tests/unit/infrastructure/sparql/algebra/AggregateTranslator.test.ts",
+      "code": "TS6133",
+      "count": 2
+    },
+    {
+      "file": "packages/core/tests/unit/infrastructure/sparql/algebra/ExpressionTranslator.test.ts",
+      "code": "TS6133",
+      "count": 1
+    },
+    {
+      "file": "packages/core/tests/unit/infrastructure/sparql/algebra/ExpressionTranslator.test.ts",
+      "code": "TS6196",
+      "count": 1
+    },
+    {
+      "file": "packages/core/tests/unit/infrastructure/sparql/algebra/PatternTranslator.test.ts",
+      "code": "TS6133",
+      "count": 3
+    },
+    {
+      "file": "packages/core/tests/unit/infrastructure/sparql/AlgebraTranslator.test.ts",
+      "code": "TS6133",
+      "count": 2
+    },
+    {
+      "file": "packages/core/tests/unit/infrastructure/sparql/DescribeOptionsTransformer.test.ts",
+      "code": "TS6133",
+      "count": 1
+    },
+    {
+      "file": "packages/core/tests/unit/infrastructure/sparql/executors/BGPExecutor.branch.test.ts",
+      "code": "TS6133",
+      "count": 1
+    },
+    {
+      "file": "packages/core/tests/unit/infrastructure/sparql/executors/QueryExecutor.branch.test.ts",
+      "code": "TS6133",
+      "count": 2
+    },
+    {
+      "file": "packages/core/tests/unit/infrastructure/sparql/executors/QueryExecutor.test.ts",
+      "code": "TS6133",
+      "count": 1
+    },
+    {
+      "file": "packages/core/tests/unit/infrastructure/sparql/executors/ServiceExecutor.test.ts",
+      "code": "TS6133",
+      "count": 2
+    },
+    {
+      "file": "packages/core/tests/unit/services/CommandResolver.universalDefaultTemplate.test.ts",
+      "code": "TS6133",
+      "count": 1
+    },
+    {
+      "file": "packages/core/tests/unit/services/EnumValueResolver.test.ts",
+      "code": "TS6133",
+      "count": 1
+    },
+    {
+      "file": "packages/core/tests/unit/services/FolderRepairService.test.ts",
+      "code": "TS6196",
+      "count": 1
+    },
+    {
+      "file": "packages/core/tests/unit/services/GenericAssetCreationService.test.ts",
+      "code": "TS6133",
+      "count": 1
+    },
+    {
+      "file": "packages/core/tests/unit/services/GraphQueryService.test.ts",
+      "code": "TS6133",
+      "count": 1
+    },
+    {
+      "file": "packages/core/tests/unit/services/InstantiationRuleResolver.test.ts",
+      "code": "TS6133",
+      "count": 1
+    },
+    {
+      "file": "packages/core/tests/unit/services/NoteToRDFConverter.rfc-31c1a0be-grounding-ref.test.ts",
+      "code": "TS6133",
+      "count": 1
+    },
+    {
+      "file": "packages/core/tests/unit/services/PrototypeChainMaterializer.test.ts",
+      "code": "TS6133",
+      "count": 5
+    },
+    {
+      "file": "packages/core/tests/unit/services/sync/ParityValidator.test.ts",
+      "code": "TS6133",
+      "count": 1
+    },
+    {
+      "file": "packages/core/tests/unit/sparql/subquery-acceptance.test.ts",
+      "code": "TS6133",
+      "count": 1
+    },
+    {
+      "file": "packages/core/tests/utilities/FrontmatterService.test.ts",
+      "code": "TS6133",
+      "count": 2
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/__mocks__/obsidian.ts",
+      "code": "TS2339",
+      "count": 1
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/__mocks__/obsidian.ts",
+      "code": "TS2345",
+      "count": 6
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/__mocks__/obsidian.ts",
+      "code": "TS2367",
+      "count": 2
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/__mocks__/obsidian.ts",
+      "code": "TS2687",
+      "count": 2
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/__mocks__/obsidian.ts",
+      "code": "TS2722",
+      "count": 1
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/__mocks__/obsidian.ts",
+      "code": "TS6133",
+      "count": 48
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/component/AreaHierarchyTree.spec.tsx",
+      "code": "TS2345",
+      "count": 2
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/component/AreaHierarchyTree.spec.tsx",
+      "code": "TS2686",
+      "count": 16
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/component/AssetRelationsTable.spec.tsx",
+      "code": "TS2686",
+      "count": 41
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/component/AssetRelationsTable.spec.tsx",
+      "code": "TS6133",
+      "count": 1
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/component/DailyTasksTable.spec.tsx",
+      "code": "TS2739",
+      "count": 18
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/component/DailyTasksTable.visual.spec.tsx",
+      "code": "TS2739",
+      "count": 1
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/component/ErrorBoundary.test.tsx",
+      "code": "TS2307",
+      "count": 1
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/component/ErrorBoundary.test.tsx",
+      "code": "TS6133",
+      "count": 3
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/component/ErrorBoundary.testHelpers.tsx",
+      "code": "TS2307",
+      "count": 1
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/component/exo-layout-docs-renders.spec.tsx",
+      "code": "TS6133",
+      "count": 1
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/component/properties/DateTimePropertyField.spec.tsx",
+      "code": "TS2686",
+      "count": 21
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/component/properties/TextPropertyField.spec.tsx",
+      "code": "TS2686",
+      "count": 11
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/component/property-editor/fields/BooleanField.spec.tsx",
+      "code": "TS2686",
+      "count": 16
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/component/property-editor/fields/NumberField.spec.tsx",
+      "code": "TS2686",
+      "count": 18
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/component/property-editor/fields/SelectField.spec.tsx",
+      "code": "TS2686",
+      "count": 17
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/component/property-editor/fields/TextField.spec.tsx",
+      "code": "TS2686",
+      "count": 16
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/component/property-editor/fields/TimestampField.spec.tsx",
+      "code": "TS2686",
+      "count": 13
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/component/property-editor/fields/WikiLinkField.spec.tsx",
+      "code": "TS2686",
+      "count": 21
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/component/RenderingPerformance.spec.tsx",
+      "code": "TS6133",
+      "count": 3
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/component/ResponsiveLayout.spec.tsx",
+      "code": "TS2345",
+      "count": 4
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/component/ResponsiveLayout.spec.tsx",
+      "code": "TS2686",
+      "count": 2
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/component/ResponsiveLayout.spec.tsx",
+      "code": "TS2739",
+      "count": 1
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/e2e/eka/eka-obsidian-leg.spec.ts",
+      "code": "TS6133",
+      "count": 1
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/e2e/specs/area-tree-collapsible.spec.ts",
+      "code": "TS18047",
+      "count": 8
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/e2e/specs/brat-installation-compatibility.spec.ts",
+      "code": "TS6133",
+      "count": 1
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/e2e/specs/exo-layout-smoke.spec.ts",
+      "code": "TS18047",
+      "count": 3
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/e2e/specs/exo-layout-smoke.spec.ts",
+      "code": "TS2353",
+      "count": 1
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/e2e/specs/file-explorer-icons.spec.ts",
+      "code": "TS2353",
+      "count": 1
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/e2e/specs/layout-overflow-styling.spec.ts",
+      "code": "TS2339",
+      "count": 3
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/e2e/specs/settings-live-mirror.spec.ts",
+      "code": "TS2538",
+      "count": 1
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/e2e/specs/table-virtualization-large-datasets.spec.ts",
+      "code": "TS2339",
+      "count": 2
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/e2e/specs/table-virtualization-large-datasets.spec.ts",
+      "code": "TS2352",
+      "count": 1
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/e2e/specs/wikilink-label-parity.spec.ts",
+      "code": "TS2353",
+      "count": 3
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/e2e/utils/obsidian-launcher.ts",
+      "code": "TS6133",
+      "count": 4
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/infrastructure/caching/BacklinksCacheManager.test.ts",
+      "code": "TS2307",
+      "count": 1
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/infrastructure/services/FrontmatterService.test.ts",
+      "code": "TS2307",
+      "count": 1
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/infrastructure/utilities/DateFormatter.test.ts",
+      "code": "TS2307",
+      "count": 1
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/infrastructure/utilities/EffortSortingHelpers.test.ts",
+      "code": "TS2307",
+      "count": 1
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/infrastructure/utilities/MetadataExtractor.test.ts",
+      "code": "TS2307",
+      "count": 1
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/infrastructure/utilities/MetadataHelpers.test.ts",
+      "code": "TS2307",
+      "count": 1
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/infrastructure/utilities/WikiLinkHelpers.test.ts",
+      "code": "TS2307",
+      "count": 1
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/integration/display-name/wikilink-resolution.test.ts",
+      "code": "TS6133",
+      "count": 1
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/integration/layout-parsing.test.ts",
+      "code": "TS6133",
+      "count": 2
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/ui/ActionButtonsLayout.ui.test.ts",
+      "code": "TS2345",
+      "count": 2
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/ui/ActionButtonsLayout.ui.test.ts",
+      "code": "TS6133",
+      "count": 3
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/ui/UniversalLayoutRenderer.ui.test.ts",
+      "code": "TS18049",
+      "count": 1
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/ui/UniversalLayoutRenderer.ui.test.ts",
+      "code": "TS2304",
+      "count": 51
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/ui/UniversalLayoutRenderer.ui.test.ts",
+      "code": "TS2345",
+      "count": 4
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/ui/UniversalLayoutRenderer.ui.test.ts",
+      "code": "TS2352",
+      "count": 1
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/ui/UniversalLayoutRenderer.ui.test.ts",
+      "code": "TS2554",
+      "count": 70
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/ui/UniversalLayoutRenderer.ui.test.ts",
+      "code": "TS6133",
+      "count": 2
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/adapters/logging/activityLog.integration.test.ts",
+      "code": "TS2345",
+      "count": 2
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/adapters/logging/activityLog.integration.test.ts",
+      "code": "TS2683",
+      "count": 4
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/api/ExocortexAPI.test.ts",
+      "code": "TS2345",
+      "count": 3
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/api/ExocortexAPI.test.ts",
+      "code": "TS2554",
+      "count": 1
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/api/ExocortexAPI.test.ts",
+      "code": "TS2739",
+      "count": 1
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/api/ExocortexAPI.test.ts",
+      "code": "TS6133",
+      "count": 2
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/api/SPARQLApi.test.ts",
+      "code": "TS2345",
+      "count": 1
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/application/layout/LayoutQueryBuilder.test.ts",
+      "code": "TS6133",
+      "count": 1
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/application/layout/LayoutService.test.ts",
+      "code": "TS2322",
+      "count": 1
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/application/layout/LayoutService.test.ts",
+      "code": "TS2345",
+      "count": 34
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/application/layout/LayoutService.test.ts",
+      "code": "TS2739",
+      "count": 2
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/application/layout/LayoutService.test.ts",
+      "code": "TS6196",
+      "count": 1
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/application/processors/LayoutActionExecution.integration.test.ts",
+      "code": "TS2554",
+      "count": 1
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/application/processors/LayoutActionPreconditionGating.integration.test.ts",
+      "code": "TS2554",
+      "count": 1
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/application/processors/LayoutCodeBlockProcessor.homoiconicDisplayName.test.ts",
+      "code": "TS2554",
+      "count": 1
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/application/processors/LayoutCodeBlockProcessor.test.ts",
+      "code": "TS2345",
+      "count": 1
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/AreaHierarchyBuilder.test.ts",
+      "code": "TS2339",
+      "count": 32
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/AreaHierarchyBuilder.test.ts",
+      "code": "TS6133",
+      "count": 1
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/builders/buttonGroups/ButtonGroupsBuilder.build.test.ts",
+      "code": "TS2322",
+      "count": 7
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/builders/buttonGroups/ButtonGroupsBuilder.build.test.ts",
+      "code": "TS2353",
+      "count": 8
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/builders/buttonGroups/ButtonGroupsBuilder.build.test.ts",
+      "code": "TS2739",
+      "count": 6
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/builders/buttonGroups/ButtonGroupsBuilder.dynamicCommands.test.ts",
+      "code": "TS2307",
+      "count": 1
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/builders/buttonGroups/ButtonGroupsBuilder.dynamicCommands.test.ts",
+      "code": "TS6133",
+      "count": 3
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/builders/buttonGroups/ButtonGroupsBuilder.fixtures.ts",
+      "code": "TS1205",
+      "count": 1
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/builders/buttonGroups/ButtonGroupsBuilder.fixtures.ts",
+      "code": "TS2307",
+      "count": 1
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/builders/buttonGroups/ButtonGroupsBuilder.fixtures.ts",
+      "code": "TS2740",
+      "count": 2
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/builders/buttonGroups/ButtonGroupsBuilder.handlers.test.ts",
+      "code": "TS2322",
+      "count": 3
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/builders/buttonGroups/ButtonGroupsBuilder.handlers.test.ts",
+      "code": "TS2353",
+      "count": 5
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/builders/buttonGroups/ButtonGroupsBuilder.handlers.test.ts",
+      "code": "TS2739",
+      "count": 1
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/ClassCreationService.test.ts",
+      "code": "TS2352",
+      "count": 1
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/CommandHelpers.test.ts",
+      "code": "TS2345",
+      "count": 1
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/commands-index.test.ts",
+      "code": "TS7053",
+      "count": 4
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/commands/manager/CommandManager.fixtures.ts",
+      "code": "TS2554",
+      "count": 1
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/domain/concept-definition/ConceptDefinitionResolver.test.ts",
+      "code": "TS2554",
+      "count": 1
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/domain/concept-definition/ConceptDefinitionSpecService.test.ts",
+      "code": "TS2554",
+      "count": 1
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/domain/display-name/DisplayNamePrintedPropertyFallback.test.ts",
+      "code": "TS2554",
+      "count": 1
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/domain/display-name/DisplayNameResolver.composition.test.ts",
+      "code": "TS2554",
+      "count": 2
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/domain/display-name/DisplayNameResolver.multiClass.test.ts",
+      "code": "TS2554",
+      "count": 1
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/domain/display-name/DisplayNameResolver.tboxProjection.test.ts",
+      "code": "TS2554",
+      "count": 1
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/domain/display-name/DisplayNameResolver.test.ts",
+      "code": "TS6133",
+      "count": 1
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/domain/display-name/DisplayNameSeparatorAndFormat.test.ts",
+      "code": "TS2554",
+      "count": 1
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/domain/display-name/PrintNameRuleService.episodeOngoing.test.ts",
+      "code": "TS2554",
+      "count": 1
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/domain/display-name/PrintNameRuleService.matchPathKeyPath.test.ts",
+      "code": "TS2554",
+      "count": 1
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/domain/display-name/PrintNameRuleService.test.ts",
+      "code": "TS2554",
+      "count": 2
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/domain/layout/Layout.test.ts",
+      "code": "TS6133",
+      "count": 2
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/domain/layout/LayoutGroup.test.ts",
+      "code": "TS6133",
+      "count": 1
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/domain/layout/LayoutSort.test.ts",
+      "code": "TS6133",
+      "count": 2
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/EditPropertiesCommand.test.ts",
+      "code": "TS2352",
+      "count": 1
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/EditPropertiesCommand.test.ts",
+      "code": "TS6133",
+      "count": 1
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/error-handling.test.ts",
+      "code": "TS2353",
+      "count": 3
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/error-handling.test.ts",
+      "code": "TS6133",
+      "count": 1
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/error-handling/error-scenarios.test.ts",
+      "code": "TS6133",
+      "count": 1
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/error-handling/ObsidianVaultAdapter.error.test.ts",
+      "code": "TS6133",
+      "count": 2
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/ErrorBoundary.test.ts",
+      "code": "TS18046",
+      "count": 17
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/ErrorBoundary.test.ts",
+      "code": "TS2322",
+      "count": 2
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/ErrorBoundary.test.ts",
+      "code": "TS6133",
+      "count": 5
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/EventListenerManager.test.ts",
+      "code": "TS2345",
+      "count": 3
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/ExocortexPlugin.test.ts",
+      "code": "TS2345",
+      "count": 6
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/ExocortexPlugin.test.ts",
+      "code": "TS7006",
+      "count": 4
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/ExocortexSettingTab.informationArchitecture.test.ts",
+      "code": "TS6133",
+      "count": 1
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/FolderRepairService.test.ts",
+      "code": "TS2339",
+      "count": 13
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/GitHubRestClient.test.ts",
+      "code": "TS2503",
+      "count": 1
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/helpers/TestFixtureBuilder.test.ts",
+      "code": "TS6133",
+      "count": 2
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/helpers/TestFixtureBuilder.ts",
+      "code": "TS2352",
+      "count": 1
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/helpers/testHelpers.ts",
+      "code": "TS2352",
+      "count": 1
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/helpers/testHelpers.ts",
+      "code": "TS6133",
+      "count": 1
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/IncrementalUpdateHandler.test.ts",
+      "code": "TS2345",
+      "count": 13
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/infrastructure/adapters/AssetSpaceManager.pullAssetSpace.test.ts",
+      "code": "TS2345",
+      "count": 3
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/infrastructure/adapters/BootstrapAssetSpaceCommands.test.ts",
+      "code": "TS2352",
+      "count": 2
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/infrastructure/adapters/RestAssetSpaceMount.test.ts",
+      "code": "TS2345",
+      "count": 1
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/infrastructure/adapters/VaultSettingsStore.test.ts",
+      "code": "TS6133",
+      "count": 1
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/infrastructure/di/ObsidianNotificationService.test.ts",
+      "code": "TS2345",
+      "count": 5
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/infrastructure/di/ObsidianNotificationService.test.ts",
+      "code": "TS2352",
+      "count": 1
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/infrastructure/di/ObsidianNotificationService.test.ts",
+      "code": "TS6133",
+      "count": 1
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/infrastructure/di/PluginContainer.test.ts",
+      "code": "TS18046",
+      "count": 22
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/infrastructure/layout/LayoutParser.test.ts",
+      "code": "TS6133",
+      "count": 2
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/infrastructure/precondition/createHasEmptyPropertiesHostFunction.test.ts",
+      "code": "TS2554",
+      "count": 7
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/infrastructure/precondition/createIsInWrongFolderHostFunction.test.ts",
+      "code": "TS2554",
+      "count": 2
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/infrastructure/repositories/ExoLayoutRepository.test.ts",
+      "code": "TS2559",
+      "count": 8
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/infrastructure/repositories/ObsidianExoLayoutAdapter.test.ts",
+      "code": "TS2554",
+      "count": 2
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/infrastructure/VaultRDFIndexer.excluded-folders.test.ts",
+      "code": "TS6196",
+      "count": 1
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/infrastructure/VaultRDFIndexer.test.ts",
+      "code": "TS2322",
+      "count": 8
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/infrastructure/VaultRDFIndexer.test.ts",
+      "code": "TS2739",
+      "count": 4
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/integration/ApplyEndToEnd.integration.test.ts",
+      "code": "TS6133",
+      "count": 1
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/integration/AssetSpaceManager.integration.test.ts",
+      "code": "TS2345",
+      "count": 1
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/integration/BootstrapAssetSpace.integration.test.ts",
+      "code": "TS2353",
+      "count": 1
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/integration/BootstrapAssetSpaceMobile.integration.test.ts",
+      "code": "TS2345",
+      "count": 1
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/integration/sparql-critical-paths.test.ts",
+      "code": "TS6133",
+      "count": 1
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/integration/wikilink-resolution.test.ts",
+      "code": "TS6133",
+      "count": 1
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/LayoutErrorFallback.test.tsx",
+      "code": "TS18046",
+      "count": 6
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/LayoutErrorFallback.test.tsx",
+      "code": "TS2339",
+      "count": 33
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/LoggerFactory.test.ts",
+      "code": "TS2576",
+      "count": 1
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/ModalConfirmGate.test.ts",
+      "code": "TS2339",
+      "count": 1
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/ModalConfirmGate.test.ts",
+      "code": "TS2345",
+      "count": 2
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/ModalConfirmGate.test.ts",
+      "code": "TS2683",
+      "count": 2
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/ObsidianFileOpener.test.ts",
+      "code": "TS2554",
+      "count": 1
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/ObsidianVaultAdapter.test.ts",
+      "code": "TS6133",
+      "count": 3
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/OntologySchemaService.test.ts",
+      "code": "TS6133",
+      "count": 1
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/presentation/asset-space/AssetSpaceStatusIconPatch.test.ts",
+      "code": "TS2345",
+      "count": 1
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/presentation/asset-space/AssetSpaceStatusIconPatch.test.ts",
+      "code": "TS6133",
+      "count": 1
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/presentation/body/BodyLinkPatch.test.ts",
+      "code": "TS2345",
+      "count": 55
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/presentation/builders/DynamicCommandButtonGroupBuilder.test.ts",
+      "code": "TS2304",
+      "count": 21
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/presentation/components/AreaHierarchyTree.test.tsx",
+      "code": "TS18046",
+      "count": 3
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/presentation/components/AreaHierarchyTree.test.tsx",
+      "code": "TS2339",
+      "count": 9
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/presentation/components/AreaHierarchyTree.test.tsx",
+      "code": "TS2345",
+      "count": 2
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/presentation/components/AssetRelationsTable.accent.test.tsx",
+      "code": "TS18046",
+      "count": 3
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/presentation/components/AssetRelationsTable.accent.test.tsx",
+      "code": "TS2339",
+      "count": 3
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/presentation/components/AssetRelationsTable.accent.test.tsx",
+      "code": "TS2344",
+      "count": 4
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/presentation/components/AssetRelationsTable.accent.test.tsx",
+      "code": "TS2571",
+      "count": 2
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/presentation/components/AssetRelationsTable.edit-affordance.test.tsx",
+      "code": "TS2344",
+      "count": 2
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/presentation/components/AssetRelationsTable.edit-affordance.test.tsx",
+      "code": "TS2345",
+      "count": 2
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/presentation/components/AssetRelationsTable.edit-affordance.test.tsx",
+      "code": "TS2571",
+      "count": 1
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/presentation/components/AssetRelationsTable.reified-marker.test.tsx",
+      "code": "TS2339",
+      "count": 10
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/presentation/components/AssetRelationsTable.reified-marker.test.tsx",
+      "code": "TS2344",
+      "count": 8
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/presentation/components/AssetRelationsTable.reified-marker.test.tsx",
+      "code": "TS2345",
+      "count": 1
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/presentation/components/AssetRelationsTable.reified-marker.test.tsx",
+      "code": "TS2571",
+      "count": 2
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/presentation/components/DynamicForm.test.tsx",
+      "code": "TS2345",
+      "count": 35
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/presentation/components/PropertyEditorForm.relations.test.tsx",
+      "code": "TS2345",
+      "count": 1
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/presentation/components/ReferencePicker.test.tsx",
+      "code": "TS2345",
+      "count": 15
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/presentation/components/RelationsSection.test.tsx",
+      "code": "TS2345",
+      "count": 12
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/presentation/fileexplorer/FileExplorerIconPatch.test.ts",
+      "code": "TS2322",
+      "count": 1
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/presentation/fileexplorer/FileExplorerIconPatch.test.ts",
+      "code": "TS2344",
+      "count": 1
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/presentation/fileexplorer/FileExplorerIconPatch.test.ts",
+      "code": "TS2345",
+      "count": 19
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/presentation/fileexplorer/FileExplorerLabelPatch.test.ts",
+      "code": "TS2339",
+      "count": 10
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/presentation/fileexplorer/FileExplorerLabelPatch.test.ts",
+      "code": "TS2344",
+      "count": 8
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/presentation/fileexplorer/FileExplorerLabelPatch.test.ts",
+      "code": "TS2345",
+      "count": 16
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/presentation/fileexplorer/FileExplorerLabelPatch.test.ts",
+      "code": "TS2749",
+      "count": 3
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/presentation/graph-view/GraphViewPatch.test.ts",
+      "code": "TS2739",
+      "count": 2
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/presentation/graph-view/GraphViewPatch.test.ts",
+      "code": "TS2741",
+      "count": 2
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/presentation/modals/ActivityLogModal.test.ts",
+      "code": "TS2345",
+      "count": 2
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/presentation/modals/ActivityLogModal.test.ts",
+      "code": "TS2683",
+      "count": 4
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/presentation/modals/AddAssetSpaceModal.a11y.test.ts",
+      "code": "TS2345",
+      "count": 2
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/presentation/modals/AddAssetSpaceModal.a11y.test.ts",
+      "code": "TS2352",
+      "count": 2
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/presentation/modals/AddAssetSpaceModal.a11y.test.ts",
+      "code": "TS2683",
+      "count": 5
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/presentation/modals/BootstrapModals.test.ts",
+      "code": "TS2345",
+      "count": 2
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/presentation/modals/BootstrapModals.test.ts",
+      "code": "TS2352",
+      "count": 5
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/presentation/modals/BootstrapModals.test.ts",
+      "code": "TS2683",
+      "count": 5
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/presentation/modals/BootstrapVaultModal.a11y.test.ts",
+      "code": "TS2345",
+      "count": 2
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/presentation/modals/BootstrapVaultModal.a11y.test.ts",
+      "code": "TS2352",
+      "count": 3
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/presentation/modals/BootstrapVaultModal.a11y.test.ts",
+      "code": "TS2683",
+      "count": 5
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/presentation/modals/FirstRunOnboardingModal.test.ts",
+      "code": "TS2322",
+      "count": 2
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/presentation/modals/FirstRunOnboardingModal.test.ts",
+      "code": "TS2345",
+      "count": 2
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/presentation/modals/FirstRunOnboardingModal.test.ts",
+      "code": "TS2352",
+      "count": 6
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/presentation/modals/FirstRunOnboardingModal.test.ts",
+      "code": "TS2683",
+      "count": 5
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/presentation/modals/LogFileModal.test.ts",
+      "code": "TS2345",
+      "count": 2
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/presentation/modals/LogFileModal.test.ts",
+      "code": "TS2683",
+      "count": 4
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/presentation/modals/OnboardingResultStepSync.test.ts",
+      "code": "TS18046",
+      "count": 1
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/presentation/modals/OnboardingResultStepSync.test.ts",
+      "code": "TS2339",
+      "count": 1
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/presentation/modals/OnboardingResultStepSync.test.ts",
+      "code": "TS2344",
+      "count": 2
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/presentation/modals/OnboardingResultStepSync.test.ts",
+      "code": "TS2345",
+      "count": 2
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/presentation/modals/OnboardingResultStepSync.test.ts",
+      "code": "TS2683",
+      "count": 5
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/presentation/modals/OnboardingResultStepSync.test.ts",
+      "code": "TS2740",
+      "count": 1
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/presentation/modals/SimpleConfirmModal.test.ts",
+      "code": "TS2339",
+      "count": 4
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/presentation/modals/SimpleConfirmModal.test.ts",
+      "code": "TS2345",
+      "count": 2
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/presentation/modals/SimpleConfirmModal.test.ts",
+      "code": "TS2683",
+      "count": 2
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/presentation/parked/ParkedLinkPlaceholder.test.ts",
+      "code": "TS2345",
+      "count": 16
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/presentation/properties/PropertiesDefinitionValuePatch.test.ts",
+      "code": "TS2339",
+      "count": 1
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/presentation/properties/PropertiesDefinitionValuePatch.test.ts",
+      "code": "TS2344",
+      "count": 1
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/presentation/properties/PropertiesDefinitionValuePatch.test.ts",
+      "code": "TS2345",
+      "count": 8
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/presentation/properties/PropertiesDefinitionValuePatch.test.ts",
+      "code": "TS2554",
+      "count": 1
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/presentation/properties/PropertiesLabelPatch.test.ts",
+      "code": "TS2339",
+      "count": 39
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/presentation/properties/PropertiesLabelPatch.test.ts",
+      "code": "TS2344",
+      "count": 34
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/presentation/properties/PropertiesLabelPatch.test.ts",
+      "code": "TS2345",
+      "count": 41
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/presentation/properties/PropertiesLinkPatch.test.ts",
+      "code": "TS2345",
+      "count": 16
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/presentation/properties/PropertiesUidCopyPatch.test.ts",
+      "code": "TS2345",
+      "count": 36
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/presentation/properties/PropertiesUidCopyPatch.test.ts",
+      "code": "TS2352",
+      "count": 4
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/presentation/reading-mode/ReadingModeEnforcer.test.ts",
+      "code": "TS2345",
+      "count": 7
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/presentation/reading-mode/ReadingModeEnforcer.test.ts",
+      "code": "TS6133",
+      "count": 1
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/presentation/renderers/calendar/CalendarEvent.test.tsx",
+      "code": "TS2345",
+      "count": 2
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/presentation/renderers/calendar/CalendarEvent.test.tsx",
+      "code": "TS6133",
+      "count": 1
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/presentation/renderers/calendar/CalendarLayoutRenderer.test.tsx",
+      "code": "TS2345",
+      "count": 8
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/presentation/renderers/calendar/CalendarLayoutRenderer.test.tsx",
+      "code": "TS6133",
+      "count": 1
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/presentation/renderers/cell-renderers/ActionsRenderer.test.tsx",
+      "code": "TS2345",
+      "count": 8
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/presentation/renderers/cell-renderers/ActionsRenderer.test.tsx",
+      "code": "TS2743",
+      "count": 2
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/presentation/renderers/cell-renderers/ActionsRenderer.test.tsx",
+      "code": "TS6196",
+      "count": 1
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/presentation/renderers/cell-renderers/BadgeRenderer.test.tsx",
+      "code": "TS2345",
+      "count": 1
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/presentation/renderers/cell-renderers/BooleanRenderer.test.tsx",
+      "code": "TS2345",
+      "count": 1
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/presentation/renderers/cell-renderers/DateTimeRenderer.test.tsx",
+      "code": "TS2352",
+      "count": 4
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/presentation/renderers/cell-renderers/LinkRenderer.test.tsx",
+      "code": "TS2345",
+      "count": 3
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/presentation/renderers/cell-renderers/LinkRenderer.test.tsx",
+      "code": "TS6133",
+      "count": 1
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/presentation/renderers/cell-renderers/NumberRenderer.test.tsx",
+      "code": "TS2345",
+      "count": 7
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/presentation/renderers/cell-renderers/ProgressRenderer.test.tsx",
+      "code": "TS2352",
+      "count": 1
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/presentation/renderers/cell-renderers/TagsRenderer.test.tsx",
+      "code": "TS2322",
+      "count": 14
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/presentation/renderers/cell-renderers/TagsRenderer.test.tsx",
+      "code": "TS2345",
+      "count": 1
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/presentation/renderers/ExoLayoutRenderer.dailyEfforts.test.ts",
+      "code": "TS2322",
+      "count": 1
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/presentation/renderers/ExoLayoutRenderer.dailyEfforts.test.ts",
+      "code": "TS2345",
+      "count": 1
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/presentation/renderers/ExoLayoutRenderer.dailyEfforts.test.ts",
+      "code": "TS6133",
+      "count": 1
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/presentation/renderers/ExoLayoutRenderer.dailyEffortsClosed.test.ts",
+      "code": "TS2322",
+      "count": 1
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/presentation/renderers/ExoLayoutRenderer.dailyEffortsClosed.test.ts",
+      "code": "TS2345",
+      "count": 1
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/presentation/renderers/ExoLayoutRenderer.test.ts",
+      "code": "TS2322",
+      "count": 1
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/presentation/renderers/ExoLayoutRenderer.test.ts",
+      "code": "TS2345",
+      "count": 1
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/presentation/renderers/ExoLayoutRenderer.test.ts",
+      "code": "TS6133",
+      "count": 2
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/presentation/renderers/TableLayoutRenderer.test.tsx",
+      "code": "TS2345",
+      "count": 10
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/presentation/renderers/TableLayoutRenderer.test.tsx",
+      "code": "TS2556",
+      "count": 1
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/presentation/renderers/UniversalLayoutRenderer.dailyEffortsSuppression.test.ts",
+      "code": "TS2345",
+      "count": 2
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/presentation/settings/patSetupHelper.test.ts",
+      "code": "TS2352",
+      "count": 1
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/presentation/settings/patSetupHelper.test.ts",
+      "code": "TS2683",
+      "count": 1
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/presentation/tab-titles/InlineTitlePatch.test.ts",
+      "code": "TS2345",
+      "count": 1
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/presentation/tab-titles/InlineTitlePatch.test.ts",
+      "code": "TS6133",
+      "count": 1
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/presentation/tab-titles/TabTitlePatch.test.ts",
+      "code": "TS6133",
+      "count": 1
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/ProfileApplyManager.apply.test.ts",
+      "code": "TS1501",
+      "count": 1
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/ProfileApplyManager.apply.test.ts",
+      "code": "TS2322",
+      "count": 1
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/ProfileApplyManager.apply.test.ts",
+      "code": "TS2339",
+      "count": 1
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/ProfileApplyManager.apply.test.ts",
+      "code": "TS2493",
+      "count": 1
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/ProfileApplyManager.restAtomicity.test.ts",
+      "code": "TS6133",
+      "count": 2
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/ProfileApplyManager.test.ts",
+      "code": "TS6133",
+      "count": 1
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/property-editor/EditPropertiesCommand.test.ts",
+      "code": "TS6133",
+      "count": 2
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/property-fields/BooleanPropertyField.test.ts",
+      "code": "TS2345",
+      "count": 7
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/property-fields/DatePropertyField.test.ts",
+      "code": "TS2345",
+      "count": 7
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/property-fields/DateTimePropertyField.test.ts",
+      "code": "TS2345",
+      "count": 7
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/property-fields/EnumPropertyField.test.ts",
+      "code": "TS2345",
+      "count": 8
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/property-fields/NumberPropertyField.test.ts",
+      "code": "TS2345",
+      "count": 7
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/property-fields/PropertyFieldFactory.test.ts",
+      "code": "TS2345",
+      "count": 11
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/property-fields/ReferencePropertyField.test.ts",
+      "code": "TS2345",
+      "count": 7
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/property-fields/ReferencePropertyField.test.ts",
+      "code": "TS6133",
+      "count": 1
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/property-fields/SizeSelectPropertyField.test.ts",
+      "code": "TS2345",
+      "count": 8
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/property-fields/StatusSelectPropertyField.test.ts",
+      "code": "TS2345",
+      "count": 8
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/property-fields/TextPropertyField.test.ts",
+      "code": "TS2345",
+      "count": 8
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/property-fields/TextPropertyField.test.ts",
+      "code": "TS2352",
+      "count": 3
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/property-fields/TimestampPropertyField.test.ts",
+      "code": "TS2345",
+      "count": 6
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/property-fields/WikilinkPropertyField.test.ts",
+      "code": "TS2345",
+      "count": 7
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/PropertyCleanupService.test.ts",
+      "code": "TS2345",
+      "count": 1
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/PropertyValidationService.test.ts",
+      "code": "TS2740",
+      "count": 17
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/ReactRenderer.test.tsx",
+      "code": "TS2339",
+      "count": 1
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/ReactRenderer.test.tsx",
+      "code": "TS2352",
+      "count": 4
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/ReactRenderer.test.tsx",
+      "code": "TS4114",
+      "count": 2
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/RelationsRenderer.test.ts",
+      "code": "TS2531",
+      "count": 6
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/RelationsRenderer.test.ts",
+      "code": "TS7006",
+      "count": 17
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/RenameToUidService.test.ts",
+      "code": "TS2339",
+      "count": 1
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/RenameToUidService.test.ts",
+      "code": "TS6133",
+      "count": 2
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/renderers/dailyTasks/DailyTasksRenderer.callbacks.test.ts",
+      "code": "TS2571",
+      "count": 4
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/renderers/dailyTasks/DailyTasksRenderer.core.test.ts",
+      "code": "TS2571",
+      "count": 8
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/renderers/dailyTasks/DailyTasksRenderer.edgeCases.test.ts",
+      "code": "TS2571",
+      "count": 5
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/renderers/dailyTasks/DailyTasksRenderer.fixtures.ts",
+      "code": "TS2307",
+      "count": 1
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/renderers/dailyTasks/DailyTasksRenderer.fixtures.ts",
+      "code": "TS2345",
+      "count": 1
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/renderers/dailyTasks/DailyTasksRenderer.helpers.test.ts",
+      "code": "TS18046",
+      "count": 3
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/renderers/dailyTasks/DailyTasksRenderer.helpers.test.ts",
+      "code": "TS2571",
+      "count": 11
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/renderers/dailyTasks/DailyTasksRenderer.homoiconicDisplayName.test.ts",
+      "code": "TS2307",
+      "count": 1
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/renderers/dailyTasks/DailyTasksRenderer.homoiconicDisplayName.test.ts",
+      "code": "TS2345",
+      "count": 2
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/renderers/dailyTasks/DailyTasksRenderer.homoiconicDisplayName.test.ts",
+      "code": "TS2554",
+      "count": 1
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/renderers/dailyTasks/DailyTasksRenderer.properties.test.ts",
+      "code": "TS2571",
+      "count": 7
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/renderers/dailyTasks/DailyTasksRenderer.timeEstimate.test.ts",
+      "code": "TS2571",
+      "count": 3
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/renderers/helpers/DailyNavigationRenderer.test.ts",
+      "code": "TS2345",
+      "count": 3
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/renderers/helpers/DailyNavigationRenderer.test.ts",
+      "code": "TS2352",
+      "count": 2
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/renderers/helpers/SectionStateManager.test.ts",
+      "code": "TS2345",
+      "count": 9
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/renderers/helpers/SectionStateManager.test.ts",
+      "code": "TS2352",
+      "count": 4
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/renderers/helpers/SectionStateManager.test.ts",
+      "code": "TS2683",
+      "count": 1
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/renderers/layout/RelationsRenderer.homoiconicDisplayName.test.ts",
+      "code": "TS2554",
+      "count": 3
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/services/AliasSyncService.test.ts",
+      "code": "TS6133",
+      "count": 9
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/services/ClassDiscoveryService.test.ts",
+      "code": "TS2345",
+      "count": 9
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/services/ClassDiscoveryService.test.ts",
+      "code": "TS2769",
+      "count": 2
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/services/OntologySchemaService.test.ts",
+      "code": "TS1501",
+      "count": 1
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/services/OntologySchemaService.test.ts",
+      "code": "TS2345",
+      "count": 1
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/services/OntologySchemaService.test.ts",
+      "code": "TS2740",
+      "count": 44
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/services/PropertyUpdateService.test.ts",
+      "code": "TS6133",
+      "count": 1
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/services/SPARQLQueryService.integration.test.ts",
+      "code": "TS2554",
+      "count": 1
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/stores/tableSortStore.test.ts",
+      "code": "TS6133",
+      "count": 1
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/stores/uiStore.test.ts",
+      "code": "TS6133",
+      "count": 1
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/sync/ExoSyncPostSyncReindex.test.ts",
+      "code": "TS2554",
+      "count": 1
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/sync/QuarantineResolverModal.test.ts",
+      "code": "TS2339",
+      "count": 7
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/sync/QuarantineResolverModal.test.ts",
+      "code": "TS2344",
+      "count": 13
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/sync/QuarantineResolverModal.test.ts",
+      "code": "TS2488",
+      "count": 11
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/sync/QuarantineResolverModal.test.ts",
+      "code": "TS2571",
+      "count": 3
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/TarExtractor.test.ts",
+      "code": "TS2345",
+      "count": 2
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/ToggleArchivedAssetsCommand.test.ts",
+      "code": "TS2322",
+      "count": 1
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/ToggleArchivedAssetsCommand.test.ts",
+      "code": "TS6133",
+      "count": 1
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/ToggleLayoutVisibilityCommand.test.ts",
+      "code": "TS6133",
+      "count": 1
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/UniversalLayoutRenderer.test.ts",
+      "code": "TS2345",
+      "count": 1
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/UniversalLayoutRenderer.test.ts",
+      "code": "TS2352",
+      "count": 1
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/wiring/BootstrapPatRefresh.integration.test.ts",
+      "code": "TS2322",
+      "count": 1
+    },
+    {
+      "file": "packages/obsidian-plugin/tests/unit/wiring/BootstrapPatRefresh.integration.test.ts",
+      "code": "TS2345",
+      "count": 1
+    },
+    {
+      "file": "packages/test-utils/tests/reporters/flaky-reporter.test.ts",
+      "code": "TS2345",
+      "count": 9
+    }
+  ]
+}

--- a/tsconfig.tests.json
+++ b/tsconfig.tests.json
@@ -1,0 +1,37 @@
+{
+  // Type-check configuration for TEST files (issue #4084).
+  //
+  // ⛔ Why this file exists: NO tsconfig in the repo type-checks `packages/**/tests/**`.
+  //    Measured on origin/main 2026-08-19:
+  //      packages/core/tsconfig.json    include src/**/*   exclude [..., "tests"]
+  //      packages/cli/tsconfig.json     include src/**/*   (tests simply not included)
+  //      packages/obsidian-plugin/      no package tsconfig at all
+  //      tsconfig.json (root)           exclude packages/**/tests/**/*, packages/cli/**/*
+  //    => `npm run check:types` covers packages/<non-cli>/src and nothing else.
+  //    All 975 test files are type-checked ONLY by ts-jest at run time, where an error
+  //    surfaces as "Test suite failed to run / Tests: 0" — a shape easily read as green.
+  //
+  // `src` is included NOT to gate it (that is `check:types` + check-cli-types.mjs) but
+  // because the program cannot resolve test imports without it. scripts/check-test-types.mjs
+  // filters diagnostics down to `/tests/` paths.
+  //
+  // ⛔ rootDir MUST be the repo root: packages import each other's SOURCES (obsidian-plugin
+  //    → packages/core/src), so a package-scoped rootDir yields TS6059 for every such file
+  //    and tsc stops before checking anything. Measured: 277 TS6059 with rootDir=packages/obsidian-plugin.
+  //
+  // ⛔ declaration/declarationMap/composite are forced off: the inherited config sets
+  //    declarationMap, and `declarationMap` without `declaration`/`composite` is TS5069 —
+  //    a CONFIG error that aborts the run while still printing a positioned diagnostic
+  //    (it points at this file). See the scope guard in check-test-types.mjs.
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": ".",
+    "declaration": false,
+    "declarationMap": false,
+    "composite": false,
+    "skipLibCheck": true
+  },
+  "include": ["packages/*/src/**/*", "packages/*/tests/**/*"],
+  "exclude": ["**/node_modules", "**/dist"]
+}

--- a/tsconfig.tests.json
+++ b/tsconfig.tests.json
@@ -23,10 +23,48 @@
   //    declarationMap, and `declarationMap` without `declaration`/`composite` is TS5069 —
   //    a CONFIG error that aborts the run while still printing a positioned diagnostic
   //    (it points at this file). See the scope guard in check-test-types.mjs.
+  //
+  // ⛔ target MUST be set explicitly, and it is NOT cosmetic. The root config says
+  //    `target: "ES6"`; every runtime that actually compiles these files says ES2020:
+  //      packages/obsidian-plugin/jest.config.js  ts-jest inline → target "es2020"
+  //      packages/cli/tsconfig.json               target "ES2020" (ts-jest's inline
+  //                                               {module,moduleResolution,esModuleInterop}
+  //                                               does not override it)
+  //      packages/core/tsconfig.json              target "ES2020"
+  //    Inheriting ES6 made this gate check a program NO runtime compiles, and it showed:
+  //    70 phantom `TS1378` pairs ("top-level await requires target es2017+"), all in cli,
+  //    that do not exist at run time. Measured 2026-08-19 — ES6: 505 pairs / 2502
+  //    diagnostics; ES2020: 433 / 2396, TS1378 = 0.
+  //    ⛤ The sibling check-cli-types.mjs does NOT have this problem because it runs the
+  //    PACKAGE's own tsconfig, which sets target itself. The hazard is created by
+  //    AGGREGATING several packages under one config: aggregation silently drops each
+  //    package's target and falls back to the root's. An aggregate tsconfig must state it.
+  // ⛤ `lib` is deliberately left INHERITED (`DOM,ES5,ES6,ES7,ESNext`), and this is a
+  //    MEASUREMENT, not an argument. The tempting argument — "a wider lib can only hide
+  //    an error, never invent one" — is NOT categorically true: a wider lib also adds
+  //    GLOBAL NAMES, which can collide with declarations in the checked code (TS2300 /
+  //    TS2451; the canonical case is lib.esnext's global `Iterator`). So it was measured
+  //    instead (2026-08-19, target ES2020 throughout, set-diff of (file,code) pairs):
+  //      inherited superset            433 pairs   —
+  //      lib: ["ES2020","DOM"]         433 pairs   0 added, 0 removed  ← controlled comparison
+  //      lib: ["ES2020"] (no DOM)      554 pairs   +220, −99
+  //    The superset is byte-identical in effect to the plugin's declared ["es2020","dom"],
+  //    so the redundant ES5/ES6/ES7/ESNext entries are a measured no-op here. Setting lib
+  //    explicitly buys nothing and adds a fourth knob to drift out of sync with three
+  //    jest configs.
+  //    ⚠ KNOWN BLIND SPOT, currently zero-exposure: DOM leaks into the node-side packages
+  //    (core/cli/services declare no DOM). Measured as zero TODAY — stripping DOM adds 220
+  //    pairs, ALL 220 in obsidian-plugin, none in core/cli/services/test-utils. A future
+  //    core test using `document`/`structuredClone` would be green here and red under
+  //    ts-jest. This is a point measurement of today's corpus, not an invariant.
+  //    ⛔ Do not read the third row as "a narrower lib invents errors": it also REMOVES 99
+  //    pairs, which is cascade suppression (once `document` fails to resolve, downstream
+  //    checks stop firing). Only the second row is a controlled comparison.
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "noEmit": true,
     "rootDir": ".",
+    "target": "ES2020",
     "declaration": false,
     "declarationMap": false,
     "composite": false,


### PR DESCRIPTION
Closes #4084. Sibling half of #4074 — same hole, same shape of fix, other half of the surface.

## The hole

No tsconfig in the repo type-checks `packages/**/tests/**`. Measured on `origin/main` 2026-08-19:

| tsconfig | `include` | `exclude` |
|---|---|---|
| root `tsconfig.json` | `packages/**/*.ts(x)` | `packages/**/tests/**/*`, **`packages/cli/**/*`** |
| `packages/core/tsconfig.json` | `src/**/*` | `node_modules`, `dist`, **`tests`** |
| `packages/cli/tsconfig.json` | `src/**/*` | *(tests simply not included)* |
| `packages/obsidian-plugin/` | — | *(no package tsconfig at all)* |

⇒ the required `typecheck` job covers `packages/<non-cli>/src` **and nothing else**. All 975 test files are type-checked only by ts-jest **at run time**, where a type error surfaces as `Test suite failed to run / Tests: 0` — a shape that reads as green.

## What the debt actually contains

**505 `(file, code)` pairs / 2502 diagnostics** — obsidian-plugin 328, cli 139, core 37, test-utils 1.

One class inside it is worth naming, because it is **invisible by construction**: 11 unresolved-module errors are tests importing a module that **moved packages** (`ILogger`, `DateFormatter`, `FrontmatterService`, …). Those tests **pass green today** — the import is *type-only*, ts-jest **erases** type-only imports without resolving them, and the annotation silently degrades to `any`. Nothing else in the pipeline reports this, ever.

## Three measured traps (recorded in `tsconfig.tests.json`, not re-derived by the next reader)

- **`rootDir` must be the repo root.** Packages import each other's *sources* (obsidian-plugin → `packages/core/src`), so a package-scoped `rootDir` yields TS6059 for every such file and tsc stops before checking anything. Measured: **277** TS6059.
- **`declarationMap` is inherited** and, without `declaration`/`composite`, is **TS5069** — a *config* error that **aborts** the run while still printing a **positioned** diagnostic. It therefore passes a "config errors have no position" discriminator and produced a convincing fake `ДЕЛЬТА=0`.
- **TS2307 is two different things.** Bare `@kitelev/exocortex-*` = workspace deps unbuilt (environment → `rc=2`, fix by building). Relative / deep-subpath = a module that moved = **real debt**, must be baselined, not swallowed. The first draft of the guard would have rejected the single most valuable finding as "environment".

## Scope guard (why the ratchet cannot silently pass)

It counts **distinct files** compiled under `packages/*/tests`. Zero test files compiled while other files did ⇒ the config broke ⇒ `exit 2`, never "clean". A position-less-error check alone misses TS5069 — which is exactly how the fake zero above was produced.

## Revert-verify (local, three runs)

| run | result |
|---|---|
| clean tree | `505/505` ✅ green |
| new test file with `const n: number = "definitely not a number"` | ⛔ **RED** — names `file(line,col): error TS2322`, and explicitly refuses "add it to the baseline" |
| file removed | `505/505` ✅ green |

CI revert-verify (disposable branch + `workflow_dispatch`) run number added as a comment below once it lands — the local runs prove the ratchet *discriminates*; the CI run proves the step is *delivered* into the `lint` job. Those are two independent axes.

## Also

`docs/reference/ci/required-checks.md` now states what `typecheck` does and does not cover, so "typecheck green" stops reading as "the diff was checked". Reporting a gate by its exit code alone is false for any PR whose main artefact is a test.
