### PR TITLE
feat(archgate): CI-001 — manifest ↔ environment version parity

### DIFF
--- a/.archgate/adrs/CI-001-manifest-environment-version-parity.md
+++ b/.archgate/adrs/CI-001-manifest-environment-version-parity.md
@@ -1,0 +1,69 @@
+---
+id: CI-001
+title: A version pinned in two places must not drift between manifest and CI environment
+domain: ci
+rules: true
+files: ["package.json", ".github/workflows/*.yml"]
+---
+
+# Manifest ↔ Environment Version Parity
+
+## Context
+
+Some versions are declared **twice**: once in a manifest (`package.json`) and
+once in the description of the environment (a container tag, `node-version:`).
+Dependabot reads manifests. It does not read the environment, because the
+environment is written inline in a workflow — so a bump lands on one side and
+the two drift, with nothing in the repo comparing them.
+
+Measured twice within one hour on 2026-08-20, and the two failure shapes are
+**opposite**:
+
+| pair | manifest | environment | symptom |
+| --- | --- | --- | --- |
+| Playwright | `@playwright/test` 1.57 → 1.62 (#4163) | `container: mcr.microsoft.com/playwright:v1.57.0-jammy` — **3** occurrences in `ci.yml` | `test-component`: **322 failed**, every one `Executable doesn't exist at /ms-playwright/chromium_headless_shell-1234/…` |
+| Node | `@types/node` 20 → 26 (#4147) | `node-version: "22"` (8 workflows), one on 20 | **nothing** — CI is green, because it compiles rather than runs |
+
+The Node row is the reason this ADR exists. A green CI is not evidence for that
+pair and structurally cannot be: `tsc` accepts an API the runtime lacks, and the
+`ReferenceError` waits for the first caller. Demonstrated on the real
+`packages/core/tsconfig.json` (`lib: ["ES2020","ES2022"]`, **no DOM**, so the
+global can only come from `@types/node`):
+
+| types | `new URLPattern({ pathname: "/x" })` — a Node-24 global |
+| --- | --- |
+| `@types/node@22.20.1` | 1 error |
+| `@types/node@26.2.0` | **0 errors** |
+
+## Decision
+
+Compare the two declarations mechanically. The predicates are **not symmetric**,
+and the asymmetry is measured rather than stylistic:
+
+- **Playwright — exact equality.** The browsers ship in the image; the harness
+  asks for the revision its npm version expects.
+- **Node — types major ≤ MINIMUM `node-version`.** Types describing *less* than
+  the runtime is safe (you cannot type an API you do not have); describing
+  *more* is the hole. Minimum, not maximum, because the oldest workflow is where
+  the code breaks first.
+
+## Consequences
+
+- A partial bump now fails `archgate` instead of failing a browser job with 322
+  identical errors, or not failing at all.
+- `.github/dependabot.yml` carries an `ignore` for `@types/node` majors with the
+  lifting condition written next to it. That comment is a **signature, not a
+  gate** — this rule is the gate.
+- ⚠ Counting matters: the Playwright tag has three occurrences in `ci.yml`, and
+  a first pass read "two" from a `grep … | head -20`. The rule reports **every**
+  occurrence rather than the first.
+
+## Alternatives considered
+
+- **A milder Playwright predicate (major.minor).** Rejected: `main` carried
+  `^1.56.1` against a `v1.57.0` image and was green, so *some* skew is tolerated
+  — but the tolerated width is undocumented upstream, and "it happened to work
+  at one minor" is not a contract. Equality is the only line that does not
+  require guessing where tolerance ends.
+- **Leaving it to the `dependabot.yml` comment.** Rejected: a comment does not
+  turn red.

--- a/.archgate/adrs/CI-001-manifest-environment-version-parity.rules.ts
+++ b/.archgate/adrs/CI-001-manifest-environment-version-parity.rules.ts
@@ -1,0 +1,151 @@
+/// <reference path="../rules.d.ts" />
+
+// CI-001 — a version pinned in TWO places, bumped in ONE.
+//
+// Dependabot reads MANIFESTS. It does not read the ENVIRONMENT, because the
+// environment is written inline in a workflow: a container tag, a
+// `node-version:`. So a bump lands on one side and the two drift — silently,
+// because nothing in the repo compares them.
+//
+// ⛤ MEASURED, twice within one hour on 2026-08-20, and the two failure shapes
+// are OPPOSITE — which is why a single rule covers both:
+//
+//   pair        manifest                   environment                    symptom
+//   ─────────── ────────────────────────── ────────────────────────────── ──────────────────────
+//   Playwright  @playwright/test 1.57→1.62 container mcr…playwright:v1.57 322 failed, every one
+//                                          (3 occurrences in ci.yml)      "Executable doesn't
+//                                                                          exist at …
+//                                                                          chromium_headless_shell-1234"
+//   Node        @types/node 20→26          node-version: "22" (×8), 20    NOTHING. CI is green —
+//                                                                          it compiles, it does not
+//                                                                          run. `new URLPattern(…)`
+//                                                                          (a Node-24 global) errors
+//                                                                          under types 22 and is
+//                                                                          clean under 26, so the
+//                                                                          ReferenceError waits for
+//                                                                          the first caller.
+//
+// The second shape is the reason this rule exists at all: a green CI is not
+// evidence for the Node pair, and cannot be. Only a comparison of the two
+// declarations is.
+//
+// ⛔ THE PREDICATES ARE NOT SYMMETRIC, and that asymmetry is measured, not
+// stylistic:
+//
+//   • Playwright — EXACT equality. The browsers live in the image, and the
+//     harness asks for the revision its npm version expects. 1.62 npm against a
+//     1.57 image produced 322 identical failures. (A milder predicate was
+//     considered and rejected: main carried @playwright/test ^1.56.1 against a
+//     v1.57.0 image and was green, so SOME skew is tolerated — but the tolerated
+//     width is undocumented upstream, and "it happened to work at 1 minor" is
+//     not a contract. Equality is the only line that does not require guessing
+//     where the tolerance ends.)
+//
+//   • Node — types major ≤ MINIMUM node-version, not equality. Types describe a
+//     runtime; describing LESS than the runtime is safe (you simply cannot type
+//     an API you have), describing MORE is the hole. Minimum, not maximum,
+//     because the oldest workflow is where the code breaks first.
+//
+// Known limitations (line-based, same trade-off as MOBILE-001/002/003/005):
+//  - `node-version:` inside a comment or a string would be read as a
+//    declaration (no such case exists today — measured);
+//  - a matrix `node-version: [20, 22]` is NOT parsed; the regex reads a single
+//    scalar. If a matrix is introduced, this rule silently sees only what the
+//    scalar regex matches — worth a follow-up, and stated here rather than
+//    pretended away;
+//  - the manifest side reads the ROOT package.json only. Workspace members
+//    declaring their own @types/node are not compared (they are kept in step by
+//    the root today — measured: all five carry the same specifier).
+
+interface WorkflowHit {
+  readonly file: string;
+  readonly line: number;
+  readonly value: string;
+}
+
+const NODE_VERSION_RE = /node-version:\s*["']?(\d+)(?:\.[\d.]+)?["']?/;
+const PLAYWRIGHT_IMAGE_RE = /mcr\.microsoft\.com\/playwright:v([0-9]+\.[0-9]+\.[0-9]+)/;
+
+/** Strip a semver range prefix: "^1.62.1" → "1.62.1", "~22.20.1" → "22.20.1". */
+function baseVersion(specifier: string): string {
+  return specifier.replace(/^[\^~>=<\s]+/, "").trim();
+}
+
+function majorOf(version: string): number {
+  return Number.parseInt(version.split(".")[0] ?? "", 10);
+}
+
+async function collect(
+  ctx: RuleContext,
+  files: readonly string[],
+  re: RegExp,
+): Promise<WorkflowHit[]> {
+  const out: WorkflowHit[] = [];
+  for (const file of files) {
+    const content = await ctx.readFile(file);
+    const lines = content.split("\n");
+    for (let i = 0; i < lines.length; i += 1) {
+      const raw = lines[i] ?? "";
+      if (raw.trimStart().startsWith("#")) continue;
+      const m = re.exec(raw);
+      if (m && m[1]) out.push({ file, line: i + 1, value: m[1] });
+    }
+  }
+  return out;
+}
+
+export default {
+  rules: {
+    "manifest-environment-version-parity": {
+      description:
+        "A version declared in both a manifest and the CI environment (container tag, node-version) must not drift — Dependabot bumps the manifest and cannot see the environment",
+      severity: "error",
+      async check(ctx) {
+        const workflows = await ctx.glob(".github/workflows/*.yml");
+        const manifest = JSON.parse(await ctx.readFile("package.json")) as {
+          dependencies?: Record<string, string>;
+          devDependencies?: Record<string, string>;
+        };
+        const deps = { ...manifest.dependencies, ...manifest.devDependencies };
+
+        // ── pair 1: @playwright/test ↔ container image tag ────────────────────
+        const pwSpec = deps["@playwright/test"];
+        const images = await collect(ctx, workflows, PLAYWRIGHT_IMAGE_RE);
+        if (pwSpec && images.length > 0) {
+          const want = baseVersion(pwSpec);
+          for (const hit of images) {
+            if (hit.value === want) continue;
+            ctx.report.violation({
+              message: `Playwright version drift: package.json declares @playwright/test ${pwSpec} (→ ${want}), this container image pins v${hit.value}. The browsers come from the IMAGE, so the harness will ask for a revision the image does not ship and every browser test fails with "Executable doesn't exist at /ms-playwright/…".`,
+              file: hit.file,
+              line: hit.line,
+              fix: `Bump the image tag to mcr.microsoft.com/playwright:v${want}-jammy in EVERY occurrence (there are ${images.length} in this repo), or lower the npm version to match.`,
+            });
+          }
+        }
+
+        // ── pair 2: @types/node major ↔ minimum node-version ──────────────────
+        const typesSpec = deps["@types/node"];
+        const nodeVersions = await collect(ctx, workflows, NODE_VERSION_RE);
+        if (typesSpec && nodeVersions.length > 0) {
+          const typesMajor = majorOf(baseVersion(typesSpec));
+          let lowest = nodeVersions[0]!;
+          for (const hit of nodeVersions) {
+            if (Number.parseInt(hit.value, 10) < Number.parseInt(lowest.value, 10)) {
+              lowest = hit;
+            }
+          }
+          const lowestMajor = Number.parseInt(lowest.value, 10);
+          if (Number.isFinite(typesMajor) && typesMajor > lowestMajor) {
+            ctx.report.violation({
+              message: `Node types outrun the runtime: package.json declares @types/node ${typesSpec} (major ${typesMajor}) while this workflow runs Node ${lowestMajor} — the LOWEST in the repo. tsc will then accept APIs that do not exist at run time (measured: \`new URLPattern(...)\`, a Node-24 global, errors under @types/node@22 and compiles clean under 26), and CI stays green because it compiles rather than runs.`,
+              file: lowest.file,
+              line: lowest.line,
+              fix: `Raise this workflow's node-version to ${typesMajor} (and keep the others in step), or lower @types/node to major ${lowestMajor}. Types describing LESS than the runtime is safe; describing more is the hole.`,
+            });
+          }
+        }
+      },
+    },
+  },
+} satisfies RuleSet;

--- a/.github/workflows/living-docs.yml
+++ b/.github/workflows/living-docs.yml
@@ -67,7 +67,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
 
       - name: Install generator deps (docs-site, standalone)
         working-directory: docs-site


### PR DESCRIPTION
Closes #4162.

## Наблюдаемое

Версия объявлена в **двух** местах — в манифесте и в описании окружения, — а бампается в одном. Dependabot читает манифесты; окружение записано **инлайном в воркфлоу**, и он его не видит. Сравнить их было нечем.

За один час 2026-08-20 класс всплыл **дважды**, и формы отказа **противоположны**:

| пара | манифест | окружение | симптом |
|---|---|---|---|
| Playwright | `@playwright/test` 1.57 → 1.62 (#4163) | `container: mcr.microsoft.com/playwright:v1.57.0-jammy`, **3** вхождения в `ci.yml` | `test-component`: **322 failed**, все — `Executable doesn't exist at /ms-playwright/chromium_headless_shell-1234/…` |
| Node | `@types/node` 20 → 26 (#4147) | `node-version: "22"` (8 воркфлоу), один на 20 | ⛔ **ничего**: CI зелёный, он компилирует, а не исполняет |

Вторая строка — причина существования правила. Зелёный CI **не является** проверкой этой оси и не может ею быть: `tsc` принимает API, которого в рантайме нет, а `ReferenceError` ждёт первого вызова. Предъявлено на реальном `packages/core/tsconfig.json` (`lib: ES2020/ES2022`, **без DOM** ⇒ глобал приходит только из `@types/node`):

| типы | `new URLPattern({ pathname: "/x" })` — глобал Node 24 |
|---|---|
| `@types/node@22.20.1` | 1 ошибка |
| `@types/node@26.2.0` | **0 ошибок** |

## Предикаты асимметричны — и это ЗАМЕР, а не стиль

- **Playwright — точное равенство.** Браузеры живут в образе, харнесс просит ревизию, которой ждёт его npm-версия.
  ⛤ Мягкий вариант (`major.minor`) рассматривался и **отвергнут**: main нёс `^1.56.1` против образа `v1.57.0` и был зелёным ⇒ какой-то зазор терпится. Но ширина зазора апстримом не документирована, а «на одном миноре повезло» — не контракт. Равенство — единственная граница, не требующая гадать, где терпимость кончается.
- **Node — major типов ≤ МИНИМАЛЬНОГО `node-version`**, не равенство. Типы, описывающие **меньше** рантайма, безопасны (нельзя затипизировать API, которого у тебя нет); описывающие больше — и есть дыра. Минимум, а не максимум: самый старый воркфлоу — то место, где код упадёт первым.

## Revert-verify (archgate **0.50.0** — пиненная в CI; локальная 0.43.0 это другая версия)

Контроль: `total 25 → 26`, CI-001 `pass`, 0 violations. ⛔ Рост счётчика доказывает **регистрацию**, а не срабатывание — поэтому 4 мутанта:

| мутант | ожидал | факт |
|---|---|---|
| один образ откатить на 1.57 | 1 violation, Playwright | ✅ 1 |
| **все три** образа откатить | **3** violations | ✅ 3 — репортит каждое вхождение, а не первое |
| `living-docs` вернуть на Node 20 | 1 violation, Node | ✅ 1 |
| типы поднять до 26 | 1 violation, Node | ✅ 1 |

Дерево после прогона чистое.

## Сопутствующая правка: `living-docs.yml` Node 20 → 22

Это был **единственный** отставший воркфлоу (остальные восемь на 22), и именно он задаёт минимум, против которого меряет предикат. `docs-site` не объявляет `engines`, так что подъём безопасен. Без него правило краснело бы на самом main — то есть было бы отгружено уже нарушенным.

⚠ **Обе пары на main были разъехавшимися до этой сессии** — `^1.56.1` против образа `1.57.0` и типы 22 против воркфлоу на 20. Правило пришлось писать **после** того, как обе привели в порядок (#4163 и эта правка), иначе оно родилось бы красным. Это стоит помнить при добавлении следующей пары в таблицу: сперва замер и выравнивание, потом гейт.

## Ограничения — названы в шапке правила, а не замолчаны

- матрица `node-version: [20, 22]` **не** парсится (regex читает скаляр). Если матрица появится, правило увидит только скалярные объявления — follow-up, а не скрытая дыра;
- сравнивается **корневой** `package.json`; члены воркспейса со своим `@types/node` не участвуют (сегодня все пять несут тот же спецификатор — замерено);
- эвристика построчная, как у `MOBILE-001/002/003/005`.
