### PR TITLE
feat(core): derive the status dropdown from the canon too

### DIFF
--- a/packages/core/src/domain/constants/EffortStatusOptions.ts
+++ b/packages/core/src/domain/constants/EffortStatusOptions.ts
@@ -19,6 +19,8 @@
  * for fixture factories.
  */
 
+import { EFFORT_STATUS_UID } from "./EffortStatusCanon";
+
 /**
  * Effort status values with label and wikilink, for UI dropdowns and selects.
  *
@@ -31,15 +33,31 @@
  * mirror the shared ontology (req `fcbde537-f09a-410e-8bee-d3d607a70302`):
  * `Analysis` / `To Do` were removed when their TBox instances were deleted
  * (`exoas-public@c35a660d`), `Waiting` added in their place.
+ *
+ * ⛤ DERIVED from {@link EFFORT_STATUS_UID} (issue #4121), not authored here.
+ * That deletion had to be hand-applied to FOUR holders of the same vocabulary;
+ * #4056 folded two of them into the canon and named this one as the remaining
+ * write-side list. Deriving closes it: a status added or removed in one place
+ * cannot leave this dropdown behind.
+ *
+ * ⛔ The values stay SYMBOLIC (`[[ems__EffortStatusDoing]]`) — deriving does NOT
+ * migrate them to UUID-canon. The canon is keyed BY symbol, so the mapping only
+ * needs its keys; the coordinated `NoteToRDFConverter` + starter-kit ASK
+ * migration the file header defers is untouched.
+ *
+ * ⚠ The label is the symbol's tail (`ems__EffortStatusBacklog` → `Backlog`),
+ * which reproduces every label this table carried by hand — measured, not
+ * assumed. A future status whose human label is NOT its tail (a space, as the
+ * deleted `To Do` had) would need its own mapping rather than this one.
  */
 export const EFFORT_STATUS_OPTIONS: ReadonlyArray<{
   readonly value: string;
   readonly label: string;
-}> = [
-  { value: "[[ems__EffortStatusDraft]]", label: "Draft" },
-  { value: "[[ems__EffortStatusBacklog]]", label: "Backlog" },
-  { value: "[[ems__EffortStatusDoing]]", label: "Doing" },
-  { value: "[[ems__EffortStatusWaiting]]", label: "Waiting" },
-  { value: "[[ems__EffortStatusDone]]", label: "Done" },
-  { value: "[[ems__EffortStatusTrashed]]", label: "Trashed" },
-] as const;
+}> = Object.freeze(
+  Object.keys(EFFORT_STATUS_UID).map((symbol) =>
+    Object.freeze({
+      value: `[[${symbol}]]`,
+      label: symbol.replace(/^ems__EffortStatus/, ""),
+    }),
+  ),
+);

--- a/packages/core/tests/domain/constants/EffortStatusOptions.derivation.test.ts
+++ b/packages/core/tests/domain/constants/EffortStatusOptions.derivation.test.ts
@@ -1,0 +1,48 @@
+/**
+ * @req:355d9379-ed7b-4241-9ce7-0af955653127 — the dropdown list is DERIVED from
+ * the canon, not restated beside it (issue #4121).
+ *
+ * The neighbouring `EffortStatusOptions.test.ts` locks the CONTENT (six entries,
+ * `Draft` / `Doing` / `Done` present). It cannot lock the DERIVATION: restate the
+ * six literals and every one of its axes stays green, because the content is
+ * identical — which is exactly how this table drifted before. When `ToDo` and
+ * `Analysis` were deleted from `exoas-public` (2026-08-13) the same six UIDs had
+ * to be hand-edited in FOUR places; #4056 folded two into the canon and left this
+ * one named as the remainder.
+ *
+ * ⛔ Content axes cannot substitute for these. `toHaveLength(6)` reds when the
+ * canon grows — and the natural repair is to bump the 6, which restores green
+ * WITHOUT restoring the link. Only an axis that reads the canon can tell the two
+ * repairs apart.
+ */
+import { EFFORT_STATUS_UID } from "../../../src/domain/constants/EffortStatusCanon";
+import { EFFORT_STATUS_OPTIONS } from "../../../src/domain/constants";
+
+describe("@req:355d9379-ed7b-4241-9ce7-0af955653127 EFFORT_STATUS_OPTIONS derives from the canon", () => {
+  it("carries exactly the canon's symbols, in the canon's order", () => {
+    expect(EFFORT_STATUS_OPTIONS.map((o) => o.value)).toEqual(
+      Object.keys(EFFORT_STATUS_UID).map((s) => `[[${s}]]`),
+    );
+  });
+
+  it("still offers a label for every canon status", () => {
+    // The tail-of-symbol mapping must cover the whole canon, not most of it —
+    // a status whose label came out empty would render as a blank dropdown row.
+    for (const symbol of Object.keys(EFFORT_STATUS_UID)) {
+      const entry = EFFORT_STATUS_OPTIONS.find(
+        (o) => o.value === `[[${symbol}]]`,
+      );
+      expect(entry).toBeDefined();
+      expect(entry?.label.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("⛔ keeps the SYMBOLIC value form — deriving is not the UUID migration", () => {
+    // The file header defers UUID-canon values to a coordinated
+    // NoteToRDFConverter + starter-kit ASK migration. Deriving from a canon that
+    // is KEYED by symbol must not smuggle that migration in.
+    for (const o of EFFORT_STATUS_OPTIONS) {
+      expect(o.value).toMatch(/^\[\[ems__EffortStatus[A-Za-z]+\]\]$/);
+    }
+  });
+});


### PR DESCRIPTION
## Что закрывает

#4056 свёл **два** из четырёх держателей словаря `ems__Effort_status` к одному канону и назвал этот — `EFFORT_STATUS_OPTIONS`, список опций на запись за дропдауном редактора свойств — как остаток. Это он.

При удалении `ToDo` и `Analysis` из `exoas-public` (2026-08-13) одни и те же шесть UID правились руками **в четырёх местах**. Два больше дрейфовать не могут; это был третий.

## ⛔ Значения остаются SYMBOLIC — вывод это НЕ UUID-миграция

Шапка файла откладывает перевод значений в UUID-канон до **скоординированной** миграции `NoteToRDFConverter` + starter-kit ASK. Вывод её не трогает: канон ключуется **по символу**, поэтому отображению нужны только его ключи.

⛤ Это залочено отдельной осью — самая лёгкая ошибка здесь как раз «заодно мигрировать», пока «просто вывожу».

## ⛤ Почему существующие content-оси эту связь запереть не могут

Соседний `EffortStatusOptions.test.ts` проверяет **содержимое** (шесть записей, `Draft`/`Doing`/`Done` на месте). Восстанови шесть литералов — **все его оси зелены**, содержимое-то идентично. Ровно так таблица и дрейфовала.

⛔ Хуже: `toHaveLength(6)` **краснеет**, когда канон растёт, — и естественная починка «поправить 6» возвращает зелёный **не восстанавливая связь**. Отличить две починки может только ось, читающая канон.

## Revert-verify

Мутант: восстановить литеральный массив **и** вырастить канон на `Probe`.

```
✕ carries exactly the canon's symbols, in the canon's order
✕ still offers a label for every canon status
✓ ⛔ keeps the SYMBOLIC value form   ← ось про форму, к связи не относится → зелена, как и должна
```

Контроль: **64/64** (`tests/domain/constants` + `tests/integration/status-model`) — **без единой правки существующих осей**, то есть выдача не изменилась.

## Замер, из которого выведено отображение

`label` = хвост символа (`ems__EffortStatusBacklog` → `Backlog`). Порядок ключей канона (`Draft → Backlog → Doing → Waiting → Done → Trashed`) **совпадает** с прежним порядком опций, и хвост воспроизводит **каждую** метку, которую таблица несла руками.

⚠ Будущий статус, чья человеческая метка **не** является хвостом (пробел, как у удалённого `To Do`), потребует собственного отображения — это сказано в докстринге, а не оставлено следующему автору на выяснение.

## Гейты

| | |
|---|---|
| core | `9 failed / 8631 passed` — та же пред-существующая тройка `dynamic-commands` |
| plugin `property-editor` | 128/128 |
| `check-cli-types` | 13 → 13, rc=0 |
| `check-test-types` | 433 → 433, rc=0 |
| `check-test-antipatterns` | зелёный |

⛤ Остаётся **четвёртый** держатель — `FALLBACK_EFFORT_STATUS_VALUES` в плагине (**#4122**): его вывод упирается в архитектурную границу (ct-граф + barrel + tsyringe), это своя единица работы.

req `355d9379` (`proposed`)

Closes #4121

https://claude.ai/code/session_01RLVkQZvShweokvfZUCn7wE
