### PR TITLE
fix(core): lazy walk follows exo:Asset_isDefinedBy so data-driven preconditions evaluate at render

### DIFF
--- a/packages/core/src/services/LazyAssetGraphLoader.ts
+++ b/packages/core/src/services/LazyAssetGraphLoader.ts
@@ -42,7 +42,8 @@ export interface INoteConverter {
  * 1. Call `INoteConverter.convertNote(file)` to obtain the file's
  *    triples; add them to the store.
  * 2. Inspect the loaded triples for `exo:Instance_class`,
- *    `exo:Class_superClass`, and `exo:Asset_prototype` objects.
+ *    `exo:Class_superClass`, `exo:Asset_prototype`, and
+ *    `exo:Asset_isDefinedBy` objects.
  * 3. For each IRI object referenced via those predicates, resolve it
  *    to an `IFile` via `IFileResolver.resolveByIRI`, then recursively
  *    ensure-load it.
@@ -77,10 +78,15 @@ export interface INoteConverter {
  * - **No TBox preload.** Phase 3 wires startup bootstrap of
  *   `assetspaces/{exo,ems,ims,exocmd}` by calling `ensureFileLoaded`
  *   on each ontology asset upfront.
- * - **No SPARQL-AST inspection for data-driven preconditions.** Phase 1
- *   audit (`9271ef44`) found zero data-driven preconditions in the
- *   in-scope vaults, so AST-walk-then-retry is deferred per RFC
- *   `c7da0bca` Q4 decision.
+ * - **Partial support for data-driven preconditions.** The Phase 1 audit
+ *   (`9271ef44`) reported ZERO data-driven preconditions and that premise
+ *   is now known to be WRONG: a 2026-08-29 desktop measurement found
+ *   `38ff3c61` walking `$target exo:Asset_isDefinedBy ?onto .
+ *   ?onto exo:Ontology_archiveOntology ?a` — two data hops — which kept
+ *   four command buttons hidden for the whole cold-start window.
+ *   `exo:Asset_isDefinedBy` was therefore added to the walk (step 2 above).
+ *   General AST-walk-then-retry remains deferred per RFC `c7da0bca` Q4:
+ *   this covers the ontology hop specifically, not arbitrary predicates.
  *
  * @see RFC c7da0bca, Phase 1 audit 9271ef44
  */
@@ -90,6 +96,7 @@ export class LazyAssetGraphLoader {
   private readonly instanceClassPredicate: IRI;
   private readonly superClassPredicate: IRI;
   private readonly prototypePredicate: IRI;
+  private readonly isDefinedByPredicate: IRI;
 
   constructor(
     private readonly converter: INoteConverter,
@@ -100,6 +107,7 @@ export class LazyAssetGraphLoader {
     this.instanceClassPredicate = Namespace.EXO.term("Instance_class");
     this.superClassPredicate = Namespace.EXO.term("Class_superClass");
     this.prototypePredicate = Namespace.EXO.term("Asset_prototype");
+    this.isDefinedByPredicate = Namespace.EXO.term("Asset_isDefinedBy");
   }
 
   /**
@@ -314,7 +322,30 @@ export class LazyAssetGraphLoader {
       if (
         predicateValue === this.instanceClassPredicate.value ||
         predicateValue === this.superClassPredicate.value ||
-        predicateValue === this.prototypePredicate.value
+        predicateValue === this.prototypePredicate.value ||
+        // exo:Asset_isDefinedBy — the asset's ONTOLOGY. Added 2026-08-29 after a
+        // live desktop measurement: data-driven preconditions DO exist in the
+        // production vaults, contradicting the Phase 1 audit (9271ef44) that this
+        // class's header cites as the reason to defer them.
+        //
+        // Concretely, precondition 38ff3c61 ("Source ontology declares an archive
+        // ontology") is
+        //     ASK { $target exo:Asset_isDefinedBy ?onto .
+        //           ?onto  exo:Ontology_archiveOntology ?a . }
+        // — two hops, the second one INSIDE the ontology asset. Without this
+        // predicate in the walk the ontology never enters the store on a render,
+        // so the ASK is false and the button stays hidden until the full
+        // convertVault() finishes (~25 s measured on desktop, 20-30 s on iPhone).
+        //
+        // The TBox bootstrap does not cover it either: lazyBootstrapFolders lists
+        // exo/ ems/ ems-commands/ ims/ exocmd/, and a personal ontology such as
+        // $my-efforts lives in assetspaces/<owner>/exoas-my/my-efforts/ — zero
+        // matches (measured on the live vault).
+        //
+        // Cost is bounded by the loadedIRIs cache: 8857 assets in vault-my point
+        // at only 145 distinct ontologies, so the added hop collapses to at most
+        // one extra file per ontology per session, not per asset.
+        predicateValue === this.isDefinedByPredicate.value
       ) {
         targets.push(t.object);
       }

--- a/packages/core/tests/unit/services/LazyAssetGraphLoader.test.ts
+++ b/packages/core/tests/unit/services/LazyAssetGraphLoader.test.ts
@@ -756,4 +756,63 @@ describe("LazyAssetGraphLoader", () => {
       expect(converter.callCounts.get("task.md")).toBe(2);
     });
   });
+
+  // @req:044a6890-414e-452f-9870-b6ed67b0bf92 — ontology hop (exo:Asset_isDefinedBy) in the lazy walk.
+  //
+  // Measured live on desktop 2026-08-29 (plugin 16.235.2): four command buttons
+  // stayed hidden for the whole cold-start window (~25 s) because precondition
+  // 38ff3c61 is `ASK { $target exo:Asset_isDefinedBy ?onto .
+  // ?onto exo:Ontology_archiveOntology ?a . }` and the ontology never reached
+  // the store — neither via this walk (the predicate was absent) nor via the
+  // TBox bootstrap (lazyBootstrapFolders lists exo/ ems/ ims/ exocmd/, while a
+  // personal ontology lives in assetspaces/<owner>/exoas-my/<ns>/ — zero match).
+  describe("ensureFileLoaded — ontology hop (isDefinedBy)", () => {
+    const isDefinedByPred = Namespace.EXO.term("Asset_isDefinedBy");
+    const archiveOntologyPred = Namespace.EXO.term("Ontology_archiveOntology");
+    const relatesPred = Namespace.EXO.term("Asset_relates");
+
+    it("walks exo:Asset_isDefinedBy so the ontology's own triples enter the store", async () => {
+      const asset = makeFile("my-efforts/asset.md");
+      const ontology = makeFile("my-efforts/ontology.md");
+      const assetIRI = pathToIRI(asset.path);
+      const ontologyIRI = pathToIRI(ontology.path);
+      const archiveIRI = pathToIRI("my-efforts/archived.md");
+
+      converter.registerFile(asset, [
+        new Triple(assetIRI, isDefinedByPred, ontologyIRI),
+      ]);
+      // The second hop of the ASK lives INSIDE the ontology asset.
+      converter.registerFile(ontology, [
+        new Triple(ontologyIRI, archiveOntologyPred, archiveIRI),
+      ]);
+      resolver.register(ontology);
+
+      await loader.ensureFileLoaded(asset);
+
+      // Proves the WIRING, not a helper: the ontology file was converted…
+      expect(converter.callCounts.get(ontology.path)).toBe(1);
+      // …and its own triple — the ASK's second hop — is queryable.
+      const hop2 = await store.match(ontologyIRI, archiveOntologyPred, undefined);
+      expect(hop2).toHaveLength(1);
+    });
+
+    it("control: a predicate outside the walk list does NOT pull its target", async () => {
+      const asset = makeFile("my-efforts/other.md");
+      const neighbour = makeFile("my-efforts/neighbour.md");
+
+      converter.registerFile(asset, [
+        new Triple(pathToIRI(asset.path), relatesPred, pathToIRI(neighbour.path)),
+      ]);
+      converter.registerFile(neighbour, []);
+      resolver.register(neighbour);
+
+      await loader.ensureFileLoaded(asset);
+
+      // The radius stays bounded — adding isDefinedBy must not turn the walk
+      // into "follow every IRI object".
+      expect(converter.callCounts.get(neighbour.path)).toBeUndefined();
+      expect(loader.loadedCount).toBe(1);
+    });
+  });
+
 });


### PR DESCRIPTION
## Что чинит

Кнопки команд гейтятся **precondition-ASK**, а не наличием ассета в store. Часть ASK
**data-driven** и ходит на два хопа — например `38ff3c61`:

```sparql
ASK { $target exo:Asset_isDefinedBy ?onto .
      ?onto   exo:Ontology_archiveOntology ?a . }
```

Второй хоп читает свойство **онтологии**. `LazyAssetGraphLoader` (render-authoritative
для кнопок, `DynamicCommandButtonGroupBuilder:418`) обходил три предиката —
`Instance_class`, `Class_superClass`, `Asset_prototype` — и `exo:Asset_isDefinedBy`
среди них не было ⇒ онтология в store на рендере не попадала ⇒ ASK ложен ⇒ кнопка
скрыта до конца полного `convertVault()`.

TBox-бутстрап не покрывал: `lazyBootstrapFolders` = `exo/ ems/ ems-commands/ ims/
exocmd/`, а личная онтология (`$my-efforts`) лежит в
`assetspaces/<owner>/exoas-my/my-efforts/` — **ноль совпадений** (замер на живом vault).

## Замер, из-за которого это заведено

Десктоп 2026-08-29, v16.235.2, холодный кэш сразу после reload: **3 из 7** кнопок;
через 25 с — **7 из 7**. Reload подтверждён (renderer PID 79448 → 86015, manifest
16.235.2, bundle 7 вхождений).

⛔ Tier 1 (`req 7d00a60b`, чтение frontmatter с диска) на это **не влияет**: он чинит
слой ниже, а гейт здесь — **предусловие**, а не наличие ассета в store. Это и был
дефект моей исходной диагностики; сказано прямо, а не подано как решение.

## Цена (замерена ДО правки)

8857 ассетов `vault-my` ссылаются на **145** различных онтологий ⇒ `loadedIRIs`-кэш
схлопывает хоп до «не более одного лишнего файла **на онтологию за сессию**», а не
на ассет.

## Revert-verify

| состояние | результат |
|---|---|
| с фиксом | **33/33** зелёных |
| мутант (условие обхода → `false`) | **ровно 1** красная: `walks exo:Asset_isDefinedBy so the ontology's own triples enter the store` (`Expected: 1 / Received: undefined`) |
| контрольная ось (`Asset_relates` НЕ тянет цель) | зелена в **обоих** состояниях ⇒ радиус не расширился до «идти по любой IRI» |

Прод-файл восстановлен байт-в-байт (`cmp -s`).

## Прочие проверки

- `tsc --noEmit` по `packages/core` — чист.
- **Семь** guard-скриптов lint-job (перечислены из `ci.yml`, не по памяти) — все `rc=0`.
- `MultiHopPrototypeChainPerformance` изолированно **6/6 зелёных трижды в ОБЕИХ ветках**
  (с фиксом и на `origin/main`). Падение возникает только вместе с соседними сьютами в
  одном jest-процессе ⇒ пред-существующая флаки-хрупкость порога 50 мс, **не** регрессия
  добавленного хопа. Промежуточное ограничение `depth === 1`, введённое по ложному
  основанию «чиню регрессию», **откачено**.

## Показанная коррекция в заголовке класса

Заголовок ссылался на аудит `9271ef44` как на причину отложить data-driven
preconditions — тот сообщал **ЗЕРО** таких preconditions. Посылка опровергнута
замером; исправлено показанной формой (⛔ было → ✅ фактически), а не переписано молча.

Requirement: `044a6890-414e-452f-9870-b6ed67b0bf92` (Approved) →
Active после merge.

https://claude.ai/code/session_01Lnkv4spfyz66KS3WG2aN5y
