### PR TITLE
fix(ci): убрать запись dependabot для /packages/core — она ломает npm ci в корне

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -65,23 +65,19 @@ updates:
       - dependency-name: "react-dom"
         update-types: ["version-update:semver-major"]
 
-  # ── npm: packages/core (вход npm-audit гейта; дрейфовал от корневого) ──────
-  - package-ecosystem: "npm"
-    directory: "/packages/core"
-    schedule:
-      interval: "weekly"
-      day: "monday"
-      time: "09:00"
-      timezone: "UTC"
-    open-pull-requests-limit: 2
-    labels:
-      - "dependencies"
-    commit-message:
-      prefix: "chore(deps)"
-    groups:
-      core-lock:
-        patterns: ["*"]
-        update-types: ["minor", "patch"]
+  # ⛔ Записи для /packages/core здесь НЕТ, и это осознанно (проверено замером
+  # 2026-08-20, PR #4129 → #4143). `packages/core` — workspace-ЧЛЕН, его зависимости
+  # живут в КОРНЕВОМ локе, и корневая запись выше обновляет их правильно: PR #4139
+  # тронул package-lock.json + манифесты core/cli/plugin/req-audit синхронно.
+  #
+  # Отдельная запись `directory: "/packages/core"` обновляет ТОЛЬКО манифест члена
+  # и его лок — корневой остаётся прежним, и `npm ci` в корне падает
+  # `Missing: <pkg> from lock file` (так упал PR #4140, job NPM Security Audit).
+  #
+  # ⚠ Остаток: packages/core/package-lock.json продолжает дрейфовать от корневого
+  # (js-yaml 3.14.2 против 3.15.1). Он не источник установки — только
+  # cache-dependency-path и вход `npm audit --omit=dev` job-а npm-audit-exocortex.
+  # Лечится не здесь; см. #4128.
 
   # ── npm: docs-site (вне workspaces корня) ─────────────────────────────────
   - package-ecosystem: "npm"


### PR DESCRIPTION
Само-коррекция к #4129 (мой же PR, ~час назад).

## Что оказалось неверным

Запись `directory: "/packages/core"` добавлялась, чтобы закрыть наблюдаемый дрейф `js-yaml` в `packages/core/package-lock.json`. **Замер показал, что она этого не делает — зато производит PR, ломающие `npm ci`.**

| PR | какая запись | что тронул | исход |
|---|---|---|---|
| **#4139** | `npm /` (корневая) | `package-lock.json` + манифесты `core`, `cli`, `obsidian-plugin`, `req-audit` — **синхронно** | корректный бамп |
| **#4140** | `npm /packages/core` | **только** `packages/core/package.json` + его лок | ⛔ `npm ci` в корне: `Missing: js-yaml@… from lock file` |

**Механизм:** `packages/core` — workspace-**член**, его зависимости живут в **корневом** локе. Корневая запись обновляет их правильно. Отдельная запись по каталогу члена обновляет манифест члена и его лок, корневой не трогает ⇒ рассинхрон, и `npm ci` отказывается ставить.

⇒ запись убрана, **на её месте — причина в самом файле**: без этого следующий читатель добавит её обратно ровно с тем же рассуждением, что и я («у core же свой лок»).

## Что НЕ трогаю

- **`/docs-site` остаётся** — он **вне** workspaces корня (`workspaces: ["packages/*", …]`) и имеет собственный лок, корневая запись его не видит. Проверено, а не предположено.
- **Дрейф `packages/core/package-lock.json` остаётся открытым.** Он не источник установки — только `cache-dependency-path` и вход `npm audit --omit=dev` job-а `npm-audit-exocortex`. Лечится не конфигурацией Dependabot; остаток назван в #4128.

## Проверено

- конфиг соответствует схеме `dependabot-2.0` (SchemaStore) — 0 нарушений; валидатор ранее предъявлен не-вакуумным (три мутанта краснеют);
- три оставшиеся записи распарсены: `npm /`, `npm /docs-site`, `github-actions /`.

⛤ Побочно это подтверждает, что канал работает: обе конкурирующие записи произвели PR, и разница между ними стала наблюдаемой за час.

https://claude.ai/code/session_01RLVkQZvShweokvfZUCn7wE