### PR TITLE
ci(deps): восстановить .github/dependabot.yml (снесён побочно 2025-12-14)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,122 @@
+# Restored 2026-08-20 (issue #4128). Файл был снесён ПОБОЧНО 2025-12-14 коммитом
+# 4e42ceaa «refactor: rename packages» (512 файлов) — плановых обновлений не было
+# восемь месяцев. Security-updates при этом работали (они включаются в настройках
+# репо, а не здесь), и живые security-PR маскировали мёртвый плановый канал.
+#
+# ⛔ Три npm-записи — это НЕ дубль. В репо три package-lock.json, и корневой
+# покрывает только workspaces (`packages/*`):
+#   /               — корневой лок, весь workspace-граф
+#   /packages/core  — СВОЙ лок; он вход `npm audit` job-а npm-audit-exocortex
+#                     (ci.yml: working-directory: packages/core) и его
+#                     cache-dependency-path. Без этой записи он дрейфует от
+#                     корневого — что и наблюдалось: js-yaml 3.14.2 против 3.15.1.
+#   /docs-site      — ВНЕ workspaces корня, поэтому корневая запись его не видит.
+#
+# ⛤ `reviewers:` из прежней версии убран — ключ deprecated в схеме Dependabot.
+# CODEOWNERS в репо нет, PR и так приходят владельцу.
+version: 2
+
+updates:
+  # ── npm: корневой лок (весь workspace-граф) ────────────────────────────────
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "UTC"
+    # ⛤ 3, а не прежние 10: после восьми месяцев тишины накопленная дельта
+    # выльется залпом. Поднять, когда первая волна разгребена.
+    open-pull-requests-limit: 3
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "chore(deps)"
+    groups:
+      production-dependencies:
+        patterns: ["*"]
+        exclude-patterns:
+          - "@types/*"
+          - "eslint*"
+          - "prettier*"
+          - "jest*"
+          - "@jest/*"
+          - "typescript"
+          - "@playwright/*"
+          - "playwright*"
+        update-types: ["minor", "patch"]
+      dev-dependencies:
+        patterns:
+          - "@types/*"
+          - "eslint*"
+          - "prettier*"
+          - "jest*"
+          - "@jest/*"
+          - "typescript"
+          - "@playwright/*"
+          - "playwright*"
+        update-types: ["minor", "patch"]
+    # major-версии этих трёх ломают рантайм плагина — только вручную, с прогоном e2e
+    ignore:
+      - dependency-name: "obsidian"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "react"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "react-dom"
+        update-types: ["version-update:semver-major"]
+
+  # ── npm: packages/core (вход npm-audit гейта; дрейфовал от корневого) ──────
+  - package-ecosystem: "npm"
+    directory: "/packages/core"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "UTC"
+    open-pull-requests-limit: 2
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "chore(deps)"
+    groups:
+      core-lock:
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
+
+  # ── npm: docs-site (вне workspaces корня) ─────────────────────────────────
+  - package-ecosystem: "npm"
+    directory: "/docs-site"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "UTC"
+    open-pull-requests-limit: 2
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "chore(deps)"
+    groups:
+      docs-site:
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
+
+  # ── GitHub Actions ────────────────────────────────────────────────────────
+  # Дрейф уже наблюдаем: actions/checkout@v4 и @v6 сосуществуют в одном репо.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "UTC"
+    open-pull-requests-limit: 3
+    labels:
+      - "dependencies"
+      - "github-actions"
+    commit-message:
+      prefix: "ci(deps)"
+    groups:
+      github-actions:
+        patterns: ["*"]
+        update-types: ["minor", "patch"]


### PR DESCRIPTION
Closes #4128

Восстановление `.github/dependabot.yml`, снесённого **побочно** 2025-12-14 коммитом `4e42ceaa` («refactor: rename packages», 512 файлов). Плановых обновлений зависимостей не было **восемь месяцев**.

## Почему это не выглядело сломанным

У Dependabot **два независимых канала**, и выжил только один:

| канал | где включается | состояние |
|---|---|---|
| security updates | настройки репо (UI) | ✅ работал — PR #4028 создан ботом сегодня |
| version updates (плановые) | **этот файл** | ⛔ мертвы с 2025-12-14 |

⇒ «Dependabot же присылает PR» было верно и **не** доказывало, что конфиг цел. Живой канал маскировал мёртвый.

## Что восстановлено — и почему не дословным откатом

Репо с декабря переименовало пакеты (тем же коммитом) и обзавелось **тремя** лок-файлами вместо одного:

| запись | зачем |
|---|---|
| `npm /` | корневой лок = весь workspace-граф (`workspaces: packages/*`) |
| `npm /packages/core` | ⛤ **свой** лок, и он вход `npm audit` job-а `npm-audit-exocortex` (`working-directory: packages/core`) + его `cache-dependency-path`. Без записи дрейфует от корневого — что и наблюдалось: `js-yaml` **3.14.2** против **3.15.1** |
| `npm /docs-site` | **вне** workspaces корня ⇒ корневая запись его не видит |
| `github-actions /` | дрейф уже наблюдаем: `actions/checkout@v4` **и** `@v6` сосуществуют в репо |

⛔ Три npm-записи — **не дубль**, и в самом файле стоит комментарий об этом: иначе следующий читатель сочтёт их избыточными и уберёт.

## Отличия от прежней версии

- **лимит PR 10 → 3** на корне. После восьми месяцев тишины накопленная дельта выльется залпом; суммарно по четырём записям 10. Поднять, когда первая волна разгребена.
- **`reviewers:` убран** — ключ deprecated в схеме Dependabot. CODEOWNERS в репо нет (проверено), PR и так приходят владельцу.
- **`ignore` для major `obsidian`/`react`/`react-dom` сохранён** — все три живы (в 3 и 2 манифестах, проверено), их major ломает рантайм плагина.

## Проверено

Конфиг соответствует опубликованной схеме **dependabot-2.0** (SchemaStore): **0 нарушений**.

⛤ И валидатор предъявлен **не вакуумным** — три мутанта краснеют по одному нарушению каждый:

| мутант | нарушений |
|---|---|
| реальный конфиг | **0** |
| несуществующий `package-ecosystem` | 1 |
| убран `directory` | 1 |
| `version: 1` | 1 |

Без этого «схема зелёная» не значило бы ничего.

## ⚠ Что НЕ проверено

**Примет ли конфиг сам GitHub.** Это наблюдаемо только после мержа — по появлению version-PR в ближайший понедельник. Схема SchemaStore близка к официальной, но не тождественна ей; у GitHub могут быть свои ограничения (например на запись для лока **внутри** workspace-графа).

⇒ Приёмка третьего AC issue переносится на первый плановый прогон, и это свойство механики, а не недоделка.

https://claude.ai/code/session_01RLVkQZvShweokvfZUCn7wE
