### PR TITLE
fix(cli): derive the EARL outcome from severity instead of assigning failed

### DIFF
--- a/packages/cli/src/commands/validate-schema.ts
+++ b/packages/cli/src/commands/validate-schema.ts
@@ -846,6 +846,27 @@ export interface EARLReport {
 }
 
 /**
+ * Maps a SHACL severity onto an EARL outcome.
+ *
+ * EARL has no "warning" outcome — its vocabulary offers passed / failed /
+ * cantTell / inapplicable / untested. `earl:cantTell` is the one that means
+ * "the assertion was made, but the result is neither a pass nor a fail",
+ * which is exactly what an sh:Warning (or sh:Info) is here: the CLI keeps
+ * `conforms` true and exits 0 for them, so reporting them as `earl:failed`
+ * made the EARL surface contradict the other two.
+ *
+ * The set enumerates the NON-failing severities rather than the failing one
+ * on purpose: an unrecognised severity then lands on `earl:failed`, so an
+ * EARL consumer gating on failures errs towards a false alarm rather than
+ * towards silence.
+ */
+const NON_FAILING_SEVERITIES = new Set(["sh:Warning", "sh:Info"]);
+
+function earlOutcomeFor(severity: string): string {
+  return NON_FAILING_SEVERITIES.has(severity) ? "earl:cantTell" : "earl:failed";
+}
+
+/**
  * Formats a ValidationReport as W3C EARL JSON-LD.
  */
 export function buildEARLReport(vaultPath: string, report: ValidationReport): EARLReport {
@@ -892,7 +913,7 @@ export function buildEARLReport(vaultPath: string, report: ValidationReport): EA
         "earl:test": { "@id": v.propertyPath },
         "earl:result": {
           "@type": "earl:TestResult",
-          "earl:outcome": { "@id": "earl:failed" },
+          "earl:outcome": { "@id": earlOutcomeFor(v.severity) },
           "dc:description": v.message,
           "sh:focusNode": v.focusNode,
           "sh:resultPath": v.propertyPath,

--- a/packages/cli/tests/unit/commands/validate-schema.test.ts
+++ b/packages/cli/tests/unit/commands/validate-schema.test.ts
@@ -3,6 +3,8 @@ import { Command } from "commander";
 import { mkdirSync, writeFileSync } from "fs";
 
 // Mock exocortex (heavy dependency)
+import type { Severity, Violation } from "@kitelev/exocortex-core";
+
 jest.unstable_mockModule("@kitelev/exocortex-core", () => ({
   InMemoryTripleStore: jest.fn(),
   ExoQLParser: jest.fn(),
@@ -981,6 +983,68 @@ describe("P1.6 buildEARLReport", () => {
     const failed = report["@graph"].find((n: any) => n["earl:result"]?.["earl:outcome"]?.["@id"] === "earl:failed");
     expect(failed).toBeDefined();
     expect((failed as any)["earl:result"]["dc:description"]).toBe("Missing required property");
+  });
+
+  // @req:cef65fd5-8bf0-4082-afcc-9d0fb3fe68ac
+  //
+  // The three surfaces of one check must agree. `conforms` and the exit code
+  // already treat sh:Warning as a non-failure; EARL was the outlier, mapping
+  // every finding to earl:failed regardless of severity — while reading that
+  // same severity one line below, for sh:resultSeverity.
+  const outcomes = (report: any): string[] =>
+    report["@graph"]
+      .filter((n: any) => n["earl:result"])
+      .map((n: any) => n["earl:result"]["earl:outcome"]["@id"]);
+
+  const finding = (severity: Severity, message: string): Violation => ({
+    focusNode: `https://node.com/${message}`,
+    propertyPath: "https://prop.com/p1",
+    severity,
+    message,
+    constraint: "minCount",
+  });
+
+  it("does not report a warning as a failure", () => {
+    // conforms stays true for warnings — the CLI exits 0 — so EARL must not
+    // say "failed". Pre-fix this returned earl:failed for both entries.
+    const report = buildEARLReport("/vault", {
+      conforms: true,
+      violations: [
+        finding("sh:Warning", "unresolvable ref"),
+        finding("sh:Warning", "second ref"),
+      ],
+    });
+    expect(outcomes(report)).toEqual(["earl:cantTell", "earl:cantTell"]);
+  });
+
+  it("still reports a violation as a failure", () => {
+    // Canary: ~every existing EARL consumer gates on earl:failed. Green in
+    // BOTH states — the fix must not have bought warnings at its expense.
+    const report = buildEARLReport("/vault", {
+      conforms: false,
+      violations: [finding("sh:Violation", "missing property")],
+    });
+    expect(outcomes(report)).toEqual(["earl:failed"]);
+  });
+
+  it("distinguishes the two within one report", () => {
+    // The load-bearing axis. A fix mapping EVERYTHING onto one outcome would
+    // pass a violations-only axis or a warnings-only axis, but not this one.
+    const report = buildEARLReport("/vault", {
+      conforms: false,
+      violations: [
+        finding("sh:Violation", "hard"),
+        finding("sh:Warning", "soft"),
+      ],
+    });
+    expect(outcomes(report)).toEqual(["earl:failed", "earl:cantTell"]);
+  });
+
+  it("leaves a clean vault untouched", () => {
+    // Canary: green in BOTH states.
+    expect(
+      outcomes(buildEARLReport("/vault", { conforms: true, violations: [] })),
+    ).toEqual(["earl:passed"]);
   });
 });
 


### PR DESCRIPTION
Closes #4072.

## What was wrong

`buildEARLReport` assigned `earl:failed` to **every** entry of `report.violations`, regardless of severity — while reading that same severity one line below, for `sh:resultSeverity`. The data for the right mapping was there all along; only `earl:outcome` ignored it.

⇒ **The three surfaces of one check contradicted each other**, and they cannot all be right:

| surface | a report whose only findings are `sh:Warning` |
|---|---|
| `conforms` | `true` |
| exit code | `0` |
| **`--format earl`** | **`earl:failed`** |

## Scope — pre-existing, not a regression

`report.violations` already carries cross-vault unresolvable-ref warnings: **640** in vault-exodev today. So the severity-blind mapping is older than the term-IRI collision check (#4070) and affects every one of them — that check merely made the mismatch easy to reach.

⛤ This is also why #4070 didn't touch it: the founder's constraint there was "a warning must not flip `conforms`", and that holds on `json` and `text`. `earl` was the one surface where it didn't.

## The fix

```ts
const NON_FAILING_SEVERITIES = new Set(["sh:Warning", "sh:Info"]);

function earlOutcomeFor(severity: string): string {
  return NON_FAILING_SEVERITIES.has(severity) ? "earl:cantTell" : "earl:failed";
}
```

EARL has no "warning" outcome — its vocabulary offers `passed` / `failed` / `cantTell` / `inapplicable` / `untested`. `earl:cantTell` is the one that means *"the assertion was made, but the result is neither a pass nor a fail"*, which is exactly what an `sh:Warning` is here.

⛤ **The set enumerates the NON-failing severities on purpose.** Should `Severity` ever grow a member, it lands on `earl:failed` — a consumer gating on failures then errs towards a false alarm rather than towards silence. Inverting that (list the failing one, everything else is soft) would fail quietly, which is the worse direction for a gate.

## Revert-verify — the flip names its axes

Restore `{ "@id": "earl:failed" }` and **exactly two** axes go red:

```
  ✓ produces earl:passed when conforms=true          ← canary (pre-existing)
  ✓ produces earl:failed entries for violations      ← canary (pre-existing)
  ✕ does not report a warning as a failure
  ✓ still reports a violation as a failure           ← canary
  ✕ distinguishes the two within one report
  ✓ leaves a clean vault untouched                   ← canary
```

Restore the fix → 6/6 green.

⛤ **The load-bearing axis is the third one.** A fix that mapped *everything* onto a single outcome would pass a violations-only axis and a warnings-only axis; only a **mixed** report tells the two designs apart.

⛤ **The pre-existing `earl:failed` axis is a canary, not a codified bug** — it builds its finding with `severity: "sh:Violation"`, so it was green for the right reason and stays green. Nothing asserted `sh:Warning` anywhere, which is why the defect survived: the property was true-but-unlocked.

## An axis I wrote and then dropped

I had a fifth axis — "an unrecognised severity is a failure" — driving it with `"sh:Fatal" as any`. `Severity` is a **closed union of three**, so that axis guards an input the type system forbids and production cannot produce. Same call as #4058: a guard over an impossible input is a design question, not a test. The polarity it was meant to protect now lives in the comment above the set, where it costs nothing.

## Gates

- both type ratchets green, **zero additions**: `check-cli-types` 13 → 13 pairs, `check-test-types` 433 → 433
- `check-test-antipatterns` / `validate-shard-assignments` / `check-coverage-monotonic` — green
- full CLI suite **165/166 suites, 1964 passed**; the one failure (`sparql-exo003.integration`) is **identical on `origin/main`**
- `typecheck` reports two `TS6133` in `SPARQLErrorEnhancer.ts` — **identical on `origin/main`**, untouched here
- prettier: both files were already dirty on `origin/main` (309 and 1105 lines of drift), so no blanket `--write`; my own lines were broken by hand until prettier touches **0 of them**

Requirement: `cef65fd5-8bf0-4082-afcc-9d0fb3fe68ac` (`proposed` — bound via `@req:` in the test, so the active-gate is untouched until it is approved).
