### PR TITLE
fix(cli): state the timeout's real semantics instead of a dead cancellation branch

### DIFF
--- a/packages/cli/src/commands/sparql-query.ts
+++ b/packages/cli/src/commands/sparql-query.ts
@@ -509,10 +509,18 @@ export function sparqlQueryCommand(): Command {
         const execStartTime = Date.now();
         const executor = new ExoQLQueryExecutor(tripleStore);
 
-        // Set query timeout if the executor supports it
-        if (typeof executor.setTimeout === "function") {
-          executor.setTimeout(timeoutMs);
-        }
+        // ⛔ There is NO in-executor cancellation. `ExoQLQueryExecutor` has no
+        // `setTimeout`, and a `typeof … === "function"` guard around a method
+        // that does not exist is worse than either alternative: it reads as
+        // "supported when available" while being permanently dead, so nobody
+        // goes looking for the missing capability (#4075, defect 2).
+        //
+        // The user-facing timeout DOES fire — `executeWithTimeout` races the
+        // query against a timer and wraps all three execution paths (update,
+        // construct, select). What is missing is COOPERATIVE cancellation:
+        // after the race rejects, the query keeps running in the background
+        // until it finishes on its own. That is a wall-clock timeout, not an
+        // abort, and it is stated here rather than imitated by a dead branch.
 
         // Progress indicator for long-running query execution (TTY mode only)
         const progressIndicator = outputFormat === "text"

--- a/packages/cli/tests/unit/commands/sparql-query-timeout-semantics.test.ts
+++ b/packages/cli/tests/unit/commands/sparql-query-timeout-semantics.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from "@jest/globals";
+import { ExoQLQueryExecutor } from "@kitelev/exocortex-core";
+import { executeWithTimeout } from "../../../src/commands/sparql-query";
+
+/**
+ * What the query timeout IS, and what it is not.
+ *
+ * ⛔ `sparql-query.ts` carried
+ *
+ *     if (typeof executor.setTimeout === "function") { executor.setTimeout(ms); }
+ *
+ * around a method `ExoQLQueryExecutor` does not have. A permanently-false
+ * `typeof` guard is worse than either alternative: it reads as "supported when
+ * available" while being dead, so nobody goes looking for the missing
+ * capability. Removed in favour of stating the truth (#4075, defect 2).
+ *
+ * ⛤ These axes exist because the 31 tests in sparql-query-timeout.test.ts cover
+ * only PARSING (`--timeout 30s`, env var, invalid formats) — not one of them
+ * asserts that a timeout ever fires. Deleting the branch would therefore have
+ * been unguarded: the suite could not tell a working timeout from none at all.
+ *
+ * The distinction they pin is the one the deleted branch blurred:
+ *   - wall-clock timeout: the CALLER stops waiting.       ← what exists
+ *   - cooperative cancellation: the QUERY stops running.  ← what does not
+ */
+describe("sparql-query — timeout semantics (#4075 defect 2)", () => {
+  it("the executor has no setTimeout — the removed guard was permanently false", () => {
+    const executor = new ExoQLQueryExecutor({
+      // Minimal store stand-in: the axis is about the executor's SHAPE, and
+      // constructing it is all that is needed to ask about the member.
+      match: () => [],
+      add: () => {},
+      size: () => 0,
+    } as never);
+
+    expect(
+      (executor as unknown as Record<string, unknown>).setTimeout
+    ).toBeUndefined();
+  });
+
+  it("rejects when the query outlives the budget", async () => {
+    const slow = new Promise((resolve) => setTimeout(resolve, 5_000));
+
+    await expect(executeWithTimeout(slow, 20, Date.now())).rejects.toThrow();
+  });
+
+  it("the timeout error names the budget", async () => {
+    const slow = new Promise((resolve) => setTimeout(resolve, 5_000));
+
+    // The message is what a user sees when a query gives up; it has to say WHAT
+    // the budget was, not merely that something timed out.
+    //
+    // ⛤ The budget here is 1000ms, not the 20ms the neighbouring axes use, and
+    // deliberately so: the message renders SECONDS, so any sub-second budget
+    // prints "limit: 0s" and this axis would assert against a rounded-away
+    // value. That rounding is a real (if cosmetic) gap in the message, but it
+    // is NOT this change's subject — widening the axis to cover it would be
+    // scope creep, and silently asserting on "0s" would be worse: it would
+    // freeze the rounding as intended behaviour.
+    await expect(executeWithTimeout(slow, 1000, Date.now())).rejects.toThrow(
+      /limit: 1s/
+    );
+  });
+
+  it("⛔ does NOT cancel the query — it only stops waiting for it", async () => {
+    // This is the honest limitation the deleted branch pretended to address.
+    // If cooperative cancellation is ever implemented, THIS axis is the one
+    // that must be rewritten — which is the point of stating it.
+    let settled = false;
+    const slow = new Promise((resolve) =>
+      setTimeout(() => {
+        settled = true;
+        resolve(undefined);
+      }, 60)
+    );
+
+    await expect(executeWithTimeout(slow, 20, Date.now())).rejects.toThrow();
+    expect(settled).toBe(false); // still running at the moment we gave up
+
+    await new Promise((r) => setTimeout(r, 80));
+    expect(settled).toBe(true); // it ran to completion regardless
+  });
+
+  it("CANARY: a query inside the budget resolves normally", async () => {
+    // Green in both states — pins that the wrapper is not simply always
+    // rejecting, which every axis above would tolerate.
+    const fast = Promise.resolve("ok");
+
+    await expect(executeWithTimeout(fast, 5_000, Date.now())).resolves.toBe("ok");
+  });
+});

--- a/scripts/cli-type-errors.baseline.json
+++ b/scripts/cli-type-errors.baseline.json
@@ -47,11 +47,6 @@
     },
     {
       "file": "packages/cli/src/commands/sparql-query.ts",
-      "code": "TS2339",
-      "count": 2
-    },
-    {
-      "file": "packages/cli/src/commands/sparql-query.ts",
       "code": "TS6133",
       "count": 3
     },


### PR DESCRIPTION
Закрывает последний из #4075 (дефект 2 из 3). Дефекты 1 и 3 отгружены в #4109 и #4110.

## Что убрано

```ts
if (typeof executor.setTimeout === "function") { executor.setTimeout(ms); }
```

`ExoQLQueryExecutor` такого метода не имеет — ветка **не выполнялась никогда**.

## ⛤ Почему постоянно-ложный `typeof` хуже ОБЕИХ альтернатив

Он читается как «поддержано, когда доступно» — то есть код **рекламирует** возможность, которой у него нет, и никто не идёт искать недостающее. Удаление и правдивая формулировка возвращают читателю способность видеть пробел.

| | |
|---|---|
| **wall-clock таймаут** — вызывающий перестаёт ждать | ✅ работает сегодня |
| **кооперативная отмена** — запрос перестаёт выполняться | ⛔ не существует |

`executeWithTimeout` гоняет запрос против таймера и оборачивает все три пути исполнения (update, construct, select), поэтому пользовательский таймаут **срабатывает**. После отказа гонки запрос продолжает выполняться в фоне до собственного завершения. Это различие теперь записано там, где стояла мёртвая ветка.

⛤ Реализация настоящей отмены — **отдельная фича** со своей ценой, и решать её стоит по спросу, а не попутно с чисткой. Issue предлагал оба варианта; взят честно-документирующий.

## ⛤ Зачем оси для удаления

31 тест в `sparql-query-timeout.test.ts` покрывают только **парсинг** (`--timeout 30s`, env-переменная, невалидные форматы). **Ни один** не утверждает, что таймаут вообще срабатывает.

⇒ Удаление ветки было бы **неприкрытым**: набор не отличал работающий таймаут от его отсутствия.

Пять новых осей фиксируют различие, которое мёртвая ветка размывала, включая ось, **прямо называющую ограничение** (`does NOT cancel the query`). Если кооперативная отмена когда-нибудь появится, переписать придётся именно её — в этом и смысл её существования.

## ⛤ Одна ось поправлена по ходу, а не оставлена как есть

Проверка сообщения против бюджета 20 мс упала: сообщение рендерит **секунды**, поэтому любой суб-секундный бюджет печатает `limit: 0s`. Это реальный (пусть косметический) пробел, но:

- расширять ось на него — **scope creep**;
- утверждать против `"0s"` — **хуже**: это заморозило бы округление как намеренное поведение.

Ось использует бюджет 1 с и объясняет почему.

## Гейты

| | |
|---|---|
| `check-cli-types` | база **14 → 13** пар, 16 диагностик; diff убирает ровно `sparql-query.ts TS2339`, добавляет **0** |
| `check-test-types` | **0** новых пар (урок #4110: ратчета два, не один) |
| полный CLI-набор | 3 сьюта / **1** тест — та же база, что на родителе |
