### PR TITLE
fix(plugin): resolve classIsPrototype through the vault adapter (cold cache)

### DIFF
--- a/packages/core/src/interfaces/IVaultAdapter.ts
+++ b/packages/core/src/interfaces/IVaultAdapter.ts
@@ -70,6 +70,17 @@ export interface IVaultFolderManager {
  */
 export interface IVaultFrontmatterManager {
   getFrontmatter(file: IFile): IFrontmatter | null;
+  /**
+   * Frontmatter with a disk fallback for when the platform's metadata cache is
+   * cold (a reset index, a fresh device, a large re-sync).
+   *
+   * OPTIONAL because it is a platform capability, not a universal contract: an
+   * adapter that already reads the filesystem directly (the CLI one) has no
+   * second tier to fall back to, and the 15 in-memory test adapters have no
+   * disk at all. Callers therefore feature-detect and degrade to the cached
+   * `getFrontmatter` when it is absent.
+   */
+  getFrontmatterWithFallback?(file: IFile): Promise<IFrontmatter | null>;
   updateFrontmatter(
     file: IFile,
     updater: (current: IFrontmatter) => IFrontmatter,

--- a/packages/obsidian-plugin/src/presentation/builders/ButtonGroupsBuilder.ts
+++ b/packages/obsidian-plugin/src/presentation/builders/ButtonGroupsBuilder.ts
@@ -158,7 +158,7 @@ export class ButtonGroupsBuilder {
 
     // Resolve whether the asset's class is a prototype (Issue #2261)
     // This handles UUID-based instanceClass refs like [[64e14e5e-...|ztlk__FleetingNotePrototype]]
-    const classIsPrototype = this.resolveClassIsPrototype(instanceClass);
+    const classIsPrototype = await this.resolveClassIsPrototype(instanceClass);
 
     const visibilityContext: CommandVisibilityContext = {
       instanceClass,
@@ -210,9 +210,21 @@ export class ButtonGroupsBuilder {
    * Check if any of the asset's instance classes is a prototype.
    * Resolves UUID-based class references by looking up the class file's metadata.
    */
-  private resolveClassIsPrototype(instanceClass: string | string[] | null): boolean {
+  private async resolveClassIsPrototype(
+    instanceClass: string | string[] | null,
+  ): Promise<boolean> {
     if (!instanceClass) return false;
-    if (!this.app.metadataCache?.getFirstLinkpathDest) return false;
+
+    // req c3072a80: BOTH cache reads below fail on a cold metadataCache, and the
+    // fall-through yields `false` — so a prototype silently renders the ORDINARY
+    // button set. Route them through the vault adapter, which resolves a class
+    // file from the file registry (req 7d00a60b, Tier 2) and reads frontmatter
+    // with a disk fallback.
+    //
+    // Degrades to the raw cache path when no adapter is wired (test doubles),
+    // so behaviour is unchanged wherever the adapter is absent.
+    const adapter = this.plugin?.vaultAdapter;
+    if (!adapter && !this.app.metadataCache?.getFirstLinkpathDest) return false;
 
     const classes = Array.isArray(instanceClass) ? instanceClass : [instanceClass];
 
@@ -220,12 +232,24 @@ export class ButtonGroupsBuilder {
       const normalized = WikiLinkHelpers.normalize(cls);
       if (!normalized) continue;
 
-      // Try to resolve the class file
-      const classFile = this.app.metadataCache.getFirstLinkpathDest(normalized, "");
+      const classFile = adapter
+        ? adapter.getFirstLinkpathDest(normalized, "")
+        : this.app.metadataCache.getFirstLinkpathDest(normalized, "");
       if (!classFile) continue;
 
-      const classCache = this.app.metadataCache.getFileCache(classFile);
-      const classMeta = classCache?.frontmatter;
+      // `getFrontmatterWithFallback` is an optional platform capability: present
+      // on the Obsidian adapter (cache -> disk), absent on adapters that already
+      // read the filesystem and on in-memory test doubles.
+      let classMeta: Record<string, unknown> | null | undefined;
+      if (adapter) {
+        classMeta = adapter.getFrontmatterWithFallback
+          ? await adapter.getFrontmatterWithFallback(classFile as never)
+          : adapter.getFrontmatter(classFile as never);
+      } else {
+        classMeta = this.app.metadataCache.getFileCache(
+          classFile as never,
+        )?.frontmatter;
+      }
       if (!classMeta) continue;
 
       // Check if the class file has exo__Prototype in its instanceClass

--- a/packages/obsidian-plugin/tests/unit/builders/buttonGroups/ButtonGroupsBuilder.prototypeColdCache.test.ts
+++ b/packages/obsidian-plugin/tests/unit/builders/buttonGroups/ButtonGroupsBuilder.prototypeColdCache.test.ts
@@ -1,0 +1,145 @@
+/**
+ * classIsPrototype under a COLD metadataCache — @req:c3072a80-5b1b-433e-b5b3-57006ff47682
+ *
+ * On a cold cache both of the old cache reads fail (`getFirstLinkpathDest` -> null,
+ * then `getFileCache` -> null) and the fall-through yields `false`, so a prototype
+ * silently renders the ORDINARY button set. These axes lock the fix: the class file
+ * is located through the vault adapter (which falls back to the file registry, req
+ * 7d00a60b) and its frontmatter is read with the adapter's disk fallback.
+ *
+ * ⛔ A mutant on `1bd848a6` that reduced BOTH copies of `resolveClassIsPrototype` to
+ * `return false` left 18 suites / 275 tests green — the property was specified by
+ * nothing. That is why these axes exist.
+ */
+import {
+  setupButtonGroupsBuilderTest,
+  ButtonGroupsBuilderTestContext,
+  TFile,
+} from "./ButtonGroupsBuilder.fixtures";
+
+const PROTOTYPE_UID = "ebf717aa-4070-4b37-abde-10a700e354fc";
+
+/** A class file whose frontmatter marks it as a prototype. */
+const classFile = { path: "classes/Proto.md", basename: "Proto", name: "Proto.md" };
+
+/**
+ * An adapter whose cache is COLD: it resolves the class file (the file registry
+ * still works) and only yields frontmatter through the disk fallback.
+ */
+function coldAdapter(opts: { withFallback?: boolean } = {}) {
+  const withFallback = opts.withFallback !== false;
+  const adapter: Record<string, unknown> = {
+    getFirstLinkpathDest: jest.fn().mockReturnValue(classFile),
+    // cold cache: the synchronous, cache-backed read yields nothing
+    getFrontmatter: jest.fn().mockReturnValue(null),
+  };
+  if (withFallback) {
+    adapter.getFrontmatterWithFallback = jest
+      .fn()
+      .mockResolvedValue({ exo__Instance_class: `[[${PROTOTYPE_UID}]]` });
+  }
+  return adapter;
+}
+
+/** Drive `build()` far enough to compute the visibility context, and capture it. */
+async function captureContext(ctx: ButtonGroupsBuilderTestContext) {
+  const captured: Record<string, unknown>[] = [];
+  (ctx.builder as unknown as { builders: unknown[] }).builders = [
+    {
+      build: async (c: { visibilityContext: Record<string, unknown> }) => {
+        captured.push(c.visibilityContext);
+        return []; // no buttons — the group is dropped, we only want the context
+      },
+      getGroupId: () => "capture",
+      getGroupTitle: () => "capture",
+    },
+  ];
+
+  const file = { path: "n.md", parent: { path: "N" }, basename: "n" } as TFile;
+  ctx.mockMetadataExtractor.extractMetadata.mockReturnValue({});
+  ctx.mockMetadataExtractor.extractInstanceClass.mockReturnValue("[[Proto]]");
+  ctx.mockMetadataExtractor.extractStatus.mockReturnValue(null);
+  ctx.mockMetadataExtractor.extractIsArchived.mockReturnValue(false);
+  ctx.mockFolderRepairService.getExpectedFolder.mockResolvedValue(null);
+
+  await ctx.builder.build(file);
+  return captured[0];
+}
+
+describe("ButtonGroupsBuilder — classIsPrototype on a cold metadataCache", () => {
+  let ctx: ButtonGroupsBuilderTestContext;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    ctx = setupButtonGroupsBuilderTest();
+  });
+
+  it("P1 resolves a prototype class from disk when the cache is cold", async () => {
+    ctx.mockPlugin.vaultAdapter = coldAdapter();
+
+    const result = await (
+      ctx.builder as unknown as {
+        resolveClassIsPrototype: (c: string) => Promise<boolean>;
+      }
+    ).resolveClassIsPrototype("[[Proto]]");
+
+    expect(result).toBe(true);
+  });
+
+  it("P2 locates the class file through the ADAPTER, not the raw metadataCache", async () => {
+    const adapter = coldAdapter();
+    ctx.mockPlugin.vaultAdapter = adapter;
+
+    await captureContext(ctx);
+
+    expect(adapter.getFirstLinkpathDest).toHaveBeenCalled();
+  });
+
+  it("P3 reads the class frontmatter through the DISK fallback", async () => {
+    const adapter = coldAdapter();
+    ctx.mockPlugin.vaultAdapter = adapter;
+
+    await captureContext(ctx);
+
+    expect(adapter.getFrontmatterWithFallback).toHaveBeenCalled();
+  });
+
+  it("P4 puts a resolved BOOLEAN into the visibility context (locks the await)", async () => {
+    ctx.mockPlugin.vaultAdapter = coldAdapter();
+
+    const visibility = await captureContext(ctx);
+
+    // ⛔ Without the `await` at the call site this is a Promise — truthy, so a
+    // plain `toBe(true)` would NOT catch it. Assert the type as well.
+    expect(typeof visibility.classIsPrototype).toBe("boolean");
+    expect(visibility.classIsPrototype).toBe(true);
+  });
+
+  it("P5 degrades to the cached getFrontmatter when the adapter has no disk fallback", async () => {
+    const adapter = coldAdapter({ withFallback: false });
+    (adapter.getFrontmatter as jest.Mock).mockReturnValue({
+      exo__Instance_class: `[[${PROTOTYPE_UID}]]`,
+    });
+    ctx.mockPlugin.vaultAdapter = adapter;
+
+    const visibility = await captureContext(ctx);
+
+    expect(adapter.getFrontmatter).toHaveBeenCalled();
+    expect(visibility.classIsPrototype).toBe(true);
+  });
+
+  it("P6 keeps the legacy metadataCache path when no adapter is wired", async () => {
+    ctx.mockPlugin.vaultAdapter = undefined;
+    ctx.mockApp.metadataCache = {
+      getFirstLinkpathDest: jest.fn().mockReturnValue(classFile),
+      getFileCache: jest.fn().mockReturnValue({
+        frontmatter: { exo__Instance_class: `[[${PROTOTYPE_UID}]]` },
+      }),
+    };
+
+    const visibility = await captureContext(ctx);
+
+    expect(ctx.mockApp.metadataCache.getFirstLinkpathDest).toHaveBeenCalled();
+    expect(visibility.classIsPrototype).toBe(true);
+  });
+});


### PR DESCRIPTION
Addresses #4200 — **partially, and the measurement contradicts the issue's own proposal.**

## What was broken

`ButtonGroupsBuilder.resolveClassIsPrototype` read the class file and its frontmatter straight off Obsidian's `metadataCache`. Both reads miss while the cache is cold (a reset index, a fresh device, a large re-sync), and the fall-through yields `false` — so a **prototype asset silently renders the ORDINARY button set**.

This is a **third, separate signal** from the `rdf:type` conveyor decoupled by req `7d00a60b` (v16.235.0). It fails *safe* — the surface **degrades** rather than breaking — which is exactly why it survived that work unnoticed.

## What changed

Both reads now go through the vault adapter, which resolves a class file from the file registry (Tier 2) and reads frontmatter with a disk fallback. The raw-cache path is kept for callers with no adapter wired, so in-memory test doubles behave exactly as before.

`getFrontmatterWithFallback` is declared **optional** on `IVaultFrontmatterManager`: it is a platform capability, not a universal contract. 15 of the 17 `IVaultAdapter` implementations are in-memory test doubles with no disk, and the CLI adapter already reads the filesystem directly. Callers feature-detect and degrade — zero mock churn.

## ⛔ Where this DIVERGES from #4200

The issue proposed (a) de-duplicating the two `resolveClassIsPrototype` copies and (b) routing both through the adapter. Measurement says otherwise:

| proposal | measurement |
|---|---|
| de-duplicate the two copies | **contra-indicated** — `CommandManager` reaches its copy from Obsidian's `checkCallback`, which must return a `boolean` **synchronously**. The two call sites now need different contracts. |
| route `CommandManager` through the adapter too | **would be inert** — its step 2 still dies on `getFileCache`. A half-fix there reads as coverage while changing nothing. |

So `CommandManager` is deliberately **out of scope**, and the divergence is written into the requirement body rather than silently dropped. Whether #4200 should be closed or re-scoped is the maintainer's call, hence `Addresses`, not `Closes`.

## Routing

Step 0 was decided by **execution, not reasoning**: reducing both copies to `return false` on `origin/main` left 275/275 green ⇒ the property is specified by nothing ⇒ **new req**, not a bug-fix. Requirement `c3072a80-5b1b-433e-b5b3-57006ff47682` (P1, Component binding).

## Revert-verify — 6 axes, 4 mutants, every signature distinct

| mutant | axes reddened |
|---|---|
| M1 file resolution not via adapter | P1 P2 P3 P4 P5 |
| M2 frontmatter without disk fallback | P1 P3 P4 |
| M3 call site without `await` | P4 P5 P6 |
| M4 degradation removed | P6 |

Control green; source restored byte-for-byte (sha256 matched). All four signatures differ, so each mutant is individually distinguishable.

Two expectations were **wrong and were corrected** (the axes were not): M1 also reddens P3 because without file resolution the fallback is never reached; M3 also reddens P5/P6 because without `await` the context carries a Promise. **P4 asserts `typeof === "boolean"`** — that is what uniquely locks the `await`, since a Promise is truthy and asserting the value alone would not catch it.

## Gates

- `check:types` rc=0, `build` rc=0
- core **386/386** suites, plugin **354/354** suites
- all six `lint`-job guard scripts rc=0 (`check-test-types`: 431 baseline pairs, **no new diagnostics**)

⚠ 23 pre-existing failures in this worktree turned out to be **uninitialised submodules**, not a regression — `git submodule update --init packages/exoas-exo packages/exoas-exocmd` turned every suite green.
