### PR TITLE
fix(plugin): resolve a dash-prefixed reified predicate to its frontmatter key

### DIFF
--- a/packages/obsidian-plugin/src/presentation/renderers/layout/RelationsRenderer.ts
+++ b/packages/obsidian-plugin/src/presentation/renderers/layout/RelationsRenderer.ts
@@ -553,6 +553,30 @@ export class RelationsRenderer {
       return typeof uid === "string" && uid ? `uid:${uid}` : `path:${path}`;
     };
 
+    // The frontmatter KEY a reified predicate stands for. `predicateIriToKey`
+    // canonicalises ontology-base IRIs and returns anything else verbatim —
+    // correct for a pure function, but `exo__Statement_predicate` resolves to a
+    // PATH-form IRI whenever the predicate definition's own label is not itself
+    // parseable as `prefix__Local`, which a DASH-bearing prefix
+    // (`adapter-exo-ims__relatesToConcept`) is not. The raw IRI then reached both
+    // the group heading AND the dedup key, so such a relation showed its IRI as a
+    // heading and could never match its inline twin (issue #4011).
+    //
+    // The second hop mirrors `pathIriToToken` directly above — same adapter, same
+    // source of truth, one field over. Fail-open: an unresolvable definition
+    // keeps the raw IRI, so the relation still surfaces.
+    const predicateKey = (iri: string): string => {
+      const canonical = predicateIriToKey(iri);
+      if (canonical !== iri) return canonical;
+      const path = iriToVaultPath(iri);
+      if (!path) return iri;
+      const f = this.vaultAdapter.getAbstractFileByPath(path);
+      const label = f
+        ? this.vaultAdapter.getFrontmatter(f as IFile)?.exo__Asset_label
+        : undefined;
+      return typeof label === "string" && label.trim() ? label.trim() : iri;
+    };
+
     const tokenFor = async (iri: string): Promise<string> => {
       if (iri === aSymbolic) return aToken;
       const pathToken = pathIriToToken(iri);
@@ -610,7 +634,7 @@ export class RelationsRenderer {
 
       const subjToken = await tokenFor(r.subject);
       const objToken = await tokenFor(r.object);
-      const key = `${subjToken}|${predicateIriToKey(r.predicate)}|${objToken}`;
+      const key = `${subjToken}|${predicateKey(r.predicate)}|${objToken}`;
       if (seenKeys.has(key)) continue; // inline-wins + reified-vs-reified dedup
       seenKeys.add(key);
 
@@ -647,7 +671,7 @@ export class RelationsRenderer {
         path: otherPath ?? otherIri,
         title,
         metadata,
-        propertyName: predicateIriToKey(r.predicate),
+        propertyName: predicateKey(r.predicate),
         isBodyLink: false,
         isArchived: MetadataHelpers.isAssetArchived(metadata),
         isBlocked: BlockerHelpers.isEffortBlocked(this.app, metadata),

--- a/packages/obsidian-plugin/tests/unit/renderers/layout/RelationsRenderer.dashPredicate.test.ts
+++ b/packages/obsidian-plugin/tests/unit/renderers/layout/RelationsRenderer.dashPredicate.test.ts
@@ -1,0 +1,168 @@
+/**
+ * Issue #4011 — a dash-prefixed reified predicate rendered as a raw IRI and
+ * broke the inline↔reified dedup.
+ *
+ * `exo__Statement_predicate` resolves to a PATH-form IRI whenever the predicate
+ * definition's `exo__Asset_label` is not itself parseable as `prefix__Local` —
+ * which a dash-bearing prefix (`adapter-exo-ims__relatesToConcept`) is not. The
+ * pure `predicateIriToKey` canonicalises only ontology-base IRIs and returns
+ * anything else verbatim, so the raw `obsidian://…/<uid>.md` reached BOTH
+ * consumers:
+ *
+ *   1. `propertyName` → the Asset Relations group heading showed the raw IRI
+ *      (pixel-verified on the live vault, 2026-07-31);
+ *   2. the dedup key → it could never equal the inline side's frontmatter key,
+ *      so a relation existing in BOTH forms surfaced twice, defeating the
+ *      documented "inline-wins" contract.
+ *
+ * ⛤ `predicateIriToKey` itself is NOT changed: it is a pure function with no
+ * vault access, and "pass a non-ontology IRI through" is a correct contract for
+ * it — its existing axis stays green for the right reason. The second hop needs
+ * the vault, so it lives where the vault already is.
+ *
+ * ⚠ Grade 2 was derived from the code in the reporting session and NOT
+ * reproduced there (the probe asset had no inline twin). It is reproduced here.
+ *
+ * Revert-verify: dropping the second hop turns both axes RED; the symbolic and
+ * unresolvable axes stay GREEN in both states.
+ */
+import { RelationsRenderer } from "@plugin/presentation/renderers/layout/RelationsRenderer";
+import { InMemoryTripleStore } from "@kitelev/exocortex-core";
+import { Triple, IRI, Namespace } from "@kitelev/exocortex-core";
+import type { TFile } from "obsidian";
+
+const VAULT_IRI_PREFIX = "obsidian://vault/";
+const iriOf = (path: string) => new IRI(VAULT_IRI_PREFIX + path);
+
+const A_PATH = "assetspaces/kitelev/exoas-my/my/aaaaaaaa-0001.md";
+const B_PATH = "assetspaces/kitelev/exoas-public/concept/bbbbbbbb-0002.md";
+const S_PATH = "assetspaces/kitelev/exoas-class-relations/cr/11111111-0011.md";
+/** The predicate DEFINITION asset — its label is the frontmatter key. */
+const PRED_PATH =
+  "assetspaces/kitelev/exoas-public/adapter-exo-ims/0967a771.md";
+const PRED_KEY = "adapter-exo-ims__relatesToConcept";
+
+describe("Issue #4011: a dash-prefixed reified predicate resolves to its key", () => {
+  /** Frontmatter by vault path — the only thing the renderer reads for the hop. */
+  const fmByPath = new Map<string, Record<string, unknown>>([
+    [A_PATH, { exo__Asset_uid: "uid-a" }],
+    [B_PATH, { exo__Asset_uid: "uid-b" }],
+    [PRED_PATH, { exo__Asset_label: PRED_KEY }],
+  ]);
+
+  /**
+   * Seeds one reified statement. `incoming` puts B on the subject side, which is
+   * the shape the inline dedup seed mirrors: it keys inline relations as
+   * "sourceFile --propertyName--> A", i.e. edges POINTING AT the open asset.
+   */
+  async function seed(
+    store: InMemoryTripleStore,
+    predicate: IRI,
+    incoming = false,
+  ) {
+    const [subj, obj] = incoming
+      ? [iriOf(B_PATH), iriOf(A_PATH)]
+      : [iriOf(A_PATH), iriOf(B_PATH)];
+    const stmt = iriOf(S_PATH);
+    await store.add(
+      new Triple(
+        stmt,
+        Namespace.RDF.term("type"),
+        Namespace.EXO.term("Statement"),
+      ),
+    );
+    await store.add(
+      new Triple(stmt, Namespace.EXO.term("Statement_subject"), subj),
+    );
+    await store.add(
+      new Triple(stmt, Namespace.EXO.term("Statement_predicate"), predicate),
+    );
+    await store.add(
+      new Triple(stmt, Namespace.EXO.term("Statement_object"), obj),
+    );
+    await store.add(new Triple(subj, predicate, obj));
+  }
+
+  function makeRenderer(store: InMemoryTripleStore): RelationsRenderer {
+    const vaultAdapter = {
+      getAbstractFileByPath: (p: string) =>
+        fmByPath.has(p) ? ({ path: p } as never) : null,
+      getFrontmatter: (f: { path: string } | null) =>
+        (f ? (fmByPath.get(f.path) ?? null) : null) as never,
+    };
+    const metadataService = { getAssetLabel: () => null };
+    return new RelationsRenderer(
+      {} as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      metadataService as never,
+      {} as never,
+      (() => {}) as never,
+      vaultAdapter as never,
+      store,
+      () => true,
+      ((p: string) => iriOf(p)) as never,
+    );
+  }
+
+  /** Runs the private merge and returns the reified relations it appended. */
+  async function merged(
+    predicate: IRI,
+    seedInline: boolean,
+  ): Promise<{ propertyName?: string; provenance?: string }[]> {
+    const store = new InMemoryTripleStore();
+    await seed(store, predicate, seedInline);
+    const renderer = makeRenderer(store);
+    const relations: Record<string, unknown>[] = seedInline
+      ? [
+          {
+            provenance: "inline",
+            propertyName: PRED_KEY,
+            path: B_PATH,
+            metadata: { exo__Asset_uid: "uid-b" },
+          },
+        ]
+      : [];
+    await (
+      renderer as unknown as {
+        mergeReifiedRelations: (f: TFile, r: unknown[]) => Promise<void>;
+      }
+    ).mergeReifiedRelations({ path: A_PATH } as TFile, relations);
+    return relations as { propertyName?: string; provenance?: string }[];
+  }
+
+  it("names the group by the frontmatter key, not the raw IRI", async () => {
+    // Grade 1 — the pixel-verified symptom.
+    const out = await merged(iriOf(PRED_PATH), false);
+    const reified = out.filter((r) => r.provenance === "reified");
+    expect(reified).toHaveLength(1);
+    expect(reified[0].propertyName).toBe(PRED_KEY);
+  });
+
+  it("dedups against the inline twin (inline wins)", async () => {
+    // Grade 2 — derived from code in the reporting session, reproduced here.
+    const out = await merged(iriOf(PRED_PATH), true);
+    expect(out.filter((r) => r.provenance === "reified")).toHaveLength(0);
+    expect(out).toHaveLength(1);
+  });
+
+  it("leaves a SYMBOLIC ontology predicate alone", async () => {
+    // Canary — green in BOTH states; the pure function already handles this.
+    const out = await merged(
+      new IRI("https://exocortex.my/ontology/exo-ims#relatesToConcept"),
+      false,
+    );
+    const reified = out.filter((r) => r.provenance === "reified");
+    expect(reified[0].propertyName).toBe("exo-ims__relatesToConcept");
+  });
+
+  it("falls back to the raw IRI when the definition cannot be resolved", async () => {
+    // Canary — green in BOTH states. Fail-open: an unknown predicate must still
+    // surface the relation rather than crash or drop it.
+    const unknown = iriOf("assetspaces/nowhere/does-not-exist.md");
+    const out = await merged(unknown, false);
+    const reified = out.filter((r) => r.provenance === "reified");
+    expect(reified[0].propertyName).toBe(unknown.value);
+  });
+});


### PR DESCRIPTION
Closes #4011.

## The mechanism

`exo__Statement_predicate` resolves to a **path-form** IRI whenever the predicate definition's own `exo__Asset_label` is not itself parseable as `prefix__Local` — which a dash-bearing prefix (`adapter-exo-ims__relatesToConcept`) is not. `predicateIriToKey` canonicalises ontology-base IRIs and returns anything else verbatim, so the raw `obsidian://…/<uid>.md` reached **both** of its consumers.

| grade | consumer | effect |
|---|---|---|
| 1 | `propertyName` | the Asset Relations group heading rendered the raw IRI — pixel-verified on the live vault when reported |
| 2 | the dedup key | can never equal the inline side's frontmatter key ⇒ a relation existing in BOTH forms surfaces **twice**, defeating the documented "inline-wins" contract |

⛤ **Grade 2 was derived from the code and never reproduced** — the reporting session's probe asset had no inline twin, and the issue says so and asks for repro-first. It is reproduced here, red before the fix.

## Where the fix goes

`predicateIriToKey` is **unchanged**. It is a pure function with no vault access, and "pass a non-ontology IRI through" is a correct contract for it — its existing axis (`expect(predicateIriToKey("obsidian://vault/foo.md")).toBe(…)`) stays green *for the right reason*, not as codified debt.

The second hop needs the vault, so it lives where the vault already is — inside `mergeReifiedRelations`, mirroring `pathIriToToken` a few lines above:

```ts
const predicateKey = (iri: string): string => {
  const canonical = predicateIriToKey(iri);
  if (canonical !== iri) return canonical;   // symbolic — already done
  const path = iriToVaultPath(iri);
  if (!path) return iri;
  const f = this.vaultAdapter.getAbstractFileByPath(path);
  const label = f ? this.vaultAdapter.getFrontmatter(f as IFile)?.exo__Asset_label : undefined;
  return typeof label === "string" && label.trim() ? label.trim() : iri;
};
```

Same adapter, same source of truth as the sibling token resolver, one field over. **Fail-open**: an unresolvable definition keeps the raw IRI, so the relation still surfaces rather than disappearing.

⛤ The issue suggested reusing `reifiedPredicateFrontmatterKey`. It takes `(iri, uidOf, keyByDefUid)` — a reverse-map this call site does not build and would have to thread through. The hop it performs is the one written above, against the adapter already in hand; borrowing the shape rather than the signature keeps the change to one method.

## Revert-verify

Restore `predicateIriToKey(r.predicate)` at both call sites → **both** grades red, **two canaries** green in both states:

```
  ✕ names the group by the frontmatter key, not the raw IRI    (grade 1)
  ✕ dedups against the inline twin (inline wins)               (grade 2)
  ✓ leaves a SYMBOLIC ontology predicate alone      ← canary
  ✓ falls back to the raw IRI when unresolvable     ← canary (fail-open)
```

⛤ **A fixture correction worth naming.** The dedup axis was red at first *for the wrong reason*: I seeded an OUTGOING statement, while the inline dedup seed keys edges **pointing at** the open asset (`sourceFile --propertyName--> A`). Reading the received object — the key was already correct, the direction was not — showed it was the fixture, not the fix. Direction is now a parameter, and the axis fails only when the fix is removed.

## Gates

- both ratchets green, **zero additions**: `check-cli-types` 13 → 13, `check-test-types` 433 → 433
- `check-test-antipatterns` — green
- full **plugin** suite (350 suites, 6025 tests): the 4 failing suites are the `ExocortexPlugin.*` / `VaultSettingsRegistry` ones that fail identically on `origin/main`
- relations suites specifically: **99 passed**
- prettier: the new file is clean; `RelationsRenderer.ts` was already dirty on `origin/main`, so no blanket `--write` — prettier touches **0** of my lines
