### PR TITLE
feat(archgate): CI-002 — published engines must not be weaker than its deps'

### DIFF
--- a/.archgate/adrs/CI-002-published-engines-not-weaker-than-deps.md
+++ b/.archgate/adrs/CI-002-published-engines-not-weaker-than-deps.md
@@ -1,0 +1,81 @@
+---
+id: CI-002
+title: A published package must not promise an older Node than its dependencies require
+domain: ci
+rules: true
+files: ["packages/*/package.json", "package-lock.json"]
+---
+
+# Published `engines` ↔ Dependency `engines`
+
+## Context
+
+A package we publish declares `engines.node`. Every dependency it pulls declares
+its own. Nothing in the repository compares the two, so a routine dependency
+bump can raise what the code **requires** without touching what the manifest
+**promises**.
+
+Measured on 2026-08-21 (PR #4169, `commander` 14 → 15), read from the lockfile:
+
+```
+packages/cli/node_modules/commander  15.0.0  engines: { node: '>=22.12.0' }
+packages/cli/package.json                    engines: { node: '>=20.0.0'  }
+```
+
+The published package promised Node 20 and required 22.12.
+
+## The part that makes this a rule rather than a checklist item
+
+CI cannot catch it **by construction**. The workflows run `node-version: "22"`,
+which resolves above 22.12, so every job is green. The gap exists precisely
+where we do not test — at a consumer on Node 20 — and none of the required
+checks reads `engines` at all.
+
+The failure therefore surfaces as somebody else's install error, days later,
+with no signal on our side. That is the same shape as CI-001's Node pair: a
+green pipeline is not evidence, because the pipeline never exercises the
+declaration.
+
+## Relationship to CI-001
+
+CI-001 compares a manifest against the **CI environment**. This is the third
+form of one class, and its second side is different:
+
+| # | manifest | second side | caught today |
+|---|---|---|---|
+| #4163 | `@playwright/test` | container tag in `ci.yml` | CI (322 red) + CI-001 |
+| #4147 / #4161 | `@types/node` | `node-version:` | CI compiles, does not run → CI-001 |
+| **this** | our `engines` | **dependencies' `engines`** | nothing — breaks at the consumer |
+
+The data source differs (`package-lock.json`, not a workflow), which is why it
+is a separate rule rather than a third pair inside CI-001.
+
+## Decision
+
+For every **published** package (`private` not `true`) that declares
+`engines.node`, compare its floor against the floor of each **direct**
+dependency's `engines.node`, resolved through `package-lock.json` (nearest
+entry first, matching npm resolution). A dependency floor **above** ours is a
+violation.
+
+## Limits — chosen, not overlooked
+
+1. **Direct dependencies only.** Transitive requirements are not ours to
+   satisfy, and their declarations are often absent or stale; including them
+   would bury the actionable signal under noise.
+
+2. **Lower bounds, not range containment.** `engines` may be a disjunction —
+   `20 || >=22` and `^12.17.0 || ^14.13 || >=16.0.0` both appear in this
+   lockfile today — and the rule compares the lowest version each side admits.
+   This catches "the dependency needs a newer Node than we promise", the shape
+   that shipped. It does not catch a hole *inside* a disjunction (we allow Node
+   21 while a dependency admits `20 || >=22`). Closing that needs a real semver
+   implementation, and rule files may import only `node:*`.
+
+## Consequences
+
+- A `commander`-style bump now fails `archgate` instead of reaching npm.
+- Raising `engines` becomes an explicit, reviewed act rather than a silent
+  omission.
+- Adding a published package with no `engines` declaration stays allowed — the
+  rule only fires where a promise exists to contradict.

--- a/.archgate/adrs/CI-002-published-engines-not-weaker-than-deps.rules.ts
+++ b/.archgate/adrs/CI-002-published-engines-not-weaker-than-deps.rules.ts
@@ -1,0 +1,135 @@
+/// <reference path="../rules.d.ts" />
+
+// CI-002 — a published package promising a Node it cannot actually run on.
+//
+// A package we publish declares `engines.node`. Its dependencies declare theirs.
+// Nothing compares the two, so a routine dependency bump can raise what the code
+// REQUIRES without touching what the manifest PROMISES — and the two drift.
+//
+// ⛤ MEASURED on 2026-08-21 (PR #4169, commander 14 → 15), read from the lockfile
+// rather than from release notes:
+//
+//     packages/cli/node_modules/commander  15.0.0  engines: { node: '>=22.12.0' }
+//     packages/cli/package.json                    engines: { node: '>=20.0.0'  }
+//
+// ⇒ the published package promised Node 20 and required 22.12.
+//
+// ⛔ CI cannot catch this BY CONSTRUCTION. It runs `node-version: "22"`, which
+// resolves above 22.12, so the gap lives exactly where we do not test — at a
+// consumer on Node 20. None of the required checks reads `engines` at all. The
+// failure surfaces as somebody else's `SyntaxError`, in their install, days later.
+//
+// ── Relationship to CI-001 ───────────────────────────────────────────────────
+// CI-001 compares a manifest against the CI ENVIRONMENT (container tag,
+// `node-version:`). This is the third form of the same class — manifest against
+// the MANIFESTS OF ITS DEPENDENCIES — and the data source differs
+// (`package-lock.json`, not a workflow file), which is why it is a separate rule
+// rather than a third pair inside CI-001.
+//
+// ── Two limits, both deliberate, both stated rather than implied ─────────────
+//
+//  1. DIRECT dependencies only. Transitive requirements are not ours to satisfy,
+//     and their declarations are frequently absent or stale; including them would
+//     bury the signal we can act on under noise we cannot.
+//
+//  2. LOWER BOUNDS only, not full range containment. `engines` may be a
+//     disjunction (`20 || >=22`, `^12.17.0 || ^14.13 || >=16.0.0` — both live in
+//     this lockfile today), and this rule compares the LOWEST version each side
+//     admits. It therefore catches "the dependency needs a newer Node than we
+//     promise", which is the shape that shipped. It does NOT catch a hole inside
+//     a disjunction — e.g. we allow Node 21 while a dependency admits `20 || >=22`.
+//     Closing that needs a real semver-range implementation; rule files may only
+//     import `node:*`, so that would mean vendoring one. Named here so the next
+//     reader knows the boundary is chosen, not overlooked.
+
+interface Manifest {
+  readonly name?: string;
+  readonly private?: boolean;
+  readonly engines?: { readonly node?: string };
+  readonly dependencies?: Record<string, string>;
+}
+
+interface LockEntry {
+  readonly engines?: { readonly node?: string };
+}
+
+type Version = readonly [number, number, number];
+
+/**
+ * The lowest Node version a range admits.
+ *
+ * A disjunction is "any of", so its floor is the MINIMUM across branches — not
+ * the first one written. Missing minor/patch count as 0 (`20` → 20.0.0), which
+ * is what a bare major means.
+ */
+function lowestAdmitted(range: string | undefined): Version | null {
+  if (!range) return null;
+  let lowest: Version | null = null;
+  for (const branch of range.split("||")) {
+    const m = /(\d+)(?:\.(\d+))?(?:\.(\d+))?/.exec(branch);
+    if (!m) continue;
+    const v: Version = [
+      Number.parseInt(m[1] ?? "0", 10),
+      Number.parseInt(m[2] ?? "0", 10),
+      Number.parseInt(m[3] ?? "0", 10),
+    ];
+    if (lowest === null || compare(v, lowest) < 0) lowest = v;
+  }
+  return lowest;
+}
+
+function compare(a: Version, b: Version): number {
+  for (let i = 0; i < 3; i += 1) {
+    const d = (a[i] ?? 0) - (b[i] ?? 0);
+    if (d !== 0) return d;
+  }
+  return 0;
+}
+
+const show = (v: Version): string => v.join(".");
+
+export default {
+  rules: {
+    "published-engines-not-weaker-than-deps": {
+      description:
+        "A published package's engines.node must not promise an older Node than its direct dependencies require — CI runs one version and cannot see the gap",
+      severity: "error",
+      async check(ctx) {
+        const lock = JSON.parse(await ctx.readFile("package-lock.json")) as {
+          packages?: Record<string, LockEntry>;
+        };
+        const lockPackages = lock.packages ?? {};
+
+        for (const manifestPath of await ctx.glob("packages/*/package.json")) {
+          const manifest = JSON.parse(
+            await ctx.readFile(manifestPath),
+          ) as Manifest;
+          if (manifest.private === true) continue; // not published — no consumer to mislead
+
+          const ours = lowestAdmitted(manifest.engines?.node);
+          if (ours === null) continue; // no promise made, nothing to contradict
+
+          const packageDir = manifestPath.replace(/\/package\.json$/, "");
+
+          for (const dep of Object.keys(manifest.dependencies ?? {})) {
+            // npm hoists, so the dependency sits either beside the member or at
+            // the root. Nearest wins, exactly as resolution does.
+            const entry =
+              lockPackages[`${packageDir}/node_modules/${dep}`] ??
+              lockPackages[`node_modules/${dep}`];
+            const theirs = lowestAdmitted(entry?.engines?.node);
+            if (theirs === null) continue; // dependency states no requirement
+
+            if (compare(theirs, ours) > 0) {
+              ctx.report.violation({
+                message: `${manifest.name ?? packageDir} promises engines.node ${manifest.engines?.node} (floor ${show(ours)}) but its dependency ${dep} requires ${entry?.engines?.node} (floor ${show(theirs)}). Installing this package on Node ${show(ours)} therefore satisfies our manifest and breaks on ${dep}. CI cannot see this: it runs a single Node version, above both floors.`,
+                file: manifestPath,
+                fix: `Raise engines.node in ${manifestPath} to >=${show(theirs)} to match ${dep}, or pin ${dep} back to a release that still supports Node ${show(ours)}.`,
+              });
+            }
+          }
+        }
+      },
+    },
+  },
+} satisfies RuleSet;


### PR DESCRIPTION
A package we publish declares `engines.node`; its dependencies declare theirs.
Nothing compared the two, so a routine bump could raise what the code REQUIRES
without touching what the manifest PROMISES.

Measured on 2026-08-21 (PR #4169, commander 14 → 15), read from the lockfile:

    packages/cli/node_modules/commander  15.0.0  engines: { node: '>=22.12.0' }
    packages/cli/package.json                    engines: { node: '>=20.0.0'  }

⛔ CI cannot catch this by construction. The workflows run `node-version: "22"`,
which resolves above 22.12, so every job is green — the gap lives exactly where
we do not test, at a consumer on Node 20, and surfaces as somebody else's
install error days later. None of the 14 required checks reads `engines`.

Third form of the CI-001 class, with a different second side:

  #4163         @playwright/test ↔ container tag      caught by CI (322 red)
  #4147/#4161   @types/node      ↔ node-version:      CI compiles, does not run
  this          our engines      ↔ deps' engines      breaks at the consumer

The data source differs (package-lock.json, not a workflow), hence a separate
rule rather than a third pair inside CI-001.

Two limits, stated in the rule header rather than implied:
- DIRECT dependencies only — transitive requirements are not ours to satisfy and
  their declarations are frequently absent or stale.
- LOWER BOUNDS, not range containment. `engines` is often a disjunction
  (`20 || >=22` and `^12.17.0 || ^14.13 || >=16.0.0` both live in this lockfile),
  and the floor of a disjunction is the MINIMUM across branches, not the first
  branch written. This catches "the dependency needs a newer Node than we
  promise" — the shape that shipped. It does not catch a hole INSIDE a
  disjunction; that needs a real semver implementation, and rule files may
  import only `node:*`.

Revert-verified against archgate@0.50.0 — the version CI pins, not the locally
installed 0.45.3:

  control                          total=27  pass  CI-002 checks=1  failed=0
  both ADR files removed           total=26        CI-002 checks=0   ⇒ registered
  engines lowered to >=20.0.0      total=27  FAIL  violation names both floors
  restored                         total=27  pass  failed=0

⛤ The registration axis had to be corrected mid-verification: removing only the
`.rules.ts` leaves the `.md` declaring `rules: true`, and archgate then reports
`status: error` / `ruleErrors: 1` while `failed` stays 0. So `failed` is the
wrong discriminator — `pass` (rc=2) is the right one. Removing BOTH files is
what actually moves `total`.

Closes #4172
