### PR TITLE
fix(cli): blank nodes must serialise their id, not undefined

### DIFF
--- a/packages/cli/src/cache/tripleSerialization.ts
+++ b/packages/cli/src/cache/tripleSerialization.ts
@@ -45,7 +45,17 @@ export function serializeNode(
   }
 
   if (node instanceof BlankNode) {
-    return { type: "BlankNode", value: node.value };
+    // ⛔ `.id`, NOT `.value` — BlankNode has no `value` member. Reading it gave
+    // `undefined`, JSON.stringify then DROPPED the key, and deserialising the
+    // record called `new BlankNode(undefined)` → TypeError on `.trim()`. The
+    // poisoned record persists in .exocortex/cache/triples.json and breaks the
+    // five commands fed by loadOrBuild() until the file is deleted by hand.
+    //
+    // packages/cli/src is type-checked nowhere (root tsconfig excludes it,
+    // esbuild does not check types), so the compiler never saw the missing
+    // member. Surfaced by the ratchet in #4074; same class as the collision
+    // detector fixed in #4070.
+    return { type: "BlankNode", value: node.id };
   }
 
   // Fallback for QuotedTriple or unknown types

--- a/packages/cli/tests/unit/cache/tripleSerialization.blankNode.test.ts
+++ b/packages/cli/tests/unit/cache/tripleSerialization.blankNode.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from "@jest/globals";
+import { BlankNode, IRI, Literal } from "@kitelev/exocortex-core";
+import {
+  serializeNode,
+  deserializeNode,
+} from "../../../src/cache/tripleSerialization";
+
+/**
+ * Blank nodes must survive the cache round-trip.
+ *
+ * ⛔ `serializeNode` read `node.value` on a BlankNode. BlankNode exposes `.id`,
+ * not `.value`, so the field was `undefined`, `JSON.stringify` DROPPED the key
+ * entirely, and reading the record back called `new BlankNode(undefined)` →
+ * `TypeError: Cannot read properties of undefined (reading 'trim')`.
+ *
+ * The failure is STICKY: the poisoned record lands in
+ * `.exocortex/cache/triples.json`, which `loadOrBuild()` feeds to five commands
+ * (`classes`, `run-query`, `sparql-index`, `validate-schema`, `sparql-query`).
+ * All five throw until the cache file is deleted by hand.
+ *
+ * ⛤ `packages/cli/src` is type-checked nowhere — the root tsconfig excludes it
+ * and esbuild does not check types — so the compiler never saw `.value` on a
+ * type that has no such member. The defect surfaced only via the ratchet added
+ * in #4074.
+ *
+ * ⛤ These axes use a REAL `BlankNode`, not a `{ value }` stub. A stub is
+ * exactly what hid the sibling instance of this class (#4070) through two
+ * review rounds: a fake shaped like the WRONG assumption confirms the wrong
+ * assumption. The JSON.stringify step is included deliberately — the key drop
+ * happens there, not in serializeNode, so an assertion on the in-memory object
+ * alone would miss it.
+ *
+ * @req: none — bug-fix restoring already-required behaviour (feature-sdd Step 0).
+ */
+describe("tripleSerialization — BlankNode round-trip", () => {
+  it("serialises the blank node id, not undefined", () => {
+    const bn = new BlankNode("b0");
+
+    const serialized = serializeNode(bn);
+
+    expect(serialized.type).toBe("BlankNode");
+    // ⛔ Before the fix this was `undefined`.
+    expect(serialized.value).toBe("b0");
+  });
+
+  it("survives JSON.stringify — the step where the dropped key becomes fatal", () => {
+    const bn = new BlankNode("b0");
+
+    const record = JSON.parse(JSON.stringify(serializeNode(bn)));
+
+    // ⛔ Before the fix: {"type":"BlankNode"} — the key was gone entirely,
+    // because JSON.stringify omits properties whose value is undefined.
+    expect(record).toEqual({ type: "BlankNode", value: "b0" });
+  });
+
+  it("deserialises back to an equal BlankNode", () => {
+    const bn = new BlankNode("b0");
+
+    const restored = deserializeNode(
+      JSON.parse(JSON.stringify(serializeNode(bn)))
+    );
+
+    // ⛔ Before the fix this threw:
+    //   TypeError: Cannot read properties of undefined (reading 'trim')
+    expect(restored).toBeInstanceOf(BlankNode);
+    expect((restored as BlankNode).id).toBe("b0");
+    expect((restored as BlankNode).equals(bn)).toBe(true);
+  });
+
+  it("keeps ids distinct across several blank nodes", () => {
+    // A single-node axis would pass against a fix that hardcoded any string.
+    const ids = ["b0", "b1", "genid-42"];
+
+    const restored = ids.map((id) =>
+      deserializeNode(JSON.parse(JSON.stringify(serializeNode(new BlankNode(id)))))
+    );
+
+    expect(restored.map((n) => (n as BlankNode).id)).toEqual(ids);
+  });
+
+  it("CANARY: IRI and Literal round-trips are unaffected", () => {
+    // Green in BOTH states. The fix touches a shared serializer, so a change
+    // that broke the neighbouring branches would otherwise look like a clean
+    // pass on the blank-node axes alone.
+    const iri = deserializeNode(
+      JSON.parse(JSON.stringify(serializeNode(new IRI("urn:exo:x"))))
+    );
+    expect((iri as IRI).value).toBe("urn:exo:x");
+
+    const lit = deserializeNode(
+      JSON.parse(
+        JSON.stringify(serializeNode(new Literal("42", new IRI("http://www.w3.org/2001/XMLSchema#integer"))))
+      )
+    );
+    expect((lit as Literal).value).toBe("42");
+  });
+});

--- a/scripts/cli-type-errors.baseline.json
+++ b/scripts/cli-type-errors.baseline.json
@@ -11,11 +11,6 @@
       "count": 1
     },
     {
-      "file": "packages/cli/src/cache/tripleSerialization.ts",
-      "code": "TS2339",
-      "count": 1
-    },
-    {
       "file": "packages/cli/src/commands/exosync-parity.ts",
       "code": "TS2322",
       "count": 1


### PR DESCRIPTION
Часть #4075 (дефект 1 из 3).

## Что сломано

`serializeNode` читал `node.value` у `BlankNode`. У `BlankNode` есть `.id` и **нет** члена `value`:

```
bn.id        = "b0"
bn.value     = undefined
cache record = {"type":"BlankNode"}      ← ключ ИСЧЕЗ целиком
round-trip   → TypeError: Cannot read properties of undefined (reading 'trim')
```

`JSON.stringify` опускает свойства со значением `undefined`, поэтому в кэш уезжала запись **без ключа**, а чтение обратно звало `new BlankNode(undefined)`.

## ⛤ Отказ STICKY — этим он хуже броска на месте

Отравленная запись попадает в `.exocortex/cache/triples.json`, который `loadOrBuild()` отдаёт **пяти** командам: `classes`, `run-query`, `sparql-index`, `validate-schema`, `sparql-query`. Все пять бросают **до тех пор, пока файл не удалят руками**.

## Достижимость — сформулирована точно

Конвертер vault→RDF **эмитит** blank nodes (`NoteToRDFConverter`: путь `owl:sameAs` и путь statement-файлов Exo 0.0.3), и делают это **обычные файлы vault**, а не SPARQL. Сегодня путь не достигается только потому, что ни в одном текущем vault нет Exo 0.0.3 `blank_node` / `statement` файлов.

⇒ Это **«данных, которые это триггерят, пока нет»**, а не «код недостижим».

## ⛤ Почему компилятор молчал

`packages/cli/src` не типизируется **нигде** — корневой tsconfig его исключает, а esbuild типы не проверяет. Дефект всплыл только через ratchet из #4074.

Ratchet это подтверждает и с моей стороны: его база падает **18 → 17** пар, причём diff **убирает ровно одну** запись (`tripleSerialization.ts TS2339`) и **ничего не добавляет**.

Тот же класс, что HIGH, починенный в #4070 — там был детектор коллизий, здесь оставалось живым в кэше.

## Revert-verify

**4 RED → 5 GREEN.** Пятая — **канарейка** (round-trip `IRI` и `Literal`), зелёная в **обоих** состояниях: фикс трогает общий сериализатор, и правка, сломавшая соседние ветки, иначе читалась бы как чистый прогон.

⛤ Оси используют **настоящий** `BlankNode`, а не заглушку `{ value }`, и включают шаг `JSON.stringify`. Оба выбора несущие:

- заглушка **формы неверного допущения** это допущение и подтверждает — ровно она скрыла экземпляр #4070 через два раунда ревью;
- потеря ключа происходит **внутри** `stringify`, поэтому ассерт на объекте в памяти её бы не увидел.

## Регрессия

| | сьютов | тестов |
|---|---|---|
| с фиксом | 3 failed | 1 failed / 1922 |
| **родитель, тот же собранный dist** | **3 failed** | **1 failed** |

Идентично. Три сьюта (`sparql-exo003`, `cross-runtime-mount-parity`, `BootstrapAssetSpaceService`) падают в обоих состояниях; локально они зависят от неинициализированного сабмодуля.

⚠ Первый прогон дал 112 красных сьютов — это была **среда**, не код: CLI-jest требует `node --experimental-vm-modules` (штатный `npm test` пакета), а интеграционные тесты гоняют `dist`, который надо пересобрать. После корректного запуска и сборки — 10 failed → 1 failed, и этот один падает и на родителе.

`check-cli-types` ratchet: rc=0 после обновления базы.
