### PR TITLE
feat(plugin): resolve a class wikilink from the file registry when metadataCache is cold (Tier 2)

### DIFF
--- a/packages/obsidian-plugin/src/adapters/ObsidianVaultAdapter.ts
+++ b/packages/obsidian-plugin/src/adapters/ObsidianVaultAdapter.ts
@@ -1,8 +1,25 @@
 import { Vault, TFile, TFolder, MetadataCache, App, parseYaml } from "obsidian";
 import { IVaultAdapter, IFile, IFolder, IFrontmatter, FrontmatterService } from "@kitelev/exocortex-core";
 
+/** A linkpath body that is exactly a uuid — the `uid-bare` wikilink form. */
+const UUID_LINKPATH =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+/** A UID-CANON filename: the uuid is the basename (optionally with a suffix). */
+const UUID_BASENAME =
+  /^([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})/i;
+
 export class ObsidianVaultAdapter implements IVaultAdapter {
   private fileCache: WeakMap<IFile, TFile> = new WeakMap();
+
+  /**
+   * uuid -> vault path, built from the FILE REGISTRY (see
+   * {@link resolveUuidFromRegistry}). Paths, not `IFile`s: a path is re-resolved
+   * through the registry on read, so a since-deleted file yields `null` instead
+   * of a stale object.
+   */
+  private uuidRegistry: Map<string, string> | null = null;
+  /** File count the registry was built from — its cheap invalidation key. */
+  private uuidRegistryCount = -1;
 
   constructor(
     private vault: Vault,
@@ -159,8 +176,60 @@ export class ObsidianVaultAdapter implements IVaultAdapter {
 
   getFirstLinkpathDest(linkpath: string, sourcePath: string): IFile | null {
     const file = this.metadataCache.getFirstLinkpathDest(linkpath, sourcePath);
-    if (!file) return null;
-    return this.fromObsidianFile(file);
+    if (file) return this.fromObsidianFile(file);
+    // Tier 2 (req 7d00a60b): metadataCache is cold (reset index, fresh device,
+    // large re-sync) — fall back to the file registry so class references keep
+    // resolving and rdf:type-gated command buttons still render.
+    return this.resolveUuidFromRegistry(linkpath);
+  }
+
+  /**
+   * Resolve a `uid-bare` linkpath WITHOUT metadataCache (req 7d00a60b, Tier 2).
+   *
+   * `vault.getMarkdownFiles()` is the file REGISTRY — synchronous and separate
+   * from the metadata cache, so it is populated while Obsidian is still
+   * re-indexing. Under the UID-CANON TBox invariant a class file's basename IS
+   * its uuid, so the index is built from NAMES ALONE: no file is read, which is
+   * what makes this affordable on a phone (contrast the CLI's basename/alias
+   * index, which reads every file).
+   *
+   * Scope is deliberately the uuid form only. Measured over 40 656
+   * `exo__Instance_class` values (2026-08-29): `uid-bare` 94.2 % — the ONLY form
+   * that reaches a vault lookup; `uid+alias` 5.4 % and `label-bare` 0.4 %
+   * already resolve upstream in `NoteToRDFConverter.valueToClassURI` (layers 1-2)
+   * without touching the vault at all. Resolving them here would add cost for
+   * callers that never arrive.
+   *
+   * The alias half of `[[uuid|label]]` is stripped first, mirroring the CLI
+   * adapter's `linkpath.split("|")[0]`, so both wikilink spellings land here
+   * identically if a caller ever passes the raw form.
+   */
+  private resolveUuidFromRegistry(linkpath: string): IFile | null {
+    const head = linkpath.split("|")[0].trim();
+    if (!UUID_LINKPATH.test(head)) return null;
+
+    const files = this.vault.getMarkdownFiles();
+    // Rebuild when the file count moved. A rename that keeps the count is not
+    // covered — by then metadataCache has normally caught up and the fallback
+    // is not reached; a stale entry still fails safe, because the path is
+    // re-resolved through the registry below and yields null when it is gone.
+    if (this.uuidRegistry === null || this.uuidRegistryCount !== files.length) {
+      const index = new Map<string, string>();
+      for (const f of files) {
+        const match = UUID_BASENAME.exec(f.basename);
+        // First-write-wins on a duplicate uuid, matching the CLI adapter.
+        if (match && !index.has(match[1].toLowerCase())) {
+          index.set(match[1].toLowerCase(), f.path);
+        }
+      }
+      this.uuidRegistry = index;
+      this.uuidRegistryCount = files.length;
+    }
+
+    const path = this.uuidRegistry.get(head.toLowerCase());
+    if (path === undefined) return null;
+    const resolved = this.vault.getAbstractFileByPath(path);
+    return resolved instanceof TFile ? this.fromObsidianFile(resolved) : null;
   }
 
   async process(file: IFile, fn: (content: string) => string): Promise<string> {

--- a/packages/obsidian-plugin/tests/unit/ObsidianVaultAdapter.test.ts
+++ b/packages/obsidian-plugin/tests/unit/ObsidianVaultAdapter.test.ts
@@ -704,6 +704,119 @@ nested:
     });
   });
 
+  // @req:7d00a60b-5ca3-457e-a160-5bf955e8c195
+  // Tier 2 — a cold metadataCache must not yield ZERO command buttons.
+  // The break it guards: cache cold -> getFirstLinkpathDest null -> the class
+  // wikilink stays a Literal -> walkClassAndPrototypeRelations drops it -> no
+  // rdf:type -> findPaletteEnabledCommands matches nothing.
+  describe("getFirstLinkpathDest — cold metadataCache (Tier 2, req 7d00a60b)", () => {
+    const CLASS_UUID = "1b20a8f0-d745-4e93-91db-4531b3df120e";
+
+    /** A UID-CANON class file: its basename IS the uuid. */
+    function classFile(uuid: string, suffix = "") {
+      const f = Object.create(TFile.prototype);
+      Object.assign(f, {
+        path: `assetspaces/kitelev/exoas-public/ems/${uuid}${suffix}.md`,
+        basename: `${uuid}${suffix}`,
+        name: `${uuid}${suffix}.md`,
+        parent: null,
+      });
+      return f;
+    }
+
+    it("resolves a uid-bare linkpath from the file registry when the cache is cold", () => {
+      const target = classFile(CLASS_UUID);
+      mockMetadataCache.getFirstLinkpathDest.mockReturnValue(null); // cold
+      mockVault.getMarkdownFiles.mockReturnValue([target]);
+      mockVault.getAbstractFileByPath.mockReturnValue(target);
+
+      const result = adapter.getFirstLinkpathDest(CLASS_UUID, "note.md");
+
+      expect(result).not.toBeNull();
+      expect(result!.path).toBe(target.path);
+      expect(result!.basename).toBe(CLASS_UUID);
+    });
+
+    it("does NOT touch the registry when the cache resolves (already-working path untouched)", () => {
+      const cached = classFile(CLASS_UUID);
+      mockMetadataCache.getFirstLinkpathDest.mockReturnValue(cached);
+
+      const result = adapter.getFirstLinkpathDest(CLASS_UUID, "note.md");
+
+      expect(result!.path).toBe(cached.path);
+      // The whole point: a warm cache costs exactly what it cost before.
+      expect(mockVault.getMarkdownFiles).not.toHaveBeenCalled();
+    });
+
+    it("ignores a non-uuid linkpath without building the registry", () => {
+      mockMetadataCache.getFirstLinkpathDest.mockReturnValue(null);
+
+      const result = adapter.getFirstLinkpathDest("ems__Task", "note.md");
+
+      expect(result).toBeNull();
+      // Measured 2026-08-29: label-bare/uid+alias already resolve upstream in
+      // valueToClassURI, so they must not pay for an index they never read.
+      expect(mockVault.getMarkdownFiles).not.toHaveBeenCalled();
+    });
+
+    it("strips the alias half before matching (uuid|label)", () => {
+      const target = classFile(CLASS_UUID);
+      mockMetadataCache.getFirstLinkpathDest.mockReturnValue(null);
+      mockVault.getMarkdownFiles.mockReturnValue([target]);
+      mockVault.getAbstractFileByPath.mockReturnValue(target);
+
+      const result = adapter.getFirstLinkpathDest(
+        `${CLASS_UUID}|ems__Task`,
+        "note.md"
+      );
+
+      expect(result).not.toBeNull();
+      expect(result!.path).toBe(target.path);
+    });
+
+    it("matches a UID-CANON basename that carries a suffix", () => {
+      const target = classFile(CLASS_UUID, "-ems__Task");
+      mockMetadataCache.getFirstLinkpathDest.mockReturnValue(null);
+      mockVault.getMarkdownFiles.mockReturnValue([target]);
+      mockVault.getAbstractFileByPath.mockReturnValue(target);
+
+      const result = adapter.getFirstLinkpathDest(CLASS_UUID, "note.md");
+
+      expect(result!.path).toBe(target.path);
+    });
+
+    it("rebuilds the index when the file count changes", () => {
+      const first = classFile(CLASS_UUID);
+      const secondUuid = "7db5eeff-718a-49b0-8d2b-39b084a356e3";
+      const second = classFile(secondUuid);
+
+      mockMetadataCache.getFirstLinkpathDest.mockReturnValue(null);
+      mockVault.getMarkdownFiles.mockReturnValue([first]);
+      mockVault.getAbstractFileByPath.mockImplementation((p: string) =>
+        p === first.path ? first : p === second.path ? second : null
+      );
+
+      expect(adapter.getFirstLinkpathDest(secondUuid, "note.md")).toBeNull();
+
+      // A new class file lands (ExoSync pull, profile apply) — the count moves.
+      mockVault.getMarkdownFiles.mockReturnValue([first, second]);
+
+      const result = adapter.getFirstLinkpathDest(secondUuid, "note.md");
+      expect(result).not.toBeNull();
+      expect(result!.path).toBe(second.path);
+    });
+
+    it("fails safe when the indexed path no longer resolves", () => {
+      const target = classFile(CLASS_UUID);
+      mockMetadataCache.getFirstLinkpathDest.mockReturnValue(null);
+      mockVault.getMarkdownFiles.mockReturnValue([target]);
+      // The file was deleted after the index was built.
+      mockVault.getAbstractFileByPath.mockReturnValue(null);
+
+      expect(adapter.getFirstLinkpathDest(CLASS_UUID, "note.md")).toBeNull();
+    });
+  });
+
   describe("process", () => {
     it("should process file content", async () => {
       const file: IFile = {


### PR DESCRIPTION
## Problem

A reset Obsidian index yields **ZERO command buttons, not fewer** — and it is all-or-nothing by construction:

```
cold metadataCache
  → getFirstLinkpathDest returns null
  → valueToClassURI falls through to `new Literal(...)`
  → walkClassAndPrototypeRelations drops the non-IRI object
  → the note gets no rdf:type
  → findPaletteEnabledCommands matches nothing
```

On a phone re-indexing a large vault that is minutes-to-hours with the plugin looking broken. Reported from an iPhone: *"пока он не переиндексируется, я не могу пользоваться экзокортексом, так как не отображаются кнопки"*.

The same literal-vs-IRI break is documented independently from a different root (class file absent from disk — RFC `430e84f1` P3), which is what makes it worth fixing at the adapter rather than per-call-site.

## Why this is a NEW requirement, not a bug-fix

`NoteToRDFConverter.ts:198-208` — the docstring of the active req (RFC 8f93ff95) **explicitly defers** this:

> …decoupling the per-file conversion from metadataCache freshness. Wikilink **TARGET** resolution (prototype / Exo 0.0.3 anchors) still flows through the adapter — acceptable for Tier 1 … Full disk-resolution of wikilinks is **Tier 2**.

Tier 1 (an asset's OWN frontmatter) is already decoupled. This closes Tier 2.

`@req:7d00a60b-5ca3-457e-a160-5bf955e8c195` (Approved, P0, bindingClass Component)

## Change

`ObsidianVaultAdapter.getFirstLinkpathDest` falls back to the **file registry** when the cache misses:

- `vault.getMarkdownFiles()` is synchronous and independent of `metadataCache`, so it is already populated while Obsidian re-indexes.
- Under the **UID-CANON TBox invariant** a class file's basename IS its uuid, so the `uuid → path` index is built from **names alone** — *no file is read*. That is what makes it affordable on mobile (contrast `FileSystemVaultAdapter`, whose basename/alias index reads every file, and is `fs-extra`-bound anyway).
- Paths are cached, not `IFile`s: the path is re-resolved through the registry on read, so a since-deleted file yields `null` instead of a stale object.
- Index invalidation keys on `files.length`. A rename that keeps the count is **not** covered — by then metadataCache has normally caught up and the fallback is not reached; a stale entry still fails safe.

**Kept synchronous on purpose.** `IVaultAdapter:84` declares `getFirstLinkpathDest(...): IFile | null`; making it async cascades ~500-1000 LOC through the converter.

### Scope: `uid-bare` only — measured, not assumed

| form | share of 40 656 `exo__Instance_class` values | reaches a vault lookup? |
|---|---|---|
| `uid-bare` | **94.2 %** | **yes** — this PR's path |
| `uid+alias` | 5.4 % | no — resolves in `valueToClassURI` layer 1-2 |
| `label-bare` | 0.4 % | no — same |

The 5.8 % already work on a cold cache. Resolving them here would add cost for callers that never arrive — so the expensive alias index the CLI builds is **not needed at all**. (An earlier draft of this claim said "99.6 % depends on the cache"; execution refuted it.)

## Verification

| gate | result |
|---|---|
| `tsc --noEmit --skipLibCheck` | rc=0, 0 errors |
| unit | **59/59** in `ObsidianVaultAdapter.test.ts` (7 new axes) |
| lint | **delta 0** vs HEAD (276 = 276 problems, all pre-existing) |
| `build` | rc=0 |
| **mobile gate EXECUTED** | `[mobile-loadable] main.js module-evals without Node (67 require(s) intercepted: obsidian, @codemirror/*). Plugin class exported OK.` |
| six lint-job guards | all rc=0 — `check-test-types` compiled **1008** test files (baseline 431 unchanged), `check-cli-types` **116** src files (baseline 13) |

### revert-verify — 4 mutants, each reddens exactly its own axis

| mutant | red axes |
|---|---|
| drop the fallback entirely | 4 resolution axes — the two *"registry untouched"* axes stay **green** (they assert absence of a call) |
| drop the uuid-form guard | `ignores a non-uuid` **and the PRE-EXISTING** `should return null if no linked file` |
| drop count invalidation | `rebuilds the index when the file count changes` |
| drop the path re-resolve | `resolves a uid-bare linkpath…` + `fails safe when the indexed path no longer resolves` |

Source restored byte-for-byte afterwards (sha256 match).

⛤ The second mutant is the informative one: the uuid-form guard turns out to protect an **already-shipped** test too — without it a non-uuid linkpath would walk into the registry.

## Non-goals

- Reading class frontmatter from disk (`vault.adapter.read`) — that is the async half, and `valueToClassURI` needs it only when the basename is not itself resolvable, which UID-CANON makes rare.
- Touching `FileSystemVaultAdapter` (CLI) — it already resolves from disk.
- Any change to `NoteToRDFConverter`.

https://claude.ai/code/session_01Lnkv4spfyz66KS3WG2aN5y
