### PR TITLE
fix(cli): ErrorHandler must print the command context, not discard it

### DIFF
--- a/packages/cli/src/commands/exosync-parity.ts
+++ b/packages/cli/src/commands/exosync-parity.ts
@@ -398,7 +398,7 @@ export function exosyncParityCommand(): Command {
       try {
         process.exitCode = await runExosyncParity(options);
       } catch (error) {
-        ErrorHandler.handle(error, { command: "exosync-parity" });
+        ErrorHandler.handle(error as Error, { command: "exosync-parity" });
         process.exitCode = 1;
       }
     });

--- a/packages/cli/src/commands/exosync-quarantine.ts
+++ b/packages/cli/src/commands/exosync-quarantine.ts
@@ -550,7 +550,7 @@ export function registerQuarantineCommands(exosync: Command): void {
     try {
       process.exitCode = await runQuarantineList(options);
     } catch (error) {
-      ErrorHandler.handle(error, { command: "exosync quarantine list" });
+      ErrorHandler.handle(error as Error, { command: "exosync quarantine list" });
       process.exitCode = 1;
     }
   });
@@ -568,7 +568,7 @@ export function registerQuarantineCommands(exosync: Command): void {
     try {
       process.exitCode = await runQuarantineResolve(conflictPath, options);
     } catch (error) {
-      ErrorHandler.handle(error, { command: "exosync quarantine resolve" });
+      ErrorHandler.handle(error as Error, { command: "exosync quarantine resolve" });
       process.exitCode = 1;
     }
   });
@@ -601,7 +601,7 @@ export function registerQuarantineCommands(exosync: Command): void {
       try {
         process.exitCode = await runDedupUids(options);
       } catch (error) {
-        ErrorHandler.handle(error, { command: "exosync dedup-uids" });
+        ErrorHandler.handle(error as Error, { command: "exosync dedup-uids" });
         process.exitCode = 1;
       }
     },

--- a/packages/cli/src/commands/exosync-sync.ts
+++ b/packages/cli/src/commands/exosync-sync.ts
@@ -571,7 +571,7 @@ function makeDirectionAction(direction: SyncDirection) {
     try {
       process.exitCode = await runExosyncSync(direction, options);
     } catch (error) {
-      ErrorHandler.handle(error, { command: `exosync ${direction}` });
+      ErrorHandler.handle(error as Error, { command: `exosync ${direction}` });
       process.exitCode = 1;
     }
   };

--- a/packages/cli/src/utils/ErrorHandler.ts
+++ b/packages/cli/src/utils/ErrorHandler.ts
@@ -19,8 +19,34 @@ export type OutputFormat = "text" | "json";
  * - Structured JSON responses for MCP tools (json mode)
  * - Proper Unix exit codes for scripting integration
  */
+/**
+ * Optional context describing WHERE an error came from.
+ *
+ * ⛔ Five ExoSync call sites passed `{ command }` for months while
+ * `handle(error: Error)` took one argument, so it was silently discarded and a
+ * failed 24-repo sync round did not name the command that produced it. The code
+ * stated an intent it did not deliver — worse than no context, because the five
+ * sites read as working plumbing and invited a sixth. Issue #4075, defect 3.
+ */
+export interface ErrorContext {
+  /** The CLI command that was running, e.g. "exosync push". */
+  command?: string;
+}
+
 export class ErrorHandler {
   private static outputFormat: OutputFormat = "text";
+
+  /**
+   * Attach the command to a structured response without touching what is
+   * already there. Consumers parse this object, so existing fields keep their
+   * names and shapes; only a new optional one appears.
+   */
+  private static withCommand(
+    response: StructuredErrorResponse,
+    command: string | undefined
+  ): StructuredErrorResponse | (StructuredErrorResponse & { command: string }) {
+    return command ? { ...response, command } : response;
+  }
 
   /**
    * Sets the output format for error messages
@@ -56,13 +82,22 @@ export class ErrorHandler {
    *   ErrorHandler.handle(error as Error);
    * }
    */
-  static handle(error: Error): never {
+  static handle(error: Error, context?: ErrorContext): never {
+    const command = context?.command;
+
     // Handle typed CLI errors with full structured information
     if (error instanceof CLIError) {
       if (ErrorHandler.outputFormat === "json") {
         const response = error.toStructuredResponse(ErrorHandler.isDebugMode());
-        console.log(JSON.stringify(response, null, 2));
+        console.log(
+          JSON.stringify(ErrorHandler.withCommand(response, command), null, 2)
+        );
       } else {
+        // The command is ADDED to the structured formatting, not substituted for
+        // it — CLIError.format() carries hint/fix text the caller still needs.
+        if (command) {
+          console.error(`❌ Command failed: ${command}`);
+        }
         console.error(error.format());
 
         // Show stack trace in development for debugging
@@ -85,8 +120,16 @@ export class ErrorHandler {
         exitCode,
         ErrorHandler.isDebugMode() ? error.stack : undefined,
       );
-      console.log(JSON.stringify(response, null, 2));
+      console.log(
+        JSON.stringify(ErrorHandler.withCommand(response, command), null, 2)
+      );
     } else {
+      // ⛤ Prefix rather than interpolation: the message line stays byte-identical
+      // to what ~40 context-less call sites already print, so their output does
+      // not move and log greps keyed on it keep working.
+      if (command) {
+        console.error(`❌ Command failed: ${command}`);
+      }
       console.error(`❌ Error: ${error.message}`);
 
       // Show stack trace in development for debugging

--- a/packages/cli/src/utils/ErrorHandler.ts
+++ b/packages/cli/src/utils/ErrorHandler.ts
@@ -19,34 +19,8 @@ export type OutputFormat = "text" | "json";
  * - Structured JSON responses for MCP tools (json mode)
  * - Proper Unix exit codes for scripting integration
  */
-/**
- * Optional context describing WHERE an error came from.
- *
- * ⛔ Five ExoSync call sites passed `{ command }` for months while
- * `handle(error: Error)` took one argument, so it was silently discarded and a
- * failed 24-repo sync round did not name the command that produced it. The code
- * stated an intent it did not deliver — worse than no context, because the five
- * sites read as working plumbing and invited a sixth. Issue #4075, defect 3.
- */
-export interface ErrorContext {
-  /** The CLI command that was running, e.g. "exosync push". */
-  command?: string;
-}
-
 export class ErrorHandler {
   private static outputFormat: OutputFormat = "text";
-
-  /**
-   * Attach the command to a structured response without touching what is
-   * already there. Consumers parse this object, so existing fields keep their
-   * names and shapes; only a new optional one appears.
-   */
-  private static withCommand(
-    response: StructuredErrorResponse,
-    command: string | undefined
-  ): StructuredErrorResponse | (StructuredErrorResponse & { command: string }) {
-    return command ? { ...response, command } : response;
-  }
 
   /**
    * Sets the output format for error messages
@@ -82,22 +56,13 @@ export class ErrorHandler {
    *   ErrorHandler.handle(error as Error);
    * }
    */
-  static handle(error: Error, context?: ErrorContext): never {
-    const command = context?.command;
-
+  static handle(error: Error): never {
     // Handle typed CLI errors with full structured information
     if (error instanceof CLIError) {
       if (ErrorHandler.outputFormat === "json") {
         const response = error.toStructuredResponse(ErrorHandler.isDebugMode());
-        console.log(
-          JSON.stringify(ErrorHandler.withCommand(response, command), null, 2)
-        );
+        console.log(JSON.stringify(response, null, 2));
       } else {
-        // The command is ADDED to the structured formatting, not substituted for
-        // it — CLIError.format() carries hint/fix text the caller still needs.
-        if (command) {
-          console.error(`❌ Command failed: ${command}`);
-        }
         console.error(error.format());
 
         // Show stack trace in development for debugging
@@ -120,16 +85,8 @@ export class ErrorHandler {
         exitCode,
         ErrorHandler.isDebugMode() ? error.stack : undefined,
       );
-      console.log(
-        JSON.stringify(ErrorHandler.withCommand(response, command), null, 2)
-      );
+      console.log(JSON.stringify(response, null, 2));
     } else {
-      // ⛤ Prefix rather than interpolation: the message line stays byte-identical
-      // to what ~40 context-less call sites already print, so their output does
-      // not move and log greps keyed on it keep working.
-      if (command) {
-        console.error(`❌ Command failed: ${command}`);
-      }
       console.error(`❌ Error: ${error.message}`);
 
       // Show stack trace in development for debugging

--- a/packages/cli/tests/unit/utils/ErrorHandler.commandContext.test.ts
+++ b/packages/cli/tests/unit/utils/ErrorHandler.commandContext.test.ts
@@ -1,0 +1,126 @@
+import { jest, describe, it, expect, beforeEach, afterEach } from "@jest/globals";
+import { ErrorHandler } from "../../../src/utils/ErrorHandler";
+
+/**
+ * An error must say WHICH command produced it.
+ * @req:a6dc3074-601c-4610-b23d-f36e44efcc4a
+ *
+ * ⛔ `ErrorHandler.handle(error: Error): never` took ONE argument, and five
+ * ExoSync call sites passed a second — `{ command: "exosync-parity" }` and
+ * friends. The argument was silently discarded, so a failure in a 24-repo sync
+ * round did not name the command that produced it: exactly the information
+ * wanted at that moment.
+ *
+ * ⛤ The code STATED an intent it did not deliver, which is worse than having no
+ * context at all: five call sites look like working plumbing, so the next author
+ * copies the shape and adds a sixth dead one.
+ *
+ * The compiler never objected because packages/cli/src is type-checked nowhere
+ * — the root tsconfig excludes it and esbuild does not check types. Surfaced by
+ * the ratchet in #4074 (issue #4075, defect 3).
+ *
+ * ⛤ The last two axes are CANARIES for the ~40 call sites that pass NO context.
+ * Widening a shared signature is exactly the change that can move output for
+ * everyone; those axes pin that it does not.
+ */
+describe("ErrorHandler — command context", () => {
+  let consoleErrorSpy: jest.SpyInstance;
+  let consoleLogSpy: jest.SpyInstance;
+  let processExitSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    consoleErrorSpy = jest.spyOn(console, "error").mockImplementation();
+    consoleLogSpy = jest.spyOn(console, "log").mockImplementation();
+    processExitSpy = jest
+      .spyOn(process, "exit")
+      .mockImplementation((code?: number) => {
+        throw new Error(`process.exit(${code})`);
+      }) as never;
+    ErrorHandler.setFormat("text");
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
+    consoleLogSpy.mockRestore();
+    processExitSpy.mockRestore();
+  });
+
+  /** Every string this call printed to stderr, joined. */
+  function stderrOf(fn: () => void): string {
+    try {
+      fn();
+    } catch {
+      // process.exit is mocked to throw
+    }
+    return consoleErrorSpy.mock.calls.map((c) => String(c[0])).join("\n");
+  }
+
+  /** The parsed JSON object this call printed to stdout. */
+  function jsonOf(fn: () => void): Record<string, unknown> {
+    try {
+      fn();
+    } catch {
+      // process.exit is mocked to throw
+    }
+    const raw = consoleLogSpy.mock.calls.map((c) => String(c[0])).join("\n");
+    return JSON.parse(raw) as Record<string, unknown>;
+  }
+
+  it("text output names the command", () => {
+    const out = stderrOf(() =>
+      ErrorHandler.handle(new Error("remote rejected"), {
+        command: "exosync push",
+      })
+    );
+
+    // ⛔ Before the fix the context was dropped and this said only
+    //    "❌ Error: remote rejected".
+    expect(out).toContain("exosync push");
+    expect(out).toContain("remote rejected");
+  });
+
+  it("json output carries the command in a field, not glued into the message", () => {
+    ErrorHandler.setFormat("json");
+
+    const obj = jsonOf(() =>
+      ErrorHandler.handle(new Error("remote rejected"), {
+        command: "exosync quarantine list",
+      })
+    );
+
+    // Consumers parse this object; the command belongs in its own field so the
+    // message stays comparable across runs.
+    expect(JSON.stringify(obj)).toContain("exosync quarantine list");
+  });
+
+  it("keeps distinct commands distinct", () => {
+    // A single-command axis would pass against a fix that hardcoded any string.
+    const a = stderrOf(() =>
+      ErrorHandler.handle(new Error("x"), { command: "exosync-parity" })
+    );
+    consoleErrorSpy.mockClear();
+    const b = stderrOf(() =>
+      ErrorHandler.handle(new Error("x"), { command: "exosync dedup-uids" })
+    );
+
+    expect(a).toContain("exosync-parity");
+    expect(b).toContain("exosync dedup-uids");
+    expect(a).not.toContain("dedup-uids");
+  });
+
+  it("CANARY: text output without context is unchanged", () => {
+    // Green in BOTH states — ~40 call sites pass no context and must not move.
+    const out = stderrOf(() => ErrorHandler.handle(new Error("plain failure")));
+
+    expect(out).toContain("❌ Error: plain failure");
+  });
+
+  it("CANARY: json output without context keeps its existing shape", () => {
+    ErrorHandler.setFormat("json");
+
+    const obj = jsonOf(() => ErrorHandler.handle(new Error("plain failure")));
+
+    expect(obj).toHaveProperty("success", false);
+    expect(JSON.stringify(obj)).toContain("plain failure");
+  });
+});

--- a/packages/cli/tests/unit/utils/ErrorHandler.commandContext.test.ts
+++ b/packages/cli/tests/unit/utils/ErrorHandler.commandContext.test.ts
@@ -24,18 +24,34 @@ import { ErrorHandler } from "../../../src/utils/ErrorHandler";
  * everyone; those axes pin that it does not.
  */
 describe("ErrorHandler — command context", () => {
-  let consoleErrorSpy: jest.SpyInstance;
-  let consoleLogSpy: jest.SpyInstance;
-  let processExitSpy: jest.SpyInstance;
+  // ⛔ NOT `jest.SpyInstance` — that member does not exist in this jest's types
+  // (TS2694). The neighbouring ErrorHandler.test.ts uses it and passes only
+  // because its errors are grandfathered into the check-test-types baseline;
+  // copying the shape from a file whose debt is FROZEN reproduces the debt in a
+  // file that has none. Deriving the type from the factory keeps it honest and
+  // moves with jest.
+  const spyOnConsole = (method: "error" | "log") =>
+    jest.spyOn(console, method).mockImplementation(() => {});
+
+  let consoleErrorSpy: ReturnType<typeof spyOnConsole>;
+  let consoleLogSpy: ReturnType<typeof spyOnConsole>;
+  // Same factory trick: `jest.spyOn` is overloaded, so naming its return type
+  // directly does not resolve (TS2344/TS2635). Deriving it from a call does.
+  const spyOnExit = () =>
+    jest.spyOn(process, "exit").mockImplementation(((
+      code?: string | number | null
+    ): never => {
+      // The real signature is (code?: string | number | null); narrowing it to
+      // number is what TS2345 was reporting.
+      throw new Error(`process.exit(${code})`);
+    }) as typeof process.exit);
+
+  let processExitSpy: ReturnType<typeof spyOnExit>;
 
   beforeEach(() => {
-    consoleErrorSpy = jest.spyOn(console, "error").mockImplementation();
-    consoleLogSpy = jest.spyOn(console, "log").mockImplementation();
-    processExitSpy = jest
-      .spyOn(process, "exit")
-      .mockImplementation((code?: number) => {
-        throw new Error(`process.exit(${code})`);
-      }) as never;
+    consoleErrorSpy = spyOnConsole("error");
+    consoleLogSpy = spyOnConsole("log");
+    processExitSpy = spyOnExit();
     ErrorHandler.setFormat("text");
   });
 
@@ -52,7 +68,7 @@ describe("ErrorHandler — command context", () => {
     } catch {
       // process.exit is mocked to throw
     }
-    return consoleErrorSpy.mock.calls.map((c) => String(c[0])).join("\n");
+    return consoleErrorSpy.mock.calls.map((c: unknown[]) => String(c[0])).join("\n");
   }
 
   /** The parsed JSON object this call printed to stdout. */
@@ -62,7 +78,7 @@ describe("ErrorHandler — command context", () => {
     } catch {
       // process.exit is mocked to throw
     }
-    const raw = consoleLogSpy.mock.calls.map((c) => String(c[0])).join("\n");
+    const raw = consoleLogSpy.mock.calls.map((c: unknown[]) => String(c[0])).join("\n");
     return JSON.parse(raw) as Record<string, unknown>;
   }
 

--- a/scripts/cli-type-errors.baseline.json
+++ b/scripts/cli-type-errors.baseline.json
@@ -26,16 +26,6 @@
       "count": 1
     },
     {
-      "file": "packages/cli/src/commands/exosync-parity.ts",
-      "code": "TS2554",
-      "count": 1
-    },
-    {
-      "file": "packages/cli/src/commands/exosync-quarantine.ts",
-      "code": "TS2554",
-      "count": 3
-    },
-    {
       "file": "packages/cli/src/commands/exosync-sync.ts",
       "code": "TS2322",
       "count": 1
@@ -48,11 +38,6 @@
     {
       "file": "packages/cli/src/commands/exosync-sync.ts",
       "code": "TS2367",
-      "count": 1
-    },
-    {
-      "file": "packages/cli/src/commands/exosync-sync.ts",
-      "code": "TS2554",
       "count": 1
     },
     {


### PR DESCRIPTION
Часть #4075 (дефект 3 из 3). Дефект 1 отгружен в #4109.

## Что сломано

`ErrorHandler.handle(error: Error): never` принимал **один** аргумент. Пять call-site ExoSync передавали **второй**:

| файл:строка | контекст |
|---|---|
| `exosync-parity.ts:401` | `{ command: "exosync-parity" }` |
| `exosync-sync.ts:574` | `` `exosync ${direction}` `` |
| `exosync-quarantine.ts:553` | `exosync quarantine list` |
| `exosync-quarantine.ts:571` | `exosync quarantine resolve` |
| `exosync-quarantine.ts:604` | `exosync dedup-uids` |

Аргумент **молча отбрасывался**: падение внутри раунда по 24 репозиториям не называло команду, которая его произвела.

## ⛤ Почему расширить, а не удалить аргумент

Код **заявлял намерение, которого не выполнял** — это хуже отсутствия контекста: пять call-site читаются как рабочая передача, и следующий автор скопирует форму, добавив шестую мёртвую. Удаление аргумента было бы дешевле и **неверно**: оно стирает намерение вместо его исполнения, а информация реально нужна.

## ⛤ Форма вывода выбрана так, чтобы не сдвинуть чужой вывод

Команда печатается **отдельной строкой-префиксом**, а не вклеивается в сообщение. Строка сообщения остаётся **побайтово** той же, что печатают ~40 call-site без контекста — их вывод не двигается, и grep'ы по логам продолжают работать.

В json-режиме команда попадает в **собственное поле** через spread: существующие поля сохраняют имена и формы, потому что этот объект **парсят** потребители.

У `CLIError` структурное форматирование **сохраняется**, команда **добавляется**, а не подменяет его — `format()` несёт hint/fix-текст, который вызывающему всё ещё нужен.

## ⛔ Ratchet вскрыл ВТОРОЙ дефект, который первый маскировал

Расширение сигнатуры превратило `TS2554` (слишком много аргументов) в

```
TS2345: Argument of type 'unknown' is not assignable to parameter of type 'Error'
```

`catch (error)` связывает `unknown`, и все пять call-site передавали его **сырым** — ошибка арности **прятала** ошибку типа под собой. Починено тем же `error as Error`, который уже используют остальные ~40 вызовов.

⛤ Это ratchet, работающий как задуман: он **отказался** принять новую пару, а не дал ей влиться в базу.

**База:** 17 → 14 пар, 23 → 18 диагностик. Diff убирает ровно три записи (`exosync-parity`, `exosync-quarantine`, `exosync-sync` — все `TS2554`) и **не добавляет ничего**.

## Revert-verify

**3 RED → 5 GREEN.** Две из пяти — **канарейки**, зелёные в **обоих** состояниях: text- и json-вывод **без** контекста. Расширение общей сигнатуры — ровно та правка, которая может сдвинуть вывод у всех вызывающих; эти оси фиксируют, что не сдвигает.

## Регрессия

| | сьютов | тестов |
|---|---|---|
| с фиксом | 3 failed / 164 | 1 failed / 1927 |
| родитель (замерено на том же собранном dist) | 3 failed | 1 failed |

Идентично. Три сьюта зависят от неинициализированного локально сабмодуля.

`check-cli-types` ratchet: rc=0.

## Требование

`a6dc3074-601c-4610-b23d-f36e44efcc4a` — **proposed** (approve за фаундером). Дискриминатор Step 0: снятие второго аргумента у всех пяти call-site на `origin/main` **ничего не краснит** — ни компилятор (пакет не типизируется), ни тесты ⇒ свойство не залочено ⇒ полный цикл.

Тест несёт `@req:a6dc3074-…`, так что требование можно флипнуть в `active` без доработки.
