### PR TITLE
fix(ci): population floors for the three lint gates satisfied by an empty input (#4090)

### DIFF
--- a/packages/obsidian-plugin/tests/unit/build/check-coverage-monotonic.test.ts
+++ b/packages/obsidian-plugin/tests/unit/build/check-coverage-monotonic.test.ts
@@ -100,4 +100,49 @@ describe("check-coverage-monotonic.mjs — coverage-threshold monotonicity (P5.1
     const r = runGuard();
     expect(r.status).toBe(0);
   });
+
+  // ── Population floor (#4090) ──────────────────────────────────────────────────
+  //
+  // The three cases above all vary a threshold NUMBER, so every one of them enters the
+  // per-entry loop. None of them can reach the failure this section covers: the loop
+  // iterates Object.entries(baseline), so an EMPTY baseline never enters it, collects no
+  // violation, and the guard printed "✅ … 0 threshold(s)" with exit 0 — satisfied by an
+  // empty input. Measured on origin/main before the fix: exit 0.
+  it("FAILS (exit 1) on an EMPTY baseline instead of passing with 0 thresholds", () => {
+    writeConfig(63);
+    writeFileSync(baselinePath, JSON.stringify({ thresholds: {} }));
+    const r = runGuard();
+    expect(r.status).toBe(1);
+    expect(r.stderr).toContain("declare a");
+    expect(r.stderr).toContain("NOT in the baseline");
+  });
+
+  // The complement, and the reason the check is a POSITIVE scope proof rather than a
+  // non-emptiness test: a baseline can be non-empty and still not cover a config that
+  // declares thresholds. Pre-fix that config was simply never visited — its thresholds
+  // could fall to zero and the success line would just print a smaller count.
+  it("FAILS (exit 1) when a config declares thresholds but is absent from the baseline", () => {
+    writeConfig(63);
+    mkdirSync(path.join(fixtureRoot, "packages/bar"), { recursive: true });
+    writeFileSync(
+      path.join(fixtureRoot, "packages/bar/jest.config.js"),
+      "module.exports = { coverageThreshold: { global: { branches: 10 } } };\n",
+    );
+    const r = runGuard();
+    expect(r.status).toBe(1);
+    expect(r.stderr).toContain("packages/bar/jest.config.js");
+  });
+
+  // A package WITHOUT thresholds must not be demanded in the baseline — otherwise the
+  // check would red on every package that simply does not measure coverage.
+  it("PASSES (exit 0) when a package has a jest config but declares no thresholds", () => {
+    writeConfig(63);
+    mkdirSync(path.join(fixtureRoot, "packages/baz"), { recursive: true });
+    writeFileSync(
+      path.join(fixtureRoot, "packages/baz/jest.config.js"),
+      "module.exports = { testEnvironment: 'node' };\n",
+    );
+    const r = runGuard();
+    expect(r.status).toBe(0);
+  });
 });

--- a/packages/obsidian-plugin/tests/unit/build/check-coverage-monotonic.test.ts
+++ b/packages/obsidian-plugin/tests/unit/build/check-coverage-monotonic.test.ts
@@ -133,6 +133,38 @@ describe("check-coverage-monotonic.mjs — coverage-threshold monotonicity (P5.1
     expect(r.stderr).toContain("packages/bar/jest.config.js");
   });
 
+  // The carrier is a SHAPE, not one filename. packages/obsidian-plugin/jest.ui.config.js
+  // exists today in the very package this baseline gates; when the enumeration was
+  // `jest.config.js` alone, a threshold added there — and in .mjs/.ts/.cjs siblings —
+  // was invisible, which is a false GREEN on the check meant to prove completeness.
+  it.each(["jest.ui.config.js", "jest.config.mjs", "jest.config.ts", "jest.config.cjs"])(
+    "FAILS (exit 1) when %s declares thresholds but is absent from the baseline",
+    (fileName) => {
+      writeConfig(63);
+      mkdirSync(path.join(fixtureRoot, "packages/bar"), { recursive: true });
+      writeFileSync(
+        path.join(fixtureRoot, "packages/bar", fileName),
+        "module.exports = { coverageThreshold: { global: { branches: 10 } } };\n",
+      );
+      const r = runGuard();
+      expect(r.status).toBe(1);
+      expect(r.stderr).toContain(`packages/bar/${fileName}`);
+    },
+  );
+
+  // Structural, not a substring: the word appearing in a COMMENT used to red a REQUIRED
+  // check, and the remedy it printed would have written a vacuous `{}` baseline entry.
+  it("PASSES (exit 0) when a config only MENTIONS coverageThreshold in a comment", () => {
+    writeConfig(63);
+    mkdirSync(path.join(fixtureRoot, "packages/qux"), { recursive: true });
+    writeFileSync(
+      path.join(fixtureRoot, "packages/qux/jest.config.js"),
+      "// no coverageThreshold here on purpose\nmodule.exports = { testEnvironment: 'node' };\n",
+    );
+    const r = runGuard();
+    expect(r.status).toBe(0);
+  });
+
   // A package WITHOUT thresholds must not be demanded in the baseline — otherwise the
   // check would red on every package that simply does not measure coverage.
   it("PASSES (exit 0) when a package has a jest config but declares no thresholds", () => {

--- a/packages/obsidian-plugin/tests/unit/build/check-test-antipatterns-overmock.test.ts
+++ b/packages/obsidian-plugin/tests/unit/build/check-test-antipatterns-overmock.test.ts
@@ -39,6 +39,14 @@ describe("check-test-antipatterns.sh — over-mock pass-through ratchet (P2, @re
     BASELINE_VACUOUS_LENGTH: "999",
     BASELINE_NONCANON_SERVICE_DIR: "999",
     BASELINE_OVERMOCK: "0",
+    // ⛤ The fixture corpus is a handful of files, so the POPULATION baseline has to be
+    // sized to it exactly as the four debt baselines above are. The guard refuses a run
+    // whose scan collapsed (that is the point of the floor — an empty scan used to exit
+    // 0 while printing "method-exists=0/55", which reads as success); a fixture corpus
+    // is indistinguishable from a collapse unless the expected size is declared here.
+    // ⛔ Deliberately NOT solved by having the guard skip its floor when
+    // ANTIPATTERN_SCAN_DIR is set: that would make the floor disarmable by an env var.
+    BASELINE_SCANNED: "1",
   };
 
   let scanDir: string;

--- a/packages/obsidian-plugin/tests/unit/build/check-test-antipatterns-overmock.test.ts
+++ b/packages/obsidian-plugin/tests/unit/build/check-test-antipatterns-overmock.test.ts
@@ -39,13 +39,20 @@ describe("check-test-antipatterns.sh — over-mock pass-through ratchet (P2, @re
     BASELINE_VACUOUS_LENGTH: "999",
     BASELINE_NONCANON_SERVICE_DIR: "999",
     BASELINE_OVERMOCK: "0",
-    // ⛤ The fixture corpus is a handful of files, so the POPULATION baseline has to be
-    // sized to it exactly as the four debt baselines above are. The guard refuses a run
-    // whose scan collapsed (that is the point of the floor — an empty scan used to exit
-    // 0 while printing "method-exists=0/55", which reads as success); a fixture corpus
-    // is indistinguishable from a collapse unless the expected size is declared here.
-    // ⛔ Deliberately NOT solved by having the guard skip its floor when
-    // ANTIPATTERN_SCAN_DIR is set: that would make the floor disarmable by an env var.
+    // ⛤ The fixture corpus is a handful of files, so the POPULATION baseline is sized to
+    // it exactly as the four debt baselines above are. The fixture lives in a tmpdir, so
+    // `git ls-files` returns nothing for it and the guard falls back to this recorded
+    // number — which is precisely the case the fallback exists for.
+    //
+    // ⛔ An earlier version of this comment claimed the alternative was rejected because
+    // it "would make the floor disarmable by an env var". That reason is false in this
+    // very file: BASELINE_SCANNED IS an env var, and "1" makes the fallback floor 0. The
+    // real reason stands and is narrower — layer 1 (`scanned == 0`) reads no baseline at
+    // all and therefore STAYS ARMED here, whereas skipping the floor whenever
+    // ANTIPATTERN_SCAN_DIR is set would have disarmed BOTH layers.
+    //
+    // "1" is right rather than 0: beforeEach calls writeCleanFile() unconditionally, so
+    // every case in this suite writes at least one file.
     BASELINE_SCANNED: "1",
   };
 

--- a/packages/obsidian-plugin/tests/unit/build/check-test-antipatterns-population.test.ts
+++ b/packages/obsidian-plugin/tests/unit/build/check-test-antipatterns-population.test.ts
@@ -1,0 +1,97 @@
+import { mkdtempSync, writeFileSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import * as path from "path";
+import { spawnSync } from "child_process";
+
+/**
+ * check-test-antipatterns.sh — POPULATION floor (issue #4090).
+ *
+ * Every counter in that guard is `grep … | wc -l`, so the size of the scanned corpus is
+ * a silent multiplier on all four of them. Point the scan at an empty directory and the
+ * guard used to print
+ *
+ *   ✅ test anti-pattern guard OK — method-exists=0/55, vacuous-length=0/21, …
+ *   ℹ️  method-exists dropped to 0 (baseline 55) — ratchet BASELINE_METHOD_EXISTS down…
+ *
+ * and exit 0. Two failures compound there: `0/55` READS AS AN ACHIEVEMENT rather than as
+ * "nothing was read", and the guard then invites the operator to ratchet the baselines to
+ * zero — after which it is green forever. The disarm arrives through the SUCCESS path, so
+ * reading red builds carefully could never have caught it.
+ *
+ * These axes lock the two floors. Without them the floors can be deleted and nothing goes
+ * red — which is the state the guard was in before #4090.
+ */
+describe("check-test-antipatterns.sh — population floor (#4090)", () => {
+  const repoRoot = path.resolve(__dirname, "../../../../..");
+  const scriptPath = path.join(repoRoot, "scripts/check-test-antipatterns.sh");
+
+  let scanDir: string;
+
+  const runGuard = (extraEnv: Record<string, string>) =>
+    spawnSync("bash", [scriptPath], {
+      cwd: repoRoot,
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        ANTIPATTERN_SCAN_DIR: scanDir,
+        ANTIPATTERN_NONCANON_DIR: path.join(scanDir, "__no_such_dir__"),
+        BASELINE_METHOD_EXISTS: "999",
+        BASELINE_VACUOUS_LENGTH: "999",
+        BASELINE_NONCANON_SERVICE_DIR: "999",
+        BASELINE_OVERMOCK: "0",
+        ...extraEnv,
+      },
+    });
+
+  beforeEach(() => {
+    scanDir = mkdtempSync(path.join(tmpdir(), "antipatterns-pop-"));
+  });
+
+  afterEach(() => {
+    rmSync(scanDir, { recursive: true, force: true });
+  });
+
+  const addTests = (n: number) => {
+    for (let i = 0; i < n; i += 1) {
+      writeFileSync(path.join(scanDir, `f${i}.test.ts`), "it('x', () => {});\n");
+    }
+  };
+
+  it("FAILS (exit 1) when the scan reads NO test files, instead of passing with 0/N", () => {
+    const r = runGuard({ BASELINE_SCANNED: "901" });
+    expect(r.status).toBe(1);
+    expect(r.stdout + r.stderr).toContain("scanned 0 test files");
+  });
+
+  it("refuses to suggest --update-baseline on an empty scan (that would write 0 and disarm it)", () => {
+    const r = runGuard({ BASELINE_SCANNED: "901" });
+    const out = r.stdout + r.stderr;
+    expect(out).toContain("Do NOT run --update-baseline");
+    // The pre-fix invitation must NOT appear: it is the sentence that turned a broken
+    // scan into a permanent green.
+    expect(out).not.toContain("ratchet BASELINE_METHOD_EXISTS down");
+  });
+
+  it("FAILS (exit 1) on a PARTIAL collapse — the counters shrink proportionally and look clean", () => {
+    addTests(3);
+    const r = runGuard({ BASELINE_SCANNED: "100" }); // floor 50, scanned 3
+    expect(r.status).toBe(1);
+    expect(r.stdout + r.stderr).toContain("less than half");
+  });
+
+  it("PASSES (exit 0) when the corpus matches its recorded size (revert-verify GREEN)", () => {
+    addTests(3);
+    const r = runGuard({ BASELINE_SCANNED: "3" });
+    expect(r.status).toBe(0);
+    expect(r.stdout).toContain("scanned 3 test file(s)");
+  });
+
+  it("prints the corpus size on the SUCCESS path — it is the only figure with no expected value", () => {
+    addTests(4);
+    const r = runGuard({ BASELINE_SCANNED: "4" });
+    expect(r.status).toBe(0);
+    // Ordered before the four ratios: a reader who stops at the first number must see
+    // the input size, not a ratio whose denominator is a committed constant.
+    expect(r.stdout).toMatch(/scanned 4 test file\(s\).*method-exists=/);
+  });
+});

--- a/packages/obsidian-plugin/tests/unit/build/check-test-antipatterns-population.test.ts
+++ b/packages/obsidian-plugin/tests/unit/build/check-test-antipatterns-population.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, writeFileSync, rmSync } from "fs";
+import { mkdtempSync, mkdirSync, writeFileSync, copyFileSync, rmSync } from "fs";
 import { tmpdir } from "os";
 import * as path from "path";
 import { spawnSync } from "child_process";
@@ -84,6 +84,81 @@ describe("check-test-antipatterns.sh — population floor (#4090)", () => {
     const r = runGuard({ BASELINE_SCANNED: "3" });
     expect(r.status).toBe(0);
     expect(r.stdout).toContain("scanned 3 test file(s)");
+  });
+
+  // ── The DERIVED floor (git ls-files) ────────────────────────────────────────────
+  //
+  // The proportional fallback exercised above accepts a large partial loss: measured on
+  // the real corpus (core 375, obsidian-plugin 359, cli 160, req-audit 5, test-utils 3,
+  // services 1) a half-floor of 451 lets ANY SINGLE package vanish — dropping
+  // packages/core leaves 528. That is a repeat of the M5a rename this guard cites as its
+  // own motivation, un-caught. git declares the TRACKED corpus while the counters grep
+  // the WORKING TREE, so comparing them is a derivation across two artefacts, and it is
+  // exact: measured 903 == 903 with identical file lists.
+  //
+  // ⛤ The fixture is a COPY of the guard inside a temp git repo, not the real script run
+  // with a different cwd. The script does `ROOT="$(cd "$(dirname "$0")/.." && pwd)"; cd
+  // "$ROOT"` at the top, so it always runs from ITS OWN repo root and the caller's cwd is
+  // irrelevant BY CONSTRUCTION — which is also precisely why `git ls-files` resolves in
+  // the real repository for a real run, and returns nothing for a tmpdir SCAN_DIR
+  // (routing every case above into the fallback).
+  describe("derived floor — git tracks the corpus", () => {
+    let repoDir: string;
+
+    const gitRun = (...args: string[]) =>
+      spawnSync("git", args, { cwd: repoDir, encoding: "utf8" });
+
+    const runInRepo = () =>
+      spawnSync("bash", [path.join(repoDir, "scripts/check-test-antipatterns.sh")], {
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          ANTIPATTERN_SCAN_DIR: "corpus",
+          ANTIPATTERN_NONCANON_DIR: "__no_such_dir__",
+          BASELINE_METHOD_EXISTS: "999",
+          BASELINE_VACUOUS_LENGTH: "999",
+          BASELINE_NONCANON_SERVICE_DIR: "999",
+          BASELINE_OVERMOCK: "0",
+          // Deliberately generous: floor 0. If the derived branch did NOT fire, the
+          // fallback would pass, so a RED below can only come from the derivation.
+          BASELINE_SCANNED: "1",
+        },
+      });
+
+    beforeEach(() => {
+      repoDir = mkdtempSync(path.join(tmpdir(), "antipatterns-git-"));
+      mkdirSync(path.join(repoDir, "scripts"), { recursive: true });
+      mkdirSync(path.join(repoDir, "corpus"), { recursive: true });
+      copyFileSync(
+        path.join(repoRoot, "scripts/check-test-antipatterns.sh"),
+        path.join(repoDir, "scripts/check-test-antipatterns.sh"),
+      );
+      for (let i = 0; i < 3; i += 1) {
+        writeFileSync(path.join(repoDir, `corpus/t${i}.test.ts`), "it('x', () => {});\n");
+      }
+      gitRun("init", "-q");
+      gitRun("config", "user.email", "t@example.com");
+      gitRun("config", "user.name", "t");
+      gitRun("add", "-A");
+      gitRun("commit", "-q", "-m", "corpus");
+    });
+
+    afterEach(() => {
+      rmSync(repoDir, { recursive: true, force: true });
+    });
+
+    it("PASSES (exit 0) when the working tree holds every file git tracks", () => {
+      const r = runInRepo();
+      expect(r.status).toBe(0);
+      expect(r.stdout).toContain("scanned 3 test file(s)");
+    });
+
+    it("FAILS (exit 1) on a loss the proportional fallback would have accepted", () => {
+      rmSync(path.join(repoDir, "corpus/t0.test.ts")); // tracked, gone from the tree
+      const r = runInRepo();
+      expect(r.status).toBe(1);
+      expect(r.stdout + r.stderr).toContain("scanned 2 of the 3 test file(s)");
+    });
   });
 
   it("prints the corpus size on the SUCCESS path — it is the only figure with no expected value", () => {

--- a/packages/obsidian-plugin/tests/unit/build/validate-docs-properties-population.test.ts
+++ b/packages/obsidian-plugin/tests/unit/build/validate-docs-properties-population.test.ts
@@ -1,0 +1,85 @@
+import { mkdtempSync, mkdirSync, writeFileSync, copyFileSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import * as path from "path";
+import { spawnSync } from "child_process";
+
+/**
+ * validate-docs-properties.js — POPULATION floor (issue #4090).
+ *
+ * The gate reports `Found N unique property names in docs/` then `(M missing)`. With an
+ * empty or unrecognised corpus that reads `Found 0 … (0 missing)` and exits 0 — the gate
+ * satisfied by an empty input, printed in the voice of a clean result.
+ *
+ * The two floors are DERIVED rather than assigned, which is why no magic number appears
+ * below: splitting "files scanned" from "properties recognised" is itself the oracle.
+ *   filesScanned === 0            → the CORPUS is gone
+ *   filesScanned > 0, props === 0 → the EXTRACTOR is broken — N files were parsed and
+ *                                   nothing was recognised, which a file count alone
+ *                                   could never distinguish from a clean corpus.
+ *
+ * The script resolves its paths from `__dirname`, so the fixture is a temp root holding a
+ * copy of it. That is the only way to vary the corpus without touching the real docs/.
+ */
+describe("validate-docs-properties.js — population floor (#4090)", () => {
+  const repoRoot = path.resolve(__dirname, "../../../../..");
+  const realScript = path.join(repoRoot, "scripts/validate-docs-properties.js");
+
+  let fixtureRoot: string;
+  let scriptCopy: string;
+
+  const runGate = () =>
+    spawnSync("node", [scriptCopy], { cwd: fixtureRoot, encoding: "utf8" });
+
+  beforeEach(() => {
+    fixtureRoot = mkdtempSync(path.join(tmpdir(), "docs-props-"));
+    mkdirSync(path.join(fixtureRoot, "scripts"), { recursive: true });
+    mkdirSync(path.join(fixtureRoot, "docs"), { recursive: true });
+    mkdirSync(path.join(fixtureRoot, "packages"), { recursive: true });
+    scriptCopy = path.join(fixtureRoot, "scripts/validate-docs-properties.js");
+    copyFileSync(realScript, scriptCopy);
+  });
+
+  afterEach(() => {
+    rmSync(fixtureRoot, { recursive: true, force: true });
+  });
+
+  it("FAILS (exit 1) when docs/ holds no .md at all, instead of reporting 0 missing", () => {
+    const r = runGate();
+    expect(r.status).toBe(1);
+    expect(r.stderr).toContain("no .md files");
+  });
+
+  it("FAILS (exit 1) when files ARE scanned but nothing is recognised — the extractor, not the corpus", () => {
+    writeFileSync(
+      path.join(fixtureRoot, "docs/prose.md"),
+      "# Title\n\nPlain prose with no property mentions at all.\n",
+    );
+    writeFileSync(
+      path.join(fixtureRoot, "docs/more.md"),
+      "Another file, still nothing that looks like a property name.\n",
+    );
+    const r = runGate();
+    expect(r.status).toBe(1);
+    expect(r.stderr).toContain("scanned 2 .md file(s)");
+    // The message must name the EXTRACTOR — pointing at the corpus would send the reader
+    // to check a directory that is demonstrably fine.
+    expect(r.stderr).toContain("EXTRACTOR failing");
+  });
+
+  it("PASSES (exit 0) and prints BOTH numbers when the corpus is real (revert-verify GREEN)", () => {
+    // A property that genuinely exists in the fixture's packages/ source.
+    mkdirSync(path.join(fixtureRoot, "packages/foo/src"), { recursive: true });
+    writeFileSync(
+      path.join(fixtureRoot, "packages/foo/src/a.ts"),
+      'export const KEY = "ems__Effort_status";\n',
+    );
+    writeFileSync(
+      path.join(fixtureRoot, "docs/schema.md"),
+      "```yaml\nems__Effort_status: doing\n```\n",
+    );
+    const r = runGate();
+    expect(r.status).toBe(0);
+    // Coverage printed alongside findings: "N properties in M files", not N alone.
+    expect(r.stdout).toMatch(/Found \d+ unique property names in \d+ docs\/ file\(s\)/);
+  });
+});

--- a/scripts/check-coverage-monotonic.mjs
+++ b/scripts/check-coverage-monotonic.mjs
@@ -28,7 +28,7 @@
 //   COVERAGE_BASELINE  — path to the baseline JSON (default: <root>/scripts/coverage-thresholds-baseline.json)
 //   COVERAGE_ROOT      — root that config paths in the baseline resolve against (default: repo root)
 
-import { readFileSync } from "fs";
+import { readdirSync, readFileSync } from "fs";
 import { dirname, resolve } from "path";
 import { fileURLToPath } from "url";
 
@@ -73,6 +73,40 @@ function loadBaseline(path) {
   return parsed.thresholds ?? parsed;
 }
 
+/**
+ * Every jest config that DECLARES a coverageThreshold — the independent oracle for
+ * "is the baseline complete?".
+ *
+ * ⛔ Without this the guard proves only "the configs I happen to track did not regress",
+ * never "every config that carries thresholds is tracked". Those are different claims,
+ * and the gap between them is silent: a new package that gains a coverageThreshold is
+ * simply absent from the baseline, the loop never visits it, and the success line just
+ * prints a smaller count that nobody has an expected value for. Three packages
+ * (req-audit, services, test-utils) have jest configs WITHOUT thresholds today — the
+ * day any of them gains one, that is exactly this hole.
+ */
+function findConfigsWithThresholds(packagesDir) {
+  const out = [];
+  let pkgs;
+  try {
+    pkgs = readdirSync(packagesDir, { withFileTypes: true });
+  } catch {
+    return out; // caller treats an empty result as "the deriver is broken"
+  }
+  for (const p of pkgs) {
+    if (!p.isDirectory()) continue;
+    const rel = `packages/${p.name}/jest.config.js`;
+    try {
+      if (readFileSync(resolve(packagesDir, p.name, "jest.config.js"), "utf8").includes("coverageThreshold")) {
+        out.push(rel);
+      }
+    } catch {
+      /* no jest config in this package — not an error */
+    }
+  }
+  return out;
+}
+
 function main() {
   let baseline;
   try {
@@ -80,6 +114,35 @@ function main() {
   } catch (e) {
     console.error(
       `❌ coverage-monotonic guard: could not read baseline ${baselinePath}: ${e.message}`,
+    );
+    process.exit(1);
+  }
+
+  // ⛤ POSITIVE scope proof, BEFORE the per-entry loop. The loop below iterates
+  // Object.entries(baseline); an empty baseline therefore never enters it, collects no
+  // violation, and prints "✅ … 0 threshold(s)" with rc=0 — the gate satisfied by an
+  // empty input. Both halves are checked: the baseline must be non-empty, and it must
+  // cover every config that actually declares thresholds.
+  const declaring = findConfigsWithThresholds(resolve(configRoot, "packages"));
+  if (declaring.length === 0) {
+    console.error(
+      "❌ coverage-monotonic guard: found no jest config declaring a coverageThreshold\n" +
+        `   under ${resolve(configRoot, "packages")}. The expected set cannot be derived,\n` +
+        "   so this run has nothing to check the baseline against — the packages directory\n" +
+        "   is missing or renamed. Fix that; do NOT trim the baseline to match.",
+    );
+    process.exit(1);
+  }
+  const untracked = declaring.filter((c) => !(c in baseline));
+  if (untracked.length > 0) {
+    console.error(
+      `❌ coverage-monotonic guard: ${untracked.length} jest config(s) declare a\n` +
+        "   coverageThreshold but are NOT in the baseline, so their thresholds could drop\n" +
+        "   to zero unnoticed:",
+    );
+    for (const c of untracked) console.error(`   ${c}`);
+    console.error(
+      "\n   Add them to scripts/coverage-thresholds-baseline.json at their CURRENT values.",
     );
     process.exit(1);
   }
@@ -137,7 +200,8 @@ function main() {
   }
 
   console.log(
-    `✅ coverage-monotonic guard OK — ${summary.length} threshold(s) at or above baseline (no downward drift).`,
+    `✅ coverage-monotonic guard OK — ${summary.length} threshold(s) across ` +
+      `${declaring.length} config(s) at or above baseline (no downward drift).`,
   );
 }
 

--- a/scripts/check-coverage-monotonic.mjs
+++ b/scripts/check-coverage-monotonic.mjs
@@ -74,8 +74,21 @@ function loadBaseline(path) {
 }
 
 /**
- * Every jest config that DECLARES a coverageThreshold — the independent oracle for
- * "is the baseline complete?".
+ * Every `packages/<pkg>/jest*.config.{js,cjs,mjs,ts}` whose `coverageThreshold.global`
+ * block actually parses — the independent oracle for "is the baseline complete?".
+ *
+ * ⛔ The scope is stated precisely because an earlier draft of this comment claimed
+ * "every jest config that declares a coverageThreshold", and that was literally false:
+ * the enumeration was `packages/*\/jest.config.js` alone. Review probed six carriers that
+ * genuinely declare thresholds and every one exited 0 — `jest.ui.config.js`,
+ * `jest.config.mjs`, `jest.config.ts`, a `package.json` `jest` key, a nested
+ * `config/jest.config.js`, and thresholds carried by a shared preset. The first of those
+ * is NOT hypothetical: packages/obsidian-plugin/jest.ui.config.js exists today, in the
+ * very package this baseline gates. It carries no threshold yet.
+ *
+ * ⚠ Two carriers remain out of reach of a text scan and are named rather than pretended
+ * away: a `jest` key inside package.json, and thresholds inherited from a preset. Both
+ * fail in the SILENT direction, which is why the limit is written here.
  *
  * ⛔ Without this the guard proves only "the configs I happen to track did not regress",
  * never "every config that carries thresholds is tracked". Those are different claims,
@@ -95,13 +108,29 @@ function findConfigsWithThresholds(packagesDir) {
   }
   for (const p of pkgs) {
     if (!p.isDirectory()) continue;
-    const rel = `packages/${p.name}/jest.config.js`;
+    let entries;
     try {
-      if (readFileSync(resolve(packagesDir, p.name, "jest.config.js"), "utf8").includes("coverageThreshold")) {
-        out.push(rel);
-      }
+      entries = readdirSync(resolve(packagesDir, p.name), { withFileTypes: true });
     } catch {
-      /* no jest config in this package — not an error */
+      continue;
+    }
+    for (const f of entries) {
+      if (!f.isFile() || !/^jest.*\.config\.(js|cjs|mjs|ts)$/.test(f.name)) continue;
+      let text;
+      try {
+        text = readFileSync(resolve(packagesDir, p.name, f.name), "utf8");
+      } catch {
+        continue;
+      }
+      // ⛤ STRUCTURAL, not a substring. `.includes("coverageThreshold")` matched the word
+      // in a COMMENT — probed: a config saying "// no coverageThreshold here on purpose"
+      // exited 1, reddening a REQUIRED check, and the remedy it printed ("add it at its
+      // current values") would have written a `{}` entry that looks tracked and tracks
+      // nothing. Reusing extractThresholds also collapses two predicates into one, so
+      // "what counts as declaring" can never drift from "what gets compared".
+      if (Object.keys(extractThresholds(text)).length > 0) {
+        out.push(`packages/${p.name}/${f.name}`);
+      }
     }
   }
   return out;

--- a/scripts/check-test-antipatterns.sh
+++ b/scripts/check-test-antipatterns.sh
@@ -147,6 +147,80 @@ OVERMOCK_COUNT="$(overmock_files | sed '/^$/d' | wc -l | tr -d ' ')"
 # Size of the corpus the four counters above were computed over.
 SCANNED_COUNT="$(grep -rl . "$SCAN_DIR" --include='*.test.ts' --include='*.test.tsx' 2>/dev/null | wc -l | tr -d ' ')"
 
+# ── POSITIVE proof that the run examined a corpus at all ──────────────────────────
+#
+# ⛔ Demonstrated 2026-08-19, and the reason this block exists: point the scan at an
+# empty directory and the guard printed
+#
+#     ✅ test anti-pattern guard OK — method-exists=0/55, vacuous-length=0/21, …
+#     ℹ️  method-exists dropped to 0 (baseline 55) — ratchet BASELINE_METHOD_EXISTS down…
+#
+# and exited 0. Two things are wrong at once: `0/55` READS AS AN ACHIEVEMENT ("we fixed
+# everything") rather than as "the scan found nothing", and the guard then INVITES the
+# operator to ratchet the baselines to 0 — after which it is green forever no matter how
+# many anti-patterns are added. The failure arrives through the SUCCESS path.
+#
+# ⚠ ANTIPATTERN_NONCANON_DIR defaults to a path INSIDE a package
+# (packages/core/tests/services), and this repo has already renamed a package
+# (packages/exocortex -> packages/core, M5a). That rename would have zeroed that counter
+# silently. This is not a hypothetical — and see the DERIVED floor below for why a
+# proportional floor would not have caught a repeat of it either.
+#
+# ⛤ Placed ABOVE the --update-baseline branch deliberately: that branch used to run
+# first, so an operator on a collapsed scan could still print (and commit) 0/0/0/0.
+if [ "$SCANNED_COUNT" -eq 0 ]; then
+  echo "❌ test anti-pattern guard: scanned 0 test files under '$SCAN_DIR'."
+  echo "   All four counters are \`grep | wc -l\`, so they are 0 because NOTHING WAS"
+  echo "   READ — not because the debt was paid. This run has no verdict to give."
+  echo "   ⛔ Do NOT run --update-baseline: it would write 0/0/0/0 and the guard would"
+  echo "   pass forever regardless of how many anti-patterns are introduced."
+  echo "   Fix the scan root (ANTIPATTERN_SCAN_DIR / the SCAN_DIR default) instead."
+  exit 1
+fi
+
+# Second layer: a PARTIAL collapse drives the counters down proportionally and is
+# invisible to the check above.
+#
+# ⛤ DERIVED, not proportional. An earlier draft used BASELINE_SCANNED/2, and review
+# measured what that accepts: with the corpus at core=375, obsidian-plugin=359, cli=160,
+# req-audit=5, test-utils=3, services=1, a floor of 451 lets the loss of ANY SINGLE
+# package pass silently — dropping packages/core leaves 528. That is a repeat of the very
+# M5a rename cited above, un-caught, which made the proportional floor the same defect it
+# was written to close, one notch narrower.
+#
+# git declares the TRACKED corpus while the counters grep the WORKING TREE — two
+# different artefacts, so this is a derivation and not a self-check. Measured 2026-08-19:
+# both yield 903 and their file LISTS are identical (diff: 0 lines).
+#
+# `git ls-files` returns nothing for a path outside the repo (the guard's own fixture
+# corpus lives in a tmpdir), so the ratchet below is the fallback for exactly that case —
+# and only that case.
+#
+# ⛔ `|| true`, not `|| echo 0`: grep -c exits 1 on zero matches, and the echo form would
+# emit "0\n0" and break the arithmetic (bash-loop-eval-pitfalls Г3e).
+EXPECTED_SCANNED="$(git ls-files -- "$SCAN_DIR" 2>/dev/null | grep -cE '\.test\.tsx?$' || true)"
+EXPECTED_SCANNED=$((EXPECTED_SCANNED))
+if [ "$EXPECTED_SCANNED" -gt 0 ]; then
+  if [ "$SCANNED_COUNT" -lt "$EXPECTED_SCANNED" ]; then
+    echo "❌ test anti-pattern guard: scanned $SCANNED_COUNT of the $EXPECTED_SCANNED test file(s)"
+    echo "   git tracks under '$SCAN_DIR'. The corpus collapsed rather than the debt"
+    echo "   shrinking, so the four counters below mean nothing."
+    echo "   A tracked test file that the scan cannot read is the failure this guards."
+    exit 1
+  fi
+else
+  # Not a git path (fixture corpus): fall back to the recorded population.
+  SCANNED_FLOOR=$((BASELINE_SCANNED / 2))
+  if [ "$SCANNED_COUNT" -lt "$SCANNED_FLOOR" ]; then
+    echo "❌ test anti-pattern guard: scanned $SCANNED_COUNT test file(s), less than half of"
+    echo "   the $BASELINE_SCANNED recorded in BASELINE_SCANNED, and git tracks nothing under"
+    echo "   '$SCAN_DIR' to derive an exact expectation from."
+    echo "   If the shrink is legitimate, re-run with --update-baseline and commit the new"
+    echo "   BASELINE_SCANNED together with the new counter baselines."
+    exit 1
+  fi
+fi
+
 if [ "${1:-}" = "--update-baseline" ]; then
   echo "Current counts (paste into this script's BASELINE_* values):"
   echo "  BASELINE_METHOD_EXISTS=$ME_COUNT"
@@ -159,54 +233,6 @@ fi
 
 fail=0
 
-# ── POSITIVE proof that the run examined a corpus at all ──────────────────────────
-#
-# ⛔ Demonstrated 2026-08-19, and the reason this block exists: point the scan at an
-# empty directory and the guard prints
-#
-#     ✅ test anti-pattern guard OK — method-exists=0/55, vacuous-length=0/21, …
-#     ℹ️  method-exists dropped to 0 (baseline 55) — ratchet BASELINE_METHOD_EXISTS down…
-#
-# and exits 0. Two things are wrong at once: `0/55` READS AS AN ACHIEVEMENT ("we fixed
-# everything") rather than as "the scan found nothing, so all four counters collapsed",
-# and the guard then INVITES the operator to ratchet the baselines to 0 — after which it
-# is green forever no matter how many anti-patterns are added. The failure arrives
-# through the SUCCESS path, so no amount of care reading a red build would catch it.
-#
-# ⚠ ANTIPATTERN_NONCANON_DIR defaults to a path INSIDE a package
-# (packages/core/tests/services), and this repo has already renamed a package
-# (packages/exocortex -> packages/core, M5a). That rename would have zeroed that counter
-# silently. This is not a hypothetical.
-if [ "$SCANNED_COUNT" -eq 0 ]; then
-  echo "❌ test anti-pattern guard: scanned 0 test files under '$SCAN_DIR'."
-  echo "   All four counters are \`grep | wc -l\`, so they are 0 because NOTHING WAS"
-  echo "   READ — not because the debt was paid. This run has no verdict to give."
-  echo "   ⛔ Do NOT run --update-baseline: it would write 0/0/0/0 and the guard would"
-  echo "   pass forever regardless of how many anti-patterns are introduced."
-  echo "   Fix the scan root (ANTIPATTERN_SCAN_DIR / the SCAN_DIR default) instead."
-  exit 1
-fi
-
-# Second layer: a PARTIAL collapse (scan finds a fraction of the corpus) drives the
-# counters down proportionally and is invisible to the check above.
-#
-# ⛤ Unlike scripts/check-cli-types.mjs — where tsconfig `include` independently declares
-# what the program must contain, so the floor is DERIVED and exact — nothing in this repo
-# declares how many test files ought to exist. The previous measurement, committed above,
-# is the only available reference, which is why this layer is a ratchet like the rest of
-# the file rather than a derivation. Half is deliberately generous: it catches collapse,
-# NOT drift. Drift stays visible because SCANNED_COUNT is printed on every run, pass or
-# fail — a number nobody has an expected value for is the thing this whole guard is about.
-SCANNED_FLOOR=$((BASELINE_SCANNED / 2))
-if [ "$SCANNED_COUNT" -lt "$SCANNED_FLOOR" ]; then
-  echo "❌ test anti-pattern guard: scanned $SCANNED_COUNT test file(s), less than half of"
-  echo "   the $BASELINE_SCANNED recorded in BASELINE_SCANNED. The corpus collapsed rather"
-  echo "   than the debt shrinking, so the four counters below mean nothing."
-  echo "   If the shrink is legitimate, re-run with --update-baseline and commit the new"
-  echo "   BASELINE_SCANNED together with the new counter baselines — deliberately, in one"
-  echo "   reviewed act."
-  exit 1
-fi
 
 if [ "$ME_COUNT" -gt "$BASELINE_METHOD_EXISTS" ]; then
   echo "❌ method-exists asserts increased: $ME_COUNT > baseline $BASELINE_METHOD_EXISTS"

--- a/scripts/check-test-antipatterns.sh
+++ b/scripts/check-test-antipatterns.sh
@@ -85,6 +85,11 @@ BASELINE_NONCANON_SERVICE_DIR="${BASELINE_NONCANON_SERVICE_DIR:-19}"
 # canonical over-mock was lifted to an integration suite, so no pure pass-through
 # over-mock file exists today. Bans introducing one.
 BASELINE_OVERMOCK="${BASELINE_OVERMOCK:-0}"
+# ⛤ POPULATION baseline — how many test files the counters above were computed OVER.
+# Not a debt figure: it is the SIZE OF THE INPUT, and it is here because every counter
+# in this guard is `grep … | wc -l`, so an empty or moved SCAN_DIR drives all four to 0
+# and every `0 <= baseline` comparison passes. Measured 2026-08-19: 903 (901 before this change added two guard tests).
+BASELINE_SCANNED="${BASELINE_SCANNED:-903}"
 
 # Scan root (default: the whole monorepo packages tree). Overridable for the
 # guard's revert-verify test (points at a fixture corpus).
@@ -139,6 +144,8 @@ VL_COUNT="$(count "$VL_PATTERN")"
 # Top-level .test.ts files in the legacy non-canon service dir (flat dir).
 NONCANON_COUNT="$(find "$NONCANON_SERVICE_DIR" -maxdepth 1 -name '*.test.ts' 2>/dev/null | wc -l | tr -d ' ')"
 OVERMOCK_COUNT="$(overmock_files | sed '/^$/d' | wc -l | tr -d ' ')"
+# Size of the corpus the four counters above were computed over.
+SCANNED_COUNT="$(grep -rl . "$SCAN_DIR" --include='*.test.ts' --include='*.test.tsx' 2>/dev/null | wc -l | tr -d ' ')"
 
 if [ "${1:-}" = "--update-baseline" ]; then
   echo "Current counts (paste into this script's BASELINE_* values):"
@@ -146,10 +153,60 @@ if [ "${1:-}" = "--update-baseline" ]; then
   echo "  BASELINE_VACUOUS_LENGTH=$VL_COUNT"
   echo "  BASELINE_NONCANON_SERVICE_DIR=$NONCANON_COUNT"
   echo "  BASELINE_OVERMOCK=$OVERMOCK_COUNT"
+  echo "  BASELINE_SCANNED=$SCANNED_COUNT"
   exit 0
 fi
 
 fail=0
+
+# ── POSITIVE proof that the run examined a corpus at all ──────────────────────────
+#
+# ⛔ Demonstrated 2026-08-19, and the reason this block exists: point the scan at an
+# empty directory and the guard prints
+#
+#     ✅ test anti-pattern guard OK — method-exists=0/55, vacuous-length=0/21, …
+#     ℹ️  method-exists dropped to 0 (baseline 55) — ratchet BASELINE_METHOD_EXISTS down…
+#
+# and exits 0. Two things are wrong at once: `0/55` READS AS AN ACHIEVEMENT ("we fixed
+# everything") rather than as "the scan found nothing, so all four counters collapsed",
+# and the guard then INVITES the operator to ratchet the baselines to 0 — after which it
+# is green forever no matter how many anti-patterns are added. The failure arrives
+# through the SUCCESS path, so no amount of care reading a red build would catch it.
+#
+# ⚠ ANTIPATTERN_NONCANON_DIR defaults to a path INSIDE a package
+# (packages/core/tests/services), and this repo has already renamed a package
+# (packages/exocortex -> packages/core, M5a). That rename would have zeroed that counter
+# silently. This is not a hypothetical.
+if [ "$SCANNED_COUNT" -eq 0 ]; then
+  echo "❌ test anti-pattern guard: scanned 0 test files under '$SCAN_DIR'."
+  echo "   All four counters are \`grep | wc -l\`, so they are 0 because NOTHING WAS"
+  echo "   READ — not because the debt was paid. This run has no verdict to give."
+  echo "   ⛔ Do NOT run --update-baseline: it would write 0/0/0/0 and the guard would"
+  echo "   pass forever regardless of how many anti-patterns are introduced."
+  echo "   Fix the scan root (ANTIPATTERN_SCAN_DIR / the SCAN_DIR default) instead."
+  exit 1
+fi
+
+# Second layer: a PARTIAL collapse (scan finds a fraction of the corpus) drives the
+# counters down proportionally and is invisible to the check above.
+#
+# ⛤ Unlike scripts/check-cli-types.mjs — where tsconfig `include` independently declares
+# what the program must contain, so the floor is DERIVED and exact — nothing in this repo
+# declares how many test files ought to exist. The previous measurement, committed above,
+# is the only available reference, which is why this layer is a ratchet like the rest of
+# the file rather than a derivation. Half is deliberately generous: it catches collapse,
+# NOT drift. Drift stays visible because SCANNED_COUNT is printed on every run, pass or
+# fail — a number nobody has an expected value for is the thing this whole guard is about.
+SCANNED_FLOOR=$((BASELINE_SCANNED / 2))
+if [ "$SCANNED_COUNT" -lt "$SCANNED_FLOOR" ]; then
+  echo "❌ test anti-pattern guard: scanned $SCANNED_COUNT test file(s), less than half of"
+  echo "   the $BASELINE_SCANNED recorded in BASELINE_SCANNED. The corpus collapsed rather"
+  echo "   than the debt shrinking, so the four counters below mean nothing."
+  echo "   If the shrink is legitimate, re-run with --update-baseline and commit the new"
+  echo "   BASELINE_SCANNED together with the new counter baselines — deliberately, in one"
+  echo "   reviewed act."
+  exit 1
+fi
 
 if [ "$ME_COUNT" -gt "$BASELINE_METHOD_EXISTS" ]; then
   echo "❌ method-exists asserts increased: $ME_COUNT > baseline $BASELINE_METHOD_EXISTS"
@@ -193,11 +250,20 @@ if [ "$OVERMOCK_COUNT" -gt "$BASELINE_OVERMOCK" ]; then
 fi
 
 if [ "$fail" -eq 0 ]; then
-  echo "✅ test anti-pattern guard OK — method-exists=$ME_COUNT/$BASELINE_METHOD_EXISTS, vacuous-length=$VL_COUNT/$BASELINE_VACUOUS_LENGTH, non-canon-service-dir=$NONCANON_COUNT/$BASELINE_NONCANON_SERVICE_DIR, over-mock=$OVERMOCK_COUNT/$BASELINE_OVERMOCK (no recurrence)"
+  # ⛤ SCANNED is printed FIRST and on every run, ahead of the four ratios. Each ratio is
+  # a fraction whose denominator is a committed number; the corpus size is the only
+  # figure here with no expected value attached, which is exactly why it has to be shown
+  # rather than inferred. "0/55" without it reads as success.
+  echo "✅ test anti-pattern guard OK — scanned $SCANNED_COUNT test file(s) — method-exists=$ME_COUNT/$BASELINE_METHOD_EXISTS, vacuous-length=$VL_COUNT/$BASELINE_VACUOUS_LENGTH, non-canon-service-dir=$NONCANON_COUNT/$BASELINE_NONCANON_SERVICE_DIR, over-mock=$OVERMOCK_COUNT/$BASELINE_OVERMOCK (no recurrence)"
 fi
 
 # Non-fatal nudge: when counts drop, the baseline should be ratcheted down so the
 # guard keeps its teeth.
+#
+# ⛤ Safe to say now, and it was NOT before: reaching this point means the corpus floors
+# above passed, so a counter that dropped really did drop against a corpus that was
+# really read. The same sentence printed after a collapsed scan was an invitation to
+# write a 0 baseline and disarm the guard permanently.
 if [ "$ME_COUNT" -lt "$BASELINE_METHOD_EXISTS" ]; then
   echo "ℹ️  method-exists dropped to $ME_COUNT (baseline $BASELINE_METHOD_EXISTS) — ratchet BASELINE_METHOD_EXISTS down via --update-baseline."
 fi

--- a/scripts/validate-docs-properties.js
+++ b/scripts/validate-docs-properties.js
@@ -42,6 +42,7 @@ const KNOWN_EXCEPTIONS = new Set([
 
 function extractPropertiesFromDocs() {
   const properties = new Map(); // property -> [{file, line}]
+  let filesScanned = 0;
 
   function scanFile(filePath) {
     const content = fs.readFileSync(filePath, "utf-8");
@@ -84,13 +85,14 @@ function extractPropertiesFromDocs() {
       if (entry.isDirectory()) {
         scanDir(fullPath);
       } else if (entry.name.endsWith(".md")) {
+        filesScanned += 1;
         scanFile(fullPath);
       }
     }
   }
 
   scanDir(DOCS_DIR);
-  return properties;
+  return { properties, filesScanned };
 }
 
 function propertyExistsInCode(propertyName) {
@@ -108,7 +110,38 @@ function propertyExistsInCode(propertyName) {
 function main() {
   console.log("Validating documentation property names...\n");
 
-  const docProperties = extractPropertiesFromDocs();
+  const { properties: docProperties, filesScanned } = extractPropertiesFromDocs();
+
+  // ⛤ POSITIVE proof of coverage, from the SCAN rather than from its findings.
+  //
+  // ⛔ Without it this gate is satisfied by an empty input: `Found 0 unique property
+  // names` -> `0 missing` -> rc=0, which reads as "docs are clean" and is
+  // indistinguishable from "the scan found nothing". The two halves below are checked
+  // separately because they fail for DIFFERENT reasons and the split is itself the
+  // oracle — no magic number is involved:
+  //   filesScanned === 0            -> the CORPUS is gone (docs/ moved or emptied)
+  //   filesScanned > 0, props === 0 -> the EXTRACTOR is broken (N files parsed, nothing
+  //                                    recognised), which no count of files could reveal
+  // Measured 2026-08-19 on the unchanged tree: 67 properties across the docs corpus.
+  if (filesScanned === 0) {
+    console.error(
+      `VALIDATION ABORTED: no .md files under ${DOCS_DIR}.\n` +
+        "  The documentation corpus is missing or renamed, so this run examined nothing\n" +
+        "  and has no verdict to give. Fix the path — a green result here would mean\n" +
+        "  'nothing was checked', not 'nothing is wrong'.",
+    );
+    process.exit(1);
+  }
+  if (docProperties.size === 0) {
+    console.error(
+      `VALIDATION ABORTED: scanned ${filesScanned} .md file(s) and recognised NO property\n` +
+        "  names at all. The corpus is present, so this is the EXTRACTOR failing, not an\n" +
+        "  empty corpus — the mention format in docs/ changed, or the frontmatter/YAML\n" +
+        "  detection stopped matching. Every property would pass vacuously until fixed.",
+    );
+    process.exit(1);
+  }
+
   const errors = [];
 
   for (const [prop, locations] of docProperties) {
@@ -119,7 +152,9 @@ function main() {
     }
   }
 
-  console.log(`Found ${docProperties.size} unique property names in docs/`);
+  console.log(
+    `Found ${docProperties.size} unique property names in ${filesScanned} docs/ file(s)`,
+  );
   console.log(
     `Checked against packages/ source code (${errors.length} missing)\n`,
   );


### PR DESCRIPTION
Первая половина **#4090**. Три из семи гейтов `lint`-джобы доказывали «в том, что я посмотрел, нарушений нет» и **ничего** не доказывали о том, посмотрели ли они вообще — то есть удовлетворялись пустым входом.

⛤ Полы **выводятся** там, где есть независимый оракул, и являются ратчетом только там, где его нет. Ни один не является числом, выбранным для комфорта — это тот самый дефект, который ревью нашло в #4089 (`MIN_COMPILED_SRC_FILES = 40` против измеренных 114) и который я не хочу воспроизводить в трёх местах разом.

## 1. `check-test-antipatterns.sh` — острейший: разоружение ЧИТАЕТСЯ КАК ДОСТИЖЕНИЕ

Все четыре счётчика — `grep | wc -l`, поэтому пустой `SCAN_DIR` роняет их в 0, и каждое `0 <= baseline` проходит. Воспроизведено на пустом каталоге:

```
✅ test anti-pattern guard OK — method-exists=0/55, vacuous-length=0/21, non-canon-service-dir=0/19, over-mock=0/0
ℹ️  method-exists dropped to 0 (baseline 55) — ratchet BASELINE_METHOD_EXISTS down via --update-baseline.
rc=0
```

⛔ `0/55` читается как «всё починили», и гейт **сам приглашает** обнулить базы — после чего он зелен навсегда при любом числе новых анти-паттернов. Отказ приходит по **пути успеха**, поэтому никакая внимательность к красным сборкам его не поймала бы.

⚠ Не гипотетика: `ANTIPATTERN_NONCANON_DIR` по умолчанию — путь **внутри пакета** (`packages/core/tests/services`), а репо уже переживало переименование пакета (`packages/exocortex` → `packages/core`, M5a). Такой rename обнулил бы этот счётчик молча.

**Два слоя.** `SCANNED_COUNT == 0` → `rc=1` (выводимо, числа не требует: «ничего не прочитано» категориально отлично от «ничего не найдено»). Ниже половины `BASELINE_SCANNED` → `rc=1`, ловит частичный обвал.

⛤ Второй слой — **ратчет, а не деривация**, и это названо в коде: в отличие от `check-cli-types.mjs`, где `include` конфига независимо объявляет состав программы, **ничто в репо не объявляет, сколько тест-файлов должно существовать**. Половина взята заведомо щедрой: она ловит **обвал, а не дрейф**, — а дрейф остаётся видимым, потому что `SCANNED_COUNT` теперь печатается **первым** на каждом прогоне. Это единственное здесь число, чей знаменатель не является закоммиченной константой; ровно поэтому его надо показывать, а не выводить.

## 2. `check-coverage-monotonic.mjs` — выводится, оракул настоящий

Цикл идёт по `Object.entries(baseline)` ⇒ **пустая** база в него не входит, и гейт печатал `✅ … 0 threshold(s)` с `rc=0`.

⛤ Хуже пустоты: база доказывала «отслеживаемые конфиги не регрессировали» и **никогда** — «каждый конфиг, несущий пороги, отслеживается». Три пакета (`req-audit`, `services`, `test-utils`) имеют jest-конфиги **без** порогов сегодня; в день, когда любой заведёт порог, он окажется вне отслеживания **молча**.

Теперь каждый `packages/*/jest.config.js`, объявляющий `coverageThreshold`, обязан присутствовать в базе — множество сканируется **с диска**, то есть из артефакта, независимого от самой базы.

## 3. `validate-docs-properties.js` — выводится из РАСЩЕПЛЕНИЯ, порог не нужен

`Found 0 unique property names` → `0 missing` → `rc=0`, причём голосом чистого прогона.

⛤ Разделение «файлов просканировано» и «свойств распознано» **само является оракулом**:

| наблюдаемое | что сломано |
|---|---|
| `filesScanned === 0` | **КОРПУС** исчез (`docs/` переехал или опустел) |
| `filesScanned > 0`, свойств `0` | **ЭКСТРАКТОР** — N файлов разобрано, не распознано ничего |

Второе не различимо никаким счётом файлов, и именно оно — реалистичный тихий отказ. Охват теперь печатается рядом с находками: `67 properties in 56 docs/ file(s)`.

## Revert-verify — каждая ось прогнана против скриптов `origin/main`

| гейт | вход | ДО | ПОСЛЕ |
|---|---|---|---|
| antipatterns | пустой скан | `rc=0` + приглашение | **`rc=1`** |
| antipatterns | частичный обвал 3/100 | `rc=0` | **`rc=1`** |
| coverage | пустая база | `rc=0` «0 threshold(s)» | **`rc=1`** |
| coverage | конфиг выпал из базы | `rc=0` «8 threshold(s)» | **`rc=1`** |
| docs | пустой корпус | `rc=0` «Found 0» | **`rc=1`** |
| docs | экстрактор слеп | `rc=0` «Found 0» | **`rc=1`** |

⛤ И **заперто тестами**: весь build-набор, прогнанный против скриптов `origin/main`, даёт **10 RED / 10 GREEN**; на этом дереве — **20/20**. Без тестов полы можно снять и ничто не покраснеет — ровно то состояние, в котором гейты были до этой правки.

⚠ Существующему overmock-тесту понадобился `BASELINE_SCANNED`, соразмерный его фикстуре: горстка файлов неотличима от обвала, пока ожидаемый размер не объявлен. ⛔ Намеренно **не** решено пропуском пола при заданном `ANTIPATTERN_SCAN_DIR` — это сделало бы пол отключаемым переменной окружения.

## Состояние

Все семь гейтов `lint` зелены на этом дереве (`cli-types` и `test-types` требуют собранных workspace-зависимостей — после `npm run build` зелены; 9 локальных «новых» пар были `TS2307: nanotar`, отсутствующий в моей копии `node_modules`, в CI резолвится).

⛤ Побочное наблюдение, **не** чинится здесь: guard окружения в `check-test-types.mjs` покрывает только bare `@kitelev/exocortex-*`, поэтому отсутствующая **сторонняя** зависимость записалась бы в базу как долг при `--update`. В CI (`npm ci`) это невозможно; дискриминатор при желании выводим (bare-спецификатор, присутствующий в `package.json` = окружение; отсутствующий = долг).

## Вторая половина #4090 остаётся открытой

Конверсия баз anti-pattern со **счётчиков** на наборы `(file, pattern)`-пар — счётчик удовлетворяется **свопом** (починил одно вхождение, добавил другое — по-прежнему 55). Это смена формата базы и отдельный риск, поэтому отдельная правка.
