### PR TITLE
feat(cli): the guard names only commands that resolve in the live vault

### DIFF
--- a/packages/cli/src/commands/propertyMutationShared.ts
+++ b/packages/cli/src/commands/propertyMutationShared.ts
@@ -154,6 +154,54 @@ export const GUARDED_ROUTES: Record<string, GuardedRoute> = {
 };
 
 /** Render a route as the sentence the guard surfaces to the user. */
+/**
+ * The route for a guarded property, or `undefined` when the property is not
+ * guarded. Own-key lookup, so `toString` / `constructor` never match an
+ * inherited `Object.prototype` key (#3795 review M2) — same guard as
+ * {@link guardedReason}, which this complements: that one returns the rendered
+ * SENTENCE, this one the structured route the live-vault filter needs.
+ */
+export function guardedRouteFor(property: string): GuardedRoute | undefined {
+  return Object.prototype.hasOwnProperty.call(GUARDED_ROUTES, property)
+    ? GUARDED_ROUTES[property]
+    : undefined;
+}
+
+/**
+ * {@link renderGuardedRoute}, but naming only commands that RESOLVE in the
+ * user's vault (req `72419d3c`).
+ *
+ * ⛔ `known` EMPTY means "nothing mounted", NOT "nothing resolves": the route is
+ * rendered unfiltered, exactly as today. A partial or degenerate mount must
+ * never turn a correct refusal into a false one — the same must-have the
+ * sibling property-name validator carries.
+ *
+ * When SOME names resolve, only those are offered: a name `apply` cannot
+ * resolve is not a path, and printing it as one is what left the user with no
+ * sanctioned route at all.
+ *
+ * When NONE do (non-empty registry, no overlap), the sentence says so rather
+ * than presenting the list as an instruction. The wording deliberately avoids
+ * the classifier's trigger substrings (`transaction`, `concurrent`, `modified`,
+ * `not found`, `Invalid`) so the exit code a scripted consumer branches on is
+ * unchanged — the axis in `guardedRoutes.test.ts` locks that for every route.
+ */
+export function renderGuardedRouteResolved(
+  route: GuardedRoute,
+  known: ReadonlySet<string>,
+): string {
+  if (known.size === 0) return renderGuardedRoute(route);
+
+  const resolving = route.commands.filter((c) => known.has(c));
+  if (resolving.length === 0) {
+    return (
+      `apply ${route.commands.join("|")} <path>  ` +
+      `(⛔ none of these resolve in this vault — the owning assetspace looks unmounted)`
+    );
+  }
+  return renderGuardedRoute({ ...route, commands: resolving });
+}
+
 export function renderGuardedRoute(route: GuardedRoute): string {
   const invocation = `apply ${route.commands.join("|")} <path>`;
   const withArg = route.argSuffix

--- a/packages/cli/src/commands/remove-property.ts
+++ b/packages/cli/src/commands/remove-property.ts
@@ -11,13 +11,15 @@ import {
 import {
   DEFAULT_TIMEZONE,
   UPDATED_AT_KEY,
-  GUARDED_PROPERTIES,
+  guardedRouteFor,
+  renderGuardedRouteResolved,
   renderGuardRefusal,
   IMMUTABLE_PROPERTIES,
   canonicalYamlKey,
   guardedReason,
   stampTimestamp,
 } from "./propertyMutationShared.js";
+import { CommandNameRegistry } from "../services/CommandNameRegistry.js";
 
 interface RemovePropertyOptions {
   vault: string;
@@ -184,14 +186,19 @@ export function removePropertyCommand(): Command {
             `Refusing to remove "${property}" — ${immutableReason}.`,
           );
         }
-        const guardedCommand = guardedReason(GUARDED_PROPERTIES, property);
-        if (guardedCommand !== undefined) {
+        // Render the route against the LIVE vault: a listed cliName that `apply`
+        // cannot resolve is not a sanctioned path, and offering it as one is how
+        // three phantoms left users with no path at all (req 72419d3c, issue #4103).
+        // An empty registry fails OPEN — see renderGuardedRouteResolved.
+        const guardedRoute = guardedRouteFor(property);
+        if (guardedRoute !== undefined) {
+          const known = await new CommandNameRegistry(vaultPath).collect();
           throw new Error(
             renderGuardRefusal(
               "remove",
               "remove-property",
               property,
-              guardedCommand,
+              renderGuardedRouteResolved(guardedRoute, known),
             ),
           );
         }

--- a/packages/cli/src/commands/set-property.ts
+++ b/packages/cli/src/commands/set-property.ts
@@ -18,13 +18,15 @@ import { resolveCoLocationFolder } from "../executors/folderRepairHelpers.js";
 import {
   DEFAULT_TIMEZONE,
   UPDATED_AT_KEY,
-  GUARDED_PROPERTIES,
+  guardedRouteFor,
+  renderGuardedRouteResolved,
   renderGuardRefusal,
   IMMUTABLE_PROPERTIES,
   canonicalYamlKey,
   guardedReason,
   stampTimestamp,
 } from "./propertyMutationShared.js";
+import { CommandNameRegistry } from "../services/CommandNameRegistry.js";
 
 const ISDEFINEDBY_KEY = "exo__Asset_isDefinedBy";
 
@@ -272,10 +274,20 @@ export function setPropertyCommand(): Command {
             `Refusing to set "${property}" — ${immutableReason}.`,
           );
         }
-        const guardedCommand = guardedReason(GUARDED_PROPERTIES, property);
-        if (guardedCommand !== undefined) {
+        // Render the route against the LIVE vault: a listed cliName that `apply`
+        // cannot resolve is not a sanctioned path, and offering it as one is how
+        // three phantoms left users with no path at all (req 72419d3c, issue #4103).
+        // An empty registry fails OPEN — see renderGuardedRouteResolved.
+        const guardedRoute = guardedRouteFor(property);
+        if (guardedRoute !== undefined) {
+          const known = await new CommandNameRegistry(vaultPath).collect();
           throw new Error(
-            renderGuardRefusal("set", "set-property", property, guardedCommand),
+            renderGuardRefusal(
+              "set",
+              "set-property",
+              property,
+              renderGuardedRouteResolved(guardedRoute, known),
+            ),
           );
         }
 

--- a/packages/cli/src/services/CommandNameRegistry.ts
+++ b/packages/cli/src/services/CommandNameRegistry.ts
@@ -1,0 +1,103 @@
+/**
+ * @file The set of `exocmd__Command_cliName`s that actually resolve in a vault.
+ *
+ * `GUARDED_ROUTES` tells a user which dedicated command owns the property they
+ * tried to mutate directly. Nothing checked that a listed name EXISTS — which is
+ * how three phantoms (`remove-start-timestamp`, `remove-end-timestamp`,
+ * `archive-completed`) survived for months: the guard refused the mutation and
+ * then pointed at a command `apply` cannot resolve, leaving no sanctioned path
+ * at all.
+ *
+ * ⛔ The check cannot live in CI. The registry is SPLIT across assetspaces and
+ * exocortex pins only `exoas-exocmd`; against the pinned SHA a "every listed
+ * name resolves" gate would today PASS the phantom and FAIL five correct names
+ * (`archive`, `un-archive`, `re-open`, `park-waiting`, `rollback-to-backlog`).
+ * The live vault is available exactly where the refusal happens, so that is
+ * where the resolution belongs — the same reasoning, and the same one-pass
+ * scan, as {@link PropertyNameValidator} (reqs `40a9a81b` / `c616a289`).
+ *
+ * ⛤ Deliberately NOT a SPARQL query. The collector runs inside a refusal path
+ * that already has a plain vault path and no store; a line scan over the same
+ * files the sibling validator already walks costs the same and adds no engine
+ * dependency to a code path whose only job is to render a sentence.
+ *
+ * ⛔ An EMPTY registry fails OPEN — a partial or degenerate mount (no `exocmd`
+ * assetspace) must never turn a correct refusal into a false one, nor strip a
+ * route down to nothing. Same must-have as the sibling validator.
+ *
+ * req 72419d3c-b425-4a0e-ad42-346853efc9cf
+ */
+
+/** `exocmd__Command_cliName: move-to-backlog` — quoted or bare, one per line. */
+const CLI_NAME_LINE = /^\s*exocmd__Command_cliName:\s*(.+?)\s*$/gm;
+
+/** Strips wrapping quotes a YAML printer may have added. */
+function unquote(raw: string): string {
+  const t = raw.trim();
+  if (
+    t.length >= 2 &&
+    (t[0] === '"' || t[0] === "'") &&
+    t[t.length - 1] === t[0]
+  ) {
+    return t.slice(1, -1).trim();
+  }
+  return t;
+}
+
+/**
+ * Collects every `cliName` declared by the mounted assetspaces of one vault.
+ *
+ * Cached per instance: a single refusal renders one route, but both mutation
+ * primitives construct this once per invocation and a caller may render more
+ * than one sentence.
+ */
+export class CommandNameRegistry {
+  private cache: Set<string> | undefined;
+
+  constructor(private readonly vaultPath: string) {}
+
+  /**
+   * @returns the declared cliNames; EMPTY means "nothing mounted", which every
+   *   caller must treat as fail-open rather than as "nothing resolves".
+   */
+  async collect(): Promise<ReadonlySet<string>> {
+    if (this.cache) return this.cache;
+
+    // eslint-disable-next-line import/no-nodejs-modules
+    const { readdir, readFile } = await import("fs/promises");
+
+    const names = new Set<string>();
+
+    const walk = async (dir: string): Promise<void> => {
+      let entries: import("fs").Dirent[];
+      try {
+        entries = await readdir(dir, { withFileTypes: true });
+      } catch {
+        return; // unreadable subtree — same fail-open direction as the sibling
+      }
+      for (const entry of entries) {
+        const full = `${dir}/${entry.name}`;
+        if (entry.isDirectory()) {
+          if (entry.name === ".git" || entry.name === "node_modules") continue;
+          await walk(full);
+        } else if (entry.isFile() && entry.name.endsWith(".md")) {
+          let content: string;
+          try {
+            content = await readFile(full, "utf-8");
+          } catch {
+            continue;
+          }
+          for (const m of content.matchAll(CLI_NAME_LINE)) {
+            const name = unquote(m[1]);
+            if (name) names.add(name);
+          }
+        }
+      }
+    };
+
+    await walk(this.vaultPath);
+
+    this.cache = names;
+    return names;
+  }
+}

--- a/packages/cli/tests/integration/guarded-route-resolution.integration.test.ts
+++ b/packages/cli/tests/integration/guarded-route-resolution.integration.test.ts
@@ -1,0 +1,161 @@
+/**
+ * @file The refusal SENTENCE is rendered against the live vault — wiring axis.
+ *
+ * The unit axes next door (`guardedRouteResolution.test.ts`) lock what
+ * `renderGuardedRouteResolved` DOES. They cannot lock that the two mutation
+ * primitives actually CALL it: revert the wiring in `set-property.ts` back to
+ * the unfiltered `GUARDED_PROPERTIES` string and every one of them stays green,
+ * because they never go through the command.
+ *
+ * ⛤ So this file drives the real command against a real temp vault, and asserts
+ * on what a user would read. Same shape as the sibling name-validation
+ * integration test, and for the same reason: the guarantee is about the sentence
+ * the command prints, not about a helper's return value.
+ *
+ * req 72419d3c-b425-4a0e-ad42-346853efc9cf · issue #4103
+ */
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { jest } from "@jest/globals";
+
+const { setPropertyCommand } =
+  await import("../../src/commands/set-property.js");
+const { removePropertyCommand } =
+  await import("../../src/commands/remove-property.js");
+
+// `@req:${REQ}` in an it() title is not statically resolvable, so the binding is
+// declared as a literal here too (archgate REQ-001, same as the sibling file).
+const REQ = "72419d3c-b425-4a0e-ad42-346853efc9cf";
+
+const TARGET_REL = "assetspaces/kitelev/exoas-my/my/target.md";
+
+/** A vault holding ONE real command asset — `mark-done` resolves, the rest do not. */
+function buildVault(vault: string, withCommands: boolean): void {
+  const target = path.join(vault, TARGET_REL);
+  fs.mkdirSync(path.dirname(target), { recursive: true });
+  fs.writeFileSync(
+    target,
+    [
+      "---",
+      "exo__Asset_uid: cafe0000-0000-0000-0000-000000000001",
+      "exo__Asset_label: target",
+      'ems__Effort_status: "[[753a44d5-846c-4b82-9196-4fd9a4d48777]]"',
+      "---",
+      "",
+    ].join("\n"),
+    "utf-8",
+  );
+  if (!withCommands) return;
+
+  const cmdDir = path.join(vault, "assetspaces/kitelev/exoas-exocmd/exocmd");
+  fs.mkdirSync(cmdDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(cmdDir, "mark-done.md"),
+    ["---", "exocmd__Command_cliName: mark-done", "---", ""].join("\n"),
+    "utf-8",
+  );
+}
+
+describe("guarded-route resolution reaches the user @req:72419d3c-b425-4a0e-ad42-346853efc9cf", () => {
+  let vault: string;
+  let errorSpy: ReturnType<typeof jest.spyOn>;
+  let exitSpy: ReturnType<typeof jest.spyOn>;
+  let logSpy: ReturnType<typeof jest.spyOn>;
+  let stdoutSpy: ReturnType<typeof jest.spyOn>;
+  let stderrSpy: ReturnType<typeof jest.spyOn>;
+
+  const spies = (): void => {
+    exitSpy = jest
+      .spyOn(process, "exit")
+      .mockImplementation((() => undefined as never) as never);
+    stdoutSpy = jest
+      .spyOn(process.stdout, "write")
+      .mockImplementation((() => true) as never);
+    stderrSpy = jest
+      .spyOn(process.stderr, "write")
+      .mockImplementation((() => true) as never);
+    logSpy = jest.spyOn(console, "log").mockImplementation(() => {});
+    errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+  };
+
+  afterEach(() => {
+    exitSpy.mockRestore();
+    stdoutSpy.mockRestore();
+    stderrSpy.mockRestore();
+    logSpy.mockRestore();
+    errorSpy.mockRestore();
+    fs.rmSync(vault, { recursive: true, force: true });
+  });
+
+  const stderrText = (): string => errorSpy.mock.calls.flat().join("\n");
+
+  it(`set-property names ONLY the resolving command @req:${REQ}`, async () => {
+    vault = fs.mkdtempSync(path.join(os.tmpdir(), "cli-guardres-"));
+    buildVault(vault, true);
+    spies();
+
+    await setPropertyCommand().parseAsync(
+      [
+        TARGET_REL,
+        "--property",
+        "ems__Effort_status",
+        "--value",
+        "x",
+        "--vault",
+        vault,
+      ],
+      { from: "user" },
+    );
+
+    const out = stderrText();
+    expect(out).toContain("dedicated guarded command");
+    expect(out).toContain("mark-done");
+    // These are real names in the routing table but absent from THIS vault, so
+    // offering them would be the very defect: a path `apply` cannot resolve.
+    expect(out).not.toContain("move-to-backlog");
+    expect(out).not.toContain("start-effort");
+  });
+
+  it(`remove-property is wired the same way @req:${REQ}`, async () => {
+    vault = fs.mkdtempSync(path.join(os.tmpdir(), "cli-guardres-"));
+    buildVault(vault, true);
+    spies();
+
+    await removePropertyCommand().parseAsync(
+      [TARGET_REL, "--property", "ems__Effort_status", "--vault", vault],
+      { from: "user" },
+    );
+
+    const out = stderrText();
+    expect(out).toContain("mark-done");
+    expect(out).not.toContain("move-to-backlog");
+  });
+
+  it(`⛔ an UNMOUNTED registry keeps today's full sentence — fail-open @req:${REQ}`, async () => {
+    vault = fs.mkdtempSync(path.join(os.tmpdir(), "cli-guardres-"));
+    buildVault(vault, false); // no exocmd assetspace at all
+    spies();
+
+    await setPropertyCommand().parseAsync(
+      [
+        TARGET_REL,
+        "--property",
+        "ems__Effort_status",
+        "--value",
+        "x",
+        "--vault",
+        vault,
+      ],
+      { from: "user" },
+    );
+
+    const out = stderrText();
+    expect(out).toContain("dedicated guarded command");
+    // Every listed name is still offered — a partial mount must not turn a
+    // correct refusal into a false or empty one.
+    expect(out).toContain("mark-done");
+    expect(out).toContain("move-to-backlog");
+    expect(out).toContain("start-effort");
+  });
+});

--- a/packages/cli/tests/unit/guardedRouteResolution.test.ts
+++ b/packages/cli/tests/unit/guardedRouteResolution.test.ts
@@ -1,0 +1,139 @@
+/**
+ * @req:72419d3c-b425-4a0e-ad42-346853efc9cf — the guard names only commands that
+ * resolve in the live vault.
+ *
+ * The sibling file (`guardedRoutes.test.ts`) locks that the SENTENCE cannot name
+ * anything the machine-readable array does not list, and says in its own header
+ * that existence "needs the live vault — that is a separate follow-up". This is
+ * that follow-up.
+ *
+ * ⛔ Measured 2026-08-20 before writing a line: all 25 listed cliNames resolve
+ * today (76 `exocmd__Command_cliName` across vault-my ∪ vault-exodev), and a
+ * mutant adding `phantom-command-that-does-not-exist` to the table left
+ * `guardedRoutes.test.ts` **12/12 green**. So the property is TRUE and UNLOCKED —
+ * these axes are its spec, not a repair of a visible break.
+ */
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import {
+  GUARDED_ROUTES,
+  guardedRouteFor,
+  renderGuardedRoute,
+  renderGuardedRouteResolved,
+} from "../../src/commands/propertyMutationShared";
+import { CommandNameRegistry } from "../../src/services/CommandNameRegistry";
+
+const ROUTE = { commands: ["mark-done", "phantom-cmd", "start-effort"] };
+
+describe("@req:72419d3c-b425-4a0e-ad42-346853efc9cf guarded route resolution", () => {
+  describe("renderGuardedRouteResolved", () => {
+    it("names only the commands present in the registry", () => {
+      const out = renderGuardedRouteResolved(
+        ROUTE,
+        new Set(["mark-done", "start-effort", "unrelated"]),
+      );
+      expect(out).toContain("mark-done");
+      expect(out).toContain("start-effort");
+      expect(out).not.toContain("phantom-cmd");
+    });
+
+    it("⛔ fails OPEN on an EMPTY registry — byte-identical to today", () => {
+      // A degenerate / partial mount must never turn a correct refusal into a
+      // false one, nor strip the route to nothing. This is the control that
+      // keeps every minimal fixture working.
+      expect(renderGuardedRouteResolved(ROUTE, new Set())).toBe(
+        renderGuardedRoute(ROUTE),
+      );
+    });
+
+    it("says so when NONE of a route's commands resolve, instead of instructing", () => {
+      const out = renderGuardedRouteResolved(
+        ROUTE,
+        new Set(["something-else"]),
+      );
+      // The names are still shown — the user may need them to diagnose the mount —
+      // but the sentence no longer presents them as a path that works.
+      expect(out).toContain("none of these resolve in this vault");
+    });
+
+    it("does not collide with the exit-code classifier for ANY real route", () => {
+      // Same guarantee the sibling axis makes for the unfiltered sentence: the
+      // classifier picks the process exit code by SUBSTRING, so a word chosen for
+      // readability can silently change what a scripted consumer branches on.
+      const triggers = [
+        "transaction",
+        "concurrent",
+        "modified",
+        "not found",
+        "Invalid",
+      ];
+      for (const route of Object.values(GUARDED_ROUTES)) {
+        for (const known of [new Set<string>(), new Set(["nothing-matches"])]) {
+          const out = renderGuardedRouteResolved(route, known);
+          for (const t of triggers) expect(out).not.toContain(t);
+        }
+      }
+    });
+  });
+
+  describe("guardedRouteFor", () => {
+    it("returns the route for a guarded property", () => {
+      expect(guardedRouteFor("ems__Effort_status")?.commands).toContain(
+        "mark-done",
+      );
+    });
+
+    it("does not match an inherited Object.prototype key", () => {
+      // Same own-key guard as `guardedReason` (#3795 review M2): a user-supplied
+      // property name like `toString` must not resolve to a route.
+      expect(guardedRouteFor("toString")).toBeUndefined();
+      expect(guardedRouteFor("constructor")).toBeUndefined();
+    });
+  });
+
+  describe("CommandNameRegistry", () => {
+    let vault: string;
+
+    beforeEach(() => {
+      vault = mkdtempSync(join(tmpdir(), "cmdreg-"));
+    });
+    afterEach(() => rmSync(vault, { recursive: true, force: true }));
+
+    const write = (rel: string, body: string): void => {
+      const full = join(vault, rel);
+      mkdirSync(join(full, ".."), { recursive: true });
+      writeFileSync(full, body, "utf-8");
+    };
+
+    it("collects cliNames, quoted or bare, across nested assetspaces", async () => {
+      write(
+        "assetspaces/a/exocmd/one.md",
+        "---\nexocmd__Command_cliName: mark-done\n---\n",
+      );
+      write(
+        "assetspaces/b/deeper/two.md",
+        '---\nexocmd__Command_cliName: "start-effort"\n---\n',
+      );
+      const names = await new CommandNameRegistry(vault).collect();
+      expect([...names].sort()).toEqual(["mark-done", "start-effort"]);
+    });
+
+    it("returns an EMPTY set for a vault with no commands — the fail-open input", async () => {
+      write("assetspaces/a/plain.md", "---\nexo__Asset_label: nothing\n---\n");
+      expect((await new CommandNameRegistry(vault).collect()).size).toBe(0);
+    });
+
+    it("end-to-end: a phantom in the route is dropped once the vault is read", async () => {
+      write(
+        "assetspaces/a/one.md",
+        "---\nexocmd__Command_cliName: mark-done\n---\n",
+      );
+      const known = await new CommandNameRegistry(vault).collect();
+      const out = renderGuardedRouteResolved(ROUTE, known);
+      expect(out).toContain("mark-done");
+      expect(out).not.toContain("phantom-cmd");
+      expect(out).not.toContain("start-effort");
+    });
+  });
+});


### PR DESCRIPTION
## Что не так было

`GUARDED_ROUTES` сообщает, какая выделенная команда владеет свойством, которое пользователь попытался изменить напрямую. **Ничто не проверяло, что перечисленное имя существует** — так три фантома (`remove-start-timestamp`, `remove-end-timestamp`, `archive-completed`) прожили месяцами: гвард отказывал в мутации и отправлял к команде, которую `apply` разрешить не может. Санкционированного пути не оставалось **вовсе**.

## ⛤ Замер ДО написания строки кода — и он определил маршрут

| | |
|---|---|
| живых `exocmd__Command_cliName` (vault-my ∪ vault-exodev) | **76** |
| имён в `GUARDED_ROUTES` | **25** |
| **фантомов сегодня** | **0** |

То есть половина A (данные) уже починена. Но мутант, вписывающий `phantom-command-that-does-not-exist` в таблицу, оставляет `guardedRoutes.test.ts` **12/12 зелёным** ⇒ свойство **истинно и не залочено ничем**.

По дискриминатору `/feature-sdd` Step 0 (убей охраняемый механизм на копии `origin/main` — краснеет ли что-нибудь? **ноль**) это **новый req**, а не bug-fix: спека и есть поставка. req `72419d3c`, `proposed`.

## ⛔ Почему проверка не может жить в CI — и почему наивная была бы ИНВЕРТИРОВАНА

Реестр расщеплён, exocortex пинит только `exoas-exocmd`. Против запиненного SHA гейт «каждое имя резолвится» сегодня **пропустил бы фантом и завалил пять верных имён** (`archive`, `un-archive`, `re-open`, `park-waiting`, `rollback-to-backlog`).

Живой vault доступен ровно там, где происходит отказ: обе команды уже принимают `--vault` и уже его сканируют. Та же форма и тот же профиль стоимости, что у `PropertyNameValidator` (reqs `40a9a81b` / `c616a289`).

## Решение

- `CommandNameRegistry` — однопроходный обход по образцу соседа, кэш на экземпляр;
- `renderGuardedRouteResolved(route, known)` — называет только резолвящиеся; если не резолвится **ни одно** — говорит об этом, а не выдаёт список за инструкцию;
- ⛔ **пустой реестр — fail-open**, байт-в-байт сегодняшнее предложение. Частичный или вырожденный монтаж не должен превращать верный отказ в ложный.

## ⛤ Проводка получает СВОЮ ось — девять юнит-осей её запереть не могут

Юниты запирают, что `renderGuardedRouteResolved` **делает**. Что примитивы её **зовут** — не запирают: откат call-site `set-property` к нефильтрованному оставляет **все девять зелёными**. Поэтому интеграционные оси гоняют настоящие команды против настоящего temp-vault и ассертят на то, что читает пользователь.

## Revert-verify — четыре мутанта, каждый на свою ось

| мутант | краснеет |
|---|---|
| снят фильтр (`filter` → `slice`) | 3 оси резолюции |
| снят fail-open | ровно ось «пустой реестр» |
| снят own-key guard | ровно ось `Object.prototype` |
| **откат проводки** в `set-property` | ровно интеграционная ось set-property; **все 9 юнит-осей зелены** |

Контроль: 9/9 юнит + 3/3 интеграционных; соседний `guardedRoutes.test.ts` 12/12 без правок.

## Гейты

| | |
|---|---|
| cli | `10 failed / 1972 passed` — те же 10 (`sparql-exo003`), измерено на родителе: `10 failed, 10 total` |
| `check-cli-types` | 13 → 13, rc=0 |
| `check-test-types` | 433 → 433, rc=0 |
| `check-test-antipatterns` · `validate-shard-assignments` · `check-coverage-monotonic` | зелёные |

⚠ Локальный cli-jest требует `NODE_OPTIONS=--experimental-vm-modules` — без него 80 сьютов «не парсятся», что читается как провал. Первый прогон дал именно это; контроль соседним сьютом показал, что дело в способе запуска, а не в коде.

Closes #4103

https://claude.ai/code/session_01RLVkQZvShweokvfZUCn7wE
