### PR TITLE
fix(cli): expand backslash-n for --body only, never for --body-file or stdin

### DIFF
--- a/packages/cli/src/commands/create.ts
+++ b/packages/cli/src/commands/create.ts
@@ -192,22 +192,24 @@ function parseProperties(
  *
  * @returns Body content string, or undefined if no body source specified
  */
-async function resolveBody(options: CreateCommandOptions): Promise<string | undefined> {
+async function resolveBody(
+  options: CreateCommandOptions,
+): Promise<{ text: string; source: "file" | "stdin" | "inline" } | undefined> {
   // --body-file takes precedence if both specified
   if (options.bodyFile) {
     if (!existsSync(options.bodyFile)) {
       throw new Error(`Body file not found: ${options.bodyFile}`);
     }
-    return readFileSync(options.bodyFile, "utf-8");
+    return { text: readFileSync(options.bodyFile, "utf-8"), source: "file" };
   }
 
   if (options.body === "-") {
     // Read from stdin with timeout
-    return readStdin(30_000);
+    return { text: await readStdin(30_000), source: "stdin" };
   }
 
   if (options.body) {
-    return options.body;
+    return { text: options.body, source: "inline" };
   }
 
   return undefined;
@@ -336,9 +338,17 @@ export function createCommand(): Command {
         const propertyNameValidator = new PropertyNameValidator(vaultPath);
         await propertyNameValidator.validate(Object.keys(properties));
 
-        // Resolve body content and parse escape sequences
-        let body = await resolveBody(options);
-        if (body) {
+        // Resolve body content. `\n` escapes are expanded ONLY for the inline
+        // `--body "a\nb"` form — that is exactly what issue #2288 asked for ("Given
+        // --body \"Line1\\n\\nLine2\"), because a single shell argument cannot carry a
+        // real newline.
+        //
+        // ⛔ NOT for --body-file or stdin: those already carry real newlines, so a
+        // backslash-n in them is authored text (a regex, a Windows path) and expanding
+        // it silently corrupts the document.
+        const resolvedBody = await resolveBody(options);
+        let body = resolvedBody?.text;
+        if (body !== undefined && resolvedBody?.source === "inline") {
           body = body.replace(/\\n/g, "\n");
         }
 

--- a/packages/cli/src/commands/set-body.ts
+++ b/packages/cli/src/commands/set-body.ts
@@ -42,24 +42,32 @@ function readStdin(timeoutMs: number): Promise<string> {
 }
 
 /**
+ * Where the body text came from. Returned ALONGSIDE the text because the caller
+ * must treat the three sources differently and cannot re-derive this safely:
+ * only the `inline` form needs `\n` escapes expanded (issue #2288), and doing it
+ * to the other two silently CORRUPTS prose — see the call site.
+ */
+type BodySource = "file" | "stdin" | "inline";
+
+/**
  * Resolve the new body content from `--body-file` / `--body` / `--body -`
  * (stdin). `--body-file` takes precedence. Returns undefined when neither is
  * given (the caller rejects that).
  */
 async function resolveNewBody(
   options: SetBodyOptions,
-): Promise<string | undefined> {
+): Promise<{ text: string; source: BodySource } | undefined> {
   if (options.bodyFile) {
     if (!existsSync(options.bodyFile)) {
       throw new Error(`Body file not found: ${options.bodyFile}`);
     }
-    return readFileSync(options.bodyFile, "utf-8");
+    return { text: readFileSync(options.bodyFile, "utf-8"), source: "file" };
   }
   if (options.body === "-") {
-    return readStdin(30_000);
+    return { text: await readStdin(30_000), source: "stdin" };
   }
   if (options.body !== undefined) {
-    return options.body;
+    return { text: options.body, source: "inline" };
   }
   return undefined;
 }
@@ -161,9 +169,21 @@ export function setBodyCommand(): Command {
         // FRONTMATTER_REGEX's match: `---\n<yaml>\n---`).
         const frontmatterBlock = `---\n${parsed.content}\n---`;
 
-        // Resolve + normalise the new body (parse `\n` escapes like create).
-        let newBody = (await resolveNewBody(options)) ?? "";
-        newBody = newBody.replace(/\\n/g, "\n");
+        // Resolve the new body. `\n` escapes are expanded ONLY for the inline
+        // `--body "a\nb"` form, which is what issue #2288 asked for: a single shell
+        // argument has no way to carry a real newline.
+        //
+        // ⛔ NOT for --body-file or stdin. Those already carry real newlines, so any
+        // backslash-n in them is text the author typed — a regex in prose, a Windows
+        // path. Expanding it silently CORRUPTS the document and nothing reports it:
+        // measured on a 2-line body containing `\n` and `C:\new`, the write produced
+        // 4 lines and 0 backslashes. This code expanded unconditionally because the
+        // call site could not see the source; the resolver now returns it.
+        const resolved = await resolveNewBody(options);
+        let newBody = resolved?.text ?? "";
+        if (resolved?.source === "inline") {
+          newBody = newBody.replace(/\\n/g, "\n");
+        }
 
         // Validate wikilinks in the NEW body (the CLI/Bash write bypasses the
         // PreToolUse validate-wikilinks hook — validate here like create /

--- a/packages/cli/tests/integration/create-body-escapes.integration.test.ts
+++ b/packages/cli/tests/integration/create-body-escapes.integration.test.ts
@@ -1,0 +1,138 @@
+/**
+ * `cli create` must expand a backslash-n escape ONLY for the inline `--body "a\nb"`
+ * form, never for `--body-file`.
+ *
+ * Issue #2288 introduced the expansion, and its acceptance criterion names the inline
+ * form explicitly ("Given --body \"Line1\\n\\nLine2\""): a single shell argument has no
+ * way to carry a real newline. The implementation applied it to the RESOLVED body
+ * regardless of where that body came from, so a file — which already carries real
+ * newlines — had its authored backslash sequences rewritten too. `set-body` then
+ * copied the behaviour verbatim ("parse \n escapes like create").
+ *
+ * The damage is silent and looks like nothing: measured on a 2-line body containing
+ * a regex in prose and a Windows path, the write produced 4 lines and 0 backslashes.
+ * Nothing validates it, so the corruption reaches the vault and the author discovers
+ * it later, in a document that no longer says what they wrote.
+ *
+ * Revert-verify (~/dotfiles/.claude/rules/integration-test-revert-verify.md): drop the
+ * `source === "inline"` condition in create.ts so the expansion is unconditional again
+ * → the --body-file axis goes RED while the inline axis stays GREEN. Remove the
+ * expansion entirely → the inline axis goes RED and the file axis stays GREEN. The two
+ * axes therefore pin the DISCRIMINATOR, not merely the presence of an expansion.
+ */
+import { jest, describe, it, expect, beforeEach, afterEach } from "@jest/globals";
+import * as fs from "fs";
+import * as path from "path";
+import * as os from "os";
+
+const { createCommand } = await import("../../src/commands/create.js");
+
+const TASK_CLASS_UID = "1b20a8f0-d745-4e93-91db-4531b3df120e";
+const EFFORT_CLASS_UID = "086f71fa-dd30-4284-90cf-e609f2a6c461";
+const BACKLOG_UID = "753a44d5-846c-4b82-9196-4fd9a4d48777";
+const EXOASSISTANT_UID = "4ef3962d-b8a7-42b5-bd28-88ec846f1d13";
+const EMS_DIR = "assetspaces/kitelev/exoas-public/ems";
+
+function md(frontmatter: Record<string, string | string[]>): string {
+  const lines = ["---"];
+  for (const [k, v] of Object.entries(frontmatter)) {
+    if (Array.isArray(v)) {
+      lines.push(`${k}:`);
+      for (const item of v) lines.push(`  - "${item}"`);
+    } else lines.push(`${k}: ${v}`);
+  }
+  lines.push("---", "");
+  return lines.join("\n");
+}
+
+describe("cli create — backslash-n is expanded for --body only, never for --body-file", () => {
+  let vault: string;
+  let exitSpy: ReturnType<typeof jest.spyOn>;
+  let stdoutSpy: ReturnType<typeof jest.spyOn>;
+  let logSpy: ReturnType<typeof jest.spyOn>;
+  let stdoutChunks: string[];
+
+  beforeEach(() => {
+    vault = fs.mkdtempSync(path.join(os.tmpdir(), "cli-body-escapes-"));
+    const emsDir = path.join(vault, EMS_DIR);
+    fs.mkdirSync(emsDir, { recursive: true });
+    // The class chain create walks to decide the status default, plus the enum it
+    // resolves to. Without these create errors out and (process.exit being mocked)
+    // simply writes nothing — which reads as "the assertion is wrong", not "the
+    // fixture is short".
+    fs.writeFileSync(
+      path.join(emsDir, `${EFFORT_CLASS_UID}.md`),
+      md({ exo__Asset_uid: EFFORT_CLASS_UID, exo__Asset_label: "ems__Effort" }),
+    );
+    fs.writeFileSync(
+      path.join(emsDir, `${TASK_CLASS_UID}.md`),
+      md({
+        exo__Asset_uid: TASK_CLASS_UID,
+        exo__Asset_label: "ems__Task",
+        exo__Class_superClass: [`[[${EFFORT_CLASS_UID}]]`],
+      }),
+    );
+    fs.writeFileSync(
+      path.join(emsDir, `${BACKLOG_UID}.md`),
+      md({ exo__Asset_uid: BACKLOG_UID, exo__Asset_label: "ems__EffortStatusBacklog" }),
+    );
+    fs.writeFileSync(
+      path.join(emsDir, `${EXOASSISTANT_UID}.md`),
+      md({ exo__Asset_uid: EXOASSISTANT_UID, exo__Asset_label: "ExoAssistant" }),
+    );
+    fs.mkdirSync(path.join(vault, "01 Inbox"), { recursive: true });
+
+    stdoutChunks = [];
+    exitSpy = jest
+      .spyOn(process, "exit")
+      .mockImplementation((() => undefined as never) as never);
+    stdoutSpy = jest
+      .spyOn(process.stdout, "write")
+      .mockImplementation(((chunk: unknown) => {
+        stdoutChunks.push(String(chunk));
+        return true;
+      }) as never);
+    logSpy = jest.spyOn(console, "log").mockImplementation((...args: unknown[]) => {
+      stdoutChunks.push(args.map(String).join(" "));
+    });
+  });
+
+  afterEach(() => {
+    exitSpy.mockRestore();
+    stdoutSpy.mockRestore();
+    logSpy.mockRestore();
+    fs.rmSync(vault, { recursive: true, force: true });
+  });
+
+  /** Run the REAL create command via commander and return the BODY it wrote. */
+  const runCreate = async (extra: string[]): Promise<string> => {
+    const cmd = createCommand();
+    await cmd.parseAsync(
+      ["--vault", vault, "--class", TASK_CLASS_UID, "--label", "escape probe", ...extra],
+      { from: "user" },
+    );
+    const inbox = path.join(vault, "01 Inbox");
+    const written = fs.readdirSync(inbox).filter((f) => f.endsWith(".md"));
+    expect(written).toHaveLength(1);
+    return fs.readFileSync(path.join(inbox, written[0]), "utf-8").split("---")[2];
+  };
+
+  it("preserves a literal backslash-n from --body-file (authored prose, not an escape)", async () => {
+    const bodyFile = path.join(vault, "literal-escapes.md");
+    fs.writeFileSync(bodyFile, "regex `\\n` and path C:\\new\nsecond line\n");
+
+    const body = await runCreate(["--body-file", bodyFile]);
+
+    expect(body).toContain("C:\\new");
+    expect(body).toContain("`\\n`");
+    // 4 lines here would mean the two sequences were expanded.
+    expect(body.trim().split("\n")).toHaveLength(2);
+  });
+
+  it("still expands backslash-n for the inline --body form (issue #2288 AC)", async () => {
+    const body = await runCreate(["--body", "Line1\\nLine2"]);
+
+    expect(body.trim().split("\n")).toHaveLength(2);
+    expect(body).not.toContain("Line1\\nLine2");
+  });
+});

--- a/packages/cli/tests/integration/set-body.integration.test.ts
+++ b/packages/cli/tests/integration/set-body.integration.test.ts
@@ -210,6 +210,38 @@ describe("Issue #3943: `cli set-body` overwrites the markdown body of an existin
     expect(echo.bodyBytes).not.toBe(asCodeUnits);
   });
 
+  // ⛔ A literal backslash-n in a FILE body is authored text — a regex in prose, a
+  // Windows path — not an escape to expand. Expanding it silently corrupts the
+  // document: measured on this very fixture, the pre-fix write produced 4 lines and
+  // 0 backslashes from 2 lines and 2 backslashes, and nothing reported it.
+  it("preserves a literal backslash-n from --body-file @req:664123d3-5b91-4793-8085-485d48471546", async () => {
+    const bodyFile = path.join(vault, "literal-escapes.md");
+    fs.writeFileSync(bodyFile, "regex `\\n` and path C:\\new\nsecond line\n");
+
+    const out = await runSetBody(taskPath, ["--body-file", bodyFile]);
+
+    expect(out.exit).toContain(0);
+    const body = out.content.split("---")[2];
+    // The two backslash sequences survive verbatim...
+    expect(body).toContain("C:\\new");
+    expect(body).toContain("`\\n`");
+    // ...and the file's real line count is unchanged (4 lines here means expansion).
+    expect(body.trim().split("\n")).toHaveLength(2);
+  });
+
+  // The paired axis, and the one that stops the fix from over-reaching: issue #2288
+  // asked for exactly this — a single shell argument cannot carry a real newline, so
+  // the INLINE form must keep expanding. Drop the `source === "inline"` branch and
+  // this goes RED while the axis above stays green.
+  it("still expands backslash-n for the INLINE --body form (issue #2288) @req:664123d3-5b91-4793-8085-485d48471546", async () => {
+    const out = await runSetBody(taskPath, ["--body", "Line1\\nLine2"]);
+
+    expect(out.exit).toContain(0);
+    const body = out.content.split("---")[2];
+    expect(body.trim().split("\n")).toHaveLength(2);
+    expect(body).not.toContain("Line1\\nLine2");
+  });
+
   it("--dry-run previews the result without writing @req:664123d3-5b91-4793-8085-485d48471546", async () => {
     const out = await runSetBody(taskPath, [
       "--body",


### PR DESCRIPTION
## Measured

Body file with a regex in prose and a Windows path:

| | строк | обратных слэшей |
|---|---|---|
| input file | 2 | 2 |
| written asset (`16.224.7`) | **4** | **0** |

`` `\n` `` became a real newline, `C:\new` became `C:` + newline + `ew`. Silent — nothing validates it, so it lands in the vault and is found later in a document that no longer says what was written.

## Why it exists

#2288 asked for the expansion and its AC names the **inline** form: *"Given `--body \"Line1\\n\\nLine2\"`"*. A single shell argument cannot carry a real newline. The implementation applied `replace(/\\n/g, "\n")` to the resolved body regardless of source; `set-body` copied it (*"parse `\n` escapes like create"*).

## Fix

Each resolver now returns `{ text, source }` with `source: "file" | "stdin" | "inline"`, and only `inline` is expanded. Deciding at the call site is what produced the bug — it could not see the source. **#2288 is preserved.**

## Revert-verify

Two mutants redden **opposite** pairs, so the axes pin the discriminator, not the presence of an expansion:

| state | red |
|---|---|
| control | 0 / 10 |
| expansion unconditional again (pre-fix) | both `--body-file` axes |
| expansion removed entirely | both inline axes (#2288) |

Closes #4095

https://claude.ai/code/session_012vsjb4Je8ae7m4KYYn3WFt