### PR TITLE
test(reqs): bind the two specs shipped without an owner

### DIFF
--- a/packages/core/tests/unit/domain/constants/EffortStatusCanon.test.ts
+++ b/packages/core/tests/unit/domain/constants/EffortStatusCanon.test.ts
@@ -26,7 +26,7 @@ import { STATUS_UID_BY_ENUM } from "../../../../src/services/GroundingExecutor";
 
 const DONE_UID = "7b9b3116-7c3c-438c-9618-94fe301320a6";
 
-describe("Issue #4056: the effort-status canon", () => {
+describe("@req:355d9379-ed7b-4241-9ce7-0af955653127 Issue #4056: the effort-status canon", () => {
   describe("one source", () => {
     it("the workflow table IS the canon, not a copy of it", () => {
       // The DoD axis. A literal re-declaration in GroundingExecutor makes this

--- a/packages/obsidian-plugin/tests/unit/presentation/properties/PropertiesDefinitionValuePatch.aliasUnwrap.test.ts
+++ b/packages/obsidian-plugin/tests/unit/presentation/properties/PropertiesDefinitionValuePatch.aliasUnwrap.test.ts
@@ -66,7 +66,7 @@ function resolverOf(): (t: string) => Record<string, unknown> | null {
   ).buildMetadataResolver();
 }
 
-describe("Issue #4041: the patch's resolver strips a display alias too", () => {
+describe("@req:7405c664-826e-40af-a1df-395534530eb2 Issue #4041: the patch's resolver strips a display alias too", () => {
   it("resolves an ALIASED reference exactly as the bare one", () => {
     // The defect: `getFirstLinkpathDest("<uid>|<label>")` never resolves, so this
     // returned null — a silent non-match with no diagnostic.


### PR DESCRIPTION
## Наблюдаемое

Два PR этой сессии отгрузили исполняемую спеку, и **ни один** не нёс `@req:`-тега:

| PR | тест | req |
|---|---|---|
| #4119 | `PropertiesDefinitionValuePatch.aliasUnwrap.test.ts` | `7405c664` |
| #4120 | `EffortStatusCanon.test.ts` | `355d9379` |

Замер: `git grep -l "@req:<uid>" origin/main` → **0** для обоих (у остальных четырёх требований сессии — по 1).

## Почему сейчас тихо и почему это всё равно дефект

Оба требования в статусе `proposed`, а active-gate судит только `active` — поэтому CI зелёный. Но в момент, когда фаундер одобрит любое из них и оно станет `active`, гейт откажет **repo-wide, на каждом открытом PR**: активное требование без привязки — hard orphan.

⛤ И это ровно то, ради чего тег существует: тест без владельца — гвард, который следующий рефактор снимет при зелёном CI.

## Правка

Только заголовок `describe`, оси не тронуты.

## Гейты

| | |
|---|---|
| core `EffortStatusCanon.test.ts` | 17/17 |
| plugin `PropertiesDefinitionValuePatch.aliasUnwrap.test.ts` | 4/4 |
| `check-test-types` | 433 → 433, rc=0 |

⛔ Оба UID **резолвлены из ассетспейса требований**, а не набраны: первый черновик этого коммита выдумал хвост для `7405c664` — правдоподобный и указывающий в никуда.

https://claude.ai/code/session_01RLVkQZvShweokvfZUCn7wE
