### PR TITLE
chore(deps): bump @types/node 20 → 22 (match the CI runtime), pin majors

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -92,6 +92,16 @@ updates:
         update-types: ["version-update:semver-major"]
       - dependency-name: "react-dom"
         update-types: ["version-update:semver-major"]
+      # ⛤ @types/node описывает РАНТАЙМ, а рантайм здесь — Node 22 (8 воркфлоу
+      # `node-version: "22"`, один на 20). Типы 26 принимают API, которых в этом
+      # рантайме нет: замер 2026-08-20 на `packages/core` (lib ES2020/ES2022, БЕЗ
+      # DOM) — `new URLPattern(...)` (глобал с Node 24) даёт ошибку под типами 22
+      # и компилируется под 26. То есть major-бамп типов открывает окно
+      # «tsc принял → Node бросил ReferenceError», причём при зелёном CI.
+      # ⇒ снимать этот ignore ВМЕСТЕ с подъёмом `node-version` в .github/workflows,
+      #   а не раньше; условие проверяется одним grep-ом по воркфлоу.
+      - dependency-name: "@types/node"
+        update-types: ["version-update:semver-major"]
 
   # ⛔ Записи для /packages/core здесь НЕТ, и это осознанно (проверено замером
   # 2026-08-20, PR #4129 → #4143). `packages/core` — workspace-ЧЛЕН, его зависимости

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
         "@testing-library/react": "^16.3.2",
         "@testing-library/user-event": "^14.6.4",
         "@types/jest": "^30.0.0",
-        "@types/node": "^20.19.24",
+        "@types/node": "^22.20.1",
         "@types/react": "^19.2.18",
         "@types/react-dom": "^19.2.4",
         "@types/uuid": "^10.0.0",
@@ -50,7 +50,7 @@
         "jest-environment-obsidian": "^0.0.1",
         "jsdom": "^26.1.0",
         "lint-staged": "^16.2.7",
-        "obsidian": "*",
+        "obsidian": "latest",
         "preact": "^10.29.8",
         "prettier": "^3.6.2",
         "ts-jest": "^29.4.12",
@@ -4440,9 +4440,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "20.19.38",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.38.tgz",
-      "integrity": "sha512-grSwveyouVpXDwUvnpIb5noOpZQGOzbVdZXdjw8P9WOjnrUenKj2YuIh35OpXQ+UCmMQEgyvRobT5uuK9iDCUQ==",
+      "version": "22.20.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
+      "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -15238,7 +15238,7 @@
         "@types/fs-extra": "^11.0.0",
         "@types/jest": "^30.0.0",
         "@types/js-yaml": "^4.0.0",
-        "@types/node": "^20.19.24",
+        "@types/node": "^22.20.1",
         "esbuild": "^0.28.2",
         "jest": "^30.4.2",
         "reflect-metadata": "^0.2.2",
@@ -15310,7 +15310,7 @@
       "devDependencies": {
         "@types/jest": "^30.0.0",
         "@types/js-yaml": "^4.0.0",
-        "@types/node": "^20.19.24",
+        "@types/node": "^22.20.1",
         "@types/sparqljs": "^3.1.12",
         "@types/uuid": "^10.0.0",
         "eslint": "^9.38.0",
@@ -15345,7 +15345,7 @@
         "@tanstack/react-query": "^5.101.4",
         "@tanstack/react-virtual": "^3.14.9",
         "nanotar": "0.3.0",
-        "obsidian": "*",
+        "obsidian": "latest",
         "react": "^19.2.8",
         "react-dom": "^19.2.8",
         "reflect-metadata": "^0.2.2",
@@ -15414,7 +15414,7 @@
       "devDependencies": {
         "@types/jest": "^30.0.0",
         "@types/js-yaml": "^4.0.0",
-        "@types/node": "^20.19.24",
+        "@types/node": "^22.20.1",
         "jest": "^30.4.2",
         "ts-jest": "^29.4.12",
         "tsx": "^4.23.12",
@@ -15430,7 +15430,7 @@
       },
       "devDependencies": {
         "@types/jest": "^30.0.0",
-        "@types/node": "^20.19.24",
+        "@types/node": "^22.20.1",
         "jest": "^30.4.2",
         "ts-jest": "^29.4.12",
         "typescript": "^5.9.3"

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.6.4",
     "@types/jest": "^30.0.0",
-    "@types/node": "^20.19.24",
+    "@types/node": "^22.20.1",
     "@types/react": "^19.2.18",
     "@types/react-dom": "^19.2.4",
     "@types/uuid": "^10.0.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -66,7 +66,7 @@
     "@types/fs-extra": "^11.0.0",
     "@types/jest": "^30.0.0",
     "@types/js-yaml": "^4.0.0",
-    "@types/node": "^20.19.24",
+    "@types/node": "^22.20.1",
     "esbuild": "^0.28.2",
     "jest": "^30.4.2",
     "reflect-metadata": "^0.2.2",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -54,7 +54,7 @@
   "devDependencies": {
     "@types/jest": "^30.0.0",
     "@types/js-yaml": "^4.0.0",
-    "@types/node": "^20.19.24",
+    "@types/node": "^22.20.1",
     "@types/sparqljs": "^3.1.12",
     "@types/uuid": "^10.0.0",
     "eslint": "^9.38.0",

--- a/packages/req-audit/package.json
+++ b/packages/req-audit/package.json
@@ -17,7 +17,7 @@
   "devDependencies": {
     "@types/jest": "^30.0.0",
     "@types/js-yaml": "^4.0.0",
-    "@types/node": "^20.19.24",
+    "@types/node": "^22.20.1",
     "jest": "^30.4.2",
     "ts-jest": "^29.4.12",
     "tsx": "^4.23.12",

--- a/packages/services/package.json
+++ b/packages/services/package.json
@@ -33,7 +33,7 @@
   },
   "devDependencies": {
     "@types/jest": "^30.0.0",
-    "@types/node": "^20.19.24",
+    "@types/node": "^22.20.1",
     "jest": "^30.4.2",
     "ts-jest": "^29.4.12",
     "typescript": "^5.9.3"


### PR DESCRIPTION
Заменяет #4147 (`20 → 26`). Dependabot ту ветку ребейзить отказался («PR has been edited by someone other than Dependabot»), но дело не в этом — **сама цель бампа была неверной**.

## Почему не 26

`@types/node` описывает **рантайм**, а рантайм здесь — Node 22:

```
$ grep -rhoE 'node-version:\s*\S+' .github/workflows/*.yml | sort | uniq -c
      8 node-version: "22"
      1 node-version: 20
```

Типы, опережающие рантайм, дают `tsc` право принять API, которого в этом рантайме нет. CI при этом **зелёный по построению** — он компилирует, а не исполняет.

## Замер (на реальном конфиге, не на синтетическом)

`packages/core/tsconfig.json` → `lib: ["ES2020","ES2022"]`, **без DOM** ⇒ глобал может прийти только из `@types/node`. Проба — `new URLPattern({ pathname: "/x" })` (глобал с Node 24):

| типы | tsc |
|---|---|
| `@types/node@22.20.1` | **1 ошибка** |
| `@types/node@26.2.0` | **0 ошибок** |

То есть под 26 этот код собирается и падает `ReferenceError` на Node 22. Ровно тот класс, против которого в репо уже стоит archgate-правило `MOBILE-005 no-silent-es2022-runtime-api` — только там мобильный Safari, а тут Node.

⚠ Честно про границы замера: первая проба (`process.execve`, Node 23.11) **различия не показала** — типы 22 её принимают. Значит окно уже, чем «всё после 22», но оно непусто, и `URLPattern` это предъявляет.

## Что в PR

- `@types/node` `^20.19.24` → `^22.20.1` в 5 манифестах + перегенерированный корневой лок (`npm install --package-lock-only`, затем проверено `npm ci`).
- `ignore` для major-обновлений `@types/node` в `.github/dependabot.yml` — **с механизмом и условием снятия рядом**: поднимать вместе с `node-version` в воркфлоу, а не раньше. Иначе тот же PR приедет снова через неделю.

⛤ Барьер поставлен там же, где уже стоят `obsidian`/`react`/`react-dom` — их комментарий («major ломает рантайм плагина») ровно про этот же класс, так что запись ложится в существующую конвенцию, а не заводит новую.

## Гейты (полный `npm ci`, 950 пакетов)

| проверка | результат |
|---|---|
| `npm ci` | rc=0 |
| `check:types` | rc=0, 0 ошибок TS |
| `check-cli-types` | rc=0 — 116 файлов, **13 пар = baseline** |
| `check-test-types` | rc=0 — 1003 файла, **431 пара = baseline** |
| `check-test-antipatterns` | rc=0 — 929 файлов, все счётчики на baseline |
| `check-coverage-monotonic` | rc=0 |
| `validate-shard-assignments` | rc=0 |

⚠ `check-cli-types` с первого раза дал **rc=2** — это «проверка не смогла отработать» (нужен собранный `@kitelev/exocortex-services`), а не «нашла новые ошибки». После `npm run build -w` — rc=0 на baseline. Отмечаю, потому что спутать эти два исхода легко, а вывод из них противоположный.

## Что дальше (не в этом PR)

Комментарий в `dependabot.yml` — это **подпись**, а не механизм: он не покраснеет, если кто-то поднимет типы, не тронув воркфлоу. Механическая форма — archgate-правило, сверяющее major `@types/node` с `node-version`. Завожу отдельно; смешивать с бампом не стал.

Closes #4147
