### PR TITLE
fix(sparql): make || and && error-tolerant per SPARQL 1.1 §17.4.1.5

### DIFF
--- a/packages/core/src/infrastructure/sparql/executors/FilterExecutor.ts
+++ b/packages/core/src/infrastructure/sparql/executors/FilterExecutor.ts
@@ -274,6 +274,24 @@ export class FilterExecutor {
   /**
    * Evaluate logical expression asynchronously to handle nested EXISTS.
    */
+  /**
+   * SPARQL 1.1 §17.4.1.5 — `||` and `&&` are ERROR-TOLERANT.
+   *
+   *   ||:  true ∨ error = true   |  false ∨ error = error  |  error ∨ error = error
+   *   &&:  false ∧ error = false |  true ∧ error = error   |  error ∧ error = error
+   *
+   * ⛔ Evaluating every operand eagerly and only THEN combining (what this used to do)
+   *    lets an operand's throw escape past a decision the other operand had already made,
+   *    so the whole solution is dropped. Measured 2026-08-20 on the live graph:
+   *      FILTER(true)                     → 1185 rows
+   *      FILTER(true || (STR(?e) >= "a")) →  226 rows   ⛔ 959 lost, silently
+   *    with `?e` bound by an OPTIONAL. Every "the interval is not closed yet" query
+   *    therefore drops exactly the rows it asks for.
+   *
+   * ⛤ NOT short-circuit: the spec is order-INDEPENDENT, so `error || true` must be `true`
+   *    just as `true || error` is. Left-to-right short-circuiting would pass one and fail
+   *    the other. Hence: evaluate all operands, capturing errors, then apply the table.
+   */
   private async evaluateLogicalAsync(expr: import("../algebra/AlgebraOperation").LogicalExpression, solution: SolutionMapping): Promise<boolean> {
     if (expr.operator === "!") {
       const operand = await this.evaluateExpressionAsync(expr.operands[0], solution);
@@ -281,16 +299,24 @@ export class FilterExecutor {
     }
 
     const results: boolean[] = [];
+    let errored = false;
     for (const op of expr.operands) {
-      const result = await this.evaluateExpressionAsync(op, solution);
-      results.push(result as boolean);
+      try {
+        results.push((await this.evaluateExpressionAsync(op, solution)) as boolean);
+      } catch {
+        errored = true;
+      }
     }
 
     if (expr.operator === "&&") {
+      if (results.some((r) => r === false)) return false; // a false absorbs the error
+      if (errored) throw new FilterExecutorError("&& operand raised and no false absorbed it");
       return BuiltInFunctions.logicalAnd(results);
     }
 
     if (expr.operator === "||") {
+      if (results.some((r) => r === true)) return true; // a true absorbs the error
+      if (errored) throw new FilterExecutorError("|| operand raised and no true absorbed it");
       return BuiltInFunctions.logicalOr(results);
     }
 
@@ -396,16 +422,25 @@ export class FilterExecutor {
       return BuiltInFunctions.logicalNot(operand as boolean);
     }
 
-    const results = expr.operands.map((op: Expression) => {
-      const result = this.evaluateExpression(op, solution);
-      return result as boolean;
-    });
+    const results: boolean[] = [];
+    let errored = false;
+    for (const op of expr.operands) {
+      try {
+        results.push(this.evaluateExpression(op, solution) as boolean);
+      } catch {
+        errored = true;
+      }
+    }
 
     if (expr.operator === "&&") {
+      if (results.some((r) => r === false)) return false; // a false absorbs the error
+      if (errored) throw new FilterExecutorError("&& operand raised and no false absorbed it");
       return BuiltInFunctions.logicalAnd(results);
     }
 
     if (expr.operator === "||") {
+      if (results.some((r) => r === true)) return true; // a true absorbs the error
+      if (errored) throw new FilterExecutorError("|| operand raised and no true absorbed it");
       return BuiltInFunctions.logicalOr(results);
     }
 

--- a/packages/core/tests/unit/infrastructure/sparql/executors/FilterExecutor.errorTolerance.test.ts
+++ b/packages/core/tests/unit/infrastructure/sparql/executors/FilterExecutor.errorTolerance.test.ts
@@ -1,0 +1,128 @@
+/**
+ * SPARQL 1.1 §17.4.1.5 — error-tolerant semantics of `||` and `&&`.
+ *
+ * ⛔ THE DEFECT (measured on the live graph, vault-exodev task e242a74b):
+ *   `FILTER(!BOUND(?e) || STR(?e) >= "2026-08-02")` returned **0** rows where ≥6 were due,
+ *   and `FILTER(true || <error>)` returned **16** rows out of **22**. The right operand was
+ *   evaluated and its error killed the row even though the left one had already decided the
+ *   result. Any "the interval is not closed yet" query therefore drops the very rows it asks
+ *   for — silently, with no error surfaced to the caller.
+ *
+ * ⛤ THE SPEC: for `||` an error is absorbed by a `true`; for `&&` it is absorbed by a `false`.
+ *
+ *   ||:  true ∨ error = true  |  false ∨ error = error  |  error ∨ error = error
+ *   &&:  false ∧ error = false |  true ∧ error = error  |  error ∧ error = error
+ *
+ * ⛤ ORDER IS IRRELEVANT — the erroring operand is tested on BOTH sides, because the natural
+ *   fix (short-circuit left-to-right) would pass `error ∨ true` only by accident of ordering
+ *   and would still drop the row when the error comes first. That asymmetry is what the
+ *   "reversed" cases below lock.
+ */
+
+import { FilterExecutor } from "../../../../../src/infrastructure/sparql/executors/FilterExecutor";
+import { SolutionMapping } from "../../../../../src/infrastructure/sparql/SolutionMapping";
+import { IRI } from "../../../../../src/domain/models/rdf/IRI";
+import { Literal } from "../../../../../src/domain/models/rdf/Literal";
+import type {
+  Expression,
+  FilterOperation,
+} from "../../../../../src/infrastructure/sparql/algebra/AlgebraOperation";
+
+describe("FilterExecutor — error tolerance of logical operators (SPARQL 1.1 §17.4.1.5)", () => {
+  let executor: FilterExecutor;
+  const xsdInt = new IRI("http://www.w3.org/2001/XMLSchema#integer");
+
+  beforeEach(() => {
+    executor = new FilterExecutor();
+  });
+
+  /**
+   * An operand that genuinely ERRORS — `STR()` applied to an UNBOUND variable.
+   *
+   * ⛔ NOT `?missing > 1` (a bare comparison against an unbound variable): measured
+   *    2026-08-20 on the live graph, that shape yields a plain `false` rather than an
+   *    error, so every case below would pass in BOTH directions and the whole file would
+   *    be vacuous. The discriminator was found by narrowing on the live engine:
+   *      FILTER(true)                    → 1185 rows   (baseline)
+   *      FILTER(true || BOUND(?e))       → 1185        (variable alone: fine)
+   *      FILTER(true || (?e = ?e))       → 1185        (comparison on unbound: fine)
+   *      FILTER(true || (STR(?e) >= "a")) →  226   ⛔  (959 rows lost)
+   *    ⇒ the carrier of the defect is a FUNCTION over an unbound variable, not `||`.
+   */
+  const erroring: Expression = {
+    type: "comparison",
+    operator: ">=",
+    left: {
+      type: "function",
+      function: "STR",
+      args: [{ type: "variable", name: "missing" }],
+    },
+    right: { type: "literal", value: "a" },
+  } as Expression;
+  const truthy: Expression = {
+    type: "comparison",
+    operator: "=",
+    left: { type: "literal", value: 1 },
+    right: { type: "literal", value: 1 },
+  };
+  const falsy: Expression = {
+    type: "comparison",
+    operator: "=",
+    left: { type: "literal", value: 1 },
+    right: { type: "literal", value: 2 },
+  };
+
+  const filterOf = (operator: "&&" | "||", operands: Expression[]): FilterOperation => ({
+    type: "filter",
+    expression: { type: "logical", operator, operands } as Expression,
+    input: { type: "bgp", triples: [] },
+  });
+
+  const oneSolution = (): SolutionMapping[] => {
+    const s = new SolutionMapping();
+    s.set("x", new Literal("10", xsdInt));
+    return [s];
+  };
+
+  describe("|| absorbs an error next to a true", () => {
+    it("true || error → row KEPT", async () => {
+      const results = await executor.executeAll(filterOf("||", [truthy, erroring]), oneSolution());
+      expect(results).toHaveLength(1);
+    });
+
+    it("error || true → row KEPT (order must not matter)", async () => {
+      const results = await executor.executeAll(filterOf("||", [erroring, truthy]), oneSolution());
+      expect(results).toHaveLength(1);
+    });
+
+    it("false || error → row DROPPED (error is not silently a false)", async () => {
+      const results = await executor.executeAll(filterOf("||", [falsy, erroring]), oneSolution());
+      expect(results).toHaveLength(0);
+    });
+  });
+
+  describe("&& absorbs an error next to a false", () => {
+    it("false && error → row DROPPED (the false already decided it — no throw escapes)", async () => {
+      const results = await executor.executeAll(filterOf("&&", [falsy, erroring]), oneSolution());
+      expect(results).toHaveLength(0);
+    });
+
+    it("error && false → row DROPPED (order must not matter)", async () => {
+      const results = await executor.executeAll(filterOf("&&", [erroring, falsy]), oneSolution());
+      expect(results).toHaveLength(0);
+    });
+
+    it("true && error → row DROPPED", async () => {
+      const results = await executor.executeAll(filterOf("&&", [truthy, erroring]), oneSolution());
+      expect(results).toHaveLength(0);
+    });
+  });
+
+  it("CANARY — the erroring operand errors ON ITS OWN, and errors differently from a plain false", async () => {
+    const results = await executor.executeAll(
+      { type: "filter", expression: erroring, input: { type: "bgp", triples: [] } },
+      oneSolution(),
+    );
+    expect(results).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
Closes #4016

## Дефект

`FILTER(true || <error>)` **роняет** solution вместо того, чтобы её пропустить. Обе точки
вычисления логических выражений (`evaluateLogicalAsync` и синхронная) вычисляли **каждый**
операнд жадно и только потом комбинировали булевы — поэтому throw одного операнда проскакивал
мимо решения, которое другой операнд уже принял.

### Замер на живом графе (vault-my, `?e` связана через `OPTIONAL`)

| FILTER | строк | |
|---|---|---|
| `(true)` | 1185 | базовая линия |
| `(true \|\| BOUND(?e))` | 1185 | переменная сама по себе — исправно |
| `(true \|\| (?e = ?e))` | 1185 | сравнение с несвязанной — исправно |
| `(true \|\| (STR(?e) >= "a"))` | **226** | ⛔ потеряно **959 (81 %)** |

⛤ **Носитель — ФУНКЦИЯ над несвязанной переменной, а не `||`.** Голое сравнение с несвязанной
даёт плоский `false`, не ошибку. Это различие не педантизм: первый repro брал форму сравнения и
оказался **вакуумным** — 7/7 зелёных ДО фикса. Способ локализации записан в докстринге теста,
чтобы следующий читатель не выводил его заново.

**Почему это било по каждому «ещё не закрыт»-запросу:** идиома — `FILTER(!BOUND(?end) || <end
достаточно поздний>)`, и правый операнд ошибается ровно на тех несвязанных строках, ради допуска
которых стоит левый.

## Фикс

Вычислять все операнды, перехватывая ошибки, затем применить таблицу спеки:

```
||:  true ∨ error = true   |  false ∨ error = error  |  error ∨ error = error
&&:  false ∧ error = false |  true ∧ error = error   |  error ∧ error = error
```

⛔ **НЕ short-circuit.** Спека порядок-независима: `error || true` обязан дать `true` так же, как
`true || error`; ленивое вычисление слева направо прошло бы один случай и провалило другой. Оба
порядка запёрты осями.

## Revert-verify

**2 из 7** осей RED до фикса (`true || error`, `error || true`) → **7/7** GREEN после.
Канарейка утверждает, что ошибающийся операнд ошибается сам по себе — без неё файл проходил бы
в обе стороны.

⚠ **Названное ограничение:** оси `&&` внутри FILTER **неразличимы** (и ошибка, и `false` роняют
строку одинаково). Они регресс-замки, а не доказательства; корректность `&&` несёт общий с `||`
путь кода. Различимая ось потребовала бы контекста BIND/значения, а не FILTER.

## Scope

Bug-fix против **внешней** спецификации (W3C SPARQL 1.1 §17.4.1.5) ⇒ нового `req__Requirement`
не заводится: ни один активный req не покрывает семантику ошибок логических операторов, а
авторитет здесь — сама спека.

## Трассировка

Issue **#4016** (заведён 2026-08-02) описывает ровно этот дефект. Он же задокументирован в корпусе
правил как `sparql-iri-form-pre-verify` §A17 с предписанным обходом `COALESCE(STR(?x), <дефолт>)`
— после мержа обход перестаёт быть обязательным, и правило будет обновлено отдельным коммитом
(⛔ только после мержа: до него правило врало бы, что «уже можно»).

## Регресс

| прогон | результат |
|---|---|
| SPARQL-сьюты `packages/core/tests/unit/infrastructure/sparql` | **72/72 сьюта, 2922 теста — зелёные** |
| весь `packages/core` | 9 тестов в 2 сьютах красные |

⛤ **Красные — НЕ регрессия, проверено сравнением с РОДИТЕЛЕМ:** те же 2 сьюта и те же 9 тестов
падают на `HEAD~1` (фикс откачен `git checkout HEAD~1 -- FilterExecutor.ts`, восстановлен сразу
после). **9 до = 9 после.**

Причина — **локальное окружение, не код**: оба сьюта (`grounding-type-vault-fixture-parity`,
`PrototypePreconditionRevertVerify`) читают submodule `exoas-exocmd`, который в worktree не
инициализирован (`git submodule status` → префикс `-`, каталог пуст). Тест честно сообщает
`Expected length: 11 / Received length: 0`. В CI submodules инициализируются, поэтому там сьюты
зелёные.
