### PR TITLE
chore: mark the workspace root private, and let CI-002 see it

### DIFF
--- a/.archgate/adrs/CI-002-published-engines-not-weaker-than-deps.rules.ts
+++ b/.archgate/adrs/CI-002-published-engines-not-weaker-than-deps.rules.ts
@@ -100,7 +100,19 @@ export default {
         };
         const lockPackages = lock.packages ?? {};
 
-        for (const manifestPath of await ctx.glob("packages/*/package.json")) {
+        // The ROOT manifest is included deliberately. It is a workspace root and
+        // is not published — but that is only true because it says
+        // `private: true`, and the rule should learn that from the FLAG rather
+        // than from a glob that happens not to reach it. Measured when this was
+        // added: the root declares 5 runtime dependencies (react, react-dom,
+        // reflect-metadata, tsyringe, uuid) whose floors all sit below its own,
+        // so including it costs nothing today and guards the day the flag goes.
+        const manifests = [
+          "package.json",
+          ...(await ctx.glob("packages/*/package.json")),
+        ];
+        
+        for (const manifestPath of manifests) {
           const manifest = JSON.parse(
             await ctx.readFile(manifestPath),
           ) as Manifest;

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "exocortex-monorepo",
+  "private": true,
   "version": "16.7.0",
   "description": "Exocortex: A configurable UI system for Obsidian that transforms knowledge management through ontology-driven layouts and semantic capabilities",
   "main": "main.js",


### PR DESCRIPTION
Two halves of one fact: the root manifest is not published, and nothing said so.

`exocortex-monorepo` carried no `private` flag while declaring
`engines.node: ">=18.0.0"`. Both publish paths run from `packages/cli`
(`auto-release.yml` does `cd packages/cli`, `npm-publish-cli.yml` sets
`working-directory: packages/cli`) and no root script publishes anything, so the
package has never been meant for npm — the flag was simply missing, and an
accidental `npm publish` at the root would have shipped the monorepo.

The rule change is the other half. CI-002 globbed `packages/*/package.json`, so
it never reached the root — which meant "the root is exempt" was true by
accident of a glob rather than by the `private` flag the rule already honours.
Now the root is in the list and the flag does the exempting.

⛤ Measured before extending, so this is not a vacuous widening: the root
declares 5 runtime dependencies (react, react-dom, reflect-metadata, tsyringe,
uuid) and their floors all sit below its own — 0 violations today. It costs
nothing now and guards the day someone drops the flag.

Revert-verified against archgate@0.50.0 (the version CI pins):

  control                                   pass=true   CI-002 pass, 0 violations
  private removed + engines → >=5.0.0       pass=FALSE  CI-002 fail, 1 violation:
      "exocortex-monorepo promises engines.node >=5.0.0 (floor 5.0.0) but its
       dependency tsyringe requires >= 6.0.0 (floor 6.0.0)"
  restored                                  pass=true   CI-002 pass, 0 violations

The mutant has to strip BOTH the flag and the floor: stripping the flag alone
proves the rule reaches the root but finds nothing there, which is exactly the
measured state and would read as a passing axis for the wrong reason.
