### PR TITLE
fix(sparql): EXISTS must substitute outer bindings into its pattern

### DIFF
--- a/packages/core/src/infrastructure/sparql/executors/QueryExecutor.ts
+++ b/packages/core/src/infrastructure/sparql/executors/QueryExecutor.ts
@@ -156,10 +156,25 @@ export class ExoQLQueryExecutor {
     pattern: AlgebraOperation,
     solution: SolutionMapping
   ): Promise<boolean> {
-    // Execute the pattern and check if any result is found
-    // The pattern is evaluated against the full triple store,
-    // but we need to join with current bindings
-    for await (const result of this.execute(pattern)) {
+    // SPARQL 1.1 §8.1.1: EXISTS is evaluated by SUBSTITUTING the current
+    // solution into the pattern, then asking whether the result is non-empty.
+    //
+    // ⛔ Executing the bare pattern and merging afterwards is NOT equivalent.
+    // It happens to work for a plain BGP — `merge` discards the incompatible
+    // rows after the fact — but not for anything that READS an outer variable
+    // while the pattern runs. A nested `FILTER(?score > ?limit)` sees `?limit`
+    // unbound, drops every row, EXISTS is false, and `NOT EXISTS` becomes
+    // unconditionally TRUE. Measured on a live vault: 519 of 519 rows survived
+    // a filter that should have kept 116.
+    //
+    // Substituting first is the same bind-join mechanism `executeJoin` already
+    // uses, and `substituteInOperation` deliberately recurses into filter
+    // expressions ("handles EXISTS/NOT EXISTS patterns") for exactly this.
+    const boundPattern = this.substituteVariables(pattern, solution);
+
+    // The post-substitution merge is KEPT: substitution rewrites the variables
+    // it can see, and the merge still guards the rows it cannot.
+    for await (const result of this.execute(boundPattern)) {
       // Check if result is compatible with current solution
       const merged = solution.merge(result);
       if (merged !== null) {
@@ -691,6 +706,28 @@ export class ExoQLQueryExecutor {
       expr.pattern = this.substituteInOperation(expr.pattern as AlgebraOperation, bindings);
     }
 
+    // ⛔ A variable REFERENCE inside an expression was never replaced — this
+    // method only recursed. Recursion alone is enough for a bind join (the
+    // BGP triples carry the correlation), but not for EXISTS: SPARQL 1.1
+    // §8.1.1 evaluates EXISTS by substituting the outer solution INTO the
+    // pattern, and an inner `FILTER(?score > ?limit)` reads `?limit` while
+    // that pattern runs. Unsubstituted, it is unbound, the filter drops every
+    // row, EXISTS is false and NOT EXISTS becomes unconditionally TRUE.
+    //
+    // Expression position stores the name in `.name` (triple position uses
+    // `.value`), so the node is rewritten in place into the literal/iri it is
+    // bound to. Unbound variables are LEFT ALONE — they must stay variables so
+    // the inner pattern can still bind them itself.
+    if (expr.type === 'variable' && typeof expr.name === 'string') {
+      const asTerm = this.termToAlgebraNode(bindings.get(expr.name));
+      if (asTerm !== null) {
+        delete expr.name;
+        for (const [key, val] of Object.entries(asTerm)) {
+          expr[key] = val;
+        }
+      }
+    }
+
     // Recurse into sub-expressions
     if (expr.left) this.substituteInExpression(expr.left as Record<string, unknown>, bindings);
     if (expr.right) this.substituteInExpression(expr.right as Record<string, unknown>, bindings);
@@ -730,25 +767,41 @@ export class ExoQLQueryExecutor {
    */
   private substituteInTripleElement(element: Record<string, unknown>, bindings: SolutionMapping): unknown {
     if (element && element.type === 'variable') {
-      const value = bindings.get(element.value as string);
-      if (value != null) {
-        const valueRecord = value as unknown as Record<string, unknown>;
-        // Convert RDF term to algebra representation
-        if (value instanceof IRI || valueRecord.termType === 'NamedNode') {
-          return { type: 'iri', value: (value as { value: string }).value };
-        }
-        // Handle Literal
-        if (valueRecord.termType === 'Literal' || typeof valueRecord.value === 'string') {
-          return {
-            type: 'literal',
-            value: valueRecord.value,
-            datatype: (valueRecord.datatype as Record<string, unknown>)?.value ?? (valueRecord._datatype as Record<string, unknown>)?.value,
-            language: valueRecord.language ?? valueRecord._language,
-          };
-        }
+      // In TRIPLE position the variable name lives in `.value`; in EXPRESSION
+      // position it lives in `.name` (see substituteInExpression).
+      const asTerm = this.termToAlgebraNode(bindings.get(element.value as string));
+      if (asTerm !== null) {
+        return asTerm;
       }
     }
     return element;
+  }
+
+  /**
+   * Convert a bound RDF term into its algebra node, or null if there is no
+   * usable binding. Shared by triple-position and expression-position
+   * substitution so the two can never drift on datatype/language handling.
+   */
+  private termToAlgebraNode(value: unknown): Record<string, unknown> | null {
+    if (value == null) {
+      return null;
+    }
+    const valueRecord = value as unknown as Record<string, unknown>;
+
+    if (value instanceof IRI || valueRecord.termType === 'NamedNode') {
+      return { type: 'iri', value: (value as { value: string }).value };
+    }
+
+    if (valueRecord.termType === 'Literal' || typeof valueRecord.value === 'string') {
+      return {
+        type: 'literal',
+        value: valueRecord.value,
+        datatype: (valueRecord.datatype as Record<string, unknown>)?.value ?? (valueRecord._datatype as Record<string, unknown>)?.value,
+        language: valueRecord.language ?? valueRecord._language,
+      };
+    }
+
+    return null;
   }
 
   /**

--- a/packages/core/tests/unit/sparql/exists-outer-vars-acceptance.test.ts
+++ b/packages/core/tests/unit/sparql/exists-outer-vars-acceptance.test.ts
@@ -1,0 +1,128 @@
+/**
+ * NOT EXISTS / EXISTS must see the OUTER solution's bindings inside their
+ * pattern — including inside a nested FILTER.
+ *
+ * SPARQL 1.1 §8.1.1: EXISTS is evaluated by SUBSTITUTING the current solution
+ * into the pattern and asking whether the result is non-empty. The substitution
+ * is the whole mechanism; without it the inner group is evaluated against the
+ * bare store and any reference to an outer variable is unbound.
+ *
+ * ⛔ The defect (vault-exodev task 0c24668f, defect 1): `evaluateExistsPattern`
+ * executed the pattern FIRST and only then merged each result with the outer
+ * solution. For a plain BGP that accidentally works — `merge` filters the
+ * incompatible rows after the fact. For an inner FILTER comparing against an
+ * OUTER variable it does not: that variable is unbound while the filter runs,
+ * so the filter drops everything, EXISTS is false, and `NOT EXISTS` is
+ * unconditionally TRUE. The live measurement was 519 of 519 rows surviving a
+ * filter that should have kept 116.
+ *
+ * ⛤ Why this shape and not a bare `NOT EXISTS { ?s ?p ?o }`: the post-hoc merge
+ * makes the simple cases pass, which is exactly why the defect survived. Only a
+ * comparison against an outer variable discriminates.
+ */
+
+import { InMemoryTripleStore } from "../../../src/infrastructure/rdf/InMemoryTripleStore";
+import { SPARQLParser } from "../../../src/infrastructure/sparql/SPARQLParser";
+import { ExoQLAlgebraTranslator } from "../../../src/infrastructure/sparql/algebra/AlgebraTranslator";
+import { ExoQLQueryExecutor } from "../../../src/infrastructure/sparql/executors/QueryExecutor";
+import { Triple } from "../../../src/domain/models/rdf/Triple";
+import { IRI } from "../../../src/domain/models/rdf/IRI";
+import { Literal } from "../../../src/domain/models/rdf/Literal";
+import { Namespace } from "../../../src/domain/models/rdf/Namespace";
+
+describe("EXISTS / NOT EXISTS — outer variables inside the pattern", () => {
+  let store: InMemoryTripleStore;
+  let parser: SPARQLParser;
+  let translator: ExoQLAlgebraTranslator;
+
+  const taskA = new IRI("urn:exo:task-a");
+  const taskB = new IRI("urn:exo:task-b");
+  const taskC = new IRI("urn:exo:task-c");
+
+  const hasScore = Namespace.EXO.term("Asset_score");
+  const hasLimit = Namespace.EXO.term("Asset_limit");
+  const hasLabel = Namespace.EXO.term("Asset_label");
+  const xsdInteger = new IRI("http://www.w3.org/2001/XMLSchema#integer");
+
+  const PREFIXES = `
+    PREFIX exo: <https://exocortex.my/ontology/exo#>
+  `;
+
+  async function executeQuery(sparql: string) {
+    const ast = parser.parse(sparql);
+    const algebra = translator.translate(ast);
+    return new ExoQLQueryExecutor(store).executeAll(algebra);
+  }
+
+  beforeEach(async () => {
+    store = new InMemoryTripleStore();
+    parser = new SPARQLParser();
+    translator = new ExoQLAlgebraTranslator();
+
+    // Each task carries a score and a limit. "Over limit" = score > limit.
+    // taskA: 10 > 5  → over        taskB: 3 > 5 → not over
+    // taskC: 8 > 5  → over
+    await store.addAll([
+      new Triple(taskA, hasLabel, new Literal("A")),
+      new Triple(taskA, hasScore, new Literal("10", xsdInteger)),
+      new Triple(taskA, hasLimit, new Literal("5", xsdInteger)),
+
+      new Triple(taskB, hasLabel, new Literal("B")),
+      new Triple(taskB, hasScore, new Literal("3", xsdInteger)),
+      new Triple(taskB, hasLimit, new Literal("5", xsdInteger)),
+
+      new Triple(taskC, hasLabel, new Literal("C")),
+      new Triple(taskC, hasScore, new Literal("8", xsdInteger)),
+      new Triple(taskC, hasLimit, new Literal("5", xsdInteger)),
+    ]);
+  });
+
+  it("EXISTS sees an outer variable used inside a nested FILTER", async () => {
+    const rows = await executeQuery(`${PREFIXES}
+      SELECT ?task WHERE {
+        ?task exo:Asset_limit ?limit .
+        FILTER EXISTS { ?task exo:Asset_score ?score . FILTER(?score > ?limit) }
+      }`);
+
+    const got = rows.map((r) => (r.get("task") as IRI).value).sort();
+    expect(got).toEqual(["urn:exo:task-a", "urn:exo:task-c"]);
+  });
+
+  it("NOT EXISTS is not unconditionally true when the inner FILTER uses an outer variable", async () => {
+    const rows = await executeQuery(`${PREFIXES}
+      SELECT ?task WHERE {
+        ?task exo:Asset_limit ?limit .
+        FILTER NOT EXISTS { ?task exo:Asset_score ?score . FILTER(?score > ?limit) }
+      }`);
+
+    // ⛔ Before the fix this returned ALL THREE — the inner filter saw ?limit
+    // unbound, matched nothing, so NOT EXISTS was true for every row.
+    const got = rows.map((r) => (r.get("task") as IRI).value);
+    expect(got).toEqual(["urn:exo:task-b"]);
+  });
+
+  it("CANARY: plain NOT EXISTS over a BGP (no inner FILTER) keeps working", async () => {
+    // Green in BOTH states — the post-hoc merge already handled this shape.
+    // It is here so that a fix which broke the simple path could not hide.
+    await store.addAll([new Triple(taskB, Namespace.EXO.term("Asset_flag"), new Literal("x"))]);
+
+    const rows = await executeQuery(`${PREFIXES}
+      SELECT ?task WHERE {
+        ?task exo:Asset_limit ?limit .
+        FILTER NOT EXISTS { ?task exo:Asset_flag ?f }
+      }`);
+
+    const got = rows.map((r) => (r.get("task") as IRI).value).sort();
+    expect(got).toEqual(["urn:exo:task-a", "urn:exo:task-c"]);
+  });
+
+  it("CANARY: EXISTS over a BGP correlated only by the shared subject keeps working", async () => {
+    const rows = await executeQuery(`${PREFIXES}
+      SELECT ?task WHERE {
+        ?task exo:Asset_limit ?limit .
+        FILTER EXISTS { ?task exo:Asset_score ?score }
+      }`);
+
+    expect(rows).toHaveLength(3);
+  });
+});


### PR DESCRIPTION
## Что сломано

```sparql
SELECT ?task WHERE {
  ?task ems:limit ?limit .
  FILTER NOT EXISTS { ?task ems:score ?score . FILTER(?score > ?limit) }
}
```

`NOT EXISTS` был **безусловно TRUE**. На живом vault фильтр пропустил **519 из 519** строк там, где должен был оставить 116.

## Механизм

SPARQL 1.1 §8.1.1: `EXISTS` вычисляется **подстановкой** текущего решения в паттерн с последующей проверкой на непустоту. `evaluateExistsPattern` делал наоборот — исполнял голый паттерн и **потом** мержил каждый результат с внешним решением.

Для простого BGP это **случайно работает**: `merge` отбрасывает несовместимые строки постфактум. Не работает для всего, что **читает** внешнюю переменную **во время** исполнения паттерна: внутренний `FILTER(?score > ?limit)` видит `?limit` несвязанной, отбрасывает все строки, `EXISTS` = false, `NOT EXISTS` = true для всего.

⛤ Эта случайность и есть причина живучести: любая простая форма `EXISTS` ведёт себя корректно, поэтому оператор выглядит здоровым, пока не появится коррелированный фильтр.

## Две правки, и настоящая — вторая

**1.** `evaluateExistsPattern` подставляет привязки перед исполнением — тот же bind-join, что уже использует `executeJoin`.

**2.** ⛔ **Одно это не изменило НИЧЕГО**, и падающий repro так и сказал. Четырёхслучайная проба изолировала слой:

| проба | до |
|---|---|
| var-vs-var `FILTER` вне `EXISTS` | ✅ работает |
| `EXISTS` над BGP | ✅ работает |
| `EXISTS` + внутренний `FILTER` по **константе** | ✅ работает |
| `EXISTS` + внутренний `FILTER` по **внешней переменной** | ⛔ пусто |

`substituteInExpression` **только рекурсировала** по выражениям — она никогда не заменяла ссылку на переменную её значением. Рекурсии достаточно для bind-join (корреляцию несут триплы BGP) и недостаточно здесь.

Теперь связанный узел `{type:"variable", name}` переписывается на месте в literal/iri, которым он связан.

⛤ В **позиции выражения** имя лежит в `.name`, в **позиции трипла** — в `.value`; поэтому это никогда не был один путь. Конверсия терма вынесена в общий `termToAlgebraNode`, чтобы обработка datatype/language не могла разойтись между ними.

**Несвязанные переменные намеренно не трогаются** — они обязаны остаться переменными, чтобы внутренний паттерн мог связать их сам.

## Revert-verify

**2 RED → 4 GREEN.** Две из четырёх — **канарейки**, зелёные в **обоих** состояниях: простой `NOT EXISTS` над BGP и `EXISTS`, коррелированный только общим субъектом. Они существуют потому, что фикс трогает путь подстановки, которым пользуется **каждый** bind-join; правка, сломавшая простые формы, иначе выглядела бы чистым прогоном.

## Регрессия

Полный core-набор — **два** прогона:

| прогон | сьютов | тестов |
|---|---|---|
| 1-й | 6 failed | 10 failed |
| 2-й | **5 failed** | **9 failed** |
| родитель (замерено ранее) | 5 failed | 9 failed |

Расхождение — `tests/performance/TripleStorePerformance.test.ts`. Это **не** регрессия, и доказано двумя независимыми способами:

1. **Механически:** в тесте **0** упоминаний `EXISTS` и **0** упоминаний движка запросов — он меряет только `InMemoryTripleStore`. Правка живёт в `QueryExecutor` ⇒ её код там не исполняется **by construction**.
2. **Воспроизводимостью:** изолированный прогон — 11/11 passed; второй полный прогон — зелёный.

Пороги теста — `toBeLessThan(1)` мс, то есть он структурно чувствителен к нагрузке полного `--runInBand`.

Остальные 5 сьютов / 9 тестов зависят от неинициализированного локально сабмодуля `exoas-exocmd` — они же падают на родителе, в CI этого нет.

`tsc --noEmit` — rc=0.

---

Дефект 1 из 3 по задаче `0c24668f` (vault-exodev). Дефекты 2 и 3 отгружены в #4106 и #4105 — все три независимы, у каждого свой red-before/green-after.
