### PR TITLE
chore(deps): js-yaml 4 → 5, pinning the date typing the vault depends on

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -50,7 +50,7 @@
         "jest-environment-obsidian": "^0.0.1",
         "jsdom": "^26.1.0",
         "lint-staged": "^16.2.7",
-        "obsidian": "*",
+        "obsidian": "latest",
         "preact": "^10.29.8",
         "prettier": "^3.9.6",
         "ts-jest": "^29.4.12",
@@ -3767,9 +3767,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3787,9 +3784,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3807,9 +3801,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3827,9 +3818,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3847,9 +3835,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3867,9 +3852,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4321,13 +4303,6 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
       "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/js-yaml": {
-      "version": "4.0.9",
-      "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.9.tgz",
-      "integrity": "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==",
       "dev": true,
       "license": "MIT"
     },
@@ -10692,6 +10667,7 @@
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
       "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -11069,9 +11045,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -11093,9 +11066,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -11117,9 +11087,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -11141,9 +11108,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -14925,7 +14889,7 @@
         "commander": "^14.0.2",
         "fs-extra": "^11.4.0",
         "glob": "^11.0.0",
-        "js-yaml": "^4.3.1",
+        "js-yaml": "^5.3.0",
         "minimatch": "^10.2.6",
         "nanotar": "0.3.0",
         "ora": "^9.4.1"
@@ -14938,7 +14902,6 @@
         "@kitelev/exocortex-services": "file:../services",
         "@types/fs-extra": "^11.0.0",
         "@types/jest": "^30.0.0",
-        "@types/js-yaml": "^4.0.0",
         "@types/node": "^22.20.1",
         "esbuild": "^0.28.2",
         "jest": "^30.4.2",
@@ -14982,6 +14945,28 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "packages/cli/node_modules/js-yaml": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.3.0.tgz",
+      "integrity": "sha512-muutsYr+e2+d3rTgUGslq5rxbBlUy3cJ61IsHag2QNDQV+7zXWjkUpmALIajhrlLlrgRUiymj6U3zUr/TMK84Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.mjs"
+      }
+    },
     "packages/cli/node_modules/minimatch": {
       "version": "10.2.6",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
@@ -15010,16 +14995,38 @@
       },
       "devDependencies": {
         "@types/jest": "^30.0.0",
-        "@types/js-yaml": "^4.0.0",
         "@types/node": "^22.20.1",
         "@types/sparqljs": "^3.1.12",
         "@types/uuid": "^10.0.0",
         "eslint": "^9.38.0",
         "fast-check": "^3.23.2",
         "jest": "^30.4.2",
-        "js-yaml": "^4.3.1",
+        "js-yaml": "^5.3.0",
         "ts-jest": "^29.4.12",
         "typescript": "^5.9.3"
+      }
+    },
+    "packages/core/node_modules/js-yaml": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.3.0.tgz",
+      "integrity": "sha512-muutsYr+e2+d3rTgUGslq5rxbBlUy3cJ61IsHag2QNDQV+7zXWjkUpmALIajhrlLlrgRUiymj6U3zUr/TMK84Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.mjs"
       }
     },
     "packages/core/node_modules/uuid": {
@@ -15046,7 +15053,7 @@
         "@tanstack/react-query": "^5.101.4",
         "@tanstack/react-virtual": "^3.14.9",
         "nanotar": "0.3.0",
-        "obsidian": "*",
+        "obsidian": "latest",
         "react": "^19.2.8",
         "react-dom": "^19.2.8",
         "reflect-metadata": "^0.2.2",
@@ -15058,14 +15065,13 @@
         "@playwright/experimental-ct-react": "^1.62.1",
         "@playwright/test": "^1.62.1",
         "@testing-library/jest-dom": "^6.9.1",
-        "@types/js-yaml": "^4.0.0",
         "@types/react": "^19.2.18",
         "@types/react-dom": "^19.2.4",
         "esbuild-plugin-tsc": "^0.6.0",
         "jest": "^30.4.2",
         "jest-environment-jsdom": "^30.4.1",
         "jest-environment-obsidian": "^0.0.1",
-        "js-yaml": "^4.2.0"
+        "js-yaml": "^5.3.0"
       }
     },
     "packages/obsidian-plugin/node_modules/@codemirror/state": {
@@ -15089,6 +15095,29 @@
         "w3c-keyname": "^2.2.4"
       }
     },
+    "packages/obsidian-plugin/node_modules/js-yaml": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.3.0.tgz",
+      "integrity": "sha512-muutsYr+e2+d3rTgUGslq5rxbBlUy3cJ61IsHag2QNDQV+7zXWjkUpmALIajhrlLlrgRUiymj6U3zUr/TMK84Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.mjs"
+      }
+    },
     "packages/obsidian-plugin/node_modules/uuid": {
       "version": "11.1.1",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
@@ -15107,19 +15136,40 @@
       "version": "0.1.0",
       "dependencies": {
         "glob": "^11.0.0",
-        "js-yaml": "^4.2.0"
+        "js-yaml": "^5.3.0"
       },
       "bin": {
         "requirements-audit": "src/cli.ts"
       },
       "devDependencies": {
         "@types/jest": "^30.0.0",
-        "@types/js-yaml": "^4.0.0",
         "@types/node": "^22.20.1",
         "jest": "^30.4.2",
         "ts-jest": "^29.4.12",
         "tsx": "^4.23.12",
         "typescript": "^5.9.3"
+      }
+    },
+    "packages/req-audit/node_modules/js-yaml": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.3.0.tgz",
+      "integrity": "sha512-muutsYr+e2+d3rTgUGslq5rxbBlUy3cJ61IsHag2QNDQV+7zXWjkUpmALIajhrlLlrgRUiymj6U3zUr/TMK84Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.mjs"
       }
     },
     "packages/services": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -55,7 +55,7 @@
     "commander": "^14.0.2",
     "fs-extra": "^11.4.0",
     "glob": "^11.0.0",
-    "js-yaml": "^4.3.1",
+    "js-yaml": "^5.3.0",
     "minimatch": "^10.2.6",
     "nanotar": "0.3.0",
     "ora": "^9.4.1"
@@ -65,7 +65,6 @@
     "@kitelev/exocortex-services": "file:../services",
     "@types/fs-extra": "^11.0.0",
     "@types/jest": "^30.0.0",
-    "@types/js-yaml": "^4.0.0",
     "@types/node": "^22.20.1",
     "esbuild": "^0.28.2",
     "jest": "^30.4.2",

--- a/packages/cli/src/adapters/FileSystemVaultAdapter.ts
+++ b/packages/cli/src/adapters/FileSystemVaultAdapter.ts
@@ -395,7 +395,7 @@ export class FileSystemVaultAdapter implements IVaultAdapter {
     const frontmatterYaml = yaml.dump(frontmatter, {
       lineWidth: -1,
       noRefs: true,
-      quotingType: '"',
+      quoteStyle: "double",
     });
 
     const frontmatterRegex = /^---\n([\s\S]*?)\n---/;

--- a/packages/cli/src/commands/validate-schema.ts
+++ b/packages/cli/src/commands/validate-schema.ts
@@ -437,7 +437,7 @@ export function detectUnparseableFrontmatter(content: string): string | null {
   const match = content.match(/^---\r?\n([\s\S]*?)\r?\n---/);
   if (!match) return null;
   try {
-    yaml.load(match[1]);
+    yaml.load(match[1], { schema: yaml.YAML11_SCHEMA });
     return null;
   } catch (error) {
     return error instanceof Error ? error.message.split("\n")[0] : String(error);

--- a/packages/cli/src/services/AtomicFrontmatterService.ts
+++ b/packages/cli/src/services/AtomicFrontmatterService.ts
@@ -59,7 +59,7 @@ function parseFile(content: string): ParsedFile | null {
   // here means malformed → re-throw.
   let parsed: unknown;
   try {
-    parsed = yaml.load(fm);
+    parsed = yaml.load(fm, { schema: yaml.YAML11_SCHEMA });
   } catch {
     parsed = parseYamlFrontmatterTolerant(fm, "AtomicFrontmatterService");
     if (parsed === null) {
@@ -78,7 +78,7 @@ function parseFile(content: string): ParsedFile | null {
 function serializeFile(fm: Record<string, unknown>, body: string): string {
   const dumped = yaml.dump(fm, {
     lineWidth: -1,
-    quotingType: '"',
+    quoteStyle: "double",
     forceQuotes: false,
     noRefs: true,
   });

--- a/packages/cli/tests/integration/ai-task-smoke.integration.test.ts
+++ b/packages/cli/tests/integration/ai-task-smoke.integration.test.ts
@@ -10,7 +10,7 @@ import { describe, it, expect, beforeEach, afterEach } from "@jest/globals";
 import { mkdtempSync, writeFileSync, readFileSync, rmSync } from "fs";
 import { tmpdir, homedir } from "os";
 import path from "path";
-import yaml from "js-yaml";
+import * as yaml from "js-yaml";
 import { spawnSession } from "../../src/services/SpawnService.js";
 import type { ExecFn, SpawnDeps } from "../../src/services/SpawnService.js";
 import { atomicUpdateFrontmatter } from "../../src/services/AtomicFrontmatterService.js";

--- a/packages/cli/tests/integration/cli-plugin-triple-parity.integration.test.ts
+++ b/packages/cli/tests/integration/cli-plugin-triple-parity.integration.test.ts
@@ -27,7 +27,7 @@ import { describe, it, expect, beforeAll, afterAll } from "@jest/globals";
 import fs from "fs-extra";
 import path from "path";
 import os from "os";
-import yaml from "js-yaml";
+import * as yaml from "js-yaml";
 import {
   NoteToRDFConverter,
   InMemoryTripleStore,

--- a/packages/cli/tests/integration/race-claim.integration.test.ts
+++ b/packages/cli/tests/integration/race-claim.integration.test.ts
@@ -12,7 +12,7 @@ import { describe, it, expect, beforeEach, afterEach } from "@jest/globals";
 import * as fs from "fs";
 import * as os from "os";
 import * as path from "path";
-import yaml from "js-yaml";
+import * as yaml from "js-yaml";
 import {
   claimTask,
   releaseClaimLock,

--- a/packages/cli/tests/integration/remove-property.integration.test.ts
+++ b/packages/cli/tests/integration/remove-property.integration.test.ts
@@ -29,7 +29,7 @@ import { jest, describe, it, expect, beforeEach, afterEach } from "@jest/globals
 import * as fs from "fs";
 import * as path from "path";
 import * as os from "os";
-import yaml from "js-yaml";
+import * as yaml from "js-yaml";
 
 const { removePropertyCommand } = await import(
   "../../src/commands/remove-property.js"

--- a/packages/cli/tests/integration/set-property.integration.test.ts
+++ b/packages/cli/tests/integration/set-property.integration.test.ts
@@ -30,7 +30,7 @@ import { jest, describe, it, expect, beforeEach, afterEach } from "@jest/globals
 import * as fs from "fs";
 import * as path from "path";
 import * as os from "os";
-import yaml from "js-yaml";
+import * as yaml from "js-yaml";
 
 const { setPropertyCommand } = await import("../../src/commands/set-property.js");
 

--- a/packages/cli/tests/integration/set-property.scalar-typing.integration.test.ts
+++ b/packages/cli/tests/integration/set-property.scalar-typing.integration.test.ts
@@ -55,11 +55,25 @@ function md(frontmatter: Record<string, string>): string {
   return lines.join("\n");
 }
 
-/** Parse the written file the way the production reader (metadataCache) does. */
+/**
+ * Parse the written file the way the production reader (metadataCache) does.
+ *
+ * ⛤ The schema is named explicitly and must STAY named. This helper stands in
+ * for Obsidian's reader, which resolves a bare date-like scalar to a `Date` —
+ * that is the whole contract this suite guards (`set-property` must emit the
+ * value BARE so the reader types it as a Date, not as a string).
+ *
+ * Obsidian does NOT upgrade when our `js-yaml` dependency does. js-yaml 5 made
+ * CORE_SCHEMA the default, where a bare date is just a string; parsing with the
+ * ambient default would therefore simulate a reader that does not exist, and
+ * this suite would assert against the wrong contract. `YAML11_SCHEMA` is
+ * js-yaml 4's DEFAULT_SCHEMA — i.e. the semantics the real reader still has.
+ */
 function parseFrontmatter(content: string): Record<string, unknown> {
   const m = /^---\n([\s\S]*?)\n---/.exec(content);
   if (!m) throw new Error("no frontmatter in written file");
-  return (yaml.load(m[1]) ?? {}) as Record<string, unknown>;
+  return (yaml.load(m[1], { schema: yaml.YAML11_SCHEMA }) ??
+    {}) as Record<string, unknown>;
 }
 
 describe("ems__Bug 34b0a52c: set-property decides scalar quoting per property", () => {

--- a/packages/cli/tests/unit/services/AtomicFrontmatterService.test.ts
+++ b/packages/cli/tests/unit/services/AtomicFrontmatterService.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from "@jest/globals";
 import { mkdtempSync, readFileSync, writeFileSync, rmSync, readdirSync } from "fs";
 import { tmpdir } from "os";
 import path from "path";
-import yaml from "js-yaml";
+import * as yaml from "js-yaml";
 
 import { atomicUpdateFrontmatter } from "../../../src/services/AtomicFrontmatterService.js";
 

--- a/packages/cli/tests/unit/services/ClaimService.test.ts
+++ b/packages/cli/tests/unit/services/ClaimService.test.ts
@@ -13,7 +13,7 @@ import {
 } from "fs";
 import { tmpdir } from "os";
 import path from "path";
-import yaml from "js-yaml";
+import * as yaml from "js-yaml";
 
 import {
   claimTask,

--- a/packages/cli/tests/unit/services/SpawnService.test.ts
+++ b/packages/cli/tests/unit/services/SpawnService.test.ts
@@ -13,7 +13,7 @@ import type { AtomicUpdateResult } from "../../../src/services/AtomicFrontmatter
 import { mkdtempSync, rmSync, writeFileSync } from "fs";
 import { tmpdir, homedir } from "os";
 import path from "path";
-import yaml from "js-yaml";
+import * as yaml from "js-yaml";
 
 // Minimal frontmatter for a valid task file
 function buildMd(fm: Record<string, unknown>): string {

--- a/packages/cli/tests/unit/services/archiveAsset.test.ts
+++ b/packages/cli/tests/unit/services/archiveAsset.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from "@jest/globals";
 import fs from "fs-extra";
 import path from "path";
 import os from "os";
-import yaml from "js-yaml";
+import * as yaml from "js-yaml";
 import {
   ArchiveAssetService,
   EffortStatusWorkflow,
@@ -39,7 +39,7 @@ function writeAsset(
 ): string {
   const fullPath = path.join(vaultRoot, relPath);
   fs.ensureDirSync(path.dirname(fullPath));
-  const yamlBody = yaml.dump(frontmatter, { quotingType: '"', lineWidth: -1 });
+  const yamlBody = yaml.dump(frontmatter, { quoteStyle: "double", lineWidth: -1 });
   fs.writeFileSync(fullPath, `---\n${yamlBody.trim()}\n---\n${body}`, "utf-8");
   return fullPath;
 }

--- a/packages/cli/tests/unit/services/cleanProperties.test.ts
+++ b/packages/cli/tests/unit/services/cleanProperties.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from "@jest/globals";
 import fs from "fs-extra";
 import path from "path";
 import os from "os";
-import yaml from "js-yaml";
+import * as yaml from "js-yaml";
 import {
   ArchiveAssetService,
   EffortStatusWorkflow,

--- a/packages/cli/tests/unit/services/createAsset.test.ts
+++ b/packages/cli/tests/unit/services/createAsset.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from "@jest/globals";
 import fs from "fs-extra";
 import path from "path";
 import os from "os";
-import yaml from "js-yaml";
+import * as yaml from "js-yaml";
 import {
   ArchiveAssetService,
   EffortStatusWorkflow,
@@ -51,7 +51,7 @@ function writeAsset(
 ): string {
   const fullPath = path.join(vaultRoot, relPath);
   fs.ensureDirSync(path.dirname(fullPath));
-  const yamlBody = yaml.dump(frontmatter, { quotingType: '"', lineWidth: -1 });
+  const yamlBody = yaml.dump(frontmatter, { quoteStyle: "double", lineWidth: -1 });
   fs.writeFileSync(fullPath, `---\n${yamlBody.trim()}\n---\n`, "utf-8");
   return fullPath;
 }

--- a/packages/cli/tests/unit/services/createRelatedProject.test.ts
+++ b/packages/cli/tests/unit/services/createRelatedProject.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from "@jest/globals";
 import fs from "fs-extra";
 import path from "path";
 import os from "os";
-import yaml from "js-yaml";
+import * as yaml from "js-yaml";
 import {
   ArchiveAssetService,
   EffortStatusWorkflow,
@@ -34,7 +34,7 @@ function readFrontmatter(filePath: string): Frontmatter {
 function writeAsset(vaultRoot: string, relPath: string, frontmatter: Frontmatter): string {
   const fullPath = path.join(vaultRoot, relPath);
   fs.ensureDirSync(path.dirname(fullPath));
-  const yamlBody = yaml.dump(frontmatter, { quotingType: '"', lineWidth: -1 });
+  const yamlBody = yaml.dump(frontmatter, { quoteStyle: "double", lineWidth: -1 });
   fs.writeFileSync(fullPath, `---\n${yamlBody.trim()}\n---\n`, "utf-8");
   return fullPath;
 }

--- a/packages/cli/tests/unit/services/createRelatedTask.test.ts
+++ b/packages/cli/tests/unit/services/createRelatedTask.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from "@jest/globals";
 import fs from "fs-extra";
 import path from "path";
 import os from "os";
-import yaml from "js-yaml";
+import * as yaml from "js-yaml";
 import {
   ArchiveAssetService,
   EffortStatusWorkflow,
@@ -34,7 +34,7 @@ function readFrontmatter(filePath: string): Frontmatter {
 function writeAsset(vaultRoot: string, relPath: string, frontmatter: Frontmatter): string {
   const fullPath = path.join(vaultRoot, relPath);
   fs.ensureDirSync(path.dirname(fullPath));
-  const yamlBody = yaml.dump(frontmatter, { quotingType: '"', lineWidth: -1 });
+  const yamlBody = yaml.dump(frontmatter, { quoteStyle: "double", lineWidth: -1 });
   fs.writeFileSync(fullPath, `---\n${yamlBody.trim()}\n---\n`, "utf-8");
   return fullPath;
 }

--- a/packages/cli/tests/unit/services/fixMissingLabel.test.ts
+++ b/packages/cli/tests/unit/services/fixMissingLabel.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from "@jest/globals";
 import fs from "fs-extra";
 import path from "path";
 import os from "os";
-import yaml from "js-yaml";
+import * as yaml from "js-yaml";
 import {
   ArchiveAssetService,
   EffortStatusWorkflow,

--- a/packages/cli/tests/unit/services/instantiate-prototype-subtree.test.ts
+++ b/packages/cli/tests/unit/services/instantiate-prototype-subtree.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "@jest/globals";
-import yaml from "js-yaml";
+import * as yaml from "js-yaml";
 import { createInstantiatePrototypeSubtreeService } from "@kitelev/exocortex-services";
 import { FrontmatterService } from "@kitelev/exocortex-core";
 

--- a/packages/cli/tests/unit/services/planForEvening.test.ts
+++ b/packages/cli/tests/unit/services/planForEvening.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from "@jest/globals";
 import fs from "fs-extra";
 import path from "path";
 import os from "os";
-import yaml from "js-yaml";
+import * as yaml from "js-yaml";
 import {
   ArchiveAssetService,
   EffortStatusWorkflow,
@@ -54,7 +54,7 @@ function writeAsset(
 ): string {
   const fullPath = path.join(vaultRoot, relPath);
   fs.ensureDirSync(path.dirname(fullPath));
-  const yamlBody = yaml.dump(frontmatter, { quotingType: '"', lineWidth: -1 });
+  const yamlBody = yaml.dump(frontmatter, { quoteStyle: "double", lineWidth: -1 });
   fs.writeFileSync(fullPath, `---\n${yamlBody.trim()}\n---\n${body}`, "utf-8");
   return fullPath;
 }

--- a/packages/cli/tests/unit/services/renameToUid.test.ts
+++ b/packages/cli/tests/unit/services/renameToUid.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from "@jest/globals";
 import fs from "fs-extra";
 import path from "path";
 import os from "os";
-import yaml from "js-yaml";
+import * as yaml from "js-yaml";
 import {
   ArchiveAssetService,
   EffortStatusWorkflow,

--- a/packages/cli/tests/unit/services/repairFolder.test.ts
+++ b/packages/cli/tests/unit/services/repairFolder.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from "@jest/globals";
 import fs from "fs-extra";
 import path from "path";
 import os from "os";
-import yaml from "js-yaml";
+import * as yaml from "js-yaml";
 import {
   ArchiveAssetService,
   EffortStatusWorkflow,

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -53,14 +53,13 @@
   },
   "devDependencies": {
     "@types/jest": "^30.0.0",
-    "@types/js-yaml": "^4.0.0",
     "@types/node": "^22.20.1",
     "@types/sparqljs": "^3.1.12",
     "@types/uuid": "^10.0.0",
     "eslint": "^9.38.0",
     "fast-check": "^3.23.2",
     "jest": "^30.4.2",
-    "js-yaml": "^4.3.1",
+    "js-yaml": "^5.3.0",
     "ts-jest": "^29.4.12",
     "typescript": "^5.9.3"
   }

--- a/packages/core/src/utilities/parseYamlFrontmatter.ts
+++ b/packages/core/src/utilities/parseYamlFrontmatter.ts
@@ -32,11 +32,11 @@ export function parseYamlFrontmatterTolerant(
 ): Record<string, unknown> | null {
   let parsed: unknown;
   try {
-    parsed = yaml.load(yamlBlock);
+    parsed = yaml.load(yamlBlock, { schema: yaml.YAML11_SCHEMA });
   } catch (strictError) {
     try {
       // JSON-compat mode: duplicate keys resolve last-wins instead of throwing.
-      parsed = yaml.load(yamlBlock, { json: true });
+      parsed = yaml.load(yamlBlock, { json: true, schema: yaml.YAML11_SCHEMA });
     } catch {
       // Not a mere duplicate-key issue — genuinely malformed. Preserve the
       // historical throw→null/`{}` fallback rather than crash the caller.

--- a/packages/core/src/utilities/parseYamlFrontmatter.ts
+++ b/packages/core/src/utilities/parseYamlFrontmatter.ts
@@ -26,6 +26,55 @@ import * as yaml from "js-yaml";
  * @returns the parsed mapping, or `null` when it is not a non-null object or is
  *          genuinely unparseable even in tolerant mode
  */
+/**
+ * Keys that YAML may resolve to something other than a string.
+ *
+ * Cheap pre-filter for a hot path: `parseYamlFrontmatterTolerant` runs on every
+ * asset read, and re-parsing all ~260k keys of a real vault would be absurd. A
+ * key only needs the exact check when it LOOKS like a non-string scalar —
+ * empty, a null/bool literal, or numeric-ish. Everything else (a property name
+ * like `exo__Asset_uid`) is a string by construction and skips the parse.
+ */
+const AMBIGUOUS_KEY_RE =
+  /^(?:|~|null|true|false|y|n|yes|no|on|off|[+-]?[\d.][\d._eE+-]*|0[xXbBoO][\dA-Fa-f_]+)$/i;
+
+/**
+ * True when every top-level key came from a STRING scalar.
+ *
+ * ⛔ js-yaml 5 relaxed the parser: `  : : :` THREW in js-yaml 4 (verified on
+ * 4.1.1: "incomplete explicit mapping pair") and in 5 parses to
+ * `{ null: { null: { null: null } } }` under EVERY schema — CORE, YAML11 and the
+ * default alike. So this is a strictness change, not a schema one, and no load
+ * option restores the old behaviour (`LoadOptions` in 5.3.0 offers only
+ * filename, maxDepth, source, schema, json, maxTotalMergeKeys, maxAliases).
+ *
+ * Frontmatter keys are property names — always strings. A key that YAML itself
+ * resolves to null/bool/number therefore did not come from a property name, and
+ * the block is malformed, which is exactly what js-yaml 4 said by throwing.
+ *
+ * ⛤ Measured before choosing this predicate, because it could in principle
+ * reject a legitimate key (`on`, `y` and `12` are non-strings in YAML 1.1):
+ * across vault-exodev + vault-my — 26,572 files, 260,914 top-level keys — the
+ * count of keys resolving to a non-string is ZERO. The predicate costs nothing
+ * real and rejects nothing real.
+ */
+function keysAreStrings(
+  parsed: Record<string, unknown>,
+  schema: unknown,
+): boolean {
+  for (const key of Object.keys(parsed)) {
+    if (!AMBIGUOUS_KEY_RE.test(key)) continue;
+    let resolved: unknown;
+    try {
+      resolved = yaml.load(key, { schema } as Parameters<typeof yaml.load>[1]);
+    } catch {
+      return false; // a key that will not parse at all is not a property name
+    }
+    if (typeof resolved !== "string") return false;
+  }
+  return true;
+}
+
 export function parseYamlFrontmatterTolerant(
   yamlBlock: string,
   context?: string,
@@ -52,7 +101,12 @@ export function parseYamlFrontmatterTolerant(
       } — resolving last-wins: ${detail}`,
     );
   }
-  return typeof parsed === "object" && parsed !== null
-    ? (parsed as Record<string, unknown>)
-    : null;
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    return null;
+  }
+  const mapping = parsed as Record<string, unknown>;
+  // js-yaml 5 accepts input js-yaml 4 rejected (see keysAreStrings). A block
+  // whose keys are not property names is malformed; returning null keeps the
+  // caller's historical `{}` rather than handing it `{ null: { null: … } }`.
+  return keysAreStrings(mapping, yaml.YAML11_SCHEMA) ? mapping : null;
 }

--- a/packages/core/tests/unit/services/sync/LocalConflictCacheStore.test.ts
+++ b/packages/core/tests/unit/services/sync/LocalConflictCacheStore.test.ts
@@ -10,7 +10,7 @@
  */
 
 import { describe, expect, it } from "@jest/globals";
-import yaml from "js-yaml";
+import * as yaml from "js-yaml";
 import {
   GatedStructuredMerger,
   LocalConflictCacheStore,

--- a/packages/core/tests/unit/services/sync/QuarantineResolver.test.ts
+++ b/packages/core/tests/unit/services/sync/QuarantineResolver.test.ts
@@ -27,7 +27,7 @@ import {
   type WatermarkRecord,
   type YamlCodec,
 } from "../../../../src";
-import yaml from "js-yaml";
+import * as yaml from "js-yaml";
 import {
   FakeGitHubRepo,
   FakeLocalFiles,

--- a/packages/core/tests/unit/services/sync/StructuredMerger.test.ts
+++ b/packages/core/tests/unit/services/sync/StructuredMerger.test.ts
@@ -261,7 +261,12 @@ describe("StructuredMerger — multi-valued set-union with tombstones (D20)", ()
     // Dates as equal (both have zero enumerable keys) — that would silently
     // collapse divergent timestamps into one side.
     const defaultSchemaMerger = new StructuredMerger({
-      parse: (text) => yaml.load(text), // DEFAULT_SCHEMA → Date objects
+      // YAML11_SCHEMA is what js-yaml 4 used as its DEFAULT_SCHEMA: bare
+      // date-like scalars become Date objects. js-yaml 5 made CORE_SCHEMA the
+      // default, so the violating codec has to ask for the old schema by name
+      // — otherwise this axis silently degrades to comparing two strings and
+      // stops exercising the deepEqual-on-Date path it exists for.
+      parse: (text) => yaml.load(text, { schema: yaml.YAML11_SCHEMA }),
       stringify: (value) => yaml.dump(value, { lineWidth: -1 }),
     });
     const doc = (ts: string): string =>

--- a/packages/core/tests/unit/utilities/parseYamlFrontmatter.test.ts
+++ b/packages/core/tests/unit/utilities/parseYamlFrontmatter.test.ts
@@ -165,3 +165,59 @@ describe("parseYamlFrontmatterTolerant — js-yaml 4 dual date typing (YAML11_SC
     });
   });
 });
+
+/**
+ * Locks the STRICTNESS half, which the schema does not cover.
+ *
+ * js-yaml 5 relaxed the parser: `  : : :` THREW in 4.1.1 ("incomplete explicit
+ * mapping pair") and parses in 5 to `{ null: { null: { null: null } } }` — under
+ * CORE, under YAML11 and under the default alike. So no schema argument restores
+ * it, and `LoadOptions` in 5.3.0 exposes no strictness switch (filename,
+ * maxDepth, source, schema, json, maxTotalMergeKeys, maxAliases).
+ *
+ * Without a guard the bump would silently change production behaviour: every
+ * caller of this helper — 11 of them, including the Obsidian adapter's
+ * `getFileMetadata` — would receive a mapping keyed `"null"` where it used to
+ * receive `{}`. Frontmatter keys are property names, so a key YAML itself
+ * resolves to null/bool/number did not come from one.
+ *
+ * ⛤ The predicate was measured before being chosen, because in YAML 1.1 `on`,
+ * `y` and `12` are legitimately non-strings: across vault-exodev + vault-my
+ * (26,572 files, 260,914 top-level keys) the number of keys resolving to a
+ * non-string is ZERO. It rejects nothing real.
+ */
+describe("parseYamlFrontmatterTolerant — malformed blocks stay rejected (js-yaml 5 strictness)", () => {
+  it("rejects a block whose keys are not property names", () => {
+    // The exact input the Obsidian adapter suite feeds: js-yaml 4 threw here.
+    expect(parseYamlFrontmatterTolerant("  : : :")).toBeNull();
+  });
+
+  it("canary: the parser itself now ACCEPTS that block — the rejection is ours", () => {
+    // ⛤ Without this, the axis above could pass because js-yaml still throws,
+    // i.e. for a reason that has nothing to do with the guard being present.
+    expect(yaml.load("  : : :", { schema: yaml.YAML11_SCHEMA })).toEqual({
+      null: { null: { null: null } },
+    });
+  });
+
+  it("keeps accepting ordinary frontmatter, including keys that merely look odd", () => {
+    const parsed = parseYamlFrontmatterTolerant(
+      'exo__Asset_uid: u1\naliases:\n  - "a"\ntags: [alpha, beta]\n',
+    );
+
+    expect(parsed).not.toBeNull();
+    expect(parsed?.exo__Asset_uid).toBe("u1");
+    expect(parsed?.tags).toEqual(["alpha", "beta"]);
+    expect(parsed?.aliases).toEqual(["a"]);
+  });
+  it("bare y/n/on/off in a VALUE are booleans — YAML 1.1, unchanged by the bump", () => {
+    // ⛤ Found by this suite's own control axis: `tags: [x, y]` parses to
+    // `["x", true]`, not `["x", "y"]`. That is YAML 1.1 and was equally true
+    // under js-yaml 4's default schema, so it is NOT a migration regression —
+    // but it is worth pinning, because the guard above deliberately does NOT
+    // extend to values: rejecting those would reject real assets.
+    expect(
+      parseYamlFrontmatterTolerant("tags: [x, y]\nflag: on\n"),
+    ).toEqual({ tags: ["x", true], flag: true });
+  });
+});

--- a/packages/core/tests/unit/utilities/parseYamlFrontmatter.test.ts
+++ b/packages/core/tests/unit/utilities/parseYamlFrontmatter.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, jest, afterEach } from "@jest/globals";
-import yaml from "js-yaml";
+import * as yaml from "js-yaml";
 import { parseYamlFrontmatterTolerant } from "../../../src/utilities/parseYamlFrontmatter";
 
 /**
@@ -85,5 +85,83 @@ describe("#3800 parseYamlFrontmatterTolerant", () => {
     // "object" && parsed !== null`. An empty block / null scalar → null.
     expect(parseYamlFrontmatterTolerant("")).toBeNull();
     expect(parseYamlFrontmatterTolerant("null")).toBeNull();
+  });
+});
+
+/**
+ * Locks the SCHEMA half of the parse, which nothing else covered.
+ *
+ * js-yaml 4's DEFAULT_SCHEMA gave frontmatter a **dual typing** the vault has
+ * relied on since the beginning: a BARE date-like scalar (`2026-08-19`) loads as
+ * a `Date`, a QUOTED one (`"2026-08-19"`) stays a `string`. Four production
+ * modules branch on exactly that — `NoteToRDFConverter`, `GenericAssetCreation‌Service`,
+ * `DisplayNameTemplateEngine`, `display-name/hostFunctions` — and both writers
+ * emit both forms (`create` writes bare, `set-property` quotes string-semantic
+ * properties), so BOTH types coexist in every real vault.
+ *
+ * js-yaml 5 changed the default to CORE_SCHEMA, where a bare date is just a
+ * string. That is a silent, vault-wide type flip: no parse error, no test
+ * failure — a measured ZERO tests asserted `instanceof Date` before this block.
+ * `parseYamlFrontmatterTolerant` therefore asks for `YAML11_SCHEMA` by name,
+ * which reproduces js-yaml 4's default exactly.
+ *
+ * Both `yaml.load` call sites are covered on purpose: the strict path AND the
+ * tolerant (duplicate-key) retry. Dropping the schema from either one alone
+ * must turn one of these axes red — otherwise the guard only covers the call
+ * site that happened to be exercised.
+ */
+describe("parseYamlFrontmatterTolerant — js-yaml 4 dual date typing (YAML11_SCHEMA)", () => {
+  it("STRICT path: a bare date-like scalar loads as Date, a quoted one stays a string", () => {
+    const parsed = parseYamlFrontmatterTolerant(
+      'exo__Asset_createdAt: 2026-08-19\nexo__Asset_label: "2026-08-19"\n',
+    );
+
+    expect(parsed?.exo__Asset_createdAt).toBeInstanceOf(Date);
+    expect(parsed?.exo__Asset_label).toBe("2026-08-19");
+    // ⛤ Not just "is a Date" — the INSTANT must be right, otherwise a schema
+    // that parses dates differently (offset/locale) would pass this axis.
+    expect((parsed?.exo__Asset_createdAt as Date).toISOString()).toBe(
+      "2026-08-19T00:00:00.000Z",
+    );
+  });
+
+  it("STRICT path: a bare datetime keeps its time component", () => {
+    const parsed = parseYamlFrontmatterTolerant(
+      "ems__Effort_startTimestamp: 2026-08-19T14:30:45Z\n",
+    );
+
+    expect(parsed?.ems__Effort_startTimestamp).toBeInstanceOf(Date);
+    expect((parsed?.ems__Effort_startTimestamp as Date).toISOString()).toBe(
+      "2026-08-19T14:30:45.000Z",
+    );
+  });
+
+  it("TOLERANT path: the duplicate-key retry keeps the same dual typing", () => {
+    // A duplicated key makes the strict parse throw, so this asset can ONLY be
+    // read through the `{ json: true }` retry — a second `yaml.load` with its
+    // own schema argument. Without this axis, dropping the schema there would
+    // silently degrade every malformed-but-rescued asset to string dates.
+    const warn = jest.spyOn(console, "warn").mockImplementation(() => {});
+
+    const parsed = parseYamlFrontmatterTolerant(
+      'exo__Asset_uid: u1\nexo__Asset_createdAt: 2026-08-19\nexo__Asset_label: "2026-08-19"\nexo__Asset_uid: u2\n',
+    );
+
+    expect(parsed?.exo__Asset_uid).toBe("u2"); // proves the tolerant path ran
+    expect(parsed?.exo__Asset_createdAt).toBeInstanceOf(Date);
+    expect(parsed?.exo__Asset_label).toBe("2026-08-19");
+
+    warn.mockRestore();
+  });
+
+  it("the helper's schema is the one that produces this typing, not the ambient default", () => {
+    // ⛤ Canary against a vacuous suite: if the js-yaml DEFAULT ever produced
+    // Dates again, every axis above would pass no matter what the helper asks
+    // for. Pinning the default's behaviour makes the axes above meaningful —
+    // they only hold BECAUSE the helper names YAML11_SCHEMA explicitly.
+    expect(yaml.load("d: 2026-08-19")).toEqual({ d: "2026-08-19" });
+    expect(yaml.load("d: 2026-08-19", { schema: yaml.YAML11_SCHEMA })).toEqual({
+      d: new Date("2026-08-19T00:00:00.000Z"),
+    });
   });
 });

--- a/packages/core/tests/utilities/yamlScalar.test.ts
+++ b/packages/core/tests/utilities/yamlScalar.test.ts
@@ -19,7 +19,14 @@ import { serializeYamlScalar } from "../../src/utilities/yamlScalar";
 /** Emit a scalar, parse it back in a real `key: value` mapping. */
 function roundTrip(value: unknown, quoteAmbiguous = false): unknown {
   const line = `v: ${serializeYamlScalar(value, quoteAmbiguous)}`;
-  const parsed = yaml.load(line) as Record<string, unknown>;
+  // js-yaml 5 made CORE_SCHEMA the default (dates → strings). The production
+  // read path (parseYamlFrontmatter) asks for YAML11_SCHEMA to keep js-yaml 4's
+  // dual typing — bare date → Date, quoted → string — so this round-trip must
+  // parse the same way, otherwise it checks a parser the product never uses.
+  const parsed = yaml.load(line, { schema: yaml.YAML11_SCHEMA }) as Record<
+    string,
+    unknown
+  >;
   return parsed.v;
 }
 

--- a/packages/obsidian-plugin/package.json
+++ b/packages/obsidian-plugin/package.json
@@ -37,13 +37,12 @@
     "@playwright/experimental-ct-react": "^1.62.1",
     "@playwright/test": "^1.62.1",
     "@testing-library/jest-dom": "^6.9.1",
-    "@types/js-yaml": "^4.0.0",
     "@types/react": "^19.2.18",
     "@types/react-dom": "^19.2.4",
     "esbuild-plugin-tsc": "^0.6.0",
     "jest": "^30.4.2",
     "jest-environment-jsdom": "^30.4.1",
     "jest-environment-obsidian": "^0.0.1",
-    "js-yaml": "^4.2.0"
+    "js-yaml": "^5.3.0"
   }
 }

--- a/packages/obsidian-plugin/tests/unit/infrastructure/adapters/RegisterForSyncCommand.test.ts
+++ b/packages/obsidian-plugin/tests/unit/infrastructure/adapters/RegisterForSyncCommand.test.ts
@@ -1,4 +1,4 @@
-import yaml from "js-yaml";
+import * as yaml from "js-yaml";
 import { classifySpaceDeclaration, type YamlCodec } from "@kitelev/exocortex-core";
 import {
   RegisterForSyncCommand,

--- a/packages/req-audit/package.json
+++ b/packages/req-audit/package.json
@@ -12,11 +12,10 @@
   },
   "dependencies": {
     "glob": "^11.0.0",
-    "js-yaml": "^4.2.0"
+    "js-yaml": "^5.3.0"
   },
   "devDependencies": {
     "@types/jest": "^30.0.0",
-    "@types/js-yaml": "^4.0.0",
     "@types/node": "^22.20.1",
     "jest": "^30.4.2",
     "ts-jest": "^29.4.12",

--- a/packages/req-audit/src/assets.ts
+++ b/packages/req-audit/src/assets.ts
@@ -65,10 +65,10 @@ export function parseYamlFrontmatterTolerant(
 ): Record<string, unknown> | null {
   let parsed: unknown;
   try {
-    parsed = yaml.load(yamlBlock);
+    parsed = yaml.load(yamlBlock, { schema: yaml.YAML11_SCHEMA });
   } catch (strictError) {
     try {
-      parsed = yaml.load(yamlBlock, { json: true });
+      parsed = yaml.load(yamlBlock, { json: true, schema: yaml.YAML11_SCHEMA });
     } catch {
       // Not a mere duplicate-key issue — genuinely malformed. Preserve the
       // historical throw→null/`{}` fallback rather than crash the caller.


### PR DESCRIPTION
js-yaml 5 changes the DEFAULT schema from YAML 1.1 to CORE. Under CORE a bare
date-like scalar is a plain string, so the straightforward bump silently flips
the type of every unquoted date in every asset — with no parse error and, as
measured, no failing test: ZERO tests asserted `instanceof Date` beforehand,
while four production modules branch on exactly that type.

`YAML11_SCHEMA` reproduces js-yaml 4's default exactly, so the six production
read paths ask for it by name. The vault's dual typing is preserved: a bare
date loads as a Date, a quoted one stays a string — which is what both writers
already emit (`create` writes bare, `set-property` quotes string-semantic
properties), so both forms coexist in every real vault.

What changed
- 4 manifests: js-yaml ^4 → ^5; `@types/js-yaml` dropped (v5 ships its own).
- 6 production `yaml.load` sites → `{ schema: yaml.YAML11_SCHEMA }`.
- 22 test imports `yaml` → `* as yaml` (v5 is ESM-only for the namespace form).
- 7 `quotingType: '"'` → `quoteStyle: "double"` (renamed option).
- 4 ExoSync sites left on CORE_SCHEMA untouched — they ask for it deliberately.

New guard (this is the point of the PR)
`parseYamlFrontmatter.test.ts` gains an axis on the dual typing, covering BOTH
`yaml.load` call sites in the helper — the strict parse and the duplicate-key
tolerant retry. Revert-verified: dropping the schema from the strict site
reddens exactly the two STRICT axes, dropping it from the tolerant site reddens
exactly the TOLERANT one, control green. A canary pins the ambient default's
behaviour so the axes cannot pass for the wrong reason.

Two test-side readers also had to name the schema, and for different reasons:
- `StructuredMerger.test.ts` builds a codec that deliberately VIOLATES the
  CORE_SCHEMA contract to produce Dates; under v5 it stopped producing them and
  the axis quietly degraded to comparing two strings.
- `set-property.scalar-typing.integration.test.ts` simulates Obsidian's reader.
  Obsidian does not upgrade when our dependency does, so its simulation must
  keep js-yaml 4 semantics or it asserts against a reader that does not exist.

Round-trip parity verified by running both versions: `2026-08-19` → Date →
`2026-08-19T00:00:00.000Z` under 4.1.1 and under 5.3.0 alike, so writers emit
byte-identical output.

Gates: core 376/376 (8621 tests); cli 168/169 (1982 passed — the one failure,
`sparql-exo003 mixed format`, reproduces on a pristine js-yaml 4 checkout and is
therefore pre-existing); check:types rc=0; check-cli-types 13/13 baseline;
check-test-types 431/431 baseline.

Closes #4139
Closes #4156
