### PR TITLE
feat(archgate): MOBILE-005 — ban the ES2022 runtime APIs tsc lets through

### DIFF
--- a/.archgate/adrs/MOBILE-005-no-silent-es2022-runtime-api.md
+++ b/.archgate/adrs/MOBILE-005-no-silent-es2022-runtime-api.md
@@ -1,0 +1,80 @@
+---
+id: MOBILE-005
+title: No ES2022 runtime APIs that tsc accepts under target ES2020
+domain: frontend
+rules: true
+files:
+  [
+    "packages/core/src/**/*.ts",
+    "packages/core/src/**/*.tsx",
+    "packages/services/src/**/*.ts",
+    "packages/services/src/**/*.tsx",
+  ]
+---
+
+# No Silent ES2022 Runtime APIs in Mobile-Reachable Src
+
+## Context
+
+`packages/core/tsconfig.json` sets `"target": "ES2020"` with
+`"lib": ["ES2020", "ES2022"]`. The `lib` entry types APIs the `target` does not
+downlevel, so some ES2022 runtime methods **type-check cleanly and ship a
+`TypeError`** on any runtime below Safari / iOS 15.4. The plugin builds with
+`isDesktopOnly: false`, so that runtime is in the delivery scope.
+
+The concrete trap (Issue #4064): an author "simplifying"
+
+```ts
+Object.prototype.hasOwnProperty.call(source, key)  →  Object.hasOwn(source, key)
+```
+
+gets a **green build and green CI**. Until this rule, the invariant was defended
+by a docstring in `keyPathResolver.ts` and nothing else — five point-fixes of the
+surrounding own-property class had already shipped (#4052, #4058, #4060, #4062,
+#4063) with the invariants kept in prose only.
+
+Fifth layer of the mobile cluster: #3464 module-eval imports (MOBILE-001),
+#3469 runtime `process` access (MOBILE-002), #3486 runtime `Buffer` access
+(MOBILE-003), #3535 desktop-only command gating (MOBILE-004), and this rule.
+
+## Decision
+
+The ban covers exactly the APIs **the compiler lets through** — measured, not
+assumed. Each candidate was run through `tsc` under both lib settings:
+
+| API | `--lib ES2020` | `--lib ES2020,ES2022` (the repo) | banned |
+| --- | --- | --- | --- |
+| `Object.hasOwn` | `TS2550` error | **no error** | yes |
+| `.at()` | no error | no error | yes |
+| `.findLast()` | `TS2550` error | `TS2550` error | **no** |
+
+`findLast` is deliberately EXCLUDED. `tsc` already refuses it under both
+settings, so banning it here would duplicate the compiler and imply a coverage
+this rule does not provide for the cases `tsc` misses. A guard that restates
+what another gate already enforces reads as broader than it is.
+
+Scope: `packages/core/src/**` and `packages/services/src/**` — both are bundled
+into the plugin transitively and therefore mobile-reachable.
+`packages/obsidian-plugin/src` is NOT scanned, mirroring MOBILE-003: it has
+legitimate desktop-only usage behind the lazy-node-modules boundary.
+
+Comments are skipped. Four live mentions of `Object.hasOwn` exist today and all
+four are docstrings warning against it — a guard that flagged its own warning
+text would be born red and would be silenced rather than obeyed.
+
+## Sanctioned replacements
+
+| banned | use instead |
+| --- | --- |
+| `Object.hasOwn(o, k)` | `Object.prototype.hasOwnProperty.call(o, k)`, or the `ownProperty` helper in `packages/core/src/domain/display-name/keyPathResolver.ts` |
+| `arr.at(-1)` | `arr[arr.length - 1]` |
+| `arr.at(i)` / `str.at(i)` | `arr[i]` / `str[i]` |
+
+## Consequences
+
+- A "simplification" to an ES2022 method in mobile-reachable code now fails the
+  `archgate` job (a required check) instead of passing CI and breaking on phones.
+- The rule does not replace raising the `target`/`lib` question — it makes the
+  current pairing safe to keep.
+- Heuristics are line-based, same trade-off as MOBILE-001/002/003; the known
+  false-negative and false-positive shapes are enumerated in the rules file.

--- a/.archgate/adrs/MOBILE-005-no-silent-es2022-runtime-api.rules.ts
+++ b/.archgate/adrs/MOBILE-005-no-silent-es2022-runtime-api.rules.ts
@@ -1,0 +1,132 @@
+/// <reference path="../rules.d.ts" />
+
+// MOBILE-005 — ban the ES2022 runtime APIs that the COMPILER LETS THROUGH.
+//
+// packages/core/tsconfig.json sets "target": "ES2020" with
+// "lib": ["ES2020", "ES2022"]. The lib entry types APIs the target does not
+// downlevel, so an author "simplifying"
+//   Object.prototype.hasOwnProperty.call(o, k)  →  Object.hasOwn(o, k)
+// gets a green build AND green CI, and ships a TypeError on any runtime below
+// Safari / iOS 15.4. The plugin builds with isDesktopOnly: false, so that
+// runtime is in scope. Until now this was defended by a docstring and nothing
+// else (Issue #4064; five point-fixes of the surrounding class had already
+// shipped: #4052, #4058, #4060, #4062, #4063).
+//
+// ⛤ SCOPE OF THE BAN IS MEASURED, NOT ASSUMED. Each candidate was run through
+// tsc under both lib settings; only the ones the compiler MISSES are banned:
+//
+//   API                  --lib ES2020    --lib ES2020,ES2022 (the repo)
+//   Object.hasOwn        TS2550 error    (no error)          ← banned
+//   .at()                (no error)      (no error)          ← banned
+//   .findLast()          TS2550 error    TS2550 error        ← NOT banned
+//
+// `findLast` is deliberately absent: tsc already owns it, and banning it here
+// would imply a coverage this rule does not provide for the cases tsc misses.
+// A guard that duplicates the compiler reads as broader than it is.
+//
+// Scanned: packages/core/src + packages/services/src — both are bundled into
+// the plugin transitively, so both are mobile-reachable. packages/obsidian-plugin/src
+// is NOT scanned, mirroring MOBILE-003: it has legitimate desktop-only usage
+// behind the lazy-node-modules boundary.
+//
+// Sanctioned replacements:
+//   Object.hasOwn(o, k)  →  Object.prototype.hasOwnProperty.call(o, k)
+//                           (or the `ownProperty` helper in
+//                            packages/core/src/domain/display-name/keyPathResolver.ts)
+//   arr.at(-1)           →  arr[arr.length - 1]
+//   arr.at(i) / str.at(i) →  arr[i] / str[i]  (or .charAt for strings)
+
+// Known heuristic limitations (line-based, same trade-off as MOBILE-001/002/003):
+//  - a `//` sequence inside a string literal truncates the scanned line, so a
+//    banned call AFTER it on the same line is missed (false negative);
+//  - a string literal containing `Object.hasOwn` would be flagged (false
+//    positive — none exist in scope; the four live mentions are all docstrings
+//    warning against it, and those are skipped as comments);
+//  - mid-line block comments (`/* Object.hasOwn */ code`) are not stripped;
+//  - `.at(` is matched on the call shape, so a user-defined method literally
+//    named `at` on a domain object would be flagged. None exist today (measured:
+//    zero `.at(` occurrences in either scanned package), and a domain method
+//    named `at` in platform-neutral code is itself worth a second look.
+
+interface BannedApi {
+  readonly grep: RegExp;
+  readonly line: RegExp;
+  readonly label: string;
+  readonly fix: string;
+}
+
+const BANNED: readonly BannedApi[] = [
+  {
+    // `Object.hasOwn(` — the method, not the word in prose.
+    grep: /Object\.hasOwn/,
+    line: /\bObject\s*\.\s*hasOwn\s*\(/,
+    label: "`Object.hasOwn`",
+    fix: "Use `Object.prototype.hasOwnProperty.call(source, key)` — or the `ownProperty` helper in packages/core/src/domain/display-name/keyPathResolver.ts, which already wraps it.",
+  },
+  {
+    // `.at(` — Array.prototype.at / String.prototype.at (ES2022).
+    //
+    // ⛔ The lookbehind sits immediately BEFORE THE DOT, not before the whole
+    // member expression. An earlier draft used `(?<![.\w$])[\w$\])]\s*\.\s*at\(`
+    // and matched NOTHING on `[key].at(0)`: the lookbehind then applies before
+    // the `]`, where the preceding char is `y` — a word char — so it failed.
+    // The axis was written before the regex and caught it; without that mutant
+    // the guard would have shipped enforcing only half of its stated ban.
+    grep: /\.at\(/,
+    line: /(?<!\.)\.\s*at\s*\(/,
+    label: "`.at()`",
+    fix: "Use index access — `arr[arr.length - 1]` for `.at(-1)`, `arr[i]` / `str[i]` otherwise.",
+  },
+];
+
+function isCommentLine(rawLine: string): boolean {
+  const trimmed = rawLine.trimStart();
+  return (
+    trimmed.startsWith("*") || trimmed.startsWith("//") || trimmed.startsWith("/*")
+  );
+}
+
+function stripTrailingComment(rawLine: string): string {
+  // Drop trailing line comments so prose like `// not Object.hasOwn` on the
+  // same line as clean code cannot flag it.
+  return rawLine.replace(/\/\/.*$/, "");
+}
+
+export default {
+  rules: {
+    "no-silent-es2022-runtime-api": {
+      description:
+        "ES2022 runtime APIs that tsc accepts under target ES2020 throw on Obsidian mobile below Safari/iOS 15.4 (Issue #4064)",
+      severity: "error",
+      async check(ctx) {
+        const files = [
+          ...(await ctx.glob("packages/core/src/**/*.{ts,tsx}")),
+          ...(await ctx.glob("packages/services/src/**/*.{ts,tsx}")),
+        ];
+
+        for (const file of files) {
+          for (const api of BANNED) {
+            const hits = await ctx.grep(file, api.grep);
+            if (hits.length === 0) continue;
+
+            const content = await ctx.readFile(file);
+            const lines = content.split("\n");
+
+            for (const hit of hits) {
+              const raw = lines[hit.line - 1] || "";
+              if (isCommentLine(raw)) continue;
+              if (!api.line.test(stripTrailingComment(raw))) continue;
+
+              ctx.report.violation({
+                message: `${api.label} is an ES2022 runtime API — it type-checks here only because tsconfig lists lib ES2022 while target is ES2020, and it throws a TypeError on Obsidian mobile below Safari/iOS 15.4 (Issue #4064).`,
+                file: hit.file,
+                line: hit.line,
+                fix: api.fix,
+              });
+            }
+          }
+        }
+      },
+    },
+  },
+} satisfies RuleSet;

--- a/packages/obsidian-plugin/tests/unit/build/archgate-mobile-005-patterns.test.ts
+++ b/packages/obsidian-plugin/tests/unit/build/archgate-mobile-005-patterns.test.ts
@@ -1,0 +1,111 @@
+import { readFileSync } from "fs";
+import * as path from "path";
+
+/**
+ * MOBILE-005 — the line matchers of the archgate rule, tested directly.
+ * @req:50b54def-5a44-4a49-b288-529d22aad5d9
+ *
+ * The rule itself is verified by running the archgate binary (a rule that
+ * merely REGISTERS raises `check passed` by one without proving it can fire —
+ * see ci-lint-job-is-not-just-eslint §A2). These axes cover the layer that
+ * prove-by-running does NOT: whether each matcher discriminates the shapes it
+ * claims to.
+ *
+ * ⛔ This is not theoretical. The first draft of the `.at(` matcher was
+ *
+ *     /(?<![.\w$])[\w$\])]\s*\.\s*at\s*\(/
+ *
+ * and it matched NOTHING on `[key].at(0)`. The lookbehind applies before the
+ * `]`, where the preceding character is `y` — a word char — so it failed. The
+ * `Object.hasOwn` half fired correctly, the binary said `1 failed`, and the
+ * guard would have shipped enforcing HALF of its stated ban with a green
+ * revert-verify. Only a per-matcher mutant exposed it.
+ *
+ * ⛤ These axes read the matchers OUT OF the rule file rather than restating
+ * them. A copy here would drift from the rule silently and then assert about
+ * itself.
+ */
+describe("archgate MOBILE-005 — line matchers", () => {
+  const repoRoot = path.resolve(__dirname, "../../../../..");
+  const rulePath = path.join(
+    repoRoot,
+    ".archgate/adrs/MOBILE-005-no-silent-es2022-runtime-api.rules.ts"
+  );
+
+  const source = readFileSync(rulePath, "utf-8");
+
+  /** Extract a `line:` regex literal that follows the given label marker. */
+  function lineMatcherFor(labelFragment: string): RegExp {
+    const idx = source.indexOf(labelFragment);
+    if (idx < 0) {
+      throw new Error(`label fragment not found in rule file: ${labelFragment}`);
+    }
+    // The `line:` literal precedes the label within the same entry.
+    const head = source.slice(0, idx);
+    const matches = [...head.matchAll(/line:\s*(\/(?:[^/\\\n]|\\.)+\/)[a-z]*,/g)];
+    const last = matches[matches.length - 1];
+    if (!last) {
+      throw new Error(`no line: matcher found before ${labelFragment}`);
+    }
+    // eslint-disable-next-line no-eval
+    return eval(last[1]) as RegExp;
+  }
+
+  describe("Object.hasOwn", () => {
+    const re = lineMatcherFor("label: \"`Object.hasOwn`\"");
+
+    it("matches the call form", () => {
+      expect(re.test("  return Object.hasOwn(source, key);")).toBe(true);
+    });
+
+    it("matches with incidental whitespace", () => {
+      expect(re.test("return Object . hasOwn (o, k);")).toBe(true);
+    });
+
+    it("does NOT match a mere mention without the call", () => {
+      // The four live occurrences in core src are all of this shape.
+      expect(re.test("the sanctioned replacement for Object.hasOwn is")).toBe(false);
+    });
+  });
+
+  describe(".at()", () => {
+    const re = lineMatcherFor("label: \"`.at()`\"");
+
+    it("matches an identifier receiver", () => {
+      expect(re.test("const last = arr.at(-1);")).toBe(true);
+    });
+
+    it("matches a bracket-expression receiver — the shape the first draft MISSED", () => {
+      // Regression axis for the drafting defect described in the docblock.
+      expect(re.test("return [key].at(0) !== undefined;")).toBe(true);
+    });
+
+    it("matches a call-expression receiver", () => {
+      expect(re.test("const c = getList().at(2);")).toBe(true);
+    });
+
+    it("does NOT match a property named at without a call", () => {
+      expect(re.test("const when = event.at;")).toBe(false);
+    });
+
+    it("does NOT match a double dot", () => {
+      // Guards the one thing the lookbehind is actually for.
+      expect(re.test("const x = a..at(0);")).toBe(false);
+    });
+  });
+
+  describe("scope of the ban", () => {
+    it("does NOT list findLast — tsc already refuses it under both lib settings", () => {
+      // Measured: `--lib ES2020` and `--lib ES2020,ES2022` BOTH emit TS2550 for
+      // findLast. Banning it here would duplicate the compiler and imply a
+      // coverage this rule does not provide for the cases tsc misses.
+      expect(source).not.toMatch(/grep:\s*\/[^/]*findLast/);
+    });
+
+    it("scans core and services src, and NOT the plugin package", () => {
+      expect(source).toContain("packages/core/src/**");
+      expect(source).toContain("packages/services/src/**");
+      expect(source).not.toContain("packages/obsidian-plugin/src/**");
+    });
+  });
+});


### PR DESCRIPTION
Closes #4064.

## Что защищаем

`packages/core/tsconfig.json`: `"target": "ES2020"` при `"lib": ["ES2020", "ES2022"]`. `lib` типизирует API, которые `target` **не** транспилирует ⇒ «упрощение»

```ts
Object.prototype.hasOwnProperty.call(o, k)  →  Object.hasOwn(o, k)
```

даёт **зелёный билд и зелёный CI** и отгружает `TypeError` на рантайме ниже Safari/iOS 15.4. Плагин собирается с `isDesktopOnly: false` — мобильный рантайм в области поставки.

До сих пор это держал **докстринг и больше ничего**. Пять точечных фиксов окружающего класса уже отгружены (#4052, #4058, #4060, #4062, #4063) — с инвариантами в прозе.

## ⛤ Объём бана ИЗМЕРЕН, а не назначен

Каждый кандидат прогнан через `tsc` под обеими настройками `lib`; банится **только то, что компилятор пропускает**:

| API | `--lib ES2020` | `--lib ES2020,ES2022` (репо) | |
|---|---|---|---|
| `Object.hasOwn` | `TS2550` | **ошибки нет** | ⛔ банить |
| `.at()` | ошибки нет | ошибки нет | ⛔ банить |
| `.findLast()` | `TS2550` | `TS2550` | ✅ **не** банить |

`findLast` исключён **намеренно**: `tsc` уже им владеет. Бан здесь дублировал бы компилятор и создавал впечатление покрытия, которого правило **не даёт** для случаев, где `tsc` слеп. Гвард, повторяющий чужой гейт, читается шире, чем он есть.

⛔ **Почему не ESLint:** шаг eslint в job `lint` помечен `continue-on-error: true` — правило там не гейтило бы ничего. `archgate` — required check.

## Revert-verify против CI-пиненного бинаря

Прогон `archgate@0.50.0` (а не 0.43/0.45, что лежат в PATH — версии расходятся, и проверять надо той, что в CI):

| состояние | результат |
|---|---|
| `Object.hasOwn` вставлен | `check failed: 24 passed, **1 failed**` |
| восстановлено | `check passed: **25 passed**, 0 failed` |
| `.at()` вставлен | 1 находка |
| `findLast` вставлен | **0** находок (негативный контроль) |
| чистое дерево | 0 находок — четыре живых упоминания `Object.hasOwn` суть докстринги |

## ⛔ Первый черновик `.at(` не ловил НИЧЕГО — и бинарь этого не показал

```js
/(?<![.\w$])[\w$\])]\s*\.\s*at\s*\(/
```

На `[key].at(0)` lookbehind применяется **перед `]`**, где предыдущий символ — `y`, то есть `\w` ⇒ матч не состоялся. Половина `Object.hasOwn` при этом фаерила, бинарь честно сказал `1 failed`, и гвард уехал бы, охраняя **половину** объявленного бана при зелёном revert-verify.

Поймал только **по-матчерный мутант**. Поэтому jest-оси тестируют матчеры **по отдельности**, а не доверяют агрегатному вердикту бинаря.

⛤ Оси **читают матчеры ИЗ файла правила**, а не переписывают их: копия разошлась бы молча и дальше утверждала о себе. Флип: **2 RED → 10 GREEN** при возвращённом старом regex; остальные 8 зелены в обоих состояниях.

## ⛤ Парный ADR `.md` — МЕХАНИЗМ, а не украшение

Без `MOBILE-005-no-silent-es2022-runtime-api.md` rule-файл **молча не загружался**: `check passed` оставался 24 с ним и без него, а вставленное нарушение не репортилось вовсе. У каждого соседнего `.rules.ts` такой файл есть — это и есть механизм регистрации.

## Гейты

| | |
|---|---|
| `archgate check --ci` | `25 passed, 0 failed` |
| `check-test-antipatterns.sh` | OK — 913 файлов, ни одного рецидива |
| `validate-shard-assignments.mjs` | rc=0 |
| `check-coverage-monotonic.mjs` | rc=0 |
| `tsc --noEmit` (core) | rc=0 |
| новые jest-оси | 10/10 |

⚠ `eslint` на новом тесте ругается на импорты `fs`/`path` (`import/no-nodejs-modules`) — **тот же вывод даёт соседний** `check-test-antipatterns-pairset.test.ts`. Это существующий шум конфигурации в build-тестах, не дефект этого PR; шаг eslint в CI `continue-on-error`.

## Требование

`50b54def-5a44-4a49-b288-529d22aad5d9` — **proposed** (approve за фаундером). Несёт Gherkin и дискриминатор Step 0: мутация продового вызова на `origin/main` дала `tsc` rc=0, `eslint` rc=0 и **680/680** тестов домена зелёными. **Ноль краснот** ⇒ свойство истинно, но не залочено ⇒ полный цикл, а не exempt-refactor.

Тест несёт `@req:50b54def-…`, так что требование можно флипнуть в `active` без доработки. Пока оно `proposed`, active-gate его не касается.
