### PR TITLE
chore(supply-chain): npm provenance + OCI-лейблы ci-образа

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -10,6 +10,7 @@ on:
 
 permissions:
   contents: write
+  id-token: write # npm provenance (OIDC) — publishConfig.provenance в packages/cli/package.json
 
 jobs:
   auto-release:

--- a/.github/workflows/npm-publish-cli.yml
+++ b/.github/workflows/npm-publish-cli.yml
@@ -12,6 +12,7 @@ on:
 
 permissions:
   contents: read
+  id-token: write # npm provenance (OIDC) — publishConfig.provenance в packages/cli/package.json
 
 jobs:
   publish:

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -34,6 +34,10 @@
   ],
   "author": "A. Kitelev",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/kitelev/exocortex.git",

--- a/packages/obsidian-plugin/Dockerfile.ci
+++ b/packages/obsidian-plugin/Dockerfile.ci
@@ -9,6 +9,13 @@
 # churn (rare), so steady-state cache-hit rate is high.
 FROM mcr.microsoft.com/playwright:v1.55.1-jammy
 
+# OCI-лейблы: закрепляют линк пакет→репо ЯВНО. Авто-линк ghcr работает только
+# пока пуш идёт GITHUB_TOKEN'ом из Actions этого репо; source-лейбл переживает
+# смену способа пуша и рендерится как «Source» на странице пакета.
+LABEL org.opencontainers.image.source="https://github.com/kitelev/exocortex" \
+      org.opencontainers.image.description="Pre-built CI base image for Exocortex e2e: Playwright + Obsidian + xvfb + node_modules" \
+      org.opencontainers.image.licenses="MIT"
+
 # xvfb + window manager + Obsidian runtime deps (matches Dockerfile.e2e
 # Stage 1 verbatim so the two image layers stay binary-compatible).
 RUN apt-get update && apt-get install -y \


### PR DESCRIPTION
Closes #4004

Две находки supply-chain-аудита, обе аддитивные (13 строк, 4 файла, ноль изменений поведения продукта).

## A — npm provenance

⛤ **Один источник вместо двух флагов.** Issue предлагал `--provenance` в обеих publish-командах ИЛИ `publishConfig`. Взял `publishConfig.provenance: true` — потому что два call-site это **два перечисления**, которые расходятся молча, а одно поле в манифесте действует на **все** publish-пути, включая будущие.

Плюс инверсия полярности: provenance теперь включён **по умолчанию**, забыть его нельзя, а забытый `id-token` падает **громко** (npm отказывается генерировать бандл без OIDC), а не тихо публикует без подписи.

`id-token: write` — в top-level `permissions` обоих workflow. В каждом файле **ровно один job** (проверено), поэтому top-level ничего лишнего не расширяет и, в отличие от job-level, не **заменяет** существующие права целиком.

### Механизм проверен ЧТЕНИЕМ, а не «npm это поддерживает»

⛔ Сперва пробовал исполнением — **проба оказалась вакуумной**: `npm publish --dry-run` локально падает на auth раньше provenance, и состояние «с полем» и мутант «без поля» дали **идентичный** исход. Мутант не покраснел ⇒ проба не различала предмет, и её вывод не значил ничего.

Цепочка прочитана в npm 11.9.0 дословно:

| звено | файл:строка | что доказывает |
|---|---|---|
| `provenance: new Definition('provenance', …)` | `@npmcli/config/lib/definitions/definitions.js:1659` | ключ **известный** ⇒ `checkUnknown` на него не ругается |
| `publishConfig` → фильтр по CLI-флагам → `flatten(filteredPublishConfig, opts)` | `npm/lib/commands/publish.js:268-279` | поле реально доезжает до `opts.provenance` |
| `if (provenance === true \|\| provenanceFile)` → `generateProvenance(...)` | `libnpmpublish/lib/publish.js:132` | `opts.provenance` и есть переключатель генерации |

CLI-флаг `--provenance`, если бы его добавили, только **перекрыл** бы это поле — приоритет у CLI явный в том же коде.

## B — OCI-лейблы `Dockerfile.ci`

Было **0** вхождений `LABEL` (замерено). Добавлены `source` / `description` / `licenses`.

`source` закрепляет линк пакет→репо **явно**: авто-линк ghcr держится, только пока пуш идёт `GITHUB_TOKEN`'ом из Actions этого репо, а лейбл переживает смену способа пуша и рендерится как «Source» на странице пакета.

`MIT` резолвнут из `package.json` + файла `LICENSE`, не по памяти.

## Приёмка — разнесена по времени намеренно

| AC | когда проверяемо | почему |
|---|---|---|
| provenance-бейдж на npmjs | **следующий релиз** | publish-путь в PR-CI не исполняется вовсе |
| `id-token` + provenance в обоих workflow | сейчас, чтением YAML | ✅ `permissions` распарсены: `{contents, id-token}` в обоих |
| `docker inspect` → `image.source` | **сразу после мержа** | `ci-image.yml` триггерится на push в main с `paths:` включающими `Dockerfile.ci` |
| behaviour-preserving | этот CI | правки только в YAML/JSON/Dockerfile |

⚠ Первый AC этим PR закрыть **нельзя** — и это свойство механики, а не недоделка. Проверю на первом же релизе после мержа.

## Проверено дополнительно

- JSON и оба YAML распарсены (`json.load` / `yaml.safe_load`), а не «выглядят валидными»;
- prettier на `packages/cli/package.json` **идемпотентен** — lint-staged не переформатирует и не забандлит чужой дифф (блast-радиус замерен на копии до правки: 0 строк);
- каждая из 4 правок применена якорем с `assert n == 1`.

## Out of scope (осознанно)

Дублирование пакета в `npm.pkg.github.com` ради раздела Packages. Scoped-пакет оттуда требует `.npmrc` + токен у **каждого** потребителя ⇒ сломает `npx -y @kitelev/exocortex-cli@latest`, а он load-bearing (догфудинг, боты, скиллы, онбординг). Выгода косметическая, риск реальный.

https://claude.ai/code/session_01RLVkQZvShweokvfZUCn7wE
