### PR TITLE
fix(core): skip the PropertyDefault entry only for STRING-valued properties

### DIFF
--- a/packages/core/src/services/CommandResolver.ts
+++ b/packages/core/src/services/CommandResolver.ts
@@ -2,6 +2,7 @@ import { injectable } from "tsyringe";
 import type { ITripleStore } from "../interfaces/ITripleStore";
 import type { ILogger } from "../interfaces/ILogger";
 import { NullLogger } from "../infrastructure/NullLogger";
+import { STRING_SCALAR_PROPERTIES } from "../utilities/yamlScalar";
 import { IRI } from "../domain/models/rdf/IRI";
 import { Literal } from "../domain/models/rdf/Literal";
 import { Namespace } from "../domain/models/rdf/Namespace";
@@ -2766,27 +2767,35 @@ export class CommandResolver {
           ),
         );
       }
-      // ⛔ SKIP the entry — do NOT write a link into a VALUE slot.
+      // ⛔ SKIP the entry ONLY for a property whose value is a STRING.
       //
-      // This branch used to `return "[[<uid>]]"`, and its own warning said what was
-      // wrong with that: "emitting wikilink (a link, not the substituted value)".
-      // A link in exo__Asset_label is never a valid outcome — it is silent, it reaches
-      // the vault, and the user's typed string survives only in `aliases`.
+      // This branch used to `return "[[<uid>]]"` unconditionally, and its own warning
+      // said what was wrong with that: "a link, not the substituted value". But the
+      // branch serves TWO cases that are indistinguishable once the asset is missing
+      // from the store:
       //
-      // `null` is this function's OWN documented signal for "skip this entry" (see the
-      // docstring), and the caller already honours it with `continue`. So the property
-      // is simply not set, and GroundingExecutor's existing degradation chain takes
-      // over — `labelTemplate` if the grounding declares one, else "Untitled". That
-      // path is built and tested; the wikilink fallback was bypassing it.
+      //   • value is a SubstitutionToken  → the link points at a TOKEN DEFINITION and
+      //     is garbage: the user's typed string survives only in `aliases`.
+      //   • value is a plain asset ref (a status enum, a class, a person)
+      //     → the link IS the value, and emitting it is correct.
       //
-      // ⚠ The causal link to the four corrupted assets (defect 0310aa28) remains
-      // narrowed by ELIMINATION, not measured — reproducing it needs a store missing
-      // the token on the creating device. The change does not rest on that: writing a
-      // link where a value belongs is wrong on this function's own contract.
+      // A first attempt skipped both and broke the second: two integration axes
+      // (req 2d1ffced, req 87361a62) lost `ems__Effort_status: "[[753a44d5-…]]"` on the
+      // spawned iteration. So the discriminator cannot be store presence — it has to be
+      // the TARGET PROPERTY.
       //
-      // ⛤ NOT touched: the non-UUID (legacy symbolic) pass-through above, where a
-      // wikilink IS the intended value.
-      return null;
+      // `STRING_SCALAR_PROPERTIES` (exo__Asset_label, aliases) is exactly the set whose
+      // value is a name, never a reference. A wikilink there is wrong under any origin,
+      // so skipping is safe: GroundingExecutor's existing chain takes over
+      // (`labelTemplate` → "Untitled"), a path that is built and tested and which this
+      // fallback was bypassing. Object-valued properties keep the old behaviour.
+      //
+      // ⚠ The causal link to the four corrupted assets (defect 0310aa28 / issue #4097)
+      // stays narrowed by ELIMINATION, not measured.
+      if (STRING_SCALAR_PROPERTIES.has(propertyName)) {
+        return null;
+      }
+      return `"[[${valueRefUid}]]"`;
     }
 
     // RFC 727572d2 — TokenInvocation wrapper detection. When the value asset

--- a/packages/core/src/services/CommandResolver.ts
+++ b/packages/core/src/services/CommandResolver.ts
@@ -2762,11 +2762,31 @@ export class CommandResolver {
         this._fallbackWarnedKeys.add(fallbackKey);
         this.logger.warn(
           this.capWarning(
-            `Grounding ${groundingUid}: PropertyDefault '${propertyName}' → value asset ${valueRefUid} not in store; emitting wikilink (a link, not the substituted value).`,
+            `Grounding ${groundingUid}: PropertyDefault '${propertyName}' → value asset ${valueRefUid} not in store; SKIPPING the property (the executor's own default applies). Previously this emitted a wikilink, i.e. a link written where a value belongs.`,
           ),
         );
       }
-      return `"[[${valueRefUid}]]"`;
+      // ⛔ SKIP the entry — do NOT write a link into a VALUE slot.
+      //
+      // This branch used to `return "[[<uid>]]"`, and its own warning said what was
+      // wrong with that: "emitting wikilink (a link, not the substituted value)".
+      // A link in exo__Asset_label is never a valid outcome — it is silent, it reaches
+      // the vault, and the user's typed string survives only in `aliases`.
+      //
+      // `null` is this function's OWN documented signal for "skip this entry" (see the
+      // docstring), and the caller already honours it with `continue`. So the property
+      // is simply not set, and GroundingExecutor's existing degradation chain takes
+      // over — `labelTemplate` if the grounding declares one, else "Untitled". That
+      // path is built and tested; the wikilink fallback was bypassing it.
+      //
+      // ⚠ The causal link to the four corrupted assets (defect 0310aa28) remains
+      // narrowed by ELIMINATION, not measured — reproducing it needs a store missing
+      // the token on the creating device. The change does not rest on that: writing a
+      // link where a value belongs is wrong on this function's own contract.
+      //
+      // ⛤ NOT touched: the non-UUID (legacy symbolic) pass-through above, where a
+      // wikilink IS the intended value.
+      return null;
     }
 
     // RFC 727572d2 — TokenInvocation wrapper detection. When the value asset

--- a/packages/core/tests/unit/services/CommandResolver.substitutionToken.test.ts
+++ b/packages/core/tests/unit/services/CommandResolver.substitutionToken.test.ts
@@ -636,18 +636,12 @@ describe("CommandResolver — RFC v2 Phase 3a SubstitutionToken dispatch", () =>
 
     const cmd = await resolver.loadCommand(COMMAND_UID);
 
-    // ⛔ The entry is SKIPPED, not baked as a wikilink. The comment above still
-    // describes the damage this used to cause ("poisoning every instance created in
-    // that session") — that is exactly what stopped: a link written where a value
-    // belongs never reaches the vault, and GroundingExecutor's own degradation chain
-    // (labelTemplate → "Untitled") takes over.
-    //
-    // The req's deliverable — the warning — is unchanged and still asserted below.
-    expect(
-      (cmd!.grounding.propertyDefault ?? []).some(
-        (pd) => pd.value === `"[[${TOKEN_ABSENT_UID}]]"`,
-      ),
-    ).toBe(false);
+    // ⛤ PROP_UID is `ems__Effort_plannedStartTimestamp` — an OBJECT-valued property,
+    // where `"[[<uid>]]"` IS the value. The wikilink is correct here and must survive;
+    // the paired axis below covers the string-valued case where it is not.
+    expect(cmd!.grounding.propertyDefault![0].value).toBe(
+      `"[[${TOKEN_ABSENT_UID}]]"`,
+    );
     // The warning is the whole deliverable: it must name the value uid (what
     // to look for), the property (where the damage lands) and the grounding
     // (which command) — enough to identify the case without a repro.
@@ -658,6 +652,44 @@ describe("CommandResolver — RFC v2 Phase 3a SubstitutionToken dispatch", () =>
     // The user-facing string must NOT assert a cause the PR itself calls
     // unmeasured — candidate causes live in the code comment.
     expect(hit).not.toMatch(/cold-start|pruned vault/);
+  });
+
+  // ⛔ The discriminator is the TARGET PROPERTY, not store presence. An earlier attempt
+  // skipped the entry whenever the value asset was missing and broke the object case:
+  // two integration axes (req 2d1ffced, req 87361a62) lost `ems__Effort_status` on the
+  // spawned iteration, because for a status enum the link IS the value.
+  //
+  // `exo__Asset_label` is in STRING_SCALAR_PROPERTIES: its value is a NAME, never a
+  // reference, so a wikilink there is wrong under any origin — and that is the shape
+  // observed in defect 0310aa28 (label holding a link to the token definition while the
+  // user's typed string survived only in `aliases`).
+  it("@req:b354316b-3b26-478b-a8c0-18606da8e6ec SKIPS the entry — never writes a link — when the absent value targets a string-valued property", async () => {
+    const LABEL_PROP_UID = "22222222-2222-4222-8222-222222222222";
+    await addLabelledAsset(store, LABEL_PROP_UID, "exo__Asset_label");
+    expect(await store.findSubjectsByUUID(TOKEN_ABSENT_UID)).toHaveLength(0);
+    await addPropertyDefault(store, {
+      uid: PD_UID,
+      propertyRefUid: LABEL_PROP_UID,
+      valueRefUid: TOKEN_ABSENT_UID,
+    });
+    await addGrounding(store, {
+      uid: GROUNDING_UID,
+      label: "Grounding whose label token is not in the store",
+      propertyDefaultRefs: [PD_UID],
+    });
+    await addCommand(store, COMMAND_UID, GROUNDING_UID);
+
+    const cmd = await resolver.loadCommand(COMMAND_UID);
+
+    // No entry at all — GroundingExecutor's own chain (labelTemplate → "Untitled")
+    // takes over, instead of a link reaching the vault as the asset's name.
+    expect(
+      (cmd!.grounding.propertyDefault ?? []).some(
+        (pd) => pd.value === `"[[${TOKEN_ABSENT_UID}]]"`,
+      ),
+    ).toBe(false);
+    // The warning still fires — it is the req's deliverable.
+    expect(logger.warnings.find((w) => w.includes(TOKEN_ABSENT_UID))).toBeDefined();
   });
 
   it("@req:b354316b-3b26-478b-a8c0-18606da8e6ec warns ONCE per (grounding, value) across repeated resolves", async () => {

--- a/packages/core/tests/unit/services/CommandResolver.substitutionToken.test.ts
+++ b/packages/core/tests/unit/services/CommandResolver.substitutionToken.test.ts
@@ -636,9 +636,18 @@ describe("CommandResolver — RFC v2 Phase 3a SubstitutionToken dispatch", () =>
 
     const cmd = await resolver.loadCommand(COMMAND_UID);
 
-    expect(cmd!.grounding.propertyDefault![0].value).toBe(
-      `"[[${TOKEN_ABSENT_UID}]]"`,
-    );
+    // ⛔ The entry is SKIPPED, not baked as a wikilink. The comment above still
+    // describes the damage this used to cause ("poisoning every instance created in
+    // that session") — that is exactly what stopped: a link written where a value
+    // belongs never reaches the vault, and GroundingExecutor's own degradation chain
+    // (labelTemplate → "Untitled") takes over.
+    //
+    // The req's deliverable — the warning — is unchanged and still asserted below.
+    expect(
+      (cmd!.grounding.propertyDefault ?? []).some(
+        (pd) => pd.value === `"[[${TOKEN_ABSENT_UID}]]"`,
+      ),
+    ).toBe(false);
     // The warning is the whole deliverable: it must name the value uid (what
     // to look for), the property (where the damage lands) and the grounding
     // (which command) — enough to identify the case without a repro.


### PR DESCRIPTION
When the value asset of a `PropertyDefault_value` ref is not in the store, `resolvePropertyDefaultValue` emitted `"[[<uid>]]"`. For `exo__Asset_label` that writes a **link where a name belongs**: the created asset is labelled with a reference to the token definition while the user's typed string survives only in `aliases` — the shape observed in #4097.

## ⛔ CI falsified the first version, and the history keeps it

The first commit skipped the entry **whenever** the value asset was missing. Two integration axes (`req 2d1ffced`, `req 87361a62`) lost `ems__Effort_status: "[[753a44d5-…]]"` on the spawned iteration.

The branch serves two cases that are indistinguishable once the asset is gone:

| value asset | the wikilink is |
|---|---|
| a `SubstitutionToken` | ⛔ a link to a **token definition** — garbage |
| a plain asset ref (status enum, class, person) | ✅ **the value itself** |

⇒ store presence cannot be the discriminator.

## The discriminator is the TARGET PROPERTY

`STRING_SCALAR_PROPERTIES` = `{ exo__Asset_label, aliases }` — exactly the set whose value is a **name**, never a reference. It already exists in core (`GroundingExecutor` imports it), so this is an established concept rather than one invented for the fix. Skipping there is safe under any origin; object-valued properties are untouched.

With the entry skipped, `GroundingExecutor`'s existing chain takes over — `labelTemplate` → `"Untitled"` — a path that is built and tested and which the fallback was bypassing. `null` is the function's own documented "skip this entry" signal and the caller already honours it.

## Revert-verify — two OPPOSITE mutants, each reddening exactly one axis

| mutant | red |
|---|---|
| skip always (the falsified form) | the **object** axis — and, per CI, both integration axes |
| never skip (pre-fix) | the **string** axis |
| control | 0 / 492 across 29 suites |

Both integration axes now run locally too; the earlier run missed them because the test-path pattern did not match their filenames.

## Honest bound

The causal link to the four corrupted assets stays narrowed by **elimination, not measured** — reproducing needs a store missing the token on the creating device. Two rival hypotheses were falsified first: a swapped value-source pair (there is only ONE value) and an unmounted exocmd TBox (token, class and PropertyDefault share one assetspace, and the button rendered).

Closes #4097

https://claude.ai/code/session_012vsjb4Je8ae7m4KYYn3WFt