### PR TITLE
fix(sparql): MINUS must subtract from the group that precedes it

### DIFF
--- a/packages/core/src/infrastructure/sparql/algebra/PatternTranslator.ts
+++ b/packages/core/src/infrastructure/sparql/algebra/PatternTranslator.ts
@@ -123,6 +123,24 @@ export class PatternTranslator {
             right: this.translateWhere(rightPattern.patterns),
             expression: rightOptExpr ? this.translateExpressionFn(rightOptExpr) : undefined,
           } as LeftJoinOperation;
+        } else if (rightPattern.type === "minus") {
+          // MINUS subtracts from the group that PRECEDES it (SPARQL 1.1
+          // §8.3.2 / §18.5: `{ P } MINUS { Q }` = Diff(eval(P), eval(Q))).
+          //
+          // ⛔ Falling through to the generic `join` below produced
+          // `Join(P, Minus(∅, Q))`, which is NOT the same operation:
+          // `Minus(∅, Q)` shares no variables with Q, so it removes nothing and
+          // yields the single empty solution; joining P with that returns P
+          // unchanged. MINUS degraded to a silent no-op in every query that had
+          // anything before it — i.e. in every real query.
+          //
+          // Mirrors the OPTIONAL branch above, which already threads `result`
+          // as its left operand for exactly the same reason.
+          result = {
+            type: "minus",
+            left: result,
+            right: this.translateWhere(rightPattern.patterns),
+          } as MinusOperation;
         } else {
           const right = this.translatePattern(rightPattern);
           result = { type: "join", left: result, right };

--- a/packages/core/tests/unit/infrastructure/sparql/AlgebraTranslator.test.ts
+++ b/packages/core/tests/unit/infrastructure/sparql/AlgebraTranslator.test.ts
@@ -329,11 +329,14 @@ describe("AlgebraTranslator", () => {
 
       expect(algebra.type).toBe("project");
       const input = (algebra as any).input;
-      expect(input.type).toBe("join");
+      // ⛔ This asserted "join" until 2026-08-20, codifying the defect:
+      // `Join(P, Minus(∅, Q))` left MINUS subtracting from nothing, so the
+      // query returned ALL tasks including the done ones. The operator has to
+      // BE the top node with P as its left operand.
+      expect(input.type).toBe("minus");
 
-      const minusOp = input.right;
-      expect(minusOp.type).toBe("minus");
-      expect(minusOp.right.type).toBe("bgp");
+      expect(input.left.type).toBe("bgp");
+      expect(input.right.type).toBe("bgp");
     });
 
     it("translates MINUS with multiple patterns", () => {
@@ -353,12 +356,11 @@ describe("AlgebraTranslator", () => {
 
       expect(algebra.type).toBe("project");
       const input = (algebra as any).input;
-      expect(input.type).toBe("join");
+      expect(input.type).toBe("minus");
 
-      const minusOp = input.right;
-      expect(minusOp.type).toBe("minus");
+      expect(input.left.type).toBe("bgp");
       // The right side should be a BGP with 2 triples or a join of BGPs
-      expect(minusOp.right).toBeDefined();
+      expect(input.right).toBeDefined();
     });
 
     it("translates MINUS combined with OPTIONAL", () => {
@@ -375,9 +377,11 @@ describe("AlgebraTranslator", () => {
       const algebra = translator.translate(ast);
 
       expect(algebra.type).toBe("project");
-      // Should have join of (join(bgp, leftjoin)), minus)
+      // Minus(LeftJoin(bgp, opt), Q) — MINUS subtracts from EVERYTHING that
+      // precedes it, which here includes the OPTIONAL group.
       const input = (algebra as any).input;
-      expect(input.type).toBe("join");
+      expect(input.type).toBe("minus");
+      expect(input.left.type).toBe("leftjoin");
     });
   });
 

--- a/packages/core/tests/unit/infrastructure/sparql/algebra/PatternTranslator.minusLeftOperand.test.ts
+++ b/packages/core/tests/unit/infrastructure/sparql/algebra/PatternTranslator.minusLeftOperand.test.ts
@@ -1,0 +1,123 @@
+import { PatternTranslator } from "../../../../../src/infrastructure/sparql/algebra/PatternTranslator";
+import type { AlgebraOperation } from "../../../../../src/infrastructure/sparql/algebra/AlgebraOperation";
+import type {
+  SparqljsPattern,
+  SparqljsExpression,
+} from "../../../../../src/infrastructure/sparql/SparqljsTypes";
+import type { SelectQuery } from "../../../../../src/infrastructure/sparql/SPARQLParser";
+
+/**
+ * MINUS must subtract from the PRECEDING patterns, not from nothing.
+ *
+ * SPARQL 1.1 §8.3.2 / §18.5: `{ P } MINUS { Q }` is `Diff(eval(P), eval(Q))`.
+ * The left operand of the algebra's Minus IS the group that precedes it.
+ *
+ * ⛔ The defect: `translateWhere` had a dedicated branch for OPTIONAL (which
+ * correctly threads `left: result`) but NOT for MINUS, so MINUS fell into the
+ * generic `else` and became `Join(P, Minus(∅, Q))`. That is not the same
+ * operation — `Minus(∅, Q)` yields the single empty solution (it shares no
+ * variables with Q, so nothing is removed), and joining P with one empty
+ * solution returns P UNCHANGED. MINUS silently degraded to a no-op.
+ *
+ * ⛤ Why it stayed hidden: the existing translator tests assert only
+ * `result.type === "minus"` on a STANDALONE MINUS pattern. Standalone MINUS is
+ * exactly the one case where an empty left operand is CORRECT — so every test
+ * passed while the operator did nothing in every real query, which always has
+ * a preceding group.
+ *
+ * The four axes below lock the left operand itself. The fifth is a CANARY: a
+ * standalone MINUS must KEEP its empty left, otherwise a fix that blindly
+ * threads `result` everywhere would go unnoticed.
+ */
+describe("PatternTranslator — MINUS left operand", () => {
+  let translator: PatternTranslator;
+
+  const mockTranslateExpression = jest.fn((_expr: SparqljsExpression) => ({
+    type: "literal" as const,
+    value: "mock",
+  }));
+  const mockTranslateSelect = jest.fn(
+    (_query: SelectQuery) => ({ type: "bgp" as const, triples: [] }) as AlgebraOperation
+  );
+  // Distinguishable BGPs: the assertions must be able to tell WHICH group
+  // ended up on the left, not merely that something non-empty is there.
+  const mockTranslateBGP = jest.fn(
+    (pattern: SparqljsPattern) =>
+      ({
+        type: "bgp" as const,
+        triples: ((pattern as unknown as { triples?: unknown[] }).triples ?? []) as never[],
+      }) as AlgebraOperation
+  );
+
+  const bgp = (marker: string): SparqljsPattern =>
+    ({
+      type: "bgp",
+      triples: [{ subject: { termType: "Variable", value: marker } }],
+    }) as unknown as SparqljsPattern;
+
+  const minusOf = (inner: SparqljsPattern): SparqljsPattern =>
+    ({ type: "minus", patterns: [inner] }) as unknown as SparqljsPattern;
+
+  const leftMarker = (op: AlgebraOperation): string | undefined => {
+    const triples = (op as unknown as { triples?: Array<{ subject?: { value?: string } }> }).triples;
+    return triples?.[0]?.subject?.value;
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    translator = new PatternTranslator({
+      translateExpression: mockTranslateExpression,
+      translateSelect: mockTranslateSelect,
+      translateBGP: mockTranslateBGP,
+    });
+  });
+
+  it("produces a Minus at the top, not a Join wrapping an empty-left Minus", () => {
+    const result = translator.translateWhere([bgp("P"), minusOf(bgp("Q"))]);
+
+    // ⛔ Before the fix this was "join" — the operator was still THERE, just
+    // subtracting from nothing, which is why no existing test caught it.
+    expect(result.type).toBe("minus");
+  });
+
+  it("puts the preceding group on the left of MINUS", () => {
+    const result = translator.translateWhere([bgp("P"), minusOf(bgp("Q"))]);
+
+    expect(result.type).toBe("minus");
+    const left = (result as unknown as { left: AlgebraOperation }).left;
+    expect(leftMarker(left)).toBe("P");
+  });
+
+  it("keeps the MINUS inner group on the right", () => {
+    const result = translator.translateWhere([bgp("P"), minusOf(bgp("Q"))]);
+
+    const right = (result as unknown as { right: AlgebraOperation }).right;
+    expect(leftMarker(right)).toBe("Q");
+  });
+
+  it("subtracts from EVERYTHING that precedes it, not just the nearest pattern", () => {
+    // { P . R . MINUS { Q } }  →  Minus(Join(P, R), Q)
+    const result = translator.translateWhere([bgp("P"), bgp("R"), minusOf(bgp("Q"))]);
+
+    expect(result.type).toBe("minus");
+    const left = (result as unknown as { left: AlgebraOperation }).left;
+    // The left operand must be the JOIN of both preceding groups — if only the
+    // nearest one were threaded, MINUS would subtract from a wider set than the
+    // query describes and silently return rows it should have removed.
+    expect(left.type).toBe("join");
+    expect(leftMarker((left as unknown as { left: AlgebraOperation }).left)).toBe("P");
+    expect(leftMarker((left as unknown as { right: AlgebraOperation }).right)).toBe("R");
+  });
+
+  it("CANARY: a standalone MINUS keeps its empty left operand", () => {
+    // Nothing precedes it, so subtracting from the empty solution set is the
+    // CORRECT reading here. This axis stays green in BOTH states — it is what
+    // proves the fix threads the preceding group rather than inventing one.
+    const result = translator.translatePattern(minusOf(bgp("Q")));
+
+    expect(result.type).toBe("minus");
+    const left = (result as unknown as { left: AlgebraOperation }).left;
+    expect(left.type).toBe("bgp");
+    expect(((left as unknown as { triples: unknown[] }).triples ?? []).length).toBe(0);
+  });
+});

--- a/packages/core/tests/unit/sparql/minus-acceptance.test.ts
+++ b/packages/core/tests/unit/sparql/minus-acceptance.test.ts
@@ -1,0 +1,123 @@
+/**
+ * End-to-end acceptance for MINUS (vault-exodev task 0c24668f, defect 2).
+ *
+ * The translator-level axes in
+ * `algebra/PatternTranslator.minusLeftOperand.test.ts` lock the SHAPE
+ * (`Minus(P, Q)` instead of `Join(P, Minus(∅, Q))`). These axes lock the
+ * OBSERVABLE: how many rows the engine actually returns.
+ *
+ * ⛔ The measurement that exposed the defect, on a live 303k-triple vault:
+ * `SELECT ?s WHERE { ?s exo:Asset_uid ?u . MINUS { ?s ?y ?z } }` returned all
+ * 17025 subjects. Every subject has at least one triple, so the right side
+ * subsumes the left and the answer had to be 0. MINUS was a silent no-op.
+ *
+ * ⛤ The two-form probe is what made it conclusive: with NO shared variable
+ * (`MINUS { ?x ?y ?z }`) returning everything is CORRECT per SPARQL 1.1 §18.5,
+ * and that form alone would have "confirmed" the engine was fine. Only the
+ * shared-variable form discriminates — so both are kept below, the disjoint one
+ * as a canary that the fix did not overcorrect into removing rows it must keep.
+ */
+
+import { InMemoryTripleStore } from "../../../src/infrastructure/rdf/InMemoryTripleStore";
+import { SPARQLParser } from "../../../src/infrastructure/sparql/SPARQLParser";
+import { ExoQLAlgebraTranslator } from "../../../src/infrastructure/sparql/algebra/AlgebraTranslator";
+import { ExoQLQueryExecutor } from "../../../src/infrastructure/sparql/executors/QueryExecutor";
+import { Triple } from "../../../src/domain/models/rdf/Triple";
+import { IRI } from "../../../src/domain/models/rdf/IRI";
+import { Literal } from "../../../src/domain/models/rdf/Literal";
+import { Namespace } from "../../../src/domain/models/rdf/Namespace";
+
+describe("MINUS — subtracts from the preceding group (defect 0c24668f-2)", () => {
+  let store: InMemoryTripleStore;
+  let parser: SPARQLParser;
+  let translator: ExoQLAlgebraTranslator;
+
+  const task1 = new IRI("urn:exo:task-1");
+  const task2 = new IRI("urn:exo:task-2");
+  const task3 = new IRI("urn:exo:task-3");
+  const other = new IRI("urn:exo:unrelated");
+
+  const hasLabel = Namespace.EXO.term("Asset_label");
+  const hasStatus = Namespace.EMS.term("Effort_status");
+  const hasNote = Namespace.EXO.term("Asset_note");
+  const statusDone = new IRI("urn:exo:status-done");
+
+  async function executeQuery(sparql: string) {
+    const ast = parser.parse(sparql);
+    const algebra = translator.translate(ast);
+    return new ExoQLQueryExecutor(store).executeAll(algebra);
+  }
+
+  const PREFIXES = `
+    PREFIX exo: <https://exocortex.my/ontology/exo#>
+    PREFIX ems: <https://exocortex.my/ontology/ems#>
+  `;
+
+  beforeEach(async () => {
+    store = new InMemoryTripleStore();
+    parser = new SPARQLParser();
+    translator = new ExoQLAlgebraTranslator();
+
+    await store.addAll([
+      new Triple(task1, hasLabel, new Literal("One")),
+      new Triple(task2, hasLabel, new Literal("Two")),
+      new Triple(task3, hasLabel, new Literal("Three")),
+      // task2 is the one MINUS must remove
+      new Triple(task2, hasStatus, statusDone),
+      // A subject that is NOT in the left side at all — present so the
+      // "subtract everything" axis cannot pass by the store being trivial.
+      new Triple(other, hasNote, new Literal("noise")),
+    ]);
+  });
+
+  it("removes the matching subject (the textbook case)", async () => {
+    const rows = await executeQuery(`${PREFIXES}
+      SELECT ?task WHERE {
+        ?task exo:Asset_label ?label .
+        MINUS { ?task ems:Effort_status ?st }
+      }`);
+
+    // ⛔ Before the fix this returned all THREE — MINUS removed nothing.
+    const got = rows.map((r) => (r.get("task") as IRI).value).sort();
+    expect(got).toEqual(["urn:exo:task-1", "urn:exo:task-3"]);
+  });
+
+  it("returns nothing when the right side subsumes the left", async () => {
+    // This is the live-vault measurement in miniature: every ?task has at
+    // least one triple, so the whole left side must be subtracted.
+    const rows = await executeQuery(`${PREFIXES}
+      SELECT ?task WHERE {
+        ?task exo:Asset_label ?label .
+        MINUS { ?task ?p ?o }
+      }`);
+
+    expect(rows).toHaveLength(0);
+  });
+
+  it("subtracts from EVERYTHING that precedes it, not just the nearest group", async () => {
+    // { label . status . MINUS { … } } — the left operand is the join of both.
+    await store.addAll([new Triple(task1, hasStatus, statusDone)]);
+
+    const rows = await executeQuery(`${PREFIXES}
+      SELECT ?task WHERE {
+        ?task exo:Asset_label ?label .
+        ?task ems:Effort_status ?st .
+        MINUS { ?task ems:Effort_status <urn:exo:status-done> }
+      }`);
+
+    // task1 and task2 are both done → both removed; nothing survives.
+    expect(rows).toHaveLength(0);
+  });
+
+  it("CANARY: MINUS with NO shared variable removes nothing (SPARQL 1.1 §18.5)", async () => {
+    // Green in BOTH states. Its job is to catch an overcorrection — a fix that
+    // made MINUS subtract unconditionally would turn this to 0 and be wrong.
+    const rows = await executeQuery(`${PREFIXES}
+      SELECT ?task WHERE {
+        ?task exo:Asset_label ?label .
+        MINUS { ?x ?y ?z }
+      }`);
+
+    expect(rows).toHaveLength(3);
+  });
+});


### PR DESCRIPTION
## Что сломано

```sparql
SELECT ?s WHERE { ?s exo:Asset_uid ?u . MINUS { ?s ?y ?z } }
```

На живом vault (303k триплов) вернуло **все 17025 субъектов**. Каждый субъект имеет хотя бы один трипл ⇒ правая сторона поглощает левую ⇒ ответ обязан быть **0**. `MINUS` был **тихим no-op**.

## Исполнитель ни при чём — ломалась ТРАНСЛЯЦИЯ

`MinusExecutor` реализует SPARQL 1.1 §18.5 дословно (включая «без общих переменных не удаляет ничего»), `executeMinus` корректно собирает обе стороны.

У `translateWhere` есть выделенная ветка для `OPTIONAL`, тянущая `left: result`. Для `MINUS` её **не было** — он падал в генерический `else`:

```
Join(P, Minus(∅, Q))        вместо        Minus(P, Q)
```

`Minus(∅, Q)` не делит с `Q` ни одной переменной ⇒ ничего не удаляет ⇒ отдаёт одно пустое решение; join `P` с одним пустым решением возвращает `P` **без изменений**. Оператор присутствовал и не делал ничего — в каждом запросе, где перед ним что-то стоит, то есть в каждом реальном.

## ⛤ Почему дожило: тесты запирали БАГ

Существующие тесты транслятора проверяли `result.type === "minus"` на **standalone**-паттерне — а это единственный случай, где пустая левая **корректна** (перед `MINUS` ничего нет). Набор был зелёным, пока оператор был инертен.

Три ассерта в `AlgebraTranslator.test.ts` ожидали `input.type === "join"`, то есть **кодифицировали сам дефект**. Они обновлены на `"minus"` и **усилены**: теперь запирают и левую сторону, которую **ни один** из них не проверял вовсе. Ровно поэтому набор не мог поймать регрессию, которую номинально покрывал.

## Фикс

Ветка для `minus`, зеркальная `OPTIONAL`.

## Revert-verify — два уровня, у каждого своя канарейка

| уровень | до фикса | после |
|---|---|---|
| **трансляция** (`PatternTranslator.minusLeftOperand.test.ts`) | 4 RED | **5 GREEN** |
| **исполнение** (`minus-acceptance.test.ts`, in-memory store) | 3 RED | **4 GREEN** |

Канарейки зелены в **обоих** состояниях:
- standalone `MINUS` сохраняет пустую левую;
- `MINUS` без общей переменной по-прежнему **не** удаляет ничего (§18.5).

Именно они ловят переusправление: фикс, который стал бы вычитать безусловно, покрасил бы ровно их.

⛤ Трансляционные оси запирают **форму**, e2e — **наблюдаемое** (сколько строк реально вернул движок). Одних форм-осей мало: они не отвечают на вопрос, ради которого фикс и делается.

## ⛤ Метод: гипотезу опровергло исполнение, а не рассуждение о спеке

Первой гипотезой было, что поведение **спек-корректно** — §18.5 говорит, что `MINUS` без общих переменных не вычитает ничего, и исходный замер мог просто использовать несвязанный inner-паттерн. Разрешил вопрос прогон **обеих** форм на живом vault:

| форма | ожидание | получено |
|---|---|---|
| `MINUS { ?x ?y ?z }` (нет общих переменных) | 17025 — не вычитает, спека | 17025 ✅ |
| `MINUS { ?s ?y ?z }` (делит `?s`) | **0** | **17025** ⛔ |

Форма без общей переменной **одна** «подтвердила» бы исправность движка. Дискриминирует только вторая.

## Регрессия

Полный core-набор: **8579 passed**, 9 failed / 5 сьютов — **те же 9 тестов и те же 5 сьютов, что на родителе** (зависят от неинициализированного локально сабмодуля `exoas-exocmd`, в CI этого нет). Сравнение с родителем предъявлено замером, а не предположено.

`tsc --noEmit` — rc=0.

---

Дефект 2 из 3 по задаче `0c24668f` (vault-exodev). Дефект 3 отгружен в #4105. Дефект 1 (`NOT EXISTS` с внешней переменной во внутреннем `FILTER`) локализован: `evaluateExistsPattern` исполняет паттерн **до** подстановки внешних привязок, поэтому внутренний `FILTER` видит внешнюю переменную несвязанной; механизм подстановки в классе уже есть (bind-join). Отдельным PR.
