### PR TITLE
fix(e2e): wait for the exocortex plugin in the launcher, not in each spec

### DIFF
--- a/packages/obsidian-plugin/tests/e2e/utils/obsidian-launcher.ts
+++ b/packages/obsidian-plugin/tests/e2e/utils/obsidian-launcher.ts
@@ -202,6 +202,9 @@ export class ObsidianLauncher {
     console.log("[ObsidianLauncher] Waiting for vault to finish indexing...");
     await this.waitForVaultReady();
 
+    console.log("[ObsidianLauncher] Waiting for the exocortex plugin to load...");
+    await this.waitForPluginReady();
+
     console.log("[ObsidianLauncher] Obsidian ready!");
   }
 
@@ -296,6 +299,62 @@ export class ObsidianLauncher {
         "[ObsidianLauncher] No trust dialog found or error handling it:",
         error,
       );
+    }
+  }
+
+  /**
+   * Wait until the exocortex plugin object is actually reachable.
+   *
+   * ⛤ WHY THIS LIVES HERE, not in the specs. `waitForVaultReady` waits for the
+   * VAULT (markdown files indexed) — it says nothing about the PLUGIN. Specs then
+   * used to spin their own `for (let i = 0; i < 20; i++) { …500ms }` loop, i.e. a
+   * hard 10s ceiling — while the launcher grants 45s for the CDP port, 30s for the
+   * window and 30s for the vault. Under a loaded CI runner (the e2e image runs
+   * amd64) 10s is simply not enough, and the spec then fails as
+   * `expect(result.pluginLoaded).toBe(true)` — a message that names the SYMPTOM and
+   * hides the cause. Measured on `origin/main`: e2e-shard (1)/(3)/(5) each flaked
+   * ~5% of attempts, the aggregate `e2e-tests` 15%, and EVERY sampled failure log
+   * carried `pluginLoaded`.
+   *
+   * Two fixes in one place: (a) the ceiling becomes consistent with its
+   * neighbours, (b) a timeout now reports what WAS loaded, so a red run carries
+   * evidence instead of a bare boolean.
+   */
+  private async waitForPluginReady(): Promise<void> {
+    if (!this.window) {
+      throw new Error("Window not available");
+    }
+
+    const maxWaitTime = 30000;
+    const checkInterval = 500;
+    const startTime = Date.now();
+
+    for (;;) {
+      const status = await this.window.evaluate(() => {
+        const app = (window as any).app;
+        return {
+          loaded: !!app?.plugins?.plugins?.exocortex,
+          enabled: Object.keys(app?.plugins?.plugins ?? {}),
+        };
+      });
+
+      if (status.loaded) {
+        console.log(
+          `[ObsidianLauncher] Plugin ready after ${Date.now() - startTime}ms`,
+        );
+        return;
+      }
+
+      if (Date.now() - startTime >= maxWaitTime) {
+        // ⛤ fail LOUD and with evidence: the plugin list is the one datum that
+        // distinguishes "still loading" from "failed to load / not installed".
+        throw new Error(
+          `[ObsidianLauncher] exocortex plugin did not load within ${maxWaitTime}ms. ` +
+            `Loaded plugins: [${status.enabled.join(", ") || "none"}]`,
+        );
+      }
+
+      await new Promise((resolve) => setTimeout(resolve, checkInterval));
     }
   }
 

--- a/packages/obsidian-plugin/tests/unit/e2e-utils/obsidian-launcher.plugin-wait.test.ts
+++ b/packages/obsidian-plugin/tests/unit/e2e-utils/obsidian-launcher.plugin-wait.test.ts
@@ -1,0 +1,97 @@
+// The launcher imports @playwright/test at module scope; loading the real bundle
+// under jsdom pulls in the whole MCP browser stack. Nothing under test touches
+// it — `chromium` is only used inside `launchAttempt`, which these axes never call.
+jest.mock("@playwright/test", () => ({ chromium: {} }));
+
+import { ObsidianLauncher } from "../../e2e/utils/obsidian-launcher";
+
+/**
+ * Guards the fix for the `pluginLoaded` e2e flake.
+ *
+ * BEFORE: `launchAttempt` waited for the VAULT (`waitForVaultReady`, 30s) and
+ * stopped there. Each spec then spun its own `for (let i = 0; i < 20; i++)
+ * { …500ms }` loop — a hard 10s ceiling — and failed as
+ * `expect(result.pluginLoaded).toBe(true)`, a message that names the symptom and
+ * hides the cause. Measured on origin/main over 20 runs × all attempts:
+ * e2e-shard (1)/(3)/(5) flaked ~5% each, the aggregate `e2e-tests` 15%, and every
+ * sampled failure log carried `pluginLoaded`.
+ *
+ * AFTER: the launcher itself waits for the plugin, with a ceiling consistent with
+ * its neighbours (CDP port 45s, window 30s, vault 30s → plugin 30s) and a
+ * failure that carries evidence. Because the wait lives inside `launchAttempt`,
+ * a plugin that never loads now also triggers `launch()`'s existing 3-attempt
+ * relaunch with backoff instead of failing the spec outright.
+ */
+describe("ObsidianLauncher.waitForPluginReady", () => {
+  const makeLauncher = (evaluate: jest.Mock): ObsidianLauncher => {
+    const launcher = new ObsidianLauncher("/tmp/does-not-matter");
+    // The method only touches `this.window.evaluate`; a fake window is enough and
+    // keeps the test free of Playwright/Obsidian.
+    (launcher as unknown as { window: { evaluate: jest.Mock } }).window = {
+      evaluate,
+    };
+    return launcher;
+  };
+
+  const callWait = (launcher: ObsidianLauncher): Promise<void> =>
+    (
+      launcher as unknown as { waitForPluginReady: () => Promise<void> }
+    ).waitForPluginReady();
+
+  it("resolves once the exocortex plugin is reachable", async () => {
+    // Not loaded on the first poll, loaded on the second — proves it actually
+    // waits rather than sampling once.
+    const evaluate = jest
+      .fn()
+      .mockResolvedValueOnce({ loaded: false, enabled: ["dataview"] })
+      .mockResolvedValueOnce({ loaded: true, enabled: ["dataview", "exocortex"] });
+
+    await expect(callWait(makeLauncher(evaluate))).resolves.toBeUndefined();
+    expect(evaluate).toHaveBeenCalledTimes(2);
+  });
+
+  it("throws with the loaded-plugin list when the plugin never appears", async () => {
+    // ⛤ The evidence half: a bare `pluginLoaded: false` cannot distinguish "still
+    // loading" from "failed to load / not installed". The plugin list can.
+    const evaluate = jest
+      .fn()
+      .mockResolvedValue({ loaded: false, enabled: ["dataview", "templater"] });
+
+    const launcher = makeLauncher(evaluate);
+    const nowSpy = jest.spyOn(Date, "now");
+    // t0, then a value past the 30s ceiling on the first ceiling check.
+    nowSpy.mockReturnValueOnce(0).mockReturnValue(30_001);
+
+    await expect(callWait(launcher)).rejects.toThrow(
+      /exocortex plugin did not load within 30000ms.*dataview, templater/s,
+    );
+
+    nowSpy.mockRestore();
+  });
+
+  it("throws a distinct error when there is no window at all", async () => {
+    const launcher = new ObsidianLauncher("/tmp/does-not-matter");
+    await expect(callWait(launcher)).rejects.toThrow("Window not available");
+  });
+
+  it("is wired into launchAttempt AFTER the vault wait", () => {
+    // ⛤ Structural, and deliberately so: the behaviour axes above pin the helper,
+    // but nothing in them would notice if the CALL were dropped from
+    // `launchAttempt` — the helper would keep passing while the flake returned.
+    // Driving the real `launchAttempt` would mean spawning Obsidian, so this axis
+    // reads the compiled method body instead. It is weaker than an execution axis
+    // and is stated as such; it exists to catch a silent removal of the wiring.
+    const body = (
+      ObsidianLauncher.prototype as unknown as {
+        launchAttempt: () => Promise<void>;
+      }
+    ).launchAttempt.toString();
+
+    const vaultCall = body.indexOf("waitForVaultReady");
+    const pluginCall = body.indexOf("waitForPluginReady");
+
+    expect(vaultCall).toBeGreaterThan(-1);
+    expect(pluginCall).toBeGreaterThan(-1);
+    expect(pluginCall).toBeGreaterThan(vaultCall);
+  });
+});


### PR DESCRIPTION
## Наблюдаемое

`pluginLoaded` — самый частый флак этого репо. Замер на `origin/main`, 20 последних прогонов `ci.yml`, **с обходом по `run_attempt`** (эндпоинт `/runs/{id}/jobs` отдаёт только ПОСЛЕДНЮЮ попытку, поэтому `gh run rerun` стирает улику — по нему частота выходит 0 %):

| джоб | падений |
|---|---|
| `e2e-shard (1)` | 1/20 |
| `e2e-shard (3)` | 1/20 |
| `e2e-shard (5)` | 1/20 |
| **`e2e-tests` (агрегат)** | **3/20 = 15 %** |

Каждый просмотренный лог падения нёс `pluginLoaded`. За эту сессию флак уронил #4142, #4155 и `eka-gui` на main.

## Корень

`launchAttempt` ждал **vault** (`waitForVaultReady`, 30 с) и на этом останавливался. Дальше **каждая спека** крутила свой цикл:

```ts
for (let i = 0; i < 20; i++) { …; await sleep(500); }   // жёсткий потолок 10 с
expect(result.pluginLoaded).toBe(true);                  // симптом без причины
```

То есть плагину давалось **10 с** там, где соседние ожидания лаунчера дают 45 с (CDP-порт), 30 с (окно), 30 с (vault). `waitForVaultReady` ждёт **файлы** и о плагине не знает вовсе.

Класс живёт в 3 файлах (`dynamic-commands.spec.ts`, `dynamic-command-buttons-render.spec.ts`, один unit) — поэтому фикс идёт в **лаунчер**, одно место на все спеки.

## Что сделано

`waitForPluginReady()` в `launchAttempt`, сразу после `waitForVaultReady()`:

- потолок **30 с**, согласован с соседями (45/30/30);
- отказ несёт **список загруженных плагинов** — единственные данные, отличающие «ещё грузится» от «не установлен / упал при загрузке». Голый `pluginLoaded: false` их не различает;
- ⛤ поскольку ожидание внутри `launchAttempt`, не загрузившийся плагин теперь **запускает существующий 3-попыточный relaunch с backoff** в `launch()`, а не роняет спеку сразу. Раньше эта ветка была недостижима — спека падала уже после успешного `launch()`.

## Оси (`tests/unit/e2e-utils/obsidian-launcher.plugin-wait.test.ts`)

Revert-verify, **4 мутанта — каждый красит ровно свою ось** (контроль 0 красных; красноту читаю по ИМЕНИ, `--verbose` обязателен — без него jest глиф `✕` не печатает):

| мутант | покраснело |
|---|---|
| снять **вызов** из `launchAttempt` | `is wired into launchAttempt AFTER the vault wait` |
| метод резолвится немедленно | `resolves…` + `throws with the loaded-plugin list` + `no window at all` |
| снять guard отсутствующего окна | `throws a distinct error when there is no window at all` |
| снять перечень плагинов из сообщения | `throws with the loaded-plugin list when the plugin never appears` |

⛤ Четвёртая ось **структурная и намеренно слабее** остальных: поведенческие пинят хелпер, но ни одна не заметила бы **удаления вызова** — хелпер продолжал бы проходить, пока флак возвращается. Гонять настоящий `launchAttempt` значит поднимать Obsidian, поэтому ось читает тело скомпилированного метода (`Function.prototype.toString`). Это названо в самом тесте, а не выдано за исполнительную проверку.

## Гейты

| проверка | результат |
|---|---|
| `npm ci` | rc=0, 950 пакетов |
| `check:types` | rc=0 |
| `eslint` тест-файла | rc=0 |
| `check-test-types` | rc=0 — 1003 файла, 431 пара = baseline |
| `check-test-antipatterns` | rc=0 — 929 файлов, все счётчики на baseline |
| новый сьют | 4/4 |
| archgate (pre-commit) | 25/25 pass |

⚠ `eslint` по самому `obsidian-launcher.ts`: 89 → 92 проблемы, дельта = **2 `no-console` + 1 `as any`** — обе локальные идиомы файла (в baseline 66 `console.log` с префиксом `[ObsidianLauncher]` и 5 `(window as any).app`). Новых классов нарушений не внесено; `import/no-nodejs-modules`, всплывший в первой редакции теста, снят — ось перешла на интроспекцию скомпилированного метода вместо чтения файла с диска.

## Чего этот PR НЕ делает

Не трогает сами спеки: их 10-секундные циклы остаются как есть и теперь просто никогда не доходят до потолка. Снять их — отдельная уборка, здесь она размыла бы дифф и смешала два концерна.
