### PR TITLE
fix(core): fold a term-IRI label back to its key form in resolveLabelByUID

### DIFF
--- a/packages/core/src/services/CommandResolver.ts
+++ b/packages/core/src/services/CommandResolver.ts
@@ -10,6 +10,14 @@ import { GroundingType } from "../domain/constants/GroundingType";
 import { resolveGroundingTypeFromIRI } from "../domain/constants/GroundingTypeUIDs";
 import { utf8ToBase64 } from "../utilities/base64";
 import { iriToObsidianName } from "../utilities/iriToObsidianName";
+
+/**
+ * Absolute-IRI shape (`scheme://…`). Gates the label fold-back in
+ * {@link CommandResolver.resolveLabelByUID}: only a value that IS an IRI is
+ * handed to `iriToObsidianName`, whose vault-URL shape would otherwise strip a
+ * trailing `.md` off an ordinary label.
+ */
+const LOOKS_LIKE_IRI = /^[a-z][a-z0-9+.-]*:\/\//i;
 import {
   COMMAND_VARIANT_VALUES,
   LABEL_CLASS_VALUES,
@@ -3341,7 +3349,25 @@ export class CommandResolver {
   async resolveLabelByUID(uid: string): Promise<string | null> {
     const subject = await this.findSubjectByUID(uid);
     if (!subject) return null;
-    return this.getLiteralValue(subject, Namespace.EXO.term("Asset_label"));
+    const raw = await this.getLiteralValue(
+      subject,
+      Namespace.EXO.term("Asset_label"),
+    );
+    if (raw === null) return null;
+    // ⛔ A label that itself parses as `prefix__LocalName` — which EVERY property
+    // definition's label does (`ems__Effort_area`) — is emitted by the converter
+    // as a term IRI, not a Literal, so `getLiteralValue` hands back
+    // `https://exocortex.my/ontology/ems#Effort_area`. Callers want the label;
+    // an InheritanceRule that took this verbatim wrote the raw IRI as the
+    // frontmatter KEY, and `apply start-effort` then failed to find
+    // `ems__Effort_status` and appended a SECOND status (issue #4007).
+    //
+    // Folded back through the shared inverse of the forward emission path, so
+    // this cannot drift from it and covers every registered namespace — an
+    // explicit prefix list is what silently dropped the ad-hoc ones before
+    // (#3274). Guarded on IRI shape so an ordinary label ending in `.md` is not
+    // mistaken for a vault URL by that helper's second shape.
+    return LOOKS_LIKE_IRI.test(raw) ? (iriToObsidianName(raw) ?? raw) : raw;
   }
 
   /**

--- a/packages/core/tests/unit/services/CommandResolver.labelIriFoldback.test.ts
+++ b/packages/core/tests/unit/services/CommandResolver.labelIriFoldback.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Issue #4007 — an InheritanceRule wrote the raw IRI as a frontmatter KEY.
+ *
+ * `exocmd__InheritanceRule_targetProperty` points at the UID of a property
+ * DEFINITION, so the executor derives the key name by resolving that UID's
+ * `exo__Asset_label`. Every property definition's label parses as
+ * `prefix__LocalName` (`ems__Effort_area`), and the converter emits such a
+ * label as a term IRI rather than a Literal — so `resolveLabelByUID` handed
+ * back `https://exocortex.my/ontology/ems#Effort_area`, which then became the
+ * key on disk.
+ *
+ * ⛤ The damage was not cosmetic. A task created that way carried
+ * `…ems#Effort_status: "[[Draft]]"`; three seconds later `apply start-effort`
+ * looked for `ems__Effort_status`, did not find it, and appended a SECOND
+ * status. The asset held two statuses at once.
+ *
+ * ⛔ Why no existing test caught it: every fixture in the neighbouring suites
+ * adds labels as `new Literal(label)`, which is NOT what the converter
+ * produces for a parseable label. Measured on the real converter before
+ * writing this: `exo__Asset_label: ems__Effort_area` is emitted as
+ * `IRI(https://exocortex.my/ontology/ems#Effort_area)`. These fixtures use the
+ * IRI form deliberately — production shape, not the convenient one.
+ *
+ * Revert-verify: dropping the fold-back in `resolveLabelByUID` turns the two
+ * IRI-form axes RED; the Literal-form and the ordinary-label axes stay GREEN
+ * in both states.
+ */
+
+import { CommandResolver } from "../../../src/services/CommandResolver";
+import { InMemoryTripleStore } from "../../../src/infrastructure/rdf/InMemoryTripleStore";
+import { Triple } from "../../../src/domain/models/rdf/Triple";
+import { IRI } from "../../../src/domain/models/rdf/IRI";
+import { Literal } from "../../../src/domain/models/rdf/Literal";
+import { Namespace } from "../../../src/domain/models/rdf/Namespace";
+import type { ILogger } from "../../../src/interfaces/ILogger";
+
+const silentLogger: ILogger = {
+  debug() {},
+  info() {},
+  warn() {},
+  error() {},
+};
+
+const PROP_UID = "9be36e9d-1111-4111-8111-111111111111";
+
+/** Adds an asset whose `exo__Asset_label` is emitted the way the CONVERTER emits it. */
+async function addAsset(
+  store: InMemoryTripleStore,
+  uid: string,
+  label: IRI | Literal,
+): Promise<void> {
+  const subject = new IRI(`obsidian://vault/${uid}.md`);
+  await store.addAll([
+    new Triple(subject, Namespace.EXO.term("Asset_uid"), new Literal(uid)),
+    new Triple(subject, Namespace.EXO.term("Asset_label"), label),
+  ]);
+}
+
+describe("Issue #4007: resolveLabelByUID folds a term-IRI label back to its key form", () => {
+  let store: InMemoryTripleStore;
+  let resolver: CommandResolver;
+
+  beforeEach(() => {
+    store = new InMemoryTripleStore();
+    resolver = new CommandResolver(store, silentLogger);
+  });
+
+  it("folds a term IRI back to prefix__LocalName", async () => {
+    // Exactly what the converter emits for `exo__Asset_label: ems__Effort_area`.
+    await addAsset(
+      store,
+      PROP_UID,
+      new IRI("https://exocortex.my/ontology/ems#Effort_area"),
+    );
+    expect(await resolver.resolveLabelByUID(PROP_UID)).toBe("ems__Effort_area");
+  });
+
+  it("folds an ad-hoc namespace too, not just the well-known ones", async () => {
+    // A hardcoded prefix list is what silently dropped ad-hoc namespaces before
+    // (#3274); the shared inverse of the emission path covers them by shape.
+    await addAsset(
+      store,
+      PROP_UID,
+      new IRI("https://exocortex.my/ontology/aiKnow#Memory_decay"),
+    );
+    expect(await resolver.resolveLabelByUID(PROP_UID)).toBe(
+      "aiKnow__Memory_decay",
+    );
+  });
+
+  it("leaves a Literal label untouched", async () => {
+    // Canary — green in BOTH states. Non-parseable labels are still Literals.
+    await addAsset(store, PROP_UID, new Literal("Some Human Label"));
+    expect(await resolver.resolveLabelByUID(PROP_UID)).toBe("Some Human Label");
+  });
+
+  it("leaves a plain label that ends in .md untouched", async () => {
+    // Canary — green in BOTH states. `iriToObsidianName`'s second shape strips
+    // a trailing `.md` off a vault URL; unguarded, it would eat this label.
+    await addAsset(store, PROP_UID, new Literal("Notes about foo.md"));
+    expect(await resolver.resolveLabelByUID(PROP_UID)).toBe(
+      "Notes about foo.md",
+    );
+  });
+
+  it("returns null for an unknown UID", async () => {
+    // Canary — green in BOTH states.
+    expect(
+      await resolver.resolveLabelByUID("00000000-0000-4000-8000-000000000000"),
+    ).toBeNull();
+  });
+});


### PR DESCRIPTION
Closes #4007.

## What happened, in order

1. An InheritanceRule points `exocmd__InheritanceRule_targetProperty` at the **UID of a property definition**, so the executor must derive the frontmatter key by resolving that UID's `exo__Asset_label`.
2. Every property definition's label parses as `prefix__LocalName` — `ems__Effort_area`.
3. The converter emits such a label as a **term IRI**, not a Literal.
4. `resolveLabelByUID` → `getLiteralValue` hit `if (obj instanceof IRI) return obj.value` and handed back `https://exocortex.my/ontology/ems#Effort_area`.
5. That string became the **key** on disk.

⛤ **The damage was not cosmetic.** The reported task carried `…ems#Effort_status: "[[Draft]]"`. Three seconds later `apply start-effort` looked for `ems__Effort_status`, did not find it, and **appended a second status**. The asset held `Draft` and `Doing` simultaneously, and anything reading its status was unreliable.

## Step 3 measured, not assumed

The issue offered it as the likely mechanism. Driving the **real** `NoteToRDFConverter` with `exo__Asset_label: ems__Effort_area`:

```
PROBE  IRI => https://exocortex.my/ontology/ems#Effort_area
```

so the label genuinely arrives as an IRI, and step 4 follows from the code as written.

## Why no test caught it

Every fixture in the neighbouring `CommandResolver.*` suites adds labels as `new Literal(label)` — which is **not** what the converter produces for a parseable label. The suites were green for a shape production never emits. The new fixtures use the IRI form deliberately.

## Where the fix goes — the class, not the instance

| candidate | call sites | verdict |
|---|---|---|
| `getLiteralValue` | **59** | ❌ many legitimately want the raw IRI; a blanket fold is a wide blast radius |
| **`resolveLabelByUID`** | **9** | ✅ its contract *is* "resolve a UID to the asset's label" — an IRI was wrong at every one |

Fixing at the label boundary closes the whole family in one place: not just InheritanceRule, but `PropertyDefault` target properties and substitution refs, which resolve their names the same way.

```ts
return LOOKS_LIKE_IRI.test(raw) ? (iriToObsidianName(raw) ?? raw) : raw;
```

⛤ `iriToObsidianName` is the **shared inverse of the forward emission path** (`Namespace.fromTermIRI`), so this direction cannot drift from it, and it covers ad-hoc namespaces by shape — a hardcoded prefix list is exactly what silently dropped `kitelev__` / `aiKnow__` before (#3274). There is an axis pinning an ad-hoc namespace for that reason.

⛔ The IRI-shape guard is load-bearing: `iriToObsidianName`'s second shape maps `…/<basename>.md` → `<basename>`, so an ordinary label ending in `.md` would be silently truncated without it. There is a canary for that too.

## Revert-verify

Drop the fold-back → **two** axes red, **three canaries** green in both states:

```
  ✕ folds a term IRI back to prefix__LocalName
  ✕ folds an ad-hoc namespace too, not just the well-known ones
  ✓ leaves a Literal label untouched              ← canary
  ✓ leaves a plain label that ends in .md untouched ← canary (the shape guard)
  ✓ returns null for an unknown UID               ← canary
```

## Gates

- both ratchets green, **zero additions**: `check-cli-types` 13 → 13, `check-test-types` 433 → 433
- full **core** suite (380 suites, 8663 tests) — the 3 failing suites are **identical on `origin/main`** (9 failed / 2 passed both ways)
- `TripleStorePerformance` failed once **under a concurrent build** and passes twice in quiet — a load artefact, not this change
- prettier: the new test file is clean; `CommandResolver.ts` was already dirty on `origin/main`, so no blanket `--write`

Bug-fix branch of feature-sdd Step 0: restores behaviour the InheritanceRule mechanism already promised.

## Left for a separate call

The issue's step 4 also suggests a **guard in the status mutators** — `start-effort` normalising an existing full-IRI key instead of appending a second one. That is a second, independent defence (it would have limited the damage even with this bug present) and a behaviour change of its own; it is not needed to close the reported cause, so it is not bundled here.
