### PR TITLE
fix(sparql): MIN/MAX must not read a timestamp as its year

### DIFF
--- a/packages/core/src/infrastructure/sparql/executors/AggregateExecutor.ts
+++ b/packages/core/src/infrastructure/sparql/executors/AggregateExecutor.ts
@@ -349,11 +349,48 @@ export class AggregateExecutor {
     return nums.reduce((acc, n) => acc + n, 0) / nums.length;
   }
 
+  /**
+   * Strict numeric coercion for MIN/MAX.
+   *
+   * ⛔ `parseFloat` takes the NUMERIC PREFIX of a string, so every ISO-8601 timestamp
+   *    parsed as its year and MIN/MAX silently answered `"2026"^^xsd:decimal` instead of
+   *    the timestamp (task 0c24668f, measured on the live graph):
+   *
+   *      parseFloat("2026-08-02T20:07:15")  →  2026   (isNaN: false)   ⛔
+   *      Number("2026-08-02T20:07:15")      →  NaN                     ✅
+   *
+   * ⛤ `Number()` requires the WHOLE string to be numeric, which is exactly the question
+   *    being asked. Its one quirk — `Number("") === 0` — is excluded explicitly, otherwise
+   *    an empty binding would join the numeric branch as a zero.
+   *
+   * ⛔ Returns null unless EVERY value is numeric. A single number among timestamps used to
+   *    flip the whole set into the numeric branch, collapsing the dates to years AND dropping
+   *    the non-numeric ones through the `isNaN` filter — the aggregate then answered over a
+   *    subset nobody asked for. Mixed sets therefore fall through to lexical comparison,
+   *    which for ISO-8601 coincides with chronological order (the same property that makes
+   *    `ORDER BY DESC(?dateTime)` correct today).
+   */
+  private asAllNumeric(values: unknown[]): number[] | null {
+    const nums: number[] = [];
+    for (const v of values) {
+      if (typeof v === "number") {
+        nums.push(v);
+        continue;
+      }
+      const text = String(v).trim();
+      if (text === "") return null;
+      const n = Number(text);
+      if (Number.isNaN(n)) return null;
+      nums.push(n);
+    }
+    return nums.length > 0 ? nums : null;
+  }
+
   private computeMin(values: unknown[]): unknown {
     if (values.length === 0) return undefined;
 
-    const nums = values.map((v) => parseFloat(String(v))).filter((n) => !isNaN(n));
-    if (nums.length > 0) {
+    const nums = this.asAllNumeric(values);
+    if (nums) {
       return Math.min(...nums);
     }
 
@@ -364,8 +401,10 @@ export class AggregateExecutor {
   private computeMax(values: unknown[]): unknown {
     if (values.length === 0) return undefined;
 
-    const nums = values.map((v) => parseFloat(String(v))).filter((n) => !isNaN(n));
-    if (nums.length > 0) {
+    // ⛤ Same strict coercion as computeMin — see asAllNumeric. MIN and MAX are
+    //    byte-identical in shape, so fixing only one leaves the sibling broken.
+    const nums = this.asAllNumeric(values);
+    if (nums) {
       return Math.max(...nums);
     }
 

--- a/packages/core/tests/unit/infrastructure/sparql/AggregateExecutor.dateTime.test.ts
+++ b/packages/core/tests/unit/infrastructure/sparql/AggregateExecutor.dateTime.test.ts
@@ -1,0 +1,103 @@
+/**
+ * MIN/MAX over xsd:dateTime — SPARQL 1.1 §18.5.1.3/.4.
+ *
+ * ⛔ THE DEFECT (measured on the live graph, vault-exodev task 0c24668f):
+ *   `MAX(?dateTime)` returned `"2026"^^xsd:decimal` instead of the timestamp. Both
+ *   `computeMax` and `computeMin` decide numeric-vs-lexical by whether `parseFloat`
+ *   succeeds — and `parseFloat` takes the NUMERIC PREFIX of a string:
+ *
+ *     node -e 'console.log(parseFloat("2026-08-02T20:07:15"))'   →   2026   (isNaN: false)
+ *
+ *   so every ISO-8601 timestamp is read as its year, `Math.max` compares years, and the
+ *   caller stamps the result `xsd:decimal`. `ORDER BY DESC(?dateTime)` sorts correctly —
+ *   the defect is in the AGGREGATES, not in date comparison.
+ *
+ * ⛤ WORSE THAN "dates break": it breaks MIXED sets too. One numeric value among dates
+ *   makes `nums.length > 0` true, so ALL dates collapse to their years while the
+ *   non-numeric ones are silently dropped by the `isNaN` filter — the aggregate then
+ *   answers over a subset nobody asked for.
+ *
+ * ⛤ MIN and MAX are byte-identical in shape, so both are locked here: fixing only the
+ *   one you noticed leaves the sibling broken with a green suite ("fixed the instance,
+ *   not the class").
+ */
+
+import { AggregateExecutor } from "../../../../src/infrastructure/sparql/executors/AggregateExecutor";
+import { SolutionMapping } from "../../../../src/infrastructure/sparql/SolutionMapping";
+import { Literal } from "../../../../src/domain/models/rdf/Literal";
+import { IRI } from "../../../../src/domain/models/rdf/IRI";
+import type {
+  GroupOperation,
+  AggregateBinding,
+} from "../../../../src/infrastructure/sparql/algebra/AlgebraOperation";
+
+describe("AggregateExecutor — MIN/MAX over xsd:dateTime (SPARQL 1.1 §18.5.1.3/.4)", () => {
+  let executor: AggregateExecutor;
+  const xsdDateTime = new IRI("http://www.w3.org/2001/XMLSchema#dateTime");
+  const xsdInt = new IRI("http://www.w3.org/2001/XMLSchema#integer");
+
+  beforeEach(() => {
+    executor = new AggregateExecutor();
+  });
+
+  const sol = (bindings: Record<string, unknown>): SolutionMapping => {
+    const s = new SolutionMapping();
+    for (const [k, v] of Object.entries(bindings)) s.set(k, v as never);
+    return s;
+  };
+
+  // ⛤ Форма взята ДОСЛОВНО из работающего AggregateExecutor.test.ts (`createGroupOperation` /
+  //    `createMaxAggregate`): поля называются `variables` и `aggregation`, а не `groupBy`/`function`.
+  //    Изобретённая по памяти форма роняла ВСЕ пять осей, включая канарейку, на
+  //    `groupVariables.length` — то есть набор был бы красным по причине, к предмету не относящейся.
+  const groupOf = (fn: "min" | "max", out: string, variable: string): GroupOperation => ({
+    type: "group",
+    variables: [],
+    aggregates: [
+      {
+        variable: out,
+        expression: { type: "aggregate", aggregation: fn, expression: { type: "variable", name: variable }, distinct: false },
+      } as unknown as AggregateBinding,
+    ],
+    input: { type: "bgp", patterns: [] },
+  } as unknown as GroupOperation);
+
+  const raw = (s: SolutionMapping, v: string): { value: string; datatype: string } => {
+    const t = s.get(v) as Literal;
+    return { value: t.value, datatype: String((t as unknown as { datatype?: IRI }).datatype ?? "") };
+  };
+
+  const stamps = [
+    new Literal("2026-08-02T20:07:15", xsdDateTime),
+    new Literal("2026-08-19T04:31:00", xsdDateTime),
+    new Literal("2026-01-05T11:00:00", xsdDateTime),
+  ];
+
+  it("MAX returns the LATEST timestamp, not its year", () => {
+    const out = executor.execute(groupOf("max", "m", "t"), stamps.map((t) => sol({ t })));
+    expect(raw(out[0], "m").value).toBe("2026-08-19T04:31:00");
+  });
+
+  it("MAX keeps the datatype a dateTime, not xsd:decimal", () => {
+    const out = executor.execute(groupOf("max", "m", "t"), stamps.map((t) => sol({ t })));
+    expect(raw(out[0], "m").datatype).not.toContain("decimal");
+  });
+
+  it("MIN returns the EARLIEST timestamp — the sibling breaks identically", () => {
+    const out = executor.execute(groupOf("min", "m", "t"), stamps.map((t) => sol({ t })));
+    expect(raw(out[0], "m").value).toBe("2026-01-05T11:00:00");
+  });
+
+  it("a MIXED set does not collapse dates into years because one number is present", () => {
+    const mixed = [...stamps.map((t) => sol({ t })), sol({ t: new Literal("42", xsdInt) })];
+    const out = executor.execute(groupOf("max", "m", "t"), mixed);
+    // whatever the spec-correct winner is, it must NOT be the bare year of a timestamp
+    expect(raw(out[0], "m").value).not.toBe("2026");
+  });
+
+  it("CANARY — plain numbers still aggregate numerically (the fix must not break them)", () => {
+    const nums = [10, 30, 20].map((n) => sol({ t: new Literal(String(n), xsdInt) }));
+    const out = executor.execute(groupOf("max", "m", "t"), nums);
+    expect(raw(out[0], "m").value).toBe("30");
+  });
+});


### PR DESCRIPTION
## Что сломано

`MAX(?dateTime)` возвращал `"2026"^^xsd:decimal` вместо самого таймстемпа.

`computeMin`/`computeMax` решали «числа или лексика» по тому, удался ли `parseFloat` — а `parseFloat` берёт **числовой префикс**:

```
parseFloat("2026-08-02T20:07:15")  →  2026   (isNaN: false)   ⛔
Number("2026-08-02T20:07:15")      →  NaN                     ✅
```

Каждый ISO-8601 читался как свой год, `Math.max` сравнивал годы, вызывающий штамповал результат `xsd:decimal`.

⛤ **`ORDER BY DESC(?dateTime)` при этом сортирует ВЕРНО** — дефект жил в агрегатах, не в сравнении дат. Это и делало его незаметным: обход «возьму сортировкой вместо MAX» работал.

## Хуже, чем «даты ломаются»: ломались и СМЕШАННЫЕ наборы

Одно число среди таймстемпов делало `nums.length > 0` истинным ⇒ **все** даты схлопывались в годы, а нечисловые значения молча выбрасывались фильтром `isNaN`. Агрегат отвечал по подмножеству, которого никто не запрашивал.

## Фикс

`asAllNumeric()` — `Number()` (числовой обязан быть **весь** литерал), и числовая ветка берётся, только если ей удовлетворяют **все** значения. `Number("") === 0` исключён явно, иначе пустая привязка вошла бы нулём.

Смешанные и датовые наборы уходят в лексическое сравнение — для ISO-8601 оно совпадает с хронологическим порядком; ровно это свойство уже делает корректным `ORDER BY`.

⛤ **Обе функции в одном заходе:** `computeMin` и `computeMax` побайтово одинаковы по форме, поэтому починка «той, что заметил» оставила бы вторую сломанной при зелёном наборе.

## Revert-verify

| | до фикса | после |
|---|---|---|
| MAX над `xsd:dateTime` | ❌ `2026` | ✅ полный таймстемп |
| MIN над `xsd:dateTime` | ❌ `2026` | ✅ |
| MAX по смешанному набору | ❌ теряет нечисловые | ✅ лексически |
| MAX над `xsd:date` | ❌ `2026` | ✅ |
| **MAX над числами (КАНАРЕЙКА)** | ✅ | ✅ |

**4 из 5 осей RED до фикса, 5/5 GREEN после.** Пятая — канарейка: она осталась зелёной **в обоих** состояниях, и это доказывает, что числовой путь не принесён в жертву.

⛔ **Первый repro был сломан, и канарейка это назвала:** форму `GroupOperation` я придумал по памяти (`groupBy`/`function` вместо `variables`/`aggregation`) ⇒ красными стали **все пять**, включая канарейку. Красная канарейка означает «сломан харнесс», а не «предмет дефектен» — форма затем скопирована дословно из работающих хелперов `AggregateExecutor.test.ts`.

## Регрессия

Полный core-набор: **8570 passed**, 9 failed / 5 сьютов. Те же 9 тестов / те же 5 сьютов падают **и на родителе** (`origin/main` @ `0882f9a5`) — они зависят от неинициализированного локально сабмодуля `exoas-exocmd` (`Expected length: 11 / Received length: 0`), в CI этого нет. Регрессии не внесено; сравнение с родителем предъявлено, а не предположено.

`tsc --noEmit` — rc=0.

---

Дефект 3 из 3 по задаче `0c24668f` (vault-exodev). Дефект 1 (`NOT EXISTS` с внешней переменной) и 2 (`MINUS`) остаются — по второму есть гипотеза, что текущее поведение спек-корректно, и её надо проверить **до** «починки».
