### PR TITLE
feat(display-name): one unwrap for both 1-hop resolvers, alias included

### DIFF
--- a/packages/core/src/domain/display-name/PrintNameRuleService.ts
+++ b/packages/core/src/domain/display-name/PrintNameRuleService.ts
@@ -1,5 +1,6 @@
 import type { VaultMetadataPort } from "./VaultMetadataPort";
 import { resolvePreferenceList } from "./preferenceList";
+import { unwrapLinkTarget } from "./linkTarget";
 import {
   ownProperty,
   resolveKeyPath,
@@ -405,23 +406,15 @@ export class PrintNameRuleService {
 
   createMetadataResolver(): MetadataResolver {
     return (wikilinkTarget: string): Record<string, unknown> | null => {
-      const unwrapped = wikilinkTarget
-        .replace(/^\[\[|\]\]$/g, "")
-        .replace(/^"|"$/g, "")
-        .trim();
-
-      // Strip a display alias: `[[<uid>|<label>]]` points at <uid> exactly as `[[<uid>]]`
-      // does, but getFirstLinkpathDest("<uid>|<label>") never resolves — so before this the
-      // aliased form produced a SILENT non-match (req fedeaa6e scenario 3). Both wikilink
-      // forms must resolve identically; that is the dual-IRI floor the corpus mandates.
-      const cleaned = unwrapped.includes("|")
-        ? (unwrapped.split("|")[0]?.trim() ?? "")
-        : unwrapped;
-
+      // ⛤ The unwrap — brackets, quotes, and the display ALIAS — is shared with
+      // `PropertiesDefinitionValuePatch`, which resolves the same authored value
+      // through a different adapter. Letting each keep its own copy is how they
+      // drifted after req fedeaa6e (#4041); the HOP stays each caller's own.
+      const cleaned = unwrapLinkTarget(wikilinkTarget);
       if (!cleaned) return null;
-
-      // The `.md`-suffix retry is the adapter's business (see VaultMetadataPort) — the
-      // engine hands over an already-unwrapped, alias-stripped target and asks once.
+  
+      // The `.md`-suffix retry is the adapter's business (see VaultMetadataPort) —
+      // the engine hands over an already-unwrapped target and asks once.
       const fm = this.vault.resolveLinkpathFrontmatter(cleaned);
       return fm ? { ...fm } : null;
     };

--- a/packages/core/src/domain/display-name/linkTarget.ts
+++ b/packages/core/src/domain/display-name/linkTarget.ts
@@ -1,0 +1,30 @@
+/**
+ * Unwrap a frontmatter wikilink value into the linkpath a vault lookup expects:
+ * quotes off, `[[ ]]` off, display alias off, trimmed.
+ *
+ * ⛔ The ALIAS strip is the part that matters. `[[<uid>|<label>]]` points at
+ * `<uid>` exactly as `[[<uid>]]` does, but a lookup for `"<uid>|<label>"` never
+ * resolves — so an aliased reference produced a SILENT non-match (req fedeaa6e
+ * scenario 3). Both wikilink forms must resolve identically; that is the
+ * dual-IRI floor.
+ *
+ * ⛤ This lives on its own because TWO surfaces unwrap the same authored value
+ * and then hop through DIFFERENT adapters by construction — the display-name
+ * engine through a `VaultMetadataPort`, `PropertiesDefinitionValuePatch`
+ * through Obsidian's `metadataCache` (it deliberately does not depend on
+ * `PrintNameRuleService`). The hop is legitimately theirs; the unwrap is not,
+ * and letting each keep its own is how they drifted (issue #4041).
+ *
+ * ⚠ The `.md`-suffix retry stays with the caller's adapter: one of them retries
+ * and the other's port promises to, so it is not part of this contract.
+ */
+export function unwrapLinkTarget(raw: string): string {
+  const unwrapped = raw
+    .replace(/^\[\[|\]\]$/g, "")
+    .replace(/^"|"$/g, "")
+    .trim();
+  const target = unwrapped.includes("|")
+    ? (unwrapped.split("|")[0]?.trim() ?? "")
+    : unwrapped;
+  return target;
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -899,6 +899,8 @@ export type { VaultMetadataPort } from "./domain/display-name/VaultMetadataPort"
 // The ONE definition of what a multi-value exo__PrintedProperty_property means
 // (an ordered preference list), shared by both subsystems that compile it (#4050).
 export { resolvePreferenceList } from "./domain/display-name/preferenceList";
+// The ONE way an authored wikilink becomes a linkpath — alias included (#4041).
+export { unwrapLinkTarget } from "./domain/display-name/linkTarget";
 export type { DisplayNameSettings } from "./domain/display-name/DisplayNameSettings";
 export { DEFAULT_DISPLAY_NAME_SETTINGS } from "./domain/display-name/DisplayNameSettings";
 export { PrintNameRuleService } from "./domain/display-name/PrintNameRuleService";

--- a/packages/obsidian-plugin/src/presentation/properties/PropertiesDefinitionValuePatch.ts
+++ b/packages/obsidian-plugin/src/presentation/properties/PropertiesDefinitionValuePatch.ts
@@ -3,6 +3,7 @@ import {
   ConceptDefinitionResolver,
   type MetadataResolver,
 } from "@plugin/domain/concept-definition/ConceptDefinitionResolver";
+import { unwrapLinkTarget } from "@kitelev/exocortex-core";
 import { ConceptDefinitionSpecService } from "@plugin/domain/concept-definition/ConceptDefinitionSpecService";
 
 /**
@@ -151,18 +152,22 @@ export class PropertiesDefinitionValuePatch {
    */
   private buildMetadataResolver(): MetadataResolver {
     return (wikilinkTarget: string): Record<string, unknown> | null => {
-      const cleaned = wikilinkTarget
-        .replace(/^\[\[|\]\]$/g, "")
-        .replace(/^"|"$/g, "")
-        .trim();
+      // ⛤ The unwrap is now the SHARED one (#4041) — the copy here had stopped
+      // stripping the display alias after req fedeaa6e changed the canonical
+      // resolver, so a dot-path over an ALIASED intermediate reference kept a
+      // silent non-match on this surface while resolving on the other three.
+      // The HOP stays inline: the patch deliberately does not depend on
+      // PrintNameRuleService, and going through metadataCache rather than a
+      // VaultMetadataPort is not what diverged.
+      const cleaned = unwrapLinkTarget(wikilinkTarget);
       if (!cleaned) return null;
-
+  
       let file = this.app.metadataCache.getFirstLinkpathDest(cleaned, "");
       if (!file && !cleaned.endsWith(".md")) {
         file = this.app.metadataCache.getFirstLinkpathDest(cleaned + ".md", "");
       }
       if (!(file instanceof TFile)) return null;
-
+  
       const cache = this.app.metadataCache.getFileCache(file);
       return cache?.frontmatter ? { ...cache.frontmatter } : null;
     };

--- a/packages/obsidian-plugin/tests/unit/presentation/properties/PropertiesDefinitionValuePatch.aliasUnwrap.test.ts
+++ b/packages/obsidian-plugin/tests/unit/presentation/properties/PropertiesDefinitionValuePatch.aliasUnwrap.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Issue #4041 — the two 1-hop resolvers stopped agreeing on the unwrap.
+ *
+ * `PropertiesDefinitionValuePatch.buildMetadataResolver` is an inline copy of
+ * `PrintNameRuleService.createMetadataResolver`, deliberately inline so the
+ * patch does not depend on the service. After req fedeaa6e the canonical one
+ * began stripping a display alias (`[[uid|label]]` → `uid`) and the copy did
+ * not — so the two changes in that PR landed on a DIFFERENT number of surfaces,
+ * and a concept-definition dot-path over an aliased intermediate reference kept
+ * a silent non-match while the same authoring form resolved everywhere else.
+ *
+ * ⛤ What is shared now is the UNWRAP, not the hop: the canonical resolver goes
+ * through a `VaultMetadataPort`, this one through Obsidian's `metadataCache`,
+ * and that difference is by construction — it is not what diverged.
+ *
+ * ⛤ Live radius when written: ZERO. Measured over the raw frontmatter of all
+ * three canonical vaults — 138 parts carry `exo__PrintedProperty_property`, the
+ * 3 dot-paths among them all belong to `exo__DisplayNameSpec`, not to a
+ * concept-definition spec. This closes an authoring trap before anyone falls in.
+ * (⛔ Not measurable by SPARQL: the store emits the wikilink TARGET and discards
+ * the alias, so a query for "how many are aliased" answers zero regardless.)
+ *
+ * Revert-verify: restoring the alias-blind unwrap here turns the aliased axis
+ * RED; the plain axes stay GREEN in both states.
+ */
+import { TFile } from "obsidian";
+import type { App, CachedMetadata } from "obsidian";
+import { PropertiesDefinitionValuePatch } from "@plugin/presentation/properties/PropertiesDefinitionValuePatch";
+
+const TARGET_PATH = "assetspaces/kitelev/exoas-my/my/cccccccc-0003.md";
+const TARGET_UID = "cccccccc-0003";
+
+function app(): App {
+  const file = Object.assign(new TFile(), {
+    path: TARGET_PATH,
+    basename: TARGET_UID,
+    extension: "md",
+  });
+  const cache = new Map<string, CachedMetadata>([
+    [
+      TARGET_PATH,
+      { frontmatter: { exo__Asset_label: "Целевой ассет" } } as CachedMetadata,
+    ],
+  ]);
+  return {
+    metadataCache: {
+      getFileCache: (f: TFile) => cache.get(f.path) ?? null,
+      // Resolves ONLY the bare uid — exactly like Obsidian: an unstripped
+      // `uid|label` linkpath finds nothing.
+      getFirstLinkpathDest: (p: string) =>
+        p === TARGET_UID || p === `${TARGET_UID}.md` ? file : null,
+    },
+    workspace: { getLeavesOfType: () => [] },
+  } as unknown as App;
+}
+
+/** The private resolver under test — the patch builds it for its dot-path hops. */
+function resolverOf(): (t: string) => Record<string, unknown> | null {
+  const patch = new PropertiesDefinitionValuePatch({ app: app() } as never);
+  return (
+    patch as unknown as {
+      buildMetadataResolver: () => (
+        t: string,
+      ) => Record<string, unknown> | null;
+    }
+  ).buildMetadataResolver();
+}
+
+describe("Issue #4041: the patch's resolver strips a display alias too", () => {
+  it("resolves an ALIASED reference exactly as the bare one", () => {
+    // The defect: `getFirstLinkpathDest("<uid>|<label>")` never resolves, so this
+    // returned null — a silent non-match with no diagnostic.
+    expect(resolverOf()(`[[${TARGET_UID}|Целевой ассет]]`)).toEqual({
+      exo__Asset_label: "Целевой ассет",
+    });
+  });
+
+  it("resolves a BARE reference unchanged", () => {
+    // Canary — green in BOTH states. Every live part is this shape or simpler.
+    expect(resolverOf()(`[[${TARGET_UID}]]`)).toEqual({
+      exo__Asset_label: "Целевой ассет",
+    });
+  });
+
+  it("still returns null for an unknown target", () => {
+    // Canary — green in BOTH states. Fail-closed is unchanged.
+    expect(resolverOf()("[[nope-does-not-exist]]")).toBeNull();
+  });
+
+  it("still returns null for an empty target", () => {
+    // Canary — an alias-only value (`[[|label]]`) normalises to "" and must not
+    // become a lookup for the label.
+    expect(resolverOf()("[[|Целевой ассет]]")).toBeNull();
+  });
+});


### PR DESCRIPTION
Closes #4041. Requirement: `7405c664-826e-40af-a1df-395534530eb2` (`proposed` — bound via `@req:` is not needed here; the axes name the issue, and the active-gate is untouched until the req is approved).

## What diverged

`PropertiesDefinitionValuePatch.buildMetadataResolver` is an inline copy of `PrintNameRuleService.createMetadataResolver` — inline **on purpose**, so the patch does not depend on the service. After req `fedeaa6e` the canonical one began stripping a display alias and the copy did not:

| change in #4040 | matcher | display-name templates | concept-definition |
|---|---|---|---|
| first-element **list** hop (shared `resolveKeyPath`) | ✅ | ✅ | ✅ |
| **`\|alias` strip** (`createMetadataResolver`) | ✅ | ✅ | ⛔ |

⇒ a concept-definition dot-path over an **aliased** intermediate reference kept a silent non-match, while the identical authoring form resolved on the other three surfaces.

## What is shared now — and what deliberately is not

```ts
// core: the ONE way an authored wikilink becomes a linkpath
export function unwrapLinkTarget(raw: string): string { … }   // brackets, quotes, ALIAS, trim
```

⛤ Shared: the **unwrap**. NOT shared: the **hop** — the canonical resolver goes through a `VaultMetadataPort`, this one through Obsidian's `metadataCache`, and that difference is by construction. Sharing the hop would have to pick one adapter and would destroy the patch's deliberate independence from `PrintNameRuleService`, which the issue explicitly wants preserved. The `.md`-suffix retry likewise stays with each adapter.

This is the same shape as #4117 (`resolvePreferenceList`): when two subsystems read one authored value through different adapters, what must not drift is the **interpretation**, not the plumbing.

## Live radius today: ZERO

Measured over the **raw frontmatter** of all three canonical vaults: **138** parts carry `exo__PrintedProperty_property`; **129** are aliased; **3** are dot-paths — and all three belong to `exo__DisplayNameSpec`, not to a concept-definition spec. Nothing renders differently today; this closes an authoring trap.

⛔ **Not measurable by SPARQL** — the store emits the wikilink TARGET and discards the alias, so a query for "how many references are aliased" is structurally blind and answers zero regardless of the data. My first attempt did exactly that and reported `51/51 dot-paths`, which was the `.` inside `exocortex.my`.

## Revert-verify — two mutants, because one surface is not enough

**Mutant A — the shared unwrap stops stripping the alias:** 5 axes red across BOTH surfaces (mine + the `fedeaa6e` set), 6 green.

**Mutant B — only the patch surface reverts** (a plausible one-sided "fix"):

```
  ✓ …fedeaa6e scenario 1 … 5   (7 axes, all green — the canonical surface is fine)
  ✕ resolves an ALIASED reference exactly as the bare one   ← mine, the only red
  ✓ resolves a BARE reference unchanged            ← canary
  ✓ still returns null for an unknown target       ← canary
  ✓ still returns null for an empty target         ← canary (`[[|label]]` must not
                                                      become a lookup for the label)
```

⛤ Mutant B is the load-bearing one: it shows the existing `fedeaa6e` axes **cannot** see this surface, so without the new axis a one-sided fix would ship green. Conversely mutant A shows the refactor of the canonical resolver onto the shared unwrap is itself covered.

## Gates

- both ratchets green, **zero additions**: `check-cli-types` 13 → 13, `check-test-types` 433 → 433
- `check-test-antipatterns` — green
- full **plugin** suite: 3 failed — the pre-existing `ExocortexPlugin.*` / `VaultSettingsRegistry` ones, identical on `origin/main`
- full **core** suite: 9 failed in 3 `dynamic-commands` suites — **identical on `origin/main`** (9 failed / 57 passed both ways)
- ⚠ a parallel run of both suites reported 11 core failures; re-run in quiet it is 9 — a load artefact, named rather than glossed
- prettier: both new files clean; the two touched files were already dirty on `origin/main`, so no blanket `--write` — prettier touches **0** of my lines in either
