### PR TITLE
fix(ci): развести dev-группу dependabot по семействам

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -38,23 +38,51 @@ updates:
         exclude-patterns:
           - "@types/*"
           - "eslint*"
+          # ⛔ @typescript-eslint/* НЕ покрывается ни `eslint*` (начинается с @),
+          # ни `typescript` (точное совпадение) — без этой строки пакет попал бы
+          # и в production-группу, и в linters.
+          - "@typescript-eslint/*"
           - "prettier*"
           - "jest*"
           - "@jest/*"
+          # ⛔ ts-jest не покрывается `jest*` — он начинается с `ts-`.
+          - "ts-jest"
           - "typescript"
           - "@playwright/*"
           - "playwright*"
         update-types: ["minor", "patch"]
-      dev-dependencies:
+      # ⛤ Dev-инструменты РАЗВЕДЕНЫ по семействам, а не свалены в одну группу.
+      # Причина замерена на PR #4138: единая dev-группа притащила jest 30.4.2
+      # ВМЕСТЕ с jest-environment-jsdom 30.4.1 — разъехавшийся лок-степ внутри
+      # семейства дал `TypeError: this._moduleMocker.clearMocksOnScope is not a
+      # function`, и в том же PR ехали @playwright/* 1.57→1.62 и
+      # eslint-plugin-obsidianmd 0.1.9→0.4.1. Разобрать такой PR нельзя — в нём
+      # смешаны несвязанные причины отказа.
+      #
+      # ⛔ jest и jest-environment-* обязаны двигаться ОДНИМ PR (общий jest-mock),
+      # поэтому они в одной группе — но отдельно от всего прочего.
+      jest:
         patterns:
-          - "@types/*"
-          - "eslint*"
-          - "prettier*"
-          - "jest*"
+          - "jest"
+          - "jest-*"
           - "@jest/*"
-          - "typescript"
+          - "ts-jest"
+        update-types: ["minor", "patch"]
+      playwright:
+        patterns:
           - "@playwright/*"
           - "playwright*"
+        update-types: ["minor", "patch"]
+      linters:
+        patterns:
+          - "eslint*"
+          - "@typescript-eslint/*"
+          - "prettier*"
+        update-types: ["minor", "patch"]
+      types-and-tsc:
+        patterns:
+          - "@types/*"
+          - "typescript"
         update-types: ["minor", "patch"]
     # major-версии этих трёх ломают рантайм плагина — только вручную, с прогоном e2e
     ignore:


### PR DESCRIPTION
Следствие диагноза #4138 — правка **моего же** конфига из #4129.

## Что не так с единой dev-группой

Замерено на живом PR #4138: в одном PR приехали

| пакет | версии | последствие |
|---|---|---|
| `jest` | 30.2.0 → **30.4.2** | ⛔ вместе с ↓ даёт `TypeError: this._moduleMocker.clearMocksOnScope is not a function` |
| `jest-environment-jsdom` | 30.2.0 → **30.4.1** | разъехавшийся лок-степ (общий `jest-mock`) |
| `@playwright/test`, `@playwright/experimental-ct-react` | 1.57.0 → 1.62.1 | гейтят `test-component` |
| `eslint-plugin-obsidianmd` | 0.1.9 → **0.4.1** | новый набор правил ⇒ потенциально краснота по всему репо |

⇒ причины отказа **несвязанные**, и понять, что именно чинишь, нельзя. Такой PR не мержится и не разбирается.

## Что сделано

Разведено на четыре семейства: **jest** · **playwright** · **linters** · **types-and-tsc**.

⛤ `jest` + `jest-*` + `@jest/*` + `ts-jest` оставлены **в одной** группе намеренно — они обязаны двигаться одним PR из-за общего `jest-mock`; именно их разъезд и сломал #4138.

## ⛔ Заодно закрыта дыра в `exclude-patterns`

| паттерн | почему не покрывался |
|---|---|
| `@typescript-eslint/*` | не матчится `eslint*` (начинается с `@`) и не матчится `typescript` (точное совпадение) |
| `ts-jest` | не матчится `jest*` (начинается с `ts-`) |

Без них оба пакета попадали бы **и** в `production-dependencies`, **и** в новую dev-группу.

## ⚠ Как проверял — матчингом, а не сравнением строк

Грубое сравнение списков паттернов дало **4** «непокрытых»; реальных — **2**: `jest*` глобом покрывает и `jest`, и `jest-*`. Различил `fnmatch`-прогоном на 13 реальных именах пакетов:

```
✅ jest / jest-environment-jsdom / @jest/globals / ts-jest      dev=True  excluded=True
✅ @playwright/test / playwright                                 dev=True  excluded=True
✅ eslint / eslint-plugin-obsidianmd / @typescript-eslint/parser dev=True  excluded=True
✅ prettier / typescript / @types/node                           dev=True  excluded=True
✅ react                                                          dev=False excluded=False
```

Схема `dependabot-2.0` — 0 нарушений.

https://claude.ai/code/session_01RLVkQZvShweokvfZUCn7wE