### PR TITLE
fix(core): read the asset's own frontmatter from disk when the cache is cold (req 7d00a60b)

### DIFF
--- a/packages/core/src/services/NoteToRDFConverter.ts
+++ b/packages/core/src/services/NoteToRDFConverter.ts
@@ -240,10 +240,20 @@ export class NoteToRDFConverter {
    * ```
    */
   async convertNote(file: IFile): Promise<Triple[]> {
-    return this.convertNoteFromFrontmatter(
-      file,
-      this.vault.getFrontmatter(file),
-    );
+    // Tier 1 of RFC 8f93ff95 (req 7d00a60b): the asset's OWN frontmatter must not
+    // be gated on Obsidian's metadataCache. On a cold cache getFrontmatter()
+    // returns null, convertNoteFromFrontmatter short-circuits to [], and the whole
+    // vault sweep (VaultRDFIndexer) yields an EMPTY store -> no exocmd bindings
+    // match -> the dynamic inline buttons vanish. Measured live on desktop
+    // 2026-08-29 (plugin 16.235.1): 4 of 7 buttons gone until the cache warmed.
+    //
+    // Feature-detected, not required: the capability is optional on IVaultAdapter
+    // because CLI adapters already read from disk and the in-memory test doubles
+    // have no disk at all. Mirrors the same guard used in ButtonGroupsBuilder.
+    const frontmatter = this.vault.getFrontmatterWithFallback
+      ? await this.vault.getFrontmatterWithFallback(file)
+      : this.vault.getFrontmatter(file);
+    return this.convertNoteFromFrontmatter(file, frontmatter);
   }
 
   /**

--- a/packages/core/tests/unit/services/NoteToRDFConverter.cold-cache-disk-fallback.test.ts
+++ b/packages/core/tests/unit/services/NoteToRDFConverter.cold-cache-disk-fallback.test.ts
@@ -1,0 +1,101 @@
+import "reflect-metadata";
+import { NoteToRDFConverter } from "../../../src/services/NoteToRDFConverter";
+import {
+  IVaultAdapter,
+  IFile,
+} from "../../../src/interfaces/IVaultAdapter";
+import type { ILogger } from "../../../src/interfaces/ILogger";
+import { Namespace } from "../../../src/domain/models/rdf/Namespace";
+
+function createMockLogger(): jest.Mocked<ILogger> {
+  return {
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  };
+}
+
+/** Adapter WITHOUT the optional disk fallback — the CLI adapter and the
+ *  in-memory test doubles look like this. */
+function createVaultWithoutFallback(): jest.Mocked<IVaultAdapter> {
+  return {
+    getFrontmatter: jest.fn(),
+    getAllFiles: jest.fn(),
+    read: jest.fn(),
+    create: jest.fn(),
+    modify: jest.fn(),
+    delete: jest.fn(),
+    exists: jest.fn(),
+    getAbstractFileByPath: jest.fn(),
+    updateFrontmatter: jest.fn(),
+    rename: jest.fn(),
+    createFolder: jest.fn(),
+    getFirstLinkpathDest: jest.fn(),
+    process: jest.fn(),
+    updateLinks: jest.fn(),
+    getDefaultNewFileParent: jest.fn(),
+  } as unknown as jest.Mocked<IVaultAdapter>;
+}
+
+/** Adapter WITH the disk fallback — the Obsidian one (req c3072a80). */
+function createVaultWithFallback(): jest.Mocked<IVaultAdapter> {
+  const v = createVaultWithoutFallback() as jest.Mocked<IVaultAdapter> & {
+    getFrontmatterWithFallback: jest.Mock;
+  };
+  v.getFrontmatterWithFallback = jest.fn();
+  return v;
+}
+
+const FILE: IFile = {
+  path: "assetspaces/kitelev/exoas-my/my-efforts/96e2a59a.md",
+  basename: "96e2a59a",
+  name: "96e2a59a.md",
+} as IFile;
+
+const ON_DISK = {
+  exo__Asset_uid: "96e2a59a-6ac1-47fb-83ab-12a9964a5bea",
+  exo__Asset_label: "Выпить Бринтелликс 10 мг",
+};
+
+/**
+ * @req:7d00a60b-5ca3-457e-a160-5bf955e8c195
+ *
+ * Tier 1 of RFC 8f93ff95 — the asset's OWN frontmatter must not be gated on
+ * Obsidian's metadataCache. The break this guards, measured live on the desktop
+ * (2026-08-29, plugin 16.235.1, vault-my):
+ *
+ *   cold cache -> getFrontmatter() === null -> convertNote returns []
+ *   -> ZERO triples -> the store is empty -> no exocmd bindings match
+ *   -> 4 of 7 inline buttons vanish (the dynamic ones; the 3 static ones stay).
+ *
+ * The selective disappearance is what proves the store — not the render — was
+ * empty: an unfinished render would have dropped ALL buttons.
+ */
+describe("NoteToRDFConverter — cold metadataCache (Tier 1, req 7d00a60b)", () => {
+  it("emits triples from DISK when the metadata cache is cold", async () => {
+    const vault = createVaultWithFallback();
+    vault.getFrontmatter.mockReturnValue(null); // cold cache
+    (
+      vault as unknown as { getFrontmatterWithFallback: jest.Mock }
+    ).getFrontmatterWithFallback.mockResolvedValue(ON_DISK); // disk has it
+
+    const converter = new NoteToRDFConverter(vault, createMockLogger());
+    const triples = await converter.convertNote(FILE);
+
+    expect(triples.length).toBeGreaterThan(0);
+    const predicates = triples.map((t) => t.predicate.toString());
+    expect(predicates).toContain(Namespace.EXO.term("Asset_label").toString());
+  });
+
+  it("still uses the cached read when the adapter has no disk fallback", async () => {
+    const vault = createVaultWithoutFallback();
+    vault.getFrontmatter.mockReturnValue(ON_DISK);
+
+    const converter = new NoteToRDFConverter(vault, createMockLogger());
+    const triples = await converter.convertNote(FILE);
+
+    expect(vault.getFrontmatter).toHaveBeenCalledWith(FILE);
+    expect(triples.length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Что не работало

Отвязка от индексации Obsidian (#4201, req `c3072a80`) починила **Tier 2** — резолв
класса-ссылки через vault-адаптер, то есть *какие* кнопки показать. Но управление
до него не доходит: `NoteToRDFConverter.convertNote()` читал frontmatter через
`getFrontmatter()`, а это **чистый `metadataCache`, без дискового пути**.

Цепочка отказа:

```
холодный кэш → getFrontmatter() === null
             → convertNoteFromFrontmatter(file, null) → return []
             → VaultRDFIndexer:328 (единственный вызывающий) собирает ПУСТОЙ store
             → ни один exocmd-биндинг не матчится
             → динамических инлайн-кнопок нет вовсе
```

## Как воспроизведено

На десктопе с **установленным и загруженным 16.235.1** (то есть фикс #4201 в памяти),
ассет `96e2a59a` (`ems__ActionPrototype`), после холодной перезагрузки:

| кнопка | тёплый кэш | холодный |
|---|---|---|
| Create Action Instance | ✅ | ⛔ нет |
| Create Execute & Archive | ✅ | ⛔ нет |
| Archive | ✅ | ⛔ нет |
| Set Ontology | ✅ | ⛔ нет |
| Copy uid / Collapse Relations / Add relation | ✅ | ✅ |

**Избирательность исчезновения и есть доказательство**, что пуст был *store*, а не
недорисован рендер: недорисованный рендер уронил бы **все** кнопки. Восстановление на
десктопе ~15 с; на iPhone после сброса индекса это окно — часы, поэтому проблема
всплыла именно там.

## Правка

Feature-detect на уже существующую (введённую #4201) опциональную способность
адаптера. Не `required`, потому что CLI-адаптеры и так читают с диска, а 15 in-memory
тестовых дублей диска не имеют вовсе. Форма зеркалит guard, уже применённый в
`DynamicCommandButtonGroupBuilder`.

## Проверки

**Revert-verify, две оси:**

| ось | до фикса | после |
|---|---|---|
| холодный кэш + дисковый фолбэк | 🔴 `Received: 0` (ноль триплов) | ✅ |
| адаптер БЕЗ фолбэка (контроль) | ✅ | ✅ |

Контрольная ось зелена в обе стороны ⇒ поведение CLI и тестовых дублей не изменено.

**Сьюты.** Падения пред-существующие — это неинициализированные сабмодульные фикстуры
(`packages/exoas-exo`, `packages/exoas-exocmd` в worktree пусты). Проверено прогоном
**контроля** — того же набора на дереве без этой правки:

| пакет | с фиксом | контроль (без фикса) |
|---|---|---|
| core | 8656 passed / 9 failed | 8654 passed / 9 failed |
| obsidian-plugin | 6163 passed / 3 failed | 6157 passed / 3 failed |

Составы упавших тестов **идентичны** (сверено `diff` по именам); `+2 passed` в core —
ровно новые оси.

## Маршрут

Bug-fix по конформности с **уже Active** req `7d00a60b`, чей `covers` дословно обещает
«холодный `metadataCache` **больше не даёт НОЛЬ командных кнопок**… резолвится через
vault-адаптер, читающий **ДИСК**». То есть спека уже существовала — отсутствовала
проводка: у `@req:7d00a60b` был **1** тестовый биндинг и **0** упоминаний в
`packages/*/src`. Новый req не заводится; тест расширяет покрытие существующего.

⚠ Не покрыто этим PR: e2e на холодном кэше в CI (⛔ локальный Docker-прогон запрещён —
QEMU-эмуляция + параллельные сессии дают kernel panic). Стоит завести отдельно.

https://claude.ai/code/session_01Lnkv4spfyz66KS3WG2aN5y
