### PR TITLE
fix(sparql): agg: aggregates fail loudly on unknown name and wrong arity

### DIFF
--- a/packages/core/src/infrastructure/sparql/algebra/AggregateTranslator.ts
+++ b/packages/core/src/infrastructure/sparql/algebra/AggregateTranslator.ts
@@ -17,7 +17,7 @@ import type {
 } from "../SparqljsTypes";
 import { isVariableExpression, isFunctionCallExpression } from "../SparqljsTypes";
 import { CustomAggregateRegistry } from "../aggregates/CustomAggregateRegistry";
-import { BUILT_IN_AGGREGATES } from "../aggregates/BuiltInAggregates";
+import { BUILT_IN_AGGREGATES, EXO_AGGREGATE_NS } from "../aggregates/BuiltInAggregates";
 
 /**
  * Translates SPARQL aggregate-related constructs from the sparqljs AST
@@ -274,7 +274,29 @@ export class AggregateTranslator {
     const registered =
       iri in BUILT_IN_AGGREGATES ||
       CustomAggregateRegistry.getInstance().get(iri) !== undefined;
-    return registered ? iri : null;
+    if (registered) return iri;
+
+    // Polarity is INVERTED on purpose: inside the `agg:` namespace we enumerate what
+    // is SAFE (registered) and treat everything else as an error, rather than listing
+    // known-bad names. A typo (`agg:medain`) used to fall through to `null` here, be
+    // re-read as an ordinary function call, and therefore never aggregate at all — the
+    // query then returned one empty solution per row (`[{},{},{}…]`), which reads as
+    // data, not as a failure. Outside the namespace nothing changes: a non-`agg:` IRI
+    // is a normal function call and must keep flowing to collectNestedAggregates.
+    if (iri.startsWith(EXO_AGGREGATE_NS)) {
+      const known = [
+        ...Object.keys(BUILT_IN_AGGREGATES),
+        ...CustomAggregateRegistry.getInstance().getRegisteredIris(),
+      ]
+        .filter((k) => k.startsWith(EXO_AGGREGATE_NS))
+        .map((k) => k.slice(EXO_AGGREGATE_NS.length))
+        .sort();
+      throw new Error(
+        `Unknown aggregate agg:${iri.slice(EXO_AGGREGATE_NS.length)}. ` +
+          `Registered: ${known.length > 0 ? known.map((k) => `agg:${k}`).join(", ") : "(none)"}.`,
+      );
+    }
+    return null;
   }
 
   /**
@@ -289,7 +311,23 @@ export class AggregateTranslator {
       args?: SparqljsExpression[];
       distinct?: boolean;
     };
-    const arg = fc.args && fc.args.length > 0 ? fc.args[0] : undefined;
+    // Every registered aggregate accumulates ONE value per solution, so a call with
+    // more arguments cannot mean what it looks like. Before this guard the extra
+    // arguments were silently dropped and `agg:median(?x, ?y)` returned the median of
+    // ?x alone — indistinguishable from a working two-column statistic. That is the
+    // exact shape a user writes for `agg:corr(?x, ?y)` (#3994), so the failure had to
+    // become loud BEFORE the two-column aggregates land, not after.
+    const argc = fc.args?.length ?? 0;
+    if (argc > 1) {
+      const local = iri.startsWith(EXO_AGGREGATE_NS)
+        ? `agg:${iri.slice(EXO_AGGREGATE_NS.length)}`
+        : iri;
+      throw new Error(
+        `${local} takes exactly 1 argument, got ${argc}. ` +
+          `Two-column aggregates (corr/slope/intercept) are not implemented — see issue #3994.`,
+      );
+    }
+    const arg = argc > 0 ? fc.args?.[0] : undefined;
     return {
       type: "aggregate",
       aggregation: { type: "custom", iri },

--- a/packages/core/tests/integration/sparql/custom-aggregate-failloud.test.ts
+++ b/packages/core/tests/integration/sparql/custom-aggregate-failloud.test.ts
@@ -1,0 +1,124 @@
+import { SPARQLParser } from "../../../src/infrastructure/sparql/SPARQLParser";
+import { AlgebraTranslator } from "../../../src/infrastructure/sparql/algebra/AlgebraTranslator";
+import { QueryExecutor } from "../../../src/infrastructure/sparql/executors/QueryExecutor";
+import { InMemoryTripleStore } from "../../../src/infrastructure/rdf/InMemoryTripleStore";
+import { Triple } from "../../../src/domain/models/rdf/Triple";
+import { IRI } from "../../../src/domain/models/rdf/IRI";
+import { Literal } from "../../../src/domain/models/rdf/Literal";
+
+const EX = "http://example.org/";
+const AGG = "https://exocortex.my/ontology/agg#";
+const XSD_INTEGER = new IRI("http://www.w3.org/2001/XMLSchema#integer");
+
+/**
+ * @req:0a8977bb-51f8-469b-a0f2-b2514ac45290
+ *
+ * Guard for the two SILENT failure modes of the `agg:` custom-aggregate path,
+ * both measured on published CLI 16.230.0 against a real vault before the fix:
+ *
+ *   agg:bogusZzz(?n)     →  [ {}, {}, {} … ]   no error, no aggregation at all
+ *   agg:median(?n, ?n)   →  "33"                2nd argument SILENTLY dropped
+ *
+ * Neither raised. Both returned output that reads as data — the second is the exact
+ * shape a user writes for a two-column statistic (`agg:corr(?x, ?y)`, #3994) and it
+ * answered with a plausible ONE-column number.
+ *
+ * Revert-verify (each axis fails alone, the other three stay green):
+ *   • drop the `iri.startsWith(EXO_AGGREGATE_NS)` throw in customAggregateIri
+ *       → axis 1 RED (the unknown name degrades to a plain function call again)
+ *   • drop the `argc > 1` throw in translateCustomAggregateFunctionCall
+ *       → axis 3 RED (the extra argument is silently dropped again)
+ *   • axes 2 and 4 are the non-vacuity controls: they must stay GREEN under BOTH
+ *     mutations, otherwise the guards reach past their stated scope.
+ */
+describe("agg: custom aggregates fail loudly instead of degrading silently", () => {
+  let parser: SPARQLParser;
+  let translator: AlgebraTranslator;
+  let executor: QueryExecutor;
+  let store: InMemoryTripleStore;
+
+  beforeEach(async () => {
+    parser = new SPARQLParser();
+    translator = new AlgebraTranslator();
+    store = new InMemoryTripleStore();
+    executor = new QueryExecutor(store);
+    await store.addAll(
+      [10, 20, 30, 40, 50].map(
+        (v, i) =>
+          new Triple(
+            new IRI(`${EX}s${i}`),
+            new IRI(`${EX}val`),
+            new Literal(String(v), XSD_INTEGER),
+          ),
+      ),
+    );
+  });
+
+  const run = async (q: string) => {
+    const algebra = translator.translate(parser.parse(q));
+    return executor.executeAll(algebra);
+  };
+
+  it("axis 1 — an UNREGISTERED name inside the agg: namespace raises and names the registered ones", async () => {
+    await expect(
+      run(`
+        PREFIX ex: <${EX}>
+        PREFIX agg: <${AGG}>
+        SELECT (agg:bogusZzz(?v) AS ?r) WHERE { ?s ex:val ?v }
+      `),
+    ).rejects.toThrow(/Unknown aggregate agg:bogusZzz/);
+
+    // The message must be actionable, not merely loud: it lists what IS registered so a
+    // typo is self-correcting. Asserted separately so a bare "throws" cannot pass this.
+    await expect(
+      run(`
+        PREFIX ex: <${EX}>
+        PREFIX agg: <${AGG}>
+        SELECT (agg:bogusZzz(?v) AS ?r) WHERE { ?s ex:val ?v }
+      `),
+    ).rejects.toThrow(/agg:median/);
+
+    // `agg:corr` is the name a user reaches for after reading #3994. It is caught by
+    // THIS guard (unregistered name), not by the arity guard — asserted here so each
+    // mutant below drops exactly one axis.
+    await expect(
+      run(`
+        PREFIX ex: <${EX}>
+        PREFIX agg: <${AGG}>
+        SELECT (agg:corr(?v, ?v) AS ?r) WHERE { ?s ex:val ?v }
+      `),
+    ).rejects.toThrow(/Unknown aggregate agg:corr/);
+  });
+
+  it("axis 2 — a function OUTSIDE the agg: namespace is untouched (non-vacuity control)", async () => {
+    // Scope control: the guard must key on the agg: namespace, not on "unknown IRI".
+    // An ordinary function call in another namespace still flows to the non-aggregate
+    // path exactly as before — it must NOT be turned into an error by this change.
+    const rows = await run(`
+      PREFIX ex: <${EX}>
+      SELECT (ex:myFunction(?v) AS ?r) WHERE { ?s ex:val ?v }
+    `);
+    expect(Array.isArray(rows)).toBe(true);
+  });
+
+  it("axis 3 — a wrong-arity call to a REGISTERED aggregate raises and points at #3994", async () => {
+    await expect(
+      run(`
+        PREFIX ex: <${EX}>
+        PREFIX agg: <${AGG}>
+        SELECT (agg:median(?v, ?v) AS ?r) WHERE { ?s ex:val ?v }
+      `),
+    ).rejects.toThrow(/takes exactly 1 argument, got 2/);
+
+  });
+
+  it("axis 4 — a correct single-argument call is unaffected (non-vacuity control)", async () => {
+    const rows = await run(`
+      PREFIX ex: <${EX}>
+      PREFIX agg: <${AGG}>
+      SELECT (agg:median(?v) AS ?med) WHERE { ?s ex:val ?v }
+    `);
+    expect(rows).toHaveLength(1);
+    expect(Number(String((rows[0].get("med") as { value?: string })?.value ?? ""))).toBe(30);
+  });
+});


### PR DESCRIPTION
## What

Two **silent** failure modes in the `agg:` custom-aggregate path. Measured on published CLI 16.230.0 against a real vault (~1.8k assets) — neither raised, both returned output that reads as data:

```
agg:bogusZzz(?n)     →  [ {}, {}, {} … ]   no error, no aggregation at all
agg:median(?n, ?n)   →  "33"                2nd argument SILENTLY dropped
```

The second is the dangerous one: it is **exactly the shape a user writes for a two-column statistic** (`agg:corr(?x, ?y)`, #3994) and it answers with a plausible ONE-column number. Shipping #3994 later without this guard would leave a partial implementation indistinguishable from a working one.

## Root cause

| | before |
|---|---|
| `customAggregateIri()` | unregistered IRI → `null` → call re-read as an **ordinary function** → never aggregated → one empty solution per row |
| `translateCustomAggregateFunctionCall()` | threaded `args[0]` only, discarded the rest **without comment** |

## Fix

Both in `AggregateTranslator`:

- **Unknown name:** inside the `agg:` namespace the polarity is **inverted** — registered names are enumerated as *safe*, everything else raises and **lists what IS registered** (so a typo is self-correcting). Outside the namespace nothing changes: `ex:foo(?v)` is still a normal function call, not an aggregate.
- **Wrong arity:** a registered aggregate called with >1 argument raises, naming the arity **and pointing at #3994** — otherwise the user is told "wrong arity" and left guessing whether two-column statistics exist at all.

## Revert-verify

Each mutant drops **exactly its own axis**; the two controls stay green under **both**:

| run | red axes |
|---|---|
| control (no mutation) | **0** |
| drop the unknown-name guard | `axis 1` only |
| drop the arity guard | `axis 3` only |

⛤ The first mutant attempt (`if (false)`) reported BROKEN rather than red — it removed TypeScript **narrowing** (`iri: string \| null`), so the suite stopped compiling instead of changing behaviour. Replaced with a condition that keeps the same call shape and is never true at runtime, so the mutant measures behaviour and not the type-checker.

Axes 2 and 4 are the non-vacuity controls: a non-`agg:` function is untouched, and a correct single-argument call is unaffected.

## Gates

- core: **385/385 suites, 8698 tests, 0 failed**
- all five `lint`-job guards rc=0 — cli-types, test-types, shard-assignments, coverage-monotonic, antipatterns

⚠ 51 suites failed on the first local run and **none of it was this change**: the worktree's copied `node_modules` predated main (js-yaml 4.1.1 against `^5.3.0` manifests, missing `@kitelev/exocortex-core` + `test-utils` symlinks, missing `nanotar`, empty `exoas-exocmd` submodule). Restoring CI parity took it to 385/385 without touching the diff. Diagnosed by the control-first discipline: the **pristine** suite failed identically.

## Scope

Does **not** implement two-column aggregates — it makes their absence loud. #3994 stays open and is now safe to land incrementally.

@req:0a8977bb-51f8-469b-a0f2-b2514ac45290 (approved)

Refs #3994

https://claude.ai/code/session_01RLVkQZvShweokvfZUCn7wE
