### PR TITLE
fix(cli): derive the guard message from a machine-readable routing table (#8f35fec0)

### DIFF
--- a/packages/cli/src/commands/propertyMutationShared.ts
+++ b/packages/cli/src/commands/propertyMutationShared.ts
@@ -46,38 +46,157 @@ export { canonicalYamlKey };
  * user-supplied property name like `toString` / `constructor` never matches an
  * inherited Object.prototype key (#3795 review M2).
  */
-export const GUARDED_PROPERTIES: Record<string, string> = {
+/**
+ * A guarded property's ROUTE: the cliNames of the dedicated `exocmd__Command`s
+ * that own it, plus optional prose. This is the MACHINE-READABLE half — the
+ * human message in {@link GUARDED_PROPERTIES} is DERIVED from it.
+ *
+ * ⛤ Why a structure and not a hand-authored sentence: the message is a CLAIM
+ * about which commands exist. When it was authored as free prose it drifted —
+ * three of its names (`remove-start-timestamp`, `remove-end-timestamp`,
+ * `archive-completed`) never existed in any live registry, so the guard refused
+ * the mutation and then pointed the user at a command that does not resolve.
+ * `remove-start-timestamp` exists only as an e2e TEST FIXTURE
+ * (`tests/e2e/test-vault/03 Knowledge/commands/cmd-remove-start-timestamp.md`),
+ * which is where the false name came from. Deriving the sentence from this array
+ * makes "the message names a command not listed here" impossible by construction.
+ *
+ * ⛔ The rendered sentence is ALSO the INPUT of `ErrorHandler.classifyError`,
+ * which picks the process exit code by SUBSTRING (`transition` → 6,
+ * `transaction` → 7, `concurrent`/`modified` → 8, `not found` → 4, `Invalid` →
+ * 2, …). So a word chosen for readability silently changes the exit code a
+ * scripted consumer branches on — an early draft of the timestamp notes said
+ * "as a transition side effect" and turned the refusal from 1 into 6. The
+ * `guard messages do not collide with the exit-code classifier` axis in
+ * `tests/unit/guardedRoutes.test.ts` locks this.
+ *
+ * ⛔ It does NOT make "a listed cliName exists in the user's vault" checkable in
+ * CI: the command registry is split across assetspaces and exocortex pins only
+ * `exoas-exocmd` — `archive`, `set-criticality-*`, `set-planned-*` live in the
+ * UNPINNED `exoas-public`. Verifying existence needs the live vault, which the
+ * commands do have at refusal time; that is a separate follow-up.
+ */
+export interface GuardedRoute {
+  /** cliNames of the dedicated commands, in the order to present them. */
+  readonly commands: readonly string[];
+  /** Rendered after `<path>` (e.g. a required `--input` payload). */
+  readonly argSuffix?: string;
+  /** Rendered in parentheses after the invocation. */
+  readonly note?: string;
+}
+
+/**
+ * Machine-readable routing table — see {@link GuardedRoute}.
+ *
+ * Every cliName here was verified against the live registry on 2026-08-19
+ * (76 `exocmd__Command_cliName` across the mounted assetspaces).
+ */
+export const GUARDED_ROUTES: Record<string, GuardedRoute> = {
   // Status state machine (transitions carry preconditions).
-  ems__Effort_status:
-    "apply mark-done|move-to-backlog|rollback-to-backlog|start-effort|set-draft-status <path>",
+  ems__Effort_status: {
+    commands: [
+      "mark-done",
+      "move-to-backlog",
+      "rollback-to-backlog",
+      "start-effort",
+      "set-draft-status",
+    ],
+  },
   // Criticality zone (not-a-prototype precondition guard).
-  ems__Task_zone: "apply set-criticality-high|medium|low <path>",
+  ems__Task_zone: {
+    commands: [
+      "set-criticality-high",
+      "set-criticality-medium",
+      "set-criticality-low",
+    ],
+  },
   // Parent / label — dedicated guarded commands (#3779).
-  ems__Effort_parent: 'apply set-parent <path> --input \'{"parent":"<uid>"}\'',
-  exo__Asset_label: 'apply set-label <path> --input \'{"label":"<text>"}\'',
+  ems__Effort_parent: {
+    commands: ["set-parent"],
+    argSuffix: `--input '{"parent":"<uid>"}'`,
+  },
+  exo__Asset_label: {
+    commands: ["set-label"],
+    argSuffix: `--input '{"label":"<text>"}'`,
+  },
   // Reclassing — dedicated Convert commands (raw set desyncs class vs co-location).
-  exo__Instance_class:
-    "apply convert-to-task|convert-to-project <path>  (reclassing is a semantic operation with a precondition)",
+  exo__Instance_class: {
+    commands: ["convert-to-task", "convert-to-project"],
+    note: "reclassing is a semantic operation with a precondition",
+  },
   // Status-transition FACT timestamps (set only as status-transition side effects).
-  ems__Effort_startTimestamp:
-    "apply start-effort <path>  (or apply remove-start-timestamp <path>)",
-  ems__Effort_endTimestamp:
-    "apply mark-done <path>  (or apply remove-end-timestamp <path>)",
-  ems__Effort_resolutionTimestamp: "apply mark-done <path>",
+  //
+  // ⛤ There is no standalone "remove the timestamp" command — CLEARING it is a
+  // side effect of a workflow transition (`ems__WorkflowTransition_postActions`),
+  // so the commands below both SET and CLEAR depending on direction.
+  ems__Effort_startTimestamp: {
+    commands: ["start-effort", "rollback-to-backlog", "park-waiting"],
+    note: "start-effort sets it; the others clear it as a side effect of the status change",
+  },
+  ems__Effort_endTimestamp: {
+    commands: ["mark-done", "re-open"],
+    note: "mark-done sets it; re-open clears it as a side effect of the status change",
+  },
+  ems__Effort_resolutionTimestamp: { commands: ["mark-done"] },
   // Plan / schedule dates — dedicated commands.
-  ems__Effort_plannedStartTimestamp:
-    "apply set-planned-start|plan-on-today|plan-for-evening|shift-day-forward|shift-day-backward <path>",
-  ems__Effort_plannedEndTimestamp: "apply set-planned-end <path>",
-  ems__Effort_scheduledDate: "apply set-scheduled-date <path>",
+  ems__Effort_plannedStartTimestamp: {
+    commands: [
+      "set-planned-start",
+      "plan-on-today",
+      "plan-for-evening",
+      "shift-day-forward",
+      "shift-day-backward",
+    ],
+  },
+  ems__Effort_plannedEndTimestamp: { commands: ["set-planned-end"] },
+  ems__Effort_scheduledDate: { commands: ["set-scheduled-date"] },
   // Votes — dedicated command.
-  ems__Effort_votes: "apply vote-on-effort <path>",
+  ems__Effort_votes: { commands: ["vote-on-effort"] },
   // Archive flag (bare `archived:` in frontmatter; `exo__Asset_archived` when
   // prefixed) — dedicated archive/un-archive commands (un-archive has a Done
   // precondition).
-  archived: "apply archive-completed|archive-ontologically|un-archive <path>",
-  exo__Asset_archived:
-    "apply archive-completed|archive-ontologically|un-archive <path>",
+  archived: { commands: ["archive", "archive-ontologically", "un-archive"] },
+  exo__Asset_archived: {
+    commands: ["archive", "archive-ontologically", "un-archive"],
+  },
 };
+
+/** Render a route as the sentence the guard surfaces to the user. */
+export function renderGuardedRoute(route: GuardedRoute): string {
+  const invocation = `apply ${route.commands.join("|")} <path>`;
+  const withArg = route.argSuffix
+    ? `${invocation} ${route.argSuffix}`
+    : invocation;
+  return route.note ? `${withArg}  (${route.note})` : withArg;
+}
+
+/**
+ * Properties the generic mutation primitives REFUSE because a dedicated guarded
+ * `exocmd__Command` owns them — each enforces a state-machine transition or a
+ * precondition guard, so mutating the property directly would bypass that guard.
+ * The value is the dedicated command to use instead. This is a SUPERSET of the
+ * `dogfood-cli-mutation` hook's routing table: every property that has a
+ * dedicated command is refused here and routed to that command, so the generic
+ * primitives only ever handle the "everything else" class the hook leaves to them.
+ *
+ * ⛤ DERIVED from {@link GUARDED_ROUTES} — do not hand-edit. The shape
+ * (`Record<string, string>`) is unchanged, so every consumer and every existing
+ * assertion keeps working.
+ *
+ * NOT guarded (so the primitives handle them): `exo__Asset_isDefinedBy` (issue
+ * #3848 — set-property allows it with a co-location warning), and any other
+ * scalar / boolean / enum / wikilink property with no dedicated command.
+ *
+ * Looked up via {@link guardedReason} (own-key `hasOwnProperty` check) so a
+ * user-supplied property name like `toString` / `constructor` never matches an
+ * inherited Object.prototype key (#3795 review M2).
+ */
+export const GUARDED_PROPERTIES: Record<string, string> = Object.fromEntries(
+  Object.entries(GUARDED_ROUTES).map(([property, route]) => [
+    property,
+    renderGuardedRoute(route),
+  ]),
+);
 
 /**
  * Properties the generic mutation primitives REFUSE as immutable identity /

--- a/packages/cli/src/commands/propertyMutationShared.ts
+++ b/packages/cli/src/commands/propertyMutationShared.ts
@@ -204,12 +204,18 @@ export const IMMUTABLE_PROPERTIES: Record<string, string> = {
  * Render the refusal a generic mutation primitive surfaces when a property is
  * owned by a dedicated command.
  *
- * ⛤ Shared by BOTH call sites (and by the axis in
+ * ⛤ Shared by both GUARDED-PROPERTY call sites (and by the axis in
  * `tests/unit/guardedRoutes.test.ts`) so the sentence exists in ONE place. It has
  * to: the whole string — wrapper included — is the input of
  * `classifyMessage`, which picks the process exit code by SUBSTRING. When the
  * wrapper was an inline literal per command, a trigger word introduced there was
  * invisible to any test asserting on the routing fragment alone.
+ *
+ * ⚠ Scope: "both call sites" means the two GENERIC mutation primitives. Two other
+ * refusal surfaces share the classifier exposure and are NOT routed through here —
+ * `create.ts`'s self-managed-field guard (a different concern: it guards `create`'s
+ * own fields, not a `GUARDED_ROUTES` route) and the `IMMUTABLE_PROPERTIES` refusals
+ * (a different sentence). The latter IS covered by the axis; the former is not.
  *
  * @param verb - the primitive's own verb, e.g. `set` / `remove`
  * @param command - the CLI name of that primitive, e.g. `set-property`

--- a/packages/cli/src/commands/propertyMutationShared.ts
+++ b/packages/cli/src/commands/propertyMutationShared.ts
@@ -30,23 +30,6 @@ export const UPDATED_AT_KEY = "exo__Asset_updatedAt";
 export { canonicalYamlKey };
 
 /**
- * Properties the generic mutation primitives REFUSE because a dedicated guarded
- * `exocmd__Command` owns them — each enforces a state-machine transition or a
- * precondition guard, so mutating the property directly would bypass that guard.
- * The value is the dedicated command to use instead. This is a SUPERSET of the
- * `dogfood-cli-mutation` hook's routing table: every property that has a
- * dedicated command is refused here and routed to that command, so the generic
- * primitives only ever handle the "everything else" class the hook leaves to them.
- *
- * NOT guarded (so the primitives handle them): `exo__Asset_isDefinedBy` (issue
- * #3848 — set-property allows it with a co-location warning), and any other
- * scalar / boolean / enum / wikilink property with no dedicated command.
- *
- * Looked up via {@link guardedReason} (own-key `hasOwnProperty` check) so a
- * user-supplied property name like `toString` / `constructor` never matches an
- * inherited Object.prototype key (#3795 review M2).
- */
-/**
  * A guarded property's ROUTE: the cliNames of the dedicated `exocmd__Command`s
  * that own it, plus optional prose. This is the MACHINE-READABLE half — the
  * human message in {@link GUARDED_PROPERTIES} is DERIVED from it.
@@ -56,10 +39,16 @@ export { canonicalYamlKey };
  * three of its names (`remove-start-timestamp`, `remove-end-timestamp`,
  * `archive-completed`) never existed in any live registry, so the guard refused
  * the mutation and then pointed the user at a command that does not resolve.
- * `remove-start-timestamp` exists only as an e2e TEST FIXTURE
- * (`tests/e2e/test-vault/03 Knowledge/commands/cmd-remove-start-timestamp.md`),
- * which is where the false name came from. Deriving the sentence from this array
- * makes "the message names a command not listed here" impossible by construction.
+ * ⛤ The three had DIFFERENT causes, and only one was prose-drift:
+ *   `remove-start-timestamp` / `remove-end-timestamp` — never existed anywhere but
+ *     an e2e TEST FIXTURE (`tests/e2e/test-vault/03 Knowledge/commands/
+ *     cmd-remove-start-timestamp.md`), i.e. a fixture name leaked into prose;
+ *   `archive-completed` — WAS a real command, renamed to `archive` upstream. It is
+ *     still PRESENT in the pinned `exoas-exocmd` submodule. So the mechanism there
+ *     is "upstream rename + stale pin", not invention — and that is the cause that
+ *     will recur.
+ * Deriving the sentence from this array makes "the message names a command not
+ * listed here" impossible by construction; it does NOT stop an upstream rename.
  *
  * ⛔ The rendered sentence is ALSO the INPUT of `ErrorHandler.classifyError`,
  * which picks the process exit code by SUBSTRING (`transition` → 6,
@@ -137,7 +126,10 @@ export const GUARDED_ROUTES: Record<string, GuardedRoute> = {
     commands: ["mark-done", "re-open"],
     note: "mark-done sets it; re-open clears it as a side effect of the status change",
   },
-  ems__Effort_resolutionTimestamp: { commands: ["mark-done"] },
+  ems__Effort_resolutionTimestamp: {
+    commands: ["mark-done", "re-open"],
+    note: "mark-done sets it; re-open clears it as a side effect of the status change",
+  },
   // Plan / schedule dates — dedicated commands.
   ems__Effort_plannedStartTimestamp: {
     commands: [
@@ -207,6 +199,33 @@ export const IMMUTABLE_PROPERTIES: Record<string, string> = {
     "the asset identity — changing it breaks UID-canon filenames and every inbound [[uid]] wikilink",
   [UPDATED_AT_KEY]: "auto-managed (bumped on every mutation)",
 };
+
+/**
+ * Render the refusal a generic mutation primitive surfaces when a property is
+ * owned by a dedicated command.
+ *
+ * ⛤ Shared by BOTH call sites (and by the axis in
+ * `tests/unit/guardedRoutes.test.ts`) so the sentence exists in ONE place. It has
+ * to: the whole string — wrapper included — is the input of
+ * `classifyMessage`, which picks the process exit code by SUBSTRING. When the
+ * wrapper was an inline literal per command, a trigger word introduced there was
+ * invisible to any test asserting on the routing fragment alone.
+ *
+ * @param verb - the primitive's own verb, e.g. `set` / `remove`
+ * @param command - the CLI name of that primitive, e.g. `set-property`
+ */
+export function renderGuardRefusal(
+  verb: string,
+  command: string,
+  property: string,
+  routeFragment: string,
+): string {
+  return (
+    `Refusing to ${verb} "${property}" via ${command} — it has a dedicated guarded ` +
+    `command so the state machine / precondition is not bypassed. ` +
+    `Use:  exocortex ${routeFragment} --vault <v>`
+  );
+}
 
 /** Own-key lookup on a denylist that never matches inherited Object.prototype keys. */
 export function guardedReason(

--- a/packages/cli/src/commands/remove-property.ts
+++ b/packages/cli/src/commands/remove-property.ts
@@ -12,6 +12,7 @@ import {
   DEFAULT_TIMEZONE,
   UPDATED_AT_KEY,
   GUARDED_PROPERTIES,
+  renderGuardRefusal,
   IMMUTABLE_PROPERTIES,
   canonicalYamlKey,
   guardedReason,
@@ -53,7 +54,11 @@ function resolveProperty(options: RemovePropertyOptions): string {
       const msg = err instanceof Error ? err.message : String(err);
       throw new Error(`--input: invalid JSON (${msg})`);
     }
-    if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    if (
+      typeof parsed !== "object" ||
+      parsed === null ||
+      Array.isArray(parsed)
+    ) {
       throw new Error(
         `--input must be a JSON object of the form {"property":"<name>"}`,
       );
@@ -182,7 +187,12 @@ export function removePropertyCommand(): Command {
         const guardedCommand = guardedReason(GUARDED_PROPERTIES, property);
         if (guardedCommand !== undefined) {
           throw new Error(
-            `Refusing to remove "${property}" via remove-property — it has a dedicated guarded command so the state machine / precondition is not bypassed. Use:  exocortex ${guardedCommand} --vault <v>`,
+            renderGuardRefusal(
+              "remove",
+              "remove-property",
+              property,
+              guardedCommand,
+            ),
           );
         }
 

--- a/packages/cli/src/commands/set-property.ts
+++ b/packages/cli/src/commands/set-property.ts
@@ -1,11 +1,5 @@
 import { Command } from "commander";
-import {
-  resolve,
-  relative,
-  dirname,
-  isAbsolute,
-  sep as pathSep,
-} from "path";
+import { resolve, relative, dirname, isAbsolute, sep as pathSep } from "path";
 import { existsSync, readFileSync, writeFileSync } from "fs";
 import {
   FrontmatterService,
@@ -25,6 +19,7 @@ import {
   DEFAULT_TIMEZONE,
   UPDATED_AT_KEY,
   GUARDED_PROPERTIES,
+  renderGuardRefusal,
   IMMUTABLE_PROPERTIES,
   canonicalYamlKey,
   guardedReason,
@@ -94,7 +89,11 @@ function resolvePropertyAndValue(options: SetPropertyOptions): {
       const msg = err instanceof Error ? err.message : String(err);
       throw new Error(`--input: invalid JSON (${msg})`);
     }
-    if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    if (
+      typeof parsed !== "object" ||
+      parsed === null ||
+      Array.isArray(parsed)
+    ) {
       throw new Error(
         `--input must be a JSON object of the form {"property":"<name>","value":<v>}`,
       );
@@ -116,7 +115,10 @@ function resolvePropertyAndValue(options: SetPropertyOptions): {
         `--property requires --value (or use --input for a typed/array value)`,
       );
     }
-    return { property: (options.property as string).trim(), value: options.value };
+    return {
+      property: (options.property as string).trim(),
+      value: options.value,
+    };
   }
 
   throw new InvalidArgumentsError(
@@ -257,7 +259,8 @@ export function setPropertyCommand(): Command {
           );
         }
 
-        const { property: rawProperty, value } = resolvePropertyAndValue(options);
+        const { property: rawProperty, value } =
+          resolvePropertyAndValue(options);
         // Normalise a full-IRI-shaped property to prefixed form so the guard
         // denylists (prefixed keys) still match (mirrors executePropertySet).
         const property = FrontmatterService.normalizeIRI(rawProperty);
@@ -272,7 +275,7 @@ export function setPropertyCommand(): Command {
         const guardedCommand = guardedReason(GUARDED_PROPERTIES, property);
         if (guardedCommand !== undefined) {
           throw new Error(
-            `Refusing to set "${property}" via set-property — it has a dedicated guarded command so the state machine / precondition is not bypassed. Use:  exocortex ${guardedCommand} --vault <v>`,
+            renderGuardRefusal("set", "set-property", property, guardedCommand),
           );
         }
 

--- a/packages/cli/src/utils/ErrorHandler.ts
+++ b/packages/cli/src/utils/ErrorHandler.ts
@@ -131,71 +131,7 @@ export class ErrorHandler {
     exitCode: ExitCodes;
     errorCode: ErrorCode;
   } {
-    const message = error.message.toLowerCase();
-
-    // State transition errors (check before "Invalid")
-    if (message.includes("transition")) {
-      return {
-        exitCode: ExitCodes.INVALID_STATE_TRANSITION,
-        errorCode: ErrorCode.STATE_INVALID_TRANSITION,
-      };
-    }
-
-    // Transaction errors (check before generic errors)
-    if (message.includes("transaction")) {
-      return {
-        exitCode: ExitCodes.TRANSACTION_FAILED,
-        errorCode: ErrorCode.INTERNAL_TRANSACTION_FAILED,
-      };
-    }
-
-    // Concurrent modification
-    if (message.includes("concurrent") || message.includes("modified")) {
-      return {
-        exitCode: ExitCodes.CONCURRENT_MODIFICATION,
-        errorCode: ErrorCode.STATE_CONCURRENT_MODIFICATION,
-      };
-    }
-
-    // File not found errors
-    if (
-      error.message.includes("not found") ||
-      error.message.includes("ENOENT")
-    ) {
-      return {
-        exitCode: ExitCodes.FILE_NOT_FOUND,
-        errorCode: ErrorCode.VALIDATION_FILE_NOT_FOUND,
-      };
-    }
-
-    // Permission errors
-    if (
-      error.message.includes("EACCES") ||
-      error.message.includes("permission denied")
-    ) {
-      return {
-        exitCode: ExitCodes.PERMISSION_DENIED,
-        errorCode: ErrorCode.PERMISSION_DENIED,
-      };
-    }
-
-    // Invalid arguments (validation errors) - check last as "Invalid" is broad
-    if (
-      error.message.includes("Invalid") ||
-      error.message.includes("outside vault") ||
-      error.message.includes("Not a")
-    ) {
-      return {
-        exitCode: ExitCodes.INVALID_ARGUMENTS,
-        errorCode: ErrorCode.VALIDATION_INVALID_ARGUMENTS,
-      };
-    }
-
-    // Generic error (catch-all)
-    return {
-      exitCode: ExitCodes.GENERAL_ERROR,
-      errorCode: ErrorCode.INTERNAL_UNKNOWN,
-    };
+    return classifyMessage(error.message);
   }
 
   /**
@@ -216,14 +152,16 @@ export class ErrorHandler {
   /**
    * Gets recovery hint for an error code
    */
-  private static getRecoveryHint(
-    errorCode: ErrorCode,
-  ): { message: string; suggestion?: string } {
+  private static getRecoveryHint(errorCode: ErrorCode): {
+    message: string;
+    suggestion?: string;
+  } {
     switch (errorCode) {
       case ErrorCode.VALIDATION_FILE_NOT_FOUND:
         return {
           message: "Verify the file path is correct and the file exists",
-          suggestion: "Check file path spelling and ensure the file is in the vault",
+          suggestion:
+            "Check file path spelling and ensure the file is in the vault",
         };
 
       case ErrorCode.VALIDATION_VAULT_NOT_FOUND:
@@ -269,4 +207,84 @@ export class ErrorHandler {
         };
     }
   }
+}
+
+/**
+ * Classify an error MESSAGE into its exit code / error code.
+ *
+ * ⛤ Exported as a PURE function so a caller can ask "what exit code will this
+ * message produce?" without constructing an Error and without the process-exiting
+ * side effects of {@link ErrorHandler.handle}. `ErrorHandler.classifyError`
+ * delegates here, so there is ONE implementation, not a copy.
+ *
+ * This matters because classification is by SUBSTRING: a message worded for
+ * readability silently re-routes the exit code a scripted consumer branches on.
+ * The `set-property` / `remove-property` guard sentences are asserted against THIS
+ * function in `tests/unit/guardedRoutes.test.ts` — testing the real mechanism on
+ * the FULL rendered message, rather than a hand-maintained copy of the trigger
+ * list checked against a fragment. A copy can drift; this cannot.
+ */
+export function classifyMessage(raw: string): {
+  exitCode: ExitCodes;
+  errorCode: ErrorCode;
+} {
+  const message = raw.toLowerCase();
+
+  // State transition errors (check before "Invalid")
+  if (message.includes("transition")) {
+    return {
+      exitCode: ExitCodes.INVALID_STATE_TRANSITION,
+      errorCode: ErrorCode.STATE_INVALID_TRANSITION,
+    };
+  }
+
+  // Transaction errors (check before generic errors)
+  if (message.includes("transaction")) {
+    return {
+      exitCode: ExitCodes.TRANSACTION_FAILED,
+      errorCode: ErrorCode.INTERNAL_TRANSACTION_FAILED,
+    };
+  }
+
+  // Concurrent modification
+  if (message.includes("concurrent") || message.includes("modified")) {
+    return {
+      exitCode: ExitCodes.CONCURRENT_MODIFICATION,
+      errorCode: ErrorCode.STATE_CONCURRENT_MODIFICATION,
+    };
+  }
+
+  // File not found errors
+  if (raw.includes("not found") || raw.includes("ENOENT")) {
+    return {
+      exitCode: ExitCodes.FILE_NOT_FOUND,
+      errorCode: ErrorCode.VALIDATION_FILE_NOT_FOUND,
+    };
+  }
+
+  // Permission errors
+  if (raw.includes("EACCES") || raw.includes("permission denied")) {
+    return {
+      exitCode: ExitCodes.PERMISSION_DENIED,
+      errorCode: ErrorCode.PERMISSION_DENIED,
+    };
+  }
+
+  // Invalid arguments (validation errors) - check last as "Invalid" is broad
+  if (
+    raw.includes("Invalid") ||
+    raw.includes("outside vault") ||
+    raw.includes("Not a")
+  ) {
+    return {
+      exitCode: ExitCodes.INVALID_ARGUMENTS,
+      errorCode: ErrorCode.VALIDATION_INVALID_ARGUMENTS,
+    };
+  }
+
+  // Generic error (catch-all)
+  return {
+    exitCode: ExitCodes.GENERAL_ERROR,
+    errorCode: ErrorCode.INTERNAL_UNKNOWN,
+  };
 }

--- a/packages/cli/tests/unit/guardedRoutes.test.ts
+++ b/packages/cli/tests/unit/guardedRoutes.test.ts
@@ -1,0 +1,169 @@
+/**
+ * Guard-message ⇄ routing-table parity (req 3800d995, bug 8f35fec0).
+ *
+ * The `set-property` / `remove-property` refusal message is a CLAIM about which
+ * dedicated commands exist. Req `3800d995` promises an "error that NAMES the
+ * dedicated command" — so a name that resolves nowhere makes that promise false
+ * while every existing test stays green (they only assert the substring
+ * "dedicated guarded command" or a loose `/set-criticality/`).
+ *
+ * That is exactly what happened: three of the hand-authored names never existed
+ * in any live registry —
+ *   `remove-start-timestamp`, `remove-end-timestamp`, `archive-completed`
+ * — so the guard refused the mutation and then pointed the user at a command
+ * that `apply` cannot resolve. `remove-start-timestamp` exists ONLY as an e2e
+ * test fixture, which is where the false name came from.
+ *
+ * ⛔ WHY THESE AXES AND NOT "every cliName resolves in the registry": the
+ * registry is SPLIT across assetspaces and exocortex pins only `exoas-exocmd`
+ * (`archive`, `set-criticality-*`, `set-planned-*` live in the UNPINNED
+ * `exoas-public`), so a CI-side existence check would cover a MINORITY and need
+ * an exempt-list for the rest. Existence needs the live vault — which the
+ * commands DO have at refusal time; that is a separate follow-up. What IS
+ * checkable here is that the sentence cannot name anything the machine-readable
+ * array does not list.
+ */
+import {
+  GUARDED_PROPERTIES,
+  GUARDED_ROUTES,
+  renderGuardedRoute,
+} from "../../src/commands/propertyMutationShared";
+
+const REQ = "3800d995-2bae-401f-a23a-dac914505e9d";
+
+/**
+ * Names that were shipped in the message but exist in NO live registry.
+ * Verified 2026-08-19 against 76 `exocmd__Command_cliName` across the mounted
+ * assetspaces of vault-my. Kept as a regression guard: each came from prose,
+ * and `remove-start-timestamp` specifically leaked in from an e2e fixture.
+ */
+const PHANTOM_NAMES = [
+  "remove-start-timestamp",
+  "remove-end-timestamp",
+  "archive-completed",
+];
+
+describe(`guard message is DERIVED from the routing table (bug 8f35fec0)`, () => {
+  it(`the routing table is non-empty (canary: an empty table makes every axis below vacuous) @req:${REQ}`, () => {
+    expect(Object.keys(GUARDED_ROUTES).length).toBeGreaterThan(0);
+    expect(Object.keys(GUARDED_PROPERTIES)).toEqual(
+      Object.keys(GUARDED_ROUTES),
+    );
+  });
+
+  it(`every rendered message names EXACTLY the cliNames its route lists @req:${REQ}`, () => {
+    const mismatches: string[] = [];
+    for (const [property, route] of Object.entries(GUARDED_ROUTES)) {
+      const message = GUARDED_PROPERTIES[property];
+      // The invocation head is `apply <a|b|c> <path>` — parse it back out, so a
+      // name added to the sentence by hand (bypassing the array) is detectable.
+      const head = message.match(/^apply ([^ ]+) <path>/);
+      if (!head) {
+        mismatches.push(
+          `${property}: message does not start with "apply … <path>" (${message})`,
+        );
+        continue;
+      }
+      const named = head[1].split("|");
+      if (named.join("|") !== route.commands.join("|")) {
+        mismatches.push(
+          `${property}: message names [${named.join(", ")}] but the route lists [${route.commands.join(", ")}]`,
+        );
+      }
+    }
+    expect(mismatches).toEqual([]);
+  });
+
+  it(`no route recommends a command that exists in NO live registry @req:${REQ}`, () => {
+    const offenders: string[] = [];
+    for (const [property, route] of Object.entries(GUARDED_ROUTES)) {
+      for (const name of route.commands) {
+        if (PHANTOM_NAMES.includes(name)) {
+          offenders.push(`${property} → ${name}`);
+        }
+      }
+    }
+    expect(offenders).toEqual([]);
+  });
+
+  it(`no phantom name survives anywhere in a rendered message (incl. prose/notes) @req:${REQ}`, () => {
+    const offenders: string[] = [];
+    for (const [property, message] of Object.entries(GUARDED_PROPERTIES)) {
+      for (const phantom of PHANTOM_NAMES) {
+        if (message.includes(phantom))
+          offenders.push(`${property}: ${phantom}`);
+      }
+    }
+    expect(offenders).toEqual([]);
+  });
+
+  it(`every cliName is a well-formed, non-duplicated kebab-case token @req:${REQ}`, () => {
+    const malformed: string[] = [];
+    for (const [property, route] of Object.entries(GUARDED_ROUTES)) {
+      expect(route.commands.length).toBeGreaterThan(0);
+      const seen = new Set<string>();
+      for (const name of route.commands) {
+        if (!/^[a-z][a-z0-9]*(-[a-z0-9]+)*$/.test(name)) {
+          malformed.push(`${property} → "${name}" is not kebab-case`);
+        }
+        if (seen.has(name))
+          malformed.push(`${property} → "${name}" duplicated`);
+        seen.add(name);
+      }
+    }
+    expect(malformed).toEqual([]);
+  });
+
+  /**
+   * `ErrorHandler.classifyError` picks the process EXIT CODE by scanning the
+   * error message for substrings. The guard message is part of that error, so a
+   * word chosen for readability silently re-routes the exit code a scripted
+   * consumer branches on.
+   *
+   * Measured: an early draft of the timestamp notes read "as a transition side
+   * effect" → `message.includes("transition")` → exit 6
+   * (INVALID_STATE_TRANSITION) instead of 1 (GENERAL_ERROR), and the existing
+   * `set-property` guard tests caught it only as a bare `expect(exit).toContain(1)`
+   * failure with no hint at the cause.
+   *
+   * Kept in sync with ErrorHandler.classifyError (packages/cli/src/utils/).
+   */
+  const CLASSIFIER_TRIGGERS = [
+    "transition",
+    "transaction",
+    "concurrent",
+    "modified",
+    "not found",
+    "enoent",
+    "eacces",
+    "permission denied",
+    "invalid",
+    "outside vault",
+    "not a",
+  ];
+
+  it(`guard messages do not collide with the exit-code classifier @req:${REQ}`, () => {
+    const collisions: string[] = [];
+    for (const [property, message] of Object.entries(GUARDED_PROPERTIES)) {
+      const lowered = message.toLowerCase();
+      for (const trigger of CLASSIFIER_TRIGGERS) {
+        if (lowered.includes(trigger)) {
+          collisions.push(`${property}: "${trigger}" in "${message}"`);
+        }
+      }
+    }
+    expect(collisions).toEqual([]);
+  });
+
+  it(`renderGuardedRoute places argSuffix after <path> and note in parentheses @req:${REQ}`, () => {
+    expect(renderGuardedRoute({ commands: ["a", "b"] })).toBe(
+      "apply a|b <path>",
+    );
+    expect(renderGuardedRoute({ commands: ["a"], argSuffix: "--x 1" })).toBe(
+      "apply a <path> --x 1",
+    );
+    expect(renderGuardedRoute({ commands: ["a"], note: "why" })).toBe(
+      "apply a <path>  (why)",
+    );
+  });
+});

--- a/packages/cli/tests/unit/guardedRoutes.test.ts
+++ b/packages/cli/tests/unit/guardedRoutes.test.ts
@@ -27,7 +27,10 @@ import {
   GUARDED_PROPERTIES,
   GUARDED_ROUTES,
   renderGuardedRoute,
+  renderGuardRefusal,
 } from "../../src/commands/propertyMutationShared";
+import { classifyMessage } from "../../src/utils/ErrorHandler";
+import { ExitCodes } from "../../src/utils/ExitCodes";
 
 /**
  * Names that were shipped in the message but exist in NO live registry.
@@ -113,44 +116,57 @@ describe(`guard message is DERIVED from the routing table (bug 8f35fec0)`, () =>
   });
 
   /**
-   * `ErrorHandler.classifyError` picks the process EXIT CODE by scanning the
-   * error message for substrings. The guard message is part of that error, so a
-   * word chosen for readability silently re-routes the exit code a scripted
-   * consumer branches on.
+   * The guard sentence is ALSO the input of the exit-code classifier, which picks
+   * the process exit code by SUBSTRING. A word chosen for readability silently
+   * re-routes the code a scripted consumer branches on.
    *
    * Measured: an early draft of the timestamp notes read "as a transition side
-   * effect" → `message.includes("transition")` → exit 6
-   * (INVALID_STATE_TRANSITION) instead of 1 (GENERAL_ERROR), and the existing
-   * `set-property` guard tests caught it only as a bare `expect(exit).toContain(1)`
-   * failure with no hint at the cause.
+   * effect" → `message.includes("transition")` → exit 6 (INVALID_STATE_TRANSITION)
+   * instead of 1 (GENERAL_ERROR). The existing `set-property` tests caught it only
+   * as a bare `expect(exit).toContain(1)` failure with no hint at the cause.
    *
-   * Kept in sync with ErrorHandler.classifyError (packages/cli/src/utils/).
+   * ⛔ This axis asserts on the FULL rendered error, not on the `GUARDED_PROPERTIES`
+   * fragment: the call sites wrap the fragment in ~25 more words, and those are
+   * classified too. An earlier version of this axis read only the fragment and was
+   * therefore blind to a trigger word introduced in the wrapper — demonstrated by
+   * review, which injected "Invalid" into the wrapper and left this file green
+   * while the integration suite went red with the very `toContain(1)` failure this
+   * axis exists to diagnose.
+   *
+   * ⛤ And it asserts BEHAVIOUR (`classifyMessage`), not a copied trigger list: a
+   * hand-maintained list drifts the moment a branch is added to the classifier.
    */
-  const CLASSIFIER_TRIGGERS = [
-    "transition",
-    "transaction",
-    "concurrent",
-    "modified",
-    "not found",
-    "enoent",
-    "eacces",
-    "permission denied",
-    "invalid",
-    "outside vault",
-    "not a",
+  /** The SAME renderer both primitives use — no copy to drift. */
+  const SURFACES: ReadonlyArray<readonly [string, string]> = [
+    ["set", "set-property"],
+    ["remove", "remove-property"],
   ];
 
-  it("guard messages do not collide with the exit-code classifier @req:3800d995-2bae-401f-a23a-dac914505e9d", () => {
-    const collisions: string[] = [];
-    for (const [property, message] of Object.entries(GUARDED_PROPERTIES)) {
-      const lowered = message.toLowerCase();
-      for (const trigger of CLASSIFIER_TRIGGERS) {
-        if (lowered.includes(trigger)) {
-          collisions.push(`${property}: "${trigger}" in "${message}"`);
+  it("every guard refusal classifies as GENERAL_ERROR, on the FULL rendered message @req:3800d995-2bae-401f-a23a-dac914505e9d", () => {
+    const misrouted: string[] = [];
+    for (const [property, fragment] of Object.entries(GUARDED_PROPERTIES)) {
+      for (const [verb, command] of SURFACES) {
+        const message = renderGuardRefusal(verb, command, property, fragment);
+        const { exitCode } = classifyMessage(message);
+        if (exitCode !== ExitCodes.GENERAL_ERROR) {
+          misrouted.push(`${property}: exit ${exitCode} — "${message}"`);
         }
       }
     }
-    expect(collisions).toEqual([]);
+    expect(misrouted).toEqual([]);
+  });
+
+  it("the classifier axis is not vacuous — a trigger word IS detected @req:3800d995-2bae-401f-a23a-dac914505e9d", () => {
+    // Negative control: if this ever stops failing, the axis above proves nothing.
+    const poisoned = renderGuardRefusal(
+      "set",
+      "set-property",
+      "ems__Effort_startTimestamp",
+      "apply start-effort <path>  (cleared as a transition side effect)",
+    );
+    expect(classifyMessage(poisoned).exitCode).not.toBe(
+      ExitCodes.GENERAL_ERROR,
+    );
   });
 
   it("renderGuardedRoute places argSuffix after <path> and note in parentheses @req:3800d995-2bae-401f-a23a-dac914505e9d", () => {

--- a/packages/cli/tests/unit/guardedRoutes.test.ts
+++ b/packages/cli/tests/unit/guardedRoutes.test.ts
@@ -26,6 +26,7 @@
 import {
   GUARDED_PROPERTIES,
   GUARDED_ROUTES,
+  IMMUTABLE_PROPERTIES,
   renderGuardedRoute,
   renderGuardRefusal,
 } from "../../src/commands/propertyMutationShared";
@@ -167,6 +168,102 @@ describe(`guard message is DERIVED from the routing table (bug 8f35fec0)`, () =>
     expect(classifyMessage(poisoned).exitCode).not.toBe(
       ExitCodes.GENERAL_ERROR,
     );
+  });
+
+  /**
+   * MEDIUM-A from review: the `resolutionTimestamp` fix (adding `re-open`) was
+   * correct but UNPROTECTED — dropping it again left every axis green, because
+   * the integration assertion is a loose `/mark-done/` that both forms satisfy.
+   *
+   * ⛔ The obvious guard — "these three routes must list these commands" — would be
+   * CIRCULAR: asserting route content against a copy of route content. This axis
+   * instead checks the route against ITSELF for internal consistency: a `note` that
+   * claims something CLEARS the property is a claim about the `commands` array, so
+   * the two must agree. Removing `re-open` while leaving the note reddens this;
+   * removing both is a deliberate semantic edit, not a silent regression.
+   */
+  it("a route whose note claims a command CLEARS the property lists more than one command @req:3800d995-2bae-401f-a23a-dac914505e9d", () => {
+    const inconsistent: string[] = [];
+    for (const [property, route] of Object.entries(GUARDED_ROUTES)) {
+      const claimsClearing = /clears? it/i.test(route.note ?? "");
+      if (claimsClearing && route.commands.length < 2) {
+        inconsistent.push(
+          `${property}: note claims a clearing command but lists only [${route.commands.join(", ")}]`,
+        );
+      }
+    }
+    expect(inconsistent).toEqual([]);
+  });
+
+  /**
+   * The fact timestamps are SET as a status-transition side effect and CLEARED by
+   * the reverse transition (`ems__WorkflowTransition_postActions`). Measured on the
+   * live graph: `← Doing` (re-open) carries BOTH `2c53ea68` "Delete end timestamp"
+   * and `d08d588c` "Delete resolution timestamp", in the Task AND Project workflows.
+   *
+   * So a route for one of them that offers only a SETTING command sends the user to
+   * a command that writes the value they are removing — the defect this file exists
+   * to prevent, one notch softer.
+   */
+  it("every fact-timestamp route offers a way to CLEAR, not only to set @req:3800d995-2bae-401f-a23a-dac914505e9d", () => {
+    const FACT_TIMESTAMPS = [
+      "ems__Effort_startTimestamp",
+      "ems__Effort_endTimestamp",
+      "ems__Effort_resolutionTimestamp",
+    ];
+    const setOnly: string[] = [];
+    for (const property of FACT_TIMESTAMPS) {
+      const route = GUARDED_ROUTES[property];
+      expect(route).toBeDefined(); // canary: a renamed property must not silently skip
+      if (!/clears? it/i.test(route.note ?? "")) {
+        setOnly.push(
+          `${property}: no note describing how the value is cleared`,
+        );
+      }
+    }
+    expect(setOnly).toEqual([]);
+  });
+
+  /**
+   * `classifyMessage` mixes two operands ON PURPOSE: `transition` / `transaction` /
+   * `concurrent` / `modified` match the LOWERCASED message, while `Invalid` /
+   * `Not a` / `ENOENT` / `EACCES` match the RAW one. Extracting the function
+   * preserved that exactly — but review showed nothing ENFORCED it: lowercasing the
+   * `Invalid` branch left the whole 359-test error suite green, and a user-supplied
+   * property name containing "invalid" would then newly route to exit 2.
+   *
+   * Pre-existing, and more exposed now that the function is exported — so pin it.
+   */
+  it("classifyMessage keeps the case-SENSITIVE branches case-sensitive @req:3800d995-2bae-401f-a23a-dac914505e9d", () => {
+    // Capitalised → the Invalid branch.
+    expect(classifyMessage("Invalid file path").exitCode).toBe(
+      ExitCodes.INVALID_ARGUMENTS,
+    );
+    // Lower-cased → must NOT hit it (a property name is user-supplied text).
+    expect(
+      classifyMessage('Refusing to set "x__invalid_field" — no.').exitCode,
+    ).toBe(ExitCodes.GENERAL_ERROR);
+    // The lowercase-matched family behaves the opposite way, by design.
+    expect(classifyMessage("TRANSITION not allowed").exitCode).toBe(
+      ExitCodes.INVALID_STATE_TRANSITION,
+    );
+  });
+
+  /**
+   * `IMMUTABLE_PROPERTIES` refusals share the classifier exposure but take a
+   * different sentence, so the axis above does not reach them (review LOW).
+   */
+  it("immutable-property refusals also classify as GENERAL_ERROR @req:3800d995-2bae-401f-a23a-dac914505e9d", () => {
+    const misrouted: string[] = [];
+    for (const [property, reason] of Object.entries(IMMUTABLE_PROPERTIES)) {
+      for (const verb of ["set", "remove"]) {
+        const message = `Refusing to ${verb} "${property}" — ${reason}.`;
+        if (classifyMessage(message).exitCode !== ExitCodes.GENERAL_ERROR) {
+          misrouted.push(`${property}: "${message}"`);
+        }
+      }
+    }
+    expect(misrouted).toEqual([]);
   });
 
   it("renderGuardedRoute places argSuffix after <path> and note in parentheses @req:3800d995-2bae-401f-a23a-dac914505e9d", () => {

--- a/packages/cli/tests/unit/guardedRoutes.test.ts
+++ b/packages/cli/tests/unit/guardedRoutes.test.ts
@@ -29,8 +29,6 @@ import {
   renderGuardedRoute,
 } from "../../src/commands/propertyMutationShared";
 
-const REQ = "3800d995-2bae-401f-a23a-dac914505e9d";
-
 /**
  * Names that were shipped in the message but exist in NO live registry.
  * Verified 2026-08-19 against 76 `exocmd__Command_cliName` across the mounted
@@ -44,14 +42,14 @@ const PHANTOM_NAMES = [
 ];
 
 describe(`guard message is DERIVED from the routing table (bug 8f35fec0)`, () => {
-  it(`the routing table is non-empty (canary: an empty table makes every axis below vacuous) @req:${REQ}`, () => {
+  it("the routing table is non-empty (canary: an empty table makes every axis below vacuous) @req:3800d995-2bae-401f-a23a-dac914505e9d", () => {
     expect(Object.keys(GUARDED_ROUTES).length).toBeGreaterThan(0);
     expect(Object.keys(GUARDED_PROPERTIES)).toEqual(
       Object.keys(GUARDED_ROUTES),
     );
   });
 
-  it(`every rendered message names EXACTLY the cliNames its route lists @req:${REQ}`, () => {
+  it("every rendered message names EXACTLY the cliNames its route lists @req:3800d995-2bae-401f-a23a-dac914505e9d", () => {
     const mismatches: string[] = [];
     for (const [property, route] of Object.entries(GUARDED_ROUTES)) {
       const message = GUARDED_PROPERTIES[property];
@@ -74,7 +72,7 @@ describe(`guard message is DERIVED from the routing table (bug 8f35fec0)`, () =>
     expect(mismatches).toEqual([]);
   });
 
-  it(`no route recommends a command that exists in NO live registry @req:${REQ}`, () => {
+  it("no route recommends a command that exists in NO live registry @req:3800d995-2bae-401f-a23a-dac914505e9d", () => {
     const offenders: string[] = [];
     for (const [property, route] of Object.entries(GUARDED_ROUTES)) {
       for (const name of route.commands) {
@@ -86,7 +84,7 @@ describe(`guard message is DERIVED from the routing table (bug 8f35fec0)`, () =>
     expect(offenders).toEqual([]);
   });
 
-  it(`no phantom name survives anywhere in a rendered message (incl. prose/notes) @req:${REQ}`, () => {
+  it("no phantom name survives anywhere in a rendered message (incl. prose/notes) @req:3800d995-2bae-401f-a23a-dac914505e9d", () => {
     const offenders: string[] = [];
     for (const [property, message] of Object.entries(GUARDED_PROPERTIES)) {
       for (const phantom of PHANTOM_NAMES) {
@@ -97,7 +95,7 @@ describe(`guard message is DERIVED from the routing table (bug 8f35fec0)`, () =>
     expect(offenders).toEqual([]);
   });
 
-  it(`every cliName is a well-formed, non-duplicated kebab-case token @req:${REQ}`, () => {
+  it("every cliName is a well-formed, non-duplicated kebab-case token @req:3800d995-2bae-401f-a23a-dac914505e9d", () => {
     const malformed: string[] = [];
     for (const [property, route] of Object.entries(GUARDED_ROUTES)) {
       expect(route.commands.length).toBeGreaterThan(0);
@@ -142,7 +140,7 @@ describe(`guard message is DERIVED from the routing table (bug 8f35fec0)`, () =>
     "not a",
   ];
 
-  it(`guard messages do not collide with the exit-code classifier @req:${REQ}`, () => {
+  it("guard messages do not collide with the exit-code classifier @req:3800d995-2bae-401f-a23a-dac914505e9d", () => {
     const collisions: string[] = [];
     for (const [property, message] of Object.entries(GUARDED_PROPERTIES)) {
       const lowered = message.toLowerCase();
@@ -155,7 +153,7 @@ describe(`guard message is DERIVED from the routing table (bug 8f35fec0)`, () =>
     expect(collisions).toEqual([]);
   });
 
-  it(`renderGuardedRoute places argSuffix after <path> and note in parentheses @req:${REQ}`, () => {
+  it("renderGuardedRoute places argSuffix after <path> and note in parentheses @req:3800d995-2bae-401f-a23a-dac914505e9d", () => {
     expect(renderGuardedRoute({ commands: ["a", "b"] })).toBe(
       "apply a|b <path>",
     );


### PR DESCRIPTION
Fixes the CLI half of vault bug `8f35fec0`.

## The defect

The `set-property` / `remove-property` refusal message named **three commands that exist in no registry** — `remove-start-timestamp`, `remove-end-timestamp`, `archive-completed`. The guard refused the mutation and then pointed the user at a command `apply` cannot resolve, so there was **no sanctioned path at all**:

```
$ remove-property … --property ems__Effort_startTimestamp --dry-run
❌ Refusing … it has a dedicated guarded command … Use:
     exocortex apply start-effort <path>  (or apply remove-start-timestamp <path>)

$ apply remove-start-timestamp <path>
❌ No command found with UUID or cliName "remove-start-timestamp".
```

Verified against **76 live `exocmd__Command_cliName`**. ⛤ `remove-start-timestamp` exists only as an **e2e test fixture** (`tests/e2e/test-vault/03 Knowledge/commands/cmd-remove-start-timestamp.md`) — that is where the false name came from.

## Why this is a bug-fix, not a new req

Active req `3800d995` promises *"an error that **NAMES the dedicated command**"*. A name that resolves nowhere makes that promise false ⇒ conformance-with-an-active-req.

⛔ The **spec itself carried the same false name** (`archive-completed` in its clause). Fixed in the same window: [`exoas-exo-reqs@main`](https://github.com/kitelev/exoas-exo-reqs/blob/main/exo-reqs/3800d995-2bae-401f-a23a-dac914505e9d.md). The req also now states the mechanism — there is **no standalone `remove-*-timestamp` command**; clearing is a workflow-transition side effect (`ems__WorkflowTransition_postActions`).

## What changed

| | |
|---|---|
| `GUARDED_ROUTES` | **machine-readable**: property → cliNames (+ optional `argSuffix` / `note`) |
| `GUARDED_PROPERTIES` | now **DERIVED** from it via `renderGuardedRoute` — the sentence cannot name anything the array does not list |
| public shape | **unchanged** (`Record<string, string>`) ⇒ zero consumer / assertion churn |

Corrected names:

| property | was | now |
|---|---|---|
| `ems__Effort_startTimestamp` | `start-effort` *(or `remove-start-timestamp`)* | `start-effort\|rollback-to-backlog\|park-waiting` |
| `ems__Effort_endTimestamp` | `mark-done` *(or `remove-end-timestamp`)* | `mark-done\|re-open` |
| `archived` / `exo__Asset_archived` | `archive-completed\|…` | `archive\|…` |
| `ems__Task_zone` | `set-criticality-high\|medium\|low` | spelled out in full |

## ⛤ Found while running the existing guard tests

The rendered sentence is **also the INPUT of `ErrorHandler.classifyError`**, which picks the process **exit code by substring**. A first draft of the timestamp notes read *"as a transition side effect"* → `message.includes("transition")` → exit **6** (`INVALID_STATE_TRANSITION`) instead of **1** (`GENERAL_ERROR`) — a word chosen for readability silently re-routing the exit code a scripted consumer branches on.

The existing tests caught it only as a bare `expect(exit).toContain(1)` failure with no hint at the cause. New axis `guard messages do not collide with the exit-code classifier` names the offending word.

## Why there is no CI check that "every cliName resolves"

⛤ **The decisive reason is not coverage — it is that such a gate would be INVERTED today.** Checked directly against the pinned submodule (`packages/exoas-exocmd` @ `829e06b`, 32 commits stale):

| name | live registry | **pinned SHA** |
|---|---|---|
| `archive-completed` *(the phantom)* | absent | **PRESENT** |
| `archive` | present | absent |
| `un-archive` · `re-open` · `park-waiting` · `rollback-to-backlog` | present | absent |

A check "every cliName resolves in the pinned assetspace" would today **pass the phantom and fail five of the correct names** — it would have greenlit the bug and blocked this fix.

Secondary: the registry is also **split** — 13 of the 25 names live in the pinned `exoas-exocmd`, 12 in the unpinned `exoas-public`.

A cheap partial *does* exist and needs no exempt-list: a **ratchet** ("names that resolve in the pinned space must keep resolving; the count may not decrease"). It is worth nothing until the pin is bumped — and bumping it also reds a neighbour's brittle count assertion (`PrototypePreconditionRevertVerify`: `>= 20` lifecycle commands → 19). So the follow-up is **"bump the pin, then ratchet"**, not "find a way to check existence".

## Verification

**5 mutants, each reddens exactly its own axes:**

| mutant | reddens |
|---|---|
| M1 phantom back in the array | regression + prose axes |
| M2 renderer ignores the array | derivation + render-shape axes |
| M3 non-kebab cliName | well-formedness axis |
| M4 phantom smuggled into a `note` (bypassing the array) | prose axis **only** — proves it is not vacuous |
| M5 classifier trigger word back | classifier axis (and, separately, the integration exit-code assertion) |

- control **7/7** green; the six affected CLI suites **70/70**, rc=0
- `check-cli-types`: 115 files compiled, **0 new** type errors (baseline matched)
- lint-job guards: shard ✅ · antipatterns ✅ (`method-exists=55/55`) · coverage ✅

Req: 3800d995-2bae-401f-a23a-dac914505e9d
