### PR TITLE
fix(lint): точечный disable no-tfile-tfolder-cast с обоснованием

### DIFF
--- a/packages/obsidian-plugin/src/domain/display-name/ObsidianVaultMetadataAdapter.ts
+++ b/packages/obsidian-plugin/src/domain/display-name/ObsidianVaultMetadataAdapter.ts
@@ -46,6 +46,11 @@ export class ObsidianVaultMetadataAdapter implements VaultMetadataPort {
     // ⛔ `{}` — NOT null — when the file resolves but has no frontmatter: see the port's
     // contract. `getFileCache` returns null for an unindexed file too, but by this point the
     // linkpath HAS resolved, so "resolved, nothing to read" is the honest reading.
+    // ⛤ Сужение УЖЕ сделано строкой выше (`children in file`), и оно duck-typed
+    // НАМЕРЕННО: `instanceof TFile` молча ужесточает blocker-путь (req 5cd9fffe) и
+    // ломается при двух копиях модуля obsidian. Правило справедливо в общем случае;
+    // здесь его требование опровергнуто тестом, а не проигнорировано.
+    // eslint-disable-next-line obsidianmd/no-tfile-tfolder-cast
     return this.app.metadataCache.getFileCache(file as TFile)?.frontmatter ?? {};
   }
 }


### PR DESCRIPTION
## Что и почему

eslint падает на `ObsidianVaultMetadataAdapter.ts:49` правилом `obsidianmd/no-tfile-tfolder-cast`.

⛤ **Долг дремал с 2026-08-15** (#4052). Job `lint` на main зелен, потому что eslint-шаг там **не запускался** — merge-коммиты не трогали `packages/obsidian-plugin/src`. Первый же PR, который его тронул (#4141), разбудил проверку по всей директории и вскрыл долг.

⇒ Он заблокирует **любой** PR в `plugin/src`, поэтому вынесен отдельно, а не вбандлен.

## ⛔ Почему НЕ «починить как требует правило»

Прямо над строкой стоит развёрнутое обоснование автора (req `5cd9fffe`): сужение сделано **duck-typed намеренно**, потому что `instanceof TFile`

- **молча ужесточает blocker-путь** — ловится тестом `DailyTasksRenderer.core` → «should handle task with blockers», чей мок возвращает плоский объект;
- **ломается, когда в игре две копии модуля obsidian**.

То есть требование правила здесь **уже опровергнуто тестом**. Замена cast на `instanceof` была бы регрессией, замаскированной под соблюдение линтера.

⇒ Точечный `eslint-disable-next-line` на **одну** строку с причиной рядом — не правка кода и не исключение на весь файл.

## Проверено

| | |
|---|---|
| `eslint packages/obsidian-plugin/src --ext .ts,.tsx` (команда CI) | **0 problems** |
| дифф | **5 строк, все комментарии** — поведение изменить нечем |
| «should handle task with blockers» | ✅ passed |

⚠ Первая попытка поставила директиву перед блоком комментариев, а не перед строкой кода — eslint честно сказал «Unused eslint-disable directive», и это поймано до коммита.

https://claude.ai/code/session_01RLVkQZvShweokvfZUCn7wE