### PR TITLE
chore(ci): снять гейт Verify npm auth из auto-release

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -276,14 +276,24 @@ jobs:
           draft: false
           prerelease: false
 
-      - name: Verify npm auth
-        if: steps.commits.outputs.has_commits == 'true' && steps.check_tag.outputs.tag_exists == 'false'
-        run: |
-          echo "🔑 Verifying npm authentication..."
-          npm whoami --registry https://registry.npmjs.org
-          echo "✅ npm auth verified"
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      # ⛔ Здесь НЕ должно быть предварительной проверки npm-аутентификации
+      # (`npm whoami`). Такой шаг стоял тут до 2026-08-20 и был снят (#4126):
+      #
+      #   1. он добавлял СВОЙ способ отказа сверх того, которым и так падает
+      #      `npm publish` — а тот падает громко и с точной ошибкой (E401/ENEEDAUTH);
+      #   2. `npm whoami` и `npm publish` требуют РАЗНЫХ прав: granular access-токен
+      #      способен публиковать и при этом отдавать 401 на whoami ⇒ гейт валил
+      #      релиз при полностью исправном токене;
+      #   3. он стоял ПОСЛЕ `Create git tag` + `Create GitHub Release`, поэтому его
+      #      срабатывание гарантированно оставляло расхождение «тег есть, пакета
+      #      нет» — ровно оно наблюдалось в #4088 (теги дошли до v16.230.0,
+      #      npm стоял на 16.224.7);
+      #   4. он делил `if:` с publish-шагами, поэтому перезапуск на теге без новых
+      #      коммитов пропускал и гейт, и публикацию — «зелёный» такого прогона
+      #      не отличим от «гейт прошёл» и ничего не доказывал.
+      #
+      # ⚠ Остаётся неатомарность: если упадёт сам `npm publish`, GitHub-релиз уже
+      # создан. Это отдельный вопрос — снятие гейта его не решает и не ухудшает.
 
       - name: Update CLI package version
         if: steps.commits.outputs.has_commits == 'true' && steps.check_tag.outputs.tag_exists == 'false'


### PR DESCRIPTION
Closes #4126

Снимаю шаг `Verify npm auth` (`npm whoami`) из `auto-release.yml`. Он не добавлял гарантии, зато добавлял **собственный способ отказа** — и именно на нём встала публикация (#4088).

## Четыре основания, каждое замерено

**1. Дублирование.** `npm publish` падает при неверном токене громко и с точной ошибкой (`E401` / `ENEEDAUTH`). Предварительная проверка не сообщает ничего, чего не сообщил бы сам publish секундой позже.

**2. Ложно-красное.** `npm whoami` и `npm publish` требуют **разных** прав: granular access-токен способен публиковать и при этом отдавать 401 на `whoami`. Тогда гейт валит релиз при **полностью исправном** токене. Тип текущего токена не зафиксирован ⇒ сегодня неизвестно, воспроизведётся ли это на следующем релизе — то есть риск не гипотетический, а неизмеренный.

**3. Расположение — и это сильнейшее.** Порядок шагов (номера строк на `origin/main` до правки):

```
256  Create git tag
265  Create GitHub Release
279  Verify npm auth        ← гейт
288  Update CLI package version
300  Publish CLI to npm
```

⇒ срабатывание гейта **гарантированно** оставляло расхождение «тег есть, пакета нет». Ровно оно и наблюдалось: теги дошли до `v16.230.0`, npm стоял на `16.224.7`.

**4. Непроверяемость.** Гейт делил `if:` с publish-шагами:

```yaml
if: steps.commits.outputs.has_commits == 'true' && steps.check_tag.outputs.tag_exists == 'false'
```

⇒ перезапуск на теге без новых коммитов пропускал **и гейт, и публикацию**, а «зелёный» такого прогона **неотличим** от «гейт прошёл». Так и был получен вакуумный зелёный на прогоне `32328466211` attempt 3. Проверить этот гейт перезапуском было невозможно **по построению**.

## Почему на месте шага остался комментарий

Без него следующий добросовестный читатель вернёт проверку обратно — «давайте убедимся в токене заранее» звучит разумно, и все четыре причины выше из YAML не видны. Причина снятия должна жить в **исполняемом носителе**, а не только в issue, который никто не откроет.

## Проверено

| | |
|---|---|
| исполняемых `whoami` в файле | **0** (3 упоминания — все внутри комментария) |
| YAML парсится | ✅ `yaml.safe_load`, 19 шагов |
| порядок соседей сохранён | `Create GitHub Release` → `Update CLI package version` → `Publish CLI to npm` |

## Что это значит для #4088

Симптом («Auto Release падает на `Verify npm auth`») **снимается** — падать больше нечему, и вопрос о типе токена перестаёт влиять на релиз.

⛔ Закрывать ли сам #4088 — не решаю: Андрей оставил его открытым осознанно. Здесь только убираю механизм, который его порождал.

## Что НЕ решается

**Неатомарность.** Если упадёт сам `npm publish`, GitHub-релиз уже создан. Снятие гейта это не чинит и не ухудшает; вопрос назван в #4126 и остаётся отдельным.

https://claude.ai/code/session_01RLVkQZvShweokvfZUCn7wE
