### PR TITLE
feat(cli): remove-property distinguishes guarded properties by whether a CLEARING command exists

### DIFF
--- a/packages/cli/src/commands/propertyMutationShared.ts
+++ b/packages/cli/src/commands/propertyMutationShared.ts
@@ -72,6 +72,20 @@ export interface GuardedRoute {
   readonly argSuffix?: string;
   /** Rendered in parentheses after the invocation. */
   readonly note?: string;
+  /**
+   * The subset of {@link commands} that CLEARS the property (as opposed to
+   * setting it). Empty/absent means no sanctioned way to remove it exists.
+   *
+   * ⛤ Why this is a FIELD and not prose: the distinction was already stated —
+   * in `note`, in English, on three of thirteen routes ("start-effort sets it;
+   * the others clear it"). Prose cannot be consulted by the delete-side guard,
+   * so `remove-property` answered BOTH cases identically and, for a property
+   * with no clearing command, named commands that cannot help: they set a
+   * different value, they do not remove the key. The operation then left the
+   * product entirely (a raw Bash strip past the PreToolUse hooks) — the same
+   * failure mode issue #3926 closed for unknown properties (req 148ce5a4).
+   */
+  readonly clearedBy?: readonly string[];
 }
 
 /**
@@ -120,14 +134,17 @@ export const GUARDED_ROUTES: Record<string, GuardedRoute> = {
   // so the commands below both SET and CLEAR depending on direction.
   ems__Effort_startTimestamp: {
     commands: ["start-effort", "rollback-to-backlog", "park-waiting"],
+    clearedBy: ["rollback-to-backlog", "park-waiting"],
     note: "start-effort sets it; the others clear it as a side effect of the status change",
   },
   ems__Effort_endTimestamp: {
     commands: ["mark-done", "re-open"],
+    clearedBy: ["re-open"],
     note: "mark-done sets it; re-open clears it as a side effect of the status change",
   },
   ems__Effort_resolutionTimestamp: {
     commands: ["mark-done", "re-open"],
+    clearedBy: ["re-open"],
     note: "mark-done sets it; re-open clears it as a side effect of the status change",
   },
   // Plan / schedule dates — dedicated commands.
@@ -147,9 +164,13 @@ export const GUARDED_ROUTES: Record<string, GuardedRoute> = {
   // Archive flag (bare `archived:` in frontmatter; `exo__Asset_archived` when
   // prefixed) — dedicated archive/un-archive commands (un-archive has a Done
   // precondition).
-  archived: { commands: ["archive", "archive-ontologically", "un-archive"] },
+  archived: {
+    commands: ["archive", "archive-ontologically", "un-archive"],
+    clearedBy: ["un-archive"],
+  },
   exo__Asset_archived: {
     commands: ["archive", "archive-ontologically", "un-archive"],
+    clearedBy: ["un-archive"],
   },
 };
 
@@ -268,6 +289,49 @@ export const IMMUTABLE_PROPERTIES: Record<string, string> = {
  * @param verb - the primitive's own verb, e.g. `set` / `remove`
  * @param command - the CLI name of that primitive, e.g. `set-property`
  */
+/**
+ * The route restricted to its CLEARING commands, or `undefined` when the
+ * property has no sanctioned removal path at all.
+ *
+ * ⛔ Returning `undefined` is NOT "not guarded" — the property stays guarded on
+ * the SET side. It means the delete-side guard has nothing to route the user
+ * to, which is the case `remove-property --force` exists for (req 148ce5a4).
+ */
+export function clearingRouteFor(property: string): GuardedRoute | undefined {
+  const route = guardedRouteFor(property);
+  if (route === undefined) return undefined;
+  const clearing = route.clearedBy ?? [];
+  if (clearing.length === 0) return undefined;
+  // ⛔ `note` is dropped on purpose: it explains the FULL route ("mark-done sets
+  // it; re-open clears it"), so carrying it into a narrowed one re-introduces
+  // exactly the setter this narrowing exists to withhold — and does it in prose,
+  // where the caller's `not.toContain` reads it as a real offer.
+  const { note: _fullRouteNote, ...rest } = route;
+  return { ...rest, commands: clearing };
+}
+
+/**
+ * The refusal for a guarded property whose route contains NO clearing command.
+ *
+ * ⛤ Deliberately does NOT list `route.commands`: every one of them SETS a
+ * value, so naming them answers a question the user did not ask and reads as
+ * "here is your path" when there is none.
+ *
+ * ⛔ Wording is constrained by {@link ErrorHandler.classifyError}, which picks
+ * the exit code by SUBSTRING — "transition"/"transaction"/"concurrent"/
+ * "modified"/"not found"/"Invalid" all reroute it. The
+ * `guard messages do not collide with the exit-code classifier` axis in
+ * `tests/unit/guardedRoutes.test.ts` locks this for the whole family.
+ */
+export function renderNoClearingPathRefusal(property: string): string {
+  return (
+    `Refusing to remove "${property}" via remove-property — it is guarded, and ` +
+    `no dedicated command clears it (the ones that own it assign a value). ` +
+    `If dropping the facet is intended, say so explicitly:  ` +
+    `--force --reason "<why>"`
+  );
+}
+
 export function renderGuardRefusal(
   verb: string,
   command: string,

--- a/packages/cli/src/commands/remove-property.ts
+++ b/packages/cli/src/commands/remove-property.ts
@@ -11,8 +11,10 @@ import {
 import {
   DEFAULT_TIMEZONE,
   UPDATED_AT_KEY,
+  clearingRouteFor,
   guardedRouteFor,
   renderGuardedRouteResolved,
+  renderNoClearingPathRefusal,
   renderGuardRefusal,
   IMMUTABLE_PROPERTIES,
   canonicalYamlKey,
@@ -29,6 +31,8 @@ interface RemovePropertyOptions {
   frozenClock?: string;
   dryRun?: boolean;
   yes?: boolean;
+  force?: boolean;
+  reason?: string;
 }
 
 /**
@@ -130,6 +134,14 @@ export function removePropertyCommand(): Command {
       "--frozen-clock <iso>",
       "Freeze the updatedAt clock to an ISO timestamp for test/replay",
     )
+    .option(
+      "--force",
+      "Remove a guarded property that has NO clearing command (requires --reason). Refused when a clearing command exists — see req 148ce5a4.",
+    )
+    .option(
+      "--reason <text>",
+      "Why the guarded property is being dropped; recorded on stderr as the audit trail of a deliberate bypass",
+    )
     .option("--dry-run", "Preview the resulting frontmatter without writing")
     .option(
       "--yes",
@@ -190,16 +202,38 @@ export function removePropertyCommand(): Command {
         // cannot resolve is not a sanctioned path, and offering it as one is how
         // three phantoms left users with no path at all (req 72419d3c, issue #4103).
         // An empty registry fails OPEN — see renderGuardedRouteResolved.
+        // ⛤ Two cases the old guard answered identically (req 148ce5a4):
+        //   (a) a CLEARING command exists  → refuse, naming ONLY the clearers;
+        //   (b) none does                  → refuse, saying so, and offer the
+        //       audited --force path. Naming the setters here is worse than
+        //       naming nothing: they cannot remove the key, so the user is sent
+        //       down a path that does not exist and ends up stripping the key
+        //       with raw Bash — past the PreToolUse hooks and the SHACL floor.
+        // ⛔ --force does NOT override case (a): a bypass that also covers the
+        //   properties WITH a sanctioned path would not widen the guard, it
+        //   would repeal it.
         const guardedRoute = guardedRouteFor(property);
         if (guardedRoute !== undefined) {
-          const known = await new CommandNameRegistry(vaultPath).collect();
-          throw new Error(
-            renderGuardRefusal(
-              "remove",
-              "remove-property",
-              property,
-              renderGuardedRouteResolved(guardedRoute, known),
-            ),
+          const clearingRoute = clearingRouteFor(property);
+          if (clearingRoute !== undefined) {
+            const known = await new CommandNameRegistry(vaultPath).collect();
+            throw new Error(
+              renderGuardRefusal(
+                "remove",
+                "remove-property",
+                property,
+                renderGuardedRouteResolved(clearingRoute, known),
+              ),
+            );
+          }
+          const reason =
+            typeof options.reason === "string" ? options.reason.trim() : "";
+          if (options.force !== true || reason.length === 0) {
+            throw new Error(renderNoClearingPathRefusal(property));
+          }
+          // The bypass is deliberate — leave a trail that says so.
+          console.error(
+            `[guard-bypass] remove-property "${property}" on ${vaultRelative} — reason: ${reason}`,
           );
         }
 

--- a/packages/cli/tests/integration/guarded-route-resolution.integration.test.ts
+++ b/packages/cli/tests/integration/guarded-route-resolution.integration.test.ts
@@ -41,6 +41,11 @@ function buildVault(vault: string, withCommands: boolean): void {
       "exo__Asset_uid: cafe0000-0000-0000-0000-000000000001",
       "exo__Asset_label: target",
       'ems__Effort_status: "[[753a44d5-846c-4b82-9196-4fd9a4d48777]]"',
+      // ⛤ req 148ce5a4: the remove-side axis below needs a property that HAS a
+      // clearing command — `ems__Effort_status` no longer renders a route at all
+      // (all five of its commands set a value). `endTimestamp` is cleared by
+      // `re-open`, so it still exercises the live-registry filter this file locks.
+      "ems__Effort_endTimestamp: 2026-08-21T10:00:00",
       "---",
       "",
     ].join("\n"),
@@ -50,11 +55,13 @@ function buildVault(vault: string, withCommands: boolean): void {
 
   const cmdDir = path.join(vault, "assetspaces/kitelev/exoas-exocmd/exocmd");
   fs.mkdirSync(cmdDir, { recursive: true });
-  fs.writeFileSync(
-    path.join(cmdDir, "mark-done.md"),
-    ["---", "exocmd__Command_cliName: mark-done", "---", ""].join("\n"),
-    "utf-8",
-  );
+  for (const name of ["mark-done", "re-open"]) {
+    fs.writeFileSync(
+      path.join(cmdDir, `${name}.md`),
+      ["---", `exocmd__Command_cliName: ${name}`, "---", ""].join("\n"),
+      "utf-8",
+    );
+  }
 }
 
 describe("guarded-route resolution reaches the user @req:72419d3c-b425-4a0e-ad42-346853efc9cf", () => {
@@ -123,13 +130,16 @@ describe("guarded-route resolution reaches the user @req:72419d3c-b425-4a0e-ad42
     spies();
 
     await removePropertyCommand().parseAsync(
-      [TARGET_REL, "--property", "ems__Effort_status", "--vault", vault],
+      [TARGET_REL, "--property", "ems__Effort_endTimestamp", "--vault", vault],
       { from: "user" },
     );
 
     const out = stderrText();
-    expect(out).toContain("mark-done");
-    expect(out).not.toContain("move-to-backlog");
+    // `re-open` clears the property AND resolves in this vault → it is offered.
+    expect(out).toContain("re-open");
+    // `mark-done` resolves here too, but it SETS the property — the narrowed
+    // route withholds it (req 148ce5a4). Both filters are exercised at once.
+    expect(out).not.toContain("mark-done");
   });
 
   it(`⛔ an UNMOUNTED registry keeps today's full sentence — fail-open @req:${REQ}`, async () => {

--- a/packages/cli/tests/integration/remove-property-clearing-discriminator.integration.test.ts
+++ b/packages/cli/tests/integration/remove-property-clearing-discriminator.integration.test.ts
@@ -54,7 +54,11 @@ function buildVault(vault: string): void {
   }
 }
 
-describe(`remove-property clearing discriminator @req:${REQ}`, () => {
+// ⛔ The describe title carries the binding as a LITERAL: `@req:${REQ}` in a
+// template is not statically resolvable, so `requirements audit` (and archgate
+// REQ-001) cannot see it — the requirement would read as unbound. Same shape,
+// same reason, as the sibling guarded-route-resolution file.
+describe("remove-property clearing discriminator @req:148ce5a4-f9b8-4544-9897-e5bd9755981a", () => {
   let vault: string;
   let errorSpy: ReturnType<typeof jest.spyOn>;
   let exitSpy: ReturnType<typeof jest.spyOn>;

--- a/packages/cli/tests/integration/remove-property-clearing-discriminator.integration.test.ts
+++ b/packages/cli/tests/integration/remove-property-clearing-discriminator.integration.test.ts
@@ -1,0 +1,160 @@
+/**
+ * @file `remove-property` distinguishes guarded properties by whether a CLEARING
+ * command exists — and only where none does is an audited `--force` accepted.
+ *
+ * ⛤ Why integration and not unit: the guarantee is about the sentence the user
+ * reads and the file on disk. `clearingRouteFor` can be perfectly correct while
+ * the command still routes both cases through the old branch — reverting the
+ * wiring in `remove-property.ts` leaves every unit axis green, because none of
+ * them goes through the command.
+ *
+ * ⛔ The bearing pair is A1 (clearing command EXISTS → refuse, name it) against
+ * A5 (`--force` on that same property → still refused). Without A5 the flag
+ * would be a universal repeal of the guard rather than a widening of it.
+ *
+ * req 148ce5a4-f9b8-4544-9897-e5bd9755981a
+ */
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { jest } from "@jest/globals";
+
+const { removePropertyCommand } =
+  await import("../../src/commands/remove-property.js");
+
+const REQ = "148ce5a4-f9b8-4544-9897-e5bd9755981a";
+const TARGET_REL = "assetspaces/kitelev/exoas-my/my/target.md";
+
+/** A vault whose target carries BOTH a no-clearing property and a clearable one. */
+function buildVault(vault: string): void {
+  const target = path.join(vault, TARGET_REL);
+  fs.mkdirSync(path.dirname(target), { recursive: true });
+  fs.writeFileSync(
+    target,
+    [
+      "---",
+      "exo__Asset_uid: cafe0000-0000-0000-0000-0000000000c1",
+      "exo__Asset_label: target",
+      'ems__Effort_status: "[[753a44d5-846c-4b82-9196-4fd9a4d48777]]"',
+      "ems__Effort_endTimestamp: 2026-08-21T10:00:00",
+      "---",
+      "",
+    ].join("\n"),
+    "utf-8",
+  );
+  // `re-open` clears endTimestamp; it must RESOLVE for the route to be offered.
+  const cmdDir = path.join(vault, "assetspaces/kitelev/exoas-exocmd/exocmd");
+  fs.mkdirSync(cmdDir, { recursive: true });
+  for (const name of ["re-open", "mark-done"]) {
+    fs.writeFileSync(
+      path.join(cmdDir, `${name}.md`),
+      ["---", `exocmd__Command_cliName: ${name}`, "---", ""].join("\n"),
+      "utf-8",
+    );
+  }
+}
+
+describe(`remove-property clearing discriminator @req:${REQ}`, () => {
+  let vault: string;
+  let errorSpy: ReturnType<typeof jest.spyOn>;
+  let exitSpy: ReturnType<typeof jest.spyOn>;
+  let logSpy: ReturnType<typeof jest.spyOn>;
+  let stdoutSpy: ReturnType<typeof jest.spyOn>;
+  let stderrSpy: ReturnType<typeof jest.spyOn>;
+
+  beforeEach(() => {
+    vault = fs.mkdtempSync(path.join(os.tmpdir(), "cli-clearing-"));
+    buildVault(vault);
+    exitSpy = jest
+      .spyOn(process, "exit")
+      .mockImplementation((() => undefined as never) as never);
+    stdoutSpy = jest
+      .spyOn(process.stdout, "write")
+      .mockImplementation((() => true) as never);
+    stderrSpy = jest
+      .spyOn(process.stderr, "write")
+      .mockImplementation((() => true) as never);
+    logSpy = jest.spyOn(console, "log").mockImplementation(() => {});
+    errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    exitSpy.mockRestore();
+    stdoutSpy.mockRestore();
+    stderrSpy.mockRestore();
+    logSpy.mockRestore();
+    errorSpy.mockRestore();
+    fs.rmSync(vault, { recursive: true, force: true });
+  });
+
+  const stderrText = (): string => errorSpy.mock.calls.flat().join("\n");
+  const frontmatter = (): string =>
+    fs.readFileSync(path.join(vault, TARGET_REL), "utf-8");
+
+  const run = async (...extra: string[]): Promise<void> => {
+    await removePropertyCommand().parseAsync(
+      [TARGET_REL, "--vault", vault, ...extra],
+      { from: "user" },
+    );
+  };
+
+  it(`A1 clearing command exists → refuse naming ONLY the clearer @req:${REQ}`, async () => {
+    await run("--property", "ems__Effort_endTimestamp");
+    const out = stderrText();
+    expect(out).toContain("dedicated guarded command");
+    expect(out).toContain("re-open");
+    // `mark-done` owns the property but SETS it — naming it answers a question
+    // the user did not ask and reads as a path that does not remove anything.
+    expect(out).not.toContain("mark-done");
+    expect(frontmatter()).toContain("ems__Effort_endTimestamp");
+  });
+
+  it(`A2 no clearing command → refusal says so and offers --force @req:${REQ}`, async () => {
+    await run("--property", "ems__Effort_status");
+    const out = stderrText();
+    expect(out).toContain("no dedicated command clears it");
+    expect(out).toContain("--force");
+    expect(out).toContain("--reason");
+    // ⛔ The setters must NOT be offered: they cannot remove the key.
+    expect(out).not.toContain("move-to-backlog");
+    expect(frontmatter()).toContain("ems__Effort_status");
+  });
+
+  it(`A3 --force without --reason is refused @req:${REQ}`, async () => {
+    await run("--property", "ems__Effort_status", "--force");
+    expect(stderrText()).toContain("no dedicated command clears it");
+    expect(frontmatter()).toContain("ems__Effort_status");
+  });
+
+  it(`A4 --force --reason removes it and records the reason @req:${REQ}`, async () => {
+    await run(
+      "--property",
+      "ems__Effort_status",
+      "--force",
+      "--reason",
+      "facet moved to 7db5eeff",
+      "--yes",
+    );
+    const fm = frontmatter();
+    expect(fm).not.toContain("ems__Effort_status");
+    expect(fm).toContain("exo__Asset_updatedAt");
+    const out = stderrText();
+    expect(out).toContain("guard-bypass");
+    expect(out).toContain("facet moved to 7db5eeff");
+  });
+
+  it(`A5 --force does NOT override a property that HAS a clearer @req:${REQ}`, async () => {
+    await run(
+      "--property",
+      "ems__Effort_endTimestamp",
+      "--force",
+      "--reason",
+      "I want to",
+      "--yes",
+    );
+    const out = stderrText();
+    expect(out).toContain("dedicated guarded command");
+    expect(out).toContain("re-open");
+    expect(frontmatter()).toContain("ems__Effort_endTimestamp");
+  });
+});

--- a/packages/cli/tests/integration/remove-property-unknown-name.integration.test.ts
+++ b/packages/cli/tests/integration/remove-property-unknown-name.integration.test.ts
@@ -247,7 +247,11 @@ describe("req 59220c17: remove-property accepts an undeclared property (set-prop
     const r = await runRemove("--property", "ems__Effort_status");
 
     expect(r.exit).not.toContain(0);
-    expect(r.errorLog).toContain("dedicated guarded command");
+    // ⛤ req 148ce5a4 changed WHAT the refusal can offer, not WHETHER it refuses:
+    // `ems__Effort_status` has no clearing command, so the sentence says so
+    // instead of naming setters. The contrast this axis draws — undeclared is
+    // accepted, guarded is not — is unchanged.
+    expect(r.errorLog).toContain("no dedicated command clears it");
     expect(r.content).toBe(before);
   });
 });

--- a/packages/cli/tests/integration/remove-property.integration.test.ts
+++ b/packages/cli/tests/integration/remove-property.integration.test.ts
@@ -269,17 +269,20 @@ describe("Issue #3926: `cli remove-property` deletes a non-guarded frontmatter p
     expect(out.exit).toContain(1);
     expect(out.exit).not.toContain(0);
     expect(out.errorLog).toMatch(/Refusing to remove "ems__Effort_status"/);
-    expect(out.errorLog).toMatch(/mark-done|move-to-backlog|start-effort/);
+    // ⛤ req 148ce5a4: the setters are no longer named. All five commands routed
+    // for this property are TRANSITIONS — they assign a value, none removes the
+    // key, so offering them sent the user down a path that does not exist.
+    expect(out.errorLog).toMatch(/no dedicated command clears it/);
+    expect(out.errorLog).not.toMatch(/mark-done|move-to-backlog|start-effort/);
     // File byte-identical — the guard did not delete anything.
     expect(out.content).toBe(before);
   });
 
+  // ⛤ req 148ce5a4 split this table in two. The guarantee is unchanged for both
+  // halves — refuse, leave the file byte-identical — but WHAT the refusal can
+  // offer is not: only a property with a CLEARING command has a path to name.
   it.each([
-    ["exo__Asset_label", /set-label/],
-    ["ems__Effort_parent", /set-parent/],
-    ["ems__Task_zone", /set-criticality/],
-    ["ems__Effort_plannedStartTimestamp", /set-planned-start/],
-    ["archived", /archive-completed|un-archive/],
+    ["archived", /un-archive/],
   ])(
     `REFUSES guarded property %s → dedicated command, file unchanged ${REQ}`,
     async (prop, expectedCommand) => {
@@ -290,6 +293,25 @@ describe("Issue #3926: `cli remove-property` deletes a non-guarded frontmatter p
         new RegExp(`Refusing to remove "${prop}"`),
       );
       expect(out.errorLog).toMatch(expectedCommand);
+      expect(out.content).toBe(before);
+    },
+  );
+
+  it.each([
+    ["exo__Asset_label"],
+    ["ems__Effort_parent"],
+    ["ems__Task_zone"],
+    ["ems__Effort_plannedStartTimestamp"],
+  ])(
+    `REFUSES guarded property %s with no clearing command, file unchanged ${REQ}`,
+    async (prop) => {
+      const before = fs.readFileSync(path.join(vault, taskPath), "utf-8");
+      const out = await run(taskPath, ["--property", prop]);
+      expect(out.exit).toContain(1);
+      expect(out.errorLog).toMatch(
+        new RegExp(`Refusing to remove "${prop}"`),
+      );
+      expect(out.errorLog).toMatch(/no dedicated command clears it/);
       expect(out.content).toBe(before);
     },
   );


### PR DESCRIPTION
## Что не так

`remove-property` отказывает на **любом** guarded-свойстве одним и тем же сообщением,
перечисляя команды его маршрута. Но у маршрута две принципиально разные ситуации:

| | пример | что сегодня печатает отказ |
|---|---|---|
| команда, **снимающая** свойство, есть | `ems__Effort_endTimestamp` ← `re-open` очищает его как side-effect перехода | `mark-done`, `re-open` — половина названного **ставит** значение |
| снимающей команды **нет** | `ems__Effort_status`: все пять команд — переходы | пять команд, **ни одна не удалит ключ** |

Во втором случае пользователь получает «вот твой путь» там, где пути нет: пойдя по любой
названной команде, он запишет другой статус, а не уберёт свойство. Операция «этот ассет
больше не эффорт» невыразима штатно ⇒ уходит в surgical-python **мимо PreToolUse-хуков и
SHACL-флора** — ровно тот разрыв, который issue #3926 закрыл для необъявленных свойств.

⛤ Различие **уже было выражено** — прозой, в поле `note`, у трёх маршрутов из тринадцати
(«start-effort sets it; the others clear it»). Гвард прозу консультировать не может, поэтому
подпись существовала отдельно от механизма и разойтись могла молча.

## Что сделано

- `GuardedRoute.clearedBy` — машинно-читаемое подмножество `commands`, которое СНИМАЕТ свойство.
  Размечены пять маршрутов, где снятие действительно существует (`startTimestamp`,
  `endTimestamp`, `resolutionTimestamp`, `archived`, `exo__Asset_archived`).
- `clearingRouteFor()` — маршрут, суженный до снимающих; `undefined`, если таких нет.
  ⛔ `note` полного маршрута при сужении **отбрасывается**: он объясняет пару set/clear и
  протащил бы обратно ровно тот сеттер, ради сокрытия которого сужение и делается.
- `remove-property` разводит два случая: **(а)** отказ, называющий только снимающие;
  **(б)** отказ, честно говорящий, что снятия нет, + `--force --reason "<why>"` как
  осознанный обход со следом в stderr.
- ⛔ `--force` **не** отменяет случай (а): обход, покрывающий и свойства со штатным путём,
  не расширял бы гвард, а отменял его.

## Приёмка

Новый интеграционный набор (5 осей, гоняет реальную команду против реального temp-vault):

| ось | что запирает |
|---|---|
| A1 | снимающая команда есть ⇒ отказ называет **только** её (`re-open`), не сеттер (`mark-done`) |
| A2 | снимающей нет ⇒ отказ говорит об этом и предлагает `--force`, сеттеры **не** названы |
| A3 | `--force` без `--reason` отвергнут |
| A4 | `--force --reason` снимает свойство, бампает `updatedAt`, пишет причину в stderr |
| A5 | `--force` на свойстве **со** снимающей командой всё равно отвергнут |

⛤ Несущая пара — **A1 против A5**: без A5 флаг был бы универсальной отменой гварда.

**Revert-verify, 4 мутанта, каждый краснит ровно свою ось** (контроль зелёный):

| мутация | краснеет |
|---|---|
| `clearingRouteFor` всегда `undefined` | A1, A5 |
| `--force` не требует причины | A3 |
| `--force` перебивает существующий clearer | A5 |
| `note` полного маршрута не отбрасывается | A1 |

Три пред-существующие оси обновлены: их **гарантия** (отказ + файл байт-в-байт) не менялась,
изменилось лишь то, что отказ может предложить.

⚠ Локально красны три набора (`sparql-exo003`, `cross-runtime-mount-parity`,
`BootstrapAssetSpaceService`) — проверено на **пристинном** дереве: падают и там,
к этому диффу отношения не имеют.

Closes #3795-adjacent gap · req `148ce5a4-f9b8-4544-9897-e5bd9755981a`

https://claude.ai/code/session_01RLVkQZvShweokvfZUCn7wE
