### PR TITLE
fix(cli): refuse an unresolvable link whatever form it takes

### DIFF
--- a/packages/cli/src/adapters/NodeFsAdapter.ts
+++ b/packages/cli/src/adapters/NodeFsAdapter.ts
@@ -132,6 +132,93 @@ export class NodeFsAdapter implements IFileSystemAdapter {
    *
    * @returns vault-relative path of the first match, or null.
    */
+  /**
+   * Resolve a LABEL-FORM linkpath — `[[ems__Task]]` — to a vault file.
+   *
+   * Obsidian resolves a linkpath by basename first, then by the target's
+   * `exo__Asset_label` / `aliases`. This mirrors that order, and the order is
+   * load-bearing for cost: the basename walk is a directory scan, while the
+   * metadata pass has to READ every markdown file. Most links hit the walk.
+   *
+   * ⛤ Exists because `WikilinkValidator` had no way to check a non-UUID link
+   * and therefore skipped every one of them (#4068). Label-form is the shape a
+   * joinable reference REQUIRES — a bare UUID emits a symbolic IRI carrying
+   * none of the target's predicates — so the only working form was also the
+   * only unvalidated one.
+   *
+   * @returns vault-relative path of the first match, or null.
+   */
+  async findFileByLinkpath(target: string): Promise<string | null> {
+    const wanted = target.trim();
+    if (wanted.length === 0) {
+      return null;
+    }
+
+    // 1. Basename: <target>.md anywhere in the vault.
+    const byBasename = await this.findFileByBasename(`${wanted}.md`);
+    if (byBasename) {
+      return byBasename;
+    }
+
+    // 2. Label or alias. One pass, both fields — two passes would double the
+    //    cost of the expensive branch for no gain.
+    const allFiles = await this.getMarkdownFiles();
+    for (const file of allFiles) {
+      let metadata: Record<string, unknown>;
+      try {
+        metadata = (await this.getFileMetadata(file)) as Record<string, unknown>;
+      } catch {
+        // Malformed frontmatter: unreadable, not a match. The basename walk
+        // above already covers such files when they are named after the link.
+        continue;
+      }
+
+      if (metadata["exo__Asset_label"] === wanted) {
+        return file;
+      }
+
+      const aliases = metadata["aliases"];
+      if (Array.isArray(aliases) && aliases.some((a) => a === wanted)) {
+        return file;
+      }
+      if (typeof aliases === "string" && aliases === wanted) {
+        return file;
+      }
+    }
+
+    return null;
+  }
+
+  /** Recursive basename lookup, sharing the walk shape of findFileByUidFilename. */
+  private async findFileByBasename(basename: string): Promise<string | null> {
+    const walk = async (dir: string): Promise<string | null> => {
+      let entries;
+      try {
+        entries = await fs.readdir(dir, { withFileTypes: true });
+      } catch {
+        return null;
+      }
+
+      for (const entry of entries) {
+        const fullPath = path.join(dir, entry.name);
+
+        if (entry.isDirectory()) {
+          if (entry.name.startsWith(".") || entry.name === "node_modules") {
+            continue;
+          }
+          const found = await walk(fullPath);
+          if (found) return found;
+        } else if (entry.isFile() && entry.name === basename) {
+          return path.relative(this.rootPath, fullPath);
+        }
+      }
+
+      return null;
+    };
+
+    return walk(this.rootPath);
+  }
+
   async findFileByUidFilename(uid: string): Promise<string | null> {
     const uidLower = uid.toLowerCase();
 

--- a/packages/cli/src/services/WikilinkValidator.ts
+++ b/packages/cli/src/services/WikilinkValidator.ts
@@ -94,8 +94,28 @@ export class WikilinkValidator {
    * @throws WikilinkNotFoundError if file not found
    */
   private async validateWikilink(uuid: string, label?: string): Promise<void> {
-    // Skip non-UUID references (e.g., date wikilinks like [[2025-01-01]])
+    // ⛔ This used to `return` for every non-UUID reference — the comment said
+    // "skip date wikilinks like [[2025-01-01]]", the code said "skip anything
+    // that is not a UUID". So a label-form linkpath was NEVER checked, and a
+    // typo in it produced a bare literal instead of a file-IRI: the join dies,
+    // SHACL stays green (a literal is not a dangling ref), and the defect
+    // surfaces much later as "the query returns nothing" (#4068).
+    //
+    // ⛤ The asymmetry pointed the wrong way. Label-form is the shape a JOINABLE
+    // reference requires — a bare UUID emits a symbolic IRI that carries none of
+    // the target's predicates — so the only working form was the unvalidated one.
+    //
+    // Label-form now goes through the same "does the target exist" question,
+    // resolved the way Obsidian resolves a linkpath: basename, then label,
+    // then aliases. A genuinely forward reference (a daily note not yet
+    // created) stays expressible via --skip-wikilink-validation, which `create`
+    // already has; enumerating exceptions like "except dates" would be a
+    // whitelist that goes stale on the first new naming scheme.
     if (!this.looksLikeUUID(uuid)) {
+      const resolved = await this.fsAdapter.findFileByLinkpath(uuid);
+      if (!resolved) {
+        throw new WikilinkNotFoundError(uuid, label);
+      }
       return;
     }
 

--- a/packages/cli/tests/unit/services/WikilinkValidator.labelForm.test.ts
+++ b/packages/cli/tests/unit/services/WikilinkValidator.labelForm.test.ts
@@ -1,0 +1,117 @@
+import { jest, describe, it, expect, beforeEach } from "@jest/globals";
+
+/**
+ * A link that resolves to nothing must be refused WHATEVER FORM it takes.
+ * @req:1cfb6f3b-bd77-49d3-8270-2eeecf0272f3
+ *
+ * ⛔ `validateWikilink` opened with
+ *
+ *     if (!this.looksLikeUUID(uuid)) { return; }   // "Skip non-UUID references"
+ *
+ * so every label-form linkpath left the validator unchecked. The intent named in
+ * that comment was narrow (skip date wikilinks like `[[2025-01-01]]`); the
+ * implementation was "skip everything that is not a UUID".
+ *
+ * ⛤ The asymmetry pointed the wrong way. Label-form is the form the graph
+ * REQUIRES for a joinable reference — a bare UUID emits a symbolic IRI that
+ * carries none of the target's predicates, so the join dies. The only working
+ * form was therefore the unvalidated one, and a typo in it produced a bare
+ * literal that SHACL cannot flag (a literal is not a dangling ref). The defect
+ * surfaced much later as "the query returns nothing", which reads as "no data".
+ *
+ * Issue #4068; siblings #3701, #3352, #3362.
+ */
+
+const mockFsAdapter = {
+  getMarkdownFiles: jest.fn(),
+  getFileMetadata: jest.fn(),
+  readFile: jest.fn(),
+  fileExists: jest.fn<(path: string) => Promise<boolean>>(),
+  createFile: jest.fn(),
+  updateFile: jest.fn(),
+  writeFile: jest.fn(),
+  deleteFile: jest.fn(),
+  renameFile: jest.fn(),
+  createDirectory: jest.fn(),
+  directoryExists: jest.fn(),
+  findFilesByMetadata:
+    jest.fn<(query: Record<string, unknown>) => Promise<string[]>>(),
+  findFileByUID: jest.fn<(uid: string) => Promise<string | null>>(),
+  findFileByUidFilename: jest.fn<(uid: string) => Promise<string | null>>(),
+  findFileByLinkpath: jest.fn<(target: string) => Promise<string | null>>(),
+};
+
+jest.unstable_mockModule("../../../src/adapters/NodeFsAdapter.js", () => ({
+  NodeFsAdapter: jest.fn(() => mockFsAdapter),
+}));
+
+const { WikilinkValidator, WikilinkNotFoundError } = await import(
+  "../../../src/services/WikilinkValidator.js"
+);
+
+describe("WikilinkValidator — label-form linkpaths (#4068)", () => {
+  let validator: InstanceType<typeof WikilinkValidator>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    validator = new WikilinkValidator(mockFsAdapter as never);
+  });
+
+  it("refuses a label-form link that resolves to nothing", async () => {
+    mockFsAdapter.findFileByLinkpath.mockResolvedValue(null);
+
+    // ⛔ Before the fix this resolved silently and the reference landed in the
+    // file as a bare literal.
+    await expect(
+      validator.validateValue("[[flow__NoSuchThing]]")
+    ).rejects.toThrow(WikilinkNotFoundError);
+  });
+
+  it("names the unresolvable target in the error", async () => {
+    mockFsAdapter.findFileByLinkpath.mockResolvedValue(null);
+
+    // The message is what the user acts on; it has to say WHICH link failed.
+    await expect(
+      validator.validateValue("[[flow__NoSuchThing]]")
+    ).rejects.toThrow(/flow__NoSuchThing/);
+  });
+
+  it("accepts a label-form link that resolves", async () => {
+    // ⛤ Load-bearing: this is the form the graph requires for a joinable
+    // reference. Tightening must not make the only working form unusable.
+    mockFsAdapter.findFileByLinkpath.mockResolvedValue("assetspaces/x/ems__Task.md");
+
+    await expect(validator.validateValue("[[ems__Task]]")).resolves.toBeUndefined();
+  });
+
+  it("passes the ALIAS-bearing form through the same lookup", async () => {
+    mockFsAdapter.findFileByLinkpath.mockResolvedValue("assetspaces/x/a.md");
+
+    await expect(
+      validator.validateValue("[[ems__Task|Задача]]")
+    ).resolves.toBeUndefined();
+    // The lookup must receive the TARGET, not the alias — an alias is display
+    // text and resolves to nothing.
+    expect(mockFsAdapter.findFileByLinkpath).toHaveBeenCalledWith("ems__Task");
+  });
+
+  it("CANARY: UUID-form still resolves through the UID lookup, untouched", async () => {
+    // Green in BOTH states. ~all current callers depend on this path and on the
+    // exact error message, which is greppable in logs.
+    mockFsAdapter.findFileByUidFilename.mockResolvedValue("assetspaces/x/uid.md");
+
+    await expect(
+      validator.validateValue("[[3fa85f64-5717-4562-b3fc-2c963f66afa6]]")
+    ).resolves.toBeUndefined();
+    expect(mockFsAdapter.findFileByLinkpath).not.toHaveBeenCalled();
+  });
+
+  it("CANARY: UUID-form that resolves to nothing still throws", async () => {
+    mockFsAdapter.findFileByUidFilename.mockResolvedValue(null);
+    mockFsAdapter.findFilesByMetadata.mockResolvedValue([]);
+
+    await expect(
+      validator.validateValue("[[3fa85f64-5717-4562-b3fc-2c963f66afa6]]")
+    ).rejects.toThrow(WikilinkNotFoundError);
+  });
+});

--- a/packages/cli/tests/unit/services/WikilinkValidator.test.ts
+++ b/packages/cli/tests/unit/services/WikilinkValidator.test.ts
@@ -17,6 +17,7 @@ const mockFsAdapter = {
   findFileByUID: jest.fn<(uid: string) => Promise<string | null>>(),
   findFileByUidFilename:
     jest.fn<(uid: string) => Promise<string | null>>(),
+  findFileByLinkpath: jest.fn<(target: string) => Promise<string | null>>(),
 };
 
 jest.unstable_mockModule("../../../src/adapters/NodeFsAdapter.js", () => ({
@@ -105,18 +106,30 @@ describe("WikilinkValidator", () => {
       ).rejects.toThrow(WikilinkNotFoundError);
     });
 
-    it("should skip non-UUID wikilinks (e.g., date references)", async () => {
-      // Date wikilinks like [[2025-01-01]] should be skipped
+    it("resolves a date wikilink as a linkpath, not as a UUID", async () => {
+      // ⛔ This asserted that non-UUID links were SKIPPED — the very gap #4068
+      // reports. A date link is now resolved like any other linkpath: the daily
+      // note exists, so it passes; if it does not, --skip-wikilink-validation
+      // is the deliberate way to reference forward.
+      mockFsAdapter.findFileByLinkpath.mockResolvedValue("Daily/2025-01-01.md");
+
       await expect(
         validator.validatePropertyValues({
           "ems__Effort_day": "[[2025-01-01]]",
         }),
       ).resolves.toBeUndefined();
 
+      // Still NOT routed through the UID lookup — that part was always correct.
       expect(mockFsAdapter.findFileByUidFilename).not.toHaveBeenCalled();
+      expect(mockFsAdapter.findFileByLinkpath).toHaveBeenCalledWith("2025-01-01");
     });
 
-    it("should skip non-UUID wikilinks like class names", async () => {
+    it("resolves a class-name wikilink as a linkpath", async () => {
+      // ⛔ Also asserted the skip. A class reference is exactly the case that
+      // MUST resolve: it is the joinable form, and a typo in it used to become
+      // a bare literal that nothing reported.
+      mockFsAdapter.findFileByLinkpath.mockResolvedValue("assetspaces/ems/Task.md");
+
       await expect(
         validator.validatePropertyValues({
           "exo__Instance_class": "[[ems__Task]]",
@@ -124,6 +137,7 @@ describe("WikilinkValidator", () => {
       ).resolves.toBeUndefined();
 
       expect(mockFsAdapter.findFileByUidFilename).not.toHaveBeenCalled();
+      expect(mockFsAdapter.findFileByLinkpath).toHaveBeenCalledWith("ems__Task");
     });
 
     it("should validate across multiple properties", async () => {


### PR DESCRIPTION
Closes #4068.

## Что сломано

`create` **отвергал** нерезолвимый wikilink UUID-формы и **молча принимал** нерезолвимый label-form linkpath. Ссылка попадала в файл и (per #3352/#3362) вырождалась в **голый литерал** вместо file-IRI — джойн мёртв, и об этом никто не сообщал.

⛤ **Асимметрия направлена в неверную сторону.** Label-form — это форма, которую джойнимая ссылка **требует**: bare-UUID эмитит symbolic-IRI, не несущий ни одного предиката цели. То есть **единственная работающая форма была единственной невалидируемой**, а опечатка в ней невидима: SHACL зелен (литерал — не dangling ref), и дефект всплывает много позже как «запрос ничего не возвращает», что читается как «данных нет».

## Корень — одна строка

```ts
if (!this.looksLikeUUID(uuid)) { return; }   // «Skip non-UUID references»
```

Комментарий называет узкое намерение (пропускать даты вроде `[[2025-01-01]]`), код говорит «пропускать всё, что не UUID».

## Фикс

Label-form проходит тот же вопрос «существует ли цель», разрешаемый так же, как Obsidian разрешает linkpath: **basename → `exo__Asset_label` → `aliases`**.

⛤ Порядок несущий по **стоимости**: basename — обход каталогов, а проход по метаданным **читает каждый файл**. Большинство ссылок попадает в обход.

⛔ **Не список исключений.** «Кроме дат» — белый список, устаревающий от первой новой схемы именования; «резолвится / не резолвится» — структурный признак и самодостаточен. Сознательная ссылка вперёд остаётся выразимой через `--skip-wikilink-validation`, который у `create` **уже есть**.

## Замер на живом vault, до и после

| форма | до | после |
|---|---|---|
| label, существует | принят | принят |
| daily note `2025-08-27` | принят | принят |
| label, **не существует** | принят | ⛔ **ОТКАЗ** ← дефект |
| дата, ещё не создана | принят | ⛔ ОТКАЗ ← предсказано; escape есть |
| UUID, не существует | ОТКАЗ | ОТКАЗ ← не тронуто |

⛤ Ось про daily note **пере-измерена**: первая попытка оказалась **вакуумной** — `find '20*-*-*.md'` сматчил UUID-имя файла, и утверждение «существующая daily note проходит» прошло по UUID-пути, а не по label-пути. Повторено против настоящего `????-??-??.md`.

## Два существующих теста закрепляли пробел

`«should skip non-UUID wikilinks (e.g. date references)»` и `«…like class names»` утверждали ровно тот пропуск, который issue называет дефектом. Они обновлены **и усилены**: теперь каждый проверяет, что резолюция **вызывается**, причём с **таргетом**, а не с алиасом. Раньше они утверждали лишь, что ничего не произошло.

## Revert-verify

**3 RED → 6 GREEN.** Три оси зелены в **обоих** состояниях: две канарейки на UUID-путь (поведение и сообщение — оно greppable в логах существующих вызывающих) и одна на «резолвимый label-form по-прежнему проходит» — именно её сломало бы переужесточение.

## Гейты

| | |
|---|---|
| `check-cli-types` | 14 пар — без изменений |
| `check-test-types` | **0** новых пар |
| полный CLI-набор | 3 сьюта / 1 тест — та же база, что на родителе |

## Граница

⚠ `create` **не превращён в `set-body`**: cross-vault таргеты по-прежнему проходят иначе, чем у `set-body` — резолюция локальная, и асимметрия сохранена намеренно.

## Требование

`1cfb6f3b-bd77-49d3-8270-2eeecf0272f3` — **proposed** (approve за фаундером). Тест несёт `@req:1cfb6f3b-…`.
