### PR TITLE
test: finish the frontmatter-reader migration — cli + obsidian-plugin

### DIFF
--- a/packages/cli/jest.config.js
+++ b/packages/cli/jest.config.js
@@ -5,6 +5,12 @@ module.exports = {
   testMatch: ["<rootDir>/tests/**/*.test.ts"],
   setupFilesAfterEnv: ["<rootDir>/tests/setup.ts"],
   moduleNameMapper: {
+    // `test-utils` is a private workspace package with no build step; tests
+    // resolve it straight from source. Mapped to the helper FILE rather than the
+    // package index on purpose — the index also re-exports Obsidian mocks and
+    // the flaky reporter, which these suites have no business loading.
+    "^@kitelev/exocortex-test-utils$":
+      "<rootDir>/../test-utils/src/helpers/frontmatter.helpers.ts",
     "^@kitelev/exocortex-core$": "<rootDir>/../core/src/index.ts",
     "^@kitelev/exocortex-services$": "<rootDir>/../services/src/index.ts",
     "^(\\.{1,2}/.*)\\.js$": "$1",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -61,6 +61,7 @@
     "ora": "^9.4.1"
   },
   "devDependencies": {
+    "@kitelev/exocortex-test-utils": "*",
     "@kitelev/exocortex-core": "file:../core",
     "@kitelev/exocortex-services": "file:../services",
     "@types/fs-extra": "^11.0.0",

--- a/packages/cli/tests/integration/ai-task-smoke.integration.test.ts
+++ b/packages/cli/tests/integration/ai-task-smoke.integration.test.ts
@@ -14,6 +14,7 @@ import * as yaml from "js-yaml";
 import { spawnSession } from "../../src/services/SpawnService.js";
 import type { ExecFn, SpawnDeps } from "../../src/services/SpawnService.js";
 import { atomicUpdateFrontmatter } from "../../src/services/AtomicFrontmatterService.js";
+import { parseFrontmatterAsReader } from "@kitelev/exocortex-test-utils";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -38,7 +39,7 @@ function parseFrontmatter(filePath: string): Record<string, unknown> {
   const content = readFileSync(filePath, "utf8");
   const match = content.match(/^---\s*\r?\n([\s\S]*?)\r?\n---/);
   if (!match) throw new Error("No frontmatter in " + filePath);
-  const parsed = yaml.load(match[1]);
+  const parsed = parseFrontmatterAsReader(content);
   if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
     throw new Error("Invalid frontmatter");
   }

--- a/packages/cli/tests/integration/canonical-key-single-source.integration.test.ts
+++ b/packages/cli/tests/integration/canonical-key-single-source.integration.test.ts
@@ -26,7 +26,7 @@ import { jest, describe, it, expect, beforeEach, afterEach } from "@jest/globals
 import * as fs from "fs";
 import * as path from "path";
 import * as os from "os";
-import * as yaml from "js-yaml";
+import { parseFrontmatterAsReader } from "@kitelev/exocortex-test-utils";
 
 const { setPropertyCommand } = await import("../../src/commands/set-property.js");
 const { removePropertyCommand } = await import(
@@ -50,7 +50,7 @@ function md(frontmatter: Record<string, string>): string {
 function parseFrontmatter(content: string): Record<string, unknown> {
   const m = /^---\n([\s\S]*?)\n---/.exec(content);
   if (!m) throw new Error("no frontmatter in written file");
-  return (yaml.load(m[1]) ?? {}) as Record<string, unknown>;
+  return (parseFrontmatterAsReader(content) ?? {}) as Record<string, unknown>;
 }
 
 describe("req 869561bf: one canonical-key source in core, used by every writer", () => {

--- a/packages/cli/tests/integration/cli-plugin-triple-parity.integration.test.ts
+++ b/packages/cli/tests/integration/cli-plugin-triple-parity.integration.test.ts
@@ -27,7 +27,6 @@ import { describe, it, expect, beforeAll, afterAll } from "@jest/globals";
 import fs from "fs-extra";
 import path from "path";
 import os from "os";
-import * as yaml from "js-yaml";
 import {
   NoteToRDFConverter,
   InMemoryTripleStore,
@@ -38,6 +37,7 @@ import {
   type Triple,
 } from "@kitelev/exocortex-core";
 import { FileSystemVaultAdapter } from "../../src/adapters/FileSystemVaultAdapter.js";
+import { parseFrontmatterAsReader } from "@kitelev/exocortex-test-utils";
 
 /**
  * Independent reference implementation of Obsidian's
@@ -92,7 +92,7 @@ class OracleVaultAdapter implements IVaultAdapter {
     const match = content.match(/^---\n([\s\S]*?)\n---/);
     if (!match) return null;
     try {
-      const parsed = yaml.load(match[1]);
+      const parsed = parseFrontmatterAsReader(content);
       return typeof parsed === "object" && parsed !== null
         ? (parsed as IFrontmatter)
         : null;

--- a/packages/cli/tests/integration/create-property-verbatim-value.integration.test.ts
+++ b/packages/cli/tests/integration/create-property-verbatim-value.integration.test.ts
@@ -28,7 +28,7 @@ import {
 import * as fs from "fs";
 import * as path from "path";
 import * as os from "os";
-import * as yaml from "js-yaml";
+import { parseYamlAsReader } from "@kitelev/exocortex-test-utils";
 
 const { createCommand } = await import("../../src/commands/create.js");
 
@@ -106,7 +106,7 @@ describe("Issue #4014: cli create --property keeps the value verbatim", () => {
       );
     const out = JSON.parse(stdout);
     const content = fs.readFileSync(path.join(vault, out.path), "utf-8");
-    const frontmatter = yaml.load(content.split("---\n")[1]) as Record<
+    const frontmatter = parseYamlAsReader(content.split("---\n")[1]) as Record<
       string,
       unknown
     >;

--- a/packages/cli/tests/integration/race-claim.integration.test.ts
+++ b/packages/cli/tests/integration/race-claim.integration.test.ts
@@ -12,11 +12,11 @@ import { describe, it, expect, beforeEach, afterEach } from "@jest/globals";
 import * as fs from "fs";
 import * as os from "os";
 import * as path from "path";
-import * as yaml from "js-yaml";
 import {
   claimTask,
   releaseClaimLock,
 } from "../../src/services/ClaimService.js";
+import { parseFrontmatterAsReader } from "@kitelev/exocortex-test-utils";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -41,7 +41,7 @@ function parseFrontmatter(filePath: string): Record<string, unknown> | null {
   const content = fs.readFileSync(filePath, "utf8");
   const match = content.match(/^---\s*\r?\n([\s\S]*?)\r?\n---/);
   if (!match) return null;
-  const parsed = yaml.load(match[1]);
+  const parsed = parseFrontmatterAsReader(content);
   if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
     return null;
   }

--- a/packages/cli/tests/integration/remove-property.integration.test.ts
+++ b/packages/cli/tests/integration/remove-property.integration.test.ts
@@ -29,7 +29,7 @@ import { jest, describe, it, expect, beforeEach, afterEach } from "@jest/globals
 import * as fs from "fs";
 import * as path from "path";
 import * as os from "os";
-import * as yaml from "js-yaml";
+import { parseFrontmatterAsReader } from "@kitelev/exocortex-test-utils";
 
 const { removePropertyCommand } = await import(
   "../../src/commands/remove-property.js"
@@ -61,7 +61,7 @@ const EXPECTED_UPDATED_AT = "2026-07-12T15:00:00";
 function parseFrontmatter(content: string): Record<string, unknown> {
   const match = content.match(/^---\n([\s\S]*?)\n---/);
   if (!match) throw new Error("no frontmatter block");
-  return (yaml.load(match[1]) ?? {}) as Record<string, unknown>;
+  return (parseFrontmatterAsReader(content) ?? {}) as Record<string, unknown>;
 }
 
 describe("Issue #3926: `cli remove-property` deletes a non-guarded frontmatter property", () => {

--- a/packages/cli/tests/integration/set-property.integration.test.ts
+++ b/packages/cli/tests/integration/set-property.integration.test.ts
@@ -30,7 +30,7 @@ import { jest, describe, it, expect, beforeEach, afterEach } from "@jest/globals
 import * as fs from "fs";
 import * as path from "path";
 import * as os from "os";
-import * as yaml from "js-yaml";
+import { parseFrontmatterAsReader } from "@kitelev/exocortex-test-utils";
 
 const { setPropertyCommand } = await import("../../src/commands/set-property.js");
 
@@ -61,7 +61,7 @@ const EXPECTED_UPDATED_AT = "2026-07-12T15:00:00";
 function parseFrontmatter(content: string): Record<string, unknown> {
   const match = content.match(/^---\n([\s\S]*?)\n---/);
   if (!match) throw new Error("no frontmatter block");
-  return (yaml.load(match[1]) ?? {}) as Record<string, unknown>;
+  return (parseFrontmatterAsReader(content) ?? {}) as Record<string, unknown>;
 }
 
 function md(frontmatter: Record<string, string>): string {

--- a/packages/cli/tests/unit/services/AtomicFrontmatterService.test.ts
+++ b/packages/cli/tests/unit/services/AtomicFrontmatterService.test.ts
@@ -5,6 +5,7 @@ import path from "path";
 import * as yaml from "js-yaml";
 
 import { atomicUpdateFrontmatter } from "../../../src/services/AtomicFrontmatterService.js";
+import { parseYamlAsReader } from "@kitelev/exocortex-test-utils";
 
 function buildMd(fm: Record<string, unknown>, body = ""): string {
   return `---\n${yaml.dump(fm)}---\n${body}`;
@@ -37,7 +38,7 @@ describe("AtomicFrontmatterService", () => {
     expect(r.verified).toBe(true);
 
     const after = readFileSync(target, "utf8");
-    const parsed = yaml.load(after.split("---")[1]) as Record<string, unknown>;
+    const parsed = parseYamlAsReader(after.split("---")[1]) as Record<string, unknown>;
     expect(parsed["ems__Effort_status"]).toBe("[[ems__EffortStatusDoing]]");
     expect(parsed["existing"]).toBe("keep");
     expect(parsed["exo__Asset_uid"]).toBe("uuid-1");
@@ -76,9 +77,9 @@ describe("AtomicFrontmatterService", () => {
     const r = atomicUpdateFrontmatter(target, { aiTask__Task_claimedBy: "99999" });
 
     expect(r.success).toBe(true);
-    const parsed = yaml.load(
+    const parsed = parseYamlAsReader(
       readFileSync(target, "utf8").split("---")[1],
-    ) as Record<string, unknown>;
+    );
     expect(parsed["dup"]).toBe("second"); // last-wins
     expect(parsed["aiTask__Task_claimedBy"]).toBe("99999");
     expect(parsed["exo__Asset_uid"]).toBe("uuid-1");
@@ -157,7 +158,7 @@ describe("AtomicFrontmatterService", () => {
     }
 
     const finalContent = readFileSync(target, "utf8");
-    const fm = yaml.load(finalContent.split("---")[1]) as Record<string, unknown>;
+    const fm = parseYamlAsReader(finalContent.split("---")[1]) as Record<string, unknown>;
     expect(fm["counter"]).toBe(100);
     expect(fm["exo__Asset_uid"]).toBe("uuid-1");
   });

--- a/packages/cli/tests/unit/services/archiveAsset.test.ts
+++ b/packages/cli/tests/unit/services/archiveAsset.test.ts
@@ -21,6 +21,7 @@ import {
   populateCliServiceRegistry,
   CliServiceNotImplementedError,
 } from "../../../src/services/CliServiceRegistryPopulator.js";
+import { parseFrontmatterAsReader } from "@kitelev/exocortex-test-utils";
 
 type Frontmatter = Record<string, unknown>;
 
@@ -28,7 +29,7 @@ function readFrontmatter(filePath: string): Frontmatter {
   const content = fs.readFileSync(filePath, "utf-8");
   const match = content.match(/^---\n([\s\S]*?)\n---/);
   if (!match) throw new Error(`No frontmatter in ${filePath}`);
-  return yaml.load(match[1]) as Frontmatter;
+  return parseFrontmatterAsReader(content) as Frontmatter;
 }
 
 function writeAsset(

--- a/packages/cli/tests/unit/services/cleanProperties.test.ts
+++ b/packages/cli/tests/unit/services/cleanProperties.test.ts
@@ -2,7 +2,6 @@ import { describe, it, expect, beforeEach, afterEach } from "@jest/globals";
 import fs from "fs-extra";
 import path from "path";
 import os from "os";
-import * as yaml from "js-yaml";
 import {
   ArchiveAssetService,
   EffortStatusWorkflow,
@@ -21,6 +20,7 @@ import {
   populateCliServiceRegistry,
   CliServiceNotImplementedError,
 } from "../../../src/services/CliServiceRegistryPopulator.js";
+import { parseFrontmatterAsReader } from "@kitelev/exocortex-test-utils";
 
 type Frontmatter = Record<string, unknown>;
 
@@ -28,7 +28,7 @@ function readFrontmatter(filePath: string): Frontmatter {
   const content = fs.readFileSync(filePath, "utf-8");
   const match = content.match(/^---\n([\s\S]*?)\n---/);
   if (!match) throw new Error(`No frontmatter in ${filePath}`);
-  return yaml.load(match[1]) as Frontmatter;
+  return parseFrontmatterAsReader(content) as Frontmatter;
 }
 
 function writeRaw(vaultRoot: string, relPath: string, content: string): string {

--- a/packages/cli/tests/unit/services/createAsset.test.ts
+++ b/packages/cli/tests/unit/services/createAsset.test.ts
@@ -21,6 +21,7 @@ import {
   populateCliServiceRegistry,
   CliServiceNotImplementedError,
 } from "../../../src/services/CliServiceRegistryPopulator.js";
+import { parseFrontmatterAsReader } from "@kitelev/exocortex-test-utils";
 
 /**
  * Phase 3.5 (Issue #3164) — registry-level integration tests for the new
@@ -41,7 +42,7 @@ function readFrontmatter(filePath: string): Frontmatter {
   const content = fs.readFileSync(filePath, "utf-8");
   const match = content.match(/^---\n([\s\S]*?)\n---/);
   if (!match) throw new Error(`No frontmatter in ${filePath}`);
-  return yaml.load(match[1]) as Frontmatter;
+  return parseFrontmatterAsReader(content) as Frontmatter;
 }
 
 function writeAsset(

--- a/packages/cli/tests/unit/services/createRelatedProject.test.ts
+++ b/packages/cli/tests/unit/services/createRelatedProject.test.ts
@@ -21,6 +21,7 @@ import {
   populateCliServiceRegistry,
   CliServiceNotImplementedError,
 } from "../../../src/services/CliServiceRegistryPopulator.js";
+import { parseFrontmatterAsReader } from "@kitelev/exocortex-test-utils";
 
 type Frontmatter = Record<string, unknown>;
 
@@ -28,7 +29,7 @@ function readFrontmatter(filePath: string): Frontmatter {
   const content = fs.readFileSync(filePath, "utf-8");
   const match = content.match(/^---\n([\s\S]*?)\n---/);
   if (!match) throw new Error(`No frontmatter in ${filePath}`);
-  return yaml.load(match[1]) as Frontmatter;
+  return parseFrontmatterAsReader(content) as Frontmatter;
 }
 
 function writeAsset(vaultRoot: string, relPath: string, frontmatter: Frontmatter): string {

--- a/packages/cli/tests/unit/services/createRelatedTask.test.ts
+++ b/packages/cli/tests/unit/services/createRelatedTask.test.ts
@@ -21,6 +21,7 @@ import {
   populateCliServiceRegistry,
   CliServiceNotImplementedError,
 } from "../../../src/services/CliServiceRegistryPopulator.js";
+import { parseFrontmatterAsReader } from "@kitelev/exocortex-test-utils";
 
 type Frontmatter = Record<string, unknown>;
 
@@ -28,7 +29,7 @@ function readFrontmatter(filePath: string): Frontmatter {
   const content = fs.readFileSync(filePath, "utf-8");
   const match = content.match(/^---\n([\s\S]*?)\n---/);
   if (!match) throw new Error(`No frontmatter in ${filePath}`);
-  return yaml.load(match[1]) as Frontmatter;
+  return parseFrontmatterAsReader(content) as Frontmatter;
 }
 
 function writeAsset(vaultRoot: string, relPath: string, frontmatter: Frontmatter): string {

--- a/packages/cli/tests/unit/services/fixMissingLabel.test.ts
+++ b/packages/cli/tests/unit/services/fixMissingLabel.test.ts
@@ -2,7 +2,6 @@ import { describe, it, expect, beforeEach, afterEach } from "@jest/globals";
 import fs from "fs-extra";
 import path from "path";
 import os from "os";
-import * as yaml from "js-yaml";
 import {
   ArchiveAssetService,
   EffortStatusWorkflow,
@@ -21,6 +20,7 @@ import {
   populateCliServiceRegistry,
   CliServiceNotImplementedError,
 } from "../../../src/services/CliServiceRegistryPopulator.js";
+import { parseFrontmatterAsReader } from "@kitelev/exocortex-test-utils";
 
 type Frontmatter = Record<string, unknown>;
 
@@ -28,7 +28,7 @@ function readFrontmatter(filePath: string): Frontmatter {
   const content = fs.readFileSync(filePath, "utf-8");
   const match = content.match(/^---\n([\s\S]*?)\n---/);
   if (!match) throw new Error(`No frontmatter in ${filePath}`);
-  return yaml.load(match[1]) as Frontmatter;
+  return parseFrontmatterAsReader(content) as Frontmatter;
 }
 
 function writeRaw(vaultRoot: string, relPath: string, content: string): string {

--- a/packages/cli/tests/unit/services/instantiate-prototype-subtree.test.ts
+++ b/packages/cli/tests/unit/services/instantiate-prototype-subtree.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from "@jest/globals";
-import * as yaml from "js-yaml";
 import { createInstantiatePrototypeSubtreeService } from "@kitelev/exocortex-services";
 import { FrontmatterService } from "@kitelev/exocortex-core";
+import { parseYamlAsReader } from "@kitelev/exocortex-test-utils";
 
 /**
  * Production-shape revert-verify test for the `instantiatePrototypeSubtree`
@@ -221,7 +221,7 @@ describe("instantiatePrototypeSubtree (issue #3881 Gap 3)", () => {
       w.content.includes(`exo__Asset_prototype: "[[${ROOT}]]"`),
     )!;
     const fmBlock = rootWrite.content.split("---")[1];
-    const y = yaml.load(fmBlock) as Record<string, unknown>;
+    const y = parseYamlAsReader(fmBlock) as Record<string, unknown>;
     expect(y.exo__Asset_label).toBe("Ревьюшница n.rudopas Q3-26"); // js-yaml strips quotes
     expect(y.exo__Instance_class).toEqual([
       `[[${EMS_PROJECT_CLS}|ems__Project]]`,

--- a/packages/cli/tests/unit/services/planForEvening.test.ts
+++ b/packages/cli/tests/unit/services/planForEvening.test.ts
@@ -21,6 +21,7 @@ import {
   populateCliServiceRegistry,
   CliServiceNotImplementedError,
 } from "../../../src/services/CliServiceRegistryPopulator.js";
+import { parseFrontmatterAsReader } from "@kitelev/exocortex-test-utils";
 
 type Frontmatter = Record<string, unknown>;
 
@@ -28,7 +29,7 @@ function readFrontmatter(filePath: string): Frontmatter {
   const content = fs.readFileSync(filePath, "utf-8");
   const match = content.match(/^---\n([\s\S]*?)\n---/);
   if (!match) throw new Error(`No frontmatter in ${filePath}`);
-  return yaml.load(match[1]) as Frontmatter;
+  return parseFrontmatterAsReader(content) as Frontmatter;
 }
 
 /**

--- a/packages/cli/tests/unit/services/renameToUid.test.ts
+++ b/packages/cli/tests/unit/services/renameToUid.test.ts
@@ -2,7 +2,6 @@ import { describe, it, expect, beforeEach, afterEach } from "@jest/globals";
 import fs from "fs-extra";
 import path from "path";
 import os from "os";
-import * as yaml from "js-yaml";
 import {
   ArchiveAssetService,
   EffortStatusWorkflow,
@@ -21,6 +20,7 @@ import {
   populateCliServiceRegistry,
   CliServiceNotImplementedError,
 } from "../../../src/services/CliServiceRegistryPopulator.js";
+import { parseFrontmatterAsReader } from "@kitelev/exocortex-test-utils";
 
 type Frontmatter = Record<string, unknown>;
 
@@ -28,7 +28,7 @@ function readFrontmatter(filePath: string): Frontmatter {
   const content = fs.readFileSync(filePath, "utf-8");
   const match = content.match(/^---\n([\s\S]*?)\n---/);
   if (!match) throw new Error(`No frontmatter in ${filePath}`);
-  return yaml.load(match[1]) as Frontmatter;
+  return parseFrontmatterAsReader(content) as Frontmatter;
 }
 
 function writeRaw(vaultRoot: string, relPath: string, content: string): string {

--- a/packages/cli/tests/unit/services/repairFolder.test.ts
+++ b/packages/cli/tests/unit/services/repairFolder.test.ts
@@ -2,7 +2,6 @@ import { describe, it, expect, beforeEach, afterEach } from "@jest/globals";
 import fs from "fs-extra";
 import path from "path";
 import os from "os";
-import * as yaml from "js-yaml";
 import {
   ArchiveAssetService,
   EffortStatusWorkflow,
@@ -21,6 +20,7 @@ import {
   populateCliServiceRegistry,
   CliServiceNotImplementedError,
 } from "../../../src/services/CliServiceRegistryPopulator.js";
+import { parseFrontmatterAsReader } from "@kitelev/exocortex-test-utils";
 
 type Frontmatter = Record<string, unknown>;
 
@@ -28,7 +28,7 @@ function readFrontmatter(filePath: string): Frontmatter {
   const content = fs.readFileSync(filePath, "utf-8");
   const match = content.match(/^---\n([\s\S]*?)\n---/);
   if (!match) throw new Error(`No frontmatter in ${filePath}`);
-  return yaml.load(match[1]) as Frontmatter;
+  return parseFrontmatterAsReader(content) as Frontmatter;
 }
 
 function writeRaw(vaultRoot: string, relPath: string, content: string): string {

--- a/packages/obsidian-plugin/jest.config.js
+++ b/packages/obsidian-plugin/jest.config.js
@@ -27,6 +27,12 @@ module.exports = {
     "!**/tests/**",
   ],
   moduleNameMapper: {
+    // `test-utils` is a private workspace package with no build step; tests
+    // resolve it straight from source. Mapped to the helper FILE rather than the
+    // package index on purpose — the index also re-exports Obsidian mocks and
+    // the flaky reporter, which these suites have no business loading.
+    '^@kitelev/exocortex-test-utils$':
+      '<rootDir>/../test-utils/src/helpers/frontmatter.helpers.ts',
     // Подпуть ДО точного: moduleNameMapper берёт первый совпавший паттерн.
     "^@kitelev/exocortex-core/(.*)$": "<rootDir>/../core/src/$1",
     "^@kitelev/exocortex-core$": "<rootDir>/../core/src/index.ts",

--- a/packages/obsidian-plugin/package.json
+++ b/packages/obsidian-plugin/package.json
@@ -34,6 +34,7 @@
     "zustand": "^5.0.15"
   },
   "devDependencies": {
+    "@kitelev/exocortex-test-utils": "*",
     "@playwright/experimental-ct-react": "^1.62.1",
     "@playwright/test": "^1.62.1",
     "@testing-library/jest-dom": "^6.9.1",

--- a/packages/obsidian-plugin/tests/unit/settings/ExocortexSettingsSource.test.ts
+++ b/packages/obsidian-plugin/tests/unit/settings/ExocortexSettingsSource.test.ts
@@ -7,7 +7,6 @@
  * real allowlist/denylist (no NON_HOMOICONIZABLE field is exportable) and that a
  * full round-trip restores the snapshot.
  */
-import * as yaml from "js-yaml";
 import {
   exportSettings,
   importSettings,
@@ -18,11 +17,12 @@ import {
   NON_HOMOICONIZABLE_FIELDS,
   VAULT_SETTINGS_REGISTRY,
 } from "@plugin/domain/settings/VaultSettingsRegistry";
+import { parseFrontmatterAsReader } from "@kitelev/exocortex-test-utils";
 
 function parseAsset(content: string, path: string): ImportableSettingAsset {
   const m = content.match(/^---\n([\s\S]*?)\n---/);
   if (!m) throw new Error(`no frontmatter in ${path}`);
-  return { path, frontmatter: yaml.load(m[1]) as Record<string, unknown> };
+  return { path, frontmatter: parseFrontmatterAsReader(content) as Record<string, unknown> };
 }
 
 describe("ExocortexSettingsSource (production-shape over the real registry)", () => {


### PR DESCRIPTION
Second and final step after the core pilot (#4177). 21 more hand-rolled
`yaml.load(...)` call sites across 19 files now go through the shared reader, so
the simulated reader's schema is named once instead of inherited 29 times from
whatever js-yaml happens to default to.

After this, every remaining `yaml.load` in a test is deliberate:
- 3 canaries that assert what the AMBIENT default does (they exist to prove the
  helper's axes are about the helper, not about a default that happens to agree);
- `StructuredMerger.test.ts`, which asks for CORE_SCHEMA on purpose — it builds a
  codec that violates the frontmatter contract to produce Dates.

## Wiring

cli and obsidian-plugin get the same two lines core got in #4177: a devDep on
`@kitelev/exocortex-test-utils` and one `moduleNameMapper` entry pointing at the
helper FILE rather than the package index (the index also re-exports Obsidian
mocks and the flaky reporter, which these suites have no business loading).

## ⛔ The mapping had to be rewritten once, and the first version was wrong

My first pass took the parameter name from the enclosing function's signature.
That silently broke `createAsset.test.ts`:

```ts
function readFrontmatter(filePath: string): Frontmatter {
  const content = fs.readFileSync(filePath, "utf-8");
  const match = content.match(/^---\n([\s\S]*?)\n---/);
  return parseFrontmatterAsReader(filePath) as Frontmatter;   // ← the PATH
}
```

The parameter is a path; the thing being parsed is `content`. Caught by the suite
(`fm.exo__Asset_label` → undefined), reverted all 14 files, and redone against the
right anchor: the variable the `match`/`exec` was taken FROM, not the function's
parameter. 15 files migrated with zero skips on the second pass.

Split-style call sites (`content.split("---\n")[1]`) use `parseYamlAsReader`
instead — they hand over an already-separated block, so re-cutting the fences
would be wrong.

12 `import * as yaml` lines became unused and were removed. ⛤ Detected by
counting usages in CODE only: my earlier check grepped `yaml.` and counted
mentions in doc comments, which is exactly how one slipped past me into CI on
#4177.

Gates (all five lint-job guards run locally this time, not just check:types):
validate-shard-assignments · check-cli-types · check-test-types ·
check-coverage-monotonic · check-test-antipatterns — all rc=0.
cli 1982 passed (the single failure, `sparql-exo003 mixed format`, reproduces on
a pristine js-yaml 4 checkout and predates this work);
obsidian-plugin 353/353 suites, 6153 tests.

Closes #4174
