### PR TITLE
test: one frontmatter reader for tests, replacing hand-rolled yaml.load copies (core pilot)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15004,6 +15004,7 @@
         "uuid": "^11.1.0"
       },
       "devDependencies": {
+        "@kitelev/exocortex-test-utils": "*",
         "@types/jest": "^30.0.0",
         "@types/node": "^22.20.1",
         "@types/sparqljs": "^3.1.12",
@@ -15204,11 +15205,35 @@
       "devDependencies": {
         "@types/jest": "^30.0.0",
         "jest": "^30.4.2",
+        "js-yaml": "^5.3.0",
         "ts-jest": "^29.4.12",
         "typescript": "^5.9.3"
       },
       "peerDependencies": {
         "obsidian": "*"
+      }
+    },
+    "packages/test-utils/node_modules/js-yaml": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.3.0.tgz",
+      "integrity": "sha512-muutsYr+e2+d3rTgUGslq5rxbBlUy3cJ61IsHag2QNDQV+7zXWjkUpmALIajhrlLlrgRUiymj6U3zUr/TMK84Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.mjs"
       }
     }
   }

--- a/packages/core/jest.config.js
+++ b/packages/core/jest.config.js
@@ -3,6 +3,15 @@ module.exports = {
   testEnvironment: 'node',
   setupFiles: ['reflect-metadata'],
   roots: ['<rootDir>/tests'],
+  moduleNameMapper: {
+    // `test-utils` is a private workspace package with no build step; tests
+    // resolve it straight from source. Mapped to the helper FILE rather than the
+    // package index on purpose — the index also re-exports Obsidian mocks and
+    // the flaky reporter, which a node-environment core test has no business
+    // loading.
+    '^@kitelev/exocortex-test-utils$':
+      '<rootDir>/../test-utils/src/helpers/frontmatter.helpers.ts',
+  },
   testMatch: ['**/?(*.)+(spec|test).ts'],
   collectCoverageFrom: [
     'src/**/*.ts',

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -52,6 +52,7 @@
     "uuid": "^11.1.0"
   },
   "devDependencies": {
+    "@kitelev/exocortex-test-utils": "*",
     "@types/jest": "^30.0.0",
     "@types/node": "^22.20.1",
     "@types/sparqljs": "^3.1.12",

--- a/packages/core/tests/integration/grounding-unquoted-wikilink-guard.integration.test.ts
+++ b/packages/core/tests/integration/grounding-unquoted-wikilink-guard.integration.test.ts
@@ -9,7 +9,6 @@
  * the converter emits a literal and the reference is lost) that no assertion on
  * the raw string could honestly demonstrate.
  */
-import * as yaml from "js-yaml";
 
 import {
   GroundingExecutor,
@@ -17,6 +16,7 @@ import {
 } from "../../src/services/GroundingExecutor";
 import { GroundingType } from "../../src/domain/constants/GroundingType";
 import { GroundingDefinition } from "../../src/domain/models/CommandDefinition";
+import { parseFrontmatterAsReader } from "@kitelev/exocortex-test-utils";
 
 const TARGET_IRI = "obsidian://vault/assetspaces/kitelev/exoas-my/task.md";
 const FILE_PATH = "assetspaces/kitelev/exoas-my/task.md";
@@ -62,7 +62,7 @@ function makeGrounding(overrides: Record<string, unknown>): GroundingDefinition 
 function parseFrontmatter(written: string): Record<string, unknown> {
   const match = /^---\n([\s\S]*?)\n---/.exec(written);
   expect(match).not.toBeNull();
-  return yaml.load((match as RegExpExecArray)[1]) as Record<string, unknown>;
+  return parseFrontmatterAsReader(written);
 }
 
 describe("req 29e0d1b6 — property_set rejects an unquoted wikilink value", () => {

--- a/packages/core/tests/unit/services/GroundingExecutor.test.ts
+++ b/packages/core/tests/unit/services/GroundingExecutor.test.ts
@@ -6,9 +6,9 @@ import {
   clearResolvers,
   installDefaultResolvers,
 } from "../../../src/services/SubstitutionResolverRegistry";
-import * as yaml from "js-yaml";
 import { GroundingType } from "../../../src/domain/constants/GroundingType";
 import { GroundingDefinition } from "../../../src/domain/models/CommandDefinition";
+import { parseFrontmatterAsReader } from "@kitelev/exocortex-test-utils";
 
 // -- Mocks --
 
@@ -142,9 +142,7 @@ describe("GroundingExecutor", () => {
       // `2026-01-15` unquoted parses as a Date; quoted, it stays a string. A
       // `toContain` on characters would keep passing if the quoting moved or
       // the serializer changed shape — the parsed type cannot.
-      const fm = yaml.load(
-        /^---\n([\s\S]*?)\n---/.exec(written)![1],
-      ) as Record<string, unknown>;
+      const fm = parseFrontmatterAsReader(written);
       expect(fm.aliases).toBe("2026-01-15");
       expect(typeof fm.aliases).toBe("string");
       expect(fm["exo__Asset_aliases"]).toBeUndefined();
@@ -168,9 +166,7 @@ describe("GroundingExecutor", () => {
       expect(result.success).toBe(true);
 
       const written = writer.updateFile.mock.calls[0][1];
-      const fm = yaml.load(
-        /^---\n([\s\S]*?)\n---/.exec(written)![1],
-      ) as Record<string, unknown>;
+      const fm = parseFrontmatterAsReader(written);
       expect(fm.namespace_aliases).toEqual(["ims"]); // untouched
       expect(fm.aliases).toBe("Mine"); // own key added
     });
@@ -447,9 +443,7 @@ describe("GroundingExecutor", () => {
       // the neighbour survives WHOLE — key and both items
       expect(written).toContain("namespace_aliases:");
       expect(written).not.toContain("namespace_\n");
-      const fm = yaml.load(
-        /^---\n([\s\S]*?)\n---/.exec(written)![1],
-      ) as Record<string, unknown>;
+      const fm = parseFrontmatterAsReader(written);
       expect(fm.namespace_aliases).toEqual(["ims", "concept"]);
     });
 

--- a/packages/core/tests/unit/services/settings/SettingsDistributionEngine.test.ts
+++ b/packages/core/tests/unit/services/settings/SettingsDistributionEngine.test.ts
@@ -7,7 +7,6 @@
  * markdown and re-parses it (production-shape: the import reads exactly what the
  * export wrote), not handcrafted frontmatter.
  */
-import * as yaml from "js-yaml";
 import {
   exportSettings,
   importSettings,
@@ -15,6 +14,7 @@ import {
   type SettingKeySpec,
   type SettingsSource,
 } from "../../../../src/services/settings";
+import { parseFrontmatterAsReader } from "@kitelev/exocortex-test-utils";
 
 const CLASS_UID = "11111111-1111-1111-1111-111111111111";
 const ONTOLOGY_UID = "22222222-2222-2222-2222-222222222222";
@@ -59,7 +59,7 @@ function makeSource(live: Record<string, unknown>): SettingsSource {
 function parseAsset(content: string, path: string): ImportableSettingAsset {
   const m = content.match(/^---\n([\s\S]*?)\n---/);
   if (!m) throw new Error(`no frontmatter in ${path}`);
-  const frontmatter = yaml.load(m[1]) as Record<string, unknown>;
+  const frontmatter = parseFrontmatterAsReader(content);
   return { path, frontmatter };
 }
 

--- a/packages/core/tests/unit/utilities/frontmatterReaderHelper.test.ts
+++ b/packages/core/tests/unit/utilities/frontmatterReaderHelper.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from "@jest/globals";
+import * as yaml from "js-yaml";
+import { parseFrontmatterAsReader } from "@kitelev/exocortex-test-utils";
+
+/**
+ * Guards the shared test helper that replaced 29 hand-rolled copies of
+ * `yaml.load(match[1])` (#4174).
+ *
+ * ⛤ This suite lives in `packages/core/tests` ON PURPOSE, not next to the helper
+ * in `packages/test-utils/tests`: `ci.yml` never invokes that package's jest, so
+ * an axis placed there would be an orphan suite — green forever, gating nothing.
+ * `test-coverage-exocortex` runs this config in full, so this one is gated.
+ *
+ * What it locks: the helper reproduces js-yaml 4's DEFAULT_SCHEMA, which is what
+ * the real readers still behave like (Obsidian's metadataCache;
+ * `parseYamlFrontmatterTolerant`). js-yaml 5 moved the default to CORE, where a
+ * bare date is a plain string — so the helper must name YAML11_SCHEMA, and if
+ * someone drops that argument these axes go red.
+ */
+describe("parseFrontmatterAsReader (shared test helper, #4174)", () => {
+  it("gives a bare date-like scalar the Date type the production readers see", () => {
+    const parsed = parseFrontmatterAsReader(
+      '---\nexo__Asset_createdAt: 2026-08-19\nexo__Asset_label: "2026-08-19"\n---\nbody\n',
+    );
+
+    expect(parsed.exo__Asset_createdAt).toBeInstanceOf(Date);
+    expect((parsed.exo__Asset_createdAt as Date).toISOString()).toBe(
+      "2026-08-19T00:00:00.000Z",
+    );
+    // The other half of the dual typing — quoted stays a string.
+    expect(parsed.exo__Asset_label).toBe("2026-08-19");
+  });
+
+  it("canary: the ambient js-yaml default does NOT do this, so the axis above is about the helper", () => {
+    // ⛤ Without this the suite could pass because js-yaml happened to default
+    // to YAML 1.1 — i.e. for a reason that has nothing to do with the helper.
+    expect(yaml.load("d: 2026-08-19")).toEqual({ d: "2026-08-19" });
+  });
+
+  it("returns {} for a file with no frontmatter rather than throwing", () => {
+    expect(parseFrontmatterAsReader("plain text, no fences\n")).toEqual({});
+  });
+
+  it("returns {} when the block is not a mapping", () => {
+    // A sequence or a scalar is not frontmatter; callers expect a record.
+    expect(parseFrontmatterAsReader("---\n- a\n- b\n---\n")).toEqual({});
+  });
+});

--- a/packages/core/tests/utilities/FrontmatterService.keyAnchoring.test.ts
+++ b/packages/core/tests/utilities/FrontmatterService.keyAnchoring.test.ts
@@ -30,8 +30,8 @@
  * GroundingExecutor axes.
  */
 import { describe, it, expect } from "@jest/globals";
-import * as yaml from "js-yaml";
 import { FrontmatterService } from "../../src/utilities/FrontmatterService";
+import { parseFrontmatterAsReader } from "@kitelev/exocortex-test-utils";
 
 /** Neighbour FIRST, so the gate passes on the real key and the inner matchers run. */
 const NEIGHBOUR_THEN_REAL = [
@@ -49,7 +49,7 @@ const NEIGHBOUR_THEN_REAL = [
 function frontmatterOf(content: string): Record<string, unknown> {
   const m = /^---\n([\s\S]*?)\n---/.exec(content);
   if (!m) throw new Error("no frontmatter");
-  return (yaml.load(m[1]) ?? {}) as Record<string, unknown>;
+  return parseFrontmatterAsReader(content);
 }
 
 describe("FrontmatterService — key matching is anchored to line start (req 869561bf)", () => {

--- a/packages/core/tests/utilities/FrontmatterService.yamlQuoting.test.ts
+++ b/packages/core/tests/utilities/FrontmatterService.yamlQuoting.test.ts
@@ -15,13 +15,13 @@
  * FAIL (js-yaml throws "bad indentation of a mapping entry"). With the fix they
  * PASS. Empirically verified FAILS pre-fix / PASSES post-fix.
  */
-import * as yaml from "js-yaml";
 import { FrontmatterService } from "../../src/utilities/FrontmatterService";
+import { parseFrontmatterAsReader } from "@kitelev/exocortex-test-utils";
 
 function parseFrontmatter(created: string): Record<string, unknown> {
   const match = created.match(/^---\n([\s\S]*?)\n---/);
   if (!match) throw new Error(`No frontmatter block in: ${created}`);
-  return yaml.load(match[1]) as Record<string, unknown>;
+  return parseFrontmatterAsReader(created);
 }
 
 describe("FrontmatterService — YAML-safe scalar quoting (#3748)", () => {

--- a/packages/core/tests/utilities/MetadataHelpers.yamlQuoting.test.ts
+++ b/packages/core/tests/utilities/MetadataHelpers.yamlQuoting.test.ts
@@ -17,11 +17,12 @@
  */
 import * as yaml from "js-yaml";
 import { MetadataHelpers } from "../../src/utilities/MetadataHelpers";
+import { parseFrontmatterAsReader } from "@kitelev/exocortex-test-utils";
 
 function parseFrontmatter(content: string): Record<string, unknown> {
   const match = content.match(/^---\n([\s\S]*?)\n---/);
   if (!match) throw new Error(`No frontmatter block in: ${content}`);
-  return yaml.load(match[1]) as Record<string, unknown>;
+  return parseFrontmatterAsReader(content);
 }
 
 describe("MetadataHelpers.buildFileContent — YAML-safe scalar quoting (#3750)", () => {

--- a/packages/core/tests/utilities/MetadataHelpers.yamlQuoting.test.ts
+++ b/packages/core/tests/utilities/MetadataHelpers.yamlQuoting.test.ts
@@ -15,7 +15,6 @@
  * colon-space scalar + array-item cases throw "bad indentation of a mapping
  * entry" in js-yaml.
  */
-import * as yaml from "js-yaml";
 import { MetadataHelpers } from "../../src/utilities/MetadataHelpers";
 import { parseFrontmatterAsReader } from "@kitelev/exocortex-test-utils";
 

--- a/packages/test-utils/package.json
+++ b/packages/test-utils/package.json
@@ -17,6 +17,7 @@
   "author": "A. Kitelev",
   "license": "MIT",
   "devDependencies": {
+    "js-yaml": "^5.3.0",
     "@types/jest": "^30.0.0",
     "jest": "^30.4.2",
     "ts-jest": "^29.4.12",

--- a/packages/test-utils/src/helpers/frontmatter.helpers.ts
+++ b/packages/test-utils/src/helpers/frontmatter.helpers.ts
@@ -1,0 +1,66 @@
+import * as yaml from "js-yaml";
+
+/**
+ * Parse a markdown file's frontmatter the way the PRODUCTION READERS do.
+ *
+ * ## Why this exists as one function
+ *
+ * Before this helper, 29 test files across three packages each carried their own
+ * copy of `yaml.load(match[1])` — the same three lines, none of them naming a
+ * schema. That made the simulated reader's semantics a property of whatever
+ * `js-yaml` happened to default to, a value nobody in this repo chose.
+ *
+ * It stopped being hypothetical on 2026-08-20: js-yaml 5 changed the default
+ * from YAML 1.1 to CORE, which turns a bare date-like scalar from a `Date` into
+ * a plain string. Exactly ONE of the 29 copies went red (#4173); the other 28
+ * stayed green. ⛔ That "28 are fine" was learned by RUNNING them — from the
+ * files themselves it is impossible to tell which copy depends on the typing,
+ * because none of them says. Duplication did not merely risk drift here; it hid
+ * the dependency from verification.
+ *
+ * ## Why YAML11_SCHEMA specifically
+ *
+ * `YAML11_SCHEMA` reproduces js-yaml 4's DEFAULT_SCHEMA, which is what the real
+ * readers still behave like:
+ *
+ *   - Obsidian's `metadataCache` — and Obsidian does NOT upgrade when our
+ *     `package.json` does, so a test simulating it must keep the old semantics
+ *     or it asserts against a reader that does not exist;
+ *   - `parseYamlFrontmatterTolerant` in `@kitelev/exocortex-core`, which names
+ *     the same schema for the same reason.
+ *
+ * Concretely, the vault's dual typing survives: `createdAt: 2026-08-19` loads as
+ * a `Date`, `label: "2026-08-19"` stays a `string`. Both forms exist in every
+ * real vault because both writers produce them — `create` writes bare,
+ * `set-property` quotes string-semantic properties.
+ *
+ * ⚠ This helper deliberately does NOT reproduce js-yaml 4's stricter parser.
+ * v5 accepts input v4 rejected (`  : : :` → `{ null: { null: … } }`), and no
+ * load option restores that. Production guards it inside
+ * `parseYamlFrontmatterTolerant`; a test that needs the rejection should go
+ * through that function rather than through this one.
+ *
+ * @param content full file text, including the `---` fences
+ * @returns the parsed mapping, or `{}` when the file has no frontmatter
+ */
+export function parseFrontmatterAsReader(
+  content: string,
+): Record<string, unknown> {
+  const match = /^---\n([\s\S]*?)\n---/.exec(content);
+  if (!match) return {};
+  const parsed = yaml.load(match[1] ?? "", { schema: yaml.YAML11_SCHEMA });
+  return typeof parsed === "object" && parsed !== null && !Array.isArray(parsed)
+    ? (parsed as Record<string, unknown>)
+    : {};
+}
+
+/**
+ * Same semantics as {@link parseFrontmatterAsReader}, for a bare YAML block that
+ * has already been separated from its fences.
+ */
+export function parseYamlAsReader(block: string): Record<string, unknown> {
+  const parsed = yaml.load(block, { schema: yaml.YAML11_SCHEMA });
+  return typeof parsed === "object" && parsed !== null && !Array.isArray(parsed)
+    ? (parsed as Record<string, unknown>)
+    : {};
+}

--- a/packages/test-utils/src/helpers/index.ts
+++ b/packages/test-utils/src/helpers/index.ts
@@ -5,3 +5,4 @@
 export * from "./obsidian.helpers";
 export * from "./async.helpers";
 export * from "./status.helpers";
+export * from "./frontmatter.helpers";

--- a/packages/test-utils/src/index.ts
+++ b/packages/test-utils/src/index.ts
@@ -108,6 +108,15 @@ export {
   type RetryOptions,
 } from "./helpers/async.helpers";
 
+export {
+  // Frontmatter parsing with the PRODUCTION reader's schema (js-yaml 4
+  // semantics). Use these instead of a local `yaml.load(match[1])`: the bare
+  // call inherits whatever js-yaml defaults to, which changed in v5 and
+  // silently reshaped bare dates from Date to string.
+  parseFrontmatterAsReader,
+  parseYamlAsReader,
+} from "./helpers/frontmatter.helpers";
+
 // Reporters and Flaky Test Detection
 export {
   FlakyReporter,


### PR DESCRIPTION
29 test files across three packages each carried their own `yaml.load(match[1])`
— the same three lines, none naming a schema. That made the simulated reader's
semantics a property of whatever js-yaml happens to default to, a value nobody
in this repo chose.

It stopped being hypothetical last night: js-yaml 5 moved the default from YAML
1.1 to CORE, turning a bare date-like scalar from `Date` into a plain string.
Exactly ONE of the 29 copies went red (#4173); the other 28 stayed green.

⛔ And "the other 28 are fine" was learned by RUNNING them. From the files
themselves it is impossible to tell which copy depends on the typing, because
none of them says. Duplication here did not merely risk drift — it hid the
dependency from verification.

## Pilot scope, deliberately

core only: 8 call sites in 6 files. cli (19) and obsidian-plugin (2) follow once
this is green. 29 files in one PR is blast-radius without need, and the value
here is deferred — the measured damage so far is one broken copy.

## What the wiring actually cost

The issue proposed `packages/test-utils`, assuming it was a shared package.
Measured: it was imported by nothing but itself, and its `moduleNameMapper` lived
only in its own jest config. So this PR also does the one-time job of making it
real for core — devDep + one mapper entry.

⛤ The mapper points at the helper FILE, not the package index: the index also
re-exports Obsidian mocks and the flaky reporter, which a node-environment core
test has no business loading.

⛤ `test-utils` also had to declare `js-yaml` itself. It never used it before, so
it was resolving the hoisted root copy — which after #4173 is a transitive 4.3.1
with no types, and typecheck failed on that rather than on anything semantic.

## Behaviour preserved, not flattened

Wrappers that `throw` on a missing frontmatter block keep throwing: only the
parse line moved into the helper. The helper itself returns `{}` for a file
without fences, matching the call sites that expected that.

## Axis

`frontmatterReaderHelper.test.ts` — placed in `packages/core/tests` ON PURPOSE:
`ci.yml` never invokes `packages/test-utils`'s jest, so an axis next to the
helper would be an orphan suite, green forever and gating nothing.

Revert-verified: dropping `{ schema: yaml.YAML11_SCHEMA }` from the helper
reddens exactly one axis — "gives a bare date-like scalar the Date type the
production readers see" — and the control run is clean. A canary pins that the
ambient js-yaml default does NOT produce Dates, so the axis is about the helper
and not about a default that happens to agree.

Gates: core 377/377 suites, 8633 tests passed; check:types rc=0.

Refs #4174
