### PR TITLE
refactor(plugin): вывести FALLBACK_EFFORT_STATUS_VALUES из канона статусов

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -13,6 +13,11 @@
       "import": "./dist/index.js",
       "require": "./dist/index.js"
     },
+    "./domain/constants": {
+      "types": "./dist/domain/constants/index.d.ts",
+      "import": "./dist/domain/constants/index.js",
+      "require": "./dist/domain/constants/index.js"
+    },
     "./domain/errors": {
       "types": "./dist/domain/errors/index.d.ts",
       "import": "./dist/domain/errors/index.js",

--- a/packages/core/src/domain/constants/index.ts
+++ b/packages/core/src/domain/constants/index.ts
@@ -1,5 +1,9 @@
 export { AssetClass } from "./AssetClass";
 export { EffortStatus } from "./EffortStatus";
+// ⛤ Канон экспортируется ИЗ ПОДПУТИ намеренно: плагинные потребители (например
+// PropertySchemas в ct-графе) не могут импортировать значение из корневого barrel —
+// он тянет CommandResolver → tsyringe, а reflect-metadata там нет.
+export { EFFORT_STATUS_UID, EFFORT_STATUS_BY_UID, normalizeEffortStatus } from "./EffortStatusCanon";
 export { EFFORT_STATUS_OPTIONS } from "./EffortStatusOptions";
 export { GroundingType } from "./GroundingType";
 export {

--- a/packages/obsidian-plugin/jest.config.js
+++ b/packages/obsidian-plugin/jest.config.js
@@ -27,6 +27,8 @@ module.exports = {
     "!**/tests/**",
   ],
   moduleNameMapper: {
+    // Подпуть ДО точного: moduleNameMapper берёт первый совпавший паттерн.
+    "^@kitelev/exocortex-core/(.*)$": "<rootDir>/../core/src/$1",
     "^@kitelev/exocortex-core$": "<rootDir>/../core/src/index.ts",
     "^@kitelev/exocortex-services$": "<rootDir>/../services/src/index.ts",
     "^@plugin/types$": "<rootDir>/src/types/index.ts",
@@ -116,6 +118,7 @@ module.exports = {
           isolatedModules: true,
           paths: {
             "@kitelev/exocortex-core": ["<rootDir>/../core/src/index.ts"],
+            "@kitelev/exocortex-core/*": ["<rootDir>/../core/src/*"],
             "@kitelev/exocortex-services": ["<rootDir>/../services/src/index.ts"],
             "@plugin/types": ["<rootDir>/src/types/index.ts"],
             "@plugin/types/*": ["<rootDir>/src/types/*"],

--- a/packages/obsidian-plugin/jest.ui.config.js
+++ b/packages/obsidian-plugin/jest.ui.config.js
@@ -26,6 +26,7 @@ module.exports = {
           isolatedModules: true,
           paths: {
             "@kitelev/exocortex-core": ["<rootDir>/../core/src/index.ts"],
+            "@kitelev/exocortex-core/*": ["<rootDir>/../core/src/*"],
             "@plugin/types": ["<rootDir>/src/types/index.ts"],
             "@plugin/types/*": ["<rootDir>/src/types/*"],
             "@plugin/adapters/*": ["<rootDir>/src/adapters/*"],
@@ -41,6 +42,8 @@ module.exports = {
   },
   transformIgnorePatterns: ["node_modules/(?!(react|react-dom)/)"],
   moduleNameMapper: {
+    // Подпуть ДО точного: moduleNameMapper берёт первый совпавший паттерн.
+    "^@kitelev/exocortex-core/(.*)$": "<rootDir>/../core/src/$1",
     "^@kitelev/exocortex-core$": "<rootDir>/../core/src/index.ts",
     "^@plugin/types$": "<rootDir>/src/types/index.ts",
     "^@plugin/types/(.*)$": "<rootDir>/src/types/$1",

--- a/packages/obsidian-plugin/src/domain/property-editor/PropertySchemas.ts
+++ b/packages/obsidian-plugin/src/domain/property-editor/PropertySchemas.ts
@@ -1,4 +1,5 @@
 import type { PropertySchemaResolver, ClassHierarchyResolver, EnumValueResolver, EnumValue } from "@kitelev/exocortex-core";
+import { EFFORT_STATUS_UID, EffortStatus } from "@kitelev/exocortex-core/domain/constants";
 import { PropertySchemaService } from "./PropertySchemaService";
 
 export type PropertyFieldType =
@@ -47,14 +48,39 @@ export interface SizeEnumValue {
 // (exoas-public@c35a660d, 2026-08-13) and dropped here; Waiting (0610947c-…)
 // took their place — req fcbde537-f09a-410e-8bee-d3d607a70302. Resolve any
 // new UUID on disk before adding it.
-const FALLBACK_EFFORT_STATUS_VALUES: StatusEnumValue[] = [
-  { value: "[[753a44d5-846c-4b82-9196-4fd9a4d48777]]", wikilink: "[[753a44d5-846c-4b82-9196-4fd9a4d48777|Backlog]]", label: "Backlog" },
-  { value: "[[027e78f4-6e16-4b36-b8fb-5510507d5745]]", wikilink: "[[027e78f4-6e16-4b36-b8fb-5510507d5745|Doing]]", label: "Doing" },
-  { value: "[[0610947c-6a62-41c8-9d44-7863d3ba3a8e]]", wikilink: "[[0610947c-6a62-41c8-9d44-7863d3ba3a8e|Waiting]]", label: "Waiting" },
-  { value: "[[7b9b3116-7c3c-438c-9618-94fe301320a6]]", wikilink: "[[7b9b3116-7c3c-438c-9618-94fe301320a6|Done]]", label: "Done" },
-  { value: "[[5d14f18d-db2b-4847-9ac1-144cb93b2541]]", wikilink: "[[5d14f18d-db2b-4847-9ac1-144cb93b2541|Trashed]]", label: "Trashed" },
-  { value: "[[c42245d0-01de-4c35-bfcf-d910445ea28e]]", wikilink: "[[c42245d0-01de-4c35-bfcf-d910445ea28e|Draft]]", label: "Draft" },
+/**
+ * Порядок ВЫПАДАЮЩЕГО СПИСКА — не порядок канона, и это намеренно.
+ *
+ * `EFFORT_STATUS_UID` перечисляет статусы по жизненному циклу
+ * (`Draft → Backlog → Doing → Waiting → Done → Trashed`), а список показывает
+ * сперва рабочие статусы и уводит `Draft` в конец. Это два разных решения:
+ * канон — про модель, порядок ниже — про UX. Поэтому он объявлен ЯВНО, а из
+ * канона берутся только UID.
+ *
+ * ⛔ Не заменять на `Object.keys(EFFORT_STATUS_UID)` — это молча переставит
+ * `Draft` на первую позицию.
+ */
+const FALLBACK_STATUS_ORDER: readonly EffortStatus[] = [
+  EffortStatus.BACKLOG,
+  EffortStatus.DOING,
+  EffortStatus.WAITING,
+  EffortStatus.DONE,
+  EffortStatus.TRASHED,
+  EffortStatus.DRAFT,
 ];
+
+/**
+ * Выведено из канона: UID больше не дублируются здесь литералами. До этого
+ * шесть UID жили копией, и расхождение с `EFFORT_STATUS_UID` прошло бы молча —
+ * ни один тест не сравнивал два списка.
+ */
+const FALLBACK_EFFORT_STATUS_VALUES: StatusEnumValue[] = FALLBACK_STATUS_ORDER.map(
+  (symbol) => {
+    const uid = EFFORT_STATUS_UID[symbol];
+    const label = symbol.replace(/^ems__EffortStatus/, "");
+    return { value: `[[${uid}]]`, wikilink: `[[${uid}|${label}]]`, label };
+  },
+);
 
 const FALLBACK_TASK_SIZE_VALUES: SizeEnumValue[] = [
   { value: "[[ems__TaskSize_XXS]]", label: "XXS" },

--- a/packages/obsidian-plugin/tests/unit/property-editor/PropertySchemas.canonDerivation.test.ts
+++ b/packages/obsidian-plugin/tests/unit/property-editor/PropertySchemas.canonDerivation.test.ts
@@ -1,0 +1,62 @@
+import { FALLBACK_EFFORT_STATUS_VALUES } from "../../../src/domain/property-editor/PropertySchemas";
+import {
+  EFFORT_STATUS_UID,
+  EffortStatus,
+} from "@kitelev/exocortex-core/domain/constants";
+
+/**
+ * Что здесь заперто (issue #4122).
+ *
+ * До этого шесть статусных UID жили в PropertySchemas ЛИТЕРАЛЬНОЙ копией
+ * рядом с `EFFORT_STATUS_UID`. Ни один тест не сравнивал два списка, поэтому
+ * расхождение прошло бы МОЛЧА: существующий PropertySchemas.test.ts (56 осей)
+ * проверяет ЗНАЧЕНИЯ выдачи и остался бы зелёным при любом дрейфе канона.
+ *
+ * ⛤ Оси ниже проверяют не выдачу, а ПРОИЗВОДНОСТЬ — то, чего 56 осей не видят.
+ */
+describe("FALLBACK_EFFORT_STATUS_VALUES выведен из канона", () => {
+  const labelOf = (s: EffortStatus) => s.replace(/^ems__EffortStatus/, "");
+
+  it("каждый UID берётся из EFFORT_STATUS_UID, а не из литерала", () => {
+    for (const entry of FALLBACK_EFFORT_STATUS_VALUES) {
+      const symbol = (Object.values(EffortStatus) as EffortStatus[]).find(
+        (s) => labelOf(s) === entry.label,
+      );
+      expect(symbol).toBeDefined();
+      expect(entry.value).toBe(`[[${EFFORT_STATUS_UID[symbol!]}]]`);
+    }
+  });
+
+  it("wikilink согласован с тем же UID и меткой", () => {
+    for (const entry of FALLBACK_EFFORT_STATUS_VALUES) {
+      const uid = entry.value.slice(2, -2);
+      expect(entry.wikilink).toBe(`[[${uid}|${entry.label}]]`);
+    }
+  });
+
+  it("представлены ВСЕ статусы канона, ровно по одному разу", () => {
+    const labels = FALLBACK_EFFORT_STATUS_VALUES.map((e) => e.label).sort();
+    const expected = (Object.keys(EFFORT_STATUS_UID) as EffortStatus[])
+      .map(labelOf)
+      .sort();
+    expect(labels).toEqual(expected);
+  });
+
+  /**
+   * ⛔ Ось-предохранитель. Порядок списка — решение про UX (сперва рабочие
+   * статусы, `Draft` в конец), порядок канона — про жизненный цикл
+   * (`Draft` первым). Они РАЗНЫЕ, и «упрощение» до `Object.keys(EFFORT_STATUS_UID)`
+   * молча переставило бы `Draft` на первую позицию выпадающего списка.
+   *
+   * Эта ось краснеет ровно на такой замене.
+   */
+  it("порядок списка НЕ наследуется от канона (Draft последним, не первым)", () => {
+    const listOrder = FALLBACK_EFFORT_STATUS_VALUES.map((e) => e.label);
+    const canonOrder = (Object.keys(EFFORT_STATUS_UID) as EffortStatus[]).map(labelOf);
+
+    expect(listOrder).not.toEqual(canonOrder);
+    expect(listOrder[listOrder.length - 1]).toBe("Draft");
+    expect(canonOrder[0]).toBe("Draft");
+    expect(listOrder[0]).toBe("Backlog");
+  });
+});

--- a/scripts/test-type-errors.baseline.json
+++ b/scripts/test-type-errors.baseline.json
@@ -592,18 +592,8 @@
     },
     {
       "file": "packages/obsidian-plugin/tests/component/ErrorBoundary.test.tsx",
-      "code": "TS2307",
-      "count": 1
-    },
-    {
-      "file": "packages/obsidian-plugin/tests/component/ErrorBoundary.test.tsx",
       "code": "TS6133",
       "count": 3
-    },
-    {
-      "file": "packages/obsidian-plugin/tests/component/ErrorBoundary.testHelpers.tsx",
-      "code": "TS2307",
-      "count": 1
     },
     {
       "file": "packages/obsidian-plugin/tests/component/exo-layout-docs-renders.spec.tsx",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
     "baseUrl": ".",
     "paths": {
       "@kitelev/exocortex-core": ["./packages/core/src/index.ts"],
+      "@kitelev/exocortex-core/*": ["./packages/core/src/*"],
       "@kitelev/exocortex-services": ["./packages/services/src/index.ts"],
       "@plugin/types": ["./packages/obsidian-plugin/src/types/index.ts"],
       "@plugin/types/*": ["./packages/obsidian-plugin/src/types/*"],


### PR DESCRIPTION
Closes #4122

Шесть статусных UID жили в `PropertySchemas.ts` **литеральной копией** рядом с `EFFORT_STATUS_UID`. Ни один тест не сравнивал два списка ⇒ расхождение прошло бы **молча**: существующие 56 осей проверяют *значения выдачи* и остались бы зелёными при любом дрейфе канона.

## ⛔ Моё же утверждение в issue оказалось неверным

Issue #4122 (я его писал) заявлял: «порядок канона = порядок дропдауна — **замерено**». Проверил перед реализацией — **ложь**:

| | порядок |
|---|---|
| канон `EFFORT_STATUS_UID` | `Draft → Backlog → Doing → Waiting → Done → Trashed` (жизненный цикл) |
| выпадающий список | `Backlog → Doing → Waiting → Done → Trashed → **Draft**` (сперва рабочие) |

`Draft` в каноне **первый**, в списке — **последний**. Прямой `Object.keys(EFFORT_STATUS_UID)` молча переставил бы его на первую позицию UI.

⇒ Порядок остался **явным** (`FALLBACK_STATUS_ORDER`), а из канона берутся только UID. Это два разных решения: канон — про модель, порядок — про UX. Слить их было бы регрессией, замаскированной под упрощение.

## Резолюция подпути

Значение (не тип) из корневого barrel тянет `CommandResolver` → `tsyringe`, а `reflect-metadata` нет в ct-графе — на этом упала первая попытка (#4120). Barrel-free подпуть добавлен в три слоя, каждый якорился на **точное** имя пакета:

| слой | что добавлено |
|---|---|
| `packages/core/package.json` | `exports["./domain/constants"]` |
| `obsidian-plugin/jest.config.js` | `moduleNameMapper` (подпуть **перед** точным — берётся первый совпавший паттерн) + ts-jest `paths` |
| корневой `tsconfig.json` | `paths` |

⛤ **ct-конфиг правки не потребовал**: его алиас указывает на **директорию** `packages/core/src`, поэтому подпуть резолвится там сам. Это ровно то, что делало ct единственным работающим слоем до PR.

⛤ Подпуть **чист от DI по построению**: в `packages/core/src/domain/constants` исполняемых импортов tsyringe — **0** (два совпадения грепа оказались прозой докстринга, который я сам и писал в #4120).

## Проверено

| проверка | результат |
|---|---|
| 56 существующих осей | ✅ зелены **без единой правки теста** — это и есть доказательство неизменности выдачи |
| 4 новые оси на производность | ✅ + **4 мутанта, соответствие 1:1 по имени оси** |
| `tsc --noEmit --skipLibCheck` (команда CI) | ✅ 0 ошибок |
| **`test-component` локально** | ✅ **371 passed, 1 skipped, 0 failed** — тот самый гейт, на котором упала первая попытка |
| полный plugin-suite | 4 failed suite — **пред-существующие** (см. ниже) |

### Мутанты — каждый краснит ровно свою ось

| мутант | покрасневшая ось |
|---|---|
| литеральный UID вместо канона | `каждый UID берётся из EFFORT_STATUS_UID, а не из литерала` |
| `Object.keys(EFFORT_STATUS_UID)` вместо явного порядка | `порядок списка НЕ наследуется от канона (Draft последним)` |
| пропущен статус | `представлены ВСЕ статусы канона, ровно по одному разу` |
| сломан wikilink | `wikilink согласован с тем же UID и меткой` |

Контроль без мутации — 0 красных. ⛤ Первый прогон печатал только счётчик («1 failed»), из чего **не следует**, что покраснела та ось; пере-прогон с `--verbose` дал имена.

### Про 4 красных suite

Дискриминатор на **пристинном** дереве (`git stash -u`) даёт **ровно те же 4 failed / 3 failed теста** ⇒ пред-существующие. Мои правки добавили `+1 suite` и `+4 теста` (6023 → 6027 passed).

⚠ Первый прогон в этом worktree дал **195 failed** — это оказалось окружение, а не код: worktree засеян `cp -a node_modules`, и в нём не было пакет-локального `uuid@11` (хойстнут 13.0.0, pure ESM) и `nanotar`. Оба восстановлены до паритета с `npm ci`; после этого 195 → 4.

https://claude.ai/code/session_01RLVkQZvShweokvfZUCn7wE
